### PR TITLE
Fix macOS Bluetooth audio route handling

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -24,6 +24,10 @@
 
 namespace AetherSDR {
 
+namespace {
+constexpr qint64 kTxAutoRestartMinRuntimeMs = 60000;
+}
+
 void AudioEngine::updateRxBufferStats()
 {
     m_rxBufferBytes.store(m_rxBuffer.size());
@@ -187,8 +191,41 @@ bool AudioEngine::startRxStream()
     m_lastAudioFeedTime.start();  // initialize liveness watchdog (#1411)
 
     QAudioFormat fmt = makeFormat();
-    const QAudioDevice dev = m_outputDevice.isNull()
+    QAudioDevice dev = m_outputDevice.isNull()
         ? QMediaDevices::defaultAudioOutput() : m_outputDevice;
+
+#ifdef Q_OS_MAC
+    if (!m_allowBluetoothTelephonyOutput.load()) {
+        QAudioFormat preferredFmt = makeFormat();
+        preferredFmt.setSampleRate(48000);
+        if (!dev.isFormatSupported(preferredFmt)) {
+            const auto supportsPreferredOutput = [&preferredFmt](const QAudioDevice& candidate) {
+                return !candidate.isNull() && candidate.isFormatSupported(preferredFmt);
+            };
+
+            const QAudioDevice defaultDev = QMediaDevices::defaultAudioOutput();
+            if (supportsPreferredOutput(defaultDev)) {
+                qCWarning(lcAudio) << "AudioEngine: selected output route looks telephony-only, using default 48k-capable output instead:"
+                                   << defaultDev.description();
+                dev = defaultDev;
+            } else {
+                const QString selectedDescription = dev.description();
+                for (const QAudioDevice& candidate : QMediaDevices::audioOutputs()) {
+                    if (candidate.id() == dev.id()) {
+                        continue;
+                    }
+                    if (candidate.description() == selectedDescription
+                        && supportsPreferredOutput(candidate)) {
+                        qCWarning(lcAudio) << "AudioEngine: selected output route looks telephony-only, using sibling 48k-capable output instead:"
+                                           << candidate.description();
+                        dev = candidate;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+#endif
 
     // Windows WASAPI shared mode handles sample rate conversion transparently,
     // but Qt's isFormatSupported() often returns false for valid formats (e.g.
@@ -222,8 +259,18 @@ bool AudioEngine::startRxStream()
     // watchdog already handles stale WASAPI sessions after idle/sleep.
     connect(m_audioSink, &QAudioSink::stateChanged, this,
             [this](QAudio::State state) {
-        if (state != QAudio::StoppedState) return;
-        if (!m_audioSink) return;   // intentional stop (stopRxStream nulls this)
+        if (state != QAudio::StoppedState) {
+            return;
+        }
+        if (!m_audioSink) {
+            return;   // intentional stop (stopRxStream nulls this)
+        }
+        const QAudio::Error error = m_audioSink->error();
+        if (error != QAudio::NoError) {
+            qCWarning(lcAudio) << "AudioEngine: QAudioSink stopped with error, not auto-restarting RX"
+                               << error;
+            return;
+        }
         QMetaObject::invokeMethod(this, [this]() {
             if (!m_audioSink) return;
             qCWarning(lcAudio) << "AudioEngine: QAudioSink stopped unexpectedly, restarting RX (#1303)";
@@ -237,17 +284,48 @@ bool AudioEngine::startRxStream()
     emit rxStarted();
     return true;
 #else
-    if (!dev.isFormatSupported(fmt)) {
-        qCWarning(lcAudio) << "AudioEngine: output device does not support 24kHz stereo Int16, trying 48kHz";
-        fmt.setSampleRate(48000);
-        m_resampleTo48k = true;
-        if (!dev.isFormatSupported(fmt)) {
-            qCWarning(lcAudio) << "AudioEngine: output device does not support 48kHz stereo Int16 either";
-            qCWarning(lcAudio) << "No audio device detected";
-            return false;
+    auto configureOutputFormat = [this, &dev](QAudioFormat& candidateFmt) {
+        candidateFmt = makeFormat();
+#ifdef Q_OS_MAC
+        // CoreAudio can route Bluetooth headsets onto the HFP/telephony
+        // transport when opened directly at 24 kHz. Prefer 48 kHz on macOS
+        // so A2DP-capable devices stay on the normal output profile.
+        candidateFmt.setSampleRate(48000);
+        if (dev.isFormatSupported(candidateFmt)) {
+            m_resampleTo48k = true;
+            return true;
         }
-    } else {
-        m_resampleTo48k = false;
+
+        qCWarning(lcAudio) << "AudioEngine: output device does not support 48kHz stereo float, trying 24kHz";
+        candidateFmt.setSampleRate(DEFAULT_SAMPLE_RATE);
+        if (dev.isFormatSupported(candidateFmt)) {
+            m_resampleTo48k = false;
+            return true;
+        }
+
+        qCWarning(lcAudio) << "AudioEngine: output device does not support 24kHz stereo float either";
+        return false;
+#else
+        if (dev.isFormatSupported(candidateFmt)) {
+            m_resampleTo48k = false;
+            return true;
+        }
+
+        qCWarning(lcAudio) << "AudioEngine: output device does not support 24kHz stereo Int16, trying 48kHz";
+        candidateFmt.setSampleRate(48000);
+        if (dev.isFormatSupported(candidateFmt)) {
+            m_resampleTo48k = true;
+            return true;
+        }
+
+        qCWarning(lcAudio) << "AudioEngine: output device does not support 48kHz stereo Int16 either";
+        return false;
+#endif
+    };
+
+    if (!configureOutputFormat(fmt)) {
+        qCWarning(lcAudio) << "No audio device detected";
+        return false;
     }
 #endif
 
@@ -270,8 +348,18 @@ bool AudioEngine::startRxStream()
     // watchdog already handles stale WASAPI sessions after idle/sleep.
     connect(m_audioSink, &QAudioSink::stateChanged, this,
             [this](QAudio::State state) {
-        if (state != QAudio::StoppedState) return;
-        if (!m_audioSink) return;   // intentional stop (stopRxStream nulls this)
+        if (state != QAudio::StoppedState) {
+            return;
+        }
+        if (!m_audioSink) {
+            return;   // intentional stop (stopRxStream nulls this)
+        }
+        const QAudio::Error error = m_audioSink->error();
+        if (error != QAudio::NoError) {
+            qCWarning(lcAudio) << "AudioEngine: QAudioSink stopped with error, not auto-restarting RX"
+                               << error;
+            return;
+        }
         QMetaObject::invokeMethod(this, [this]() {
             if (!m_audioSink) return;
             qCWarning(lcAudio) << "AudioEngine: QAudioSink stopped unexpectedly, restarting RX (#1303)";
@@ -919,6 +1007,7 @@ bool AudioEngine::startTxStream(const QHostAddress& radioAddress, quint16 radioP
 
 #ifdef Q_OS_MAC
     // macOS: QAudioSource pull mode broken — use push mode with QBuffer
+    const quint64 txLifecycleGeneration = ++m_txLifecycleGeneration;
     m_micBuffer = new QBuffer(this);
     m_micBuffer->open(QIODevice::ReadWrite);
     m_audioSource = new QAudioSource(dev, fmt, this);
@@ -941,10 +1030,42 @@ bool AudioEngine::startTxStream(const QHostAddress& radioAddress, quint16 radioP
     // runtime (~16h). Detect the silent stop, pause the timer, and restart
     // cleanly so onTxAudioReady never touches a stale m_micBuffer. (#1149)
     connect(m_audioSource, &QAudioSource::stateChanged, this,
-            [this](QAudio::State state) {
-        if (state != QAudio::StoppedState) return;
-        if (!m_txPollTimer) return;  // intentional stop already handled
+            [this, txLifecycleGeneration](QAudio::State state) {
+        if (state != QAudio::StoppedState) {
+            return;
+        }
+        if (txLifecycleGeneration != m_txLifecycleGeneration) {
+            return;
+        }
+        if (!m_audioSource || !m_txPollTimer) {
+            return;  // intentional stop already handled
+        }
+
+        const QAudio::Error error = m_audioSource->error();
         m_txPollTimer->stop();
+        if (error != QAudio::NoError) {
+            qCWarning(lcAudio) << "AudioEngine: QAudioSource stopped with error, not auto-restarting TX"
+                               << error;
+            QMetaObject::invokeMethod(this, [this]() {
+                if (m_audioSource) {
+                    stopTxStream();
+                }
+            }, Qt::QueuedConnection);
+            return;
+        }
+
+        const qint64 runtimeMs = m_txSourceStartTime.isValid() ? m_txSourceStartTime.elapsed() : 0;
+        if (!m_txSourceStartTime.isValid() || runtimeMs < kTxAutoRestartMinRuntimeMs) {
+            qCWarning(lcAudio) << "AudioEngine: QAudioSource stopped too soon, not auto-restarting TX"
+                               << runtimeMs << "ms";
+            QMetaObject::invokeMethod(this, [this]() {
+                if (m_audioSource) {
+                    stopTxStream();
+                }
+            }, Qt::QueuedConnection);
+            return;
+        }
+
         QHostAddress addr = m_txAddress;
         quint16 port = m_txPort;
         QMetaObject::invokeMethod(this, [this, addr, port]() {
@@ -1005,6 +1126,7 @@ bool AudioEngine::startTxStream(const QHostAddress& radioAddress, quint16 radioP
     connect(m_micDevice, &QIODevice::readyRead, this, &AudioEngine::onTxAudioReady);
 #endif
 
+    m_txSourceStartTime.restart();
     qCWarning(lcAudio) << "AudioEngine: TX stream started ->" << radioAddress.toString()
              << ":" << radioPort << "streamId:" << Qt::hex << m_txStreamId
              << "device:" << dev.description() << "rate:" << fmt.sampleRate()
@@ -1014,33 +1136,42 @@ bool AudioEngine::startTxStream(const QHostAddress& radioAddress, quint16 radioP
 
 void AudioEngine::stopTxStream()
 {
+    ++m_txLifecycleGeneration;
 #ifdef Q_OS_MAC
-    if (m_txPollTimer) {
-        m_txPollTimer->stop();
-        delete m_txPollTimer;
-        m_txPollTimer = nullptr;
+    QTimer* pollTimer = m_txPollTimer;
+    m_txPollTimer = nullptr;
+    QBuffer* micBuffer = m_micBuffer;
+    m_micBuffer = nullptr;
+#endif
+    QAudioSource* audioSource = m_audioSource;
+    m_audioSource = nullptr;
+    m_micDevice = nullptr;
+
+#ifdef Q_OS_MAC
+    if (pollTimer) {
+        pollTimer->stop();
+        delete pollTimer;
     }
 #endif
-    if (m_audioSource) {
+    if (audioSource) {
         // Guard: calling stop() on an already-stopped QAudioSource on macOS causes
         // AudioOutputUnitStop to dereference a stale CoreAudio device handle,
         // producing EXC_ARM_DA_ALIGN / EXC_BAD_ACCESS (#1059).
-        if (m_audioSource->state() != QAudio::StoppedState)
-            m_audioSource->stop();
-        delete m_audioSource;
-        m_audioSource = nullptr;
-        m_micDevice   = nullptr;
+        if (audioSource->state() != QAudio::StoppedState) {
+            audioSource->stop();
+        }
+        delete audioSource;
     }
 #ifdef Q_OS_MAC
-    if (m_micBuffer) {
-        delete m_micBuffer;
-        m_micBuffer = nullptr;
+    if (micBuffer) {
+        delete micBuffer;
     }
 #endif
     m_txSocket.close();
     m_txAccumulator.clear();
     m_txFloatAccumulator.clear();
     m_txResampler.reset();
+    m_txSourceStartTime.invalidate();
 }
 
 void AudioEngine::onTxAudioReady()
@@ -1343,6 +1474,19 @@ void AudioEngine::setInputDevice(const QAudioDevice& dev)
         startTxStream(addr, port);
     }
 }
+
+#ifdef Q_OS_MAC
+void AudioEngine::setAllowBluetoothTelephonyOutput(bool on)
+{
+    const bool changed = (m_allowBluetoothTelephonyOutput.exchange(on) != on);
+    if (!changed || !m_audioSink) {
+        return;
+    }
+
+    stopRxStream();
+    startRxStream();
+}
+#endif
 
 // ─── RADE digital voice support ──────────────────────────────────────────────
 

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -156,6 +156,9 @@ public:
     // Device selection (restarts the stream if currently running)
     void setOutputDevice(const QAudioDevice& dev);
     void setInputDevice(const QAudioDevice& dev);
+#ifdef Q_OS_MAC
+    void setAllowBluetoothTelephonyOutput(bool on);
+#endif
     QAudioDevice outputDevice() const { return m_outputDevice; }
     QAudioDevice inputDevice()  const { return m_inputDevice; }
     qsizetype rxBufferBytes() const { return m_rxBufferBytes.load(); }
@@ -218,6 +221,11 @@ private:
     std::atomic<bool> m_radeMode{false}; // RADE digital voice mode active (atomic: cross-thread)
     std::atomic<float> m_pcMicGain{1.0f};     // client-side PC mic gain (0.0-1.0)
     std::atomic<bool>  m_daxTxMode{false};    // DAX TX mode: VirtualAudioBridge handles TX
+    QElapsedTimer      m_txSourceStartTime;
+    quint64            m_txLifecycleGeneration{0};
+#ifdef Q_OS_MAC
+    std::atomic<bool>  m_allowBluetoothTelephonyOutput{false};
+#endif
     std::atomic<bool>  m_daxTxUseRadioRoute{false}; // false = low-latency route (dax=0)
     std::atomic<bool>  m_transmitting{false}; // true when radio is in TX AND we own TX
     std::atomic<bool>  m_radioTransmitting{false}; // true when radio is in TX (any owner)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -766,21 +766,33 @@ MainWindow::MainWindow(QWidget* parent)
         m_audio->setRemoteTxStreamId(streamId);
         // Radio always forces Opus for remote_audio_tx (confirmed v1.4.0.0)
         m_audio->setOpusTxEnabled(true);
-        // Restore PC mic gain from client-side settings (radio has no
-        // hardware gain stage for PC input — client-authoritative)
+        // Only the PC mic path needs local audio capture. For radio-side mic
+        // selections, remote_audio_tx still exists for VOX/met_in_rx, but the
+        // radio owns the actual input path. Starting QAudioSource here on
+        // macOS pins Bluetooth output in telephony mode.
         if (m_radioModel.transmitModel().micSelection() == "PC") {
+            // Restore PC mic gain from client-side settings (radio has no
+            // hardware gain stage for PC input — client-authoritative)
             int gain = AppSettings::instance().value("PcMicGain", 100).toInt();
             m_audio->setPcMicGain(gain);
+            if (!m_audio->isTxStreaming()) {
+                audioStartTx(m_radioModel.radioAddress(), 4991);
+            }
+        } else if (m_audio->isTxStreaming()) {
+            audioStopTx();
         }
         qDebug() << "MainWindow: remote audio TX stream ID set to" << Qt::hex << streamId;
-        // Ensure mic TX stream is running for VOX monitoring
-        if (!m_audio->isTxStreaming()) {
-            audioStartTx(m_radioModel.radioAddress(), 4991);
-        }
     });
     // Start/stop PC audio TX when mic_selection changes
     connect(&m_radioModel.transmitModel(), &TransmitModel::micStateChanged,
             this, [this]() {
+#ifdef Q_OS_MAC
+        const bool allowBluetoothTelephonyOutput =
+            m_radioModel.transmitModel().micSelection() == "PC";
+        QMetaObject::invokeMethod(m_audio, [this, allowBluetoothTelephonyOutput]() {
+            m_audio->setAllowBluetoothTelephonyOutput(allowBluetoothTelephonyOutput);
+        }, Qt::QueuedConnection);
+#endif
         if (m_radioModel.transmitModel().micSelection() == "PC") {
             // Restore PC mic gain from client-side settings
             int gain = AppSettings::instance().value("PcMicGain", 100).toInt();
@@ -795,6 +807,13 @@ MainWindow::MainWindow(QWidget* parent)
             audioStopTx();
         }
     });
+#ifdef Q_OS_MAC
+    const bool allowBluetoothTelephonyOutput =
+        m_radioModel.transmitModel().micSelection() == "PC";
+    QMetaObject::invokeMethod(m_audio, [this, allowBluetoothTelephonyOutput]() {
+        m_audio->setAllowBluetoothTelephonyOutput(allowBluetoothTelephonyOutput);
+    }, Qt::QueuedConnection);
+#endif
     // Sync PC mic gain directly from slider (radio ignores mic_level for PC input)
     connect(m_appletPanel->phoneCwApplet(), &PhoneCwApplet::micLevelChanged,
             this, [this](int level) {

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -385,7 +385,12 @@ void TransmitModel::setMicInputList(const QStringList& inputs)
 
 void TransmitModel::setMicSelection(const QString& input)
 {
-    emit commandReady(QString("mic input %1").arg(input.toUpper()));
+    const QString normalized = input.toUpper();
+    if (m_micSelection != normalized) {
+        m_micSelection = normalized;
+        emit micStateChanged();
+    }
+    emit commandReady(QString("mic input %1").arg(normalized));
 }
 
 void TransmitModel::setMicLevel(int level)


### PR DESCRIPTION
## Summary

This fixes a cluster of related macOS CoreAudio/Bluetooth regressions in AetherSDR's RX/TX audio handling.

User-visible symptoms before this patch:
- Launching AetherSDR with Bluetooth headphones could push the headset into telephony/HFP mode even when the radio mic source was `MIC`.
- After quitting, the headset could remain in telephony mode or leave CoreAudio in a bad state, so the next app launch had no audio until `coreaudiod` was restarted.
- When `mic_selection=PC`, switching the selected PC input device on macOS could briefly enter telephony mode, drop the mic, flash the macOS menu-bar microphone indicator, and in some cases crash the app.

## Root Causes

There were multiple bugs interacting here:

1. On macOS, AetherSDR's RX output path preferred opening the Bluetooth output route at 24 kHz. In practice, that could cause CoreAudio to choose the headset's telephony/HFP transport instead of the normal stereo route.
2. The app could start local PC mic capture just because `remote_audio_tx` existed, even when the radio mic source was not `PC`.
3. Switching away from `PC` mic selection waited for the radio status echo before stopping local capture, leaving a window where the local mic path kept running unnecessarily.
4. macOS-only audio route toggles and device switches were able to race with `AudioEngine` teardown/startup.
5. The macOS `QAudioSource` recovery path could restart or tear down the wrong source after an input-device switch because stale `stateChanged(StoppedState)` callbacks from an old source were still acting on the current one.

## What This Changes

### RX / Bluetooth output routing on macOS
- Prefer 48 kHz first for the macOS RX sink so Bluetooth headsets stay on the normal stereo/A2DP route when possible.
- Only allow the telephony-capable Bluetooth output route when the radio mic selection is actually `PC`.
- Queue telephony-route changes onto the audio thread instead of touching the audio engine directly from the GUI thread.

### PC mic gating and mic selection handling
- Only start local PC mic capture when `mic_selection == PC`.
- Update the local transmit model immediately when the user changes mic selection, so leaving `PC` stops local capture right away instead of waiting for the radio echo.

### macOS TX lifecycle hardening
- Do not auto-restart a `QAudioSource` on macOS if it stopped with an actual backend error.
- Do not auto-restart a `QAudioSource` that stops immediately after opening; shut it down instead. This prevents the menu-bar microphone indicator from flashing due to a rapid reopen loop.
- Track a TX lifecycle generation so stale `QAudioSource::stateChanged(StoppedState)` signals from a previous input device cannot tear down a newly opened source after a device switch.
- Null the active TX source/buffer/timer before teardown so intentional device switches cannot race against CoreAudio callbacks.

## Scope

This PR is intentionally scoped to the validated audio fixes.

Platform impact:
- The Bluetooth routing and TX lifecycle changes are macOS-specific.
- The `mic_selection == PC` gating and immediate local model update are cross-platform correctness fixes, but they only prevent starting/stopping the local PC mic path at the wrong time.
- Linux and Windows RX/TX backends are otherwise unchanged.

## Verification

Verified manually on macOS by building with:

```bash
cmake --build build --target AetherSDR -j4
```

Manual repro/verification covered:
- `MIC` selected with Bluetooth headphones as output: headset stays out of telephony mode and relaunch audio works.
- `PC` selected with Bluetooth headset used for input/output: telephony mode is only used when expected.
- Switching the selected PC input device between an external mic (`Yeti X`) and the Bluetooth headset no longer causes a TX restart loop, menu-bar mic flashing, or loss of the newly selected microphone.
