### PR TITLE
Smooth S-meter peak hold animation

### DIFF
--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -18,6 +18,7 @@ SMeterWidget::SMeterWidget(QWidget* parent)
 
     m_needleFraction = dbmToFraction(m_levelDbm);
     m_targetNeedleFraction = m_needleFraction;
+    m_peakHoldDecayStartDbm = m_peakHoldDbm;
 
     m_needleAnimation.setTimerType(Qt::PreciseTimer);
     m_needleAnimation.setInterval(kNeedleAnimationIntervalMs);
@@ -61,16 +62,11 @@ void SMeterWidget::setLevel(float dbm)
     if (m_peakHoldEnabled) {
         if (dbm > m_peakHoldDbm) {
             m_peakHoldDbm = dbm;
+            m_peakHoldDecayStartDbm = dbm;
             m_peakHoldTimer.start();
             m_peakHoldTimerRunning = true;
-        } else if (m_peakHoldTimerRunning
-                   && m_peakHoldTimer.elapsed() > m_peakHoldTimeMs) {
-            // Decay phase: meter refresh is ~50ms (from m_peakDecay interval)
-            const float dt = 0.05f;
-            m_peakHoldDbm -= m_peakDecayDbPerSec * dt;
-            if (m_peakHoldDbm < m_levelDbm)
-                m_peakHoldDbm = m_levelDbm;
         }
+        updatePeakHoldValue();
     }
 
     updateNeedleTarget();
@@ -149,6 +145,8 @@ void SMeterWidget::setRxMode(const QString& mode)
 
 void SMeterWidget::updateNeedleTarget()
 {
+    updatePeakHoldValue();
+
     if (m_transmitting) {
         m_targetNeedleFraction = txValueToFraction(currentTxValue());
     } else if (m_rxMode == RxMode::SMeterPeak) {
@@ -157,8 +155,17 @@ void SMeterWidget::updateNeedleTarget()
         m_targetNeedleFraction = dbmToFraction(m_levelDbm);
     }
 
-    if (qAbs(m_targetNeedleFraction - m_needleFraction) <= kNeedleSnapEpsilon) {
+    const bool needleAtTarget = qAbs(m_targetNeedleFraction - m_needleFraction) <= kNeedleSnapEpsilon;
+    if (needleAtTarget) {
         m_needleFraction = m_targetNeedleFraction;
+    }
+
+    const bool peakHoldAnimating = m_peakHoldEnabled
+        && m_peakHoldTimerRunning
+        && m_peakHoldTimer.elapsed() > m_peakHoldTimeMs
+        && m_peakHoldDbm > m_levelDbm + 0.01f;
+
+    if (needleAtTarget && !peakHoldAnimating) {
         if (m_needleAnimation.isActive()) {
             m_needleAnimation.stop();
         }
@@ -178,20 +185,49 @@ void SMeterWidget::animateNeedle()
         return;
     }
 
+    updatePeakHoldValue();
+
     const float delta = m_targetNeedleFraction - m_needleFraction;
     const float elapsedSeconds = static_cast<float>(elapsedMs) / 1000.0f;
     const float timeConstant = (delta >= 0.0f) ? kNeedleAttackTimeSeconds
                                                 : kNeedleReleaseTimeSeconds;
     const float alpha = 1.0f - std::exp(-elapsedSeconds / timeConstant);
-
-    if (qAbs(delta) <= kNeedleSnapEpsilon) {
+    const bool needleAtTarget = qAbs(delta) <= kNeedleSnapEpsilon;
+    if (needleAtTarget) {
         m_needleFraction = m_targetNeedleFraction;
-        m_needleAnimation.stop();
     } else {
         m_needleFraction += delta * alpha;
     }
 
+    const bool peakHoldAnimating = m_peakHoldEnabled
+        && m_peakHoldTimerRunning
+        && m_peakHoldTimer.elapsed() > m_peakHoldTimeMs
+        && m_peakHoldDbm > m_levelDbm + 0.01f;
+
+    if (needleAtTarget && !peakHoldAnimating) {
+        m_needleAnimation.stop();
+    }
+
     update();
+}
+
+void SMeterWidget::updatePeakHoldValue()
+{
+    if (!m_peakHoldEnabled || !m_peakHoldTimerRunning) {
+        return;
+    }
+
+    const qint64 elapsedMs = m_peakHoldTimer.elapsed();
+    if (elapsedMs <= m_peakHoldTimeMs) {
+        return;
+    }
+
+    const float decayElapsedSeconds =
+        static_cast<float>(elapsedMs - m_peakHoldTimeMs) / 1000.0f;
+    m_peakHoldDbm = m_peakHoldDecayStartDbm - (m_peakDecayDbPerSec * decayElapsedSeconds);
+    if (m_peakHoldDbm <= m_levelDbm) {
+        m_peakHoldDbm = m_levelDbm;
+    }
 }
 
 QString SMeterWidget::sUnitsText() const
@@ -524,7 +560,12 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     // -- Draw peak hold line (configurable overlay, independent of RX mode) ---
     if (m_peakHoldEnabled && !m_transmitting
         && m_peakHoldDbm > S0_DBM + 1.0f) {
-        const float frac = dbmToFraction(m_peakHoldDbm);
+        float frac = dbmToFraction(m_peakHoldDbm);
+        if (m_peakHoldDbm <= m_levelDbm + 0.01f) {
+            frac = m_needleFraction;
+        } else {
+            frac = qMax(frac, m_needleFraction);
+        }
         const float angle = fractionToAngle(frac);
 
         const float cosA = std::cos(angle);
@@ -619,8 +660,10 @@ void SMeterWidget::setPowerScale(int maxWatts, bool hasAmplifier)
 void SMeterWidget::setPeakHoldEnabled(bool enabled)
 {
     m_peakHoldEnabled = enabled;
-    if (!enabled)
-        m_peakHoldDbm = m_levelDbm;
+    m_peakHoldDbm = m_levelDbm;
+    m_peakHoldDecayStartDbm = m_levelDbm;
+    m_peakHoldTimerRunning = false;
+    updateNeedleTarget();
     update();
 }
 
@@ -648,6 +691,7 @@ void SMeterWidget::setPeakDecayRate(const QString& rate)
 void SMeterWidget::resetPeak()
 {
     m_peakHoldDbm = m_levelDbm;
+    m_peakHoldDecayStartDbm = m_levelDbm;
     m_peakHoldTimerRunning = false;
     updateNeedleTarget();
     update();

--- a/src/gui/SMeterWidget.h
+++ b/src/gui/SMeterWidget.h
@@ -66,6 +66,7 @@ protected:
 private:
     void updateNeedleTarget();
     void animateNeedle();
+    void updatePeakHoldValue();
 
     // Map dBm to fraction (0.0 = left, 1.0 = right) for RX S-meter scale
     float dbmToFraction(float dbm) const;
@@ -103,6 +104,7 @@ private:
     // Peak hold line state
     bool           m_peakHoldEnabled{false};
     float          m_peakHoldDbm{-127.0f};
+    float          m_peakHoldDecayStartDbm{-127.0f};
     int            m_peakHoldTimeMs{1000};
     float          m_peakDecayDbPerSec{10.0f};  // Medium default
     QElapsedTimer  m_peakHoldTimer;


### PR DESCRIPTION
## Summary

Smooth the analog S-meter peak hold line without changing the main needle behavior.

This keeps the peak hold line visually continuous, especially at faster decay rates, while preserving the configured hold/decay timing.

## What changed

- change peak hold decay from fixed per-update decrements to elapsed-time decay
- keep the widget animation timer running while peak hold decay is active so the hold line can repaint continuously
- reset peak hold state when Peak Hold is toggled on/off to avoid reviving a stale held value
- keep the hold line visually tied to the displayed main needle while a new peak is being pushed upward
- keep the hold line from rendering below the displayed main needle during decay

## Why

The previous implementation decayed the peak hold value in coarse 50 ms steps. On `Fast`, that produced visible quantization on the way down. During testing there were also a few edge cases where the hold line could:

- remain stuck ahead of the needle after enabling Peak Hold
- briefly render slightly ahead of the displayed needle during a fresh rise
- briefly render below the displayed needle at faster decay rates

This change keeps the scope limited to `SMeterWidget` and addresses those visual artifacts without changing the main needle animation path.

## Files changed

- `src/gui/SMeterWidget.cpp`
- `src/gui/SMeterWidget.h`

## Testing

- `cmake --build build --target AetherSDR -j4`
- verified peak hold behavior interactively while switching between `Fast`, `Medium`, and `Slow`