### PR TITLE
Fix CW decoder header jitter when WPM changes

### DIFF
--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -117,6 +117,8 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
 
     m_cwStatsLabel = new QLabel;
     m_cwStatsLabel->setStyleSheet("QLabel { color: #6a8090; font-size: 10px; background: transparent; }");
+    m_cwStatsLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    m_cwStatsLabel->setFixedWidth(m_cwStatsLabel->fontMetrics().horizontalAdvance("1200 Hz  120 WPM"));
     cwBar->addWidget(m_cwStatsLabel);
 
     // Sensitivity slider — filters low-confidence decodes


### PR DESCRIPTION
## Summary
- reserve a stable width for the CW decoder stats label in the panadapter footer
- left-align the label content so changing WPM values do not shift controls to the right
- keep the fix scoped to the existing CW decoder panel layout only

## Testing
- cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
- cmake --build build -j4 --target AetherSDR
