### PR TITLE
Fix PC Audio button showing wrong state on radio connect (#1536)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4466,8 +4466,13 @@ void MainWindow::onConnectionStateChanged(bool connected)
         // remote_audio_rx stream for TCI clients; the sink should stay
         // silent in that case. The PC Audio toggle handler starts/stops
         // the sink when the user flips it.
-        if (AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True") {
-            audioStartRx();
+        // Always sync the button to the setting here so any divergence
+        // (e.g. from a profile load before connect) is corrected (#1536).
+        {
+            const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+            m_titleBar->setPcAudioEnabled(pcAudio);
+            if (pcAudio)
+                audioStartRx();
         }
         updateNr2Availability();  // Disable NR2 if connected via SmartLink/Opus (#1597)
         // TX audio stream will start when the radio assigns a stream ID


### PR DESCRIPTION
## Summary

- `setPcAudioEnabled()` existed on `TitleBar` (with a `QSignalBlocker` to prevent spurious saves) but was never called from `MainWindow`, so the button's visual state could diverge from reality.
- If a profile was imported before connect — or on any platform where `AppSettings` is read at a slightly different moment than the button initialises — audio could be active while the button showed inactive, or vice versa.

## Fix

In `onConnectionStateChanged`, read `PcAudioEnabled` once and call both `setPcAudioEnabled()` (syncs the button without re-saving) and `audioStartRx()` from the same decision, so button and audio sink are guaranteed to be in agreement whenever the radio connects.

## Test plan

- [ ] Set PC Audio OFF, restart AetherSDR, connect — button should show OFF and no audio should play
- [ ] Set PC Audio ON, restart, connect — button should show ON and audio should play
- [ ] Import a profile that has the opposite PC Audio setting to the current session, then connect — button should match the imported setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)