### PR TITLE
Fix zoom +/− buttons unable to reach full panadapter bandwidth (#1458)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7035,11 +7035,11 @@ void MainWindow::registerShortcutActions()
         }
 
         const double currentBw = sw->bandwidthMhz();
-        const double newBw = currentBw * factor;
-        if (newBw < m_radioModel.minPanBandwidthMhz()
-                || newBw > m_radioModel.maxPanBandwidthMhz()) {
-            return;
-        }
+        // Clamp to limits so the final keypress snaps to exact min/max (#1458).
+        const double newBw = std::clamp(currentBw * factor,
+                                        m_radioModel.minPanBandwidthMhz(),
+                                        m_radioModel.maxPanBandwidthMhz());
+        if (newBw == currentBw) return;  // already at the hard limit
 
         double newCenter = sw->centerMhz();
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -208,8 +208,10 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     // Send both bandwidth AND current center to prevent the radio from
     // auto-centering the panadapter (which causes band jumps).
     auto emitZoom = [this](double factor) {
-        const double newBw = m_bandwidthMhz * factor;
-        if (newBw < m_minBwMhz || newBw > m_maxBwMhz) { return; }  // at limit
+        // Clamp to limits so the final click always reaches the exact min/max,
+        // matching mouse-drag which uses std::clamp (#1458).
+        const double newBw = std::clamp(m_bandwidthMhz * factor, m_minBwMhz, m_maxBwMhz);
+        if (newBw == m_bandwidthMhz) return;  // already at the hard limit
 
         // When zooming in, shift center toward the active VFO so it stays visible
         double newCenter = m_centerMhz;


### PR DESCRIPTION
## Summary

The zoom-out button (and keyboard `−` shortcut) multiplied bandwidth by 1.5× per click and returned early if the result exceeded the radio's maximum. Because 1.5× steps never divide evenly into the hardware limit, the last click was always blocked — e.g. on a FLEX-6600 (max 5.4 MHz) the button stalled at 5.126 MHz, ~5% short of full range.

Mouse-drag already reached the exact limit because it used `std::clamp`.

## Fix

Replace the early-return guard with `std::clamp` in both paths:
- `SpectrumWidget::emitZoom` (zoom buttons)
- `MainWindow::registerShortcutActions` keyboard zoom lambda

The final click/keypress now snaps to exactly `m_maxBwMhz` (or `m_minBwMhz` when zooming in). Subsequent clicks become no-ops (`newBw == currentBw`). The behaviour is now identical to mouse-drag.

## Test plan

- [ ] Click zoom-out repeatedly — final click should reach the radio's maximum bandwidth exactly
- [ ] Press `−` key repeatedly — same result
- [ ] Click zoom-in repeatedly — should reach minimum bandwidth exactly
- [ ] Verify mouse-drag still works to the same limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)