### PR TITLE
Fix cursor frequency readout never matching VFO flag value (#1369)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1500,7 +1500,9 @@ int SpectrumWidget::mhzToX(double mhz) const
     const double startMhz = m_centerMhz - m_bandwidthMhz / 2.0;
     const double px = (mhz - startMhz) / m_bandwidthMhz * width();
     if (std::isnan(px) || std::isinf(px)) return -1;
-    return static_cast<int>(std::clamp(px, -1.0e6, 1.0e6));
+    // Round to nearest pixel so markers are centred on the true frequency;
+    // truncation (the old behaviour) placed them up to 1px left (#1369).
+    return static_cast<int>(std::round(std::clamp(px, -1.0e6, 1.0e6)));
 }
 
 double SpectrumWidget::xToMhz(int x) const
@@ -3193,7 +3195,16 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             // Cursor frequency label (#726)
             if (m_showCursorFreq && m_cursorPos.x() >= 0
                 && m_cursorPos.y() >= 0) {
-                const double freqMhz = xToMhz(m_cursorPos.x());
+                double freqMhz = xToMhz(m_cursorPos.x());
+                // Snap to the exact VFO frequency when hovering within 8 px
+                // of a slice marker so the readout exactly matches the flag
+                // value instead of showing a pixel-grid approximation (#1369).
+                for (const auto& so : m_sliceOverlays) {
+                    if (std::abs(m_cursorPos.x() - mhzToX(so.freqMhz)) <= 8) {
+                        freqMhz = so.freqMhz;
+                        break;
+                    }
+                }
                 const QString label = QString::number(freqMhz, 'f', 6);
                 QFont f = p.font();
                 f.setPointSize(9);


### PR DESCRIPTION
## Summary

Two bugs in `SpectrumWidget` combined to make the cursor frequency overlay always disagree with the VFO flag:

**1. `mhzToX()` truncated instead of rounding**
`static_cast<int>(px)` floors toward zero, so every VFO marker, filter edge, and spot pin was drawn up to 1 pixel left of its true frequency. Changed to `std::round()`.

**2. Cursor readout had no VFO snap**
`xToMhz(cursorPixel)` maps a discrete pixel back to MHz. At typical zoom levels (1 MHz bandwidth, 800px wide) one pixel ≈ 1250 Hz, so hovering directly over a VFO marker could show a frequency several hundred Hz away from the flag value — the two could never be exactly equal.

Fix: if the cursor is within 8 px of any slice's VFO marker, the readout snaps to the radio-reported exact frequency. Elsewhere it continues to show the pixel-derived value.

## Test plan

- [ ] Hover cursor slowly over a VFO flag — readout should snap to match the flag frequency exactly when within ~8 px
- [ ] Move cursor away from all flags — readout should show the interpolated pixel frequency normally
- [ ] With two slices active, verify each snaps independently
- [ ] Zoom in to narrow bandwidth — VFO marker should be visually centred on the correct frequency

🤖 Generated with [Claude Code](https://claude.com/claude-code)