### PR TITLE
Remove filter passband shading from waterfall display (#1270)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4415,11 +4415,11 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
         const int fW   = fX2 - fX1;
 
         // ── Filter passband shading ──────────────────────────────────────
-        // All slices use the same style — color distinguishes them.
+        // Drawn only in the spectrum area. The waterfall is a historical
+        // record of received signals; painting a UI affordance over it
+        // makes the passband look like a signal in the history (#1270).
         p.fillRect(QRect(fX1, specRect.top(), fW, specRect.height()),
                    QColor(col.red(), col.green(), col.blue(), 35));
-        p.fillRect(QRect(fX1, wfRect.top(), fW, wfRect.height()),
-                   QColor(col.red(), col.green(), col.blue(), 25));
 
         // Filter edge lines — user-hidden via per-slice VFO flag toggle (#1526)
         if (!so.filterEdgesHidden) {


### PR DESCRIPTION
## Summary

The slice filter passband fill (the semi-transparent coloured region showing the receiver filter bandwidth) was drawn in **both** the spectrum trace and the waterfall area. The waterfall is a historical record of received RF signals — painting a UI affordance on top of it made the passband look like real signal energy in the history and tinted the signal colours within the passband.

One `fillRect` call removed from `drawSliceMarkers()`. The spectrum shading is unchanged.

## What's kept unchanged

- **Spectrum shading** — still drawn in `specRect`, exactly as before.
- **Filter edge lines** — already restricted to `specRect.top()→specRect.bottom()`, unaffected.
- **TNF overlays** — intentionally span both regions (they represent an active notch and are the drag target); those are unchanged.

## Test plan

- [ ] With a slice active, confirm the coloured filter passband shading appears on the spectrum trace as normal
- [ ] Scroll the waterfall back in time — no coloured tint should appear in the waterfall for the filter passband region
- [ ] With multiple slices, confirm each slice's colour shading is absent from the waterfall
- [ ] Confirm TNF overlays still appear across both spectrum and waterfall (drag handle behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)