### PR TITLE
Fix RX applet pan slider broken with NR active (#1796)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7280,10 +7280,14 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
             sw->setSliceOverlayMarkerStyle(sliceId, thin, hideEdges);
     });
 
-    // Pan re-apply after NR mono-mix (#1460): keep AudioEngine in sync with the
-    // radio-side pan so client NR can restore the balance on its output.
-    connect(w, &VfoWidget::rxPanChanged, this, [this](int v) {
-        m_audio->setRxPan(v);
+    // Pan re-apply after NR mono-mix (#1460, #1796): keep AudioEngine in sync
+    // with the radio-side pan value from ALL sources (VFO panel, RX applet,
+    // MIDI, radio echo-back on connect).  Connecting SliceModel::audioPanChanged
+    // covers every path that calls setAudioPan(); only the active slice's value
+    // matters because AudioEngine plays one slice at a time.
+    connect(s, &SliceModel::audioPanChanged, this, [this, sliceId](int v) {
+        if (sliceId == m_activeSliceId)
+            m_audio->setRxPan(v);
     });
 
     // Per-slice AF mute persistence (#1560): save state to AppSettings on each


### PR DESCRIPTION
## Problem

The original #1460 fix re-applies pan after client-side NR collapses audio to mono, but it only tracked pan changes from the **VFO panel** slider. The **RX applet** pan slider — and MIDI/keyboard shortcuts — call `SliceModel::setAudioPan()` directly without going through `VfoWidget`, so `AudioEngine::m_rxPan` never gets updated and stays at 50 (centre). `applyRxPanInPlace` with pan=50 is a no-op, making the RX applet pan slider appear completely non-functional when NR is active.

The reporter confirmed: VFO panel pan works, RX applet pan does not.

## Root cause

```cpp
// Before — only fires for VFO panel slider
connect(w, &VfoWidget::rxPanChanged, this, [this](int v) {
    m_audio->setRxPan(v);
});
```

`VfoWidget::rxPanChanged` is only emitted by the VFO widget's internal slider. The RX applet calls `m_slice->setAudioPan(v)` which emits `SliceModel::audioPanChanged` — a signal that wasn't connected to AudioEngine at all.

## Fix

Connect `SliceModel::audioPanChanged` instead. Every code path that changes the pan calls `setAudioPan()`, which emits `audioPanChanged`. One connection covers all sources:

- VFO panel pan slider ✅
- RX applet pan slider ✅  
- MIDI / keyboard shortcuts ✅
- Radio echo-back on connect (session restore) ✅

The active-slice guard (`sliceId == m_activeSliceId`) preserves the existing behaviour where AudioEngine tracks the pan of the currently active slice.

## Verification

1. Connect radio, enable NR2 (or NR4/DFNR)
2. Move the **RX applet** pan slider to full left — audio should be left-only
3. Move to full right — audio should be right-only
4. VFO panel slider should continue to work as before

Fixes #1796

🤖 Generated with [Claude Code](https://claude.com/claude-code)