### PR TITLE
Seamless ADIF logbook auto-reload for DXCC spot colouring

### DIFF
--- a/src/core/AdifParser.cpp
+++ b/src/core/AdifParser.cpp
@@ -2,6 +2,7 @@
 
 #include <QFile>
 #include <QRegularExpression>
+#include <QThread>
 #include <QtAlgorithms>
 
 namespace AetherSDR {
@@ -150,7 +151,25 @@ QVector<QsoRecord> AdifParser::parseFile(const QString& path)
 
 void AdifParser::parseFileAsync(const QString& path)
 {
-    emit finished(parseFile(path));
+    // If the file is held open by an external logger (common on Windows),
+    // QFile::open() will fail.  Retry a few times before giving up so that
+    // a brief write-lock doesn't wipe every spot colour.
+    constexpr int kMaxAttempts  = 3;
+    constexpr int kRetryDelayMs = 500;
+
+    for (int attempt = 0; attempt < kMaxAttempts; ++attempt) {
+        QFile f(path);
+        if (f.open(QIODevice::ReadOnly)) {
+            emit finished(parse(f.readAll()));
+            return;
+        }
+        if (attempt + 1 < kMaxAttempts)
+            QThread::msleep(kRetryDelayMs);
+    }
+
+    // All attempts failed — tell the caller so it can keep its existing
+    // worked status rather than replacing it with an empty result set.
+    emit openFailed(path);
 }
 
 } // namespace AetherSDR

--- a/src/core/AdifParser.h
+++ b/src/core/AdifParser.h
@@ -34,6 +34,10 @@ public:
 
 signals:
     void finished(QVector<QsoRecord> records);
+    // Emitted when the file cannot be opened after all retry attempts
+    // (e.g. locked by an external logger).  The existing worked status
+    // should be preserved and the caller may schedule a later retry.
+    void openFailed(QString path);
 
 private:
     static QVector<QsoRecord> parse(const QByteArray& data);

--- a/src/core/DxccColorProvider.cpp
+++ b/src/core/DxccColorProvider.cpp
@@ -15,20 +15,27 @@ DxccColorProvider::DxccColorProvider(QObject* parent)
             Qt::QueuedConnection);
     m_parseThread.start();
 
-    // Debounce timer: fires 2 seconds after the last file-changed notification
+    // Debounce timer: fires 2 seconds after the last file-changed notification.
+    // Re-adding the path here (rather than in fileChanged) ensures we register
+    // the *new* inode when a logger atomically replaces the file via rename —
+    // by the time the 2-second window expires the replacement file is present.
     m_debounceTimer.setSingleShot(true);
     m_debounceTimer.setInterval(2000);
     connect(&m_debounceTimer, &QTimer::timeout, this, [this]() {
-        if (!m_watchedPath.isEmpty())
-            importAdifFile(m_watchedPath);
+        if (m_watchedPath.isEmpty()) return;
+        // Re-arm: atomic file replacement (temp→final rename) changes the inode
+        // so the watcher loses the file.  Add the path again before importing
+        // so subsequent changes to the newly-written file are also caught.
+        if (!m_fileWatcher.files().contains(m_watchedPath))
+            m_fileWatcher.addPath(m_watchedPath);
+        importAdifFile(m_watchedPath);
     });
 
     connect(&m_fileWatcher, &QFileSystemWatcher::fileChanged,
             this, [this](const QString&) {
-        // Re-add the path: some editors replace the file (inode changes)
-        if (!m_watchedPath.isEmpty() && !m_fileWatcher.files().contains(m_watchedPath))
-            m_fileWatcher.addPath(m_watchedPath);
-        m_debounceTimer.start();  // restart the 2-second window
+        // Just (re)start the debounce window.  Path re-registration happens in
+        // the timeout handler once the replacement file is guaranteed present.
+        m_debounceTimer.start();
     });
 }
 
@@ -46,6 +53,7 @@ bool DxccColorProvider::loadCtyDat(const QString& resourcePath)
 
 void DxccColorProvider::importAdifFile(const QString& path)
 {
+    emit importStarted();
     QMetaObject::invokeMethod(m_parser, "parseFileAsync",
                               Qt::QueuedConnection,
                               Q_ARG(QString, path));

--- a/src/core/DxccColorProvider.cpp
+++ b/src/core/DxccColorProvider.cpp
@@ -1,6 +1,7 @@
 #include "DxccColorProvider.h"
 #include "AdifParser.h"
 
+#include <QFileInfo>
 #include <QMetaObject>
 
 namespace AetherSDR {
@@ -13,6 +14,9 @@ DxccColorProvider::DxccColorProvider(QObject* parent)
     connect(m_parser, &AdifParser::finished,
             this,     &DxccColorProvider::onParseFinished,
             Qt::QueuedConnection);
+    connect(m_parser, &AdifParser::openFailed,
+            this,     &DxccColorProvider::onParseFailed,
+            Qt::QueuedConnection);
     m_parseThread.start();
 
     // Debounce timer: fires 2 seconds after the last file-changed notification.
@@ -23,6 +27,9 @@ DxccColorProvider::DxccColorProvider(QObject* parent)
     m_debounceTimer.setInterval(2000);
     connect(&m_debounceTimer, &QTimer::timeout, this, [this]() {
         if (m_watchedPath.isEmpty()) return;
+        // If the file no longer exists (deleted, not just locked), don't attempt
+        // a parse — the directory watcher will re-arm us when it reappears.
+        if (!QFileInfo::exists(m_watchedPath)) return;
         // Re-arm: atomic file replacement (temp→final rename) changes the inode
         // so the watcher loses the file.  Add the path again before importing
         // so subsequent changes to the newly-written file are also caught.
@@ -36,6 +43,24 @@ DxccColorProvider::DxccColorProvider(QObject* parent)
         // Just (re)start the debounce window.  Path re-registration happens in
         // the timeout handler once the replacement file is guaranteed present.
         m_debounceTimer.start();
+    });
+
+    // Also watch the parent directory so we catch the case where the file is
+    // deleted and a new file is later dropped/exported to the same path.
+    // QFileSystemWatcher can only watch files that exist — once the file is
+    // gone and addPath() fails in the debounce handler, the file watcher goes
+    // dark.  The directory watcher stays alive regardless, and fires whenever
+    // anything in the folder changes (create, rename, delete).  We check
+    // whether our target file has (re)appeared and re-arm the file watcher.
+    connect(&m_fileWatcher, &QFileSystemWatcher::directoryChanged,
+            this, [this](const QString&) {
+        if (m_watchedPath.isEmpty()) return;
+        if (QFileInfo::exists(m_watchedPath) &&
+            !m_fileWatcher.files().contains(m_watchedPath)) {
+            // File has reappeared — start watching it again and reload.
+            m_fileWatcher.addPath(m_watchedPath);
+            m_debounceTimer.start();
+        }
     });
 }
 
@@ -61,14 +86,21 @@ void DxccColorProvider::importAdifFile(const QString& path)
 
 void DxccColorProvider::setAutoReload(bool on, const QString& path)
 {
-    // Remove any existing watched paths
+    // Remove any existing watched file and directory paths
     if (!m_fileWatcher.files().isEmpty())
         m_fileWatcher.removePaths(m_fileWatcher.files());
+    if (!m_fileWatcher.directories().isEmpty())
+        m_fileWatcher.removePaths(m_fileWatcher.directories());
     m_debounceTimer.stop();
 
     if (on && !path.isEmpty()) {
         m_watchedPath = path;
-        m_fileWatcher.addPath(path);
+        m_fileWatcher.addPath(path);  // watch the file (exists now)
+        // Watch the parent directory so we catch delete-then-recreate:
+        // if the file is removed and a new one dropped in later, the directory
+        // watcher fires and re-arms the file watcher when the file reappears.
+        const QString dir = QFileInfo(path).absolutePath();
+        m_fileWatcher.addPath(dir);
     } else {
         m_watchedPath.clear();
     }
@@ -81,6 +113,24 @@ void DxccColorProvider::onParseFinished(QVector<QsoRecord> records)
         r.dxccPrefix = m_ctyParser.resolvePrimaryPrefix(r.callsign);
 
     m_workedStatus.load(records);
+    emit importFinished(m_workedStatus.totalQsos(), m_workedStatus.entityCount());
+}
+
+void DxccColorProvider::onParseFailed(const QString& /*path*/)
+{
+    // The file could not be opened — either locked by an external logger or
+    // deleted between the existence check and the open attempt.
+    //
+    // Either way, keep the existing worked status intact.
+    //
+    // Only re-arm the debounce timer if the file still exists (locked case):
+    // we'll retry in 2 s and should succeed once the lock is released.
+    // If the file is gone (deleted case), don't loop — the directory watcher
+    // will fire when the file reappears and re-arm us at that point.
+    if (!m_watchedPath.isEmpty() && QFileInfo::exists(m_watchedPath))
+        m_debounceTimer.start();
+
+    // Emit importFinished so any "Updating…" UI label clears to the current counts.
     emit importFinished(m_workedStatus.totalQsos(), m_workedStatus.entityCount());
 }
 

--- a/src/core/DxccColorProvider.h
+++ b/src/core/DxccColorProvider.h
@@ -67,6 +67,7 @@ signals:
 
 private slots:
     void onParseFinished(QVector<QsoRecord> records);
+    void onParseFailed(const QString& path);
 
 private:
     // Band/mode helpers (same logic as AdifParser, but for live spot data)

--- a/src/core/DxccColorProvider.h
+++ b/src/core/DxccColorProvider.h
@@ -61,6 +61,8 @@ public:
     QColor colorWorked {0x60, 0x60, 0x60};   // dim grey
 
 signals:
+    // Emitted just before async parsing begins (used to show "Updating…" in UI).
+    void importStarted();
     void importFinished(int qsoCount, int entityCount);
 
 private slots:

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2077,26 +2077,8 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
 
         layout->addLayout(dxccGrid);
 
-        // Auto-reload toggle
-        bool autoReloadEnabled = AppSettings::instance().value("DxccAutoReloadAdif", "False").toString() == "True";
-        auto* autoReloadToggle = new QPushButton(autoReloadEnabled ? "Enabled" : "Disabled");
-        autoReloadToggle->setCheckable(true);
-        autoReloadToggle->setChecked(autoReloadEnabled);
-        autoReloadToggle->setFixedWidth(80);
-        autoReloadToggle->setStyleSheet(
-            "QPushButton:checked { background: #2a6a2a; } QPushButton:!checked { background: #5a2a2a; }");
-        connect(autoReloadToggle, &QPushButton::toggled, this, [this, autoReloadToggle, save](bool on) {
-            autoReloadToggle->setText(on ? "Enabled" : "Disabled");
-            save("DxccAutoReloadAdif", on ? "True" : "False");
-            if (m_dxccProvider) {
-                const QString path = AppSettings::instance().value("DxccAdifFilePath", "").toString();
-                m_dxccProvider->setAutoReload(on, path);
-            }
-        });
-        dxccGrid->addWidget(new QLabel("Auto-Reload Log:"), drow, 0);
-        dxccGrid->addWidget(autoReloadToggle, drow++, 1, Qt::AlignLeft);
-
-        // Wire browse button
+        // Wire browse button — always arms the file watcher automatically so
+        // spot colours update whenever the user exports a new log (#logbook-autoreload).
         connect(browseBtn, &QPushButton::clicked, this, [this, adifPathLabel, save](bool) {
             const QString path = QFileDialog::getOpenFileName(
                 this, "Select ADIF Log File", QDir::homePath(),
@@ -2105,15 +2087,18 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
             adifPathLabel->setText(QFileInfo(path).fileName());
             save("DxccAdifFilePath", path);
             if (m_dxccProvider) {
-                if (m_dxccStatsLabel) m_dxccStatsLabel->setText("Importing\xe2\x80\xa6");
-                m_dxccProvider->importAdifFile(path);
-                const bool autoReload = AppSettings::instance().value("DxccAutoReloadAdif","False").toString() == "True";
-                m_dxccProvider->setAutoReload(autoReload, path);
+                m_dxccProvider->importAdifFile(path);   // importStarted → "Updating…" via signal below
+                m_dxccProvider->setAutoReload(true, path);  // always watch after selection
             }
         });
 
-        // Update stats when import finishes
+        // importStarted → "Updating…", importFinished → live stats
         if (m_dxccProvider) {
+            connect(m_dxccProvider, &DxccColorProvider::importStarted,
+                    this, [this]() {
+                if (m_dxccStatsLabel)
+                    m_dxccStatsLabel->setText("Updating\xe2\x80\xa6");
+            });
             connect(m_dxccProvider, &DxccColorProvider::importFinished,
                     this, [this](int qsos, int entities) {
                 if (m_dxccStatsLabel)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -388,8 +388,9 @@ MainWindow::MainWindow(QWidget* parent)
         const QString adifPath = s.value("DxccAdifFilePath", "").toString();
         if (!adifPath.isEmpty()) {
             m_dxccProvider.importAdifFile(adifPath);
-            if (s.value("DxccAutoReloadAdif", "False").toString() == "True")
-                m_dxccProvider.setAutoReload(true, adifPath);
+            // Always watch the file so spot colours update automatically when
+            // the user exports a new log — no manual reload step needed.
+            m_dxccProvider.setAutoReload(true, adifPath);
         }
     }
     connect(&m_dxccProvider, &DxccColorProvider::importFinished,


### PR DESCRIPTION
## Summary

- Previously spot DXCC colours only updated when the user manually clicked **Browse** and reloaded the file in the DX Cluster dialog. Exporting a fresh log to the same path had no effect until they clicked Browse again by hand.
- The "Auto-Reload Log" toggle defaulted to off, and even when on, edge cases (atomic rename, file deletion, Windows write-locks) meant it frequently stopped working silently.
- This PR removes the toggle entirely and makes auto-reload always-on: point AetherSDR at your `.adi`/`.adif` file once and spot colours stay current automatically.

## How to use

1. Open the **DX Cluster** dialog and connect to a cluster
2. In the **DXCC Colouring** section click **Browse** and select your logbook file (`.adi` or `.adif`)
3. AetherSDR loads the log immediately and begins watching the file — **no further action needed**
4. Whenever your logging program exports to that same path, spot colours update within ~2 seconds automatically

## Changes

**`src/gui/DxClusterDialog.cpp`**
- Removed the "Auto-Reload Log" toggle — the watcher is now armed automatically on Browse
- Shows **"Updating…"** while the async parse runs, then updates QSO / entity count on completion

**`src/gui/MainWindow.cpp`**
- At startup, if a saved ADIF path exists the watcher is armed unconditionally (was previously gated behind the now-removed toggle setting)

**`src/core/DxccColorProvider`** (`.h` / `.cpp`)
- Added `importStarted()` signal so the UI can show "Updating…" during async parsing
- 2-second debounce coalesces rapid change notifications before triggering a reload
- Watcher re-registration moved into the debounce callback so atomic-rename exports (N1MM, Log4OM, etc.) are caught correctly — the replacement file is present by the time the 2 s window expires
- Directory watcher on the parent folder handles **delete→recreate**: if the file is deleted and a new one later dropped to the same path, the directory watcher detects it and re-arms the file watcher
- New `AdifParser::openFailed` signal: if the file is locked by the logger during export, `parseFileAsync` retries 3× at 500 ms intervals on the worker thread rather than immediately emitting an empty result that would wipe spot colours. On all-retry failure `onParseFailed` preserves the existing worked status and only re-arms the debounce timer if the file still exists (locked not deleted), preventing an infinite retry loop on intentional deletion

## Behaviour matrix

| Scenario | Result |
|---|---|
| Logger exports to same path | Colours update within 2 s ✓ |
| Logger uses atomic rename (temp→rename) | Caught by post-debounce re-arm ✓ |
| Logger holds write-lock during export | Retries ×3 at 500 ms; colours preserved until success ✓ |
| File deleted | Colours preserved in memory; no retry loop ✓ |
| File deleted, new file dropped to same path later | Directory watcher detects reappearance, reloads ✓ |

## Test plan
- [ ] Export log to watched path → spots recolour within 2 s
- [ ] Rename watched file away, rename a different file to the watched path → spots update
- [ ] Delete watched file → QSO count preserved, no crash, no colour flicker
- [ ] Delete watched file, drop new file to same path → spots reload automatically
- [ ] Restart AetherSDR with a saved ADIF path → watcher armed on startup without touching the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)