### PR TITLE
Fix TCI DAX audio crosstalk between slices: per-channel resamplers (#1806)

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -193,7 +193,7 @@ void TciServer::stop()
         cs.socket->close();
         cs.socket->deleteLater();
         delete cs.protocol;
-        delete cs.resampler;
+        qDeleteAll(cs.resamplers);
     }
     m_clients.clear();
     releaseDaxForTci();
@@ -253,8 +253,8 @@ void TciServer::onNewConnection()
         ClientState cs;
         cs.socket = ws;
         cs.protocol = protocol;
-        // Default 48kHz — create 24→48kHz resampler for RX audio
-        cs.resampler = new Resampler(24000.0, 48000.0, 4096);
+        // Resamplers are created lazily per-channel in onDaxAudioReady()
+        // so each DAX channel has its own stateful r8brain instance (#1806).
         m_clients.append(cs);
 
         connect(ws, &QWebSocket::textMessageReceived,
@@ -307,7 +307,7 @@ void TciServer::onClientDisconnected()
                 }
             }
             delete m_clients[i].protocol;
-            delete m_clients[i].resampler;
+            qDeleteAll(m_clients[i].resamplers);
             m_clients.removeAt(i);
 
             // Release DAX if no remaining clients want audio (#1331)
@@ -382,12 +382,11 @@ void TciServer::onTextMessage(const QString& msg)
             int rate = trimmed.mid(colonIdx2 + 1).toInt();
             if (rate == 8000 || rate == 12000 || rate == 24000 || rate == 48000) {
                 client.audioSampleRate = rate;
-                // Create or destroy resampler as needed
-                delete client.resampler;
-                if (rate != 24000)
-                    client.resampler = new Resampler(24000.0, rate, 4096);
-                else
-                    client.resampler = nullptr;
+                // Discard all per-channel resamplers — they were built for
+                // the old rate and carry stale filter history.  New instances
+                // at the correct rate are lazily created in onDaxAudioReady().
+                qDeleteAll(client.resamplers);
+                client.resamplers.clear();
                 qCInfo(lcCat) << "TCI: audio sample rate set to" << rate
                               << "for" << ws->peerAddress().toString();
             }
@@ -716,9 +715,12 @@ void TciServer::onRxAudioReady(const QByteArray& pcm)
         int audioFrames = stereoFrames;
         QByteArray resampledBuf;
 
-        // Resample if client wants a different rate (float32 I/O)
-        if (cs.resampler) {
-            resampledBuf = cs.resampler->processStereoToStereo(src, stereoFrames);
+        // Resample if client wants a different rate (float32 I/O).
+        // Non-DAX path: use channel key 0 (DAX channels are 1-based).
+        if (cs.audioSampleRate != 24000) {
+            if (!cs.resamplers.contains(0))
+                cs.resamplers[0] = new Resampler(24000.0, cs.audioSampleRate, 4096);
+            resampledBuf = cs.resamplers[0]->processStereoToStereo(src, stereoFrames);
             audioSrc = reinterpret_cast<const float*>(resampledBuf.constData());
             audioFrames = resampledBuf.size() / (2 * static_cast<int>(sizeof(float)));
         }
@@ -830,9 +832,20 @@ void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
 
         int accumFrames = accumBuf.size() / (2 * static_cast<int>(sizeof(float)));
 
-        // If no resampler, flush immediately (native 24kHz pass-through)
-        // If resampling, wait for enough data to feed r8brain cleanly
-        if (cs.resampler && accumFrames < kAccumMinFrames) {
+        // Obtain (or lazily create) the per-channel resampler.
+        // Each DAX channel needs its own stateful r8brain instance so that
+        // filter history from slice A cannot bleed into slice B (#1806).
+        // No resampler is needed when the client requested native 24 kHz.
+        Resampler* resampler = nullptr;
+        if (cs.audioSampleRate != 24000) {
+            if (!cs.resamplers.contains(channel))
+                cs.resamplers[channel] = new Resampler(24000.0, cs.audioSampleRate, 4096);
+            resampler = cs.resamplers[channel];
+        }
+
+        // If resampling, wait for enough data to feed r8brain cleanly.
+        // Native 24kHz path flushes immediately.
+        if (resampler && accumFrames < kAccumMinFrames) {
             continue;
         }
 
@@ -840,8 +853,8 @@ void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
         int audioFrames = accumFrames;
         QByteArray resampledBuf;
 
-        if (cs.resampler) {
-            resampledBuf = cs.resampler->processStereoToStereo(audioSrc, audioFrames);
+        if (resampler) {
+            resampledBuf = resampler->processStereoToStereo(audioSrc, audioFrames);
             audioSrc = reinterpret_cast<const float*>(resampledBuf.constData());
             audioFrames = resampledBuf.size() / (2 * static_cast<int>(sizeof(float)));
         }

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -98,7 +98,13 @@ private:
         int          audioSampleRate{48000}; // requested output rate (48kHz for WSJT-X compat)
         int          audioChannels{2};       // 1=mono, 2=stereo
         int          audioFormat{3};         // 0=int16, 3=float32
-        Resampler*   resampler{nullptr};    // null if rate == 24000 (native)
+        // Per-DAX-channel resamplers.  A single shared r8brain instance would
+        // carry filter state from slice A into slice B, causing audible
+        // crosstalk (#1806).  Each channel gets its own stateful instance,
+        // lazily created in onDaxAudioReady() and deleted/recreated whenever
+        // the client changes its audio_samplerate.  No entry (or nullptr) for
+        // a channel means 24 kHz pass-through (no resampling needed).
+        QHash<int, Resampler*> resamplers;
         // Per-DAX-channel accumulation buffers. Concatenating multi-channel
         // packets into a shared buffer would interleave audio from different
         // slices and destroy the resampler output, so each channel maintains


### PR DESCRIPTION
## Problem

When two DAX channels are active (e.g. dual-band WSJT-X, or satellite full-duplex RX), audio from Slice A bleeds into Slice B and vice versa in the TCI output.

**Root cause:** `r8brain CDSPResampler` is a *stateful* filter — it maintains internal history across calls. `ClientState` held a single shared `Resampler*` for all DAX channels. Each time `onDaxAudioReady()` processed channel 2 (Slice B), the filter state left by channel 1 (Slice A) carried over, mixing both streams together.

The code comment already acknowledged the same problem for accumulation buffers (`QHash<int, QByteArray> rxAccumBuf` is correctly per-channel), but the resampler was never given the same treatment.

## Fix

Replace `Resampler* resampler` in `ClientState` with `QHash<int, Resampler*> resamplers` keyed by DAX channel, matching the existing `rxAccumBuf` pattern:

- **`onNewConnection()`** — removed eager single-resampler creation; instances are now lazily created per-channel on first audio packet
- **`onDaxAudioReady()`** — looks up `cs.resamplers[channel]`, creating a fresh `Resampler(24000, audioSampleRate, 4096)` on first use for that channel
- **`audio_samplerate` handler** — `qDeleteAll(resamplers)` on rate change; new instances are lazily recreated at the new rate
- **`onClientDisconnected()` / `stop()`** — `qDeleteAll(resamplers)` replaces single `delete resampler`
- **`onRxAudioReady()`** (non-DAX, currently unused) — uses channel key `0` as a sentinel (DAX channels are 1-based), same lazy pattern

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Single DAX channel | Correct | Correct (no change) |
| Two DAX channels simultaneously | Slice A audio bleeds into Slice B | Fully isolated ✓ |
| Client reconnects / changes rate | Resampler state reset | Resampler state reset ✓ |

## Test plan
- [ ] Single TCI client, single slice — audio unchanged, no regression
- [ ] Two active DAX slices (e.g. 40m + 20m) — confirm each slice's audio is clean and isolated in the TCI stream
- [ ] Change `audio_samplerate` while connected — confirm audio still works cleanly after rate switch
- [ ] Disconnect and reconnect TCI client — no memory leak, clean state

🤖 Generated with [Claude Code](https://claude.com/claude-code)