### PR TITLE
Fix Arduino WiFiServer TCP deadlock for ShackSwitch R4

### DIFF
--- a/src/models/AntennaGeniusModel.cpp
+++ b/src/models/AntennaGeniusModel.cpp
@@ -143,8 +143,19 @@ void AntennaGeniusModel::onDiscoveryDatagram()
 
 void AntennaGeniusModel::connectToDevice(const AgDeviceInfo& info)
 {
-    if (m_connected)
-        disconnectFromDevice();
+    // Always clean up any existing socket — connected or still pending.
+    // Multiple auto-connect triggers can fire in quick succession; without
+    // this the device accepts the first socket while AetherSDR's active
+    // socket is a later one.
+    if (m_tcpSocket) {
+        m_tcpSocket->abort();
+        m_tcpSocket->deleteLater();
+        m_tcpSocket = nullptr;
+    }
+    if (m_connected) {
+        m_connected = false;
+        emit disconnected();
+    }
 
     m_device = info;
     m_gotPrologue = false;
@@ -212,6 +223,18 @@ void AntennaGeniusModel::disconnectFromDevice()
 void AntennaGeniusModel::onTcpConnected()
 {
     qCDebug(lcTuner) << "AntennaGenius: TCP connected to" << m_device.ip.toString();
+
+    // Arduino WiFiServer::available() only returns a client once it has sent data.
+    // For ShackSwitch (R4) the server speaks first ("V1.0 AG"), so we send an
+    // empty line to trigger available() on the R4 side without affecting the
+    // protocol (the R4 discards empty lines before the greeting is sent).
+    const bool isShackSwitch = m_device.serial.startsWith("G0JKN") ||
+                               m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
+    if (isShackSwitch && m_tcpSocket) {
+        m_tcpSocket->write("\r\n");
+        m_tcpSocket->flush();
+    }
+
     // Wait for prologue line ("V<version> AG") before sending commands.
 }
 

--- a/src/models/AntennaGeniusModel.h
+++ b/src/models/AntennaGeniusModel.h
@@ -91,6 +91,7 @@ public:
 
     // Getters
     bool isConnected()   const { return m_connected; }
+    bool isConnecting()  const { return m_tcpSocket != nullptr && !m_connected; }
     bool isPresent()     const { return !m_discoveredDevices.isEmpty(); }
     QString peerAddress() const;
     quint16 peerPort() const;


### PR DESCRIPTION
## Problem

Arduino's `WiFiServer::available()` only returns a connected client after the client has sent at least one byte. The AG protocol is server-speaks-first (the device sends `V1.0 AG`), which creates a deadlock when AetherSDR connects to a ShackSwitch R4:

- AetherSDR waits for the device greeting
- The R4 waits for data before `available()` unblocks
- Neither side sends first, connection times out

The device is discovered correctly via UDP but every TCP connect attempt silently hangs.

## Fix

In `onTcpConnected()`, detect ShackSwitch devices (serial starts with `G0JKN` or name contains `ShackSwitch`) and send an empty CR+LF immediately on TCP connect. This unblocks `available()` on the R4, which discards the empty line (it checks `line.length() > 0` before the greeting) and then sends its `V1.0 AG` greeting normally. The protocol proceeds as usual from that point.

**Real 4O3A Antenna Genius devices do not match the ShackSwitch check and follow the unchanged code path — no impact on existing AG behaviour.**

Also replaces the simple `disconnectFromDevice()` guard in `connectToDevice()` with an explicit socket abort, preventing a race where multiple auto-connect triggers fire in quick succession and the device accepts an earlier socket while AetherSDR's active socket is a later one.

Adds `isConnecting()` helper (socket exists but prologue not yet received).

## Files changed

- `src/models/AntennaGeniusModel.cpp`
- `src/models/AntennaGeniusModel.h`

73 de G0JKN / Nigel