### PR TITLE
[panadapter] Tighten incremental pan-follow margins

### DIFF
--- a/RECENTER.md
+++ b/RECENTER.md
@@ -162,8 +162,8 @@ Current behavior:
 
 Current constants in `MainWindow.cpp`:
 
-- incremental trigger edge margin: `0.12`
-- incremental settle edge margin: `0.18`
+- incremental trigger edge margin: `0.05`
+- incremental settle edge margin: `0.06`
 - small follow animation target: `110 ms`
 
 Operationally:
@@ -171,6 +171,7 @@ Operationally:
 - if the tuned frequency remains inside the trigger window, no recenter happens
 - once it crosses the trigger fence, pan follow uses the configured step size as its nudge quantum when that step is available
 - the center moves in step-sized increments only far enough to bring the slice back to the trigger boundary, instead of jumping straight to the settle boundary
+- the narrow `5% -> 6%` trigger/settle gap keeps nearly all of the spectrum usable while still adding a small hysteresis band for coarse or bursty inputs
 - the older settle target is still used as a safety cap and as the fallback when no step size is available
 
 ### 2. `AbsoluteJump`

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -156,8 +156,8 @@ namespace AetherSDR {
 
 namespace {
 
-constexpr double kIncrementalTriggerEdgeMarginFrac = 0.12;
-constexpr double kIncrementalSettleEdgeMarginFrac = 0.18;
+constexpr double kIncrementalTriggerEdgeMarginFrac = 0.05;
+constexpr double kIncrementalSettleEdgeMarginFrac = 0.06;
 constexpr double kRevealComfortEdgeMarginFrac = 0.18;
 constexpr int kPanFollowAnimationDurationMs = 110;
 


### PR DESCRIPTION
## Summary

Fixes #1877 by tightening the `IncrementalTune` pan-follow margins introduced by the recenter policy refactor.

This restores the near-edge "fence" behavior operators expect from Pan Follows VFO while keeping the newer shared intent model intact:

- changes incremental trigger margin from `12%` to `5%` of visible bandwidth per side
- changes incremental settle margin from `18%` to `6%` of visible bandwidth per side
- leaves `kRevealComfortEdgeMarginFrac` at `18%` for non-incremental reveal paths
- updates `RECENTER.md` so the architecture notes match the new incremental behavior

## Problem

The recenter policy work made pan-follow behavior more consistent across tuning modalities, but its first incremental margins were too conservative for regular tuning. With `12%` trigger and `18%` settle margins, the usable center area of the panadapter dropped from roughly `90%` to roughly `76%`.

That made normal VFO following feel like it was wasting spectrum real estate at both edges. Wayne's report in #1877 captured the user impact well: when tuning near an edge, the operator expects the panadapter to scroll just enough to keep the tuned signal/filter visible, not to pull the slice noticeably inward and give up a large amount of display space.

## Why This Fix

For `IncrementalTune`, the best behavior is close to the old fence model:

- the slice can move freely through most of the panadapter
- follow engages only near the visible edge
- follow motion remains step-sized and predictable
- the pan does not dead-center during wheel, keyboard, knob, or drag tuning

The existing step-quantized pan-follow logic from #1861 is still useful and is left unchanged. This PR only changes the incremental margins so the policy uses nearly all of the panadapter again.

## Intent Boundaries

This PR intentionally changes only `IncrementalTune`.

Unchanged behavior:

- `AbsoluteJump` still uses the existing comfort reveal margin for click-to-tune, ordinary spots, DX cluster tune, BandStack recall, and "Move Here".
- `CommandedTargetCenter` still centers deliberate command targets such as VFO direct entry, Go To Frequency, quick memory recall, Memory dialog recall, and memory spots.
- `ExplicitPan` / combined pan range handling remains unchanged.
- Explicit center actions remain true center actions.

I did not reduce `kRevealComfortEdgeMarginFrac` to `5%`, even though one issue comment tested that locally. That constant controls jump/reveal behavior, not pan-follow VFO. Keeping it at `18%` preserves the distinction between "continuous tuning near an edge" and "make this discrete target comfortably visible".

## Testing Notes

Testing performed across the recenter policy work before this follow-up:

- Trackpad scroll and keyboard arrow tuning were tested after the step-quantized incremental follow change and felt smooth at the edge.
- MIDI control knob tuning was tested and confirmed smooth with the shared `IncrementalTune` path.
- Regular spots were tested near center and near the edge; they stayed reveal-only and avoided hard recentering.
- Memory spots were tested after bypassing the generic spot-click path; the delayed double-motion issue was resolved.
- Quick memory recall and Memory dialog recall were tested through `CommandedTargetCenter`.
- Go To Frequency and VFO direct entry were tested as commanded-center paths.
- Trackpad bandwidth drag was tested after combined center/bandwidth range handling; no waterfall loss or lag was observed.
- Keyboard zoom and mode jumps such as USB/SAM were tested after combined range handling and behaved correctly.
- This margin change was tested locally with keyboard and trackpad and gave better spectrum usage at the edges.

Known follow-up from testing:

- Very coarse control knob steps can still expose a separate visual issue where the floating VFO card/indicator may clip at the panadapter edge.
- We agreed not to solve that by widening pan-follow margins again, because that would waste spectrum real estate for every tuning source.
- The future fix should live in VFO widget placement/clamping, likely around `VfoWidget::updatePosition(...)` and the `SpectrumWidget` call sites that pass VFO marker positions.
- The intended future behavior is: keep the RF marker/passband near the efficient 5% fence, while the floating card independently flips, docks, or clamps inside the visible spectrum bounds.

## Validation

- `cmake --build build -j10`
- `ctest --output-on-failure -j10`

`ctest` completed successfully but reported that no tests were registered in this build tree.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
