### PR TITLE
[tuning] Restore Flex band-stack selection keys

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7169,15 +7169,31 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         qDebug() << "MainWindow: switching to band" << bandName
                  << "freq:" << freqMhz << "mode:" << mode;
 
-        // Radio-authoritative band change: the radio manages its own band
-        // stack recall (frequency, mode, filters, pan center, bandwidth,
-        // antennas). Aether only has to provide the correct band-stack key.
-        // Translate the UI band label to the radio's band-stack key. Mapping
-        // determined from SmartSDR pcap captures (#1540/#1211):
-        //   - Standard HF names (160, 80, ..., 6, 2200, 630): pass through
-        //   - XVTR display names ("2m"): send band=X<order> (xvtr setup order)
-        //   - WWV / GEN: send numeric band-stack slot 33 / 34 (per pcap)
-        //   - Anything else: refuse; do not synthesize a slice tune fallback
+        // Maintainer note: keep band changes radio-authoritative.
+        //
+        // The Flex band stack owns the state users expect to survive a band
+        // jump: frequency, mode, filters, pan center, bandwidth/zoom, and
+        // built-in antenna selection. Aether should therefore send exactly one
+        // `display pan set <panId> band=<key>` command when it can form a
+        // spec-correct key. Do not use the `freqMhz` / `mode` arguments as a
+        // local fallback; those are static UI defaults, and the old fallback
+        // reset users to band-center SSB instead of restoring their saved stack
+        // state (#1876, #1852, #1856, #1849).
+        //
+        // UI band names are not always protocol keys:
+        //   - Native bands are displayed as "20m", "630m", etc., but Flex
+        //     expects bare keys such as "20" and "630".
+        //   - XVTR names are user labels such as "2m" or "70cm"; do not strip
+        //     those into native-band keys. Flex expects `X<order>`, where
+        //     `order` is the radio's XVTR setup order, not the xvtr status
+        //     object index, RF frequency, or display name.
+        //   - WWV / GEN use numeric band-stack slots 33 / 34 from SmartSDR
+        //     capture history (#1540/#1211).
+        //
+        // If no exact mapping exists, refuse the band change and leave the
+        // current slice/pan state untouched. Guessing is worse than failing
+        // visibly because a wrong tune destroys the very band-stack state this
+        // path exists to preserve.
         static const QSet<QString> kPassThroughBands = {
             "160", "80", "60", "40", "30", "20", "17", "15", "12", "10", "6",
             "2200", "630"

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7170,16 +7170,14 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                  << "freq:" << freqMhz << "mode:" << mode;
 
         // Radio-authoritative band change: the radio manages its own band
-        // stack (frequency, mode, filters, pan center, bandwidth, antennas).
-        // One command handles everything.
-        m_bandSettings.setCurrentBand(bandName);
-
+        // stack recall (frequency, mode, filters, pan center, bandwidth,
+        // antennas). Aether only has to provide the correct band-stack key.
         // Translate the UI band label to the radio's band-stack key. Mapping
         // determined from SmartSDR pcap captures (#1540/#1211):
         //   - Standard HF names (160, 80, ..., 6, 2200, 630): pass through
-        //   - XVTR display names ("2m"): send band=X<idx> (xvtr index)
+        //   - XVTR display names ("2m"): send band=X<order> (xvtr setup order)
         //   - WWV / GEN: send numeric band-stack slot 33 / 34 (per pcap)
-        //   - Anything else: fall back to tuning the slice directly
+        //   - Anything else: refuse; do not synthesize a slice tune fallback
         static const QSet<QString> kPassThroughBands = {
             "160", "80", "60", "40", "30", "20", "17", "15", "12", "10", "6",
             "2200", "630"
@@ -7189,9 +7187,21 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             { QStringLiteral("GEN"), 34 },
         };
 
+        // Band names from the UI carry the human suffix ("20m", "630m"),
+        // while the radio's band-stack keys are bare numbers ("20", "630").
+        // Only strip when the bare value is a known native band so XVTR names
+        // such as "2m" still fall through to the XVTR lookup below.
+        QString radioKey = bandName;
+        if (radioKey.endsWith('m') && radioKey.length() > 1) {
+            const QString stripped = radioKey.chopped(1);
+            if (kPassThroughBands.contains(stripped))
+                radioKey = stripped;
+        }
+
         QString stackKey;
-        if (kPassThroughBands.contains(bandName)) {
-            stackKey = bandName;
+        QString unsupportedBandReason;
+        if (kPassThroughBands.contains(radioKey)) {
+            stackKey = radioKey;
         } else if (kNumericBandSlots.contains(bandName)) {
             stackKey = QString::number(kNumericBandSlots.value(bandName));
             qDebug() << "  ↳ numeric band slot:" << bandName << "->" << stackKey;
@@ -7199,36 +7209,30 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             for (auto it = m_radioModel.xvtrList().constBegin();
                  it != m_radioModel.xvtrList().constEnd(); ++it) {
                 if (it.value().isValid && it.value().name == bandName) {
-                    stackKey = QString("X%1").arg(it.key());
-                    qDebug() << "  ↳ XVTR match:" << bandName << "->" << stackKey;
+                    if (it.value().order < 0) {
+                        unsupportedBandReason =
+                            QString("XVTR %1 has no setup order; cannot form Flex band= key")
+                                .arg(bandName);
+                    } else {
+                        stackKey = QString("X%1").arg(it.value().order);
+                        qDebug() << "  ↳ XVTR match:" << bandName << "->" << stackKey;
+                    }
                     break;
                 }
             }
         }
 
         if (stackKey.isEmpty()) {
-            // Unrecognized band — tune slice directly as a safety net.
-            qDebug() << "  ↳ unrecognized band" << bandName << "— tuning slice directly";
-            SliceModel* s = nullptr;
-            for (auto* sl : m_radioModel.slices()) {
-                if (sl->panId() == applet->panId()) { s = sl; break; }
+            if (unsupportedBandReason.isEmpty()) {
+                unsupportedBandReason =
+                    QString("Band %1 has no Flex display pan band= mapping").arg(bandName);
             }
-            if (!s) s = activeSlice();
-            if (s) {
-                if (!mode.isEmpty() && s->mode() != mode) s->setMode(mode);
-                TuneCenteringResult result;
-                if (auto* pan = m_radioModel.panadapter(s->panId())) {
-                    result.oldCenterMhz = pan->centerMhz();
-                    result.bandwidthMhz = pan->bandwidthMhz();
-                }
-                result.newCenterMhz = freqMhz;
-                result.followRevealTriggered = true;
-                result.hardCenterUsed = true;
-                logTunePolicyDecision("band-fallback", TuneIntent::AbsoluteJump,
-                                      s->frequency(), freqMhz, result);
-                s->tuneAndRecenter(freqMhz);
-            }
+            qWarning() << "MainWindow: refusing unsupported band change:"
+                       << unsupportedBandReason;
+            statusBar()->showMessage(unsupportedBandReason, 5000);
+            return;
         } else {
+            m_bandSettings.setCurrentBand(bandName);
             m_radioModel.sendCommand(
                 QString("display pan set %1 band=%2").arg(applet->panId()).arg(stackKey));
         }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1696,6 +1696,7 @@ void RadioModel::onStatusReceived(const QString& object,
             }
             auto& x = m_xvtrList[idx];
             x.index = idx;
+            if (kvs.contains("order"))     x.order   = kvs["order"].toInt();
             if (kvs.contains("name"))      x.name     = kvs["name"];
             if (kvs.contains("rf_freq"))   x.rfFreq   = kvs["rf_freq"].toDouble();
             if (kvs.contains("if_freq"))   x.ifFreq   = kvs["if_freq"].toDouble();

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -523,6 +523,7 @@ public:
 
     struct XvtrInfo {
         int     index{0};
+        int     order{-1};
         QString name;
         double  rfFreq{0.0};
         double  ifFreq{0.0};


### PR DESCRIPTION
## Summary

Fixes #1876.

This restores radio-authoritative Flex band-stack selection from the spectrum band menu. Native band buttons now send the Flex band-stack key the radio expects, transverter bands are mapped through the radio's XVTR setup order, and unsupported bands are refused instead of falling back to a direct slice tune.

The important behavior change is that AetherSDR again lets the radio own band-stack recall for frequency, mode, filters, pan center, bandwidth/zoom, and antenna state. We do not synthesize a local frequency/mode restore and we do not force a client-side recenter after the band switch.

Manual testing also confirmed that built-in Flex RX/TX antenna selections persist across band changes once Aether uses the correct radio-authoritative `band=` path. This does not add a separate Aether-side antenna memory layer; it restores the radio-owned behavior that was bypassed by the fallback tune path.

## Root Cause

The band selector UI emits human-facing labels such as `20m`, `40m`, `630m`, etc. The band-switching handler was checking those values against a native-band pass-through set containing bare Flex keys such as `20`, `40`, and `630`.

That mismatch meant ordinary native bands missed the intended path:

```text
display pan set <panId> band=20
```

and instead fell into the old unrecognized-band fallback. The fallback directly changed the slice mode and tuned to the static band-grid default, for example `14.225 USB` on 20m. That bypassed the radio's band stack, so user state that should have been restored by the radio was replaced by Aether's hard-coded defaults.

This is why users saw symptoms like:

- returning to 20m at `14.225 USB` instead of their last CW frequency
- returning to 40m at the band edge/default instead of the last used frequency
- span/zoom and pan position appearing to reset across band changes
- mode changing back to SSB when the previous per-band state was CW or another mode
- built-in Flex RX/TX antenna selections appearing not to persist per band when the fallback path bypassed the radio's saved band-stack state

## What Changed

- Normalize native UI labels only when the stripped key is a known Flex native band:
  - `20m` -> `band=20`
  - `630m` -> `band=630`
  - `2200m` -> `band=2200`
- Preserve the existing WWV/GEN behavior:
  - `WWV` -> `band=33`
  - `GEN` -> `band=34`
- Parse the radio's XVTR `order` status field into `RadioModel::XvtrInfo`.
- Map configured transverter display names to Flex XVTR band selectors using `X<order>`:
  - configured `2m` with `order=0` -> `band=X0`
  - configured `70cm` with `order=1` -> `band=X1`
- Remove the unsafe fallback that did `slice set mode=...` plus direct `slice tune ...`.
- Restore radio-owned antenna recall for band changes by ensuring Aether uses the Flex band-stack selector instead of bypassing it with direct slice tune commands.
- If Aether cannot form a spec-correct `band=` key, log a warning, show a short status-bar message, and leave the slice/panadapter untouched.

## Flex API Notes

The public Flex `display pan set` API exposes band selection as a panadapter property:

```text
display pan set <panId> band=<bandKey>
```

For native bands, the key is the radio band-stack name, not the UI label with the meter suffix. For transverters, the selector is the radio's XVTR setup slot in `X<n>` form. The `name` field is the user's display label; the `order` field is the value that determines the `X<n>` selector.

This distinction matters because the XVTR status index is not necessarily the correct selector. This PR uses `order`, not the `xvtr <index>` map key.

## Behavior Matrix

| User selection | Flex command behavior | Notes |
|---|---|---|
| `160m` | `display pan set <panId> band=160` | Native band stack |
| `80m` | `display pan set <panId> band=80` | Native band stack |
| `60m` | `display pan set <panId> band=60` | Native band stack |
| `40m` | `display pan set <panId> band=40` | Native band stack |
| `30m` | `display pan set <panId> band=30` | Native band stack |
| `20m` | `display pan set <panId> band=20` | Native band stack |
| `17m` | `display pan set <panId> band=17` | Native band stack |
| `15m` | `display pan set <panId> band=15` | Native band stack |
| `12m` | `display pan set <panId> band=12` | Native band stack |
| `10m` | `display pan set <panId> band=10` | Native band stack |
| `6m` | `display pan set <panId> band=6` | Native band stack |
| `630m` | `display pan set <panId> band=630` | Native band stack |
| `2200m` | `display pan set <panId> band=2200` | Native band stack |
| `WWV` | `display pan set <panId> band=33` | Existing numeric slot retained |
| `GEN` | `display pan set <panId> band=34` | Existing numeric slot retained |
| XVTR `2m`, `order=0` | `display pan set <panId> band=X0` | Uses XVTR setup order |
| XVTR `70cm`, `order=1` | `display pan set <panId> band=X1` | Uses XVTR setup order |
| XVTR with no `order` | Refuse; no tune fallback | Safer than tuning wrong band |
| Unknown band label | Refuse; no tune fallback | Safer than resetting mode/frequency |

## Issue History

This PR directly fixes the failure proven in #1876: native band changes were not using the radio band stack and instead reset VFO/span state to Aether's defaults.

It also appears to address the same regression pattern reported in:

- #1852: span and VFO freeze / reset when changing bands; reporter confirmed it was the same as #1876
- #1856: last band settings not saved; returning to 20m lands on `14.300` SSB instead of the previous CW QRG
- #1849: returning to a band lands at the band upper edge/default instead of the last used frequency
- #1800: VFO switches to SSB mode at every band change
- #1761: mode and frequency not retained in v0.8.18/v0.8.19
- #1743: VFO/span not memorized; returns to SSB center band
- #1662: v0.8.16 no longer memorizes slices; returns to SSB and pan center
- #1093: older report describing pan/VFO position not remaining where the user left it
- #1886: built-in Flex TX/RX antenna selection not remembered per band; testing confirmed this PR restores antenna persistence when the radio band stack owns the saved antenna state
- #1758: antenna 1 / antenna 2 state not memorized across band changes

Related prior history:

- #1880: draft minimal fix that stripped the `m` suffix for native bands. This PR keeps that core idea, but also removes the unsafe fallback and fixes XVTR selection against the Flex API shape.
- #649: earlier zoom/bandwidth persistence report. This PR relies on the radio band stack to restore the bandwidth/zoom state rather than adding a separate Aether-side zoom override.
- #1540: WWV, GEN, and XVTR band stack failures / blank waterfall history. This PR preserves WWV/GEN numeric slots and hardens XVTR key generation.
- #1211: loss of transverter operation after 8.7.
- #1213: Antenna Genius band-to-antenna recall race. This is a separate external AG path, but useful history because it shows the same user expectation: band changes should recall the appropriate antenna.
- #571: XVTR bands not appearing in the main selector after configuration.
- #695: 6700 native VHF band visibility history; adjacent to band listing behavior but not directly changed here.

## Validation

Automated/local checks:

- `git diff --check`
- `cmake --build build -j10`

Build succeeded. The compiler still reports unrelated pre-existing lambda-capture warnings in `MainWindow.cpp`.

Manual validation performed:

- Native band switching restores last-used frequency and zoom/span instead of resetting to hard-coded defaults.
- No client-side recenter override is applied after band switch; this matches SmartSDR behavior where the radio restores the band stack's pan center.
- Built-in Flex RX/TX antenna selections persist across band changes when set per band and recalled through the restored `display pan set ... band=` path.
- XVTR entries can be configured without physical transverter hardware and selected from the band menu.
- Test XVTR profile:
  - `2m`: RF `144.200`, IF `28.200`, LO `116.000`, RX Only enabled, Max Power `0.0`
  - `70cm`: RF `432.100`, IF `28.100`, LO `404.000`, RX Only enabled, Max Power `0.0`
- Switching across `2m`, `70cm`, and native HF bands preserves frequency and zoom/span state.

## Suggested Test Plan

### Native Band Stack

1. Start on `20m`.
2. Tune to a non-default frequency, for example `14.360.000`.
3. Set a distinctive mode, for example CW.
4. Adjust pan position so the VFO is visible but not necessarily centered.
5. Set a distinctive panadapter bandwidth/zoom.
6. Switch to `40m`.
7. Tune `40m` to a different non-default frequency and use a different zoom/span.
8. Switch back to `20m`.
9. Verify frequency, mode, pan center, and bandwidth/zoom match the prior `20m` state.
10. Repeat across several native bands, including `630m` or `2200m` if available.

### Two Slice Regression

1. Create Slice A and Slice B on different bands.
2. Give each slice a different frequency, mode, pan position, and zoom/span.
3. Change bands from each slice's panadapter.
4. Return to the original bands.
5. Verify each slice/panadapter returns to its own band-stack state and does not inherit the other slice's defaults.

### WWV / GEN

1. Select `WWV`.
2. Verify the radio changes via the band stack and does not use direct slice tuning fallback.
3. Select `GEN`.
4. Verify the same.
5. Confirm there are no status-bar warnings for these selections.

### Built-in Flex Antenna Persistence

1. Start on `20m`.
2. Select a distinctive built-in RX/TX antenna, for example `ANT2`.
3. Switch to `40m`.
4. Select a different built-in RX/TX antenna, for example `ANT1`.
5. Switch back to `20m`.
6. Verify the radio/Aether restore the prior `20m` antenna selection.
7. Switch back to `40m`.
8. Verify the prior `40m` antenna selection is restored.
9. Repeat with the opposite direction and, where available, with separate RX and TX antenna choices.

### XVTR Without Physical Hardware

1. Open Radio Setup -> XVTR.
2. Add a `2m` XVTR:
   - Name: `2m`
   - RF Freq: `144.200`
   - IF Freq: `28.200`
   - LO Freq: `116.000`
   - LO Error: `0`
   - RX Gain: `0.0`
   - RX Only: enabled
   - Max Power: `0.0`
3. Add a `70cm` XVTR:
   - Name: `70cm`
   - RF Freq: `432.100`
   - IF Freq: `28.100`
   - LO Freq: `404.000`
   - LO Error: `0`
   - RX Gain: `0.0`
   - RX Only: enabled
   - Max Power: `0.0`
4. Close Radio Setup and open the band selector.
5. Select `2m`; verify the panadapter tunes to the XVTR band.
6. Set a distinctive zoom/span and tune within the XVTR band.
7. Switch to a native HF band, then back to `2m`; verify frequency and zoom/span persist.
8. Repeat with `70cm`.

### XVTR Order Regression

1. With two XVTR entries configured, verify the debug log reports `XVTR match: "2m" -> "X0"` and `XVTR match: "70cm" -> "X1"` or the corresponding order values reported by the radio.
2. If the radio UI allows reordering, reorder the XVTR entries.
3. Reconnect or force status refresh.
4. Verify Aether follows the radio's updated `order` value rather than the status object index.

### Negative / Safety Behavior

1. Attempt to select an invalid or unsupported band mapping, if one can be produced from a test build or malformed radio status.
2. Verify Aether shows a status-bar warning and logs a warning.
3. Verify Aether does not send a direct `slice tune` fallback and does not change the slice mode/frequency.

## Risk Notes

- This intentionally removes the direct-tune fallback. That is safer for preserving radio state, but it means a malformed or unsupported band entry now fails visibly instead of trying to guess a frequency/mode.
- XVTR selection now depends on the radio reporting `order`. That matches the Flex API behavior we need for `X<n>` selectors; if a radio/firmware does not provide `order`, Aether refuses the XVTR selection rather than risking the wrong transverter.
- No Aether-side recentering is applied after band switches. This is intentional because SmartSDR preserves the band stack's pan center when returning to a band.
- Built-in Flex antenna persistence still relies on the radio band stack. This PR does not add a separate client-side `rxant` / `txant` memory layer in Aether. If a future radio/firmware path does not save antenna changes into the band stack, that would need a separate #1886-style follow-up.

## Files Changed

- `src/gui/MainWindow.cpp`
- `src/models/RadioModel.cpp`
- `src/models/RadioModel.h`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
