### PR TITLE
[feature] Add remote client disconnect flows (LAN, SmartLink, Maestro)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -481,6 +481,7 @@ set(MODEL_SOURCES
 set(GUI_SOURCES
     src/gui/MainWindow.cpp
     src/gui/ConnectionPanel.cpp
+    src/gui/ClientDisconnectDialog.cpp
     src/gui/SpectrumWidget.cpp
     src/gui/SpectrumOverlayMenu.cpp
     src/gui/VfoWidget.cpp

--- a/src/core/SmartLinkClient.cpp
+++ b/src/core/SmartLinkClient.cpp
@@ -252,6 +252,27 @@ void SmartLinkClient::requestConnect(const QString& serial, quint16 holePunchPor
     m_socket.write(cmd.toUtf8());
 }
 
+void SmartLinkClient::disconnectRadioClients(const QString& serial, const QList<quint32>& handles)
+{
+    if (!m_serverConnected || serial.isEmpty())
+        return;
+
+    QList<quint32> uniqueHandles;
+    for (quint32 handle : handles) {
+        if (handle != 0 && !uniqueHandles.contains(handle))
+            uniqueHandles.append(handle);
+    }
+
+    for (quint32 handle : uniqueHandles) {
+        const QString handleText = QString("0x%1").arg(handle, 0, 16);
+        const QString cmd = QString("application disconnect_users serial=%1 handle=%2\n")
+                                .arg(serial, handleText);
+        qCDebug(lcSmartLink) << "SmartLinkClient: disconnecting GUI client"
+                             << handleText << "from radio" << serial;
+        m_socket.write(cmd.toUtf8());
+    }
+}
+
 // ── TLS Socket Callbacks ─────────────────────────────────────────────────────
 
 void SmartLinkClient::onSslConnected()

--- a/src/core/SmartLinkClient.h
+++ b/src/core/SmartLinkClient.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QList>
 #include <QSslSocket>
 #include <QString>
 #include <QStringList>
@@ -61,6 +62,8 @@ public:
     // holePunchPort is the local UDP port we've bound for VITA-49 reception;
     // the SmartLink server tells the radio to send UDP to our public IP:port.
     void requestConnect(const QString& serial, quint16 holePunchPort = 0);
+    // Ask the SmartLink server to force-disconnect specific GUI clients.
+    void disconnectRadioClients(const QString& serial, const QList<quint32>& handles);
     // Disconnect from SmartLink server
     void disconnect();
 

--- a/src/gui/ClientDisconnectDialog.cpp
+++ b/src/gui/ClientDisconnectDialog.cpp
@@ -1,0 +1,217 @@
+#include "ClientDisconnectDialog.h"
+
+#include <QAbstractButton>
+#include <QApplication>
+#include <QCursor>
+#include <QFrame>
+#include <QGuiApplication>
+#include <QLabel>
+#include <QPushButton>
+#include <QScreen>
+#include <QScrollArea>
+#include <QShowEvent>
+#include <QVBoxLayout>
+#include <QWindow>
+#include <algorithm>
+
+namespace AetherSDR {
+
+namespace {
+
+const char* kDialogStyle =
+    "QDialog { background: #0f0f1a; }"
+    "QFrame#clientDisconnectHeader {"
+    "  background: qlineargradient(x1:0, y1:0, x2:1, y2:0,"
+    "    stop:0 #103626, stop:1 #10283a);"
+    "  border-bottom: 1px solid #00b4d8;"
+    "}"
+    "QLabel { color: #c8d8e8; background: transparent; }"
+    "QLabel#eyebrow { color: #40ff80; background: transparent; font-weight: bold; }"
+    "QLabel#title { color: #ffffff; background: transparent; font-size: 18px; font-weight: bold; }"
+    "QLabel#body { color: #c8d8e8; background: transparent; }"
+    "QLabel#prompt { color: #8aa8c0; background: transparent; font-weight: bold; }"
+    "QPushButton {"
+    "  background: #1a2a3a;"
+    "  border: 1px solid #304050;"
+    "  border-radius: 3px;"
+    "  color: #c8d8e8;"
+    "  padding: 6px 14px;"
+    "}"
+    "QPushButton:hover { background: #203040; border-color: #00b4d8; }"
+    "QPushButton:pressed { background: #102030; }"
+    "QPushButton#primaryButton {"
+    "  background: #00b4d8;"
+    "  border-color: #00c8f0;"
+    "  color: #0f0f1a;"
+    "  font-weight: bold;"
+    "}"
+    "QPushButton#primaryButton:hover { background: #00c8f0; }"
+    "QPushButton#cancelButton { color: #8aa8c0; }"
+    "QScrollArea { background: transparent; border: none; }"
+    "QScrollBar:vertical { background: #0a0a14; width: 8px; }"
+    "QScrollBar::handle:vertical { background: #304050; border-radius: 4px; }"
+    "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }";
+
+QList<quint32> allHandles(const QList<ClientDisconnectDialog::Client>& clients)
+{
+    QList<quint32> handles;
+    for (const auto& client : clients) {
+        if (client.handle != 0 && !handles.contains(client.handle))
+            handles.append(client.handle);
+    }
+    return handles;
+}
+
+} // namespace
+
+ClientDisconnectDialog::ClientDisconnectDialog(const QList<Client>& clients,
+                                               int maxSlices,
+                                               QWidget* parent,
+                                               Mode mode)
+    : QDialog(parent)
+    , m_clients(clients)
+{
+    const bool remoteMode = mode == Mode::RemoteClientDisconnect;
+
+    setWindowTitle(remoteMode ? tr("Disconnect remote clients") : tr("Radio in use"));
+    setModal(true);
+    setWindowModality(Qt::ApplicationModal);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    setSizeGripEnabled(false);
+    setStyleSheet(kDialogStyle);
+
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    auto* header = new QFrame(this);
+    header->setObjectName("clientDisconnectHeader");
+    auto* headerLayout = new QVBoxLayout(header);
+    headerLayout->setContentsMargins(18, 14, 18, 14);
+    headerLayout->setSpacing(4);
+
+    auto* eyebrow = new QLabel(remoteMode ? tr("Remote clients") : tr("Radio in use"), header);
+    eyebrow->setObjectName("eyebrow");
+    headerLayout->addWidget(eyebrow);
+
+    auto* title = new QLabel(remoteMode ? tr("Disconnect clients") : tr("No available slices"), header);
+    title->setObjectName("title");
+    headerLayout->addWidget(title);
+    outer->addWidget(header);
+
+    auto* content = new QWidget(this);
+    auto* layout = new QVBoxLayout(content);
+    layout->setContentsMargins(18, 16, 18, 18);
+    layout->setSpacing(10);
+
+    auto* body = new QLabel(remoteMode
+            ? tr("Choose a SmartLink client to disconnect from this radio, or disconnect all clients.")
+            : tr("All available receiver slices on this radio are currently being used by other clients. "
+                 "Disconnect a client to free a slice, or cancel the connection."),
+        content);
+    body->setObjectName("body");
+    body->setWordWrap(true);
+    layout->addWidget(body);
+
+    auto* prompt = new QLabel(tr("Please select:"), content);
+    prompt->setObjectName("prompt");
+    layout->addWidget(prompt);
+
+    auto addButton = [this, layout, content](const QString& text,
+                                             const QList<quint32>& handles,
+                                             const QString& objectName = QString()) {
+        auto* button = new QPushButton(text, content);
+        if (!objectName.isEmpty())
+            button->setObjectName(objectName);
+        button->setCursor(Qt::PointingHandCursor);
+        button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        button->setMinimumHeight(32);
+        connect(button, &QPushButton::clicked, this, [this, handles] {
+            acceptWithHandles(handles);
+        });
+        layout->addWidget(button);
+    };
+
+    addButton(tr("Disconnect all clients"), allHandles(m_clients), QStringLiteral("primaryButton"));
+
+    auto* scroll = new QScrollArea(content);
+    scroll->setWidgetResizable(true);
+    scroll->setFrameShape(QFrame::NoFrame);
+    auto* scrollContents = new QWidget(scroll);
+    auto* clientLayout = new QVBoxLayout(scrollContents);
+    clientLayout->setContentsMargins(0, 0, 0, 0);
+    clientLayout->setSpacing(8);
+    scroll->setWidget(scrollContents);
+
+    for (const auto& client : m_clients) {
+        auto* button = new QPushButton(tr("Disconnect %1").arg(displayName(client)), scrollContents);
+        button->setCursor(Qt::PointingHandCursor);
+        button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        button->setMinimumHeight(32);
+        connect(button, &QPushButton::clicked, this, [this, handle = client.handle] {
+            acceptWithHandles({handle});
+        });
+        clientLayout->addWidget(button);
+    }
+
+    const int clientCount = static_cast<int>(m_clients.size());
+    const int visibleRows = std::min(4, std::max(1, clientCount));
+    scroll->setFixedHeight(visibleRows * 34 + std::max(0, visibleRows - 1) * 8);
+    layout->addWidget(scroll);
+
+    auto* cancel = new QPushButton(tr("Cancel"), content);
+    cancel->setObjectName("cancelButton");
+    cancel->setCursor(Qt::PointingHandCursor);
+    cancel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    cancel->setMinimumHeight(32);
+    connect(cancel, &QPushButton::clicked, this, &QDialog::reject);
+    layout->addWidget(cancel);
+    outer->addWidget(content);
+
+    const int width = std::clamp(440 + std::max(0, maxSlices - 4) * 10, 440, 560);
+    resize(width, sizeHint().height());
+}
+
+void ClientDisconnectDialog::showEvent(QShowEvent* event)
+{
+    QDialog::showEvent(event);
+
+    QScreen* screen = nullptr;
+    if (parentWidget() && parentWidget()->windowHandle())
+        screen = parentWidget()->windowHandle()->screen();
+    if (!screen)
+        screen = QGuiApplication::screenAt(QCursor::pos());
+    if (!screen)
+        screen = QGuiApplication::primaryScreen();
+    if (!screen)
+        return;
+
+    const QRect area = screen->availableGeometry();
+    move(area.center() - rect().center());
+}
+
+QString ClientDisconnectDialog::displayName(const Client& client) const
+{
+    const QString program = client.program.trimmed();
+    const QString station = client.station.trimmed();
+
+    if (!program.isEmpty() && !station.isEmpty() && program != station)
+        return tr("%1: %2").arg(program, station);
+    if (!station.isEmpty())
+        return station;
+    if (!program.isEmpty())
+        return program;
+    return tr("client 0x%1").arg(client.handle, 8, 16, QChar('0')).toUpper();
+}
+
+void ClientDisconnectDialog::acceptWithHandles(const QList<quint32>& handles)
+{
+    m_selectedHandles.clear();
+    for (quint32 handle : handles) {
+        if (handle != 0 && !m_selectedHandles.contains(handle))
+            m_selectedHandles.append(handle);
+    }
+    accept();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientDisconnectDialog.h
+++ b/src/gui/ClientDisconnectDialog.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QDialog>
+#include <QList>
+#include <QString>
+
+namespace AetherSDR {
+
+class ClientDisconnectDialog : public QDialog {
+public:
+    enum class Mode {
+        SliceSlotsFull,
+        RemoteClientDisconnect
+    };
+
+    struct Client {
+        quint32 handle{0};
+        QString program;
+        QString station;
+    };
+
+    explicit ClientDisconnectDialog(const QList<Client>& clients,
+                                    int maxSlices,
+                                    QWidget* parent = nullptr,
+                                    Mode mode = Mode::SliceSlotsFull);
+
+    QList<quint32> selectedHandles() const { return m_selectedHandles; }
+
+protected:
+    void showEvent(QShowEvent* event) override;
+
+private:
+    QString displayName(const Client& client) const;
+    void acceptWithHandles(const QList<quint32>& handles);
+
+    QList<Client> m_clients;
+    QList<quint32> m_selectedHandles;
+};
+
+} // namespace AetherSDR

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -301,9 +301,20 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     loginLayout->addRow(QString(), m_loginBtn);
     accountLayout->addWidget(m_loginForm);
 
-    m_logoutBtn = new QPushButton("Sign Out", accountGroup);
+    auto* accountActionBar = new QWidget(accountGroup);
+    auto* accountActionRow = new QHBoxLayout(accountActionBar);
+    accountActionRow->setContentsMargins(0, 0, 0, 0);
+    accountActionRow->setSpacing(10);
+
+    m_logoutBtn = new QPushButton("Sign Out", accountActionBar);
     m_logoutBtn->setVisible(false);
-    accountLayout->addWidget(m_logoutBtn, 0, Qt::AlignLeft);
+    accountActionRow->addWidget(m_logoutBtn);
+    m_wanDisconnectClientsBtn = new QPushButton("Disconnect Remote Clients", accountActionBar);
+    m_wanDisconnectClientsBtn->setVisible(false);
+    m_wanDisconnectClientsBtn->setEnabled(false);
+    accountActionRow->addWidget(m_wanDisconnectClientsBtn);
+    accountActionRow->addStretch();
+    accountLayout->addWidget(accountActionBar);
 
     m_slUserLabel = makeWrappedLabel("Sign in to see radios at remote stations.", kHintLabelStyle);
     accountLayout->addWidget(m_slUserLabel);
@@ -466,6 +477,8 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
             this, &ConnectionPanel::onLocalConnectClicked);
     connect(m_wanConnectBtn, &QPushButton::clicked,
             this, &ConnectionPanel::onWanConnectClicked);
+    connect(m_wanDisconnectClientsBtn, &QPushButton::clicked,
+            this, &ConnectionPanel::onWanDisconnectClientsClicked);
     connect(m_disconnectBtn, &QPushButton::clicked,
             this, &ConnectionPanel::disconnectRequested);
     connect(m_radioList, &QListWidget::itemDoubleClicked, this, [this](QListWidgetItem*) {
@@ -622,6 +635,7 @@ void ConnectionPanel::updateSmartLinkUi()
 
     m_loginForm->setVisible(!authed);
     m_logoutBtn->setVisible(authed);
+    m_wanDisconnectClientsBtn->setVisible(authed);
     m_wanList->setVisible(hasWanRadios);
     m_wanConnectBtn->setVisible(authed);
 
@@ -663,6 +677,16 @@ void ConnectionPanel::updateActionState()
         && m_smartLink->isAuthenticated()
         && m_wanList->currentItem() != nullptr;
     m_wanConnectBtn->setEnabled(smartLinkReady);
+
+    const int wanRow = m_wanList->currentRow();
+    const bool remoteClientsAvailable = wanRow >= 0
+        && wanRow < m_wanRadios.size()
+        && !m_wanRadios[wanRow].guiClientHandles.trimmed().isEmpty();
+    const bool smartLinkDisconnectReady = m_smartLink
+        && m_smartLink->isAuthenticated()
+        && m_smartLink->isConnected()
+        && remoteClientsAvailable;
+    m_wanDisconnectClientsBtn->setEnabled(smartLinkDisconnectReady);
 
     const bool manualReady = !m_connected && !m_manualIpEdit->text().trimmed().isEmpty();
     m_manualConnectBtn->setEnabled(manualReady);
@@ -814,6 +838,15 @@ void ConnectionPanel::onWanConnectClicked()
 
     saveLowBandwidthPreference(m_lowBwCheck->isChecked());
     emit wanConnectRequested(m_wanRadios[row]);
+}
+
+void ConnectionPanel::onWanDisconnectClientsClicked()
+{
+    const int row = m_wanList->currentRow();
+    if (row < 0 || row >= m_wanRadios.size())
+        return;
+
+    emit wanDisconnectClientsRequested(m_wanRadios[row]);
 }
 
 void ConnectionPanel::setSmartLinkClient(SmartLinkClient* client)

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -43,6 +43,7 @@ public slots:
 signals:
     void connectRequested(const RadioInfo& radio);
     void wanConnectRequested(const WanRadioInfo& radio);
+    void wanDisconnectClientsRequested(const WanRadioInfo& radio);
     void disconnectRequested();
     void routedRadioFound(const RadioInfo& radio);
     void retryDiscoveryRequested();
@@ -55,6 +56,7 @@ private slots:
     void onWanSelectionChanged();
     void onLocalConnectClicked();
     void onWanConnectClicked();
+    void onWanDisconnectClientsClicked();
     void onManualIpChanged(const QString& ip);
     void onManualConnectClicked();
     void onManualAdvancedToggled(bool checked);
@@ -110,6 +112,7 @@ private:
     QLabel*      m_slUserLabel{nullptr};
     QListWidget* m_wanList{nullptr};
     QLabel*      m_smartLinkEmptyLabel{nullptr};
+    QPushButton* m_wanDisconnectClientsBtn{nullptr};
     QPushButton* m_wanConnectBtn{nullptr};
     QList<WanRadioInfo> m_wanRadios;
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3,6 +3,7 @@
 #include "MqttApplet.h"
 #endif
 #include "ConnectionPanel.h"
+#include "ClientDisconnectDialog.h"
 #include "TitleBar.h"
 #include "PanadapterApplet.h"
 #include "PanadapterStack.h"
@@ -115,6 +116,7 @@
 #include <QLabel>
 #include <QCloseEvent>
 #include <QMessageBox>
+#include <QPushButton>
 #include <QShortcut>
 #include <QScrollArea>
 #include <QFrame>
@@ -315,6 +317,335 @@ static bool shortcutGuard() {
     return s_keyboardShortcutsEnabled && !isTextInputFocused();
 }
 
+static QStringList splitClientField(const QString& raw)
+{
+    QString cleaned = raw;
+    cleaned.replace(QChar(0x7f), QLatin1Char(' '));
+
+    QStringList values;
+    for (const QString& value : cleaned.split(',', Qt::SkipEmptyParts))
+        values << value.trimmed();
+    return values;
+}
+
+static quint32 parseClientHandle(QString text)
+{
+    text = text.trimmed();
+    if (text.startsWith("0x", Qt::CaseInsensitive))
+        text = text.mid(2);
+
+    bool ok = false;
+    const quint32 handle = text.toUInt(&ok, 16);
+    return ok ? handle : 0;
+}
+
+static QList<ClientDisconnectDialog::Client> buildDisconnectClients(const QStringList& handles,
+                                                                    const QStringList& programs,
+                                                                    const QStringList& stations)
+{
+    QList<ClientDisconnectDialog::Client> clients;
+    for (int i = 0; i < handles.size(); ++i) {
+        const quint32 handle = parseClientHandle(handles[i]);
+        if (handle == 0)
+            continue;
+
+        if (std::any_of(clients.cbegin(), clients.cend(), [handle](const auto& client) {
+                return client.handle == handle;
+            })) {
+            continue;
+        }
+
+        ClientDisconnectDialog::Client client;
+        client.handle = handle;
+        if (i < programs.size())
+            client.program = programs[i];
+        if (i < stations.size())
+            client.station = stations[i];
+        clients.append(client);
+    }
+    return clients;
+}
+
+static QList<ClientDisconnectDialog::Client> buildDisconnectClients(const RadioInfo& info)
+{
+    return buildDisconnectClients(info.guiClientHandles,
+                                  info.guiClientPrograms,
+                                  info.guiClientStations);
+}
+
+static QList<ClientDisconnectDialog::Client> buildDisconnectClients(const WanRadioInfo& info)
+{
+    return buildDisconnectClients(splitClientField(info.guiClientHandles),
+                                  splitClientField(info.guiClientPrograms),
+                                  splitClientField(info.guiClientStations));
+}
+
+bool MainWindow::confirmClientSlotAvailability(const RadioInfo& info,
+                                               QList<quint32>* disconnectHandles)
+{
+    if (disconnectHandles)
+        disconnectHandles->clear();
+
+    const auto clients = buildDisconnectClients(info);
+    const int maxSlices = RadioModel::maxSlicesForModel(info.model);
+    if (clients.isEmpty() || clients.size() < maxSlices)
+        return true;
+
+    ClientDisconnectDialog dialog(clients, maxSlices, this);
+    if (dialog.exec() != QDialog::Accepted)
+        return false;
+
+    if (disconnectHandles)
+        *disconnectHandles = dialog.selectedHandles();
+    return !dialog.selectedHandles().isEmpty();
+}
+
+bool MainWindow::confirmClientSlotAvailability(const WanRadioInfo& info,
+                                               QList<quint32>* disconnectHandles)
+{
+    if (disconnectHandles)
+        disconnectHandles->clear();
+
+    const auto clients = buildDisconnectClients(info);
+    const int maxSlices = RadioModel::maxSlicesForModel(info.model);
+    if (clients.isEmpty() || clients.size() < maxSlices)
+        return true;
+
+    ClientDisconnectDialog dialog(clients, maxSlices, this);
+    if (dialog.exec() != QDialog::Accepted)
+        return false;
+
+    if (disconnectHandles)
+        *disconnectHandles = dialog.selectedHandles();
+    return !dialog.selectedHandles().isEmpty();
+}
+
+void MainWindow::disconnectWanRadioClients(const WanRadioInfo& info)
+{
+    if (!m_smartLink.isConnected()) {
+        m_connPanel->setStatusText("SmartLink is not connected");
+        return;
+    }
+
+    const auto clients = buildDisconnectClients(info);
+    if (clients.isEmpty()) {
+        m_connPanel->setStatusText("No remote clients to disconnect");
+        statusBar()->showMessage("No remote clients are currently reported for that radio.", 4000);
+        return;
+    }
+
+    ClientDisconnectDialog dialog(clients,
+                                  RadioModel::maxSlicesForModel(info.model),
+                                  this,
+                                  ClientDisconnectDialog::Mode::RemoteClientDisconnect);
+    if (dialog.exec() != QDialog::Accepted)
+        return;
+
+    const QList<quint32> handles = dialog.selectedHandles();
+    if (handles.isEmpty())
+        return;
+
+    m_smartLink.disconnectRadioClients(info.serial, handles);
+    m_connPanel->setStatusText("Disconnect request sent");
+    statusBar()->showMessage("Remote client disconnect request sent through SmartLink.", 4000);
+}
+
+void MainWindow::startWanRadioConnect(const WanRadioInfo& info)
+{
+    QList<quint32> disconnectHandles;
+    if (!confirmClientSlotAvailability(info, &disconnectHandles)) {
+        m_connPanel->setStatusText("Connection canceled");
+        setPanadapterConnectionAnimation(false);
+        return;
+    }
+
+    m_userDisconnected = false;
+    m_radioModel.setPendingClientDisconnects(disconnectHandles);
+    m_connPanel->setStatusText("Requesting SmartLink connection…");
+    setPanadapterConnectionAnimation(true, "Connecting to remote radio…");
+    // Store WAN radio info for when connect_ready arrives
+    m_pendingWanRadio = info;
+
+    // Pre-bind UDP socket for VITA-49 reception BEFORE requesting
+    // connection, so we can pass our port to the SmartLink server.
+    // The server tells the radio our public IP:port for UDP streaming.
+    quint16 udpPort = m_radioModel.panStream()->localPort();
+    if (udpPort == 0) {
+        // Not yet bound — start WAN early to get a port
+        const quint16 radioUdpPort = static_cast<quint16>(
+            info.publicUdpPort > 0 ? info.publicUdpPort : 4993);
+        auto* ps = m_radioModel.panStream();
+        QMetaObject::invokeMethod(ps, [ps, info, radioUdpPort]() {
+            ps->startWan(QHostAddress(info.publicIp), radioUdpPort);
+        }, Qt::BlockingQueuedConnection);
+        udpPort = ps->localPort();
+    }
+    qDebug() << "MainWindow: pre-bound UDP port" << udpPort << "for WAN hole punch";
+    auto requestSmartLinkConnect = [this, serial = info.serial, udpPort] {
+        if (serial != m_pendingWanRadio.serial)
+            return;
+        m_smartLink.requestConnect(serial, udpPort);
+    };
+    if (!disconnectHandles.isEmpty()) {
+        m_smartLink.disconnectRadioClients(info.serial, disconnectHandles);
+        QTimer::singleShot(350, this, requestSmartLinkConnect);
+    } else {
+        requestSmartLinkConnect();
+    }
+}
+
+void MainWindow::showForcedDisconnectDialog(bool wasWan,
+                                            const RadioInfo& radioInfo,
+                                            const WanRadioInfo& wanInfo)
+{
+    if (m_reconnectDlg) {
+        m_reconnectDlg->close();
+        m_reconnectDlg->deleteLater();
+        m_reconnectDlg = nullptr;
+    }
+
+    auto* dialog = new QDialog(this);
+    m_reconnectDlg = dialog;
+    dialog->setWindowTitle(tr("Radio Disconnected"));
+    dialog->setModal(true);
+    dialog->setWindowModality(Qt::ApplicationModal);
+    dialog->setWindowFlags(dialog->windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    dialog->setFixedWidth(460);
+    dialog->setStyleSheet(
+        "QDialog { background: #0f0f1a; }"
+        "QFrame#forcedDisconnectHeader {"
+        "  background: qlineargradient(x1:0, y1:0, x2:1, y2:0,"
+        "    stop:0 #103626, stop:1 #10283a);"
+        "  border-bottom: 1px solid #00b4d8;"
+        "}"
+        "QLabel { color: #c8d8e8; background: transparent; }"
+        "QLabel#eyebrow { color: #40ff80; background: transparent; font-weight: bold; }"
+        "QLabel#title { color: #ffffff; background: transparent; font-size: 18px; font-weight: bold; }"
+        "QLabel#body { color: #c8d8e8; background: transparent; }"
+        "QPushButton {"
+        "  background: #1a2a3a;"
+        "  border: 1px solid #304050;"
+        "  border-radius: 3px;"
+        "  color: #c8d8e8;"
+        "  padding: 7px 16px;"
+        "}"
+        "QPushButton:hover { background: #203040; border-color: #00b4d8; }"
+        "QPushButton#primaryButton {"
+        "  background: #00b4d8;"
+        "  border-color: #00c8f0;"
+        "  color: #0f0f1a;"
+        "  font-weight: bold;"
+        "}"
+        "QPushButton#primaryButton:hover { background: #00c8f0; }");
+
+    auto* outer = new QVBoxLayout(dialog);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    auto* header = new QFrame(dialog);
+    header->setObjectName("forcedDisconnectHeader");
+    auto* headerLayout = new QVBoxLayout(header);
+    headerLayout->setContentsMargins(18, 14, 18, 14);
+    headerLayout->setSpacing(4);
+
+    auto* eyebrow = new QLabel(tr("CONNECTION ENDED"), header);
+    eyebrow->setObjectName("eyebrow");
+    headerLayout->addWidget(eyebrow);
+
+    auto* title = new QLabel(tr("Disconnected by another client"), header);
+    title->setObjectName("title");
+    headerLayout->addWidget(title);
+    outer->addWidget(header);
+
+    auto* content = new QWidget(dialog);
+    auto* layout = new QVBoxLayout(content);
+    layout->setContentsMargins(18, 16, 18, 18);
+    layout->setSpacing(14);
+
+    auto* body = new QLabel(
+        tr("Another client requested this AetherSDR session to disconnect. "
+           "Automatic reconnect has been paused so the other operator can use the radio safely."),
+        content);
+    body->setObjectName("body");
+    body->setWordWrap(true);
+    layout->addWidget(body);
+
+    auto* buttons = new QHBoxLayout;
+    buttons->setSpacing(10);
+
+    auto* quit = new QPushButton(tr("Quit"), content);
+    quit->setCursor(Qt::PointingHandCursor);
+    quit->setMinimumHeight(34);
+    buttons->addWidget(quit);
+
+    auto* reconnect = new QPushButton(tr("Reconnect"), content);
+    reconnect->setObjectName("primaryButton");
+    reconnect->setCursor(Qt::PointingHandCursor);
+    reconnect->setMinimumHeight(34);
+    buttons->addWidget(reconnect);
+    layout->addLayout(buttons);
+    outer->addWidget(content);
+
+    connect(dialog, &QObject::destroyed, this, [this, dialog] {
+        if (m_reconnectDlg == dialog)
+            m_reconnectDlg = nullptr;
+    });
+
+    connect(quit, &QPushButton::clicked, this, [this, dialog] {
+        m_userDisconnected = true;
+        if (m_reconnectDlg == dialog)
+            m_reconnectDlg = nullptr;
+        dialog->close();
+        dialog->deleteLater();
+        QApplication::quit();
+    });
+
+    connect(reconnect, &QPushButton::clicked, this, [this, dialog, wasWan, radioInfo, wanInfo] {
+        if (m_reconnectDlg == dialog)
+            m_reconnectDlg = nullptr;
+        dialog->close();
+        dialog->deleteLater();
+
+        m_userDisconnected = false;
+        m_connPanel->setStatusText("Reconnecting…");
+        setPanadapterConnectionAnimation(true, "Reconnecting to radio…");
+
+        QTimer::singleShot(300, this, [this, wasWan, radioInfo, wanInfo] {
+            if (wasWan && !wanInfo.serial.isEmpty()) {
+                startWanRadioConnect(wanInfo);
+                return;
+            }
+
+            if (radioInfo.address.isNull()) {
+                setPanadapterConnectionAnimation(false);
+                m_connPanel->setStatusText("Select a radio to reconnect");
+                m_connPanel->show();
+                return;
+            }
+
+            QList<quint32> disconnectHandles;
+            if (!confirmClientSlotAvailability(radioInfo, &disconnectHandles)) {
+                m_userDisconnected = true;
+                m_connPanel->setStatusText("Connection canceled");
+                setPanadapterConnectionAnimation(false);
+                return;
+            }
+
+            m_radioModel.setPendingClientDisconnects(disconnectHandles);
+            m_radioModel.connectToRadio(radioInfo);
+        });
+    });
+
+    dialog->adjustSize();
+    if (QScreen* screen = windowHandle() ? windowHandle()->screen() : QApplication::primaryScreen()) {
+        const QRect area = screen->availableGeometry();
+        dialog->move(area.center() - dialog->rect().center());
+    }
+    dialog->show();
+    dialog->raise();
+    dialog->activateWindow();
+}
+
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
 {
@@ -470,6 +801,13 @@ MainWindow::MainWindow(QWidget* parent)
 
     connect(m_connPanel, &ConnectionPanel::connectRequested,
             this, [this](const RadioInfo& info){
+        QList<quint32> disconnectHandles;
+        if (!confirmClientSlotAvailability(info, &disconnectHandles)) {
+            m_connPanel->setStatusText("Connection canceled");
+            setPanadapterConnectionAnimation(false);
+            return;
+        }
+        m_radioModel.setPendingClientDisconnects(disconnectHandles);
         m_connPanel->setStatusText("Connecting…");
         m_userDisconnected = false;
         setPanadapterConnectionAnimation(true, "Connecting to radio…");
@@ -492,6 +830,14 @@ MainWindow::MainWindow(QWidget* parent)
             .value("LastConnectedRadioSerial").toString();
         if (!lastSerial.isEmpty() && info.serial == lastSerial
             && !m_radioModel.isConnected()) {
+            QList<quint32> disconnectHandles;
+            if (!confirmClientSlotAvailability(info, &disconnectHandles)) {
+                m_userDisconnected = true;
+                m_connPanel->setStatusText("Connection canceled");
+                setPanadapterConnectionAnimation(false);
+                return;
+            }
+            m_radioModel.setPendingClientDisconnects(disconnectHandles);
             qDebug() << "Auto-connecting to" << info.displayName();
             m_connPanel->setStatusText("Auto-connecting…");
             setPanadapterConnectionAnimation(true, "Connecting to radio…");
@@ -520,27 +866,11 @@ MainWindow::MainWindow(QWidget* parent)
     // WAN radio connect: ask SmartLink server for a handle, then TLS to radio
     connect(m_connPanel, &ConnectionPanel::wanConnectRequested,
             this, [this](const WanRadioInfo& info) {
-        m_connPanel->setStatusText("Requesting SmartLink connection…");
-        setPanadapterConnectionAnimation(true, "Connecting to remote radio…");
-        // Store WAN radio info for when connect_ready arrives
-        m_pendingWanRadio = info;
-
-        // Pre-bind UDP socket for VITA-49 reception BEFORE requesting
-        // connection, so we can pass our port to the SmartLink server.
-        // The server tells the radio our public IP:port for UDP streaming.
-        quint16 udpPort = m_radioModel.panStream()->localPort();
-        if (udpPort == 0) {
-            // Not yet bound — start WAN early to get a port
-            const quint16 radioUdpPort = static_cast<quint16>(
-                info.publicUdpPort > 0 ? info.publicUdpPort : 4993);
-            auto* ps = m_radioModel.panStream();
-            QMetaObject::invokeMethod(ps, [ps, info, radioUdpPort]() {
-                ps->startWan(QHostAddress(info.publicIp), radioUdpPort);
-            }, Qt::BlockingQueuedConnection);
-            udpPort = ps->localPort();
-        }
-        qDebug() << "MainWindow: pre-bound UDP port" << udpPort << "for WAN hole punch";
-        m_smartLink.requestConnect(info.serial, udpPort);
+        startWanRadioConnect(info);
+    });
+    connect(m_connPanel, &ConnectionPanel::wanDisconnectClientsRequested,
+            this, [this](const WanRadioInfo& info) {
+        disconnectWanRadioClients(info);
     });
 
     // SmartLink server says radio is ready — connect via TLS
@@ -833,6 +1163,17 @@ MainWindow::MainWindow(QWidget* parent)
             this, &MainWindow::onConnectionStateChanged);
     connect(&m_radioModel, &RadioModel::connectionError,
             this, &MainWindow::onConnectionError);
+    connect(&m_radioModel, &RadioModel::forcedDisconnectRequested,
+            this, [this] {
+        const bool wasWan = m_radioModel.isWan();
+        const RadioInfo radioInfo = m_radioModel.lastRadioInfo();
+        const WanRadioInfo wanInfo = m_pendingWanRadio;
+
+        m_userDisconnected = true;
+        m_connPanel->setStatusText("Disconnected by another client");
+        setPanadapterConnectionAnimation(false);
+        showForcedDisconnectDialog(wasWan, radioInfo, wanInfo);
+    });
     connect(&m_radioModel, &RadioModel::sliceAdded,
             this, &MainWindow::onSliceAdded);
     connect(&m_radioModel, &RadioModel::sliceRemoved,
@@ -2720,6 +3061,14 @@ MainWindow::MainWindow(QWidget* parent)
         const QString lastSerial = AppSettings::instance()
             .value("LastConnectedRadioSerial").toString();
         if (!lastSerial.isEmpty() && info.serial == lastSerial) {
+            QList<quint32> disconnectHandles;
+            if (!confirmClientSlotAvailability(info, &disconnectHandles)) {
+                m_userDisconnected = true;
+                m_connPanel->setStatusText("Connection canceled");
+                setPanadapterConnectionAnimation(false);
+                return;
+            }
+            m_radioModel.setPendingClientDisconnects(disconnectHandles);
             qDebug() << "Auto-connecting to routed radio" << info.address.toString();
             m_connPanel->setStatusText("Auto-connecting…");
             setPanadapterConnectionAnimation(true, "Connecting to radio…");

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -176,6 +176,11 @@ private:
     void updatePaTempLabel();
     void showNetworkDiagnosticsDialog();
     void showPropDashboard();
+    bool confirmClientSlotAvailability(const RadioInfo& info, QList<quint32>* disconnectHandles);
+    bool confirmClientSlotAvailability(const WanRadioInfo& info, QList<quint32>* disconnectHandles);
+    void disconnectWanRadioClients(const WanRadioInfo& info);
+    void startWanRadioConnect(const WanRadioInfo& info);
+    void showForcedDisconnectDialog(bool wasWan, const RadioInfo& radioInfo, const WanRadioInfo& wanInfo);
     void setPaTempDisplayUnit(bool useFahrenheit);
     void setPanadapterConnectionAnimation(bool visible, const QString& label = {});
     void finishPanadapterConnectionAnimation();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -12,6 +12,7 @@
 #include <QtEndian>
 #include <algorithm>
 #include <cmath>
+#include <memory>
 
 namespace AetherSDR {
 
@@ -59,6 +60,13 @@ QString atuStatusToString(ATUStatus status)
     case ATUStatus::ManualBypass: return "ManualBypass";
     }
     return "Unknown";
+}
+
+bool statusFlagSet(const QMap<QString, QString>& kvs, const QString& key)
+{
+    const QString value = kvs.value(key).trimmed();
+    return value == QStringLiteral("1")
+        || value.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0;
 }
 
 QJsonObject panToJson(const PanadapterModel* pan, const QString& activePanId)
@@ -249,6 +257,21 @@ bool RadioModel::isConnected() const
     return m_connection->isConnected() || (m_wanConn && m_wanConn->isConnected());
 }
 
+int RadioModel::maxSlicesForModel(const QString& model)
+{
+    const QString normalized = model.toUpper();
+    // FlexRadio lists slice capacity as independent receivers per model family.
+    if (normalized.contains("6700"))
+        return 8;
+    if (normalized.contains("6600") || normalized.contains("6500")
+            || normalized.contains("8600") || normalized.contains("AU-520"))
+        return 4;
+    if (normalized.contains("6300") || normalized.contains("6400")
+            || normalized.contains("8400") || normalized.contains("AU-510"))
+        return 2;
+    return 4;
+}
+
 SliceModel* RadioModel::slice(int id) const
 {
     for (auto* s : m_slices)
@@ -263,10 +286,12 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     m_wanConn = nullptr;  // LAN mode
     m_lastInfo = info;
     m_intentionalDisconnect = false;
+    m_forcedDisconnectInProgress = false;
     m_reconnectTimer.stop();
     m_name    = info.name;
     m_model   = info.model;
     m_version = info.version;
+    m_maxSlices = maxSlicesForModel(m_model);
     // Populate client station map from discovery data
     m_clientStations.clear();
     m_clientInfoMap.clear();
@@ -296,6 +321,7 @@ void RadioModel::connectViaWan(WanConnection* wan, const QString& publicIp, quin
     m_wanPublicIp = publicIp;
     m_wanUdpPort = udpPort;
     m_intentionalDisconnect = false;
+    m_forcedDisconnectInProgress = false;
     m_reconnectTimer.stop();
 
     // Wire WAN connection signals (same as RadioConnection)
@@ -319,6 +345,15 @@ void RadioModel::connectViaWan(WanConnection* wan, const QString& publicIp, quin
         onConnected();
     } else {
         qCDebug(lcProtocol) << "RadioModel: WAN not yet connected, waiting for connected signal";
+    }
+}
+
+void RadioModel::setPendingClientDisconnects(const QList<quint32>& handles)
+{
+    m_pendingClientDisconnects.clear();
+    for (quint32 handle : handles) {
+        if (handle != 0 && !m_pendingClientDisconnects.contains(handle))
+            m_pendingClientDisconnects.append(handle);
     }
 }
 
@@ -770,15 +805,87 @@ void RadioModel::onConnected()
     // especially on WAN/SmartLink where the radio is stricter.
     const QString clientId = AppSettings::instance().value("GUIClientID").toString();
 
-    if (m_wanConn) {
-        // On WAN: wait for client ip response before sending client gui.
-        // The radio needs time after wan validate to accept GUI registration.
-        sendCmd("client ip", [this, clientId](int, const QString& body) {
-            qCDebug(lcProtocol) << "RadioModel: client ip ->" << body.trimmed();
+    disconnectPendingClientsThen([this, clientId] {
+        if (m_wanConn) {
+            // On WAN: wait for client ip response before sending client gui.
+            // The radio needs time after wan validate to accept GUI registration.
+            sendCmd("client ip", [this, clientId](int, const QString& body) {
+                qCDebug(lcProtocol) << "RadioModel: client ip ->" << body.trimmed();
+                registerAsGuiClient(clientId);
+            });
+        } else {
             registerAsGuiClient(clientId);
+        }
+    });
+}
+
+void RadioModel::disconnectPendingClientsThen(std::function<void()> continuation)
+{
+    QList<quint32> handles;
+    const quint32 ours = clientHandle();
+    for (quint32 handle : m_pendingClientDisconnects) {
+        if (handle != 0 && handle != ours && !handles.contains(handle))
+            handles.append(handle);
+    }
+    m_pendingClientDisconnects.clear();
+
+    if (handles.isEmpty()) {
+        continuation();
+        return;
+    }
+
+    auto remaining = std::make_shared<QList<quint32>>(handles);
+    auto step = std::make_shared<std::function<void()>>();
+    *step = [this, remaining, continuation, step]() mutable {
+        if (remaining->isEmpty()) {
+            QTimer::singleShot(250, this, [continuation]() mutable {
+                continuation();
+            });
+            return;
+        }
+
+        const quint32 handle = remaining->takeFirst();
+        const QString command = QString("client disconnect 0x%1").arg(handle, 0, 16);
+        qCDebug(lcProtocol) << "RadioModel: disconnecting occupied client" << Qt::hex << handle;
+        sendCmd(command, [handle, step](int code, const QString& body) {
+            if (code != 0) {
+                qCWarning(lcProtocol) << "RadioModel: client disconnect failed for"
+                                      << Qt::hex << handle
+                                      << "code" << code
+                                      << "body:" << body;
+            }
+            (*step)();
+        });
+    };
+
+    (*step)();
+}
+
+void RadioModel::handleForcedClientDisconnect()
+{
+    if (m_forcedDisconnectInProgress)
+        return;
+
+    m_forcedDisconnectInProgress = true;
+    m_intentionalDisconnect = true;
+    m_reconnectTimer.stop();
+
+    qCWarning(lcProtocol) << "RadioModel: this GUI client was force-disconnected by another client";
+    emit forcedDisconnectRequested();
+
+    if (m_wanConn) {
+        m_wanConn->disconnectFromRadio();
+        return;
+    }
+
+    const quint32 handle = clientHandle();
+    const QString streamId = m_rxAudioStreamId;
+    if (m_connection->isConnected()) {
+        QMetaObject::invokeMethod(m_connection, [conn = m_connection, handle, streamId]() {
+            conn->gracefulDisconnect(handle, streamId);
         });
     } else {
-        registerAsGuiClient(clientId);
+        QMetaObject::invokeMethod(m_connection, &RadioConnection::disconnectFromRadio);
     }
 }
 
@@ -1208,6 +1315,7 @@ void RadioModel::onDisconnected()
     m_ampHandle.clear();
     m_ampOperate = false;
     m_fullDuplex = false;
+    m_maxSlices = 4;
     m_model.clear();
     m_version.clear();
     m_chassisSerial.clear();
@@ -1238,6 +1346,7 @@ void RadioModel::onDisconnected()
     m_clientInfoMap.clear();
     emit otherClientsChanged(0, {});
     emit connectionStateChanged(false);
+    m_forcedDisconnectInProgress = false;
 
     if (m_wanConn) {
         qCDebug(lcProtocol) << "RadioModel: WAN disconnected (no auto-reconnect for SmartLink)";
@@ -1667,6 +1776,8 @@ void RadioModel::onStatusReceived(const QString& object,
             QString action = cm.captured(2);  // "disconnected" or empty
 
             if (action == "disconnected") {
+                if (handle == clientHandle() && statusFlagSet(kvs, QStringLiteral("forced")))
+                    handleForcedClientDisconnect();
                 m_clientStations.remove(handle);
                 m_clientInfoMap.remove(handle);
                 emitOtherClientsChanged();
@@ -2235,7 +2346,7 @@ void RadioModel::setMultiFlexEnabled(bool on)
 void RadioModel::handleRadioStatus(const QMap<QString, QString>& kvs)
 {
     bool changed = false;
-    if (kvs.contains("model"))    { m_model = kvs["model"]; changed = true; }
+    if (kvs.contains("model"))    { m_model = kvs["model"]; m_maxSlices = maxSlicesForModel(m_model); changed = true; }
     if (kvs.contains("slices")) {
         // slices=N reports available (unused) slots; total capacity = open + available
         int available = kvs["slices"].toInt();

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -24,6 +24,7 @@
 #include <QJsonObject>
 #include <QMap>
 #include <QSet>
+#include <functional>
 
 namespace AetherSDR {
 
@@ -110,6 +111,7 @@ public:
     QString region()       const { return m_region; }
     int     rttyMarkDefault() const { return m_rttyMarkDefault; }
     QString radioOptions() const { return m_radioOptions; }
+    RadioInfo lastRadioInfo() const { return m_lastInfo; }
 
     // License info (populated from "sub license all" responses)
     QString licenseRadioId()        const { return m_licenseRadioId; }
@@ -137,6 +139,7 @@ public:
 
     // Max slices reported by radio
     int maxSlices() const { return m_maxSlices; }
+    static int maxSlicesForModel(const QString& model);
 
     // Max panadapters supported by this radio model.
     // FLEX-6700: 8 (dual SCU, high-capacity)
@@ -251,6 +254,7 @@ public:
     // High-level actions
     void connectToRadio(const RadioInfo& info);
     void connectViaWan(WanConnection* wan, const QString& publicIp, quint16 udpPort);
+    void setPendingClientDisconnects(const QList<quint32>& handles);
     void disconnectFromRadio();
     void forceDisconnect();  // Close TCP but allow auto-reconnect
     bool isWan() const { return m_wanConn != nullptr; }
@@ -293,6 +297,8 @@ signals:
     void sliceRemoved(int sliceId);
     void metersChanged();
     void connectionError(const QString& msg);
+    // Emitted when another GUI client forces this client to disconnect.
+    void forcedDisconnectRequested();
     // Emitted when a panadapter's center frequency or bandwidth changes.
     void panadapterInfoChanged(double centerMhz, double bandwidthMhz);
     // Emitted when the radio reports the panadapter's dBm display range.
@@ -378,6 +384,8 @@ private:
     void configurePan();
     void configureWaterfall();
     void registerAsGuiClient(const QString& clientId);
+    void disconnectPendingClientsThen(std::function<void()> continuation);
+    void handleForcedClientDisconnect();
 
     // Route command to active connection (LAN or WAN)
     using ResponseCallback = RadioConnection::ResponseCallback;
@@ -576,10 +584,12 @@ private:
     quint32            m_txClientHandle{0};  // handle of the client that owns TX
     QMap<quint32, ClientInfo> m_clientInfoMap; // handle → full client info
     QMap<quint32, QString> m_clientStations;   // handle → station name (legacy, kept in sync)
+    QList<quint32> m_pendingClientDisconnects; // handles chosen before connecting
 
     SleepInhibitor m_sleepInhibitor;     // prevents OS idle sleep while connected
     RadioInfo m_lastInfo;               // stored for auto-reconnect
     bool      m_intentionalDisconnect{false};
+    bool      m_forcedDisconnectInProgress{false};
     QTimer    m_reconnectTimer;
 
     // ── Network quality monitor (matches FlexLib MonitorNetworkQuality) ──


### PR DESCRIPTION

<img width="552" height="492" alt="Screenshot 2026-04-23 at 8 55 22 PM" src="https://github.com/user-attachments/assets/1ea27d61-0a75-4f1d-b7cd-2bea43d6b57a" />

## Summary

This PR adds a complete remote-client disconnect workflow for radios whose available slice slots are already occupied by other GUI clients.

When AetherSDR attempts to connect to a LAN, routed, or SmartLink radio and all receiver slice slots are already in use, it now presents a modal dialog that explains the situation and lets the operator:

- disconnect all reported clients
- disconnect one specific reported client
- cancel the connection

The same disconnect capability is also available proactively from the `Remote with SmartLink` tab. After SmartLink sign-in, a `Disconnect Remote Clients` button appears next to `Sign Out`. It operates on the currently selected remote radio and sends the SmartLink disconnect request without starting a connection.

This PR also handles the reverse case: when another client force-disconnects AetherSDR, the app no longer immediately reconnects. Instead, it treats the radio's `client <handle> disconnected forced=1` status as intentional, closes the current radio session, pauses auto-reconnect, and shows a Reconnect/Quit dialog.

## Why

Remote operators may be away from the physical radio and unable to close a local SmartSDR, Maestro, iOS, or other GUI client. If all available receiver slices are occupied, a remote AetherSDR connection cannot safely proceed. SmartSDR already offers a similar disconnect prompt; AetherSDR now provides the same core safety/remote-access affordance.

The forced-disconnect handling is equally important. Before this change, AetherSDR could receive a forced-disconnect message from SmartSDR or another client and then immediately reconnect through the normal unexpected-disconnect path, undoing the other operator's intent. This PR stops that loop and lets the user explicitly decide whether to reconnect or quit.

## Use Cases

### Remote operator needs to free a slice before connecting

A remote user signs in through SmartLink and sees that the radio is in use by other clients. They can select the remote radio, choose `Disconnect Remote Clients`, disconnect one client or all clients, then connect normally.

### Connect attempt discovers that all slices are occupied

When connecting via LAN, routed IP, or SmartLink, AetherSDR checks the reported GUI client list against the model's slice capacity. If all available slices are occupied, the user gets a clear `Radio in use` dialog before AetherSDR completes registration as a GUI client.

### Another client intentionally disconnects AetherSDR

If SmartSDR, SmartSDR for iOS, Maestro, or another GUI client force-disconnects this AetherSDR session, AetherSDR pauses reconnect behavior and shows a dialog with `Reconnect` and `Quit` instead of immediately reclaiming the radio.

### Local integrated Maestro panel needs priority

When a local integrated Maestro panel or local GUI client needs control, it can force-disconnect AetherSDR. AetherSDR should honor that request, avoid automatic reconnection, and leave reconnect as a deliberate user action.

## Implementation Notes

- Adds `ClientDisconnectDialog`, styled consistently with the existing dark AetherSDR UI.
- Uses clearer copy: `Radio in use`, `No available slices`, and “receiver slices” in the body text.
- Determines slice capacity by model family before deciding whether to show the dialog.
- Parses GUI client handles/programs/stations from LAN discovery and SmartLink radio list data.
- Sends direct radio disconnects as `client disconnect <handle>`, matching FlexLib's specific-client command form.
- Sends SmartLink disconnects as `application disconnect_users serial=<serial> handle=<handle>`, matching FlexLib's SmartLink server flow.
- Adds a manual `Disconnect Remote Clients` button beside `Sign Out` on the SmartLink account row.
- Detects `client <our handle> disconnected forced=1` and emits a dedicated forced-disconnect signal.
- Suppresses normal auto-reconnect while handling forced disconnects.

## Test Flows

### LAN / Local Network

1. Start SmartSDR or another GUI client on the same LAN and open enough clients/slices to occupy all slice slots for the radio model.
2. Launch AetherSDR.
3. Select the radio on the `On This Network` tab.
4. Click `Connect Selected Radio`.
5. Confirm that the `Radio in use` dialog appears only when all available receiver slices are occupied.
6. Click an individual `Disconnect ...` button.
7. Confirm the selected client receives a forced disconnect and AetherSDR proceeds to connect.
8. Repeat with `Disconnect all clients`.
9. Repeat with `Cancel` and confirm AetherSDR does not connect.

### SmartLink / Remote Radio

1. Sign in on the `Remote with SmartLink` tab.
2. Select a remote radio that reports one or more GUI clients.
3. Click `Disconnect Remote Clients` next to `Sign Out`.
4. Confirm the client picker appears without initiating a radio connection.
5. Disconnect one remote client and confirm the request is sent through SmartLink.
6. Repeat with `Disconnect all clients`.
7. With all slices occupied, click `Connect Remote Radio`.
8. Confirm the same `Radio in use` dialog appears before the connection request.
9. Confirm selecting a client sends the SmartLink disconnect command before `application connect`.

### Integrated Maestro / Local Panel

1. Connect AetherSDR to the radio.
2. From SmartSDR, SmartSDR for iOS, Maestro, or an integrated local panel, force-disconnect the AetherSDR client.
3. Confirm AetherSDR does not immediately reconnect.
4. Confirm AetherSDR shows the forced-disconnect dialog explaining that another client requested the disconnect.
5. Click `Reconnect` and confirm AetherSDR reconnects deliberately.
6. Repeat and click `Quit`; confirm the app exits instead of reconnecting.

## Validation

- `cmake --build build -j 10`
- `git diff --check`
- `ctest --test-dir build -j 10 --output-on-failure` (no tests registered in this build)

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
