### PR TITLE
Persist CAT/TCI/DAX IQ enabled state across restarts

### DIFF
--- a/src/gui/CatControlApplet.cpp
+++ b/src/gui/CatControlApplet.cpp
@@ -67,12 +67,22 @@ void CatControlApplet::buildUI()
     m_tcpEnable->setCheckable(true);
     m_tcpEnable->setStyleSheet(kGreenToggle);
     m_tcpEnable->setFixedSize(76, 22);
+    {
+        QSignalBlocker b(m_tcpEnable);
+        m_tcpEnable->setChecked(
+            settings.value("AutoStartRigctld", "False").toString() == "True");
+    }
     enableRow->addWidget(m_tcpEnable);
 
     m_ptyEnable = new QPushButton("Enable TTY");
     m_ptyEnable->setCheckable(true);
     m_ptyEnable->setStyleSheet(kGreenToggle);
     m_ptyEnable->setFixedSize(76, 22);
+    {
+        QSignalBlocker b(m_ptyEnable);
+        m_ptyEnable->setChecked(
+            settings.value("AutoStartCAT", "False").toString() == "True");
+    }
     enableRow->addWidget(m_ptyEnable);
 
     enableRow->addStretch();
@@ -116,6 +126,7 @@ void CatControlApplet::buildUI()
         }
         auto& ss = AppSettings::instance();
         ss.setValue("CatTcpPort", QString::number(basePort));
+        ss.setValue("AutoStartRigctld", on ? "True" : "False");
         ss.save();
         for (int i = 0; i < kChannels; ++i) {
             if (!m_servers[i]) {
@@ -132,6 +143,9 @@ void CatControlApplet::buildUI()
 
     // PTY toggle: start/stop all 4 PTYs
     connect(m_ptyEnable, &QPushButton::toggled, this, [this](bool on) {
+        auto& ss = AppSettings::instance();
+        ss.setValue("AutoStartCAT", on ? "True" : "False");
+        ss.save();
         for (int i = 0; i < kChannels; ++i) {
             if (!m_ptys[i]) {
                 continue;

--- a/src/gui/DaxIqApplet.cpp
+++ b/src/gui/DaxIqApplet.cpp
@@ -12,6 +12,7 @@
 #include <QComboBox>
 #include <QProgressBar>
 #include <QSignalBlocker>
+#include <QTimer>
 #include <algorithm>
 #include <cmath>
 
@@ -134,29 +135,51 @@ void DaxIqApplet::setRadioModel(RadioModel* model)
         return;
     }
 
-    // DAX IQ streams are per-session. On reconnect: reset UI then re-enable
-    // any channels the user had on before disconnect.
+    // DAX IQ streams are per-session. On reconnect: reset the UI immediately,
+    // then re-enable persisted channels after a short delay. connectionStateChanged(true)
+    // fires at TCP connect, before sub/stream setup completes; emitting
+    // iqEnableRequested immediately risks a rejected stream create if the radio
+    // isn't ready yet.
     connect(model, &RadioModel::connectionStateChanged,
             this, [this](bool connected) {
-        if (!connected) {
-            return;
-        }
-        auto& ss = AppSettings::instance();
         for (int i = 0; i < kChannels; ++i) {
             if (!m_iqEnable[i]) {
                 continue;
             }
+            if (!connected) {
+                m_iqEnable[i]->setText("Off");
+                m_iqEnable[i]->setStyleSheet(kIqBtnOff);
+                if (m_iqMeter[i]) {
+                    m_iqMeter[i]->setValue(0);
+                }
+                continue;
+            }
+            // Reset to Off; stream requests follow after session setup settles.
             m_iqEnable[i]->setText("Off");
             m_iqEnable[i]->setStyleSheet(kIqBtnOff);
             if (m_iqMeter[i]) {
                 m_iqMeter[i]->setValue(0);
             }
-            if (ss.value(QStringLiteral("DaxIqEnabled%1").arg(i + 1), "False").toString() == "True") {
-                emit iqEnableRequested(i + 1);
-                m_iqEnable[i]->setText("On");
-                m_iqEnable[i]->setStyleSheet(kIqBtnOn);
-            }
         }
+        if (!connected) {
+            return;
+        }
+        QTimer::singleShot(1500, this, [this]() {
+            if (!m_model || !m_model->isConnected()) {
+                return;
+            }
+            auto& ss = AppSettings::instance();
+            for (int i = 0; i < kChannels; ++i) {
+                if (!m_iqEnable[i]) {
+                    continue;
+                }
+                if (ss.value(QStringLiteral("DaxIqEnabled%1").arg(i + 1), "False").toString() == "True") {
+                    emit iqEnableRequested(i + 1);
+                    m_iqEnable[i]->setText("On");
+                    m_iqEnable[i]->setStyleSheet(kIqBtnOn);
+                }
+            }
+        });
     });
 
     // Wire DAX IQ stream state changes → sync On/Off buttons

--- a/src/gui/DaxIqApplet.cpp
+++ b/src/gui/DaxIqApplet.cpp
@@ -1,6 +1,7 @@
 #include "DaxIqApplet.h"
 #include "ComboStyle.h"
 #include "GuardedSlider.h"
+#include "core/AppSettings.h"
 #include "models/RadioModel.h"
 #include "models/DaxIqModel.h"
 
@@ -69,10 +70,23 @@ void DaxIqApplet::buildUI()
         m_iqRateCombo[i]->addItem("48k",  48000);
         m_iqRateCombo[i]->addItem("96k",  96000);
         m_iqRateCombo[i]->addItem("192k", 192000);
-        m_iqRateCombo[i]->setCurrentIndex(1);  // default 48k
+        {
+            int savedRate = AppSettings::instance()
+                .value(QStringLiteral("DaxIqRate%1").arg(i + 1), "48000").toInt();
+            QSignalBlocker sb(m_iqRateCombo[i]);
+            for (int j = 0; j < m_iqRateCombo[i]->count(); ++j) {
+                if (m_iqRateCombo[i]->itemData(j).toInt() == savedRate) {
+                    m_iqRateCombo[i]->setCurrentIndex(j);
+                    break;
+                }
+            }
+        }
         m_iqRateCombo[i]->setFixedWidth(60);
         connect(m_iqRateCombo[i], &QComboBox::currentIndexChanged, this, [this, i]() {
             int rate = m_iqRateCombo[i]->currentData().toInt();
+            auto& ss = AppSettings::instance();
+            ss.setValue(QStringLiteral("DaxIqRate%1").arg(i + 1), QString::number(rate));
+            ss.save();
             emit iqRateChanged(i + 1, rate);
         });
         row->addWidget(m_iqRateCombo[i]);
@@ -92,16 +106,20 @@ void DaxIqApplet::buildUI()
         m_iqEnable[i]->setStyleSheet(kIqBtnOff);
         connect(m_iqEnable[i], &QPushButton::clicked, this, [this, i]() {
             bool wasOn = m_iqEnable[i]->text() == "On";
+            auto& ss = AppSettings::instance();
             if (wasOn) {
                 emit iqDisableRequested(i + 1);
                 m_iqEnable[i]->setText("Off");
                 m_iqEnable[i]->setStyleSheet(kIqBtnOff);
                 m_iqMeter[i]->setValue(0);
+                ss.setValue(QStringLiteral("DaxIqEnabled%1").arg(i + 1), "False");
             } else {
                 emit iqEnableRequested(i + 1);
                 m_iqEnable[i]->setText("On");
                 m_iqEnable[i]->setStyleSheet(kIqBtnOn);
+                ss.setValue(QStringLiteral("DaxIqEnabled%1").arg(i + 1), "True");
             }
+            ss.save();
         });
         row->addWidget(m_iqEnable[i]);
 
@@ -116,20 +134,27 @@ void DaxIqApplet::setRadioModel(RadioModel* model)
         return;
     }
 
-    // Reset IQ buttons on connection state change — streams are per-session,
-    // not persisted by the radio.
+    // DAX IQ streams are per-session. On reconnect: reset UI then re-enable
+    // any channels the user had on before disconnect.
     connect(model, &RadioModel::connectionStateChanged,
             this, [this](bool connected) {
         if (!connected) {
             return;
         }
+        auto& ss = AppSettings::instance();
         for (int i = 0; i < kChannels; ++i) {
-            if (m_iqEnable[i]) {
-                m_iqEnable[i]->setText("Off");
-                m_iqEnable[i]->setStyleSheet(kIqBtnOff);
-                if (m_iqMeter[i]) {
-                    m_iqMeter[i]->setValue(0);
-                }
+            if (!m_iqEnable[i]) {
+                continue;
+            }
+            m_iqEnable[i]->setText("Off");
+            m_iqEnable[i]->setStyleSheet(kIqBtnOff);
+            if (m_iqMeter[i]) {
+                m_iqMeter[i]->setValue(0);
+            }
+            if (ss.value(QStringLiteral("DaxIqEnabled%1").arg(i + 1), "False").toString() == "True") {
+                emit iqEnableRequested(i + 1);
+                m_iqEnable[i]->setText("On");
+                m_iqEnable[i]->setStyleSheet(kIqBtnOn);
             }
         }
     });

--- a/src/gui/TciApplet.cpp
+++ b/src/gui/TciApplet.cpp
@@ -202,9 +202,8 @@ void TciApplet::buildUI()
                     m_tciStatus->setText("(port in use)");
                     m_tciStatus->setStyleSheet(
                         "QLabel { color: #cc3333; font-size: 10px; }");
-                    auto& ss2 = AppSettings::instance();
-                    ss2.setValue("AutoStartTCI", "False");
-                    ss2.save();
+                    ss.setValue("AutoStartTCI", "False");
+                    ss.save();
                     emit tciToggled(false);
                     return;
                 }

--- a/src/gui/TciApplet.cpp
+++ b/src/gui/TciApplet.cpp
@@ -156,6 +156,11 @@ void TciApplet::buildUI()
     m_tciEnable->setCheckable(true);
     m_tciEnable->setStyleSheet(kGreenToggle);
     m_tciEnable->setFixedSize(60, 22);
+    {
+        QSignalBlocker b(m_tciEnable);
+        m_tciEnable->setChecked(
+            settings.value("AutoStartTCI", "False").toString() == "True");
+    }
     enableRow->addWidget(m_tciEnable);
 
     outer->addLayout(enableRow);
@@ -184,6 +189,7 @@ void TciApplet::buildUI()
         }
         auto& ss = AppSettings::instance();
         ss.setValue("TciPort", QString::number(port));
+        ss.setValue("AutoStartTCI", on ? "True" : "False");
         ss.save();
         if (m_tciServer) {
             if (on) {
@@ -196,6 +202,9 @@ void TciApplet::buildUI()
                     m_tciStatus->setText("(port in use)");
                     m_tciStatus->setStyleSheet(
                         "QLabel { color: #cc3333; font-size: 10px; }");
+                    auto& ss2 = AppSettings::instance();
+                    ss2.setValue("AutoStartTCI", "False");
+                    ss2.save();
                     emit tciToggled(false);
                     return;
                 }


### PR DESCRIPTION

Previously the Enable TCP, Enable TTY, TCI Enable, and DAX IQ On/Off
buttons did not save their state. Only the Settings menu "Autostart"
actions wrote to AppSettings, so enabling via the applet UI was lost on
restart.

Changes:
- CatControlApplet: save AutoStartRigctld on TCP toggle, AutoStartCAT on
  TTY toggle; restore both button states from settings on construction
- TciApplet: save AutoStartTCI on Enable toggle (including clearing it
  when the port-in-use fallback snaps the button off); restore button
  state from settings on construction
- DaxIqApplet: save DaxIqRate{1-4} on rate change, restore on buildUI();
  save DaxIqEnabled{1-4} on On/Off click, auto-re-enable persisted
  channels after each reconnect (streams are per-session)

DAX Audio was already fully persisted via AutoStartDAX; no changes there.
