### PR TITLE
fix versioning label issue (seen on Windows)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1396,6 +1396,12 @@ MainWindow::MainWindow(QWidget* parent)
         m_appletPanel->setMaxSlices(m_radioModel.maxSlices());
     });
 
+    // software_ver arrives after onConnectionStateChanged, so refresh the label
+    connect(&m_radioModel, &RadioModel::infoChanged, this, [this]() {
+        if (m_radioVersionLabel && !m_radioModel.version().isEmpty())
+            m_radioVersionLabel->setText(m_radioModel.version());
+    });
+
     // Propagate late-arriving SmartSDR+ subscription + dual-SCU diversity
     // eligibility to all existing VFOs. Both depend on radio info (license
     // subscription / model) that can arrive after a slice is created — in


### PR DESCRIPTION
Minor fix to address an issue on Windows where the radio firmware version was not being displayed correctly in the status bar

<img width="248" height="44" alt="Screenshot 2026-04-23 230518" src="https://github.com/user-attachments/assets/09c4f967-44e9-4ec2-a83a-098459d4ac1c" />
