### PR TITLE
[feature] Show LAN and SmartLink client login notifications

### DIFF
--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -125,6 +125,13 @@ RadioInfo RadioDiscovery::parseDiscoveryPacket(const QByteArray& data) const
             cleaned.replace('\x7f', ' ');
             info.guiClientPrograms = cleaned.split(',', Qt::SkipEmptyParts);
         }
+        else if (key == "gui_client_ips")
+            info.guiClientIps = value.split(',', Qt::SkipEmptyParts);
+        else if (key == "gui_client_hosts") {
+            QString cleaned = value;
+            cleaned.replace('\x7f', ' ');
+            info.guiClientHosts = cleaned.split(',', Qt::SkipEmptyParts);
+        }
     }
     return info;
 }

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -69,6 +69,8 @@ struct RadioInfo {
     QStringList guiClientStations;
     QStringList guiClientHandles;
     QStringList guiClientPrograms;
+    QStringList guiClientIps;
+    QStringList guiClientHosts;
 
     QString displayName() const {
         QString suffix;

--- a/src/core/SmartLinkClient.cpp
+++ b/src/core/SmartLinkClient.cpp
@@ -394,6 +394,8 @@ void SmartLinkClient::parseRadioList(const QString& msg)
         info.guiClientPrograms = kv.value("gui_client_programs");
         info.guiClientStations = kv.value("gui_client_stations");
         info.guiClientHandles  = kv.value("gui_client_handles");
+        info.guiClientIps      = kv.value("gui_client_ips");
+        info.guiClientHosts    = kv.value("gui_client_hosts");
 
         // Port selection: prefer manual port forwards, fall back to UPnP
         // (matches FlexLib WanServer.cs logic)

--- a/src/core/SmartLinkClient.h
+++ b/src/core/SmartLinkClient.h
@@ -27,6 +27,8 @@ struct WanRadioInfo {
     QString guiClientPrograms;
     QString guiClientStations;
     QString guiClientHandles;
+    QString guiClientIps;
+    QString guiClientHosts;
 };
 
 // SmartLink client — manages the TLS connection to smartlink.flexradio.com

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -494,7 +494,9 @@ void MainWindow::startWanRadioConnect(const WanRadioInfo& info)
     m_userDisconnected = false;
     m_radioModel.setKnownGuiClients(splitClientField(info.guiClientHandles),
                                     splitClientField(info.guiClientPrograms),
-                                    splitClientField(info.guiClientStations));
+                                    splitClientField(info.guiClientStations),
+                                    splitClientField(info.guiClientIps),
+                                    splitClientField(info.guiClientHosts));
     m_radioModel.setPendingClientDisconnects(disconnectHandles);
     m_connPanel->setStatusText("Requesting SmartLink connection…");
     setPanadapterConnectionAnimation(true, "Connecting to remote radio…");
@@ -808,6 +810,17 @@ MainWindow::MainWindow(QWidget* parent)
             m_connPanel, &ConnectionPanel::onRadioDiscovered);
     connect(&m_discovery, &RadioDiscovery::radioUpdated,
             m_connPanel, &ConnectionPanel::onRadioUpdated);
+    connect(&m_discovery, &RadioDiscovery::radioUpdated,
+            this, [this](const RadioInfo& info) {
+        if (!m_radioModel.isConnected() || m_radioModel.serial() != info.serial)
+            return;
+
+        m_radioModel.mergeKnownGuiClients(info.guiClientHandles,
+                                          info.guiClientPrograms,
+                                          info.guiClientStations,
+                                          info.guiClientIps,
+                                          info.guiClientHosts);
+    });
     connect(&m_discovery, &RadioDiscovery::radioLost,
             m_connPanel, &ConnectionPanel::onRadioLost);
     connect(m_connPanel, &ConnectionPanel::retryDiscoveryRequested, this, [this] {
@@ -906,6 +919,23 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_connPanel, &ConnectionPanel::wanDisconnectClientsRequested,
             this, [this](const WanRadioInfo& info) {
         disconnectWanRadioClients(info);
+    });
+    connect(&m_smartLink, &SmartLinkClient::radioListReceived,
+            this, [this](const QList<WanRadioInfo>& radios) {
+        if (!m_radioModel.isConnected() || !m_radioModel.isWan())
+            return;
+
+        for (const auto& info : radios) {
+            if (info.serial != m_pendingWanRadio.serial)
+                continue;
+
+            m_radioModel.mergeKnownGuiClients(splitClientField(info.guiClientHandles),
+                                              splitClientField(info.guiClientPrograms),
+                                              splitClientField(info.guiClientStations),
+                                              splitClientField(info.guiClientIps),
+                                              splitClientField(info.guiClientHosts));
+            break;
+        }
     });
 
     // SmartLink server says radio is ready — connect via TLS

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -380,6 +380,38 @@ static QList<ClientDisconnectDialog::Client> buildDisconnectClients(const WanRad
                                   splitClientField(info.guiClientStations));
 }
 
+static QString cleanClientDisplayText(QString value)
+{
+    value.replace(QChar(0x7f), QLatin1Char(' '));
+    return value.trimmed();
+}
+
+static QString clientConnectionStatusMessage(quint32 handle,
+                                             const QString& source,
+                                             const QString& station,
+                                             const QString& program)
+{
+    QString from = cleanClientDisplayText(source);
+    const QString stationText = cleanClientDisplayText(station);
+    const QString programText = cleanClientDisplayText(program);
+    QString detail = stationText;
+
+    if (detail.isEmpty() || detail.compare(QStringLiteral("Unknown"), Qt::CaseInsensitive) == 0)
+        detail = programText;
+    if (detail.compare(QStringLiteral("Unknown"), Qt::CaseInsensitive) == 0)
+        detail.clear();
+
+    if (from.isEmpty())
+        from = detail;
+    if (from.isEmpty())
+        from = QStringLiteral("client 0x%1").arg(handle, 8, 16, QChar('0')).toUpper();
+
+    if (!detail.isEmpty() && detail.compare(from, Qt::CaseInsensitive) != 0)
+        return QObject::tr("New client connection from %1 (%2)").arg(from, detail);
+
+    return QObject::tr("New client connection from %1").arg(from);
+}
+
 bool MainWindow::confirmClientSlotAvailability(const RadioInfo& info,
                                                QList<quint32>* disconnectHandles)
 {
@@ -460,6 +492,9 @@ void MainWindow::startWanRadioConnect(const WanRadioInfo& info)
     }
 
     m_userDisconnected = false;
+    m_radioModel.setKnownGuiClients(splitClientField(info.guiClientHandles),
+                                    splitClientField(info.guiClientPrograms),
+                                    splitClientField(info.guiClientStations));
     m_radioModel.setPendingClientDisconnects(disconnectHandles);
     m_connPanel->setStatusText("Requesting SmartLink connection…");
     setPanadapterConnectionAnimation(true, "Connecting to remote radio…");
@@ -1942,6 +1977,15 @@ MainWindow::MainWindow(QWidget* parent)
     // Multi-Flex: title bar indicator when other clients are connected
     connect(&m_radioModel, &RadioModel::otherClientsChanged,
             m_titleBar, &TitleBar::setMultiFlexStatus);
+    connect(&m_radioModel, &RadioModel::clientConnected,
+            this, [this](quint32 handle,
+                         const QString& source,
+                         const QString& station,
+                         const QString& program) {
+        statusBar()->showMessage(
+            clientConnectionStatusMessage(handle, source, station, program),
+            10000);
+    });
 
     // Apply saved master volume
     int savedMasterVol = AppSettings::instance().value("MasterVolume", "100").toInt();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -86,19 +86,25 @@ quint32 parseClientHandle(QString text)
     return ok ? handle : 0;
 }
 
+bool looksLikeClientId(const QString& value)
+{
+    static const QRegularExpression guidRe(
+        QStringLiteral(R"(^\{?[0-9A-Fa-f]{8}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{12}\}?$)"));
+    return guidRe.match(value.trimmed()).hasMatch();
+}
+
 QString clientConnectionSource(const QMap<QString, QString>& kvs)
 {
     const QStringList keys = {
         QStringLiteral("ip"),
         QStringLiteral("client_ip"),
         QStringLiteral("remote_ip"),
-        QStringLiteral("name"),
-        QStringLiteral("client_id")
+        QStringLiteral("name")
     };
 
     for (const QString& key : keys) {
         const QString value = cleanClientText(kvs.value(key));
-        if (!value.isEmpty())
+        if (!value.isEmpty() && !looksLikeClientId(value))
             return value;
     }
 
@@ -137,6 +143,7 @@ QJsonObject clientInfoToJson(quint32 handle,
     obj["role"] = (handle == ourHandle) ? "current_app" : "other_client";
     obj["owns_tx"] = (txHandle != 0 && handle == txHandle);
     obj["program"] = info.program;
+    obj["source"] = info.source;
     obj["local_ptt"] = info.localPtt;
     obj["tx_antenna"] = info.txAntenna;
     obj["tx_freq_mhz"] = info.txFreqMhz;
@@ -323,12 +330,17 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     m_lastInfo = info;
     m_intentionalDisconnect = false;
     m_forcedDisconnectInProgress = false;
+    m_announcedClientConnections.clear();
     m_reconnectTimer.stop();
     m_name    = info.name;
     m_model   = info.model;
     m_version = info.version;
     m_maxSlices = maxSlicesForModel(m_model);
-    setKnownGuiClients(info.guiClientHandles, info.guiClientPrograms, info.guiClientStations);
+    setKnownGuiClients(info.guiClientHandles,
+                       info.guiClientPrograms,
+                       info.guiClientStations,
+                       info.guiClientIps,
+                       info.guiClientHosts);
     QMetaObject::invokeMethod(m_connection, [conn = m_connection, info] {
         conn->connectToRadio(info);
     });
@@ -349,6 +361,7 @@ void RadioModel::connectViaWan(WanConnection* wan, const QString& publicIp, quin
     m_wanUdpPort = udpPort;
     m_intentionalDisconnect = false;
     m_forcedDisconnectInProgress = false;
+    m_announcedClientConnections.clear();
     m_reconnectTimer.stop();
 
     // Wire WAN connection signals (same as RadioConnection)
@@ -386,10 +399,33 @@ void RadioModel::setPendingClientDisconnects(const QList<quint32>& handles)
 
 void RadioModel::setKnownGuiClients(const QStringList& handles,
                                     const QStringList& programs,
-                                    const QStringList& stations)
+                                    const QStringList& stations,
+                                    const QStringList& ips,
+                                    const QStringList& hosts)
 {
-    m_clientStations.clear();
-    m_clientInfoMap.clear();
+    applyKnownGuiClients(handles, programs, stations, ips, hosts, true);
+}
+
+void RadioModel::mergeKnownGuiClients(const QStringList& handles,
+                                      const QStringList& programs,
+                                      const QStringList& stations,
+                                      const QStringList& ips,
+                                      const QStringList& hosts)
+{
+    applyKnownGuiClients(handles, programs, stations, ips, hosts, false);
+}
+
+void RadioModel::applyKnownGuiClients(const QStringList& handles,
+                                      const QStringList& programs,
+                                      const QStringList& stations,
+                                      const QStringList& ips,
+                                      const QStringList& hosts,
+                                      bool replaceExisting)
+{
+    if (replaceExisting) {
+        m_clientStations.clear();
+        m_clientInfoMap.clear();
+    }
 
     for (int i = 0; i < handles.size(); ++i) {
         const quint32 handle = parseClientHandle(handles[i]);
@@ -402,14 +438,59 @@ void RadioModel::setKnownGuiClients(const QStringList& handles,
         const QString station = i < stations.size()
             ? cleanClientText(stations[i])
             : program;
+        QString source = i < ips.size()
+            ? cleanClientText(ips[i])
+            : QString();
+        if (source.isEmpty() && i < hosts.size())
+            source = cleanClientText(hosts[i]);
 
-        m_clientStations[handle] = station.isEmpty() ? program : station;
-        ClientInfo client;
-        client.station = station;
-        client.program = program;
-        client.localPtt = false;
+        ClientInfo client = m_clientInfoMap.value(handle);
+        if (!station.isEmpty())
+            client.station = station;
+        if (!program.isEmpty() && program != QStringLiteral("Unknown"))
+            client.program = program;
+        if (!source.isEmpty())
+            client.source = source;
+
+        m_clientStations[handle] = client.station.isEmpty() ? client.program : client.station;
         m_clientInfoMap[handle] = client;
     }
+}
+
+void RadioModel::announceClientConnection(quint32 handle,
+                                          const QString& source,
+                                          const QString& station,
+                                          const QString& program)
+{
+    if (handle == clientHandle() || m_announcedClientConnections.contains(handle))
+        return;
+
+    m_announcedClientConnections.insert(handle);
+    QTimer::singleShot(750, this, [this, handle, source, station, program] {
+        if (!m_clientInfoMap.contains(handle))
+            return;
+
+        const auto client = m_clientInfoMap.value(handle);
+        QString latestSource = client.source.isEmpty() ? source : client.source;
+        QString latestStation = client.station.isEmpty() ? station : client.station;
+        QString latestProgram = client.program.isEmpty() ? program : client.program;
+
+        if (m_wanConn && (latestSource.isEmpty() || latestSource == QStringLiteral("SmartLink"))) {
+            QTimer::singleShot(1250, this, [this, handle, latestSource, latestStation, latestProgram] {
+                if (!m_clientInfoMap.contains(handle))
+                    return;
+
+                const auto client = m_clientInfoMap.value(handle);
+                emit clientConnected(handle,
+                                     client.source.isEmpty() ? latestSource : client.source,
+                                     client.station.isEmpty() ? latestStation : client.station,
+                                     client.program.isEmpty() ? latestProgram : client.program);
+            });
+            return;
+        }
+
+        emit clientConnected(handle, latestSource, latestStation, latestProgram);
+    });
 }
 
 void RadioModel::disconnectFromRadio()
@@ -1399,6 +1480,7 @@ void RadioModel::onDisconnected()
     }
     m_clientStations.clear();
     m_clientInfoMap.clear();
+    m_announcedClientConnections.clear();
     emit otherClientsChanged(0, {});
     emit connectionStateChanged(false);
     m_forcedDisconnectInProgress = false;
@@ -1835,23 +1917,27 @@ void RadioModel::onStatusReceived(const QString& object,
                     handleForcedClientDisconnect();
                 m_clientStations.remove(handle);
                 m_clientInfoMap.remove(handle);
+                m_announcedClientConnections.remove(handle);
                 emitOtherClientsChanged();
             } else if (action == "connected" || kvs.contains("connected")) {
-                const bool knownClient = m_clientStations.contains(handle)
-                    || m_clientInfoMap.contains(handle);
                 QString program = cleanClientText(kvs.value("program", "Unknown"));
                 QString station = cleanClientText(kvs.value("station", program));
-                const QString source = clientConnectionSource(kvs);
+                QString source = clientConnectionSource(kvs);
+                auto existing = m_clientInfoMap.constFind(handle);
+                if (source.isEmpty() && existing != m_clientInfoMap.cend())
+                    source = existing->source;
+                if (source.isEmpty() && m_wanConn)
+                    source = QStringLiteral("SmartLink");
                 bool ptt = kvs.value("local_ptt", "0") == "1";
                 m_clientStations[handle] = station;
                 ClientInfo client;
                 client.station = station;
                 client.program = program;
+                client.source = source;
                 client.localPtt = ptt;
                 m_clientInfoMap[handle] = client;
                 emitOtherClientsChanged();
-                if (handle != clientHandle() && !knownClient)
-                    emit clientConnected(handle, source, station, program);
+                announceClientConnection(handle, source, station, program);
             }
         }
         return;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -69,6 +69,42 @@ bool statusFlagSet(const QMap<QString, QString>& kvs, const QString& key)
         || value.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0;
 }
 
+QString cleanClientText(QString value)
+{
+    value.replace(QChar(0x7f), QLatin1Char(' '));
+    return value.trimmed();
+}
+
+quint32 parseClientHandle(QString text)
+{
+    text = text.trimmed();
+    if (text.startsWith(QStringLiteral("0x"), Qt::CaseInsensitive))
+        text = text.mid(2);
+
+    bool ok = false;
+    const quint32 handle = text.toUInt(&ok, 16);
+    return ok ? handle : 0;
+}
+
+QString clientConnectionSource(const QMap<QString, QString>& kvs)
+{
+    const QStringList keys = {
+        QStringLiteral("ip"),
+        QStringLiteral("client_ip"),
+        QStringLiteral("remote_ip"),
+        QStringLiteral("name"),
+        QStringLiteral("client_id")
+    };
+
+    for (const QString& key : keys) {
+        const QString value = cleanClientText(kvs.value(key));
+        if (!value.isEmpty())
+            return value;
+    }
+
+    return {};
+}
+
 QJsonObject panToJson(const PanadapterModel* pan, const QString& activePanId)
 {
     QJsonObject obj;
@@ -292,16 +328,7 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     m_model   = info.model;
     m_version = info.version;
     m_maxSlices = maxSlicesForModel(m_model);
-    // Populate client station map from discovery data
-    m_clientStations.clear();
-    m_clientInfoMap.clear();
-    for (int i = 0; i < info.guiClientHandles.size(); ++i) {
-        quint32 h = info.guiClientHandles[i].toUInt(nullptr, 16);
-        QString station = (i < info.guiClientStations.size())
-            ? info.guiClientStations[i]
-            : (i < info.guiClientPrograms.size() ? info.guiClientPrograms[i] : "Unknown");
-        m_clientStations[h] = station;
-    }
+    setKnownGuiClients(info.guiClientHandles, info.guiClientPrograms, info.guiClientStations);
     QMetaObject::invokeMethod(m_connection, [conn = m_connection, info] {
         conn->connectToRadio(info);
     });
@@ -354,6 +381,34 @@ void RadioModel::setPendingClientDisconnects(const QList<quint32>& handles)
     for (quint32 handle : handles) {
         if (handle != 0 && !m_pendingClientDisconnects.contains(handle))
             m_pendingClientDisconnects.append(handle);
+    }
+}
+
+void RadioModel::setKnownGuiClients(const QStringList& handles,
+                                    const QStringList& programs,
+                                    const QStringList& stations)
+{
+    m_clientStations.clear();
+    m_clientInfoMap.clear();
+
+    for (int i = 0; i < handles.size(); ++i) {
+        const quint32 handle = parseClientHandle(handles[i]);
+        if (handle == 0)
+            continue;
+
+        const QString program = i < programs.size()
+            ? cleanClientText(programs[i])
+            : QStringLiteral("Unknown");
+        const QString station = i < stations.size()
+            ? cleanClientText(stations[i])
+            : program;
+
+        m_clientStations[handle] = station.isEmpty() ? program : station;
+        ClientInfo client;
+        client.station = station;
+        client.program = program;
+        client.localPtt = false;
+        m_clientInfoMap[handle] = client;
     }
 }
 
@@ -1782,12 +1837,21 @@ void RadioModel::onStatusReceived(const QString& object,
                 m_clientInfoMap.remove(handle);
                 emitOtherClientsChanged();
             } else if (action == "connected" || kvs.contains("connected")) {
-                QString program = kvs.value("program", "Unknown");
-                QString station = kvs.value("station", program);
+                const bool knownClient = m_clientStations.contains(handle)
+                    || m_clientInfoMap.contains(handle);
+                QString program = cleanClientText(kvs.value("program", "Unknown"));
+                QString station = cleanClientText(kvs.value("station", program));
+                const QString source = clientConnectionSource(kvs);
                 bool ptt = kvs.value("local_ptt", "0") == "1";
                 m_clientStations[handle] = station;
-                m_clientInfoMap[handle] = {station, program, ptt};
+                ClientInfo client;
+                client.station = station;
+                client.program = program;
+                client.localPtt = ptt;
+                m_clientInfoMap[handle] = client;
                 emitOtherClientsChanged();
+                if (handle != clientHandle() && !knownClient)
+                    emit clientConnected(handle, source, station, program);
             }
         }
         return;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -232,6 +232,7 @@ public:
     struct ClientInfo {
         QString station;
         QString program;
+        QString source;
         bool localPtt{false};
         QString txAntenna;
         double txFreqMhz{0};
@@ -239,7 +240,14 @@ public:
     const QMap<quint32, ClientInfo>& clientInfoMap() const { return m_clientInfoMap; }
     void    setKnownGuiClients(const QStringList& handles,
                                const QStringList& programs,
-                               const QStringList& stations);
+                               const QStringList& stations,
+                               const QStringList& ips = {},
+                               const QStringList& hosts = {});
+    void    mergeKnownGuiClients(const QStringList& handles,
+                                 const QStringList& programs,
+                                 const QStringList& stations,
+                                 const QStringList& ips = {},
+                                 const QStringList& hosts = {});
     void    setRemoteOnEnabled(bool on);
     void    setMultiFlexEnabled(bool on);
     // Panadapter access (delegates to active pan)
@@ -394,6 +402,16 @@ private:
     void registerAsGuiClient(const QString& clientId);
     void disconnectPendingClientsThen(std::function<void()> continuation);
     void handleForcedClientDisconnect();
+    void applyKnownGuiClients(const QStringList& handles,
+                              const QStringList& programs,
+                              const QStringList& stations,
+                              const QStringList& ips,
+                              const QStringList& hosts,
+                              bool replaceExisting);
+    void announceClientConnection(quint32 handle,
+                                  const QString& source,
+                                  const QString& station,
+                                  const QString& program);
 
     // Route command to active connection (LAN or WAN)
     using ResponseCallback = RadioConnection::ResponseCallback;
@@ -594,6 +612,7 @@ private:
     QMap<quint32, ClientInfo> m_clientInfoMap; // handle → full client info
     QMap<quint32, QString> m_clientStations;   // handle → station name (legacy, kept in sync)
     QList<quint32> m_pendingClientDisconnects; // handles chosen before connecting
+    QSet<quint32> m_announcedClientConnections; // client login notices shown this session
 
     SleepInhibitor m_sleepInhibitor;     // prevents OS idle sleep while connected
     RadioInfo m_lastInfo;               // stored for auto-reconnect

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -237,6 +237,9 @@ public:
         double txFreqMhz{0};
     };
     const QMap<quint32, ClientInfo>& clientInfoMap() const { return m_clientInfoMap; }
+    void    setKnownGuiClients(const QStringList& handles,
+                               const QStringList& programs,
+                               const QStringList& stations);
     void    setRemoteOnEnabled(bool on);
     void    setMultiFlexEnabled(bool on);
     // Panadapter access (delegates to active pan)
@@ -325,6 +328,11 @@ signals:
     void txOwnerChanged(bool ownedByUs, const QString& otherStation);
     // Emitted when the set of other connected clients changes.
     void otherClientsChanged(int count, const QStringList& names);
+    // Emitted when another GUI client logs in after our known client list.
+    void clientConnected(quint32 handle,
+                         const QString& source,
+                         const QString& station,
+                         const QString& program);
     // Emitted when GPS status changes (from "sub gps all").
     void gpsStatusChanged(const QString& status, int tracked, int visible,
                           const QString& grid, const QString& altitude,


### PR DESCRIPTION

<img width="1820" height="1128" alt="Screenshot 2026-04-23 at 10 17 22 PM" src="https://github.com/user-attachments/assets/64ad2a75-5e9c-46f5-8135-75bc7a978b0c" />

## Stacking note

This PR is intentionally stacked on #1889, which adds the MultiFlex remote-client disconnect workflow. Please merge #1889 first.

The login-notification work in this child PR is:

- `11801bb` Show client login events in status bar
- `9458c17` Show client source in login notifications

Until #1889 merges, GitHub will also show the parent commit in this PR because both branches are compared against `main`.

## Summary

This adds temporary status-bar notifications when another MultiFlex or SmartLink GUI client connects, then improves the message so it can include the connecting client's reported IP address or host name:

> New client connection from 127.0.0.1 (Pat's Phone)

The implementation avoids showing GUID-style `client_id` values as a source, which was the confusing behavior observed during testing.

## API findings

FlexLib's live `client <handle> connected` status does not include an IP address. It carries fields like `client_id`, `program`, `station`, and `local_ptt`.

The richer client source metadata is exposed elsewhere:

- LAN discovery packets include `gui_client_ips`, `gui_client_hosts`, `gui_client_programs`, `gui_client_stations`, and `gui_client_handles`.
- SmartLink radio-list payloads include the same `gui_client_ips` / `gui_client_hosts` fields.

Because those fields are keyed by GUI client handle, this PR caches the metadata by handle and reuses it when the live client connection event arrives.

## What changed

- Emits a temporary status-bar notice for new MultiFlex / SmartLink client login events.
- Shows the notice for 10 seconds using the existing Qt status bar path.
- Parses `gui_client_ips` and `gui_client_hosts` from LAN discovery.
- Parses `gui_client_ips` and `gui_client_hosts` from SmartLink radio-list responses.
- Stores a `source` field in `RadioModel::ClientInfo`.
- Merges refreshed LAN discovery and SmartLink radio-list metadata into the active model while connected.
- Suppresses GUID-like `client_id` values as a status-bar source.
- Delays login notifications briefly so late-arriving discovery/SmartLink metadata can enrich the message.
- Uses the original fast notification timing for LAN and already-enriched SmartLink events.
- Adds an extra SmartLink-only grace period when the source is still missing or only says `SmartLink`, which made LTE-tether SmartLink testing reliable.

## User impact

Operators get a clearer status-bar notice when another GUI client connects, with a useful source address or host where the radio/SmartLink API provides it. When source metadata is not available, the message stays clean and avoids exposing opaque GUIDs.

## Use cases

- A local LAN client connects while AetherSDR is already connected.
- A SmartLink client connects while AetherSDR is connected through SmartLink.
- Both clients are remote over SmartLink, including higher-latency LTE tethering.
- A discovery or SmartLink radio-list update arrives after the live client event and enriches the pending notice before display.
- A client disconnects and reconnects without stale metadata being kept after the radio reports the disconnect.

## Validation

- Built with `cmake --build build -j 10`.
- Ran `git diff --check`.
- Ran `ctest --test-dir build -j 10 --output-on-failure`; no tests are registered in this build.
- Manual LAN test: status notification reliably included the LAN client source.
- Manual SmartLink/LTE test: initial shorter delay missed IP source intermittently; the SmartLink grace-period update made the notification reliable across repeated attempts.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
