### PR TITLE
Fix MultiFlex PTT label, row-selection, and correct PTT command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ key=value pairs by locating the last space before the first `=` sign.
 ### Firmware v1.4.0.0 Quirks
 
 - `client set udpport` returns `0x50001000` — use the one-byte UDP packet method
+- `client set enforce_local_ptt=1` returns `0x50001000` — correct command is `client set local_ptt=1`; the radio echoes a full `connected` status to ALL clients updating their `local_ptt` field when ownership changes
 - Slice frequency is `RF_frequency` (not `freq`) in status messages
 - Streams are discriminated by **PacketClassCode** (PCC), NOT by packet type
 - `audio_level` is the status key for AF gain (not `audio_gain`)

--- a/src/gui/MultiFlexDialog.cpp
+++ b/src/gui/MultiFlexDialog.cpp
@@ -71,9 +71,7 @@ MultiFlexDialog::MultiFlexDialog(RadioModel* model, QWidget* parent)
     pttRow->addWidget(m_pttLabel);
     m_pttBtn = new QPushButton("Enable");
     connect(m_pttBtn, &QPushButton::clicked, this, [this]() {
-        // Request local PTT for our station
-        m_model->sendCommand("client set enforce_local_ptt=1");
-        // The radio will echo back updated client status with local_ptt=1
+        m_model->requestLocalPtt();
     });
     pttRow->addWidget(m_pttBtn);
     pttRow->addStretch();
@@ -87,15 +85,19 @@ MultiFlexDialog::MultiFlexDialog(RadioModel* model, QWidget* parent)
     closeRow->addWidget(closeBtn);
     root->addLayout(closeRow);
 
-    // Refresh on client changes
+    // Refresh on client changes or row selection
     connect(m_model, &RadioModel::otherClientsChanged, this, [this]() { refresh(); });
     connect(m_model, &RadioModel::infoChanged, this, [this]() { refresh(); });
+    connect(m_table, &QTableWidget::itemSelectionChanged, this, [this]() { refresh(); });
 
     refresh();
 }
 
 void MultiFlexDialog::refresh()
 {
+    if (m_refreshing) return;
+    m_refreshing = true;
+
     // Enable button style
     bool enabled = m_model->multiFlexEnabled();
     m_enableBtn->setText(enabled ? "Enabled" : "Disabled");
@@ -107,10 +109,8 @@ void MultiFlexDialog::refresh()
           "border-radius: 3px; padding: 6px 20px; font-weight: bold; font-size: 13px; }"
           "QPushButton:hover { background: #702020; }");
 
-    // Build per-client TX info from all slices (including other clients' slices)
-    // Each client's TX slice has tx=1 and client_handle matching the client
     const auto& infoMap = m_model->clientInfoMap();
-    quint32 ourHandle = m_model->ourClientHandle();
+    const quint32 ourHandle = m_model->ourClientHandle();
 
     // Build local TX info override from our own slices (ClientInfo may not
     // have TX data if slice status arrived before client connected status)
@@ -124,28 +124,41 @@ void MultiFlexDialog::refresh()
         }
     }
 
+    // Remember selected handle across repopulation
+    quint32 selectedHandle = 0;
+    {
+        const auto sel = m_table->selectedItems();
+        if (!sel.isEmpty())
+            selectedHandle = sel.first()->data(Qt::UserRole).toUInt();
+    }
+
     // Populate table
     m_table->setRowCount(infoMap.size());
 
-    // Track if we have PTT for the bottom label
     bool weHavePtt = false;
-    QString otherStation;
-
+    QString ourStation;
+    int restoreRow = -1;
     int row = 0;
+
     for (auto it = infoMap.cbegin(); it != infoMap.cend(); ++it) {
         quint32 handle = it.key();
         const auto& info = it.value();
         bool isUs = (handle == ourHandle);
         bool hasPtt = info.localPtt || (isUs && infoMap.size() == 1);
 
-        if (isUs && hasPtt) weHavePtt = true;
-        if (!isUs) otherStation = info.station;
+        if (isUs) {
+            weHavePtt = hasPtt;
+            ourStation = info.station;
+        }
+        if (handle == selectedHandle)
+            restoreRow = row;
 
         // LOCAL PTT
         auto* pttItem = new QTableWidgetItem(hasPtt ? "\xE2\x9C\x94" : "");
         pttItem->setTextAlignment(Qt::AlignCenter);
         if (hasPtt)
             pttItem->setForeground(QColor(0x40, 0xff, 0x40));
+        pttItem->setData(Qt::UserRole, handle);
         m_table->setItem(row, 0, pttItem);
 
         // STATION — program: station
@@ -156,6 +169,7 @@ void MultiFlexDialog::refresh()
         stationItem->setTextAlignment(Qt::AlignCenter);
         if (isUs)
             stationItem->setForeground(QColor(0x00, 0xb4, 0xd8));
+        stationItem->setData(Qt::UserRole, handle);
         m_table->setItem(row, 1, stationItem);
 
         // TX ANT and TX FREQ — from slice status, with fallback to our own slices
@@ -177,14 +191,43 @@ void MultiFlexDialog::refresh()
         ++row;
     }
 
-    // Local PTT button — show when another client has PTT
-    if (infoMap.size() > 1 && !weHavePtt) {
-        m_pttLabel->setText(QString("Enable Local PTT for this station (%1):").arg(otherStation));
-        m_pttLabel->show();
-        m_pttBtn->show();
-    } else {
+    // Restore row selection after repopulation (blocked to avoid re-entrancy)
+    if (restoreRow >= 0) {
+        QSignalBlocker sb(m_table);
+        m_table->selectRow(restoreRow);
+    }
+
+    m_refreshing = false;
+
+    // Local PTT section — determine what the selected row is asking for
+    if (infoMap.size() <= 1) {
         m_pttLabel->hide();
         m_pttBtn->hide();
+        return;
+    }
+
+    if (weHavePtt) {
+        // We already hold PTT; another station cannot be granted it from here —
+        // they must request it from their own client.
+        const auto sel = m_table->selectedItems();
+        quint32 selHandle = sel.isEmpty() ? 0 : sel.first()->data(Qt::UserRole).toUInt();
+        bool selIsUs = (selHandle == ourHandle || selHandle == 0);
+        if (!selIsUs && infoMap.contains(selHandle)) {
+            QString selStation = infoMap.value(selHandle).station;
+            m_pttLabel->setText(
+                QString("%1 must claim PTT from their station.").arg(selStation));
+            m_pttLabel->show();
+        } else {
+            m_pttLabel->hide();
+        }
+        m_pttBtn->hide();
+    } else {
+        // We don't have PTT — offer to claim it for our station
+        m_pttLabel->setText(
+            QString("Enable Local PTT for this station (%1):").arg(ourStation));
+        m_pttLabel->show();
+        m_pttBtn->setText("Enable");
+        m_pttBtn->show();
     }
 }
 

--- a/src/gui/MultiFlexDialog.h
+++ b/src/gui/MultiFlexDialog.h
@@ -23,6 +23,7 @@ private:
     QPushButton* m_enableBtn;
     QLabel* m_pttLabel;
     QPushButton* m_pttBtn;
+    bool m_refreshing{false};
 };
 
 } // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1849,6 +1849,26 @@ void RadioModel::sendCmdPublic(const QString& cmd, ResponseCallback cb)
     sendCmd(cmd, cb);
 }
 
+void RadioModel::requestLocalPtt()
+{
+    // "enforce_local_ptt" returns 0x50001000; the settable key matches the
+    // status key the radio broadcasts: local_ptt.  Firmware v1.4.0.0 quirk.
+    sendCmd("client set local_ptt=1", [this](int code, const QString& body) {
+        if (code != 0) {
+            qCWarning(lcProtocol) << "requestLocalPtt: radio returned error"
+                                  << Qt::hex << code << body;
+            return;
+        }
+        // Optimistic update: mark our own entry as having PTT in case the radio
+        // doesn't echo a local_ptt=1 status message back to us.
+        quint32 ours = clientHandle();
+        if (m_clientInfoMap.contains(ours)) {
+            m_clientInfoMap[ours].localPtt = true;
+            emitOtherClientsChanged();
+        }
+    });
+}
+
 void RadioModel::setAmpOperate(bool on)
 {
     if (m_ampHandle.isEmpty()) return;
@@ -1965,6 +1985,11 @@ void RadioModel::onStatusReceived(const QString& object,
                 emitOtherClientsChanged();
                 if (!shouldSuppressClientConnectionNotice(handle))
                     announceClientConnection(handle, source, station, program);
+            } else if (kvs.contains("local_ptt") && m_clientInfoMap.contains(handle)) {
+                // Partial update: radio echoes local_ptt state change without
+                // a full connected message (e.g. after enforce_local_ptt command).
+                m_clientInfoMap[handle].localPtt = kvs.value("local_ptt") == "1";
+                emitOtherClientsChanged();
             }
         }
         return;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -369,6 +369,10 @@ public:
     // Send a raw command to the radio (for dialogs that need direct protocol access).
     void sendCommand(const QString& cmd);
 
+    // Request local PTT for our station. Sends "client set local_ptt=1" and applies
+    // an optimistic update in case the radio doesn't echo the state change.
+    void requestLocalPtt();
+
     // PC Audio: create/remove remote_audio_rx stream
     void createRxAudioStream();
     void removeRxAudioStream();


### PR DESCRIPTION
Fix MultiFlex PTT label, row-selection, and correct PTT command

Three bugs fixed:

1. Label showed wrong station name — used otherStation (remote) instead of
   ourStation (our own). Fixed to use infoMap[ourHandle].station.

2. Row selection had no effect — added itemSelectionChanged handler with
   re-entrance guard (m_refreshing + QSignalBlocker on selectRow). When we
   have PTT and a remote row is selected, show "<station> must claim PTT
   from their station" since the protocol does not allow forcing PTT onto
   another client.

3. Wrong PTT command — "client set enforce_local_ptt=1" returns 0x50001000
   (command not supported, same as client set udpport). Correct command is
   "client set local_ptt=1". The radio echoes a full "connected" status to
   all clients updating their local_ptt when ownership changes, so the
   existing parser handles the UI refresh. Added optimistic update as
   fallback in requestLocalPtt() in case echo is delayed.

Also added handling for partial client status updates (local_ptt-only echo)
as a safety net, and documented the correct command in CLAUDE.md quirks.
