### PR TITLE
[spots] Add Passive Spots mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,6 +421,7 @@ set(CORE_SOURCES
     src/core/SpotCollectorClient.cpp
     src/core/PotaClient.cpp
     src/core/PropForecastClient.cpp
+    src/core/SpotCommandPolicy.cpp
     src/core/RigctlServer.cpp
     src/core/TciServer.cpp
     src/core/TciProtocol.cpp
@@ -1095,6 +1096,14 @@ add_executable(client_reverb_test
     src/core/ClientReverb.cpp
 )
 target_include_directories(client_reverb_test PRIVATE src)
+
+add_executable(passive_spots_policy_test
+    tests/passive_spots_policy_test.cpp
+    src/core/AppSettings.cpp
+    src/core/SpotCommandPolicy.cpp
+)
+target_include_directories(passive_spots_policy_test PRIVATE src)
+target_link_libraries(passive_spots_policy_test PRIVATE Qt6::Core)
 
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -299,6 +299,7 @@ void AppSettings::migrateFromQSettings()
         setValue("GUIClientID", QUuid::createUuid().toString(QUuid::WithoutBraces));
         setValue("IsSingleClickTuneEnabled", "False");
         setValue("IsSpotsEnabled", "True");
+        setValue("PassiveSpotsMode", "False");
         setValue("SpotsMaxLevel", "3");
         setValue("SpotFontSize", "16");
         setValue("FavoriteMode0", "USB");
@@ -352,6 +353,8 @@ void AppSettings::migrateFromQSettings()
     setValue("GUIClientID", QUuid::createUuid().toString(QUuid::WithoutBraces));
     if (!contains("IsSingleClickTuneEnabled"))
         setValue("IsSingleClickTuneEnabled", "False");
+    if (!contains("PassiveSpotsMode"))
+        setValue("PassiveSpotsMode", "False");
     if (!contains("FavoriteMode0")) setValue("FavoriteMode0", "USB");
     if (!contains("FavoriteMode1")) setValue("FavoriteMode1", "CW");
     if (!contains("FavoriteMode2")) setValue("FavoriteMode2", "AM");

--- a/src/core/SpotCommandPolicy.cpp
+++ b/src/core/SpotCommandPolicy.cpp
@@ -1,0 +1,23 @@
+#include "SpotCommandPolicy.h"
+
+#include "AppSettings.h"
+
+namespace AetherSDR::SpotCommandPolicy {
+
+bool passiveModeFromSetting(const QVariant& value)
+{
+    return value.toString() == "True";
+}
+
+bool passiveSpotsModeEnabled()
+{
+    return passiveModeFromSetting(
+        AppSettings::instance().value(kPassiveSpotsModeKey, "False"));
+}
+
+bool shouldSendSpotAddCommands()
+{
+    return !passiveSpotsModeEnabled();
+}
+
+} // namespace AetherSDR::SpotCommandPolicy

--- a/src/core/SpotCommandPolicy.h
+++ b/src/core/SpotCommandPolicy.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QVariant>
+
+namespace AetherSDR::SpotCommandPolicy {
+
+inline constexpr const char* kPassiveSpotsModeKey = "PassiveSpotsMode";
+
+bool passiveModeFromSetting(const QVariant& value);
+bool passiveSpotsModeEnabled();
+bool shouldSendSpotAddCommands();
+
+} // namespace AetherSDR::SpotCommandPolicy

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2,6 +2,7 @@
 #include "GuardedSlider.h"
 #include "core/DxClusterClient.h"
 #include "core/AppSettings.h"
+#include "core/SpotCommandPolicy.h"
 #include "models/RadioModel.h"
 
 #include <QVBoxLayout>
@@ -1724,6 +1725,8 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
 
     auto& s = AppSettings::instance();
     bool spotsEnabled     = s.value("IsSpotsEnabled", "True").toString() == "True";
+    bool passiveSpots     = SpotCommandPolicy::passiveModeFromSetting(
+                                s.value(SpotCommandPolicy::kPassiveSpotsModeKey, "False"));
     bool memoriesEnabled  = s.value("IsMemorySpotsEnabled", "False").toString() == "True";
     bool overrideColors   = s.value("IsSpotsOverrideColorsEnabled", "False").toString() == "True";
     bool overrideBg       = s.value("IsSpotsOverrideBackgroundColorsEnabled", "True").toString() == "True";
@@ -1769,6 +1772,23 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         save("IsSpotsEnabled", on ? "True" : "False");
     });
     grid->addWidget(spotsToggle, row++, 1, Qt::AlignLeft);
+
+    // ── Passive Spots: receive/render only, do not publish spot add commands ──
+    grid->addWidget(new QLabel("Passive Spots:"), row, 0);
+    auto* passiveToggle = new QPushButton(passiveSpots ? "Enabled" : "Disabled");
+    passiveToggle->setCheckable(true);
+    passiveToggle->setChecked(passiveSpots);
+    passiveToggle->setFixedWidth(80);
+    passiveToggle->setToolTip(
+        "Receive and render radio spots without sending spot add commands to the radio.");
+    passiveToggle->setStyleSheet(
+        "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
+        "QPushButton:!checked { background: #603020; }");
+    connect(passiveToggle, &QPushButton::toggled, this, [passiveToggle, save](bool on) {
+        passiveToggle->setText(on ? "Enabled" : "Disabled");
+        save(SpotCommandPolicy::kPassiveSpotsModeKey, on ? "True" : "False");
+    });
+    grid->addWidget(passiveToggle, row++, 1, Qt::AlignLeft);
 
     // ── Memory feed visibility ──────────────────────────────────────────
     grid->addWidget(new QLabel("Memories:"), row, 0);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -135,6 +135,7 @@
 #include <QProgressDialog>
 #include <QThread>
 #include "core/AppSettings.h"
+#include "core/SpotCommandPolicy.h"
 #ifdef HAVE_RADE
 #include "core/RADEEngine.h"
 #endif
@@ -248,6 +249,7 @@ static QString buildNetworkTooltip(const RadioModel& model)
 
 static constexpr const char* kPaTempUnitSettingKey = "PaTempDisplayUnit";
 static constexpr int kMemorySpotIdBase = 1000000;
+static constexpr int kPassiveSpotIdBase = 2000000;
 
 static bool s_keyboardShortcutsEnabled = false;
 
@@ -261,6 +263,11 @@ static int memoryIndexFromSpotId(int spotIndex)
     if (spotIndex > -kMemorySpotIdBase)
         return -1;
     return -spotIndex - kMemorySpotIdBase;
+}
+
+static bool isPassiveLocalSpotId(int spotIndex)
+{
+    return spotIndex <= -kPassiveSpotIdBase;
 }
 
 static QString memorySpotLabel(const MemoryEntry& memory)
@@ -1074,23 +1081,23 @@ MainWindow::MainWindow(QWidget* parent)
         return false;
     };
 
-    // Build spot add command and queue for batch send
-    auto queueSpotCmd = [this, isDuplicateSpot](const DxSpot& spot, const QString& source) {
-        if (!m_radioModel.isConnected()) return;
-        if (isDuplicateSpot(spot)) return;
-        QString call = QString(spot.dxCall).replace(' ', QChar(0x7f));
-        QString freq = QString::number(spot.freqMhz, 'f', 6);
-        QString cmd = "spot add callsign=" + call + " rx_freq=" + freq
-                     + " tx_freq=" + freq
-                     + " source=" + source
-                     + " spotter_callsign=" + spot.spotterCall
-                     + " lifetime_seconds=" + QString::number(
-                           spot.lifetimeSec > 0 ? spot.lifetimeSec
-                           : [&]() { int s = AppSettings::instance().value("DxClusterSpotLifetimeSec", 0).toInt();
-                                     return s > 0 ? s : AppSettings::instance().value("DxClusterSpotLifetime", 30).toInt() * 60; }());
-        if (!spot.comment.isEmpty())
-            cmd += " comment=" + QString(spot.comment).replace(' ', QChar(0x7f));
-        // Apply source-specific color if not already set
+    auto spotLifetimeSeconds = [](const DxSpot& spot, const QString& source) {
+        if (spot.lifetimeSec > 0)
+            return spot.lifetimeSec;
+
+        auto& as = AppSettings::instance();
+        if (source == "WSJT-X")
+            return as.value("WsjtxSpotLifetime", 120).toInt();
+        if (source == "FreeDV")
+            return as.value("FreeDvSpotLifetime", 120).toInt();
+
+        int sec = as.value("DxClusterSpotLifetimeSec", 0).toInt();
+        if (sec <= 0)
+            sec = as.value("DxClusterSpotLifetime", 30).toInt() * 60;
+        return sec;
+    };
+
+    auto spotColorForSource = [](const DxSpot& spot, const QString& source) {
         QString spotColor = spot.color;
         if (spotColor.isEmpty()) {
             auto& as = AppSettings::instance();
@@ -1103,10 +1110,62 @@ MainWindow::MainWindow(QWidget* parent)
             else if (source == "FreeDV")
                 spotColor = as.value("FreeDvSpotColor", "#FF8C00").toString();  // HAVE_WEBSOCKETS
         }
-        if (!spotColor.isEmpty()) {
-            if (spotColor.length() == 7) spotColor = "#FF" + spotColor.mid(1);
-            cmd += " color=" + spotColor;
+        if (spotColor.length() == 7)
+            spotColor = "#FF" + spotColor.mid(1);
+        return spotColor;
+    };
+
+    auto addPassiveSpotToModel = [this](const DxSpot& spot, const QString& source,
+                                        const QString& color, int lifetimeSec) {
+        if (spot.dxCall.trimmed().isEmpty() || spot.freqMhz <= 0.0)
+            return;
+
+        QMap<QString, QString> kvs;
+        kvs["callsign"] = QString(spot.dxCall).replace(' ', QChar(0x7f));
+        kvs["rx_freq"] = QString::number(spot.freqMhz, 'f', 6);
+        kvs["tx_freq"] = QString::number(spot.freqMhz, 'f', 6);
+        kvs["source"] = source;
+        kvs["spotter_callsign"] = spot.spotterCall;
+        kvs["lifetime_seconds"] = QString::number(lifetimeSec);
+        kvs["timestamp"] = QString::number(QDateTime::currentSecsSinceEpoch());
+        if (!spot.comment.isEmpty())
+            kvs["comment"] = QString(spot.comment).replace(' ', QChar(0x7f));
+        if (!color.isEmpty())
+            kvs["color"] = color;
+
+        const int spotId = m_nextPassiveSpotId--;
+        m_radioModel.spotModel().applySpotStatus(spotId, kvs);
+        if (lifetimeSec > 0) {
+            const qint64 expiresAt = QDateTime::currentMSecsSinceEpoch()
+                                   + qint64(lifetimeSec) * 1000;
+            m_passiveSpotExpiryMs.insert(spotId, expiresAt);
         }
+    };
+
+    // Build spot add command and queue for batch send
+    auto queueSpotCmd = [this, isDuplicateSpot, spotLifetimeSeconds,
+                         spotColorForSource, addPassiveSpotToModel]
+                        (const DxSpot& spot, const QString& source) {
+        if (!m_radioModel.isConnected()) return;
+        if (isDuplicateSpot(spot)) return;
+        const int lifetimeSec = spotLifetimeSeconds(spot, source);
+        const QString spotColor = spotColorForSource(spot, source);
+        if (!SpotCommandPolicy::shouldSendSpotAddCommands()) {
+            addPassiveSpotToModel(spot, source, spotColor, lifetimeSec);
+            return;
+        }
+
+        QString call = QString(spot.dxCall).replace(' ', QChar(0x7f));
+        QString freq = QString::number(spot.freqMhz, 'f', 6);
+        QString cmd = "spot add callsign=" + call + " rx_freq=" + freq
+                     + " tx_freq=" + freq
+                     + " source=" + source
+                     + " spotter_callsign=" + spot.spotterCall
+                     + " lifetime_seconds=" + QString::number(lifetimeSec);
+        if (!spot.comment.isEmpty())
+            cmd += " comment=" + QString(spot.comment).replace(' ', QChar(0x7f));
+        if (!spotColor.isEmpty())
+            cmd += " color=" + spotColor;
         m_spotCmdBatch.append(cmd);
     };
 
@@ -1115,6 +1174,10 @@ MainWindow::MainWindow(QWidget* parent)
     spotCmdTimer->start(1000);
     connect(spotCmdTimer, &QTimer::timeout, this, [this] {
         if (m_spotCmdBatch.isEmpty() || !m_radioModel.isConnected()) return;
+        if (!SpotCommandPolicy::shouldSendSpotAddCommands()) {
+            m_spotCmdBatch.clear();
+            return;
+        }
         // Send up to RbnRateLimit commands per tick
         int limit = AppSettings::instance().value("RbnRateLimit", 10).toInt();
         int count = std::min(static_cast<int>(m_spotCmdBatch.size()), limit);
@@ -1122,6 +1185,27 @@ MainWindow::MainWindow(QWidget* parent)
             m_radioModel.sendCommand(m_spotCmdBatch[i]);
         m_spotCmdBatch.remove(0, count);
     });
+
+    auto* passiveSpotExpiryTimer = new QTimer(this);
+    passiveSpotExpiryTimer->start(1000);
+    connect(passiveSpotExpiryTimer, &QTimer::timeout, this, [this] {
+        if (m_passiveSpotExpiryMs.isEmpty())
+            return;
+
+        const qint64 now = QDateTime::currentMSecsSinceEpoch();
+        QVector<int> expired;
+        for (auto it = m_passiveSpotExpiryMs.cbegin(); it != m_passiveSpotExpiryMs.cend(); ++it) {
+            if (it.value() <= now)
+                expired.append(it.key());
+        }
+
+        for (int spotId : expired) {
+            m_passiveSpotExpiryMs.remove(spotId);
+            m_radioModel.spotModel().removeSpot(spotId);
+        }
+    });
+    connect(&m_radioModel.spotModel(), &SpotModel::spotsCleared,
+            this, [this] { m_passiveSpotExpiryMs.clear(); });
 
     connect(m_dxCluster, &DxClusterClient::spotReceived,
             this, [queueSpotCmd](const DxSpot& spot) {
@@ -1134,7 +1218,7 @@ MainWindow::MainWindow(QWidget* parent)
     });
 
     connect(m_wsjtxClient, &WsjtxClient::spotReceived,
-            this, [this, isDuplicateSpot](const DxSpot& spot) {
+            this, [this, isDuplicateSpot, spotLifetimeSeconds, addPassiveSpotToModel](const DxSpot& spot) {
         if (!m_radioModel.isConnected()) return;
         if (isDuplicateSpot(spot)) return;
 
@@ -1198,11 +1282,16 @@ MainWindow::MainWindow(QWidget* parent)
                      + " source=WSJT-X"
                      + " spotter_callsign=" + colored.spotterCall
                      + " lifetime_seconds=" + QString::number(
-                           as.value("WsjtxSpotLifetime", 120).toInt());
+                           spotLifetimeSeconds(colored, "WSJT-X"));
         if (!colored.comment.isEmpty())
             cmd += " comment=" + QString(colored.comment).replace(' ', QChar(0x7f));
         if (!colored.color.isEmpty())
             cmd += " color=" + colored.color;
+        if (!SpotCommandPolicy::shouldSendSpotAddCommands()) {
+            addPassiveSpotToModel(colored, "WSJT-X", colored.color,
+                                  spotLifetimeSeconds(colored, "WSJT-X"));
+            return;
+        }
         m_spotCmdBatch.append(cmd);
     });
 
@@ -4036,7 +4125,10 @@ void MainWindow::buildMenuBar()
                 this, [this] { QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->stopConnection(); }); });
 #endif
         connect(dlg, &DxClusterDialog::spotsClearedAll,
-                this, [this] { m_spotDedup.clear(); });
+                this, [this] {
+            m_spotDedup.clear();
+            m_radioModel.spotModel().clear();
+        });
         connect(dlg, &DxClusterDialog::tuneRequested,
                 this, [this](double freqMhz) {
             if (auto* sl = activeSlice())
@@ -7435,7 +7527,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             return;
         }
 
-        m_radioModel.sendCommand(QString("spot trigger %1").arg(spotIndex));
+        if (!isPassiveLocalSpotId(spotIndex))
+            m_radioModel.sendCommand(QString("spot trigger %1").arg(spotIndex));
 
         // Auto-switch mode from spot metadata (#424)
         if (AppSettings::instance().value("SpotAutoSwitchMode", "False").toString() != "True")
@@ -7527,7 +7620,29 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         QString spotColor = as.value("ManualSpotColor", "#00FF00").toString();
         if (spotColor.length() == 7) spotColor = "#FF" + spotColor.mid(1);
         cmd += " color=" + spotColor;
-        m_radioModel.sendCommand(cmd);
+        if (SpotCommandPolicy::shouldSendSpotAddCommands()) {
+            m_radioModel.sendCommand(cmd);
+        } else {
+            QMap<QString, QString> kvs;
+            kvs["callsign"] = QString(callsign).replace(' ', QChar(0x7f));
+            kvs["rx_freq"] = freq;
+            kvs["tx_freq"] = freq;
+            kvs["source"] = "Manual";
+            kvs["spotter_callsign"] = myCall;
+            kvs["lifetime_seconds"] = QString::number(lifetimeSec);
+            kvs["timestamp"] = QString::number(QDateTime::currentSecsSinceEpoch());
+            if (!comment.isEmpty())
+                kvs["comment"] = QString(comment).replace(' ', QChar(0x7f));
+            kvs["color"] = spotColor;
+
+            const int spotId = m_nextPassiveSpotId--;
+            m_radioModel.spotModel().applySpotStatus(spotId, kvs);
+            if (lifetimeSec > 0) {
+                m_passiveSpotExpiryMs.insert(
+                    spotId,
+                    QDateTime::currentMSecsSinceEpoch() + qint64(lifetimeSec) * 1000);
+            }
+        }
 
         // Forward to DX cluster if requested
         if (forwardToCluster && m_dxCluster && m_dxCluster->isConnected()) {
@@ -7541,6 +7656,11 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         }
     });
     connect(sw, &SpectrumWidget::spotRemoveRequested, this, [this](int spotIndex) {
+        if (isPassiveLocalSpotId(spotIndex)) {
+            m_passiveSpotExpiryMs.remove(spotIndex);
+            m_radioModel.spotModel().removeSpot(spotIndex);
+            return;
+        }
         m_radioModel.sendCommand(QString("spot remove %1").arg(spotIndex));
     });
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -48,6 +48,7 @@
 #include <QLabel>
 #include <QMenu>
 #include <QStatusBar>
+#include <QHash>
 
 namespace AetherSDR {
 
@@ -242,6 +243,8 @@ private:
 
     // Batched spot add commands (flushed 1/sec)
     QStringList m_spotCmdBatch;
+    int m_nextPassiveSpotId{-2000000};
+    QHash<int, qint64> m_passiveSpotExpiryMs;
     // External controllers run on a dedicated worker thread (#502)
     QThread*             m_extCtrlThread{nullptr};
 #ifdef HAVE_SERIALPORT

--- a/tests/passive_spots_policy_test.cpp
+++ b/tests/passive_spots_policy_test.cpp
@@ -1,0 +1,59 @@
+#include "core/AppSettings.h"
+#include "core/SpotCommandPolicy.h"
+
+#include <QCoreApplication>
+#include <QString>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) ++g_failed;
+}
+
+void testSettingParsing()
+{
+    using namespace SpotCommandPolicy;
+
+    report("PassiveSpotsMode True enables passive mode",
+           passiveModeFromSetting(QStringLiteral("True")));
+    report("PassiveSpotsMode False disables passive mode",
+           !passiveModeFromSetting(QStringLiteral("False")));
+    report("missing PassiveSpotsMode defaults inactive",
+           !passiveModeFromSetting({}));
+}
+
+void testSendPolicyUsesAppSettings()
+{
+    auto& settings = AppSettings::instance();
+    settings.reset();
+
+    report("default policy sends spot add commands",
+           SpotCommandPolicy::shouldSendSpotAddCommands());
+
+    settings.setValue(SpotCommandPolicy::kPassiveSpotsModeKey, "True");
+    report("passive mode suppresses spot add commands",
+           !SpotCommandPolicy::shouldSendSpotAddCommands());
+
+    settings.setValue(SpotCommandPolicy::kPassiveSpotsModeKey, "False");
+    report("disabling passive mode resumes spot add commands",
+           SpotCommandPolicy::shouldSendSpotAddCommands());
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    testSettingParsing();
+    testSendPolicyUsesAppSettings();
+
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adds a persisted Passive Spots mode to SpotHub Display.

- Adds a `Passive Spots` toggle backed by `PassiveSpotsMode`.
- Suppresses outbound radio `spot add` commands while passive mode is enabled.
- Keeps AetherSDR-originated spots visible locally on the panadapter using private local spot IDs and normal expiry.
- Keeps received radio spots from `sub spot all` unchanged, so other clients' spots still render.
- Clears private passive spots when SpotHub Clear All Spots is used.

## Validation

- `cmake -S . -B build -G Ninja`
- `cmake --build build --target AetherSDR --parallel 10`
- `cmake --build build --target passive_spots_policy_test --parallel 10`
- `./build/passive_spots_policy_test`
- `git diff --check`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
