### PR TITLE
[help] Add audio and control device details to Slice Troubleshooter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,7 @@ set(CORE_SOURCES
     src/core/LogManager.cpp
     src/core/ShortcutManager.cpp
     src/core/SupportBundle.cpp
+    src/core/DeviceDiagnostics.cpp
     src/core/SerialPortController.cpp
     src/core/FlexControlManager.cpp
     src/core/OpusCodec.cpp
@@ -1115,6 +1116,12 @@ target_link_libraries(help_dialog_test PRIVATE
     Qt6::Core Qt6::Widgets Qt6::Test
 )
 set_target_properties(help_dialog_test PROPERTIES AUTOMOC ON)
+
+add_executable(device_diagnostics_test
+    tests/device_diagnostics_test.cpp
+)
+target_include_directories(device_diagnostics_test PRIVATE src)
+target_link_libraries(device_diagnostics_test PRIVATE Qt6::Core)
 
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -97,6 +97,7 @@ public:
 
     bool isMuted() const       { return m_muted.load(); }
     void setMuted(bool m);
+    bool isRxStreaming() const { return m_audioSink != nullptr; }
     bool isTxStreaming() const { return m_audioSource != nullptr; }
 
     // Client-side PC mic gain (0-100 → 0.0-1.0, applied before Opus encoding)

--- a/src/core/DeviceDiagnostics.cpp
+++ b/src/core/DeviceDiagnostics.cpp
@@ -1,0 +1,257 @@
+#include "DeviceDiagnostics.h"
+#include "AppSettings.h"
+#include "AudioEngine.h"
+
+#include <QAudioDevice>
+#include <QAudioFormat>
+#include <QCryptographicHash>
+#include <QJsonArray>
+#include <QJsonValue>
+#include <QMediaDevices>
+#include <QtGlobal>
+
+#include <cmath>
+
+namespace AetherSDR::DeviceDiagnostics {
+
+namespace {
+
+bool isSavedTrue(const QString& key, const QString& defaultValue = QStringLiteral("False"))
+{
+    return AppSettings::instance().value(key, defaultValue).toString() == QStringLiteral("True");
+}
+
+bool sameDevice(const QAudioDevice& lhs, const QAudioDevice& rhs)
+{
+    return !lhs.isNull() && !rhs.isNull() && lhs.id() == rhs.id();
+}
+
+QString sampleFormatName(QAudioFormat::SampleFormat format)
+{
+    switch (format) {
+    case QAudioFormat::Unknown: return QStringLiteral("Unknown");
+    case QAudioFormat::UInt8:   return QStringLiteral("UInt8");
+    case QAudioFormat::Int16:   return QStringLiteral("Int16");
+    case QAudioFormat::Int32:   return QStringLiteral("Int32");
+    case QAudioFormat::Float:   return QStringLiteral("Float");
+    default:                    return QStringLiteral("Unknown");
+    }
+    return QStringLiteral("Unknown");
+}
+
+QJsonObject formatToJson(const QAudioFormat& format)
+{
+    QJsonObject obj;
+    obj["sample_rate"] = format.sampleRate();
+    obj["channel_count"] = format.channelCount();
+    obj["sample_format"] = sampleFormatName(format.sampleFormat());
+    return obj;
+}
+
+bool supportsFormat(const QAudioDevice& device,
+                    int sampleRate,
+                    int channelCount,
+                    QAudioFormat::SampleFormat sampleFormat)
+{
+    if (device.isNull())
+        return false;
+
+    QAudioFormat format;
+    format.setSampleRate(sampleRate);
+    format.setChannelCount(channelCount);
+    format.setSampleFormat(sampleFormat);
+    return device.isFormatSupported(format);
+}
+
+QString idFingerprint(const QByteArray& id)
+{
+    if (id.isEmpty())
+        return {};
+
+    return QString::fromLatin1(
+        QCryptographicHash::hash(id, QCryptographicHash::Sha256).toHex().left(12));
+}
+
+QJsonObject deviceToJson(const QAudioDevice& device,
+                         const QAudioDevice& selected,
+                         const QAudioDevice& defaultDevice,
+                         const QString& direction)
+{
+    QJsonObject obj;
+    obj["direction"] = direction;
+    obj["available"] = !device.isNull();
+    if (device.isNull()) {
+        obj["description"] = "Unavailable";
+        obj["bus_type"] = "Unknown";
+        obj["bus_type_source"] = "no device";
+        return obj;
+    }
+
+    const AudioBusType bus = inferAudioBusType(device.description(), device.id());
+    obj["description"] = device.description();
+    obj["id_available"] = !device.id().isEmpty();
+    obj["id_fingerprint"] = idFingerprint(device.id());
+    obj["bus_type"] = bus.type;
+    obj["bus_type_source"] = bus.source;
+    obj["selected"] = sameDevice(device, selected);
+    obj["default"] = sameDevice(device, defaultDevice);
+    obj["minimum_sample_rate"] = device.minimumSampleRate();
+    obj["maximum_sample_rate"] = device.maximumSampleRate();
+    obj["minimum_channel_count"] = device.minimumChannelCount();
+    obj["maximum_channel_count"] = device.maximumChannelCount();
+    obj["preferred_format"] = formatToJson(device.preferredFormat());
+
+    if (direction == QStringLiteral("output")) {
+        obj["supports_24k_float_stereo"] = supportsFormat(device, 24000, 2, QAudioFormat::Float);
+        obj["supports_48k_float_stereo"] = supportsFormat(device, 48000, 2, QAudioFormat::Float);
+    } else {
+        obj["supports_24k_int16_stereo"] = supportsFormat(device, 24000, 2, QAudioFormat::Int16);
+        obj["supports_48k_int16_stereo"] = supportsFormat(device, 48000, 2, QAudioFormat::Int16);
+        obj["supports_24k_int16_mono"] = supportsFormat(device, 24000, 1, QAudioFormat::Int16);
+        obj["supports_48k_int16_mono"] = supportsFormat(device, 48000, 1, QAudioFormat::Int16);
+    }
+
+    return obj;
+}
+
+QJsonArray deviceListToJson(const QList<QAudioDevice>& devices,
+                            const QAudioDevice& selected,
+                            const QAudioDevice& defaultDevice,
+                            const QString& direction)
+{
+    QJsonArray array;
+    for (const QAudioDevice& device : devices)
+        array.append(deviceToJson(device, selected, defaultDevice, direction));
+    return array;
+}
+
+bool devicePresent(const QList<QAudioDevice>& devices, const QAudioDevice& selected)
+{
+    for (const QAudioDevice& device : devices) {
+        if (sameDevice(device, selected))
+            return true;
+    }
+    return false;
+}
+
+QString micRouteName(const QJsonObject& mic)
+{
+    const QString selection = mic["selection"].toString();
+    if (selection.compare(QStringLiteral("PC"), Qt::CaseInsensitive) == 0)
+        return QStringLiteral("PC audio input");
+    if (mic["dax_on"].toBool())
+        return QStringLiteral("Radio DAX audio");
+    return QStringLiteral("Radio audio input");
+}
+
+} // namespace
+
+QJsonObject buildAudioDevicesSnapshot(const AudioEngine* audio, const QJsonObject& snapshot)
+{
+    const QList<QAudioDevice> inputs = QMediaDevices::audioInputs();
+    const QList<QAudioDevice> outputs = QMediaDevices::audioOutputs();
+    const QAudioDevice defaultInput = QMediaDevices::defaultAudioInput();
+    const QAudioDevice defaultOutput = QMediaDevices::defaultAudioOutput();
+
+    const QAudioDevice selectedInput = (audio && !audio->inputDevice().isNull())
+        ? audio->inputDevice()
+        : defaultInput;
+    const QAudioDevice selectedOutput = (audio && !audio->outputDevice().isNull())
+        ? audio->outputDevice()
+        : defaultOutput;
+
+    QJsonObject obj;
+    obj["available"] = audio != nullptr;
+    obj["qt_multimedia"] = true;
+    obj["input_device_count"] = inputs.size();
+    obj["output_device_count"] = outputs.size();
+    obj["selected_input_source"] = (audio && !audio->inputDevice().isNull()) ? "saved selection" : "system default";
+    obj["selected_output_source"] = (audio && !audio->outputDevice().isNull()) ? "saved selection" : "system default";
+    obj["selected_input_present"] = devicePresent(inputs, selectedInput);
+    obj["selected_output_present"] = devicePresent(outputs, selectedOutput);
+    obj["selected_input"] = deviceToJson(selectedInput, selectedInput, defaultInput, QStringLiteral("input"));
+    obj["selected_output"] = deviceToJson(selectedOutput, selectedOutput, defaultOutput, QStringLiteral("output"));
+    obj["input_devices"] = deviceListToJson(inputs, selectedInput, defaultInput, QStringLiteral("input"));
+    obj["output_devices"] = deviceListToJson(outputs, selectedOutput, defaultOutput, QStringLiteral("output"));
+
+    const QJsonObject transmit = snapshot["transmit"].toObject();
+    const QJsonObject mic = transmit["mic"].toObject();
+    const bool pcAudioEnabled = isSavedTrue(QStringLiteral("PcAudioEnabled"), QStringLiteral("True"));
+
+    QJsonObject rxRoute;
+    rxRoute["output"] = pcAudioEnabled ? "PC audio" : "Radio audio";
+    rxRoute["source"] = "PcAudioEnabled app setting";
+    rxRoute["selected_output_device"] = selectedOutput.description();
+    rxRoute["radio_lineout_available"] = true;
+    obj["rx_route"] = rxRoute;
+
+    QJsonObject txRoute;
+    txRoute["input"] = micRouteName(mic);
+    txRoute["source"] = "transmit mic/DAX state";
+    txRoute["mic_selection"] = mic["selection"].toString();
+    txRoute["dax_on"] = mic["dax_on"].toBool();
+    txRoute["selected_input_device"] = selectedInput.description();
+    obj["tx_route"] = txRoute;
+
+    QJsonObject volumes;
+    volumes["pc_audio_enabled"] = pcAudioEnabled;
+    volumes["pc_audio_muted"] = isSavedTrue(QStringLiteral("PcAudioMuted"));
+    volumes["pc_master_volume_pct"] = AppSettings::instance().value("MasterVolume", "100").toInt();
+    volumes["pc_mic_gain_pct"] = AppSettings::instance().value("PcMicGain", 100).toInt();
+
+    const QJsonObject radio = snapshot["radio"].toObject();
+    const QJsonObject radioAudio = radio["audio_outputs"].toObject();
+    volumes["radio_lineout_gain"] = radioAudio["lineout_gain"];
+    volumes["radio_lineout_mute"] = radioAudio["lineout_mute"];
+    volumes["radio_headphone_gain"] = radioAudio["headphone_gain"];
+    volumes["radio_headphone_mute"] = radioAudio["headphone_mute"];
+    volumes["radio_front_speaker_mute"] = radioAudio["front_speaker_mute"];
+
+    if (audio) {
+        volumes["engine_rx_volume_pct"] = qRound(audio->rxVolume() * 100.0f);
+        volumes["engine_rx_muted"] = audio->isMuted();
+        volumes["engine_rx_boost"] = audio->rxBoost();
+        obj["rx_streaming"] = audio->isRxStreaming();
+        obj["tx_streaming"] = audio->isTxStreaming();
+        obj["dax_tx_mode"] = audio->isDaxTxMode();
+        obj["dax_tx_use_radio_route"] = audio->daxTxUseRadioRoute();
+    } else {
+        volumes["engine_rx_volume_pct"] = QJsonValue();
+        volumes["engine_rx_muted"] = QJsonValue();
+        volumes["engine_rx_boost"] = QJsonValue();
+        obj["rx_streaming"] = QJsonValue();
+        obj["tx_streaming"] = QJsonValue();
+        obj["dax_tx_mode"] = QJsonValue();
+        obj["dax_tx_use_radio_route"] = QJsonValue();
+    }
+
+    obj["volumes"] = volumes;
+    return obj;
+}
+
+void annotateSliceAudioRoutes(QJsonObject* snapshot, const QJsonObject& audioDevices)
+{
+    if (!snapshot)
+        return;
+
+    const QJsonObject rxRoute = audioDevices["rx_route"].toObject();
+    const QJsonObject selectedOutput = audioDevices["selected_output"].toObject();
+
+    QJsonArray updatedSlices;
+    const QJsonArray slices = (*snapshot)["slices"].toArray();
+    for (const QJsonValue& value : slices) {
+        QJsonObject slice = value.toObject();
+        QJsonObject audio = slice["audio"].toObject();
+        audio["rx_route"] = rxRoute["output"].toString("Unknown");
+        audio["rx_route_source"] = rxRoute["source"].toString();
+        audio["pc_audio_enabled"] = audioDevices["volumes"].toObject()["pc_audio_enabled"].toBool();
+        audio["selected_output_device"] = selectedOutput["description"].toString("Unavailable");
+        audio["selected_output_bus_type"] = selectedOutput["bus_type"].toString("Unknown");
+        slice["audio"] = audio;
+        updatedSlices.append(slice);
+    }
+
+    (*snapshot)["slices"] = updatedSlices;
+}
+
+} // namespace AetherSDR::DeviceDiagnostics

--- a/src/core/DeviceDiagnostics.h
+++ b/src/core/DeviceDiagnostics.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QByteArray>
+#include <QJsonObject>
+#include <QString>
+
+namespace AetherSDR {
+
+class AudioEngine;
+
+namespace DeviceDiagnostics {
+
+struct AudioBusType {
+    QString type;
+    QString source;
+};
+
+inline AudioBusType inferAudioBusType(const QString& description, const QByteArray& id)
+{
+    const QString text = (description + QLatin1Char(' ') + QString::fromLatin1(id)).toLower();
+
+    if (text.contains(QStringLiteral("bluetooth"))
+        || text.contains(QStringLiteral("airpods"))
+        || text.contains(QStringLiteral(" bt "))
+        || text.startsWith(QStringLiteral("bt "))
+        || text.endsWith(QStringLiteral(" bt"))
+        || text.contains(QStringLiteral("bth"))
+        || text.contains(QStringLiteral("hfp"))
+        || text.contains(QStringLiteral("sco"))) {
+        return {QStringLiteral("Bluetooth"), QStringLiteral("name/id heuristic")};
+    }
+
+    if (text.contains(QStringLiteral("usb"))
+        || text.contains(QStringLiteral("vid_"))
+        || text.contains(QStringLiteral("pid_"))
+        || text.contains(QStringLiteral("vid:"))
+        || text.contains(QStringLiteral("pid:"))) {
+        return {QStringLiteral("USB"), QStringLiteral("name/id heuristic")};
+    }
+
+    return {QStringLiteral("Unknown"), QStringLiteral("not exposed by Qt")};
+}
+
+QJsonObject buildAudioDevicesSnapshot(const AudioEngine* audio, const QJsonObject& snapshot);
+void annotateSliceAudioRoutes(QJsonObject* snapshot, const QJsonObject& audioDevices);
+
+} // namespace DeviceDiagnostics
+} // namespace AetherSDR

--- a/src/core/FlexControlManager.h
+++ b/src/core/FlexControlManager.h
@@ -31,6 +31,7 @@ public:
     bool open(const QString& portName);
     void close();
     bool isOpen() const { return m_port.isOpen(); }
+    QString portName() const { return m_port.portName(); }
 
     // Scan QSerialPortInfo for VID 0x2192, PID 0x0010
     static QString detectPort();

--- a/src/core/HidEncoderManager.h
+++ b/src/core/HidEncoderManager.h
@@ -27,6 +27,8 @@ public:
     void close();
     bool isOpen() const { return m_device != nullptr; }
     QString deviceName() const { return m_deviceName; }
+    uint16_t vendorId() const { return m_openVid; }
+    uint16_t productId() const { return m_openPid; }
 
     void setInvertDirection(bool invert) { m_invertDirection = invert; }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3458,6 +3458,231 @@ void MainWindow::showNetworkDiagnosticsDialog()
     m_networkDiagnosticsDialog->activateWindow();
 }
 
+QJsonObject MainWindow::buildControlDevicesSnapshot() const
+{
+    auto stringArray = [](const QStringList& values) {
+        QJsonArray array;
+        for (const QString& value : values)
+            array.append(value);
+        return array;
+    };
+
+    auto buttonBindings = [](const QString& prefix, int buttonCount) {
+        static const char* kActionNames[] = {"tap", "double_tap", "hold"};
+        QJsonArray bindings;
+        auto& settings = AppSettings::instance();
+        for (int button = 1; button <= buttonCount; ++button) {
+            for (int action = 0; action < 3; ++action) {
+                const QString key = QString("%1Btn%2Action%3").arg(prefix).arg(button).arg(action);
+                const QString mappedAction = settings.value(key, "None").toString();
+                if (mappedAction == QStringLiteral("None"))
+                    continue;
+                QJsonObject obj;
+                obj["button"] = button;
+                obj["gesture"] = kActionNames[action];
+                obj["action"] = mappedAction;
+                bindings.append(obj);
+            }
+        }
+        return bindings;
+    };
+
+    auto addTarget = [this](QJsonObject* obj) {
+        if (m_activeSliceId >= 0)
+            (*obj)["target_slice_id"] = m_activeSliceId;
+        else
+            (*obj)["target_slice_id"] = QJsonValue();
+        (*obj)["target_scope"] = "active_slice";
+    };
+
+    auto flexWheelModeName = [](FlexWheelMode mode) {
+        switch (mode) {
+        case FlexWheelMode::Frequency: return QStringLiteral("Frequency");
+        case FlexWheelMode::Volume:    return QStringLiteral("Volume");
+        case FlexWheelMode::Power:     return QStringLiteral("Power");
+        }
+        return QStringLiteral("Unknown");
+    };
+
+    const bool activeSliceAvailable = activeSlice() != nullptr;
+    QJsonArray devices;
+    int activeDeviceCount = 0;
+
+    auto appendDevice = [&devices, &activeDeviceCount](QJsonObject device) {
+        if (device["active"].toBool())
+            ++activeDeviceCount;
+        devices.append(device);
+    };
+
+#ifdef HAVE_SERIALPORT
+    {
+        const bool active = m_flexControl && m_flexControl->isOpen();
+        QJsonObject flex;
+        flex["type"] = "FlexControl";
+        flex["available"] = true;
+        flex["active"] = active;
+        flex["active_for_current_slice"] = active && activeSliceAvailable;
+        flex["bus_type"] = "USB";
+        flex["transport"] = "USB serial";
+        flex["wheel_mode"] = flexWheelModeName(m_flexWheelMode);
+        flex["port_name"] = (m_flexControl && active)
+            ? m_flexControl->portName()
+            : AppSettings::instance().value("FlexControlPort").toString();
+        flex["auto_detect"] = AppSettings::instance().value("FlexControlAutoDetect", "True").toString() == "True";
+        flex["invert_direction"] = AppSettings::instance().value("FlexControlInvertDir", "False").toString() == "True";
+        flex["button_bindings"] = buttonBindings(QStringLiteral("FlexControl"), 4);
+        addTarget(&flex);
+        flex["detail"] = active
+            ? QString("Flex wheel controls %1 on the active slice").arg(flex["wheel_mode"].toString())
+            : QStringLiteral("FlexControl is not connected");
+        appendDevice(flex);
+    }
+#else
+    appendDevice(QJsonObject{
+        {"type", "FlexControl"},
+        {"available", false},
+        {"active", false},
+        {"active_for_current_slice", false},
+        {"bus_type", "USB"},
+        {"detail", "Qt SerialPort support is not compiled in"}
+    });
+#endif
+
+#ifdef HAVE_HIDAPI
+    {
+        const bool active = m_hidEncoder && m_hidEncoder->isOpen();
+        QJsonObject hid;
+        hid["type"] = "USB HID Wheel";
+        hid["available"] = true;
+        hid["active"] = active;
+        hid["active_for_current_slice"] = active && activeSliceAvailable;
+        hid["bus_type"] = "USB";
+        hid["transport"] = "hidapi";
+        hid["device_name"] = m_hidEncoder ? m_hidEncoder->deviceName() : QString();
+        hid["vendor_id"] = (m_hidEncoder && m_hidEncoder->vendorId() != 0)
+            ? QString("0x%1").arg(m_hidEncoder->vendorId(), 4, 16, QChar('0'))
+            : QString();
+        hid["product_id"] = (m_hidEncoder && m_hidEncoder->productId() != 0)
+            ? QString("0x%1").arg(m_hidEncoder->productId(), 4, 16, QChar('0'))
+            : QString();
+        hid["auto_detect"] = AppSettings::instance().value("HidEncoderAutoDetect", "True").toString() == "True";
+        hid["invert_direction"] = AppSettings::instance().value("HidEncoderInvertDir", "False").toString() == "True";
+        hid["button_bindings"] = buttonBindings(QStringLiteral("HidEncoder"), 16);
+        addTarget(&hid);
+        hid["detail"] = active
+            ? QString("HID wheel `%1` tunes the active slice").arg(hid["device_name"].toString())
+            : QStringLiteral("No supported HID wheel is connected");
+        appendDevice(hid);
+    }
+#else
+    appendDevice(QJsonObject{
+        {"type", "USB HID Wheel"},
+        {"available", false},
+        {"active", false},
+        {"active_for_current_slice", false},
+        {"bus_type", "USB"},
+        {"detail", "hidapi support is not compiled in"}
+    });
+#endif
+
+#ifdef HAVE_MIDI
+    {
+        auto messageTypeName = [](MidiBinding::MsgType type) {
+            switch (type) {
+            case MidiBinding::CC:        return QStringLiteral("CC");
+            case MidiBinding::NoteOn:    return QStringLiteral("NoteOn");
+            case MidiBinding::NoteOff:   return QStringLiteral("NoteOff");
+            case MidiBinding::PitchBend: return QStringLiteral("PitchBend");
+            }
+            return QStringLiteral("Unknown");
+        };
+
+        auto bindingScope = [](const QString& paramId, const QString& category) {
+            if (paramId.startsWith(QStringLiteral("rx."))
+                || paramId == QStringLiteral("global.nextSlice")
+                || paramId == QStringLiteral("global.prevSlice")) {
+                return QStringLiteral("active_slice");
+            }
+            if (category == QStringLiteral("Global"))
+                return QStringLiteral("global");
+            if (category == QStringLiteral("TX") || category == QStringLiteral("Phone/CW"))
+                return QStringLiteral("transmit");
+            return category.toLower();
+        };
+
+        const bool active = m_midiControl && m_midiControl->isOpen();
+        QJsonArray bindings;
+        int sliceBindingCount = 0;
+        if (m_midiControl) {
+            for (const MidiBinding& binding : m_midiControl->bindings()) {
+                const MidiParam* param = m_midiControl->findParam(binding.paramId);
+                const QString category = param ? param->category : QString();
+                const QString scope = bindingScope(binding.paramId, category);
+                if (scope == QStringLiteral("active_slice"))
+                    ++sliceBindingCount;
+
+                QJsonObject obj;
+                obj["source"] = binding.sourceDisplayName();
+                obj["channel"] = binding.channel < 0
+                    ? QStringLiteral("any")
+                    : QString::number(binding.channel + 1);
+                obj["message_type"] = messageTypeName(binding.msgType);
+                obj["number"] = binding.number;
+                obj["param_id"] = binding.paramId;
+                obj["param_name"] = param ? param->displayName : binding.paramId;
+                obj["category"] = category;
+                obj["relative"] = binding.relative;
+                obj["inverted"] = binding.inverted;
+                obj["scope"] = scope;
+                bindings.append(obj);
+            }
+        }
+
+        QJsonObject midi;
+        midi["type"] = "MIDI Controller";
+        midi["available"] = true;
+        midi["active"] = active;
+        midi["active_for_current_slice"] = active && activeSliceAvailable && sliceBindingCount > 0;
+        midi["bus_type"] = "Unknown";
+        midi["transport"] = "RtMidi";
+        midi["port_name"] = m_midiControl ? m_midiControl->currentPortName() : QString();
+        midi["available_ports"] = m_midiControl ? stringArray(m_midiControl->availablePorts()) : QJsonArray{};
+        midi["binding_count"] = bindings.size();
+        midi["slice_binding_count"] = sliceBindingCount;
+        midi["bindings"] = bindings;
+        addTarget(&midi);
+        midi["detail"] = active
+            ? QString("MIDI port `%1` has %2 active-slice binding(s)")
+                  .arg(midi["port_name"].toString())
+                  .arg(sliceBindingCount)
+            : QStringLiteral("MIDI controller is not connected");
+        appendDevice(midi);
+    }
+#else
+    appendDevice(QJsonObject{
+        {"type", "MIDI Controller"},
+        {"available", false},
+        {"active", false},
+        {"active_for_current_slice", false},
+        {"bus_type", "Unknown"},
+        {"detail", "MIDI support is not compiled in"}
+    });
+#endif
+
+    QJsonObject snapshot;
+    snapshot["available"] = true;
+    snapshot["target_scope"] = "active_slice";
+    snapshot["active_slice_available"] = activeSliceAvailable;
+    if (m_activeSliceId >= 0)
+        snapshot["target_slice_id"] = m_activeSliceId;
+    else
+        snapshot["target_slice_id"] = QJsonValue();
+    snapshot["active_device_count"] = activeDeviceCount;
+    snapshot["devices"] = devices;
+    snapshot["note"] = "External wheel controls operate on the current active slice unless a binding changes slices.";
+    return snapshot;
+}
+
 void MainWindow::showPropDashboard()
 {
     if (!m_propDashboardDialog) {
@@ -4867,7 +5092,8 @@ void MainWindow::buildMenuBar()
         dlg->raise();
     });
     helpMenu->addAction("Slice Troubleshooting...", this, [this]() {
-        SliceTroubleshootingDialog dlg(&m_radioModel, m_audio, this);
+        SliceTroubleshootingDialog dlg(&m_radioModel, m_audio, this,
+                                       [this]() { return buildControlDevicesSnapshot(); });
         dlg.exec();
     });
     helpMenu->addAction("What's New...", this, [this]() {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -49,6 +49,7 @@
 #include <QMenu>
 #include <QStatusBar>
 #include <QHash>
+#include <QJsonObject>
 
 namespace AetherSDR {
 
@@ -176,6 +177,7 @@ private:
                                 std::shared_ptr<QStringList> panIds, int created);
     void updatePaTempLabel();
     void showNetworkDiagnosticsDialog();
+    QJsonObject buildControlDevicesSnapshot() const;
     void showPropDashboard();
     bool confirmClientSlotAvailability(const RadioInfo& info, QList<quint32>* disconnectHandles);
     bool confirmClientSlotAvailability(const WanRadioInfo& info, QList<quint32>* disconnectHandles);

--- a/src/gui/SliceTroubleshootingDialog.cpp
+++ b/src/gui/SliceTroubleshootingDialog.cpp
@@ -2,6 +2,7 @@
 #include "GuardedSlider.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
+#include "core/DeviceDiagnostics.h"
 #include "models/RadioModel.h"
 
 #include <QApplication>
@@ -20,6 +21,7 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <QStringList>
+#include <utility>
 
 namespace AetherSDR {
 
@@ -114,6 +116,90 @@ QString formatClientBullet(const QJsonObject& client)
         .arg(formatNumber(client["tx_freq_mhz"], 6));
 }
 
+QString formatBoolValue(const QJsonValue& value)
+{
+    return value.isBool() ? yesNo(value.toBool()) : QStringLiteral("n/a");
+}
+
+QString formatPercentValue(const QJsonValue& value)
+{
+    return value.isDouble() ? QString("%1%").arg(qRound(value.toDouble())) : QStringLiteral("n/a");
+}
+
+QString formatAudioDeviceShort(const QJsonObject& device)
+{
+    const QString description = orPlaceholder(device["description"].toString(), "Unavailable");
+    const QString bus = orPlaceholder(device["bus_type"].toString(), "Unknown");
+    return QString("`%1` (bus `%2`)").arg(description, bus);
+}
+
+QString formatAudioSupport(const QJsonObject& device)
+{
+    if (device["direction"].toString() == QStringLiteral("output")) {
+        return QString("24k float `%1`, 48k float `%2`")
+            .arg(yesNo(device["supports_24k_float_stereo"].toBool()))
+            .arg(yesNo(device["supports_48k_float_stereo"].toBool()));
+    }
+
+    return QString("24k stereo `%1`, 48k stereo `%2`, 24k mono `%3`, 48k mono `%4`")
+        .arg(yesNo(device["supports_24k_int16_stereo"].toBool()))
+        .arg(yesNo(device["supports_48k_int16_stereo"].toBool()))
+        .arg(yesNo(device["supports_24k_int16_mono"].toBool()))
+        .arg(yesNo(device["supports_48k_int16_mono"].toBool()));
+}
+
+QString formatAudioDeviceBullet(const QJsonObject& device, const QString& prefix = "- ")
+{
+    QStringList flags;
+    if (device["selected"].toBool())
+        flags << "selected";
+    if (device["default"].toBool())
+        flags << "default";
+    if (flags.isEmpty())
+        flags << "available";
+
+    const QJsonObject preferred = device["preferred_format"].toObject();
+    return QString("%1`%2` (%3): bus `%4`, rates `%5-%6 Hz`, channels `%7-%8`, preferred `%9 Hz/%10 ch/%11`, %12")
+        .arg(prefix)
+        .arg(orPlaceholder(device["description"].toString(), "Unavailable"))
+        .arg(flags.join(", "))
+        .arg(orPlaceholder(device["bus_type"].toString(), "Unknown"))
+        .arg(device["minimum_sample_rate"].toInt())
+        .arg(device["maximum_sample_rate"].toInt())
+        .arg(device["minimum_channel_count"].toInt())
+        .arg(device["maximum_channel_count"].toInt())
+        .arg(preferred["sample_rate"].toInt())
+        .arg(preferred["channel_count"].toInt())
+        .arg(orPlaceholder(preferred["sample_format"].toString(), "Unknown"))
+        .arg(formatAudioSupport(device));
+}
+
+QString formatControlDeviceBullet(const QJsonObject& device)
+{
+    return QString("- `%1`: active `%2`, active for slice `%3`, bus `%4`, target slice `%5`, detail `%6`")
+        .arg(orPlaceholder(device["type"].toString()))
+        .arg(yesNo(device["active"].toBool()))
+        .arg(yesNo(device["active_for_current_slice"].toBool()))
+        .arg(orPlaceholder(device["bus_type"].toString(), "Unknown"))
+        .arg(device.contains("target_slice_id") && device["target_slice_id"].isDouble()
+                 ? QString::number(device["target_slice_id"].toInt())
+                 : QStringLiteral("n/a"))
+        .arg(orPlaceholder(device["detail"].toString(), "n/a"));
+}
+
+QString formatMidiBindingBullet(const QJsonObject& binding, const QString& prefix = "  - ")
+{
+    return QString("%1`%2` -> `%3` (`%4`, channel `%5`, relative `%6`, inverted `%7`, scope `%8`)")
+        .arg(prefix)
+        .arg(orPlaceholder(binding["source"].toString()))
+        .arg(orPlaceholder(binding["param_name"].toString(), binding["param_id"].toString()))
+        .arg(orPlaceholder(binding["message_type"].toString()))
+        .arg(orPlaceholder(binding["channel"].toString()))
+        .arg(yesNo(binding["relative"].toBool()))
+        .arg(yesNo(binding["inverted"].toBool()))
+        .arg(orPlaceholder(binding["scope"].toString(), "unknown"));
+}
+
 QString formatTxBandBullet(const QJsonObject& band)
 {
     return QString("- `%1` (ID `%2`): RF `%3`, tune `%4`, inhibit `%5`, HWALC `%6`, "
@@ -200,8 +286,14 @@ QJsonObject buildClientDspSnapshot(const AudioEngine* audio)
 
 } // namespace
 
-SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model, AudioEngine* audio, QWidget* parent)
-    : QDialog(parent), m_model(model), m_audio(audio)
+SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model,
+                                                       AudioEngine* audio,
+                                                       QWidget* parent,
+                                                       SnapshotProvider controlDevicesProvider)
+    : QDialog(parent)
+    , m_model(model)
+    , m_audio(audio)
+    , m_controlDevicesProvider(std::move(controlDevicesProvider))
 {
     setWindowTitle("Slice Troubleshooting");
     setMinimumSize(920, 720);
@@ -285,7 +377,19 @@ void SliceTroubleshootingDialog::refreshSnapshot()
     ui["controls_locked"] = ::ControlsLock::isLocked();
     m_snapshot["ui"] = ui;
     m_snapshot["client_dsp"] = buildClientDspSnapshot(m_audio);
-    m_snapshot["schema_version"] = 2;
+
+    const QJsonObject audioDevices = DeviceDiagnostics::buildAudioDevicesSnapshot(m_audio, m_snapshot);
+    m_snapshot["audio_devices"] = audioDevices;
+    DeviceDiagnostics::annotateSliceAudioRoutes(&m_snapshot, audioDevices);
+
+    m_snapshot["control_devices"] = m_controlDevicesProvider
+        ? m_controlDevicesProvider()
+        : QJsonObject{
+            {"available", false},
+            {"note", "No control device provider registered."},
+            {"devices", QJsonArray{}}
+        };
+    m_snapshot["schema_version"] = 3;
 
     m_summaryText = buildSummary(m_snapshot);
     m_jsonText = QString::fromUtf8(QJsonDocument(m_snapshot).toJson(QJsonDocument::Indented));
@@ -374,6 +478,11 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
     const QJsonObject nr4 = clientDsp["nr4"].toObject();
     const QJsonObject rn2 = clientDsp["rn2"].toObject();
     const QJsonObject dfnr = clientDsp["dfnr"].toObject();
+    const QJsonObject audioDevices = snapshot["audio_devices"].toObject();
+    const QJsonObject audioVolumes = audioDevices["volumes"].toObject();
+    const QJsonObject rxRoute = audioDevices["rx_route"].toObject();
+    const QJsonObject txRoute = audioDevices["tx_route"].toObject();
+    const QJsonObject controlDevices = snapshot["control_devices"].toObject();
 
     lines << "# Slice Troubleshooting Snapshot";
     lines << "";
@@ -503,6 +612,89 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
                      .arg(yesNo(dfnr["enabled"].toBool()))
                      .arg(formatNumber(dfnr["atten_limit_db"], 0))
                      .arg(formatNumber(dfnr["post_filter_beta"], 2));
+    }
+    lines << "";
+
+    lines << "## Audio Devices";
+    if (!audioDevices["available"].toBool()) {
+        lines << "- Live audio engine state is unavailable; Qt Multimedia device enumeration is still included below.";
+    }
+    lines << QString("- RX route: `%1` (source `%2`), PC audio enabled `%3`, PC mute `%4`, master `%5`, engine volume `%6`, engine mute `%7`, RX stream `%8`")
+                 .arg(orPlaceholder(rxRoute["output"].toString(), "Unknown"))
+                 .arg(orPlaceholder(rxRoute["source"].toString()))
+                 .arg(yesNo(audioVolumes["pc_audio_enabled"].toBool()))
+                 .arg(yesNo(audioVolumes["pc_audio_muted"].toBool()))
+                 .arg(formatPercentValue(audioVolumes["pc_master_volume_pct"]))
+                 .arg(formatPercentValue(audioVolumes["engine_rx_volume_pct"]))
+                 .arg(formatBoolValue(audioVolumes["engine_rx_muted"]))
+                 .arg(formatBoolValue(audioDevices["rx_streaming"]));
+    lines << QString("- TX input route: `%1` (mic `%2`, DAX `%3`), PC mic gain `%4`, TX stream `%5`, DAX TX mode `%6`, DAX radio route `%7`")
+                 .arg(orPlaceholder(txRoute["input"].toString(), "Unknown"))
+                 .arg(orPlaceholder(txRoute["mic_selection"].toString()))
+                 .arg(yesNo(txRoute["dax_on"].toBool()))
+                 .arg(formatPercentValue(audioVolumes["pc_mic_gain_pct"]))
+                 .arg(formatBoolValue(audioDevices["tx_streaming"]))
+                 .arg(formatBoolValue(audioDevices["dax_tx_mode"]))
+                 .arg(formatBoolValue(audioDevices["dax_tx_use_radio_route"]));
+    lines << QString("- Selected input: %1 (source `%2`, present `%3`)")
+                 .arg(formatAudioDeviceShort(audioDevices["selected_input"].toObject()))
+                 .arg(orPlaceholder(audioDevices["selected_input_source"].toString()))
+                 .arg(yesNo(audioDevices["selected_input_present"].toBool()));
+    lines << QString("- Selected output: %1 (source `%2`, present `%3`)")
+                 .arg(formatAudioDeviceShort(audioDevices["selected_output"].toObject()))
+                 .arg(orPlaceholder(audioDevices["selected_output_source"].toString()))
+                 .arg(yesNo(audioDevices["selected_output_present"].toBool()));
+    lines << QString("- Radio output levels: lineout `%1` (mute `%2`), headphones `%3` (mute `%4`), front speaker mute `%5`")
+                 .arg(audioVolumes["radio_lineout_gain"].toInt())
+                 .arg(yesNo(audioVolumes["radio_lineout_mute"].toBool()))
+                 .arg(audioVolumes["radio_headphone_gain"].toInt())
+                 .arg(yesNo(audioVolumes["radio_headphone_mute"].toBool()))
+                 .arg(yesNo(audioVolumes["radio_front_speaker_mute"].toBool()));
+
+    lines << "- Input device list:";
+    const QJsonArray inputDevices = audioDevices["input_devices"].toArray();
+    if (inputDevices.isEmpty()) {
+        lines << "  - None reported by Qt Multimedia.";
+    } else {
+        for (const QJsonValue& value : inputDevices)
+            lines << formatAudioDeviceBullet(value.toObject(), "  - ");
+    }
+
+    lines << "- Output device list:";
+    const QJsonArray outputDevices = audioDevices["output_devices"].toArray();
+    if (outputDevices.isEmpty()) {
+        lines << "  - None reported by Qt Multimedia.";
+    } else {
+        for (const QJsonValue& value : outputDevices)
+            lines << formatAudioDeviceBullet(value.toObject(), "  - ");
+    }
+    lines << "";
+
+    lines << "## Control Devices";
+    if (!controlDevices["available"].toBool()) {
+        lines << QString("- %1").arg(orPlaceholder(controlDevices["note"].toString(), "Control device state is unavailable."));
+    }
+    lines << QString("- Target scope: `%1`, target slice `%2`, active slice available `%3`, active device count `%4`")
+                 .arg(orPlaceholder(controlDevices["target_scope"].toString(), "active_slice"))
+                 .arg(controlDevices.contains("target_slice_id") && controlDevices["target_slice_id"].isDouble()
+                          ? QString::number(controlDevices["target_slice_id"].toInt())
+                          : QStringLiteral("n/a"))
+                 .arg(yesNo(controlDevices["active_slice_available"].toBool()))
+                 .arg(controlDevices["active_device_count"].toInt());
+    const QJsonArray controlDeviceList = controlDevices["devices"].toArray();
+    if (controlDeviceList.isEmpty()) {
+        lines << "- No control device entries are available.";
+    } else {
+        for (const QJsonValue& value : controlDeviceList) {
+            const QJsonObject device = value.toObject();
+            lines << formatControlDeviceBullet(device);
+            const QJsonArray bindings = device["bindings"].toArray();
+            if (!bindings.isEmpty()) {
+                lines << "  - MIDI bindings:";
+                for (const QJsonValue& binding : bindings)
+                    lines << formatMidiBindingBullet(binding.toObject(), "    - ");
+            }
+        }
     }
     lines << "";
 
@@ -637,6 +829,10 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
             const QJsonObject digital = slice["digital"].toObject();
             const QJsonObject fm = slice["fm"].toObject();
             const QJsonObject pan = slice["panadapter_state"].toObject();
+            const QString sliceRxRoute = orPlaceholder(audio["rx_route"].toString(), "Unknown");
+            const QString sliceRxTarget = sliceRxRoute == QStringLiteral("PC audio")
+                ? orPlaceholder(audio["selected_output_device"].toString(), "Unavailable")
+                : QStringLiteral("radio lineout/headphones");
 
             lines << QString("### Slice %1").arg(slice["slice_id"].toInt());
             lines << QString("- Pan `%1`, active `%2`, TX slice `%3`, frequency `%4 MHz`, mode `%5`")
@@ -650,11 +846,13 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
                          .arg(filter["high_hz"].toInt())
                          .arg(tuning["step_hz"].toInt())
                          .arg(joinArray(slice["mode_list"].toArray()));
-            lines << QString("- Audio / RF: audio gain `%1`, audio pan `%2`, audio mute `%3`, RF gain `%4`")
+            lines << QString("- Audio / RF: audio gain `%1`, audio pan `%2`, audio mute `%3`, RF gain `%4`, route `%5` via `%6`")
                          .arg(formatNumber(audio["gain"]))
                          .arg(audio["pan"].toInt())
                          .arg(yesNo(audio["mute"].toBool()))
-                         .arg(formatNumber(slice["rf_gain"], 1));
+                         .arg(formatNumber(slice["rf_gain"], 1))
+                         .arg(sliceRxRoute)
+                         .arg(sliceRxTarget);
             lines << QString("- Antennas / control: RX `%1`, TX `%2`, locked `%3`, QSK `%4`, "
                               "record `%5`, play `%6` (enabled `%7`)")
                          .arg(orPlaceholder(antennas["rx"].toString()))

--- a/src/gui/SliceTroubleshootingDialog.h
+++ b/src/gui/SliceTroubleshootingDialog.h
@@ -2,6 +2,7 @@
 
 #include <QDialog>
 #include <QJsonObject>
+#include <functional>
 
 class QLabel;
 class QPlainTextEdit;
@@ -15,7 +16,12 @@ class SliceTroubleshootingDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit SliceTroubleshootingDialog(RadioModel* model, AudioEngine* audio = nullptr, QWidget* parent = nullptr);
+    using SnapshotProvider = std::function<QJsonObject()>;
+
+    explicit SliceTroubleshootingDialog(RadioModel* model,
+                                        AudioEngine* audio = nullptr,
+                                        QWidget* parent = nullptr,
+                                        SnapshotProvider controlDevicesProvider = {});
 
 private:
     void refreshSnapshot();
@@ -28,6 +34,7 @@ private:
 
     RadioModel* m_model{nullptr};
     AudioEngine* m_audio{nullptr};
+    SnapshotProvider m_controlDevicesProvider;
     QJsonObject m_snapshot;
     QString m_summaryText;
     QString m_jsonText;

--- a/tests/device_diagnostics_test.cpp
+++ b/tests/device_diagnostics_test.cpp
@@ -1,0 +1,67 @@
+// Standalone test harness for portable device diagnostics helpers.
+// Run:   ./build/device_diagnostics_test
+
+#include "core/DeviceDiagnostics.h"
+
+#include <cstdio>
+#include <string>
+
+using AetherSDR::DeviceDiagnostics::inferAudioBusType;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-48s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+void expectBus(const char* name, const QString& description, const QByteArray& id, const QString& expected)
+{
+    const auto result = inferAudioBusType(description, id);
+    report(name,
+           result.type == expected,
+           QString("got=%1 expected=%2 source=%3")
+               .arg(result.type, expected, result.source)
+               .toStdString());
+}
+
+} // namespace
+
+int main()
+{
+    std::printf("Device diagnostics tests\n\n");
+
+    expectBus("USB from device name",
+              QStringLiteral("USB Audio CODEC"),
+              QByteArray(),
+              QStringLiteral("USB"));
+    expectBus("USB from opaque id",
+              QStringLiteral("External Speaker"),
+              QByteArray("swdevice\\mmdevapi\\usb#vid_1234&pid_abcd"),
+              QStringLiteral("USB"));
+    expectBus("Bluetooth from device name",
+              QStringLiteral("AirPods Pro"),
+              QByteArray(),
+              QStringLiteral("Bluetooth"));
+    expectBus("Bluetooth from BT token",
+              QStringLiteral("JBL BT Speaker"),
+              QByteArray(),
+              QStringLiteral("Bluetooth"));
+    expectBus("Bluetooth from id",
+              QStringLiteral("Headphones"),
+              QByteArray("BTHENUM\\Dev_123456"),
+              QStringLiteral("Bluetooth"));
+    expectBus("Unknown when Qt gives no transport hint",
+              QStringLiteral("Built-in Output"),
+              QByteArray("coreaudio-default-output"),
+              QStringLiteral("Unknown"));
+
+    std::printf("\n%s\n", g_failed == 0 ? "All tests passed." : "Some tests failed.");
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Expands Slice Troubleshooter with portable audio and control-device diagnostics.

- Adds selected input/output audio devices, full Qt Multimedia device lists, format support, and volume/route state.
- Reports whether receive audio is routed through PC audio or radio audio based on current app routing.
- Adds bus type details where Qt exposes enough signal, and labels USB/Bluetooth detection as a heuristic when it is name/id based.
- Adds active control-surface details for FlexControl, USB HID wheels, and MIDI bindings.
- Adds a focused diagnostics helper test for audio bus inference.

## Validation

- `cmake -S . -B build -G Ninja`
- `cmake --build build --parallel 10`
- `./build/device_diagnostics_test`
- `git diff --check`

## Notes

Qt does not expose portable hardware bus or OS mixer volume fields for every platform, so unknown values are reported explicitly instead of using platform-specific guesses.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
