### PR TITLE
[help] Add find search to help dialogs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1105,6 +1105,17 @@ add_executable(passive_spots_policy_test
 target_include_directories(passive_spots_policy_test PRIVATE src)
 target_link_libraries(passive_spots_policy_test PRIVATE Qt6::Core)
 
+# Help guide search tests - needs QApplication + Widgets.
+add_executable(help_dialog_test
+    tests/help_dialog_test.cpp
+    src/gui/HelpDialog.cpp
+)
+target_include_directories(help_dialog_test PRIVATE src)
+target_link_libraries(help_dialog_test PRIVATE
+    Qt6::Core Qt6::Widgets Qt6::Test
+)
+set_target_properties(help_dialog_test PROPERTIES AUTOMOC ON)
+
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test
     tests/container_widget_test.cpp

--- a/src/gui/HelpDialog.cpp
+++ b/src/gui/HelpDialog.cpp
@@ -99,14 +99,7 @@ void HelpDialog::buildUI(const QString& resourcePath)
     m_findEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     findLayout->addWidget(m_findEdit, 1);
 
-    m_findButton = new QPushButton("Find", findRow);
-    m_findButton->setObjectName("helpFindButton");
-    m_findButton->setCursor(Qt::PointingHandCursor);
-    m_findButton->setAutoDefault(false);
-    m_findButton->setDefault(false);
-    m_findButton->setEnabled(false);
-    m_findButton->setToolTip("Find next match");
-    m_findButton->setStyleSheet(
+    const QString kFindButtonStyle =
         "QPushButton {"
         "  background: #203040;"
         "  color: #d8e4ee;"
@@ -117,7 +110,26 @@ void HelpDialog::buildUI(const QString& resourcePath)
         "  padding: 0 12px;"
         "}"
         "QPushButton:hover:enabled { background: #28435a; }"
-        "QPushButton:disabled { color: #5f7080; border-color: #263442; }");
+        "QPushButton:disabled { color: #5f7080; border-color: #263442; }";
+
+    m_findPrevButton = new QPushButton("Previous", findRow);
+    m_findPrevButton->setObjectName("helpFindPrevButton");
+    m_findPrevButton->setCursor(Qt::PointingHandCursor);
+    m_findPrevButton->setAutoDefault(false);
+    m_findPrevButton->setDefault(false);
+    m_findPrevButton->setEnabled(false);
+    m_findPrevButton->setToolTip("Find previous match (Shift+Return)");
+    m_findPrevButton->setStyleSheet(kFindButtonStyle);
+    findLayout->addWidget(m_findPrevButton);
+
+    m_findButton = new QPushButton("Next", findRow);
+    m_findButton->setObjectName("helpFindButton");
+    m_findButton->setCursor(Qt::PointingHandCursor);
+    m_findButton->setAutoDefault(false);
+    m_findButton->setDefault(false);
+    m_findButton->setEnabled(false);
+    m_findButton->setToolTip("Find next match (Return)");
+    m_findButton->setStyleSheet(kFindButtonStyle);
     findLayout->addWidget(m_findButton);
 
     m_findStatus = new QLabel(findRow);
@@ -199,13 +211,21 @@ void HelpDialog::buildUI(const QString& resourcePath)
     layout->addWidget(m_browser, 1);
 
     connect(m_findEdit, &QLineEdit::textChanged, this, [this](const QString& text) {
-        if (m_findButton)
-            m_findButton->setEnabled(!text.isEmpty());
+        const bool hasTerm = !text.isEmpty();
+        if (m_findButton)      m_findButton->setEnabled(hasTerm);
+        if (m_findPrevButton)  m_findPrevButton->setEnabled(hasTerm);
         resetFindState();
     });
     connect(m_findEdit, &QLineEdit::returnPressed, this, &HelpDialog::findNext);
     connect(m_findButton, &QPushButton::clicked, this, &HelpDialog::findNext);
+    connect(m_findPrevButton, &QPushButton::clicked, this, &HelpDialog::findPrevious);
     new QShortcut(QKeySequence::Find, this, [this]() { focusFindField(); });
+    // Shift+Return inside the find field → previous match.  Scope to the
+    // find field so the shortcut is only active when typing a query.
+    auto* prevShortcut = new QShortcut(QKeySequence(Qt::SHIFT | Qt::Key_Return),
+                                       m_findEdit,
+                                       [this]() { findPrevious(); });
+    prevShortcut->setContext(Qt::WidgetShortcut);
 
     auto* footer = new QWidget(this);
     footer->setStyleSheet("background: #0a0a14;");
@@ -255,6 +275,16 @@ void HelpDialog::focusFindField()
 
 void HelpDialog::findNext()
 {
+    runFind(/*backward=*/false);
+}
+
+void HelpDialog::findPrevious()
+{
+    runFind(/*backward=*/true);
+}
+
+void HelpDialog::runFind(bool backward)
+{
     if (!m_browser || !m_findEdit)
         return;
 
@@ -265,19 +295,26 @@ void HelpDialog::findNext()
         return;
     }
 
-    if (m_browser->find(term)) {
+    const QTextDocument::FindFlags flags = backward
+        ? QTextDocument::FindFlags(QTextDocument::FindBackward)
+        : QTextDocument::FindFlags();
+
+    if (m_browser->find(term, flags)) {
         updateFindFeedback(QString(), false);
         m_findEdit->setFocus(Qt::OtherFocusReason);
         return;
     }
 
+    // No match from the current cursor position.  Wrap to the opposite
+    // end of the document (top for forward, bottom for backward) and
+    // retry so Return/Shift+Return both circle through matches.
     QTextCursor cursor = m_browser->textCursor();
-    cursor.movePosition(QTextCursor::Start);
+    cursor.movePosition(backward ? QTextCursor::End : QTextCursor::Start);
     cursor.clearSelection();
     m_browser->setTextCursor(cursor);
 
-    if (m_browser->find(term)) {
-        updateFindFeedback("Wrapped to top", false);
+    if (m_browser->find(term, flags)) {
+        updateFindFeedback(backward ? "Wrapped to bottom" : "Wrapped to top", false);
     } else {
         cursor = m_browser->textCursor();
         cursor.movePosition(QTextCursor::Start);

--- a/src/gui/HelpDialog.cpp
+++ b/src/gui/HelpDialog.cpp
@@ -3,12 +3,42 @@
 #include <QDialogButtonBox>
 #include <QFile>
 #include <QHBoxLayout>
+#include <QKeySequence>
 #include <QLabel>
+#include <QLineEdit>
 #include <QPushButton>
+#include <QShortcut>
 #include <QTextBrowser>
+#include <QTextCursor>
 #include <QVBoxLayout>
 
 namespace AetherSDR {
+
+namespace {
+
+const char* kFindEditStyle =
+    "QLineEdit {"
+    "  background: #111d29;"
+    "  color: #d8e4ee;"
+    "  border: 1px solid #304050;"
+    "  border-radius: 4px;"
+    "  min-height: 26px;"
+    "  padding: 2px 8px;"
+    "}"
+    "QLineEdit:focus { border-color: #00b4d8; }";
+
+const char* kFindEditNoMatchStyle =
+    "QLineEdit {"
+    "  background: #111d29;"
+    "  color: #d8e4ee;"
+    "  border: 1px solid #c65050;"
+    "  border-radius: 4px;"
+    "  min-height: 26px;"
+    "  padding: 2px 8px;"
+    "}"
+    "QLineEdit:focus { border-color: #e07070; }";
+
+} // namespace
 
 HelpDialog::HelpDialog(const QString& windowTitle,
                        const QString& resourcePath,
@@ -51,6 +81,53 @@ void HelpDialog::buildUI(const QString& resourcePath)
     subtitle->setStyleSheet("color: #8aa8c0; font-size: 12px;");
     headerLayout->addWidget(subtitle);
 
+    auto* findRow = new QWidget(header);
+    findRow->setObjectName("helpFindRow");
+    auto* findLayout = new QHBoxLayout(findRow);
+    findLayout->setContentsMargins(0, 8, 0, 0);
+    findLayout->setSpacing(8);
+
+    auto* findLabel = new QLabel("Find:", findRow);
+    findLabel->setStyleSheet("color: #8aa8c0; font-size: 12px; font-weight: 700;");
+    findLayout->addWidget(findLabel);
+
+    m_findEdit = new QLineEdit(findRow);
+    m_findEdit->setObjectName("helpFindEdit");
+    m_findEdit->setPlaceholderText("Subject or term");
+    m_findEdit->setClearButtonEnabled(true);
+    m_findEdit->setStyleSheet(kFindEditStyle);
+    m_findEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    findLayout->addWidget(m_findEdit, 1);
+
+    m_findButton = new QPushButton("Find", findRow);
+    m_findButton->setObjectName("helpFindButton");
+    m_findButton->setCursor(Qt::PointingHandCursor);
+    m_findButton->setAutoDefault(false);
+    m_findButton->setDefault(false);
+    m_findButton->setEnabled(false);
+    m_findButton->setToolTip("Find next match");
+    m_findButton->setStyleSheet(
+        "QPushButton {"
+        "  background: #203040;"
+        "  color: #d8e4ee;"
+        "  border: 1px solid #38506a;"
+        "  border-radius: 4px;"
+        "  min-width: 72px;"
+        "  min-height: 28px;"
+        "  padding: 0 12px;"
+        "}"
+        "QPushButton:hover:enabled { background: #28435a; }"
+        "QPushButton:disabled { color: #5f7080; border-color: #263442; }");
+    findLayout->addWidget(m_findButton);
+
+    m_findStatus = new QLabel(findRow);
+    m_findStatus->setObjectName("helpFindStatus");
+    m_findStatus->setMinimumWidth(96);
+    m_findStatus->setStyleSheet("color: #7f93a7; font-size: 11px;");
+    findLayout->addWidget(m_findStatus);
+
+    headerLayout->addWidget(findRow);
+
     layout->addWidget(header);
 
     auto* separator = new QWidget(this);
@@ -58,12 +135,13 @@ void HelpDialog::buildUI(const QString& resourcePath)
     separator->setStyleSheet("background: #203040;");
     layout->addWidget(separator);
 
-    auto* browser = new QTextBrowser(this);
-    browser->setReadOnly(true);
-    browser->setOpenExternalLinks(true);
-    browser->setOpenLinks(true);
-    browser->document()->setDocumentMargin(18);
-    browser->document()->setDefaultStyleSheet(
+    m_browser = new QTextBrowser(this);
+    m_browser->setObjectName("helpBrowser");
+    m_browser->setReadOnly(true);
+    m_browser->setOpenExternalLinks(true);
+    m_browser->setOpenLinks(true);
+    m_browser->document()->setDocumentMargin(18);
+    m_browser->document()->setDefaultStyleSheet(
         "body { color: #c8d8e8; font-size: 12px; font-family: sans-serif; }"
         "h1 { color: #00b4d8; font-size: 22px; font-weight: 700; margin: 0 0 16px 0; }"
         "h2 { color: #c8d8e8; font-size: 18px; font-weight: 700; margin: 18px 0 8px 0; }"
@@ -78,8 +156,8 @@ void HelpDialog::buildUI(const QString& resourcePath)
         "em { color: #8898a8; font-style: italic; }"
         "code { color: #d8e4ee; background-color: #152230; }"
         "a { color: #00b4d8; text-decoration: none; }");
-    browser->setMarkdown(loadMarkdown(resourcePath));
-    browser->setStyleSheet(
+    m_browser->setMarkdown(loadMarkdown(resourcePath));
+    m_browser->setStyleSheet(
         "QTextBrowser {"
         "  background: #0f0f1a;"
         "  color: #d8e4ee;"
@@ -118,7 +196,16 @@ void HelpDialog::buildUI(const QString& resourcePath)
         "QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {"
         "  width: 0px;"
         "}");
-    layout->addWidget(browser, 1);
+    layout->addWidget(m_browser, 1);
+
+    connect(m_findEdit, &QLineEdit::textChanged, this, [this](const QString& text) {
+        if (m_findButton)
+            m_findButton->setEnabled(!text.isEmpty());
+        resetFindState();
+    });
+    connect(m_findEdit, &QLineEdit::returnPressed, this, &HelpDialog::findNext);
+    connect(m_findButton, &QPushButton::clicked, this, &HelpDialog::findNext);
+    new QShortcut(QKeySequence::Find, this, [this]() { focusFindField(); });
 
     auto* footer = new QWidget(this);
     footer->setStyleSheet("background: #0a0a14;");
@@ -135,6 +222,8 @@ void HelpDialog::buildUI(const QString& resourcePath)
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, footer);
     auto* closeButton = buttons->button(QDialogButtonBox::Close);
     closeButton->setCursor(Qt::PointingHandCursor);
+    closeButton->setAutoDefault(false);
+    closeButton->setDefault(false);
     closeButton->setStyleSheet(
         "QPushButton {"
         "  background: #00b4d8;"
@@ -155,6 +244,51 @@ void HelpDialog::buildUI(const QString& resourcePath)
     setStyleSheet("HelpDialog { background: #0f0f1a; }");
 }
 
+void HelpDialog::focusFindField()
+{
+    if (!m_findEdit)
+        return;
+
+    m_findEdit->setFocus(Qt::ShortcutFocusReason);
+    m_findEdit->selectAll();
+}
+
+void HelpDialog::findNext()
+{
+    if (!m_browser || !m_findEdit)
+        return;
+
+    const QString term = m_findEdit->text();
+    if (term.isEmpty()) {
+        updateFindFeedback(QString(), false);
+        focusFindField();
+        return;
+    }
+
+    if (m_browser->find(term)) {
+        updateFindFeedback(QString(), false);
+        m_findEdit->setFocus(Qt::OtherFocusReason);
+        return;
+    }
+
+    QTextCursor cursor = m_browser->textCursor();
+    cursor.movePosition(QTextCursor::Start);
+    cursor.clearSelection();
+    m_browser->setTextCursor(cursor);
+
+    if (m_browser->find(term)) {
+        updateFindFeedback("Wrapped to top", false);
+    } else {
+        cursor = m_browser->textCursor();
+        cursor.movePosition(QTextCursor::Start);
+        cursor.clearSelection();
+        m_browser->setTextCursor(cursor);
+        updateFindFeedback("No matches", true);
+    }
+
+    m_findEdit->setFocus(Qt::OtherFocusReason);
+}
+
 QString HelpDialog::loadMarkdown(const QString& resourcePath) const
 {
     QFile file(resourcePath);
@@ -166,6 +300,31 @@ QString HelpDialog::loadMarkdown(const QString& resourcePath) const
     }
 
     return QString::fromUtf8(file.readAll());
+}
+
+void HelpDialog::resetFindState()
+{
+    if (!m_browser)
+        return;
+
+    QTextCursor cursor = m_browser->textCursor();
+    cursor.movePosition(QTextCursor::Start);
+    cursor.clearSelection();
+    m_browser->setTextCursor(cursor);
+    updateFindFeedback(QString(), false);
+}
+
+void HelpDialog::updateFindFeedback(const QString& message, bool noMatch)
+{
+    if (m_findStatus) {
+        m_findStatus->setText(message);
+        m_findStatus->setStyleSheet(noMatch
+            ? "color: #e07070; font-size: 11px; font-weight: 700;"
+            : "color: #7f93a7; font-size: 11px;");
+    }
+
+    if (m_findEdit)
+        m_findEdit->setStyleSheet(noMatch ? kFindEditNoMatchStyle : kFindEditStyle);
 }
 
 } // namespace AetherSDR

--- a/src/gui/HelpDialog.h
+++ b/src/gui/HelpDialog.h
@@ -22,6 +22,8 @@ private:
     void buildUI(const QString& resourcePath);
     void focusFindField();
     void findNext();
+    void findPrevious();
+    void runFind(bool backward);
     QString loadMarkdown(const QString& resourcePath) const;
     void resetFindState();
     void updateFindFeedback(const QString& message, bool noMatch);
@@ -29,6 +31,7 @@ private:
     QTextBrowser* m_browser{nullptr};
     QLineEdit* m_findEdit{nullptr};
     QPushButton* m_findButton{nullptr};
+    QPushButton* m_findPrevButton{nullptr};
     QLabel* m_findStatus{nullptr};
 };
 

--- a/src/gui/HelpDialog.h
+++ b/src/gui/HelpDialog.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include <QDialog>
+#include <QString>
 
-class QString;
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class QTextBrowser;
 
 namespace AetherSDR {
 
@@ -16,7 +20,16 @@ public:
 
 private:
     void buildUI(const QString& resourcePath);
+    void focusFindField();
+    void findNext();
     QString loadMarkdown(const QString& resourcePath) const;
+    void resetFindState();
+    void updateFindFeedback(const QString& message, bool noMatch);
+
+    QTextBrowser* m_browser{nullptr};
+    QLineEdit* m_findEdit{nullptr};
+    QPushButton* m_findButton{nullptr};
+    QLabel* m_findStatus{nullptr};
 };
 
 } // namespace AetherSDR

--- a/tests/help_dialog_test.cpp
+++ b/tests/help_dialog_test.cpp
@@ -1,0 +1,195 @@
+// Standalone test harness for HelpDialog guide search.
+// Build: CMake target `help_dialog_test`. Exit 0 = pass.
+
+#include "gui/HelpDialog.h"
+
+#include <QApplication>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMetaObject>
+#include <QPushButton>
+#include <QTemporaryFile>
+#include <QTextBrowser>
+#include <QTextCursor>
+#include <cstdio>
+#include <string>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-56s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+bool writeTempHelp(QTemporaryFile& file)
+{
+    if (!file.open())
+        return false;
+
+    const QByteArray body =
+        "target first\n\n"
+        "middle line\n\n"
+        "target second\n\n"
+        "end marker\n";
+    const bool ok = file.write(body) == body.size() && file.flush();
+    file.close();
+    return ok;
+}
+
+struct HelpWidgets {
+    QLineEdit* edit{nullptr};
+    QPushButton* button{nullptr};
+    QLabel* status{nullptr};
+    QTextBrowser* browser{nullptr};
+};
+
+HelpWidgets findWidgets(HelpDialog& dialog)
+{
+    return {
+        dialog.findChild<QLineEdit*>("helpFindEdit"),
+        dialog.findChild<QPushButton*>("helpFindButton"),
+        dialog.findChild<QLabel*>("helpFindStatus"),
+        dialog.findChild<QTextBrowser*>("helpBrowser")
+    };
+}
+
+bool requireWidgets(const HelpWidgets& widgets)
+{
+    const bool ok = widgets.edit && widgets.button && widgets.status && widgets.browser;
+    report("find widgets are present", ok);
+    return ok;
+}
+
+bool selectedTextEquals(QTextBrowser* browser, const QString& expected)
+{
+    return browser->textCursor().selectedText().compare(expected, Qt::CaseInsensitive) == 0;
+}
+
+void testFindNextAndWrap()
+{
+    QTemporaryFile file;
+    const bool wrote = writeTempHelp(file);
+    report("temp help document created", wrote);
+    if (!wrote)
+        return;
+
+    HelpDialog dialog("Search Test", file.fileName());
+    HelpWidgets widgets = findWidgets(dialog);
+    if (!requireWidgets(widgets))
+        return;
+
+    widgets.edit->setText("target");
+    report("find button enables with query", widgets.button->isEnabled());
+
+    widgets.button->click();
+    const QTextCursor firstCursor = widgets.browser->textCursor();
+    const int firstStart = firstCursor.selectionStart();
+    report("first find selects match", selectedTextEquals(widgets.browser, "target"));
+
+    widgets.button->click();
+    const QTextCursor secondCursor = widgets.browser->textCursor();
+    const int secondStart = secondCursor.selectionStart();
+    report("find next advances", selectedTextEquals(widgets.browser, "target") && secondStart > firstStart,
+           "first=" + std::to_string(firstStart) + " second=" + std::to_string(secondStart));
+
+    widgets.button->click();
+    const QTextCursor wrapCursor = widgets.browser->textCursor();
+    report("find next wraps to first match",
+           selectedTextEquals(widgets.browser, "target") && wrapCursor.selectionStart() == firstStart);
+    report("wrap status is shown", widgets.status->text() == "Wrapped to top",
+           widgets.status->text().toStdString());
+}
+
+void testNoMatchClearsSelectionAndRecovers()
+{
+    QTemporaryFile file;
+    const bool wrote = writeTempHelp(file);
+    report("temp help document created", wrote);
+    if (!wrote)
+        return;
+
+    HelpDialog dialog("Search Test", file.fileName());
+    HelpWidgets widgets = findWidgets(dialog);
+    if (!requireWidgets(widgets))
+        return;
+
+    widgets.edit->setText("absent");
+    widgets.button->click();
+    report("no match status is shown", widgets.status->text() == "No matches",
+           widgets.status->text().toStdString());
+    report("no match leaves no selection", !widgets.browser->textCursor().hasSelection());
+
+    widgets.edit->setText("middle");
+    report("query change clears status", widgets.status->text().isEmpty(),
+           widgets.status->text().toStdString());
+    report("query change clears selection", !widgets.browser->textCursor().hasSelection());
+
+    widgets.button->click();
+    report("search recovers after no match", selectedTextEquals(widgets.browser, "middle"));
+}
+
+void testReturnPressedFindsNext()
+{
+    QTemporaryFile file;
+    const bool wrote = writeTempHelp(file);
+    report("temp help document created", wrote);
+    if (!wrote)
+        return;
+
+    HelpDialog dialog("Search Test", file.fileName());
+    HelpWidgets widgets = findWidgets(dialog);
+    if (!requireWidgets(widgets))
+        return;
+
+    widgets.edit->setText("target");
+    const bool invoked = QMetaObject::invokeMethod(widgets.edit, "returnPressed", Qt::DirectConnection);
+    report("returnPressed signal invoked", invoked);
+    report("Return finds first match", selectedTextEquals(widgets.browser, "target"));
+}
+
+void testEmptyQueryDisablesFind()
+{
+    QTemporaryFile file;
+    const bool wrote = writeTempHelp(file);
+    report("temp help document created", wrote);
+    if (!wrote)
+        return;
+
+    HelpDialog dialog("Search Test", file.fileName());
+    HelpWidgets widgets = findWidgets(dialog);
+    if (!requireWidgets(widgets))
+        return;
+
+    report("find button starts disabled", !widgets.button->isEnabled());
+    widgets.edit->setText("target");
+    report("find button enables", widgets.button->isEnabled());
+    widgets.edit->clear();
+    report("find button disables when query clears", !widgets.button->isEnabled());
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    std::printf("HelpDialog find test harness\n\n");
+
+    testFindNextAndWrap();
+    testNoMatchClearsSelectionAndRecovers();
+    testReturnPressedFindsNext();
+    testEmptyQueryDisablesFind();
+
+    std::printf("\n%s\n",
+                g_failed == 0
+                    ? "All tests passed."
+                    : (std::to_string(g_failed) + " test(s) failed.").c_str());
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adds a shared Find bar to Help guide dialogs.

- Adds a top search row to `HelpDialog`, so every Help menu guide gets the feature.
- Supports Find Next behavior from the button and Return key.
- Adds Ctrl+F focus, wrap-to-top feedback, no-match feedback, and empty-query button state.
- Adds a focused Qt widget test covering next match, wraparound, no-match recovery, Return, and empty-query behavior.

## Validation

- `cmake -S . -B build -G Ninja`
- `cmake --build build --parallel 10`
- `build/help_dialog_test`
- `git diff --check`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
