### PR TITLE
[bug] Suppress startup client login replays

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -425,12 +425,15 @@ void RadioModel::applyKnownGuiClients(const QStringList& handles,
     if (replaceExisting) {
         m_clientStations.clear();
         m_clientInfoMap.clear();
+        m_startupClientConnections.clear();
     }
 
     for (int i = 0; i < handles.size(); ++i) {
         const quint32 handle = parseClientHandle(handles[i]);
         if (handle == 0)
             continue;
+        if (replaceExisting)
+            m_startupClientConnections.insert(handle);
 
         const QString program = i < programs.size()
             ? cleanClientText(programs[i])
@@ -455,6 +458,25 @@ void RadioModel::applyKnownGuiClients(const QStringList& handles,
         m_clientStations[handle] = client.station.isEmpty() ? client.program : client.station;
         m_clientInfoMap[handle] = client;
     }
+}
+
+bool RadioModel::shouldSuppressClientConnectionNotice(quint32 handle)
+{
+    if (handle == 0 || handle == clientHandle())
+        return true;
+
+    if (m_startupClientConnections.remove(handle)) {
+        m_announcedClientConnections.insert(handle);
+        return true;
+    }
+
+    if (m_clientConnectionNoticeTimer.isValid()
+            && m_clientConnectionNoticeTimer.elapsed() < CLIENT_CONNECTION_STARTUP_SUPPRESS_MS) {
+        m_announcedClientConnections.insert(handle);
+        return true;
+    }
+
+    return false;
 }
 
 void RadioModel::announceClientConnection(quint32 handle,
@@ -923,6 +945,7 @@ void RadioModel::setPanNoiseFloorEnable(bool on)
 void RadioModel::onConnected()
 {
     qCDebug(lcProtocol) << "RadioModel: connected";
+    m_clientConnectionNoticeTimer.restart();
     setActivePanResized(false);
 
     // Inhibit system sleep while connected if the user has opted in (#1420)
@@ -1481,6 +1504,8 @@ void RadioModel::onDisconnected()
     m_clientStations.clear();
     m_clientInfoMap.clear();
     m_announcedClientConnections.clear();
+    m_startupClientConnections.clear();
+    m_clientConnectionNoticeTimer.invalidate();
     emit otherClientsChanged(0, {});
     emit connectionStateChanged(false);
     m_forcedDisconnectInProgress = false;
@@ -1918,6 +1943,7 @@ void RadioModel::onStatusReceived(const QString& object,
                 m_clientStations.remove(handle);
                 m_clientInfoMap.remove(handle);
                 m_announcedClientConnections.remove(handle);
+                m_startupClientConnections.remove(handle);
                 emitOtherClientsChanged();
             } else if (action == "connected" || kvs.contains("connected")) {
                 QString program = cleanClientText(kvs.value("program", "Unknown"));
@@ -1937,7 +1963,8 @@ void RadioModel::onStatusReceived(const QString& object,
                 client.localPtt = ptt;
                 m_clientInfoMap[handle] = client;
                 emitOtherClientsChanged();
-                announceClientConnection(handle, source, station, program);
+                if (!shouldSuppressClientConnectionNotice(handle))
+                    announceClientConnection(handle, source, station, program);
             }
         }
         return;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -408,6 +408,7 @@ private:
                               const QStringList& ips,
                               const QStringList& hosts,
                               bool replaceExisting);
+    bool shouldSuppressClientConnectionNotice(quint32 handle);
     void announceClientConnection(quint32 handle,
                                   const QString& source,
                                   const QString& station,
@@ -613,6 +614,9 @@ private:
     QMap<quint32, QString> m_clientStations;   // handle → station name (legacy, kept in sync)
     QList<quint32> m_pendingClientDisconnects; // handles chosen before connecting
     QSet<quint32> m_announcedClientConnections; // client login notices shown this session
+    QSet<quint32> m_startupClientConnections; // clients present before our connect status replay
+    QElapsedTimer m_clientConnectionNoticeTimer;
+    static constexpr qint64 CLIENT_CONNECTION_STARTUP_SUPPRESS_MS = 5000;
 
     SleepInhibitor m_sleepInhibitor;     // prevents OS idle sleep while connected
     RadioInfo m_lastInfo;               // stored for auto-reconnect


### PR DESCRIPTION
## Summary

Suppresses false client-login status bar notifications immediately after connecting to a radio. Existing LAN and SmartLink client handles captured from discovery or the SmartLink radio list are treated as already present, so the radio status replay from `sub client all` does not announce them as new arrivals.

## Root cause

PR #1892 added notifications for live `client ... connected` status messages. During startup the radio also replays the current client list after AetherSDR subscribes to client status, so already-connected clients looked indistinguishable from newly connected clients.

## What changed

- Track client handles known before the connection status replay.
- Suppress notifications for those startup handles.
- Add a 5-second startup grace window as a fallback when discovery or SmartLink metadata is stale.
- Clear suppressed handles on disconnect so later reconnects can notify normally.

## Validation

- Built with `cmake --build build -j 10`.
- Ran `git diff --check` and `git diff --cached --check`.
- Ran built DSP and container test binaries directly; Qt container tests passed with `QT_QPA_PLATFORM=offscreen`.
- Manual LAN test by @jensenpat: existing clients did not replay, new clients triggered notifications.
- Manual SmartLink test by @jensenpat: existing clients did not replay, new clients triggered notifications.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat