### PR TITLE
fix: close all floating windows when main window closes

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -18,6 +18,7 @@
 #include "SpectrumOverlayMenu.h"
 #include "VfoWidget.h"
 #include "AppletPanel.h"
+#include "containers/ContainerManager.h"
 #include "RxApplet.h"
 #include "SMeterWidget.h"
 #include "TunerApplet.h"
@@ -3347,6 +3348,9 @@ void MainWindow::closeEvent(QCloseEvent* event)
 {
     m_shuttingDown = true;
     m_panStack->prepareShutdown();
+    if (m_appletPanel && m_appletPanel->containerManager()) {
+        m_appletPanel->containerManager()->prepareShutdown();
+    }
     auto& s = AppSettings::instance();
     s.setValue("MainWindowGeometry", saveGeometry().toBase64());
     s.setValue("MainWindowState",   saveState().toBase64());

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -593,6 +593,7 @@ void PanadapterStack::prepareShutdown()
     for (auto* fw : m_floatingWindows) {
         fw->saveWindowGeometry();
         fw->setShuttingDown(true);
+        fw->close();
     }
 }
 

--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -270,6 +270,14 @@ void ContainerManager::dockContainer(const QString& id)
     saveState();
 }
 
+void ContainerManager::prepareShutdown()
+{
+    for (auto* win : m_floatingWindows) {
+        win->prepareShutdown();
+    }
+    m_floatingWindows.clear();
+}
+
 void ContainerManager::wireContainer(ContainerWidget* c)
 {
     connect(c, &ContainerWidget::floatRequested,

--- a/src/gui/containers/ContainerManager.h
+++ b/src/gui/containers/ContainerManager.h
@@ -86,6 +86,10 @@ public:
     void floatContainer(const QString& id);
     void dockContainer(const QString& id);
 
+    // Save geometry and close all floating windows without triggering
+    // dock-back behaviour.  Call from MainWindow::closeEvent().
+    void prepareShutdown();
+
     // ── Persistence ──────────────────────────────────────────────
     //
     // State is stored as JSON under the AppSettings key

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -125,8 +125,20 @@ void FloatingContainerWindow::saveGeometryToKey() const
         m_geometryKey, saveGeometry().toBase64());
 }
 
+void FloatingContainerWindow::prepareShutdown()
+{
+    m_saveTimer.stop();
+    saveGeometryToKey();
+    m_shuttingDown = true;
+    close();
+}
+
 void FloatingContainerWindow::closeEvent(QCloseEvent* ev)
 {
+    if (m_shuttingDown) {
+        ev->accept();
+        return;
+    }
     // Close = dock.  Manager handles reparenting via dockRequested.
     if (m_container) {
         emit dockRequested(m_container);

--- a/src/gui/containers/FloatingContainerWindow.h
+++ b/src/gui/containers/FloatingContainerWindow.h
@@ -44,6 +44,10 @@ public:
     void setGeometryKey(const QString& key);
     QString geometryKey() const { return m_geometryKey; }
 
+    // Called by ContainerManager before the app exits.  Saves geometry,
+    // suppresses the dock-on-close behaviour, and closes the window.
+    void prepareShutdown();
+
     // Restore the window's geometry from the key, clamping to a
     // visible screen.  If no saved geometry exists, centres on the
     // anchor's current screen at a reasonable default size.  Safe to
@@ -68,6 +72,7 @@ private:
     QVBoxLayout*     m_layout{nullptr};
     QString          m_geometryKey;
     bool             m_restoring{false};
+    bool             m_shuttingDown{false};
     QTimer           m_saveTimer;
 };
 


### PR DESCRIPTION
Closing the main window left popped-out panadapter and applet windows alive, keeping the Qt event loop running. The app only exited when the user manually closed a floating pan window.

Root cause: PanadapterStack::prepareShutdown() set the shutdown flag and saved geometry on each PanFloatingWindow but never called close(). Those windows are top-level widgets with WA_QuitOnClose=true (Qt default), so they kept the app alive. FloatingContainerWindow (applet containers) had no shutdown guard, so its closeEvent would emit dockRequested into an already-torn-down panel during teardown.

Changes:

PanadapterStack::prepareShutdown(): call fw->close() after setting the shutdown flag so floating pan windows are actually dismissed.

FloatingContainerWindow: add m_shuttingDown member and prepareShutdown() method that flushes geometry, sets the flag, and calls close(). closeEvent() now short-circuits on the flag instead of emitting dockRequested when the panel is gone.

ContainerManager: add prepareShutdown() that calls prepareShutdown() on each FloatingContainerWindow and clears the floating windows map.

MainWindow::closeEvent(): call m_appletPanel->containerManager()->
prepareShutdown() alongside the existing m_panStack->prepareShutdown() call so all floating applet containers are closed cleanly before settings are saved and the radio disconnects.