### PR TITLE
Frameless pop-out windows for all applets and panadapters

### DIFF
--- a/src/gui/PanFloatingWindow.cpp
+++ b/src/gui/PanFloatingWindow.cpp
@@ -11,13 +11,18 @@
 namespace AetherSDR {
 
 PanFloatingWindow::PanFloatingWindow(QWidget* parent)
+#ifdef Q_OS_WIN
+    // Windows: keep native frame.  FramelessWindowHint is unreliable on
+    // Windows and combined with QRhiWidget reparenting (the GPU spectrum)
+    // it triggers a crash on pop-out.
+    : QWidget(parent, Qt::Window)
+#else
     : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
+#endif
 {
-    // Windows quirk: the constructor flag bitmask is sometimes ignored
-    // and the native frame still gets drawn.  Re-applying via setWindowFlags
-    // before show() forces the platform plugin to honour FramelessWindowHint
-    // on all Qt versions / widget hierarchies.
+#ifndef Q_OS_WIN
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+#endif
     setMinimumSize(400, 300);
 
     m_layout = new QVBoxLayout(this);
@@ -42,13 +47,16 @@ void PanFloatingWindow::adoptApplet(PanadapterApplet* applet)
     // This avoids corrupting the main window's NSResponder chain on macOS.
     m_layout->addWidget(m_applet, 1);
 
+#ifndef Q_OS_WIN
     // Bottom-right resize grip — frameless windows lose OS edge resize.
+    // Windows keeps native frame so the OS already provides edge resize.
     auto* gripRow = new QHBoxLayout;
     gripRow->setContentsMargins(0, 0, 0, 0);
     gripRow->addStretch(1);
     gripRow->addWidget(new QSizeGrip(this), 0,
                        Qt::AlignBottom | Qt::AlignRight);
     m_layout->addLayout(gripRow);
+#endif
 
     // Show dock icon in the applet's title bar
     m_applet->setFloatingState(true);

--- a/src/gui/PanFloatingWindow.cpp
+++ b/src/gui/PanFloatingWindow.cpp
@@ -3,13 +3,15 @@
 #include "core/AppSettings.h"
 
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QCloseEvent>
 #include <QPushButton>
+#include <QSizeGrip>
 
 namespace AetherSDR {
 
 PanFloatingWindow::PanFloatingWindow(QWidget* parent)
-    : QWidget(parent, Qt::Window)
+    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
 {
     setMinimumSize(400, 300);
 
@@ -34,6 +36,14 @@ void PanFloatingWindow::adoptApplet(PanadapterApplet* applet)
     // floating window without an intermediate nullptr/top-level state.
     // This avoids corrupting the main window's NSResponder chain on macOS.
     m_layout->addWidget(m_applet, 1);
+
+    // Bottom-right resize grip — frameless windows lose OS edge resize.
+    auto* gripRow = new QHBoxLayout;
+    gripRow->setContentsMargins(0, 0, 0, 0);
+    gripRow->addStretch(1);
+    gripRow->addWidget(new QSizeGrip(this), 0,
+                       Qt::AlignBottom | Qt::AlignRight);
+    m_layout->addLayout(gripRow);
 
     // Show dock icon in the applet's title bar
     m_applet->setFloatingState(true);

--- a/src/gui/PanFloatingWindow.cpp
+++ b/src/gui/PanFloatingWindow.cpp
@@ -13,6 +13,11 @@ namespace AetherSDR {
 PanFloatingWindow::PanFloatingWindow(QWidget* parent)
     : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
 {
+    // Windows quirk: the constructor flag bitmask is sometimes ignored
+    // and the native frame still gets drawn.  Re-applying via setWindowFlags
+    // before show() forces the platform plugin to honour FramelessWindowHint
+    // on all Qt versions / widget hierarchies.
+    setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
     setMinimumSize(400, 300);
 
     m_layout = new QVBoxLayout(this);

--- a/src/gui/PanFloatingWindow.cpp
+++ b/src/gui/PanFloatingWindow.cpp
@@ -11,18 +11,13 @@
 namespace AetherSDR {
 
 PanFloatingWindow::PanFloatingWindow(QWidget* parent)
-#ifdef Q_OS_WIN
-    // Windows: keep native frame.  FramelessWindowHint is unreliable on
-    // Windows and combined with QRhiWidget reparenting (the GPU spectrum)
-    // it triggers a crash on pop-out.
-    : QWidget(parent, Qt::Window)
-#else
     : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
-#endif
 {
-#ifndef Q_OS_WIN
+    // Windows quirk: the constructor flag bitmask is sometimes ignored
+    // and the native frame still gets drawn.  Re-applying via setWindowFlags
+    // before show() forces the platform plugin to honour FramelessWindowHint
+    // on all Qt versions / widget hierarchies.
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
-#endif
     setMinimumSize(400, 300);
 
     m_layout = new QVBoxLayout(this);
@@ -47,16 +42,13 @@ void PanFloatingWindow::adoptApplet(PanadapterApplet* applet)
     // This avoids corrupting the main window's NSResponder chain on macOS.
     m_layout->addWidget(m_applet, 1);
 
-#ifndef Q_OS_WIN
     // Bottom-right resize grip — frameless windows lose OS edge resize.
-    // Windows keeps native frame so the OS already provides edge resize.
     auto* gripRow = new QHBoxLayout;
     gripRow->setContentsMargins(0, 0, 0, 0);
     gripRow->addStretch(1);
     gripRow->addWidget(new QSizeGrip(this), 0,
                        Qt::AlignBottom | Qt::AlignRight);
     m_layout->addLayout(gripRow);
-#endif
 
     // Show dock icon in the applet's title bar
     m_applet->setFloatingState(true);

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -31,13 +31,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
         "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
         "stop:0 #3a4a5a, stop:0.5 #2a3a4a, stop:1 #1a2a38); "
         "border-bottom: 1px solid #0a1a28; }");
-#ifndef Q_OS_WIN
-    // Drag-to-move when floating uses startSystemMove on Linux/macOS.
-    // Windows keeps the native frame, so no title-bar event filter — and
-    // installing one there triggers spurious setActivePan calls that
-    // destabilise the float→dock→re-float cycle.
-    m_titleBar->installEventFilter(this);
-#endif
+    m_titleBar->installEventFilter(this);  // drag-to-move when floating
     auto* titleBar = m_titleBar;
 
     auto* barLayout = new QHBoxLayout(titleBar);

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -8,8 +8,10 @@
 #include <QSlider>
 #include <QEvent>
 #include <QLabel>
+#include <QMouseEvent>
 #include <QPushButton>
 #include <QTextEdit>
+#include <QWindow>
 #include <QGuiApplication>
 #include <QClipboard>
 
@@ -23,12 +25,14 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     layout->setSpacing(0);
 
     // ── Title bar (16px gradient, matching applet style) ─────────────────
-    auto* titleBar = new QWidget;
-    titleBar->setFixedHeight(16);
-    titleBar->setStyleSheet(
+    m_titleBar = new QWidget;
+    m_titleBar->setFixedHeight(16);
+    m_titleBar->setStyleSheet(
         "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
         "stop:0 #3a4a5a, stop:0.5 #2a3a4a, stop:1 #1a2a38); "
         "border-bottom: 1px solid #0a1a28; }");
+    m_titleBar->installEventFilter(this);  // drag-to-move when floating
+    auto* titleBar = m_titleBar;
 
     auto* barLayout = new QHBoxLayout(titleBar);
     barLayout->setContentsMargins(6, 1, 4, 1);
@@ -372,6 +376,21 @@ void PanadapterApplet::clearCwText()
 
 bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
 {
+    // Title-bar drag in floating mode → move the OS window via Qt 6's
+    // cross-platform startSystemMove.  Frameless pop-outs have no native
+    // title bar, so the applet's own title strip becomes the drag handle.
+    if (obj == m_titleBar && m_isFloating
+        && ev->type() == QEvent::MouseButtonPress) {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (me->button() == Qt::LeftButton) {
+            if (auto* w = window()) {
+                if (auto* h = w->windowHandle()) {
+                    h->startSystemMove();
+                    return true;
+                }
+            }
+        }
+    }
     if (ev->type() == QEvent::MouseButtonPress)
         emit activated(m_panId);
     return QWidget::eventFilter(obj, ev);

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -376,9 +376,11 @@ void PanadapterApplet::clearCwText()
 
 bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
 {
+#ifndef Q_OS_WIN
     // Title-bar drag in floating mode → move the OS window via Qt 6's
     // cross-platform startSystemMove.  Frameless pop-outs have no native
     // title bar, so the applet's own title strip becomes the drag handle.
+    // Windows keeps the native frame, so the OS title bar handles moves.
     if (obj == m_titleBar && m_isFloating
         && ev->type() == QEvent::MouseButtonPress) {
         auto* me = static_cast<QMouseEvent*>(ev);
@@ -391,6 +393,7 @@ bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
             }
         }
     }
+#endif
     if (ev->type() == QEvent::MouseButtonPress)
         emit activated(m_panId);
     return QWidget::eventFilter(obj, ev);

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -376,11 +376,9 @@ void PanadapterApplet::clearCwText()
 
 bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
 {
-#ifndef Q_OS_WIN
     // Title-bar drag in floating mode → move the OS window via Qt 6's
     // cross-platform startSystemMove.  Frameless pop-outs have no native
     // title bar, so the applet's own title strip becomes the drag handle.
-    // Windows keeps the native frame, so the OS title bar handles moves.
     if (obj == m_titleBar && m_isFloating
         && ev->type() == QEvent::MouseButtonPress) {
         auto* me = static_cast<QMouseEvent*>(ev);
@@ -393,7 +391,6 @@ bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
             }
         }
     }
-#endif
     if (ev->type() == QEvent::MouseButtonPress)
         emit activated(m_panId);
     return QWidget::eventFilter(obj, ev);

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -31,7 +31,13 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
         "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
         "stop:0 #3a4a5a, stop:0.5 #2a3a4a, stop:1 #1a2a38); "
         "border-bottom: 1px solid #0a1a28; }");
-    m_titleBar->installEventFilter(this);  // drag-to-move when floating
+#ifndef Q_OS_WIN
+    // Drag-to-move when floating uses startSystemMove on Linux/macOS.
+    // Windows keeps the native frame, so no title-bar event filter — and
+    // installing one there triggers spurious setActivePan calls that
+    // destabilise the float→dock→re-float cycle.
+    m_titleBar->installEventFilter(this);
+#endif
     auto* titleBar = m_titleBar;
 
     auto* barLayout = new QHBoxLayout(titleBar);

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -59,6 +59,7 @@ protected:
 private:
     QString m_panId;
     SpectrumWidget* m_spectrum{nullptr};
+    QWidget*        m_titleBar{nullptr};
     QLabel*         m_titleLabel{nullptr};
     QPushButton*    m_popOutBtn{nullptr};
     QPushButton*    m_maxBtn{nullptr};

--- a/src/gui/containers/ContainerTitleBar.cpp
+++ b/src/gui/containers/ContainerTitleBar.cpp
@@ -83,6 +83,7 @@ QString ContainerTitleBar::title() const
 
 void ContainerTitleBar::setFloatingState(bool isFloating)
 {
+    m_isFloating = isFloating;
     // "↙" when floating (to dock) / "⚊" when docked (to float).
     m_floatBtn->setText(isFloating
         ? QString::fromUtf8("\xe2\x86\x99")
@@ -90,11 +91,15 @@ void ContainerTitleBar::setFloatingState(bool isFloating)
     m_floatBtn->setToolTip(isFloating
         ? "Return to panel"
         : "Pop out into a floating window");
+    // ↙ already covers "close + dock" while floating, so the redundant
+    // × button hides itself in float mode and reappears when docked.
+    if (m_closeBtn) m_closeBtn->setVisible(m_closeAllowed && !isFloating);
 }
 
 void ContainerTitleBar::setCloseButtonVisible(bool visible)
 {
-    if (m_closeBtn) m_closeBtn->setVisible(visible);
+    m_closeAllowed = visible;
+    if (m_closeBtn) m_closeBtn->setVisible(visible && !m_isFloating);
 }
 
 void ContainerTitleBar::mousePressEvent(QMouseEvent* ev)

--- a/src/gui/containers/ContainerTitleBar.h
+++ b/src/gui/containers/ContainerTitleBar.h
@@ -49,6 +49,8 @@ private:
     QPushButton* m_closeBtn{nullptr};
     QPoint       m_pressPos;
     bool         m_pressed{false};
+    bool         m_closeAllowed{true};   // false = explicitly disabled (sidebar)
+    bool         m_isFloating{false};
 };
 
 } // namespace AetherSDR

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -135,9 +135,12 @@ void ContainerWidget::onTitleBarDragStart(const QPoint& /*globalPos*/)
 {
     if (!m_titleBar) return;
 
-    // Floating window: title-bar drag moves the OS window via the Qt 6
-    // cross-platform primitive that hands the move off to the compositor.
-    // (Pop-out windows are frameless — no native title bar to grab.)
+#ifndef Q_OS_WIN
+    // Floating frameless window: title-bar drag moves the OS window via
+    // the Qt 6 cross-platform primitive that hands the move off to the
+    // compositor.  Windows pop-outs keep their native frame, so the user
+    // moves the window via the OS title bar instead — fall through to
+    // the QDrag-reorder path below for both docked and floating cases.
     if (m_dockMode == DockMode::Floating) {
         if (auto* w = window()) {
             if (auto* h = w->windowHandle()) {
@@ -146,6 +149,7 @@ void ContainerWidget::onTitleBarDragStart(const QPoint& /*globalPos*/)
             }
         }
     }
+#endif
 
     // MIME type is shared with AppletDropArea's drag-reorder handling.
     auto* drag = new QDrag(m_titleBar);

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -135,12 +135,9 @@ void ContainerWidget::onTitleBarDragStart(const QPoint& /*globalPos*/)
 {
     if (!m_titleBar) return;
 
-#ifndef Q_OS_WIN
-    // Floating frameless window: title-bar drag moves the OS window via
-    // the Qt 6 cross-platform primitive that hands the move off to the
-    // compositor.  Windows pop-outs keep their native frame, so the user
-    // moves the window via the OS title bar instead — fall through to
-    // the QDrag-reorder path below for both docked and floating cases.
+    // Floating window: title-bar drag moves the OS window via the Qt 6
+    // cross-platform primitive that hands the move off to the compositor.
+    // (Pop-out windows are frameless — no native title bar to grab.)
     if (m_dockMode == DockMode::Floating) {
         if (auto* w = window()) {
             if (auto* h = w->windowHandle()) {
@@ -149,7 +146,6 @@ void ContainerWidget::onTitleBarDragStart(const QPoint& /*globalPos*/)
             }
         }
     }
-#endif
 
     // MIME type is shared with AppletDropArea's drag-reorder handling.
     auto* drag = new QDrag(m_titleBar);

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -5,6 +5,7 @@
 #include <QMimeData>
 #include <QPixmap>
 #include <QVBoxLayout>
+#include <QWindow>
 
 namespace AetherSDR {
 
@@ -132,8 +133,21 @@ void ContainerWidget::onTitleBarClose()
 
 void ContainerWidget::onTitleBarDragStart(const QPoint& /*globalPos*/)
 {
-    // MIME type is shared with AppletDropArea's drag-reorder handling.
     if (!m_titleBar) return;
+
+    // Floating window: title-bar drag moves the OS window via the Qt 6
+    // cross-platform primitive that hands the move off to the compositor.
+    // (Pop-out windows are frameless — no native title bar to grab.)
+    if (m_dockMode == DockMode::Floating) {
+        if (auto* w = window()) {
+            if (auto* h = w->windowHandle()) {
+                h->startSystemMove();
+                return;
+            }
+        }
+    }
+
+    // MIME type is shared with AppletDropArea's drag-reorder handling.
     auto* drag = new QDrag(m_titleBar);
     auto* mime = new QMimeData;
     mime->setData("application/x-aethersdr-applet", m_id.toUtf8());

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -22,18 +22,13 @@ constexpr int kDefaultH = 240;
 } // namespace
 
 FloatingContainerWindow::FloatingContainerWindow(QWidget* parent)
-#ifdef Q_OS_WIN
-    // Windows: keep native frame.  FramelessWindowHint is unreliable on
-    // Windows (constructor bitmask sometimes ignored) and the GPU/QRhi
-    // reparent path crashes when the layout is wired for frameless.
-    : QWidget(parent, Qt::Window)
-#else
     : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
-#endif
 {
-#ifndef Q_OS_WIN
+    // Windows quirk: the constructor flag bitmask is sometimes ignored
+    // and the native frame still gets drawn.  Re-applying via setWindowFlags
+    // before show() forces the platform plugin to honour FramelessWindowHint
+    // on all Qt versions / widget hierarchies.
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
-#endif
     setAttribute(Qt::WA_DeleteOnClose, false);
     setAttribute(Qt::WA_QuitOnClose, false);
     setStyleSheet("QWidget { background: #08121d; }");
@@ -65,16 +60,14 @@ void FloatingContainerWindow::takeContainer(ContainerWidget* container)
         m_container->setDockMode(ContainerWidget::DockMode::Floating);
         setWindowTitle(m_container->title());
 
-#ifndef Q_OS_WIN
         // Bottom-right resize grip — frameless windows lose OS edge resize.
-        // Windows keeps native frame so the OS already provides edge resize.
+        // Append after the container so it sits at the bottom of the layout.
         auto* gripRow = new QHBoxLayout;
         gripRow->setContentsMargins(0, 0, 0, 0);
         gripRow->addStretch(1);
         gripRow->addWidget(new QSizeGrip(this), 0,
                            Qt::AlignBottom | Qt::AlignRight);
         m_layout->addLayout(gripRow);
-#endif
     }
 }
 

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -22,13 +22,18 @@ constexpr int kDefaultH = 240;
 } // namespace
 
 FloatingContainerWindow::FloatingContainerWindow(QWidget* parent)
+#ifdef Q_OS_WIN
+    // Windows: keep native frame.  FramelessWindowHint is unreliable on
+    // Windows (constructor bitmask sometimes ignored) and the GPU/QRhi
+    // reparent path crashes when the layout is wired for frameless.
+    : QWidget(parent, Qt::Window)
+#else
     : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
+#endif
 {
-    // Windows quirk: the constructor flag bitmask is sometimes ignored
-    // and the native frame still gets drawn.  Re-applying via setWindowFlags
-    // before show() forces the platform plugin to honour FramelessWindowHint
-    // on all Qt versions / widget hierarchies.
+#ifndef Q_OS_WIN
     setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+#endif
     setAttribute(Qt::WA_DeleteOnClose, false);
     setAttribute(Qt::WA_QuitOnClose, false);
     setStyleSheet("QWidget { background: #08121d; }");
@@ -60,14 +65,16 @@ void FloatingContainerWindow::takeContainer(ContainerWidget* container)
         m_container->setDockMode(ContainerWidget::DockMode::Floating);
         setWindowTitle(m_container->title());
 
+#ifndef Q_OS_WIN
         // Bottom-right resize grip — frameless windows lose OS edge resize.
-        // Append after the container so it sits at the bottom of the layout.
+        // Windows keeps native frame so the OS already provides edge resize.
         auto* gripRow = new QHBoxLayout;
         gripRow->setContentsMargins(0, 0, 0, 0);
         gripRow->addStretch(1);
         gripRow->addWidget(new QSizeGrip(this), 0,
                            Qt::AlignBottom | Qt::AlignRight);
         m_layout->addLayout(gripRow);
+#endif
     }
 }
 

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -5,9 +5,11 @@
 #include <QByteArray>
 #include <QCloseEvent>
 #include <QGuiApplication>
+#include <QHBoxLayout>
 #include <QMoveEvent>
 #include <QResizeEvent>
 #include <QScreen>
+#include <QSizeGrip>
 #include <QVBoxLayout>
 
 namespace AetherSDR {
@@ -20,7 +22,7 @@ constexpr int kDefaultH = 240;
 } // namespace
 
 FloatingContainerWindow::FloatingContainerWindow(QWidget* parent)
-    : QWidget(parent, Qt::Window)
+    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
 {
     setAttribute(Qt::WA_DeleteOnClose, false);
     setAttribute(Qt::WA_QuitOnClose, false);
@@ -52,6 +54,15 @@ void FloatingContainerWindow::takeContainer(ContainerWidget* container)
         m_container->show();
         m_container->setDockMode(ContainerWidget::DockMode::Floating);
         setWindowTitle(m_container->title());
+
+        // Bottom-right resize grip — frameless windows lose OS edge resize.
+        // Append after the container so it sits at the bottom of the layout.
+        auto* gripRow = new QHBoxLayout;
+        gripRow->setContentsMargins(0, 0, 0, 0);
+        gripRow->addStretch(1);
+        gripRow->addWidget(new QSizeGrip(this), 0,
+                           Qt::AlignBottom | Qt::AlignRight);
+        m_layout->addLayout(gripRow);
     }
 }
 

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -24,6 +24,11 @@ constexpr int kDefaultH = 240;
 FloatingContainerWindow::FloatingContainerWindow(QWidget* parent)
     : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
 {
+    // Windows quirk: the constructor flag bitmask is sometimes ignored
+    // and the native frame still gets drawn.  Re-applying via setWindowFlags
+    // before show() forces the platform plugin to honour FramelessWindowHint
+    // on all Qt versions / widget hierarchies.
+    setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
     setAttribute(Qt::WA_DeleteOnClose, false);
     setAttribute(Qt::WA_QuitOnClose, false);
     setStyleSheet("QWidget { background: #08121d; }");


### PR DESCRIPTION
## Summary

All floating containers (\`FloatingContainerWindow\` + \`PanFloatingWindow\`) now use \`Qt::FramelessWindowHint\`. The native title bars are removed; each applet's existing 16-18 px title strip becomes the drag handle and houses the dock/close affordances.

## Mechanics

- Title-bar drag → \`window()->windowHandle()->startSystemMove()\` — Qt 6's cross-platform compositor primitive (X11, Wayland, Windows, macOS).
- \`QSizeGrip\` in the bottom-right of every floating window so users can still resize without OS edge handles.
- \`ContainerTitleBar\`'s \`×\` button auto-hides while floating since the \`↩\` dock button covers the same intent. Re-shows when re-docked.
- \`PanadapterApplet\`'s \`×\` stays visible — that one deletes the panadapter (a distinct action from dock).
- \`setWindowFlags()\` is called in the body in addition to the constructor flag pass, to work around a Qt-on-Windows quirk where the constructor bitmask is sometimes ignored.

## Code

- \`FloatingContainerWindow\` opens with FramelessWindowHint and appends a \`QSizeGrip\` after the container.
- \`ContainerWidget::onTitleBarDragStart\` routes to \`startSystemMove\` when floating; falls through to QDrag-reorder when docked.
- \`ContainerTitleBar\` tracks \`m_closeAllowed\`/\`m_isFloating\` to compute effective close-button visibility, preserving the explicit hide used by the sidebar root container.
- \`PanFloatingWindow\` gets FramelessWindowHint + QSizeGrip.
- \`PanadapterApplet\`'s title strip is exposed as \`m_titleBar\`; \`eventFilter\` detects mouse press on it and calls \`startSystemMove\` when floating.

## Branch history

5 commits — initial + Windows debugging cycle. Two Windows-specific guards were tried and reverted; final state is uniform cross-platform frameless.

## Test plan

- [ ] **Linux**: pop out RX/MTR/EQ/VU + a panadapter, drag from title bar, resize from corner grip, dock back, re-pop. ✅ verified
- [ ] **Windows**: same pop/dock/re-pop cycle. *Crash investigation needs follow-up — see branch history.*
- [ ] **macOS**: pop out a panadapter; verify spectrum/waterfall GPU rendering still works (#1344/#1668 NSView fragility class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)