### PR TITLE
Frameless main window with title-bar drag, min/max/close, and size grip

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -120,6 +120,8 @@
 #include <QPushButton>
 #include <QShortcut>
 #include <QScrollArea>
+#include <QSizeGrip>
+#include <QStatusBar>
 #include <QFrame>
 #include <QFileDialog>
 #include <QNetworkAccessManager>
@@ -711,8 +713,23 @@ MainWindow::MainWindow(QWidget* parent)
     // Apply frameless flag before first show() so the window is created
     // without chrome from the start — avoids the flash + re-create that
     // setWindowFlags() after show would cause (#framleess via View menu).
-    if (AppSettings::instance().value("FramelessWindow", "False").toString() == "True")
-        setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
+    // Default ON: TitleBar provides drag, double-click-maximize, and the
+    // min/max/close trio at the far right.  View → Frameless Window can
+    // still toggle it off as an escape hatch.
+    {
+        auto& s = AppSettings::instance();
+        // One-shot migration: existing installs have FramelessWindow=False
+        // saved from when frameless was opt-in.  Force ON for the
+        // transition so users see the new chrome by default; the View
+        // menu toggle still lets them flip it off afterwards.
+        if (!s.contains("FramelessMigratedV0823")) {
+            s.setValue("FramelessWindow", "True");
+            s.setValue("FramelessMigratedV0823", "True");
+            s.save();
+        }
+        if (s.value("FramelessWindow", "True").toString() == "True")
+            setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
+    }
 
     applyDarkTheme();
 
@@ -3344,6 +3361,20 @@ MainWindow::~MainWindow()
 #endif
 }
 
+void MainWindow::resizeEvent(QResizeEvent* event)
+{
+    QMainWindow::resizeEvent(event);
+    // Anchor the frameless-mode size grip to the bottom-right corner,
+    // overlaying the status bar.  Direct child of MainWindow so the
+    // grip's native dotted-texture paint isn't suppressed by the
+    // status-bar stylesheet.
+    if (m_sizeGrip) {
+        const int s = m_sizeGrip->width();
+        m_sizeGrip->move(width() - s - 1, height() - s - 1);
+        m_sizeGrip->raise();
+    }
+}
+
 void MainWindow::closeEvent(QCloseEvent* event)
 {
     m_shuttingDown = true;
@@ -4974,10 +5005,11 @@ void MainWindow::buildMenuBar()
     framelessAct->setCheckable(true);
     framelessAct->setShortcut(QKeySequence("Ctrl+Shift+F"));
     framelessAct->setToolTip(
-        "Hide the OS title bar to gain screen space.\n"
-        "When enabled, move/close via keyboard shortcuts or taskbar.");
+        "Hide the OS title bar.  Drag the AetherSDR title bar to move,\n"
+        "double-click to maximize, or use the min/max/close buttons on\n"
+        "the right.  Toggle off if your compositor mishandles it.");
     framelessAct->setChecked(
-        AppSettings::instance().value("FramelessWindow", "False").toString() == "True");
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
     connect(framelessAct, &QAction::toggled, this, [this](bool on) {
         setFramelessWindow(on);
     });
@@ -5606,6 +5638,14 @@ void MainWindow::buildUI()
     // ── Status bar (SmartSDR-style, double height) ─────────────────────
     statusBar()->setFixedHeight(46);
     statusBar()->setSizeGripEnabled(false);
+    // Bottom-right resize grip — direct child of MainWindow (not parented
+    // into the status bar, whose stylesheet was suppressing the grip's
+    // dotted texture).  Position is maintained in resizeEvent.
+    m_sizeGrip = new QSizeGrip(this);
+    m_sizeGrip->setFixedSize(16, 16);
+    m_sizeGrip->raise();
+    m_sizeGrip->setVisible(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
     statusBar()->setStyleSheet(
         "QStatusBar { background: #0a0a14; border-top: 1px solid #203040; }"
         "QStatusBar::item { border: none; }"
@@ -8779,6 +8819,9 @@ void MainWindow::setFramelessWindow(bool on)
     setGeometry(geom);
     if (wasVisible)
         show();
+
+    // Keep the bottom-right size grip in sync — only useful when frameless.
+    if (m_sizeGrip) m_sizeGrip->setVisible(on);
 }
 
 void MainWindow::toggleMinimalMode(bool on)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -48,6 +48,7 @@
 #include <QLabel>
 #include <QMenu>
 #include <QStatusBar>
+#include <QSizeGrip>
 #include <QHash>
 #include <QJsonObject>
 
@@ -87,6 +88,7 @@ public:
 
 protected:
     void closeEvent(QCloseEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
@@ -275,6 +277,7 @@ private:
 
     // GUI — main area
     TitleBar*         m_titleBar{nullptr};
+    ::QSizeGrip*      m_sizeGrip{nullptr};
     QSplitter*        m_splitter{nullptr};
     PanadapterStack*  m_panStack{nullptr};
     QPointer<PanadapterApplet> m_panApplet;  // backward compat alias to active applet

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -5,6 +5,7 @@
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QDialog>
+#include <QMouseEvent>
 #include <QPointer>
 #include <QPushButton>
 #include <QSlider>
@@ -15,6 +16,7 @@
 #include <QClipboard>
 #include <QApplication>
 #include <QTimer>
+#include <QWindow>
 #include <QMenu>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
@@ -277,6 +279,132 @@ TitleBar::TitleBar(QWidget* parent)
         "QPushButton:hover { background: #504000; color: #ffe080; }");
     connect(featureBtn, &QPushButton::clicked, this, &TitleBar::showFeatureRequestDialog);
     m_hbox->addWidget(featureBtn);
+
+    // ── Window-control trio (min / max / close) ───────────────────────────
+    // Flat labels — click is wired via eventFilter().  Close uses a red
+    // hover for the standard "destructive action" cue.
+    m_hbox->addSpacing(8);
+
+    const QString winLblStyle = QStringLiteral(
+        "QLabel { color: #8aa8c0; font-size: 14px; padding: 0 6px; }"
+        "QLabel:hover { color: #00b4d8; }");
+    const QString winCloseLblStyle = QStringLiteral(
+        "QLabel { color: #8aa8c0; font-size: 14px; padding: 0 6px; }"
+        "QLabel:hover { color: #ff4040; }");
+
+    m_minimizeLbl = new QLabel(QString::fromUtf8("\xe2\x80\x94"));  // — em dash
+    m_minimizeLbl->setAlignment(Qt::AlignCenter);
+    m_minimizeLbl->setCursor(Qt::PointingHandCursor);
+    m_minimizeLbl->setToolTip("Minimize");
+    m_minimizeLbl->setAccessibleName("Minimize window");
+    m_minimizeLbl->setStyleSheet(winLblStyle);
+    m_minimizeLbl->installEventFilter(this);
+    m_hbox->addWidget(m_minimizeLbl);
+
+    m_maximizeLbl = new QLabel(QString::fromUtf8("\xe2\x96\xa1"));  // □ U+25A1
+    m_maximizeLbl->setAlignment(Qt::AlignCenter);
+    m_maximizeLbl->setCursor(Qt::PointingHandCursor);
+    m_maximizeLbl->setToolTip("Maximize");
+    m_maximizeLbl->setAccessibleName("Maximize window");
+    m_maximizeLbl->setStyleSheet(winLblStyle);
+    m_maximizeLbl->installEventFilter(this);
+    m_hbox->addWidget(m_maximizeLbl);
+
+    m_closeLbl = new QLabel(QString::fromUtf8("\xe2\x9c\x95"));  // ✕ U+2715
+    m_closeLbl->setAlignment(Qt::AlignCenter);
+    m_closeLbl->setCursor(Qt::PointingHandCursor);
+    m_closeLbl->setToolTip("Close");
+    m_closeLbl->setAccessibleName("Close window");
+    m_closeLbl->setStyleSheet(winCloseLblStyle);
+    m_closeLbl->installEventFilter(this);
+    m_hbox->addWidget(m_closeLbl);
+}
+
+void TitleBar::showEvent(QShowEvent* ev)
+{
+    QWidget::showEvent(ev);
+    // Install event filter on the host window once it's known so we can
+    // refresh the maximize-button icon when the window state changes.
+    if (auto* w = window()) {
+        w->installEventFilter(this);
+        updateMaximizeIcon();
+    }
+}
+
+bool TitleBar::eventFilter(QObject* obj, QEvent* ev)
+{
+    if (obj == window() && ev->type() == QEvent::WindowStateChange) {
+        updateMaximizeIcon();
+        return QWidget::eventFilter(obj, ev);
+    }
+
+    if (ev->type() == QEvent::MouseButtonPress) {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (me->button() == Qt::LeftButton) {
+            if (obj == m_minimizeLbl) {
+                if (auto* w = window()) w->showMinimized();
+                return true;
+            }
+            if (obj == m_maximizeLbl) {
+                if (auto* w = window()) {
+                    if (w->isMaximized()) w->showNormal();
+                    else                  w->showMaximized();
+                }
+                return true;
+            }
+            if (obj == m_closeLbl) {
+                if (auto* w = window()) w->close();
+                return true;
+            }
+        }
+    }
+    return QWidget::eventFilter(obj, ev);
+}
+
+void TitleBar::updateMaximizeIcon()
+{
+    if (!m_maximizeLbl) return;
+    auto* w = window();
+    const bool maxed = w && w->isMaximized();
+    // ❐ U+2750 (overlapped squares) when maximized → "restore down"
+    // □ U+25A1 (single square) when normal → "maximize"
+    m_maximizeLbl->setText(maxed
+        ? QString::fromUtf8("\xe2\x9d\x90")
+        : QString::fromUtf8("\xe2\x96\xa1"));
+    m_maximizeLbl->setToolTip(maxed ? "Restore" : "Maximize");
+}
+
+void TitleBar::mousePressEvent(QMouseEvent* ev)
+{
+    // Children (menu bar items, buttons, sliders) intercept their own
+    // clicks before bubbling to TitleBar — so by the time we see the
+    // press it landed on bare background.  Hand the move to the
+    // compositor via Qt 6's cross-platform startSystemMove.
+    if (ev->button() == Qt::LeftButton) {
+        if (auto* w = window()) {
+            if (auto* h = w->windowHandle()) {
+                h->startSystemMove();
+                ev->accept();
+                return;
+            }
+        }
+    }
+    QWidget::mousePressEvent(ev);
+}
+
+void TitleBar::mouseDoubleClickEvent(QMouseEvent* ev)
+{
+    // Standard Linux/Windows convention: double-click the title bar to
+    // toggle maximize.  Same child-passthrough rule as mousePressEvent.
+    if (ev->button() == Qt::LeftButton) {
+        if (auto* w = window()) {
+            if (w->isMaximized()) w->showNormal();
+            else                  w->showMaximized();
+            ev->accept();
+            return;
+        }
+    }
+    QWidget::mouseDoubleClickEvent(ev);
 }
 
 void TitleBar::setMenuBar(QMenuBar* mb)

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -62,6 +62,12 @@ private:
     QPushButton* m_minimalBtn{nullptr};
     QPushButton* m_featureBtn{nullptr};
 
+    // Window-control trio (frameless mode): minimize, maximize/restore, close.
+    // QLabels (not buttons) for a flat look; click is wired via eventFilter.
+    QLabel*      m_minimizeLbl{nullptr};
+    QLabel*      m_maximizeLbl{nullptr};
+    QLabel*      m_closeLbl{nullptr};
+
     // Heartbeat indicator
     QLabel*      m_heartbeat{nullptr};
     QTimer*      m_heartbeatOffTimer{nullptr};   // 100ms green→grey
@@ -70,6 +76,18 @@ private:
     bool         m_alarmRed{false};
     bool         m_blinkEnabled{true};  // persisted via AppSettings "HeartbeatBlinkEnabled"
     bool         m_discovering{false};  // solid amber while waiting for connection
+
+protected:
+    // Drag-to-move + double-click-to-maximize for frameless main window.
+    // Click hits a child first (menu bar item, button, slider) and only
+    // bubbles to TitleBar when the press lands on bare background.
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseDoubleClickEvent(QMouseEvent* ev) override;
+    bool eventFilter(QObject* obj, QEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+
+private:
+    void updateMaximizeIcon();
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Summary

Make the whole app frameless by default — no more OS title bar.  TitleBar gains drag-to-move, double-click-to-maximize, and a min/max/close trio at the far right.  A QSizeGrip in the bottom-right corner provides resize.

## What's in

- One-shot \`FramelessMigratedV0823\` AppSettings migration flips existing installs from the prior opt-in (\`FramelessWindow=False\`) default.  View → Frameless Window keeps the toggle as an escape hatch.
- TitleBar drag → \`window()->windowHandle()->startSystemMove()\` (Qt 6 cross-platform compositor primitive).  Children intercept their own clicks; drag only fires on truly empty areas.
- Double-click to toggle maximize / restore.
- Three flat QLabels at the far right (—, □/❐, ✕) styled to match the rest of the bar.  Cyan hover for min/max, red hover for close.  Click via eventFilter.
- Maximize icon auto-swaps via WindowStateChange event filter on the host window.
- QSizeGrip anchored as a direct child of MainWindow (not parented into the styled QStatusBar, which suppresses the dotted-texture paint).  Repositioned in resizeEvent.  Same approach pop-out windows already use.

## Test plan

- [x] Linux: drag from bare title-bar areas, double-click to maximize, min/max/close all work, size grip resizes
- [ ] Windows: confirm Qt-on-Windows quirk (constructor flag bitmask) doesn't bite — \`setWindowFlags()\` is already used for the Frameless toggle path
- [ ] macOS: confirm chrome behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)