### PR TITLE
[crash] Fix Core MIDI init crash during MIDI auto-connect

### DIFF
--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -102,7 +102,10 @@ bool MidiControlManager::openPortByName(const QString& portName)
             if (QString::fromStdString(probe.getPortName(i)).contains(portName, Qt::CaseInsensitive))
                 return openPort(static_cast<int>(i));
         }
-    } catch (const RtMidiError&) {}
+    } catch (const RtMidiError& e) {
+        qCWarning(lcDevices) << "MidiControlManager: error finding port:" << e.what();
+        emit portError(QString::fromStdString(e.getMessage()));
+    }
     return false;
 }
 

--- a/third_party/rtmidi/RtMidi.cpp
+++ b/third_party/rtmidi/RtMidi.cpp
@@ -111,7 +111,7 @@ class MidiInCore: public MidiInApi
   std::string getPortName( unsigned int portNumber );
 
  protected:
-  MIDIClientRef getCoreMidiClientSingleton(const std::string& clientName) throw();
+  MIDIClientRef getCoreMidiClientSingleton(const std::string& clientName);
   void initialize( const std::string& clientName );
 };
 
@@ -131,7 +131,7 @@ class MidiOutCore: public MidiOutApi
   void sendMessage( const unsigned char *message, size_t size );
 
  protected:
-  MIDIClientRef getCoreMidiClientSingleton(const std::string& clientName) throw();
+  MIDIClientRef getCoreMidiClientSingleton(const std::string& clientName);
   void initialize( const std::string& clientName );
 };
 
@@ -1159,7 +1159,7 @@ MidiInCore :: ~MidiInCore( void )
   delete data;
 }
 
-MIDIClientRef MidiInCore::getCoreMidiClientSingleton(const std::string& clientName) throw() {
+MIDIClientRef MidiInCore::getCoreMidiClientSingleton(const std::string& clientName) {
 
   if (CoreMidiClientSingleton == 0){
       // Set up our client.
@@ -1496,7 +1496,7 @@ MidiOutCore :: ~MidiOutCore( void )
   delete data;
 }
 
-MIDIClientRef MidiOutCore::getCoreMidiClientSingleton(const std::string& clientName) throw() {
+MIDIClientRef MidiOutCore::getCoreMidiClientSingleton(const std::string& clientName) {
 
   if (CoreMidiClientSingleton == 0){
       // Set up our client.
@@ -1506,7 +1506,7 @@ MIDIClientRef MidiOutCore::getCoreMidiClientSingleton(const std::string& clientN
       OSStatus result = MIDIClientCreate(name, NULL, NULL, &client );
       if ( result != noErr ) {
         std::ostringstream ost;
-        ost << "MidiInCore::initialize: error creating OS-X MIDI client object (" << result << ").";
+        ost << "MidiOutCore::initialize: error creating OS-X MIDI client object (" << result << ").";
         errorString_ = ost.str();
         error( RtMidiError::DRIVER_ERROR, errorString_ );
         return 0;


### PR DESCRIPTION
## Summary
- allow CoreMIDI client creation errors in RtMidi to propagate as catchable RtMidiError exceptions instead of terminating through throw()
- report MIDI port lookup failures through MidiControlManager's existing logging and portError path
- fix the MidiOutCore client creation diagnostic label while touching the same failure path

## Testing
- cmake -S . -B build -G Ninja
- cmake --build build -j 10
- ctest --test-dir build -j 10 --output-on-failure (no registered tests in this build dir)
- standalone test binaries passed; container GUI tests passed with QT_QPA_PLATFORM=offscreen
- manual: launched 10 times with and without the MIDI controller plugged in; no crashes observed

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat