### PR TITLE
[midi] Preserve MIDI bindings when saving device settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1123,6 +1123,14 @@ add_executable(device_diagnostics_test
 target_include_directories(device_diagnostics_test PRIVATE src)
 target_link_libraries(device_diagnostics_test PRIVATE Qt6::Core)
 
+add_executable(midi_settings_test
+    tests/midi_settings_test.cpp
+    src/core/MidiSettings.cpp
+)
+target_compile_definitions(midi_settings_test PRIVATE HAVE_MIDI)
+target_include_directories(midi_settings_test PRIVATE src third_party/rtmidi)
+target_link_libraries(midi_settings_test PRIVATE Qt6::Core)
+
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test
     tests/container_widget_test.cpp

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -53,6 +53,7 @@ void MidiSettings::save()
 {
     QString path = settingsFilePath();
     QDir().mkpath(QFileInfo(path).absolutePath());
+    auto bindings = loadBindings();
 
     QFile file(path);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
@@ -69,7 +70,6 @@ void MidiSettings::save()
     xml.writeTextElement("AutoConnect", m_autoConnect ? "True" : "False");
 
     // Write bindings inline in the main settings file
-    auto bindings = loadBindings();
     xml.writeStartElement("Bindings");
     for (const auto& b : bindings) {
         xml.writeStartElement("Binding");

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -1,0 +1,95 @@
+#include "core/MidiSettings.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    return condition;
+}
+
+bool sameBinding(const MidiBinding& a, const MidiBinding& b)
+{
+    return a.channel == b.channel
+        && a.msgType == b.msgType
+        && a.number == b.number
+        && a.paramId == b.paramId
+        && a.inverted == b.inverted
+        && a.relative == b.relative;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QTemporaryDir fakeHome(QDir::tempPath() + "/aether-midi-settings-test-XXXXXX");
+    if (!fakeHome.isValid()) {
+        std::cerr << "[FAIL] create temporary home\n";
+        return 1;
+    }
+    qputenv("HOME", fakeHome.path().toUtf8());
+    qputenv("CFFIXED_USER_HOME", fakeHome.path().toUtf8());
+    QStandardPaths::setTestModeEnabled(true);
+    QCoreApplication app(argc, argv);
+
+    const QString configRoot =
+        QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
+    QDir(configRoot + "/AetherSDR").removeRecursively();
+
+    MidiBinding afGain;
+    afGain.channel = 2;
+    afGain.msgType = MidiBinding::CC;
+    afGain.number = 74;
+    afGain.paramId = "rx.afGain";
+    afGain.inverted = true;
+    afGain.relative = true;
+
+    MidiBinding tuneKnob;
+    tuneKnob.channel = -1;
+    tuneKnob.msgType = MidiBinding::PitchBend;
+    tuneKnob.number = -1;
+    tuneKnob.paramId = "rx.tuneKnob";
+
+    QVector<MidiBinding> saved{afGain, tuneKnob};
+
+    auto& settings = MidiSettings::instance();
+    settings.setLastDevice("Initial Controller");
+    settings.setAutoConnect(true);
+    settings.saveBindings(saved);
+
+    settings.setLastDevice("Renamed Controller");
+    settings.setAutoConnect(false);
+    settings.save();
+
+    const auto loaded = settings.loadBindings();
+    bool ok = true;
+    ok &= expect(loaded.size() == saved.size(),
+                 "preference-only save preserves binding count");
+    if (loaded.size() == saved.size()) {
+        ok &= expect(sameBinding(loaded[0], saved[0]),
+                     "preference-only save preserves first binding");
+        ok &= expect(sameBinding(loaded[1], saved[1]),
+                     "preference-only save preserves second binding");
+    }
+
+    settings.load();
+    ok &= expect(settings.lastDevice() == "Renamed Controller",
+                 "preference-only save updates last device");
+    ok &= expect(!settings.autoConnect(),
+                 "preference-only save updates auto-connect");
+
+    QFile::remove(configRoot + "/AetherSDR/midi.settings");
+    QDir(configRoot + "/AetherSDR").removeRecursively();
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- preserve existing MIDI bindings before `MidiSettings::save()` opens `midi.settings` for writing
- add a standalone `midi_settings_test` regression harness for preference-only saves
- wire the new MIDI settings test target into the CMake test harness section

## What we discovered
`MidiSettings::save()` was intended to update device preferences such as `LastDevice` and `AutoConnect` while keeping the existing `<Binding>` entries. The code opened `midi.settings` with `QIODevice::WriteOnly` and then called `loadBindings()` from the same path. On `QFile`, opening with `WriteOnly` truncates the file as soon as `open()` succeeds, so the subsequent `loadBindings()` read happened after the old XML contents were already gone. That made preference-only actions, like connecting a MIDI device or toggling auto-connect, capable of rewriting the file with an empty bindings list.

The fix loads the bindings before opening the file for write, then serializes those preserved bindings into the updated settings document.

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build -j 10`
- `build/midi_settings_test`
- `build/client_eq_test`
- `build/client_comp_test`
- `build/client_gate_test`
- `build/client_deess_test`
- `build/client_tube_test`
- `build/client_pudu_test`
- `build/client_reverb_test`
- `build/passive_spots_policy_test`
- `build/device_diagnostics_test`
- `build/help_dialog_test`
- `QT_QPA_PLATFORM=offscreen build/container_widget_test`
- `QT_QPA_PLATFORM=offscreen build/container_manager_test`
- `QT_QPA_PLATFORM=offscreen build/container_nesting_test`
- `ctest --test-dir build -j 10 --output-on-failure` (no registered tests in this build dir)
- manual: verified MIDI settings persistence behavior in the built app

Build link: /tmp/aether-midi-settings-preserve-bindings/build/AetherSDR.app

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
