### PR TITLE
Fix choppy/harsh RADE decoded audio: dedicated RX buffer + sample-wise mix (regression from #1875)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -159,9 +159,12 @@ AudioEngine::AudioEngine(QObject* parent)
             // Drop oldest samples to keep latency bounded
             m_rxBuffer.remove(0, m_rxBuffer.size() - maxBufBytes);
         }
+        if (m_radeRxBuffer.size() > maxBufBytes) {
+            m_radeRxBuffer.remove(0, m_radeRxBuffer.size() - maxBufBytes);
+        }
 
         const qsizetype freeBytes = m_audioSink->bytesFree();
-        if (freeBytes > 0 && m_rxBuffer.isEmpty()) {
+        if (freeBytes > 0 && m_rxBuffer.isEmpty() && m_radeRxBuffer.isEmpty()) {
             m_rxBufferUnderrunCount.fetch_add(1);
         }
 
@@ -203,12 +206,46 @@ AudioEngine::AudioEngine(QObject* parent)
             return;
         }
 
-        qsizetype len = freeBytes;
-        len = std::min(len, m_rxBuffer.size());
+        // Align to float32 frame boundary before any arithmetic.
+        const qsizetype floatBytes = static_cast<qsizetype>(sizeof(float));
+        qsizetype len = (freeBytes / floatBytes) * floatBytes;
+        len = std::min(len, std::max(m_rxBuffer.size(), m_radeRxBuffer.size()));
         if (len > 0)
         {
-            len = m_audioDevice->write(m_rxBuffer.left(len));
-            m_rxBuffer.remove(0, len);
+            QByteArray chunk;
+            if (m_radeRxBuffer.isEmpty()) {
+                // Fast path: no RADE speech active — write m_rxBuffer directly.
+                chunk = m_rxBuffer.left(len);
+                m_rxBuffer.remove(0, chunk.size());
+            } else {
+                // Mix path: add m_rxBuffer (SSB/CW audio or zero-filled muted-RADE
+                // frames) and m_radeRxBuffer (decoded RADE speech) sample-wise.
+                // Both are float32 stereo at the same rate. Zero-init the output
+                // so that whichever buffer is shorter contributes silence for its
+                // missing tail samples without special-casing.
+                chunk = QByteArray(len, '\0');
+                auto* out = reinterpret_cast<float*>(chunk.data());
+
+                const qsizetype rxTake = (std::min(len, m_rxBuffer.size()) / floatBytes) * floatBytes;
+                if (rxTake > 0) {
+                    const auto* rx = reinterpret_cast<const float*>(m_rxBuffer.constData());
+                    const qsizetype rxSamples = rxTake / floatBytes;
+                    for (qsizetype i = 0; i < rxSamples; ++i)
+                        out[i] += rx[i];
+                    m_rxBuffer.remove(0, rxTake);
+                }
+
+                const qsizetype radeTake = (std::min(len, m_radeRxBuffer.size()) / floatBytes) * floatBytes;
+                if (radeTake > 0) {
+                    const auto* rade = reinterpret_cast<const float*>(m_radeRxBuffer.constData());
+                    const qsizetype radeSamples = radeTake / floatBytes;
+                    for (qsizetype i = 0; i < radeSamples; ++i)
+                        out[i] = std::clamp(out[i] + rade[i], -1.0f, 1.0f);
+                    m_radeRxBuffer.remove(0, radeTake);
+                }
+            }
+
+            len = m_audioDevice->write(chunk);
 
             // Stale session watchdog: if we're writing data but processedUSecs()
             // hasn't advanced, the WASAPI session is silently discarding audio
@@ -547,9 +584,15 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
 {
     if (!m_audioSink) return;  // PC audio disabled
     m_lastAudioFeedTime.start();  // reset liveness watchdog (#1411)
-    // m_radeMode does NOT block feedAudioData — the RADE slice's raw OFDM
-    // noise is muted at the slice level (audio_mute=1) so it never arrives
-    // here. Decoded RADE speech uses feedDecodedSpeech() instead.
+
+    // feedAudioData() handles all remote_audio_rx paths: SSB/CW/digital on any pan,
+    // and the zero-filled frames the radio sends for the muted RADE slice
+    // (audio_mute=1 zeroes the payload — it does NOT suppress packets).
+    // All of these write to m_rxBuffer. Decoded RADE speech is separate:
+    // feedDecodedSpeech() writes to m_radeRxBuffer. The drain timer mixes both
+    // sample-wise before writing to the device, so zero frames from the muted
+    // RADE slice add nothing to the output and SSB audio on a second pan is
+    // heard alongside RADE decoded speech without fill-rate interference.
 
     auto writeAudio = [this](const QByteArray& data) {
         if (!m_audioDevice || !m_audioDevice->isOpen()) return;
@@ -651,10 +694,6 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
             processBnr(pcm);
             // processBnr writes audio and emits level internally
         } else {
-            // No client-side DSP active — write PCM directly.
-            // m_radeMode does NOT gate this path: RADE's raw OFDM noise is
-            // muted at the slice level (audio_mute=1) so it never reaches
-            // feedAudioData, and decoded RADE speech uses feedDecodedSpeech().
             writeAudio(pcm);
             emit levelChanged(computeRMS(pcm));
         }
@@ -2700,6 +2739,8 @@ void AudioEngine::setRadeMode(bool on)
     // use the physical mic and discard every dax_tx packet, producing no
     // TX waveform. feedDaxTxAudio/m_daxTxUseRadioRoute are irrelevant:
     // RADE bypasses feedDaxTxAudio entirely.
+    if (!on)
+        m_radeRxBuffer.clear();
     clearTxAccumulators();
 }
 
@@ -2873,12 +2914,20 @@ void AudioEngine::feedDecodedSpeech(const QByteArray& pcm)
 {
     if (!m_audioSink || !m_audioDevice || !m_audioDevice->isOpen()) return;
 
-    // note: RX timer will handle actual audio device write
-    if (m_resampleTo48k)
-        m_rxBuffer.append(resampleStereo(pcm));
-    else
-        m_rxBuffer.append(pcm);
-    updateRxBufferStats();
+    // Decoded RADE speech goes into its own buffer. The drain timer mixes
+    // m_radeRxBuffer with m_rxBuffer sample-wise so both are heard simultaneously
+    // without doubling the fill rate. A dedicated resampler preserves the filter
+    // state independently from the m_rxResampler used by feedAudioData().
+    if (m_resampleTo48k) {
+        if (!m_radeRxResampler)
+            m_radeRxResampler = std::make_unique<Resampler>(24000, 48000);
+        const auto* src = reinterpret_cast<const float*>(pcm.constData());
+        m_radeRxBuffer.append(
+            m_radeRxResampler->processStereoToStereo(
+                src, pcm.size() / (2 * static_cast<int>(sizeof(float)))));
+    } else {
+        m_radeRxBuffer.append(pcm);
+    }
 }
 
 } // namespace AetherSDR

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -423,7 +423,8 @@ private:
     std::atomic<int>   m_rxBufferCapMs{200}; // RX buffer cap in ms (#1505)
     std::atomic<bool>  m_muted{false};
     bool  m_resampleTo48k{false};      // RX: upsample 24kHz → 48kHz output
-    std::unique_ptr<Resampler> m_rxResampler;  // 24k stereo → 48k stereo (lazy init)
+    std::unique_ptr<Resampler> m_rxResampler;      // 24k stereo → 48k stereo (lazy init)
+    std::unique_ptr<Resampler> m_radeRxResampler;  // separate 24k→48k for RADE decoded speech
     bool  m_txNeedsResample{false};      // TX: input rate != 24kHz, needs resampling
     bool  m_txInputMono{false};          // TX: input device is mono
     int   m_txInputRate{24000};          // TX: actual input sample rate
@@ -550,6 +551,7 @@ private:
     // RX audio buffer handling
     QTimer*       m_rxTimer{nullptr};
     QByteArray    m_rxBuffer;
+    QByteArray    m_radeRxBuffer;  // decoded RADE speech; mixed into drain output, never appended to m_rxBuffer
     std::atomic<qsizetype> m_rxBufferBytes{0};
     std::atomic<qsizetype> m_rxBufferPeakBytes{0};
     std::atomic<quint64>   m_rxBufferUnderrunCount{0};


### PR DESCRIPTION
## Regression

Commit `401d5d7` (PR #1875, \"Fix silent audio in SSB/Digital modes when m_radeMode is active\") introduced a regression: decoded RADE RX audio sounds choppy, harsh, and perceptibly slowed down.

## Root Cause

PR #1875 removed the `!m_radeMode` guard from `feedAudioData`'s final branch on the premise that:

> *"RADE's raw OFDM noise is muted at the slice level (audio_mute=1) so it never reaches feedAudioData"*

**This premise is false.** Pcap analysis (`rade-harsh-audio.pcapng`, FLEX-8400 v4.1.5.39794) shows that when `audio_mute=1` is applied to the RADE slice, the radio does **not** suppress `remote_audio_rx` VITA-49 packets. It **zero-fills** the float32 payload (stream `0x04000008`, PCC `0x03E3`) and keeps sending at the normal ~5 ms cadence. The pcap shows the transition from non-zero audio to all-`0x00000000` within one packet cadence of `audio_mute=1` taking effect, then staying zero for the rest of the capture.

### Why that causes choppy audio

`m_rxBuffer` is a single queue drained by the RX timer. Before `401d5d7`:

- `feedDecodedSpeech()` → `m_rxBuffer` at rate **R**  
- `feedAudioData()` (muted-RADE slice) → **blocked** by `!m_radeMode`  
- Fill rate = **1× drain rate** ✅

After `401d5d7`:

- `feedDecodedSpeech()` → `m_rxBuffer` at rate **R**  
- `feedAudioData()` (zero-filled frames) → `m_rxBuffer` at rate **R**  
- Combined fill = **2× drain rate** → 200 ms cap fires every ~200 ms → ~200 ms of decoded speech dropped periodically → **choppy/harsh/slowed audio** ❌

The multi-pan case (RADE on Pan A, SSB on Pan B) triggers the same symptom: SSB audio from Pan B fills `m_rxBuffer` alongside decoded RADE speech, again doubling the fill rate. An intermediate RMS-gate fix was considered (block zero frames, pass non-zero) but reproduced the harsh audio on the SSB pan — same root cause, different source of the extra fill.

## Fix

**Dedicated `m_radeRxBuffer` + sample-wise mix in the drain timer.**

`feedDecodedSpeech()` now writes to `m_radeRxBuffer` instead of `m_rxBuffer`. `feedAudioData()` continues writing to `m_rxBuffer` as always (SSB/CW audio from any pan, plus zero-filled muted-RADE-slice frames). The RX drain timer mixes both buffers sample-wise (float32 addition) before writing to the device:

```
m_rxBuffer (SSB audio or zeros)  +  m_radeRxBuffer (RADE speech)
─────────────────────────────────────────────────────────────────
output = SSB + RADE   ← both pans heard simultaneously ✅
output = 0   + RADE   ← RADE only, single-pan (zeros add nothing) ✅
output = SSB + 0      ← no RADE active, fast-path zero copy ✅
```

Each buffer fills at rate R and drains at rate R. No cap is triggered. The original intent of #1875 (non-RADE-slice audio audible while RADE is active) is fully preserved.

A dedicated `m_radeRxResampler` (24 k→48 k) is used in `feedDecodedSpeech()` to keep the r8brain filter state independent from `m_rxResampler` — sharing a stateful FIR filter between two independent audio streams produces output corruption via filter delay-line contamination.

`m_radeRxBuffer` is capped by the same `maxBufBytes` policy as `m_rxBuffer`, the underrun counter now requires both buffers empty before incrementing, and `m_radeRxBuffer` is cleared on `setRadeMode(false)` to prevent stale frames bleeding into the next session.

## Files Changed

- `src/core/AudioEngine.h` — `m_radeRxBuffer`, `m_radeRxResampler`
- `src/core/AudioEngine.cpp` — `feedDecodedSpeech()`, drain timer, `setRadeMode()`

## Test Results

| Scenario | Result |
|---|---|
| Pure SSB/CW, no RADE — non-regression check | ✅ Verified: audio clean, unaffected |
| RADE on Pan A + SSB on Pan B — Pan B audio | ✅ Verified: SSB audio clean, no interference |
| Single-pan RADE decoded audio quality | ⏳ Pending: no RADE traffic available during testing |
| Multi-pan RADE decoded audio + SSB simultaneous | ⏳ Pending: no RADE traffic available during testing |

The two pending cases require an on-air RADE signal to validate. The fix is mechanically sound (zero-filled frames add 0 to the mix → output is pure RADE speech; non-RADE mix is not affected by the RADE buffer path). Wider testing via this PR is the intent.

## References

- Regression: commit `401d5d7`, PR #1875
- Protocol behaviour confirmed by pcap (FLEX-8400 firmware v4.1.5.39794)