### PR TITLE
[ux] Cancel frequency entry with Escape

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -23,6 +23,7 @@
 #include <QAction>
 #include <QPainter>
 #include <QWheelEvent>
+#include <QKeyEvent>
 #include <QDoubleSpinBox>
 #include <QDir>
 #include <cmath>
@@ -416,6 +417,7 @@ void RxApplet::buildUI()
             " font-weight: bold; padding: 0 4px; }");
         m_freqEdit->setAlignment(Qt::AlignRight);
         m_freqEdit->setPlaceholderText("MHz");
+        m_freqEdit->installEventFilter(this);
         m_freqStack->addWidget(m_freqEdit);
         m_freqStack->setCurrentIndex(0);
 
@@ -1813,6 +1815,21 @@ void RxApplet::applyOffsetDir(const QString& dir)
 
 bool RxApplet::eventFilter(QObject* obj, QEvent* ev)
 {
+    if (obj == m_freqEdit
+        && (ev->type() == QEvent::ShortcutOverride
+            || ev->type() == QEvent::KeyPress)) {
+        auto* ke = static_cast<QKeyEvent*>(ev);
+        if ((ke->key() == Qt::Key_Escape || ke->key() == Qt::Key_Cancel)
+            && m_freqStack->currentIndex() == 1) {
+            if (m_slice)
+                m_freqEdit->setText(QString::number(m_slice->frequency(), 'f', 6));
+            m_freqStack->setCurrentIndex(0);
+            m_freqEdit->clearFocus();
+            ev->accept();
+            return true;
+        }
+    }
+
     // Double-click frequency label → inline edit
     if (obj == m_freqLabel && ev->type() == QEvent::MouseButtonDblClick) {
         if (m_slice) {

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -26,6 +26,7 @@
 #include <QFile>
 #include <QPixmap>
 #include <QEvent>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <cmath>
 
@@ -487,6 +488,7 @@ void VfoWidget::buildUI()
     const int stackW = QFontMetrics(labelFont).horizontalAdvance("0000.000.000") + 8;
     m_freqStack->setFixedWidth(stackW);
     m_freqEdit->setPlaceholderText("MHz (e.g. 14.225)");
+    m_freqEdit->installEventFilter(this);
     m_freqStack->addWidget(m_freqEdit);
     m_freqStack->setCurrentIndex(0);  // show label by default
 
@@ -2731,6 +2733,19 @@ void VfoWidget::beginDirectEntry(QString source)
     });
 }
 
+bool VfoWidget::cancelDirectEntry()
+{
+    if (!m_freqStack || !m_freqEdit || m_freqStack->currentIndex() != 1)
+        return false;
+
+    m_directEntrySource = "vfo-direct-entry";
+    if (m_slice)
+        m_freqEdit->setText(QString::number(m_slice->frequency(), 'f', 6));
+    m_freqStack->setCurrentIndex(0);
+    m_freqEdit->clearFocus();
+    return true;
+}
+
 void VfoWidget::syncFromSlice()
 {
     if (!m_slice) return;
@@ -3346,6 +3361,17 @@ void VfoWidget::setTransmitModel(TransmitModel* txModel)
 
 bool VfoWidget::eventFilter(QObject* obj, QEvent* event)
 {
+    if (obj == m_freqEdit
+        && (event->type() == QEvent::ShortcutOverride
+            || event->type() == QEvent::KeyPress)) {
+        auto* ke = static_cast<QKeyEvent*>(event);
+        if ((ke->key() == Qt::Key_Escape || ke->key() == Qt::Key_Cancel)
+            && cancelDirectEntry()) {
+            event->accept();
+            return true;
+        }
+    }
+
     // Double-click on DIG offset label → switch to inline edit
     if (obj == m_digOffsetLabel && event->type() == QEvent::MouseButtonDblClick) {
         if (m_digOffsetStack && m_digOffsetEdit) {

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -130,6 +130,7 @@ private:
     void updateTxBadgeStyle(bool isTx);
     void showTab(int index);
     void updateFreqLabel();
+    bool cancelDirectEntry();
     void updateFilterLabel();
     void updateModeTab();
     void rebuildFilterButtons();


### PR DESCRIPTION
**Summary**
- Add explicit Escape/Cancel handling for VFO direct frequency entry.
- Apply the same cancel behavior to the RX applet inline frequency editor.
- Restore the normal frequency display and clear edit focus without committing a tune request.

**Root Cause**
The Go to Frequency shortcut moves focus into the VFO frequency QLineEdit, but the inline editor did not define a cancel path. Pressing Escape could be consumed by Qt's shortcut resolution path or app-wide Escape shortcuts before the line edit received a normal keypress, leaving the frequency entry active instead of canceling it.

**User Impact**
Operators can press G, reconsider the frequency change, and press Escape to back out cleanly. The same expectation now holds for the RX applet frequency inline editor: Escape closes the editor, leaves the slice frequency unchanged, and returns focus to normal operating shortcuts.

**Implementation Notes**
- Install an event filter on the VFO and RX applet frequency line edits.
- Handle both QEvent::ShortcutOverride and QEvent::KeyPress for Escape/Cancel so the inline editor wins before application-wide shortcuts can intercept the key.
- Factor VFO cancellation into cancelDirectEntry() so the source state, displayed value, stacked-widget page, and focus cleanup stay together.

**Validation**
- Built successfully with cmake --build build --parallel 10.
- Ran ctest --test-dir build --output-on-failure -j10; no tests were registered in this build directory.
- Manual verification by @jensenpat: G opens frequency entry and Escape now cancels the edit without tuning.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat