### PR TITLE
Fix pop-out applet panel white background and add Qt 6.2 version guard for startSystemMove

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10610,6 +10610,7 @@ void MainWindow::floatAppletPanel()
     m_appletPanelFloatWindow = new QWidget(nullptr, Qt::Window);
     m_appletPanelFloatWindow->setWindowTitle("AetherSDR — Applet Panel");
     m_appletPanelFloatWindow->setAttribute(Qt::WA_DeleteOnClose, false);
+    m_appletPanelFloatWindow->setStyleSheet("QWidget { background: #0a0a18; }");
     auto* layout = new QVBoxLayout(m_appletPanelFloatWindow);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10610,7 +10610,9 @@ void MainWindow::floatAppletPanel()
     m_appletPanelFloatWindow = new QWidget(nullptr, Qt::Window);
     m_appletPanelFloatWindow->setWindowTitle("AetherSDR — Applet Panel");
     m_appletPanelFloatWindow->setAttribute(Qt::WA_DeleteOnClose, false);
-    m_appletPanelFloatWindow->setStyleSheet("QWidget { background: #0a0a18; }");
+    static const QString kBgStyleSheet =
+        QStringLiteral("QWidget { background: #0a0a18; }");
+    m_appletPanelFloatWindow->setStyleSheet(kBgStyleSheet);
     auto* layout = new QVBoxLayout(m_appletPanelFloatWindow);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -379,14 +379,21 @@ void TitleBar::mousePressEvent(QMouseEvent* ev)
     // Children (menu bar items, buttons, sliders) intercept their own
     // clicks before bubbling to TitleBar — so by the time we see the
     // press it landed on bare background.  Hand the move to the
-    // compositor via Qt 6's cross-platform startSystemMove.
+    // compositor via Qt 6's cross-platform startSystemMove (requires 6.2+).
     if (ev->button() == Qt::LeftButton) {
         if (auto* w = window()) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
             if (auto* h = w->windowHandle()) {
                 h->startSystemMove();
                 ev->accept();
                 return;
             }
+#else
+            m_dragActive = true;
+            m_dragOffset = ev->globalPosition().toPoint() - w->frameGeometry().topLeft();
+            ev->accept();
+            return;
+#endif
         }
     }
     QWidget::mousePressEvent(ev);
@@ -406,6 +413,29 @@ void TitleBar::mouseDoubleClickEvent(QMouseEvent* ev)
     }
     QWidget::mouseDoubleClickEvent(ev);
 }
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
+void TitleBar::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (m_dragActive) {
+        if (auto* w = window())
+            w->move(ev->globalPosition().toPoint() - m_dragOffset);
+        ev->accept();
+        return;
+    }
+    QWidget::mouseMoveEvent(ev);
+}
+
+void TitleBar::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (ev->button() == Qt::LeftButton && m_dragActive) {
+        m_dragActive = false;
+        ev->accept();
+        return;
+    }
+    QWidget::mouseReleaseEvent(ev);
+}
+#endif
 
 void TitleBar::setMenuBar(QMenuBar* mb)
 {

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QPoint>
 #include <QWidget>
 
 class QPushButton;
@@ -76,6 +77,10 @@ private:
     bool         m_alarmRed{false};
     bool         m_blinkEnabled{true};  // persisted via AppSettings "HeartbeatBlinkEnabled"
     bool         m_discovering{false};  // solid amber while waiting for connection
+#if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
+    bool         m_dragActive{false};
+    QPoint       m_dragOffset;
+#endif
 
 protected:
     // Drag-to-move + double-click-to-maximize for frameless main window.
@@ -85,6 +90,10 @@ protected:
     void mouseDoubleClickEvent(QMouseEvent* ev) override;
     bool eventFilter(QObject* obj, QEvent* ev) override;
     void showEvent(QShowEvent* ev) override;
+#if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
+#endif
 
 private:
     void updateMaximizeIcon();


### PR DESCRIPTION
Fixes #1956

> **Note on #1955 (window drag):** The drag fix (commit cfdd7b8) is already on `main` — it landed after the 0.8.22 release was cut. This PR does not re-introduce that fix; it builds on top of it.

## What this PR adds

**White background on pop-out applet panel** (`MainWindow.cpp`)
`floatAppletPanel()` creates a `QWidget(nullptr, Qt::Window)` with no parent, so Qt stylesheet inheritance is broken and the widget gets a white default background. Fix: set an explicit `QWidget { background: #0a0a18; }` stylesheet at construction time, before the window is shown.

**Qt 6.2 version guard on `startSystemMove`** (`TitleBar.cpp/h`)
`QWindow::startSystemMove()` was introduced in Qt 6.2. The existing call in `mousePressEvent` has no version guard, so it would fail to compile on Qt 6.0/6.1. This PR wraps it in `#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)` and adds a manual mouse-tracking fallback (`mouseMoveEvent` + `mouseReleaseEvent`) for older Qt builds.

## Test plan

- [ ] View → Pop Out Applet Panel (Ctrl+Shift+S) — floating window should have a dark background matching the app theme
- [ ] Dock the applet panel back — re-embeds cleanly with correct sizing
- [ ] Confirm drag still works on a Qt 6.2+ build
- [ ] Confirm the code compiles cleanly on Qt < 6.2 (if available)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)