### PR TITLE
Guard startSystemMove behind Qt 6.2 version check with manual fallback

### DIFF
--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -377,6 +377,10 @@ void TitleBar::mousePressEvent(QMouseEvent* ev)
             }
 #else
             // Qt < 6.2: no startSystemMove — track the drag manually.
+            // Restore first if maximised so the drag doesn't move a full-screen
+            // window (startSystemMove handles snap-away automatically on 6.2+).
+            if (w->isMaximized())
+                w->showNormal();
             m_dragActive = true;
             m_dragOffset = ev->globalPosition().toPoint() - w->frameGeometry().topLeft();
             ev->accept();

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -366,18 +366,49 @@ void TitleBar::mousePressEvent(QMouseEvent* ev)
     // Children (menu bar items, buttons, sliders) intercept their own
     // clicks before bubbling to TitleBar — so by the time we see the
     // press it landed on bare background.  Hand the move to the
-    // compositor via Qt 6's cross-platform startSystemMove.
+    // compositor via Qt 6's cross-platform startSystemMove (requires 6.2+).
     if (ev->button() == Qt::LeftButton) {
         if (auto* w = window()) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
             if (auto* h = w->windowHandle()) {
                 h->startSystemMove();
                 ev->accept();
                 return;
             }
+#else
+            // Qt < 6.2: no startSystemMove — track the drag manually.
+            m_dragActive = true;
+            m_dragOffset = ev->globalPosition().toPoint() - w->frameGeometry().topLeft();
+            ev->accept();
+            return;
+#endif
         }
     }
     QWidget::mousePressEvent(ev);
 }
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
+void TitleBar::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (m_dragActive) {
+        if (auto* w = window())
+            w->move(ev->globalPosition().toPoint() - m_dragOffset);
+        ev->accept();
+        return;
+    }
+    QWidget::mouseMoveEvent(ev);
+}
+
+void TitleBar::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (ev->button() == Qt::LeftButton && m_dragActive) {
+        m_dragActive = false;
+        ev->accept();
+        return;
+    }
+    QWidget::mouseReleaseEvent(ev);
+}
+#endif
 
 void TitleBar::mouseDoubleClickEvent(QMouseEvent* ev)
 {

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QPoint>
 #include <QWidget>
 
 class QPushButton;
@@ -76,6 +77,10 @@ private:
     bool         m_alarmRed{false};
     bool         m_blinkEnabled{true};  // persisted via AppSettings "HeartbeatBlinkEnabled"
     bool         m_discovering{false};  // solid amber while waiting for connection
+#if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
+    bool         m_dragActive{false};
+    QPoint       m_dragOffset;
+#endif
 
 protected:
     // Drag-to-move + double-click-to-maximize for frameless main window.
@@ -85,6 +90,10 @@ protected:
     void mouseDoubleClickEvent(QMouseEvent* ev) override;
     bool eventFilter(QObject* obj, QEvent* ev) override;
     void showEvent(QShowEvent* ev) override;
+#if QT_VERSION < QT_VERSION_CHECK(6, 2, 0)
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
+#endif
 
 private:
     void updateMaximizeIcon();


### PR DESCRIPTION
## Summary

`QWindow::startSystemMove()` was introduced in Qt 6.2. The call in `TitleBar::mousePressEvent` (added in #1926) has no version guard, so it would fail to compile on Qt 6.0/6.1.

## Changes

**`TitleBar.cpp`** — `mousePressEvent` wraps `startSystemMove` in `#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)`. For Qt < 6.2, the press offset is stored and the window is moved manually in `mouseMoveEvent`, cleared in `mouseReleaseEvent`.

**`TitleBar.h`** — The two fallback overrides (`mouseMoveEvent`, `mouseReleaseEvent`) and their member variables (`m_dragActive`, `m_dragOffset`) are declared inside the same version guard — they compile out entirely on Qt 6.2+.

Single-responsibility change — no behaviour difference on Qt 6.2+.

## Test plan

- [ ] Drag the title bar on Qt 6.2+ — behaviour unchanged
- [ ] Confirm clean compile on Qt < 6.2 (if available)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)