### PR TITLE
[xvtr] Add XVTR policy manager and regression test coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,6 +477,7 @@ set(MODEL_SOURCES
     src/models/DvkModel.cpp
     src/models/BandSettings.cpp
     src/models/BandPlanManager.cpp
+    src/models/XvtrPolicy.cpp
     src/models/AntennaGeniusModel.cpp
 )
 
@@ -1105,6 +1106,13 @@ add_executable(passive_spots_policy_test
 )
 target_include_directories(passive_spots_policy_test PRIVATE src)
 target_link_libraries(passive_spots_policy_test PRIVATE Qt6::Core)
+
+add_executable(xvtr_policy_test
+    tests/xvtr_policy_test.cpp
+    src/models/XvtrPolicy.cpp
+)
+target_include_directories(xvtr_policy_test PRIVATE src)
+target_link_libraries(xvtr_policy_test PRIVATE Qt6::Core)
 
 # Help guide search tests - needs QApplication + Widgets.
 add_executable(help_dialog_test

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -75,6 +75,7 @@
 #include "models/MeterModel.h"
 #include "models/BandDefs.h"
 #include "models/BandPlanManager.h"
+#include "models/XvtrPolicy.h"
 #include "core/BandStackSettings.h"
 #include "gui/BandStackPanel.h"
 #include "models/TunerModel.h"
@@ -167,6 +168,18 @@ constexpr double kIncrementalSettleEdgeMarginFrac = 0.06;
 constexpr double kRevealComfortEdgeMarginFrac = 0.18;
 constexpr double kSpectrumClickEdgeMarginFrac = 0.05;
 constexpr int kPanFollowAnimationDurationMs = 110;
+
+QVector<XvtrPolicy::Transverter> xvtrPolicyBandsFrom(
+    const QMap<int, RadioModel::XvtrInfo>& xvtrs)
+{
+    QVector<XvtrPolicy::Transverter> bands;
+    bands.reserve(xvtrs.size());
+    for (auto it = xvtrs.cbegin(); it != xvtrs.cend(); ++it) {
+        const auto& x = it.value();
+        bands.append({x.index, x.order, x.name, x.rfFreq, x.ifFreq, x.isValid});
+    }
+    return bands;
+}
 
 double quantizeIncrementalFollowDelta(double overshootMhz, double stepMhz)
 {
@@ -1608,41 +1621,29 @@ MainWindow::MainWindow(QWidget* parent)
                          double low, double high, quint32 tc) {
         for (auto* pan : m_radioModel.panadapters()) {
             if (pan->wfStreamId() == streamId) {
-                const double tileCenter = (low + high) / 2.0;
-                const double panCenter  = pan->centerMhz();
-                const double tileBw     = high - low;
-                bool xvtrTileNeedsShift = false;
-                if (tileBw > 0 && std::abs(tileCenter - panCenter) > tileBw) {
+                const double panCenter = pan->centerMhz();
+                if (XvtrPolicy::isWaterfallTileOutsidePan(low, high, panCenter)) {
                     // Only reinterpret non-overlapping tile ranges for real XVTR
                     // IF/RF translation. Ordinary HF pans can briefly see stale
                     // tile centers while dragging; shifting those corrupts rows.
-                    const double observedOffset = panCenter - tileCenter;
-                    const double toleranceMhz = std::max(tileBw, 0.25);
-                    for (const auto& xvtr : m_radioModel.xvtrList()) {
-                        if (!xvtr.isValid || xvtr.rfFreq <= 0.0 || xvtr.ifFreq <= 0.0)
-                            continue;
-                        const double expectedOffset = xvtr.rfFreq - xvtr.ifFreq;
-                        if (std::abs(observedOffset - expectedOffset) <= toleranceMhz) {
-                            xvtrTileNeedsShift = true;
-                            break;
-                        }
-                    }
-                    if (!xvtrTileNeedsShift) {
+                    const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
+                    bool hasXvtrSliceAntenna = false;
+                    if (!XvtrPolicy::waterfallTileMatchesTransverterOffset(
+                            low, high, panCenter, xvtrs)) {
                         for (auto* slice : m_radioModel.slices()) {
                             if (!slice || slice->panId() != pan->panId())
                                 continue;
                             if (slice->rxAntenna().startsWith(QStringLiteral("XVT"),
                                                                Qt::CaseInsensitive)) {
-                                xvtrTileNeedsShift = true;
+                                hasXvtrSliceAntenna = true;
                                 break;
                             }
                         }
                     }
-                }
-                if (xvtrTileNeedsShift) {
-                    const double offset = panCenter - tileCenter;
-                    low  += offset;
-                    high += offset;
+                    const auto mapped = XvtrPolicy::mapWaterfallTileRange(
+                        low, high, panCenter, xvtrs, hasXvtrSliceAntenna);
+                    low = mapped.lowMhz;
+                    high = mapped.highMhz;
                 }
                 if (auto* sw = m_panStack->spectrum(pan->panId())) {
                     sw->updateWaterfallRow(bins, low, high, tc);
@@ -8166,60 +8167,18 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // current slice/pan state untouched. Guessing is worse than failing
         // visibly because a wrong tune destroys the very band-stack state this
         // path exists to preserve.
-        static const QSet<QString> kPassThroughBands = {
-            "160", "80", "60", "40", "30", "20", "17", "15", "12", "10", "6",
-            "2200", "630"
-        };
-        static const QMap<QString, int> kNumericBandSlots = {
-            { QStringLiteral("WWV"), 33 },
-            { QStringLiteral("GEN"), 34 },
-        };
-
-        // Band names from the UI carry the human suffix ("20m", "630m"),
-        // while the radio's band-stack keys are bare numbers ("20", "630").
-        // Only strip when the bare value is a known native band so XVTR names
-        // such as "2m" still fall through to the XVTR lookup below.
-        QString radioKey = bandName;
-        if (radioKey.endsWith('m') && radioKey.length() > 1) {
-            const QString stripped = radioKey.chopped(1);
-            if (kPassThroughBands.contains(stripped))
-                radioKey = stripped;
-        }
-
-        QString stackKey;
-        QString unsupportedBandReason;
-        if (kPassThroughBands.contains(radioKey)) {
-            stackKey = radioKey;
-        } else if (kNumericBandSlots.contains(bandName)) {
-            stackKey = QString::number(kNumericBandSlots.value(bandName));
-            qDebug() << "  ↳ numeric band slot:" << bandName << "->" << stackKey;
-        } else {
-            for (auto it = m_radioModel.xvtrList().constBegin();
-                 it != m_radioModel.xvtrList().constEnd(); ++it) {
-                if (it.value().isValid && it.value().name == bandName) {
-                    if (it.value().order < 0) {
-                        unsupportedBandReason =
-                            QString("XVTR %1 has no setup order; cannot form Flex band= key")
-                                .arg(bandName);
-                    } else {
-                        stackKey = QString("X%1").arg(it.value().order);
-                        qDebug() << "  ↳ XVTR match:" << bandName << "->" << stackKey;
-                    }
-                    break;
-                }
-            }
-        }
+        const auto stackKeyResult = XvtrPolicy::resolveBandStackKey(
+            bandName, xvtrPolicyBandsFrom(m_radioModel.xvtrList()));
+        const QString stackKey = stackKeyResult.key;
+        QString unsupportedBandReason = stackKeyResult.unsupportedReason;
 
         if (stackKey.isEmpty()) {
-            if (unsupportedBandReason.isEmpty()) {
-                unsupportedBandReason =
-                    QString("Band %1 has no Flex display pan band= mapping").arg(bandName);
-            }
             qWarning() << "MainWindow: refusing unsupported band change:"
                        << unsupportedBandReason;
             statusBar()->showMessage(unsupportedBandReason, 5000);
             return;
         } else {
+            qDebug() << "  ↳ Flex band key:" << bandName << "->" << stackKey;
             m_bandSettings.setCurrentBand(bandName);
             m_radioModel.sendCommand(
                 QString("display pan set %1 band=%2").arg(applet->panId()).arg(stackKey));

--- a/src/models/XvtrPolicy.cpp
+++ b/src/models/XvtrPolicy.cpp
@@ -1,0 +1,131 @@
+#include "XvtrPolicy.h"
+
+#include <QMap>
+#include <QSet>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR::XvtrPolicy {
+
+namespace {
+
+bool isNativeBandKey(const QString& key)
+{
+    static const QSet<QString> kNativeBandKeys = {
+        QStringLiteral("160"), QStringLiteral("80"), QStringLiteral("60"),
+        QStringLiteral("40"),  QStringLiteral("30"), QStringLiteral("20"),
+        QStringLiteral("17"),  QStringLiteral("15"), QStringLiteral("12"),
+        QStringLiteral("10"),  QStringLiteral("6"),
+        QStringLiteral("2200"), QStringLiteral("630")
+    };
+    return kNativeBandKeys.contains(key);
+}
+
+QString normalizedNativeBandKey(const QString& bandName)
+{
+    QString key = bandName;
+    if (key.endsWith('m') && key.length() > 1) {
+        const QString stripped = key.chopped(1);
+        if (isNativeBandKey(stripped))
+            key = stripped;
+    }
+    return key;
+}
+
+double tileBandwidth(double lowMhz, double highMhz)
+{
+    return highMhz - lowMhz;
+}
+
+double tileCenter(double lowMhz, double highMhz)
+{
+    return (lowMhz + highMhz) / 2.0;
+}
+
+} // namespace
+
+BandStackKeyResult resolveBandStackKey(const QString& bandName,
+                                       const QVector<Transverter>& xvtrs)
+{
+    static const QMap<QString, int> kNumericBandSlots = {
+        { QStringLiteral("WWV"), 33 },
+        { QStringLiteral("GEN"), 34 },
+    };
+
+    const QString radioKey = normalizedNativeBandKey(bandName);
+    if (isNativeBandKey(radioKey))
+        return {radioKey, {}};
+
+    if (kNumericBandSlots.contains(bandName))
+        return {QString::number(kNumericBandSlots.value(bandName)), {}};
+
+    for (const auto& xvtr : xvtrs) {
+        if (!xvtr.isValid || xvtr.name != bandName)
+            continue;
+
+        if (xvtr.order < 0) {
+            return {
+                {},
+                QString("XVTR %1 has no setup order; cannot form Flex band= key")
+                    .arg(bandName)
+            };
+        }
+
+        return {QString("X%1").arg(xvtr.order), {}};
+    }
+
+    return {
+        {},
+        QString("Band %1 has no Flex display pan band= mapping").arg(bandName)
+    };
+}
+
+bool isWaterfallTileOutsidePan(double lowMhz, double highMhz, double panCenterMhz)
+{
+    const double bw = tileBandwidth(lowMhz, highMhz);
+    if (bw <= 0.0)
+        return false;
+
+    return std::abs(tileCenter(lowMhz, highMhz) - panCenterMhz) > bw;
+}
+
+bool waterfallTileMatchesTransverterOffset(double lowMhz, double highMhz,
+                                           double panCenterMhz,
+                                           const QVector<Transverter>& xvtrs)
+{
+    const double bw = tileBandwidth(lowMhz, highMhz);
+    if (bw <= 0.0 || !isWaterfallTileOutsidePan(lowMhz, highMhz, panCenterMhz))
+        return false;
+
+    const double observedOffset = panCenterMhz - tileCenter(lowMhz, highMhz);
+    const double toleranceMhz = std::max(bw, 0.25);
+    for (const auto& xvtr : xvtrs) {
+        if (!xvtr.isValid || xvtr.rfFreqMhz <= 0.0 || xvtr.ifFreqMhz <= 0.0)
+            continue;
+
+        const double expectedOffset = xvtr.rfFreqMhz - xvtr.ifFreqMhz;
+        if (std::abs(observedOffset - expectedOffset) <= toleranceMhz)
+            return true;
+    }
+
+    return false;
+}
+
+WaterfallTileRange mapWaterfallTileRange(double lowMhz, double highMhz,
+                                         double panCenterMhz,
+                                         const QVector<Transverter>& xvtrs,
+                                         bool hasXvtrSliceAntenna)
+{
+    if (!isWaterfallTileOutsidePan(lowMhz, highMhz, panCenterMhz))
+        return {lowMhz, highMhz, false};
+
+    if (!hasXvtrSliceAntenna &&
+        !waterfallTileMatchesTransverterOffset(lowMhz, highMhz, panCenterMhz, xvtrs)) {
+        return {lowMhz, highMhz, false};
+    }
+
+    const double offset = panCenterMhz - tileCenter(lowMhz, highMhz);
+    return {lowMhz + offset, highMhz + offset, true};
+}
+
+} // namespace AetherSDR::XvtrPolicy

--- a/src/models/XvtrPolicy.h
+++ b/src/models/XvtrPolicy.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QString>
+#include <QVector>
+
+namespace AetherSDR::XvtrPolicy {
+
+struct Transverter {
+    int     index{0};
+    int     order{-1};
+    QString name;
+    double  rfFreqMhz{0.0};
+    double  ifFreqMhz{0.0};
+    bool    isValid{false};
+};
+
+struct BandStackKeyResult {
+    QString key;
+    QString unsupportedReason;
+
+    bool isSupported() const { return !key.isEmpty(); }
+};
+
+struct WaterfallTileRange {
+    double lowMhz{0.0};
+    double highMhz{0.0};
+    bool   shifted{false};
+};
+
+BandStackKeyResult resolveBandStackKey(const QString& bandName,
+                                       const QVector<Transverter>& xvtrs);
+
+bool isWaterfallTileOutsidePan(double lowMhz, double highMhz, double panCenterMhz);
+
+bool waterfallTileMatchesTransverterOffset(double lowMhz, double highMhz,
+                                           double panCenterMhz,
+                                           const QVector<Transverter>& xvtrs);
+
+WaterfallTileRange mapWaterfallTileRange(double lowMhz, double highMhz,
+                                         double panCenterMhz,
+                                         const QVector<Transverter>& xvtrs,
+                                         bool hasXvtrSliceAntenna);
+
+} // namespace AetherSDR::XvtrPolicy

--- a/tests/xvtr_policy_test.cpp
+++ b/tests/xvtr_policy_test.cpp
@@ -1,0 +1,201 @@
+// Standalone regression tests for XVTR band-stack keys and waterfall IF/RF
+// mapping. Build target: xvtr_policy_test.
+
+#include "models/XvtrPolicy.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-72s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+bool near(double a, double b, double eps = 1e-9)
+{
+    return std::abs(a - b) <= eps;
+}
+
+XvtrPolicy::Transverter xvtr(int index, int order, const char* name,
+                             double rfMhz, double ifMhz, bool valid = true)
+{
+    return {index, order, QString::fromLatin1(name), rfMhz, ifMhz, valid};
+}
+
+std::string detailFor(const XvtrPolicy::WaterfallTileRange& range)
+{
+    return "low=" + std::to_string(range.lowMhz)
+        + " high=" + std::to_string(range.highMhz)
+        + " shifted=" + std::to_string(range.shifted);
+}
+
+void expectBandKey(const char* label, const QString& bandName,
+                   const QVector<XvtrPolicy::Transverter>& xvtrs,
+                   const QString& expectedKey)
+{
+    const auto result = XvtrPolicy::resolveBandStackKey(bandName, xvtrs);
+    report(label,
+           result.isSupported() && result.key == expectedKey,
+           QStringLiteral("key=%1 reason=%2")
+               .arg(result.key, result.unsupportedReason)
+               .toStdString());
+}
+
+void expectUnsupportedBand(const char* label, const QString& bandName,
+                           const QVector<XvtrPolicy::Transverter>& xvtrs,
+                           const QString& expectedReasonFragment)
+{
+    const auto result = XvtrPolicy::resolveBandStackKey(bandName, xvtrs);
+    report(label,
+           !result.isSupported() &&
+               result.unsupportedReason.contains(expectedReasonFragment),
+           QStringLiteral("key=%1 reason=%2")
+               .arg(result.key, result.unsupportedReason)
+               .toStdString());
+}
+
+void expectRange(const char* label, const XvtrPolicy::WaterfallTileRange& range,
+                 double expectedLow, double expectedHigh, bool expectedShifted)
+{
+    report(label,
+           near(range.lowMhz, expectedLow) &&
+               near(range.highMhz, expectedHigh) &&
+               range.shifted == expectedShifted,
+           detailFor(range));
+}
+
+void testBandStackKeysUseFlexOrder()
+{
+    const QVector<XvtrPolicy::Transverter> xvtrs = {
+        xvtr(12, 3, "2m",    144.0, 28.0),
+        xvtr(4,  7, "70cm",  432.0, 28.0),
+        xvtr(1,  9, "1.2G", 1296.0, 28.0),
+    };
+
+    expectBandKey("native HF strips UI suffix", "20m", xvtrs, "20");
+    expectBandKey("native utility slot WWV", "WWV", xvtrs, "33");
+    expectBandKey("native utility slot GEN", "GEN", xvtrs, "34");
+    expectBandKey("XVTR 2m uses setup order, not status index", "2m", xvtrs, "X3");
+    expectBandKey("XVTR 70cm uses setup order, not RF frequency", "70cm", xvtrs, "X7");
+    expectBandKey("XVTR 1.2G uses setup order", "1.2G", xvtrs, "X9");
+}
+
+void testBandStackKeysRefuseGuesses()
+{
+    const QVector<XvtrPolicy::Transverter> xvtrs = {
+        xvtr(2, -1, "2m", 144.0, 28.0),
+        xvtr(3,  5, "70cm", 432.0, 28.0, false),
+    };
+
+    expectUnsupportedBand("XVTR with missing order is refused",
+                          "2m", xvtrs, "has no setup order");
+    expectUnsupportedBand("invalid XVTR entry is ignored",
+                          "70cm", xvtrs, "has no Flex display pan band= mapping");
+    expectUnsupportedBand("unknown band does not use freq/mode fallback",
+                          "1.2G", xvtrs, "has no Flex display pan band= mapping");
+}
+
+void testHfWaterfallDoesNotShiftWhenTileLagsByOneSpan()
+{
+    const QVector<XvtrPolicy::Transverter> xvtrs = {
+        xvtr(12, 3, "2m", 144.0, 28.0),
+    };
+
+    const auto boundary = XvtrPolicy::mapWaterfallTileRange(
+        16.150, 16.650, 16.900, xvtrs, false);
+    expectRange("HF tile at one 500 kHz span is unchanged",
+                boundary, 16.150, 16.650, false);
+
+    const auto beyond = XvtrPolicy::mapWaterfallTileRange(
+        16.150, 16.650, 16.901, xvtrs, false);
+    expectRange("HF tile beyond one 500 kHz span is still unchanged",
+                beyond, 16.150, 16.650, false);
+}
+
+void testXvtrWaterfallMapsIfToRfBands()
+{
+    {
+        const QVector<XvtrPolicy::Transverter> xvtrs = {
+            xvtr(12, 3, "2m", 144.0, 28.0),
+        };
+        const auto mapped = XvtrPolicy::mapWaterfallTileRange(
+            28.125, 28.625, 144.375, xvtrs, false);
+        expectRange("2m XVTR maps IF waterfall range into RF range",
+                    mapped, 144.125, 144.625, true);
+        report("2m XVTR mapped range stays inside 144-148 MHz",
+               mapped.lowMhz >= 144.0 && mapped.highMhz <= 148.0,
+               detailFor(mapped));
+    }
+
+    {
+        const QVector<XvtrPolicy::Transverter> xvtrs = {
+            xvtr(4, 7, "70cm", 432.0, 28.0),
+        };
+        const auto mapped = XvtrPolicy::mapWaterfallTileRange(
+            28.200, 28.700, 432.450, xvtrs, false);
+        expectRange("70cm XVTR maps IF waterfall range into RF range",
+                    mapped, 432.200, 432.700, true);
+        report("70cm XVTR mapped range stays inside 420-450 MHz",
+               mapped.lowMhz >= 420.0 && mapped.highMhz <= 450.0,
+               detailFor(mapped));
+    }
+
+    {
+        const QVector<XvtrPolicy::Transverter> xvtrs = {
+            xvtr(1, 9, "1.2G", 1296.0, 28.0),
+        };
+        const auto mapped = XvtrPolicy::mapWaterfallTileRange(
+            28.050, 28.550, 1296.300, xvtrs, false);
+        expectRange("1.2 GHz XVTR maps IF waterfall range into RF range",
+                    mapped, 1296.050, 1296.550, true);
+        report("1.2 GHz XVTR mapped range stays inside 1240-1300 MHz",
+               mapped.lowMhz >= 1240.0 && mapped.highMhz <= 1300.0,
+               detailFor(mapped));
+    }
+}
+
+void testXvtrWaterfallGuardrails()
+{
+    const QVector<XvtrPolicy::Transverter> invalidXvtr = {
+        xvtr(12, 3, "2m", 144.0, 28.0, false),
+    };
+
+    const auto invalid = XvtrPolicy::mapWaterfallTileRange(
+        28.125, 28.625, 144.375, invalidXvtr, false);
+    expectRange("invalid XVTR does not trigger IF/RF waterfall shift",
+                invalid, 28.125, 28.625, false);
+
+    const auto antennaFallback = XvtrPolicy::mapWaterfallTileRange(
+        28.125, 28.625, 144.375, {}, true);
+    expectRange("XVT slice antenna can authorize IF/RF waterfall shift",
+                antennaFallback, 144.125, 144.625, true);
+
+    const auto inRange = XvtrPolicy::mapWaterfallTileRange(
+        144.125, 144.625, 144.375, {}, true);
+    expectRange("XVT slice antenna does not shift already-in-range rows",
+                inRange, 144.125, 144.625, false);
+}
+
+} // namespace
+
+int main()
+{
+    testBandStackKeysUseFlexOrder();
+    testBandStackKeysRefuseGuesses();
+    testHfWaterfallDoesNotShiftWhenTileLagsByOneSpan();
+    testXvtrWaterfallMapsIfToRfBands();
+    testXvtrWaterfallGuardrails();
+
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adds regression coverage for the XVTR behavior we just debugged and moves the policy into a small testable helper used by `MainWindow`.

The production behavior stays the same as the merged waterfall fix from #1925, but the key decisions are no longer embedded only in UI lambdas. The new `XvtrPolicy` helper is exercised by a standalone `xvtr_policy_test` target so future changes have to preserve the important XVTR/HF distinctions.

## What This Covers

### XVTR band switching uses the Flex setup order

The test verifies that XVTR band-stack keys are formed from the radio's XVTR `order` field:

- `2m` -> `X3` in the fixture
- `70cm` -> `X7`
- `1.2G` -> `X9`

It also verifies that this does not accidentally use the XVTR status object index, RF frequency, or display label.

### Native and utility band mappings stay intact

The same policy test keeps the existing non-XVTR band-stack behavior covered:

- Native UI labels such as `20m` still map to Flex band keys such as `20`.
- `WWV` and `GEN` still map to numeric SmartSDR band-stack slots `33` and `34`.

### Unsupported XVTR mappings fail closed

The test captures one of the more important defensive learnings: a bad mapping should not guess and should not fall back to static frequency/mode defaults.

Covered cases:

- An XVTR with no setup `order` is refused.
- An invalid XVTR entry is ignored.
- Unknown bands return an unsupported mapping instead of silently tuning.

### HF waterfall panning does not reinterpret stale rows

The test reproduces the core post-release lesson from the black-waterfall bug:

- A normal HF waterfall tile that is one 500 kHz span behind the pan center must be left unchanged.
- A normal HF tile just beyond that span must still be left unchanged.

This protects against the regression where ordinary HF panning was mistaken for XVTR IF/RF translation and the client shifted stale waterfall rows into the wrong frequency range.

### XVTR IF/RF waterfall mapping remains supported

The test verifies that actual XVTR offsets still shift IF-space rows into the expected RF-space ranges:

- 28 MHz IF -> 144 MHz / 2m
- 28 MHz IF -> 432 MHz / 70cm
- 28 MHz IF -> 1296 MHz / 1.2 GHz

Each mapped row is also checked against the expected RF band span so we catch incorrect offsets, reversed offsets, or accidental native-band normalization.

### XVTR guardrails

Additional guardrails cover edge cases that are easy to regress:

- Invalid XVTR definitions do not authorize a waterfall shift.
- An `XVT*` slice antenna can still authorize the fallback shift path.
- Already-in-range waterfall rows are never shifted just because a slice uses an XVTR antenna.

## Implementation Notes

`MainWindow` now calls `XvtrPolicy` for:

- resolving Flex `display pan set ... band=` keys from UI band labels
- deciding whether a waterfall tile is outside the pan
- deciding whether a tile/pan offset matches a valid XVTR IF/RF translation
- mapping waterfall tile ranges when XVTR evidence is present

That keeps the UI path and test path using the same logic.

## Validation

- Rebased after fetching latest `origin/main` (`2a0ef99`).
- Built the focused test target with `cmake --build build --target xvtr_policy_test --parallel 10`.
- Ran `./build/xvtr_policy_test` successfully.
- Ran `cmake --build build --parallel 10` successfully.

Build artifact for local testing: `/tmp/AetherSDR-post-release-root-cause/build/AetherSDR.app`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
