### PR TITLE
cmake: declare Qt 6.2 minimum (matches Ubuntu 22.04 LTS, gates startSystemMove)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,11 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Qt6 components
-find_package(Qt6 REQUIRED COMPONENTS
+# Qt 6.2 minimum: matches Ubuntu 22.04 LTS (our oldest supported distro)
+# and is the floor where QWindow::startSystemMove() — used by the
+# frameless title-bar drag in TitleBar / ContainerWidget / PanadapterApplet
+# — became available.  Binary distributions bundle Qt 6.7+ for QRhiWidget.
+find_package(Qt6 6.2 REQUIRED COMPONENTS
     Core
     Widgets
     Network


### PR DESCRIPTION
Set the explicit Qt floor at 6.2 in find_package().  The frameless
title-bar drag uses QWindow::startSystemMove() in three call sites
(TitleBar, ContainerWidget, PanadapterApplet) which was added in
Qt 6.2 — without an explicit floor, source builds against older Qt
fail with confusing compile errors instead of a clear configure-time
message.

6.2 matches Ubuntu 22.04 LTS, our oldest supported distro.  All binary
distributions bundle Qt 6.7+ already (required by QRhiWidget for the
GPU spectrum), so this only affects source builds.

Closes the conversation around #1959 — credit to @Chaosuk97 for
flagging the underlying gap.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
