### PR TITLE
ci(windows): switch to Ninja so sccache actually wraps cl.exe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,11 @@ jobs:
   #   * MSVC object files — sccache via GitHub Actions cache backend
   # Net effect: cold cache ~5 min, warm cache ~2-3 min (was ~14 min).
   check-windows:
-    needs: [build, check-paths]
+    # Only depend on check-paths so the conditional resolves; run in
+    # parallel with the Linux build instead of after it.  Linux passes
+    # the vast majority of PRs, so the wall-clock saving (~3 min) is
+    # worth the rare wasted Windows runner time when Linux fails first.
+    needs: [check-paths]
     if: needs.check-paths.outputs.build-changed == 'true'
     runs-on: windows-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,15 +84,26 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.6
 
+      # CMAKE_CXX_COMPILER_LAUNCHER is honoured by Ninja and Make
+      # generators, NOT by the Visual Studio / MSBuild generator that
+      # CMake selects by default on windows-latest.  Switch to Ninja so
+      # cl.exe invocations actually route through sccache.  msvc-dev-cmd
+      # puts the MSVC toolchain on PATH (cl.exe, link.exe, etc.) so
+      # Ninja can find them.
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: Configure
         run: >
-          cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_RADE=OFF
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_RADE=OFF
           -DCMAKE_C_COMPILER_LAUNCHER=sccache
           -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
 
       - name: Build
-        run: cmake --build build --config Release -j $env:NUMBER_OF_PROCESSORS
+        run: cmake --build build -j $env:NUMBER_OF_PROCESSORS
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,12 +99,43 @@ jobs:
         with:
           arch: x64
 
+      # Verify sccache can actually compile through the backend.  GitHub
+      # Actions Cache occasionally has outages; when that happens, sccache's
+      # GHA backend can't read/write and every compile through sccache
+      # fails.  Pre-flight a tiny test compile so we can fall through to a
+      # plain build instead of failing the whole job.
+      - name: Test sccache health
+        id: sccache_health
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          'int main(){return 0;}' | Out-File -Encoding ASCII test.cpp
+          sccache cl /c test.cpp /Fo:test.obj 2>&1 | Tee-Object -Variable scOut
+          $exit = $LASTEXITCODE
+          Remove-Item test.cpp,test.obj -ErrorAction SilentlyContinue
+          if ($exit -eq 0) {
+            "healthy=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            Write-Host "sccache OK"
+          } else {
+            "healthy=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            Write-Host "::warning::sccache unhealthy (exit $exit) — building without compiler cache"
+          }
+
       - name: Configure
-        run: >
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_RADE=OFF
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
+        shell: pwsh
+        run: |
+          $launcher = "${{ steps.sccache_health.outputs.healthy }}" -eq "true"
+          $cargs = @(
+            "-B","build","-G","Ninja",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DENABLE_RADE=OFF",
+            "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded"
+          )
+          if ($launcher) {
+            $cargs += "-DCMAKE_C_COMPILER_LAUNCHER=sccache"
+            $cargs += "-DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+          }
+          & cmake @cargs
 
       - name: Build
         run: cmake --build build -j $env:NUMBER_OF_PROCESSORS


### PR DESCRIPTION
## Summary

The sccache work in #1913 was effectively a no-op.  \`sccache --show-stats\` from recent runs shows:

\`\`\`
Compile requests        0
Compile requests executed  0
Cache hits              0
Cache misses            0
\`\`\`

Builds still take ~13 min — same as pre-#1913.

## Root cause

\`CMAKE_CXX_COMPILER_LAUNCHER\` is honoured by **Ninja and Makefiles generators** only — not by the **Visual Studio / MSBuild generator** that CMake selects by default on \`windows-latest\`.  Our Configure step was \`cmake -B build ...\` with no \`-G\` flag, so MSBuild ran cl.exe directly and never went through sccache.

## Fix

- Add \`ilammy/msvc-dev-cmd@v1\` step to put the MSVC toolchain (cl.exe, link.exe) on PATH
- Pass \`-G Ninja\` to the configure step so \`COMPILER_LAUNCHER\` is applied
- Drop \`--config Release\` from the build invocation (Ninja is single-config; the flag was a Visual Studio carryover)

## Expected impact

- **First run after this lands**: ~12 min (cache populates for real)
- **Subsequent runs hitting the same TUs**: 2-3 min target

The \`sccache stats\` step at the end of the job will now show non-zero compile requests + cache hits, which we can verify on the second run.

## Test plan

- [ ] First CI run completes in roughly current time (~12 min, cache populating)
- [ ] Second run on this branch (force-push or no-op commit) completes in 2-3 min
- [ ] \`sccache --show-stats\` shows >70% hit rate on the second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)