### PR TITLE
[xvtr] Add XVTR diagnostic logging for waterfall mapping

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -170,6 +170,7 @@ constexpr double kRevealComfortEdgeMarginFrac = 0.18;
 constexpr double kSpectrumClickEdgeMarginFrac = 0.05;
 constexpr int kPanFollowAnimationDurationMs = 110;
 constexpr int kSliderShortcutLeaseMs = 2000;
+constexpr qint64 kXvtrWaterfallDecisionLogIntervalMs = 20000;
 
 QVector<XvtrPolicy::Transverter> xvtrPolicyBandsFrom(
     const QMap<int, RadioModel::XvtrInfo>& xvtrs)
@@ -181,6 +182,102 @@ QVector<XvtrPolicy::Transverter> xvtrPolicyBandsFrom(
         bands.append({x.index, x.order, x.name, x.rfFreq, x.ifFreq, x.isValid});
     }
     return bands;
+}
+
+QString xvtrSummary(const XvtrPolicy::Transverter& xvtr)
+{
+    return QStringLiteral("%1[idx=%2 order=%3 valid=%4 rf=%5 if=%6 offset=%7]")
+        .arg(xvtr.name.isEmpty() ? QStringLiteral("(unnamed)") : xvtr.name)
+        .arg(xvtr.index)
+        .arg(xvtr.order)
+        .arg(xvtr.isValid ? QStringLiteral("true") : QStringLiteral("false"))
+        .arg(xvtr.rfFreqMhz, 0, 'f', 6)
+        .arg(xvtr.ifFreqMhz, 0, 'f', 6)
+        .arg(xvtr.rfFreqMhz - xvtr.ifFreqMhz, 0, 'f', 6);
+}
+
+QString xvtrListSummary(const QVector<XvtrPolicy::Transverter>& xvtrs)
+{
+    QStringList entries;
+    entries.reserve(xvtrs.size());
+    for (const auto& xvtr : xvtrs)
+        entries << xvtrSummary(xvtr);
+    return entries.isEmpty() ? QStringLiteral("(none)") : entries.join(QStringLiteral("; "));
+}
+
+QString xvtrForBandSummary(const QString& bandName,
+                           const QVector<XvtrPolicy::Transverter>& xvtrs)
+{
+    for (const auto& xvtr : xvtrs) {
+        if (xvtr.name == bandName)
+            return xvtrSummary(xvtr);
+    }
+    return QStringLiteral("(none)");
+}
+
+void logXvtrWaterfallDecision(quint32 streamId,
+                              const QString& panId,
+                              double panCenterMhz,
+                              double originalLowMhz,
+                              double originalHighMhz,
+                              const XvtrPolicy::WaterfallTileRange& mapped,
+                              const XvtrPolicy::WaterfallTileMatch& match,
+                              bool hasXvtrSliceAntenna,
+                              const QVector<XvtrPolicy::Transverter>& xvtrs)
+{
+    if (!lcConnection().isDebugEnabled())
+        return;
+
+    const QString reason = mapped.shifted
+        ? (match.matched ? QStringLiteral("matched_xvtr_offset")
+                         : QStringLiteral("xvt_slice_antenna_fallback"))
+        : QStringLiteral("no_xvtr_evidence");
+    const QString key = QStringLiteral("%1:%2").arg(streamId).arg(panId);
+    const QString signature = QStringLiteral("%1:%2:%3:%4")
+        .arg(reason)
+        .arg(mapped.shifted ? QStringLiteral("shifted") : QStringLiteral("unchanged"))
+        .arg(match.matched ? match.name : QStringLiteral("(none)"))
+        .arg(hasXvtrSliceAntenna ? QStringLiteral("xvt_ant") : QStringLiteral("no_xvt_ant"));
+
+    struct LogState {
+        QString signature;
+        qint64 lastLoggedMs{0};
+    };
+    static QHash<QString, LogState> logStateByStream;
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    auto& state = logStateByStream[key];
+    if (state.signature == signature &&
+        state.lastLoggedMs > 0 &&
+        now - state.lastLoggedMs < kXvtrWaterfallDecisionLogIntervalMs) {
+        return;
+    }
+    state.signature = signature;
+    state.lastLoggedMs = now;
+
+    qCDebug(lcConnection).noquote().nospace()
+        << "WaterfallXVTR: stream=0x" << QString::number(streamId, 16)
+        << " pan=" << panId
+        << " reason=" << reason
+        << " shifted=" << mapped.shifted
+        << " pan_center_mhz=" << QString::number(panCenterMhz, 'f', 6)
+        << " tile_mhz=" << QString::number(originalLowMhz, 'f', 6)
+        << ".." << QString::number(originalHighMhz, 'f', 6)
+        << " mapped_mhz=" << QString::number(mapped.lowMhz, 'f', 6)
+        << ".." << QString::number(mapped.highMhz, 'f', 6)
+        << " observed_offset_mhz=" << QString::number(match.observedOffsetMhz, 'f', 6)
+        << " expected_offset_mhz=" << (match.matched
+               ? QString::number(match.expectedOffsetMhz, 'f', 6)
+               : QStringLiteral("n/a"))
+        << " tolerance_mhz=" << QString::number(match.toleranceMhz, 'f', 6)
+        << " matched_xvtr=" << (match.matched
+               ? QStringLiteral("%1[idx=%2 order=%3]")
+                     .arg(match.name.isEmpty() ? QStringLiteral("(unnamed)") : match.name)
+                     .arg(match.index)
+                     .arg(match.order)
+               : QStringLiteral("(none)"))
+        << " has_xvt_slice_antenna=" << hasXvtrSliceAntenna
+        << " candidates=" << xvtrListSummary(xvtrs);
 }
 
 double quantizeIncrementalFollowDelta(double overshootMhz, double stepMhz)
@@ -1633,9 +1730,10 @@ MainWindow::MainWindow(QWidget* parent)
                     // IF/RF translation. Ordinary HF pans can briefly see stale
                     // tile centers while dragging; shifting those corrupts rows.
                     const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
+                    const auto match = XvtrPolicy::matchWaterfallTileTransverterOffset(
+                        low, high, panCenter, xvtrs);
                     bool hasXvtrSliceAntenna = false;
-                    if (!XvtrPolicy::waterfallTileMatchesTransverterOffset(
-                            low, high, panCenter, xvtrs)) {
+                    if (!match.matched) {
                         for (auto* slice : m_radioModel.slices()) {
                             if (!slice || slice->panId() != pan->panId())
                                 continue;
@@ -1648,6 +1746,9 @@ MainWindow::MainWindow(QWidget* parent)
                     }
                     const auto mapped = XvtrPolicy::mapWaterfallTileRange(
                         low, high, panCenter, xvtrs, hasXvtrSliceAntenna);
+                    logXvtrWaterfallDecision(streamId, pan->panId(), panCenter,
+                                             low, high, mapped, match,
+                                             hasXvtrSliceAntenna, xvtrs);
                     low = mapped.lowMhz;
                     high = mapped.highMhz;
                 }
@@ -8243,18 +8344,26 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // current slice/pan state untouched. Guessing is worse than failing
         // visibly because a wrong tune destroys the very band-stack state this
         // path exists to preserve.
-        const auto stackKeyResult = XvtrPolicy::resolveBandStackKey(
-            bandName, xvtrPolicyBandsFrom(m_radioModel.xvtrList()));
+        const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
+        const auto stackKeyResult = XvtrPolicy::resolveBandStackKey(bandName, xvtrs);
         const QString stackKey = stackKeyResult.key;
         QString unsupportedBandReason = stackKeyResult.unsupportedReason;
 
         if (stackKey.isEmpty()) {
-            qWarning() << "MainWindow: refusing unsupported band change:"
-                       << unsupportedBandReason;
+            qCWarning(lcProtocol).noquote().nospace()
+                << "MainWindow: refusing unsupported band change band=" << bandName
+                << " reason=" << unsupportedBandReason
+                << " available_xvtrs=" << xvtrListSummary(xvtrs);
             statusBar()->showMessage(unsupportedBandReason, 5000);
             return;
         } else {
-            qDebug() << "  ↳ Flex band key:" << bandName << "->" << stackKey;
+            qCDebug(lcProtocol).noquote().nospace()
+                << "MainWindow: band switch band=" << bandName
+                << " pan=" << applet->panId()
+                << " key=" << stackKey
+                << " freq_hint_mhz=" << QString::number(freqMhz, 'f', 6)
+                << " mode_hint=" << mode
+                << " xvtr=" << xvtrForBandSummary(bandName, xvtrs);
             m_bandSettings.setCurrentBand(bandName);
             m_radioModel.sendCommand(
                 QString("display pan set %1 band=%2").arg(applet->panId()).arg(stackKey));

--- a/src/gui/SliceTroubleshootingDialog.cpp
+++ b/src/gui/SliceTroubleshootingDialog.cpp
@@ -105,6 +105,23 @@ QString formatPanBullet(const QJsonObject& pan)
         .arg(orPlaceholder(pan["waterfall_id"].toString()));
 }
 
+QString formatXvtrBullet(const QJsonObject& xvtr)
+{
+    return QString(
+        "- `%1` idx `%2`, order `%3`, RF `%4 MHz`, IF `%5 MHz`, offset `%6 MHz`, "
+        "valid `%7`, has is_valid `%8`, rx only `%9`, max power `%10`")
+        .arg(orPlaceholder(xvtr["name"].toString()))
+        .arg(xvtr["index"].toInt())
+        .arg(xvtr["order"].toInt())
+        .arg(formatNumber(xvtr["rf_freq_mhz"], 6))
+        .arg(formatNumber(xvtr["if_freq_mhz"], 6))
+        .arg(formatNumber(xvtr["offset_mhz"], 6))
+        .arg(yesNo(xvtr["is_valid"].toBool()))
+        .arg(yesNo(xvtr["has_is_valid"].toBool()))
+        .arg(yesNo(xvtr["rx_only"].toBool()))
+        .arg(formatNumber(xvtr["max_power"], 2));
+}
+
 QString formatClientBullet(const QJsonObject& client)
 {
     return QString("- `%1`: program `%2`, owns TX `%3`, local PTT `%4`, TX ant `%5`, TX freq `%6 MHz`")
@@ -713,6 +730,15 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
     } else {
         for (const QJsonValue& value : snapshot["panadapters"].toArray())
             lines << formatPanBullet(value.toObject());
+    }
+    lines << "";
+
+    lines << "## XVTRs";
+    if (snapshot["xvtrs"].toArray().isEmpty()) {
+        lines << "- None";
+    } else {
+        for (const QJsonValue& value : snapshot["xvtrs"].toArray())
+            lines << formatXvtrBullet(value.toObject());
     }
     lines << "";
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -134,6 +134,24 @@ QJsonObject panToJson(const PanadapterModel* pan, const QString& activePanId)
     return obj;
 }
 
+QJsonObject xvtrToJson(const RadioModel::XvtrInfo& xvtr)
+{
+    QJsonObject obj;
+    obj["index"] = xvtr.index;
+    obj["order"] = xvtr.order;
+    obj["name"] = xvtr.name;
+    obj["rf_freq_mhz"] = xvtr.rfFreq;
+    obj["if_freq_mhz"] = xvtr.ifFreq;
+    obj["offset_mhz"] = xvtr.rfFreq - xvtr.ifFreq;
+    obj["lo_error"] = xvtr.loError;
+    obj["rx_gain"] = xvtr.rxGain;
+    obj["max_power"] = xvtr.maxPower;
+    obj["rx_only"] = xvtr.rxOnly;
+    obj["is_valid"] = xvtr.isValid;
+    obj["has_is_valid"] = xvtr.hasIsValid;
+    return obj;
+}
+
 QJsonObject clientInfoToJson(quint32 handle,
                              quint32 ourHandle,
                              quint32 txHandle,
@@ -2091,6 +2109,19 @@ void RadioModel::onStatusReceived(const QString& object,
             int idx = m.captured(1).toInt();
             // "in_use=0" means the xvtr was removed
             if (kvs.contains("in_use") && kvs["in_use"] == "0") {
+                const auto existing = m_xvtrList.constFind(idx);
+                if (existing != m_xvtrList.cend()) {
+                    qCDebug(lcProtocol).noquote().nospace()
+                        << "RadioModel: xvtr removed idx=" << idx
+                        << " name=" << (existing->name.isEmpty() ? QStringLiteral("(unnamed)") : existing->name)
+                        << " order=" << existing->order
+                        << " is_valid=" << existing->isValid
+                        << " has_is_valid=" << existing->hasIsValid;
+                } else {
+                    qCDebug(lcProtocol).noquote().nospace()
+                        << "RadioModel: xvtr removed idx=" << idx
+                        << " name=(unknown)";
+                }
                 m_xvtrList.remove(idx);
                 emit infoChanged();
                 return;
@@ -2105,7 +2136,23 @@ void RadioModel::onStatusReceived(const QString& object,
             if (kvs.contains("rx_gain"))   x.rxGain   = kvs["rx_gain"].toDouble();
             if (kvs.contains("max_power")) x.maxPower = kvs["max_power"].toDouble();
             if (kvs.contains("rx_only"))   x.rxOnly   = kvs["rx_only"] == "1";
-            if (kvs.contains("is_valid"))  x.isValid  = kvs["is_valid"] == "1";
+            const bool statusHasIsValid = kvs.contains("is_valid");
+            if (statusHasIsValid) {
+                x.isValid = kvs["is_valid"] == "1";
+                x.hasIsValid = true;
+            }
+            qCDebug(lcProtocol).noquote().nospace()
+                << "RadioModel: xvtr status idx=" << x.index
+                << " name=" << (x.name.isEmpty() ? QStringLiteral("(unnamed)") : x.name)
+                << " order=" << x.order
+                << " rf_mhz=" << x.rfFreq
+                << " if_mhz=" << x.ifFreq
+                << " offset_mhz=" << (x.rfFreq - x.ifFreq)
+                << " rx_only=" << x.rxOnly
+                << " max_power=" << x.maxPower
+                << " is_valid=" << x.isValid
+                << " status_has_is_valid=" << statusHasIsValid
+                << " has_is_valid=" << x.hasIsValid;
             emit infoChanged();
         }
         return;
@@ -3439,6 +3486,11 @@ QJsonObject RadioModel::troubleshootingSnapshot() const
     for (auto it = m_panadapters.cbegin(); it != m_panadapters.cend(); ++it)
         panadapters.append(panToJson(it.value(), m_activePanId));
     snapshot["panadapters"] = panadapters;
+
+    QJsonArray xvtrs;
+    for (auto it = m_xvtrList.cbegin(); it != m_xvtrList.cend(); ++it)
+        xvtrs.append(xvtrToJson(it.value()));
+    snapshot["xvtrs"] = xvtrs;
 
     auto txBandInfoToJson = [](const TxBandInfo& band) {
         QJsonObject obj;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -571,6 +571,7 @@ public:
         double  maxPower{10.0};
         bool    rxOnly{false};
         bool    isValid{false};
+        bool    hasIsValid{false};
     };
     const QMap<int, XvtrInfo>& xvtrList() const { return m_xvtrList; }
 

--- a/src/models/XvtrPolicy.cpp
+++ b/src/models/XvtrPolicy.cpp
@@ -89,26 +89,41 @@ bool isWaterfallTileOutsidePan(double lowMhz, double highMhz, double panCenterMh
     return std::abs(tileCenter(lowMhz, highMhz) - panCenterMhz) > bw;
 }
 
-bool waterfallTileMatchesTransverterOffset(double lowMhz, double highMhz,
-                                           double panCenterMhz,
-                                           const QVector<Transverter>& xvtrs)
+WaterfallTileMatch matchWaterfallTileTransverterOffset(double lowMhz, double highMhz,
+                                                       double panCenterMhz,
+                                                       const QVector<Transverter>& xvtrs)
 {
+    WaterfallTileMatch match;
     const double bw = tileBandwidth(lowMhz, highMhz);
     if (bw <= 0.0 || !isWaterfallTileOutsidePan(lowMhz, highMhz, panCenterMhz))
-        return false;
+        return match;
 
-    const double observedOffset = panCenterMhz - tileCenter(lowMhz, highMhz);
-    const double toleranceMhz = std::max(bw, 0.25);
+    match.observedOffsetMhz = panCenterMhz - tileCenter(lowMhz, highMhz);
+    match.toleranceMhz = std::max(bw, 0.25);
     for (const auto& xvtr : xvtrs) {
         if (!xvtr.isValid || xvtr.rfFreqMhz <= 0.0 || xvtr.ifFreqMhz <= 0.0)
             continue;
 
         const double expectedOffset = xvtr.rfFreqMhz - xvtr.ifFreqMhz;
-        if (std::abs(observedOffset - expectedOffset) <= toleranceMhz)
-            return true;
+        if (std::abs(match.observedOffsetMhz - expectedOffset) <= match.toleranceMhz) {
+            match.matched = true;
+            match.index = xvtr.index;
+            match.order = xvtr.order;
+            match.name = xvtr.name;
+            match.expectedOffsetMhz = expectedOffset;
+            return match;
+        }
     }
 
-    return false;
+    return match;
+}
+
+bool waterfallTileMatchesTransverterOffset(double lowMhz, double highMhz,
+                                           double panCenterMhz,
+                                           const QVector<Transverter>& xvtrs)
+{
+    return matchWaterfallTileTransverterOffset(
+        lowMhz, highMhz, panCenterMhz, xvtrs).matched;
 }
 
 WaterfallTileRange mapWaterfallTileRange(double lowMhz, double highMhz,

--- a/src/models/XvtrPolicy.h
+++ b/src/models/XvtrPolicy.h
@@ -27,10 +27,24 @@ struct WaterfallTileRange {
     bool   shifted{false};
 };
 
+struct WaterfallTileMatch {
+    bool    matched{false};
+    int     index{-1};
+    int     order{-1};
+    QString name;
+    double  observedOffsetMhz{0.0};
+    double  expectedOffsetMhz{0.0};
+    double  toleranceMhz{0.0};
+};
+
 BandStackKeyResult resolveBandStackKey(const QString& bandName,
                                        const QVector<Transverter>& xvtrs);
 
 bool isWaterfallTileOutsidePan(double lowMhz, double highMhz, double panCenterMhz);
+
+WaterfallTileMatch matchWaterfallTileTransverterOffset(double lowMhz, double highMhz,
+                                                       double panCenterMhz,
+                                                       const QVector<Transverter>& xvtrs);
 
 bool waterfallTileMatchesTransverterOffset(double lowMhz, double highMhz,
                                            double panCenterMhz,

--- a/tests/xvtr_policy_test.cpp
+++ b/tests/xvtr_policy_test.cpp
@@ -129,6 +129,25 @@ void testXvtrWaterfallMapsIfToRfBands()
         const QVector<XvtrPolicy::Transverter> xvtrs = {
             xvtr(12, 3, "2m", 144.0, 28.0),
         };
+        const auto match = XvtrPolicy::matchWaterfallTileTransverterOffset(
+            28.125, 28.625, 144.375, xvtrs);
+        report("2m XVTR offset match reports diagnostic details",
+               match.matched &&
+                   match.index == 12 &&
+                   match.order == 3 &&
+                   match.name == "2m" &&
+                   near(match.observedOffsetMhz, 116.0) &&
+                   near(match.expectedOffsetMhz, 116.0) &&
+                   near(match.toleranceMhz, 0.5),
+               QStringLiteral("matched=%1 idx=%2 order=%3 observed=%4 expected=%5 tolerance=%6")
+                   .arg(match.matched)
+                   .arg(match.index)
+                   .arg(match.order)
+                   .arg(match.observedOffsetMhz)
+                   .arg(match.expectedOffsetMhz)
+                   .arg(match.toleranceMhz)
+                   .toStdString());
+
         const auto mapped = XvtrPolicy::mapWaterfallTileRange(
             28.125, 28.625, 144.375, xvtrs, false);
         expectRange("2m XVTR maps IF waterfall range into RF range",


### PR DESCRIPTION
## Summary

This is stacked on #1960 and adds the logging/diagnostic layer for the XVTR waterfall work.

- Log parsed XVTR status with index, order, name, RF/IF frequencies, computed offset, rx-only, max power, `is_valid`, whether the current status contained `is_valid`, and whether this session has ever seen `is_valid`.
- Add a raw-command-debug-gated `WaterfallXVTR` decision log for out-of-pan waterfall rows. It is rate-limited to one line per stream/pan/reason every 20 seconds, with immediate output when the decision state changes.
- Log band-stack XVTR selection/refusal with the chosen Flex `band=` key and available XVTR candidates.
- Add parsed XVTR state to the troubleshooting snapshot and issue summary.
- Expose XVTR offset match details from `XvtrPolicy` so diagnostics and tests share the same decision metadata.

## Why

The recent XVTR/waterfall debugging showed that raw protocol logs were not enough by themselves. We could see `xvtr ... is_valid=...` when command logging was enabled, but we could not easily answer:

- Did the app parse `is_valid`, or was the key absent?
- Which XVTR entry and setup order did the band switch use?
- Did a waterfall row shift because the IF/RF offset matched, because an XVT antenna fallback authorized it, or did it stay unchanged because there was no XVTR evidence?
- What XVTR state was present in a troubleshooting snapshot after the fact?

This PR keeps the noisy waterfall decision logging behind the existing raw command/debug gate, while making low-volume XVTR status and support snapshot state easier to inspect.

## Validation

- `cmake -S . -B build -G Ninja`
- `cmake --build build --parallel 10`
- `./build/xvtr_policy_test`
- `ctest --test-dir build --output-on-failure -j10` reports no registered tests in this build tree

## Stack

Parent PR: #1960

Logging-only comparison: https://github.com/jensenpat/AetherSDR/compare/aether/xvtr-policy-regression-tests...aether/xvtr-diagnostic-logging

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
