### PR TITLE
fix: preserve rtty_mark_default when radio resets mark on band change

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2738,6 +2738,8 @@ void RadioModel::handleRadioStatus(const QMap<QString, QString>& kvs)
     }
     if (kvs.contains("rtty_mark_default")) {
         m_rttyMarkDefault = kvs["rtty_mark_default"].toInt();
+        for (SliceModel* s : m_slices)
+            s->setRttyMarkDefault(m_rttyMarkDefault);
         changed = true;
     }
     if (kvs.contains("tnf_enabled")) {
@@ -2855,6 +2857,7 @@ void RadioModel::handleSliceStatus(int id,
             return;
 
         s = new SliceModel(id, this);
+        s->setRttyMarkDefault(m_rttyMarkDefault);
         // Forward slice commands to the radio
         connect(s, &SliceModel::commandReady, this, [this](const QString& cmd){
             sendCmd(cmd);

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -721,6 +721,13 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
     }
     if (kvs.contains("rtty_mark")) {
         int v = kvs["rtty_mark"].toInt();
+        // The radio resets rtty_mark to 2125 on band changes regardless of the
+        // configured rtty_mark_default. If we know the default differs, push it
+        // back so the slice stays at the user's configured mark frequency.
+        if (v == 2125 && m_rttyMarkDefault != 2125) {
+            v = m_rttyMarkDefault;
+            sendCommand(QString("slice set %1 rtty_mark=%2").arg(m_id).arg(v));
+        }
         if (m_rttyMark != v) { m_rttyMark = v; emit rttyMarkChanged(v); }
     }
     if (kvs.contains("rtty_shift")) {

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -297,6 +297,9 @@ void SliceModel::setDaxChannel(int ch)
 void SliceModel::setRttyMark(int hz)
 {
     if (m_rttyMark == hz) return;
+    // Track explicit user override so applyStatus() won't fight an intentional
+    // choice of 2125 when rtty_mark_default is non-standard.
+    m_rttyMarkUserOverride = (hz == 2125 && m_rttyMarkDefault != 2125);
     m_rttyMark = hz;
     sendCommand(QString("slice set %1 rtty_mark=%2").arg(m_id).arg(hz));
     emit rttyMarkChanged(hz);
@@ -496,6 +499,9 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
         if (std::abs(m_frequency - f) > 1e-9) {
             m_frequency = f;
             freqChanged = true;
+            // Band change clears any user override so rtty_mark_default is
+            // restored if the radio resets the mark in the same status update.
+            m_rttyMarkUserOverride = false;
         }
     }
     if (kvs.contains("mode")) {
@@ -722,9 +728,9 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
     if (kvs.contains("rtty_mark")) {
         int v = kvs["rtty_mark"].toInt();
         // The radio resets rtty_mark to 2125 on band changes regardless of the
-        // configured rtty_mark_default. If we know the default differs, push it
-        // back so the slice stays at the user's configured mark frequency.
-        if (v == 2125 && m_rttyMarkDefault != 2125) {
+        // configured rtty_mark_default. If we know the default differs and the
+        // user has not explicitly chosen 2125, push the default back.
+        if (v == 2125 && m_rttyMarkDefault != 2125 && !m_rttyMarkUserOverride) {
             v = m_rttyMarkDefault;
             sendCommand(QString("slice set %1 rtty_mark=%2").arg(m_id).arg(v));
         }

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -288,6 +288,7 @@ private:
     int     m_daxChannel{0};
     int     m_rttyMark{2125};
     int     m_rttyMarkDefault{2125};
+    bool    m_rttyMarkUserOverride{false};
     int     m_rttyShift{170};
     int     m_diglOffset{2210};
     int     m_diguOffset{1500};

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -72,7 +72,8 @@ public:
     int     stepHz()      const { return m_stepHz; }
     QVector<int> stepList() const { return m_stepList; }
     int     daxChannel()  const { return m_daxChannel; }
-    int     rttyMark()    const { return m_rttyMark; }
+    int     rttyMark()        const { return m_rttyMark; }
+    int     rttyMarkDefault() const { return m_rttyMarkDefault; }
     int     rttyShift()   const { return m_rttyShift; }
     int     diglOffset()  const { return m_diglOffset; }
     int     diguOffset()  const { return m_diguOffset; }
@@ -141,6 +142,8 @@ public:
     void setDaxChannel(int ch);
     void setRttyMark(int hz);
     void setRttyShift(int hz);
+    // Called by RadioModel when the radio's rtty_mark_default changes.
+    void setRttyMarkDefault(int hz) { m_rttyMarkDefault = hz; }
     void setDiglOffset(int hz);
     void setDiguOffset(int hz);
     void setTxSlice(bool on);
@@ -284,6 +287,7 @@ private:
     int     m_xitFreq{0};
     int     m_daxChannel{0};
     int     m_rttyMark{2125};
+    int     m_rttyMarkDefault{2125};
     int     m_rttyShift{170};
     int     m_diglOffset{2210};
     int     m_diguOffset{1500};


### PR DESCRIPTION
When rtty_mark_default is set to a non-standard value (e.g. 915 Hz), changing bands while in RTTY mode caused the slice rtty_mark to snap back to 2125 Hz. Audio channel offset and TX mark frequency were wrong until the user changed mode away from RTTY and back.

Root cause: the radio always resets a slice's rtty_mark to 2125 in the status broadcast that follows a band change, regardless of the configured rtty_mark_default. SliceModel::applyStatus() accepted this value blindly, overwriting the user's configured mark frequency.

Changes:

SliceModel: add m_rttyMarkDefault member (default 2125) and setRttyMarkDefault() setter. In applyStatus(), when rtty_mark=2125 arrives but m_rttyMarkDefault differs, push the correct value back to the radio with "slice set <id> rtty_mark=<default>" and update the local model to the default rather than the factory-reset value.

RadioModel: call s->setRttyMarkDefault(m_rttyMarkDefault) immediately after constructing a new SliceModel so the correct default is in place before the first applyStatus() call. Also propagate the value to all existing slices whenever the radio status updates rtty_mark_default.