### PR TITLE
[ux] Fix Flex compression meter derivation for 8000 series radios

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1118,6 +1118,16 @@ add_executable(xvtr_policy_test
 target_include_directories(xvtr_policy_test PRIVATE src)
 target_link_libraries(xvtr_policy_test PRIVATE Qt6::Core)
 
+add_executable(meter_model_test
+    tests/meter_model_test.cpp
+    src/models/MeterModel.cpp
+    src/core/LogManager.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(meter_model_test PRIVATE src)
+target_link_libraries(meter_model_test PRIVATE Qt6::Core)
+set_target_properties(meter_model_test PROPERTIES AUTOMOC ON)
+
 # Help guide search tests - needs QApplication + Widgets.
 add_executable(help_dialog_test
     tests/help_dialog_test.cpp

--- a/docs/tx-audio-signal-path.md
+++ b/docs/tx-audio-signal-path.md
@@ -102,7 +102,7 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 ┌─────────────────────────────┐
 │  Equalizer (8-band)         │  ◄── "eq txsc" command
 │  AFTEREQ (meter 27)         │  ◄── "Signal strength after the EQ"
-│  src=TX-, fps=20            │
+│  src=TX-, fps=20            │      Compression reference tap
 └─────────┬───────────────────┘
           │
           ▼
@@ -110,7 +110,7 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 │  Speech Processor           │  ◄── "transmit set speech_processor_enable/level"
 │  (Compander + Clipper)      │
 │  COMPPEAK (meter 28)        │  ◄── "Signal strength before CLIPPER (Compression)"
-│  src=TX-, fps=20            │      Used for P/CW applet compression gauge
+│  src=TX-, fps=20            │      Paired with AFTEREQ for compression gauge
 └─────────┬───────────────────┘
           │
           ▼
@@ -199,8 +199,8 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 | 24 | TX- | CODEC | dBFS | 10 | CODEC output (post mic gain) | — |
 | 25 | TX- | TXAGC | dBFS | 10 | Post AGC/fixed gain | — |
 | 26 | TX- | SC_MIC | dBFS | 10 | MIC output (PC audio entry point) | P/CW mic gauge (PC mic) |
-| 27 | TX- | AFTEREQ | dBFS | 20 | Post equalizer | — |
-| 28 | TX- | COMPPEAK | dBFS | 20 | Pre-clipper (compression) | P/CW compression gauge |
+| 27 | TX- | AFTEREQ | dBFS | 20 | Post equalizer / processor input reference | P/CW level and compression derivation |
+| 28 | TX- | COMPPEAK | dBFS | 20 | Processor/clipper-stage level tap | P/CW compression derivation |
 | 29 | TX- | SC_FILT_1 | dBFS | 20 | Post TX filter 1 | — |
 | 30 | TX- | ALC | dBFS | 10 | Post SW ALC (SSB peak) | P/CW ALC indicator |
 | 31 | TX- | RM_TX_AGC | dBFS | 10 | Post remote TX AGC | — |
@@ -221,6 +221,20 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
   VOX detection and P/CW mic level display.
 - **Meter IDs are dynamic**: The radio assigns meter IDs on connection. The IDs shown
   here are from one session — match by name, not by ID.
+- **Compression meter input**: AetherSDR derives the compression gauge only from
+  radio-provided `AFTEREQ` and `COMPPEAK` TX meters. Captures from the FLEX-8400M
+  show `COMPPEAK` as a dBFS level tap, not a ready-to-display gain-reduction
+  meter, so AetherSDR displays `max(0, COMPPEAK - AFTEREQ)` as a negative
+  right-to-left gauge value. If either meter is missing, the compression meter is
+  unavailable; it does not fall back to local PC mic level, `SC_MIC`, or a raw
+  `COMPPEAK` display.
+- **Compression display gating**: The compression gauge is hidden/zeroed when
+  PROC is off or tune/two-tone is active, because those states should not show
+  voice-correlated compressor activity.
+- **P/CW level display**: When `AFTEREQ` is available, AetherSDR uses it for the
+  P/CW level meter so the level and compression gauges share the same radio-side
+  meter cadence. Radios that do not expose `AFTEREQ` keep the existing hardware
+  mic or local PC mic level path for level display.
 - **Unit conversion**: dBm meters (FWDPWR) need watts = 10^(dBm/10)/1000.
   SWR is raw. degC/degF use raw/64.0f. Volts/Amps use raw/1024.0f.
 

--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -98,10 +98,14 @@ protected:
         p.setPen(QColor(0x20, 0x30, 0x40));
         p.drawRect(barX, barY, barW - 1, barH - 1);
 
+        const bool available = isEnabled();
+
         // Filled portion (animated)
         int fillW = static_cast<int>(m_smooth.value() * barW);
 
-        if (m_reversed) {
+        if (!available) {
+            // No fill for unavailable meters; the centered label carries state.
+        } else if (m_reversed) {
             // Reversed: bar fills from right to left, single color.
             // frac=1 (max) means empty, frac=0 (min) means full bar.
             int revFillW = barW - fillW;
@@ -134,7 +138,7 @@ protected:
         }
 
         // Peak-hold marker (thin white vertical line)
-        if (m_peakEnabled) {
+        if (available && m_peakEnabled) {
             float peakFrac = qBound(0.0f, (m_peakValue - m_min) / (m_max - m_min), 1.0f);
             int peakX = barX + static_cast<int>(peakFrac * barW);
             if (m_reversed) {
@@ -159,7 +163,8 @@ protected:
         for (const auto& tick : m_ticks) {
             float tf = (tick.value - m_min) / (m_max - m_min);
             int tx = barX + static_cast<int>(tf * barW);
-            QColor tickColor = (tick.value >= m_redStart) ? QColor(0xcc, 0x33, 0x33)
+            QColor tickColor = !available ? QColor(0x50, 0x58, 0x64)
+                             : (tick.value >= m_redStart) ? QColor(0xcc, 0x33, 0x33)
                              : (tick.value >= m_yellowStart) ? QColor(0x99, 0x88, 0x00)
                              : QColor(0xc8, 0xd8, 0xe8);
             p.setPen(tickColor);
@@ -175,10 +180,11 @@ protected:
         lblFont.setPixelSize(10);
         lblFont.setBold(true);
         p.setFont(lblFont);
-        p.setPen(QColor(0xff, 0xff, 0xff));
+        p.setPen(available ? QColor(0xff, 0xff, 0xff) : QColor(0x70, 0x78, 0x84));
         const QFontMetrics lfm(lblFont);
-        int labelW = lfm.horizontalAdvance(m_label);
-        p.drawText((w - labelW) / 2, barY + barH / 2 + lfm.ascent() / 2 - 1, m_label);
+        const QString label = available ? m_label : QStringLiteral("%1 N/A").arg(m_label);
+        int labelW = lfm.horizontalAdvance(label);
+        p.drawText((w - labelW) / 2, barY + barH / 2 + lfm.ascent() / 2 - 1, label);
     }
 
 private:

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2283,6 +2283,24 @@ MainWindow::MainWindow(QWidget* parent)
             m_appletPanel->sMeterWidget(), &SMeterWidget::setMicMeters);
     connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
             m_appletPanel->sMeterWidget(), &SMeterWidget::setTransmitting);
+    auto updateCompressionUiAvailability = [this]() {
+        const auto& meterModel = m_radioModel.meterModel();
+        const auto& txModel = m_radioModel.transmitModel();
+        const bool available = meterModel.hasCompressionMeterValue()
+            && txModel.speechProcessorEnable()
+            && !txModel.isTuning();
+        m_appletPanel->sMeterWidget()->setCompressionAvailable(available);
+        m_appletPanel->phoneCwApplet()->setCompressionAvailable(available);
+        if (!available)
+            m_appletPanel->phoneCwApplet()->updateCompression(0.0f);
+    };
+    connect(&m_radioModel.meterModel(), &MeterModel::compressionMeterAvailabilityChanged,
+            this, updateCompressionUiAvailability);
+    connect(&m_radioModel.transmitModel(), &TransmitModel::micStateChanged,
+            this, updateCompressionUiAvailability);
+    connect(&m_radioModel.transmitModel(), &TransmitModel::tuneChanged,
+            this, updateCompressionUiAvailability);
+    updateCompressionUiAvailability();
 
     // ── Tuner: MeterModel TX meters → TunerApplet gauges ────────────────
     // Use TGXL-specific meters when available (disambiguated from PGXL by handle)
@@ -2753,21 +2771,23 @@ MainWindow::MainWindow(QWidget* parent)
 #endif
 
     // ── P/CW applet: mic meters + ALC meter + model ────────────────────────
-    // Suppress radio CODEC meters when mic_selection=PC (they just show noise).
-    // Client-side metering handles PC mic display below.
-    // Compression gauge: full 20fps meter rate, gated on speech_processor_enable.
+    // Prefer the radio's AFTEREQ TX-chain meter for level when present so
+    // level and compression share the same radio-side meter cadence.
+    // Fall back to client-side PC metering only on radios without AFTEREQ.
+    // Compression gauge: full 20fps meter rate, gated on PROC and not shown during tune.
     {
         connect(&m_radioModel.meterModel(), &MeterModel::micMetersChanged,
                 this, [this](float micLevel, float compLevel, float micPeak, float compPeak) {
-            // Mic level: hardware mic uses radio meters, PC uses client-side
-            if (m_radioModel.transmitModel().micSelection() != "PC")
+            const bool hasRadioTxLevel = m_radioModel.meterModel().hasRadioTxAudioLevelValue();
+            if (hasRadioTxLevel || m_radioModel.transmitModel().micSelection() != "PC")
                 m_appletPanel->phoneCwApplet()->updateMeters(micLevel, compLevel, micPeak, 0.0f);
 
-            // Compression gauge: full rate (20fps from radio), gated on PROC
-            {
-                float comp = m_radioModel.transmitModel().speechProcessorEnable() ? compPeak : 0.0f;
-                m_appletPanel->phoneCwApplet()->updateCompression(comp);
-            }
+            const auto& txModel = m_radioModel.transmitModel();
+            const bool showCompression = m_radioModel.meterModel().hasCompressionMeterValue()
+                && txModel.speechProcessorEnable()
+                && !txModel.isTuning();
+            const float comp = showCompression ? compPeak : 0.0f;
+            m_appletPanel->phoneCwApplet()->updateCompression(comp);
         });
     }
     connect(&m_radioModel.meterModel(), &MeterModel::alcChanged,
@@ -2780,6 +2800,7 @@ MainWindow::MainWindow(QWidget* parent)
         connect(m_audio, &AudioEngine::pcMicLevelChanged,
                 this, [this, heldLevel, heldPeak](float peakDb, float avgDb) {
             if (m_radioModel.transmitModel().micSelection() != "PC") return;
+            if (m_radioModel.meterModel().hasRadioTxAudioLevelValue()) return;
             constexpr float kDecayPerUpdate = 1.0f;  // ~20 dB/sec at 20 updates/sec
             // Level: fast attack, slow decay
             if (avgDb > *heldLevel)
@@ -9276,6 +9297,17 @@ void MainWindow::registerShortcutActions()
                 m_radioModel.transmitModel().stopTune();
             else
                 m_radioModel.transmitModel().startTune();
+        });
+    m_shortcutManager.registerAction("two_tone_tune", "Two-Tone Tune", "TX",
+        QKeySequence(), [this]() {
+            if (!m_radioModel.isConnected()) return;
+            auto& tx = m_radioModel.transmitModel();
+            if (tx.isTuning()) {
+                tx.stopTune();
+            } else {
+                tx.setTuneMode(QStringLiteral("two_tone"));
+                tx.startTune();
+            }
         });
 
     // ── Audio ───────────────────────────────────────────────────────────

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -137,8 +137,9 @@ void PhoneCwApplet::buildPhonePanel()
     m_compGauge = new HGauge(-25.0f, 0.0f, 1.0f, "Compression", "",
         {{-25, "-25dB"}, {-20, "-20"}, {-15, "-15"}, {-10, "-10"}, {-5, "-5"}, {0, "0"}});
     m_compGauge->setReversed(true);
+    m_compGauge->setEnabled(false);
     m_compGauge->setAccessibleName("Compression gauge");
-    m_compGauge->setAccessibleDescription("Speech compression amount in dB");
+    m_compGauge->setAccessibleDescription("Compression meter unavailable until AFTEREQ and COMPPEAK data are received");
     vbox->addWidget(m_compGauge);
     vbox->addSpacing(4);
 
@@ -721,10 +722,26 @@ void PhoneCwApplet::updateMeters(float micLevel, float compLevel,
 
 void PhoneCwApplet::updateCompression(float compPeak)
 {
-    // compPeak is raw dBFS from COMPPEAK meter.
-    // Silence (-150) → 0. Speech (-10..+14) → clamp to -25..0 range.
-    float gauge = (compPeak > -30.0f) ? qBound(-25.0f, compPeak, 0.0f) : 0.0f;
-    m_compGauge->setValue(gauge);
+    if (!m_compGauge->isEnabled()) {
+        m_compGauge->setValue(0.0f);
+        return;
+    }
+
+    // MeterModel emits derived compressor reduction normalized for this gauge:
+    // 0 = none, negative = active compression.
+    m_compGauge->setValue(qBound(-25.0f, compPeak, 0.0f));
+}
+
+void PhoneCwApplet::setCompressionAvailable(bool available)
+{
+    m_compGauge->setEnabled(available);
+    if (!available)
+        m_compGauge->setValue(0.0f);
+
+    m_compGauge->setAccessibleDescription(
+        available
+            ? QStringLiteral("Speech compression amount in dB")
+            : QStringLiteral("Compression meter unavailable until AFTEREQ and COMPPEAK data are received"));
 }
 
 void PhoneCwApplet::updateAlc(float alc)

--- a/src/gui/PhoneCwApplet.h
+++ b/src/gui/PhoneCwApplet.h
@@ -32,6 +32,7 @@ public slots:
     void updateMeters(float micLevel, float compLevel,
                       float micPeak, float compPeak);
     void updateCompression(float compPeak);
+    void setCompressionAvailable(bool available);
 
     // CW meter (ALC 0–100)
     void updateAlc(float alc);

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -96,15 +96,28 @@ void SMeterWidget::setMicMeters(float micLevel, float compLevel, float micPeak, 
     Q_UNUSED(micLevel);
     Q_UNUSED(compLevel);
     m_micLevel = micPeak;
-    // compPeak is raw dBFS from COMPPEAK. Silence gate at -30.
-    const float comp = (compPeak > -30.0f) ? qBound(-25.0f, compPeak, 0.0f) : 0.0f;
-    m_compLevel = comp;
+    if (m_compressionAvailable) {
+        // MeterModel emits derived compressor reduction normalized for this gauge:
+        // 0 = none, negative = active compression.
+        m_compLevel = qBound(-25.0f, compPeak, 0.0f);
+    }
 
     updateNeedleTarget();
 
     if (m_transmitting && (m_txMode == TxMode::Level || m_txMode == TxMode::Compression)) {
         update();
     }
+}
+
+void SMeterWidget::setCompressionAvailable(bool available)
+{
+    if (m_compressionAvailable == available) return;
+    m_compressionAvailable = available;
+    if (!available)
+        m_compLevel = 0.0f;
+
+    updateNeedleTarget();
+    update();
 }
 
 void SMeterWidget::setTransmitting(bool tx)
@@ -269,6 +282,8 @@ float SMeterWidget::txValueToFraction(float value) const
         // -40 to +5
         return qBound(0.0f, (value + 40.0f) / 45.0f, 1.0f);
     case TxMode::Compression:
+        if (!m_compressionAvailable)
+            return 1.0f;
         // Gain reduction: 0 = none, -25 = heavy compression
         return qBound(0.0f, (value + 25.0f) / 25.0f, 1.0f);
     }
@@ -281,7 +296,7 @@ float SMeterWidget::currentTxValue() const
     case TxMode::Power:       return m_txPower;
     case TxMode::SWR:         return m_txSwr;
     case TxMode::Level:       return m_micLevel;
-    case TxMode::Compression: return m_compLevel;
+    case TxMode::Compression: return m_compressionAvailable ? m_compLevel : 0.0f;
     }
     return 0.0f;
 }
@@ -609,7 +624,11 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         case TxMode::Power:       valText = QString("%1 W").arg(m_txPower, 0, 'f', 0); break;
         case TxMode::SWR:         valText = QString("%1").arg(m_txSwr, 0, 'f', 1); break;
         case TxMode::Level:       valText = QString("%1 dB").arg(m_micLevel, 0, 'f', 0); break;
-        case TxMode::Compression: valText = QString("%1 dB").arg(m_compLevel, 0, 'f', 0); break;
+        case TxMode::Compression:
+            valText = m_compressionAvailable
+                ? QString("%1 dB").arg(m_compLevel, 0, 'f', 0)
+                : QStringLiteral("N/A");
+            break;
         }
         p.setPen(QColor(0xc8, 0xd8, 0xe8));
         p.drawText(w - vfm.horizontalAdvance(valText) - 6, topY, valText);

--- a/src/gui/SMeterWidget.h
+++ b/src/gui/SMeterWidget.h
@@ -42,6 +42,7 @@ public slots:
 
     // Update mic/compression meter values.
     void setMicMeters(float micLevel, float compLevel, float micPeak, float compPeak);
+    void setCompressionAvailable(bool available);
 
     // Switch between RX and TX needle source.
     void setTransmitting(bool tx);
@@ -87,6 +88,7 @@ private:
     float   m_txSwr{1.0f};
     float   m_micLevel{-50.0f};
     float   m_compLevel{0.0f};
+    bool    m_compressionAvailable{false};
 
     // Mode state
     TxMode  m_txMode{TxMode::Power};

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -10,6 +10,18 @@ namespace AetherSDR {
 
 namespace {
 
+float compressionReductionForGauge(float afterEqDbfs, float compPeakDbfs)
+{
+    // FLEX-8400M captures show COMPPEAK is a dBFS level tap at the speech
+    // processor/clipper stage, while AFTEREQ is the processor input reference.
+    // SmartSDR-style compression tracks the lift through that stage:
+    //   reduction = COMPPEAK - AFTEREQ
+    // The gauge is reversed and uses negative values internally:
+    //   0 = none, -25 = heavy.
+    const float reduction = qMax(0.0f, compPeakDbfs - afterEqDbfs);
+    return -qBound(0.0f, reduction, 25.0f);
+}
+
 QJsonObject meterToJson(const MeterDef& def, bool hasValue, float value)
 {
     QJsonObject obj;
@@ -78,9 +90,9 @@ void MeterModel::defineMeter(const MeterDef& def)
         m_swrIdx = def.index;
     else if (def.name == "MICPEAK")
         m_micPeakIdx = def.index;
-    else if (def.name == "COMPPEAK")
+    else if (def.source.startsWith("TX") && def.name == "COMPPEAK")
         m_compPeakIdx = def.index;
-    else if (def.name == "AFTEREQ")
+    else if (def.source.startsWith("TX") && def.name == "AFTEREQ")
         m_afterEqIdx = def.index;
     else if (def.name == "MIC")
         m_micLevelIdx = def.index;
@@ -134,8 +146,18 @@ void MeterModel::removeMeter(int index)
     if (index == m_fwdPwrIdx)   m_fwdPwrIdx = -1;
     if (index == m_swrIdx)      m_swrIdx = -1;
     if (index == m_micPeakIdx)   m_micPeakIdx = -1;
-    if (index == m_compPeakIdx)  m_compPeakIdx = -1;
-    if (index == m_afterEqIdx)   m_afterEqIdx = -1;
+    if (index == m_compPeakIdx) {
+        m_compPeakIdx = -1;
+        m_compPeak = 0.0f;
+        m_hasCompPeakLevel = false;
+        setCompressionMeterAvailable(false);
+    }
+    if (index == m_afterEqIdx) {
+        m_afterEqIdx = -1;
+        m_compPeak = 0.0f;
+        m_hasAfterEqLevel = false;
+        setCompressionMeterAvailable(false);
+    }
     if (index == m_micLevelIdx)  m_micLevelIdx = -1;
     if (index == m_compLevelIdx) m_compLevelIdx = -1;
     if (index == m_alcIdx)       m_alcIdx = -1;
@@ -158,6 +180,36 @@ float MeterModel::convertRaw(const MeterDef& def, qint16 raw) const
     if (def.unit == "degF" || def.unit == "degC")
         return static_cast<float>(raw) / 64.0f;
     return static_cast<float>(raw);
+}
+
+void MeterModel::setCompressionMeterAvailable(bool available)
+{
+    if (m_hasCompPeakValue == available) return;
+    m_hasCompPeakValue = available;
+    emit compressionMeterAvailabilityChanged(available);
+}
+
+bool MeterModel::updateCompressionReduction()
+{
+    if (!m_hasAfterEqLevel || !m_hasCompPeakLevel) {
+        m_compPeak = 0.0f;
+        setCompressionMeterAvailable(false);
+        return false;
+    }
+
+    m_compPeak = compressionReductionForGauge(m_afterEqLevel, m_compPeakLevel);
+    setCompressionMeterAvailable(true);
+    return true;
+}
+
+float MeterModel::displayedMicLevel() const
+{
+    return m_hasAfterEqLevel ? m_afterEqLevel : m_micLevel;
+}
+
+float MeterModel::displayedMicPeak() const
+{
+    return m_hasAfterEqLevel ? m_afterEqLevel : m_micPeak;
 }
 
 bool MeterModel::hasRecentTxMeters(qint64 maxAgeMs) const
@@ -231,23 +283,17 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
         } else if (idx == m_micPeakIdx) {
             m_micPeak = v;
             micChanged = true;
-        } else if (idx == m_afterEqIdx) {
-            // Smooth AFTEREQ to reduce async timing noise with COMPPEAK
-            constexpr float kEqAlpha = 0.3f;
-            m_afterEq = (m_afterEq < -140.0f) ? v : kEqAlpha * v + (1.0f - kEqAlpha) * m_afterEq;
         } else if (idx == m_compPeakIdx) {
-            // COMPPEAK: raw dBFS output level from the radio's compressor.
-            // Smooth it, then compute gain reduction = output - input (negative when compressing).
-            constexpr float kAlpha = 0.3f;
-            m_compPeakRaw = (m_compPeakRaw < -140.0f) ? v : kAlpha * v + (1.0f - kAlpha) * m_compPeakRaw;
-
-            // Gain reduction = compressor output - compressor input.
-            // Both must be valid (> -140 dBFS) for a meaningful result.
-            if (m_afterEq > -140.0f && m_compPeakRaw > -140.0f) {
-                m_compPeak = m_compPeakRaw - m_afterEq;  // 0 = no reduction, negative = compressing
-            } else {
-                m_compPeak = 0.0f;  // silence — no meaningful reduction to display
-            }
+            // COMPPEAK is a dBFS level tap. Pair it with AFTEREQ to derive
+            // SmartSDR-style compression reduction.
+            m_compPeakLevel = v;
+            m_hasCompPeakLevel = true;
+            updateCompressionReduction();
+            micChanged = true;
+        } else if (idx == m_afterEqIdx) {
+            m_afterEqLevel = v;
+            m_hasAfterEqLevel = true;
+            updateCompressionReduction();
             micChanged = true;
         } else if (idx == m_micLevelIdx) {
             m_micLevel = v;
@@ -290,7 +336,8 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
     if (txChanged)
         emit txMetersChanged(m_fwdPower, m_swr);
     if (micChanged)
-        emit micMetersChanged(m_micLevel, m_compLevel, m_micPeak, m_compPeak);
+        emit micMetersChanged(displayedMicLevel(), m_compLevel,
+                              displayedMicPeak(), m_compPeak);
     if (alcChanged)
         emit this->alcChanged(m_alc);
     if (hwChanged)

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -77,13 +77,15 @@ public:
     qint64 txMetersUpdatedAtMs() const { return m_lastTxMeterUpdateMs; }
     bool hasRecentTxMeters(qint64 maxAgeMs) const;
 
-    // Convenience: mic peak level (dBFS) and compression peak (dB).
+    // Convenience: mic peak level (dBFS) and derived compression reduction (dB).
     float micPeak()  const { return m_micPeak; }
     float compPeak() const { return m_compPeak; }
+    bool hasCompressionMeterValue() const { return m_hasCompPeakValue; }
 
     // Convenience: instantaneous mic level and compression (non-peak).
     float micLevel() const { return m_micLevel; }
     float compLevel() const { return m_compLevel; }
+    bool hasRadioTxAudioLevelValue() const { return m_hasAfterEqLevel; }
 
     // Convenience: ALC level (0–100 scale, from TX "HWALC" meter).
     float alc() const { return m_alc; }
@@ -110,6 +112,9 @@ signals:
     void micMetersChanged(float micLevel, float compLevel,
                           float micPeak, float compPeak);
 
+    // Emitted when the radio-provided compression meter becomes usable/unusable.
+    void compressionMeterAvailabilityChanged(bool available);
+
     // Emitted when ALC meter changes (0–100 scale).
     void alcChanged(float alc);
 
@@ -125,6 +130,10 @@ signals:
 
 private:
     float convertRaw(const MeterDef& def, qint16 raw) const;
+    void setCompressionMeterAvailable(bool available);
+    bool updateCompressionReduction();
+    float displayedMicLevel() const;
+    float displayedMicPeak() const;
 
     QMap<int, MeterDef> m_defs;        // meter index → definition
     QMap<int, float>    m_values;      // meter index → last converted value
@@ -135,8 +144,8 @@ private:
     int m_fwdPwrIdx{-1};     // "FWDPWR"
     int m_swrIdx{-1};        // "SWR"
     int m_micPeakIdx{-1};    // "COD-" / "MICPEAK" (hardware mic)
-    int m_compPeakIdx{-1};   // "TX" / "COMPPEAK"
-    int m_afterEqIdx{-1};    // "TX" / "AFTEREQ" (compressor input)
+    int m_compPeakIdx{-1};   // "TX" / "COMPPEAK" (processor/clipper-stage dBFS tap)
+    int m_afterEqIdx{-1};    // "TX" / "AFTEREQ" (processor input reference)
     int m_micLevelIdx{-1};   // "COD-" / "MIC" (hardware mic RX level)
     int m_compLevelIdx{-1};  // "TX" / "COMP" (instantaneous)
     int m_alcIdx{-1};        // "TX" / "HWALC"
@@ -157,9 +166,12 @@ private:
     float m_swr{1.0f};
     qint64 m_lastTxMeterUpdateMs{0};
     float m_micPeak{-50.0f};
-    float m_compPeak{0.0f};      // computed gain reduction (displayed)
-    float m_compPeakRaw{-150.0f}; // smoothed COMPPEAK value
-    float m_afterEq{-150.0f};    // smoothed AFTEREQ (compressor input)
+    float m_compPeak{0.0f};       // derived compression reduction for the reversed gauge
+    bool m_hasCompPeakValue{false};
+    float m_afterEqLevel{-150.0f};
+    float m_compPeakLevel{-150.0f};
+    bool m_hasAfterEqLevel{false};
+    bool m_hasCompPeakLevel{false};
     float m_micLevel{-50.0f};
     float m_compLevel{0.0f};
     float m_alc{0.0f};

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -307,6 +307,22 @@ void TransmitModel::setTunePower(int power)
     emit commandReady(QString("transmit set tunepower=%1").arg(power));
 }
 
+void TransmitModel::setTuneMode(const QString& mode)
+{
+    QString normalized = mode.trimmed().toLower();
+    normalized.replace(' ', '_');
+    if (normalized != "single_tone" && normalized != "two_tone") {
+        qWarning() << "TransmitModel: unsupported tune mode" << mode;
+        return;
+    }
+
+    if (m_tuneMode != normalized) {
+        m_tuneMode = normalized;
+        emit stateChanged();
+    }
+    emit commandReady(QString("transmit set tune_mode=%1").arg(normalized));
+}
+
 void TransmitModel::startTune()
 {
     emit commandReady("transmit tune 1");

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -129,6 +129,7 @@ public:
     // ── Command methods (emit commandReady) ─────────────────────────────────
     void setRfPower(int power);
     void setTunePower(int power);
+    void setTuneMode(const QString& mode);
     void startTune();
     void stopTune();
     void setMox(bool on);

--- a/tests/meter_model_test.cpp
+++ b/tests/meter_model_test.cpp
@@ -1,0 +1,193 @@
+#include "models/MeterModel.h"
+
+#include <QCoreApplication>
+#include <QVector>
+
+#include <cmath>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) ++g_failed;
+}
+
+bool nearlyEqual(float a, float b)
+{
+    return std::fabs(a - b) < 0.01f;
+}
+
+qint16 rawDb(float db)
+{
+    return static_cast<qint16>(std::lround(db * 128.0f));
+}
+
+MeterDef txMeter(int index, const QString& name, const QString& unit = QStringLiteral("dBFS"))
+{
+    MeterDef def;
+    def.index = index;
+    def.source = "TX-";
+    def.name = name;
+    def.unit = unit;
+    def.low = -150.0;
+    def.high = 20.0;
+    return def;
+}
+
+void testAdjacentMetersDoNotSynthesizeCompression()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(22, "SC_MIC", "dBFS"));
+
+    model.updateValues({22}, {rawDb(-10.0f)});
+
+    report("adjacent TX audio meters do not synthesize compression",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testCompPeakRequiresAfterEq()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({28}, {rawDb(-40.0f)});
+
+    report("COMPPEAK alone does not expose compression",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testAfterEqRequiresCompPeak()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+
+    model.updateValues({27}, {rawDb(-60.0f)});
+
+    report("AFTEREQ alone does not expose compression",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testAfterEqFeedsDisplayedMicLevel()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(2, "MIC"));
+    model.defineMeter(txMeter(1, "MICPEAK"));
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+
+    bool seen = false;
+    float level = 0.0f;
+    float peak = 0.0f;
+    QObject::connect(&model, &MeterModel::micMetersChanged,
+                     [&seen, &level, &peak](float micLevel, float, float micPeak, float) {
+        seen = true;
+        level = micLevel;
+        peak = micPeak;
+    });
+
+    model.updateValues({2, 1}, {rawDb(-35.0f), rawDb(-20.0f)});
+    model.updateValues({27}, {rawDb(-18.0f)});
+
+    report("AFTEREQ feeds displayed TX level when present",
+           seen && model.hasRadioTxAudioLevelValue()
+           && nearlyEqual(level, -18.0f)
+           && nearlyEqual(peak, -18.0f));
+}
+
+void testCompPeakMinusAfterEqDrivesGauge()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({27, 28}, {rawDb(-60.0f), rawDb(-40.0f)});
+
+    report("COMPPEAK minus AFTEREQ maps to negative gauge value",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+}
+
+void testCompPeakAndAfterEqAreOrderIndependent()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({28}, {rawDb(-40.0f)});
+    model.updateValues({27}, {rawDb(-60.0f)});
+
+    report("compression derivation is order independent",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+}
+
+void testNoStageLiftShowsNoCompression()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({27, 28}, {rawDb(-30.0f), rawDb(-45.0f)});
+
+    report("COMPPEAK below AFTEREQ shows no compression",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testDerivedCompressionClampsToGaugeRange()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({27, 28}, {rawDb(-80.0f), rawDb(-40.0f)});
+
+    report("derived compression clamps to the compression gauge range",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -25.0f));
+}
+
+void testRemovingCompPeakMarksCompressionUnavailable()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+    model.updateValues({27, 28}, {rawDb(-60.0f), rawDb(-40.0f)});
+    model.removeMeter(28);
+
+    report("removing COMPPEAK marks compression unavailable",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testRemovingAfterEqMarksCompressionUnavailable()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+    model.updateValues({27, 28}, {rawDb(-60.0f), rawDb(-40.0f)});
+    model.removeMeter(27);
+
+    report("removing AFTEREQ marks compression unavailable",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    testAdjacentMetersDoNotSynthesizeCompression();
+    testCompPeakRequiresAfterEq();
+    testAfterEqRequiresCompPeak();
+    testAfterEqFeedsDisplayedMicLevel();
+    testCompPeakMinusAfterEqDrivesGauge();
+    testCompPeakAndAfterEqAreOrderIndependent();
+    testNoStageLiftShowsNoCompression();
+    testDerivedCompressionClampsToGaugeRange();
+    testRemovingCompPeakMarksCompressionUnavailable();
+    testRemovingAfterEqMarksCompressionUnavailable();
+
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

This PR fixes the Flex compression meter path so AetherSDR no longer displays raw `COMPPEAK` as if it were compression reduction. The new implementation requires the radio to provide both `AFTEREQ` and `COMPPEAK`, derives the displayed compression as `max(0, COMPPEAK - AFTEREQ)`, clamps the result to the existing 0..25 dB gauge range, and renders it as the negative right-to-left gauge value used by the existing UI.

It also adds a no-default-binding shortcut registry entry for `Two-Tone Tune`, improves unavailable-meter behavior, and documents the TX audio meter path findings so future work has the packet/API context in-tree.

## Background

The old compression meter behavior was painful because it treated a TX audio level tap as the displayed compressor value. On radios where `COMPPEAK` is reported as dBFS, this made the compression gauge appear active at idle or show values that looked like compression but were actually signal level. That created two failure modes:

- raw `COMPPEAK` could light the reversed compression gauge even when it was not a gain-reduction reading
- PC mic metering could move ahead of radio-side compression metering, making the level/compression relationship feel delayed or inconsistent

Local FlexLib/API review and on-air comparison against SmartSDR showed that, on the tested FLEX-8400M path, `COMPPEAK` is best treated as a processor/clipper-stage dBFS tap and `AFTEREQ` as the processor input/reference tap. SmartSDR-aligned compression is the lift between those two points, not raw `COMPPEAK`.

## What Changed

- Derive compression only from radio-provided TX `AFTEREQ` + `COMPPEAK`.
- Mark compression unavailable when either required meter is missing.
- Gate the visible compression gauge off when PROC is off or tune/two-tone tune is active.
- Prefer the radio's `AFTEREQ` meter for the P/CW level gauge when available, so level and compression share the same radio-side meter cadence.
- Keep the existing hardware mic / local PC mic level behavior as fallback for radios that do not expose `AFTEREQ`.
- Add unavailable/`N/A` handling for the compression UI instead of rendering misleading values.
- Add a `Two-Tone Tune` shortcut action with no default key binding.
- Add focused `meter_model_test` coverage for the compression derivation and availability rules.
- Document the relevant TX meter chain and the reason we key by source/name rather than hard-coded meter IDs.

## Important Behavior

For radios exposing `AFTEREQ` and `COMPPEAK`:

- `COMPPEAK` alone is not enough to display compression.
- `AFTEREQ` alone is not enough to display compression.
- `COMPPEAK - AFTEREQ <= 0` displays no compression.
- positive lift displays as a negative gauge value, clamped at `-25 dB`.
- PROC off and tune/two-tone tune force the visible compression meter to unavailable/zeroed.

For radios that do not expose `AFTEREQ`, this PR deliberately does not guess. The compression gauge remains unavailable rather than falling back to raw `COMPPEAK` or a PC mic value. A follow-up commit/PR will add validated 6000-series behavior once the FLEX-6600 traces are collected and compared against SmartSDR.

## Validation

- Verified on a FLEX-8400M against SmartSDR: AetherSDR compression now aligns with SmartSDR in PROC modes.
- Confirmed the idle/full-red behavior is gone because raw negative dBFS `COMPPEAK` is no longer displayed.
- Confirmed P/CW level and compression feel aligned on the FLEX-8400M after moving level display to radio-side `AFTEREQ`.
- Ran:
  - `cmake --build build --target meter_model_test --parallel 10`
  - `./build/meter_model_test`
  - `cmake --build build --target AetherSDR --parallel 10`
  - `git diff --check`

## Follow-Up

FLEX-6600 manifests show a different TX meter set: `COMPPEAK` is present, but `AFTEREQ` is not present in the supplied 4.0.1/4.1.5 manifests. A diagnostic Python meter script has been updated locally to compare candidate 6000-series formulas against SmartSDR, but that support is intentionally not included here. The next commit should add 6600 support only after those traces identify the correct source/name-based model.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
