### PR TITLE
[ux] Fix Flex compression meter derivation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1127,6 +1127,16 @@ add_executable(cw_sidetone_test
 target_include_directories(cw_sidetone_test PRIVATE src)
 target_link_libraries(cw_sidetone_test PRIVATE Qt6::Core)
 
+add_executable(meter_model_test
+    tests/meter_model_test.cpp
+    src/models/MeterModel.cpp
+    src/core/LogManager.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(meter_model_test PRIVATE src)
+target_link_libraries(meter_model_test PRIVATE Qt6::Core)
+set_target_properties(meter_model_test PROPERTIES AUTOMOC ON)
+
 # Help guide search tests - needs QApplication + Widgets.
 add_executable(help_dialog_test
     tests/help_dialog_test.cpp

--- a/docs/flex-meter-learnings.md
+++ b/docs/flex-meter-learnings.md
@@ -1,0 +1,131 @@
+# FlexRadio Meter Learnings
+
+This document captures the working conclusions from AetherSDR compression
+meter debugging across FLEX-8000 series radios and a FLEX-6600. It is meant to
+record capture-backed behavior, not API guesses.
+
+Related implementation context lives in `docs/tx-audio-signal-path.md`.
+
+## Core Rules
+
+- Match meters by `source` and `name`, not by numeric ID. Flex meter IDs are
+  assigned per session and differ by platform.
+- Do not synthesize compression when required radio meters are unavailable. A
+  missing compression input should make the compression meter unavailable, not
+  approximate a value from local mic audio.
+- This work preserves the existing Phone/CW gauge presentation. Availability is
+  tracked in `MeterModel`; the UI still receives `0 dB` when no valid
+  compression pair is available, rather than adding new N/A rendering.
+- `COMPPEAK` is a dBFS signal-level tap near the speech processor/clipper. It
+  is not, by itself, the SmartSDR compression display value.
+- The AetherSDR P/CW compression gauge is reversed: `0 dB` means no visible
+  compression and `-25 dB` means full-scale/heavy compression.
+
+## Compression Formulas
+
+### FLEX-8000 Series
+
+The 8000-series model validated against SmartSDR uses `AFTEREQ` and
+`COMPPEAK`:
+
+```text
+compression_lift_db = max(0, COMPPEAK - AFTEREQ)
+display_db = -clamp(compression_lift_db, 0, 25)
+```
+
+`AFTEREQ` is the processor input reference after the TX equalizer. `COMPPEAK`
+is the processor/clipper-stage tap. Both meters advertise `20 fps`, so the two
+inputs are naturally well matched for a derived compression display.
+
+If either meter is missing, AetherSDR should not show a derived compression
+value.
+
+### FLEX-6600 / 6000-Series Evidence
+
+The captured FLEX-6600 manifest does not expose `AFTEREQ`. The relevant TX
+meters observed were:
+
+- `CODEC` as TX meter `21`
+- `SC_MIC` as TX meter `22`
+- `COMPPEAK` as TX meter `23`
+
+The strongest candidate formula is:
+
+```text
+compression_lift_db = max(0, COMPPEAK - SC_MIC)
+display_db = -clamp(compression_lift_db, 0, 25)
+```
+
+Why this is the current model:
+
+- Raw `COMPPEAK` does not behave like the SmartSDR compression display. In
+  strong RF-output rows it often goes positive and would clamp to `0 dB`, just
+  when compression should be visible.
+- The opposite direction, `SC_MIC - COMPPEAK`, was effectively dead in the
+  user captures and stayed at `0 dB`.
+- `CODEC` is a plausible alternate reference, but in the 6600 captures it was
+  consistently about 3 dB lower than `SC_MIC`, which would make
+  `COMPPEAK - CODEC` read slightly heavier. `SC_MIC` is the better named
+  pre-processor mic-chain reference.
+
+The remaining engineering caution is timing. On the 6600, `SC_MIC` advertises
+`10 fps` while `COMPPEAK` advertises `20 fps`. AetherSDR guards the derived
+6600 compression value by requiring the reference sample and `COMPPEAK` sample
+to be close in time before marking the compression meter available.
+
+## Meter FPS Comparison
+
+| Meter | 8000 Series FPS | FLEX-6600 FPS | Notes |
+|---|---:|---:|---|
+| `MICPEAK` | 40 | 40 | Codec hardware mic peak |
+| `MIC` | 20 | 20 | Codec hardware mic average |
+| `HWALC` | 20 | 20 | Hardware ALC input |
+| `FWDPWR` | 20 | 20 | Forward RF power |
+| `REFPWR` | 20 | 20 | Reflected RF power |
+| `SWR` | 20 | 20 | RF SWR |
+| `PATEMP` | 0 | 0 | PA temperature |
+| `CODEC` | 10 | 10 | TX codec/mic-chain level |
+| `TXAGC` | 10 | Not seen | Present in 8000 captures |
+| `SC_MIC` | 10 | 10 | TX mic-chain tap; 6600 compression reference when `AFTEREQ` is absent |
+| `AFTEREQ` | 20 | Not present | 8000 compression reference |
+| `COMPPEAK` | 20 | 20 | Processor/clipper-stage tap |
+| `SC_FILT_1` | 20 | 10 | Post TX filter 1 |
+| `ALC` | 10 | 10 | SW ALC / SSB peak |
+| `RM_TX_AGC` | 10 | Not seen | Present in 8000 captures |
+| `PRE_WAVE_AGC` | Not seen | 10 | Present in 6600 manifest |
+| `SC_FILT_2` | 10 | 10 | Post TX filter 2 |
+| `PRE_WAVE` | Not seen | 10 | Present in 6600 manifest |
+| `B4RAMP` | 10 | 10 | Before ramp/key envelope |
+| `AFRAMP` | 10 | 10 | After ramp/key envelope |
+| `POST_P` | 10 | 10 | After processing, before power attenuation |
+| `GAIN` | Not seen | 10 | Present in 6600 manifest |
+| `ATTN_FPGA` | 10 | Not seen | Present in 8000 path documentation |
+
+## P/CW Level Meter
+
+The P/CW level meter is intentionally separate from the compression derivation.
+The FPS-testing experiment that drove voice/CW level strictly from `SC_MIC` was
+backed out. Current behavior keeps the existing UI path: hardware mic meters
+for hardware inputs, and client-side PC metering for PC audio. The Phone/CW
+level gauge and `HGauge`/`MeterSmoother` dampening are not changed by the
+compression work.
+
+`SC_MIC` is used as a 6000-series compression reference only when `AFTEREQ` is
+not present. It is not used as a strict replacement for the P/CW level meter.
+
+## Two-Tone Tune Observations
+
+Two-tone tune is useful for producing deterministic RF output and checking the
+radio-side signal path. During two-tone testing, the transmitted RF can contain
+only the radio-generated two-tone audio even while local PC mic meters move.
+For this reason, AetherSDR should not use local mic activity to drive the
+compression gauge.
+
+The current implementation does not add special UI behavior for two-tone tune;
+this note records why future work should be careful not to derive compression
+from local mic activity during radio-generated test tones.
+
+## Open Questions
+
+- Confirm the 6600 scale against SmartSDR with a capture that includes the
+  visible SmartSDR Comp reading at the same time as `SC_MIC` and `COMPPEAK`.

--- a/docs/tx-audio-signal-path.md
+++ b/docs/tx-audio-signal-path.md
@@ -3,6 +3,9 @@
 Documented from FLEX-8600 firmware v4.1.5 meter definitions.
 All meters are source `TX-` unless noted. Units are dBFS unless noted.
 
+For capture-backed 8000/6000-series compression formulas and FPS notes, see
+`docs/flex-meter-learnings.md`.
+
 ## Client-side TX DSP (PooDoo™ Audio, before the radio)
 
 Since v0.8.15 AetherSDR applies its own client-side DSP chain to the
@@ -102,7 +105,7 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 ┌─────────────────────────────┐
 │  Equalizer (8-band)         │  ◄── "eq txsc" command
 │  AFTEREQ (meter 27)         │  ◄── "Signal strength after the EQ"
-│  src=TX-, fps=20            │
+│  src=TX-, fps=20            │      Compression reference tap
 └─────────┬───────────────────┘
           │
           ▼
@@ -110,7 +113,7 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 │  Speech Processor           │  ◄── "transmit set speech_processor_enable/level"
 │  (Compander + Clipper)      │
 │  COMPPEAK (meter 28)        │  ◄── "Signal strength before CLIPPER (Compression)"
-│  src=TX-, fps=20            │      Used for P/CW applet compression gauge
+│  src=TX-, fps=20            │      Paired with AFTEREQ for compression gauge
 └─────────┬───────────────────┘
           │
           ▼
@@ -198,9 +201,9 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 | 11 | TX- | PATEMP | degC | 0 | PA temperature | Status bar |
 | 24 | TX- | CODEC | dBFS | 10 | CODEC output (post mic gain) | — |
 | 25 | TX- | TXAGC | dBFS | 10 | Post AGC/fixed gain | — |
-| 26 | TX- | SC_MIC | dBFS | 10 | MIC output (PC audio entry point) | P/CW mic gauge (PC mic) |
-| 27 | TX- | AFTEREQ | dBFS | 20 | Post equalizer | — |
-| 28 | TX- | COMPPEAK | dBFS | 20 | Pre-clipper (compression) | P/CW compression gauge |
+| 26 | TX- | SC_MIC | dBFS | 10 | MIC output (PC audio entry point) | P/CW mic gauge (PC mic); 6000-series compression reference |
+| 27 | TX- | AFTEREQ | dBFS | 20 | Post equalizer / processor input reference | 8000-series compression derivation |
+| 28 | TX- | COMPPEAK | dBFS | 20 | Processor/clipper-stage level tap | P/CW compression derivation |
 | 29 | TX- | SC_FILT_1 | dBFS | 20 | Post TX filter 1 | — |
 | 30 | TX- | ALC | dBFS | 10 | Post SW ALC (SSB peak) | P/CW ALC indicator |
 | 31 | TX- | RM_TX_AGC | dBFS | 10 | Post remote TX AGC | — |
@@ -221,6 +224,17 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
   VOX detection and P/CW mic level display.
 - **Meter IDs are dynamic**: The radio assigns meter IDs on connection. The IDs shown
   here are from one session — match by name, not by ID.
+- **Compression meter input**: AetherSDR derives the compression gauge from
+  radio-provided TX meters only. FLEX-8000 series radios use
+  `max(0, COMPPEAK - AFTEREQ)`. 6000-series radios that do not expose `AFTEREQ`
+  use `max(0, COMPPEAK - SC_MIC)`. `COMPPEAK` is a dBFS level tap, not a
+  ready-to-display gain-reduction meter. If the required pair is missing or not
+  fresh enough, `MeterModel` marks the compression value unavailable and emits
+  `0 dB` to preserve the existing gauge presentation; it does not fall back to
+  local PC mic level or a raw `COMPPEAK` display.
+- **P/CW level display**: The Phone/CW level meter UI and smoothing are
+  unchanged by the compression derivation. `AFTEREQ` and `SC_MIC` are used only
+  as compression reference taps.
 - **Unit conversion**: dBm meters (FWDPWR) need watts = 10^(dBm/10)/1000.
   SWR is raw. degC/degF use raw/64.0f. Volts/Amps use raw/1024.0f.
 

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -154,7 +154,7 @@ void MeterModel::removeMeter(int index)
         m_compPeak = 0.0f;
         m_hasCompPeakLevel = false;
         m_compPeakUpdatedMs = 0;
-        setCompressionMeterAvailable(false);
+        m_hasCompPeakValue = false;
     }
     if (index == m_afterEqIdx) {
         m_afterEqIdx = -1;
@@ -193,18 +193,12 @@ float MeterModel::convertRaw(const MeterDef& def, qint16 raw) const
     return static_cast<float>(raw);
 }
 
-void MeterModel::setCompressionMeterAvailable(bool available)
-{
-    if (m_hasCompPeakValue == available) return;
-    m_hasCompPeakValue = available;
-}
-
-bool MeterModel::updateCompressionReduction()
+void MeterModel::updateCompressionReduction()
 {
     if (!m_hasCompPeakLevel) {
         m_compPeak = 0.0f;
-        setCompressionMeterAvailable(false);
-        return false;
+        m_hasCompPeakValue = false;
+        return;
     }
 
     float referenceLevel = 0.0f;
@@ -222,34 +216,33 @@ bool MeterModel::updateCompressionReduction()
     if (m_afterEqIdx >= 0) {
         if (!m_hasAfterEqLevel) {
             m_compPeak = 0.0f;
-            setCompressionMeterAvailable(false);
-            return false;
+            m_hasCompPeakValue = false;
+            return;
         }
         referenceLevel = m_afterEqLevel;
         referenceUpdatedMs = m_afterEqUpdatedMs;
     } else if (m_scMicIdx >= 0) {
         if (!m_hasScMicLevel) {
             m_compPeak = 0.0f;
-            setCompressionMeterAvailable(false);
-            return false;
+            m_hasCompPeakValue = false;
+            return;
         }
         referenceLevel = m_scMicLevel;
         referenceUpdatedMs = m_scMicUpdatedMs;
     } else {
         m_compPeak = 0.0f;
-        setCompressionMeterAvailable(false);
-        return false;
+        m_hasCompPeakValue = false;
+        return;
     }
 
     if (!compressionSamplesFresh(referenceUpdatedMs)) {
         m_compPeak = 0.0f;
-        setCompressionMeterAvailable(false);
-        return false;
+        m_hasCompPeakValue = false;
+        return;
     }
 
     m_compPeak = compressionReductionForGauge(referenceLevel, m_compPeakLevel);
-    setCompressionMeterAvailable(true);
-    return true;
+    m_hasCompPeakValue = true;
 }
 
 bool MeterModel::compressionSamplesFresh(qint64 referenceUpdatedMs) const

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -10,6 +10,19 @@ namespace AetherSDR {
 
 namespace {
 
+constexpr qint64 kCompressionReferenceMaxSkewMs = 250;
+
+float compressionReductionForGauge(float referenceDbfs, float compPeakDbfs)
+{
+    // COMPPEAK is a dBFS level tap at the speech processor/clipper stage.
+    // SmartSDR-style compression tracks the lift from the model-specific
+    // processor reference tap to COMPPEAK.
+    // The gauge is reversed and uses negative values internally:
+    //   0 = none, -25 = heavy.
+    const float reduction = qMax(0.0f, compPeakDbfs - referenceDbfs);
+    return -qBound(0.0f, reduction, 25.0f);
+}
+
 QJsonObject meterToJson(const MeterDef& def, bool hasValue, float value)
 {
     QJsonObject obj;
@@ -78,10 +91,12 @@ void MeterModel::defineMeter(const MeterDef& def)
         m_swrIdx = def.index;
     else if (def.name == "MICPEAK")
         m_micPeakIdx = def.index;
-    else if (def.name == "COMPPEAK")
+    else if (def.source.startsWith("TX") && def.name == "COMPPEAK")
         m_compPeakIdx = def.index;
-    else if (def.name == "AFTEREQ")
+    else if (def.source.startsWith("TX") && def.name == "AFTEREQ")
         m_afterEqIdx = def.index;
+    else if (def.source.startsWith("TX") && def.name == "SC_MIC")
+        m_scMicIdx = def.index;
     else if (def.name == "MIC")
         m_micLevelIdx = def.index;
     else if (def.name == "COMP")
@@ -134,8 +149,26 @@ void MeterModel::removeMeter(int index)
     if (index == m_fwdPwrIdx)   m_fwdPwrIdx = -1;
     if (index == m_swrIdx)      m_swrIdx = -1;
     if (index == m_micPeakIdx)   m_micPeakIdx = -1;
-    if (index == m_compPeakIdx)  m_compPeakIdx = -1;
-    if (index == m_afterEqIdx)   m_afterEqIdx = -1;
+    if (index == m_compPeakIdx) {
+        m_compPeakIdx = -1;
+        m_compPeak = 0.0f;
+        m_hasCompPeakLevel = false;
+        m_compPeakUpdatedMs = 0;
+        setCompressionMeterAvailable(false);
+    }
+    if (index == m_afterEqIdx) {
+        m_afterEqIdx = -1;
+        m_compPeak = 0.0f;
+        m_hasAfterEqLevel = false;
+        m_afterEqUpdatedMs = 0;
+        updateCompressionReduction();
+    }
+    if (index == m_scMicIdx) {
+        m_scMicIdx = -1;
+        m_hasScMicLevel = false;
+        m_scMicUpdatedMs = 0;
+        updateCompressionReduction();
+    }
     if (index == m_micLevelIdx)  m_micLevelIdx = -1;
     if (index == m_compLevelIdx) m_compLevelIdx = -1;
     if (index == m_alcIdx)       m_alcIdx = -1;
@@ -160,6 +193,76 @@ float MeterModel::convertRaw(const MeterDef& def, qint16 raw) const
     return static_cast<float>(raw);
 }
 
+void MeterModel::setCompressionMeterAvailable(bool available)
+{
+    if (m_hasCompPeakValue == available) return;
+    m_hasCompPeakValue = available;
+}
+
+bool MeterModel::updateCompressionReduction()
+{
+    if (!m_hasCompPeakLevel) {
+        m_compPeak = 0.0f;
+        setCompressionMeterAvailable(false);
+        return false;
+    }
+
+    float referenceLevel = 0.0f;
+    qint64 referenceUpdatedMs = 0;
+
+    // Flex meter manifests differ by radio family:
+    // - FLEX-8000 series exposes TX/AFTEREQ at 20 fps. Captures against
+    //   SmartSDR show this is the post-EQ processor input reference, so the
+    //   compression display is the lift from AFTEREQ to TX/COMPPEAK.
+    // - FLEX-6600 captures do not expose AFTEREQ. The best matching reference
+    //   is TX/SC_MIC at 10 fps, with TX/COMPPEAK still at 20 fps. That mixed
+    //   cadence can compare a fresh COMPPEAK against a stale SC_MIC sample, so
+    //   compressionSamplesFresh() gates the derived 6000-series value. If an
+    //   8000-style AFTEREQ exists, prefer it over SC_MIC.
+    if (m_afterEqIdx >= 0) {
+        if (!m_hasAfterEqLevel) {
+            m_compPeak = 0.0f;
+            setCompressionMeterAvailable(false);
+            return false;
+        }
+        referenceLevel = m_afterEqLevel;
+        referenceUpdatedMs = m_afterEqUpdatedMs;
+    } else if (m_scMicIdx >= 0) {
+        if (!m_hasScMicLevel) {
+            m_compPeak = 0.0f;
+            setCompressionMeterAvailable(false);
+            return false;
+        }
+        referenceLevel = m_scMicLevel;
+        referenceUpdatedMs = m_scMicUpdatedMs;
+    } else {
+        m_compPeak = 0.0f;
+        setCompressionMeterAvailable(false);
+        return false;
+    }
+
+    if (!compressionSamplesFresh(referenceUpdatedMs)) {
+        m_compPeak = 0.0f;
+        setCompressionMeterAvailable(false);
+        return false;
+    }
+
+    m_compPeak = compressionReductionForGauge(referenceLevel, m_compPeakLevel);
+    setCompressionMeterAvailable(true);
+    return true;
+}
+
+bool MeterModel::compressionSamplesFresh(qint64 referenceUpdatedMs) const
+{
+    if (m_compPeakUpdatedMs <= 0 || referenceUpdatedMs <= 0)
+        return false;
+
+    const qint64 skewMs = m_compPeakUpdatedMs > referenceUpdatedMs
+        ? m_compPeakUpdatedMs - referenceUpdatedMs
+        : referenceUpdatedMs - m_compPeakUpdatedMs;
+    return skewMs <= kCompressionReferenceMaxSkewMs;
+}
+
 bool MeterModel::hasRecentTxMeters(qint64 maxAgeMs) const
 {
     if (m_lastTxMeterUpdateMs <= 0 || maxAgeMs < 0)
@@ -172,6 +275,7 @@ bool MeterModel::hasRecentTxMeters(qint64 maxAgeMs) const
 void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>& vals)
 {
     const int n = qMin(ids.size(), vals.size());
+    const qint64 packetUpdatedMs = QDateTime::currentMSecsSinceEpoch();
     // sLevelChanged is emitted per-slice inline in the loop below
     bool txChanged = false;
     bool micChanged = false;
@@ -231,23 +335,26 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
         } else if (idx == m_micPeakIdx) {
             m_micPeak = v;
             micChanged = true;
-        } else if (idx == m_afterEqIdx) {
-            // Smooth AFTEREQ to reduce async timing noise with COMPPEAK
-            constexpr float kEqAlpha = 0.3f;
-            m_afterEq = (m_afterEq < -140.0f) ? v : kEqAlpha * v + (1.0f - kEqAlpha) * m_afterEq;
         } else if (idx == m_compPeakIdx) {
-            // COMPPEAK: raw dBFS output level from the radio's compressor.
-            // Smooth it, then compute gain reduction = output - input (negative when compressing).
-            constexpr float kAlpha = 0.3f;
-            m_compPeakRaw = (m_compPeakRaw < -140.0f) ? v : kAlpha * v + (1.0f - kAlpha) * m_compPeakRaw;
-
-            // Gain reduction = compressor output - compressor input.
-            // Both must be valid (> -140 dBFS) for a meaningful result.
-            if (m_afterEq > -140.0f && m_compPeakRaw > -140.0f) {
-                m_compPeak = m_compPeakRaw - m_afterEq;  // 0 = no reduction, negative = compressing
-            } else {
-                m_compPeak = 0.0f;  // silence — no meaningful reduction to display
-            }
+            // COMPPEAK is a dBFS level tap. Pair it with AFTEREQ on 8000
+            // series radios, or SC_MIC on 6000-series radios that do not
+            // expose AFTEREQ.
+            m_compPeakLevel = v;
+            m_hasCompPeakLevel = true;
+            m_compPeakUpdatedMs = packetUpdatedMs;
+            updateCompressionReduction();
+            micChanged = true;
+        } else if (idx == m_afterEqIdx) {
+            m_afterEqLevel = v;
+            m_hasAfterEqLevel = true;
+            m_afterEqUpdatedMs = packetUpdatedMs;
+            updateCompressionReduction();
+            micChanged = true;
+        } else if (idx == m_scMicIdx) {
+            m_scMicLevel = v;
+            m_hasScMicLevel = true;
+            m_scMicUpdatedMs = packetUpdatedMs;
+            updateCompressionReduction();
             micChanged = true;
         } else if (idx == m_micLevelIdx) {
             m_micLevel = v;

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -77,9 +77,10 @@ public:
     qint64 txMetersUpdatedAtMs() const { return m_lastTxMeterUpdateMs; }
     bool hasRecentTxMeters(qint64 maxAgeMs) const;
 
-    // Convenience: mic peak level (dBFS) and compression peak (dB).
+    // Convenience: mic peak level (dBFS) and derived compression reduction (dB).
     float micPeak()  const { return m_micPeak; }
     float compPeak() const { return m_compPeak; }
+    bool hasCompressionMeterValue() const { return m_hasCompPeakValue; }
 
     // Convenience: instantaneous mic level and compression (non-peak).
     float micLevel() const { return m_micLevel; }
@@ -125,6 +126,9 @@ signals:
 
 private:
     float convertRaw(const MeterDef& def, qint16 raw) const;
+    void setCompressionMeterAvailable(bool available);
+    bool updateCompressionReduction();
+    bool compressionSamplesFresh(qint64 referenceUpdatedMs) const;
 
     QMap<int, MeterDef> m_defs;        // meter index → definition
     QMap<int, float>    m_values;      // meter index → last converted value
@@ -135,8 +139,9 @@ private:
     int m_fwdPwrIdx{-1};     // "FWDPWR"
     int m_swrIdx{-1};        // "SWR"
     int m_micPeakIdx{-1};    // "COD-" / "MICPEAK" (hardware mic)
-    int m_compPeakIdx{-1};   // "TX" / "COMPPEAK"
-    int m_afterEqIdx{-1};    // "TX" / "AFTEREQ" (compressor input)
+    int m_compPeakIdx{-1};   // "TX" / "COMPPEAK" (processor/clipper-stage dBFS tap)
+    int m_afterEqIdx{-1};    // "TX" / "AFTEREQ" (processor input reference)
+    int m_scMicIdx{-1};      // "TX" / "SC_MIC" (6000-series compression reference)
     int m_micLevelIdx{-1};   // "COD-" / "MIC" (hardware mic RX level)
     int m_compLevelIdx{-1};  // "TX" / "COMP" (instantaneous)
     int m_alcIdx{-1};        // "TX" / "HWALC"
@@ -157,9 +162,17 @@ private:
     float m_swr{1.0f};
     qint64 m_lastTxMeterUpdateMs{0};
     float m_micPeak{-50.0f};
-    float m_compPeak{0.0f};      // computed gain reduction (displayed)
-    float m_compPeakRaw{-150.0f}; // smoothed COMPPEAK value
-    float m_afterEq{-150.0f};    // smoothed AFTEREQ (compressor input)
+    float m_compPeak{0.0f};       // derived compression reduction for the reversed gauge
+    bool m_hasCompPeakValue{false};
+    float m_afterEqLevel{-150.0f};
+    float m_scMicLevel{-150.0f};
+    float m_compPeakLevel{-150.0f};
+    bool m_hasAfterEqLevel{false};
+    bool m_hasScMicLevel{false};
+    bool m_hasCompPeakLevel{false};
+    qint64 m_afterEqUpdatedMs{0};
+    qint64 m_scMicUpdatedMs{0};
+    qint64 m_compPeakUpdatedMs{0};
     float m_micLevel{-50.0f};
     float m_compLevel{0.0f};
     float m_alc{0.0f};

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -126,8 +126,7 @@ signals:
 
 private:
     float convertRaw(const MeterDef& def, qint16 raw) const;
-    void setCompressionMeterAvailable(bool available);
-    bool updateCompressionReduction();
+    void updateCompressionReduction();
     bool compressionSamplesFresh(qint64 referenceUpdatedMs) const;
 
     QMap<int, MeterDef> m_defs;        // meter index → definition

--- a/tests/meter_model_test.cpp
+++ b/tests/meter_model_test.cpp
@@ -1,0 +1,254 @@
+#include "models/MeterModel.h"
+
+#include <QCoreApplication>
+#include <QThread>
+#include <QVector>
+
+#include <cmath>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) ++g_failed;
+}
+
+bool nearlyEqual(float a, float b)
+{
+    return std::fabs(a - b) < 0.01f;
+}
+
+qint16 rawDb(float db)
+{
+    return static_cast<qint16>(std::lround(db * 128.0f));
+}
+
+MeterDef txMeter(int index, const QString& name, const QString& unit = QStringLiteral("dBFS"))
+{
+    MeterDef def;
+    def.index = index;
+    def.source = "TX-";
+    def.name = name;
+    def.unit = unit;
+    def.low = -150.0;
+    def.high = 20.0;
+    return def;
+}
+
+void testAdjacentMetersDoNotSynthesizeCompression()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(22, "SC_MIC", "dBFS"));
+
+    model.updateValues({22}, {rawDb(-10.0f)});
+
+    report("adjacent TX audio meters do not synthesize compression",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testCompPeakRequiresAfterEq()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({28}, {rawDb(-40.0f)});
+
+    report("COMPPEAK alone does not expose compression",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testAfterEqRequiresCompPeak()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+
+    model.updateValues({27}, {rawDb(-60.0f)});
+
+    report("AFTEREQ alone does not expose compression",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testCompPeakMinusAfterEqDrivesGauge()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({27, 28}, {rawDb(-60.0f), rawDb(-40.0f)});
+
+    report("COMPPEAK minus AFTEREQ maps to negative gauge value",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+}
+
+void testCompPeakMinusScMicDrivesGaugeWhenAfterEqMissing()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(22, "SC_MIC"));
+    model.defineMeter(txMeter(23, "COMPPEAK"));
+
+    model.updateValues({22, 23}, {rawDb(-42.0f), rawDb(-22.0f)});
+
+    report("COMPPEAK minus SC_MIC maps 6000-series compression",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+}
+
+void testScMicCompressionDerivationIsOrderIndependent()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(22, "SC_MIC"));
+    model.defineMeter(txMeter(23, "COMPPEAK"));
+
+    model.updateValues({23}, {rawDb(-22.0f)});
+    model.updateValues({22}, {rawDb(-42.0f)});
+
+    report("SC_MIC compression derivation is order independent",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+}
+
+void testAfterEqPreferredOverScMicWhenBothAreDefined()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(22, "SC_MIC"));
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({22, 27, 28}, {rawDb(-80.0f), rawDb(-20.0f), rawDb(-10.0f)});
+
+    report("AFTEREQ is preferred over SC_MIC when both are present",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -10.0f));
+}
+
+void testAfterEqDefinitionDoesNotFallbackToScMicWithoutAfterEqValue()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(22, "SC_MIC"));
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({22, 28}, {rawDb(-80.0f), rawDb(-40.0f)});
+
+    report("AFTEREQ definition requires AFTEREQ data and does not fallback",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testCompPeakAndAfterEqAreOrderIndependent()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({28}, {rawDb(-40.0f)});
+    model.updateValues({27}, {rawDb(-60.0f)});
+
+    report("compression derivation is order independent",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+}
+
+void testNoStageLiftShowsNoCompression()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({27, 28}, {rawDb(-30.0f), rawDb(-45.0f)});
+
+    report("COMPPEAK below AFTEREQ shows no compression",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testDerivedCompressionClampsToGaugeRange()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+
+    model.updateValues({27, 28}, {rawDb(-80.0f), rawDb(-40.0f)});
+
+    report("derived compression clamps to the compression gauge range",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -25.0f));
+}
+
+void testStaleScMicReferenceDoesNotDriveCompression()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(22, "SC_MIC"));
+    model.defineMeter(txMeter(23, "COMPPEAK"));
+
+    model.updateValues({22}, {rawDb(-42.0f)});
+    QThread::msleep(300);
+    model.updateValues({23}, {rawDb(-22.0f)});
+
+    report("stale SC_MIC reference does not drive compression",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+
+    model.updateValues({22}, {rawDb(-42.0f)});
+    report("fresh SC_MIC reference restores compression",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+}
+
+void testRemovingCompPeakMarksCompressionUnavailable()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+    model.updateValues({27, 28}, {rawDb(-60.0f), rawDb(-40.0f)});
+    model.removeMeter(28);
+
+    report("removing COMPPEAK marks compression unavailable",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testRemovingAfterEqMarksCompressionUnavailable()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(txMeter(28, "COMPPEAK"));
+    model.updateValues({27, 28}, {rawDb(-60.0f), rawDb(-40.0f)});
+    model.removeMeter(27);
+
+    report("removing AFTEREQ marks compression unavailable",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+void testRemovingScMicMarks6000CompressionUnavailable()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(22, "SC_MIC"));
+    model.defineMeter(txMeter(23, "COMPPEAK"));
+    model.updateValues({22, 23}, {rawDb(-42.0f), rawDb(-22.0f)});
+    model.removeMeter(22);
+
+    report("removing SC_MIC marks 6000-series compression unavailable",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    testAdjacentMetersDoNotSynthesizeCompression();
+    testCompPeakRequiresAfterEq();
+    testAfterEqRequiresCompPeak();
+    testCompPeakMinusAfterEqDrivesGauge();
+    testCompPeakMinusScMicDrivesGaugeWhenAfterEqMissing();
+    testScMicCompressionDerivationIsOrderIndependent();
+    testAfterEqPreferredOverScMicWhenBothAreDefined();
+    testAfterEqDefinitionDoesNotFallbackToScMicWithoutAfterEqValue();
+    testCompPeakAndAfterEqAreOrderIndependent();
+    testNoStageLiftShowsNoCompression();
+    testDerivedCompressionClampsToGaugeRange();
+    testStaleScMicReferenceDoesNotDriveCompression();
+    testRemovingCompPeakMarksCompressionUnavailable();
+    testRemovingAfterEqMarksCompressionUnavailable();
+    testRemovingScMicMarks6000CompressionUnavailable();
+
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

This PR updates the Phone/CW compression meter data path to derive SmartSDR-style compression from radio TX meter pairs instead of displaying raw `COMPPEAK` level data.

- FLEX-8000 series: `display_db = -clamp(max(0, COMPPEAK - AFTEREQ), 0, 25)`
- FLEX-6600 / 6000-series when `AFTEREQ` is absent: `display_db = -clamp(max(0, COMPPEAK - SC_MIC), 0, 25)`
- Meter selection now keys on TX meter `source` + `name`, not numeric IDs, because IDs are dynamic across sessions and radio families.
- No local PC mic fallback and no raw `COMPPEAK` fallback are used; if the required radio-side pair is missing or stale, `MeterModel` marks the compression value unavailable and emits `0 dB` to preserve the existing gauge presentation.
- Phone/CW level meter behavior and UI layout are intentionally unchanged.

## Investigation Notes

The 8000-series captures and SmartSDR comparison showed that `COMPPEAK` is a dBFS signal-level tap near the speech processor/clipper stage, not the value SmartSDR renders directly as compression. Comparing `COMPPEAK` against the post-EQ reference meter `AFTEREQ` produced the matching compression scale on the 8400M/8000-series path.

The FLEX-6600 meter manifest supplied by testing did not expose `AFTEREQ`. Its relevant TX meters were `SC_MIC` and `COMPPEAK`; using `COMPPEAK - SC_MIC` is the best-supported 6000-series model from the captures. `SC_MIC` advertises 10 fps while `COMPPEAK` advertises 20 fps, so the implementation includes a freshness guard to avoid comparing a fresh processor sample against a stale reference sample.

The two-tone testing also confirmed why the compression meter must be radio-meter derived: radio-generated two-tone RF can be active while local PC microphone meters still move, so local mic activity is not a reliable indicator of transmitted compression.

I'd like to recognize Randy AG4Q for his valuable assistance in testing, calibrating and debugging meters on the 6600. Thank you, Randy.

## Documentation

- Adds `docs/flex-meter-learnings.md` with the capture-backed meter rules, family-specific formulas, FPS table, two-tone notes.
- Updates `docs/tx-audio-signal-path.md` to link the meter findings and document how `AFTEREQ`, `SC_MIC`, and `COMPPEAK` are used.

## Validation

- `git diff --check origin/main`
- `cmake --build build --target meter_model_test --parallel 10`
- `./build/meter_model_test`
- `cmake --build build --target AetherSDR --parallel 10`

Built app: `/Users/patj/.codex/worktrees/be95/AetherSDR/build/AetherSDR.app`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
