### PR TITLE
[shortcut] Add two-tone Tune shortcut

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1152,6 +1152,15 @@ target_compile_definitions(midi_settings_test PRIVATE HAVE_MIDI)
 target_include_directories(midi_settings_test PRIVATE src third_party/rtmidi)
 target_link_libraries(midi_settings_test PRIVATE Qt6::Core)
 
+add_executable(transmit_model_test
+    tests/transmit_model_test.cpp
+    src/models/TransmitModel.cpp
+    src/core/AppSettings.cpp
+    src/core/LogManager.cpp
+)
+target_include_directories(transmit_model_test PRIVATE src)
+target_link_libraries(transmit_model_test PRIVATE Qt6::Core)
+
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test
     tests/container_widget_test.cpp

--- a/resources/help/configuring-aethersdr-controls.md
+++ b/resources/help/configuring-aethersdr-controls.md
@@ -71,6 +71,7 @@ The shortcut editor also includes many actions that ship **unassigned** until yo
 - Band jumps for `160m`, `80m`, `60m`, `40m`, `30m`, `20m`, `17m`, `15m`, `12m`, `10m`, `6m`, and `2m`
 - Mode changes such as `USB`, `LSB`, `CW`, `CWL`, `AM`, `SAM`, `FM`, `NFM`, `DFM`, `DIGU`, `DIGL`, and `RTTY`
 - `TUNE` toggle
+- `Two-Tone Tune`
 - Next or previous slice
 - Split toggle
 - Filter widen and narrow

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9376,6 +9376,11 @@ void MainWindow::registerShortcutActions()
             else
                 m_radioModel.transmitModel().startTune();
         });
+    m_shortcutManager.registerAction("two_tone_tune", "Two-Tone Tune", "TX",
+        QKeySequence(), [this]() {
+            if (!m_radioModel.isConnected()) return;
+            m_radioModel.transmitModel().toggleTwoToneTune();
+        });
 
     // ── Audio ───────────────────────────────────────────────────────────
     m_shortcutManager.registerAction("af_gain_up", "AF Gain Up", "Audio",

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -307,9 +307,32 @@ void TransmitModel::setTunePower(int power)
     emit commandReady(QString("transmit set tunepower=%1").arg(power));
 }
 
+void TransmitModel::setTuneMode(const QString& mode)
+{
+    if (mode != "single_tone" && mode != "two_tone") {
+        qWarning() << "TransmitModel: ignoring invalid tune mode:" << mode;
+        return;
+    }
+    emit commandReady("transmit set tune_mode=" + mode);
+}
+
 void TransmitModel::startTune()
 {
     emit commandReady("transmit tune 1");
+}
+
+void TransmitModel::startTwoToneTune()
+{
+    setTuneMode("two_tone");
+    startTune();
+}
+
+void TransmitModel::toggleTwoToneTune()
+{
+    if (isTuning())
+        stopTune();
+    else
+        startTwoToneTune();
 }
 
 void TransmitModel::stopTune()

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -329,10 +329,14 @@ void TransmitModel::startTwoToneTune()
 
 void TransmitModel::toggleTwoToneTune()
 {
-    if (isTuning())
+    if (isTuning()) {
         stopTune();
-    else
+        // Restore single-tone so the next regular Tune press isn't surprised
+        // by sticky two-tone state on the radio.
+        setTuneMode("single_tone");
+    } else {
         startTwoToneTune();
+    }
 }
 
 void TransmitModel::stopTune()

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -129,7 +129,10 @@ public:
     // ── Command methods (emit commandReady) ─────────────────────────────────
     void setRfPower(int power);
     void setTunePower(int power);
+    void setTuneMode(const QString& mode);
     void startTune();
+    void startTwoToneTune();
+    void toggleTwoToneTune();
     void stopTune();
     void setMox(bool on);
     void atuStart();

--- a/tests/transmit_model_test.cpp
+++ b/tests/transmit_model_test.cpp
@@ -1,0 +1,65 @@
+#include "models/TransmitModel.h"
+
+#include <QCoreApplication>
+#include <QObject>
+#include <QStringList>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    return condition;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    TransmitModel tx;
+    QStringList commands;
+    QObject::connect(&tx, &TransmitModel::commandReady,
+                     [&commands](const QString& cmd) { commands.append(cmd); });
+
+    bool ok = true;
+
+    tx.startTwoToneTune();
+    ok &= expect(commands == QStringList({
+                     "transmit set tune_mode=two_tone",
+                     "transmit tune 1",
+                 }),
+                 "two-tone tune sets mode before starting tune");
+
+    tx.applyTransmitStatus({{"tune", "1"}});
+    commands.clear();
+    tx.toggleTwoToneTune();
+    ok &= expect(commands == QStringList({"transmit tune 0"}),
+                 "two-tone tune toggle stops when already tuning");
+
+    tx.applyTransmitStatus({{"tune", "0"}});
+    commands.clear();
+    tx.toggleTwoToneTune();
+    ok &= expect(commands == QStringList({
+                     "transmit set tune_mode=two_tone",
+                     "transmit tune 1",
+                 }),
+                 "two-tone tune toggle starts two-tone when not tuning");
+
+    commands.clear();
+    tx.setTuneMode("single_tone");
+    ok &= expect(commands == QStringList({"transmit set tune_mode=single_tone"}),
+                 "single-tone tune mode command is accepted");
+
+    commands.clear();
+    tx.setTuneMode("invalid");
+    ok &= expect(commands.isEmpty(),
+                 "invalid tune mode is ignored");
+
+    return ok ? 0 : 1;
+}

--- a/tests/transmit_model_test.cpp
+++ b/tests/transmit_model_test.cpp
@@ -39,8 +39,11 @@ int main(int argc, char** argv)
     tx.applyTransmitStatus({{"tune", "1"}});
     commands.clear();
     tx.toggleTwoToneTune();
-    ok &= expect(commands == QStringList({"transmit tune 0"}),
-                 "two-tone tune toggle stops when already tuning");
+    ok &= expect(commands == QStringList({
+                     "transmit tune 0",
+                     "transmit set tune_mode=single_tone",
+                 }),
+                 "two-tone tune toggle stops and restores single-tone mode");
 
     tx.applyTransmitStatus({{"tune", "0"}});
     commands.clear();


### PR DESCRIPTION
## Summary

- Adds an unassigned `Two-Tone Tune` keyboard shortcut action under TX.
- Sends `transmit set tune_mode=two_tone` before starting Tune, and toggles Tune off on a second press.
- Documents the assignable shortcut and adds a focused `TransmitModel` regression test.

## Testing

- `cmake --build build -j 10`
- `./build/transmit_model_test`
- `git diff --check`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
