### PR TITLE
PooDoo: RX drag-to-reorder, Aetherial labels, frameless editor windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,8 @@ set(GUI_SOURCES
     src/gui/ClientEqParamRow.cpp
     src/gui/ClientChainApplet.cpp
     src/gui/ClientChainWidget.cpp
+    src/gui/ClientRxChainWidget.cpp
+    src/gui/EditorFramelessTitleBar.cpp
     src/gui/containers/ContainerManager.cpp
     src/gui/containers/ContainerTitleBar.cpp
     src/gui/containers/ContainerWidget.cpp

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -64,10 +64,14 @@ AudioEngine::AudioEngine(QObject* parent)
     , m_clientEqRx(std::make_unique<ClientEq>())
     , m_clientEqTx(std::make_unique<ClientEq>())
     , m_clientCompTx(std::make_unique<ClientComp>())
+    , m_clientCompRx(std::make_unique<ClientComp>())
     , m_clientGateTx(std::make_unique<ClientGate>())
+    , m_clientGateRx(std::make_unique<ClientGate>())
     , m_clientDeEssTx(std::make_unique<ClientDeEss>())
     , m_clientTubeTx(std::make_unique<ClientTube>())
+    , m_clientTubeRx(std::make_unique<ClientTube>())
     , m_clientPuduTx(std::make_unique<ClientPudu>())
+    , m_clientPuduRx(std::make_unique<ClientPudu>())
     , m_clientReverbTx(std::make_unique<ClientReverb>())
     , m_cwSidetone(std::make_unique<CwSidetoneGenerator>(48000))
 {
@@ -77,6 +81,10 @@ AudioEngine::AudioEngine(QObject* parent)
     m_clientEqTx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientCompTx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientGateTx->prepare(DEFAULT_SAMPLE_RATE);
+    m_clientGateRx->prepare(DEFAULT_SAMPLE_RATE);
+    m_clientCompRx->prepare(DEFAULT_SAMPLE_RATE);
+    m_clientTubeRx->prepare(DEFAULT_SAMPLE_RATE);
+    m_clientPuduRx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientDeEssTx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientTubeTx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientPuduTx->prepare(DEFAULT_SAMPLE_RATE);
@@ -84,10 +92,15 @@ AudioEngine::AudioEngine(QObject* parent)
     loadClientEqSettings();      // restore persisted bands before first audio
     loadClientCompSettings();    // restore persisted comp params + chain order
     loadClientGateSettings();    // restore persisted gate params
+    loadClientGateRxSettings();  // restore persisted RX gate params
+    loadClientCompRxSettings();  // restore persisted RX comp params
+    loadClientTubeRxSettings();  // restore persisted RX tube params
+    loadClientPuduRxSettings();  // restore persisted RX PUDU params
     loadClientDeEssSettings();   // restore persisted de-esser params
     loadClientTubeSettings();    // restore persisted tube params
     loadClientPuduSettings();    // restore persisted PUDU params
     loadClientReverbSettings();  // restore persisted reverb params
+    loadClientRxChainOrder();    // restore persisted RX chain order (Phase 0+)
 
     // Restore saved audio device selections
     auto& s = AppSettings::instance();
@@ -551,9 +564,12 @@ void AudioEngine::setRxVolume(float v)
 
 void AudioEngine::setMuted(bool muted)
 {
+    const bool prev = m_muted.load();
     m_muted.store(muted);
     if (m_audioSink)
         m_audioSink->setVolume(muted ? 0.0f : m_rxVolume.load());
+    if (prev != muted)
+        emit mutedChanged(muted);
 }
 
 bool AudioEngine::startSidetoneStream()
@@ -730,7 +746,43 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
                 tapFrames);
         }
 
-        const QByteArray& resampled = m_resampleTo48k ? resampleStereo(*eqSource) : *eqSource;
+        // RX chain stage: GATE — runs after EQ, in place on a scratch
+        // buffer so the EQ tap above sees the post-EQ / pre-gate signal
+        // (matches the user's signal-flow expectation).  Skip during TX
+        // for the same reason as EQ.
+        const QByteArray* gateSource = eqSource;
+        if (m_clientGateRx && m_clientGateRx->isEnabled() && !m_radioTransmitting) {
+            m_clientGateRxScratch = *eqSource;
+            applyClientGateRxFloat32(m_clientGateRxScratch);
+            gateSource = &m_clientGateRxScratch;
+        }
+
+        // RX chain stage: COMP — runs after GATE.  Same scratch-copy
+        // pattern.
+        const QByteArray* compSource = gateSource;
+        if (m_clientCompRx && m_clientCompRx->isEnabled() && !m_radioTransmitting) {
+            m_clientCompRxScratch = *gateSource;
+            applyClientCompRxFloat32(m_clientCompRxScratch);
+            compSource = &m_clientCompRxScratch;
+        }
+
+        // RX chain stage: TUBE — runs after COMP.
+        const QByteArray* tubeSource = compSource;
+        if (m_clientTubeRx && m_clientTubeRx->isEnabled() && !m_radioTransmitting) {
+            m_clientTubeRxScratch = *compSource;
+            applyClientTubeRxFloat32(m_clientTubeRxScratch);
+            tubeSource = &m_clientTubeRxScratch;
+        }
+
+        // RX chain stage: PUDU — runs after TUBE.
+        const QByteArray* puduSource = tubeSource;
+        if (m_clientPuduRx && m_clientPuduRx->isEnabled() && !m_radioTransmitting) {
+            m_clientPuduRxScratch = *tubeSource;
+            applyClientPuduRxFloat32(m_clientPuduRxScratch);
+            puduSource = &m_clientPuduRxScratch;
+        }
+
+        const QByteArray& resampled = m_resampleTo48k ? resampleStereo(*puduSource) : *puduSource;
         if (m_rxBoost.load()) {
             // Soft-knee boost — increases perceived loudness without hard clipping.
             // Uses tanh compression: loud signals are gently limited while quiet
@@ -1068,6 +1120,17 @@ void AudioEngine::applyClientCompTxFloat32(QByteArray& float32)
                             frames, channels);
 }
 
+void AudioEngine::applyClientCompRxFloat32(QByteArray& float32)
+{
+    if (!m_clientCompRx || !m_clientCompRx->isEnabled()) return;
+    if (float32.isEmpty()) return;
+    const int samples = float32.size() / static_cast<int>(sizeof(float));
+    if ((samples & 1) != 0) return;
+    const int frames = samples / 2;
+    m_clientCompRx->process(reinterpret_cast<float*>(float32.data()),
+                            frames, 2);
+}
+
 void AudioEngine::applyClientGateTxInt16(QByteArray& int16stereo)
 {
     if (!m_clientGateTx || !m_clientGateTx->isEnabled()) return;
@@ -1100,6 +1163,17 @@ void AudioEngine::applyClientGateTxFloat32(QByteArray& float32)
     const int frames   = samples / channels;
     m_clientGateTx->process(reinterpret_cast<float*>(float32.data()),
                             frames, channels);
+}
+
+void AudioEngine::applyClientGateRxFloat32(QByteArray& float32)
+{
+    if (!m_clientGateRx || !m_clientGateRx->isEnabled()) return;
+    if (float32.isEmpty()) return;
+    const int samples = float32.size() / static_cast<int>(sizeof(float));
+    if ((samples & 1) != 0) return;
+    const int frames = samples / 2;  // RX path is always stereo
+    m_clientGateRx->process(reinterpret_cast<float*>(float32.data()),
+                            frames, 2);
 }
 
 void AudioEngine::applyClientDeEssTxInt16(QByteArray& int16stereo)
@@ -1170,6 +1244,17 @@ void AudioEngine::applyClientTubeTxFloat32(QByteArray& float32)
                             frames, channels);
 }
 
+void AudioEngine::applyClientTubeRxFloat32(QByteArray& float32)
+{
+    if (!m_clientTubeRx || !m_clientTubeRx->isEnabled()) return;
+    if (float32.isEmpty()) return;
+    const int samples = float32.size() / static_cast<int>(sizeof(float));
+    if ((samples & 1) != 0) return;
+    const int frames = samples / 2;
+    m_clientTubeRx->process(reinterpret_cast<float*>(float32.data()),
+                            frames, 2);
+}
+
 void AudioEngine::applyClientPuduTxInt16(QByteArray& int16stereo)
 {
     if (!m_clientPuduTx || !m_clientPuduTx->isEnabled()) return;
@@ -1202,6 +1287,17 @@ void AudioEngine::applyClientPuduTxFloat32(QByteArray& float32)
     const int frames   = samples / channels;
     m_clientPuduTx->process(reinterpret_cast<float*>(float32.data()),
                             frames, channels);
+}
+
+void AudioEngine::applyClientPuduRxFloat32(QByteArray& float32)
+{
+    if (!m_clientPuduRx || !m_clientPuduRx->isEnabled()) return;
+    if (float32.isEmpty()) return;
+    const int samples = float32.size() / static_cast<int>(sizeof(float));
+    if ((samples & 1) != 0) return;
+    const int frames = samples / 2;
+    m_clientPuduRx->process(reinterpret_cast<float*>(float32.data()),
+                            frames, 2);
 }
 
 void AudioEngine::applyClientReverbTxInt16(QByteArray& int16stereo)
@@ -1284,6 +1380,28 @@ void AudioEngine::applyClientTxDspFloat32(QByteArray& float32)
     }
 }
 
+void AudioEngine::applyClientRxDspFloat32(QByteArray& float32)
+{
+    // Walk the packed RX chain-stage list and dispatch each entry to
+    // its per-stage apply helper.  Phase 0 ships with no implemented
+    // stages — every entry is a no-op until Phase 1+ slot in the DSP
+    // classes (RX EQ first).  Same atomic-load pattern as TX so the
+    // audio thread reads the entire chain order in one access.
+    const uint64_t packed = m_rxChainPacked.load(std::memory_order_acquire);
+    for (int i = 0; i < kMaxRxChainStages; ++i) {
+        const auto stage = static_cast<RxChainStage>((packed >> (i * 8)) & 0xFF);
+        switch (stage) {
+            case RxChainStage::None: return;     // end-of-list marker
+            case RxChainStage::Eq:   /* TODO Phase 1 */ break;
+            case RxChainStage::Gate: /* TODO Phase 2 */ break;
+            case RxChainStage::Comp: /* TODO Phase 3 */ break;
+            case RxChainStage::Tube: /* TODO Phase 4 */ break;
+            case RxChainStage::Pudu: /* TODO Phase 5 */ break;
+        }
+    }
+    (void)float32;  // unused until first stage lands
+}
+
 namespace {
 
 // Pack a stage list into the uint64_t atomic format used by the audio
@@ -1357,6 +1475,69 @@ QVector<AudioEngine::TxChainStage> defaultChain()
     };
 }
 
+// ── RX chain helpers — parallel to the TX functions above ───────────────
+
+uint64_t packRxChain(const QVector<AudioEngine::RxChainStage>& stages)
+{
+    uint64_t v = 0;
+    const int n = std::min(static_cast<int>(stages.size()),
+                           AudioEngine::kMaxRxChainStages);
+    for (int i = 0; i < n; ++i) {
+        v |= static_cast<uint64_t>(static_cast<uint8_t>(stages[i])) << (i * 8);
+    }
+    return v;
+}
+
+QVector<AudioEngine::RxChainStage> unpackRxChain(uint64_t v)
+{
+    QVector<AudioEngine::RxChainStage> out;
+    out.reserve(AudioEngine::kMaxRxChainStages);
+    for (int i = 0; i < AudioEngine::kMaxRxChainStages; ++i) {
+        const auto s = static_cast<AudioEngine::RxChainStage>((v >> (i * 8)) & 0xFF);
+        if (s == AudioEngine::RxChainStage::None) break;
+        out.append(s);
+    }
+    return out;
+}
+
+QString rxStageName(AudioEngine::RxChainStage s)
+{
+    switch (s) {
+        case AudioEngine::RxChainStage::Eq:   return "Eq";
+        case AudioEngine::RxChainStage::Gate: return "Gate";
+        case AudioEngine::RxChainStage::Comp: return "Comp";
+        case AudioEngine::RxChainStage::Tube: return "Tube";
+        case AudioEngine::RxChainStage::Pudu: return "Pudu";
+        case AudioEngine::RxChainStage::None: return "";
+    }
+    return "";
+}
+
+AudioEngine::RxChainStage rxStageFromName(const QString& name)
+{
+    if (name == "Eq")   return AudioEngine::RxChainStage::Eq;
+    if (name == "Gate") return AudioEngine::RxChainStage::Gate;
+    if (name == "Comp") return AudioEngine::RxChainStage::Comp;
+    if (name == "Tube") return AudioEngine::RxChainStage::Tube;
+    if (name == "Pudu") return AudioEngine::RxChainStage::Pudu;
+    return AudioEngine::RxChainStage::None;
+}
+
+// Canonical RX order matches the user's diagram in plans/poodoo-rx-chain.md:
+//   [RADIO]→[DSP]→[RX EQ]→[GATE]→[COMP]→[TUBE]→[PUDU]→[SPEAK]
+// RADIO / DSP / SPEAK are status-only tiles handled by the chain widget;
+// the audio path only sees the user-controllable stages between them.
+QVector<AudioEngine::RxChainStage> defaultRxChain()
+{
+    return {
+        AudioEngine::RxChainStage::Eq,
+        AudioEngine::RxChainStage::Gate,
+        AudioEngine::RxChainStage::Comp,
+        AudioEngine::RxChainStage::Tube,
+        AudioEngine::RxChainStage::Pudu,
+    };
+}
+
 } // namespace
 
 void AudioEngine::setTxChainStages(const QVector<TxChainStage>& stages)
@@ -1374,6 +1555,73 @@ void AudioEngine::setTxChainStages(const QVector<TxChainStage>& stages)
 QVector<AudioEngine::TxChainStage> AudioEngine::txChainStages() const
 {
     return unpackChain(m_txChainPacked.load(std::memory_order_acquire));
+}
+
+void AudioEngine::setRxChainStages(const QVector<RxChainStage>& stages)
+{
+    m_rxChainPacked.store(packRxChain(stages), std::memory_order_release);
+    QStringList names;
+    for (auto s : stages) {
+        const QString n = rxStageName(s);
+        if (!n.isEmpty()) names.append(n);
+    }
+    AppSettings::instance().setValue(
+        "ClientRxChainStages", names.join(","));
+}
+
+QVector<AudioEngine::RxChainStage> AudioEngine::rxChainStages() const
+{
+    return unpackRxChain(m_rxChainPacked.load(std::memory_order_acquire));
+}
+
+void AudioEngine::loadClientRxChainOrder()
+{
+    auto& s = AppSettings::instance();
+    QVector<RxChainStage> stages;
+    bool sawUnknown = false;
+    const QString stored = s.value("ClientRxChainStages", "").toString();
+    if (!stored.isEmpty()) {
+        for (const QString& name : stored.split(',', Qt::SkipEmptyParts)) {
+            const auto stage = rxStageFromName(name.trimmed());
+            if (stage != RxChainStage::None) stages.append(stage);
+            else                              sawUnknown = true;
+        }
+    }
+    // Any unknown name in the stored list is a strong signal that the
+    // settings file is from a different (or old) version of AetherSDR.
+    // Reset to the canonical default rather than silently filtering the
+    // unknown entries — that filtering shuffles the remaining stages
+    // into a misleading order.
+    const bool resetFromStale = sawUnknown;
+    if (sawUnknown || stages.isEmpty()) stages = defaultRxChain();
+
+    // Append any canonical stages missing from the loaded list so future
+    // phases slot in without a migration.
+    for (auto canon : defaultRxChain()) {
+        if (!stages.contains(canon)) stages.append(canon);
+    }
+    m_rxChainPacked.store(packRxChain(stages), std::memory_order_release);
+
+    // Overwrite the stale value on disk so the user's settings file
+    // doesn't keep showing names from a previous build.
+    if (resetFromStale) {
+        QStringList names;
+        for (auto st : stages) {
+            const QString n = rxStageName(st);
+            if (!n.isEmpty()) names.append(n);
+        }
+        s.setValue("ClientRxChainStages", names.join(","));
+    }
+}
+
+void AudioEngine::saveClientRxChainOrder() const
+{
+    QStringList names;
+    for (auto s : rxChainStages()) {
+        const QString n = rxStageName(s);
+        if (!n.isEmpty()) names.append(n);
+    }
+    AppSettings::instance().setValue("ClientRxChainStages", names.join(","));
 }
 
 void AudioEngine::setTxChainOrder(TxChainOrder order)
@@ -1494,6 +1742,47 @@ void AudioEngine::saveClientCompSettings() const
     s.setValue("ClientCompTxChainStages", names.join(","));
 }
 
+void AudioEngine::loadClientCompRxSettings()
+{
+    if (!m_clientCompRx) return;
+    auto& s = AppSettings::instance();
+    m_clientCompRx->setEnabled(
+        s.value("ClientCompRxEnabled", "False").toString() == "True");
+    m_clientCompRx->setThresholdDb(
+        s.value("ClientCompRxThresholdDb", "-18.0").toFloat());
+    m_clientCompRx->setRatio(
+        s.value("ClientCompRxRatio", "3.0").toFloat());
+    m_clientCompRx->setAttackMs(
+        s.value("ClientCompRxAttackMs", "20.0").toFloat());
+    m_clientCompRx->setReleaseMs(
+        s.value("ClientCompRxReleaseMs", "200.0").toFloat());
+    m_clientCompRx->setKneeDb(
+        s.value("ClientCompRxKneeDb", "6.0").toFloat());
+    m_clientCompRx->setMakeupDb(
+        s.value("ClientCompRxMakeupDb", "0.0").toFloat());
+    m_clientCompRx->setLimiterEnabled(
+        s.value("ClientCompRxLimEnabled", "True").toString() == "True");
+    m_clientCompRx->setLimiterCeilingDb(
+        s.value("ClientCompRxLimCeilingDb", "-1.0").toFloat());
+}
+
+void AudioEngine::saveClientCompRxSettings() const
+{
+    if (!m_clientCompRx) return;
+    auto& s = AppSettings::instance();
+    auto toBool = [](bool on) { return on ? QString("True") : QString("False"); };
+    s.setValue("ClientCompRxEnabled",     toBool(m_clientCompRx->isEnabled()));
+    s.setValue("ClientCompRxThresholdDb", QString::number(m_clientCompRx->thresholdDb()));
+    s.setValue("ClientCompRxRatio",       QString::number(m_clientCompRx->ratio()));
+    s.setValue("ClientCompRxAttackMs",    QString::number(m_clientCompRx->attackMs()));
+    s.setValue("ClientCompRxReleaseMs",   QString::number(m_clientCompRx->releaseMs()));
+    s.setValue("ClientCompRxKneeDb",      QString::number(m_clientCompRx->kneeDb()));
+    s.setValue("ClientCompRxMakeupDb",    QString::number(m_clientCompRx->makeupDb()));
+    s.setValue("ClientCompRxLimEnabled",  toBool(m_clientCompRx->limiterEnabled()));
+    s.setValue("ClientCompRxLimCeilingDb",
+               QString::number(m_clientCompRx->limiterCeilingDb()));
+}
+
 void AudioEngine::loadClientGateSettings()
 {
     if (!m_clientGateTx) return;
@@ -1548,6 +1837,60 @@ void AudioEngine::saveClientGateSettings() const
         QString::number(m_clientGateTx->floorDb()));
     s.setValue("ClientGateTxLookaheadMs",
         QString::number(m_clientGateTx->lookaheadMs()));
+}
+
+void AudioEngine::loadClientGateRxSettings()
+{
+    if (!m_clientGateRx) return;
+    auto& s = AppSettings::instance();
+    m_clientGateRx->setEnabled(
+        s.value("ClientGateRxEnabled", "False").toString() == "True");
+    const int modeInt = s.value("ClientGateRxMode", "0").toInt();
+    m_clientGateRx->setMode(modeInt == 1
+        ? ClientGate::Mode::Gate
+        : ClientGate::Mode::Expander);
+    m_clientGateRx->setThresholdDb(
+        s.value("ClientGateRxThresholdDb", "-40.0").toFloat());
+    m_clientGateRx->setReturnDb(
+        s.value("ClientGateRxReturnDb", "2.0").toFloat());
+    m_clientGateRx->setRatio(
+        s.value("ClientGateRxRatio", "2.0").toFloat());
+    m_clientGateRx->setAttackMs(
+        s.value("ClientGateRxAttackMs", "0.5").toFloat());
+    m_clientGateRx->setHoldMs(
+        s.value("ClientGateRxHoldMs", "20.0").toFloat());
+    m_clientGateRx->setReleaseMs(
+        s.value("ClientGateRxReleaseMs", "100.0").toFloat());
+    m_clientGateRx->setFloorDb(
+        s.value("ClientGateRxFloorDb", "-15.0").toFloat());
+    m_clientGateRx->setLookaheadMs(
+        s.value("ClientGateRxLookaheadMs", "0.0").toFloat());
+}
+
+void AudioEngine::saveClientGateRxSettings() const
+{
+    if (!m_clientGateRx) return;
+    auto& s = AppSettings::instance();
+    auto toBool = [](bool on) { return on ? QString("True") : QString("False"); };
+    s.setValue("ClientGateRxEnabled", toBool(m_clientGateRx->isEnabled()));
+    s.setValue("ClientGateRxMode",
+        QString::number(static_cast<int>(m_clientGateRx->mode())));
+    s.setValue("ClientGateRxThresholdDb",
+        QString::number(m_clientGateRx->thresholdDb()));
+    s.setValue("ClientGateRxReturnDb",
+        QString::number(m_clientGateRx->returnDb()));
+    s.setValue("ClientGateRxRatio",
+        QString::number(m_clientGateRx->ratio()));
+    s.setValue("ClientGateRxAttackMs",
+        QString::number(m_clientGateRx->attackMs()));
+    s.setValue("ClientGateRxHoldMs",
+        QString::number(m_clientGateRx->holdMs()));
+    s.setValue("ClientGateRxReleaseMs",
+        QString::number(m_clientGateRx->releaseMs()));
+    s.setValue("ClientGateRxFloorDb",
+        QString::number(m_clientGateRx->floorDb()));
+    s.setValue("ClientGateRxLookaheadMs",
+        QString::number(m_clientGateRx->lookaheadMs()));
 }
 
 void AudioEngine::loadClientDeEssSettings()
@@ -1646,6 +1989,61 @@ void AudioEngine::saveClientTubeSettings() const
         QString::number(m_clientTubeTx->releaseMs()));
 }
 
+void AudioEngine::loadClientTubeRxSettings()
+{
+    if (!m_clientTubeRx) return;
+    auto& s = AppSettings::instance();
+    m_clientTubeRx->setEnabled(
+        s.value("ClientTubeRxEnabled", "False").toString() == "True");
+    const int modelInt = s.value("ClientTubeRxModel", "0").toInt();
+    m_clientTubeRx->setModel(
+        modelInt == 1 ? ClientTube::Model::B :
+        modelInt == 2 ? ClientTube::Model::C :
+                        ClientTube::Model::A);
+    m_clientTubeRx->setDriveDb(
+        s.value("ClientTubeRxDriveDb", "0.0").toFloat());
+    m_clientTubeRx->setBiasAmount(
+        s.value("ClientTubeRxBias", "0.0").toFloat());
+    m_clientTubeRx->setTone(
+        s.value("ClientTubeRxTone", "0.0").toFloat());
+    m_clientTubeRx->setOutputGainDb(
+        s.value("ClientTubeRxOutputDb", "0.0").toFloat());
+    m_clientTubeRx->setDryWet(
+        s.value("ClientTubeRxDryWet", "1.0").toFloat());
+    m_clientTubeRx->setEnvelopeAmount(
+        s.value("ClientTubeRxEnvelope", "0.0").toFloat());
+    m_clientTubeRx->setAttackMs(
+        s.value("ClientTubeRxAttackMs", "5.0").toFloat());
+    m_clientTubeRx->setReleaseMs(
+        s.value("ClientTubeRxReleaseMs", "35.0").toFloat());
+}
+
+void AudioEngine::saveClientTubeRxSettings() const
+{
+    if (!m_clientTubeRx) return;
+    auto& s = AppSettings::instance();
+    auto toBool = [](bool on) { return on ? QString("True") : QString("False"); };
+    s.setValue("ClientTubeRxEnabled",  toBool(m_clientTubeRx->isEnabled()));
+    s.setValue("ClientTubeRxModel",
+        QString::number(static_cast<int>(m_clientTubeRx->model())));
+    s.setValue("ClientTubeRxDriveDb",
+        QString::number(m_clientTubeRx->driveDb()));
+    s.setValue("ClientTubeRxBias",
+        QString::number(m_clientTubeRx->biasAmount()));
+    s.setValue("ClientTubeRxTone",
+        QString::number(m_clientTubeRx->tone()));
+    s.setValue("ClientTubeRxOutputDb",
+        QString::number(m_clientTubeRx->outputGainDb()));
+    s.setValue("ClientTubeRxDryWet",
+        QString::number(m_clientTubeRx->dryWet()));
+    s.setValue("ClientTubeRxEnvelope",
+        QString::number(m_clientTubeRx->envelopeAmount()));
+    s.setValue("ClientTubeRxAttackMs",
+        QString::number(m_clientTubeRx->attackMs()));
+    s.setValue("ClientTubeRxReleaseMs",
+        QString::number(m_clientTubeRx->releaseMs()));
+}
+
 void AudioEngine::loadClientPuduSettings()
 {
     if (!m_clientPuduTx) return;
@@ -1697,6 +2095,52 @@ void AudioEngine::saveClientPuduSettings() const
         QString::number(m_clientPuduTx->dooHarmonicsDb()));
     s.setValue("ClientPuduTxDooMix",
         QString::number(m_clientPuduTx->dooMix()));
+}
+
+void AudioEngine::loadClientPuduRxSettings()
+{
+    if (!m_clientPuduRx) return;
+    auto& s = AppSettings::instance();
+    m_clientPuduRx->setEnabled(
+        s.value("ClientPuduRxEnabled", "False").toString() == "True");
+    const int modeInt = s.value("ClientPuduRxMode", "0").toInt();
+    m_clientPuduRx->setMode(modeInt == 1
+        ? ClientPudu::Mode::Behringer
+        : ClientPudu::Mode::Aphex);
+    m_clientPuduRx->setPooDriveDb(
+        s.value("ClientPuduRxPooDriveDb", "6.0").toFloat());
+    m_clientPuduRx->setPooTuneHz(
+        s.value("ClientPuduRxPooTuneHz", "100.0").toFloat());
+    m_clientPuduRx->setPooMix(
+        s.value("ClientPuduRxPooMix", "0.3").toFloat());
+    m_clientPuduRx->setDooTuneHz(
+        s.value("ClientPuduRxDooTuneHz", "5000.0").toFloat());
+    m_clientPuduRx->setDooHarmonicsDb(
+        s.value("ClientPuduRxDooHarmonicsDb", "6.0").toFloat());
+    m_clientPuduRx->setDooMix(
+        s.value("ClientPuduRxDooMix", "0.3").toFloat());
+}
+
+void AudioEngine::saveClientPuduRxSettings() const
+{
+    if (!m_clientPuduRx) return;
+    auto& s = AppSettings::instance();
+    auto toBool = [](bool on) { return on ? QString("True") : QString("False"); };
+    s.setValue("ClientPuduRxEnabled", toBool(m_clientPuduRx->isEnabled()));
+    s.setValue("ClientPuduRxMode",
+        QString::number(static_cast<int>(m_clientPuduRx->mode())));
+    s.setValue("ClientPuduRxPooDriveDb",
+        QString::number(m_clientPuduRx->pooDriveDb()));
+    s.setValue("ClientPuduRxPooTuneHz",
+        QString::number(m_clientPuduRx->pooTuneHz()));
+    s.setValue("ClientPuduRxPooMix",
+        QString::number(m_clientPuduRx->pooMix()));
+    s.setValue("ClientPuduRxDooTuneHz",
+        QString::number(m_clientPuduRx->dooTuneHz()));
+    s.setValue("ClientPuduRxDooHarmonicsDb",
+        QString::number(m_clientPuduRx->dooHarmonicsDb()));
+    s.setValue("ClientPuduRxDooMix",
+        QString::number(m_clientPuduRx->dooMix()));
 }
 
 void AudioEngine::loadClientReverbSettings()

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -195,11 +195,13 @@ public:
     // brickwall limiter, #1661).  Runs on the TX audio path only.
     // Execution order is controlled by the TX chain order below.
     ClientComp* clientCompTx() { return m_clientCompTx.get(); }
+    ClientComp* clientCompRx() { return m_clientCompRx.get(); }
 
     // Client-side TX downward expander / noise gate (#1661 Phase 2).
     // Single DSP module with an Expander ↔ Gate mode toggle that
     // snaps ratio + floor to known-good presets.
     ClientGate* clientGateTx() { return m_clientGateTx.get(); }
+    ClientGate* clientGateRx() { return m_clientGateRx.get(); }
 
     // Client-side TX de-esser (#1661 Phase 3).  Sidechain-filtered
     // dynamics: a user-tunable bandpass feeds the envelope detector,
@@ -211,11 +213,13 @@ public:
     // selectable curves, bipolar envelope-driven drive, tilt tone
     // pre-filter, parallel dry/wet mix.
     ClientTube* clientTubeTx() { return m_clientTubeTx.get(); }
+    ClientTube* clientTubeRx() { return m_clientTubeRx.get(); }
 
     // Client-side TX exciter — PUDU (#1661 Phase 5).  Aphex-lineage
     // vs. Behringer-lineage two-band exciter, the centrepiece of the
     // PooDoo Audio™ chain.
     ClientPudu* clientPuduTx() { return m_clientPuduTx.get(); }
+    ClientPudu* clientPuduRx() { return m_clientPuduRx.get(); }
 
     // Client-side TX reverb — Freeverb-based room/hall effect, final
     // optional stage in the PooDoo™ chain.
@@ -243,6 +247,26 @@ public:
     };
     static constexpr int kMaxTxChainStages = 8;  // packs into uint64_t
 
+    // RX chain — same packed-atomic dispatcher pattern as TX, applied
+    // to playback audio after the radio's NR has run.  Phase 0 ships
+    // the framework with no implemented stages; Phase 1+ slot in the
+    // RX-side ClientEq, ClientGate, ClientComp, ClientTube, ClientPudu
+    // instances.  See plans/poodoo-rx-chain.md.
+    enum class RxChainStage : uint8_t {
+        None = 0,   // sentinel / end-of-list marker
+        Eq   = 1,
+        Gate = 2,
+        Comp = 3,
+        Tube = 4,
+        Pudu = 5,
+    };
+    static constexpr int kMaxRxChainStages = 8;  // packs into uint64_t
+
+    void setRxChainStages(const QVector<RxChainStage>& stages);
+    QVector<RxChainStage> rxChainStages() const;
+    void loadClientRxChainOrder();
+    void saveClientRxChainOrder() const;
+
     // Set the ordered list of stages.  UI thread API; commits an
     // atomic snapshot that the audio thread picks up on its next block.
     // Order may contain any subset of stages; unlisted stages are
@@ -263,10 +287,14 @@ public:
     TxChainOrder txChainOrder() const;
 
     void loadClientCompSettings();
+    void loadClientCompRxSettings();
+    void saveClientCompRxSettings() const;
     void saveClientCompSettings() const;
 
     // Client-side TX gate — persistence mirrors the compressor.
     void loadClientGateSettings();
+    void loadClientGateRxSettings();
+    void saveClientGateRxSettings() const;
     void saveClientGateSettings() const;
 
     // Client-side TX de-esser — persistence.
@@ -275,10 +303,14 @@ public:
 
     // Client-side TX dynamic tube — persistence.
     void loadClientTubeSettings();
+    void loadClientTubeRxSettings();
+    void saveClientTubeRxSettings() const;
     void saveClientTubeSettings() const;
 
     // Client-side TX PUDU exciter — persistence.
     void loadClientPuduSettings();
+    void loadClientPuduRxSettings();
+    void saveClientPuduRxSettings() const;
     void saveClientPuduSettings() const;
 
     // Client-side TX reverb (Freeverb) — persistence.
@@ -344,6 +376,7 @@ signals:
     void txPacketReady(const QByteArray& vitaPacket);  // VITA-49 TX packet for PanadapterStream
 
     void pcMicLevelChanged(float peakDbfs, float avgDbfs);  // client-side PC mic metering
+    void mutedChanged(bool muted);                          // local audio output mute state
 
 private slots:
     void onTxAudioReady();
@@ -363,24 +396,38 @@ private:
     // Apply client-side TX compressor in-place.  No-op if disabled.
     void applyClientCompTxInt16(QByteArray& int16stereo);
     void applyClientCompTxFloat32(QByteArray& float32);
+    // RX comp operates on the post-Gate float32 stereo buffer.
+    void applyClientCompRxFloat32(QByteArray& float32);
     // Apply client-side TX gate in-place.  No-op if disabled.
     void applyClientGateTxInt16(QByteArray& int16stereo);
     void applyClientGateTxFloat32(QByteArray& float32);
+    // RX gate operates on the post-EQ float32 stereo buffer.
+    void applyClientGateRxFloat32(QByteArray& float32);
     // Apply client-side TX de-esser in-place.  No-op if disabled.
     void applyClientDeEssTxInt16(QByteArray& int16stereo);
     void applyClientDeEssTxFloat32(QByteArray& float32);
     // Apply client-side TX tube saturator in-place.  No-op if disabled.
     void applyClientTubeTxInt16(QByteArray& int16stereo);
     void applyClientTubeTxFloat32(QByteArray& float32);
+    // RX tube operates on the post-Comp float32 stereo buffer.
+    void applyClientTubeRxFloat32(QByteArray& float32);
     // Apply client-side TX PUDU exciter in-place.  No-op if disabled.
     void applyClientPuduTxInt16(QByteArray& int16stereo);
     void applyClientPuduTxFloat32(QByteArray& float32);
+    // RX pudu operates on the post-Tube float32 stereo buffer.
+    void applyClientPuduRxFloat32(QByteArray& float32);
     // Apply client-side TX reverb in-place.  No-op if disabled.
     void applyClientReverbTxInt16(QByteArray& int16stereo);
     void applyClientReverbTxFloat32(QByteArray& float32);
     // Apply the whole TX DSP chain (CMP + EQ) in the configured order.
     void applyClientTxDspInt16(QByteArray& int16stereo);
     void applyClientTxDspFloat32(QByteArray& float32);
+
+    // Apply the whole RX DSP chain in the configured order.  Phase 0
+    // ships the dispatcher with no implemented stages — every entry is
+    // a no-op until its class lands.  Plays float32 stereo (the native
+    // RX format after NR).
+    void applyClientRxDspFloat32(QByteArray& float32);
 
     // RX
     QAudioSink*   m_audioSink{nullptr};
@@ -496,14 +543,18 @@ private:
     std::unique_ptr<ClientEq> m_clientEqTx;
     // Client-side TX compressor (Pro-XL-style).
     std::unique_ptr<ClientComp> m_clientCompTx;
+    std::unique_ptr<ClientComp> m_clientCompRx;
     // Client-side TX downward expander / noise gate.
     std::unique_ptr<ClientGate> m_clientGateTx;
+    std::unique_ptr<ClientGate> m_clientGateRx;
     // Client-side TX de-esser.
     std::unique_ptr<ClientDeEss> m_clientDeEssTx;
     // Client-side TX tube saturator.
     std::unique_ptr<ClientTube> m_clientTubeTx;
+    std::unique_ptr<ClientTube> m_clientTubeRx;
     // Client-side TX PUDU exciter.
     std::unique_ptr<ClientPudu> m_clientPuduTx;
+    std::unique_ptr<ClientPudu> m_clientPuduRx;
     // Client-side TX reverb.
     std::unique_ptr<ClientReverb> m_clientReverbTx;
     // Post-DSP TX monitor — owned by MainWindow; we just hold a
@@ -516,14 +567,22 @@ private:
     // [Gate, Eq, DeEss, Comp, Tube, Enh] — but only Eq and Comp have
     // implementations today, so the others are no-op pass-throughs.
     std::atomic<uint64_t> m_txChainPacked{0};
+    // RX chain — same packing convention.  RxChainStage::None terminates
+    // the list.  Phase 0 dispatcher iterates this but every stage is a
+    // no-op until its DSP class lands in a later phase.
+    std::atomic<uint64_t> m_rxChainPacked{0};
     // Scratch buffer for in-place EQ on the RX path (avoids per-call alloc).
     QByteArray m_clientEqRxScratch;
     QByteArray m_clientEqTxScratch;
     QByteArray m_clientCompTxScratch;
+    QByteArray m_clientCompRxScratch;
     QByteArray m_clientGateTxScratch;
+    QByteArray m_clientGateRxScratch;
     QByteArray m_clientDeEssTxScratch;
     QByteArray m_clientTubeTxScratch;
+    QByteArray m_clientTubeRxScratch;
     QByteArray m_clientPuduTxScratch;
+    QByteArray m_clientPuduRxScratch;
     QByteArray m_clientReverbTxScratch;
     // Post-EQ analyzer tap. One ring per path, mono (L+R averaged).
     // Audio thread writes via tapClientEqRxStereo() / tapClientEqTxInt16()

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -614,17 +614,25 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // the three sub-containers live inside a parent "tx_dsp"
     // container whose own titlebar is hidden (the outer AppletEntry
     // wrapper provides the group's drag-handle + tray-toggle).
-    m_clientEqApplet    = new ClientEqApplet;
-    m_clientCompApplet  = new ClientCompApplet;
-    m_clientGateApplet  = new ClientGateApplet;
+    // Phase 7.1: CEQ split — one Tx-bound copy + one Rx-bound copy.
+    // No internal Rx/Tx tab anymore; each tile owns one path for its
+    // entire lifetime.
+    m_clientEqTxApplet  = new ClientEqApplet(ClientEqApplet::Path::Tx);
+    m_clientEqRxApplet  = new ClientEqApplet(ClientEqApplet::Path::Rx);
+    m_clientCompApplet   = new ClientCompApplet(ClientCompApplet::Side::Tx);
+    m_clientCompRxApplet = new ClientCompApplet(ClientCompApplet::Side::Rx);
+    m_clientGateApplet   = new ClientGateApplet(ClientGateApplet::Side::Tx);
+    m_clientGateRxApplet = new ClientGateApplet(ClientGateApplet::Side::Rx);
     m_clientDeEssApplet = new ClientDeEssApplet;
-    m_clientTubeApplet  = new ClientTubeApplet;
-    m_clientPuduApplet  = new ClientPuduApplet;
+    m_clientTubeApplet   = new ClientTubeApplet(ClientTubeApplet::Side::Tx);
+    m_clientTubeRxApplet = new ClientTubeApplet(ClientTubeApplet::Side::Rx);
+    m_clientPuduApplet   = new ClientPuduApplet(ClientPuduApplet::Side::Tx);
+    m_clientPuduRxApplet = new ClientPuduApplet(ClientPuduApplet::Side::Rx);
     m_clientReverbApplet = new ClientReverbApplet;
     m_clientChainApplet = new ClientChainApplet;
 
     auto* txDsp = m_containerMgr->createContainer(
-        "tx_dsp", QString::fromUtf8("PooDoo\xe2\x84\xa2 Audio"));
+        "tx_dsp", QString::fromUtf8("Aetherial Audio\xe2\x84\xa2"));
 
     auto makeChildContainer = [this, txDsp](const QString& id,
                                             const QString& title,
@@ -641,13 +649,18 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // pop-outable sub-containers since users commonly want them
     // floating while working on the chain.)
     if (txDsp) txDsp->insertChildWidget(-1, m_clientChainApplet);
-    makeChildContainer("gate",  "GATE",  m_clientGateApplet,   -1);
-    makeChildContainer("ceq",   "CEQ",   m_clientEqApplet,     -1);
-    makeChildContainer("dess",  "DESS",  m_clientDeEssApplet,  -1);
-    makeChildContainer("cmp",   "COMPRESSOR",   m_clientCompApplet,   -1);
-    makeChildContainer("tube",  "TUBE",  m_clientTubeApplet,   -1);
-    makeChildContainer("pudu",  "PUDU",  m_clientPuduApplet,   -1);
-    makeChildContainer("reverb","REVERB",m_clientReverbApplet, -1);
+    makeChildContainer("gate",    "Aetherial TX Gate",       m_clientGateApplet,   -1);
+    makeChildContainer("gate-rx", "Aetherial AGC-T",          m_clientGateRxApplet, -1);
+    makeChildContainer("ceq",     "Aetherial TX EQ",          m_clientEqTxApplet,   -1);
+    makeChildContainer("ceq-rx",  "Aetherial RX EQ",          m_clientEqRxApplet,   -1);
+    makeChildContainer("dess",    "Aetherial De-Esser",       m_clientDeEssApplet,  -1);
+    makeChildContainer("cmp",     "Aetherial Compressor",     m_clientCompApplet,   -1);
+    makeChildContainer("cmp-rx",  "Aetherial AGC-C",          m_clientCompRxApplet, -1);
+    makeChildContainer("tube",    "Aetherial Mic-PreAmp",     m_clientTubeApplet,   -1);
+    makeChildContainer("tube-rx", "Aetherial Dynamic Tube",   m_clientTubeRxApplet, -1);
+    makeChildContainer("pudu",    QString::fromUtf8("Aetherial TX Poodoo\xe2\x84\xa2"), m_clientPuduApplet,   -1);
+    makeChildContainer("pudu-rx", QString::fromUtf8("Aetherial RX Poodoo\xe2\x84\xa2"), m_clientPuduRxApplet, -1);
+    makeChildContainer("reverb",  "Aetherial FreeVerb",       m_clientReverbApplet, -1);
 
     // One-shot settings migration (#1713 Phase 4b): carry over the
     // legacy Applet_CHAIN visibility to the new Applet_TXDSP key so
@@ -785,6 +798,43 @@ void AppletPanel::setAppletVisible(const QString& id, bool visible)
     }
 }
 
+void AppletPanel::setPooDooActiveSide(PooDooSide side)
+{
+    if (!m_containerMgr) return;
+    // Containers tagged as TX-only or RX-only.  CEQ has dedicated
+    // tiles per side ("ceq" = TX, "ceq-rx" = RX), as do GATE / CMP /
+    // TUBE / PUDU once Phases 7.2-7.5 ship (their RX siblings will
+    // join this list as they're added).  DESS and REVERB are TX-only
+    // — they hide entirely on RX and reappear on TX.
+    static const QStringList kTxOnly{
+        QStringLiteral("ceq"),
+        QStringLiteral("dess"),
+        QStringLiteral("gate"),
+        QStringLiteral("cmp"),
+        QStringLiteral("tube"),
+        QStringLiteral("pudu"),
+        QStringLiteral("reverb"),
+    };
+    static const QStringList kRxOnly{
+        QStringLiteral("ceq-rx"),
+        QStringLiteral("gate-rx"),
+        QStringLiteral("cmp-rx"),
+        QStringLiteral("tube-rx"),
+        QStringLiteral("pudu-rx"),
+    };
+    const bool txActive = (side == PooDooSide::Tx);
+
+    auto applyVisibility = [this](const QStringList& ids, bool visible) {
+        for (const auto& id : ids) {
+            if (auto* c = m_containerMgr->container(id)) {
+                c->setContainerVisible(visible);
+            }
+        }
+    };
+    applyVisibility(kTxOnly, txActive);
+    applyVisibility(kRxOnly, !txActive);
+}
+
 void AppletPanel::resetOrder()
 {
     // Reorder m_appletOrder to match kDefaultOrder
@@ -893,6 +943,35 @@ void AppletPanel::setMaxSlices(int maxSlices)
 void AppletPanel::updateSliceButtons(const QList<SliceModel*>& slices, int activeSliceId)
 {
     m_rxApplet->updateSliceButtons(slices, activeSliceId);
+}
+
+void AppletPanel::setRxDspChainOrder(
+    const QVector<AudioEngine::RxChainStage>& stages)
+{
+    if (!m_containerMgr) return;
+    auto* parent = m_containerMgr->container("tx_dsp");
+    if (!parent) return;
+
+    auto idFor = [](AudioEngine::RxChainStage s) -> QString {
+        switch (s) {
+            case AudioEngine::RxChainStage::Eq:   return "ceq-rx";
+            case AudioEngine::RxChainStage::Gate: return "gate-rx";
+            case AudioEngine::RxChainStage::Comp: return "cmp-rx";
+            case AudioEngine::RxChainStage::Tube: return "tube-rx";
+            case AudioEngine::RxChainStage::Pudu: return "pudu-rx";
+            case AudioEngine::RxChainStage::None: return {};
+        }
+        return {};
+    };
+
+    for (auto s : stages) {
+        const QString id = idFor(s);
+        if (id.isEmpty()) continue;
+        auto* child = m_containerMgr->container(id);
+        if (!child) continue;
+        parent->removeChildWidget(child);
+        parent->insertChildWidget(-1, child);
+    }
 }
 
 void AppletPanel::setTxDspChainOrder(

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -67,12 +67,35 @@ public:
     PhoneCwApplet*  phoneCwApplet()  { return m_phoneCwApplet; }
     PhoneApplet*    phoneApplet()    { return m_phoneApplet; }
     EqApplet*       eqApplet()       { return m_eqApplet; }
-    ClientEqApplet* clientEqApplet() { return m_clientEqApplet; }
-    ClientCompApplet* clientCompApplet() { return m_clientCompApplet; }
-    ClientGateApplet* clientGateApplet() { return m_clientGateApplet; }
+    // Phase 7.1: each side has its own CEQ applet — clientEqTxApplet()
+    // is the original "ceq" tile bound to TX, clientEqRxApplet() is
+    // the new "ceq-rx" tile bound to RX.  clientEqApplet() retained as
+    // an alias for the TX-side instance so legacy call sites compile
+    // unchanged.
+    ClientEqApplet* clientEqApplet()   { return m_clientEqTxApplet; }
+    ClientEqApplet* clientEqTxApplet() { return m_clientEqTxApplet; }
+    ClientEqApplet* clientEqRxApplet() { return m_clientEqRxApplet; }
+    // Phase 7.3: CMP-TX retains the legacy accessor; CMP-RX is the new
+    // sibling tile bound to AudioEngine::clientCompRx().
+    ClientCompApplet* clientCompApplet()   { return m_clientCompApplet; }
+    ClientCompApplet* clientCompTxApplet() { return m_clientCompApplet; }
+    ClientCompApplet* clientCompRxApplet() { return m_clientCompRxApplet; }
+    // Phase 7.2: GATE-TX retains the legacy accessor name; GATE-RX is
+    // the new sibling tile bound to AudioEngine::clientGateRx().
+    ClientGateApplet* clientGateApplet()   { return m_clientGateApplet; }
+    ClientGateApplet* clientGateTxApplet() { return m_clientGateApplet; }
+    ClientGateApplet* clientGateRxApplet() { return m_clientGateRxApplet; }
     ClientDeEssApplet* clientDeEssApplet() { return m_clientDeEssApplet; }
-    ClientTubeApplet* clientTubeApplet() { return m_clientTubeApplet; }
-    ClientPuduApplet* clientPuduApplet() { return m_clientPuduApplet; }
+    // Phase 7.4: TUBE-TX retains the legacy accessor; TUBE-RX is the new
+    // sibling tile bound to AudioEngine::clientTubeRx().
+    ClientTubeApplet* clientTubeApplet()   { return m_clientTubeApplet; }
+    ClientTubeApplet* clientTubeTxApplet() { return m_clientTubeApplet; }
+    ClientTubeApplet* clientTubeRxApplet() { return m_clientTubeRxApplet; }
+    // Phase 7.5: PUDU-TX retains the legacy accessor; PUDU-RX is the new
+    // sibling tile bound to AudioEngine::clientPuduRx().
+    ClientPuduApplet* clientPuduApplet()   { return m_clientPuduApplet; }
+    ClientPuduApplet* clientPuduTxApplet() { return m_clientPuduApplet; }
+    ClientPuduApplet* clientPuduRxApplet() { return m_clientPuduRxApplet; }
     ClientReverbApplet* clientReverbApplet() { return m_clientReverbApplet; }
     ClientChainApplet* clientChainApplet() { return m_clientChainApplet; }
     CatControlApplet* catControlApplet() { return m_catControlApplet; }
@@ -102,10 +125,20 @@ public:
     // CEQ and CMP tile visibility).  No-op for unknown IDs.
     void setAppletVisible(const QString& id, bool visible);
 
+    // Phase 7.1+: side filter for the PooDoo Audio sub-containers.
+    // ClientChainApplet calls this when the TX/RX tab flips.  Sub-
+    // containers tagged for the inactive side are hidden; tiles for
+    // the active side are restored to their last visibility state
+    // (driven by per-stage bypass).  TX-only tiles (DESS, REVERB)
+    // hide entirely on RX.
+    enum class PooDooSide { Tx, Rx };
+    void setPooDooActiveSide(PooDooSide side);
+
     // Reorder the TX DSP sub-containers inside the "tx_dsp" parent to
     // mirror the CHAIN's current stage order.  Call whenever the user
     // drags to reorder the chain; the applet tiles follow.
     void setTxDspChainOrder(const QVector<AudioEngine::TxChainStage>& stages);
+    void setRxDspChainOrder(const QVector<AudioEngine::RxChainStage>& stages);
 
     // ── Container system (Phase 4a groundwork, #1713) ───────────
     //
@@ -159,12 +192,17 @@ private:
     PhoneCwApplet* m_phoneCwApplet{nullptr};
     PhoneApplet*   m_phoneApplet{nullptr};
     EqApplet*      m_eqApplet{nullptr};
-    ClientEqApplet* m_clientEqApplet{nullptr};
+    ClientEqApplet* m_clientEqTxApplet{nullptr};
+    ClientEqApplet* m_clientEqRxApplet{nullptr};
     ClientCompApplet* m_clientCompApplet{nullptr};
+    ClientCompApplet* m_clientCompRxApplet{nullptr};
     ClientGateApplet* m_clientGateApplet{nullptr};
+    ClientGateApplet* m_clientGateRxApplet{nullptr};
     ClientDeEssApplet* m_clientDeEssApplet{nullptr};
     ClientTubeApplet* m_clientTubeApplet{nullptr};
+    ClientTubeApplet* m_clientTubeRxApplet{nullptr};
     ClientPuduApplet* m_clientPuduApplet{nullptr};
+    ClientPuduApplet* m_clientPuduRxApplet{nullptr};
     ClientReverbApplet* m_clientReverbApplet{nullptr};
     ClientChainApplet* m_clientChainApplet{nullptr};
     CatControlApplet* m_catControlApplet{nullptr};

--- a/src/gui/ClientChainApplet.cpp
+++ b/src/gui/ClientChainApplet.cpp
@@ -1,5 +1,7 @@
 #include "ClientChainApplet.h"
 #include "ClientChainWidget.h"
+#include "ClientRxChainWidget.h"
+#include "core/AppSettings.h"
 #include "core/ClientComp.h"
 #include "core/ClientDeEss.h"
 #include "core/ClientEq.h"
@@ -107,7 +109,7 @@ ClientChainApplet::ClientChainApplet(QWidget* parent) : QWidget(parent)
         m_rxBtn->setCheckable(true);
         m_rxBtn->setStyleSheet(kModeBtnStyle);
         m_rxBtn->setFixedHeight(22);
-        m_rxBtn->setToolTip("Show and edit the RX DSP chain (coming soon)");
+        m_rxBtn->setToolTip("Show and edit the RX DSP chain");
         group->addButton(m_rxBtn, static_cast<int>(ChainMode::Rx));
         row->addWidget(m_rxBtn);
 
@@ -180,18 +182,16 @@ ClientChainApplet::ClientChainApplet(QWidget* parent) : QWidget(parent)
         outer->addLayout(row);
     }
 
-    // ── Chain strip (TX) + RX placeholder, stacked — only one visible
+    // ── Chain strips (TX + RX), stacked — only one visible at a time.
+    // Phase 0: the RX strip ships with three live status tiles
+    // (RADIO / DSP / SPEAK) bracketing five "coming soon" placeholders
+    // for the user-controllable stages.
     m_chain = new ClientChainWidget;
     outer->addWidget(m_chain);
 
-    m_rxPlaceholder = new QLabel("Client RX chain — coming in a future phase");
-    m_rxPlaceholder->setAlignment(Qt::AlignCenter);
-    m_rxPlaceholder->setStyleSheet(
-        "QLabel { color: #607888; font-size: 10px; font-style: italic;"
-        "         background: #0e1b28; border: 1px dashed #243a4e;"
-        "         border-radius: 3px; padding: 14px; }");
-    m_rxPlaceholder->hide();
-    outer->addWidget(m_rxPlaceholder);
+    m_rxChain = new ClientRxChainWidget;
+    m_rxChain->hide();
+    outer->addWidget(m_rxChain);
 
     // ── Hint (below the chain) ──────────────────────────────────
     m_hint = new QLabel(
@@ -208,6 +208,21 @@ ClientChainApplet::ClientChainApplet(QWidget* parent) : QWidget(parent)
             this, &ClientChainApplet::stageEnabledChanged);
     connect(m_chain, &ClientChainWidget::chainReordered,
             this, &ClientChainApplet::chainReordered);
+    connect(m_rxChain, &ClientRxChainWidget::editRequested,
+            this, &ClientChainApplet::rxEditRequested);
+    connect(m_rxChain, &ClientRxChainWidget::stageEnabledChanged,
+            this, &ClientChainApplet::rxStageEnabledChanged);
+    connect(m_rxChain, &ClientRxChainWidget::chainReordered,
+            this, &ClientChainApplet::rxChainReordered);
+
+    // Restore last-active tab now that everything is wired.  Toggling
+    // the button fires the group's idToggled signal which calls
+    // setMode(), swapping widget visibility and saving the setting.
+    const QString savedTab = AppSettings::instance()
+        .value("PooDooAudioActiveTab", "TX").toString();
+    if (savedTab == "RX" && m_rxBtn) {
+        m_rxBtn->setChecked(true);
+    }
 
     hide();  // hidden until toggled on from the applet tray
 }
@@ -215,7 +230,8 @@ ClientChainApplet::ClientChainApplet(QWidget* parent) : QWidget(parent)
 void ClientChainApplet::setAudioEngine(AudioEngine* engine)
 {
     m_audio = engine;
-    if (m_chain) m_chain->setAudioEngine(engine);
+    if (m_chain)   m_chain->setAudioEngine(engine);
+    if (m_rxChain) m_rxChain->setAudioEngine(engine);
 }
 
 void ClientChainApplet::refreshFromEngine()
@@ -331,19 +347,146 @@ void ClientChainApplet::setMode(ChainMode m)
     m_mode = m;
 
     const bool tx = (m == ChainMode::Tx);
-    if (m_chain)          m_chain->setVisible(tx);
-    if (m_rxPlaceholder)  m_rxPlaceholder->setVisible(!tx);
-    // Hint text only makes sense for TX since that's the only
-    // interactive chain today.
-    if (m_hint)           m_hint->setVisible(tx);
+    if (m_chain)      m_chain->setVisible(tx);
+    if (m_rxChain)    m_rxChain->setVisible(!tx);
+    // Monitor record/play buttons capture post-PUDU TX audio; they're
+    // meaningless on the RX chain so hide them when RX is showing.
+    if (m_monRecBtn)  m_monRecBtn->setVisible(tx);
+    if (m_monPlayBtn) m_monPlayBtn->setVisible(tx);
+    // Hint text applies to whichever chain is showing — both sides
+    // now support the click-bypass / double-click-edit gestures.
+    if (m_hint)       m_hint->setVisible(true);
+
+    // BYPASS button visual must reflect the *current* tab's bypass
+    // state — each side has its own snapshot.  QSignalBlocker keeps
+    // the toggled() handler from re-firing onBypassToggled and
+    // touching the engine.
+    if (m_bypassBtn) {
+        const bool bypassed = tx ? !m_bypassSnapshot.isEmpty()
+                                 : !m_rxBypassSnapshot.isEmpty();
+        QSignalBlocker blocker(m_bypassBtn);
+        m_bypassBtn->setChecked(bypassed);
+    }
+
+    AppSettings::instance().setValue(
+        "PooDooAudioActiveTab", tx ? "TX" : "RX");
+
+    emit chainModeChanged(m);
+}
+
+void ClientChainApplet::setActiveTab(ChainMode m)
+{
+    if (m == m_mode) return;
+    // Re-route through the button group so the visual checked state
+    // tracks; setMode() below runs as a side effect of the toggle.
+    QPushButton* btn = (m == ChainMode::Tx) ? m_txBtn : m_rxBtn;
+    if (btn) {
+        QSignalBlocker blocker(btn);
+        btn->setChecked(true);
+    }
+    setMode(m);
+}
+
+void ClientChainApplet::setRxPcAudioEnabled(bool on)
+{
+    if (m_rxChain) m_rxChain->setPcAudioEnabled(on);
+}
+
+void ClientChainApplet::setRxClientDspActive(bool on, const QString& label)
+{
+    if (m_rxChain) m_rxChain->setClientDspActive(on, label);
+}
+
+void ClientChainApplet::setRxOutputUnmuted(bool on)
+{
+    if (m_rxChain) m_rxChain->setOutputUnmuted(on);
 }
 
 void ClientChainApplet::onBypassToggled(bool checked)
 {
     if (!m_audio) return;
-    if (m_mode != ChainMode::Tx) {
-        // RX mode: no DSP yet.  Leave the button in whatever state
-        // the user clicked — it's a no-op until the RX chain ships.
+    if (m_mode == ChainMode::Rx) {
+        // RX BYPASS — same snapshot-and-disable / restore-on-uncheck
+        // behaviour as TX, but routed through the RX engine instances
+        // and per-side AppSettings keys.
+        auto setRxStageEnabled = [&](AudioEngine::RxChainStage stage, bool on) {
+            switch (stage) {
+                case AudioEngine::RxChainStage::Eq:
+                    if (auto* d = m_audio->clientEqRx()) {
+                        d->setEnabled(on);
+                        m_audio->saveClientEqSettings();
+                    }
+                    break;
+                case AudioEngine::RxChainStage::Gate:
+                    if (auto* d = m_audio->clientGateRx()) {
+                        d->setEnabled(on);
+                        m_audio->saveClientGateRxSettings();
+                    }
+                    break;
+                case AudioEngine::RxChainStage::Comp:
+                    if (auto* d = m_audio->clientCompRx()) {
+                        d->setEnabled(on);
+                        m_audio->saveClientCompRxSettings();
+                    }
+                    break;
+                case AudioEngine::RxChainStage::Tube:
+                    if (auto* d = m_audio->clientTubeRx()) {
+                        d->setEnabled(on);
+                        m_audio->saveClientTubeRxSettings();
+                    }
+                    break;
+                case AudioEngine::RxChainStage::Pudu:
+                    if (auto* d = m_audio->clientPuduRx()) {
+                        d->setEnabled(on);
+                        m_audio->saveClientPuduRxSettings();
+                    }
+                    break;
+                case AudioEngine::RxChainStage::None:
+                    break;
+            }
+            emit rxStageEnabledChanged(stage, on);
+        };
+
+        auto isRxEnabled = [&](AudioEngine::RxChainStage stage) {
+            switch (stage) {
+                case AudioEngine::RxChainStage::Eq:
+                    return m_audio->clientEqRx() && m_audio->clientEqRx()->isEnabled();
+                case AudioEngine::RxChainStage::Gate:
+                    return m_audio->clientGateRx() && m_audio->clientGateRx()->isEnabled();
+                case AudioEngine::RxChainStage::Comp:
+                    return m_audio->clientCompRx() && m_audio->clientCompRx()->isEnabled();
+                case AudioEngine::RxChainStage::Tube:
+                    return m_audio->clientTubeRx() && m_audio->clientTubeRx()->isEnabled();
+                case AudioEngine::RxChainStage::Pudu:
+                    return m_audio->clientPuduRx() && m_audio->clientPuduRx()->isEnabled();
+                case AudioEngine::RxChainStage::None:
+                    return false;
+            }
+            return false;
+        };
+
+        static const QVector<AudioEngine::RxChainStage> kAllRxStages{
+            AudioEngine::RxChainStage::Eq,
+            AudioEngine::RxChainStage::Gate,
+            AudioEngine::RxChainStage::Comp,
+            AudioEngine::RxChainStage::Tube,
+            AudioEngine::RxChainStage::Pudu,
+        };
+
+        if (checked) {
+            m_rxBypassSnapshot.clear();
+            for (auto s : kAllRxStages) {
+                if (isRxEnabled(s)) {
+                    m_rxBypassSnapshot.append(s);
+                    setRxStageEnabled(s, false);
+                }
+            }
+        } else {
+            for (auto s : m_rxBypassSnapshot) setRxStageEnabled(s, true);
+            m_rxBypassSnapshot.clear();
+        }
+
+        if (m_rxChain) m_rxChain->update();
         return;
     }
 

--- a/src/gui/ClientChainApplet.h
+++ b/src/gui/ClientChainApplet.h
@@ -10,6 +10,7 @@ class QPushButton;
 namespace AetherSDR {
 
 class ClientChainWidget;
+class ClientRxChainWidget;
 
 // Docked chain tile — header with [TX] [RX] [BYPASS] buttons, the
 // chain strip, and an interaction hint at the bottom.
@@ -53,9 +54,33 @@ public:
     void setMonitorPlaying(bool on);
     void setMonitorHasRecording(bool has);
 
+    // Phase 0 RX chassis — status-tile inputs forwarded to the RX
+    // chain widget.  See ClientRxChainWidget for semantics.
+    void setRxPcAudioEnabled(bool on);
+    // label = active module's short name (e.g. "NR4"); empty → generic "DSP"
+    void setRxClientDspActive(bool on, const QString& label = QString());
+    void setRxOutputUnmuted(bool on);
+
+    // Programmatic tab switch — used to restore PooDooAudioActiveTab
+    // on startup.  Public so MainWindow can drive it after settings
+    // load.  Does nothing if the requested mode is already active.
+    void setActiveTab(ChainMode m);
+
 signals:
     void editRequested(AudioEngine::TxChainStage stage);
     void stageEnabledChanged(AudioEngine::TxChainStage stage, bool enabled);
+    // RX equivalents — forwarded from ClientRxChainWidget so MainWindow
+    // can route them to the right editor / applet without depending on
+    // the chain widget directly.
+    void rxEditRequested(AudioEngine::RxChainStage stage);
+    void rxStageEnabledChanged(AudioEngine::RxChainStage stage, bool enabled);
+    // Emitted after a successful drag-reorder of the RX chain.  Mirrors
+    // chainReordered() above on the TX side.
+    void rxChainReordered();
+    // Emitted whenever the user flips the TX/RX tab.  MainWindow
+    // routes this to AppletPanel::setPooDooActiveSide so the per-stage
+    // tiles for the inactive side get hidden.
+    void chainModeChanged(ChainMode mode);
     // Emitted after the user drags a stage to a new position.  MainWindow
     // subscribes so the applet-panel sub-container order can be kept
     // in lock-step with the chain order.
@@ -82,9 +107,9 @@ private:
     void applyPlayButtonStyle();
     void updateMonitorButtonEnables();
 
-    AudioEngine*       m_audio{nullptr};
-    ClientChainWidget* m_chain{nullptr};
-    QLabel*            m_rxPlaceholder{nullptr};
+    AudioEngine*         m_audio{nullptr};
+    ClientChainWidget*   m_chain{nullptr};
+    ClientRxChainWidget* m_rxChain{nullptr};
     QLabel*            m_hint{nullptr};
     QPushButton*       m_txBtn{nullptr};
     QPushButton*       m_rxBtn{nullptr};
@@ -100,7 +125,8 @@ private:
     bool               m_monHasRecording{false};
     bool               m_micReady{false};
     ChainMode          m_mode{ChainMode::Tx};
-    QVector<AudioEngine::TxChainStage> m_bypassSnapshot;  // stages that were on before BYPASS
+    QVector<AudioEngine::TxChainStage> m_bypassSnapshot;     // TX stages that were on before BYPASS
+    QVector<AudioEngine::RxChainStage> m_rxBypassSnapshot;   // RX stages that were on before BYPASS
 };
 
 } // namespace AetherSDR

--- a/src/gui/ClientCompApplet.cpp
+++ b/src/gui/ClientCompApplet.cpp
@@ -101,10 +101,26 @@ constexpr const char* kEditStyle =
 
 } // namespace
 
-ClientCompApplet::ClientCompApplet(QWidget* parent) : QWidget(parent)
+ClientCompApplet::ClientCompApplet(Side side, QWidget* parent)
+    : QWidget(parent)
+    , m_side(side)
 {
     buildUI();
     hide();  // hidden until toggled on from the button tray
+}
+
+ClientComp* ClientCompApplet::comp() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientCompRx()
+                              : m_audio->clientCompTx();
+}
+
+void ClientCompApplet::saveCompSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientCompRxSettings();
+    else                    m_audio->saveClientCompSettings();
 }
 
 void ClientCompApplet::buildUI()
@@ -209,9 +225,9 @@ void ClientCompApplet::buildUI()
 
     auto wire = [this](ClientCompKnob* k, auto setter) {
         connect(k, &ClientCompKnob::valueChanged, this, [this, setter](float v) {
-            if (!m_audio || !m_audio->clientCompTx()) return;
-            (m_audio->clientCompTx()->*setter)(v);
-            m_audio->saveClientCompSettings();
+            if (!m_audio || !comp()) return;
+            (comp()->*setter)(v);
+            saveCompSettings();
         });
     };
     wire(m_thresh,  &ClientComp::setThresholdDb);
@@ -229,7 +245,7 @@ void ClientCompApplet::setAudioEngine(AudioEngine* engine)
 {
     m_audio = engine;
     if (!m_audio) return;
-    m_curve->setComp(m_audio->clientCompTx());
+    m_curve->setComp(comp());
     syncEnableFromEngine();
     m_meterTimer->start();
 }
@@ -237,8 +253,8 @@ void ClientCompApplet::setAudioEngine(AudioEngine* engine)
 void ClientCompApplet::syncEnableFromEngine()
 {
     if (m_curve) m_curve->update();
-    if (!m_audio || !m_audio->clientCompTx()) return;
-    ClientComp* c = m_audio->clientCompTx();
+    if (!m_audio || !comp()) return;
+    ClientComp* c = comp();
     if (m_thresh)  { QSignalBlocker b(m_thresh);  m_thresh->setValue(c->thresholdDb()); }
     if (m_ratio)   { QSignalBlocker b(m_ratio);   m_ratio->setValue(c->ratio()); }
     if (m_attack)  { QSignalBlocker b(m_attack);  m_attack->setValue(c->attackMs()); }
@@ -254,17 +270,17 @@ void ClientCompApplet::refreshEnableFromEngine()
 void ClientCompApplet::onEnableToggled(bool on)
 {
     if (!m_audio) return;
-    ClientComp* c = m_audio->clientCompTx();
+    ClientComp* c = comp();
     if (!c) return;
     c->setEnabled(on);
-    m_audio->saveClientCompSettings();
+    saveCompSettings();
     if (m_curve) m_curve->update();
 }
 
 void ClientCompApplet::tickMeter()
 {
     if (!m_audio || !m_grBar) return;
-    ClientComp* c = m_audio->clientCompTx();
+    ClientComp* c = comp();
     if (!c) return;
     const float gr = c->gainReductionDb();
     m_grBar->setGrDb(gr);

--- a/src/gui/ClientCompApplet.h
+++ b/src/gui/ClientCompApplet.h
@@ -18,17 +18,20 @@ class ClientCompKnob;
 // Edit… buttons.  The full interactive editor lives in a separate
 // floating window (ClientCompEditor).
 //
-// Single-path design: unlike the EQ applet there's no RX / TX tab —
-// Phase 1 only exposes the TX-side compressor.  Phase 2+ can extend
-// this if we ever add an RX-side compressor; today that would just be
-// a CPU-waste feature.
+// Path is locked at construction; AppletPanel instantiates one Tx-
+// bound copy and one Rx-bound copy for the two PooDoo Audio sub-
+// containers.  Engine accesses route through comp() / saveCompSettings()
+// so a single class serves both sides.
 class ClientCompApplet : public QWidget {
     Q_OBJECT
 
 public:
-    explicit ClientCompApplet(QWidget* parent = nullptr);
+    enum class Side { Tx, Rx };
+
+    explicit ClientCompApplet(Side side = Side::Tx, QWidget* parent = nullptr);
 
     void setAudioEngine(AudioEngine* engine);
+    Side side() const { return m_side; }
 
     // Pull the Bypass toggle state from the bound ClientComp.  Called
     // by MainWindow after the floating editor toggles its bypass
@@ -47,6 +50,9 @@ private:
     void tickMeter();
 
     AudioEngine*          m_audio{nullptr};
+    const Side            m_side{Side::Tx};
+    class ClientComp*     comp() const;
+    void                  saveCompSettings() const;
     QPushButton*          m_enable{nullptr};
     QPushButton*          m_edit{nullptr};
     ClientCompCurveWidget* m_curve{nullptr};

--- a/src/gui/ClientCompEditor.cpp
+++ b/src/gui/ClientCompEditor.cpp
@@ -4,6 +4,7 @@
 #include "ClientCompLimiterButton.h"
 #include "ClientCompMeter.h"
 #include "ClientCompThresholdFader.h"
+#include "EditorFramelessTitleBar.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/ClientComp.h"
@@ -63,16 +64,20 @@ const QString kLimBtnStyle = QStringLiteral(
 } // namespace
 
 ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
-    : QWidget(parent, Qt::Window)
+    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
     , m_audio(engine)
 {
-    setWindowTitle("Client Compressor");
+    setWindowTitle("Aetherial Compressor");
     setStyleSheet(kWindowStyle);
     resize(kDefaultWidth, kDefaultHeight);
 
     auto* root = new QVBoxLayout(this);
-    root->setContentsMargins(8, 8, 8, 8);
+    root->setContentsMargins(8, 0, 8, 8);
     root->setSpacing(6);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    m_titleBar = titleBar;
+    root->addWidget(titleBar);
 
     // Bypass moved to the CHAIN widget's single-click gesture — nothing
     // here in the header.
@@ -234,8 +239,8 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
     }
 
     // ── Signal wiring ───────────────────────────────────────────────
-    if (m_audio && m_audio->clientCompTx()) {
-        m_canvas->setComp(m_audio->clientCompTx());
+    if (m_audio && comp()) {
+        m_canvas->setComp(comp());
     }
 
     connect(m_canvas, &ClientCompEditorCanvas::thresholdChanged,
@@ -270,8 +275,44 @@ ClientCompEditor::ClientCompEditor(AudioEngine* engine, QWidget* parent)
 
 ClientCompEditor::~ClientCompEditor() = default;
 
+ClientComp* ClientCompEditor::comp() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientCompRx()
+                              : m_audio->clientCompTx();
+}
+
+void ClientCompEditor::saveCompSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientCompRxSettings();
+    else                    m_audio->saveClientCompSettings();
+}
+
 void ClientCompEditor::showForTx()
 {
+    m_side = Side::Tx;
+    if (m_canvas && comp()) m_canvas->setComp(comp());
+    const QString title = QString::fromUtf8("Aetherial Compressor \xe2\x80\x94 TX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    restoreGeometryFromSettings();
+    syncControlsFromEngine();
+    if (m_meterTimer) m_meterTimer->start();
+    show();
+    raise();
+    activateWindow();
+}
+
+void ClientCompEditor::showForRx()
+{
+    m_side = Side::Rx;
+    if (m_canvas && comp()) m_canvas->setComp(comp());
+    const QString title = QString::fromUtf8("Aetherial Compressor \xe2\x80\x94 RX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
     restoreGeometryFromSettings();
     syncControlsFromEngine();
     if (m_meterTimer) m_meterTimer->start();
@@ -283,7 +324,7 @@ void ClientCompEditor::showForTx()
 void ClientCompEditor::syncControlsFromEngine()
 {
     if (!m_audio) return;
-    ClientComp* c = m_audio->clientCompTx();
+    ClientComp* c = comp();
     if (!c) return;
     QSignalBlocker br(m_ratio);
     QSignalBlocker ba(m_attack);
@@ -307,7 +348,7 @@ void ClientCompEditor::syncControlsFromEngine()
 void ClientCompEditor::tickMeters()
 {
     if (!m_audio) return;
-    ClientComp* c = m_audio->clientCompTx();
+    ClientComp* c = comp();
     if (!c) return;
     if (m_threshFader) m_threshFader->setInputPeakDb(c->inputPeakDb());
     if (m_grMeter)     m_grMeter    ->setValueDb(c->gainReductionDb());
@@ -343,10 +384,10 @@ void ClientCompEditor::tickMeters()
 void ClientCompEditor::applyThreshold(float db)
 {
     if (!m_audio) return;
-    ClientComp* c = m_audio->clientCompTx();
+    ClientComp* c = comp();
     if (!c) return;
     c->setThresholdDb(db);
-    m_audio->saveClientCompSettings();
+    saveCompSettings();
     // Mirror the value onto whichever control didn't originate the
     // change.  Canvas chevron drags land here too, so this keeps the
     // fader handle in sync.  Signal blocking avoids a feedback loop.
@@ -360,10 +401,10 @@ void ClientCompEditor::applyThreshold(float db)
 void ClientCompEditor::applyRatio(float ratio)
 {
     if (!m_audio) return;
-    ClientComp* c = m_audio->clientCompTx();
+    ClientComp* c = comp();
     if (!c) return;
     c->setRatio(ratio);
-    m_audio->saveClientCompSettings();
+    saveCompSettings();
     // Mirror to the knob if the change came from the canvas.
     if (m_ratio && std::fabs(m_ratio->value() - ratio) > 0.001f) {
         QSignalBlocker b(m_ratio);
@@ -375,45 +416,45 @@ void ClientCompEditor::applyRatio(float ratio)
 void ClientCompEditor::applyAttack(float ms)
 {
     if (!m_audio) return;
-    if (auto* c = m_audio->clientCompTx()) c->setAttackMs(ms);
-    m_audio->saveClientCompSettings();
+    if (auto* c = comp()) c->setAttackMs(ms);
+    saveCompSettings();
 }
 
 void ClientCompEditor::applyRelease(float ms)
 {
     if (!m_audio) return;
-    if (auto* c = m_audio->clientCompTx()) c->setReleaseMs(ms);
-    m_audio->saveClientCompSettings();
+    if (auto* c = comp()) c->setReleaseMs(ms);
+    saveCompSettings();
 }
 
 void ClientCompEditor::applyKnee(float db)
 {
     if (!m_audio) return;
-    if (auto* c = m_audio->clientCompTx()) c->setKneeDb(db);
-    m_audio->saveClientCompSettings();
+    if (auto* c = comp()) c->setKneeDb(db);
+    saveCompSettings();
     if (m_canvas) m_canvas->update();
 }
 
 void ClientCompEditor::applyMakeup(float db)
 {
     if (!m_audio) return;
-    if (auto* c = m_audio->clientCompTx()) c->setMakeupDb(db);
-    m_audio->saveClientCompSettings();
+    if (auto* c = comp()) c->setMakeupDb(db);
+    saveCompSettings();
     if (m_canvas) m_canvas->update();
 }
 
 void ClientCompEditor::applyLimiterEnabled(bool on)
 {
     if (!m_audio) return;
-    if (auto* c = m_audio->clientCompTx()) c->setLimiterEnabled(on);
-    m_audio->saveClientCompSettings();
+    if (auto* c = comp()) c->setLimiterEnabled(on);
+    saveCompSettings();
 }
 
 void ClientCompEditor::applyLimiterCeiling(float db)
 {
     if (!m_audio) return;
-    if (auto* c = m_audio->clientCompTx()) c->setLimiterCeilingDb(db);
-    m_audio->saveClientCompSettings();
+    if (auto* c = comp()) c->setLimiterCeilingDb(db);
+    saveCompSettings();
 }
 
 void ClientCompEditor::saveGeometryToSettings()

--- a/src/gui/ClientCompEditor.h
+++ b/src/gui/ClientCompEditor.h
@@ -35,16 +35,20 @@ class ClientCompEditor : public QWidget {
     Q_OBJECT
 
 public:
+    enum class Side { Tx, Rx };
+
     explicit ClientCompEditor(AudioEngine* engine, QWidget* parent = nullptr);
     ~ClientCompEditor() override;
 
     void showForTx();
+    void showForRx();
 
 signals:
     // Fired when the bypass button is toggled inside the editor.  The
     // docked applet subscribes so its Enable toggle stays in sync —
     // both widgets read / write the same ClientComp::enabled flag.
-    void bypassToggled(bool bypassed);
+    // side identifies which path (Tx or Rx) was toggled.
+    void bypassToggled(Side side, bool bypassed);
 
 protected:
     void closeEvent(QCloseEvent* ev) override;
@@ -76,6 +80,10 @@ private:
     void applyLimiterCeiling(float db);
 
     AudioEngine*             m_audio{nullptr};
+    Side                     m_side{Side::Tx};
+    QWidget*                 m_titleBar{nullptr};   // EditorFramelessTitleBar*
+    class ClientComp*        comp() const;
+    void                     saveCompSettings() const;
     ClientCompEditorCanvas*  m_canvas{nullptr};
     ClientCompKnob*          m_ratio{nullptr};
     ClientCompKnob*          m_attack{nullptr};

--- a/src/gui/ClientDeEssEditor.cpp
+++ b/src/gui/ClientDeEssEditor.cpp
@@ -1,6 +1,7 @@
 #include "ClientDeEssEditor.h"
 #include "ClientCompKnob.h"
 #include "ClientDeEssCurveWidget.h"
+#include "EditorFramelessTitleBar.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/ClientDeEss.h"
@@ -49,16 +50,21 @@ const QString kBypassStyle = QStringLiteral(
 } // namespace
 
 ClientDeEssEditor::ClientDeEssEditor(AudioEngine* engine, QWidget* parent)
-    : QWidget(parent, Qt::Window)
+    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
     , m_audio(engine)
 {
-    setWindowTitle("Client De-esser");
+    const QString title = QString::fromUtf8("Aetherial De-Esser \xe2\x80\x94 TX");
+    setWindowTitle(title);
     setStyleSheet(kWindowStyle);
     resize(kDefaultWidth, kDefaultHeight);
 
     auto* root = new QVBoxLayout(this);
-    root->setContentsMargins(8, 8, 8, 8);
+    root->setContentsMargins(8, 0, 8, 8);
     root->setSpacing(6);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    titleBar->setTitleText(title);
+    root->addWidget(titleBar);
 
     // Bypass moved to the CHAIN widget's single-click gesture.
 

--- a/src/gui/ClientEqApplet.cpp
+++ b/src/gui/ClientEqApplet.cpp
@@ -3,57 +3,13 @@
 #include "core/AudioEngine.h"
 #include "core/ClientEq.h"
 
-#include <QHBoxLayout>
 #include <QVBoxLayout>
-#include <QPushButton>
-#include <QSignalBlocker>
 
 namespace AetherSDR {
 
-namespace {
-
-// Tab button: small rectangle, checked state highlighted. Two of these
-// live at the top of the applet (RX / TX). Shared style to keep them
-// visually symmetric.
-constexpr const char* kTabStyle =
-    "QPushButton {"
-    "  background: #0e1b28;"
-    "  color: #8aa8c0;"
-    "  border: 1px solid #203040;"
-    "  border-radius: 3px;"
-    "  font-size: 10px;"
-    "  font-weight: bold;"
-    "  padding: 2px 10px;"
-    "}"
-    "QPushButton:checked {"
-    "  background: #0070c0;"
-    "  color: #ffffff;"
-    "  border-color: #0090e0;"
-    "}"
-    "QPushButton:hover { background: #1a2a3a; }"
-    "QPushButton:checked:hover { background: #0080d0; }";
-
-// Enable is the prominent green toggle. Matches other applet Enable toggles.
-const QString kEnableStyle =
-    "QPushButton {"
-    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
-    "  color: #c8d8e8; font-size: 11px; font-weight: bold; padding: 2px 10px;"
-    "}"
-    "QPushButton:hover { background: #204060; }"
-    "QPushButton:checked {"
-    "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
-    "}";
-
-constexpr const char* kEditStyle =
-    "QPushButton {"
-    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
-    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
-    "}"
-    "QPushButton:hover { background: #204060; }";
-
-} // namespace
-
-ClientEqApplet::ClientEqApplet(QWidget* parent) : QWidget(parent)
+ClientEqApplet::ClientEqApplet(Path path, QWidget* parent)
+    : QWidget(parent)
+    , m_currentPath(path)
 {
     buildUI();
     hide();  // hidden until toggled on from the button tray
@@ -67,66 +23,21 @@ void ClientEqApplet::buildUI()
     outer->setContentsMargins(4, 4, 4, 4);
     outer->setSpacing(4);
 
-    // Tab row — RX / TX selector.
-    {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(2);
-
-        m_rxTab = new QPushButton("RX");
-        m_rxTab->setCheckable(true);
-        m_rxTab->setChecked(true);
-        m_rxTab->setStyleSheet(kTabStyle);
-        m_rxTab->setFixedHeight(20);
-        row->addWidget(m_rxTab);
-
-        m_txTab = new QPushButton("TX");
-        m_txTab->setCheckable(true);
-        m_txTab->setStyleSheet(kTabStyle);
-        m_txTab->setFixedHeight(20);
-        row->addWidget(m_txTab);
-        row->addStretch();
-
-        connect(m_rxTab, &QPushButton::clicked, this, [this]() { setPath(Path::Rx); });
-        connect(m_txTab, &QPushButton::clicked, this, [this]() { setPath(Path::Tx); });
-
-        outer->addLayout(row);
-    }
-
-    // Curve / analyzer area. Phase B.1 draws just the grid; B.2 wires in
-    // the summed response from the current path's ClientEq; B.3 adds the
-    // live FFT analyzer overlay.
+    // Curve / analyzer.  Rx/Tx selector lived above this in the prior
+    // shared-applet design; with one instance per side, the tile is
+    // pure curve + analyzer and the side comes from m_currentPath.
     m_curve = new ClientEqCurveWidget;
     m_curve->setMinimumHeight(110);
     outer->addWidget(m_curve, 1);
-
-    // Enable / Edit buttons removed — CHAIN widget handles bypass
-    // (single-click) and editor-open (double-click).  RX vs TX path
-    // selection still lives in the tab row above.
 }
 
 void ClientEqApplet::setAudioEngine(AudioEngine* engine)
 {
     m_audio = engine;
-    if (!m_audio) return;
-    // Bind the curve widget to the currently-selected path so it can
-    // render band state (meaningful once B.2 draws the summed curve).
-    m_curve->setEq(m_audio->clientEqRx());
-    syncEnableFromEngine();
-}
-
-void ClientEqApplet::setPath(Path p)
-{
-    m_currentPath = p;
-    if (m_rxTab) {
-        QSignalBlocker b1(m_rxTab);
-        QSignalBlocker b2(m_txTab);
-        m_rxTab->setChecked(p == Path::Rx);
-        m_txTab->setChecked(p == Path::Tx);
-    }
-    if (m_audio && m_curve) {
-        m_curve->setEq(p == Path::Rx ? m_audio->clientEqRx()
-                                     : m_audio->clientEqTx());
-    }
+    if (!m_audio || !m_curve) return;
+    m_curve->setEq(m_currentPath == Path::Rx
+                       ? m_audio->clientEqRx()
+                       : m_audio->clientEqTx());
     syncEnableFromEngine();
 }
 
@@ -138,17 +49,6 @@ void ClientEqApplet::syncEnableFromEngine()
 void ClientEqApplet::refreshEnableFromEngine()
 {
     syncEnableFromEngine();
-}
-
-void ClientEqApplet::onEnableToggled(bool on)
-{
-    if (!m_audio) return;
-    ClientEq* eq = (m_currentPath == Path::Rx)
-        ? m_audio->clientEqRx() : m_audio->clientEqTx();
-    if (!eq) return;
-    eq->setEnabled(on);
-    m_audio->saveClientEqSettings();
-    if (m_curve) m_curve->update();
 }
 
 } // namespace AetherSDR

--- a/src/gui/ClientEqApplet.h
+++ b/src/gui/ClientEqApplet.h
@@ -2,27 +2,27 @@
 
 #include <QWidget>
 
-class QPushButton;
-
 namespace AetherSDR {
 
 class AudioEngine;
 class ClientEqCurveWidget;
 
-// Docked applet for client-side parametric EQ. Shows a compact live
-// analyzer with the summed EQ response overlaid; the separate floating
-// editor window (Edit… button) is where users add, remove, and configure
-// bands interactively.
+// Docked applet for client-side parametric EQ — single path, set at
+// construction.  Shows a compact analyzer + summed EQ curve; the
+// separate floating editor (opened from the chain widget via double-
+// click) is where bands are added / removed / configured.
 //
-// RX and TX share the applet — the tab at top selects which path is
-// being viewed. The Enable toggle controls the selected path's EQ.
+// One instance per side: AppletPanel constructs an Rx-bound copy
+// for the RX chain tile and a Tx-bound copy for the TX chain tile.
+// There's no internal Rx/Tx selector — the chain widget's tab is
+// the single source of truth for which side the user is editing.
 class ClientEqApplet : public QWidget {
     Q_OBJECT
 
 public:
     enum class Path { Rx = 0, Tx = 1 };
 
-    explicit ClientEqApplet(QWidget* parent = nullptr);
+    explicit ClientEqApplet(Path path, QWidget* parent = nullptr);
 
     void setAudioEngine(AudioEngine* engine);
 
@@ -34,23 +34,18 @@ public:
     void refreshEnableFromEngine();
 
 signals:
-    // Fired when the user clicks Edit…. MainWindow owns the single
-    // editor window instance and shows / raises it in response.
+    // Fired when the user clicks Edit (currently no in-applet trigger;
+    // editor opens via the chain widget's double-click gesture).
+    // Retained for forward compat with future Edit affordance.
     void editRequested(Path path);
 
 private:
     void buildUI();
-    void setPath(Path p);
     void syncEnableFromEngine();
-    void onEnableToggled(bool on);
 
     AudioEngine* m_audio{nullptr};
-    Path         m_currentPath{Path::Rx};
+    const Path   m_currentPath{Path::Tx};
 
-    QPushButton*         m_rxTab{nullptr};
-    QPushButton*         m_txTab{nullptr};
-    QPushButton*         m_enable{nullptr};
-    QPushButton*         m_edit{nullptr};
     ClientEqCurveWidget* m_curve{nullptr};
 };
 

--- a/src/gui/ClientEqEditor.cpp
+++ b/src/gui/ClientEqEditor.cpp
@@ -4,6 +4,7 @@
 #include "ClientEqIconRow.h"
 #include "ClientEqOutputFader.h"
 #include "ClientEqParamRow.h"
+#include "EditorFramelessTitleBar.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/ClientEq.h"
@@ -56,25 +57,32 @@ const QString kBypassStyle = QStringLiteral(
 } // namespace
 
 ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
-    : QWidget(parent, Qt::Window)
+    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
     , m_audio(engine)
 {
-    setWindowTitle("Client EQ");
+    setWindowTitle("Aetherial Parametric EQ");
     setStyleSheet(kWindowStyle);
     resize(kDefaultWidth, kDefaultHeight);
 
     auto* root = new QVBoxLayout(this);
-    root->setContentsMargins(8, 8, 8, 8);
+    // Margin trimmed to 0 at the top so the frameless title bar hugs
+    // the window edge; sides + bottom keep the original 8 px padding.
+    root->setContentsMargins(8, 0, 8, 8);
     root->setSpacing(6);
 
-    // Path indicator + interaction hint + bypass strip.
+    // Custom 20 px-tall title bar with the active path heading on the
+    // left and the min / max / close trio on the right.  Press-and-drag
+    // anywhere on it starts a window move.  Stored as a QWidget* in the
+    // header to avoid leaking the inline class — cast at use sites.
+    auto* titleBar = new EditorFramelessTitleBar;
+    m_titleBar = titleBar;
+    root->addWidget(titleBar);
+
+    // Interaction hint + filter family + bypass strip.  Path heading
+    // lives in the frameless title bar above instead.
     {
         auto* row = new QHBoxLayout;
         row->setSpacing(8);
-        m_pathLabel = new QLabel("RX");
-        m_pathLabel->setStyleSheet(
-            "QLabel { color: #d7e7f2; font-size: 12px; font-weight: bold; }");
-        row->addWidget(m_pathLabel);
         auto* hint = new QLabel(
             "Drag peak/shelf = freq + gain · "
             "drag HP/LP = freq + Q · Shift + drag for Q · "
@@ -275,12 +283,14 @@ void ClientEqEditor::showForPath(ClientEqApplet::Path path)
     // Clear selection on path swap — the previously-selected index
     // almost certainly doesn't correspond to the other path's bands.
     syncSelection(-1);
-    m_pathLabel->setText(path == ClientEqApplet::Path::Rx
-                         ? "Client EQ — RX"
-                         : "Client EQ — TX");
-    setWindowTitle(path == ClientEqApplet::Path::Rx
-                   ? "Client EQ — RX"
-                   : "Client EQ — TX");
+    const QString title = path == ClientEqApplet::Path::Rx
+        ? QStringLiteral("Aetherial Parametric EQ — RX")
+        : QStringLiteral("Aetherial Parametric EQ — TX");
+    // m_titleBar is always an EditorFramelessTitleBar* — kept as
+    // QWidget* in the header so the inline class stays cpp-only.
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
 
     if (!isVisible()) {
         show();

--- a/src/gui/ClientEqEditor.h
+++ b/src/gui/ClientEqEditor.h
@@ -68,7 +68,11 @@ private:
 
     AudioEngine*               m_audio{nullptr};
     ClientEqApplet::Path       m_path{ClientEqApplet::Path::Rx};
-    QLabel*                    m_pathLabel{nullptr};
+    // The frameless title bar carries the active path label (e.g.
+    // "Aetherial Parametric EQ — TX").  Held as a void* + cast at use
+    // site to keep the inline EditorFramelessTitleBar class out of the
+    // public header.
+    QWidget*                   m_titleBar{nullptr};
     QComboBox*                 m_familyCombo{nullptr};
     QPushButton*               m_bypass{nullptr};
     ClientEqIconRow*           m_iconRow{nullptr};

--- a/src/gui/ClientGateApplet.cpp
+++ b/src/gui/ClientGateApplet.cpp
@@ -101,10 +101,26 @@ constexpr const char* kEditStyle =
 
 } // namespace
 
-ClientGateApplet::ClientGateApplet(QWidget* parent) : QWidget(parent)
+ClientGateApplet::ClientGateApplet(Side side, QWidget* parent)
+    : QWidget(parent)
+    , m_side(side)
 {
     buildUI();
     hide();
+}
+
+ClientGate* ClientGateApplet::gate() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientGateRx()
+                              : m_audio->clientGateTx();
+}
+
+void ClientGateApplet::saveGateSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientGateRxSettings();
+    else                    m_audio->saveClientGateSettings();
 }
 
 void ClientGateApplet::buildUI()
@@ -207,9 +223,9 @@ void ClientGateApplet::buildUI()
     // connect lines read cleanly.
     auto wire = [this](ClientCompKnob* k, auto setter) {
         connect(k, &ClientCompKnob::valueChanged, this, [this, setter](float v) {
-            if (!m_audio || !m_audio->clientGateTx()) return;
-            (m_audio->clientGateTx()->*setter)(v);
-            m_audio->saveClientGateSettings();
+            if (!m_audio || !gate()) return;
+            (gate()->*setter)(v);
+            saveGateSettings();
         });
     };
     wire(m_thresh,  &ClientGate::setThresholdDb);
@@ -227,7 +243,7 @@ void ClientGateApplet::setAudioEngine(AudioEngine* engine)
 {
     m_audio = engine;
     if (!m_audio) return;
-    m_curve->setGate(m_audio->clientGateTx());
+    m_curve->setGate(gate());
     syncEnableFromEngine();
     m_meterTimer->start();
 }
@@ -235,8 +251,8 @@ void ClientGateApplet::setAudioEngine(AudioEngine* engine)
 void ClientGateApplet::syncEnableFromEngine()
 {
     if (m_curve) m_curve->update();
-    if (!m_audio || !m_audio->clientGateTx()) return;
-    ClientGate* g = m_audio->clientGateTx();
+    if (!m_audio || !gate()) return;
+    ClientGate* g = gate();
     if (m_thresh)  { QSignalBlocker b(m_thresh);  m_thresh->setValue(g->thresholdDb()); }
     if (m_ratio)   { QSignalBlocker b(m_ratio);   m_ratio->setValue(g->ratio()); }
     if (m_attack)  { QSignalBlocker b(m_attack);  m_attack->setValue(g->attackMs()); }
@@ -252,17 +268,17 @@ void ClientGateApplet::refreshEnableFromEngine()
 void ClientGateApplet::onEnableToggled(bool on)
 {
     if (!m_audio) return;
-    ClientGate* g = m_audio->clientGateTx();
+    ClientGate* g = gate();
     if (!g) return;
     g->setEnabled(on);
-    m_audio->saveClientGateSettings();
+    saveGateSettings();
     if (m_curve) m_curve->update();
 }
 
 void ClientGateApplet::tickMeter()
 {
     if (!m_audio || !m_grBar) return;
-    ClientGate* g = m_audio->clientGateTx();
+    ClientGate* g = gate();
     if (!g) return;
     const float gr = g->gainReductionDb();
     m_grBar->setGrDb(gr);

--- a/src/gui/ClientGateApplet.h
+++ b/src/gui/ClientGateApplet.h
@@ -12,21 +12,26 @@ class ClientCompKnob;
 class ClientGateCurveWidget;
 class ClientGateGrBar;
 
-// Docked tile for the client-side TX gate / expander.  View-only —
-// shows the static transfer curve with a live ball at the current
-// input level, plus a compact horizontal gain-reduction strip, plus
-// Enable / Edit… buttons.  The interactive editor lives in a separate
-// floating window (ClientGateEditor).
+// Docked tile for the client-side gate / expander.  View-only — shows
+// the static transfer curve with a live ball at the current input
+// level, plus a compact horizontal gain-reduction strip.  The
+// interactive editor lives in a separate floating window
+// (ClientGateEditor).
 //
-// Single-path (TX only) to match ClientCompApplet — gates on a ham
-// RX feed are a rare configuration and can be added later if asked for.
+// Path is locked at construction; AppletPanel instantiates one Tx-
+// bound copy and one Rx-bound copy for the two PooDoo Audio sub-
+// containers.  All engine accesses route through the gate() / save()
+// helpers below so a single class serves both sides.
 class ClientGateApplet : public QWidget {
     Q_OBJECT
 
 public:
-    explicit ClientGateApplet(QWidget* parent = nullptr);
+    enum class Side { Tx, Rx };
+
+    explicit ClientGateApplet(Side side = Side::Tx, QWidget* parent = nullptr);
 
     void setAudioEngine(AudioEngine* engine);
+    Side side() const { return m_side; }
 
     // Pull the Enable toggle state from the bound ClientGate.  Called
     // by MainWindow after the floating editor toggles its bypass button
@@ -43,6 +48,9 @@ private:
     void tickMeter();
 
     AudioEngine*           m_audio{nullptr};
+    const Side             m_side{Side::Tx};
+    class ClientGate*      gate() const;
+    void                   saveGateSettings() const;
     QPushButton*           m_enable{nullptr};
     QPushButton*           m_edit{nullptr};
     ClientGateCurveWidget* m_curve{nullptr};

--- a/src/gui/ClientGateEditor.cpp
+++ b/src/gui/ClientGateEditor.cpp
@@ -1,6 +1,7 @@
 #include "ClientGateEditor.h"
 #include "ClientCompKnob.h"
 #include "ClientGateLevelView.h"
+#include "EditorFramelessTitleBar.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/ClientGate.h"
@@ -72,16 +73,20 @@ const QList<float> kLookaheadOptions{ 0.0f, 1.0f, 1.5f, 3.0f, 5.0f };
 } // namespace
 
 ClientGateEditor::ClientGateEditor(AudioEngine* engine, QWidget* parent)
-    : QWidget(parent, Qt::Window)
+    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
     , m_audio(engine)
 {
-    setWindowTitle("Client Gate");
+    setWindowTitle("Aetherial Gate");
     setStyleSheet(kWindowStyle);
     resize(kDefaultWidth, kDefaultHeight);
 
     auto* root = new QVBoxLayout(this);
-    root->setContentsMargins(8, 8, 8, 8);
+    root->setContentsMargins(8, 0, 8, 8);
     root->setSpacing(6);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    m_titleBar = titleBar;
+    root->addWidget(titleBar);
 
     // Bypass moved to the CHAIN widget's single-click gesture.
 
@@ -277,8 +282,8 @@ ClientGateEditor::ClientGateEditor(AudioEngine* engine, QWidget* parent)
     root->addLayout(body);
 
     // Bind the level view to the gate once so it starts polling.
-    if (m_audio && m_audio->clientGateTx()) {
-        m_levelView->setGate(m_audio->clientGateTx());
+    if (m_audio && gate()) {
+        m_levelView->setGate(gate());
     }
 
     // Initial sync from the engine state.
@@ -295,8 +300,44 @@ ClientGateEditor::ClientGateEditor(AudioEngine* engine, QWidget* parent)
 
 ClientGateEditor::~ClientGateEditor() = default;
 
+ClientGate* ClientGateEditor::gate() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientGateRx()
+                              : m_audio->clientGateTx();
+}
+
+void ClientGateEditor::saveGateSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientGateRxSettings();
+    else                    m_audio->saveClientGateSettings();
+}
+
 void ClientGateEditor::showForTx()
 {
+    m_side = Side::Tx;
+    if (m_levelView && gate()) m_levelView->setGate(gate());
+    const QString title = QString::fromUtf8("Aetherial Gate \xe2\x80\x94 TX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void ClientGateEditor::showForRx()
+{
+    m_side = Side::Rx;
+    if (m_levelView && gate()) m_levelView->setGate(gate());
+    const QString title = QString::fromUtf8("Aetherial Gate \xe2\x80\x94 RX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
     syncControlsFromEngine();
     restoreGeometryFromSettings();
     show();
@@ -307,8 +348,8 @@ void ClientGateEditor::showForTx()
 
 void ClientGateEditor::syncControlsFromEngine()
 {
-    if (!m_audio || !m_audio->clientGateTx()) return;
-    ClientGate* g = m_audio->clientGateTx();
+    if (!m_audio || !gate()) return;
+    ClientGate* g = gate();
 
     m_restoring = true;
 
@@ -356,67 +397,67 @@ void ClientGateEditor::syncControlsFromEngine()
 void ClientGateEditor::applyThreshold(float db)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientGateTx()->setThresholdDb(db);
-    m_audio->saveClientGateSettings();
+    gate()->setThresholdDb(db);
+    saveGateSettings();
     if (m_levelView) m_levelView->update();
 }
 
 void ClientGateEditor::applyReturn(float db)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientGateTx()->setReturnDb(db);
-    m_audio->saveClientGateSettings();
+    gate()->setReturnDb(db);
+    saveGateSettings();
     if (m_levelView) m_levelView->update();
 }
 
 void ClientGateEditor::applyRatio(float ratio)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientGateTx()->setRatio(ratio);
-    m_audio->saveClientGateSettings();
+    gate()->setRatio(ratio);
+    saveGateSettings();
 }
 
 void ClientGateEditor::applyAttack(float ms)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientGateTx()->setAttackMs(ms);
-    m_audio->saveClientGateSettings();
+    gate()->setAttackMs(ms);
+    saveGateSettings();
 }
 
 void ClientGateEditor::applyHold(float ms)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientGateTx()->setHoldMs(ms);
-    m_audio->saveClientGateSettings();
+    gate()->setHoldMs(ms);
+    saveGateSettings();
 }
 
 void ClientGateEditor::applyRelease(float ms)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientGateTx()->setReleaseMs(ms);
-    m_audio->saveClientGateSettings();
+    gate()->setReleaseMs(ms);
+    saveGateSettings();
 }
 
 void ClientGateEditor::applyFloor(float db)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientGateTx()->setFloorDb(db);
-    m_audio->saveClientGateSettings();
+    gate()->setFloorDb(db);
+    saveGateSettings();
 }
 
 void ClientGateEditor::applyLookahead(float ms)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientGateTx()->setLookaheadMs(ms);
-    m_audio->saveClientGateSettings();
+    gate()->setLookaheadMs(ms);
+    saveGateSettings();
 }
 
 void ClientGateEditor::applyMode(int modeIdx)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientGateTx()->setMode(
+    gate()->setMode(
         modeIdx == 1 ? ClientGate::Mode::Gate : ClientGate::Mode::Expander);
-    m_audio->saveClientGateSettings();
+    saveGateSettings();
     // Mode snaps ratio + floor; re-sync so the knobs show the new values.
     syncControlsFromEngine();
 }

--- a/src/gui/ClientGateEditor.h
+++ b/src/gui/ClientGateEditor.h
@@ -35,15 +35,19 @@ class ClientGateEditor : public QWidget {
     Q_OBJECT
 
 public:
+    enum class Side { Tx, Rx };
+
     explicit ClientGateEditor(AudioEngine* engine, QWidget* parent = nullptr);
     ~ClientGateEditor() override;
 
     void showForTx();
+    void showForRx();
 
 signals:
     // Fired when bypass toggles.  Docked applet subscribes to keep
-    // its Enable button in sync.
-    void bypassToggled(bool bypassed);
+    // its Enable button in sync.  side identifies which path (Tx or
+    // Rx) was toggled — both share the editor instance.
+    void bypassToggled(Side side, bool bypassed);
 
 protected:
     void closeEvent(QCloseEvent* ev) override;
@@ -70,6 +74,12 @@ private:
     void applyMode(int modeIdx);   // 0=Expander, 1=Gate
 
     AudioEngine*          m_audio{nullptr};
+    Side                  m_side{Side::Tx};
+    // Side-aware accessor — picks Tx or Rx instance based on m_side.
+    // Saves dispatch logic at every parameter setter.
+    class ClientGate* gate() const;
+    void              saveGateSettings() const;
+    QWidget*              m_titleBar{nullptr};   // EditorFramelessTitleBar*
     ClientGateLevelView*  m_levelView{nullptr};
     ClientCompKnob*       m_threshold{nullptr};
     ClientCompKnob*       m_returnKnob{nullptr};

--- a/src/gui/ClientPuduApplet.cpp
+++ b/src/gui/ClientPuduApplet.cpp
@@ -77,10 +77,26 @@ QWidget* makeBracketLabel(const QString& text)
 
 } // namespace
 
-ClientPuduApplet::ClientPuduApplet(QWidget* parent) : QWidget(parent)
+ClientPuduApplet::ClientPuduApplet(Side side, QWidget* parent)
+    : QWidget(parent)
+    , m_side(side)
 {
     buildUI();
     hide();
+}
+
+ClientPudu* ClientPuduApplet::pudu() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientPuduRx()
+                              : m_audio->clientPuduTx();
+}
+
+void ClientPuduApplet::savePuduSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientPuduRxSettings();
+    else                    m_audio->saveClientPuduSettings();
 }
 
 void ClientPuduApplet::buildUI()
@@ -249,14 +265,14 @@ void ClientPuduApplet::setAudioEngine(AudioEngine* engine)
 {
     m_audio = engine;
     if (!m_audio) return;
-    if (m_logo) m_logo->setPudu(m_audio->clientPuduTx());
+    if (m_logo) m_logo->setPudu(pudu());
     syncControlsFromEngine();
 }
 
 void ClientPuduApplet::syncControlsFromEngine()
 {
-    if (!m_audio || !m_audio->clientPuduTx()) return;
-    ClientPudu* p = m_audio->clientPuduTx();
+    if (!m_audio || !pudu()) return;
+    ClientPudu* p = pudu();
 
     m_restoring = true;
     {
@@ -283,55 +299,55 @@ void ClientPuduApplet::refreshEnableFromEngine()
 void ClientPuduApplet::onEnableToggled(bool on)
 {
     if (m_restoring || !m_audio) return;
-    ClientPudu* p = m_audio->clientPuduTx();
+    ClientPudu* p = pudu();
     if (!p) return;
     p->setEnabled(on);
-    m_audio->saveClientPuduSettings();
+    savePuduSettings();
 }
 
 void ClientPuduApplet::onModeToggled(int id)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setMode(
+    pudu()->setMode(
         id == 1 ? ClientPudu::Mode::Behringer : ClientPudu::Mode::Aphex);
-    m_audio->saveClientPuduSettings();
+    savePuduSettings();
 }
 
 void ClientPuduApplet::applyPooDrive(float db)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setPooDriveDb(db);
-    m_audio->saveClientPuduSettings();
+    pudu()->setPooDriveDb(db);
+    savePuduSettings();
 }
 void ClientPuduApplet::applyPooTune(float hz)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setPooTuneHz(hz);
-    m_audio->saveClientPuduSettings();
+    pudu()->setPooTuneHz(hz);
+    savePuduSettings();
 }
 void ClientPuduApplet::applyPooMix(float v)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setPooMix(v);
-    m_audio->saveClientPuduSettings();
+    pudu()->setPooMix(v);
+    savePuduSettings();
 }
 void ClientPuduApplet::applyDooTune(float hz)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setDooTuneHz(hz);
-    m_audio->saveClientPuduSettings();
+    pudu()->setDooTuneHz(hz);
+    savePuduSettings();
 }
 void ClientPuduApplet::applyDooHarmonics(float db)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setDooHarmonicsDb(db);
-    m_audio->saveClientPuduSettings();
+    pudu()->setDooHarmonicsDb(db);
+    savePuduSettings();
 }
 void ClientPuduApplet::applyDooMix(float v)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setDooMix(v);
-    m_audio->saveClientPuduSettings();
+    pudu()->setDooMix(v);
+    savePuduSettings();
 }
 
 } // namespace AetherSDR

--- a/src/gui/ClientPuduApplet.h
+++ b/src/gui/ClientPuduApplet.h
@@ -26,10 +26,13 @@ class ClientPuduApplet : public QWidget {
     Q_OBJECT
 
 public:
-    explicit ClientPuduApplet(QWidget* parent = nullptr);
+    enum class Side { Tx, Rx };
+
+    explicit ClientPuduApplet(Side side = Side::Tx, QWidget* parent = nullptr);
 
     void setAudioEngine(AudioEngine* engine);
     void refreshEnableFromEngine();
+    Side side() const { return m_side; }
 
 signals:
     void editRequested();
@@ -48,6 +51,9 @@ private:
     void applyDooMix(float v);
 
     AudioEngine*    m_audio{nullptr};
+    const Side      m_side{Side::Tx};
+    class ClientPudu* pudu() const;
+    void              savePuduSettings() const;
     PooDooLogo*     m_logo{nullptr};
     QPushButton*    m_modeA{nullptr};
     QPushButton*    m_modeB{nullptr};

--- a/src/gui/ClientPuduEditor.cpp
+++ b/src/gui/ClientPuduEditor.cpp
@@ -1,5 +1,6 @@
 #include "ClientPuduEditor.h"
 #include "ClientCompKnob.h"
+#include "EditorFramelessTitleBar.h"
 #include "PooDooLogo.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
@@ -86,16 +87,20 @@ QWidget* makeBracketLabel(const QString& text)
 } // namespace
 
 ClientPuduEditor::ClientPuduEditor(AudioEngine* engine, QWidget* parent)
-    : QWidget(parent, Qt::Window)
+    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
     , m_audio(engine)
 {
-    setWindowTitle(QString::fromUtf8("PooDoo\xe2\x84\xa2 Audio — PUDU"));
+    setWindowTitle(QString::fromUtf8("Aetherial Poodoo\xe2\x84\xa2"));
     setStyleSheet(kWindowStyle);
     resize(kDefaultWidth, kDefaultHeight);
 
     auto* root = new QVBoxLayout(this);
-    root->setContentsMargins(12, 10, 12, 10);
+    root->setContentsMargins(12, 0, 12, 10);
     root->setSpacing(8);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    m_titleBar = titleBar;
+    root->addWidget(titleBar);
 
     // ── Logo (big in the editor) ────────────────────────────────
     m_logo = new PooDooLogo;
@@ -257,8 +262,8 @@ ClientPuduEditor::ClientPuduEditor(AudioEngine* engine, QWidget* parent)
 
     root->addStretch();
 
-    if (m_audio && m_audio->clientPuduTx()) {
-        m_logo->setPudu(m_audio->clientPuduTx());
+    if (m_audio && pudu()) {
+        m_logo->setPudu(pudu());
     }
 
     syncControlsFromEngine();
@@ -266,8 +271,43 @@ ClientPuduEditor::ClientPuduEditor(AudioEngine* engine, QWidget* parent)
 
 ClientPuduEditor::~ClientPuduEditor() = default;
 
+ClientPudu* ClientPuduEditor::pudu() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientPuduRx()
+                              : m_audio->clientPuduTx();
+}
+
+void ClientPuduEditor::savePuduSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientPuduRxSettings();
+    else                    m_audio->saveClientPuduSettings();
+}
+
 void ClientPuduEditor::showForTx()
 {
+    m_side = Side::Tx;
+    if (m_logo && pudu()) m_logo->setPudu(pudu());
+    const QString title = QString::fromUtf8("Aetherial Poodoo\xe2\x84\xa2 \xe2\x80\x94 TX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+}
+
+void ClientPuduEditor::showForRx()
+{
+    m_side = Side::Rx;
+    if (m_logo && pudu()) m_logo->setPudu(pudu());
+    const QString title = QString::fromUtf8("Aetherial Poodoo\xe2\x84\xa2 \xe2\x80\x94 RX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
     syncControlsFromEngine();
     restoreGeometryFromSettings();
     show();
@@ -277,8 +317,8 @@ void ClientPuduEditor::showForTx()
 
 void ClientPuduEditor::syncControlsFromEngine()
 {
-    if (!m_audio || !m_audio->clientPuduTx()) return;
-    ClientPudu* p = m_audio->clientPuduTx();
+    if (!m_audio || !pudu()) return;
+    ClientPudu* p = pudu();
     m_restoring = true;
 
     {
@@ -301,46 +341,46 @@ void ClientPuduEditor::syncControlsFromEngine()
 void ClientPuduEditor::onModeToggled(int id)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setMode(
+    pudu()->setMode(
         id == 1 ? ClientPudu::Mode::Behringer : ClientPudu::Mode::Aphex);
-    m_audio->saveClientPuduSettings();
+    savePuduSettings();
 }
 
 void ClientPuduEditor::applyPooDrive(float db)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setPooDriveDb(db);
-    m_audio->saveClientPuduSettings();
+    pudu()->setPooDriveDb(db);
+    savePuduSettings();
 }
 void ClientPuduEditor::applyPooTune(float hz)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setPooTuneHz(hz);
-    m_audio->saveClientPuduSettings();
+    pudu()->setPooTuneHz(hz);
+    savePuduSettings();
 }
 void ClientPuduEditor::applyPooMix(float v)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setPooMix(v);
-    m_audio->saveClientPuduSettings();
+    pudu()->setPooMix(v);
+    savePuduSettings();
 }
 void ClientPuduEditor::applyDooTune(float hz)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setDooTuneHz(hz);
-    m_audio->saveClientPuduSettings();
+    pudu()->setDooTuneHz(hz);
+    savePuduSettings();
 }
 void ClientPuduEditor::applyDooHarmonics(float db)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setDooHarmonicsDb(db);
-    m_audio->saveClientPuduSettings();
+    pudu()->setDooHarmonicsDb(db);
+    savePuduSettings();
 }
 void ClientPuduEditor::applyDooMix(float v)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientPuduTx()->setDooMix(v);
-    m_audio->saveClientPuduSettings();
+    pudu()->setDooMix(v);
+    savePuduSettings();
 }
 
 void ClientPuduEditor::saveGeometryToSettings()

--- a/src/gui/ClientPuduEditor.h
+++ b/src/gui/ClientPuduEditor.h
@@ -18,13 +18,16 @@ class ClientPuduEditor : public QWidget {
     Q_OBJECT
 
 public:
+    enum class Side { Tx, Rx };
+
     explicit ClientPuduEditor(AudioEngine* engine, QWidget* parent = nullptr);
     ~ClientPuduEditor() override;
 
     void showForTx();
+    void showForRx();
 
 signals:
-    void bypassToggled(bool bypassed);
+    void bypassToggled(Side side, bool bypassed);
 
 protected:
     void closeEvent(QCloseEvent* ev) override;
@@ -47,6 +50,10 @@ private:
     void applyDooMix(float v);
 
     AudioEngine*    m_audio{nullptr};
+    Side            m_side{Side::Tx};
+    QWidget*        m_titleBar{nullptr};   // EditorFramelessTitleBar*
+    class ClientPudu* pudu() const;
+    void              savePuduSettings() const;
     PooDooLogo*     m_logo{nullptr};
     QPushButton*    m_bypass{nullptr};
     QPushButton*    m_modeA{nullptr};

--- a/src/gui/ClientReverbEditor.cpp
+++ b/src/gui/ClientReverbEditor.cpp
@@ -1,5 +1,6 @@
 #include "ClientReverbEditor.h"
 #include "ClientCompKnob.h"
+#include "EditorFramelessTitleBar.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/ClientReverb.h"
@@ -26,16 +27,21 @@ constexpr const char* kWindowStyle =
 } // namespace
 
 ClientReverbEditor::ClientReverbEditor(AudioEngine* engine, QWidget* parent)
-    : QWidget(parent, Qt::Window)
+    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
     , m_audio(engine)
 {
-    setWindowTitle(QString::fromUtf8("Client Reverb"));
+    const QString title = QString::fromUtf8("Aetherial FreeVerb \xe2\x80\x94 TX");
+    setWindowTitle(title);
     setStyleSheet(kWindowStyle);
     resize(480, 180);
 
     auto* root = new QVBoxLayout(this);
-    root->setContentsMargins(16, 14, 16, 14);
+    root->setContentsMargins(16, 0, 16, 14);
     root->setSpacing(8);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    titleBar->setTitleText(title);
+    root->addWidget(titleBar);
 
     auto* row = new QHBoxLayout;
     row->setSpacing(12);

--- a/src/gui/ClientRxChainWidget.cpp
+++ b/src/gui/ClientRxChainWidget.cpp
@@ -1,0 +1,687 @@
+#include "ClientRxChainWidget.h"
+
+#include "core/AppSettings.h"
+#include "core/ClientComp.h"
+#include "core/ClientEq.h"
+#include "core/ClientGate.h"
+#include "core/ClientPudu.h"
+#include "core/ClientTube.h"
+
+#include <QApplication>
+#include <QDrag>
+#include <QDragEnterEvent>
+#include <QDragLeaveEvent>
+#include <QDragMoveEvent>
+#include <QDropEvent>
+#include <QMimeData>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPixmap>
+#include <QTimer>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace AetherSDR {
+
+namespace {
+
+// Layout constants — match ClientChainWidget so the TX and RX strips
+// look like siblings.  When the user toggles between the two tabs in
+// the PooDoo applet the box geometry stays put.
+constexpr int   kBoxHeight     = 20;
+constexpr int   kBoxWidthMin   = 36;
+constexpr int   kBoxWidthMax   = 54;
+constexpr int   kBoxGapMin     = 6;
+constexpr int   kBoxGapPref    = 10;
+constexpr int   kMarginX       = 10;
+constexpr int   kRowLeftPad    = 16;
+constexpr int   kMarginY       = 4;
+constexpr int   kRowGap        = 12;
+constexpr int   kTurnOffset    = 4;
+constexpr int   kArrowTip      = 3;
+constexpr qreal kRadius        = 5.0;
+
+const QColor kBgBox          ("#0e1b28");
+const QColor kBgEndpoint     ("#1a2030");
+const QColor kBgActive       ("#14253a");
+const QColor kBorderIdle     ("#2a3a4a");
+const QColor kBorderActive   ("#4db8d4");
+const QColor kBorderGrey     ("#1e2a38");
+
+// Status-tile "active" treatment — matches the MIC-ready green from
+// the TX widget so the visual language carries across.
+const QColor kBgStatusActive ("#006040");
+const QColor kBorderStatusActive("#00a060");
+const QColor kTextStatusActive("#00ff88");
+
+const QColor kConnector      ("#2a3a4a");
+const QColor kTextLabel      ("#c8d8e8");
+const QColor kTextDim        ("#506070");
+const QColor kDropIndicator  ("#4db8d4");
+
+// Distinct from the TX chain's mime so a stray drag from one widget
+// can't be dropped on the other.
+constexpr const char* kMimeFormat = "application/x-aethersdr-rx-chain-stage";
+
+// Short label per RX stage — kept ≤4 chars to fit inside the narrow box.
+QString stageLabel(AudioEngine::RxChainStage s)
+{
+    switch (s) {
+        case AudioEngine::RxChainStage::Eq:   return "EQ";
+        case AudioEngine::RxChainStage::Gate: return "GATE";
+        case AudioEngine::RxChainStage::Comp: return "COMP";
+        case AudioEngine::RxChainStage::Tube: return "TUBE";
+        case AudioEngine::RxChainStage::Pudu: return "PUDU";
+        case AudioEngine::RxChainStage::None: return "";
+    }
+    return "";
+}
+
+} // namespace
+
+ClientRxChainWidget::ClientRxChainWidget(QWidget* parent) : QWidget(parent)
+{
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    setMinimumHeight(kBoxHeight + 2 * kMarginY);
+    setCursor(Qt::ArrowCursor);
+    setAcceptDrops(true);
+    setMouseTracking(true);   // hover-cursor over interactive tiles
+
+    // Deferred single-click timer — toggles bypass on fire, cancelled
+    // by a double-click arriving within the double-click interval.
+    m_clickTimer = new QTimer(this);
+    m_clickTimer->setSingleShot(true);
+    connect(m_clickTimer, &QTimer::timeout, this, [this]() {
+        if (m_pendingClickIdx >= 0) {
+            const int idx = m_pendingClickIdx;
+            m_pendingClickIdx = -1;
+            toggleStageBypass(idx);
+        }
+    });
+}
+
+void ClientRxChainWidget::setAudioEngine(AudioEngine* engine)
+{
+    m_audio = engine;
+    update();
+}
+
+void ClientRxChainWidget::setPcAudioEnabled(bool on)
+{
+    if (m_pcAudioOn == on) return;
+    m_pcAudioOn = on;
+    update();
+}
+
+void ClientRxChainWidget::setClientDspActive(bool on, const QString& label)
+{
+    if (m_dspActive == on && m_dspLabel == label) return;
+    m_dspActive = on;
+    m_dspLabel  = label;
+    update();
+}
+
+void ClientRxChainWidget::setOutputUnmuted(bool on)
+{
+    if (m_outputUnmuted == on) return;
+    m_outputUnmuted = on;
+    update();
+}
+
+QSize ClientRxChainWidget::sizeHint() const
+{
+    return QSize(260, kBoxHeight * 2 + kRowGap + 2 * kMarginY);
+}
+
+bool ClientRxChainWidget::isStageImplemented(AudioEngine::RxChainStage s) const
+{
+    // Phase 1: only EQ has a working DSP core.  Phase 2-5 will flip
+    // their entries to true as each stage's class lands.
+    switch (s) {
+        case AudioEngine::RxChainStage::Eq:   return true;
+        case AudioEngine::RxChainStage::Gate: return true;
+        case AudioEngine::RxChainStage::Comp: return true;
+        case AudioEngine::RxChainStage::Tube: return true;
+        case AudioEngine::RxChainStage::Pudu: return true;
+        case AudioEngine::RxChainStage::None: return false;
+    }
+    return false;
+}
+
+bool ClientRxChainWidget::isStageBypassed(AudioEngine::RxChainStage s) const
+{
+    if (!m_audio) return true;
+    switch (s) {
+        case AudioEngine::RxChainStage::Eq:
+            return m_audio->clientEqRx() ? !m_audio->clientEqRx()->isEnabled() : true;
+        case AudioEngine::RxChainStage::Gate:
+            return m_audio->clientGateRx() ? !m_audio->clientGateRx()->isEnabled() : true;
+        case AudioEngine::RxChainStage::Comp:
+            return m_audio->clientCompRx() ? !m_audio->clientCompRx()->isEnabled() : true;
+        case AudioEngine::RxChainStage::Tube:
+            return m_audio->clientTubeRx() ? !m_audio->clientTubeRx()->isEnabled() : true;
+        case AudioEngine::RxChainStage::Pudu:
+            return m_audio->clientPuduRx() ? !m_audio->clientPuduRx()->isEnabled() : true;
+        case AudioEngine::RxChainStage::None:
+            return true;
+    }
+    return true;
+}
+
+int ClientRxChainWidget::hitTest(const QPointF& pos) const
+{
+    for (int i = 0; i < m_boxes.size(); ++i) {
+        if (m_boxes[i].rect.contains(pos)) return i;
+    }
+    return -1;
+}
+
+int ClientRxChainWidget::dropInsertIndex(const QPointF& pos) const
+{
+    // Return an index in the user-stage list where the dragged stage
+    // should be inserted.  Stage tiles live at m_boxes[2 .. size-2]
+    // (RADIO+DSP at the head, SPEAK at the tail are non-draggable
+    // status tiles).  The processor index = signalIdx - 2.
+    if (m_boxes.size() < 4) return 0;
+    const int nStages = static_cast<int>(m_boxes.size()) - 3;
+
+    int nearestSignalIdx = -1;
+    qreal nearestDist2 = std::numeric_limits<qreal>::max();
+    for (int i = 0; i < m_boxes.size(); ++i) {
+        const QPointF c = m_boxes[i].rect.center();
+        const qreal dx = pos.x() - c.x();
+        const qreal dy = pos.y() - c.y();
+        const qreal d2 = dx * dx + dy * dy;
+        if (d2 < nearestDist2) {
+            nearestDist2 = d2;
+            nearestSignalIdx = i;
+        }
+    }
+    if (nearestSignalIdx < 0) return 0;
+
+    const QRectF r = m_boxes[nearestSignalIdx].rect;
+    bool rowIsOdd = false;
+    if (nearestSignalIdx > 0) {
+        rowIsOdd =
+            m_boxes[nearestSignalIdx].rect.right() <
+            m_boxes[nearestSignalIdx - 1].rect.right() - 1.0 &&
+            qFuzzyCompare(m_boxes[nearestSignalIdx].rect.center().y(),
+                          m_boxes[nearestSignalIdx - 1].rect.center().y());
+    }
+    const bool cursorLeftOfBox = pos.x() < r.center().x();
+    const bool beforeInSignal  = rowIsOdd ? !cursorLeftOfBox : cursorLeftOfBox;
+
+    // Convert nearest signal-order index → user-stage insert index.
+    // Status leaders (RADIO=0, DSP=1) clamp to 0; SPEAK trailer
+    // clamps to nStages.  Otherwise: stage signal idx i maps to
+    // proc idx (i - 2); "before" inserts at that proc idx, "after"
+    // inserts at proc idx + 1.
+    int procIdx;
+    if (nearestSignalIdx <= 1) {
+        procIdx = 0;
+    } else if (nearestSignalIdx == m_boxes.size() - 1) {
+        procIdx = nStages;
+    } else {
+        const int p = nearestSignalIdx - 2;
+        procIdx = beforeInSignal ? p : p + 1;
+    }
+    return std::clamp(procIdx, 0, nStages);
+}
+
+void ClientRxChainWidget::toggleStageBypass(int boxIdx)
+{
+    if (!m_audio || boxIdx < 0 || boxIdx >= m_boxes.size()) return;
+    const auto& box = m_boxes[boxIdx];
+    if (box.kind != TileKind::Stage) return;
+    if (!isStageImplemented(box.stage)) return;
+
+    const bool willEnable = isStageBypassed(box.stage);
+    switch (box.stage) {
+        case AudioEngine::RxChainStage::Eq:
+            if (auto* eq = m_audio->clientEqRx()) {
+                eq->setEnabled(willEnable);
+                m_audio->saveClientEqSettings();
+            }
+            break;
+        case AudioEngine::RxChainStage::Gate:
+            if (auto* g = m_audio->clientGateRx()) {
+                g->setEnabled(willEnable);
+                m_audio->saveClientGateRxSettings();
+            }
+            break;
+        case AudioEngine::RxChainStage::Comp:
+            if (auto* c = m_audio->clientCompRx()) {
+                c->setEnabled(willEnable);
+                m_audio->saveClientCompRxSettings();
+            }
+            break;
+        case AudioEngine::RxChainStage::Tube:
+            if (auto* t = m_audio->clientTubeRx()) {
+                t->setEnabled(willEnable);
+                m_audio->saveClientTubeRxSettings();
+            }
+            break;
+        case AudioEngine::RxChainStage::Pudu:
+            if (auto* p = m_audio->clientPuduRx()) {
+                p->setEnabled(willEnable);
+                m_audio->saveClientPuduRxSettings();
+            }
+            break;
+        default:
+            break;
+    }
+    emit stageEnabledChanged(box.stage, willEnable);
+    update();
+}
+
+void ClientRxChainWidget::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() != Qt::LeftButton) {
+        QWidget::mousePressEvent(ev);
+        return;
+    }
+    const int idx = hitTest(ev->position());
+    if (idx < 0) {
+        m_pressIndex = -1;
+        QWidget::mousePressEvent(ev);
+        return;
+    }
+    const auto& box = m_boxes[idx];
+    if (box.kind != TileKind::Stage || !isStageImplemented(box.stage)) {
+        // Status tiles + unimplemented stages: nothing on click.
+        m_pressIndex = -1;
+        QWidget::mousePressEvent(ev);
+        return;
+    }
+    // Record press; mouseMoveEvent decides drag-vs-click based on
+    // movement distance, mouseReleaseEvent fires the deferred bypass
+    // toggle if no drag happened.
+    m_pressPos   = ev->position().toPoint();
+    m_pressIndex = idx;
+    ev->accept();
+}
+
+void ClientRxChainWidget::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (m_pressIndex < 0 || !(ev->buttons() & Qt::LeftButton)) {
+        // Hover → cursor reflects whether the tile is interactive.
+        const int idx = hitTest(ev->position());
+        const bool interactive = (idx >= 0)
+            && m_boxes[idx].kind == TileKind::Stage
+            && isStageImplemented(m_boxes[idx].stage);
+        setCursor(interactive ? Qt::PointingHandCursor : Qt::ArrowCursor);
+        QWidget::mouseMoveEvent(ev);
+        return;
+    }
+    // Distinguish drag from click — require ~6 px of movement.
+    if ((ev->position().toPoint() - m_pressPos).manhattanLength() < 6) return;
+
+    const auto& b = m_boxes[m_pressIndex];
+    auto* drag = new QDrag(this);
+    auto* mime = new QMimeData;
+    mime->setData(kMimeFormat,
+                  QByteArray::number(static_cast<int>(b.stage)));
+    drag->setMimeData(mime);
+
+    // Drag pixmap snapshot — same active treatment as the painted tile.
+    QPixmap pix(b.rect.size().toSize());
+    pix.fill(Qt::transparent);
+    {
+        QPainter pp(&pix);
+        pp.setRenderHint(QPainter::Antialiasing, true);
+        pp.setBrush(kBgActive);
+        pp.setPen(QPen(kBorderActive, 1.0));
+        pp.drawRoundedRect(QRectF(0, 0, pix.width() - 1, pix.height() - 1),
+                           kRadius, kRadius);
+        QFont f = pp.font();
+        f.setPixelSize(9);
+        f.setBold(true);
+        pp.setFont(f);
+        pp.setPen(kTextLabel);
+        pp.drawText(pix.rect(), Qt::AlignCenter, stageLabel(b.stage));
+    }
+    drag->setPixmap(pix);
+    drag->setHotSpot(QPoint(pix.width() / 2, pix.height() / 2));
+
+    // Cancel any pending click — mouseReleaseEvent won't fire for the
+    // drag end, but we want to be defensive.
+    if (m_clickTimer && m_clickTimer->isActive()) m_clickTimer->stop();
+    m_pendingClickIdx = -1;
+    m_pressIndex      = -1;
+    drag->exec(Qt::MoveAction);
+    m_dropIndex = -1;
+    update();
+}
+
+void ClientRxChainWidget::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (ev->button() != Qt::LeftButton) {
+        QWidget::mouseReleaseEvent(ev);
+        return;
+    }
+    // If m_pressIndex was cleared by mouseMoveEvent (drag started)
+    // the release isn't a click.  Otherwise queue a deferred bypass-
+    // toggle that a follow-up double-click can cancel.
+    if (m_pressIndex < 0) return;
+    const int idx = m_pressIndex;
+    m_pressIndex = -1;
+    if (idx < 0 || idx >= m_boxes.size()) return;
+    const auto& box = m_boxes[idx];
+    if (box.kind != TileKind::Stage || !isStageImplemented(box.stage)) return;
+    m_pendingClickIdx = idx;
+    if (m_clickTimer)
+        m_clickTimer->start(QApplication::doubleClickInterval());
+}
+
+void ClientRxChainWidget::mouseDoubleClickEvent(QMouseEvent* ev)
+{
+    // Cancel the pending single-click bypass so a double-click only
+    // opens the editor.
+    if (m_clickTimer && m_clickTimer->isActive()) m_clickTimer->stop();
+    m_pendingClickIdx = -1;
+
+    const int idx = hitTest(ev->position());
+    if (idx < 0) { QWidget::mouseDoubleClickEvent(ev); return; }
+    const auto& box = m_boxes[idx];
+    if (box.kind != TileKind::Stage || !isStageImplemented(box.stage)) {
+        QWidget::mouseDoubleClickEvent(ev);
+        return;
+    }
+    emit editRequested(box.stage);
+    ev->accept();
+}
+
+void ClientRxChainWidget::dragEnterEvent(QDragEnterEvent* ev)
+{
+    if (ev->mimeData()->hasFormat(kMimeFormat))
+        ev->acceptProposedAction();
+}
+
+void ClientRxChainWidget::dragMoveEvent(QDragMoveEvent* ev)
+{
+    if (!ev->mimeData()->hasFormat(kMimeFormat)) return;
+    const int idx = dropInsertIndex(ev->position());
+    if (idx != m_dropIndex) { m_dropIndex = idx; update(); }
+    ev->acceptProposedAction();
+}
+
+void ClientRxChainWidget::dragLeaveEvent(QDragLeaveEvent*)
+{
+    m_dropIndex = -1;
+    update();
+}
+
+void ClientRxChainWidget::dropEvent(QDropEvent* ev)
+{
+    if (!m_audio || !ev->mimeData()->hasFormat(kMimeFormat)) {
+        m_dropIndex = -1;
+        update();
+        return;
+    }
+    const auto stage = static_cast<AudioEngine::RxChainStage>(
+        ev->mimeData()->data(kMimeFormat).toInt());
+    auto stages = m_audio->rxChainStages();
+    const int from = stages.indexOf(stage);
+    if (from < 0) { m_dropIndex = -1; update(); return; }
+
+    int to = dropInsertIndex(ev->position());
+    // Account for removal-before-insertion shift.
+    stages.removeAt(from);
+    if (to > from) --to;
+    to = std::clamp(to, 0, static_cast<int>(stages.size()));
+    stages.insert(to, stage);
+
+    m_audio->setRxChainStages(stages);
+    m_dropIndex = -1;
+    rebuildLayout();
+    update();
+    emit chainReordered();
+    ev->acceptProposedAction();
+}
+
+void ClientRxChainWidget::leaveEvent(QEvent*)
+{
+    setCursor(Qt::ArrowCursor);
+}
+
+void ClientRxChainWidget::rebuildLayout()
+{
+    m_boxes.clear();
+    if (!m_audio) return;
+
+    // Assemble: [RADIO] [DSP] + user RX stages + [SPEAK]
+    const auto stages = m_audio->rxChainStages();
+    const int totalBoxes = 3 + stages.size();
+    if (totalBoxes <= 0) return;
+
+    const int avail = std::max(0, width() - 2 * kMarginX);
+    int gap  = kBoxGapPref;
+    int boxW = kBoxWidthMax;
+
+    auto computeBoxesPerRow = [&]() {
+        if (boxW <= 0) return 1;
+        return std::max(1, (avail + gap) / (boxW + gap));
+    };
+    int boxesPerRow = std::min(totalBoxes, computeBoxesPerRow());
+
+    if (boxesPerRow < 2 && totalBoxes > 1) {
+        gap  = kBoxGapMin;
+        boxW = kBoxWidthMin;
+        boxesPerRow = std::min(totalBoxes, computeBoxesPerRow());
+    }
+
+    const int numRows = (totalBoxes + boxesPerRow - 1) / boxesPerRow;
+    const qreal yStart = kMarginY;
+
+    auto boxRect = [&](int visualPos, int row) {
+        const qreal x = kMarginX + kRowLeftPad + visualPos * (boxW + gap);
+        const qreal y = yStart + row * (kBoxHeight + kRowGap);
+        return QRectF(x, y, boxW, kBoxHeight);
+    };
+
+    auto addBox = [&](TileKind kind, AudioEngine::RxChainStage s, int signalIdx) {
+        const int row = signalIdx / boxesPerRow;
+        const int posInRow = signalIdx % boxesPerRow;
+        const int visualPos = (row & 1)
+            ? (boxesPerRow - 1 - posInRow)
+            : posInRow;
+        BoxRect b;
+        b.kind  = kind;
+        b.stage = s;
+        b.rect  = boxRect(visualPos, row);
+        m_boxes.append(b);
+    };
+
+    int idx = 0;
+    addBox(TileKind::StatusRadio, AudioEngine::RxChainStage::None, idx++);
+    addBox(TileKind::StatusDsp,   AudioEngine::RxChainStage::None, idx++);
+    for (auto s : stages) addBox(TileKind::Stage, s, idx++);
+    addBox(TileKind::StatusSpeak, AudioEngine::RxChainStage::None, idx++);
+
+    const int desiredH = 2 * kMarginY + numRows * kBoxHeight
+                         + (numRows - 1) * kRowGap;
+    if (height() != desiredH) setFixedHeight(desiredH);
+}
+
+void ClientRxChainWidget::paintEvent(QPaintEvent*)
+{
+    rebuildLayout();
+
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+    p.fillRect(rect(), QColor("#08121d"));
+
+    if (m_boxes.isEmpty()) return;
+
+    // Connectors — same snake-aware logic as ClientChainWidget.
+    auto drawArrowHead = [&](QPointF tip, QPointF from) {
+        const QPointF dir = tip - from;
+        const qreal   len = std::hypot(dir.x(), dir.y());
+        if (len < 0.01) return;
+        const QPointF u(dir.x() / len, dir.y() / len);
+        const QPointF perp(-u.y(), u.x());
+        QPainterPath head;
+        head.moveTo(tip);
+        head.lineTo(tip.x() - u.x() * kArrowTip + perp.x() * kArrowTip,
+                    tip.y() - u.y() * kArrowTip + perp.y() * kArrowTip);
+        head.lineTo(tip.x() - u.x() * kArrowTip - perp.x() * kArrowTip,
+                    tip.y() - u.y() * kArrowTip - perp.y() * kArrowTip);
+        head.closeSubpath();
+        p.setBrush(kConnector);
+        p.setPen(Qt::NoPen);
+        p.drawPath(head);
+    };
+
+    p.setPen(QPen(kConnector, 2.0));
+    for (int i = 0; i + 1 < m_boxes.size(); ++i) {
+        const QRectF a = m_boxes[i].rect;
+        const QRectF b = m_boxes[i + 1].rect;
+        const bool sameRow = qFuzzyCompare(a.center().y(), b.center().y());
+        if (sameRow) {
+            const bool rtl = a.center().x() > b.center().x();
+            QPointF from, to;
+            if (rtl) {
+                from = QPointF(a.left(), a.center().y());
+                to   = QPointF(b.right() + 1, b.center().y());
+            } else {
+                from = QPointF(a.right(), a.center().y());
+                to   = QPointF(b.left() - 1, b.center().y());
+            }
+            p.setPen(QPen(kConnector, 2.0));
+            p.drawLine(from, to);
+            drawArrowHead(to, from);
+        } else {
+            const bool turnRight = a.center().x() > rect().center().x();
+            const QPointF aEdge = turnRight
+                ? QPointF(a.right(), a.center().y())
+                : QPointF(a.left(),  a.center().y());
+            const QPointF bEdge = turnRight
+                ? QPointF(b.right(), b.center().y())
+                : QPointF(b.left(),  b.center().y());
+            const qreal turnX = turnRight ? aEdge.x() + kTurnOffset
+                                          : aEdge.x() - kTurnOffset;
+            p.setPen(QPen(kConnector, 2.0));
+            p.drawLine(aEdge,                       QPointF(turnX, aEdge.y()));
+            p.drawLine(QPointF(turnX, aEdge.y()),   QPointF(turnX, bEdge.y()));
+            p.drawLine(QPointF(turnX, bEdge.y()),   bEdge);
+            drawArrowHead(bEdge, QPointF(turnX, bEdge.y()));
+        }
+    }
+
+    // Boxes.
+    QFont labelFont = p.font();
+    labelFont.setPixelSize(9);
+    labelFont.setBold(true);
+    p.setFont(labelFont);
+
+    for (const auto& b : m_boxes) {
+        QString label;
+        bool active = false;
+        bool implemented = false;
+
+        switch (b.kind) {
+            case TileKind::StatusRadio:
+                label = "RADIO";
+                active = m_pcAudioOn;
+                break;
+            case TileKind::StatusDsp:
+                // Show the active module's name when on, generic "DSP"
+                // when off or when the caller didn't supply a label.
+                label = (m_dspActive && !m_dspLabel.isEmpty())
+                    ? m_dspLabel
+                    : QStringLiteral("DSP");
+                active = m_dspActive;
+                break;
+            case TileKind::StatusSpeak:
+                label = "SPEAK";
+                active = m_outputUnmuted;
+                break;
+            case TileKind::Stage:
+                label = stageLabel(b.stage);
+                implemented = isStageImplemented(b.stage);
+                break;
+        }
+
+        QBrush bodyBrush(kBgEndpoint);
+        QColor borderCol = kBorderGrey;
+        QColor textCol   = kTextLabel;
+
+        // The DSP tile reads as a stage indicator (which client-side
+        // NR is running) more than a binary status, so it adopts the
+        // same blue-ring + green-LED-dot styling as the implemented
+        // stage tiles.  RADIO and SPEAK keep the green-when-active
+        // status-tile look.
+        const bool dspStyleAsStage = (b.kind == TileKind::StatusDsp);
+
+        if (b.kind == TileKind::StatusRadio || b.kind == TileKind::StatusSpeak) {
+            if (active) {
+                bodyBrush = kBgStatusActive;
+                borderCol = kBorderStatusActive;
+                textCol   = kTextStatusActive;
+            }
+        } else if (dspStyleAsStage) {
+            // Mirror the implemented-stage paint: dim body when
+            // inactive, blue ring when active, with a green LED dot
+            // top-right echoing the on/off state.
+            bodyBrush = active ? kBgActive : kBgBox;
+            borderCol = active ? kBorderActive : kBorderIdle;
+            textCol   = kTextLabel;
+        } else if (implemented) {
+            const bool bypassed = isStageBypassed(b.stage);
+            bodyBrush = bypassed ? kBgBox : kBgActive;
+            borderCol = bypassed ? kBorderIdle : kBorderActive;
+            textCol   = kTextLabel;
+        } else {
+            // Coming-soon placeholder: greyed body, dim text — reads as
+            // "this slot exists but the DSP isn't here yet."
+            bodyBrush = kBgBox;
+            borderCol = kBorderGrey;
+            textCol   = kTextDim;
+        }
+
+        p.setBrush(bodyBrush);
+        p.setPen(QPen(borderCol, 1.0));
+        p.drawRoundedRect(b.rect, kRadius, kRadius);
+
+        // LED dot top-right — green when active, dim when off.  Drawn
+        // for implemented stage tiles AND for the DSP status tile so
+        // both share the same visual vocabulary.
+        const bool drawLed = (b.kind == TileKind::Stage && implemented)
+                          || dspStyleAsStage;
+        if (drawLed) {
+            const bool ledOn = (b.kind == TileKind::Stage)
+                ? !isStageBypassed(b.stage)
+                : active;
+            const QPointF led(b.rect.right() - 4, b.rect.top() + 4);
+            p.setBrush(ledOn ? QColor("#00ff88") : QColor("#2a3a4a"));
+            p.setPen(Qt::NoPen);
+            p.drawEllipse(led, 1.8, 1.8);
+        }
+
+        p.setPen(textCol);
+        p.drawText(b.rect, Qt::AlignCenter, label);
+    }
+
+    // Drop-position indicator — vertical bar between the two boxes
+    // that sandwich the drop slot.  m_dropIndex is in user-stage
+    // coordinates; convert to signal-order m_boxes coordinates by
+    // adding the 2-tile leading status block.
+    if (m_dropIndex >= 0 && m_boxes.size() >= 4) {
+        const int leftSignal  = m_dropIndex + 1;  // last box that stays "before" the drop
+        const int rightSignal = m_dropIndex + 2;  // first box that lands "after" the drop
+        if (leftSignal >= 0 && rightSignal < m_boxes.size()) {
+            const QRectF lr = m_boxes[leftSignal].rect;
+            const QRectF rr = m_boxes[rightSignal].rect;
+            const QPointF mid((lr.center().x() + rr.center().x()) * 0.5,
+                              (lr.center().y() + rr.center().y()) * 0.5);
+            p.setPen(QPen(kDropIndicator, 3.0));
+            p.drawLine(QPointF(mid.x(), rr.top() - 2),
+                       QPointF(mid.x(), rr.bottom() + 2));
+        }
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientRxChainWidget.h
+++ b/src/gui/ClientRxChainWidget.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "core/AudioEngine.h"
+
+#include <QVector>
+#include <QWidget>
+
+namespace AetherSDR {
+
+// Visual RX DSP signal chain.  Paints a horizontal strip:
+//
+//   [RADIO]→[DSP]→[RX EQ]→[GATE]→[COMP]→[TUBE]→[PUDU]→[SPEAK]
+//
+// Three of the eight tiles are status-only (non-interactive):
+//   - RADIO  — green when PC Audio (standard SSB stream) is enabled
+//   - DSP    — green when any client-side NR (NR4 / DFNR / BNR) is on
+//   - SPEAK  — green when AetherSDR's audio output is unmuted
+//
+// The remaining five (RX EQ / GATE / COMP / TUBE / PUDU) are user-
+// controllable DSP stages.  Phase 0 ships them as greyed "coming
+// soon" placeholders with no interactivity; later phases enable
+// click-to-bypass, double-click-to-edit, and drag-to-reorder.
+class ClientRxChainWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientRxChainWidget(QWidget* parent = nullptr);
+
+    void setAudioEngine(AudioEngine* engine);
+
+    // Status-tile inputs.  Each setter is idempotent (no repaint when
+    // unchanged) so it's safe to call from a signal handler at any
+    // frequency.
+    void setPcAudioEnabled(bool on);
+    // DSP tile state — the label rotates to show the active module's
+    // short name (e.g. "NR4", "DFNR", "BNR").  Empty label falls back
+    // to the generic "DSP" placeholder.  Tile greens whenever active is
+    // true regardless of label.
+    void setClientDspActive(bool on, const QString& label = QString());
+    void setOutputUnmuted(bool on);
+
+signals:
+    // Emitted when the user double-clicks an implemented stage tile —
+    // MainWindow maps this to opening the right editor in RX mode.
+    void editRequested(AudioEngine::RxChainStage stage);
+    // Emitted when the user single-clicks an implemented stage tile —
+    // toggles the stage's enabled state.  ClientChainApplet listens so
+    // it can refresh BYPASS button visuals.
+    void stageEnabledChanged(AudioEngine::RxChainStage stage, bool enabled);
+    // Emitted after a successful drag-reorder.  AudioEngine has the
+    // new order by this point — the signal informs MainWindow so it
+    // can mirror the order onto the applet tile stack.
+    void chainReordered();
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
+    void mouseDoubleClickEvent(QMouseEvent* ev) override;
+    void dragEnterEvent(QDragEnterEvent* ev) override;
+    void dragMoveEvent(QDragMoveEvent* ev) override;
+    void dragLeaveEvent(QDragLeaveEvent* ev) override;
+    void dropEvent(QDropEvent* ev) override;
+    void leaveEvent(QEvent* ev) override;
+    QSize sizeHint() const override;
+
+private:
+    enum class TileKind : uint8_t {
+        StatusRadio,
+        StatusDsp,
+        StatusSpeak,
+        Stage,            // user DSP stage (RxChainStage)
+    };
+
+    struct BoxRect {
+        TileKind                  kind;
+        AudioEngine::RxChainStage stage{AudioEngine::RxChainStage::None};
+        QRectF                    rect;
+    };
+    QVector<BoxRect> m_boxes;
+
+    void rebuildLayout();
+    int  hitTest(const QPointF& pos) const;        // index into m_boxes, or -1
+    int  dropInsertIndex(const QPointF& pos) const; // index into the user-stage list
+    bool isStageImplemented(AudioEngine::RxChainStage s) const;
+    bool isStageBypassed(AudioEngine::RxChainStage s) const;
+    void toggleStageBypass(int boxIdx);
+
+    AudioEngine* m_audio{nullptr};
+    // Deferred single-click → toggle-bypass timer.  Single click fires
+    // after QApplication::doubleClickInterval() so a genuine double
+    // click (editor-open) can cancel it before it fires.  Same UX as
+    // ClientChainWidget on the TX side.
+    class QTimer* m_clickTimer{nullptr};
+    int           m_pendingClickIdx{-1};
+    // Drag state — tracks the press point and the drag target once
+    // the mouse has moved far enough to distinguish click from drag.
+    QPoint m_pressPos;
+    int    m_pressIndex{-1};
+    int    m_dropIndex{-1};      // where the drag is currently hovering
+    bool         m_pcAudioOn{false};
+    bool         m_dspActive{false};
+    QString      m_dspLabel;          // active module's short name; empty → "DSP"
+    bool         m_outputUnmuted{true};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientTubeApplet.cpp
+++ b/src/gui/ClientTubeApplet.cpp
@@ -33,10 +33,26 @@ constexpr const char* kEditStyle =
 
 } // namespace
 
-ClientTubeApplet::ClientTubeApplet(QWidget* parent) : QWidget(parent)
+ClientTubeApplet::ClientTubeApplet(Side side, QWidget* parent)
+    : QWidget(parent)
+    , m_side(side)
 {
     buildUI();
     hide();
+}
+
+ClientTube* ClientTubeApplet::tube() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientTubeRx()
+                              : m_audio->clientTubeTx();
+}
+
+void ClientTubeApplet::saveTubeSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientTubeRxSettings();
+    else                    m_audio->saveClientTubeSettings();
 }
 
 void ClientTubeApplet::buildUI()
@@ -124,9 +140,9 @@ void ClientTubeApplet::buildUI()
 
     auto wire = [this](ClientCompKnob* k, auto setter) {
         connect(k, &ClientCompKnob::valueChanged, this, [this, setter](float v) {
-            if (!m_audio || !m_audio->clientTubeTx()) return;
-            (m_audio->clientTubeTx()->*setter)(v);
-            m_audio->saveClientTubeSettings();
+            if (!m_audio || !tube()) return;
+            (tube()->*setter)(v);
+            saveTubeSettings();
         });
     };
     wire(m_drive,  &ClientTube::setDriveDb);
@@ -147,7 +163,7 @@ void ClientTubeApplet::setAudioEngine(AudioEngine* engine)
 {
     m_audio = engine;
     if (!m_audio) return;
-    m_curve->setTube(m_audio->clientTubeTx());
+    m_curve->setTube(tube());
     syncEnableFromEngine();
     if (m_syncTimer) m_syncTimer->start();
 }
@@ -155,8 +171,8 @@ void ClientTubeApplet::setAudioEngine(AudioEngine* engine)
 void ClientTubeApplet::syncEnableFromEngine()
 {
     if (m_curve) m_curve->update();
-    if (!m_audio || !m_audio->clientTubeTx()) return;
-    ClientTube* t = m_audio->clientTubeTx();
+    if (!m_audio || !tube()) return;
+    ClientTube* t = tube();
     if (m_drive)  { QSignalBlocker b(m_drive);  m_drive->setValue(t->driveDb()); }
     if (m_tone)   { QSignalBlocker b(m_tone);   m_tone->setValue(t->tone()); }
     if (m_bias)   { QSignalBlocker b(m_bias);   m_bias->setValue(t->biasAmount()); }
@@ -172,10 +188,10 @@ void ClientTubeApplet::refreshEnableFromEngine()
 void ClientTubeApplet::onEnableToggled(bool on)
 {
     if (!m_audio) return;
-    ClientTube* t = m_audio->clientTubeTx();
+    ClientTube* t = tube();
     if (!t) return;
     t->setEnabled(on);
-    m_audio->saveClientTubeSettings();
+    saveTubeSettings();
     if (m_curve) m_curve->update();
 }
 

--- a/src/gui/ClientTubeApplet.h
+++ b/src/gui/ClientTubeApplet.h
@@ -11,18 +11,23 @@ class AudioEngine;
 class ClientCompKnob;
 class ClientTubeCurveWidget;
 
-// Docked tile for the client-side TX dynamic tube saturator.  Shows
+// Docked tile for the client-side dynamic tube saturator.  Shows
 // the transfer curve (which bends with Drive / Bias / Model) and a
-// live input ball, plus Enable / Edit buttons.  Interactive editor
-// is in ClientTubeEditor.
+// live input ball.  Path is locked at construction; AppletPanel
+// instantiates one Tx-bound copy and one Rx-bound copy for the two
+// PooDoo Audio sub-containers.  Engine accesses route through tube()
+// / saveTubeSettings() so a single class serves both sides.
 class ClientTubeApplet : public QWidget {
     Q_OBJECT
 
 public:
-    explicit ClientTubeApplet(QWidget* parent = nullptr);
+    enum class Side { Tx, Rx };
+
+    explicit ClientTubeApplet(Side side = Side::Tx, QWidget* parent = nullptr);
 
     void setAudioEngine(AudioEngine* engine);
     void refreshEnableFromEngine();
+    Side side() const { return m_side; }
 
 signals:
     void editRequested();
@@ -33,6 +38,9 @@ private:
     void onEnableToggled(bool on);
 
     AudioEngine*           m_audio{nullptr};
+    const Side             m_side{Side::Tx};
+    class ClientTube*      tube() const;
+    void                   saveTubeSettings() const;
     QPushButton*           m_enable{nullptr};
     QPushButton*           m_edit{nullptr};
     ClientTubeCurveWidget* m_curve{nullptr};

--- a/src/gui/ClientTubeEditor.cpp
+++ b/src/gui/ClientTubeEditor.cpp
@@ -1,6 +1,7 @@
 #include "ClientTubeEditor.h"
 #include "ClientCompKnob.h"
 #include "ClientTubeCurveWidget.h"
+#include "EditorFramelessTitleBar.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/ClientTube.h"
@@ -62,16 +63,20 @@ const QString kModelStyle = QStringLiteral(
 } // namespace
 
 ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
-    : QWidget(parent, Qt::Window)
+    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
     , m_audio(engine)
 {
-    setWindowTitle("Dynamic Tube");
+    setWindowTitle("Aetherial Tube");
     setStyleSheet(kWindowStyle);
     resize(kDefaultWidth, kDefaultHeight);
 
     auto* root = new QVBoxLayout(this);
-    root->setContentsMargins(8, 8, 8, 8);
+    root->setContentsMargins(8, 0, 8, 8);
     root->setSpacing(6);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    m_titleBar = titleBar;
+    root->addWidget(titleBar);
 
     // Bypass moved to the CHAIN widget's single-click gesture.
     // Exclusive model group — buttons are created below in the Tone/Bias
@@ -278,8 +283,8 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
 
     root->addLayout(body);
 
-    if (m_audio && m_audio->clientTubeTx()) {
-        m_curve->setTube(m_audio->clientTubeTx());
+    if (m_audio && tube()) {
+        m_curve->setTube(tube());
     }
 
     syncControlsFromEngine();
@@ -292,8 +297,44 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
 
 ClientTubeEditor::~ClientTubeEditor() = default;
 
+ClientTube* ClientTubeEditor::tube() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientTubeRx()
+                              : m_audio->clientTubeTx();
+}
+
+void ClientTubeEditor::saveTubeSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientTubeRxSettings();
+    else                    m_audio->saveClientTubeSettings();
+}
+
 void ClientTubeEditor::showForTx()
 {
+    m_side = Side::Tx;
+    if (m_curve && tube()) m_curve->setTube(tube());
+    const QString title = QString::fromUtf8("Aetherial Tube \xe2\x80\x94 TX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void ClientTubeEditor::showForRx()
+{
+    m_side = Side::Rx;
+    if (m_curve && tube()) m_curve->setTube(tube());
+    const QString title = QString::fromUtf8("Aetherial Tube \xe2\x80\x94 RX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
     syncControlsFromEngine();
     restoreGeometryFromSettings();
     show();
@@ -304,8 +345,8 @@ void ClientTubeEditor::showForTx()
 
 void ClientTubeEditor::syncControlsFromEngine()
 {
-    if (!m_audio || !m_audio->clientTubeTx()) return;
-    ClientTube* t = m_audio->clientTubeTx();
+    if (!m_audio || !tube()) return;
+    ClientTube* t = tube();
     m_restoring = true;
 
     {
@@ -331,70 +372,70 @@ void ClientTubeEditor::syncControlsFromEngine()
 void ClientTubeEditor::applyModel(int idx)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientTubeTx()->setModel(
+    tube()->setModel(
         idx == 1 ? ClientTube::Model::B :
         idx == 2 ? ClientTube::Model::C :
                    ClientTube::Model::A);
-    m_audio->saveClientTubeSettings();
+    saveTubeSettings();
     if (m_curve) m_curve->update();
 }
 
 void ClientTubeEditor::applyDrive(float db)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientTubeTx()->setDriveDb(db);
-    m_audio->saveClientTubeSettings();
+    tube()->setDriveDb(db);
+    saveTubeSettings();
     if (m_curve) m_curve->update();
 }
 
 void ClientTubeEditor::applyBias(float v)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientTubeTx()->setBiasAmount(v);
-    m_audio->saveClientTubeSettings();
+    tube()->setBiasAmount(v);
+    saveTubeSettings();
     if (m_curve) m_curve->update();
 }
 
 void ClientTubeEditor::applyTone(float v)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientTubeTx()->setTone(v);
-    m_audio->saveClientTubeSettings();
+    tube()->setTone(v);
+    saveTubeSettings();
 }
 
 void ClientTubeEditor::applyOutput(float db)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientTubeTx()->setOutputGainDb(db);
-    m_audio->saveClientTubeSettings();
+    tube()->setOutputGainDb(db);
+    saveTubeSettings();
 }
 
 void ClientTubeEditor::applyDryWet(float v)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientTubeTx()->setDryWet(v);
-    m_audio->saveClientTubeSettings();
+    tube()->setDryWet(v);
+    saveTubeSettings();
 }
 
 void ClientTubeEditor::applyEnvelope(float v)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientTubeTx()->setEnvelopeAmount(v);
-    m_audio->saveClientTubeSettings();
+    tube()->setEnvelopeAmount(v);
+    saveTubeSettings();
 }
 
 void ClientTubeEditor::applyAttack(float ms)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientTubeTx()->setAttackMs(ms);
-    m_audio->saveClientTubeSettings();
+    tube()->setAttackMs(ms);
+    saveTubeSettings();
 }
 
 void ClientTubeEditor::applyRelease(float ms)
 {
     if (m_restoring || !m_audio) return;
-    m_audio->clientTubeTx()->setReleaseMs(ms);
-    m_audio->saveClientTubeSettings();
+    tube()->setReleaseMs(ms);
+    saveTubeSettings();
 }
 
 void ClientTubeEditor::saveGeometryToSettings()

--- a/src/gui/ClientTubeEditor.h
+++ b/src/gui/ClientTubeEditor.h
@@ -29,13 +29,16 @@ class ClientTubeEditor : public QWidget {
     Q_OBJECT
 
 public:
+    enum class Side { Tx, Rx };
+
     explicit ClientTubeEditor(AudioEngine* engine, QWidget* parent = nullptr);
     ~ClientTubeEditor() override;
 
     void showForTx();
+    void showForRx();
 
 signals:
-    void bypassToggled(bool bypassed);
+    void bypassToggled(Side side, bool bypassed);
 
 protected:
     void closeEvent(QCloseEvent* ev) override;
@@ -60,6 +63,10 @@ private:
     void applyRelease(float ms);
 
     AudioEngine*           m_audio{nullptr};
+    Side                   m_side{Side::Tx};
+    QWidget*               m_titleBar{nullptr};   // EditorFramelessTitleBar*
+    class ClientTube*      tube() const;
+    void                   saveTubeSettings() const;
     ClientTubeCurveWidget* m_curve{nullptr};
     ClientCompKnob*        m_dryWet{nullptr};
     ClientCompKnob*        m_output{nullptr};

--- a/src/gui/EditorFramelessTitleBar.cpp
+++ b/src/gui/EditorFramelessTitleBar.cpp
@@ -1,0 +1,122 @@
+#include "EditorFramelessTitleBar.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMouseEvent>
+#include <QWindow>
+
+namespace AetherSDR {
+
+EditorFramelessTitleBar::EditorFramelessTitleBar(QWidget* parent)
+    : QWidget(parent)
+{
+    setFixedHeight(20);
+    setStyleSheet("background: #08121d;");
+
+    auto* row = new QHBoxLayout(this);
+    row->setContentsMargins(8, 0, 4, 0);
+    row->setSpacing(2);
+
+    m_titleLbl = new QLabel(this);
+    m_titleLbl->setStyleSheet(
+        "QLabel { color: #d7e7f2; font-size: 11px; "
+        "font-weight: bold; background: transparent; }");
+    m_titleLbl->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+    row->addWidget(m_titleLbl);
+    row->addStretch();
+
+    const QString lblStyle = QStringLiteral(
+        "QLabel { color: #8aa8c0; font-size: 14px; padding: 0 8px; "
+        "border-radius: 3px; }"
+        "QLabel:hover { color: #ffffff; background: #203040; }");
+    const QString closeStyle = QStringLiteral(
+        "QLabel { color: #8aa8c0; font-size: 14px; padding: 0 8px; "
+        "border-radius: 3px; }"
+        "QLabel:hover { color: #ffffff; background: #cc2030; }");
+
+    m_minLbl = new QLabel(QString::fromUtf8("\xe2\x80\x94"), this);  // —
+    m_minLbl->setFixedHeight(20);
+    m_minLbl->setAlignment(Qt::AlignCenter);
+    m_minLbl->setCursor(Qt::PointingHandCursor);
+    m_minLbl->setToolTip("Minimize");
+    m_minLbl->setStyleSheet(lblStyle);
+    m_minLbl->installEventFilter(this);
+    row->addWidget(m_minLbl);
+
+    m_maxLbl = new QLabel(QString::fromUtf8("\xe2\x96\xa1"), this);  // □
+    m_maxLbl->setFixedHeight(20);
+    m_maxLbl->setAlignment(Qt::AlignCenter);
+    m_maxLbl->setCursor(Qt::PointingHandCursor);
+    m_maxLbl->setToolTip("Maximize");
+    m_maxLbl->setStyleSheet(lblStyle);
+    m_maxLbl->installEventFilter(this);
+    row->addWidget(m_maxLbl);
+
+    m_closeLbl = new QLabel(QString::fromUtf8("\xe2\x9c\x95"), this); // ✕
+    m_closeLbl->setFixedHeight(20);
+    m_closeLbl->setAlignment(Qt::AlignCenter);
+    m_closeLbl->setCursor(Qt::PointingHandCursor);
+    m_closeLbl->setToolTip("Close");
+    m_closeLbl->setStyleSheet(closeStyle);
+    m_closeLbl->installEventFilter(this);
+    row->addWidget(m_closeLbl);
+}
+
+void EditorFramelessTitleBar::setTitleText(const QString& text)
+{
+    if (m_titleLbl) m_titleLbl->setText(text);
+}
+
+void EditorFramelessTitleBar::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() == Qt::LeftButton) {
+        if (auto* w = window()) {
+            if (auto* h = w->windowHandle()) {
+                h->startSystemMove();
+                ev->accept();
+                return;
+            }
+        }
+    }
+    QWidget::mousePressEvent(ev);
+}
+
+void EditorFramelessTitleBar::mouseDoubleClickEvent(QMouseEvent* ev)
+{
+    if (ev->button() == Qt::LeftButton) {
+        if (auto* w = window()) {
+            if (w->isMaximized()) w->showNormal();
+            else                  w->showMaximized();
+            ev->accept();
+            return;
+        }
+    }
+    QWidget::mouseDoubleClickEvent(ev);
+}
+
+bool EditorFramelessTitleBar::eventFilter(QObject* obj, QEvent* ev)
+{
+    if (ev->type() == QEvent::MouseButtonPress) {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (me->button() == Qt::LeftButton) {
+            if (obj == m_minLbl) {
+                if (auto* w = window()) w->showMinimized();
+                return true;
+            }
+            if (obj == m_maxLbl) {
+                if (auto* w = window()) {
+                    if (w->isMaximized()) w->showNormal();
+                    else                  w->showMaximized();
+                }
+                return true;
+            }
+            if (obj == m_closeLbl) {
+                if (auto* w = window()) w->close();
+                return true;
+            }
+        }
+    }
+    return QWidget::eventFilter(obj, ev);
+}
+
+} // namespace AetherSDR

--- a/src/gui/EditorFramelessTitleBar.h
+++ b/src/gui/EditorFramelessTitleBar.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+
+namespace AetherSDR {
+
+// Reusable 20 px-tall title bar for the PooDoo Audio editor windows
+// (parametric EQ, compressor, gate, tube, PUDU, reverb, de-esser).
+// Each editor sets Qt::FramelessWindowHint at construction and adds
+// this widget at the very top of its layout.  Behaviour:
+//
+//  - Press-and-drag anywhere on the bar starts a compositor-managed
+//    window move via QWindow::startSystemMove() — same pattern as
+//    the main window's TitleBar.
+//  - Double-click toggles maximize.
+//  - The trio at the right (— □ ✕) wires to showMinimized /
+//    showMaximized / close on the host window via an installed event
+//    filter on each glyph QLabel.
+//  - setTitleText() drives the heading on the left so the host editor
+//    can flip the label when its Side / Path changes.
+class EditorFramelessTitleBar : public QWidget {
+public:
+    explicit EditorFramelessTitleBar(QWidget* parent = nullptr);
+
+    void setTitleText(const QString& text);
+
+protected:
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseDoubleClickEvent(QMouseEvent* ev) override;
+    bool eventFilter(QObject* obj, QEvent* ev) override;
+
+private:
+    QLabel* m_titleLbl{nullptr};
+    QLabel* m_minLbl{nullptr};
+    QLabel* m_maxLbl{nullptr};
+    QLabel* m_closeLbl{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2335,6 +2335,77 @@ MainWindow::MainWindow(QWidget* parent)
         s.setValue("PcAudioMuted", muted ? "True" : "False");
         s.save();
     });
+
+    // ── PooDoo RX chain status tiles (Phase 0 chassis) ─────────────────────
+    // RADIO tile = PC Audio enabled (standard SSB / remote_audio_rx stream).
+    // DSP tile   = any client-side NR active (NR4 / DFNR / BNR).
+    // SPEAK tile = AudioEngine output unmuted.
+    if (auto* chain = m_appletPanel->clientChainApplet()) {
+        // RADIO — driven by the existing PC Audio toggle in TitleBar.
+        connect(m_titleBar, &TitleBar::pcAudioToggled,
+                chain, &ClientChainApplet::setRxPcAudioEnabled);
+
+        // DSP — aggregate of every client-side NR module.  These are
+        // mutually exclusive in AudioEngine::processRx (chained
+        // if/else), so at most one is active at a time.  The tile
+        // greens whenever any is on, and its label rotates to the
+        // active module's short name (NR2 / RN2 / NR4 / DFNR / MNR /
+        // BNR).  Shared state lives in a struct held by shared_ptr
+        // captured into each lambda so lifetime ends with the last
+        // connected slot.
+        struct DspState {
+            bool nr2{false}, rn2{false}, nr4{false},
+                 dfnr{false}, mnr{false}, bnr{false};
+        };
+        auto dspState = std::make_shared<DspState>();
+        auto pushDsp = [chain, dspState]() {
+            // Priority order picks the most "specific" / most-recent
+            // module if more than one is somehow on at once.  Same
+            // order as the audio-thread dispatcher so the displayed
+            // label matches what's actually processing.
+            QString label;
+            if      (dspState->bnr)  label = "BNR";
+            else if (dspState->mnr)  label = "MNR";
+            else if (dspState->dfnr) label = "DFNR";
+            else if (dspState->nr4)  label = "NR4";
+            else if (dspState->rn2)  label = "RN2";
+            else if (dspState->nr2)  label = "NR2";
+            const bool anyOn = !label.isEmpty();
+            chain->setRxClientDspActive(anyOn, label);
+        };
+        connect(m_audio, &AudioEngine::nr2EnabledChanged, chain,
+                [dspState, pushDsp](bool on) { dspState->nr2 = on; pushDsp(); });
+        connect(m_audio, &AudioEngine::rn2EnabledChanged, chain,
+                [dspState, pushDsp](bool on) { dspState->rn2 = on; pushDsp(); });
+        connect(m_audio, &AudioEngine::nr4EnabledChanged, chain,
+                [dspState, pushDsp](bool on) { dspState->nr4 = on; pushDsp(); });
+        connect(m_audio, &AudioEngine::dfnrEnabledChanged, chain,
+                [dspState, pushDsp](bool on) { dspState->dfnr = on; pushDsp(); });
+        connect(m_audio, &AudioEngine::mnrEnabledChanged, chain,
+                [dspState, pushDsp](bool on) { dspState->mnr = on; pushDsp(); });
+        connect(m_audio, &AudioEngine::bnrEnabledChanged, chain,
+                [dspState, pushDsp](bool on) { dspState->bnr = on; pushDsp(); });
+
+        // SPEAK — AudioEngine emits mutedChanged on every setMuted() flip.
+        connect(m_audio, &AudioEngine::mutedChanged, chain,
+                [chain](bool muted) { chain->setRxOutputUnmuted(!muted); });
+
+        // Seed initial state — settings and engine values are already
+        // loaded by the time we reach this wiring code.  We pull from
+        // the engine (not signals) so an already-on NR module shows up
+        // immediately instead of waiting for the next toggle.
+        const bool pcOn = AppSettings::instance()
+            .value("PcAudioEnabled", "True").toString() == "True";
+        chain->setRxPcAudioEnabled(pcOn);
+        dspState->nr2  = m_audio->nr2Enabled();
+        dspState->rn2  = m_audio->rn2Enabled();
+        dspState->nr4  = m_audio->nr4Enabled();
+        dspState->dfnr = m_audio->dfnrEnabled();
+        dspState->mnr  = m_audio->mnrEnabled();
+        dspState->bnr  = m_audio->bnrEnabled();
+        pushDsp();
+        chain->setRxOutputUnmuted(!m_audio->isMuted());
+    }
     connect(m_titleBar, &TitleBar::headphoneMuteChanged, this, [this](bool muted) {
         m_radioModel.sendCommand(QString("mixer headphone mute %1").arg(muted ? 1 : 0));
     });
@@ -2903,68 +2974,34 @@ MainWindow::MainWindow(QWidget* parent)
     // ── EQ applet: graphic equalizer ─────────────────────────────────────────
     m_appletPanel->eqApplet()->setEqualizerModel(&m_radioModel.equalizerModel());
 
-    // ── Client EQ applet: client-side parametric EQ for RX/TX paths ──────────
-    m_appletPanel->clientEqApplet()->setAudioEngine(m_audio);
-    // Edit… requests land here — the floating editor window lands in the
-    // next PR in this series. For now we surface a concise toast so users
-    // understand the feature is arriving incrementally.
-    connect(m_appletPanel->clientEqApplet(), &ClientEqApplet::editRequested,
-            this, [this](ClientEqApplet::Path path) {
-        if (!m_clientEqEditor) {
-            m_clientEqEditor = new ClientEqEditor(m_audio, this);
-            // Editor-side bypass updates the applet's Enable toggle and
-            // drives CEQ tile visibility for TX-path changes (the tile
-            // follows TX EQ bypass state in sync with the CHAIN widget).
-            connect(m_clientEqEditor, &ClientEqEditor::bypassToggled,
-                    this, [this](ClientEqApplet::Path bypassPath, bool bypassed) {
-                if (m_appletPanel && m_appletPanel->clientEqApplet())
-                    m_appletPanel->clientEqApplet()->refreshEnableFromEngine();
-                if (m_appletPanel && m_appletPanel->clientChainApplet())
-                    m_appletPanel->clientChainApplet()->refreshFromEngine();
-                if (bypassPath == ClientEqApplet::Path::Tx && m_appletPanel)
-                    m_appletPanel->setAppletVisible("CEQ", !bypassed);
-            });
-        }
-        m_clientEqEditor->showForPath(path);
-    });
+    // ── Client EQ applets: dedicated TX and RX tiles (Phase 7.1) ───────────
+    m_appletPanel->clientEqTxApplet()->setAudioEngine(m_audio);
+    m_appletPanel->clientEqRxApplet()->setAudioEngine(m_audio);
 
-    // ── Client Compressor applet: client-side TX dynamics processor ──────────
-    m_appletPanel->clientCompApplet()->setAudioEngine(m_audio);
-    connect(m_appletPanel->clientCompApplet(), &ClientCompApplet::editRequested,
-            this, [this]() {
-        if (!m_clientCompEditor) {
-            m_clientCompEditor = new ClientCompEditor(m_audio, this);
-            connect(m_clientCompEditor, &ClientCompEditor::bypassToggled,
-                    this, [this](bool bypassed) {
-                if (m_appletPanel && m_appletPanel->clientCompApplet())
-                    m_appletPanel->clientCompApplet()->refreshEnableFromEngine();
-                if (m_appletPanel && m_appletPanel->clientChainApplet())
-                    m_appletPanel->clientChainApplet()->refreshFromEngine();
-                if (m_appletPanel)
-                    m_appletPanel->setAppletVisible("CMP", !bypassed);
-            });
-        }
-        m_clientCompEditor->showForTx();
-    });
+    auto wireEqEditOpen = [this](ClientEqApplet* applet) {
+        connect(applet, &ClientEqApplet::editRequested, this,
+                [this](ClientEqApplet::Path path) {
+            ensureClientEqEditor()->showForPath(path);
+        });
+    };
+    wireEqEditOpen(m_appletPanel->clientEqTxApplet());
+    wireEqEditOpen(m_appletPanel->clientEqRxApplet());
 
-    // ── Client Gate applet: TX downward expander / noise gate (#1661 Phase 2) ─
-    m_appletPanel->clientGateApplet()->setAudioEngine(m_audio);
-    connect(m_appletPanel->clientGateApplet(), &ClientGateApplet::editRequested,
-            this, [this]() {
-        if (!m_clientGateEditor) {
-            m_clientGateEditor = new ClientGateEditor(m_audio, this);
-            connect(m_clientGateEditor, &ClientGateEditor::bypassToggled,
-                    this, [this](bool bypassed) {
-                if (m_appletPanel && m_appletPanel->clientGateApplet())
-                    m_appletPanel->clientGateApplet()->refreshEnableFromEngine();
-                if (m_appletPanel && m_appletPanel->clientChainApplet())
-                    m_appletPanel->clientChainApplet()->refreshFromEngine();
-                if (m_appletPanel)
-                    m_appletPanel->setAppletVisible("GATE", !bypassed);
-            });
-        }
-        m_clientGateEditor->showForTx();
-    });
+    // ── Client Compressor applets: TX (#1661) + RX (Phase 7.3) ─────────────
+    m_appletPanel->clientCompTxApplet()->setAudioEngine(m_audio);
+    m_appletPanel->clientCompRxApplet()->setAudioEngine(m_audio);
+    connect(m_appletPanel->clientCompTxApplet(), &ClientCompApplet::editRequested,
+            this, [this]() { ensureClientCompEditor()->showForTx(); });
+    connect(m_appletPanel->clientCompRxApplet(), &ClientCompApplet::editRequested,
+            this, [this]() { ensureClientCompEditor()->showForRx(); });
+
+    // ── Client Gate applets: TX (#1661 Phase 2) + RX (Phase 7.2) ───────────
+    m_appletPanel->clientGateTxApplet()->setAudioEngine(m_audio);
+    m_appletPanel->clientGateRxApplet()->setAudioEngine(m_audio);
+    connect(m_appletPanel->clientGateTxApplet(), &ClientGateApplet::editRequested,
+            this, [this]() { ensureClientGateEditor()->showForTx(); });
+    connect(m_appletPanel->clientGateRxApplet(), &ClientGateApplet::editRequested,
+            this, [this]() { ensureClientGateEditor()->showForRx(); });
 
     // ── Client De-esser applet: TX sidechain-filtered dynamics (#1661 Phase 3) ─
     m_appletPanel->clientDeEssApplet()->setAudioEngine(m_audio);
@@ -2985,46 +3022,24 @@ MainWindow::MainWindow(QWidget* parent)
         m_clientDeEssEditor->showForTx();
     });
 
-    // ── Client Tube applet: TX dynamic tube saturator (#1661 Phase 4) ────────
-    m_appletPanel->clientTubeApplet()->setAudioEngine(m_audio);
-    connect(m_appletPanel->clientTubeApplet(), &ClientTubeApplet::editRequested,
-            this, [this]() {
-        if (!m_clientTubeEditor) {
-            m_clientTubeEditor = new ClientTubeEditor(m_audio, this);
-            connect(m_clientTubeEditor, &ClientTubeEditor::bypassToggled,
-                    this, [this](bool bypassed) {
-                if (m_appletPanel && m_appletPanel->clientTubeApplet())
-                    m_appletPanel->clientTubeApplet()->refreshEnableFromEngine();
-                if (m_appletPanel && m_appletPanel->clientChainApplet())
-                    m_appletPanel->clientChainApplet()->refreshFromEngine();
-                if (m_appletPanel)
-                    m_appletPanel->setAppletVisible("TUBE", !bypassed);
-            });
-        }
-        m_clientTubeEditor->showForTx();
-    });
+    // ── Client Tube applets: TX (#1661) + RX (Phase 7.4) ───────────────────
+    m_appletPanel->clientTubeTxApplet()->setAudioEngine(m_audio);
+    m_appletPanel->clientTubeRxApplet()->setAudioEngine(m_audio);
+    connect(m_appletPanel->clientTubeTxApplet(), &ClientTubeApplet::editRequested,
+            this, [this]() { ensureClientTubeEditor()->showForTx(); });
+    connect(m_appletPanel->clientTubeRxApplet(), &ClientTubeApplet::editRequested,
+            this, [this]() { ensureClientTubeEditor()->showForRx(); });
 
     // ── Client Reverb applet: TX reverb (Freeverb) ─
     m_appletPanel->clientReverbApplet()->setAudioEngine(m_audio);
 
-    // ── Client PUDU applet: TX exciter — PooDoo™ centrepiece (#1661 Phase 5) ─
-    m_appletPanel->clientPuduApplet()->setAudioEngine(m_audio);
-    connect(m_appletPanel->clientPuduApplet(), &ClientPuduApplet::editRequested,
-            this, [this]() {
-        if (!m_clientPuduEditor) {
-            m_clientPuduEditor = new ClientPuduEditor(m_audio, this);
-            connect(m_clientPuduEditor, &ClientPuduEditor::bypassToggled,
-                    this, [this](bool bypassed) {
-                if (m_appletPanel && m_appletPanel->clientPuduApplet())
-                    m_appletPanel->clientPuduApplet()->refreshEnableFromEngine();
-                if (m_appletPanel && m_appletPanel->clientChainApplet())
-                    m_appletPanel->clientChainApplet()->refreshFromEngine();
-                if (m_appletPanel)
-                    m_appletPanel->setAppletVisible("PUDU", !bypassed);
-            });
-        }
-        m_clientPuduEditor->showForTx();
-    });
+    // ── Client PUDU applets: TX (#1661 Phase 5) + RX (Phase 7.5) ───────────
+    m_appletPanel->clientPuduTxApplet()->setAudioEngine(m_audio);
+    m_appletPanel->clientPuduRxApplet()->setAudioEngine(m_audio);
+    connect(m_appletPanel->clientPuduTxApplet(), &ClientPuduApplet::editRequested,
+            this, [this]() { ensureClientPuduEditor()->showForTx(); });
+    connect(m_appletPanel->clientPuduRxApplet(), &ClientPuduApplet::editRequested,
+            this, [this]() { ensureClientPuduEditor()->showForRx(); });
 
     // ── TX signal-chain applet (#1661) ──────────────────────────────────────
     // Visual strip showing MIC → stages → TX with per-stage bypass +
@@ -3038,6 +3053,23 @@ MainWindow::MainWindow(QWidget* parent)
     // stageEnabledChanged → setAppletVisible here.  Initial state is
     // seeded from the engine below so settings persist across launches.
     m_appletPanel->clientChainApplet()->setAudioEngine(m_audio);
+    // PooDoo TX/RX tab → AppletPanel side filter.  Hides the inactive
+    // side's per-stage applet tiles whenever the user flips the chain
+    // tab.  Seed the initial side from the saved tab so the first
+    // paint is correct.
+    connect(m_appletPanel->clientChainApplet(),
+            &ClientChainApplet::chainModeChanged,
+            this, [this](ClientChainApplet::ChainMode mode) {
+        if (!m_appletPanel) return;
+        m_appletPanel->setPooDooActiveSide(
+            mode == ClientChainApplet::ChainMode::Tx
+                ? AppletPanel::PooDooSide::Tx
+                : AppletPanel::PooDooSide::Rx);
+    });
+    // Side-filter seed is moved further down — must run AFTER
+    // setTxDspChainOrder, otherwise that helper's insertChildWidget
+    // calls re-show every TX container we just hid.
+
     // Seed the PooDoo MIC-ready + TX-pulse indicators from current
     // state — subsequent changes flow through the TransmitModel
     // signal connections above (micStateChanged + moxChanged).
@@ -3143,17 +3175,49 @@ MainWindow::MainWindow(QWidget* parent)
             "REVERB", m_audio->clientReverbTx()->isEnabled());
     }
 
-    // Initial applet-stack order mirrors the persisted chain order, and
-    // stays in sync on every subsequent drag-reorder.
+    // Initial applet-stack order mirrors the persisted chain order
+    // for both sides, and stays in sync on every subsequent drag-
+    // reorder.
     if (m_audio) {
         m_appletPanel->setTxDspChainOrder(m_audio->txChainStages());
+        m_appletPanel->setRxDspChainOrder(m_audio->rxChainStages());
     }
+    auto reapplyPooDooSide = [this]() {
+        if (!m_appletPanel) return;
+        const QString savedTab = AppSettings::instance()
+            .value("PooDooAudioActiveTab", "TX").toString();
+        m_appletPanel->setPooDooActiveSide(
+            savedTab == "RX" ? AppletPanel::PooDooSide::Rx
+                             : AppletPanel::PooDooSide::Tx);
+    };
     connect(m_appletPanel->clientChainApplet(),
             &ClientChainApplet::chainReordered,
-            this, [this]() {
-        if (m_appletPanel && m_audio)
-            m_appletPanel->setTxDspChainOrder(m_audio->txChainStages());
+            this, [this, reapplyPooDooSide]() {
+        if (!m_appletPanel || !m_audio) return;
+        m_appletPanel->setTxDspChainOrder(m_audio->txChainStages());
+        // setTxDspChainOrder re-shows every reinserted child, so re-
+        // apply the side filter to keep the inactive side hidden.
+        reapplyPooDooSide();
     });
+    connect(m_appletPanel->clientChainApplet(),
+            &ClientChainApplet::rxChainReordered,
+            this, [this, reapplyPooDooSide]() {
+        if (!m_appletPanel || !m_audio) return;
+        m_appletPanel->setRxDspChainOrder(m_audio->rxChainStages());
+        reapplyPooDooSide();
+    });
+
+    // PooDoo TX/RX side-filter seed — runs AFTER setTxDspChainOrder
+    // because that helper's insertChildWidget unconditionally shows
+    // each child it reinserts, undoing any earlier hide.  Putting the
+    // seed here ensures the inactive side stays hidden on first paint.
+    {
+        const QString savedTab = AppSettings::instance()
+            .value("PooDooAudioActiveTab", "TX").toString();
+        m_appletPanel->setPooDooActiveSide(
+            savedTab == "RX" ? AppletPanel::PooDooSide::Rx
+                             : AppletPanel::PooDooSide::Tx);
+    }
 
     connect(m_appletPanel->clientChainApplet(),
             &ClientChainApplet::stageEnabledChanged,
@@ -3194,52 +3258,13 @@ MainWindow::MainWindow(QWidget* parent)
             this, [this](AudioEngine::TxChainStage stage) {
         switch (stage) {
             case AudioEngine::TxChainStage::Eq:
-                if (!m_clientEqEditor) {
-                    m_clientEqEditor = new ClientEqEditor(m_audio, this);
-                    connect(m_clientEqEditor, &ClientEqEditor::bypassToggled,
-                            this, [this](ClientEqApplet::Path path, bool bypassed) {
-                        if (m_appletPanel && m_appletPanel->clientEqApplet())
-                            m_appletPanel->clientEqApplet()->refreshEnableFromEngine();
-                        if (m_appletPanel && m_appletPanel->clientChainApplet())
-                            m_appletPanel->clientChainApplet()->refreshFromEngine();
-                        // TX bypass drives CEQ tile visibility to stay in
-                        // sync with the chain widget.  RX bypass is not
-                        // represented in the TX chain, so no tile change.
-                        if (path == ClientEqApplet::Path::Tx && m_appletPanel)
-                            m_appletPanel->setAppletVisible("CEQ", !bypassed);
-                    });
-                }
-                m_clientEqEditor->showForPath(ClientEqApplet::Path::Tx);
+                ensureClientEqEditor()->showForPath(ClientEqApplet::Path::Tx);
                 break;
             case AudioEngine::TxChainStage::Comp:
-                if (!m_clientCompEditor) {
-                    m_clientCompEditor = new ClientCompEditor(m_audio, this);
-                    connect(m_clientCompEditor, &ClientCompEditor::bypassToggled,
-                            this, [this](bool bypassed) {
-                        if (m_appletPanel && m_appletPanel->clientCompApplet())
-                            m_appletPanel->clientCompApplet()->refreshEnableFromEngine();
-                        if (m_appletPanel && m_appletPanel->clientChainApplet())
-                            m_appletPanel->clientChainApplet()->refreshFromEngine();
-                        if (m_appletPanel)
-                            m_appletPanel->setAppletVisible("CMP", !bypassed);
-                    });
-                }
-                m_clientCompEditor->showForTx();
+                ensureClientCompEditor()->showForTx();
                 break;
             case AudioEngine::TxChainStage::Gate:
-                if (!m_clientGateEditor) {
-                    m_clientGateEditor = new ClientGateEditor(m_audio, this);
-                    connect(m_clientGateEditor, &ClientGateEditor::bypassToggled,
-                            this, [this](bool bypassed) {
-                        if (m_appletPanel && m_appletPanel->clientGateApplet())
-                            m_appletPanel->clientGateApplet()->refreshEnableFromEngine();
-                        if (m_appletPanel && m_appletPanel->clientChainApplet())
-                            m_appletPanel->clientChainApplet()->refreshFromEngine();
-                        if (m_appletPanel)
-                            m_appletPanel->setAppletVisible("GATE", !bypassed);
-                    });
-                }
-                m_clientGateEditor->showForTx();
+                ensureClientGateEditor()->showForTx();
                 break;
             case AudioEngine::TxChainStage::DeEss:
                 if (!m_clientDeEssEditor) {
@@ -3257,35 +3282,11 @@ MainWindow::MainWindow(QWidget* parent)
                 m_clientDeEssEditor->showForTx();
                 break;
             case AudioEngine::TxChainStage::Tube:
-                if (!m_clientTubeEditor) {
-                    m_clientTubeEditor = new ClientTubeEditor(m_audio, this);
-                    connect(m_clientTubeEditor, &ClientTubeEditor::bypassToggled,
-                            this, [this](bool bypassed) {
-                        if (m_appletPanel && m_appletPanel->clientTubeApplet())
-                            m_appletPanel->clientTubeApplet()->refreshEnableFromEngine();
-                        if (m_appletPanel && m_appletPanel->clientChainApplet())
-                            m_appletPanel->clientChainApplet()->refreshFromEngine();
-                        if (m_appletPanel)
-                            m_appletPanel->setAppletVisible("TUBE", !bypassed);
-                    });
-                }
-                m_clientTubeEditor->showForTx();
+                ensureClientTubeEditor()->showForTx();
                 break;
             case AudioEngine::TxChainStage::Enh:
                 // Enh slot hosts PUDU.
-                if (!m_clientPuduEditor) {
-                    m_clientPuduEditor = new ClientPuduEditor(m_audio, this);
-                    connect(m_clientPuduEditor, &ClientPuduEditor::bypassToggled,
-                            this, [this](bool bypassed) {
-                        if (m_appletPanel && m_appletPanel->clientPuduApplet())
-                            m_appletPanel->clientPuduApplet()->refreshEnableFromEngine();
-                        if (m_appletPanel && m_appletPanel->clientChainApplet())
-                            m_appletPanel->clientChainApplet()->refreshFromEngine();
-                        if (m_appletPanel)
-                            m_appletPanel->setAppletVisible("PUDU", !bypassed);
-                    });
-                }
-                m_clientPuduEditor->showForTx();
+                ensureClientPuduEditor()->showForTx();
                 break;
             case AudioEngine::TxChainStage::Reverb:
                 if (!m_clientReverbEditor) {
@@ -3301,6 +3302,67 @@ MainWindow::MainWindow(QWidget* parent)
                     });
                 }
                 m_clientReverbEditor->showForTx();
+                break;
+            default:
+                break;
+        }
+    });
+
+    // ── RX chain edit + bypass ──────────────────────────────────────────────
+    // Phase 1 routes RX EQ double-clicks to the existing ClientEqEditor in
+    // RX path mode.  Click-bypass lands on the engine via the chain widget
+    // itself; we just refresh the CEQ applet's Enable toggle here so it
+    // stays in sync.
+    connect(m_appletPanel->clientChainApplet(),
+            &ClientChainApplet::rxEditRequested,
+            this, [this](AudioEngine::RxChainStage stage) {
+        switch (stage) {
+            case AudioEngine::RxChainStage::Eq:
+                ensureClientEqEditor()->showForPath(ClientEqApplet::Path::Rx);
+                break;
+            case AudioEngine::RxChainStage::Gate:
+                ensureClientGateEditor()->showForRx();
+                break;
+            case AudioEngine::RxChainStage::Comp:
+                ensureClientCompEditor()->showForRx();
+                break;
+            case AudioEngine::RxChainStage::Tube:
+                ensureClientTubeEditor()->showForRx();
+                break;
+            case AudioEngine::RxChainStage::Pudu:
+                ensureClientPuduEditor()->showForRx();
+                break;
+            default:
+                break;
+        }
+    });
+    connect(m_appletPanel->clientChainApplet(),
+            &ClientChainApplet::rxStageEnabledChanged,
+            this, [this](AudioEngine::RxChainStage stage, bool /*enabled*/) {
+        // Keep the shared per-stage applet's Enable toggle in lock-
+        // step with the click-bypass that just fired on the chain
+        // widget.  Each stage routes to its own applet refresh.
+        if (!m_appletPanel) return;
+        switch (stage) {
+            case AudioEngine::RxChainStage::Eq:
+                if (m_appletPanel->clientEqRxApplet())
+                    m_appletPanel->clientEqRxApplet()->refreshEnableFromEngine();
+                break;
+            case AudioEngine::RxChainStage::Gate:
+                if (m_appletPanel->clientGateRxApplet())
+                    m_appletPanel->clientGateRxApplet()->refreshEnableFromEngine();
+                break;
+            case AudioEngine::RxChainStage::Comp:
+                if (m_appletPanel->clientCompRxApplet())
+                    m_appletPanel->clientCompRxApplet()->refreshEnableFromEngine();
+                break;
+            case AudioEngine::RxChainStage::Tube:
+                if (m_appletPanel->clientTubeRxApplet())
+                    m_appletPanel->clientTubeRxApplet()->refreshEnableFromEngine();
+                break;
+            case AudioEngine::RxChainStage::Pudu:
+                if (m_appletPanel->clientPuduRxApplet())
+                    m_appletPanel->clientPuduRxApplet()->refreshEnableFromEngine();
                 break;
             default:
                 break;
@@ -3585,6 +3647,121 @@ MainWindow::~MainWindow()
 #ifdef HAVE_HIDAPI
     delete m_hidEncoder;
 #endif
+}
+
+ClientEqEditor* MainWindow::ensureClientEqEditor()
+{
+    if (!m_clientEqEditor) {
+        m_clientEqEditor = new ClientEqEditor(m_audio, this);
+        connect(m_clientEqEditor, &ClientEqEditor::bypassToggled,
+                this, [this](ClientEqApplet::Path path, bool bypassed) {
+            if (!m_appletPanel) return;
+            if (path == ClientEqApplet::Path::Tx) {
+                if (m_appletPanel->clientEqTxApplet())
+                    m_appletPanel->clientEqTxApplet()->refreshEnableFromEngine();
+                m_appletPanel->setAppletVisible("CEQ", !bypassed);
+            } else {
+                if (m_appletPanel->clientEqRxApplet())
+                    m_appletPanel->clientEqRxApplet()->refreshEnableFromEngine();
+                m_appletPanel->setAppletVisible("CEQ-RX", !bypassed);
+            }
+            if (m_appletPanel->clientChainApplet())
+                m_appletPanel->clientChainApplet()->refreshFromEngine();
+        });
+    }
+    return m_clientEqEditor;
+}
+
+ClientGateEditor* MainWindow::ensureClientGateEditor()
+{
+    if (!m_clientGateEditor) {
+        m_clientGateEditor = new ClientGateEditor(m_audio, this);
+        connect(m_clientGateEditor, &ClientGateEditor::bypassToggled,
+                this, [this](ClientGateEditor::Side side, bool bypassed) {
+            if (!m_appletPanel) return;
+            if (side == ClientGateEditor::Side::Tx) {
+                if (m_appletPanel->clientGateTxApplet())
+                    m_appletPanel->clientGateTxApplet()->refreshEnableFromEngine();
+                m_appletPanel->setAppletVisible("GATE", !bypassed);
+            } else {
+                if (m_appletPanel->clientGateRxApplet())
+                    m_appletPanel->clientGateRxApplet()->refreshEnableFromEngine();
+                m_appletPanel->setAppletVisible("GATE-RX", !bypassed);
+            }
+            if (m_appletPanel->clientChainApplet())
+                m_appletPanel->clientChainApplet()->refreshFromEngine();
+        });
+    }
+    return m_clientGateEditor;
+}
+
+ClientCompEditor* MainWindow::ensureClientCompEditor()
+{
+    if (!m_clientCompEditor) {
+        m_clientCompEditor = new ClientCompEditor(m_audio, this);
+        connect(m_clientCompEditor, &ClientCompEditor::bypassToggled,
+                this, [this](ClientCompEditor::Side side, bool bypassed) {
+            if (!m_appletPanel) return;
+            if (side == ClientCompEditor::Side::Tx) {
+                if (m_appletPanel->clientCompTxApplet())
+                    m_appletPanel->clientCompTxApplet()->refreshEnableFromEngine();
+                m_appletPanel->setAppletVisible("CMP", !bypassed);
+            } else {
+                if (m_appletPanel->clientCompRxApplet())
+                    m_appletPanel->clientCompRxApplet()->refreshEnableFromEngine();
+                m_appletPanel->setAppletVisible("CMP-RX", !bypassed);
+            }
+            if (m_appletPanel->clientChainApplet())
+                m_appletPanel->clientChainApplet()->refreshFromEngine();
+        });
+    }
+    return m_clientCompEditor;
+}
+
+ClientTubeEditor* MainWindow::ensureClientTubeEditor()
+{
+    if (!m_clientTubeEditor) {
+        m_clientTubeEditor = new ClientTubeEditor(m_audio, this);
+        connect(m_clientTubeEditor, &ClientTubeEditor::bypassToggled,
+                this, [this](ClientTubeEditor::Side side, bool bypassed) {
+            if (!m_appletPanel) return;
+            if (side == ClientTubeEditor::Side::Tx) {
+                if (m_appletPanel->clientTubeTxApplet())
+                    m_appletPanel->clientTubeTxApplet()->refreshEnableFromEngine();
+                m_appletPanel->setAppletVisible("TUBE", !bypassed);
+            } else {
+                if (m_appletPanel->clientTubeRxApplet())
+                    m_appletPanel->clientTubeRxApplet()->refreshEnableFromEngine();
+                m_appletPanel->setAppletVisible("TUBE-RX", !bypassed);
+            }
+            if (m_appletPanel->clientChainApplet())
+                m_appletPanel->clientChainApplet()->refreshFromEngine();
+        });
+    }
+    return m_clientTubeEditor;
+}
+
+ClientPuduEditor* MainWindow::ensureClientPuduEditor()
+{
+    if (!m_clientPuduEditor) {
+        m_clientPuduEditor = new ClientPuduEditor(m_audio, this);
+        connect(m_clientPuduEditor, &ClientPuduEditor::bypassToggled,
+                this, [this](ClientPuduEditor::Side side, bool bypassed) {
+            if (!m_appletPanel) return;
+            if (side == ClientPuduEditor::Side::Tx) {
+                if (m_appletPanel->clientPuduTxApplet())
+                    m_appletPanel->clientPuduTxApplet()->refreshEnableFromEngine();
+                m_appletPanel->setAppletVisible("PUDU", !bypassed);
+            } else {
+                if (m_appletPanel->clientPuduRxApplet())
+                    m_appletPanel->clientPuduRxApplet()->refreshEnableFromEngine();
+                m_appletPanel->setAppletVisible("PUDU-RX", !bypassed);
+            }
+            if (m_appletPanel->clientChainApplet())
+                m_appletPanel->clientChainApplet()->refreshFromEngine();
+        });
+    }
+    return m_clientPuduEditor;
 }
 
 void MainWindow::resizeEvent(QResizeEvent* event)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -365,6 +365,15 @@ private:
     bool m_userDisconnected{false};  // true after explicit disconnect, blocks auto-connect
     QDialog* m_reconnectDlg{nullptr}; // shown on unexpected disconnect, dismissed on reconnect
     class ClientEqEditor* m_clientEqEditor{nullptr}; // lazy — created on first Edit… click
+    // Lazy-construct the floating EQ editor on first access, with all
+    // bypass-toggled wiring set up once.  Used from every site that
+    // wants to open the editor (CEQ-TX applet, CEQ-RX applet, TX
+    // chain widget Eq stage, RX chain widget Eq stage).
+    class ClientEqEditor* ensureClientEqEditor();
+    class ClientGateEditor* ensureClientGateEditor();
+    class ClientCompEditor* ensureClientCompEditor();
+    class ClientTubeEditor* ensureClientTubeEditor();
+    class ClientPuduEditor* ensureClientPuduEditor();
     class ClientCompEditor* m_clientCompEditor{nullptr}; // lazy — created on first Edit… click
     class ClientGateEditor* m_clientGateEditor{nullptr}; // lazy — created on first Edit… click
     class ClientDeEssEditor* m_clientDeEssEditor{nullptr}; // lazy — created on first Edit… click


### PR DESCRIPTION
- PooDoo RX chain Phase 0: chassis + status tiles
- PooDoo RX chain Phase 1: RX EQ tile interactive
- PooDoo RX chain Phase 2: RX Gate
- PooDoo RX chain Phase 3: RX Comp
- PooDoo RX chain Phase 4: RX Tube
- PooDoo RX chain Phase 5: RX PUDU
- PooDoo RX chain polish: BYPASS, DSP tile styling, monitor buttons, stale-settings guard
- PooDoo RX applets Phase 7.1: CEQ split + setPooDooActiveSide
- PooDoo RX applets Phase 7.2: GATE-RX
- PooDoo RX applets Phase 7.3: CMP-RX
- PooDoo RX applets Phase 7.4: TUBE-RX
- PooDoo RX applets Phase 7.5: PUDU-RX + side-filter seed-order fix
- PooDoo: RX drag-to-reorder, Aetherial labels, frameless editor windows
