### PR TITLE
[fix] Frameless floating windows: resize, state persistence, geometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,6 +506,7 @@ set(GUI_SOURCES
     src/gui/DxClusterDialog.cpp
     src/gui/CwxPanel.cpp
     src/gui/BandStackPanel.cpp
+    src/gui/FramelessResizer.cpp
     src/gui/PanFloatingWindow.cpp
     src/gui/DvkPanel.cpp
     src/gui/AmpApplet.cpp
@@ -1176,6 +1177,7 @@ target_link_libraries(transmit_model_test PRIVATE Qt6::Core)
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test
     tests/container_widget_test.cpp
+    src/gui/FramelessResizer.cpp
     src/gui/containers/ContainerTitleBar.cpp
     src/gui/containers/ContainerWidget.cpp
     src/gui/containers/FloatingContainerWindow.cpp
@@ -1189,6 +1191,7 @@ set_target_properties(container_widget_test PROPERTIES AUTOMOC ON)
 
 add_executable(container_manager_test
     tests/container_manager_test.cpp
+    src/gui/FramelessResizer.cpp
     src/gui/containers/ContainerManager.cpp
     src/gui/containers/ContainerTitleBar.cpp
     src/gui/containers/ContainerWidget.cpp
@@ -1203,6 +1206,7 @@ set_target_properties(container_manager_test PROPERTIES AUTOMOC ON)
 
 add_executable(container_nesting_test
     tests/container_nesting_test.cpp
+    src/gui/FramelessResizer.cpp
     src/gui/containers/ContainerManager.cpp
     src/gui/containers/ContainerTitleBar.cpp
     src/gui/containers/ContainerWidget.cpp

--- a/src/gui/FramelessResizer.cpp
+++ b/src/gui/FramelessResizer.cpp
@@ -1,0 +1,111 @@
+#include "FramelessResizer.h"
+
+#include <QChildEvent>
+#include <QEvent>
+#include <QMouseEvent>
+#include <QWidget>
+#include <QWindow>
+
+namespace AetherSDR {
+
+void FramelessResizer::install(QWidget* window, int margin)
+{
+    auto* r = new FramelessResizer(window, margin);
+    r->attachToWidget(window);
+}
+
+FramelessResizer::FramelessResizer(QWidget* window, int margin)
+    : QObject(window), m_window(window), m_margin(margin)
+{
+}
+
+void FramelessResizer::attachToWidget(QWidget* w)
+{
+    w->installEventFilter(this);
+    w->setMouseTracking(true);
+    for (QObject* child : w->children()) {
+        if (QWidget* cw = qobject_cast<QWidget*>(child)) {
+            attachToWidget(cw);
+        }
+    }
+}
+
+Qt::Edges FramelessResizer::edgesAt(const QPoint& p) const
+{
+    const QRect r = m_window->rect();
+    Qt::Edges edges;
+    if (p.x() <= m_margin)                 edges |= Qt::LeftEdge;
+    if (p.x() >= r.width()  - m_margin)    edges |= Qt::RightEdge;
+    if (p.y() <= m_margin)                 edges |= Qt::TopEdge;
+    if (p.y() >= r.height() - m_margin)    edges |= Qt::BottomEdge;
+    return edges;
+}
+
+void FramelessResizer::applyCursor(Qt::Edges edges)
+{
+    if      (edges == (Qt::TopEdge | Qt::LeftEdge))     m_window->setCursor(Qt::SizeFDiagCursor);
+    else if (edges == (Qt::TopEdge | Qt::RightEdge))    m_window->setCursor(Qt::SizeBDiagCursor);
+    else if (edges == (Qt::BottomEdge | Qt::LeftEdge))  m_window->setCursor(Qt::SizeBDiagCursor);
+    else if (edges == (Qt::BottomEdge | Qt::RightEdge)) m_window->setCursor(Qt::SizeFDiagCursor);
+    else if (edges & (Qt::LeftEdge | Qt::RightEdge))    m_window->setCursor(Qt::SizeHorCursor);
+    else if (edges & (Qt::TopEdge  | Qt::BottomEdge))   m_window->setCursor(Qt::SizeVerCursor);
+    else                                                 m_window->unsetCursor();
+}
+
+bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
+{
+    // Hands off when the window has native decorations — the OS handles resize.
+    if (!(m_window->windowFlags() & Qt::FramelessWindowHint))
+        return false;
+
+    switch (ev->type()) {
+
+    case QEvent::MouseMove: {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (me->buttons() != Qt::NoButton) break;
+        QWidget* w = qobject_cast<QWidget*>(obj);
+        if (!w) break;
+        const QPoint pos = (w == m_window) ? me->pos()
+                                           : w->mapTo(m_window, me->pos());
+        applyCursor(edgesAt(pos));
+        break;
+    }
+
+    case QEvent::MouseButtonPress: {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (me->button() != Qt::LeftButton) break;
+        QWidget* w = qobject_cast<QWidget*>(obj);
+        if (!w) break;
+        const QPoint pos = (w == m_window) ? me->pos()
+                                           : w->mapTo(m_window, me->pos());
+        Qt::Edges edges = edgesAt(pos);
+        if (edges && m_window->windowHandle()) {
+            m_window->windowHandle()->startSystemResize(edges);
+            return true;
+        }
+        break;
+    }
+
+    case QEvent::Leave:
+        // Only reset when leaving the top-level window itself, not children.
+        if (obj == m_window) {
+            m_window->unsetCursor();
+        }
+        break;
+
+    case QEvent::ChildAdded: {
+        // Pick up widgets added after install (e.g. container reparented in).
+        auto* ce = static_cast<QChildEvent*>(ev);
+        if (QWidget* cw = qobject_cast<QWidget*>(ce->child())) {
+            attachToWidget(cw);
+        }
+        break;
+    }
+
+    default:
+        break;
+    }
+    return false;
+}
+
+} // namespace AetherSDR

--- a/src/gui/FramelessResizer.h
+++ b/src/gui/FramelessResizer.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QObject>
+#include <Qt>
+
+class QWidget;
+
+namespace AetherSDR {
+
+// Adds all-edge resize to a Qt::FramelessWindowHint top-level QWidget using
+// QWindow::startSystemResize() (the same compositor-managed path already used
+// for startSystemMove in TitleBar / ContainerWidget / PanadapterApplet).
+//
+// Install once after construction; the helper then monitors the window AND
+// every child widget so resize intent is detected regardless of which child
+// the cursor happens to be over at the moment.  New children added later are
+// picked up via QEvent::ChildAdded.
+//
+// Usage:
+//   FramelessResizer::install(this);          // from a QWidget constructor
+//   FramelessResizer::install(win, 6);        // explicit margin
+class FramelessResizer : public QObject {
+    Q_OBJECT
+public:
+    static void install(QWidget* window, int margin = 6);
+
+protected:
+    bool eventFilter(QObject* obj, QEvent* ev) override;
+
+private:
+    explicit FramelessResizer(QWidget* window, int margin);
+    void attachToWidget(QWidget* w);
+    Qt::Edges edgesAt(const QPoint& windowPos) const;
+    void applyCursor(Qt::Edges edges);
+
+    QWidget* m_window{nullptr};
+    int      m_margin{6};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2003,51 +2003,56 @@ MainWindow::MainWindow(QWidget* parent)
             connect(m_layoutRestoreTimer, &QTimer::timeout, this, [this]() {
                 // The radio restores pans from the GUIClientID session.
                 // Accept whatever the radio gives and arrange based on count.
-                int panCount = m_panStack->count();
-                if (panCount <= 1) return;  // single pan, nothing to arrange
-                // Pick a layout based on the number of pans the radio restored
-                const QString saved = AppSettings::instance()
-                    .value("PanadapterLayout", "1").toString();
-                // Only rearrange if the saved layout matches the pan count
-                static const QMap<QString, int> layoutPanCount = {
-                    {"1", 1}, {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"3v", 3}, {"2x2", 4}, {"4v", 4}
-                };
-                if (layoutPanCount.value(saved, 1) == panCount)
-                    m_panStack->rearrangeLayout(saved);
-                else if (panCount == 2)
-                    m_panStack->rearrangeLayout("2v");  // default 2-pan to vertical
-                else if (panCount == 3)
-                    m_panStack->rearrangeLayout("2h1"); // default 3-pan
-                else if (panCount >= 4)
-                    m_panStack->rearrangeLayout("2x2"); // default 4-pan
+                const int panCount = m_panStack->count();
+                if (panCount > 1) {
+                    // Pick a layout based on the number of pans the radio restored
+                    const QString saved = AppSettings::instance()
+                        .value("PanadapterLayout", "1").toString();
+                    // Only rearrange if the saved layout matches the pan count
+                    static const QMap<QString, int> layoutPanCount = {
+                        {"1", 1}, {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"3v", 3}, {"2x2", 4}, {"4v", 4}
+                    };
+                    if (layoutPanCount.value(saved, 1) == panCount)
+                        m_panStack->rearrangeLayout(saved);
+                    else if (panCount == 2)
+                        m_panStack->rearrangeLayout("2v");  // default 2-pan to vertical
+                    else if (panCount == 3)
+                        m_panStack->rearrangeLayout("2h1"); // default 3-pan
+                    else if (panCount >= 4)
+                        m_panStack->rearrangeLayout("2x2"); // default 4-pan
 
-                // Optimistically set local yPixels immediately so FFT frames
-                // arriving before the radio echoes back use correct scaling (#1511).
-                for (auto* a : m_panStack->allApplets()) {
-                    auto* s = a->spectrumWidget();
-                    auto* p = m_radioModel.panadapter(a->panId());
-                    if (!s || !p || !p->panStreamId()) continue;
-                    int y = s->height();
-                    if (y >= 100)
-                        m_radioModel.panStream()->setYPixels(p->panStreamId(), y);
+                    // Optimistically set local yPixels immediately so FFT frames
+                    // arriving before the radio echoes back use correct scaling (#1511).
+                    for (auto* a : m_panStack->allApplets()) {
+                        auto* s = a->spectrumWidget();
+                        auto* p = m_radioModel.panadapter(a->panId());
+                        if (!s || !p || !p->panStreamId()) continue;
+                        int y = s->height();
+                        if (y >= 100)
+                            m_radioModel.panStream()->setYPixels(p->panStreamId(), y);
+                    }
+
+                    // Defensive re-push xpixels for all pans after layout settles.
+                    // Covers race where radio hadn't finished pan init when first push arrived.
+                    QTimer::singleShot(500, this, [this]() {
+                        for (auto* applet : m_panStack->allApplets()) {
+                            auto* sw = applet->spectrumWidget();
+                            auto* pan = m_radioModel.panadapter(applet->panId());
+                            if (!sw || !pan) continue;
+                            int xpix = qMax(sw->width(), 1024);
+                            int ypix = qMax(sw->height(), 200);
+                            m_radioModel.sendCommand(
+                                QString("display pan set %1 xpixels=%2 ypixels=%3")
+                                    .arg(pan->panId()).arg(xpix).arg(ypix));
+                            if (pan->panStreamId())
+                                m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+                        }
+                    });
                 }
 
-                // Defensive re-push xpixels for all pans after layout settles.
-                // Covers race where radio hadn't finished pan init when first push arrived.
-                QTimer::singleShot(500, this, [this]() {
-                    for (auto* applet : m_panStack->allApplets()) {
-                        auto* sw = applet->spectrumWidget();
-                        auto* pan = m_radioModel.panadapter(applet->panId());
-                        if (!sw || !pan) continue;
-                        int xpix = qMax(sw->width(), 1024);
-                        int ypix = qMax(sw->height(), 200);
-                        m_radioModel.sendCommand(
-                            QString("display pan set %1 xpixels=%2 ypixels=%3")
-                                .arg(pan->panId()).arg(xpix).arg(ypix));
-                        if (pan->panStreamId())
-                            m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
-                    }
-                });
+                // Restore floating-pan state saved from the previous session.
+                // Runs for any pan count so a single floated pan is also restored.
+                m_panStack->restoreFloatingState();
             });
         }
         m_layoutRestoreTimer->start();  // restart on each new pan
@@ -6104,6 +6109,14 @@ void MainWindow::buildUI()
     splitter->setStretchFactor(3, 0);
     splitter->setCollapsible(3, false);
 
+    // Restore floating-container state from the previous session.  Deferred
+    // one event-loop cycle so AppletPanel's own legacy-migration singleShot(0)
+    // timers fire first (they write ContainerTree) before we read it back.
+    QTimer::singleShot(0, this, [this]() {
+        if (m_appletPanel && m_appletPanel->containerManager())
+            m_appletPanel->containerManager()->restoreState();
+    });
+
     // Set initial splitter sizes: CWX=0, DVK=0 (both hidden), center=stretch, right=310
     const int centerWidth = qMax(400, width() - 310);
     splitter->setSizes({0, 0, centerWidth, 310});
@@ -9265,6 +9278,11 @@ void MainWindow::setFramelessWindow(bool on)
 
     // Keep the bottom-right size grip in sync — only useful when frameless.
     if (m_sizeGrip) m_sizeGrip->setVisible(on);
+
+    // Propagate to all currently-floating child windows so they match.
+    if (m_panStack) m_panStack->setFramelessMode(on);
+    if (m_appletPanel && m_appletPanel->containerManager())
+        m_appletPanel->containerManager()->setFramelessMode(on);
 }
 
 void MainWindow::toggleMinimalMode(bool on)

--- a/src/gui/PanFloatingWindow.cpp
+++ b/src/gui/PanFloatingWindow.cpp
@@ -1,28 +1,33 @@
 #include "PanFloatingWindow.h"
+#include "FramelessResizer.h"
 #include "PanadapterApplet.h"
 #include "core/AppSettings.h"
 
-#include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QCloseEvent>
-#include <QPushButton>
-#include <QSizeGrip>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QStringList>
+#include <QVBoxLayout>
 
 namespace AetherSDR {
 
 PanFloatingWindow::PanFloatingWindow(QWidget* parent)
-    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
+    : QWidget(parent, Qt::Window)
 {
-    // Windows quirk: the constructor flag bitmask is sometimes ignored
-    // and the native frame still gets drawn.  Re-applying via setWindowFlags
-    // before show() forces the platform plugin to honour FramelessWindowHint
-    // on all Qt versions / widget hierarchies.
-    setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+    const bool frameless =
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True";
+    Qt::WindowFlags flags = Qt::Window;
+    if (frameless) flags |= Qt::FramelessWindowHint;
+    // Re-apply via setWindowFlags — some platform plugins ignore the
+    // constructor bitmask and need an explicit call before show().
+    setWindowFlags(flags);
     setMinimumSize(400, 300);
 
     m_layout = new QVBoxLayout(this);
     m_layout->setContentsMargins(0, 0, 0, 0);
     m_layout->setSpacing(0);
+
+    FramelessResizer::install(this);
 }
 
 void PanFloatingWindow::adoptApplet(PanadapterApplet* applet)
@@ -41,14 +46,6 @@ void PanFloatingWindow::adoptApplet(PanadapterApplet* applet)
     // floating window without an intermediate nullptr/top-level state.
     // This avoids corrupting the main window's NSResponder chain on macOS.
     m_layout->addWidget(m_applet, 1);
-
-    // Bottom-right resize grip — frameless windows lose OS edge resize.
-    auto* gripRow = new QHBoxLayout;
-    gripRow->setContentsMargins(0, 0, 0, 0);
-    gripRow->addStretch(1);
-    gripRow->addWidget(new QSizeGrip(this), 0,
-                       Qt::AlignBottom | Qt::AlignRight);
-    m_layout->addLayout(gripRow);
 
     // Show dock icon in the applet's title bar
     m_applet->setFloatingState(true);
@@ -72,6 +69,21 @@ PanadapterApplet* PanFloatingWindow::takeApplet()
     return a;
 }
 
+void PanFloatingWindow::setFramelessMode(bool on)
+{
+    const bool wasVisible = isVisible();
+    const QRect geom = geometry();
+    Qt::WindowFlags flags = windowFlags();
+    if (on) {
+        flags |= Qt::FramelessWindowHint;
+    } else {
+        flags &= ~Qt::FramelessWindowHint;
+    }
+    setWindowFlags(flags);
+    setGeometry(geom);
+    if (wasVisible) show();
+}
+
 void PanFloatingWindow::closeEvent(QCloseEvent* ev)
 {
     if (m_shuttingDown) {
@@ -85,18 +97,52 @@ void PanFloatingWindow::closeEvent(QCloseEvent* ev)
 
 void PanFloatingWindow::saveWindowGeometry()
 {
-    auto& s = AppSettings::instance();
-    s.setValue(QString("FloatingPan_%1_Geometry").arg(panId()),
-              QString::fromLatin1(saveGeometry().toBase64()));
+    // Store client-area rect as "x,y,w,h" — frame-agnostic, so geometry
+    // restores correctly whether the window is frameless or decorated.
+    const QRect r = geometry();
+    AppSettings::instance().setValue(
+        QString("FloatingPan_%1_Geometry").arg(panId()),
+        QString("%1,%2,%3,%4").arg(r.x()).arg(r.y()).arg(r.width()).arg(r.height()));
 }
 
 void PanFloatingWindow::restoreWindowGeometry()
 {
-    auto& s = AppSettings::instance();
-    QString geom = s.value(QString("FloatingPan_%1_Geometry").arg(panId())).toString();
-    if (!geom.isEmpty()) {
-        restoreGeometry(QByteArray::fromBase64(geom.toLatin1()));
+    const QString val = AppSettings::instance()
+        .value(QString("FloatingPan_%1_Geometry").arg(panId())).toString();
+    if (val.isEmpty()) return;
+
+    // New format: "x,y,w,h" — frame-agnostic.
+    const QStringList parts = val.split(',');
+    if (parts.size() == 4) {
+        bool ok0, ok1, ok2, ok3;
+        const int x = parts[0].toInt(&ok0);
+        const int y = parts[1].toInt(&ok1);
+        const int w = parts[2].toInt(&ok2);
+        const int h = parts[3].toInt(&ok3);
+        if (ok0 && ok1 && ok2 && ok3 && w > 0 && h > 0) {
+            // Clamp top-left to a visible screen so windows on
+            // disconnected monitors don't land off-screen.
+            QRect r(x, y, w, h);
+            bool onScreen = false;
+            for (QScreen* s : QGuiApplication::screens()) {
+                if (s->availableGeometry().contains(r.topLeft())) {
+                    onScreen = true;
+                    break;
+                }
+            }
+            if (!onScreen) {
+                QScreen* s = QGuiApplication::primaryScreen();
+                if (s) {
+                    const QRect avail = s->availableGeometry();
+                    r.moveCenter(avail.center());
+                }
+            }
+            setGeometry(r);
+            return;
+        }
     }
+    // Legacy: base64-encoded QWidget::saveGeometry() blob from older builds.
+    restoreGeometry(QByteArray::fromBase64(val.toLatin1()));
 }
 
 } // namespace AetherSDR

--- a/src/gui/PanFloatingWindow.h
+++ b/src/gui/PanFloatingWindow.h
@@ -25,6 +25,9 @@ public:
     void restoreWindowGeometry();
     void setShuttingDown(bool on) { m_shuttingDown = on; }
 
+    // Follow the main-window frameless setting.  Preserves position.
+    void setFramelessMode(bool on);
+
 signals:
     void dockRequested(const QString& panId);
 

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -3,9 +3,11 @@
 #include "PanFloatingWindow.h"
 #include "PanadapterApplet.h"
 #include "SpectrumWidget.h"
+#include "core/AppSettings.h"
 
 #include <QHBoxLayout>
 #include <QLayout>
+#include <QStringList>
 #include <QVBoxLayout>
 #include <QTimer>
 #include <QWindow>
@@ -502,6 +504,7 @@ void PanadapterStack::floatPanadapter(const QString& panId)
     fw->restoreWindowGeometry();
     fw->show();
     fw->raise();
+    saveFloatingState();
 
     connect(fw, &PanFloatingWindow::dockRequested,
             this, &PanadapterStack::dockPanadapter);
@@ -539,6 +542,7 @@ void PanadapterStack::dockPanadapter(const QString& panId)
     applet = fw->takeApplet();
     fw->hide();
     fw->deleteLater();
+    saveFloatingState();
 
     if (!applet) return;
 
@@ -590,10 +594,39 @@ bool PanadapterStack::isFloating(const QString& panId) const
 
 void PanadapterStack::prepareShutdown()
 {
+    saveFloatingState();
     for (auto* fw : m_floatingWindows) {
         fw->saveWindowGeometry();
         fw->setShuttingDown(true);
         fw->close();
+    }
+}
+
+void PanadapterStack::setFramelessMode(bool on)
+{
+    for (auto* fw : m_floatingWindows) {
+        fw->setFramelessMode(on);
+    }
+}
+
+void PanadapterStack::saveFloatingState() const
+{
+    QStringList ids;
+    for (const QString& id : m_floatingWindows.keys()) {
+        ids << id;
+    }
+    AppSettings::instance().setValue("FloatingPanIds", ids.join(','));
+}
+
+void PanadapterStack::restoreFloatingState()
+{
+    const QString saved =
+        AppSettings::instance().value("FloatingPanIds", "").toString();
+    if (saved.isEmpty()) return;
+    for (const QString& id : saved.split(',', Qt::SkipEmptyParts)) {
+        if (m_pans.contains(id) && !m_floatingWindows.contains(id)) {
+            floatPanadapter(id);
+        }
     }
 }
 

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -52,6 +52,17 @@ public:
     void floatPanadapter(const QString& panId);
     void dockPanadapter(const QString& panId);
     bool isFloating(const QString& panId) const;
+
+    // Follow the main-window frameless setting for all active floating windows.
+    void setFramelessMode(bool on);
+
+    // Persist / restore which pans are currently floating (AppSettings key
+    // "FloatingPanIds").  saveFloatingState is called automatically on every
+    // float/dock transition and at shutdown; restoreFloatingState is called
+    // once after all pans have been added following a radio connect.
+    void saveFloatingState() const;
+    void restoreFloatingState();
+
     void prepareShutdown();
 
 signals:

--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -270,8 +270,16 @@ void ContainerManager::dockContainer(const QString& id)
     saveState();
 }
 
+void ContainerManager::setFramelessMode(bool on)
+{
+    for (auto* win : m_floatingWindows) {
+        if (win) win->setFramelessMode(on);
+    }
+}
+
 void ContainerManager::prepareShutdown()
 {
+    saveState();  // commit current floating/visibility state before closing windows
     for (auto* win : m_floatingWindows) {
         win->prepareShutdown();
     }

--- a/src/gui/containers/ContainerManager.h
+++ b/src/gui/containers/ContainerManager.h
@@ -86,6 +86,9 @@ public:
     void floatContainer(const QString& id);
     void dockContainer(const QString& id);
 
+    // Follow the main-window frameless setting for all active floating windows.
+    void setFramelessMode(bool on);
+
     // Save geometry and close all floating windows without triggering
     // dock-back behaviour.  Call from MainWindow::closeEvent().
     void prepareShutdown();

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -1,15 +1,15 @@
 #include "FloatingContainerWindow.h"
 #include "ContainerWidget.h"
 #include "core/AppSettings.h"
+#include "gui/FramelessResizer.h"
 
 #include <QByteArray>
 #include <QCloseEvent>
 #include <QGuiApplication>
-#include <QHBoxLayout>
 #include <QMoveEvent>
 #include <QResizeEvent>
 #include <QScreen>
-#include <QSizeGrip>
+#include <QStringList>
 #include <QVBoxLayout>
 
 namespace AetherSDR {
@@ -22,13 +22,15 @@ constexpr int kDefaultH = 240;
 } // namespace
 
 FloatingContainerWindow::FloatingContainerWindow(QWidget* parent)
-    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
+    : QWidget(parent, Qt::Window)
 {
-    // Windows quirk: the constructor flag bitmask is sometimes ignored
-    // and the native frame still gets drawn.  Re-applying via setWindowFlags
-    // before show() forces the platform plugin to honour FramelessWindowHint
-    // on all Qt versions / widget hierarchies.
-    setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+    const bool frameless =
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True";
+    Qt::WindowFlags flags = Qt::Window;
+    if (frameless) flags |= Qt::FramelessWindowHint;
+    // Re-apply via setWindowFlags — some platform plugins ignore the
+    // constructor bitmask and need an explicit call before show().
+    setWindowFlags(flags);
     setAttribute(Qt::WA_DeleteOnClose, false);
     setAttribute(Qt::WA_QuitOnClose, false);
     setStyleSheet("QWidget { background: #08121d; }");
@@ -40,6 +42,8 @@ FloatingContainerWindow::FloatingContainerWindow(QWidget* parent)
     m_saveTimer.setInterval(400);
     connect(&m_saveTimer, &QTimer::timeout, this,
             &FloatingContainerWindow::saveGeometryToKey);
+
+    FramelessResizer::install(this);
 }
 
 FloatingContainerWindow::~FloatingContainerWindow() = default;
@@ -59,15 +63,6 @@ void FloatingContainerWindow::takeContainer(ContainerWidget* container)
         m_container->show();
         m_container->setDockMode(ContainerWidget::DockMode::Floating);
         setWindowTitle(m_container->title());
-
-        // Bottom-right resize grip — frameless windows lose OS edge resize.
-        // Append after the container so it sits at the bottom of the layout.
-        auto* gripRow = new QHBoxLayout;
-        gripRow->setContentsMargins(0, 0, 0, 0);
-        gripRow->addStretch(1);
-        gripRow->addWidget(new QSizeGrip(this), 0,
-                           Qt::AlignBottom | Qt::AlignRight);
-        m_layout->addLayout(gripRow);
     }
 }
 
@@ -93,11 +88,29 @@ void FloatingContainerWindow::restoreAndEnsureVisible(QWidget* anchor)
     m_restoring = true;
     bool restored = false;
     if (!m_geometryKey.isEmpty()) {
-        const QByteArray geom = QByteArray::fromBase64(
-            AppSettings::instance()
-                .value(m_geometryKey, "").toByteArray());
-        if (!geom.isEmpty() && restoreGeometry(geom)) {
-            restored = true;
+        const QString val = AppSettings::instance()
+            .value(m_geometryKey, "").toString();
+        if (!val.isEmpty()) {
+            // New format: "x,y,w,h" — frame-agnostic, works across
+            // frameless ↔ decorated mode changes.
+            const QStringList parts = val.split(',');
+            if (parts.size() == 4) {
+                bool ok0, ok1, ok2, ok3;
+                const int x = parts[0].toInt(&ok0);
+                const int y = parts[1].toInt(&ok1);
+                const int w = parts[2].toInt(&ok2);
+                const int h = parts[3].toInt(&ok3);
+                if (ok0 && ok1 && ok2 && ok3 && w > 0 && h > 0) {
+                    setGeometry(x, y, w, h);
+                    restored = true;
+                }
+            }
+            if (!restored) {
+                // Legacy: base64-encoded QWidget::saveGeometry() blob.
+                const QByteArray blob = QByteArray::fromBase64(val.toUtf8());
+                if (!blob.isEmpty() && restoreGeometry(blob))
+                    restored = true;
+            }
         }
     }
     if (!restored) {
@@ -114,8 +127,8 @@ void FloatingContainerWindow::restoreAndEnsureVisible(QWidget* anchor)
             resize(kDefaultW, kDefaultH);
         }
     } else {
-        // Clamp to any visible screen — saved geometry may reference
-        // a monitor that's no longer connected.
+        // Clamp top-left to a visible screen — saved position may
+        // reference a monitor that's no longer connected.
         bool onScreen = false;
         const QPoint tl = geometry().topLeft();
         for (QScreen* s : QGuiApplication::screens()) {
@@ -137,8 +150,12 @@ void FloatingContainerWindow::restoreAndEnsureVisible(QWidget* anchor)
 void FloatingContainerWindow::saveGeometryToKey() const
 {
     if (m_geometryKey.isEmpty()) return;
+    // Store client-area rect as "x,y,w,h" — frame-agnostic so geometry
+    // restores correctly whether the window is frameless or decorated.
+    const QRect r = geometry();
     AppSettings::instance().setValue(
-        m_geometryKey, saveGeometry().toBase64());
+        m_geometryKey,
+        QString("%1,%2,%3,%4").arg(r.x()).arg(r.y()).arg(r.width()).arg(r.height()));
 }
 
 void FloatingContainerWindow::prepareShutdown()
@@ -147,6 +164,21 @@ void FloatingContainerWindow::prepareShutdown()
     saveGeometryToKey();
     m_shuttingDown = true;
     close();
+}
+
+void FloatingContainerWindow::setFramelessMode(bool on)
+{
+    const bool wasVisible = isVisible();
+    const QRect geom = geometry();
+    Qt::WindowFlags flags = windowFlags();
+    if (on) {
+        flags |= Qt::FramelessWindowHint;
+    } else {
+        flags &= ~Qt::FramelessWindowHint;
+    }
+    setWindowFlags(flags);
+    setGeometry(geom);
+    if (wasVisible) show();
 }
 
 void FloatingContainerWindow::closeEvent(QCloseEvent* ev)

--- a/src/gui/containers/FloatingContainerWindow.h
+++ b/src/gui/containers/FloatingContainerWindow.h
@@ -44,6 +44,9 @@ public:
     void setGeometryKey(const QString& key);
     QString geometryKey() const { return m_geometryKey; }
 
+    // Follow the main-window frameless setting.  Preserves position.
+    void setFramelessMode(bool on);
+
     // Called by ContainerManager before the app exits.  Saves geometry,
     // suppresses the dock-on-close behaviour, and closes the window.
     void prepareShutdown();


### PR DESCRIPTION
## What changed

### New: FramelessResizer (src/gui/FramelessResizer.h/.cpp)

Added a reusable QObject event-filter that provides all-8-edge resize for any Qt::FramelessWindowHint top-level window using QWindow::startSystemResize() — the same compositor-managed path already used for drag-to-move via startSystemMove().

Previously, frameless pop-out windows (panadapters and applets) only had a QSizeGrip in the bottom-right corner. On Linux/Wayland this grip often does nothing. The new resizer installs itself recursively on the window and all child widgets (picking up new children via ChildAdded events), translates cursor positions to window-local coordinates, detects which of the 8 edges/corners the mouse is near (within 6 px), updates the cursor shape, and calls startSystemResize() on press. When the window is not frameless the resizer is a no-op so it does not interfere with native decorations.

The old QSizeGrip rows in PanFloatingWindow and FloatingContainerWindow were removed since the resizer supersedes them.

---

### Fix 1: Frameless mode toggle not propagating to floating windows

**Symptom:** Switching View -> Frameless Window updated the main window chrome but left any already-open floating panadapter or applet windows unchanged.

**Root cause:** setFramelessWindow() in MainWindow only modified its own Qt::FramelessWindowHint flag. PanFloatingWindow and FloatingContainerWindow had the flag hardcoded at construction and were never updated.

**Changes:**
- PanFloatingWindow constructor now reads AppSettings["FramelessWindow"] instead of hardcoding Qt::FramelessWindowHint.
- PanFloatingWindow::setFramelessMode(bool) added — same setWindowFlags + setGeometry + show() pattern as MainWindow::setFramelessWindow.
- FloatingContainerWindow constructor same fix.
- FloatingContainerWindow::setFramelessMode(bool) added.
- PanadapterStack::setFramelessMode(bool) added — iterates all live floating windows and calls setFramelessMode on each.
- ContainerManager::setFramelessMode(bool) added — same for applet windows.
- MainWindow::setFramelessWindow() now calls m_panStack->setFramelessMode() and containerManager()->setFramelessMode() after updating itself.

---

### Fix 2: Floating panadapter state not saved or restored across restarts

**Symptom:** Popped-out panadapters came back docked after every restart.

**Root cause:** PanadapterStack saved window geometry (position/size) but never recorded which pans were floating. There was no restore path.

**Changes:**
- PanadapterStack::saveFloatingState() — writes the comma-separated list of currently-floating pan IDs to AppSettings["FloatingPanIds"]. Called automatically from floatPanadapter(), dockPanadapter(), and prepareShutdown().
- PanadapterStack::restoreFloatingState() — reads "FloatingPanIds" and calls floatPanadapter() for each ID that exists and is not already floating. Safe on reconnect (unknown IDs are skipped, already-floating pans are no-ops).
- MainWindow m_layoutRestoreTimer lambda: previously did an early return for single-pan sessions, blocking any restore. Restructured to always call restoreFloatingState() regardless of pan count after layout settles (~1 s after radio connect).

---

### Fix 3: Floating applet state not restored across restarts

**Symptom:** Popped-out applet containers (EQ, S-Meter, etc.) came back docked after every restart.

**Root cause:** ContainerManager::restoreState() was fully implemented and ContainerManager::saveState() was already called on every float/dock transition, but restoreState() was never called anywhere. The ContainerTree JSON key was written at runtime but never read back on launch.

**Changes:**
- ContainerManager::prepareShutdown() now calls saveState() first, guaranteeing the ContainerTree JSON reflects the final floating/visibility state before windows close — previously a crash or force-quit could leave it stale.
- MainWindow: after `m_appletPanel = new AppletPanel(splitter)`, a QTimer::singleShot(0) schedules containerManager()->restoreState(). The one-event-loop delay lets AppletPanel's own legacy-migration singleShot(0) timers fire first (they write ContainerTree for pre-container-system saves), then restoreState() reads the up-to-date JSON and re-floats containers.

---

### Fix 4: Floating window geometry wrong after frameless mode change

**Symptom:** A window saved while frameless would appear at an offset position after switching to decorated mode (or vice versa), by roughly the height of the OS title bar.

**Root cause:** QWidget::saveGeometry() serialises frame-extent data (the platform's window decoration size) alongside the window position. restoreGeometry() then applies those frame extents when placing the window. If the decoration mode has changed between save and restore, the wrong frame size is applied, shifting the window by the title bar height (~30 px on most Linux/Windows themes).

**Changes (PanFloatingWindow + FloatingContainerWindow):**
- saveWindowGeometry() / saveGeometryToKey() now store plain "x,y,w,h" from geometry() (the client-area rect, always frame-agnostic) instead of the opaque QWidget::saveGeometry() blob.
- restoreWindowGeometry() / restoreAndEnsureVisible() parse the "x,y,w,h" format and call setGeometry() directly — no frame arithmetic, works identically frameless or decorated.
- Legacy fallback: if the stored value is not four integers (i.e. it is a base64 blob from a build before this fix), the code falls through to the old restoreGeometry() path so existing saves are not lost on upgrade.
- Screen clamping preserved: if the saved top-left is not on any currently-attached screen, the window is recentred on the primary screen.

---

## Files changed

  CMakeLists.txt                                 add FramelessResizer to all targets
  src/gui/FramelessResizer.h                     new: all-edge resize event-filter
  src/gui/FramelessResizer.cpp                   new
  src/gui/PanFloatingWindow.h                    add setFramelessMode()
  src/gui/PanFloatingWindow.cpp                  fix constructor, setFramelessMode,
                                                 frame-agnostic geometry save/restore
  src/gui/PanadapterStack.h                      add setFramelessMode, save/restoreFloatingState
  src/gui/PanadapterStack.cpp                    implement above, hook into lifecycle
  src/gui/containers/FloatingContainerWindow.h   add setFramelessMode()
  src/gui/containers/FloatingContainerWindow.cpp fix constructor, setFramelessMode,
                                                 frame-agnostic geometry save/restore
  src/gui/containers/ContainerManager.h          add setFramelessMode()
  src/gui/containers/ContainerManager.cpp        implement setFramelessMode,
                                                 saveState in prepareShutdown
  src/gui/MainWindow.cpp                         propagate frameless toggle,
                                                 call restoreState on startup,
                                                 restore floating pans in layout timer