### PR TITLE
fix: remove stale RADE DSP guards that silenced NR4/NR2/etc. on unrelated pans

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -55,8 +55,9 @@ bool devicePresent(const QList<QAudioDevice>& devices, const QAudioDevice& targe
 
 void AudioEngine::updateRxBufferStats()
 {
-    m_rxBufferBytes.store(m_rxBuffer.size());
-    m_rxBufferPeakBytes.store(std::max(m_rxBufferPeakBytes.load(), m_rxBuffer.size()));
+    const qsizetype total = m_rxBuffer.size() + m_radeRxBuffer.size();
+    m_rxBufferBytes.store(total);
+    m_rxBufferPeakBytes.store(std::max(m_rxBufferPeakBytes.load(), total));
 }
 
 AudioEngine::AudioEngine(QObject* parent)
@@ -257,9 +258,13 @@ AudioEngine::AudioEngine(QObject* parent)
                     const auto* rade = reinterpret_cast<const float*>(m_radeRxBuffer.constData());
                     const qsizetype radeSamples = radeTake / floatBytes;
                     for (qsizetype i = 0; i < radeSamples; ++i)
-                        out[i] = std::clamp(out[i] + rade[i], -1.0f, 1.0f);
+                        out[i] += rade[i];
                     m_radeRxBuffer.remove(0, radeTake);
                 }
+                // Single clamp pass after all sources are mixed.
+                const qsizetype totalSamples = len / floatBytes;
+                for (qsizetype i = 0; i < totalSamples; ++i)
+                    out[i] = std::clamp(out[i], -1.0f, 1.0f);
             }
 
             len = m_audioDevice->write(chunk);
@@ -2209,8 +2214,6 @@ void AudioEngine::generateWisdom(std::function<void(int,int,const std::string&)>
 void AudioEngine::setNr2Enabled(bool on)
 {
     if (m_nr2Enabled == on) return;
-    // RADE outputs decoded speech — client-side DSP has no effect
-    if (on && m_radeMode) return;
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (on) {
         // Disable all other NR modes — they're mutually exclusive
@@ -2261,7 +2264,6 @@ void AudioEngine::setNr4Enabled(bool on)
     if (m_nr4Enabled == on) return;
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (on) {
-        if (m_radeMode) return;
         if (m_nr2Enabled)  setNr2Enabled(false);
         if (m_rn2Enabled)  setRn2Enabled(false);
         if (m_bnrEnabled)  setBnrEnabled(false);
@@ -2314,8 +2316,6 @@ void AudioEngine::setNr4SuppressionStrength(float) {}
 void AudioEngine::setMnrEnabled(bool on)
 {
     if (m_mnrEnabled == on) return;
-    // RADE outputs decoded speech — client-side DSP has no effect
-    if (on && m_radeMode) return;
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
 #ifdef __APPLE__
     if (on) {
@@ -2361,7 +2361,6 @@ float AudioEngine::mnrStrength() const
 void AudioEngine::setRn2Enabled(bool on)
 {
     if (m_rn2Enabled == on) return;
-    if (on && m_radeMode) return;
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (on) {
         // Disable all other NR modes — they're mutually exclusive
@@ -2392,7 +2391,6 @@ void AudioEngine::setRn2Enabled(bool on)
 void AudioEngine::setBnrEnabled(bool on)
 {
     if (m_bnrEnabled == on) return;
-    if (on && m_radeMode) return;
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (on) {
         // Mutual exclusion with all other NR modes
@@ -2563,7 +2561,6 @@ void AudioEngine::processBnr(const QByteArray& stereoPcm)
 void AudioEngine::setDfnrEnabled(bool on)
 {
     if (m_dfnrEnabled == on) return;
-    if (on && m_radeMode) return;
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (on) {
         // Mutual exclusion with all other NR modes
@@ -3268,18 +3265,6 @@ void AudioEngine::setRadeMode(bool on)
 {
     if (m_radeMode == on) return;
     m_radeMode = on;
-    // RADE outputs decoded speech — client-side DSP has no effect.
-    // Disable any active DSP when entering RADE mode.
-    if (on) {
-        if (m_nr2Enabled) setNr2Enabled(false);
-        if (m_rn2Enabled) setRn2Enabled(false);
-        if (m_nr4Enabled) setNr4Enabled(false);
-        if (m_bnrEnabled) setBnrEnabled(false);
-#ifdef HAVE_DFNR
-        if (m_dfnrEnabled) setDfnrEnabled(false);
-#endif
-    }
-
     // RADE TX: onTxAudioReady() emits txRawPcmReady (float32) then returns
     // early — the Opus voice TX path never runs. RADEEngine receives the
     // raw PCM, encodes it to a modem waveform, and emits it via


### PR DESCRIPTION
## Background

This fix was identified during post-merge testing of PR #1953 (dual-buffer RADE
RX architecture). After #1953 landed, multi-pan testing revealed that
client-side DSP (NR4, NR2, RN2, BNR, DFNR, MNR) was completely silenced on any
non-RADE pan while RADE was active — a regression introduced by guards that were
correct before #1953 but became harmful once the dual-buffer design separated
RADE decoded audio from the DSP pipeline entirely.

## Problem

In a two-pan setup (Pan A = RADE/FreeDV, Pan B = SSB/CW), engaging NR4 or any
client-side DSP on Pan B had no effect. The UI buttons illuminated correctly,
but the audio pipeline was untouched.

## Root Cause

`AudioEngine` had `if (m_radeMode) return;` guards at the top of every DSP
setter (`setNr4Enabled`, `setNr2Enabled`, `setRn2Enabled`, `setBnrEnabled`,
`setDfnrEnabled`, `setMnrEnabled`) and a teardown loop in `setRadeMode(on=true)`
that forcibly disabled all DSP.

These guards were appropriate when RADE decoded audio flowed through the same
`m_rxBuffer` / DSP pipeline as regular audio — running NR on decoded speech
would have degraded it. **They are no longer correct** after PR #1953: decoded
speech now flows exclusively through `m_radeRxBuffer` and is mixed in the drain
timer *after* the DSP stage. The DSP pipeline only ever touches `m_rxBuffer`;
RADE audio never enters it.

## Fix

- Remove `if (m_radeMode) return;` from all six client-side DSP setters
- Remove the DSP teardown loop from `setRadeMode(on=true)`
- Correct `updateRxBufferStats()` to sum both buffers for accurate diagnostics
- Correct the drain timer mix to apply the final `std::clamp` in a single pass
  over the full output block (was only clamping the RADE portion)

## Testing

Tested on **FLEX-8400, firmware v4.1.5.39794**, two-panadapter layout:
- Pan A: Slice 0 in RADE/FreeDV mode, RADE active, receiving decoded speech
- Pan B: Slice 1 in USB — NR4/NR2 engaged → audio processing confirmed active
- No regressions on single-pan operation or non-RADE modes
- RADE decoded audio quality unaffected (DSP path is upstream of the mix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)