### PR TITLE
fix: RADE deactivated by mode change on unrelated slice in multi-pan setup

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2267,7 +2267,10 @@ MainWindow::MainWindow(QWidget* parent)
 
 #ifdef HAVE_RADE
     connect(m_appletPanel->rxApplet(), &RxApplet::radeActivated,
-            this, [this](bool on, int sliceId) { if (on) activateRADE(sliceId); else deactivateRADE(); });
+            this, [this](bool on, int sliceId) {
+        if (on) activateRADE(sliceId);
+        else if (sliceId == m_radeSliceId) deactivateRADE();
+    });
 #endif
 
     // ── Tuning step size → AppSettings + radio command ─────────────────────
@@ -9046,7 +9049,8 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
 
 #ifdef HAVE_RADE
     connect(w, &VfoWidget::radeActivated, this, [this](bool on, int sliceId) {
-        if (on) activateRADE(sliceId); else deactivateRADE();
+        if (on) activateRADE(sliceId);
+        else if (sliceId == m_radeSliceId) deactivateRADE();
     });
 #endif
 
@@ -10499,9 +10503,9 @@ void MainWindow::activateRADE(int sliceId)
     }
 
     // RADE status indicator in VFO widget.
-    // Use vfoWidget(sliceId) — the no-arg alias (m_vfoWidget) may be null
-    // if setActiveVfoWidget() hasn't been called yet for this slice.
-    if (auto* sw = spectrum()) {
+    // Use spectrumForSlice() to find the correct pan — in multi-pan layouts
+    // spectrum() returns the *active* pan, which may not be the RADE slice's pan.
+    if (auto* sw = spectrumForSlice(m_radioModel.slice(sliceId))) {
         if (auto* vfo = sw->vfoWidget(sliceId)) {
             vfo->setRadeActive(true);
             // Show initial unsynchronised state immediately — syncChanged only fires
@@ -10526,7 +10530,7 @@ void MainWindow::deactivateRADE()
         if (auto* s = m_radioModel.slice(m_radeSliceId))
             s->setAudioMute(m_radePrevMute);
         // Clear RADE status label before resetting sliceId
-        if (auto* sw = spectrum()) {
+        if (auto* sw = spectrumForSlice(m_radioModel.slice(m_radeSliceId))) {
             if (auto* vfo = sw->vfoWidget(m_radeSliceId))
                 vfo->setRadeActive(false);
         }

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1472,7 +1472,12 @@ void VfoWidget::buildTabContent()
                 emit radeActivated(true, m_slice ? m_slice->sliceId() : -1);
                 return;
             }
-            emit radeActivated(false, m_slice ? m_slice->sliceId() : -1);
+            // Only deactivate RADE if it was active on THIS slice's widget —
+            // same guard used by the quick-mode buttons below (line ~1514).
+            // Without this, any slice switching away from a non-RADE mode
+            // would fire radeActivated(false) and kill RADE on a different pan.
+            if (m_radeActive)
+                emit radeActivated(false, m_slice ? m_slice->sliceId() : -1);
 #endif
             if (!m_updatingFromModel && m_slice)
                 m_slice->setMode(mode);


### PR DESCRIPTION
## Background

This fix was identified during post-merge testing of PR #1953 (dual-buffer RADE
RX architecture). Multi-pan verification of the new RADE audio path uncovered
two independent bugs that together caused RADE to be torn down whenever the mode
was changed on a completely unrelated slice.

## Problem

In a two-panadapter setup, switching Slice B to DIGU (or any non-RADE mode via
the mode combo box) **killed RADE on Slice A**:

- RADE status indicators (icon, sync light, SNR, freq offset) disappeared from
  Pan A's VFO
- RADE decoded audio stopped
- The radio's RADE waveform stream was torn down

Switching Slice B mode again did not restore RADE — a full manual re-activation
was required.

## Root Cause (three independent bugs)

**Bug 1 — Unconditional `radeActivated(false)` emit in VfoWidget:**
The mode combo-box `currentTextChanged` handler emitted `radeActivated(false,
sliceId)` for *every* non-RADE mode selection, regardless of whether RADE was
active on that widget. The quick-mode buttons directly below in the same file
already had the correct `if (m_radeActive)` guard; the combo handler was missing
it.

**Bug 2 — Missing `sliceId` guard in MainWindow handlers:**
Both `radeActivated` signal handlers in MainWindow (one wired to RxApplet, one
to VfoWidget) called `deactivateRADE()` unconditionally on `on=false`. A
spurious `radeActivated(false, sliceB)` from Bug 1 was enough to tear down RADE
even when `m_radeSliceId` pointed to Slice A.

**Bug 3 — Wrong spectrum lookup in `activateRADE`/`deactivateRADE`:**
Both methods called `spectrum()` (returns the currently focused pan's
SpectrumWidget) instead of `spectrumForSlice()` (looks up by pan ID). RADE
status indicators would appear/disappear on the wrong pan if a different pan
was focused at the time of activation.

## Fix

- **VfoWidget.cpp**: add `if (m_radeActive)` guard before
  `emit radeActivated(false, ...)` in the combo handler, matching the existing
  guard on the quick-mode buttons
- **MainWindow.cpp** (both handlers): change `else deactivateRADE()` →
  `else if (sliceId == m_radeSliceId) deactivateRADE()` so only the owning
  slice can trigger deactivation
- **MainWindow.cpp** (`activateRADE` / `deactivateRADE`): replace `spectrum()`
  with `spectrumForSlice(m_radioModel.slice(...))` for correct indicator
  placement in any pan layout

## Testing

Tested on **FLEX-8400, firmware v4.1.5.39794**, two-panadapter layout:
- Pan A: Slice 0 in RADE/FreeDV, RADE active
- Pan B: Slice 1 — cycled through DIGU, DIGL, USB, LSB, AM, FM repeatedly
- RADE on Pan A remained active throughout; status indicators stayed on Pan A
- RADE activate/deactivate from Pan A VFO still works correctly
- No regressions on single-pan operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)