### PR TITLE
Add CODEOWNERS with three review tiers; document them in CONTRIBUTING

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,40 @@
+# AetherSDR CODEOWNERS
+#
+# Three tiers, last-matching-pattern wins:
+#   1. Broad default — jensenpat + maintainer
+#   2. Mechanical/safe paths — also approvable by @AetherClaude (machine user)
+#   3. Maintainer-only — direction-impacting paths reserved to @ten9876
+#
+# Self-approval is hard-blocked by GitHub regardless of CODEOWNERS membership,
+# so a contributor cannot approve their own PR even on paths they own.
+
+# ── Tier 1: broad default ──────────────────────────────────────────────────
+*                            @ten9876 @jensenpat
+
+# ── Tier 2: mechanical/safe paths — bot can also approve ───────────────────
+tests/                       @ten9876 @jensenpat @AetherClaude
+docs/                        @ten9876 @jensenpat @AetherClaude
+*.md                         @ten9876 @jensenpat @AetherClaude
+.github/dependabot.yml       @ten9876 @jensenpat @AetherClaude
+.github/docker/              @ten9876 @jensenpat @AetherClaude
+.github/ISSUE_TEMPLATE/      @ten9876 @jensenpat @AetherClaude
+
+# ── Tier 3: maintainer-only — direction, architecture, project policy ──────
+# Visual/UX direction (per CLAUDE.md "AI Agent Boundaries")
+src/gui/MainWindow.h         @ten9876
+src/gui/MainWindow.cpp       @ten9876
+
+# Architecture — central state, threading, protocol bedrock
+src/core/RadioModel.h        @ten9876
+src/core/RadioModel.cpp      @ten9876
+src/core/AudioEngine.h       @ten9876
+src/core/AudioEngine.cpp     @ten9876
+src/core/PanadapterStream.h  @ten9876
+src/core/PanadapterStream.cpp @ten9876
+
+# Build, project policy, and infrastructure
+CMakeLists.txt               @ten9876
+CLAUDE.md                    @ten9876
+CONTRIBUTING.md              @ten9876
+.github/CODEOWNERS           @ten9876
+.github/workflows/           @ten9876

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,28 @@ If `gpg` hangs, set `export GPG_TTY=$(tty)` in your shell profile.
 
 ---
 
+## Reviews and merging
+
+PR review responsibility is divided into three tiers via
+[`.github/CODEOWNERS`](.github/CODEOWNERS). Self-approval is blocked by
+GitHub on every tier — your own PR always needs review from someone else.
+
+| Tier | Paths | Who can approve |
+|---|---|---|
+| **Default** | Everything not listed below | @ten9876, @jensenpat |
+| **Mechanical / safe** | `tests/`, `docs/`, `*.md`, `.github/dependabot.yml`, `.github/docker/`, `.github/ISSUE_TEMPLATE/` | @ten9876, @jensenpat, @AetherClaude |
+| **Maintainer-only** | `src/gui/MainWindow.{h,cpp}`, `src/core/RadioModel.{h,cpp}`, `src/core/AudioEngine.{h,cpp}`, `src/core/PanadapterStream.{h,cpp}`, `CMakeLists.txt`, `CLAUDE.md`, `CONTRIBUTING.md`, `.github/CODEOWNERS`, `.github/workflows/` | @ten9876 |
+
+The maintainer-only tier covers *direction-impacting* paths: visual/UX,
+threading and central-state architecture, protocol bedrock, build
+configuration, and project policy. Per
+[CLAUDE.md](CLAUDE.md#autonomous-agent-boundaries), changes here need
+maintainer eyes regardless of who wrote them.
+
+The mechanical tier exists so the @AetherClaude bot can land low-risk
+changes (test additions, documentation tweaks, dependency bumps,
+template updates) without queueing on human review.
+
 ## What We Will Not Accept
 
 - **Wine/Crossover workarounds.** The goal is fully native.


### PR DESCRIPTION
Tier 1 (broad default): @ten9876 + @jensenpat
Tier 2 (mechanical/safe paths — tests, docs, dependabot, docker,
issue templates): also @AetherClaude
Tier 3 (maintainer-only — visual/UX, threading and central-state
architecture, protocol bedrock, build config, project policy): @ten9876

Self-approval is hard-blocked by GitHub regardless of CODEOWNERS
membership, so contributors still need a second pair of eyes on
their own PRs even on paths they own. Branch protection already
has require_code_owner_reviews=true and require_signatures=true,
so this takes effect immediately on the next merge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
