### PR TITLE
Remove root CODEOWNERS — superseded by .github/CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# All files require review from the project owner.
-* @ten9876


### PR DESCRIPTION
GitHub's lookup order prefers .github/CODEOWNERS over the root one,
so the root file (just "* @ten9876") was being ignored anyway. It
showed up in the root file browser and made it look like the active
CODEOWNERS hadn't been updated, which was confusing. Drop it so
there's a single source of truth.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
