### PR TITLE
Aetherial Audio polish: RX tile labels, AGC-T knob, popped-out sizing

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -633,6 +633,10 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     auto* txDsp = m_containerMgr->createContainer(
         "tx_dsp", QString::fromUtf8("Aetherial Audio\xe2\x84\xa2"));
+    // Cap the column width so popped-out floating windows don't grow
+    // wider than the chain visualisation needs.  Docked columns are
+    // already narrower so this is a no-op there.
+    if (txDsp) txDsp->setMaximumWidth(280);
 
     auto makeChildContainer = [this, txDsp](const QString& id,
                                             const QString& title,
@@ -833,6 +837,22 @@ void AppletPanel::setPooDooActiveSide(PooDooSide side)
     };
     applyVisibility(kTxOnly, txActive);
     applyVisibility(kRxOnly, !txActive);
+
+    // If the parent tx_dsp container is currently floating, the set of
+    // visible children just changed — its sizeHint shrank or grew but
+    // the floating window won't refit on its own.  Defer one event-loop
+    // tick so child layouts (e.g. ClientChainWidget, which dynamically
+    // setFixedHeight()s itself based on row count) finish recalculating
+    // before we read sizeHint.
+    if (auto* parent = m_containerMgr->container("tx_dsp")) {
+        if (parent->isFloating()) {
+            if (QWidget* win = parent->window()) {
+                QTimer::singleShot(0, win, [win]() {
+                    win->adjustSize();
+                });
+            }
+        }
+    }
 }
 
 void AppletPanel::resetOrder()

--- a/src/gui/ClientGateApplet.cpp
+++ b/src/gui/ClientGateApplet.cpp
@@ -177,19 +177,15 @@ void ClientGateApplet::buildUI()
         });
         row->addWidget(m_ratio);
 
-        m_attack = makeKnob("Attack");
-        m_attack->setRange(0.1f, 100.0f);
-        m_attack->setDefault(0.5f);
-        m_attack->setValueFromNorm([](float n) {
-            return 0.1f * std::pow(1000.0f, n);
+        m_return = makeKnob("Return");
+        m_return->setRange(0.0f, 20.0f);
+        m_return->setDefault(2.0f);
+        m_return->setValueFromNorm([](float n) { return n * 20.0f; });
+        m_return->setNormFromValue([](float v) { return v / 20.0f; });
+        m_return->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 2) + " dB";
         });
-        m_attack->setNormFromValue([](float v) {
-            return std::log(std::max(0.1f, v) / 0.1f) / std::log(1000.0f);
-        });
-        m_attack->setLabelFormat([](float v) {
-            return QString::number(v, 'f', v < 10.0f ? 2 : 1) + " ms";
-        });
-        row->addWidget(m_attack);
+        row->addWidget(m_return);
 
         m_release = makeKnob("Release");
         m_release->setRange(5.0f, 2000.0f);
@@ -230,7 +226,7 @@ void ClientGateApplet::buildUI()
     };
     wire(m_thresh,  &ClientGate::setThresholdDb);
     wire(m_ratio,   &ClientGate::setRatio);
-    wire(m_attack,  &ClientGate::setAttackMs);
+    wire(m_return,  &ClientGate::setReturnDb);
     wire(m_release, &ClientGate::setReleaseMs);
     wire(m_floor,   &ClientGate::setFloorDb);
 
@@ -255,7 +251,7 @@ void ClientGateApplet::syncEnableFromEngine()
     ClientGate* g = gate();
     if (m_thresh)  { QSignalBlocker b(m_thresh);  m_thresh->setValue(g->thresholdDb()); }
     if (m_ratio)   { QSignalBlocker b(m_ratio);   m_ratio->setValue(g->ratio()); }
-    if (m_attack)  { QSignalBlocker b(m_attack);  m_attack->setValue(g->attackMs()); }
+    if (m_return)  { QSignalBlocker b(m_return);  m_return->setValue(g->returnDb()); }
     if (m_release) { QSignalBlocker b(m_release); m_release->setValue(g->releaseMs()); }
     if (m_floor)   { QSignalBlocker b(m_floor);   m_floor->setValue(g->floorDb()); }
 }
@@ -289,7 +285,7 @@ void ClientGateApplet::tickMeter()
     // prevents the setValue from re-driving the engine.
     if (m_thresh)  { QSignalBlocker b(m_thresh);  m_thresh->setValue(g->thresholdDb()); }
     if (m_ratio)   { QSignalBlocker b(m_ratio);   m_ratio->setValue(g->ratio()); }
-    if (m_attack)  { QSignalBlocker b(m_attack);  m_attack->setValue(g->attackMs()); }
+    if (m_return)  { QSignalBlocker b(m_return);  m_return->setValue(g->returnDb()); }
     if (m_release) { QSignalBlocker b(m_release); m_release->setValue(g->releaseMs()); }
     if (m_floor)   { QSignalBlocker b(m_floor);   m_floor->setValue(g->floorDb()); }
 }

--- a/src/gui/ClientGateApplet.h
+++ b/src/gui/ClientGateApplet.h
@@ -56,11 +56,11 @@ private:
     ClientGateCurveWidget* m_curve{nullptr};
     ClientGateGrBar*       m_grBar{nullptr};
     // Five most-tuned knobs mirroring the editor: threshold, ratio,
-    // attack, release, floor.  Saves a trip to the floating editor for
+    // return, release, floor.  Saves a trip to the floating editor for
     // everyday tuning.
     ClientCompKnob*        m_thresh{nullptr};
     ClientCompKnob*        m_ratio{nullptr};
-    ClientCompKnob*        m_attack{nullptr};
+    ClientCompKnob*        m_return{nullptr};
     ClientCompKnob*        m_release{nullptr};
     ClientCompKnob*        m_floor{nullptr};
     QTimer*                m_meterTimer{nullptr};

--- a/src/gui/ClientRxChainWidget.cpp
+++ b/src/gui/ClientRxChainWidget.cpp
@@ -66,13 +66,13 @@ const QColor kDropIndicator  ("#4db8d4");
 // can't be dropped on the other.
 constexpr const char* kMimeFormat = "application/x-aethersdr-rx-chain-stage";
 
-// Short label per RX stage — kept ≤4 chars to fit inside the narrow box.
+// Short label per RX stage — kept ≤5 chars to fit inside the narrow box.
 QString stageLabel(AudioEngine::RxChainStage s)
 {
     switch (s) {
         case AudioEngine::RxChainStage::Eq:   return "EQ";
-        case AudioEngine::RxChainStage::Gate: return "GATE";
-        case AudioEngine::RxChainStage::Comp: return "COMP";
+        case AudioEngine::RxChainStage::Gate: return "AGC-T";
+        case AudioEngine::RxChainStage::Comp: return "AGC-C";
         case AudioEngine::RxChainStage::Tube: return "TUBE";
         case AudioEngine::RxChainStage::Pudu: return "PUDU";
         case AudioEngine::RxChainStage::None: return "";

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -101,17 +101,21 @@ void FloatingContainerWindow::restoreAndEnsureVisible(QWidget* anchor)
         }
     }
     if (!restored) {
-        // Default: centre on the anchor's screen at a reasonable size.
+        // Default: size to the container's natural sizeHint so we don't
+        // open with dead space above and below the children.  Width
+        // falls back to kDefaultW when the hint is too narrow to read.
+        adjustSize();
+        const QSize hint = sizeHint();
+        const int w = std::max(kDefaultW, hint.width());
+        const int h = std::max(hint.height(), 80);  // tiny floor
+        resize(w, h);
         QScreen* screen = anchor && anchor->screen()
             ? anchor->screen()
             : QGuiApplication::primaryScreen();
         if (screen) {
             const QRect g = screen->availableGeometry();
-            resize(kDefaultW, kDefaultH);
-            move(g.center().x() - kDefaultW / 2,
-                 g.center().y() - kDefaultH / 2);
-        } else {
-            resize(kDefaultW, kDefaultH);
+            move(g.center().x() - w / 2,
+                 g.center().y() - h / 2);
         }
     } else {
         // Clamp to any visible screen — saved geometry may reference


### PR DESCRIPTION
- RX chain tile labels: GATE → AGC-T, COMP → AGC-C (matches the
  applet/editor titles introduced in v0.9.0).
- AGC-T applet replaces the Attack knob with Return so the inline row
  surfaces the gate's hysteresis instead of attack timing — the editor
  still exposes Attack.
- FloatingContainerWindow first-time pop-out now sizes to the
  container's sizeHint instead of a fixed 300x240 default, so popped-
  out windows open without dead space above or below the children.
- After the CHAIN side-toggle changes which sub-containers are visible,
  the floating tx_dsp window adjustSize()s on the next event loop tick
  so sizeHint reflects the post-toggle state.
- Cap the tx_dsp container at 280px wide so the floating window can't
  grow wider than the chain visualisation needs.  Docked columns are
  already narrower so this is a no-op there.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
