### PR TITLE
Follow-up to #2008: JSON-array FloatingPanIds + legacy-fallback TODOs

### DIFF
--- a/src/gui/PanFloatingWindow.cpp
+++ b/src/gui/PanFloatingWindow.cpp
@@ -142,6 +142,8 @@ void PanFloatingWindow::restoreWindowGeometry()
         }
     }
     // Legacy: base64-encoded QWidget::saveGeometry() blob from older builds.
+    // TODO(post-v0.10): drop this fallback once users have run a build that
+    // saves in the new "x,y,w,h" format.
     restoreGeometry(QByteArray::fromBase64(val.toLatin1()));
 }
 

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -6,6 +6,9 @@
 #include "core/AppSettings.h"
 
 #include <QHBoxLayout>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonParseError>
 #include <QLayout>
 #include <QStringList>
 #include <QVBoxLayout>
@@ -611,11 +614,13 @@ void PanadapterStack::setFramelessMode(bool on)
 
 void PanadapterStack::saveFloatingState() const
 {
-    QStringList ids;
+    QJsonArray ids;
     for (const QString& id : m_floatingWindows.keys()) {
-        ids << id;
+        ids.append(id);
     }
-    AppSettings::instance().setValue("FloatingPanIds", ids.join(','));
+    AppSettings::instance().setValue(
+        "FloatingPanIds",
+        QString::fromUtf8(QJsonDocument(ids).toJson(QJsonDocument::Compact)));
 }
 
 void PanadapterStack::restoreFloatingState()
@@ -623,7 +628,22 @@ void PanadapterStack::restoreFloatingState()
     const QString saved =
         AppSettings::instance().value("FloatingPanIds", "").toString();
     if (saved.isEmpty()) return;
-    for (const QString& id : saved.split(',', Qt::SkipEmptyParts)) {
+
+    QStringList ids;
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(saved.toUtf8(), &err);
+    if (err.error == QJsonParseError::NoError && doc.isArray()) {
+        for (const auto& v : doc.array()) {
+            if (v.isString()) ids << v.toString();
+        }
+    } else {
+        // Legacy: comma-separated list from earlier builds.
+        // TODO(post-v0.10): drop this fallback once users have run a build
+        // that saves in the new JSON-array format.
+        ids = saved.split(',', Qt::SkipEmptyParts);
+    }
+
+    for (const QString& id : ids) {
         if (m_pans.contains(id) && !m_floatingWindows.contains(id)) {
             floatPanadapter(id);
         }

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -107,6 +107,8 @@ void FloatingContainerWindow::restoreAndEnsureVisible(QWidget* anchor)
             }
             if (!restored) {
                 // Legacy: base64-encoded QWidget::saveGeometry() blob.
+                // TODO(post-v0.10): drop this fallback once users have run a
+                // build that saves in the new "x,y,w,h" format.
                 const QByteArray blob = QByteArray::fromBase64(val.toUtf8());
                 if (!blob.isEmpty() && restoreGeometry(blob))
                     restored = true;


### PR DESCRIPTION
Migrate the FloatingPanIds AppSettings entry from a comma-separated
string to a JSON array, matching the project's preferred nested-JSON
storage pattern (also used by ContainerTree).  Reads still accept the
legacy CSV format so existing saves don't break, and a TODO marks the
fallback for removal post-v0.10.

Same TODO marker added to the base64 saveGeometry() legacy fallbacks
introduced in #2008 so they're easy to find when it's time to drop them.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
