### PR TITLE
Visualise Return hysteresis on the AGC-T curve widget

### DIFF
--- a/src/gui/ClientGateCurveWidget.cpp
+++ b/src/gui/ClientGateCurveWidget.cpp
@@ -98,8 +98,32 @@ void ClientGateCurveWidget::paintEvent(QPaintEvent*)
     const QRectF r = rect();
     p.fillRect(r, kBgColor);
     drawGrid(p, r);
+    drawHysteresisBand(p, r);
     drawCurve(p, r);
     if (m_gate) drawBall(p, r);
+}
+
+void ClientGateCurveWidget::drawHysteresisBand(QPainter& p, const QRectF& r) const
+{
+    // Visualises the Return knob: a vertical band on the input axis
+    // between (Thresh − Return) and Thresh.  When the input envelope
+    // (the glowing ball) sits inside this band the gate's state is
+    // "sticky" — opens above Thresh, doesn't close until below
+    // Thresh − Return.  Width of the band == Return value in dB.
+    if (!m_gate) return;
+    const float T   = m_gate->thresholdDb();
+    const float ret = m_gate->returnDb();
+    if (ret <= 0.05f) return;   // no visible deadband
+
+    const float xR = dbToX(T);
+    const float xL = dbToX(T - ret);
+    if (xR <= xL) return;
+
+    p.save();
+    p.setPen(Qt::NoPen);
+    p.fillRect(QRectF(xL, r.top(), xR - xL, r.height()),
+               QColor(80, 180, 220, 45));   // soft cyan, low alpha
+    p.restore();
 }
 
 void ClientGateCurveWidget::drawGrid(QPainter& p, const QRectF& r) const

--- a/src/gui/ClientGateCurveWidget.h
+++ b/src/gui/ClientGateCurveWidget.h
@@ -45,6 +45,7 @@ protected:
     float curveOutputDb(float inDb) const;
 
     void drawGrid(QPainter& p, const QRectF& rect) const;
+    void drawHysteresisBand(QPainter& p, const QRectF& rect) const;
     void drawCurve(QPainter& p, const QRectF& rect) const;
     void drawBall(QPainter& p, const QRectF& rect) const;
 


### PR DESCRIPTION
Draws a soft-cyan vertical band on the input axis between
(Thresh − Return) and Thresh.  When the envelope ball is inside the
band the gate's state is sticky — opens above Thresh, doesn't close
until below Thresh − Return.  Width of the band == current Return
value in dB, updates live alongside the threshold and envelope.

Helps users see the deadband they've dialled in without having to
open the floating editor — particularly useful on the new RX chain
where Return replaces Attack in the applet's compact knob row.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
