### PR TITLE
[feature] Add WAVE Waveform Scope applet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,6 +523,8 @@ set(GUI_SOURCES
     src/gui/PhoneCwApplet.cpp
     src/gui/PhoneApplet.cpp
     src/gui/EqApplet.cpp
+    src/gui/WaveApplet.cpp
+    src/gui/WaveformWidget.cpp
     src/gui/ClientEqApplet.cpp
     src/gui/ClientEqCurveWidget.cpp
     src/gui/ClientEqEditor.cpp

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -40,6 +40,7 @@ namespace AetherSDR {
 
 namespace {
 constexpr qint64 kTxAutoRestartMinRuntimeMs = 60000;
+constexpr qint64 kScopeEmitMinIntervalMs = 25;  // ~40 fps, per RX/TX source
 
 bool devicePresent(const QList<QAudioDevice>& devices, const QAudioDevice& target)
 {
@@ -51,6 +52,81 @@ bool devicePresent(const QList<QAudioDevice>& devices, const QAudioDevice& targe
         return device.id() == target.id();
     });
 }
+}
+
+void AudioEngine::emitScopeFromFloat32Stereo(const QByteArray& pcm,
+                                             int sampleRate,
+                                             bool tx)
+{
+    const int floatSamples = pcm.size() / static_cast<int>(sizeof(float));
+    if (floatSamples <= 0)
+        return;
+
+    QElapsedTimer& throttle = tx ? m_lastTxScopeEmit : m_lastRxScopeEmit;
+    if (throttle.isValid() && throttle.elapsed() < kScopeEmitMinIntervalMs)
+        return;
+
+    const bool stereo = (floatSamples % 2) == 0;
+    const int monoSamples = stereo ? floatSamples / 2 : floatSamples;
+    QByteArray& mono = tx ? m_scopeTxScratch : m_scopeRxScratch;
+    mono.resize(monoSamples * static_cast<int>(sizeof(float)));
+
+    const auto* src = reinterpret_cast<const float*>(pcm.constData());
+    auto* dst = reinterpret_cast<float*>(mono.data());
+    if (stereo) {
+        for (int i = 0; i < monoSamples; ++i) {
+            const float avg = (src[i * 2] + src[i * 2 + 1]) * 0.5f;
+            dst[i] = std::clamp(std::isfinite(avg) ? avg : 0.0f, -1.0f, 1.0f);
+        }
+    } else {
+        for (int i = 0; i < monoSamples; ++i) {
+            const float s = src[i];
+            dst[i] = std::clamp(std::isfinite(s) ? s : 0.0f, -1.0f, 1.0f);
+        }
+    }
+
+    if (throttle.isValid())
+        throttle.restart();
+    else
+        throttle.start();
+    emit scopeSamplesReady(mono, sampleRate > 0 ? sampleRate : DEFAULT_SAMPLE_RATE, tx);
+}
+
+void AudioEngine::emitScopeFromInt16Stereo(const QByteArray& pcm,
+                                           int sampleRate,
+                                           bool tx)
+{
+    const int intSamples = pcm.size() / static_cast<int>(sizeof(int16_t));
+    if (intSamples <= 0)
+        return;
+
+    QElapsedTimer& throttle = tx ? m_lastTxScopeEmit : m_lastRxScopeEmit;
+    if (throttle.isValid() && throttle.elapsed() < kScopeEmitMinIntervalMs)
+        return;
+
+    const bool stereo = (intSamples % 2) == 0;
+    const int monoSamples = stereo ? intSamples / 2 : intSamples;
+    QByteArray& mono = tx ? m_scopeTxScratch : m_scopeRxScratch;
+    mono.resize(monoSamples * static_cast<int>(sizeof(float)));
+
+    const auto* src = reinterpret_cast<const int16_t*>(pcm.constData());
+    auto* dst = reinterpret_cast<float*>(mono.data());
+    if (stereo) {
+        for (int i = 0; i < monoSamples; ++i) {
+            const float l = src[i * 2] / 32768.0f;
+            const float r = src[i * 2 + 1] / 32768.0f;
+            dst[i] = std::clamp((l + r) * 0.5f, -1.0f, 1.0f);
+        }
+    } else {
+        for (int i = 0; i < monoSamples; ++i)
+            dst[i] = std::clamp(src[i] / 32768.0f, -1.0f, 1.0f);
+    }
+
+    if (throttle.isValid())
+        throttle.restart();
+    else
+        throttle.start();
+    emit scopeSamplesReady(mono, sampleRate > 0 ? sampleRate : DEFAULT_SAMPLE_RATE, tx);
 }
 
 void AudioEngine::updateRxBufferStats()
@@ -782,22 +858,25 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
             puduSource = &m_clientPuduRxScratch;
         }
 
+        const int scopeSampleRate = m_resampleTo48k ? 48000 : DEFAULT_SAMPLE_RATE;
         const QByteArray& resampled = m_resampleTo48k ? resampleStereo(*puduSource) : *puduSource;
+        const QByteArray* output = &resampled;
+        QByteArray boosted;
         if (m_rxBoost.load()) {
             // Soft-knee boost — increases perceived loudness without hard clipping.
             // Uses tanh compression: loud signals are gently limited while quiet
             // signals get ~2x gain.  tanh(2*x) ≈ 2*x for small x, ≈ 1.0 for large x.
-            QByteArray boosted(resampled.size(), Qt::Uninitialized);
+            boosted.resize(resampled.size());
             const auto* src = reinterpret_cast<const float*>(resampled.constData());
             auto* dst = reinterpret_cast<float*>(boosted.data());
             const int nSamples = resampled.size() / static_cast<int>(sizeof(float));
             for (int i = 0; i < nSamples; ++i) {
                 dst[i] = std::tanh(src[i] * 2.0f);
             }
-            m_rxBuffer.append(boosted);
-        } else {
-            m_rxBuffer.append(resampled);
+            output = &boosted;
         }
+        m_rxBuffer.append(*output);
+        emitScopeFromFloat32Stereo(*output, scopeSampleRate, false);
         updateRxBufferStats();
     };
 
@@ -2545,10 +2624,10 @@ void AudioEngine::processBnr(const QByteArray& stereoPcm)
         m_bnrOutBuf.remove(0, wantBytes);
 
         if (m_audioDevice && m_audioDevice->isOpen()) {
-            if (m_resampleTo48k)
-                m_rxBuffer.append(resampleStereo(chunk));
-            else
-                m_rxBuffer.append(chunk);
+            const int scopeSampleRate = m_resampleTo48k ? 48000 : DEFAULT_SAMPLE_RATE;
+            const QByteArray& output = m_resampleTo48k ? resampleStereo(chunk) : chunk;
+            m_rxBuffer.append(output);
+            emitScopeFromFloat32Stereo(output, scopeSampleRate, false);
             updateRxBufferStats();
         }
         emit levelChanged(computeRMS(chunk));
@@ -3055,6 +3134,8 @@ void AudioEngine::onTxAudioReady()
         }
     }
 
+    emitScopeFromInt16Stereo(data, DEFAULT_SAMPLE_RATE, true);
+
     // ── Opus TX path: always active for remote_audio_tx ────────────────
     // Sends Opus during both RX (VOX/met_in_rx metering) and TX (voice).
     // The radio requires Opus on remote_audio_tx (enforces compression=OPUS).
@@ -3300,6 +3381,9 @@ void AudioEngine::sendModemTxAudio(const QByteArray& float32pcm)
 {
     if (m_txStreamId == 0) return;
 
+    if (m_radioTransmitting)
+        emitScopeFromFloat32Stereo(float32pcm, DEFAULT_SAMPLE_RATE, true);
+
     m_txFloatAccumulator.append(float32pcm);
 
     constexpr int FLOAT_BYTES_PER_PKT = TX_SAMPLES_PER_PACKET * 2 * sizeof(float); // 1024
@@ -3332,7 +3416,9 @@ void AudioEngine::setTransmitting(bool tx)
 
 void AudioEngine::setRadioTransmitting(bool tx)
 {
-    m_radioTransmitting = tx;
+    const bool previous = m_radioTransmitting.exchange(tx);
+    if (previous != tx)
+        emit radioTransmittingChanged(tx);
 }
 
 void AudioEngine::setDaxTxUseRadioRoute(bool on)
@@ -3381,6 +3467,11 @@ void AudioEngine::feedDaxTxAudio(const QByteArray& inPcm)
             m_pcMicSampleCount = 0;
         }
     }
+
+    const bool daxAudioWillTransmit = m_radioTransmitting
+        && (!m_daxTxUseRadioRoute || !(m_transmitting && !m_daxTxMode));
+    if (daxAudioWillTransmit)
+        emitScopeFromFloat32Stereo(float32pcm, DEFAULT_SAMPLE_RATE, true);
 
     if (!m_daxTxUseRadioRoute) {
         // Low-latency route: keep radio on mic path (dax=0) and packetize

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -376,6 +376,8 @@ signals:
     void txPacketReady(const QByteArray& vitaPacket);  // VITA-49 TX packet for PanadapterStream
 
     void pcMicLevelChanged(float peakDbfs, float avgDbfs);  // client-side PC mic metering
+    void scopeSamplesReady(const QByteArray& monoFloat32Pcm, int sampleRate, bool tx);
+    void radioTransmittingChanged(bool tx);
     void mutedChanged(bool muted);                          // local audio output mute state
 
 private slots:
@@ -387,6 +389,8 @@ private:
     QByteArray applyBoost(const QByteArray& pcm, float gain) const;
     QByteArray buildVitaTxPacket(const float* samples, int numStereoSamples);
     void sendVoiceTxPacket(const QByteArray& pcmData, quint32 streamId);
+    void emitScopeFromFloat32Stereo(const QByteArray& pcm, int sampleRate, bool tx);
+    void emitScopeFromInt16Stereo(const QByteArray& pcm, int sampleRate, bool tx);
     QByteArray resampleStereo(const QByteArray& pcm);
     void processNr2(const QByteArray& stereoPcm);
     void updateRxBufferStats();
@@ -481,6 +485,11 @@ private:
     double        m_pcMicSumSq{0.0};
     int           m_pcMicSampleCount{0};
     static constexpr int kMicMeterWindowSamples = 24000 / 20;  // ~50ms at 24kHz
+
+    QElapsedTimer m_lastRxScopeEmit;
+    QElapsedTimer m_lastTxScopeEmit;
+    QByteArray    m_scopeRxScratch;
+    QByteArray    m_scopeTxScratch;
 
     QAudioDevice m_outputDevice;
     QAudioDevice m_inputDevice;

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -12,6 +12,7 @@
 #include "PhoneCwApplet.h"
 #include "PhoneApplet.h"
 #include "EqApplet.h"
+#include "WaveApplet.h"
 #include "ClientEqApplet.h"
 #include "ClientCompApplet.h"
 #include "ClientGateApplet.h"
@@ -54,7 +55,7 @@
 namespace AetherSDR {
 
 const QStringList AppletPanel::kDefaultOrder = {
-    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "TXDSP", "CAT", "DAX", "TCI", "IQ", "MTR", "AG"
+    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "WAVE", "TXDSP", "CAT", "DAX", "TCI", "IQ", "MTR", "AG"
 };
 
 // ── Drop-aware scroll area ──────────────────────────────────────────────────
@@ -82,20 +83,32 @@ protected:
 
         // Find the Y position for the indicator
         int indicatorY = 0;
-        if (idx < m_panel->m_appletOrder.size()) {
-            auto* w = m_panel->m_appletOrder[idx].titleBar;
-            if (w) {
-                auto* cw = qobject_cast<ContainerWidget*>(m_panel->m_appletOrder[idx].widget);
-                if (!cw || !cw->isFloating())
-                    indicatorY = w->mapTo(widget(), QPoint(0, 0)).y();
+        bool indicatorPlaced = false;
+        auto isDockedVisible = [](const AppletPanel::AppletEntry& entry) {
+            auto* w = entry.widget;
+            if (!w || !w->isVisible()) return false;
+            if (auto* cw = qobject_cast<ContainerWidget*>(w); cw && cw->isFloating())
+                return false;
+            return true;
+        };
+        for (int i = idx; i < m_panel->m_appletOrder.size(); ++i) {
+            const auto& entry = m_panel->m_appletOrder[i];
+            if (!isDockedVisible(entry)) continue;
+            if (auto* title = entry.titleBar) {
+                indicatorY = title->mapTo(widget(), QPoint(0, 0)).y();
+                indicatorPlaced = true;
+                break;
             }
-        } else if (!m_panel->m_appletOrder.isEmpty()) {
-            auto& last = m_panel->m_appletOrder.back();
-            auto* w = last.widget;
-            if (w) {
-                auto* cw = qobject_cast<ContainerWidget*>(w);
-                if (!cw || !cw->isFloating())
+        }
+        if (!indicatorPlaced) {
+            for (int i = m_panel->m_appletOrder.size() - 1; i >= 0; --i) {
+                const auto& entry = m_panel->m_appletOrder[i];
+                if (!isDockedVisible(entry)) continue;
+                if (auto* w = entry.widget) {
                     indicatorY = w->mapTo(widget(), QPoint(0, w->height())).y();
+                    indicatorPlaced = true;
+                    break;
+                }
             }
         }
         m_panel->m_dropIndicator->setParent(widget());
@@ -604,6 +617,9 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_eqApplet = new EqApplet;
     m_appletOrder.append(makeEntry("EQ", "Equalizer", m_eqApplet, true, btnRow1, btnLayout1));
 
+    m_waveApplet = new WaveApplet;
+    m_appletOrder.append(makeEntry("WAVE", "Waveform", m_waveApplet, true, btnRow1, btnLayout1));
+
     // CEQ and CMP intentionally have no toggle button in the tray —
     // their visibility follows DSP bypass state, driven externally
     // from the CHAIN widget and the respective floating editors.
@@ -732,9 +748,37 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
                 }
             }
         }
+
+        // One-shot migration for saved layouts from before WAVE existed:
+        // place WAVE immediately after EQ instead of letting the generic
+        // "new applets" append path put it at the very end.
+        bool migratedWaveOrder = false;
+        if (ids.contains("EQ") && !ids.contains("WAVE")) {
+            int waveIdx = -1;
+            for (int i = 0; i < m_appletOrder.size(); ++i) {
+                if (m_appletOrder[i].id == "WAVE") {
+                    waveIdx = i;
+                    break;
+                }
+            }
+            if (waveIdx >= 0) {
+                const AppletEntry waveEntry = m_appletOrder[waveIdx];
+                m_appletOrder.remove(waveIdx);
+                for (int i = 0; i < reordered.size(); ++i) {
+                    if (reordered[i].id == "EQ") {
+                        reordered.insert(i + 1, waveEntry);
+                        migratedWaveOrder = true;
+                        break;
+                    }
+                }
+            }
+        }
+
         // Append any remaining (new applets not in saved order)
         reordered.append(m_appletOrder);
         m_appletOrder = reordered;
+        if (migratedWaveOrder)
+            saveOrder();
     }
 
     rebuildStackOrder();
@@ -862,6 +906,7 @@ int AppletPanel::dropIndexFromY(int localY) const
         auto* w = m_appletOrder[i].widget;
         if (!w) continue;
         if (auto* cw = qobject_cast<ContainerWidget*>(w); cw && cw->isFloating()) continue;
+        if (!w->isVisible()) continue;
         int mid = w->mapTo(m_scrollArea->widget(), QPoint(0, w->height() / 2)).y();
         if (localY > mid) idx = i + 1;
     }

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -28,6 +28,7 @@ class TxApplet;
 class PhoneCwApplet;
 class PhoneApplet;
 class EqApplet;
+class WaveApplet;
 class ClientEqApplet;
 class ClientCompApplet;
 class ClientGateApplet;
@@ -67,6 +68,7 @@ public:
     PhoneCwApplet*  phoneCwApplet()  { return m_phoneCwApplet; }
     PhoneApplet*    phoneApplet()    { return m_phoneApplet; }
     EqApplet*       eqApplet()       { return m_eqApplet; }
+    WaveApplet*     waveApplet() const { return m_waveApplet; }
     // Phase 7.1: each side has its own CEQ applet — clientEqTxApplet()
     // is the original "ceq" tile bound to TX, clientEqRxApplet() is
     // the new "ceq-rx" tile bound to RX.  clientEqApplet() retained as
@@ -192,6 +194,7 @@ private:
     PhoneCwApplet* m_phoneCwApplet{nullptr};
     PhoneApplet*   m_phoneApplet{nullptr};
     EqApplet*      m_eqApplet{nullptr};
+    WaveApplet*    m_waveApplet{nullptr};
     ClientEqApplet* m_clientEqTxApplet{nullptr};
     ClientEqApplet* m_clientEqRxApplet{nullptr};
     ClientCompApplet* m_clientCompApplet{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -26,6 +26,7 @@
 #include "PhoneCwApplet.h"
 #include "PhoneApplet.h"
 #include "EqApplet.h"
+#include "WaveApplet.h"
 #include "ClientEqApplet.h"
 #include "ClientEqEditor.h"
 #include "ClientCompApplet.h"
@@ -922,6 +923,16 @@ MainWindow::MainWindow(QWidget* parent)
     buildMenuBar();
     buildUI();
     registerShortcutActions();
+
+    if (auto* wave = m_appletPanel ? m_appletPanel->waveApplet() : nullptr) {
+        connect(m_audio, &AudioEngine::scopeSamplesReady,
+                wave, &WaveApplet::appendScopeSamples,
+                Qt::QueuedConnection);
+        connect(m_audio, &AudioEngine::radioTransmittingChanged,
+                wave, &WaveApplet::setTransmitting,
+                Qt::QueuedConnection);
+    }
+
     m_paTempUseFahrenheit =
         AppSettings::instance().value(kPaTempUnitSettingKey, "Fahrenheit").toString() != "Celsius";
     updatePaTempLabel();

--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -1,0 +1,38 @@
+#include "WaveApplet.h"
+
+#include "WaveformWidget.h"
+
+#include <QSizePolicy>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+WaveApplet::WaveApplet(QWidget* parent)
+    : QWidget(parent)
+{
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(2, 2, 2, 2);
+    layout->setSpacing(0);
+
+    m_waveform = new WaveformWidget(this);
+    layout->addWidget(m_waveform);
+
+    setMinimumHeight(120);
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+}
+
+void WaveApplet::appendScopeSamples(const QByteArray& monoFloat32Pcm,
+                                    int sampleRate,
+                                    bool tx)
+{
+    if (m_waveform)
+        m_waveform->appendScopeSamples(monoFloat32Pcm, sampleRate, tx);
+}
+
+void WaveApplet::setTransmitting(bool tx)
+{
+    if (m_waveform)
+        m_waveform->setTransmitting(tx);
+}
+
+} // namespace AetherSDR

--- a/src/gui/WaveApplet.h
+++ b/src/gui/WaveApplet.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QByteArray>
+#include <QWidget>
+
+namespace AetherSDR {
+
+class WaveformWidget;
+
+class WaveApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit WaveApplet(QWidget* parent = nullptr);
+
+    QSize sizeHint() const override { return {240, 165}; }
+    QSize minimumSizeHint() const override { return {220, 120}; }
+
+public slots:
+    void appendScopeSamples(const QByteArray& monoFloat32Pcm, int sampleRate, bool tx);
+    void setTransmitting(bool tx);
+
+private:
+    WaveformWidget* m_waveform{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/WaveformWidget.cpp
+++ b/src/gui/WaveformWidget.cpp
@@ -1,0 +1,568 @@
+#include "WaveformWidget.h"
+
+#include "core/AppSettings.h"
+
+#include <QApplication>
+#include <QFontMetrics>
+#include <QMouseEvent>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QSizePolicy>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+// WAVE is intentionally QPainter-only for v1: the sidebar scope is small,
+// cross-platform, and cheap to repaint; future QRhi support can follow the
+// SpectrumWidget path without making GPU builds depend on another renderer now.
+namespace {
+
+constexpr int kDefaultSampleRate = 24000;
+constexpr int kMinSampleRate = 8000;
+constexpr int kMaxSampleRate = 192000;
+constexpr int kNoAudioTimeoutMs = 1000;
+constexpr int kRepaintMinIntervalMs = 16;
+constexpr float kAmplitudeZoom = 1.7f;
+
+const QColor kBackground(0x0a, 0x0a, 0x14);
+const QColor kGridMajor(0x30, 0x40, 0x50, 130);
+const QColor kGridMinor(0x18, 0x28, 0x38, 150);
+const QColor kCenterLine(0x58, 0x78, 0x90, 150);
+const QColor kWaveFallback(0x00, 0xe5, 0xff);
+const QColor kPeakColor(0x00, 0xb4, 0xd8, 180);
+const QColor kRmsColor(0x20, 0xc0, 0x60, 210);
+const QColor kLabelColor(0xd8, 0xe6, 0xf0);
+const QColor kMutedLabel(0x90, 0xa0, 0xb0);
+const QColor kClipColor(0xff, 0x50, 0x50);
+
+QColor waveformColor()
+{
+    QColor c(AppSettings::instance().value("DisplayFftFillColor", "#00e5ff").toString());
+    return c.isValid() ? c : kWaveFallback;
+}
+
+float waveformLineWidth()
+{
+    const float w = AppSettings::instance().value("DisplayFftLineWidth", "2.0").toFloat();
+    return std::clamp(w, 1.0f, 3.0f);
+}
+
+bool showGrid()
+{
+    return AppSettings::instance().value("DisplayShowGrid", "True").toString() == "True";
+}
+
+QString formatSampleRate(int sampleRate)
+{
+    if (sampleRate % 1000 == 0)
+        return QStringLiteral("%1 kHz").arg(sampleRate / 1000);
+    return QStringLiteral("%1 kHz").arg(sampleRate / 1000.0, 0, 'f', 1);
+}
+
+} // namespace
+
+WaveformWidget::WaveformWidget(QWidget* parent)
+    : QWidget(parent)
+{
+    setMinimumSize(minimumSizeHint());
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    setAttribute(Qt::WA_OpaquePaintEvent);
+    setAutoFillBackground(false);
+    setToolTip("Click to pause/resume waveform capture");
+
+    m_clickTimer.setSingleShot(true);
+    m_clickTimer.setInterval(QApplication::doubleClickInterval());
+    connect(&m_clickTimer, &QTimer::timeout, this, [this]() {
+        setPaused(!m_paused);
+    });
+}
+
+void WaveformWidget::appendScopeSamples(const QByteArray& monoFloat32Pcm,
+                                        int sampleRate,
+                                        bool tx)
+{
+    if (m_paused || monoFloat32Pcm.isEmpty())
+        return;
+
+    const int samples = monoFloat32Pcm.size() / static_cast<int>(sizeof(float));
+    if (samples <= 0)
+        return;
+
+    const auto* src = reinterpret_cast<const float*>(monoFloat32Pcm.constData());
+    appendToRing(tx ? m_tx : m_rx, src, samples, sanitizeSampleRate(sampleRate));
+    scheduleRepaint();
+}
+
+void WaveformWidget::setTransmitting(bool tx)
+{
+    if (m_transmitting == tx)
+        return;
+    m_transmitting = tx;
+    update();
+}
+
+void WaveformWidget::clear()
+{
+    clearRing(m_rx);
+    clearRing(m_tx);
+    update();
+}
+
+void WaveformWidget::paintEvent(QPaintEvent* event)
+{
+    Q_UNUSED(event);
+
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, false);
+    painter.fillRect(rect(), kBackground);
+
+    QRectF plotRect = QRectF(rect()).adjusted(5.0, 18.0, -34.0, -17.0);
+    if (plotRect.width() < 24.0 || plotRect.height() < 36.0)
+        plotRect = QRectF(rect()).adjusted(4.0, 17.0, -30.0, -16.0);
+
+    const RingBuffer& buffer = activeBuffer();
+    const QString source = (m_paused ? m_pausedTransmitting : m_transmitting)
+        ? QStringLiteral("TX")
+        : QStringLiteral("RX");
+    const int sampleRate = sanitizeSampleRate(m_paused
+        ? m_pausedSampleRate
+        : buffer.sampleRate);
+    if (m_paused) {
+        m_displaySamples = m_pausedSamples;
+    } else {
+        const int windowSamples = std::max(1, sampleRate * m_windowMs / 1000);
+        copyLatest(buffer, windowSamples, m_displaySamples);
+    }
+
+    float peak = 0.0f;
+    double sumSq = 0.0;
+    int clipCount = 0;
+    for (float s : m_displaySamples) {
+        const float a = std::abs(s);
+        peak = std::max(peak, a);
+        sumSq += static_cast<double>(s) * s;
+        if (a >= 0.98f)
+            ++clipCount;
+    }
+    const float rms = m_displaySamples.isEmpty()
+        ? 0.0f
+        : static_cast<float>(std::sqrt(sumSq / m_displaySamples.size()));
+    const float peakDb = linearToDb(peak);
+    const float rmsDb = linearToDb(rms);
+
+    drawGrid(painter, plotRect, sampleRate);
+
+    const int columnCount = std::max(1, static_cast<int>(std::floor(plotRect.width())));
+    buildColumns(columnCount);
+
+    if (!m_displaySamples.isEmpty()) {
+        const qreal centerY = plotRect.center().y();
+        const qreal halfHeight = std::max<qreal>(1.0, plotRect.height() * 0.5 - 2.0);
+        const qreal left = plotRect.left();
+        const QColor wave = waveformColor();
+
+        QPainterPath peakTop;
+        QPainterPath peakBottom;
+        QPainterPath rmsTop;
+        QPainterPath rmsBottom;
+
+        painter.setPen(QPen(wave, waveformLineWidth(), Qt::SolidLine, Qt::RoundCap));
+        for (int x = 0; x < m_columns.size(); ++x) {
+            const ColumnStats& c = m_columns[x];
+            const qreal px = left + x + 0.5;
+            const qreal minY = centerY - std::clamp(c.min * kAmplitudeZoom, -1.0f, 1.0f) * halfHeight;
+            const qreal maxY = centerY - std::clamp(c.max * kAmplitudeZoom, -1.0f, 1.0f) * halfHeight;
+            painter.drawLine(QPointF(px, minY), QPointF(px, maxY));
+
+            const qreal peak = std::clamp(c.peak * kAmplitudeZoom, 0.0f, 1.0f);
+            const qreal rms = std::clamp(c.rms * kAmplitudeZoom, 0.0f, 1.0f);
+            const qreal peakTopY = centerY - peak * halfHeight;
+            const qreal peakBottomY = centerY + peak * halfHeight;
+            const qreal rmsTopY = centerY - rms * halfHeight;
+            const qreal rmsBottomY = centerY + rms * halfHeight;
+            if (x == 0) {
+                peakTop.moveTo(px, peakTopY);
+                peakBottom.moveTo(px, peakBottomY);
+                rmsTop.moveTo(px, rmsTopY);
+                rmsBottom.moveTo(px, rmsBottomY);
+            } else {
+                peakTop.lineTo(px, peakTopY);
+                peakBottom.lineTo(px, peakBottomY);
+                rmsTop.lineTo(px, rmsTopY);
+                rmsBottom.lineTo(px, rmsBottomY);
+            }
+        }
+
+        painter.setRenderHint(QPainter::Antialiasing, true);
+        painter.setPen(QPen(kPeakColor, 1.0));
+        painter.drawPath(peakTop);
+        painter.drawPath(peakBottom);
+        painter.setPen(QPen(kRmsColor, 1.4));
+        painter.drawPath(rmsTop);
+        painter.drawPath(rmsBottom);
+        painter.setRenderHint(QPainter::Antialiasing, false);
+
+        if (clipCount > 0) {
+            painter.setPen(QPen(kClipColor, 1.0));
+            for (int x = 0; x < m_columns.size(); ++x) {
+                if (m_columns[x].clipped <= 0)
+                    continue;
+                const qreal px = left + x + 0.5;
+                painter.drawLine(QPointF(px, plotRect.top()),
+                                 QPointF(px, plotRect.top() + 4.0));
+                painter.drawLine(QPointF(px, plotRect.bottom() - 4.0),
+                                 QPointF(px, plotRect.bottom()));
+            }
+        }
+    }
+
+    QFont labelFont = font();
+    labelFont.setPointSizeF(std::max(7.0, labelFont.pointSizeF() - 1.0));
+    painter.setFont(labelFont);
+    painter.setPen(kLabelColor);
+    const QString readout = QStringLiteral("%1  RMS %2 dBFS  PK %3 dBFS")
+        .arg(source)
+        .arg(rmsDb, 0, 'f', 1)
+        .arg(peakDb, 0, 'f', 1);
+    painter.drawText(QRectF(7.0, 3.0, width() - 14.0, 16.0),
+                     Qt::AlignLeft | Qt::AlignVCenter,
+                     readout);
+
+    if (clipCount > 0) {
+        QFont clipFont = labelFont;
+        clipFont.setBold(true);
+        painter.setFont(clipFont);
+        painter.setPen(kClipColor);
+        painter.drawText(QRectF(7.0, 3.0, width() - 14.0, 16.0),
+                         Qt::AlignRight | Qt::AlignVCenter,
+                         QStringLiteral("CLIP %1").arg(clipCount));
+        painter.setFont(labelFont);
+    }
+
+    painter.setPen(kMutedLabel);
+    const QString timeText = QString::fromUtf8("%1 \xc2\xb7 %2 ms \xc2\xb7 %3 ms/div")
+        .arg(formatSampleRate(sampleRate))
+        .arg(m_windowMs)
+        .arg(std::max(1, m_windowMs / 10));
+    const QRectF footerRect(plotRect.left(), plotRect.bottom() + 2.0,
+                            plotRect.width(), 15.0);
+    painter.drawText(m_paused ? footerRect.adjusted(0.0, 0.0, -52.0, 0.0) : footerRect,
+                     Qt::AlignLeft | Qt::AlignVCenter,
+                     timeText);
+
+    const bool stale = !m_paused
+        && (!buffer.lastSamples.isValid()
+        || buffer.lastSamples.elapsed() > kNoAudioTimeoutMs);
+    if (m_displaySamples.isEmpty() || stale)
+        drawNoAudio(painter, plotRect, source);
+
+    if (m_paused)
+        drawPausedBadge(painter, footerRect);
+}
+
+void WaveformWidget::mouseReleaseEvent(QMouseEvent* event)
+{
+    if (event->button() == Qt::LeftButton) {
+        if (m_ignoreNextRelease) {
+            m_ignoreNextRelease = false;
+        } else if (!m_clickTimer.isActive()) {
+            m_clickTimer.start();
+        }
+        event->accept();
+        return;
+    }
+    QWidget::mouseReleaseEvent(event);
+}
+
+void WaveformWidget::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    if (event->button() == Qt::LeftButton) {
+        m_clickTimer.stop();
+        m_ignoreNextRelease = true;
+        clearActiveRing();
+        event->accept();
+        return;
+    }
+    QWidget::mouseDoubleClickEvent(event);
+}
+
+WaveformWidget::RingBuffer& WaveformWidget::activeBuffer()
+{
+    return m_transmitting ? m_tx : m_rx;
+}
+
+const WaveformWidget::RingBuffer& WaveformWidget::activeBuffer() const
+{
+    return m_transmitting ? m_tx : m_rx;
+}
+
+void WaveformWidget::ensureCapacity(RingBuffer& buffer, int sampleRate)
+{
+    const int rate = sanitizeSampleRate(sampleRate);
+    const int capacity = std::max(kDefaultSampleRate, rate);
+    if (buffer.samples.size() == capacity) {
+        buffer.sampleRate = rate;
+        return;
+    }
+
+    QVector<float> preserved;
+    copyLatest(buffer, std::min(buffer.filled, capacity), preserved);
+
+    buffer.samples = QVector<float>(capacity, 0.0f);
+    buffer.writeIndex = 0;
+    buffer.filled = 0;
+    buffer.sampleRate = rate;
+
+    const int newCapacity = buffer.samples.size();
+    for (float s : preserved) {
+        buffer.samples[buffer.writeIndex] = s;
+        buffer.writeIndex = (buffer.writeIndex + 1) % newCapacity;
+        buffer.filled = std::min(buffer.filled + 1, newCapacity);
+    }
+}
+
+void WaveformWidget::appendToRing(RingBuffer& buffer,
+                                  const float* samples,
+                                  int count,
+                                  int sampleRate)
+{
+    ensureCapacity(buffer, sampleRate);
+    if (buffer.samples.isEmpty())
+        return;
+
+    const int capacity = buffer.samples.size();
+    for (int i = 0; i < count; ++i) {
+        buffer.samples[buffer.writeIndex] = clampSample(samples[i]);
+        buffer.writeIndex = (buffer.writeIndex + 1) % capacity;
+        buffer.filled = std::min(buffer.filled + 1, capacity);
+    }
+    buffer.lastSamples.restart();
+}
+
+void WaveformWidget::clearRing(RingBuffer& buffer)
+{
+    buffer.samples.fill(0.0f);
+    buffer.writeIndex = 0;
+    buffer.filled = 0;
+    buffer.lastSamples.invalidate();
+}
+
+void WaveformWidget::clearActiveRing()
+{
+    clearRing(activeBuffer());
+    if (m_paused)
+        m_pausedSamples.clear();
+    update();
+}
+
+void WaveformWidget::copyLatest(const RingBuffer& buffer, int count, QVector<float>& out) const
+{
+    out.clear();
+    if (count <= 0 || buffer.filled <= 0 || buffer.samples.isEmpty())
+        return;
+
+    count = std::min(count, buffer.filled);
+    out.resize(count);
+
+    const int capacity = buffer.samples.size();
+    int start = buffer.writeIndex - count;
+    while (start < 0)
+        start += capacity;
+
+    for (int i = 0; i < count; ++i)
+        out[i] = buffer.samples[(start + i) % capacity];
+}
+
+void WaveformWidget::setPaused(bool paused)
+{
+    if (m_paused == paused)
+        return;
+
+    if (paused) {
+        const RingBuffer& buffer = activeBuffer();
+        m_pausedTransmitting = m_transmitting;
+        m_pausedSampleRate = sanitizeSampleRate(buffer.sampleRate);
+        const int windowSamples = std::max(1, m_pausedSampleRate * m_windowMs / 1000);
+        copyLatest(buffer, windowSamples, m_pausedSamples);
+    } else {
+        m_pausedSamples.clear();
+    }
+
+    m_paused = paused;
+    update();
+}
+
+void WaveformWidget::buildColumns(int columnCount)
+{
+    m_columns.clear();
+    if (columnCount <= 0 || m_displaySamples.isEmpty())
+        return;
+
+    m_columns.resize(columnCount);
+    const int n = m_displaySamples.size();
+
+    for (int x = 0; x < columnCount; ++x) {
+        int start = (x * n) / columnCount;
+        int end = ((x + 1) * n) / columnCount;
+        if (end <= start)
+            end = start + 1;
+        start = std::clamp(start, 0, n - 1);
+        end = std::clamp(end, start + 1, n);
+
+        float mn = 1.0f;
+        float mx = -1.0f;
+        float peak = 0.0f;
+        double sumSq = 0.0;
+        int clipped = 0;
+        for (int i = start; i < end; ++i) {
+            const float s = clampSample(m_displaySamples[i]);
+            mn = std::min(mn, s);
+            mx = std::max(mx, s);
+            const float a = std::abs(s);
+            peak = std::max(peak, a);
+            sumSq += static_cast<double>(s) * s;
+            if (a >= 0.98f)
+                ++clipped;
+        }
+
+        ColumnStats& c = m_columns[x];
+        c.min = mn;
+        c.max = mx;
+        c.peak = peak;
+        c.rms = static_cast<float>(std::sqrt(sumSq / (end - start)));
+        c.clipped = clipped;
+    }
+}
+
+void WaveformWidget::drawGrid(QPainter& painter,
+                              const QRectF& plotRect,
+                              int sampleRate) const
+{
+    Q_UNUSED(sampleRate);
+
+    painter.save();
+
+    if (showGrid()) {
+        painter.setPen(QPen(kGridMinor, 1.0));
+        for (int i = 0; i <= 10; ++i) {
+            const qreal x = plotRect.left() + plotRect.width() * i / 10.0;
+            painter.drawLine(QPointF(x, plotRect.top()),
+                             QPointF(x, plotRect.bottom()));
+        }
+    }
+
+    const qreal centerY = plotRect.center().y();
+    const qreal halfHeight = std::max<qreal>(1.0, plotRect.height() * 0.5 - 2.0);
+    const int refs[] = {0, -6, -12, -24, -48};
+
+    QFont labelFont = font();
+    labelFont.setPointSizeF(std::max(7.0, labelFont.pointSizeF() - 2.0));
+    painter.setFont(labelFont);
+
+    for (int db : refs) {
+        const qreal rawOffset = dbToAmplitude(static_cast<float>(db)) * kAmplitudeZoom * halfHeight;
+        if (db <= -48 && rawOffset < 3.0)
+            continue;
+        const qreal offset = std::min(rawOffset, halfHeight);
+
+        painter.setPen(QPen(db >= -12 ? kGridMajor : kGridMinor, 1.0));
+        const qreal yTop = centerY - offset;
+        const qreal yBottom = centerY + offset;
+        if (rawOffset <= halfHeight + 0.5) {
+            painter.drawLine(QPointF(plotRect.left(), yTop), QPointF(plotRect.right(), yTop));
+            painter.drawLine(QPointF(plotRect.left(), yBottom), QPointF(plotRect.right(), yBottom));
+        } else {
+            painter.drawLine(QPointF(plotRect.left(), plotRect.top()),
+                             QPointF(plotRect.right(), plotRect.top()));
+            painter.drawLine(QPointF(plotRect.left(), plotRect.bottom()),
+                             QPointF(plotRect.right(), plotRect.bottom()));
+        }
+
+        painter.setPen(kMutedLabel);
+        painter.drawText(QRectF(plotRect.right() + 4.0, yTop - 7.0,
+                                width() - plotRect.right() - 5.0, 14.0),
+                         Qt::AlignLeft | Qt::AlignVCenter,
+                         QString::number(db));
+    }
+
+    painter.setPen(QPen(kCenterLine, 1.0));
+    painter.drawLine(QPointF(plotRect.left(), centerY),
+                     QPointF(plotRect.right(), centerY));
+
+    painter.setPen(kMutedLabel);
+    painter.drawText(QRectF(plotRect.right() + 4.0, plotRect.bottom() - 12.0,
+                            width() - plotRect.right() - 5.0, 12.0),
+                     Qt::AlignLeft | Qt::AlignVCenter,
+                     QStringLiteral("dBFS"));
+
+    painter.restore();
+}
+
+void WaveformWidget::drawNoAudio(QPainter& painter,
+                                 const QRectF& plotRect,
+                                 const QString& source) const
+{
+    painter.save();
+    QFont f = font();
+    f.setPointSizeF(std::max(8.0, f.pointSizeF() - 1.0));
+    painter.setFont(f);
+    painter.setPen(kMutedLabel);
+    painter.drawText(plotRect, Qt::AlignCenter,
+                     QStringLiteral("no %1 audio").arg(source));
+    painter.restore();
+}
+
+void WaveformWidget::drawPausedBadge(QPainter& painter, const QRectF& footerRect) const
+{
+    painter.save();
+    QFont f = font();
+    f.setBold(true);
+    f.setPointSizeF(std::max(7.0, f.pointSizeF() - 1.0));
+    painter.setFont(f);
+    painter.setPen(QColor(0xff, 0xd1, 0x66));
+    painter.drawText(footerRect, Qt::AlignRight | Qt::AlignVCenter,
+                     QStringLiteral("PAUSED"));
+    painter.restore();
+}
+
+void WaveformWidget::scheduleRepaint()
+{
+    if (!isVisible())
+        return;
+
+    if (!m_repaintThrottle.isValid()
+        || m_repaintThrottle.elapsed() >= kRepaintMinIntervalMs) {
+        update();
+        m_repaintThrottle.restart();
+    }
+}
+
+int WaveformWidget::sanitizeSampleRate(int sampleRate)
+{
+    if (sampleRate <= 0)
+        sampleRate = kDefaultSampleRate;
+    return std::clamp(sampleRate, kMinSampleRate, kMaxSampleRate);
+}
+
+float WaveformWidget::clampSample(float sample)
+{
+    if (!std::isfinite(sample))
+        return 0.0f;
+    return std::clamp(sample, -1.0f, 1.0f);
+}
+
+float WaveformWidget::dbToAmplitude(float db)
+{
+    return std::pow(10.0f, db / 20.0f);
+}
+
+float WaveformWidget::linearToDb(float value)
+{
+    const float db = 20.0f * std::log10(std::max(value, 1e-9f));
+    return std::max(db, -120.0f);
+}
+
+} // namespace AetherSDR

--- a/src/gui/WaveformWidget.h
+++ b/src/gui/WaveformWidget.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <QByteArray>
+#include <QElapsedTimer>
+#include <QRectF>
+#include <QString>
+#include <QTimer>
+#include <QVector>
+#include <QWidget>
+
+class QMouseEvent;
+class QPainter;
+class QPaintEvent;
+
+namespace AetherSDR {
+
+class WaveformWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit WaveformWidget(QWidget* parent = nullptr);
+
+    QSize sizeHint() const override { return {240, 160}; }
+    QSize minimumSizeHint() const override { return {220, 110}; }
+
+public slots:
+    void appendScopeSamples(const QByteArray& monoFloat32Pcm, int sampleRate, bool tx);
+    void setTransmitting(bool tx);
+    void clear();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
+
+private:
+    struct RingBuffer {
+        QVector<float> samples;
+        int writeIndex{0};
+        int filled{0};
+        int sampleRate{24000};
+        QElapsedTimer lastSamples;
+    };
+
+    struct ColumnStats {
+        float min{0.0f};
+        float max{0.0f};
+        float peak{0.0f};
+        float rms{0.0f};
+        int clipped{0};
+    };
+
+    RingBuffer& activeBuffer();
+    const RingBuffer& activeBuffer() const;
+    void ensureCapacity(RingBuffer& buffer, int sampleRate);
+    void appendToRing(RingBuffer& buffer, const float* samples, int count, int sampleRate);
+    void clearRing(RingBuffer& buffer);
+    void clearActiveRing();
+    void copyLatest(const RingBuffer& buffer, int count, QVector<float>& out) const;
+    void setPaused(bool paused);
+    void buildColumns(int columnCount);
+    void drawGrid(QPainter& painter, const QRectF& plotRect, int sampleRate) const;
+    void drawNoAudio(QPainter& painter, const QRectF& plotRect, const QString& source) const;
+    void drawPausedBadge(QPainter& painter, const QRectF& footerRect) const;
+    void scheduleRepaint();
+
+    static int sanitizeSampleRate(int sampleRate);
+    static float clampSample(float sample);
+    static float dbToAmplitude(float db);
+    static float linearToDb(float value);
+
+    RingBuffer m_rx;
+    RingBuffer m_tx;
+    QVector<float> m_displaySamples;
+    QVector<float> m_pausedSamples;
+    QVector<ColumnStats> m_columns;
+
+    QTimer m_clickTimer;
+    QElapsedTimer m_repaintThrottle;
+    bool m_ignoreNextRelease{false};
+    bool m_paused{false};
+    bool m_pausedTransmitting{false};
+    bool m_transmitting{false};
+    int m_pausedSampleRate{24000};
+    int m_windowMs{100};
+};
+
+} // namespace AetherSDR


### PR DESCRIPTION

<img width="1395" height="1184" alt="Screenshot 2026-04-26 at 1 14 30 PM" src="https://github.com/user-attachments/assets/252d0f6e-0b39-46f9-bca4-5a2afbcfe3f7" />

## Summary

Adds a new right-sidebar `WAVE` applet that displays a live time-domain audio waveform scope for receive and transmit audio. The applet is inserted immediately after `EQ` in the sidebar button row and default applet stack, and saved applet orders are migrated so existing users get `WAVE` next to `EQ` instead of appended at the end.

## Features

- Adds a new `Waveform` applet with `WAVE` sidebar button text.
- Displays post-DSP RX audio while receiving.
- Automatically switches to TX audio while the radio is transmitting, then returns to RX when transmit ends.
- Maintains separate RX and TX ring buffers so source switching preserves each source's recent history.
- Uses a lightweight Qt/QPainter renderer with no new third-party dependencies and no `QOpenGLWidget`.
- Builds cleanly with `AETHER_GPU_SPECTRUM` both `ON` and `OFF`.
- Uses queued Qt signal delivery from `AudioEngine` to the UI so audio-thread taps do not call widget methods directly.
- Includes graticule, center line, dBFS reference labels, sample-rate/time-window text, RX/TX source label, RMS and peak readouts, RMS envelope, peak envelope, and clipping indicator.
- Click pauses/resumes capture by freezing the current waveform snapshot and showing a compact `PAUSED` badge in the footer.
- Double-click clears the active RX or TX buffer.
- Shows stale-source messaging after roughly one second without active-source samples.
- Keeps redraws cheap while hidden.
- Fixes applet drag/drop ordering around hidden/floating applets so `WAVE` can be reordered above `MTR` and persisted normally.

## Use Cases

- Quickly verify RX audio shape after filtering, demodulation, and DSP choices without opening a separate tool.
- Watch TX microphone audio before packetization to catch low drive, clipping, silence, or abnormal level changes.
- Confirm DAX TX audio is present while transmitting data modes without applying voice DSP to DAX.
- Observe RADE/modem TX waveform behavior during transmit.
- Compare behavior across slices and modes while the applet stays docked, reordered, or floated with the rest of the sidebar.
- Leave the scope visible during long operating sessions as a low-overhead audio confidence meter.

## Implementation Notes

- New UI files:
  - `src/gui/WaveApplet.h`
  - `src/gui/WaveApplet.cpp`
  - `src/gui/WaveformWidget.h`
  - `src/gui/WaveformWidget.cpp`
- `AppletPanel` now creates `WAVE` immediately after `EQ`, exposes `waveApplet()`, and migrates saved orders that lack `WAVE`.
- `MainWindow` wires `AudioEngine::scopeSamplesReady` and `AudioEngine::radioTransmittingChanged` to the applet with `Qt::QueuedConnection`.
- `AudioEngine` adds scoped, throttled RX/TX sample emission helpers for float32 and int16 PCM.
- RX scope taps final audible post-DSP audio.
- PC microphone TX taps post-resample, post-client-DSP, post-gain audio before packetization.
- DAX TX taps float32 audio while transmitting.
- RADE modem TX taps float32 audio while transmitting.
- Rendering is intentionally QPainter-only for v1 because this is a compact sidebar scope and must remain cross-platform

## Validation

- Built with GPU spectrum disabled:
  - `cmake -S . -B build-gpu-off -G Ninja -DAETHER_GPU_SPECTRUM=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo`
  - `cmake --build build-gpu-off --parallel 10`
- Built with GPU spectrum enabled:
  - `cmake -S . -B build-gpu-on -G Ninja -DAETHER_GPU_SPECTRUM=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo`
  - `cmake --build build-gpu-on --parallel 10`
- Rebuilt both `build-gpu-off` and `build-gpu-on` after final UI/reorder adjustments.
- Ran `git diff --cached --check`.

## Manual Test Matrix

- Tested MW and HF receive behavior.
- Tested phone and data modes.
- Tested accelerated and non-accelerated GPU builds.
- Tested multi-slice behavior.
- Tested CW keyer transmit behavior; waveform displayed positive signal activity.
- Tested disconnect/reconnect behavior; waveform recovered gracefully after reconnect.
- Left WAVE visible for over an hour with no crashes.
- Observed no significant CPU impact with the applet enabled.
- Confirmed waveform order persisted successfully after restarting the app.
- Confirmed applet can be shown, hidden, reordered, and moved above `MTR`.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
