### PR TITLE
Aetherial Audio polish (round 2): Peak Hold, Reset, Tube meter, stay-on-top

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,6 +532,7 @@ set(GUI_SOURCES
     src/gui/ClientEqFftAnalyzer.cpp
     src/gui/ClientEqIconRow.cpp
     src/gui/ClientEqOutputFader.cpp
+    src/gui/ClientLevelMeter.cpp
     src/gui/ClientEqParamRow.cpp
     src/gui/ClientChainApplet.cpp
     src/gui/ClientChainWidget.cpp

--- a/src/gui/ClientEqCurveWidget.cpp
+++ b/src/gui/ClientEqCurveWidget.cpp
@@ -91,7 +91,26 @@ void ClientEqCurveWidget::setFftBinsDb(const std::vector<float>& binsDb,
 {
     m_fftBinsDb = binsDb;
     m_fftSampleRate = sampleRate > 0.0 ? sampleRate : 24000.0;
+
+    // Peak-hold trail: per-bin running max, decaying ~10 dB/sec at 25 Hz
+    // updates so recent resonances stay visible without permanent clutter.
+    // Frozen mode skips decay so the trace sticks at the max.
+    constexpr float kPeakDecayDb = 0.5f;
+    constexpr float kPeakFloorDb = -100.0f;
+    if (m_peakHoldDb.size() != m_fftBinsDb.size()) {
+        m_peakHoldDb.assign(m_fftBinsDb.size(), kPeakFloorDb);
+    }
+    const float decayStep = m_peakHoldFrozen ? 0.0f : kPeakDecayDb;
+    for (size_t i = 0; i < m_fftBinsDb.size(); ++i) {
+        const float decayed = m_peakHoldDb[i] - decayStep;
+        m_peakHoldDb[i] = std::max(decayed, m_fftBinsDb[i]);
+    }
     update();
+}
+
+void ClientEqCurveWidget::setPeakHoldFrozen(bool frozen)
+{
+    m_peakHoldFrozen = frozen;
 }
 
 float ClientEqCurveWidget::freqToX(float hz) const
@@ -228,6 +247,31 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
         p.setPen(Qt::NoPen);
         p.setBrush(grad);
         p.drawPath(fftPath);
+
+        // Peak-hold line — same dBFS scale as the live spectrum.  Drawn
+        // on top so resonances and harsh peaks stand out as the user
+        // tunes.  Soft off-white reads cleanly against the cool-cyan
+        // analyzer.
+        if (!m_peakHoldDb.empty() && m_peakHoldDb.size() == m_fftBinsDb.size()) {
+            QPainterPath peakPath;
+            bool peakStarted = false;
+            for (int i = 1; i < bins; ++i) {
+                const float f = static_cast<float>(i) *
+                                static_cast<float>(m_fftSampleRate) /
+                                static_cast<float>((bins - 1) * 2);
+                const float x = freqToX(f);
+                if (x < 0 || x > r.width()) continue;
+                const float y = dbfsToY(m_peakHoldDb[i]);
+                if (!peakStarted) { peakPath.moveTo(x, y); peakStarted = true; }
+                else              peakPath.lineTo(x, y);
+            }
+            QPen peakPen(QColor(220, 222, 230, 210), 1.4);
+            peakPen.setJoinStyle(Qt::RoundJoin);
+            peakPen.setCapStyle(Qt::RoundCap);
+            p.setPen(peakPen);
+            p.setBrush(Qt::NoBrush);
+            p.drawPath(peakPath);
+        }
     }
 
     if (!m_eq || m_eq->activeBandCount() == 0) {

--- a/src/gui/ClientEqCurveWidget.h
+++ b/src/gui/ClientEqCurveWidget.h
@@ -44,6 +44,11 @@ public:
     void setFftBinsDb(const std::vector<float>& binsDb,
                       double sampleRate);
 
+    // When true, the per-bin peak-hold trace stops decaying — peaks
+    // stick at whatever maximum has been observed so far.  Toggling
+    // back to false resumes the normal decay.
+    void setPeakHoldFrozen(bool frozen);
+
 signals:
     void selectedBandChanged(int idx);
     // Fired whenever band params mutate on the audio side from user
@@ -73,6 +78,8 @@ protected:
     int                m_selectedBand{-1};
     bool               m_showFilled{true};
     std::vector<float> m_fftBinsDb;      // empty = no analyzer drawn
+    std::vector<float> m_peakHoldDb;     // per-bin peak-hold trail
+    bool               m_peakHoldFrozen{false};
     double             m_fftSampleRate{24000.0};
 };
 

--- a/src/gui/ClientEqEditor.cpp
+++ b/src/gui/ClientEqEditor.cpp
@@ -90,6 +90,32 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
         hint->setStyleSheet("QLabel { color: #506070; font-size: 10px; }");
         row->addWidget(hint, 1);
 
+        // Peak Hold — when checked, the analyzer's per-bin peak trace
+        // stops decaying so the highest level seen at each frequency
+        // stays put.  Useful for spotting resonances while tuning.
+        auto* peakHoldBtn = new QPushButton("Peak Hold");
+        peakHoldBtn->setCheckable(true);
+        peakHoldBtn->setFixedHeight(24);
+        peakHoldBtn->setToolTip(
+            "Freeze the analyzer peak-hold trace at its highest level.\n"
+            "Toggle off to resume normal decay.");
+        peakHoldBtn->setStyleSheet(
+            "QPushButton {"
+            "  background: #0e1b28; color: #c8d8e8;"
+            "  border: 1px solid #243a4e; border-radius: 3px;"
+            "  padding: 2px 12px; font-size: 11px; font-weight: bold;"
+            "}"
+            "QPushButton:hover { background: #1a2a3a; }"
+            "QPushButton:checked {"
+            "  background: #c8a040; color: #0a0a18;"
+            "  border-color: #d4b050;"
+            "}"
+            "QPushButton:checked:hover { background: #d4b050; }");
+        connect(peakHoldBtn, &QPushButton::toggled, this, [this](bool on) {
+            if (m_canvas) m_canvas->setPeakHoldFrozen(on);
+        });
+        row->addWidget(peakHoldBtn);
+
         // Global filter-family selector — applies to HP/LP cascade math.
         // Shelves and peaks keep their native 2nd-order topology.
         m_familyCombo = new QComboBox;
@@ -131,6 +157,42 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
             if (m_canvas) m_canvas->update();
         });
         row->addWidget(m_familyCombo);
+
+        // Reset — drops every band back to ClientEq::defaultBand(i),
+        // restores the default 10-band count, and resets the filter
+        // family to Butterworth.  Saves immediately so the wipe
+        // survives a restart.
+        auto* resetBtn = new QPushButton("Reset");
+        resetBtn->setFixedHeight(24);
+        resetBtn->setToolTip("Reset all bands to default values");
+        resetBtn->setStyleSheet(
+            "QPushButton {"
+            "  background: #0e1b28; color: #c8d8e8;"
+            "  border: 1px solid #243a4e; border-radius: 3px;"
+            "  padding: 2px 12px; font-size: 11px; font-weight: bold;"
+            "}"
+            "QPushButton:hover { background: #1a2a3a; }"
+            "QPushButton:pressed { background: #243a4e; }");
+        connect(resetBtn, &QPushButton::clicked, this, [this]() {
+            ClientEq* eq = (m_path == ClientEqApplet::Path::Rx)
+                ? m_audio->clientEqRx() : m_audio->clientEqTx();
+            if (!eq) return;
+            eq->setActiveBandCount(ClientEq::kDefaultBandCount);
+            for (int i = 0; i < ClientEq::kDefaultBandCount; ++i) {
+                eq->setBand(i, ClientEq::defaultBand(i));
+            }
+            eq->setFilterFamily(ClientEq::FilterFamily::Butterworth);
+            if (m_audio) m_audio->saveClientEqSettings();
+
+            if (m_familyCombo) {
+                QSignalBlocker b(m_familyCombo);
+                m_familyCombo->setCurrentIndex(0);   // Butterworth
+            }
+            if (m_canvas)   m_canvas->update();
+            if (m_iconRow)  m_iconRow->update();
+            if (m_paramRow) m_paramRow->update();
+        });
+        row->addWidget(resetBtn);
 
         // Bypass button moved to the CHAIN widget's single-click
         // gesture.  Keyboard shortcut retired along with the button.

--- a/src/gui/ClientLevelMeter.cpp
+++ b/src/gui/ClientLevelMeter.cpp
@@ -1,0 +1,153 @@
+#include "ClientLevelMeter.h"
+
+#include <QFontMetrics>
+#include <QLabel>
+#include <QLinearGradient>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QVBoxLayout>
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+float linearToDb(float linear)
+{
+    if (linear <= 1e-6f) return -120.0f;
+    return 20.0f * std::log10(linear);
+}
+
+// Same fast-attack / slow-release ballistics as ClientEqOutputFader so
+// the meter feels visually consistent across applets.
+constexpr float kPeakAttack  = 0.6f;
+constexpr float kPeakRelease = 0.08f;
+
+} // namespace
+
+ClientLevelMeter::ClientLevelMeter(QWidget* parent) : QWidget(parent)
+{
+    setFixedWidth(kLabelColW + kGap + kBarW + 2);
+    setMinimumHeight(160);
+    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+}
+
+void ClientLevelMeter::setHeaderText(const QString& text)
+{
+    if (m_headerText == text) return;
+    m_headerText = text;
+    update();
+}
+
+void ClientLevelMeter::setPeakDb(float peakDb)
+{
+    const float alpha = (peakDb > m_smoothedPeak) ? kPeakAttack : kPeakRelease;
+    m_smoothedPeak += alpha * (peakDb - m_smoothedPeak);
+    update();
+}
+
+void ClientLevelMeter::setPeakLinear(float peakLinear)
+{
+    setPeakDb(linearToDb(std::max(peakLinear, 1e-6f)));
+}
+
+void ClientLevelMeter::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, false);
+    p.setRenderHint(QPainter::TextAntialiasing, true);
+
+    const int topLabelH = m_headerText.isEmpty() ? 0 : 16;
+    const int botLabelH = 14;
+    const int stripTop  = topLabelH + kStripTopPad;
+    const int stripBot  = height() - botLabelH - kStripBottomPad;
+    const int stripH    = std::max(1, stripBot - stripTop);
+
+    const int barLeft = kLabelColW + kGap;
+    const QRect barR(barLeft, stripTop, kBarW, stripH);
+
+    // Header text.
+    if (!m_headerText.isEmpty()) {
+        QFont f = p.font();
+        f.setPixelSize(10);
+        f.setBold(true);
+        p.setFont(f);
+        p.setPen(QColor("#8aa8c0"));
+        p.drawText(QRect(0, 0, width(), topLabelH),
+                   Qt::AlignCenter, m_headerText);
+    }
+
+    // Bar background.
+    p.fillRect(barR, QColor("#06111c"));
+
+    // Level fill — green→amber→red gradient, height proportional to
+    // the smoothed peak in dB.
+    const float peakNorm = std::clamp(
+        (m_smoothedPeak - kMeterMinDb) / (kMeterMaxDb - kMeterMinDb),
+        0.0f, 1.0f);
+    const int fillH = static_cast<int>(peakNorm * stripH);
+    if (fillH > 0) {
+        const QRect fill(barR.x(), barR.y() + stripH - fillH,
+                         kBarW, fillH);
+        QLinearGradient grad(0, barR.y() + stripH, 0, barR.y());
+        grad.setColorAt(0.0,  QColor("#2f9e6a"));   // green bottom
+        grad.setColorAt(0.55, QColor("#6cc56a"));   // lime
+        grad.setColorAt(0.80, QColor("#e8b94c"));   // amber
+        grad.setColorAt(0.95, QColor("#e8553c"));   // red top
+        grad.setColorAt(1.0,  QColor("#f2362a"));
+        p.fillRect(fill, grad);
+    }
+
+    // Bar outline.
+    p.setPen(QPen(QColor("#243a4e"), 1));
+    p.setBrush(Qt::NoBrush);
+    p.drawRect(barR.adjusted(0, 0, -1, -1));
+
+    // dB scale + tick marks on the left.
+    QFont tf = p.font();
+    tf.setPixelSize(8);
+    tf.setBold(false);
+    p.setFont(tf);
+    const QFontMetrics fm(tf);
+    const int textRight = kLabelColW - 2;
+
+    struct Tick { float db; const char* label; };
+    static constexpr Tick kTicks[] = {
+        {   0.0f,  "0" },
+        {  -6.0f,  "-6" },
+        { -12.0f,  "-12" },
+        { -20.0f,  "-20" },
+        { -40.0f,  "-40" },
+    };
+    for (const auto& t : kTicks) {
+        const float norm = (t.db - kMeterMinDb) / (kMeterMaxDb - kMeterMinDb);
+        const int y = stripTop + static_cast<int>((1.0f - norm) * stripH);
+
+        p.setPen(QColor("#7f93a5"));
+        const QString s = QString::fromLatin1(t.label);
+        const int tw = fm.horizontalAdvance(s);
+        const int ty = std::clamp(y + fm.ascent() / 2 - 1,
+                                  stripTop + fm.ascent() - 1,
+                                  stripTop + stripH - 1);
+        p.drawText(textRight - tw, ty, s);
+
+        p.setPen(QColor("#405060"));
+        p.drawLine(textRight, y, barLeft - 1, y);
+    }
+
+    // Numeric readout below the strip.
+    QFont vf = p.font();
+    vf.setPixelSize(10);
+    vf.setBold(true);
+    p.setFont(vf);
+    p.setPen(QColor("#d7e7f2"));
+    const QString readout = (m_smoothedPeak <= kMeterMinDb + 0.5f)
+        ? QStringLiteral("-inf")
+        : QString::asprintf("%+.1f dB", m_smoothedPeak);
+    p.drawText(QRect(0, height() - botLabelH, width(), botLabelH),
+               Qt::AlignCenter, readout);
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientLevelMeter.h
+++ b/src/gui/ClientLevelMeter.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+
+namespace AetherSDR {
+
+// Vertical level meter — gradient-filled bar with dB scale labels and a
+// numeric readout below.  Same visual language as the meter half of
+// ClientEqOutputFader, without the fader handle / drag interaction.
+//
+// Drive it from any UI-thread polling timer:
+//   meter->setPeakDb(eq->outputPeakDb());
+// or for a linear value:
+//   meter->setPeakLinear(0.5f);
+class ClientLevelMeter : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientLevelMeter(QWidget* parent = nullptr);
+
+    // Header label — defaults to "OUT".  Empty string hides the header.
+    void setHeaderText(const QString& text);
+
+    // Update the meter.  Both apply the same fast-attack / slow-release
+    // smoothing as the EQ output fader so the visual feel matches.
+    void setPeakDb(float peakDb);
+    void setPeakLinear(float peakLinear);
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+
+private:
+    QString m_headerText{"OUT"};
+    float   m_smoothedPeak{-120.0f};
+
+    static constexpr float kMeterMinDb = -60.0f;
+    static constexpr float kMeterMaxDb =   0.0f;
+    static constexpr int   kLabelColW  = 20;
+    static constexpr int   kGap        = 2;
+    static constexpr int   kBarW       = 16;
+    static constexpr int   kStripTopPad    = 4;
+    static constexpr int   kStripBottomPad = 4;
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientTubeEditor.cpp
+++ b/src/gui/ClientTubeEditor.cpp
@@ -1,5 +1,6 @@
 #include "ClientTubeEditor.h"
 #include "ClientCompKnob.h"
+#include "ClientLevelMeter.h"
 #include "ClientTubeCurveWidget.h"
 #include "EditorFramelessTitleBar.h"
 #include "core/AppSettings.h"
@@ -281,6 +282,10 @@ ClientTubeEditor::ClientTubeEditor(AudioEngine* engine, QWidget* parent)
     right->addStretch();
     body->addLayout(right, 0);
 
+    // ── Output level meter — far-right column, mirrors EQ editor ────
+    m_outMeter = new ClientLevelMeter;
+    body->addWidget(m_outMeter);
+
     root->addLayout(body);
 
     if (m_audio && tube()) {
@@ -365,6 +370,8 @@ void ClientTubeEditor::syncControlsFromEngine()
     { QSignalBlocker b(m_envelope); m_envelope->setValue(t->envelopeAmount()); }
     { QSignalBlocker b(m_attack);   m_attack->setValue(t->attackMs()); }
     { QSignalBlocker b(m_release);  m_release->setValue(t->releaseMs()); }
+
+    if (m_outMeter) m_outMeter->setPeakDb(t->outputPeakDb());
 
     m_restoring = false;
 }

--- a/src/gui/ClientTubeEditor.h
+++ b/src/gui/ClientTubeEditor.h
@@ -10,6 +10,7 @@ namespace AetherSDR {
 
 class AudioEngine;
 class ClientCompKnob;         // reused — generic rotary knob
+class ClientLevelMeter;
 class ClientTubeCurveWidget;
 
 // Floating editor for the client-side dynamic tube saturator.
@@ -76,6 +77,7 @@ private:
     ClientCompKnob*        m_envelope{nullptr};
     ClientCompKnob*        m_attack{nullptr};
     ClientCompKnob*        m_release{nullptr};
+    ClientLevelMeter*      m_outMeter{nullptr};
     QPushButton*           m_modelA{nullptr};
     QPushButton*           m_modelB{nullptr};
     QPushButton*           m_modelC{nullptr};

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -494,7 +494,12 @@ void PanadapterStack::floatPanadapter(const QString& panId)
     // nullptr. Using adoptApplet() calls addWidget() internally which sets
     // the parent to the floating window in one step, avoiding the transient
     // top-level NSWindow that corrupts the NSResponder chain (#1668).
-    auto* fw = new PanFloatingWindow(nullptr);
+    // Parenting the floating window to MainWindow keeps it on top of the
+    // main window without becoming WindowStaysOnTopHint (which would
+    // float above other apps too).  Qt::Window inside PanFloatingWindow
+    // keeps it as a top-level window — the parent only affects z-order
+    // and lifetime.
+    auto* fw = new PanFloatingWindow(window());
     fw->adoptApplet(applet);
     applet->spectrumWidget()->setFloating(true);
 

--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -217,7 +217,15 @@ void ContainerManager::floatContainer(const QString& id)
         c->setParent(nullptr);
     }
 
-    auto* win = new FloatingContainerWindow;
+    // Parent the popped-out window to the main application window so it
+    // stays on top of MainWindow without becoming WindowStaysOnTopHint
+    // (which would float above all apps, including others when the user
+    // alt-tabs away).  Qt::Window inside FloatingContainerWindow keeps
+    // it as a separate top-level — the parent only affects z-order and
+    // lifetime.
+    QWidget* parentWindow = nullptr;
+    if (auto* pw = qobject_cast<QWidget*>(parent())) parentWindow = pw->window();
+    auto* win = new FloatingContainerWindow(parentWindow);
     win->setGeometryKey(geometryKeyFor(id));
     win->takeContainer(c);
     connect(win, &FloatingContainerWindow::dockRequested,


### PR DESCRIPTION
EQ editor:
- New Peak Hold toggle (left of the family combo) freezes the analyzer
  peak trace at its running maximum so the user can spot resonances
  while tuning.  Toggle off resumes normal decay.
- New Reset button (right of the family combo) drops every band back
  to ClientEq::defaultBand(i), restores the default 10-band count, and
  resets the filter family to Butterworth.  Saves immediately.
- Per-bin peak-hold trail rendered over the live FFT in soft off-white
  so it reads cleanly against the cool-cyan analyzer fill.

Tube editor:
- New ClientLevelMeter widget — vertical gradient meter with dB ticks
  and numeric readout, mirroring the EQ output fader's meter half but
  without the fader handle / drag interaction.
- Wired into the Tube editor's far-right column, fed from
  ClientTube::outputPeakDb() at the same 30 Hz sync cadence as the
  rest of the editor.  Side-bound so TX/RX show their respective
  tube outputs.

Floating window stay-on-top:
- ContainerManager and PanadapterStack now parent popped-out windows
  to the main application window.  Qt::Window flag preserves
  top-level status; the parent only affects z-order and lifetime so
  applets stay on top of MainWindow without floating above other
  apps when the user alt-tabs away.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
