### PR TITLE
[fix] Floating panadapter and applet state not restored across restarts

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2003,51 +2003,56 @@ MainWindow::MainWindow(QWidget* parent)
             connect(m_layoutRestoreTimer, &QTimer::timeout, this, [this]() {
                 // The radio restores pans from the GUIClientID session.
                 // Accept whatever the radio gives and arrange based on count.
-                int panCount = m_panStack->count();
-                if (panCount <= 1) return;  // single pan, nothing to arrange
-                // Pick a layout based on the number of pans the radio restored
-                const QString saved = AppSettings::instance()
-                    .value("PanadapterLayout", "1").toString();
-                // Only rearrange if the saved layout matches the pan count
-                static const QMap<QString, int> layoutPanCount = {
-                    {"1", 1}, {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"3v", 3}, {"2x2", 4}, {"4v", 4}
-                };
-                if (layoutPanCount.value(saved, 1) == panCount)
-                    m_panStack->rearrangeLayout(saved);
-                else if (panCount == 2)
-                    m_panStack->rearrangeLayout("2v");  // default 2-pan to vertical
-                else if (panCount == 3)
-                    m_panStack->rearrangeLayout("2h1"); // default 3-pan
-                else if (panCount >= 4)
-                    m_panStack->rearrangeLayout("2x2"); // default 4-pan
+                const int panCount = m_panStack->count();
+                if (panCount > 1) {
+                    // Pick a layout based on the number of pans the radio restored
+                    const QString saved = AppSettings::instance()
+                        .value("PanadapterLayout", "1").toString();
+                    // Only rearrange if the saved layout matches the pan count
+                    static const QMap<QString, int> layoutPanCount = {
+                        {"1", 1}, {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"3v", 3}, {"2x2", 4}, {"4v", 4}
+                    };
+                    if (layoutPanCount.value(saved, 1) == panCount)
+                        m_panStack->rearrangeLayout(saved);
+                    else if (panCount == 2)
+                        m_panStack->rearrangeLayout("2v");  // default 2-pan to vertical
+                    else if (panCount == 3)
+                        m_panStack->rearrangeLayout("2h1"); // default 3-pan
+                    else if (panCount >= 4)
+                        m_panStack->rearrangeLayout("2x2"); // default 4-pan
 
-                // Optimistically set local yPixels immediately so FFT frames
-                // arriving before the radio echoes back use correct scaling (#1511).
-                for (auto* a : m_panStack->allApplets()) {
-                    auto* s = a->spectrumWidget();
-                    auto* p = m_radioModel.panadapter(a->panId());
-                    if (!s || !p || !p->panStreamId()) continue;
-                    int y = s->height();
-                    if (y >= 100)
-                        m_radioModel.panStream()->setYPixels(p->panStreamId(), y);
+                    // Optimistically set local yPixels immediately so FFT frames
+                    // arriving before the radio echoes back use correct scaling (#1511).
+                    for (auto* a : m_panStack->allApplets()) {
+                        auto* s = a->spectrumWidget();
+                        auto* p = m_radioModel.panadapter(a->panId());
+                        if (!s || !p || !p->panStreamId()) continue;
+                        int y = s->height();
+                        if (y >= 100)
+                            m_radioModel.panStream()->setYPixels(p->panStreamId(), y);
+                    }
+
+                    // Defensive re-push xpixels for all pans after layout settles.
+                    // Covers race where radio hadn't finished pan init when first push arrived.
+                    QTimer::singleShot(500, this, [this]() {
+                        for (auto* applet : m_panStack->allApplets()) {
+                            auto* sw = applet->spectrumWidget();
+                            auto* pan = m_radioModel.panadapter(applet->panId());
+                            if (!sw || !pan) continue;
+                            int xpix = qMax(sw->width(), 1024);
+                            int ypix = qMax(sw->height(), 200);
+                            m_radioModel.sendCommand(
+                                QString("display pan set %1 xpixels=%2 ypixels=%3")
+                                    .arg(pan->panId()).arg(xpix).arg(ypix));
+                            if (pan->panStreamId())
+                                m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+                        }
+                    });
                 }
 
-                // Defensive re-push xpixels for all pans after layout settles.
-                // Covers race where radio hadn't finished pan init when first push arrived.
-                QTimer::singleShot(500, this, [this]() {
-                    for (auto* applet : m_panStack->allApplets()) {
-                        auto* sw = applet->spectrumWidget();
-                        auto* pan = m_radioModel.panadapter(applet->panId());
-                        if (!sw || !pan) continue;
-                        int xpix = qMax(sw->width(), 1024);
-                        int ypix = qMax(sw->height(), 200);
-                        m_radioModel.sendCommand(
-                            QString("display pan set %1 xpixels=%2 ypixels=%3")
-                                .arg(pan->panId()).arg(xpix).arg(ypix));
-                        if (pan->panStreamId())
-                            m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
-                    }
-                });
+                // Restore floating-pan state saved from the previous session.
+                // Runs for any pan count so a single floated pan is also restored.
+                m_panStack->restoreFloatingState();
             });
         }
         m_layoutRestoreTimer->start();  // restart on each new pan
@@ -6103,6 +6108,14 @@ void MainWindow::buildUI()
     splitter->addWidget(m_appletPanel);
     splitter->setStretchFactor(3, 0);
     splitter->setCollapsible(3, false);
+
+    // Restore floating-container state from the previous session.  Deferred
+    // one event-loop cycle so AppletPanel's own legacy-migration singleShot(0)
+    // timers fire first (they write ContainerTree) before we read it back.
+    QTimer::singleShot(0, this, [this]() {
+        if (m_appletPanel && m_appletPanel->containerManager())
+            m_appletPanel->containerManager()->restoreState();
+    });
 
     // Set initial splitter sizes: CWX=0, DVK=0 (both hidden), center=stretch, right=310
     const int centerWidth = qMax(400, width() - 310);

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -3,9 +3,11 @@
 #include "PanFloatingWindow.h"
 #include "PanadapterApplet.h"
 #include "SpectrumWidget.h"
+#include "core/AppSettings.h"
 
 #include <QHBoxLayout>
 #include <QLayout>
+#include <QStringList>
 #include <QVBoxLayout>
 #include <QTimer>
 #include <QWindow>
@@ -502,6 +504,7 @@ void PanadapterStack::floatPanadapter(const QString& panId)
     fw->restoreWindowGeometry();
     fw->show();
     fw->raise();
+    saveFloatingState();
 
     connect(fw, &PanFloatingWindow::dockRequested,
             this, &PanadapterStack::dockPanadapter);
@@ -539,6 +542,7 @@ void PanadapterStack::dockPanadapter(const QString& panId)
     applet = fw->takeApplet();
     fw->hide();
     fw->deleteLater();
+    saveFloatingState();
 
     if (!applet) return;
 
@@ -590,10 +594,32 @@ bool PanadapterStack::isFloating(const QString& panId) const
 
 void PanadapterStack::prepareShutdown()
 {
+    saveFloatingState();
     for (auto* fw : m_floatingWindows) {
         fw->saveWindowGeometry();
         fw->setShuttingDown(true);
         fw->close();
+    }
+}
+
+void PanadapterStack::saveFloatingState() const
+{
+    QStringList ids;
+    for (const QString& id : m_floatingWindows.keys()) {
+        ids << id;
+    }
+    AppSettings::instance().setValue("FloatingPanIds", ids.join(','));
+}
+
+void PanadapterStack::restoreFloatingState()
+{
+    const QString saved =
+        AppSettings::instance().value("FloatingPanIds", "").toString();
+    if (saved.isEmpty()) return;
+    for (const QString& id : saved.split(',', Qt::SkipEmptyParts)) {
+        if (m_pans.contains(id) && !m_floatingWindows.contains(id)) {
+            floatPanadapter(id);
+        }
     }
 }
 

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -52,6 +52,14 @@ public:
     void floatPanadapter(const QString& panId);
     void dockPanadapter(const QString& panId);
     bool isFloating(const QString& panId) const;
+
+    // Persist / restore which pans are currently floating (AppSettings key
+    // "FloatingPanIds").  saveFloatingState is called automatically on every
+    // float/dock transition and at shutdown; restoreFloatingState is called
+    // once after all pans have been added following a radio connect.
+    void saveFloatingState() const;
+    void restoreFloatingState();
+
     void prepareShutdown();
 
 signals:

--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -272,6 +272,7 @@ void ContainerManager::dockContainer(const QString& id)
 
 void ContainerManager::prepareShutdown()
 {
+    saveState();  // commit current floating/visibility state before closing windows
     for (auto* win : m_floatingWindows) {
         win->prepareShutdown();
     }


### PR DESCRIPTION
Two separate bugs caused popped-out windows to come back docked after every restart.

--- Fix 1: Floating panadapter state ---

PanadapterStack saved window geometry (position/size) but never recorded which pans were floating.  There was no restore path.

- PanadapterStack::saveFloatingState() writes the comma-separated list of currently-floating pan IDs to AppSettings["FloatingPanIds"].  Called automatically from floatPanadapter(), dockPanadapter(), and prepareShutdown().
- PanadapterStack::restoreFloatingState() reads "FloatingPanIds" and calls floatPanadapter() for each ID that exists and is not already floating. Safe on reconnect: unknown IDs are skipped, already-floating pans are no-ops.
- MainWindow m_layoutRestoreTimer lambda: previously did an early return for single-pan sessions, blocking any restore.  Restructured to wrap multi-pan layout code in if (panCount > 1) and always call restoreFloatingState() at the end, for any pan count.

--- Fix 2: Floating applet state not restored ---

ContainerManager::restoreState() was fully implemented and saveState() was already called on every float/dock transition, but restoreState() was never called anywhere.  The ContainerTree JSON key was written but never read back on launch.

- ContainerManager::prepareShutdown() now calls saveState() first so the ContainerTree JSON is always current before windows close, even on an unexpected quit.
- MainWindow: after new AppletPanel(splitter), a QTimer::singleShot(0) schedules containerManager()->restoreState(). The one-event-loop delay lets AppletPanel's own legacy-migration singleShot(0) timers fire first (they write ContainerTree), then restoreState() reads the up-to-date JSON and re-floats containers.