### PR TITLE
[feat] FramelessResizer: all-edge resize for frameless floating windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,6 +506,7 @@ set(GUI_SOURCES
     src/gui/DxClusterDialog.cpp
     src/gui/CwxPanel.cpp
     src/gui/BandStackPanel.cpp
+    src/gui/FramelessResizer.cpp
     src/gui/PanFloatingWindow.cpp
     src/gui/DvkPanel.cpp
     src/gui/AmpApplet.cpp
@@ -1176,6 +1177,7 @@ target_link_libraries(transmit_model_test PRIVATE Qt6::Core)
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test
     tests/container_widget_test.cpp
+    src/gui/FramelessResizer.cpp
     src/gui/containers/ContainerTitleBar.cpp
     src/gui/containers/ContainerWidget.cpp
     src/gui/containers/FloatingContainerWindow.cpp
@@ -1189,6 +1191,7 @@ set_target_properties(container_widget_test PROPERTIES AUTOMOC ON)
 
 add_executable(container_manager_test
     tests/container_manager_test.cpp
+    src/gui/FramelessResizer.cpp
     src/gui/containers/ContainerManager.cpp
     src/gui/containers/ContainerTitleBar.cpp
     src/gui/containers/ContainerWidget.cpp
@@ -1203,6 +1206,7 @@ set_target_properties(container_manager_test PROPERTIES AUTOMOC ON)
 
 add_executable(container_nesting_test
     tests/container_nesting_test.cpp
+    src/gui/FramelessResizer.cpp
     src/gui/containers/ContainerManager.cpp
     src/gui/containers/ContainerTitleBar.cpp
     src/gui/containers/ContainerWidget.cpp

--- a/src/gui/FramelessResizer.cpp
+++ b/src/gui/FramelessResizer.cpp
@@ -1,0 +1,125 @@
+#include "FramelessResizer.h"
+
+#include <QEvent>
+#include <QGuiApplication>
+#include <QMouseEvent>
+#include <QWidget>
+#include <QWindow>
+
+namespace AetherSDR {
+
+void FramelessResizer::install(QWidget* window, int margin)
+{
+    new FramelessResizer(window, margin);
+}
+
+FramelessResizer::FramelessResizer(QWidget* window, int margin)
+    : QObject(window), m_window(window), m_margin(margin)
+{
+    if (window->windowHandle()) {
+        // Native window already exists — install directly on it.
+        window->windowHandle()->installEventFilter(this);
+    } else {
+        // Native window not yet created (called from constructor before
+        // show()).  Install on the QWidget temporarily and migrate to the
+        // QWindow when WinIdChange fires.
+        window->installEventFilter(this);
+    }
+}
+
+Qt::Edges FramelessResizer::edgesAt(const QPoint& p) const
+{
+    const QRect r = m_window->rect();
+    Qt::Edges edges;
+    if (p.x() <= m_margin)              edges |= Qt::LeftEdge;
+    if (p.x() >= r.width()  - m_margin) edges |= Qt::RightEdge;
+    if (p.y() <= m_margin)              edges |= Qt::TopEdge;
+    if (p.y() >= r.height() - m_margin) edges |= Qt::BottomEdge;
+    return edges;
+}
+
+void FramelessResizer::enterEdgeZone(Qt::Edges edges)
+{
+    if (edges == m_lastEdges && m_cursorOverridden) return;
+
+    Qt::CursorShape shape;
+    if      (edges == (Qt::TopEdge    | Qt::LeftEdge))  shape = Qt::SizeFDiagCursor;
+    else if (edges == (Qt::TopEdge    | Qt::RightEdge)) shape = Qt::SizeBDiagCursor;
+    else if (edges == (Qt::BottomEdge | Qt::LeftEdge))  shape = Qt::SizeBDiagCursor;
+    else if (edges == (Qt::BottomEdge | Qt::RightEdge)) shape = Qt::SizeFDiagCursor;
+    else if (edges & (Qt::LeftEdge  | Qt::RightEdge))   shape = Qt::SizeHorCursor;
+    else                                                 shape = Qt::SizeVerCursor;
+
+    if (m_cursorOverridden) QGuiApplication::restoreOverrideCursor();
+    QGuiApplication::setOverrideCursor(QCursor(shape));
+    m_cursorOverridden = true;
+    m_lastEdges = edges;
+}
+
+void FramelessResizer::leaveEdgeZone()
+{
+    if (m_cursorOverridden) {
+        QGuiApplication::restoreOverrideCursor();
+        m_cursorOverridden = false;
+        m_lastEdges = {};
+    }
+}
+
+bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
+{
+    // ── Phase 1: QWidget (pre-native-window) ─────────────────────────────
+    // Waiting for the native window to be created.  Once WinIdChange fires,
+    // migrate the filter to the QWindow and stay there.
+    if (obj == m_window) {
+        if (ev->type() == QEvent::WinIdChange && m_window->windowHandle()) {
+            m_window->removeEventFilter(this);
+            m_window->windowHandle()->installEventFilter(this);
+        }
+        return false;
+    }
+
+    // ── Phase 2: QWindow (native handle) ─────────────────────────────────
+    // Hands off when the window has native decorations — the OS handles resize.
+    if (!(m_window->windowFlags() & Qt::FramelessWindowHint)) {
+        leaveEdgeZone();
+        return false;
+    }
+
+    switch (ev->type()) {
+
+    case QEvent::MouseMove: {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (me->buttons() != Qt::NoButton) break;
+        // QWindow delivers mouse positions in window-local coordinates.
+        const Qt::Edges edges = edgesAt(me->position().toPoint());
+        if (edges) {
+            enterEdgeZone(edges);
+        } else {
+            leaveEdgeZone();
+        }
+        break;
+    }
+
+    case QEvent::MouseButtonPress: {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (me->button() != Qt::LeftButton) break;
+        const Qt::Edges edges = edgesAt(me->position().toPoint());
+        if (edges && m_window->windowHandle()) {
+            leaveEdgeZone();  // hand cursor control back to the OS
+            m_window->windowHandle()->startSystemResize(edges);
+            return true;      // consume: no widget should receive this press
+        }
+        break;
+    }
+
+    case QEvent::Leave:
+        leaveEdgeZone();
+        break;
+
+    default:
+        break;
+    }
+    return false;
+}
+
+} // namespace AetherSDR

--- a/src/gui/FramelessResizer.h
+++ b/src/gui/FramelessResizer.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QObject>
+#include <Qt>
+
+class QWidget;
+
+namespace AetherSDR {
+
+// Adds all-edge resize to a Qt::FramelessWindowHint top-level QWidget using
+// QWindow::startSystemResize() — the same compositor-managed path used for
+// startSystemMove in TitleBar / ContainerWidget / PanadapterApplet.
+//
+// The filter is installed on the QWindow (native handle) rather than on the
+// QWidget tree.  QWindow receives all platform mouse events *before* they
+// are dispatched to the widget hierarchy, so resize intent is detected across
+// the whole window without touching any child widget's event stream.  This
+// avoids breaking nested controls (knobs, drag tiles, sub-containers) that
+// happen to be near the window edges.
+//
+// Timing: the native QWindow is created lazily on first show().  If install()
+// is called before show() (e.g. from the constructor), the filter starts on
+// the QWidget itself and migrates to the QWindow on QEvent::WinIdChange.
+//
+// Usage:
+//   FramelessResizer::install(this);       // from a QWidget constructor
+//   FramelessResizer::install(win, 6);     // explicit margin
+class FramelessResizer : public QObject {
+    Q_OBJECT
+public:
+    static void install(QWidget* window, int margin = 6);
+
+protected:
+    bool eventFilter(QObject* obj, QEvent* ev) override;
+
+private:
+    explicit FramelessResizer(QWidget* window, int margin);
+    Qt::Edges edgesAt(const QPoint& windowPos) const;
+    void enterEdgeZone(Qt::Edges edges);
+    void leaveEdgeZone();
+
+    QWidget*  m_window{nullptr};
+    int       m_margin{6};
+    bool      m_cursorOverridden{false};
+    Qt::Edges m_lastEdges{};
+};
+
+} // namespace AetherSDR

--- a/src/gui/PanFloatingWindow.cpp
+++ b/src/gui/PanFloatingWindow.cpp
@@ -1,12 +1,10 @@
 #include "PanFloatingWindow.h"
+#include "FramelessResizer.h"
 #include "PanadapterApplet.h"
 #include "core/AppSettings.h"
 
-#include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QCloseEvent>
-#include <QPushButton>
-#include <QSizeGrip>
+#include <QVBoxLayout>
 
 namespace AetherSDR {
 
@@ -23,6 +21,8 @@ PanFloatingWindow::PanFloatingWindow(QWidget* parent)
     m_layout = new QVBoxLayout(this);
     m_layout->setContentsMargins(0, 0, 0, 0);
     m_layout->setSpacing(0);
+
+    FramelessResizer::install(this);
 }
 
 void PanFloatingWindow::adoptApplet(PanadapterApplet* applet)
@@ -41,14 +41,6 @@ void PanFloatingWindow::adoptApplet(PanadapterApplet* applet)
     // floating window without an intermediate nullptr/top-level state.
     // This avoids corrupting the main window's NSResponder chain on macOS.
     m_layout->addWidget(m_applet, 1);
-
-    // Bottom-right resize grip — frameless windows lose OS edge resize.
-    auto* gripRow = new QHBoxLayout;
-    gripRow->setContentsMargins(0, 0, 0, 0);
-    gripRow->addStretch(1);
-    gripRow->addWidget(new QSizeGrip(this), 0,
-                       Qt::AlignBottom | Qt::AlignRight);
-    m_layout->addLayout(gripRow);
 
     // Show dock icon in the applet's title bar
     m_applet->setFloatingState(true);

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -1,15 +1,14 @@
 #include "FloatingContainerWindow.h"
 #include "ContainerWidget.h"
 #include "core/AppSettings.h"
+#include "gui/FramelessResizer.h"
 
 #include <QByteArray>
 #include <QCloseEvent>
 #include <QGuiApplication>
-#include <QHBoxLayout>
 #include <QMoveEvent>
 #include <QResizeEvent>
 #include <QScreen>
-#include <QSizeGrip>
 #include <QVBoxLayout>
 
 namespace AetherSDR {
@@ -40,6 +39,8 @@ FloatingContainerWindow::FloatingContainerWindow(QWidget* parent)
     m_saveTimer.setInterval(400);
     connect(&m_saveTimer, &QTimer::timeout, this,
             &FloatingContainerWindow::saveGeometryToKey);
+
+    FramelessResizer::install(this);
 }
 
 FloatingContainerWindow::~FloatingContainerWindow() = default;
@@ -59,15 +60,6 @@ void FloatingContainerWindow::takeContainer(ContainerWidget* container)
         m_container->show();
         m_container->setDockMode(ContainerWidget::DockMode::Floating);
         setWindowTitle(m_container->title());
-
-        // Bottom-right resize grip — frameless windows lose OS edge resize.
-        // Append after the container so it sits at the bottom of the layout.
-        auto* gripRow = new QHBoxLayout;
-        gripRow->setContentsMargins(0, 0, 0, 0);
-        gripRow->addStretch(1);
-        gripRow->addWidget(new QSizeGrip(this), 0,
-                           Qt::AlignBottom | Qt::AlignRight);
-        m_layout->addLayout(gripRow);
     }
 }
 


### PR DESCRIPTION
Popped-out panadapter and applet windows use Qt::FramelessWindowHint, which removes OS-provided resize borders.  The previous workaround was a QSizeGrip in the bottom-right corner, which is unreliable on Wayland and covers only one corner.

New FramelessResizer (src/gui/FramelessResizer.h/.cpp) provides all-8-edge resize using QWindow::startSystemResize() — the same compositor-managed path already used for drag-to-move via startSystemMove() in TitleBar and ContainerWidget.

The filter is installed on the QWindow (native handle) rather than on the QWidget tree.  QWindow receives all platform mouse events before they are dispatched to the widget hierarchy, so resize intent is detected across the whole window without touching any child widget's event stream.  This avoids breaking nested controls (knobs, drag tiles, sub-containers) that happen to be near the window edges — the regression that caused PR #2042 to be reverted.

Original approach (PR #2042, reverted): recursively installed an event filter on the window and every descendant widget, with a ChildAdded watcher to pick up new children.  For the Aetherial Audio tx_dsp container this put the filter in front of hundreds of controls and had the 6 px top-edge zone intercept clicks at y=0–6, calling startSystemResize() before the title bar's mousePressEvent could call startSystemMove().

Revised approach: one filter on the QWindow; cursor feedback uses QGuiApplication::setOverrideCursor() so the resize cursor wins over any child widget cursor without touching the widget tree.  MouseButtonPress is consumed only when the cursor is within 6 px of a window edge.

Timing: the native QWindow is created lazily on first show().  If install() is called before show() (e.g. from the constructor), the filter starts on the QWidget itself and migrates to the QWindow on QEvent::WinIdChange.

The old QSizeGrip bottom-right rows in PanFloatingWindow and FloatingContainerWindow are removed since the resizer covers all edges.

CMakeLists: FramelessResizer.cpp added to the main AetherSDR target and to the three container test executables that compile FloatingContainerWindow.cpp directly (container_widget_test, container_manager_test, container_nesting_test).