### PR TITLE
[fix] Frameless toggle not propagating to open floating windows

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9265,6 +9265,11 @@ void MainWindow::setFramelessWindow(bool on)
 
     // Keep the bottom-right size grip in sync — only useful when frameless.
     if (m_sizeGrip) m_sizeGrip->setVisible(on);
+
+    // Propagate to all currently-floating child windows so they match.
+    if (m_panStack) m_panStack->setFramelessMode(on);
+    if (m_appletPanel && m_appletPanel->containerManager())
+        m_appletPanel->containerManager()->setFramelessMode(on);
 }
 
 void MainWindow::toggleMinimalMode(bool on)

--- a/src/gui/PanFloatingWindow.cpp
+++ b/src/gui/PanFloatingWindow.cpp
@@ -11,13 +11,15 @@
 namespace AetherSDR {
 
 PanFloatingWindow::PanFloatingWindow(QWidget* parent)
-    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
+    : QWidget(parent, Qt::Window)
 {
-    // Windows quirk: the constructor flag bitmask is sometimes ignored
-    // and the native frame still gets drawn.  Re-applying via setWindowFlags
-    // before show() forces the platform plugin to honour FramelessWindowHint
-    // on all Qt versions / widget hierarchies.
-    setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+    const bool frameless =
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True";
+    Qt::WindowFlags flags = Qt::Window;
+    if (frameless) flags |= Qt::FramelessWindowHint;
+    // Re-apply via setWindowFlags — some platform plugins ignore the
+    // constructor bitmask and need an explicit call before show().
+    setWindowFlags(flags);
     setMinimumSize(400, 300);
 
     m_layout = new QVBoxLayout(this);
@@ -70,6 +72,21 @@ PanadapterApplet* PanFloatingWindow::takeApplet()
     a->setParent(nullptr);
     m_applet = nullptr;
     return a;
+}
+
+void PanFloatingWindow::setFramelessMode(bool on)
+{
+    const bool wasVisible = isVisible();
+    const QRect geom = geometry();
+    Qt::WindowFlags flags = windowFlags();
+    if (on) {
+        flags |= Qt::FramelessWindowHint;
+    } else {
+        flags &= ~Qt::FramelessWindowHint;
+    }
+    setWindowFlags(flags);
+    setGeometry(geom);
+    if (wasVisible) show();
 }
 
 void PanFloatingWindow::closeEvent(QCloseEvent* ev)

--- a/src/gui/PanFloatingWindow.h
+++ b/src/gui/PanFloatingWindow.h
@@ -25,6 +25,10 @@ public:
     void restoreWindowGeometry();
     void setShuttingDown(bool on) { m_shuttingDown = on; }
 
+    // Apply or remove Qt::FramelessWindowHint at runtime to match the
+    // main-window frameless setting.  Preserves geometry and visibility.
+    void setFramelessMode(bool on);
+
 signals:
     void dockRequested(const QString& panId);
 

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -588,6 +588,13 @@ bool PanadapterStack::isFloating(const QString& panId) const
     return m_floatingWindows.contains(panId);
 }
 
+void PanadapterStack::setFramelessMode(bool on)
+{
+    for (auto* fw : m_floatingWindows) {
+        fw->setFramelessMode(on);
+    }
+}
+
 void PanadapterStack::prepareShutdown()
 {
     for (auto* fw : m_floatingWindows) {

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -52,6 +52,10 @@ public:
     void floatPanadapter(const QString& panId);
     void dockPanadapter(const QString& panId);
     bool isFloating(const QString& panId) const;
+
+    // Follow the main-window frameless setting for all active floating windows.
+    void setFramelessMode(bool on);
+
     void prepareShutdown();
 
 signals:

--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -270,6 +270,13 @@ void ContainerManager::dockContainer(const QString& id)
     saveState();
 }
 
+void ContainerManager::setFramelessMode(bool on)
+{
+    for (auto* win : m_floatingWindows) {
+        if (win) win->setFramelessMode(on);
+    }
+}
+
 void ContainerManager::prepareShutdown()
 {
     for (auto* win : m_floatingWindows) {

--- a/src/gui/containers/ContainerManager.h
+++ b/src/gui/containers/ContainerManager.h
@@ -86,6 +86,9 @@ public:
     void floatContainer(const QString& id);
     void dockContainer(const QString& id);
 
+    // Follow the main-window frameless setting for all active floating windows.
+    void setFramelessMode(bool on);
+
     // Save geometry and close all floating windows without triggering
     // dock-back behaviour.  Call from MainWindow::closeEvent().
     void prepareShutdown();

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -22,13 +22,15 @@ constexpr int kDefaultH = 240;
 } // namespace
 
 FloatingContainerWindow::FloatingContainerWindow(QWidget* parent)
-    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
+    : QWidget(parent, Qt::Window)
 {
-    // Windows quirk: the constructor flag bitmask is sometimes ignored
-    // and the native frame still gets drawn.  Re-applying via setWindowFlags
-    // before show() forces the platform plugin to honour FramelessWindowHint
-    // on all Qt versions / widget hierarchies.
-    setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+    const bool frameless =
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True";
+    Qt::WindowFlags flags = Qt::Window;
+    if (frameless) flags |= Qt::FramelessWindowHint;
+    // Re-apply via setWindowFlags — some platform plugins ignore the
+    // constructor bitmask and need an explicit call before show().
+    setWindowFlags(flags);
     setAttribute(Qt::WA_DeleteOnClose, false);
     setAttribute(Qt::WA_QuitOnClose, false);
     setStyleSheet("QWidget { background: #08121d; }");
@@ -147,6 +149,21 @@ void FloatingContainerWindow::prepareShutdown()
     saveGeometryToKey();
     m_shuttingDown = true;
     close();
+}
+
+void FloatingContainerWindow::setFramelessMode(bool on)
+{
+    const bool wasVisible = isVisible();
+    const QRect geom = geometry();
+    Qt::WindowFlags flags = windowFlags();
+    if (on) {
+        flags |= Qt::FramelessWindowHint;
+    } else {
+        flags &= ~Qt::FramelessWindowHint;
+    }
+    setWindowFlags(flags);
+    setGeometry(geom);
+    if (wasVisible) show();
 }
 
 void FloatingContainerWindow::closeEvent(QCloseEvent* ev)

--- a/src/gui/containers/FloatingContainerWindow.h
+++ b/src/gui/containers/FloatingContainerWindow.h
@@ -48,6 +48,10 @@ public:
     // suppresses the dock-on-close behaviour, and closes the window.
     void prepareShutdown();
 
+    // Apply or remove Qt::FramelessWindowHint at runtime to match the
+    // main-window frameless setting.  Preserves geometry and visibility.
+    void setFramelessMode(bool on);
+
     // Restore the window's geometry from the key, clamping to a
     // visible screen.  If no saved geometry exists, centres on the
     // anchor's current screen at a reasonable default size.  Safe to


### PR DESCRIPTION
Switching View → Frameless Window updated the main window chrome but left any already-open floating panadapter or applet windows unchanged, because setFramelessWindow() in MainWindow only modified its own Qt::FramelessWindowHint flag.  PanFloatingWindow and FloatingContainerWindow had the flag hardcoded at construction and were never updated at runtime.

Changes:

- PanFloatingWindow constructor now reads AppSettings["FramelessWindow"] instead of hardcoding Qt::FramelessWindowHint, so newly created windows open in the correct mode.
- PanFloatingWindow::setFramelessMode(bool) added — setWindowFlags + setGeometry + show() to switch a live window without losing position.
- FloatingContainerWindow constructor same fix.
- FloatingContainerWindow::setFramelessMode(bool) added.
- PanadapterStack::setFramelessMode(bool) — iterates all live floating panadapter windows and calls setFramelessMode on each.
- ContainerManager::setFramelessMode(bool) — same for applet windows.
- MainWindow::setFramelessWindow() now calls both after updating itself.