### PR TITLE
[fix] Frame-agnostic geometry save/restore for floating windows

### DIFF
--- a/src/gui/PanFloatingWindow.cpp
+++ b/src/gui/PanFloatingWindow.cpp
@@ -2,11 +2,13 @@
 #include "PanadapterApplet.h"
 #include "core/AppSettings.h"
 
-#include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QCloseEvent>
-#include <QPushButton>
+#include <QGuiApplication>
+#include <QHBoxLayout>
+#include <QScreen>
 #include <QSizeGrip>
+#include <QStringList>
+#include <QVBoxLayout>
 
 namespace AetherSDR {
 
@@ -85,18 +87,52 @@ void PanFloatingWindow::closeEvent(QCloseEvent* ev)
 
 void PanFloatingWindow::saveWindowGeometry()
 {
-    auto& s = AppSettings::instance();
-    s.setValue(QString("FloatingPan_%1_Geometry").arg(panId()),
-              QString::fromLatin1(saveGeometry().toBase64()));
+    // Store client-area rect as "x,y,w,h" — frame-agnostic, so geometry
+    // restores correctly whether the window is frameless or decorated.
+    const QRect r = geometry();
+    AppSettings::instance().setValue(
+        QString("FloatingPan_%1_Geometry").arg(panId()),
+        QString("%1,%2,%3,%4").arg(r.x()).arg(r.y()).arg(r.width()).arg(r.height()));
 }
 
 void PanFloatingWindow::restoreWindowGeometry()
 {
-    auto& s = AppSettings::instance();
-    QString geom = s.value(QString("FloatingPan_%1_Geometry").arg(panId())).toString();
-    if (!geom.isEmpty()) {
-        restoreGeometry(QByteArray::fromBase64(geom.toLatin1()));
+    const QString val = AppSettings::instance()
+        .value(QString("FloatingPan_%1_Geometry").arg(panId())).toString();
+    if (val.isEmpty()) return;
+
+    // New format: "x,y,w,h" — frame-agnostic.
+    const QStringList parts = val.split(',');
+    if (parts.size() == 4) {
+        bool ok0, ok1, ok2, ok3;
+        const int x = parts[0].toInt(&ok0);
+        const int y = parts[1].toInt(&ok1);
+        const int w = parts[2].toInt(&ok2);
+        const int h = parts[3].toInt(&ok3);
+        if (ok0 && ok1 && ok2 && ok3 && w > 0 && h > 0) {
+            // Clamp top-left to a visible screen so windows on
+            // disconnected monitors don't land off-screen.
+            QRect r(x, y, w, h);
+            bool onScreen = false;
+            for (QScreen* s : QGuiApplication::screens()) {
+                if (s->availableGeometry().contains(r.topLeft())) {
+                    onScreen = true;
+                    break;
+                }
+            }
+            if (!onScreen) {
+                QScreen* s = QGuiApplication::primaryScreen();
+                if (s) {
+                    const QRect avail = s->availableGeometry();
+                    r.moveCenter(avail.center());
+                }
+            }
+            setGeometry(r);
+            return;
+        }
     }
+    // Legacy: base64-encoded QWidget::saveGeometry() blob from older builds.
+    restoreGeometry(QByteArray::fromBase64(val.toLatin1()));
 }
 
 } // namespace AetherSDR

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -10,6 +10,7 @@
 #include <QResizeEvent>
 #include <QScreen>
 #include <QSizeGrip>
+#include <QStringList>
 #include <QVBoxLayout>
 
 namespace AetherSDR {
@@ -93,11 +94,29 @@ void FloatingContainerWindow::restoreAndEnsureVisible(QWidget* anchor)
     m_restoring = true;
     bool restored = false;
     if (!m_geometryKey.isEmpty()) {
-        const QByteArray geom = QByteArray::fromBase64(
-            AppSettings::instance()
-                .value(m_geometryKey, "").toByteArray());
-        if (!geom.isEmpty() && restoreGeometry(geom)) {
-            restored = true;
+        const QString val = AppSettings::instance()
+            .value(m_geometryKey, "").toString();
+        if (!val.isEmpty()) {
+            // New format: "x,y,w,h" — frame-agnostic, works across
+            // frameless ↔ decorated mode changes.
+            const QStringList parts = val.split(',');
+            if (parts.size() == 4) {
+                bool ok0, ok1, ok2, ok3;
+                const int x = parts[0].toInt(&ok0);
+                const int y = parts[1].toInt(&ok1);
+                const int w = parts[2].toInt(&ok2);
+                const int h = parts[3].toInt(&ok3);
+                if (ok0 && ok1 && ok2 && ok3 && w > 0 && h > 0) {
+                    setGeometry(x, y, w, h);
+                    restored = true;
+                }
+            }
+            if (!restored) {
+                // Legacy: base64-encoded QWidget::saveGeometry() blob.
+                const QByteArray blob = QByteArray::fromBase64(val.toUtf8());
+                if (!blob.isEmpty() && restoreGeometry(blob))
+                    restored = true;
+            }
         }
     }
     if (!restored) {
@@ -114,8 +133,8 @@ void FloatingContainerWindow::restoreAndEnsureVisible(QWidget* anchor)
             resize(kDefaultW, kDefaultH);
         }
     } else {
-        // Clamp to any visible screen — saved geometry may reference
-        // a monitor that's no longer connected.
+        // Clamp top-left to a visible screen — saved position may
+        // reference a monitor that's no longer connected.
         bool onScreen = false;
         const QPoint tl = geometry().topLeft();
         for (QScreen* s : QGuiApplication::screens()) {
@@ -137,8 +156,12 @@ void FloatingContainerWindow::restoreAndEnsureVisible(QWidget* anchor)
 void FloatingContainerWindow::saveGeometryToKey() const
 {
     if (m_geometryKey.isEmpty()) return;
+    // Store client-area rect as "x,y,w,h" — frame-agnostic so geometry
+    // restores correctly whether the window is frameless or decorated.
+    const QRect r = geometry();
     AppSettings::instance().setValue(
-        m_geometryKey, saveGeometry().toBase64());
+        m_geometryKey,
+        QString("%1,%2,%3,%4").arg(r.x()).arg(r.y()).arg(r.width()).arg(r.height()));
 }
 
 void FloatingContainerWindow::prepareShutdown()


### PR DESCRIPTION
QWidget::saveGeometry() bakes in platform frame-extent data. When the decoration mode changes between save and restore (frameless ↔ decorated), the wrong frame size is applied and the window shifts by the title-bar height (~30 px on most Linux/Windows themes).

Replace the opaque base64 blob with a plain "x,y,w,h" string read from geometry() (the client-area rect, always frame-agnostic) and restore with setGeometry() directly. No frame arithmetic needed; works identically in both modes.

Legacy fallback: if the stored value is not four integers (i.e. it is a base64 blob from a build before this fix), the old restoreGeometry() path is used so existing saves survive the upgrade.

Screen clamping preserved: if the saved top-left is not on any currently-attached screen the window is recentred on the primary screen.

Affected: PanFloatingWindow, FloatingContainerWindow.