### PR TITLE
Floating state persistence + insertChildWidget guard

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2014,51 +2014,56 @@ MainWindow::MainWindow(QWidget* parent)
             connect(m_layoutRestoreTimer, &QTimer::timeout, this, [this]() {
                 // The radio restores pans from the GUIClientID session.
                 // Accept whatever the radio gives and arrange based on count.
-                int panCount = m_panStack->count();
-                if (panCount <= 1) return;  // single pan, nothing to arrange
-                // Pick a layout based on the number of pans the radio restored
-                const QString saved = AppSettings::instance()
-                    .value("PanadapterLayout", "1").toString();
-                // Only rearrange if the saved layout matches the pan count
-                static const QMap<QString, int> layoutPanCount = {
-                    {"1", 1}, {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"3v", 3}, {"2x2", 4}, {"4v", 4}
-                };
-                if (layoutPanCount.value(saved, 1) == panCount)
-                    m_panStack->rearrangeLayout(saved);
-                else if (panCount == 2)
-                    m_panStack->rearrangeLayout("2v");  // default 2-pan to vertical
-                else if (panCount == 3)
-                    m_panStack->rearrangeLayout("2h1"); // default 3-pan
-                else if (panCount >= 4)
-                    m_panStack->rearrangeLayout("2x2"); // default 4-pan
+                const int panCount = m_panStack->count();
+                if (panCount > 1) {
+                    // Pick a layout based on the number of pans the radio restored
+                    const QString saved = AppSettings::instance()
+                        .value("PanadapterLayout", "1").toString();
+                    // Only rearrange if the saved layout matches the pan count
+                    static const QMap<QString, int> layoutPanCount = {
+                        {"1", 1}, {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"3v", 3}, {"2x2", 4}, {"4v", 4}
+                    };
+                    if (layoutPanCount.value(saved, 1) == panCount)
+                        m_panStack->rearrangeLayout(saved);
+                    else if (panCount == 2)
+                        m_panStack->rearrangeLayout("2v");  // default 2-pan to vertical
+                    else if (panCount == 3)
+                        m_panStack->rearrangeLayout("2h1"); // default 3-pan
+                    else if (panCount >= 4)
+                        m_panStack->rearrangeLayout("2x2"); // default 4-pan
 
-                // Optimistically set local yPixels immediately so FFT frames
-                // arriving before the radio echoes back use correct scaling (#1511).
-                for (auto* a : m_panStack->allApplets()) {
-                    auto* s = a->spectrumWidget();
-                    auto* p = m_radioModel.panadapter(a->panId());
-                    if (!s || !p || !p->panStreamId()) continue;
-                    int y = s->height();
-                    if (y >= 100)
-                        m_radioModel.panStream()->setYPixels(p->panStreamId(), y);
+                    // Optimistically set local yPixels immediately so FFT frames
+                    // arriving before the radio echoes back use correct scaling (#1511).
+                    for (auto* a : m_panStack->allApplets()) {
+                        auto* s = a->spectrumWidget();
+                        auto* p = m_radioModel.panadapter(a->panId());
+                        if (!s || !p || !p->panStreamId()) continue;
+                        int y = s->height();
+                        if (y >= 100)
+                            m_radioModel.panStream()->setYPixels(p->panStreamId(), y);
+                    }
+
+                    // Defensive re-push xpixels for all pans after layout settles.
+                    // Covers race where radio hadn't finished pan init when first push arrived.
+                    QTimer::singleShot(500, this, [this]() {
+                        for (auto* applet : m_panStack->allApplets()) {
+                            auto* sw = applet->spectrumWidget();
+                            auto* pan = m_radioModel.panadapter(applet->panId());
+                            if (!sw || !pan) continue;
+                            int xpix = qMax(sw->width(), 1024);
+                            int ypix = qMax(sw->height(), 200);
+                            m_radioModel.sendCommand(
+                                QString("display pan set %1 xpixels=%2 ypixels=%3")
+                                    .arg(pan->panId()).arg(xpix).arg(ypix));
+                            if (pan->panStreamId())
+                                m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+                        }
+                    });
                 }
 
-                // Defensive re-push xpixels for all pans after layout settles.
-                // Covers race where radio hadn't finished pan init when first push arrived.
-                QTimer::singleShot(500, this, [this]() {
-                    for (auto* applet : m_panStack->allApplets()) {
-                        auto* sw = applet->spectrumWidget();
-                        auto* pan = m_radioModel.panadapter(applet->panId());
-                        if (!sw || !pan) continue;
-                        int xpix = qMax(sw->width(), 1024);
-                        int ypix = qMax(sw->height(), 200);
-                        m_radioModel.sendCommand(
-                            QString("display pan set %1 xpixels=%2 ypixels=%3")
-                                .arg(pan->panId()).arg(xpix).arg(ypix));
-                        if (pan->panStreamId())
-                            m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
-                    }
-                });
+                // Restore floating-pan state saved from the previous session.
+                // Runs for any pan count so a single floated pan is also restored.
+                m_panStack->restoreFloatingState();
             });
         }
         m_layoutRestoreTimer->start();  // restart on each new pan
@@ -6117,6 +6122,14 @@ void MainWindow::buildUI()
     splitter->addWidget(m_appletPanel);
     splitter->setStretchFactor(3, 0);
     splitter->setCollapsible(3, false);
+
+    // Restore floating-container state from the previous session.  Deferred
+    // one event-loop cycle so AppletPanel's own legacy-migration singleShot(0)
+    // timers fire first (they write ContainerTree) before we read it back.
+    QTimer::singleShot(0, this, [this]() {
+        if (m_appletPanel && m_appletPanel->containerManager())
+            m_appletPanel->containerManager()->restoreState();
+    });
 
     // Set initial splitter sizes: CWX=0, DVK=0 (both hidden), center=stretch, right=310
     const int centerWidth = qMax(400, width() - 310);

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -3,9 +3,11 @@
 #include "PanFloatingWindow.h"
 #include "PanadapterApplet.h"
 #include "SpectrumWidget.h"
+#include "core/AppSettings.h"
 
 #include <QHBoxLayout>
 #include <QLayout>
+#include <QStringList>
 #include <QVBoxLayout>
 #include <QTimer>
 #include <QWindow>
@@ -507,6 +509,7 @@ void PanadapterStack::floatPanadapter(const QString& panId)
     fw->restoreWindowGeometry();
     fw->show();
     fw->raise();
+    saveFloatingState();
 
     connect(fw, &PanFloatingWindow::dockRequested,
             this, &PanadapterStack::dockPanadapter);
@@ -544,6 +547,7 @@ void PanadapterStack::dockPanadapter(const QString& panId)
     applet = fw->takeApplet();
     fw->hide();
     fw->deleteLater();
+    saveFloatingState();
 
     if (!applet) return;
 
@@ -595,10 +599,32 @@ bool PanadapterStack::isFloating(const QString& panId) const
 
 void PanadapterStack::prepareShutdown()
 {
+    saveFloatingState();
     for (auto* fw : m_floatingWindows) {
         fw->saveWindowGeometry();
         fw->setShuttingDown(true);
         fw->close();
+    }
+}
+
+void PanadapterStack::saveFloatingState() const
+{
+    QStringList ids;
+    for (const QString& id : m_floatingWindows.keys()) {
+        ids << id;
+    }
+    AppSettings::instance().setValue("FloatingPanIds", ids.join(','));
+}
+
+void PanadapterStack::restoreFloatingState()
+{
+    const QString saved =
+        AppSettings::instance().value("FloatingPanIds", "").toString();
+    if (saved.isEmpty()) return;
+    for (const QString& id : saved.split(',', Qt::SkipEmptyParts)) {
+        if (m_pans.contains(id) && !m_floatingWindows.contains(id)) {
+            floatPanadapter(id);
+        }
     }
 }
 

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -52,6 +52,14 @@ public:
     void floatPanadapter(const QString& panId);
     void dockPanadapter(const QString& panId);
     bool isFloating(const QString& panId) const;
+
+    // Persist / restore which pans are currently floating (AppSettings key
+    // "FloatingPanIds").  saveFloatingState is called automatically on every
+    // float/dock transition and at shutdown; restoreFloatingState is called
+    // once after all pans have been added following a radio connect.
+    void saveFloatingState() const;
+    void restoreFloatingState();
+
     void prepareShutdown();
 
 signals:

--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -280,6 +280,7 @@ void ContainerManager::dockContainer(const QString& id)
 
 void ContainerManager::prepareShutdown()
 {
+    saveState();  // commit current floating/visibility state before closing windows
     for (auto* win : m_floatingWindows) {
         win->prepareShutdown();
     }

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -66,6 +66,14 @@ QWidget* ContainerWidget::setContent(QWidget* content)
 void ContainerWidget::insertChildWidget(int index, QWidget* child)
 {
     if (!child || !m_bodyLayout) return;
+    // If the child is already in this layout, leave it where AppletPanel
+    // placed it.  Without this guard, ContainerManager::restoreState()'s
+    // second pass would re-insert each saved child at indices 0..N-1,
+    // displacing non-container peers (e.g. ClientChainApplet) that
+    // AppletPanel inserted directly without recording them in the
+    // ContainerTree JSON.  Drag-reorder persistence flows through the
+    // packed-atomic chain order, not through this path.
+    if (m_bodyLayout->indexOf(child) >= 0) return;
     child->setParent(m_body);
     if (index < 0 || index > m_bodyLayout->count())
         index = m_bodyLayout->count();


### PR DESCRIPTION
Combines two changes:

### 1. Cherry-picked persistence fix (originally #2057, by @chibondking)

`PanadapterStack::saveFloatingState/restoreFloatingState` for popped-out panadapters and `ContainerManager::saveState()` in `prepareShutdown` for popped-out applet containers, plus `MainWindow` calls to restore both at launch. PR #2057 was based on a stale main; cherry-picked the four-file diff onto current main and verified clean.

### 2. `ContainerWidget::insertChildWidget` guard

While testing #1 on top of current main, the Aetherial Audio container's CHAIN widget displaced from index 0 down to the bottom of the layout. Root cause: `ContainerManager::saveState()` skips non-`ContainerWidget` children (line 337 `qobject_cast<ContainerWidget*>(w)`), so `ClientChainApplet` (a plain QWidget) is silently omitted from the saved children list. Then `restoreState()`'s second pass calls `insertChildWidget(i, child)` for each saved child at indices 0..N-1; Qt's `insertWidget` on a widget already in the layout moves it, shifting CHAIN further down each iteration.

Fix: `insertChildWidget` no-ops when the child is already in this layout. AppletPanel populates children once at construction; restoreState's re-add was the bug. Drag-reorder of chain stages is unaffected because that path does `removeChildWidget` first.

### Closes #2057

Closing in favour of this combined PR. Thanks @chibondking for the persistence work — the cherry-pick applied cleanly and your design is solid; we just hit a latent bug in the existing ContainerManager API that #2057 was the first thing to exercise.

Co-Authored-By: CJ Johnson <cj@cedrick.io>