### PR TITLE
[meters] Fix per-slice compression meter resolution

### DIFF
--- a/docs/flex-meter-learnings.md
+++ b/docs/flex-meter-learnings.md
@@ -10,6 +10,10 @@ Related implementation context lives in `docs/tx-audio-signal-path.md`.
 
 - Match meters by `source` and `name`, not by numeric ID. Flex meter IDs are
   assigned per session and differ by platform.
+- Compression TX-chain meters are repeated per active slice on multi-slice
+  radios. Track `COMPPEAK`, `AFTEREQ`, and `SC_MIC` by active slice. Some
+  radios expose distinct TX waveform `sourceIndex` values, while 8000-series
+  captures can repeat `TX- num=0` blocks after each `SLC` slice block.
 - Do not synthesize compression when required radio meters are unavailable. A
   missing compression input should make the compression meter unavailable, not
   approximate a value from local mic audio.
@@ -72,6 +76,45 @@ The remaining engineering caution is timing. On the 6600, `SC_MIC` advertises
 `10 fps` while `COMPPEAK` advertises `20 fps`. AetherSDR guards the derived
 6600 compression value by requiring the reference sample and `COMPPEAK` sample
 to be close in time before marking the compression meter available.
+
+## Multi-Slice Meter Resolution
+
+FLEX radios can repeat the TX waveform meter block once per active slice. In a
+captured FLEX-6600 four-slice manifest, `SC_MIC` / `COMPPEAK` appeared as
+`22/23`, `44/45`, `66/67`, and `88/89`. Those numeric IDs are not stable API
+contracts; they are manifest slots for that session.
+
+AetherSDR stores compression meter IDs by explicit TX waveform `sourceIndex`
+when the manifest provides one. In 8000-series captures where repeated TX
+blocks all report `num=0`, AetherSDR keys those block-local meters to the most
+recent `SLC` slice context from the manifest. The formula remains
+family-specific by available meter name: use active-slice `AFTEREQ` when
+present, otherwise active-slice `SC_MIC`, paired with active-slice `COMPPEAK`.
+
+The implementation intentionally derives a slice/source key and then looks up
+the manifest IDs for that key. It does not calculate the final meter IDs
+directly.
+
+| Radio family / manifest shape | Slice/source resolution | Reference meter | Compression meter | Gauge formula |
+|---|---|---|---|---|
+| FLEX-6600 / 6000-style explicit TX source | `txBase = min(TX sourceIndex >= 8) - min(SLC sourceIndex)`, then `activeTxSource = txBase + activeTxSlice` | `SC_MIC` at `activeTxSource` | `COMPPEAK` at `activeTxSource` | `-clamp(max(0, COMPPEAK - SC_MIC), 0, 25)` |
+| FLEX-8000-style explicit TX source | Same explicit TX-source lookup when the manifest provides per-slice TX source indices | `AFTEREQ` at `activeTxSource` | `COMPPEAK` at `activeTxSource` | `-clamp(max(0, COMPPEAK - AFTEREQ), 0, 25)` |
+| FLEX-8000-style repeated `TX- num=0` blocks | Use the most recent `SLC` source index as manifest context, then resolve by `activeTxSlice` at runtime | `AFTEREQ` mapped to `activeTxSlice` | `COMPPEAK` mapped to `activeTxSlice` | `-clamp(max(0, COMPPEAK - AFTEREQ), 0, 25)` |
+
+Issue #2040 describes the 6600 failure mode this avoids: the old scalar
+indexes were last-match-wins, so a multi-slice 6600 session could bind to the
+highest-numbered slice's `SC_MIC` / `COMPPEAK` pair while the VITA meter stream
+was publishing values for a different active TX slice.
+
+## Diagnostic Logging
+
+Enable `Meters` in Help > Support to capture compression diagnostics. The log
+emits a `compression meter map` row for each discovered `COMPPEAK`, `AFTEREQ`,
+or `SC_MIC` meter, then throttles live `compression summary` rows to twice per
+second unless the state changes. The summary includes active TX slice,
+waveform `sourceIndex`, selected reference meter, reference and `COMPPEAK`
+values, sample skew, computed lift, displayed gauge value, and availability
+reason.
 
 ## Meter FPS Comparison
 

--- a/docs/tx-audio-signal-path.md
+++ b/docs/tx-audio-signal-path.md
@@ -224,6 +224,14 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
   VOX detection and P/CW mic level display.
 - **Meter IDs are dynamic**: The radio assigns meter IDs on connection. The IDs shown
   here are from one session — match by name, not by ID.
+- **Multi-slice TX chains**: Radios can expose one TX waveform meter block per
+  active slice. AetherSDR resolves compression meters through the active TX
+  slice. FLEX-6600 captures expose distinct TX waveform `sourceIndex` values,
+  while FLEX-8000 captures can repeat `TX- num=0` blocks after each `SLC`
+  slice block. In both cases `COMPPEAK` is paired with the matching `AFTEREQ`
+  or `SC_MIC` from the same slice. The code derives the active TX source or
+  implicit slice context first, then looks up the manifest IDs for that slice;
+  it never assumes fixed IDs like `22/23`.
 - **Compression meter input**: AetherSDR derives the compression gauge from
   radio-provided TX meters only. FLEX-8000 series radios use
   `max(0, COMPPEAK - AFTEREQ)`. 6000-series radios that do not expose `AFTEREQ`

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -11,6 +11,8 @@ namespace AetherSDR {
 namespace {
 
 constexpr qint64 kCompressionReferenceMaxSkewMs = 250;
+constexpr qint64 kCompressionSummaryLogIntervalMs = 500;
+constexpr int kMinTxWaveformSourceIndex = 8;
 
 float compressionReductionForGauge(float referenceDbfs, float compPeakDbfs)
 {
@@ -79,6 +81,8 @@ void MeterModel::setTgxlHandle(quint32 handle)
 void MeterModel::defineMeter(const MeterDef& def)
 {
     m_defs[def.index] = def;
+    if (def.source == "SLC")
+        m_manifestSliceContext = def.sourceIndex;
 
     // Cache indices for high-frequency lookups
     if (def.source == "SLC" && def.name == "LEVEL")
@@ -91,12 +95,24 @@ void MeterModel::defineMeter(const MeterDef& def)
         m_swrIdx = def.index;
     else if (def.name == "MICPEAK")
         m_micPeakIdx = def.index;
-    else if (def.source.startsWith("TX") && def.name == "COMPPEAK")
-        m_compPeakIdx = def.index;
-    else if (def.source.startsWith("TX") && def.name == "AFTEREQ")
-        m_afterEqIdx = def.index;
-    else if (def.source.startsWith("TX") && def.name == "SC_MIC")
-        m_scMicIdx = def.index;
+    else if (isTxWaveformMeter(def) && def.name == "COMPPEAK") {
+        if (hasExplicitTxWaveformSourceIndex(def))
+            m_compPeakIdxByTxSource[def.sourceIndex] = def.index;
+        else
+            m_compPeakIdxBySlice[implicitTxWaveformSliceIndex()] = def.index;
+    }
+    else if (isTxWaveformMeter(def) && def.name == "AFTEREQ") {
+        if (hasExplicitTxWaveformSourceIndex(def))
+            m_afterEqIdxByTxSource[def.sourceIndex] = def.index;
+        else
+            m_afterEqIdxBySlice[implicitTxWaveformSliceIndex()] = def.index;
+    }
+    else if (isTxWaveformMeter(def) && def.name == "SC_MIC") {
+        if (hasExplicitTxWaveformSourceIndex(def))
+            m_scMicIdxByTxSource[def.sourceIndex] = def.index;
+        else
+            m_scMicIdxBySlice[implicitTxWaveformSliceIndex()] = def.index;
+    }
     else if (def.name == "MIC")
         m_micLevelIdx = def.index;
     else if (def.name == "COMP")
@@ -127,9 +143,15 @@ void MeterModel::defineMeter(const MeterDef& def)
     else if (def.source == "AMP" && def.name == "TEMP")
         m_ampTempIdx = def.index;
 
+    recomputeSourceIndexMins();
+
     qCDebug(lcMeters) << "MeterModel: defined meter" << def.index
              << def.source << def.sourceIndex << def.name
              << def.unit << "[" << def.low << "->" << def.high << "]";
+    if (isTxWaveformMeter(def)
+        && (def.name == "COMPPEAK" || def.name == "AFTEREQ" || def.name == "SC_MIC")) {
+        logCompressionMeterMap(def);
+    }
 }
 
 void MeterModel::removeMeter(int index)
@@ -146,29 +168,58 @@ void MeterModel::removeMeter(int index)
         if (it.value() == index) it = m_escLevelIdxBySlice.erase(it);
         else ++it;
     }
+    bool compressionMapChanged = false;
+    for (auto it = m_compPeakIdxByTxSource.begin(); it != m_compPeakIdxByTxSource.end(); ) {
+        if (it.value() == index) {
+            it = m_compPeakIdxByTxSource.erase(it);
+            compressionMapChanged = true;
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = m_compPeakIdxBySlice.begin(); it != m_compPeakIdxBySlice.end(); ) {
+        if (it.value() == index) {
+            it = m_compPeakIdxBySlice.erase(it);
+            compressionMapChanged = true;
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = m_afterEqIdxByTxSource.begin(); it != m_afterEqIdxByTxSource.end(); ) {
+        if (it.value() == index) {
+            it = m_afterEqIdxByTxSource.erase(it);
+            compressionMapChanged = true;
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = m_afterEqIdxBySlice.begin(); it != m_afterEqIdxBySlice.end(); ) {
+        if (it.value() == index) {
+            it = m_afterEqIdxBySlice.erase(it);
+            compressionMapChanged = true;
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = m_scMicIdxByTxSource.begin(); it != m_scMicIdxByTxSource.end(); ) {
+        if (it.value() == index) {
+            it = m_scMicIdxByTxSource.erase(it);
+            compressionMapChanged = true;
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = m_scMicIdxBySlice.begin(); it != m_scMicIdxBySlice.end(); ) {
+        if (it.value() == index) {
+            it = m_scMicIdxBySlice.erase(it);
+            compressionMapChanged = true;
+        } else {
+            ++it;
+        }
+    }
     if (index == m_fwdPwrIdx)   m_fwdPwrIdx = -1;
     if (index == m_swrIdx)      m_swrIdx = -1;
     if (index == m_micPeakIdx)   m_micPeakIdx = -1;
-    if (index == m_compPeakIdx) {
-        m_compPeakIdx = -1;
-        m_compPeak = 0.0f;
-        m_hasCompPeakLevel = false;
-        m_compPeakUpdatedMs = 0;
-        m_hasCompPeakValue = false;
-    }
-    if (index == m_afterEqIdx) {
-        m_afterEqIdx = -1;
-        m_compPeak = 0.0f;
-        m_hasAfterEqLevel = false;
-        m_afterEqUpdatedMs = 0;
-        updateCompressionReduction();
-    }
-    if (index == m_scMicIdx) {
-        m_scMicIdx = -1;
-        m_hasScMicLevel = false;
-        m_scMicUpdatedMs = 0;
-        updateCompressionReduction();
-    }
     if (index == m_micLevelIdx)  m_micLevelIdx = -1;
     if (index == m_compLevelIdx) m_compLevelIdx = -1;
     if (index == m_alcIdx)       m_alcIdx = -1;
@@ -177,6 +228,12 @@ void MeterModel::removeMeter(int index)
     if (index == m_ampFwdPwrIdx) m_ampFwdPwrIdx = -1;
     if (index == m_ampSwrIdx)    m_ampSwrIdx = -1;
     if (index == m_ampTempIdx)   m_ampTempIdx = -1;
+
+    recomputeSourceIndexMins();
+    if (compressionMapChanged) {
+        clearCompressionState();
+        updateCompressionReduction();
+    }
 }
 
 float MeterModel::convertRaw(const MeterDef& def, qint16 raw) const
@@ -193,11 +250,167 @@ float MeterModel::convertRaw(const MeterDef& def, qint16 raw) const
     return static_cast<float>(raw);
 }
 
+void MeterModel::clear()
+{
+    m_defs.clear();
+    m_values.clear();
+    m_sLevelIdxBySlice.clear();
+    m_escLevelIdxBySlice.clear();
+    m_compPeakIdxByTxSource.clear();
+    m_afterEqIdxByTxSource.clear();
+    m_scMicIdxByTxSource.clear();
+    m_compPeakIdxBySlice.clear();
+    m_afterEqIdxBySlice.clear();
+    m_scMicIdxBySlice.clear();
+    m_minSliceSourceIndex = -1;
+    m_minTxWaveformSourceIndex = -1;
+    m_manifestSliceContext = -1;
+    m_activeTxSlice = -1;
+    m_fwdPwrIdx = -1;
+    m_swrIdx = -1;
+    m_micPeakIdx = -1;
+    m_micLevelIdx = -1;
+    m_compLevelIdx = -1;
+    m_alcIdx = -1;
+    m_paTempIdx = -1;
+    m_supplyIdx = -1;
+    m_ampFwdPwrIdx = -1;
+    m_ampSwrIdx = -1;
+    m_ampTempIdx = -1;
+    m_tgxlFwdIdx = -1;
+    m_tgxlSwrIdx = -1;
+    m_tgxlHandle = 0;
+    m_tgxlFwdPwr = 0.0f;
+    m_tgxlSwr = 1.0f;
+    m_sLevel = -130.0f;
+    m_fwdPower = 0.0f;
+    m_swr = 1.0f;
+    m_lastTxMeterUpdateMs = 0;
+    m_micPeak = -50.0f;
+    clearCompressionState();
+    m_micLevel = -50.0f;
+    m_compLevel = 0.0f;
+    m_alc = 0.0f;
+    m_paTemp = 0.0f;
+    m_supplyVolts = 0.0f;
+    m_ampFwdPwr = 0.0f;
+    m_ampSwr = 1.0f;
+    m_ampTemp = 0.0f;
+}
+
+void MeterModel::setActiveTxSlice(int sliceIndex)
+{
+    if (m_activeTxSlice == sliceIndex)
+        return;
+
+    m_activeTxSlice = sliceIndex;
+    clearCompressionState();
+    logCompressionSummary("active-slice-change", true);
+    emit micMetersChanged(m_micLevel, m_compLevel, m_micPeak, m_compPeak);
+}
+
+void MeterModel::clearCompressionState()
+{
+    m_compPeak = 0.0f;
+    m_hasCompPeakValue = false;
+    m_afterEqLevel = -150.0f;
+    m_scMicLevel = -150.0f;
+    m_compPeakLevel = -150.0f;
+    m_hasAfterEqLevel = false;
+    m_hasScMicLevel = false;
+    m_hasCompPeakLevel = false;
+    m_afterEqUpdatedMs = 0;
+    m_scMicUpdatedMs = 0;
+    m_compPeakUpdatedMs = 0;
+    m_lastCompressionSummaryLogMs = 0;
+    m_lastCompressionSummaryReason.clear();
+}
+
+bool MeterModel::isTxWaveformMeter(const MeterDef& def) const
+{
+    return def.source.startsWith("TX");
+}
+
+bool MeterModel::hasExplicitTxWaveformSourceIndex(const MeterDef& def) const
+{
+    return isTxWaveformMeter(def) && def.sourceIndex >= kMinTxWaveformSourceIndex;
+}
+
+int MeterModel::implicitTxWaveformSliceIndex() const
+{
+    if (m_manifestSliceContext >= 0)
+        return m_manifestSliceContext;
+    return 0;
+}
+
+void MeterModel::recomputeSourceIndexMins()
+{
+    m_minSliceSourceIndex = -1;
+    m_minTxWaveformSourceIndex = -1;
+
+    for (auto it = m_defs.constBegin(); it != m_defs.constEnd(); ++it) {
+        const MeterDef& def = *it;
+        if (def.source == "SLC") {
+            if (m_minSliceSourceIndex < 0 || def.sourceIndex < m_minSliceSourceIndex)
+                m_minSliceSourceIndex = def.sourceIndex;
+        } else if (hasExplicitTxWaveformSourceIndex(def)) {
+            if (m_minTxWaveformSourceIndex < 0 || def.sourceIndex < m_minTxWaveformSourceIndex)
+                m_minTxWaveformSourceIndex = def.sourceIndex;
+        }
+    }
+}
+
+int MeterModel::txWaveformBase() const
+{
+    if (m_minTxWaveformSourceIndex < 0)
+        return -1;
+    if (m_minSliceSourceIndex >= 0)
+        return m_minTxWaveformSourceIndex - m_minSliceSourceIndex;
+    return m_minTxWaveformSourceIndex;
+}
+
+int MeterModel::activeTxWaveformSourceIndex() const
+{
+    if (m_activeTxSlice < 0)
+        return -1;
+
+    const int base = txWaveformBase();
+    if (base < 0)
+        return -1;
+
+    return base + m_activeTxSlice;
+}
+
+int MeterModel::compPeakIndexForActiveTxSlice() const
+{
+    const int txSource = activeTxWaveformSourceIndex();
+    if (txSource >= 0 && m_compPeakIdxByTxSource.contains(txSource))
+        return m_compPeakIdxByTxSource.value(txSource);
+    return m_compPeakIdxBySlice.value(m_activeTxSlice, -1);
+}
+
+int MeterModel::afterEqIndexForActiveTxSlice() const
+{
+    const int txSource = activeTxWaveformSourceIndex();
+    if (txSource >= 0 && m_afterEqIdxByTxSource.contains(txSource))
+        return m_afterEqIdxByTxSource.value(txSource);
+    return m_afterEqIdxBySlice.value(m_activeTxSlice, -1);
+}
+
+int MeterModel::scMicIndexForActiveTxSlice() const
+{
+    const int txSource = activeTxWaveformSourceIndex();
+    if (txSource >= 0 && m_scMicIdxByTxSource.contains(txSource))
+        return m_scMicIdxByTxSource.value(txSource);
+    return m_scMicIdxBySlice.value(m_activeTxSlice, -1);
+}
+
 void MeterModel::updateCompressionReduction()
 {
     if (!m_hasCompPeakLevel) {
         m_compPeak = 0.0f;
         m_hasCompPeakValue = false;
+        logCompressionSummary("missing-comppeak");
         return;
     }
 
@@ -213,18 +426,23 @@ void MeterModel::updateCompressionReduction()
     //   cadence can compare a fresh COMPPEAK against a stale SC_MIC sample, so
     //   compressionSamplesFresh() gates the derived 6000-series value. If an
     //   8000-style AFTEREQ exists, prefer it over SC_MIC.
-    if (m_afterEqIdx >= 0) {
+    const int afterEqIdx = afterEqIndexForActiveTxSlice();
+    const int scMicIdx = scMicIndexForActiveTxSlice();
+
+    if (afterEqIdx >= 0) {
         if (!m_hasAfterEqLevel) {
             m_compPeak = 0.0f;
             m_hasCompPeakValue = false;
+            logCompressionSummary("missing-aftereq");
             return;
         }
         referenceLevel = m_afterEqLevel;
         referenceUpdatedMs = m_afterEqUpdatedMs;
-    } else if (m_scMicIdx >= 0) {
+    } else if (scMicIdx >= 0) {
         if (!m_hasScMicLevel) {
             m_compPeak = 0.0f;
             m_hasCompPeakValue = false;
+            logCompressionSummary("missing-scmic");
             return;
         }
         referenceLevel = m_scMicLevel;
@@ -232,17 +450,20 @@ void MeterModel::updateCompressionReduction()
     } else {
         m_compPeak = 0.0f;
         m_hasCompPeakValue = false;
+        logCompressionSummary("missing-reference");
         return;
     }
 
     if (!compressionSamplesFresh(referenceUpdatedMs)) {
         m_compPeak = 0.0f;
         m_hasCompPeakValue = false;
+        logCompressionSummary("stale-reference");
         return;
     }
 
     m_compPeak = compressionReductionForGauge(referenceLevel, m_compPeakLevel);
     m_hasCompPeakValue = true;
+    logCompressionSummary("ok");
 }
 
 bool MeterModel::compressionSamplesFresh(qint64 referenceUpdatedMs) const
@@ -254,6 +475,84 @@ bool MeterModel::compressionSamplesFresh(qint64 referenceUpdatedMs) const
         ? m_compPeakUpdatedMs - referenceUpdatedMs
         : referenceUpdatedMs - m_compPeakUpdatedMs;
     return skewMs <= kCompressionReferenceMaxSkewMs;
+}
+
+void MeterModel::logCompressionMeterMap(const MeterDef& def) const
+{
+    if (!lcMeters().isDebugEnabled())
+        return;
+
+    const int base = txWaveformBase();
+    const int slice = hasExplicitTxWaveformSourceIndex(def)
+        ? (base >= 0 ? def.sourceIndex - base : -1)
+        : implicitTxWaveformSliceIndex();
+    qCDebug(lcMeters) << "MeterModel: compression meter map"
+                      << "name" << def.name
+                      << "id" << def.index
+                      << "txSource" << def.sourceIndex
+                      << "txBase" << base
+                      << "slice" << slice
+                      << "explicitTxSource" << hasExplicitTxWaveformSourceIndex(def)
+                      << "description" << def.description;
+}
+
+void MeterModel::logCompressionSummary(const char* reason, bool force)
+{
+    if (!lcMeters().isDebugEnabled())
+        return;
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    const QString reasonText = QString::fromLatin1(reason ? reason : "");
+    const bool reasonChanged = reasonText != m_lastCompressionSummaryReason;
+    if (!force && !reasonChanged && now - m_lastCompressionSummaryLogMs < kCompressionSummaryLogIntervalMs)
+        return;
+
+    m_lastCompressionSummaryLogMs = now;
+    m_lastCompressionSummaryReason = reasonText;
+
+    const int afterEqIdx = afterEqIndexForActiveTxSlice();
+    const int scMicIdx = scMicIndexForActiveTxSlice();
+    const bool useAfterEq = afterEqIdx >= 0;
+    const bool useScMic = !useAfterEq && scMicIdx >= 0;
+    const QString referenceName = useAfterEq
+        ? QStringLiteral("AFTEREQ")
+        : (useScMic ? QStringLiteral("SC_MIC") : QStringLiteral("none"));
+    const int referenceIdx = useAfterEq ? afterEqIdx : (useScMic ? scMicIdx : -1);
+    const float referenceDbfs = useAfterEq ? m_afterEqLevel : (useScMic ? m_scMicLevel : 0.0f);
+    const bool hasReference = useAfterEq ? m_hasAfterEqLevel : (useScMic && m_hasScMicLevel);
+    const qint64 referenceUpdatedMs = useAfterEq ? m_afterEqUpdatedMs : (useScMic ? m_scMicUpdatedMs : 0);
+
+    qint64 skewMs = -1;
+    if (m_compPeakUpdatedMs > 0 && referenceUpdatedMs > 0) {
+        skewMs = m_compPeakUpdatedMs > referenceUpdatedMs
+            ? m_compPeakUpdatedMs - referenceUpdatedMs
+            : referenceUpdatedMs - m_compPeakUpdatedMs;
+    }
+
+    const float liftDb = (m_hasCompPeakLevel && hasReference)
+        ? qMax(0.0f, m_compPeakLevel - referenceDbfs)
+        : 0.0f;
+
+    qCDebug(lcMeters) << "MeterModel: compression summary"
+                      << "reason" << reasonText
+                      << "activeSlice" << m_activeTxSlice
+                      << "txBase" << txWaveformBase()
+                      << "txSource" << activeTxWaveformSourceIndex()
+                      << "usingImplicitSliceMap"
+                      << (!m_compPeakIdxByTxSource.contains(activeTxWaveformSourceIndex())
+                          && m_compPeakIdxBySlice.contains(m_activeTxSlice))
+                      << "reference" << referenceName
+                      << "referenceId" << referenceIdx
+                      << "referenceDbfs" << referenceDbfs
+                      << "hasReference" << hasReference
+                      << "compPeakId" << compPeakIndexForActiveTxSlice()
+                      << "compPeakDbfs" << m_compPeakLevel
+                      << "hasCompPeak" << m_hasCompPeakLevel
+                      << "skewMs" << skewMs
+                      << "fresh" << compressionSamplesFresh(referenceUpdatedMs)
+                      << "liftDb" << liftDb
+                      << "displayDb" << m_compPeak
+                      << "available" << m_hasCompPeakValue;
 }
 
 bool MeterModel::hasRecentTxMeters(qint64 maxAgeMs) const
@@ -269,6 +568,9 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
 {
     const int n = qMin(ids.size(), vals.size());
     const qint64 packetUpdatedMs = QDateTime::currentMSecsSinceEpoch();
+    const int activeCompPeakIdx = compPeakIndexForActiveTxSlice();
+    const int activeAfterEqIdx = afterEqIndexForActiveTxSlice();
+    const int activeScMicIdx = scMicIndexForActiveTxSlice();
     // sLevelChanged is emitted per-slice inline in the loop below
     bool txChanged = false;
     bool micChanged = false;
@@ -328,7 +630,7 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
         } else if (idx == m_micPeakIdx) {
             m_micPeak = v;
             micChanged = true;
-        } else if (idx == m_compPeakIdx) {
+        } else if (idx == activeCompPeakIdx) {
             // COMPPEAK is a dBFS level tap. Pair it with AFTEREQ on 8000
             // series radios, or SC_MIC on 6000-series radios that do not
             // expose AFTEREQ.
@@ -337,13 +639,13 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
             m_compPeakUpdatedMs = packetUpdatedMs;
             updateCompressionReduction();
             micChanged = true;
-        } else if (idx == m_afterEqIdx) {
+        } else if (idx == activeAfterEqIdx) {
             m_afterEqLevel = v;
             m_hasAfterEqLevel = true;
             m_afterEqUpdatedMs = packetUpdatedMs;
             updateCompressionReduction();
             micChanged = true;
-        } else if (idx == m_scMicIdx) {
+        } else if (idx == activeScMicIdx) {
             m_scMicLevel = v;
             m_hasScMicLevel = true;
             m_scMicUpdatedMs = packetUpdatedMs;

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -47,6 +47,14 @@ public:
     // Remove a meter by index.
     void removeMeter(int index);
 
+    // Clear all meter definitions and cached values on disconnect/reconnect.
+    void clear();
+
+    // Track which radio slice currently owns TX. Compression TX-chain meters
+    // are repeated per slice, so MeterModel must resolve COMPPEAK/reference
+    // indexes against this slice instead of using last-match-wins globals.
+    void setActiveTxSlice(int sliceIndex);
+
     // Process a batch of raw meter values from a VITA-49 packet.
     // ids[i] is the meter index, vals[i] is the raw int16 value.
     void updateValues(const QVector<quint16>& ids, const QVector<qint16>& vals);
@@ -126,8 +134,20 @@ signals:
 
 private:
     float convertRaw(const MeterDef& def, qint16 raw) const;
+    void clearCompressionState();
+    void recomputeSourceIndexMins();
+    bool isTxWaveformMeter(const MeterDef& def) const;
+    bool hasExplicitTxWaveformSourceIndex(const MeterDef& def) const;
+    int implicitTxWaveformSliceIndex() const;
+    int txWaveformBase() const;
+    int activeTxWaveformSourceIndex() const;
+    int compPeakIndexForActiveTxSlice() const;
+    int afterEqIndexForActiveTxSlice() const;
+    int scMicIndexForActiveTxSlice() const;
     void updateCompressionReduction();
     bool compressionSamplesFresh(qint64 referenceUpdatedMs) const;
+    void logCompressionMeterMap(const MeterDef& def) const;
+    void logCompressionSummary(const char* reason, bool force = false);
 
     QMap<int, MeterDef> m_defs;        // meter index → definition
     QMap<int, float>    m_values;      // meter index → last converted value
@@ -135,12 +155,19 @@ private:
     // Cached indices for fast lookup of important meters
     QMap<int, int> m_sLevelIdxBySlice;  // sliceIndex → meter index for "SLC"/"LEVEL"
     QMap<int, int> m_escLevelIdxBySlice; // sliceIndex → meter index for "SLC"/"ESC"
+    QMap<int, int> m_compPeakIdxByTxSource; // TX waveform sourceIndex → "COMPPEAK"
+    QMap<int, int> m_afterEqIdxByTxSource;  // TX waveform sourceIndex → "AFTEREQ"
+    QMap<int, int> m_scMicIdxByTxSource;    // TX waveform sourceIndex → "SC_MIC"
+    QMap<int, int> m_compPeakIdxBySlice;    // active slice → "COMPPEAK" for TX blocks with num=0
+    QMap<int, int> m_afterEqIdxBySlice;     // active slice → "AFTEREQ" for TX blocks with num=0
+    QMap<int, int> m_scMicIdxBySlice;       // active slice → "SC_MIC" for TX blocks with num=0
+    int m_minSliceSourceIndex{-1};
+    int m_minTxWaveformSourceIndex{-1};
+    int m_manifestSliceContext{-1};
+    int m_activeTxSlice{0};
     int m_fwdPwrIdx{-1};     // "FWDPWR"
     int m_swrIdx{-1};        // "SWR"
     int m_micPeakIdx{-1};    // "COD-" / "MICPEAK" (hardware mic)
-    int m_compPeakIdx{-1};   // "TX" / "COMPPEAK" (processor/clipper-stage dBFS tap)
-    int m_afterEqIdx{-1};    // "TX" / "AFTEREQ" (processor input reference)
-    int m_scMicIdx{-1};      // "TX" / "SC_MIC" (6000-series compression reference)
     int m_micLevelIdx{-1};   // "COD-" / "MIC" (hardware mic RX level)
     int m_compLevelIdx{-1};  // "TX" / "COMP" (instantaneous)
     int m_alcIdx{-1};        // "TX" / "HWALC"
@@ -172,6 +199,8 @@ private:
     qint64 m_afterEqUpdatedMs{0};
     qint64 m_scMicUpdatedMs{0};
     qint64 m_compPeakUpdatedMs{0};
+    qint64 m_lastCompressionSummaryLogMs{0};
+    QString m_lastCompressionSummaryReason;
     float m_micLevel{-50.0f};
     float m_compLevel{0.0f};
     float m_alc{0.0f};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -340,6 +340,15 @@ SliceModel* RadioModel::slice(int id) const
     return nullptr;
 }
 
+int RadioModel::activeTxSliceNum() const
+{
+    for (auto* s : m_slices) {
+        if (s && s->isTxSlice())
+            return s->sliceId();
+    }
+    return -1;
+}
+
 // ─── Actions ──────────────────────────────────────────────────────────────────
 
 void RadioModel::connectToRadio(const RadioInfo& info)
@@ -1511,6 +1520,7 @@ void RadioModel::onDisconnected()
     }
     m_transmitModel.setTransmitting(false);
     m_transmitModel.resetState();
+    m_meterModel.clear();
 
     // Reset radio-model-specific state — different radios have different
     // capabilities (APD, max power, pan count, TGXL, amplifier, XVTR, etc.)
@@ -2853,9 +2863,12 @@ void RadioModel::handleSliceStatus(int id,
             m_ownedSliceIds.remove(id);
             // If we already have a SliceModel for this ID, remove it
             if (SliceModel* existing = slice(id)) {
+                const bool wasTxSlice = existing->isTxSlice();
                 m_slices.removeOne(existing);
                 emit sliceRemoved(id);
                 existing->deleteLater();
+                if (wasTxSlice)
+                    m_meterModel.setActiveTxSlice(activeTxSliceNum());
             }
             return;  // slice belongs to another client
         }
@@ -2871,9 +2884,12 @@ void RadioModel::handleSliceStatus(int id,
 
     if (removed) {
         if (s) {
+            const bool wasTxSlice = s->isTxSlice();
             m_slices.removeOne(s);
             emit sliceRemoved(id);
             s->deleteLater();
+            if (wasTxSlice)
+                m_meterModel.setActiveTxSlice(activeTxSliceNum());
         }
         return;
     }
@@ -2891,13 +2907,18 @@ void RadioModel::handleSliceStatus(int id,
         connect(s, &SliceModel::commandReady, this, [this](const QString& cmd){
             sendCmd(cmd);
         });
+        connect(s, &SliceModel::txSliceChanged, this, [this](bool) {
+            m_meterModel.setActiveTxSlice(activeTxSliceNum());
+        });
         m_slices.append(s);
         s->applyStatus(kvs);  // populate frequency/mode before notifying UI
+        m_meterModel.setActiveTxSlice(activeTxSliceNum());
         emit sliceAdded(s);
         return;                // applyStatus already called below; skip second call
     }
 
     s->applyStatus(kvs);
+    m_meterModel.setActiveTxSlice(activeTxSliceNum());
 
     // Aurora/AU-520: max_internal_pa_power in slice status reports the true
     // system power capability (e.g. 500W) while transmit status max_power_level

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -261,6 +261,7 @@ public:
 
     QList<SliceModel*> slices() const { return m_slices; }
     SliceModel* slice(int id) const;
+    int activeTxSliceNum() const;
 
     // High-level actions
     void connectToRadio(const RadioInfo& info);

--- a/tests/meter_model_test.cpp
+++ b/tests/meter_model_test.cpp
@@ -29,13 +29,28 @@ qint16 rawDb(float db)
     return static_cast<qint16>(std::lround(db * 128.0f));
 }
 
-MeterDef txMeter(int index, const QString& name, const QString& unit = QStringLiteral("dBFS"))
+MeterDef txMeter(int index, const QString& name, const QString& unit = QStringLiteral("dBFS"),
+                 int sourceIndex = 8)
 {
     MeterDef def;
     def.index = index;
     def.source = "TX-";
+    def.sourceIndex = sourceIndex;
     def.name = name;
     def.unit = unit;
+    def.low = -150.0;
+    def.high = 20.0;
+    return def;
+}
+
+MeterDef slcMeter(int index, int sliceIndex)
+{
+    MeterDef def;
+    def.index = index;
+    def.source = "SLC";
+    def.sourceIndex = sliceIndex;
+    def.name = "LEVEL";
+    def.unit = "dBm";
     def.low = -150.0;
     def.high = 20.0;
     return def;
@@ -95,6 +110,88 @@ void testCompPeakMinusScMicDrivesGaugeWhenAfterEqMissing()
     model.updateValues({22, 23}, {rawDb(-42.0f), rawDb(-22.0f)});
 
     report("COMPPEAK minus SC_MIC maps 6000-series compression",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+}
+
+void testActiveTxSliceSelects6000CompressionPair()
+{
+    MeterModel model;
+    model.defineMeter(slcMeter(15, 0));
+    model.defineMeter(txMeter(22, "SC_MIC", "dBFS", 8));
+    model.defineMeter(txMeter(23, "COMPPEAK", "dBFS", 8));
+    model.defineMeter(slcMeter(37, 1));
+    model.defineMeter(txMeter(44, "SC_MIC", "dBFS", 9));
+    model.defineMeter(txMeter(45, "COMPPEAK", "dBFS", 9));
+
+    model.setActiveTxSlice(0);
+    model.updateValues({22, 23}, {rawDb(-42.0f), rawDb(-22.0f)});
+    report("active TX slice 0 uses its 6000-series compression pair",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+
+    model.updateValues({44, 45}, {rawDb(-80.0f), rawDb(-40.0f)});
+    report("inactive 6000-series compression pair is ignored",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+
+    model.setActiveTxSlice(1);
+    report("changing active TX slice clears stale compression",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+
+    model.updateValues({44, 45}, {rawDb(-80.0f), rawDb(-40.0f)});
+    report("active TX slice 1 uses its 6000-series compression pair",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -25.0f));
+}
+
+void testActiveTxSliceSelects8000CompressionPair()
+{
+    MeterModel model;
+    model.defineMeter(slcMeter(21, 0));
+    model.defineMeter(txMeter(27, "AFTEREQ", "dBFS", 8));
+    model.defineMeter(txMeter(28, "COMPPEAK", "dBFS", 8));
+    model.defineMeter(slcMeter(43, 1));
+    model.defineMeter(txMeter(49, "AFTEREQ", "dBFS", 9));
+    model.defineMeter(txMeter(50, "COMPPEAK", "dBFS", 9));
+
+    model.setActiveTxSlice(1);
+    model.updateValues({27, 28}, {rawDb(-80.0f), rawDb(-40.0f)});
+    report("inactive 8000-series compression pair is ignored",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+
+    model.updateValues({49, 50}, {rawDb(-30.0f), rawDb(-15.0f)});
+    report("active TX slice 1 uses its 8000-series compression pair",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -15.0f));
+}
+
+void testZeroSource8000MetersUseSliceContext()
+{
+    MeterModel model;
+    model.defineMeter(slcMeter(14, 0));
+    model.defineMeter(txMeter(19, "AFTEREQ", "dBFS", 0));
+    model.defineMeter(txMeter(20, "COMPPEAK", "dBFS", 0));
+    model.defineMeter(slcMeter(32, 1));
+    model.defineMeter(txMeter(43, "AFTEREQ", "dBFS", 0));
+    model.defineMeter(txMeter(44, "COMPPEAK", "dBFS", 0));
+
+    model.setActiveTxSlice(1);
+    model.updateValues({19, 20}, {rawDb(-80.0f), rawDb(-40.0f)});
+    report("inactive zero-source 8000 compression pair is ignored",
+           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+
+    model.updateValues({43, 44}, {rawDb(-30.0f), rawDb(-15.0f)});
+    report("zero-source 8000 compression pair follows active slice context",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -15.0f));
+}
+
+void testSparseSliceIdsUseManifestDerivedWaveformBase()
+{
+    MeterModel model;
+    model.defineMeter(slcMeter(37, 1));
+    model.defineMeter(txMeter(44, "SC_MIC", "dBFS", 9));
+    model.defineMeter(txMeter(45, "COMPPEAK", "dBFS", 9));
+
+    model.setActiveTxSlice(1);
+    model.updateValues({44, 45}, {rawDb(-42.0f), rawDb(-22.0f)});
+
+    report("sparse slice IDs use manifest-derived TX waveform base",
            model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
 }
 
@@ -239,6 +336,10 @@ int main(int argc, char** argv)
     testAfterEqRequiresCompPeak();
     testCompPeakMinusAfterEqDrivesGauge();
     testCompPeakMinusScMicDrivesGaugeWhenAfterEqMissing();
+    testActiveTxSliceSelects6000CompressionPair();
+    testActiveTxSliceSelects8000CompressionPair();
+    testZeroSource8000MetersUseSliceContext();
+    testSparseSliceIdsUseManifestDerivedWaveformBase();
     testScMicCompressionDerivationIsOrderIndependent();
     testAfterEqPreferredOverScMicWhenBothAreDefined();
     testAfterEqDefinitionDoesNotFallbackToScMicWithoutAfterEqValue();


### PR DESCRIPTION
## Summary

This PR fixes the compression gauge on multi-slice sessions by resolving TX compression meters against the active TX slice instead of using last-match-wins global meter IDs.

The implementation now tracks `COMPPEAK`, `AFTEREQ`, and `SC_MIC` by TX waveform source when the radio provides explicit per-slice source indices, and by manifest slice context for repeated `TX- num=0` blocks seen on 8000-series captures. `RadioModel` keeps `MeterModel` updated with the active TX slice so runtime TX reassignment selects the correct meter pair without reconnecting.

## Investigation Notes

Issue #2040 matches our FLEX-6600 findings. The 6600 manifest repeats TX waveform blocks per slice, with observed `SC_MIC` / `COMPPEAK` pairs such as `22/23`, `44/45`, `66/67`, and `88/89`. Those numeric IDs are session-specific manifest slots, not API contracts. The old scalar indexes bound to the highest-numbered slice, so any other active TX slice could publish VITA meter values that were silently ignored.

For 6000-series radios without `AFTEREQ`, the derived gauge uses active-slice `SC_MIC` and `COMPPEAK`:

```text
compression_lift_db = max(0, COMPPEAK - SC_MIC)
display_db = -clamp(compression_lift_db, 0, 25)
```

For 8000-series radios with `AFTEREQ`, the derived gauge uses active-slice `AFTEREQ` and `COMPPEAK`:

```text
compression_lift_db = max(0, COMPPEAK - AFTEREQ)
display_db = -clamp(compression_lift_db, 0, 25)
```

The 8400M validation logs showed slice 0 using `AFTEREQ 24` + `COMPPEAK 25` and slice 1 using `AFTEREQ 47` + `COMPPEAK 48`, with compression activity on both slices after TX reassignment.

## Changes

- Replace scalar compression meter indexes with per-source and per-slice maps in `MeterModel`.
- Add active TX slice tracking from `RadioModel` into `MeterModel`.
- Clear stale compression state when the active TX slice changes or compression meter definitions are removed.
- Add throttled meter diagnostics showing selected reference meter, `COMPPEAK`, active slice, source index, freshness, lift, display value, and availability.
- Add unit tests for 6000-series explicit source mapping, 8000-series explicit source mapping, 8000-series repeated `TX- num=0` mapping, sparse slice IDs, removal handling, freshness gating, and no-fallback behavior.
- Update meter documentation with current formulas, FPS notes, and multi-slice resolution rules.

## Validation

- Rebasing branch onto latest `origin/main` at `c215b4c` completed cleanly.
- `cmake --build build -j 10`
- `./build/meter_model_test`
- `git diff --check`
- Manual 8400M log review confirmed both slice 0 and slice 1 resolve active-slice compression pairs and show live compression values.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat