### PR TITLE
[memory] Restore repeater offset, tone details on memory recall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,7 @@ set(CORE_SOURCES
     src/core/DxccColorProvider.cpp
     src/core/SleepInhibitor.cpp
     src/core/MemoryCsvCompat.cpp
+    src/core/MemoryRecallPolicy.cpp
 )
 
 if(APPLE)
@@ -1144,6 +1145,13 @@ add_executable(meter_model_test
 target_include_directories(meter_model_test PRIVATE src)
 target_link_libraries(meter_model_test PRIVATE Qt6::Core)
 set_target_properties(meter_model_test PROPERTIES AUTOMOC ON)
+
+add_executable(memory_recall_policy_test
+    tests/memory_recall_policy_test.cpp
+    src/core/MemoryRecallPolicy.cpp
+)
+target_include_directories(memory_recall_policy_test PRIVATE src)
+target_link_libraries(memory_recall_policy_test PRIVATE Qt6::Core)
 
 # Help guide search tests - needs QApplication + Widgets.
 add_executable(help_dialog_test

--- a/src/core/MemoryRecallPolicy.cpp
+++ b/src/core/MemoryRecallPolicy.cpp
@@ -1,0 +1,58 @@
+#include "core/MemoryRecallPolicy.h"
+
+#include <QStringList>
+
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+QString normalizedRepeaterDirection(const QString& direction)
+{
+    const QString normalized = direction.trimmed().toLower();
+    if (normalized == "up" || normalized == "down" || normalized == "simplex")
+        return normalized;
+    return {};
+}
+
+} // namespace
+
+double memoryRepeaterTxOffsetFreq(const MemoryEntry& memory)
+{
+    const QString direction = normalizedRepeaterDirection(memory.offsetDir);
+    const double offsetMhz = std::abs(memory.repeaterOffset);
+    if (offsetMhz == 0.0)
+        return 0.0;
+    if (direction == "up")
+        return offsetMhz;
+    if (direction == "down")
+        return -offsetMhz;
+    return 0.0;
+}
+
+QString buildMemoryRecallSliceFixupCommand(int sliceId, const MemoryEntry& memory)
+{
+    QStringList fields;
+
+    const QString direction = normalizedRepeaterDirection(memory.offsetDir);
+    if (!direction.isEmpty()) {
+        const double offsetMhz = std::abs(memory.repeaterOffset);
+        fields << QString("repeater_offset_dir=%1").arg(direction);
+        fields << QString("fm_repeater_offset_freq=%1").arg(offsetMhz, 0, 'f', 6);
+        fields << QString("tx_offset_freq=%1")
+            .arg(memoryRepeaterTxOffsetFreq(memory), 0, 'f', 6);
+    }
+
+    const QString toneMode = memory.toneMode.trimmed().toLower();
+    if (!toneMode.isEmpty())
+        fields << QString("fm_tone_mode=%1").arg(toneMode);
+    if (!toneMode.isEmpty() || memory.toneValue > 0.0)
+        fields << QString("fm_tone_value=%1").arg(memory.toneValue, 0, 'f', 1);
+
+    if (fields.isEmpty())
+        return {};
+    return QString("slice set %1 %2").arg(sliceId).arg(fields.join(' '));
+}
+
+} // namespace AetherSDR

--- a/src/core/MemoryRecallPolicy.h
+++ b/src/core/MemoryRecallPolicy.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "models/MemoryEntry.h"
+
+namespace AetherSDR {
+
+double memoryRepeaterTxOffsetFreq(const MemoryEntry& memory);
+QString buildMemoryRecallSliceFixupCommand(int sliceId, const MemoryEntry& memory);
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10,6 +10,7 @@
 #include "PanLayoutDialog.h"
 #include "core/CommandParser.h"
 #include "core/LogManager.h"
+#include "core/MemoryRecallPolicy.h"
 #include "models/PanadapterModel.h"
 #include "SpectrumWidget.h"
 #ifdef AETHER_GPU_SPECTRUM
@@ -7064,6 +7065,10 @@ bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPan
     if (it->step > 0)
         m_radioModel.sendCommand(QString("slice set %1 step=%2")
             .arg(sliceId).arg(it->step));
+    const QString repeaterFixup =
+        AetherSDR::buildMemoryRecallSliceFixupCommand(sliceId, it.value());
+    if (!repeaterFixup.isEmpty())
+        m_radioModel.sendCommand(repeaterFixup);
     return true;
 }
 

--- a/src/models/MemoryEntry.h
+++ b/src/models/MemoryEntry.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+struct MemoryEntry {
+    int     index{-1};
+    QString group;
+    QString owner;
+    double  freq{0.0};
+    QString name;
+    QString mode;
+    int     step{100};
+    QString offsetDir;       // "simplex", "up", "down"
+    double  repeaterOffset{0.0};
+    QString toneMode;        // "off", "ctcss_tx", ...
+    double  toneValue{0.0};
+    bool    squelch{false};
+    int     squelchLevel{0};
+    int     rxFilterLow{0};
+    int     rxFilterHigh{0};
+    int     rttyMark{2125};
+    int     rttyShift{170};
+    int     diglOffset{2210};
+    int     diguOffset{1500};
+};
+
+} // namespace AetherSDR

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -17,6 +17,7 @@
 #include "DvkModel.h"
 #include "UsbCableModel.h"
 #include "DaxIqModel.h"
+#include "MemoryEntry.h"
 
 #include <QObject>
 #include <QString>
@@ -26,31 +27,6 @@
 #include <QSet>
 #include <functional>
 
-namespace AetherSDR {
-
-struct MemoryEntry {
-    int     index{-1};
-    QString group;
-    QString owner;
-    double  freq{0.0};
-    QString name;
-    QString mode;
-    int     step{100};
-    QString offsetDir;       // "simplex", "up", "down"
-    double  repeaterOffset{0.0};
-    QString toneMode;        // "off", "ctcss_tx", ...
-    double  toneValue{0.0};
-    bool    squelch{false};
-    int     squelchLevel{0};
-    int     rxFilterLow{0};
-    int     rxFilterHigh{0};
-    int     rttyMark{2125};
-    int     rttyShift{170};
-    int     diglOffset{2210};
-    int     diguOffset{1500};
-};
-
-} // namespace AetherSDR
 #include <QTimer>
 #include <QElapsedTimer>
 

--- a/tests/memory_recall_policy_test.cpp
+++ b/tests/memory_recall_policy_test.cpp
@@ -1,0 +1,67 @@
+#include "core/MemoryRecallPolicy.h"
+
+#include <QString>
+
+#include <iostream>
+
+namespace {
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition)
+        std::cerr << "FAIL: " << message << '\n';
+    return condition;
+}
+
+} // namespace
+
+int main()
+{
+    bool ok = true;
+
+    AetherSDR::MemoryEntry up;
+    up.offsetDir = "up";
+    up.repeaterOffset = 0.1;
+    up.toneMode = "ctcss_tx";
+    up.toneValue = 88.5;
+    ok &= expect(AetherSDR::memoryRepeaterTxOffsetFreq(up) == 0.1,
+                 "up repeater offset produces positive tx_offset_freq");
+    ok &= expect(AetherSDR::buildMemoryRecallSliceFixupCommand(3, up)
+                     == "slice set 3 repeater_offset_dir=up fm_repeater_offset_freq=0.100000 "
+                        "tx_offset_freq=0.100000 fm_tone_mode=ctcss_tx fm_tone_value=88.5",
+                 "up repeater memory builds complete slice fixup command");
+
+    AetherSDR::MemoryEntry down;
+    down.offsetDir = "DOWN";
+    down.repeaterOffset = -0.6;
+    down.toneMode = "OFF";
+    down.toneValue = 0.0;
+    ok &= expect(AetherSDR::memoryRepeaterTxOffsetFreq(down) == -0.6,
+                 "down repeater offset produces negative tx_offset_freq");
+    ok &= expect(AetherSDR::buildMemoryRecallSliceFixupCommand(7, down)
+                     == "slice set 7 repeater_offset_dir=down fm_repeater_offset_freq=0.600000 "
+                        "tx_offset_freq=-0.600000 fm_tone_mode=off fm_tone_value=0.0",
+                 "down repeater memory normalizes direction, magnitude, and tone mode");
+
+    AetherSDR::MemoryEntry simplex;
+    simplex.offsetDir = "simplex";
+    simplex.repeaterOffset = 0.6;
+    ok &= expect(AetherSDR::memoryRepeaterTxOffsetFreq(simplex) == 0.0,
+                 "simplex memory clears tx_offset_freq");
+    ok &= expect(AetherSDR::buildMemoryRecallSliceFixupCommand(1, simplex)
+                     == "slice set 1 repeater_offset_dir=simplex fm_repeater_offset_freq=0.600000 "
+                        "tx_offset_freq=0.000000",
+                 "simplex memory still clears stale repeater offset state");
+
+    AetherSDR::MemoryEntry toneOnly;
+    toneOnly.toneValue = 123.0;
+    ok &= expect(AetherSDR::buildMemoryRecallSliceFixupCommand(2, toneOnly)
+                     == "slice set 2 fm_tone_value=123.0",
+                 "tone value can be fixed up even when tone mode is absent");
+
+    AetherSDR::MemoryEntry empty;
+    ok &= expect(AetherSDR::buildMemoryRecallSliceFixupCommand(2, empty).isEmpty(),
+                 "memory without repeater or tone details does not emit a fixup command");
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Reapply recalled FM repeater direction, repeater offset, and CTCSS tone settings after `memory apply`
- Derive `tx_offset_freq` from the recalled memory direction/offset so stale transmit offsets are cleared
- Add a focused memory recall policy test covering up, down, simplex, and tone fix-up command generation

## Root Cause

The radio restores memory fields like repeater direction and offset during recall, but the derived slice field `tx_offset_freq` can remain stale. Both quick recall and the Memory dialog route through `MainWindow::activateMemorySpot()`, so the fix-up lives there and applies to both paths.

## Validation

- `./build/memory_recall_policy_test`
- `cmake --build build -j 10`
- User confirmed recalled repeater memories now work correctly on radio

Fixes #1871
Fixes #1965

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
