### PR TITLE
Fix Resampler heap corruption when input block exceeds r8b MaxInLen

### DIFF
--- a/src/core/Resampler.cpp
+++ b/src/core/Resampler.cpp
@@ -7,6 +7,7 @@ namespace AetherSDR {
 Resampler::Resampler(double srcRate, double dstRate, int maxBlockSamples)
     : m_srcRate(srcRate)
     , m_dstRate(dstRate)
+    , m_maxBlockSamples(maxBlockSamples)
     , m_resampler(std::make_unique<r8b::CDSPResampler24>(srcRate, dstRate, maxBlockSamples))
 {
     m_inBuf.reserve(maxBlockSamples);
@@ -17,6 +18,15 @@ Resampler::~Resampler() = default;
 QByteArray Resampler::process(const float* in, int numSamples)
 {
     if (numSamples <= 0) return {};
+
+    // r8b does not bounds-check against aMaxInLen; exceeding it silently
+    // overflows internal filter buffers. Chunk so each call stays within limit.
+    if (numSamples > m_maxBlockSamples) {
+        QByteArray result;
+        for (int offset = 0; offset < numSamples; offset += m_maxBlockSamples)
+            result.append(process(in + offset, std::min(numSamples - offset, m_maxBlockSamples)));
+        return result;
+    }
 
     // Convert float32 → double
     m_inBuf.resize(numSamples);
@@ -41,6 +51,13 @@ QByteArray Resampler::processStereoToMono(const float* stereoIn, int numStereoFr
 {
     if (numStereoFrames <= 0) return {};
 
+    if (numStereoFrames > m_maxBlockSamples) {
+        QByteArray result;
+        for (int offset = 0; offset < numStereoFrames; offset += m_maxBlockSamples)
+            result.append(processStereoToMono(stereoIn + offset * 2, std::min(numStereoFrames - offset, m_maxBlockSamples)));
+        return result;
+    }
+
     // Downmix stereo → mono
     m_inBuf.resize(numStereoFrames);
     for (int i = 0; i < numStereoFrames; ++i)
@@ -63,6 +80,13 @@ QByteArray Resampler::processStereoToMono(const float* stereoIn, int numStereoFr
 QByteArray Resampler::processMonoToStereo(const float* monoIn, int numSamples)
 {
     if (numSamples <= 0) return {};
+
+    if (numSamples > m_maxBlockSamples) {
+        QByteArray result;
+        for (int offset = 0; offset < numSamples; offset += m_maxBlockSamples)
+            result.append(processMonoToStereo(monoIn + offset, std::min(numSamples - offset, m_maxBlockSamples)));
+        return result;
+    }
 
     // Convert float32 → double
     m_inBuf.resize(numSamples);
@@ -89,6 +113,13 @@ QByteArray Resampler::processMonoToStereo(const float* monoIn, int numSamples)
 QByteArray Resampler::processStereoToStereo(const float* stereoIn, int numStereoFrames)
 {
     if (numStereoFrames <= 0) return {};
+
+    if (numStereoFrames > m_maxBlockSamples) {
+        QByteArray result;
+        for (int offset = 0; offset < numStereoFrames; offset += m_maxBlockSamples)
+            result.append(processStereoToStereo(stereoIn + offset * 2, std::min(numStereoFrames - offset, m_maxBlockSamples)));
+        return result;
+    }
 
     // Downmix stereo → mono, resample, duplicate back to stereo
     m_inBuf.resize(numStereoFrames);

--- a/src/core/Resampler.h
+++ b/src/core/Resampler.h
@@ -41,6 +41,7 @@ public:
 private:
     double m_srcRate;
     double m_dstRate;
+    int    m_maxBlockSamples;
     std::unique_ptr<r8b::CDSPResampler24> m_resampler;
     std::vector<double> m_inBuf;   // float32 → double conversion buffer
 };


### PR DESCRIPTION
## Problem

`r8b::CDSPResampler24` pre-allocates its internal filter buffers (`TmpBufs`) to
`aMaxInLen` at construction time. The library **does not bounds-check** the
`l` parameter on subsequent `process()` calls — if `l > aMaxInLen`, it silently
overflows those pre-allocated buffers and corrupts adjacent heap memory.

`Resampler` was constructed with the default `maxBlockSamples = 4096`, which
equals approximately 170 ms of audio at 24 kHz (the RADE TX sample rate). The
overflow guard was never stored, so there was no way to enforce it at call sites.

### How the overflow was triggered in practice

The TX audio path reads mic data via `QAudioSource::readAll()` inside
`onTxAudioReady()`. `readAll()` returns **all data accumulated in the OS audio
buffer since the last call** — not just one fixed-size block.

When the Qt event loop is stalled for longer than ~170 ms (for example, while
processing a burst of DX cluster or POTA spot messages, or during heavy UI
redraws), mic data accumulates in the PulseAudio/PipeWire server-side buffer.
On resume, the single `readAll()` call returns a block that can be several
hundred milliseconds deep — 2–3× the r8b `MaxInLen` limit.

When RADE mode is active on the TX slice, `onTxAudioReady()` runs continuously
regardless of MOX state (by design, for zero-latency key-up). This kept the TX
resampler active and accumulating data even while not transmitting, making it
reachable on any event loop stall.

### Observed crash signature

```
malloc(): invalid size (unsorted)
Aborted (core dumped)
```

This is the glibc allocator detecting corrupted free-chunk metadata in the
unsorted bin. The corruption itself happened inside r8b's `TmpBufs` overflow;
the detection was triggered by the next `QByteArray` allocation in
`processStereoToMono()`. Three instances were recorded on 2026-04-26 at
07:59, 08:46, and 19:23 CDT on a FLEX-8400 running firmware v4.1.5.39794.

## Fix

Store `maxBlockSamples` as `m_maxBlockSamples` in `Resampler` so it is
available at call time. Add an overflow guard at the top of all four
`process*()` methods:

```cpp
if (numSamples > m_maxBlockSamples) {
    QByteArray result;
    for (int offset = 0; offset < numSamples; offset += m_maxBlockSamples)
        result.append(process(in + offset, std::min(numSamples - offset, m_maxBlockSamples)));
    return result;
}
```

Each method recurses into itself with chunks ≤ `m_maxBlockSamples`. Because
`r8b::CDSPResampler24` maintains its filter state across calls on the same
instance, chunking is transparent to output quality — the resampled stream is
continuous across chunk boundaries.

Stereo methods use `offset * 2` for pointer arithmetic to account for
interleaved L/R samples.

## Changes

- `src/core/Resampler.h` — add `int m_maxBlockSamples` to private section
- `src/core/Resampler.cpp` — store `maxBlockSamples` in constructor init list;
  add overflow guard to `process()`, `processStereoToMono()`,
  `processMonoToStereo()`, and `processStereoToStereo()`

## Testing

Tested on Linux (Arch) with a FLEX-8400, firmware v4.1.5.39794, RADE mode
active on the TX slice (no transmission — MOX was not keyed).

To reliably reproduce a block larger than the 170 ms / 4096-frame threshold,
the process was frozen with `SIGSTOP` for 500 ms then resumed with `SIGCONT`:

```bash
pid=$(pgrep -x AetherSDR)
kill -SIGSTOP $pid
sleep 0.5
kill -SIGCONT $pid
```

This forces PulseAudio/PipeWire to accumulate ~500 ms of mic data in the
server-side buffer. On resume, `readAll()` returns a single ~12 000-frame
block — approximately 3× the old `MaxInLen` limit. Under the same conditions
that produced three hard crashes on the unpatched binary, the patched binary
resumed cleanly with no crash and no audio artifacts. The test was repeated
multiple times consecutively with consistent results.