### PR TITLE
[bug] Fix Flex TCXO frequency offset calibration

### DIFF
--- a/docs/tx-audio-signal-path.md
+++ b/docs/tx-audio-signal-path.md
@@ -246,6 +246,54 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 - **Unit conversion**: dBm meters (FWDPWR) need watts = 10^(dBm/10)/1000.
   SWR is raw. degC/degF use raw/64.0f. Volts/Amps use raw/1024.0f.
 
+## Agent Notes: 10 MHz TXO Calibration
+
+This is not part of the TX audio chain, but it is a related FlexRadio protocol
+lesson from issues #1237/#2095 and belongs somewhere agents will check before
+guessing at radio commands.
+
+- **Do not use `radio calibrate`** for the Radio Setup → RX frequency-offset
+  Start button. FLEX-6600 firmware v4.1.5 rejects it with `0x50000016`
+  (`unknown command`).
+- **Do not hide calibration when GPSDO is present**. SmartSDR/Mac still exposes
+  the frequency-offset controls with a GPSDO installed. Let the operator choose
+  the oscillator/reference source (`TCXO`, `GPSDO`, `External`, or `Auto`) rather
+  than deciding that calibration is unnecessary.
+- **Use the SmartSDR/FlexLib command sequence**:
+  1. `radio set cal_freq=<MHz>`
+  2. `radio set freq_error_ppb=0`
+  3. `radio pll_start`
+- **Second source verification**: the reporter's SmartSDR TCP capture showed
+  `radio set freq_error_ppb=0` followed by `radio pll_start`, with the radio
+  broadcasting `pll_done=0` while running and `pll_done=1 freq_error_ppb=<value>`
+  when complete. The official FlexLib API v2.10.1 source confirms the same
+  command: `Radio.StartOffsetEnabled=false` sends `radio pll_start`, while
+  `CalFreq`, `FreqErrorPPB`, and `pll_done` are parsed as radio status fields.
+- **Completion signal**: track `radio` status messages containing `pll_done`.
+  `pll_done=0` means calibration has started/in progress. `pll_done=1` means the
+  Start button can be re-enabled; if `freq_error_ppb` is present on that status,
+  it is the completed calibration result to show/log.
+- **Event-order gotcha**: resetting `freq_error_ppb` can produce stale
+  `pll_done=1` status before the new `radio pll_start` run has actually reported
+  `pll_done=0`. Do not treat `pll_done=1` as completion for the active button
+  press until `pll_done=0` has been observed for that run; otherwise the UI can
+  complete on the previous/zeroed value and then get stuck showing
+  `Calibrating...` when the delayed command response arrives.
+- **Timeout gotcha**: make timeout callbacks run-specific. A prior run's
+  20-second timer can fire after that run completed and during a later
+  calibration. If the callback only checks a shared `active` flag, it can mark
+  the newer run as `No response` before the radio's real `pll_done=1` result
+  arrives.
+- **Debug workflow**: ask reporters to enable protocol logging and capture the
+  full lifecycle, not just TX/RX command lines:
+  `QT_LOGGING_RULES="aether.protocol.debug=true" ./AetherSDR`. Useful breadcrumbs
+  are request, `pll_start` response code/body, every `pll_done` transition,
+  final `freq_error_ppb`, and timeout if `pll_done=1` never arrives.
+- **Capture gotcha**: Flex command traffic is TCP, normally port 4992. UDP ports
+  4993/4994 are VITA/discovery/data and will not contain the command stream.
+  If a Wireshark file has no TCP stream, it cannot prove which command SmartSDR
+  sent.
+
 ## Future: TX Audio Path Meter Panel
 
 A dedicated panel showing all TX-chain meters as a vertical stack of horizontal

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -3,6 +3,7 @@
 #include "ComboStyle.h"
 #include "models/RadioModel.h"
 #include "core/AppSettings.h"
+#include "core/LogManager.h"
 #include <QSysInfo>
 #include "core/AudioEngine.h"
 #ifdef HAVE_SERIALPORT
@@ -44,6 +45,10 @@
 #include <QPlainTextEdit>
 #include <QSplitter>
 #include <QHostAddress>
+#include <QDebug>
+#include <QPointer>
+
+#include <memory>
 
 namespace AetherSDR {
 
@@ -1231,65 +1236,209 @@ QWidget* RadioSetupDialog::buildRxTab()
         auto* gvb = new QVBoxLayout(group);
         gvb->setSpacing(4);
 
-        if (m_model->gpsdoPresent()) {
-            auto* lbl = new QLabel("GPSDO is installed. Frequency error correction is not required.");
-            lbl->setStyleSheet("QLabel { color: #00c040; font-size: 12px; }");
-            lbl->setWordWrap(true);
-            gvb->addWidget(lbl);
-        } else {
-            auto* lbl = new QLabel("No GPSDO installed. Manual frequency offset calibration available.");
-            lbl->setStyleSheet("QLabel { color: #c0a000; font-size: 12px; }");
-            lbl->setWordWrap(true);
-            gvb->addWidget(lbl);
+        auto* lbl = new QLabel(m_model->gpsdoPresent()
+            ? "GPSDO installed. Manual frequency offset calibration available."
+            : "Manual frequency offset calibration available.");
+        lbl->setStyleSheet(m_model->gpsdoPresent()
+            ? "QLabel { color: #00c040; font-size: 12px; }"
+            : "QLabel { color: #c0a000; font-size: 12px; }");
+        lbl->setWordWrap(true);
+        gvb->addWidget(lbl);
 
-            // Cal Frequency row
-            auto* calRow = new QHBoxLayout;
-            calRow->setSpacing(4);
-            auto* calLbl = new QLabel("Cal Frequency (MHz):");
-            calLbl->setStyleSheet(kLabelStyle);
-            calRow->addWidget(calLbl);
-            auto* calEdit = new QLineEdit(QString::number(m_model->calFreqMhz(), 'f', 6));
-            calEdit->setStyleSheet(kEditStyle);
-            calEdit->setFixedWidth(100);
-            connect(calEdit, &QLineEdit::editingFinished, this, [this, calEdit] {
-                m_model->sendCommand(
-                    "radio set cal_freq=" + calEdit->text());
-            });
-            calRow->addWidget(calEdit);
+        auto* offsetGrid = new QGridLayout;
+        offsetGrid->setSpacing(6);
 
-            auto* startBtn = new QPushButton("Start");
-            startBtn->setStyleSheet(kTogStyle);
-            startBtn->setFixedWidth(60);
-            connect(startBtn, &QPushButton::clicked, this, [this, calEdit] {
-                // Set cal_freq and trigger calibration
-                m_model->sendCommand(
-                    "radio set cal_freq=" + calEdit->text());
-                m_model->sendCommand("radio calibrate");
-            });
-            calRow->addWidget(startBtn);
-            calRow->addStretch(1);
-            gvb->addLayout(calRow);
+        // Cal Frequency row
+        auto* calLbl = new QLabel("Cal Frequency (MHz):");
+        calLbl->setStyleSheet(kLabelStyle);
+        offsetGrid->addWidget(calLbl, 0, 0);
+        auto* calEdit = new QLineEdit(QString::number(m_model->calFreqMhz(), 'f', 6));
+        calEdit->setStyleSheet(kEditStyle);
+        calEdit->setFixedWidth(100);
+        connect(calEdit, &QLineEdit::editingFinished, this, [this, calEdit] {
+            m_model->sendCommand(
+                "radio set cal_freq=" + calEdit->text());
+        });
+        offsetGrid->addWidget(calEdit, 0, 1);
 
-            // Freq Error PPB row
-            auto* row = new QHBoxLayout;
-            row->setSpacing(4);
-            auto* ppbLbl = new QLabel("Freq Offset (ppb):");
-            ppbLbl->setStyleSheet(kLabelStyle);
-            row->addWidget(ppbLbl);
-            auto* ppbEdit = new QLineEdit(QString::number(m_model->freqErrorPpb()));
-            ppbEdit->setStyleSheet(kEditStyle);
-            ppbEdit->setFixedWidth(80);
-            connect(ppbEdit, &QLineEdit::editingFinished, this, [this, ppbEdit] {
-                m_model->sendCommand(
-                    "radio set freq_error_ppb=" + ppbEdit->text());
+        auto* startBtn = new QPushButton("Start");
+        startBtn->setStyleSheet(kTogStyle);
+        startBtn->setFixedWidth(60);
+        auto* calStatus = new QLabel;
+        calStatus->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; }");
+        calStatus->setMinimumWidth(130);
+
+        auto calibrationActive = std::make_shared<bool>(false);
+        auto pllRunningSeen = std::make_shared<bool>(false);
+        auto calibrationRun = std::make_shared<int>(0);
+        auto setCalStatus = [calStatus](const QString& text, const QString& color) {
+            calStatus->setText(text);
+            calStatus->setStyleSheet(
+                QStringLiteral("QLabel { color: %1; font-size: 11px; }").arg(color));
+        };
+
+        connect(startBtn, &QPushButton::clicked, this,
+                [this, calEdit, startBtn, calStatus, calibrationActive, pllRunningSeen,
+                 calibrationRun, setCalStatus] {
+            const QString calFreq = calEdit->text().trimmed();
+            if (calFreq.isEmpty()) {
+                setCalStatus("Enter cal frequency", "#e0a050");
+                return;
+            }
+
+            const int runId = ++(*calibrationRun);
+            *calibrationActive = true;
+            *pllRunningSeen = false;
+            startBtn->setEnabled(false);
+            startBtn->setText("Busy");
+            setCalStatus("Starting...", "#8aa8c0");
+
+            qCDebug(lcProtocol) << "RadioSetupDialog: frequency calibration requested"
+                                 << "cal_freq=" << calFreq
+                                 << "reset_freq_error_ppb=0"
+                                 << "run_id=" << runId;
+            m_model->sendCommand("radio set cal_freq=" + calFreq);
+            m_model->sendCommand("radio set freq_error_ppb=0");
+
+            QPointer<RadioSetupDialog> dialog(this);
+            QPointer<QPushButton> startGuard(startBtn);
+            QPointer<QLabel> statusGuard(calStatus);
+            // FlexLib's StartOffsetEnabled=false path starts calibration with radio pll_start.
+            m_model->sendCmdPublic("radio pll_start",
+                [dialog, startGuard, statusGuard, calibrationActive, calibrationRun, runId](
+                    int code, const QString& body) {
+                if (!dialog)
+                    return;
+                QMetaObject::invokeMethod(dialog, [dialog, startGuard, statusGuard,
+                                                   calibrationActive, calibrationRun, runId,
+                                                   code, body] {
+                    if (!dialog || !startGuard || !statusGuard)
+                        return;
+                    if (!*calibrationActive || *calibrationRun != runId) {
+                        qCDebug(lcProtocol)
+                            << "RadioSetupDialog: ignoring radio pll_start response for inactive calibration"
+                            << "run_id=" << runId
+                            << "current_run_id=" << *calibrationRun
+                            << "code" << code << "body:" << body;
+                        return;
+                    }
+                    if (code == 0) {
+                        statusGuard->setText("Calibrating...");
+                        statusGuard->setStyleSheet(
+                            "QLabel { color: #00c8ff; font-size: 11px; }");
+                        qCDebug(lcProtocol)
+                            << "RadioSetupDialog: radio pll_start accepted";
+                        return;
+                    }
+
+                    *calibrationActive = false;
+                    startGuard->setEnabled(true);
+                    startGuard->setText("Start");
+                    statusGuard->setText(QString("Error 0x%1")
+                        .arg(code, 0, 16).toUpper());
+                    statusGuard->setStyleSheet(
+                        "QLabel { color: #ff7070; font-size: 11px; }");
+                    qCWarning(lcProtocol)
+                        << "RadioSetupDialog: radio pll_start failed: code"
+                        << Qt::hex << code << "body:" << body;
+                });
             });
-            row->addWidget(ppbEdit);
-            auto* ppbUnitLbl = new QLabel("ppb");
-            ppbUnitLbl->setStyleSheet(kLabelStyle);
-            row->addWidget(ppbUnitLbl);
-            row->addStretch(1);
-            gvb->addLayout(row);
-        }
+
+            QTimer::singleShot(20000, this,
+                [startGuard, statusGuard, calibrationActive, calibrationRun, runId] {
+                if (!startGuard || !statusGuard || !*calibrationActive
+                    || *calibrationRun != runId)
+                    return;
+                *calibrationActive = false;
+                startGuard->setEnabled(true);
+                startGuard->setText("Start");
+                statusGuard->setText("No response");
+                statusGuard->setStyleSheet(
+                    "QLabel { color: #ff7070; font-size: 11px; }");
+                qCWarning(lcProtocol)
+                    << "RadioSetupDialog: frequency calibration timed out waiting for pll_done=1"
+                    << "run_id=" << runId;
+            });
+        });
+        offsetGrid->addWidget(startBtn, 0, 2);
+        offsetGrid->addWidget(calStatus, 0, 3);
+
+        // Freq Error PPB row
+        auto* ppbLbl = new QLabel("Freq Offset (ppb):");
+        ppbLbl->setStyleSheet(kLabelStyle);
+        offsetGrid->addWidget(ppbLbl, 1, 0);
+        auto* ppbEdit = new QLineEdit(QString::number(m_model->freqErrorPpb()));
+        ppbEdit->setStyleSheet(kEditStyle);
+        ppbEdit->setFixedWidth(80);
+        connect(ppbEdit, &QLineEdit::editingFinished, this, [this, ppbEdit] {
+            m_model->sendCommand(
+                "radio set freq_error_ppb=" + ppbEdit->text());
+        });
+        offsetGrid->addWidget(ppbEdit, 1, 1);
+        auto* ppbUnitLbl = new QLabel("ppb");
+        ppbUnitLbl->setStyleSheet(kLabelStyle);
+        offsetGrid->addWidget(ppbUnitLbl, 1, 2);
+        offsetGrid->setColumnStretch(3, 1);
+        gvb->addLayout(offsetGrid);
+
+        connect(m_model, &RadioModel::infoChanged, this, [this, calEdit, ppbEdit] {
+            if (!calEdit->hasFocus())
+                calEdit->setText(QString::number(m_model->calFreqMhz(), 'f', 6));
+            if (!ppbEdit->hasFocus())
+                ppbEdit->setText(QString::number(m_model->freqErrorPpb()));
+        });
+
+        connect(m_model, &RadioModel::statusReceived, this,
+                [startBtn, calStatus, calibrationActive, pllRunningSeen](
+                    const QString& object, const QMap<QString, QString>& kvs) {
+            if (object != QStringLiteral("radio") || !kvs.contains(QStringLiteral("pll_done")))
+                return;
+
+            const QString pllDone = kvs.value(QStringLiteral("pll_done"));
+            const QString freqError = kvs.value(QStringLiteral("freq_error_ppb"));
+            const QString calFreq = kvs.value(QStringLiteral("cal_freq"));
+            qCDebug(lcProtocol)
+                << "RadioSetupDialog: frequency calibration status"
+                << "pll_done=" << pllDone
+                << "freq_error_ppb=" << freqError
+                << "cal_freq=" << calFreq
+                << "active=" << *calibrationActive
+                << "running_seen=" << *pllRunningSeen;
+
+            if (!*calibrationActive)
+                return;
+
+            if (pllDone == QStringLiteral("0")) {
+                *pllRunningSeen = true;
+                calStatus->setText("Calibrating...");
+                calStatus->setStyleSheet(
+                    "QLabel { color: #00c8ff; font-size: 11px; }");
+                return;
+            }
+
+            if (pllDone == QStringLiteral("1") && !*pllRunningSeen) {
+                qCDebug(lcProtocol)
+                    << "RadioSetupDialog: ignoring pll_done=1 before pll_done=0 for active calibration"
+                    << "freq_error_ppb=" << freqError
+                    << "cal_freq=" << calFreq;
+                return;
+            }
+
+            if (pllDone == QStringLiteral("1")) {
+                *calibrationActive = false;
+                startBtn->setEnabled(true);
+                startBtn->setText("Start");
+                calStatus->setText(freqError.isEmpty()
+                    ? QStringLiteral("Complete")
+                    : QStringLiteral("Complete (%1 ppb)").arg(freqError));
+                calStatus->setStyleSheet(
+                    "QLabel { color: #00e060; font-size: 11px; }");
+                qCDebug(lcProtocol)
+                    << "RadioSetupDialog: frequency calibration completed"
+                    << "freq_error_ppb=" << freqError
+                    << "cal_freq=" << calFreq;
+            }
+        });
 
         vbox->addWidget(group);
     }


### PR DESCRIPTION

<img width="932" height="764" alt="Screenshot 2026-04-27 at 6 38 10 PM" src="https://github.com/user-attachments/assets/39aa9eee-bfde-4910-8f02-542108e3a392" />

## Summary

This PR fixes the Radio Setup → RX → Frequency Offset calibration workflow for FlexRadio hardware and documents the protocol lesson so future follow-up agents do not rediscover the same command mismatch.

The existing UI exposed a Start button for manual frequency-offset calibration on radios without a GPSDO, but it sent `radio calibrate`. On the reporter's FLEX-6600 running firmware v4.1.5, that command returns `0x50000016` (`unknown command`), so the button could not actually start calibration.

Issue #2095 supplied a SmartSDR TCP command capture showing the working sequence:

1. `radio set freq_error_ppb=0`
2. `radio pll_start`
3. Radio status broadcasts `pll_done=0` while calibration is running.
4. Radio status broadcasts `pll_done=1 freq_error_ppb=<value> cal_freq=<value>` when calibration completes.

I also verified the command against a second source: the official FlexLib API v2.10.1 source. In `Radio.cs`, `StartOffsetEnabled=false` sends `radio pll_start`, and the same radio status fields (`cal_freq`, `freq_error_ppb`, and `pll_done`) are parsed from status updates.

Fixes #1237.
Fixes #2095.

## What Changed

### Calibration command path

- Replaced the unsupported `radio calibrate` call with the SmartSDR/FlexLib-compatible sequence:
  - `radio set cal_freq=<entered MHz>`
  - `radio set freq_error_ppb=0`
  - `radio pll_start`
- Uses `sendCmdPublic` for `radio pll_start` so the UI can react to the immediate command response.
- Leaves the user-entered calibration frequency as the explicit source of truth when Start is clicked.

### Completion tracking and user feedback

- Added a small calibration status label beside the Start button.
- Shows `Starting...` immediately after the user starts calibration.
- Shows `Calibrating...` after `radio pll_start` is accepted or when `pll_done=0` arrives.
- Shows `Complete (<ppb> ppb)` when `pll_done=1` arrives with a `freq_error_ppb` value.
- Shows `Complete` if the completion status arrives without a ppb value.
- Shows `Error 0x...` if `radio pll_start` returns a non-zero response.
- Shows `No response` if calibration does not report `pll_done=1` within 20 seconds.
- Keeps the successful completion message visible instead of clearing it after a timer, so the operator can read the measured value and decide whether to enter or adjust the offset.
- Treats completion as a `pll_done=0` then `pll_done=1` transition for the active Start press, rather than accepting the first `pll_done=1` seen after the reset commands.
- Guards the delayed `radio pll_start` command response so it cannot overwrite the label after the active run has already been cleared.
- Makes timeout callbacks run-specific so a prior successful calibration's 20-second timer cannot fire during a later calibration and incorrectly mark the newer run as `No response`.

### GPSDO behavior

- Removed the GPSDO-present gate that hid the manual calibration controls.
- With a GPSDO installed, the dialog now says: `GPSDO installed. Manual frequency offset calibration available.`
- This matches the requested SmartSDR/Mac-style behavior: the operator can manually calibrate TCXO or choose GPSDO/external/auto reference behavior from the adjacent 10 MHz Reference source dropdown.
- The app no longer decides that frequency calibration is unnecessary just because a GPSDO is present.

### Debug visibility

- Added `aether.protocol` debug breadcrumbs for the calibration lifecycle:
  - calibration requested, including `cal_freq` and the reset-to-zero step
  - `radio pll_start` accepted
  - `radio pll_start` failed, including response code/body
  - every `pll_done` status transition observed by the dialog
  - final `freq_error_ppb` and `cal_freq` on completion
  - timeout when `pll_done=1` never arrives
- This gives reporters and maintainers a clean way to verify that the radio accepted the command and that the app observed the expected completion status.

### Live value updates

- The frequency calibration and ppb fields now refresh from `RadioModel::infoChanged` when the user is not actively editing them.
- This lets the completed `freq_error_ppb` value flow back into the field when the radio reports the new state, without overwriting a user in the middle of typing.

### Layout polish

- Reworked the Frequency Offset controls from independent horizontal rows into a small grid.
- The calibration frequency entry, Start button, completion status, frequency offset label, and ppb entry now share consistent columns and visually line up better with the 10 MHz Reference source row.

### Agent documentation

- Added an `Agent Notes: 10 MHz TXO Calibration` section to `docs/tx-audio-signal-path.md`.
- The note records:
  - why `radio calibrate` should not be used
  - why GPSDO-present radios should still expose manual calibration controls
  - the SmartSDR/FlexLib command sequence
  - the `pll_done` completion semantics
  - the recommended debug logging workflow
  - the capture gotcha that Flex command traffic is TCP, normally port 4992, not the UDP VITA/discovery streams

## Why This Fix

The original bug was not a UI-only issue. The button failed because AetherSDR was using a command that the radio firmware does not recognize for this workflow. The reporter's SmartSDR capture and FlexLib both point to `radio pll_start` as the correct start command.

The completion behavior also matters: `radio pll_start` only acknowledges that the radio accepted the command. The actual calibration result arrives later as radio status, so the dialog has to listen for the calibration state transition and report the final `freq_error_ppb` value.

Follow-up testing showed that the radio can broadcast stale `pll_done=1` status immediately after `radio set freq_error_ppb=0`, before the new calibration has actually entered `pll_done=0`. If the UI treats that first `pll_done=1` as completion, it can show the previous or zeroed ppb value, clear its active flag too early, and then get stuck on `Calibrating...` when the delayed `pll_start` response arrives. This PR now waits for `pll_done=0` for the active run before accepting `pll_done=1` as completion.

Additional repeated-run testing exposed a second race: a previous run's 20-second timeout can still be pending after that run completed successfully. If the operator starts another calibration before the old timer fires, that stale callback can see the shared active flag from the newer run and incorrectly set the UI to `No response`. The timeout and delayed `pll_start` response callbacks now carry the run id they were created for, so stale callbacks are ignored.

Finally, GPSDO presence should not remove the user's ability to manually calibrate. A GPSDO-equipped radio can still expose manual offset calibration, and SmartSDR/Mac does so. This PR follows that model and lets the operator choose the reference source instead of making that choice implicitly in the dialog.

## User Impact

- The Frequency Offset Start button should now start calibration on affected FlexRadio models.
- Operators can see when calibration is starting, running, failed, timed out, or complete.
- Successful calibration results stay visible until the next calibration/status change.
- Stale pre-run `pll_done=1` updates are ignored, so the Start button stays disabled until the real calibration finishes or times out.
- Stale timeout callbacks from previous runs are ignored, so repeated calibrations do not get marked `No response` before the radio returns the real result.
- GPSDO-equipped radios can still use the manual calibration controls.
- Debug logs now provide enough lifecycle detail to confirm whether calibration fired and completed correctly.

## Validation

- Built successfully with:
  - `cmake --build build --parallel 10`
- Ran the configured CTest suite with:
  - `ctest --test-dir build --output-on-failure -j 10`
- CTest reported no tests were found in this build tree.
- Confirmed `CHANGELOG.md` and generated What's New data are not modified; those files are left for the project maintainer.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
