### PR TITLE
[ux] Polish connect-radio dialog grouping

### DIFF
--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -25,9 +25,12 @@ constexpr int kSourceInterfaceNameRole = Qt::UserRole + 12;
 constexpr int kSourceAddressRole = Qt::UserRole + 13;
 constexpr int kSourceStaleRole = Qt::UserRole + 14;
 
-const char* kHintLabelStyle = "QLabel { color: #8aa8c0; font-size: 11px; }";
-const char* kInfoLabelStyle = "QLabel { color: #9bd1ff; font-size: 11px; }";
-const char* kErrorLabelStyle = "QLabel { color: #ff8f8f; font-size: 11px; }";
+const char* kHintLabelStyle =
+    "QLabel { color: #8aa8c0; font-size: 11px; background: transparent; border: none; }";
+const char* kInfoLabelStyle =
+    "QLabel { color: #9bd1ff; font-size: 11px; background: transparent; border: none; }";
+const char* kErrorLabelStyle =
+    "QLabel { color: #ff8f8f; font-size: 11px; background: transparent; border: none; }";
 
 QJsonObject loadRoutedProfiles()
 {
@@ -132,9 +135,13 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
         "QCommandLinkButton:hover { border-color: #4e6a86; background: #172334; }"
         "QCommandLinkButton:checked { border-color: #66a8ff; background: #1a3046; }";
     const QString calloutStyle =
-        "QFrame { border: 1px solid #304050; border-radius: 8px; background: #121a25; }";
+        "QFrame#connectionCallout { border: 1px solid #304050; border-radius: 8px; "
+        "background: #121a25; }"
+        "QFrame#connectionCallout QLabel { background: transparent; border: none; }"
+        "QFrame#connectionCallout QCheckBox { background: transparent; border: none; }";
     const QString lowBandwidthCheckStyle =
-        "QCheckBox { color: #d7e4f2; spacing: 8px; padding: 2px 0; }"
+        "QCheckBox { color: #d7e4f2; spacing: 8px; padding: 2px 0; "
+        "background: transparent; border: none; }"
         "QCheckBox::indicator { width: 16px; height: 16px; "
         "border: 2px solid #5d748d; border-radius: 3px; background: #0b1520; }"
         "QCheckBox::indicator:hover { border-color: #81abd9; background: #142130; }"
@@ -146,7 +153,9 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     root->setSpacing(10);
 
     auto* titleLabel = new QLabel("Connect to a Radio", this);
-    titleLabel->setStyleSheet("QLabel { color: #e7f1fb; font-size: 18px; font-weight: bold; }");
+    titleLabel->setStyleSheet(
+        "QLabel { color: #e7f1fb; font-size: 18px; font-weight: bold; "
+        "background: transparent; border: none; }");
     root->addWidget(titleLabel);
 
     auto* introLabel = makeWrappedLabel(
@@ -240,12 +249,15 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     emptyLayout->setContentsMargins(0, 0, 0, 0);
     emptyLayout->setSpacing(8);
     auto* emptyCallout = new QFrame(m_localEmptyState);
+    emptyCallout->setObjectName("connectionCallout");
     emptyCallout->setStyleSheet(calloutStyle);
     auto* emptyCalloutLayout = new QVBoxLayout(emptyCallout);
     emptyCalloutLayout->setContentsMargins(14, 14, 14, 14);
     emptyCalloutLayout->setSpacing(8);
     auto* emptyTitle = new QLabel("No local radios found yet", emptyCallout);
-    emptyTitle->setStyleSheet("QLabel { color: #e7f1fb; font-size: 15px; font-weight: bold; }");
+    emptyTitle->setStyleSheet(
+        "QLabel { color: #e7f1fb; font-size: 15px; font-weight: bold; "
+        "background: transparent; border: none; }");
     emptyCalloutLayout->addWidget(emptyTitle);
     emptyCalloutLayout->addWidget(makeWrappedLabel(
         "AetherSDR is still listening for discovery packets. If your station is on a VPN "
@@ -327,23 +339,27 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     m_wanList->setSelectionMode(QAbstractItemView::SingleSelection);
     m_wanList->setWordWrap(true);
     m_wanList->setSpacing(2);
-    m_wanList->setMinimumHeight(220);
+    m_wanList->setMinimumHeight(120);
+    m_wanList->setMaximumHeight(160);
+    m_wanList->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     remoteLayout->addWidget(m_wanList);
     m_smartLinkEmptyLabel = makeWrappedLabel(
         "Remote radios appear here after SmartLink sign-in.",
         kHintLabelStyle);
     remoteLayout->addWidget(m_smartLinkEmptyLabel);
-    auto* wanActionBar = new QWidget(remoteGroup);
+    smartLinkLayout->addWidget(remoteGroup);
+
+    auto* wanActionBar = new QWidget(smartLinkPage);
     auto* wanActionRow = new QHBoxLayout(wanActionBar);
-    wanActionRow->setContentsMargins(0, 6, 18, 0);
+    wanActionRow->setContentsMargins(0, 0, 0, 0);
     wanActionRow->setSpacing(10);
     wanActionRow->addStretch();
     m_wanConnectBtn = new QPushButton("Connect Remote Radio", wanActionBar);
     m_wanConnectBtn->setEnabled(false);
     m_wanConnectBtn->setMinimumWidth(190);
     wanActionRow->addWidget(m_wanConnectBtn);
-    remoteLayout->addWidget(wanActionBar);
-    smartLinkLayout->addWidget(remoteGroup, 1);
+    smartLinkLayout->addWidget(wanActionBar);
+    smartLinkLayout->addStretch(1);
 
     m_modeStack->addWidget(smartLinkPage);
 
@@ -415,12 +431,14 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
 
     // ── Contextual options ────────────────────────────────────────────────
     m_linkOptionsWidget = new QFrame(this);
+    m_linkOptionsWidget->setObjectName("connectionCallout");
     m_linkOptionsWidget->setStyleSheet(calloutStyle);
     auto* optionsLayout = new QVBoxLayout(m_linkOptionsWidget);
     optionsLayout->setContentsMargins(12, 10, 12, 10);
     optionsLayout->setSpacing(6);
     auto* optionsTitle = new QLabel("Connection options for slower links", m_linkOptionsWidget);
-    optionsTitle->setStyleSheet("QLabel { color: #e7f1fb; font-weight: bold; }");
+    optionsTitle->setStyleSheet(
+        "QLabel { color: #e7f1fb; font-weight: bold; background: transparent; border: none; }");
     optionsLayout->addWidget(optionsTitle);
     m_lowBwHintLabel = makeWrappedLabel(QString(), kHintLabelStyle);
     optionsLayout->addWidget(m_lowBwHintLabel);


### PR DESCRIPTION

<img width="872" height="804" alt="Screenshot 2026-04-27 at 7 47 53 PM" src="https://github.com/user-attachments/assets/4661550b-7bbc-461f-a4ea-6fe38fb6c89e" />

## Summary

- Scope the Connect to Radio callout styling so grouped panels keep their borders without giving child labels their own framed backgrounds.
- Make reused label and low-bandwidth checkbox text styles explicitly transparent and borderless for consistent Qt rendering on macOS, Windows, and Linux.
- Tighten the SmartLink remote-radio list height and move the Connect Remote Radio action outside the Remote radios group.

## Details

The dialog previously used a broad `QFrame` stylesheet for the local empty-state and slower-link callout panels. Because `QLabel` inherits from `QFrame`, Qt applied the panel border/background styling to static text labels inside those groups on some platforms. This made labels like “No local radios found yet,” “Connection options for slower links,” and the associated hint text look like nested bordered boxes even though they were already inside a grouped container.

This change gives the callout frames a dedicated object name and scopes the border/background rule to those frames. Child labels and the low-bandwidth checkbox text are now explicitly transparent and borderless, while the checkbox indicator keeps its intentional control styling.

The SmartLink Remote radios group also had a tall list area with the Connect Remote Radio button placed inside the group. The list is now capped to a more compact height, and the connect action sits below the group so the button reads as the next action rather than part of the radio list.

## Validation

- Built successfully on macOS with `cmake --build build -j10`.
- Manually checked the Connect to Radio dialog layout in the built app while iterating on the reported screenshots.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
