### PR TITLE
[ux] Fix CWX Live toggle and Send action

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1146,6 +1146,18 @@ add_executable(cw_sidetone_test
 target_include_directories(cw_sidetone_test PRIVATE src)
 target_link_libraries(cw_sidetone_test PRIVATE Qt6::Core)
 
+add_executable(cwx_panel_test
+    tests/cwx_panel_test.cpp
+    src/gui/CwxPanel.cpp
+    src/gui/CwxPanel.h
+    src/models/CwxModel.cpp
+    src/models/CwxModel.h
+)
+target_include_directories(cwx_panel_test PRIVATE src)
+target_link_libraries(cwx_panel_test PRIVATE
+    Qt6::Core Qt6::Widgets
+)
+
 add_executable(meter_model_test
     tests/meter_model_test.cpp
     src/models/MeterModel.cpp

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -126,8 +126,6 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
     barLayout->setSpacing(4);
 
     m_sendBtn = new QPushButton("Send");
-    m_sendBtn->setCheckable(true);
-    m_sendBtn->setChecked(true);
     m_sendBtn->setStyleSheet(kBtnStyle);
     barLayout->addWidget(m_sendBtn);
 
@@ -159,24 +157,31 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
 
     // ── Connections ─────────────────────────────────────────────
 
-    // Send/Live/Setup toggle — mutual exclusion
+    // Send submits the buffer when Live is off.  If Live is on, it first
+    // returns the panel to safe non-live typing without retransmitting text
+    // that may already have been keyed character-by-character.
     connect(m_sendBtn, &QPushButton::clicked, this, [this]() {
-        m_sendBtn->setChecked(true);
-        m_liveBtn->setChecked(false);
+        const bool wasLive = m_model ? m_model->isLive()
+                                     : (m_liveBtn && m_liveBtn->isChecked());
+        if (m_model)
+            m_model->setLive(false);
+        else if (m_liveBtn)
+            m_liveBtn->setChecked(false);
         m_setupBtn->setChecked(false);
-        if (m_model) m_model->setLive(false);
         showSendView();
+        if (!wasLive)
+            sendBuffer();
     });
-    connect(m_liveBtn, &QPushButton::clicked, this, [this]() {
-        m_sendBtn->setChecked(false);
-        m_liveBtn->setChecked(true);
+    connect(m_liveBtn, &QPushButton::clicked, this, [this](bool on) {
         m_setupBtn->setChecked(false);
-        if (m_model) m_model->setLive(true);
+        if (m_model) m_model->setLive(on);
         showSendView();
     });
     connect(m_setupBtn, &QPushButton::clicked, this, [this]() {
-        m_sendBtn->setChecked(false);
-        m_liveBtn->setChecked(false);
+        if (m_model)
+            m_model->setLive(false);
+        else
+            m_liveBtn->setChecked(false);
         m_setupBtn->setChecked(true);
         showSetupView();
     });
@@ -225,6 +230,11 @@ void CwxPanel::setModel(CwxModel* model)
     m_model = model;
     if (!m_model) return;
 
+    if (m_liveBtn) {
+        QSignalBlocker b(m_liveBtn);
+        m_liveBtn->setChecked(m_model->isLive());
+    }
+
     connect(m_model, &CwxModel::charSent, this, &CwxPanel::onCharSent);
     connect(m_model, &CwxModel::speedChanged, this, &CwxPanel::onSpeedChanged);
     connect(m_model, &CwxModel::macroChanged, this, [this](int idx, const QString& text) {
@@ -243,6 +253,17 @@ void CwxPanel::setModel(CwxModel* model)
         if (m_qskBtn) {
             QSignalBlocker b(m_qskBtn);
             m_qskBtn->setChecked(on);
+        }
+    });
+    connect(m_model, &CwxModel::liveChanged, this, [this](bool on) {
+        if (m_liveBtn) {
+            QSignalBlocker b(m_liveBtn);
+            m_liveBtn->setChecked(on);
+        }
+        if (on) {
+            if (m_setupBtn)
+                m_setupBtn->setChecked(false);
+            showSendView();
         }
     });
 }

--- a/tests/cwx_panel_test.cpp
+++ b/tests/cwx_panel_test.cpp
@@ -1,0 +1,190 @@
+// Focused CWX panel behavior tests.
+// Run: ./build/cwx_panel_test
+
+#include "gui/CwxPanel.h"
+#include "models/CwxModel.h"
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QKeyEvent>
+#include <QPushButton>
+#include <QStringList>
+#include <QTextEdit>
+#include <cstdio>
+#include <string>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-56s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+QPushButton* buttonByText(CwxPanel& panel, const QString& text)
+{
+    const auto buttons = panel.findChildren<QPushButton*>();
+    for (auto* button : buttons) {
+        if (button->text() == text)
+            return button;
+    }
+    return nullptr;
+}
+
+QTextEdit* inputEdit(CwxPanel& panel)
+{
+    const auto edits = panel.findChildren<QTextEdit*>();
+    for (auto* edit : edits) {
+        if (edit->placeholderText() == QLatin1String("Type CW message..."))
+            return edit;
+    }
+    return nullptr;
+}
+
+struct Fixture {
+    CwxModel model;
+    CwxPanel panel{&model};
+    QStringList commands;
+
+    Fixture()
+    {
+        QObject::connect(&model, &CwxModel::commandReady,
+                         [this](const QString& command) {
+                             commands.push_back(command);
+                         });
+    }
+};
+
+bool requireSendWidgets(Fixture& fixture, QPushButton*& send, QPushButton*& live,
+                        QPushButton*& setup, QTextEdit*& input)
+{
+    send = buttonByText(fixture.panel, "Send");
+    live = buttonByText(fixture.panel, "Live");
+    setup = buttonByText(fixture.panel, "Setup");
+    input = inputEdit(fixture.panel);
+
+    const bool ok = send && live && setup && input;
+    report("CWX controls are present", ok);
+    return ok;
+}
+
+QString sendCommand(const QString& text, int block)
+{
+    QString encoded = text;
+    encoded.replace(' ', QChar(0x7f));
+    return QString("cwx send \"%1\" %2").arg(encoded).arg(block);
+}
+
+void testLiveButtonTogglesOff()
+{
+    Fixture f;
+    QPushButton *send = nullptr, *live = nullptr, *setup = nullptr;
+    QTextEdit* input = nullptr;
+    if (!requireSendWidgets(f, send, live, setup, input))
+        return;
+
+    live->click();
+    report("Live click enables live mode",
+           f.model.isLive() && live->isChecked());
+
+    live->click();
+    report("second Live click disables live mode",
+           !f.model.isLive() && !live->isChecked());
+}
+
+void testSendButtonSendsWhenLiveOff()
+{
+    Fixture f;
+    QPushButton *send = nullptr, *live = nullptr, *setup = nullptr;
+    QTextEdit* input = nullptr;
+    if (!requireSendWidgets(f, send, live, setup, input))
+        return;
+
+    input->setPlainText("CQ TEST");
+    send->click();
+
+    report("Send button sends current input",
+           f.commands == QStringList{sendCommand("CQ TEST", 1)});
+    report("Send button clears input after send",
+           input->toPlainText().isEmpty());
+}
+
+void testEnterStillSendsWhenLiveOff()
+{
+    Fixture f;
+    QPushButton *send = nullptr, *live = nullptr, *setup = nullptr;
+    QTextEdit* input = nullptr;
+    if (!requireSendWidgets(f, send, live, setup, input))
+        return;
+
+    input->setPlainText("73");
+    QKeyEvent enter(QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier, "\r");
+    QCoreApplication::sendEvent(input, &enter);
+
+    report("Enter key still sends current input",
+           f.commands == QStringList{sendCommand("73", 1)});
+}
+
+void testSendButtonTurnsLiveOffWithoutDuplicateSend()
+{
+    Fixture f;
+    QPushButton *send = nullptr, *live = nullptr, *setup = nullptr;
+    QTextEdit* input = nullptr;
+    if (!requireSendWidgets(f, send, live, setup, input))
+        return;
+
+    live->click();
+    input->setPlainText("ALREADY KEYED");
+    f.commands.clear();
+
+    send->click();
+
+    report("Send button exits live mode",
+           !f.model.isLive() && !live->isChecked());
+    report("Send button does not duplicate-send live text",
+           f.commands.isEmpty());
+    report("Send button keeps live text visible when exiting live",
+           input->toPlainText() == QLatin1String("ALREADY KEYED"));
+}
+
+void testSetupTurnsLiveOff()
+{
+    Fixture f;
+    QPushButton *send = nullptr, *live = nullptr, *setup = nullptr;
+    QTextEdit* input = nullptr;
+    if (!requireSendWidgets(f, send, live, setup, input))
+        return;
+
+    live->click();
+    setup->click();
+
+    report("Setup exits live mode",
+           !f.model.isLive() && !live->isChecked() && setup->isChecked());
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    std::printf("CWX panel behavior test harness\n\n");
+
+    testLiveButtonTogglesOff();
+    testSendButtonSendsWhenLiveOff();
+    testEnterStillSendsWhenLiveOff();
+    testSendButtonTurnsLiveOffWithoutDuplicateSend();
+    testSetupTurnsLiveOff();
+
+    std::printf("\n%s\n",
+                g_failed == 0
+                    ? "All tests passed."
+                    : (std::to_string(g_failed) + " test(s) failed.").c_str());
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Make the CWX `Live` button a true toggle so operators can turn live keying back off.
- Make the CWX `Send` button submit the current input when Live is off, matching the existing Enter key behavior.
- Turn Live off when entering Setup, and make `Send` exit Live without duplicate-sending text that may already have been keyed character-by-character.
- Add a focused `cwx_panel_test` harness covering Live toggling, Send-click submission, Enter submission, and Live exit safety.
- Matches SmartSDR Windows tested behavior.

## Root Cause

The CWX bottom bar treated `Send`, `Live`, and `Setup` as mutually exclusive mode buttons. Clicking `Live` always forced the model into live mode, so a second click could not turn it off. The `Send` button only selected send mode instead of sending the current buffer, while Enter already sent the buffer from the input event path.

## Testing

- `cmake --build build -- -j10`
- `./build/cwx_panel_test`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
