### PR TITLE
[feature] WAVE Phase 2: Enhance applet visualization controls

### DIFF
--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -116,7 +116,7 @@ WaveApplet::WaveApplet(QWidget* parent)
     m_waveform->setRefreshRateHz(refreshRate);
     updateRefreshLabel();
 
-    setSettingsExpanded(false);
+    setSettingsExpanded(true);
     setMinimumHeight(minimumSizeHint().height());
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 

--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -1,24 +1,283 @@
 #include "WaveApplet.h"
 
+#include "ComboStyle.h"
+#include "GuardedSlider.h"
 #include "WaveformWidget.h"
+#include "core/AppSettings.h"
 
+#include <QComboBox>
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QLabel>
 #include <QSizePolicy>
+#include <QSignalBlocker>
+#include <QSlider>
 #include <QVBoxLayout>
 
+#include <algorithm>
+
 namespace AetherSDR {
+
+namespace {
+
+constexpr int kMinZoomPercent = 100;
+constexpr int kMaxZoomPercent = 600;
+constexpr int kDefaultZoomPercent = 170;
+constexpr int kMinFps = 5;
+constexpr int kMaxFps = 30;
+constexpr int kDefaultFps = 24;
+
+const QString kSliderStyle =
+    "QSlider::groove:horizontal { height: 4px; background: #203040; border-radius: 2px; }"
+    "QSlider::sub-page:horizontal { background: #00b4d8; border-radius: 2px; }"
+    "QSlider::handle:horizontal { width: 12px; height: 12px; margin: -4px 0; "
+    "background: #c8d8e8; border: 1px solid #00b4d8; border-radius: 6px; }";
+
+QLabel* makeSettingLabel(const QString& text, QWidget* parent)
+{
+    auto* label = new QLabel(text, parent);
+    label->setFixedWidth(62);
+    label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    label->setStyleSheet("QLabel { color: #8aa8c0; font-size: 10px; }");
+    return label;
+}
+
+WaveformWidget::ViewMode viewModeFromSetting(const QString& value)
+{
+    if (value.compare("Bands", Qt::CaseInsensitive) == 0)
+        return WaveformWidget::ViewMode::VerticalBars;
+    if (value.compare("History", Qt::CaseInsensitive) == 0)
+        return WaveformWidget::ViewMode::Bars;
+    if (value.compare("Envelope", Qt::CaseInsensitive) == 0)
+        return WaveformWidget::ViewMode::Envelope;
+    return WaveformWidget::ViewMode::Graph;
+}
+
+QString settingForViewMode(WaveformWidget::ViewMode mode)
+{
+    switch (mode) {
+    case WaveformWidget::ViewMode::Envelope:
+        return QStringLiteral("Envelope");
+    case WaveformWidget::ViewMode::Bars:
+        return QStringLiteral("History");
+    case WaveformWidget::ViewMode::VerticalBars:
+        return QStringLiteral("Bands");
+    case WaveformWidget::ViewMode::Graph:
+        return QStringLiteral("Graph");
+    }
+    return QStringLiteral("Graph");
+}
+
+} // namespace
 
 WaveApplet::WaveApplet(QWidget* parent)
     : QWidget(parent)
 {
     auto* layout = new QVBoxLayout(this);
     layout->setContentsMargins(2, 2, 2, 2);
-    layout->setSpacing(0);
+    layout->setSpacing(3);
 
     m_waveform = new WaveformWidget(this);
     layout->addWidget(m_waveform);
 
-    setMinimumHeight(120);
+    buildSettingsDrawer();
+    layout->addWidget(m_settingsDrawer);
+
+    auto& settings = AppSettings::instance();
+
+    const auto viewMode = viewModeFromSetting(
+        settings.value("WaveApplet_ViewMode", "Graph").toString());
+    m_waveform->setViewMode(viewMode);
+    if (m_viewCombo) {
+        const int idx = m_viewCombo->findData(settingForViewMode(viewMode));
+        QSignalBlocker block(m_viewCombo);
+        m_viewCombo->setCurrentIndex(idx >= 0 ? idx : 0);
+    }
+
+    const int zoomPercent = std::clamp(
+        settings.value("WaveApplet_ZoomPercent", kDefaultZoomPercent).toInt(),
+        kMinZoomPercent,
+        kMaxZoomPercent);
+    {
+        QSignalBlocker block(m_zoomSlider);
+        m_zoomSlider->setValue(zoomPercent);
+    }
+    m_waveform->setAmplitudeZoom(zoomPercent / 100.0f);
+    updateZoomLabel();
+
+    const int refreshRate = std::clamp(
+        settings.value("WaveApplet_RefreshRateHz", kDefaultFps).toInt(),
+        kMinFps,
+        kMaxFps);
+    {
+        QSignalBlocker block(m_refreshSlider);
+        m_refreshSlider->setValue(refreshRate);
+    }
+    m_waveform->setRefreshRateHz(refreshRate);
+    updateRefreshLabel();
+
+    setSettingsExpanded(false);
+    setMinimumHeight(minimumSizeHint().height());
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
+    connect(m_waveform, &WaveformWidget::settingsDrawerToggleRequested,
+            this, [this]() {
+        setSettingsExpanded(m_settingsDrawer->isHidden());
+    });
+}
+
+QSize WaveApplet::sizeHint() const
+{
+    const int waveformHeight = m_waveform ? m_waveform->sizeHint().height() : 160;
+    const int drawerHeight = (m_settingsDrawer && !m_settingsDrawer->isHidden())
+        ? m_settingsDrawer->sizeHint().height() + 3
+        : 0;
+    return {240, std::max(165, waveformHeight + drawerHeight + 4)};
+}
+
+QSize WaveApplet::minimumSizeHint() const
+{
+    const int waveformHeight = m_waveform ? m_waveform->minimumSizeHint().height() : 110;
+    const int drawerHeight = (m_settingsDrawer && !m_settingsDrawer->isHidden())
+        ? m_settingsDrawer->minimumSizeHint().height() + 3
+        : 0;
+    return {220, std::max(120, waveformHeight + drawerHeight + 4)};
+}
+
+void WaveApplet::buildSettingsDrawer()
+{
+    m_settingsDrawer = new QFrame(this);
+    m_settingsDrawer->setObjectName("WaveSettingsDrawer");
+    m_settingsDrawer->setStyleSheet(
+        "QFrame#WaveSettingsDrawer { background-color: #0f1a24; "
+        "border: 1px solid #20384d; border-radius: 3px; }");
+
+    auto* drawer = new QVBoxLayout(m_settingsDrawer);
+    drawer->setContentsMargins(5, 4, 5, 5);
+    drawer->setSpacing(4);
+
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(5);
+        row->addWidget(makeSettingLabel("View:", m_settingsDrawer));
+
+        m_viewCombo = new GuardedComboBox(m_settingsDrawer);
+        applyComboStyle(m_viewCombo);
+        m_viewCombo->setFixedHeight(20);
+        m_viewCombo->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+        m_viewCombo->setToolTip("Choose the WAVE visualization");
+        m_viewCombo->addItem("Scope", QStringLiteral("Graph"));
+        m_viewCombo->addItem("Envelope", QStringLiteral("Envelope"));
+        m_viewCombo->addItem("History", QStringLiteral("History"));
+        m_viewCombo->addItem("Bands", QStringLiteral("Bands"));
+        row->addWidget(m_viewCombo, 1);
+
+        connect(m_viewCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+                this, [this](int index) {
+            if (index < 0)
+                return;
+            const auto mode = viewModeFromSetting(m_viewCombo->itemData(index).toString());
+            m_waveform->setViewMode(mode);
+            auto& settings = AppSettings::instance();
+            settings.setValue("WaveApplet_ViewMode", settingForViewMode(mode));
+            settings.save();
+        });
+
+        drawer->addLayout(row);
+    }
+
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(5);
+        row->addWidget(makeSettingLabel("Zoom:", m_settingsDrawer));
+
+        m_zoomSlider = new GuardedSlider(Qt::Horizontal, m_settingsDrawer);
+        m_zoomSlider->setRange(kMinZoomPercent, kMaxZoomPercent);
+        m_zoomSlider->setSingleStep(10);
+        m_zoomSlider->setPageStep(50);
+        m_zoomSlider->setTickInterval(100);
+        m_zoomSlider->setTickPosition(QSlider::NoTicks);
+        m_zoomSlider->setStyleSheet(kSliderStyle);
+        row->addWidget(m_zoomSlider, 1);
+
+        m_zoomValue = new QLabel(m_settingsDrawer);
+        m_zoomValue->setFixedWidth(38);
+        m_zoomValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        m_zoomValue->setStyleSheet("QLabel { color: #c8d8e8; font-size: 10px; }");
+        row->addWidget(m_zoomValue);
+
+        connect(m_zoomSlider, &QSlider::valueChanged, this, [this](int value) {
+            m_waveform->setAmplitudeZoom(value / 100.0f);
+            updateZoomLabel();
+            auto& settings = AppSettings::instance();
+            settings.setValue("WaveApplet_ZoomPercent", value);
+            settings.save();
+        });
+
+        drawer->addLayout(row);
+    }
+
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(5);
+        row->addWidget(makeSettingLabel("FPS:", m_settingsDrawer));
+
+        m_refreshSlider = new GuardedSlider(Qt::Horizontal, m_settingsDrawer);
+        m_refreshSlider->setRange(kMinFps, kMaxFps);
+        m_refreshSlider->setSingleStep(5);
+        m_refreshSlider->setPageStep(10);
+        m_refreshSlider->setTickInterval(5);
+        m_refreshSlider->setTickPosition(QSlider::NoTicks);
+        m_refreshSlider->setStyleSheet(kSliderStyle);
+        row->addWidget(m_refreshSlider, 1);
+
+        m_refreshValue = new QLabel(m_settingsDrawer);
+        m_refreshValue->setFixedWidth(38);
+        m_refreshValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        m_refreshValue->setStyleSheet("QLabel { color: #c8d8e8; font-size: 10px; }");
+        row->addWidget(m_refreshValue);
+
+        connect(m_refreshSlider, &QSlider::valueChanged, this, [this](int value) {
+            m_waveform->setRefreshRateHz(value);
+            updateRefreshLabel();
+            auto& settings = AppSettings::instance();
+            settings.setValue("WaveApplet_RefreshRateHz", value);
+            settings.save();
+        });
+
+        drawer->addLayout(row);
+    }
+}
+
+void WaveApplet::setSettingsExpanded(bool expanded)
+{
+    if (!m_settingsDrawer)
+        return;
+
+    const bool currentlyExpanded = !m_settingsDrawer->isHidden();
+    if (currentlyExpanded == expanded)
+        return;
+
+    m_settingsDrawer->setVisible(expanded);
+    setMinimumHeight(minimumSizeHint().height());
+    updateGeometry();
+    adjustSize();
+    if (auto* p = parentWidget())
+        p->updateGeometry();
+}
+
+void WaveApplet::updateZoomLabel()
+{
+    if (!m_zoomSlider || !m_zoomValue)
+        return;
+    m_zoomValue->setText(QStringLiteral("%1x").arg(m_zoomSlider->value() / 100.0, 0, 'f', 1));
+}
+
+void WaveApplet::updateRefreshLabel()
+{
+    if (!m_refreshSlider || !m_refreshValue)
+        return;
+    m_refreshValue->setText(QStringLiteral("%1 fps").arg(m_refreshSlider->value()));
 }
 
 void WaveApplet::appendScopeSamples(const QByteArray& monoFloat32Pcm,

--- a/src/gui/WaveApplet.h
+++ b/src/gui/WaveApplet.h
@@ -3,6 +3,11 @@
 #include <QByteArray>
 #include <QWidget>
 
+class QLabel;
+class QFrame;
+class GuardedComboBox;
+class GuardedSlider;
+
 namespace AetherSDR {
 
 class WaveformWidget;
@@ -13,15 +18,26 @@ class WaveApplet : public QWidget {
 public:
     explicit WaveApplet(QWidget* parent = nullptr);
 
-    QSize sizeHint() const override { return {240, 165}; }
-    QSize minimumSizeHint() const override { return {220, 120}; }
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
 
 public slots:
     void appendScopeSamples(const QByteArray& monoFloat32Pcm, int sampleRate, bool tx);
     void setTransmitting(bool tx);
 
 private:
+    void buildSettingsDrawer();
+    void setSettingsExpanded(bool expanded);
+    void updateZoomLabel();
+    void updateRefreshLabel();
+
     WaveformWidget* m_waveform{nullptr};
+    QFrame* m_settingsDrawer{nullptr};
+    GuardedComboBox* m_viewCombo{nullptr};
+    GuardedSlider* m_zoomSlider{nullptr};
+    GuardedSlider* m_refreshSlider{nullptr};
+    QLabel* m_zoomValue{nullptr};
+    QLabel* m_refreshValue{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/WaveformWidget.cpp
+++ b/src/gui/WaveformWidget.cpp
@@ -4,6 +4,7 @@
 
 #include <QApplication>
 #include <QFontMetrics>
+#include <QLinearGradient>
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
@@ -24,8 +25,11 @@ constexpr int kDefaultSampleRate = 24000;
 constexpr int kMinSampleRate = 8000;
 constexpr int kMaxSampleRate = 192000;
 constexpr int kNoAudioTimeoutMs = 1000;
-constexpr int kRepaintMinIntervalMs = 16;
-constexpr float kAmplitudeZoom = 1.7f;
+constexpr int kMinWindowMs = 40;
+constexpr int kMaxWindowMs = 240;
+constexpr int kMinRefreshRateHz = 5;
+constexpr int kMaxRefreshRateHz = 30;
+constexpr double kPi = 3.14159265358979323846;
 
 const QColor kBackground(0x0a, 0x0a, 0x14);
 const QColor kGridMajor(0x30, 0x40, 0x50, 130);
@@ -37,6 +41,8 @@ const QColor kRmsColor(0x20, 0xc0, 0x60, 210);
 const QColor kLabelColor(0xd8, 0xe6, 0xf0);
 const QColor kMutedLabel(0x90, 0xa0, 0xb0);
 const QColor kClipColor(0xff, 0x50, 0x50);
+const QColor kBarEmpty(0x14, 0x24, 0x32, 170);
+const QColor kBarPeakHold(0xff, 0xd1, 0x66);
 
 QColor waveformColor()
 {
@@ -71,7 +77,7 @@ WaveformWidget::WaveformWidget(QWidget* parent)
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     setAttribute(Qt::WA_OpaquePaintEvent);
     setAutoFillBackground(false);
-    setToolTip("Click to pause/resume waveform capture");
+    setToolTip("Click to pause/resume waveform capture; double-click for WAVE settings");
 
     m_clickTimer.setSingleShot(true);
     m_clickTimer.setInterval(QApplication::doubleClickInterval());
@@ -108,6 +114,48 @@ void WaveformWidget::clear()
 {
     clearRing(m_rx);
     clearRing(m_tx);
+    update();
+}
+
+void WaveformWidget::setViewMode(ViewMode mode)
+{
+    if (m_viewMode == mode)
+        return;
+    m_viewMode = mode;
+    update();
+}
+
+void WaveformWidget::setZoomWindowMs(int windowMs)
+{
+    const int sanitized = sanitizeWindowMs(windowMs);
+    if (m_windowMs == sanitized)
+        return;
+
+    m_windowMs = sanitized;
+    if (m_paused) {
+        const RingBuffer& buffer = activeBuffer();
+        m_pausedSampleRate = sanitizeSampleRate(buffer.sampleRate);
+        const int windowSamples = std::max(1, m_pausedSampleRate * m_windowMs / 1000);
+        copyLatest(buffer, windowSamples, m_pausedSamples);
+    }
+    update();
+}
+
+void WaveformWidget::setRefreshRateHz(int hz)
+{
+    const int sanitized = sanitizeRefreshRateHz(hz);
+    if (m_refreshRateHz == sanitized)
+        return;
+    m_refreshRateHz = sanitized;
+    update();
+}
+
+void WaveformWidget::setAmplitudeZoom(float zoom)
+{
+    const float sanitized = sanitizeAmplitudeZoom(zoom);
+    if (std::abs(m_amplitudeZoom - sanitized) < 0.01f)
+        return;
+    m_amplitudeZoom = sanitized;
     update();
 }
 
@@ -153,70 +201,22 @@ void WaveformWidget::paintEvent(QPaintEvent* event)
     const float peakDb = linearToDb(peak);
     const float rmsDb = linearToDb(rms);
 
-    drawGrid(painter, plotRect, sampleRate);
-
-    const int columnCount = std::max(1, static_cast<int>(std::floor(plotRect.width())));
-    buildColumns(columnCount);
-
-    if (!m_displaySamples.isEmpty()) {
-        const qreal centerY = plotRect.center().y();
-        const qreal halfHeight = std::max<qreal>(1.0, plotRect.height() * 0.5 - 2.0);
-        const qreal left = plotRect.left();
-        const QColor wave = waveformColor();
-
-        QPainterPath peakTop;
-        QPainterPath peakBottom;
-        QPainterPath rmsTop;
-        QPainterPath rmsBottom;
-
-        painter.setPen(QPen(wave, waveformLineWidth(), Qt::SolidLine, Qt::RoundCap));
-        for (int x = 0; x < m_columns.size(); ++x) {
-            const ColumnStats& c = m_columns[x];
-            const qreal px = left + x + 0.5;
-            const qreal minY = centerY - std::clamp(c.min * kAmplitudeZoom, -1.0f, 1.0f) * halfHeight;
-            const qreal maxY = centerY - std::clamp(c.max * kAmplitudeZoom, -1.0f, 1.0f) * halfHeight;
-            painter.drawLine(QPointF(px, minY), QPointF(px, maxY));
-
-            const qreal peak = std::clamp(c.peak * kAmplitudeZoom, 0.0f, 1.0f);
-            const qreal rms = std::clamp(c.rms * kAmplitudeZoom, 0.0f, 1.0f);
-            const qreal peakTopY = centerY - peak * halfHeight;
-            const qreal peakBottomY = centerY + peak * halfHeight;
-            const qreal rmsTopY = centerY - rms * halfHeight;
-            const qreal rmsBottomY = centerY + rms * halfHeight;
-            if (x == 0) {
-                peakTop.moveTo(px, peakTopY);
-                peakBottom.moveTo(px, peakBottomY);
-                rmsTop.moveTo(px, rmsTopY);
-                rmsBottom.moveTo(px, rmsBottomY);
-            } else {
-                peakTop.lineTo(px, peakTopY);
-                peakBottom.lineTo(px, peakBottomY);
-                rmsTop.lineTo(px, rmsTopY);
-                rmsBottom.lineTo(px, rmsBottomY);
-            }
-        }
-
-        painter.setRenderHint(QPainter::Antialiasing, true);
-        painter.setPen(QPen(kPeakColor, 1.0));
-        painter.drawPath(peakTop);
-        painter.drawPath(peakBottom);
-        painter.setPen(QPen(kRmsColor, 1.4));
-        painter.drawPath(rmsTop);
-        painter.drawPath(rmsBottom);
-        painter.setRenderHint(QPainter::Antialiasing, false);
-
-        if (clipCount > 0) {
-            painter.setPen(QPen(kClipColor, 1.0));
-            for (int x = 0; x < m_columns.size(); ++x) {
-                if (m_columns[x].clipped <= 0)
-                    continue;
-                const qreal px = left + x + 0.5;
-                painter.drawLine(QPointF(px, plotRect.top()),
-                                 QPointF(px, plotRect.top() + 4.0));
-                painter.drawLine(QPointF(px, plotRect.bottom() - 4.0),
-                                 QPointF(px, plotRect.bottom()));
-            }
-        }
+    if (m_viewMode == ViewMode::VerticalBars) {
+        drawBarsGrid(painter, plotRect);
+        if (!m_displaySamples.isEmpty())
+            drawVerticalBars(painter, plotRect, sampleRate);
+    } else if (m_viewMode == ViewMode::Envelope) {
+        drawGrid(painter, plotRect, sampleRate);
+        if (!m_displaySamples.isEmpty())
+            drawEnvelope(painter, plotRect, clipCount);
+    } else if (m_viewMode == ViewMode::Bars) {
+        drawBarsGrid(painter, plotRect);
+        if (!m_displaySamples.isEmpty())
+            drawBars(painter, plotRect);
+    } else {
+        drawGrid(painter, plotRect, sampleRate);
+        if (!m_displaySamples.isEmpty())
+            drawGraph(painter, plotRect, clipCount);
     }
 
     QFont labelFont = font();
@@ -243,10 +243,14 @@ void WaveformWidget::paintEvent(QPaintEvent* event)
     }
 
     painter.setPen(kMutedLabel);
-    const QString timeText = QString::fromUtf8("%1 \xc2\xb7 %2 ms \xc2\xb7 %3 ms/div")
-        .arg(formatSampleRate(sampleRate))
-        .arg(m_windowMs)
-        .arg(std::max(1, m_windowMs / 10));
+    const QString timeText = m_viewMode == ViewMode::VerticalBars
+        ? QString::fromUtf8("%1 \xc2\xb7 %2 ms \xc2\xb7 frequency bands")
+            .arg(formatSampleRate(sampleRate))
+            .arg(m_windowMs)
+        : QString::fromUtf8("%1 \xc2\xb7 %2 ms \xc2\xb7 %3 ms/div")
+            .arg(formatSampleRate(sampleRate))
+            .arg(m_windowMs)
+            .arg(std::max(1, m_windowMs / 10));
     const QRectF footerRect(plotRect.left(), plotRect.bottom() + 2.0,
                             plotRect.width(), 15.0);
     painter.drawText(m_paused ? footerRect.adjusted(0.0, 0.0, -52.0, 0.0) : footerRect,
@@ -282,7 +286,7 @@ void WaveformWidget::mouseDoubleClickEvent(QMouseEvent* event)
     if (event->button() == Qt::LeftButton) {
         m_clickTimer.stop();
         m_ignoreNextRelease = true;
-        clearActiveRing();
+        emit settingsDrawerToggleRequested();
         event->accept();
         return;
     }
@@ -348,14 +352,6 @@ void WaveformWidget::clearRing(RingBuffer& buffer)
     buffer.writeIndex = 0;
     buffer.filled = 0;
     buffer.lastSamples.invalidate();
-}
-
-void WaveformWidget::clearActiveRing()
-{
-    clearRing(activeBuffer());
-    if (m_paused)
-        m_pausedSamples.clear();
-    update();
 }
 
 void WaveformWidget::copyLatest(const RingBuffer& buffer, int count, QVector<float>& out) const
@@ -437,6 +433,354 @@ void WaveformWidget::buildColumns(int columnCount)
     }
 }
 
+void WaveformWidget::drawGraph(QPainter& painter,
+                               const QRectF& plotRect,
+                               int clipCount)
+{
+    const int columnCount = std::max(1, static_cast<int>(std::floor(plotRect.width())));
+    buildColumns(columnCount);
+    if (m_columns.isEmpty())
+        return;
+
+    const qreal centerY = plotRect.center().y();
+    const qreal halfHeight = std::max<qreal>(1.0, plotRect.height() * 0.5 - 2.0);
+    const qreal left = plotRect.left();
+    const QColor wave = waveformColor();
+
+    QPainterPath peakTop;
+    QPainterPath peakBottom;
+    QPainterPath rmsTop;
+    QPainterPath rmsBottom;
+
+    painter.setPen(QPen(wave, waveformLineWidth(), Qt::SolidLine, Qt::RoundCap));
+    for (int x = 0; x < m_columns.size(); ++x) {
+        const ColumnStats& c = m_columns[x];
+        const qreal px = left + x + 0.5;
+        const qreal minY = centerY - std::clamp(c.min * m_amplitudeZoom, -1.0f, 1.0f) * halfHeight;
+        const qreal maxY = centerY - std::clamp(c.max * m_amplitudeZoom, -1.0f, 1.0f) * halfHeight;
+        painter.drawLine(QPointF(px, minY), QPointF(px, maxY));
+
+        const qreal peak = std::clamp(c.peak * m_amplitudeZoom, 0.0f, 1.0f);
+        const qreal rms = std::clamp(c.rms * m_amplitudeZoom, 0.0f, 1.0f);
+        const qreal peakTopY = centerY - peak * halfHeight;
+        const qreal peakBottomY = centerY + peak * halfHeight;
+        const qreal rmsTopY = centerY - rms * halfHeight;
+        const qreal rmsBottomY = centerY + rms * halfHeight;
+        if (x == 0) {
+            peakTop.moveTo(px, peakTopY);
+            peakBottom.moveTo(px, peakBottomY);
+            rmsTop.moveTo(px, rmsTopY);
+            rmsBottom.moveTo(px, rmsBottomY);
+        } else {
+            peakTop.lineTo(px, peakTopY);
+            peakBottom.lineTo(px, peakBottomY);
+            rmsTop.lineTo(px, rmsTopY);
+            rmsBottom.lineTo(px, rmsBottomY);
+        }
+    }
+
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(QPen(kPeakColor, 1.0));
+    painter.drawPath(peakTop);
+    painter.drawPath(peakBottom);
+    painter.setPen(QPen(kRmsColor, 1.4));
+    painter.drawPath(rmsTop);
+    painter.drawPath(rmsBottom);
+    painter.setRenderHint(QPainter::Antialiasing, false);
+
+    if (clipCount > 0) {
+        painter.setPen(QPen(kClipColor, 1.0));
+        for (int x = 0; x < m_columns.size(); ++x) {
+            if (m_columns[x].clipped <= 0)
+                continue;
+            const qreal px = left + x + 0.5;
+            painter.drawLine(QPointF(px, plotRect.top()),
+                             QPointF(px, plotRect.top() + 4.0));
+            painter.drawLine(QPointF(px, plotRect.bottom() - 4.0),
+                             QPointF(px, plotRect.bottom()));
+        }
+    }
+}
+
+void WaveformWidget::drawEnvelope(QPainter& painter,
+                                  const QRectF& plotRect,
+                                  int clipCount)
+{
+    const int columnCount = std::max(1, static_cast<int>(std::floor(plotRect.width())));
+    buildColumns(columnCount);
+    if (m_columns.isEmpty())
+        return;
+
+    const qreal centerY = plotRect.center().y();
+    const qreal halfHeight = std::max<qreal>(1.0, plotRect.height() * 0.5 - 2.0);
+    const qreal left = plotRect.left();
+    const QColor wave = waveformColor();
+
+    QVector<QPointF> rmsTop;
+    QVector<QPointF> rmsBottom;
+    QPainterPath peakTop;
+    QPainterPath peakBottom;
+    QPainterPath rmsLineTop;
+    QPainterPath rmsLineBottom;
+
+    rmsTop.reserve(m_columns.size());
+    rmsBottom.reserve(m_columns.size());
+
+    for (int x = 0; x < m_columns.size(); ++x) {
+        const ColumnStats& c = m_columns[x];
+        const qreal px = left + x + 0.5;
+        const qreal peak = std::clamp(c.peak * m_amplitudeZoom, 0.0f, 1.0f);
+        const qreal rms = std::clamp(c.rms * m_amplitudeZoom, 0.0f, 1.0f);
+        const qreal peakTopY = centerY - peak * halfHeight;
+        const qreal peakBottomY = centerY + peak * halfHeight;
+        const qreal rmsTopY = centerY - rms * halfHeight;
+        const qreal rmsBottomY = centerY + rms * halfHeight;
+
+        rmsTop.append(QPointF(px, rmsTopY));
+        rmsBottom.append(QPointF(px, rmsBottomY));
+
+        if (x == 0) {
+            peakTop.moveTo(px, peakTopY);
+            peakBottom.moveTo(px, peakBottomY);
+            rmsLineTop.moveTo(px, rmsTopY);
+            rmsLineBottom.moveTo(px, rmsBottomY);
+        } else {
+            peakTop.lineTo(px, peakTopY);
+            peakBottom.lineTo(px, peakBottomY);
+            rmsLineTop.lineTo(px, rmsTopY);
+            rmsLineBottom.lineTo(px, rmsBottomY);
+        }
+    }
+
+    QPainterPath fillPath;
+    fillPath.moveTo(rmsTop.first());
+    for (int i = 1; i < rmsTop.size(); ++i)
+        fillPath.lineTo(rmsTop[i]);
+    for (int i = rmsBottom.size() - 1; i >= 0; --i)
+        fillPath.lineTo(rmsBottom[i]);
+    fillPath.closeSubpath();
+
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    QColor fill = wave;
+    fill.setAlpha(65);
+    painter.fillPath(fillPath, fill);
+
+    QColor centerFill = kRmsColor;
+    centerFill.setAlpha(55);
+    painter.setPen(QPen(centerFill, 1.0));
+    painter.drawLine(QPointF(plotRect.left(), centerY),
+                     QPointF(plotRect.right(), centerY));
+
+    painter.setPen(QPen(kRmsColor, 1.3));
+    painter.drawPath(rmsLineTop);
+    painter.drawPath(rmsLineBottom);
+
+    QColor peak = kPeakColor;
+    peak.setAlpha(210);
+    painter.setPen(QPen(peak, 1.0));
+    painter.drawPath(peakTop);
+    painter.drawPath(peakBottom);
+
+    painter.restore();
+
+    if (clipCount > 0) {
+        painter.setPen(QPen(kClipColor, 1.0));
+        for (int x = 0; x < m_columns.size(); ++x) {
+            if (m_columns[x].clipped <= 0)
+                continue;
+            const qreal px = left + x + 0.5;
+            painter.drawLine(QPointF(px, plotRect.top()),
+                             QPointF(px, plotRect.top() + 4.0));
+            painter.drawLine(QPointF(px, plotRect.bottom() - 4.0),
+                             QPointF(px, plotRect.bottom()));
+        }
+    }
+}
+
+void WaveformWidget::drawBars(QPainter& painter, const QRectF& plotRect)
+{
+    const int targetBars = std::clamp(static_cast<int>(plotRect.width() / 5.0), 12, 64);
+    buildColumns(targetBars);
+    if (m_columns.isEmpty())
+        return;
+
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, false);
+
+    const QColor wave = waveformColor();
+    const qreal slot = plotRect.width() / m_columns.size();
+    const qreal barWidth = std::max<qreal>(2.0, slot - 1.5);
+    const qreal bottom = plotRect.bottom();
+    const qreal maxHeight = std::max<qreal>(1.0, plotRect.height() - 1.0);
+
+    for (int i = 0; i < m_columns.size(); ++i) {
+        const ColumnStats& c = m_columns[i];
+        const qreal x = plotRect.left() + i * slot + (slot - barWidth) * 0.5;
+        const QRectF rail(x, plotRect.top(), barWidth, maxHeight);
+        painter.fillRect(rail, kBarEmpty);
+
+        const qreal peak = std::clamp(c.peak * m_amplitudeZoom, 0.0f, 1.0f);
+        const qreal rms = std::clamp(c.rms * m_amplitudeZoom, 0.0f, 1.0f);
+        if (peak <= 0.0)
+            continue;
+
+        QColor fill = wave;
+        if (c.clipped > 0 || peak >= 0.96)
+            fill = kClipColor;
+        else if (peak >= 0.78)
+            fill = QColor(0xff, 0xd1, 0x66);
+        else if (peak < 0.42)
+            fill = kRmsColor;
+
+        const qreal h = std::max<qreal>(1.0, peak * maxHeight);
+        const QRectF bar(x, bottom - h, barWidth, h);
+        QLinearGradient grad(bar.topLeft(), bar.bottomLeft());
+        grad.setColorAt(0.0, fill.lighter(125));
+        grad.setColorAt(1.0, fill.darker(150));
+        painter.fillRect(bar, grad);
+
+        const qreal rmsY = bottom - std::max<qreal>(1.0, rms * maxHeight);
+        painter.setPen(QPen(kRmsColor.lighter(115), 1.0));
+        painter.drawLine(QPointF(x, rmsY), QPointF(x + barWidth, rmsY));
+
+        const qreal capY = std::max(plotRect.top(), bar.top() - 2.0);
+        painter.setPen(QPen(c.clipped > 0 ? kClipColor : kBarPeakHold, 1.0));
+        painter.drawLine(QPointF(x, capY), QPointF(x + barWidth, capY));
+    }
+
+    painter.restore();
+}
+
+void WaveformWidget::drawVerticalBars(QPainter& painter,
+                                      const QRectF& plotRect,
+                                      int sampleRate)
+{
+    if (m_displaySamples.isEmpty())
+        return;
+
+    const int bandCount = std::clamp(static_cast<int>(plotRect.width() / 12.0), 10, 18);
+    const int analysisCount = std::min(
+        static_cast<int>(m_displaySamples.size()),
+        std::clamp(sampleRate / 25, 256, 1536));
+    if (analysisCount < 32)
+        return;
+
+    const int start = m_displaySamples.size() - analysisCount;
+    const double lowHz = 70.0;
+    const double highHz = std::max(lowHz * 2.0, std::min(sampleRate * 0.45, 7000.0));
+    const double logLow = std::log(lowHz);
+    const double logHigh = std::log(highHz);
+    double windowSum = 0.0;
+    for (int i = 0; i < analysisCount; ++i)
+        windowSum += 0.5 - 0.5 * std::cos(2.0 * kPi * i / std::max(1, analysisCount - 1));
+    windowSum = std::max(windowSum, 1.0);
+
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, false);
+
+    const qreal slot = plotRect.width() / bandCount;
+    const qreal barWidth = std::max<qreal>(4.0, slot - 3.0);
+    const qreal bottom = plotRect.bottom();
+    const qreal maxHeight = std::max<qreal>(1.0, plotRect.height() - 1.0);
+    const QColor wave = waveformColor();
+
+    for (int band = 0; band < bandCount; ++band) {
+        const double t = bandCount == 1
+            ? 0.0
+            : static_cast<double>(band) / (bandCount - 1);
+        const double frequency = std::exp(logLow + (logHigh - logLow) * t);
+        const double omega = 2.0 * kPi * frequency / sampleRate;
+        const double coeff = 2.0 * std::cos(omega);
+        double q1 = 0.0;
+        double q2 = 0.0;
+
+        for (int i = 0; i < analysisCount; ++i) {
+            const double window = 0.5 - 0.5 * std::cos(2.0 * kPi * i / std::max(1, analysisCount - 1));
+            const double sample = clampSample(m_displaySamples[start + i]) * window;
+            const double q0 = sample + coeff * q1 - q2;
+            q2 = q1;
+            q1 = q0;
+        }
+
+        const double power = std::max(0.0, q1 * q1 + q2 * q2 - coeff * q1 * q2);
+        const double amplitude = std::clamp((2.0 * std::sqrt(power) / windowSum) * m_amplitudeZoom, 0.0, 1.0);
+        const double db = std::max(20.0 * std::log10(std::max(amplitude, 1e-9)), -60.0);
+        const qreal level = std::clamp((db + 60.0) / 60.0, 0.0, 1.0);
+
+        const qreal x = plotRect.left() + band * slot + (slot - barWidth) * 0.5;
+        const QRectF rail(x, plotRect.top(), barWidth, maxHeight);
+        painter.fillRect(rail, kBarEmpty);
+
+        QColor fill = wave;
+        if (amplitude >= 0.96)
+            fill = kClipColor;
+        else if (level >= 0.82)
+            fill = QColor(0xff, 0xd1, 0x66);
+        else if (level < 0.42)
+            fill = kRmsColor;
+
+        const qreal h = std::max<qreal>(1.0, level * maxHeight);
+        const QRectF bar(x, bottom - h, barWidth, h);
+        QLinearGradient grad(bar.topLeft(), bar.bottomLeft());
+        grad.setColorAt(0.0, fill.lighter(125));
+        grad.setColorAt(0.55, fill);
+        grad.setColorAt(1.0, fill.darker(145));
+        painter.fillRect(bar, grad);
+
+        const qreal capY = std::max(plotRect.top(), bar.top() - 2.0);
+        painter.setPen(QPen(amplitude >= 0.96 ? kClipColor : kBarPeakHold, 1.0));
+        painter.drawLine(QPointF(x, capY), QPointF(x + barWidth, capY));
+    }
+
+    painter.restore();
+}
+
+void WaveformWidget::drawBarsGrid(QPainter& painter, const QRectF& plotRect) const
+{
+    painter.save();
+
+    if (showGrid()) {
+        painter.setPen(QPen(kGridMinor, 1.0));
+        for (int i = 0; i <= 10; ++i) {
+            const qreal x = plotRect.left() + plotRect.width() * i / 10.0;
+            painter.drawLine(QPointF(x, plotRect.top()),
+                             QPointF(x, plotRect.bottom()));
+        }
+    }
+
+    const int refs[] = {0, -6, -12, -24, -48};
+
+    QFont labelFont = font();
+    labelFont.setPointSizeF(std::max(7.0, labelFont.pointSizeF() - 2.0));
+    painter.setFont(labelFont);
+
+    for (int db : refs) {
+        const qreal rawHeight = dbToAmplitude(static_cast<float>(db)) * m_amplitudeZoom * plotRect.height();
+        if (db <= -48 && rawHeight < 3.0)
+            continue;
+        const qreal y = plotRect.bottom() - std::min(rawHeight, plotRect.height());
+
+        painter.setPen(QPen(db >= -12 ? kGridMajor : kGridMinor, 1.0));
+        painter.drawLine(QPointF(plotRect.left(), y), QPointF(plotRect.right(), y));
+
+        painter.setPen(kMutedLabel);
+        painter.drawText(QRectF(plotRect.right() + 4.0, y - 7.0,
+                                width() - plotRect.right() - 5.0, 14.0),
+                         Qt::AlignLeft | Qt::AlignVCenter,
+                         QString::number(db));
+    }
+
+    painter.setPen(kMutedLabel);
+    painter.drawText(QRectF(plotRect.right() + 4.0, plotRect.bottom() - 12.0,
+                            width() - plotRect.right() - 5.0, 12.0),
+                     Qt::AlignLeft | Qt::AlignVCenter,
+                     QStringLiteral("dBFS"));
+
+    painter.restore();
+}
+
 void WaveformWidget::drawGrid(QPainter& painter,
                               const QRectF& plotRect,
                               int sampleRate) const
@@ -463,7 +807,7 @@ void WaveformWidget::drawGrid(QPainter& painter,
     painter.setFont(labelFont);
 
     for (int db : refs) {
-        const qreal rawOffset = dbToAmplitude(static_cast<float>(db)) * kAmplitudeZoom * halfHeight;
+        const qreal rawOffset = dbToAmplitude(static_cast<float>(db)) * m_amplitudeZoom * halfHeight;
         if (db <= -48 && rawOffset < 3.0)
             continue;
         const qreal offset = std::min(rawOffset, halfHeight);
@@ -534,7 +878,7 @@ void WaveformWidget::scheduleRepaint()
         return;
 
     if (!m_repaintThrottle.isValid()
-        || m_repaintThrottle.elapsed() >= kRepaintMinIntervalMs) {
+        || m_repaintThrottle.elapsed() >= std::max(1, 1000 / m_refreshRateHz)) {
         update();
         m_repaintThrottle.restart();
     }
@@ -545,6 +889,23 @@ int WaveformWidget::sanitizeSampleRate(int sampleRate)
     if (sampleRate <= 0)
         sampleRate = kDefaultSampleRate;
     return std::clamp(sampleRate, kMinSampleRate, kMaxSampleRate);
+}
+
+int WaveformWidget::sanitizeWindowMs(int windowMs)
+{
+    return std::clamp(windowMs, kMinWindowMs, kMaxWindowMs);
+}
+
+int WaveformWidget::sanitizeRefreshRateHz(int hz)
+{
+    return std::clamp(hz, kMinRefreshRateHz, kMaxRefreshRateHz);
+}
+
+float WaveformWidget::sanitizeAmplitudeZoom(float zoom)
+{
+    if (!std::isfinite(zoom))
+        zoom = 1.7f;
+    return std::clamp(zoom, 1.0f, 6.0f);
 }
 
 float WaveformWidget::clampSample(float sample)

--- a/src/gui/WaveformWidget.h
+++ b/src/gui/WaveformWidget.h
@@ -18,15 +18,35 @@ class WaveformWidget : public QWidget {
     Q_OBJECT
 
 public:
+    enum class ViewMode {
+        Graph,
+        Envelope,
+        Bars,
+        VerticalBars
+    };
+
     explicit WaveformWidget(QWidget* parent = nullptr);
 
     QSize sizeHint() const override { return {240, 160}; }
     QSize minimumSizeHint() const override { return {220, 110}; }
 
+    ViewMode viewMode() const { return m_viewMode; }
+    int zoomWindowMs() const { return m_windowMs; }
+    int refreshRateHz() const { return m_refreshRateHz; }
+    float amplitudeZoom() const { return m_amplitudeZoom; }
+
+    void setViewMode(ViewMode mode);
+    void setZoomWindowMs(int windowMs);
+    void setRefreshRateHz(int hz);
+    void setAmplitudeZoom(float zoom);
+
 public slots:
     void appendScopeSamples(const QByteArray& monoFloat32Pcm, int sampleRate, bool tx);
     void setTransmitting(bool tx);
     void clear();
+
+signals:
+    void settingsDrawerToggleRequested();
 
 protected:
     void paintEvent(QPaintEvent* event) override;
@@ -55,16 +75,23 @@ private:
     void ensureCapacity(RingBuffer& buffer, int sampleRate);
     void appendToRing(RingBuffer& buffer, const float* samples, int count, int sampleRate);
     void clearRing(RingBuffer& buffer);
-    void clearActiveRing();
     void copyLatest(const RingBuffer& buffer, int count, QVector<float>& out) const;
     void setPaused(bool paused);
     void buildColumns(int columnCount);
     void drawGrid(QPainter& painter, const QRectF& plotRect, int sampleRate) const;
+    void drawBarsGrid(QPainter& painter, const QRectF& plotRect) const;
+    void drawGraph(QPainter& painter, const QRectF& plotRect, int clipCount);
+    void drawEnvelope(QPainter& painter, const QRectF& plotRect, int clipCount);
+    void drawBars(QPainter& painter, const QRectF& plotRect);
+    void drawVerticalBars(QPainter& painter, const QRectF& plotRect, int sampleRate);
     void drawNoAudio(QPainter& painter, const QRectF& plotRect, const QString& source) const;
     void drawPausedBadge(QPainter& painter, const QRectF& footerRect) const;
     void scheduleRepaint();
 
     static int sanitizeSampleRate(int sampleRate);
+    static int sanitizeWindowMs(int windowMs);
+    static int sanitizeRefreshRateHz(int hz);
+    static float sanitizeAmplitudeZoom(float zoom);
     static float clampSample(float sample);
     static float dbToAmplitude(float db);
     static float linearToDb(float value);
@@ -83,6 +110,9 @@ private:
     bool m_transmitting{false};
     int m_pausedSampleRate{24000};
     int m_windowMs{100};
+    int m_refreshRateHz{24};
+    float m_amplitudeZoom{1.7f};
+    ViewMode m_viewMode{ViewMode::Graph};
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION

<img width="262" height="232" alt="Screenshot 2026-04-27 at 9 51 39 PM" src="https://github.com/user-attachments/assets/27747b1f-af43-4e2e-997a-250fda5649dc" />

## Summary

This expands the WAVE waveform applet into a more useful live signal monitor while keeping the compact applet footprint by default.

- Double-clicking the waveform now opens or closes a settings drawer instead of clearing samples.
- Adds a compact `View` dropdown with four visualizations:
  - `Scope`: the original waveform trace, still persisted as the deployed `Graph` setting value.
  - `Envelope`: a filled RMS envelope with peak outlines for easier level shape reading.
  - `History`: a side-scrolling bar history view for recent signal activity.
  - `Bands`: vertical EQ-style frequency bands for a more useful live spectral readout.
- Adds persisted `Zoom` and `FPS` controls in the drawer.
- Updates the settings controls to use the smaller, lighter applet typography used by the existing power labels.

## Details

The drawer is hidden by default and participates in the applet size hint when expanded, so the WAVE applet stays compact until the user asks for controls. The view selector uses the existing guarded combo styling instead of a row of mode buttons, which keeps the drawer from feeling crowded as the visualization list grows.

The zoom control is wired as amplitude gain across all views, not just as a time-window preference, so users can visibly change signal scale in Scope, Envelope, History, and Bands. The FPS control maps directly to the waveform repaint schedule, defaults to 24 fps, and is clamped from 5 to 30 fps to calm down the more active meters without making the display feel stale.

Settings persisted by this PR:

- `WaveApplet_ViewMode`
- `WaveApplet_ZoomPercent`
- `WaveApplet_RefreshRateHz`

For compatibility with the only previously deployed value, Scope continues to save as `Graph`. The new modes save as `Envelope`, `History`, and `Bands`.

## Validation

- `git diff --check`
- `cmake --build build -j10 --target AetherSDR`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
