### PR TITLE
Fix serial PTT input non-functional: port never opened + polarity default mismatch

### DIFF
--- a/src/core/SerialPortController.cpp
+++ b/src/core/SerialPortController.cpp
@@ -238,16 +238,25 @@ void SerialPortController::loadSettings()
 
     m_ctsFn = strToInputFn(s.value("SerialCtsFunction", "None").toString());
     m_dsrFn = strToInputFn(s.value("SerialDsrFunction", "None").toString());
-    m_ctsActiveHigh = s.value("SerialCtsPolarity", "ActiveLow").toString() == "ActiveHigh";
-    m_dsrActiveHigh = s.value("SerialDsrPolarity", "ActiveLow").toString() == "ActiveHigh";
+    m_ctsActiveHigh = s.value("SerialCtsPolarity", "ActiveHigh").toString() == "ActiveHigh";
+    m_dsrActiveHigh = s.value("SerialDsrPolarity", "ActiveHigh").toString() == "ActiveHigh";
     m_paddleSwap = s.value("SerialPaddleSwap", "False").toString() == "True";
 
-    if (!port.isEmpty() && s.value("SerialAutoOpen", "False").toString() == "True") {
+    bool shouldOpen = s.value("SerialAutoOpen", "False").toString() == "True"
+                   || s.value("SerialPortOpen", "False").toString() == "True";
+
+    if (!port.isEmpty() && shouldOpen) {
         int baud = s.value("SerialBaudRate", "9600").toInt();
         int data = s.value("SerialDataBits", "8").toInt();
         int par  = s.value("SerialParity", "0").toInt();
         int stop = s.value("SerialStopBits", "1").toInt();
         open(port, baud, data, par, stop);
+    } else if (!shouldOpen && isOpen()) {
+        close();
+    } else {
+        // Port state unchanged — still refresh polling in case function
+        // assignments changed while the port was already open.
+        updatePolling();
     }
 }
 
@@ -285,6 +294,7 @@ void SerialPortController::saveSettings()
     s.setValue("SerialDsrPolarity", m_dsrActiveHigh ? "ActiveHigh" : "ActiveLow");
     s.setValue("SerialPaddleSwap", m_paddleSwap ? "True" : "False");
     s.setValue("SerialAutoOpen", isOpen() ? "True" : "False");
+    s.setValue("SerialPortOpen", isOpen() ? "True" : "False");
     s.save();
 }
 

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -3069,8 +3069,62 @@ QWidget* RadioSetupDialog::buildSerialTab()
         vbox->addWidget(group);
     }
 
-    // ── Auto-open toggle ─────────────────────────────────────────────────
+    // ── Open / Close / Auto-open ────────────────────────────────────────
     {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(8);
+
+        const QString btnStyle =
+            "QPushButton { background: #00b4d8; color: #0f0f1a; font-weight: bold; "
+            "border: 1px solid #008ba8; padding: 3px; border-radius: 3px; }"
+            "QPushButton:hover { background: #00c8f0; }"
+            "QPushButton:disabled { background: #203040; color: #506070; border-color: #304050; }";
+
+        auto* openBtn = new QPushButton("Open");
+        openBtn->setFixedWidth(80);
+        openBtn->setStyleSheet(btnStyle);
+        auto* closeBtn = new QPushButton("Close");
+        closeBtn->setFixedWidth(80);
+        closeBtn->setStyleSheet(btnStyle);
+
+        auto* statusLabel = new QLabel;
+        statusLabel->setStyleSheet("QLabel { font-size: 11px; }");
+
+        row->addWidget(openBtn);
+        row->addWidget(closeBtn);
+        row->addWidget(statusLabel);
+        row->addStretch();
+
+        auto updatePortStatus = [openBtn, closeBtn, statusLabel]() {
+            bool open = AppSettings::instance().value("SerialPortOpen", "False").toString() == "True";
+            openBtn->setEnabled(!open);
+            closeBtn->setEnabled(open);
+            if (open) {
+                statusLabel->setText("Open");
+                statusLabel->setStyleSheet("QLabel { color: #30d050; font-size: 11px; }");
+            } else {
+                statusLabel->setText("Closed");
+                statusLabel->setStyleSheet("QLabel { color: #808080; font-size: 11px; }");
+            }
+        };
+
+        connect(openBtn, &QPushButton::clicked, this, [updatePortStatus]() {
+            auto& s = AppSettings::instance();
+            s.setValue("SerialPortOpen", "True");
+            s.save();
+            updatePortStatus();
+        });
+
+        connect(closeBtn, &QPushButton::clicked, this, [updatePortStatus]() {
+            auto& s = AppSettings::instance();
+            s.setValue("SerialPortOpen", "False");
+            s.save();
+            updatePortStatus();
+        });
+
+        updatePortStatus();
+        vbox->addLayout(row);
+
         auto* autoOpen = new QCheckBox("Auto-open serial port on startup");
         autoOpen->setStyleSheet("QCheckBox { color: #c8d8e8; }");
         autoOpen->setChecked(settings.value("SerialAutoOpen", "False").toString() == "True");


### PR DESCRIPTION
## Problem

Users report that configuring DSR (or CTS) as PTT Input in Radio Setup → Serial has no effect — pressing the footswitch produces no RF output and no interlock state change, even when hardware is confirmed working via FRStack.

Three independent bugs blocked the PTT path:

---

### Bug 1 — No way to open the serial port without restarting

`loadSettings()` only opened the port when `SerialAutoOpen == "True"`. The Serial tab had no Open/Close buttons, so users who configured settings in a running session had no mechanism to activate the port until the next restart. Even with auto-open enabled, the label "Auto-open serial port on **startup**" implied a restart was required — many users did not realize that closing the dialog alone was sufficient to trigger `loadSettings()`.

### Bug 2 — Polarity default mismatch (silent inversion)

`loadSettings()` fell back to `"ActiveLow"` for `SerialCtsPolarity` and `SerialDsrPolarity` when the key was absent from AppSettings. The polarity combo in the dialog defaulted to displaying `"Active High"` (index 0), but its `currentIndexChanged` signal is connected *after* the initial index is set, so leaving polarity at the displayed default wrote nothing to AppSettings. Result: a user who configured DSR → PTT Input and left polarity at the displayed "Active High" default would have the controller silently invert the logic — footswitch press reads as inactive, PTT never fires.

### Bug 3 — `updatePolling()` not called when function assignments change on an open port

When the dialog was closed and `loadSettings()` ran with `SerialAutoOpen == "False"` (port not being re-opened), the poll timer state was never refreshed. If a user changed a pin function from None → PttInput while the port was already open, the 10 ms poll timer would not start and the new assignment would be silently inert.

---

## Fix

### `src/core/SerialPortController.cpp`

- **`loadSettings()`**: open condition now checks `SerialAutoOpen || SerialPortOpen` so the new Open button in the dialog takes effect when the dialog closes.
- **`loadSettings()`**: added explicit close path (`!shouldOpen && isOpen()`) so the Close button also takes effect without a restart.
- **`loadSettings()`**: added `updatePolling()` in the else branch (port state unchanged) so pin function changes on an already-open port correctly start or stop the 10 ms poll timer.
- **`loadSettings()`**: changed `SerialCtsPolarity` and `SerialDsrPolarity` fallback defaults from `"ActiveLow"` to `"ActiveHigh"` to match the combo's displayed default, eliminating the silent polarity inversion for first-time users who leave the polarity combo untouched.
- **`saveSettings()`**: now also persists `SerialPortOpen` so a port opened manually via the button survives restart (same semantics as `SerialAutoOpen`).

### `src/gui/RadioSetupDialog.cpp`

- Added **Open** and **Close** buttons to the Serial tab with a live status indicator ("Open" green / "Closed" grey). Clicking Open sets `SerialPortOpen = True` in AppSettings; clicking Close sets it to `False`. Both take effect when the dialog is closed, triggering `loadSettings()` on the worker thread via the existing `QMetaObject::invokeMethod` in MainWindow.
- Retained the "Auto-open serial port on startup" checkbox beneath the buttons.

---

## Signal path (verified end-to-end)

```
footswitch asserts DSR (active high)
  → SerialPortController::pollInputPins() [10 ms QTimer, worker thread]
    → dsrActive=true, m_lastDsrActive=false, debounceOk=true
      → emit externalPttChanged(true)           [queued → main thread]
        → RadioModel::setTransmit(true)
          → sendCmd("xmit 1")                   [TCP → FLEX-8600 → RF output]
```

CTS PTT path is identical (`m_ctsFn == InputFunction::PttInput`).

---

## Steps to reproduce (before fix)

1. Connect USB-serial adapter; footswitch on DSR pin, active high.
2. Open Radio Setup → Serial.
3. Select port, set DSR = PTT Input, Polarity = Active High.
4. Close dialog (auto-open not checked, no restart).
5. Press footswitch → no keying, no interlock change.

## Steps to verify (after fix)

1. Same hardware setup.
2. Open Radio Setup → Serial; configure port and pin assignment.
3. Click **Open** → status label changes to "Open" (green).
4. Close dialog.
5. Press footswitch → radio keys, RF output observed.
6. Re-open dialog, click **Close** → status "Closed"; footswitch no longer keys.
7. Enable **Auto-open serial port on startup**, exit and restart → port opens automatically on startup, footswitch keys without manual Open step.

---

## Files changed

  src/core/SerialPortController.cpp   loadSettings: SerialPortOpen flag, close path,
                                      updatePolling, polarity defaults (ActiveLow→ActiveHigh)
                                      saveSettings: persist SerialPortOpen
  src/gui/RadioSetupDialog.cpp        Serial tab: add Open/Close buttons + status label