### PR TITLE
[bug] Fix Slice audio loss after band changes

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7933,6 +7933,22 @@ void MainWindow::updateSplitState()
 // OverlayMenu signals to RadioModel, TnfModel, and MainWindow handlers.
 // In multi-pan mode (Phase 6+), called for each new panadapter.
 
+void MainWindow::reassertUnmutedSliceAudioForPan(const QString& panId)
+{
+    const auto slices = m_radioModel.slices();
+    if (slices.size() <= 1) return;
+
+    for (auto* slice : slices) {
+        if (!slice || slice->panId() != panId || slice->audioMute())
+            continue;
+
+        // The model already shows unmuted, so SliceModel::setAudioMute(false)
+        // would no-op. Send the command directly to rebuild radio audio routing.
+        m_radioModel.sendCommand(
+            QString("slice set %1 audio_mute=0").arg(slice->sliceId()));
+    }
+}
+
 void MainWindow::setActivePanApplet(PanadapterApplet* applet)
 {
     if (applet == m_panApplet) return;
@@ -8719,6 +8735,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             m_bandSettings.setCurrentBand(bandName);
             m_radioModel.sendCommand(
                 QString("display pan set %1 band=%2").arg(applet->panId()).arg(stackKey));
+            QTimer::singleShot(300, this, [this, panId = applet->panId()]() {
+                reassertUnmutedSliceAudioForPan(panId);
+            });
         }
     });
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -156,6 +156,7 @@ private:
     void updateSplitState();
     void disableSplit();
     void wirePanadapter(PanadapterApplet* applet);
+    void reassertUnmutedSliceAudioForPan(const QString& panId);
     void setActivePanApplet(PanadapterApplet* applet);
     void routeCwDecoderOutput();  // wire CW decoder to the pan owning the active slice
     SpectrumWidget* spectrumForSlice(SliceModel* s) const;


### PR DESCRIPTION
Fixes #2064

## Summary

This PR fixes the reported Slice B audio loss after changing bands in a two-slice setup. After Aether sends the radio-authoritative `display pan set <pan> band=<key>` command, it now waits briefly for the Flex band stack restore to settle, then reasserts `audio_mute=0` for any unmuted slice on that pan.

## Problem

The issue report describes a Windows 10 FLEX-6400 setup with two panadapters/slices. Slice B remains visually unmuted after a band change, but its audio goes silent until the user manually clicks the speaker icon muted and then unmuted again.

The Slice Troubleshooter snapshot captured while the problem was active showed:

- PC audio enabled
- RX stream active
- Audio engine not muted
- Slice B `audio mute` reported as `No`
- Slice B audio gain was up and the speaker route was correct

That means the app model and UI still believed Slice B was unmuted. The failure was below the UI state: the radio-side audio contribution for that slice was no longer being mixed/routed even though no `audio_mute=1` status was reflected in Aether.

## Root Cause

Band buttons intentionally use `display pan set <pan> band=<key>` so the Flex firmware remains authoritative for band-stack state: frequency, mode, filters, pan geometry, antenna selection, and related slice properties.

That command can also make the radio tear down and rebuild slice audio routing during the band transition. In the failing case, the radio appears to leave the slice out of the audio mix without sending an `audio_mute` status change. Since Aether's model already says `audioMute() == false`, calling `SliceModel::setAudioMute(false)` would no-op and would not send anything to the radio. The manual mute/unmute workaround works because it forces a fresh `slice set <id> audio_mute=0` command after the transition.

## Fix

After a successful band-stack command, Aether now schedules a 300 ms deferred reassertion:

- Only runs when more than one slice exists
- Only touches slices on the pan whose band changed
- Skips slices the model says are intentionally muted
- Sends `slice set <id> audio_mute=0` directly, bypassing the no-op setter path

This preserves user-muted slices while giving the radio the same explicit nudge that the manual mute/off toggle provides.

## Validation

- `git diff --check`
- `cmake --build build -j10`

Local app bundle from the validated build:
`/Users/patj/.codex/worktrees/3b89/AetherSDR/build/AetherSDR.app`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
