### PR TITLE
[dax] Add support for DAX2 and TCI multi-stream routing

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -3355,7 +3355,13 @@ void AudioEngine::sendModemTxAudio(const QByteArray& float32pcm)
 
 void AudioEngine::setDaxTxMode(bool on)
 {
-    m_daxTxMode = on;
+    const bool previous = m_daxTxMode.exchange(on);
+    if (previous != on) {
+        qCDebug(lcDax) << "AudioEngine: DAX TX mode"
+                       << (on ? "enabled" : "disabled")
+                       << "route=" << (m_daxTxUseRadioRoute ? "radio-dax" : "float32-dax-tx")
+                       << "stream=0x" + QString::number(m_txStreamId, 16);
+    }
 }
 
 void AudioEngine::setTransmitting(bool tx)
@@ -3386,6 +3392,9 @@ void AudioEngine::setDaxTxUseRadioRoute(bool on)
     // Switching route changes payload format; drop partial buffered samples.
     m_txFloatAccumulator.clear();
     m_daxPreTxBuffer.clear();
+    qCDebug(lcDax) << "AudioEngine: DAX TX route"
+                   << (on ? "radio-dax pcc=0x0123" : "float32 pcc=0x03e3")
+                   << "stream=0x" + QString::number(m_txStreamId, 16);
 }
 
 void AudioEngine::feedDaxTxAudio(const QByteArray& inPcm)

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -5,6 +5,7 @@
 
 #include <QNetworkDatagram>
 #include <QHostAddress>
+#include <QStringList>
 #include <QtEndian>
 #include <QSet>
 #include <cstring>
@@ -318,6 +319,10 @@ void PanadapterStream::clearRegisteredStreams()
     m_frames.clear();
     m_wfFrames.clear();
     m_dbmRanges.clear();
+    m_daxStreamIds.clear();
+    m_iqStreamIds.clear();
+    m_loggedDaxPacketStreams.clear();
+    m_loggedIqPacketStreams.clear();
     qCDebug(lcVita49) << "PanadapterStream: cleared all registered streams";
 }
 
@@ -382,6 +387,7 @@ void PanadapterStream::processDatagram(const QByteArray& data)
 
     // PacketClassCode is in the lower 16 bits of word 3 (bytes 12-15).
     const quint16 pcc = static_cast<quint16>(qFromBigEndian<quint32>(raw + 12) & 0xFFFFu);
+    const int vitaSeq = (word0 >> 16) & 0x0F;
 
     // Log the first occurrence of each unique stream ID.
     static QSet<quint32> seenIds;
@@ -398,14 +404,40 @@ void PanadapterStream::processDatagram(const QByteArray& data)
     // Lock for stream ID lookups (written from main thread) (#502)
     int daxChannel = -1, iqChannel = -1;
     bool isPan = false, isWf = false;
+    bool logFirstDaxPacket = false;
+    bool logFirstIqPacket = false;
     {
         QMutexLocker lock(&m_streamMutex);
         if (m_daxStreamIds.contains(streamId))
             daxChannel = m_daxStreamIds[streamId];
         if (m_iqStreamIds.contains(streamId))
             iqChannel = m_iqStreamIds[streamId];
+        if (daxChannel >= 0 && !m_loggedDaxPacketStreams.contains(streamId)) {
+            m_loggedDaxPacketStreams.insert(streamId);
+            logFirstDaxPacket = true;
+        }
+        if (iqChannel >= 0 && !m_loggedIqPacketStreams.contains(streamId)) {
+            m_loggedIqPacketStreams.insert(streamId);
+            logFirstIqPacket = true;
+        }
         isPan = m_knownPanStreams.isEmpty() || m_knownPanStreams.contains(streamId);
         isWf  = m_knownWfStreams.isEmpty() || m_knownWfStreams.contains(streamId);
+    }
+
+    if (logFirstDaxPacket || logFirstIqPacket) {
+        const QStringList fields = {
+            QStringLiteral("kind=%1").arg(logFirstDaxPacket ? QStringLiteral("rx") : QStringLiteral("iq")),
+            QStringLiteral("stream=0x%1").arg(QString::number(streamId, 16)),
+            QStringLiteral("channel=%1").arg(logFirstDaxPacket ? daxChannel : iqChannel),
+            QStringLiteral("pcc=0x%1").arg(QString::number(pcc, 16).rightJustified(4, QLatin1Char('0'))),
+            QStringLiteral("bytes=%1").arg(data.size()),
+            QStringLiteral("seq=%1").arg(vitaSeq),
+            QStringLiteral("trailer=%1").arg(hasTrailer ? 1 : 0)
+        };
+        qCDebug(lcDax).noquote()
+            << "PanadapterStream: first DAX packet" << fields.join(QLatin1Char(' '));
+        qCDebug(lcCat).noquote()
+            << "PanadapterStream: first DAX packet" << fields.join(QLatin1Char(' '));
     }
 
     // Determine category for per-stream-type stats (#455)
@@ -426,17 +458,16 @@ void PanadapterStream::processDatagram(const QByteArray& data)
     if (cat != CatCount) {
         m_catStats[cat].bytes += data.size();
         m_catStats[cat].packets++;
-        const int seq = (word0 >> 16) & 0x0F;
         auto& stats = m_streamStats[streamId];
         stats.totalCount++;
         if (stats.lastSeq >= 0) {
             const int expected = (stats.lastSeq + 1) & 0x0F;
-            if (seq != expected) {
+            if (vitaSeq != expected) {
                 stats.errorCount++;
                 m_catStats[cat].errors++;
             }
         }
-        stats.lastSeq = seq;
+        stats.lastSeq = vitaSeq;
 
         if (cat == CatAudio) {
             if (m_audioPacketTimerStarted) {
@@ -874,6 +905,7 @@ void PanadapterStream::registerDaxStream(quint32 streamId, int channel)
         }
     }
     m_daxStreamIds[streamId] = channel;
+    m_loggedDaxPacketStreams.remove(streamId);
     qCDebug(lcVita49) << "PanadapterStream: registered DAX stream" << Qt::hex << streamId << "-> channel" << channel;
 }
 
@@ -891,6 +923,7 @@ void PanadapterStream::unregisterDaxStream(quint32 streamId)
 {
     QMutexLocker lock(&m_streamMutex);
     m_daxStreamIds.remove(streamId);
+    m_loggedDaxPacketStreams.remove(streamId);
     qCDebug(lcVita49) << "PanadapterStream: unregistered DAX stream" << Qt::hex << streamId;
 }
 
@@ -904,6 +937,7 @@ void PanadapterStream::registerIqStream(quint32 streamId, int channel)
 {
     QMutexLocker lock(&m_streamMutex);
     m_iqStreamIds[streamId] = channel;
+    m_loggedIqPacketStreams.remove(streamId);
     qCDebug(lcVita49) << "PanadapterStream: registered IQ stream" << Qt::hex << streamId << "-> channel" << channel;
 }
 
@@ -911,6 +945,7 @@ void PanadapterStream::unregisterIqStream(quint32 streamId)
 {
     QMutexLocker lock(&m_streamMutex);
     m_iqStreamIds.remove(streamId);
+    m_loggedIqPacketStreams.remove(streamId);
     qCDebug(lcVita49) << "PanadapterStream: unregistered IQ stream" << Qt::hex << streamId;
 }
 

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -230,6 +230,8 @@ private:
     QMap<quint32, int> m_daxStreamIds;
     // DAX IQ stream routing: stream ID → IQ channel (1-4)
     QMap<quint32, int> m_iqStreamIds;
+    QSet<quint32> m_loggedDaxPacketStreams;
+    QSet<quint32> m_loggedIqPacketStreams;
     QHostAddress m_radioAddress;
     quint16      m_radioPort{0};
     QHostAddress m_localAddress;

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -7,10 +7,23 @@
 #include "models/SpotModel.h"
 #include "models/DaxIqModel.h"
 
+#include <QList>
 #include <QMetaObject>
 #include <cmath>
 
 namespace AetherSDR {
+
+namespace {
+
+int tciTrxForSlice(const QList<SliceModel*>& slices, const SliceModel* slice)
+{
+    if (!slice)
+        return 0;
+    const int index = slices.indexOf(const_cast<SliceModel*>(slice));
+    return index >= 0 ? index : slice->sliceId();
+}
+
+} // namespace
 
 TciProtocol::TciProtocol(RadioModel* model)
     : m_model(model)
@@ -50,11 +63,16 @@ QString TciProtocol::tciToSmartSDR(const QString& mode)
 SliceModel* TciProtocol::sliceForTrx(int trx) const
 {
     if (!m_model || !m_model->isConnected()) return nullptr;
+    auto slices = m_model->slices();
+    if (trx >= 0 && trx < slices.size())
+        return slices.at(trx);
+
+    // Compatibility fallback for clients that learned raw Flex slice ids from
+    // older AetherSDR builds.
     for (auto* s : m_model->slices()) {
         if (s->sliceId() == trx) return s;
     }
     // Fallback: first slice
-    auto slices = m_model->slices();
     return slices.isEmpty() ? nullptr : slices.first();
 }
 
@@ -69,8 +87,11 @@ QString TciProtocol::generateInitBurst()
                 : QStringLiteral("AetherSDR"));
     burst += QStringLiteral("receive_only:false;");
 
-    // Count TRXs based on owned slices
-    int trxCount = m_model ? m_model->slices().size() : 1;
+    // Count TRXs based on owned slices and expose them as contiguous TCI
+    // receivers (0..N-1). Flex slice ids may start at 1 when another client
+    // owns slice 0, but TCI clients use indexes within the advertised count.
+    const auto slices = m_model ? m_model->slices() : QList<SliceModel*>{};
+    int trxCount = slices.size();
     if (trxCount < 1) trxCount = 1;
     burst += QStringLiteral("trx_count:%1;").arg(trxCount);
     burst += QStringLiteral("channels_count:1;");
@@ -80,8 +101,8 @@ QString TciProtocol::generateInitBurst()
 
     // Per-slice state
     if (m_model) {
-        for (auto* s : m_model->slices()) {
-            int trx = s->sliceId();
+        for (auto* s : slices) {
+            int trx = tciTrxForSlice(slices, s);
             long long hz = static_cast<long long>(std::round(s->frequency() * 1e6));
             burst += QStringLiteral("vfo:%1,0,%2;").arg(trx).arg(hz);
             burst += QStringLiteral("modulation:%1,%2;")
@@ -135,8 +156,11 @@ QString TciProtocol::generateInitBurst()
         auto& tx = m_model->transmitModel();
         bool isTx = tx.isTransmitting();
         int txTrx = 0;
-        for (auto* s : m_model->slices()) {
-            if (s->isTxSlice()) { txTrx = s->sliceId(); break; }
+        for (auto* s : slices) {
+            if (s->isTxSlice()) {
+                txTrx = tciTrxForSlice(slices, s);
+                break;
+            }
         }
         // ESDR3 format requires TRX index prefix for drive commands.
         // Without it, WSJT-X/JTDX crash parsing args.at(1) on a 1-element list.

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -14,6 +14,7 @@
 
 #include <QWebSocketServer>
 #include <QWebSocket>
+#include <QStringList>
 #include <QTimer>
 #include <QtEndian>
 #include <algorithm>
@@ -47,6 +48,38 @@ constexpr qint64 kTxChronoPeriodNs =
     (static_cast<qint64>(kTxChronoStereoFrames) * 1000000000LL) / 48000LL;
 constexpr int kTxChronoPollMs = 5;
 constexpr qint64 kTxSummaryEveryBlocks = 48;
+
+quint32 parseStatusHandle(QString text)
+{
+    text = text.trimmed();
+    bool ok = false;
+    quint32 value = text.toUInt(&ok, 0);
+    if (ok)
+        return value;
+
+    if (text.startsWith(QStringLiteral("0x"), Qt::CaseInsensitive))
+        text = text.mid(2);
+    value = text.toUInt(&ok, 16);
+    return ok ? value : 0;
+}
+
+bool streamStatusBelongsToUs(const QMap<QString, QString>& kvs, quint32 ourHandle)
+{
+    if (!kvs.contains(QStringLiteral("client_handle")))
+        return true; // Preserve compatibility with status lines that omit ownership.
+    const quint32 owner = parseStatusHandle(kvs.value(QStringLiteral("client_handle")));
+    return owner == 0 || owner == ourHandle;
+}
+
+int tciTrxForSlice(RadioModel* model, const SliceModel* slice)
+{
+    if (!model || !slice)
+        return 0;
+
+    const auto slices = model->slices();
+    const int index = slices.indexOf(const_cast<SliceModel*>(slice));
+    return index >= 0 ? index : slice->sliceId();
+}
 
 } // namespace
 
@@ -99,8 +132,32 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
         connect(m_model, &RadioModel::statusReceived,
                 this, [this](const QString& obj, const QMap<QString,QString>& kvs) {
             if (!obj.startsWith("stream ")) return;
+            const QStringList parts = obj.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+            if (parts.size() < 2) return;
+            bool ok = false;
+            quint32 streamId = parts[1].toUInt(&ok, 0);
+            if (!ok || streamId == 0) return;
+            const bool removed = parts.contains(QStringLiteral("removed")) || kvs.contains(QStringLiteral("removed"));
+            if (removed) {
+                for (auto it = m_tciDaxStreamIds.begin(); it != m_tciDaxStreamIds.end(); ++it) {
+                    if (it.value() == streamId) {
+                        qCInfo(lcCat) << "TCI: radio removed DAX RX stream" << Qt::hex << streamId
+                                      << "for channel" << it.key();
+                        it.value() = 0;
+                        break;
+                    }
+                }
+                if (m_model->panStream())
+                    m_model->panStream()->unregisterDaxStream(streamId);
+                return;
+            }
             if (kvs.value("type") != "dax_rx") return;
-            quint32 streamId = obj.mid(7).toUInt(nullptr, 16);
+            if (!streamStatusBelongsToUs(kvs, m_model->ourClientHandle())) {
+                qCDebug(lcCat) << "TCI: ignoring DAX RX stream for another client"
+                               << "stream=0x" + QString::number(streamId, 16)
+                               << "owner=" << kvs.value("client_handle");
+                return;
+            }
             int ch = kvs.value("dax_channel").toInt();
             if (!streamId || ch < 1 || ch > 4) return;
             // Only register if this channel is one we requested (placeholder = 0)
@@ -109,6 +166,9 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
             m_tciDaxStreamIds[ch] = streamId;
             if (m_model->panStream()) {
                 m_model->panStream()->registerDaxStream(streamId, ch);
+                qCDebug(lcCat) << "TCI: registered DAX RX stream"
+                               << "0x" + QString::number(streamId, 16)
+                               << "for channel" << ch;
                 qCInfo(lcCat) << "TCI: registered DAX RX stream" << Qt::hex << streamId
                               << "for channel" << ch << "(#1331)";
             }
@@ -352,9 +412,27 @@ void TciServer::onTextMessage(const QString& msg)
 
         // Handle audio start/stop at server level (affects per-client state)
         if (trimmed.startsWith("audio_start")) {
+            int requestedReceiver = -1;
+            const int colonIdx2 = trimmed.indexOf(':');
+            if (colonIdx2 >= 0) {
+                const QString receiverText = trimmed.mid(colonIdx2 + 1)
+                                                 .section(QLatin1Char(','), 0, 0)
+                                                 .trimmed();
+                bool ok = false;
+                const int parsedReceiver = receiverText.toInt(&ok);
+                if (ok)
+                    requestedReceiver = parsedReceiver;
+            }
             client.audioEnabled = true;
+            client.audioReceiver = requestedReceiver;
             ensureDaxForTci();
             ws->sendTextMessage(cmd.trimmed() + ";");
+            qCDebug(lcCat) << "TCI: audio started"
+                           << "receiver=" << client.audioReceiver
+                           << "rate=" << client.audioSampleRate
+                           << "channels=" << client.audioChannels
+                           << "format=" << client.audioFormat
+                           << "peer=" << ws->peerAddress().toString();
             qCInfo(lcCat) << "TCI: audio started for client"
                           << ws->peerAddress().toString()
                           << "rate=" << client.audioSampleRate
@@ -364,6 +442,7 @@ void TciServer::onTextMessage(const QString& msg)
         }
         if (trimmed.startsWith("audio_stop")) {
             client.audioEnabled = false;
+            client.audioReceiver = -1;
             // Release DAX if no other clients still want audio
             bool anyAudio = false;
             for (const auto& cs : m_clients) {
@@ -786,23 +865,31 @@ void TciServer::onRxAudioReady(const QByteArray& pcm)
 
 void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
 {
-    // Check if any client has audio enabled
-    bool anyAudio = false;
-    for (const auto& cs : m_clients) {
-        if (cs.audioEnabled) { anyAudio = true; break; }
-    }
-    if (!anyAudio) return;
-
-    // Map DAX channel → TRX by finding which slice owns this channel.
-    int trx = 0;
+    // Map DAX channel -> TCI TRX by the slice that owns the channel. Flex
+    // slice ids are not necessarily zero-based for this client when another
+    // client owns slice 0, but TCI receivers are advertised as 0..N-1.
+    int trx = std::max(0, channel - 1);
+    int owningSliceId = -1;
     if (m_model) {
         for (auto* s : m_model->slices()) {
             if (s->daxChannel() == channel) {
-                trx = s->sliceId();
+                trx = tciTrxForSlice(m_model, s);
+                owningSliceId = s->sliceId();
                 break;
             }
         }
     }
+
+    // Check if any client has this receiver's audio enabled. A client that
+    // sends audio_start with no receiver keeps the legacy all-receiver behavior.
+    int enabledClients = 0;
+    for (const auto& cs : m_clients) {
+        if (cs.audioEnabled && (cs.audioReceiver < 0 || cs.audioReceiver == trx))
+            ++enabledClients;
+    }
+    if (enabledClients == 0) return;
+
+    ++m_rxAudioPackets;
 
     const float channelGain = (channel >= 1 && channel <= 4)
         ? m_rxChannelGain[channel - 1] : 1.0f;
@@ -819,9 +906,16 @@ void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
         }
     }
 
+    int sentClients = 0;
+    int lastOutputFrames = 0;
+    int lastSampleRate = 0;
+    int lastChannels = 0;
+    int lastFormat = 0;
+
     // Per-client: accumulate then resample
     for (auto& cs : m_clients) {
         if (!cs.audioEnabled) continue;
+        if (cs.audioReceiver >= 0 && cs.audioReceiver != trx) continue;
 
         // Accumulate DAX packets into a buffer before resampling.
         // DAX delivers ~128-frame packets; r8brain needs larger blocks
@@ -881,17 +975,29 @@ void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
         if (cs.audioFormat == 3) {
             // float32 output — pass through directly
             if (cs.audioChannels == 2) {
-                cs.socket->sendBinaryMessage(
+                const QByteArray frame =
                     buildAudioFrame(trx, 1, cs.audioSampleRate, 2,
-                                    audioSrc, audioFrames));
+                                    audioSrc, audioFrames);
+                cs.socket->sendBinaryMessage(frame);
+                ++sentClients;
+                lastOutputFrames = audioFrames;
+                lastSampleRate = cs.audioSampleRate;
+                lastChannels = 2;
+                lastFormat = cs.audioFormat;
             } else {
                 // Mono: average L+R
                 QVector<float> monoBuf(audioFrames);
                 for (int i = 0; i < audioFrames; ++i)
                     monoBuf[i] = (audioSrc[i*2] + audioSrc[i*2+1]) * 0.5f;
-                cs.socket->sendBinaryMessage(
+                const QByteArray frame =
                     buildAudioFrame(trx, 1, cs.audioSampleRate, 1,
-                                    monoBuf.constData(), audioFrames));
+                                    monoBuf.constData(), audioFrames);
+                cs.socket->sendBinaryMessage(frame);
+                ++sentClients;
+                lastOutputFrames = audioFrames;
+                lastSampleRate = cs.audioSampleRate;
+                lastChannels = 1;
+                lastFormat = cs.audioFormat;
             }
         } else {
             // int16 output — convert float32 → int16
@@ -911,6 +1017,11 @@ void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
                     i16dst[i] = static_cast<qint16>(std::clamp(audioSrc[i] * 32768.0f, -32768.0f, 32767.0f));
                 }
                 cs.socket->sendBinaryMessage(frame);
+                ++sentClients;
+                lastOutputFrames = audioFrames;
+                lastSampleRate = cs.audioSampleRate;
+                lastChannels = 2;
+                lastFormat = cs.audioFormat;
             } else {
                 // Mono int16
                 int payloadBytes = audioFrames * static_cast<int>(sizeof(qint16));
@@ -928,8 +1039,36 @@ void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
                     i16dst[i] = static_cast<qint16>(std::clamp(
                         (audioSrc[i*2] + audioSrc[i*2+1]) * 0.5f * 32768.0f, -32768.0f, 32767.0f));
                 cs.socket->sendBinaryMessage(frame);
+                ++sentClients;
+                lastOutputFrames = audioFrames;
+                lastSampleRate = cs.audioSampleRate;
+                lastChannels = 1;
+                lastFormat = cs.audioFormat;
             }
         }
+    }
+
+    if (sentClients > 0)
+        m_rxAudioFramesSent += static_cast<qint64>(lastOutputFrames) * sentClients;
+
+    const bool firstLog = !m_rxAudioLogTimer.isValid();
+    const bool shouldLog = firstLog || m_rxAudioLogTimer.elapsed() >= 2000;
+    if (shouldLog && (sentClients > 0 || firstLog)) {
+        qCDebug(lcCat).noquote()
+            << "TCI: DAX RX audio"
+            << QStringLiteral("dax_ch=%1").arg(channel)
+            << QStringLiteral("slice=%1").arg(owningSliceId)
+            << QStringLiteral("receiver=%1").arg(trx)
+            << QStringLiteral("in_bytes=%1").arg(pcm.size())
+            << QStringLiteral("enabled_clients=%1").arg(enabledClients)
+            << QStringLiteral("sent_clients=%1").arg(sentClients)
+            << QStringLiteral("out_frames=%1").arg(lastOutputFrames)
+            << QStringLiteral("rate=%1").arg(lastSampleRate)
+            << QStringLiteral("channels=%1").arg(lastChannels)
+            << QStringLiteral("format=%1").arg(lastFormat)
+            << QStringLiteral("packets=%1").arg(m_rxAudioPackets)
+            << QStringLiteral("frames_sent=%1").arg(m_rxAudioFramesSent);
+        m_rxAudioLogTimer.restart();
     }
 }
 
@@ -970,33 +1109,39 @@ QByteArray TciServer::buildAudioFrame(int receiver, int type,
 void TciServer::wireSlice(int trx, SliceModel* slice)
 {
     if (!slice) return;
+    Q_UNUSED(trx);
 
-    connect(slice, &SliceModel::frequencyChanged, this, [this, trx](double mhz) {
+    connect(slice, &SliceModel::frequencyChanged, this, [this, slice](double mhz) {
         if (m_clients.isEmpty()) return;
+        const int trx = tciTrxForSlice(m_model, slice);
         long long hz = static_cast<long long>(std::round(mhz * 1e6));
         broadcast(QStringLiteral("vfo:%1,0,%2;").arg(trx).arg(hz));
     });
 
-    connect(slice, &SliceModel::modeChanged, this, [this, trx](const QString& mode) {
+    connect(slice, &SliceModel::modeChanged, this, [this, slice](const QString& mode) {
         if (m_clients.isEmpty()) return;
+        const int trx = tciTrxForSlice(m_model, slice);
         broadcast(QStringLiteral("modulation:%1,%2;")
                       .arg(trx).arg(TciProtocol::smartsdrToTci(mode)));
     });
 
-    connect(slice, &SliceModel::filterChanged, this, [this, trx](int lo, int hi) {
+    connect(slice, &SliceModel::filterChanged, this, [this, slice](int lo, int hi) {
         if (m_clients.isEmpty()) return;
+        const int trx = tciTrxForSlice(m_model, slice);
         broadcast(QStringLiteral("rx_filter_band:%1,%2,%3;")
                       .arg(trx).arg(lo).arg(hi));
     });
 
-    connect(slice, &SliceModel::txSliceChanged, this, [this, trx](bool tx) {
+    connect(slice, &SliceModel::txSliceChanged, this, [this, slice](bool tx) {
         if (m_clients.isEmpty()) return;
+        const int trx = tciTrxForSlice(m_model, slice);
         broadcast(QStringLiteral("tx_enable:%1,%2;")
                       .arg(trx).arg(tx ? "true" : "false"));
     });
 
-    connect(slice, &SliceModel::lockedChanged, this, [this, trx](bool locked) {
+    connect(slice, &SliceModel::lockedChanged, this, [this, slice](bool locked) {
         if (m_clients.isEmpty()) return;
+        const int trx = tciTrxForSlice(m_model, slice);
         broadcast(QStringLiteral("lock:%1,%2;")
                       .arg(trx).arg(locked ? "true" : "false"));
     });
@@ -1029,6 +1174,18 @@ void TciServer::sendInitBurst(QWebSocket* client)
         if (cs.socket == client) { protocol = cs.protocol; break; }
     }
     if (!protocol) return;
+
+    QStringList receiverMap;
+    const auto slices = m_model->slices();
+    for (auto* s : slices) {
+        receiverMap << QStringLiteral("trx%1=slice%2/dax%3")
+                           .arg(tciTrxForSlice(m_model, s))
+                           .arg(s->sliceId())
+                           .arg(s->daxChannel());
+    }
+    qCDebug(lcCat).noquote()
+        << "TCI: receiver map"
+        << (receiverMap.isEmpty() ? QStringLiteral("(none)") : receiverMap.join(QLatin1Char(' ')));
 
     // TCI protocol requires one command per WebSocket message.
     // Split the concatenated burst into individual messages.
@@ -1204,9 +1361,10 @@ void TciServer::broadcastStatus()
     // Broadcast S-meter for each owned slice (throttled to 200ms)
     // TCI spec: rx_smeter:receiver,value; (2 args)
     for (auto* s : m_model->slices()) {
-        int trx = s->sliceId();
-        if (trx >= 0 && trx < 8) {
-            float dbm = m_cachedSLevel[trx];
+        const int trx = tciTrxForSlice(m_model, s);
+        const int meterIndex = s->sliceId();
+        if (trx >= 0 && meterIndex >= 0 && meterIndex < 8) {
+            float dbm = m_cachedSLevel[meterIndex];
             if (dbm > -200.0f)
                 broadcast(QStringLiteral("rx_smeter:%1,%2;")
                               .arg(trx).arg(static_cast<int>(dbm)));
@@ -1217,9 +1375,10 @@ void TciServer::broadcastStatus()
     for (auto& cs : m_clients) {
         if (cs.rxSensorsEnabled) {
             for (auto* s : m_model->slices()) {
-                int trx = s->sliceId();
-                if (trx >= 0 && trx < 8) {
-                    float dbm = m_cachedSLevel[trx];
+                const int trx = tciTrxForSlice(m_model, s);
+                const int meterIndex = s->sliceId();
+                if (trx >= 0 && meterIndex >= 0 && meterIndex < 8) {
+                    float dbm = m_cachedSLevel[meterIndex];
                     if (dbm > -200.0f)
                         cs.socket->sendTextMessage(
                             QStringLiteral("rx_channel_sensors:%1,0,%2;")
@@ -1246,7 +1405,7 @@ void TciServer::broadcastStatus()
         double txFreqMhz = 0;
         for (auto* s : m_model->slices()) {
             if (s->isTxSlice()) {
-                txTrx = s->sliceId();
+                txTrx = tciTrxForSlice(m_model, s);
                 txFreqMhz = s->frequency();
                 break;
             }
@@ -1327,6 +1486,8 @@ void TciServer::ensureDaxForTci()
             }
             for (int ch = 1; ch <= 4; ++ch) {
                 if (!used.contains(ch)) {
+                    qCDebug(lcCat) << "TCI: auto-assigning DAX channel" << ch
+                                   << "to slice" << s->sliceId();
                     qCInfo(lcCat) << "TCI: auto-assigning DAX channel" << ch
                                   << "to slice" << s->sliceId() << "for TCI audio (#1331)";
                     s->setDaxChannel(ch);
@@ -1355,11 +1516,15 @@ void TciServer::ensureDaxForTci()
         if (existingId != 0) {
             m_tciDaxStreamIds[ch] = existingId;
             m_tciDaxBorrowedChannels.insert(ch);
+            qCDebug(lcCat) << "TCI: reusing existing DAX RX stream"
+                           << "0x" + QString::number(existingId, 16)
+                           << "for channel" << ch;
             qCInfo(lcCat) << "TCI: reusing existing DAX RX stream" << Qt::hex << existingId
                           << "for channel" << ch << "(#1331)";
         } else {
             m_tciDaxStreamIds[ch] = 0;
             m_model->sendCommand(QString("stream create type=dax_rx dax_channel=%1").arg(ch));
+            qCDebug(lcCat) << "TCI: creating DAX RX stream for channel" << ch;
             qCInfo(lcCat) << "TCI: creating DAX RX stream for channel" << ch << "(#1331)";
         }
     }
@@ -1372,6 +1537,8 @@ void TciServer::ensureDaxForTci()
         if (ch > 0 && channelsNeeded.contains(ch)) {
             m_model->sendCommand(QString("slice set %1 dax=%2")
                 .arg(s->sliceId()).arg(ch));
+            qCDebug(lcCat) << "TCI: re-asserting DAX channel" << ch
+                           << "on slice" << s->sliceId();
             qCInfo(lcCat) << "TCI: re-asserting dax=" << ch
                           << "on slice" << s->sliceId();
         }

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -95,6 +95,7 @@ private:
         QWebSocket*  socket{nullptr};
         TciProtocol* protocol{nullptr};
         bool         audioEnabled{false};   // client sent AUDIO_START
+        int          audioReceiver{-1};     // -1 = all receivers, otherwise TCI TRX
         int          audioSampleRate{48000}; // requested output rate (48kHz for WSJT-X compat)
         int          audioChannels{2};       // 1=mono, 2=stereo
         int          audioFormat{3};         // 0=int16, 3=float32
@@ -152,6 +153,9 @@ private:
     double            m_txAudioSumSq{0.0};
     float             m_txAudioPeak{0.0f};
     bool              m_txSawDuplicatedStereo{false};
+    QElapsedTimer     m_rxAudioLogTimer;
+    qint64            m_rxAudioPackets{0};
+    qint64            m_rxAudioFramesSent{0};
     bool              m_lastTx{false};
     float             m_cachedSLevel[8]{-130,-130,-130,-130,-130,-130,-130,-130};
     float             m_cachedFwdPower{0};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -230,6 +230,28 @@ QString xvtrForBandSummary(const QString& bandName,
     return QStringLiteral("(none)");
 }
 
+quint32 parseStatusHandle(QString text)
+{
+    text = text.trimmed();
+    bool ok = false;
+    quint32 value = text.toUInt(&ok, 0);
+    if (ok)
+        return value;
+
+    if (text.startsWith(QStringLiteral("0x"), Qt::CaseInsensitive))
+        text = text.mid(2);
+    value = text.toUInt(&ok, 16);
+    return ok ? value : 0;
+}
+
+bool streamStatusBelongsToUs(const QMap<QString, QString>& kvs, quint32 ourHandle)
+{
+    if (!kvs.contains(QStringLiteral("client_handle")))
+        return true; // Older firmware/status lines may omit ownership.
+    const quint32 owner = parseStatusHandle(kvs.value(QStringLiteral("client_handle")));
+    return owner == 0 || owner == ourHandle;
+}
+
 void logXvtrWaterfallDecision(quint32 streamId,
                               const QString& panId,
                               double panCenterMhz,
@@ -3466,14 +3488,21 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_tciServer, &TciServer::txLevel,
             m_appletPanel->tciApplet(), &TciApplet::setTciTxLevel);
 
-    // Wire slice state changes → TCI broadcasts
-    connect(&m_radioModel, &RadioModel::sliceAdded, this, [this](SliceModel* s) {
-        if (m_tciServer)
-            m_tciServer->wireSlice(s->sliceId(), s);
+    // Wire slice state changes -> TCI broadcasts. TCI receivers are contiguous
+    // indexes within our owned slice list; Flex slice ids can be non-zero when
+    // another client owns lower-numbered slices.
+    auto wireTciSlice = [this](SliceModel* s) {
+        if (!m_tciServer || !s)
+            return;
+        const int trx = m_radioModel.slices().indexOf(s);
+        m_tciServer->wireSlice(trx >= 0 ? trx : s->sliceId(), s);
+    };
+    connect(&m_radioModel, &RadioModel::sliceAdded, this, [wireTciSlice](SliceModel* s) {
+        wireTciSlice(s);
     });
     // Wire existing slices (radio may already be connected with slices)
     for (auto* s : m_radioModel.slices())
-        m_tciServer->wireSlice(s->sliceId(), s);
+        wireTciSlice(s);
     m_tciServer->wireSpotModel();
 
     // Wire RX audio from PanadapterStream → TCI server for audio streaming.
@@ -10744,14 +10773,31 @@ bool MainWindow::startDax()
     connect(&m_radioModel, &RadioModel::statusReceived,
             m_daxBridge, [this](const QString& obj, const QMap<QString,QString>& kvs) {
         if (!obj.startsWith("stream ")) return;
+        const QStringList parts = obj.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() < 2) return;
+        bool ok = false;
+        quint32 streamId = parts[1].toUInt(&ok, 0);
+        if (!ok) return;
+        const bool removed = parts.contains(QStringLiteral("removed")) || kvs.contains(QStringLiteral("removed"));
+        if (removed) {
+            m_radioModel.panStream()->unregisterDaxStream(streamId);
+            qCDebug(lcDax) << "MainWindow: unregistered removed DAX RX stream"
+                           << "0x" + QString::number(streamId, 16);
+            return;
+        }
         QString type = kvs.value("type");
         if (type == "dax_rx") {
-            quint32 streamId = obj.mid(7).toUInt(nullptr, 16);
+            if (!streamStatusBelongsToUs(kvs, m_radioModel.ourClientHandle())) {
+                qCDebug(lcDax) << "MainWindow: ignoring DAX RX stream for another client"
+                                << "stream=0x" + QString::number(streamId, 16)
+                                << "owner=" << kvs.value("client_handle");
+                return;
+            }
             int ch = kvs.value("dax_channel").toInt();
             if (streamId && ch >= 1 && ch <= 4) {
                 m_radioModel.panStream()->registerDaxStream(streamId, ch);
-                qDebug() << "MainWindow: registered DAX RX ch" << ch
-                         << "stream" << Qt::hex << streamId;
+                qCDebug(lcDax) << "MainWindow: registered DAX RX ch" << ch
+                                << "stream=0x" + QString::number(streamId, 16);
             }
         }
     });
@@ -10776,20 +10822,35 @@ bool MainWindow::startDax()
     connect(&m_radioModel, &RadioModel::statusReceived,
             this, [this](const QString& obj, const QMap<QString,QString>& kvs) {
         if (!obj.startsWith("stream ")) return;
+        const QStringList parts = obj.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() < 2) return;
+        bool ok = false;
+        quint32 streamId = parts[1].toUInt(&ok, 0);
+        if (!ok) return;
+        const bool removed = parts.contains(QStringLiteral("removed")) || kvs.contains(QStringLiteral("removed"));
+        if (removed) {
+            m_radioModel.panStream()->unregisterIqStream(streamId);
+            m_radioModel.daxIqModel().handleStreamRemoved(streamId);
+            qCDebug(lcDax) << "MainWindow: unregistered removed DAX IQ stream"
+                           << "0x" + QString::number(streamId, 16);
+            return;
+        }
         QString type = kvs.value("type");
         if (type == "dax_iq") {
-            qDebug() << "DAX IQ STREAM STATUS:" << obj << "keys=" << kvs.keys()
-                     << "ch=" << kvs.value("daxiq_channel") << "ip=" << kvs.value("ip");
-            quint32 streamId = obj.mid(7).toUInt(nullptr, 0);
-            if (kvs.contains("removed")) {
-                m_radioModel.panStream()->unregisterIqStream(streamId);
-                m_radioModel.daxIqModel().handleStreamRemoved(streamId);
-            } else {
-                m_radioModel.daxIqModel().applyStreamStatus(streamId, kvs);
-                int ch = kvs.value("daxiq_channel").toInt();
-                if (streamId && ch >= 1 && ch <= 4)
-                    m_radioModel.panStream()->registerIqStream(streamId, ch);
+            if (!streamStatusBelongsToUs(kvs, m_radioModel.ourClientHandle())) {
+                qCDebug(lcDax) << "MainWindow: ignoring DAX IQ stream for another client"
+                                << "stream=0x" + QString::number(streamId, 16)
+                                << "owner=" << kvs.value("client_handle");
+                return;
             }
+            qCDebug(lcDax) << "MainWindow: DAX IQ stream status" << obj
+                           << "keys=" << kvs.keys()
+                           << "ch=" << kvs.value("daxiq_channel")
+                           << "ip=" << kvs.value("ip");
+            m_radioModel.daxIqModel().applyStreamStatus(streamId, kvs);
+            int ch = kvs.value("daxiq_channel").toInt();
+            if (streamId && ch >= 1 && ch <= 4)
+                m_radioModel.panStream()->registerIqStream(streamId, ch);
         }
     });
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -86,6 +86,66 @@ quint32 parseClientHandle(QString text)
     return ok ? handle : 0;
 }
 
+quint32 parseStreamToken(QString text)
+{
+    text = text.trimmed();
+    bool ok = false;
+    quint32 value = text.toUInt(&ok, 0);
+    if (ok)
+        return value;
+
+    if (text.startsWith(QStringLiteral("0x"), Qt::CaseInsensitive))
+        text = text.mid(2);
+
+    value = text.toUInt(&ok, 16);
+    return ok ? value : 0;
+}
+
+QString hexId(quint32 value)
+{
+    return QStringLiteral("0x%1")
+        .arg(QString::number(value, 16).rightJustified(8, QLatin1Char('0')));
+}
+
+struct StreamObjectParts {
+    bool valid{false};
+    quint32 streamId{0};
+    QString action;
+};
+
+StreamObjectParts parseStreamObject(const QString& object, const QString& prefix)
+{
+    if (!object.startsWith(prefix + QLatin1Char(' ')))
+        return {};
+
+    const QString rest = object.mid(prefix.size() + 1).trimmed();
+    const int firstSpace = rest.indexOf(QLatin1Char(' '));
+    const QString idText = firstSpace >= 0 ? rest.left(firstSpace) : rest;
+
+    StreamObjectParts parts;
+    parts.streamId = parseStreamToken(idText);
+    parts.valid = parts.streamId != 0;
+    if (firstSpace >= 0)
+        parts.action = rest.mid(firstSpace + 1).trimmed();
+    return parts;
+}
+
+bool isDaxStreamType(const QString& type)
+{
+    return type == QStringLiteral("dax_rx")
+        || type == QStringLiteral("dax_tx")
+        || type == QStringLiteral("dax_mic")
+        || type == QStringLiteral("dax_iq");
+}
+
+bool streamStatusRemoved(const StreamObjectParts& stream,
+                         const QMap<QString, QString>& kvs)
+{
+    return stream.action == QStringLiteral("removed")
+        || kvs.contains(QStringLiteral("removed"))
+        || kvs.value(QStringLiteral("in_use")) == QStringLiteral("0");
+}
+
 bool looksLikeClientId(const QString& value)
 {
     static const QRegularExpression guidRe(
@@ -1352,8 +1412,14 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                             [this](int code, const QString& body) {
                                 if (code == 0) {
                                     quint32 id = body.trimmed().toUInt(nullptr, 16);
+                                    m_daxTxStreamId = id;
+                                    m_daxTxActive = false;
+                                    m_daxTxClientHandle = 0;
                                     qCDebug(lcProtocol) << "RadioModel: dax_tx stream created, id:"
                                              << Qt::hex << id;
+                                    qCDebug(lcDax).noquote()
+                                        << "RadioModel: requested DAX TX stream"
+                                        << QStringLiteral("stream=%1").arg(hexId(id));
                                     emit txAudioStreamReady(id);
                                 } else {
                                     qCWarning(lcProtocol) << "RadioModel: dax_tx failed, code"
@@ -1543,6 +1609,10 @@ void RadioModel::onDisconnected()
     m_transmitModel.setTransmitting(false);
     m_transmitModel.resetState();
     m_meterModel.clear();
+    m_daxStreamDebug.clear();
+    m_daxTxStreamId = 0;
+    m_daxTxActive = false;
+    m_daxTxClientHandle = 0;
 
     // Reset radio-model-specific state — different radios have different
     // capabilities (APD, max power, pan count, TGXL, amplifier, XVTR, etc.)
@@ -2103,11 +2173,146 @@ void RadioModel::emitOtherClientsChanged()
     emit otherClientsChanged(names.size(), names);
 }
 
+void RadioModel::traceDaxStreamStatus(const QString& object,
+                                      const QMap<QString, QString>& kvs)
+{
+    const auto stream = parseStreamObject(object, QStringLiteral("stream"));
+    if (stream.valid) {
+        const QString incomingType = kvs.value(QStringLiteral("type"));
+        const QString knownType = m_daxStreamDebug.value(stream.streamId).type;
+        const bool daxRelated = isDaxStreamType(incomingType)
+            || isDaxStreamType(knownType)
+            || stream.streamId == m_daxTxStreamId;
+        if (!daxRelated)
+            return;
+
+        const bool removed = streamStatusRemoved(stream, kvs);
+        const QString type = incomingType.isEmpty() ? knownType : incomingType;
+        if (removed) {
+            qCDebug(lcDax).noquote()
+                << "RadioModel: DAX stream removed"
+                << QStringLiteral("stream=%1").arg(hexId(stream.streamId))
+                << QStringLiteral("type=%1").arg(type.isEmpty() ? QStringLiteral("(unknown)") : type)
+                << QStringLiteral("keys=%1").arg(kvs.keys().join(QLatin1Char(',')));
+            if (stream.streamId == m_daxTxStreamId) {
+                m_daxTxStreamId = 0;
+                m_daxTxActive = false;
+                m_daxTxClientHandle = 0;
+            }
+            m_daxStreamDebug.remove(stream.streamId);
+            return;
+        }
+
+        auto& state = m_daxStreamDebug[stream.streamId];
+        if (!incomingType.isEmpty())
+            state.type = incomingType;
+        if (kvs.contains(QStringLiteral("client_handle")))
+            state.clientHandle = parseClientHandle(kvs.value(QStringLiteral("client_handle")));
+        if (kvs.contains(QStringLiteral("dax_channel")))
+            state.daxChannel = kvs.value(QStringLiteral("dax_channel")).toInt();
+        if (kvs.contains(QStringLiteral("daxiq_channel")))
+            state.daxIqChannel = kvs.value(QStringLiteral("daxiq_channel")).toInt();
+        if (kvs.contains(QStringLiteral("slice")))
+            state.sliceId = kvs.value(QStringLiteral("slice")).toInt();
+        if (kvs.contains(QStringLiteral("daxiq_rate")))
+            state.daxIqRate = kvs.value(QStringLiteral("daxiq_rate")).toInt();
+        if (kvs.contains(QStringLiteral("pan")))
+            state.panId = kvs.value(QStringLiteral("pan"));
+        if (kvs.contains(QStringLiteral("active"))) {
+            state.active = kvs.value(QStringLiteral("active")) == QStringLiteral("1");
+            state.activeKnown = true;
+        }
+        if (kvs.contains(QStringLiteral("tx"))) {
+            state.tx = kvs.value(QStringLiteral("tx")) == QStringLiteral("1");
+            state.txKnown = true;
+        }
+
+        if (state.type == QStringLiteral("dax_tx")) {
+            m_daxTxStreamId = stream.streamId;
+            m_daxTxActive = state.tx;
+            m_daxTxClientHandle = state.clientHandle;
+        }
+
+        const bool ownerKnown = state.clientHandle != 0;
+        const bool ownedByUs = ownerKnown && state.clientHandle == clientHandle();
+        QStringList fields;
+        fields << QStringLiteral("stream=%1").arg(hexId(stream.streamId));
+        fields << QStringLiteral("type=%1").arg(state.type.isEmpty() ? QStringLiteral("(unknown)") : state.type);
+        fields << QStringLiteral("owner=%1").arg(ownerKnown ? hexId(state.clientHandle) : QStringLiteral("(unknown)"));
+        fields << QStringLiteral("ours=%1").arg(ownerKnown ? (ownedByUs ? QStringLiteral("1") : QStringLiteral("0"))
+                                                            : QStringLiteral("?"));
+        if (state.daxChannel > 0)
+            fields << QStringLiteral("dax_ch=%1").arg(state.daxChannel);
+        if (state.daxIqChannel > 0)
+            fields << QStringLiteral("daxiq_ch=%1").arg(state.daxIqChannel);
+        if (state.sliceId >= 0)
+            fields << QStringLiteral("slice=%1").arg(state.sliceId);
+        if (state.daxIqRate > 0)
+            fields << QStringLiteral("daxiq_rate=%1").arg(state.daxIqRate);
+        if (!state.panId.isEmpty())
+            fields << QStringLiteral("pan=%1").arg(state.panId);
+        if (state.activeKnown)
+            fields << QStringLiteral("active=%1").arg(state.active ? 1 : 0);
+        if (state.txKnown)
+            fields << QStringLiteral("tx=%1").arg(state.tx ? 1 : 0);
+        fields << QStringLiteral("keys=%1").arg(kvs.keys().join(QLatin1Char(',')));
+
+        qCDebug(lcDax).noquote()
+            << "RadioModel: DAX stream status" << fields.join(QLatin1Char(' '));
+        return;
+    }
+
+    const auto txAudioStream = parseStreamObject(object, QStringLiteral("tx_audio_stream"));
+    if (!txAudioStream.valid)
+        return;
+
+    const bool removed = streamStatusRemoved(txAudioStream, kvs);
+    if (removed) {
+        qCDebug(lcDax).noquote()
+            << "RadioModel: DAX tx_audio_stream removed"
+            << QStringLiteral("stream=%1").arg(hexId(txAudioStream.streamId))
+            << QStringLiteral("keys=%1").arg(kvs.keys().join(QLatin1Char(',')));
+        if (txAudioStream.streamId == m_daxTxStreamId) {
+            m_daxTxStreamId = 0;
+            m_daxTxActive = false;
+            m_daxTxClientHandle = 0;
+        }
+        m_daxStreamDebug.remove(txAudioStream.streamId);
+        return;
+    }
+
+    auto& state = m_daxStreamDebug[txAudioStream.streamId];
+    state.type = QStringLiteral("dax_tx");
+    if (kvs.contains(QStringLiteral("client_handle")))
+        state.clientHandle = parseClientHandle(kvs.value(QStringLiteral("client_handle")));
+    if (kvs.contains(QStringLiteral("tx"))) {
+        state.tx = kvs.value(QStringLiteral("tx")) == QStringLiteral("1");
+        state.txKnown = true;
+    }
+    m_daxTxStreamId = txAudioStream.streamId;
+    m_daxTxActive = state.tx;
+    m_daxTxClientHandle = state.clientHandle;
+
+    const bool ownerKnown = state.clientHandle != 0;
+    const bool ownedByUs = ownerKnown && state.clientHandle == clientHandle();
+    qCDebug(lcDax).noquote()
+        << "RadioModel: DAX tx_audio_stream status"
+        << QStringLiteral("stream=%1").arg(hexId(txAudioStream.streamId))
+        << QStringLiteral("owner=%1").arg(ownerKnown ? hexId(state.clientHandle) : QStringLiteral("(unknown)"))
+        << QStringLiteral("ours=%1").arg(ownerKnown ? (ownedByUs ? QStringLiteral("1") : QStringLiteral("0"))
+                                                    : QStringLiteral("?"))
+        << QStringLiteral("tx=%1").arg(state.txKnown ? (state.tx ? QStringLiteral("1") : QStringLiteral("0"))
+                                                     : QStringLiteral("?"))
+        << QStringLiteral("keys=%1").arg(kvs.keys().join(QLatin1Char(',')));
+}
+
 void RadioModel::onStatusReceived(const QString& object,
                                   const QMap<QString, QString>& kvs)
 {
     // Relay to listeners (e.g., MemoryDialog)
     emit statusReceived(object, kvs);
+
+    traceDaxStreamStatus(object, kvs);
 
     if (object == "radio") {
         handleRadioStatus(kvs);
@@ -3320,7 +3525,13 @@ void RadioModel::createAudioStream()
         [this](int code, const QString& body) {
             if (code == 0) {
                 quint32 id = body.trimmed().toUInt(nullptr, 16);
+                m_daxTxStreamId = id;
+                m_daxTxActive = false;
+                m_daxTxClientHandle = 0;
                 qCDebug(lcProtocol) << "RadioModel: dax_tx stream re-created, id:" << Qt::hex << id;
+                qCDebug(lcDax).noquote()
+                    << "RadioModel: requested DAX TX stream"
+                    << QStringLiteral("stream=%1").arg(hexId(id));
                 emit txAudioStreamReady(id);
             }
         });

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -387,6 +387,7 @@ private:
     void handlePanadapterStatus(const QString& panId, const QMap<QString, QString>& kvs);
     void handleProfileStatus(const QString& object, const QMap<QString, QString>& kvs);
     void handleProfileStatusRaw(const QString& profileType, const QString& rawBody);
+    void traceDaxStreamStatus(const QString& object, const QMap<QString, QString>& kvs);
 
     void configurePan();
     void configureWaterfall();
@@ -594,6 +595,23 @@ private:
     QStringList m_globalProfiles;
     QString     m_activeGlobalProfile;
     QString     m_rxAudioStreamId;
+    struct DaxStreamDebugState {
+        QString type;
+        quint32 clientHandle{0};
+        int daxChannel{0};
+        int daxIqChannel{0};
+        int sliceId{-1};
+        int daxIqRate{0};
+        QString panId;
+        bool active{false};
+        bool tx{false};
+        bool activeKnown{false};
+        bool txKnown{false};
+    };
+    QMap<quint32, DaxStreamDebugState> m_daxStreamDebug;
+    quint32     m_daxTxStreamId{0};
+    bool        m_daxTxActive{false};
+    quint32     m_daxTxClientHandle{0};
     WanConnection* m_wanConn{nullptr};  // non-null when connected via SmartLink
     QString  m_wanPublicIp;
     quint16  m_wanUdpPort{4991};


### PR DESCRIPTION

<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/b845e26d-4e3c-46a7-b043-3dd63fbde9b7" />

## Summary

This PR updates the DAX/TCI audio path for the newer FlexRadio 4.2.18 firmware behavior while preserving compatibility with earlier firmware status formats.

- Filter DAX RX/IQ stream status by `client_handle` when the radio reports stream ownership, while accepting ownership-less status lines from older firmware.
- Track DAX RX, DAX IQ, DAX TX, and DAX mic stream status in `RadioModel` so the logs identify stream IDs, ownership, DAX channel, slice, active/TX state, and removal events.
- Handle radio stream removal messages by unregistering DAX/IQ streams and clearing TCI DAX stream placeholders.
- Advertise TCI receivers as contiguous owned-slice indexes (`0..N-1`) rather than raw Flex slice IDs, with a raw-slice fallback for older clients.
- Route TCI RX audio by the slice that owns the incoming DAX channel, and honor per-client `audio_start:<receiver>` selection so multi-slice WSJT-X instances receive the intended audio stream.
- Add focused diagnostics for first DAX VITA packets, TCI receiver maps, DAX RX audio delivery, DAX TX route selection, and DAX channel reassertion.

## Why

Firmware 4.2.18 reports DAX stream ownership more explicitly, and multiple clients can now expose DAX-related stream status for the same DAX channel. The previous path could register another client's DAX stream or expose raw Flex slice IDs through TCI, which breaks clients like WSJT-X when this AetherSDR instance owns slice `1` but advertises only one TCI receiver.

The fix makes stream ownership explicit where the firmware provides it, keeps older firmware working when `client_handle` is absent, and keeps TCI receiver numbering aligned with what clients actually see in `trx_count`.

## Compatibility

Older firmware remains supported:

- DAX stream status without `client_handle` is still accepted.
- TCI commands that reference raw Flex slice IDs still fall back to slice-id lookup after contiguous receiver lookup.
- Receiver-less `audio_start` keeps the existing all-receiver audio behavior.
- DAX channel routing falls back to `channel - 1` if a slice-to-DAX mapping is unavailable.

## Multi-Slice Behavior

TCI now treats the current owned slice list as the receiver namespace:

- First owned slice is TCI receiver `0`.
- Second owned slice is TCI receiver `1`.
- Signal broadcasts compute the receiver index live, so slice removal or reordering does not leave stale captured indexes.
- DAX RX audio is delivered only to clients that requested the mapped receiver via `audio_start:<receiver>`, while legacy clients still receive all enabled audio.

## Validation

- `cmake --build build -j10`
- `ctest --test-dir build --output-on-failure -j10` reports no registered tests in this build tree.
- Manual WSJT-X validation by @jensenpat:
  - Confirmed DAX TX/RX QSOs.
  - Confirmed TCI TX/RX QSOs.
  - Confirmed multi-slice TCI operation using WSJT-X TCI1 and TCI2 drivers.

## Notes

The added logging is intentionally targeted around DAX/TCI stream ownership and first-packet/audio-routing diagnostics. It should make future firmware behavior changes easier to identify without changing the core protocol behavior for older radios.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
