### PR TITLE
VfoWidget: collapse marker + edges buttons; add Marker: Off state

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9150,11 +9150,11 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     // filter-edge visibility preferences to this slice's overlay whenever they
     // change. Also fires once on setSlice() below to apply loaded defaults.
     connect(w, &VfoWidget::markerStyleChanged, this,
-            [this, sliceId](bool thin, bool hideEdges) {
+            [this, sliceId](int markerWidth, bool hideEdges) {
         auto* sl = m_radioModel.slice(sliceId);
         if (!sl) return;
         if (auto* sw = spectrumForSlice(sl))
-            sw->setSliceOverlayMarkerStyle(sliceId, thin, hideEdges);
+            sw->setSliceOverlayMarkerStyle(sliceId, markerWidth, hideEdges);
     });
 
     // Pan re-apply after NR mono-mix (#1460, #1796): keep AudioEngine in sync

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1201,13 +1201,13 @@ void SpectrumWidget::setSliceOverlay(int sliceId, double freq, int fLow, int fHi
     }
 }
 
-void SpectrumWidget::setSliceOverlayMarkerStyle(int sliceId, bool markerThin, bool filterEdgesHidden)
+void SpectrumWidget::setSliceOverlayMarkerStyle(int sliceId, int markerWidth, bool filterEdgesHidden)
 {
     int idx = overlayIndex(sliceId);
     if (idx < 0) return;
     auto& o = m_sliceOverlays[idx];
-    if (o.markerThin == markerThin && o.filterEdgesHidden == filterEdgesHidden) return;
-    o.markerThin = markerThin;
+    if (o.markerWidth == markerWidth && o.filterEdgesHidden == filterEdgesHidden) return;
+    o.markerWidth = markerWidth;
     o.filterEdgesHidden = filterEdgesHidden;
     markOverlayDirty();
 }
@@ -4748,12 +4748,14 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
             p.drawText(markX + 2, specRect.top() + 12, "M");
             p.setPen(QColor(220, 60, 60, 240));
             p.drawText(spaceX + 2, specRect.top() + 12, "S");
-        } else {
+        } else if (so.markerWidth > 0) {
             // ── Standard VFO center line ─────────────────────────────────
+            // Skipped entirely when markerWidth == 0 (user chose
+            // "Marker: Off") — passband bracket only.
             int markerX = vfoX;
 
             // Per-slice VFO marker thickness — user-toggled via VFO flag (#1526)
-            const qreal vfoLineW = so.markerThin ? 1.0 : 2.0;
+            const qreal vfoLineW = static_cast<qreal>(so.markerWidth);
             p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 220), vfoLineW));
             p.drawLine(markerX, specRect.top(), markerX, freqLineBottom);
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -247,8 +247,10 @@ public:
         int    ritFreq{0};          // Hz offset
         bool   xitOn{false};
         int    xitFreq{0};          // Hz offset
-        // Per-slice VFO marker display preferences (#1526)
-        bool   markerThin{false};         // 1px center line instead of 2px
+        // Per-slice VFO marker display preferences (#1526).
+        // markerWidth: 0 = off (no center line / triangle, passband only),
+        // 1 = 1 px, 3 = 3 px.
+        int    markerWidth{1};
         bool   filterEdgesHidden{false};  // skip drawing filter-edge vertical lines
     };
 
@@ -262,7 +264,7 @@ public:
     // Update just the frequency on an existing overlay (for optimistic scroll-to-tune)
     void setSliceOverlayFreq(int sliceId, double freqMhz);
     // Update per-slice marker display style (#1526)
-    void setSliceOverlayMarkerStyle(int sliceId, bool markerThin, bool filterEdgesHidden);
+    void setSliceOverlayMarkerStyle(int sliceId, int markerWidth, bool filterEdgesHidden);
     // Remove a slice overlay.
     void removeSliceOverlay(int sliceId);
 

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1914,15 +1914,23 @@ void VfoWidget::setSmartSdrPlus(bool has)
 
 // ── Per-slice VFO marker display prefs (#1526) ───────────────────────────────
 
-void VfoWidget::setMarkerThin(bool thin)
+void VfoWidget::setMarkerWidth(int widthPx)
 {
-    if (m_markerThin != thin) {
-        m_markerThin = thin;
+    // Snap to one of the supported states: 0 (off), 1, 3.
+    if (widthPx <= 0)      widthPx = 0;
+    else if (widthPx <= 1) widthPx = 1;
+    else                   widthPx = 3;
+
+    if (m_markerWidth != widthPx) {
+        m_markerWidth = widthPx;
         saveDisplayPrefs();
-        emit markerStyleChanged(m_markerThin, m_filterEdgesHidden);
+        emit markerStyleChanged(m_markerWidth, m_filterEdgesHidden);
     }
-    if (m_markerThinBtn)  m_markerThinBtn->setChecked(thin);
-    if (m_markerThickBtn) m_markerThickBtn->setChecked(!thin);
+    if (m_markerThicknessBtn) {
+        const QString label = (widthPx == 0) ? QStringLiteral("Marker: Off")
+                            : QStringLiteral("Marker: %1px").arg(widthPx);
+        m_markerThicknessBtn->setText(label);
+    }
 }
 
 void VfoWidget::setFilterEdgesHidden(bool hide)
@@ -1930,19 +1938,26 @@ void VfoWidget::setFilterEdgesHidden(bool hide)
     if (m_filterEdgesHidden != hide) {
         m_filterEdgesHidden = hide;
         saveDisplayPrefs();
-        emit markerStyleChanged(m_markerThin, m_filterEdgesHidden);
+        emit markerStyleChanged(m_markerWidth, m_filterEdgesHidden);
     }
-    if (m_edgesShowBtn) m_edgesShowBtn->setChecked(!hide);
-    if (m_edgesHideBtn) m_edgesHideBtn->setChecked(hide);
+    if (m_edgesBtn) m_edgesBtn->setChecked(!hide);
 }
 
 void VfoWidget::loadDisplayPrefs()
 {
     if (!m_slice) return;
     auto& s = AppSettings::instance();
+    const QString keyW = QStringLiteral("Slice%1_MarkerWidth").arg(m_slice->sliceId());
     const QString keyT = QStringLiteral("Slice%1_MarkerThin").arg(m_slice->sliceId());
     const QString keyH = QStringLiteral("Slice%1_FilterEdgesHidden").arg(m_slice->sliceId());
-    m_markerThin        = s.value(keyT, "False").toString() == "True";
+    if (s.contains(keyW)) {
+        m_markerWidth = s.value(keyW, "1").toString().toInt();
+    } else {
+        // Migrate from the old MarkerThin bool: True (thin) → 1, False (thick) → 3.
+        m_markerWidth = (s.value(keyT, "False").toString() == "True") ? 1 : 3;
+    }
+    if (m_markerWidth != 0 && m_markerWidth != 1 && m_markerWidth != 3)
+        m_markerWidth = 1;
     m_filterEdgesHidden = s.value(keyH, "False").toString() == "True";
 }
 
@@ -1950,9 +1965,9 @@ void VfoWidget::saveDisplayPrefs()
 {
     if (!m_slice) return;
     auto& s = AppSettings::instance();
-    const QString keyT = QStringLiteral("Slice%1_MarkerThin").arg(m_slice->sliceId());
+    const QString keyW = QStringLiteral("Slice%1_MarkerWidth").arg(m_slice->sliceId());
     const QString keyH = QStringLiteral("Slice%1_FilterEdgesHidden").arg(m_slice->sliceId());
-    s.setValue(keyT, m_markerThin ? "True" : "False");
+    s.setValue(keyW, QString::number(m_markerWidth));
     s.setValue(keyH, m_filterEdgesHidden ? "True" : "False");
     s.save();
 }
@@ -2310,7 +2325,7 @@ void VfoWidget::setSlice(SliceModel* slice)
     // them out so the SpectrumWidget's overlay picks up the saved style. This
     // runs after wireVfoWidget() has connected markerStyleChanged (#1526).
     loadDisplayPrefs();
-    emit markerStyleChanged(m_markerThin, m_filterEdgesHidden);
+    emit markerStyleChanged(m_markerWidth, m_filterEdgesHidden);
 
     // Frequency
     connect(m_slice, &SliceModel::frequencyChanged, this, [this](double) { updateFreqLabel(); });
@@ -3097,10 +3112,8 @@ void VfoWidget::rebuildFilterButtons()
         m_zeroBeatBtn = nullptr;
     }
     // Remove marker-style buttons if they exist (re-added for CW only, #1526)
-    if (m_markerThinBtn)  { delete m_markerThinBtn;  m_markerThinBtn = nullptr; }
-    if (m_markerThickBtn) { delete m_markerThickBtn; m_markerThickBtn = nullptr; }
-    if (m_edgesShowBtn)   { delete m_edgesShowBtn;   m_edgesShowBtn = nullptr; }
-    if (m_edgesHideBtn)   { delete m_edgesHideBtn;   m_edgesHideBtn = nullptr; }
+    if (m_markerThicknessBtn) { delete m_markerThicknessBtn; m_markerThicknessBtn = nullptr; }
+    if (m_edgesBtn)           { delete m_edgesBtn;           m_edgesBtn = nullptr; }
 
     for (int i = 0; i < m_filterWidths.size(); ++i) {
         const int w = m_filterWidths[i];
@@ -3152,41 +3165,33 @@ void VfoWidget::rebuildFilterButtons()
     {
         int row = (m_filterWidths.size() + 3) / 4;
 
-        m_markerThinBtn = new QPushButton("Thin");
-        m_markerThinBtn->setCheckable(true);
-        m_markerThinBtn->setChecked(m_markerThin);
-        m_markerThinBtn->setFixedHeight(26);
-        m_markerThinBtn->setStyleSheet(kModeBtn);
-        m_markerThinBtn->setToolTip("Thin VFO center line");
-        connect(m_markerThinBtn, &QPushButton::clicked, this, [this]() { setMarkerThin(true); });
-        m_filterGrid->addWidget(m_markerThinBtn, row, 0);
+        // Marker: cycle through Off → 1 px → 3 px on each click.  Label
+        // reflects the current state.  Off removes the center line and the
+        // top triangle entirely so only the passband bracket is shown.
+        const QString markerLabel = (m_markerWidth == 0)
+            ? QStringLiteral("Marker: Off")
+            : QStringLiteral("Marker: %1px").arg(m_markerWidth);
+        m_markerThicknessBtn = new QPushButton(markerLabel);
+        m_markerThicknessBtn->setFixedHeight(26);
+        m_markerThicknessBtn->setStyleSheet(kModeBtn);
+        m_markerThicknessBtn->setToolTip("Cycle VFO marker: Off → 1 px → 3 px");
+        connect(m_markerThicknessBtn, &QPushButton::clicked, this, [this]() {
+            int next = (m_markerWidth == 0) ? 1 : (m_markerWidth == 1) ? 3 : 0;
+            setMarkerWidth(next);
+        });
+        m_filterGrid->addWidget(m_markerThicknessBtn, row, 0, 1, 2);
 
-        m_markerThickBtn = new QPushButton("Thick");
-        m_markerThickBtn->setCheckable(true);
-        m_markerThickBtn->setChecked(!m_markerThin);
-        m_markerThickBtn->setFixedHeight(26);
-        m_markerThickBtn->setStyleSheet(kModeBtn);
-        m_markerThickBtn->setToolTip("Thick VFO center line");
-        connect(m_markerThickBtn, &QPushButton::clicked, this, [this]() { setMarkerThin(false); });
-        m_filterGrid->addWidget(m_markerThickBtn, row, 1);
-
-        m_edgesShowBtn = new QPushButton("Edges");
-        m_edgesShowBtn->setCheckable(true);
-        m_edgesShowBtn->setChecked(!m_filterEdgesHidden);
-        m_edgesShowBtn->setFixedHeight(26);
-        m_edgesShowBtn->setStyleSheet(kModeBtn);
-        m_edgesShowBtn->setToolTip("Show filter edge lines");
-        connect(m_edgesShowBtn, &QPushButton::clicked, this, [this]() { setFilterEdgesHidden(false); });
-        m_filterGrid->addWidget(m_edgesShowBtn, row, 2);
-
-        m_edgesHideBtn = new QPushButton("Hide");
-        m_edgesHideBtn->setCheckable(true);
-        m_edgesHideBtn->setChecked(m_filterEdgesHidden);
-        m_edgesHideBtn->setFixedHeight(26);
-        m_edgesHideBtn->setStyleSheet(kModeBtn);
-        m_edgesHideBtn->setToolTip("Hide filter edge lines");
-        connect(m_edgesHideBtn, &QPushButton::clicked, this, [this]() { setFilterEdgesHidden(true); });
-        m_filterGrid->addWidget(m_edgesHideBtn, row, 3);
+        // Filter edge lines: checkable on/off.  Checked = edges shown.
+        m_edgesBtn = new QPushButton("Filter Edge");
+        m_edgesBtn->setCheckable(true);
+        m_edgesBtn->setChecked(!m_filterEdgesHidden);
+        m_edgesBtn->setFixedHeight(26);
+        m_edgesBtn->setStyleSheet(kModeBtn);
+        m_edgesBtn->setToolTip("Show filter edge lines");
+        connect(m_edgesBtn, &QPushButton::toggled, this, [this](bool on) {
+            setFilterEdgesHidden(!on);
+        });
+        m_filterGrid->addWidget(m_edgesBtn, row, 2, 1, 2);
     }
 
     // Add CW autotune row spanning all 4 columns when in CW mode

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -110,8 +110,10 @@ Q_SIGNALS:
     // tuning/reveal policy.
     void stepTuneRequested(double mhz);
     void directEntryCommitted(double mhz, const QString& source);
-    // Per-slice VFO marker style changed (#1526)
-    void markerStyleChanged(bool markerThin, bool filterEdgesHidden);
+    // Per-slice VFO marker style changed (#1526).  markerWidth: 0 = off
+    // (no center line / no top triangle, passband only), 1 = 1 px line,
+    // 3 = 3 px line.
+    void markerStyleChanged(int markerWidth, bool filterEdgesHidden);
 
 protected:
     void paintEvent(QPaintEvent* event) override;
@@ -210,18 +212,21 @@ public:
     void setDiversityAllowed(bool allowed);
     void setSmartSdrPlus(bool has);
 
-    // Per-slice VFO marker display prefs, persisted by slice ID (#1526)
-    bool markerThin() const { return m_markerThin; }
+    // Per-slice VFO marker display prefs, persisted by slice ID (#1526).
+    // markerWidth: 0 = off, 1 = 1 px, 3 = 3 px.
+    int  markerWidth() const { return m_markerWidth; }
     bool filterEdgesHidden() const { return m_filterEdgesHidden; }
-    void setMarkerThin(bool thin);
+    void setMarkerWidth(int widthPx);
     void setFilterEdgesHidden(bool hide);
 private:
-    bool m_markerThin{false};
+    int  m_markerWidth{1};
     bool m_filterEdgesHidden{false};
-    class QPushButton* m_markerThinBtn{nullptr};
-    class QPushButton* m_markerThickBtn{nullptr};
-    class QPushButton* m_edgesShowBtn{nullptr};
-    class QPushButton* m_edgesHideBtn{nullptr};
+    // Marker: single button cycling Off → 1 px → 3 px on click.  Label
+    // reflects the current state.
+    class QPushButton* m_markerThicknessBtn{nullptr};
+    // Filter edge lines: single checkable button — checked = edges shown,
+    // unchecked = edges hidden.
+    class QPushButton* m_edgesBtn{nullptr};
     void loadDisplayPrefs();
     void saveDisplayPrefs();
 


### PR DESCRIPTION
The four-button row in the per-slice DSP panel (Thin / Thick / Edges /
Hide) is collapsed to two:

- **Marker** — cycles Off → 1 px → 3 px on click.  Label reflects
  the current state ("Marker: Off" / "Marker: 1px" / "Marker: 3px").
  Off skips both the center line and the top triangle, leaving only
  the passband bracket.
- **Filter Edge** — checkable on/off.  Checked = edges shown.

Internally `bool m_markerThin` becomes `int m_markerWidth` (0 / 1 / 3),
the `markerStyleChanged` signal becomes `(int markerWidth, bool
filterEdgesHidden)`, and `SpectrumWidget::SliceOverlay::markerThin`
becomes `markerWidth` with a render-path guard for the off case.

Settings: new `Slice<N>_MarkerWidth` int key.  Old `Slice<N>_MarkerThin`
bool key is read once for migration (True → 1, False → 3) and then
the new key takes over.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
