### PR TITLE
fix: serial PTT — Win32 WaitCommEvent path for FTDI DSR detection

### DIFF
--- a/src/core/SerialPortController.cpp
+++ b/src/core/SerialPortController.cpp
@@ -57,6 +57,13 @@ bool SerialPortController::open(const QString& portName, int baudRate,
         bool dsr = pinState.testFlag(QSerialPort::DataSetReadySignal);
         m_lastCtsActive = m_ctsActiveHigh ? cts : !cts;
         m_lastDsrActive = m_dsrActiveHigh ? dsr : !dsr;
+        qCDebug(lcDevices) << "SerialPortController: open() initial pin sample —"
+                           << "raw=" << Qt::hex << static_cast<int>(pinState)
+                           << "DSR=" << dsr << "CTS=" << cts
+                           << "dsrActiveHigh=" << m_dsrActiveHigh
+                           << "ctsActiveHigh=" << m_ctsActiveHigh
+                           << "→ lastDsrActive=" << m_lastDsrActive
+                           << "lastCtsActive=" << m_lastCtsActive;
     }
     m_pollLogged = false;
     m_debounceTimer.start();
@@ -64,7 +71,10 @@ bool SerialPortController::open(const QString& portName, int baudRate,
     // Start polling if any input function is configured
     updatePolling();
 
-    qCDebug(lcDevices) << "SerialPortController: opened" << portName << "at" << baudRate;
+    qCDebug(lcDevices) << "SerialPortController: opened" << portName << "at" << baudRate
+                       << "dsrFn=" << static_cast<int>(m_dsrFn)
+                       << "ctsFn=" << static_cast<int>(m_ctsFn)
+                       << "pollActive=" << m_pollTimer.isActive();
     return true;
 #else
     Q_UNUSED(portName); Q_UNUSED(baudRate);
@@ -166,13 +176,6 @@ void SerialPortController::pollInputPins()
         return;
     }
 
-    // One-shot: log raw pin state on first successful poll for diagnostics (#1413)
-    if (!m_pollLogged) {
-        m_pollLogged = true;
-        qCDebug(lcDevices) << "SerialPortController: first poll — raw pinoutSignals ="
-                           << Qt::hex << static_cast<int>(pinState);
-    }
-
     bool cts = pinState.testFlag(QSerialPort::ClearToSendSignal);
     bool dsr = pinState.testFlag(QSerialPort::DataSetReadySignal);
 
@@ -183,13 +186,46 @@ void SerialPortController::pollInputPins()
     // Debounce: ignore changes within DEBOUNCE_MS of the last change
     bool debounceOk = m_debounceTimer.elapsed() >= DEBOUNCE_MS;
 
+    // Verbose PTT diagnostics — logs every poll when a PTT input is configured
+    // so we can see whether pinoutSignals() is actually tracking the hardware.
+    bool hasPttInput = (m_ctsFn == InputFunction::PttInput || m_dsrFn == InputFunction::PttInput);
+    if (hasPttInput) {
+        static QSerialPort::PinoutSignals lastRaw{};
+        static bool lastDebounceOk{false};
+        if (pinState != lastRaw || debounceOk != lastDebounceOk || !m_pollLogged) {
+            lastRaw = pinState;
+            lastDebounceOk = debounceOk;
+            qCDebug(lcDevices)
+                << "SerialPortController poll:"
+                << "raw=" << Qt::hex << static_cast<int>(pinState)
+                << "CTS=" << cts << "DSR=" << dsr
+                << "ctsActive=" << ctsActive << "dsrActive=" << dsrActive
+                << "lastCts=" << m_lastCtsActive << "lastDsr=" << m_lastDsrActive
+                << "debounceOk=" << debounceOk
+                << "debounceElapsed=" << m_debounceTimer.elapsed() << "ms"
+                << "ctsFn=" << static_cast<int>(m_ctsFn)
+                << "dsrFn=" << static_cast<int>(m_dsrFn)
+                << "ctsPolActiveHigh=" << m_ctsActiveHigh
+                << "dsrPolActiveHigh=" << m_dsrActiveHigh;
+        }
+    }
+
+    if (!m_pollLogged) {
+        m_pollLogged = true;
+        qCDebug(lcDevices) << "SerialPortController: first poll — raw pinoutSignals ="
+                           << Qt::hex << static_cast<int>(pinState)
+                           << "DSR=" << dsr << "CTS=" << cts;
+    }
+
     // ── PTT input ────────────────────────────────────────────────────────
     if (m_ctsFn == InputFunction::PttInput && ctsActive != m_lastCtsActive && debounceOk) {
+        qCDebug(lcDevices) << "SerialPortController: CTS PTT edge →" << ctsActive;
         m_lastCtsActive = ctsActive;
         m_debounceTimer.restart();
         emit externalPttChanged(ctsActive);
     }
     if (m_dsrFn == InputFunction::PttInput && dsrActive != m_lastDsrActive && debounceOk) {
+        qCDebug(lcDevices) << "SerialPortController: DSR PTT edge →" << dsrActive;
         m_lastDsrActive = dsrActive;
         m_debounceTimer.restart();
         emit externalPttChanged(dsrActive);
@@ -258,6 +294,15 @@ void SerialPortController::loadSettings()
     bool shouldOpen = s.value("SerialAutoOpen", "False").toString() == "True"
                    || s.value("SerialPortOpen", "False").toString() == "True";
 
+    qCDebug(lcDevices) << "SerialPortController::loadSettings:"
+                       << "port=" << port
+                       << "shouldOpen=" << shouldOpen
+                       << "isOpen=" << isOpen()
+                       << "dsrFn=" << static_cast<int>(m_dsrFn)
+                       << "ctsFn=" << static_cast<int>(m_ctsFn)
+                       << "dsrActiveHigh=" << m_dsrActiveHigh
+                       << "ctsActiveHigh=" << m_ctsActiveHigh;
+
     if (!port.isEmpty() && shouldOpen) {
         int baud = s.value("SerialBaudRate", "9600").toInt();
         int data = s.value("SerialDataBits", "8").toInt();
@@ -267,6 +312,7 @@ void SerialPortController::loadSettings()
             // Port already open on the same port/baud — just update in-place
             // without reopening so we don't lose the current DSR/CTS state
             // (a reopen resets m_lastDsrActive, causing a spurious PTT event).
+            qCDebug(lcDevices) << "SerialPortController::loadSettings: in-place update (no reopen)";
             updatePolling();
         } else {
             open(port, baud, data, par, stop);

--- a/src/core/SerialPortController.cpp
+++ b/src/core/SerialPortController.cpp
@@ -50,9 +50,14 @@ bool SerialPortController::open(const QString& portName, int baudRate,
     m_port.setDataTerminalReady(!m_dtrActiveHigh);
     m_port.setRequestToSend(!m_rtsActiveHigh);
 
-    // Reset input state
-    m_lastCtsActive = false;
-    m_lastDsrActive = false;
+    // Sample actual pin state so the first poll doesn't fire a spurious PTT event
+    {
+        auto pinState = m_port.pinoutSignals();
+        bool cts = pinState.testFlag(QSerialPort::ClearToSendSignal);
+        bool dsr = pinState.testFlag(QSerialPort::DataSetReadySignal);
+        m_lastCtsActive = m_ctsActiveHigh ? cts : !cts;
+        m_lastDsrActive = m_dsrActiveHigh ? dsr : !dsr;
+    }
     m_pollLogged = false;
     m_debounceTimer.start();
 
@@ -73,7 +78,15 @@ void SerialPortController::close()
 #ifdef HAVE_SERIALPORT
     m_pollTimer.stop();
     if (m_port.isOpen()) {
-        // Deassert all output lines before closing
+        // If PTT was active, release it before closing to avoid stuck TX
+        bool pttWasActive = (m_ctsFn == InputFunction::PttInput && m_lastCtsActive)
+                         || (m_dsrFn == InputFunction::PttInput && m_lastDsrActive);
+        if (pttWasActive)
+            emit externalPttChanged(false);
+
+        m_lastCtsActive = false;
+        m_lastDsrActive = false;
+
         m_port.setDataTerminalReady(!m_dtrActiveHigh);
         m_port.setRequestToSend(!m_rtsActiveHigh);
         m_port.close();
@@ -250,7 +263,14 @@ void SerialPortController::loadSettings()
         int data = s.value("SerialDataBits", "8").toInt();
         int par  = s.value("SerialParity", "0").toInt();
         int stop = s.value("SerialStopBits", "1").toInt();
-        open(port, baud, data, par, stop);
+        if (isOpen() && m_port.portName() == port && m_port.baudRate() == baud) {
+            // Port already open on the same port/baud — just update in-place
+            // without reopening so we don't lose the current DSR/CTS state
+            // (a reopen resets m_lastDsrActive, causing a spurious PTT event).
+            updatePolling();
+        } else {
+            open(port, baud, data, par, stop);
+        }
     } else if (!shouldOpen && isOpen()) {
         close();
     } else {

--- a/src/core/SerialPortController.cpp
+++ b/src/core/SerialPortController.cpp
@@ -2,8 +2,18 @@
 #include "AppSettings.h"
 #include "LogManager.h"
 
+#ifndef Q_OS_WIN
 #ifdef HAVE_SERIALPORT
 #include <QSerialPortInfo>
+#endif
+#endif
+
+#ifdef Q_OS_WIN
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <QThread>
+#include <QMetaObject>
 #endif
 
 namespace AetherSDR {
@@ -11,7 +21,7 @@ namespace AetherSDR {
 SerialPortController::SerialPortController(QObject* parent)
     : QObject(parent)
 {
-#ifdef HAVE_SERIALPORT
+#if defined(HAVE_SERIALPORT) && !defined(Q_OS_WIN)
     // Set this as parent so moveToThread() moves them with us.
     // Without this, m_port and m_pollTimer stay on the creating thread,
     // causing cross-thread QObject access that silently fails on macOS.
@@ -25,6 +35,260 @@ SerialPortController::~SerialPortController()
 {
     close();
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Windows implementation — Win32 WaitCommEvent
+// ─────────────────────────────────────────────────────────────────────────────
+#ifdef Q_OS_WIN
+
+bool SerialPortController::open(const QString& portName, int baudRate,
+                                 int dataBits, int parity, int stopBits)
+{
+    if (isOpen()) close();
+
+    // Prepend "\\.\" so COMxx > COM9 open correctly
+    QString devPath = portName.startsWith("COM", Qt::CaseInsensitive)
+                    ? "\\\\.\\" + portName : portName;
+
+    // Non-overlapped: WaitCommEvent is called synchronously in the watcher thread,
+    // which blocks until a pin change occurs. SetCommMask(0) aborts it on close.
+    // Overlapped mode causes silent WaitCommEvent failures on some FTDI VCP drivers.
+    HANDLE hPort = ::CreateFileW(
+        reinterpret_cast<LPCWSTR>(devPath.utf16()),
+        GENERIC_READ | GENERIC_WRITE,
+        0,               // no sharing — COM ports are exclusive
+        nullptr,
+        OPEN_EXISTING,
+        0,               // synchronous I/O
+        nullptr
+    );
+    if (hPort == INVALID_HANDLE_VALUE) {
+        DWORD err = ::GetLastError();
+        qCWarning(lcDevices) << "SerialPortController: failed to open" << portName
+                             << "Win32 error" << err;
+        emit errorOccurred(QString("Failed to open %1 (error %2)").arg(portName).arg(err));
+        return false;
+    }
+
+    // Configure baud rate / framing via DCB
+    DCB dcb = {};
+    dcb.DCBlength = sizeof(DCB);
+    if (!::GetCommState(hPort, &dcb)) {
+        ::CloseHandle(hPort);
+        return false;
+    }
+    dcb.BaudRate        = static_cast<DWORD>(baudRate);
+    dcb.ByteSize        = static_cast<BYTE>(dataBits);
+    dcb.Parity          = static_cast<BYTE>(parity);
+    dcb.StopBits        = (stopBits == 2) ? TWOSTOPBITS : ONESTOPBIT;
+    dcb.fBinary         = TRUE;
+    dcb.fParity         = (parity != NOPARITY);
+    // Software-controlled outputs, start HIGH (Windows default on open)
+    dcb.fDtrControl     = DTR_CONTROL_ENABLE;
+    dcb.fRtsControl     = RTS_CONTROL_ENABLE;
+    dcb.fOutxCtsFlow    = FALSE;
+    dcb.fOutxDsrFlow    = FALSE;
+    dcb.fDsrSensitivity = FALSE;
+    if (!::SetCommState(hPort, &dcb)) {
+        ::CloseHandle(hPort);
+        return false;
+    }
+
+    // Monitor DSR and CTS changes — required for FTDI drivers where
+    // GetCommModemStatus only refreshes in a WaitCommEvent completion context.
+    ::SetCommMask(hPort, EV_DSR | EV_CTS | EV_RLSD);
+
+    // Deassert PTT/CW output pins that have a function assigned.
+    // Pins with no function stay HIGH (OS default), providing source voltage
+    // for foot switch circuits that loop an output pin back to DSR/CTS.
+    if (m_dtrFn != PinFunction::None)
+        ::EscapeCommFunction(hPort, m_dtrActiveHigh ? CLRDTR : SETDTR);
+    if (m_rtsFn != PinFunction::None)
+        ::EscapeCommFunction(hPort, m_rtsActiveHigh ? CLRRTS : SETRTS);
+
+    // Sample initial pin state
+    DWORD modemStat = 0;
+    ::GetCommModemStatus(hPort, &modemStat);
+    bool cts = (modemStat & MS_CTS_ON) != 0;
+    bool dsr = (modemStat & MS_DSR_ON) != 0;
+    m_lastCtsActive = m_ctsActiveHigh ? cts : !cts;
+    m_lastDsrActive = m_dsrActiveHigh ? dsr : !dsr;
+    m_debounceTimer.start();
+
+    m_hWin        = static_cast<void*>(hPort);
+    m_winPortName = portName;
+    m_winBaudRate = baudRate;
+
+    qCDebug(lcDevices) << "SerialPortController: opened" << portName << "at" << baudRate
+                       << "(Win32) DSR=" << dsr << "CTS=" << cts
+                       << "dsrFn=" << static_cast<int>(m_dsrFn)
+                       << "ctsFn=" << static_cast<int>(m_ctsFn);
+
+    // Start the WaitCommEvent watcher thread
+    m_stopWinWatch.store(false);
+    m_winWatchThread = QThread::create([this]() { runWinWatcher(); });
+    m_winWatchThread->setObjectName("SerialWatcher");
+    m_winWatchThread->start();
+
+    return true;
+}
+
+void SerialPortController::close()
+{
+    if (!isOpen()) return;
+
+    HANDLE hPort = static_cast<HANDLE>(m_hWin);
+
+    // Emit PTT release before closing to avoid stuck TX
+    bool pttWasActive = (m_ctsFn == InputFunction::PttInput && m_lastCtsActive)
+                     || (m_dsrFn == InputFunction::PttInput && m_lastDsrActive);
+    if (pttWasActive)
+        emit externalPttChanged(false);
+
+    m_lastCtsActive = false;
+    m_lastDsrActive = false;
+
+    // Deassert configured output pins
+    if (m_dtrFn != PinFunction::None)
+        ::EscapeCommFunction(hPort, m_dtrActiveHigh ? CLRDTR : SETDTR);
+    if (m_rtsFn != PinFunction::None)
+        ::EscapeCommFunction(hPort, m_rtsActiveHigh ? CLRRTS : SETRTS);
+
+    // Stop watcher thread: flag it, then abort the pending WaitCommEvent
+    m_stopWinWatch.store(true);
+    ::SetCommMask(hPort, 0);    // causes pending WaitCommEvent to return immediately
+
+    if (m_winWatchThread) {
+        m_winWatchThread->wait(3000);
+        delete m_winWatchThread;
+        m_winWatchThread = nullptr;
+    }
+
+    ::CloseHandle(hPort);
+    m_hWin        = nullptr;
+    m_winPortName.clear();
+    m_winBaudRate = 0;
+
+    qCDebug(lcDevices) << "SerialPortController: closed (Win32)";
+}
+
+bool SerialPortController::isOpen() const
+{
+    return m_hWin != nullptr;
+}
+
+QString SerialPortController::portName() const
+{
+    return m_winPortName;
+}
+
+void SerialPortController::applyPin(PinFunction targetFn, bool active)
+{
+    if (!isOpen()) return;
+    HANDLE hPort = static_cast<HANDLE>(m_hWin);
+    if (m_dtrFn == targetFn) {
+        bool level = m_dtrActiveHigh ? active : !active;
+        ::EscapeCommFunction(hPort, level ? SETDTR : CLRDTR);
+    }
+    if (m_rtsFn == targetFn) {
+        bool level = m_rtsActiveHigh ? active : !active;
+        ::EscapeCommFunction(hPort, level ? SETRTS : CLRRTS);
+    }
+}
+
+void SerialPortController::updatePolling()
+{
+    // No-op on Windows: detection is event-driven via runWinWatcher()
+}
+
+void SerialPortController::runWinWatcher()
+{
+    HANDLE hPort = static_cast<HANDLE>(m_hWin);
+
+    qCDebug(lcDevices) << "SerialPortController: watcher thread started";
+
+    while (!m_stopWinWatch.load()) {
+        DWORD evtMask = 0;
+        // Synchronous blocking call — returns when a pin changes or SetCommMask(0) aborts it
+        if (!::WaitCommEvent(hPort, &evtMask, nullptr)) {
+            DWORD err = ::GetLastError();
+            if (err == ERROR_OPERATION_ABORTED || err == ERROR_INVALID_HANDLE) break;
+            qCWarning(lcDevices) << "SerialPortController: WaitCommEvent error" << err;
+            break;
+        }
+
+        if (m_stopWinWatch.load()) break;
+
+        // Read pin state immediately after the event — FTDI only refreshes
+        // GetCommModemStatus in the context of a WaitCommEvent completion.
+        DWORD modemStat = 0;
+        ::GetCommModemStatus(hPort, &modemStat);
+        bool dsr = (modemStat & MS_DSR_ON) != 0;
+        bool cts = (modemStat & MS_CTS_ON) != 0;
+
+        qCDebug(lcDevices) << "SerialPortController: WaitCommEvent"
+                           << Qt::hex << evtMask << "DSR=" << dsr << "CTS=" << cts;
+
+        // Marshal the pin state back to this object's thread
+        QMetaObject::invokeMethod(this, [this, dsr, cts]() {
+            processWinPinChange(dsr, cts);
+        }, Qt::QueuedConnection);
+    }
+
+    qCDebug(lcDevices) << "SerialPortController: watcher thread exiting";
+}
+
+void SerialPortController::processWinPinChange(bool dsrRaw, bool ctsRaw)
+{
+    bool ctsActive = m_ctsActiveHigh ? ctsRaw : !ctsRaw;
+    bool dsrActive = m_dsrActiveHigh ? dsrRaw : !dsrRaw;
+
+    bool debounceOk = m_debounceTimer.elapsed() >= DEBOUNCE_MS;
+
+    // ── PTT input ────────────────────────────────────────────────────────
+    if (m_ctsFn == InputFunction::PttInput && ctsActive != m_lastCtsActive && debounceOk) {
+        qCDebug(lcDevices) << "SerialPortController: CTS PTT edge →" << ctsActive;
+        m_lastCtsActive = ctsActive;
+        m_debounceTimer.restart();
+        emit externalPttChanged(ctsActive);
+    }
+    if (m_dsrFn == InputFunction::PttInput && dsrActive != m_lastDsrActive && debounceOk) {
+        qCDebug(lcDevices) << "SerialPortController: DSR PTT edge →" << dsrActive;
+        m_lastDsrActive = dsrActive;
+        m_debounceTimer.restart();
+        emit externalPttChanged(dsrActive);
+    }
+
+    // ── CW straight key ──────────────────────────────────────────────────
+    bool keyDown = false;
+    bool hasKey = false;
+    if (m_ctsFn == InputFunction::CwKeyInput) { keyDown = ctsActive; hasKey = true; }
+    if (m_dsrFn == InputFunction::CwKeyInput) { keyDown = dsrActive; hasKey = true; }
+    if (hasKey && keyDown != m_lastKeyDown) {
+        m_lastKeyDown = keyDown;
+        emit cwKeyChanged(keyDown);
+    }
+
+    // ── CW paddle (dit/dah) ──────────────────────────────────────────────
+    bool ditActive = false, dahActive = false;
+    bool hasPaddle = false;
+    if (m_ctsFn == InputFunction::CwDitInput) { ditActive = ctsActive; hasPaddle = true; }
+    if (m_dsrFn == InputFunction::CwDitInput) { ditActive = dsrActive; hasPaddle = true; }
+    if (m_ctsFn == InputFunction::CwDahInput) { dahActive = ctsActive; hasPaddle = true; }
+    if (m_dsrFn == InputFunction::CwDahInput) { dahActive = dsrActive; hasPaddle = true; }
+
+    if (m_paddleSwap) std::swap(ditActive, dahActive);
+
+    if (hasPaddle && (ditActive != m_lastDitActive || dahActive != m_lastDahActive)) {
+        m_lastDitActive = ditActive;
+        m_lastDahActive = dahActive;
+        emit cwPaddleChanged(ditActive, dahActive);
+    }
+}
+
+#else  // ─────────────────────────────────────────────────────────────────────
+// Non-Windows implementation — QSerialPort polling
+// ─────────────────────────────────────────────────────────────────────────────
 
 bool SerialPortController::open(const QString& portName, int baudRate,
                                  int dataBits, int parity, int stopBits)
@@ -46,9 +310,13 @@ bool SerialPortController::open(const QString& portName, int baudRate,
         return false;
     }
 
-    // Start with all output lines deasserted
-    m_port.setDataTerminalReady(!m_dtrActiveHigh);
-    m_port.setRequestToSend(!m_rtsActiveHigh);
+    // Deassert output pins that have a PTT/CW function assigned — prevents spurious TX
+    // on open. Pins with no function are left at the OS default (HIGH), which provides
+    // the source voltage for foot switch circuits that loop an output back to DSR/CTS.
+    if (m_dtrFn != PinFunction::None)
+        m_port.setDataTerminalReady(!m_dtrActiveHigh);
+    if (m_rtsFn != PinFunction::None)
+        m_port.setRequestToSend(!m_rtsActiveHigh);
 
     // Sample actual pin state so the first poll doesn't fire a spurious PTT event
     {
@@ -68,7 +336,6 @@ bool SerialPortController::open(const QString& portName, int baudRate,
     m_pollLogged = false;
     m_debounceTimer.start();
 
-    // Start polling if any input function is configured
     updatePolling();
 
     qCDebug(lcDevices) << "SerialPortController: opened" << portName << "at" << baudRate
@@ -88,7 +355,6 @@ void SerialPortController::close()
 #ifdef HAVE_SERIALPORT
     m_pollTimer.stop();
     if (m_port.isOpen()) {
-        // If PTT was active, release it before closing to avoid stuck TX
         bool pttWasActive = (m_ctsFn == InputFunction::PttInput && m_lastCtsActive)
                          || (m_dsrFn == InputFunction::PttInput && m_lastDsrActive);
         if (pttWasActive)
@@ -97,8 +363,10 @@ void SerialPortController::close()
         m_lastCtsActive = false;
         m_lastDsrActive = false;
 
-        m_port.setDataTerminalReady(!m_dtrActiveHigh);
-        m_port.setRequestToSend(!m_rtsActiveHigh);
+        if (m_dtrFn != PinFunction::None)
+            m_port.setDataTerminalReady(!m_dtrActiveHigh);
+        if (m_rtsFn != PinFunction::None)
+            m_port.setRequestToSend(!m_rtsActiveHigh);
         m_port.close();
         qCDebug(lcDevices) << "SerialPortController: closed";
     }
@@ -121,17 +389,6 @@ QString SerialPortController::portName() const
 #else
     return {};
 #endif
-}
-
-void SerialPortController::setTransmitting(bool tx)
-{
-    applyPin(PinFunction::PTT, tx);
-    applyPin(PinFunction::CwPTT, tx);
-}
-
-void SerialPortController::setCwKeyDown(bool down)
-{
-    applyPin(PinFunction::CwKey, down);
 }
 
 void SerialPortController::applyPin(PinFunction targetFn, bool active)
@@ -179,15 +436,11 @@ void SerialPortController::pollInputPins()
     bool cts = pinState.testFlag(QSerialPort::ClearToSendSignal);
     bool dsr = pinState.testFlag(QSerialPort::DataSetReadySignal);
 
-    // Resolve active state per polarity
     bool ctsActive = m_ctsActiveHigh ? cts : !cts;
     bool dsrActive = m_dsrActiveHigh ? dsr : !dsr;
 
-    // Debounce: ignore changes within DEBOUNCE_MS of the last change
     bool debounceOk = m_debounceTimer.elapsed() >= DEBOUNCE_MS;
 
-    // Verbose PTT diagnostics — logs every poll when a PTT input is configured
-    // so we can see whether pinoutSignals() is actually tracking the hardware.
     bool hasPttInput = (m_ctsFn == InputFunction::PttInput || m_dsrFn == InputFunction::PttInput);
     if (hasPttInput) {
         static QSerialPort::PinoutSignals lastRaw{};
@@ -231,8 +484,7 @@ void SerialPortController::pollInputPins()
         emit externalPttChanged(dsrActive);
     }
 
-    // ── CW straight key input ────────────────────────────────────────────
-    // Either CTS or DSR can be a straight key — whichever is configured
+    // ── CW straight key ──────────────────────────────────────────────────
     bool keyDown = false;
     bool hasKey = false;
     if (m_ctsFn == InputFunction::CwKeyInput) { keyDown = ctsActive; hasKey = true; }
@@ -242,7 +494,7 @@ void SerialPortController::pollInputPins()
         emit cwKeyChanged(keyDown);
     }
 
-    // ── CW paddle (dit/dah) input ────────────────────────────────────────
+    // ── CW paddle (dit/dah) ──────────────────────────────────────────────
     bool ditActive = false, dahActive = false;
     bool hasPaddle = false;
     if (m_ctsFn == InputFunction::CwDitInput) { ditActive = ctsActive; hasPaddle = true; }
@@ -258,7 +510,24 @@ void SerialPortController::pollInputPins()
         emit cwPaddleChanged(ditActive, dahActive);
     }
 }
-#endif
+#endif  // HAVE_SERIALPORT
+
+#endif  // !Q_OS_WIN
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Platform-common: shared output control and settings persistence
+// ─────────────────────────────────────────────────────────────────────────────
+
+void SerialPortController::setTransmitting(bool tx)
+{
+    applyPin(PinFunction::PTT, tx);
+    applyPin(PinFunction::CwPTT, tx);
+}
+
+void SerialPortController::setCwKeyDown(bool down)
+{
+    applyPin(PinFunction::CwKey, down);
+}
 
 void SerialPortController::loadSettings()
 {
@@ -308,20 +577,48 @@ void SerialPortController::loadSettings()
         int data = s.value("SerialDataBits", "8").toInt();
         int par  = s.value("SerialParity", "0").toInt();
         int stop = s.value("SerialStopBits", "1").toInt();
-        if (isOpen() && m_port.portName() == port && m_port.baudRate() == baud) {
-            // Port already open on the same port/baud — just update in-place
-            // without reopening so we don't lose the current DSR/CTS state
-            // (a reopen resets m_lastDsrActive, causing a spurious PTT event).
+
+#ifdef Q_OS_WIN
+        bool samePort = isOpen() && m_winPortName == port && m_winBaudRate == baud;
+#else
+        bool samePort = false;
+#  ifdef HAVE_SERIALPORT
+        samePort = isOpen() && m_port.portName() == port && m_port.baudRate() == baud;
+#  endif
+#endif
+
+        if (samePort) {
+            // Port already open on the same port/baud — update settings in-place.
+            // Re-sample pin state with new polarity so next event/poll doesn't
+            // see a phantom edge from the polarity flip.
             qCDebug(lcDevices) << "SerialPortController::loadSettings: in-place update (no reopen)";
+#ifdef Q_OS_WIN
+            {
+                DWORD modemStat = 0;
+                ::GetCommModemStatus(static_cast<HANDLE>(m_hWin), &modemStat);
+                bool cts = (modemStat & MS_CTS_ON) != 0;
+                bool dsr = (modemStat & MS_DSR_ON) != 0;
+                m_lastCtsActive = m_ctsActiveHigh ? cts : !cts;
+                m_lastDsrActive = m_dsrActiveHigh ? dsr : !dsr;
+            }
+#else
+#  ifdef HAVE_SERIALPORT
+            {
+                auto pinState = m_port.pinoutSignals();
+                bool cts = pinState.testFlag(QSerialPort::ClearToSendSignal);
+                bool dsr = pinState.testFlag(QSerialPort::DataSetReadySignal);
+                m_lastCtsActive = m_ctsActiveHigh ? cts : !cts;
+                m_lastDsrActive = m_dsrActiveHigh ? dsr : !dsr;
+            }
             updatePolling();
+#  endif
+#endif
         } else {
             open(port, baud, data, par, stop);
         }
     } else if (!shouldOpen && isOpen()) {
         close();
     } else {
-        // Port state unchanged — still refresh polling in case function
-        // assignments changed while the port was already open.
         updatePolling();
     }
 }

--- a/src/core/SerialPortController.h
+++ b/src/core/SerialPortController.h
@@ -4,20 +4,34 @@
 #include <QString>
 
 #ifdef HAVE_SERIALPORT
+#include <QElapsedTimer>
+#ifndef Q_OS_WIN
 #include <QSerialPort>
 #include <QTimer>
-#include <QElapsedTimer>
+#endif
+#endif
+
+#ifdef Q_OS_WIN
+#include <atomic>
+#include <QThread>
 #endif
 
 namespace AetherSDR {
 
 // Controls DTR/RTS lines on a USB-serial adapter for hardware PTT
-// and CW keying, and polls CTS/DSR for external PTT and CW key/paddle input.
+// and CW keying, and monitors CTS/DSR for external PTT and CW key/paddle input.
 //
 // Output: Assert DTR/RTS when transmitting (amplifier keying, sequencer)
-// Input:  Poll CTS/DSR for foot switch PTT, straight key, or iambic paddle
+// Input:  Monitor CTS/DSR for foot switch PTT, straight key, or iambic paddle
 //
-// Requires Qt6::SerialPort. Compiles to a no-op stub without HAVE_SERIALPORT.
+// On Windows, uses Win32 WaitCommEvent directly — QSerialPort::pinoutSignals()
+// (backed by GetCommModemStatus) returns stale data on FTDI and similar drivers
+// unless called in the context of a WaitCommEvent completion.
+//
+// On Linux/macOS, polls QSerialPort::pinoutSignals() on a timer.
+//
+// Requires Qt6::SerialPort on non-Windows. Compiles to a no-op stub without
+// HAVE_SERIALPORT on non-Windows platforms.
 
 class SerialPortController : public QObject {
     Q_OBJECT
@@ -94,18 +108,36 @@ private:
     bool m_dsrActiveHigh{false};
     bool m_paddleSwap{false};
 
-#ifdef HAVE_SERIALPORT
-    QSerialPort m_port;
-    QTimer      m_pollTimer;
-    bool        m_lastCtsActive{false};
-    bool        m_lastDsrActive{false};
-    bool        m_lastKeyDown{false};
-    bool        m_lastDitActive{false};
-    bool        m_lastDahActive{false};
-    bool        m_pollLogged{false};
+#if defined(HAVE_SERIALPORT) || defined(Q_OS_WIN)
+    // Shared input tracking state (always accessed on this object's thread)
+    bool          m_lastCtsActive{false};
+    bool          m_lastDsrActive{false};
+    bool          m_lastKeyDown{false};
+    bool          m_lastDitActive{false};
+    bool          m_lastDahActive{false};
     QElapsedTimer m_debounceTimer;
-    static constexpr int POLL_INTERVAL_MS = 10;
     static constexpr int DEBOUNCE_MS = 20;
+#endif
+
+#ifdef Q_OS_WIN
+    // Win32 path: owns the COM port handle exclusively for WaitCommEvent-based detection
+    void*         m_hWin{nullptr};      // Win32 HANDLE cast to void*; nullptr = closed
+    QString       m_winPortName;
+    int           m_winBaudRate{0};
+    QThread*      m_winWatchThread{nullptr};
+    std::atomic<bool> m_stopWinWatch{false};
+
+    void runWinWatcher();
+
+private slots:
+    void processWinPinChange(bool dsrRaw, bool ctsRaw);
+
+#elif defined(HAVE_SERIALPORT)
+    // Non-Windows path: poll via QSerialPort timer
+    QSerialPort   m_port;
+    QTimer        m_pollTimer;
+    bool          m_pollLogged{false};
+    static constexpr int POLL_INTERVAL_MS = 10;
 
 private slots:
     void pollInputPins();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4742,6 +4742,11 @@ void MainWindow::buildMenuBar()
         m_radioSetupDialog = dlg;
         connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
                 m_txBandAction, &QAction::trigger);
+#ifdef HAVE_SERIALPORT
+        connect(dlg, &RadioSetupDialog::serialSettingsChanged, this, [this]() {
+            QMetaObject::invokeMethod(m_serialPort, [this] { m_serialPort->loadSettings(); });
+        });
+#endif
         connect(dlg, &QDialog::finished, this, [this, prevComp]() {
 #ifdef HAVE_SERIALPORT
             // Re-load serial port settings if changed (on worker thread)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3691,10 +3691,20 @@ MainWindow::~MainWindow()
 
     // Stop external controller thread (#502)
     if (m_extCtrlThread && m_extCtrlThread->isRunning()) {
+        // Close serial port on its own thread before stopping it to avoid
+        // the cross-thread QObject access crash (QSerialPort has thread affinity
+        // to m_extCtrlThread; calling close() from main thread hits a fatal assert).
+#ifdef HAVE_SERIALPORT
+        QMetaObject::invokeMethod(m_serialPort, [this] { m_serialPort->close(); },
+                                  Qt::BlockingQueuedConnection);
+#endif
         m_extCtrlThread->quit();
         m_extCtrlThread->wait(3000);
     }
 #ifdef HAVE_SERIALPORT
+    // Move back to main thread so the destructor runs safely here.
+    m_serialPort->moveToThread(QThread::currentThread());
+    m_flexControl->moveToThread(QThread::currentThread());
     delete m_serialPort;
     delete m_flexControl;
 #endif

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -3257,18 +3257,20 @@ QWidget* RadioSetupDialog::buildSerialTab()
             }
         };
 
-        connect(openBtn, &QPushButton::clicked, this, [updatePortStatus]() {
+        connect(openBtn, &QPushButton::clicked, this, [this, updatePortStatus]() {
             auto& s = AppSettings::instance();
             s.setValue("SerialPortOpen", "True");
             s.save();
             updatePortStatus();
+            emit serialSettingsChanged();
         });
 
-        connect(closeBtn, &QPushButton::clicked, this, [updatePortStatus]() {
+        connect(closeBtn, &QPushButton::clicked, this, [this, updatePortStatus]() {
             auto& s = AppSettings::instance();
             s.setValue("SerialPortOpen", "False");
             s.save();
             updatePortStatus();
+            emit serialSettingsChanged();
         });
 
         updatePortStatus();

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -36,6 +36,7 @@ public:
 
 signals:
     void txBandSettingsRequested();
+    void serialSettingsChanged();
 
 protected:
     void closeEvent(QCloseEvent* event) override;


### PR DESCRIPTION

                                                                                                                                          
  QSerialPort::pinoutSignals() wraps GetCommModemStatus(), which returns                                                                
  stale zeros on FTDI VCP drivers. The FTDI driver only refreshes modem
  status in the context of a WaitCommEvent completion — not from a
  background poll. Adding EV_DSR to Qt's comm mask does not help because
  Qt owns the port handle exclusively and its own WaitCommEvent loop
  consumes the completions.

  Fix: on Windows, bypass QSerialPort entirely. Open the COM port with
  CreateFile (synchronous, non-overlapped) and dedicate a QThread to a
  blocking WaitCommEvent loop. When EV_DSR or EV_CTS fires, read
  GetCommModemStatus immediately in that completion context (where FTDI
  guarantees fresh data) and marshal the result back to the controller
  thread via QueuedConnection.

  The Linux/macOS QSerialPort polling path is unchanged.

  Also fix MainWindow destructor: call SerialPortController::close() on
  the ExtControllers thread via BlockingQueuedConnection before quitting
  the thread, then moveToThread back to main before deletion. Prevents
  the "Cannot send events to objects owned by a different thread" fatal
  assert seen on app exit.

  Also fix spurious PTT on open: only deassert DTR/RTS pins that have an
  assigned PTT/CW function. Unassigned pins stay HIGH (OS default),
  providing the source voltage for foot switch circuits that loop an
  output pin back to DSR/CTS.

  Also fix phantom PTT edge on polarity change: in-place settings update
  now re-samples pin state after polarity flip so the next event/poll
  doesn't see a false edge.

  Tested: FTDI-based foot switch on COM17, DSR active-high. Clean press
  and release edges with contact-bounce debouncing at 20 ms.