### PR TITLE
[fix] Systemic fix for applet pop-out persistence race condition

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -478,8 +478,11 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         const QString legacyFloatKey =
             QStringLiteral("FloatingApplet_%1_IsFloating").arg(safeId);
         if (settings.value(legacyFloatKey, "False").toString() == "True" && on) {
-            QTimer::singleShot(0, this, [this, id]() {
-                if (m_containerMgr) m_containerMgr->floatContainer(id);
+            QTimer::singleShot(0, this, [this, id, legacyFloatKey]() {
+                if (!m_containerMgr) return;
+                m_containerMgr->floatContainer(id);
+                AppSettings::instance().remove(legacyFloatKey);
+                AppSettings::instance().save();
             });
         }
 
@@ -573,7 +576,10 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         if (sMeterOn && settings.value(
                 "FloatingApplet_VU_IsFloating", "False").toString() == "True") {
             QTimer::singleShot(0, this, [this]() {
-                if (m_containerMgr) m_containerMgr->floatContainer("VU");
+                if (!m_containerMgr) return;
+                m_containerMgr->floatContainer("VU");
+                AppSettings::instance().remove("FloatingApplet_VU_IsFloating");
+                AppSettings::instance().save();
             });
         }
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6197,13 +6197,12 @@ void MainWindow::buildUI()
     splitter->setStretchFactor(3, 0);
     splitter->setCollapsible(3, false);
 
-    // Restore floating-container state from the previous session.  Deferred
-    // one event-loop cycle so AppletPanel's own legacy-migration singleShot(0)
-    // timers fire first (they write ContainerTree) before we read it back.
-    QTimer::singleShot(0, this, [this]() {
-        if (m_appletPanel && m_appletPanel->containerManager())
-            m_appletPanel->containerManager()->restoreState();
-    });
+    // Restore floating-container state from the previous session.
+    // Called synchronously here, before the event loop starts, so that legacy
+    // float migration singleShot(0) timers posted inside AppletPanel::makeEntry()
+    // cannot call saveState() and overwrite ContainerTree before we read it.
+    if (m_appletPanel && m_appletPanel->containerManager())
+        m_appletPanel->containerManager()->restoreState();
 
     // Set initial splitter sizes: CWX=0, DVK=0 (both hidden), center=stretch, right=310
     const int centerWidth = qMax(400, width() - 310);

--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -118,7 +118,6 @@ WaveApplet::WaveApplet(QWidget* parent)
 
     setSettingsExpanded(true);
     setMinimumHeight(minimumSizeHint().height());
-    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
     connect(m_waveform, &WaveformWidget::settingsDrawerToggleRequested,
             this, [this]() {


### PR DESCRIPTION
Fixes a race where newly-added applets (WAVE, and any future additions) would not restore their floating state across sessions.

Root cause: ContainerManager::restoreState() was deferred via QTimer::singleShot(0) in MainWindow, but AppletPanel's legacy float migration timers were also singleShot(0) and posted earlier (during AppletPanel construction). The migration timers fired first, called floatContainer() → saveState(), overwriting ContainerTree with the current docked state before restoreState() could read the saved state.

Three-part fix:

1. MainWindow.cpp: Call restoreState() synchronously immediately after AppletPanel is constructed, before any event-loop iteration.  This ensures ContainerTree is read from disk before any singleShot(0) legacy migration can overwrite it.

2. AppletPanel.cpp: Delete the FloatingApplet_<id>_IsFloating legacy key after each migration fires (makeEntry + VU meter paths).  The key was never removed, so the interference repeated on every launch for long-time users.  ContainerManager now owns the persistence.

3. WaveApplet.cpp: Remove QSizePolicy::Fixed vertical policy that was preventing the floating window's saved height from being restored correctly.