### PR TITLE
[feature] UI Enhancements: Customizable Slice Colors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,6 +496,7 @@ set(GUI_SOURCES
     src/gui/ClientDisconnectDialog.cpp
     src/gui/SpectrumWidget.cpp
     src/gui/SpectrumOverlayMenu.cpp
+    src/gui/SliceColorManager.cpp
     src/gui/VfoWidget.cpp
     src/gui/RadioSetupDialog.cpp
     src/gui/NetworkDiagnosticsDialog.cpp

--- a/src/gui/CatControlApplet.cpp
+++ b/src/gui/CatControlApplet.cpp
@@ -1,5 +1,4 @@
 #include "CatControlApplet.h"
-#include "SliceColors.h"
 #include "SliceColorManager.h"
 #include "core/RigctlServer.h"
 #include "core/RigctlPty.h"

--- a/src/gui/CatControlApplet.cpp
+++ b/src/gui/CatControlApplet.cpp
@@ -1,5 +1,6 @@
 #include "CatControlApplet.h"
 #include "SliceColors.h"
+#include "SliceColorManager.h"
 #include "core/RigctlServer.h"
 #include "core/RigctlPty.h"
 #include "core/AppSettings.h"
@@ -172,7 +173,7 @@ void CatControlApplet::buildUI()
         m_rows[i].badge->setAlignment(Qt::AlignCenter);
         m_rows[i].badge->setStyleSheet(
             QStringLiteral("QLabel { color: %1; font-size: 11px; font-weight: bold; }")
-                .arg(kSliceColors[i].hexActive));
+                .arg(SliceColorManager::instance().hexActive(i)));
         row->addWidget(m_rows[i].badge);
 
         // TCP status
@@ -253,7 +254,7 @@ void CatControlApplet::updateChannelStatus(int ch)
                 .arg(n == 1 ? "" : "s"));
         m_rows[ch].tcpStatus->setStyleSheet(
             n > 0 ? QStringLiteral("QLabel { color: %1; font-size: 10px; }")
-                         .arg(kSliceColors[ch].hexActive)
+                         .arg(SliceColorManager::instance().hexActive(ch))
                    : "QLabel { color: #8090a0; font-size: 10px; }");
     }
 }

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -3723,7 +3723,7 @@ QWidget* RadioSetupDialog::buildUiEnhancementsTab()
     SliceColorManager* pMgr = &SliceColorManager::instance();
 
     // Updates a single button's background to reflect current color.
-    auto applyBtnColor = [pMgr, colorBtns, kBtnBase](int idx) mutable {
+    auto applyBtnColor = [pMgr, colorBtns](int idx) mutable {
         QColor c = pMgr->activeColor(idx);
         bool light = (c.red() * 299 + c.green() * 587 + c.blue() * 114) > 128000;
         QString textColor = light ? "#000000" : "#ffffff";

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -112,7 +112,7 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
     addDeferred("XVTR",        [this] { return buildXvtrTab(); });
     addDeferred("USB Cables",      [this] { return buildUsbCablesTab(); });
     addDeferred("Peripherals",     [this] { return buildPeripheralsTab(); });
-    addDeferred("UI Enhancements", [this] { return buildUiEnhancementsTab(); });
+    addDeferred("Themes",          [this] { return buildUiEnhancementsTab(); });
 #ifdef HAVE_SERIALPORT
     addDeferred("Serial",          [this] { return buildSerialTab(); });
 #endif

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1,6 +1,7 @@
 #include "RadioSetupDialog.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
+#include "SliceColorManager.h"
 #include "models/RadioModel.h"
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
@@ -38,6 +39,8 @@
 #include <QStandardPaths>
 #include <QFileInfo>
 #include <QMessageBox>
+#include <QColorDialog>
+#include <QRadioButton>
 #include <QProgressBar>
 #include <QProcess>
 #include <QListWidget>
@@ -107,10 +110,11 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
     addDeferred("RX",          [this] { return buildRxTab(); });
     addDeferred("Filters",     [this] { return buildFiltersTab(); });
     addDeferred("XVTR",        [this] { return buildXvtrTab(); });
-    addDeferred("USB Cables",  [this] { return buildUsbCablesTab(); });
-    addDeferred("Peripherals", [this] { return buildPeripheralsTab(); });
+    addDeferred("USB Cables",      [this] { return buildUsbCablesTab(); });
+    addDeferred("Peripherals",     [this] { return buildPeripheralsTab(); });
+    addDeferred("UI Enhancements", [this] { return buildUiEnhancementsTab(); });
 #ifdef HAVE_SERIALPORT
-    addDeferred("Serial",      [this] { return buildSerialTab(); });
+    addDeferred("Serial",          [this] { return buildSerialTab(); });
 #endif
 
     connect(tabs, &QTabWidget::currentChanged, this, &RadioSetupDialog::buildDeferredTab);
@@ -3637,6 +3641,163 @@ void RadioSetupDialog::selectTab(const QString& tabName)
             return;
         }
     }
+}
+
+// ── UI Enhancements tab ───────────────────────────────────────────────────────
+
+QWidget* RadioSetupDialog::buildUiEnhancementsTab()
+{
+    static const QString kBtnBase =
+        "QPushButton { border: 1px solid #304050; border-radius: 3px; "
+        "font-weight: bold; font-size: 13px; min-width: 36px; min-height: 36px; }"
+        "QPushButton:hover { border: 2px solid #60a0c0; }";
+
+    auto* page = new QWidget;
+    auto* vbox = new QVBoxLayout(page);
+    vbox->setSpacing(12);
+    vbox->setContentsMargins(16, 16, 16, 16);
+
+    // ── Slice color group ────────────────────────────────────────────────────
+    auto* grp = new QGroupBox("Slice Colors");
+    grp->setStyleSheet(kGroupStyle);
+    auto* grpLayout = new QVBoxLayout(grp);
+    grpLayout->setSpacing(10);
+
+    auto* modeLayout = new QHBoxLayout;
+    auto* defaultsRadio = new QRadioButton("Use Aether defaults");
+    auto* customRadio   = new QRadioButton("Custom colors");
+    defaultsRadio->setStyleSheet("QRadioButton { color: #c8d8e8; font-size: 12px; }");
+    customRadio->setStyleSheet("QRadioButton { color: #c8d8e8; font-size: 12px; }");
+    modeLayout->addWidget(defaultsRadio);
+    modeLayout->addWidget(customRadio);
+    modeLayout->addStretch();
+    grpLayout->addLayout(modeLayout);
+
+    auto* desc = new QLabel(
+        "Customize the color used for each slice marker, filter band, and badge.");
+    desc->setStyleSheet("QLabel { color: #7090a0; font-size: 11px; }");
+    desc->setWordWrap(true);
+    grpLayout->addWidget(desc);
+
+    // Grid of 8 color buttons (A–H)
+    auto* colorGrid = new QHBoxLayout;
+    colorGrid->setSpacing(8);
+
+    static const char kLetters[] = "ABCDEFGH";
+    // One button per slice; holds the current color as its background.
+    QVector<QPushButton*> colorBtns;
+    for (int i = 0; i < AetherSDR::kSliceColorCount; ++i) {
+        auto* col = new QVBoxLayout;
+        col->setSpacing(4);
+
+        auto* lbl = new QLabel(QString(kLetters[i]));
+        lbl->setAlignment(Qt::AlignCenter);
+        lbl->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; }");
+
+        auto* btn = new QPushButton(QString(kLetters[i]));
+        btn->setStyleSheet(kBtnBase);
+        colorBtns.append(btn);
+
+        col->addWidget(lbl);
+        col->addWidget(btn);
+        colorGrid->addLayout(col);
+    }
+    colorGrid->addStretch();
+    grpLayout->addLayout(colorGrid);
+
+    // Reset-all button
+    auto* resetRow = new QHBoxLayout;
+    auto* resetBtn = new QPushButton("Reset All to Defaults");
+    resetBtn->setStyleSheet(
+        "QPushButton { background: #1a2a3a; border: 1px solid #304050; "
+        "border-radius: 3px; color: #c8d8e8; font-size: 11px; padding: 3px 12px; }"
+        "QPushButton:hover { background: #203040; }");
+    resetRow->addWidget(resetBtn);
+    resetRow->addStretch();
+    grpLayout->addLayout(resetRow);
+
+    vbox->addWidget(grp);
+    vbox->addStretch();
+
+    // ── Helpers (capture manager by pointer, buttons by value) ────────────────
+    SliceColorManager* pMgr = &SliceColorManager::instance();
+
+    // Updates a single button's background to reflect current color.
+    auto applyBtnColor = [pMgr, colorBtns, kBtnBase](int idx) mutable {
+        QColor c = pMgr->activeColor(idx);
+        bool light = (c.red() * 299 + c.green() * 587 + c.blue() * 114) > 128000;
+        QString textColor = light ? "#000000" : "#ffffff";
+        colorBtns[idx]->setStyleSheet(
+            kBtnBase +
+            QStringLiteral("QPushButton { background: %1; color: %2; }")
+                .arg(c.name(), textColor));
+    };
+
+    auto refreshAllBtns = [applyBtnColor]() mutable {
+        for (int i = 0; i < AetherSDR::kSliceColorCount; ++i)
+            applyBtnColor(i);
+    };
+
+    auto syncModeRadios = [defaultsRadio, customRadio, colorBtns](bool custom) mutable {
+        defaultsRadio->blockSignals(true);
+        customRadio->blockSignals(true);
+        defaultsRadio->setChecked(!custom);
+        customRadio->setChecked(custom);
+        defaultsRadio->blockSignals(false);
+        customRadio->blockSignals(false);
+        for (QPushButton* b : colorBtns)
+            b->setEnabled(custom);
+    };
+
+    // ── Initial state ─────────────────────────────────────────────────────────
+    syncModeRadios(pMgr->useCustomColors());
+    refreshAllBtns();
+
+    // ── Signals ───────────────────────────────────────────────────────────────
+    connect(defaultsRadio, &QRadioButton::toggled, page,
+            [pMgr, syncModeRadios, refreshAllBtns](bool checked) mutable {
+        if (!checked) return;
+        pMgr->setUseCustomColors(false);
+        syncModeRadios(false);
+        refreshAllBtns();
+    });
+
+    connect(customRadio, &QRadioButton::toggled, page,
+            [pMgr, syncModeRadios, refreshAllBtns](bool checked) mutable {
+        if (!checked) return;
+        pMgr->setUseCustomColors(true);
+        syncModeRadios(true);
+        refreshAllBtns();
+    });
+
+    for (int i = 0; i < AetherSDR::kSliceColorCount; ++i) {
+        connect(colorBtns[i], &QPushButton::clicked, page,
+                [i, pMgr, applyBtnColor, page]() mutable {
+            QColor initial = pMgr->customColor(i);
+            QColor chosen = QColorDialog::getColor(initial, page,
+                                                   QStringLiteral("Slice %1 Color")
+                                                       .arg(QChar('A' + i)));
+            if (!chosen.isValid()) return;
+            pMgr->setCustomColor(i, chosen);
+            applyBtnColor(i);
+        });
+    }
+
+    connect(resetBtn, &QPushButton::clicked, page,
+            [pMgr, refreshAllBtns]() mutable {
+        for (int i = 0; i < AetherSDR::kSliceColorCount; ++i)
+            pMgr->resetToDefault(i);
+        refreshAllBtns();
+    });
+
+    // Sync button backgrounds when another widget changes a color
+    connect(pMgr, &SliceColorManager::colorsChanged, page,
+            [syncModeRadios, refreshAllBtns, pMgr]() mutable {
+        syncModeRadios(pMgr->useCustomColors());
+        refreshAllBtns();
+    });
+
+    return page;
 }
 
 } // namespace AetherSDR

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -53,6 +53,7 @@ private:
     QWidget* buildXvtrTab();
     QWidget* buildUsbCablesTab();
     QWidget* buildPeripheralsTab();
+    QWidget* buildUiEnhancementsTab();
 #ifdef HAVE_SERIALPORT
     QWidget* buildSerialTab();
 #endif

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -2,7 +2,6 @@
 #include "FilterPassbandWidget.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
-#include "SliceColors.h"
 #include "SliceColorManager.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -3,6 +3,7 @@
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "SliceColors.h"
+#include "SliceColorManager.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
 
@@ -1029,7 +1030,7 @@ void RxApplet::setMaxSlices(int maxSlices)
         btn->setEnabled(false);  // disabled until a slice occupies this slot
         btn->setFixedSize(22, 20);
 
-        const char* color = (i < kSliceColorCount) ? kSliceColors[i].hexActive : "#888888";
+        QString color = SliceColorManager::instance().hexActive(i);
         btn->setStyleSheet(
             QString("QToolButton { background: #2a2a2a; color: %1; border: 1px solid %1; "
                     "border-radius: 3px; font-weight: bold; font-size: 10px; padding: 0; }"
@@ -1126,11 +1127,10 @@ void RxApplet::connectSlice(SliceModel* s)
     const QChar letter = QChar('A' + s->sliceId());
     m_sliceBadge->setText(QString(letter));
     const int sid = s->sliceId();
-    const char* badgeColor = (sid >= 0 && sid < kSliceColorCount)
-        ? kSliceColors[sid].hexActive : "#0070c0";
     m_sliceBadge->setStyleSheet(
         QString("QLabel { background: %1; color: #000000; "
-                "border-radius: 3px; font-weight: bold; font-size: 11px; }").arg(badgeColor));
+                "border-radius: 3px; font-weight: bold; font-size: 11px; }")
+            .arg(SliceColorManager::instance().hexActive(sid)));
 
     // Lock
     {

--- a/src/gui/SliceColorManager.cpp
+++ b/src/gui/SliceColorManager.cpp
@@ -21,7 +21,9 @@ SliceColorManager::SliceColorManager()
 
 int SliceColorManager::safeIdx(int sliceId)
 {
-    Q_ASSERT(sliceId >= 0);
+    // Defensive: callers normally pass 0..kSliceColorCount-1, but transient
+    // sentinels (e.g. -1 during slice teardown) must not index out of range
+    // or invoke implementation-defined behavior on negative-modulo.
     return std::abs(sliceId) % kSliceColorCount;
 }
 

--- a/src/gui/SliceColorManager.cpp
+++ b/src/gui/SliceColorManager.cpp
@@ -1,0 +1,128 @@
+#include "SliceColorManager.h"
+#include "core/AppSettings.h"
+
+namespace AetherSDR {
+
+static SliceColorManager* s_instance = nullptr;
+
+SliceColorManager& SliceColorManager::instance()
+{
+    if (!s_instance)
+        s_instance = new SliceColorManager;
+    return *s_instance;
+}
+
+SliceColorManager::SliceColorManager()
+{
+    for (int i = 0; i < kSliceColorCount; ++i)
+        m_customColors[i] = defaultActive(i);
+    rebuildHexCache();
+}
+
+QColor SliceColorManager::defaultActive(int idx)
+{
+    const auto& c = kSliceColors[idx % kSliceColorCount];
+    return QColor(c.r, c.g, c.b);
+}
+
+QColor SliceColorManager::defaultDim(int idx)
+{
+    const auto& c = kSliceColors[idx % kSliceColorCount];
+    return QColor(c.dr, c.dg, c.db);
+}
+
+QColor SliceColorManager::activeColor(int sliceId) const
+{
+    int idx = sliceId % kSliceColorCount;
+    if (m_useCustom)
+        return m_customColors[idx];
+    return defaultActive(idx);
+}
+
+QColor SliceColorManager::dimColor(int sliceId) const
+{
+    int idx = sliceId % kSliceColorCount;
+    if (m_useCustom) {
+        // Derive dim color at ~40% of the custom active color's value.
+        QColor c = m_customColors[idx];
+        return QColor(c.red() * 2 / 5, c.green() * 2 / 5, c.blue() * 2 / 5);
+    }
+    return defaultDim(idx);
+}
+
+QString SliceColorManager::hexActive(int sliceId) const
+{
+    return m_hexCache[sliceId % kSliceColorCount];
+}
+
+QColor SliceColorManager::customColor(int sliceId) const
+{
+    return m_customColors[sliceId % kSliceColorCount];
+}
+
+void SliceColorManager::setUseCustomColors(bool enabled)
+{
+    if (m_useCustom == enabled)
+        return;
+    m_useCustom = enabled;
+    rebuildHexCache();
+    save();
+    emit colorsChanged();
+}
+
+void SliceColorManager::setCustomColor(int sliceId, QColor color)
+{
+    int idx = sliceId % kSliceColorCount;
+    if (m_customColors[idx] == color)
+        return;
+    m_customColors[idx] = color;
+    rebuildHexCache();
+    if (m_useCustom) {
+        save();
+        emit colorsChanged();
+    }
+}
+
+void SliceColorManager::resetToDefault(int sliceId)
+{
+    int idx = sliceId % kSliceColorCount;
+    m_customColors[idx] = defaultActive(idx);
+    rebuildHexCache();
+    if (m_useCustom) {
+        save();
+        emit colorsChanged();
+    }
+}
+
+void SliceColorManager::rebuildHexCache()
+{
+    for (int i = 0; i < kSliceColorCount; ++i)
+        m_hexCache[i] = activeColor(i).name();
+}
+
+void SliceColorManager::save() const
+{
+    auto& s = AppSettings::instance();
+    s.setValue("SliceColorsUseCustom", m_useCustom ? "True" : "False");
+    for (int i = 0; i < kSliceColorCount; ++i) {
+        s.setValue(QStringLiteral("SliceColor%1").arg(i),
+                   m_customColors[i].name());
+    }
+    s.save();
+}
+
+void SliceColorManager::load()
+{
+    auto& s = AppSettings::instance();
+    m_useCustom = s.value("SliceColorsUseCustom", "False").toString() == "True";
+    for (int i = 0; i < kSliceColorCount; ++i) {
+        QColor def = defaultActive(i);
+        QString saved = s.value(QStringLiteral("SliceColor%1").arg(i),
+                                def.name()).toString();
+        QColor c(saved);
+        m_customColors[i] = c.isValid() ? c : def;
+    }
+    rebuildHexCache();
+}
+
+} // namespace AetherSDR

--- a/src/gui/SliceColorManager.cpp
+++ b/src/gui/SliceColorManager.cpp
@@ -19,6 +19,12 @@ SliceColorManager::SliceColorManager()
     rebuildHexCache();
 }
 
+int SliceColorManager::safeIdx(int sliceId)
+{
+    Q_ASSERT(sliceId >= 0);
+    return std::abs(sliceId) % kSliceColorCount;
+}
+
 QColor SliceColorManager::defaultActive(int idx)
 {
     const auto& c = kSliceColors[idx % kSliceColorCount];
@@ -33,7 +39,7 @@ QColor SliceColorManager::defaultDim(int idx)
 
 QColor SliceColorManager::activeColor(int sliceId) const
 {
-    int idx = sliceId % kSliceColorCount;
+    int idx = safeIdx(sliceId);
     if (m_useCustom)
         return m_customColors[idx];
     return defaultActive(idx);
@@ -41,7 +47,7 @@ QColor SliceColorManager::activeColor(int sliceId) const
 
 QColor SliceColorManager::dimColor(int sliceId) const
 {
-    int idx = sliceId % kSliceColorCount;
+    int idx = safeIdx(sliceId);
     if (m_useCustom) {
         // Derive dim color at ~40% of the custom active color's value.
         QColor c = m_customColors[idx];
@@ -52,12 +58,12 @@ QColor SliceColorManager::dimColor(int sliceId) const
 
 QString SliceColorManager::hexActive(int sliceId) const
 {
-    return m_hexCache[sliceId % kSliceColorCount];
+    return m_hexCache[safeIdx(sliceId)];
 }
 
 QColor SliceColorManager::customColor(int sliceId) const
 {
-    return m_customColors[sliceId % kSliceColorCount];
+    return m_customColors[safeIdx(sliceId)];
 }
 
 void SliceColorManager::setUseCustomColors(bool enabled)
@@ -72,7 +78,7 @@ void SliceColorManager::setUseCustomColors(bool enabled)
 
 void SliceColorManager::setCustomColor(int sliceId, QColor color)
 {
-    int idx = sliceId % kSliceColorCount;
+    int idx = safeIdx(sliceId);
     if (m_customColors[idx] == color)
         return;
     m_customColors[idx] = color;
@@ -85,7 +91,7 @@ void SliceColorManager::setCustomColor(int sliceId, QColor color)
 
 void SliceColorManager::resetToDefault(int sliceId)
 {
-    int idx = sliceId % kSliceColorCount;
+    int idx = safeIdx(sliceId);
     m_customColors[idx] = defaultActive(idx);
     rebuildHexCache();
     if (m_useCustom) {

--- a/src/gui/SliceColorManager.h
+++ b/src/gui/SliceColorManager.h
@@ -46,8 +46,9 @@ private:
 
     bool m_useCustom{false};
     std::array<QColor, kSliceColorCount> m_customColors;
-    mutable std::array<QString, kSliceColorCount> m_hexCache;
+    std::array<QString, kSliceColorCount> m_hexCache;
 
+    static int safeIdx(int sliceId);
     static QColor defaultActive(int idx);
     static QColor defaultDim(int idx);
     void rebuildHexCache();

--- a/src/gui/SliceColorManager.h
+++ b/src/gui/SliceColorManager.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "SliceColors.h"
+#include <QColor>
+#include <QObject>
+#include <QString>
+#include <array>
+
+namespace AetherSDR {
+
+// Manages per-slice color overrides.  Consumers call activeColor()/dimColor()
+// instead of reading kSliceColors[] directly.  Connect to colorsChanged() to
+// repaint widgets when the user updates colors in Settings.
+class SliceColorManager : public QObject {
+    Q_OBJECT
+public:
+    static SliceColorManager& instance();
+
+    // Returns the effective active/dim color for sliceId (% 8 applied).
+    QColor activeColor(int sliceId) const;
+    QColor dimColor(int sliceId) const;
+    // Returns the hex string for CSS stylesheets (e.g. "#00d4ff").
+    QString hexActive(int sliceId) const;
+
+    // Whether custom colors are enabled (false = Aether defaults).
+    bool useCustomColors() const { return m_useCustom; }
+    void setUseCustomColors(bool enabled);
+
+    // Get / set a custom base color for the given slice (0-7).
+    QColor customColor(int sliceId) const;
+    void setCustomColor(int sliceId, QColor color);
+
+    // Persist current state to AppSettings.
+    void save() const;
+    // Load from AppSettings (called at startup).
+    void load();
+
+    // Reset a single slot to its default color.
+    void resetToDefault(int sliceId);
+
+signals:
+    void colorsChanged();
+
+private:
+    SliceColorManager();
+
+    bool m_useCustom{false};
+    std::array<QColor, kSliceColorCount> m_customColors;
+    mutable std::array<QString, kSliceColorCount> m_hexCache;
+
+    static QColor defaultActive(int idx);
+    static QColor defaultDim(int idx);
+    void rebuildHexCache();
+};
+
+} // namespace AetherSDR

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2,6 +2,7 @@
 #include "SpectrumOverlayMenu.h"
 #include "VfoWidget.h"
 #include "SliceColors.h"
+#include "SliceColorManager.h"
 #include <QVariantAnimation>
 
 #ifdef AETHER_GPU_SPECTRUM
@@ -255,6 +256,9 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     };
     connect(m_zoomOutBtn, &QPushButton::clicked, this, [emitZoom]() { emitZoom(1.5); });
     connect(m_zoomInBtn,  &QPushButton::clicked, this, [emitZoom]() { emitZoom(1.0 / 1.5); });
+
+    connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged,
+            this, [this]() { markOverlayDirty(); });
 }
 
 // ── Multi-VfoWidget management ────────────────────────────────────────────────
@@ -1146,9 +1150,8 @@ void SpectrumWidget::setDbmRange(float minDbm, float maxDbm)
 // ─── Slice color table (shared via SliceColors.h) ────────────────────────────
 
 static QColor sliceColor(int sliceId, bool active) {
-    const auto& c = kSliceColors[sliceId % kSliceColorCount];
-    if (active) return QColor(c.r, c.g, c.b);
-    return QColor(c.dr, c.dg, c.db);
+    if (active) return SliceColorManager::instance().activeColor(sliceId);
+    return SliceColorManager::instance().dimColor(sliceId);
 }
 
 // ─── Multi-slice overlay management ──────────────────────────────────────────

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2,7 +2,6 @@
 #include "PhaseKnob.h"
 #include "ComboStyle.h"
 #include "GuardedSlider.h"
-#include "SliceColors.h"
 #include "SliceColorManager.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -3,6 +3,7 @@
 #include "ComboStyle.h"
 #include "GuardedSlider.h"
 #include "SliceColors.h"
+#include "SliceColorManager.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
 #include "core/AppSettings.h"
@@ -197,6 +198,12 @@ VfoWidget::VfoWidget(QWidget* parent)
     connect(&m_signalMeterAnimation, &QTimer::timeout, this, &VfoWidget::animateSignalMeter);
 
     buildUI();
+
+    connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged,
+            this, [this]() {
+        syncFromSlice();  // refreshes badge stylesheet
+        update();         // refreshes collapsed-mode painter
+    });
 }
 
 void VfoWidget::wheelEvent(QWheelEvent* ev)
@@ -2111,10 +2118,8 @@ void VfoWidget::paintEvent(QPaintEvent* event)
 
         // Slice letter badge
         int sliceId = m_slice ? m_slice->sliceId() : 0;
-        const char* badgeColor = (sliceId >= 0 && sliceId < kSliceColorCount)
-            ? kSliceColors[sliceId].hexActive : "#0070c0";
         QRect badgeRect(margin, yPos, badgeSize, badgeSize);
-        p.setBrush(QColor(badgeColor));
+        p.setBrush(SliceColorManager::instance().activeColor(sliceId));
         p.setPen(Qt::NoPen);
         p.drawRoundedRect(badgeRect, 3, 3);
 
@@ -2783,11 +2788,10 @@ void VfoWidget::syncFromSlice()
     int id = m_slice->sliceId();
     m_sliceBadge->setText(QString(QChar(id >= 0 && id < 8 ? letters[id] : '?')));
     // Color-code the slice badge to match the spectrum overlay colors
-    const char* badgeColor = (id >= 0 && id < kSliceColorCount)
-        ? kSliceColors[id].hexActive : "#0070c0";
     m_sliceBadge->setStyleSheet(
         QString("QLabel { background: %1; color: #000000; "
-                "border-radius: 3px; font-weight: bold; font-size: 11px; }").arg(badgeColor));
+                "border-radius: 3px; font-weight: bold; font-size: 11px; }")
+            .arg(SliceColorManager::instance().hexActive(id)));
     updateFreqLabel();
     updateFilterLabel();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "gui/MainWindow.h"
+#include "gui/SliceColorManager.h"
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
 #include "core/MacMicPermission.h"
@@ -235,6 +236,9 @@ int main(int argc, char* argv[])
 
     // Load XML settings (auto-migrates from QSettings on first run)
     AetherSDR::AppSettings::instance().load();
+
+    // Load slice color overrides (must be after AppSettings::load)
+    AetherSDR::SliceColorManager::instance().load();
 
     // Load per-module logging toggles (must be after AppSettings::load)
     AetherSDR::LogManager::instance().loadSettings();


### PR DESCRIPTION
## Summary

Adds a new **UI Enhancements** settings tab that lets users choose between the
built-in Aether default slice colors or a fully custom palette. Changes take
effect immediately across the entire UI — no restart required — and are
persisted across sessions.

## Motivation

Slice A–H colors were previously hardcoded in `SliceColors.h` and scattered
throughout the rendering and widget code with no way for users to change them.
Users with color vision deficiencies, specific monitor profiles, or personal
preference had no recourse. This feature brings the slice color palette under
user control while keeping the existing Aether defaults as the out-of-the-box
experience.

---

## What Changed

### New: `SliceColorManager` (singleton, `src/gui/SliceColorManager.h/.cpp`)

The central piece of this feature. A `QObject` singleton that sits between the
static `kSliceColors[]` table and every widget that renders slice colors.

- `activeColor(int sliceId)` / `dimColor(int sliceId)` — returns the effective
  color for a given slice, either from the Aether defaults or the user's custom
  palette.
- `hexActive(int sliceId)` — returns a CSS hex string (e.g. `"#00d4ff"`) for
  use in `setStyleSheet()` calls.
- `useCustomColors()` / `setUseCustomColors(bool)` — toggles the mode.
- `customColor(int)` / `setCustomColor(int, QColor)` — gets/sets an individual
  slot's custom color.
- `resetToDefault(int)` — restores a single slot to the Aether default.
- `load()` / `save()` — reads and writes to `AppSettings`. Keys:
  - `SliceColorsUseCustom` — `"True"` / `"False"`
  - `SliceColor0` through `SliceColor7` — hex color strings
- `Q_SIGNAL void colorsChanged()` — emitted on any effective color change.
  All consumer widgets connect to this signal to repaint/re-stylesheet
  themselves in real time.

Dim colors for custom slots are derived automatically at ~40 % of the active
color's RGB values (same relative attenuation as the built-in defaults), so
the inactive-slice shading remains readable without requiring a separate picker
for every state.

---

### New Settings Tab: "UI Enhancements" (in Radio Setup dialog)

Added as a deferred-load tab following the same lazy-construction pattern used
by all other tabs since #1776.

**Controls:**

| Control | Behavior |
|---|---|
| **Use Aether defaults** radio button | Switches to the built-in palette; color buttons are disabled |
| **Custom colors** radio button | Enables the custom palette; color buttons become interactive |
| **A–H color buttons** | Each button shows its current color as a background. Clicking opens a native `QColorDialog`. The change is applied and saved immediately — no "Apply" step needed. |
| **Reset All to Defaults** button | Resets all eight custom color slots to the Aether defaults without switching the mode radio button |

The tab also connects to `SliceColorManager::colorsChanged()` so that if a
color is ever programmatically changed elsewhere, the swatches stay in sync.

---

### Consumer Widgets Updated

All direct accesses to `kSliceColors[i]` in rendering/widget code have been
replaced with `SliceColorManager::instance()` calls. Each widget also connects
`colorsChanged()` to refresh itself:

| File | What changed |
|---|---|
| `SpectrumWidget.cpp` | `sliceColor()` helper delegates to manager; constructor connects `colorsChanged` → `markOverlayDirty()` to repaint the filter-band overlay |
| `VfoWidget.cpp` | Slice letter badge in both expanded and collapsed (painter) modes uses manager; constructor connects `colorsChanged` → `syncFromSlice()` + `update()` |
| `RxApplet.cpp` | Slice selector toolbar buttons and the header badge use manager |
| `CatControlApplet.cpp` | Slice letter badges and TCP-client status labels use manager |

---

### `main.cpp`

`SliceColorManager::instance().load()` is called immediately after
`AppSettings::instance().load()` at startup, so custom colors are active
before any widget is constructed.

---

### `CMakeLists.txt`

`src/gui/SliceColorManager.cpp` added to the source list.

---

## Settings Persistence

```
~/.config/AetherSDR/AetherSDR.settings
  SliceColorsUseCustom = True
  SliceColor0 = #00d4ff
  SliceColor1 = #ff40ff
  ...
  SliceColor7 = #b080ff
```

When `SliceColorsUseCustom` is `False` (the default for new installs),
the custom color keys are still written on first save so the slots are
pre-populated with the Aether defaults and ready to edit.

---

## Testing Notes

- Verified clean build (0 errors, 0 new warnings) with Ninja/GCC on Arch Linux.
- Open Radio Setup → UI Enhancements tab:
  - Defaults mode: color buttons disabled, spectrum/VFO badges show Aether colors.
  - Switch to Custom: buttons enable, pick a new color for slice A → spectrum
    filter band, VFO badge, and RX applet badge all update immediately without
    reopening the dialog.
  - Restart app → custom colors restore from `AetherSDR.settings`.
  - Reset All → reverts swatches and live UI to defaults without changing mode.
- No changes to radio protocol, slice model, or audio path.
