### PR TITLE
VfoWidget: clear orphaned Slice<N>_MarkerThin key after migration

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1955,6 +1955,8 @@ void VfoWidget::loadDisplayPrefs()
     } else {
         // Migrate from the old MarkerThin bool: True (thin) → 1, False (thick) → 3.
         m_markerWidth = (s.value(keyT, "False").toString() == "True") ? 1 : 3;
+        if (s.contains(keyT))
+            s.remove(keyT);
     }
     if (m_markerWidth != 0 && m_markerWidth != 1 && m_markerWidth != 3)
         m_markerWidth = 1;


### PR DESCRIPTION
Resolves #2143.

#2141 migrated per-slice marker-style preferences from `Slice<N>_MarkerThin` (bool) to `Slice<N>_MarkerWidth` (int 0/1/3). `loadDisplayPrefs()` reads the old key only as a fallback when the new key is absent, but never deletes it — so the orphan accumulates in `~/.config/AetherSDR/AetherSDR.settings` indefinitely.

## Change

After migrating the value into `m_markerWidth`, remove the old key so subsequent `saveDisplayPrefs()` calls don't carry the orphan forward:

```cpp
} else {
    // Migrate from the old MarkerThin bool: True (thin) → 1, False (thick) → 3.
    m_markerWidth = (s.value(keyT, "False").toString() == "True") ? 1 : 3;
    if (s.contains(keyT))
        s.remove(keyT);
}
```

The remove only fires once per slice (the next load will already see `keyW` and skip the `else` branch entirely), so this is a one-time cleanup per settings file.

The next `saveDisplayPrefs()` call (or the first one after this load) writes the new layout without the orphan, matching the issue's "save once on the next opportunity" approach.

Tiny single-file fix as flagged in the issue.