### PR TITLE
TunerModel: prefer direct TGXL autotune (port 9010) over firmware-routed command

### DIFF
--- a/src/core/TgxlConnection.cpp
+++ b/src/core/TgxlConnection.cpp
@@ -168,6 +168,12 @@ void TgxlConnection::adjustRelay(int relay, int direction)
     sendCommand(QString("tune relay=%1 move=%2").arg(relay).arg(move));
 }
 
+void TgxlConnection::requestAutotune()
+{
+    if (!m_connected) return;
+    sendCommand("autotune");
+}
+
 void TgxlConnection::pollStatus()
 {
     if (m_connected)

--- a/src/core/TgxlConnection.h
+++ b/src/core/TgxlConnection.h
@@ -36,6 +36,12 @@ public:
     // Manual relay adjustment: relay 0=C1, 1=L, 2=C2; direction +1 or -1
     void adjustRelay(int relay, int direction);
 
+    // Native autotune over the direct port-9010 channel. The TGXL drives
+    // radio PTT via its hardware interlock cable, so no client-side keying
+    // is required. Bypasses the firmware's `tgxl autotune` command path
+    // (broken in firmware 4.2 — see issue tracker for "TUNE button on TGXL").
+    void requestAutotune();
+
     // Send an arbitrary command to the TGXL (e.g. "activate ant=2")
     quint32 sendCommand(const QString& cmd);
 

--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -104,8 +104,17 @@ void TunerModel::setBypass(bool on)
 
 void TunerModel::autoTune()
 {
+    // Prefer the direct port-9010 channel when available: bypasses the radio's
+    // `tgxl autotune` command path, which broke for some users in firmware 4.2.
+    // The TGXL drives radio PTT via its hardware interlock cable, so we don't
+    // need to key the radio from the client.
+    if (m_directConn && m_directConn->isConnected()) {
+        qCDebug(lcTuner) << "TunerModel::autoTune: using direct TGXL path";
+        m_directConn->requestAutotune();
+        return;
+    }
     if (m_handle.isEmpty()) {
-        qCDebug(lcTuner) << "TunerModel::autoTune: no handle yet, ignoring";
+        qCDebug(lcTuner) << "TunerModel::autoTune: no direct conn and no handle, ignoring";
         return;
     }
     const QString cmd = "tgxl autotune handle=" + m_handle;


### PR DESCRIPTION
## Summary

When a direct TGXL connection (port 9010) is configured, sends the native `autotune` command directly to the TGXL instead of routing `tgxl autotune handle=<H>` through the radio's command channel. Falls back to the radio path when no direct connection is available.

## Why

SmartSDR firmware 4.2 changed the radio↔TGXL handshake — users on both AetherSDR and SmartSDR report the TUNE button no longer works on TGXL after the upgrade. The direct-to-TGXL channel is independent of the radio's command stream and isn't affected, so this gives affected users a working path again without waiting on a firmware fix.

## Protocol

Reverse-engineered from a 4O3A management-app pcap (`reference/TGXL_TUNE.json`):

```
T+0.820s   →TGXL    C437|autotune
T+0.823s   TGXL→    R437|0|                      ← ack code 0 = success
T+0.832s   TGXL→    S0|state ... tuning=1 ...    ← sweep begins
                    (TGXL keys radio via hardware interlock cable)
T+2.768s   TGXL→    S0|state ... tuning=0 relayC1=16 relayL=4 relayC2=8
                    ← sweep complete (~1.94 s for 14.291 MHz)
```

The TGXL drives radio PTT via its hardware interlock cable when it receives `autotune`, so the client doesn't need to key the radio. The existing `stateUpdated` / `statusUpdated` signals already deliver `tuning=` and `swr=` to [TunerApplet](src/gui/TunerApplet.cpp), so the TUNING…→SWR readout UI feedback works unchanged.

## Changes

- [src/core/TgxlConnection.h](src/core/TgxlConnection.h) — declare `requestAutotune()`
- [src/core/TgxlConnection.cpp](src/core/TgxlConnection.cpp) — send `autotune` command on port 9010
- [src/models/TunerModel.cpp](src/models/TunerModel.cpp) — prefer direct path in `autoTune()`, fall back to `tgxl autotune handle=<H>` if no direct connection

22 insertions, 1 deletion.

## Test plan

- [ ] Build passes (verified locally)
- [ ] **On-air test with TGXL on firmware 4.2**: configure direct TGXL IP in Radio Setup, press TUNE in the Tuner applet, confirm:
  - [ ] Radio keys at tune power (TGXL drives PTT)
  - [ ] Tuning…→SWR readout cycles correctly in the TUNE button
  - [ ] Final SWR is reasonable for the band/antenna
  - [ ] Logs show `TunerModel::autoTune: using direct TGXL path`
- [ ] **Fallback test (no direct connection)**: clear direct TGXL IP, press TUNE, confirm legacy `tgxl autotune handle=<H>` command still fires (or fails the same way it does on 4.2 today — this branch doesn't fix that case)
- [ ] **Regression test**: manual relay adjust (C1/L/C2 stepper) and antenna switch (3x1 ANT1/2/3) still work — these share the direct connection but go through different commands

## Risks

- Users without a direct TGXL connection configured will still hit the firmware bug on 4.2 — they can work around it by configuring direct, or wait for a firmware fix.
- In a Multi-Flex scenario, two clients firing native `autotune` simultaneously have no coordination (the native command takes no `handle=`). Acceptable; rare edge case.
- If TGXL refuses `autotune` when `state.active=0`, we may need to send `activate ant=<N>` first. Capture didn't include a from-cold case — worth verifying during on-air test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)