### PR TITLE
FirmwareStager: support v4.2+ MSI (native libmspack) + user-selected installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,8 @@ set(CORE_SOURCES
     src/core/DvkWavTransfer.cpp
     src/core/QsoRecorder.cpp
     src/core/FirmwareStager.cpp
+    src/core/OleCompoundFile.cpp
+    src/core/CabExtractor.cpp
     src/core/RNNoiseFilter.cpp
     src/core/SpecbleachFilter.cpp
     src/core/CwDecoder.cpp
@@ -770,6 +772,11 @@ if(AETHER_GPU_SPECTRUM)
             resources/shaders/spectrum.frag
     )
 endif()
+
+# Bundled libmspack (LGPL-2.1) — CAB+LZX decompression for the v4.2+ MSI
+# firmware-installer extraction path. See third_party/libmspack/README.md.
+add_subdirectory(third_party/libmspack)
+target_link_libraries(AetherSDR PRIVATE mspack_static)
 
 # Bundled RtMidi (MIT license) — MIDI controller support on all platforms
 message(STATUS "MIDI controller support enabled (bundled RtMidi)")
@@ -1131,6 +1138,16 @@ add_executable(passive_spots_policy_test
 )
 target_include_directories(passive_spots_policy_test PRIVATE src)
 target_link_libraries(passive_spots_policy_test PRIVATE Qt6::Core)
+
+add_executable(ole_compound_file_test
+    tests/ole_compound_file_test.cpp
+    src/core/OleCompoundFile.cpp
+    src/core/CabExtractor.cpp
+    src/core/LogManager.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(ole_compound_file_test PRIVATE src)
+target_link_libraries(ole_compound_file_test PRIVATE Qt6::Core mspack_static)
 
 add_executable(xvtr_policy_test
     tests/xvtr_policy_test.cpp

--- a/src/core/CabExtractor.cpp
+++ b/src/core/CabExtractor.cpp
@@ -1,0 +1,217 @@
+#include "CabExtractor.h"
+#include "LogManager.h"
+
+extern "C" {
+#include <mspack.h>
+}
+
+#include <cstdarg>
+#include <cstdlib>
+#include <cstring>
+
+namespace AetherSDR {
+
+namespace {
+
+// Per-file state passed back to libmspack callbacks. mspack treats this
+// as opaque — we cast to our concrete type in each callback.
+struct MemFile {
+    const QByteArray* readBuf{nullptr};   // non-null when this file is input
+    QByteArray*       writeBuf{nullptr};  // non-null when this file is output
+    qint64            offset{0};
+};
+
+// Our mspack_system extension. mspack_system is the first member so a
+// pointer to one can be safely cast to/from our struct.
+struct MemSystem {
+    mspack_system base;
+    const QByteArray* cabSource{nullptr};  // cab input, set before open()
+    QByteArray*       payloadSink{nullptr}; // payload output, set before extract()
+};
+
+// ─── mspack_system callbacks ────────────────────────────────────────────────
+
+mspack_file* mem_open(mspack_system* self, const char* /*filename*/, int mode)
+{
+    auto* sys = reinterpret_cast<MemSystem*>(self);
+    auto* mf = new MemFile;
+    if (mode == MSPACK_SYS_OPEN_READ) {
+        if (!sys->cabSource) {
+            delete mf;
+            return nullptr;
+        }
+        mf->readBuf = sys->cabSource;
+    } else if (mode == MSPACK_SYS_OPEN_WRITE) {
+        if (!sys->payloadSink) {
+            delete mf;
+            return nullptr;
+        }
+        mf->writeBuf = sys->payloadSink;
+    } else {
+        // We don't support UPDATE or APPEND — cab extraction never asks for them.
+        delete mf;
+        return nullptr;
+    }
+    return reinterpret_cast<mspack_file*>(mf);
+}
+
+void mem_close(mspack_file* file)
+{
+    delete reinterpret_cast<MemFile*>(file);
+}
+
+int mem_read(mspack_file* file, void* buffer, int bytes)
+{
+    auto* mf = reinterpret_cast<MemFile*>(file);
+    if (!mf->readBuf) return -1;
+    const qint64 remaining = mf->readBuf->size() - mf->offset;
+    const qint64 n = qMin<qint64>(remaining, bytes);
+    if (n <= 0) return 0;
+    std::memcpy(buffer, mf->readBuf->constData() + mf->offset, static_cast<size_t>(n));
+    mf->offset += n;
+    return static_cast<int>(n);
+}
+
+int mem_write(mspack_file* file, void* buffer, int bytes)
+{
+    auto* mf = reinterpret_cast<MemFile*>(file);
+    if (!mf->writeBuf) return -1;
+    if (bytes <= 0) return 0;
+    mf->writeBuf->append(static_cast<const char*>(buffer), bytes);
+    mf->offset += bytes;
+    return bytes;
+}
+
+int mem_seek(mspack_file* file, off_t offset, int mode)
+{
+    auto* mf = reinterpret_cast<MemFile*>(file);
+    if (!mf->readBuf) return -1;
+    qint64 newOffset = mf->offset;
+    switch (mode) {
+        case MSPACK_SYS_SEEK_START: newOffset = offset; break;
+        case MSPACK_SYS_SEEK_CUR:   newOffset += offset; break;
+        case MSPACK_SYS_SEEK_END:   newOffset = mf->readBuf->size() + offset; break;
+        default: return -1;
+    }
+    if (newOffset < 0 || newOffset > mf->readBuf->size())
+        return -1;
+    mf->offset = newOffset;
+    return 0;
+}
+
+off_t mem_tell(mspack_file* file)
+{
+    return reinterpret_cast<MemFile*>(file)->offset;
+}
+
+void mem_message(mspack_file* /*file*/, const char* format, ...)
+{
+    char buf[512];
+    va_list ap;
+    va_start(ap, format);
+    std::vsnprintf(buf, sizeof(buf), format, ap);
+    va_end(ap);
+    qCWarning(lcFirmware) << "libmspack:" << buf;
+}
+
+void* mem_alloc(mspack_system* /*self*/, size_t bytes)
+{
+    return std::malloc(bytes);
+}
+
+void mem_free(void* ptr)
+{
+    std::free(ptr);
+}
+
+void mem_copy(void* src, void* dest, size_t bytes)
+{
+    std::memcpy(dest, src, bytes);
+}
+
+} // anonymous namespace
+
+bool CabExtractor::extractAll(const QByteArray& cabBytes,
+                               QList<QPair<QString, QByteArray>>& out)
+{
+    out.clear();
+    if (cabBytes.isEmpty()) {
+        m_lastError = "empty cab buffer";
+        return false;
+    }
+
+    MemSystem sys{};
+    sys.base.open    = &mem_open;
+    sys.base.close   = &mem_close;
+    sys.base.read    = &mem_read;
+    sys.base.write   = &mem_write;
+    sys.base.seek    = &mem_seek;
+    sys.base.tell    = &mem_tell;
+    sys.base.message = &mem_message;
+    sys.base.alloc   = &mem_alloc;
+    sys.base.free    = &mem_free;
+    sys.base.copy    = &mem_copy;
+    sys.cabSource    = &cabBytes;
+    // sys.payloadSink is rebound per-file inside the loop below.
+
+    auto* cabd = mspack_create_cab_decompressor(&sys.base);
+    if (!cabd) {
+        m_lastError = "mspack_create_cab_decompressor failed";
+        return false;
+    }
+
+    auto* cab = cabd->open(cabd, const_cast<char*>("<cab>"));
+    if (!cab) {
+        m_lastError = QString("cabd->open: error %1").arg(cabd->last_error(cabd));
+        mspack_destroy_cab_decompressor(cabd);
+        return false;
+    }
+
+    if (!cab->files) {
+        m_lastError = "cabinet has no files";
+        cabd->close(cabd, cab);
+        mspack_destroy_cab_decompressor(cabd);
+        return false;
+    }
+
+    for (auto* file = cab->files; file; file = file->next) {
+        QByteArray payload;
+        sys.payloadSink = &payload;
+        const int rc = cabd->extract(cabd, file, const_cast<char*>("<out>"));
+        if (rc != MSPACK_ERR_OK) {
+            m_lastError = QString("cabd->extract(%1): error %2")
+                .arg(QString::fromLocal8Bit(file->filename ? file->filename : "?"))
+                .arg(rc);
+            out.clear();
+            cabd->close(cabd, cab);
+            mspack_destroy_cab_decompressor(cabd);
+            return false;
+        }
+        out.append({QString::fromLocal8Bit(file->filename ? file->filename : ""),
+                    std::move(payload)});
+    }
+
+    cabd->close(cabd, cab);
+    mspack_destroy_cab_decompressor(cabd);
+    return true;
+}
+
+bool CabExtractor::extractFirstMatchingMagic(const QByteArray& cabBytes,
+                                              const QByteArray& magic,
+                                              QByteArray& out)
+{
+    out.clear();
+    QList<QPair<QString, QByteArray>> all;
+    if (!extractAll(cabBytes, all))
+        return false;
+    for (auto& [name, data] : all) {
+        if (data.startsWith(magic)) {
+            out = std::move(data);
+            return true;
+        }
+    }
+    m_lastError = "no file in cab matched the requested magic";
+    return false;
+}
+
+} // namespace AetherSDR

--- a/src/core/CabExtractor.h
+++ b/src/core/CabExtractor.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <QByteArray>
+#include <QList>
+#include <QPair>
+#include <QString>
+
+namespace AetherSDR {
+
+// Extract files from a Microsoft CAB archive that lives entirely in
+// memory. Used by the firmware-update path to unpack `cab*.cab` streams
+// pulled from a WiX MSI.
+//
+// libmspack does the actual CAB+LZX/MSZIP/Quantum decompression. We
+// supply a custom mspack_system that reads the cabinet bytes from a
+// QByteArray and writes the decompressed payload to another QByteArray —
+// no temp files involved.
+class CabExtractor {
+public:
+    // Extract every file in `cabBytes` into `out` as (filename, bytes)
+    // pairs, in cabinet order. Returns true on success.
+    bool extractAll(const QByteArray& cabBytes,
+                    QList<QPair<QString, QByteArray>>& out);
+
+    // Convenience: extract every file and return the first whose
+    // payload begins with `magic`. Used by the firmware-update path
+    // to grab the .ssdr blob (magic="Salted__") and ignore the
+    // sibling driver/installer files in the same cab.
+    bool extractFirstMatchingMagic(const QByteArray& cabBytes,
+                                   const QByteArray& magic,
+                                   QByteArray& out);
+
+    QString lastError() const { return m_lastError; }
+
+private:
+    QString m_lastError;
+};
+
+} // namespace AetherSDR

--- a/src/core/FirmwareStager.cpp
+++ b/src/core/FirmwareStager.cpp
@@ -131,6 +131,83 @@ void FirmwareStager::checkForUpdate(const QString& currentVersion)
     });
 }
 
+// ─── Step 2a: Stage from a user-selected local file ─────────────────────────
+
+void FirmwareStager::stageFromLocalFile(const QString& installerPath,
+                                         const QString& modelFamily)
+{
+    m_modelFamily   = modelFamily;
+    m_cancelled     = false;
+    m_stagedPath.clear();
+    m_stagedVersion.clear();
+    m_installerPath = installerPath;
+    m_expectedMd5.clear();   // user's responsibility — we don't have an authoritative source
+
+    QFileInfo fi(installerPath);
+    if (!fi.exists() || !fi.isReadable()) {
+        emit stageFailed("Cannot read installer: " + installerPath);
+        return;
+    }
+
+    // Parse version from filename so the staged .ssdr ends up named correctly.
+    // Patterns we support:
+    //   SmartSDR_v4.2.18_x64.msi
+    //   SmartSDR_v4.1.5_Installer.exe
+    //   FLEX-6x00_v4.2.18.41174.ssdr      (already-extracted firmware)
+    QRegularExpression verRe(R"(v(\d+\.\d+\.\d+(?:\.\d+)?))",
+                              QRegularExpression::CaseInsensitiveOption);
+    auto m = verRe.match(fi.fileName());
+    m_targetVersion = m.hasMatch() ? m.captured(1) : QStringLiteral("unknown");
+
+    // If the user picked a pre-extracted .ssdr, no extraction needed —
+    // copy it into the staging dir under our canonical name and we're done.
+    if (fi.suffix().compare("ssdr", Qt::CaseInsensitive) == 0) {
+        emit stageProgress(20, "Validating .ssdr file...");
+        QFile probe(installerPath);
+        if (!probe.open(QIODevice::ReadOnly)) {
+            emit stageFailed("Cannot open .ssdr: " + probe.errorString());
+            return;
+        }
+        const QByteArray hdr = probe.read(8);
+        probe.close();
+        if (hdr != QByteArrayLiteral("Salted__")) {
+            emit stageFailed("Selected .ssdr file has invalid header.");
+            return;
+        }
+
+        emit stageProgress(60, "Staging firmware...");
+        const QString outName = "FLEX-" + m_modelFamily + "_v" + m_targetVersion + ".ssdr";
+        const QString outPath = stagingDir() + "/" + outName;
+        QFile::remove(outPath);
+        if (!QFile::copy(installerPath, outPath)) {
+            emit stageFailed("Failed to copy .ssdr into staging directory.");
+            return;
+        }
+
+        QFile h(outPath);
+        if (!h.open(QIODevice::ReadOnly)) {
+            emit stageFailed("Cannot read staged firmware for hashing.");
+            return;
+        }
+        QCryptographicHash fwHash(QCryptographicHash::Md5);
+        fwHash.addData(&h);
+        const QString fwMd5 = fwHash.result().toHex().toLower();
+        const qint64 fwSize = h.size();
+        h.close();
+
+        m_stagedPath = outPath;
+        m_stagedVersion = m_targetVersion;
+        emit stageProgress(100, QString("Firmware staged and ready ✓\n"
+            "%1 (%2 MB)\nMD5: %3").arg(outName).arg(fwSize / (1024*1024)).arg(fwMd5));
+        emit stageComplete(outPath, m_targetVersion);
+        return;
+    }
+
+    // Otherwise it's an installer (.msi or .exe) — go straight to extraction.
+    // verifyAndExtract() handles format detection from the file header.
+    verifyAndExtract();
+}
+
 // ─── Step 2: Download installer ──────────────────────────────────────────────
 
 void FirmwareStager::downloadAndStage(const QString& version, const QString& modelFamily)

--- a/src/core/FirmwareStager.cpp
+++ b/src/core/FirmwareStager.cpp
@@ -6,6 +6,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QNetworkRequest>
+#include <QProcess>
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QUrl>
@@ -38,6 +39,48 @@ QString FirmwareStager::modelToFamily(const QString& model)
     if (model.contains("9600"))
         return "9600";
     return "6x00";
+}
+
+bool FirmwareStager::versionUsesMsi(const QString& version)
+{
+    // FlexRadio switched from InnoSetup (.exe) to WiX MSI in SmartSDR v4.2.
+    const auto parts = version.split('.');
+    if (parts.size() < 2) return false;
+    bool ok1 = false, ok2 = false;
+    const int major = parts[0].toInt(&ok1);
+    const int minor = parts[1].toInt(&ok2);
+    if (!ok1 || !ok2) return false;
+    return (major > 4) || (major == 4 && minor >= 2);
+}
+
+QString FirmwareStager::findExtractionTool()
+{
+    // 7z handles both MSI (OLE Compound File) and the LZX-compressed CABs
+    // inside, so we use it as a single tool. Try the common binary names.
+    static const QStringList candidates = {
+        "7z", "7zz", "7za",
+        "/usr/local/bin/7z",       // macOS Intel Homebrew
+        "/opt/homebrew/bin/7z",    // macOS Apple Silicon Homebrew
+        "/opt/homebrew/bin/7zz",
+    };
+    for (const QString& cand : candidates) {
+        // Absolute paths: check existence directly.
+        if (cand.startsWith('/')) {
+            if (QFileInfo::exists(cand) && QFileInfo(cand).isExecutable())
+                return cand;
+            continue;
+        }
+        // Otherwise probe via QProcess (catches PATH lookups portably).
+        QProcess p;
+        p.setProgram(cand);
+        p.setArguments({"--help"});
+        p.start();
+        if (p.waitForStarted(2000)) {
+            p.waitForFinished(3000);
+            return cand;
+        }
+    }
+    return QString();
 }
 
 // ─── Step 1: Check for update ────────────────────────────────────────────────
@@ -123,9 +166,15 @@ void FirmwareStager::downloadAndStage(const QString& version, const QString& mod
             qCWarning(lcFirmware) << "FirmwareStager: MD5 hash file not available (non-fatal)";
         }
 
-        // Now download the installer
-        const QString installerUrl = QString(INSTALLER_URL_FMT).arg(version);
-        m_installerPath = stagingDir() + "/SmartSDR_v" + version + "_Installer.exe";
+        // Now download the installer. v4.2+ ships as a WiX MSI; older
+        // releases used an InnoSetup .exe.
+        const bool useMsi = versionUsesMsi(version);
+        const QString installerUrl = useMsi
+            ? QString(INSTALLER_URL_FMT_MSI).arg(version)
+            : QString(INSTALLER_URL_FMT_EXE).arg(version);
+        m_installerPath = stagingDir()
+            + (useMsi ? "/SmartSDR_v" + version + "_x64.msi"
+                      : "/SmartSDR_v" + version + "_Installer.exe");
 
         // Check if we already have it cached
         if (QFileInfo::exists(m_installerPath) && !m_expectedMd5.isEmpty()) {
@@ -241,16 +290,86 @@ void FirmwareStager::verifyAndExtract()
     // Step 4: Extract .ssdr firmware
     emit stageProgress(70, "Extracting firmware...");
 
-    QFile installer(m_installerPath);
-    if (!installer.open(QIODevice::ReadOnly)) {
+    // Detect installer format from the first 8 bytes:
+    //   InnoSetup .exe → "MZ" (PE/COFF) header
+    //   WiX MSI        → OLE Compound File: D0 CF 11 E0 A1 B1 1A E1
+    QFile probe(m_installerPath);
+    if (!probe.open(QIODevice::ReadOnly)) {
         emit stageFailed("Cannot open installer for extraction.");
         return;
     }
+    const QByteArray header = probe.read(8);
+    probe.close();
 
-    const QByteArray data = installer.readAll();
-    installer.close();
+    const QByteArray oleMagic("\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1", 8);
+    const bool isMsi = (header == oleMagic);
 
-    // Find all "Salted__" signatures
+    // Compute output path early so both extractors can target the same place.
+    const QString targetName = "FLEX-" + m_modelFamily + "_v" + m_targetVersion + ".ssdr";
+    const QString outPath = stagingDir() + "/" + targetName;
+    QFile::remove(outPath);
+
+    bool ok = false;
+    if (isMsi) {
+        ok = extractFromMsi(m_installerPath, outPath);
+    } else {
+        QFile installer(m_installerPath);
+        if (!installer.open(QIODevice::ReadOnly)) {
+            emit stageFailed("Cannot open installer for extraction.");
+            return;
+        }
+        const QByteArray data = installer.readAll();
+        installer.close();
+        ok = extractFromInnoSetup(data, outPath);
+    }
+    if (!ok) {
+        // The format-specific extractor already emitted stageFailed.
+        return;
+    }
+
+    // Common downstream: validate header, MD5, emit completion.
+    emit stageProgress(92, "Validating extracted firmware...");
+    QFile check(outPath);
+    if (!check.open(QIODevice::ReadOnly)) {
+        emit stageFailed("Cannot read extracted firmware for validation.");
+        return;
+    }
+    const QByteArray fwHeader = check.read(8);
+    check.close();
+
+    if (fwHeader != QByteArrayLiteral("Salted__")) {
+        emit stageFailed("Extracted firmware failed validation (bad header).");
+        QFile::remove(outPath);
+        return;
+    }
+
+    QFile hashFile(outPath);
+    hashFile.open(QIODevice::ReadOnly);
+    QCryptographicHash fwHash(QCryptographicHash::Md5);
+    fwHash.addData(&hashFile);
+    const QString fwMd5 = fwHash.result().toHex().toLower();
+    const qint64 fwSize = hashFile.size();
+    hashFile.close();
+
+    m_stagedPath = outPath;
+    m_stagedVersion = m_targetVersion;
+
+    emit stageProgress(100, QString("Firmware staged and ready ✓\n"
+        "%1 (%2 MB)\nMD5: %3")
+        .arg(targetName)
+        .arg(fwSize / (1024*1024))
+        .arg(fwMd5));
+    emit stageComplete(outPath, m_targetVersion);
+}
+
+// ─── Format-specific extractors ─────────────────────────────────────────────
+
+bool FirmwareStager::extractFromInnoSetup(const QByteArray& data, const QString& outPath)
+{
+    // v4.1.x and earlier: InnoSetup self-extracting .exe with two .ssdr blobs
+    // stored as OpenSSL-encrypted "Salted__"-prefixed payloads, separated by an
+    // InnoSetup LZMA block marker. Boundaries are deduced by scanning.
+
     const QByteArray saltSig("Salted__");
     QList<qint64> saltOffsets;
     qint64 pos = 0;
@@ -265,114 +384,185 @@ void FirmwareStager::verifyAndExtract()
         emit stageFailed(QString("Expected 2 firmware files in installer, found %1.\n"
             "The installer format may have changed.")
             .arg(saltOffsets.size()));
-        return;
+        return false;
     }
 
     emit stageProgress(75, QString("Found %1 firmware files.").arg(saltOffsets.size()));
 
-    // Determine file boundaries
-    // File 1 (6x00): offset[0] to offset[1]
-    // File 2 (9600): offset[1] to next InnoSetup LZMA header
     const qint64 off1 = saltOffsets[0];
     const qint64 off2 = saltOffsets[1];
     const qint64 size1 = off2 - off1;
 
-    // Find end of file 2: search for InnoSetup LZMA block header after off2
+    // Find end of file 2: next InnoSetup LZMA block header at least 50 MB out.
     const QByteArray zlbSig("\x7a\x6c\x62\x1a\x5d\x00\x00\x80", 8);
     qint64 size2 = -1;
-    pos = off2 + 1024;  // skip past the Salted__ header
+    pos = off2 + 1024;
     while (true) {
         qint64 idx = data.indexOf(zlbSig, pos);
         if (idx < 0) break;
-        qint64 candidate = idx - off2;
-        // The .ssdr file should be > 50MB
+        const qint64 candidate = idx - off2;
         if (candidate > 50 * 1024 * 1024) {
             size2 = candidate;
             break;
         }
         pos = idx + 1;
     }
-
     if (size2 < 0) {
-        // Fallback: use everything from off2 to EOF minus a reasonable trailer
         size2 = data.size() - off2;
-        qCWarning(lcFirmware) << "FirmwareStager: could not find LZMA boundary, using" << size2 << "bytes";
+        qCWarning(lcFirmware) << "FirmwareStager: could not find LZMA boundary, using"
+                              << size2 << "bytes";
     }
 
-    emit stageProgress(80, "Extracting firmware files...");
+    // File 1 is FLEX-6x00 (consumer multi-platform), File 2 is FLEX-9600.
+    const qint64 offset = (m_modelFamily == "9600") ? off2  : off1;
+    const qint64 size   = (m_modelFamily == "9600") ? size2 : size1;
 
-    // Determine which file we need
-    struct FwFile {
-        QString name;
-        qint64 offset;
-        qint64 size;
-    };
-    QList<FwFile> files = {
-        {"FLEX-6x00_v" + m_targetVersion + ".ssdr", off1, size1},
-        {"FLEX-9600_v" + m_targetVersion + ".ssdr", off2, size2},
-    };
+    emit stageProgress(85, QString("Extracting %1 MB...").arg(size / (1024*1024)));
 
-    // Find the one matching our model family
-    int targetIdx = -1;
-    for (int i = 0; i < files.size(); ++i) {
-        if (files[i].name.contains(m_modelFamily)) {
-            targetIdx = i;
-            break;
-        }
-    }
-    if (targetIdx < 0) {
-        emit stageFailed("Cannot find firmware for model family: " + m_modelFamily);
-        return;
-    }
-
-    const auto& target = files[targetIdx];
-    emit stageProgress(85, QString("Extracting %1 (%2 MB)...")
-                           .arg(target.name)
-                           .arg(target.size / (1024*1024)));
-
-    // Extract to staging directory
-    const QString outPath = stagingDir() + "/" + target.name;
     QFile out(outPath);
     if (!out.open(QIODevice::WriteOnly)) {
         emit stageFailed("Cannot write firmware file: " + out.errorString());
-        return;
+        return false;
     }
-    out.write(data.constData() + target.offset, target.size);
+    out.write(data.constData() + offset, size);
     out.close();
+    return true;
+}
 
-    // Validate: first 8 bytes must be "Salted__"
-    emit stageProgress(92, "Validating extracted firmware...");
-    QFile check(outPath);
-    if (!check.open(QIODevice::ReadOnly)) {
-        emit stageFailed("Cannot read extracted firmware for validation.");
-        return;
+bool FirmwareStager::extractFromMsi(const QString& msiPath, const QString& outPath)
+{
+    // v4.2+: WiX MSI (OLE Compound File) with the .ssdr files stored as
+    // LZX-compressed CAB streams (cab1.cab, cab2.cab, ...). Each cab contains
+    // exactly one payload file, hashed-named, that decompresses to a raw
+    // Salted__-prefixed .ssdr blob.
+    //
+    // Strategy: shell out to 7-Zip to do the OLE+LZX heavy lifting, scan the
+    // decompressed payloads for the Salted__ magic, sort by size, and pick the
+    // matching firmware family (consumer 6x00 is several hundred MB; the 9600
+    // government build is much smaller).
+
+    const QString sevenZ = findExtractionTool();
+    if (sevenZ.isEmpty()) {
+        emit stageFailed(
+            "Firmware extraction requires 7-Zip but it could not be found.\n\n"
+            "Install 7-Zip and ensure it is on PATH:\n"
+            "  • Linux:   sudo pacman -S p7zip   (or apt/dnf equivalent)\n"
+            "  • macOS:   brew install p7zip\n"
+            "  • Windows: install from https://7-zip.org and add to PATH"
+        );
+        return false;
     }
-    const QByteArray header = check.read(8);
-    check.close();
 
-    if (header != saltSig) {
-        emit stageFailed("Extracted firmware failed validation (bad header).");
-        QFile::remove(outPath);
-        return;
+    const QString tempDir = stagingDir() + "/_msi_tmp";
+    {
+        QDir td(tempDir);
+        if (td.exists()) td.removeRecursively();
+    }
+    if (!QDir().mkpath(tempDir)) {
+        emit stageFailed("Cannot create extraction temp directory.");
+        return false;
     }
 
-    // Compute MD5 of extracted file
-    QFile hashFile(outPath);
-    hashFile.open(QIODevice::ReadOnly);
-    QCryptographicHash fwHash(QCryptographicHash::Md5);
-    fwHash.addData(&hashFile);
-    const QString fwMd5 = fwHash.result().toHex().toLower();
-    hashFile.close();
+    auto runSevenZip = [&](const QStringList& args, const QString& step) -> bool {
+        QProcess p;
+        p.setProgram(sevenZ);
+        p.setArguments(args);
+        p.start();
+        if (!p.waitForStarted(5000)) {
+            emit stageFailed(step + " failed to start: " + p.errorString());
+            return false;
+        }
+        // MSI extraction can be slow on large installers — give it 5 minutes.
+        if (!p.waitForFinished(300000)) {
+            p.kill();
+            emit stageFailed(step + " timed out.");
+            return false;
+        }
+        if (p.exitCode() != 0) {
+            const QString err = QString::fromUtf8(p.readAllStandardError()).trimmed();
+            emit stageFailed(step + " failed: " + (err.isEmpty() ? "exit code "
+                + QString::number(p.exitCode()) : err));
+            return false;
+        }
+        return true;
+    };
 
-    m_stagedPath = outPath;
-    m_stagedVersion = m_targetVersion;
+    // Extract the embedded CAB streams from the MSI's OLE Compound File.
+    emit stageProgress(75, "Extracting installer streams...");
+    if (!runSevenZip({"x", "-y", "-o" + tempDir, msiPath, "cab*.cab"},
+                     "MSI stream extraction"))
+        return false;
 
-    emit stageProgress(100, QString("Firmware staged and ready ✓\n"
-        "%1 (%2 MB)\nMD5: %3")
-        .arg(target.name)
-        .arg(target.size / (1024*1024))
-        .arg(fwMd5));
-    emit stageComplete(outPath, m_targetVersion);
+    QDir td(tempDir);
+    QStringList cabFiles = td.entryList({"cab*.cab"}, QDir::Files);
+    if (cabFiles.isEmpty()) {
+        emit stageFailed("No CAB streams found in MSI.");
+        return false;
+    }
+
+    // Each CAB has a single LZX-compressed payload; decompress all.
+    emit stageProgress(82, QString("Decompressing %1 CAB streams...").arg(cabFiles.size()));
+    for (const QString& cab : cabFiles) {
+        if (!runSevenZip({"x", "-y", "-o" + tempDir, tempDir + "/" + cab},
+                         "CAB " + cab + " decompression"))
+            return false;
+    }
+
+    // Scan the decompressed payloads for Salted__ magic.
+    emit stageProgress(88, "Locating firmware blobs...");
+    struct Blob { QString path; qint64 size; };
+    QList<Blob> blobs;
+    for (const QFileInfo& fi : td.entryInfoList(QDir::Files)) {
+        if (fi.fileName().startsWith("cab"))
+            continue;
+        QFile f(fi.absoluteFilePath());
+        if (!f.open(QIODevice::ReadOnly))
+            continue;
+        const QByteArray hdr = f.read(8);
+        f.close();
+        if (hdr == QByteArrayLiteral("Salted__"))
+            blobs.append({fi.absoluteFilePath(), fi.size()});
+    }
+
+    if (blobs.isEmpty()) {
+        emit stageFailed("No firmware blobs (Salted__ header) found in MSI cabinets.");
+        return false;
+    }
+
+    // FLEX-6x00 consumer firmware bundles every consumer platform and is
+    // significantly larger than the FLEX-9600 government build, so size order
+    // gives us the family mapping reliably.
+    std::sort(blobs.begin(), blobs.end(), [](const Blob& a, const Blob& b) {
+        return a.size > b.size;
+    });
+
+    int targetIdx = -1;
+    if (m_modelFamily == "9600") {
+        if (blobs.size() < 2) {
+            emit stageFailed("FLEX-9600 firmware not present in this installer.");
+            td.removeRecursively();
+            return false;
+        }
+        targetIdx = blobs.size() - 1;  // smallest blob
+    } else {
+        targetIdx = 0;                  // largest blob (multi-platform consumer)
+    }
+
+    const Blob& target = blobs[targetIdx];
+    emit stageProgress(90, QString("Staging firmware (%1 MB)...").arg(target.size / (1024*1024)));
+
+    if (!QFile::rename(target.path, outPath)) {
+        // Cross-device fallback (e.g. /tmp on tmpfs vs ~/.config on disk).
+        if (!QFile::copy(target.path, outPath)) {
+            emit stageFailed("Failed to stage firmware file from temp dir.");
+            td.removeRecursively();
+            return false;
+        }
+        QFile::remove(target.path);
+    }
+
+    td.removeRecursively();
+    return true;
 }
 
 } // namespace AetherSDR

--- a/src/core/FirmwareStager.cpp
+++ b/src/core/FirmwareStager.cpp
@@ -1,12 +1,13 @@
 #include "FirmwareStager.h"
+#include "CabExtractor.h"
 #include "LogManager.h"
+#include "OleCompoundFile.h"
 
 #include <QCryptographicHash>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QNetworkRequest>
-#include <QProcess>
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QUrl>
@@ -51,36 +52,6 @@ bool FirmwareStager::versionUsesMsi(const QString& version)
     const int minor = parts[1].toInt(&ok2);
     if (!ok1 || !ok2) return false;
     return (major > 4) || (major == 4 && minor >= 2);
-}
-
-QString FirmwareStager::findExtractionTool()
-{
-    // 7z handles both MSI (OLE Compound File) and the LZX-compressed CABs
-    // inside, so we use it as a single tool. Try the common binary names.
-    static const QStringList candidates = {
-        "7z", "7zz", "7za",
-        "/usr/local/bin/7z",       // macOS Intel Homebrew
-        "/opt/homebrew/bin/7z",    // macOS Apple Silicon Homebrew
-        "/opt/homebrew/bin/7zz",
-    };
-    for (const QString& cand : candidates) {
-        // Absolute paths: check existence directly.
-        if (cand.startsWith('/')) {
-            if (QFileInfo::exists(cand) && QFileInfo(cand).isExecutable())
-                return cand;
-            continue;
-        }
-        // Otherwise probe via QProcess (catches PATH lookups portably).
-        QProcess p;
-        p.setProgram(cand);
-        p.setArguments({"--help"});
-        p.start();
-        if (p.waitForStarted(2000)) {
-            p.waitForFinished(3000);
-            return cand;
-        }
-    }
-    return QString();
 }
 
 // ─── Step 1: Check for update ────────────────────────────────────────────────
@@ -508,137 +479,104 @@ bool FirmwareStager::extractFromInnoSetup(const QByteArray& data, const QString&
 
 bool FirmwareStager::extractFromMsi(const QString& msiPath, const QString& outPath)
 {
-    // v4.2+: WiX MSI (OLE Compound File) with the .ssdr files stored as
-    // LZX-compressed CAB streams (cab1.cab, cab2.cab, ...). Each cab contains
-    // exactly one payload file, hashed-named, that decompresses to a raw
-    // Salted__-prefixed .ssdr blob.
+    // v4.2+: WiX MSI (OLE Compound File) with `.ssdr` blobs hidden inside
+    // LZX-compressed CAB streams (cab1.cab, cab2.cab, ...). Native pipeline:
     //
-    // Strategy: shell out to 7-Zip to do the OLE+LZX heavy lifting, scan the
-    // decompressed payloads for the Salted__ magic, sort by size, and pick the
-    // matching firmware family (consumer 6x00 is several hundred MB; the 9600
-    // government build is much smaller).
+    //   OleCompoundFile → all cab*.cab streams (in memory)
+    //   CabExtractor (libmspack) → all files inside each cab (in memory)
+    //   Filter for Salted__ magic → list of firmware blobs
+    //   Sort by size desc, pick by family, write to outPath
+    //
+    // No external tools, no temp files.
 
-    const QString sevenZ = findExtractionTool();
-    if (sevenZ.isEmpty()) {
-        emit stageFailed(
-            "Firmware extraction requires 7-Zip but it could not be found.\n\n"
-            "Install 7-Zip and ensure it is on PATH:\n"
-            "  • Linux:   sudo pacman -S p7zip   (or apt/dnf equivalent)\n"
-            "  • macOS:   brew install p7zip\n"
-            "  • Windows: install from https://7-zip.org and add to PATH"
-        );
+    OleCompoundFile cfb;
+    if (!cfb.open(msiPath)) {
+        emit stageFailed("Could not open MSI: " + cfb.lastError());
         return false;
     }
 
-    const QString tempDir = stagingDir() + "/_msi_tmp";
-    {
-        QDir td(tempDir);
-        if (td.exists()) td.removeRecursively();
-    }
-    if (!QDir().mkpath(tempDir)) {
-        emit stageFailed("Cannot create extraction temp directory.");
-        return false;
-    }
-
-    auto runSevenZip = [&](const QStringList& args, const QString& step) -> bool {
-        QProcess p;
-        p.setProgram(sevenZ);
-        p.setArguments(args);
-        p.start();
-        if (!p.waitForStarted(5000)) {
-            emit stageFailed(step + " failed to start: " + p.errorString());
-            return false;
-        }
-        // MSI extraction can be slow on large installers — give it 5 minutes.
-        if (!p.waitForFinished(300000)) {
-            p.kill();
-            emit stageFailed(step + " timed out.");
-            return false;
-        }
-        if (p.exitCode() != 0) {
-            const QString err = QString::fromUtf8(p.readAllStandardError()).trimmed();
-            emit stageFailed(step + " failed: " + (err.isEmpty() ? "exit code "
-                + QString::number(p.exitCode()) : err));
-            return false;
-        }
-        return true;
-    };
-
-    // Extract the embedded CAB streams from the MSI's OLE Compound File.
-    emit stageProgress(75, "Extracting installer streams...");
-    if (!runSevenZip({"x", "-y", "-o" + tempDir, msiPath, "cab*.cab"},
-                     "MSI stream extraction"))
-        return false;
-
-    QDir td(tempDir);
-    QStringList cabFiles = td.entryList({"cab*.cab"}, QDir::Files);
-    if (cabFiles.isEmpty()) {
+    emit stageProgress(72, "Reading installer streams...");
+    const auto cabStreams = cfb.readMsiStreamsByPrefixSuffix("cab", ".cab");
+    if (cabStreams.isEmpty()) {
         emit stageFailed("No CAB streams found in MSI.");
         return false;
     }
 
-    // Each CAB has a single LZX-compressed payload; decompress all.
-    emit stageProgress(82, QString("Decompressing %1 CAB streams...").arg(cabFiles.size()));
-    for (const QString& cab : cabFiles) {
-        if (!runSevenZip({"x", "-y", "-o" + tempDir, tempDir + "/" + cab},
-                         "CAB " + cab + " decompression"))
-            return false;
-    }
+    emit stageProgress(78,
+        QString("Decompressing %1 CAB streams...").arg(cabStreams.size()));
 
-    // Scan the decompressed payloads for Salted__ magic.
-    emit stageProgress(88, "Locating firmware blobs...");
-    struct Blob { QString path; qint64 size; };
+    struct Blob {
+        QString cabName;
+        QByteArray data;
+    };
     QList<Blob> blobs;
-    for (const QFileInfo& fi : td.entryInfoList(QDir::Files)) {
-        if (fi.fileName().startsWith("cab"))
+
+    CabExtractor cx;
+    int progressBase = 78;
+    int progressSpan = 12;  // 78..90
+    int idx = 0;
+    for (const auto& [cabName, cabBytes] : cabStreams) {
+        QByteArray ssdr;
+        if (!cx.extractFirstMatchingMagic(cabBytes,
+                                          QByteArrayLiteral("Salted__"),
+                                          ssdr)) {
+            // No firmware in this cab — that's expected for cabs that
+            // hold drivers/installer support files. Move on.
+            ++idx;
+            const int pct = progressBase + (progressSpan * idx) / cabStreams.size();
+            emit stageProgress(pct,
+                QString("Scanning %1 (no firmware)...").arg(cabName));
             continue;
-        QFile f(fi.absoluteFilePath());
-        if (!f.open(QIODevice::ReadOnly))
-            continue;
-        const QByteArray hdr = f.read(8);
-        f.close();
-        if (hdr == QByteArrayLiteral("Salted__"))
-            blobs.append({fi.absoluteFilePath(), fi.size()});
+        }
+        blobs.append({cabName, std::move(ssdr)});
+        ++idx;
+        const int pct = progressBase + (progressSpan * idx) / cabStreams.size();
+        emit stageProgress(pct,
+            QString("Found firmware in %1 (%2 MB)...")
+                .arg(cabName).arg(blobs.last().data.size() / (1024*1024)));
     }
 
     if (blobs.isEmpty()) {
-        emit stageFailed("No firmware blobs (Salted__ header) found in MSI cabinets.");
+        emit stageFailed(
+            "No firmware blobs (Salted__ header) found in any MSI cabinet.");
         return false;
     }
 
     // FLEX-6x00 consumer firmware bundles every consumer platform and is
-    // significantly larger than the FLEX-9600 government build, so size order
-    // gives us the family mapping reliably.
-    std::sort(blobs.begin(), blobs.end(), [](const Blob& a, const Blob& b) {
-        return a.size > b.size;
-    });
+    // significantly larger than the FLEX-9600 government build, so size
+    // order gives us the family mapping reliably.
+    std::sort(blobs.begin(), blobs.end(),
+              [](const Blob& a, const Blob& b) {
+                  return a.data.size() > b.data.size();
+              });
 
-    int targetIdx = -1;
+    const Blob* target = nullptr;
     if (m_modelFamily == "9600") {
         if (blobs.size() < 2) {
             emit stageFailed("FLEX-9600 firmware not present in this installer.");
-            td.removeRecursively();
             return false;
         }
-        targetIdx = blobs.size() - 1;  // smallest blob
+        target = &blobs.last();   // smallest = government 9600 build
     } else {
-        targetIdx = 0;                  // largest blob (multi-platform consumer)
+        target = &blobs.first();  // largest = multi-platform consumer
     }
 
-    const Blob& target = blobs[targetIdx];
-    emit stageProgress(90, QString("Staging firmware (%1 MB)...").arg(target.size / (1024*1024)));
+    emit stageProgress(92,
+        QString("Staging firmware (%1 MB)...").arg(target->data.size() / (1024*1024)));
 
-    if (!QFile::rename(target.path, outPath)) {
-        // Cross-device fallback (e.g. /tmp on tmpfs vs ~/.config on disk).
-        if (!QFile::copy(target.path, outPath)) {
-            emit stageFailed("Failed to stage firmware file from temp dir.");
-            td.removeRecursively();
-            return false;
-        }
-        QFile::remove(target.path);
+    QFile out(outPath);
+    if (!out.open(QIODevice::WriteOnly)) {
+        emit stageFailed("Cannot write firmware file: " + out.errorString());
+        return false;
     }
-
-    td.removeRecursively();
+    const qint64 written = out.write(target->data);
+    out.close();
+    if (written != target->data.size()) {
+        emit stageFailed(
+            QString("Short write: %1 of %2 bytes").arg(written).arg(target->data.size()));
+        QFile::remove(outPath);
+        return false;
+    }
     return true;
 }
 

--- a/src/core/FirmwareStager.h
+++ b/src/core/FirmwareStager.h
@@ -70,10 +70,6 @@ private:
     // of the older InnoSetup .exe.
     static bool versionUsesMsi(const QString& version);
 
-    // Locate a 7z-compatible CLI (7z / 7zz / 7za) in PATH and common Homebrew
-    // locations. Returns empty string if none found.
-    static QString findExtractionTool();
-
     QNetworkAccessManager m_nam;
     QNetworkReply*  m_downloadReply{nullptr};
     QString         m_installerPath;

--- a/src/core/FirmwareStager.h
+++ b/src/core/FirmwareStager.h
@@ -55,6 +55,19 @@ private:
     void onInstallerDownloadFinished();
     void verifyAndExtract();
 
+    // Format-specific extractors. Both produce a .ssdr file at outPath and
+    // emit progress/failed signals on the way.
+    bool extractFromInnoSetup(const QByteArray& data, const QString& outPath);
+    bool extractFromMsi(const QString& msiPath, const QString& outPath);
+
+    // Returns true if the version uses the WiX MSI installer (v4.2+) instead
+    // of the older InnoSetup .exe.
+    static bool versionUsesMsi(const QString& version);
+
+    // Locate a 7z-compatible CLI (7z / 7zz / 7za) in PATH and common Homebrew
+    // locations. Returns empty string if none found.
+    static QString findExtractionTool();
+
     QNetworkAccessManager m_nam;
     QNetworkReply*  m_downloadReply{nullptr};
     QString         m_installerPath;
@@ -65,8 +78,12 @@ private:
     QString         m_stagedVersion;
     bool            m_cancelled{false};
 
-    static constexpr const char* INSTALLER_URL_FMT =
+    // v4.1.x and earlier: InnoSetup self-extracting .exe.
+    // v4.2+: WiX 6 MSI (OLE Compound File with embedded LZX-compressed CABs).
+    static constexpr const char* INSTALLER_URL_FMT_EXE =
         "https://smartsdr.flexradio.com/SmartSDR_v%1_Installer.exe";
+    static constexpr const char* INSTALLER_URL_FMT_MSI =
+        "https://smartsdr.flexradio.com/SmartSDR_v%1_x64.msi";
     static constexpr const char* MD5_URL_FMT =
         "https://edge.flexradio.com/www/offload/20251215133656/"
         "SmartSDR-v%1-Installer-MD5-Hash-File.txt";

--- a/src/core/FirmwareStager.h
+++ b/src/core/FirmwareStager.h
@@ -26,6 +26,12 @@ public:
     // modelFamily: "6x00" or "9600"
     void downloadAndStage(const QString& version, const QString& modelFamily);
 
+    // Stage firmware from an installer file the user has already downloaded.
+    // Accepts .msi (v4.2+), .exe (v4.1.x and earlier), or .ssdr (no extraction
+    // needed; passed straight through to staging). Version is parsed from the
+    // filename when present, otherwise stays empty until the radio confirms.
+    void stageFromLocalFile(const QString& installerPath, const QString& modelFamily);
+
     // Cancel in-progress download
     void cancel();
 

--- a/src/core/FirmwareUploader.cpp
+++ b/src/core/FirmwareUploader.cpp
@@ -3,6 +3,7 @@
 #include "../models/RadioModel.h"
 #include "../core/RadioConnection.h"
 
+#include <QCryptographicHash>
 #include <QFile>
 #include <QFileInfo>
 #include <QHostAddress>
@@ -16,6 +17,17 @@ FirmwareUploader::FirmwareUploader(RadioModel* model, QObject* parent)
     connect(&m_socket, &QTcpSocket::connected, this, &FirmwareUploader::onConnected);
     connect(&m_socket, &QTcpSocket::bytesWritten, this, &FirmwareUploader::onBytesWritten);
     connect(&m_socket, &QTcpSocket::errorOccurred, this, [this] { onError(); });
+
+    // State transitions are critical breadcrumbs if the upload misbehaves —
+    // capture them at info level so they're visible without the firmware
+    // category having to be at debug level.
+    connect(&m_socket, &QTcpSocket::stateChanged, this,
+            [](QAbstractSocket::SocketState s) {
+        qCInfo(lcFirmware) << "FirmwareUploader: socket state ->" << s;
+    });
+    connect(&m_socket, &QTcpSocket::disconnected, this, []() {
+        qCInfo(lcFirmware) << "FirmwareUploader: socket disconnected";
+    });
 }
 
 void FirmwareUploader::upload(const QString& filePath)
@@ -52,17 +64,43 @@ void FirmwareUploader::upload(const QString& filePath)
     m_uploading = true;
     m_cancelled = false;
 
+    // Pre-flight diagnostic dump — captures everything we'd want to know
+    // post-mortem if the flash misbehaves. This is the kind of state that's
+    // trivially knowable now and impossible to reconstruct after the fact.
+    QCryptographicHash hash(QCryptographicHash::Md5);
+    hash.addData(m_fileData);
+    const QString fileMd5 = hash.result().toHex().toLower();
+    const QByteArray header = m_fileData.left(8);
+
+    qCInfo(lcFirmware) << "FirmwareUploader: ===== PRE-UPLOAD DIAGNOSTIC =====";
+    qCInfo(lcFirmware) << "FirmwareUploader: file       =" << filePath;
+    qCInfo(lcFirmware) << "FirmwareUploader: filename   =" << m_fileName;
+    qCInfo(lcFirmware) << "FirmwareUploader: size       =" << m_fileData.size()
+                        << "bytes (" << (m_fileData.size() / (1024.0*1024.0)) << "MB)";
+    qCInfo(lcFirmware) << "FirmwareUploader: md5        =" << fileMd5;
+    qCInfo(lcFirmware) << "FirmwareUploader: header(8B) =" << header.toHex();
+    qCInfo(lcFirmware) << "FirmwareUploader: header str =" << QString::fromLatin1(header);
+    qCInfo(lcFirmware) << "FirmwareUploader: radio      =" << m_model->model()
+                        << "serial" << m_model->serial();
+    qCInfo(lcFirmware) << "FirmwareUploader: radio addr =" << m_model->radioAddress();
+    qCInfo(lcFirmware) << "FirmwareUploader: cur fw     =" << m_model->softwareVersion();
+    qCInfo(lcFirmware) << "FirmwareUploader: ================================";
+
     emit progressChanged(0, "Preparing upload...");
 
     // Step 1: Send filename to radio
+    qCInfo(lcFirmware) << "FirmwareUploader: TX 'file filename" << m_fileName << "'";
     m_model->sendCommand("file filename " + m_fileName);
 
     // Step 2: Request upload — radio responds with port number
     emit progressChanged(0, "Requesting upload port...");
 
-    m_model->sendCmdPublic(
-        QString("file upload %1 update").arg(m_fileData.size()),
+    const QString uploadCmd = QString("file upload %1 update").arg(m_fileData.size());
+    qCInfo(lcFirmware) << "FirmwareUploader: TX '" << uploadCmd << "'";
+    m_model->sendCmdPublic(uploadCmd,
         [this](int code, const QString& body) {
+            qCInfo(lcFirmware) << "FirmwareUploader: RX upload response code=0x"
+                << QString::number(code, 16) << "body='" << body << "'";
             onUploadPortReceived(code, body);
         });
 }
@@ -171,10 +209,15 @@ void FirmwareUploader::onError()
 {
     if (m_cancelled) return;
 
+    qCWarning(lcFirmware) << "FirmwareUploader: SOCKET ERROR err="
+        << m_socket.error() << "msg='" << m_socket.errorString() << "'"
+        << "bytesSent=" << m_bytesSent << "/" << m_fileData.size()
+        << "port=" << m_uploadPort;
+
     // If we haven't sent anything and this is the first port attempt, try fallback
     if (m_bytesSent == 0 && m_uploadPort != FALLBACK_PORT) {
         m_uploadPort = FALLBACK_PORT;
-        qCDebug(lcFirmware) << "FirmwareUploader: error on primary port, trying" << FALLBACK_PORT;
+        qCInfo(lcFirmware) << "FirmwareUploader: error on primary port, trying" << FALLBACK_PORT;
         emit progressChanged(0, QString("Retrying on port %1...").arg(FALLBACK_PORT));
         m_socket.abort();
         m_socket.connectToHost(m_model->radioAddress(), m_uploadPort);

--- a/src/core/FirmwareUploader.cpp
+++ b/src/core/FirmwareUploader.cpp
@@ -3,7 +3,6 @@
 #include "../models/RadioModel.h"
 #include "../core/RadioConnection.h"
 
-#include <QCryptographicHash>
 #include <QFile>
 #include <QFileInfo>
 #include <QHostAddress>
@@ -17,17 +16,6 @@ FirmwareUploader::FirmwareUploader(RadioModel* model, QObject* parent)
     connect(&m_socket, &QTcpSocket::connected, this, &FirmwareUploader::onConnected);
     connect(&m_socket, &QTcpSocket::bytesWritten, this, &FirmwareUploader::onBytesWritten);
     connect(&m_socket, &QTcpSocket::errorOccurred, this, [this] { onError(); });
-
-    // State transitions are critical breadcrumbs if the upload misbehaves —
-    // capture them at info level so they're visible without the firmware
-    // category having to be at debug level.
-    connect(&m_socket, &QTcpSocket::stateChanged, this,
-            [](QAbstractSocket::SocketState s) {
-        qCInfo(lcFirmware) << "FirmwareUploader: socket state ->" << s;
-    });
-    connect(&m_socket, &QTcpSocket::disconnected, this, []() {
-        qCInfo(lcFirmware) << "FirmwareUploader: socket disconnected";
-    });
 }
 
 void FirmwareUploader::upload(const QString& filePath)
@@ -64,43 +52,17 @@ void FirmwareUploader::upload(const QString& filePath)
     m_uploading = true;
     m_cancelled = false;
 
-    // Pre-flight diagnostic dump — captures everything we'd want to know
-    // post-mortem if the flash misbehaves. This is the kind of state that's
-    // trivially knowable now and impossible to reconstruct after the fact.
-    QCryptographicHash hash(QCryptographicHash::Md5);
-    hash.addData(m_fileData);
-    const QString fileMd5 = hash.result().toHex().toLower();
-    const QByteArray header = m_fileData.left(8);
-
-    qCInfo(lcFirmware) << "FirmwareUploader: ===== PRE-UPLOAD DIAGNOSTIC =====";
-    qCInfo(lcFirmware) << "FirmwareUploader: file       =" << filePath;
-    qCInfo(lcFirmware) << "FirmwareUploader: filename   =" << m_fileName;
-    qCInfo(lcFirmware) << "FirmwareUploader: size       =" << m_fileData.size()
-                        << "bytes (" << (m_fileData.size() / (1024.0*1024.0)) << "MB)";
-    qCInfo(lcFirmware) << "FirmwareUploader: md5        =" << fileMd5;
-    qCInfo(lcFirmware) << "FirmwareUploader: header(8B) =" << header.toHex();
-    qCInfo(lcFirmware) << "FirmwareUploader: header str =" << QString::fromLatin1(header);
-    qCInfo(lcFirmware) << "FirmwareUploader: radio      =" << m_model->model()
-                        << "serial" << m_model->serial();
-    qCInfo(lcFirmware) << "FirmwareUploader: radio addr =" << m_model->radioAddress();
-    qCInfo(lcFirmware) << "FirmwareUploader: cur fw     =" << m_model->softwareVersion();
-    qCInfo(lcFirmware) << "FirmwareUploader: ================================";
-
     emit progressChanged(0, "Preparing upload...");
 
     // Step 1: Send filename to radio
-    qCInfo(lcFirmware) << "FirmwareUploader: TX 'file filename" << m_fileName << "'";
     m_model->sendCommand("file filename " + m_fileName);
 
     // Step 2: Request upload — radio responds with port number
     emit progressChanged(0, "Requesting upload port...");
 
-    const QString uploadCmd = QString("file upload %1 update").arg(m_fileData.size());
-    qCInfo(lcFirmware) << "FirmwareUploader: TX '" << uploadCmd << "'";
-    m_model->sendCmdPublic(uploadCmd,
+    m_model->sendCmdPublic(
+        QString("file upload %1 update").arg(m_fileData.size()),
         [this](int code, const QString& body) {
-            qCInfo(lcFirmware) << "FirmwareUploader: RX upload response code=0x"
-                << QString::number(code, 16) << "body='" << body << "'";
             onUploadPortReceived(code, body);
         });
 }
@@ -209,15 +171,10 @@ void FirmwareUploader::onError()
 {
     if (m_cancelled) return;
 
-    qCWarning(lcFirmware) << "FirmwareUploader: SOCKET ERROR err="
-        << m_socket.error() << "msg='" << m_socket.errorString() << "'"
-        << "bytesSent=" << m_bytesSent << "/" << m_fileData.size()
-        << "port=" << m_uploadPort;
-
     // If we haven't sent anything and this is the first port attempt, try fallback
     if (m_bytesSent == 0 && m_uploadPort != FALLBACK_PORT) {
         m_uploadPort = FALLBACK_PORT;
-        qCInfo(lcFirmware) << "FirmwareUploader: error on primary port, trying" << FALLBACK_PORT;
+        qCDebug(lcFirmware) << "FirmwareUploader: error on primary port, trying" << FALLBACK_PORT;
         emit progressChanged(0, QString("Retrying on port %1...").arg(FALLBACK_PORT));
         m_socket.abort();
         m_socket.connectToHost(m_model->radioAddress(), m_uploadPort);

--- a/src/core/OleCompoundFile.cpp
+++ b/src/core/OleCompoundFile.cpp
@@ -1,0 +1,399 @@
+#include "OleCompoundFile.h"
+#include "LogManager.h"
+
+#include <QtEndian>
+
+namespace AetherSDR {
+
+namespace {
+
+// CFB magic at offset 0. [MS-CFB] §2.2.
+constexpr quint8 kCfbMagic[8] = {0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1};
+
+// Read a little-endian integer from a byte buffer at a given offset.
+template <typename T>
+T readLE(const QByteArray& buf, qsizetype offset) {
+    T value{};
+    if (offset + static_cast<qsizetype>(sizeof(T)) > buf.size())
+        return value;
+    std::memcpy(&value, buf.constData() + offset, sizeof(T));
+    return qFromLittleEndian(value);
+}
+
+// Decode a UTF-16LE directory-entry name field.  The 64-byte name area
+// is followed by a 2-byte "name length in bytes including the trailing
+// NUL" field.  Returns the name without the NUL.
+QString decodeDirName(const QByteArray& entry) {
+    quint16 nameLenBytes = readLE<quint16>(entry, 64);
+    if (nameLenBytes < 2 || nameLenBytes > 64)
+        return QString();
+    // nameLenBytes counts the trailing UTF-16 NUL (2 bytes), so subtract.
+    const int u16len = (nameLenBytes - 2) / 2;
+    QString out;
+    out.reserve(u16len);
+    for (int i = 0; i < u16len; ++i) {
+        const quint16 ch = readLE<quint16>(entry, i * 2);
+        out.append(QChar(ch));
+    }
+    return out;
+}
+
+} // anonymous namespace
+
+bool OleCompoundFile::open(const QString& path)
+{
+    m_file.setFileName(path);
+    if (!m_file.open(QIODevice::ReadOnly)) {
+        m_lastError = "open failed: " + m_file.errorString();
+        return false;
+    }
+    if (!readHeader())     return false;
+    if (!readDifat())      return false;
+    if (!readFat())        return false;
+    if (!readMiniFat())    return false;
+    if (!readDirectory())  return false;
+    if (!readMiniStream()) return false;
+    return true;
+}
+
+bool OleCompoundFile::readHeader()
+{
+    m_file.seek(0);
+    const QByteArray hdr = m_file.read(512);
+    if (hdr.size() != 512) {
+        m_lastError = "header truncated";
+        return false;
+    }
+    if (std::memcmp(hdr.constData(), kCfbMagic, 8) != 0) {
+        m_lastError = "not a CFB file (magic mismatch)";
+        return false;
+    }
+    const quint16 majorVersion = readLE<quint16>(hdr, 26);
+    if (majorVersion != 3 && majorVersion != 4) {
+        m_lastError = QString("unsupported CFB major version %1").arg(majorVersion);
+        return false;
+    }
+    m_header.sectorShift          = readLE<quint16>(hdr, 30);
+    m_header.miniSectorShift      = readLE<quint16>(hdr, 32);
+    m_header.numDirectorySectors  = readLE<quint32>(hdr, 40);
+    m_header.numFatSectors        = readLE<quint32>(hdr, 44);
+    m_header.firstDirSector       = readLE<quint32>(hdr, 48);
+    m_header.miniStreamCutoff     = readLE<quint32>(hdr, 56);
+    m_header.firstMiniFatSector   = readLE<quint32>(hdr, 60);
+    m_header.numMiniFatSectors    = readLE<quint32>(hdr, 64);
+    m_header.firstDifatSector     = readLE<quint32>(hdr, 68);
+    m_header.numDifatSectors      = readLE<quint32>(hdr, 72);
+
+    // Sanity bounds — guard against corrupt/malicious headers before
+    // we use these values to size other allocations.
+    if (m_header.sectorShift < 7 || m_header.sectorShift > 16) {
+        m_lastError = QString("implausible sector shift %1").arg(m_header.sectorShift);
+        return false;
+    }
+    if (m_header.numFatSectors > 1u << 24) {
+        m_lastError = "implausible FAT-sector count";
+        return false;
+    }
+
+    // Inline DIFAT: header bytes 76..511, 109 entries of 4 bytes each.
+    m_difat.reserve(static_cast<int>(m_header.numFatSectors));
+    for (int i = 0; i < 109; ++i) {
+        const quint32 fatSector = readLE<quint32>(hdr, 76 + i * 4);
+        if (fatSector == kFatFreeSector) break;
+        m_difat.append(fatSector);
+    }
+    return true;
+}
+
+bool OleCompoundFile::readDifat()
+{
+    // If everything fit in the 109 inline slots, we're done.
+    if (m_header.numDifatSectors == 0)
+        return true;
+
+    quint32 nextDifat = m_header.firstDifatSector;
+    quint32 difatHops = 0;
+    const quint32 entriesPerSector = (sectorSize() / 4) - 1;  // last slot = next pointer
+
+    while (nextDifat != kFatEndOfChain && nextDifat != kFatFreeSector) {
+        if (++difatHops > m_header.numDifatSectors + 4) {
+            m_lastError = "DIFAT chain longer than declared";
+            return false;
+        }
+        const QByteArray sec = readSector(nextDifat);
+        if (sec.size() != static_cast<int>(sectorSize())) {
+            m_lastError = "DIFAT sector read failure";
+            return false;
+        }
+        for (quint32 i = 0; i < entriesPerSector; ++i) {
+            const quint32 fatSector = readLE<quint32>(sec, i * 4);
+            if (fatSector == kFatFreeSector) continue;
+            m_difat.append(fatSector);
+        }
+        // Last 4 bytes of the DIFAT sector point to the next DIFAT sector.
+        nextDifat = readLE<quint32>(sec, sectorSize() - 4);
+    }
+    return true;
+}
+
+bool OleCompoundFile::readFat()
+{
+    const quint32 entriesPerSector = sectorSize() / 4;
+    m_fat.reserve(m_difat.size() * static_cast<int>(entriesPerSector));
+    for (quint32 fatSector : m_difat) {
+        const QByteArray sec = readSector(fatSector);
+        if (sec.size() != static_cast<int>(sectorSize())) {
+            m_lastError = "FAT sector read failure";
+            return false;
+        }
+        for (quint32 i = 0; i < entriesPerSector; ++i)
+            m_fat.append(readLE<quint32>(sec, i * 4));
+    }
+    return true;
+}
+
+bool OleCompoundFile::readMiniFat()
+{
+    if (m_header.numMiniFatSectors == 0)
+        return true;
+    quint32 sector = m_header.firstMiniFatSector;
+    const quint32 entriesPerSector = sectorSize() / 4;
+    quint32 hops = 0;
+    while (sector != kFatEndOfChain && sector != kFatFreeSector) {
+        if (++hops > m_header.numMiniFatSectors + 4) {
+            m_lastError = "mini-FAT chain longer than declared";
+            return false;
+        }
+        const QByteArray sec = readSector(sector);
+        if (sec.size() != static_cast<int>(sectorSize()))
+            return false;
+        for (quint32 i = 0; i < entriesPerSector; ++i)
+            m_miniFat.append(readLE<quint32>(sec, i * 4));
+        if (sector >= static_cast<quint32>(m_fat.size())) {
+            m_lastError = "mini-FAT sector index out of range";
+            return false;
+        }
+        sector = m_fat.at(sector);
+    }
+    return true;
+}
+
+bool OleCompoundFile::readDirectory()
+{
+    const QByteArray dirData = readChain(m_header.firstDirSector,
+        // Directory size is technically unbounded; walk the FAT chain
+        // until end and stop. We pass 0 for "until end of chain".
+        0);
+    if (dirData.isEmpty()) {
+        m_lastError = "empty directory chain";
+        return false;
+    }
+    // Each directory entry is exactly 128 bytes per spec.
+    const int numEntries = dirData.size() / 128;
+    m_entries.reserve(numEntries);
+    for (int i = 0; i < numEntries; ++i) {
+        const QByteArray entry = dirData.mid(i * 128, 128);
+        DirEntry e;
+        e.name = decodeDirName(entry);
+        const quint8 typeRaw = static_cast<quint8>(entry.at(66));
+        e.type = static_cast<EntryType>(typeRaw);
+        e.startSector = readLE<quint32>(entry, 116);
+        // CFB v4 has a 64-bit size field (lo 4 bytes at 120, hi 4 bytes at 124).
+        // CFB v3 only uses the low 4 bytes.
+        const quint32 sizeLo = readLE<quint32>(entry, 120);
+        const quint32 sizeHi = readLE<quint32>(entry, 124);
+        e.streamSize = (static_cast<quint64>(sizeHi) << 32) | sizeLo;
+        m_entries.append(e);
+    }
+    return true;
+}
+
+bool OleCompoundFile::readMiniStream()
+{
+    // The root entry (entry 0) holds the mini stream's location.
+    if (m_entries.isEmpty() || m_entries.first().type != EntryType::RootEntry) {
+        // No root or no mini stream — fine, we just won't be able to read
+        // tiny streams (which we don't expect to need anyway).
+        return true;
+    }
+    const DirEntry& root = m_entries.first();
+    if (root.streamSize == 0)
+        return true;
+    m_miniStream = readChain(root.startSector, root.streamSize);
+    return true;
+}
+
+QStringList OleCompoundFile::streamNames() const
+{
+    QStringList out;
+    for (const auto& e : m_entries) {
+        if (e.type == EntryType::Stream)
+            out.append(e.name);
+    }
+    return out;
+}
+
+QByteArray OleCompoundFile::readStream(const QString& name) const
+{
+    for (const auto& e : m_entries) {
+        if (e.type != EntryType::Stream) continue;
+        if (e.name != name) continue;
+        if (e.streamSize < m_header.miniStreamCutoff)
+            return readMiniChain(e.startSector, e.streamSize);
+        return readChain(e.startSector, e.streamSize);
+    }
+    m_lastError = "stream not found: " + name;
+    return QByteArray();
+}
+
+QList<QPair<QString, QByteArray>> OleCompoundFile::readStreamsByPrefixSuffix(
+    const QString& prefix, const QString& suffix) const
+{
+    QList<QPair<QString, QByteArray>> out;
+    for (const auto& e : m_entries) {
+        if (e.type != EntryType::Stream) continue;
+        if (!e.name.startsWith(prefix)) continue;
+        if (!e.name.endsWith(suffix)) continue;
+        QByteArray data = (e.streamSize < m_header.miniStreamCutoff)
+            ? readMiniChain(e.startSector, e.streamSize)
+            : readChain(e.startSector, e.streamSize);
+        if (!data.isEmpty())
+            out.append({e.name, std::move(data)});
+    }
+    return out;
+}
+
+// ─── MSI-aware accessors ─────────────────────────────────────────────
+
+QString OleCompoundFile::decodeMsiName(const QString& encoded)
+{
+    // 64-entry MSI alphabet (digits, upper, lower, '.', '_').
+    static const char kTable[65] =
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._";
+
+    QString out;
+    out.reserve(encoded.size() * 2);
+    for (QChar qc : encoded) {
+        const ushort cp = qc.unicode();
+        if (cp >= 0x3800 && cp < 0x4840) {
+            const ushort v = cp - 0x3800;
+            out.append(QChar::fromLatin1(kTable[v & 0x3F]));
+            const ushort hi = (v >> 6) & 0x3F;
+            if (hi != 0)
+                out.append(QChar::fromLatin1(kTable[hi]));
+        } else if (cp == 0x4840) {
+            // MSI stream-name marker (vs. table-name) — drop silently.
+            continue;
+        } else {
+            // ASCII control chars (e.g. \005SummaryInformation) and
+            // anything outside the MSI compression range pass through.
+            out.append(qc);
+        }
+    }
+    return out;
+}
+
+QStringList OleCompoundFile::msiStreamNames() const
+{
+    QStringList out;
+    for (const auto& e : m_entries) {
+        if (e.type == EntryType::Stream)
+            out.append(decodeMsiName(e.name));
+    }
+    return out;
+}
+
+QByteArray OleCompoundFile::readMsiStream(const QString& decodedName) const
+{
+    for (const auto& e : m_entries) {
+        if (e.type != EntryType::Stream) continue;
+        if (decodeMsiName(e.name) != decodedName) continue;
+        if (e.streamSize < m_header.miniStreamCutoff)
+            return readMiniChain(e.startSector, e.streamSize);
+        return readChain(e.startSector, e.streamSize);
+    }
+    m_lastError = "MSI stream not found: " + decodedName;
+    return QByteArray();
+}
+
+QList<QPair<QString, QByteArray>> OleCompoundFile::readMsiStreamsByPrefixSuffix(
+    const QString& prefix, const QString& suffix) const
+{
+    QList<QPair<QString, QByteArray>> out;
+    for (const auto& e : m_entries) {
+        if (e.type != EntryType::Stream) continue;
+        const QString decoded = decodeMsiName(e.name);
+        if (!decoded.startsWith(prefix)) continue;
+        if (!decoded.endsWith(suffix)) continue;
+        QByteArray data = (e.streamSize < m_header.miniStreamCutoff)
+            ? readMiniChain(e.startSector, e.streamSize)
+            : readChain(e.startSector, e.streamSize);
+        if (!data.isEmpty())
+            out.append({decoded, std::move(data)});
+    }
+    return out;
+}
+
+QByteArray OleCompoundFile::readSector(quint32 sectorIndex) const
+{
+    const qint64 offset = sectorOffset(sectorIndex);
+    if (!m_file.seek(offset))
+        return QByteArray();
+    return m_file.read(sectorSize());
+}
+
+QByteArray OleCompoundFile::readChain(quint32 startSector, quint64 totalSize) const
+{
+    QByteArray out;
+    out.reserve(static_cast<int>(totalSize > 0 ? totalSize : sectorSize()));
+    quint32 sector = startSector;
+    quint32 hops = 0;
+    const quint32 maxHops = static_cast<quint32>(m_fat.size()) + 4;
+    while (sector != kFatEndOfChain && sector != kFatFreeSector) {
+        if (++hops > maxHops) {
+            m_lastError = "FAT chain loop or runaway";
+            return QByteArray();
+        }
+        if (sector >= static_cast<quint32>(m_fat.size())) {
+            m_lastError = "FAT sector index out of range";
+            return QByteArray();
+        }
+        out.append(readSector(sector));
+        sector = m_fat.at(sector);
+    }
+    if (totalSize > 0 && static_cast<quint64>(out.size()) > totalSize)
+        out.truncate(static_cast<int>(totalSize));
+    return out;
+}
+
+QByteArray OleCompoundFile::readMiniChain(quint32 startSector, quint64 totalSize) const
+{
+    QByteArray out;
+    out.reserve(static_cast<int>(totalSize));
+    quint32 sector = startSector;
+    quint32 hops = 0;
+    const quint32 maxHops = static_cast<quint32>(m_miniFat.size()) + 4;
+    const quint32 mss = miniSectorSize();
+    while (sector != kFatEndOfChain && sector != kFatFreeSector) {
+        if (++hops > maxHops) {
+            m_lastError = "mini-FAT chain loop or runaway";
+            return QByteArray();
+        }
+        if (sector >= static_cast<quint32>(m_miniFat.size())) {
+            m_lastError = "mini-FAT sector index out of range";
+            return QByteArray();
+        }
+        const qint64 offset = static_cast<qint64>(sector) * mss;
+        if (offset + mss > static_cast<qint64>(m_miniStream.size())) {
+            m_lastError = "mini-FAT offset past end of mini stream";
+            return QByteArray();
+        }
+        out.append(m_miniStream.constData() + offset, mss);
+        sector = m_miniFat.at(sector);
+    }
+    if (out.size() > static_cast<int>(totalSize))
+        out.truncate(static_cast<int>(totalSize));
+    return out;
+}
+
+} // namespace AetherSDR

--- a/src/core/OleCompoundFile.h
+++ b/src/core/OleCompoundFile.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <QByteArray>
+#include <QFile>
+#include <QList>
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+// Read-only reader for the Microsoft OLE Compound File Binary (CFB)
+// format, also known as Compound Document, Structured Storage, or
+// "the inside of a .doc/.xls/.msi". Specification: [MS-CFB].
+//
+// Scope: this implementation supports only the subset we need to
+// extract `cab*.cab` streams from FlexRadio's WiX MSI installers:
+//
+//   • Read-only; no write or modify operations.
+//   • Stream lookup by name (UTF-16LE → UTF-8 conversion).
+//   • Streams of any size (regular FAT chain).
+//   • Mini-stream (small file < 4096 bytes) read-out included for
+//     completeness but not exercised by our cab use case.
+//
+// Out of scope: storage hierarchies (we treat the directory as a
+// flat list, ignoring storage parent/child relationships), property
+// sets, transactioning, encryption.
+class OleCompoundFile {
+public:
+    OleCompoundFile() = default;
+    ~OleCompoundFile() = default;
+
+    // Open the file and parse header + FAT + directory.  Returns false
+    // on any failure (not a CFB, truncated, version mismatch, etc.).
+    bool open(const QString& path);
+
+    // Names of every stream entry in the directory.  Stream entries
+    // only — storage entries (directories) and the root entry are
+    // excluded.
+    QStringList streamNames() const;
+
+    // Read a stream by exact name match (case-sensitive). Returns
+    // empty QByteArray if not found or unreadable.
+    QByteArray readStream(const QString& name) const;
+
+    // Convenience: every stream whose name starts with `prefix` and
+    // ends with `suffix`.  Returned in directory order.  This is
+    // enough for our `cab*.cab` use case without bringing in a real
+    // wildcard matcher.
+    QList<QPair<QString, QByteArray>> readStreamsByPrefixSuffix(
+        const QString& prefix, const QString& suffix) const;
+
+    // MSI-aware variants. Microsoft Installer (.msi) files store
+    // table and stream names using a 5-bit packed encoding that lives
+    // inside Unicode code points 0x3800-0x4840. The plain accessors
+    // above return the raw encoded names; the variants below return
+    // the decoded human-readable form.
+    QStringList msiStreamNames() const;
+    QByteArray  readMsiStream(const QString& decodedName) const;
+    QList<QPair<QString, QByteArray>> readMsiStreamsByPrefixSuffix(
+        const QString& prefix, const QString& suffix) const;
+
+    // Decode a single MSI-encoded name.  Exposed publicly because it
+    // is sometimes useful to a caller that wants to interpret a name
+    // it already has (e.g. from a directory listing).
+    static QString decodeMsiName(const QString& encoded);
+
+    // Last error message, for diagnostics.
+    QString lastError() const { return m_lastError; }
+
+private:
+    struct Header {
+        quint16 sectorShift{};      // 2^N bytes per sector (typically 9 or 12)
+        quint16 miniSectorShift{};  // 2^N bytes per mini-sector (typically 6)
+        quint32 numDirectorySectors{};
+        quint32 numFatSectors{};
+        quint32 firstDirSector{};
+        quint32 firstMiniFatSector{};
+        quint32 numMiniFatSectors{};
+        quint32 firstDifatSector{};
+        quint32 numDifatSectors{};
+        quint32 miniStreamCutoff{};
+    };
+
+    // Directory entry types (offset 66 in each 128-byte entry).
+    enum class EntryType : quint8 {
+        Unknown    = 0,
+        Storage    = 1,
+        Stream     = 2,
+        RootEntry  = 5,
+    };
+
+    struct DirEntry {
+        QString    name;            // UTF-8 form of the UTF-16LE name
+        EntryType  type{EntryType::Unknown};
+        quint32    startSector{};   // First sector of the data chain
+        quint64    streamSize{};    // 64-bit on CFB v4; 32-bit on v3
+    };
+
+    // FAT chain terminator constants (per [MS-CFB]).
+    static constexpr quint32 kFatEndOfChain = 0xFFFFFFFE;
+    static constexpr quint32 kFatFreeSector = 0xFFFFFFFF;
+    static constexpr quint32 kFatFatSector  = 0xFFFFFFFD;
+    static constexpr quint32 kFatDifSector  = 0xFFFFFFFC;
+
+    bool readHeader();
+    bool readDifat();          // Assemble full FAT-sector index list
+    bool readFat();            // Read every FAT sector into m_fat
+    bool readMiniFat();        // Read mini-FAT sectors into m_miniFat
+    bool readDirectory();      // Walk directory chain; populate m_entries
+    bool readMiniStream();     // Cache the root entry's mini stream
+
+    QByteArray readSector(quint32 sectorIndex) const;
+    QByteArray readChain(quint32 startSector, quint64 totalSize) const;
+    QByteArray readMiniChain(quint32 startSector, quint64 totalSize) const;
+
+    quint32 sectorSize() const { return 1u << m_header.sectorShift; }
+    quint32 miniSectorSize() const { return 1u << m_header.miniSectorShift; }
+    qint64  sectorOffset(quint32 sectorIndex) const {
+        // CFB stream data starts at sector 1 (header occupies sector 0
+        // for v4 with 4 KB sectors; for v3 with 512 B sectors, the header
+        // is exactly 512 B and sector 0 is the first data sector — so the
+        // formula is "header bytes + sectorIndex * sectorSize", where
+        // header bytes is just one sector.)
+        return static_cast<qint64>(sectorIndex + 1) * sectorSize();
+    }
+
+    mutable QFile     m_file;
+    Header            m_header{};
+    QList<quint32>    m_difat;       // Concatenated FAT-sector index list
+    QList<quint32>    m_fat;         // Per-sector chain (sector → next sector)
+    QList<quint32>    m_miniFat;     // Per-mini-sector chain
+    QByteArray        m_miniStream;  // Concatenated mini-stream data
+    QList<DirEntry>   m_entries;
+    mutable QString   m_lastError;
+};
+
+} // namespace AetherSDR

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -379,7 +379,7 @@ QWidget* RadioSetupDialog::buildRadioTab()
             "QPushButton:hover { background: #2a3a4a; }");
         btnRow->addWidget(checkBtn);
 
-        auto* browseBtn = new QPushButton("Browse .ssdr...");
+        auto* browseBtn = new QPushButton("Select Installer...");
         browseBtn->setStyleSheet(checkBtn->styleSheet());
         btnRow->addWidget(browseBtn);
 
@@ -407,18 +407,10 @@ QWidget* RadioSetupDialog::buildRadioTab()
             checkBtn->setEnabled(true);
             if (avail) {
                 m_fwStatusLabel->setStyleSheet("QLabel { color: #f0c040; font-size: 10px; }");
-                m_fwStatusLabel->setText(QString("Update available: v%1\n"
-                    "Click 'Check for Update' again to download and stage.").arg(latest));
-                // Re-wire the check button to trigger download
-                checkBtn->disconnect();
-                checkBtn->setText("Download v" + latest);
-                connect(checkBtn, &QPushButton::clicked, this, [this, checkBtn, latest] {
-                    checkBtn->setEnabled(false);
-                    m_fwProgress->show();
-                    m_fwProgress->setValue(0);
-                    m_stager->downloadAndStage(latest,
-                        FirmwareStager::modelToFamily(m_model->model()));
-                });
+                m_fwStatusLabel->setText(QString(
+                    "Update available: v%1\n"
+                    "Download the SmartSDR installer from flexradio.com,\n"
+                    "then click 'Select Installer...' to stage it.").arg(latest));
             } else {
                 m_fwStatusLabel->setStyleSheet("QLabel { color: #80e080; font-size: 10px; }");
                 m_fwStatusLabel->setText("Firmware is up to date (v" + latest + ").");
@@ -453,20 +445,31 @@ QWidget* RadioSetupDialog::buildRadioTab()
             m_fwStatusLabel->setText(err);
         });
 
-        // ── Browse .ssdr manually ─────────────────────────────────────
+        // ── Browse / select installer manually ────────────────────────
+        // Accepts the SmartSDR installer the user has already downloaded
+        // from FlexRadio (.msi for v4.2+, .exe for older releases) or a
+        // pre-extracted .ssdr file. The stager auto-detects which.
         connect(browseBtn, &QPushButton::clicked, this, [this] {
             const QString path = QFileDialog::getOpenFileName(
-                this, "Select Firmware File", QString(),
-                "SmartSDR Firmware (*.ssdr);;All Files (*)");
+                this, "Select SmartSDR Installer or Firmware File", QString(),
+                "SmartSDR installer or firmware (*.msi *.exe *.ssdr);;"
+                "MSI installer (*.msi);;"
+                "EXE installer (*.exe);;"
+                "Extracted firmware (*.ssdr);;"
+                "All files (*)");
             if (path.isEmpty()) return;
-            m_fwFilePath = path;
-            m_fwUploadBtn->setEnabled(true);
+
+            m_fwFilePath.clear();
+            m_fwUploadBtn->setEnabled(false);
             m_fwProgress->show();
-            m_fwProgress->setValue(100);
-            m_fwStatusLabel->setStyleSheet("QLabel { color: #80e080; font-size: 10px; }");
-            m_fwStatusLabel->setText(QString("Ready to upload: %1 (%2 MB)")
-                .arg(QFileInfo(path).fileName())
-                .arg(QFileInfo(path).size() / (1024*1024)));
+            m_fwProgress->setValue(0);
+            m_fwStatusLabel->setStyleSheet("QLabel { color: #6888a0; font-size: 10px; }");
+            m_fwStatusLabel->setText("Preparing firmware from " + QFileInfo(path).fileName() + "...");
+
+            // The stager emits stageProgress / stageComplete / stageFailed.
+            // Existing slots wire to those (set above) so we just kick it off.
+            m_stager->stageFromLocalFile(path,
+                FirmwareStager::modelToFamily(m_model->model()));
         });
 
         // ── Upload ────────────────────────────────────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,11 +62,16 @@ static QString redactPii(const QString& msg)
     QString out = msg;
 
     // IPv4 addresses: 192.168.50.121 → *.*.*. 121 (keep last octet)
-    // Negative lookbehind/lookahead skip quoted strings ("0.9.2.1") and
-    // v-prefixed versions (v0.9.2.1) so AetherSDR's own 4-component version
-    // string isn't mistaken for an IP.
+    // Negative lookbehind/lookahead skip 4-component version strings:
+    //   "0.9.2.1"            — quoted (Qt qDebug output)
+    //   v0.9.2.1             — v-prefixed
+    //   software_ver=4.2.18.41174  — protocol field with trailing build number
+    //   firmware_ver=…       — same shape
+    // The trailing (?![\d"]) handles the build-number case where the 4th
+    // captured "octet" is part of a longer number (e.g. 41174 → matches as
+    // 411 with 74 dangling, which is the bug we're fixing).
     static const QRegularExpression* ipRe = new QRegularExpression(
-        R"((?<![v"])(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?!"))");
+        R"((?<!ver=)(?<![v"])(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?![\d"]))");
     out.replace(*ipRe, QStringLiteral("*.*.*. \\4"));
 
     // Radio serial: 4424-1213-8600-7836 → ****-****-****-7836

--- a/tests/ole_compound_file_test.cpp
+++ b/tests/ole_compound_file_test.cpp
@@ -1,0 +1,165 @@
+// Standalone test harness for OleCompoundFile.
+//
+// Verifies the reader against a real WiX MSI containing six cab*.cab
+// streams. The test fixture is the SmartSDR v4.2.18 installer, which
+// is FlexRadio's licensed property and therefore not checked into the
+// repo. The test:
+//   1. Looks for the MSI at $AETHERSDR_TEST_MSI
+//   2. Falls back to ~/build/reference/SmartSDR_v4.2.18_x64.msi
+//   3. Skips with code 77 (autotools "skipped") if neither is present.
+//
+// Build: produced by CMake as `ole_compound_file_test`.
+// Run:   ./build/ole_compound_file_test
+// Exit:  0 = pass, 1 = fail, 77 = skipped (no fixture available).
+
+#include "core/OleCompoundFile.h"
+#include "core/CabExtractor.h"
+
+#include <QByteArray>
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFileInfo>
+#include <QString>
+
+#include <cstdio>
+#include <cstdlib>
+
+using AetherSDR::OleCompoundFile;
+using AetherSDR::CabExtractor;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const QString& detail = {}) {
+    std::printf("%s %-52s %s\n", ok ? "[ OK ]" : "[FAIL]", name,
+                detail.toUtf8().constData());
+    if (!ok) ++g_failed;
+}
+
+QString locateFixture() {
+    if (auto* env = std::getenv("AETHERSDR_TEST_MSI")) {
+        const QString p = QString::fromUtf8(env);
+        if (QFileInfo::exists(p)) return p;
+    }
+    const QString home = QString::fromUtf8(std::getenv("HOME") ? std::getenv("HOME") : "");
+    const QString fallback = home + "/build/reference/SmartSDR_v4.2.18_x64.msi";
+    if (QFileInfo::exists(fallback)) return fallback;
+    return QString();
+}
+
+QString md5Of(const QByteArray& data) {
+    QCryptographicHash hash(QCryptographicHash::Md5);
+    hash.addData(data);
+    return QString::fromLatin1(hash.result().toHex().toLower());
+}
+
+} // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+    const QString fixture = locateFixture();
+    if (fixture.isEmpty()) {
+        std::printf("[SKIP] no MSI fixture available — set AETHERSDR_TEST_MSI\n");
+        return 77;
+    }
+    std::printf("Using fixture: %s\n", fixture.toUtf8().constData());
+
+    OleCompoundFile cfb;
+    const bool opened = cfb.open(fixture);
+    report("open() succeeds on real MSI", opened, cfb.lastError());
+    if (!opened) return 1;
+
+    const auto msiNames = cfb.msiStreamNames();
+    report("MSI has at least 6 cab streams",
+           [&]() {
+               int cabCount = 0;
+               for (const auto& n : msiNames)
+                   if (n.startsWith("cab") && n.endsWith(".cab"))
+                       ++cabCount;
+               return cabCount >= 6;
+           }(),
+           QString("found %1 stream entries total").arg(msiNames.size()));
+
+    // Read cab*.cab streams using the MSI-aware accessor.
+    const auto cabs = cfb.readMsiStreamsByPrefixSuffix("cab", ".cab");
+    report("readStreamsByPrefixSuffix returns 6 cabs",
+           cabs.size() == 6,
+           QString("got %1").arg(cabs.size()));
+
+    // Validate cab1.cab and cab2.cab — these are the firmware-bearing ones.
+    QByteArray cab1, cab2;
+    for (const auto& [name, data] : cabs) {
+        if (name == "cab1.cab") cab1 = data;
+        if (name == "cab2.cab") cab2 = data;
+    }
+    report("cab1.cab present", !cab1.isEmpty());
+    report("cab2.cab present", !cab2.isEmpty());
+
+    // Cab files start with "MSCF" magic.
+    report("cab1.cab starts with MSCF", cab1.startsWith("MSCF"),
+           QString("first 8 bytes: %1").arg(QString::fromLatin1(cab1.left(8).toHex())));
+    report("cab2.cab starts with MSCF", cab2.startsWith("MSCF"),
+           QString("first 8 bytes: %1").arg(QString::fromLatin1(cab2.left(8).toHex())));
+
+    // Sizes from the MSI File table (we measured these directly with 7z
+    // extraction earlier in the project): cab1=64,953,412, cab2=386,480,873.
+    report("cab1.cab size matches MSI File table",
+           cab1.size() == 64953412,
+           QString("got %1, expected 64953412").arg(cab1.size()));
+    report("cab2.cab size matches MSI File table",
+           cab2.size() == 386480873,
+           QString("got %1, expected 386480873").arg(cab2.size()));
+
+    // Cab MD5s — bit-identical to 7-Zip's MSI extraction (cross-checked).
+    report("cab1.cab MD5 matches 7z extraction",
+           md5Of(cab1) == "2e135892456cfe663d9a4ac146e10394",
+           md5Of(cab1));
+    report("cab2.cab MD5 matches 7z extraction",
+           md5Of(cab2) == "93238ef77d8d65d5ccd8e4e738411dd2",
+           md5Of(cab2));
+
+    // CabExtractor — pull out every file in each cab, then locate the
+    // firmware blob by Salted__ magic. cab1 has multiple files (driver
+    // DLLs, INFs, etc. plus the FLEX-9600 firmware); cab2 has just the
+    // FLEX-6x00 firmware blob.
+    CabExtractor cx;
+
+    QList<QPair<QString, QByteArray>> cab1Files;
+    report("CabExtractor extracts all files from cab1",
+           cx.extractAll(cab1, cab1Files), cx.lastError());
+    std::printf("       cab1 contained %lld files:\n", (long long)cab1Files.size());
+    for (const auto& [name, data] : cab1Files)
+        std::printf("         - %s (%lld bytes)\n",
+                    name.toUtf8().constData(), (long long)data.size());
+
+    QByteArray ssdr6x00;
+    report("CabExtractor finds Salted__ blob in cab2",
+           cx.extractFirstMatchingMagic(cab2, "Salted__", ssdr6x00),
+           cx.lastError());
+
+    QByteArray ssdr9600;
+    report("CabExtractor finds Salted__ blob in cab1",
+           cx.extractFirstMatchingMagic(cab1, "Salted__", ssdr9600),
+           cx.lastError());
+
+    // The FLEX-6x00 firmware was the one we flashed to the radio
+    // earlier this session — bit-identical match is required.
+    report("FLEX-6x00 firmware MD5 matches the bytes we flashed",
+           md5Of(ssdr6x00) == "9e8888dc0558ee420ed82f370f805025",
+           md5Of(ssdr6x00));
+    report("FLEX-6x00 firmware size",
+           ssdr6x00.size() == 386289360,
+           QString("got %1").arg(ssdr6x00.size()));
+
+    // FLEX-9600 firmware (we don't have an authoritative MD5 — record
+    // observed value as a regression check for future builds).
+    std::printf("       FLEX-9600 firmware: size=%lld md5=%s\n",
+                (long long)ssdr9600.size(),
+                md5Of(ssdr9600).toUtf8().constData());
+
+    if (g_failed == 0)
+        std::printf("\nAll OleCompoundFile + CabExtractor tests passed.\n");
+    else
+        std::printf("\n%d test(s) failed.\n", g_failed);
+    return g_failed == 0 ? 0 : 1;
+}

--- a/third_party/libmspack/CMakeLists.txt
+++ b/third_party/libmspack/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Vendored subset of libmspack 0.11alpha (LGPL-2.1).
+# See README.md in this directory for what's included and why.
+
+add_library(mspack_static STATIC
+    mspack/system.c
+    mspack/cabd.c
+    mspack/mszipd.c
+    mspack/lzxd.c
+    mspack/qtmd.c
+    mspack/crc32.c
+)
+
+# libmspack source files use #include <name.h> for internal headers,
+# so the mspack/ directory needs to be on the include path. Keep that
+# private — consumers in AetherSDR only need the public API in mspack.h.
+target_include_directories(mspack_static
+    PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mspack>
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/mspack
+)
+
+# We don't supply a config.h; libmspack's source guards every reference
+# behind HAVE_CONFIG_H so undefined is the right state.
+target_compile_definitions(mspack_static PRIVATE
+    MSPACK_NO_DEFAULT_SYSTEM=0
+)
+
+# Upstream code emits a fair amount of -Wall noise (sign comparisons,
+# implicit narrowing, missing-field-init). We don't want those polluting
+# our own build output, and we don't want to modify upstream sources to
+# silence them — that would break the "vendored verbatim" property.
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+    target_compile_options(mspack_static PRIVATE -w)
+elseif(MSVC)
+    target_compile_options(mspack_static PRIVATE /w)
+endif()
+
+# Position-independent code so we can link into AetherSDR (which is built
+# with PIE on most platforms). Also disable Qt's AUTOMOC/AUTOUIC/AUTORCC —
+# this is plain C with no Qt usage, so they're pure overhead.
+set_target_properties(mspack_static PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    AUTOMOC OFF
+    AUTOUIC OFF
+    AUTORCC OFF
+)

--- a/third_party/libmspack/CMakeLists.txt
+++ b/third_party/libmspack/CMakeLists.txt
@@ -19,10 +19,12 @@ target_include_directories(mspack_static
 )
 
 # We don't supply a config.h; libmspack's source guards every reference
-# behind HAVE_CONFIG_H so undefined is the right state.
-target_compile_definitions(mspack_static PRIVATE
-    MSPACK_NO_DEFAULT_SYSTEM=0
-)
+# behind HAVE_CONFIG_H so undefined is the right state. We deliberately
+# do NOT define MSPACK_NO_DEFAULT_SYSTEM — that macro is checked with
+# #ifndef in system.h, so the value is irrelevant; just defining it at
+# all (even to 0) makes libmspack provide its own memcmp/memset/strlen,
+# which collides with MSVC's compiler intrinsics for those functions
+# (error C2169: "intrinsic function, cannot be defined").
 
 # Upstream code emits a fair amount of -Wall noise (sign comparisons,
 # implicit narrowing, missing-field-init). We don't want those polluting

--- a/third_party/libmspack/COPYING.LIB
+++ b/third_party/libmspack/COPYING.LIB
@@ -1,0 +1,504 @@
+		  GNU LESSER GENERAL PUBLIC LICENSE
+		       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+

--- a/third_party/libmspack/README.md
+++ b/third_party/libmspack/README.md
@@ -1,0 +1,61 @@
+# libmspack (vendored subset)
+
+This directory vendors a subset of [libmspack](https://www.cabextract.org.uk/libmspack/)
+for in-tree CAB + LZX decompression, used by `FirmwareStager::extractFromMsi()`
+to unpack `.ssdr` firmware files from FlexRadio's WiX MSI installers.
+
+## Version
+
+- **Upstream version**: libmspack 0.11alpha (released 2023-02-05)
+- **Source archive**: https://www.cabextract.org.uk/libmspack/libmspack-0.11alpha.tar.gz
+- **License**: GNU LGPL v2.1 (see `COPYING.LIB`)
+
+## Why vendored
+
+Earlier MSI-extraction prototypes shelled out to `7z` via QProcess. That
+introduced a runtime dependency that is unreliable on Windows
+(uncommonly installed) and disallowed in sandboxed environments
+(Snap, Flatpak, App Sandbox). Vendoring libmspack gives us a fully
+self-contained extraction path.
+
+We use only a small subset of libmspack's functionality: read-only CAB
+decompression with LZX (and MSZIP / Quantum, which the CAB dispatcher
+references unconditionally). Encoders and unrelated formats (CHM, HLP,
+KWAJ, LIT, OAB, SZDD) are intentionally not vendored.
+
+## File inventory
+
+The following files are copied verbatim from upstream `mspack/`:
+
+| File | Purpose |
+|---|---|
+| `mspack.h` | Public API |
+| `system.h`, `system.c` | I/O abstraction layer |
+| `cab.h`, `cabd.c` | CAB decompressor |
+| `mszip.h`, `mszipd.c` | MSZIP decoder |
+| `lzx.h`, `lzxd.c` | LZX decoder (primary path for MSI cabs) |
+| `qtm.h`, `qtmd.c` | Quantum decoder (referenced by CAB dispatcher) |
+| `crc32.h`, `crc32.c` | CRC-32 validation |
+| `readbits.h`, `readhuff.h` | Bit-stream + Huffman helpers |
+| `macros.h` | Utility macros |
+
+## License compatibility
+
+libmspack is LGPL-2.1. AetherSDR is GPL-3.0. The two are compatible:
+LGPL-2.1 §3 explicitly allows opting into "any later version" of the
+GPL, which includes GPL-3. The vendored source headers retain their
+original copyright notices, and `COPYING.LIB` is preserved here.
+
+## Updating
+
+To pull in a newer libmspack release:
+
+1. Download the new source archive from the upstream site
+2. Replace each file listed above with the upstream version of the same name
+3. Re-run the AetherSDR test suite, particularly `firmware_extract_test`
+4. Update the version + date in this README
+
+If upstream adds new internal includes that the vendored files reference,
+copy those too. Run a build to find missing-header errors.
+
+If a CVE is announced in upstream, cherry-pick the affected file(s).

--- a/third_party/libmspack/mspack/cab.h
+++ b/third_party/libmspack/mspack/cab.h
@@ -1,0 +1,140 @@
+/* This file is part of libmspack.
+ * (C) 2003-2018 Stuart Caie.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+#ifndef MSPACK_CAB_H
+#define MSPACK_CAB_H 1
+
+/* generic CAB definitions */
+
+/* structure offsets */
+#define cfhead_Signature         (0x00)
+#define cfhead_CabinetSize       (0x08)
+#define cfhead_FileOffset        (0x10)
+#define cfhead_MinorVersion      (0x18)
+#define cfhead_MajorVersion      (0x19)
+#define cfhead_NumFolders        (0x1A)
+#define cfhead_NumFiles          (0x1C)
+#define cfhead_Flags             (0x1E)
+#define cfhead_SetID             (0x20)
+#define cfhead_CabinetIndex      (0x22)
+#define cfhead_SIZEOF            (0x24)
+#define cfheadext_HeaderReserved (0x00)
+#define cfheadext_FolderReserved (0x02)
+#define cfheadext_DataReserved   (0x03)
+#define cfheadext_SIZEOF         (0x04)
+#define cffold_DataOffset        (0x00)
+#define cffold_NumBlocks         (0x04)
+#define cffold_CompType          (0x06)
+#define cffold_SIZEOF            (0x08)
+#define cffile_UncompressedSize  (0x00)
+#define cffile_FolderOffset      (0x04)
+#define cffile_FolderIndex       (0x08)
+#define cffile_Date              (0x0A)
+#define cffile_Time              (0x0C)
+#define cffile_Attribs           (0x0E)
+#define cffile_SIZEOF            (0x10)
+#define cfdata_CheckSum          (0x00)
+#define cfdata_CompressedSize    (0x04)
+#define cfdata_UncompressedSize  (0x06)
+#define cfdata_SIZEOF            (0x08)
+
+/* flags */
+#define cffoldCOMPTYPE_MASK            (0x000f)
+#define cffoldCOMPTYPE_NONE            (0x0000)
+#define cffoldCOMPTYPE_MSZIP           (0x0001)
+#define cffoldCOMPTYPE_QUANTUM         (0x0002)
+#define cffoldCOMPTYPE_LZX             (0x0003)
+#define cfheadPREV_CABINET             (0x0001)
+#define cfheadNEXT_CABINET             (0x0002)
+#define cfheadRESERVE_PRESENT          (0x0004)
+#define cffileCONTINUED_FROM_PREV      (0xFFFD)
+#define cffileCONTINUED_TO_NEXT        (0xFFFE)
+#define cffileCONTINUED_PREV_AND_NEXT  (0xFFFF)
+
+/* CAB data blocks are <= 32768 bytes in uncompressed form. Uncompressed
+ * blocks have zero growth. MSZIP guarantees that it won't grow above
+ * uncompressed size by more than 12 bytes. LZX guarantees it won't grow
+ * more than 6144 bytes. Quantum has no documentation, but the largest
+ * block seen in the wild is 337 bytes above uncompressed size.
+ */
+#define CAB_BLOCKMAX (32768)
+#define CAB_INPUTMAX (CAB_BLOCKMAX+6144)
+
+/* input buffer needs to be CAB_INPUTMAX + 1 byte to allow for max-sized block
+ * plus 1 trailer byte added by cabd_sys_read_block() for Quantum alignment.
+ *
+ * When MSCABD_PARAM_SALVAGE is set, block size is not checked so can be
+ * up to 65535 bytes, so max input buffer size needed is 65535 + 1
+ */
+#define CAB_INPUTMAX_SALVAGE (65535)
+#define CAB_INPUTBUF (CAB_INPUTMAX_SALVAGE + 1)
+
+/* There are no more than 65535 data blocks per folder, so a folder cannot
+ * be more than 32768*65535 bytes in length. As files cannot span more than
+ * one folder, this is also their max offset, length and offset+length limit.
+ */
+#define CAB_FOLDERMAX (65535)
+#define CAB_LENGTHMAX (CAB_BLOCKMAX * CAB_FOLDERMAX)
+
+/* CAB compression definitions */
+
+struct mscab_compressor_p {
+  struct mscab_compressor base;
+  struct mspack_system *system;
+  /* todo */
+};
+
+/* CAB decompression definitions */
+
+struct mscabd_decompress_state {
+  struct mscabd_folder_p *folder;    /* current folder we're extracting from */
+  struct mscabd_folder_data *data;   /* current folder split we're in        */
+  unsigned int offset;               /* uncompressed offset within folder    */
+  unsigned int block;                /* which block are we decompressing?    */
+  off_t outlen;                      /* cumulative sum of block output sizes */
+  struct mspack_system sys;          /* special I/O code for decompressor    */
+  int comp_type;                     /* type of compression used by folder   */
+  int (*decompress)(void *, off_t);  /* decompressor code                    */
+  void *state;                       /* decompressor state                   */
+  struct mscabd_cabinet_p *incab;    /* cabinet where input data comes from  */
+  struct mspack_file *infh;          /* input file handle                    */
+  struct mspack_file *outfh;         /* output file handle                   */
+  unsigned char *i_ptr, *i_end;      /* input data consumed, end             */
+  unsigned char input[CAB_INPUTBUF]; /* one input block of data              */
+};
+
+struct mscab_decompressor_p {
+  struct mscab_decompressor base;
+  struct mscabd_decompress_state *d;
+  struct mspack_system *system;
+  int buf_size, searchbuf_size, fix_mszip, salvage; /* params */
+  int error, read_error;
+};
+
+struct mscabd_cabinet_p {
+  struct mscabd_cabinet base;
+  off_t blocks_off;                  /* offset to data blocks                */
+  int block_resv;                    /* reserved space in data blocks        */
+};
+
+/* there is one of these for every cabinet a folder spans */
+struct mscabd_folder_data {
+  struct mscabd_folder_data *next;
+  struct mscabd_cabinet_p *cab;      /* cabinet file of this folder span     */
+  off_t offset;                      /* cabinet offset of first datablock    */
+};
+
+struct mscabd_folder_p {
+  struct mscabd_folder base;
+  struct mscabd_folder_data data;    /* where are the data blocks?           */
+  struct mscabd_file *merge_prev;    /* first file needing backwards merge   */
+  struct mscabd_file *merge_next;    /* first file needing forwards merge    */
+};
+
+#endif

--- a/third_party/libmspack/mspack/cabd.c
+++ b/third_party/libmspack/mspack/cabd.c
@@ -1,0 +1,1510 @@
+/* This file is part of libmspack.
+ * (C) 2003-2023 Stuart Caie.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+/* Cabinet (.CAB) files are a form of file archive. Each cabinet contains
+ * "folders", which are compressed spans of data. Each cabinet has
+ * "files", whose metadata is in the cabinet header, but whose actual data
+ * is stored compressed in one of the "folders". Cabinets can span more
+ * than one physical file on disk, in which case they are a "cabinet set",
+ * and usually the last folder of each cabinet extends into the next
+ * cabinet.
+ *
+ * For a complete description of the format, see the MSDN site:
+ *   http://msdn.microsoft.com/en-us/library/bb267310.aspx
+ */
+
+/* CAB decompression implementation */
+
+#include <system.h>
+#include <cab.h>
+#include <mszip.h>
+#include <lzx.h>
+#include <qtm.h>
+
+/* Notes on compliance with cabinet specification:
+ *
+ * One of the main changes between cabextract 0.6 and libmspack's cab
+ * decompressor is the move from block-oriented decompression to
+ * stream-oriented decompression.
+ *
+ * cabextract would read one data block from disk, decompress it with the
+ * appropriate method, then write the decompressed data. The CAB
+ * specification is specifically designed to work like this, as it ensures
+ * compression matches do not span the maximum decompressed block size
+ * limit of 32kb.
+ *
+ * However, the compression algorithms used are stream oriented, with
+ * specific hacks added to them to enforce the "individual 32kb blocks"
+ * rule in CABs. In other file formats, they do not have this limitation.
+ *
+ * In order to make more generalised decompressors, libmspack's CAB
+ * decompressor has moved from being block-oriented to more stream
+ * oriented. This also makes decompression slightly faster.
+ *
+ * However, this leads to incompliance with the CAB specification. The
+ * CAB controller can no longer ensure each block of input given to the
+ * decompressors is matched with their output. The "decompressed size" of
+ * each individual block is thrown away.
+ *
+ * Each CAB block is supposed to be seen as individually compressed. This
+ * means each consecutive data block can have completely different
+ * "uncompressed" sizes, ranging from 1 to 32768 bytes. However, in
+ * reality, all data blocks in a folder decompress to exactly 32768 bytes,
+ * excepting the final block. 
+ *
+ * Given this situation, the decompression algorithms are designed to
+ * realign their input bitstreams on 32768 output-byte boundaries, and
+ * various other special cases have been made. libmspack will not
+ * correctly decompress LZX or Quantum compressed folders where the blocks
+ * do not follow this "32768 bytes until last block" pattern. It could be
+ * implemented if needed, but hopefully this is not necessary -- it has
+ * not been seen in over 3Gb of CAB archives.
+ */
+
+/* prototypes */
+static struct mscabd_cabinet * cabd_open(
+  struct mscab_decompressor *base, const char *filename);
+static void cabd_close(
+  struct mscab_decompressor *base, struct mscabd_cabinet *origcab);
+static int cabd_read_headers(
+  struct mspack_system *sys, struct mspack_file *fh,
+  struct mscabd_cabinet_p *cab, off_t offset, int salvage, int quiet);
+static char *cabd_read_string(
+  struct mspack_system *sys, struct mspack_file *fh, int permit_empty,
+  int *error);
+
+static struct mscabd_cabinet *cabd_search(
+  struct mscab_decompressor *base, const char *filename);
+static int cabd_find(
+  struct mscab_decompressor_p *self, unsigned char *buf,
+  struct mspack_file *fh, const char *filename, off_t flen,
+  off_t *firstlen, struct mscabd_cabinet_p **firstcab);
+
+static int cabd_prepend(
+  struct mscab_decompressor *base, struct mscabd_cabinet *cab,
+  struct mscabd_cabinet *prevcab);
+static int cabd_append(
+  struct mscab_decompressor *base, struct mscabd_cabinet *cab,
+  struct mscabd_cabinet *nextcab);
+static int cabd_merge(
+  struct mscab_decompressor *base, struct mscabd_cabinet *lcab,
+  struct mscabd_cabinet *rcab);
+static int cabd_can_merge_folders(
+  struct mspack_system *sys, struct mscabd_folder_p *lfol,
+  struct mscabd_folder_p *rfol);
+
+static int cabd_extract(
+  struct mscab_decompressor *base, struct mscabd_file *file,
+  const char *filename);
+static int cabd_init_decomp(
+  struct mscab_decompressor_p *self, unsigned int ct);
+static void cabd_free_decomp(
+  struct mscab_decompressor_p *self);
+static int cabd_sys_read(
+  struct mspack_file *file, void *buffer, int bytes);
+static int cabd_sys_write(
+  struct mspack_file *file, void *buffer, int bytes);
+static int cabd_sys_read_block(
+  struct mspack_system *sys, struct mscabd_decompress_state *d, int *out,
+  int ignore_cksum, int ignore_blocksize);
+static unsigned int cabd_checksum(
+  unsigned char *data, unsigned int bytes, unsigned int cksum);
+static struct noned_state *noned_init(
+  struct mspack_system *sys, struct mspack_file *in, struct mspack_file *out,
+  int bufsize);
+
+static int noned_decompress(
+  struct noned_state *s, off_t bytes);
+static void noned_free(
+  struct noned_state *state);
+
+static int cabd_param(
+  struct mscab_decompressor *base, int param, int value);
+
+static int cabd_error(
+  struct mscab_decompressor *base);
+
+
+/***************************************
+ * MSPACK_CREATE_CAB_DECOMPRESSOR
+ ***************************************
+ * constructor
+ */
+struct mscab_decompressor *
+  mspack_create_cab_decompressor(struct mspack_system *sys)
+{
+  struct mscab_decompressor_p *self = NULL;
+
+  if (!sys) sys = mspack_default_system;
+  if (!mspack_valid_system(sys)) return NULL;
+
+  if ((self = (struct mscab_decompressor_p *) sys->alloc(sys, sizeof(struct mscab_decompressor_p)))) {
+    self->base.open       = &cabd_open;
+    self->base.close      = &cabd_close;
+    self->base.search     = &cabd_search;
+    self->base.extract    = &cabd_extract;
+    self->base.prepend    = &cabd_prepend;
+    self->base.append     = &cabd_append;
+    self->base.set_param  = &cabd_param;
+    self->base.last_error = &cabd_error;
+    self->system          = sys;
+    self->d               = NULL;
+    self->error           = MSPACK_ERR_OK;
+
+    self->searchbuf_size  = 32768;
+    self->fix_mszip       = 0;
+    self->buf_size        = 4096;
+    self->salvage         = 0;
+  }
+  return (struct mscab_decompressor *) self;
+}
+
+/***************************************
+ * MSPACK_DESTROY_CAB_DECOMPRESSOR
+ ***************************************
+ * destructor
+ */
+void mspack_destroy_cab_decompressor(struct mscab_decompressor *base) {
+  struct mscab_decompressor_p *self = (struct mscab_decompressor_p *) base;
+  if (self) {
+    struct mspack_system *sys = self->system;
+    if (self->d) {
+      if (self->d->infh) sys->close(self->d->infh);
+      cabd_free_decomp(self);
+      sys->free(self->d);
+    }
+    sys->free(self);
+  }
+}
+
+
+/***************************************
+ * CABD_OPEN
+ ***************************************
+ * opens a file and tries to read it as a cabinet file
+ */
+static struct mscabd_cabinet *cabd_open(struct mscab_decompressor *base,
+                                        const char *filename)
+{
+  struct mscab_decompressor_p *self = (struct mscab_decompressor_p *) base;
+  struct mscabd_cabinet_p *cab = NULL;
+  struct mspack_system *sys;
+  struct mspack_file *fh;
+  int error;
+
+  if (!base) return NULL;
+  sys = self->system;
+
+  if ((fh = sys->open(sys, filename, MSPACK_SYS_OPEN_READ))) {
+    if ((cab = (struct mscabd_cabinet_p *) sys->alloc(sys, sizeof(struct mscabd_cabinet_p)))) {
+      cab->base.filename = filename;
+      error = cabd_read_headers(sys, fh, cab, (off_t) 0, self->salvage, 0);
+      if (error) {
+        cabd_close(base, (struct mscabd_cabinet *) cab);
+        cab = NULL;
+      }
+      self->error = error;
+    }
+    else {
+      self->error = MSPACK_ERR_NOMEMORY;
+    }
+    sys->close(fh);
+  }
+  else {
+    self->error = MSPACK_ERR_OPEN;
+  }
+  return (struct mscabd_cabinet *) cab;
+}
+
+/***************************************
+ * CABD_CLOSE
+ ***************************************
+ * frees all memory associated with a given mscabd_cabinet.
+ */
+static void cabd_close(struct mscab_decompressor *base,
+                       struct mscabd_cabinet *origcab)
+{
+  struct mscab_decompressor_p *self = (struct mscab_decompressor_p *) base;
+  struct mscabd_folder_data *dat, *ndat;
+  struct mscabd_cabinet *cab, *ncab;
+  struct mscabd_folder *fol, *nfol;
+  struct mscabd_file *fi, *nfi;
+  struct mspack_system *sys;
+
+  if (!base) return;
+  sys = self->system;
+
+  self->error = MSPACK_ERR_OK;
+
+  while (origcab) {
+    /* free files */
+    for (fi = origcab->files; fi; fi = nfi) {
+      nfi = fi->next;
+      sys->free(fi->filename);
+      sys->free(fi);
+    }
+
+    /* free folders */
+    for (fol = origcab->folders; fol; fol = nfol) {
+      nfol = fol->next;
+
+      /* free folder decompression state if it has been decompressed */
+      if (self->d && (self->d->folder == (struct mscabd_folder_p *) fol)) {
+        if (self->d->infh) sys->close(self->d->infh);
+        cabd_free_decomp(self);
+        sys->free(self->d);
+        self->d = NULL;
+      }
+
+      /* free folder data segments */
+      for (dat = ((struct mscabd_folder_p *)fol)->data.next; dat; dat = ndat) {
+        ndat = dat->next;
+        sys->free(dat);
+      }
+      sys->free(fol);
+    }
+
+    /* free predecessor cabinets (and the original cabinet's strings) */
+    for (cab = origcab; cab; cab = ncab) {
+      ncab = cab->prevcab;
+      sys->free(cab->prevname);
+      sys->free(cab->nextname);
+      sys->free(cab->previnfo);
+      sys->free(cab->nextinfo);
+      if (cab != origcab) sys->free(cab);
+    }
+
+    /* free successor cabinets */
+    for (cab = origcab->nextcab; cab; cab = ncab) {
+      ncab = cab->nextcab;
+      sys->free(cab->prevname);
+      sys->free(cab->nextname);
+      sys->free(cab->previnfo);
+      sys->free(cab->nextinfo);
+      sys->free(cab);
+    }
+
+    /* free actual cabinet structure */
+    cab = origcab->next;
+    sys->free(origcab);
+
+    /* repeat full procedure again with the cab->next pointer (if set) */
+    origcab = cab;
+  }
+}
+
+/***************************************
+ * CABD_READ_HEADERS
+ ***************************************
+ * reads the cabinet file header, folder list and file list.
+ * fills out a pre-existing mscabd_cabinet structure, allocates memory
+ * for folders and files as necessary
+ */
+static int cabd_read_headers(struct mspack_system *sys,
+                             struct mspack_file *fh,
+                             struct mscabd_cabinet_p *cab,
+                             off_t offset, int salvage, int quiet)
+{
+  int num_folders, num_files, folder_resv, i, x, err, fidx;
+  struct mscabd_folder_p *fol, *linkfol = NULL;
+  struct mscabd_file *file, *linkfile = NULL;
+  unsigned char buf[64];
+
+  /* initialise pointers */
+  cab->base.next     = NULL;
+  cab->base.files    = NULL;
+  cab->base.folders  = NULL;
+  cab->base.prevcab  = cab->base.nextcab  = NULL;
+  cab->base.prevname = cab->base.nextname = NULL;
+  cab->base.previnfo = cab->base.nextinfo = NULL;
+
+  cab->base.base_offset = offset;
+
+  /* seek to CFHEADER */
+  if (sys->seek(fh, offset, MSPACK_SYS_SEEK_START)) {
+    return MSPACK_ERR_SEEK;
+  }
+
+  /* read in the CFHEADER */
+  if (sys->read(fh, &buf[0], cfhead_SIZEOF) != cfhead_SIZEOF) {
+    return MSPACK_ERR_READ;
+  }
+
+  /* check for "MSCF" signature */
+  if (EndGetI32(&buf[cfhead_Signature]) != 0x4643534D) {
+    return MSPACK_ERR_SIGNATURE;
+  }
+
+  /* some basic header fields */
+  cab->base.length    = EndGetI32(&buf[cfhead_CabinetSize]);
+  cab->base.set_id    = EndGetI16(&buf[cfhead_SetID]);
+  cab->base.set_index = EndGetI16(&buf[cfhead_CabinetIndex]);
+
+  /* get the number of folders */
+  num_folders = EndGetI16(&buf[cfhead_NumFolders]);
+  if (num_folders == 0) {
+    if (!quiet) sys->message(fh, "no folders in cabinet.");
+    return MSPACK_ERR_DATAFORMAT;
+  }
+
+  /* get the number of files */
+  num_files = EndGetI16(&buf[cfhead_NumFiles]);
+  if (num_files == 0) {
+    if (!quiet) sys->message(fh, "no files in cabinet.");
+    return MSPACK_ERR_DATAFORMAT;
+  }
+
+  /* check cabinet version */
+  if ((buf[cfhead_MajorVersion] != 1) && (buf[cfhead_MinorVersion] != 3)) {
+    if (!quiet) sys->message(fh, "WARNING; cabinet version is not 1.3");
+  }
+
+  /* read the reserved-sizes part of header, if present */
+  cab->base.flags = EndGetI16(&buf[cfhead_Flags]);
+
+  if (cab->base.flags & cfheadRESERVE_PRESENT) {
+    if (sys->read(fh, &buf[0], cfheadext_SIZEOF) != cfheadext_SIZEOF) {
+      return MSPACK_ERR_READ;
+    }
+    cab->base.header_resv = EndGetI16(&buf[cfheadext_HeaderReserved]);
+    folder_resv           = buf[cfheadext_FolderReserved];
+    cab->block_resv       = buf[cfheadext_DataReserved];
+
+    if (cab->base.header_resv > 60000) {
+      if (!quiet) sys->message(fh, "WARNING; reserved header > 60000.");
+    }
+
+    /* skip the reserved header */
+    if (cab->base.header_resv) {
+      if (sys->seek(fh, (off_t) cab->base.header_resv, MSPACK_SYS_SEEK_CUR)) {
+        return MSPACK_ERR_SEEK;
+      }
+    }
+  }
+  else {
+    cab->base.header_resv = 0;
+    folder_resv           = 0; 
+    cab->block_resv       = 0;
+  }
+
+  /* read name and info of preceeding cabinet in set, if present */
+  if (cab->base.flags & cfheadPREV_CABINET) {
+    cab->base.prevname = cabd_read_string(sys, fh, 0, &err);
+    if (err) return err;
+    cab->base.previnfo = cabd_read_string(sys, fh, 1, &err);
+    if (err) return err;
+  }
+
+  /* read name and info of next cabinet in set, if present */
+  if (cab->base.flags & cfheadNEXT_CABINET) {
+    cab->base.nextname = cabd_read_string(sys, fh, 0, &err);
+    if (err) return err;
+    cab->base.nextinfo = cabd_read_string(sys, fh, 1, &err);
+    if (err) return err;
+  }
+
+  /* read folders */
+  for (i = 0; i < num_folders; i++) {
+    if (sys->read(fh, &buf[0], cffold_SIZEOF) != cffold_SIZEOF) {
+      return MSPACK_ERR_READ;
+    }
+    if (folder_resv) {
+      if (sys->seek(fh, (off_t) folder_resv, MSPACK_SYS_SEEK_CUR)) {
+        return MSPACK_ERR_SEEK;
+      }
+    }
+
+    if (!(fol = (struct mscabd_folder_p *) sys->alloc(sys, sizeof(struct mscabd_folder_p)))) {
+      return MSPACK_ERR_NOMEMORY;
+    }
+    fol->base.next       = NULL;
+    fol->base.comp_type  = EndGetI16(&buf[cffold_CompType]);
+    fol->base.num_blocks = EndGetI16(&buf[cffold_NumBlocks]);
+    fol->data.next       = NULL;
+    fol->data.cab        = (struct mscabd_cabinet_p *) cab;
+    fol->data.offset     = offset + (off_t)
+      ( (unsigned int) EndGetI32(&buf[cffold_DataOffset]) );
+    fol->merge_prev      = NULL;
+    fol->merge_next      = NULL;
+
+    /* link folder into list of folders */
+    if (!linkfol) cab->base.folders = (struct mscabd_folder *) fol;
+    else linkfol->base.next = (struct mscabd_folder *) fol;
+    linkfol = fol;
+  }
+
+  /* read files */
+  for (i = 0; i < num_files; i++) {
+    if (sys->read(fh, &buf[0], cffile_SIZEOF) != cffile_SIZEOF) {
+      return MSPACK_ERR_READ;
+    }
+
+    if (!(file = (struct mscabd_file *) sys->alloc(sys, sizeof(struct mscabd_file)))) {
+      return MSPACK_ERR_NOMEMORY;
+    }
+
+    file->next     = NULL;
+    file->length   = EndGetI32(&buf[cffile_UncompressedSize]);
+    file->attribs  = EndGetI16(&buf[cffile_Attribs]);
+    file->offset   = EndGetI32(&buf[cffile_FolderOffset]);
+
+    /* set folder pointer */
+    fidx = EndGetI16(&buf[cffile_FolderIndex]);
+    if (fidx < cffileCONTINUED_FROM_PREV) {
+      /* normal folder index; count up to the correct folder */
+      if (fidx < num_folders) {
+        struct mscabd_folder *ifol = cab->base.folders;
+        while (fidx--) if (ifol) ifol = ifol->next;
+        file->folder = ifol;
+      }
+      else {
+        D(("invalid folder index"))
+        file->folder = NULL;
+      }
+    }
+    else {
+      /* either CONTINUED_TO_NEXT, CONTINUED_FROM_PREV or
+       * CONTINUED_PREV_AND_NEXT */
+      if ((fidx == cffileCONTINUED_TO_NEXT) ||
+          (fidx == cffileCONTINUED_PREV_AND_NEXT))
+      {
+        /* get last folder */
+        struct mscabd_folder *ifol = cab->base.folders;
+        while (ifol->next) ifol = ifol->next;
+        file->folder = ifol;
+
+        /* set "merge next" pointer */
+        fol = (struct mscabd_folder_p *) ifol;
+        if (!fol->merge_next) fol->merge_next = file;
+      }
+
+      if ((fidx == cffileCONTINUED_FROM_PREV) ||
+          (fidx == cffileCONTINUED_PREV_AND_NEXT))
+      {
+        /* get first folder */
+        file->folder = cab->base.folders;
+
+        /* set "merge prev" pointer */
+        fol = (struct mscabd_folder_p *) file->folder;
+        if (!fol->merge_prev) fol->merge_prev = file;
+      }
+    }
+
+    /* get time */
+    x = EndGetI16(&buf[cffile_Time]);
+    file->time_h = x >> 11;
+    file->time_m = (x >> 5) & 0x3F;
+    file->time_s = (x << 1) & 0x3E;
+
+    /* get date */
+    x = EndGetI16(&buf[cffile_Date]);
+    file->date_d = x & 0x1F;
+    file->date_m = (x >> 5) & 0xF;
+    file->date_y = (x >> 9) + 1980;
+
+    /* get filename */
+    file->filename = cabd_read_string(sys, fh, 0, &err);
+
+    /* if folder index or filename are bad, either skip it or fail */
+    if (err || !file->folder) {
+      sys->free(file->filename);
+      sys->free(file);
+      if (salvage) continue;
+      return err ? err : MSPACK_ERR_DATAFORMAT;
+    }
+
+    /* link file entry into file list */
+    if (!linkfile) cab->base.files = file;
+    else linkfile->next = file;
+    linkfile = file;
+  }
+
+  if (cab->base.files == NULL) {
+    /* We never actually added any files to the file list.  Something went wrong.
+     * The file header may have been invalid */
+    D(("No files found, even though header claimed to have %d files", num_files))
+    return MSPACK_ERR_DATAFORMAT;
+  }
+
+  return MSPACK_ERR_OK;
+}
+
+static char *cabd_read_string(struct mspack_system *sys,
+                              struct mspack_file *fh, int permit_empty,
+                              int *error)
+{
+  off_t base = sys->tell(fh);
+  char buf[256], *str;
+  int len, i, ok;
+
+  /* read up to 256 bytes */
+  if ((len = sys->read(fh, &buf[0], 256)) <= 0) {
+    *error = MSPACK_ERR_READ;
+    return NULL;
+  }
+
+  /* search for a null terminator in the buffer */
+  for (i = 0, ok = 0; i < len; i++) if (!buf[i]) { ok = 1; break; }
+  /* optionally reject empty strings */
+  if (i == 0 && !permit_empty) ok = 0;
+
+  if (!ok) {
+    *error = MSPACK_ERR_DATAFORMAT;
+    return NULL;
+  }
+
+  len = i + 1;
+
+  /* set the data stream to just after the string and return */
+  if (sys->seek(fh, base + (off_t)len, MSPACK_SYS_SEEK_START)) {
+    *error = MSPACK_ERR_SEEK;
+    return NULL;
+  }
+
+  if (!(str = (char *) sys->alloc(sys, len))) {
+    *error = MSPACK_ERR_NOMEMORY;
+    return NULL;
+  }
+
+  sys->copy(&buf[0], str, len);
+  *error = MSPACK_ERR_OK;
+  return str;
+}
+    
+/***************************************
+ * CABD_SEARCH, CABD_FIND
+ ***************************************
+ * cabd_search opens a file, finds its extent, allocates a search buffer,
+ * then reads through the whole file looking for possible cabinet headers.
+ * if it finds any, it tries to read them as real cabinets. returns a linked
+ * list of results
+ *
+ * cabd_find is the inner loop of cabd_search, to make it easier to
+ * break out of the loop and be sure that all resources are freed
+ */
+static struct mscabd_cabinet *cabd_search(struct mscab_decompressor *base,
+                                          const char *filename)
+{
+  struct mscab_decompressor_p *self = (struct mscab_decompressor_p *) base;
+  struct mscabd_cabinet_p *cab = NULL;
+  struct mspack_system *sys;
+  unsigned char *search_buf;
+  struct mspack_file *fh;
+  off_t filelen, firstlen = 0;
+
+  if (!base) return NULL;
+  sys = self->system;
+
+  /* allocate a search buffer */
+  search_buf = (unsigned char *) sys->alloc(sys, (size_t) self->searchbuf_size);
+  if (!search_buf) {
+    self->error = MSPACK_ERR_NOMEMORY;
+    return NULL;
+  }
+
+  /* open file and get its full file length */
+  if ((fh = sys->open(sys, filename, MSPACK_SYS_OPEN_READ))) {
+    if (!(self->error = mspack_sys_filelen(sys, fh, &filelen))) {
+      self->error = cabd_find(self, search_buf, fh, filename,
+                              filelen, &firstlen, &cab);
+    }
+
+    /* truncated / extraneous data warning: */
+    if (firstlen && (firstlen != filelen) &&
+        (!cab || (cab->base.base_offset == 0)))
+    {
+      if (firstlen < filelen) {
+        sys->message(fh, "WARNING; possible %" LD
+                     " extra bytes at end of file.",
+                     filelen - firstlen);
+      }
+      else {
+        sys->message(fh, "WARNING; file possibly truncated by %" LD " bytes.",
+                     firstlen - filelen);
+      }
+    }
+    
+    sys->close(fh);
+  }
+  else {
+    self->error = MSPACK_ERR_OPEN;
+  }
+
+  /* free the search buffer */
+  sys->free(search_buf);
+
+  return (struct mscabd_cabinet *) cab;
+}
+
+static int cabd_find(struct mscab_decompressor_p *self, unsigned char *buf,
+                     struct mspack_file *fh, const char *filename, off_t flen,
+                     off_t *firstlen, struct mscabd_cabinet_p **firstcab)
+{
+  struct mscabd_cabinet_p *cab, *link = NULL;
+  off_t caboff, offset, length;
+  struct mspack_system *sys = self->system;
+  unsigned char *p, *pend, state = 0;
+  unsigned int cablen_u32 = 0, foffset_u32 = 0;
+  int false_cabs = 0;
+
+#if SIZEOF_OFF_T < 8
+  /* detect 32-bit off_t overflow */
+  if (flen < 0) {
+    sys->message(fh, "library not compiled to support large files.");
+    return MSPACK_ERR_OK;
+  }
+#endif
+
+  /* search through the full file length */
+  for (offset = 0; offset < flen; offset += length) {
+    /* search length is either the full length of the search buffer, or the
+     * amount of data remaining to the end of the file, whichever is less. */
+    length = flen - offset;
+    if (length > self->searchbuf_size) {
+      length = self->searchbuf_size;
+    }
+
+    /* fill the search buffer with data from disk */
+    if (sys->read(fh, &buf[0], (int) length) != (int) length) {
+      return MSPACK_ERR_READ;
+    }
+
+    /* FAQ avoidance strategy */
+    if ((offset == 0) && (EndGetI32(&buf[0]) == 0x28635349)) {
+      sys->message(fh, "WARNING; found InstallShield header. Use unshield "
+                   "(https://github.com/twogood/unshield) to unpack this file"); 
+    }
+
+    /* read through the entire buffer. */
+    for (p = &buf[0], pend = &buf[length]; p < pend; ) {
+      switch (state) {
+        /* starting state */
+      case 0:
+        /* we spend most of our time in this while loop, looking for
+         * a leading 'M' of the 'MSCF' signature */
+        while (p < pend && *p != 0x4D) p++;
+        /* if we found tht 'M', advance state */
+        if (p++ < pend) state = 1;
+        break;
+
+      /* verify that the next 3 bytes are 'S', 'C' and 'F' */
+      case 1: state = (*p++ == 0x53) ? 2 : 0; break;
+      case 2: state = (*p++ == 0x43) ? 3 : 0; break;
+      case 3: state = (*p++ == 0x46) ? 4 : 0; break;
+
+      /* we don't care about bytes 4-7 (see default: for action) */
+
+      /* bytes 8-11 are the overall length of the cabinet */
+      case 8:  cablen_u32  = *p++;       state++; break;
+      case 9:  cablen_u32 |= *p++ << 8;  state++; break;
+      case 10: cablen_u32 |= *p++ << 16; state++; break;
+      case 11: cablen_u32 |= *p++ << 24; state++; break;
+
+      /* we don't care about bytes 12-15 (see default: for action) */
+
+      /* bytes 16-19 are the offset within the cabinet of the filedata */
+      case 16: foffset_u32  = *p++;       state++; break;
+      case 17: foffset_u32 |= *p++ << 8;  state++; break;
+      case 18: foffset_u32 |= *p++ << 16; state++; break;
+      case 19: foffset_u32 |= *p++ << 24;
+        /* now we have recieved 20 bytes of potential cab header. work out
+         * the offset in the file of this potential cabinet */
+        caboff = offset + (p - &buf[0]) - 20;
+
+        /* should reading cabinet fail, restart search just after 'MSCF' */
+        offset = caboff + 4;
+
+        /* capture the "length of cabinet" field if there is a cabinet at
+         * offset 0 in the file, regardless of whether the cabinet can be
+         * read correctly or not */
+        if (caboff == 0) *firstlen = (off_t) cablen_u32;
+
+        /* check that the files offset is less than the alleged length of
+         * the cabinet, and that the offset + the alleged length are
+         * 'roughly' within the end of overall file length. In salvage
+         * mode, don't check the alleged length, allow it to be garbage */
+        if ((foffset_u32 < cablen_u32) &&
+            ((caboff + (off_t) foffset_u32) < (flen + 32)) &&
+            (((caboff + (off_t) cablen_u32)  < (flen + 32)) || self->salvage))
+        {
+          /* likely cabinet found -- try reading it */
+          if (!(cab = (struct mscabd_cabinet_p *) sys->alloc(sys, sizeof(struct mscabd_cabinet_p)))) {
+            return MSPACK_ERR_NOMEMORY;
+          }
+          cab->base.filename = filename;
+          if (cabd_read_headers(sys, fh, cab, caboff, self->salvage, 1)) {
+            /* destroy the failed cabinet */
+            cabd_close((struct mscab_decompressor *) self,
+                       (struct mscabd_cabinet *) cab);
+            false_cabs++;
+          }
+          else {
+            /* cabinet read correctly! */
+
+            /* link the cab into the list */
+            if (!link) *firstcab = cab;
+            else link->base.next = (struct mscabd_cabinet *) cab;
+            link = cab;
+
+            /* cause the search to restart after this cab's data. */
+            offset = caboff + (off_t) cablen_u32;
+
+#if SIZEOF_OFF_T < 8
+            /* detect 32-bit off_t overflow */
+            if (offset < caboff) {
+              sys->message(fh, "library not compiled to support large files.");
+              return MSPACK_ERR_OK;
+            }
+#endif        
+          }
+        }
+
+        /* restart search */
+        if (offset >= flen) return MSPACK_ERR_OK;
+        if (sys->seek(fh, offset, MSPACK_SYS_SEEK_START)) {
+          return MSPACK_ERR_SEEK;
+        }
+        length = 0;
+        p = pend;
+        state = 0;
+        break;
+
+      /* for bytes 4-7 and 12-15, just advance state/pointer */
+      default:
+        p++, state++;
+      } /* switch(state) */
+    } /* for (... p < pend ...) */
+  } /* for (... offset < length ...) */
+
+  if (false_cabs) {
+    D(("%d false cabinets found", false_cabs))
+  }
+
+  return MSPACK_ERR_OK;
+}
+                                             
+/***************************************
+ * CABD_MERGE, CABD_PREPEND, CABD_APPEND
+ ***************************************
+ * joins cabinets together, also merges split folders between these two
+ * cabinets only. This includes freeing the duplicate folder and file(s)
+ * and allocating a further mscabd_folder_data structure to append to the
+ * merged folder's data parts list.
+ */
+static int cabd_prepend(struct mscab_decompressor *base,
+                        struct mscabd_cabinet *cab,
+                        struct mscabd_cabinet *prevcab)
+{
+  return cabd_merge(base, prevcab, cab);
+}
+
+static int cabd_append(struct mscab_decompressor *base,
+                        struct mscabd_cabinet *cab,
+                        struct mscabd_cabinet *nextcab)
+{
+  return cabd_merge(base, cab, nextcab);
+}
+
+static int cabd_merge(struct mscab_decompressor *base,
+                      struct mscabd_cabinet *lcab,
+                      struct mscabd_cabinet *rcab)
+{
+  struct mscab_decompressor_p *self = (struct mscab_decompressor_p *) base;
+  struct mscabd_folder_data *data, *ndata;
+  struct mscabd_folder_p *lfol, *rfol;
+  struct mscabd_file *fi, *rfi, *lfi;
+  struct mscabd_cabinet *cab;
+  struct mspack_system *sys;
+
+  if (!self) return MSPACK_ERR_ARGS;
+  sys = self->system;
+
+  /* basic args check */
+  if (!lcab || !rcab || (lcab == rcab)) {
+    D(("lcab NULL, rcab NULL or lcab = rcab"))
+    return self->error = MSPACK_ERR_ARGS;
+  }
+
+  /* check there's not already a cabinet attached */
+  if (lcab->nextcab || rcab->prevcab) {
+    D(("cabs already joined"))
+    return self->error = MSPACK_ERR_ARGS;
+  }
+
+  /* do not create circular cabinet chains */
+  for (cab = lcab->prevcab; cab; cab = cab->prevcab) {
+    if (cab == rcab) {D(("circular!")) return self->error = MSPACK_ERR_ARGS;}
+  }
+  for (cab = rcab->nextcab; cab; cab = cab->nextcab) {
+    if (cab == lcab) {D(("circular!")) return self->error = MSPACK_ERR_ARGS;}
+  }
+
+  /* warn about odd set IDs or indices */
+  if (lcab->set_id != rcab->set_id) {
+    sys->message(NULL, "WARNING; merged cabinets with differing Set IDs.");
+  }
+
+  if (lcab->set_index > rcab->set_index) {
+    sys->message(NULL, "WARNING; merged cabinets with odd order.");
+  }
+
+  /* merging the last folder in lcab with the first folder in rcab */
+  lfol = (struct mscabd_folder_p *) lcab->folders;
+  rfol = (struct mscabd_folder_p *) rcab->folders;
+  while (lfol->base.next) lfol = (struct mscabd_folder_p *) lfol->base.next;
+
+  /* do we need to merge folders? */
+  if (!lfol->merge_next && !rfol->merge_prev) {
+    /* no, at least one of the folders is not for merging */
+
+    /* attach cabs */
+    lcab->nextcab = rcab;
+    rcab->prevcab = lcab;
+
+    /* attach folders */
+    lfol->base.next = (struct mscabd_folder *) rfol;
+
+    /* attach files */
+    fi = lcab->files;
+    while (fi->next) fi = fi->next;
+    fi->next = rcab->files;
+  }
+  else {
+    /* folder merge required - do the files match? */
+    if (! cabd_can_merge_folders(sys, lfol, rfol)) {
+      return self->error = MSPACK_ERR_DATAFORMAT;
+    }
+
+    /* allocate a new folder data structure */
+    if (!(data = (struct mscabd_folder_data *) sys->alloc(sys, sizeof(struct mscabd_folder_data)))) {
+      return self->error = MSPACK_ERR_NOMEMORY;
+    }
+
+    /* attach cabs */
+    lcab->nextcab = rcab;
+    rcab->prevcab = lcab;
+
+    /* append rfol's data to lfol */
+    ndata = &lfol->data;
+    while (ndata->next) ndata = ndata->next;
+    ndata->next = data;
+    *data = rfol->data;
+    rfol->data.next = NULL;
+
+    /* lfol becomes rfol.
+     * NOTE: special case, don't merge if rfol is merge prev and next,
+     * rfol->merge_next is going to be deleted, so keep lfol's version
+     * instead */
+    lfol->base.num_blocks += rfol->base.num_blocks - 1;
+    if ((rfol->merge_next == NULL) ||
+        (rfol->merge_next->folder != (struct mscabd_folder *) rfol))
+    {
+      lfol->merge_next = rfol->merge_next;
+    }
+
+    /* attach the rfol's folder (except the merge folder) */
+    while (lfol->base.next) lfol = (struct mscabd_folder_p *) lfol->base.next;
+    lfol->base.next = rfol->base.next;
+
+    /* free disused merge folder */
+    sys->free(rfol);
+
+    /* attach rfol's files */
+    fi = lcab->files;
+    while (fi->next) fi = fi->next;
+    fi->next = rcab->files;
+
+    /* delete all files from rfol's merge folder */
+    lfi = NULL;
+    for (fi = lcab->files; fi ; fi = rfi) {
+      rfi = fi->next;
+      /* if file's folder matches the merge folder, unlink and free it */
+      if (fi->folder == (struct mscabd_folder *) rfol) {
+        if (lfi) lfi->next = rfi; else lcab->files = rfi;
+        sys->free(fi->filename);
+        sys->free(fi);
+      }
+      else lfi = fi;
+    }
+  }
+
+  /* all done! fix files and folders pointers in all cabs so they all
+   * point to the same list  */
+  for (cab = lcab->prevcab; cab; cab = cab->prevcab) {
+    cab->files   = lcab->files;
+    cab->folders = lcab->folders;
+  }
+
+  for (cab = lcab->nextcab; cab; cab = cab->nextcab) {
+    cab->files   = lcab->files;
+    cab->folders = lcab->folders;
+  }
+
+  return self->error = MSPACK_ERR_OK;
+}
+
+/* decides if two folders are OK to merge */
+static int cabd_can_merge_folders(struct mspack_system *sys,
+                                  struct mscabd_folder_p *lfol,
+                                  struct mscabd_folder_p *rfol)
+{
+    struct mscabd_file *lfi, *rfi, *l, *r;
+    int matching = 1;
+
+    /* check that both folders use the same compression method/settings */
+    if (lfol->base.comp_type != rfol->base.comp_type) {
+        D(("folder merge: compression type mismatch"))
+        return 0;
+    }
+
+    /* check there are not too many data blocks after merging */
+    if ((lfol->base.num_blocks + rfol->base.num_blocks) > CAB_FOLDERMAX) {
+        D(("folder merge: too many data blocks in merged folders"))
+        return 0;
+    }
+
+    if (!(lfi = lfol->merge_next) || !(rfi = rfol->merge_prev)) {
+        D(("folder merge: one cabinet has no files to merge"))
+        return 0;
+    }
+
+    /* for all files in lfol (which is the last folder in whichever cab and
+     * only has files to merge), compare them to the files from rfol. They
+     * should be identical in number and order. to verify this, check the
+     * offset and length of each file. */
+    for (l=lfi, r=rfi; l; l=l->next, r=r->next) {
+        if (!r || (l->offset != r->offset) || (l->length != r->length)) {
+            matching = 0;
+            break;
+        }
+    }
+
+    if (matching) return 1;
+
+    /* if rfol does not begin with an identical copy of the files in lfol, make
+     * make a judgement call; if at least ONE file from lfol is in rfol, allow
+     * the merge with a warning about missing files. */
+    matching = 0;
+    for (l = lfi; l; l = l->next) {
+        for (r = rfi; r; r = r->next) {
+            if (l->offset == r->offset && l->length == r->length) break;
+        }
+        if (r) matching = 1; else sys->message(NULL,
+            "WARNING; merged file %s not listed in both cabinets", l->filename);
+    }
+    return matching;
+}
+
+
+/***************************************
+ * CABD_EXTRACT
+ ***************************************
+ * extracts a file from a cabinet
+ */
+static int cabd_extract(struct mscab_decompressor *base,
+                        struct mscabd_file *file, const char *filename)
+{
+  struct mscab_decompressor_p *self = (struct mscab_decompressor_p *) base;
+  struct mscabd_folder_p *fol;
+  struct mspack_system *sys;
+  struct mspack_file *fh;
+  unsigned int filelen;
+
+  if (!self) return MSPACK_ERR_ARGS;
+  if (!file) return self->error = MSPACK_ERR_ARGS;
+
+  sys = self->system;
+  fol = (struct mscabd_folder_p *) file->folder;
+
+  /* if offset is beyond 2GB, nothing can be extracted */
+  if (file->offset > CAB_LENGTHMAX) {
+    return self->error = MSPACK_ERR_DATAFORMAT;
+  }
+
+  /* if file claims to go beyond 2GB either error out,
+   * or in salvage mode reduce file length so it fits 2GB limit
+   */
+  filelen = file->length;
+  if (filelen > (CAB_LENGTHMAX - file->offset)) {
+    if (self->salvage) {
+      filelen = CAB_LENGTHMAX - file->offset;
+    }
+    else {
+      return self->error = MSPACK_ERR_DATAFORMAT;
+    }
+  }
+
+  /* extraction impossible if no folder, or folder needs predecessor */
+  if (!fol || fol->merge_prev) {
+    sys->message(NULL, "ERROR; file \"%s\" cannot be extracted, "
+                 "cabinet set is incomplete", file->filename);
+    return self->error = MSPACK_ERR_DECRUNCH;
+  }
+
+  /* if file goes beyond what can be decoded, given an error.
+   * In salvage mode, don't assume block sizes, just try decoding
+   */
+  if (!self->salvage) {
+    unsigned int maxlen = fol->base.num_blocks * CAB_BLOCKMAX;
+    if (file->offset > maxlen || filelen > (maxlen - file->offset)) {
+      sys->message(NULL, "ERROR; file \"%s\" cannot be extracted, "
+                   "cabinet set is incomplete", file->filename);
+      return self->error = MSPACK_ERR_DECRUNCH;
+    }
+  }
+
+  /* allocate generic decompression state */
+  if (!self->d) {
+    self->d = (struct mscabd_decompress_state *) sys->alloc(sys, sizeof(struct mscabd_decompress_state));
+    if (!self->d) return self->error = MSPACK_ERR_NOMEMORY;
+    self->d->folder     = NULL;
+    self->d->data       = NULL;
+    self->d->sys        = *sys;
+    self->d->sys.read   = &cabd_sys_read;
+    self->d->sys.write  = &cabd_sys_write;
+    self->d->state      = NULL;
+    self->d->infh       = NULL;
+    self->d->incab      = NULL;
+  }
+
+  /* do we need to change folder or reset the current folder? */
+  if ((self->d->folder != fol) || (self->d->offset > file->offset) ||
+      !self->d->state)
+  {
+    /* free any existing decompressor */
+    cabd_free_decomp(self);
+
+    /* do we need to open a new cab file? */
+    if (!self->d->infh || (fol->data.cab != self->d->incab)) {
+      /* close previous file handle if from a different cab */
+      if (self->d->infh) sys->close(self->d->infh);
+      self->d->incab = fol->data.cab;
+      self->d->infh = sys->open(sys, fol->data.cab->base.filename,
+                                MSPACK_SYS_OPEN_READ);
+      if (!self->d->infh) return self->error = MSPACK_ERR_OPEN;
+    }
+    /* seek to start of data blocks */
+    if (sys->seek(self->d->infh, fol->data.offset, MSPACK_SYS_SEEK_START)) {
+      return self->error = MSPACK_ERR_SEEK;
+    }
+
+    /* set up decompressor */
+    if (cabd_init_decomp(self, (unsigned int) fol->base.comp_type)) {
+      return self->error;
+    }
+
+    /* initialise new folder state */
+    self->d->folder = fol;
+    self->d->data   = &fol->data;
+    self->d->offset = 0;
+    self->d->block  = 0;
+    self->d->outlen = 0;
+    self->d->i_ptr = self->d->i_end = &self->d->input[0];
+
+    /* read_error lasts for the lifetime of a decompressor */
+    self->read_error = MSPACK_ERR_OK;
+  }
+
+  /* open file for output */
+  if (!(fh = sys->open(sys, filename, MSPACK_SYS_OPEN_WRITE))) {
+    return self->error = MSPACK_ERR_OPEN;
+  }
+
+  self->error = MSPACK_ERR_OK;
+
+  /* if file has more than 0 bytes */
+  if (filelen) {
+    off_t bytes;
+    int error;
+    /* get to correct offset.
+     * - use NULL fh to say 'no writing' to cabd_sys_write()
+     * - if cabd_sys_read() has an error, it will set self->read_error
+     *   and pass back MSPACK_ERR_READ
+     */
+    self->d->outfh = NULL;
+    if ((bytes = file->offset - self->d->offset)) {
+        error = self->d->decompress(self->d->state, bytes);
+        self->error = (error == MSPACK_ERR_READ) ? self->read_error : error;
+    }
+
+    /* if getting to the correct offset was error free, unpack file */
+    if (!self->error) {
+      self->d->outfh = fh;
+      error = self->d->decompress(self->d->state, filelen);
+      self->error = (error == MSPACK_ERR_READ) ? self->read_error : error;
+    }
+  }
+
+  /* close output file */
+  sys->close(fh);
+  self->d->outfh = NULL;
+
+  return self->error;
+}
+
+/***************************************
+ * CABD_INIT_DECOMP, CABD_FREE_DECOMP
+ ***************************************
+ * cabd_init_decomp initialises decompression state, according to which
+ * decompression method was used. relies on self->d->folder being the same
+ * as when initialised.
+ *
+ * cabd_free_decomp frees decompression state, according to which method
+ * was used.
+ */
+static int cabd_init_decomp(struct mscab_decompressor_p *self, unsigned int ct)
+{
+  struct mspack_file *fh = (struct mspack_file *) self;
+
+  self->d->comp_type = ct;
+
+  switch (ct & cffoldCOMPTYPE_MASK) {
+  case cffoldCOMPTYPE_NONE:
+    self->d->decompress = (int (*)(void *, off_t)) &noned_decompress;
+    self->d->state = noned_init(&self->d->sys, fh, fh, self->buf_size);
+    break;
+  case cffoldCOMPTYPE_MSZIP:
+    self->d->decompress = (int (*)(void *, off_t)) &mszipd_decompress;
+    self->d->state = mszipd_init(&self->d->sys, fh, fh, self->buf_size,
+                                 self->fix_mszip);
+    break;
+  case cffoldCOMPTYPE_QUANTUM:
+    self->d->decompress = (int (*)(void *, off_t)) &qtmd_decompress;
+    self->d->state = qtmd_init(&self->d->sys, fh, fh, (int) (ct >> 8) & 0x1f,
+                               self->buf_size);
+    break;
+  case cffoldCOMPTYPE_LZX:
+    self->d->decompress = (int (*)(void *, off_t)) &lzxd_decompress;
+    self->d->state = lzxd_init(&self->d->sys, fh, fh, (int) (ct >> 8) & 0x1f, 0,
+                               self->buf_size, (off_t)0,0);
+    break;
+  default:
+    return self->error = MSPACK_ERR_DATAFORMAT;
+  }
+  return self->error = (self->d->state) ? MSPACK_ERR_OK : MSPACK_ERR_NOMEMORY;
+}
+
+static void cabd_free_decomp(struct mscab_decompressor_p *self) {
+  if (!self || !self->d || !self->d->state) return;
+
+  switch (self->d->comp_type & cffoldCOMPTYPE_MASK) {
+  case cffoldCOMPTYPE_NONE:    noned_free((struct noned_state *) self->d->state);   break;
+  case cffoldCOMPTYPE_MSZIP:   mszipd_free((struct mszipd_stream *) self->d->state);  break;
+  case cffoldCOMPTYPE_QUANTUM: qtmd_free((struct qtmd_stream *) self->d->state);    break;
+  case cffoldCOMPTYPE_LZX:     lzxd_free((struct lzxd_stream *) self->d->state);    break;
+  }
+  self->d->decompress = NULL;
+  self->d->state      = NULL;
+}
+
+/***************************************
+ * CABD_SYS_READ, CABD_SYS_WRITE
+ ***************************************
+ * cabd_sys_read is the internal reader function which the decompressors
+ * use. will read data blocks (and merge split blocks) from the cabinet
+ * and serve the read bytes to the decompressors
+ *
+ * cabd_sys_write is the internal writer function which the decompressors
+ * use. it either writes data to disk (self->d->outfh) with the real
+ * sys->write() function, or does nothing with the data when
+ * self->d->outfh == NULL. advances self->d->offset
+ */
+static int cabd_sys_read(struct mspack_file *file, void *buffer, int bytes) {
+  struct mscab_decompressor_p *self = (struct mscab_decompressor_p *) file;
+  unsigned char *buf = (unsigned char *) buffer;
+  struct mspack_system *sys = self->system;
+  int avail, todo, outlen, ignore_cksum, ignore_blocksize;
+
+  ignore_cksum = self->salvage ||
+    (self->fix_mszip && 
+     ((self->d->comp_type & cffoldCOMPTYPE_MASK) == cffoldCOMPTYPE_MSZIP));
+  ignore_blocksize = self->salvage;
+
+  todo = bytes;
+  while (todo > 0) {
+    avail = self->d->i_end - self->d->i_ptr;
+
+    /* if out of input data, read a new block */
+    if (avail) {
+      /* copy as many input bytes available as possible */
+      if (avail > todo) avail = todo;
+      sys->copy(self->d->i_ptr, buf, (size_t) avail);
+      self->d->i_ptr += avail;
+      buf  += avail;
+      todo -= avail;
+    }
+    else {
+      /* out of data, read a new block */
+
+      /* check if we're out of input blocks, advance block counter */
+      if (self->d->block++ >= self->d->folder->base.num_blocks) {
+        if (!self->salvage) {
+          self->read_error = MSPACK_ERR_DATAFORMAT;
+        }
+        else {
+          D(("Ran out of CAB input blocks prematurely"))
+        }
+        break;
+      }
+
+      /* read a block */
+      self->read_error = cabd_sys_read_block(sys, self->d, &outlen,
+        ignore_cksum, ignore_blocksize);
+      if (self->read_error) return -1;
+      self->d->outlen += outlen;
+
+      /* special Quantum hack -- trailer byte to allow the decompressor
+       * to realign itself. CAB Quantum blocks, unlike LZX blocks, can have
+       * anything from 0 to 4 trailing null bytes. */
+      if ((self->d->comp_type & cffoldCOMPTYPE_MASK)==cffoldCOMPTYPE_QUANTUM) {
+        *self->d->i_end++ = 0xFF;
+      }
+
+      /* is this the last block? */
+      if (self->d->block >= self->d->folder->base.num_blocks) {
+        if ((self->d->comp_type & cffoldCOMPTYPE_MASK) == cffoldCOMPTYPE_LZX) {
+          /* special LZX hack -- on the last block, inform LZX of the
+           * size of the output data stream. */
+          lzxd_set_output_length((struct lzxd_stream *) self->d->state, self->d->outlen);
+        }
+      }
+    } /* if (avail) */
+  } /* while (todo > 0) */
+  return bytes - todo;
+}
+
+static int cabd_sys_write(struct mspack_file *file, void *buffer, int bytes) {
+  struct mscab_decompressor_p *self = (struct mscab_decompressor_p *) file;
+  self->d->offset += bytes;
+  if (self->d->outfh) {
+    return self->system->write(self->d->outfh, buffer, bytes);
+  }
+  return bytes;
+}
+
+/***************************************
+ * CABD_SYS_READ_BLOCK
+ ***************************************
+ * reads a whole data block from a cab file. the block may span more than
+ * one cab file, if it does then the fragments will be reassembled
+ */
+static int cabd_sys_read_block(struct mspack_system *sys,
+                               struct mscabd_decompress_state *d,
+                               int *out, int ignore_cksum,
+                               int ignore_blocksize)
+{
+  unsigned char hdr[cfdata_SIZEOF];
+  unsigned int cksum;
+  int len, full_len;
+
+  /* reset the input block pointer and end of block pointer */
+  d->i_ptr = d->i_end = &d->input[0];
+
+  do {
+    /* read the block header */
+    if (sys->read(d->infh, &hdr[0], cfdata_SIZEOF) != cfdata_SIZEOF) {
+      return MSPACK_ERR_READ;
+    }
+
+    /* skip any reserved block headers */
+    if (d->data->cab->block_resv &&
+        sys->seek(d->infh, (off_t) d->data->cab->block_resv,
+                  MSPACK_SYS_SEEK_CUR))
+    {
+      return MSPACK_ERR_SEEK;
+    }
+
+    /* blocks must not be over CAB_INPUTMAX in size */
+    len = EndGetI16(&hdr[cfdata_CompressedSize]);
+    full_len = (d->i_end - d->i_ptr) + len; /* include cab-spanning blocks */
+    if (full_len > CAB_INPUTMAX) {
+      D(("block size %d > CAB_INPUTMAX", full_len));
+      /* in salvage mode, blocks can be 65535 bytes but no more than that */
+      if (!ignore_blocksize || full_len > CAB_INPUTMAX_SALVAGE) {
+          return MSPACK_ERR_DATAFORMAT;
+      }
+    }
+
+     /* blocks must not expand to more than CAB_BLOCKMAX */
+    if (EndGetI16(&hdr[cfdata_UncompressedSize]) > CAB_BLOCKMAX) {
+      D(("block size > CAB_BLOCKMAX"))
+      if (!ignore_blocksize) return MSPACK_ERR_DATAFORMAT;
+    }
+
+    /* read the block data */
+    if (sys->read(d->infh, d->i_end, len) != len) {
+      return MSPACK_ERR_READ;
+    }
+
+    /* perform checksum test on the block (if one is stored) */
+    if ((cksum = EndGetI32(&hdr[cfdata_CheckSum]))) {
+      unsigned int sum2 = cabd_checksum(d->i_end, (unsigned int) len, 0);
+      if (cabd_checksum(&hdr[4], 4, sum2) != cksum) {
+        if (!ignore_cksum) return MSPACK_ERR_CHECKSUM;
+        sys->message(d->infh, "WARNING; bad block checksum found");
+      }
+    }
+
+    /* advance end of block pointer to include newly read data */
+    d->i_end += len;
+
+    /* uncompressed size == 0 means this block was part of a split block
+     * and it continues as the first block of the next cabinet in the set.
+     * otherwise, this is the last part of the block, and no more block
+     * reading needs to be done.
+     */
+    /* EXIT POINT OF LOOP -- uncompressed size != 0 */
+    if ((*out = EndGetI16(&hdr[cfdata_UncompressedSize]))) {
+      return MSPACK_ERR_OK;
+    }
+
+    /* otherwise, advance to next cabinet */
+
+    /* close current file handle */
+    sys->close(d->infh);
+    d->infh = NULL;
+
+    /* advance to next member in the cabinet set */
+    if (!(d->data = d->data->next)) {
+      sys->message(d->infh, "WARNING; ran out of cabinets in set. Are any missing?");
+      return MSPACK_ERR_DATAFORMAT;
+    }
+
+    /* open next cab file */
+    d->incab = d->data->cab;
+    if (!(d->infh = sys->open(sys, d->incab->base.filename,
+                              MSPACK_SYS_OPEN_READ)))
+    {
+      return MSPACK_ERR_OPEN;
+    }
+
+    /* seek to start of data blocks */
+    if (sys->seek(d->infh, d->data->offset, MSPACK_SYS_SEEK_START)) {
+      return MSPACK_ERR_SEEK;
+    }
+  } while (1);
+
+  /* not reached */
+  return MSPACK_ERR_OK;
+}
+
+static unsigned int cabd_checksum(unsigned char *data, unsigned int bytes,
+                                  unsigned int cksum)
+{
+  unsigned int len, ul = 0;
+
+  for (len = bytes >> 2; len--; data += 4) {
+    cksum ^= EndGetI32(data);
+  }
+
+  switch (bytes & 3) {
+  case 3: ul |= *data++ << 16; /*@fallthrough@*/
+  case 2: ul |= *data++ <<  8; /*@fallthrough@*/
+  case 1: ul |= *data;
+  }
+  cksum ^= ul;
+
+  return cksum;
+}
+
+/***************************************
+ * NONED_INIT, NONED_DECOMPRESS, NONED_FREE
+ ***************************************
+ * the "not compressed" method decompressor
+ */
+struct noned_state {
+  struct mspack_system *sys;
+  struct mspack_file *i;
+  struct mspack_file *o;
+  unsigned char *buf;
+  int bufsize;
+};
+
+static struct noned_state *noned_init(struct mspack_system *sys,
+                                      struct mspack_file *in,
+                                      struct mspack_file *out,
+                                      int bufsize)
+{
+  struct noned_state *state = (struct noned_state *) sys->alloc(sys, sizeof(struct noned_state));
+  unsigned char *buf = (unsigned char *) sys->alloc(sys, (size_t) bufsize);
+  if (state && buf) {
+    state->sys     = sys;
+    state->i       = in;
+    state->o       = out;
+    state->buf     = buf;
+    state->bufsize = bufsize;
+  }
+  else {
+    sys->free(buf);
+    sys->free(state);
+    state = NULL;
+  }
+  return state;
+}
+
+static int noned_decompress(struct noned_state *s, off_t bytes) {
+  int run;
+  while (bytes > 0) {
+    run = (bytes > s->bufsize) ? s->bufsize : (int) bytes;
+    if (s->sys->read(s->i, &s->buf[0], run) != run) return MSPACK_ERR_READ;
+    if (s->sys->write(s->o, &s->buf[0], run) != run) return MSPACK_ERR_WRITE;
+    bytes -= run;
+  }
+  return MSPACK_ERR_OK;
+}
+
+static void noned_free(struct noned_state *state) {
+  struct mspack_system *sys;
+  if (state) {
+    sys = state->sys;
+    sys->free(state->buf);
+    sys->free(state);
+  }
+}
+
+
+/***************************************
+ * CABD_PARAM
+ ***************************************
+ * allows a parameter to be set
+ */
+static int cabd_param(struct mscab_decompressor *base, int param, int value) {
+  struct mscab_decompressor_p *self = (struct mscab_decompressor_p *) base;
+  if (!self) return MSPACK_ERR_ARGS;
+
+  switch (param) {
+  case MSCABD_PARAM_SEARCHBUF:
+    if (value < 4) return MSPACK_ERR_ARGS;
+    self->searchbuf_size = value;
+    break;
+  case MSCABD_PARAM_FIXMSZIP:
+    self->fix_mszip = value;
+    break;
+  case MSCABD_PARAM_DECOMPBUF:
+    if (value < 4) return MSPACK_ERR_ARGS;
+    self->buf_size = value;
+    break;
+  case MSCABD_PARAM_SALVAGE:
+    self->salvage = value;
+    break;
+  default:
+    return MSPACK_ERR_ARGS;
+  }
+  return MSPACK_ERR_OK;
+}
+
+/***************************************
+ * CABD_ERROR
+ ***************************************
+ * returns the last error that occurred
+ */
+static int cabd_error(struct mscab_decompressor *base) {
+  struct mscab_decompressor_p *self = (struct mscab_decompressor_p *) base;
+  return (self) ? self->error : MSPACK_ERR_ARGS;
+}

--- a/third_party/libmspack/mspack/crc32.c
+++ b/third_party/libmspack/mspack/crc32.c
@@ -1,0 +1,95 @@
+/*
+ *  COPYRIGHT (C) 1986 Gary S. Brown.  You may use this program, or
+ *  code or tables extracted from it, as desired without restriction.
+ *
+ *  First, the polynomial itself and its table of feedback terms.  The
+ *  polynomial is
+ *  X^32+X^26+X^23+X^22+X^16+X^12+X^11+X^10+X^8+X^7+X^5+X^4+X^2+X^1+X^0
+ *
+ *  Note that we take it "backwards" and put the highest-order term in
+ *  the lowest-order bit.  The X^32 term is "implied"; the LSB is the
+ *  X^31 term, etc.  The X^0 term (usually shown as "+1") results in
+ *  the MSB being 1
+ *
+ *  Note that the usual hardware shift register implementation, which
+ *  is what we're using (we're merely optimizing it by doing eight-bit
+ *  chunks at a time) shifts bits into the lowest-order term.  In our
+ *  implementation, that means shifting towards the right.  Why do we
+ *  do it this way?  Because the calculated CRC must be transmitted in
+ *  order from highest-order term to lowest-order term.  UARTs transmit
+ *  characters in order from LSB to MSB.  By storing the CRC this way
+ *  we hand it to the UART in the order low-byte to high-byte; the UART
+ *  sends each low-bit to hight-bit; and the result is transmission bit
+ *  by bit from highest- to lowest-order term without requiring any bit
+ *  shuffling on our part.  Reception works similarly
+ *
+ *  The feedback terms table consists of 256, 32-bit entries.  Notes
+ *
+ *      The table can be generated at runtime if desired; code to do so
+ *      is shown later.  It might not be obvious, but the feedback
+ *      terms simply represent the results of eight shift/xor opera
+ *      tions for all combinations of data and CRC register values
+ *
+ *      The values must be right-shifted by eight bits by the "updcrc
+ *      logic; the shift must be unsigned (bring in zeroes).  On some
+ *      hardware you could probably optimize the shift in assembler by
+ *      using byte-swap instructions
+ *      polynomial $edb88320
+ */
+
+#include "crc32.h"
+
+const unsigned int crc32_table[256] = {
+        0x00000000L, 0x77073096L, 0xee0e612cL, 0x990951baL, 0x076dc419L,
+        0x706af48fL, 0xe963a535L, 0x9e6495a3L, 0x0edb8832L, 0x79dcb8a4L,
+        0xe0d5e91eL, 0x97d2d988L, 0x09b64c2bL, 0x7eb17cbdL, 0xe7b82d07L,
+        0x90bf1d91L, 0x1db71064L, 0x6ab020f2L, 0xf3b97148L, 0x84be41deL,
+        0x1adad47dL, 0x6ddde4ebL, 0xf4d4b551L, 0x83d385c7L, 0x136c9856L,
+        0x646ba8c0L, 0xfd62f97aL, 0x8a65c9ecL, 0x14015c4fL, 0x63066cd9L,
+        0xfa0f3d63L, 0x8d080df5L, 0x3b6e20c8L, 0x4c69105eL, 0xd56041e4L,
+        0xa2677172L, 0x3c03e4d1L, 0x4b04d447L, 0xd20d85fdL, 0xa50ab56bL,
+        0x35b5a8faL, 0x42b2986cL, 0xdbbbc9d6L, 0xacbcf940L, 0x32d86ce3L,
+        0x45df5c75L, 0xdcd60dcfL, 0xabd13d59L, 0x26d930acL, 0x51de003aL,
+        0xc8d75180L, 0xbfd06116L, 0x21b4f4b5L, 0x56b3c423L, 0xcfba9599L,
+        0xb8bda50fL, 0x2802b89eL, 0x5f058808L, 0xc60cd9b2L, 0xb10be924L,
+        0x2f6f7c87L, 0x58684c11L, 0xc1611dabL, 0xb6662d3dL, 0x76dc4190L,
+        0x01db7106L, 0x98d220bcL, 0xefd5102aL, 0x71b18589L, 0x06b6b51fL,
+        0x9fbfe4a5L, 0xe8b8d433L, 0x7807c9a2L, 0x0f00f934L, 0x9609a88eL,
+        0xe10e9818L, 0x7f6a0dbbL, 0x086d3d2dL, 0x91646c97L, 0xe6635c01L,
+        0x6b6b51f4L, 0x1c6c6162L, 0x856530d8L, 0xf262004eL, 0x6c0695edL,
+        0x1b01a57bL, 0x8208f4c1L, 0xf50fc457L, 0x65b0d9c6L, 0x12b7e950L,
+        0x8bbeb8eaL, 0xfcb9887cL, 0x62dd1ddfL, 0x15da2d49L, 0x8cd37cf3L,
+        0xfbd44c65L, 0x4db26158L, 0x3ab551ceL, 0xa3bc0074L, 0xd4bb30e2L,
+        0x4adfa541L, 0x3dd895d7L, 0xa4d1c46dL, 0xd3d6f4fbL, 0x4369e96aL,
+        0x346ed9fcL, 0xad678846L, 0xda60b8d0L, 0x44042d73L, 0x33031de5L,
+        0xaa0a4c5fL, 0xdd0d7cc9L, 0x5005713cL, 0x270241aaL, 0xbe0b1010L,
+        0xc90c2086L, 0x5768b525L, 0x206f85b3L, 0xb966d409L, 0xce61e49fL,
+        0x5edef90eL, 0x29d9c998L, 0xb0d09822L, 0xc7d7a8b4L, 0x59b33d17L,
+        0x2eb40d81L, 0xb7bd5c3bL, 0xc0ba6cadL, 0xedb88320L, 0x9abfb3b6L,
+        0x03b6e20cL, 0x74b1d29aL, 0xead54739L, 0x9dd277afL, 0x04db2615L,
+        0x73dc1683L, 0xe3630b12L, 0x94643b84L, 0x0d6d6a3eL, 0x7a6a5aa8L,
+        0xe40ecf0bL, 0x9309ff9dL, 0x0a00ae27L, 0x7d079eb1L, 0xf00f9344L,
+        0x8708a3d2L, 0x1e01f268L, 0x6906c2feL, 0xf762575dL, 0x806567cbL,
+        0x196c3671L, 0x6e6b06e7L, 0xfed41b76L, 0x89d32be0L, 0x10da7a5aL,
+        0x67dd4accL, 0xf9b9df6fL, 0x8ebeeff9L, 0x17b7be43L, 0x60b08ed5L,
+        0xd6d6a3e8L, 0xa1d1937eL, 0x38d8c2c4L, 0x4fdff252L, 0xd1bb67f1L,
+        0xa6bc5767L, 0x3fb506ddL, 0x48b2364bL, 0xd80d2bdaL, 0xaf0a1b4cL,
+        0x36034af6L, 0x41047a60L, 0xdf60efc3L, 0xa867df55L, 0x316e8eefL,
+        0x4669be79L, 0xcb61b38cL, 0xbc66831aL, 0x256fd2a0L, 0x5268e236L,
+        0xcc0c7795L, 0xbb0b4703L, 0x220216b9L, 0x5505262fL, 0xc5ba3bbeL,
+        0xb2bd0b28L, 0x2bb45a92L, 0x5cb36a04L, 0xc2d7ffa7L, 0xb5d0cf31L,
+        0x2cd99e8bL, 0x5bdeae1dL, 0x9b64c2b0L, 0xec63f226L, 0x756aa39cL,
+        0x026d930aL, 0x9c0906a9L, 0xeb0e363fL, 0x72076785L, 0x05005713L,
+        0x95bf4a82L, 0xe2b87a14L, 0x7bb12baeL, 0x0cb61b38L, 0x92d28e9bL,
+        0xe5d5be0dL, 0x7cdcefb7L, 0x0bdbdf21L, 0x86d3d2d4L, 0xf1d4e242L,
+        0x68ddb3f8L, 0x1fda836eL, 0x81be16cdL, 0xf6b9265bL, 0x6fb077e1L,
+        0x18b74777L, 0x88085ae6L, 0xff0f6a70L, 0x66063bcaL, 0x11010b5cL,
+        0x8f659effL, 0xf862ae69L, 0x616bffd3L, 0x166ccf45L, 0xa00ae278L,
+        0xd70dd2eeL, 0x4e048354L, 0x3903b3c2L, 0xa7672661L, 0xd06016f7L,
+        0x4969474dL, 0x3e6e77dbL, 0xaed16a4aL, 0xd9d65adcL, 0x40df0b66L,
+        0x37d83bf0L, 0xa9bcae53L, 0xdebb9ec5L, 0x47b2cf7fL, 0x30b5ffe9L,
+        0xbdbdf21cL, 0xcabac28aL, 0x53b39330L, 0x24b4a3a6L, 0xbad03605L,
+        0xcdd70693L, 0x54de5729L, 0x23d967bfL, 0xb3667a2eL, 0xc4614ab8L,
+        0x5d681b02L, 0x2a6f2b94L, 0xb40bbe37L, 0xc30c8ea1L, 0x5a05df1bL,
+        0x2d02ef8dL
+};

--- a/third_party/libmspack/mspack/crc32.h
+++ b/third_party/libmspack/mspack/crc32.h
@@ -1,0 +1,17 @@
+#ifndef CRC32_H
+#define CRC32_H
+
+extern const unsigned int crc32_table[256];
+
+/* Return a 32-bit CRC of the contents of the buffer. */
+
+static inline unsigned int
+crc32(unsigned int val, const void *ss, int len)
+{
+        const unsigned char *s = ss;
+        while (--len >= 0)
+                val = crc32_table[(val ^ *s++) & 0xff] ^ (val >> 8);
+        return val;
+}
+
+#endif

--- a/third_party/libmspack/mspack/lzx.h
+++ b/third_party/libmspack/mspack/lzx.h
@@ -1,0 +1,220 @@
+/* This file is part of libmspack.
+ * (C) 2003-2013 Stuart Caie.
+ *
+ * The LZX method was created by Jonathan Forbes and Tomi Poutanen, adapted
+ * by Microsoft Corporation.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+#ifndef MSPACK_LZX_H
+#define MSPACK_LZX_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* LZX compression / decompression definitions */
+
+/* some constants defined by the LZX specification */
+#define LZX_MIN_MATCH                (2)
+#define LZX_MAX_MATCH                (257)
+#define LZX_NUM_CHARS                (256)
+#define LZX_BLOCKTYPE_INVALID        (0)   /* also blocktypes 4-7 invalid */
+#define LZX_BLOCKTYPE_VERBATIM       (1)
+#define LZX_BLOCKTYPE_ALIGNED        (2)
+#define LZX_BLOCKTYPE_UNCOMPRESSED   (3)
+#define LZX_PRETREE_NUM_ELEMENTS     (20)
+#define LZX_ALIGNED_NUM_ELEMENTS     (8)   /* aligned offset tree #elements */
+#define LZX_NUM_PRIMARY_LENGTHS      (7)   /* this one missing from spec! */
+#define LZX_NUM_SECONDARY_LENGTHS    (249) /* length tree #elements */
+
+/* LZX huffman defines: tweak tablebits as desired */
+#define LZX_PRETREE_MAXSYMBOLS  (LZX_PRETREE_NUM_ELEMENTS)
+#define LZX_PRETREE_TABLEBITS   (6)
+#define LZX_MAINTREE_MAXSYMBOLS (LZX_NUM_CHARS + 290*8)
+#define LZX_MAINTREE_TABLEBITS  (12)
+#define LZX_LENGTH_MAXSYMBOLS   (LZX_NUM_SECONDARY_LENGTHS+1)
+#define LZX_LENGTH_TABLEBITS    (12)
+#define LZX_ALIGNED_MAXSYMBOLS  (LZX_ALIGNED_NUM_ELEMENTS)
+#define LZX_ALIGNED_TABLEBITS   (7)
+#define LZX_LENTABLE_SAFETY (64)  /* table decoding overruns are allowed */
+
+#define LZX_FRAME_SIZE (32768) /* the size of a frame in LZX */
+
+struct lzxd_stream {
+  struct mspack_system *sys;      /* I/O routines                            */
+  struct mspack_file   *input;    /* input file handle                       */
+  struct mspack_file   *output;   /* output file handle                      */
+
+  off_t   offset;                 /* number of bytes actually output         */
+  off_t   length;                 /* overall decompressed length of stream   */
+
+  unsigned char *window;          /* decoding window                         */
+  unsigned int   window_size;     /* window size                             */
+  unsigned int   ref_data_size;   /* LZX DELTA reference data size           */
+  unsigned int   num_offsets;     /* number of match_offset entries in table */
+  unsigned int   window_posn;     /* decompression offset within window      */
+  unsigned int   frame_posn;      /* current frame offset within in window   */
+  unsigned int   frame;           /* the number of 32kb frames processed     */
+  unsigned int   reset_interval;  /* which frame do we reset the compressor? */
+
+  unsigned int   R0, R1, R2;      /* for the LRU offset system               */
+  unsigned int   block_length;    /* uncompressed length of this LZX block   */
+  unsigned int   block_remaining; /* uncompressed bytes still left to decode */
+
+  signed int     intel_filesize;  /* magic header value used for transform   */
+
+  unsigned char  intel_started;   /* has intel E8 decoding started?          */
+  unsigned char  block_type;      /* type of the current block               */
+  unsigned char  header_read;     /* have we started decoding at all yet?    */
+  unsigned char  input_end;       /* have we reached the end of input?       */
+  unsigned char  is_delta;        /* does stream follow LZX DELTA spec?      */
+
+  int error;
+
+  /* I/O buffering */
+  unsigned char *inbuf, *i_ptr, *i_end, *o_ptr, *o_end;
+  unsigned int  bit_buffer, bits_left, inbuf_size;
+
+  /* huffman code lengths */
+  unsigned char PRETREE_len  [LZX_PRETREE_MAXSYMBOLS  + LZX_LENTABLE_SAFETY];
+  unsigned char MAINTREE_len [LZX_MAINTREE_MAXSYMBOLS + LZX_LENTABLE_SAFETY];
+  unsigned char LENGTH_len   [LZX_LENGTH_MAXSYMBOLS   + LZX_LENTABLE_SAFETY];
+  unsigned char ALIGNED_len  [LZX_ALIGNED_MAXSYMBOLS  + LZX_LENTABLE_SAFETY];
+
+  /* huffman decoding tables */
+  unsigned short PRETREE_table [(1 << LZX_PRETREE_TABLEBITS) +
+                                (LZX_PRETREE_MAXSYMBOLS * 2)];
+  unsigned short MAINTREE_table[(1 << LZX_MAINTREE_TABLEBITS) +
+                                (LZX_MAINTREE_MAXSYMBOLS * 2)];
+  unsigned short LENGTH_table  [(1 << LZX_LENGTH_TABLEBITS) +
+                                (LZX_LENGTH_MAXSYMBOLS * 2)];
+  unsigned short ALIGNED_table [(1 << LZX_ALIGNED_TABLEBITS) +
+                                (LZX_ALIGNED_MAXSYMBOLS * 2)];
+  unsigned char LENGTH_empty;
+
+  /* this is used purely for doing the intel E8 transform */
+  unsigned char  e8_buf[LZX_FRAME_SIZE];
+};
+
+/**
+ * Allocates and initialises LZX decompression state for decoding an LZX
+ * stream.
+ *
+ * This routine uses system->alloc() to allocate memory. If memory
+ * allocation fails, or the parameters to this function are invalid,
+ * NULL is returned.
+ *
+ * @param system             an mspack_system structure used to read from
+ *                           the input stream and write to the output
+ *                           stream, also to allocate and free memory.
+ * @param input              an input stream with the LZX data.
+ * @param output             an output stream to write the decoded data to.
+ * @param window_bits        the size of the decoding window, which must be
+ *                           between 15 and 21 inclusive for regular LZX
+ *                           data, or between 17 and 25 inclusive for
+ *                           LZX DELTA data.
+ * @param reset_interval     the interval at which the LZX bitstream is
+ *                           reset, in multiples of LZX frames (32678
+ *                           bytes), e.g. a value of 2 indicates the input
+ *                           stream resets after every 65536 output bytes.
+ *                           A value of 0 indicates that the bitstream never
+ *                           resets, such as in CAB LZX streams.
+ * @param input_buffer_size  the number of bytes to use as an input
+ *                           bitstream buffer.
+ * @param output_length      the length in bytes of the entirely
+ *                           decompressed output stream, if known in
+ *                           advance. It is used to correctly perform the
+ *                           Intel E8 transformation, which must stop 6
+ *                           bytes before the very end of the
+ *                           decompressed stream. It is not otherwise used
+ *                           or adhered to. If the full decompressed
+ *                           length is known in advance, set it here.
+ *                           If it is NOT known, use the value 0, and call
+ *                           lzxd_set_output_length() once it is
+ *                           known. If never set, 4 of the final 6 bytes
+ *                           of the output stream may be incorrect.
+ * @param is_delta           should be zero for all regular LZX data,
+ *                           non-zero for LZX DELTA encoded data.
+ * @return a pointer to an initialised lzxd_stream structure, or NULL if
+ * there was not enough memory or parameters to the function were wrong.
+ */
+extern struct lzxd_stream *lzxd_init(struct mspack_system *system,
+                                     struct mspack_file *input,
+                                     struct mspack_file *output,
+                                     int window_bits,
+                                     int reset_interval,
+                                     int input_buffer_size,
+                                     off_t output_length,
+                                     char is_delta);
+
+/* see description of output_length in lzxd_init() */
+extern void lzxd_set_output_length(struct lzxd_stream *lzx,
+                                   off_t output_length);
+
+/**
+ * Reads LZX DELTA reference data into the window and allows
+ * lzxd_decompress() to reference it.
+ *
+ * Call this before the first call to lzxd_decompress().
+
+ * @param lzx    the LZX stream to apply this reference data to
+ * @param system an mspack_system implementation to use with the
+ *               input param. Only read() will be called.
+ * @param input  an input file handle to read reference data using
+ *               system->read().
+ * @param length the length of the reference data. Cannot be longer
+ *               than the LZX window size.
+ * @return an error code, or MSPACK_ERR_OK if successful
+ */
+extern int lzxd_set_reference_data(struct lzxd_stream *lzx,
+                                   struct mspack_system *system,
+                                   struct mspack_file *input,
+                                   unsigned int length);
+
+/**
+ * Decompresses entire or partial LZX streams.
+ *
+ * The number of bytes of data that should be decompressed is given as the
+ * out_bytes parameter. If more bytes are decoded than are needed, they
+ * will be kept over for a later invocation.
+ *
+ * The output bytes will be passed to the system->write() function given in
+ * lzxd_init(), using the output file handle given in lzxd_init(). More than
+ * one call may be made to system->write().
+
+ * Input bytes will be read in as necessary using the system->read()
+ * function given in lzxd_init(), using the input file handle given in
+ * lzxd_init().  This will continue until system->read() returns 0 bytes,
+ * or an error. Errors will be passed out of the function as
+ * MSPACK_ERR_READ errors.  Input streams should convey an "end of input
+ * stream" by refusing to supply all the bytes that LZX asks for when they
+ * reach the end of the stream, rather than return an error code.
+ *
+ * If any error code other than MSPACK_ERR_OK is returned, the stream
+ * should be considered unusable and lzxd_decompress() should not be
+ * called again on this stream.
+ *
+ * @param lzx       LZX decompression state, as allocated by lzxd_init().
+ * @param out_bytes the number of bytes of data to decompress.
+ * @return an error code, or MSPACK_ERR_OK if successful
+ */
+extern int lzxd_decompress(struct lzxd_stream *lzx, off_t out_bytes);
+
+/**
+ * Frees all state associated with an LZX data stream. This will call
+ * system->free() using the system pointer given in lzxd_init().
+ *
+ * @param lzx LZX decompression state to free.
+ */
+void lzxd_free(struct lzxd_stream *lzx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/third_party/libmspack/mspack/lzxd.c
+++ b/third_party/libmspack/mspack/lzxd.c
@@ -1,0 +1,781 @@
+/* This file is part of libmspack.
+ * (C) 2003-2023 Stuart Caie.
+ *
+ * The LZX method was created by Jonathan Forbes and Tomi Poutanen, adapted
+ * by Microsoft Corporation.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+/* LZX decompression implementation */
+
+#include <system.h>
+#include <lzx.h>
+
+/* Microsoft's LZX document (in cab-sdk.exe) and their implementation
+ * of the com.ms.util.cab Java package do not concur.
+ *
+ * In the LZX document, there is a table showing the correlation between
+ * window size and the number of position slots. It states that the 1MB
+ * window = 40 slots and the 2MB window = 42 slots. In the implementation,
+ * 1MB = 42 slots, 2MB = 50 slots. The actual calculation is 'find the
+ * first slot whose position base is equal to or more than the required
+ * window size'. This would explain why other tables in the document refer
+ * to 50 slots rather than 42.
+ *
+ * The constant NUM_PRIMARY_LENGTHS used in the decompression pseudocode
+ * is not defined in the specification.
+ *
+ * The LZX document does not state the uncompressed block has an
+ * uncompressed length field. Where does this length field come from, so
+ * we can know how large the block is? The implementation has it as the 24
+ * bits following after the 3 blocktype bits, before the alignment
+ * padding.
+ *
+ * The LZX document states that aligned offset blocks have their aligned
+ * offset huffman tree AFTER the main and length trees. The implementation
+ * suggests that the aligned offset tree is BEFORE the main and length
+ * trees.
+ *
+ * The LZX document decoding algorithm states that, in an aligned offset
+ * block, if an extra_bits value is 1, 2 or 3, then that number of bits
+ * should be read and the result added to the match offset. This is
+ * correct for 1 and 2, but not 3, where just a huffman symbol (using the
+ * aligned tree) should be read.
+ *
+ * Regarding the E8 preprocessing, the LZX document states 'No translation
+ * may be performed on the last 6 bytes of the input block'. This is
+ * correct.  However, the pseudocode provided checks for the *E8 leader*
+ * up to the last 6 bytes. If the leader appears between -10 and -7 bytes
+ * from the end, this would cause the next four bytes to be modified, at
+ * least one of which would be in the last 6 bytes, which is not allowed
+ * according to the spec.
+ *
+ * The specification states that the huffman trees must always contain at
+ * least one element. However, many CAB files contain blocks where the
+ * length tree is completely empty (because there are no matches), and
+ * this is expected to succeed.
+ *
+ * The errors in LZX documentation appear have been corrected in the
+ * new documentation for the LZX DELTA format.
+ *
+ *     http://msdn.microsoft.com/en-us/library/cc483133.aspx
+ *
+ * However, this is a different format, an extension of regular LZX.
+ * I have noticed the following differences, there may be more:
+ *
+ * The maximum window size has increased from 2MB to 32MB. This also
+ * increases the maximum number of position slots, etc.
+ *
+ * If the match length is 257 (the maximum possible), this signals
+ * a further length decoding step, that allows for matches up to
+ * 33024 bytes long.
+ *
+ * The format now allows for "reference data", supplied by the caller.
+ * If match offsets go further back than the number of bytes
+ * decompressed so far, that is them accessing the reference data.
+ */
+
+/* import bit-reading macros and code */
+#define BITS_TYPE struct lzxd_stream
+#define BITS_VAR lzx
+#define BITS_ORDER_MSB
+#define READ_BYTES do {                 \
+    unsigned char b0, b1;               \
+    READ_IF_NEEDED; b0 = *i_ptr++;      \
+    READ_IF_NEEDED; b1 = *i_ptr++;      \
+    INJECT_BITS((b1 << 8) | b0, 16);    \
+} while (0)
+#include <readbits.h>
+
+/* import huffman-reading macros and code */
+#define TABLEBITS(tbl)      LZX_##tbl##_TABLEBITS
+#define MAXSYMBOLS(tbl)     LZX_##tbl##_MAXSYMBOLS
+#define HUFF_TABLE(tbl,idx) lzx->tbl##_table[idx]
+#define HUFF_LEN(tbl,idx)   lzx->tbl##_len[idx]
+#define HUFF_ERROR          return lzx->error = MSPACK_ERR_DECRUNCH
+#include <readhuff.h>
+
+/* BUILD_TABLE(tbl) builds a huffman lookup table from code lengths */
+#define BUILD_TABLE(tbl)                                                \
+    if (make_decode_table(MAXSYMBOLS(tbl), TABLEBITS(tbl),              \
+                          &HUFF_LEN(tbl,0), &HUFF_TABLE(tbl,0)))        \
+    {                                                                   \
+        D(("failed to build %s table", #tbl))                           \
+        return lzx->error = MSPACK_ERR_DECRUNCH;                        \
+    }
+
+#define BUILD_TABLE_MAYBE_EMPTY(tbl) do {                               \
+    lzx->tbl##_empty = 0;                                               \
+    if (make_decode_table(MAXSYMBOLS(tbl), TABLEBITS(tbl),              \
+                          &HUFF_LEN(tbl,0), &HUFF_TABLE(tbl,0)))        \
+    {                                                                   \
+        for (i = 0; i < MAXSYMBOLS(tbl); i++) {                         \
+            if (HUFF_LEN(tbl, i) > 0) {                                 \
+                D(("failed to build %s table", #tbl))                   \
+                return lzx->error = MSPACK_ERR_DECRUNCH;                \
+            }                                                           \
+        }                                                               \
+        /* empty tree - allow it, but don't decode symbols with it */   \
+        lzx->tbl##_empty = 1;                                           \
+    }                                                                   \
+} while (0)
+
+/* READ_LENGTHS(tablename, first, last) reads in code lengths for symbols
+ * first to last in the given table. The code lengths are stored in their
+ * own special LZX way.
+ */
+#define READ_LENGTHS(tbl, first, last) do {             \
+  STORE_BITS;                                           \
+  if (lzxd_read_lens(lzx, &HUFF_LEN(tbl, 0), (first),   \
+    (unsigned int)(last))) return lzx->error;           \
+  RESTORE_BITS;                                         \
+} while (0)
+
+static int lzxd_read_lens(struct lzxd_stream *lzx, unsigned char *lens,
+                          unsigned int first, unsigned int last)
+{
+  DECLARE_HUFF_VARS;
+  unsigned int x, y;
+  int z;
+
+  RESTORE_BITS;
+  
+  /* read lengths for pretree (20 symbols, lengths stored in fixed 4 bits) */
+  for (x = 0; x < 20; x++) {
+    READ_BITS(y, 4);
+    lzx->PRETREE_len[x] = y;
+  }
+  BUILD_TABLE(PRETREE);
+
+  for (x = first; x < last; ) {
+    READ_HUFFSYM(PRETREE, z);
+    if (z == 17) {
+      /* code = 17, run of ([read 4 bits]+4) zeros */
+      READ_BITS(y, 4); y += 4;
+      while (y--) lens[x++] = 0;
+    }
+    else if (z == 18) {
+      /* code = 18, run of ([read 5 bits]+20) zeros */
+      READ_BITS(y, 5); y += 20;
+      while (y--) lens[x++] = 0;
+    }
+    else if (z == 19) {
+      /* code = 19, run of ([read 1 bit]+4) [read huffman symbol] */
+      READ_BITS(y, 1); y += 4;
+      READ_HUFFSYM(PRETREE, z);
+      z = lens[x] - z; if (z < 0) z += 17;
+      while (y--) lens[x++] = z;
+    }
+    else {
+      /* code = 0 to 16, delta current length entry */
+      z = lens[x] - z; if (z < 0) z += 17;
+      lens[x++] = z;
+    }
+  }
+
+  STORE_BITS;
+
+  return MSPACK_ERR_OK;
+}
+
+/* LZX static data tables:
+ *
+ * LZX uses 'position slots' to represent match offsets.  For every match,
+ * a small 'position slot' number and a small offset from that slot are
+ * encoded instead of one large offset.
+ *
+ * The number of slots is decided by how many are needed to encode the
+ * largest offset for a given window size. This is easy when the gap between
+ * slots is less than 128Kb, it's a linear relationship. But when extra_bits
+ * reaches its limit of 17 (because LZX can only ensure reading 17 bits of
+ * data at a time), we can only jump 128Kb at a time and have to start
+ * using more and more position slots as each window size doubles.
+ *
+ * position_base[] is an index to the position slot bases
+ *
+ * extra_bits[] states how many bits of offset-from-base data is needed.
+ *
+ * They are calculated as follows:
+ * extra_bits[i] = 0 where i < 4
+ * extra_bits[i] = floor(i/2)-1 where i >= 4 && i < 36
+ * extra_bits[i] = 17 where i >= 36
+ * position_base[0] = 0
+ * position_base[i] = position_base[i-1] + (1 << extra_bits[i-1])
+ */
+static const unsigned int position_slots[11] = {
+    30, 32, 34, 36, 38, 42, 50, 66, 98, 162, 290
+};
+static const unsigned char extra_bits[36] = {
+    0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8,
+    9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16
+};
+static const unsigned int position_base[290] = {
+    0, 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128, 192, 256, 384, 512,
+    768, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 12288, 16384, 24576, 32768,
+    49152, 65536, 98304, 131072, 196608, 262144, 393216, 524288, 655360,
+    786432, 917504, 1048576, 1179648, 1310720, 1441792, 1572864, 1703936,
+    1835008, 1966080, 2097152, 2228224, 2359296, 2490368, 2621440, 2752512,
+    2883584, 3014656, 3145728, 3276800, 3407872, 3538944, 3670016, 3801088,
+    3932160, 4063232, 4194304, 4325376, 4456448, 4587520, 4718592, 4849664,
+    4980736, 5111808, 5242880, 5373952, 5505024, 5636096, 5767168, 5898240,
+    6029312, 6160384, 6291456, 6422528, 6553600, 6684672, 6815744, 6946816,
+    7077888, 7208960, 7340032, 7471104, 7602176, 7733248, 7864320, 7995392,
+    8126464, 8257536, 8388608, 8519680, 8650752, 8781824, 8912896, 9043968,
+    9175040, 9306112, 9437184, 9568256, 9699328, 9830400, 9961472, 10092544,
+    10223616, 10354688, 10485760, 10616832, 10747904, 10878976, 11010048,
+    11141120, 11272192, 11403264, 11534336, 11665408, 11796480, 11927552,
+    12058624, 12189696, 12320768, 12451840, 12582912, 12713984, 12845056,
+    12976128, 13107200, 13238272, 13369344, 13500416, 13631488, 13762560,
+    13893632, 14024704, 14155776, 14286848, 14417920, 14548992, 14680064,
+    14811136, 14942208, 15073280, 15204352, 15335424, 15466496, 15597568,
+    15728640, 15859712, 15990784, 16121856, 16252928, 16384000, 16515072,
+    16646144, 16777216, 16908288, 17039360, 17170432, 17301504, 17432576,
+    17563648, 17694720, 17825792, 17956864, 18087936, 18219008, 18350080,
+    18481152, 18612224, 18743296, 18874368, 19005440, 19136512, 19267584,
+    19398656, 19529728, 19660800, 19791872, 19922944, 20054016, 20185088,
+    20316160, 20447232, 20578304, 20709376, 20840448, 20971520, 21102592,
+    21233664, 21364736, 21495808, 21626880, 21757952, 21889024, 22020096,
+    22151168, 22282240, 22413312, 22544384, 22675456, 22806528, 22937600,
+    23068672, 23199744, 23330816, 23461888, 23592960, 23724032, 23855104,
+    23986176, 24117248, 24248320, 24379392, 24510464, 24641536, 24772608,
+    24903680, 25034752, 25165824, 25296896, 25427968, 25559040, 25690112,
+    25821184, 25952256, 26083328, 26214400, 26345472, 26476544, 26607616,
+    26738688, 26869760, 27000832, 27131904, 27262976, 27394048, 27525120,
+    27656192, 27787264, 27918336, 28049408, 28180480, 28311552, 28442624,
+    28573696, 28704768, 28835840, 28966912, 29097984, 29229056, 29360128,
+    29491200, 29622272, 29753344, 29884416, 30015488, 30146560, 30277632,
+    30408704, 30539776, 30670848, 30801920, 30932992, 31064064, 31195136,
+    31326208, 31457280, 31588352, 31719424, 31850496, 31981568, 32112640,
+    32243712, 32374784, 32505856, 32636928, 32768000, 32899072, 33030144,
+    33161216, 33292288, 33423360
+};
+
+static void lzxd_reset_state(struct lzxd_stream *lzx) {
+  int i;
+
+  lzx->R0              = 1;
+  lzx->R1              = 1;
+  lzx->R2              = 1;
+  lzx->header_read     = 0;
+  lzx->block_remaining = 0;
+  lzx->block_type      = LZX_BLOCKTYPE_INVALID;
+
+  /* initialise tables to 0 (because deltas will be applied to them) */
+  for (i = 0; i < LZX_MAINTREE_MAXSYMBOLS; i++) lzx->MAINTREE_len[i] = 0;
+  for (i = 0; i < LZX_LENGTH_MAXSYMBOLS; i++)   lzx->LENGTH_len[i]   = 0;
+}
+
+/*-------- main LZX code --------*/
+
+struct lzxd_stream *lzxd_init(struct mspack_system *system,
+                              struct mspack_file *input,
+                              struct mspack_file *output,
+                              int window_bits,
+                              int reset_interval,
+                              int input_buffer_size,
+                              off_t output_length,
+                              char is_delta)
+{
+  unsigned int window_size = 1 << window_bits;
+  struct lzxd_stream *lzx;
+
+  if (!system) return NULL;
+
+  /* LZX DELTA window sizes are between 2^17 (128KiB) and 2^25 (32MiB),
+   * regular LZX windows are between 2^15 (32KiB) and 2^21 (2MiB)
+   */
+  if (is_delta) {
+      if (window_bits < 17 || window_bits > 25) return NULL;
+  }
+  else {
+      if (window_bits < 15 || window_bits > 21) return NULL;
+  }
+
+  if (reset_interval < 0 || output_length < 0) {
+      D(("reset interval or output length < 0"))
+      return NULL;
+  }
+
+  /* round up input buffer size to multiple of two */
+  input_buffer_size = (input_buffer_size + 1) & -2;
+  if (input_buffer_size < 2) return NULL;
+
+  /* allocate decompression state */
+  if (!(lzx = (struct lzxd_stream *) system->alloc(system, sizeof(struct lzxd_stream)))) {
+    return NULL;
+  }
+
+  /* allocate decompression window and input buffer */
+  lzx->window = (unsigned char *) system->alloc(system, window_size);
+  lzx->inbuf  = (unsigned char *) system->alloc(system, input_buffer_size);
+  if (!lzx->window || !lzx->inbuf) {
+    system->free(lzx->window);
+    system->free(lzx->inbuf);
+    system->free(lzx);
+    return NULL;
+  }
+
+  /* initialise decompression state */
+  lzx->sys             = system;
+  lzx->input           = input;
+  lzx->output          = output;
+  lzx->offset          = 0;
+  lzx->length          = output_length;
+
+  lzx->inbuf_size      = input_buffer_size;
+  lzx->window_size     = 1 << window_bits;
+  lzx->ref_data_size   = 0;
+  lzx->window_posn     = 0;
+  lzx->frame_posn      = 0;
+  lzx->frame           = 0;
+  lzx->reset_interval  = reset_interval;
+  lzx->intel_filesize  = 0;
+  lzx->intel_started   = 0;
+  lzx->error           = MSPACK_ERR_OK;
+  lzx->num_offsets     = position_slots[window_bits - 15] << 3;
+  lzx->is_delta        = is_delta;
+
+  lzx->o_ptr = lzx->o_end = &lzx->e8_buf[0];
+  lzxd_reset_state(lzx);
+  INIT_BITS;
+  return lzx;
+}
+
+int lzxd_set_reference_data(struct lzxd_stream *lzx,
+                            struct mspack_system *system,
+                            struct mspack_file *input,
+                            unsigned int length)
+{
+    if (!lzx) return MSPACK_ERR_ARGS;
+
+    if (!lzx->is_delta) {
+        D(("only LZX DELTA streams support reference data"))
+        return MSPACK_ERR_ARGS;
+    }
+    if (lzx->offset) {
+        D(("too late to set reference data after decoding starts"))
+        return MSPACK_ERR_ARGS;
+    }
+    if (length > lzx->window_size) {
+        D(("reference length (%u) is longer than the window", length))
+        return MSPACK_ERR_ARGS;
+    }
+    if (length > 0 && (!system || !input)) {
+        D(("length > 0 but no system or input"))
+        return MSPACK_ERR_ARGS;
+    }
+
+    lzx->ref_data_size = length;
+    if (length > 0) {
+        /* copy reference data */
+        unsigned char *pos = &lzx->window[lzx->window_size - length];
+        int bytes = system->read(input, pos, length);
+        /* length can't be more than 2^25, so no signedness problem */
+        if (bytes < (int)length) return MSPACK_ERR_READ;
+    }
+    lzx->ref_data_size = length;
+    return MSPACK_ERR_OK;
+}
+
+void lzxd_set_output_length(struct lzxd_stream *lzx, off_t out_bytes) {
+  if (lzx && out_bytes > 0) lzx->length = out_bytes;
+}
+
+int lzxd_decompress(struct lzxd_stream *lzx, off_t out_bytes) {
+  DECLARE_HUFF_VARS;
+  unsigned char *window, *runsrc, *rundest, buf[12], warned = 0;
+  unsigned int frame_size, end_frame, window_posn, R0, R1, R2;
+  int bytes_todo, this_run, i, j;
+
+  /* easy answers */
+  if (!lzx || (out_bytes < 0)) return MSPACK_ERR_ARGS;
+  if (lzx->error) return lzx->error;
+
+  /* flush out any stored-up bytes before we begin */
+  i = lzx->o_end - lzx->o_ptr;
+  if ((off_t) i > out_bytes) i = (int) out_bytes;
+  if (i) {
+    if (lzx->sys->write(lzx->output, lzx->o_ptr, i) != i) {
+      return lzx->error = MSPACK_ERR_WRITE;
+    }
+    lzx->o_ptr  += i;
+    lzx->offset += i;
+    out_bytes   -= i;
+  }
+  if (out_bytes == 0) return MSPACK_ERR_OK;
+
+  /* restore local state */
+  RESTORE_BITS;
+  window = lzx->window;
+  window_posn = lzx->window_posn;
+  R0 = lzx->R0;
+  R1 = lzx->R1;
+  R2 = lzx->R2;
+
+  end_frame = (unsigned int)((lzx->offset + out_bytes) / LZX_FRAME_SIZE) + 1;
+
+  while (lzx->frame < end_frame) {
+    /* have we reached the reset interval? (if there is one?) */
+    if (lzx->reset_interval && ((lzx->frame % lzx->reset_interval) == 0)) {
+      if (lzx->block_remaining) {
+        /* this is a file format error, we can make a best effort to extract what we can */
+        D(("%d bytes remaining at reset interval", lzx->block_remaining))
+        if (!warned) {
+          lzx->sys->message(NULL, "WARNING; invalid reset interval detected during LZX decompression");
+          warned++;
+        }
+      }
+
+      /* re-read the intel header and reset the huffman lengths */
+      lzxd_reset_state(lzx);
+      R0 = lzx->R0;
+      R1 = lzx->R1;
+      R2 = lzx->R2;
+    }
+
+    /* LZX DELTA format has chunk_size, not present in LZX format */
+    if (lzx->is_delta) {
+      ENSURE_BITS(16);
+      REMOVE_BITS(16);
+    }
+
+    /* read header if necessary */
+    if (!lzx->header_read) {
+      /* read 1 bit. if bit=0, intel filesize = 0.
+       * if bit=1, read intel filesize (32 bits) */
+      j = 0; READ_BITS(i, 1); if (i) { READ_BITS(i, 16); READ_BITS(j, 16); }
+      lzx->intel_filesize = (i << 16) | j;
+      lzx->header_read = 1;
+    } 
+
+    /* calculate size of frame: all frames are 32k except the final frame
+     * which is 32kb or less. this can only be calculated when lzx->length
+     * has been filled in. */
+    frame_size = LZX_FRAME_SIZE;
+    if (lzx->length && (lzx->length - lzx->offset) < (off_t)frame_size) {
+      frame_size = lzx->length - lzx->offset;
+    }
+
+    /* decode until one more frame is available */
+    bytes_todo = lzx->frame_posn + frame_size - window_posn;
+    while (bytes_todo > 0) {
+      /* initialise new block, if one is needed */
+      if (lzx->block_remaining == 0) {
+        /* realign if previous block was an odd-sized UNCOMPRESSED block */
+        if ((lzx->block_type == LZX_BLOCKTYPE_UNCOMPRESSED) &&
+            (lzx->block_length & 1))
+        {
+          READ_IF_NEEDED;
+          i_ptr++;
+        }
+
+        /* read block type (3 bits) and block length (24 bits) */
+        READ_BITS(lzx->block_type, 3);
+        READ_BITS(i, 16); READ_BITS(j, 8);
+        lzx->block_remaining = lzx->block_length = (i << 8) | j;
+        /*D(("new block t%d len %u", lzx->block_type, lzx->block_length))*/
+
+        /* read individual block headers */
+        switch (lzx->block_type) {
+        case LZX_BLOCKTYPE_ALIGNED:
+          /* read lengths of and build aligned huffman decoding tree */
+          for (i = 0; i < 8; i++) { READ_BITS(j, 3); lzx->ALIGNED_len[i] = j; }
+          BUILD_TABLE(ALIGNED);
+          /* rest of aligned header is same as verbatim */ /*@fallthrough@*/
+        case LZX_BLOCKTYPE_VERBATIM:
+          /* read lengths of and build main huffman decoding tree */
+          READ_LENGTHS(MAINTREE, 0, 256);
+          READ_LENGTHS(MAINTREE, 256, LZX_NUM_CHARS + lzx->num_offsets);
+          BUILD_TABLE(MAINTREE);
+          /* if the literal 0xE8 is anywhere in the block... */
+          if (lzx->MAINTREE_len[0xE8] != 0) lzx->intel_started = 1;
+          /* read lengths of and build lengths huffman decoding tree */
+          READ_LENGTHS(LENGTH, 0, LZX_NUM_SECONDARY_LENGTHS);
+          BUILD_TABLE_MAYBE_EMPTY(LENGTH);
+          break;
+
+        case LZX_BLOCKTYPE_UNCOMPRESSED:
+          /* because we can't assume otherwise */
+          lzx->intel_started = 1;
+
+          /* read 1-16 (not 0-15) bits to align to bytes */
+          if (bits_left == 0) ENSURE_BITS(16);
+          bits_left = 0; bit_buffer = 0;
+
+          /* read 12 bytes of stored R0 / R1 / R2 values */
+          for (rundest = &buf[0], i = 0; i < 12; i++) {
+            READ_IF_NEEDED;
+            *rundest++ = *i_ptr++;
+          }
+          R0 = EndGetI32(&buf[0]);
+          R1 = EndGetI32(&buf[4]);
+          R2 = EndGetI32(&buf[8]);
+          break;
+
+        default:
+          D(("bad block type"))
+          return lzx->error = MSPACK_ERR_DECRUNCH;
+        }
+      }
+
+      /* decode more of the block:
+       * run = min(what's available, what's needed) */
+      this_run = lzx->block_remaining;
+      if (this_run > bytes_todo) this_run = bytes_todo;
+
+      /* assume we decode exactly this_run bytes, for now */
+      bytes_todo           -= this_run;
+      lzx->block_remaining -= this_run;
+
+      /* decode at least this_run bytes */
+      switch (lzx->block_type) {
+      case LZX_BLOCKTYPE_ALIGNED:
+      case LZX_BLOCKTYPE_VERBATIM:
+        while (this_run > 0) {
+	  int main_element, length_footer, verbatim_bits, aligned_bits, extra;
+	  int match_length;
+	  unsigned int match_offset;
+          READ_HUFFSYM(MAINTREE, main_element);
+          if (main_element < LZX_NUM_CHARS) {
+            /* literal: 0 to LZX_NUM_CHARS-1 */
+            window[window_posn++] = main_element;
+            this_run--;
+          }
+          else {
+            /* match: LZX_NUM_CHARS + ((slot<<3) | length_header (3 bits)) */
+            main_element -= LZX_NUM_CHARS;
+
+            /* get match length */
+            match_length = main_element & LZX_NUM_PRIMARY_LENGTHS;
+            if (match_length == LZX_NUM_PRIMARY_LENGTHS) {
+              if (lzx->LENGTH_empty) {
+                D(("LENGTH symbol needed but tree is empty"))
+                return lzx->error = MSPACK_ERR_DECRUNCH;
+              }
+              READ_HUFFSYM(LENGTH, length_footer);
+              match_length += length_footer;
+            }
+            match_length += LZX_MIN_MATCH;
+
+            /* get match offset */
+            switch ((match_offset = (main_element >> 3))) {
+            case 0: match_offset = R0; break;
+            case 1: match_offset = R1; R1=R0; R0 = match_offset; break;
+            case 2: match_offset = R2; R2=R0; R0 = match_offset; break;
+            default:
+              extra = (match_offset >= 36) ? 17 : extra_bits[match_offset];
+              match_offset = position_base[match_offset] - 2;
+              if (extra >= 3 && lzx->block_type == LZX_BLOCKTYPE_ALIGNED) {
+                if (extra > 3) {
+                  READ_BITS(verbatim_bits, extra - 3); /* 1-14 bits */
+                  match_offset += verbatim_bits << 3;
+                }
+                READ_HUFFSYM(ALIGNED, aligned_bits);
+                match_offset += aligned_bits;
+              }
+              else if (extra) {
+                READ_BITS(verbatim_bits, extra); /* 1-17 bits */
+                match_offset += verbatim_bits;
+              }
+              /* update repeated offset LRU queue */
+              R2 = R1; R1 = R0; R0 = match_offset;
+            }
+
+            /* LZX DELTA uses max match length to signal even longer match */
+            if (match_length == LZX_MAX_MATCH && lzx->is_delta) {
+                int extra_len = 0;
+                ENSURE_BITS(3); /* 4 entry huffman tree */
+                if (PEEK_BITS(1) == 0) {
+                    REMOVE_BITS(1); /* '0' -> 8 extra length bits */
+                    READ_BITS(extra_len, 8);
+                }
+                else if (PEEK_BITS(2) == 2) {
+                    REMOVE_BITS(2); /* '10' -> 10 extra length bits + 0x100 */
+                    READ_BITS(extra_len, 10);
+                    extra_len += 0x100;
+                }
+                else if (PEEK_BITS(3) == 6) {
+                    REMOVE_BITS(3); /* '110' -> 12 extra length bits + 0x500 */
+                    READ_BITS(extra_len, 12);
+                    extra_len += 0x500;
+                }
+                else {
+                    REMOVE_BITS(3); /* '111' -> 15 extra length bits */
+                    READ_BITS(extra_len, 15);
+                }
+                match_length += extra_len;
+            }
+
+            if ((window_posn + match_length) > lzx->window_size) {
+              D(("match ran over window wrap"))
+              return lzx->error = MSPACK_ERR_DECRUNCH;
+            }
+
+            /* copy match */
+            rundest = &window[window_posn];
+            i = match_length;
+            /* does match offset wrap the window? */
+            if (match_offset > window_posn) {
+	      if ((off_t)match_offset > lzx->offset &&
+                  (match_offset - window_posn) > lzx->ref_data_size)
+              {
+                D(("match offset beyond LZX stream"))
+                return lzx->error = MSPACK_ERR_DECRUNCH;
+              }
+              /* j = length from match offset to end of window */
+              j = match_offset - window_posn;
+              if (j > (int) lzx->window_size) {
+                D(("match offset beyond window boundaries"))
+                return lzx->error = MSPACK_ERR_DECRUNCH;
+              }
+              runsrc = &window[lzx->window_size - j];
+              if (j < i) {
+                /* if match goes over the window edge, do two copy runs */
+                i -= j; while (j-- > 0) *rundest++ = *runsrc++;
+                runsrc = window;
+              }
+              while (i-- > 0) *rundest++ = *runsrc++;
+            }
+            else {
+              runsrc = rundest - match_offset;
+              while (i-- > 0) *rundest++ = *runsrc++;
+            }
+
+            this_run    -= match_length;
+            window_posn += match_length;
+          }
+        } /* while (this_run > 0) */
+        break;
+
+      case LZX_BLOCKTYPE_UNCOMPRESSED:
+        /* as this_run is limited not to wrap a frame, this also means it
+         * won't wrap the window (as the window is a multiple of 32k) */
+        rundest = &window[window_posn];
+        window_posn += this_run;
+        while (this_run > 0) {
+          if ((i = i_end - i_ptr) == 0) {
+            READ_IF_NEEDED;
+          }
+          else {
+            if (i > this_run) i = this_run;
+            lzx->sys->copy(i_ptr, rundest, i);
+            rundest  += i;
+            i_ptr    += i;
+            this_run -= i;
+          }
+        }
+        break;
+
+      default:
+        return lzx->error = MSPACK_ERR_DECRUNCH; /* might as well */
+      }
+
+      /* did the final match overrun our desired this_run length? */
+      if (this_run < 0) {
+        if ((unsigned int)(-this_run) > lzx->block_remaining) {
+          D(("overrun went past end of block by %d (%d remaining)",
+             -this_run, lzx->block_remaining ))
+          return lzx->error = MSPACK_ERR_DECRUNCH;
+        }
+        lzx->block_remaining -= -this_run;
+      }
+    } /* while (bytes_todo > 0) */
+
+    /* streams don't extend over frame boundaries */
+    if ((window_posn - lzx->frame_posn) != frame_size) {
+      D(("decode beyond output frame limits! %d != %d",
+         window_posn - lzx->frame_posn, frame_size))
+      return lzx->error = MSPACK_ERR_DECRUNCH;
+    }
+
+    /* re-align input bitstream */
+    if (bits_left > 0) ENSURE_BITS(16);
+    if (bits_left & 15) REMOVE_BITS(bits_left & 15);
+
+    /* check that we've used all of the previous frame first */
+    if (lzx->o_ptr != lzx->o_end) {
+      D(("%ld avail bytes, new %d frame",
+          (long)(lzx->o_end - lzx->o_ptr), frame_size))
+      return lzx->error = MSPACK_ERR_DECRUNCH;
+    }
+
+    /* does this intel block _really_ need decoding? */
+    if (lzx->intel_started && lzx->intel_filesize &&
+        (lzx->frame < 32768) && (frame_size > 10))
+    {
+      unsigned char *data    = &lzx->e8_buf[0];
+      unsigned char *dataend = &lzx->e8_buf[frame_size - 10];
+      signed int curpos      = (int) lzx->offset;
+      signed int filesize    = lzx->intel_filesize;
+      signed int abs_off, rel_off;
+
+      /* copy e8 block to the e8 buffer and tweak if needed */
+      lzx->o_ptr = data;
+      lzx->sys->copy(&lzx->window[lzx->frame_posn], data, frame_size);
+
+      while (data < dataend) {
+        if (*data++ != 0xE8) { curpos++; continue; }
+        abs_off = EndGetI32(data);
+        if ((abs_off >= -curpos) && (abs_off < filesize)) {
+          rel_off = (abs_off >= 0) ? abs_off - curpos : abs_off + filesize;
+          data[0] = (unsigned char) rel_off;
+          data[1] = (unsigned char) (rel_off >> 8);
+          data[2] = (unsigned char) (rel_off >> 16);
+          data[3] = (unsigned char) (rel_off >> 24);
+        }
+        data += 4;
+        curpos += 5;
+      }
+    }
+    else {
+      lzx->o_ptr = &lzx->window[lzx->frame_posn];
+    }
+    lzx->o_end = &lzx->o_ptr[frame_size];
+
+    /* write a frame */
+    i = (out_bytes < (off_t)frame_size) ? (unsigned int)out_bytes : frame_size;
+    if (lzx->sys->write(lzx->output, lzx->o_ptr, i) != i) {
+      return lzx->error = MSPACK_ERR_WRITE;
+    }
+    lzx->o_ptr  += i;
+    lzx->offset += i;
+    out_bytes   -= i;
+
+    /* advance frame start position */
+    lzx->frame_posn += frame_size;
+    lzx->frame++;
+
+    /* wrap window / frame position pointers */
+    if (window_posn == lzx->window_size)     window_posn = 0;
+    if (lzx->frame_posn == lzx->window_size) lzx->frame_posn = 0;
+
+  } /* while (lzx->frame < end_frame) */
+
+  if (out_bytes) {
+    D(("bytes left to output"))
+    return lzx->error = MSPACK_ERR_DECRUNCH;
+  }
+
+  /* store local state */
+  STORE_BITS;
+  lzx->window_posn = window_posn;
+  lzx->R0 = R0;
+  lzx->R1 = R1;
+  lzx->R2 = R2;
+
+  return MSPACK_ERR_OK;
+}
+
+void lzxd_free(struct lzxd_stream *lzx) {
+  struct mspack_system *sys;
+  if (lzx) {
+    sys = lzx->sys;
+    sys->free(lzx->inbuf);
+    sys->free(lzx->window);
+    sys->free(lzx);
+  }
+}

--- a/third_party/libmspack/mspack/macros.h
+++ b/third_party/libmspack/mspack/macros.h
@@ -1,0 +1,64 @@
+/* This file is part of libmspack.
+ * (C) 2003-2020 Stuart Caie.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+#ifndef MSPACK_MACROS_H
+#define MSPACK_MACROS_H 1
+
+/* define LD and LU as printf-format for signed and unsigned long offsets */
+#if HAVE_INTTYPES_H
+# include <inttypes.h>
+#else
+# define PRId64 "lld"
+# define PRIu64 "llu"
+# define PRId32 "ld"
+# define PRIu32 "lu"
+#endif
+
+#if SIZEOF_OFF_T >= 8
+# define LD PRId64
+# define LU PRIu64
+#else
+# define LD PRId32
+# define LU PRIu32
+#endif
+
+/* endian-neutral reading of little-endian data */
+#define __egi32(a,n) (((unsigned int) ((unsigned char *)(a))[n+3] << 24) | \
+                      ((unsigned int) ((unsigned char *)(a))[n+2] << 16) | \
+                      ((unsigned int) ((unsigned char *)(a))[n+1] <<  8) | \
+                      ((unsigned int) ((unsigned char *)(a))[n]))
+#define EndGetI64(a) (((unsigned long long int) __egi32(a,4) << 32) | __egi32(a,0))
+#define EndGetI32(a) __egi32(a,0)
+#define EndGetI16(a) ((((a)[1])<<8)|((a)[0]))
+
+/* endian-neutral reading of big-endian data */
+#define EndGetM32(a) (((unsigned int) ((unsigned char *)(a))[0] << 24) | \
+                      ((unsigned int) ((unsigned char *)(a))[1] << 16) | \
+                      ((unsigned int) ((unsigned char *)(a))[2] <<  8) | \
+                      ((unsigned int) ((unsigned char *)(a))[3]))
+#define EndGetM16(a) ((((a)[0])<<8)|((a)[1]))
+
+/* D(("formatstring", args)) prints debug messages if DEBUG defined */
+#if DEBUG
+ /* http://gcc.gnu.org/onlinedocs/gcc/Function-Names.html */
+# if __STDC_VERSION__ < 199901L
+#  if __GNUC__ >= 2
+#   define __func__ __FUNCTION__
+#  else
+#   define __func__ "<unknown>"
+#  endif
+# endif
+# include <stdio.h>
+# define D(x) do { printf("%s:%d (%s) ",__FILE__, __LINE__, __func__); \
+                   printf x ; fputc('\n', stdout); fflush(stdout);} while (0);
+#else
+# define D(x)
+#endif
+
+#endif

--- a/third_party/libmspack/mspack/mspack.h
+++ b/third_party/libmspack/mspack/mspack.h
@@ -1,0 +1,2385 @@
+/* libmspack -- a library for working with Microsoft compression formats.
+ * (C) 2003-2019 Stuart Caie <kyzer@cabextract.org.uk>
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/** \mainpage
+ *
+ * \section intro Introduction
+ *
+ * libmspack is a library which provides compressors and decompressors,
+ * archivers and dearchivers for Microsoft compression formats.
+ *
+ * \section formats Formats supported
+ *
+ * The following file formats are supported:
+ * - SZDD files, which use LZSS compression
+ * - KWAJ files, which use LZSS, LZSS+Huffman or deflate compression
+ * - .HLP (MS Help) files, which use LZSS compression
+ * - .CAB (MS Cabinet) files, which use deflate, LZX or Quantum compression
+ * - .CHM (HTML Help) files, which use LZX compression
+ * - .LIT (MS EBook) files, which use LZX compression and DES encryption
+ * - .LZX (Exchange Offline Addressbook) files, which use LZX compression
+ *
+ * To determine the capabilities of the library, and the binary
+ * compatibility version of any particular compressor or decompressor, use
+ * the mspack_version() function. The UNIX library interface version is
+ * defined as the highest-versioned library component.
+ *
+ * \section starting Getting started
+ *
+ * The macro MSPACK_SYS_SELFTEST() should be used to ensure the library can
+ * be used. In particular, it checks if the caller is using 32-bit file I/O
+ * when the library is compiled for 64-bit file I/O and vice versa.
+ *
+ * If compiled normally, the library includes basic file I/O and memory
+ * management functionality using the standard C library. This can be
+ * customised and replaced entirely by creating a mspack_system structure.
+ *
+ * A compressor or decompressor for the required format must be
+ * instantiated before it can be used. Each construction function takes
+ * one parameter, which is either a pointer to a custom mspack_system
+ * structure, or NULL to use the default. The instantiation returned, if
+ * not NULL, contains function pointers (methods) to work with the given
+ * file format.
+ * 
+ * For compression:
+ * - mspack_create_cab_compressor() creates a mscab_compressor
+ * - mspack_create_chm_compressor() creates a mschm_compressor
+ * - mspack_create_lit_compressor() creates a mslit_compressor
+ * - mspack_create_hlp_compressor() creates a mshlp_compressor
+ * - mspack_create_szdd_compressor() creates a msszdd_compressor
+ * - mspack_create_kwaj_compressor() creates a mskwaj_compressor
+ * - mspack_create_oab_compressor() creates a msoab_compressor
+ *
+ * For decompression:
+ * - mspack_create_cab_decompressor() creates a mscab_decompressor
+ * - mspack_create_chm_decompressor() creates a mschm_decompressor
+ * - mspack_create_lit_decompressor() creates a mslit_decompressor
+ * - mspack_create_hlp_decompressor() creates a mshlp_decompressor
+ * - mspack_create_szdd_decompressor() creates a msszdd_decompressor
+ * - mspack_create_kwaj_decompressor() creates a mskwaj_decompressor
+ * - mspack_create_oab_decompressor() creates a msoab_decompressor
+ *
+ * Once finished working with a format, each kind of
+ * compressor/decompressor has its own specific destructor:
+ * - mspack_destroy_cab_compressor()
+ * - mspack_destroy_cab_decompressor()
+ * - mspack_destroy_chm_compressor()
+ * - mspack_destroy_chm_decompressor()
+ * - mspack_destroy_lit_compressor()
+ * - mspack_destroy_lit_decompressor()
+ * - mspack_destroy_hlp_compressor()
+ * - mspack_destroy_hlp_decompressor()
+ * - mspack_destroy_szdd_compressor()
+ * - mspack_destroy_szdd_decompressor()
+ * - mspack_destroy_kwaj_compressor()
+ * - mspack_destroy_kwaj_decompressor()
+ * - mspack_destroy_oab_compressor()
+ * - mspack_destroy_oab_decompressor()
+ *
+ * Destroying a compressor or decompressor does not destroy any objects,
+ * structures or handles that have been created using that compressor or
+ * decompressor. Ensure that everything created or opened is destroyed or
+ * closed before compressor/decompressor is itself destroyed.
+ *
+ * \section errors Error codes
+ *
+ * All compressors and decompressors use the same set of error codes. Most
+ * methods return an error code directly. For methods which do not
+ * return error codes directly, the error code can be obtained with the
+ * last_error() method.
+ *
+ * - #MSPACK_ERR_OK is used to indicate success. This error code is defined
+ *   as zero, all other code are non-zero.
+ * - #MSPACK_ERR_ARGS indicates that a method was called with inappropriate
+ *   arguments.
+ * - #MSPACK_ERR_OPEN indicates that mspack_system::open() failed.
+ * - #MSPACK_ERR_READ indicates that mspack_system::read() failed.
+ * - #MSPACK_ERR_WRITE indicates that mspack_system::write() failed.
+ * - #MSPACK_ERR_SEEK indicates that mspack_system::seek() failed.
+ * - #MSPACK_ERR_NOMEMORY indicates that mspack_system::alloc() failed.
+ * - #MSPACK_ERR_SIGNATURE indicates that the file being read does not
+ *   have the correct "signature". It is probably not a valid file for
+ *   whatever format is being read.
+ * - #MSPACK_ERR_DATAFORMAT indicates that the file being used or read
+ *   is corrupt.
+ * - #MSPACK_ERR_CHECKSUM indicates that a data checksum has failed.
+ * - #MSPACK_ERR_CRUNCH indicates an error occured during compression.
+ * - #MSPACK_ERR_DECRUNCH indicates an error occured during decompression.
+ *
+ * \section threading Multi-threading
+ *
+ * libmspack methods are reentrant and multithreading-safe when each
+ * thread has its own compressor or decompressor.
+
+ * You should not call multiple methods simultaneously on a single
+ * compressor or decompressor instance.
+ *
+ * If this may happen, you can either use one compressor or
+ * decompressor per thread, or you can use your preferred lock,
+ * semaphore or mutex library to ensure no more than one method on a
+ * compressor/decompressor is called simultaneously. libmspack will
+ * not do this locking for you.
+ *
+ * Example of incorrect behaviour:
+ * - thread 1 calls mspack_create_cab_decompressor()
+ * - thread 1 calls open()
+ * - thread 1 calls extract() for one file
+ * - thread 2 simultaneously calls extract() for another file
+ *
+ * Correct behaviour:
+ * - thread 1 calls mspack_create_cab_decompressor()
+ * - thread 2 calls mspack_create_cab_decompressor()
+ * - thread 1 calls its own open() / extract()
+ * - thread 2 simultaneously calls its own open() / extract()
+ *
+ * Also correct behaviour:
+ * - thread 1 calls mspack_create_cab_decompressor()
+ * - thread 1 locks a mutex for with the decompressor before
+ *   calling any methods on it, and unlocks the mutex after each
+ *   method returns.
+ * - thread 1 can share the results of open() with thread 2, and both
+ *   can call extract(), provided they both guard against simultaneous
+ *   use of extract(), and any other methods, with the mutex
+ */
+
+#ifndef LIB_MSPACK_H
+#define LIB_MSPACK_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/types.h>
+#include <stdlib.h>
+
+/**
+ * System self-test function, to ensure both library and calling program
+ * can use one another.
+ *
+ * A result of MSPACK_ERR_OK means the library and caller are
+ * compatible. Any other result indicates that the library and caller are
+ * not compatible and should not be used. In particular, a value of
+ * MSPACK_ERR_SEEK means the library and caller use different off_t
+ * datatypes.
+ *
+ * It should be used like so:
+ *
+ * @code
+ * int selftest_result;
+ * MSPACK_SYS_SELFTEST(selftest_result);
+ * if (selftest_result != MSPACK_ERR_OK) {
+ *   fprintf(stderr, "incompatible with this build of libmspack\n");
+ *   exit(0);
+ * }
+ * @endcode
+ *
+ * @param  result   an int variable to store the result of the self-test
+ */
+#define MSPACK_SYS_SELFTEST(result)  do { \
+  (result) = mspack_sys_selftest_internal(sizeof(off_t)); \
+} while (0)
+
+/** Part of the MSPACK_SYS_SELFTEST() macro, must not be used directly. */
+extern int mspack_sys_selftest_internal(int);
+
+/**
+ * Enquire about the binary compatibility version of a specific interface in
+ * the library. Currently, the following interfaces are defined:
+ *
+ * - #MSPACK_VER_LIBRARY: the overall library
+ * - #MSPACK_VER_SYSTEM: the mspack_system interface
+ * - #MSPACK_VER_MSCABD: the mscab_decompressor interface
+ * - #MSPACK_VER_MSCABC: the mscab_compressor interface
+ * - #MSPACK_VER_MSCHMD: the mschm_decompressor interface
+ * - #MSPACK_VER_MSCHMC: the mschm_compressor interface
+ * - #MSPACK_VER_MSLITD: the mslit_decompressor interface
+ * - #MSPACK_VER_MSLITC: the mslit_compressor interface
+ * - #MSPACK_VER_MSHLPD: the mshlp_decompressor interface
+ * - #MSPACK_VER_MSHLPC: the mshlp_compressor interface
+ * - #MSPACK_VER_MSSZDDD: the msszdd_decompressor interface
+ * - #MSPACK_VER_MSSZDDC: the msszdd_compressor interface
+ * - #MSPACK_VER_MSKWAJD: the mskwaj_decompressor interface
+ * - #MSPACK_VER_MSKWAJC: the mskwaj_compressor interface
+ * - #MSPACK_VER_MSOABD: the msoab_decompressor interface
+ * - #MSPACK_VER_MSOABC: the msoab_compressor interface
+ *
+ * The result of the function should be interpreted as follows:
+ * - -1: this interface is completely unknown to the library
+ * - 0: this interface is known, but non-functioning
+ * - 1: this interface has all basic functionality
+ * - 2, 3, ...: this interface has additional functionality, clearly marked
+ *   in the documentation as "version 2", "version 3" and so on.
+ *
+ * @param entity the interface to request current version of
+ * @return the version of the requested interface
+ */
+extern int mspack_version(int entity);
+
+/** Pass to mspack_version() to get the overall library version */
+#define MSPACK_VER_LIBRARY   (0)
+/** Pass to mspack_version() to get the mspack_system version */
+#define MSPACK_VER_SYSTEM    (1)
+/** Pass to mspack_version() to get the mscab_decompressor version */
+#define MSPACK_VER_MSCABD    (2)
+/** Pass to mspack_version() to get the mscab_compressor version */
+#define MSPACK_VER_MSCABC    (3)
+/** Pass to mspack_version() to get the mschm_decompressor version */
+#define MSPACK_VER_MSCHMD    (4)
+/** Pass to mspack_version() to get the mschm_compressor version */
+#define MSPACK_VER_MSCHMC    (5)
+/** Pass to mspack_version() to get the mslit_decompressor version */
+#define MSPACK_VER_MSLITD    (6)
+/** Pass to mspack_version() to get the mslit_compressor version */
+#define MSPACK_VER_MSLITC    (7)
+/** Pass to mspack_version() to get the mshlp_decompressor version */
+#define MSPACK_VER_MSHLPD    (8)
+/** Pass to mspack_version() to get the mshlp_compressor version */
+#define MSPACK_VER_MSHLPC    (9)
+/** Pass to mspack_version() to get the msszdd_decompressor version */
+#define MSPACK_VER_MSSZDDD   (10)
+/** Pass to mspack_version() to get the msszdd_compressor version */
+#define MSPACK_VER_MSSZDDC   (11)
+/** Pass to mspack_version() to get the mskwaj_decompressor version */
+#define MSPACK_VER_MSKWAJD   (12)
+/** Pass to mspack_version() to get the mskwaj_compressor version */
+#define MSPACK_VER_MSKWAJC   (13)
+/** Pass to mspack_version() to get the msoab_decompressor version */
+#define MSPACK_VER_MSOABD    (14)
+/** Pass to mspack_version() to get the msoab_compressor version */
+#define MSPACK_VER_MSOABC    (15)
+
+/* --- file I/O abstraction ------------------------------------------------ */
+
+/**
+ * A structure which abstracts file I/O and memory management.
+ *
+ * The library always uses the mspack_system structure for interaction
+ * with the file system and to allocate, free and copy all memory. It also
+ * uses it to send literal messages to the library user.
+ *
+ * When the library is compiled normally, passing NULL to a compressor or
+ * decompressor constructor will result in a default mspack_system being
+ * used, where all methods are implemented with the standard C library.
+ * However, all constructors support being given a custom created
+ * mspack_system structure, with the library user's own methods. This
+ * allows for more abstract interaction, such as reading and writing files
+ * directly to memory, or from a network socket or pipe.
+ *
+ * Implementors of an mspack_system structure should read all
+ * documentation entries for every structure member, and write methods
+ * which conform to those standards.
+ */
+struct mspack_system {
+  /**
+   * Opens a file for reading, writing, appending or updating.
+   *
+   * @param self     a self-referential pointer to the mspack_system
+   *                 structure whose open() method is being called. If
+   *                 this pointer is required by close(), read(), write(),
+   *                 seek() or tell(), it should be stored in the result
+   *                 structure at this time.
+   * @param filename the file to be opened. It is passed directly from the
+   *                 library caller without being modified, so it is up to
+   *                 the caller what this parameter actually represents.
+   * @param mode     one of #MSPACK_SYS_OPEN_READ (open an existing file
+   *                 for reading), #MSPACK_SYS_OPEN_WRITE (open a new file
+   *                 for writing), #MSPACK_SYS_OPEN_UPDATE (open an existing
+   *                 file for reading/writing from the start of the file) or
+   *                 #MSPACK_SYS_OPEN_APPEND (open an existing file for
+   *                 reading/writing from the end of the file)
+   * @return a pointer to a mspack_file structure. This structure officially
+   *         contains no members, its true contents are up to the
+   *         mspack_system implementor. It should contain whatever is needed
+   *         for other mspack_system methods to operate. Returning the NULL
+   *         pointer indicates an error condition.
+   * @see close(), read(), write(), seek(), tell(), message()
+   */
+  struct mspack_file * (*open)(struct mspack_system *self,
+                               const char *filename,
+                               int mode);
+
+  /**
+   * Closes a previously opened file. If any memory was allocated for this
+   * particular file handle, it should be freed at this time.
+   * 
+   * @param file the file to close
+   * @see open()
+   */
+  void (*close)(struct mspack_file *file);
+
+  /**
+   * Reads a given number of bytes from an open file.
+   *
+   * @param file    the file to read from
+   * @param buffer  the location where the read bytes should be stored
+   * @param bytes   the number of bytes to read from the file.
+   * @return the number of bytes successfully read (this can be less than
+   *         the number requested), zero to mark the end of file, or less
+   *         than zero to indicate an error. The library does not "retry"
+   *         reads and assumes short reads are due to EOF, so you should
+   *         avoid returning short reads because of transient errors.
+   * @see open(), write()
+   */
+  int (*read)(struct mspack_file *file,
+              void *buffer,
+              int bytes);
+
+  /**
+   * Writes a given number of bytes to an open file.
+   *
+   * @param file    the file to write to
+   * @param buffer  the location where the written bytes should be read from
+   * @param bytes   the number of bytes to write to the file.
+   * @return the number of bytes successfully written, this can be less
+   *         than the number requested. Zero or less can indicate an error
+   *         where no bytes at all could be written. All cases where less
+   *         bytes were written than requested are considered by the library
+   *         to be an error.
+   * @see open(), read()
+   */
+  int (*write)(struct mspack_file *file,
+               void *buffer,
+               int bytes);
+
+  /**
+   * Seeks to a specific file offset within an open file.
+   *
+   * Sometimes the library needs to know the length of a file. It does
+   * this by seeking to the end of the file with seek(file, 0,
+   * MSPACK_SYS_SEEK_END), then calling tell(). Implementations may want
+   * to make a special case for this.
+   *
+   * Due to the potentially varying 32/64 bit datatype off_t on some
+   * architectures, the #MSPACK_SYS_SELFTEST macro MUST be used before
+   * using the library. If not, the error caused by the library passing an
+   * inappropriate stackframe to seek() is subtle and hard to trace.
+   *
+   * @param file   the file to be seeked
+   * @param offset an offset to seek, measured in bytes
+   * @param mode   one of #MSPACK_SYS_SEEK_START (the offset should be
+   *               measured from the start of the file), #MSPACK_SYS_SEEK_CUR
+   *               (the offset should be measured from the current file offset)
+   *               or #MSPACK_SYS_SEEK_END (the offset should be measured from
+   *               the end of the file)
+   * @return zero for success, non-zero for an error
+   * @see open(), tell()
+   */
+  int (*seek)(struct mspack_file *file,
+              off_t offset,
+              int mode);
+
+  /**
+   * Returns the current file position (in bytes) of the given file.
+   *
+   * @param file the file whose file position is wanted
+   * @return the current file position of the file
+   * @see open(), seek()
+   */
+  off_t (*tell)(struct mspack_file *file);
+  
+  /**
+   * Used to send messages from the library to the user.
+   *
+   * Occasionally, the library generates warnings or other messages in
+   * plain english to inform the human user. These are informational only
+   * and can be ignored if not wanted.
+   *
+   * @param file   may be a file handle returned from open() if this message
+   *               pertains to a specific open file, or NULL if not related to
+   *               a specific file.
+   * @param format a printf() style format string. It does NOT include a
+   *               trailing newline.
+   * @see open()
+   */
+  void (*message)(struct mspack_file *file,
+                  const char *format,
+                  ...);
+
+  /**
+   * Allocates memory.
+   *
+   * @param self     a self-referential pointer to the mspack_system
+   *                 structure whose alloc() method is being called.
+   * @param bytes    the number of bytes to allocate
+   * @result a pointer to the requested number of bytes, or NULL if
+   *         not enough memory is available
+   * @see free()
+   */
+  void * (*alloc)(struct mspack_system *self,
+                  size_t bytes);
+  
+  /**
+   * Frees memory.
+   * 
+   * @param ptr the memory to be freed. NULL is accepted and ignored.
+   * @see alloc()
+   */
+  void (*free)(void *ptr);
+
+  /**
+   * Copies from one region of memory to another.
+   * 
+   * The regions of memory are guaranteed not to overlap, are usually less
+   * than 256 bytes, and may not be aligned. Please note that the source
+   * parameter comes before the destination parameter, unlike the standard
+   * C function memcpy().
+   *
+   * @param src   the region of memory to copy from
+   * @param dest  the region of memory to copy to
+   * @param bytes the size of the memory region, in bytes
+   */
+  void (*copy)(void *src,
+               void *dest,
+               size_t bytes);
+
+  /**
+   * A null pointer to mark the end of mspack_system. It must equal NULL.
+   *
+   * Should the mspack_system structure extend in the future, this NULL
+   * will be seen, rather than have an invalid method pointer called.
+   */
+  void *null_ptr;
+};
+
+/** mspack_system::open() mode: open existing file for reading. */
+#define MSPACK_SYS_OPEN_READ   (0)
+/** mspack_system::open() mode: open new file for writing */
+#define MSPACK_SYS_OPEN_WRITE  (1)
+/** mspack_system::open() mode: open existing file for writing */
+#define MSPACK_SYS_OPEN_UPDATE (2)
+/** mspack_system::open() mode: open existing file for writing */
+#define MSPACK_SYS_OPEN_APPEND (3)
+
+/** mspack_system::seek() mode: seek relative to start of file */
+#define MSPACK_SYS_SEEK_START  (0)
+/** mspack_system::seek() mode: seek relative to current offset */
+#define MSPACK_SYS_SEEK_CUR    (1)
+/** mspack_system::seek() mode: seek relative to end of file */
+#define MSPACK_SYS_SEEK_END    (2)
+
+/** 
+ * A structure which represents an open file handle. The contents of this
+ * structure are determined by the implementation of the
+ * mspack_system::open() method.
+ */
+struct mspack_file {
+  int dummy;
+};
+
+/* --- error codes --------------------------------------------------------- */
+
+/** Error code: no error */
+#define MSPACK_ERR_OK          (0)
+/** Error code: bad arguments to method */
+#define MSPACK_ERR_ARGS        (1)
+/** Error code: error opening file */
+#define MSPACK_ERR_OPEN        (2)
+/** Error code: error reading file */
+#define MSPACK_ERR_READ        (3)
+/** Error code: error writing file */
+#define MSPACK_ERR_WRITE       (4)
+/** Error code: seek error */
+#define MSPACK_ERR_SEEK        (5)
+/** Error code: out of memory */
+#define MSPACK_ERR_NOMEMORY    (6)
+/** Error code: bad "magic id" in file */
+#define MSPACK_ERR_SIGNATURE   (7)
+/** Error code: bad or corrupt file format */
+#define MSPACK_ERR_DATAFORMAT  (8)
+/** Error code: bad checksum or CRC */
+#define MSPACK_ERR_CHECKSUM    (9)
+/** Error code: error during compression */
+#define MSPACK_ERR_CRUNCH      (10)
+/** Error code: error during decompression */
+#define MSPACK_ERR_DECRUNCH    (11)
+
+/* --- functions available in library -------------------------------------- */
+
+/** Creates a new CAB compressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #mscab_compressor or NULL
+ */
+extern struct mscab_compressor *
+  mspack_create_cab_compressor(struct mspack_system *sys);
+
+/** Creates a new CAB decompressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #mscab_decompressor or NULL
+ */
+extern struct mscab_decompressor *
+  mspack_create_cab_decompressor(struct mspack_system *sys);
+
+/** Destroys an existing CAB compressor.
+ * @param self the #mscab_compressor to destroy
+ */
+extern void mspack_destroy_cab_compressor(struct mscab_compressor *self);
+
+/** Destroys an existing CAB decompressor.
+ * @param self the #mscab_decompressor to destroy
+ */
+extern void mspack_destroy_cab_decompressor(struct mscab_decompressor *self);
+
+
+/** Creates a new CHM compressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #mschm_compressor or NULL
+ */
+extern struct mschm_compressor *
+  mspack_create_chm_compressor(struct mspack_system *sys);
+
+/** Creates a new CHM decompressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #mschm_decompressor or NULL
+ */
+extern struct mschm_decompressor *
+  mspack_create_chm_decompressor(struct mspack_system *sys);
+
+/** Destroys an existing CHM compressor.
+ * @param self the #mschm_compressor to destroy
+ */
+extern void mspack_destroy_chm_compressor(struct mschm_compressor *self);
+
+/** Destroys an existing CHM decompressor.
+ * @param self the #mschm_decompressor to destroy
+ */
+extern void mspack_destroy_chm_decompressor(struct mschm_decompressor *self);
+
+
+/** Creates a new LIT compressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #mslit_compressor or NULL
+ */
+extern struct mslit_compressor *
+  mspack_create_lit_compressor(struct mspack_system *sys);
+
+/** Creates a new LIT decompressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #mslit_decompressor or NULL
+ */
+extern struct mslit_decompressor *
+  mspack_create_lit_decompressor(struct mspack_system *sys);
+
+/** Destroys an existing LIT compressor.
+ * @param self the #mslit_compressor to destroy
+ */
+extern void mspack_destroy_lit_compressor(struct mslit_compressor *self);
+
+/** Destroys an existing LIT decompressor.
+ * @param self the #mslit_decompressor to destroy
+ */
+extern void mspack_destroy_lit_decompressor(struct mslit_decompressor *self);
+
+
+/** Creates a new HLP compressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #mshlp_compressor or NULL
+ */
+extern struct mshlp_compressor *
+  mspack_create_hlp_compressor(struct mspack_system *sys);
+
+/** Creates a new HLP decompressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #mshlp_decompressor or NULL
+ */
+extern struct mshlp_decompressor *
+  mspack_create_hlp_decompressor(struct mspack_system *sys);
+
+/** Destroys an existing hlp compressor.
+ * @param self the #mshlp_compressor to destroy
+ */
+extern void mspack_destroy_hlp_compressor(struct mshlp_compressor *self);
+
+/** Destroys an existing hlp decompressor.
+ * @param self the #mshlp_decompressor to destroy
+ */
+extern void mspack_destroy_hlp_decompressor(struct mshlp_decompressor *self);
+
+
+/** Creates a new SZDD compressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #msszdd_compressor or NULL
+ */
+extern struct msszdd_compressor *
+  mspack_create_szdd_compressor(struct mspack_system *sys);
+
+/** Creates a new SZDD decompressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #msszdd_decompressor or NULL
+ */
+extern struct msszdd_decompressor *
+  mspack_create_szdd_decompressor(struct mspack_system *sys);
+
+/** Destroys an existing SZDD compressor.
+ * @param self the #msszdd_compressor to destroy
+ */
+extern void mspack_destroy_szdd_compressor(struct msszdd_compressor *self);
+
+/** Destroys an existing SZDD decompressor.
+ * @param self the #msszdd_decompressor to destroy
+ */
+extern void mspack_destroy_szdd_decompressor(struct msszdd_decompressor *self);
+
+
+/** Creates a new KWAJ compressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #mskwaj_compressor or NULL
+ */
+extern struct mskwaj_compressor *
+  mspack_create_kwaj_compressor(struct mspack_system *sys);
+
+/** Creates a new KWAJ decompressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #mskwaj_decompressor or NULL
+ */
+extern struct mskwaj_decompressor *
+  mspack_create_kwaj_decompressor(struct mspack_system *sys);
+
+/** Destroys an existing KWAJ compressor.
+ * @param self the #mskwaj_compressor to destroy
+ */
+extern void mspack_destroy_kwaj_compressor(struct mskwaj_compressor *self);
+
+/** Destroys an existing KWAJ decompressor.
+ * @param self the #mskwaj_decompressor to destroy
+ */
+extern void mspack_destroy_kwaj_decompressor(struct mskwaj_decompressor *self);
+
+
+/** Creates a new OAB compressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #msoab_compressor or NULL
+ */
+extern struct msoab_compressor *
+  mspack_create_oab_compressor(struct mspack_system *sys);
+
+/** Creates a new OAB decompressor.
+ * @param sys a custom mspack_system structure, or NULL to use the default
+ * @return a #msoab_decompressor or NULL
+ */
+extern struct msoab_decompressor *
+  mspack_create_oab_decompressor(struct mspack_system *sys);
+
+/** Destroys an existing OAB compressor.
+ * @param self the #msoab_compressor to destroy
+ */
+extern void mspack_destroy_oab_compressor(struct msoab_compressor *self);
+
+/** Destroys an existing OAB decompressor.
+ * @param self the #msoab_decompressor to destroy
+ */
+extern void mspack_destroy_oab_decompressor(struct msoab_decompressor *self);
+
+
+/* --- support for .CAB (MS Cabinet) file format --------------------------- */
+
+/**
+ * A structure which represents a single cabinet file.
+ *
+ * All fields are READ ONLY.
+ *
+ * If this cabinet is part of a merged cabinet set, the #files and #folders
+ * fields are common to all cabinets in the set, and will be identical.
+ *
+ * @see mscab_decompressor::open(), mscab_decompressor::close(),
+ *      mscab_decompressor::search()
+ */
+struct mscabd_cabinet {
+  /**
+   * The next cabinet in a chained list, if this cabinet was opened with
+   * mscab_decompressor::search(). May be NULL to mark the end of the
+   * list.
+   */
+  struct mscabd_cabinet *next;
+
+  /**
+   * The filename of the cabinet. More correctly, the filename of the
+   * physical file that the cabinet resides in. This is given by the
+   * library user and may be in any format.
+   */
+  const char *filename;
+  
+  /** The file offset of cabinet within the physical file it resides in. */
+  off_t base_offset;
+
+  /** The length of the cabinet file in bytes. */
+  unsigned int length;
+
+  /** The previous cabinet in a cabinet set, or NULL. */
+  struct mscabd_cabinet *prevcab;
+
+  /** The next cabinet in a cabinet set, or NULL. */
+  struct mscabd_cabinet *nextcab;
+
+  /** The filename of the previous cabinet in a cabinet set, or NULL. */
+  char *prevname;
+
+  /** The filename of the next cabinet in a cabinet set, or NULL. */
+  char *nextname;
+
+  /** The name of the disk containing the previous cabinet in a cabinet
+   * set, or NULL.
+   */
+  char *previnfo;
+
+  /** The name of the disk containing the next cabinet in a cabinet set,
+   * or NULL.
+   */
+  char *nextinfo;
+
+  /** A list of all files in the cabinet or cabinet set. */
+  struct mscabd_file *files;
+
+  /** A list of all folders in the cabinet or cabinet set. */
+  struct mscabd_folder *folders;
+
+  /** 
+   * The set ID of the cabinet. All cabinets in the same set should have
+   * the same set ID.
+   */
+  unsigned short set_id;
+
+  /**
+   * The index number of the cabinet within the set. Numbering should
+   * start from 0 for the first cabinet in the set, and increment by 1 for
+   * each following cabinet.
+   */
+  unsigned short set_index;
+
+  /**
+   * The number of bytes reserved in the header area of the cabinet.
+   *
+   * If this is non-zero and flags has MSCAB_HDR_RESV set, this data can
+   * be read by the calling application. It is of the given length,
+   * located at offset (base_offset + MSCAB_HDR_RESV_OFFSET) in the
+   * cabinet file.
+   *
+   * @see flags
+   */
+  unsigned short header_resv;
+
+  /**
+   * Header flags.
+   *
+   * - MSCAB_HDR_PREVCAB indicates the cabinet is part of a cabinet set, and
+   *                     has a predecessor cabinet.
+   * - MSCAB_HDR_NEXTCAB indicates the cabinet is part of a cabinet set, and
+   *                     has a successor cabinet.
+   * - MSCAB_HDR_RESV indicates the cabinet has reserved header space.
+   *
+   * @see prevname, previnfo, nextname, nextinfo, header_resv
+   */
+  int flags;
+};
+
+/** Offset from start of cabinet to the reserved header data (if present). */
+#define MSCAB_HDR_RESV_OFFSET (0x28)
+
+/** Cabinet header flag: cabinet has a predecessor */
+#define MSCAB_HDR_PREVCAB (0x01)
+/** Cabinet header flag: cabinet has a successor */
+#define MSCAB_HDR_NEXTCAB (0x02)
+/** Cabinet header flag: cabinet has reserved header space */
+#define MSCAB_HDR_RESV    (0x04)
+
+/**
+ * A structure which represents a single folder in a cabinet or cabinet set.
+ *
+ * All fields are READ ONLY.
+ *
+ * A folder is a single compressed stream of data. When uncompressed, it
+ * holds the data of one or more files. A folder may be split across more
+ * than one cabinet.
+ */
+struct mscabd_folder {
+  /**
+   * A pointer to the next folder in this cabinet or cabinet set, or NULL
+   * if this is the final folder.
+   */
+  struct mscabd_folder *next;
+
+  /** 
+   * The compression format used by this folder.
+   *
+   * The macro MSCABD_COMP_METHOD() should be used on this field to get
+   * the algorithm used. The macro MSCABD_COMP_LEVEL() should be used to get
+   * the "compression level".
+   *
+   * @see MSCABD_COMP_METHOD(), MSCABD_COMP_LEVEL()
+   */
+  int comp_type;
+
+  /**
+   * The total number of data blocks used by this folder. This includes
+   * data blocks present in other files, if this folder spans more than
+   * one cabinet.
+   */
+  unsigned int num_blocks;
+};
+
+/**
+ * Returns the compression method used by a folder.
+ *
+ * @param comp_type a mscabd_folder::comp_type value
+ * @return one of #MSCAB_COMP_NONE, #MSCAB_COMP_MSZIP, #MSCAB_COMP_QUANTUM
+ *         or #MSCAB_COMP_LZX
+ */
+#define MSCABD_COMP_METHOD(comp_type) ((comp_type) & 0x0F)
+/**
+ * Returns the compression level used by a folder.
+ *
+ * @param comp_type a mscabd_folder::comp_type value
+ * @return the compression level. This is only defined by LZX and Quantum
+ *         compression
+ */
+#define MSCABD_COMP_LEVEL(comp_type) (((comp_type) >> 8) & 0x1F)
+
+/** Compression mode: no compression. */
+#define MSCAB_COMP_NONE       (0)
+/** Compression mode: MSZIP (deflate) compression. */
+#define MSCAB_COMP_MSZIP      (1)
+/** Compression mode: Quantum compression */
+#define MSCAB_COMP_QUANTUM    (2)
+/** Compression mode: LZX compression */
+#define MSCAB_COMP_LZX        (3)
+
+/**
+ * A structure which represents a single file in a cabinet or cabinet set.
+ *
+ * All fields are READ ONLY.
+ */
+struct mscabd_file {
+  /**
+   * The next file in the cabinet or cabinet set, or NULL if this is the
+   * final file.
+   */
+  struct mscabd_file *next;
+
+  /**
+   * The filename of the file.
+   *
+   * A null terminated string of up to 255 bytes in length, it may be in
+   * either ISO-8859-1 or UTF8 format, depending on the file attributes.
+   *
+   * @see attribs
+   */
+  char *filename;
+
+  /** The uncompressed length of the file, in bytes. */
+  unsigned int length;
+
+  /**
+   * File attributes.
+   *
+   * The following attributes are defined:
+   * - #MSCAB_ATTRIB_RDONLY indicates the file is write protected.
+   * - #MSCAB_ATTRIB_HIDDEN indicates the file is hidden.
+   * - #MSCAB_ATTRIB_SYSTEM indicates the file is a operating system file.
+   * - #MSCAB_ATTRIB_ARCH indicates the file is "archived".
+   * - #MSCAB_ATTRIB_EXEC indicates the file is an executable program.
+   * - #MSCAB_ATTRIB_UTF_NAME indicates the filename is in UTF8 format rather
+   *   than ISO-8859-1.
+   */
+  int attribs;
+
+  /** File's last modified time, hour field. */
+  char time_h;
+  /** File's last modified time, minute field. */
+  char time_m;
+  /** File's last modified time, second field. */
+  char time_s;
+
+  /** File's last modified date, day field. */
+  char date_d;
+  /** File's last modified date, month field. */
+  char date_m;
+  /** File's last modified date, year field. */
+  int date_y;
+
+  /** A pointer to the folder that contains this file. */
+  struct mscabd_folder *folder;
+
+  /** The uncompressed offset of this file in its folder. */
+  unsigned int offset;
+};
+
+/** mscabd_file::attribs attribute: file is read-only. */
+#define MSCAB_ATTRIB_RDONLY   (0x01)
+/** mscabd_file::attribs attribute: file is hidden. */
+#define MSCAB_ATTRIB_HIDDEN   (0x02)
+/** mscabd_file::attribs attribute: file is an operating system file. */
+#define MSCAB_ATTRIB_SYSTEM   (0x04)
+/** mscabd_file::attribs attribute: file is "archived". */
+#define MSCAB_ATTRIB_ARCH     (0x20)
+/** mscabd_file::attribs attribute: file is an executable program. */
+#define MSCAB_ATTRIB_EXEC     (0x40)
+/** mscabd_file::attribs attribute: filename is UTF8, not ISO-8859-1. */
+#define MSCAB_ATTRIB_UTF_NAME (0x80)
+
+/** mscab_decompressor::set_param() parameter: search buffer size. */
+#define MSCABD_PARAM_SEARCHBUF (0)
+/** mscab_decompressor::set_param() parameter: repair MS-ZIP streams? */
+#define MSCABD_PARAM_FIXMSZIP  (1)
+/** mscab_decompressor::set_param() parameter: size of decompression buffer */
+#define MSCABD_PARAM_DECOMPBUF (2)
+/** mscab_decompressor::set_param() parameter: salvage data from bad cabinets?
+ * If enabled, open() will skip file with bad folder indices or filenames
+ * rather than reject the whole cabinet, and extract() will limit rather than
+ * reject files with invalid offsets and lengths, and bad data block checksums
+ * will be ignored. Available only in CAB decoder version 2 and above.
+ */
+#define MSCABD_PARAM_SALVAGE   (3)
+
+/** TODO */
+struct mscab_compressor {
+  int dummy; 
+};
+
+/**
+ * A decompressor for .CAB (Microsoft Cabinet) files
+ *
+ * All fields are READ ONLY.
+ *
+ * @see mspack_create_cab_decompressor(), mspack_destroy_cab_decompressor()
+ */
+struct mscab_decompressor {
+  /**
+   * Opens a cabinet file and reads its contents.
+   *
+   * If the file opened is a valid cabinet file, all headers will be read
+   * and a mscabd_cabinet structure will be returned, with a full list of
+   * folders and files.
+   *
+   * In the case of an error occuring, NULL is returned and the error code
+   * is available from last_error().
+   *
+   * The filename pointer should be considered "in use" until close() is
+   * called on the cabinet.
+   *
+   * @param  self     a self-referential pointer to the mscab_decompressor
+   *                  instance being called
+   * @param  filename the filename of the cabinet file. This is passed
+   *                  directly to mspack_system::open().
+   * @return a pointer to a mscabd_cabinet structure, or NULL on failure
+   * @see close(), search(), last_error()
+   */
+  struct mscabd_cabinet * (*open) (struct mscab_decompressor *self,
+                                   const char *filename);
+
+  /**
+   * Closes a previously opened cabinet or cabinet set.
+   *
+   * This closes a cabinet, all cabinets associated with it via the
+   * mscabd_cabinet::next, mscabd_cabinet::prevcab and
+   * mscabd_cabinet::nextcab pointers, and all folders and files. All
+   * memory used by these entities is freed.
+   *
+   * The cabinet pointer is now invalid and cannot be used again. All
+   * mscabd_folder and mscabd_file pointers from that cabinet or cabinet
+   * set are also now invalid, and cannot be used again.
+   *
+   * If the cabinet pointer given was created using search(), it MUST be
+   * the cabinet pointer returned by search() and not one of the later
+   * cabinet pointers further along the mscabd_cabinet::next chain.
+
+   * If extra cabinets have been added using append() or prepend(), these
+   * will all be freed, even if the cabinet pointer given is not the first
+   * cabinet in the set. Do NOT close() more than one cabinet in the set.
+   *
+   * The mscabd_cabinet::filename is not freed by the library, as it is
+   * not allocated by the library. The caller should free this itself if
+   * necessary, before it is lost forever.
+   *
+   * @param  self     a self-referential pointer to the mscab_decompressor
+   *                  instance being called
+   * @param  cab      the cabinet to close
+   * @see open(), search(), append(), prepend()
+   */
+  void (*close)(struct mscab_decompressor *self,
+                struct mscabd_cabinet *cab);
+
+  /**
+   * Searches a regular file for embedded cabinets.
+   *
+   * This opens a normal file with the given filename and will search the
+   * entire file for embedded cabinet files
+   *
+   * If any cabinets are found, the equivalent of open() is called on each
+   * potential cabinet file at the offset it was found. All successfully
+   * open()ed cabinets are kept in a list.
+   *
+   * The first cabinet found will be returned directly as the result of
+   * this method. Any further cabinets found will be chained in a list
+   * using the mscabd_cabinet::next field.
+   *
+   * In the case of an error occuring anywhere other than the simulated
+   * open(), NULL is returned and the error code is available from
+   * last_error().
+   *
+   * If no error occurs, but no cabinets can be found in the file, NULL is
+   * returned and last_error() returns MSPACK_ERR_OK.
+   *
+   * The filename pointer should be considered in use until close() is
+   * called on the cabinet.
+   *
+   * close() should only be called on the result of search(), not on any
+   * subsequent cabinets in the mscabd_cabinet::next chain.
+   *
+   * @param  self     a self-referential pointer to the mscab_decompressor
+   *                  instance being called
+   * @param  filename the filename of the file to search for cabinets. This
+   *                  is passed directly to mspack_system::open().
+   * @return a pointer to a mscabd_cabinet structure, or NULL
+   * @see close(), open(), last_error()
+   */
+  struct mscabd_cabinet * (*search) (struct mscab_decompressor *self,
+                                     const char *filename);
+
+  /**
+   * Appends one mscabd_cabinet to another, forming or extending a cabinet
+   * set.
+   *
+   * This will attempt to append one cabinet to another such that
+   * <tt>(cab->nextcab == nextcab) && (nextcab->prevcab == cab)</tt> and
+   * any folders split between the two cabinets are merged.
+   *
+   * The cabinets MUST be part of a cabinet set -- a cabinet set is a
+   * cabinet that spans more than one physical cabinet file on disk -- and
+   * must be appropriately matched.
+   *
+   * It can be determined if a cabinet has further parts to load by
+   * examining the mscabd_cabinet::flags field:
+   *
+   * - if <tt>(flags & MSCAB_HDR_PREVCAB)</tt> is non-zero, there is a
+   *   predecessor cabinet to open() and prepend(). Its MS-DOS
+   *   case-insensitive filename is mscabd_cabinet::prevname
+   * - if <tt>(flags & MSCAB_HDR_NEXTCAB)</tt> is non-zero, there is a
+   *   successor cabinet to open() and append(). Its MS-DOS case-insensitive
+   *   filename is mscabd_cabinet::nextname
+   *
+   * If the cabinets do not match, an error code will be returned. Neither
+   * cabinet has been altered, and both should be closed seperately.
+   *
+   * Files and folders in a cabinet set are a single entity. All cabinets
+   * in a set use the same file list, which is updated as cabinets in the
+   * set are added. All pointers to mscabd_folder and mscabd_file
+   * structures in either cabinet must be discarded and re-obtained after
+   * merging.
+   *
+   * @param  self     a self-referential pointer to the mscab_decompressor
+   *                  instance being called
+   * @param  cab      the cabinet which will be appended to,
+   *                  predecessor of nextcab
+   * @param  nextcab  the cabinet which will be appended,
+   *                  successor of cab
+   * @return an error code, or MSPACK_ERR_OK if successful
+   * @see prepend(), open(), close()
+   */
+  int (*append) (struct mscab_decompressor *self,
+                 struct mscabd_cabinet *cab,
+                 struct mscabd_cabinet *nextcab);
+
+  /**
+   * Prepends one mscabd_cabinet to another, forming or extending a
+   * cabinet set.
+   *
+   * This will attempt to prepend one cabinet to another, such that
+   * <tt>(cab->prevcab == prevcab) && (prevcab->nextcab == cab)</tt>. In
+   * all other respects, it is identical to append(). See append() for the
+   * full documentation.
+   *
+   * @param  self     a self-referential pointer to the mscab_decompressor
+   *                  instance being called
+   * @param  cab      the cabinet which will be prepended to,
+   *                  successor of prevcab
+   * @param  prevcab  the cabinet which will be prepended,
+   *                  predecessor of cab
+   * @return an error code, or MSPACK_ERR_OK if successful
+   * @see append(), open(), close()
+   */
+  int (*prepend) (struct mscab_decompressor *self,
+                  struct mscabd_cabinet *cab,
+                  struct mscabd_cabinet *prevcab);
+
+  /**
+   * Extracts a file from a cabinet or cabinet set.
+   *
+   * This extracts a compressed file in a cabinet and writes it to the given
+   * filename.
+   *
+   * The MS-DOS filename of the file, mscabd_file::filename, is NOT USED
+   * by extract(). The caller must examine this MS-DOS filename, copy and
+   * change it as necessary, create directories as necessary, and provide
+   * the correct filename as a parameter, which will be passed unchanged
+   * to the decompressor's mspack_system::open()
+   *
+   * If the file belongs to a split folder in a multi-part cabinet set,
+   * and not enough parts of the cabinet set have been loaded and appended
+   * or prepended, an error will be returned immediately.
+   *
+   * @param  self     a self-referential pointer to the mscab_decompressor
+   *                  instance being called
+   * @param  file     the file to be decompressed
+   * @param  filename the filename of the file being written to
+   * @return an error code, or MSPACK_ERR_OK if successful
+   */
+  int (*extract)(struct mscab_decompressor *self,
+                 struct mscabd_file *file,
+                 const char *filename);
+
+  /**
+   * Sets a CAB decompression engine parameter.
+   *
+   * The following parameters are defined:
+   * - #MSCABD_PARAM_SEARCHBUF: How many bytes should be allocated as a
+   *   buffer when using search()? The minimum value is 4.  The default
+   *   value is 32768.
+   * - #MSCABD_PARAM_FIXMSZIP: If non-zero, extract() will ignore bad
+   *   checksums and recover from decompression errors in MS-ZIP
+   *   compressed folders. The default value is 0 (don't recover).
+   * - #MSCABD_PARAM_DECOMPBUF: How many bytes should be used as an input
+   *   bit buffer by decompressors? The minimum value is 4. The default
+   *   value is 4096.
+   *
+   * @param  self     a self-referential pointer to the mscab_decompressor
+   *                  instance being called
+   * @param  param    the parameter to set
+   * @param  value    the value to set the parameter to
+   * @return MSPACK_ERR_OK if all is OK, or MSPACK_ERR_ARGS if there
+   *         is a problem with either parameter or value.
+   * @see search(), extract()
+   */
+  int (*set_param)(struct mscab_decompressor *self,
+                   int param,
+                   int value);
+
+  /**
+   * Returns the error code set by the most recently called method.
+   *
+   * This is useful for open() and search(), which do not return an error
+   * code directly.
+   *
+   * @param  self     a self-referential pointer to the mscab_decompressor
+   *                  instance being called
+   * @return the most recent error code
+   * @see open(), search()
+   */
+  int (*last_error)(struct mscab_decompressor *self);
+};
+
+/* --- support for .CHM (HTMLHelp) file format ----------------------------- */
+
+/**
+ * A structure which represents a file to be placed in a CHM helpfile.
+ *
+ * A contiguous array of these structures should be passed to
+ * mschm_compressor::generate(). The array list is terminated with an
+ * entry whose mschmc_file::section field is set to #MSCHMC_ENDLIST, the
+ * other fields in this entry are ignored.
+ */
+struct mschmc_file {
+  /** One of #MSCHMC_ENDLIST, #MSCHMC_UNCOMP or #MSCHMC_MSCOMP. */
+  int section;
+
+  /** The filename of the source file that will be added to the CHM. This
+   * is passed directly to mspack_system::open(). */
+  const char *filename;
+
+  /** The full path and filename of the file within the CHM helpfile, a
+   * UTF-1 encoded null-terminated string. */
+  char *chm_filename;
+
+  /** The length of the file, in bytes. This will be adhered to strictly
+   * and a read error will be issued if this many bytes cannot be read
+   * from the real file at CHM generation time. */
+  off_t length;
+};
+
+/**
+ * A structure which represents a section of a CHM helpfile.
+ *
+ * All fields are READ ONLY.
+ *
+ * Not used directly, but used as a generic base type for
+ * mschmd_sec_uncompressed and mschmd_sec_mscompressed.
+ */
+struct mschmd_section {
+  /** A pointer to the CHM helpfile that contains this section. */
+  struct mschmd_header *chm;
+
+  /**
+   * The section ID. Either 0 for the uncompressed section
+   * mschmd_sec_uncompressed, or 1 for the LZX compressed section
+   * mschmd_sec_mscompressed. No other section IDs are known.
+   */
+  unsigned int id;
+};
+
+/**
+ * A structure which represents the uncompressed section of a CHM helpfile.
+ * 
+ * All fields are READ ONLY.
+ */
+struct mschmd_sec_uncompressed {
+  /** Generic section data. */
+  struct mschmd_section base;
+
+  /** The file offset of where this section begins in the CHM helpfile. */
+  off_t offset;
+};
+
+/**
+ * A structure which represents the LZX compressed section of a CHM helpfile. 
+ * 
+ * All fields are READ ONLY.
+ */
+struct mschmd_sec_mscompressed {
+  /** Generic section data. */
+  struct mschmd_section base;
+
+  /** A pointer to the meta-file which represents all LZX compressed data. */
+  struct mschmd_file *content;
+
+  /** A pointer to the file which contains the LZX control data. */
+  struct mschmd_file *control;
+
+  /** A pointer to the file which contains the LZX reset table. */
+  struct mschmd_file *rtable;
+
+  /** A pointer to the file which contains the LZX span information.
+   * Available only in CHM decoder version 2 and above.
+   */
+  struct mschmd_file *spaninfo;
+};
+
+/**
+ * A structure which represents a CHM helpfile.
+ * 
+ * All fields are READ ONLY.
+ */
+struct mschmd_header {
+  /** The version of the CHM file format used in this file. */
+  unsigned int version;
+
+  /**
+   * The "timestamp" of the CHM helpfile. 
+   *
+   * It is the lower 32 bits of a 64-bit value representing the number of
+   * centiseconds since 1601-01-01 00:00:00 UTC, plus 42. It is not useful
+   * as a timestamp, but it is useful as a semi-unique ID.
+   */
+  unsigned int timestamp;
+      
+  /**
+   * The default Language and Country ID (LCID) of the user who ran the
+   * HTMLHelp Compiler. This is not the language of the CHM file itself.
+   */
+  unsigned int language;
+
+  /**
+   * The filename of the CHM helpfile. This is given by the library user
+   * and may be in any format.
+   */
+  const char *filename;
+
+  /** The length of the CHM helpfile, in bytes. */
+  off_t length;
+
+  /** A list of all non-system files in the CHM helpfile. */
+  struct mschmd_file *files;
+
+  /**
+   * A list of all system files in the CHM helpfile.
+   *
+   * System files are files which begin with "::". They are meta-files
+   * generated by the CHM creation process.
+   */
+  struct mschmd_file *sysfiles;
+
+  /** The section 0 (uncompressed) data in this CHM helpfile. */
+  struct mschmd_sec_uncompressed sec0;
+
+  /** The section 1 (MSCompressed) data in this CHM helpfile. */
+  struct mschmd_sec_mscompressed sec1;
+
+  /** The file offset of the first PMGL/PMGI directory chunk. */
+  off_t dir_offset;
+
+  /** The number of PMGL/PMGI directory chunks in this CHM helpfile. */
+  unsigned int num_chunks;
+
+  /** The size of each PMGL/PMGI chunk, in bytes. */
+  unsigned int chunk_size;
+
+  /** The "density" of the quick-reference section in PMGL/PMGI chunks. */
+  unsigned int density;
+
+  /** The depth of the index tree.
+   *
+   * - if 1, there are no PMGI chunks, only PMGL chunks.
+   * - if 2, there is 1 PMGI chunk. All chunk indices point to PMGL chunks.
+   * - if 3, the root PMGI chunk points to secondary PMGI chunks, which in
+   *         turn point to PMGL chunks.
+   * - and so on...
+   */
+  unsigned int depth;
+
+  /**
+   * The number of the root PMGI chunk.
+   *
+   * If there is no index in the CHM helpfile, this will be 0xFFFFFFFF.
+   */
+  unsigned int index_root;
+
+  /**
+   * The number of the first PMGL chunk. Usually zero.
+   * Available only in CHM decoder version 2 and above.
+   */
+  unsigned int first_pmgl;
+
+  /**
+   * The number of the last PMGL chunk. Usually num_chunks-1.
+   * Available only in CHM decoder version 2 and above.
+   */
+  unsigned int last_pmgl;
+
+  /**
+   * A cache of loaded chunks, filled in by mschm_decoder::fast_find().
+   * Available only in CHM decoder version 2 and above.
+   */
+  unsigned char **chunk_cache;
+};
+
+/**
+ * A structure which represents a file stored in a CHM helpfile.
+ * 
+ * All fields are READ ONLY.
+ */
+struct mschmd_file {
+  /**
+   * A pointer to the next file in the list, or NULL if this is the final
+   * file.
+   */
+  struct mschmd_file *next;
+
+  /**
+   * A pointer to the section that this file is located in. Indirectly,
+   * it also points to the CHM helpfile the file is located in.
+   */
+  struct mschmd_section *section;
+
+  /** The offset within the section data that this file is located at. */
+  off_t offset;
+
+  /** The length of this file, in bytes */
+  off_t length;
+
+  /** The filename of this file -- a null terminated string in UTF-8. */
+  char *filename;
+};
+
+/** mschmc_file::section value: end of CHM file list */
+#define MSCHMC_ENDLIST   (0)
+/** mschmc_file::section value: this file is in the Uncompressed section */
+#define MSCHMC_UNCOMP    (1)
+/** mschmc_file::section value: this file is in the MSCompressed section */
+#define MSCHMC_MSCOMP    (2)
+ 
+/** mschm_compressor::set_param() parameter: "timestamp" header */
+#define MSCHMC_PARAM_TIMESTAMP  (0)
+/** mschm_compressor::set_param() parameter: "language" header */
+#define MSCHMC_PARAM_LANGUAGE   (1)
+/** mschm_compressor::set_param() parameter: LZX window size */
+#define MSCHMC_PARAM_LZXWINDOW  (2)
+/** mschm_compressor::set_param() parameter: intra-chunk quickref density */
+#define MSCHMC_PARAM_DENSITY    (3)
+/** mschm_compressor::set_param() parameter: whether to create indices */
+#define MSCHMC_PARAM_INDEX      (4)
+
+/**
+ * A compressor for .CHM (Microsoft HTMLHelp) files.
+ *
+ * All fields are READ ONLY.
+ *
+ * @see mspack_create_chm_compressor(), mspack_destroy_chm_compressor()
+ */
+struct mschm_compressor {
+  /**
+   * Generates a CHM help file.
+   *
+   * The help file will contain up to two sections, an Uncompressed
+   * section and potentially an MSCompressed (LZX compressed)
+   * section.
+   *
+   * While the contents listing of a CHM file is always in lexical order,
+   * the file list passed in will be taken as the correct order for files
+   * within the sections.  It is in your interest to place similar files
+   * together for better compression.
+   *
+   * There are two modes of generation, to use a temporary file or not to
+   * use one. See use_temporary_file() for the behaviour of generate() in
+   * these two different modes.
+   *
+   * @param  self        a self-referential pointer to the mschm_compressor
+   *                     instance being called
+   * @param  file_list   an array of mschmc_file structures, terminated
+   *                     with an entry whose mschmc_file::section field is
+   *                     #MSCHMC_ENDLIST. The order of the list is
+   *                     preserved within each section. The length of any
+   *                     mschmc_file::chm_filename string cannot exceed
+   *                     roughly 4096 bytes. Each source file must be able
+   *                     to supply as many bytes as given in the
+   *                     mschmc_file::length field.
+   * @param  output_file the file to write the generated CHM helpfile to.
+   *                     This is passed directly to mspack_system::open()
+   * @return an error code, or MSPACK_ERR_OK if successful
+   * @see use_temporary_file() set_param()
+   */
+  int (*generate)(struct mschm_compressor *self,
+                  struct mschmc_file file_list[],
+                  const char *output_file);
+
+  /**
+   * Specifies whether a temporary file is used during CHM generation.
+   *
+   * The CHM file format includes data about the compressed section (such
+   * as its overall size) that is stored in the output CHM file prior to
+   * the compressed section itself. This unavoidably requires that the
+   * compressed section has to be generated, before these details can be
+   * set. There are several ways this can be handled. Firstly, the
+   * compressed section could be generated entirely in memory before
+   * writing any of the output CHM file. This approach is not used in
+   * libmspack, as the compressed section can exceed the addressable
+   * memory space on most architectures.
+   *
+   * libmspack has two options, either to write these unknowable sections
+   * with blank data, generate the compressed section, then re-open the
+   * output file for update once the compressed section has been
+   * completed, or to write the compressed section to a temporary file,
+   * then write the entire output file at once, performing a simple
+   * file-to-file copy for the compressed section.
+   *
+   * The simple solution of buffering the entire compressed section in
+   * memory can still be used, if desired. As the temporary file's
+   * filename is passed directly to mspack_system::open(), it is possible
+   * for a custom mspack_system implementation to hold this file in memory,
+   * without writing to a disk.
+   *
+   * If a temporary file is set, generate() performs the following
+   * sequence of events: the temporary file is opened for writing, the
+   * compression algorithm writes to the temporary file, the temporary
+   * file is closed.  Then the output file is opened for writing and the
+   * temporary file is re-opened for reading. The output file is written
+   * and the temporary file is read from. Both files are then closed. The
+   * temporary file itself is not deleted. If that is desired, the
+   * temporary file should be deleted after the completion of generate(),
+   * if it exists.
+   *
+   * If a temporary file is set not to be used, generate() performs the
+   * following sequence of events: the output file is opened for writing,
+   * then it is written and closed. The output file is then re-opened for
+   * update, the appropriate sections are seek()ed to and re-written, then
+   * the output file is closed.
+   *
+   * @param  self          a self-referential pointer to the
+   *                       mschm_compressor instance being called
+   * @param  use_temp_file non-zero if the temporary file should be used,
+   *                       zero if the temporary file should not be used.
+   * @param  temp_file     a file to temporarily write compressed data to,
+   *                       before opening it for reading and copying the
+   *                       contents to the output file. This is passed
+   *                       directly to mspack_system::open().
+   * @return an error code, or MSPACK_ERR_OK if successful
+   * @see generate()
+   */
+  int (*use_temporary_file)(struct mschm_compressor *self,
+                            int use_temp_file,
+                            const char *temp_file);
+  /**
+   * Sets a CHM compression engine parameter.
+   *
+   * The following parameters are defined:
+
+   * - #MSCHMC_PARAM_TIMESTAMP: Sets the "timestamp" of the CHM file
+   *   generated. This is not a timestamp, see mschmd_header::timestamp
+   *   for a description. If this timestamp is 0, generate() will use its
+   *   own algorithm for making a unique ID, based on the lengths and
+   *   names of files in the CHM itself. Defaults to 0, any value between
+   *   0 and (2^32)-1 is valid.
+   * - #MSCHMC_PARAM_LANGUAGE: Sets the "language" of the CHM file
+   *   generated.  This is not the language used in the CHM file, but the
+   *   language setting of the user who ran the HTMLHelp compiler. It
+   *   defaults to 0x0409. The valid range is between 0x0000 and 0x7F7F.
+   * - #MSCHMC_PARAM_LZXWINDOW: Sets the size of the LZX history window,
+   *   which is also the interval at which the compressed data stream can be
+   *   randomly accessed. The value is not a size in bytes, but a power of
+   *   two. The default value is 16 (which makes the window 2^16 bytes, or
+   *   64 kilobytes), the valid range is from 15 (32 kilobytes) to 21 (2
+   *   megabytes).
+   * - #MSCHMC_PARAM_DENSITY: Sets the "density" of quick reference
+   *   entries stored at the end of directory listing chunk. Each chunk is
+   *   4096 bytes in size, and contains as many file entries as there is
+   *   room for. At the other end of the chunk, a list of "quick reference"
+   *   pointers is included. The offset of every 'N'th file entry is given a
+   *   quick reference, where N = (2^density) + 1. The default density is
+   *   2. The smallest density is 0 (N=2), the maximum is 10 (N=1025). As
+   *   each file entry requires at least 5 bytes, the maximum number of
+   *   entries in a single chunk is roughly 800, so the maximum value 10
+   *   can be used to indicate there are no quickrefs at all.
+   * - #MSCHMC_PARAM_INDEX: Sets whether or not to include quick lookup
+   *   index chunk(s), in addition to normal directory listing chunks. A
+   *   value of zero means no index chunks will be created, a non-zero value
+   *   means index chunks will be created. The default is zero, "don't
+   *   create an index".
+   *
+   * @param  self     a self-referential pointer to the mschm_compressor
+   *                  instance being called
+   * @param  param    the parameter to set
+   * @param  value    the value to set the parameter to
+   * @return MSPACK_ERR_OK if all is OK, or MSPACK_ERR_ARGS if there
+   *         is a problem with either parameter or value.
+   * @see generate()
+   */
+  int (*set_param)(struct mschm_compressor *self,
+                   int param,
+                   int value);
+
+  /**
+   * Returns the error code set by the most recently called method.
+   *
+   * @param  self     a self-referential pointer to the mschm_compressor
+   *                  instance being called
+   * @return the most recent error code
+   * @see set_param(), generate()
+   */
+  int (*last_error)(struct mschm_compressor *self);
+};
+
+/**
+ * A decompressor for .CHM (Microsoft HTMLHelp) files
+ *
+ * All fields are READ ONLY.
+ *
+ * @see mspack_create_chm_decompressor(), mspack_destroy_chm_decompressor()
+ */
+struct mschm_decompressor {
+  /**
+   * Opens a CHM helpfile and reads its contents.
+   *
+   * If the file opened is a valid CHM helpfile, all headers will be read
+   * and a mschmd_header structure will be returned, with a full list of
+   * files.
+   *
+   * In the case of an error occuring, NULL is returned and the error code
+   * is available from last_error().
+   *
+   * The filename pointer should be considered "in use" until close() is
+   * called on the CHM helpfile.
+   *
+   * @param  self     a self-referential pointer to the mschm_decompressor
+   *                  instance being called
+   * @param  filename the filename of the CHM helpfile. This is passed
+   *                  directly to mspack_system::open().
+   * @return a pointer to a mschmd_header structure, or NULL on failure
+   * @see close()
+   */
+  struct mschmd_header *(*open)(struct mschm_decompressor *self,
+                                const char *filename);
+
+  /**
+   * Closes a previously opened CHM helpfile.
+   *
+   * This closes a CHM helpfile, frees the mschmd_header and all
+   * mschmd_file structures associated with it (if any). This works on
+   * both helpfiles opened with open() and helpfiles opened with
+   * fast_open().
+   *
+   * The CHM header pointer is now invalid and cannot be used again. All
+   * mschmd_file pointers referencing that CHM are also now invalid, and
+   * cannot be used again.
+   *
+   * @param  self     a self-referential pointer to the mschm_decompressor
+   *                  instance being called
+   * @param  chm      the CHM helpfile to close
+   * @see open(), fast_open()
+   */
+  void (*close)(struct mschm_decompressor *self,
+                struct mschmd_header *chm);
+
+  /**
+   * Extracts a file from a CHM helpfile.
+   *
+   * This extracts a file from a CHM helpfile and writes it to the given
+   * filename. The filename of the file, mscabd_file::filename, is not
+   * used by extract(), but can be used by the caller as a guide for
+   * constructing an appropriate filename.
+   *
+   * This method works both with files found in the mschmd_header::files
+   * and mschmd_header::sysfiles list and mschmd_file structures generated
+   * on the fly by fast_find().
+   *
+   * @param  self     a self-referential pointer to the mschm_decompressor
+   *                  instance being called
+   * @param  file     the file to be decompressed
+   * @param  filename the filename of the file being written to
+   * @return an error code, or MSPACK_ERR_OK if successful
+   */
+  int (*extract)(struct mschm_decompressor *self,
+                 struct mschmd_file *file,
+                 const char *filename);
+
+  /**
+   * Returns the error code set by the most recently called method.
+   *
+   * This is useful for open() and fast_open(), which do not return an
+   * error code directly.
+   *
+   * @param  self     a self-referential pointer to the mschm_decompressor
+   *                  instance being called
+   * @return the most recent error code
+   * @see open(), extract()
+   */
+  int (*last_error)(struct mschm_decompressor *self);
+
+  /**
+   * Opens a CHM helpfile quickly.
+   *
+   * If the file opened is a valid CHM helpfile, only essential headers
+   * will be read. A mschmd_header structure will be still be returned, as
+   * with open(), but the mschmd_header::files field will be NULL. No
+   * files details will be automatically read.  The fast_find() method
+   * must be used to obtain file details.
+   *
+   * In the case of an error occuring, NULL is returned and the error code
+   * is available from last_error().
+   *
+   * The filename pointer should be considered "in use" until close() is
+   * called on the CHM helpfile.
+   *
+   * @param  self     a self-referential pointer to the mschm_decompressor
+   *                  instance being called
+   * @param  filename the filename of the CHM helpfile. This is passed
+   *                  directly to mspack_system::open().
+   * @return a pointer to a mschmd_header structure, or NULL on failure
+   * @see open(), close(), fast_find(), extract()
+   */
+  struct mschmd_header *(*fast_open)(struct mschm_decompressor *self,
+                                     const char *filename);
+
+  /**
+   * Finds file details quickly.
+   *
+   * Instead of reading all CHM helpfile headers and building a list of
+   * files, fast_open() and fast_find() are intended for finding file
+   * details only when they are needed. The CHM file format includes an
+   * on-disk file index to allow this.
+   *
+   * Given a case-sensitive filename, fast_find() will search the on-disk
+   * index for that file.
+   *
+   * If the file was found, the caller-provided mschmd_file structure will
+   * be filled out like so:
+   * - section: the correct value for the found file
+   * - offset: the correct value for the found file
+   * - length: the correct value for the found file
+   * - all other structure elements: NULL or 0
+   *
+   * If the file was not found, MSPACK_ERR_OK will still be returned as the
+   * result, but the caller-provided structure will be filled out like so:
+   * - section: NULL
+   * - offset: 0
+   * - length: 0
+   * - all other structure elements: NULL or 0
+   *
+   * This method is intended to be used in conjunction with CHM helpfiles
+   * opened with fast_open(), but it also works with helpfiles opened
+   * using the regular open().
+   *
+   * @param  self     a self-referential pointer to the mschm_decompressor
+   *                  instance being called
+   * @param  chm      the CHM helpfile to search for the file
+   * @param  filename the filename of the file to search for
+   * @param  f_ptr    a pointer to a caller-provded mschmd_file structure
+   * @param  f_size   <tt>sizeof(struct mschmd_file)</tt>
+   * @return an error code, or MSPACK_ERR_OK if successful
+   * @see open(), close(), fast_find(), extract()
+   */
+  int (*fast_find)(struct mschm_decompressor *self,
+                   struct mschmd_header *chm,
+                   const char *filename,
+                   struct mschmd_file *f_ptr,
+                   int f_size);
+};
+
+/* --- support for .LIT (EBook) file format -------------------------------- */
+
+/** TODO */
+struct mslit_compressor {
+  int dummy; 
+};
+
+/** TODO */
+struct mslit_decompressor {
+  int dummy; 
+};
+
+
+/* --- support for .HLP (MS Help) file format ------------------------------ */
+
+/** TODO */
+struct mshlp_compressor {
+  int dummy; 
+};
+
+/** TODO */
+struct mshlp_decompressor {
+  int dummy; 
+};
+
+
+/* --- support for SZDD file format ---------------------------------------- */
+
+/** msszdd_compressor::set_param() parameter: the missing character */
+#define MSSZDDC_PARAM_MISSINGCHAR (0)
+
+/** msszddd_header::format value - a regular SZDD file */
+#define MSSZDD_FMT_NORMAL (0)
+
+/** msszddd_header::format value - a special QBasic SZDD file */
+#define MSSZDD_FMT_QBASIC (1)
+
+/**
+ * A structure which represents an SZDD compressed file.
+ *
+ * All fields are READ ONLY.
+ */
+struct msszddd_header {
+  /** The file format; either #MSSZDD_FMT_NORMAL or #MSSZDD_FMT_QBASIC */
+  int format;
+
+  /** The amount of data in the SZDD file once uncompressed. */
+  off_t length;
+
+  /**
+   * The last character in the filename, traditionally replaced with an
+   * underscore to show the file is compressed. The null character is used
+   * to show that this character has not been stored (e.g. because the
+   * filename is not known). Generally, only characters that may appear in
+   * an MS-DOS filename (except ".") are valid.
+   */
+  char missing_char;
+};
+
+/**
+ * A compressor for the SZDD file format.
+ *
+ * All fields are READ ONLY.
+ *
+ * @see mspack_create_szdd_compressor(), mspack_destroy_szdd_compressor()
+ */
+struct msszdd_compressor {
+  /**
+   * Reads an input file and creates a compressed output file in the
+   * SZDD compressed file format. The SZDD compression format is quick
+   * but gives poor compression. It is possible for the compressed output
+   * file to be larger than the input file.
+   *
+   * Conventionally, SZDD compressed files have the final character in
+   * their filename replaced with an underscore, to show they are
+   * compressed.  The missing character is stored in the compressed file
+   * itself. This is due to the restricted filename conventions of MS-DOS,
+   * most operating systems, such as UNIX, simply append another file
+   * extension to the existing filename. As mspack does not deal with
+   * filenames, this is left up to you. If you wish to set the missing
+   * character stored in the file header, use set_param() with the
+   * #MSSZDDC_PARAM_MISSINGCHAR parameter.
+   *
+   * "Stream" compression (where the length of the input data is not
+   * known) is not possible. The length of the input data is stored in the
+   * header of the SZDD file and must therefore be known before any data
+   * is compressed. Due to technical limitations of the file format, the
+   * maximum size of uncompressed file that will be accepted is 2147483647
+   * bytes.
+   *
+   * @param  self    a self-referential pointer to the msszdd_compressor
+   *                 instance being called
+   * @param  input   the name of the file to compressed. This is passed
+   *                 passed directly to mspack_system::open()
+   * @param  output  the name of the file to write compressed data to.
+   *                 This is passed directly to mspack_system::open().
+   * @param  length  the length of the uncompressed file, or -1 to indicate
+   *                 that this should be determined automatically by using
+   *                 mspack_system::seek() on the input file.
+   * @return an error code, or MSPACK_ERR_OK if successful
+   * @see set_param()
+   */
+  int (*compress)(struct msszdd_compressor *self,
+                  const char *input,
+                  const char *output,
+                  off_t length);
+
+  /**
+   * Sets an SZDD compression engine parameter.
+   *
+   * The following parameters are defined:
+
+   * - #MSSZDDC_PARAM_CHARACTER: the "missing character", the last character
+   *   in the uncompressed file's filename, which is traditionally replaced
+   *   with an underscore to show the file is compressed. Traditionally,
+   *   this can only be a character that is a valid part of an MS-DOS,
+   *   filename, but libmspack permits any character between 0x00 and 0xFF
+   *   to be stored. 0x00 is the default, and it represents "no character
+   *   stored".
+   *
+   * @param  self     a self-referential pointer to the msszdd_compressor
+   *                  instance being called
+   * @param  param    the parameter to set
+   * @param  value    the value to set the parameter to
+   * @return MSPACK_ERR_OK if all is OK, or MSPACK_ERR_ARGS if there
+   *         is a problem with either parameter or value.
+   * @see compress()
+   */
+  int (*set_param)(struct msszdd_compressor *self,
+                   int param,
+                   int value);
+
+  /**
+   * Returns the error code set by the most recently called method.
+   *
+   * @param  self     a self-referential pointer to the msszdd_compressor
+   *                  instance being called
+   * @return the most recent error code
+   * @see compress()
+   */
+  int (*last_error)(struct mschm_decompressor *self);
+};
+
+/**
+ * A decompressor for SZDD compressed files.
+ *
+ * All fields are READ ONLY.
+ *
+ * @see mspack_create_szdd_decompressor(), mspack_destroy_szdd_decompressor()
+ */
+struct msszdd_decompressor {
+  /**
+   * Opens a SZDD file and reads the header.
+   *
+   * If the file opened is a valid SZDD file, all headers will be read and
+   * a msszddd_header structure will be returned.
+   *
+   * In the case of an error occuring, NULL is returned and the error code
+   * is available from last_error().
+   *
+   * The filename pointer should be considered "in use" until close() is
+   * called on the SZDD file.
+   *
+   * @param  self     a self-referential pointer to the msszdd_decompressor
+   *                  instance being called
+   * @param  filename the filename of the SZDD compressed file. This is
+   *                  passed directly to mspack_system::open().
+   * @return a pointer to a msszddd_header structure, or NULL on failure
+   * @see close()
+   */
+  struct msszddd_header *(*open)(struct msszdd_decompressor *self,
+                                 const char *filename);
+
+  /**
+   * Closes a previously opened SZDD file.
+   *
+   * This closes a SZDD file and frees the msszddd_header associated with
+   * it.
+   *
+   * The SZDD header pointer is now invalid and cannot be used again.
+   *
+   * @param  self     a self-referential pointer to the msszdd_decompressor
+   *                  instance being called
+   * @param  szdd     the SZDD file to close
+   * @see open()
+   */
+  void (*close)(struct msszdd_decompressor *self,
+                struct msszddd_header *szdd);
+
+  /**
+   * Extracts the compressed data from a SZDD file.
+   *
+   * This decompresses the compressed SZDD data stream and writes it to
+   * an output file.
+   *
+   * @param  self     a self-referential pointer to the msszdd_decompressor
+   *                  instance being called
+   * @param  szdd     the SZDD file to extract data from
+   * @param  filename the filename to write the decompressed data to. This
+   *                  is passed directly to mspack_system::open().
+   * @return an error code, or MSPACK_ERR_OK if successful
+   */
+  int (*extract)(struct msszdd_decompressor *self,
+                 struct msszddd_header *szdd,
+                 const char *filename);
+
+  /**
+   * Decompresses an SZDD file to an output file in one step.
+   *
+   * This opens an SZDD file as input, reads the header, then decompresses
+   * the compressed data immediately to an output file, finally closing
+   * both the input and output file. It is more convenient to use than
+   * open() then extract() then close(), if you do not need to know the
+   * SZDD output size or missing character.
+   *
+   * @param  self     a self-referential pointer to the msszdd_decompressor
+   *                  instance being called
+   * @param  input    the filename of the input SZDD file. This is passed
+   *                  directly to mspack_system::open().
+   * @param  output   the filename to write the decompressed data to. This
+   *                  is passed directly to mspack_system::open().
+   * @return an error code, or MSPACK_ERR_OK if successful
+   */
+  int (*decompress)(struct msszdd_decompressor *self,
+                    const char *input,
+                    const char *output);
+
+  /**
+   * Returns the error code set by the most recently called method.
+   *
+   * This is useful for open() which does not return an
+   * error code directly.
+   *
+   * @param  self     a self-referential pointer to the msszdd_decompressor
+   *                  instance being called
+   * @return the most recent error code
+   * @see open(), extract(), decompress()
+   */
+  int (*last_error)(struct msszdd_decompressor *self);
+};
+
+/* --- support for KWAJ file format ---------------------------------------- */
+
+/** mskwaj_compressor::set_param() parameter: compression type */
+#define MSKWAJC_PARAM_COMP_TYPE  (0)
+
+/** mskwaj_compressor::set_param() parameter: include the length of the
+ * uncompressed file in the header?
+ */
+#define MSKWAJC_PARAM_INCLUDE_LENGTH (1)
+
+/** KWAJ compression type: no compression. */
+#define MSKWAJ_COMP_NONE (0)
+/** KWAJ compression type: no compression, 0xFF XOR "encryption". */
+#define MSKWAJ_COMP_XOR (1)
+/** KWAJ compression type: LZSS (same method as SZDD) */
+#define MSKWAJ_COMP_SZDD (2)
+/** KWAJ compression type: LZ+Huffman compression */
+#define MSKWAJ_COMP_LZH (3)
+/** KWAJ compression type: MSZIP */
+#define MSKWAJ_COMP_MSZIP (4)
+
+/** KWAJ optional header flag: decompressed file length is included */
+#define MSKWAJ_HDR_HASLENGTH (0x01)
+
+/** KWAJ optional header flag: unknown 2-byte structure is included */
+#define MSKWAJ_HDR_HASUNKNOWN1 (0x02)
+
+/** KWAJ optional header flag: unknown multi-sized structure is included */
+#define MSKWAJ_HDR_HASUNKNOWN2 (0x04)
+
+/** KWAJ optional header flag: file name (no extension) is included */
+#define MSKWAJ_HDR_HASFILENAME (0x08)
+
+/** KWAJ optional header flag: file extension is included */
+#define MSKWAJ_HDR_HASFILEEXT (0x10)
+
+/** KWAJ optional header flag: extra text is included */
+#define MSKWAJ_HDR_HASEXTRATEXT (0x20)
+
+/**
+ * A structure which represents an KWAJ compressed file.
+ *
+ * All fields are READ ONLY.
+ */
+struct mskwajd_header {
+  /** The compression type; should be one of #MSKWAJ_COMP_NONE,
+   * #MSKWAJ_COMP_XOR, #MSKWAJ_COMP_SZDD or #MSKWAJ_COMP_LZH
+   */
+  unsigned short comp_type;
+
+  /** The offset in the file where the compressed data stream begins */
+  off_t data_offset;
+
+  /** Flags indicating which optional headers were included. */
+  int headers;
+
+  /** The amount of uncompressed data in the file, or 0 if not present. */
+  off_t length;
+
+  /** output filename, or NULL if not present */
+  char *filename;
+
+  /** extra uncompressed data (usually text) in the header.
+   * This data can contain nulls so use extra_length to get the size.
+   */
+  char *extra;
+
+  /** length of extra uncompressed data in the header */
+  unsigned short extra_length;
+};
+
+/**
+ * A compressor for the KWAJ file format.
+ *
+ * All fields are READ ONLY.
+ *
+ * @see mspack_create_kwaj_compressor(), mspack_destroy_kwaj_compressor()
+ */
+struct mskwaj_compressor {
+  /**
+   * Reads an input file and creates a compressed output file in the
+   * KWAJ compressed file format. The KWAJ compression format is quick
+   * but gives poor compression. It is possible for the compressed output
+   * file to be larger than the input file.
+   *
+   * @param  self    a self-referential pointer to the mskwaj_compressor
+   *                 instance being called
+   * @param  input   the name of the file to compressed. This is passed
+   *                 passed directly to mspack_system::open()
+   * @param  output  the name of the file to write compressed data to.
+   *                 This is passed directly to mspack_system::open().
+   * @param  length  the length of the uncompressed file, or -1 to indicate
+   *                 that this should be determined automatically by using
+   *                 mspack_system::seek() on the input file.
+   * @return an error code, or MSPACK_ERR_OK if successful
+   * @see set_param()
+   */
+  int (*compress)(struct mskwaj_compressor *self,
+                  const char *input,
+                  const char *output,
+                  off_t length);
+
+  /**
+   * Sets an KWAJ compression engine parameter.
+   *
+   * The following parameters are defined:
+   *
+   * - #MSKWAJC_PARAM_COMP_TYPE: the compression method to use. Must
+   *   be one of #MSKWAJC_COMP_NONE, #MSKWAJC_COMP_XOR, #MSKWAJ_COMP_SZDD
+   *   or #MSKWAJ_COMP_LZH. The default is #MSKWAJ_COMP_LZH.
+   *
+   * - #MSKWAJC_PARAM_INCLUDE_LENGTH: a boolean; should the compressed
+   *   output file should include the uncompressed length of the input
+   *   file in the header? This adds 4 bytes to the size of the output
+   *   file. A value of zero says "no", non-zero says "yes". The default
+   *   is "no".
+   *
+   * @param  self     a self-referential pointer to the mskwaj_compressor
+   *                  instance being called
+   * @param  param    the parameter to set
+   * @param  value    the value to set the parameter to
+   * @return MSPACK_ERR_OK if all is OK, or MSPACK_ERR_ARGS if there
+   *         is a problem with either parameter or value.
+   * @see generate()
+   */
+  int (*set_param)(struct mskwaj_compressor *self,
+                   int param,
+                   int value);
+
+
+  /**
+   * Sets the original filename of the file before compression,
+   * which will be stored in the header of the output file.
+   *
+   * The filename should be a null-terminated string, it must be an
+   * MS-DOS "8.3" type filename (up to 8 bytes for the filename, then
+   * optionally a "." and up to 3 bytes for a filename extension).
+   *
+   * If NULL is passed as the filename, no filename is included in the
+   * header. This is the default.
+   *
+   * @param  self     a self-referential pointer to the mskwaj_compressor
+   *                  instance being called
+   * @param  filename the original filename to use
+   * @return MSPACK_ERR_OK if all is OK, or MSPACK_ERR_ARGS if the
+   *         filename is too long
+   */
+  int (*set_filename)(struct mskwaj_compressor *self,
+                      const char *filename);
+
+  /**
+   * Sets arbitrary data that will be stored in the header of the
+   * output file, uncompressed. It can be up to roughly 64 kilobytes,
+   * as the overall size of the header must not exceed 65535 bytes.
+   * The data can contain null bytes if desired.
+   *
+   * If NULL is passed as the data pointer, or zero is passed as the
+   * length, no extra data is included in the header. This is the
+   * default.
+   *
+   * @param  self     a self-referential pointer to the mskwaj_compressor
+   *                  instance being called
+   * @param  data     a pointer to the data to be stored in the header
+   * @param  bytes    the length of the data in bytes
+   * @return MSPACK_ERR_OK if all is OK, or MSPACK_ERR_ARGS extra data
+   *         is too long
+   */
+  int (*set_extra_data)(struct mskwaj_compressor *self,
+                        void *data,
+                        size_t bytes);
+
+  /**
+   * Returns the error code set by the most recently called method.
+   *
+   * @param  self     a self-referential pointer to the mskwaj_compressor
+   *                  instance being called
+   * @return the most recent error code
+   * @see compress()
+   */
+  int (*last_error)(struct mschm_decompressor *self);
+};
+
+/**
+ * A decompressor for KWAJ compressed files.
+ *
+ * All fields are READ ONLY.
+ *
+ * @see mspack_create_kwaj_decompressor(), mspack_destroy_kwaj_decompressor()
+ */
+struct mskwaj_decompressor {
+  /**
+   * Opens a KWAJ file and reads the header.
+   *
+   * If the file opened is a valid KWAJ file, all headers will be read and
+   * a mskwajd_header structure will be returned.
+   *
+   * In the case of an error occuring, NULL is returned and the error code
+   * is available from last_error().
+   *
+   * The filename pointer should be considered "in use" until close() is
+   * called on the KWAJ file.
+   *
+   * @param  self     a self-referential pointer to the mskwaj_decompressor
+   *                  instance being called
+   * @param  filename the filename of the KWAJ compressed file. This is
+   *                  passed directly to mspack_system::open().
+   * @return a pointer to a mskwajd_header structure, or NULL on failure
+   * @see close()
+   */
+  struct mskwajd_header *(*open)(struct mskwaj_decompressor *self,
+                                 const char *filename);
+
+  /**
+   * Closes a previously opened KWAJ file.
+   *
+   * This closes a KWAJ file and frees the mskwajd_header associated
+   * with it. The KWAJ header pointer is now invalid and cannot be
+   * used again.
+   *
+   * @param  self     a self-referential pointer to the mskwaj_decompressor
+   *                  instance being called
+   * @param  kwaj     the KWAJ file to close
+   * @see open()
+   */
+  void (*close)(struct mskwaj_decompressor *self,
+                struct mskwajd_header *kwaj);
+
+  /**
+   * Extracts the compressed data from a KWAJ file.
+   *
+   * This decompresses the compressed KWAJ data stream and writes it to
+   * an output file.
+   *
+   * @param  self     a self-referential pointer to the mskwaj_decompressor
+   *                  instance being called
+   * @param  kwaj     the KWAJ file to extract data from
+   * @param  filename the filename to write the decompressed data to. This
+   *                  is passed directly to mspack_system::open().
+   * @return an error code, or MSPACK_ERR_OK if successful
+   */
+  int (*extract)(struct mskwaj_decompressor *self,
+                 struct mskwajd_header *kwaj,
+                 const char *filename);
+
+  /**
+   * Decompresses an KWAJ file to an output file in one step.
+   *
+   * This opens an KWAJ file as input, reads the header, then decompresses
+   * the compressed data immediately to an output file, finally closing
+   * both the input and output file. It is more convenient to use than
+   * open() then extract() then close(), if you do not need to know the
+   * KWAJ output size or output filename.
+   *
+   * @param  self     a self-referential pointer to the mskwaj_decompressor
+   *                  instance being called
+   * @param  input    the filename of the input KWAJ file. This is passed
+   *                  directly to mspack_system::open().
+   * @param  output   the filename to write the decompressed data to. This
+   *                  is passed directly to mspack_system::open().
+   * @return an error code, or MSPACK_ERR_OK if successful
+   */
+  int (*decompress)(struct mskwaj_decompressor *self,
+                    const char *input,
+                    const char *output);
+
+  /**
+   * Returns the error code set by the most recently called method.
+   *
+   * This is useful for open() which does not return an
+   * error code directly.
+   *
+   * @param  self     a self-referential pointer to the mskwaj_decompressor
+   *                  instance being called
+   * @return the most recent error code
+   * @see open(), search()
+   */
+  int (*last_error)(struct mskwaj_decompressor *self);
+};
+
+/* --- support for .LZX (Offline Address Book) file format ----------------- */
+
+/**
+ * A compressor for the Offline Address Book (OAB) format.
+ *
+ * All fields are READ ONLY.
+ *
+ * @see mspack_create_oab_compressor(), mspack_destroy_oab_compressor()
+ */
+struct msoab_compressor {
+  /**
+   * Compress a full OAB file.
+   *
+   * The input file will be read and the compressed contents written to the
+   * output file.
+   *
+   * @param  self     a self-referential pointer to the msoab_decompressor
+   *                  instance being called
+   * @param  input    the filename of the input file. This is passed
+   *                  directly to mspack_system::open().
+   * @param  output   the filename of the output file. This is passed
+   *                  directly to mspack_system::open().
+   * @return an error code, or MSPACK_ERR_OK if successful
+   */
+  int (*compress) (struct msoab_compressor *self,
+                   const char *input,
+                   const char *output);
+
+  /**
+   * Generate a compressed incremental OAB patch file.
+   *
+   * The two uncompressed files "input" and "base" will be read, and an
+   * incremental patch to generate "input" from "base" will be written to
+   * the output file.
+   *
+   * @param  self     a self-referential pointer to the msoab_compressor
+   *                  instance being called
+   * @param  input    the filename of the input file containing the new
+   *                  version of its contents. This is passed directly
+   *                  to mspack_system::open().
+   * @param  base     the filename of the original base file containing
+   *                  the old version of its contents, against which the
+   *                  incremental patch shall generated. This is passed
+   *                  directly to mspack_system::open().
+   * @param  output   the filename of the output file. This is passed
+   *                  directly to mspack_system::open().
+   * @return an error code, or MSPACK_ERR_OK if successful
+   */
+  int (*compress_incremental) (struct msoab_compressor *self,
+                               const char *input,
+                               const char *base,
+                               const char *output);
+};
+
+/**
+ * A decompressor for .LZX (Offline Address Book) files
+ *
+ * All fields are READ ONLY.
+ *
+ * @see mspack_create_oab_decompressor(), mspack_destroy_oab_decompressor()
+ */
+struct msoab_decompressor {
+  /**
+   * Decompresses a full Offline Address Book file.
+   *
+   * If the input file is a valid compressed Offline Address Book file, 
+   * it will be read and the decompressed contents will be written to
+   * the output file.
+   *
+   * @param  self     a self-referential pointer to the msoab_decompressor
+   *                  instance being called
+   * @param  input    the filename of the input file. This is passed
+   *                  directly to mspack_system::open().
+   * @param  output   the filename of the output file. This is passed
+   *                  directly to mspack_system::open().
+   * @return an error code, or MSPACK_ERR_OK if successful
+   */
+  int (*decompress) (struct msoab_decompressor *self,
+                     const char *input,
+                     const char *output);
+
+  /**
+   * Decompresses an Offline Address Book with an incremental patch file.
+   *
+   * This requires both a full UNCOMPRESSED Offline Address Book file to
+   * act as the "base", and a compressed incremental patch file as input.
+   * If the input file is valid, it will be decompressed with reference to
+   * the base file, and the decompressed contents will be written to the
+   * output file.
+   *
+   * There is no way to tell what the right base file is for the given
+   * incremental patch, but if you get it wrong, this will usually result
+   * in incorrect data being decompressed, which will then fail a checksum
+   * test.
+   *
+   * @param  self     a self-referential pointer to the msoab_decompressor
+   *                  instance being called
+   * @param  input    the filename of the input file. This is passed
+   *                  directly to mspack_system::open().
+   * @param  base     the filename of the base file to which the
+   *                  incremental patch shall be applied. This is passed
+   *                  directly to mspack_system::open().
+   * @param  output   the filename of the output file. This is passed
+   *                  directly to mspack_system::open().
+   * @return an error code, or MSPACK_ERR_OK if successful
+   */
+  int (*decompress_incremental) (struct msoab_decompressor *self,
+                                 const char *input,
+                                 const char *base,
+                                 const char *output);
+
+  /**
+   * Sets an OAB decompression engine parameter. Available only in OAB
+   * decompressor version 2 and above.
+   *
+   * - #MSOABD_PARAM_DECOMPBUF: How many bytes should be used as an input
+   *   buffer by decompressors? The minimum value is 16. The default value
+   *   is 4096.
+   *
+   * @param  self     a self-referential pointer to the msoab_decompressor
+   *                  instance being called
+   * @param  param    the parameter to set
+   * @param  value    the value to set the parameter to
+   * @return MSPACK_ERR_OK if all is OK, or MSPACK_ERR_ARGS if there
+   *         is a problem with either parameter or value.
+   */
+  int (*set_param)(struct msoab_decompressor *self,
+                   int param,
+                   int value);
+
+};
+
+/** msoab_decompressor::set_param() parameter: size of decompression buffer */
+#define MSOABD_PARAM_DECOMPBUF (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/third_party/libmspack/mspack/mszip.h
+++ b/third_party/libmspack/mspack/mszip.h
@@ -1,0 +1,126 @@
+/* This file is part of libmspack.
+ * (C) 2003-2004 Stuart Caie.
+ *
+ * The deflate method was created by Phil Katz. MSZIP is equivalent to the
+ * deflate method.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+#ifndef MSPACK_MSZIP_H
+#define MSPACK_MSZIP_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* MSZIP (deflate) compression / (inflate) decompression definitions */
+
+#define MSZIP_FRAME_SIZE          (32768) /* size of LZ history window */
+#define MSZIP_LITERAL_MAXSYMBOLS  (288)   /* literal/length huffman tree */
+#define MSZIP_LITERAL_TABLEBITS   (9)
+#define MSZIP_DISTANCE_MAXSYMBOLS (32)    /* distance huffman tree */
+#define MSZIP_DISTANCE_TABLEBITS  (6)
+
+/* if there are less direct lookup entries than symbols, the longer
+ * code pointers will be <= maxsymbols. This must not happen, or we
+ * will decode entries badly */
+#if (1 << MSZIP_LITERAL_TABLEBITS) < (MSZIP_LITERAL_MAXSYMBOLS * 2)
+# define MSZIP_LITERAL_TABLESIZE (MSZIP_LITERAL_MAXSYMBOLS * 4)
+#else
+# define MSZIP_LITERAL_TABLESIZE ((1 << MSZIP_LITERAL_TABLEBITS) + \
+                                  (MSZIP_LITERAL_MAXSYMBOLS * 2))
+#endif
+
+#if (1 << MSZIP_DISTANCE_TABLEBITS) < (MSZIP_DISTANCE_MAXSYMBOLS * 2)
+# define MSZIP_DISTANCE_TABLESIZE (MSZIP_DISTANCE_MAXSYMBOLS * 4)
+#else
+# define MSZIP_DISTANCE_TABLESIZE ((1 << MSZIP_DISTANCE_TABLEBITS) + \
+                                  (MSZIP_DISTANCE_MAXSYMBOLS * 2))
+#endif
+
+struct mszipd_stream {
+  struct mspack_system *sys;            /* I/O routines          */
+  struct mspack_file   *input;          /* input file handle     */
+  struct mspack_file   *output;         /* output file handle    */
+  unsigned int window_posn;             /* offset within window  */
+
+  /* inflate() will call this whenever the window should be emptied. */
+  int (*flush_window)(struct mszipd_stream *, unsigned int);
+
+  int error, repair_mode, bytes_output;
+
+  /* I/O buffering */
+  unsigned char *inbuf, *i_ptr, *i_end, *o_ptr, *o_end, input_end;
+  unsigned int bit_buffer, bits_left, inbuf_size;
+
+
+  /* huffman code lengths */
+  unsigned char  LITERAL_len[MSZIP_LITERAL_MAXSYMBOLS];
+  unsigned char  DISTANCE_len[MSZIP_DISTANCE_MAXSYMBOLS];
+
+  /* huffman decoding tables */
+  unsigned short LITERAL_table [MSZIP_LITERAL_TABLESIZE];
+  unsigned short DISTANCE_table[MSZIP_DISTANCE_TABLESIZE];
+
+  /* 32kb history window */
+  unsigned char window[MSZIP_FRAME_SIZE];
+};
+
+/* allocates MS-ZIP decompression stream for decoding the given stream.
+ *
+ * - uses system->alloc() to allocate memory
+ *
+ * - returns NULL if not enough memory
+ *
+ * - input_buffer_size is how many bytes to use as an input bitstream buffer
+ *
+ * - if repair_mode is non-zero, errors in decompression will be skipped
+ *   and 'holes' left will be filled with zero bytes. This allows at least
+ *   a partial recovery of erroneous data.
+ */
+extern struct mszipd_stream *mszipd_init(struct mspack_system *system,
+                                        struct mspack_file *input,
+                                        struct mspack_file *output,
+                                        int input_buffer_size,
+                                        int repair_mode);
+
+/* decompresses, or decompresses more of, an MS-ZIP stream.
+ *
+ * - out_bytes of data will be decompressed and the function will return
+ *   with an MSPACK_ERR_OK return code.
+ *
+ * - decompressing will stop as soon as out_bytes is reached. if the true
+ *   amount of bytes decoded spills over that amount, they will be kept for
+ *   a later invocation of mszipd_decompress().
+ *
+ * - the output bytes will be passed to the system->write() function given in
+ *   mszipd_init(), using the output file handle given in mszipd_init(). More
+ *   than one call may be made to system->write()
+ *
+ * - MS-ZIP will read input bytes as necessary using the system->read()
+ *   function given in mszipd_init(), using the input file handle given in
+ *   mszipd_init(). This will continue until system->read() returns 0 bytes,
+ *   or an error.
+ */
+extern int mszipd_decompress(struct mszipd_stream *zip, off_t out_bytes);
+
+/* decompresses an entire MS-ZIP stream in a KWAJ file. Acts very much
+ * like mszipd_decompress(), but doesn't take an out_bytes parameter
+ */
+extern int mszipd_decompress_kwaj(struct mszipd_stream *zip);
+
+/* frees all stream associated with an MS-ZIP data stream
+ *
+ * - calls system->free() using the system pointer given in mszipd_init()
+ */
+void mszipd_free(struct mszipd_stream *zip);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/third_party/libmspack/mspack/mszipd.c
+++ b/third_party/libmspack/mspack/mszipd.c
@@ -1,0 +1,504 @@
+/* This file is part of libmspack.
+ * (C) 2003-2023 Stuart Caie.
+ *
+ * The deflate method was created by Phil Katz. MSZIP is equivalent to the
+ * deflate method.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+/* MS-ZIP decompression implementation. */
+
+#include <system.h>
+#include <mszip.h>
+
+/* import bit-reading macros and code */
+#define BITS_TYPE struct mszipd_stream
+#define BITS_VAR zip
+#define BITS_ORDER_LSB
+#define BITS_LSB_TABLE
+#define READ_BYTES do {         \
+    READ_IF_NEEDED;             \
+    INJECT_BITS(*i_ptr++, 8);   \
+} while (0)
+#include <readbits.h>
+
+/* import huffman macros and code */
+#define TABLEBITS(tbl)      MSZIP_##tbl##_TABLEBITS
+#define MAXSYMBOLS(tbl)     MSZIP_##tbl##_MAXSYMBOLS
+#define HUFF_TABLE(tbl,idx) zip->tbl##_table[idx]
+#define HUFF_LEN(tbl,idx)   zip->tbl##_len[idx]
+#define HUFF_ERROR          return INF_ERR_HUFFSYM
+#include <readhuff.h>
+
+#define FLUSH_IF_NEEDED do {                            \
+    if (zip->window_posn == MSZIP_FRAME_SIZE) {         \
+        if (zip->flush_window(zip, MSZIP_FRAME_SIZE)) { \
+            return INF_ERR_FLUSH;                       \
+        }                                               \
+        zip->window_posn = 0;                           \
+    }                                                   \
+} while (0)
+
+/* match lengths for literal codes 257.. 285 */
+static const unsigned short lit_lengths[29] = {
+  3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27,
+  31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258
+};
+
+/* match offsets for distance codes 0 .. 29 */
+static const unsigned short dist_offsets[30] = {
+  1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385,
+  513, 769, 1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577
+};
+
+/* extra bits required for literal codes 257.. 285 */
+static const unsigned char lit_extrabits[29] = {
+  0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2,
+  2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0
+};
+
+/* extra bits required for distance codes 0 .. 29 */
+static const unsigned char dist_extrabits[30] = {
+  0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6,
+  6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13
+};
+
+/* the order of the bit length Huffman code lengths */
+static const unsigned char bitlen_order[19] = {
+  16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15
+};
+
+/* inflate() error codes */
+#define INF_ERR_BLOCKTYPE   (-1)  /* unknown block type                      */
+#define INF_ERR_COMPLEMENT  (-2)  /* block size complement mismatch          */
+#define INF_ERR_FLUSH       (-3)  /* error from flush_window() callback      */
+#define INF_ERR_BITBUF      (-4)  /* too many bits in bit buffer             */
+#define INF_ERR_SYMLENS     (-5)  /* too many symbols in blocktype 2 header  */
+#define INF_ERR_BITLENTBL   (-6)  /* failed to build bitlens huffman table   */
+#define INF_ERR_LITERALTBL  (-7)  /* failed to build literals huffman table  */
+#define INF_ERR_DISTANCETBL (-8)  /* failed to build distance huffman table  */
+#define INF_ERR_BITOVERRUN  (-9)  /* bitlen RLE code goes over table size    */
+#define INF_ERR_BADBITLEN   (-10) /* invalid bit-length code                 */
+#define INF_ERR_LITCODE     (-11) /* out-of-range literal code               */
+#define INF_ERR_DISTCODE    (-12) /* out-of-range distance code              */
+#define INF_ERR_DISTANCE    (-13) /* somehow, distance is beyond 32k         */
+#define INF_ERR_HUFFSYM     (-14) /* out of bits decoding huffman symbol     */
+
+static int zip_read_lens(struct mszipd_stream *zip) {
+  DECLARE_BIT_VARS;
+
+  /* bitlen Huffman codes -- immediate lookup, 7 bit max code length */
+  unsigned short bl_table[(1 << 7)];
+  unsigned char bl_len[19];
+
+  unsigned char lens[MSZIP_LITERAL_MAXSYMBOLS + MSZIP_DISTANCE_MAXSYMBOLS];
+  unsigned int lit_codes, dist_codes, code, last_code=0, bitlen_codes, i, run;
+
+  RESTORE_BITS;
+
+  /* read the number of codes */
+  READ_BITS(lit_codes,    5); lit_codes    += 257;
+  READ_BITS(dist_codes,   5); dist_codes   += 1;
+  READ_BITS(bitlen_codes, 4); bitlen_codes += 4;
+  if (lit_codes  > MSZIP_LITERAL_MAXSYMBOLS)  return INF_ERR_SYMLENS;
+  if (dist_codes > MSZIP_DISTANCE_MAXSYMBOLS) return INF_ERR_SYMLENS;
+
+  /* read in the bit lengths in their unusual order */
+  for (i = 0; i < bitlen_codes; i++) READ_BITS(bl_len[bitlen_order[i]], 3);
+  while (i < 19) bl_len[bitlen_order[i++]] = 0;
+
+  /* create decoding table with an immediate lookup */
+  if (make_decode_table(19, 7, &bl_len[0], &bl_table[0])) {
+    return INF_ERR_BITLENTBL;
+  }
+
+  /* read literal / distance code lengths */
+  for (i = 0; i < (lit_codes + dist_codes); i++) {
+    /* single-level huffman lookup */
+    ENSURE_BITS(7);
+    code = bl_table[PEEK_BITS(7)];
+    REMOVE_BITS(bl_len[code]);
+
+    if (code < 16) lens[i] = last_code = code;
+    else {
+      switch (code) {
+      case 16: READ_BITS(run, 2); run += 3;  code = last_code; break;
+      case 17: READ_BITS(run, 3); run += 3;  code = 0;         break;
+      case 18: READ_BITS(run, 7); run += 11; code = 0;         break;
+      default: D(("bad code!: %u", code)) return INF_ERR_BADBITLEN;
+      }
+      if ((i + run) > (lit_codes + dist_codes)) return INF_ERR_BITOVERRUN;
+      while (run--) lens[i++] = code;
+      i--;
+    }
+  }
+
+  /* copy LITERAL code lengths and clear any remaining */
+  i = lit_codes;
+  zip->sys->copy(&lens[0], &zip->LITERAL_len[0], i);
+  while (i < MSZIP_LITERAL_MAXSYMBOLS) zip->LITERAL_len[i++] = 0;
+
+  i = dist_codes;
+  zip->sys->copy(&lens[lit_codes], &zip->DISTANCE_len[0], i);
+  while (i < MSZIP_DISTANCE_MAXSYMBOLS) zip->DISTANCE_len[i++] = 0;
+
+  STORE_BITS;
+  return 0;
+}
+
+/* a clean implementation of RFC 1951 / inflate */
+static int inflate(struct mszipd_stream *zip) {
+  DECLARE_HUFF_VARS;
+  unsigned int last_block, block_type, distance, length, this_run;
+  int i;
+
+  RESTORE_BITS;
+
+  do {
+    /* read in last block bit */
+    READ_BITS(last_block, 1);
+
+    /* read in block type */
+    READ_BITS(block_type, 2);
+
+    if (block_type == 0) {
+      /* uncompressed block */
+      unsigned char lens_buf[4];
+
+      /* go to byte boundary */
+      i = bits_left & 7; REMOVE_BITS(i);
+
+      /* read 4 bytes of data, emptying the bit-buffer if necessary */
+      for (i = 0; (bits_left >= 8); i++) {
+        if (i == 4) return INF_ERR_BITBUF;
+        lens_buf[i] = PEEK_BITS(8);
+        REMOVE_BITS(8);
+      }
+      if (bits_left != 0) return INF_ERR_BITBUF;
+      while (i < 4) {
+        READ_IF_NEEDED;
+        lens_buf[i++] = *i_ptr++;
+      }
+
+      /* get the length and its complement */
+      length = lens_buf[0] | (lens_buf[1] << 8);
+      i      = lens_buf[2] | (lens_buf[3] << 8);
+      if (length != (~i & 0xFFFF)) return INF_ERR_COMPLEMENT;
+
+      /* read and copy the uncompressed data into the window */
+      while (length > 0) {
+        READ_IF_NEEDED;
+
+        this_run = length;
+        if (this_run > (unsigned int)(i_end - i_ptr)) this_run = i_end - i_ptr;
+        if (this_run > (MSZIP_FRAME_SIZE - zip->window_posn))
+          this_run = MSZIP_FRAME_SIZE - zip->window_posn;
+
+        zip->sys->copy(i_ptr, &zip->window[zip->window_posn], this_run);
+        zip->window_posn += this_run;
+        i_ptr    += this_run;
+        length   -= this_run;
+        FLUSH_IF_NEEDED;
+      }
+    }
+    else if ((block_type == 1) || (block_type == 2)) {
+      /* Huffman-compressed LZ77 block */
+      unsigned int match_posn, code;
+
+      if (block_type == 1) {
+        /* block with fixed Huffman codes */
+        i = 0;
+        while (i < 144) zip->LITERAL_len[i++] = 8;
+        while (i < 256) zip->LITERAL_len[i++] = 9;
+        while (i < 280) zip->LITERAL_len[i++] = 7;
+        while (i < 288) zip->LITERAL_len[i++] = 8;
+        for (i = 0; i < 32; i++) zip->DISTANCE_len[i] = 5;
+      }
+      else {
+        /* block with dynamic Huffman codes */
+        STORE_BITS;
+        if ((i = zip_read_lens(zip))) return i;
+        RESTORE_BITS;
+      }
+
+      /* now huffman lengths are read for either kind of block, 
+       * create huffman decoding tables */
+      if (make_decode_table(MSZIP_LITERAL_MAXSYMBOLS, MSZIP_LITERAL_TABLEBITS,
+                            &zip->LITERAL_len[0], &zip->LITERAL_table[0]))
+      {
+        return INF_ERR_LITERALTBL;
+      }
+
+      if (make_decode_table(MSZIP_DISTANCE_MAXSYMBOLS,MSZIP_DISTANCE_TABLEBITS,
+                            &zip->DISTANCE_len[0], &zip->DISTANCE_table[0]))
+      {
+        return INF_ERR_DISTANCETBL;
+      }
+
+      /* decode forever until end of block code */
+      for (;;) {
+        READ_HUFFSYM(LITERAL, code);
+        if (code < 256) {
+          zip->window[zip->window_posn++] = (unsigned char) code;
+          FLUSH_IF_NEEDED;
+        }
+        else if (code == 256) {
+          /* END OF BLOCK CODE: loop break point */
+          break;
+        }
+        else {
+          code -= 257; /* codes 257-285 are matches */
+          if (code >= 29) return INF_ERR_LITCODE; /* codes 286-287 are illegal */
+          READ_BITS_T(length, lit_extrabits[code]);
+          length += lit_lengths[code];
+
+          READ_HUFFSYM(DISTANCE, code);
+          if (code >= 30) return INF_ERR_DISTCODE;
+          READ_BITS_T(distance, dist_extrabits[code]);
+          distance += dist_offsets[code];
+
+          /* match position is window position minus distance. If distance
+           * is more than window position numerically, it must 'wrap
+           * around' the frame size. */ 
+          match_posn = ((distance > zip->window_posn) ? MSZIP_FRAME_SIZE : 0)
+            + zip->window_posn - distance;
+
+          /* copy match */
+          if (length < 12) {
+            /* short match, use slower loop but no loop setup code */
+            while (length--) {
+              zip->window[zip->window_posn++] = zip->window[match_posn++];
+              match_posn &= MSZIP_FRAME_SIZE - 1;
+              FLUSH_IF_NEEDED;
+            }
+          }
+          else {
+            /* longer match, use faster loop but with setup expense */
+            unsigned char *runsrc, *rundest;
+            do {
+              this_run = length;
+              if ((match_posn + this_run) > MSZIP_FRAME_SIZE)
+                this_run = MSZIP_FRAME_SIZE - match_posn;
+              if ((zip->window_posn + this_run) > MSZIP_FRAME_SIZE)
+                this_run = MSZIP_FRAME_SIZE - zip->window_posn;
+
+              rundest = &zip->window[zip->window_posn]; zip->window_posn += this_run;
+              runsrc  = &zip->window[match_posn];  match_posn  += this_run;
+              length -= this_run;
+              while (this_run--) *rundest++ = *runsrc++;
+              if (match_posn == MSZIP_FRAME_SIZE) match_posn = 0;
+              FLUSH_IF_NEEDED;
+            } while (length > 0);
+          }
+
+        } /* else (code >= 257) */
+
+      } /* for(;;) -- break point at 'code == 256' */
+    }
+    else {
+      /* block_type == 3 -- bad block type */
+      return INF_ERR_BLOCKTYPE;
+    }
+  } while (!last_block);
+
+  /* flush the remaining data */
+  if (zip->window_posn) {
+    if (zip->flush_window(zip, zip->window_posn)) return INF_ERR_FLUSH;
+  }
+  STORE_BITS;
+
+  /* return success */
+  return 0;
+}
+
+/* inflate() calls this whenever the window should be flushed. As
+ * MSZIP only expands to the size of the window, the implementation used
+ * simply keeps track of the amount of data flushed, and if more than 32k
+ * is flushed, an error is raised.
+ */  
+static int mszipd_flush_window(struct mszipd_stream *zip,
+                               unsigned int data_flushed)
+{
+  zip->bytes_output += data_flushed;
+  if (zip->bytes_output > MSZIP_FRAME_SIZE) {
+    D(("overflow: %u bytes flushed, total is now %u",
+       data_flushed, zip->bytes_output))
+    return 1;
+  }
+  return 0;
+}
+
+struct mszipd_stream *mszipd_init(struct mspack_system *system,
+                                  struct mspack_file *input,
+                                  struct mspack_file *output,
+                                  int input_buffer_size,
+                                  int repair_mode)
+{
+  struct mszipd_stream *zip;
+
+  if (!system) return NULL;
+
+  /* round up input buffer size to multiple of two */
+  input_buffer_size = (input_buffer_size + 1) & -2;
+  if (input_buffer_size < 2) return NULL;
+
+  /* allocate decompression state */
+  if (!(zip = (struct mszipd_stream *) system->alloc(system, sizeof(struct mszipd_stream)))) {
+    return NULL;
+  }
+
+  /* allocate input buffer */
+  zip->inbuf  = (unsigned char *) system->alloc(system, input_buffer_size);
+  if (!zip->inbuf) {
+    system->free(zip);
+    return NULL;
+  }
+
+  /* initialise decompression state */
+  zip->sys             = system;
+  zip->input           = input;
+  zip->output          = output;
+  zip->inbuf_size      = input_buffer_size;
+  zip->input_end       = 0;
+  zip->error           = MSPACK_ERR_OK;
+  zip->repair_mode     = repair_mode;
+  zip->flush_window    = &mszipd_flush_window;
+
+  zip->i_ptr = zip->i_end = &zip->inbuf[0];
+  zip->o_ptr = zip->o_end = NULL;
+  zip->bit_buffer = 0; zip->bits_left = 0;
+  return zip;
+}
+
+int mszipd_decompress(struct mszipd_stream *zip, off_t out_bytes) {
+  /* for the bit buffer */
+  register unsigned int bit_buffer;
+  register int bits_left;
+  unsigned char *i_ptr, *i_end;
+
+  int i, state, error;
+
+  /* easy answers */
+  if (!zip || (out_bytes < 0)) return MSPACK_ERR_ARGS;
+  if (zip->error) return zip->error;
+
+  /* flush out any stored-up bytes before we begin */
+  i = zip->o_end - zip->o_ptr;
+  if ((off_t) i > out_bytes) i = (int) out_bytes;
+  if (i) {
+    if (zip->sys->write(zip->output, zip->o_ptr, i) != i) {
+      return zip->error = MSPACK_ERR_WRITE;
+    }
+    zip->o_ptr  += i;
+    out_bytes   -= i;
+  }
+  if (out_bytes == 0) return MSPACK_ERR_OK;
+
+
+  while (out_bytes > 0) {
+    /* unpack another block */
+    RESTORE_BITS;
+
+    /* skip to next read 'CK' header */
+    i = bits_left & 7; REMOVE_BITS(i); /* align to bytestream */
+    state = 0;
+    do {
+      READ_BITS(i, 8);
+      if (i == 'C') state = 1;
+      else if ((state == 1) && (i == 'K')) state = 2;
+      else state = 0;
+    } while (state != 2);
+
+    /* inflate a block, repair and realign if necessary */
+    zip->window_posn = 0;
+    zip->bytes_output = 0;
+    STORE_BITS;
+    if ((error = inflate(zip))) {
+      D(("inflate error %d", error))
+      if (zip->repair_mode) {
+        /* recover partially-inflated buffers */
+        if (zip->bytes_output == 0 && zip->window_posn > 0) {
+          zip->flush_window(zip, zip->window_posn);
+        }
+        zip->sys->message(NULL, "MSZIP error, %u bytes of data lost.",
+                          MSZIP_FRAME_SIZE - zip->bytes_output);
+        for (i = zip->bytes_output; i < MSZIP_FRAME_SIZE; i++) {
+          zip->window[i] = '\0';
+        }
+        zip->bytes_output = MSZIP_FRAME_SIZE;
+      }
+      else {
+        return zip->error = (error > 0) ? error : MSPACK_ERR_DECRUNCH;
+      }
+    }
+    zip->o_ptr = &zip->window[0];
+    zip->o_end = &zip->o_ptr[zip->bytes_output];
+
+    /* write a frame */
+    i = (out_bytes < (off_t)zip->bytes_output) ?
+      (int)out_bytes : zip->bytes_output;
+    if (zip->sys->write(zip->output, zip->o_ptr, i) != i) {
+      return zip->error = MSPACK_ERR_WRITE;
+    }
+
+    /* mspack errors (i.e. read errors) are fatal and can't be recovered */
+    if ((error > 0) && zip->repair_mode) return error;
+
+    zip->o_ptr  += i;
+    out_bytes   -= i;
+  }
+
+  if (out_bytes) {
+    D(("bytes left to output"))
+    return zip->error = MSPACK_ERR_DECRUNCH;
+  }
+  return MSPACK_ERR_OK;
+}
+
+int mszipd_decompress_kwaj(struct mszipd_stream *zip) {
+    DECLARE_BIT_VARS;
+    int i, error, block_len;
+
+    /* unpack blocks until block_len == 0 */
+    for (;;) {
+        RESTORE_BITS;
+
+        /* align to bytestream, read block_len */
+        i = bits_left & 7; REMOVE_BITS(i);
+        READ_BITS(block_len, 8);
+        READ_BITS(i, 8); block_len |= i << 8;
+
+        if (block_len == 0) break;
+
+        /* read "CK" header */
+        READ_BITS(i, 8); if (i != 'C') return MSPACK_ERR_DATAFORMAT;
+        READ_BITS(i, 8); if (i != 'K') return MSPACK_ERR_DATAFORMAT;
+
+        /* inflate block */
+        zip->window_posn = 0;
+        zip->bytes_output = 0;
+        STORE_BITS;
+        if ((error = inflate(zip))) {
+            D(("inflate error %d", error))
+            return zip->error = (error > 0) ? error : MSPACK_ERR_DECRUNCH;
+        }
+
+        /* write inflated block */
+        if (zip->sys->write(zip->output, &zip->window[0], zip->bytes_output)
+            != zip->bytes_output) return zip->error = MSPACK_ERR_WRITE;
+    }
+    return MSPACK_ERR_OK;
+}
+
+void mszipd_free(struct mszipd_stream *zip) {
+  struct mspack_system *sys;
+  if (zip) {
+    sys = zip->sys;
+    sys->free(zip->inbuf);
+    sys->free(zip);
+  }
+}

--- a/third_party/libmspack/mspack/qtm.h
+++ b/third_party/libmspack/mspack/qtm.h
@@ -1,0 +1,128 @@
+/* This file is part of libmspack.
+ * (C) 2003-2004 Stuart Caie.
+ *
+ * The Quantum method was created by David Stafford, adapted by Microsoft
+ * Corporation.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+#ifndef MSPACK_QTM_H
+#define MSPACK_QTM_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Quantum compression / decompression definitions */
+
+#define QTM_FRAME_SIZE (32768)
+
+struct qtmd_modelsym {
+  unsigned short sym, cumfreq;
+};
+
+struct qtmd_model {
+  int shiftsleft, entries;
+  struct qtmd_modelsym *syms;
+};
+
+struct qtmd_stream {
+  struct mspack_system *sys;      /* I/O routines                            */
+  struct mspack_file   *input;    /* input file handle                       */
+  struct mspack_file   *output;   /* output file handle                      */
+
+  unsigned char *window;          /* decoding window                         */
+  unsigned int window_size;       /* window size                             */
+  unsigned int window_posn;       /* decompression offset within window      */
+  unsigned int frame_todo;        /* bytes remaining for current frame       */
+
+  unsigned short H, L, C;         /* high/low/current: arith coding state    */
+  unsigned char header_read;      /* have we started decoding a new frame?   */
+
+  int error;
+
+  /* I/O buffers */
+  unsigned char *inbuf, *i_ptr, *i_end, *o_ptr, *o_end;
+  unsigned int  bit_buffer, inbuf_size;
+  unsigned char bits_left, input_end;
+
+  /* four literal models, each representing 64 symbols
+   * model0 for literals from   0 to  63 (selector = 0)
+   * model1 for literals from  64 to 127 (selector = 1)
+   * model2 for literals from 128 to 191 (selector = 2)
+   * model3 for literals from 129 to 255 (selector = 3) */
+  struct qtmd_model model0, model1, model2, model3;
+
+  /* three match models.
+   * model4 for match with fixed length of 3 bytes
+   * model5 for match with fixed length of 4 bytes
+   * model6 for variable length match, encoded with model6len model */
+  struct qtmd_model model4, model5, model6, model6len;
+
+  /* selector model. 0-6 to say literal (0,1,2,3) or match (4,5,6) */
+  struct qtmd_model model7;
+
+  /* symbol arrays for all models */
+  struct qtmd_modelsym m0sym[64 + 1];
+  struct qtmd_modelsym m1sym[64 + 1];
+  struct qtmd_modelsym m2sym[64 + 1];
+  struct qtmd_modelsym m3sym[64 + 1];
+  struct qtmd_modelsym m4sym[24 + 1];
+  struct qtmd_modelsym m5sym[36 + 1];
+  struct qtmd_modelsym m6sym[42 + 1], m6lsym[27 + 1];
+  struct qtmd_modelsym m7sym[7 + 1];
+};
+
+/* allocates Quantum decompression state for decoding the given stream.
+ *
+ * - returns NULL if window_bits is outwith the range 10 to 21 (inclusive).
+ *
+ * - uses system->alloc() to allocate memory
+ *
+ * - returns NULL if not enough memory
+ *
+ * - window_bits is the size of the Quantum window, from 1Kb (10) to 2Mb (21).
+ *
+ * - input_buffer_size is the number of bytes to use to store bitstream data.
+ */
+extern struct qtmd_stream *qtmd_init(struct mspack_system *system,
+                                     struct mspack_file *input,
+                                     struct mspack_file *output,
+                                     int window_bits,
+                                     int input_buffer_size);
+
+/* decompresses, or decompresses more of, a Quantum stream.
+ *
+ * - out_bytes of data will be decompressed and the function will return
+ *   with an MSPACK_ERR_OK return code.
+ *
+ * - decompressing will stop as soon as out_bytes is reached. if the true
+ *   amount of bytes decoded spills over that amount, they will be kept for
+ *   a later invocation of qtmd_decompress().
+ *
+ * - the output bytes will be passed to the system->write() function given in
+ *   qtmd_init(), using the output file handle given in qtmd_init(). More
+ *   than one call may be made to system->write()
+ *
+ * - Quantum will read input bytes as necessary using the system->read()
+ *   function given in qtmd_init(), using the input file handle given in
+ *   qtmd_init(). This will continue until system->read() returns 0 bytes,
+ *   or an error.
+ */
+extern int qtmd_decompress(struct qtmd_stream *qtm, off_t out_bytes);
+
+/* frees all state associated with a Quantum data stream
+ *
+ * - calls system->free() using the system pointer given in qtmd_init()
+ */
+void qtmd_free(struct qtmd_stream *qtm);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/third_party/libmspack/mspack/qtmd.c
+++ b/third_party/libmspack/mspack/qtmd.c
@@ -1,0 +1,488 @@
+/* This file is part of libmspack.
+ * (C) 2003-2023 Stuart Caie.
+ *
+ * The Quantum method was created by David Stafford, adapted by Microsoft
+ * Corporation.
+ *
+ * This decompressor is based on an implementation by Matthew Russotto, used
+ * with permission.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+/* Quantum decompression implementation */
+
+/* This decompressor was researched and implemented by Matthew Russotto. It
+ * has since been tidied up by Stuart Caie. More information can be found at
+ * http://www.speakeasy.org/~russotto/quantumcomp.html
+ */
+
+#include <system.h>
+#include <qtm.h>
+
+/* import bit-reading macros and code */
+#define BITS_TYPE struct qtmd_stream
+#define BITS_VAR qtm
+#define BITS_ORDER_MSB
+#define READ_BYTES do {                 \
+    unsigned char b0, b1;               \
+    READ_IF_NEEDED; b0 = *i_ptr++;      \
+    READ_IF_NEEDED; b1 = *i_ptr++;      \
+    INJECT_BITS((b0 << 8) | b1, 16);    \
+} while (0)
+#include <readbits.h>
+
+/* Quantum static data tables:
+ *
+ * Quantum uses 'position slots' to represent match offsets.  For every
+ * match, a small 'position slot' number and a small offset from that slot
+ * are encoded instead of one large offset.
+ *
+ * position_base[] is an index to the position slot bases
+ *
+ * extra_bits[] states how many bits of offset-from-base data is needed.
+ *
+ * length_base[] and length_extra[] are equivalent in function, but are
+ * used for encoding selector 6 (variable length match) match lengths,
+ * instead of match offsets.
+ *
+ * They are generated with the following code:
+ *   unsigned int i, offset;
+ *   for (i = 0, offset = 0; i < 42; i++) {
+ *     position_base[i] = offset;
+ *     extra_bits[i] = ((i < 2) ? 0 : (i - 2)) >> 1;
+ *     offset += 1 << extra_bits[i];
+ *   }
+ *   for (i = 0, offset = 0; i < 26; i++) {
+ *     length_base[i] = offset;
+ *     length_extra[i] = (i < 2 ? 0 : i - 2) >> 2;
+ *     offset += 1 << length_extra[i];
+ *   }
+ *   length_base[26] = 254; length_extra[26] = 0;
+ */
+static const unsigned int position_base[42] = {
+  0, 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128, 192, 256, 384, 512, 768,
+  1024, 1536, 2048, 3072, 4096, 6144, 8192, 12288, 16384, 24576, 32768, 49152,
+  65536, 98304, 131072, 196608, 262144, 393216, 524288, 786432, 1048576, 1572864
+};
+static const unsigned char extra_bits[42] = {
+  0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10,
+  11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19
+};
+static const unsigned char length_base[27] = {
+  0, 1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 18, 22, 26,
+  30, 38, 46, 54, 62, 78, 94, 110, 126, 158, 190, 222, 254
+};
+static const unsigned char length_extra[27] = {
+  0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2,
+  3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0
+};
+
+
+/* Arithmetic decoder:
+ * 
+ * GET_SYMBOL(model, var) fetches the next symbol from the stated model
+ * and puts it in var.
+ *
+ * If necessary, qtmd_update_model() is called.
+ */
+#define GET_SYMBOL(model, var) do {                                     \
+  range = ((H - L) & 0xFFFF) + 1;                                       \
+  symf = ((((C - L + 1) * model.syms[0].cumfreq)-1) / range) & 0xFFFF;  \
+                                                                        \
+  for (i = 1; i < model.entries; i++) {                                 \
+    if (model.syms[i].cumfreq <= symf) break;                           \
+  }                                                                     \
+  (var) = model.syms[i-1].sym;                                          \
+                                                                        \
+  range = (H - L) + 1;                                                  \
+  symf = model.syms[0].cumfreq;                                         \
+  H = L + ((model.syms[i-1].cumfreq * range) / symf) - 1;               \
+  L = L + ((model.syms[i].cumfreq   * range) / symf);                   \
+                                                                        \
+  do { model.syms[--i].cumfreq += 8; } while (i > 0);                   \
+  if (model.syms[0].cumfreq > 3800) qtmd_update_model(&model);          \
+                                                                        \
+  while (1) {                                                           \
+    if ((L & 0x8000) != (H & 0x8000)) {                                 \
+      if ((L & 0x4000) && !(H & 0x4000)) {                              \
+        /* underflow case */                                            \
+        C ^= 0x4000; L &= 0x3FFF; H |= 0x4000;                          \
+      }                                                                 \
+      else break;                                                       \
+    }                                                                   \
+    L <<= 1; H = (H << 1) | 1;                                          \
+    ENSURE_BITS(1);                                                     \
+    C  = (C << 1) | PEEK_BITS(1);                                       \
+    REMOVE_BITS(1);                                                     \
+  }                                                                     \
+} while (0)
+
+static void qtmd_update_model(struct qtmd_model *model) {
+  struct qtmd_modelsym tmp;
+  int i, j;
+
+  if (--model->shiftsleft) {
+    for (i = model->entries - 1; i >= 0; i--) {
+      /* -1, not -2; the 0 entry saves this */
+      model->syms[i].cumfreq >>= 1;
+      if (model->syms[i].cumfreq <= model->syms[i+1].cumfreq) {
+        model->syms[i].cumfreq = model->syms[i+1].cumfreq + 1;
+      }
+    }
+  }
+  else {
+    model->shiftsleft = 50;
+    for (i = 0; i < model->entries; i++) {
+      /* no -1, want to include the 0 entry */
+      /* this converts cumfreqs into frequencies, then shifts right */
+      model->syms[i].cumfreq -= model->syms[i+1].cumfreq;
+      model->syms[i].cumfreq++; /* avoid losing things entirely */
+      model->syms[i].cumfreq >>= 1;
+    }
+
+    /* now sort by frequencies, decreasing order -- this must be an
+     * inplace selection sort, or a sort with the same (in)stability
+     * characteristics */
+    for (i = 0; i < model->entries - 1; i++) {
+      for (j = i + 1; j < model->entries; j++) {
+        if (model->syms[i].cumfreq < model->syms[j].cumfreq) {
+          tmp = model->syms[i];
+          model->syms[i] = model->syms[j];
+          model->syms[j] = tmp;
+        }
+      }
+    }
+
+    /* then convert frequencies back to cumfreq */
+    for (i = model->entries - 1; i >= 0; i--) {
+      model->syms[i].cumfreq += model->syms[i+1].cumfreq;
+    }
+  }
+}
+
+/* Initialises a model to decode symbols from [start] to [start]+[len]-1 */
+static void qtmd_init_model(struct qtmd_model *model,
+                            struct qtmd_modelsym *syms, int start, int len)
+{
+  int i;
+
+  model->shiftsleft = 4;
+  model->entries    = len;
+  model->syms       = syms;
+
+  for (i = 0; i <= len; i++) {
+    syms[i].sym     = start + i; /* actual symbol */
+    syms[i].cumfreq = len - i;   /* current frequency of that symbol */
+  }
+}
+
+
+/*-------- main Quantum code --------*/
+
+struct qtmd_stream *qtmd_init(struct mspack_system *system,
+                              struct mspack_file *input,
+                              struct mspack_file *output,
+                              int window_bits, int input_buffer_size)
+{
+  unsigned int window_size = 1 << window_bits;
+  struct qtmd_stream *qtm;
+  int i;
+
+  if (!system) return NULL;
+
+  /* Quantum supports window sizes of 2^10 (1Kb) through 2^21 (2Mb) */
+  if (window_bits < 10 || window_bits > 21) return NULL;
+
+  /* round up input buffer size to multiple of two */
+  input_buffer_size = (input_buffer_size + 1) & -2;
+  if (input_buffer_size < 2) return NULL;
+
+  /* allocate decompression state */
+  if (!(qtm = (struct qtmd_stream *) system->alloc(system, sizeof(struct qtmd_stream)))) {
+    return NULL;
+  }
+
+  /* allocate decompression window and input buffer */
+  qtm->window = (unsigned char *) system->alloc(system, (size_t) window_size);
+  qtm->inbuf  = (unsigned char *) system->alloc(system, (size_t) input_buffer_size);
+  if (!qtm->window || !qtm->inbuf) {
+    system->free(qtm->window);
+    system->free(qtm->inbuf);
+    system->free(qtm);
+    return NULL;
+  }
+
+  /* initialise decompression state */
+  qtm->sys         = system;
+  qtm->input       = input;
+  qtm->output      = output;
+  qtm->inbuf_size  = input_buffer_size;
+  qtm->window_size = window_size;
+  qtm->window_posn = 0;
+  qtm->frame_todo  = QTM_FRAME_SIZE;
+  qtm->header_read = 0;
+  qtm->error       = MSPACK_ERR_OK;
+
+  qtm->i_ptr = qtm->i_end = &qtm->inbuf[0];
+  qtm->o_ptr = qtm->o_end = &qtm->window[0];
+  qtm->input_end = 0;
+  qtm->bits_left = 0;
+  qtm->bit_buffer = 0;
+
+  /* initialise arithmetic coding models
+   * - model 4    depends on window size, ranges from 20 to 24
+   * - model 5    depends on window size, ranges from 20 to 36
+   * - model 6pos depends on window size, ranges from 20 to 42
+   */
+  i = window_bits * 2;
+  qtmd_init_model(&qtm->model0,    &qtm->m0sym[0],   0, 64);
+  qtmd_init_model(&qtm->model1,    &qtm->m1sym[0],  64, 64);
+  qtmd_init_model(&qtm->model2,    &qtm->m2sym[0], 128, 64);
+  qtmd_init_model(&qtm->model3,    &qtm->m3sym[0], 192, 64);
+  qtmd_init_model(&qtm->model4,    &qtm->m4sym[0],   0, (i > 24) ? 24 : i);
+  qtmd_init_model(&qtm->model5,    &qtm->m5sym[0],   0, (i > 36) ? 36 : i);
+  qtmd_init_model(&qtm->model6,    &qtm->m6sym[0],   0, i);
+  qtmd_init_model(&qtm->model6len, &qtm->m6lsym[0],  0, 27);
+  qtmd_init_model(&qtm->model7,    &qtm->m7sym[0],   0, 7);
+
+  /* all ok */
+  return qtm;
+}
+
+int qtmd_decompress(struct qtmd_stream *qtm, off_t out_bytes) {
+  DECLARE_BIT_VARS;
+  unsigned int frame_todo, frame_end, window_posn, match_offset, range;
+  unsigned char *window, *runsrc, *rundest;
+  int i, j, selector, extra, sym, match_length;
+  unsigned short H, L, C, symf;
+
+  /* easy answers */
+  if (!qtm || (out_bytes < 0)) return MSPACK_ERR_ARGS;
+  if (qtm->error) return qtm->error;
+
+  /* flush out any stored-up bytes before we begin */
+  i = qtm->o_end - qtm->o_ptr;
+  if ((off_t) i > out_bytes) i = (int) out_bytes;
+  if (i) {
+    if (qtm->sys->write(qtm->output, qtm->o_ptr, i) != i) {
+      return qtm->error = MSPACK_ERR_WRITE;
+    }
+    qtm->o_ptr  += i;
+    out_bytes   -= i;
+  }
+  if (out_bytes == 0) return MSPACK_ERR_OK;
+
+  /* restore local state */
+  RESTORE_BITS;
+  window = qtm->window;
+  window_posn = qtm->window_posn;
+  frame_todo = qtm->frame_todo;
+  H = qtm->H;
+  L = qtm->L;
+  C = qtm->C;
+
+  /* while we do not have enough decoded bytes in reserve: */
+  while ((qtm->o_end - qtm->o_ptr) < out_bytes) {
+    /* read header if necessary. Initialises H, L and C */
+    if (!qtm->header_read) {
+      H = 0xFFFF; L = 0; READ_BITS(C, 16);
+      qtm->header_read = 1;
+    }
+
+    /* decode more, up to the number of bytes needed, the frame boundary,
+     * or the window boundary, whichever comes first */
+    frame_end = window_posn + (out_bytes - (qtm->o_end - qtm->o_ptr));
+    if ((window_posn + frame_todo) < frame_end) {
+      frame_end = window_posn + frame_todo;
+    }
+    if (frame_end > qtm->window_size) {
+      frame_end = qtm->window_size;
+    }
+
+    while (window_posn < frame_end) {
+      GET_SYMBOL(qtm->model7, selector);
+      if (selector < 4) {
+        /* literal byte */
+        struct qtmd_model *mdl = (selector == 0) ? &qtm->model0 :
+                                ((selector == 1) ? &qtm->model1 :
+                                ((selector == 2) ? &qtm->model2 :
+                                                   &qtm->model3));
+        GET_SYMBOL((*mdl), sym);
+        window[window_posn++] = sym;
+        frame_todo--;
+      }
+      else {
+        /* match repeated string */
+        switch (selector) {
+        case 4: /* selector 4 = fixed length match (3 bytes) */
+          GET_SYMBOL(qtm->model4, sym);
+          READ_MANY_BITS(extra, extra_bits[sym]);
+          match_offset = position_base[sym] + extra + 1;
+          match_length = 3;
+          break;
+
+        case 5: /* selector 5 = fixed length match (4 bytes) */
+          GET_SYMBOL(qtm->model5, sym);
+          READ_MANY_BITS(extra, extra_bits[sym]);
+          match_offset = position_base[sym] + extra + 1;
+          match_length = 4;
+          break;
+
+        case 6: /* selector 6 = variable length match */
+          GET_SYMBOL(qtm->model6len, sym);
+          READ_MANY_BITS(extra, length_extra[sym]);
+          match_length = length_base[sym] + extra + 5;
+
+          GET_SYMBOL(qtm->model6, sym);
+          READ_MANY_BITS(extra, extra_bits[sym]);
+          match_offset = position_base[sym] + extra + 1;
+          break;
+
+        default:
+          /* should be impossible, model7 can only return 0-6 */
+          D(("got %d from selector", selector))
+          return qtm->error = MSPACK_ERR_DECRUNCH;
+        }
+
+        rundest = &window[window_posn];
+        frame_todo -= match_length;
+
+        /* does match destination wrap the window? This situation is possible
+         * where the window size is less than the 32k frame size, but matches
+         * must not go beyond a frame boundary */
+        if ((window_posn + match_length) > qtm->window_size) {
+          /* copy first part of match, before window end */
+          i = qtm->window_size - window_posn;
+          j = window_posn - match_offset;
+          while (i--) *rundest++ = window[j++ & (qtm->window_size - 1)];
+
+          /* flush currently stored data */
+          i = (&window[qtm->window_size] - qtm->o_ptr);
+
+          /* this should not happen, but if it does then this code
+           * can't handle the situation (can't flush up to the end of
+           * the window, but can't break out either because we haven't
+           * finished writing the match). bail out in this case */
+          if (i > out_bytes) {
+            D(("during window-wrap match; %d bytes to flush but only need %d",
+               i, (int) out_bytes))
+            return qtm->error = MSPACK_ERR_DECRUNCH;
+          }
+          if (qtm->sys->write(qtm->output, qtm->o_ptr, i) != i) {
+            return qtm->error = MSPACK_ERR_WRITE;
+          }
+          out_bytes -= i;
+          qtm->o_ptr = &window[0];
+          qtm->o_end = &window[0]; 
+
+          /* copy second part of match, after window wrap */
+          rundest = &window[0];
+          i = match_length - (qtm->window_size - window_posn);
+          while (i--) *rundest++ = window[j++ & (qtm->window_size - 1)];
+          window_posn = window_posn + match_length - qtm->window_size;
+
+          break; /* because "window_posn < frame_end" has now failed */
+        }
+        else {
+          /* normal match - output won't wrap window or frame end */
+          i = match_length;
+
+          /* does match _offset_ wrap the window? */
+          if (match_offset > window_posn) {
+            /* j = length from match offset to end of window */
+            j = match_offset - window_posn;
+            if (j > (int) qtm->window_size) {
+              D(("match offset beyond window boundaries"))
+              return qtm->error = MSPACK_ERR_DECRUNCH;
+            }
+            runsrc = &window[qtm->window_size - j];
+            if (j < i) {
+              /* if match goes over the window edge, do two copy runs */
+              i -= j; while (j-- > 0) *rundest++ = *runsrc++;
+              runsrc = window;
+            }
+            while (i-- > 0) *rundest++ = *runsrc++;
+          }
+          else {
+            runsrc = rundest - match_offset;
+            while (i-- > 0) *rundest++ = *runsrc++;
+          }
+          window_posn += match_length;
+        }
+      } /* if (window_posn+match_length > frame_end) */
+    } /* while (window_posn < frame_end) */
+
+    qtm->o_end = &window[window_posn];
+
+   /* if we subtracted too much from frame_todo, it will
+    * wrap around past zero and go above its max value */
+   if (frame_todo > QTM_FRAME_SIZE) {
+     D(("overshot frame alignment"))
+     return qtm->error = MSPACK_ERR_DECRUNCH;
+   }
+
+    /* another frame completed? */
+    if (frame_todo == 0) {
+      /* re-align input */
+      if (bits_left & 7) REMOVE_BITS(bits_left & 7);
+
+      /* special Quantum hack -- cabd.c injects a trailer byte to allow the
+       * decompressor to realign itself. CAB Quantum blocks, unlike LZX
+       * blocks, can have anything from 0 to 4 trailing null bytes. */
+      do { READ_BITS(i, 8); } while (i != 0xFF);
+
+      qtm->header_read = 0;
+
+      frame_todo = QTM_FRAME_SIZE;
+    }
+
+    /* window wrap? */
+    if (window_posn == qtm->window_size) {
+      /* flush all currently stored data */
+      i = (qtm->o_end - qtm->o_ptr);
+      /* break out if we have more than enough to finish this request */
+      if (i >= out_bytes) break;
+      if (qtm->sys->write(qtm->output, qtm->o_ptr, i) != i) {
+        return qtm->error = MSPACK_ERR_WRITE;
+      }
+      out_bytes -= i;
+      qtm->o_ptr = &window[0];
+      qtm->o_end = &window[0]; 
+      window_posn = 0;
+   }
+
+  } /* while (more bytes needed) */
+
+  if (out_bytes) {
+    i = (int) out_bytes;
+    if (qtm->sys->write(qtm->output, qtm->o_ptr, i) != i) {
+      return qtm->error = MSPACK_ERR_WRITE;
+    }
+    qtm->o_ptr += i;
+  }
+
+  /* store local state */
+
+  STORE_BITS;
+  qtm->window_posn = window_posn;
+  qtm->frame_todo = frame_todo;
+  qtm->H = H;
+  qtm->L = L;
+  qtm->C = C;
+
+  return MSPACK_ERR_OK;
+}
+
+void qtmd_free(struct qtmd_stream *qtm) {
+  struct mspack_system *sys;
+  if (qtm) {
+    sys = qtm->sys;
+    sys->free(qtm->window);
+    sys->free(qtm->inbuf);
+    sys->free(qtm);
+  }
+}

--- a/third_party/libmspack/mspack/readbits.h
+++ b/third_party/libmspack/mspack/readbits.h
@@ -1,0 +1,216 @@
+/* This file is part of libmspack.
+ * (C) 2003-2010 Stuart Caie.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+#ifndef MSPACK_READBITS_H
+#define MSPACK_READBITS_H 1
+
+/* this header defines macros that read data streams by
+ * the individual bits
+ *
+ * DECLARE_BIT_VARS  declares local variables
+ * INIT_BITS         initialises bitstream state in state structure
+ * STORE_BITS        stores bitstream state in state structure
+ * RESTORE_BITS      restores bitstream state from state structure
+ * ENSURE_BITS(n)    ensure there are at least N bits in the bit buffer
+ * READ_BITS(var,n)  takes N bits from the buffer and puts them in var
+ * PEEK_BITS(n)      extracts without removing N bits from the bit buffer
+ * REMOVE_BITS(n)    removes N bits from the bit buffer
+ *
+ * READ_BITS simply calls ENSURE_BITS, PEEK_BITS and REMOVE_BITS,
+ * which means it's limited to reading the number of bits you can
+ * ensure at any one time. It also fails if asked to read zero bits.
+ * If you need to read zero bits, or more bits than can be ensured in
+ * one go, use READ_MANY_BITS instead.
+ *
+ * These macros have variable names baked into them, so to use them
+ * you have to define some macros:
+ * - BITS_TYPE: the type name of your state structure
+ * - BITS_VAR: the variable that points to your state structure
+ * - define BITS_ORDER_MSB if bits are read from the MSB, or
+ *   define BITS_ORDER_LSB if bits are read from the LSB
+ * - READ_BYTES: some code that reads more data into the bit buffer,
+ *   it should use READ_IF_NEEDED (calls read_input if the byte buffer
+ *   is empty), then INJECT_BITS(data,n) to put data from the byte
+ *   buffer into the bit buffer.
+ *
+ * You also need to define some variables and structure members:
+ * - unsigned char *i_ptr;    // current position in the byte buffer
+ * - unsigned char *i_end;    // end of the byte buffer
+ * - unsigned int bit_buffer; // the bit buffer itself
+ * - unsigned int bits_left;  // number of bits remaining
+ *
+ * If you use read_input() and READ_IF_NEEDED, they also expect these
+ * structure members:
+ * - struct mspack_system *sys;  // to access sys->read()
+ * - unsigned int error;         // to record/return read errors
+ * - unsigned char input_end;    // to mark reaching the EOF
+ * - unsigned char *inbuf;       // the input byte buffer
+ * - unsigned int inbuf_size;    // the size of the input byte buffer
+ *
+ * Your READ_BYTES implementation should read data from *i_ptr and
+ * put them in the bit buffer. READ_IF_NEEDED will call read_input()
+ * if i_ptr reaches i_end, and will fill up inbuf and set i_ptr to
+ * the start of inbuf and i_end to the end of inbuf.
+ *
+ * If you're reading in MSB order, the routines work by using the area
+ * beyond the MSB and the LSB of the bit buffer as a free source of
+ * zeroes when shifting. This avoids having to mask any bits. So we
+ * have to know the bit width of the bit buffer variable. We use
+ * <limits.h> and CHAR_BIT to find the size of the bit buffer in bits.
+ *
+ * If you are reading in LSB order, bits need to be masked. Normally
+ * this is done by computing the mask: N bits are masked by the value
+ * (1<<N)-1). However, you can define BITS_LSB_TABLE to use a lookup
+ * table instead of computing this. This adds two new macros,
+ * PEEK_BITS_T and READ_BITS_T which work the same way as PEEK_BITS
+ * and READ_BITS, except they use this lookup table. This is useful if
+ * you need to look up a number of bits that are only known at
+ * runtime, so the bit mask can't be turned into a constant by the
+ * compiler.
+
+ * The bit buffer datatype should be at least 32 bits wide: it must be
+ * possible to ENSURE_BITS(17), so it must be possible to add 16 new bits
+ * to the bit buffer when the bit buffer already has 1 to 15 bits left.
+ */
+
+#ifndef BITS_VAR
+# error "define BITS_VAR as the state structure poiner variable name"
+#endif
+#ifndef BITS_TYPE
+# error "define BITS_TYPE as the state structure type"
+#endif
+#if defined(BITS_ORDER_MSB) && defined(BITS_ORDER_LSB)
+# error "you must define either BITS_ORDER_MSB or BITS_ORDER_LSB"
+#else
+# if !(defined(BITS_ORDER_MSB) || defined(BITS_ORDER_LSB))
+#  error "you must define BITS_ORDER_MSB or BITS_ORDER_LSB"
+# endif
+#endif
+
+typedef unsigned int bitbuf_type;
+
+#if HAVE_LIMITS_H
+# include <limits.h>
+#endif
+#ifndef CHAR_BIT
+# define CHAR_BIT (8)
+#endif
+#define BITBUF_WIDTH (sizeof(bitbuf_type) * CHAR_BIT)
+
+#define DECLARE_BIT_VARS \
+   unsigned char *i_ptr, *i_end; \
+   register bitbuf_type bit_buffer; \
+   register int bits_left
+
+#define INIT_BITS do {                          \
+    BITS_VAR->i_ptr      = &BITS_VAR->inbuf[0]; \
+    BITS_VAR->i_end      = &BITS_VAR->inbuf[0]; \
+    BITS_VAR->bit_buffer = 0;                   \
+    BITS_VAR->bits_left  = 0;                   \
+    BITS_VAR->input_end  = 0;                   \
+} while (0)
+
+#define STORE_BITS do {                 \
+    BITS_VAR->i_ptr      = i_ptr;       \
+    BITS_VAR->i_end      = i_end;       \
+    BITS_VAR->bit_buffer = bit_buffer;  \
+    BITS_VAR->bits_left  = bits_left;   \
+} while (0)
+
+#define RESTORE_BITS do {               \
+    i_ptr      = BITS_VAR->i_ptr;       \
+    i_end      = BITS_VAR->i_end;       \
+    bit_buffer = BITS_VAR->bit_buffer;  \
+    bits_left  = BITS_VAR->bits_left;   \
+} while (0)
+
+#define ENSURE_BITS(nbits) do {                 \
+    while (bits_left < (nbits)) READ_BYTES;     \
+} while (0)
+
+#define READ_BITS(val, nbits) do {              \
+    ENSURE_BITS(nbits);                         \
+    (val) = PEEK_BITS(nbits);                   \
+    REMOVE_BITS(nbits);                         \
+} while (0)
+
+#define READ_MANY_BITS(val, bits) do {                          \
+    unsigned char needed = (bits), bitrun;                      \
+    (val) = 0;                                                  \
+    while (needed > 0) {                                        \
+        if (bits_left <= (int)(BITBUF_WIDTH - 16)) READ_BYTES;	\
+        bitrun = (bits_left < needed) ? bits_left : needed;     \
+        (val) = ((val) << bitrun) | PEEK_BITS(bitrun);          \
+        REMOVE_BITS(bitrun);                                    \
+        needed -= bitrun;                                       \
+    }                                                           \
+} while (0)
+
+#ifdef BITS_ORDER_MSB
+# define PEEK_BITS(nbits)   (bit_buffer >> (BITBUF_WIDTH - (nbits)))
+# define REMOVE_BITS(nbits) ((bit_buffer <<= (nbits)), (bits_left -= (nbits)))
+# define INJECT_BITS(bitdata,nbits) ((bit_buffer |= \
+    (bitbuf_type)(bitdata) << (BITBUF_WIDTH - (nbits) - bits_left)), \
+    (bits_left += (nbits)))
+#else /* BITS_ORDER_LSB */
+# define PEEK_BITS(nbits)   (bit_buffer & ((bitbuf_type)(1 << (nbits))-1))
+# define REMOVE_BITS(nbits) ((bit_buffer >>= (nbits)), (bits_left -= (nbits)))
+# define INJECT_BITS(bitdata,nbits) ((bit_buffer |= \
+    (bitbuf_type)(bitdata) << bits_left), (bits_left += (nbits)))
+#endif
+
+#ifdef BITS_LSB_TABLE
+/* lsb_bit_mask[n] = (1 << n) - 1 */
+static const unsigned short lsb_bit_mask[17] = {
+    0x0000, 0x0001, 0x0003, 0x0007, 0x000f, 0x001f, 0x003f, 0x007f, 0x00ff,
+    0x01ff, 0x03ff, 0x07ff, 0x0fff, 0x1fff, 0x3fff, 0x7fff, 0xffff
+};
+# define PEEK_BITS_T(nbits) (bit_buffer & lsb_bit_mask[(nbits)])
+# define READ_BITS_T(val, nbits) do {   \
+    ENSURE_BITS(nbits);                 \
+    (val) = PEEK_BITS_T(nbits);         \
+    REMOVE_BITS(nbits);                 \
+} while (0)
+#endif
+
+#ifndef BITS_NO_READ_INPUT
+# define READ_IF_NEEDED do {            \
+    if (i_ptr >= i_end) {               \
+        if (read_input(BITS_VAR))       \
+            return BITS_VAR->error;     \
+        i_ptr = BITS_VAR->i_ptr;        \
+        i_end = BITS_VAR->i_end;        \
+    }                                   \
+} while (0)
+
+static int read_input(BITS_TYPE *p) {
+    int read = p->sys->read(p->input, &p->inbuf[0], (int)p->inbuf_size);
+    if (read < 0) return p->error = MSPACK_ERR_READ;
+
+    /* we might overrun the input stream by asking for bits we don't use,
+     * so fake 2 more bytes at the end of input */
+    if (read == 0) {
+        if (p->input_end) {
+            D(("out of input bytes"))
+            return p->error = MSPACK_ERR_READ;
+        }
+        else {
+            read = 2;
+            p->inbuf[0] = p->inbuf[1] = 0;
+            p->input_end = 1;
+        }
+    }
+
+    /* update i_ptr and i_end */
+    p->i_ptr = &p->inbuf[0];
+    p->i_end = &p->inbuf[read];
+    return MSPACK_ERR_OK;
+}
+#endif
+#endif

--- a/third_party/libmspack/mspack/readhuff.h
+++ b/third_party/libmspack/mspack/readhuff.h
@@ -1,0 +1,177 @@
+/* This file is part of libmspack.
+ * (C) 2003-2014 Stuart Caie.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+#ifndef MSPACK_READHUFF_H
+#define MSPACK_READHUFF_H 1
+
+/* This implements a fast Huffman tree decoding system. */
+
+#if !(defined(BITS_ORDER_MSB) || defined(BITS_ORDER_LSB))
+# error "readhuff.h is used in conjunction with readbits.h, include that first"
+#endif
+#if !(defined(TABLEBITS) && defined(MAXSYMBOLS))
+# error "define TABLEBITS(tbl) and MAXSYMBOLS(tbl) before using readhuff.h"
+#endif
+#if !(defined(HUFF_TABLE) && defined(HUFF_LEN))
+# error "define HUFF_TABLE(tbl) and HUFF_LEN(tbl) before using readhuff.h"
+#endif
+#ifndef HUFF_ERROR
+# error "define HUFF_ERROR before using readhuff.h"
+#endif
+#ifndef HUFF_MAXBITS
+# define HUFF_MAXBITS 16
+#endif
+
+#define DECLARE_HUFF_VARS \
+   DECLARE_BIT_VARS; \
+   register int huff_idx; \
+   register unsigned short huff_sym
+
+/* Decodes the next huffman symbol from the input bitstream into var.
+ * Do not use this macro on a table unless build_decode_table() succeeded.
+ */
+#define READ_HUFFSYM(tbl, var) do {                                 \
+    ENSURE_BITS(HUFF_MAXBITS);                                      \
+    huff_sym = HUFF_TABLE(tbl, PEEK_BITS(TABLEBITS(tbl)));          \
+    if (huff_sym >= MAXSYMBOLS(tbl)) HUFF_TRAVERSE(tbl);            \
+    (var) = huff_sym;                                               \
+    huff_idx = HUFF_LEN(tbl, huff_sym);                             \
+    REMOVE_BITS(huff_idx);                                          \
+} while (0)
+
+#ifdef BITS_ORDER_LSB
+# define HUFF_TRAVERSE(tbl) do {                                    \
+    huff_idx = TABLEBITS(tbl) - 1;                                  \
+    do {                                                            \
+        if (huff_idx++ > HUFF_MAXBITS) HUFF_ERROR;                  \
+        huff_sym = HUFF_TABLE(tbl,                                  \
+            (huff_sym << 1) | ((bit_buffer >> huff_idx) & 1));      \
+    } while (huff_sym >= MAXSYMBOLS(tbl));                          \
+} while (0)
+#else
+#define HUFF_TRAVERSE(tbl) do {                                     \
+    huff_idx = 1 << (BITBUF_WIDTH - TABLEBITS(tbl));                \
+    do {                                                            \
+        if ((huff_idx >>= 1) == 0) HUFF_ERROR;                      \
+        huff_sym = HUFF_TABLE(tbl,                                  \
+            (huff_sym << 1) | ((bit_buffer & huff_idx) ? 1 : 0));   \
+    } while (huff_sym >= MAXSYMBOLS(tbl));                          \
+} while (0)
+#endif
+
+/* make_decode_table(nsyms, nbits, length[], table[])
+ *
+ * This function was originally coded by David Tritscher.
+ * It builds a fast huffman decoding table from
+ * a canonical huffman code lengths table.
+ *
+ * nsyms  = total number of symbols in this huffman tree.
+ * nbits  = any symbols with a code length of nbits or less can be decoded
+ *          in one lookup of the table.
+ * length = A table to get code lengths from [0 to nsyms-1]
+ * table  = The table to fill up with decoded symbols and pointers.
+ *          Should be ((1<<nbits) + (nsyms*2)) in length.
+ *
+ * Returns 0 for OK or 1 for error
+ */
+static int make_decode_table(unsigned int nsyms, unsigned int nbits,
+                             unsigned char *length, unsigned short *table)
+{
+    register unsigned short sym, next_symbol;
+    register unsigned int leaf, fill;
+#ifdef BITS_ORDER_LSB
+    register unsigned int reverse;
+#endif
+    register unsigned char bit_num;
+    unsigned int pos         = 0; /* the current position in the decode table */
+    unsigned int table_mask  = 1 << nbits;
+    unsigned int bit_mask    = table_mask >> 1; /* don't do 0 length codes */
+
+    /* fill entries for codes short enough for a direct mapping */
+    for (bit_num = 1; bit_num <= nbits; bit_num++) {
+        for (sym = 0; sym < nsyms; sym++) {
+            if (length[sym] != bit_num) continue;
+#ifdef BITS_ORDER_MSB
+            leaf = pos;
+#else
+            /* reverse the significant bits */
+            fill = length[sym]; reverse = pos >> (nbits - fill); leaf = 0;
+            do {leaf <<= 1; leaf |= reverse & 1; reverse >>= 1;} while (--fill);
+#endif
+
+            if((pos += bit_mask) > table_mask) return 1; /* table overrun */
+
+            /* fill all possible lookups of this symbol with the symbol itself */
+#ifdef BITS_ORDER_MSB
+            for (fill = bit_mask; fill-- > 0;) table[leaf++] = sym;
+#else
+            fill = bit_mask; next_symbol = 1 << bit_num;
+            do { table[leaf] = sym; leaf += next_symbol; } while (--fill);
+#endif
+        }
+        bit_mask >>= 1;
+    }
+
+    /* exit with success if table is now complete */
+    if (pos == table_mask) return 0;
+
+    /* mark all remaining table entries as unused */
+    for (sym = pos; sym < table_mask; sym++) {
+#ifdef BITS_ORDER_MSB
+        table[sym] = 0xFFFF;
+#else
+        reverse = sym; leaf = 0; fill = nbits;
+        do { leaf <<= 1; leaf |= reverse & 1; reverse >>= 1; } while (--fill);
+        table[leaf] = 0xFFFF;
+#endif
+    }
+
+    /* next_symbol = base of allocation for long codes */
+    next_symbol = ((table_mask >> 1) < nsyms) ? nsyms : (table_mask >> 1);
+
+    /* give ourselves room for codes to grow by up to 16 more bits.
+     * codes now start at bit nbits+16 and end at (nbits+16-codelength) */
+    pos <<= 16;
+    table_mask <<= 16;
+    bit_mask = 1 << 15;
+
+    for (bit_num = nbits+1; bit_num <= HUFF_MAXBITS; bit_num++) {
+        for (sym = 0; sym < nsyms; sym++) {
+            if (length[sym] != bit_num) continue;
+            if (pos >= table_mask) return 1; /* table overflow */
+
+#ifdef BITS_ORDER_MSB
+            leaf = pos >> 16;
+#else
+            /* leaf = the first nbits of the code, reversed */
+            reverse = pos >> 16; leaf = 0; fill = nbits;
+            do {leaf <<= 1; leaf |= reverse & 1; reverse >>= 1;} while (--fill);
+#endif
+            for (fill = 0; fill < (bit_num - nbits); fill++) {
+                /* if this path hasn't been taken yet, 'allocate' two entries */
+                if (table[leaf] == 0xFFFF) {
+                    table[(next_symbol << 1)     ] = 0xFFFF;
+                    table[(next_symbol << 1) + 1 ] = 0xFFFF;
+                    table[leaf] = next_symbol++;
+                }
+
+                /* follow the path and select either left or right for next bit */
+                leaf = table[leaf] << 1;
+                if ((pos >> (15-fill)) & 1) leaf++;
+            }
+            table[leaf] = sym;
+            pos += bit_mask;
+        }
+        bit_mask >>= 1;
+    }
+
+    /* full table? */
+    return (pos == table_mask) ? 0 : 1;
+}
+#endif

--- a/third_party/libmspack/mspack/system.c
+++ b/third_party/libmspack/mspack/system.c
@@ -1,0 +1,240 @@
+/* This file is part of libmspack.
+ * (C) 2003-2004 Stuart Caie.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <system.h>
+
+int mspack_version(int entity) {
+  switch (entity) {
+   /* CHM decoder version 1 -> 2 changes:
+    * - added mschmd_sec_mscompressed::spaninfo
+    * - added mschmd_header::first_pmgl
+    * - added mschmd_header::last_pmgl
+    * - added mschmd_header::chunk_cache;
+    */
+  case MSPACK_VER_MSCHMD:
+  /* CAB decoder version 1 -> 2 changes:
+   * - added MSCABD_PARAM_SALVAGE
+   */
+  case MSPACK_VER_MSCABD:
+  /* OAB decoder version  1 -> 2 changes:
+   * - added msoab_decompressor::set_param and MSOABD_PARAM_DECOMPBUF
+   */
+  case MSPACK_VER_MSOABD:
+    return 2;
+  case MSPACK_VER_LIBRARY:
+  case MSPACK_VER_SYSTEM:
+  case MSPACK_VER_MSSZDDD:
+  case MSPACK_VER_MSKWAJD:
+    return 1;
+  case MSPACK_VER_MSCABC:
+  case MSPACK_VER_MSCHMC:
+  case MSPACK_VER_MSLITD:
+  case MSPACK_VER_MSLITC:
+  case MSPACK_VER_MSHLPD:
+  case MSPACK_VER_MSHLPC:
+  case MSPACK_VER_MSSZDDC:
+  case MSPACK_VER_MSKWAJC:
+  case MSPACK_VER_MSOABC:
+    return 0;
+  }
+  return -1;
+}
+
+int mspack_sys_selftest_internal(int offt_size) {
+  return (sizeof(off_t) == offt_size) ? MSPACK_ERR_OK : MSPACK_ERR_SEEK;
+}
+
+/* validates a system structure */
+int mspack_valid_system(struct mspack_system *sys) {
+  return (sys != NULL) && (sys->open != NULL) && (sys->close != NULL) &&
+    (sys->read != NULL) && (sys->write != NULL) && (sys->seek != NULL) &&
+    (sys->tell != NULL) && (sys->message != NULL) && (sys->alloc != NULL) &&
+    (sys->free != NULL) && (sys->copy != NULL) && (sys->null_ptr == NULL);
+}
+
+/* returns the length of a file opened for reading */
+int mspack_sys_filelen(struct mspack_system *system,
+                       struct mspack_file *file, off_t *length)
+{
+  off_t current;
+
+  if (!system || !file || !length) return MSPACK_ERR_OPEN;
+
+  /* get current offset */
+  current = system->tell(file);
+
+  /* seek to end of file */
+  if (system->seek(file, (off_t) 0, MSPACK_SYS_SEEK_END)) {
+    return MSPACK_ERR_SEEK;
+  }
+
+  /* get offset of end of file */
+  *length = system->tell(file);
+
+  /* seek back to original offset */
+  if (system->seek(file, current, MSPACK_SYS_SEEK_START)) {
+    return MSPACK_ERR_SEEK;
+  }
+
+  return MSPACK_ERR_OK;
+}
+
+
+
+/* definition of mspack_default_system -- if the library is compiled with
+ * MSPACK_NO_DEFAULT_SYSTEM, no default system will be provided. Otherwise,
+ * an appropriate default system (e.g. the standard C library, or some native
+ * API calls)
+ */
+
+#ifdef MSPACK_NO_DEFAULT_SYSTEM
+struct mspack_system *mspack_default_system = NULL;
+#else
+
+/* implementation of mspack_default_system for standard C library */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+struct mspack_file_p {
+  FILE *fh;
+  const char *name;
+};
+
+static struct mspack_file *msp_open(struct mspack_system *self,
+                                    const char *filename, int mode)
+{
+  struct mspack_file_p *fh;
+  const char *fmode;
+
+  switch (mode) {
+  case MSPACK_SYS_OPEN_READ:   fmode = "rb";  break;
+  case MSPACK_SYS_OPEN_WRITE:  fmode = "wb";  break;
+  case MSPACK_SYS_OPEN_UPDATE: fmode = "r+b"; break;
+  case MSPACK_SYS_OPEN_APPEND: fmode = "ab";  break;
+  default: return NULL;
+  }
+
+  if ((fh = (struct mspack_file_p *) malloc(sizeof(struct mspack_file_p)))) {
+    fh->name = filename;
+    if ((fh->fh = fopen(filename, fmode))) return (struct mspack_file *) fh;
+    free(fh);
+  }
+  return NULL;
+}
+
+static void msp_close(struct mspack_file *file) {
+  struct mspack_file_p *self = (struct mspack_file_p *) file;
+  if (self) {
+    fclose(self->fh);
+    free(self);
+  }
+}
+
+static int msp_read(struct mspack_file *file, void *buffer, int bytes) {
+  struct mspack_file_p *self = (struct mspack_file_p *) file;
+  if (self && buffer && bytes >= 0) {
+    size_t count = fread(buffer, 1, (size_t) bytes, self->fh);
+    if (!ferror(self->fh)) return (int) count;
+  }
+  return -1;
+}
+
+static int msp_write(struct mspack_file *file, void *buffer, int bytes) {
+  struct mspack_file_p *self = (struct mspack_file_p *) file;
+  if (self && buffer && bytes >= 0) {
+    size_t count = fwrite(buffer, 1, (size_t) bytes, self->fh);
+    if (!ferror(self->fh)) return (int) count;
+  }
+  return -1;
+}
+
+static int msp_seek(struct mspack_file *file, off_t offset, int mode) {
+  struct mspack_file_p *self = (struct mspack_file_p *) file;
+  if (self) {
+    switch (mode) {
+    case MSPACK_SYS_SEEK_START: mode = SEEK_SET; break;
+    case MSPACK_SYS_SEEK_CUR:   mode = SEEK_CUR; break;
+    case MSPACK_SYS_SEEK_END:   mode = SEEK_END; break;
+    default: return -1;
+    }
+#if HAVE_FSEEKO
+    return fseeko(self->fh, offset, mode);
+#else
+    return fseek(self->fh, offset, mode);
+#endif
+  }
+  return -1;
+}
+
+static off_t msp_tell(struct mspack_file *file) {
+  struct mspack_file_p *self = (struct mspack_file_p *) file;
+#if HAVE_FSEEKO
+  return (self) ? (off_t) ftello(self->fh) : 0;
+#else
+  return (self) ? (off_t) ftell(self->fh) : 0;
+#endif
+}
+
+static void msp_msg(struct mspack_file *file, const char *format, ...) {
+  va_list ap;
+  if (file) fprintf(stderr, "%s: ", ((struct mspack_file_p *) file)->name);
+  va_start(ap, format);
+  vfprintf(stderr, format, ap);
+  va_end(ap);
+  fputc((int) '\n', stderr);
+  fflush(stderr);
+}
+
+static void *msp_alloc(struct mspack_system *self, size_t bytes) {
+#if DEBUG
+  /* make uninitialised data obvious */
+  char *buf = malloc(bytes + 8);
+  if (buf) memset(buf, 0xDC, bytes);
+  *((size_t *)buf) = bytes;
+  return &buf[8];
+#else
+  return malloc(bytes);
+#endif
+}
+
+static void msp_free(void *buffer) {
+#if DEBUG
+  char *buf = buffer;
+  size_t bytes;
+  if (buf) {
+    buf -= 8;
+    bytes = *((size_t *)buf);
+    /* make freed data obvious */
+    memset(buf, 0xED, bytes);
+    free(buf);
+  }
+#else
+  free(buffer);
+#endif
+}
+
+static void msp_copy(void *src, void *dest, size_t bytes) {
+  memcpy(dest, src, bytes);
+}
+
+static struct mspack_system msp_system = {
+  &msp_open, &msp_close, &msp_read,  &msp_write, &msp_seek,
+  &msp_tell, &msp_msg, &msp_alloc, &msp_free, &msp_copy, NULL
+};
+
+struct mspack_system *mspack_default_system = &msp_system;
+
+#endif

--- a/third_party/libmspack/mspack/system.h
+++ b/third_party/libmspack/mspack/system.h
@@ -1,0 +1,65 @@
+/* This file is part of libmspack.
+ * (C) 2003-2018 Stuart Caie.
+ *
+ * libmspack is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (LGPL) version 2.1
+ *
+ * For further details, see the file COPYING.LIB distributed with libmspack
+ */
+
+#ifndef MSPACK_SYSTEM_H
+#define MSPACK_SYSTEM_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ensure config.h is read before mspack.h */
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+#include <mspack.h>
+#include <macros.h>
+
+/* assume <string.h> exists */
+#ifndef MSPACK_NO_DEFAULT_SYSTEM
+# include <string.h>
+#else
+ /* but if no default system wanted, avoid using <string.h> entirely,
+  * to avoid linking to even these standard C library functions */
+static inline int memcmp(const void *s1, const void *s2, size_t n) {
+    const unsigned char *a = s1, *b = s2;
+    while (n--) if (*a++ != *b++) return a[-1] - b[-1];
+    return 0;
+}
+static inline void *memset(void *s, int c, size_t n) {
+    unsigned char *s2 = s, c2 = (unsigned char) c;
+    while (n--) *s2++ = c2;
+    return s;
+}
+static inline size_t strlen(const char *s) {
+    size_t c = 0; while (*s++) c++; return c;
+}
+#endif
+
+/* fix for problem with GCC 4 and glibc (thanks to Ville Skytta)
+ * http://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=150429
+ */
+#ifdef read
+# undef read
+#endif
+
+extern struct mspack_system *mspack_default_system;
+
+/* returns the length of a file opened for reading */
+extern int mspack_sys_filelen(struct mspack_system *system,
+                              struct mspack_file *file, off_t *length);
+
+/* validates a system structure */
+extern int mspack_valid_system(struct mspack_system *sys);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
## Summary

Three coupled changes that make the firmware-update path work for SmartSDR v4.2+ without runtime dependencies:

1. **Native MSI extraction** — vendored libmspack (LGPL-2.1, ~6k lines C) plus a small in-tree OLE Compound File reader. Pure in-tree, no `7z`, no `QProcess`, no temp files, no external runtime deps. Works in any sandboxing model that disallows process spawning.
2. **User-selected installer** — replaces auto-download with a "Select Installer..." file picker. The user downloads the SmartSDR installer themselves from flexradio.com, then points us at it. No URL guesswork.
3. **PII redactor + diagnostic-logging cleanup** — fixes a regex regression (`software_ver=4.2.18.41174` was being mangled to `*.*.*. 41174` in logs) and removes one-shot diagnostic instrumentation that was added for the first flash attempt.

## Why native instead of `7z`

Earlier prototypes shelled out to `7z` for MSI extraction. That approach worked on Linux but would have created silent regressions for Windows users (overwhelmingly don't have 7z on PATH) and broken in sandboxed environments. The native pipeline:

- Zero new runtime dependencies anywhere
- Works in App Sandbox / Snap / Flatpak
- Returns structured errors we can present in the UI
- ~3.75 days of work tracked in [#2172](https://github.com/ten9876/AetherSDR/issues/2172)

## Pipeline

```
SmartSDR_v<x.y.z>_x64.msi
  ↓ OleCompoundFile.readMsiStreamsByPrefixSuffix("cab", ".cab")
cab1.cab, cab2.cab, …  (in memory, MSI-decoded names)
  ↓ CabExtractor.extractFirstMatchingMagic(bytes, "Salted__")
.ssdr blobs  (in memory)
  ↓ sort by size desc, pick by m_modelFamily
chosen blob  →  write to staging dir
```

| Format | Detection | Extraction |
|---|---|---|
| InnoSetup `.exe` (v4.1.x and earlier) | `MZ` (PE/COFF) header | Existing byte-pattern scanner |
| WiX MSI (v4.2+) | OLE magic `D0 CF 11 E0 A1 B1 1A E1` | New native pipeline |
| Pre-extracted `.ssdr` | filename suffix | Direct copy + header validation |

## What landed

### Vendored library

- [`third_party/libmspack/`](third_party/libmspack/) — LGPL-2.1, GPL-3 compatible
- 11 source files (~6k lines C) — only CAB+LZX+MSZIP+Quantum decompression. No encoders, no CHM/HLP/KWAJ/LIT/OAB.
- Built as a static lib via [`third_party/libmspack/CMakeLists.txt`](third_party/libmspack/CMakeLists.txt) with `-w` to keep upstream warning style out of our build output.
- [`third_party/libmspack/README.md`](third_party/libmspack/README.md) documents version, license, file inventory, update procedure.

### New AetherSDR sources

- [`src/core/OleCompoundFile.{h,cpp}`](src/core/OleCompoundFile.cpp) — read-only [MS-CFB] reader. Parses header, FAT chain, directory; reads streams by name. MSI-aware accessor decodes Microsoft's 5-bit-packed name encoding. ~290 lines total.
- [`src/core/CabExtractor.{h,cpp}`](src/core/CabExtractor.cpp) — in-memory `mspack_system` adapter. Reads cab bytes from a `QByteArray` and writes decompressed payloads to `QByteArray`s. ~190 lines.

### Changed AetherSDR sources

- [`src/core/FirmwareStager.{h,cpp}`](src/core/FirmwareStager.cpp) — `extractFromMsi()` body fully rewritten (~130 → ~80 lines); `findExtractionTool()` deleted; new `stageFromLocalFile()` for the file-selection entry point; URL handling switches between `_x64.msi` (v4.2+) and `_Installer.exe` (older).
- [`src/gui/RadioSetupDialog.cpp`](src/gui/RadioSetupDialog.cpp) — "Browse .ssdr..." renamed to "Select Installer..."; file dialog accepts `.msi` / `.exe` / `.ssdr`; "Check for Update" no longer auto-downloads, just reports the latest version.
- [`src/main.cpp`](src/main.cpp) — `redactPii` regex extended to skip `_ver=` prefixed and trailing-digit cases.
- [`src/core/FirmwareUploader.cpp`](src/core/FirmwareUploader.cpp) — diagnostic logging from the one-shot-flash session removed (the actual flash succeeded; the scaffolding isn't needed anymore).

### Tests

- [`tests/ole_compound_file_test.cpp`](tests/ole_compound_file_test.cpp) — 17 assertions covering OLE CFB stream extraction, MSI name decoding, libmspack CAB decompression, and the end-to-end firmware-blob match.
- Skips with exit 77 if the licensed MSI fixture isn't available (looks at `$AETHERSDR_TEST_MSI` then `~/build/reference/SmartSDR_v4.2.18_x64.msi`). CI doesn't have the file, so the test no-ops there.

## Verification

End-to-end test against `SmartSDR_v4.2.18_x64.msi`:

| Check | Result |
|---|---|
| OLE CFB opens | ✅ |
| 6 cab streams extracted | ✅ byte-identical to 7z |
| Cab MSCF magic | ✅ `4D 53 43 46` |
| FLEX-6x00 firmware extracted | ✅ 386,289,360 bytes, `Salted__` header |
| **Final MD5** | **✅ `9e8888dc0558ee420ed82f370f805025`** — same bytes that successfully flashed a real FLEX-8600 earlier in this branch |
| FLEX-9600 firmware extracted | ✅ 63,813,240 bytes, `Salted__` header |

The tracking issue is [#2172](https://github.com/ten9876/AetherSDR/issues/2172) — can be closed on merge.

## Acceptance criteria (all met)

- [x] libmspack vendored with LGPL-2.1 text and version-tracking README
- [x] `OleCompoundFile` reads streams from real MSI
- [x] `extractFromMsi()` no longer calls `QProcess` or references 7-Zip
- [x] `findExtractionTool()` deleted
- [x] Integration test extracts a `.ssdr` matching the known-good MD5
- [x] Manual smoke test in the UI: Select Installer → MSI → staged file matches MD5
- [x] Build clean on Linux x86_64; tests pass

## Test plan

- [x] Build passes locally
- [x] `ole_compound_file_test` passes (17 assertions)
- [x] Manual UI test: staged file MD5 matches known-good
- [ ] CI green (Linux + macOS + Windows)
- [ ] On-air test: someone running this build flashes their radio with v4.2 firmware

🤖 Generated with [Claude Code](https://claude.com/claude-code)