### PR TITLE
docs: scrub remaining DIGI applet references after #1939

### DIFF
--- a/docs/audio_test_plan.md
+++ b/docs/audio_test_plan.md
@@ -145,7 +145,7 @@
 3. Reopen WSJT-X — TCI should reconnect and audio should flow again
 
 ### D5. TCI with DAX already running
-1. Enable DAX in the DIGI applet (Autostart DAX)
+1. Enable DAX in the DAX Audio tile (Autostart DAX)
 2. Then connect WSJT-X via TCI
 3. Both should work simultaneously
 4. Disconnect WSJT-X — user's DAX should remain active
@@ -203,8 +203,8 @@
 
 ### DAX RX Audio
 
-#### G1. DAX RX via DIGI applet (Autostart DAX)
-1. Open DIGI applet, check "Autostart DAX"
+#### G1. DAX RX via DAX Audio tile (Autostart DAX)
+1. Open the DAX Audio tile (click `DAX` in the applet tray), check "Autostart DAX"
 2. Check log for `stream create type=dax_rx dax_channel=1`
 3. Open WSJT-X configured to use DAX audio device (not TCI)
 4. WSJT-X should show waterfall activity and produce FT8 decodes
@@ -248,7 +248,7 @@
 ### DAX IQ Streaming
 
 #### G8. DAX IQ stream creation
-1. Enable DAX IQ on a slice (DIGI applet → IQ channel selector)
+1. Enable DAX IQ on a slice (DAX IQ tile → IQ channel selector)
 2. Check log for `stream create type=dax_iq dax_channel=<ch>`
 3. An IQ-capable application (e.g., SDR++) should receive IQ data
 
@@ -292,7 +292,7 @@
 ### TCI Audio — Lifecycle
 
 #### G16. TCI audio_start creates DAX RX streams
-1. DAX Autostart OFF in DIGI applet
+1. DAX Autostart OFF in the DAX Audio tile
 2. Connect TCI client, send `audio_start;`
 3. Check log for:
    - `slice set <id> dax=<ch>` (channel assignment)
@@ -329,7 +329,7 @@
 ### Cross-Path Interactions
 
 #### G21. DAX bridge + TCI simultaneous
-1. Enable DAX Autostart in DIGI applet (creates DAX bridge streams)
+1. Enable DAX Autostart in the DAX Audio tile (creates DAX bridge streams)
 2. Connect WSJT-X via TCI (creates TCI's own DAX streams or piggybacks)
 3. Both should receive audio simultaneously
 4. Disable DAX Autostart — TCI should continue working (owns its own streams)

--- a/resources/help/aethersdr-help.md
+++ b/resources/help/aethersdr-help.md
@@ -228,18 +228,24 @@ This applet is mode-sensitive. In phone-oriented modes it exposes microphone-ori
 
 The EQ applet is for transmit and receive equalization. Small moves are best. Shape the audio, then listen and measure before making another large adjustment.
 
-### `DIGI`
+### `CAT`, `DAX`, `TCI`, `IQ` (data mode tiles)
 
-The DIGI applet is the bridge between AetherSDR and external software. It handles:
+The bridge between AetherSDR and external software is split across four
+independent, drag-reorderable tiles. Each one is toggled from its own button
+in the applet tray:
 
-- CAT over TCP
-- virtual TTY or PTY control
-- TCI server enablement
-- DAX enablement
-- DAX receive and transmit levels
-- DAX IQ integration
+- **`CAT`** — CAT Control tile: rigctld TCP servers + virtual TTY/PTY ports
+  for any application that speaks Hamlib rigctld
+- **`DAX`** — DAX Audio tile: virtual audio devices for the four RX channels
+  and the TX channel, with per-channel gain and level meters
+- **`TCI`** — TCI Server tile: WebSocket server speaking the TCI v2.0
+  protocol (CAT + audio + IQ + CW + spots in one connection)
+- **`IQ`** — DAX IQ tile: raw I/Q streams at 24/48/96/192 kHz for SDR
+  applications
 
-If you use computer-driven digital modes, this applet deserves a permanent place in your operating layout.
+If you use computer-driven digital modes, the relevant tiles deserve a
+permanent place in your operating layout. See **Configuring Data Modes** in
+the help topics for the full setup walkthrough.
 
 ### `MTR`
 


### PR DESCRIPTION
## Summary

Follow-up to #1939, which fixed \`understanding-data-modes.md\` but left two other docs still describing the old monolithic DIGI applet UI.

## Changes

- [\`resources/help/aethersdr-help.md\`](resources/help/aethersdr-help.md) — the user-facing help index had a \`### DIGI\` section describing the unified applet with bullet points. Replaced with a single section covering the four current data-mode tiles (\`CAT\`, \`DAX\`, \`TCI\`, \`IQ\`) and pointing readers at the **Configuring Data Modes** deep-dive that #1939 just rewrote.

- [\`docs/audio_test_plan.md\`](docs/audio_test_plan.md) — internal test-plan steps referenced "the DIGI applet" in five places. Each updated to name the specific tile that step is exercising (DAX Audio tile or DAX IQ tile).

## What's left intact

\`CHANGELOG.md\` historical entries are NOT changed — those describe the DIGI applet as it existed at the time, including the entry at line 1527 which documents the split itself ("DIGI applet split into CAT, DAX, TCI, IQ (#1627)"). Rewriting historical changelog entries would be misleading.

## Verification

\`\`\`
$ grep -rn "DIGI applet" resources/help/ docs/ *.md
CHANGELOG.md:1527:**DIGI applet split into CAT, DAX, TCI, IQ (#1627)**
CHANGELOG.md:2606:- DIGI applet controls, autostart option
... (all CHANGELOG entries — historical, correct)
\`\`\`

No remaining live-doc references to the old DIGI applet UI.

## Test plan

- [x] Verify no \`DIGI applet\` matches outside CHANGELOG
- [ ] CI green (docs-only — no code path affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)