### PR TITLE
RadioModel: track CWX active state to keep audio gate open during send

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -318,6 +318,12 @@ RadioModel::RadioModel(QObject* parent)
         sendCmd(cmd);
     });
     connect(&m_cwxModel, &CwxModel::commandReady, this, [this](const QString& cmd){
+        // Track CWX send state so the interlock handler recognises local
+        // CWX TX and doesn't force the audio gate off. (#2047, #2097)
+        if (cmd.startsWith("cwx send") || cmd.startsWith("cwx macro send"))
+            m_cwxActive = true;
+        else if (cmd.startsWith("cwx clear"))
+            m_cwxActive = false;
         sendCmd(cmd);
     });
     connect(&m_dvkModel, &DvkModel::commandReady, this, [this](const QString& cmd){
@@ -1602,6 +1608,7 @@ void RadioModel::onDisconnected()
 
     m_txRequested = false;
     m_cwKeyActive = false;
+    m_cwxActive = false;
     if (m_txAudioGate) {
         m_txAudioGate = false;
         emit txAudioGateChanged(false);
@@ -2865,7 +2872,7 @@ void RadioModel::onStatusReceived(const QString& object,
             const bool radioTx = (state == "TRANSMITTING");
             emit radioTransmittingChanged(radioTx);
 
-            if (!m_txOwnedByUs || (!m_txRequested && !m_cwKeyActive && !m_transmitModel.isTuning())) {
+            if (!m_txOwnedByUs || (!m_txRequested && !m_cwKeyActive && !m_cwxActive && !m_transmitModel.isTuning())) {
                 // Another client owns TX, or local unkey requested:
                 // force local TX/audio gate off through all interlock states.
                 m_transmitModel.setTransmitting(false);
@@ -2886,8 +2893,10 @@ void RadioModel::onStatusReceived(const QString& object,
                 // modem/PTT edge alignment.
                 const bool transitioningToTx =
                     state.contains("REQUESTED") || state.contains("DELAY");
-                if (!transitioningToTx)
+                if (!transitioningToTx) {
                     m_transmitModel.setTransmitting(false);
+                    m_cwxActive = false; // CWX send complete (#2097)
+                }
                 if (!transitioningToTx && m_txAudioGate) {
                     m_txAudioGate = false;
                     emit txAudioGateChanged(false);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -504,6 +504,7 @@ private:
     bool        m_multiFlexEnabled{true};
     bool        m_txRequested{false}; // local MOX command intent (for edge sync)
     bool        m_cwKeyActive{false}; // true while CW key/paddle is held (#1379)
+    bool        m_cwxActive{false};   // true while CWX send is in flight (#2047, #2097)
     bool        m_txAudioGate{false}; // actual TX audio gate state
     QStringList m_antList;
 


### PR DESCRIPTION
## Summary

Carves out the substantive CWX-tracking part of PR #2103 (which had a merge conflict because its other change — `startSidetoneStream()` in AudioEngine — landed earlier today via PR #2105).

## What was wrong

When CWX is sending, the radio enters TRANSMITTING via CW keying. The interlock handler in `RadioModel::onStatusReceived` gates `m_txAudioGate` based on whether we believe we're the source of TX:

```cpp
if (!m_txOwnedByUs || (!m_txRequested && !m_cwKeyActive && !m_transmitModel.isTuning())) {
    // force local TX/audio gate off
}
```

For CWX there was no signal that the local CWX queue is in flight, so this check thought we were a passive observer of someone else's TX and forced the gate off — silencing local sidetone.

## What changed

Added `m_cwxActive` flag:

- **Set** in the `cwxModel.commandReady` lambda when `cwx send` or `cwx macro send` is dispatched
- **Cleared** on `cwx clear` and on radio state leaving TRANSMITTING (with the existing setTransmitting(false) path)
- **Cleared** on disconnect alongside the other interlock state

The interlock guard now reads `!m_cwxActive` so CWX-driven TX keeps the audio gate open.

## Provenance

This is the RadioModel.cpp/h changes from PR #2103 (authored by AetherClaude bot), replayed by hand. The AudioEngine.cpp portion of #2103 (`startSidetoneStream()` call) was the same line PR #2105 added; that's already on main, so it's omitted here.

## Test plan

- [x] Build clean
- [ ] CI green
- [ ] On-air: Windows user with CW mode + CWX panel → enter message → click Send → local sidetone audible

🤖 Generated with [Claude Code](https://claude.com/claude-code)