### PR TITLE
SpectrumWidget: blank waterfall rows for 400ms after TX→RX (#2117)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1331,15 +1331,28 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
         if (!freeze && !m_waterfall.isNull())
             pushWaterfallRow(binsDbm, m_waterfall.width());
     } else {
-        if (m_hasNativeWaterfall) {
+        // Suppress post-TX transient noise rows (#2117).  The receiver AGC
+        // needs ~400 ms to settle after TX→RX; discard waterfall data during
+        // that window so the user doesn't see the bright transient stripe.
+        bool postTxBlanking = false;
+        if (m_txEndMs > 0) {
             const qint64 now = QDateTime::currentMSecsSinceEpoch();
-            if (now - m_lastNativeTileMs > 2000) {
-                m_hasNativeWaterfall = false;
-                qDebug() << "SpectrumWidget: native waterfall tiles timed out, falling back to FFT-derived";
-            }
+            if (now - m_txEndMs < 400)
+                postTxBlanking = true;
+            else
+                m_txEndMs = 0;
         }
-        if (!m_hasNativeWaterfall && !m_waterfall.isNull())
-            pushWaterfallRow(binsDbm, m_waterfall.width());
+        if (!postTxBlanking) {
+            if (m_hasNativeWaterfall) {
+                const qint64 now = QDateTime::currentMSecsSinceEpoch();
+                if (now - m_lastNativeTileMs > 2000) {
+                    m_hasNativeWaterfall = false;
+                    qDebug() << "SpectrumWidget: native waterfall tiles timed out, falling back to FFT-derived";
+                }
+            }
+            if (!m_hasNativeWaterfall && !m_waterfall.isNull())
+                pushWaterfallRow(binsDbm, m_waterfall.width());
+        }
     }
 
     update();
@@ -1360,6 +1373,15 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     // Freeze waterfall during TX if show-tx-in-waterfall is off and this pan
     // contains the TX slice. Non-TX pans keep scrolling in multi-pan.
     if (m_transmitting && !m_showTxInWaterfall && m_hasTxSlice) return;
+
+    // Suppress post-TX transient noise rows (#2117). The receiver AGC needs
+    // ~400 ms to settle after TX→RX; discard waterfall data during that
+    // window.
+    if (m_txEndMs > 0) {
+        const qint64 now = QDateTime::currentMSecsSinceEpoch();
+        if (now - m_txEndMs < 400) return;
+        m_txEndMs = 0;
+    }
 
     // Derive ms-per-row by measuring wall-clock / timecode delta.
     // Collect data for the first 50 tiles to converge, then lock the value.

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -319,6 +319,8 @@ public:
             m_hasNativeWaterfall = false;  // force FFT fallback until tiles resume
             m_wfPrevTimecode   = 0;
             m_wfPrevTimecodeMs = 0;
+            m_txEndMs = QDateTime::currentMSecsSinceEpoch(); // post-TX blanking (#2117)
+            m_wfBlankerRingCount = 0;                        // reset stale blanker baseline
         }
         m_transmitting = tx;
     }
@@ -626,6 +628,7 @@ private:
 
     bool     m_transmitting{false};
     float    m_preTxAutoBlack{145.0f}; // auto-black threshold saved before TX
+    qint64   m_txEndMs{0};             // post-TX blanking: timestamp of TX→RX transition (#2117)
 
     // Waterfall time scale: ms-per-row derived from tile timecodes + wall-clock.
     // Calibrates over the first 50 tiles, then locks to prevent jitter.


### PR DESCRIPTION
## Summary

Adds a 400 ms blanking window after TX→RX so the receiver AGC's settling transient doesn't paint a bright stripe across the waterfall (issue #2117).

## Provenance

Carve-out of PR #2118 (authored by AetherClaude bot, \`maintainerCanModify: false\`).  The bot's PR conflicted on rebase because it also touched the \`setTransmitting(false)\` block that PR #2171 landed earlier today.  Both fixes belong in that block:

- **#2171 (merged)**: \`m_hasNativeWaterfall = false\` + timecode reset → forces FFT fallback after TX
- **#2117 (this PR)**: \`m_txEndMs = now\` + blanker reset → suppresses the AGC-settling transient

This branch re-applies just the #2117 logic on top of current main, preserving both fixes.

## Implementation

- New private member \`qint64 m_txEndMs{0}\` in \`SpectrumWidget\`
- \`setTransmitting(false)\` records \`m_txEndMs = QDateTime::currentMSecsSinceEpoch()\` and zeroes the blanker ring count
- Both push paths (\`updateSpectrum\` for FFT-derived rows, \`updateWaterfallRow\` for native tiles) check \`now - m_txEndMs < 400\` and skip; after the window passes, the timestamp is cleared so subsequent rows render normally

## Test plan

- [x] Build clean
- [ ] CI green
- [ ] Visual: TX a few seconds of carrier on FLEX-8600 / Windows; observe no transient bright stripe at TX→RX

🤖 Generated with [Claude Code](https://claude.com/claude-code)