### PR TITLE
[shortcuts] Center active VFO when zooming in from keyboard

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9829,15 +9829,10 @@ void MainWindow::registerShortcutActions()
 
         double newCenter = sw->centerMhz();
 
-        // When zooming in, shift center toward the active slice frequency
-        // so it stays visible (mirrors Flex SDR behavior)
+        // When zooming in, center on the active slice so repeated keypresses do
+        // not push it toward the panadapter edge (#1932).
         if (factor < 1.0) {
-            const double vfoMhz = s->frequency();
-            const double halfBw = newBw / 2.0;
-            if (vfoMhz > newCenter + halfBw)
-                newCenter = vfoMhz - halfBw * 0.8;
-            else if (vfoMhz < newCenter - halfBw)
-                newCenter = vfoMhz + halfBw * 0.8;
+            newCenter = s->frequency();
         }
 
         sw->setFrequencyRange(newCenter, newBw);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -235,17 +235,13 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         const double newBw = std::clamp(m_bandwidthMhz * factor, m_minBwMhz, m_maxBwMhz);
         if (newBw == m_bandwidthMhz) return;  // already at the hard limit
 
-        // When zooming in, shift center toward the active VFO so it stays visible
+        // When zooming in, center on the active VFO so repeated clicks do not
+        // push it toward the panadapter edge (#1932).
         double newCenter = m_centerMhz;
         if (factor < 1.0) {  // zooming in
             const auto* ao = activeOverlay();
-            if (ao) {
-                const double halfBw = newBw / 2.0;
-                if (ao->freqMhz > newCenter + halfBw)
-                    newCenter = ao->freqMhz - halfBw * 0.8;
-                else if (ao->freqMhz < newCenter - halfBw)
-                    newCenter = ao->freqMhz + halfBw * 0.8;
-            }
+            if (ao)
+                newCenter = ao->freqMhz;
         }
 
         reprojectWaterfall(m_centerMhz, m_bandwidthMhz, newCenter, newBw);


### PR DESCRIPTION
## Summary

This fixes #1932 by changing command zoom-in behavior to center the panadapter on the active VFO/slice instead of only nudging the center when the VFO would fall outside the newly zoomed bandwidth.

The patch is intentionally narrow:

- keyboard zoom-in now uses the active slice frequency as the new panadapter center
- on-screen zoom-in now uses the active overlay/VFO frequency as the new panadapter center
- zoom-out behavior is unchanged
- trackpad pinch behavior is unchanged, so pinch continues to anchor around the cursor
- memory recall/bookmark behavior is left on the existing radio-native path

## Problem

Before this change, repeated zoom-in commands could gradually push the active signal toward the edge of the visible panadapter. The previous logic only adjusted the center if the active VFO would be outside the new bandwidth, and even then it used an 80% edge-preserving offset. That kept the signal visible, but did not keep it centered during repeated command zooms.

For issue #1932, the expected behavior is that command-style zoom-in keeps the active operating frequency centered so the operator can repeatedly zoom in without chasing the signal across the display.

## Solution

The zoom-in paths now make command zoom deterministic:

- `MainWindow::registerShortcutActions()` centers keyboard zoom-in on `SliceModel::frequency()`
- `SpectrumWidget` centers button/menu zoom-in on the active overlay frequency

The change deliberately does not route through the broader tune centering policy or memory recall code. Memory application remains radio-native via the existing `memory apply` semantics, which preserves radio-supported fields such as repeater offsets and avoids replaying an incomplete local subset of memory attributes.

## Validation

- `git diff --check`
- `cmake --build build -j10`
- `./build/memory_recall_policy_test`

Manual verification covered:

- click and center
- click and center (multiple slices)
- memory recall and center
- rapid zoom in/out
- slice bookmark recall
- trackpad pinch anchoring at the cursor

Closes #1932, #1866, #1722

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
