### PR TITLE
Hide 8000-series DSP filters (NRL, NRS, RNN, NRF) on 6000-series radios (#2177)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7417,6 +7417,10 @@ void MainWindow::onSliceAdded(SliceModel* s)
         vfo->setSmartSdrPlus(hasPlus);
     }
 
+    // Set extended DSP flag before wireVfoWidget so the mode-change lambda
+    // in setSlice() gates NRL/NRS/RNN/NRF visibility correctly (#2177)
+    vfo->setHasExtendedDsp(m_radioModel.hasExtendedDspFilters());
+
     wireVfoWidget(vfo, s);
 
     // NR2/RN2/RADE are now wired permanently in wireVfoWidget — no
@@ -8025,6 +8029,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     // Set panId on the overlay menu so +RX routes to the correct pan
     menu->setPanId(applet->panId());
     menu->setMemories(m_radioModel.memories());
+
+    // Hide 8000-series-only DSP filters on 6000-series radios (#2177)
+    menu->setHasExtendedDsp(m_radioModel.hasExtendedDspFilters());
 
     // Antenna list → this overlay menu (per-pan, mirrors VfoWidget pattern) (#1260)
     connect(&m_radioModel, &RadioModel::antListChanged,

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -742,6 +742,23 @@ void SpectrumOverlayMenu::buildDspPanel()
     // Wiring is done in setSlice() since we need the slice model
 }
 
+void SpectrumOverlayMenu::setHasExtendedDsp(bool has)
+{
+    m_hasExtendedDsp = has;
+    if (m_dspRows.isEmpty()) return;
+    // Hide 8000-series-only firmware DSP rows: NRL(4), NRS(5), RNN(6), NRF(8) (#2177)
+    auto hideRow = [](DspRow& r, bool visible) {
+        r.btn->setVisible(visible);
+        if (r.slider)   r.slider->setVisible(visible);
+        if (r.valueLbl) r.valueLbl->setVisible(visible);
+    };
+    hideRow(m_dspRows[4], has);
+    hideRow(m_dspRows[5], has);
+    hideRow(m_dspRows[6], has);
+    hideRow(m_dspRows[8], has);
+    if (m_dspPanel) m_dspPanel->adjustSize();
+}
+
 void SpectrumOverlayMenu::syncDspPanel()
 {
     if (!m_slice) return;

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -64,6 +64,7 @@ public:
     struct XvtrBand { QString name; double rfFreqMhz; };
     void setXvtrBands(const QVector<XvtrBand>& bands);
     void syncDaxIqChannel(int channel);
+    void setHasExtendedDsp(bool has);
     QPushButton* dspNr2Button() const;
     QPushButton* dspRn2Button() const;
     QPushButton* dspBnrButton() const;
@@ -244,6 +245,7 @@ private:
     QSlider*     m_bgOpacitySlider{nullptr};
     QLabel*      m_bgOpacityLabel{nullptr};
 
+    bool         m_hasExtendedDsp{false};
     QStringList  m_antList;
     QPointer<SliceModel> m_slice;
     bool         m_updatingFromModel{false};

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1940,6 +1940,11 @@ void VfoWidget::setSmartSdrPlus(bool has)
     if (m_slice) rebuildFilterButtons();
 }
 
+void VfoWidget::setHasExtendedDsp(bool has)
+{
+    m_hasExtendedDsp = has;
+}
+
 // ── Per-slice VFO marker display prefs (#1526) ───────────────────────────────
 
 void VfoWidget::setMarkerWidth(int widthPx)
@@ -2431,7 +2436,6 @@ void VfoWidget::setSlice(SliceModel* slice)
         }
         m_apfBtn->setVisible(isCw);
         m_anfBtn->setVisible(isVoice);
-        m_rnnBtn->setVisible(!isCw && !isFm);
         m_rn2Btn->setVisible(!isCw && !isFm);
         m_anflBtn->setVisible(isVoice);
         m_anftBtn->setVisible(isVoice);
@@ -2439,8 +2443,11 @@ void VfoWidget::setSlice(SliceModel* slice)
         m_nrBtn->setVisible(!isFm);
         m_nr2Btn->setVisible(!isFm);
         m_nbBtn->setVisible(!isFm);
-        m_nrlBtn->setVisible(!isFm);
-        m_nrsBtn->setVisible(!isFm);
+        // 8000-series-only firmware DSP filters (#2177)
+        m_nrlBtn->setVisible(!isFm && m_hasExtendedDsp);
+        m_nrsBtn->setVisible(!isFm && m_hasExtendedDsp);
+        m_rnnBtn->setVisible(!isCw && !isFm && m_hasExtendedDsp);
+        m_nrfBtn->setVisible(!isFm && m_hasExtendedDsp);
 #ifdef HAVE_BNR
         m_bnrBtn->setVisible(!isFm);
 #endif
@@ -2450,7 +2457,6 @@ void VfoWidget::setSlice(SliceModel* slice)
 #ifdef HAVE_DFNR
         m_dfnrBtn->setVisible(!isFm);
 #endif
-        m_nrfBtn->setVisible(!isFm);
         relayoutDspGrid();
         updateFilterLabel();
         if (m_tabStack->isVisible()) adjustSize();
@@ -2906,7 +2912,6 @@ void VfoWidget::syncFromSlice()
     m_tabBtns[1]->setText(isFm ? "OPT" : "DSP");
     m_apfBtn->setVisible(isCw);
     m_anfBtn->setVisible(!isRtty && !isCw && !isDig && !isFm);
-    m_rnnBtn->setVisible(!isCw && !isFm);
     m_rn2Btn->setVisible(!isCw && !isFm);
     m_anflBtn->setVisible(!isRtty && !isCw && !isDig && !isFm);
     m_anftBtn->setVisible(!isRtty && !isCw && !isDig && !isFm);
@@ -2922,9 +2927,11 @@ void VfoWidget::syncFromSlice()
 #ifdef HAVE_DFNR
     m_dfnrBtn->setVisible(!isFm);
 #endif
-    m_nrlBtn->setVisible(!isFm);
-    m_nrsBtn->setVisible(!isFm);
-    m_nrfBtn->setVisible(!isFm);
+    // 8000-series-only firmware DSP filters (#2177)
+    m_nrlBtn->setVisible(!isFm && m_hasExtendedDsp);
+    m_nrsBtn->setVisible(!isFm && m_hasExtendedDsp);
+    m_rnnBtn->setVisible(!isCw && !isFm && m_hasExtendedDsp);
+    m_nrfBtn->setVisible(!isFm && m_hasExtendedDsp);
     m_apfContainer->setVisible(isCw);
     m_digContainer->setVisible(isDig);
     m_fmContainer->setVisible(isFm);

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -214,6 +214,7 @@ private:
 public:
     void setDiversityAllowed(bool allowed);
     void setSmartSdrPlus(bool has);
+    void setHasExtendedDsp(bool has);
 
     // Per-slice VFO marker display prefs, persisted by slice ID (#1526).
     // markerWidth: 0 = off, 1 = 1 px, 3 = 3 px.
@@ -294,6 +295,7 @@ private:
     QPushButton* m_autotuneLoopBtn{nullptr};
     QPushButton* m_zeroBeatBtn{nullptr};
     bool         m_hasSmartSdrPlus{false};
+    bool         m_hasExtendedDsp{false};
     // RIT/XIT tab
     QPushButton* m_ritBtn{nullptr};
     QPushButton* m_xitBtn{nullptr};

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -117,6 +117,16 @@ public:
     int maxSlices() const { return m_maxSlices; }
     static int maxSlicesForModel(const QString& model);
 
+    // Returns true for BigBend/DragonFire-platform radios (8400, 8600,
+    // AU-series, ML-series, CL-series, RT-series) that support the extended
+    // firmware DSP filters (NRL, NRS, RNN, NRF).  6000-series radios don't
+    // expose these filters and the UI hides them when this returns false. (#2177)
+    bool hasExtendedDspFilters() const {
+        return m_model.contains("8400") || m_model.contains("8600")
+            || m_model.contains("AU-")  || m_model.contains("ML-")
+            || m_model.contains("CL-")  || m_model.contains("RT-");
+    }
+
     // Max panadapters supported by this radio model.
     // FLEX-6700: 8 (dual SCU, high-capacity)
     // FLEX-6600 / FLEX-6500 / FLEX-8600 / AU-520: 4 (dual SCU)


### PR DESCRIPTION
## Summary

Hides the four extended firmware DSP filters (NRL, NRS, RNN, NRF) when connected to a 6000-series radio, since those filters only exist on BigBend/DragonFire-platform hardware (8400, 8600, AU-/ML-/CL-/RT-series).

## Provenance

Carve-out of PR #2178 (authored by AetherClaude bot, \`maintainerCanModify: false\`).  The bot's branch was based on the moment PR #2155 (Customizable Slice Colors) landed but didn't include the new SliceColorManager source files, so rebasing showed those as **−390 deletions** — i.e., merging #2178 as-submitted would silently revert chibondking's slice-colors work that landed earlier today.

This branch contains just the substantive +47/-4 hide-filter change, applied cleanly on top of current main.

## Implementation

- **\`RadioModel::hasExtendedDspFilters()\`** — returns true for 8400, 8600, AU-, ML-, CL-, RT- model strings.
- **\`SpectrumOverlayMenu::setHasExtendedDsp(bool)\`** — toggles visibility on the four DSP rows (indexes 4, 5, 6, 8 = NRL, NRS, RNN, NRF). Adjusts panel size after hiding.
- **\`VfoWidget::setHasExtendedDsp(bool)\`** — stores the flag; both \`setSlice()\`'s mode-change lambda AND the \`syncFromSlice()\` path apply \`&& m_hasExtendedDsp\` to the four button visibility checks.
- **\`MainWindow\`** — calls \`setHasExtendedDsp\` on each VfoWidget in \`onSliceAdded\` and on each SpectrumOverlayMenu in \`wirePanadapter\`.

## Improvement over the original PR

The bot only added the gating to the \`setSlice\` mode-change lambda.  This commit also adds it to \`syncFromSlice\` (line 2915 region) — a sibling code path — so subsequent mode changes re-apply the gating consistently.  Without that, switching from FM → USB → FM on a 6000-series would re-show the four buttons.

## Test plan

- [x] Build clean
- [ ] CI green
- [ ] Visual: connect to a FLEX-6600 → DSP panel and VfoWidget DSP buttons should not show NRL/NRS/RNN/NRF
- [ ] Visual: connect to a FLEX-8600 / AU-520 → those four filters should still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)