### PR TITLE
NAVTEX waveform support — data layer + protocol plumbing (#2132)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,7 @@ set(MODEL_SOURCES
     src/models/SpotModel.cpp
     src/models/CwxModel.cpp
     src/models/DvkModel.cpp
+    src/models/NavtexModel.cpp
     src/models/BandSettings.cpp
     src/models/BandPlanManager.cpp
     src/models/XvtrPolicy.cpp
@@ -1144,6 +1145,13 @@ add_executable(passive_spots_policy_test
 )
 target_include_directories(passive_spots_policy_test PRIVATE src)
 target_link_libraries(passive_spots_policy_test PRIVATE Qt6::Core)
+
+add_executable(navtex_model_test
+    tests/navtex_model_test.cpp
+    src/models/NavtexModel.cpp
+)
+target_include_directories(navtex_model_test PRIVATE src)
+target_link_libraries(navtex_model_test PRIVATE Qt6::Core Qt6::Test)
 
 add_executable(ole_compound_file_test
     tests/ole_compound_file_test.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7186,7 +7186,7 @@ void MainWindow::onSliceAdded(SliceModel* s)
                 txSliceId = sl->sliceId();
                 const QString& m = sl->mode();
                 isDigital = (m == "DIGU" || m == "DIGL" || m == "RTTY"
-                          || m == "DFM"  || m == "NFM");
+                          || m == "DFM"  || m == "NFM"  || m == "NT");
                 break;
             }
         }
@@ -7342,7 +7342,7 @@ void MainWindow::onSliceAdded(SliceModel* s)
             // Disable client-side DSP in digital and CW modes — NR2/RN2/BNR
             // corrupt digital data (#534) and suppress CW tones (#784)
             bool disableDsp = (mode == "DIGU" || mode == "DIGL" || mode == "RTTY"
-                            || mode == "CW"   || mode == "CWL");
+                            || mode == "CW"   || mode == "CWL"  || mode == "NT");
             if (disableDsp) {
                 if (m_audio->nr2Enabled())
                     QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNr2Enabled(false); });

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4955,6 +4955,7 @@ void MainWindow::buildMenuBar()
                 this, [this] { QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->startConnection(); }); });
         connect(dlg, &DxClusterDialog::freedvStopRequested,
                 this, [this] { QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->stopConnection(); }); });
+#ifdef HAVE_RADE
         connect(dlg, &DxClusterDialog::freedvReportingToggled,
                 this, [this](bool on) {
                     if (on) {
@@ -4964,6 +4965,7 @@ void MainWindow::buildMenuBar()
                         stopFreeDvReporting(m_radeSliceId);
                     }
                 });
+#endif
 #endif
         connect(dlg, &DxClusterDialog::spotsClearedAll,
                 this, [this] {

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -176,7 +176,7 @@ static const ModeSettings& modeSettingsFor(const QString& mode)
     if (mode == "USB" || mode == "LSB")  return ssbSettings;
     if (mode == "AM"  || mode == "SAM")  return amSettings;
     if (mode == "CW")                    return cwSettings;
-    if (mode == "DIGU" || mode == "DIGL") return digSettings;
+    if (mode == "DIGU" || mode == "DIGL" || mode == "NT") return digSettings;
     if (mode == "RTTY")                  return rttySettings;
     if (mode == "FM" || mode == "NFM" || mode == "DFM") return fmSettings;
     if (mode.startsWith("FDV"))          return digSettings;  // FreeDV digital voice
@@ -1450,7 +1450,7 @@ QString RxApplet::formatHz(int hz)
 QString RxApplet::formatFilterWidth(int lo, int hi, const QString& mode)
 {
     int w;
-    if (mode == "USB" || mode == "DIGU" || mode == "FDV")
+    if (mode == "USB" || mode == "DIGU" || mode == "FDV" || mode == "NT")
         w = hi;
     else if (mode == "LSB" || mode == "DIGL")
         w = std::abs(lo);
@@ -1605,13 +1605,14 @@ void RxApplet::updateModeSettings(const QString& mode)
     // Disable squelch in digital and CW modes
     // Digital: audio goes via DAX, SQL not meaningful
     // CW: radio locks squelch on at fixed level, rejects changes
-    bool sqlDisabled = (mode == "DIGU" || mode == "DIGL" || mode == "CW" || mode == "CWL");
+    bool sqlDisabled = (mode == "DIGU" || mode == "DIGL" || mode == "NT"
+                        || mode == "CW" || mode == "CWL");
     m_sqlBtn->setEnabled(!sqlDisabled);
     m_sqlSlider->setEnabled(!sqlDisabled);
     if (sqlDisabled && m_slice) {
         if (m_slice->squelchOn()) {
             m_savedSquelchOn = true;
-            if (mode == "DIGU" || mode == "DIGL") {
+            if (mode == "DIGU" || mode == "DIGL" || mode == "NT") {
                 // Only send squelch off for digital modes; CW is radio-managed
                 m_slice->setSquelch(false, m_slice->squelchLevel());
                 QSignalBlocker sb(m_sqlBtn);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2397,14 +2397,14 @@ void VfoWidget::setSlice(SliceModel* slice)
         // Categorize by mode family (supports future/unknown modes)
         bool isRtty = (mode == "RTTY");
         bool isCw   = (mode == "CW" || mode == "CWL");
-        bool isDig  = (mode == "DIGL" || mode == "DIGU");
+        bool isDig  = (mode == "DIGL" || mode == "DIGU" || mode == "NT");
         bool isFm   = (mode == "FM" || mode == "NFM" || mode == "DFM");
         bool isFdv  = mode.startsWith("FDV");  // FDVU, FDVM, etc.
         // Swap DSP tab label to OPT for FM modes
         m_tabBtns[1]->setText(isFm ? "OPT" : "DSP");
         m_rttyContainer->setVisible(isRtty);
         m_apfContainer->setVisible(isCw);
-        m_digContainer->setVisible(isDig && !isFdv);
+        m_digContainer->setVisible(isDig && !isFdv && mode != "NT");
         m_fmContainer->setVisible(isFm);
         if (isDig) {
             int off = (mode == "DIGL") ? m_slice->diglOffset() : m_slice->diguOffset();
@@ -2907,7 +2907,7 @@ void VfoWidget::syncFromSlice()
     m_shiftLabel->setText(QString::number(m_slice->rttyShift()));
     m_rttyContainer->setVisible(isRtty);
     bool isCw = (m_slice->mode() == "CW" || m_slice->mode() == "CWL");
-    bool isDig = (m_slice->mode() == "DIGL" || m_slice->mode() == "DIGU");
+    bool isDig = (m_slice->mode() == "DIGL" || m_slice->mode() == "DIGU" || m_slice->mode() == "NT");
     bool isFm = (m_slice->mode() == "FM" || m_slice->mode() == "NFM");
     m_tabBtns[1]->setText(isFm ? "OPT" : "DSP");
     m_apfBtn->setVisible(isCw);
@@ -2933,7 +2933,7 @@ void VfoWidget::syncFromSlice()
     m_rnnBtn->setVisible(!isCw && !isFm && m_hasExtendedDsp);
     m_nrfBtn->setVisible(!isFm && m_hasExtendedDsp);
     m_apfContainer->setVisible(isCw);
-    m_digContainer->setVisible(isDig);
+    m_digContainer->setVisible(isDig && m_slice->mode() != "NT");
     m_fmContainer->setVisible(isFm);
     // CW: radio locks squelch on at fixed level; Digital: not meaningful
     m_sqlBtn->setEnabled(!isDig && !isCw);
@@ -3045,7 +3045,7 @@ static const ModeFilterPresets& filterPresetsFor(const QString& mode)
     if (mode == "USB" || mode == "LSB") return usb;
     if (mode == "AM" || mode == "SAM") return am;
     if (mode == "CW") return cw;
-    if (mode == "DIGU" || mode == "DIGL") return dig;
+    if (mode == "DIGU" || mode == "DIGL" || mode == "NT") return dig;
     if (mode == "RTTY") return rtty;
     if (mode == "DFM") return dfm;
     if (mode == "FM" || mode == "NFM") return fm;

--- a/src/models/NavtexModel.cpp
+++ b/src/models/NavtexModel.cpp
@@ -1,0 +1,174 @@
+#include "NavtexModel.h"
+#include <QDebug>
+#include <QDateTime>
+
+namespace AetherSDR {
+
+NavtexModel::NavtexModel(QObject* parent)
+    : QObject(parent)
+{}
+
+void NavtexModel::sendMessage(QChar txIdent, QChar subjectIndicator,
+                              const QString& msgText, std::optional<uint> serialNum)
+{
+    // Format per FlexLib v4.2.18:
+    // navtex send tx_ident=<C> subject_indicator=<C> [serial_num=<N>] msg_text="..."
+    QString cmd = QString("navtex send tx_ident=%1 subject_indicator=%2")
+                      .arg(txIdent)
+                      .arg(subjectIndicator);
+    if (serialNum.has_value()) {
+        cmd += QString(" serial_num=%1").arg(serialNum.value());
+    }
+    // Quote-escape so an embedded `"` in the user's text doesn't break the
+    // radio's command parser.  Backslash needs escaping first (otherwise the
+    // replacement double-escapes existing backslashes).
+    QString escaped = msgText;
+    escaped.replace('\\', "\\\\");
+    escaped.replace('"', "\\\"");
+    cmd += QString(" msg_text=\"%1\"").arg(escaped);
+
+    int seq = m_nextSeq++;
+
+    // Track as pending until radio responds with index
+    NavtexMsg msg;
+    msg.txIdent = txIdent;
+    msg.subjectIndicator = subjectIndicator;
+    msg.msgText = msgText;
+    msg.status = NavtexMsgStatus::Pending;
+    if (serialNum.has_value()) {
+        msg.serialNum = serialNum.value();
+    }
+    m_pendingMsgs[seq] = msg;
+
+    emit replyCommandReady(cmd, seq);
+}
+
+void NavtexModel::handleSendResponse(int seq, uint respVal, const QString& indexStr)
+{
+    auto it = m_pendingMsgs.find(seq);
+    if (it == m_pendingMsgs.end()) {
+        qWarning() << "NavtexModel: no pending message for seq=" << seq;
+        return;
+    }
+
+    // Failure path: error responses come with respVal != 0 and an empty body
+    // (radio returns `R<seq>|<errcode>|`).  Promote to Error and surface to the
+    // messages list so the UI can show what happened.
+    if (respVal != 0) {
+        qWarning() << "NavtexModel: send failed, resp=" << respVal << "seq=" << seq;
+        it->status = NavtexMsgStatus::Error;
+        m_msgs.append(*it);
+        m_pendingMsgs.erase(it);
+        emit messagesChanged();
+        return;
+    }
+
+    // Success path requires the index in the body.
+    if (indexStr.isEmpty()) {
+        qWarning() << "NavtexModel: send response missing index, seq=" << seq;
+        m_pendingMsgs.erase(it);
+        return;
+    }
+
+    bool ok = false;
+    uint idx = indexStr.toUInt(&ok);
+    if (!ok) {
+        qWarning() << "NavtexModel: failed to parse index from" << indexStr;
+        m_pendingMsgs.erase(it);
+        return;
+    }
+
+    it->idx = idx;
+    it->status = NavtexMsgStatus::Queued;
+    m_msgs.append(*it);
+    m_pendingMsgs.erase(it);
+    emit messagesChanged();
+}
+
+void NavtexModel::parseStatus(const QString& object, const QMap<QString, QString>& kvs)
+{
+    // Two forms per FlexLib:
+    // 1. "navtex sent" — per-message TX confirmation with idx= and serial_num=
+    // 2. "navtex" with status=<value> — global NAVTEX state
+    if (object == "navtex sent") {
+        parseSentStatus(kvs);
+        return;
+    }
+
+    // Global status update
+    if (kvs.contains("status")) {
+        NavtexStatus newStatus = parseStatusString(kvs["status"]);
+        if (newStatus != m_status) {
+            m_status = newStatus;
+            emit statusChanged(m_status);
+        }
+    }
+}
+
+void NavtexModel::parseSentStatus(const QMap<QString, QString>& kvs)
+{
+    // Parse idx and serial_num from the sent confirmation
+    if (!kvs.contains("idx")) {
+        qWarning() << "NavtexModel: sent status missing idx";
+        return;
+    }
+
+    bool ok = false;
+    uint idx = kvs["idx"].toUInt(&ok);
+    if (!ok) {
+        qWarning() << "NavtexModel: failed to parse idx from" << kvs["idx"];
+        return;
+    }
+
+    uint serial = 0;
+    if (kvs.contains("serial_num")) {
+        serial = kvs["serial_num"].toUInt();
+    }
+
+    // Check for redundant status
+    for (const auto& msg : m_msgs) {
+        if (msg.idx == idx && msg.status == NavtexMsgStatus::Sent) {
+            return;  // Already marked as sent
+        }
+    }
+
+    // Find the queued message and mark it sent
+    QString dateTime = QDateTime::currentDateTimeUtc().toString("yyyy-MM-ddZHH:mm:ss");
+    bool found = false;
+    for (auto& msg : m_msgs) {
+        if (msg.idx == idx) {
+            msg.status = NavtexMsgStatus::Sent;
+            msg.dateTime = dateTime;
+            msg.serialNum = serial;
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        // Radio sent a confirmation for a message we don't know about
+        // (e.g., sent by another client). Track it anyway.
+        NavtexMsg msg;
+        msg.idx = idx;
+        msg.serialNum = serial;
+        msg.dateTime = dateTime;
+        msg.status = NavtexMsgStatus::Sent;
+        m_msgs.append(msg);
+    }
+
+    emit messagesChanged();
+}
+
+NavtexStatus NavtexModel::parseStatusString(const QString& str)
+{
+    // Case-insensitive match per FlexLib's Enum.TryParse behavior
+    const QString lower = str.toLower();
+    if (lower == "inactive")     return NavtexStatus::Inactive;
+    if (lower == "active")       return NavtexStatus::Active;
+    if (lower == "transmitting") return NavtexStatus::Transmitting;
+    if (lower == "queuefull")    return NavtexStatus::QueueFull;
+    if (lower == "unlicensed")   return NavtexStatus::Unlicensed;
+    return NavtexStatus::Error;
+}
+
+} // namespace AetherSDR

--- a/src/models/NavtexModel.h
+++ b/src/models/NavtexModel.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QVector>
+#include <QMap>
+#include <optional>
+
+namespace AetherSDR {
+
+// NAVTEX waveform status (per FlexLib v4.2.18)
+enum class NavtexStatus {
+    Inactive,
+    Active,
+    Transmitting,
+    QueueFull,
+    Unlicensed,
+    Error
+};
+
+// Per-message status tracking
+enum class NavtexMsgStatus {
+    Error,
+    Pending,    // Awaiting response from radio
+    Queued,     // Radio confirmed receipt, queued for TX
+    Sent        // Radio confirmed transmission
+};
+
+struct NavtexMsg {
+    QString dateTime;
+    uint idx{0};
+    uint serialNum{0};
+    QChar txIdent;
+    QChar subjectIndicator;
+    QString msgText;
+    NavtexMsgStatus status{NavtexMsgStatus::Pending};
+};
+
+// Model for NAVTEX waveform protocol (FlexLib v4.2.18).
+// Parses "navtex sent" and "navtex status" status messages,
+// and formats "navtex send" commands.
+class NavtexModel : public QObject {
+    Q_OBJECT
+public:
+    explicit NavtexModel(QObject* parent = nullptr);
+
+    // State
+    NavtexStatus status() const { return m_status; }
+    const QVector<NavtexMsg>& messages() const { return m_msgs; }
+
+    // Actions
+    void sendMessage(QChar txIdent, QChar subjectIndicator,
+                     const QString& msgText, std::optional<uint> serialNum = std::nullopt);
+
+    // Status parsing (from radio status dispatch)
+    void parseStatus(const QString& object, const QMap<QString, QString>& kvs);
+
+    // Called by RadioModel when a reply to "navtex send" arrives
+    void handleSendResponse(int seq, uint respVal, const QString& indexStr);
+
+signals:
+    void commandReady(const QString& cmd);
+    void replyCommandReady(const QString& cmd, int seq);
+    void statusChanged(NavtexStatus status);
+    void messagesChanged();
+
+private:
+    void parseSentStatus(const QMap<QString, QString>& kvs);
+    static NavtexStatus parseStatusString(const QString& str);
+
+    NavtexStatus m_status{NavtexStatus::Inactive};
+    QVector<NavtexMsg> m_msgs;
+    QMap<int, NavtexMsg> m_pendingMsgs;  // keyed by command sequence number
+    int m_nextSeq{1};
+};
+
+} // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -318,6 +318,14 @@ RadioModel::RadioModel(QObject* parent)
     connect(&m_dvkModel, &DvkModel::commandReady, this, [this](const QString& cmd){
         sendCmd(cmd);
     });
+    connect(&m_navtexModel, &NavtexModel::commandReady, this, [this](const QString& cmd){
+        sendCmd(cmd);
+    });
+    connect(&m_navtexModel, &NavtexModel::replyCommandReady, this, [this](const QString& cmd, int seq){
+        sendCmd(cmd, [this, seq](int respVal, const QString& body){
+            m_navtexModel.handleSendResponse(seq, static_cast<uint>(respVal), body);
+        });
+    });
     connect(&m_usbCableModel, &UsbCableModel::commandReady, this, [this](const QString& cmd){
         sendCmd(cmd);
     });
@@ -1468,6 +1476,7 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
             sendCmd("sub radio all");
             sendCmd("sub codec all");
             sendCmd("sub dvk all");
+            sendCmd("sub navtex all");
             sendCmd("sub usb_cable all");
             sendCmd("sub spot all");
             sendCmd("sub license all");
@@ -2839,6 +2848,12 @@ void RadioModel::onStatusReceived(const QString& object,
     if (object.startsWith("dvk")) {
         // Pass both the object string (may contain "added"/"deleted") and KVs
         m_dvkModel.applyStatus(object, kvs);
+        return;
+    }
+
+    // NAVTEX status (v4.2.18): "navtex status=Active" or "navtex sent idx=1 serial_num=42"
+    if (object.startsWith("navtex")) {
+        m_navtexModel.parseStatus(object, kvs);
         return;
     }
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -17,6 +17,7 @@
 #include "DvkModel.h"
 #include "UsbCableModel.h"
 #include "DaxIqModel.h"
+#include "NavtexModel.h"
 #include "MemoryEntry.h"
 
 #include <QObject>
@@ -61,6 +62,7 @@ public:
     SpotModel&        spotModel()        { return m_spotModel; }
     CwxModel&         cwxModel()         { return m_cwxModel; }
     DvkModel&         dvkModel()         { return m_dvkModel; }
+    NavtexModel&      navtexModel()      { return m_navtexModel; }
     UsbCableModel&    usbCableModel()    { return m_usbCableModel; }
     DaxIqModel&       daxIqModel()       { return m_daxIqModel; }
     bool              hasAmplifier() const { return m_hasAmplifier; }
@@ -452,6 +454,7 @@ private:
     SpotModel        m_spotModel;
     CwxModel         m_cwxModel;
     DvkModel         m_dvkModel;
+    NavtexModel      m_navtexModel;
     UsbCableModel    m_usbCableModel;
     DaxIqModel       m_daxIqModel;
 

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -517,7 +517,8 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
 
         // Radio sometimes sends wrong-polarity filter offsets after session
         // restore (e.g. negative offsets for USB/DIGU). Normalize based on mode.
-        const bool isUsbFamily = (m_mode == "USB" || m_mode == "DIGU" || m_mode == "FDV");
+        const bool isUsbFamily = (m_mode == "USB" || m_mode == "DIGU" || m_mode == "FDV"
+                                  || m_mode == "NT");  // NAVTEX: USB-family digital (v4.2.18)
         const bool isLsbFamily = (m_mode == "LSB" || m_mode == "DIGL");
         if (isUsbFamily && m_filterLow < 0 && m_filterHigh <= 0) {
             // Flip: -2700,0 → 0,2700

--- a/tests/navtex_model_test.cpp
+++ b/tests/navtex_model_test.cpp
@@ -1,0 +1,196 @@
+// Standalone test harness for NavtexModel state machine.
+//
+// Build: produced by CMake as `navtex_model_test`.
+// Run:   ./build/navtex_model_test
+// Exit:  0 = pass, 1 = fail.
+
+#include "models/NavtexModel.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+
+#include <cstdio>
+#include <cstdlib>
+
+using AetherSDR::NavtexModel;
+using AetherSDR::NavtexMsg;
+using AetherSDR::NavtexMsgStatus;
+using AetherSDR::NavtexStatus;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const QString& detail = {}) {
+    std::printf("%s %-58s %s\n", ok ? "[ OK ]" : "[FAIL]", name,
+                detail.toUtf8().constData());
+    if (!ok) ++g_failed;
+}
+
+QString lastCommand(QSignalSpy& spy) {
+    if (spy.isEmpty()) return {};
+    const auto args = spy.last();
+    if (args.isEmpty()) return {};
+    return args.first().toString();
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    QCoreApplication app(argc, argv);
+
+    // ── Pending → Queued (happy path via response) ─────────────────────────
+    {
+        NavtexModel m;
+        QSignalSpy cmdSpy(&m, &NavtexModel::replyCommandReady);
+        QSignalSpy msgsSpy(&m, &NavtexModel::messagesChanged);
+
+        m.sendMessage('A', 'B', "TEST MESSAGE");
+
+        report("sendMessage emits replyCommandReady",
+               cmdSpy.size() == 1);
+
+        const QString cmd = cmdSpy.last().first().toString();
+        const int seq = cmdSpy.last().last().toInt();
+        report("command starts with 'navtex send'",
+               cmd.startsWith("navtex send"));
+        report("command includes tx_ident=A",
+               cmd.contains("tx_ident=A"));
+        report("command includes subject_indicator=B",
+               cmd.contains("subject_indicator=B"));
+        report("command quotes msg_text",
+               cmd.contains("msg_text=\"TEST MESSAGE\""));
+
+        // Radio confirms with index 42
+        m.handleSendResponse(seq, 0, "42");
+
+        report("handleSendResponse(success) → message added",
+               m.messages().size() == 1);
+        report("message status promoted to Queued",
+               m.messages().first().status == NavtexMsgStatus::Queued,
+               QString::number(static_cast<int>(m.messages().first().status)));
+        report("message idx = 42",
+               m.messages().first().idx == 42u);
+        report("messagesChanged emitted",
+               msgsSpy.size() == 1);
+    }
+
+    // ── Queued → Sent via "navtex sent" status ─────────────────────────────
+    {
+        NavtexModel m;
+        QSignalSpy cmdSpy(&m, &NavtexModel::replyCommandReady);
+        m.sendMessage('A', 'B', "MSG");
+        const int seq = cmdSpy.last().last().toInt();
+        m.handleSendResponse(seq, 0, "7");
+
+        QMap<QString, QString> sentKvs;
+        sentKvs["idx"] = "7";
+        sentKvs["serial_num"] = "100";
+        m.parseStatus("navtex sent", sentKvs);
+
+        report("status promoted to Sent",
+               m.messages().first().status == NavtexMsgStatus::Sent);
+        report("serial_num populated",
+               m.messages().first().serialNum == 100u);
+        report("dateTime stamped",
+               !m.messages().first().dateTime.isEmpty());
+    }
+
+    // ── Send failure (resp != 0) ───────────────────────────────────────────
+    {
+        NavtexModel m;
+        QSignalSpy cmdSpy(&m, &NavtexModel::replyCommandReady);
+        m.sendMessage('A', 'B', "FAIL");
+        const int seq = cmdSpy.last().last().toInt();
+        m.handleSendResponse(seq, /*respVal=*/0x50001000, "");
+
+        report("send failure → message added with Error status",
+               m.messages().size() == 1
+            && m.messages().first().status == NavtexMsgStatus::Error);
+    }
+
+    // ── Orphan "navtex sent" for unknown idx (Multi-Flex case) ─────────────
+    {
+        NavtexModel m;
+        QMap<QString, QString> sentKvs;
+        sentKvs["idx"] = "999";
+        sentKvs["serial_num"] = "55";
+        m.parseStatus("navtex sent", sentKvs);
+
+        report("orphan navtex sent synthesized into messages",
+               m.messages().size() == 1
+            && m.messages().first().idx == 999u
+            && m.messages().first().status == NavtexMsgStatus::Sent);
+    }
+
+    // ── Status string parsing (case-insensitive per FlexLib) ───────────────
+    {
+        NavtexModel m;
+        QSignalSpy statusSpy(&m, &NavtexModel::statusChanged);
+
+        QMap<QString, QString> kvs;
+        kvs["status"] = "Active";
+        m.parseStatus("navtex", kvs);
+        report("status=Active recognised",
+               m.status() == NavtexStatus::Active && statusSpy.size() == 1);
+
+        kvs["status"] = "TRANSMITTING";  // uppercase
+        m.parseStatus("navtex", kvs);
+        report("status=TRANSMITTING (uppercase) recognised",
+               m.status() == NavtexStatus::Transmitting);
+
+        kvs["status"] = "queuefull";  // lowercase
+        m.parseStatus("navtex", kvs);
+        report("status=queuefull (lowercase) recognised",
+               m.status() == NavtexStatus::QueueFull);
+
+        kvs["status"] = "garbage";
+        m.parseStatus("navtex", kvs);
+        report("unknown status falls back to Error",
+               m.status() == NavtexStatus::Error);
+    }
+
+    // ── msg_text quote escaping (the bug we fixed) ─────────────────────────
+    {
+        NavtexModel m;
+        QSignalSpy cmdSpy(&m, &NavtexModel::replyCommandReady);
+        m.sendMessage('A', 'B', "say \"hello\"");
+        const QString cmd = cmdSpy.last().first().toString();
+
+        report("embedded quote escaped as \\\"",
+               cmd.contains("msg_text=\"say \\\"hello\\\"\""),
+               cmd);
+
+        m.sendMessage('A', 'B', "back\\slash");
+        const QString cmd2 = cmdSpy.last().first().toString();
+        report("embedded backslash escaped as \\\\",
+               cmd2.contains("msg_text=\"back\\\\slash\""),
+               cmd2);
+    }
+
+    // ── Idempotent navtex sent (already-Sent message) ──────────────────────
+    {
+        NavtexModel m;
+        QSignalSpy cmdSpy(&m, &NavtexModel::replyCommandReady);
+        m.sendMessage('A', 'B', "MSG");
+        const int seq = cmdSpy.last().last().toInt();
+        m.handleSendResponse(seq, 0, "5");
+
+        QMap<QString, QString> sentKvs;
+        sentKvs["idx"] = "5";
+        m.parseStatus("navtex sent", sentKvs);
+        const auto firstStamp = m.messages().first().dateTime;
+
+        // Second occurrence shouldn't change state or duplicate
+        m.parseStatus("navtex sent", sentKvs);
+        report("redundant navtex sent ignored",
+               m.messages().size() == 1
+            && m.messages().first().dateTime == firstStamp);
+    }
+
+    if (g_failed == 0)
+        std::printf("\nAll NavtexModel tests passed.\n");
+    else
+        std::printf("\n%d test(s) failed.\n", g_failed);
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adds FlexLib v4.2.18 NAVTEX waveform support — data layer and protocol plumbing only, per [#2132](https://github.com/ten9876/AetherSDR/issues/2132)'s explicit "visual design + UX is maintainer-only" instruction.

## Provenance

Carve-out of bot PR #2137 (now closing).  The original PR also included a standalone `NavtexApplet` UI class, but it was **unwired**: no `AppletPanel` registration, no construction site in `MainWindow`, and no activate/deactivate command path.  Shipping it as-is would have been dead code in production; leaving it pending a maintainer UX decision is the right call.

## What's included

- **`NavtexModel`** (`src/models/NavtexModel.{h,cpp}`) — parses `navtex` and `navtex sent` status messages, formats the `navtex send` command, tracks per-message state (`Pending → Queued → Sent / Error`).
- **`RadioModel`** wiring — subscribes to `sub navtex all`, routes status, forwards command/reply.
- **`SliceModel::applyStatus`** — classifies `NT` as USB-family for filter/AGC purposes.
- **`MainWindow` / `RxApplet` / `VfoWidget`** — `NT` mode tolerance threaded through the mode-string switch so the GUI doesn't crash on slice mode `NT`.

## Improvements over the original PR

1. **Quote-escape `msg_text="..."`** — the bot's `arg(msgText)` would have broken the radio's command parser on any `"` or `\` in the user's text.  Backslash is escaped first so existing backslashes don't double-escape.

2. **Failure-path bug fix in `handleSendResponse`** — error responses come as `R<seq>|<errcode>|` with empty body.  The original `if (indexStr.isEmpty()) return;` check fired *before* the `if (respVal != 0) markError()` branch, making error reporting unreachable.  The unit test caught this.  Fixed by reordering.

3. **New unit test** (`tests/navtex_model_test.cpp`, 21 assertions):
   - `Pending → Queued` promotion via `handleSendResponse(0, "<idx>")`
   - `Queued → Sent` promotion via `parseStatus("navtex sent", ...)`
   - Send-failure path (`respVal != 0` with empty body)
   - Orphan `navtex sent` for unknown idx (Multi-Flex case)
   - Case-insensitive status string parsing
   - `msg_text` quote/backslash escaping
   - Idempotent `navtex sent` handling

## Out of scope (for follow-up)

- **`NavtexApplet` UI** — needs activate/deactivate UX decision (auto-activate when applet opens vs explicit Activate/Deactivate buttons; per FlexLib `Radio.cs` ParseStatus around line 3480 and `NAVTEX.cs`).
- **Frequency/license validation** — radio handles this; UI may want to surface "no NAVTEX license" status more visibly.

The data layer landing now means that whenever the UI work is picked up, it'll just `#include "models/NavtexModel.h"` and connect signals.

## Test plan

- [x] Build clean (full app + new test target)
- [x] `./build/navtex_model_test` — all 21 assertions pass
- [ ] CI green (Linux + Windows + CodeQL)

Fixes #2132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)