### PR TITLE
Add External APD support (Radio Setup tab + sampler protocol)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1206,6 +1206,16 @@ add_executable(memory_recall_policy_test
 target_include_directories(memory_recall_policy_test PRIVATE src)
 target_link_libraries(memory_recall_policy_test PRIVATE Qt6::Core)
 
+add_executable(transmit_model_apd_test
+    tests/transmit_model_apd_test.cpp
+    src/models/TransmitModel.cpp
+    src/core/LogManager.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(transmit_model_apd_test PRIVATE src)
+target_link_libraries(transmit_model_apd_test PRIVATE Qt6::Core Qt6::Test)
+set_target_properties(transmit_model_apd_test PROPERTIES AUTOMOC ON)
+
 # Help guide search tests - needs QApplication + Widgets.
 add_executable(help_dialog_test
     tests/help_dialog_test.cpp

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -110,6 +110,15 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
     addDeferred("RX",          [this] { return buildRxTab(); });
     addDeferred("Filters",     [this] { return buildFiltersTab(); });
     addDeferred("XVTR",        [this] { return buildXvtrTab(); });
+    // External APD tab (#2186) — only present on radios that report
+    // `apd configurable=1` (FLEX-8x00 series with SmartSDR 4.2.18+).
+    m_apdTabIndex = tabs->addTab(new QWidget, "APD");
+    m_deferredBuilders[m_apdTabIndex] = [this] { return buildApdTab(); };
+    tabs->setTabVisible(m_apdTabIndex, m_model->transmitModel().apdConfigurable());
+    connect(&m_model->transmitModel(), &TransmitModel::apdStateChanged,
+            this, [this, tabs] {
+        tabs->setTabVisible(m_apdTabIndex, m_model->transmitModel().apdConfigurable());
+    });
     addDeferred("USB Cables",      [this] { return buildUsbCablesTab(); });
     addDeferred("Peripherals",     [this] { return buildPeripheralsTab(); });
     addDeferred("Themes",          [this] { return buildUiEnhancementsTab(); });
@@ -2402,6 +2411,112 @@ QWidget* RadioSetupDialog::buildXvtrTab()
 
     vbox->addWidget(xvtrTabs);
     return page;
+}
+
+// ── APD tab (External Adaptive Pre-Distortion) ──────────────────────────────
+//
+// Per-TX-antenna selection of the sample port the radio uses for APD
+// adaptation.  INTERNAL samples inside the radio (legacy behaviour);
+// RX_A/RX_B/XVTA/XVTB take a coupled feedback signal from one of the
+// receive or transverter inputs — required to train APD against the
+// real RF when transmitting through an external linear amplifier.
+//
+// Tab is added eagerly but kept hidden until the radio reports
+// `apd configurable=1`.  Only the FLEX-8x00 series on SmartSDR 4.2.18+
+// reports this; older firmware and 6000-series radios stay hidden.
+
+QWidget* RadioSetupDialog::buildApdTab()
+{
+    auto* page = new QWidget;
+    auto* vbox = new QVBoxLayout(page);
+    vbox->setSpacing(8);
+
+    // Model header — matches other tabs (e.g. Filters, TX)
+    {
+        auto* hdr = new QHBoxLayout;
+        hdr->addStretch(1);
+        auto* modelLbl = new QLabel(m_model->model());
+        modelLbl->setStyleSheet("QLabel { color: #00c8ff; font-size: 20px; font-weight: bold; }");
+        hdr->addWidget(modelLbl);
+        vbox->addLayout(hdr);
+    }
+
+    auto& tx = m_model->transmitModel();
+
+    // External Sampler group — 2-column grid: ANT1/XVTA on the top row,
+    // ANT2/XVTB on the bottom row, then the Reset button on its own row.
+    {
+        auto* group = new QGroupBox("External Sampler (per TX ANT)");
+        group->setStyleSheet(kGroupStyle);
+        auto* grid = new QGridLayout(group);
+        grid->setSpacing(8);
+
+        // Row, col-pair, antenna name → builds label + combo, hooks signals.
+        auto buildRow = [&](int row, int colBase, const QString& ant) {
+            auto* lbl = new QLabel(ant + ":");
+            lbl->setStyleSheet(kLabelStyle);
+            grid->addWidget(lbl, row, colBase);
+
+            auto* combo = new QComboBox;
+            const auto s = tx.apdSampler(ant);
+            combo->addItems(s.available);
+            combo->setCurrentText(s.selected);
+            AetherSDR::applyComboStyle(combo);
+            grid->addWidget(combo, row, colBase + 1);
+
+            m_apdSamplerCombos.insert(ant, combo);
+
+            connect(combo, &QComboBox::currentTextChanged, this,
+                    [this, ant](const QString& port) {
+                if (port.isEmpty()) return;
+                m_model->transmitModel().setApdSamplerPort(ant, port);
+            });
+        };
+
+        buildRow(0, 0, "ANT1");
+        buildRow(0, 2, "XVTA");
+        buildRow(1, 0, "ANT2");
+        buildRow(1, 2, "XVTB");
+
+        // Equalizer Reset button (row 2) — clears all per-antenna training.
+        auto* resetLbl = new QLabel("Equalizer Reset:");
+        resetLbl->setStyleSheet(kLabelStyle);
+        grid->addWidget(resetLbl, 2, 0);
+
+        auto* resetBtn = new QPushButton("Reset");
+        resetBtn->setStyleSheet(
+            "QPushButton { background: #1a2a3a; border: 1px solid #304050; "
+            "border-radius: 3px; color: #c8d8e8; font-size: 11px; "
+            "font-weight: bold; padding: 3px 16px; }"
+            "QPushButton:hover { background: #203040; }");
+        connect(resetBtn, &QPushButton::clicked, this, [this] {
+            m_model->transmitModel().resetApdEqualizer();
+        });
+        grid->addWidget(resetBtn, 2, 1, Qt::AlignLeft);
+
+        vbox->addWidget(group);
+    }
+
+    // Live updates: when sampler status arrives later (e.g. ANT changes,
+    // first-connection populate), refresh the relevant combo's options
+    // without firing change-signals back to the radio.
+    connect(&tx, &TransmitModel::apdSamplerChanged, this,
+            &RadioSetupDialog::refreshApdSamplerCombo);
+
+    vbox->addStretch(1);
+    return page;
+}
+
+void RadioSetupDialog::refreshApdSamplerCombo(const QString& txAnt)
+{
+    auto* combo = m_apdSamplerCombos.value(txAnt);
+    if (!combo) return;
+
+    const auto s = m_model->transmitModel().apdSampler(txAnt);
+    QSignalBlocker b(combo);
+    combo->clear();
+    combo->addItems(s.available);
+    combo->setCurrentText(s.selected);
 }
 
 // ── USB Cables tab ───────────────────────────────────────────────────────────

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -10,6 +10,7 @@ class QLineEdit;
 class QGroupBox;
 class QProgressBar;
 class QPushButton;
+class QComboBox;
 
 namespace AetherSDR {
 
@@ -52,6 +53,8 @@ private:
     QWidget* buildAudioTab();
     QWidget* buildFiltersTab();
     QWidget* buildXvtrTab();
+    QWidget* buildApdTab();
+    void     refreshApdSamplerCombo(const QString& txAnt);
     QWidget* buildUsbCablesTab();
     QWidget* buildPeripheralsTab();
     QWidget* buildUiEnhancementsTab();
@@ -94,6 +97,10 @@ private:
     // Lazy tab construction — deferred builders keyed by tab index (#1776)
     QHash<int, std::function<QWidget*()>> m_deferredBuilders;
     void buildDeferredTab(int index);
+
+    // External APD tab (visible only when the radio reports apd configurable=1)
+    int                       m_apdTabIndex{-1};
+    QHash<QString, QComboBox*> m_apdSamplerCombos;
 };
 
 } // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2679,9 +2679,25 @@ void RadioModel::onStatusReceived(const QString& object,
         return;
     }
 
-    // APD status: "apd enable=1 ..."
-    if (object == "apd") {
-        m_transmitModel.applyApdStatus(kvs);
+    // APD status family.  Forms:
+    //   "apd enable=1 configurable=1"               → object "apd"
+    //   "apd equalizer_active=1 ant=ANT1 freq=... rfpower=..."  → object "apd"
+    //   "apd equalizer_reset"                        → object "apd equalizer_reset"
+    //   "apd sampler tx_ant=ANT1 selected_sampler=RX_A valid_samplers=..."
+    //                                                → object "apd sampler"
+    // Our parser splits object/kvs at the last space before the first '=',
+    // so any leading bare flags get absorbed into the object name.
+    if (object == "apd sampler") {
+        m_transmitModel.applyApdSamplerStatus(kvs);
+        return;
+    }
+    if (object == "apd" || object.startsWith("apd ")) {
+        QMap<QString, QString> merged = kvs;
+        if (object.length() > 3) {
+            const QStringList flags = object.mid(4).split(' ', Qt::SkipEmptyParts);
+            for (const auto& f : flags) merged.insert(f, QString{});
+        }
+        m_transmitModel.applyApdStatus(merged);
         return;
     }
 

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -13,6 +13,7 @@ void TransmitModel::resetState()
     m_apdEnabled = false;
     m_apdConfigurable = false;
     m_apdEqActive = false;
+    m_apdSamplers.clear();
     m_rfPower = 100;
     m_tunePower = 10;
     m_tune = false;
@@ -268,8 +269,46 @@ void TransmitModel::applyApdStatus(const QMap<QString, QString>& kvs)
         bool v = kvs["equalizer_active"] == "1";
         if (m_apdEqActive != v) { m_apdEqActive = v; changed = true; }
     }
+    // Bare flag (no `=`) — radio signals all per-antenna equalizers cleared.
+    if (kvs.contains("equalizer_reset")) {
+        if (m_apdEqActive) { m_apdEqActive = false; changed = true; }
+        emit apdEqualizerResetReceived();
+    }
 
     if (changed) emit apdStateChanged();
+}
+
+// "apd sampler tx_ant=ANT1 selected_sampler=RX_A valid_samplers=RX_A,XVTA"
+void TransmitModel::applyApdSamplerStatus(const QMap<QString, QString>& kvs)
+{
+    const QString txAnt = kvs.value("tx_ant").toUpper();
+    if (txAnt.isEmpty()) return;
+
+    ApdSampler s = m_apdSamplers.value(txAnt);
+    bool changed = false;
+
+    if (kvs.contains("valid_samplers")) {
+        QStringList ports = kvs["valid_samplers"].split(',', Qt::SkipEmptyParts);
+        QStringList avail{"INTERNAL"};
+        for (const auto& p : ports) {
+            const QString u = p.trimmed().toUpper();
+            if (!u.isEmpty() && !avail.contains(u)) avail.append(u);
+        }
+        if (s.available != avail) { s.available = avail; changed = true; }
+    }
+
+    if (kvs.contains("selected_sampler")) {
+        QString sel = kvs["selected_sampler"].toUpper();
+        // Match FlexLib: if selected_sampler isn't in the available list,
+        // fall back to INTERNAL.
+        if (!s.available.contains(sel)) sel = "INTERNAL";
+        if (s.selected != sel) { s.selected = sel; changed = true; }
+    }
+
+    if (changed) {
+        m_apdSamplers.insert(txAnt, s);
+        emit apdSamplerChanged(txAnt);
+    }
 }
 
 void TransmitModel::setApdEnabled(bool on)
@@ -279,6 +318,18 @@ void TransmitModel::setApdEnabled(bool on)
         emit apdStateChanged();
     }
     emit commandReady(QString("apd enable=%1").arg(on ? 1 : 0));
+}
+
+void TransmitModel::setApdSamplerPort(const QString& txAnt, const QString& port)
+{
+    if (txAnt.isEmpty() || port.isEmpty()) return;
+    emit commandReady(QString("apd sampler tx_ant=%1 sample_port=%2")
+                          .arg(txAnt.toUpper(), port.toUpper()));
+}
+
+void TransmitModel::resetApdEqualizer()
+{
+    emit commandReady(QStringLiteral("apd reset"));
 }
 
 void TransmitModel::setProfileList(const QStringList& profiles)

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QHash>
 #include <QMap>
 #include <QString>
 #include <QStringList>
@@ -99,6 +100,13 @@ public:
     bool    apdEnabled()        const { return m_apdEnabled; }
     bool    apdConfigurable()   const { return m_apdConfigurable; }
     bool    apdEqualizerActive()const { return m_apdEqActive; }
+
+    // External APD per-TX-antenna sampler-port assignment (SmartSDR 4.2.18+).
+    struct ApdSampler {
+        QString     selected{"INTERNAL"};
+        QStringList available{"INTERNAL"};
+    };
+    ApdSampler apdSampler(const QString& txAnt) const { return m_apdSamplers.value(txAnt); }
     // Reset all state to defaults on disconnect — different radio models
     // have different capabilities (APD, max power, pan count, etc.)
     void resetState();
@@ -121,6 +129,7 @@ public:
     void applyInterlockStatus(const QMap<QString, QString>& kvs);
     void applyAtuStatus(const QMap<QString, QString>& kvs);
     void applyApdStatus(const QMap<QString, QString>& kvs);
+    void applyApdSamplerStatus(const QMap<QString, QString>& kvs);
     void setProfileList(const QStringList& profiles);
     void setActiveProfile(const QString& profile);
     void setMicProfileList(const QStringList& profiles);
@@ -141,6 +150,8 @@ public:
     void setAtuMemories(bool on);
     void loadProfile(const QString& name);
     void setApdEnabled(bool on);
+    void setApdSamplerPort(const QString& txAnt, const QString& port);
+    void resetApdEqualizer();
 
     // ── Mic / monitor / processor commands ────────────────────────────────
     void setMicSelection(const QString& input);
@@ -189,6 +200,8 @@ signals:
     void micInputListChanged();
     void phoneStateChanged();       // VOX or CW property changed
     void apdStateChanged();
+    void apdSamplerChanged(const QString& txAnt);
+    void apdEqualizerResetReceived();
     void maxPowerLevelChanged(int maxWatts);
     void commandReady(const QString& cmd);
 
@@ -199,6 +212,7 @@ private:
     bool m_apdEnabled{false};
     bool m_apdConfigurable{false};
     bool m_apdEqActive{false};
+    QHash<QString, ApdSampler> m_apdSamplers;  // keyed by ANT1/ANT2/XVTA/XVTB
 
     // Transmit state
     int  m_rfPower{100};

--- a/tests/transmit_model_apd_test.cpp
+++ b/tests/transmit_model_apd_test.cpp
@@ -1,0 +1,189 @@
+// Unit tests for External APD plumbing on TransmitModel — covers status
+// parsing, sampler-port commands, equalizer reset, and idempotency.
+
+#include "models/TransmitModel.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) ++g_failed;
+}
+
+QMap<QString, QString> kvs(std::initializer_list<std::pair<QString, QString>> pairs)
+{
+    QMap<QString, QString> m;
+    for (const auto& p : pairs) m.insert(p.first, p.second);
+    return m;
+}
+
+void testSamplerStatusPopulatesAvailableAndSelected()
+{
+    TransmitModel tx;
+    QSignalSpy spy(&tx, &TransmitModel::apdSamplerChanged);
+
+    tx.applyApdSamplerStatus(kvs({
+        {"tx_ant", "ANT1"},
+        {"selected_sampler", "RX_A"},
+        {"valid_samplers", "RX_A,XVTA"},
+    }));
+
+    const auto s = tx.apdSampler("ANT1");
+    report("sampler ANT1 selected = RX_A", s.selected == "RX_A");
+    report("sampler ANT1 includes INTERNAL first",
+        !s.available.isEmpty() && s.available.first() == "INTERNAL");
+    report("sampler ANT1 contains RX_A and XVTA",
+        s.available.contains("RX_A") && s.available.contains("XVTA"));
+    report("apdSamplerChanged emitted once", spy.count() == 1);
+}
+
+void testSelectedFallbackWhenNotInValidList()
+{
+    TransmitModel tx;
+
+    // selected_sampler isn't present in valid_samplers — FlexLib falls back
+    // to INTERNAL rather than displaying a value the user can't pick.
+    tx.applyApdSamplerStatus(kvs({
+        {"tx_ant", "ANT2"},
+        {"selected_sampler", "BOGUS"},
+        {"valid_samplers", "RX_B"},
+    }));
+
+    report("invalid selected_sampler falls back to INTERNAL",
+        tx.apdSampler("ANT2").selected == "INTERNAL");
+}
+
+void testSetSamplerPortEmitsCommand()
+{
+    TransmitModel tx;
+    QSignalSpy cmds(&tx, &TransmitModel::commandReady);
+
+    tx.setApdSamplerPort("ANT2", "RX_B");
+    report("setApdSamplerPort emits one command", cmds.count() == 1);
+    report("command formatted correctly",
+        cmds.first().first().toString() == "apd sampler tx_ant=ANT2 sample_port=RX_B");
+
+    // Lowercase input is normalised to uppercase to match the radio's case.
+    tx.setApdSamplerPort("xvta", "internal");
+    report("sampler command upcases ant and port",
+        cmds.last().first().toString() == "apd sampler tx_ant=XVTA sample_port=INTERNAL");
+
+    // Empty inputs are ignored — no spurious command.
+    int before = cmds.count();
+    tx.setApdSamplerPort("", "RX_A");
+    tx.setApdSamplerPort("ANT1", "");
+    report("empty txAnt or port silently dropped", cmds.count() == before);
+}
+
+void testResetEqualizerEmitsCommand()
+{
+    TransmitModel tx;
+    QSignalSpy cmds(&tx, &TransmitModel::commandReady);
+
+    tx.resetApdEqualizer();
+    report("resetApdEqualizer emits one command", cmds.count() == 1);
+    report("reset command is 'apd reset'",
+        cmds.first().first().toString() == "apd reset");
+}
+
+void testEqualizerResetStatusFlagClearsActive()
+{
+    TransmitModel tx;
+    // Drive equalizer_active=1 first.
+    tx.applyApdStatus(kvs({{"equalizer_active", "1"}}));
+    report("equalizer_active goes true", tx.apdEqualizerActive());
+
+    QSignalSpy resetSpy(&tx, &TransmitModel::apdEqualizerResetReceived);
+    QSignalSpy stateSpy(&tx, &TransmitModel::apdStateChanged);
+
+    // Bare flag form: dispatcher merges "equalizer_reset" into kvs as
+    // an empty-valued key.
+    tx.applyApdStatus(kvs({{"equalizer_reset", ""}}));
+
+    report("apdEqualizerResetReceived emitted", resetSpy.count() == 1);
+    report("equalizer_active clears on reset", !tx.apdEqualizerActive());
+    report("apdStateChanged emitted on reset", stateSpy.count() >= 1);
+}
+
+void testConfigurableEnablesUiVisibility()
+{
+    TransmitModel tx;
+    QSignalSpy spy(&tx, &TransmitModel::apdStateChanged);
+
+    report("apdConfigurable starts false", !tx.apdConfigurable());
+    tx.applyApdStatus(kvs({{"configurable", "1"}}));
+    report("configurable=1 flips apdConfigurable", tx.apdConfigurable());
+    report("apdStateChanged emitted", spy.count() >= 1);
+
+    tx.applyApdStatus(kvs({{"configurable", "0"}}));
+    report("configurable=0 turns it back off", !tx.apdConfigurable());
+}
+
+void testSamplerStatusIdempotent()
+{
+    TransmitModel tx;
+
+    tx.applyApdSamplerStatus(kvs({
+        {"tx_ant", "ANT1"},
+        {"selected_sampler", "RX_A"},
+        {"valid_samplers", "RX_A,XVTA"},
+    }));
+
+    QSignalSpy spy(&tx, &TransmitModel::apdSamplerChanged);
+    // Re-apply identical status — must not re-emit.
+    tx.applyApdSamplerStatus(kvs({
+        {"tx_ant", "ANT1"},
+        {"selected_sampler", "RX_A"},
+        {"valid_samplers", "RX_A,XVTA"},
+    }));
+    report("identical sampler status is idempotent", spy.count() == 0);
+}
+
+void testResetStateClearsSamplers()
+{
+    TransmitModel tx;
+    tx.applyApdSamplerStatus(kvs({
+        {"tx_ant", "ANT1"},
+        {"selected_sampler", "RX_A"},
+        {"valid_samplers", "RX_A"},
+    }));
+    report("sampler set before reset", tx.apdSampler("ANT1").selected == "RX_A");
+
+    tx.resetState();
+    report("resetState clears sampler hash",
+        tx.apdSampler("ANT1").selected == "INTERNAL"
+        && tx.apdSampler("ANT1").available == QStringList{"INTERNAL"});
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    testSamplerStatusPopulatesAvailableAndSelected();
+    testSelectedFallbackWhenNotInValidList();
+    testSetSamplerPortEmitsCommand();
+    testResetEqualizerEmitsCommand();
+    testEqualizerResetStatusFlagClearsActive();
+    testConfigurableEnablesUiVisibility();
+    testSamplerStatusIdempotent();
+    testResetStateClearsSamplers();
+
+    if (g_failed == 0) {
+        std::printf("\nAll APD tests passed.\n");
+        return 0;
+    }
+    std::printf("\n%d test(s) FAILED.\n", g_failed);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements External APD support for SmartSDR 4.2.18 firmware.  External APD lets the radio sample its outgoing RF from a coupled feedback path on one of the RX/XVTR inputs (rather than the internal sampler), so the predistortion engine trains against the *actual* transmitted signal — required when a FLEX-8x00 drives an external linear amplifier (PGXL, etc.).

The `apd enable` / `configurable` / `equalizer_active` plumbing was already in place.  This PR adds the sampler subobject, the equalizer-reset command, and the UI.

## Changes

**Protocol (`TransmitModel`)**
- New `apdSampler(txAnt)` getter returning `{selected, available}` per ANT1/ANT2/XVTA/XVTB.
- `applyApdSamplerStatus(kvs)` parses `apd sampler tx_ant=ANT1 selected_sampler=RX_A valid_samplers=RX_A,XVTA`.  If `selected_sampler` isn't in the valid list, falls back to `INTERNAL` (matches FlexLib behaviour).
- `setApdSamplerPort(txAnt, port)` emits `apd sampler tx_ant=ANT sample_port=PORT`.
- `resetApdEqualizer()` emits `apd reset`.
- `applyApdStatus()` now also handles the bare `equalizer_reset` flag, emitting a new `apdEqualizerResetReceived` signal.
- `RadioModel` dispatcher routes `"apd sampler"` to `applyApdSamplerStatus`; the bare-flag form gets merged into kvs and routed to `applyApdStatus`.

**UI (`RadioSetupDialog`)**
- New "APD" tab between **XVTR** and **USB Cables**.  Eagerly added but visibility is gated on `transmitModel.apdConfigurable()` and updates live via `apdStateChanged`, so the tab stays hidden on 6000-series radios and pre-4.2.18 firmware.
- Layout matches the SmartSDR 4.2.18 "External Sampler (per TX ANT)" group: ANT1/XVTA on top row, ANT2/XVTB on bottom, each with a port combo; Equalizer Reset button on its own row.
- Combo options + selection are kept in sync with the model via `apdSamplerChanged` (signal-blocked refresh, so user-driven changes don't echo back to the radio).

**Tests** — `tests/transmit_model_apd_test.cpp`, 22 assertions:
- Sampler status populates `available` (with `INTERNAL` first) and `selected`.
- Invalid `selected_sampler` falls back to `INTERNAL`.
- Sampler-port command formatted correctly + case-normalised.
- Empty txAnt or port silently dropped (no spurious command).
- `resetApdEqualizer()` emits `apd reset`.
- Bare `equalizer_reset` clears `equalizer_active` and fires the reset signal.
- `configurable=1`/`=0` toggles `apdConfigurable()`.
- Identical sampler status is idempotent (no re-emit).
- `resetState()` clears the sampler hash on disconnect.

Reference: `Flex.Smoothlake.FlexLib` v4.2.18, `FlexLib/APD.cs`.

## Test plan

- [ ] `./build/transmit_model_apd_test` — all 22 pass locally.
- [ ] Connect to a FLEX-8600 on firmware 4.2.18: APD tab visible.
- [ ] Connect to a FLEX-6000 series: APD tab not present.
- [ ] Per-antenna combo shows the radio's `valid_samplers` plus `INTERNAL`.
- [ ] Selecting `RX_A` for ANT1 sends `apd sampler tx_ant=ANT1 sample_port=RX_A`; the echoed status updates the combo without firing a second command.
- [ ] Reset button sends `apd reset`; subsequent status arrival clears the active indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)