### PR TITLE
fix: include QElapsedTimer for Windows build without HAVE_SERIALPORT

### DIFF
--- a/src/core/SerialPortController.h
+++ b/src/core/SerialPortController.h
@@ -3,8 +3,10 @@
 #include <QObject>
 #include <QString>
 
-#ifdef HAVE_SERIALPORT
+#if defined(HAVE_SERIALPORT) || defined(Q_OS_WIN)
 #include <QElapsedTimer>
+#endif
+#ifdef HAVE_SERIALPORT
 #ifndef Q_OS_WIN
 #include <QSerialPort>
 #include <QTimer>


### PR DESCRIPTION
## Summary

Fixes a Windows build failure introduced by #2147 (serial PTT Win32 rewrite).

## Problem

`QElapsedTimer` is included inside `#ifdef HAVE_SERIALPORT` in `SerialPortController.h`, but `m_debounceTimer` is declared inside the broader `#if defined(HAVE_SERIALPORT) || defined(Q_OS_WIN)` guard. On Windows when `Qt6::SerialPort` is not present (`HAVE_SERIALPORT` undefined), `Q_OS_WIN` is still true so the member block is compiled, but the `QElapsedTimer` include was skipped — resulting in:

```
error: 'QElapsedTimer' does not name a type
error: 'm_debounceTimer' was not declared in this scope
```

## Fix

Move the `#include <QElapsedTimer>` to use the same `#if defined(HAVE_SERIALPORT) || defined(Q_OS_WIN)` guard as the member that depends on it.

## Test Plan

- [x] Builds cleanly on Windows (MinGW GCC 13.1.0 / Qt 6.11.0) with `Qt6::SerialPort` disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)