### PR TITLE
[feature] AetherSweep SWR analyzer

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -48,9 +48,7 @@
 #include <QScrollBar>
 #include <QPainter>
 #include <QPixmap>
-#include <QMenu>
 #include <QTimer>
-#include <QContextMenuEvent>
 
 namespace AetherSDR {
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -179,6 +179,19 @@ constexpr int kPanFollowAnimationDurationMs = 110;
 constexpr int kSliderShortcutLeaseMs = 2000;
 constexpr int kPanadapterSliceCapacityStatusMs = 4000;
 constexpr qint64 kXvtrWaterfallDecisionLogIntervalMs = 20000;
+constexpr double kSwrSweepStepMhz = 0.020;
+constexpr double kSwrSweepEdgeGuardMhz = 0.005;
+constexpr double kSwrSweepPanPaddingMhz = 0.020;
+constexpr int kSwrSweepPollMs = 50;
+constexpr int kSwrSweepInitialSettleMs = 350;
+constexpr int kSwrSweepStepSettleMs = 160;
+constexpr int kSwrSweepMaxSettleMs = 900;
+constexpr int kSwrSweepTgxlBypassTimeoutMs = 3500;
+constexpr int kSwrSweepTgxlRelaySettleMs = 250;
+constexpr int kSwrSweepTuneStopWaitMs = 350;
+constexpr int kSwrSweepTuneStopTimeoutMs = 1800;
+constexpr int kSwrSweepTgxlRestoreTimeoutMs = 3500;
+constexpr int kSwrSweepMaxPoints = 260;
 
 int panCountForLayoutId(const QString& layoutId)
 {
@@ -939,6 +952,11 @@ MainWindow::MainWindow(QWidget* parent)
     buildMenuBar();
     buildUI();
     registerShortcutActions();
+
+    m_swrSweepTimer.setTimerType(Qt::PreciseTimer);
+    m_swrSweepTimer.setInterval(kSwrSweepPollMs);
+    connect(&m_swrSweepTimer, &QTimer::timeout,
+            this, &MainWindow::advanceSwrSweep);
 
     if (auto* wave = m_appletPanel ? m_appletPanel->waveApplet() : nullptr) {
         connect(m_audio, &AudioEngine::scopeSamplesReady,
@@ -4306,6 +4324,14 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
     // which widget has focus (buttons, combos, etc. won't steal Space).
     if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease) {
         auto* ke = static_cast<QKeyEvent*>(event);
+        if (m_swrSweep.running) {
+            if (event->type() == QEvent::KeyPress
+                && ke->key() == Qt::Key_Escape
+                && !ke->isAutoRepeat()) {
+                finishSwrSweep(true, QStringLiteral("SWR sweep stopped"));
+            }
+            return true;
+        }
         if (ke->key() == Qt::Key_Space && !ke->isAutoRepeat()
             && !shortcutInputCaptured()
             && m_radioModel.isConnected()) {
@@ -6832,6 +6858,8 @@ void MainWindow::onConnectionStateChanged(bool connected)
             }
         }
     } else {
+        if (m_swrSweep.running)
+            finishSwrSweep(true, QStringLiteral("SWR sweep stopped on disconnect"));
         QMetaObject::invokeMethod(m_dxCluster, [=] { m_dxCluster->disconnect(); });
         QMetaObject::invokeMethod(m_rbnClient, [=] { m_rbnClient->disconnect(); });
         QMetaObject::invokeMethod(m_wsjtxClient, [=] { m_wsjtxClient->stopListening(); });
@@ -7643,6 +7671,8 @@ void MainWindow::applyTuneRequest(SliceModel* slice, double mhz,
                                   TuneIntent intent, const char* source)
 {
     if (!slice)
+        return;
+    if (m_swrSweep.running)
         return;
 
     const double oldFreqMhz = slice->frequency();
@@ -8759,6 +8789,10 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         s.setValue(sw->settingsKey("DisplayRfGain"), QString::number(gain));
         s.save();
     });
+    connect(menu, &SpectrumOverlayMenu::swrSweepStartRequested,
+            this, &MainWindow::startSwrSweep);
+    connect(menu, &SpectrumOverlayMenu::swrSweepClearRequested,
+            this, &MainWindow::clearSwrSweepPlot);
 
     // ── NR2/RN2 overlay toggle → AudioEngine ───────────────────────────
     // Button sync back to overlay + VFO handled by nr2/rn2EnabledChanged above.
@@ -10469,6 +10503,519 @@ void MainWindow::restoreBandState(const BandSnapshot& snap)
         sw->setWnbActive(snap.wnbOn);
     }
     m_updatingFromModel = false;
+}
+
+SliceModel* MainWindow::swrSweepTargetSlice(int requestedSliceId) const
+{
+    if (requestedSliceId >= 0)
+        return m_radioModel.slice(requestedSliceId);
+
+    if (auto* s = activeSlice(); s && s->isTxSlice())
+        return s;
+
+    for (auto* s : m_radioModel.slices()) {
+        if (s && s->isTxSlice())
+            return s;
+    }
+
+    return activeSlice();
+}
+
+void MainWindow::setSwrSweepInputsLocked(bool locked)
+{
+    if (locked) {
+        m_swrSweep.appletPanelWasEnabled = !m_appletPanel || m_appletPanel->isEnabled();
+        m_swrSweep.panStackWasEnabled = !m_panStack || m_panStack->isEnabled();
+        if (m_appletPanel)
+            m_appletPanel->setEnabled(false);
+        if (m_panStack)
+            m_panStack->setEnabled(false);
+        setFocus(Qt::OtherFocusReason);
+        return;
+    }
+
+    if (m_appletPanel)
+        m_appletPanel->setEnabled(m_swrSweep.appletPanelWasEnabled);
+    if (m_panStack)
+        m_panStack->setEnabled(m_swrSweep.panStackWasEnabled);
+}
+
+void MainWindow::clearSwrSweepPlot()
+{
+    if (m_swrSweep.running) {
+        m_swrSweep.clearPlotOnFinish = true;
+        finishSwrSweep(true, QStringLiteral("SWR sweep cleared"));
+        return;
+    }
+
+    m_swrSweep.samples.clear();
+    m_swrSweep.sourceLabel.clear();
+    for (auto* applet : m_panStack ? m_panStack->allApplets() : QList<PanadapterApplet*>{}) {
+        if (auto* sw = applet ? applet->spectrumWidget() : nullptr)
+            sw->clearSwrSweepPoints();
+    }
+    statusBar()->showMessage(QStringLiteral("SWR sweep plot cleared"), 2500);
+}
+
+void MainWindow::updateSwrSweepOverlay(double currentFreqMhz)
+{
+    QVector<SpectrumWidget::SwrSweepPoint> points;
+    points.reserve(m_swrSweep.samples.size());
+    for (const auto& sample : m_swrSweep.samples)
+        points.append({sample.freqMhz, sample.swr});
+
+    if (!m_panStack)
+        return;
+
+    for (auto* applet : m_panStack->allApplets()) {
+        auto* sw = applet ? applet->spectrumWidget() : nullptr;
+        if (!sw)
+            continue;
+        if (applet->panId() == m_swrSweep.panId) {
+            sw->setSwrSweepPoints(points, m_swrSweep.running, currentFreqMhz,
+                                  m_swrSweep.sourceLabel);
+        } else if (m_swrSweep.running) {
+            sw->clearSwrSweepPoints();
+        }
+    }
+}
+
+void MainWindow::commandSwrSweepFrequency(double freqMhz, int settleMs)
+{
+    auto* s = m_radioModel.slice(m_swrSweep.sliceId);
+    if (!s) {
+        finishSwrSweep(true, QStringLiteral("SWR sweep stopped: slice closed"));
+        return;
+    }
+
+    s->setFrequency(freqMhz);
+    if (auto* sw = spectrumForSlice(s))
+        sw->setSliceOverlayFreq(s->sliceId(), freqMhz);
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    m_swrSweep.commandIssuedAtMs = now;
+    m_swrSweep.sampleNotBeforeMs = now + settleMs;
+    updateSwrSweepOverlay(freqMhz);
+}
+
+void MainWindow::beginSwrSweepRf()
+{
+    if (!m_swrSweep.running)
+        return;
+
+    auto* s = m_radioModel.slice(m_swrSweep.sliceId);
+    if (!s) {
+        finishSwrSweep(true, QStringLiteral("SWR sweep stopped: slice closed"));
+        return;
+    }
+
+    if (m_swrSweep.meterSource == SwrSweepMeterSource::Tgxl) {
+        const auto& tuner = m_radioModel.tunerModel();
+        if (!tuner.isPresent() || !tuner.isOperate() || !tuner.isBypass()) {
+            finishSwrSweep(true,
+                           QStringLiteral("SWR sweep stopped: TGXL bypass was not confirmed"));
+            return;
+        }
+    }
+
+    const QString bandName = BandSettings::bandForFrequency(m_swrSweep.originalFreqMhz);
+    const BandDef& band = BandSettings::bandDef(bandName);
+    const double displayCenter = (band.lowMhz + band.highMhz) * 0.5;
+    const double displayBw = (band.highMhz - band.lowMhz) + 2.0 * kSwrSweepPanPaddingMhz;
+
+    m_swrSweep.phase = SwrSweepPhase::Sweeping;
+    m_swrSweep.phaseStartedAtMs = QDateTime::currentMSecsSinceEpoch();
+    applyPanRangeRequest(m_swrSweep.panId, displayCenter, displayBw, "swr-sweep");
+
+    commandSwrSweepFrequency(m_swrSweep.frequencies.first(), kSwrSweepInitialSettleMs);
+    m_radioModel.transmitModel().startTune();
+    m_swrSweep.tuneStarted = true;
+    m_swrSweepTimer.start(kSwrSweepPollMs);
+
+    statusBar()->showMessage(
+        tr("SWR sweep running on %1 with Tune Power %2 W%3. Press Esc to stop.")
+            .arg(QString::fromLatin1(band.name))
+            .arg(m_radioModel.transmitModel().tunePower())
+            .arg(m_swrSweep.sourceLabel.isEmpty()
+                     ? QString()
+                     : QStringLiteral(" (%1)").arg(m_swrSweep.sourceLabel)),
+        5000);
+}
+
+void MainWindow::startSwrSweep(int requestedSliceId)
+{
+    if (m_swrSweep.running)
+        return;
+
+    if (!m_radioModel.isConnected()) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("Connect to a radio before starting an SWR sweep."));
+        return;
+    }
+    if (m_splitActive) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("Disable split before running an SWR sweep."));
+        return;
+    }
+
+    auto* s = swrSweepTargetSlice(requestedSliceId);
+    if (!s || !s->isTxSlice()) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("Select the TX slice before running an SWR sweep."));
+        return;
+    }
+    if (s->isLocked()) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("Unlock the TX slice before running an SWR sweep."));
+        return;
+    }
+    if (s->panId().isEmpty() || !spectrumForSlice(s)) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("The TX slice needs a visible panadapter before running an SWR sweep."));
+        return;
+    }
+
+    auto& tx = m_radioModel.transmitModel();
+    if (tx.isTuning() || tx.isMox() || tx.isTransmitting()) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("Stop transmit or tune before starting an SWR sweep."));
+        return;
+    }
+    if (tx.tunePower() <= 0) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("Tune Power is 0 W. Set a non-zero Tune Power first."));
+        return;
+    }
+
+    const QString bandName = BandSettings::bandForFrequency(s->frequency());
+    const BandDef& band = BandSettings::bandDef(bandName);
+    if (bandName == QLatin1String("GEN") || band.lowMhz <= 0.0 || band.highMhz <= band.lowMhz) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("The current TX frequency is not inside a supported amateur band."));
+        return;
+    }
+    if (bandName == QLatin1String("60m")) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("SWR sweep is disabled on 60 m because the band is channelized."));
+        return;
+    }
+
+    const double safeLow = band.lowMhz + kSwrSweepEdgeGuardMhz;
+    const double safeHigh = band.highMhz - kSwrSweepEdgeGuardMhz;
+    if (safeHigh <= safeLow) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("This band is too narrow for the configured SWR sweep guard."));
+        return;
+    }
+
+    const double displayBw = (band.highMhz - band.lowMhz) + 2.0 * kSwrSweepPanPaddingMhz;
+    if (displayBw > m_radioModel.maxPanBandwidthMhz()) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("This band is wider than the radio can display in one panadapter."));
+        return;
+    }
+
+    QVector<double> sweepFreqs;
+    for (double f = safeLow; f <= safeHigh + 1.0e-9; f += kSwrSweepStepMhz)
+        sweepFreqs.append(std::round(f * 1.0e6) / 1.0e6);
+    if (sweepFreqs.isEmpty()) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("No in-band sweep points were available."));
+        return;
+    }
+    if (sweepFreqs.size() > kSwrSweepMaxPoints) {
+        QMessageBox::warning(this, tr("SWR Sweep"),
+                             tr("This band would need too many sweep points for one fast pass."));
+        return;
+    }
+
+    m_swrSweep = SwrSweepState{};
+    m_swrSweep.running = true;
+    m_swrSweep.sliceId = s->sliceId();
+    m_swrSweep.panId = s->panId();
+    m_swrSweep.originalFreqMhz = s->frequency();
+    m_swrSweep.frequencies = sweepFreqs;
+    m_swrSweep.currentIndex = 0;
+    m_swrSweep.minimumForwardPowerW = qBound(0.05f,
+                                             static_cast<float>(tx.tunePower()) * 0.05f,
+                                             1.0f);
+    auto& tuner = m_radioModel.tunerModel();
+    m_swrSweep.tgxlOriginalOperate = tuner.isOperate();
+    m_swrSweep.tgxlOriginalBypass = tuner.isBypass();
+    if (tuner.isPresent() && tuner.isOperate()) {
+        m_swrSweep.meterSource = SwrSweepMeterSource::Tgxl;
+        m_swrSweep.sourceLabel = QStringLiteral("TGXL BYPASS");
+        if (!tuner.isBypass()) {
+            m_swrSweep.tgxlBypassRequested = true;
+            m_swrSweep.tgxlRestoreNeeded = true;
+        }
+    } else {
+        m_swrSweep.sourceLabel = tuner.isPresent()
+            ? QStringLiteral("RADIO")
+            : QString();
+    }
+
+    if (auto* sw = spectrumForSlice(s)) {
+        m_swrSweep.originalPanCenterMhz = sw->centerMhz();
+        m_swrSweep.originalPanBandwidthMhz = sw->bandwidthMhz();
+    }
+
+    for (auto* applet : m_panStack ? m_panStack->allApplets() : QList<PanadapterApplet*>{}) {
+        if (auto* sw = applet ? applet->spectrumWidget() : nullptr)
+            sw->clearSwrSweepPoints();
+    }
+
+    setSwrSweepInputsLocked(true);
+
+    if (m_swrSweep.tgxlBypassRequested) {
+        m_swrSweep.phase = SwrSweepPhase::WaitingForTgxlBypass;
+        m_swrSweep.phaseStartedAtMs = QDateTime::currentMSecsSinceEpoch();
+        tuner.setBypass(true);
+        m_swrSweepTimer.start(kSwrSweepPollMs);
+        statusBar()->showMessage(
+            tr("Preparing SWR sweep: placing TGXL in BYPASS before applying RF..."),
+            5000);
+        updateSwrSweepOverlay(-1.0);
+        return;
+    }
+
+    beginSwrSweepRf();
+}
+
+void MainWindow::advanceSwrSweep()
+{
+    if (!m_swrSweep.running)
+        return;
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    auto& tuner = m_radioModel.tunerModel();
+
+    if (m_swrSweep.phase == SwrSweepPhase::WaitingForTgxlBypass) {
+        if (!tuner.isPresent() || !tuner.isOperate()) {
+            finishSwrSweep(true,
+                           QStringLiteral("SWR sweep stopped: TGXL is no longer available"));
+            return;
+        }
+        if (tuner.isBypass()) {
+            m_swrSweep.phase = SwrSweepPhase::TgxlBypassSettle;
+            m_swrSweep.phaseStartedAtMs = now;
+            statusBar()->showMessage(
+                tr("TGXL BYPASS confirmed. Waiting for relays to settle..."),
+                2500);
+            return;
+        }
+        if (now - m_swrSweep.phaseStartedAtMs >= kSwrSweepTgxlBypassTimeoutMs) {
+            finishSwrSweep(true,
+                           QStringLiteral("SWR sweep stopped: TGXL did not enter bypass"));
+        }
+        return;
+    }
+
+    if (m_swrSweep.phase == SwrSweepPhase::TgxlBypassSettle) {
+        if (!tuner.isPresent() || !tuner.isOperate() || !tuner.isBypass()) {
+            finishSwrSweep(true,
+                           QStringLiteral("SWR sweep stopped: TGXL left bypass"));
+            return;
+        }
+        if (now - m_swrSweep.phaseStartedAtMs >= kSwrSweepTgxlRelaySettleMs)
+            beginSwrSweepRf();
+        return;
+    }
+
+    if (m_swrSweep.phase == SwrSweepPhase::StoppingTune) {
+        const bool waitedMinimum = now - m_swrSweep.phaseStartedAtMs >= kSwrSweepTuneStopWaitMs;
+        const bool stopped = !m_radioModel.transmitModel().isTuning();
+        const bool timedOut = now - m_swrSweep.phaseStartedAtMs >= kSwrSweepTuneStopTimeoutMs;
+        if (!waitedMinimum || (!stopped && !timedOut))
+            return;
+
+        finishSwrSweepAfterTuneStopped();
+        return;
+    }
+
+    if (m_swrSweep.phase == SwrSweepPhase::RestoringTgxl) {
+        const bool restored = !tuner.isPresent()
+            || tuner.isBypass() == m_swrSweep.tgxlOriginalBypass;
+        if (restored) {
+            completeSwrSweepFinish();
+            return;
+        }
+        if (now - m_swrSweep.phaseStartedAtMs >= kSwrSweepTgxlRestoreTimeoutMs) {
+            m_swrSweep.tgxlRestoreTimedOut = true;
+            completeSwrSweepFinish();
+        }
+        return;
+    }
+
+    auto* s = m_radioModel.slice(m_swrSweep.sliceId);
+    if (!s) {
+        finishSwrSweep(true, QStringLiteral("SWR sweep stopped: slice closed"));
+        return;
+    }
+
+    if (m_swrSweep.phase != SwrSweepPhase::Sweeping)
+        return;
+
+    if (m_swrSweep.meterSource == SwrSweepMeterSource::Tgxl
+        && (!tuner.isPresent() || !tuner.isOperate() || !tuner.isBypass())) {
+        finishSwrSweep(true, QStringLiteral("SWR sweep stopped: TGXL left bypass"));
+        return;
+    }
+
+    if (now < m_swrSweep.sampleNotBeforeMs)
+        return;
+
+    const auto& meters = m_radioModel.meterModel();
+    const bool useTgxlMeters = m_swrSweep.meterSource == SwrSweepMeterSource::Tgxl;
+    const bool swrFresh = useTgxlMeters
+        ? meters.tgxlSwrUpdatedAtMs() >= m_swrSweep.sampleNotBeforeMs
+        : meters.swrUpdatedAtMs() >= m_swrSweep.sampleNotBeforeMs;
+    const bool fwdFresh = useTgxlMeters
+        ? meters.tgxlFwdPowerUpdatedAtMs() >= m_swrSweep.sampleNotBeforeMs
+        : meters.fwdPowerUpdatedAtMs() >= m_swrSweep.sampleNotBeforeMs;
+    const bool hasForwardPower =
+        (useTgxlMeters ? meters.tgxlFwdPower() : meters.fwdPowerInstant())
+            >= m_swrSweep.minimumForwardPowerW;
+    if (!swrFresh || !fwdFresh || !hasForwardPower) {
+        if (now - m_swrSweep.commandIssuedAtMs < kSwrSweepMaxSettleMs)
+            return;
+
+        if (!swrFresh) {
+            finishSwrSweep(true,
+                           useTgxlMeters
+                               ? QStringLiteral("SWR sweep stopped: no fresh TGXL SWR meter data")
+                               : QStringLiteral("SWR sweep stopped: no fresh SWR meter data"));
+        } else {
+            finishSwrSweep(true,
+                           useTgxlMeters
+                               ? QStringLiteral("SWR sweep stopped: no TGXL forward power detected")
+                               : QStringLiteral("SWR sweep stopped: no forward power detected"));
+        }
+        return;
+    }
+
+    if (m_swrSweep.currentIndex < 0
+        || m_swrSweep.currentIndex >= m_swrSweep.frequencies.size()) {
+        finishSwrSweep(false, QStringLiteral("SWR sweep complete"));
+        return;
+    }
+
+    float swr = useTgxlMeters ? meters.tgxlSwr() : meters.swr();
+    if (!std::isfinite(static_cast<double>(swr)) || swr < 1.0f)
+        swr = 1.0f;
+
+    const double sampleFreq = m_swrSweep.frequencies[m_swrSweep.currentIndex];
+    m_swrSweep.samples.append({sampleFreq, swr});
+    updateSwrSweepOverlay(sampleFreq);
+
+    ++m_swrSweep.currentIndex;
+    if (m_swrSweep.currentIndex >= m_swrSweep.frequencies.size()) {
+        finishSwrSweep(false, QStringLiteral("SWR sweep complete"));
+        return;
+    }
+
+    commandSwrSweepFrequency(m_swrSweep.frequencies[m_swrSweep.currentIndex],
+                             kSwrSweepStepSettleMs);
+}
+
+void MainWindow::finishSwrSweep(bool aborted, const QString& reason)
+{
+    if (!m_swrSweep.running)
+        return;
+
+    if (!reason.isEmpty())
+        m_swrSweep.finalReason = reason;
+    m_swrSweep.finalAborted = m_swrSweep.finalAborted || aborted;
+
+    if (m_swrSweep.phase == SwrSweepPhase::StoppingTune
+        || m_swrSweep.phase == SwrSweepPhase::RestoringTgxl) {
+        return;
+    }
+
+    if (m_radioModel.isConnected() && m_swrSweep.tuneStarted) {
+        m_radioModel.transmitModel().stopTune();
+        m_swrSweep.phase = SwrSweepPhase::StoppingTune;
+        m_swrSweep.phaseStartedAtMs = QDateTime::currentMSecsSinceEpoch();
+        m_swrSweepTimer.start(kSwrSweepPollMs);
+        statusBar()->showMessage(tr("Stopping SWR sweep tune carrier..."), 2500);
+        return;
+    }
+
+    finishSwrSweepAfterTuneStopped();
+}
+
+void MainWindow::finishSwrSweepAfterTuneStopped()
+{
+    if (!m_swrSweep.running)
+        return;
+
+    if (m_radioModel.isConnected()) {
+        if (auto* s = m_radioModel.slice(m_swrSweep.sliceId);
+            s && m_swrSweep.originalFreqMhz > 0.0) {
+            s->setFrequency(m_swrSweep.originalFreqMhz);
+        }
+
+        if (m_swrSweep.finalAborted && !m_swrSweep.panId.isEmpty()
+            && m_swrSweep.originalPanCenterMhz > 0.0
+            && m_swrSweep.originalPanBandwidthMhz > 0.0) {
+            applyPanRangeRequest(m_swrSweep.panId,
+                                 m_swrSweep.originalPanCenterMhz,
+                                 m_swrSweep.originalPanBandwidthMhz,
+                                 "swr-sweep-stop");
+        }
+
+        auto& tuner = m_radioModel.tunerModel();
+        if (m_swrSweep.tgxlRestoreNeeded
+            && tuner.isPresent()
+            && tuner.isOperate()
+            && (tuner.isBypass() != m_swrSweep.tgxlOriginalBypass
+                || m_swrSweep.tgxlBypassRequested)) {
+            tuner.setBypass(m_swrSweep.tgxlOriginalBypass);
+            m_swrSweep.phase = SwrSweepPhase::RestoringTgxl;
+            m_swrSweep.phaseStartedAtMs = QDateTime::currentMSecsSinceEpoch();
+            m_swrSweepTimer.start(kSwrSweepPollMs);
+            statusBar()->showMessage(tr("Restoring TGXL tuner state..."), 3000);
+            return;
+        }
+    }
+
+    completeSwrSweepFinish();
+}
+
+void MainWindow::completeSwrSweepFinish()
+{
+    if (!m_swrSweep.running)
+        return;
+
+    m_swrSweepTimer.stop();
+
+    const bool clearPlot = m_swrSweep.clearPlotOnFinish;
+    const bool aborted = m_swrSweep.finalAborted;
+    QString msg = m_swrSweep.finalReason.isEmpty()
+        ? (aborted ? QStringLiteral("SWR sweep stopped")
+                   : QStringLiteral("SWR sweep complete"))
+        : m_swrSweep.finalReason;
+    if (m_swrSweep.tgxlRestoreTimedOut)
+        msg += QStringLiteral("; TGXL restore was not confirmed");
+
+    m_swrSweep.running = false;
+    m_swrSweep.phase = SwrSweepPhase::Idle;
+
+    if (clearPlot) {
+        m_swrSweep.samples.clear();
+        m_swrSweep.sourceLabel.clear();
+        for (auto* applet : m_panStack ? m_panStack->allApplets() : QList<PanadapterApplet*>{}) {
+            if (auto* sw = applet ? applet->spectrumWidget() : nullptr)
+                sw->clearSwrSweepPoints();
+        }
+        msg = QStringLiteral("SWR sweep plot cleared");
+    } else {
+        updateSwrSweepOverlay(-1.0);
+    }
+
+    setSwrSweepInputsLocked(false);
+
+    statusBar()->showMessage(msg, aborted ? 3000 : 5000);
 }
 
 // ─── GUI control handlers ─────────────────────────────────────────────────────

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -208,6 +208,17 @@ private:
 
     BandSnapshot captureCurrentBandState() const;
     void restoreBandState(const BandSnapshot& snap);
+    void startSwrSweep(int requestedSliceId = -1);
+    void clearSwrSweepPlot();
+    void advanceSwrSweep();
+    void finishSwrSweep(bool aborted, const QString& reason = {});
+    void beginSwrSweepRf();
+    void finishSwrSweepAfterTuneStopped();
+    void completeSwrSweepFinish();
+    void commandSwrSweepFrequency(double freqMhz, int settleMs);
+    void updateSwrSweepOverlay(double currentFreqMhz = -1.0);
+    void setSwrSweepInputsLocked(bool locked);
+    SliceModel* swrSweepTargetSlice(int requestedSliceId = -1) const;
 
     // Core objects
     RadioDiscovery    m_discovery;
@@ -404,6 +415,53 @@ private:
     bool m_spacePttActive{false};          // true while Space is held for PTT
     QPointer<QAbstractSlider> m_sliderShortcutLease;
     QTimer m_sliderShortcutLeaseTimer;
+    struct SwrSweepSample {
+        double freqMhz{0.0};
+        float swr{1.0f};
+    };
+    enum class SwrSweepPhase {
+        Idle,
+        WaitingForTgxlBypass,
+        TgxlBypassSettle,
+        Sweeping,
+        StoppingTune,
+        RestoringTgxl,
+    };
+    enum class SwrSweepMeterSource {
+        Radio,
+        Tgxl,
+    };
+    struct SwrSweepState {
+        bool running{false};
+        SwrSweepPhase phase{SwrSweepPhase::Idle};
+        SwrSweepMeterSource meterSource{SwrSweepMeterSource::Radio};
+        int sliceId{-1};
+        QString panId;
+        double originalFreqMhz{0.0};
+        double originalPanCenterMhz{0.0};
+        double originalPanBandwidthMhz{0.0};
+        QVector<double> frequencies;
+        QVector<SwrSweepSample> samples;
+        int currentIndex{-1};
+        qint64 commandIssuedAtMs{0};
+        qint64 sampleNotBeforeMs{0};
+        qint64 phaseStartedAtMs{0};
+        float minimumForwardPowerW{0.0f};
+        bool tuneStarted{false};
+        bool finalAborted{false};
+        bool clearPlotOnFinish{false};
+        bool tgxlOriginalOperate{false};
+        bool tgxlOriginalBypass{false};
+        bool tgxlBypassRequested{false};
+        bool tgxlRestoreNeeded{false};
+        bool tgxlRestoreTimedOut{false};
+        QString finalReason;
+        QString sourceLabel;
+        bool appletPanelWasEnabled{true};
+        bool panStackWasEnabled{true};
+    };
+    SwrSweepState m_swrSweep;
+    QTimer m_swrSweepTimer;
     bool m_minimalMode{false};             // true when spectrum is hidden (#208)
     QAction* m_minimalModeAction{nullptr};
     bool m_panadapterConnectionAnimationVisible{false};

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -379,11 +379,42 @@ void SpectrumOverlayMenu::buildAntPanel()
         emit wnbLevelChanged(v);
     });
 
+    const QString sweepBtnStyle =
+        "QPushButton { background: rgba(38, 34, 24, 235); "
+        "border: 1px solid #705820; border-radius: 2px; "
+        "color: #ffd070; font-size: 10px; font-weight: bold; padding: 1px 4px; }"
+        "QPushButton:hover { background: rgba(120, 80, 20, 210); "
+        "border: 1px solid #ffc040; color: #ffffff; }"
+        "QPushButton:disabled { color: #706858; border-color: #403828; }";
+    auto* sweepRow = new QHBoxLayout;
+    sweepRow->setSpacing(4);
+    m_swrStartBtn = new QPushButton("Start Sweep");
+    m_swrStartBtn->setMinimumHeight(22);
+    m_swrStartBtn->setStyleSheet(sweepBtnStyle);
+    m_swrClearBtn = new QPushButton("Clear Sweep");
+    m_swrClearBtn->setMinimumHeight(22);
+    m_swrClearBtn->setStyleSheet(sweepBtnStyle);
+    sweepRow->addWidget(m_swrStartBtn, 1);
+    sweepRow->addWidget(m_swrClearBtn, 1);
+    vbox->addLayout(sweepRow);
+
+    connect(m_swrStartBtn, &QPushButton::clicked, this, [this]() {
+        const int sliceId = m_slice ? m_slice->sliceId() : -1;
+        hideAllSubPanels();
+        emit swrSweepStartRequested(sliceId);
+    });
+    connect(m_swrClearBtn, &QPushButton::clicked, this, [this]() {
+        hideAllSubPanels();
+        emit swrSweepClearRequested();
+    });
+
     // ANT panel tooltips
     m_rxAntCmb->setToolTip("Select the receive antenna port for this slice.");
     m_rfGainSlider->setToolTip("Adjusts receiver IF gain. Lower values reduce strong-signal overload.");
     m_wnbBtn->setToolTip("Wideband noise blanker \u2014 suppresses correlated impulse noise across the full panadapter bandwidth.");
     m_wnbSlider->setToolTip("Adjusts WNB threshold. Higher values blank more aggressively.");
+    m_swrStartBtn->setToolTip("Run a low-power tune sweep across the current TX band and plot SWR on the panadapter.");
+    m_swrClearBtn->setToolTip("Clear the displayed SWR sweep trace.");
 
     m_antPanel->setFixedWidth(180);
     m_antPanel->adjustSize();

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -129,6 +129,8 @@ signals:
     void wnbLevelChanged(int level);
     // Emitted when RF gain slider changes (panadapter-level).
     void rfGainChanged(int gain);
+    void swrSweepStartRequested(int sliceId);
+    void swrSweepClearRequested();
     // NB Waterfall Blanker (#277)
     void wfBlankerEnabledChanged(bool on);
     void wfBlankerThresholdChanged(float threshold);
@@ -189,6 +191,8 @@ private:
     QPushButton* m_wnbBtn{nullptr};
     QSlider*     m_wnbSlider{nullptr};
     QLabel*      m_wnbLabel{nullptr};
+    QPushButton* m_swrStartBtn{nullptr};
+    QPushButton* m_swrClearBtn{nullptr};
 
     // DSP sub-panel
     QWidget* m_dspPanel{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -3291,6 +3291,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             drawTnfMarkers(p, specRect);
             if (m_showSpots)
                 drawSpotMarkers(p, specRect);
+            drawSwrSweep(p, specRect);
             drawSliceMarkers(p, specRect, wfRect);
             drawOffScreenSlices(p, specRect);
 
@@ -3824,6 +3825,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         drawTimeScale(p, wfRect);
         drawTnfMarkers(p, specRect);
         if (m_showSpots) drawSpotMarkers(p, specRect);
+        drawSwrSweep(p, specRect);
         drawSliceMarkers(p, specRect, wfRect);
         drawOffScreenSlices(p, specRect);
         drawConnectionAnimation(p, specRect);
@@ -4345,6 +4347,27 @@ void SpectrumWidget::setSpotMarkers(const QVector<SpotMarker>& markers)
     markOverlayDirty();
 }
 
+void SpectrumWidget::setSwrSweepPoints(const QVector<SwrSweepPoint>& points,
+                                       bool running,
+                                       double currentFreqMhz,
+                                       const QString& sourceLabel)
+{
+    m_swrSweepPoints = points;
+    m_swrSweepRunning = running;
+    m_swrSweepCurrentFreqMhz = currentFreqMhz;
+    m_swrSweepSourceLabel = sourceLabel;
+    markOverlayDirty();
+}
+
+void SpectrumWidget::clearSwrSweepPoints()
+{
+    m_swrSweepPoints.clear();
+    m_swrSweepRunning = false;
+    m_swrSweepCurrentFreqMhz = -1.0;
+    m_swrSweepSourceLabel.clear();
+    markOverlayDirty();
+}
+
 void SpectrumWidget::setTnfGlobalEnabled(bool on)
 {
     m_tnfGlobalEnabled = on;
@@ -4669,6 +4692,197 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
     }
 
     p.setFont(QFont());  // restore default
+}
+
+void SpectrumWidget::drawSwrSweep(QPainter& p, const QRect& specRect)
+{
+    if (m_swrSweepPoints.isEmpty() && !m_swrSweepRunning)
+        return;
+
+    const int rightEdge = specRect.right() - DBM_STRIP_W - 8;
+    const int plotLeft = specRect.left() + 8;
+    const int plotHeight = qBound(42, specRect.height() / 5, 64);
+
+    int wantedTop = specRect.top() + 6;
+    bool sawVfo = false;
+    for (auto it = m_vfoWidgets.cbegin(); it != m_vfoWidgets.cend(); ++it) {
+        auto* vfo = it.value();
+        if (!vfo || !vfo->isVisible())
+            continue;
+        sawVfo = true;
+        wantedTop = qMax(wantedTop, vfo->geometry().bottom() + 8);
+    }
+    if (!sawVfo && !m_sliceOverlays.isEmpty())
+        wantedTop = specRect.top() + 96;
+
+    const int minTop = specRect.top() + 6;
+    const int maxTop = qMax(minTop, specRect.bottom() - plotHeight - 8);
+    const int plotTop = qBound(minTop, wantedTop, maxTop);
+    const QRect plotRect(plotLeft, plotTop,
+                         qMax(0, rightEdge - plotLeft), plotHeight);
+    if (plotRect.width() < 80 || plotRect.height() < 28)
+        return;
+
+    float maxSwr = 3.0f;
+    for (const auto& point : m_swrSweepPoints) {
+        if (std::isfinite(static_cast<double>(point.swr)))
+            maxSwr = qMax(maxSwr, point.swr);
+    }
+    maxSwr = qBound(2.0f, std::ceil(maxSwr * 2.0f) / 2.0f, 10.0f);
+    constexpr float minSwr = 1.0f;
+    const float swrRange = qMax(0.1f, maxSwr - minSwr);
+
+    auto yForSwr = [&](float swr) {
+        const float clipped = qBound(minSwr, swr, maxSwr);
+        const float frac = (clipped - minSwr) / swrRange;
+        return plotRect.bottom() - frac * plotRect.height();
+    };
+
+    p.save();
+    p.setClipRect(specRect);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    p.setPen(Qt::NoPen);
+    p.setBrush(QColor(0x06, 0x0d, 0x12, 190));
+    p.drawRoundedRect(plotRect, 3, 3);
+
+    p.setPen(QPen(QColor(0x80, 0x90, 0xa0, 120), 1, Qt::DotLine));
+    p.drawLine(plotRect.left(), yForSwr(1.5f), plotRect.right(), yForSwr(1.5f));
+    p.drawLine(plotRect.left(), yForSwr(2.0f), plotRect.right(), yForSwr(2.0f));
+
+    struct PlotPoint {
+        QPointF pos;
+        float swr{1.0f};
+    };
+    QVector<PlotPoint> visiblePoints;
+    QPolygonF poly;
+    for (const auto& point : m_swrSweepPoints) {
+        if (!std::isfinite(static_cast<double>(point.freqMhz))
+            || !std::isfinite(static_cast<double>(point.swr))) {
+            continue;
+        }
+        const int x = mhzToX(point.freqMhz);
+        if (x < plotRect.left() - 4 || x > plotRect.right() + 4)
+            continue;
+        const QPointF pos(x, yForSwr(point.swr));
+        visiblePoints.append({pos, point.swr});
+        poly << pos;
+    }
+
+    if (poly.size() >= 2) {
+        p.setPen(QPen(QColor(0xff, 0xc0, 0x40, 230), 2));
+        p.drawPolyline(poly);
+    }
+    p.setPen(QPen(QColor(0x0a, 0x0a, 0x14, 220), 1));
+    p.setBrush(QColor(0xff, 0xc0, 0x40, 240));
+    for (const QPointF& pt : poly)
+        p.drawEllipse(pt, 3.2, 3.2);
+
+    if (m_swrSweepCurrentFreqMhz > 0.0) {
+        const int cx = mhzToX(m_swrSweepCurrentFreqMhz);
+        if (cx >= plotRect.left() && cx <= plotRect.right()) {
+            p.setPen(QPen(QColor(0x00, 0xb4, 0xd8, 210), 1, Qt::DashLine));
+            p.drawLine(cx, plotRect.top(), cx, plotRect.bottom());
+        }
+    }
+
+    QFont f = p.font();
+    f.setPixelSize(10);
+    f.setBold(true);
+    p.setFont(f);
+    const QFontMetrics fm(f);
+    const QString latest = m_swrSweepPoints.isEmpty()
+        ? QStringLiteral("SWR Sweep")
+        : QStringLiteral("SWR %1:1").arg(m_swrSweepPoints.last().swr, 0, 'f', 2);
+    QString label = m_swrSweepRunning
+        ? latest + QStringLiteral("  RUN")
+        : latest;
+    if (!m_swrSweepSourceLabel.isEmpty())
+        label += QStringLiteral("  ") + m_swrSweepSourceLabel;
+    const int labelW = fm.horizontalAdvance(label) + 8;
+    const int labelH = fm.height() + 2;
+    int labelX = plotRect.left() + 4;
+    int labelY = plotRect.top() - labelH - 3;
+    if (labelY < specRect.top() + 3)
+        labelY = plotRect.top() + 3;
+
+    QRect labelRect(labelX, labelY, labelW, labelH);
+    if (m_overlayMenu && m_overlayMenu->isVisible()
+        && labelRect.intersects(m_overlayMenu->geometry().adjusted(-4, -4, 8, 4))) {
+        labelX = m_overlayMenu->geometry().right() + 8;
+        const int maxLabelX = qMax(plotRect.left() + 4, plotRect.right() - labelW - 4);
+        labelX = qBound(plotRect.left() + 4, labelX, maxLabelX);
+        labelRect.moveLeft(labelX);
+    }
+    p.setPen(Qt::NoPen);
+    p.setBrush(QColor(0x0a, 0x0a, 0x14, 220));
+    p.drawRoundedRect(labelRect, 2, 2);
+    p.setPen(QColor(0xff, 0xd0, 0x70));
+    p.drawText(labelRect, Qt::AlignCenter, label);
+
+    if (!visiblePoints.isEmpty()) {
+        const int valueGap = 4;
+        const int valueH = fm.height() + 4;
+        const bool placeBelow = plotRect.bottom() + valueGap + valueH
+            <= specRect.bottom() - 4;
+        const int valueY = placeBelow
+            ? plotRect.bottom() + valueGap
+            : plotRect.bottom() - valueH - 4;
+        constexpr int kMinValueSpacingPx = 86;
+        int lastLabelRight = -1000000;
+        int lastLabeled = -1;
+
+        auto drawValueLabel = [&](int i, bool force) {
+            const PlotPoint& point = visiblePoints[i];
+            const QString text = QString::number(point.swr, 'f', 2);
+            const int valueW = fm.horizontalAdvance(text) + 8;
+            int x = qRound(point.pos.x()) - valueW / 2;
+            x = qBound(plotRect.left() + 2, x, plotRect.right() - valueW - 2);
+            const QRect valueRect(x, valueY, valueW, valueH);
+            if (!force && valueRect.left() <= lastLabelRight + 6)
+                return;
+
+            p.setPen(QPen(QColor(0xff, 0xd0, 0x70, 130), 1));
+            const qreal notchY = std::clamp(point.pos.y(),
+                                            qreal(plotRect.top() + 2),
+                                            qreal(plotRect.bottom()));
+            const QPointF notchTop(point.pos.x(), notchY);
+            const QPointF notchBottom(point.pos.x(),
+                                      placeBelow ? valueRect.top() : valueRect.bottom());
+            p.drawLine(notchTop, notchBottom);
+
+            p.setPen(Qt::NoPen);
+            p.setBrush(QColor(0x0a, 0x0a, 0x14, 230));
+            p.drawRoundedRect(valueRect, 2, 2);
+            p.setPen(QColor(0xff, 0xe0, 0x90));
+            p.drawText(valueRect, Qt::AlignCenter, text);
+
+            lastLabelRight = valueRect.right();
+            lastLabeled = i;
+        };
+
+        for (int i = 0; i < visiblePoints.size(); ++i) {
+            const bool first = (i == 0);
+            const bool spaced = qRound(visiblePoints[i].pos.x()) > lastLabelRight + kMinValueSpacingPx;
+            if (first || spaced)
+                drawValueLabel(i, first);
+        }
+
+        const int lastIndex = visiblePoints.size() - 1;
+        if (lastLabeled != lastIndex)
+            drawValueLabel(lastIndex, false);
+    }
+
+    const QString scaleLabel = QStringLiteral("%1").arg(maxSwr, 0, 'f', 1);
+    p.setPen(QColor(0x80, 0x90, 0xa0, 180));
+    p.drawText(plotRect.right() - fm.horizontalAdvance(scaleLabel) - 4,
+               plotRect.top() + fm.ascent() + 3,
+               scaleLabel);
+    p.drawText(plotRect.right() - fm.horizontalAdvance("1.0") - 4,
+               plotRect.bottom() - 3,
+               "1.0");
+
+    p.restore();
 }
 
 void SpectrumWidget::showSpotClusterPopup(const SpotCluster& cluster, const QPoint& globalPos)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -301,6 +301,16 @@ public:
         QVector<SpotMarker> spots;
     };
 
+    struct SwrSweepPoint {
+        double freqMhz{0.0};
+        float swr{1.0f};
+    };
+    void setSwrSweepPoints(const QVector<SwrSweepPoint>& points,
+                           bool running = false,
+                           double currentFreqMhz = -1.0,
+                           const QString& sourceLabel = {});
+    void clearSwrSweepPoints();
+
     void setShowSpots(bool on) { m_showSpots = on; update(); }
     bool showSpots() const { return m_showSpots; }
     void setSpotFontSize(int px) { m_spotFontSize = px; update(); }
@@ -401,6 +411,7 @@ private:
     void drawBandPlan(QPainter& p, const QRect& specRect);
     void drawTnfMarkers(QPainter& p, const QRect& specRect);
     void drawSpotMarkers(QPainter& p, const QRect& specRect);
+    void drawSwrSweep(QPainter& p, const QRect& specRect);
     void showSpotClusterPopup(const SpotCluster& cluster, const QPoint& globalPos);
     const TnfMarker* tnfMarkerById(int id) const;
     QColor tnfColor(const TnfMarker& tnf) const;
@@ -649,6 +660,10 @@ private:
     QVector<TnfMarker> m_tnfMarkers;
     bool m_tnfGlobalEnabled{true};
     QVector<SpotMarker> m_spotMarkers;
+    QVector<SwrSweepPoint> m_swrSweepPoints;
+    bool   m_swrSweepRunning{false};
+    double m_swrSweepCurrentFreqMhz{-1.0};
+    QString m_swrSweepSourceLabel;
     struct SpotHitRect {
         QRect rect;
         double freqMhz;

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -57,6 +57,10 @@ void MeterModel::setTgxlHandle(quint32 handle)
     // causing all AMP meters to be routed to the PGXL slot (#600).
     m_tgxlFwdIdx = -1;
     m_tgxlSwrIdx = -1;
+    m_tgxlFwdPwr = 0.0f;
+    m_tgxlSwr = 1.0f;
+    m_lastTgxlFwdPowerUpdateMs = 0;
+    m_lastTgxlSwrUpdateMs = 0;
     m_ampFwdPwrIdx = -1;
     m_ampSwrIdx = -1;
     m_ampTempIdx = -1;
@@ -228,6 +232,16 @@ void MeterModel::removeMeter(int index)
     if (index == m_ampFwdPwrIdx) m_ampFwdPwrIdx = -1;
     if (index == m_ampSwrIdx)    m_ampSwrIdx = -1;
     if (index == m_ampTempIdx)   m_ampTempIdx = -1;
+    if (index == m_tgxlFwdIdx) {
+        m_tgxlFwdIdx = -1;
+        m_tgxlFwdPwr = 0.0f;
+        m_lastTgxlFwdPowerUpdateMs = 0;
+    }
+    if (index == m_tgxlSwrIdx) {
+        m_tgxlSwrIdx = -1;
+        m_tgxlSwr = 1.0f;
+        m_lastTgxlSwrUpdateMs = 0;
+    }
 
     recomputeSourceIndexMins();
     if (compressionMapChanged) {
@@ -282,10 +296,15 @@ void MeterModel::clear()
     m_tgxlHandle = 0;
     m_tgxlFwdPwr = 0.0f;
     m_tgxlSwr = 1.0f;
+    m_lastTgxlFwdPowerUpdateMs = 0;
+    m_lastTgxlSwrUpdateMs = 0;
     m_sLevel = -130.0f;
     m_fwdPower = 0.0f;
+    m_fwdPowerInstant = 0.0f;
     m_swr = 1.0f;
     m_lastTxMeterUpdateMs = 0;
+    m_lastFwdPowerUpdateMs = 0;
+    m_lastSwrUpdateMs = 0;
     m_micPeak = -50.0f;
     clearCompressionState();
     m_micLevel = -50.0f;
@@ -609,11 +628,13 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
         if (isSliceLevel) {
             // no-op, already emitted
         } else if (idx == m_fwdPwrIdx) {
-            m_lastTxMeterUpdateMs = QDateTime::currentMSecsSinceEpoch();
+            m_lastTxMeterUpdateMs = packetUpdatedMs;
+            m_lastFwdPowerUpdateMs = m_lastTxMeterUpdateMs;
             // FWDPWR meter reports in dBm — convert to watts for display.
             // watts = 10^(dBm/10) / 1000
             // e.g. 50 dBm = 100 W, 47 dBm ≈ 50 W, 40 dBm = 10 W
             float watts = std::pow(10.0f, v / 10.0f) / 1000.0f;
+            m_fwdPowerInstant = watts;
             // Smooth: fast attack (α=0.5) to track peaks, slow decay (α=0.15)
             // for stable display without jitter (#980)
             if (m_fwdPower < 0.01f) {
@@ -624,7 +645,8 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
             }
             txChanged = true;
         } else if (idx == m_swrIdx) {
-            m_lastTxMeterUpdateMs = QDateTime::currentMSecsSinceEpoch();
+            m_lastTxMeterUpdateMs = packetUpdatedMs;
+            m_lastSwrUpdateMs = m_lastTxMeterUpdateMs;
             m_swr = v;
             txChanged = true;
         } else if (idx == m_micPeakIdx) {
@@ -668,10 +690,12 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
             hwChanged = true;
         } else if (idx == m_tgxlFwdIdx) {
             m_tgxlFwdPwr = std::pow(10.0f, v / 10.0f) / 1000.0f;
+            m_lastTgxlFwdPowerUpdateMs = packetUpdatedMs;
             tgxlChanged = true;
         } else if (idx == m_tgxlSwrIdx) {
             float rho = std::pow(10.0f, -v / 20.0f);
             m_tgxlSwr = (rho < 0.999f) ? (1.0f + rho) / (1.0f - rho) : 99.9f;
+            m_lastTgxlSwrUpdateMs = packetUpdatedMs;
             tgxlChanged = true;
         } else if (idx == m_ampFwdPwrIdx) {
             m_ampFwdPwr = std::pow(10.0f, v / 10.0f) / 1000.0f;  // dBm → watts

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -77,12 +77,19 @@ public:
 
     // Convenience: forward power in watts.
     float fwdPower() const { return m_fwdPower; }
+    float fwdPowerInstant() const { return m_fwdPowerInstant; }
+    float tgxlFwdPower() const { return m_tgxlFwdPwr; }
 
     // Convenience: SWR.
     float swr() const { return m_swr; }
+    float tgxlSwr() const { return m_tgxlSwr; }
 
     // Timestamp of the last TX meter sample (milliseconds since epoch).
     qint64 txMetersUpdatedAtMs() const { return m_lastTxMeterUpdateMs; }
+    qint64 fwdPowerUpdatedAtMs() const { return m_lastFwdPowerUpdateMs; }
+    qint64 swrUpdatedAtMs() const { return m_lastSwrUpdateMs; }
+    qint64 tgxlFwdPowerUpdatedAtMs() const { return m_lastTgxlFwdPowerUpdateMs; }
+    qint64 tgxlSwrUpdatedAtMs() const { return m_lastTgxlSwrUpdateMs; }
     bool hasRecentTxMeters(qint64 maxAgeMs) const;
 
     // Convenience: mic peak level (dBFS) and derived compression reduction (dB).
@@ -181,12 +188,17 @@ private:
     quint32 m_tgxlHandle{0}; // TGXL amplifier handle for meter disambiguation
     float m_tgxlFwdPwr{0.0f};
     float m_tgxlSwr{1.0f};
+    qint64 m_lastTgxlFwdPowerUpdateMs{0};
+    qint64 m_lastTgxlSwrUpdateMs{0};
 
     // Cached values
     float m_sLevel{-130.0f};
     float m_fwdPower{0.0f};
+    float m_fwdPowerInstant{0.0f};
     float m_swr{1.0f};
     qint64 m_lastTxMeterUpdateMs{0};
+    qint64 m_lastFwdPowerUpdateMs{0};
+    qint64 m_lastSwrUpdateMs{0};
     float m_micPeak{-50.0f};
     float m_compPeak{0.0f};       // derived compression reduction for the reversed gauge
     bool m_hasCompPeakValue{false};


### PR DESCRIPTION

<img width="1901" height="1318" alt="Screenshot 2026-04-30 at 7 21 05 AM" src="https://github.com/user-attachments/assets/494bf890-104c-40b8-ad06-f8c23797d144" />

## Summary

This adds an in-panadapter SWR sweep that can step through the current TX band, plot measured SWR directly on the spectrum surface, and clear the plot from the ANT slice controls.

The sweep is designed as a fast diagnostic view rather than a tuner command. It uses the existing radio tune carrier path, samples fresh meter data at each step, and draws the resulting curve low enough to stay below the slice flag so the user can compare the SWR curve against the active frequency line.

## UX

- Adds `Start Sweep` and `Clear Sweep` buttons under the ANT slice menu, below the WNB slider.
- Draws the SWR curve on top of the panadapter surface, with the current sweep frequency shown as the sweep advances.
- Shows the latest value as `SWR n.nn:1` and includes periodic value callouts along the plotted curve.
- Labels the plotted source, including `TGXL BYPASS` when the sweep is measuring antenna-side TGXL bypass data.
- Blocks normal frequency/input interaction while a sweep is running and lets Escape stop the sweep.

## Safety

- Requires a connected radio, a visible/unlocked TX slice, split disabled, and a non-zero Tune Power before starting.
- Refuses 60 m because it is channelized.
- Computes sweep points inside the current amateur band with an edge guard so the tune carrier is not commanded onto the band edge.
- Uses the normal `transmit tune 1` / `transmit tune 0` carrier path and relies on the radio interlock for final enforcement.
- Requires fresh SWR and forward-power meter samples for every step, preventing stale values from a previous band/sweep from being plotted.
- Stops the tune carrier before restoring frequency/pan state or restoring an external TGXL state.
- Aborts if the target slice disappears, TGXL leaves bypass during a TGXL sweep, or fresh meter data/forward power does not arrive within the settle window.

## TGXL behavior

When a TGXL is present and already in `OPERATE`, the sweep now measures raw antenna performance instead of the tuned result:

1. Snapshot the original TGXL bypass state.
2. If needed, request TGXL `BYPASS`.
3. Wait for the TGXL state model to confirm bypass.
4. Wait a short relay-settle interval before applying RF.
5. Start the radio tune carrier and sweep the band.
6. Sample TGXL-specific forward power and SWR meters, not radio-side SWR.
7. Stop the tune carrier.
8. Restore the original TGXL bypass state and wait for confirmation.

The sweep does not automatically switch a TGXL from standby into operate. If the TGXL is present but not operating, the sweep falls back to the radio SWR source and labels the plot accordingly.

## Validation

- `git diff --check`
- `cmake --build build -j10`
- `./build/meter_model_test`

`meter_model_test` still reports the existing compression-meter failures unrelated to this SWR/TGXL change; the build itself succeeds.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
