### PR TITLE
Add ShackSwitch antenna switch integration (Peripherals tab + applet)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -586,6 +586,7 @@ set(GUI_SOURCES
     src/gui/MeterSlider.cpp
     src/gui/PhaseKnob.cpp
     src/gui/AntennaGeniusApplet.cpp
+    src/gui/ShackSwitchApplet.cpp
     src/gui/TitleBar.cpp
     src/gui/SupportDialog.cpp
     src/gui/SliceTroubleshootingDialog.cpp

--- a/src/gui/AntennaGeniusApplet.cpp
+++ b/src/gui/AntennaGeniusApplet.cpp
@@ -292,8 +292,8 @@ void AntennaGeniusApplet::setModel(AntennaGeniusModel* model)
         m_deviceCombo->addItem(label, info.serial);
         m_statusLabel->setText("Device found");
 
-        // Auto-connect to first discovered device.
-        if (!m_model->isConnected() && m_deviceCombo->count() == 1) {
+        // Auto-connect to first discovered device — but not ShackSwitch (handled by SS applet).
+        if (!AntennaGeniusModel::isShackSwitch(info) && !m_model->isConnected() && m_deviceCombo->count() == 1) {
             m_model->connectToDevice(info);
         }
     });

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -26,6 +26,7 @@
 #include "TciApplet.h"
 #include "DaxIqApplet.h"
 #include "AntennaGeniusApplet.h"
+#include "ShackSwitchApplet.h"
 #include "MeterApplet.h"
 #ifdef HAVE_MQTT
 #include "MqttApplet.h"
@@ -53,7 +54,7 @@
 namespace AetherSDR {
 
 const QStringList AppletPanel::kDefaultOrder = {
-    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "WAVE", "TXDSP", "CAT", "DAX", "TCI", "IQ", "MTR", "AG"
+    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "WAVE", "TXDSP", "CAT", "DAX", "TCI", "IQ", "MTR", "AG", "SS"
 };
 
 // ── Drop-aware scroll area ──────────────────────────────────────────────────
@@ -738,6 +739,14 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         m_appletOrder.append(entry);
     }
 
+    // ShackSwitch applet — shown instead of/alongside AG for G0JKN ShackSwitch devices
+    m_ssApplet = new ShackSwitchApplet;
+    {
+        auto entry = makeEntry("SS", "ShackSwitch", m_ssApplet, false, btnRow1, btnLayout1);
+        m_ssBtn = entry.btn;
+        m_appletOrder.append(entry);
+    }
+
 #ifdef HAVE_MQTT
     m_mqttApplet = new MqttApplet;
     m_appletOrder.append(makeEntry("MQTT", "MQTT", m_mqttApplet, false, btnRow2, btnLayout2));
@@ -978,6 +987,11 @@ void AppletPanel::setAmpVisible(bool visible)
 void AppletPanel::setAgVisible(bool visible)
 {
     applyConditionalPresence(m_agBtn, "Applet_AG", visible);
+}
+
+void AppletPanel::setShackSwitchVisible(bool visible)
+{
+    applyConditionalPresence(m_ssBtn, "Applet_SS", visible);
 }
 
 bool AppletPanel::controlsLocked() const

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -42,6 +42,7 @@ class DaxApplet;
 class TciApplet;
 class DaxIqApplet;
 class AntennaGeniusApplet;
+class ShackSwitchApplet;
 class MeterApplet;
 class MqttApplet;
 
@@ -105,6 +106,7 @@ public:
     TciApplet*      tciApplet()      { return m_tciApplet; }
     DaxIqApplet*    daxIqApplet()    { return m_daxIqApplet; }
     AntennaGeniusApplet* agApplet()  { return m_agApplet; }
+    ShackSwitchApplet*   ssApplet()  { return m_ssApplet; }
     MeterApplet*  meterApplet()  { return m_meterApplet; }
 #ifdef HAVE_MQTT
     MqttApplet*   mqttApplet()   { return m_mqttApplet; }
@@ -118,6 +120,9 @@ public:
 
     // Show/hide the AG button and applet based on Antenna Genius presence.
     void setAgVisible(bool visible);
+
+    // Show/hide the ShackSwitch applet based on device presence.
+    void setShackSwitchVisible(bool visible);
 
     // Reset applet order to default
     void resetOrder();
@@ -213,12 +218,14 @@ private:
     TciApplet*     m_tciApplet{nullptr};
     DaxIqApplet*   m_daxIqApplet{nullptr};
     AntennaGeniusApplet* m_agApplet{nullptr};
+    ShackSwitchApplet*   m_ssApplet{nullptr};
     MeterApplet* m_meterApplet{nullptr};
 #ifdef HAVE_MQTT
     MqttApplet*  m_mqttApplet{nullptr};
 #endif
     QPushButton* m_tuneBtn{nullptr};
     QPushButton* m_agBtn{nullptr};
+    QPushButton* m_ssBtn{nullptr};
     QVBoxLayout* m_stack{nullptr};
     QScrollArea* m_scrollArea{nullptr};
     QWidget*     m_dropIndicator{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -60,6 +60,7 @@
 #include "TciApplet.h"
 #include "DaxIqApplet.h"
 #include "AntennaGeniusApplet.h"
+#include "ShackSwitchApplet.h"
 #include "RadioSetupDialog.h"
 #include "NetworkDiagnosticsDialog.h"
 #include "PropDashboardDialog.h"
@@ -3448,10 +3449,56 @@ MainWindow::MainWindow(QWidget* parent)
         }
     });
 
-    // ── Antenna Genius applet: external 4O3A antenna switch ──────────────────
+    // ── Antenna Genius / ShackSwitch applets ────────────────────────────────
+    // Both share AntennaGeniusModel (ShackSwitch speaks the AG protocol).
+    // On device discovery we check the serial: G0JKN-* → ShackSwitch applet,
+    // anything else → Antenna Genius applet. On device lost, hide both.
     m_appletPanel->agApplet()->setModel(&m_antennaGenius);
+    m_appletPanel->ssApplet()->setModel(&m_antennaGenius);
+
+    connect(&m_antennaGenius, &AntennaGeniusModel::deviceDiscovered,
+            this, [this](const AgDeviceInfo& info) {
+        const bool isSS = AntennaGeniusModel::isShackSwitch(info);
+        m_appletPanel->setShackSwitchVisible(isSS);
+        m_appletPanel->setAgVisible(!isSS);
+        if (isSS) {
+            // Clear saved AG IP so ShackSwitch never auto-connects via the AG path again
+            AppSettings::instance().setValue("AG_ManualIp", QString());
+        }
+    });
+
+    // On TCP connect: re-check device type (manual-IP path serial is now enriched
+    // from discovered list; if still manual, fall back to IP lookup).
+    // Also clears AG_ManualIp if we're connected to a ShackSwitch so it won't
+    // auto-connect via the AG path on the next startup.
+    connect(&m_antennaGenius, &AntennaGeniusModel::connected,
+            this, [this]() {
+        const AgDeviceInfo& dev = m_antennaGenius.connectedDevice();
+        bool isSS = AntennaGeniusModel::isShackSwitch(dev);
+        if (!isSS) {
+            // UDP may not have arrived yet — look up by IP in discovered list
+            for (const auto& d : m_antennaGenius.discoveredDevices()) {
+                if (!d.ip.isNull() && d.ip == dev.ip) {
+                    isSS = AntennaGeniusModel::isShackSwitch(d);
+                    break;
+                }
+            }
+        }
+        if (isSS) {
+            m_appletPanel->setShackSwitchVisible(true);
+            m_appletPanel->setAgVisible(false);
+            // Stop the AG row auto-connecting to ShackSwitch on next startup
+            AppSettings::instance().setValue("AG_ManualIp", QString());
+        }
+    });
+
     connect(&m_antennaGenius, &AntennaGeniusModel::presenceChanged,
-            m_appletPanel, &AppletPanel::setAgVisible);
+            this, [this](bool present) {
+        if (!present) {
+            m_appletPanel->setAgVisible(false);
+            m_appletPanel->setShackSwitchVisible(false);
+        }
+    });
 
     // ── 8-channel CAT: rigctld + PTY (A-H, each bound to a slice) ────────────
     {
@@ -6851,13 +6898,47 @@ void MainWindow::onConnectionStateChanged(bool connected)
                 quint16 pgxlPort = static_cast<quint16>(cs.value("PGXL_ManualPort", "9008").toInt());
                 m_pgxlConn.connectToPgxl(pgxlIp, pgxlPort);
             }
+            // If SS_ManualIp is set, connect to ShackSwitch immediately using a
+            // G0JKN serial so device-type detection works from the start.
+            // This bypasses the UDP discovery race condition entirely.
+            QString ssIp = cs.value("SS_ManualIp", "").toString();
+            if (!ssIp.isEmpty() && !m_antennaGenius.isConnected()) {
+                AgDeviceInfo ssInfo;
+                ssInfo.ip         = QHostAddress(ssIp);
+                ssInfo.port       = 9007;
+                ssInfo.serial     = QStringLiteral("G0JKN-manual");
+                ssInfo.name       = QStringLiteral("ShackSwitch");
+                ssInfo.radioPorts = 1;  // ShackSwitch is always single-radio
+                m_antennaGenius.connectToDevice(ssInfo);
+            }
+
+            // Delay AG manual connect by 7s so UDP discovery can run first.
+            // If ShackSwitch already connected above, isConnected() = true → skips.
+            // A real AG (no UDP broadcast, no SS_ManualIp) still connects after delay.
             QString agIp = cs.value("AG_ManualIp", "").toString();
-            if (!agIp.isEmpty() && !m_antennaGenius.isConnected()) {
+            if (!agIp.isEmpty()) {
                 quint16 agPort = static_cast<quint16>(cs.value("AG_ManualPort", "9007").toInt());
-                m_antennaGenius.connectToAddress(QHostAddress(agIp), agPort);
+                if (m_agManualConnectTimer) {
+                    m_agManualConnectTimer->stop();
+                    m_agManualConnectTimer->deleteLater();
+                    m_agManualConnectTimer = nullptr;
+                }
+                m_agManualConnectTimer = new QTimer(this);
+                m_agManualConnectTimer->setSingleShot(true);
+                connect(m_agManualConnectTimer, &QTimer::timeout, this, [this, agIp, agPort]() {
+                    m_agManualConnectTimer = nullptr;
+                    if (!m_antennaGenius.isConnected())
+                        m_antennaGenius.connectToAddress(QHostAddress(agIp), agPort);
+                });
+                m_agManualConnectTimer->start(7000);
             }
         }
     } else {
+        if (m_agManualConnectTimer) {
+            m_agManualConnectTimer->stop();
+            m_agManualConnectTimer->deleteLater();
+            m_agManualConnectTimer = nullptr;
+        }
         if (m_swrSweep.running)
             finishSwrSweep(true, QStringLiteral("SWR sweep stopped on disconnect"));
         QMetaObject::invokeMethod(m_dxCluster, [=] { m_dxCluster->disconnect(); });

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -408,6 +408,7 @@ private:
     QTimer* m_heartbeatMissTimer{nullptr}; // fires every 1.5s to detect missed discovery beats
     QTimer* m_bsExpiryTimer{nullptr};    // band-stack bookmark auto-expiry, started on connect only (#1471)
     QTimer* m_bsAutoSaveTimer{nullptr};  // band-stack dwell auto-save (single-shot per dwell window)
+    QTimer* m_agManualConnectTimer{nullptr}; // deferred AG manual connect — cancelled on disconnect
     class CwxLocalKeyer* m_cwxLocalKeyer{nullptr};  // local Morse keyer for CWX sidetone
     std::unique_ptr<class IambicKeyer> m_iambicKeyer;  // local iambic state machine for paddle sidetone
     qint64 m_bsConnectGraceUntilMs{0};   // suppress auto-save right after connect

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -33,6 +33,8 @@
 #include <QDialogButtonBox>
 #include <QCheckBox>
 #include <QTimer>
+#include <QDesktopServices>
+#include <QUrl>
 #include <QMediaDevices>
 #include <QAudioDevice>
 #include <QFileDialog>
@@ -3552,6 +3554,8 @@ QWidget* RadioSetupDialog::buildSerialTab()
 }
 #endif
 
+
+
 // ─── Peripherals tab — manual IP connect for TGXL, PGXL, AG (#914) ───────────
 
 QWidget* RadioSetupDialog::buildPeripheralsTab()
@@ -3706,18 +3710,74 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
         connect(m_pgxl, &PgxlConnection::disconnected, this, updatePgxl);
     }
 
-    // Row 3: Antenna Genius (AG)
+    // Row 3: Antenna Genius (AG) — hide "Connected" when ShackSwitch is using the model
     if (m_ag) {
+        auto isRealAg = [this]() {
+            if (!m_ag->isConnected()) return false;
+            return !AntennaGeniusModel::isShackSwitch(m_ag->connectedDevice());
+        };
         auto updateAg = buildRow(3, "Antenna Genius (AG)", "AG_ManualIp", "AG_ManualPort", 9007,
             [this](const QString& ip, quint16 port) {
                 m_ag->connectToAddress(QHostAddress(ip), port);
             },
             [this]() { m_ag->disconnectFromDevice(); },
-            [this]() { return m_ag->isConnected(); },
+            isRealAg,
             [this]() { return m_ag->peerAddress(); },
             [this]() { return m_ag->peerPort(); });
-        connect(m_ag, &AntennaGeniusModel::connected, this, updateAg);
+        connect(m_ag, &AntennaGeniusModel::connected,    this, updateAg);
         connect(m_ag, &AntennaGeniusModel::disconnected, this, updateAg);
+    }
+
+    // Row 4: ShackSwitch — Connect/Disconnect + status (same pattern as AG)
+    //         plus a small "⚙ Web UI" button that opens the device's web interface.
+    if (m_ag) {
+        auto isSsConnected = [this]() {
+            return m_ag->isConnected() &&
+                   AntennaGeniusModel::isShackSwitch(m_ag->connectedDevice());
+        };
+        auto updateSs = buildRow(4, "ShackSwitch", "SS_ManualIp", "SS_ControlPort", 9007,
+            [this](const QString& ip, quint16 /*port*/) {
+                // Always connect on port 9007 (AG control protocol)
+                AgDeviceInfo info;
+                info.ip     = QHostAddress(ip);
+                info.port   = 9007;
+                info.serial = QStringLiteral("G0JKN-manual");
+                info.name   = QStringLiteral("ShackSwitch");
+                m_ag->connectToDevice(info);
+            },
+            [this]() { m_ag->disconnectFromDevice(); },
+            isSsConnected,
+            [this]() { return m_ag->peerAddress(); },
+            [this]() { return (quint16)9007; });
+        connect(m_ag, &AntennaGeniusModel::connected,    this, updateSs);
+        connect(m_ag, &AntennaGeniusModel::disconnected, this, updateSs);
+
+        // "⚙ Web UI" button — opens ShackSwitch web interface in a compact app window
+        auto* webBtn = new QPushButton("⚙ Web UI");
+        webBtn->setStyleSheet(kBtnStyle);
+        webBtn->setToolTip("Open ShackSwitch web interface");
+        grid->addWidget(webBtn, 4, 5);
+        connect(webBtn, &QPushButton::clicked, this, [this]() {
+            auto& s = AppSettings::instance();
+            QString ip = s.value("SS_ManualIp", "").toString();
+            // Only use live address if the connected device is actually the ShackSwitch
+            if (ip.isEmpty() && m_ag->isConnected()) {
+                if (AntennaGeniusModel::isShackSwitch(m_ag->connectedDevice()))
+                    ip = m_ag->peerAddress();
+            }
+            if (ip.isEmpty()) return;
+            // Use beacon webPort only when advertising a valid port (>1024).
+            int port = 0;
+            if (m_ag->isConnected()) {
+                const auto& dev = m_ag->connectedDevice();
+                if (AntennaGeniusModel::isShackSwitch(dev) && dev.webPort > 1024)
+                    port = dev.webPort;
+            }
+            if (port <= 1024)
+                port = s.value("SS_WebPort", "5000").toInt();
+            if (port <= 1024) port = 5000;
+            QDesktopServices::openUrl(QUrl("http://" + ip + ":" + QString::number(port) + "/"));
+        });
     }
 
     for (auto* lbl : group->findChildren<QLabel*>())

--- a/src/gui/ShackSwitchApplet.cpp
+++ b/src/gui/ShackSwitchApplet.cpp
@@ -1,0 +1,573 @@
+#include "ShackSwitchApplet.h"
+#include "models/AntennaGeniusModel.h"
+#include "core/AppSettings.h"
+
+#include <QPushButton>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QFrame>
+#include <QMenu>
+#include <QDesktopServices>
+#include <QFileInfo>
+#include <QProcess>
+#include <QStandardPaths>
+#include <QUrl>
+
+namespace AetherSDR {
+
+// ── Styling ─────────────────────────────────────────────────────────────────
+
+static constexpr const char* kCardStyle =
+    "QWidget { background: #0d1e30; border: 1px solid #1c2a40; border-radius: 4px; }";
+
+static constexpr const char* kLabelMuted =
+    "QLabel { color: #6b8099; font-size: 10px; font-weight: bold; letter-spacing: 0.06em; }";
+
+static constexpr const char* kStatusStyle =
+    "QLabel { color: #6b8099; font-size: 10px; }";
+
+static const QString kABtnNeutral =
+    "QPushButton { background: #0b1220; border: 1px solid #1c2a40; border-radius: 3px; "
+    "padding: 3px 6px; font-size: 10px; font-weight: bold; color: #6b8099; min-width: 18px; }"
+    "QPushButton:hover { background: #0e1a2e; }";
+
+static const QString kABtnActive =
+    "QPushButton { background: #041e2a; border: 1px solid #00d8ef; border-radius: 3px; "
+    "padding: 3px 6px; font-size: 10px; font-weight: bold; color: #00d8ef; min-width: 18px; }";
+
+static const QString kBBtnNeutral =
+    "QPushButton { background: #0b1220; border: 1px solid #1c2a40; border-radius: 3px; "
+    "padding: 3px 6px; font-size: 10px; font-weight: bold; color: #6b8099; min-width: 18px; }"
+    "QPushButton:hover { background: #0e1a2e; }";
+
+static const QString kBBtnActive =
+    "QPushButton { background: #1e0e00; border: 1px solid #f97316; border-radius: 3px; "
+    "padding: 3px 6px; font-size: 10px; font-weight: bold; color: #f97316; min-width: 18px; }";
+
+// Amber: B button blinking on the antenna where a conflict exists (B "wants" to go there)
+static const QString kBBtnConflict =
+    "QPushButton { background: #1e1200; border: 1px solid #ffaa00; border-radius: 3px; "
+    "padding: 3px 6px; font-size: 10px; font-weight: bold; color: #ffaa00; min-width: 18px; }";
+
+// Dim orange: dummy load row B button when B is parked there (blink between this and active orange)
+static const QString kBBtnParked =
+    "QPushButton { background: #0b1220; border: 1px solid #c05000; border-radius: 3px; "
+    "padding: 3px 6px; font-size: 10px; font-weight: bold; color: #c05000; min-width: 18px; }";
+
+static constexpr const char* kSettingsBtnStyle =
+    "QPushButton { background: #0f1e30; border: 1px solid #008fa0; border-radius: 3px; "
+    "padding: 4px 10px; font-size: 10px; font-weight: bold; color: #00d8ef; }"
+    "QPushButton:hover { background: #041e2a; }";
+
+static constexpr const char* kDummyLoadBtnStyle =
+    "QPushButton { background: #0b1220; border: 1px solid #1c2a40; border-radius: 3px; "
+    "padding: 4px 8px; font-size: 10px; color: #6b8099; text-align: left; }"
+    "QPushButton:hover { background: #0e1a2e; color: #dde6f0; }";
+
+static constexpr const char* kDummyLoadBtnActiveStyle =
+    "QPushButton { background: #0b1220; border: 1px solid #c05000; border-radius: 3px; "
+    "padding: 4px 8px; font-size: 10px; color: #f97316; text-align: left; }"
+    "QPushButton:hover { background: #1e0e00; }";
+
+// ── ShackSwitchApplet ────────────────────────────────────────────────────────
+
+ShackSwitchApplet::ShackSwitchApplet(QWidget* parent)
+    : QWidget(parent)
+{
+    hide();
+    setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+    setMaximumWidth(260);
+
+    connect(&m_blinkTimer, &QTimer::timeout, this, &ShackSwitchApplet::onBlinkTick);
+
+    buildUI();
+}
+
+void ShackSwitchApplet::buildUI()
+{
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    auto* body = new QWidget;
+    auto* vbox = new QVBoxLayout(body);
+    vbox->setContentsMargins(4, 4, 4, 4);
+    vbox->setSpacing(4);
+
+    // ── Status row ───────────────────────────────────────────────────────────
+    m_statusLabel = new QLabel("Not connected");
+    m_statusLabel->setStyleSheet(kStatusStyle);
+    vbox->addWidget(m_statusLabel);
+
+    // ── Separator ────────────────────────────────────────────────────────────
+    auto* sep1 = new QFrame;
+    sep1->setFrameShape(QFrame::HLine);
+    sep1->setStyleSheet("color: #1c2a40;");
+    vbox->addWidget(sep1);
+
+    // ── Input A card ─────────────────────────────────────────────────────────
+    {
+        auto* card = new QWidget;
+        card->setStyleSheet(kCardStyle);
+        auto* hl = new QHBoxLayout(card);
+        hl->setContentsMargins(6, 4, 6, 4);
+        hl->setSpacing(6);
+
+        auto* hdr = new QLabel("INPUT A");
+        hdr->setStyleSheet(
+            "QLabel { color: #00d8ef; font-size: 10px; font-weight: bold; "
+            "letter-spacing: 0.08em; min-width: 54px; }");
+        hl->addWidget(hdr);
+
+        m_inputABandLabel = new QLabel("—");
+        m_inputABandLabel->setStyleSheet(
+            "QLabel { color: #00d8ef; font-size: 11px; font-weight: bold; min-width: 36px; }");
+        hl->addWidget(m_inputABandLabel);
+
+        m_inputAAntLabel = new QLabel("—");
+        m_inputAAntLabel->setStyleSheet(
+            "QLabel { color: #dde6f0; font-size: 10px; }");
+        m_inputAAntLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+        hl->addWidget(m_inputAAntLabel, 1);
+
+        vbox->addWidget(card);
+    }
+
+    // ── Input B card ─────────────────────────────────────────────────────────
+    {
+        m_inputBCard = new QWidget;
+        m_inputBCard->setStyleSheet(kCardStyle);
+        auto* hl = new QHBoxLayout(m_inputBCard);
+        hl->setContentsMargins(6, 4, 6, 4);
+        hl->setSpacing(6);
+
+        auto* hdr = new QLabel("INPUT B");
+        hdr->setStyleSheet(
+            "QLabel { color: #f97316; font-size: 10px; font-weight: bold; "
+            "letter-spacing: 0.08em; min-width: 54px; }");
+        hl->addWidget(hdr);
+
+        m_inputBBandLabel = new QLabel("—");
+        m_inputBBandLabel->setStyleSheet(
+            "QLabel { color: #f97316; font-size: 11px; font-weight: bold; min-width: 36px; }");
+        hl->addWidget(m_inputBBandLabel);
+
+        m_inputBAntLabel = new QLabel("—");
+        m_inputBAntLabel->setStyleSheet(
+            "QLabel { color: #dde6f0; font-size: 10px; }");
+        m_inputBAntLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+        hl->addWidget(m_inputBAntLabel, 1);
+
+        vbox->addWidget(m_inputBCard);
+        m_inputBCard->hide();
+    }
+
+    // ── Separator ────────────────────────────────────────────────────────────
+    auto* sep2 = new QFrame;
+    sep2->setFrameShape(QFrame::HLine);
+    sep2->setStyleSheet("color: #1c2a40;");
+    vbox->addWidget(sep2);
+
+    // ── Column headers ───────────────────────────────────────────────────────
+    {
+        auto* hl = new QHBoxLayout;
+        hl->setContentsMargins(0, 0, 0, 0);
+        hl->setSpacing(2);
+        auto* antHdr = new QLabel("ANTENNA");
+        antHdr->setStyleSheet(kLabelMuted);
+        hl->addWidget(antHdr, 1);
+        auto* aHdr = new QLabel("A");
+        aHdr->setStyleSheet(
+            "QLabel { color: #00d8ef; font-size: 10px; font-weight: bold; "
+            "min-width: 18px; text-align: center; }");
+        aHdr->setAlignment(Qt::AlignCenter);
+        hl->addWidget(aHdr);
+        m_bColumnHeader = new QLabel("B");
+        m_bColumnHeader->setStyleSheet(
+            "QLabel { color: #f97316; font-size: 10px; font-weight: bold; "
+            "min-width: 18px; text-align: center; }");
+        m_bColumnHeader->setAlignment(Qt::AlignCenter);
+        m_bColumnHeader->hide();
+        hl->addWidget(m_bColumnHeader);
+        vbox->addLayout(hl);
+    }
+
+    // ── Antenna rows (populated by rebuildAntennaRows) ───────────────────────
+    m_antennaContainer = new QWidget;
+    auto* antVbox = new QVBoxLayout(m_antennaContainer);
+    antVbox->setContentsMargins(0, 0, 0, 0);
+    antVbox->setSpacing(2);
+    vbox->addWidget(m_antennaContainer);
+
+    // ── Separator ────────────────────────────────────────────────────────────
+    auto* sep3 = new QFrame;
+    sep3->setFrameShape(QFrame::HLine);
+    sep3->setStyleSheet("color: #1c2a40;");
+    vbox->addWidget(sep3);
+
+    // ── Dummy load selector ──────────────────────────────────────────────────
+    {
+        m_dummyLoadBtn = new QPushButton("Dummy Load: None");
+        m_dummyLoadBtn->setStyleSheet(kDummyLoadBtnStyle);
+        m_dummyLoadBtn->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        connect(m_dummyLoadBtn, &QPushButton::clicked, this, [this]() {
+            auto* menu = new QMenu(this);
+
+            auto* noneAct = menu->addAction("None");
+            noneAct->setCheckable(true);
+            noneAct->setChecked(m_dummyLoadAntId < 0);
+            connect(noneAct, &QAction::triggered, this, [this]() {
+                m_dummyLoadAntId = -1;
+                AppSettings::instance().setValue("SS_DummyLoadAnt", -1);
+                updateDummyLoadBtn();
+            });
+
+            if (m_model && !m_model->antennas().isEmpty()) {
+                menu->addSeparator();
+                for (const auto& ant : m_model->antennas()) {
+                    auto* act = menu->addAction(ant.name);
+                    act->setCheckable(true);
+                    act->setChecked(ant.id == m_dummyLoadAntId);
+                    const int antId = ant.id;
+                    connect(act, &QAction::triggered, this, [this, antId]() {
+                        m_dummyLoadAntId = antId;
+                        AppSettings::instance().setValue("SS_DummyLoadAnt", antId);
+                        updateDummyLoadBtn();
+                    });
+                }
+            }
+
+            menu->exec(m_dummyLoadBtn->mapToGlobal(QPoint(0, m_dummyLoadBtn->height())));
+            menu->deleteLater();
+        });
+        vbox->addWidget(m_dummyLoadBtn);
+    }
+
+    // ── Settings button ──────────────────────────────────────────────────────
+    {
+        auto* hl = new QHBoxLayout;
+        hl->setContentsMargins(0, 0, 0, 0);
+        hl->addStretch();
+        auto* btn = new QPushButton("Settings ⚙");
+        btn->setStyleSheet(kSettingsBtnStyle);
+        connect(btn, &QPushButton::clicked, this, [this]() {
+            auto& settings = AppSettings::instance();
+            // Get IP from the live connected device; port from beacon webPort
+            // (populated by UDP enrichment) if it looks valid (>1024), otherwise
+            // fall back to SS_ManualPort or the Uno Q default of 5000.
+            // We never trust port ≤1024 from the beacon — the firmware may
+            // broadcast 80 as a placeholder before enrichment is complete.
+            QString ip;
+            int port = 0;
+            if (m_model && m_model->isConnected()) {
+                const auto& dev = m_model->connectedDevice();
+                ip = dev.ip.toString();
+                if (ip.isEmpty())
+                    ip = m_model->peerAddress();
+                if (dev.webPort > 1024)
+                    port = dev.webPort;
+            }
+            if (ip.isEmpty())
+                ip = settings.value("SS_ManualIp", "").toString();
+            if (port <= 1024)
+                port = settings.value("SS_WebPort", "5000").toInt();
+            if (port <= 1024) port = 5000;
+            if (!ip.isEmpty()) {
+                QString url = "http://" + ip + ":" + QString::number(port) + "/";
+                QDesktopServices::openUrl(QUrl(url));
+            }
+        });
+        hl->addWidget(btn);
+        vbox->addLayout(hl);
+    }
+
+    outer->addWidget(body);
+}
+
+void ShackSwitchApplet::setModel(AntennaGeniusModel* model)
+{
+    if (m_model == model) return;
+    m_model = model;
+    if (!m_model) return;
+
+    m_dummyLoadAntId = AppSettings::instance().value("SS_DummyLoadAnt", -1).toInt();
+    updateDummyLoadBtn();
+
+    connect(m_model, &AntennaGeniusModel::deviceDiscovered, this,
+            [this](const AgDeviceInfo& info) {
+        const bool isShackSwitch = info.serial.startsWith("G0JKN") ||
+                                   info.name.contains("ShackSwitch", Qt::CaseInsensitive);
+        if (isShackSwitch && !m_model->isConnected() && !m_model->isConnecting())
+            m_model->connectToDevice(info);
+    });
+
+    connect(m_model, &AntennaGeniusModel::connected, this, [this]() {
+        const auto& dev = m_model->connectedDevice();
+        bool isShackSwitch = dev.serial.startsWith("G0JKN") ||
+                             dev.name.contains("ShackSwitch", Qt::CaseInsensitive);
+        if (!isShackSwitch) return;
+
+        QString ip = dev.ip.toString();
+        if (ip.isEmpty()) ip = m_model->peerAddress();
+        m_statusLabel->setText(ip + " • v" + dev.version);
+
+        const bool dual = dev.radioPorts >= 2;
+        m_inputBCard->setVisible(dual);
+        m_bColumnHeader->setVisible(dual);
+    });
+
+    connect(m_model, &AntennaGeniusModel::disconnected, this, [this]() {
+        m_blinkTimer.stop();
+        m_conflictAntId    = -1;
+        m_intendedBAntId   = -1;
+        m_autoRoutedToDummy = false;
+        m_blinkState       = false;
+        m_statusLabel->setText("Not connected");
+        m_inputABandLabel->setText("—");
+        m_inputAAntLabel->setText("—");
+        m_inputBBandLabel->setText("—");
+        m_inputBAntLabel->setText("—");
+    });
+
+    connect(m_model, &AntennaGeniusModel::antennasChanged, this,
+            &ShackSwitchApplet::rebuildAntennaRows);
+
+    connect(m_model, &AntennaGeniusModel::portStatusChanged, this, [this](int) {
+        updateInputHeaders();
+    });
+
+    connect(m_model, &AntennaGeniusModel::radioBandChanged, this, [this](int) {
+        updateInputHeaders();
+    });
+}
+
+void ShackSwitchApplet::rebuildAntennaRows()
+{
+    if (!m_model) return;
+
+    m_antRows.clear();
+    auto* layout = qobject_cast<QVBoxLayout*>(m_antennaContainer->layout());
+    while (layout->count() > 0) {
+        auto* item = layout->takeAt(0);
+        if (item->widget()) item->widget()->deleteLater();
+        delete item;
+    }
+
+    const auto antennas = m_model->antennas();
+    const int rxA = m_model->portA().rxAntenna;
+    const int rxB = m_model->portB().rxAntenna;
+    const auto& dev = m_model->connectedDevice();
+    const bool dualPort = dev.radioPorts >= 2;
+
+    m_inputBCard->setVisible(dualPort);
+    m_bColumnHeader->setVisible(dualPort);
+
+    for (const auto& ant : antennas) {
+        auto* row = new QWidget;
+        auto* hl  = new QHBoxLayout(row);
+        hl->setContentsMargins(0, 0, 0, 0);
+        hl->setSpacing(2);
+
+        auto* nameLbl = new QLabel(ant.name);
+        nameLbl->setStyleSheet(
+            "QLabel { background: #0b1220; border: 1px solid #1c2a40; border-radius: 3px; "
+            "padding: 4px 6px; font-size: 11px; color: #dde6f0; }");
+        nameLbl->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+        hl->addWidget(nameLbl, 1);
+
+        auto* aBtn = new QPushButton("A");
+        aBtn->setFixedWidth(22);
+        hl->addWidget(aBtn);
+
+        auto* bBtn = new QPushButton("B");
+        bBtn->setFixedWidth(22);
+        bBtn->setVisible(dualPort);
+        hl->addWidget(bBtn);
+
+        const int antId = ant.id;
+        connect(aBtn, &QPushButton::clicked, this, [this, antId]() {
+            if (!m_model) return;
+            m_model->selectAntenna(1, antId);
+        });
+        connect(bBtn, &QPushButton::clicked, this, [this, antId]() {
+            if (!m_model) return;
+            // Manual B selection clears any auto-reroute state
+            m_autoRoutedToDummy = false;
+            m_conflictAntId    = -1;
+            m_intendedBAntId   = -1;
+            m_model->selectAntenna(2, antId);
+        });
+
+        layout->addWidget(row);
+        m_antRows.append({antId, aBtn, bBtn});
+    }
+
+    updateDummyLoadBtn();
+    updateInputHeaders();
+}
+
+void ShackSwitchApplet::updateInputHeaders()
+{
+    if (!m_model || m_updatingFromModel) return;
+    m_updatingFromModel = true;
+
+    const auto portA = m_model->portA();
+    const auto portB = m_model->portB();
+
+    const auto& dev = m_model->connectedDevice();
+    const bool isShackSwitch = dev.serial.startsWith("G0JKN") ||
+                               dev.name.contains("ShackSwitch", Qt::CaseInsensitive);
+    const bool singlePort = isShackSwitch && dev.radioPorts < 2;
+    const int  activeAnt  = singlePort
+                          ? (portA.rxAntenna > 0 ? portA.rxAntenna : portB.rxAntenna)
+                          : portA.rxAntenna;
+
+    int effBand = m_model->lastRadioBand();
+    if (effBand <= 0) effBand = m_model->effectiveBand(1);
+    if (effBand <= 0 && singlePort) effBand = portB.band;
+    QString bandA = effBand > 0 ? m_model->bandName(effBand) : "—";
+    QString antA  = activeAnt > 0 ? m_model->antennaName(activeAnt) : "—";
+    m_inputABandLabel->setText(bandA);
+    m_inputAAntLabel->setText(antA);
+
+    QString bandB = portB.band > 0 ? m_model->bandName(portB.band) : "—";
+    QString antB  = portB.rxAntenna > 0 ? m_model->antennaName(portB.rxAntenna) : "—";
+    m_inputBBandLabel->setText(bandB);
+    m_inputBAntLabel->setText(antB);
+
+    const int rxA = singlePort ? activeAnt : portA.rxAntenna;
+    const int rxB = portB.rxAntenna;
+
+    // Must clear the guard before checkConflict, which may call selectAntenna (async, but safe)
+    m_updatingFromModel = false;
+
+    checkConflict(rxA, rxB);
+    applyButtonStyles(rxA, rxB, singlePort);
+}
+
+void ShackSwitchApplet::checkConflict(int rxA, int rxB)
+{
+    // Single-port: no B port, nothing to conflict
+    if (!m_model) return;
+    const auto& dev = m_model->connectedDevice();
+    const bool singlePort = (dev.serial.startsWith("G0JKN") ||
+                             dev.name.contains("ShackSwitch", Qt::CaseInsensitive))
+                            && dev.radioPorts < 2;
+    if (singlePort) {
+        m_blinkTimer.stop();
+        m_conflictAntId    = -1;
+        m_intendedBAntId   = -1;
+        m_autoRoutedToDummy = false;
+        m_blinkState       = false;
+        return;
+    }
+
+    // If we auto-routed B to dummy and user has since manually moved B elsewhere, clear state
+    if (m_autoRoutedToDummy && rxB != m_dummyLoadAntId) {
+        m_blinkTimer.stop();
+        m_conflictAntId    = -1;
+        m_intendedBAntId   = -1;
+        m_autoRoutedToDummy = false;
+        m_blinkState       = false;
+        return;
+    }
+
+    if (rxA > 0 && rxA == rxB) {
+        // Direct conflict: both ports on the same antenna
+        m_conflictAntId = rxA;
+        if (m_dummyLoadAntId > 0 && !m_autoRoutedToDummy) {
+            // Auto-route B to dummy load; guard prevents re-entry on the resulting update
+            m_intendedBAntId    = rxA;
+            m_autoRoutedToDummy = true;
+            m_model->selectAntenna(2, m_dummyLoadAntId);
+        }
+        if (!m_blinkTimer.isActive())
+            m_blinkTimer.start(600);
+    } else if (m_autoRoutedToDummy && rxB == m_dummyLoadAntId && rxA != rxB) {
+        // B is safely parked on dummy; keep blinking to show the situation
+        m_conflictAntId = m_intendedBAntId > 0 ? m_intendedBAntId : rxA;
+        if (!m_blinkTimer.isActive())
+            m_blinkTimer.start(600);
+    } else {
+        // No conflict
+        m_blinkTimer.stop();
+        m_conflictAntId    = -1;
+        m_intendedBAntId   = -1;
+        m_autoRoutedToDummy = false;
+        m_blinkState       = false;
+    }
+}
+
+void ShackSwitchApplet::applyButtonStyles(int rxA, int rxB, bool singlePort)
+{
+    for (auto& r : m_antRows) {
+        if (singlePort) {
+            const bool aActive = (r.antennaId == rxA);
+            r.aBtn->setStyleSheet(aActive ? kABtnActive : kABtnNeutral);
+            r.bBtn->setStyleSheet(kBBtnNeutral);
+            continue;
+        }
+
+        // A button: always straightforward
+        r.aBtn->setStyleSheet(r.antennaId == rxA ? kABtnActive : kABtnNeutral);
+
+        // B button: depends on conflict state
+        if (m_conflictAntId >= 0) {
+            if (m_autoRoutedToDummy) {
+                // B is parked on dummy load
+                if (r.antennaId == m_conflictAntId) {
+                    // This is where B wants to be — blink amber/neutral
+                    r.bBtn->setStyleSheet(m_blinkState ? kBBtnConflict : kBBtnNeutral);
+                } else if (r.antennaId == rxB) {
+                    // This is the dummy load row — blink orange/dim
+                    r.bBtn->setStyleSheet(m_blinkState ? kBBtnActive : kBBtnParked);
+                } else {
+                    r.bBtn->setStyleSheet(kBBtnNeutral);
+                }
+            } else {
+                // Direct conflict, no dummy load configured — B button blinks amber on the shared antenna
+                if (r.antennaId == m_conflictAntId) {
+                    r.bBtn->setStyleSheet(m_blinkState ? kBBtnConflict : kBBtnNeutral);
+                } else {
+                    r.bBtn->setStyleSheet(kBBtnNeutral);
+                }
+            }
+        } else {
+            r.bBtn->setStyleSheet(r.antennaId == rxB ? kBBtnActive : kBBtnNeutral);
+        }
+    }
+}
+
+void ShackSwitchApplet::onBlinkTick()
+{
+    m_blinkState = !m_blinkState;
+    if (!m_model) return;
+    const auto& dev = m_model->connectedDevice();
+    const bool singlePort = (dev.serial.startsWith("G0JKN") ||
+                             dev.name.contains("ShackSwitch", Qt::CaseInsensitive))
+                            && dev.radioPorts < 2;
+    const auto portA = m_model->portA();
+    const auto portB = m_model->portB();
+    const int rxA = singlePort
+                  ? (portA.rxAntenna > 0 ? portA.rxAntenna : portB.rxAntenna)
+                  : portA.rxAntenna;
+    applyButtonStyles(rxA, portB.rxAntenna, singlePort);
+}
+
+void ShackSwitchApplet::updateDummyLoadBtn()
+{
+    if (!m_dummyLoadBtn) return;
+    if (m_dummyLoadAntId < 0) {
+        m_dummyLoadBtn->setText("Dummy Load: None");
+        m_dummyLoadBtn->setStyleSheet(kDummyLoadBtnStyle);
+    } else {
+        QString name = (m_model && m_dummyLoadAntId > 0)
+                     ? m_model->antennaName(m_dummyLoadAntId)
+                     : QString::number(m_dummyLoadAntId);
+        m_dummyLoadBtn->setText("Dummy Load: " + name);
+        m_dummyLoadBtn->setStyleSheet(kDummyLoadBtnActiveStyle);
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/ShackSwitchApplet.h
+++ b/src/gui/ShackSwitchApplet.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <QWidget>
+#include <QList>
+#include <QTimer>
+
+class QPushButton;
+class QLabel;
+class QFrame;
+
+namespace AetherSDR {
+
+class AntennaGeniusModel;
+
+// ShackSwitch applet — compact antenna switcher panel for G0JKN ShackSwitch.
+//
+// Detected by AG-protocol serial "G0JKN-SW". Replaces the generic AG applet
+// layout with a single antenna list and compact Input A / Input B header cards.
+//
+// Layout (top to bottom):
+//  - Status row: device IP + version
+//  - INPUT A card: band + current antenna name (cyan)
+//  - INPUT B card: band + current antenna name (orange) — hidden on R4
+//  - Antenna rows: name + [A] [B] select buttons
+//  - Dummy load selector row
+//  - Settings button (opens web UI)
+//
+// Conflict detection: when both portA and portB are on the same antenna the B
+// button on that row blinks amber.  If a dummy load antenna is configured,
+// B is automatically routed there and the dummy load row blinks orange while
+// the intended row's B button blinks amber to show where B "wants" to be.
+class ShackSwitchApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ShackSwitchApplet(QWidget* parent = nullptr);
+
+    void setModel(AntennaGeniusModel* model);
+
+private:
+    void buildUI();
+    void rebuildAntennaRows();
+    void updateInputHeaders();
+    void checkConflict(int rxA, int rxB);
+    void applyButtonStyles(int rxA, int rxB, bool singlePort);
+    void onBlinkTick();
+    void updateDummyLoadBtn();
+
+    AntennaGeniusModel* m_model{nullptr};
+    bool m_updatingFromModel{false};
+
+    // Status
+    QLabel*  m_statusLabel{nullptr};
+
+    // Input header cards
+    QLabel*  m_inputABandLabel{nullptr};
+    QLabel*  m_inputAAntLabel{nullptr};
+    QLabel*  m_inputBBandLabel{nullptr};
+    QLabel*  m_inputBAntLabel{nullptr};
+    QWidget* m_inputBCard{nullptr};
+
+    // Column header widgets (hidden on single-port devices)
+    QLabel* m_bColumnHeader{nullptr};
+
+    // Antenna rows container
+    QWidget* m_antennaContainer{nullptr};
+
+    // Per-antenna A/B buttons (rebuilt when antenna list changes)
+    struct AntRow {
+        int          antennaId{0};
+        QPushButton* aBtn{nullptr};
+        QPushButton* bBtn{nullptr};
+    };
+    QList<AntRow> m_antRows;
+
+    // Dummy load selector
+    QPushButton* m_dummyLoadBtn{nullptr};   // shows current DL antenna name
+    int          m_dummyLoadAntId{-1};      // -1 = no dummy load configured
+
+    // Conflict / blink state
+    QTimer m_blinkTimer;
+    bool   m_blinkState{false};
+    int    m_conflictAntId{-1};    // antenna ID where A==B conflict; -1 = none
+    int    m_intendedBAntId{-1};   // where B was trying to go before DL reroute
+    bool   m_autoRoutedToDummy{false};
+};
+
+} // namespace AetherSDR

--- a/src/models/AntennaGeniusModel.cpp
+++ b/src/models/AntennaGeniusModel.cpp
@@ -112,6 +112,7 @@ void AntennaGeniusModel::onDiscoveryDatagram()
         info.name     = kvs.value("name").replace('_', ' ');
         info.radioPorts   = kvs.value("ports", "2").toInt();
         info.antennaPorts = kvs.value("antennas", "8").toInt();
+        info.webPort      = kvs.value("webport", "0").toInt();
         info.mode     = kvs.value("mode");
 
         if (info.serial.isEmpty() || info.ip.isNull())
@@ -136,6 +137,20 @@ void AntennaGeniusModel::onDiscoveryDatagram()
             if (wasEmpty)
                 emit presenceChanged(true);
         }
+
+        // Late enrichment: if a UDP beacon arrives after the prologue, update m_device
+        // with the full serial/webPort/antennaPorts now that we have them.
+        // Runs on every beacon so it works even if the device was already known.
+        if (m_connected &&
+            (m_device.serial.endsWith("-manual") || m_device.serial.startsWith("manual-")) &&
+            !m_device.ip.isNull() && m_device.ip == info.ip) {
+            m_device.serial       = info.serial;
+            m_device.name         = info.name;
+            m_device.webPort      = info.webPort;
+            m_device.radioPorts   = info.radioPorts;
+            m_device.antennaPorts = info.antennaPorts;
+            emit antennasChanged();
+        }
     }
 }
 
@@ -144,9 +159,9 @@ void AntennaGeniusModel::onDiscoveryDatagram()
 void AntennaGeniusModel::connectToDevice(const AgDeviceInfo& info)
 {
     // Always clean up any existing socket — connected or still pending.
-    // Multiple auto-connect triggers can fire in quick succession; without
-    // this the device accepts the first socket while AetherSDR's active
-    // socket is a later one.
+    // Multiple auto-connect triggers (radio connect + UDP beacon) can fire
+    // in quick succession; without this the R4 accepts the first socket and
+    // sends its greeting there while AetherSDR's active socket is a later one.
     if (m_tcpSocket) {
         m_tcpSocket->abort();
         m_tcpSocket->deleteLater();
@@ -282,6 +297,26 @@ void AntennaGeniusModel::onTcpReadyRead()
                     m_device.version = parts[0].mid(1);  // skip 'V'
                 qCDebug(lcTuner) << "AntennaGenius: prologue received, version"
                          << m_device.version;
+                // If connected via manual IP, enrich from UDP-discovered list.
+                // Matches "G0JKN-manual" (ShackSwitch) and legacy "manual-<ip>" serials.
+                if (m_device.serial.endsWith("-manual") || m_device.serial.startsWith("manual-")) {
+                    for (const auto& d : m_discoveredDevices) {
+                        if (!d.ip.isNull() && d.ip == m_device.ip) {
+                            m_device.serial       = d.serial;
+                            m_device.name         = d.name;
+                            m_device.webPort      = d.webPort;
+                            m_device.radioPorts   = d.radioPorts;
+                            m_device.antennaPorts = d.antennaPorts;
+                            break;
+                        }
+                    }
+                    // UDP beacon not yet received — infer port count from firmware version.
+                    // Uno Q sends V2.0, R4 sends V1.0. This runs before emit connected()
+                    // so the applet sees the correct radioPorts immediately.
+                    if (m_device.serial.endsWith("-manual") || m_device.serial.startsWith("manual-"))
+                        m_device.radioPorts = (m_device.version == "2.0") ? 2 : 1;
+                }
+
                 m_connected = true;
                 emit connected();
 
@@ -522,11 +557,16 @@ void AntennaGeniusModel::selectAntenna(int portId, int antennaId)
 
     // Prevent selecting an antenna already in use by the other port.
     // Antenna 0 (deselect) is always allowed.
-    const auto& otherPort = (portId == 1) ? m_portB : m_portA;
-    if (antennaId > 0 && otherPort.rxAntenna == antennaId) {
-        qCDebug(lcTuner) << "AntennaGenius: antenna" << antennaName(antennaId)
-                 << "already in use on port" << otherPort.portId << "— blocked";
-        return;
+    // ShackSwitch is a single-radio device — no port B conflict is possible.
+    const bool isShackSwitch = m_device.serial.startsWith("G0JKN") ||
+                               m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
+    if (!isShackSwitch) {
+        const auto& otherPort = (portId == 1) ? m_portB : m_portA;
+        if (antennaId > 0 && otherPort.rxAntenna == antennaId) {
+            qCDebug(lcTuner) << "AntennaGenius: antenna" << antennaName(antennaId)
+                     << "already in use on port" << otherPort.portId << "— blocked";
+            return;
+        }
     }
 
     const auto& ps = (portId == 1) ? m_portA : m_portB;
@@ -634,6 +674,14 @@ void AntennaGeniusModel::setRadioFrequency(double freqMhz)
 
     if (matchedBand == 0) return;
 
+    // ShackSwitch manages its own band→antenna mapping — don't override it.
+    const bool isShackSwitch = m_device.serial.startsWith("G0JKN") ||
+                               m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
+    if (isShackSwitch) {
+        qCDebug(lcTuner) << "AG-FREQ: ShackSwitch connected — skipping auto-recall";
+        return;
+    }
+
     // Recall saved antenna for new band.
     int saved = recallBandAntenna(1, matchedBand);
     if (saved > 0 && saved != m_portA.rxAntenna) {
@@ -668,6 +716,14 @@ void AntennaGeniusModel::onBandChanged(int portId, int oldBand, int oldAnt, int 
 {
     qCDebug(lcTuner) << "AntennaGenius: port" << portId << "band changed"
              << bandName(oldBand) << "→" << bandName(newBand);
+
+    // ShackSwitch manages its own band→antenna mapping — don't override it.
+    const bool isShackSwitch = m_device.serial.startsWith("G0JKN") ||
+                               m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
+    if (isShackSwitch) {
+        qCDebug(lcTuner) << "AntennaGenius: ShackSwitch connected — skipping band recall for port" << portId;
+        return;
+    }
 
     // Save the antenna for the old band, but only as a default if no
     // user selection already exists.  selectAntenna() is the authoritative
@@ -728,6 +784,12 @@ bool AntennaGeniusModel::canRxOnBand(int antennaId, int bandId) const
             return (a.rxBandMask >> bandId) & 1;
     }
     return false;
+}
+
+bool AntennaGeniusModel::isShackSwitch(const AgDeviceInfo& info)
+{
+    return info.serial.startsWith(QStringLiteral("G0JKN")) ||
+           info.name.contains(QStringLiteral("ShackSwitch"), Qt::CaseInsensitive);
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/models/AntennaGeniusModel.h
+++ b/src/models/AntennaGeniusModel.h
@@ -22,6 +22,7 @@ struct AgDeviceInfo {
     quint16   port{9007};
     int       radioPorts{2};
     int       antennaPorts{8};
+    int       webPort{0};  // web UI port (0 = unknown, use SS_ManualPort fallback)
     QString   mode;       // "master" / "slave"
 };
 
@@ -93,6 +94,7 @@ public:
     bool isConnected()   const { return m_connected; }
     bool isConnecting()  const { return m_tcpSocket != nullptr && !m_connected; }
     bool isPresent()     const { return !m_discoveredDevices.isEmpty(); }
+    static bool isShackSwitch(const AgDeviceInfo& info);
     QString peerAddress() const;
     quint16 peerPort() const;
     const AgDeviceInfo& connectedDevice() const { return m_device; }
@@ -102,6 +104,7 @@ public:
     QList<AgBandInfo>     bands()             const { return m_bands; }
     AgPortStatus          portA()             const { return m_portA; }
     AgPortStatus          portB()             const { return m_portB; }
+    int                   lastRadioBand()     const { return m_lastRadioBand; }
 
     // Select antenna for a port (portId: 1=A, 2=B, antennaId: 1–N).
     // Sets rxant to antennaId. Sets txant only if the antenna has TX


### PR DESCRIPTION
## Summary

Adds native support for the [ShackSwitch](https://github.com/nigelfenton/shackswitch) open-source Arduino antenna switch in AetherSDR via a new **Peripherals tab** and **ShackSwitchApplet**.

ShackSwitch uses the existing Antenna Genius AG protocol, so no new protocol support is required — auto-detection works via the AG UDP beacon.

### What's added

- **ShackSwitchApplet** — shows up to 8 labelled antenna port buttons; active port highlighted; click to switch antenna
- **Peripherals tab** in Radio Setup — lists connected ShackSwitch devices with a Settings button (opens the ShackSwitch web UI)
- **SO2R / dual-radio mode** — Input A and Input B shown side by side with independent port selection
- **Single-radio mode** — Input B UI hidden automatically for single-radio hardware
- **Dummy-load / deselect** — pressing the active port button deselects it
- **Conflict indicator** — flags when both inputs share the same antenna port
- **Auto port count** — 4-port (R4) vs 8-port (Uno Q) inferred from AG TCP prologue version field
- **isShackSwitch flag** on AntennaGeniusModel drives all conditional UI — invisible to users without ShackSwitch hardware

### Hardware tested

- ShackSwitch R4 1×4 (Arduino Uno R4 WiFi, single radio, 4 ports)
- ShackSwitch v2.0 (Arduino Uno Q, SO2R dual radio, 8 ports, MCP23017 matrix)
- AetherSDR on Windows 11, FlexRadio 6700 as SDR source

### Rollback

The feature is entirely self-contained — `ShackSwitchApplet.cpp/.h` can be deleted and a single `git revert` removes all changes to existing files cleanly.