### PR TITLE
Keep NRL visible on 6000-series radios

### DIFF
--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -777,13 +777,13 @@ void SpectrumOverlayMenu::setHasExtendedDsp(bool has)
 {
     m_hasExtendedDsp = has;
     if (m_dspRows.isEmpty()) return;
-    // Hide 8000-series-only firmware DSP rows: NRL(4), NRS(5), RNN(6), NRF(8) (#2177)
+    // Hide 8000-series-only firmware DSP rows: NRS(5), RNN(6), NRF(8). NRL(4)
+    // is available on 6000-series too, so it stays visible regardless. (#2177)
     auto hideRow = [](DspRow& r, bool visible) {
         r.btn->setVisible(visible);
         if (r.slider)   r.slider->setVisible(visible);
         if (r.valueLbl) r.valueLbl->setVisible(visible);
     };
-    hideRow(m_dspRows[4], has);
     hideRow(m_dspRows[5], has);
     hideRow(m_dspRows[6], has);
     hideRow(m_dspRows[8], has);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2443,8 +2443,9 @@ void VfoWidget::setSlice(SliceModel* slice)
         m_nrBtn->setVisible(!isFm);
         m_nr2Btn->setVisible(!isFm);
         m_nbBtn->setVisible(!isFm);
+        // NRL is available on 6000-series too (#2177)
+        m_nrlBtn->setVisible(!isFm);
         // 8000-series-only firmware DSP filters (#2177)
-        m_nrlBtn->setVisible(!isFm && m_hasExtendedDsp);
         m_nrsBtn->setVisible(!isFm && m_hasExtendedDsp);
         m_rnnBtn->setVisible(!isCw && !isFm && m_hasExtendedDsp);
         m_nrfBtn->setVisible(!isFm && m_hasExtendedDsp);
@@ -2927,8 +2928,9 @@ void VfoWidget::syncFromSlice()
 #ifdef HAVE_DFNR
     m_dfnrBtn->setVisible(!isFm);
 #endif
+    // NRL is available on 6000-series too (#2177)
+    m_nrlBtn->setVisible(!isFm);
     // 8000-series-only firmware DSP filters (#2177)
-    m_nrlBtn->setVisible(!isFm && m_hasExtendedDsp);
     m_nrsBtn->setVisible(!isFm && m_hasExtendedDsp);
     m_rnnBtn->setVisible(!isCw && !isFm && m_hasExtendedDsp);
     m_nrfBtn->setVisible(!isFm && m_hasExtendedDsp);


### PR DESCRIPTION
Closes #2198

## Summary

NRL was incorrectly grouped with the 8000-series-only firmware DSP filters in #2184.  Real platform availability is:

| Filter | 6000 | 8000 / AU |
|---|---|---|
| NRL | ✅ | ✅ |
| NRS | ❌ | ✅ |
| RNN | ❌ | ✅ |
| NRF | ❌ | ✅ |

Drop NRL from the hide-list in both `SpectrumOverlayMenu::setHasExtendedDsp` and the two `VfoWidget` visibility paths (the `setSlice` mode-change lambda and `syncFromSlice`).  NRL now follows the same pattern as NB/NR/NR2 — visible unless the mode hides it (FM).

NRS/RNN/NRF stay gated — that part of #2184 was correct.

## Test plan

- [x] Build clean
- [ ] CI green
- [ ] Visual: connect to a FLEX-6600 → NRL button visible alongside NB/NR/NR2/NB/etc; NRS/RNN/NRF still hidden
- [ ] Visual: connect to a FLEX-8600 / AU-520 → all four still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)