### PR TITLE
[antenna] Add SWR sweep power and PGXL amplifier safety hardening

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -32,7 +32,9 @@
 #endif
 #include "models/SliceModel.h"
 #include <QComboBox>
+#include <QContextMenuEvent>
 #include <QLabel>
+#include <QMenu>
 #include "core/AppSettings.h"
 #include <QPushButton>
 #include <QScrollArea>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10788,7 +10788,7 @@ void MainWindow::advanceSwrSweep()
         return;
 
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
-    auto& tuner = m_radioModel.tunerModel();
+    const auto& tuner = m_radioModel.tunerModel();
 
     if (m_swrSweep.phase == SwrSweepPhase::WaitingForTgxlBypass) {
         if (!tuner.isPresent() || !tuner.isOperate()) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -192,6 +192,10 @@ constexpr int kSwrSweepTuneStopWaitMs = 350;
 constexpr int kSwrSweepTuneStopTimeoutMs = 1800;
 constexpr int kSwrSweepTgxlRestoreTimeoutMs = 3500;
 constexpr int kSwrSweepMaxPoints = 260;
+constexpr int kSwrSweepMinPowerW = 1;
+constexpr int kSwrSweepDefaultPowerW = 1;
+constexpr int kSwrSweepMaxPowerW = 10;
+constexpr const char* kSwrSweepPowerSettingKey = "SwrSweepPowerWatts";
 
 int panCountForLayoutId(const QString& layoutId)
 {
@@ -8789,6 +8793,26 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         s.setValue(sw->settingsKey("DisplayRfGain"), QString::number(gain));
         s.save();
     });
+    const int savedSweepPower = qBound(
+        kSwrSweepMinPowerW,
+        AppSettings::instance().value(kSwrSweepPowerSettingKey,
+                                      QString::number(kSwrSweepDefaultPowerW)).toInt(),
+        kSwrSweepMaxPowerW);
+    menu->setSwrSweepPowerWatts(savedSweepPower);
+    connect(menu, &SpectrumOverlayMenu::swrSweepPowerChanged,
+            this, [this, menu](int watts) {
+        watts = qBound(kSwrSweepMinPowerW, watts, kSwrSweepMaxPowerW);
+        auto& s = AppSettings::instance();
+        s.setValue(kSwrSweepPowerSettingKey, QString::number(watts));
+        s.save();
+        for (auto* applet : m_panStack ? m_panStack->allApplets() : QList<PanadapterApplet*>{}) {
+            auto* otherMenu = applet && applet->spectrumWidget()
+                ? applet->spectrumWidget()->overlayMenu()
+                : nullptr;
+            if (otherMenu && otherMenu != menu)
+                otherMenu->setSwrSweepPowerWatts(watts);
+        }
+    });
     connect(menu, &SpectrumOverlayMenu::swrSweepStartRequested,
             this, &MainWindow::startSwrSweep);
     connect(menu, &SpectrumOverlayMenu::swrSweepClearRequested,
@@ -10635,17 +10659,19 @@ void MainWindow::beginSwrSweepRf()
     statusBar()->showMessage(
         tr("SWR sweep running on %1 with Tune Power %2 W%3. Press Esc to stop.")
             .arg(QString::fromLatin1(band.name))
-            .arg(m_radioModel.transmitModel().tunePower())
+            .arg(m_swrSweep.sweepTunePower)
             .arg(m_swrSweep.sourceLabel.isEmpty()
                      ? QString()
                      : QStringLiteral(" (%1)").arg(m_swrSweep.sourceLabel)),
         5000);
 }
 
-void MainWindow::startSwrSweep(int requestedSliceId)
+void MainWindow::startSwrSweep(int requestedSliceId, int sweepPowerWatts)
 {
     if (m_swrSweep.running)
         return;
+
+    sweepPowerWatts = qBound(kSwrSweepMinPowerW, sweepPowerWatts, kSwrSweepMaxPowerW);
 
     if (!m_radioModel.isConnected()) {
         QMessageBox::warning(this, tr("SWR Sweep"),
@@ -10681,9 +10707,9 @@ void MainWindow::startSwrSweep(int requestedSliceId)
                              tr("Stop transmit or tune before starting an SWR sweep."));
         return;
     }
-    if (tx.tunePower() <= 0) {
+    if (m_radioModel.hasAmplifier() && m_radioModel.ampOperate()) {
         QMessageBox::warning(this, tr("SWR Sweep"),
-                             tr("Tune Power is 0 W. Set a non-zero Tune Power first."));
+                             tr("Put the Power Genius XL amplifier in STANDBY before running an SWR sweep."));
         return;
     }
 
@@ -10736,8 +10762,10 @@ void MainWindow::startSwrSweep(int requestedSliceId)
     m_swrSweep.originalFreqMhz = s->frequency();
     m_swrSweep.frequencies = sweepFreqs;
     m_swrSweep.currentIndex = 0;
+    m_swrSweep.originalTunePower = tx.tunePower();
+    m_swrSweep.sweepTunePower = sweepPowerWatts;
     m_swrSweep.minimumForwardPowerW = qBound(0.05f,
-                                             static_cast<float>(tx.tunePower()) * 0.05f,
+                                             static_cast<float>(sweepPowerWatts) * 0.05f,
                                              1.0f);
     auto& tuner = m_radioModel.tunerModel();
     m_swrSweep.tgxlOriginalOperate = tuner.isOperate();
@@ -10766,6 +10794,7 @@ void MainWindow::startSwrSweep(int requestedSliceId)
     }
 
     setSwrSweepInputsLocked(true);
+    tx.setTunePower(sweepPowerWatts);
 
     if (m_swrSweep.tgxlBypassRequested) {
         m_swrSweep.phase = SwrSweepPhase::WaitingForTgxlBypass;
@@ -10954,6 +10983,8 @@ void MainWindow::finishSwrSweepAfterTuneStopped()
             s && m_swrSweep.originalFreqMhz > 0.0) {
             s->setFrequency(m_swrSweep.originalFreqMhz);
         }
+        if (m_swrSweep.originalTunePower != m_swrSweep.sweepTunePower)
+            m_radioModel.transmitModel().setTunePower(m_swrSweep.originalTunePower);
 
         if (m_swrSweep.finalAborted && !m_swrSweep.panId.isEmpty()
             && m_swrSweep.originalPanCenterMhz > 0.0

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -208,7 +208,7 @@ private:
 
     BandSnapshot captureCurrentBandState() const;
     void restoreBandState(const BandSnapshot& snap);
-    void startSwrSweep(int requestedSliceId = -1);
+    void startSwrSweep(int requestedSliceId = -1, int sweepPowerWatts = 1);
     void clearSwrSweepPlot();
     void advanceSwrSweep();
     void finishSwrSweep(bool aborted, const QString& reason = {});
@@ -447,6 +447,8 @@ private:
         qint64 sampleNotBeforeMs{0};
         qint64 phaseStartedAtMs{0};
         float minimumForwardPowerW{0.0f};
+        int originalTunePower{0};
+        int sweepTunePower{1};
         bool tuneStarted{false};
         bool finalAborted{false};
         bool clearPlotOnFinish{false};

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -398,14 +398,39 @@ void SpectrumOverlayMenu::buildAntPanel()
     sweepRow->addWidget(m_swrClearBtn, 1);
     vbox->addLayout(sweepRow);
 
+    auto* sweepPowerRow = new QHBoxLayout;
+    sweepPowerRow->setSpacing(4);
+    auto* sweepPowerTitle = new QLabel("PWR");
+    sweepPowerTitle->setStyleSheet(kLabelStyle);
+    sweepPowerTitle->setFixedWidth(28);
+    sweepPowerRow->addWidget(sweepPowerTitle);
+    m_swrPowerSlider = new GuardedSlider(Qt::Horizontal);
+    m_swrPowerSlider->setRange(1, 10);
+    m_swrPowerSlider->setValue(1);
+    m_swrPowerSlider->setStyleSheet(kSliderStyle);
+    sweepPowerRow->addWidget(m_swrPowerSlider, 1);
+    m_swrPowerLabel = new QLabel("1 W");
+    m_swrPowerLabel->setStyleSheet(kLabelStyle);
+    m_swrPowerLabel->setFixedWidth(kValueW);
+    m_swrPowerLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    sweepPowerRow->addWidget(m_swrPowerLabel);
+    vbox->addLayout(sweepPowerRow);
+
     connect(m_swrStartBtn, &QPushButton::clicked, this, [this]() {
         const int sliceId = m_slice ? m_slice->sliceId() : -1;
+        const int watts = m_swrPowerSlider ? m_swrPowerSlider->value() : 1;
         hideAllSubPanels();
-        emit swrSweepStartRequested(sliceId);
+        emit swrSweepStartRequested(sliceId, watts);
     });
     connect(m_swrClearBtn, &QPushButton::clicked, this, [this]() {
         hideAllSubPanels();
         emit swrSweepClearRequested();
+    });
+    connect(m_swrPowerSlider, &QSlider::valueChanged, this, [this](int watts) {
+        watts = qBound(1, watts, 10);
+        if (m_swrPowerLabel)
+            m_swrPowerLabel->setText(QString("%1 W").arg(watts));
+        emit swrSweepPowerChanged(watts);
     });
 
     // ANT panel tooltips
@@ -415,6 +440,7 @@ void SpectrumOverlayMenu::buildAntPanel()
     m_wnbSlider->setToolTip("Adjusts WNB threshold. Higher values blank more aggressively.");
     m_swrStartBtn->setToolTip("Run a low-power tune sweep across the current TX band and plot SWR on the panadapter.");
     m_swrClearBtn->setToolTip("Clear the displayed SWR sweep trace.");
+    m_swrPowerSlider->setToolTip("Sets the low-power tune carrier used for SWR sweeps.");
 
     m_antPanel->setFixedWidth(180);
     m_antPanel->adjustSize();
@@ -1499,6 +1525,18 @@ void SpectrumOverlayMenu::setWnbState(bool on, int level)
     m_wnbBtn->setChecked(on);
     m_wnbSlider->setValue(level);
     m_wnbLabel->setText(QString::number(level));
+}
+
+void SpectrumOverlayMenu::setSwrSweepPowerWatts(int watts)
+{
+    if (!m_swrPowerSlider)
+        return;
+
+    watts = qBound(1, watts, 10);
+    QSignalBlocker blocker(m_swrPowerSlider);
+    m_swrPowerSlider->setValue(watts);
+    if (m_swrPowerLabel)
+        m_swrPowerLabel->setText(QString("%1 W").arg(watts));
 }
 
 void SpectrumOverlayMenu::setRfGain(int gain)

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -59,6 +59,7 @@ public:
     void setWnbState(bool on, int level);
     void setRfGain(int gain);
     void setRfGainRange(int low, int high, int step);
+    void setSwrSweepPowerWatts(int watts);
 
     // Populate XVTR band sub-panel
     struct XvtrBand { QString name; double rfFreqMhz; };
@@ -129,7 +130,8 @@ signals:
     void wnbLevelChanged(int level);
     // Emitted when RF gain slider changes (panadapter-level).
     void rfGainChanged(int gain);
-    void swrSweepStartRequested(int sliceId);
+    void swrSweepStartRequested(int sliceId, int sweepPowerWatts);
+    void swrSweepPowerChanged(int watts);
     void swrSweepClearRequested();
     // NB Waterfall Blanker (#277)
     void wfBlankerEnabledChanged(bool on);
@@ -193,6 +195,8 @@ private:
     QLabel*      m_wnbLabel{nullptr};
     QPushButton* m_swrStartBtn{nullptr};
     QPushButton* m_swrClearBtn{nullptr};
+    QSlider*     m_swrPowerSlider{nullptr};
+    QLabel*      m_swrPowerLabel{nullptr};
 
     // DSP sub-panel
     QWidget* m_dspPanel{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4696,7 +4696,7 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
 
 void SpectrumWidget::drawSwrSweep(QPainter& p, const QRect& specRect)
 {
-    if (m_swrSweepPoints.isEmpty() && !m_swrSweepRunning)
+    if (m_swrSweepPoints.isEmpty())
         return;
 
     const int rightEdge = specRect.right() - DBM_STRIP_W - 8;

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -359,6 +359,10 @@ void TransmitModel::setRfPower(int power)
 void TransmitModel::setTunePower(int power)
 {
     power = qBound(0, power, 100);
+    if (m_tunePower != power) {
+        m_tunePower = power;
+        emit stateChanged();
+    }
     emit commandReady(QString("transmit set tunepower=%1").arg(power));
 }
 


### PR DESCRIPTION
## Summary

Follow-up polish for the SWR sweep feature after #2202.

## Changes

- Adds a persisted sweep-power slider under the ANT panel sweep controls.
- Limits SWR sweep power to 1-10 W and defaults to 1 W.
- Saves the sweep power as `SwrSweepPowerWatts` and loads it into each panadapter overlay on startup.
- Uses the sweep-specific power when starting the radio tune carrier, then restores the user's previous Tune Power after RF is stopped.
- Refuses to start a sweep while a detected Power Genius XL amplifier is in operate mode.
- Makes `TransmitModel::setTunePower()` update optimistically so moving Tune Power from 0 W back up no longer leaves the sweep blocked on a stale model value.
- Keeps the earlier review cleanup: restored AppletPanel includes, clarified read-only tuner polling, and suppressed the empty SWR plot before the first sample.

## Safety Notes

The sweep now avoids depending on the TX applet Tune Power state. The selected sweep power is applied immediately before the sweep and restored only after the tune carrier has stopped. PGXL operate mode is treated as a hard precondition failure so users must put the amplifier in standby before the sweep can drive RF.

## Validation

- `git diff --check`
- `cmake --build build -j10`
- `./build/transmit_model_test`
- `./build/transmit_model_apd_test`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
