### PR TITLE
[dax] [panadapter] Fix multi-client startup panadapter creation

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -96,6 +96,30 @@ QString hexId(quint32 value)
         .arg(QString::number(value, 16).rightJustified(8, QLatin1Char('0')));
 }
 
+QString normalizePanadapterId(QString text)
+{
+    text = text.trimmed();
+    if (text.isEmpty())
+        return QString();
+
+    if (text.startsWith(QStringLiteral("0x"), Qt::CaseInsensitive))
+        text = text.mid(2);
+
+    bool ok = false;
+    const quint32 id = text.toUInt(&ok, 16);
+    return ok ? hexId(id) : text;
+}
+
+QString parsePanadapterCreateId(const QString& body)
+{
+    const QMap<QString, QString> kvs = CommandParser::parseKVs(body);
+    if (kvs.contains(QStringLiteral("pan")))
+        return normalizePanadapterId(kvs.value(QStringLiteral("pan")));
+    if (kvs.contains(QStringLiteral("id")))
+        return normalizePanadapterId(kvs.value(QStringLiteral("id")));
+    return normalizePanadapterId(body);
+}
+
 struct StreamObjectParts {
     bool valid{false};
     quint32 streamId{0};
@@ -905,31 +929,40 @@ void RadioModel::createPanadapter()
         emit panadapterLimitReached(limit, m_model);
         return;
     }
-    qCDebug(lcProtocol) << "RadioModel::createPanadapter: sending display panafall create";
-    sendCmd("display panafall create x=100 y=100", [this](int code, const QString& body) {
+    const auto handleCreatedPan = [this](const QString& source, int code, const QString& body) {
         if (code != 0) {
-            qCWarning(lcProtocol) << "RadioModel: panadapter create failed, code"
-                       << Qt::hex << code << "body:" << body;
+            qCWarning(lcProtocol) << "RadioModel:" << source << "failed, code"
+                                  << Qt::hex << code << "body:" << body;
+            emit panadapterLimitReached(maxPanadapters(), m_model);
             return;
         }
-        // Parse pan ID from response
-        QString panId;
-        const QMap<QString, QString> kvs = CommandParser::parseKVs(body);
-        if (kvs.contains("pan"))       panId = kvs["pan"];
-        else if (kvs.contains("id"))   panId = kvs["id"];
-        else                           panId = body.trimmed();
+        const QString panId = parsePanadapterCreateId(body);
 
         qCDebug(lcProtocol) << "RadioModel: new panadapter created, pan_id =" << panId;
 
-        // The radio will push display pan status for this panId,
-        // which triggers PanadapterModel creation in onStatusReceived
-        // and emits panadapterAdded. Configure after a short delay.
         if (!panId.isEmpty()) {
+            ensureOwnedPanadapter(panId);
             QTimer::singleShot(200, this, [this, panId]() {
                 sendCmd(QString("display pan set %1 xpixels=1024 ypixels=700").arg(panId));
                 sendCmd(QString("display pan set %1 fps=25 min_dbm=-130 max_dbm=-40").arg(panId));
             });
         }
+    };
+
+    qCDebug(lcProtocol) << "RadioModel::createPanadapter: sending display panafall create";
+    sendCmd("display panafall create x=100 y=100", [this, handleCreatedPan](int code, const QString& body) {
+        if (code == 0) {
+            handleCreatedPan(QStringLiteral("display panafall create"), code, body);
+            return;
+        }
+
+        qCWarning(lcProtocol) << "RadioModel: display panafall create failed, code"
+                              << Qt::hex << code << "body:" << body
+                              << "- trying legacy panadapter create";
+        sendCmd("panadapter create",
+                [handleCreatedPan](int legacyCode, const QString& legacyBody) {
+            handleCreatedPan(QStringLiteral("panadapter create"), legacyCode, legacyBody);
+        });
     });
 }
 
@@ -2165,6 +2198,50 @@ quint32 RadioModel::clientHandle() const
     return m_connection->clientHandle();
 }
 
+PanadapterModel* RadioModel::ensureOwnedPanadapter(const QString& panId)
+{
+    const QString normalizedPanId = normalizePanadapterId(panId);
+    if (normalizedPanId.isEmpty())
+        return nullptr;
+
+    if (auto* existing = m_panadapters.value(normalizedPanId, nullptr))
+        return existing;
+
+    auto* pan = new PanadapterModel(normalizedPanId, this);
+    pan->setClientHandle(QString::number(clientHandle(), 16));
+    m_panadapters[normalizedPanId] = pan;
+    if (m_activePanId.isEmpty())
+        m_activePanId = normalizedPanId;
+
+    connect(pan, &PanadapterModel::waterfallIdChanged,
+            this, &RadioModel::updateStreamFilters);
+    updateStreamFilters();
+
+    sendCmd(QString("display pan rfgain_info %1").arg(normalizedPanId),
+            [pan](int code, const QString& body) {
+        if (code != 0 || body.isEmpty()) return;
+        QStringList vals = body.split(',');
+        if (vals.size() < 3) return;
+        int low = vals[0].trimmed().toInt();
+        int high = vals[1].trimmed().toInt();
+        int step = vals[2].trimmed().toInt();
+        if (step > 0)
+            pan->setRfGainInfo(low, high, step);
+    });
+
+    qCDebug(lcProtocol) << "RadioModel: claimed panadapter" << normalizedPanId;
+    emit panadapterAdded(pan);
+
+    const auto pending = m_pendingPanStatuses.take(normalizedPanId);
+    if (!pending.isEmpty()) {
+        qCDebug(lcProtocol) << "RadioModel: applying deferred panadapter status for"
+                            << normalizedPanId;
+        handlePanadapterStatus(normalizedPanId, pending);
+    }
+
+    return pan;
+}
+
 quint32 RadioModel::ourClientHandle() const { return clientHandle(); }
 
 void RadioModel::emitOtherClientsChanged()
@@ -2563,6 +2640,7 @@ void RadioModel::onStatusReceived(const QString& object,
             // Handle pan removal — "display pan 0x40000001 removed" arrives
             // with no '=' so the parser puts the whole string in 'object'
             if (kvs.contains("removed") || object.endsWith("removed")) {
+                m_pendingPanStatuses.remove(panId);
                 auto* pan = m_panadapters.take(panId);
                 if (pan) {
                     m_panStream->unregisterPanStream(pan->panStreamId());
@@ -2591,36 +2669,17 @@ void RadioModel::onStatusReceived(const QString& object,
                 // AND matches our handle. Early status messages may arrive
                 // without client_handle — defer until ownership is confirmed.
                 // This prevents briefly adopting another Multi-Flex client's pan.
-                if (!kvs.contains("client_handle"))
+                if (!kvs.contains("client_handle")) {
+                    m_pendingPanStatuses[panId] = kvs;
                     return;  // defer — can't confirm ownership yet
-                quint32 owner = kvs["client_handle"].toUInt(nullptr, 16);
-                if (owner != clientHandle())
+                }
+                quint32 owner = parseClientHandle(kvs["client_handle"]);
+                if (owner != clientHandle()) {
+                    m_pendingPanStatuses.remove(panId);
                     return;  // not our panadapter, ignore
+                }
 
-                auto* pan = new PanadapterModel(panId, this);
-                pan->setClientHandle(QString::number(clientHandle(), 16));
-                m_panadapters[panId] = pan;
-                if (m_activePanId.isEmpty())
-                    m_activePanId = panId;
-                // Re-register stream IDs when waterfall ID arrives (it's not
-                // available at pan creation time — comes later in display pan status)
-                connect(pan, &PanadapterModel::waterfallIdChanged,
-                        this, &RadioModel::updateStreamFilters);
-                updateStreamFilters();
-                // Query RF gain range from radio (varies by model)
-                sendCmd(QString("display pan rfgain_info %1").arg(panId),
-                        [pan](int code, const QString& body) {
-                    if (code != 0 || body.isEmpty()) return;
-                    QStringList vals = body.split(',');
-                    if (vals.size() < 3) return;
-                    int low = vals[0].trimmed().toInt();
-                    int high = vals[1].trimmed().toInt();
-                    int step = vals[2].trimmed().toInt();
-                    if (step > 0)
-                        pan->setRfGainInfo(low, high, step);
-                });
-                qCDebug(lcProtocol) << "RadioModel: claimed panadapter" << panId;
-                emit panadapterAdded(pan);
+                ensureOwnedPanadapter(panId);
             }
             handlePanadapterStatus(panId, kvs);
         }
@@ -2638,23 +2697,35 @@ void RadioModel::onStatusReceived(const QString& object,
             // The waterfallId is set on PanadapterModel by the "display pan" status
             // message which contains "waterfall=0x42xxxxxx".
             bool ours = false;
+            PanadapterModel* ownerPan = nullptr;
             for (auto* pan : m_panadapters) {
-                if (pan->waterfallId() == wfId) { ours = true; break; }
+                if (pan->waterfallId() == wfId) {
+                    ours = true;
+                    ownerPan = pan;
+                    break;
+                }
             }
+            const QString parentPanId = normalizePanadapterId(kvs.value(QStringLiteral("panadapter")));
+            if (!ownerPan && !parentPanId.isEmpty())
+                ownerPan = m_panadapters.value(parentPanId, nullptr);
             if (!ours) {
                 // Not yet associated via display pan status — check client_handle
                 if (!kvs.contains("client_handle"))
                     return;  // defer — can't confirm ownership yet
-                quint32 owner = kvs["client_handle"].toUInt(nullptr, 16);
+                quint32 owner = parseClientHandle(kvs["client_handle"]);
                 if (owner != clientHandle())
                     return;  // not our waterfall
-                // Own it but don't force-associate — the display pan status
-                // will set the correct waterfallId on the right pan.
+                if (!ownerPan && !parentPanId.isEmpty())
+                    ownerPan = ensureOwnedPanadapter(parentPanId);
+                if (ownerPan && ownerPan->waterfallId().isEmpty())
+                    ownerPan->setWaterfallId(wfId);
                 ours = true;
             }
 
-            if (activeWfId().isEmpty())
-                setActiveWfId(wfId);
+            if (ownerPan)
+                ownerPan->applyWaterfallStatus(kvs);
+            if (activeWfId().isEmpty() && ownerPan == activePanadapter())
+                ownerPan->setWaterfallId(wfId);
             updateStreamFilters();
             qCDebug(lcProtocol) << "RadioModel: claimed waterfall" << wfId;
         }
@@ -3384,16 +3455,9 @@ void RadioModel::configureWaterfall()
     });
 }
 
-// ─── Standalone mode: create panadapter + slice ───────────────────────────────
-//
-// SmartSDR API 1.4.0.0 standalone flow:
-//   1. "panadapter create"
-//      → R|0|pan=0x40000000         (KV response; key is "pan")
-//   2. "slice create pan=0x40000000 freq=14.225000 antenna=ANT1 mode=USB"
-//      → R|0|<slice_index>          (decimal, e.g. "0")
-//   3. Radio emits S messages for the new panadapter and slice.
-//
-// Note: "display panafall create" (v2+ syntax) returns 0x50000016 on this firmware.
+// Standalone mode: create panadapter + slice.
+// FlexLib v4.2.18 uses "display panafall create x=100 y=100"; keep the
+// legacy "panadapter create" as a fallback for older firmware.
 
 void RadioModel::createDefaultSlice(const QString& freqMhz,
                                      const QString& mode,
@@ -3402,50 +3466,76 @@ void RadioModel::createDefaultSlice(const QString& freqMhz,
     qCDebug(lcProtocol) << "RadioModel: standalone mode — creating panadapter + slice"
              << freqMhz << mode << antenna;
 
-    sendCmd("panadapter create",
-        [this, freqMhz, mode, antenna](int code, const QString& body) {
-            if (code != 0) {
-                qCWarning(lcProtocol) << "RadioModel: panadapter create failed, code" << Qt::hex << code
-                           << "body:" << body;
+    const auto handleCreatedPan =
+        [this, freqMhz, mode, antenna](const QString& source,
+                                       int code,
+                                       const QString& body) -> bool {
+        if (code != 0) {
+            qCWarning(lcProtocol) << "RadioModel:" << source << "failed, code"
+                                  << Qt::hex << code << "body:" << body;
+            emit panadapterLimitReached(maxPanadapters(), m_model);
+            return false;
+        }
+
+        qCDebug(lcProtocol) << "RadioModel:" << source << "response body:" << body;
+        const QString panId = parsePanadapterCreateId(body);
+        if (panId.isEmpty()) {
+            qCWarning(lcProtocol) << "RadioModel:" << source
+                                  << "returned empty pan_id";
+            return false;
+        }
+
+        qCDebug(lcProtocol) << "RadioModel: panadapter created, pan_id =" << panId;
+        createDefaultSliceOnPan(panId, freqMhz, mode, antenna);
+        return true;
+    };
+
+    sendCmd("display panafall create x=100 y=100",
+        [this, handleCreatedPan](int code, const QString& body) {
+            if (code == 0) {
+                handleCreatedPan(QStringLiteral("display panafall create"), code, body);
                 return;
             }
 
-            qCDebug(lcProtocol) << "RadioModel: panadapter create response body:" << body;
-
-            // Response body may be a bare hex ID ("0x40000000") or KV ("pan=0x40000000").
-            // Parse KVs first; fall back to treating the whole body as the ID.
-            QString panId;
-            const QMap<QString, QString> kvs = CommandParser::parseKVs(body);
-            if (kvs.contains("pan")) {
-                panId = kvs["pan"];
-            } else if (kvs.contains("id")) {
-                panId = kvs["id"];
-            } else {
-                panId = body.trimmed();
-            }
-
-            qCDebug(lcProtocol) << "RadioModel: panadapter created, pan_id =" << panId;
-
-            if (panId.isEmpty()) {
-                qCWarning(lcProtocol) << "RadioModel: panadapter create returned empty pan_id";
-                return;
-            }
-
-            const QString sliceCmd =
-                QString("slice create pan=%1 freq=%2 antenna=%3 mode=%4")
-                    .arg(panId, freqMhz, antenna, mode);
-
-            sendCmd(sliceCmd,
-                [panId](int code2, const QString& body2) {
-                    if (code2 != 0) {
-                        qCWarning(lcProtocol) << "RadioModel: slice create failed, code"
-                                   << Qt::hex << code2 << "body:" << body2;
-                    } else {
-                        qCDebug(lcProtocol) << "RadioModel: slice created, index =" << body2;
-                        // Radio now emits S|slice N ... status messages;
-                        // handleSliceStatus() picks them up automatically.
-                    }
+            qCWarning(lcProtocol) << "RadioModel: display panafall create failed, code"
+                                  << Qt::hex << code << "body:" << body
+                                  << "- trying legacy panadapter create";
+            sendCmd("panadapter create",
+                [handleCreatedPan](int legacyCode, const QString& legacyBody) {
+                    handleCreatedPan(QStringLiteral("panadapter create"),
+                                     legacyCode,
+                                     legacyBody);
                 });
+        });
+}
+
+void RadioModel::createDefaultSliceOnPan(const QString& panId,
+                                         const QString& freqMhz,
+                                         const QString& mode,
+                                         const QString& antenna)
+{
+    auto* pan = ensureOwnedPanadapter(panId);
+    if (!pan) {
+        qCWarning(lcProtocol) << "RadioModel: cannot create slice without panadapter id";
+        return;
+    }
+
+    const QString sliceCmd =
+        QString("slice create pan=%1 freq=%2 antenna=%3 mode=%4")
+            .arg(pan->panId(), freqMhz, antenna, mode);
+
+    sendCmd(sliceCmd,
+        [this, panId = pan->panId()](int code, const QString& body) {
+            if (code != 0) {
+                qCWarning(lcProtocol) << "RadioModel: slice create failed for pan"
+                                      << panId << "code" << Qt::hex << code
+                                      << "body:" << body;
+                emit sliceCreateFailed(maxSlices(), m_model);
+            } else {
+                qCDebug(lcProtocol) << "RadioModel: slice created, index =" << body;
+                // Radio now emits S|slice N ... status messages;
+                // handleSliceStatus() picks them up automatically.
+            }
         });
 }
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1681,6 +1681,7 @@ void RadioModel::onDisconnected()
     // Clean up panadapter models
     qDeleteAll(m_panadapters);
     m_panadapters.clear();
+    m_pendingPanStatuses.clear();
     m_activePanId.clear();
     m_ownedSliceIds.clear();
     m_tnfModel.clear();

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -428,6 +428,7 @@ private:
     using ResponseCallback = RadioConnection::ResponseCallback;
     quint32 sendCmd(const QString& command, ResponseCallback cb = nullptr);
     quint32 clientHandle() const;
+    PanadapterModel* ensureOwnedPanadapter(const QString& panId);
     void updateStreamFilters();
     void handleGpsStatus(const QString& rawBody);
     void emitOtherClientsChanged();
@@ -436,6 +437,10 @@ private:
     void createDefaultSlice(const QString& freqMhz = "14.225000",
                             const QString& mode    = "USB",
                             const QString& antenna = "ANT1");
+    void createDefaultSliceOnPan(const QString& panId,
+                                 const QString& freqMhz,
+                                 const QString& mode,
+                                 const QString& antenna);
 
     RadioConnection*  m_connection{nullptr};
     QThread*          m_connThread{nullptr};
@@ -523,6 +528,7 @@ private:
 
     QMap<QString, PanadapterModel*> m_panadapters;  // panId → model
     QString m_activePanId;       // currently active panadapter
+    QMap<QString, QMap<QString, QString>> m_pendingPanStatuses;
 
     bool    m_hasAmplifier{false};  // true if a power amp (PGXL) is detected
     QString m_ampHandle;             // amplifier handle for commands


### PR DESCRIPTION
## Summary

Fixes #2194 by making AetherSDR's startup panadapter creation resilient when SmartSDR, DAX, or another GUI/audio client is already connected to the radio.

The primary startup path now matches FlexLib v4.2.18 and creates a display pair with:

```text
display panafall create x=100 y=100
```

If older firmware rejects that command, AetherSDR falls back to the legacy:

```text
panadapter create
```

The fix also hardens status handling so AetherSDR can recover when panadapter or waterfall ownership status arrives out of order during multi-client startup.

Fixes #2194, #2210, #2203, #2221, #2223, #2224

## Root Cause

When SmartSDR DAX is already running, the radio is not starting from a quiet single-client state. On connect, AetherSDR receives status for all current radio objects, including slices, pans, waterfalls, DAX streams, and TX/audio streams associated with other client handles.

AetherSDR correctly filters these objects by `client_handle` so it does not accidentally adopt SmartSDR/DAX-owned state. The failure came from the interaction between that filtering and the startup fallback:

1. AetherSDR connects and registers as a GUI client.
2. The radio replays status for multiple clients.
3. AetherSDR rejects non-owned slices and panadapters, as intended.
4. `slice list` can still return non-empty because slices exist globally on the radio.
5. AetherSDR may still have no owned slice after filtering.
6. The deferred startup fallback creates a default pan and slice for AetherSDR.
7. That fallback used the older bare `panadapter create` command and waited too heavily on later pan ownership status.
8. If `display pan` status was delayed, interleaved, or first arrived without `client_handle`, AetherSDR could fail to instantiate a `PanadapterModel`.

Without a `PanadapterModel`, FFT and waterfall stream IDs are not registered with `PanadapterStream`, so VITA-49 data never reaches the UI and the startup "getting ready" path can remain stuck.

## Why DAX Exposed This

The SmartSDR DAX app creates exactly the kind of multi-client environment that stresses this path:

- the radio reports globally existing slices even when they belong to another client
- DAX and SmartSDR stream status includes separate `client_handle` ownership
- pan/waterfall/slice status can be interleaved with AetherSDR's own startup sequence
- AetherSDR must reject other clients' objects, then create or claim its own objects

So the issue is broader than firmware 4.2.18. The newer firmware and FlexLib API made it more visible, but the underlying bug was that AetherSDR's owned-pan startup path was too dependent on later, perfectly ordered ownership status.

## Implementation

This PR changes `RadioModel` in a few coordinated ways:

- Adds normalized panadapter ID parsing for command responses that may return either `pan=0x...`, `id=0x...`, or a bare stream ID.
- Adds `ensureOwnedPanadapter()` to create and register a `PanadapterModel` as soon as AetherSDR has an owned pan ID.
- Updates manual and startup pan creation to try `display panafall create x=100 y=100` first, matching FlexLib v4.2.18.
- Keeps compatibility with older firmware by retrying `panadapter create` if `display panafall create` fails.
- Defers early `display pan` status that lacks `client_handle` instead of dropping it permanently.
- Replays deferred pan status once ownership is confirmed.
- Uses owned waterfall status with `panadapter=...` to recover the parent pan/waterfall association if waterfall status arrives before a complete pan status.
- Emits the existing status-bar capacity signals when pan or slice creation ultimately fails, so true radio resource exhaustion is visible instead of looking like a startup hang.

## Compatibility

Older firmware should continue to work. The new command is tried first because it is what current FlexLib uses, but any rejection falls back to the legacy `panadapter create` command.

This is intentionally capability-based rather than a hard firmware-version gate. The radio/API behavior varies enough across model and firmware combinations that "try current command, fall back to legacy command" is safer than guessing from version strings.

## Panadapter and Waterfall Sizing

`display panafall create x=100 y=100` is only the creation request for the paired display object. It does not set the final UI stream dimensions.

AetherSDR still pushes real dimensions after the `PanadapterModel` exists with:

```text
display pan set <pan_id> xpixels=<widget_width> ypixels=<widget_height>
```

That matches FlexLib's model: panadapter width/height drive `display pan set ... xpixels/ypixels`, while waterfall width/height do not send separate pixel sizing commands. Final FFT/waterfall sizing is therefore still controlled by AetherSDR's widget-dimension path, not by the initial `x=100 y=100` create command.

## User Impact

Users should be able to start AetherSDR while SmartSDR DAX or another client is already connected, as long as the radio still has available pan/slice capacity.

If the radio is genuinely out of resources, AetherSDR now routes that failure through the existing status-bar messages instead of silently failing to get a panadapter.

## Validation

- Reviewed issue #2194 and the attached user logs.
- Compared AetherSDR's startup path with FlexLib v4.2.18.41174.
- Confirmed FlexLib uses `display panafall create x=100 y=100`.
- Built successfully:

```text
cmake --build build -j10
```

- Ran CTest discovery:

```text
ctest --test-dir build --output-on-failure -j10
```

CTest completed successfully but reported no registered tests in this build tree.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
