### PR TITLE
[bug] Fix PC audio remote stream ownership

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1171,6 +1171,15 @@ add_executable(xvtr_policy_test
 target_include_directories(xvtr_policy_test PRIVATE src)
 target_link_libraries(xvtr_policy_test PRIVATE Qt6::Core)
 
+add_executable(radio_status_ownership_test
+    tests/radio_status_ownership_test.cpp
+    src/core/CommandParser.cpp
+)
+target_include_directories(radio_status_ownership_test PRIVATE src)
+target_link_libraries(radio_status_ownership_test PRIVATE Qt6::Core)
+enable_testing()
+add_test(NAME radio_status_ownership_test COMMAND radio_status_ownership_test)
+
 add_executable(cw_sidetone_test
     tests/cw_sidetone_test.cpp
     src/core/CwSidetoneGenerator.cpp

--- a/src/core/DeviceDiagnostics.cpp
+++ b/src/core/DeviceDiagnostics.cpp
@@ -176,6 +176,8 @@ QJsonObject buildAudioDevicesSnapshot(const AudioEngine* audio, const QJsonObjec
 
     const QJsonObject transmit = snapshot["transmit"].toObject();
     const QJsonObject mic = transmit["mic"].toObject();
+    const QJsonObject radio = snapshot["radio"].toObject();
+    const QJsonObject remoteAudioRx = radio["remote_audio_rx"].toObject();
     const bool pcAudioEnabled = isSavedTrue(QStringLiteral("PcAudioEnabled"), QStringLiteral("True"));
 
     QJsonObject rxRoute;
@@ -183,6 +185,13 @@ QJsonObject buildAudioDevicesSnapshot(const AudioEngine* audio, const QJsonObjec
     rxRoute["source"] = "PcAudioEnabled app setting";
     rxRoute["selected_output_device"] = selectedOutput.description();
     rxRoute["radio_lineout_available"] = true;
+    rxRoute["remote_audio_rx_stream_id"] = remoteAudioRx["stream_id"];
+    rxRoute["remote_audio_rx_stream_id_known"] = remoteAudioRx["stream_id_known"];
+    rxRoute["remote_audio_rx_create_pending"] = remoteAudioRx["create_pending"];
+    rxRoute["remote_audio_rx_remove_requested"] = remoteAudioRx["remove_requested"];
+    rxRoute["remote_audio_rx_status_seen"] = remoteAudioRx["status_seen"];
+    rxRoute["remote_audio_rx_owned_by_us"] = remoteAudioRx["owned_by_us"];
+    rxRoute["remote_audio_rx_expected"] = remoteAudioRx["stream_expected"];
     obj["rx_route"] = rxRoute;
 
     QJsonObject txRoute;
@@ -199,7 +208,6 @@ QJsonObject buildAudioDevicesSnapshot(const AudioEngine* audio, const QJsonObjec
     volumes["pc_master_volume_pct"] = AppSettings::instance().value("MasterVolume", "100").toInt();
     volumes["pc_mic_gain_pct"] = AppSettings::instance().value("PcMicGain", 100).toInt();
 
-    const QJsonObject radio = snapshot["radio"].toObject();
     const QJsonObject radioAudio = radio["audio_outputs"].toObject();
     volumes["radio_lineout_gain"] = radioAudio["lineout_gain"];
     volumes["radio_lineout_mute"] = radioAudio["lineout_mute"];

--- a/src/gui/SliceTroubleshootingDialog.cpp
+++ b/src/gui/SliceTroubleshootingDialog.cpp
@@ -477,6 +477,7 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
     const QJsonObject ownership = radio["ownership"].toObject();
     const QJsonObject oscillator = radio["oscillator"].toObject();
     const QJsonObject audioOutputs = radio["audio_outputs"].toObject();
+    const QJsonObject remoteAudioRx = radio["remote_audio_rx"].toObject();
     const QJsonObject filterSharpness = radio["filter_sharpness"].toObject();
     const QJsonObject telemetry = radio["telemetry"].toObject();
     const QJsonObject amplifier = radio["amplifier"].toObject();
@@ -559,6 +560,15 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
                  .arg(audioOutputs["headphone_gain"].toInt())
                  .arg(yesNo(audioOutputs["headphone_mute"].toBool()))
                  .arg(yesNo(audioOutputs["front_speaker_mute"].toBool()));
+    lines << QString("- Remote audio RX: stream `%1`, expected `%2`, pending `%3`, status seen `%4`, owned by us `%5`, compression `%6`")
+                 .arg(orPlaceholder(remoteAudioRx["stream_id"].toString()))
+                 .arg(yesNo(remoteAudioRx["stream_expected"].toBool()))
+                 .arg(yesNo(remoteAudioRx["create_pending"].toBool()))
+                 .arg(yesNo(remoteAudioRx["status_seen"].toBool()))
+                 .arg(yesNo(remoteAudioRx["owned_by_us"].toBool()))
+                 .arg(orPlaceholder(remoteAudioRx["compression"].toString()));
+    lines << QString("- Remote audio route note: %1")
+                 .arg(orPlaceholder(remoteAudioRx["routing_note"].toString()));
     lines << QString("- Oscillator: setting `%1`, locked `%2`, ext `%3`, TCXO `%4`")
                  .arg(orPlaceholder(oscillator["setting"].toString()))
                  .arg(yesNo(oscillator["locked"].toBool()))
@@ -645,6 +655,13 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
                  .arg(formatPercentValue(audioVolumes["engine_rx_volume_pct"]))
                  .arg(formatBoolValue(audioVolumes["engine_rx_muted"]))
                  .arg(formatBoolValue(audioDevices["rx_streaming"]));
+    lines << QString("- Radio stream route: remote_audio_rx `%1`, expected `%2`, create pending `%3`, remove requested `%4`, status seen `%5`, owned by us `%6`")
+                 .arg(orPlaceholder(rxRoute["remote_audio_rx_stream_id"].toString()))
+                 .arg(formatBoolValue(rxRoute["remote_audio_rx_expected"]))
+                 .arg(formatBoolValue(rxRoute["remote_audio_rx_create_pending"]))
+                 .arg(formatBoolValue(rxRoute["remote_audio_rx_remove_requested"]))
+                 .arg(formatBoolValue(rxRoute["remote_audio_rx_status_seen"]))
+                 .arg(formatBoolValue(rxRoute["remote_audio_rx_owned_by_us"]));
     lines << QString("- TX input route: `%1` (mic `%2`, DAX `%3`), PC mic gain `%4`, TX stream `%5`, DAX TX mode `%6`, DAX radio route `%7`")
                  .arg(orPlaceholder(txRoute["input"].toString(), "Unknown"))
                  .arg(orPlaceholder(txRoute["mic_selection"].toString()))

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3,6 +3,7 @@
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
 #include "core/StreamStatus.h"
+#include "RadioStatusOwnership.h"
 #include <QCoreApplication>
 #include <QDebug>
 #include <QJsonArray>
@@ -642,7 +643,7 @@ void RadioModel::disconnectFromRadio()
         // Graceful disconnect: send stream remove + client disconnect and
         // wait for TCP flush before closing. Prevents Maestro lockup. (#1359)
         quint32 handle = clientHandle();
-        QString streamId = m_rxAudioStreamId;
+        QString streamId = RadioStatusOwnership::streamCommandId(m_rxAudio.streamId);
         QMetaObject::invokeMethod(m_connection, [this, handle, streamId]() {
             m_connection->gracefulDisconnect(handle, streamId);
         }, Qt::BlockingQueuedConnection);
@@ -1212,7 +1213,7 @@ void RadioModel::handleForcedClientDisconnect()
     }
 
     const quint32 handle = clientHandle();
-    const QString streamId = m_rxAudioStreamId;
+    const QString streamId = RadioStatusOwnership::streamCommandId(m_rxAudio.streamId);
     if (m_connection->isConnected()) {
         QMetaObject::invokeMethod(m_connection, [conn = m_connection, handle, streamId]() {
             conn->gracefulDisconnect(handle, streamId);
@@ -1421,26 +1422,10 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                         }
 
                         // Create remote_audio_rx if PC Audio is on OR TCI autostart
-                        // is enabled. The stream's existence tells the radio to route
-                        // audio to PC instead of its physical outputs. (#1014, #1051)
-                        {
-                        bool needStream = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True"
-                            || AppSettings::instance().value("AutoStartTCI", "False").toString() == "True";
-                        if (needStream) {
-                            sendCmd(
-                                QString("stream create type=remote_audio_rx compression=%1").arg(audioCompressionParam()),
-                                [this](int code, const QString& body) {
-                                    if (code == 0) {
-                                        m_rxAudioStreamId = body.trimmed();
-                                        qCDebug(lcProtocol) << "RadioModel: remote_audio_rx stream created, id:" << m_rxAudioStreamId;
-                                    } else
-                                        qCWarning(lcProtocol) << "RadioModel: stream create remote_audio_rx failed, code"
-                                                   << Qt::hex << code << "body:" << body;
-                                });
-                        } else {
-                            qCDebug(lcProtocol) << "RadioModel: PC audio disabled, no TCI — skipping remote_audio_rx";
-                        }
-                        }
+                        // is enabled. Defer briefly so SmartConnect/restored stream
+                        // status can be adopted before we ask the radio for another
+                        // stream. (#1014, #1051, #2037)
+                        scheduleRxAudioStreamEnsure(QStringLiteral("connect"));
 
         // Request DAX TX audio stream (PC mic → radio, DAX mode)
                         sendCmd(
@@ -1667,7 +1652,7 @@ void RadioModel::onDisconnected()
     m_chassisSerial.clear();
     m_callsign.clear();
     m_region.clear();
-    m_rxAudioStreamId.clear();
+    m_rxAudio = {};
     m_netCwStreamId = 0;
     m_netCwIndex = 1;
     m_lineoutGain = 50;
@@ -2154,25 +2139,199 @@ void RadioModel::setAmpOperate(bool on)
 
 void RadioModel::createRxAudioStream()
 {
-    if (!m_rxAudioStreamId.isEmpty()) return;  // already exists
+    if (m_rxAudio.streamId != 0) {
+        logRemoteAudioRxSummary(QStringLiteral("create skipped: stream already known"));
+        return;
+    }
+    if (m_rxAudio.createPending) {
+        logRemoteAudioRxSummary(QStringLiteral("create skipped: request already pending"));
+        return;
+    }
+
+    m_rxAudio.createPending = true;
+    m_rxAudio.removeRequested = false;
+    logRemoteAudioRxSummary(QStringLiteral("create requested"));
     sendCmd(QString("stream create type=remote_audio_rx compression=%1").arg(audioCompressionParam()),
         [this](int code, const QString& body) {
+            m_rxAudio.createPending = false;
             if (code == 0) {
-                m_rxAudioStreamId = body.trimmed();
-                qCDebug(lcProtocol) << "RadioModel: remote_audio_rx stream created, id:" << m_rxAudioStreamId;
+                const quint32 streamId = RadioStatusOwnership::parseCreateResponseStreamId(body);
+                if (streamId == 0) {
+                    qCWarning(lcProtocol) << "RadioModel: stream create remote_audio_rx returned unparseable body:"
+                                          << body;
+                    logRemoteAudioRxSummary(QStringLiteral("create response unparseable"));
+                    return;
+                }
+
+                if (m_rxAudio.streamId != 0 && m_rxAudio.streamId != streamId) {
+                    const quint32 oldStreamId = m_rxAudio.streamId;
+                    qCDebug(lcProtocol) << "RadioModel: replacing restored remote_audio_rx"
+                                        << RadioStatusOwnership::hexId(oldStreamId)
+                                        << "with create response"
+                                        << RadioStatusOwnership::hexId(streamId);
+                    sendCmd(QString("stream remove %1").arg(RadioStatusOwnership::hexId(oldStreamId)));
+                }
+
+                m_rxAudio.streamId = streamId;
+                m_rxAudio.clientHandle = clientHandle();
+                m_rxAudio.compression = audioCompressionParam();
+                qCDebug(lcProtocol) << "RadioModel: remote_audio_rx stream created, id:"
+                                    << RadioStatusOwnership::hexId(streamId);
+                logRemoteAudioRxSummary(QStringLiteral("create response adopted"));
+                if (m_rxAudio.removeRequested)
+                    removeRxAudioStream();
             } else {
                 qCWarning(lcProtocol) << "RadioModel: stream create remote_audio_rx failed, code"
                            << Qt::hex << code << "body:" << body;
+                logRemoteAudioRxSummary(QStringLiteral("create failed"));
             }
         });
 }
 
 void RadioModel::removeRxAudioStream()
 {
-    if (m_rxAudioStreamId.isEmpty()) return;
-    sendCmd(QString("stream remove 0x%1").arg(m_rxAudioStreamId));
-    qCDebug(lcProtocol) << "RadioModel: removed remote_audio_rx stream" << m_rxAudioStreamId;
-    m_rxAudioStreamId.clear();
+    if (m_rxAudio.streamId == 0) {
+        if (m_rxAudio.createPending) {
+            m_rxAudio.removeRequested = true;
+            logRemoteAudioRxSummary(QStringLiteral("remove deferred: create pending"));
+        } else {
+            logRemoteAudioRxSummary(QStringLiteral("remove skipped: no known stream"));
+        }
+        return;
+    }
+
+    const quint32 streamId = m_rxAudio.streamId;
+    sendCmd(QString("stream remove %1").arg(RadioStatusOwnership::hexId(streamId)));
+    qCDebug(lcProtocol) << "RadioModel: removed remote_audio_rx stream"
+                        << RadioStatusOwnership::hexId(streamId);
+    m_rxAudio.streamId = 0;
+    m_rxAudio.clientHandle = 0;
+    m_rxAudio.statusSeen = false;
+    m_rxAudio.removeRequested = false;
+    m_rxAudio.compression.clear();
+    logRemoteAudioRxSummary(QStringLiteral("remove requested"));
+}
+
+void RadioModel::scheduleRxAudioStreamEnsure(const QString& reason)
+{
+    const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+    const bool autoStartTci = AppSettings::instance().value("AutoStartTCI", "False").toString() == "True";
+    if (!pcAudio && !autoStartTci) {
+        qCDebug(lcProtocol) << "RadioModel: PC audio disabled, no TCI — skipping remote_audio_rx";
+        if (m_rxAudio.streamId != 0) {
+            qCDebug(lcProtocol) << "RadioModel: removing unexpected owned remote_audio_rx while PC audio is disabled";
+            removeRxAudioStream();
+        }
+        logRemoteAudioRxSummary(QStringLiteral("ensure skipped: not needed"));
+        return;
+    }
+
+    logRemoteAudioRxSummary(QStringLiteral("ensure scheduled: ") + reason);
+    QTimer::singleShot(350, this, [this, reason]() {
+        const bool pcAudioNow = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+        const bool autoStartTciNow = AppSettings::instance().value("AutoStartTCI", "False").toString() == "True";
+        if (!isConnected()) {
+            logRemoteAudioRxSummary(QStringLiteral("ensure canceled: disconnected"));
+            return;
+        }
+        if (!pcAudioNow && !autoStartTciNow) {
+            logRemoteAudioRxSummary(QStringLiteral("ensure canceled: no longer needed"));
+            return;
+        }
+
+        qCDebug(lcProtocol) << "RadioModel: ensuring remote_audio_rx stream after status settle for"
+                            << reason;
+        createRxAudioStream();
+    });
+}
+
+bool RadioModel::handleRemoteAudioRxStreamStatus(const QString& object,
+                                                 const QMap<QString, QString>& kvs)
+{
+    const bool allowUnknownOwner = m_clientInfoMap.size() <= 1;
+    const auto action = RadioStatusOwnership::applyRemoteAudioRxStatus(
+        m_rxAudio, object, kvs, clientHandle(), allowUnknownOwner);
+
+    if (action == RadioStatusOwnership::RemoteAudioRxAction::NotRemoteAudio)
+        return false;
+
+    const auto stream = RadioStatusOwnership::parseStreamObject(object);
+    const QString streamText = stream.valid
+        ? RadioStatusOwnership::hexId(stream.streamId)
+        : QStringLiteral("(unknown)");
+
+    switch (action) {
+    case RadioStatusOwnership::RemoteAudioRxAction::DeferredUnknownOwner:
+        qCDebug(lcProtocol) << "RadioModel: deferred remote_audio_rx status without client_handle"
+                            << streamText;
+        break;
+    case RadioStatusOwnership::RemoteAudioRxAction::IgnoredOtherClient:
+        qCDebug(lcProtocol) << "RadioModel: ignored remote_audio_rx for another client"
+                            << streamText;
+        break;
+    case RadioStatusOwnership::RemoteAudioRxAction::Adopted:
+        qCDebug(lcProtocol) << "RadioModel: adopted owned remote_audio_rx status"
+                            << streamText;
+        logRemoteAudioRxSummary(QStringLiteral("status adopted"));
+        break;
+    case RadioStatusOwnership::RemoteAudioRxAction::Updated:
+        qCDebug(lcProtocol) << "RadioModel: updated owned remote_audio_rx status"
+                            << streamText;
+        logRemoteAudioRxSummary(QStringLiteral("status updated"));
+        break;
+    case RadioStatusOwnership::RemoteAudioRxAction::Removed:
+        qCDebug(lcProtocol) << "RadioModel: owned remote_audio_rx removed"
+                            << streamText;
+        logRemoteAudioRxSummary(QStringLiteral("status removed"));
+        break;
+    case RadioStatusOwnership::RemoteAudioRxAction::NotRemoteAudio:
+        break;
+    }
+
+    const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+    const bool autoStartTci = AppSettings::instance().value("AutoStartTCI", "False").toString() == "True";
+    const bool streamNeeded = pcAudio || autoStartTci;
+    if (!streamNeeded && m_rxAudio.streamId != 0
+        && (action == RadioStatusOwnership::RemoteAudioRxAction::Adopted
+            || action == RadioStatusOwnership::RemoteAudioRxAction::Updated)) {
+        qCDebug(lcProtocol) << "RadioModel: removing restored remote_audio_rx because PC audio is disabled";
+        removeRxAudioStream();
+        return true;
+    }
+
+    if (m_rxAudio.removeRequested && m_rxAudio.streamId != 0)
+        removeRxAudioStream();
+
+    return true;
+}
+
+void RadioModel::logRemoteAudioRxSummary(const QString& reason) const
+{
+    const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+    const bool autoStartTci = AppSettings::instance().value("AutoStartTCI", "False").toString() == "True";
+    const bool ownerKnown = m_rxAudio.clientHandle != 0;
+    const bool ownedByUs = ownerKnown && m_rxAudio.clientHandle == clientHandle();
+
+    QStringList fields;
+    fields << QStringLiteral("reason=\"%1\"").arg(reason);
+    fields << QStringLiteral("stream=%1").arg(
+        m_rxAudio.streamId == 0 ? QStringLiteral("(none)")
+                                : RadioStatusOwnership::hexId(m_rxAudio.streamId));
+    fields << QStringLiteral("owner=%1").arg(
+        ownerKnown ? RadioStatusOwnership::hexId(m_rxAudio.clientHandle)
+                   : QStringLiteral("(unknown)"));
+    fields << QStringLiteral("ours=%1").arg(ownerKnown ? (ownedByUs ? QStringLiteral("1") : QStringLiteral("0"))
+                                                       : QStringLiteral("?"));
+    fields << QStringLiteral("pc_audio=%1").arg(pcAudio ? 1 : 0);
+    fields << QStringLiteral("auto_tci=%1").arg(autoStartTci ? 1 : 0);
+    fields << QStringLiteral("pending=%1").arg(m_rxAudio.createPending ? 1 : 0);
+    fields << QStringLiteral("remove_requested=%1").arg(m_rxAudio.removeRequested ? 1 : 0);
+    fields << QStringLiteral("status_seen=%1").arg(m_rxAudio.statusSeen ? 1 : 0);
+    if (!m_rxAudio.compression.isEmpty())
+        fields << QStringLiteral("compression=%1").arg(m_rxAudio.compression);
+
+    qCInfo(lcProtocol).noquote()
+        << "RadioModel: remote_audio_rx summary" << fields.join(QLatin1Char(' '));
 }
 
 quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
@@ -2395,6 +2554,7 @@ void RadioModel::onStatusReceived(const QString& object,
     // Relay to listeners (e.g., MemoryDialog)
     emit statusReceived(object, kvs);
 
+    handleRemoteAudioRxStreamStatus(object, kvs);
     traceDaxStreamStatus(object, kvs);
 
     if (object == "radio") {
@@ -2665,23 +2825,19 @@ void RadioModel::onStatusReceived(const QString& object,
                     pan->setPreamp(pre);
             }
 
-            if (!m_panadapters.contains(panId)) {
-                // Only create PanadapterModel when client_handle is present
-                // AND matches our handle. Early status messages may arrive
-                // without client_handle — defer until ownership is confirmed.
-                // This prevents briefly adopting another Multi-Flex client's pan.
-                if (!kvs.contains("client_handle")) {
-                    m_pendingPanStatuses[panId] = kvs;
-                    return;  // defer — can't confirm ownership yet
-                }
-                quint32 owner = parseClientHandle(kvs["client_handle"]);
-                if (owner != clientHandle()) {
-                    m_pendingPanStatuses.remove(panId);
-                    return;  // not our panadapter, ignore
-                }
-
-                ensureOwnedPanadapter(panId);
+            const bool knownPan = m_panadapters.contains(panId);
+            const auto ownershipAction = RadioStatusOwnership::classifyOwnedStatus(
+                knownPan, kvs, false, clientHandle());
+            if (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Defer) {
+                m_pendingPanStatuses[panId] = kvs;
+                return;  // defer — can't confirm ownership yet
             }
+            if (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Ignore) {
+                m_pendingPanStatuses.remove(panId);
+                return;  // not our panadapter, ignore
+            }
+            if (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Claim)
+                ensureOwnedPanadapter(panId);
             handlePanadapterStatus(panId, kvs);
         }
         return;
@@ -3609,35 +3765,17 @@ void RadioModel::resetPanState()
 void RadioModel::createAudioStream()
 {
     // Remove old audio stream first, then create new one in the callback
-    if (!m_rxAudioStreamId.isEmpty()) {
-        const QString oldId = m_rxAudioStreamId;
-        m_rxAudioStreamId.clear();
+    if (m_rxAudio.streamId != 0) {
+        const quint32 oldId = m_rxAudio.streamId;
+        m_rxAudio = {};
         sendCmd(
-            QString("stream remove 0x%1").arg(oldId),
+            QString("stream remove %1").arg(RadioStatusOwnership::hexId(oldId)),
             [this](int, const QString&) {
                 // Old stream removed — now create the new one
-                sendCmd(
-                    QString("stream create type=remote_audio_rx compression=%1").arg(audioCompressionParam()),
-                    [this](int code, const QString& body) {
-                        if (code == 0) {
-                            m_rxAudioStreamId = body.trimmed();
-                            qCDebug(lcProtocol) << "RadioModel: remote_audio_rx stream re-created, id:" << m_rxAudioStreamId;
-                        } else
-                            qCWarning(lcProtocol) << "RadioModel: stream create remote_audio_rx failed, code"
-                                       << Qt::hex << code << "body:" << body;
-                    });
+                createRxAudioStream();
             });
     } else {
-        sendCmd(
-            QString("stream create type=remote_audio_rx compression=%1").arg(audioCompressionParam()),
-            [this](int code, const QString& body) {
-                if (code == 0) {
-                    m_rxAudioStreamId = body.trimmed();
-                    qCDebug(lcProtocol) << "RadioModel: remote_audio_rx stream re-created, id:" << m_rxAudioStreamId;
-                } else
-                    qCWarning(lcProtocol) << "RadioModel: stream create remote_audio_rx failed, code"
-                               << Qt::hex << code << "body:" << body;
-            });
+        createRxAudioStream();
     }
 
     sendCmd(
@@ -3715,6 +3853,29 @@ QJsonObject RadioModel::troubleshootingSnapshot() const
     audioOutputs["headphone_mute"] = m_headphoneMute;
     audioOutputs["front_speaker_mute"] = m_frontSpeakerMute;
     radio["audio_outputs"] = audioOutputs;
+
+    const bool pcAudioSetting = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+    const bool autoStartTci = AppSettings::instance().value("AutoStartTCI", "False").toString() == "True";
+    QJsonObject remoteAudioRx;
+    remoteAudioRx["stream_id"] = m_rxAudio.streamId == 0
+        ? QJsonValue()
+        : QJsonValue(RadioStatusOwnership::hexId(m_rxAudio.streamId));
+    remoteAudioRx["stream_id_known"] = m_rxAudio.streamId != 0;
+    remoteAudioRx["create_pending"] = m_rxAudio.createPending;
+    remoteAudioRx["remove_requested"] = m_rxAudio.removeRequested;
+    remoteAudioRx["status_seen"] = m_rxAudio.statusSeen;
+    remoteAudioRx["owner_known"] = m_rxAudio.clientHandle != 0;
+    remoteAudioRx["owned_by_us"] = m_rxAudio.clientHandle != 0 && m_rxAudio.clientHandle == ourClientHandle();
+    remoteAudioRx["compression"] = m_rxAudio.compression;
+    remoteAudioRx["pc_audio_setting"] = pcAudioSetting;
+    remoteAudioRx["auto_start_tci"] = autoStartTci;
+    remoteAudioRx["stream_expected"] = pcAudioSetting || autoStartTci;
+    remoteAudioRx["routing_note"] = pcAudioSetting
+        ? QStringLiteral("PC Audio is enabled; an owned remote_audio_rx stream should exist and the local RX sink should be running.")
+        : (autoStartTci
+               ? QStringLiteral("PC Audio is disabled, but AutoStartTCI requires remote_audio_rx for TCI audio while the local RX sink stays off.")
+               : QStringLiteral("PC Audio and AutoStartTCI are disabled; no remote_audio_rx stream is expected."));
+    radio["remote_audio_rx"] = remoteAudioRx;
 
     QJsonObject filterSharpness;
     filterSharpness["voice_level"] = m_filterVoice;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -19,6 +19,7 @@
 #include "DaxIqModel.h"
 #include "NavtexModel.h"
 #include "MemoryEntry.h"
+#include "RadioStatusOwnership.h"
 
 #include <QObject>
 #include <QString>
@@ -406,6 +407,10 @@ private:
     void handleProfileStatus(const QString& object, const QMap<QString, QString>& kvs);
     void handleProfileStatusRaw(const QString& profileType, const QString& rawBody);
     void traceDaxStreamStatus(const QString& object, const QMap<QString, QString>& kvs);
+    bool handleRemoteAudioRxStreamStatus(const QString& object,
+                                         const QMap<QString, QString>& kvs);
+    void scheduleRxAudioStreamEnsure(const QString& reason);
+    void logRemoteAudioRxSummary(const QString& reason) const;
 
     void configurePan();
     void configureWaterfall();
@@ -620,7 +625,7 @@ private:
     QMap<int, MemoryEntry> m_memories;
     QStringList m_globalProfiles;
     QString     m_activeGlobalProfile;
-    QString     m_rxAudioStreamId;
+    RadioStatusOwnership::RemoteAudioRxTracking m_rxAudio;
     struct DaxStreamDebugState {
         QString type;
         quint32 clientHandle{0};

--- a/src/models/RadioStatusOwnership.h
+++ b/src/models/RadioStatusOwnership.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include "core/CommandParser.h"
+#include "core/StreamStatus.h"
+
+#include <QMap>
+#include <QString>
+
+#include <utility>
+
+namespace AetherSDR::RadioStatusOwnership {
+
+inline QString hexId(quint32 value)
+{
+    return QStringLiteral("0x%1")
+        .arg(QString::number(value, 16).rightJustified(8, QLatin1Char('0')));
+}
+
+inline QString streamCommandId(quint32 value)
+{
+    return value == 0
+        ? QString()
+        : QString::number(value, 16).rightJustified(8, QLatin1Char('0'));
+}
+
+inline quint32 parseFlexId(QString text)
+{
+    return parseStatusHandle(std::move(text));
+}
+
+struct StreamObjectParts {
+    bool valid{false};
+    quint32 streamId{0};
+    QString action;
+};
+
+inline StreamObjectParts parseStreamObject(const QString& object,
+                                           const QString& prefix = QStringLiteral("stream"))
+{
+    if (!object.startsWith(prefix + QLatin1Char(' ')))
+        return {};
+
+    const QString rest = object.mid(prefix.size() + 1).trimmed();
+    const int firstSpace = rest.indexOf(QLatin1Char(' '));
+    const QString idText = firstSpace >= 0 ? rest.left(firstSpace) : rest;
+
+    StreamObjectParts parts;
+    parts.streamId = parseFlexId(idText);
+    parts.valid = parts.streamId != 0;
+    if (firstSpace >= 0)
+        parts.action = rest.mid(firstSpace + 1).trimmed();
+    return parts;
+}
+
+inline bool statusRemoved(const StreamObjectParts& stream,
+                          const QMap<QString, QString>& kvs)
+{
+    return stream.action == QStringLiteral("removed")
+        || kvs.contains(QStringLiteral("removed"))
+        || kvs.value(QStringLiteral("in_use")) == QStringLiteral("0");
+}
+
+enum class OwnedStatusAction {
+    Defer,
+    Claim,
+    Apply,
+    Ignore,
+    Remove
+};
+
+inline OwnedStatusAction classifyOwnedStatus(bool alreadyOwned,
+                                             const QMap<QString, QString>& kvs,
+                                             bool removed,
+                                             quint32 ourHandle)
+{
+    if (removed)
+        return OwnedStatusAction::Remove;
+
+    if (!kvs.contains(QStringLiteral("client_handle")))
+        return alreadyOwned ? OwnedStatusAction::Apply : OwnedStatusAction::Defer;
+
+    const quint32 owner = parseFlexId(kvs.value(QStringLiteral("client_handle")));
+    if (owner == ourHandle)
+        return alreadyOwned ? OwnedStatusAction::Apply : OwnedStatusAction::Claim;
+
+    return OwnedStatusAction::Ignore;
+}
+
+struct RemoteAudioRxTracking {
+    quint32 streamId{0};
+    quint32 clientHandle{0};
+    bool createPending{false};
+    bool removeRequested{false};
+    bool statusSeen{false};
+    QString compression;
+};
+
+enum class RemoteAudioRxAction {
+    NotRemoteAudio,
+    DeferredUnknownOwner,
+    IgnoredOtherClient,
+    Adopted,
+    Updated,
+    Removed
+};
+
+inline quint32 parseCreateResponseStreamId(const QString& body)
+{
+    const auto parseStreamId = [](QString text) -> quint32 {
+        text = text.trimmed();
+        if (text.startsWith(QStringLiteral("0x"), Qt::CaseInsensitive))
+            text = text.mid(2);
+
+        bool ok = false;
+        const quint32 value = text.toUInt(&ok, 16);
+        return ok ? value : 0;
+    };
+
+    const QMap<QString, QString> kvs = CommandParser::parseKVs(body);
+    if (kvs.contains(QStringLiteral("stream")))
+        return parseStreamId(kvs.value(QStringLiteral("stream")));
+    if (kvs.contains(QStringLiteral("id")))
+        return parseStreamId(kvs.value(QStringLiteral("id")));
+    return parseStreamId(body);
+}
+
+inline RemoteAudioRxAction applyRemoteAudioRxStatus(RemoteAudioRxTracking& state,
+                                                    const QString& object,
+                                                    const QMap<QString, QString>& kvs,
+                                                    quint32 ourHandle,
+                                                    bool allowUnknownOwner)
+{
+    const StreamObjectParts stream = parseStreamObject(object);
+    if (!stream.valid)
+        return RemoteAudioRxAction::NotRemoteAudio;
+
+    const QString incomingType = kvs.value(QStringLiteral("type"));
+    const bool matchesKnownStream = state.streamId != 0 && stream.streamId == state.streamId;
+    const bool isRemoteAudioRx = incomingType == QStringLiteral("remote_audio_rx")
+        || matchesKnownStream;
+
+    if (!isRemoteAudioRx)
+        return RemoteAudioRxAction::NotRemoteAudio;
+
+    const bool removed = statusRemoved(stream, kvs);
+    if (removed) {
+        if (matchesKnownStream) {
+            state.streamId = 0;
+            state.clientHandle = 0;
+            state.createPending = false;
+            state.removeRequested = false;
+            state.statusSeen = false;
+            state.compression.clear();
+            return RemoteAudioRxAction::Removed;
+        }
+        return RemoteAudioRxAction::IgnoredOtherClient;
+    }
+
+    if (!kvs.contains(QStringLiteral("client_handle"))) {
+        if (!matchesKnownStream && !allowUnknownOwner)
+            return RemoteAudioRxAction::DeferredUnknownOwner;
+    } else {
+        const quint32 owner = parseFlexId(kvs.value(QStringLiteral("client_handle")));
+        if (owner != 0 && owner != ourHandle)
+            return RemoteAudioRxAction::IgnoredOtherClient;
+        state.clientHandle = owner == 0 ? ourHandle : owner;
+    }
+
+    const bool adopted = state.streamId == 0 || state.streamId != stream.streamId;
+    state.streamId = stream.streamId;
+    if (state.clientHandle == 0)
+        state.clientHandle = ourHandle;
+    state.createPending = false;
+    state.statusSeen = true;
+    if (kvs.contains(QStringLiteral("compression")))
+        state.compression = kvs.value(QStringLiteral("compression"));
+
+    return adopted ? RemoteAudioRxAction::Adopted : RemoteAudioRxAction::Updated;
+}
+
+} // namespace AetherSDR::RadioStatusOwnership

--- a/tests/radio_status_ownership_test.cpp
+++ b/tests/radio_status_ownership_test.cpp
@@ -1,0 +1,143 @@
+#include "models/RadioStatusOwnership.h"
+
+#include <cstdio>
+
+using namespace AetherSDR;
+using namespace AetherSDR::RadioStatusOwnership;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name)
+{
+    if (condition) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n", name);
+        ++failures;
+    }
+}
+
+void testPanadapterOwnershipDecisions()
+{
+    constexpr quint32 ours = 0x12345678;
+    QMap<QString, QString> noOwner;
+    QMap<QString, QString> ourOwner{{QStringLiteral("client_handle"), QStringLiteral("0x12345678")}};
+    QMap<QString, QString> otherOwner{{QStringLiteral("client_handle"), QStringLiteral("0x87654321")}};
+
+    check(classifyOwnedStatus(false, noOwner, false, ours) == OwnedStatusAction::Defer,
+          "unknown pan without client_handle is deferred");
+    check(classifyOwnedStatus(false, ourOwner, false, ours) == OwnedStatusAction::Claim,
+          "unknown pan with our client_handle is claimed");
+    check(classifyOwnedStatus(false, otherOwner, false, ours) == OwnedStatusAction::Ignore,
+          "unknown pan with another client_handle is ignored");
+    check(classifyOwnedStatus(true, noOwner, false, ours) == OwnedStatusAction::Apply,
+          "known pan can apply legacy status without client_handle");
+    check(classifyOwnedStatus(true, otherOwner, false, ours) == OwnedStatusAction::Ignore,
+          "known pan ignores conflicting other-client status");
+    check(classifyOwnedStatus(false, noOwner, true, ours) == OwnedStatusAction::Remove,
+          "pan removal wins over ownership uncertainty");
+}
+
+void testRemoteAudioRxTracking()
+{
+    constexpr quint32 ours = 0x12345678;
+    RemoteAudioRxTracking state;
+
+    QMap<QString, QString> otherRemoteAudio{
+        {QStringLiteral("type"), QStringLiteral("remote_audio_rx")},
+        {QStringLiteral("client_handle"), QStringLiteral("0x87654321")}
+    };
+    check(applyRemoteAudioRxStatus(state,
+                                   QStringLiteral("stream 0x0400000A"),
+                                   otherRemoteAudio,
+                                   ours,
+                                   false) == RemoteAudioRxAction::IgnoredOtherClient,
+          "remote_audio_rx for another client is ignored");
+    check(state.streamId == 0, "ignored remote_audio_rx does not set stream id");
+
+    QMap<QString, QString> noOwnerRemoteAudio{
+        {QStringLiteral("type"), QStringLiteral("remote_audio_rx")}
+    };
+    check(applyRemoteAudioRxStatus(state,
+                                   QStringLiteral("stream 0x0400000A"),
+                                   noOwnerRemoteAudio,
+                                   ours,
+                                   false) == RemoteAudioRxAction::DeferredUnknownOwner,
+          "remote_audio_rx without owner is deferred when other clients may exist");
+    check(state.streamId == 0, "deferred remote_audio_rx does not set stream id");
+
+    check(applyRemoteAudioRxStatus(state,
+                                   QStringLiteral("stream 0x0400000A"),
+                                   noOwnerRemoteAudio,
+                                   ours,
+                                   true) == RemoteAudioRxAction::Adopted,
+          "remote_audio_rx without owner is adopted for legacy single-client status");
+    check(state.streamId == 0x0400000A, "legacy remote_audio_rx adoption records stream id");
+
+    state = {};
+    state.createPending = true;
+    QMap<QString, QString> ourRemoteAudio{
+        {QStringLiteral("type"), QStringLiteral("remote_audio_rx")},
+        {QStringLiteral("client_handle"), QStringLiteral("0x12345678")},
+        {QStringLiteral("compression"), QStringLiteral("NONE")}
+    };
+    check(applyRemoteAudioRxStatus(state,
+                                   QStringLiteral("stream 0x0400000B"),
+                                   ourRemoteAudio,
+                                   ours,
+                                   false) == RemoteAudioRxAction::Adopted,
+          "owned remote_audio_rx status before create callback is adopted");
+    check(state.streamId == 0x0400000B, "owned remote_audio_rx status records stream id");
+    check(!state.createPending, "owned remote_audio_rx status clears create pending");
+    check(state.clientHandle == ours, "owned remote_audio_rx status records owner");
+    check(state.compression == QStringLiteral("NONE"), "owned remote_audio_rx status records compression");
+
+    check(applyRemoteAudioRxStatus(state,
+                                   QStringLiteral("stream 0x0400000B"),
+                                   QMap<QString, QString>{},
+                                   ours,
+                                   false) == RemoteAudioRxAction::Updated,
+          "known remote_audio_rx can apply later status without type or owner");
+
+    check(applyRemoteAudioRxStatus(state,
+                                   QStringLiteral("stream 0x0400000B removed"),
+                                   QMap<QString, QString>{},
+                                   ours,
+                                   false) == RemoteAudioRxAction::Removed,
+          "known remote_audio_rx removal clears stream");
+    check(state.streamId == 0, "removed remote_audio_rx clears stream id");
+}
+
+void testCreateResponseParsing()
+{
+    check(parseCreateResponseStreamId(QStringLiteral("4000009")) == 0x04000009,
+          "numeric-only bare create response stream id parses as hex");
+    check(parseCreateResponseStreamId(QStringLiteral("400000A")) == 0x0400000A,
+          "alpha bare create response stream id parses as hex");
+    check(parseCreateResponseStreamId(QStringLiteral("stream=0x0400000B")) == 0x0400000B,
+          "keyed create response stream id parses");
+    check(parseCreateResponseStreamId(QStringLiteral("stream=4000009")) == 0x04000009,
+          "numeric-only keyed create response stream id parses as hex");
+    check(streamCommandId(0x0400000A) == QStringLiteral("0400000a"),
+          "stream command id is normalized for stream remove");
+}
+
+} // namespace
+
+int main()
+{
+    std::printf("Radio status ownership tests\n\n");
+    testPanadapterOwnershipDecisions();
+    testRemoteAudioRxTracking();
+    testCreateResponseParsing();
+
+    if (failures) {
+        std::printf("\n%d failure(s)\n", failures);
+        return 1;
+    }
+
+    std::printf("\nAll tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes the PC Audio / multi-slice audio startup failure by hardening `remote_audio_rx` stream ownership tracking and parsing.

This PR is intentionally stacked on #2222 (`Fix multi-client startup panadapter creation`) so the follow-on audio changes use the same ownership helper and avoid drifting from the panadapter fix. Until #2222 lands, the PR diff will include that base commit; after #2222 merges, this branch can be rebased and the visible diff should collapse to the PC Audio-specific changes.

## Root Cause

The failing logs showed that slices were valid and unmuted, and PC Audio was enabled, but the audio engine never received remote audio packets.

The key sequence was:

- AetherSDR requested `stream create type=remote_audio_rx compression=none`
- The radio reported the real stream status as `stream 0x04000009 type=remote_audio_rx ... client_handle=<ours>`
- The create response body returned `4000009`
- AetherSDR parsed bare `4000009` as decimal instead of unprefixed hex
- That produced `0x003d0909` instead of `0x04000009`
- AetherSDR then believed the status stream and create-response stream were different, removed the real stream `0x04000009`, and left the audio engine with no incoming remote audio packets

That explains why single-slice and multi-slice audio both failed: the shared `remote_audio_rx` pipe was being removed, so no slice-level audio state could recover it.

## What Changed

- Added `RadioStatusOwnership` as a shared, testable helper for client ownership decisions and remote audio stream tracking.
- Parse `remote_audio_rx` create-response stream ids as Flex stream ids, including bare numeric-looking responses like `4000009` as hex.
- Adopt owned `remote_audio_rx` stream status if it arrives before the create callback.
- Defer initial stream creation briefly during connect so restored/SmartConnect status can settle before requesting another stream.
- Avoid stealing or deleting streams owned by another client.
- Keep legacy no-`client_handle` compatibility for older firmware while deferring unknown-owner status in multi-client scenarios.
- Add duplicate cleanup only when the parsed create response is truly a different stream.
- Add summary logging for `remote_audio_rx` state transitions, including stream id, owner, PC Audio state, AutoStartTCI state, pending create/remove state, and compression.
- Surface remote audio stream state in Slice Troubleshooter diagnostics.
- Register the new regression test with CTest.

## Issue Coverage

This covers the PC Audio issue cluster where Windows users needed multiple toggles or saw no audio after connect:

- #2037
- #1418
- #1473

It also preserves and tests the ownership behavior needed by #2222 / #2194:

- multi-client panadapter startup ownership
- SmartSDR/DAX running before AetherSDR
- older firmware status lines without `client_handle`

## Validation

Automated checks:

- `cmake -S . -B build -G Ninja`
- `cmake --build build -j10`
- `ctest --test-dir build --output-on-failure -j10`
- `build/radio_status_ownership_test`
- `git diff --check`

Manual radio validation by @jensenpat:

- Multi-slice PC Audio works.
- PC Audio toggled 10 times; audio returned every time.
- SmartSDR and DAX started before AetherSDR; AetherSDR audio still worked.
- Completed two TCI RX2-channel FT8 QSOs.
- Completed DAX-based FT8 QSOs.

## Reviewer Notes

The most important regression test is the exact log-derived case:

- `parseCreateResponseStreamId("4000009") == 0x04000009`

Without this, AetherSDR stores the wrong id, removes the real stream, and the audio engine watchdog reports repeated `no audio data received` restarts.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
