### PR TITLE
ShackSwitch: remove hardcoded callsign from device detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -994,11 +994,11 @@ management feature (clear all, band grouping, auto-expiry).
   server-speaks-first (`V1.0 AG`).  Result: AetherSDR waits for the
   greeting, R4 waits for client data → TCP deadlock → every AG
   connect silently hangs.
-- Detect ShackSwitch devices (`serial.startsWith("G0JKN")` or
-  `name.contains("ShackSwitch")`) and send an empty `\r\n` on TCP
-  connect.  R4 firmware discards empty lines before the greeting,
-  protocol proceeds normally.  Real 4O3A Antenna Genius devices do
-  not match the check — zero impact on existing AG behaviour.
+- Detect ShackSwitch devices (`name.contains("ShackSwitch")`) and send
+  an empty `\r\n` on TCP connect.  R4 firmware discards empty lines
+  before the greeting, protocol proceeds normally.  Real 4O3A Antenna
+  Genius devices do not match the check — zero impact on existing AG
+  behaviour.
 - Also fix a reconnect-race by replacing the `if (m_connected)` guard
   with an unconditional socket abort in `connectToDevice`, plus
   add an `isConnecting()` helper for UI state.

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -739,7 +739,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         m_appletOrder.append(entry);
     }
 
-    // ShackSwitch applet — shown instead of/alongside AG for G0JKN ShackSwitch devices
+    // ShackSwitch applet — shown instead of/alongside AG for ShackSwitch devices
     m_ssApplet = new ShackSwitchApplet;
     {
         auto entry = makeEntry("SS", "ShackSwitch", m_ssApplet, false, btnRow1, btnLayout1);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3451,7 +3451,7 @@ MainWindow::MainWindow(QWidget* parent)
 
     // ── Antenna Genius / ShackSwitch applets ────────────────────────────────
     // Both share AntennaGeniusModel (ShackSwitch speaks the AG protocol).
-    // On device discovery we check the serial: G0JKN-* → ShackSwitch applet,
+    // On device discovery we check the name: "ShackSwitch" → ShackSwitch applet,
     // anything else → Antenna Genius applet. On device lost, hide both.
     m_appletPanel->agApplet()->setModel(&m_antennaGenius);
     m_appletPanel->ssApplet()->setModel(&m_antennaGenius);
@@ -6899,14 +6899,14 @@ void MainWindow::onConnectionStateChanged(bool connected)
                 m_pgxlConn.connectToPgxl(pgxlIp, pgxlPort);
             }
             // If SS_ManualIp is set, connect to ShackSwitch immediately using a
-            // G0JKN serial so device-type detection works from the start.
+            // synthetic serial so device-type detection works from the start.
             // This bypasses the UDP discovery race condition entirely.
             QString ssIp = cs.value("SS_ManualIp", "").toString();
             if (!ssIp.isEmpty() && !m_antennaGenius.isConnected()) {
                 AgDeviceInfo ssInfo;
                 ssInfo.ip         = QHostAddress(ssIp);
                 ssInfo.port       = 9007;
-                ssInfo.serial     = QStringLiteral("G0JKN-manual");
+                ssInfo.serial     = QStringLiteral("ShackSwitch-manual");
                 ssInfo.name       = QStringLiteral("ShackSwitch");
                 ssInfo.radioPorts = 1;  // ShackSwitch is always single-radio
                 m_antennaGenius.connectToDevice(ssInfo);

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -3741,7 +3741,7 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
                 AgDeviceInfo info;
                 info.ip     = QHostAddress(ip);
                 info.port   = 9007;
-                info.serial = QStringLiteral("G0JKN-manual");
+                info.serial = QStringLiteral("ShackSwitch-manual");
                 info.name   = QStringLiteral("ShackSwitch");
                 m_ag->connectToDevice(info);
             },

--- a/src/gui/ShackSwitchApplet.cpp
+++ b/src/gui/ShackSwitchApplet.cpp
@@ -296,16 +296,14 @@ void ShackSwitchApplet::setModel(AntennaGeniusModel* model)
 
     connect(m_model, &AntennaGeniusModel::deviceDiscovered, this,
             [this](const AgDeviceInfo& info) {
-        const bool isShackSwitch = info.serial.startsWith("G0JKN") ||
-                                   info.name.contains("ShackSwitch", Qt::CaseInsensitive);
+        const bool isShackSwitch = info.name.contains("ShackSwitch", Qt::CaseInsensitive);
         if (isShackSwitch && !m_model->isConnected() && !m_model->isConnecting())
             m_model->connectToDevice(info);
     });
 
     connect(m_model, &AntennaGeniusModel::connected, this, [this]() {
         const auto& dev = m_model->connectedDevice();
-        bool isShackSwitch = dev.serial.startsWith("G0JKN") ||
-                             dev.name.contains("ShackSwitch", Qt::CaseInsensitive);
+        bool isShackSwitch = dev.name.contains("ShackSwitch", Qt::CaseInsensitive);
         if (!isShackSwitch) return;
 
         QString ip = dev.ip.toString();
@@ -416,8 +414,7 @@ void ShackSwitchApplet::updateInputHeaders()
     const auto portB = m_model->portB();
 
     const auto& dev = m_model->connectedDevice();
-    const bool isShackSwitch = dev.serial.startsWith("G0JKN") ||
-                               dev.name.contains("ShackSwitch", Qt::CaseInsensitive);
+    const bool isShackSwitch = dev.name.contains("ShackSwitch", Qt::CaseInsensitive);
     const bool singlePort = isShackSwitch && dev.radioPorts < 2;
     const int  activeAnt  = singlePort
                           ? (portA.rxAntenna > 0 ? portA.rxAntenna : portB.rxAntenna)
@@ -451,8 +448,7 @@ void ShackSwitchApplet::checkConflict(int rxA, int rxB)
     // Single-port: no B port, nothing to conflict
     if (!m_model) return;
     const auto& dev = m_model->connectedDevice();
-    const bool singlePort = (dev.serial.startsWith("G0JKN") ||
-                             dev.name.contains("ShackSwitch", Qt::CaseInsensitive))
+    const bool singlePort = dev.name.contains("ShackSwitch", Qt::CaseInsensitive)
                             && dev.radioPorts < 2;
     if (singlePort) {
         m_blinkTimer.stop();
@@ -544,8 +540,7 @@ void ShackSwitchApplet::onBlinkTick()
     m_blinkState = !m_blinkState;
     if (!m_model) return;
     const auto& dev = m_model->connectedDevice();
-    const bool singlePort = (dev.serial.startsWith("G0JKN") ||
-                             dev.name.contains("ShackSwitch", Qt::CaseInsensitive))
+    const bool singlePort = dev.name.contains("ShackSwitch", Qt::CaseInsensitive)
                             && dev.radioPorts < 2;
     const auto portA = m_model->portA();
     const auto portB = m_model->portB();

--- a/src/gui/ShackSwitchApplet.h
+++ b/src/gui/ShackSwitchApplet.h
@@ -12,9 +12,9 @@ namespace AetherSDR {
 
 class AntennaGeniusModel;
 
-// ShackSwitch applet — compact antenna switcher panel for G0JKN ShackSwitch.
+// ShackSwitch applet — compact antenna switcher panel for ShackSwitch devices.
 //
-// Detected by AG-protocol serial "G0JKN-SW". Replaces the generic AG applet
+// Detected by AG-protocol device name "ShackSwitch". Replaces the generic AG applet
 // layout with a single antenna list and compact Input A / Input B header cards.
 //
 // Layout (top to bottom):

--- a/src/models/AntennaGeniusModel.cpp
+++ b/src/models/AntennaGeniusModel.cpp
@@ -243,8 +243,7 @@ void AntennaGeniusModel::onTcpConnected()
     // For ShackSwitch (R4) the server speaks first ("V1.0 AG"), so we send an
     // empty line to trigger available() on the R4 side without affecting the
     // protocol (the R4 discards empty lines before the greeting is sent).
-    const bool isShackSwitch = m_device.serial.startsWith("G0JKN") ||
-                               m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
+    const bool isShackSwitch = m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
     if (isShackSwitch && m_tcpSocket) {
         m_tcpSocket->write("\r\n");
         m_tcpSocket->flush();
@@ -298,7 +297,7 @@ void AntennaGeniusModel::onTcpReadyRead()
                 qCDebug(lcTuner) << "AntennaGenius: prologue received, version"
                          << m_device.version;
                 // If connected via manual IP, enrich from UDP-discovered list.
-                // Matches "G0JKN-manual" (ShackSwitch) and legacy "manual-<ip>" serials.
+                // Matches "ShackSwitch-manual" and legacy "manual-<ip>" serials.
                 if (m_device.serial.endsWith("-manual") || m_device.serial.startsWith("manual-")) {
                     for (const auto& d : m_discoveredDevices) {
                         if (!d.ip.isNull() && d.ip == m_device.ip) {
@@ -558,8 +557,7 @@ void AntennaGeniusModel::selectAntenna(int portId, int antennaId)
     // Prevent selecting an antenna already in use by the other port.
     // Antenna 0 (deselect) is always allowed.
     // ShackSwitch is a single-radio device — no port B conflict is possible.
-    const bool isShackSwitch = m_device.serial.startsWith("G0JKN") ||
-                               m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
+    const bool isShackSwitch = m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
     if (!isShackSwitch) {
         const auto& otherPort = (portId == 1) ? m_portB : m_portA;
         if (antennaId > 0 && otherPort.rxAntenna == antennaId) {
@@ -675,8 +673,7 @@ void AntennaGeniusModel::setRadioFrequency(double freqMhz)
     if (matchedBand == 0) return;
 
     // ShackSwitch manages its own band→antenna mapping — don't override it.
-    const bool isShackSwitch = m_device.serial.startsWith("G0JKN") ||
-                               m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
+    const bool isShackSwitch = m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
     if (isShackSwitch) {
         qCDebug(lcTuner) << "AG-FREQ: ShackSwitch connected — skipping auto-recall";
         return;
@@ -718,8 +715,7 @@ void AntennaGeniusModel::onBandChanged(int portId, int oldBand, int oldAnt, int 
              << bandName(oldBand) << "→" << bandName(newBand);
 
     // ShackSwitch manages its own band→antenna mapping — don't override it.
-    const bool isShackSwitch = m_device.serial.startsWith("G0JKN") ||
-                               m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
+    const bool isShackSwitch = m_device.name.contains("ShackSwitch", Qt::CaseInsensitive);
     if (isShackSwitch) {
         qCDebug(lcTuner) << "AntennaGenius: ShackSwitch connected — skipping band recall for port" << portId;
         return;
@@ -788,8 +784,7 @@ bool AntennaGeniusModel::canRxOnBand(int antennaId, int bandId) const
 
 bool AntennaGeniusModel::isShackSwitch(const AgDeviceInfo& info)
 {
-    return info.serial.startsWith(QStringLiteral("G0JKN")) ||
-           info.name.contains(QStringLiteral("ShackSwitch"), Qt::CaseInsensitive);
+    return info.name.contains(QStringLiteral("ShackSwitch"), Qt::CaseInsensitive);
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces all `serial.startsWith("G0JKN")` checks with the generic `name.contains("ShackSwitch")` that was already the second condition in every `||` expression
- Changes the synthetic manual-IP serial from `"G0JKN-manual"` → `"ShackSwitch-manual"`
- Updates all related comments and the CHANGELOG entry

## Why

The `G0JKN` prefix is the author's personal callsign. The ShackSwitch firmware constructs its serial from the operator's callsign in `config.json`, so any other user's device would broadcast a different prefix and fail detection entirely. The device `name` field is always `"ShackSwitch"` (set from a firmware constant) and is the correct generic discriminator. No functional change for the original device.

Raised by Jeremy (KK7GWY) — thanks for the catch.

## Files changed

| File | Change |
|------|--------|
| `AntennaGeniusModel.cpp` | 4× inline checks + static `isShackSwitch()` |
| `ShackSwitchApplet.cpp` | 4× inline checks |
| `ShackSwitchApplet.h` | Header comment |
| `MainWindow.cpp` | Sentinel serial + comment |
| `RadioSetupDialog.cpp` | Sentinel serial |
| `AppletPanel.cpp` | Comment |
| `CHANGELOG.md` | Entry updated |

## Test plan

- [ ] Auto-connect via UDP discovery: ShackSwitch broadcasts `name="ShackSwitch"` — applet loads as before
- [ ] Manual IP connect (`SS_ManualIp`): serial now `"ShackSwitch-manual"`, `name="ShackSwitch"` still set alongside — detection still works
- [ ] Real 4O3A AG device: `name` does not contain "ShackSwitch" — zero impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)