### PR TITLE
Read radio-side SWR meter when sweeping through TGXL bypass

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10852,8 +10852,13 @@ void MainWindow::startSwrSweep(int requestedSliceId, int sweepPowerWatts)
     m_swrSweep.tgxlOriginalOperate = tuner.isOperate();
     m_swrSweep.tgxlOriginalBypass = tuner.isBypass();
     if (tuner.isPresent() && tuner.isOperate()) {
-        m_swrSweep.meterSource = SwrSweepMeterSource::Tgxl;
         m_swrSweep.sourceLabel = QStringLiteral("TGXL BYPASS");
+        // Read radio-side SWR even when TGXL is bypassed: in bypass the TGXL
+        // is a passive wire-through and stops emitting RL meter packets, so
+        // tgxlSwrUpdatedAtMs never advances.  The radio's SWR coupler sees
+        // the antenna directly through the bypassed relays — equivalent
+        // reading, reliably emitted during the tune carrier.  (#2229)
+        m_swrSweep.meterSource = SwrSweepMeterSource::Radio;
         if (!tuner.isBypass()) {
             m_swrSweep.tgxlBypassRequested = true;
             m_swrSweep.tgxlRestoreNeeded = true;


### PR DESCRIPTION
Closes #2229

## Problem

SWR sweep aborts with `SWR sweep stopped: no fresh TGXL SWR meter data` whenever the user has a TGXL in OPERATE mode at sweep start.

The pre-sweep logic at [MainWindow.cpp:10854-10856](src/gui/MainWindow.cpp#L10854) selects `meterSource = Tgxl`, then commands the TGXL into BYPASS to measure raw antenna SWR. Once in bypass the TGXL is a passive wire-through — its measurement engine stops emitting `RL` (return-loss → SWR) meter packets, so `tgxlSwrUpdatedAtMs()` never advances past `sampleNotBeforeMs` and the per-step freshness check times out at 900 ms.

## Fix

While the TGXL is bypassed, the radio's own SWR coupler sees the same physical signal — the radio measures directly through the bypassed TGXL relays. The reading is equivalent and arrives reliably during the tune carrier.

Switch the meter source to `Radio` while keeping the `"TGXL BYPASS"` UI label so users still see what configuration is in use.

```cpp
if (tuner.isPresent() && tuner.isOperate()) {
    m_swrSweep.sourceLabel = QStringLiteral("TGXL BYPASS");
    // Read radio-side SWR even when TGXL is bypassed: in bypass the TGXL
    // is a passive wire-through and stops emitting RL meter packets, so
    // tgxlSwrUpdatedAtMs never advances.  The radio's SWR coupler sees
    // the antenna directly through the bypassed relays — equivalent
    // reading, reliably emitted during the tune carrier.  (#2229)
    m_swrSweep.meterSource = SwrSweepMeterSource::Radio;
    if (!tuner.isBypass()) {
        m_swrSweep.tgxlBypassRequested = true;
        m_swrSweep.tgxlRestoreNeeded = true;
    }
}
```

## Test plan

- [x] Build clean on Linux
- [x] On-air test with FLEX-8600 + TGXL in OPERATE — sweep runs to completion, TGXL restored to OPERATE after sweep
- [ ] CI green

## Follow-up

The `SwrSweepMeterSource::Tgxl` branch is now effectively dead — no operating mode prefers TGXL meters over radio meters during a sweep (TGXL OPERATE during sweep would defeat the raw-antenna-SWR purpose; BYPASS makes the radio reading equivalent and more reliable). Could be removed in a follow-up cleanup PR.

cc @jensenpat — small fix on top of your AetherSweep work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)