### PR TITLE
Fix RX slice tab capacity initialization

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2213,8 +2213,15 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_appletPanel->rxApplet(), &RxApplet::sliceActivationRequested,
             this, &MainWindow::setActiveSlice);
     // Initialize slice tab buttons once the radio reports its actual capacity
-    connect(&m_radioModel, &RadioModel::infoChanged, this, [this]() {
+    connect(&m_radioModel, &RadioModel::infoChanged, this,
+            [this, initialized = false]() mutable {
+        if (initialized || m_radioModel.model().isEmpty()) {
+            return;
+        }
+
         m_appletPanel->setMaxSlices(m_radioModel.maxSlices());
+        m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
+        initialized = true;
     });
 
     // software_ver arrives after onConnectionStateChanged, so refresh the label

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -998,7 +998,9 @@ void RxApplet::setAfGain(int pct)
 void RxApplet::setMaxSlices(int maxSlices)
 {
     // Only create buttons once
-    if (!m_sliceBtns.isEmpty()) return;
+    if (!m_sliceBtns.isEmpty()) {
+        return;
+    }
 
     if (maxSlices <= 1) {
         m_sliceTabRow->setVisible(false);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1351,7 +1351,10 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                             else if (key == "name")        m_nickname = val;
                             else if (key == "region")      m_region = val;
                             else if (key == "options")     m_radioOptions = val;
-                            else if (key == "model")       m_model = val;
+                            else if (key == "model") {
+                                m_model = val;
+                                m_maxSlices = maxSlicesForModel(m_model);
+                            }
                             else if (key == "chassis_serial") m_chassisSerial = val;
                             else if (key == "software_ver")   m_version = val;
                             else if (key == "ip")             m_ip = val;


### PR DESCRIPTION
## Summary
- Recompute radio slice capacity when the TCP info response supplies the radio model
- Delay RX Controls slice tab creation until the radio model is known, avoiding transient availability counts such as A-G on an 8-slice FLEX-6700
- Refresh slice tab enabled/checked state immediately after creating the selector so already-open slices are highlighted

## Testing
- cmake --build build
- ctest --test-dir build --output-on-failure