### PR TITLE
Refresh radio model label when info arrives

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2217,8 +2217,10 @@ MainWindow::MainWindow(QWidget* parent)
         m_appletPanel->setMaxSlices(m_radioModel.maxSlices());
     });
 
-    // software_ver arrives after onConnectionStateChanged, so refresh the label
+    // Radio info can arrive after onConnectionStateChanged, so refresh the labels.
     connect(&m_radioModel, &RadioModel::infoChanged, this, [this]() {
+        if (m_radioInfoLabel && !m_radioModel.model().isEmpty())
+            m_radioInfoLabel->setText(m_radioModel.model());
         if (m_radioVersionLabel && !m_radioModel.version().isEmpty())
             m_radioVersionLabel->setText(m_radioModel.version());
     });


### PR DESCRIPTION
## Summary

Fixes a status bar bug where the radio model number could be missing above the version number after connecting.

`onConnectionStateChanged()` populates the status bar immediately, but radio info such as `model` can arrive later through `RadioModel::infoChanged`. The version label already refreshed on `infoChanged`; this change refreshes the model label on the same signal when a non-empty model is available.

## Testing

- Configured with CMake/Ninja in `/private/tmp/aethersdr-build-radio-model-status`
- Built successfully with `cmake --build /private/tmp/aethersdr-build-radio-model-status`
- Confirmed the radio model appears above the version number when launching the built app