### PR TITLE
Fix TGXL presence when detected via direct TCP only (Fixes #2174)

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2940,6 +2940,20 @@ void RadioModel::onStatusReceived(const QString& object,
         if (m.hasMatch()) {
             const QString handle = m.captured(1);
             const QString model = kvs.value("model");
+            qCDebug(lcProtocol) << "RadioModel: amplifier status handle=" << handle << "model=" << model;
+
+            // Handle removal
+            if (kvs.contains("removed")) {
+                if (handle == m_tunerModel.handle())
+                    m_tunerModel.setHandle({});
+                if (handle == m_ampHandle) {
+                    m_ampHandle.clear();
+                    m_hasAmplifier = false;
+                    m_ampModel.clear();
+                    emit amplifierChanged(false);
+                }
+                return;
+            }
 
             // Route TunerGeniusXL to TunerModel
             if (model == "TunerGeniusXL" || handle == m_tunerModel.handle()) {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2934,15 +2934,37 @@ void RadioModel::onStatusReceived(const QString& object,
     //   model=TunerGeniusXL  → antenna tuner (TGXL)
     //   model=PowerGeniusXL  → power amplifier (PGXL)
     // "amplifier <handle> model=TunerGeniusXL operate=1 relayC1=20 ..."
+    //
+    // Removal can arrive in two forms (matches FlexLib Radio.cs:14060/14073
+    // which uses substring `s.Contains("removed")`):
+    //   1) bare:  "amplifier <handle> removed"        → trailing token, no '='
+    //   2) kvs:   "amplifier <handle> ... removed=1"  → key in kvs map
+    // Form 1 lands in `object` because our parser treats a body with no '='
+    // as all-object-name; form 2 lands in `kvs` as a normal key.
     static const QRegularExpression ampRe(R"(^amplifier\s+(\S+)$)");
+    static const QRegularExpression ampRemovedRe(R"(^amplifier\s+(\S+)\s+removed$)");
     if (object.startsWith("amplifier")) {
+        const auto rm = ampRemovedRe.match(object);
+        if (rm.hasMatch()) {
+            const QString handle = rm.captured(1);
+            qCDebug(lcProtocol) << "RadioModel: amplifier removed (bare) handle=" << handle;
+            if (handle == m_tunerModel.handle())
+                m_tunerModel.setHandle({});
+            if (handle == m_ampHandle) {
+                m_ampHandle.clear();
+                m_hasAmplifier = false;
+                m_ampModel.clear();
+                emit amplifierChanged(false);
+            }
+            return;
+        }
         const auto m = ampRe.match(object);
         if (m.hasMatch()) {
             const QString handle = m.captured(1);
             const QString model = kvs.value("model");
             qCDebug(lcProtocol) << "RadioModel: amplifier status handle=" << handle << "model=" << model;
 
-            // Handle removal
+            // Handle removal (kvs form)
             if (kvs.contains("removed")) {
                 if (handle == m_tunerModel.handle())
                     m_tunerModel.setHandle({});

--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -17,9 +17,9 @@ TunerModel::TunerModel(QObject* parent)
 void TunerModel::setHandle(const QString& handle)
 {
     if (m_handle == handle) return;
-    bool wasPres = !m_handle.isEmpty();
+    bool wasPres = isPresent();
     m_handle = handle;
-    bool nowPres = !m_handle.isEmpty();
+    bool nowPres = isPresent();
     qCDebug(lcTuner) << "TunerModel: handle set to" << m_handle;
     if (wasPres != nowPres)
         emit presenceChanged(nowPres);
@@ -145,10 +145,17 @@ void TunerModel::setDirectConnection(TgxlConnection* conn)
     if (m_directConn) {
         connect(m_directConn, &TgxlConnection::connected, this, [this]() {
             qCDebug(lcTuner) << "TunerModel: direct TGXL connection established";
+            bool wasPres = isPresent();
+            m_directPresence = true;
+            if (!wasPres)
+                emit presenceChanged(true);
             emit directConnectionChanged(true);
         });
         connect(m_directConn, &TgxlConnection::disconnected, this, [this]() {
             qCDebug(lcTuner) << "TunerModel: direct TGXL connection lost";
+            m_directPresence = false;
+            if (!isPresent())
+                emit presenceChanged(false);
             emit directConnectionChanged(false);
         });
         // Update relay values from direct state pushes

--- a/src/models/TunerModel.h
+++ b/src/models/TunerModel.h
@@ -39,7 +39,7 @@ public:
     float   fwdPower()  const { return m_fwdPower; }  // forward power in watts (from direct TGXL status)
     float   swr()       const { return m_swr; }       // SWR ratio (from direct TGXL status)
     bool    hasAntennaSwitch() const { return m_oneByThree; }  // true for TGXL 3x1 model (one_by_three=1)
-    bool    isPresent() const { return !m_handle.isEmpty(); }
+    bool    isPresent() const { return !m_handle.isEmpty() || m_directPresence; }
     bool    hasDirectConnection() const;
 
     // Apply key=value pairs from a TCP status message.
@@ -88,6 +88,7 @@ private:
     bool    m_oneByThree{false}; // true for TGXL 3x1 model (from one_by_three=1)
 
     TgxlConnection* m_directConn{nullptr};
+    bool            m_directPresence{false};
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Summary

Fixes #2174 — TUN applet not visible when the radio (Flex-8600 firmware 4.2.18) does not report the TGXL via the amplifier API.

### Root cause

`presenceChanged(true)` was only emitted from `setHandle()`, which requires the radio to push `amplifier <handle> model=TunerGeniusXL`. The existing `directConnectionChanged` signal fired correctly on direct TCP connect (port 9010) but was never wired to `presenceChanged` — leaving the TUN applet permanently hidden even though the device was fully operational.

Confirmed by protocol log: on this firmware the radio never sends an amplifier status for the TGXL. The PGXL is reported normally (`model=PowerGeniusXL`).

### Changes

**`TunerModel.h/.cpp`** — add `m_directPresence` fallback flag:
- `isPresent()` returns `!m_handle.isEmpty() || m_directPresence`
- `connected` lambda: sets `m_directPresence = true`, emits `presenceChanged(true)` if handle is absent
- `disconnected` lambda: clears `m_directPresence`, emits `presenceChanged(false)` only if handle is also empty
- `setHandle()` uses `isPresent()` for before/after comparison so clearing the handle does not hide the applet while a direct connection is live

**`RadioModel.cpp`** — two diagnostic/correctness improvements:
- Log every amplifier status handle + model at `lcProtocol` debug level (previously silent on no-match, making firmware-variant bugs undiagnosable)
- Handle amplifier removal via `kvs.contains("removed")`, clearing `TunerModel` handle or `m_ampHandle`/`m_hasAmplifier` as appropriate (previously only cleared on radio disconnect)

### Testing

Flex-8600 firmware 4.2.18.41174, TGXL firmware 1.1.20, AetherSDR v0.9.4.

![TUN applet visible with direct TCP connection](https://github.com/user-attachments/assets/placeholder)

TUN applet now appears, relay positions display correctly, TUNE initiates autotune cycle. Operate/standby via radio API requires a valid amplifier handle (unavailable when the radio omits the amplifier status message) — this is a pre-existing limitation tracked separately.

### Notes for reviewer

- `RadioModel.cpp` is touched only for logging and the removal handler — no behavioural change to the existing TGXL/PGXL routing logic
- The `m_directPresence` flag is intentionally separate from `m_handle` so the two presence sources don't interfere with each other