### PR TITLE
Widen AppletPanel scrollbar and add hover-reveal for accessibility

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -39,6 +39,9 @@
 #include "core/AppSettings.h"
 #include <QPushButton>
 #include <QScrollArea>
+#include <QScrollBar>
+#include <QStyle>
+#include <QTimer>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -368,12 +371,23 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_scrollArea->setFrameShape(QFrame::NoFrame);
     m_scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_scrollArea->setWidgetResizable(true);
+    // Handle dims to #2a3a4a at rest, brightens to #4a6880 on hover/drag.
+    // 500 ms delay before dimming back so quick drags don't flicker.
     m_scrollArea->setStyleSheet(
-        "QScrollBar:vertical { background: transparent; width: 12px; }"
-        "QScrollBar:vertical:hover { background: #0a0a14; }"
-        "QScrollBar::handle:vertical { background: transparent; border-radius: 4px; min-height: 20px; }"
-        "QScrollBar::handle:vertical:hover, QScrollBar::handle:vertical:pressed { background: #4a6880; }"
+        "QScrollBar:vertical { background: #0a0a14; width: 12px; }"
+        "QScrollBar::handle:vertical { background: #2a3a4a; border-radius: 4px; min-height: 20px; }"
+        "QScrollBar::handle:vertical[active=\"true\"] { background: #4a6880; }"
         "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }");
+
+    if (auto* sb = m_scrollArea->verticalScrollBar()) {
+        sb->setProperty("active", false);
+        sb->installEventFilter(this);
+    }
+    m_scrollDimTimer = new QTimer(this);
+    m_scrollDimTimer->setSingleShot(true);
+    m_scrollDimTimer->setInterval(500);
+    connect(m_scrollDimTimer, &QTimer::timeout, this,
+            [this]() { setScrollHandleActive(false); });
 
     auto* container = new QWidget;
     m_stack = new QVBoxLayout(container);
@@ -1104,5 +1118,35 @@ void AppletPanel::setTxDspChainOrder(
     }
 }
 
+bool AppletPanel::eventFilter(QObject* obj, QEvent* ev)
+{
+    if (m_scrollArea && obj == m_scrollArea->verticalScrollBar()) {
+        switch (ev->type()) {
+        case QEvent::Enter:
+        case QEvent::MouseButtonPress:
+            if (m_scrollDimTimer) m_scrollDimTimer->stop();
+            setScrollHandleActive(true);
+            break;
+        case QEvent::Leave:
+        case QEvent::MouseButtonRelease:
+            if (m_scrollDimTimer) m_scrollDimTimer->start();
+            break;
+        default:
+            break;
+        }
+    }
+    return QWidget::eventFilter(obj, ev);
+}
+
+void AppletPanel::setScrollHandleActive(bool active)
+{
+    if (!m_scrollArea) return;
+    auto* sb = m_scrollArea->verticalScrollBar();
+    if (!sb) return;
+    if (sb->property("active").toBool() == active) return;
+    sb->setProperty("active", active);
+    sb->style()->unpolish(sb);
+    sb->style()->polish(sb);
+}
 
 } // namespace AetherSDR

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -369,8 +369,10 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_scrollArea->setWidgetResizable(true);
     m_scrollArea->setStyleSheet(
-        "QScrollBar:vertical { background: #0a0a14; width: 6px; }"
-        "QScrollBar::handle:vertical { background: #304050; border-radius: 3px; }"
+        "QScrollBar:vertical { background: transparent; width: 12px; }"
+        "QScrollBar:vertical:hover { background: #0a0a14; }"
+        "QScrollBar::handle:vertical { background: transparent; border-radius: 4px; min-height: 20px; }"
+        "QScrollBar::handle:vertical:hover, QScrollBar::handle:vertical:pressed { background: #4a6880; }"
         "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }");
 
     auto* container = new QWidget;

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -10,6 +10,7 @@
 class QComboBox;
 class QPushButton;
 class QScrollArea;
+class QTimer;
 class QVBoxLayout;
 
 namespace AetherSDR {
@@ -175,10 +176,14 @@ public:
 
     friend class AppletDropArea;
 
+protected:
+    bool eventFilter(QObject* obj, QEvent* ev) override;
+
 private:
     void rebuildStackOrder();
     void saveOrder();
     int dropIndexFromY(int localY) const;
+    void setScrollHandleActive(bool active);
 
     ContainerManager* m_containerMgr{nullptr};
     ContainerWidget*  m_rootSidebar{nullptr};
@@ -228,6 +233,7 @@ private:
     QPushButton* m_ssBtn{nullptr};
     QVBoxLayout* m_stack{nullptr};
     QScrollArea* m_scrollArea{nullptr};
+    QTimer*      m_scrollDimTimer{nullptr};
     QWidget*     m_dropIndicator{nullptr};
     QPushButton* m_lockBtn{nullptr};   // controls-lock toggle (#745)
 


### PR DESCRIPTION
## Summary

- Increases applet panel scrollbar width from `6px` → `12px`, in line with the native OS default (~12–16px) that users were accustomed to before #2088
- Scrollbar is hidden until the user hovers over the right edge of the panel, then reveals the dark track and handle — works on macOS, Linux, and Windows
- Adds `:pressed` state so the handle stays visible while actively dragging (previously disappeared mid-scroll)
- Brightens the handle colour (`#304050` → `#4a6880`) for better contrast against the dark track
- Adds `min-height: 20px` to the handle so it never shrinks to an unclickable sliver with many applets loaded

## Background

PR #2088 introduced explicit dark-theme scrollbar styling to fix macOS hiding the bar entirely. The chosen `6px` width is significantly thinner than the ~12–16px native default users were accustomed to. Before #2088 there was no stylesheet applied, so the OS rendered its own full-width bar.

User feedback:
> *"The scroll bar on the applet panel is now very narrow. It was better before when it was wide. It's hard for us old guys with shacky hands to hit it so narrow."*

The Qt stylesheet change uses standard QSS properties and should apply uniformly across macOS, Linux, and Windows, though only tested on macOS.

## Files modified

- `src/gui/AppletPanel.cpp`

## Design note for maintainer

Width (12px), handle colour (#4a6880), and hover-reveal behaviour are open to adjustment — flagging per CLAUDE.md since this is a visual design change.

## Test plan
- [ ] Build and confirm scrollbar is hidden at rest, visible on hover
- [ ] Confirm handle stays visible while dragging (`:pressed` state)
- [ ] Confirm behaviour on Linux and Windows
- [ ] Confirm no horizontal scrollbar appears (policy: always off)