### PR TITLE
fix(ui): add dark-mode stylesheet to FreeDV Reporter checkboxes

### DIFF
--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1560,6 +1560,12 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     // not above it (avoids group-box title margin clipping on dark themes).
     m_fdvReportCheck = new QCheckBox("Enable FreeDV Reporter reporting when RADE is active");
     m_fdvReportCheck->setChecked(s.value("FreeDvAutoReport", "False").toString() == "True");
+    m_fdvReportCheck->setStyleSheet(
+        "QCheckBox { color: #d7e4f2; spacing: 8px; background: transparent; border: none; }"
+        "QCheckBox::indicator { width: 14px; height: 14px; border: 2px solid #5d748d; border-radius: 3px; background: #0b1520; }"
+        "QCheckBox::indicator:hover { border-color: #81abd9; background: #142130; }"
+        "QCheckBox::indicator:checked { border: 2px solid #8cc8ff; background: #2f71b6; }"
+        "QCheckBox::indicator:disabled { border-color: #405262; background: #10161d; }");
     connect(m_fdvReportCheck, &QCheckBox::toggled, this, [this](bool on) {
         if (on) {
             // Resolve the effective callsign and grid the same way
@@ -1629,6 +1635,12 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     m_fdvUseRadioCallsignCheck = new QCheckBox("Use radio");
     m_fdvUseRadioCallsignCheck->setChecked(
         s.value("FreeDvUseRadioCallsign", "True").toString() == "True");
+    m_fdvUseRadioCallsignCheck->setStyleSheet(
+        "QCheckBox { color: #d7e4f2; spacing: 8px; background: transparent; border: none; }"
+        "QCheckBox::indicator { width: 14px; height: 14px; border: 2px solid #5d748d; border-radius: 3px; background: #0b1520; }"
+        "QCheckBox::indicator:hover { border-color: #81abd9; background: #142130; }"
+        "QCheckBox::indicator:checked { border: 2px solid #8cc8ff; background: #2f71b6; }"
+        "QCheckBox::indicator:disabled { border-color: #405262; background: #10161d; }");
     connect(m_fdvUseRadioCallsignCheck, &QCheckBox::toggled, this, [this](bool on) {
         auto& as = AppSettings::instance();
         as.setValue("FreeDvUseRadioCallsign", on ? "True" : "False");
@@ -1664,6 +1676,12 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     // GPS checkbox — only on FLEX-8000 class and Aurora, which have GPS hardware
     if (m_radioModel->hasGpsHardware()) {
         m_fdvUseGpsCheck = new QCheckBox("Use GPS");
+        m_fdvUseGpsCheck->setStyleSheet(
+            "QCheckBox { color: #d7e4f2; spacing: 8px; background: transparent; border: none; }"
+            "QCheckBox::indicator { width: 14px; height: 14px; border: 2px solid #5d748d; border-radius: 3px; background: #0b1520; }"
+            "QCheckBox::indicator:hover { border-color: #81abd9; background: #142130; }"
+            "QCheckBox::indicator:checked { border: 2px solid #8cc8ff; background: #2f71b6; }"
+            "QCheckBox::indicator:disabled { border-color: #405262; background: #10161d; }");
         bool useGps = s.value("FreeDvUseGpsGrid", "True").toString() == "True";
         m_fdvUseGpsCheck->setChecked(useGps);
         m_fdvGridEdit->setReadOnly(useGps);

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1556,16 +1556,18 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     reportLayout->setColumnStretch(1, 1);
     int frow = 0;
 
-    // Enable checkbox spans all columns so it sits reliably inside the grid,
-    // not above it (avoids group-box title margin clipping on dark themes).
-    m_fdvReportCheck = new QCheckBox("Enable FreeDV Reporter reporting when RADE is active");
-    m_fdvReportCheck->setChecked(s.value("FreeDvAutoReport", "False").toString() == "True");
-    m_fdvReportCheck->setStyleSheet(
+    const QString fdvCheckStyle =
         "QCheckBox { color: #d7e4f2; spacing: 8px; background: transparent; border: none; }"
         "QCheckBox::indicator { width: 14px; height: 14px; border: 2px solid #5d748d; border-radius: 3px; background: #0b1520; }"
         "QCheckBox::indicator:hover { border-color: #81abd9; background: #142130; }"
         "QCheckBox::indicator:checked { border: 2px solid #8cc8ff; background: #2f71b6; }"
-        "QCheckBox::indicator:disabled { border-color: #405262; background: #10161d; }");
+        "QCheckBox::indicator:disabled { border-color: #405262; background: #10161d; }";
+
+    // Enable checkbox spans all columns so it sits reliably inside the grid,
+    // not above it (avoids group-box title margin clipping on dark themes).
+    m_fdvReportCheck = new QCheckBox("Enable FreeDV Reporter reporting when RADE is active");
+    m_fdvReportCheck->setChecked(s.value("FreeDvAutoReport", "False").toString() == "True");
+    m_fdvReportCheck->setStyleSheet(fdvCheckStyle);
     connect(m_fdvReportCheck, &QCheckBox::toggled, this, [this](bool on) {
         if (on) {
             // Resolve the effective callsign and grid the same way
@@ -1635,12 +1637,7 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     m_fdvUseRadioCallsignCheck = new QCheckBox("Use radio");
     m_fdvUseRadioCallsignCheck->setChecked(
         s.value("FreeDvUseRadioCallsign", "True").toString() == "True");
-    m_fdvUseRadioCallsignCheck->setStyleSheet(
-        "QCheckBox { color: #d7e4f2; spacing: 8px; background: transparent; border: none; }"
-        "QCheckBox::indicator { width: 14px; height: 14px; border: 2px solid #5d748d; border-radius: 3px; background: #0b1520; }"
-        "QCheckBox::indicator:hover { border-color: #81abd9; background: #142130; }"
-        "QCheckBox::indicator:checked { border: 2px solid #8cc8ff; background: #2f71b6; }"
-        "QCheckBox::indicator:disabled { border-color: #405262; background: #10161d; }");
+    m_fdvUseRadioCallsignCheck->setStyleSheet(fdvCheckStyle);
     connect(m_fdvUseRadioCallsignCheck, &QCheckBox::toggled, this, [this](bool on) {
         auto& as = AppSettings::instance();
         as.setValue("FreeDvUseRadioCallsign", on ? "True" : "False");
@@ -1676,12 +1673,7 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     // GPS checkbox — only on FLEX-8000 class and Aurora, which have GPS hardware
     if (m_radioModel->hasGpsHardware()) {
         m_fdvUseGpsCheck = new QCheckBox("Use GPS");
-        m_fdvUseGpsCheck->setStyleSheet(
-            "QCheckBox { color: #d7e4f2; spacing: 8px; background: transparent; border: none; }"
-            "QCheckBox::indicator { width: 14px; height: 14px; border: 2px solid #5d748d; border-radius: 3px; background: #0b1520; }"
-            "QCheckBox::indicator:hover { border-color: #81abd9; background: #142130; }"
-            "QCheckBox::indicator:checked { border: 2px solid #8cc8ff; background: #2f71b6; }"
-            "QCheckBox::indicator:disabled { border-color: #405262; background: #10161d; }");
+        m_fdvUseGpsCheck->setStyleSheet(fdvCheckStyle);
         bool useGps = s.value("FreeDvUseGpsGrid", "True").toString() == "True";
         m_fdvUseGpsCheck->setChecked(useGps);
         m_fdvGridEdit->setReadOnly(useGps);


### PR DESCRIPTION
## Summary

- The three `QCheckBox` widgets in the FreeDV tab → Station Reporting group (enable reporting, use radio callsign, use GPS) had no indicator stylesheet, making their outlines invisible in dark mode
- Applied the standard dark-mode indicator style used elsewhere in the codebase (matching `ConnectionPanel` and other dialogs): `#5d748d` border, hover highlight, checked fill `#2f71b6`/`#8cc8ff`, and disabled state

Fixes #2213

## Test plan

- [x] Open Spothub dialog → FreeDV tab → Station Reporting
- [x] Verify all three checkboxes show a visible border in dark mode (unchecked, checked, hover states)
- [x] Verify no visual regression in other tabs or dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)