### PR TITLE
FreeDV Reporter: Update OS reporting to match FreeDV application.

### DIFF
--- a/src/core/FreeDvClient.cpp
+++ b/src/core/FreeDvClient.cpp
@@ -176,11 +176,11 @@ void FreeDvClient::handleEngineIO(const QString& raw)
             auth["version"]          = m_mySoftwareVersion;
             auth["rx_only"]          = false;
 #if defined(Q_OS_WIN)
-            auth["os"]               = QString("Windows");
+            auth["os"]               = QString("windows");
 #elif defined(Q_OS_MAC)
-            auth["os"]               = QString("macOS");
+            auth["os"]               = QString("macos");
 #else
-            auth["os"]               = QString("Linux");
+            auth["os"]               = QString("linux");
 #endif
             auth["protocol_version"] = 2;
         } else {


### PR DESCRIPTION
AetherSDR recently added support for FreeDV Reporter. During my review of the added code (https://github.com/ten9876/AetherSDR/pull/2173), I noticed that the "os" field was using mixed case. This results in AetherSDR users showing as platform "other" (instead of the platform they're actually using) when I run monthly reports prior to the FreeDV project's monthly leadership meetings. This PR updates OS reporting to use all lower-case, same as the official FreeDV application.