### PR TITLE
Sweep: 7 small UI / contrast / indicator-routing fixes

### DIFF
--- a/src/core/FlexControlManager.cpp
+++ b/src/core/FlexControlManager.cpp
@@ -100,14 +100,21 @@ void FlexControlManager::processCommand(const QByteArray& cmd)
         emit tuneSteps(m_invertDirection ? -accel : accel);
 
     } else if (cmd.startsWith('X') && cmd.size() >= 3) {
-        // Button press: X<button><action>
-        //   button: 1, 2, 3, 4 (4 = knob press)
+        // Side-button press: X<button><action>
+        //   button: 1, 2, 3 (side buttons)
         //   action: S=tap(0), C=double-tap(1), L=hold(2)
         int button = cmd.at(1) - '0';
         if (button < 1 || button > 4) return;
         char action = cmd.at(2);
         int actionId = (action == 'S') ? 0 : (action == 'C') ? 1 : 2;
         emit buttonPressed(button, actionId);
+
+    } else if (cmd.size() == 1 && (cmd == "S" || cmd == "C" || cmd == "L")) {
+        // Knob press: bare S/C/L token (no X-prefix). Confirmed via FlexControl
+        // hardware capture (#2263). The knob is button 4 in our action-dropdown
+        // layout, matching the pre-existing X4S/X4C/X4L slot.
+        int actionId = (cmd == "S") ? 0 : (cmd == "C") ? 1 : 2;
+        emit buttonPressed(4, actionId);
 
     } else if (cmd.startsWith('F')) {
         // Init/reset — log and ignore

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3685,9 +3685,6 @@ MainWindow::MainWindow(QWidget* parent)
             m_gpsStatusLabel->setText(QString("[%1]").arg(status));
         }
 
-        if (!grid.isEmpty())
-            m_gridLabel->setText(grid);
-
         // Use GPS UTC time only when GPSDO is installed and locked.
         // GPS with no antenna/lock sends stale "00:00:00Z" — fall back to system clock.
         if (!utcTime.isEmpty()
@@ -4632,7 +4629,7 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
         m_cwxPanel->setVisible(show);
         m_cwxIndicator->setStyleSheet(show
             ? "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }"
-            : "QLabel { color: rgba(255,255,255,40); font-weight: bold; font-size: 24px; }");
+            : "QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
         if (show) {
             auto sizes = m_splitter->sizes();
             if (sizes.size() >= 4) {
@@ -4658,7 +4655,7 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
         m_dvkPanel->setVisible(show);
         m_dvkIndicator->setStyleSheet(show
             ? "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }"
-            : "QLabel { color: rgba(255,255,255,40); font-weight: bold; font-size: 24px; }");
+            : "QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
         if (show) {
             auto sizes = m_splitter->sizes();
             if (sizes.size() >= 4) {
@@ -6572,7 +6569,7 @@ void MainWindow::buildUI()
     hbox->addSpacing(8);
 
     m_tnfIndicator = new QLabel("TNF");
-    m_tnfIndicator->setStyleSheet("QLabel { color: rgba(255,255,255,128); font-weight: bold; font-size: 24px; }");
+    m_tnfIndicator->setStyleSheet(greyIndLg);
     m_tnfIndicator->setCursor(Qt::PointingHandCursor);
     m_tnfIndicator->installEventFilter(this);
     hbox->addWidget(m_tnfIndicator);
@@ -6824,16 +6821,13 @@ void MainWindow::buildUI()
 
     addSep();
 
-    // Grid square (top) + UTC time (bottom) stacked, right-aligned
+    // UTC date (top) + UTC time (bottom) stacked, right-aligned. Two-row
+    // layout matches all other telemetry stacks in the status bar (#1583).
     auto* timeStack = new QWidget;
     timeStack->setMinimumWidth(kTelemetryStackMinWidth);
     auto* timeVbox = new QVBoxLayout(timeStack);
     timeVbox->setContentsMargins(0, 0, 0, 0);
     timeVbox->setSpacing(0);
-    m_gridLabel = new QLabel("");
-    m_gridLabel->setStyleSheet("QLabel { color: #8aa8c0; font-size: 12px; }");
-    m_gridLabel->setAlignment(Qt::AlignCenter);
-    m_gridLabel->setMinimumWidth(kTelemetryStackMinWidth);
     m_gpsDateLabel = new QLabel("");
     m_gpsDateLabel->setStyleSheet("QLabel { color: #8aa8c0; font-size: 12px; }");
     m_gpsDateLabel->setAlignment(Qt::AlignCenter);
@@ -6842,7 +6836,6 @@ void MainWindow::buildUI()
     m_gpsTimeLabel->setStyleSheet("QLabel { color: #8aa8c0; font-size: 12px; }");
     m_gpsTimeLabel->setAlignment(Qt::AlignCenter);
     m_gpsTimeLabel->setMinimumWidth(kTelemetryStackMinWidth);
-    timeVbox->addWidget(m_gridLabel);
     timeVbox->addWidget(m_gpsDateLabel);
     timeVbox->addWidget(m_gpsTimeLabel);
     hbox->addWidget(timeStack);
@@ -8478,7 +8471,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     connect(tnf, &TnfModel::globalEnabledChanged,
             this, [this](bool on) {
         m_tnfIndicator->setStyleSheet(on
-            ? "QLabel { color: #00e060; font-weight: bold; font-size: 24px; }"
+            ? "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }"
             : "QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
     });
 
@@ -8486,7 +8479,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     connect(&m_radioModel, &RadioModel::infoChanged, this, [this]() {
         bool fdx = m_radioModel.fullDuplexEnabled();
         m_fdxIndicator->setStyleSheet(fdx
-            ? "QLabel { color: #00e060; font-weight: bold; font-size: 24px; }"
+            ? "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }"
             : "QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
     });
     connect(sw, &SpectrumWidget::tnfCreateRequested,   tnf, &TnfModel::createTnf);
@@ -9790,7 +9783,7 @@ SpectrumWidget* MainWindow::spectrumForSlice(SliceModel* s) const
 void MainWindow::updateKeyerAvailability(const QString& mode)
 {
     static const QString kActive   = "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }";
-    static const QString kAvail    = "QLabel { color: rgba(255,255,255,40); font-weight: bold; font-size: 24px; }";
+    static const QString kAvail    = "QLabel { color: #404858; font-weight: bold; font-size: 24px; }";
     static const QString kDisabled = "QLabel { color: #252530; font-weight: bold; font-size: 24px; }";
 
     bool isCw  = (mode == "CW" || mode == "CWL");

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -347,7 +347,6 @@ private:
     QLabel* m_stationNickLabel{nullptr};
     QLabel* m_gpsLabel{nullptr};
     QLabel* m_gpsStatusLabel{nullptr};
-    QLabel* m_gridLabel{nullptr};
     QLabel* m_bandStackIndicator{nullptr};
     QLabel* m_cpuLabel{nullptr};
     QLabel* m_memLabel{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2512,7 +2512,8 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
         // "pan drag", treat it as a click-to-tune instead
         if (m_singleClickTune && ev->button() == Qt::LeftButton && !m_spotClickConsumed) {
             QPoint delta = ev->position().toPoint() - m_clickPressPos;
-            if (delta.manhattanLength() <= 4) {
+            if (delta.manhattanLength() <= 4
+                && !m_indicatorStripRect.contains(ev->position().toPoint())) {
                 const int mx = static_cast<int>(ev->position().x());
                 if (mx < width() - DBM_STRIP_W) {
                     double rawMhz = xToMhz(mx);
@@ -2528,7 +2529,8 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
     // Single-click-to-tune in FFT area (not consumed by pan drag)
     if (m_singleClickTune && ev->button() == Qt::LeftButton && !m_spotClickConsumed) {
         QPoint delta = ev->position().toPoint() - m_clickPressPos;
-        if (delta.manhattanLength() <= 4) {
+        if (delta.manhattanLength() <= 4
+            && !m_indicatorStripRect.contains(ev->position().toPoint())) {
             const int mx = static_cast<int>(ev->position().x());
             if (mx < width() - DBM_STRIP_W) {
                 double rawMhz = xToMhz(mx);
@@ -3402,6 +3404,12 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                     int x = specRect.right() - DBM_STRIP_W - 8 - fm.horizontalAdvance(label);
                     p.drawText(x, y, label);
 
+                    // Bounding rect of the full strip — used to suppress
+                    // single-click-to-tune when clicking on these indicators (#1564).
+                    m_indicatorStripRect = QRect(x, y - fm.ascent(),
+                                                 fm.horizontalAdvance(label),
+                                                 fm.height());
+
                     // Store click rect for the prop portion only
                     if (showProp) {
                         QString propText = QString("K%1  A%2  SFI %3")
@@ -3413,6 +3421,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                     } else {
                         m_propClickRect = QRect();
                     }
+                } else {
+                    m_indicatorStripRect = QRect();
                 }
 
                 // MQTT device status overlay (#699)
@@ -4057,6 +4067,13 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
             } else {
                 m_propClickRect = QRect();
             }
+
+            // Bounding rect of the full strip (prop + WNB + RF Gain + WIDE) —
+            // used to suppress single-click-to-tune within (#1564).
+            m_indicatorStripRect = QRect(x, topY - fm.ascent(),
+                                         rightEdge - x, fm.height());
+        } else {
+            m_indicatorStripRect = QRect();
         }
     }
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -580,6 +580,9 @@ private:
     bool m_propForecastVisible{false};
     double m_propKIndex{-1.0};
     QRect  m_propClickRect;  // bounding rect of rendered prop text for click detection
+    QRect  m_indicatorStripRect;  // bounding rect of full top-right indicator strip
+                                  // (prop + WNB + RF Gain + WIDE) — single-click tune
+                                  // is suppressed inside this rect (#1564)
     int  m_propAIndex{-1};
     int  m_propSfi{-1};
 

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -101,7 +101,8 @@ TitleBar::TitleBar(QWidget* parent)
     m_hbox->addSpacing(4);
 #endif
 
-    auto* appName = new QLabel("AetherSDR");
+    auto* appName = new QLabel(
+        QString("AetherSDR v%1").arg(QCoreApplication::applicationVersion()));
     appName->setStyleSheet("QLabel { color: #00b4d8; font-size: 14px; font-weight: bold; }");
     appName->setAlignment(Qt::AlignCenter);
     m_hbox->addWidget(appName);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -407,11 +407,19 @@ void VfoWidget::buildUI()
     // Close and lock buttons — children of our parent (SpectrumWidget) so they
     // can render outside our bounds. Lifecycle managed by VfoWidget destructor.
     auto* btnParent = parentWidget() ? parentWidget() : this;
+
+    // Shared base style for the four 20x20 slice-side buttons (close, lock,
+    // record, play). All use the same background circle so they line up
+    // visually when stacked vertically on the slice edge.
+    static const QString sliceBtnStyle =
+        "QPushButton { background: rgba(255,255,255,30); border: none; "
+        "border-radius: 10px; font-size: 11px; padding: 0; }"
+        "QPushButton:hover { background: rgba(255,255,255,60); }";
+
     m_closeSliceBtn = new QPushButton("\xE2\x9C\x95", btnParent);  // ✕
     m_closeSliceBtn->setFixedSize(20, 20);
-    m_closeSliceBtn->setStyleSheet(
-        "QPushButton { background: rgba(255,255,255,15); border: none; "
-        "border-radius: 10px; color: #c8d8e8; font-size: 11px; padding: 0; }"
+    m_closeSliceBtn->setStyleSheet(sliceBtnStyle +
+        "QPushButton { color: #c8d8e8; }"
         "QPushButton:hover { background: rgba(204,32,32,180); color: #ffffff; }");
     m_closeSliceBtn->show();
     connect(m_closeSliceBtn, &QPushButton::clicked, this, [this] {
@@ -421,11 +429,8 @@ void VfoWidget::buildUI()
     m_lockVfoBtn = new QPushButton("\xF0\x9F\x94\x93", btnParent);  // 🔓
     m_lockVfoBtn->setFixedSize(20, 20);
     m_lockVfoBtn->setCheckable(true);
-    m_lockVfoBtn->setStyleSheet(
-        "QPushButton { background: rgba(255,255,255,15); border: none; "
-        "border-radius: 10px; font-size: 12px; padding: 0; }"
-        "QPushButton:checked { background: rgba(255,100,100,80); }"
-        "QPushButton:hover { background: rgba(255,255,255,40); }");
+    m_lockVfoBtn->setStyleSheet(sliceBtnStyle +
+        "QPushButton:checked { background: rgba(255,100,100,80); }");
     m_lockVfoBtn->show();
     connect(m_lockVfoBtn, &QPushButton::toggled, this, [this](bool locked) {
         m_lockVfoBtn->setText(locked ? "\xF0\x9F\x94\x92" : "\xF0\x9F\x94\x93");
@@ -433,18 +438,14 @@ void VfoWidget::buildUI()
     });
 
     // Record button
-    static const QString sliceBtnStyle =
-        "QPushButton { background: rgba(255,255,255,15); border: none; "
-        "border-radius: 10px; font-size: 11px; padding: 0; }"
-        "QPushButton:hover { background: rgba(255,255,255,40); }";
 
     m_recordBtn = new QPushButton(QString::fromUtf8("\xe2\x8f\xba"), btnParent);  // ⏺
     m_recordBtn->setFixedSize(20, 20);
     m_recordBtn->setCheckable(true);
     m_recordBtn->setToolTip("Record slice audio");
     m_recordBtn->setStyleSheet(sliceBtnStyle +
-        "QPushButton { color: #d04040; }"
-        "QPushButton:checked { color: #ff2020; background: rgba(255,50,50,60); }");
+        "QPushButton { color: #c06060; }"
+        "QPushButton:checked { color: #ff2020; background: rgba(255,50,50,110); }");
     m_recordBtn->show();
     connect(m_recordBtn, &QPushButton::clicked, this, [this](bool checked) {
         emit recordToggled(checked);
@@ -458,11 +459,11 @@ void VfoWidget::buildUI()
         static bool dim = false;
         dim = !dim;
         m_recordBtn->setStyleSheet(
-            "QPushButton { background: rgba(255,255,255,15); border: none; "
+            "QPushButton { background: rgba(255,255,255,30); border: none; "
             "border-radius: 10px; font-size: 11px; padding: 0; "
-            "color: " + QString(dim ? "#601010" : "#ff2020") + "; "
-            "background: rgba(255,50,50," + QString(dim ? "20" : "60") + "); }"
-            "QPushButton:hover { background: rgba(255,255,255,40); }");
+            "color: " + QString(dim ? "#a03030" : "#ff3030") + "; "
+            "background: rgba(255,50,50," + QString(dim ? "50" : "120") + "); }"
+            "QPushButton:hover { background: rgba(255,255,255,60); }");
     });
 
     // Play button
@@ -472,9 +473,9 @@ void VfoWidget::buildUI()
     m_playBtn->setEnabled(false);
     m_playBtn->setToolTip("Play recorded audio");
     m_playBtn->setStyleSheet(sliceBtnStyle +
-        "QPushButton { color: #70b070; }"
-        "QPushButton:checked { color: #30d050; background: rgba(50,200,80,60); }"
-        "QPushButton:disabled { color: #505050; background: rgba(255,255,255,5); }");
+        "QPushButton { color: #60a070; }"
+        "QPushButton:checked { color: #30d050; background: rgba(50,200,80,110); }"
+        "QPushButton:disabled { color: #484848; background: rgba(255,255,255,15); }");
     m_playBtn->show();
     connect(m_playBtn, &QPushButton::clicked, this, [this](bool checked) {
         emit playToggled(checked);
@@ -2750,10 +2751,10 @@ void VfoWidget::setRecordOn(bool on)
         // Restore normal checked style
         if (m_recordBtn)
             m_recordBtn->setStyleSheet(
-                "QPushButton { background: rgba(255,255,255,15); border: none; "
-                "border-radius: 10px; font-size: 11px; padding: 0; color: #804040; }"
-                "QPushButton:checked { color: #ff2020; background: rgba(255,50,50,60); }"
-                "QPushButton:hover { background: rgba(255,255,255,40); }");
+                "QPushButton { background: rgba(255,255,255,30); border: none; "
+                "border-radius: 10px; font-size: 11px; padding: 0; color: #c06060; }"
+                "QPushButton:checked { color: #ff2020; background: rgba(255,50,50,110); }"
+                "QPushButton:hover { background: rgba(255,255,255,60); }");
     }
 }
 

--- a/third_party/ggmorse/src/ggmorse.cpp
+++ b/third_party/ggmorse/src/ggmorse.cpp
@@ -84,7 +84,7 @@ const TAlphabet kMorseCode = {
     { "011010",  '@',  },
     { "0101",    '\xC6', }, // Æ (also Ä) — Latin-1 0xC6
     { "1110",    '\xD8', }, // Ø (also Ö) — Latin-1 0xD8
-    { "01110",   '\xC5', }, // Å          — Latin-1 0xC5
+    { "01101",   '\xC5', }, // Å          — Latin-1 0xC5  (·−−·− per ITU-R M.1677-1)
 };
 
 uint64_t t_us() {


### PR DESCRIPTION
Bundles seven independently-verified maintainer-reviewed fixes:

- #2027 TitleBar headline now shows running version number — regressed
  with frameless-window mode (#1926). Restored via the same
  applicationVersion() pattern used by setWindowTitle().

- #2263 FlexControl knob press tokens are bare S/C/L (not X4S/X4C/X4L).
  Verified against hardware capture from LB2EG: side buttons emit
  X1S/X1C/X1L/X2S/.../X3L (parsed correctly today), knob press emits
  bare S/C/L. Adds a new branch in processCommand() mapping the bare
  tokens to buttonPressed(4, action), keeping the X-prefix path for
  the side buttons. Dead X4S path retained as defense in depth.

- #2264 ggmorse Å sequence corrected from 01110 to 01101 per
  ITU-R M.1677-1. Confirmed Æ (0101) and Ø (1110) on the same lines
  are unaffected.

- #1564 K/SFI/WNB/RF Gain/WIDE indicator strip click suppression. New
  m_indicatorStripRect tracks the full strip in both paint paths;
  mouseReleaseEvent guards skip the frequency emit when single-click
  tune lands inside the strip. Existing m_propClickRect dialog click
  is unaffected.

- #1576 Slice record (⏺) and play (▶) button visibility. Roughly
  doubled alpha values across all four stylesheet locations and
  brightened the inactive icon colors so the buttons are legible
  against the #0a0a14 spectrum background.

- #1581 + the close (✕) and lock (🔓) buttons on each slice header
  now share a single sliceBtnStyle base with record/play, ensuring
  identical 20px circles. Status indicators (TNF/CWX/DVK/FDX) all
  use cyan #00b4d8 for active and #404858 for off; TNF init colour
  fixed (was rgba(255,255,255,128)). updateKeyerAvailability() and
  the CWX/DVK click handlers now use #404858 instead of
  rgba(255,255,255,40) for the off-state, so DVK in voice mode
  matches the rest of the indicator strip when not in use.

- #1583 Status-bar time stack reduced from 3 rows to 2 (date + UTC
  time) by removing the grid-square label, matching every other
  telemetry stack. m_gridLabel removed from MainWindow.h.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
