### PR TITLE
Stabilize DAX2 coexistence policy

### DIFF
--- a/src/core/DaxTxPolicy.h
+++ b/src/core/DaxTxPolicy.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <QString>
+#include <QtGlobal>
+
+namespace AetherSDR {
+
+enum class DaxTxRequestReason {
+    HostedDaxBridge,
+    TciTxAudio,
+    ExternalDaxRouteOnly,
+    GenericAudioRecreate
+};
+
+enum class DaxTxPlatform {
+    Windows,
+    MacOS,
+    Linux,
+    Other
+};
+
+enum class DaxTxMode {
+    None,
+    HostedDax,
+    ExternalDax2
+};
+
+struct DaxTxPolicyContext {
+    DaxTxRequestReason reason{DaxTxRequestReason::GenericAudioRecreate};
+    DaxTxPlatform platform{DaxTxPlatform::Other};
+    DaxTxMode mode{DaxTxMode::None};
+    bool hostedDaxAvailable{false};
+    bool tciDaxTxSupported{false};
+};
+
+struct DaxTxPolicyDecision {
+    bool allowed{false};
+    QString note;
+};
+
+inline QString daxTxRequestReasonName(DaxTxRequestReason reason)
+{
+    switch (reason) {
+    case DaxTxRequestReason::HostedDaxBridge:     return QStringLiteral("hosted_dax_bridge");
+    case DaxTxRequestReason::TciTxAudio:          return QStringLiteral("tci_tx_audio");
+    case DaxTxRequestReason::ExternalDaxRouteOnly:return QStringLiteral("external_dax_route_only");
+    case DaxTxRequestReason::GenericAudioRecreate:return QStringLiteral("generic_audio_recreate");
+    }
+    return QStringLiteral("unknown");
+}
+
+inline QString daxTxPlatformName(DaxTxPlatform platform)
+{
+    switch (platform) {
+    case DaxTxPlatform::Windows: return QStringLiteral("windows");
+    case DaxTxPlatform::MacOS:   return QStringLiteral("macos");
+    case DaxTxPlatform::Linux:   return QStringLiteral("linux");
+    case DaxTxPlatform::Other:   return QStringLiteral("other");
+    }
+    return QStringLiteral("other");
+}
+
+inline QString daxTxModeName(DaxTxMode mode)
+{
+    switch (mode) {
+    case DaxTxMode::None:         return QStringLiteral("none");
+    case DaxTxMode::HostedDax:    return QStringLiteral("hosted_dax");
+    case DaxTxMode::ExternalDax2: return QStringLiteral("external_dax2");
+    }
+    return QStringLiteral("none");
+}
+
+inline DaxTxPlatform currentDaxTxPlatform()
+{
+#if defined(Q_OS_WIN)
+    return DaxTxPlatform::Windows;
+#elif defined(Q_OS_MAC)
+    return DaxTxPlatform::MacOS;
+#elif defined(Q_OS_LINUX)
+    return DaxTxPlatform::Linux;
+#else
+    return DaxTxPlatform::Other;
+#endif
+}
+
+inline bool currentBuildHasHostedDax()
+{
+#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
+    return true;
+#else
+    return false;
+#endif
+}
+
+inline DaxTxMode currentDaxTxMode()
+{
+#if defined(Q_OS_WIN)
+    return DaxTxMode::ExternalDax2;
+#elif defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
+    return DaxTxMode::HostedDax;
+#else
+    return DaxTxMode::None;
+#endif
+}
+
+inline DaxTxPolicyContext currentDaxTxPolicyContext(DaxTxRequestReason reason)
+{
+    const bool hostedDax = currentBuildHasHostedDax();
+    return DaxTxPolicyContext{
+        reason,
+        currentDaxTxPlatform(),
+        currentDaxTxMode(),
+        hostedDax,
+        hostedDax
+    };
+}
+
+inline DaxTxPolicyDecision evaluateDaxTxPolicy(const DaxTxPolicyContext& context)
+{
+    switch (context.reason) {
+    case DaxTxRequestReason::HostedDaxBridge:
+        if (context.mode == DaxTxMode::HostedDax && context.hostedDaxAvailable)
+            return {true, QStringLiteral("hosted_dax_available")};
+        if (context.mode == DaxTxMode::ExternalDax2)
+            return {false, QStringLiteral("SmartSDR_DAX2_owns_windows_dax")};
+        return {false, QStringLiteral("hosted_dax_unavailable")};
+
+    case DaxTxRequestReason::TciTxAudio:
+        if (context.tciDaxTxSupported)
+            return {true, QStringLiteral("tci_dax_tx_supported")};
+        if (context.mode == DaxTxMode::ExternalDax2)
+            return {false, QStringLiteral("SmartSDR_DAX2_owns_windows_dax")};
+        return {false, QStringLiteral("tci_dax_tx_not_supported")};
+
+    case DaxTxRequestReason::ExternalDaxRouteOnly:
+        if (context.mode == DaxTxMode::ExternalDax2)
+            return {false, QStringLiteral("SmartSDR_DAX2_owns_windows_dax")};
+        return {false, QStringLiteral("route_only_does_not_require_local_stream")};
+
+    case DaxTxRequestReason::GenericAudioRecreate:
+        return {false, QStringLiteral("generic_audio_recreate_not_dax_tx")};
+    }
+
+    return {false, QStringLiteral("unknown_reason")};
+}
+
+} // namespace AetherSDR

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -12,6 +12,49 @@
 
 namespace AetherSDR {
 
+namespace {
+
+constexpr QAbstractSocket::BindMode kLanVitaBindMode = QAbstractSocket::DontShareAddress;
+
+QHostAddress chooseLanBindAddress(RadioConnection* conn,
+                                  QString* chosenReason,
+                                  QHostAddress* chosenAddress,
+                                  RadioBindMode* bindMode)
+{
+    if (chosenReason)
+        chosenReason->clear();
+    if (chosenAddress)
+        *chosenAddress = QHostAddress();
+    if (bindMode)
+        *bindMode = conn ? conn->bindMode() : RadioBindMode::Auto;
+
+    const QHostAddress explicitAddr = conn ? conn->explicitLocalBindAddress() : QHostAddress();
+    const QHostAddress sessionAddr = conn ? conn->sessionLocalBindAddress() : QHostAddress();
+    const QHostAddress tcpAddr = conn ? conn->localAddress() : QHostAddress();
+
+    QHostAddress selectedAddress;
+    QString selectedReason;
+    if (!explicitAddr.isNull() && explicitAddr.protocol() == QAbstractSocket::IPv4Protocol) {
+        selectedAddress = explicitAddr;
+        selectedReason = QStringLiteral("explicit");
+    } else if (!sessionAddr.isNull() && sessionAddr.protocol() == QAbstractSocket::IPv4Protocol) {
+        selectedAddress = sessionAddr;
+        selectedReason = QStringLiteral("probe-session");
+    } else if (!tcpAddr.isNull() && tcpAddr.protocol() == QAbstractSocket::IPv4Protocol) {
+        selectedAddress = tcpAddr;
+        selectedReason = QStringLiteral("tcp-local");
+    }
+
+    if (chosenReason)
+        *chosenReason = selectedReason;
+    if (chosenAddress)
+        *chosenAddress = selectedAddress;
+
+    return selectedAddress.isNull() ? QHostAddress(QHostAddress::AnyIPv4) : selectedAddress;
+}
+
+} // namespace
+
 // ─── VITA-49 header layout (28 bytes, big-endian) ─────────────────────────────
 // Word 0 (bytes  0- 3): Packet header (type=3 ExtData, flags, count, size)
 // Word 1 (bytes  4- 7): Stream ID
@@ -52,7 +95,6 @@ void PanadapterStream::init()
     if (!m_routedPrimeTimer) {
         m_routedPrimeTimer = new QTimer(this);
     }
-
     connect(m_socket, &QUdpSocket::readyRead,
             this, &PanadapterStream::onDatagramReady);
 
@@ -109,50 +151,23 @@ bool PanadapterStream::start(RadioConnection* conn)
     m_previousAudioPacketGapMs = 0;
     m_audioPacketJitterEstimateMs = 0.0;
 
-    // Try 4991 first (VPN/firewall rules may allow this port specifically),
-    // then count down for Multi-Flex (multiple clients on the same host).
-    static constexpr quint16 LAN_VITA_PORT = 4991;
     m_isWanMode = false;
     m_hasReceivedPacket = false;
 
-    // Resolve source address for VPN/routed connections
-    const QHostAddress explicitAddr = conn ? conn->explicitLocalBindAddress() : QHostAddress();
-    const QHostAddress sessionAddr = conn ? conn->sessionLocalBindAddress() : QHostAddress();
-    const QHostAddress tcpAddr = conn ? conn->localAddress() : QHostAddress();
-    const RadioBindMode bindMode = conn ? conn->bindMode() : RadioBindMode::Auto;
-
     QHostAddress chosenAddress;
     QString chosenReason;
-    if (!explicitAddr.isNull() && explicitAddr.protocol() == QAbstractSocket::IPv4Protocol) {
-        chosenAddress = explicitAddr;
-        chosenReason = QStringLiteral("explicit");
-    } else if (!sessionAddr.isNull() && sessionAddr.protocol() == QAbstractSocket::IPv4Protocol) {
-        chosenAddress = sessionAddr;
-        chosenReason = QStringLiteral("probe-session");
-    } else if (!tcpAddr.isNull() && tcpAddr.protocol() == QAbstractSocket::IPv4Protocol) {
-        chosenAddress = tcpAddr;
-        chosenReason = QStringLiteral("tcp-local");
-    }
+    RadioBindMode bindMode = RadioBindMode::Auto;
+    const QHostAddress bindAddr = chooseLanBindAddress(conn, &chosenReason, &chosenAddress, &bindMode);
+    const QString bindReason = chosenReason.isEmpty() ? QStringLiteral("auto") : chosenReason;
 
-    // Try port 4991 first (VPN/firewall rules), countdown for Multi-Flex.
-    static constexpr int MAX_PORT_ATTEMPTS = 10;
-    const QHostAddress bindAddr = chosenAddress.isNull() ? QHostAddress(QHostAddress::AnyIPv4) : chosenAddress;
-    bool bound = false;
-
-    for (int attempt = 0; attempt < MAX_PORT_ATTEMPTS && !bound; ++attempt) {
-        quint16 port = LAN_VITA_PORT - attempt;
-        bound = m_socket->bind(bindAddr, port);
-        if (bound) {
-            qCDebug(lcVita49) << "PanadapterStream: bound UDP to"
-                              << bindAddr.toString() << ":" << port
-                              << (chosenReason.isEmpty() ? "auto" : chosenReason);
-        }
-    }
-    if (!bound) {
-        bound = m_socket->bind(bindAddr, 0);
-        if (bound)
-            qCDebug(lcVita49) << "PanadapterStream: using OS-assigned port" << m_socket->localPort();
-    }
+    const bool bound = m_socket->bind(bindAddr, 0, kLanVitaBindMode);
+    if (bound)
+        qCInfo(lcVita49).noquote()
+            << "PanadapterStream: LAN VITA UDP bind"
+            << QStringLiteral("addr=%1").arg(bindAddr.toString())
+            << QStringLiteral("port=%1").arg(m_socket->localPort())
+            << QStringLiteral("flags=DontShareAddress")
+            << QStringLiteral("reason=%1").arg(bindReason);
     if (!bound) {
         qCWarning(lcVita49) << "PanadapterStream: failed to bind UDP socket:"
                             << m_socket->errorString()
@@ -194,6 +209,77 @@ bool PanadapterStream::start(RadioConnection* conn)
     m_radioPort = 4991;
 
     m_conn = conn;
+    return true;
+}
+
+bool PanadapterStream::rebindToEphemeralPort(RadioConnection* conn)
+{
+    if (!m_socket) {
+        qCWarning(lcVita49) << "PanadapterStream: cannot rebind UDP socket before init";
+        return false;
+    }
+
+    if (m_routedPrimeTimer)
+        m_routedPrimeTimer->stop();
+
+    if (m_socket->state() != QAbstractSocket::UnconnectedState)
+        m_socket->close();
+
+    m_audioPacketGapMs.store(0);
+    m_audioPacketGapMaxMs.store(0);
+    m_audioPacketJitterMs.store(0);
+    m_audioPacketTimerStarted = false;
+    m_previousAudioPacketGapMs = 0;
+    m_audioPacketJitterEstimateMs = 0.0;
+    m_isWanMode = false;
+    m_hasReceivedPacket = false;
+
+    QHostAddress chosenAddress;
+    QString chosenReason;
+    RadioBindMode bindMode = RadioBindMode::Auto;
+    const QHostAddress bindAddr = chooseLanBindAddress(conn, &chosenReason, &chosenAddress, &bindMode);
+    const QString bindReason = chosenReason.isEmpty() ? QStringLiteral("auto") : chosenReason;
+
+    const bool bound = m_socket->bind(bindAddr, 0, kLanVitaBindMode);
+    if (!bound) {
+        qCWarning(lcVita49) << "PanadapterStream: failed to rebind UDP socket after port collision:"
+                            << m_socket->errorString()
+                            << "mode=" << (bindMode == RadioBindMode::Explicit ? "Explicit" : "Auto")
+                            << "chosen=" << (chosenAddress.isNull() ? QStringLiteral("<none>")
+                                                                    : chosenAddress.toString());
+        return false;
+    }
+
+    m_localAddress = m_socket->localAddress();
+    m_localPort = m_socket->localPort();
+    m_radioAddress = conn ? conn->radioAddress() : QHostAddress();
+    m_radioPort = 4991;
+    m_conn = conn;
+
+    qCWarning(lcVita49).noquote()
+        << "PanadapterStream: LAN VITA UDP bind"
+        << QStringLiteral("addr=%1").arg(bindAddr.toString())
+        << QStringLiteral("port=%1").arg(m_localPort)
+        << QStringLiteral("flags=DontShareAddress")
+        << QStringLiteral("reason=%1").arg(bindReason);
+
+    if (!m_radioAddress.isNull()) {
+        const QByteArray reg(1, '\x00');
+        const qint64 sent = m_socket->writeDatagram(reg, m_radioAddress, 4992);
+        if (sent == 1) {
+            m_totalTxBytes += sent;
+            qCDebug(lcVita49) << "PanadapterStream: sent UDP registration to"
+                              << m_radioAddress.toString() << ":4992";
+            m_routedPrimeElapsed.restart();
+            m_routedPrimeTimer->start(250);
+        } else {
+            qCWarning(lcVita49) << "PanadapterStream: UDP registration send failed after rebind:"
+                                << m_socket->errorString();
+        }
+    } else {
+        qCWarning(lcVita49) << "PanadapterStream: radio address unknown - skipping UDP registration after rebind";
+    }
+
     return true;
 }
 
@@ -351,8 +437,14 @@ void PanadapterStream::onDatagramReady()
                 if (m_routedPrimeTimer) {
                     m_routedPrimeTimer->stop();
                 }
-                qCDebug(lcVita49) << "PanadapterStream: first UDP packet received from"
-                                  << dg.senderAddress().toString() << ":" << dg.senderPort();
+                const qint64 afterMs = m_routedPrimeElapsed.isValid()
+                    ? m_routedPrimeElapsed.elapsed()
+                    : -1;
+                qCInfo(lcVita49).noquote()
+                    << "PanadapterStream: first UDP packet received"
+                    << QStringLiteral("after_ms=%1").arg(afterMs)
+                    << QStringLiteral("local_port=%1").arg(m_localPort)
+                    << QStringLiteral("from=%1:%2").arg(dg.senderAddress().toString()).arg(dg.senderPort());
             }
             // On first VITA-49 packet in WAN mode: registration confirmed.
             // Stop the rapid udp_register timer and switch to ping keepalive.

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -29,7 +29,7 @@ class OpusCodec;
 // All packets from the radio use ExtDataWithStream (VITA-49 type 3), not IFDataWithStream.
 //
 // Protocol:
-//   1. Call start(conn) — binds port 4991 (LAN VITA port), falls back to OS-assigned.
+//   1. Call start(conn) - binds a unique local LAN VITA UDP port.
 //   2. Register the port with the radio via "client udpport <port>" (done by RadioModel).
 //   3. The radio streams panadapter and audio to that port.
 
@@ -49,6 +49,9 @@ public:
     // conn must remain valid for the lifetime of this stream.
     // Q_INVOKABLE: must run on the network worker thread (#502)
     Q_INVOKABLE bool start(RadioConnection* conn);
+    // Rebind to an OS-assigned LAN UDP port after the radio rejects our
+    // selected port/IP pair as already registered by another client.
+    Q_INVOKABLE bool rebindToEphemeralPort(RadioConnection* conn);
     // Start for WAN: use explicit radio address and UDP port.
     Q_INVOKABLE bool startWan(const QHostAddress& radioAddr, quint16 radioUdpPort);
 

--- a/src/core/StreamStatus.h
+++ b/src/core/StreamStatus.h
@@ -25,13 +25,40 @@ inline quint32 parseStatusHandle(QString text)
 }
 
 // Return true if a stream-status key-value map either omits client_handle
-// (legacy firmware) or matches our own handle.
+// (legacy firmware) or explicitly matches our own handle. Current firmware can
+// report orphan streams as client_handle=0x00000000 ip=0.0.0.0; those are not
+// usable client-owned streams. Treat owner=0 without that dead endpoint as
+// legacy/unknown ownership for older firmware compatibility.
 inline bool streamStatusBelongsToUs(const QMap<QString, QString>& kvs, quint32 ourHandle)
 {
     if (!kvs.contains(QStringLiteral("client_handle")))
         return true; // Preserve compatibility with status lines that omit ownership.
     const quint32 owner = parseStatusHandle(kvs.value(QStringLiteral("client_handle")));
-    return owner == 0 || owner == ourHandle;
+    if (owner == 0)
+        return kvs.value(QStringLiteral("ip")).trimmed() != QStringLiteral("0.0.0.0");
+    return owner == ourHandle;
+}
+
+inline bool isDeadOrphanDaxRxStatus(const QMap<QString, QString>& kvs)
+{
+    return kvs.contains(QStringLiteral("client_handle"))
+        && parseStatusHandle(kvs.value(QStringLiteral("client_handle"))) == 0
+        && kvs.value(QStringLiteral("ip")).trimmed() == QStringLiteral("0.0.0.0");
+}
+
+inline bool daxTxStatusCanUpdateLocalState(quint32 streamId,
+                                           quint32 currentStreamId,
+                                           const QMap<QString, QString>& kvs,
+                                           quint32 ourHandle)
+{
+    if (streamId == currentStreamId && currentStreamId != 0)
+        return true;
+
+    if (!kvs.contains(QStringLiteral("client_handle")))
+        return false;
+
+    const quint32 owner = parseStatusHandle(kvs.value(QStringLiteral("client_handle")));
+    return owner != 0 && owner == ourHandle;
 }
 
 } // namespace AetherSDR

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1236,6 +1236,7 @@ void TciServer::startTxChrono(QWebSocket* client, int trx)
         // both formats require dax=1 so the radio routes the dax_tx stream
         // to the modulator. Sending dax=0 keeps the radio on the physical
         // mic and silently discards every dax_tx packet. — fw v1.4.0.0
+        m_model->ensureDaxTxStream(DaxTxRequestReason::TciTxAudio);
         m_model->sendCmdPublic("transmit set dax=1", nullptr);
     }
 

--- a/src/core/UdpRegistrationPolicy.h
+++ b/src/core/UdpRegistrationPolicy.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+inline constexpr int kFlexUdpPortInUseCode = 0x500000A9;
+
+inline bool isUdpPortInUseError(int code, const QString& body)
+{
+    return code == kFlexUdpPortInUseCode
+        || body.contains(QStringLiteral("Port/IP pair already in use"), Qt::CaseInsensitive);
+}
+
+inline bool shouldRetryLanUdpPortRegistration(bool isWan, int code, const QString& body)
+{
+    return !isWan && isUdpPortInUseError(code, body);
+}
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7467,9 +7467,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
     if (s->isTxSlice())
         m_radioModel.sendCommand(QString("slice set %1 tx=1").arg(s->sliceId()));
 
-#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
-    // Update m_daxTxMode when TX slice or its mode changes.
-    // Digital modes (DIGU/DIGL/RTTY) use DAX bridge; voice modes use mic.
+    // Keep the radio-side TX DAX flag aligned when the TX slice or mode changes.
+    // SmartSDR DAX on Windows owns the dax_tx stream itself, so only hosted
+    // DAX platforms create/route the local stream here.
     auto updateDaxTxMode = [this]() {
         bool isDigital = false;
         int txSliceId = -1;
@@ -7482,11 +7482,17 @@ void MainWindow::onSliceAdded(SliceModel* s)
                 break;
             }
         }
-        m_audio->setDaxTxMode(isDigital);
-
-        // Auto-toggle radio-side DAX flag on mode change (#534).
         // Digital modes need dax=1 for TX audio routing through DAX.
         m_radioModel.transmitModel().setDax(isDigital);
+
+#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
+        m_audio->setDaxTxMode(isDigital);
+        if (isDigital)
+            m_radioModel.ensureDaxTxStream(DaxTxRequestReason::HostedDaxBridge);
+#else
+        if (isDigital)
+            m_radioModel.ensureDaxTxStream(DaxTxRequestReason::ExternalDaxRouteOnly);
+#endif
 
 #ifdef HAVE_RADE
         // RADE mode should only route mic→RADEEngine when the TX slice IS
@@ -7499,7 +7505,6 @@ void MainWindow::onSliceAdded(SliceModel* s)
     connect(s, &SliceModel::modeChanged, this, updateDaxTxMode);
     connect(s, &SliceModel::txSliceChanged, this, updateDaxTxMode);
     updateDaxTxMode();  // set initial state from current TX slice mode
-#endif
 
     // Push overlay for this slice to the spectrum widget
     pushSliceOverlay(s);
@@ -11821,6 +11826,7 @@ bool MainWindow::startDax()
     // mode overrides this to the low-latency route via setRadeMode()
     // when the user enters RADE — see AudioEngine::setRadeMode().
     m_audio->setDaxTxUseRadioRoute(true);
+    m_radioModel.ensureDaxTxStream(DaxTxRequestReason::HostedDaxBridge);
     m_radioModel.sendCommand("transmit set mic_selection=PC");
     // Don't force dax=1 here — radio-side DAX flag follows mode changes
     // via updateDaxTxMode(). Bridge up ≠ DAX TX active. (#534)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3,6 +3,7 @@
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
 #include "core/StreamStatus.h"
+#include "core/UdpRegistrationPolicy.h"
 #include "RadioStatusOwnership.h"
 #include <QCoreApplication>
 #include <QDebug>
@@ -95,6 +96,12 @@ QString hexId(quint32 value)
 {
     return QStringLiteral("0x%1")
         .arg(QString::number(value, 16).rightJustified(8, QLatin1Char('0')));
+}
+
+QString hexCode(int value)
+{
+    return QStringLiteral("0x%1")
+        .arg(QString::number(static_cast<quint32>(value), 16).rightJustified(8, QLatin1Char('0')));
 }
 
 QString normalizePanadapterId(QString text)
@@ -1313,7 +1320,7 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
         if (!streamOk) {
             qCWarning(lcProtocol) << "RadioModel: UDP stream setup failed — disconnecting gracefully (#894)";
             emit connectionError(tr("UDP stream setup failed. If connecting over VPN, "
-                                    "ensure UDP port 4991 is routable."));
+                                    "ensure UDP traffic from the radio is routable."));
             QTimer::singleShot(0, this, &RadioModel::disconnectFromRadio);
             return;
         }
@@ -1348,14 +1355,63 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
         }
 
         const quint16 udpPort = m_panStream->localPort();
+        qCInfo(lcProtocol).noquote()
+            << "RadioModel: client udpport requested"
+            << QStringLiteral("port=%1").arg(udpPort);
         sendCmd(
             QString("client udpport %1").arg(udpPort),
-            [this, udpPort](int code2, const QString&) {
-                if (code2 == 0)
-                    qCDebug(lcProtocol) << "RadioModel: UDP port" << udpPort << "registered via client udpport";
-                else
+            [this, udpPort](int code2, const QString& body) {
+                if (code2 == 0) {
+                    qCInfo(lcProtocol).noquote()
+                        << "RadioModel: client udpport registered"
+                        << QStringLiteral("port=%1").arg(udpPort);
+                } else if (shouldRetryLanUdpPortRegistration(m_wanConn != nullptr, code2, body)) {
+                    bool rebound = false;
+                    QMetaObject::invokeMethod(m_panStream, [this, &rebound]() {
+                        rebound = m_panStream->rebindToEphemeralPort(m_connection);
+                    }, Qt::BlockingQueuedConnection);
+
+                    if (!rebound) {
+                        qCWarning(lcProtocol) << "RadioModel: UDP port" << udpPort
+                                              << "is already registered and AetherSDR could not rebind";
+                        emit connectionError(tr("UDP port %1 is already in use by another Flex client, "
+                                                "and AetherSDR could not switch to a free UDP port.")
+                                                 .arg(udpPort));
+                        QTimer::singleShot(0, this, &RadioModel::disconnectFromRadio);
+                        return;
+                    }
+
+                    const quint16 retryUdpPort = m_panStream->localPort();
+                    qCWarning(lcProtocol).noquote()
+                        << "RadioModel: client udpport collision"
+                        << QStringLiteral("port=%1").arg(udpPort)
+                        << QStringLiteral("code=%1").arg(hexCode(code2))
+                        << QStringLiteral("retry_port=%1").arg(retryUdpPort);
+                    qCInfo(lcProtocol).noquote()
+                        << "RadioModel: client udpport requested"
+                        << QStringLiteral("port=%1").arg(retryUdpPort);
+                    sendCmd(
+                        QString("client udpport %1").arg(retryUdpPort),
+                        [this, retryUdpPort](int retryCode, const QString& retryBody) {
+                            if (retryCode == 0) {
+                                qCInfo(lcProtocol).noquote()
+                                    << "RadioModel: client udpport retry registered"
+                                    << QStringLiteral("port=%1").arg(retryUdpPort);
+                            } else {
+                                qCWarning(lcProtocol).noquote()
+                                    << "RadioModel: client udpport retry failed"
+                                    << QStringLiteral("code=%1").arg(hexCode(retryCode))
+                                    << QStringLiteral("body=%1").arg(retryBody);
+                                emit connectionError(tr("UDP port registration failed after switching to port %1: %2")
+                                                         .arg(retryUdpPort)
+                                                         .arg(retryBody));
+                                QTimer::singleShot(0, this, &RadioModel::disconnectFromRadio);
+                            }
+                        });
+                } else {
                     qCDebug(lcProtocol) << "RadioModel: client udpport returned error" << Qt::hex << code2
                              << "(expected on WAN — using udp_register instead)";
+                }
 
                 // Query radio info (region, callsign, options, etc.)
                 // Response is comma-separated key=value pairs.
@@ -1451,26 +1507,9 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                         // stream. (#1014, #1051, #2037)
                         scheduleRxAudioStreamEnsure(QStringLiteral("connect"));
 
-        // Request DAX TX audio stream (PC mic → radio, DAX mode)
-                        sendCmd(
-                            "stream create type=dax_tx",
-                            [this](int code, const QString& body) {
-                                if (code == 0) {
-                                    quint32 id = body.trimmed().toUInt(nullptr, 16);
-                                    m_daxTxStreamId = id;
-                                    m_daxTxActive = false;
-                                    m_daxTxClientHandle = 0;
-                                    qCDebug(lcProtocol) << "RadioModel: dax_tx stream created, id:"
-                                             << Qt::hex << id;
-                                    qCDebug(lcDax).noquote()
-                                        << "RadioModel: requested DAX TX stream"
-                                        << QStringLiteral("stream=%1").arg(hexId(id));
-                                    emit txAudioStreamReady(id);
-                                } else {
-                                    qCWarning(lcProtocol) << "RadioModel: dax_tx failed, code"
-                                               << Qt::hex << code << "body:" << body;
-                                }
-                            });
+                        // Do not claim a dax_tx stream at GUI attach time. SmartSDR DAX
+                        // owns that stream on Windows; AetherSDR creates one lazily only
+                        // when its own bridge/TCI path needs to feed DAX TX audio.
 
                         // Request remote audio TX stream (voice mode, VOX monitoring)
                         // This stream carries mic audio to the radio for voice TX and
@@ -1660,6 +1699,10 @@ void RadioModel::onDisconnected()
     m_daxTxStreamId = 0;
     m_daxTxActive = false;
     m_daxTxClientHandle = 0;
+    m_daxTxCreatePending = false;
+    m_deadDaxRxSeen.clear();
+    m_externalDaxTxSeen.clear();
+    m_externalDaxRxSeen.clear();
 
     // Reset radio-model-specific state — different radios have different
     // capabilities (APD, max power, pan count, TGXL, amplifier, XVTR, etc.)
@@ -2469,7 +2512,11 @@ void RadioModel::traceDaxStreamStatus(const QString& object,
                 m_daxTxStreamId = 0;
                 m_daxTxActive = false;
                 m_daxTxClientHandle = 0;
+                m_daxTxCreatePending = false;
             }
+            m_deadDaxRxSeen.remove(stream.streamId);
+            m_externalDaxTxSeen.remove(stream.streamId);
+            m_externalDaxRxSeen.remove(stream.streamId);
             m_daxStreamDebug.remove(stream.streamId);
             return;
         }
@@ -2489,6 +2536,8 @@ void RadioModel::traceDaxStreamStatus(const QString& object,
             state.daxIqRate = kvs.value(QStringLiteral("daxiq_rate")).toInt();
         if (kvs.contains(QStringLiteral("pan")))
             state.panId = kvs.value(QStringLiteral("pan"));
+        if (kvs.contains(QStringLiteral("ip")))
+            state.ip = kvs.value(QStringLiteral("ip")).trimmed();
         if (kvs.contains(QStringLiteral("active"))) {
             state.active = kvs.value(QStringLiteral("active")) == QStringLiteral("1");
             state.activeKnown = true;
@@ -2498,14 +2547,56 @@ void RadioModel::traceDaxStreamStatus(const QString& object,
             state.txKnown = true;
         }
 
-        if (state.type == QStringLiteral("dax_tx")) {
-            m_daxTxStreamId = stream.streamId;
-            m_daxTxActive = state.tx;
-            m_daxTxClientHandle = state.clientHandle;
+        if (state.type == QStringLiteral("dax_rx") && isDeadOrphanDaxRxStatus(kvs)) {
+            if (!m_deadDaxRxSeen.contains(stream.streamId)) {
+                m_deadDaxRxSeen.insert(stream.streamId);
+                qCWarning(lcDax).noquote()
+                    << "RadioModel: ignoring dead DAX RX stream status"
+                    << QStringLiteral("stream=%1").arg(hexId(stream.streamId))
+                    << QStringLiteral("dax_ch=%1").arg(state.daxChannel)
+                    << QStringLiteral("slice=%1").arg(state.sliceId >= 0
+                        ? QString::number(state.sliceId)
+                        : QStringLiteral("?"))
+                    << QStringLiteral("ip=%1").arg(state.ip);
+            }
         }
 
         const bool ownerKnown = state.clientHandle != 0;
         const bool ownedByUs = ownerKnown && state.clientHandle == clientHandle();
+        if (state.type == QStringLiteral("dax_tx") && ownerKnown && !ownedByUs) {
+            if (!m_externalDaxTxSeen.contains(stream.streamId)) {
+                m_externalDaxTxSeen.insert(stream.streamId);
+                qCInfo(lcDax).noquote()
+                    << "RadioModel: external DAX TX stream observed"
+                    << QStringLiteral("stream=%1").arg(hexId(stream.streamId))
+                    << QStringLiteral("owner=%1").arg(hexId(state.clientHandle));
+            }
+        } else if (state.type == QStringLiteral("dax_rx") && ownerKnown && !ownedByUs) {
+            if (!m_externalDaxRxSeen.contains(stream.streamId)) {
+                m_externalDaxRxSeen.insert(stream.streamId);
+                qCInfo(lcDax).noquote()
+                    << "RadioModel: external DAX RX stream observed"
+                    << QStringLiteral("stream=%1").arg(hexId(stream.streamId))
+                    << QStringLiteral("owner=%1").arg(hexId(state.clientHandle))
+                    << QStringLiteral("dax_ch=%1").arg(state.daxChannel)
+                    << QStringLiteral("slice=%1").arg(state.sliceId >= 0
+                        ? QString::number(state.sliceId)
+                        : QStringLiteral("?"))
+                    << QStringLiteral("ip=%1").arg(state.ip.isEmpty()
+                        ? QStringLiteral("?")
+                        : state.ip);
+            }
+        }
+
+        if (state.type == QStringLiteral("dax_tx")
+            && daxTxStatusCanUpdateLocalState(stream.streamId, m_daxTxStreamId, kvs, clientHandle())) {
+            m_daxTxStreamId = stream.streamId;
+            m_daxTxActive = state.tx;
+            m_daxTxClientHandle = state.clientHandle;
+            if (ownedByUs)
+                m_daxTxCreatePending = false;
+        }
+
         QStringList fields;
         fields << QStringLiteral("stream=%1").arg(hexId(stream.streamId));
         fields << QStringLiteral("type=%1").arg(state.type.isEmpty() ? QStringLiteral("(unknown)") : state.type);
@@ -2522,6 +2613,8 @@ void RadioModel::traceDaxStreamStatus(const QString& object,
             fields << QStringLiteral("daxiq_rate=%1").arg(state.daxIqRate);
         if (!state.panId.isEmpty())
             fields << QStringLiteral("pan=%1").arg(state.panId);
+        if (!state.ip.isEmpty())
+            fields << QStringLiteral("ip=%1").arg(state.ip);
         if (state.activeKnown)
             fields << QStringLiteral("active=%1").arg(state.active ? 1 : 0);
         if (state.txKnown)
@@ -2547,8 +2640,10 @@ void RadioModel::traceDaxStreamStatus(const QString& object,
             m_daxTxStreamId = 0;
             m_daxTxActive = false;
             m_daxTxClientHandle = 0;
+            m_daxTxCreatePending = false;
         }
         m_daxStreamDebug.remove(txAudioStream.streamId);
+        m_externalDaxTxSeen.remove(txAudioStream.streamId);
         return;
     }
 
@@ -2560,12 +2655,22 @@ void RadioModel::traceDaxStreamStatus(const QString& object,
         state.tx = kvs.value(QStringLiteral("tx")) == QStringLiteral("1");
         state.txKnown = true;
     }
-    m_daxTxStreamId = txAudioStream.streamId;
-    m_daxTxActive = state.tx;
-    m_daxTxClientHandle = state.clientHandle;
-
     const bool ownerKnown = state.clientHandle != 0;
     const bool ownedByUs = ownerKnown && state.clientHandle == clientHandle();
+    if (ownerKnown && !ownedByUs && !m_externalDaxTxSeen.contains(txAudioStream.streamId)) {
+        m_externalDaxTxSeen.insert(txAudioStream.streamId);
+        qCInfo(lcDax).noquote()
+            << "RadioModel: external DAX TX stream observed"
+            << QStringLiteral("stream=%1").arg(hexId(txAudioStream.streamId))
+            << QStringLiteral("owner=%1").arg(hexId(state.clientHandle));
+    }
+    if (daxTxStatusCanUpdateLocalState(txAudioStream.streamId, m_daxTxStreamId, kvs, clientHandle())) {
+        m_daxTxStreamId = txAudioStream.streamId;
+        m_daxTxActive = state.tx;
+        m_daxTxClientHandle = state.clientHandle;
+        if (ownedByUs)
+            m_daxTxCreatePending = false;
+    }
     qCDebug(lcDax).noquote()
         << "RadioModel: DAX tx_audio_stream status"
         << QStringLiteral("stream=%1").arg(hexId(txAudioStream.streamId))
@@ -3842,22 +3947,76 @@ void RadioModel::createAudioStream()
     } else {
         createRxAudioStream();
     }
+}
 
+bool RadioModel::ensureDaxTxStream(DaxTxRequestReason reason)
+{
+    const DaxTxPolicyContext policyContext = currentDaxTxPolicyContext(reason);
+    const DaxTxPolicyDecision decision = evaluateDaxTxPolicy(policyContext);
+    const quint32 ourHandle = clientHandle();
+    qCInfo(lcDax).noquote()
+        << "RadioModel: DAX TX policy"
+        << QStringLiteral("reason=%1").arg(daxTxRequestReasonName(reason))
+        << QStringLiteral("platform=%1").arg(daxTxPlatformName(policyContext.platform))
+        << QStringLiteral("allowed=%1").arg(decision.allowed ? 1 : 0)
+        << QStringLiteral("mode=%1").arg(daxTxModeName(policyContext.mode))
+        << QStringLiteral("stream=%1").arg(m_daxTxStreamId != 0
+            ? hexId(m_daxTxStreamId)
+            : QStringLiteral("none"))
+        << QStringLiteral("owner=%1").arg(m_daxTxClientHandle != 0
+            ? hexId(m_daxTxClientHandle)
+            : QStringLiteral("unknown"));
+
+    if (!decision.allowed) {
+        qCInfo(lcDax).noquote()
+            << "RadioModel: DAX TX stream not created"
+            << QStringLiteral("reason=%1").arg(daxTxRequestReasonName(reason))
+            << QStringLiteral("mode=%1").arg(daxTxModeName(policyContext.mode))
+            << QStringLiteral("note=%1").arg(decision.note);
+        return false;
+    }
+
+    const bool existingStreamIsOurs = m_daxTxStreamId != 0
+        && (m_daxTxClientHandle == 0 || m_daxTxClientHandle == ourHandle);
+    if (existingStreamIsOurs || m_daxTxCreatePending)
+        return true;
+
+    m_daxTxCreatePending = true;
+    qCInfo(lcDax).noquote()
+        << "RadioModel: DAX TX create requested"
+        << QStringLiteral("reason=%1").arg(daxTxRequestReasonName(reason));
     sendCmd(
         "stream create type=dax_tx",
-        [this](int code, const QString& body) {
-            if (code == 0) {
-                quint32 id = body.trimmed().toUInt(nullptr, 16);
-                m_daxTxStreamId = id;
-                m_daxTxActive = false;
-                m_daxTxClientHandle = 0;
-                qCDebug(lcProtocol) << "RadioModel: dax_tx stream re-created, id:" << Qt::hex << id;
-                qCDebug(lcDax).noquote()
-                    << "RadioModel: requested DAX TX stream"
-                    << QStringLiteral("stream=%1").arg(hexId(id));
-                emit txAudioStreamReady(id);
+        [this, reason](int code, const QString& body) {
+            m_daxTxCreatePending = false;
+            if (code != 0) {
+                qCWarning(lcDax).noquote()
+                    << "RadioModel: DAX TX create failed"
+                    << QStringLiteral("code=%1").arg(hexCode(code))
+                    << QStringLiteral("body=%1").arg(body)
+                    << QStringLiteral("reason=%1").arg(daxTxRequestReasonName(reason));
+                return;
             }
+
+            const quint32 id = RadioStatusOwnership::parseCreateResponseStreamId(body);
+            if (id == 0) {
+                qCWarning(lcDax).noquote()
+                    << "RadioModel: DAX TX create failed"
+                    << QStringLiteral("code=0x00000000")
+                    << QStringLiteral("body=%1").arg(body)
+                    << QStringLiteral("reason=%1").arg(daxTxRequestReasonName(reason));
+                return;
+            }
+
+            m_daxTxStreamId = id;
+            m_daxTxActive = false;
+            m_daxTxClientHandle = clientHandle();
+            qCInfo(lcDax).noquote()
+                << "RadioModel: DAX TX create succeeded"
+                << QStringLiteral("stream=%1").arg(hexId(id));
+            emit txAudioStreamReady(id);
         });
+    return true;
 }
 
 QJsonObject RadioModel::troubleshootingSnapshot() const

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -4,6 +4,7 @@
 #include "core/WanConnection.h"
 #include "core/PanadapterStream.h"
 #include "core/SleepInhibitor.h"
+#include "core/DaxTxPolicy.h"
 #include <QThread>
 #include "SliceModel.h"
 #include "MeterModel.h"
@@ -208,6 +209,7 @@ public:
     void loadGlobalProfile(const QString& name);
     void resetPanState();
     void createAudioStream();
+    bool ensureDaxTxStream(DaxTxRequestReason reason);
     QJsonObject troubleshootingSnapshot() const;
 
     // Memory channel cache
@@ -634,6 +636,7 @@ private:
         int sliceId{-1};
         int daxIqRate{0};
         QString panId;
+        QString ip;
         bool active{false};
         bool tx{false};
         bool activeKnown{false};
@@ -643,6 +646,10 @@ private:
     quint32     m_daxTxStreamId{0};
     bool        m_daxTxActive{false};
     quint32     m_daxTxClientHandle{0};  // Tracked for diagnostics only — not consulted in routing.
+    bool        m_daxTxCreatePending{false};
+    QSet<quint32> m_deadDaxRxSeen;
+    QSet<quint32> m_externalDaxTxSeen;
+    QSet<quint32> m_externalDaxRxSeen;
     WanConnection* m_wanConn{nullptr};  // non-null when connected via SmartLink
     QString  m_wanPublicIp;
     quint16  m_wanUdpPort{4991};

--- a/tests/radio_status_ownership_test.cpp
+++ b/tests/radio_status_ownership_test.cpp
@@ -1,4 +1,7 @@
 #include "models/RadioStatusOwnership.h"
+#include "core/DaxTxPolicy.h"
+#include "core/StreamStatus.h"
+#include "core/UdpRegistrationPolicy.h"
 
 #include <cstdio>
 
@@ -110,6 +113,112 @@ void testRemoteAudioRxTracking()
     check(state.streamId == 0, "removed remote_audio_rx clears stream id");
 }
 
+void testStreamStatusOwnershipCompatibility()
+{
+    constexpr quint32 ours = 0x12345678;
+    QMap<QString, QString> noOwner;
+    QMap<QString, QString> unknownOwner{{QStringLiteral("client_handle"), QStringLiteral("0x00000000")}};
+    QMap<QString, QString> orphanOwner{
+        {QStringLiteral("client_handle"), QStringLiteral("0x00000000")},
+        {QStringLiteral("ip"), QStringLiteral("0.0.0.0")}
+    };
+    QMap<QString, QString> ourOwner{{QStringLiteral("client_handle"), QStringLiteral("0x12345678")}};
+    QMap<QString, QString> otherOwner{{QStringLiteral("client_handle"), QStringLiteral("0x87654321")}};
+
+    check(streamStatusBelongsToUs(noOwner, ours),
+          "stream status without client_handle remains legacy-compatible");
+    check(streamStatusBelongsToUs(unknownOwner, ours),
+          "client_handle zero without dead endpoint remains legacy-compatible");
+    check(!streamStatusBelongsToUs(orphanOwner, ours),
+          "client_handle zero with 0.0.0.0 endpoint is ignored as a dead stream");
+    check(streamStatusBelongsToUs(ourOwner, ours),
+          "stream status with our client_handle belongs to us");
+    check(!streamStatusBelongsToUs(otherOwner, ours),
+          "stream status with another client_handle is ignored");
+    check(isDeadOrphanDaxRxStatus(orphanOwner),
+          "dead DAX RX helper identifies owner-zero 0.0.0.0 endpoint");
+    check(!isDeadOrphanDaxRxStatus(unknownOwner),
+          "owner-zero stream without dead endpoint is not classified dead");
+}
+
+void testDaxTxStatusOwnership()
+{
+    constexpr quint32 ours = 0x12345678;
+    constexpr quint32 current = 0x04000001;
+    constexpr quint32 incoming = 0x04000002;
+    QMap<QString, QString> noOwner;
+    QMap<QString, QString> ownerZero{{QStringLiteral("client_handle"), QStringLiteral("0x00000000")}};
+    QMap<QString, QString> ourOwner{{QStringLiteral("client_handle"), QStringLiteral("0x12345678")}};
+    QMap<QString, QString> otherOwner{{QStringLiteral("client_handle"), QStringLiteral("0x87654321")}};
+
+    check(!daxTxStatusCanUpdateLocalState(incoming, 0, noOwner, ours),
+          "missing DAX TX client_handle does not steal unknown stream during startup");
+    check(!daxTxStatusCanUpdateLocalState(incoming, 0, ownerZero, ours),
+          "owner-zero DAX TX status does not steal unknown stream");
+    check(daxTxStatusCanUpdateLocalState(incoming, 0, ourOwner, ours),
+          "our DAX TX client_handle is adopted");
+    check(!daxTxStatusCanUpdateLocalState(incoming, current, otherOwner, ours),
+          "foreign DAX TX status does not overwrite our stream id");
+    check(daxTxStatusCanUpdateLocalState(current, current, otherOwner, ours),
+          "already-created DAX TX stream id can update local state");
+    check(daxTxStatusCanUpdateLocalState(current, current, noOwner, ours),
+          "missing owner can update an already-created DAX TX stream");
+}
+
+void testDaxTxPolicy()
+{
+    DaxTxPolicyContext windowsExternalRoute{
+        DaxTxRequestReason::ExternalDaxRouteOnly,
+        DaxTxPlatform::Windows,
+        DaxTxMode::ExternalDax2,
+        false,
+        false
+    };
+    check(!evaluateDaxTxPolicy(windowsExternalRoute).allowed,
+          "Windows external-DAX2 route-only policy does not create dax_tx");
+
+    DaxTxPolicyContext windowsGenericAudio = windowsExternalRoute;
+    windowsGenericAudio.reason = DaxTxRequestReason::GenericAudioRecreate;
+    check(!evaluateDaxTxPolicy(windowsGenericAudio).allowed,
+          "Windows generic audio recreation policy does not create dax_tx");
+
+    DaxTxPolicyContext hostedBridge{
+        DaxTxRequestReason::HostedDaxBridge,
+        DaxTxPlatform::MacOS,
+        DaxTxMode::HostedDax,
+        true,
+        true
+    };
+    check(evaluateDaxTxPolicy(hostedBridge).allowed,
+          "hosted DAX bridge policy creates dax_tx when hosted DAX is available");
+
+    DaxTxPolicyContext hostedTci = hostedBridge;
+    hostedTci.reason = DaxTxRequestReason::TciTxAudio;
+    check(evaluateDaxTxPolicy(hostedTci).allowed,
+          "TCI DAX TX policy is explicit and allowed when supported");
+
+    DaxTxPolicyContext windowsTci = windowsExternalRoute;
+    windowsTci.reason = DaxTxRequestReason::TciTxAudio;
+    check(!evaluateDaxTxPolicy(windowsTci).allowed,
+          "Windows external-DAX2 TCI policy does not create dax_tx when unsupported");
+}
+
+void testUdpRegistrationPolicy()
+{
+    check(isUdpPortInUseError(kFlexUdpPortInUseCode, QString()),
+          "UDP port collision helper matches Flex error code");
+    check(isUdpPortInUseError(1, QStringLiteral("Port/IP pair already in use")),
+          "UDP port collision helper matches radio error body");
+    check(isUdpPortInUseError(1, QStringLiteral("port/ip PAIR already IN use")),
+          "UDP port collision helper is case-insensitive");
+    check(!isUdpPortInUseError(1, QStringLiteral("command syntax error")),
+          "UDP port collision helper ignores unrelated errors");
+    check(shouldRetryLanUdpPortRegistration(false, kFlexUdpPortInUseCode, QString()),
+          "LAN UDP registration retries on port collision");
+    check(!shouldRetryLanUdpPortRegistration(true, kFlexUdpPortInUseCode, QString()),
+          "WAN UDP registration does not trigger LAN rebind policy");
+}
+
 void testCreateResponseParsing()
 {
     check(parseCreateResponseStreamId(QStringLiteral("4000009")) == 0x04000009,
@@ -131,6 +240,10 @@ int main()
     std::printf("Radio status ownership tests\n\n");
     testPanadapterOwnershipDecisions();
     testRemoteAudioRxTracking();
+    testStreamStatusOwnershipCompatibility();
+    testDaxTxStatusOwnership();
+    testDaxTxPolicy();
+    testUdpRegistrationPolicy();
     testCreateResponseParsing();
 
     if (failures) {


### PR DESCRIPTION
## Summary

This PR stabilizes coexistence with SmartSDR DAX2 by making AetherSDR explicit about when it may create or adopt DAX TX streams, and by avoiding stale/orphan DAX stream status from being treated as locally owned state.

## Code Summary

- Added `DaxTxPolicy.h` to centralize platform-aware DAX TX decisions. Windows builds now treat SmartSDR DAX2 as the owner of the external DAX route, while hosted DAX platforms such as macOS and PipeWire can still create local `dax_tx` streams when their bridge or TCI route needs one.
- Moved DAX TX creation behind `RadioModel::ensureDaxTxStream(...)`, with request reasons for hosted DAX bridge, TCI TX audio, external route-only, and generic audio recreation. This prevents eager `stream create type=dax_tx` during GUI attach and tracks pending creates to avoid duplicate requests.
- Tightened DAX stream status ownership parsing in `StreamStatus.h` and `RadioModel.cpp`. Dead orphan DAX RX entries with `client_handle=0x00000000 ip=0.0.0.0` are ignored, external DAX RX/TX streams are logged separately, and local DAX TX state only updates from the current stream id or our own `client_handle`.
- Updated slice mode and DAX bridge startup handling in `MainWindow.cpp` so radio-side `transmit set dax=1` behavior remains aligned for digital modes, while local DAX TX stream creation is gated by the new policy.
- Added `UdpRegistrationPolicy.h` plus a LAN VITA UDP rebind path. `PanadapterStream` now binds an OS-assigned LAN UDP port with `DontShareAddress`, and `RadioModel` retries `client udpport` registration on Flex's port/IP collision error instead of leaving the session stuck.
- Added focused regression coverage in `radio_status_ownership_test` for DAX TX policy decisions, dead DAX RX status handling, DAX TX ownership updates, and UDP registration retry detection.

## Validation

- Built successfully on macOS with `cmake --build build -j10`.
- Ran `./build/radio_status_ownership_test` and all tests passed.
- Launched the built app from `build/AetherSDR.app` for manual troubleshooting.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
