### PR TITLE
Fix SmartLink disconnect teardown

### DIFF
--- a/src/core/WanConnection.cpp
+++ b/src/core/WanConnection.cpp
@@ -30,8 +30,8 @@ WanConnection::~WanConnection()
 void WanConnection::connectToRadio(const QString& host, quint16 tlsPort,
                                     const QString& wanHandle)
 {
-    if (m_connected) {
-        qCWarning(lcSmartLink) << "WanConnection: already connected";
+    if (m_connected || m_socket.state() != QAbstractSocket::UnconnectedState) {
+        qCWarning(lcSmartLink) << "WanConnection: already connected or still closing";
         return;
     }
 

--- a/src/core/WanConnection.h
+++ b/src/core/WanConnection.h
@@ -27,6 +27,7 @@ public:
     ~WanConnection() override;
 
     bool isConnected() const    { return m_connected; }
+    bool isSocketIdle() const   { return m_socket.state() == QAbstractSocket::UnconnectedState; }
     quint32 clientHandle() const { return m_handle; }
     QHostAddress radioAddress() const { return m_socket.peerAddress(); }
     quint16 localTcpPort() const { return m_socket.localPort(); }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -661,7 +661,7 @@ void RadioModel::disconnectFromRadio()
     if (m_wanConn) {
         m_wanConn->disconnect(this);  // remove signal connections to prevent duplicates on reconnect (#224)
         m_wanConn->disconnectFromRadio();
-        m_wanConn = nullptr;
+        onDisconnected();
     } else if (m_connection->isConnected()) {
         // Graceful disconnect: remove our stream and wait for the radio reply
         // before closing. Self "client disconnect" is rejected by the radio.

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -659,9 +659,17 @@ void RadioModel::disconnectFromRadio()
     m_reconnectTimer.stop();
     m_pingTimer.stop();
     if (m_wanConn) {
-        m_wanConn->disconnect(this);  // remove signal connections to prevent duplicates on reconnect (#224)
-        m_wanConn->disconnectFromRadio();
-        onDisconnected();
+        WanConnection* wan = m_wanConn;
+        wan->disconnect(this);  // remove stale signal connections before adding the one-shot teardown (#224)
+        connect(wan, &WanConnection::disconnected, this, [this, wan]() {
+            if (m_wanConn == wan) {
+                onDisconnected();
+            }
+        }, Qt::SingleShotConnection);
+        wan->disconnectFromRadio();
+        if (wan->isSocketIdle() && m_wanConn == wan) {
+            onDisconnected();
+        }
     } else if (m_connection->isConnected()) {
         // Graceful disconnect: remove our stream and wait for the radio reply
         // before closing. Self "client disconnect" is rejected by the radio.


### PR DESCRIPTION
## Bug
SmartLink/WAN disconnect closed the WAN socket after disconnecting RadioModel's WanConnection signals, then nulled m_wanConn directly. That skipped RadioModel::onDisconnected(), leaving radio-owned state such as panadapters, slices, meters, streams, and downstream UI state alive after the user clicked Disconnect.

## Fix
Run the normal RadioModel::onDisconnected() cleanup path after intentionally closing a WAN session. This preserves the existing duplicate-signal guard while making WAN disconnects emit connectionStateChanged(false) and clear model state like LAN disconnects.

## Testing
- Built successfully: cmake --build /private/tmp/AetherSDR-wan-disconnect-build -j8
- Manual SmartLink test confirmed the log now emits RadioModel: disconnected on Disconnect.
- Also verified together with the RX applet teardown branch in a temporary combined build.

## Codex
Codex model used: GPT-5.

## Related
This is required for the #2254 UI fix to take effect for SmartLink/WAN sessions, because the RX applet teardown is triggered from connectionStateChanged(false).