### PR TITLE
Reset RX slice tabs on disconnect

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -1045,6 +1045,11 @@ void AppletPanel::setMaxSlices(int maxSlices)
     m_rxApplet->setMaxSlices(maxSlices);
 }
 
+void AppletPanel::clearSliceButtons()
+{
+    m_rxApplet->clearSliceButtons();
+}
+
 void AppletPanel::updateSliceButtons(const QList<SliceModel*>& slices, int activeSliceId)
 {
     m_rxApplet->updateSliceButtons(slices, activeSliceId);

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -60,6 +60,7 @@ public:
     void setSlice(SliceModel* slice);
     void setAntennaList(const QStringList& ants);
     void setMaxSlices(int maxSlices);
+    void clearSliceButtons();
     void updateSliceButtons(const QList<SliceModel*>& slices, int activeSliceId);
 
     RxApplet*     rxApplet()      { return m_rxApplet; }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2220,15 +2220,14 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_appletPanel->rxApplet(), &RxApplet::sliceActivationRequested,
             this, &MainWindow::setActiveSlice);
     // Initialize slice tab buttons once the radio reports its actual capacity
-    connect(&m_radioModel, &RadioModel::infoChanged, this,
-            [this, initialized = false]() mutable {
-        if (initialized || m_radioModel.model().isEmpty()) {
+    connect(&m_radioModel, &RadioModel::infoChanged, this, [this]() {
+        if (m_sliceTabsInitialized || m_radioModel.model().isEmpty()) {
             return;
         }
 
         m_appletPanel->setMaxSlices(m_radioModel.maxSlices());
         m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
-        initialized = true;
+        m_sliceTabsInitialized = true;
     });
 
     // Radio info can arrive after onConnectionStateChanged, so refresh the labels.
@@ -7115,6 +7114,11 @@ void MainWindow::onConnectionStateChanged(bool connected)
             }
         }
     } else {
+        m_sliceTabsInitialized = false;
+        if (m_appletPanel) {
+            m_appletPanel->clearSliceButtons();
+        }
+
         if (m_agManualConnectTimer) {
             m_agManualConnectTimer->stop();
             m_agManualConnectTimer->deleteLater();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2219,15 +2219,14 @@ MainWindow::MainWindow(QWidget* parent)
     // ── Slice tab toggle: click A/B/C/D → switch active slice (#1278) ──
     connect(m_appletPanel->rxApplet(), &RxApplet::sliceActivationRequested,
             this, &MainWindow::setActiveSlice);
-    // Initialize slice tab buttons once the radio reports its actual capacity
+    // Sync slice tab capacity after radio info/status reports actual capacity.
     connect(&m_radioModel, &RadioModel::infoChanged, this, [this]() {
-        if (m_sliceTabsInitialized || m_radioModel.model().isEmpty()) {
+        if (m_radioModel.model().isEmpty()) {
             return;
         }
 
         m_appletPanel->setMaxSlices(m_radioModel.maxSlices());
         m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
-        m_sliceTabsInitialized = true;
     });
 
     // Radio info can arrive after onConnectionStateChanged, so refresh the labels.
@@ -7114,7 +7113,6 @@ void MainWindow::onConnectionStateChanged(bool connected)
             }
         }
     } else {
-        m_sliceTabsInitialized = false;
         if (m_appletPanel) {
             m_appletPanel->clearSliceButtons();
         }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -367,6 +367,7 @@ private:
     int  m_splitTxSliceId{-1};
     int  m_pendingMemoryRevealSliceId{-1};
     int  m_pendingSpectrumTargetSliceId{-1};
+    bool m_sliceTabsInitialized{false};
 
     // Guard: set true while updating controls from the model so shared tune
     // helpers do not echo model-driven changes back to the radio.

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -367,7 +367,6 @@ private:
     int  m_splitTxSliceId{-1};
     int  m_pendingMemoryRevealSliceId{-1};
     int  m_pendingSpectrumTargetSliceId{-1};
-    bool m_sliceTabsInitialized{false};
 
     // Guard: set true while updating controls from the model so shared tune
     // helpers do not echo model-driven changes back to the radio.

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1047,20 +1047,39 @@ void RxApplet::setMaxSlices(int maxSlices)
         m_sliceBtns.append(btn);
     }
 
-    // Wire button clicks to emit sliceActivationRequested
-    connect(m_sliceGroup, QOverload<int>::of(&QButtonGroup::idClicked),
-            this, [this](int /*buttonId*/) {
-        auto* btn = qobject_cast<QToolButton*>(m_sliceGroup->checkedButton());
-        if (btn) {
-            bool ok = false;
-            int sliceId = btn->property("sliceId").toInt(&ok);
-            if (ok) emit sliceActivationRequested(sliceId);
-        }
-    });
+    if (!m_sliceButtonClicksConnected) {
+        connect(m_sliceGroup, QOverload<int>::of(&QButtonGroup::idClicked),
+                this, [this](int /*buttonId*/) {
+            auto* btn = qobject_cast<QToolButton*>(m_sliceGroup->checkedButton());
+            if (btn) {
+                bool ok = false;
+                int sliceId = btn->property("sliceId").toInt(&ok);
+                if (ok) emit sliceActivationRequested(sliceId);
+            }
+        });
+        m_sliceButtonClicksConnected = true;
+    }
 
     if (!useInline) {
         m_sliceTabRow->setVisible(true);
     }
+}
+
+void RxApplet::clearSliceButtons()
+{
+    if (m_sliceBtns.isEmpty()) {
+        return;
+    }
+
+    QSignalBlocker blocker(m_sliceGroup);
+    while (!m_sliceBtns.isEmpty()) {
+        QToolButton* btn = m_sliceBtns.takeLast();
+        m_sliceGroup->removeButton(btn);
+        delete btn;
+    }
+
+    m_sliceTabRow->setVisible(false);
+    m_sliceBadge->setVisible(true);
 }
 
 void RxApplet::updateSliceButtons(const QList<SliceModel*>& slices, int activeSliceId)

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1000,9 +1000,11 @@ void RxApplet::setAfGain(int pct)
 
 void RxApplet::setMaxSlices(int maxSlices)
 {
-    // Only create buttons once
     if (!m_sliceBtns.isEmpty()) {
-        return;
+        if (m_sliceBtns.size() == maxSlices) {
+            return;
+        }
+        clearSliceButtons();
     }
 
     if (maxSlices <= 1) {

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -56,6 +56,7 @@ public:
     // Slice tab toggle — create N buttons (A..H) capped at hardware max.
     // If maxSlices <= 1, the row is hidden.
     void setMaxSlices(int maxSlices);
+    void clearSliceButtons();
 
     // Enable/disable buttons based on which slices are open, and check the
     // button for the currently active slice.
@@ -113,6 +114,7 @@ private:
     QWidget*                m_sliceTabRow{nullptr};
     QButtonGroup*           m_sliceGroup{nullptr};
     QVector<QToolButton*>   m_sliceBtns;
+    bool                    m_sliceButtonClicksConnected{false};
 
     // ── Header row ────────────────────────────────────────────────────────
     QLabel*      m_sliceBadge{nullptr};   // "A" / "B" / "C" / "D"


### PR DESCRIPTION
## Bug
Fixes #2254.

The RX applet slice tab row was scoped to the process lifetime. After connecting to a radio with more slice capacity, disconnecting, then connecting to a smaller radio, the stale A-H buttons stayed in place because RxApplet::setMaxSlices() only created the row once and MainWindow's infoChanged initializer only ran once per process.

## Fix
- Add RxApplet::clearSliceButtons() to tear down the generated slice tab buttons and restore the static slice badge on disconnect.
- Expose that through AppletPanel.
- Replace the one-shot lambda capture in MainWindow with a per-connection member flag, reset it on disconnect, and let the next radio's infoChanged rebuild the row from its current maxSlices.
- Guard the slice button click connection so rebuilding the row does not duplicate signal handlers.

## Testing
- Built successfully: cmake --build /private/tmp/AetherSDR-issue-2254-build -j8
- Built and manually tested with #2278 in a temporary combined build: /private/tmp/AetherSDR-2254-wan-combined-build
- Manual SmartLink test confirmed Disconnect now clears the RX tab row when paired with #2278.

## Codex
Codex model used: GPT-5.

## Dependency
For SmartLink/WAN sessions, this UI fix depends on #2278 so RadioModel emits connectionStateChanged(false) during Disconnect. Without #2278, the applet teardown hook is not reached on WAN disconnect. LAN disconnect/reconnect uses the normal model teardown path.