### PR TITLE
Fix macOS panadapter popout refresh

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2076,6 +2076,7 @@ MainWindow::MainWindow(QWidget* parent)
             m_layoutRestoreTimer->setSingleShot(true);
             m_layoutRestoreTimer->setInterval(1000);
             connect(m_layoutRestoreTimer, &QTimer::timeout, this, [this]() {
+                m_layoutRestoreTimer->setProperty("fired", true);
                 // The radio restores pans from the GUIClientID session.
                 // Accept whatever the radio gives and arrange based on count.
                 const int panCount = m_panStack->count();
@@ -2130,7 +2131,9 @@ MainWindow::MainWindow(QWidget* parent)
                 m_panStack->restoreFloatingState();
             });
         }
-        m_layoutRestoreTimer->start();  // restart on each new pan
+        if (!m_layoutRestoreTimer->property("fired").toBool()) {
+            m_layoutRestoreTimer->start();
+        }
     });
     // Re-push xpixels/ypixels when the radio requests it (profile change, reconnect, etc.)
     connect(&m_radioModel, &RadioModel::panDimensionsNeeded,
@@ -2150,6 +2153,35 @@ MainWindow::MainWindow(QWidget* parent)
         if (pan->panStreamId())
             m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
     });
+
+#ifdef Q_OS_MAC
+    auto repushPanDimensions = [this]() {
+        QTimer::singleShot(200, this, [this]() {
+            for (auto* applet : m_panStack->allApplets()) {
+                auto* sw = applet->spectrumWidget();
+                auto* pan = m_radioModel.panadapter(applet->panId());
+                if (!sw || !pan) {
+                    continue;
+                }
+                const int xpix = sw->width();
+                const int ypix = sw->height();
+                if (xpix < 100 || ypix < 100) {
+                    continue;
+                }
+                m_radioModel.sendCommand(
+                    QString("display pan set %1 xpixels=%2 ypixels=%3")
+                        .arg(pan->panId()).arg(xpix).arg(ypix));
+                if (pan->panStreamId()) {
+                    m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+                }
+            }
+        });
+    };
+    connect(m_panStack, &PanadapterStack::panFloated,
+            this, [repushPanDimensions](const QString&) { repushPanDimensions(); });
+    connect(m_panStack, &PanadapterStack::panDocked,
+            this, [repushPanDimensions](const QString&) { repushPanDimensions(); });
+#endif
 
     connect(&m_radioModel, &RadioModel::panadapterRemoved,
             this, [this](const QString& panId) {
@@ -6864,6 +6896,9 @@ void MainWindow::onConnectionStateChanged(bool connected)
 {
     m_connPanel->setConnected(connected);
     if (connected) {
+        if (m_layoutRestoreTimer) {
+            m_layoutRestoreTimer->setProperty("fired", false);
+        }
         m_radioInfoLabel->setText(m_radioModel.model());
         m_radioVersionLabel->setText(m_radioModel.version());
         m_stationLabel->setText(m_radioModel.nickname());

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -18,7 +18,21 @@
 static void refreshAfterReparent(AetherSDR::SpectrumWidget* sw)
 {
     if (!sw) return;
+#if defined(Q_OS_MAC) && defined(AETHER_GPU_SPECTRUM)
+    const bool wasVisible = sw->isVisible();
+    sw->hide();
     sw->resetGpuResources();
+    if (QWindow* windowHandle = sw->windowHandle()) {
+        windowHandle->destroy();
+    }
+    sw->setAttribute(Qt::WA_NativeWindow);
+    if (wasVisible) {
+        sw->show();
+    }
+    QTimer::singleShot(50, sw, [sw]() { sw->update(); });
+#else
+    sw->resetGpuResources();
+#endif
 }
 
 namespace AetherSDR {
@@ -336,6 +350,126 @@ void PanadapterStack::removeAll()
     layout()->addWidget(m_splitter);
 }
 
+void PanadapterStack::rebuildDockedSplitter()
+{
+    QList<PanadapterApplet*> docked;
+    for (auto it = m_pans.cbegin(); it != m_pans.cend(); ++it) {
+        if (!m_floatingWindows.contains(it.key())) {
+            docked.append(it.value());
+        }
+    }
+
+    QSplitter* oldSplitter = m_splitter;
+    auto* newSplitter = new QSplitter(Qt::Vertical, this);
+    newSplitter->setHandleWidth(3);
+    newSplitter->setChildrenCollapsible(false);
+    layout()->addWidget(newSplitter);
+
+    static const QMap<QString, int> layoutPanCount = {
+        {"1", 1}, {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"3v", 3},
+        {"2x2", 4}, {"4v", 4}, {"3h2", 5}, {"2x3", 6}, {"4h3", 7}, {"2x4", 8}
+    };
+    QString layoutId = AppSettings::instance().value("PanadapterLayout", "1").toString();
+    if (layoutPanCount.value(layoutId, -1) != docked.size()) {
+        if (docked.size() == 2) {
+            layoutId = QStringLiteral("2v");
+        } else if (docked.size() == 3) {
+            layoutId = QStringLiteral("2h1");
+        } else if (docked.size() == 4) {
+            layoutId = QStringLiteral("2x2");
+        } else {
+            layoutId = QStringLiteral("1");
+        }
+    }
+
+    auto makeSplitter = [](Qt::Orientation orientation) {
+        auto* splitter = new QSplitter(orientation);
+        splitter->setHandleWidth(3);
+        splitter->setChildrenCollapsible(false);
+        return splitter;
+    };
+
+    auto addVertical = [&]() {
+        newSplitter->setOrientation(Qt::Vertical);
+        for (PanadapterApplet* applet : docked) {
+            newSplitter->addWidget(applet);
+            applet->show();
+        }
+    };
+
+    if (layoutId == "2h" && docked.size() >= 2) {
+        newSplitter->setOrientation(Qt::Horizontal);
+        newSplitter->addWidget(docked[0]);
+        newSplitter->addWidget(docked[1]);
+    } else if (layoutId == "2h1" && docked.size() >= 3) {
+        auto* topSplit = makeSplitter(Qt::Horizontal);
+        topSplit->addWidget(docked[0]);
+        topSplit->addWidget(docked[1]);
+        newSplitter->addWidget(topSplit);
+        newSplitter->addWidget(docked[2]);
+    } else if (layoutId == "12h" && docked.size() >= 3) {
+        auto* botSplit = makeSplitter(Qt::Horizontal);
+        botSplit->addWidget(docked[1]);
+        botSplit->addWidget(docked[2]);
+        newSplitter->addWidget(docked[0]);
+        newSplitter->addWidget(botSplit);
+    } else if (layoutId == "2x2" && docked.size() >= 4) {
+        auto* topSplit = makeSplitter(Qt::Horizontal);
+        topSplit->addWidget(docked[0]);
+        topSplit->addWidget(docked[1]);
+        auto* botSplit = makeSplitter(Qt::Horizontal);
+        botSplit->addWidget(docked[2]);
+        botSplit->addWidget(docked[3]);
+        newSplitter->addWidget(topSplit);
+        newSplitter->addWidget(botSplit);
+    } else if (layoutId == "3h2" && docked.size() >= 5) {
+        auto* topSplit = makeSplitter(Qt::Horizontal);
+        topSplit->addWidget(docked[0]);
+        topSplit->addWidget(docked[1]);
+        topSplit->addWidget(docked[2]);
+        auto* botSplit = makeSplitter(Qt::Horizontal);
+        botSplit->addWidget(docked[3]);
+        botSplit->addWidget(docked[4]);
+        newSplitter->addWidget(topSplit);
+        newSplitter->addWidget(botSplit);
+    } else if (layoutId == "2x3" && docked.size() >= 6) {
+        for (int r = 0; r < 3; ++r) {
+            auto* rowSplit = makeSplitter(Qt::Horizontal);
+            rowSplit->addWidget(docked[r * 2]);
+            rowSplit->addWidget(docked[r * 2 + 1]);
+            newSplitter->addWidget(rowSplit);
+        }
+    } else if (layoutId == "4h3" && docked.size() >= 7) {
+        auto* topSplit = makeSplitter(Qt::Horizontal);
+        topSplit->addWidget(docked[0]);
+        topSplit->addWidget(docked[1]);
+        topSplit->addWidget(docked[2]);
+        topSplit->addWidget(docked[3]);
+        auto* botSplit = makeSplitter(Qt::Horizontal);
+        botSplit->addWidget(docked[4]);
+        botSplit->addWidget(docked[5]);
+        botSplit->addWidget(docked[6]);
+        newSplitter->addWidget(topSplit);
+        newSplitter->addWidget(botSplit);
+    } else if (layoutId == "2x4" && docked.size() >= 8) {
+        for (int r = 0; r < 4; ++r) {
+            auto* rowSplit = makeSplitter(Qt::Horizontal);
+            rowSplit->addWidget(docked[r * 2]);
+            rowSplit->addWidget(docked[r * 2 + 1]);
+            newSplitter->addWidget(rowSplit);
+        }
+    } else {
+        addVertical();
+    }
+
+    layout()->removeWidget(m_splitter);
+    oldSplitter->hide();
+    oldSplitter->deleteLater();
+    m_splitter = newSplitter;
+
+    QTimer::singleShot(0, this, [this]() { equalizeSizes(); });
+}
+
 void PanadapterStack::applyLayout(const QString& layoutId, const QStringList& panIds)
 {
     // Build structure based on layout ID.
@@ -506,10 +640,12 @@ void PanadapterStack::floatPanadapter(const QString& panId)
     applet->spectrumWidget()->setFloating(true);
 
     m_floatingWindows[panId] = fw;
+    rebuildDockedSplitter();
     fw->restoreWindowGeometry();
     fw->show();
     fw->raise();
     saveFloatingState();
+    emit panFloated(panId);
 
     connect(fw, &PanFloatingWindow::dockRequested,
             this, &PanadapterStack::dockPanadapter);
@@ -563,6 +699,7 @@ void PanadapterStack::dockPanadapter(const QString& panId)
     // the splitter without an intermediate top-level state.
     m_splitter->addWidget(applet);
     applet->show();
+    rebuildDockedSplitter();
 
     const int count = m_splitter->count();
     if (count > 1) {
@@ -590,6 +727,7 @@ void PanadapterStack::dockPanadapter(const QString& panId)
             refreshAfterReparent(sw);
         });
     }
+    emit panDocked(panId);
 }
 
 bool PanadapterStack::isFloating(const QString& panId) const
@@ -621,6 +759,7 @@ void PanadapterStack::saveFloatingState() const
         ids << id;
     }
     AppSettings::instance().setValue("FloatingPanIds", ids.join(','));
+    AppSettings::instance().save();
 }
 
 void PanadapterStack::restoreFloatingState()

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -67,8 +67,12 @@ public:
 
 signals:
     void activePanChanged(const QString& panId);
+    void panFloated(const QString& panId);
+    void panDocked(const QString& panId);
 
 private:
+    void rebuildDockedSplitter();
+
     BandStackPanel* m_bandStackPanel{nullptr};
     QSplitter* m_splitter{nullptr};
     QMap<QString, PanadapterApplet*> m_pans;


### PR DESCRIPTION
Summary:
- Fix macOS panadapter popouts showing a static/stale spectrum image after detaching from the main window.
- Recreate the native QRhi/Metal surface after cross-window reparenting on macOS, then request fresh pan dimensions from the radio after float/dock.
- Prevent stale floating state from being restored again after later user-added pans, and rebuild the docked splitter so floating/docking multiple pans does not leave blank placeholder space in the main window.

Bug fixed:
On macOS, popping out a panadapter could create a separate window with only a still/static panadapter image. Closing/docking that popout and later adding another panadapter could also recreate an unwanted blank floating window because saved floating state was restored after the initial layout phase. With multiple panadapters, detaching panes could leave an empty splitter slot in the main window.

Testing:
- Configured and built on macOS with cmake -B /private/tmp/aethersdr-panadapter-popout-build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo.
- Built with cmake --build /private/tmp/aethersdr-panadapter-popout-build -j8.
- Manual app testing on macOS confirmed the detached panadapter updates live after the native surface reset change.
- Manual follow-up exposed and fixed the blank main-window placeholder after detaching multiple panadapters.