### PR TITLE
Serialize Qt log file writes to fix macOS tune crash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,8 @@
 #include <QDebug>
 #include <QFile>
 #include <QDateTime>
-#include <QTextStream>
+#include <QMutex>
+#include <QMutexLocker>
 #include <QStandardPaths>
 #include <QRegularExpression>
 
@@ -50,6 +51,14 @@ static int aetherTolerantX11ErrorHandler(AetherX11Display*, AetherX11ErrorEvent*
 #endif  // __linux__
 
 static QFile* s_logFile = nullptr;
+
+static QMutex* logMutex()
+{
+    // qInstallMessageHandler callbacks can arrive concurrently from any Qt
+    // thread; leak this intentionally so shutdown logging cannot outlive it.
+    static QMutex* mutex = new QMutex;
+    return mutex;
+}
 
 // Redact PII from log messages before writing to file.
 // Patterns: IP addresses, radio serial numbers, Auth0 tokens, MAC addresses.
@@ -96,21 +105,23 @@ static QString redactPii(const QString& msg)
 static void messageHandler(QtMsgType type, const QMessageLogContext& ctx, const QString& msg)
 {
     Q_UNUSED(ctx);
+    QMutexLocker locker(logMutex());
+
     static const char* labels[] = {"DBG", "WRN", "CRT", "FTL", "INF"};
     const char* label = (type <= QtInfoMsg) ? labels[type] : "???";
 
     const QString safeMsg = redactPii(msg);
     const QString line = QString("[%1] %2: %3\n")
         .arg(QDateTime::currentDateTime().toString("HH:mm:ss.zzz"), label, safeMsg);
+    const QByteArray lineBytes = line.toUtf8();
 
     // Write to log file (PII-redacted)
     if (s_logFile && s_logFile->isOpen()) {
-        QTextStream ts(s_logFile);
-        ts << line;
-        ts.flush();
+        s_logFile->write(lineBytes);
+        s_logFile->flush();
     }
     // Also print to stderr (PII-redacted)
-    fprintf(stderr, "%s", line.toLocal8Bit().constData());
+    fprintf(stderr, "%s", lineBytes.constData());
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
## Summary

- Serialize the global Qt message handler before it touches the shared log file.
- Replace per-message `QTextStream` wrapping with a direct UTF-8 `QFile::write()`/`flush()` path.
- Leave all tune, slice, panadapter, and radio command behavior unchanged.

## Root Cause

The macOS crash report aborts in libmalloc while Qt is appending a log line:

`QDebug::~QDebug()` -> `MainWindow::logTunePolicyDecision()` -> Qt message handler -> `QTextStreamPrivate::flushWriteBuffer()` -> `QFileDevice::writeData()` -> `QRingBuffer::append()` -> malloc abort.

`qInstallMessageHandler` can receive messages from any Qt thread, but AetherSDR's handler wrote every log message through one global `QFile*` without synchronization. Concurrent `qDebug()`/`qCInfo()` output from the main thread and worker threads can corrupt Qt's internal file/write buffer state. The tune policy diagnostic line in the crash report is the log message that exposed the corruption; the failing object is the logging sink, not the Flex tune command path.

The fix adds one intentionally leaked mutex, mirroring the existing shutdown-safe treatment of the redaction regexes, and holds it across PII redaction, file write, and stderr write so the handler is fully serialized.

## Radio Behavior

This PR does not change radio command ordering or panadapter policy. The existing `applyTuneRequest()` flow still sends `slice tune ... autopan=0`, optionally applies local pan status, and then sends the same `display pan set ... center=...` command when the reveal/follow policy decides it is needed. I checked the local FlexLib v4.2.18 references for `slice tune` and `display pan set` while confirming this stayed outside the radio API path.

## Validation

- `cmake --build build --parallel 10`
- `ctest --test-dir build --output-on-failure -j10`
- `git diff --check`

Local app bundle from validation build:

`/private/tmp/AetherSDR-macos-log-crash-root-cause/build/AetherSDR.app`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
