### PR TITLE
Aetherial Noise Reduction: docked applet + DSP surface consolidation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,6 +514,8 @@ set(GUI_SOURCES
     src/gui/MemoryDialog.cpp
     src/gui/SpotSettingsDialog.cpp
     src/gui/AetherDspDialog.cpp
+    src/gui/AetherDspWidget.cpp
+    src/gui/ClientRxDspApplet.cpp
     src/gui/DspParamPopup.cpp
     src/gui/DxClusterDialog.cpp
     src/gui/CwxPanel.cpp

--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -1,697 +1,75 @@
 #include "AetherDspDialog.h"
-#include "core/AudioEngine.h"
-#include "core/AppSettings.h"
-#include "GuardedSlider.h"
+#include "AetherDspWidget.h"
 
-#include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QGridLayout>
-#include <QGroupBox>
-#include <QTabWidget>
-#include <QRadioButton>
-#include <QButtonGroup>
-#include <QCheckBox>
 #include <QLabel>
-#include <QPushButton>
+#include <QVBoxLayout>
 
 namespace AetherSDR {
 
-static const QString kDialogStyle = QStringLiteral(
-    "QDialog { background: #0f0f1a; color: #c8d8e8; }"
-    "QTabWidget::pane { border: 1px solid #304050; background: #0f0f1a; }"
-    "QTabBar::tab { background: #1a2a3a; color: #8090a0; padding: 6px 16px;"
-    "  border: 1px solid #304050; border-bottom: none; border-radius: 3px 3px 0 0; }"
-    "QTabBar::tab:selected { background: #0f0f1a; color: #c8d8e8;"
-    "  border-bottom: 1px solid #0f0f1a; }"
-    "QGroupBox { border: 1px solid #304050; border-radius: 4px;"
-    "  margin-top: 12px; padding-top: 8px; color: #8090a0; }"
-    "QGroupBox::title { subcontrol-origin: margin; left: 8px; padding: 0 4px; }"
-    "QLabel { color: #8090a0; }"
-    "QRadioButton { color: #c8d8e8; }"
-    "QCheckBox { color: #c8d8e8; }"
-    "QPushButton { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050;"
-    "  border-radius: 3px; padding: 4px 12px; }"
-    "QPushButton:hover { background: rgba(0, 112, 192, 180); border: 1px solid #0090e0; }");
-
-static const QString kSliderStyle = QStringLiteral(
-    "QSlider::groove:horizontal { height: 4px; background: #304050; border-radius: 2px; }"
-    "QSlider::handle:horizontal { width: 12px; height: 12px; margin: -4px 0;"
-    "  background: #c8d8e8; border-radius: 6px; }"
-    "QSlider::handle:horizontal:hover { background: #00b4d8; }");
-
 AetherDspDialog::AetherDspDialog(AudioEngine* audio, QWidget* parent)
     : QDialog(parent)
-    , m_audio(audio)
 {
     setWindowTitle("AetherDSP Settings");
     setMinimumSize(420, 380);
-    setStyleSheet(kDialogStyle);
+    setStyleSheet("QDialog { background: #0f0f1a; color: #c8d8e8; }");
 
     auto* root = new QVBoxLayout(this);
-
     auto* title = new QLabel("AetherDSP Settings");
     title->setAlignment(Qt::AlignCenter);
-    title->setStyleSheet("QLabel { font-size: 16px; font-weight: bold; color: #c8d8e8; }");
+    title->setStyleSheet(
+        "QLabel { font-size: 16px; font-weight: bold; color: #c8d8e8; }");
     root->addWidget(title);
     root->addSpacing(4);
 
-    m_tabs = new QTabWidget;
-    buildNr2Tab(m_tabs);
-    buildNr4Tab(m_tabs);
-    buildMnrTab(m_tabs);
-    buildDfnrTab(m_tabs);
-    buildRn2Tab(m_tabs);
-    buildBnrTab(m_tabs);
-    root->addWidget(m_tabs);
+    m_widget = new AetherDspWidget(audio, this);
+    root->addWidget(m_widget);
 
-    syncFromEngine();
+    // Forward every parameter-change signal so existing connections to
+    // AetherDspDialog::* keep working unchanged.
+    connect(m_widget, &AetherDspWidget::nr2GainMaxChanged,
+            this,    &AetherDspDialog::nr2GainMaxChanged);
+    connect(m_widget, &AetherDspWidget::nr2GainSmoothChanged,
+            this,    &AetherDspDialog::nr2GainSmoothChanged);
+    connect(m_widget, &AetherDspWidget::nr2QsppChanged,
+            this,    &AetherDspDialog::nr2QsppChanged);
+    connect(m_widget, &AetherDspWidget::nr2GainMethodChanged,
+            this,    &AetherDspDialog::nr2GainMethodChanged);
+    connect(m_widget, &AetherDspWidget::nr2NpeMethodChanged,
+            this,    &AetherDspDialog::nr2NpeMethodChanged);
+    connect(m_widget, &AetherDspWidget::nr2AeFilterChanged,
+            this,    &AetherDspDialog::nr2AeFilterChanged);
+    connect(m_widget, &AetherDspWidget::mnrEnabledChanged,
+            this,    &AetherDspDialog::mnrEnabledChanged);
+    connect(m_widget, &AetherDspWidget::mnrStrengthChanged,
+            this,    &AetherDspDialog::mnrStrengthChanged);
+    connect(m_widget, &AetherDspWidget::dfnrAttenLimitChanged,
+            this,    &AetherDspDialog::dfnrAttenLimitChanged);
+    connect(m_widget, &AetherDspWidget::dfnrPostFilterBetaChanged,
+            this,    &AetherDspDialog::dfnrPostFilterBetaChanged);
+    connect(m_widget, &AetherDspWidget::nr4ReductionChanged,
+            this,    &AetherDspDialog::nr4ReductionChanged);
+    connect(m_widget, &AetherDspWidget::nr4SmoothingChanged,
+            this,    &AetherDspDialog::nr4SmoothingChanged);
+    connect(m_widget, &AetherDspWidget::nr4WhiteningChanged,
+            this,    &AetherDspDialog::nr4WhiteningChanged);
+    connect(m_widget, &AetherDspWidget::nr4AdaptiveNoiseChanged,
+            this,    &AetherDspDialog::nr4AdaptiveNoiseChanged);
+    connect(m_widget, &AetherDspWidget::nr4NoiseMethodChanged,
+            this,    &AetherDspDialog::nr4NoiseMethodChanged);
+    connect(m_widget, &AetherDspWidget::nr4MaskingDepthChanged,
+            this,    &AetherDspDialog::nr4MaskingDepthChanged);
+    connect(m_widget, &AetherDspWidget::nr4SuppressionChanged,
+            this,    &AetherDspDialog::nr4SuppressionChanged);
+}
+
+void AetherDspDialog::syncFromEngine()
+{
+    if (m_widget) m_widget->syncFromEngine();
 }
 
 void AetherDspDialog::selectTab(const QString& name)
 {
-    if (!m_tabs) return;
-    for (int i = 0; i < m_tabs->count(); ++i) {
-        if (m_tabs->tabText(i) == name) {
-            m_tabs->setCurrentIndex(i);
-            return;
-        }
-    }
-}
-
-// ── NR2 Tab ──────────────────────────────────────────────────────────────────
-
-void AetherDspDialog::buildNr2Tab(QTabWidget* tabs)
-{
-    auto* page = new QWidget;
-    auto* vbox = new QVBoxLayout(page);
-
-    auto labelStyle = QStringLiteral("QLabel { color: #8090a0; font-size: 11px; }");
-    auto valStyle   = QStringLiteral("QLabel { color: #c8d8e8; font-size: 11px; min-width: 40px; }");
-
-    // Gain Method
-    auto* gainGroup = new QGroupBox("Gain Method");
-    auto* gainLayout = new QHBoxLayout(gainGroup);
-    m_nr2GainGroup = new QButtonGroup(this);
-    const char* gainLabels[] = {"Linear", "Log", "Gamma", "Trained"};
-    for (int i = 0; i < 4; ++i) {
-        auto* rb = new QRadioButton(gainLabels[i]);
-        m_nr2GainGroup->addButton(rb, i);
-        gainLayout->addWidget(rb);
-    }
-    m_nr2GainGroup->button(0)->setToolTip("Linear audio amplitude scale for gain computation.");
-    m_nr2GainGroup->button(1)->setToolTip("Logarithmic amplitude scale \u2014 compresses dynamic range.");
-    m_nr2GainGroup->button(2)->setToolTip("Gamma distribution model matching typical speech amplitude patterns.");
-    m_nr2GainGroup->button(3)->setToolTip("Noise reduction model trained on real speech and noise samples.");
-    m_nr2GainGroup->button(2)->setChecked(true);  // Gamma default
-    connect(m_nr2GainGroup, &QButtonGroup::idClicked, this, [this](int id) {
-        auto& s = AppSettings::instance();
-        s.setValue("NR2GainMethod", QString::number(id));
-        s.save();
-        emit nr2GainMethodChanged(id);
-    });
-    vbox->addWidget(gainGroup);
-
-    // NPE Method
-    auto* npeGroup = new QGroupBox("NPE Method");
-    auto* npeLayout = new QHBoxLayout(npeGroup);
-    m_nr2NpeGroup = new QButtonGroup(this);
-    const char* npeLabels[] = {"OSMS", "MMSE", "NSTAT"};
-    for (int i = 0; i < 3; ++i) {
-        auto* rb = new QRadioButton(npeLabels[i]);
-        m_nr2NpeGroup->addButton(rb, i);
-        npeLayout->addWidget(rb);
-    }
-    m_nr2NpeGroup->button(0)->setToolTip("Optimal Smoothing Minimum Statistics \u2014 tracks noise floor using a running minimum estimate.");
-    m_nr2NpeGroup->button(1)->setToolTip("Minimum Mean Squared Error \u2014 minimizes the expected noise estimation error.");
-    m_nr2NpeGroup->button(2)->setToolTip("Non-Stationary estimation \u2014 adapts to noise that changes over time.");
-    m_nr2NpeGroup->button(0)->setChecked(true);  // OSMS default
-    connect(m_nr2NpeGroup, &QButtonGroup::idClicked, this, [this](int id) {
-        auto& s = AppSettings::instance();
-        s.setValue("NR2NpeMethod", QString::number(id));
-        s.save();
-        emit nr2NpeMethodChanged(id);
-    });
-    vbox->addWidget(npeGroup);
-
-    // AE Filter
-    m_nr2AeCheck = new QCheckBox("AE Filter (artifact elimination)");
-    m_nr2AeCheck->setToolTip("Reduces ringing and musical artifacts typical of frequency-domain noise reduction.");
-    m_nr2AeCheck->setChecked(true);
-    connect(m_nr2AeCheck, &QCheckBox::toggled, this, [this](bool on) {
-        auto& s = AppSettings::instance();
-        s.setValue("NR2AeFilter", on ? "True" : "False");
-        s.save();
-        emit nr2AeFilterChanged(on);
-    });
-    vbox->addWidget(m_nr2AeCheck);
-
-    // Sliders: GainMax, GainSmooth, Q_SPP
-    auto* sliderGrid = new QGridLayout;
-    int row = 0;
-
-    // Gain Max (reduction depth)
-    {
-        auto* lbl = new QLabel("Reduction Depth:");
-        lbl->setStyleSheet(labelStyle);
-        sliderGrid->addWidget(lbl, row, 0);
-        m_nr2GainMaxSlider = new GuardedSlider(Qt::Horizontal);
-        m_nr2GainMaxSlider->setRange(50, 200);  // 0.50–2.00
-        m_nr2GainMaxSlider->setValue(150);       // default 1.50
-        m_nr2GainMaxSlider->setStyleSheet(kSliderStyle);
-        m_nr2GainMaxSlider->setToolTip("Maximum noise reduction depth. Higher values suppress more noise but risk distorting speech.");
-        sliderGrid->addWidget(m_nr2GainMaxSlider, row, 1);
-        m_nr2GainMaxLabel = new QLabel("1.50");
-        m_nr2GainMaxLabel->setStyleSheet(valStyle);
-        m_nr2GainMaxLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        sliderGrid->addWidget(m_nr2GainMaxLabel, row, 2);
-        connect(m_nr2GainMaxSlider, &QSlider::valueChanged, this, [this](int v) {
-            float val = v / 100.0f;
-            m_nr2GainMaxLabel->setText(QString::number(val, 'f', 2));
-            auto& s = AppSettings::instance();
-            s.setValue("NR2GainMax", QString::number(val, 'f', 2));
-            s.save();
-            emit nr2GainMaxChanged(val);
-        });
-        ++row;
-    }
-
-    // Gain Smooth
-    {
-        auto* lbl = new QLabel("Smoothing:");
-        lbl->setStyleSheet(labelStyle);
-        sliderGrid->addWidget(lbl, row, 0);
-        m_nr2SmoothSlider = new GuardedSlider(Qt::Horizontal);
-        m_nr2SmoothSlider->setRange(50, 98);  // 0.50–0.98
-        m_nr2SmoothSlider->setValue(85);       // default 0.85
-        m_nr2SmoothSlider->setStyleSheet(kSliderStyle);
-        m_nr2SmoothSlider->setToolTip("How smoothly the noise estimate tracks changes. Higher values give steadier but slower adaptation.");
-        sliderGrid->addWidget(m_nr2SmoothSlider, row, 1);
-        m_nr2SmoothLabel = new QLabel("0.85");
-        m_nr2SmoothLabel->setStyleSheet(valStyle);
-        m_nr2SmoothLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        sliderGrid->addWidget(m_nr2SmoothLabel, row, 2);
-        connect(m_nr2SmoothSlider, &QSlider::valueChanged, this, [this](int v) {
-            float val = v / 100.0f;
-            m_nr2SmoothLabel->setText(QString::number(val, 'f', 2));
-            auto& s = AppSettings::instance();
-            s.setValue("NR2GainSmooth", QString::number(val, 'f', 2));
-            s.save();
-            emit nr2GainSmoothChanged(val);
-        });
-        ++row;
-    }
-
-    // Q_SPP (voice threshold)
-    {
-        auto* lbl = new QLabel("Voice Threshold:");
-        lbl->setStyleSheet(labelStyle);
-        sliderGrid->addWidget(lbl, row, 0);
-        m_nr2QsppSlider = new GuardedSlider(Qt::Horizontal);
-        m_nr2QsppSlider->setRange(5, 50);  // 0.05–0.50
-        m_nr2QsppSlider->setValue(20);      // default 0.20
-        m_nr2QsppSlider->setStyleSheet(kSliderStyle);
-        m_nr2QsppSlider->setToolTip("Speech detection threshold. Lower values preserve quiet speech but may pass more noise.");
-        sliderGrid->addWidget(m_nr2QsppSlider, row, 1);
-        m_nr2QsppLabel = new QLabel("0.20");
-        m_nr2QsppLabel->setStyleSheet(valStyle);
-        m_nr2QsppLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        sliderGrid->addWidget(m_nr2QsppLabel, row, 2);
-        connect(m_nr2QsppSlider, &QSlider::valueChanged, this, [this](int v) {
-            float val = v / 100.0f;
-            m_nr2QsppLabel->setText(QString::number(val, 'f', 2));
-            auto& s = AppSettings::instance();
-            s.setValue("NR2Qspp", QString::number(val, 'f', 2));
-            s.save();
-            emit nr2QsppChanged(val);
-        });
-        ++row;
-    }
-
-    vbox->addLayout(sliderGrid);
-
-    // Reset button
-    auto* resetBtn = new QPushButton("Reset Defaults");
-    connect(resetBtn, &QPushButton::clicked, this, [this]() {
-        m_nr2GainGroup->button(2)->setChecked(true);    // Gamma
-        m_nr2NpeGroup->button(0)->setChecked(true);     // OSMS
-        m_nr2AeCheck->setChecked(true);
-        m_nr2GainMaxSlider->setValue(150);               // 1.50
-        m_nr2SmoothSlider->setValue(85);                 // 0.85
-        m_nr2QsppSlider->setValue(20);                   // 0.20
-    });
-    auto* btnRow = new QHBoxLayout;
-    btnRow->addStretch();
-    btnRow->addWidget(resetBtn);
-    vbox->addLayout(btnRow);
-
-    vbox->addStretch();
-    tabs->addTab(page, "NR2");
-}
-
-// ── NR4 Tab (libspecbleach) ──────────────────────────────────────────────────
-
-void AetherDspDialog::buildNr4Tab(QTabWidget* tabs)
-{
-    auto* page = new QWidget;
-    auto* vbox = new QVBoxLayout(page);
-
-    auto labelStyle = QStringLiteral("QLabel { color: #8090a0; font-size: 11px; }");
-    auto valStyle   = QStringLiteral("QLabel { color: #c8d8e8; font-size: 11px; min-width: 40px; }");
-
-    // Noise Estimation Method
-    auto* methodGroup = new QGroupBox("Noise Estimation Method");
-    auto* methodLayout = new QHBoxLayout(methodGroup);
-    m_nr4MethodGroup = new QButtonGroup(this);
-    const char* methodLabels[] = {"SPP-MMSE", "Brandt", "Martin"};
-    for (int i = 0; i < 3; ++i) {
-        auto* rb = new QRadioButton(methodLabels[i]);
-        m_nr4MethodGroup->addButton(rb, i);
-        methodLayout->addWidget(rb);
-    }
-    m_nr4MethodGroup->button(0)->setToolTip("MMSE with Speech Presence Probability \u2014 balances noise estimation with speech preservation.");
-    m_nr4MethodGroup->button(1)->setToolTip("Recursive smoothing using critical frequency bands \u2014 good for non-stationary noise.");
-    m_nr4MethodGroup->button(2)->setToolTip("Minimum statistics using running spectral minima \u2014 robust for slowly varying noise floors.");
-    m_nr4MethodGroup->button(0)->setChecked(true);
-    connect(m_nr4MethodGroup, &QButtonGroup::idClicked, this, [this](int id) {
-        auto& s = AppSettings::instance();
-        s.setValue("NR4NoiseEstimationMethod", QString::number(id));
-        s.save();
-        emit nr4NoiseMethodChanged(id);
-    });
-    vbox->addWidget(methodGroup);
-
-    // Adaptive Noise
-    m_nr4AdaptiveCheck = new QCheckBox("Adaptive Noise Estimation");
-    m_nr4AdaptiveCheck->setToolTip("Continuously re-estimates the noise floor as conditions change. Disable for stable environments.");
-    m_nr4AdaptiveCheck->setChecked(true);
-    connect(m_nr4AdaptiveCheck, &QCheckBox::toggled, this, [this](bool on) {
-        auto& s = AppSettings::instance();
-        s.setValue("NR4AdaptiveNoise", on ? "True" : "False");
-        s.save();
-        emit nr4AdaptiveNoiseChanged(on);
-    });
-    vbox->addWidget(m_nr4AdaptiveCheck);
-
-    // Sliders
-    auto* sliderGrid = new QGridLayout;
-    int row = 0;
-
-    // Reduction Amount (0–40 dB)
-    {
-        auto* lbl = new QLabel("Reduction (dB):");
-        lbl->setStyleSheet(labelStyle);
-        sliderGrid->addWidget(lbl, row, 0);
-        m_nr4ReductionSlider = new GuardedSlider(Qt::Horizontal);
-        m_nr4ReductionSlider->setRange(0, 400);  // 0.0–40.0
-        m_nr4ReductionSlider->setValue(100);      // default 10.0
-        m_nr4ReductionSlider->setStyleSheet(kSliderStyle);
-        m_nr4ReductionSlider->setToolTip("Maximum noise reduction in dB. Higher values remove more noise but may affect speech.");
-        sliderGrid->addWidget(m_nr4ReductionSlider, row, 1);
-        m_nr4ReductionLabel = new QLabel("10.0");
-        m_nr4ReductionLabel->setStyleSheet(valStyle);
-        m_nr4ReductionLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        sliderGrid->addWidget(m_nr4ReductionLabel, row, 2);
-        connect(m_nr4ReductionSlider, &QSlider::valueChanged, this, [this](int v) {
-            float val = v / 10.0f;
-            m_nr4ReductionLabel->setText(QString::number(val, 'f', 1));
-            auto& s = AppSettings::instance();
-            s.setValue("NR4ReductionAmount", QString::number(val, 'f', 1));
-            s.save();
-            emit nr4ReductionChanged(val);
-        });
-        ++row;
-    }
-
-    // Smoothing Factor (0–100%)
-    {
-        auto* lbl = new QLabel("Smoothing (%):");
-        lbl->setStyleSheet(labelStyle);
-        sliderGrid->addWidget(lbl, row, 0);
-        m_nr4SmoothingSlider = new GuardedSlider(Qt::Horizontal);
-        m_nr4SmoothingSlider->setRange(0, 100);
-        m_nr4SmoothingSlider->setValue(0);  // default 0%
-        m_nr4SmoothingSlider->setStyleSheet(kSliderStyle);
-        m_nr4SmoothingSlider->setToolTip("Time-domain smoothing of the noise estimate. Higher values produce steadier but slower reduction.");
-        sliderGrid->addWidget(m_nr4SmoothingSlider, row, 1);
-        m_nr4SmoothingLabel = new QLabel("0");
-        m_nr4SmoothingLabel->setStyleSheet(valStyle);
-        m_nr4SmoothingLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        sliderGrid->addWidget(m_nr4SmoothingLabel, row, 2);
-        connect(m_nr4SmoothingSlider, &QSlider::valueChanged, this, [this](int v) {
-            m_nr4SmoothingLabel->setText(QString::number(v));
-            auto& s = AppSettings::instance();
-            s.setValue("NR4SmoothingFactor", QString::number(static_cast<float>(v), 'f', 1));
-            s.save();
-            emit nr4SmoothingChanged(static_cast<float>(v));
-        });
-        ++row;
-    }
-
-    // Whitening Factor (0–100%)
-    {
-        auto* lbl = new QLabel("Whitening (%):");
-        lbl->setStyleSheet(labelStyle);
-        sliderGrid->addWidget(lbl, row, 0);
-        m_nr4WhiteningSlider = new GuardedSlider(Qt::Horizontal);
-        m_nr4WhiteningSlider->setRange(0, 100);
-        m_nr4WhiteningSlider->setValue(0);  // default 0%
-        m_nr4WhiteningSlider->setStyleSheet(kSliderStyle);
-        m_nr4WhiteningSlider->setToolTip("Flattens the spectral shape of residual noise so it sounds more uniform.");
-        sliderGrid->addWidget(m_nr4WhiteningSlider, row, 1);
-        m_nr4WhiteningLabel = new QLabel("0");
-        m_nr4WhiteningLabel->setStyleSheet(valStyle);
-        m_nr4WhiteningLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        sliderGrid->addWidget(m_nr4WhiteningLabel, row, 2);
-        connect(m_nr4WhiteningSlider, &QSlider::valueChanged, this, [this](int v) {
-            m_nr4WhiteningLabel->setText(QString::number(v));
-            auto& s = AppSettings::instance();
-            s.setValue("NR4WhiteningFactor", QString::number(static_cast<float>(v), 'f', 1));
-            s.save();
-            emit nr4WhiteningChanged(static_cast<float>(v));
-        });
-        ++row;
-    }
-
-    // Masking Depth (0.0–1.0)
-    {
-        auto* lbl = new QLabel("Masking Depth:");
-        lbl->setStyleSheet(labelStyle);
-        sliderGrid->addWidget(lbl, row, 0);
-        m_nr4MaskingSlider = new GuardedSlider(Qt::Horizontal);
-        m_nr4MaskingSlider->setRange(0, 100);  // 0.00–1.00
-        m_nr4MaskingSlider->setValue(50);       // default 0.50
-        m_nr4MaskingSlider->setStyleSheet(kSliderStyle);
-        m_nr4MaskingSlider->setToolTip("Depth of spectral masking. Higher values suppress more noise in masked frequency regions.");
-        sliderGrid->addWidget(m_nr4MaskingSlider, row, 1);
-        m_nr4MaskingLabel = new QLabel("0.50");
-        m_nr4MaskingLabel->setStyleSheet(valStyle);
-        m_nr4MaskingLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        sliderGrid->addWidget(m_nr4MaskingLabel, row, 2);
-        connect(m_nr4MaskingSlider, &QSlider::valueChanged, this, [this](int v) {
-            float val = v / 100.0f;
-            m_nr4MaskingLabel->setText(QString::number(val, 'f', 2));
-            auto& s = AppSettings::instance();
-            s.setValue("NR4MaskingDepth", QString::number(val, 'f', 2));
-            s.save();
-            emit nr4MaskingDepthChanged(val);
-        });
-        ++row;
-    }
-
-    // Suppression Strength (0.0–1.0)
-    {
-        auto* lbl = new QLabel("Suppression:");
-        lbl->setStyleSheet(labelStyle);
-        sliderGrid->addWidget(lbl, row, 0);
-        m_nr4SuppressionSlider = new GuardedSlider(Qt::Horizontal);
-        m_nr4SuppressionSlider->setRange(0, 100);  // 0.00–1.00
-        m_nr4SuppressionSlider->setValue(50);       // default 0.50
-        m_nr4SuppressionSlider->setStyleSheet(kSliderStyle);
-        m_nr4SuppressionSlider->setToolTip("Overall suppression strength. Higher values apply more aggressive noise removal.");
-        sliderGrid->addWidget(m_nr4SuppressionSlider, row, 1);
-        m_nr4SuppressionLabel = new QLabel("0.50");
-        m_nr4SuppressionLabel->setStyleSheet(valStyle);
-        m_nr4SuppressionLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        sliderGrid->addWidget(m_nr4SuppressionLabel, row, 2);
-        connect(m_nr4SuppressionSlider, &QSlider::valueChanged, this, [this](int v) {
-            float val = v / 100.0f;
-            m_nr4SuppressionLabel->setText(QString::number(val, 'f', 2));
-            auto& s = AppSettings::instance();
-            s.setValue("NR4SuppressionStrength", QString::number(val, 'f', 2));
-            s.save();
-            emit nr4SuppressionChanged(val);
-        });
-        ++row;
-    }
-
-    vbox->addLayout(sliderGrid);
-
-    // Reset button
-    auto* resetBtn = new QPushButton("Reset Defaults");
-    connect(resetBtn, &QPushButton::clicked, this, [this]() {
-        m_nr4MethodGroup->button(0)->setChecked(true);   // SPP-MMSE
-        m_nr4AdaptiveCheck->setChecked(true);
-        m_nr4ReductionSlider->setValue(100);              // 10.0 dB
-        m_nr4SmoothingSlider->setValue(0);                // 0%
-        m_nr4WhiteningSlider->setValue(0);                // 0%
-        m_nr4MaskingSlider->setValue(50);                 // 0.50
-        m_nr4SuppressionSlider->setValue(50);             // 0.50
-    });
-    auto* btnRow = new QHBoxLayout;
-    btnRow->addStretch();
-    btnRow->addWidget(resetBtn);
-    vbox->addLayout(btnRow);
-
-    vbox->addStretch();
-    tabs->addTab(page, "NR4");
-}
-
-// ── MNR Tab ──────────────────────────────────────────────────────────────────
-
-void AetherDspDialog::buildMnrTab(QTabWidget* tabs)
-{
-    auto* page = new QWidget;
-    auto* vbox = new QVBoxLayout(page);
-
-    auto labelStyle = QStringLiteral("QLabel { color: #8090a0; font-size: 11px; }");
-    auto valStyle   = QStringLiteral("QLabel { color: #c8d8e8; font-size: 11px; min-width: 40px; }");
-
-    // Enable checkbox
-    m_mnrEnableCheck = new QCheckBox("Enable MNR (macOS only)");
-    m_mnrEnableCheck->setToolTip("MMSE-Wiener spectral noise reduction with asymmetric gain smoothing.\n"
-                                 "Removes consistent background noise while preserving speech quality.");
-    vbox->addWidget(m_mnrEnableCheck);
-    connect(m_mnrEnableCheck, &QCheckBox::toggled, this, [this](bool checked) {
-        auto& s = AppSettings::instance();
-        s.setValue("MnrEnabled", checked ? "True" : "False");
-        s.save();
-        emit mnrEnabledChanged(checked);
-    });
-
-    // Strength slider
-    {
-        auto* row = new QHBoxLayout;
-        auto* lbl = new QLabel("Strength");
-        lbl->setStyleSheet(labelStyle);
-        row->addWidget(lbl);
-
-        m_mnrStrengthSlider = new GuardedSlider(Qt::Horizontal);
-        m_mnrStrengthSlider->setRange(0, 100);
-        m_mnrStrengthSlider->setValue(100);
-        m_mnrStrengthSlider->setStyleSheet(kSliderStyle);
-        m_mnrStrengthSlider->setToolTip("Adjust noise reduction aggressiveness (0 = mild, 100 = maximum)");
-        row->addWidget(m_mnrStrengthSlider, 1);
-
-        m_mnrStrengthLabel = new QLabel("100%");
-        m_mnrStrengthLabel->setStyleSheet(valStyle);
-        row->addWidget(m_mnrStrengthLabel);
-        vbox->addLayout(row);
-
-        connect(m_mnrStrengthSlider, &QSlider::valueChanged, this, [this](int value) {
-            float normalized = value / 100.0f;
-            m_mnrStrengthLabel->setText(QString::number(value) + "%");
-            auto& s = AppSettings::instance();
-            s.setValue("MnrStrength", QString::number(normalized, 'f', 2));
-            s.save();
-            emit mnrStrengthChanged(normalized);
-        });
-    }
-
-    // Info
-    auto* info = new QLabel("Asymmetric temporal smoothing: fast release (~15ms) for quick noise suppression,\n"
-                            "gentle attack (~64ms) to preserve speech transients without artifacts.");
-    info->setWordWrap(true);
-    info->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; }");
-    vbox->addSpacing(8);
-    vbox->addWidget(info);
-
-    vbox->addStretch();
-    tabs->addTab(page, "MNR");
-}
-
-// ── RN2 Tab ─────────────────────────────────────────────────────────────────
-
-void AetherDspDialog::buildRn2Tab(QTabWidget* tabs)
-{
-    auto* page = new QWidget;
-    auto* vbox = new QVBoxLayout(page);
-    auto* lbl = new QLabel("RN2 (RNNoise) — no adjustable parameters");
-    lbl->setAlignment(Qt::AlignCenter);
-    lbl->setStyleSheet("QLabel { color: #8aa8c0; font-size: 14px; }");
-    vbox->addWidget(lbl);
-    vbox->addStretch();
-    tabs->addTab(page, "RN2");
-}
-
-// ── BNR Tab ─────────────────────────────────────────────────────────────────
-
-void AetherDspDialog::buildBnrTab(QTabWidget* tabs)
-{
-    auto* page = new QWidget;
-    auto* vbox = new QVBoxLayout(page);
-    auto* lbl = new QLabel("BNR (NVIDIA) — intensity controlled from overlay menu");
-    lbl->setAlignment(Qt::AlignCenter);
-    lbl->setStyleSheet("QLabel { color: #8aa8c0; font-size: 14px; }");
-    vbox->addWidget(lbl);
-    vbox->addStretch();
-    tabs->addTab(page, "BNR");
-}
-
-// ── DFNR Tab ────────────────────────────────────────────────────────────────
-
-void AetherDspDialog::buildDfnrTab(QTabWidget* tabs)
-{
-    auto* page = new QWidget;
-    auto* vbox = new QVBoxLayout(page);
-
-    auto* group = new QGroupBox("DeepFilterNet3 (DFNR)");
-    auto* grid = new QGridLayout(group);
-    grid->setColumnStretch(1, 1);
-
-    auto& s = AppSettings::instance();
-
-    // Info label
-    auto* info = new QLabel("AI-powered speech enhancement \u2014 higher fidelity than RNNoise\n"
-                            "in high-noise HF environments. CPU-only, 10 ms latency, 48 kHz.");
-    info->setWordWrap(true);
-    info->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; }");
-    grid->addWidget(info, 0, 0, 1, 3);
-
-    // Attenuation Limit slider
-    grid->addWidget(new QLabel("Attenuation Limit"), 1, 0);
-    m_dfnrAttenSlider = new QSlider(Qt::Horizontal);
-    m_dfnrAttenSlider->setRange(0, 100);
-    m_dfnrAttenSlider->setValue(static_cast<int>(s.value("DfnrAttenLimit", "100").toFloat()));
-    m_dfnrAttenSlider->setStyleSheet(kSliderStyle);
-    m_dfnrAttenSlider->setToolTip("Maximum noise attenuation in dB.\n"
-                                   "0 dB = passthrough (no denoising)\n"
-                                   "100 dB = maximum noise removal\n\n"
-                                   "For weak signals: 20\u201330 dB\n"
-                                   "For casual listening: 40\u201360 dB\n"
-                                   "For strong signals: 80\u2013100 dB");
-    grid->addWidget(m_dfnrAttenSlider, 1, 1);
-    m_dfnrAttenLabel = new QLabel(QString::number(m_dfnrAttenSlider->value()));
-    m_dfnrAttenLabel->setFixedWidth(40);
-    grid->addWidget(m_dfnrAttenLabel, 1, 2);
-
-    connect(m_dfnrAttenSlider, &QSlider::valueChanged, this, [this](int v) {
-        m_dfnrAttenLabel->setText(QString::number(v));
-        float db = static_cast<float>(v);
-        auto& s = AppSettings::instance();
-        s.setValue("DfnrAttenLimit", QString::number(db, 'f', 0));
-        s.save();
-        emit dfnrAttenLimitChanged(db);
-    });
-
-    // Post-Filter Beta slider
-    grid->addWidget(new QLabel("Post-Filter Beta"), 2, 0);
-    m_dfnrBetaSlider = new QSlider(Qt::Horizontal);
-    m_dfnrBetaSlider->setRange(0, 30);  // 0.0 to 0.30 in 0.01 steps
-    m_dfnrBetaSlider->setValue(static_cast<int>(s.value("DfnrPostFilterBeta", "0.0").toFloat() * 100));
-    m_dfnrBetaSlider->setStyleSheet(kSliderStyle);
-    m_dfnrBetaSlider->setToolTip("Post-filter strength for additional noise suppression.\n"
-                                  "0 = disabled (default)\n"
-                                  "0.05\u20130.15 = subtle additional filtering\n"
-                                  "0.15\u20130.30 = aggressive post-processing");
-    grid->addWidget(m_dfnrBetaSlider, 2, 1);
-    m_dfnrBetaLabel = new QLabel(QString::number(m_dfnrBetaSlider->value() / 100.0f, 'f', 2));
-    m_dfnrBetaLabel->setFixedWidth(40);
-    grid->addWidget(m_dfnrBetaLabel, 2, 2);
-
-    connect(m_dfnrBetaSlider, &QSlider::valueChanged, this, [this](int v) {
-        float beta = v / 100.0f;
-        m_dfnrBetaLabel->setText(QString::number(beta, 'f', 2));
-        auto& s = AppSettings::instance();
-        s.setValue("DfnrPostFilterBeta", QString::number(beta, 'f', 2));
-        s.save();
-        emit dfnrPostFilterBetaChanged(beta);
-    });
-
-    vbox->addWidget(group);
-    vbox->addStretch();
-    tabs->addTab(page, "DFNR");
-}
-
-// ── Sync from saved settings ─────────────────────────────────────────────────
-
-void AetherDspDialog::syncFromEngine()
-{
-    auto& s = AppSettings::instance();
-
-    int gainMethod = s.value("NR2GainMethod", "2").toInt();
-    if (auto* btn = m_nr2GainGroup->button(gainMethod))
-        btn->setChecked(true);
-
-    int npeMethod = s.value("NR2NpeMethod", "0").toInt();
-    if (auto* btn = m_nr2NpeGroup->button(npeMethod))
-        btn->setChecked(true);
-
-    bool aeFilter = s.value("NR2AeFilter", "True").toString() == "True";
-    m_nr2AeCheck->setChecked(aeFilter);
-
-    int gainMax = static_cast<int>(s.value("NR2GainMax", "1.50").toFloat() * 100);
-    m_nr2GainMaxSlider->setValue(gainMax);
-    m_nr2GainMaxLabel->setText(QString::number(gainMax / 100.0f, 'f', 2));
-
-    int smooth = static_cast<int>(s.value("NR2GainSmooth", "0.85").toFloat() * 100);
-    m_nr2SmoothSlider->setValue(smooth);
-    m_nr2SmoothLabel->setText(QString::number(smooth / 100.0f, 'f', 2));
-
-    int qspp = static_cast<int>(s.value("NR2Qspp", "0.20").toFloat() * 100);
-    m_nr2QsppSlider->setValue(qspp);
-    m_nr2QsppLabel->setText(QString::number(qspp / 100.0f, 'f', 2));
-
-    // MNR sync — read live state from AudioEngine, not stale settings;
-    // use QSignalBlocker so restoring the checkbox state doesn't fire
-    // mnrEnabledChanged before MainWindow has wired the dialog signals.
-    if (m_mnrEnableCheck) {
-        { QSignalBlocker sb(m_mnrEnableCheck);
-          m_mnrEnableCheck->setChecked(m_audio->mnrEnabled()); }
-        { QSignalBlocker sb(m_mnrStrengthSlider);
-          int strength = static_cast<int>(m_audio->mnrStrength() * 100.0f);
-          m_mnrStrengthSlider->setValue(strength);
-          m_mnrStrengthLabel->setText(QString::number(strength) + "%"); }
-    }
-
-    // NR4 sync
-    int noiseMethod = s.value("NR4NoiseEstimationMethod", "0").toInt();
-    if (auto* btn = m_nr4MethodGroup->button(noiseMethod))
-        btn->setChecked(true);
-
-    bool adaptive = s.value("NR4AdaptiveNoise", "True").toString() == "True";
-    m_nr4AdaptiveCheck->setChecked(adaptive);
-
-    int reduction = static_cast<int>(s.value("NR4ReductionAmount", "10.0").toFloat() * 10);
-    m_nr4ReductionSlider->setValue(reduction);
-    m_nr4ReductionLabel->setText(QString::number(reduction / 10.0f, 'f', 1));
-
-    int smoothing = static_cast<int>(s.value("NR4SmoothingFactor", "0.0").toFloat());
-    m_nr4SmoothingSlider->setValue(smoothing);
-    m_nr4SmoothingLabel->setText(QString::number(smoothing));
-
-    int whitening = static_cast<int>(s.value("NR4WhiteningFactor", "0.0").toFloat());
-    m_nr4WhiteningSlider->setValue(whitening);
-    m_nr4WhiteningLabel->setText(QString::number(whitening));
-
-    int masking = static_cast<int>(s.value("NR4MaskingDepth", "0.50").toFloat() * 100);
-    m_nr4MaskingSlider->setValue(masking);
-    m_nr4MaskingLabel->setText(QString::number(masking / 100.0f, 'f', 2));
-
-    int suppression = static_cast<int>(s.value("NR4SuppressionStrength", "0.50").toFloat() * 100);
-    m_nr4SuppressionSlider->setValue(suppression);
-    m_nr4SuppressionLabel->setText(QString::number(suppression / 100.0f, 'f', 2));
-
-    // DFNR sync
-    if (m_dfnrAttenSlider) {
-        int atten = static_cast<int>(s.value("DfnrAttenLimit", "100").toFloat());
-        m_dfnrAttenSlider->setValue(atten);
-        m_dfnrAttenLabel->setText(QString::number(atten));
-    }
-    if (m_dfnrBetaSlider) {
-        int beta = static_cast<int>(s.value("DfnrPostFilterBeta", "0.0").toFloat() * 100);
-        m_dfnrBetaSlider->setValue(beta);
-        m_dfnrBetaLabel->setText(QString::number(beta / 100.0f, 'f', 2));
-    }
+    if (m_widget) m_widget->selectTab(name);
 }
 
 } // namespace AetherSDR

--- a/src/gui/AetherDspDialog.h
+++ b/src/gui/AetherDspDialog.h
@@ -1,36 +1,35 @@
 #pragma once
 
 #include <QDialog>
-#include <QTabWidget>
-
-class QSlider;
-class QLabel;
-class QPushButton;
-class QRadioButton;
-class QCheckBox;
-class QButtonGroup;
 
 namespace AetherSDR {
 
 class AudioEngine;
+class AetherDspWidget;
 
-// AetherDSP Settings — modeless dialog for client-side DSP parameters.
-// Accessible from Settings menu and "AetherDSP Settings..." in right-click popups.
-// All values persist via AppSettings (PascalCase keys).
+// AetherDSP Settings — modeless dialog wrapping AetherDspWidget.
+// Accessible from Settings menu and "AetherDSP Settings..." in right-click
+// popups.  All values persist via AppSettings (PascalCase keys).  The same
+// widget body is also embedded in ClientRxDspApplet for in-chain access.
 class AetherDspDialog : public QDialog {
     Q_OBJECT
 
 public:
     explicit AetherDspDialog(AudioEngine* audio, QWidget* parent = nullptr);
 
-    // Sync UI from current AudioEngine state
+    // Sync UI from current AudioEngine state.
     void syncFromEngine();
 
-    // Jump to a named tab (e.g. "MNR", "NR2", "DFNR")
+    // Jump to a named tab (e.g. "MNR", "NR2", "DFNR").
     void selectTab(const QString& name);
 
+    // The underlying tabbed widget — connect to its signals for parameter
+    // change notifications.  Re-emitted on this dialog as well so existing
+    // callers can keep connecting to the dialog directly.
+    AetherDspWidget* widget() const { return m_widget; }
+
 signals:
-    // NR2 parameter changes
+    // NR2 parameter changes (forwarded from m_widget)
     void nr2GainMaxChanged(float value);
     void nr2GainSmoothChanged(float value);
     void nr2QsppChanged(float value);
@@ -53,51 +52,7 @@ signals:
     void nr4SuppressionChanged(float value);
 
 private:
-    void buildNr2Tab(QTabWidget* tabs);
-    void buildNr4Tab(QTabWidget* tabs);
-    void buildMnrTab(QTabWidget* tabs);
-    void buildRn2Tab(QTabWidget* tabs);
-    void buildBnrTab(QTabWidget* tabs);
-    void buildDfnrTab(QTabWidget* tabs);
-
-    AudioEngine*  m_audio;
-    QTabWidget*   m_tabs{nullptr};
-
-    // NR2 controls
-    QButtonGroup* m_nr2GainGroup{nullptr};
-    QButtonGroup* m_nr2NpeGroup{nullptr};
-    QCheckBox*    m_nr2AeCheck{nullptr};
-    QSlider*      m_nr2GainMaxSlider{nullptr};
-    QLabel*       m_nr2GainMaxLabel{nullptr};
-    QSlider*      m_nr2SmoothSlider{nullptr};
-    QLabel*       m_nr2SmoothLabel{nullptr};
-    QSlider*      m_nr2QsppSlider{nullptr};
-    QLabel*       m_nr2QsppLabel{nullptr};
-
-    // MNR controls
-    QCheckBox*    m_mnrEnableCheck{nullptr};
-    QSlider*      m_mnrStrengthSlider{nullptr};
-    QLabel*       m_mnrStrengthLabel{nullptr};
-
-    // NR4 controls
-    QSlider*      m_nr4ReductionSlider{nullptr};
-    QLabel*       m_nr4ReductionLabel{nullptr};
-    QSlider*      m_nr4SmoothingSlider{nullptr};
-    QLabel*       m_nr4SmoothingLabel{nullptr};
-    QSlider*      m_nr4WhiteningSlider{nullptr};
-    QLabel*       m_nr4WhiteningLabel{nullptr};
-    QCheckBox*    m_nr4AdaptiveCheck{nullptr};
-    QButtonGroup* m_nr4MethodGroup{nullptr};
-    QSlider*      m_nr4MaskingSlider{nullptr};
-    QLabel*       m_nr4MaskingLabel{nullptr};
-    QSlider*      m_nr4SuppressionSlider{nullptr};
-    QLabel*       m_nr4SuppressionLabel{nullptr};
-
-    // DFNR controls
-    QSlider*      m_dfnrAttenSlider{nullptr};
-    QLabel*       m_dfnrAttenLabel{nullptr};
-    QSlider*      m_dfnrBetaSlider{nullptr};
-    QLabel*       m_dfnrBetaLabel{nullptr};
+    AetherDspWidget* m_widget{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/AetherDspWidget.cpp
+++ b/src/gui/AetherDspWidget.cpp
@@ -1,0 +1,1046 @@
+#include "AetherDspWidget.h"
+#include "core/AudioEngine.h"
+#include "core/AppSettings.h"
+#include "GuardedSlider.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QStackedWidget>
+#include <QRadioButton>
+#include <QButtonGroup>
+#include <QCheckBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QPainter>
+#include <QSignalBlocker>
+
+namespace AetherSDR {
+
+namespace {
+
+const QString kSliderStyle = QStringLiteral(
+    "QSlider::groove:horizontal { height: 4px; background: #304050; border-radius: 2px; }"
+    "QSlider::handle:horizontal { width: 12px; height: 12px; margin: -4px 0;"
+    "  background: #c8d8e8; border-radius: 6px; }"
+    "QSlider::handle:horizontal:hover { background: #00b4d8; }");
+
+const QString kWidgetStyle = QStringLiteral(
+    "QWidget { color: #c8d8e8; }"
+    "QTabWidget::pane { border: 1px solid #304050; background: #0f0f1a; }"
+    "QTabBar::tab { background: #1a2a3a; color: #8090a0; padding: 6px 16px;"
+    "  border: 1px solid #304050; border-bottom: none; border-radius: 3px 3px 0 0; }"
+    "QTabBar::tab:selected { background: #0f0f1a; color: #c8d8e8;"
+    "  border-bottom: 1px solid #0f0f1a; }"
+    "QGroupBox { border: 1px solid #304050; border-radius: 4px;"
+    "  margin-top: 12px; padding-top: 8px; color: #8090a0; }"
+    "QGroupBox::title { subcontrol-origin: margin; left: 8px; padding: 0 4px; }"
+    "QLabel { color: #8090a0; }"
+    "QRadioButton { color: #c8d8e8; }"
+    "QCheckBox { color: #c8d8e8; }"
+    "QPushButton { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050;"
+    "  border-radius: 3px; padding: 4px 12px; }"
+    "QPushButton:hover { background: rgba(0, 112, 192, 180); border: 1px solid #0090e0; }");
+
+// Compact variant — applied when the widget is embedded inside the docked
+// PooDoo applet (≤280 px wide).  Tighter tab padding so all 6 tabs fit on
+// one row, smaller GroupBox / control margins, narrower slider value
+// labels.  The Settings-menu dialog leaves this off.
+// Toggle-button look matching the slice DSP buttons (NB / NR / ANF / NRL /
+// NRS / NRF / ANFL / BNR).  Used for exclusive-selection groups that are
+// otherwise rendered as radio buttons inside a QGroupBox.  Keeps the row
+// tight and consistent with the rest of the app.
+const QString kToggleStyle = QStringLiteral(
+    "QPushButton { background: #1a2a3a; border: 1px solid #205070;"
+    "  border-radius: 3px; color: #c8d8e8; font-size: 9px;"
+    "  font-weight: bold; padding: 0px 2px; margin: 0px; }"
+    "QPushButton:hover { background: #204060; }"
+    "QPushButton:checked { background: #0070c0; color: #ffffff;"
+    "  border: 1px solid #0090e0; }"
+    "QPushButton:disabled { background: #0e1822; color: #4a5868;"
+    "  border: 1px solid #1a2838; }");
+
+static QPushButton* makeToggle(const QString& text)
+{
+    auto* b = new QPushButton(text);
+    b->setCheckable(true);
+    // Preferred (not Expanding) so each button sizes to its text — the
+    // row no longer divides space equally between "Log" and "Trained",
+    // which kept clipping the longer labels at 280 px container width.
+    b->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    b->setFixedHeight(16);
+    b->setStyleSheet(kToggleStyle);
+    return b;
+}
+
+// Compact reset icon — flat clickable QPushButton that paints its glyph
+// rotated 90° CCW through QPainter (Qt stylesheets don't support
+// transform).  Glyph is U+21BA "anticlockwise open circle arrow" — the
+// conventional undo symbol.  Each parametric tab adds one and clicking
+// dispatches to resetCurrentTab().
+class ResetIconButton : public QPushButton {
+public:
+    explicit ResetIconButton(QWidget* parent = nullptr) : QPushButton(parent)
+    {
+        setToolTip("Reset Defaults");
+        setFlat(true);
+        setCursor(Qt::PointingHandCursor);
+        // Tight to the glyph — no top/side padding.  The 16-px font fits
+        // exactly inside an 18×18 click target so the rotated arrow
+        // touches the top and side edges.
+        setFixedSize(18, 18);
+        setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        setStyleSheet(
+            "QPushButton { background: transparent; border: 0; padding: 0;"
+            "  margin: 0; }");
+    }
+
+protected:
+    void paintEvent(QPaintEvent*) override
+    {
+        QPainter p(this);
+        p.setRenderHint(QPainter::TextAntialiasing);
+        p.setRenderHint(QPainter::Antialiasing);
+        QColor c("#8090a0");
+        if (isDown())        c = QColor("#00b4d8");
+        else if (underMouse()) c = QColor("#c8d8e8");
+        p.setPen(c);
+        QFont f = font();
+        f.setPixelSize(18);
+        p.setFont(f);
+        p.translate(width() / 2.0, height() / 2.0);
+        p.rotate(-90.0);
+        QRectF box(-width() / 2.0, -height() / 2.0, width(), height());
+        p.drawText(box, Qt::AlignCenter, QString::fromUtf8("\xE2\x86\xBA"));
+    }
+};
+
+static QPushButton* makeResetIconButton()
+{
+    return new ResetIconButton;
+}
+
+const QString kCompactWidgetStyle = QStringLiteral(
+    "QWidget { color: #c8d8e8; font-size: 10px; }"
+    "QTabWidget::pane { border: 0; background: transparent; top: -1px; }"
+    "QTabBar::tab { background: #1a2a3a; color: #8090a0; padding: 3px 6px;"
+    "  font-size: 10px; min-width: 0px;"
+    "  border: 1px solid #304050; border-bottom: none; border-radius: 3px 3px 0 0; }"
+    "QTabBar::tab:selected { background: #0f0f1a; color: #c8d8e8;"
+    "  border-bottom: 1px solid #0f0f1a; }"
+    "QGroupBox { border: 1px solid #304050; border-radius: 4px;"
+    "  margin-top: 8px; padding-top: 4px; color: #8090a0; font-size: 10px; }"
+    "QGroupBox::title { subcontrol-origin: margin; left: 6px; padding: 0 3px; }"
+    "QLabel { color: #8090a0; font-size: 10px; }"
+    "QRadioButton { color: #c8d8e8; font-size: 10px; spacing: 3px; }"
+    "QRadioButton::indicator { width: 10px; height: 10px; }"
+    "QCheckBox { color: #c8d8e8; font-size: 10px; spacing: 3px; }"
+    "QCheckBox::indicator { width: 10px; height: 10px; }"
+    "QPushButton { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050;"
+    "  border-radius: 3px; padding: 2px 8px; font-size: 10px; }"
+    "QPushButton:hover { background: rgba(0, 112, 192, 180); border: 1px solid #0090e0; }");
+
+} // namespace
+
+AetherDspWidget::AetherDspWidget(AudioEngine* audio, QWidget* parent)
+    : QWidget(parent)
+    , m_audio(audio)
+{
+    setStyleSheet(kWidgetStyle);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(4, 4, 4, 4);
+    root->setSpacing(2);
+
+    // Selector row — six exclusive toggle buttons that double as DSP
+    // activators.  Checked state == engine enable state; click again
+    // to deactivate (chain bypass).  Each button is sized to span the
+    // 250 px applet width with 4 px gaps:
+    //   6 × 38 px buttons + 5 × 4 px gaps = 248 px
+    auto* btnRow = new QHBoxLayout;
+    btnRow->setContentsMargins(0, 0, 0, 0);
+    btnRow->setSpacing(4);
+    static const char* kLabels[NumDsps] = {"NR2", "NR4", "MNR", "DFNR", "RN2", "BNR"};
+    for (int i = 0; i < NumDsps; ++i) {
+        auto* b = makeToggle(kLabels[i]);
+        b->setFixedSize(38, 22);
+        b->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        // MNR (MMSE-Wiener spectral NR) is implemented only on macOS —
+        // dim the selector on Windows / Linux so users can see it exists
+        // but can't enable a path the engine has no backend for.
+#ifndef Q_OS_MAC
+        if (i == MNR) {
+            b->setEnabled(false);
+            b->setToolTip("MNR is only available on macOS.");
+        }
+#endif
+        // BNR (NVIDIA GPU neural denoising) is gated at compile time
+        // by HAVE_BNR — VfoWidget hides its button entirely; here we
+        // keep the slot visible so the 6-button row stays balanced and
+        // just dim it for builds without the BNR backend.
+#ifndef HAVE_BNR
+        if (i == BNR) {
+            b->setEnabled(false);
+            b->setToolTip("BNR requires the NVIDIA Broadcast SDK and an NVIDIA GPU.");
+        }
+#endif
+        m_dspBtns[i] = b;
+        connect(b, &QPushButton::clicked, this,
+                [this, i](bool nowChecked) { onDspButtonClicked(i, nowChecked); });
+        btnRow->addWidget(b);
+    }
+    root->addLayout(btnRow);
+
+    // Page stack — one panel per DSP.  Order MUST match DspId.
+    m_dspStack = new QStackedWidget;
+    m_dspStack->addWidget(buildNr2Page());
+    m_dspStack->addWidget(buildNr4Page());
+    m_dspStack->addWidget(buildMnrPage());
+    m_dspStack->addWidget(buildDfnrPage());
+    m_dspStack->addWidget(buildRn2Page());
+    m_dspStack->addWidget(buildBnrPage());
+    root->addWidget(m_dspStack);
+
+    // Engine → button sync: when DSP state changes externally (chain
+    // bypass, slice DSP overlay, Settings dialog) reflect it here.
+    if (m_audio) {
+        connect(m_audio, &AudioEngine::nr2EnabledChanged,
+                this, &AetherDspWidget::syncDspSelectorFromEngine);
+        connect(m_audio, &AudioEngine::nr4EnabledChanged,
+                this, &AetherDspWidget::syncDspSelectorFromEngine);
+        connect(m_audio, &AudioEngine::mnrEnabledChanged,
+                this, &AetherDspWidget::syncDspSelectorFromEngine);
+        connect(m_audio, &AudioEngine::dfnrEnabledChanged,
+                this, &AetherDspWidget::syncDspSelectorFromEngine);
+        connect(m_audio, &AudioEngine::rn2EnabledChanged,
+                this, &AetherDspWidget::syncDspSelectorFromEngine);
+        connect(m_audio, &AudioEngine::bnrEnabledChanged,
+                this, &AetherDspWidget::syncDspSelectorFromEngine);
+    }
+
+    syncDspSelectorFromEngine();
+    syncFromEngine();
+}
+
+void AetherDspWidget::onDspButtonClicked(int index, bool nowChecked)
+{
+    if (index < 0 || index >= NumDsps) return;
+    // Always bring this DSP's panel forward, regardless of new check
+    // state — toggling off keeps the panel visible so the user can
+    // re-enable from the same place.
+    m_dspStack->setCurrentIndex(index);
+    if (!m_audio) return;
+    // NR2 enable must run FFTW wisdom prep first (#2275) — kick that
+    // through MainWindow rather than calling the engine setter directly.
+    // NR2 disable + every other DSP go through the engine-thread setter.
+    if (index == NR2 && nowChecked) {
+        emit nr2EnableWithWisdomRequested();
+    } else {
+        QMetaObject::invokeMethod(m_audio, [this, index, nowChecked]() {
+            switch (index) {
+                case NR2:  m_audio->setNr2Enabled(nowChecked); break;
+                case NR4:  m_audio->setNr4Enabled(nowChecked); break;
+                case MNR:  m_audio->setMnrEnabled(nowChecked); break;
+                case DFNR: m_audio->setDfnrEnabled(nowChecked); break;
+                case RN2:  m_audio->setRn2Enabled(nowChecked); break;
+                case BNR:  m_audio->setBnrEnabled(nowChecked); break;
+            }
+        });
+    }
+    // Remember the last-enabled module so the RX chain DSP tile can
+    // re-enable it when clicked from a fully-bypassed state.  Don't
+    // overwrite on disable — we want the value to survive a turn-off.
+    if (nowChecked) {
+        static const char* kNames[NumDsps] = {"NR2", "NR4", "MNR", "DFNR", "RN2", "BNR"};
+        auto& s = AppSettings::instance();
+        s.setValue("LastClientNr", QString::fromLatin1(kNames[index]));
+        s.save();
+    }
+    // AudioEngine cascades exclusion (enabling NR2 disables DFNR, etc.)
+    // and emits *EnabledChanged signals; syncDspSelectorFromEngine()
+    // will update sibling button states without firing setters.
+}
+
+void AetherDspWidget::syncDspSelectorFromEngine()
+{
+    if (!m_audio) return;
+    const bool on[NumDsps] = {
+        m_audio->nr2Enabled(),
+        m_audio->nr4Enabled(),
+        m_audio->mnrEnabled(),
+        m_audio->dfnrEnabled(),
+        m_audio->rn2Enabled(),
+        m_audio->bnrEnabled(),
+    };
+    int active = -1;
+    for (int i = 0; i < NumDsps; ++i) {
+        if (m_dspBtns[i]) {
+            QSignalBlocker block(m_dspBtns[i]);
+            m_dspBtns[i]->setChecked(on[i]);
+        }
+        if (on[i] && active < 0) active = i;
+    }
+    // If something is active, surface its panel.  If nothing's active
+    // ("bypass"), keep whichever panel was last visible — don't yank the
+    // user back to NR2 just because they clicked the active button off.
+    if (active >= 0 && m_dspStack)
+        m_dspStack->setCurrentIndex(active);
+}
+
+void AetherDspWidget::resetCurrentTab()
+{
+    if (!m_dspStack) return;
+    const int idx = m_dspStack->currentIndex();
+    static const char* kNames[NumDsps] = {"NR2", "NR4", "MNR", "DFNR", "RN2", "BNR"};
+    const QString name = (idx >= 0 && idx < NumDsps) ? kNames[idx] : QString();
+    if (name == "NR2") {
+        if (m_nr2GainGroup) m_nr2GainGroup->button(2)->setChecked(true);
+        if (m_nr2NpeGroup)  m_nr2NpeGroup->button(0)->setChecked(true);
+        if (m_nr2AeCheck)        m_nr2AeCheck->setChecked(true);
+        if (m_nr2GainMaxSlider)  m_nr2GainMaxSlider->setValue(150);
+        if (m_nr2SmoothSlider)   m_nr2SmoothSlider->setValue(85);
+        if (m_nr2QsppSlider)     m_nr2QsppSlider->setValue(20);
+    } else if (name == "NR4") {
+        if (m_nr4MethodGroup)      m_nr4MethodGroup->button(0)->setChecked(true);
+        if (m_nr4AdaptiveCheck)    m_nr4AdaptiveCheck->setChecked(true);
+        if (m_nr4ReductionSlider)  m_nr4ReductionSlider->setValue(100);
+        if (m_nr4SmoothingSlider)  m_nr4SmoothingSlider->setValue(0);
+        if (m_nr4WhiteningSlider)  m_nr4WhiteningSlider->setValue(0);
+        if (m_nr4MaskingSlider)    m_nr4MaskingSlider->setValue(50);
+        if (m_nr4SuppressionSlider)m_nr4SuppressionSlider->setValue(50);
+    } else if (name == "MNR") {
+        if (m_mnrEnableCheck)    m_mnrEnableCheck->setChecked(false);
+        if (m_mnrStrengthSlider) m_mnrStrengthSlider->setValue(100);
+    } else if (name == "DFNR") {
+        if (m_dfnrAttenSlider) m_dfnrAttenSlider->setValue(100);
+        if (m_dfnrBetaSlider)  m_dfnrBetaSlider->setValue(0);
+    }
+    // RN2 / BNR have no adjustable parameters — Reset Defaults is a no-op.
+}
+
+void AetherDspWidget::setCompactMode(bool on)
+{
+    setStyleSheet(on ? kCompactWidgetStyle : kWidgetStyle);
+
+    // Slider value labels were sized to fit the full-dialog 40 px slot.
+    // In compact mode they're rendered with a smaller font and fit in 30
+    // px — narrower labels free up width for the slider grooves so the
+    // tile reads well at the 280 px PooDoo container limit.
+    const int valWidth = on ? 30 : 40;
+    for (auto* lbl : { m_nr2GainMaxLabel, m_nr2SmoothLabel, m_nr2QsppLabel,
+                       m_nr4ReductionLabel, m_nr4SmoothingLabel, m_nr4WhiteningLabel,
+                       m_nr4MaskingLabel, m_nr4SuppressionLabel,
+                       m_mnrStrengthLabel,
+                       m_dfnrAttenLabel, m_dfnrBetaLabel }) {
+        if (lbl) lbl->setMinimumWidth(valWidth);
+    }
+    if (m_dfnrAttenLabel) m_dfnrAttenLabel->setFixedWidth(valWidth);
+    if (m_dfnrBetaLabel)  m_dfnrBetaLabel->setFixedWidth(valWidth);
+}
+
+void AetherDspWidget::setNr2Available(bool available, const QString& tooltip)
+{
+    if (auto* btn = m_dspBtns[NR2]) {
+        btn->setEnabled(available);
+        btn->setToolTip(tooltip);
+    }
+}
+
+void AetherDspWidget::selectTab(const QString& name)
+{
+    if (!m_dspStack) return;
+    static const char* kNames[NumDsps] = {"NR2", "NR4", "MNR", "DFNR", "RN2", "BNR"};
+    for (int i = 0; i < NumDsps; ++i) {
+        if (name == kNames[i]) {
+            m_dspStack->setCurrentIndex(i);
+            return;
+        }
+    }
+}
+
+// ── NR2 Tab ──────────────────────────────────────────────────────────────────
+
+QWidget* AetherDspWidget::buildNr2Page()
+{
+    auto* page = new QWidget;
+    auto* vbox = new QVBoxLayout(page);
+
+    auto labelStyle = QStringLiteral("QLabel { color: #8090a0; font-size: 11px; }");
+    auto valStyle   = QStringLiteral("QLabel { color: #c8d8e8; font-size: 11px; min-width: 40px; }");
+
+    // Gain Method — exclusive toggle row, styled like the slice DSP buttons.
+    {
+        auto* hdr = new QLabel("Gain Method:");
+        hdr->setStyleSheet(labelStyle);
+        vbox->addWidget(hdr);
+
+        auto* row = new QHBoxLayout;
+        // 4 × 48 px buttons evenly spaced across the 250 px applet —
+        // five equal-weight stretches (left margin, three gaps, right
+        // margin) distribute the 58 px of leftover space at ≈11.6 px each.
+        row->setContentsMargins(0, 0, 0, 0);
+        row->setSpacing(0);
+        m_nr2GainGroup = new QButtonGroup(this);
+        m_nr2GainGroup->setExclusive(true);
+        const char* gainLabels[] = {"Linear", "Log", "Gamma", "Trained"};
+        const char* gainTips[] = {
+            "Linear audio amplitude scale for gain computation.",
+            "Logarithmic amplitude scale — compresses dynamic range.",
+            "Gamma distribution model matching typical speech amplitude patterns.",
+            "Noise reduction model trained on real speech and noise samples."
+        };
+        row->addStretch(1);
+        for (int i = 0; i < 4; ++i) {
+            auto* b = makeToggle(gainLabels[i]);
+            b->setToolTip(gainTips[i]);
+            b->setFixedSize(48, 18);
+            b->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+            m_nr2GainGroup->addButton(b, i);
+            row->addWidget(b);
+            row->addStretch(1);
+        }
+        m_nr2GainGroup->button(2)->setChecked(true);  // Gamma default
+        connect(m_nr2GainGroup, &QButtonGroup::idClicked, this, [this](int id) {
+            auto& s = AppSettings::instance();
+            s.setValue("NR2GainMethod", QString::number(id));
+            s.save();
+            emit nr2GainMethodChanged(id);
+        });
+        vbox->addLayout(row);
+    }
+
+    // NPE Method — exclusive toggle row.
+    {
+        auto* hdr = new QLabel("NPE Method:");
+        hdr->setStyleSheet(labelStyle);
+        vbox->addWidget(hdr);
+
+        auto* row = new QHBoxLayout;
+        // 3 × 48 px buttons evenly spaced across the 250 px applet —
+        // four equal-weight stretches share the 106 px of leftover space.
+        row->setContentsMargins(0, 0, 0, 0);
+        row->setSpacing(0);
+        m_nr2NpeGroup = new QButtonGroup(this);
+        m_nr2NpeGroup->setExclusive(true);
+        const char* npeLabels[] = {"OSMS", "MMSE", "NSTAT"};
+        const char* npeTips[] = {
+            "Optimal Smoothing Minimum Statistics — tracks noise floor using a running minimum estimate.",
+            "Minimum Mean Squared Error — minimizes the expected noise estimation error.",
+            "Non-Stationary estimation — adapts to noise that changes over time."
+        };
+        row->addStretch(1);
+        for (int i = 0; i < 3; ++i) {
+            auto* b = makeToggle(npeLabels[i]);
+            b->setToolTip(npeTips[i]);
+            b->setFixedSize(48, 18);
+            b->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+            m_nr2NpeGroup->addButton(b, i);
+            row->addWidget(b);
+            row->addStretch(1);
+        }
+        m_nr2NpeGroup->button(0)->setChecked(true);  // OSMS default
+        connect(m_nr2NpeGroup, &QButtonGroup::idClicked, this, [this](int id) {
+            auto& s = AppSettings::instance();
+            s.setValue("NR2NpeMethod", QString::number(id));
+            s.save();
+            emit nr2NpeMethodChanged(id);
+        });
+        vbox->addLayout(row);
+    }
+
+    // AE Filter checkbox + Reset Defaults icon on the same row.
+    m_nr2AeCheck = new QCheckBox("AE Filter (artifact elimination)");
+    m_nr2AeCheck->setToolTip("Reduces ringing and musical artifacts typical of frequency-domain noise reduction.");
+    m_nr2AeCheck->setChecked(true);
+    connect(m_nr2AeCheck, &QCheckBox::toggled, this, [this](bool on) {
+        auto& s = AppSettings::instance();
+        s.setValue("NR2AeFilter", on ? "True" : "False");
+        s.save();
+        emit nr2AeFilterChanged(on);
+    });
+    {
+        auto* aeRow = new QHBoxLayout;
+        aeRow->setContentsMargins(0, 0, 0, 0);
+        aeRow->setSpacing(0);
+        aeRow->addWidget(m_nr2AeCheck);
+        aeRow->addStretch(1);
+        auto* resetBtn = makeResetIconButton();
+        connect(resetBtn, &QPushButton::clicked,
+                this, &AetherDspWidget::resetCurrentTab);
+        aeRow->addWidget(resetBtn);
+        vbox->addLayout(aeRow);
+    }
+
+    // Sliders: GainMax, GainSmooth, Q_SPP
+    auto* sliderGrid = new QGridLayout;
+    int row = 0;
+
+    // Gain Max (reduction depth)
+    {
+        auto* lbl = new QLabel("Reduction:");
+        lbl->setStyleSheet(labelStyle);
+        sliderGrid->addWidget(lbl, row, 0);
+        m_nr2GainMaxSlider = new GuardedSlider(Qt::Horizontal);
+        m_nr2GainMaxSlider->setRange(50, 200);
+        m_nr2GainMaxSlider->setValue(150);
+        m_nr2GainMaxSlider->setStyleSheet(kSliderStyle);
+        m_nr2GainMaxSlider->setToolTip("Maximum noise reduction depth. Higher values suppress more noise but risk distorting speech.");
+        sliderGrid->addWidget(m_nr2GainMaxSlider, row, 1);
+        m_nr2GainMaxLabel = new QLabel("1.50");
+        m_nr2GainMaxLabel->setStyleSheet(valStyle);
+        m_nr2GainMaxLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        sliderGrid->addWidget(m_nr2GainMaxLabel, row, 2);
+        connect(m_nr2GainMaxSlider, &QSlider::valueChanged, this, [this](int v) {
+            float val = v / 100.0f;
+            m_nr2GainMaxLabel->setText(QString::number(val, 'f', 2));
+            auto& s = AppSettings::instance();
+            s.setValue("NR2GainMax", QString::number(val, 'f', 2));
+            s.save();
+            emit nr2GainMaxChanged(val);
+        });
+        ++row;
+    }
+
+    // Gain Smooth
+    {
+        auto* lbl = new QLabel("Smoothing:");
+        lbl->setStyleSheet(labelStyle);
+        sliderGrid->addWidget(lbl, row, 0);
+        m_nr2SmoothSlider = new GuardedSlider(Qt::Horizontal);
+        m_nr2SmoothSlider->setRange(50, 98);
+        m_nr2SmoothSlider->setValue(85);
+        m_nr2SmoothSlider->setStyleSheet(kSliderStyle);
+        m_nr2SmoothSlider->setToolTip("How smoothly the noise estimate tracks changes. Higher values give steadier but slower adaptation.");
+        sliderGrid->addWidget(m_nr2SmoothSlider, row, 1);
+        m_nr2SmoothLabel = new QLabel("0.85");
+        m_nr2SmoothLabel->setStyleSheet(valStyle);
+        m_nr2SmoothLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        sliderGrid->addWidget(m_nr2SmoothLabel, row, 2);
+        connect(m_nr2SmoothSlider, &QSlider::valueChanged, this, [this](int v) {
+            float val = v / 100.0f;
+            m_nr2SmoothLabel->setText(QString::number(val, 'f', 2));
+            auto& s = AppSettings::instance();
+            s.setValue("NR2GainSmooth", QString::number(val, 'f', 2));
+            s.save();
+            emit nr2GainSmoothChanged(val);
+        });
+        ++row;
+    }
+
+    // Q_SPP (voice threshold)
+    {
+        auto* lbl = new QLabel("Threshold:");
+        lbl->setStyleSheet(labelStyle);
+        sliderGrid->addWidget(lbl, row, 0);
+        m_nr2QsppSlider = new GuardedSlider(Qt::Horizontal);
+        m_nr2QsppSlider->setRange(5, 50);
+        m_nr2QsppSlider->setValue(20);
+        m_nr2QsppSlider->setStyleSheet(kSliderStyle);
+        m_nr2QsppSlider->setToolTip("Speech detection threshold. Lower values preserve quiet speech but may pass more noise.");
+        sliderGrid->addWidget(m_nr2QsppSlider, row, 1);
+        m_nr2QsppLabel = new QLabel("0.20");
+        m_nr2QsppLabel->setStyleSheet(valStyle);
+        m_nr2QsppLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        sliderGrid->addWidget(m_nr2QsppLabel, row, 2);
+        connect(m_nr2QsppSlider, &QSlider::valueChanged, this, [this](int v) {
+            float val = v / 100.0f;
+            m_nr2QsppLabel->setText(QString::number(val, 'f', 2));
+            auto& s = AppSettings::instance();
+            s.setValue("NR2Qspp", QString::number(val, 'f', 2));
+            s.save();
+            emit nr2QsppChanged(val);
+        });
+        ++row;
+    }
+
+    vbox->addLayout(sliderGrid);
+    vbox->addStretch();
+    return page;
+}
+
+// ── NR4 Tab (libspecbleach) ──────────────────────────────────────────────────
+
+QWidget* AetherDspWidget::buildNr4Page()
+{
+    auto* page = new QWidget;
+    auto* vbox = new QVBoxLayout(page);
+
+    auto labelStyle = QStringLiteral("QLabel { color: #8090a0; font-size: 11px; }");
+    auto valStyle   = QStringLiteral("QLabel { color: #c8d8e8; font-size: 11px; min-width: 40px; }");
+
+    // Noise Estimation Method — exclusive toggle row.
+    {
+        auto* hdr = new QLabel("Noise Estimation:");
+        hdr->setStyleSheet(labelStyle);
+        vbox->addWidget(hdr);
+
+        auto* row = new QHBoxLayout;
+        // 3 × 48 px buttons evenly spaced across 250 px — matches NPE row.
+        row->setContentsMargins(0, 0, 0, 0);
+        row->setSpacing(0);
+        m_nr4MethodGroup = new QButtonGroup(this);
+        m_nr4MethodGroup->setExclusive(true);
+        const char* methodLabels[] = {"MMSE", "Brandt", "Martin"};
+        const char* methodTips[] = {
+            "MMSE with Speech Presence Probability — balances noise estimation with speech preservation.",
+            "Recursive smoothing using critical frequency bands — good for non-stationary noise.",
+            "Minimum statistics using running spectral minima — robust for slowly varying noise floors."
+        };
+        row->addStretch(1);
+        for (int i = 0; i < 3; ++i) {
+            auto* b = makeToggle(methodLabels[i]);
+            b->setToolTip(methodTips[i]);
+            b->setFixedSize(48, 18);
+            b->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+            m_nr4MethodGroup->addButton(b, i);
+            row->addWidget(b);
+            row->addStretch(1);
+        }
+        m_nr4MethodGroup->button(0)->setChecked(true);
+        connect(m_nr4MethodGroup, &QButtonGroup::idClicked, this, [this](int id) {
+            auto& s = AppSettings::instance();
+            s.setValue("NR4NoiseEstimationMethod", QString::number(id));
+            s.save();
+            emit nr4NoiseMethodChanged(id);
+        });
+        vbox->addLayout(row);
+    }
+
+    // Adaptive Noise checkbox + Reset Defaults icon on the same row.
+    m_nr4AdaptiveCheck = new QCheckBox("Adaptive Noise Estimation");
+    m_nr4AdaptiveCheck->setToolTip("Continuously re-estimates the noise floor as conditions change. Disable for stable environments.");
+    m_nr4AdaptiveCheck->setChecked(true);
+    connect(m_nr4AdaptiveCheck, &QCheckBox::toggled, this, [this](bool on) {
+        auto& s = AppSettings::instance();
+        s.setValue("NR4AdaptiveNoise", on ? "True" : "False");
+        s.save();
+        emit nr4AdaptiveNoiseChanged(on);
+    });
+    {
+        auto* adRow = new QHBoxLayout;
+        adRow->setContentsMargins(0, 0, 0, 0);
+        adRow->setSpacing(0);
+        adRow->addWidget(m_nr4AdaptiveCheck);
+        adRow->addStretch(1);
+        auto* resetBtn = makeResetIconButton();
+        connect(resetBtn, &QPushButton::clicked,
+                this, &AetherDspWidget::resetCurrentTab);
+        adRow->addWidget(resetBtn);
+        vbox->addLayout(adRow);
+    }
+
+    // Sliders
+    auto* sliderGrid = new QGridLayout;
+    int row = 0;
+
+    {
+        auto* lbl = new QLabel("Reduction (dB):");
+        lbl->setStyleSheet(labelStyle);
+        sliderGrid->addWidget(lbl, row, 0);
+        m_nr4ReductionSlider = new GuardedSlider(Qt::Horizontal);
+        m_nr4ReductionSlider->setRange(0, 400);
+        m_nr4ReductionSlider->setValue(100);
+        m_nr4ReductionSlider->setStyleSheet(kSliderStyle);
+        m_nr4ReductionSlider->setToolTip("Maximum noise reduction in dB. Higher values remove more noise but may affect speech.");
+        sliderGrid->addWidget(m_nr4ReductionSlider, row, 1);
+        m_nr4ReductionLabel = new QLabel("10.0");
+        m_nr4ReductionLabel->setStyleSheet(valStyle);
+        m_nr4ReductionLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        sliderGrid->addWidget(m_nr4ReductionLabel, row, 2);
+        connect(m_nr4ReductionSlider, &QSlider::valueChanged, this, [this](int v) {
+            float val = v / 10.0f;
+            m_nr4ReductionLabel->setText(QString::number(val, 'f', 1));
+            auto& s = AppSettings::instance();
+            s.setValue("NR4ReductionAmount", QString::number(val, 'f', 1));
+            s.save();
+            emit nr4ReductionChanged(val);
+        });
+        ++row;
+    }
+
+    {
+        auto* lbl = new QLabel("Smoothing (%):");
+        lbl->setStyleSheet(labelStyle);
+        sliderGrid->addWidget(lbl, row, 0);
+        m_nr4SmoothingSlider = new GuardedSlider(Qt::Horizontal);
+        m_nr4SmoothingSlider->setRange(0, 100);
+        m_nr4SmoothingSlider->setValue(0);
+        m_nr4SmoothingSlider->setStyleSheet(kSliderStyle);
+        m_nr4SmoothingSlider->setToolTip("Time-domain smoothing of the noise estimate. Higher values produce steadier but slower reduction.");
+        sliderGrid->addWidget(m_nr4SmoothingSlider, row, 1);
+        m_nr4SmoothingLabel = new QLabel("0");
+        m_nr4SmoothingLabel->setStyleSheet(valStyle);
+        m_nr4SmoothingLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        sliderGrid->addWidget(m_nr4SmoothingLabel, row, 2);
+        connect(m_nr4SmoothingSlider, &QSlider::valueChanged, this, [this](int v) {
+            m_nr4SmoothingLabel->setText(QString::number(v));
+            auto& s = AppSettings::instance();
+            s.setValue("NR4SmoothingFactor", QString::number(static_cast<float>(v), 'f', 1));
+            s.save();
+            emit nr4SmoothingChanged(static_cast<float>(v));
+        });
+        ++row;
+    }
+
+    {
+        auto* lbl = new QLabel("Whitening (%):");
+        lbl->setStyleSheet(labelStyle);
+        sliderGrid->addWidget(lbl, row, 0);
+        m_nr4WhiteningSlider = new GuardedSlider(Qt::Horizontal);
+        m_nr4WhiteningSlider->setRange(0, 100);
+        m_nr4WhiteningSlider->setValue(0);
+        m_nr4WhiteningSlider->setStyleSheet(kSliderStyle);
+        m_nr4WhiteningSlider->setToolTip("Flattens the spectral shape of residual noise so it sounds more uniform.");
+        sliderGrid->addWidget(m_nr4WhiteningSlider, row, 1);
+        m_nr4WhiteningLabel = new QLabel("0");
+        m_nr4WhiteningLabel->setStyleSheet(valStyle);
+        m_nr4WhiteningLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        sliderGrid->addWidget(m_nr4WhiteningLabel, row, 2);
+        connect(m_nr4WhiteningSlider, &QSlider::valueChanged, this, [this](int v) {
+            m_nr4WhiteningLabel->setText(QString::number(v));
+            auto& s = AppSettings::instance();
+            s.setValue("NR4WhiteningFactor", QString::number(static_cast<float>(v), 'f', 1));
+            s.save();
+            emit nr4WhiteningChanged(static_cast<float>(v));
+        });
+        ++row;
+    }
+
+    {
+        auto* lbl = new QLabel("Masking Depth:");
+        lbl->setStyleSheet(labelStyle);
+        sliderGrid->addWidget(lbl, row, 0);
+        m_nr4MaskingSlider = new GuardedSlider(Qt::Horizontal);
+        m_nr4MaskingSlider->setRange(0, 100);
+        m_nr4MaskingSlider->setValue(50);
+        m_nr4MaskingSlider->setStyleSheet(kSliderStyle);
+        m_nr4MaskingSlider->setToolTip("Depth of spectral masking. Higher values suppress more noise in masked frequency regions.");
+        sliderGrid->addWidget(m_nr4MaskingSlider, row, 1);
+        m_nr4MaskingLabel = new QLabel("0.50");
+        m_nr4MaskingLabel->setStyleSheet(valStyle);
+        m_nr4MaskingLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        sliderGrid->addWidget(m_nr4MaskingLabel, row, 2);
+        connect(m_nr4MaskingSlider, &QSlider::valueChanged, this, [this](int v) {
+            float val = v / 100.0f;
+            m_nr4MaskingLabel->setText(QString::number(val, 'f', 2));
+            auto& s = AppSettings::instance();
+            s.setValue("NR4MaskingDepth", QString::number(val, 'f', 2));
+            s.save();
+            emit nr4MaskingDepthChanged(val);
+        });
+        ++row;
+    }
+
+    {
+        auto* lbl = new QLabel("Suppression:");
+        lbl->setStyleSheet(labelStyle);
+        sliderGrid->addWidget(lbl, row, 0);
+        m_nr4SuppressionSlider = new GuardedSlider(Qt::Horizontal);
+        m_nr4SuppressionSlider->setRange(0, 100);
+        m_nr4SuppressionSlider->setValue(50);
+        m_nr4SuppressionSlider->setStyleSheet(kSliderStyle);
+        m_nr4SuppressionSlider->setToolTip("Overall suppression strength. Higher values apply more aggressive noise removal.");
+        sliderGrid->addWidget(m_nr4SuppressionSlider, row, 1);
+        m_nr4SuppressionLabel = new QLabel("0.50");
+        m_nr4SuppressionLabel->setStyleSheet(valStyle);
+        m_nr4SuppressionLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        sliderGrid->addWidget(m_nr4SuppressionLabel, row, 2);
+        connect(m_nr4SuppressionSlider, &QSlider::valueChanged, this, [this](int v) {
+            float val = v / 100.0f;
+            m_nr4SuppressionLabel->setText(QString::number(val, 'f', 2));
+            auto& s = AppSettings::instance();
+            s.setValue("NR4SuppressionStrength", QString::number(val, 'f', 2));
+            s.save();
+            emit nr4SuppressionChanged(val);
+        });
+        ++row;
+    }
+
+    vbox->addLayout(sliderGrid);
+    vbox->addStretch();
+    return page;
+}
+
+// ── MNR Tab ──────────────────────────────────────────────────────────────────
+
+QWidget* AetherDspWidget::buildMnrPage()
+{
+    auto* page = new QWidget;
+    auto* vbox = new QVBoxLayout(page);
+
+    auto labelStyle = QStringLiteral("QLabel { color: #8090a0; font-size: 11px; }");
+    auto valStyle   = QStringLiteral("QLabel { color: #c8d8e8; font-size: 11px; min-width: 40px; }");
+
+    m_mnrEnableCheck = new QCheckBox("Enable MNR (macOS only)");
+    m_mnrEnableCheck->setToolTip("MMSE-Wiener spectral noise reduction with asymmetric gain smoothing.\n"
+                                 "Removes consistent background noise while preserving speech quality.");
+    {
+        auto* hdrRow = new QHBoxLayout;
+        hdrRow->setContentsMargins(0, 0, 0, 0);
+        hdrRow->addWidget(m_mnrEnableCheck);
+        hdrRow->addStretch(1);
+        auto* resetBtn = makeResetIconButton();
+        connect(resetBtn, &QPushButton::clicked,
+                this, &AetherDspWidget::resetCurrentTab);
+        hdrRow->addWidget(resetBtn);
+        vbox->addLayout(hdrRow);
+    }
+    connect(m_mnrEnableCheck, &QCheckBox::toggled, this, [this](bool checked) {
+        auto& s = AppSettings::instance();
+        s.setValue("MnrEnabled", checked ? "True" : "False");
+        s.save();
+        emit mnrEnabledChanged(checked);
+    });
+
+    {
+        auto* row = new QHBoxLayout;
+        auto* lbl = new QLabel("Strength");
+        lbl->setStyleSheet(labelStyle);
+        row->addWidget(lbl);
+
+        m_mnrStrengthSlider = new GuardedSlider(Qt::Horizontal);
+        m_mnrStrengthSlider->setRange(0, 100);
+        m_mnrStrengthSlider->setValue(100);
+        m_mnrStrengthSlider->setStyleSheet(kSliderStyle);
+        m_mnrStrengthSlider->setToolTip("Adjust noise reduction aggressiveness (0 = mild, 100 = maximum)");
+        row->addWidget(m_mnrStrengthSlider, 1);
+
+        m_mnrStrengthLabel = new QLabel("100%");
+        m_mnrStrengthLabel->setStyleSheet(valStyle);
+        row->addWidget(m_mnrStrengthLabel);
+        vbox->addLayout(row);
+
+        connect(m_mnrStrengthSlider, &QSlider::valueChanged, this, [this](int value) {
+            float normalized = value / 100.0f;
+            m_mnrStrengthLabel->setText(QString::number(value) + "%");
+            auto& s = AppSettings::instance();
+            s.setValue("MnrStrength", QString::number(normalized, 'f', 2));
+            s.save();
+            emit mnrStrengthChanged(normalized);
+        });
+    }
+
+    auto* info = new QLabel("Asymmetric temporal smoothing: fast release (~15ms) for quick noise suppression,\n"
+                            "gentle attack (~64ms) to preserve speech transients without artifacts.");
+    info->setWordWrap(true);
+    info->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; }");
+    vbox->addSpacing(8);
+    vbox->addWidget(info);
+
+    vbox->addStretch();
+    return page;
+}
+
+// ── RN2 Tab ─────────────────────────────────────────────────────────────────
+
+QWidget* AetherDspWidget::buildRn2Page()
+{
+    auto* page = new QWidget;
+    auto* vbox = new QVBoxLayout(page);
+    auto* lbl = new QLabel(
+        "RNNoise — open-source recurrent neural-network voice denoiser. "
+        "Removes stationary background noise (fans, hum, white-noise floor) "
+        "while preserving speech.  Lightweight and CPU-only.  No adjustable "
+        "parameters.");
+    lbl->setWordWrap(true);
+    lbl->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+    lbl->setStyleSheet("QLabel { color: #8aa8c0; font-size: 12px; }");
+    vbox->addWidget(lbl);
+    vbox->addStretch();
+    return page;
+}
+
+// ── BNR Tab ─────────────────────────────────────────────────────────────────
+
+QWidget* AetherDspWidget::buildBnrPage()
+{
+    auto* page = new QWidget;
+    auto* vbox = new QVBoxLayout(page);
+    auto* lbl = new QLabel(
+        "NVIDIA Broadcast — GPU-accelerated AI noise removal.  Strongest "
+        "against non-stationary noise (typing, traffic, dogs barking).  "
+        "Requires an NVIDIA GPU with the Broadcast SDK.  Intensity is "
+        "controlled from the slice overlay menu.");
+    lbl->setWordWrap(true);
+    lbl->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+    lbl->setStyleSheet("QLabel { color: #8aa8c0; font-size: 12px; }");
+    vbox->addWidget(lbl);
+    vbox->addStretch();
+    return page;
+}
+
+// ── DFNR Tab ────────────────────────────────────────────────────────────────
+
+QWidget* AetherDspWidget::buildDfnrPage()
+{
+    auto* page = new QWidget;
+    auto* vbox = new QVBoxLayout(page);
+    // 20 px top breathing room between the DSP selector buttons and
+    // the info paragraph; 10 px left margin for the controls body.
+    vbox->setContentsMargins(10, 20, 0, 0);
+
+    // GroupBox dropped — the rest of the AetherDSP applet uses simple
+    // labelled rows, so the rounded-frame chrome around DFNR was the
+    // odd one out.
+    auto* grid = new QGridLayout;
+    grid->setColumnStretch(1, 1);
+
+    auto& s = AppSettings::instance();
+
+    auto* info = new QLabel("AI-powered speech enhancement — higher fidelity than RNNoise "
+                            "in high-noise HF environments. CPU-only, 10 ms latency, 48 kHz.");
+    info->setWordWrap(true);
+    info->setStyleSheet("QLabel { color: #8aa8c0; font-size: 12px; }");
+    {
+        auto* infoRow = new QHBoxLayout;
+        infoRow->setContentsMargins(0, 0, 10, 0);
+        infoRow->addWidget(info);
+        vbox->addLayout(infoRow);
+    }
+
+    // Reset Defaults on its own row between the info paragraph and the
+    // slider grid — right-aligned with 10 px right padding to nudge it
+    // inboard so it lines up over the slider value-label column below.
+    {
+        auto* resetRow = new QHBoxLayout;
+        resetRow->setContentsMargins(0, 10, 10, 0);
+        resetRow->addStretch(1);
+        auto* dfnrResetBtn = makeResetIconButton();
+        connect(dfnrResetBtn, &QPushButton::clicked,
+                this, &AetherDspWidget::resetCurrentTab);
+        resetRow->addWidget(dfnrResetBtn);
+        vbox->addLayout(resetRow);
+    }
+
+    grid->addWidget(new QLabel("Attenuation Limit"), 1, 0);
+    m_dfnrAttenSlider = new QSlider(Qt::Horizontal);
+    m_dfnrAttenSlider->setRange(0, 100);
+    m_dfnrAttenSlider->setValue(static_cast<int>(s.value("DfnrAttenLimit", "100").toFloat()));
+    m_dfnrAttenSlider->setStyleSheet(kSliderStyle);
+    m_dfnrAttenSlider->setToolTip("Maximum noise attenuation in dB.\n"
+                                   "0 dB = passthrough (no denoising)\n"
+                                   "100 dB = maximum noise removal\n\n"
+                                   "For weak signals: 20–30 dB\n"
+                                   "For casual listening: 40–60 dB\n"
+                                   "For strong signals: 80–100 dB");
+    grid->addWidget(m_dfnrAttenSlider, 1, 1);
+    m_dfnrAttenLabel = new QLabel(QString::number(m_dfnrAttenSlider->value()));
+    m_dfnrAttenLabel->setFixedWidth(40);
+    grid->addWidget(m_dfnrAttenLabel, 1, 2);
+
+    connect(m_dfnrAttenSlider, &QSlider::valueChanged, this, [this](int v) {
+        m_dfnrAttenLabel->setText(QString::number(v));
+        float db = static_cast<float>(v);
+        auto& s = AppSettings::instance();
+        s.setValue("DfnrAttenLimit", QString::number(db, 'f', 0));
+        s.save();
+        emit dfnrAttenLimitChanged(db);
+    });
+
+    grid->addWidget(new QLabel("Post-Filter Beta"), 2, 0);
+    m_dfnrBetaSlider = new QSlider(Qt::Horizontal);
+    m_dfnrBetaSlider->setRange(0, 30);
+    m_dfnrBetaSlider->setValue(static_cast<int>(s.value("DfnrPostFilterBeta", "0.0").toFloat() * 100));
+    m_dfnrBetaSlider->setStyleSheet(kSliderStyle);
+    m_dfnrBetaSlider->setToolTip("Post-filter strength for additional noise suppression.\n"
+                                  "0 = disabled (default)\n"
+                                  "0.05–0.15 = subtle additional filtering\n"
+                                  "0.15–0.30 = aggressive post-processing");
+    grid->addWidget(m_dfnrBetaSlider, 2, 1);
+    m_dfnrBetaLabel = new QLabel(QString::number(m_dfnrBetaSlider->value() / 100.0f, 'f', 2));
+    m_dfnrBetaLabel->setFixedWidth(40);
+    grid->addWidget(m_dfnrBetaLabel, 2, 2);
+
+    connect(m_dfnrBetaSlider, &QSlider::valueChanged, this, [this](int v) {
+        float beta = v / 100.0f;
+        m_dfnrBetaLabel->setText(QString::number(beta, 'f', 2));
+        auto& s = AppSettings::instance();
+        s.setValue("DfnrPostFilterBeta", QString::number(beta, 'f', 2));
+        s.save();
+        emit dfnrPostFilterBetaChanged(beta);
+    });
+
+    vbox->addLayout(grid);
+    vbox->addStretch();
+    return page;
+}
+
+// ── Sync from saved settings ─────────────────────────────────────────────────
+
+void AetherDspWidget::syncFromEngine()
+{
+    auto& s = AppSettings::instance();
+
+    int gainMethod = s.value("NR2GainMethod", "2").toInt();
+    if (auto* btn = m_nr2GainGroup->button(gainMethod))
+        btn->setChecked(true);
+
+    int npeMethod = s.value("NR2NpeMethod", "0").toInt();
+    if (auto* btn = m_nr2NpeGroup->button(npeMethod))
+        btn->setChecked(true);
+
+    bool aeFilter = s.value("NR2AeFilter", "True").toString() == "True";
+    m_nr2AeCheck->setChecked(aeFilter);
+
+    int gainMax = static_cast<int>(s.value("NR2GainMax", "1.50").toFloat() * 100);
+    m_nr2GainMaxSlider->setValue(gainMax);
+    m_nr2GainMaxLabel->setText(QString::number(gainMax / 100.0f, 'f', 2));
+
+    int smooth = static_cast<int>(s.value("NR2GainSmooth", "0.85").toFloat() * 100);
+    m_nr2SmoothSlider->setValue(smooth);
+    m_nr2SmoothLabel->setText(QString::number(smooth / 100.0f, 'f', 2));
+
+    int qspp = static_cast<int>(s.value("NR2Qspp", "0.20").toFloat() * 100);
+    m_nr2QsppSlider->setValue(qspp);
+    m_nr2QsppLabel->setText(QString::number(qspp / 100.0f, 'f', 2));
+
+    if (m_mnrEnableCheck) {
+        { QSignalBlocker sb(m_mnrEnableCheck);
+          m_mnrEnableCheck->setChecked(m_audio->mnrEnabled()); }
+        { QSignalBlocker sb(m_mnrStrengthSlider);
+          int strength = static_cast<int>(m_audio->mnrStrength() * 100.0f);
+          m_mnrStrengthSlider->setValue(strength);
+          m_mnrStrengthLabel->setText(QString::number(strength) + "%"); }
+    }
+
+    int noiseMethod = s.value("NR4NoiseEstimationMethod", "0").toInt();
+    if (auto* btn = m_nr4MethodGroup->button(noiseMethod))
+        btn->setChecked(true);
+
+    bool adaptive = s.value("NR4AdaptiveNoise", "True").toString() == "True";
+    m_nr4AdaptiveCheck->setChecked(adaptive);
+
+    int reduction = static_cast<int>(s.value("NR4ReductionAmount", "10.0").toFloat() * 10);
+    m_nr4ReductionSlider->setValue(reduction);
+    m_nr4ReductionLabel->setText(QString::number(reduction / 10.0f, 'f', 1));
+
+    int smoothing = static_cast<int>(s.value("NR4SmoothingFactor", "0.0").toFloat());
+    m_nr4SmoothingSlider->setValue(smoothing);
+    m_nr4SmoothingLabel->setText(QString::number(smoothing));
+
+    int whitening = static_cast<int>(s.value("NR4WhiteningFactor", "0.0").toFloat());
+    m_nr4WhiteningSlider->setValue(whitening);
+    m_nr4WhiteningLabel->setText(QString::number(whitening));
+
+    int masking = static_cast<int>(s.value("NR4MaskingDepth", "0.50").toFloat() * 100);
+    m_nr4MaskingSlider->setValue(masking);
+    m_nr4MaskingLabel->setText(QString::number(masking / 100.0f, 'f', 2));
+
+    int suppression = static_cast<int>(s.value("NR4SuppressionStrength", "0.50").toFloat() * 100);
+    m_nr4SuppressionSlider->setValue(suppression);
+    m_nr4SuppressionLabel->setText(QString::number(suppression / 100.0f, 'f', 2));
+
+    if (m_dfnrAttenSlider) {
+        int atten = static_cast<int>(s.value("DfnrAttenLimit", "100").toFloat());
+        m_dfnrAttenSlider->setValue(atten);
+        m_dfnrAttenLabel->setText(QString::number(atten));
+    }
+    if (m_dfnrBetaSlider) {
+        int beta = static_cast<int>(s.value("DfnrPostFilterBeta", "0.0").toFloat() * 100);
+        m_dfnrBetaSlider->setValue(beta);
+        m_dfnrBetaLabel->setText(QString::number(beta / 100.0f, 'f', 2));
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/AetherDspWidget.h
+++ b/src/gui/AetherDspWidget.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <QWidget>
+#include <array>
+
+class QSlider;
+class QLabel;
+class QPushButton;
+class QRadioButton;
+class QCheckBox;
+class QButtonGroup;
+class QStackedWidget;
+
+namespace AetherSDR {
+
+class AudioEngine;
+
+// AetherDSP settings body — the QTabWidget + per-tab controls + AppSettings
+// persistence wiring shared by the modeless AetherDspDialog (Settings menu)
+// and the docked ClientRxDspApplet (PooDoo Audio RX side).
+//
+// Signals fire on every parameter change (after the new value lands in
+// AppSettings) so MainWindow can push the value into AudioEngine.  Both
+// the dialog and the applet expose a `widget()` accessor so callers can
+// connect to these signals directly.
+class AetherDspWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    // DSP selector index — buttons in the selector row act as exclusive
+    // activators for the six client-side noise-reduction modules.  The
+    // button checked-state is the engine enable state; clicking the
+    // active button toggles it off (no DSP active).
+    enum DspId { NR2 = 0, NR4, MNR, DFNR, RN2, BNR, NumDsps };
+
+    explicit AetherDspWidget(AudioEngine* audio, QWidget* parent = nullptr);
+
+    // Sync UI from current AudioEngine + AppSettings state.
+    void syncFromEngine();
+
+    // Jump to a named tab (e.g. "MNR", "NR2", "DFNR").
+    void selectTab(const QString& name);
+
+    // Tighten padding / margins / fonts for the docked-applet variant.
+    // The Settings-menu dialog leaves this off and renders at full size.
+    void setCompactMode(bool on);
+
+    // Disable the NR2 selector button when compressed (Opus / SmartLink)
+    // audio is active — NR2 amplifies codec artifacts (#1597).
+    void setNr2Available(bool available, const QString& tooltip);
+
+signals:
+    // NR2 parameter changes
+    void nr2GainMaxChanged(float value);
+    void nr2GainSmoothChanged(float value);
+    void nr2QsppChanged(float value);
+    void nr2GainMethodChanged(int method);
+    void nr2NpeMethodChanged(int method);
+    void nr2AeFilterChanged(bool on);
+    // MNR parameter changes
+    void mnrEnabledChanged(bool on);
+    void mnrStrengthChanged(float value);
+    // DFNR parameter changes
+    void dfnrAttenLimitChanged(float dB);
+    void dfnrPostFilterBetaChanged(float beta);
+    // NR4 parameter changes
+    void nr4ReductionChanged(float dB);
+    void nr4SmoothingChanged(float pct);
+    void nr4WhiteningChanged(float pct);
+    void nr4AdaptiveNoiseChanged(bool on);
+    void nr4NoiseMethodChanged(int method);
+    void nr4MaskingDepthChanged(float value);
+    void nr4SuppressionChanged(float value);
+
+    // Emitted instead of calling AudioEngine::setNr2Enabled(true) directly
+    // so MainWindow can run the FFTW-wisdom prep first (PR #2275).  NR2
+    // disable + every other DSP still go through the direct invokeMethod
+    // path inside onDspButtonClicked.
+    void nr2EnableWithWisdomRequested();
+
+private:
+    QWidget* buildNr2Page();
+    QWidget* buildNr4Page();
+    QWidget* buildMnrPage();
+    QWidget* buildRn2Page();
+    QWidget* buildBnrPage();
+    QWidget* buildDfnrPage();
+
+    // Restore defaults for the currently-selected DSP page.  No-op for
+    // RN2 / BNR which expose no adjustable parameters.
+    void resetCurrentTab();
+
+    // Click handler for the per-DSP selector buttons.  index = DspId.
+    void onDspButtonClicked(int index, bool nowChecked);
+
+    // Push current AudioEngine enable state into the buttons + page stack
+    // (without re-firing engine setters).  Called once at construction
+    // and on every *EnabledChanged signal.
+    void syncDspSelectorFromEngine();
+
+    AudioEngine*    m_audio;
+    QStackedWidget* m_dspStack{nullptr};
+    std::array<QPushButton*, NumDsps> m_dspBtns{};
+
+    // NR2 controls
+    QButtonGroup* m_nr2GainGroup{nullptr};
+    QButtonGroup* m_nr2NpeGroup{nullptr};
+    QCheckBox*    m_nr2AeCheck{nullptr};
+    QSlider*      m_nr2GainMaxSlider{nullptr};
+    QLabel*       m_nr2GainMaxLabel{nullptr};
+    QSlider*      m_nr2SmoothSlider{nullptr};
+    QLabel*       m_nr2SmoothLabel{nullptr};
+    QSlider*      m_nr2QsppSlider{nullptr};
+    QLabel*       m_nr2QsppLabel{nullptr};
+
+    // MNR controls
+    QCheckBox*    m_mnrEnableCheck{nullptr};
+    QSlider*      m_mnrStrengthSlider{nullptr};
+    QLabel*       m_mnrStrengthLabel{nullptr};
+
+    // NR4 controls
+    QSlider*      m_nr4ReductionSlider{nullptr};
+    QLabel*       m_nr4ReductionLabel{nullptr};
+    QSlider*      m_nr4SmoothingSlider{nullptr};
+    QLabel*       m_nr4SmoothingLabel{nullptr};
+    QSlider*      m_nr4WhiteningSlider{nullptr};
+    QLabel*       m_nr4WhiteningLabel{nullptr};
+    QCheckBox*    m_nr4AdaptiveCheck{nullptr};
+    QButtonGroup* m_nr4MethodGroup{nullptr};
+    QSlider*      m_nr4MaskingSlider{nullptr};
+    QLabel*       m_nr4MaskingLabel{nullptr};
+    QSlider*      m_nr4SuppressionSlider{nullptr};
+    QLabel*       m_nr4SuppressionLabel{nullptr};
+
+    // DFNR controls
+    QSlider*      m_dfnrAttenSlider{nullptr};
+    QLabel*       m_dfnrAttenLabel{nullptr};
+    QSlider*      m_dfnrBetaSlider{nullptr};
+    QLabel*       m_dfnrBetaLabel{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -20,6 +20,7 @@
 #include "ClientTubeApplet.h"
 #include "ClientPuduApplet.h"
 #include "ClientReverbApplet.h"
+#include "ClientRxDspApplet.h"
 #include "ClientChainApplet.h"
 #include "CatControlApplet.h"
 #include "DaxApplet.h"
@@ -672,6 +673,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_clientPuduApplet   = new ClientPuduApplet(ClientPuduApplet::Side::Tx);
     m_clientPuduRxApplet = new ClientPuduApplet(ClientPuduApplet::Side::Rx);
     m_clientReverbApplet = new ClientReverbApplet;
+    m_clientRxDspApplet  = new ClientRxDspApplet;
     m_clientChainApplet = new ClientChainApplet;
 
     auto* txDsp = m_containerMgr->createContainer(
@@ -708,6 +710,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     makeChildContainer("pudu",    QString::fromUtf8("Aetherial TX Poodoo\xe2\x84\xa2"), m_clientPuduApplet,   -1);
     makeChildContainer("pudu-rx", QString::fromUtf8("Aetherial RX Poodoo\xe2\x84\xa2"), m_clientPuduRxApplet, -1);
     makeChildContainer("reverb",  "Aetherial FreeVerb",       m_clientReverbApplet, -1);
+    makeChildContainer("dsp-rx",  "Aetherial Noise Reduction", m_clientRxDspApplet, -1);
 
     // One-shot settings migration (#1713 Phase 4b): carry over the
     // legacy Applet_CHAIN visibility to the new Applet_TXDSP key so
@@ -904,13 +907,20 @@ void AppletPanel::setPooDooActiveSide(PooDooSide side)
         QStringLiteral("cmp-rx"),
         QStringLiteral("tube-rx"),
         QStringLiteral("pudu-rx"),
+        QStringLiteral("dsp-rx"),
     };
     const bool txActive = (side == PooDooSide::Tx);
 
     auto applyVisibility = [this](const QStringList& ids, bool visible) {
         for (const auto& id : ids) {
             if (auto* c = m_containerMgr->container(id)) {
+                // Force the underlying QWidget visibility too — insertChildWidget
+                // calls show() directly which can leave m_visible=true while the
+                // user's saved tab says hide.  setContainerVisible() short-circuits
+                // when m_visible already matches, so call QWidget::setVisible
+                // unconditionally to reconcile.
                 c->setContainerVisible(visible);
+                c->setVisible(visible);
             }
         }
     };

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -37,6 +37,7 @@ class ClientDeEssApplet;
 class ClientTubeApplet;
 class ClientPuduApplet;
 class ClientReverbApplet;
+class ClientRxDspApplet;
 class ClientChainApplet;
 class CatControlApplet;
 class DaxApplet;
@@ -102,6 +103,7 @@ public:
     ClientPuduApplet* clientPuduTxApplet() { return m_clientPuduApplet; }
     ClientPuduApplet* clientPuduRxApplet() { return m_clientPuduRxApplet; }
     ClientReverbApplet* clientReverbApplet() { return m_clientReverbApplet; }
+    ClientRxDspApplet*  clientRxDspApplet() { return m_clientRxDspApplet; }
     ClientChainApplet* clientChainApplet() { return m_clientChainApplet; }
     CatControlApplet* catControlApplet() { return m_catControlApplet; }
     DaxApplet*      daxApplet()      { return m_daxApplet; }
@@ -218,6 +220,7 @@ private:
     ClientPuduApplet* m_clientPuduApplet{nullptr};
     ClientPuduApplet* m_clientPuduRxApplet{nullptr};
     ClientReverbApplet* m_clientReverbApplet{nullptr};
+    ClientRxDspApplet*  m_clientRxDspApplet{nullptr};
     ClientChainApplet* m_clientChainApplet{nullptr};
     CatControlApplet* m_catControlApplet{nullptr};
     DaxApplet*     m_daxApplet{nullptr};

--- a/src/gui/ClientChainApplet.cpp
+++ b/src/gui/ClientChainApplet.cpp
@@ -210,6 +210,10 @@ ClientChainApplet::ClientChainApplet(QWidget* parent) : QWidget(parent)
             this, &ClientChainApplet::chainReordered);
     connect(m_rxChain, &ClientRxChainWidget::editRequested,
             this, &ClientChainApplet::rxEditRequested);
+    connect(m_rxChain, &ClientRxChainWidget::dspEditRequested,
+            this, &ClientChainApplet::rxDspEditRequested);
+    connect(m_rxChain, &ClientRxChainWidget::nr2EnableWithWisdomRequested,
+            this, &ClientChainApplet::rxNr2EnableWithWisdomRequested);
     connect(m_rxChain, &ClientRxChainWidget::stageEnabledChanged,
             this, &ClientChainApplet::rxStageEnabledChanged);
     connect(m_rxChain, &ClientRxChainWidget::chainReordered,

--- a/src/gui/ClientChainApplet.h
+++ b/src/gui/ClientChainApplet.h
@@ -73,6 +73,11 @@ signals:
     // can route them to the right editor / applet without depending on
     // the chain widget directly.
     void rxEditRequested(AudioEngine::RxChainStage stage);
+    // Emitted when the user double-clicks the RX-chain DSP status tile.
+    void rxDspEditRequested();
+    // Forwarded from ClientRxChainWidget when single-click re-enables
+    // NR2 from LastClientNr; MainWindow runs the wisdom-prep path.
+    void rxNr2EnableWithWisdomRequested();
     void rxStageEnabledChanged(AudioEngine::RxChainStage stage, bool enabled);
     // Emitted after a successful drag-reorder of the RX chain.  Mirrors
     // chainReordered() above on the TX side.

--- a/src/gui/ClientCompApplet.cpp
+++ b/src/gui/ClientCompApplet.cpp
@@ -5,6 +5,7 @@
 #include "core/AudioEngine.h"
 #include "core/ClientComp.h"
 
+#include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QPushButton>
@@ -253,6 +254,17 @@ void ClientCompApplet::setAudioEngine(AudioEngine* engine)
 void ClientCompApplet::syncEnableFromEngine()
 {
     if (m_curve) m_curve->update();
+
+    // Bypass dim — render the whole tile at reduced opacity when the
+    // stage is bypassed, matching the dim effect on the EQ curve.
+    const bool dspEnabled = (m_audio && comp()) ? comp()->isEnabled() : true;
+    auto* eff = qobject_cast<QGraphicsOpacityEffect*>(graphicsEffect());
+    if (!eff) {
+        eff = new QGraphicsOpacityEffect(this);
+        setGraphicsEffect(eff);
+    }
+    eff->setOpacity(dspEnabled ? 1.0 : 0.55);
+
     if (!m_audio || !comp()) return;
     ClientComp* c = comp();
     if (m_thresh)  { QSignalBlocker b(m_thresh);  m_thresh->setValue(c->thresholdDb()); }

--- a/src/gui/ClientDeEssApplet.cpp
+++ b/src/gui/ClientDeEssApplet.cpp
@@ -5,6 +5,7 @@
 #include "core/AudioEngine.h"
 #include "core/ClientDeEss.h"
 
+#include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QPushButton>
@@ -216,6 +217,18 @@ void ClientDeEssApplet::setAudioEngine(AudioEngine* engine)
 void ClientDeEssApplet::syncEnableFromEngine()
 {
     if (m_curve) m_curve->update();
+
+    // Bypass dim — render the whole tile at reduced opacity when the
+    // stage is bypassed, matching the dim effect on the EQ curve.
+    auto* dsp0 = (m_audio ? m_audio->clientDeEssTx() : nullptr);
+    const bool dspEnabled = dsp0 ? dsp0->isEnabled() : true;
+    auto* eff = qobject_cast<QGraphicsOpacityEffect*>(graphicsEffect());
+    if (!eff) {
+        eff = new QGraphicsOpacityEffect(this);
+        setGraphicsEffect(eff);
+    }
+    eff->setOpacity(dspEnabled ? 1.0 : 0.55);
+
     if (!m_audio || !m_audio->clientDeEssTx()) return;
     ClientDeEss* d = m_audio->clientDeEssTx();
     if (m_freq)   { QSignalBlocker b(m_freq);   m_freq->setValue(d->frequencyHz()); }

--- a/src/gui/ClientGateApplet.cpp
+++ b/src/gui/ClientGateApplet.cpp
@@ -5,6 +5,7 @@
 #include "core/AudioEngine.h"
 #include "core/ClientGate.h"
 
+#include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QPushButton>
@@ -247,6 +248,17 @@ void ClientGateApplet::setAudioEngine(AudioEngine* engine)
 void ClientGateApplet::syncEnableFromEngine()
 {
     if (m_curve) m_curve->update();
+
+    // Bypass dim — render the whole tile at reduced opacity when the
+    // stage is bypassed, matching the dim effect on the EQ curve.
+    const bool dspEnabled = (m_audio && gate()) ? gate()->isEnabled() : true;
+    auto* eff = qobject_cast<QGraphicsOpacityEffect*>(graphicsEffect());
+    if (!eff) {
+        eff = new QGraphicsOpacityEffect(this);
+        setGraphicsEffect(eff);
+    }
+    eff->setOpacity(dspEnabled ? 1.0 : 0.55);
+
     if (!m_audio || !gate()) return;
     ClientGate* g = gate();
     if (m_thresh)  { QSignalBlocker b(m_thresh);  m_thresh->setValue(g->thresholdDb()); }

--- a/src/gui/ClientPuduApplet.cpp
+++ b/src/gui/ClientPuduApplet.cpp
@@ -7,6 +7,7 @@
 #include <QButtonGroup>
 #include <QFrame>
 #include <QGridLayout>
+#include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
@@ -271,6 +272,16 @@ void ClientPuduApplet::setAudioEngine(AudioEngine* engine)
 
 void ClientPuduApplet::syncControlsFromEngine()
 {
+    // Bypass dim — render the whole tile at reduced opacity when the
+    // stage is bypassed, matching the dim effect on the EQ curve.
+    const bool dspEnabled = (m_audio && pudu()) ? pudu()->isEnabled() : true;
+    auto* eff = qobject_cast<QGraphicsOpacityEffect*>(graphicsEffect());
+    if (!eff) {
+        eff = new QGraphicsOpacityEffect(this);
+        setGraphicsEffect(eff);
+    }
+    eff->setOpacity(dspEnabled ? 1.0 : 0.55);
+
     if (!m_audio || !pudu()) return;
     ClientPudu* p = pudu();
 

--- a/src/gui/ClientReverbApplet.cpp
+++ b/src/gui/ClientReverbApplet.cpp
@@ -3,6 +3,7 @@
 #include "core/AudioEngine.h"
 #include "core/ClientReverb.h"
 
+#include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
 #include <QSignalBlocker>
 #include <QTimer>
@@ -131,6 +132,17 @@ void ClientReverbApplet::refreshEnableFromEngine()
 
 void ClientReverbApplet::syncKnobsFromEngine()
 {
+    // Bypass dim — render the whole tile at reduced opacity when the
+    // stage is bypassed, matching the dim effect on the EQ curve.
+    auto* r0 = (m_audio ? m_audio->clientReverbTx() : nullptr);
+    const bool dspEnabled = r0 ? r0->isEnabled() : true;
+    auto* eff = qobject_cast<QGraphicsOpacityEffect*>(graphicsEffect());
+    if (!eff) {
+        eff = new QGraphicsOpacityEffect(this);
+        setGraphicsEffect(eff);
+    }
+    eff->setOpacity(dspEnabled ? 1.0 : 0.55);
+
     if (!m_audio || !m_audio->clientReverbTx()) return;
     ClientReverb* r = m_audio->clientReverbTx();
     if (m_size)    { QSignalBlocker b(m_size);    m_size->setValue(r->size()); }

--- a/src/gui/ClientRxChainWidget.cpp
+++ b/src/gui/ClientRxChainWidget.cpp
@@ -235,6 +235,45 @@ void ClientRxChainWidget::toggleStageBypass(int boxIdx)
 {
     if (!m_audio || boxIdx < 0 || boxIdx >= m_boxes.size()) return;
     const auto& box = m_boxes[boxIdx];
+
+    // DSP status tile toggle: client-side NR is exclusive, so a click
+    // here means "turn off whichever module is currently on", and a
+    // click while everything is off re-enables the last-active module
+    // saved by AetherDspWidget::onDspButtonClicked.
+    if (box.kind == TileKind::StatusDsp) {
+        const bool anyOn = m_audio->nr2Enabled()  || m_audio->nr4Enabled()
+                        || m_audio->mnrEnabled()  || m_audio->dfnrEnabled()
+                        || m_audio->rn2Enabled()  || m_audio->bnrEnabled();
+        if (anyOn) {
+            QMetaObject::invokeMethod(m_audio, [audio = m_audio]() {
+                if (audio->nr2Enabled())  audio->setNr2Enabled(false);
+                if (audio->nr4Enabled())  audio->setNr4Enabled(false);
+                if (audio->mnrEnabled())  audio->setMnrEnabled(false);
+                if (audio->dfnrEnabled()) audio->setDfnrEnabled(false);
+                if (audio->rn2Enabled())  audio->setRn2Enabled(false);
+                if (audio->bnrEnabled())  audio->setBnrEnabled(false);
+            });
+        } else {
+            const QString name = AppSettings::instance()
+                .value("LastClientNr", "").toString();
+            if (name.isEmpty()) return;
+            // NR2 enable goes through MainWindow's wisdom prep path —
+            // plain audio-thread setter can crash on bad FFTW plans.
+            if (name == "NR2") {
+                emit nr2EnableWithWisdomRequested();
+                return;
+            }
+            QMetaObject::invokeMethod(m_audio, [audio = m_audio, name]() {
+                if (name == "NR4")       audio->setNr4Enabled(true);
+                else if (name == "MNR")  audio->setMnrEnabled(true);
+                else if (name == "DFNR") audio->setDfnrEnabled(true);
+                else if (name == "RN2")  audio->setRn2Enabled(true);
+                else if (name == "BNR")  audio->setBnrEnabled(true);
+            });
+        }
+        return;
+    }
+
     if (box.kind != TileKind::Stage) return;
     if (!isStageImplemented(box.stage)) return;
 
@@ -290,8 +329,11 @@ void ClientRxChainWidget::mousePressEvent(QMouseEvent* ev)
         return;
     }
     const auto& box = m_boxes[idx];
-    if (box.kind != TileKind::Stage || !isStageImplemented(box.stage)) {
-        // Status tiles + unimplemented stages: nothing on click.
+    const bool clickableStage = (box.kind == TileKind::Stage
+                                 && isStageImplemented(box.stage));
+    const bool clickableDsp   = (box.kind == TileKind::StatusDsp);
+    if (!clickableStage && !clickableDsp) {
+        // RADIO / SPEAK status tiles + unimplemented stages: nothing on click.
         m_pressIndex = -1;
         QWidget::mousePressEvent(ev);
         return;
@@ -370,7 +412,10 @@ void ClientRxChainWidget::mouseReleaseEvent(QMouseEvent* ev)
     m_pressIndex = -1;
     if (idx < 0 || idx >= m_boxes.size()) return;
     const auto& box = m_boxes[idx];
-    if (box.kind != TileKind::Stage || !isStageImplemented(box.stage)) return;
+    const bool clickableStage = (box.kind == TileKind::Stage
+                                 && isStageImplemented(box.stage));
+    const bool clickableDsp   = (box.kind == TileKind::StatusDsp);
+    if (!clickableStage && !clickableDsp) return;
     m_pendingClickIdx = idx;
     if (m_clickTimer)
         m_clickTimer->start(QApplication::doubleClickInterval());
@@ -386,6 +431,11 @@ void ClientRxChainWidget::mouseDoubleClickEvent(QMouseEvent* ev)
     const int idx = hitTest(ev->position());
     if (idx < 0) { QWidget::mouseDoubleClickEvent(ev); return; }
     const auto& box = m_boxes[idx];
+    if (box.kind == TileKind::StatusDsp) {
+        emit dspEditRequested();
+        ev->accept();
+        return;
+    }
     if (box.kind != TileKind::Stage || !isStageImplemented(box.stage)) {
         QWidget::mouseDoubleClickEvent(ev);
         return;

--- a/src/gui/ClientRxChainWidget.h
+++ b/src/gui/ClientRxChainWidget.h
@@ -43,6 +43,13 @@ signals:
     // Emitted when the user double-clicks an implemented stage tile —
     // MainWindow maps this to opening the right editor in RX mode.
     void editRequested(AudioEngine::RxChainStage stage);
+    // Emitted when the user double-clicks the DSP status tile —
+    // MainWindow opens the full AetherDSP Settings dialog.
+    void dspEditRequested();
+    // Emitted when single-click re-enables NR2 from the AppSettings-
+    // persisted LastClientNr — MainWindow runs FFTW wisdom prep before
+    // flipping the engine on (#2275).
+    void nr2EnableWithWisdomRequested();
     // Emitted when the user single-clicks an implemented stage tile —
     // toggles the stage's enabled state.  ClientChainApplet listens so
     // it can refresh BYPASS button visuals.

--- a/src/gui/ClientRxDspApplet.cpp
+++ b/src/gui/ClientRxDspApplet.cpp
@@ -1,0 +1,32 @@
+#include "ClientRxDspApplet.h"
+#include "AetherDspWidget.h"
+#include "core/AudioEngine.h"
+
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+ClientRxDspApplet::ClientRxDspApplet(QWidget* parent) : QWidget(parent)
+{
+    setStyleSheet("QWidget { background: transparent; }");
+    // Cap horizontal width so the embedded AetherDspWidget can't push the
+    // PooDoo container wider than its 280 px slot — sliders + tab bar
+    // shrink to fit instead of clipping.
+    setMaximumWidth(250);
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+    hide();  // hidden until setAudioEngine wires it up + side filter shows it
+}
+
+void ClientRxDspApplet::setAudioEngine(AudioEngine* engine)
+{
+    m_audio = engine;
+    if (!m_audio || m_widget) return;
+    m_widget = new AetherDspWidget(m_audio, this);
+    m_widget->setCompactMode(true);
+    if (auto* lay = qobject_cast<QVBoxLayout*>(layout()))
+        lay->addWidget(m_widget);
+}
+
+} // namespace AetherSDR

--- a/src/gui/ClientRxDspApplet.h
+++ b/src/gui/ClientRxDspApplet.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <QWidget>
+
+namespace AetherSDR {
+
+class AudioEngine;
+class AetherDspWidget;
+
+// RX-side DSP applet — embeds AetherDspWidget as a docked tile inside the
+// Aetherial Audio (PooDoo) container.  Same control set and persistence as
+// the modeless AetherDspDialog (Settings menu); both views write to the
+// same AppSettings keys, so changes in one update the other on next
+// syncFromEngine().
+class ClientRxDspApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ClientRxDspApplet(QWidget* parent = nullptr);
+
+    void setAudioEngine(AudioEngine* engine);
+    AetherDspWidget* widget() const { return m_widget; }
+
+private:
+    AudioEngine*     m_audio{nullptr};
+    AetherDspWidget* m_widget{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientTubeApplet.cpp
+++ b/src/gui/ClientTubeApplet.cpp
@@ -4,6 +4,7 @@
 #include "core/AudioEngine.h"
 #include "core/ClientTube.h"
 
+#include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QPushButton>
@@ -171,6 +172,17 @@ void ClientTubeApplet::setAudioEngine(AudioEngine* engine)
 void ClientTubeApplet::syncEnableFromEngine()
 {
     if (m_curve) m_curve->update();
+
+    // Bypass dim — render the whole tile at reduced opacity when the
+    // stage is bypassed, matching the dim effect on the EQ curve.
+    const bool dspEnabled = (m_audio && tube()) ? tube()->isEnabled() : true;
+    auto* eff = qobject_cast<QGraphicsOpacityEffect*>(graphicsEffect());
+    if (!eff) {
+        eff = new QGraphicsOpacityEffect(this);
+        setGraphicsEffect(eff);
+    }
+    eff->setOpacity(dspEnabled ? 1.0 : 0.55);
+
     if (!m_audio || !tube()) return;
     ClientTube* t = tube();
     if (m_drive)  { QSignalBlocker b(m_drive);  m_drive->setValue(t->driveDb()); }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -94,6 +94,8 @@
 #include "MidiMappingDialog.h"
 #endif
 #include "AetherDspDialog.h"
+#include "AetherDspWidget.h"
+#include "ClientRxDspApplet.h"
 #include "DspParamPopup.h"
 
 #include <algorithm>
@@ -2358,98 +2360,9 @@ MainWindow::MainWindow(QWidget* parent)
         }
     });
 
-    // ── NR2/RN2 feedback: AudioEngine → all VFO + overlay buttons ──────
-    // Iterate all panadapter spectrums to find VFO widgets and overlay menus,
-    // since spectrum()/vfoWidget() lookups can return null depending on
-    // pan activation state.
-    auto syncNr2 = [this](bool on) {
-        // Iterate PanadapterStack's actual applets — avoids RadioModel→PanStack
-        // ID mismatch during connect when rekey hasn't happened yet.
-        if (m_panStack) {
-            for (auto* applet : m_panStack->allApplets()) {
-                auto* sw = applet->spectrumWidget();
-                if (auto* vfo = sw->vfoWidget(m_activeSliceId)) {
-                    QSignalBlocker sb(vfo->nr2Button());
-                    vfo->nr2Button()->setChecked(on);
-                }
-                if (auto* btn = sw->overlayMenu()->dspNr2Button())
-                    { QSignalBlocker sb(btn); btn->setChecked(on); }
-            }
-        }
-    };
-    auto syncRn2 = [this](bool on) {
-        if (m_panStack) {
-            for (auto* applet : m_panStack->allApplets()) {
-                auto* sw = applet->spectrumWidget();
-                if (auto* vfo = sw->vfoWidget(m_activeSliceId)) {
-                    QSignalBlocker sb(vfo->rn2Button());
-                    vfo->rn2Button()->setChecked(on);
-                }
-                if (auto* btn = sw->overlayMenu()->dspRn2Button())
-                    { QSignalBlocker sb(btn); btn->setChecked(on); }
-            }
-        }
-    };
-    auto syncBnr = [this](bool on) {
-        if (m_panStack) {
-            for (auto* applet : m_panStack->allApplets()) {
-                auto* sw = applet->spectrumWidget();
-                if (auto* vfo = sw->vfoWidget(m_activeSliceId)) {
-                    QSignalBlocker sb(vfo->bnrButton());
-                    vfo->bnrButton()->setChecked(on);
-                }
-                if (auto* btn = sw->overlayMenu()->dspBnrButton())
-                    { QSignalBlocker sb(btn); btn->setChecked(on); }
-            }
-        }
-    };
-    auto syncNr4 = [this](bool on) {
-        if (m_panStack) {
-            for (auto* applet : m_panStack->allApplets()) {
-                auto* sw = applet->spectrumWidget();
-                if (auto* vfo = sw->vfoWidget(m_activeSliceId)) {
-                    QSignalBlocker sb(vfo->nr4Button());
-                    vfo->nr4Button()->setChecked(on);
-                }
-                if (auto* btn = sw->overlayMenu()->dspNr4Button())
-                    { QSignalBlocker sb(btn); btn->setChecked(on); }
-            }
-        }
-    };
-    auto syncMnr = [this](bool on) {
-        if (m_panStack) {
-            for (auto* applet : m_panStack->allApplets()) {
-                auto* sw = applet->spectrumWidget();
-                if (auto* vfo = sw->vfoWidget(m_activeSliceId)) {
-                    QSignalBlocker sb(vfo->mnrButton());
-                    vfo->mnrButton()->setChecked(on);
-                }
-                if (auto* btn = sw->overlayMenu()->dspMnrButton())
-                    { QSignalBlocker sb(btn); btn->setChecked(on); }
-            }
-        }
-    };
-    auto syncDfnr = [this](bool on) {
-        if (m_panStack) {
-            for (auto* applet : m_panStack->allApplets()) {
-                auto* sw = applet->spectrumWidget();
-                if (auto* vfo = sw->vfoWidget(m_activeSliceId)) {
-                    QSignalBlocker sb(vfo->dfnrButton());
-                    vfo->dfnrButton()->setChecked(on);
-                }
-                if (auto* btn = sw->overlayMenu()->dspDfnrButton())
-                    { QSignalBlocker sb(btn); btn->setChecked(on); }
-            }
-        }
-    };
-    connect(m_audio, &AudioEngine::nr2EnabledChanged, this, syncNr2);
-    connect(m_audio, &AudioEngine::rn2EnabledChanged, this, syncRn2);
-    connect(m_audio, &AudioEngine::bnrEnabledChanged, this, syncBnr);
-    connect(m_audio, &AudioEngine::nr4EnabledChanged, this, syncNr4);
-    connect(m_audio, &AudioEngine::mnrEnabledChanged, this, syncMnr);
-    connect(m_audio, &AudioEngine::dfnrEnabledChanged, this, syncDfnr);
-    // NR2/RN2/BNR/NR4/DFNR DSP controls now only in VFO DSP tab and spectrum overlay.
-    // RxApplet DSP buttons removed — no sync wiring needed.
+    // Client-side DSP buttons (NR2 / NR4 / MNR / BNR / DFNR / RN2) now
+    // live only in the AetherDSP applet, which owns its own
+    // *EnabledChanged subscriptions.
 
 #ifdef HAVE_RADE
     connect(m_appletPanel->rxApplet(), &RxApplet::radeActivated,
@@ -3244,13 +3157,11 @@ MainWindow::MainWindow(QWidget* parent)
         if (!m_clientDeEssEditor) {
             m_clientDeEssEditor = new ClientDeEssEditor(m_audio, this);
             connect(m_clientDeEssEditor, &ClientDeEssEditor::bypassToggled,
-                    this, [this](bool bypassed) {
+                    this, [this](bool /*bypassed*/) {
                 if (m_appletPanel && m_appletPanel->clientDeEssApplet())
                     m_appletPanel->clientDeEssApplet()->refreshEnableFromEngine();
                 if (m_appletPanel && m_appletPanel->clientChainApplet())
                     m_appletPanel->clientChainApplet()->refreshFromEngine();
-                if (m_appletPanel)
-                    m_appletPanel->setAppletVisible("DESS", !bypassed);
             });
         }
         m_clientDeEssEditor->showForTx();
@@ -3267,6 +3178,16 @@ MainWindow::MainWindow(QWidget* parent)
     // ── Client Reverb applet: TX reverb (Freeverb) ─
     m_appletPanel->clientReverbApplet()->setAudioEngine(m_audio);
 
+    // ── RX-side AetherDSP applet — same controls as the Settings menu
+    // dialog, embedded as a docked tile in PooDoo Audio (RX).  Parameter
+    // changes route through the same per-signal wiring used by the dialog,
+    // factored into wireAetherDspWidget() to keep dialog + applet in sync.
+    if (auto* a = m_appletPanel->clientRxDspApplet()) {
+        a->setAudioEngine(m_audio);
+        if (auto* w = a->widget())
+            wireAetherDspWidget(w);
+    }
+
     // ── Client PUDU applets: TX (#1661 Phase 5) + RX (Phase 7.5) ───────────
     m_appletPanel->clientPuduTxApplet()->setAudioEngine(m_audio);
     m_appletPanel->clientPuduRxApplet()->setAudioEngine(m_audio);
@@ -3277,15 +3198,13 @@ MainWindow::MainWindow(QWidget* parent)
 
     // ── TX signal-chain applet (#1661) ──────────────────────────────────────
     // Visual strip showing MIC → stages → TX with per-stage bypass +
-    // drag-drop reorder.  Clicking a stage opens its floating editor
-    // (only EQ and COMP have editors today; Gate / DeEss / Tube / Enh
-    // are placeholders awaiting their DSP).
+    // drag-drop reorder.  Clicking a stage opens its floating editor.
     //
-    // CEQ and CMP tile visibility is driven by DSP bypass state — the
-    // chain widget right-click menu, and the Bypass buttons inside
-    // each floating editor, all push the new state through
-    // stageEnabledChanged → setAppletVisible here.  Initial state is
-    // seeded from the engine below so settings persist across launches.
+    // TX-stage applet visibility is independent of bypass state — the
+    // chain widget click and the editor Bypass buttons toggle the DSP
+    // and refresh the applet's bypass indicator, but do not show or
+    // hide the tile.  Users control applet visibility via the applet
+    // header ✕ and toolbar toggles (persisted as Applet_<ID>).
     m_appletPanel->clientChainApplet()->setAudioEngine(m_audio);
     // PooDoo TX/RX tab → AppletPanel side filter.  Hides the inactive
     // side's per-stage applet tiles whenever the user flips the chain
@@ -3380,34 +3299,10 @@ MainWindow::MainWindow(QWidget* parent)
         if (m_appletPanel && m_appletPanel->clientChainApplet())
             m_appletPanel->clientChainApplet()->setMonitorPlaying(false);
     });
-    if (m_audio && m_audio->clientEqTx()) {
-        m_appletPanel->setAppletVisible(
-            "CEQ", m_audio->clientEqTx()->isEnabled());
-    }
-    if (m_audio && m_audio->clientCompTx()) {
-        m_appletPanel->setAppletVisible(
-            "CMP", m_audio->clientCompTx()->isEnabled());
-    }
-    if (m_audio && m_audio->clientGateTx()) {
-        m_appletPanel->setAppletVisible(
-            "GATE", m_audio->clientGateTx()->isEnabled());
-    }
-    if (m_audio && m_audio->clientDeEssTx()) {
-        m_appletPanel->setAppletVisible(
-            "DESS", m_audio->clientDeEssTx()->isEnabled());
-    }
-    if (m_audio && m_audio->clientTubeTx()) {
-        m_appletPanel->setAppletVisible(
-            "TUBE", m_audio->clientTubeTx()->isEnabled());
-    }
-    if (m_audio && m_audio->clientPuduTx()) {
-        m_appletPanel->setAppletVisible(
-            "PUDU", m_audio->clientPuduTx()->isEnabled());
-    }
-    if (m_audio && m_audio->clientReverbTx()) {
-        m_appletPanel->setAppletVisible(
-            "REVERB", m_audio->clientReverbTx()->isEnabled());
-    }
+    // TX chain applet visibility is independent of bypass state — the
+    // user controls show/hide via the applet header ✕ and toolbar
+    // toggles, persisted via Applet_<ID>.  Bypassing a stage just
+    // shows the applet as bypassed; it doesn't hide the tile.
 
     // Initial applet-stack order mirrors the persisted chain order
     // for both sides, and stays in sync on every subsequent drag-
@@ -3455,34 +3350,28 @@ MainWindow::MainWindow(QWidget* parent)
 
     connect(m_appletPanel->clientChainApplet(),
             &ClientChainApplet::stageEnabledChanged,
-            this, [this](AudioEngine::TxChainStage stage, bool enabled) {
+            this, [this](AudioEngine::TxChainStage stage, bool /*enabled*/) {
+        // Refresh the applet's bypass indicator only — applet visibility
+        // is independent of bypass state for TX chain DSPs.
         if (stage == AudioEngine::TxChainStage::Eq) {
-            m_appletPanel->setAppletVisible("CEQ", enabled);
             if (m_appletPanel->clientEqApplet())
                 m_appletPanel->clientEqApplet()->refreshEnableFromEngine();
         } else if (stage == AudioEngine::TxChainStage::Comp) {
-            m_appletPanel->setAppletVisible("CMP", enabled);
             if (m_appletPanel->clientCompApplet())
                 m_appletPanel->clientCompApplet()->refreshEnableFromEngine();
         } else if (stage == AudioEngine::TxChainStage::Gate) {
-            m_appletPanel->setAppletVisible("GATE", enabled);
             if (m_appletPanel->clientGateApplet())
                 m_appletPanel->clientGateApplet()->refreshEnableFromEngine();
         } else if (stage == AudioEngine::TxChainStage::DeEss) {
-            m_appletPanel->setAppletVisible("DESS", enabled);
             if (m_appletPanel->clientDeEssApplet())
                 m_appletPanel->clientDeEssApplet()->refreshEnableFromEngine();
         } else if (stage == AudioEngine::TxChainStage::Tube) {
-            m_appletPanel->setAppletVisible("TUBE", enabled);
             if (m_appletPanel->clientTubeApplet())
                 m_appletPanel->clientTubeApplet()->refreshEnableFromEngine();
         } else if (stage == AudioEngine::TxChainStage::Enh) {
-            // Enh slot hosts the PUDU exciter.
-            m_appletPanel->setAppletVisible("PUDU", enabled);
             if (m_appletPanel->clientPuduApplet())
                 m_appletPanel->clientPuduApplet()->refreshEnableFromEngine();
         } else if (stage == AudioEngine::TxChainStage::Reverb) {
-            m_appletPanel->setAppletVisible("REVERB", enabled);
             if (m_appletPanel->clientReverbApplet())
                 m_appletPanel->clientReverbApplet()->refreshEnableFromEngine();
         }
@@ -3504,13 +3393,11 @@ MainWindow::MainWindow(QWidget* parent)
                 if (!m_clientDeEssEditor) {
                     m_clientDeEssEditor = new ClientDeEssEditor(m_audio, this);
                     connect(m_clientDeEssEditor, &ClientDeEssEditor::bypassToggled,
-                            this, [this](bool bypassed) {
+                            this, [this](bool /*bypassed*/) {
                         if (m_appletPanel && m_appletPanel->clientDeEssApplet())
                             m_appletPanel->clientDeEssApplet()->refreshEnableFromEngine();
                         if (m_appletPanel && m_appletPanel->clientChainApplet())
                             m_appletPanel->clientChainApplet()->refreshFromEngine();
-                        if (m_appletPanel)
-                            m_appletPanel->setAppletVisible("DESS", !bypassed);
                     });
                 }
                 m_clientDeEssEditor->showForTx();
@@ -3526,13 +3413,11 @@ MainWindow::MainWindow(QWidget* parent)
                 if (!m_clientReverbEditor) {
                     m_clientReverbEditor = new ClientReverbEditor(m_audio, this);
                     connect(m_clientReverbEditor, &ClientReverbEditor::bypassToggled,
-                            this, [this](bool bypassed) {
+                            this, [this](bool /*bypassed*/) {
                         if (m_appletPanel && m_appletPanel->clientReverbApplet())
                             m_appletPanel->clientReverbApplet()->refreshEnableFromEngine();
                         if (m_appletPanel && m_appletPanel->clientChainApplet())
                             m_appletPanel->clientChainApplet()->refreshFromEngine();
-                        if (m_appletPanel)
-                            m_appletPanel->setAppletVisible("REVERB", !bypassed);
                     });
                 }
                 m_clientReverbEditor->showForTx();
@@ -3997,9 +3882,9 @@ ClientEqEditor* MainWindow::ensureClientEqEditor()
                 this, [this](ClientEqApplet::Path path, bool bypassed) {
             if (!m_appletPanel) return;
             if (path == ClientEqApplet::Path::Tx) {
+                // TX applet visibility is independent of bypass state.
                 if (m_appletPanel->clientEqTxApplet())
                     m_appletPanel->clientEqTxApplet()->refreshEnableFromEngine();
-                m_appletPanel->setAppletVisible("CEQ", !bypassed);
             } else {
                 if (m_appletPanel->clientEqRxApplet())
                     m_appletPanel->clientEqRxApplet()->refreshEnableFromEngine();
@@ -4062,9 +3947,9 @@ ClientGateEditor* MainWindow::ensureClientGateEditor()
                 this, [this](ClientGateEditor::Side side, bool bypassed) {
             if (!m_appletPanel) return;
             if (side == ClientGateEditor::Side::Tx) {
+                // TX applet visibility is independent of bypass state.
                 if (m_appletPanel->clientGateTxApplet())
                     m_appletPanel->clientGateTxApplet()->refreshEnableFromEngine();
-                m_appletPanel->setAppletVisible("GATE", !bypassed);
             } else {
                 if (m_appletPanel->clientGateRxApplet())
                     m_appletPanel->clientGateRxApplet()->refreshEnableFromEngine();
@@ -4085,9 +3970,9 @@ ClientCompEditor* MainWindow::ensureClientCompEditor()
                 this, [this](ClientCompEditor::Side side, bool bypassed) {
             if (!m_appletPanel) return;
             if (side == ClientCompEditor::Side::Tx) {
+                // TX applet visibility is independent of bypass state.
                 if (m_appletPanel->clientCompTxApplet())
                     m_appletPanel->clientCompTxApplet()->refreshEnableFromEngine();
-                m_appletPanel->setAppletVisible("CMP", !bypassed);
             } else {
                 if (m_appletPanel->clientCompRxApplet())
                     m_appletPanel->clientCompRxApplet()->refreshEnableFromEngine();
@@ -4108,9 +3993,9 @@ ClientTubeEditor* MainWindow::ensureClientTubeEditor()
                 this, [this](ClientTubeEditor::Side side, bool bypassed) {
             if (!m_appletPanel) return;
             if (side == ClientTubeEditor::Side::Tx) {
+                // TX applet visibility is independent of bypass state.
                 if (m_appletPanel->clientTubeTxApplet())
                     m_appletPanel->clientTubeTxApplet()->refreshEnableFromEngine();
-                m_appletPanel->setAppletVisible("TUBE", !bypassed);
             } else {
                 if (m_appletPanel->clientTubeRxApplet())
                     m_appletPanel->clientTubeRxApplet()->refreshEnableFromEngine();
@@ -4131,9 +4016,9 @@ ClientPuduEditor* MainWindow::ensureClientPuduEditor()
                 this, [this](ClientPuduEditor::Side side, bool bypassed) {
             if (!m_appletPanel) return;
             if (side == ClientPuduEditor::Side::Tx) {
+                // TX applet visibility is independent of bypass state.
                 if (m_appletPanel->clientPuduTxApplet())
                     m_appletPanel->clientPuduTxApplet()->refreshEnableFromEngine();
-                m_appletPanel->setAppletVisible("PUDU", !bypassed);
             } else {
                 if (m_appletPanel->clientPuduRxApplet())
                     m_appletPanel->clientPuduRxApplet()->refreshEnableFromEngine();
@@ -4144,6 +4029,73 @@ ClientPuduEditor* MainWindow::ensureClientPuduEditor()
         });
     }
     return m_clientPuduEditor;
+}
+
+void MainWindow::wireAetherDspWidget(AetherDspWidget* w)
+{
+    if (!w || !m_audio) return;
+
+    // NR2
+    connect(w, &AetherDspWidget::nr2GainMaxChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainMax(v); });
+    });
+    connect(w, &AetherDspWidget::nr2GainSmoothChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainSmooth(v); });
+    });
+    connect(w, &AetherDspWidget::nr2QsppChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2Qspp(v); });
+    });
+    connect(w, &AetherDspWidget::nr2GainMethodChanged, this, [this](int m) {
+        QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2GainMethod(m); });
+    });
+    connect(w, &AetherDspWidget::nr2NpeMethodChanged, this, [this](int m) {
+        QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2NpeMethod(m); });
+    });
+    connect(w, &AetherDspWidget::nr2AeFilterChanged, this, [this](bool on) {
+        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr2AeFilter(on); });
+    });
+    // NR4
+    connect(w, &AetherDspWidget::nr4ReductionChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4ReductionAmount(v); });
+    });
+    connect(w, &AetherDspWidget::nr4SmoothingChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4SmoothingFactor(v); });
+    });
+    connect(w, &AetherDspWidget::nr4WhiteningChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4WhiteningFactor(v); });
+    });
+    connect(w, &AetherDspWidget::nr4AdaptiveNoiseChanged, this, [this](bool on) {
+        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr4AdaptiveNoise(on); });
+    });
+    connect(w, &AetherDspWidget::nr4NoiseMethodChanged, this, [this](int m) {
+        QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr4NoiseEstimationMethod(m); });
+    });
+    connect(w, &AetherDspWidget::nr4MaskingDepthChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4MaskingDepth(v); });
+    });
+    connect(w, &AetherDspWidget::nr4SuppressionChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4SuppressionStrength(v); });
+    });
+    // DFNR
+    connect(w, &AetherDspWidget::dfnrAttenLimitChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrAttenLimit(v); });
+    });
+    connect(w, &AetherDspWidget::dfnrPostFilterBetaChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrPostFilterBeta(v); });
+    });
+    // MNR
+    connect(w, &AetherDspWidget::mnrEnabledChanged, this, [this](bool on) {
+        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setMnrEnabled(on); });
+    });
+    connect(w, &AetherDspWidget::mnrStrengthChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setMnrStrength(v); });
+    });
+    // NR2 enable: route through enableNr2WithWisdom so FFTW plans are
+    // ready before AudioEngine constructs SpectralNR — direct enable on
+    // the audio thread can leave plans incompatible with the runtime
+    // FFTW version and crash the next feedAudioData. (#2275 / NR4→NR2)
+    connect(w, &AetherDspWidget::nr2EnableWithWisdomRequested,
+            this, &MainWindow::enableNr2WithWisdom);
 }
 
 void MainWindow::resizeEvent(QResizeEvent* event)
@@ -5568,64 +5520,22 @@ void MainWindow::buildMenuBar()
         }
         auto* dlg = new AetherDspDialog(m_audio, this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        // Wire NR2 parameter signals to AudioEngine (audio thread safe)
-        connect(dlg, &AetherDspDialog::nr2GainMaxChanged, this, [this](float v) {
-            QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainMax(v); });
-        });
-        connect(dlg, &AetherDspDialog::nr2GainSmoothChanged, this, [this](float v) {
-            QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainSmooth(v); });
-        });
-        connect(dlg, &AetherDspDialog::nr2QsppChanged, this, [this](float v) {
-            QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2Qspp(v); });
-        });
-        connect(dlg, &AetherDspDialog::nr2GainMethodChanged, this, [this](int m) {
-            QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2GainMethod(m); });
-        });
-        connect(dlg, &AetherDspDialog::nr2NpeMethodChanged, this, [this](int m) {
-            QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2NpeMethod(m); });
-        });
-        connect(dlg, &AetherDspDialog::nr2AeFilterChanged, this, [this](bool on) {
-            QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr2AeFilter(on); });
-        });
-        // Wire NR4 parameter signals to AudioEngine
-        connect(dlg, &AetherDspDialog::nr4ReductionChanged, this, [this](float v) {
-            QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4ReductionAmount(v); });
-        });
-        connect(dlg, &AetherDspDialog::nr4SmoothingChanged, this, [this](float v) {
-            QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4SmoothingFactor(v); });
-        });
-        connect(dlg, &AetherDspDialog::nr4WhiteningChanged, this, [this](float v) {
-            QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4WhiteningFactor(v); });
-        });
-        connect(dlg, &AetherDspDialog::nr4AdaptiveNoiseChanged, this, [this](bool on) {
-            QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr4AdaptiveNoise(on); });
-        });
-        connect(dlg, &AetherDspDialog::nr4NoiseMethodChanged, this, [this](int m) {
-            QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr4NoiseEstimationMethod(m); });
-        });
-        connect(dlg, &AetherDspDialog::nr4MaskingDepthChanged, this, [this](float v) {
-            QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4MaskingDepth(v); });
-        });
-        connect(dlg, &AetherDspDialog::nr4SuppressionChanged, this, [this](float v) {
-            QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4SuppressionStrength(v); });
-        });
-        // Wire DFNR parameter signals
-        connect(dlg, &AetherDspDialog::dfnrAttenLimitChanged, this, [this](float v) {
-            QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrAttenLimit(v); });
-        });
-        connect(dlg, &AetherDspDialog::dfnrPostFilterBetaChanged, this, [this](float v) {
-            QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrPostFilterBeta(v); });
-        });
-        // Wire MNR enable / strength signals
-        connect(dlg, &AetherDspDialog::mnrEnabledChanged, this, [this](bool on) {
-            QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setMnrEnabled(on); });
-        });
-        connect(dlg, &AetherDspDialog::mnrStrengthChanged, this, [this](float v) {
-            QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setMnrStrength(v); });
-        });
+        if (auto* w = dlg->widget()) wireAetherDspWidget(w);
         m_dspDialog = dlg;
         dlg->show();
     });
+    // RX chain DSP tile double-click also opens the full AetherDSP
+    // Settings dialog — same entry point as the Settings menu action.
+    if (m_appletPanel && m_appletPanel->clientChainApplet()) {
+        connect(m_appletPanel->clientChainApplet(),
+                &ClientChainApplet::rxDspEditRequested,
+                this, [dspAction]() { dspAction->trigger(); });
+        // Single-click re-enable of NR2 from LastClientNr also runs
+        // through enableNr2WithWisdom (#2275 — direct enable can crash).
+        connect(m_appletPanel->clientChainApplet(),
+                &ClientChainApplet::rxNr2EnableWithWisdomRequested,
+                this, &MainWindow::enableNr2WithWisdom);
+    }
 
     settingsMenu->addSeparator();
 
@@ -8461,9 +8371,6 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     menu->setPanId(applet->panId());
     menu->setMemories(m_radioModel.memories());
 
-    // Hide 8000-series-only DSP filters on 6000-series radios (#2177)
-    menu->setHasExtendedDsp(m_radioModel.hasExtendedDspFilters());
-
     // Antenna list → this overlay menu (per-pan, mirrors VfoWidget pattern) (#1260)
     connect(&m_radioModel, &RadioModel::antListChanged,
             menu, &SpectrumOverlayMenu::setAntennaList);
@@ -9245,65 +9152,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     connect(menu, &SpectrumOverlayMenu::swrSweepClearRequested,
             this, &MainWindow::clearSwrSweepPlot);
 
-    // ── NR2/RN2 overlay toggle → AudioEngine ───────────────────────────
-    // Button sync back to overlay + VFO handled by nr2/rn2EnabledChanged above.
-    connect(menu, &SpectrumOverlayMenu::nr2Toggled,
-            this, [this, menu](bool on) {
-        if (on) {
-            // NR2 amplifies Opus codec artifacts → disable when compressed audio active (#1597)
-            if (m_radioModel.audioCompressionParam() == "opus") {
-                QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNr2Enabled(false); });
-                statusBar()->showMessage("NR2 is not available with compressed (SmartLink) audio", 4000);
-                return;
-            }
-            QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setRn2Enabled(false); });
-            enableNr2WithWisdom();
-        } else {
-            QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNr2Enabled(false); });
-        }
-        // VFO button sync happens via AudioEngine::nr2EnabledChanged signal
-    });
-    connect(menu, &SpectrumOverlayMenu::nr2RightClicked,
-            this, [this](const QPoint& pos) { showNr2ParamPopup(pos); });
-    connect(menu, &SpectrumOverlayMenu::rn2Toggled,
-            this, [this](bool on) {
-        if (on) {
-            QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNr2Enabled(false); });
-            QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setRn2Enabled(true); });
-        } else {
-            QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setRn2Enabled(false); });
-        }
-        // VFO button sync happens via AudioEngine::rn2EnabledChanged signal
-    });
-    connect(menu, &SpectrumOverlayMenu::bnrToggled,
-            this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setBnrEnabled(on); });
-        // VFO button sync happens via AudioEngine::bnrEnabledChanged signal
-    });
-    connect(menu, &SpectrumOverlayMenu::bnrIntensityChanged,
-            this, [this](float ratio) {
-        m_audio->setBnrIntensity(ratio);
-    });
-    connect(menu, &SpectrumOverlayMenu::nr4Toggled,
-            this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr4Enabled(on); });
-        // VFO button sync happens via AudioEngine::nr4EnabledChanged signal
-    });
-    connect(menu, &SpectrumOverlayMenu::nr4RightClicked,
-            this, [this](const QPoint& pos) { showNr4ParamPopup(pos); });
-    connect(menu, &SpectrumOverlayMenu::mnrToggled,
-            this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setMnrEnabled(on); });
-        // VFO button sync happens via AudioEngine::mnrEnabledChanged signal
-    });
-    connect(menu, &SpectrumOverlayMenu::mnrRightClicked,
-            this, [this](const QPoint&) { showMnrSettings(); });
-    connect(menu, &SpectrumOverlayMenu::dfnrToggled,
-            this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setDfnrEnabled(on); });
-    });
-    connect(menu, &SpectrumOverlayMenu::dfnrRightClicked,
-            this, [this](const QPoint& pos) { showDfnrParamPopup(pos); });
+    // Client-side DSP toggles (NR2 / RN2 / NR4 / MNR / BNR / DFNR) now
+    // live exclusively in the AetherDSP applet; the spectrum overlay menu
+    // no longer surfaces them.
 }
 
 MainWindow::TuneCenteringResult MainWindow::revealFrequencyIfNeeded(
@@ -9568,42 +9419,10 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
         }
     });
 
-    // NR2 toggle with FFTW wisdom generation — wired once per VFO, never disconnected
-    connect(w, &VfoWidget::nr2Toggled, this, [this, w](bool on) {
-        if (!on) { QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNr2Enabled(false); }); return; }
-        // NR2 amplifies Opus codec artifacts → disable when compressed audio is active (#1597)
-        if (m_radioModel.audioCompressionParam() == "opus") {
-            QSignalBlocker blocker(w->nr2Button());
-            w->nr2Button()->setChecked(false);
-            statusBar()->showMessage("NR2 is not available with compressed (SmartLink) audio", 4000);
-            return;
-        }
-        enableNr2WithWisdom();
-    });
-    connect(w, &VfoWidget::nr2RightClicked,
-            this, [this](const QPoint& pos) { showNr2ParamPopup(pos); });
-
-    // RN2 toggle
-    connect(w, &VfoWidget::rn2Toggled, this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setRn2Enabled(on); });
-    });
-    connect(w, &VfoWidget::bnrToggled, this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setBnrEnabled(on); });
-    });
-    connect(w, &VfoWidget::nr4Toggled, this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr4Enabled(on); });
-    });
-    connect(w, &VfoWidget::nr4RightClicked,
-            this, [this](const QPoint& pos) { showNr4ParamPopup(pos); });
-    connect(w, &VfoWidget::mnrToggled, this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setMnrEnabled(on); });
-    });
-    connect(w, &VfoWidget::mnrRightClicked, this, [this](const QPoint&) { showMnrSettings(); });
-    connect(w, &VfoWidget::dfnrToggled, this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setDfnrEnabled(on); });
-    });
-    connect(w, &VfoWidget::dfnrRightClicked,
-            this, [this](const QPoint& pos) { showDfnrParamPopup(pos); });
+    // Client-side DSP toggles (NR2 / NR4 / MNR / BNR / DFNR / RN2) used
+    // to live on the VFO DSP grid; they were removed from there in
+    // favour of the spectrum overlay menu and the AetherDSP applet, so
+    // the per-VFO connect block that handled them is gone.
 
 #ifdef HAVE_RADE
     connect(w, &VfoWidget::radeActivated, this, [this](bool on, int sliceId) {
@@ -9673,26 +9492,13 @@ void MainWindow::updateNr2Availability()
         statusBar()->showMessage("NR2 disabled — not available with compressed (SmartLink) audio", 4000);
     }
 
-    // Update all NR2 buttons: VFO widgets and spectrum overlay menus
-    if (m_panStack) {
-        for (auto* applet : m_panStack->allApplets()) {
-            // Overlay menu NR2 button
-            if (auto* menu = applet->spectrumWidget()->overlayMenu()) {
-                if (auto* btn = menu->dspNr2Button()) {
-                    btn->setEnabled(!opusActive);
-                    btn->setToolTip(tooltip);
-                }
-            }
-            // VFO NR2 buttons (one per slice on this pan)
-            for (auto* s : m_radioModel.slices()) {
-                if (auto* vfo = applet->spectrumWidget()->vfoWidget(s->sliceId())) {
-                    if (auto* btn = vfo->nr2Button()) {
-                        btn->setEnabled(!opusActive);
-                        btn->setToolTip(tooltip);
-                    }
-                }
-            }
-        }
+    // Update the NR2 selector in the AetherDSP applet — the only
+    // remaining surface for client-side NR controls.  The modeless
+    // AetherDspDialog is created on demand and owns its own enable
+    // sync via nr2EnabledChanged + setEnabled-on-show.
+    if (auto* a = m_appletPanel ? m_appletPanel->clientRxDspApplet() : nullptr) {
+        if (auto* w = a->widget())
+            w->setNr2Available(!opusActive, tooltip);
     }
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -392,6 +392,11 @@ private:
     class ClientCompEditor* ensureClientCompEditor();
     class ClientTubeEditor* ensureClientTubeEditor();
     class ClientPuduEditor* ensureClientPuduEditor();
+
+    // Wire AetherDspWidget parameter signals to AudioEngine setters.  Used
+    // by both the modeless AetherDspDialog and the docked ClientRxDspApplet
+    // so they push every change into the engine identically.
+    void wireAetherDspWidget(class AetherDspWidget* widget);
     class ClientCompEditor* m_clientCompEditor{nullptr}; // lazy — created on first Edit… click
     class ClientGateEditor* m_clientGateEditor{nullptr}; // lazy — created on first Edit… click
     class ClientDeEssEditor* m_clientDeEssEditor{nullptr}; // lazy — created on first Edit… click

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -115,8 +115,7 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
         {"+TNF",     -1, &SpectrumOverlayMenu::addTnfClicked},  // 1
         {"Band",      0, nullptr},   // 2 — toggleBandPanel
         {"ANT",       1, nullptr},   // 3 — toggleAntPanel
-        {"DSP",       2, nullptr},   // 4 — toggleDspPanel
-        {"Display",   4, nullptr},   // 5 — toggleDisplayPanel
+        {"Display",   4, nullptr},   // 4 — toggleDisplayPanel
         {QStringLiteral("MEM\u25b8"), 5, nullptr},   // 6 — toggleMemoryPanel
         {"MEM+",      6, nullptr},   // 7 — quickAddMemoryRequested
         {"DAX",       3, nullptr},   // 8 — toggleDaxPanel
@@ -128,8 +127,6 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleBandPanel);
         else if (def.specialIdx == 1)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleAntPanel);
-        else if (def.specialIdx == 2)
-            connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleDspPanel);
         else if (def.specialIdx == 3)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleDaxPanel);
         else if (def.specialIdx == 4)
@@ -149,12 +146,11 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
     }
 
     // Menu button tooltips
-    if (m_menuBtns.size() >= 9) {
+    if (m_menuBtns.size() >= 8) {
         m_menuBtns[kBtnAddRx]->setToolTip("Add a new receive slice on this panadapter.");
         m_menuBtns[kBtnAddTnf]->setToolTip("Add a tracking notch filter at the current frequency.");
         m_menuBtns[kBtnBand]->setToolTip("Open band selector.");
         m_menuBtns[kBtnAnt]->setToolTip("Open antenna and RF gain controls.");
-        m_menuBtns[kBtnDsp]->setToolTip("Open DSP noise reduction and filter controls.");
         m_menuBtns[kBtnDisplay]->setToolTip("Open panadapter and waterfall display settings.");
         m_menuBtns[kBtnMemoryBrowse]->setToolTip("Browse saved memories for quick recall.");
         m_menuBtns[kBtnMemoryAdd]->setToolTip("Save the current slice on this panadapter as a memory.");
@@ -163,13 +159,12 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
 
     buildBandPanel();
     buildAntPanel();
-    buildDspPanel();
     buildDaxPanel();
     buildDisplayPanel();
     buildMemoryPanel();
 
     // Prevent mouse/wheel events from falling through panels to the spectrum
-    for (auto* panel : {m_bandPanel, m_antPanel, m_dspPanel, m_daxPanel, m_displayPanel,
+    for (auto* panel : {m_bandPanel, m_antPanel, m_daxPanel, m_displayPanel,
                         static_cast<QWidget*>(m_memoryPanel)})
         if (panel) panel->installEventFilter(this);
 
@@ -182,7 +177,6 @@ void SpectrumOverlayMenu::raiseAll()
     if (m_bandPanel)    m_bandPanel->raise();
     if (m_xvtrPanel)    m_xvtrPanel->raise();
     if (m_antPanel)     m_antPanel->raise();
-    if (m_dspPanel)     m_dspPanel->raise();
     if (m_daxPanel)     m_daxPanel->raise();
     if (m_displayPanel) m_displayPanel->raise();
     if (m_memoryPanel)  m_memoryPanel->raise();
@@ -478,174 +472,12 @@ void SpectrumOverlayMenu::setSlice(SliceModel* slice)
         m_updatingFromModel = false;
     });
 
-    // DSP toggle connections
-    using S = SliceModel;
-    struct DspToggleDef {
-        void (S::*setter)(bool);
-        void (S::*signal)(bool);
-    };
-    const DspToggleDef toggleDefs[] = {
-        {&S::setNb,   &S::nbChanged},    // 0
-        {&S::setNr,   &S::nrChanged},    // 1
-        {nullptr,     nullptr},           // 2 — NR2 (client-side, wired separately)
-        {&S::setAnf,  &S::anfChanged},   // 3
-        {&S::setNrl,  &S::nrlChanged},   // 4
-        {&S::setNrs,  &S::nrsChanged},   // 5
-        {&S::setRnn,  &S::rnnChanged},   // 6
-        {nullptr,     nullptr},           // 7 — RN2 (client-side, wired separately)
-        {&S::setNrf,  &S::nrfChanged},   // 8
-        {&S::setAnfl, &S::anflChanged},  // 9
-        {&S::setAnft, &S::anftChanged},  // 10
-        {nullptr,     nullptr},           // 11 — BNR (client-side, wired separately)
-        {nullptr,     nullptr},           // 12 — NR4 (client-side, wired separately)
-        {nullptr,     nullptr},           // 13 — MNR (client-side, wired separately)
-        {nullptr,     nullptr},           // 14 — DFNR (client-side, wired separately)
-    };
-
-    for (int i = 0; i < 15; ++i) {
-        if (!toggleDefs[i].setter) continue;  // skip NR2/RN2
-        auto* btn = m_dspRows[i].btn;
-        auto setter = toggleDefs[i].setter;
-        auto signal = toggleDefs[i].signal;
-
-        connect(btn, &QPushButton::toggled, this, [this, setter](bool on) {
-            if (!m_updatingFromModel && m_slice)
-                (m_slice->*setter)(on);
-        });
-        connect(m_slice, signal, this, [this, i](bool on) {
-            m_updatingFromModel = true;
-            QSignalBlocker sb(m_dspRows[i].btn);
-            m_dspRows[i].btn->setChecked(on);
-            m_updatingFromModel = false;
-        });
-    }
-
-    // DSP level connections (only for features with sliders)
-    struct DspLevelDef {
-        int row;
-        void (S::*setter)(int);
-        void (S::*signal)(int);
-    };
-    const DspLevelDef levelDefs[] = {
-        {0, &S::setNbLevel,   &S::nbLevelChanged},
-        {1, &S::setNrLevel,   &S::nrLevelChanged},
-        // NR2 (index 2) has no level slider
-        {3, &S::setAnfLevel,  &S::anfLevelChanged},
-        {4, &S::setNrlLevel,  &S::nrlLevelChanged},
-        {5, &S::setNrsLevel,  &S::nrsLevelChanged},
-        // RN2 (index 7) has no level slider
-        {8, &S::setNrfLevel,  &S::nrfLevelChanged},
-        {9, &S::setAnflLevel, &S::anflLevelChanged},
-    };
-
-    for (const auto& ld : levelDefs) {
-        auto* slider = m_dspRows[ld.row].slider;
-        auto* lbl = m_dspRows[ld.row].valueLbl;
-        auto setter = ld.setter;
-        int row = ld.row;
-
-        connect(slider, &QSlider::valueChanged, this, [this, setter, lbl](int v) {
-            lbl->setText(QString::number(v));
-            if (!m_updatingFromModel && m_slice)
-                (m_slice->*setter)(v);
-        });
-        connect(m_slice, ld.signal, this, [this, row](int v) {
-            m_updatingFromModel = true;
-            QSignalBlocker sb(m_dspRows[row].slider);
-            m_dspRows[row].slider->setValue(v);
-            m_dspRows[row].valueLbl->setText(QString::number(v));
-            m_updatingFromModel = false;
-        });
-    }
-
-    // NR2 (client-side, index 2) — emit signal for MainWindow to handle
-    connect(m_dspRows[2].btn, &QPushButton::toggled, this, [this](bool on) {
-        if (!m_updatingFromModel)
-            emit nr2Toggled(on);
-    });
-    // NR2 right-click → parameter popup
-    m_dspRows[2].btn->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(m_dspRows[2].btn, &QPushButton::customContextMenuRequested,
-            this, [this](const QPoint& pos) {
-        emit nr2RightClicked(m_dspRows[2].btn->mapToGlobal(pos));
-    });
-
-    // RN2 (client-side, index 7) — emit signal for MainWindow to handle
-    connect(m_dspRows[7].btn, &QPushButton::toggled, this, [this](bool on) {
-        if (!m_updatingFromModel)
-            emit rn2Toggled(on);
-    });
-
-    // BNR (client-side, index 11) — emit signal for MainWindow to handle
-    connect(m_dspRows[11].btn, &QPushButton::toggled, this, [this](bool on) {
-        if (!m_updatingFromModel)
-            emit bnrToggled(on);
-    });
-    if (m_dspRows[11].slider) {
-        m_dspRows[11].slider->setRange(0, 100);
-        m_dspRows[11].slider->setValue(100);  // default: max denoising
-        if (m_dspRows[11].valueLbl)
-            m_dspRows[11].valueLbl->setText("100");
-        connect(m_dspRows[11].slider, &QSlider::valueChanged, this, [this](int v) {
-            if (m_dspRows[11].valueLbl)
-                m_dspRows[11].valueLbl->setText(QString::number(v));
-            if (!m_updatingFromModel)
-                emit bnrIntensityChanged(v / 100.0f);
-        });
-    }
-#ifndef HAVE_BNR
-    m_dspRows[11].btn->setVisible(false);
-    if (m_dspRows[11].slider) m_dspRows[11].slider->setVisible(false);
-    if (m_dspRows[11].valueLbl) m_dspRows[11].valueLbl->setVisible(false);
-#endif
-
-    // NR4 (client-side, index 12) — emit signal for MainWindow to handle
-    connect(m_dspRows[12].btn, &QPushButton::toggled, this, [this](bool on) {
-        if (!m_updatingFromModel)
-            emit nr4Toggled(on);
-    });
-    // NR4 right-click → parameter popup
-    m_dspRows[12].btn->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(m_dspRows[12].btn, &QPushButton::customContextMenuRequested,
-            this, [this](const QPoint& pos) {
-        emit nr4RightClicked(m_dspRows[12].btn->mapToGlobal(pos));
-    });
-#ifndef HAVE_SPECBLEACH
-    m_dspRows[12].btn->setVisible(false);
-#endif
-
-    // MNR (client-side, index 13) — emit signal for MainWindow to handle
-    connect(m_dspRows[13].btn, &QPushButton::toggled, this, [this](bool on) {
-        if (!m_updatingFromModel)
-            emit mnrToggled(on);
-    });
-    // MNR right-click → parameter popup
-    m_dspRows[13].btn->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(m_dspRows[13].btn, &QPushButton::customContextMenuRequested,
-            this, [this](const QPoint& pos) {
-        emit mnrRightClicked(m_dspRows[13].btn->mapToGlobal(pos));
-    });
-#ifndef __APPLE__
-    m_dspRows[13].btn->setVisible(false);  // MNR is macOS only
-#endif
-
-    // DFNR (client-side, index 14) — emit signal for MainWindow to handle
-    connect(m_dspRows[14].btn, &QPushButton::toggled, this, [this](bool on) {
-        if (!m_updatingFromModel)
-            emit dfnrToggled(on);
-    });
-    // DFNR right-click → parameter popup
-    m_dspRows[14].btn->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(m_dspRows[14].btn, &QPushButton::customContextMenuRequested,
-            this, [this](const QPoint& pos) {
-        emit dfnrRightClicked(m_dspRows[14].btn->mapToGlobal(pos));
-    });
-#ifndef HAVE_DFNR
-    m_dspRows[14].btn->setVisible(false);
-#endif
+    // DSP toggle/level wiring lived here when the overlay carried a DSP
+    // sub-panel.  Slice DSP now lives on VfoWidget (radio-side) and the
+    // AetherDSP applet (client-side) — those widgets own their own slice
+    // bindings.
 
     syncAntPanel();
-    syncDspPanel();
     syncDaxPanel();
 }
 
@@ -660,209 +492,6 @@ void SpectrumOverlayMenu::syncAntPanel()
     }
     m_rfGainLabel->setText(QString("%1 dB").arg(static_cast<int>(m_slice->rfGain())));
     m_updatingFromModel = false;
-}
-
-// ── DSP sub-panel ─────────────────────────────────────────────────────────────
-
-void SpectrumOverlayMenu::buildDspPanel()
-{
-    m_dspPanel = new QWidget(parentWidget());
-    m_dspPanel->setStyleSheet(kPanelStyle);
-    m_dspPanel->hide();
-
-    auto* vbox = new QVBoxLayout(m_dspPanel);
-    vbox->setContentsMargins(6, 6, 6, 6);
-    vbox->setSpacing(3);
-
-    const QString dspBtnStyle =
-        "QPushButton { background: #1a2a3a; border: 1px solid #304050; "
-        "border-radius: 2px; color: #c8d8e8; font-size: 10px; font-weight: bold; "
-        "padding: 1px 2px; }"
-        "QPushButton:checked { background: #1a6030; color: #ffffff; "
-        "border: 1px solid #20a040; }"
-        "QPushButton:hover { border: 1px solid #0090e0; }";
-
-    // DSP feature definitions
-    struct DspDef {
-        const char* label;
-        bool hasLevel;
-    };
-    const DspDef defs[] = {
-        {"NB",   true},   // 0
-        {"NR",   true},   // 1
-        {"NR2",  false},  // 2  — client-side spectral NR
-        {"ANF",  true},   // 3
-        {"NRL",  true},   // 4
-        {"NRS",  true},   // 5
-        {"RNN",  false},  // 6
-        {"RN2",  false},  // 7  — client-side RNNoise
-        {"NRF",  true},   // 8
-        {"ANFL", true},   // 9
-        {"ANFT", false},  // 10
-        {"BNR",  true},   // 11 — client-side NVIDIA NIM (intensity slider)
-        {"NR4",  false},  // 12 — client-side spectral bleach (libspecbleach)
-        {"MNR",  false},  // 13 — macOS MMSE-Wiener spectral NR
-        {"DFNR", false},  // 14 — client-side DeepFilterNet3 neural NR
-    };
-
-    // First pass: create all buttons and collect toggle-only (no slider) indices
-    QVector<int> toggleOnlyIndices;
-    constexpr int N = sizeof(defs) / sizeof(defs[0]);
-    for (int i = 0; i < N; ++i) {
-        DspRow dspRow;
-        auto* btn = new QPushButton(defs[i].label);
-        btn->setCheckable(true);
-        btn->setFixedSize(40, 20);
-        btn->setStyleSheet(dspBtnStyle);
-        dspRow.btn = btn;
-        m_dspRows.append(dspRow);
-        if (!defs[i].hasLevel)
-            toggleOnlyIndices.append(i);
-    }
-
-    // Toggle-only buttons in a compact flow row at the top
-    if (!toggleOnlyIndices.isEmpty()) {
-        auto* toggleRow = new QHBoxLayout;
-        toggleRow->setSpacing(4);
-        for (int idx : toggleOnlyIndices) {
-            m_dspRows[idx].btn->setMinimumSize(0, 20);
-            m_dspRows[idx].btn->setMaximumHeight(20);
-            m_dspRows[idx].btn->setFixedWidth(QWIDGETSIZE_MAX);  // undo fixed 40px
-            toggleRow->addWidget(m_dspRows[idx].btn, 1);
-        }
-        vbox->addLayout(toggleRow);
-    }
-
-    // Slider rows for buttons with level controls
-    for (int i = 0; i < N; ++i) {
-        if (!defs[i].hasLevel) continue;
-
-        auto* row = new QHBoxLayout;
-        row->setSpacing(4);
-        row->addWidget(m_dspRows[i].btn);
-
-        auto* slider = new GuardedSlider(Qt::Horizontal);
-        slider->setRange(0, 100);
-        slider->setValue(50);
-        slider->setStyleSheet(kSliderStyle);
-        row->addWidget(slider, 1);
-
-        auto* lbl = new QLabel("50");
-        lbl->setStyleSheet(kLabelStyle);
-        lbl->setFixedWidth(22);
-        lbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        row->addWidget(lbl);
-
-        slider->installEventFilter(this);
-        m_dspRows[i].slider = slider;
-        m_dspRows[i].valueLbl = lbl;
-
-        vbox->addLayout(row);
-    }
-
-    // DSP button tooltips
-    m_dspRows[0].btn->setToolTip("Noise blanker \u2014 detects and removes fast impulse noise from sparks and switching sources.");
-    m_dspRows[1].btn->setToolTip("Radio-side noise reduction \u2014 attenuates uncorrelated background noise.");
-    m_dspRows[2].btn->setToolTip("Client-side spectral noise reduction (Ephraim-Malah MMSE). Right-click for NR2 settings.");
-    m_dspRows[3].btn->setToolTip("Auto notch filter \u2014 detects and cancels persistent unwanted tones.");
-    m_dspRows[4].btn->setToolTip("Leaky LMS adaptive filter \u2014 preserves correlated signals while removing uncorrelated noise. Best for daily SSB/CW.");
-    m_dspRows[5].btn->setToolTip("Spectral subtraction with voice activity detection \u2014 cuts noise most aggressively between words.");
-    m_dspRows[6].btn->setToolTip("Deep-learning recurrent neural network \u2014 separates speech from complex noise. Best at low SNR.");
-    m_dspRows[7].btn->setToolTip("Client-side RNNoise neural noise suppression. Effective for broadband noise on voice modes.");
-    m_dspRows[8].btn->setToolTip("Spectral subtraction filter \u2014 computes speech/noise probability per frequency bin to remove steady noise.");
-    m_dspRows[9].btn->setToolTip("Leaky LMS notch filter \u2014 removes steady tones such as power-line hum or carriers.");
-    m_dspRows[10].btn->setToolTip("FFT-based notch filter \u2014 removes up to five persistent tones from transformers or power supplies.");
-    m_dspRows[11].btn->setToolTip("NVIDIA GPU-accelerated neural audio denoising. Requires NVIDIA RTX 4000+ with Docker.");
-    m_dspRows[12].btn->setToolTip("Client-side spectral bleach noise reduction (libspecbleach). Right-click for NR4 settings.");
-    m_dspRows[13].btn->setToolTip("macOS only \u2014 MMSE-Wiener spectral noise reduction with asymmetric gain smoothing.\nUses Apple Accelerate vDSP for hardware-accelerated FFT on Apple Silicon.\nRemoves consistent background noise while preserving speech clarity.");
-    m_dspRows[14].btn->setToolTip("DeepFilterNet3 neural noise reduction \u2014 AI speech enhancement\nwith higher fidelity than RNNoise in high-noise environments.\nCPU-only, 10 ms latency. Right-click for DFNR settings.");
-
-    // DSP slider tooltips
-    if (m_dspRows[0].slider) m_dspRows[0].slider->setToolTip("Adjusts blanking depth. Higher values suppress more impulse noise but may clip desired signals.");
-    if (m_dspRows[1].slider) m_dspRows[1].slider->setToolTip("Adjusts noise reduction depth. Higher values remove more noise but may affect signal clarity.");
-    if (m_dspRows[3].slider) m_dspRows[3].slider->setToolTip("Adjusts notch depth. Higher values attenuate tones more aggressively.");
-    if (m_dspRows[4].slider) m_dspRows[4].slider->setToolTip("Adjusts NRL filter strength.");
-    if (m_dspRows[5].slider) m_dspRows[5].slider->setToolTip("Adjusts NRS suppression depth.");
-    if (m_dspRows[8].slider) m_dspRows[8].slider->setToolTip("Adjusts NRF filter strength.");
-    if (m_dspRows[9].slider) m_dspRows[9].slider->setToolTip("Adjusts ANFL notch depth.");
-    if (m_dspRows[11].slider) m_dspRows[11].slider->setToolTip("Adjusts BNR denoising intensity.");
-
-    // MNR adds one extra button to the toggle row on Apple builds; widen
-    // the panel only on platforms where it actually appears (#1672 review).
-#ifdef __APPLE__
-    m_dspPanel->setFixedWidth(280);
-#else
-    m_dspPanel->setFixedWidth(200);
-#endif
-    m_dspPanel->adjustSize();
-
-    // Wiring is done in setSlice() since we need the slice model
-}
-
-void SpectrumOverlayMenu::setHasExtendedDsp(bool has)
-{
-    m_hasExtendedDsp = has;
-    if (m_dspRows.isEmpty()) return;
-    // Hide 8000-series-only firmware DSP rows: NRS(5), RNN(6), NRF(8). NRL(4)
-    // is available on 6000-series too, so it stays visible regardless. (#2177)
-    auto hideRow = [](DspRow& r, bool visible) {
-        r.btn->setVisible(visible);
-        if (r.slider)   r.slider->setVisible(visible);
-        if (r.valueLbl) r.valueLbl->setVisible(visible);
-    };
-    hideRow(m_dspRows[5], has);
-    hideRow(m_dspRows[6], has);
-    hideRow(m_dspRows[8], has);
-    if (m_dspPanel) m_dspPanel->adjustSize();
-}
-
-void SpectrumOverlayMenu::syncDspPanel()
-{
-    if (!m_slice) return;
-    m_updatingFromModel = true;
-
-    // Toggle states
-    m_dspRows[0].btn->setChecked(m_slice->nbOn());
-    m_dspRows[1].btn->setChecked(m_slice->nrOn());
-    // NR2 (index 2) is client-side — synced via AudioEngine, not slice
-    m_dspRows[3].btn->setChecked(m_slice->anfOn());
-    m_dspRows[4].btn->setChecked(m_slice->nrlOn());
-    m_dspRows[5].btn->setChecked(m_slice->nrsOn());
-    m_dspRows[6].btn->setChecked(m_slice->rnnOn());
-    // RN2 (index 7) is client-side — synced via AudioEngine, not slice
-    m_dspRows[8].btn->setChecked(m_slice->nrfOn());
-    m_dspRows[9].btn->setChecked(m_slice->anflOn());
-    m_dspRows[10].btn->setChecked(m_slice->anftOn());
-
-    // Level values (only for features that have sliders)
-    auto syncSlider = [](DspRow& r, int v) {
-        if (r.slider) { r.slider->setValue(v); r.valueLbl->setText(QString::number(v)); }
-    };
-    syncSlider(m_dspRows[0], m_slice->nbLevel());
-    syncSlider(m_dspRows[1], m_slice->nrLevel());
-    syncSlider(m_dspRows[3], m_slice->anfLevel());
-    syncSlider(m_dspRows[4], m_slice->nrlLevel());
-    syncSlider(m_dspRows[5], m_slice->nrsLevel());
-    syncSlider(m_dspRows[8], m_slice->nrfLevel());
-    syncSlider(m_dspRows[9], m_slice->anflLevel());
-
-    m_updatingFromModel = false;
-}
-
-void SpectrumOverlayMenu::toggleDspPanel()
-{
-    bool wasVisible = m_dspPanelVisible;
-    hideAllSubPanels();
-    if (!wasVisible) {
-        syncDspPanel();
-        m_dspPanelVisible = true;
-        // Top-align DSP panel with the button menu
-        int panelY = y();
-        m_dspPanel->move(x() + width(), std::max(0, panelY));
-        m_dspPanel->raise();
-        m_dspPanel->show();
-        m_menuBtns[kBtnDsp]->setStyleSheet(kMenuBtnActive);
-    }
 }
 
 // ── DAX sub-panel ─────────────────────────────────────────────────────────────
@@ -969,15 +598,13 @@ void SpectrumOverlayMenu::hideAllSubPanels()
     if (m_xvtrPanel) m_xvtrPanel->hide();
     m_antPanelVisible = false;
     if (m_antPanel) m_antPanel->hide();
-    m_dspPanelVisible = false;
-    if (m_dspPanel) m_dspPanel->hide();
     m_daxPanelVisible = false;
     if (m_daxPanel) m_daxPanel->hide();
     m_displayPanelVisible = false;
     if (m_displayPanel) m_displayPanel->hide();
     m_memoryPanelVisible = false;
     if (m_memoryPanel) m_memoryPanel->hide();
-    for (int idx : {kBtnBand, kBtnAnt, kBtnDsp, kBtnDisplay,
+    for (int idx : {kBtnBand, kBtnAnt, kBtnDisplay,
                     kBtnMemoryBrowse, kBtnMemoryAdd, kBtnDax}) {
         if (idx >= 0 && idx < m_menuBtns.size())
             m_menuBtns[idx]->setStyleSheet(kMenuBtnNormal);
@@ -1769,36 +1396,6 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     m_xvtrPanel->adjustSize();
 }
 
-QPushButton* SpectrumOverlayMenu::dspNr2Button() const
-{
-    return m_dspRows.size() > 2 ? m_dspRows[2].btn : nullptr;
-}
-
-QPushButton* SpectrumOverlayMenu::dspRn2Button() const
-{
-    return m_dspRows.size() > 7 ? m_dspRows[7].btn : nullptr;
-}
-
-QPushButton* SpectrumOverlayMenu::dspBnrButton() const
-{
-    return m_dspRows.size() > 11 ? m_dspRows[11].btn : nullptr;
-}
-
-QPushButton* SpectrumOverlayMenu::dspNr4Button() const
-{
-    return m_dspRows.size() > 12 ? m_dspRows[12].btn : nullptr;
-}
-
-QPushButton* SpectrumOverlayMenu::dspMnrButton() const
-{
-    return m_dspRows.size() > 13 ? m_dspRows[13].btn : nullptr;
-}
-
-QPushButton* SpectrumOverlayMenu::dspDfnrButton() const
-{
-    return m_dspRows.size() > 14 ? m_dspRows[14].btn : nullptr;
-}
-
 bool SpectrumOverlayMenu::eventFilter(QObject* obj, QEvent* event)
 {
     if (event->type() == QEvent::MouseButtonDblClick) {
@@ -1808,7 +1405,7 @@ bool SpectrumOverlayMenu::eventFilter(QObject* obj, QEvent* event)
         }
     }
     // Consume mouse/wheel events on sub-panels so they don't reach the spectrum
-    if (obj == m_bandPanel || obj == m_antPanel || obj == m_dspPanel
+    if (obj == m_bandPanel || obj == m_antPanel
         || obj == m_daxPanel || obj == m_displayPanel || obj == m_memoryPanel) {
         if (event->type() == QEvent::Wheel
             || event->type() == QEvent::MouseButtonPress

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -65,13 +65,9 @@ public:
     struct XvtrBand { QString name; double rfFreqMhz; };
     void setXvtrBands(const QVector<XvtrBand>& bands);
     void syncDaxIqChannel(int channel);
-    void setHasExtendedDsp(bool has);
-    QPushButton* dspNr2Button() const;
-    QPushButton* dspRn2Button() const;
-    QPushButton* dspBnrButton() const;
-    QPushButton* dspNr4Button() const;
-    QPushButton* dspMnrButton() const;
-    QPushButton* dspDfnrButton() const;
+    // DSP button accessors and the DSP sub-panel were removed — radio-
+    // side DSP lives on VfoWidget only, client-side DSP lives on the
+    // AetherDSP applet only.
 
     // Show the target slice letter ('A'-'D') on the MEM buttons so users
     // know which slice will be saved/recalled.  Pass a null QChar to clear
@@ -92,17 +88,9 @@ signals:
     void daxIqChannelChanged(int channel);  // 0=Off, 1-4
     void addPanClicked();
     void daxClicked();
-    void nr2Toggled(bool on);
-    void rn2Toggled(bool on);
-    void bnrToggled(bool on);
-    void nr4Toggled(bool on);
-    void mnrToggled(bool on);
-    void dfnrToggled(bool on);
-    void bnrIntensityChanged(float ratio);
-    void nr2RightClicked(const QPoint& globalPos);
-    void nr4RightClicked(const QPoint& globalPos);
-    void mnrRightClicked(const QPoint& globalPos);
-    void dfnrRightClicked(const QPoint& globalPos);
+    // DSP-related signals (nr2Toggled / rn2Toggled / bnrToggled /
+    // nr4Toggled / mnrToggled / dfnrToggled / bnrIntensityChanged /
+    // *RightClicked) were removed with the overlay's DSP panel.
     // Display sub-panel signals
     void fftAverageChanged(int frames);
     void fftFpsChanged(int fps);
@@ -149,9 +137,6 @@ private:
     void buildBandPanel();
     void toggleAntPanel();
     void buildAntPanel();
-    void toggleDspPanel();
-    void buildDspPanel();
-    void syncDspPanel();
     void toggleDaxPanel();
     void buildDaxPanel();
     void syncDaxPanel();
@@ -167,11 +152,10 @@ private:
     static constexpr int kBtnAddTnf = 1;
     static constexpr int kBtnBand = 2;
     static constexpr int kBtnAnt = 3;
-    static constexpr int kBtnDsp = 4;
-    static constexpr int kBtnDisplay = 5;
-    static constexpr int kBtnMemoryBrowse = 6;
-    static constexpr int kBtnMemoryAdd = 7;
-    static constexpr int kBtnDax = 8;
+    static constexpr int kBtnDisplay = 4;
+    static constexpr int kBtnMemoryBrowse = 5;
+    static constexpr int kBtnMemoryAdd = 6;
+    static constexpr int kBtnDax = 7;
 
     QPushButton* m_toggleBtn{nullptr};
     QVector<QPushButton*> m_menuBtns;
@@ -197,16 +181,6 @@ private:
     QPushButton* m_swrClearBtn{nullptr};
     QSlider*     m_swrPowerSlider{nullptr};
     QLabel*      m_swrPowerLabel{nullptr};
-
-    // DSP sub-panel
-    QWidget* m_dspPanel{nullptr};
-    bool     m_dspPanelVisible{false};
-    struct DspRow {
-        QPushButton* btn{nullptr};
-        QSlider*     slider{nullptr};
-        QLabel*      valueLbl{nullptr};
-    };
-    QVector<DspRow> m_dspRows;
 
     // DAX sub-panel
     QWidget*   m_daxPanel{nullptr};
@@ -253,7 +227,6 @@ private:
     QSlider*     m_bgOpacitySlider{nullptr};
     QLabel*      m_bgOpacityLabel{nullptr};
 
-    bool         m_hasExtendedDsp{false};
     QStringList  m_antList;
     QPointer<SliceModel> m_slice;
     bool         m_updatingFromModel{false};

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -13,6 +13,7 @@
 #include <QTimer>
 #include <QLabel>
 #include <QSlider>
+#include <QGraphicsOpacityEffect>
 #include <QLineEdit>
 #include <QComboBox>
 #include <QStackedWidget>
@@ -982,8 +983,6 @@ void VfoWidget::buildTabContent()
 
         m_nrBtn   = makeDsp("NR");
         m_nrBtn->setAccessibleName("Noise reduction");
-        m_nr2Btn  = makeDsp("NR2");
-        m_nr2Btn->setAccessibleName("NR2 spectral noise reduction");
         m_nbBtn   = makeDsp("NB");
         m_nbBtn->setAccessibleName("Noise blanker");
         m_anfBtn  = makeDsp("ANF");
@@ -996,71 +995,96 @@ void VfoWidget::buildTabContent()
         m_nrsBtn->setAccessibleName("Spectral subtraction");
         m_rnnBtn  = makeDsp("RNN");
         m_rnnBtn->setAccessibleName("RNN noise reduction");
-        m_rn2Btn  = makeDsp("RN2");
-        m_rn2Btn->setAccessibleName("RNNoise noise suppression");
         m_nrfBtn  = makeDsp("NRF");
         m_nrfBtn->setAccessibleName("Spectral noise filter");
         m_anflBtn = makeDsp("ANFL");
         m_anflBtn->setAccessibleName("LMS notch filter");
         m_anftBtn = makeDsp("ANFT");
         m_anftBtn->setAccessibleName("FFT notch filter");
-        m_bnrBtn  = makeDsp("BNR");
-        m_bnrBtn->setAccessibleName("GPU neural denoising");
-        m_nr4Btn  = makeDsp("NR4");
-        m_nr4Btn->setAccessibleName("Spectral bleach noise reduction");
-        m_mnrBtn  = makeDsp("MNR");
-        m_mnrBtn->setAccessibleName("macOS MMSE-Wiener noise reduction");
-        m_dfnrBtn = makeDsp("DFNR");
-        m_dfnrBtn->setAccessibleName("DeepFilterNet3 neural noise reduction");
         m_apfBtn->hide();  // only visible in CW mode
-#ifndef HAVE_BNR
-        m_bnrBtn->hide();
-#endif
-#ifndef HAVE_SPECBLEACH
-        m_nr4Btn->hide();
-#endif
-#ifndef __APPLE__
-        m_mnrBtn->hide();  // MNR is macOS only
-#endif
-#ifndef HAVE_DFNR
-        m_dfnrBtn->hide();
-#endif
 
-        // Initial layout: 4-column grid (APF hidden, BNR only with HAVE_BNR)
+        // Radio-side DSP buttons only \u2014 client-side modules (NR2 / NR4 /
+        // MNR / BNR / DFNR / RN2) live in the spectrum overlay menu and
+        // the AetherDSP applet; users toggle them there to keep the VFO
+        // grid focused on what the radio supplies.  4-column layout:
         m_dspGrid->addWidget(m_nrBtn,   0, 0);
-        m_dspGrid->addWidget(m_nr2Btn,  0, 1);
-        m_dspGrid->addWidget(m_nbBtn,   0, 2);
-        m_dspGrid->addWidget(m_anfBtn,  0, 3);
+        m_dspGrid->addWidget(m_nbBtn,   0, 1);
+        m_dspGrid->addWidget(m_anfBtn,  0, 2);
+        m_dspGrid->addWidget(m_apfBtn,  0, 3);
         m_dspGrid->addWidget(m_nrlBtn,  1, 0);
         m_dspGrid->addWidget(m_nrsBtn,  1, 1);
         m_dspGrid->addWidget(m_rnnBtn,  1, 2);
-        m_dspGrid->addWidget(m_rn2Btn,  1, 3);
-        m_dspGrid->addWidget(m_nrfBtn,  2, 0);
-        m_dspGrid->addWidget(m_anflBtn, 2, 1);
-        m_dspGrid->addWidget(m_anftBtn, 2, 2);
-        m_dspGrid->addWidget(m_bnrBtn,  2, 3);
-        m_dspGrid->addWidget(m_nr4Btn,  3, 0);
-        m_dspGrid->addWidget(m_mnrBtn,  3, 1);
-        m_dspGrid->addWidget(m_dfnrBtn, 3, 2);
+        m_dspGrid->addWidget(m_nrfBtn,  1, 3);
+        m_dspGrid->addWidget(m_anflBtn, 2, 0);
+        m_dspGrid->addWidget(m_anftBtn, 2, 1);
         dspVb->addLayout(m_dspGrid);
+
+        // Shared DSP-level row — one slider that re-targets based on which
+        // leveled DSP is most recently turned on.  Hidden when the active
+        // target is None (no leveled DSP on, or only RNN / ANFT / APF on).
+        {
+            m_dspLevelRow = new QWidget;
+            auto* lvlHb = new QHBoxLayout(m_dspLevelRow);
+            lvlHb->setContentsMargins(0, 4, 0, 0);
+            lvlHb->setSpacing(4);
+
+            m_dspLevelLabel = new QLabel("NR");
+            m_dspLevelLabel->setStyleSheet(
+                "QLabel { color: #c8d8e8; font-size: 13px; font-weight: bold;"
+                "  min-width: 40px; }");
+            m_dspLevelLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+            lvlHb->addWidget(m_dspLevelLabel);
+
+            m_dspLevelSlider = new GuardedSlider(Qt::Horizontal);
+            m_dspLevelSlider->setRange(0, 100);
+            m_dspLevelSlider->setStyleSheet(kSliderStyle);
+            lvlHb->addWidget(m_dspLevelSlider, 1);
+
+            m_dspLevelValue = new QLabel("0");
+            m_dspLevelValue->setStyleSheet(
+                "QLabel { color: #c8d8e8; font-size: 10px; min-width: 24px;"
+                "  padding-right: 4px; }");
+            m_dspLevelValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+            lvlHb->addWidget(m_dspLevelValue);
+
+            connect(m_dspLevelSlider, &QSlider::valueChanged, this, [this](int v) {
+                m_dspLevelValue->setText(QString::number(v));
+                if (m_updatingFromModel || !m_slice) return;
+                switch (m_dspLevelTarget) {
+                    case LvlNR:   m_slice->setNrLevel(v);   break;
+                    case LvlNB:   m_slice->setNbLevel(v);   break;
+                    case LvlAnf:  m_slice->setAnfLevel(v);  break;
+                    case LvlNrl:  m_slice->setNrlLevel(v);  break;
+                    case LvlNrs:  m_slice->setNrsLevel(v);  break;
+                    case LvlNrf:  m_slice->setNrfLevel(v);  break;
+                    case LvlAnfl: m_slice->setAnflLevel(v); break;
+                    case LvlNone: break;
+                }
+            });
+
+            // Stay laid out always — toggling visibility would shift the
+            // button grid up/down each time the slider's target changes.
+            // Instead, keep the row in the layout and fade contents with
+            // an opacity effect (0 when no DSP is targeted, 1 when one
+            // is).  Stray clicks while transparent are no-ops because
+            // the slider's valueChanged handler ignores LvlNone.
+            auto* eff = new QGraphicsOpacityEffect(m_dspLevelRow);
+            eff->setOpacity(0.0);
+            m_dspLevelRow->setGraphicsEffect(eff);
+            dspVb->addWidget(m_dspLevelRow);
+        }
 
         // DSP button tooltips
         m_nrBtn->setToolTip("Radio-side noise reduction \u2014 attenuates uncorrelated background noise.");
-        m_nr2Btn->setToolTip("Client-side spectral noise reduction (Ephraim-Malah MMSE). Right-click for NR2 settings.");
         m_nbBtn->setToolTip("Noise blanker \u2014 detects and removes fast impulse noise from sparks and switching sources.");
         m_anfBtn->setToolTip("Auto notch filter \u2014 detects and cancels persistent unwanted tones.");
         m_apfBtn->setToolTip("CW audio peaking filter \u2014 narrows the audio passband around the CW pitch frequency to improve S/N.");
         m_nrlBtn->setToolTip("Leaky LMS adaptive filter \u2014 preserves correlated signals while removing uncorrelated noise. Best for daily SSB/CW.");
         m_nrsBtn->setToolTip("Spectral subtraction with voice activity detection \u2014 cuts noise most aggressively between words.");
         m_rnnBtn->setToolTip("Deep-learning recurrent neural network \u2014 separates speech from complex noise. Best at low SNR.");
-        m_rn2Btn->setToolTip("Client-side RNNoise neural noise suppression. Effective for broadband noise on voice modes.");
         m_nrfBtn->setToolTip("Spectral subtraction filter \u2014 computes speech/noise probability per frequency bin to remove steady noise.");
         m_anflBtn->setToolTip("Leaky LMS notch filter \u2014 removes steady tones such as power-line hum or carriers.");
         m_anftBtn->setToolTip("FFT-based notch filter \u2014 removes up to five persistent tones from transformers or power supplies.");
-        m_bnrBtn->setToolTip("NVIDIA GPU-accelerated neural audio denoising. Requires NVIDIA RTX 4000+ with Docker.");
-        m_nr4Btn->setToolTip("Client-side spectral bleach noise reduction (libspecbleach). Right-click for NR4 settings.");
-        m_mnrBtn->setToolTip("macOS only \u2014 MMSE-Wiener spectral noise reduction.\nRemoves consistent background noise while preserving speech clarity.");
-        m_dfnrBtn->setToolTip("DeepFilterNet3 neural noise reduction \u2014 AI speech enhancement\nwith higher fidelity than RNNoise in high-noise environments.\nCPU-only, 10 ms latency. Right-click for DFNR settings.");
 
         // DSP button accessible names (#870)
         // Accessible names set inline after each widget creation below (#870)
@@ -1441,36 +1465,28 @@ void VfoWidget::buildTabContent()
             dspVb->addWidget(m_fmContainer);
         }
 
-        connect(m_nrBtn,   &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel && m_slice) m_slice->setNr(on); });
-        connect(m_nr2Btn,  &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel) emit nr2Toggled(on); });
-        m_nr2Btn->setContextMenuPolicy(Qt::CustomContextMenu);
-        connect(m_nr2Btn, &QPushButton::customContextMenuRequested, this, [this](const QPoint& pos) {
-            emit nr2RightClicked(m_nr2Btn->mapToGlobal(pos));
-        });
-        connect(m_nbBtn,   &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel && m_slice) m_slice->setNb(on); });
-        connect(m_anfBtn,  &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel && m_slice) m_slice->setAnf(on); });
-        connect(m_nrlBtn,  &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel && m_slice) m_slice->setNrl(on); });
-        connect(m_nrsBtn,  &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel && m_slice) m_slice->setNrs(on); });
+        // Leveled DSP buttons retarget the shared slider on each toggle.
+        // ON pushes onto the activation stack (most recent at top); OFF
+        // pops it and falls back to whichever earlier-activated DSP is
+        // still on.  Slider hides when the stack is empty.
+        auto wireLeveledDsp = [this](QPushButton* btn,
+                                     void (SliceModel::* setter)(bool),
+                                     DspLevelTarget tag) {
+            connect(btn, &QPushButton::toggled, this, [this, setter, tag](bool on) {
+                if (!m_updatingFromModel && m_slice) (m_slice->*setter)(on);
+                if (on) pushDspLevelTarget(tag);
+                else    popDspLevelTarget(tag);
+            });
+        };
+        wireLeveledDsp(m_nrBtn,   &SliceModel::setNr,   LvlNR);
+        wireLeveledDsp(m_nbBtn,   &SliceModel::setNb,   LvlNB);
+        wireLeveledDsp(m_anfBtn,  &SliceModel::setAnf,  LvlAnf);
+        wireLeveledDsp(m_nrlBtn,  &SliceModel::setNrl,  LvlNrl);
+        wireLeveledDsp(m_nrsBtn,  &SliceModel::setNrs,  LvlNrs);
+        wireLeveledDsp(m_nrfBtn,  &SliceModel::setNrf,  LvlNrf);
+        wireLeveledDsp(m_anflBtn, &SliceModel::setAnfl, LvlAnfl);
+        // Toggle-only DSPs — do not interact with the shared slider.
         connect(m_rnnBtn,  &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel && m_slice) m_slice->setRnn(on); });
-        connect(m_rn2Btn,  &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel) emit rn2Toggled(on); });
-        connect(m_bnrBtn,  &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel) emit bnrToggled(on); });
-        connect(m_nr4Btn,  &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel) emit nr4Toggled(on); });
-        m_nr4Btn->setContextMenuPolicy(Qt::CustomContextMenu);
-        connect(m_nr4Btn, &QPushButton::customContextMenuRequested, this, [this](const QPoint& pos) {
-            emit nr4RightClicked(m_nr4Btn->mapToGlobal(pos));
-        });
-        connect(m_mnrBtn,  &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel) emit mnrToggled(on); });
-        m_mnrBtn->setContextMenuPolicy(Qt::CustomContextMenu);
-        connect(m_mnrBtn, &QPushButton::customContextMenuRequested, this, [this](const QPoint& pos) {
-            emit mnrRightClicked(m_mnrBtn->mapToGlobal(pos));
-        });
-        connect(m_dfnrBtn, &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel) emit dfnrToggled(on); });
-        m_dfnrBtn->setContextMenuPolicy(Qt::CustomContextMenu);
-        connect(m_dfnrBtn, &QPushButton::customContextMenuRequested, this, [this](const QPoint& pos) {
-            emit dfnrRightClicked(m_dfnrBtn->mapToGlobal(pos));
-        });
-        connect(m_nrfBtn,  &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel && m_slice) m_slice->setNrf(on); });
-        connect(m_anflBtn, &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel && m_slice) m_slice->setAnfl(on); });
         connect(m_anftBtn, &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel && m_slice) m_slice->setAnft(on); });
         connect(m_apfBtn,  &QPushButton::toggled, this, [this](bool on) { if (!m_updatingFromModel && m_slice) m_slice->setApf(on); });
 
@@ -2366,6 +2382,25 @@ void VfoWidget::setSlice(SliceModel* slice)
 
     // Frequency
     connect(m_slice, &SliceModel::frequencyChanged, this, [this](double) { updateFreqLabel(); });
+
+    // Slice-level → shared DSP slider: when the active target's level
+    // changes externally (radio echo, profile load, MIDI), update the
+    // slider in-place without firing back into the slice.
+    auto wireLevelEcho = [this](auto signal, DspLevelTarget tag) {
+        connect(m_slice, signal, this, [this, tag](int v) {
+            if (m_dspLevelTarget != tag || !m_dspLevelSlider) return;
+            QSignalBlocker b(m_dspLevelSlider);
+            m_dspLevelSlider->setValue(v);
+            m_dspLevelValue->setText(QString::number(v));
+        });
+    };
+    wireLevelEcho(&SliceModel::nrLevelChanged,   LvlNR);
+    wireLevelEcho(&SliceModel::nbLevelChanged,   LvlNB);
+    wireLevelEcho(&SliceModel::anfLevelChanged,  LvlAnf);
+    wireLevelEcho(&SliceModel::nrlLevelChanged,  LvlNrl);
+    wireLevelEcho(&SliceModel::nrsLevelChanged,  LvlNrs);
+    wireLevelEcho(&SliceModel::nrfLevelChanged,  LvlNrf);
+    wireLevelEcho(&SliceModel::anflLevelChanged, LvlAnfl);
     // Mode list (dynamic from radio)
     connect(m_slice, &SliceModel::modeListChanged, this, [this](const QStringList& modes) {
         if (modes.isEmpty()) return;          // keep static fallback list (#891)
@@ -2440,12 +2475,10 @@ void VfoWidget::setSlice(SliceModel* slice)
         }
         m_apfBtn->setVisible(isCw);
         m_anfBtn->setVisible(isVoice);
-        m_rn2Btn->setVisible(!isCw && !isFm);
         m_anflBtn->setVisible(isVoice);
         m_anftBtn->setVisible(isVoice);
         // Hide all DSP buttons in FM mode
         m_nrBtn->setVisible(!isFm);
-        m_nr2Btn->setVisible(!isFm);
         m_nbBtn->setVisible(!isFm);
         // NRL is available on 6000-series too (#2177)
         m_nrlBtn->setVisible(!isFm);
@@ -2453,15 +2486,6 @@ void VfoWidget::setSlice(SliceModel* slice)
         m_nrsBtn->setVisible(!isFm && m_hasExtendedDsp);
         m_rnnBtn->setVisible(!isCw && !isFm && m_hasExtendedDsp);
         m_nrfBtn->setVisible(!isFm && m_hasExtendedDsp);
-#ifdef HAVE_BNR
-        m_bnrBtn->setVisible(!isFm);
-#endif
-#ifdef HAVE_SPECBLEACH
-        m_nr4Btn->setVisible(!isFm);
-#endif
-#ifdef HAVE_DFNR
-        m_dfnrBtn->setVisible(!isFm);
-#endif
         relayoutDspGrid();
         updateFilterLabel();
         if (m_tabStack->isVisible()) adjustSize();
@@ -2897,6 +2921,9 @@ void VfoWidget::syncFromSlice()
     syncDsp(m_anftBtn, m_slice->anftOn());
     syncDsp(m_apfBtn, m_slice->apfOn());
 
+    // Shared DSP-level slider — pick the highest-priority enabled DSP.
+    refreshDspLevelTarget();
+
     // RIT/XIT
     {
         QSignalBlocker sb1(m_ritBtn), sb2(m_xitBtn);
@@ -2917,21 +2944,10 @@ void VfoWidget::syncFromSlice()
     m_tabBtns[1]->setText(isFm ? "OPT" : "DSP");
     m_apfBtn->setVisible(isCw);
     m_anfBtn->setVisible(!isRtty && !isCw && !isDig && !isFm);
-    m_rn2Btn->setVisible(!isCw && !isFm);
     m_anflBtn->setVisible(!isRtty && !isCw && !isDig && !isFm);
     m_anftBtn->setVisible(!isRtty && !isCw && !isDig && !isFm);
     m_nrBtn->setVisible(!isFm);
-    m_nr2Btn->setVisible(!isFm);
     m_nbBtn->setVisible(!isFm);
-#ifdef HAVE_BNR
-    m_bnrBtn->setVisible(!isFm);
-#endif
-#ifdef HAVE_SPECBLEACH
-    m_nr4Btn->setVisible(!isFm);
-#endif
-#ifdef HAVE_DFNR
-    m_dfnrBtn->setVisible(!isFm);
-#endif
     // NRL is available on 6000-series too (#2177)
     m_nrlBtn->setVisible(!isFm);
     // 8000-series-only firmware DSP filters (#2177)
@@ -3016,8 +3032,8 @@ void VfoWidget::updateFilterLabel()
 void VfoWidget::relayoutDspGrid()
 {
     // Remove all widgets from the grid (without deleting them)
-    QPushButton* all[] = {m_nrBtn, m_nr2Btn, m_nbBtn, m_anfBtn, m_apfBtn, m_nrlBtn,
-                          m_nrsBtn, m_rnnBtn, m_rn2Btn, m_nrfBtn, m_anflBtn, m_anftBtn, m_bnrBtn, m_nr4Btn, m_dfnrBtn};
+    QPushButton* all[] = {m_nrBtn, m_nbBtn, m_anfBtn, m_apfBtn, m_nrlBtn,
+                          m_nrsBtn, m_rnnBtn, m_nrfBtn, m_anflBtn, m_anftBtn};
     for (auto* btn : all)
         m_dspGrid->removeWidget(btn);
 
@@ -3029,6 +3045,92 @@ void VfoWidget::relayoutDspGrid()
             if (++col >= 4) { col = 0; ++row; }
         }
     }
+}
+
+// ── Shared DSP level slider ───────────────────────────────────────────────────
+
+void VfoWidget::pushDspLevelTarget(DspLevelTarget t)
+{
+    if (t == LvlNone) return;
+    m_dspLevelStack.removeAll(t);
+    m_dspLevelStack.append(t);
+    setDspLevelTarget(t);
+}
+
+void VfoWidget::popDspLevelTarget(DspLevelTarget t)
+{
+    m_dspLevelStack.removeAll(t);
+    if (m_dspLevelTarget == t) {
+        if (!m_dspLevelStack.isEmpty())
+            setDspLevelTarget(m_dspLevelStack.last());
+        else
+            setDspLevelTarget(LvlNone);
+    }
+}
+
+void VfoWidget::setDspLevelTarget(DspLevelTarget t)
+{
+    m_dspLevelTarget = t;
+    if (!m_dspLevelRow) return;
+    auto* eff = qobject_cast<QGraphicsOpacityEffect*>(m_dspLevelRow->graphicsEffect());
+    if (t == LvlNone || !m_slice) {
+        if (eff) eff->setOpacity(0.0);
+        return;
+    }
+    int level = 0;
+    QString name;
+    switch (t) {
+        case LvlNR:   level = m_slice->nrLevel();   name = "NR";   break;
+        case LvlNB:   level = m_slice->nbLevel();   name = "NB";   break;
+        case LvlAnf:  level = m_slice->anfLevel();  name = "ANF";  break;
+        case LvlNrl:  level = m_slice->nrlLevel();  name = "NRL";  break;
+        case LvlNrs:  level = m_slice->nrsLevel();  name = "NRS";  break;
+        case LvlNrf:  level = m_slice->nrfLevel();  name = "NRF";  break;
+        case LvlAnfl: level = m_slice->anflLevel(); name = "ANFL"; break;
+        case LvlNone: return;
+    }
+    m_dspLevelLabel->setText(name);
+    {
+        QSignalBlocker b(m_dspLevelSlider);
+        m_dspLevelSlider->setValue(level);
+    }
+    m_dspLevelValue->setText(QString::number(level));
+    if (eff) eff->setOpacity(1.0);
+}
+
+void VfoWidget::refreshDspLevelTarget()
+{
+    m_dspLevelStack.clear();
+    if (!m_slice) {
+        setDspLevelTarget(LvlNone);
+        return;
+    }
+    // Seed the activation stack from current slice state in priority
+    // order (NR, NB, ANF, NRL, NRS, NRF, ANFL) — we have no record of
+    // the radio's actual click order, so use the priority sequence as
+    // a deterministic fallback.  Most recent (last in stack) becomes
+    // the active target.
+    auto isOn = [this](DspLevelTarget t) {
+        if (!m_slice) return false;
+        switch (t) {
+            case LvlNR:   return m_slice->nrOn();
+            case LvlNB:   return m_slice->nbOn();
+            case LvlAnf:  return m_slice->anfOn();
+            case LvlNrl:  return m_slice->nrlOn();
+            case LvlNrs:  return m_slice->nrsOn();
+            case LvlNrf:  return m_slice->nrfOn();
+            case LvlAnfl: return m_slice->anflOn();
+            case LvlNone: return false;
+        }
+        return false;
+    };
+    for (auto t : { LvlNR, LvlNB, LvlAnf, LvlNrl, LvlNrs, LvlNrf, LvlAnfl }) {
+        if (isOn(t)) m_dspLevelStack.append(t);
+    }
+    if (m_dspLevelStack.isEmpty())
+        setDspLevelTarget(LvlNone);
+    else
+        setDspLevelTarget(m_dspLevelStack.last());
 }
 
 // ── Mode tab helpers ──────────────────────────────────────────────────────────

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -53,12 +53,9 @@ public:
     // Reposition relative to VFO marker x coordinate.
     void updatePosition(int vfoX, int specTop, FlagDir dir = Auto);
 
-    QPushButton* nr2Button() const { return m_nr2Btn; }
-    QPushButton* rn2Button() const { return m_rn2Btn; }
-    QPushButton* bnrButton() const { return m_bnrBtn; }
-    QPushButton* nr4Button() const { return m_nr4Btn; }
-    QPushButton* mnrButton() const { return m_mnrBtn; }
-    QPushButton* dfnrButton() const { return m_dfnrBtn; }
+    // Client-side DSP buttons (NR2 / NR4 / MNR / BNR / DFNR / RN2) were
+    // removed from the VFO DSP grid; that family lives in the spectrum
+    // overlay menu and the AetherDSP applet only.
     void setAfGain(int pct);
     void setEscLevel(float dbm);
     void syncFromSlice();
@@ -84,16 +81,8 @@ Q_SIGNALS:
     void rxPanChanged(int value);     // pan slider moved; AudioEngine re-applies after NR (#1460)
     void closeSliceRequested();
     void lockToggled(bool locked);
-    void nr2Toggled(bool on);
-    void nr2RightClicked(const QPoint& globalPos);
-    void nr4RightClicked(const QPoint& globalPos);
-    void rn2Toggled(bool on);
-    void bnrToggled(bool on);
-    void nr4Toggled(bool on);
-    void mnrToggled(bool on);
-    void mnrRightClicked(const QPoint& globalPos);
-    void dfnrToggled(bool on);
-    void dfnrRightClicked(const QPoint& globalPos);
+    // Client-side DSP signals deleted with the buttons — overlay menu
+    // and AetherDSP applet handle those toggles directly now.
 #ifdef HAVE_RADE
     void radeActivated(bool on, int sliceId);
 #endif
@@ -241,20 +230,35 @@ private:
     // DSP tab
     QPushButton* m_nbBtn{nullptr};
     QPushButton* m_nrBtn{nullptr};
-    QPushButton* m_nr2Btn{nullptr};
     QPushButton* m_anfBtn{nullptr};
     QPushButton* m_nrlBtn{nullptr};
     QPushButton* m_nrsBtn{nullptr};
     QPushButton* m_rnnBtn{nullptr};
-    QPushButton* m_rn2Btn{nullptr};
-    QPushButton* m_bnrBtn{nullptr};
-    QPushButton* m_nr4Btn{nullptr};
-    QPushButton* m_mnrBtn{nullptr};
-    QPushButton* m_dfnrBtn{nullptr};
     QPushButton* m_nrfBtn{nullptr};
     QPushButton* m_anflBtn{nullptr};
     QPushButton* m_anftBtn{nullptr};
     QPushButton* m_apfBtn{nullptr};
+
+    // Shared DSP-level row at the bottom of the DSP grid: one slider whose
+    // target switches based on which leveled DSP the user most recently
+    // turned on.  RNN / ANFT / APF are toggle-only on this slider — they
+    // either have no level (RNN, ANFT) or own a dedicated container (APF).
+    enum DspLevelTarget { LvlNone = 0, LvlNR, LvlNB, LvlAnf, LvlNrl, LvlNrs, LvlNrf, LvlAnfl };
+    QWidget* m_dspLevelRow{nullptr};
+    QLabel*  m_dspLevelLabel{nullptr};
+    QSlider* m_dspLevelSlider{nullptr};
+    QLabel*  m_dspLevelValue{nullptr};
+    DspLevelTarget m_dspLevelTarget{LvlNone};
+    // Activation stack — most recent at the back.  Lets the slider fall
+    // back to the previous still-on DSP when the active one is turned
+    // off, instead of hiding the row entirely.
+    QList<DspLevelTarget> m_dspLevelStack;
+    void pushDspLevelTarget(DspLevelTarget t);
+    void popDspLevelTarget(DspLevelTarget t);
+    void setDspLevelTarget(DspLevelTarget t);
+    // Pick a sensible initial target from the current slice's enable
+    // flags; called when m_slice is set and on mode-driven re-visibility.
+    void refreshDspLevelTarget();
     QWidget* m_apfContainer{nullptr};
     QSlider* m_apfSlider{nullptr};
     QLabel*  m_apfValueLbl{nullptr};


### PR DESCRIPTION
## Summary

Consolidates client-side DSP from three surfaces (VFO DSP grid,
spectrum overlay sub-panel, AetherDSP dialog) down to one: a new
docked **Aetherial Noise Reduction** applet on the PooDoo RX side,
which the Settings-menu dialog also embeds via shared
\`AetherDspWidget\`. Radio-side DSP now lives only on \`VfoWidget\`.

## Changes

- **New \`AetherDspWidget\`** — extracts the dialog body into a
  reusable widget with compact-mode support; both \`AetherDspDialog\`
  and the new \`ClientRxDspApplet\` embed it. Single source of truth
  for AppSettings persistence.
- **New \`ClientRxDspApplet\`** — 250 px-wide docked tile with
  exclusive DSP selector (NR2 / NR4 / MNR / DFNR / RN2 / BNR) +
  per-DSP control pages in a stacked widget. Single-click on the RX
  chain DSP tile bypasses; double-click opens the full editor.
- **VFO DSP grid** — drops the six client-side buttons; gains a
  shared DSP-level slider with a push/pop activation stack so the
  slider tracks the most-recently-enabled radio DSP and hides
  cleanly when no slider-bearing DSP is active.
- **Spectrum overlay menu** — DSP sub-panel removed entirely.
  Drops 11 toggle/right-click signals, six button accessors, the
  15-row \`DspRow\` grid, and the build/sync/toggle triplet.
- **TX chain applets** — visibility now decoupled from bypass
  state; bypassed applets dim instead of disappearing (matches
  Aetherial TX EQ).
- **NR2 enable path** — wisdom generation now runs through
  \`MainWindow::enableNr2WithWisdom()\` for both the applet and the
  RX chain widget, fixing the NR4→NR2 transition crash caused by
  FFTW wisdom version mismatch (#2275).
- **NR4 polish** — MMSE label, info paragraph at 12 px across all
  panels, undo/reset icon repositioning, padding fixes.
- **Platform guards** — MNR dimmed/disabled on non-macOS, BNR
  guarded by \`HAVE_BNR\`.

## Test plan

- [ ] Launch app — initial visibility shows only enabled chain
      applets, no double-display of TX+RX
- [ ] RX chain: single-click \`[DSP]\` tile bypasses; click again
      re-enables the last-selected DSP
- [ ] RX chain: double-click \`[DSP]\` opens the full
      \`AetherDspDialog\`
- [ ] Aetherial Noise Reduction applet: exclusive selector
      switches the engine DSP and the visible parameter page
- [ ] VFO DSP grid: shared level slider appears for slider-bearing
      DSPs, hides when last one disabled, falls back to next active
      DSP if multiple are enabled
- [ ] Spectrum overlay menu opens cleanly with no DSP entry
- [ ] NR4 → NR2 transition does not crash (PR #2275 wisdom path)
- [ ] Opus / SmartLink active → NR2 button disabled in applet
- [ ] Settings → AetherDSP dialog still works (shares widget with
      applet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)