### PR TITLE
Channel Strip presets, master-bypass sync, layout polish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,6 +411,7 @@ set(CORE_SOURCES
     src/core/TgxlConnection.cpp
     src/core/CommandParser.cpp
     src/core/AudioEngine.cpp
+    src/core/ChannelStripPresets.cpp
     src/core/ClientEq.cpp
     src/core/ClientComp.cpp
     src/core/ClientGate.cpp
@@ -544,6 +545,7 @@ set(GUI_SOURCES
     src/gui/ClientEqCurveWidget.cpp
     src/gui/ClientEqEditor.cpp
     src/gui/ClientEqEditorCanvas.cpp
+    src/gui/StripEqPanel.cpp
     src/gui/ClientEqFftAnalyzer.cpp
     src/gui/ClientEqIconRow.cpp
     src/gui/ClientEqOutputFader.cpp
@@ -551,6 +553,7 @@ set(GUI_SOURCES
     src/gui/ClientEqParamRow.cpp
     src/gui/ClientChainApplet.cpp
     src/gui/ClientChainWidget.cpp
+    src/gui/StripChainWidget.cpp
     src/gui/ClientRxChainWidget.cpp
     src/gui/EditorFramelessTitleBar.cpp
     src/gui/containers/ContainerManager.cpp
@@ -563,23 +566,30 @@ set(GUI_SOURCES
     src/gui/ClientGateApplet.cpp
     src/gui/ClientGateCurveWidget.cpp
     src/gui/ClientGateEditor.cpp
+    src/gui/StripGatePanel.cpp
     src/gui/ClientGateLevelView.cpp
     src/gui/ClientDeEssApplet.cpp
     src/gui/ClientDeEssCurveWidget.cpp
     src/gui/ClientDeEssEditor.cpp
+    src/gui/StripDeEssPanel.cpp
     src/gui/ClientTubeApplet.cpp
     src/gui/ClientTubeCurveWidget.cpp
     src/gui/ClientTubeEditor.cpp
+    src/gui/StripTubePanel.cpp
     src/gui/ClientPuduApplet.cpp
     src/gui/ClientPuduEditor.cpp
+    src/gui/StripPuduPanel.cpp
     src/gui/ClientReverbApplet.cpp
     src/gui/ClientReverbEditor.cpp
+    src/gui/StripReverbPanel.cpp
+    src/gui/AetherialAudioStrip.cpp
     src/gui/PooDooLogo.cpp
     src/gui/ClientCompLimiterButton.cpp
     src/gui/ClientCompMeter.cpp
     src/gui/ClientCompThresholdFader.cpp
     src/gui/ClientCompEditor.cpp
     src/gui/ClientCompEditorCanvas.cpp
+    src/gui/StripCompPanel.cpp
     src/gui/CatControlApplet.cpp
     src/gui/DaxApplet.cpp
     src/gui/TciApplet.cpp

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1624,6 +1624,104 @@ QVector<AudioEngine::TxChainStage> AudioEngine::txChainStages() const
     return unpackChain(m_txChainPacked.load(std::memory_order_acquire));
 }
 
+bool AudioEngine::isTxBypassed() const
+{
+    return !m_txBypassSnapshot.isEmpty();
+}
+
+void AudioEngine::setTxBypassed(bool on)
+{
+    if (on == isTxBypassed()) return;
+
+    auto setStageEnabled = [this](TxChainStage s, bool enabled) {
+        switch (s) {
+            case TxChainStage::Eq:
+                if (m_clientEqTx) {
+                    m_clientEqTx->setEnabled(enabled);
+                    saveClientEqSettings();
+                }
+                break;
+            case TxChainStage::Comp:
+                if (m_clientCompTx) {
+                    m_clientCompTx->setEnabled(enabled);
+                    saveClientCompSettings();
+                }
+                break;
+            case TxChainStage::Gate:
+                if (m_clientGateTx) {
+                    m_clientGateTx->setEnabled(enabled);
+                    saveClientGateSettings();
+                }
+                break;
+            case TxChainStage::DeEss:
+                if (m_clientDeEssTx) {
+                    m_clientDeEssTx->setEnabled(enabled);
+                    saveClientDeEssSettings();
+                }
+                break;
+            case TxChainStage::Tube:
+                if (m_clientTubeTx) {
+                    m_clientTubeTx->setEnabled(enabled);
+                    saveClientTubeSettings();
+                }
+                break;
+            case TxChainStage::Enh:   // PUDU
+                if (m_clientPuduTx) {
+                    m_clientPuduTx->setEnabled(enabled);
+                    saveClientPuduSettings();
+                }
+                break;
+            case TxChainStage::Reverb:
+                if (m_clientReverbTx) {
+                    m_clientReverbTx->setEnabled(enabled);
+                    saveClientReverbSettings();
+                }
+                break;
+            case TxChainStage::None:
+                break;
+        }
+    };
+
+    auto isEnabled = [this](TxChainStage s) -> bool {
+        switch (s) {
+            case TxChainStage::Eq:     return m_clientEqTx     && m_clientEqTx->isEnabled();
+            case TxChainStage::Comp:   return m_clientCompTx   && m_clientCompTx->isEnabled();
+            case TxChainStage::Gate:   return m_clientGateTx   && m_clientGateTx->isEnabled();
+            case TxChainStage::DeEss:  return m_clientDeEssTx  && m_clientDeEssTx->isEnabled();
+            case TxChainStage::Tube:   return m_clientTubeTx   && m_clientTubeTx->isEnabled();
+            case TxChainStage::Enh:    return m_clientPuduTx   && m_clientPuduTx->isEnabled();
+            case TxChainStage::Reverb: return m_clientReverbTx && m_clientReverbTx->isEnabled();
+            case TxChainStage::None:   return false;
+        }
+        return false;
+    };
+
+    static const QVector<TxChainStage> kAllStages{
+        TxChainStage::Eq,
+        TxChainStage::Comp,
+        TxChainStage::Gate,
+        TxChainStage::DeEss,
+        TxChainStage::Tube,
+        TxChainStage::Enh,
+        TxChainStage::Reverb,
+    };
+
+    if (on) {
+        m_txBypassSnapshot.clear();
+        for (auto s : kAllStages) {
+            if (isEnabled(s)) {
+                m_txBypassSnapshot.append(s);
+                setStageEnabled(s, false);
+            }
+        }
+    } else {
+        for (auto s : m_txBypassSnapshot) setStageEnabled(s, true);
+        m_txBypassSnapshot.clear();
+    }
+
+    emit txBypassChanged(on);
+}
+
 void AudioEngine::setRxChainStages(const QVector<RxChainStage>& stages)
 {
     m_rxChainPacked.store(packRxChain(stages), std::memory_order_release);

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -274,6 +274,18 @@ public:
     void setTxChainStages(const QVector<TxChainStage>& stages);
     QVector<TxChainStage> txChainStages() const;
 
+    // ── Master TX bypass ─────────────────────────────────────────
+    // Single source of truth for the chain-wide BYPASS state shared
+    // between the docked Chain applet's BYPASS button and the channel
+    // strip's BYPASS button.  setTxBypassed(true) snapshots the
+    // currently-enabled TX stages and disables them all; calling
+    // setTxBypassed(false) restores only those stages that were on
+    // before bypass engaged.  Stages flipped on manually while bypass
+    // was active survive the restore (they're not in the snapshot).
+    // Emits txBypassChanged(bool) on transitions.
+    void setTxBypassed(bool on);
+    bool isTxBypassed() const;
+
     // Legacy two-stage API — the existing ClientCompEditor combo box
     // still drives this during the transition to the generalised chain.
     // Reads the relative position of Comp vs Eq in the current chain.
@@ -379,6 +391,7 @@ signals:
     void scopeSamplesReady(const QByteArray& monoFloat32Pcm, int sampleRate, bool tx);
     void radioTransmittingChanged(bool tx);
     void mutedChanged(bool muted);                          // local audio output mute state
+    void txBypassChanged(bool on);                          // master TX BYPASS state
 
 private slots:
     void onTxAudioReady();
@@ -574,6 +587,11 @@ private:
     // [Gate, Eq, DeEss, Comp, Tube, Enh] — but only Eq and Comp have
     // implementations today, so the others are no-op pass-throughs.
     std::atomic<uint64_t> m_txChainPacked{0};
+    // Master-bypass snapshot — the stages that were enabled at the
+    // moment setTxBypassed(true) was called.  Lives on the engine so
+    // both the Chain applet and the channel-strip BYPASS buttons
+    // share one source of truth.  Empty ⇒ not bypassed.
+    QVector<TxChainStage> m_txBypassSnapshot;
     // RX chain — same packing convention.  RxChainStage::None terminates
     // the list.  Phase 0 dispatcher iterates this but every stage is a
     // no-op until its DSP class lands in a later phase.

--- a/src/core/ChannelStripPresets.cpp
+++ b/src/core/ChannelStripPresets.cpp
@@ -1,0 +1,642 @@
+#include "ChannelStripPresets.h"
+
+#include "AudioEngine.h"
+#include "ClientComp.h"
+#include "ClientDeEss.h"
+#include "ClientEq.h"
+#include "ClientGate.h"
+#include "ClientPudu.h"
+#include "ClientReverb.h"
+#include "ClientTube.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QStandardPaths>
+#include <algorithm>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kSchemaVersion = 1;
+
+// ── Stage enum/string mapping ─────────────────────────────────────
+// Local copy (the AudioEngine.cpp helpers are file-static); kept
+// trivial enough to maintain alongside the canonical map there.
+
+QString stageEnumToName(AudioEngine::TxChainStage s)
+{
+    switch (s) {
+        case AudioEngine::TxChainStage::Gate:   return "Gate";
+        case AudioEngine::TxChainStage::Eq:     return "Eq";
+        case AudioEngine::TxChainStage::DeEss:  return "DeEss";
+        case AudioEngine::TxChainStage::Comp:   return "Comp";
+        case AudioEngine::TxChainStage::Tube:   return "Tube";
+        case AudioEngine::TxChainStage::Enh:    return "Enh";
+        case AudioEngine::TxChainStage::Reverb: return "Reverb";
+        case AudioEngine::TxChainStage::None:   return "";
+    }
+    return "";
+}
+
+AudioEngine::TxChainStage stageNameToEnum(const QString& n)
+{
+    if (n == "Gate")   return AudioEngine::TxChainStage::Gate;
+    if (n == "Eq")     return AudioEngine::TxChainStage::Eq;
+    if (n == "DeEss")  return AudioEngine::TxChainStage::DeEss;
+    if (n == "Comp")   return AudioEngine::TxChainStage::Comp;
+    if (n == "Tube")   return AudioEngine::TxChainStage::Tube;
+    if (n == "Enh")    return AudioEngine::TxChainStage::Enh;
+    if (n == "Reverb") return AudioEngine::TxChainStage::Reverb;
+    return AudioEngine::TxChainStage::None;
+}
+
+// ── Per-module enum string maps ───────────────────────────────────
+
+QString eqFilterTypeName(ClientEq::FilterType t)
+{
+    switch (t) {
+        case ClientEq::FilterType::Peak:      return "Peak";
+        case ClientEq::FilterType::LowShelf:  return "LowShelf";
+        case ClientEq::FilterType::HighShelf: return "HighShelf";
+        case ClientEq::FilterType::LowPass:   return "LowPass";
+        case ClientEq::FilterType::HighPass:  return "HighPass";
+    }
+    return "Peak";
+}
+
+ClientEq::FilterType eqFilterTypeFromName(const QString& n)
+{
+    if (n == "LowShelf")  return ClientEq::FilterType::LowShelf;
+    if (n == "HighShelf") return ClientEq::FilterType::HighShelf;
+    if (n == "LowPass")   return ClientEq::FilterType::LowPass;
+    if (n == "HighPass")  return ClientEq::FilterType::HighPass;
+    return ClientEq::FilterType::Peak;
+}
+
+QString eqFilterFamilyName(ClientEq::FilterFamily f)
+{
+    switch (f) {
+        case ClientEq::FilterFamily::Butterworth: return "Butterworth";
+        case ClientEq::FilterFamily::Chebyshev:   return "Chebyshev";
+        case ClientEq::FilterFamily::Bessel:      return "Bessel";
+        case ClientEq::FilterFamily::Elliptic:    return "Elliptic";
+    }
+    return "Butterworth";
+}
+
+ClientEq::FilterFamily eqFilterFamilyFromName(const QString& n)
+{
+    if (n == "Chebyshev") return ClientEq::FilterFamily::Chebyshev;
+    if (n == "Bessel")    return ClientEq::FilterFamily::Bessel;
+    if (n == "Elliptic")  return ClientEq::FilterFamily::Elliptic;
+    return ClientEq::FilterFamily::Butterworth;
+}
+
+QString gateModeName(ClientGate::Mode m)
+{
+    switch (m) {
+        case ClientGate::Mode::Expander:  return "Expander";
+        case ClientGate::Mode::Gate:      return "Gate";
+    }
+    return "Expander";
+}
+
+ClientGate::Mode gateModeFromName(const QString& n)
+{
+    if (n == "Gate") return ClientGate::Mode::Gate;
+    return ClientGate::Mode::Expander;
+}
+
+QString tubeModelName(ClientTube::Model m)
+{
+    switch (m) {
+        case ClientTube::Model::A: return "A";
+        case ClientTube::Model::B: return "B";
+        case ClientTube::Model::C: return "C";
+    }
+    return "A";
+}
+
+ClientTube::Model tubeModelFromName(const QString& n)
+{
+    if (n == "B") return ClientTube::Model::B;
+    if (n == "C") return ClientTube::Model::C;
+    return ClientTube::Model::A;
+}
+
+QString puduModeName(ClientPudu::Mode m)
+{
+    switch (m) {
+        case ClientPudu::Mode::Aphex:     return "Aphex";
+        case ClientPudu::Mode::Behringer: return "Behringer";
+    }
+    return "Aphex";
+}
+
+ClientPudu::Mode puduModeFromName(const QString& n)
+{
+    if (n == "Behringer") return ClientPudu::Mode::Behringer;
+    return ClientPudu::Mode::Aphex;
+}
+
+// ── Helpers for safe JSON reads ───────────────────────────────────
+
+double jnum(const QJsonObject& o, const QString& k, double fallback)
+{
+    const auto v = o.value(k);
+    return v.isDouble() ? v.toDouble() : fallback;
+}
+
+bool jbool(const QJsonObject& o, const QString& k, bool fallback)
+{
+    const auto v = o.value(k);
+    return v.isBool() ? v.toBool() : fallback;
+}
+
+QString jstr(const QJsonObject& o, const QString& k,
+             const QString& fallback = QString())
+{
+    const auto v = o.value(k);
+    return v.isString() ? v.toString() : fallback;
+}
+
+} // namespace
+
+// ──────────────────────────────────────────────────────────────────
+// Construction
+// ──────────────────────────────────────────────────────────────────
+
+ChannelStripPresets::ChannelStripPresets(AudioEngine* engine,
+                                         QObject*     parent)
+    : QObject(parent)
+    , m_engine(engine)
+{
+    if (!loadFromDisk()) {
+        m_root = QJsonObject{
+            {"version", kSchemaVersion},
+            {"presets", QJsonObject{}},
+        };
+    }
+}
+
+QString ChannelStripPresets::filePath() const
+{
+    // Sibling of AetherSDR.settings under XDG_CONFIG_HOME.
+    const QString dir = QStandardPaths::writableLocation(
+        QStandardPaths::AppConfigLocation);
+    QDir().mkpath(dir);
+    return dir + "/ChannelStrip.settings";
+}
+
+bool ChannelStripPresets::loadFromDisk()
+{
+    QFile f(filePath());
+    if (!f.exists() || !f.open(QIODevice::ReadOnly)) return false;
+    const auto doc = QJsonDocument::fromJson(f.readAll());
+    if (!doc.isObject()) return false;
+    m_root = doc.object();
+    if (!m_root.contains("presets") || !m_root["presets"].isObject())
+        m_root["presets"] = QJsonObject{};
+    if (!m_root.contains("version"))
+        m_root["version"] = kSchemaVersion;
+    return true;
+}
+
+bool ChannelStripPresets::saveToDisk() const
+{
+    QFile f(filePath());
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return false;
+    f.write(QJsonDocument(m_root).toJson(QJsonDocument::Indented));
+    return true;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Public preset library API
+// ──────────────────────────────────────────────────────────────────
+
+QStringList ChannelStripPresets::presetNames() const
+{
+    QStringList names = m_root.value("presets").toObject().keys();
+    names.sort(Qt::CaseInsensitive);
+    return names;
+}
+
+bool ChannelStripPresets::hasPreset(const QString& name) const
+{
+    return m_root.value("presets").toObject().contains(name);
+}
+
+bool ChannelStripPresets::loadPreset(const QString& name)
+{
+    const auto presets = m_root.value("presets").toObject();
+    if (!presets.contains(name)) return false;
+    applyPresetJson(presets.value(name).toObject());
+    return true;
+}
+
+bool ChannelStripPresets::savePresetFromCurrent(const QString& name)
+{
+    if (name.trimmed().isEmpty()) return false;
+    auto presets = m_root.value("presets").toObject();
+    presets[name] = capturePresetJson();
+    m_root["presets"] = presets;
+    if (!saveToDisk()) return false;
+    emit presetsChanged();
+    return true;
+}
+
+bool ChannelStripPresets::deletePreset(const QString& name)
+{
+    auto presets = m_root.value("presets").toObject();
+    if (!presets.contains(name)) return false;
+    presets.remove(name);
+    m_root["presets"] = presets;
+    if (!saveToDisk()) return false;
+    emit presetsChanged();
+    return true;
+}
+
+bool ChannelStripPresets::exportPresetToFile(const QString& name,
+                                             const QString& path) const
+{
+    const auto presets = m_root.value("presets").toObject();
+    if (!presets.contains(name)) return false;
+
+    // Single-preset shareable format: top-level object IS the preset
+    // body, plus a `name` field so importers can recover the name
+    // even if the file was renamed on disk.
+    QJsonObject out = presets.value(name).toObject();
+    out["name"] = name;
+    out["schema"] = "AetherSDR ChannelStripPreset v1";
+
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return false;
+    f.write(QJsonDocument(out).toJson(QJsonDocument::Indented));
+    return true;
+}
+
+bool ChannelStripPresets::exportLibraryToFile(const QString& path) const
+{
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return false;
+    f.write(QJsonDocument(m_root).toJson(QJsonDocument::Indented));
+    return true;
+}
+
+bool ChannelStripPresets::exportCurrentToFile(const QString& presetName,
+                                              const QString& path) const
+{
+    QJsonObject out = capturePresetJson();
+    out["name"] = presetName;
+    out["schema"] = "AetherSDR ChannelStripPreset v1";
+
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return false;
+    f.write(QJsonDocument(out).toJson(QJsonDocument::Indented));
+    return true;
+}
+
+QString ChannelStripPresets::importPresetFromFile(const QString& path)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly)) return QString();
+    const auto doc = QJsonDocument::fromJson(f.readAll());
+    if (!doc.isObject()) return QString();
+
+    const QJsonObject root = doc.object();
+    auto presets = m_root.value("presets").toObject();
+
+    QString firstImported;
+
+    // Full library form (has "presets" wrapper).
+    if (root.contains("presets") && root.value("presets").isObject()) {
+        const auto incoming = root.value("presets").toObject();
+        for (auto it = incoming.begin(); it != incoming.end(); ++it) {
+            if (!it.value().isObject()) continue;
+            QString name = it.key();
+            // De-collide on import: append " (imported)" if a same-name
+            // preset already exists in the local library, then suffix
+            // with numbers if needed.
+            if (presets.contains(name)) {
+                QString base = name + " (imported)";
+                QString candidate = base;
+                int n = 2;
+                while (presets.contains(candidate))
+                    candidate = base + QString(" %1").arg(n++);
+                name = candidate;
+            }
+            presets[name] = it.value().toObject();
+            if (firstImported.isEmpty()) firstImported = name;
+        }
+    } else {
+        // Single-preset form (top-level object IS the preset body).
+        QString name = root.value("name").toString();
+        if (name.trimmed().isEmpty()) {
+            // Fall back to filename without extension.
+            name = QFileInfo(path).completeBaseName();
+        }
+        if (name.trimmed().isEmpty()) return QString();
+        if (presets.contains(name)) {
+            QString base = name + " (imported)";
+            QString candidate = base;
+            int n = 2;
+            while (presets.contains(candidate))
+                candidate = base + QString(" %1").arg(n++);
+            name = candidate;
+        }
+        QJsonObject body = root;
+        body.remove("name");
+        body.remove("schema");
+        presets[name] = body;
+        firstImported = name;
+    }
+
+    if (firstImported.isEmpty()) return QString();
+    m_root["presets"] = presets;
+    if (!saveToDisk()) return QString();
+    emit presetsChanged();
+    return firstImported;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Capture: engine → JSON
+// ──────────────────────────────────────────────────────────────────
+
+QJsonObject ChannelStripPresets::capturePresetJson() const
+{
+    QJsonObject preset;
+    preset["createdBy"] = "AetherSDR";
+    preset["createdAt"] = QDateTime::currentDateTimeUtc()
+        .toString(Qt::ISODate);
+
+    if (!m_engine) return preset;
+
+    // Chain order.
+    {
+        QJsonArray chain;
+        for (auto s : m_engine->txChainStages()) {
+            const QString n = stageEnumToName(s);
+            if (!n.isEmpty()) chain.append(n);
+        }
+        preset["chain"] = chain;
+    }
+
+    // Gate.
+    if (auto* g = m_engine->clientGateTx()) {
+        QJsonObject o;
+        o["enabled"]      = g->isEnabled();
+        o["mode"]         = gateModeName(g->mode());
+        o["thresholdDb"]  = g->thresholdDb();
+        o["ratio"]        = g->ratio();
+        o["attackMs"]     = g->attackMs();
+        o["releaseMs"]    = g->releaseMs();
+        o["holdMs"]       = g->holdMs();
+        o["floorDb"]      = g->floorDb();
+        o["returnDb"]     = g->returnDb();
+        o["lookaheadMs"]  = g->lookaheadMs();
+        preset["gate"] = o;
+    }
+
+    // EQ.
+    if (auto* e = m_engine->clientEqTx()) {
+        QJsonObject o;
+        o["enabled"]         = e->isEnabled();
+        o["masterGain"]      = e->masterGain();
+        o["filterFamily"]    = eqFilterFamilyName(e->filterFamily());
+        o["activeBandCount"] = e->activeBandCount();
+        QJsonArray bands;
+        for (int i = 0; i < ClientEq::kMaxBands; ++i) {
+            const auto b = e->band(i);
+            QJsonObject bo;
+            bo["freqHz"]        = b.freqHz;
+            bo["gainDb"]        = b.gainDb;
+            bo["q"]             = b.q;
+            bo["type"]          = eqFilterTypeName(b.type);
+            bo["enabled"]       = b.enabled;
+            bo["slopeDbPerOct"] = b.slopeDbPerOct;
+            bands.append(bo);
+        }
+        o["bands"] = bands;
+        preset["eq"] = o;
+    }
+
+    // Comp.
+    if (auto* c = m_engine->clientCompTx()) {
+        QJsonObject o;
+        o["enabled"]          = c->isEnabled();
+        o["thresholdDb"]      = c->thresholdDb();
+        o["ratio"]            = c->ratio();
+        o["attackMs"]         = c->attackMs();
+        o["releaseMs"]        = c->releaseMs();
+        o["kneeDb"]           = c->kneeDb();
+        o["makeupDb"]         = c->makeupDb();
+        o["limiterEnabled"]   = c->limiterEnabled();
+        o["limiterCeilingDb"] = c->limiterCeilingDb();
+        preset["comp"] = o;
+    }
+
+    // De-Esser.
+    if (auto* d = m_engine->clientDeEssTx()) {
+        QJsonObject o;
+        o["enabled"]     = d->isEnabled();
+        o["frequencyHz"] = d->frequencyHz();
+        o["q"]           = d->q();
+        o["thresholdDb"] = d->thresholdDb();
+        o["amountDb"]    = d->amountDb();
+        o["attackMs"]    = d->attackMs();
+        o["releaseMs"]   = d->releaseMs();
+        preset["deess"] = o;
+    }
+
+    // Tube.
+    if (auto* t = m_engine->clientTubeTx()) {
+        QJsonObject o;
+        o["enabled"]        = t->isEnabled();
+        o["model"]          = tubeModelName(t->model());
+        o["driveDb"]        = t->driveDb();
+        o["biasAmount"]     = t->biasAmount();
+        o["tone"]           = t->tone();
+        o["outputGainDb"]   = t->outputGainDb();
+        o["dryWet"]         = t->dryWet();
+        o["envelopeAmount"] = t->envelopeAmount();
+        o["attackMs"]       = t->attackMs();
+        o["releaseMs"]      = t->releaseMs();
+        preset["tube"] = o;
+    }
+
+    // Pudu.
+    if (auto* p = m_engine->clientPuduTx()) {
+        QJsonObject o;
+        o["enabled"]        = p->isEnabled();
+        o["mode"]           = puduModeName(p->mode());
+        o["pooDriveDb"]     = p->pooDriveDb();
+        o["pooTuneHz"]      = p->pooTuneHz();
+        o["pooMix"]         = p->pooMix();
+        o["dooTuneHz"]      = p->dooTuneHz();
+        o["dooHarmonicsDb"] = p->dooHarmonicsDb();
+        o["dooMix"]         = p->dooMix();
+        preset["pudu"] = o;
+    }
+
+    // Reverb.
+    if (auto* r = m_engine->clientReverbTx()) {
+        QJsonObject o;
+        o["enabled"]    = r->isEnabled();
+        o["size"]       = r->size();
+        o["decayS"]     = r->decayS();
+        o["damping"]    = r->damping();
+        o["preDelayMs"] = r->preDelayMs();
+        o["mix"]        = r->mix();
+        preset["reverb"] = o;
+    }
+
+    return preset;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Apply: JSON → engine
+// ──────────────────────────────────────────────────────────────────
+
+void ChannelStripPresets::applyPresetJson(const QJsonObject& preset)
+{
+    if (!m_engine) return;
+
+    // Chain order.
+    if (preset.contains("chain") && preset.value("chain").isArray()) {
+        QVector<AudioEngine::TxChainStage> stages;
+        for (const auto& v : preset.value("chain").toArray()) {
+            const auto s = stageNameToEnum(v.toString());
+            if (s != AudioEngine::TxChainStage::None) stages.append(s);
+        }
+        if (!stages.isEmpty()) m_engine->setTxChainStages(stages);
+    }
+
+    // Gate.
+    if (auto* g = m_engine->clientGateTx();
+        g && preset.contains("gate") && preset.value("gate").isObject()) {
+        const auto o = preset.value("gate").toObject();
+        g->setEnabled(jbool(o, "enabled", g->isEnabled()));
+        g->setMode(gateModeFromName(jstr(o, "mode", gateModeName(g->mode()))));
+        g->setThresholdDb(jnum(o, "thresholdDb", g->thresholdDb()));
+        g->setRatio(jnum(o, "ratio", g->ratio()));
+        g->setAttackMs(jnum(o, "attackMs", g->attackMs()));
+        g->setReleaseMs(jnum(o, "releaseMs", g->releaseMs()));
+        g->setHoldMs(jnum(o, "holdMs", g->holdMs()));
+        g->setFloorDb(jnum(o, "floorDb", g->floorDb()));
+        g->setReturnDb(jnum(o, "returnDb", g->returnDb()));
+        g->setLookaheadMs(jnum(o, "lookaheadMs", g->lookaheadMs()));
+    }
+
+    // EQ.
+    if (auto* e = m_engine->clientEqTx();
+        e && preset.contains("eq") && preset.value("eq").isObject()) {
+        const auto o = preset.value("eq").toObject();
+        e->setEnabled(jbool(o, "enabled", e->isEnabled()));
+        e->setMasterGain(static_cast<float>(jnum(o, "masterGain", e->masterGain())));
+        e->setFilterFamily(eqFilterFamilyFromName(
+            jstr(o, "filterFamily", eqFilterFamilyName(e->filterFamily()))));
+        const int activeCount = static_cast<int>(jnum(o, "activeBandCount",
+                                                       e->activeBandCount()));
+        if (o.contains("bands") && o.value("bands").isArray()) {
+            const auto bands = o.value("bands").toArray();
+            const int n = std::min<int>(bands.size(), ClientEq::kMaxBands);
+            for (int i = 0; i < n; ++i) {
+                const auto bo = bands.at(i).toObject();
+                ClientEq::BandParams p = e->band(i);
+                p.freqHz = static_cast<float>(jnum(bo, "freqHz", p.freqHz));
+                p.gainDb = static_cast<float>(jnum(bo, "gainDb", p.gainDb));
+                p.q      = static_cast<float>(jnum(bo, "q", p.q));
+                p.type   = eqFilterTypeFromName(
+                    jstr(bo, "type", eqFilterTypeName(p.type)));
+                p.enabled = jbool(bo, "enabled", p.enabled);
+                p.slopeDbPerOct = static_cast<int>(
+                    jnum(bo, "slopeDbPerOct", p.slopeDbPerOct));
+                e->setBand(i, p);
+            }
+        }
+        e->setActiveBandCount(activeCount);
+    }
+
+    // Comp.
+    if (auto* c = m_engine->clientCompTx();
+        c && preset.contains("comp") && preset.value("comp").isObject()) {
+        const auto o = preset.value("comp").toObject();
+        c->setEnabled(jbool(o, "enabled", c->isEnabled()));
+        c->setThresholdDb(jnum(o, "thresholdDb", c->thresholdDb()));
+        c->setRatio(jnum(o, "ratio", c->ratio()));
+        c->setAttackMs(jnum(o, "attackMs", c->attackMs()));
+        c->setReleaseMs(jnum(o, "releaseMs", c->releaseMs()));
+        c->setKneeDb(jnum(o, "kneeDb", c->kneeDb()));
+        c->setMakeupDb(jnum(o, "makeupDb", c->makeupDb()));
+        c->setLimiterEnabled(jbool(o, "limiterEnabled", c->limiterEnabled()));
+        c->setLimiterCeilingDb(jnum(o, "limiterCeilingDb",
+                                    c->limiterCeilingDb()));
+    }
+
+    // De-Esser.
+    if (auto* d = m_engine->clientDeEssTx();
+        d && preset.contains("deess") && preset.value("deess").isObject()) {
+        const auto o = preset.value("deess").toObject();
+        d->setEnabled(jbool(o, "enabled", d->isEnabled()));
+        d->setFrequencyHz(jnum(o, "frequencyHz", d->frequencyHz()));
+        d->setQ(jnum(o, "q", d->q()));
+        d->setThresholdDb(jnum(o, "thresholdDb", d->thresholdDb()));
+        d->setAmountDb(jnum(o, "amountDb", d->amountDb()));
+        d->setAttackMs(jnum(o, "attackMs", d->attackMs()));
+        d->setReleaseMs(jnum(o, "releaseMs", d->releaseMs()));
+    }
+
+    // Tube.
+    if (auto* t = m_engine->clientTubeTx();
+        t && preset.contains("tube") && preset.value("tube").isObject()) {
+        const auto o = preset.value("tube").toObject();
+        t->setEnabled(jbool(o, "enabled", t->isEnabled()));
+        t->setModel(tubeModelFromName(jstr(o, "model", tubeModelName(t->model()))));
+        t->setDriveDb(jnum(o, "driveDb", t->driveDb()));
+        t->setBiasAmount(jnum(o, "biasAmount", t->biasAmount()));
+        t->setTone(jnum(o, "tone", t->tone()));
+        t->setOutputGainDb(jnum(o, "outputGainDb", t->outputGainDb()));
+        t->setDryWet(jnum(o, "dryWet", t->dryWet()));
+        t->setEnvelopeAmount(jnum(o, "envelopeAmount", t->envelopeAmount()));
+        t->setAttackMs(jnum(o, "attackMs", t->attackMs()));
+        t->setReleaseMs(jnum(o, "releaseMs", t->releaseMs()));
+    }
+
+    // Pudu.
+    if (auto* p = m_engine->clientPuduTx();
+        p && preset.contains("pudu") && preset.value("pudu").isObject()) {
+        const auto o = preset.value("pudu").toObject();
+        p->setEnabled(jbool(o, "enabled", p->isEnabled()));
+        p->setMode(puduModeFromName(jstr(o, "mode", puduModeName(p->mode()))));
+        p->setPooDriveDb(jnum(o, "pooDriveDb", p->pooDriveDb()));
+        p->setPooTuneHz(jnum(o, "pooTuneHz", p->pooTuneHz()));
+        p->setPooMix(jnum(o, "pooMix", p->pooMix()));
+        p->setDooTuneHz(jnum(o, "dooTuneHz", p->dooTuneHz()));
+        p->setDooHarmonicsDb(jnum(o, "dooHarmonicsDb", p->dooHarmonicsDb()));
+        p->setDooMix(jnum(o, "dooMix", p->dooMix()));
+    }
+
+    // Reverb.
+    if (auto* r = m_engine->clientReverbTx();
+        r && preset.contains("reverb") && preset.value("reverb").isObject()) {
+        const auto o = preset.value("reverb").toObject();
+        r->setEnabled(jbool(o, "enabled", r->isEnabled()));
+        r->setSize(jnum(o, "size", r->size()));
+        r->setDecayS(jnum(o, "decayS", r->decayS()));
+        r->setDamping(jnum(o, "damping", r->damping()));
+        r->setPreDelayMs(jnum(o, "preDelayMs", r->preDelayMs()));
+        r->setMix(jnum(o, "mix", r->mix()));
+    }
+}
+
+} // namespace AetherSDR

--- a/src/core/ChannelStripPresets.h
+++ b/src/core/ChannelStripPresets.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <QJsonObject>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+class AudioEngine;
+
+// JSON-backed preset library for the Aetherial Audio Channel Strip.
+//
+// Stored at ~/.config/AetherSDR/ChannelStrip.settings as a single
+// JSON document.  Live working state continues to live in
+// AetherSDR.settings via the existing per-DSP-module load/save paths
+// — this file is purely a preset library that the user explicitly
+// saves into and recalls from.
+//
+// Format:
+//   {
+//     "version": 1,
+//     "presets": {
+//       "Broadcast Voice": {
+//         "createdBy": "AetherSDR x.y.z",
+//         "createdAt": "ISO-8601",
+//         "chain":     ["Gate","Eq",...],
+//         "gate":      { ... },
+//         "eq":        { ... },
+//         "comp":      { ... },
+//         "deess":     { ... },
+//         "tube":      { ... },
+//         "pudu":      { ... },
+//         "reverb":    { ... }
+//       },
+//       "Contest Punch": { ... }
+//     }
+//   }
+//
+// Single-file Export writes a one-preset file with the same per-preset
+// schema at the top level (no "presets" wrapper) so it's easy to
+// share online.  Import accepts either form.
+class ChannelStripPresets : public QObject {
+    Q_OBJECT
+
+public:
+    explicit ChannelStripPresets(AudioEngine* engine,
+                                 QObject* parent = nullptr);
+
+    QStringList presetNames() const;              // sorted alpha
+    bool        hasPreset(const QString& name) const;
+
+    // Apply a stored preset to all engine modules.  Returns false if
+    // the preset doesn't exist.
+    bool loadPreset(const QString& name);
+
+    // Capture current engine state and save as a named preset.
+    // Overwrites any existing preset with the same name.
+    bool savePresetFromCurrent(const QString& name);
+
+    bool deletePreset(const QString& name);
+
+    // Export a stored preset to a single-preset JSON file for sharing.
+    bool exportPresetToFile(const QString& name,
+                            const QString& filePath) const;
+
+    // Export the entire local library (all presets) as a single JSON
+    // file in the same format as the on-disk store.  Useful for
+    // bundling a personal preset collection or backing up a setup.
+    bool exportLibraryToFile(const QString& filePath) const;
+
+    // Capture *current* engine state and write it as a single-preset
+    // JSON file under the given name.  Useful for "save the current
+    // mix straight to a shareable file" without first stashing it
+    // into the local library.
+    bool exportCurrentToFile(const QString& presetName,
+                             const QString& filePath) const;
+
+    // Reads a single-preset file OR a full library file, merges any
+    // presets it contains into the local store, and returns the name
+    // of the first preset imported (empty string on failure).
+    QString importPresetFromFile(const QString& filePath);
+
+signals:
+    void presetsChanged();
+
+private:
+    QString     filePath() const;
+    bool        loadFromDisk();
+    bool        saveToDisk() const;
+    QJsonObject capturePresetJson() const;
+    void        applyPresetJson(const QJsonObject& preset);
+
+    AudioEngine* m_engine{nullptr};
+    QJsonObject  m_root;
+};
+
+} // namespace AetherSDR

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -575,13 +575,44 @@ void TciServer::onTextMessage(const QString& msg)
                 QString source;
                 if (parts.size() >= 3)
                     source = parts[2].trimmed().toLower().remove(';');
-                const bool wantDax = source.isEmpty()
-                                  || source == QStringLiteral("dax")
-                                  || source == QStringLiteral("tci");
+                // The default DAX-routed path was unconditionally
+                // enabling dax=1 on the slice the moment a TCI client
+                // keyed up.  For voice modes (USB / LSB / AM / FM /
+                // CW) this clobbered the user's PC mic selection and
+                // they'd lose audio mid-QSO.  Restrict the DAX path to
+                // the modes that actually use it: clients still ask
+                // for DAX explicitly via `,dax` / `,tci` source args,
+                // but the empty-source default now picks the route
+                // based on the slice's mode (issue #2304).
+                const bool isDigitalMode = [&] {
+                    if (!m_model) return false;
+                    // Same TRX→slice lookup that TciProtocol uses:
+                    // index into m_model->slices() with trx, fall back
+                    // to by-id, then to first slice.
+                    auto sl = m_model->slices();
+                    SliceModel* s = nullptr;
+                    if (trx >= 0 && trx < sl.size()) {
+                        s = sl.at(trx);
+                    } else {
+                        for (auto* cand : sl)
+                            if (cand && cand->sliceId() == trx) { s = cand; break; }
+                        if (!s && !sl.isEmpty()) s = sl.first();
+                    }
+                    if (!s) return false;
+                    const QString m = s->mode();
+                    return m == QStringLiteral("DIGU")
+                        || m == QStringLiteral("DIGL")
+                        || m == QStringLiteral("RTTY")
+                        || m == QStringLiteral("FDV");
+                }();
+                const bool wantDax = source == QStringLiteral("dax")
+                                  || source == QStringLiteral("tci")
+                                  || (source.isEmpty() && isDigitalMode);
                 qCInfo(lcCat) << "TCI: trx request"
                               << "trx=" << trx
                               << "txOn=" << txOn
                               << "source=" << (source.isEmpty() ? QStringLiteral("[default]") : source)
+                              << "isDigital=" << isDigitalMode
                               << "route=" << (wantDax ? QStringLiteral("tci-audio") : QStringLiteral("radio-direct"));
                 if (txOn) {
                     if (wantDax) {

--- a/src/gui/AetherialAudioStrip.cpp
+++ b/src/gui/AetherialAudioStrip.cpp
@@ -1,0 +1,972 @@
+#include "AetherialAudioStrip.h"
+
+#include "StripChainWidget.h"
+#include "ClientEqApplet.h"
+#include "EditorFramelessTitleBar.h"
+#include "StripCompPanel.h"
+#include "StripDeEssPanel.h"
+#include "StripEqPanel.h"
+#include "StripGatePanel.h"
+#include "StripPuduPanel.h"
+#include "StripReverbPanel.h"
+#include "StripTubePanel.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ChannelStripPresets.h"
+#include "core/ClientComp.h"
+#include "core/ClientDeEss.h"
+#include "core/ClientEq.h"
+#include "core/ClientGate.h"
+#include "core/ClientPudu.h"
+#include "core/ClientReverb.h"
+#include "core/ClientTube.h"
+
+#include <QButtonGroup>
+#include <QByteArray>
+#include <QCloseEvent>
+#include <QComboBox>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QHBoxLayout>
+#include <QInputDialog>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QEvent>
+#include <QFrame>
+#include <QGridLayout>
+#include <QHideEvent>
+#include <QMouseEvent>
+#include <QMoveEvent>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QStandardPaths>
+#include <QVBoxLayout>
+#include <QWindow>
+
+namespace AetherSDR {
+
+namespace {
+constexpr int kResizeMargin = 6;
+}
+
+AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
+    , m_audio(engine)
+    , m_presets(new ChannelStripPresets(engine, this))
+{
+    connect(m_presets, &ChannelStripPresets::presetsChanged, this, [this]() {
+        rebuildPresetCombo(m_currentPresetName);
+    });
+    const QString title = QString::fromUtf8("Aetherial Audio \xe2\x80\x94 Channel Strip");
+    setWindowTitle(title);
+    setStyleSheet(
+        "QWidget { background: #0f0f1a; color: #d7e4f2; }"
+        "QFrame#stripGroupBox { border: 1px solid #2a3744;"
+        " border-radius: 4px; background: transparent; }");
+    setMinimumSize(1140, 1470);
+    resize(1140, 1470);
+
+    // Track mouse without buttons pressed so the resize cursor updates
+    // while hovering the bare margin around the embedded grid.
+    setMouseTracking(true);
+
+    // Outer layout has zero margins so the title bar can run edge-to-edge
+    // across the whole window (matching the applet ContainerTitleBar).
+    // The 6 px resize hit zone + 2 px breathing room lives on a nested
+    // content layout below the title bar.
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(0, 0, 0, 0);
+    root->setSpacing(0);
+
+    // Custom title bar styled to match the applet ContainerTitleBar:
+    // 18 px tall, blue-gradient background, 10 px bold title, trio of
+    // window-control buttons at the right.  Built inline rather than
+    // via EditorFramelessTitleBar because that widget is hard-wired to
+    // the editor look (20 px flat).  The strip wants the chrome family
+    // it shares with the docked applet panels.
+    {
+        m_titleBar = new QWidget(this);
+        m_titleBar->setFixedHeight(18);
+        m_titleBar->setAttribute(Qt::WA_StyledBackground, true);
+        m_titleBar->setStyleSheet(
+            "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
+            "stop:0 #5a7494, stop:0.5 #384e68, stop:1 #1e2e3e); "
+            "border-bottom: 1px solid #0a1a28; }");
+        m_titleBar->installEventFilter(this);
+
+        auto* row = new QHBoxLayout(m_titleBar);
+        row->setContentsMargins(6, 0, 2, 0);
+        row->setSpacing(4);
+
+        // Drag grip on the left — matches ContainerTitleBar.  Decorative
+        // only; actual drag is handled on the bar as a whole via the
+        // event filter installed below.
+        auto* grip = new QLabel(QString::fromUtf8("\xe2\x8b\xae\xe2\x8b\xae"),
+                                m_titleBar);
+        grip->setStyleSheet(
+            "QLabel { background: transparent; color: #a0b4c8;"
+            " font-size: 10px; }");
+        row->addWidget(grip);
+
+        auto* titleLbl = new QLabel(title, m_titleBar);
+        titleLbl->setStyleSheet(
+            "QLabel { background: transparent; color: #e0ecf4;"
+            " font-size: 10px; font-weight: bold; }");
+        row->addWidget(titleLbl);
+        row->addStretch();
+
+        const QString btnStyle =
+            "QPushButton { background: transparent; border: none;"
+            " color: #c8d8e8; font-size: 11px; font-weight: bold;"
+            " padding: 0px 4px; }"
+            "QPushButton:hover { color: #ffffff; }";
+        const QString closeBtnStyle =
+            "QPushButton { background: transparent; border: none;"
+            " color: #c8d8e8; font-size: 11px; font-weight: bold;"
+            " padding: 0px 4px; }"
+            "QPushButton:hover { color: #ffffff; background: #cc2030; }";
+
+        auto* minBtn = new QPushButton(QString::fromUtf8("\xe2\x80\x94"), m_titleBar);  // —
+        minBtn->setFixedSize(16, 16);
+        minBtn->setCursor(Qt::ArrowCursor);
+        minBtn->setStyleSheet(btnStyle);
+        minBtn->setToolTip("Minimize");
+        connect(minBtn, &QPushButton::clicked, this, &QWidget::showMinimized);
+        row->addWidget(minBtn);
+
+        auto* maxBtn = new QPushButton(QString::fromUtf8("\xe2\x96\xa1"), m_titleBar); // □
+        maxBtn->setFixedSize(16, 16);
+        maxBtn->setCursor(Qt::ArrowCursor);
+        maxBtn->setStyleSheet(btnStyle);
+        maxBtn->setToolTip("Maximize");
+        connect(maxBtn, &QPushButton::clicked, this, [this]() {
+            if (isMaximized()) showNormal(); else showMaximized();
+        });
+        row->addWidget(maxBtn);
+
+        auto* closeBtn = new QPushButton(QString::fromUtf8("\xc3\x97"), m_titleBar); // ×
+        closeBtn->setFixedSize(16, 16);
+        closeBtn->setCursor(Qt::ArrowCursor);
+        closeBtn->setStyleSheet(closeBtnStyle);
+        closeBtn->setToolTip("Close");
+        connect(closeBtn, &QPushButton::clicked, this, &QWidget::close);
+        row->addWidget(closeBtn);
+    }
+    root->addWidget(m_titleBar);
+
+    // Content area below the title bar — has the 8 px resize-hit margin
+    // so the title bar can stay flush to the window edges above.
+    auto* content = new QWidget(this);
+    auto* body = new QVBoxLayout(content);
+    body->setContentsMargins(8, 0, 8, 8);
+    body->setSpacing(8);
+    root->addWidget(content, 1);
+
+    // Top: horizontal CHAIN strip + record/play buttons inline at the
+    // right of the TX endpoint.  The buttons just emit signals; MainWindow
+    // wires them to the same PUDU monitor as the docked ClientChainApplet.
+    {
+        auto* chainRow = new QHBoxLayout;
+        chainRow->setContentsMargins(0, 0, 0, 0);
+        chainRow->setSpacing(6);
+
+        // TX / RX mode toggles — exclusive group, TX checked by default.
+        // Visual parity with the docked chain applet's mode buttons; the
+        // strip currently embeds TX panels only, so RX is present as a
+        // no-op placeholder until RX-side strip panels arrive.
+        const QString modeBtnStyle = QStringLiteral(
+            "QPushButton {"
+            "  background: #1a2a3a; border: 1px solid #2a4458;"
+            "  border-radius: 3px; color: #8aa8c0;"
+            "  font-size: 12px; font-weight: bold;"
+            "  padding: 2px 10px; min-width: 30px;"
+            "}"
+            "QPushButton:hover { background: #24384e; }"
+            "QPushButton:checked {"
+            "  background: #3a2a0e; color: #f2c14e;"
+            "  border: 1px solid #f2c14e;"
+            "}");
+
+        auto* modeGroup = new QButtonGroup(this);
+        modeGroup->setExclusive(true);
+
+        m_txBtn = new QPushButton("TX", content);
+        m_txBtn->setCheckable(true);
+        m_txBtn->setChecked(true);
+        m_txBtn->setFixedHeight(30);
+        m_txBtn->setStyleSheet(modeBtnStyle);
+        m_txBtn->setToolTip(tr("Show and edit the TX DSP chain"));
+        modeGroup->addButton(m_txBtn);
+        chainRow->addWidget(m_txBtn);
+
+        m_rxBtn = new QPushButton("RX", content);
+        m_rxBtn->setCheckable(true);
+        m_rxBtn->setFixedHeight(30);
+        m_rxBtn->setStyleSheet(modeBtnStyle);
+        m_rxBtn->setToolTip(tr(
+            "Show and edit the RX DSP chain (coming soon — strip "
+            "currently embeds TX panels only)"));
+        modeGroup->addButton(m_rxBtn);
+        chainRow->addWidget(m_rxBtn);
+
+        m_chain = new StripChainWidget(content);
+        m_chain->setAudioEngine(m_audio);
+        // Forward stage-bypass clicks out as our own signal so MainWindow
+        // can refresh the docked Chain applet's chain widget in step.
+        connect(m_chain, &StripChainWidget::stageEnabledChanged,
+                this,    &AetherialAudioStrip::stageEnabledChanged);
+        // ClientChainWidget no longer wraps; its sizeHint is sized for
+        // the actual stage count, so a no-stretch addWidget keeps the
+        // chain at its single-row natural width and the record / play
+        // buttons land flush to the right of TX.
+        chainRow->addWidget(m_chain);
+
+        // BYPASS — sits to the right of the chain's TX endpoint.  Same
+        // checkable amber toggle as the docked applet.
+        m_bypassBtn = new QPushButton("BYPASS", content);
+        m_bypassBtn->setCheckable(true);
+        m_bypassBtn->setFixedHeight(30);
+        m_bypassBtn->setStyleSheet(
+            "QPushButton {"
+            "  background: #1a2a3a; border: 1px solid #4a3020; border-radius: 3px;"
+            "  color: #c8a070; font-size: 12px; font-weight: bold;"
+            "  padding: 2px 10px;"
+            "}"
+            "QPushButton:hover { background: #3a2818; color: #f2c14e;"
+            "                    border: 1px solid #f2c14e; }"
+            "QPushButton:checked {"
+            "  background: #4a3818; color: #f2c14e; border: 1px solid #f2c14e;"
+            "}"
+            "QPushButton:checked:hover { background: #5a4a28; }");
+        m_bypassBtn->setToolTip(
+            tr("Disable every TX stage in the chain.  Click again to "
+               "restore the stages that were on before."));
+        connect(m_bypassBtn, &QPushButton::toggled,
+                this, &AetherialAudioStrip::onBypassToggled);
+        // Initial visual state from engine, then keep it in lock-step
+        // with the docked Chain applet's BYPASS button — both observe
+        // the engine's single bypass signal.
+        if (m_audio) {
+            QSignalBlocker blocker(m_bypassBtn);
+            m_bypassBtn->setChecked(m_audio->isTxBypassed());
+            connect(m_audio, &AudioEngine::txBypassChanged,
+                    this, [this](bool on) {
+                if (!m_bypassBtn) return;
+                QSignalBlocker b(m_bypassBtn);
+                m_bypassBtn->setChecked(on);
+                if (m_chain) m_chain->update();
+            });
+        }
+        chainRow->addWidget(m_bypassBtn);
+
+        const QString monBtnBase =
+            "QPushButton { background: rgba(255,255,255,15); border: none;"
+            " border-radius: 15px; font-size: 28px; padding: 0; }"
+            "QPushButton:hover:enabled { background: rgba(255,255,255,40); }"
+            "QPushButton:disabled { color: #303030;"
+            " background: rgba(255,255,255,5); }";
+        const QString recIdle  = monBtnBase + "QPushButton:enabled { color: #804040; }";
+        const QString playIdle = monBtnBase + "QPushButton:enabled { color: #406040; }";
+
+        m_monRecBtn = new QPushButton(QString::fromUtf8("\xe2\x8f\xba"), content); // ⏺
+        m_monRecBtn->setFixedSize(30, 30);
+        m_monRecBtn->setStyleSheet(recIdle);
+        m_monRecBtn->setToolTip(
+            "Record up to 30 s of post-PooDoo\xe2\x84\xa2 TX audio (MIC must "
+            "be set to PC and DAX off).  Click again to stop; playback "
+            "starts automatically.");
+        connect(m_monRecBtn, &QPushButton::clicked,
+                this, &AetherialAudioStrip::monitorRecordClicked);
+        chainRow->addWidget(m_monRecBtn);
+
+        m_monPlayBtn = new QPushButton(QString::fromUtf8("\xe2\x96\xb6"), content); // ▶
+        m_monPlayBtn->setFixedSize(30, 30);
+        m_monPlayBtn->setStyleSheet(playIdle);
+        m_monPlayBtn->setToolTip(
+            "Play back the captured PooDoo\xe2\x84\xa2 audio.  Click again "
+            "to cancel playback.");
+        connect(m_monPlayBtn, &QPushButton::clicked,
+                this, &AetherialAudioStrip::monitorPlayClicked);
+        chainRow->addWidget(m_monPlayBtn);
+
+        // Stretch absorbs surplus row width so the preset combo +
+        // Save/Delete cluster right-aligns against the strip's edge.
+        chainRow->addStretch();
+
+        // Preset combo — right-aligned at the far end of the chain row.
+        // Items: [stored presets...] [---separator---] [Import...] [Export...]
+        // Populated lazily by rebuildPresetCombo() below.
+        m_presetCombo = new QComboBox(content);
+        m_presetCombo->setMinimumWidth(220);
+        m_presetCombo->setFixedHeight(30);
+        m_presetCombo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+        m_presetCombo->setToolTip(
+            "Channel-strip presets — pick a stored preset to load it, or use "
+            "Import\xe2\x80\xa6 / Export\xe2\x80\xa6 to share presets via files.");
+        m_presetCombo->setStyleSheet(
+            "QComboBox { background: #1a2230; color: #d7e4f2;"
+            " border: 1px solid #2a3744; border-radius: 4px;"
+            " padding: 1px 6px; font-size: 12px; }"
+            "QComboBox:hover { border-color: #4a8fcf; }"
+            "QComboBox::drop-down { width: 14px; border: none; }"
+            "QComboBox QAbstractItemView { background: #1a2230;"
+            " color: #d7e4f2; selection-background-color: #2a4a6a;"
+            " border: 1px solid #2a3744; }");
+        connect(m_presetCombo,
+                QOverload<int>::of(&QComboBox::activated),
+                this, &AetherialAudioStrip::onPresetComboActivated);
+        chainRow->addWidget(m_presetCombo);
+
+        // Save / Delete buttons live to the right of the combo.  They
+        // share the rec/play button visual language but get their own
+        // hover tint so they're discoverable as preset-management.
+        const QString presetBtnBase =
+            "QPushButton { background: rgba(255,255,255,15); color: #d7e4f2;"
+            " border: none; border-radius: 4px; font-size: 12px;"
+            " padding: 0 10px; }"
+            "QPushButton:hover:enabled { background: rgba(255,255,255,40); }"
+            "QPushButton:disabled { color: #4a5562;"
+            " background: rgba(255,255,255,5); }";
+
+        m_presetSaveBtn = new QPushButton(tr("Save"), content);
+        m_presetSaveBtn->setFixedHeight(30);
+        m_presetSaveBtn->setStyleSheet(presetBtnBase);
+        m_presetSaveBtn->setToolTip(
+            tr("Save the current channel-strip state as a preset.  If a "
+               "preset is selected, its name is prefilled — saving with "
+               "the same name overwrites it; changing the name saves a "
+               "new preset alongside the original."));
+        connect(m_presetSaveBtn, &QPushButton::clicked,
+                this, &AetherialAudioStrip::doSavePreset);
+        chainRow->addWidget(m_presetSaveBtn);
+
+        m_presetDeleteBtn = new QPushButton(tr("Delete"), content);
+        m_presetDeleteBtn->setFixedHeight(30);
+        m_presetDeleteBtn->setStyleSheet(presetBtnBase);
+        m_presetDeleteBtn->setToolTip(
+            tr("Delete the currently selected preset from the local "
+               "library.  Disabled when no preset is selected."));
+        connect(m_presetDeleteBtn, &QPushButton::clicked,
+                this, &AetherialAudioStrip::doDeletePreset);
+        chainRow->addWidget(m_presetDeleteBtn);
+
+        rebuildPresetCombo();
+
+        body->addLayout(chainRow);
+    }
+
+    // Body: 4 rows × 2 cols, EQ row spans both cols.
+    auto* grid = new QGridLayout;
+    grid->setContentsMargins(0, 0, 0, 0);
+    grid->setHorizontalSpacing(8);
+    grid->setVerticalSpacing(8);
+
+    m_tube   = new StripTubePanel  (m_audio, this);
+    m_gate   = new StripGatePanel  (m_audio, this);
+    m_eq     = new StripEqPanel    (m_audio, this);
+    m_comp   = new StripCompPanel  (m_audio, this);
+    m_dess   = new StripDeEssPanel (m_audio, this);
+    m_pudu   = new StripPuduPanel  (m_audio, this);
+    m_reverb = new StripReverbPanel(m_audio, this);
+
+    // Wrap each panel in a frame so the strip reads as a row of distinct
+    // stages rather than one continuous panel.  Object name lets the
+    // stylesheet target the wrapper without bleeding into child widgets
+    // (Qt stylesheet cascade catches every QFrame descendant otherwise).
+    auto wrap = [](QWidget* panel, Qt::Alignment align = Qt::Alignment{}) -> QWidget* {
+        auto* frame = new QFrame;
+        frame->setObjectName("stripGroupBox");
+        auto* lay = new QVBoxLayout(frame);
+        lay->setContentsMargins(2, 2, 2, 2);
+        lay->setSpacing(0);
+        lay->addWidget(panel, 0, align);
+        return frame;
+    };
+
+    int r = 0;
+    grid->addWidget(wrap(m_tube),   r,   0);
+    grid->addWidget(wrap(m_gate),   r,   1);
+    grid->addWidget(wrap(m_eq),     ++r, 0, 1, 2);  // EQ spans both columns
+    grid->addWidget(wrap(m_comp),   ++r, 0);
+    grid->addWidget(wrap(m_dess),   r,   1);
+    // Both bottom-row panels pin to the top of their frames — the row's
+    // height is set by the taller cell elsewhere in the grid (e.g. EQ),
+    // and without AlignTop these panels would inflate / centre vertically
+    // and leave dead space inside the group box.
+    grid->addWidget(wrap(m_pudu,   Qt::AlignTop), ++r, 0);
+    grid->addWidget(wrap(m_reverb, Qt::AlignTop),   r, 1);
+
+    grid->setColumnStretch(0, 1);
+    grid->setColumnStretch(1, 1);
+    // Only the EQ row (index 1) absorbs extra vertical height — its
+    // canvas scales meaningfully with size.  Tube/Gate/Comp/DeEss/Pudu
+    // /Reverb rows stay at their content's natural height so the user
+    // doesn't see dead space inside the panel borders when the strip
+    // window is taller than the minimum.
+    grid->setRowStretch(0, 0);
+    grid->setRowStretch(1, 1);
+    grid->setRowStretch(2, 0);
+    grid->setRowStretch(3, 0);
+
+    body->addLayout(grid, 1);
+
+    // Wire each panel to its TX-side engine.  The panels' showForTx() /
+    // showForPath() methods do this — they also call show() / raise() /
+    // activateWindow() which are no-ops on embedded children.  Without
+    // this, the EQ icon row + param row collapse to zero height because
+    // they have no engine to enumerate bands for, and the canvas displays
+    // the "(no EQ connected)" placeholder.
+    m_tube->showForTx();
+    m_gate->showForTx();
+    m_eq->showForPath(ClientEqApplet::Path::Tx);
+    m_comp->showForTx();
+    m_dess->showForTx();
+    m_pudu->showForTx();
+    m_reverb->showForTx();
+
+    // Forward the EQ panel's cutoff-drag signal to the strip's public
+    // signal so MainWindow can wire it the same way it wires the
+    // floating ClientEqEditor.
+    connect(m_eq, &StripEqPanel::cutoffsDragRequested,
+            this, &AetherialAudioStrip::cutoffsDragRequested);
+
+    // Hide the min / max / close trio on each embedded panel's title bar
+    // — the strip owns the window controls, so each panel just needs its
+    // name plate.  dynamic_cast (rather than findChild) because
+    // EditorFramelessTitleBar has no Q_OBJECT macro; RTTI works fine and
+    // we don't need to reach into every Strip*Panel to expose its title
+    // bar member.
+    //
+    // Same pass also rewrites each panel's own QSS so the legacy
+    // `#08121d` band colour (inherited from when the panels were
+    // duplicated from the floating-editor sources) becomes `#0f0f1a` to
+    // match SMeterWidget / applet-panel chrome.  Qt always lets a
+    // child's own stylesheet win over a parent's, regardless of selector
+    // specificity, so a strip-level override doesn't reach these — the
+    // only way to override without editing every Strip*Panel source is
+    // to rewrite their stylesheets in place at construction.
+    auto recolour = [](QWidget* w) {
+        QString s = w->styleSheet();
+        if (s.contains("#08121d")) {
+            s.replace("#08121d", "#0f0f1a");
+            w->setStyleSheet(s);
+        }
+    };
+    for (QWidget* p : { static_cast<QWidget*>(m_tube),
+                        static_cast<QWidget*>(m_gate),
+                        static_cast<QWidget*>(m_eq),
+                        static_cast<QWidget*>(m_comp),
+                        static_cast<QWidget*>(m_dess),
+                        static_cast<QWidget*>(m_pudu),
+                        static_cast<QWidget*>(m_reverb) }) {
+        recolour(p);
+        for (QObject* child : p->children()) {
+            if (auto* tb = dynamic_cast<EditorFramelessTitleBar*>(child)) {
+                tb->setControlsVisible(false);
+                recolour(tb);
+                break;
+            }
+        }
+    }
+
+    restoreGeometryFromSettings();
+}
+
+AetherialAudioStrip::~AetherialAudioStrip() = default;
+
+void AetherialAudioStrip::setTxFilterCutoffs(int lowHz, int highHz)
+{
+    if (m_eq) m_eq->setTxFilterCutoffs(lowHz, highHz);
+}
+
+namespace {
+constexpr const char* kMonBtnBase =
+    "QPushButton { background: rgba(255,255,255,15); border: none;"
+    " border-radius: 10px; font-size: 11px; padding: 0; }"
+    "QPushButton:hover:enabled { background: rgba(255,255,255,40); }"
+    "QPushButton:disabled { color: #303030;"
+    " background: rgba(255,255,255,5); }";
+constexpr const char* kRecIdle    = "QPushButton:enabled { color: #804040; }";
+constexpr const char* kRecActive  = "QPushButton { color: #ff2020;"
+                                    " background: rgba(255,50,50,60); }";
+constexpr const char* kPlayIdle   = "QPushButton:enabled { color: #406040; }";
+constexpr const char* kPlayActive = "QPushButton { color: #30d050;"
+                                    " background: rgba(50,200,80,60); }";
+} // namespace
+
+void AetherialAudioStrip::setMonitorRecording(bool on)
+{
+    m_monRecording = on;
+    if (m_monRecBtn) {
+        m_monRecBtn->setStyleSheet(on ? QString(kMonBtnBase) + kRecActive
+                                      : QString(kMonBtnBase) + kRecIdle);
+    }
+}
+
+void AetherialAudioStrip::setMonitorPlaying(bool on)
+{
+    m_monPlaying = on;
+    if (m_monPlayBtn) {
+        m_monPlayBtn->setStyleSheet(on ? QString(kMonBtnBase) + kPlayActive
+                                       : QString(kMonBtnBase) + kPlayIdle);
+    }
+}
+
+void AetherialAudioStrip::setMonitorHasRecording(bool has)
+{
+    m_monHasRecording = has;
+    if (m_monPlayBtn)
+        m_monPlayBtn->setEnabled(has || m_monPlaying);
+}
+
+void AetherialAudioStrip::setMicInputReady(bool ready)
+{
+    if (m_chain) m_chain->setMicInputReady(ready);
+}
+
+void AetherialAudioStrip::setTxActive(bool active)
+{
+    if (m_chain) m_chain->setTxActive(active);
+}
+
+void AetherialAudioStrip::refreshChainPaint()
+{
+    if (m_chain) m_chain->update();
+}
+
+void AetherialAudioStrip::saveGeometryToSettings()
+{
+    if (m_restoring) return;
+    auto& s = AppSettings::instance();
+    s.setValue("AetherialStripGeometry", saveGeometry().toBase64());
+    s.save();
+}
+
+void AetherialAudioStrip::restoreGeometryFromSettings()
+{
+    auto& s = AppSettings::instance();
+    const QByteArray geom = QByteArray::fromBase64(
+        s.value("AetherialStripGeometry").toString().toUtf8());
+    if (geom.isEmpty()) return;
+
+    m_restoring = true;
+    restoreGeometry(geom);
+    m_restoring = false;
+}
+
+void AetherialAudioStrip::closeEvent(QCloseEvent* ev)
+{
+    saveGeometryToSettings();
+    auto& s = AppSettings::instance();
+    s.setValue("AetherialStripVisible", "False");
+    s.save();
+    QWidget::closeEvent(ev);
+}
+
+void AetherialAudioStrip::moveEvent(QMoveEvent* ev)
+{
+    saveGeometryToSettings();
+    QWidget::moveEvent(ev);
+}
+
+void AetherialAudioStrip::resizeEvent(QResizeEvent* ev)
+{
+    saveGeometryToSettings();
+    QWidget::resizeEvent(ev);
+}
+
+void AetherialAudioStrip::showEvent(QShowEvent* ev)
+{
+    auto& s = AppSettings::instance();
+    s.setValue("AetherialStripVisible", "True");
+    s.save();
+    QWidget::showEvent(ev);
+}
+
+void AetherialAudioStrip::hideEvent(QHideEvent* ev)
+{
+    auto& s = AppSettings::instance();
+    s.setValue("AetherialStripVisible", "False");
+    s.save();
+    QWidget::hideEvent(ev);
+}
+
+Qt::Edges AetherialAudioStrip::edgesAt(const QPoint& pos) const
+{
+    if (isMaximized() || isFullScreen())
+        return {};
+
+    Qt::Edges edges;
+    if (pos.x() <= kResizeMargin)
+        edges |= Qt::LeftEdge;
+    else if (pos.x() >= width() - kResizeMargin)
+        edges |= Qt::RightEdge;
+    if (pos.y() <= kResizeMargin)
+        edges |= Qt::TopEdge;
+    else if (pos.y() >= height() - kResizeMargin)
+        edges |= Qt::BottomEdge;
+    return edges;
+}
+
+void AetherialAudioStrip::updateResizeCursor(const QPoint& pos)
+{
+    const Qt::Edges edges = edgesAt(pos);
+    Qt::CursorShape shape = Qt::ArrowCursor;
+    // Two diagonals → SizeFDiag (↘↖); the other two → SizeBDiag (↙↗).
+    if ((edges & (Qt::LeftEdge | Qt::TopEdge))     == (Qt::LeftEdge | Qt::TopEdge)
+        || (edges & (Qt::RightEdge | Qt::BottomEdge)) == (Qt::RightEdge | Qt::BottomEdge)) {
+        shape = Qt::SizeFDiagCursor;
+    } else if ((edges & (Qt::RightEdge | Qt::TopEdge))    == (Qt::RightEdge | Qt::TopEdge)
+        ||     (edges & (Qt::LeftEdge | Qt::BottomEdge)) == (Qt::LeftEdge | Qt::BottomEdge)) {
+        shape = Qt::SizeBDiagCursor;
+    } else if (edges & (Qt::LeftEdge | Qt::RightEdge)) {
+        shape = Qt::SizeHorCursor;
+    } else if (edges & (Qt::TopEdge | Qt::BottomEdge)) {
+        shape = Qt::SizeVerCursor;
+    }
+    setCursor(shape);
+}
+
+void AetherialAudioStrip::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (!(ev->buttons() & Qt::LeftButton))
+        updateResizeCursor(ev->pos());
+    QWidget::mouseMoveEvent(ev);
+}
+
+void AetherialAudioStrip::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() == Qt::LeftButton) {
+        const Qt::Edges edges = edgesAt(ev->pos());
+        if (edges) {
+            if (auto* h = windowHandle()) {
+                h->startSystemResize(edges);
+                ev->accept();
+                return;
+            }
+        }
+    }
+    QWidget::mousePressEvent(ev);
+}
+
+void AetherialAudioStrip::leaveEvent(QEvent* ev)
+{
+    setCursor(Qt::ArrowCursor);
+    QWidget::leaveEvent(ev);
+}
+
+bool AetherialAudioStrip::eventFilter(QObject* obj, QEvent* ev)
+{
+    // Drag-to-move via the custom title bar.  The trio buttons are
+    // independent QPushButtons that consume the press themselves, so
+    // this only fires on the bare title-bar background between the
+    // title text and the trio.
+    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonPress) {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (me->button() == Qt::LeftButton) {
+            if (auto* h = windowHandle()) {
+                h->startSystemMove();
+                me->accept();
+                return true;
+            }
+        }
+    }
+    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonDblClick) {
+        if (isMaximized()) showNormal();
+        else               showMaximized();
+        ev->accept();
+        return true;
+    }
+    return QWidget::eventFilter(obj, ev);
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Master bypass
+// ──────────────────────────────────────────────────────────────────
+
+void AetherialAudioStrip::onBypassToggled(bool checked)
+{
+    if (!m_audio) return;
+    // Engine owns the bypass snapshot — both this widget and the docked
+    // Chain applet route through setTxBypassed() and observe
+    // txBypassChanged() to keep their buttons in lock-step.
+    m_audio->setTxBypassed(checked);
+    if (m_chain) m_chain->update();
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Preset combo box
+// ──────────────────────────────────────────────────────────────────
+//
+// Items laid out as:
+//   0..N-1      stored preset names (alphabetic)
+//   N           "──────────"  (disabled separator)
+//   N+1         "Import\xe2\x80\xa6"
+//   N+2         "Export\xe2\x80\xa6"
+//
+// We deliberately use index sentinels (UserRole) rather than text
+// matching so localising the action labels later is safe.
+
+namespace {
+constexpr int kRolePresetName       = Qt::UserRole + 1;
+constexpr int kRoleAction           = Qt::UserRole + 2;
+constexpr int kActionImport         = 1;
+constexpr int kActionExportPreset   = 2;
+constexpr int kActionExportLibrary  = 3;
+}
+
+void AetherialAudioStrip::rebuildPresetCombo(const QString& selectName)
+{
+    if (!m_presetCombo || !m_presets) return;
+
+    m_buildingCombo = true;
+    m_presetCombo->clear();
+
+    int selectIdx = -1;
+    const auto names = m_presets->presetNames();
+    for (const auto& n : names) {
+        m_presetCombo->addItem(n);
+        const int row = m_presetCombo->count() - 1;
+        m_presetCombo->setItemData(row, n, kRolePresetName);
+        if (!selectName.isEmpty() && n == selectName) selectIdx = row;
+    }
+
+    // Visual separator — use addSeparator() so it renders as a thin
+    // line in the popup.  When the popup is closed and the separator
+    // is the *current* item, the combo would render an empty cell;
+    // we never let that happen because activating the separator is
+    // a no-op (handled in onPresetComboActivated).
+    if (!names.isEmpty()) m_presetCombo->insertSeparator(m_presetCombo->count());
+
+    m_presetCombo->addItem(QString::fromUtf8("Import\xe2\x80\xa6"));
+    m_presetCombo->setItemData(m_presetCombo->count() - 1,
+                               kActionImport, kRoleAction);
+
+    m_presetCombo->addItem(QString::fromUtf8("Export Preset\xe2\x80\xa6"));
+    m_presetCombo->setItemData(m_presetCombo->count() - 1,
+                               kActionExportPreset, kRoleAction);
+
+    m_presetCombo->addItem(QString::fromUtf8("Export Library\xe2\x80\xa6"));
+    m_presetCombo->setItemData(m_presetCombo->count() - 1,
+                               kActionExportLibrary, kRoleAction);
+
+    if (selectIdx >= 0) {
+        m_presetCombo->setCurrentIndex(selectIdx);
+        m_currentPresetName = selectName;
+    } else if (!m_currentPresetName.isEmpty()) {
+        // Active preset was deleted — reset display.
+        m_presetCombo->setCurrentIndex(-1);
+        m_presetCombo->setEditText(QString());
+        m_currentPresetName.clear();
+    } else {
+        m_presetCombo->setCurrentIndex(-1);
+    }
+
+    if (m_presetCombo->currentIndex() < 0 && names.isEmpty()) {
+        // No presets stored yet — show placeholder text.
+        m_presetCombo->setPlaceholderText(
+            QString::fromUtf8("Presets\xe2\x80\xa6"));
+    } else if (m_presetCombo->currentIndex() < 0) {
+        m_presetCombo->setPlaceholderText(
+            QString::fromUtf8("Pick a preset\xe2\x80\xa6"));
+    }
+
+    m_buildingCombo = false;
+    updatePresetButtonEnable();
+}
+
+void AetherialAudioStrip::updatePresetButtonEnable()
+{
+    // Delete is only meaningful when a stored preset is selected — i.e.
+    // m_currentPresetName names a preset that still exists in the
+    // library.  Save is always enabled (it can name a new preset or
+    // overwrite the active one).
+    const bool hasActive = m_presets
+        && !m_currentPresetName.isEmpty()
+        && m_presets->hasPreset(m_currentPresetName);
+    if (m_presetDeleteBtn) m_presetDeleteBtn->setEnabled(hasActive);
+}
+
+void AetherialAudioStrip::onPresetComboActivated(int idx)
+{
+    if (m_buildingCombo || !m_presetCombo || !m_presets || idx < 0) return;
+
+    const auto actionVar = m_presetCombo->itemData(idx, kRoleAction);
+    if (actionVar.isValid()) {
+        const int action = actionVar.toInt();
+        // Reset display to the active preset (if any) so the action
+        // label doesn't get stuck in the combo's edit field.
+        rebuildPresetCombo(m_currentPresetName);
+        if (action == kActionImport)              doImportPreset();
+        else if (action == kActionExportPreset)   doExportPreset();
+        else if (action == kActionExportLibrary)  doExportLibrary();
+        return;
+    }
+
+    const auto nameVar = m_presetCombo->itemData(idx, kRolePresetName);
+    if (!nameVar.isValid()) return;
+    const QString name = nameVar.toString();
+    if (m_presets->loadPreset(name)) {
+        m_currentPresetName = name;
+    }
+    updatePresetButtonEnable();
+}
+
+void AetherialAudioStrip::doImportPreset()
+{
+    const QString defaultDir = QStandardPaths::writableLocation(
+        QStandardPaths::DocumentsLocation);
+    const QString path = QFileDialog::getOpenFileName(
+        this, tr("Import Channel Strip Preset"),
+        defaultDir,
+        tr("Channel strip preset (*.json *.aetherpreset);;All files (*)"));
+    if (path.isEmpty()) return;
+
+    const QString imported = m_presets->importPresetFromFile(path);
+    if (imported.isEmpty()) {
+        QMessageBox::warning(this, tr("Import failed"),
+            tr("Could not read a valid channel-strip preset from:\n%1")
+                .arg(path));
+        return;
+    }
+    // Apply it immediately so the user sees the imported preset live.
+    if (m_presets->loadPreset(imported)) m_currentPresetName = imported;
+    rebuildPresetCombo(m_currentPresetName);
+}
+
+void AetherialAudioStrip::doExportPreset()
+{
+    // Ask the user for a preset name + destination path.  The name
+    // gets baked into the file body, so peers who import it see the
+    // author's intended name even if the filename is changed later.
+    bool ok = false;
+    const QString defaultName = m_currentPresetName.isEmpty()
+        ? tr("My Preset")
+        : m_currentPresetName;
+    const QString name = QInputDialog::getText(
+        this,
+        tr("Export Channel Strip Preset"),
+        tr("Preset name (will be saved into the file and added to your "
+           "local library):"),
+        QLineEdit::Normal, defaultName, &ok);
+    if (!ok || name.trimmed().isEmpty()) return;
+
+    const QString defaultDir = QStandardPaths::writableLocation(
+        QStandardPaths::DocumentsLocation);
+    QString suggested = defaultDir + "/" + name + ".json";
+    const QString path = QFileDialog::getSaveFileName(
+        this, tr("Export Channel Strip Preset"),
+        suggested,
+        tr("Channel strip preset (*.json);;All files (*)"));
+    if (path.isEmpty()) return;
+
+    // Save into the local library first so the new preset shows up
+    // in the dropdown straight away, *then* write it out for sharing
+    // (the on-disk file mirrors what Import would round-trip back).
+    if (!m_presets->savePresetFromCurrent(name)) {
+        QMessageBox::warning(this, tr("Export failed"),
+            tr("Could not save preset to local library."));
+        return;
+    }
+    if (!m_presets->exportPresetToFile(name, path)) {
+        QMessageBox::warning(this, tr("Export failed"),
+            tr("Could not write preset file:\n%1").arg(path));
+        return;
+    }
+    m_currentPresetName = name;
+    rebuildPresetCombo(m_currentPresetName);
+}
+
+void AetherialAudioStrip::doExportLibrary()
+{
+    if (!m_presets) return;
+    if (m_presets->presetNames().isEmpty()) {
+        QMessageBox::information(this, tr("Export Library"),
+            tr("Your local preset library is empty — save at least one "
+               "preset before exporting."));
+        return;
+    }
+
+    const QString defaultDir = QStandardPaths::writableLocation(
+        QStandardPaths::DocumentsLocation);
+    const QString suggested = defaultDir + "/AetherSDR-ChannelStrip-Library.json";
+    const QString path = QFileDialog::getSaveFileName(
+        this, tr("Export Channel Strip Library"),
+        suggested,
+        tr("Channel strip preset library (*.json);;All files (*)"));
+    if (path.isEmpty()) return;
+
+    if (!m_presets->exportLibraryToFile(path)) {
+        QMessageBox::warning(this, tr("Export failed"),
+            tr("Could not write library file:\n%1").arg(path));
+    }
+}
+
+void AetherialAudioStrip::doSavePreset()
+{
+    if (!m_presets) return;
+
+    bool ok = false;
+    const QString prefill = m_currentPresetName;  // empty if nothing active
+    const QString entered = QInputDialog::getText(
+        this,
+        tr("Save Channel Strip Preset"),
+        tr("Preset name:"),
+        QLineEdit::Normal,
+        prefill,
+        &ok);
+    if (!ok) return;
+    const QString name = entered.trimmed();
+    if (name.isEmpty()) return;
+
+    // Same name as the currently-active preset → overwrite confirmation.
+    // Different name OR no preset was active → save straight through (no
+    // prompt) even if the new name happens to collide with another stored
+    // preset, per spec ("If they change the name then it should be stored
+    // as a new preset, no confirmation required").
+    if (!prefill.isEmpty() && name == prefill && m_presets->hasPreset(name)) {
+        const auto reply = QMessageBox::question(
+            this,
+            tr("Overwrite Preset?"),
+            tr("A preset named \"%1\" already exists.  Overwrite it with "
+               "the current channel-strip settings?").arg(name),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+        if (reply != QMessageBox::Yes) return;
+    }
+
+    if (!m_presets->savePresetFromCurrent(name)) {
+        QMessageBox::warning(this, tr("Save failed"),
+            tr("Could not write preset to local library."));
+        return;
+    }
+    m_currentPresetName = name;
+    rebuildPresetCombo(m_currentPresetName);
+}
+
+void AetherialAudioStrip::doDeletePreset()
+{
+    if (!m_presets || m_currentPresetName.isEmpty()) return;
+    if (!m_presets->hasPreset(m_currentPresetName)) return;
+
+    const auto reply = QMessageBox::question(
+        this,
+        tr("Delete Preset?"),
+        tr("Delete the preset \"%1\" from your local library?  This "
+           "cannot be undone.").arg(m_currentPresetName),
+        QMessageBox::Yes | QMessageBox::No,
+        QMessageBox::No);
+    if (reply != QMessageBox::Yes) return;
+
+    const QString deleted = m_currentPresetName;
+    if (!m_presets->deletePreset(deleted)) {
+        QMessageBox::warning(this, tr("Delete failed"),
+            tr("Could not remove preset from local library."));
+        return;
+    }
+    m_currentPresetName.clear();
+    rebuildPresetCombo();
+}
+
+} // namespace AetherSDR

--- a/src/gui/AetherialAudioStrip.h
+++ b/src/gui/AetherialAudioStrip.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include "ClientEqApplet.h"   // ClientEqApplet::Path enum
+#include "core/AudioEngine.h" // AudioEngine::TxChainStage in signal sig
+
+#include <QWidget>
+
+class QPushButton;
+class QComboBox;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ChannelStripPresets;
+class StripChainWidget;
+class EditorFramelessTitleBar;
+class StripTubePanel;
+class StripGatePanel;
+class StripEqPanel;
+class StripCompPanel;
+class StripDeEssPanel;
+class StripPuduPanel;
+class StripReverbPanel;
+
+// Aetherial Audio Channel Strip — unified TX DSP window.
+//
+// First-iteration plumbing for issue #2301.  Toplevel `Qt::Window`
+// that embeds all 7 client-side TX DSP stage panels in a single
+// view, with a horizontal `ClientChainWidget` at the top for chain
+// ordering / bypass.  Per-stage editors and applets continue to
+// work alongside this window during iteration; step 6 of the plan
+// removes them.
+//
+// Geometry persists via AppSettings("AetherialStripGeometry").
+// Visibility persists via AppSettings("AetherialStripVisible") so
+// the strip reopens at last position on startup.
+class AetherialAudioStrip : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit AetherialAudioStrip(AudioEngine* engine, QWidget* parent = nullptr);
+    ~AetherialAudioStrip() override;
+
+    // Forward radio TX filter cutoffs to the embedded EQ canvas so the
+    // dashed yellow filter-edge guide lines render here too.  MainWindow
+    // calls this from its txFilterCutoffChanged subscription, the same
+    // way it does for the floating ClientEqEditor.
+    void setTxFilterCutoffs(int lowHz, int highHz);
+
+    // Mirrored from ClientChainApplet so the strip's own record / play
+    // buttons share the PUDU monitor in MainWindow.
+    void setMonitorRecording(bool on);
+    void setMonitorPlaying(bool on);
+    void setMonitorHasRecording(bool has);
+
+    // MIC endpoint goes green when PC mic is selected and DAX is off
+    // (i.e. PooDoo is actually in the TX signal path).  TX endpoint
+    // pulses red while the user is transmitting on their own slice.
+    // Both forward to the embedded StripChainWidget.
+    void setMicInputReady(bool ready);
+    void setTxActive(bool active);
+
+    // Repaint the embedded StripChainWidget — used by MainWindow when
+    // the docked Chain applet toggles a stage so the strip's tile
+    // visuals stay in sync.  Engine state is the source of truth; this
+    // just nudges the widget to repaint from it.
+    void refreshChainPaint();
+
+signals:
+    // Re-emitted from the embedded StripEqPanel when the user drags one
+    // of the dashed cutoff lines.  MainWindow connects this to the same
+    // handler as ClientEqEditor::cutoffsDragRequested so dragging in the
+    // strip writes the same TX filter command to the radio.
+    void cutoffsDragRequested(ClientEqApplet::Path path,
+                              int audioLowHz, int audioHighHz);
+
+    // Record / playback button clicks — same semantics as
+    // ClientChainApplet::monitorRecordClicked / monitorPlayClicked.
+    void monitorRecordClicked();
+    void monitorPlayClicked();
+
+    // Re-emitted from the embedded StripChainWidget when the user
+    // single-clicks a stage tile to toggle its bypass.  MainWindow
+    // routes this to the same handler as ClientChainApplet's signal
+    // so the docked Chain applet's chain widget repaints in lock-step.
+    void stageEnabledChanged(AudioEngine::TxChainStage stage, bool enabled);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+    // Frameless 8-axis resize: 4 edges + 4 corners.  Mouse hover on
+    // the bare margin around the embedded grid updates the cursor;
+    // press starts a compositor-managed resize via startSystemResize.
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void leaveEvent(QEvent* ev) override;
+    bool eventFilter(QObject* obj, QEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+    Qt::Edges edgesAt(const QPoint& pos) const;
+    void updateResizeCursor(const QPoint& pos);
+
+    // Master bypass — snapshot all enabled TX stages, then disable
+    // them.  Restores the snapshot on uncheck.  Mirrors the docked
+    // ClientChainApplet's BYPASS button.
+    void onBypassToggled(bool checked);
+
+    // Preset combo helpers.
+    void rebuildPresetCombo(const QString& selectName = QString());
+    void onPresetComboActivated(int idx);
+    void doImportPreset();
+    void doExportPreset();
+    void doExportLibrary();
+    void doSavePreset();
+    void doDeletePreset();
+    void updatePresetButtonEnable();
+
+    AudioEngine*         m_audio{nullptr};
+    ChannelStripPresets* m_presets{nullptr};
+    QWidget*             m_titleBar{nullptr};   // custom inline ContainerTitleBar-styled bar
+    StripChainWidget*    m_chain{nullptr};
+    QPushButton*         m_txBtn{nullptr};
+    QPushButton*         m_rxBtn{nullptr};
+    QPushButton*         m_bypassBtn{nullptr};
+    QPushButton*         m_monRecBtn{nullptr};
+    QPushButton*         m_monPlayBtn{nullptr};
+    QComboBox*           m_presetCombo{nullptr};
+    QPushButton*         m_presetSaveBtn{nullptr};
+    QPushButton*         m_presetDeleteBtn{nullptr};
+    QString              m_currentPresetName;
+    bool                 m_buildingCombo{false};
+    bool               m_monRecording{false};
+    bool               m_monPlaying{false};
+    bool               m_monHasRecording{false};
+    StripTubePanel*    m_tube{nullptr};
+    StripGatePanel*    m_gate{nullptr};
+    StripEqPanel*      m_eq{nullptr};
+    StripCompPanel*    m_comp{nullptr};
+    StripDeEssPanel*   m_dess{nullptr};
+    StripPuduPanel*    m_pudu{nullptr};
+    StripReverbPanel*  m_reverb{nullptr};
+    bool               m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientChainApplet.cpp
+++ b/src/gui/ClientChainApplet.cpp
@@ -200,7 +200,27 @@ ClientChainApplet::ClientChainApplet(QWidget* parent) : QWidget(parent)
         "QLabel { color: #607888; font-size: 9px;"
         " background: transparent; border: none; }");
     m_hint->setWordWrap(false);
-    outer->addWidget(m_hint);
+
+    // Easter-egg nub at the bottom-right — opens the Aetherial Audio
+    // Channel Strip (unified TX DSP window, issue #2301).  Bare egg
+    // glyph, no chrome — discoverable only to people who know it's
+    // there until the strip becomes canonical.
+    m_stripNub = new QPushButton(QString::fromUtf8("\xF0\x9F\xA5\x9A"), this);
+    m_stripNub->setFixedSize(16, 16);
+    m_stripNub->setFlat(true);
+    m_stripNub->setFocusPolicy(Qt::NoFocus);
+    m_stripNub->setStyleSheet(
+        "QPushButton { background: transparent; border: none;"
+        " font-size: 11px; padding: 0; }");
+    connect(m_stripNub, &QPushButton::clicked,
+            this, &ClientChainApplet::aetherialStripToggleRequested);
+
+    auto* hintRow = new QHBoxLayout;
+    hintRow->setContentsMargins(0, 0, 0, 0);
+    hintRow->setSpacing(4);
+    hintRow->addWidget(m_hint, 1);
+    hintRow->addWidget(m_stripNub, 0, Qt::AlignBottom | Qt::AlignRight);
+    outer->addLayout(hintRow);
 
     connect(m_chain, &ClientChainWidget::editRequested,
             this, &ClientChainApplet::editRequested);
@@ -236,6 +256,25 @@ void ClientChainApplet::setAudioEngine(AudioEngine* engine)
     m_audio = engine;
     if (m_chain)   m_chain->setAudioEngine(engine);
     if (m_rxChain) m_rxChain->setAudioEngine(engine);
+
+    // Master TX bypass is now an engine-owned state — observe its
+    // signal so the BYPASS button mirrors clicks from the channel
+    // strip's BYPASS button (and vice versa).  Only update the visual
+    // when we're actually showing the TX side.
+    if (m_audio && m_bypassBtn) {
+        QSignalBlocker blocker(m_bypassBtn);
+        if (m_mode == ChainMode::Tx) {
+            m_bypassBtn->setChecked(m_audio->isTxBypassed());
+        }
+        connect(m_audio, &AudioEngine::txBypassChanged,
+                this, [this](bool on) {
+            if (!m_bypassBtn) return;
+            if (m_mode != ChainMode::Tx) return;
+            QSignalBlocker b(m_bypassBtn);
+            m_bypassBtn->setChecked(on);
+            if (m_chain) m_chain->update();
+        });
+    }
 }
 
 void ClientChainApplet::refreshFromEngine()
@@ -366,7 +405,7 @@ void ClientChainApplet::setMode(ChainMode m)
     // the toggled() handler from re-firing onBypassToggled and
     // touching the engine.
     if (m_bypassBtn) {
-        const bool bypassed = tx ? !m_bypassSnapshot.isEmpty()
+        const bool bypassed = tx ? (m_audio && m_audio->isTxBypassed())
                                  : !m_rxBypassSnapshot.isEmpty();
         QSignalBlocker blocker(m_bypassBtn);
         m_bypassBtn->setChecked(bypassed);
@@ -494,108 +533,11 @@ void ClientChainApplet::onBypassToggled(bool checked)
         return;
     }
 
-    // Dispatch on stage so we can route to the right engine getter
-    // and settings-save function in one place.  Returns true if the
-    // stage is currently enabled.
-    auto setStageEnabled = [&](AudioEngine::TxChainStage stage, bool on) {
-        switch (stage) {
-            case AudioEngine::TxChainStage::Eq:
-                if (auto* d = m_audio->clientEqTx()) {
-                    d->setEnabled(on);
-                    m_audio->saveClientEqSettings();
-                }
-                break;
-            case AudioEngine::TxChainStage::Comp:
-                if (auto* d = m_audio->clientCompTx()) {
-                    d->setEnabled(on);
-                    m_audio->saveClientCompSettings();
-                }
-                break;
-            case AudioEngine::TxChainStage::Gate:
-                if (auto* d = m_audio->clientGateTx()) {
-                    d->setEnabled(on);
-                    m_audio->saveClientGateSettings();
-                }
-                break;
-            case AudioEngine::TxChainStage::DeEss:
-                if (auto* d = m_audio->clientDeEssTx()) {
-                    d->setEnabled(on);
-                    m_audio->saveClientDeEssSettings();
-                }
-                break;
-            case AudioEngine::TxChainStage::Tube:
-                if (auto* d = m_audio->clientTubeTx()) {
-                    d->setEnabled(on);
-                    m_audio->saveClientTubeSettings();
-                }
-                break;
-            case AudioEngine::TxChainStage::Enh:   // PUDU slot
-                if (auto* d = m_audio->clientPuduTx()) {
-                    d->setEnabled(on);
-                    m_audio->saveClientPuduSettings();
-                }
-                break;
-            case AudioEngine::TxChainStage::Reverb:
-                if (auto* d = m_audio->clientReverbTx()) {
-                    d->setEnabled(on);
-                    m_audio->saveClientReverbSettings();
-                }
-                break;
-            case AudioEngine::TxChainStage::None:
-                break;
-        }
-        emit stageEnabledChanged(stage, on);
-    };
-
-    auto isEnabled = [&](AudioEngine::TxChainStage stage) {
-        switch (stage) {
-            case AudioEngine::TxChainStage::Eq:
-                return m_audio->clientEqTx() && m_audio->clientEqTx()->isEnabled();
-            case AudioEngine::TxChainStage::Comp:
-                return m_audio->clientCompTx() && m_audio->clientCompTx()->isEnabled();
-            case AudioEngine::TxChainStage::Gate:
-                return m_audio->clientGateTx() && m_audio->clientGateTx()->isEnabled();
-            case AudioEngine::TxChainStage::DeEss:
-                return m_audio->clientDeEssTx() && m_audio->clientDeEssTx()->isEnabled();
-            case AudioEngine::TxChainStage::Tube:
-                return m_audio->clientTubeTx() && m_audio->clientTubeTx()->isEnabled();
-            case AudioEngine::TxChainStage::Enh:
-                return m_audio->clientPuduTx() && m_audio->clientPuduTx()->isEnabled();
-            case AudioEngine::TxChainStage::Reverb:
-                return m_audio->clientReverbTx() && m_audio->clientReverbTx()->isEnabled();
-            case AudioEngine::TxChainStage::None:
-                return false;
-        }
-        return false;
-    };
-
-    static const QVector<AudioEngine::TxChainStage> kAllStages{
-        AudioEngine::TxChainStage::Eq,
-        AudioEngine::TxChainStage::Comp,
-        AudioEngine::TxChainStage::Gate,
-        AudioEngine::TxChainStage::DeEss,
-        AudioEngine::TxChainStage::Tube,
-        AudioEngine::TxChainStage::Enh,
-        AudioEngine::TxChainStage::Reverb,
-    };
-
-    if (checked) {
-        // Snapshot whatever was on, then kill them all.
-        m_bypassSnapshot.clear();
-        for (auto s : kAllStages) {
-            if (isEnabled(s)) {
-                m_bypassSnapshot.append(s);
-                setStageEnabled(s, false);
-            }
-        }
-    } else {
-        // Restore only the stages we had on before.  If the user
-        // flipped anything on manually while bypass was active,
-        // those survive here because they're not in the snapshot.
-        for (auto s : m_bypassSnapshot) setStageEnabled(s, true);
-        m_bypassSnapshot.clear();
-    }
-
+    // TX bypass — route through the engine so the strip's BYPASS
+    // button stays in lock-step.  The engine owns the snapshot now;
+    // ClientChainApplet observes txBypassChanged to update its own
+    // button visual when the user toggles bypass elsewhere.
+    m_audio->setTxBypassed(checked);
     if (m_chain) m_chain->update();
 }
 

--- a/src/gui/ClientChainApplet.h
+++ b/src/gui/ClientChainApplet.h
@@ -67,6 +67,10 @@ public:
     void setActiveTab(ChainMode m);
 
 signals:
+    // Easter-egg launch nub at the bottom-right of the chain applet.
+    // Wired in MainWindow to toggle the Aetherial Audio Channel Strip
+    // (unified TX DSP window).  See issue #2301.
+    void aetherialStripToggleRequested();
     void editRequested(AudioEngine::TxChainStage stage);
     void stageEnabledChanged(AudioEngine::TxChainStage stage, bool enabled);
     // RX equivalents — forwarded from ClientRxChainWidget so MainWindow
@@ -119,6 +123,7 @@ private:
     QPushButton*       m_txBtn{nullptr};
     QPushButton*       m_rxBtn{nullptr};
     QPushButton*       m_bypassBtn{nullptr};
+    QPushButton*       m_stripNub{nullptr};      // Easter-egg launch for Channel Strip (#2301)
     QPushButton*       m_monRecBtn{nullptr};
     QPushButton*       m_monPlayBtn{nullptr};
     class QTimer*      m_monRecPulse{nullptr};

--- a/src/gui/ClientCompKnob.cpp
+++ b/src/gui/ClientCompKnob.cpp
@@ -6,6 +6,7 @@
 #include <QPainterPath>
 #include <QPaintEvent>
 #include <QPen>
+#include <QPixmap>
 #include <QWheelEvent>
 #include <algorithm>
 #include <cmath>

--- a/src/gui/EditorFramelessTitleBar.cpp
+++ b/src/gui/EditorFramelessTitleBar.cpp
@@ -67,6 +67,13 @@ void EditorFramelessTitleBar::setTitleText(const QString& text)
     if (m_titleLbl) m_titleLbl->setText(text);
 }
 
+void EditorFramelessTitleBar::setControlsVisible(bool on)
+{
+    if (m_minLbl)   m_minLbl->setVisible(on);
+    if (m_maxLbl)   m_maxLbl->setVisible(on);
+    if (m_closeLbl) m_closeLbl->setVisible(on);
+}
+
 void EditorFramelessTitleBar::mousePressEvent(QMouseEvent* ev)
 {
     if (ev->button() == Qt::LeftButton) {

--- a/src/gui/EditorFramelessTitleBar.h
+++ b/src/gui/EditorFramelessTitleBar.h
@@ -26,6 +26,12 @@ public:
 
     void setTitleText(const QString& text);
 
+    // Hide the min / max / close trio while leaving the title label
+    // visible.  Used by the AetherialAudioStrip when it embeds the
+    // per-stage editors — the strip owns its own window controls, so
+    // each embedded panel just needs the name plate (#2301).
+    void setControlsVisible(bool on);
+
 protected:
     void mousePressEvent(QMouseEvent* ev) override;
     void mouseDoubleClickEvent(QMouseEvent* ev) override;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -44,6 +44,7 @@
 #include "ClientPuduEditor.h"
 #include "ClientReverbApplet.h"
 #include "ClientReverbEditor.h"
+#include "AetherialAudioStrip.h"
 #include "ClientChainApplet.h"
 #include "core/ClientComp.h"
 #include "core/ClientEq.h"
@@ -1047,6 +1048,11 @@ MainWindow::MainWindow(QWidget* parent)
     if (AppSettings::instance().value("MinimalModeEnabled", "False").toString() == "True")
         toggleMinimalMode(true);
 
+    // Restore the Aetherial Audio Channel Strip if it was open on last
+    // exit (#2301).  toggleAetherialStrip() lazy-creates and shows.
+    if (AppSettings::instance().value("AetherialStripVisible", "False").toString() == "True")
+        toggleAetherialStrip();
+
     // ── Wire up discovery ──────────────────────────────────────────────────
     connect(&m_discovery, &RadioDiscovery::radioDiscovered,
             m_connPanel, &ConnectionPanel::onRadioDiscovered);
@@ -1727,6 +1733,10 @@ MainWindow::MainWindow(QWidget* parent)
             m_appletPanel->clientChainApplet()->setMicInputReady(ready);
             m_appletPanel->clientChainApplet()->setTxActive(
                 ready && tx.isTransmitting());
+            if (m_aetherialStrip) {
+                m_aetherialStrip->setMicInputReady(ready);
+                m_aetherialStrip->setTxActive(ready && tx.isTransmitting());
+            }
 
             // If the user pulls the plug on readiness mid-recording
             // (mic source away from PC, or DAX back on), stop the
@@ -3108,6 +3118,8 @@ MainWindow::MainWindow(QWidget* parent)
             m_appletPanel->clientEqTxApplet()->setTxFilterCutoffs(lo, hi);
         if (m_clientEqEditor)
             m_clientEqEditor->setTxFilterCutoffs(lo, hi);
+        if (m_aetherialStrip)
+            m_aetherialStrip->setTxFilterCutoffs(lo, hi);
     };
     {
         const auto& tx = m_radioModel.transmitModel();
@@ -3233,6 +3245,10 @@ MainWindow::MainWindow(QWidget* parent)
         m_appletPanel->clientChainApplet()->setMicInputReady(ready);
         m_appletPanel->clientChainApplet()->setTxActive(
             ready && tx.isTransmitting());
+        if (m_aetherialStrip) {
+            m_aetherialStrip->setMicInputReady(ready);
+            m_aetherialStrip->setTxActive(ready && tx.isTransmitting());
+        }
     }
     // Pulse the TX endpoint red when we're transmitting AND PooDoo
     // is actually in the signal path (MIC=PC and DAX off).  Otherwise
@@ -3243,11 +3259,19 @@ MainWindow::MainWindow(QWidget* parent)
         const auto& tx = m_radioModel.transmitModel();
         const bool ready = (tx.micSelection() == "PC") && !tx.daxOn();
         m_appletPanel->clientChainApplet()->setTxActive(ready && txActive);
+        if (m_aetherialStrip)
+            m_aetherialStrip->setTxActive(ready && txActive);
     });
 
     // ── PUDU monitor wiring ─────────────────────────────────────
     auto* chainApplet = m_appletPanel->clientChainApplet();
     chainApplet->setMonitorHasRecording(m_puduMonitor->hasRecording());
+
+    // Easter-egg nub on the chain applet → toggle the Aetherial Audio
+    // Channel Strip.  Stubbed in step 1 of the strip plan (#2301);
+    // step 4 lazy-creates the strip window and toggles visibility.
+    connect(chainApplet, &ClientChainApplet::aetherialStripToggleRequested,
+            this, &MainWindow::toggleAetherialStrip);
 
     // User-click → start/stop based on current monitor state.  The
     // monitor's own signals drive the button visuals back.
@@ -3272,11 +3296,15 @@ MainWindow::MainWindow(QWidget* parent)
     });
 
     // Monitor state → UI updates.  RX audio gating is handled
-    // separately via the muteRxRequested wiring above.
+    // separately via the muteRxRequested wiring above.  State is
+    // forwarded both to the docked ClientChainApplet AND to the
+    // AetherialAudioStrip's mirrored buttons (when the strip exists).
     connect(m_puduMonitor, &ClientPuduMonitor::recordingStarted,
             this, [this]() {
         if (m_appletPanel && m_appletPanel->clientChainApplet())
             m_appletPanel->clientChainApplet()->setMonitorRecording(true);
+        if (m_aetherialStrip)
+            m_aetherialStrip->setMonitorRecording(true);
     });
     connect(m_puduMonitor, &ClientPuduMonitor::recordingStopped,
             this, [this](int /*durationMs*/) {
@@ -3284,6 +3312,10 @@ MainWindow::MainWindow(QWidget* parent)
             auto* a = m_appletPanel->clientChainApplet();
             a->setMonitorRecording(false);
             a->setMonitorHasRecording(true);
+        }
+        if (m_aetherialStrip) {
+            m_aetherialStrip->setMonitorRecording(false);
+            m_aetherialStrip->setMonitorHasRecording(true);
         }
         // Auto-start playback — the mute stays installed across the
         // transition because the monitor only emits muteRxRequested
@@ -3294,11 +3326,15 @@ MainWindow::MainWindow(QWidget* parent)
             this, [this]() {
         if (m_appletPanel && m_appletPanel->clientChainApplet())
             m_appletPanel->clientChainApplet()->setMonitorPlaying(true);
+        if (m_aetherialStrip)
+            m_aetherialStrip->setMonitorPlaying(true);
     });
     connect(m_puduMonitor, &ClientPuduMonitor::playbackStopped,
             this, [this]() {
         if (m_appletPanel && m_appletPanel->clientChainApplet())
             m_appletPanel->clientChainApplet()->setMonitorPlaying(false);
+        if (m_aetherialStrip)
+            m_aetherialStrip->setMonitorPlaying(false);
     });
     // TX chain applet visibility is independent of bypass state — the
     // user controls show/hide via the applet header ✕ and toolbar
@@ -3351,32 +3387,7 @@ MainWindow::MainWindow(QWidget* parent)
 
     connect(m_appletPanel->clientChainApplet(),
             &ClientChainApplet::stageEnabledChanged,
-            this, [this](AudioEngine::TxChainStage stage, bool /*enabled*/) {
-        // Refresh the applet's bypass indicator only — applet visibility
-        // is independent of bypass state for TX chain DSPs.
-        if (stage == AudioEngine::TxChainStage::Eq) {
-            if (m_appletPanel->clientEqApplet())
-                m_appletPanel->clientEqApplet()->refreshEnableFromEngine();
-        } else if (stage == AudioEngine::TxChainStage::Comp) {
-            if (m_appletPanel->clientCompApplet())
-                m_appletPanel->clientCompApplet()->refreshEnableFromEngine();
-        } else if (stage == AudioEngine::TxChainStage::Gate) {
-            if (m_appletPanel->clientGateApplet())
-                m_appletPanel->clientGateApplet()->refreshEnableFromEngine();
-        } else if (stage == AudioEngine::TxChainStage::DeEss) {
-            if (m_appletPanel->clientDeEssApplet())
-                m_appletPanel->clientDeEssApplet()->refreshEnableFromEngine();
-        } else if (stage == AudioEngine::TxChainStage::Tube) {
-            if (m_appletPanel->clientTubeApplet())
-                m_appletPanel->clientTubeApplet()->refreshEnableFromEngine();
-        } else if (stage == AudioEngine::TxChainStage::Enh) {
-            if (m_appletPanel->clientPuduApplet())
-                m_appletPanel->clientPuduApplet()->refreshEnableFromEngine();
-        } else if (stage == AudioEngine::TxChainStage::Reverb) {
-            if (m_appletPanel->clientReverbApplet())
-                m_appletPanel->clientReverbApplet()->refreshEnableFromEngine();
-        }
-    });
+            this, &MainWindow::onTxChainStageEnabledChanged);
     connect(m_appletPanel->clientChainApplet(),
             &ClientChainApplet::editRequested,
             this, [this](AudioEngine::TxChainStage stage) {
@@ -3901,43 +3912,81 @@ ClientEqEditor* MainWindow::ensureClientEqEditor()
         m_clientEqEditor->setTxFilterCutoffs(tx.txFilterLow(), tx.txFilterHigh());
         pushRxFilterCutoffsToEq();
 
-        // Cutoff-line drag → write to the radio.  TX is direct (audio
-        // domain == TransmitModel domain).  RX requires a mode-aware
-        // conversion back from audio-domain to slice filter offsets.
+        // Cutoff-line drag → write to the radio.  Shared with the strip's
+        // embedded EQ panel via MainWindow::onEqCutoffsDragRequested.
         connect(m_clientEqEditor, &ClientEqEditor::cutoffsDragRequested,
-                this, [this](ClientEqApplet::Path path, int audioLo, int audioHi) {
-            if (path == ClientEqApplet::Path::Tx) {
-                auto& txm = m_radioModel.transmitModel();
-                if (audioLo != txm.txFilterLow())  txm.setTxFilterLow(audioLo);
-                if (audioHi != txm.txFilterHigh()) txm.setTxFilterHigh(audioHi);
-                return;
-            }
-            // RX: convert audio-domain Hz back to slice filter offsets
-            // based on the active slice's mode.
-            auto* s = activeSlice();
-            if (!s) return;
-            const QString mode = s->mode();
-            int lo = audioLo;
-            int hi = audioHi;
-            if (mode == "LSB" || mode == "DIGL") {
-                // Lower-sideband: filter offsets are negative; the audio
-                // low edge maps to the high (closest-to-zero) offset and
-                // vice versa.
-                lo = -audioHi;
-                hi = -audioLo;
-            } else if (mode == "AM" || mode == "SAM" || mode == "FM"
-                    || mode == "NFM" || mode == "DFM" || mode == "DSB") {
-                // Symmetric around carrier — only audio_high meaningfully
-                // controls bandwidth; audio_low is fixed at 0.
-                lo = -audioHi;
-                hi =  audioHi;
-            }
-            // USB / DIGU / FDV / CW / RTTY / others: audio domain matches
-            // slice domain directly — pass through.
-            s->setFilterWidth(lo, hi);
-        });
+                this, &MainWindow::onEqCutoffsDragRequested);
     }
     return m_clientEqEditor;
+}
+
+void MainWindow::onTxChainStageEnabledChanged(
+    AudioEngine::TxChainStage stage, bool /*enabled*/)
+{
+    // Refresh the matching docked applet's enable indicator.  Applet
+    // visibility is independent of bypass state for TX chain DSPs.
+    if (stage == AudioEngine::TxChainStage::Eq) {
+        if (m_appletPanel->clientEqApplet())
+            m_appletPanel->clientEqApplet()->refreshEnableFromEngine();
+    } else if (stage == AudioEngine::TxChainStage::Comp) {
+        if (m_appletPanel->clientCompApplet())
+            m_appletPanel->clientCompApplet()->refreshEnableFromEngine();
+    } else if (stage == AudioEngine::TxChainStage::Gate) {
+        if (m_appletPanel->clientGateApplet())
+            m_appletPanel->clientGateApplet()->refreshEnableFromEngine();
+    } else if (stage == AudioEngine::TxChainStage::DeEss) {
+        if (m_appletPanel->clientDeEssApplet())
+            m_appletPanel->clientDeEssApplet()->refreshEnableFromEngine();
+    } else if (stage == AudioEngine::TxChainStage::Tube) {
+        if (m_appletPanel->clientTubeApplet())
+            m_appletPanel->clientTubeApplet()->refreshEnableFromEngine();
+    } else if (stage == AudioEngine::TxChainStage::Enh) {
+        if (m_appletPanel->clientPuduApplet())
+            m_appletPanel->clientPuduApplet()->refreshEnableFromEngine();
+    } else if (stage == AudioEngine::TxChainStage::Reverb) {
+        if (m_appletPanel->clientReverbApplet())
+            m_appletPanel->clientReverbApplet()->refreshEnableFromEngine();
+    }
+    // Cross-paint: nudge whichever chain widget didn't initiate the
+    // change.  Engine state is the source of truth — both widgets read
+    // from it on paint, so a plain update() is enough.
+    if (m_appletPanel && m_appletPanel->clientChainApplet())
+        m_appletPanel->clientChainApplet()->refreshFromEngine();
+    if (m_aetherialStrip)
+        m_aetherialStrip->refreshChainPaint();
+}
+
+void MainWindow::onEqCutoffsDragRequested(ClientEqApplet::Path path,
+                                          int audioLo, int audioHi)
+{
+    if (path == ClientEqApplet::Path::Tx) {
+        auto& txm = m_radioModel.transmitModel();
+        if (audioLo != txm.txFilterLow())  txm.setTxFilterLow(audioLo);
+        if (audioHi != txm.txFilterHigh()) txm.setTxFilterHigh(audioHi);
+        return;
+    }
+    // RX: convert audio-domain Hz back to slice filter offsets based on
+    // the active slice's mode.
+    auto* s = activeSlice();
+    if (!s) return;
+    const QString mode = s->mode();
+    int lo = audioLo;
+    int hi = audioHi;
+    if (mode == "LSB" || mode == "DIGL") {
+        // Lower-sideband: filter offsets are negative; the audio low edge
+        // maps to the high (closest-to-zero) offset and vice versa.
+        lo = -audioHi;
+        hi = -audioLo;
+    } else if (mode == "AM" || mode == "SAM" || mode == "FM"
+            || mode == "NFM" || mode == "DFM" || mode == "DSB") {
+        // Symmetric around carrier — only audio_high meaningfully
+        // controls bandwidth; audio_low is fixed at 0.
+        lo = -audioHi;
+        hi =  audioHi;
+    }
+    // USB / DIGU / FDV / CW / RTTY / others: audio domain matches slice
+    // domain directly — pass through.
+    s->setFilterWidth(lo, hi);
 }
 
 ClientGateEditor* MainWindow::ensureClientGateEditor()
@@ -9668,6 +9717,63 @@ void MainWindow::setFramelessWindow(bool on)
     if (m_panStack) m_panStack->setFramelessMode(on);
     if (m_appletPanel && m_appletPanel->containerManager())
         m_appletPanel->containerManager()->setFramelessMode(on);
+}
+
+void MainWindow::toggleAetherialStrip()
+{
+    if (!m_aetherialStrip) {
+        m_aetherialStrip = new AetherialAudioStrip(m_audio, this);
+        // Override the parent-window relationship so the strip behaves as
+        // an independent window (own taskbar entry, raisable separately).
+        m_aetherialStrip->setWindowFlag(Qt::Window, true);
+        // Seed the embedded EQ with the current TX filter cutoff values
+        // so the dashed yellow guide lines render immediately rather than
+        // waiting for the next txFilterCutoffChanged signal.
+        const auto& tx = m_radioModel.transmitModel();
+        m_aetherialStrip->setTxFilterCutoffs(tx.txFilterLow(), tx.txFilterHigh());
+        // Drag-to-adjust on the strip's EQ cutoff lines → same handler
+        // the floating ClientEqEditor uses, so dragging in the strip
+        // writes the same TX filter command to the radio.
+        connect(m_aetherialStrip, &AetherialAudioStrip::cutoffsDragRequested,
+                this, &MainWindow::onEqCutoffsDragRequested);
+        // Stage bypass via the strip's chain tiles → same handler the
+        // docked Chain applet's signal connects to, so both chain
+        // widgets repaint and the matching applet refreshes.
+        connect(m_aetherialStrip, &AetherialAudioStrip::stageEnabledChanged,
+                this, &MainWindow::onTxChainStageEnabledChanged);
+        // PUDU monitor record / play — same toggle logic as the docked
+        // ClientChainApplet.
+        connect(m_aetherialStrip, &AetherialAudioStrip::monitorRecordClicked,
+                this, [this]() {
+            if (m_puduMonitor->isRecording()) {
+                m_puduMonitor->stopRecording();
+            } else {
+                if (m_puduMonitor->isPlaying()) m_puduMonitor->stopPlayback();
+                m_puduMonitor->startRecording();
+            }
+        });
+        connect(m_aetherialStrip, &AetherialAudioStrip::monitorPlayClicked,
+                this, [this]() {
+            if (m_puduMonitor->isPlaying()) m_puduMonitor->stopPlayback();
+            else                            m_puduMonitor->startPlayback();
+        });
+        // Seed the strip with the monitor's current state.
+        m_aetherialStrip->setMonitorRecording(m_puduMonitor->isRecording());
+        m_aetherialStrip->setMonitorPlaying(m_puduMonitor->isPlaying());
+        m_aetherialStrip->setMonitorHasRecording(m_puduMonitor->hasRecording());
+        // Seed the chain's MIC-ready + TX-active indicators (reuse the
+        // tx alias declared above for the EQ cutoff seeding).
+        const bool ready = (tx.micSelection() == "PC") && !tx.daxOn();
+        m_aetherialStrip->setMicInputReady(ready);
+        m_aetherialStrip->setTxActive(ready && tx.isTransmitting());
+    }
+    if (m_aetherialStrip->isVisible()) {
+        m_aetherialStrip->hide();
+    } else {
+        m_aetherialStrip->show();
+        m_aetherialStrip->raise();
+        m_aetherialStrip->activateWindow();
+    }
 }
 
 void MainWindow::toggleMinimalMode(bool on)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -55,6 +55,9 @@
 
 class QAbstractSlider;
 
+#include "gui/ClientEqApplet.h"   // ClientEqApplet::Path enum used in
+                                   // onEqCutoffsDragRequested signature.
+
 namespace AetherSDR {
 
 class ConnectionPanel;
@@ -171,6 +174,22 @@ private:
     void applyUiScale(int pct);
     void stepUiScale(int direction);  // +1 = zoom in, -1 = zoom out
     void toggleMinimalMode(bool on);
+    // Toggle the Aetherial Audio Channel Strip — unified TX DSP window.
+    // Stubbed in step 1 of #2301; step 4 lazy-creates the strip window
+    // and persists visibility via AppSettings("AetherialStripVisible").
+    void toggleAetherialStrip();
+    // Cutoff-line drag handler shared between the floating ClientEqEditor
+    // and the embedded EQ panel inside AetherialAudioStrip.  Writes TX
+    // filter cutoffs to TransmitModel, or RX filter offsets to the
+    // active SliceModel (with mode-aware audio→slice conversion).
+    void onEqCutoffsDragRequested(ClientEqApplet::Path path,
+                                  int audioLow, int audioHigh);
+    // Single handler for TX chain-stage enable/bypass changes from
+    // ANY widget (docked Chain applet OR channel strip).  Refreshes
+    // the matching applet's enable indicator and forces a repaint on
+    // both chain widgets so they stay in lock-step.
+    void onTxChainStageEnabledChanged(AudioEngine::TxChainStage stage,
+                                      bool enabled);
     // Toggle OS window-chrome on/off (Qt::FramelessWindowHint).  Persists
     // to AppSettings("FramelessWindow"). When on, users move/close the
     // window via keyboard shortcuts or taskbar.
@@ -404,6 +423,7 @@ private:
     class ClientTubeEditor* m_clientTubeEditor{nullptr}; // lazy — created on first Edit… click
     class ClientPuduEditor* m_clientPuduEditor{nullptr}; // lazy — created on first Edit… click
     class ClientReverbEditor* m_clientReverbEditor{nullptr}; // lazy — created on first Edit… click
+    class AetherialAudioStrip* m_aetherialStrip{nullptr};    // lazy — created on first egg-nub click (#2301)
 
     // Applet-panel pop-out support (#1713 Phase 6).  When floating,
     // the panel lives inside m_appletPanelFloatWindow and its splitter

--- a/src/gui/StripChainWidget.cpp
+++ b/src/gui/StripChainWidget.cpp
@@ -1,4 +1,4 @@
-#include "ClientChainWidget.h"
+#include "StripChainWidget.h"
 #include "core/ClientComp.h"
 #include "core/ClientEq.h"
 #include "core/ClientGate.h"
@@ -35,9 +35,9 @@ namespace {
 // wraps into multiple rows snake-style — row 0 reads left-to-right,
 // row 1 right-to-left, and so on — so the full 8-box chain fits
 // inside a 260 px applet panel without crushing the boxes.
-constexpr int   kBoxHeight     = 20;
-constexpr int   kBoxWidthMin   = 36;
-constexpr int   kBoxWidthMax   = 54;
+constexpr int   kBoxHeight     = 30;
+constexpr int   kBoxWidthMin   = 50;
+constexpr int   kBoxWidthMax   = 50;
 constexpr int   kBoxGapMin     = 6;
 constexpr int   kBoxGapPref    = 10;
 // kMarginX must exceed kTurnOffset so row-transition connectors don't
@@ -98,7 +98,7 @@ QString stageLabel(AudioEngine::TxChainStage s)
 
 } // namespace
 
-ClientChainWidget::ClientChainWidget(QWidget* parent) : QWidget(parent)
+StripChainWidget::StripChainWidget(QWidget* parent) : QWidget(parent)
 {
     setAcceptDrops(true);
     setMouseTracking(true);
@@ -121,21 +121,21 @@ ClientChainWidget::ClientChainWidget(QWidget* parent) : QWidget(parent)
     });
 }
 
-void ClientChainWidget::setAudioEngine(AudioEngine* engine)
+void StripChainWidget::setAudioEngine(AudioEngine* engine)
 {
     m_audio = engine;
     rebuildLayout();
     update();
 }
 
-void ClientChainWidget::setMicInputReady(bool ready)
+void StripChainWidget::setMicInputReady(bool ready)
 {
     if (m_micInputReady == ready) return;
     m_micInputReady = ready;
     update();
 }
 
-void ClientChainWidget::setTxActive(bool active)
+void StripChainWidget::setTxActive(bool active)
 {
     if (m_txActive == active) return;
     m_txActive = active;
@@ -158,7 +158,7 @@ void ClientChainWidget::setTxActive(bool active)
     update();
 }
 
-bool ClientChainWidget::isStageImplemented(AudioEngine::TxChainStage s) const
+bool StripChainWidget::isStageImplemented(AudioEngine::TxChainStage s) const
 {
     // All six TX DSP stages are now implemented.  The Enh slot hosts
     // the PUDU exciter (Phase 5) — the enum name is legacy; the
@@ -172,7 +172,7 @@ bool ClientChainWidget::isStageImplemented(AudioEngine::TxChainStage s) const
         || s == AudioEngine::TxChainStage::Reverb;
 }
 
-bool ClientChainWidget::isStageBypassed(AudioEngine::TxChainStage s) const
+bool StripChainWidget::isStageBypassed(AudioEngine::TxChainStage s) const
 {
     if (!m_audio) return true;
     switch (s) {
@@ -195,7 +195,7 @@ bool ClientChainWidget::isStageBypassed(AudioEngine::TxChainStage s) const
     }
 }
 
-void ClientChainWidget::rebuildLayout()
+void StripChainWidget::rebuildLayout()
 {
     m_boxes.clear();
     if (!m_audio) return;
@@ -206,28 +206,27 @@ void ClientChainWidget::rebuildLayout()
     const int totalBoxes = 2 + stages.size();
     if (totalBoxes <= 0) return;
 
-    // Snake layout: wrap the chain into multiple rows so 8 boxes fit
-    // inside the 260 px applet panel comfortably.  Box width is
-    // preferred size (kBoxWidthMax); gap shrinks to fit if needed;
-    // boxesPerRow falls out of how many fit in the available width.
-    const int avail = std::max(0, width() - 2 * kMarginX);
-    int gap  = kBoxGapPref;
-    int boxW = kBoxWidthMax;
-
-    auto computeBoxesPerRow = [&]() {
-        // floor((avail + gap) / (boxW + gap)) — the +gap accounts for
-        // no gap after the last box.
-        if (boxW <= 0) return 1;
-        return std::max(1, (avail + gap) / (boxW + gap));
-    };
-    int boxesPerRow = std::min(totalBoxes, computeBoxesPerRow());
-
-    // If even the minimum box fits <2 per row, shrink the gap first,
-    // then fall back to single-row cramming.
-    if (boxesPerRow < 2 && totalBoxes > 1) {
-        gap  = kBoxGapMin;
-        boxW = kBoxWidthMin;
-        boxesPerRow = std::min(totalBoxes, computeBoxesPerRow());
+    // Strip variant: never wrap.  Box width scales between
+    // kBoxWidthMin and kBoxWidthMax to fit all boxes on one row; gap
+    // drops to kBoxGapMin if at min-box the layout still wouldn't fit.
+    // boxRect() prepends kRowLeftPad to every row, so subtract it from
+    // the available width or the rightmost box ends up clipped.
+    const int avail = std::max(0, width() - 2 * kMarginX - kRowLeftPad);
+    const int boxesPerRow = totalBoxes;
+    int gap = kBoxGapPref;
+    int boxW;
+    if (totalBoxes <= 1) {
+        boxW = kBoxWidthMax;
+    } else {
+        const int totalGap = (totalBoxes - 1) * gap;
+        const int per = std::max(1, (avail - totalGap) / totalBoxes);
+        boxW = std::clamp(per, kBoxWidthMin, kBoxWidthMax);
+        if (totalBoxes * boxW + (totalBoxes - 1) * gap > avail) {
+            gap = kBoxGapMin;
+            const int totalGap2 = (totalBoxes - 1) * gap;
+            const int per2 = std::max(1, (avail - totalGap2) / totalBoxes);
+            boxW = std::max(8, std::min(per2, kBoxWidthMax));
+        }
     }
 
     const int numRows = (totalBoxes + boxesPerRow - 1) / boxesPerRow;
@@ -270,7 +269,7 @@ void ClientChainWidget::rebuildLayout()
     if (height() != desiredH) setFixedHeight(desiredH);
 }
 
-int ClientChainWidget::hitTest(const QPointF& pos) const
+int StripChainWidget::hitTest(const QPointF& pos) const
 {
     for (int i = 0; i < m_boxes.size(); ++i) {
         if (m_boxes[i].rect.contains(pos)) return i;
@@ -278,7 +277,7 @@ int ClientChainWidget::hitTest(const QPointF& pos) const
     return -1;
 }
 
-int ClientChainWidget::dropInsertIndex(const QPointF& pos) const
+int StripChainWidget::dropInsertIndex(const QPointF& pos) const
 {
     // Return an index in the *processor list* (excluding endpoints)
     // where the dragged stage should be inserted.  Processor boxes
@@ -338,7 +337,7 @@ int ClientChainWidget::dropInsertIndex(const QPointF& pos) const
     return std::clamp(procIdx, 0, nProc);
 }
 
-void ClientChainWidget::paintEvent(QPaintEvent*)
+void StripChainWidget::paintEvent(QPaintEvent*)
 {
     rebuildLayout();
 
@@ -417,9 +416,10 @@ void ClientChainWidget::paintEvent(QPaintEvent*)
         }
     }
 
-    // Boxes.  9 px bold matches the RX/TX tab label scale.
+    // Boxes.  14 px bold — sized for the strip's 30-tall tiles so
+    // 4-char labels (DESS / PUDU / VERB) read at a glance.
     QFont labelFont = p.font();
-    labelFont.setPixelSize(9);
+    labelFont.setPixelSize(12);
     labelFont.setBold(true);
     p.setFont(labelFont);
 
@@ -518,7 +518,7 @@ void ClientChainWidget::paintEvent(QPaintEvent*)
     }
 }
 
-void ClientChainWidget::mousePressEvent(QMouseEvent* ev)
+void StripChainWidget::mousePressEvent(QMouseEvent* ev)
 {
     if (ev->button() != Qt::LeftButton) { QWidget::mousePressEvent(ev); return; }
     const int idx = hitTest(ev->position());
@@ -531,7 +531,7 @@ void ClientChainWidget::mousePressEvent(QMouseEvent* ev)
     ev->accept();
 }
 
-void ClientChainWidget::mouseMoveEvent(QMouseEvent* ev)
+void StripChainWidget::mouseMoveEvent(QMouseEvent* ev)
 {
     if (m_pressIndex < 0 || !(ev->buttons() & Qt::LeftButton)) {
         // Hover → update cursor over interactive boxes.
@@ -562,7 +562,7 @@ void ClientChainWidget::mouseMoveEvent(QMouseEvent* ev)
         pp.drawRoundedRect(QRectF(0, 0, pix.width() - 1, pix.height() - 1),
                            kRadius, kRadius);
         QFont f = pp.font();
-        f.setPixelSize(9);
+        f.setPixelSize(12);
         f.setBold(true);
         pp.setFont(f);
         pp.setPen(kTextLabel);
@@ -577,7 +577,7 @@ void ClientChainWidget::mouseMoveEvent(QMouseEvent* ev)
     update();
 }
 
-void ClientChainWidget::mouseReleaseEvent(QMouseEvent* ev)
+void StripChainWidget::mouseReleaseEvent(QMouseEvent* ev)
 {
     if (ev->button() != Qt::LeftButton) { QWidget::mouseReleaseEvent(ev); return; }
     // If m_pressIndex was cleared by mouseMoveEvent (drag started) the
@@ -597,7 +597,7 @@ void ClientChainWidget::mouseReleaseEvent(QMouseEvent* ev)
     ev->accept();
 }
 
-void ClientChainWidget::mouseDoubleClickEvent(QMouseEvent* ev)
+void StripChainWidget::mouseDoubleClickEvent(QMouseEvent* ev)
 {
     // Double-click = open editor.  Cancel the deferred bypass toggle
     // queued by the preceding single-click release.
@@ -612,7 +612,7 @@ void ClientChainWidget::mouseDoubleClickEvent(QMouseEvent* ev)
     ev->accept();
 }
 
-void ClientChainWidget::toggleStageBypass(int boxIdx)
+void StripChainWidget::toggleStageBypass(int boxIdx)
 {
     if (!m_audio) return;
     if (boxIdx < 0 || boxIdx >= m_boxes.size()) return;
@@ -671,7 +671,7 @@ void ClientChainWidget::toggleStageBypass(int boxIdx)
     update();
 }
 
-void ClientChainWidget::contextMenuEvent(QContextMenuEvent* ev)
+void StripChainWidget::contextMenuEvent(QContextMenuEvent* ev)
 {
     const int idx = hitTest(ev->pos());
     if (idx < 0 || m_boxes[idx].isEndpoint) { QWidget::contextMenuEvent(ev); return; }
@@ -728,14 +728,14 @@ void ClientChainWidget::contextMenuEvent(QContextMenuEvent* ev)
     }
 }
 
-void ClientChainWidget::dragEnterEvent(QDragEnterEvent* ev)
+void StripChainWidget::dragEnterEvent(QDragEnterEvent* ev)
 {
     if (ev->mimeData()->hasFormat(kMimeFormat)) {
         ev->acceptProposedAction();
     }
 }
 
-void ClientChainWidget::dragMoveEvent(QDragMoveEvent* ev)
+void StripChainWidget::dragMoveEvent(QDragMoveEvent* ev)
 {
     if (!ev->mimeData()->hasFormat(kMimeFormat)) return;
     const int idx = dropInsertIndex(ev->position());
@@ -743,13 +743,13 @@ void ClientChainWidget::dragMoveEvent(QDragMoveEvent* ev)
     ev->acceptProposedAction();
 }
 
-void ClientChainWidget::dragLeaveEvent(QDragLeaveEvent*)
+void StripChainWidget::dragLeaveEvent(QDragLeaveEvent*)
 {
     m_dropIndex = -1;
     update();
 }
 
-void ClientChainWidget::dropEvent(QDropEvent* ev)
+void StripChainWidget::dropEvent(QDropEvent* ev)
 {
     if (!m_audio || !ev->mimeData()->hasFormat(kMimeFormat)) {
         m_dropIndex = -1;
@@ -777,17 +777,22 @@ void ClientChainWidget::dropEvent(QDropEvent* ev)
     ev->acceptProposedAction();
 }
 
-void ClientChainWidget::leaveEvent(QEvent*)
+void StripChainWidget::leaveEvent(QEvent*)
 {
     setCursor(Qt::ArrowCursor);
 }
 
-QSize ClientChainWidget::sizeHint() const
+QSize StripChainWidget::sizeHint() const
 {
-    // Minimum-height-only hint; the widget scales box widths to fit
-    // whatever horizontal space the parent layout allots (260 px in
-    // the applet panel is plenty).
-    return QSize(2 * kMarginX + 8 * kBoxWidthMin + 7 * kBoxGapMin,
+    // Single-row width hint based on the actual stage count (MIC + N
+    // chain stages + TX) so the strip's outer layout never asks the
+    // widget to shrink below a single-row fit.
+    const int totalBoxes = m_audio
+        ? 2 + static_cast<int>(m_audio->txChainStages().size())
+        : 8;
+    return QSize(2 * kMarginX + kRowLeftPad
+                                + totalBoxes * kBoxWidthMin
+                                + std::max(0, totalBoxes - 1) * kBoxGapMin,
                  2 * kMarginY + kBoxHeight);
 }
 

--- a/src/gui/StripChainWidget.h
+++ b/src/gui/StripChainWidget.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include "core/AudioEngine.h"
+
+#include <QVector>
+#include <QWidget>
+
+namespace AetherSDR {
+
+// Visual TX DSP signal chain.  Paints a horizontal strip:
+//
+//   [MIC] ─▶ [GATE] ─▶ [EQ] ─▶ [DESS] ─▶ [COMP] ─▶ [TUBE] ─▶ [ENH] ─▶ [TX]
+//            ◄────────── draggable / bypassable ──────────►
+//
+// Clicking a processor stage emits editRequested() so the parent can
+// open the corresponding floating editor.  Dragging a stage between
+// other stages reorders the chain (AudioEngine::setTxChainStages).
+// Right-click on a stage toggles its bypass via the relevant DSP
+// module (only Eq and Comp wired today; the unimplemented stages show
+// as "coming soon" greyed-out boxes but still participate in ordering
+// so users can set up their preferred chain ahead of time).
+class StripChainWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit StripChainWidget(QWidget* parent = nullptr);
+
+    // Binds the widget to the audio engine so it can read stage
+    // bypass state and publish reorder / bypass changes.  Null is
+    // safe — the widget renders the chain grey until bound.
+    void setAudioEngine(AudioEngine* engine);
+
+    // Visual indicator for whether the user's TX input is routed to
+    // the client-side DSP chain.  Required for PooDoo Audio to
+    // actually shape what goes out: mic source = PC AND radio DAX
+    // TX is off.  When true, the MIC endpoint box turns green —
+    // matches the SQL-button green in RxApplet — telling the user
+    // "your setup is actually going through PooDoo."
+    void setMicInputReady(bool ready);
+
+    // Pulse the TX endpoint red when we are actively transmitting
+    // on our own slice.  Filtered upstream (TransmitModel only sets
+    // isTransmitting() true when m_txOwnedByUs is true), so MultiFlex
+    // transmissions from other clients don't trigger the pulse.
+    void setTxActive(bool active);
+
+signals:
+    // Fired when the user clicks a processor stage.  MainWindow maps
+    // the stage to the correct editor and opens it.  Endpoint
+    // (MIC, TX) clicks don't emit.
+    void editRequested(AudioEngine::TxChainStage stage);
+
+    // Emitted after a successful reorder so the parent can refresh
+    // any downstream UI.  AudioEngine already has the new order by
+    // this point — the signal is informational.
+    void chainReordered();
+
+    // Emitted whenever the user toggles a stage's bypass from the
+    // chain's right-click menu.  MainWindow subscribes to drive the
+    // corresponding applet's tile visibility — bypassed stages don't
+    // occupy space in the applet tray.
+    void stageEnabledChanged(AudioEngine::TxChainStage stage, bool enabled);
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
+    void mouseDoubleClickEvent(QMouseEvent* ev) override;
+    void contextMenuEvent(QContextMenuEvent* ev) override;
+    void dragEnterEvent(QDragEnterEvent* ev) override;
+    void dragMoveEvent(QDragMoveEvent* ev) override;
+    void dragLeaveEvent(QDragLeaveEvent* ev) override;
+    void dropEvent(QDropEvent* ev) override;
+    void leaveEvent(QEvent* ev) override;
+    QSize sizeHint() const override;
+
+private:
+    // Layout.  Widget paints one row of box rects; the cached list
+    // lets mouse-hit + drag-drop walk the same geometry the painter
+    // laid down without recomputing.
+    struct BoxRect {
+        AudioEngine::TxChainStage stage;
+        QRectF                    rect;
+        bool                      isEndpoint;   // MIC / TX, non-interactive
+    };
+    QVector<BoxRect> m_boxes;
+
+    void rebuildLayout();   // recompute m_boxes from the current chain
+    int  hitTest(const QPointF& pos) const;           // returns index into m_boxes, or -1
+    int  dropInsertIndex(const QPointF& pos) const;   // computes new-position index for drag-over
+
+    bool isStageImplemented(AudioEngine::TxChainStage s) const;
+    bool isStageBypassed(AudioEngine::TxChainStage s) const;
+
+    // Helper: toggle bypass on the stage at m_boxes[idx], saving settings
+    // and emitting stageEnabledChanged.  Used by the deferred single-
+    // click handler and by the right-click menu.
+    void toggleStageBypass(int boxIdx);
+
+    AudioEngine* m_audio{nullptr};
+    bool         m_micInputReady{false};
+    bool         m_txActive{false};
+    class QTimer* m_txPulseTimer{nullptr};
+    float        m_txPulsePhase{0.0f};   // seconds since pulse start
+
+    // Drag state — tracks the press point and the drag target once
+    // the mouse has moved far enough to distinguish click from drag.
+    QPoint m_pressPos;
+    int    m_pressIndex{-1};
+    int    m_dropIndex{-1};      // where the drag is currently hovering (drawn as an insertion line)
+
+    // Deferred single-click → toggle-bypass timer.  Single click fires
+    // after QApplication::doubleClickInterval() so a genuine double
+    // click (editor-open) can cancel it before it fires.
+    class QTimer* m_clickTimer{nullptr};
+    int           m_pendingClickIdx{-1};
+};
+
+} // namespace AetherSDR

--- a/src/gui/StripCompPanel.cpp
+++ b/src/gui/StripCompPanel.cpp
@@ -1,0 +1,509 @@
+#include "StripCompPanel.h"
+#include "ClientCompEditorCanvas.h"
+#include "ClientCompKnob.h"
+#include "ClientCompLimiterButton.h"
+#include "ClientCompMeter.h"
+#include "ClientCompThresholdFader.h"
+#include "EditorFramelessTitleBar.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientComp.h"
+
+#include <QCloseEvent>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QLabel>
+#include <QMoveEvent>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kDefaultWidth  = 860;
+constexpr int kDefaultHeight = 400;
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+const QString kBypassStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #0e1b28;"
+    "  color: #8aa8c0;"
+    "  border: 1px solid #243a4e;"
+    "  border-radius: 3px;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 12px;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e;"
+    "  color: #f2c14e;"
+    "  border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+const QString kLimBtnStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
+    "  color: #c8d8e8; font-size: 10px; font-weight: bold; padding: 3px 6px;"
+    "}"
+    "QPushButton:hover { background: #204060; }"
+    "QPushButton:checked {"
+    "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
+    "}");
+
+} // namespace
+
+StripCompPanel::StripCompPanel(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent)
+    , m_audio(engine)
+{
+    setWindowTitle("Aetherial Compressor");
+    setStyleSheet(kWindowStyle);
+    resize(kDefaultWidth, kDefaultHeight);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(8, 0, 8, 8);
+    root->setSpacing(6);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    m_titleBar = titleBar;
+    root->addWidget(titleBar);
+
+    // Bypass moved to the CHAIN widget's single-click gesture — nothing
+    // here in the header.
+
+    // ── Main body: knobs column | canvas | meters | makeup/limiter ──
+    {
+        auto* body = new QHBoxLayout;
+        body->setSpacing(8);
+
+        // Knobs column (Ratio / Attack / Release / Knee).
+        {
+            auto* col = new QVBoxLayout;
+            col->setSpacing(4);
+
+            m_ratio = new ClientCompKnob;
+            m_ratio->setCenterLabelMode(true);
+            m_ratio->setLabel("Ratio");
+            m_ratio->setRange(1.0f, 20.0f);
+            m_ratio->setDefault(3.0f);
+            m_ratio->setValueFromNorm([](float n) {
+                // Exponential — 1:1 at 0, 20:1 at 1, with a gentle curve
+                // so the middle of the knob lands near 4:1.
+                return 1.0f * std::pow(20.0f, n);
+            });
+            m_ratio->setNormFromValue([](float v) {
+                if (v <= 1.0f) return 0.0f;
+                return std::log(v) / std::log(20.0f);
+            });
+            m_ratio->setLabelFormat([](float v) {
+                return QString::number(v, 'f', 2) + " :1";
+            });
+            m_ratio->setFixedSize(76, 76);
+            col->addWidget(m_ratio);
+
+            m_attack = new ClientCompKnob;
+            m_attack->setCenterLabelMode(true);
+            m_attack->setLabel("Attack");
+            m_attack->setRange(0.1f, 300.0f);
+            m_attack->setDefault(20.0f);
+            m_attack->setValueFromNorm([](float n) {
+                return 0.1f * std::pow(3000.0f, n);  // 0.1 .. 300 ms
+            });
+            m_attack->setNormFromValue([](float v) {
+                if (v <= 0.1f) return 0.0f;
+                return std::log(v / 0.1f) / std::log(3000.0f);
+            });
+            m_attack->setLabelFormat([](float v) {
+                return v < 10.0f ? QString::number(v, 'f', 1) + " ms"
+                                  : QString::number(v, 'f', 0) + " ms";
+            });
+            m_attack->setFixedSize(76, 76);
+            col->addWidget(m_attack);
+
+            m_release = new ClientCompKnob;
+            m_release->setCenterLabelMode(true);
+            m_release->setLabel("Release");
+            m_release->setRange(5.0f, 2000.0f);
+            m_release->setDefault(200.0f);
+            m_release->setValueFromNorm([](float n) {
+                return 5.0f * std::pow(400.0f, n);    // 5 .. 2000 ms
+            });
+            m_release->setNormFromValue([](float v) {
+                if (v <= 5.0f) return 0.0f;
+                return std::log(v / 5.0f) / std::log(400.0f);
+            });
+            m_release->setLabelFormat([](float v) {
+                return QString::number(v, 'f', 0) + " ms";
+            });
+            m_release->setFixedSize(76, 76);
+            col->addWidget(m_release);
+
+            m_knee = new ClientCompKnob;
+            m_knee->setCenterLabelMode(true);
+            m_knee->setLabel("Knee");
+            m_knee->setRange(0.0f, 24.0f);
+            m_knee->setDefault(6.0f);
+            m_knee->setLabelFormat([](float v) {
+                return QString::number(v, 'f', 1) + " dB";
+            });
+            m_knee->setFixedSize(76, 76);
+            col->addWidget(m_knee);
+
+            col->addStretch();
+            body->addLayout(col);
+        }
+
+        // Threshold fader — combined input-level meter + threshold
+        // slider, matching the Client EQ output-fader visual language.
+        // Drag the amber handle to set threshold; the chevron on the
+        // curve canvas stays linked via the shared ClientComp state.
+        m_threshFader = new ClientCompThresholdFader;
+        body->addWidget(m_threshFader);
+
+        // Canvas (center).
+        m_canvas = new ClientCompEditorCanvas;
+        body->addWidget(m_canvas, 1);
+
+        // GR + Output meters.
+        {
+            auto* col = new QVBoxLayout;
+            col->setSpacing(2);
+
+            m_grMeter = new ClientCompMeter;
+            m_grMeter->setMode(ClientCompMeter::Mode::GainReduction);
+            m_grMeter->setLabel("GR");
+            m_grMeter->setMinimumWidth(20);
+
+            m_outputMeter = new ClientCompMeter;
+            m_outputMeter->setMode(ClientCompMeter::Mode::Level);
+            m_outputMeter->setLabel("Out");
+            m_outputMeter->setMinimumWidth(20);
+
+            col->addWidget(m_grMeter, 1);
+            body->addLayout(col);
+
+            auto* col2 = new QVBoxLayout;
+            col2->setSpacing(2);
+            col2->addWidget(m_outputMeter, 1);
+            body->addLayout(col2);
+        }
+
+        // Limiter + Makeup column.
+        {
+            auto* col = new QVBoxLayout;
+            col->setSpacing(6);
+
+            m_limiterEnable = new ClientCompLimiterButton;
+            m_limiterEnable->setToolTip(
+                "Brickwall peak limiter on the compressor output.\n"
+                "Button glows red when the limiter is actively clamping.");
+            col->addWidget(m_limiterEnable);
+
+            m_ceiling = new ClientCompKnob;
+            m_ceiling->setCenterLabelMode(true);
+            m_ceiling->setLabel("Ceiling");
+            m_ceiling->setRange(-24.0f, 0.0f);
+            m_ceiling->setDefault(-1.0f);
+            m_ceiling->setLabelFormat([](float v) {
+                return QString::number(v, 'f', 1) + " dB";
+            });
+            m_ceiling->setFixedSize(76, 76);
+            col->addWidget(m_ceiling);
+
+            m_makeup = new ClientCompKnob;
+            m_makeup->setCenterLabelMode(true);
+            m_makeup->setLabel("Makeup");
+            m_makeup->setRange(-12.0f, 24.0f);
+            m_makeup->setDefault(0.0f);
+            m_makeup->setLabelFormat([](float v) {
+                return (v >= 0.0f ? "+" : "") + QString::number(v, 'f', 1) + " dB";
+            });
+            m_makeup->setFixedSize(76, 76);
+            col->addWidget(m_makeup);
+            col->addStretch();
+            body->addLayout(col);
+        }
+
+        root->addLayout(body, 1);
+    }
+
+    // ── Signal wiring ───────────────────────────────────────────────
+    if (m_audio && comp()) {
+        m_canvas->setComp(comp());
+    }
+
+    connect(m_canvas, &ClientCompEditorCanvas::thresholdChanged,
+            this, &StripCompPanel::applyThreshold);
+    connect(m_threshFader, &ClientCompThresholdFader::thresholdChanged,
+            this, &StripCompPanel::applyThreshold);
+    connect(m_canvas, &ClientCompEditorCanvas::ratioChanged,
+            this, &StripCompPanel::applyRatio);
+
+    connect(m_ratio,   &ClientCompKnob::valueChanged,
+            this, &StripCompPanel::applyRatio);
+    connect(m_attack,  &ClientCompKnob::valueChanged,
+            this, &StripCompPanel::applyAttack);
+    connect(m_release, &ClientCompKnob::valueChanged,
+            this, &StripCompPanel::applyRelease);
+    connect(m_knee,    &ClientCompKnob::valueChanged,
+            this, &StripCompPanel::applyKnee);
+    connect(m_makeup,  &ClientCompKnob::valueChanged,
+            this, &StripCompPanel::applyMakeup);
+    connect(m_ceiling, &ClientCompKnob::valueChanged,
+            this, &StripCompPanel::applyLimiterCeiling);
+    connect(m_limiterEnable, &QPushButton::toggled,
+            this, &StripCompPanel::applyLimiterEnabled);
+
+    syncControlsFromEngine();
+
+    m_meterTimer = new QTimer(this);
+    m_meterTimer->setInterval(33);  // ~30 Hz
+    connect(m_meterTimer, &QTimer::timeout,
+            this, &StripCompPanel::tickMeters);
+}
+
+StripCompPanel::~StripCompPanel() = default;
+
+ClientComp* StripCompPanel::comp() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientCompRx()
+                              : m_audio->clientCompTx();
+}
+
+void StripCompPanel::saveCompSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientCompRxSettings();
+    else                    m_audio->saveClientCompSettings();
+}
+
+void StripCompPanel::showForTx()
+{
+    m_side = Side::Tx;
+    if (m_canvas && comp()) m_canvas->setComp(comp());
+    const QString title = QString::fromUtf8("Aetherial Compressor \xe2\x80\x94 TX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    restoreGeometryFromSettings();
+    syncControlsFromEngine();
+    if (m_meterTimer) m_meterTimer->start();
+    show();
+    raise();
+    activateWindow();
+}
+
+void StripCompPanel::showForRx()
+{
+    m_side = Side::Rx;
+    if (m_canvas && comp()) m_canvas->setComp(comp());
+    const QString title = QString::fromUtf8("Aetherial Compressor \xe2\x80\x94 RX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    restoreGeometryFromSettings();
+    syncControlsFromEngine();
+    if (m_meterTimer) m_meterTimer->start();
+    show();
+    raise();
+    activateWindow();
+}
+
+void StripCompPanel::syncControlsFromEngine()
+{
+    if (!m_audio) return;
+    ClientComp* c = comp();
+    if (!c) return;
+    QSignalBlocker br(m_ratio);
+    QSignalBlocker ba(m_attack);
+    QSignalBlocker brl(m_release);
+    QSignalBlocker bk(m_knee);
+    QSignalBlocker bm(m_makeup);
+    QSignalBlocker bce(m_ceiling);
+    QSignalBlocker ble(m_limiterEnable);
+
+    m_ratio->setValue(c->ratio());
+    m_attack->setValue(c->attackMs());
+    m_release->setValue(c->releaseMs());
+    m_knee->setValue(c->kneeDb());
+    m_makeup->setValue(c->makeupDb());
+    m_ceiling->setValue(c->limiterCeilingDb());
+    m_limiterEnable->setChecked(c->limiterEnabled());
+    if (m_threshFader) m_threshFader->setThresholdDb(c->thresholdDb());
+    if (m_canvas) m_canvas->update();
+}
+
+void StripCompPanel::tickMeters()
+{
+    if (!m_audio) return;
+    ClientComp* c = comp();
+    if (!c) return;
+    if (m_threshFader) m_threshFader->setInputPeakDb(c->inputPeakDb());
+    if (m_grMeter)     m_grMeter    ->setValueDb(c->gainReductionDb());
+    if (m_outputMeter) {
+        m_outputMeter->setValueDb(c->outputPeakDb());
+        if (c->limiterEnabled()) {
+            m_outputMeter->setLimiterCeilingDb(c->limiterCeilingDb());
+            m_outputMeter->setLimiterGrDb(c->limiterGrDb());
+        } else {
+            m_outputMeter->setLimiterCeilingDb(1.0f);  // disable overlay
+            m_outputMeter->setLimiterGrDb(0.0f);
+        }
+    }
+    if (m_limiterEnable) {
+        m_limiterEnable->setActive(c->limiterActive() && c->limiterEnabled());
+    }
+
+    // Mirror parameter changes made in the applet tile (or other
+    // surfaces) back onto the editor knobs.  QSignalBlocker prevents
+    // a feedback loop through the valueChanged handlers.
+    if (m_ratio)   { QSignalBlocker b(m_ratio);   m_ratio->setValue(c->ratio()); }
+    if (m_attack)  { QSignalBlocker b(m_attack);  m_attack->setValue(c->attackMs()); }
+    if (m_release) { QSignalBlocker b(m_release); m_release->setValue(c->releaseMs()); }
+    if (m_knee)    { QSignalBlocker b(m_knee);    m_knee->setValue(c->kneeDb()); }
+    if (m_makeup)  { QSignalBlocker b(m_makeup);  m_makeup->setValue(c->makeupDb()); }
+    if (m_ceiling) { QSignalBlocker b(m_ceiling); m_ceiling->setValue(c->limiterCeilingDb()); }
+    if (m_threshFader) {
+        QSignalBlocker b(m_threshFader);
+        m_threshFader->setThresholdDb(c->thresholdDb());
+    }
+}
+
+void StripCompPanel::applyThreshold(float db)
+{
+    if (!m_audio) return;
+    ClientComp* c = comp();
+    if (!c) return;
+    c->setThresholdDb(db);
+    saveCompSettings();
+    // Mirror the value onto whichever control didn't originate the
+    // change.  Canvas chevron drags land here too, so this keeps the
+    // fader handle in sync.  Signal blocking avoids a feedback loop.
+    if (m_threshFader && std::fabs(m_threshFader->thresholdDb() - db) > 0.01f) {
+        QSignalBlocker b(m_threshFader);
+        m_threshFader->setThresholdDb(db);
+    }
+    if (m_canvas) m_canvas->update();
+}
+
+void StripCompPanel::applyRatio(float ratio)
+{
+    if (!m_audio) return;
+    ClientComp* c = comp();
+    if (!c) return;
+    c->setRatio(ratio);
+    saveCompSettings();
+    // Mirror to the knob if the change came from the canvas.
+    if (m_ratio && std::fabs(m_ratio->value() - ratio) > 0.001f) {
+        QSignalBlocker b(m_ratio);
+        m_ratio->setValue(ratio);
+    }
+    if (m_canvas) m_canvas->update();
+}
+
+void StripCompPanel::applyAttack(float ms)
+{
+    if (!m_audio) return;
+    if (auto* c = comp()) c->setAttackMs(ms);
+    saveCompSettings();
+}
+
+void StripCompPanel::applyRelease(float ms)
+{
+    if (!m_audio) return;
+    if (auto* c = comp()) c->setReleaseMs(ms);
+    saveCompSettings();
+}
+
+void StripCompPanel::applyKnee(float db)
+{
+    if (!m_audio) return;
+    if (auto* c = comp()) c->setKneeDb(db);
+    saveCompSettings();
+    if (m_canvas) m_canvas->update();
+}
+
+void StripCompPanel::applyMakeup(float db)
+{
+    if (!m_audio) return;
+    if (auto* c = comp()) c->setMakeupDb(db);
+    saveCompSettings();
+    if (m_canvas) m_canvas->update();
+}
+
+void StripCompPanel::applyLimiterEnabled(bool on)
+{
+    if (!m_audio) return;
+    if (auto* c = comp()) c->setLimiterEnabled(on);
+    saveCompSettings();
+}
+
+void StripCompPanel::applyLimiterCeiling(float db)
+{
+    if (!m_audio) return;
+    if (auto* c = comp()) c->setLimiterCeilingDb(db);
+    saveCompSettings();
+}
+
+void StripCompPanel::saveGeometryToSettings()
+{
+    auto& s = AppSettings::instance();
+    s.setValue("StripCompPanelGeometry", saveGeometry().toBase64());
+}
+
+void StripCompPanel::restoreGeometryFromSettings()
+{
+    auto& s = AppSettings::instance();
+    const QByteArray geom = QByteArray::fromBase64(
+        s.value("StripCompPanelGeometry", "").toByteArray());
+    if (!geom.isEmpty()) {
+        m_restoring = true;
+        restoreGeometry(geom);
+        m_restoring = false;
+    }
+}
+
+void StripCompPanel::closeEvent(QCloseEvent* ev)
+{
+    if (m_meterTimer) m_meterTimer->stop();
+    saveGeometryToSettings();
+    QWidget::closeEvent(ev);
+}
+
+void StripCompPanel::moveEvent(QMoveEvent* ev)
+{
+    QWidget::moveEvent(ev);
+    if (!m_restoring) saveGeometryToSettings();
+}
+
+void StripCompPanel::resizeEvent(QResizeEvent* ev)
+{
+    QWidget::resizeEvent(ev);
+    if (!m_restoring) saveGeometryToSettings();
+}
+
+void StripCompPanel::showEvent(QShowEvent* ev)
+{
+    QWidget::showEvent(ev);
+    if (m_meterTimer) m_meterTimer->start();
+}
+
+void StripCompPanel::hideEvent(QHideEvent* ev)
+{
+    QWidget::hideEvent(ev);
+    if (m_meterTimer) m_meterTimer->stop();
+}
+
+} // namespace AetherSDR

--- a/src/gui/StripCompPanel.h
+++ b/src/gui/StripCompPanel.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+class QPushButton;
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompEditorCanvas;
+class ClientCompKnob;
+class ClientCompLimiterButton;
+class ClientCompMeter;
+class ClientCompThresholdFader;
+
+// Floating editor for the Pro-XL-style TX compressor.  One instance
+// lives on MainWindow; calling showForTx() raises the window and
+// binds it to AudioEngine::clientCompTx().  Geometry persists via
+// AppSettings (`StripCompPanelGeometry` key).
+//
+// Layout (Ableton-inspired, extended for limiter + chain order):
+//   ┌─ bypass │ CMP→EQ | EQ→CMP ──────────────────── × ┐
+//   │  ratio  │  [Thresh] [transfer curve]  │GR│Out│L│M│
+//   │  attack │                             │  │  │ │a│
+//   │  rlease │                             │  │  │ │k│
+//   │  knee   │                             │  │  │ │e│
+//   └─────────────────────────────────────────────────┘
+//
+// The canvas (center column) owns the threshold slider + curve + live
+// ball.  Meter strips and limiter controls are separate child widgets
+// wired to the same ClientComp via signals.
+class StripCompPanel : public QWidget {
+    Q_OBJECT
+
+public:
+    enum class Side { Tx, Rx };
+
+    explicit StripCompPanel(AudioEngine* engine, QWidget* parent = nullptr);
+    ~StripCompPanel() override;
+
+    void showForTx();
+    void showForRx();
+
+signals:
+    // Fired when the bypass button is toggled inside the editor.  The
+    // docked applet subscribes so its Enable toggle stays in sync —
+    // both widgets read / write the same ClientComp::enabled flag.
+    // side identifies which path (Tx or Rx) was toggled.
+    void bypassToggled(Side side, bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+
+    // Pull the Bypass button / chain-order combo state from the engine
+    // so a programmatic change (e.g. loading settings) updates the UI.
+    void syncControlsFromEngine();
+
+    // Refresh meter widgets from the latest ClientComp snapshot.
+    void tickMeters();
+
+    // Commit a parameter change to the AudioEngine's ClientComp and
+    // persist via AppSettings.  All knob/canvas signals land here.
+    void applyThreshold(float db);
+    void applyRatio(float ratio);
+    void applyAttack(float ms);
+    void applyRelease(float ms);
+    void applyKnee(float db);
+    void applyMakeup(float db);
+    void applyLimiterEnabled(bool on);
+    void applyLimiterCeiling(float db);
+
+    AudioEngine*             m_audio{nullptr};
+    Side                     m_side{Side::Tx};
+    QWidget*                 m_titleBar{nullptr};   // EditorFramelessTitleBar*
+    class ClientComp*        comp() const;
+    void                     saveCompSettings() const;
+    ClientCompEditorCanvas*  m_canvas{nullptr};
+    ClientCompKnob*          m_ratio{nullptr};
+    ClientCompKnob*          m_attack{nullptr};
+    ClientCompKnob*          m_release{nullptr};
+    ClientCompKnob*          m_knee{nullptr};
+    ClientCompKnob*          m_makeup{nullptr};
+    ClientCompKnob*          m_ceiling{nullptr};
+    ClientCompThresholdFader* m_threshFader{nullptr};
+    ClientCompMeter*         m_grMeter{nullptr};
+    ClientCompMeter*         m_outputMeter{nullptr};
+    QPushButton*             m_bypass{nullptr};
+    ClientCompLimiterButton* m_limiterEnable{nullptr};
+    QTimer*                  m_meterTimer{nullptr};
+    bool                     m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/StripDeEssPanel.cpp
+++ b/src/gui/StripDeEssPanel.cpp
@@ -1,0 +1,386 @@
+#include "StripDeEssPanel.h"
+#include "ClientCompKnob.h"
+#include "ClientDeEssCurveWidget.h"
+#include "EditorFramelessTitleBar.h"
+#include "MeterSmoother.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientDeEss.h"
+
+#include <QCloseEvent>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QMoveEvent>
+#include <QElapsedTimer>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kDefaultWidth  = 720;
+constexpr int kDefaultHeight = 340;
+constexpr float kGrMaxDb    = 24.0f;   // bar full-scale (right-anchored)
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+// Gain-reduction bar mirroring ClientDeEssApplet's m_grBar — dark bg,
+// soft-red fill anchored on the right, -6 dB tick.  Uses the shared
+// MeterSmoother (30 ms attack, 180 ms release, polled at ~120 Hz) so
+// the motion matches every other meter in the app.
+class DeEssGrBar : public QWidget {
+public:
+    explicit DeEssGrBar(QWidget* parent = nullptr) : QWidget(parent)
+    {
+        setFixedHeight(10);
+        m_animTimer.setTimerType(Qt::PreciseTimer);
+        m_animTimer.setInterval(kMeterSmootherIntervalMs);
+        connect(&m_animTimer, &QTimer::timeout, this, [this]() {
+            if (!m_smooth.tick(m_animElapsed.restart()))
+                m_animTimer.stop();
+            update();
+        });
+    }
+    void setGrDb(float grDb) {
+        if (std::fabs(grDb - m_grDb) < 0.05f) return;
+        m_grDb = grDb;
+        m_smooth.setTarget(std::clamp(-grDb, 0.0f, kGrMaxDb) / kGrMaxDb);
+        if (!m_smooth.needsAnimation()) {
+            if (m_animTimer.isActive()) m_animTimer.stop();
+            update();
+        } else if (!m_animTimer.isActive()) {
+            m_animElapsed.restart();
+            m_animTimer.start();
+        }
+    }
+protected:
+    void paintEvent(QPaintEvent*) override {
+        QPainter p(this);
+        const QRectF r = rect();
+        p.fillRect(r, QColor("#0a1420"));
+        const float frac = m_smooth.value();
+        if (frac > 0.0f) {
+            const float w = frac * r.width();
+            QRectF fill(r.right() - w, r.top() + 1.0, w, r.height() - 2.0);
+            p.fillRect(fill, QColor("#d47272"));   // soft red
+        }
+        // -6 dB tick (typical Amount setting).
+        const float tickX = r.right() - (6.0f / kGrMaxDb) * r.width();
+        p.setPen(QPen(QColor("#2a4458"), 1.0));
+        p.drawLine(QPointF(tickX, r.top()), QPointF(tickX, r.bottom()));
+    }
+private:
+    float         m_grDb{0.0f};
+    MeterSmoother m_smooth;
+    QTimer        m_animTimer;
+    QElapsedTimer m_animElapsed;
+};
+
+const QString kBypassStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #0e1b28;"
+    "  color: #8aa8c0;"
+    "  border: 1px solid #243a4e;"
+    "  border-radius: 3px;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 12px;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e;"
+    "  color: #f2c14e;"
+    "  border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+} // namespace
+
+StripDeEssPanel::StripDeEssPanel(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent)
+    , m_audio(engine)
+{
+    const QString title = QString::fromUtf8("Aetherial De-Esser \xe2\x80\x94 TX");
+    setWindowTitle(title);
+    setStyleSheet(kWindowStyle);
+    resize(kDefaultWidth, kDefaultHeight);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(8, 0, 8, 8);
+    root->setSpacing(6);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    titleBar->setTitleText(title);
+    root->addWidget(titleBar);
+
+    // Bypass moved to the CHAIN widget's single-click gesture.
+
+    // Body: 3-column — left knobs | big curve | right knobs
+    auto* body = new QHBoxLayout;
+    body->setSpacing(12);
+
+    // Left column: Frequency / Q / Threshold
+    auto* left = new QVBoxLayout;
+    left->setSpacing(10);
+
+    m_freq = new ClientCompKnob;
+    m_freq->setLabel("Frequency");
+    m_freq->setCenterLabelMode(true);
+    m_freq->setRange(1000.0f, 12000.0f);
+    m_freq->setDefault(6000.0f);
+    // Log sweep across 1..12 kHz so the knob resolution matches how
+    // ears perceive frequency (doubles are equidistant).
+    m_freq->setValueFromNorm([](float n) {
+        return 1000.0f * std::pow(12.0f, n);       // 1 → 12 kHz
+    });
+    m_freq->setNormFromValue([](float v) {
+        return std::log(std::max(1000.0f, v) / 1000.0f)
+               / std::log(12.0f);
+    });
+    m_freq->setLabelFormat([](float v) {
+        return (v >= 1000.0f)
+            ? QString::number(v / 1000.0f, 'f', 2) + " kHz"
+            : QString::number(v, 'f', 0) + " Hz";
+    });
+    m_freq->setFixedSize(76, 76);
+    connect(m_freq, &ClientCompKnob::valueChanged,
+            this, &StripDeEssPanel::applyFrequency);
+    left->addWidget(m_freq, 0, Qt::AlignHCenter);
+
+    m_q = new ClientCompKnob;
+    m_q->setLabel("Q");
+    m_q->setCenterLabelMode(true);
+    m_q->setRange(0.5f, 5.0f);
+    m_q->setDefault(2.0f);
+    m_q->setValueFromNorm([](float n) { return 0.5f + n * 4.5f; });
+    m_q->setNormFromValue([](float v) { return (v - 0.5f) / 4.5f; });
+    m_q->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 2);
+    });
+    m_q->setFixedSize(76, 76);
+    connect(m_q, &ClientCompKnob::valueChanged,
+            this, &StripDeEssPanel::applyQ);
+    left->addWidget(m_q, 0, Qt::AlignHCenter);
+
+    m_threshold = new ClientCompKnob;
+    m_threshold->setLabel("Threshold");
+    m_threshold->setCenterLabelMode(true);
+    m_threshold->setRange(-60.0f, 0.0f);
+    m_threshold->setDefault(-30.0f);
+    m_threshold->setValueFromNorm([](float n) { return -60.0f + n * 60.0f; });
+    m_threshold->setNormFromValue([](float v) { return (v + 60.0f) / 60.0f; });
+    m_threshold->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + " dB";
+    });
+    m_threshold->setFixedSize(76, 76);
+    connect(m_threshold, &ClientCompKnob::valueChanged,
+            this, &StripDeEssPanel::applyThreshold);
+    left->addWidget(m_threshold, 0, Qt::AlignHCenter);
+
+    left->addStretch();
+    body->addLayout(left, 0);
+
+    // Center: sidechain bandpass response curve (bigger than the
+    // applet's compact version — shows labels, threshold line, ball).
+    // Curve on top, GR bar below — same visual family as the docked
+    // applet's gain-reduction strip.  Curve height drops from 200 to
+    // ~140 to make room for the bar without growing the panel.
+    auto* centre = new QVBoxLayout;
+    centre->setContentsMargins(0, 0, 0, 0);
+    centre->setSpacing(4);
+    m_curve = new ClientDeEssCurveWidget;
+    m_curve->setCompactMode(false);
+    m_curve->setMinimumHeight(140);
+    centre->addWidget(m_curve, 1);
+    auto* grBar = new DeEssGrBar;
+    m_grBar = grBar;
+    centre->addWidget(grBar);
+    body->addLayout(centre, 1);
+
+    // Right column: Amount / Attack / Release
+    auto* right = new QVBoxLayout;
+    right->setSpacing(10);
+
+    m_amount = new ClientCompKnob;
+    m_amount->setLabel("Amount");
+    m_amount->setCenterLabelMode(true);
+    m_amount->setRange(-24.0f, 0.0f);
+    m_amount->setDefault(-6.0f);
+    m_amount->setValueFromNorm([](float n) { return -24.0f + n * 24.0f; });
+    m_amount->setNormFromValue([](float v) { return (v + 24.0f) / 24.0f; });
+    m_amount->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + " dB";
+    });
+    m_amount->setFixedSize(76, 76);
+    connect(m_amount, &ClientCompKnob::valueChanged,
+            this, &StripDeEssPanel::applyAmount);
+    right->addWidget(m_amount, 0, Qt::AlignHCenter);
+
+    m_attack = new ClientCompKnob;
+    m_attack->setLabel("Attack");
+    m_attack->setCenterLabelMode(true);
+    m_attack->setRange(0.1f, 30.0f);
+    m_attack->setDefault(1.0f);
+    m_attack->setValueFromNorm([](float n) {
+        return 0.1f * std::pow(300.0f, n);         // 0.1..30 ms
+    });
+    m_attack->setNormFromValue([](float v) {
+        return std::log(std::max(0.1f, v) / 0.1f) / std::log(300.0f);
+    });
+    m_attack->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 10.0f ? 2 : 1) + " ms";
+    });
+    m_attack->setFixedSize(76, 76);
+    connect(m_attack, &ClientCompKnob::valueChanged,
+            this, &StripDeEssPanel::applyAttack);
+    right->addWidget(m_attack, 0, Qt::AlignHCenter);
+
+    m_release = new ClientCompKnob;
+    m_release->setLabel("Release");
+    m_release->setCenterLabelMode(true);
+    m_release->setRange(10.0f, 500.0f);
+    m_release->setDefault(100.0f);
+    m_release->setValueFromNorm([](float n) {
+        return 10.0f * std::pow(50.0f, n);         // 10..500 ms
+    });
+    m_release->setNormFromValue([](float v) {
+        return std::log(std::max(10.0f, v) / 10.0f) / std::log(50.0f);
+    });
+    m_release->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 100.0f ? 1 : 0) + " ms";
+    });
+    m_release->setFixedSize(76, 76);
+    connect(m_release, &ClientCompKnob::valueChanged,
+            this, &StripDeEssPanel::applyRelease);
+    right->addWidget(m_release, 0, Qt::AlignHCenter);
+
+    right->addStretch();
+    body->addLayout(right, 0);
+
+    root->addLayout(body);
+
+    // Bind the curve to the de-esser so it starts polling.
+    if (m_audio && m_audio->clientDeEssTx()) {
+        m_curve->setDeEss(m_audio->clientDeEssTx());
+    }
+
+    syncControlsFromEngine();
+
+    m_syncTimer = new QTimer(this);
+    m_syncTimer->setInterval(33);
+    connect(m_syncTimer, &QTimer::timeout,
+            this, &StripDeEssPanel::syncControlsFromEngine);
+}
+
+StripDeEssPanel::~StripDeEssPanel() = default;
+
+void StripDeEssPanel::showForTx()
+{
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void StripDeEssPanel::syncControlsFromEngine()
+{
+    if (!m_audio || !m_audio->clientDeEssTx()) return;
+    ClientDeEss* d = m_audio->clientDeEssTx();
+    m_restoring = true;
+
+    { QSignalBlocker b(m_freq);      m_freq->setValue(d->frequencyHz()); }
+    { QSignalBlocker b(m_q);         m_q->setValue(d->q()); }
+    { QSignalBlocker b(m_threshold); m_threshold->setValue(d->thresholdDb()); }
+    { QSignalBlocker b(m_amount);    m_amount->setValue(d->amountDb()); }
+    { QSignalBlocker b(m_attack);    m_attack->setValue(d->attackMs()); }
+    { QSignalBlocker b(m_release);   m_release->setValue(d->releaseMs()); }
+
+    if (auto* bar = static_cast<DeEssGrBar*>(m_grBar))
+        bar->setGrDb(d->gainReductionDb());
+
+    m_restoring = false;
+}
+
+void StripDeEssPanel::applyFrequency(float hz)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setFrequencyHz(hz);
+    m_audio->saveClientDeEssSettings();
+    if (m_curve) m_curve->update();
+}
+void StripDeEssPanel::applyQ(float q)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setQ(q);
+    m_audio->saveClientDeEssSettings();
+    if (m_curve) m_curve->update();
+}
+void StripDeEssPanel::applyThreshold(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setThresholdDb(db);
+    m_audio->saveClientDeEssSettings();
+    if (m_curve) m_curve->update();
+}
+void StripDeEssPanel::applyAmount(float db)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setAmountDb(db);
+    m_audio->saveClientDeEssSettings();
+}
+void StripDeEssPanel::applyAttack(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setAttackMs(ms);
+    m_audio->saveClientDeEssSettings();
+}
+void StripDeEssPanel::applyRelease(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    m_audio->clientDeEssTx()->setReleaseMs(ms);
+    m_audio->saveClientDeEssSettings();
+}
+
+void StripDeEssPanel::saveGeometryToSettings()
+{
+    if (m_restoring) return;
+    AppSettings::instance().setValue(
+        "StripDeEssPanelGeometry",
+        QString::fromLatin1(saveGeometry().toBase64()));
+}
+
+void StripDeEssPanel::restoreGeometryFromSettings()
+{
+    m_restoring = true;
+    const QString b64 = AppSettings::instance()
+        .value("StripDeEssPanelGeometry", "").toString();
+    if (!b64.isEmpty()) {
+        restoreGeometry(QByteArray::fromBase64(b64.toLatin1()));
+    }
+    m_restoring = false;
+}
+
+void StripDeEssPanel::closeEvent(QCloseEvent* ev)
+{ saveGeometryToSettings(); QWidget::closeEvent(ev); }
+void StripDeEssPanel::moveEvent(QMoveEvent* ev)
+{ saveGeometryToSettings(); QWidget::moveEvent(ev); }
+void StripDeEssPanel::resizeEvent(QResizeEvent* ev)
+{ saveGeometryToSettings(); QWidget::resizeEvent(ev); }
+void StripDeEssPanel::showEvent(QShowEvent* ev)
+{ QWidget::showEvent(ev); }
+void StripDeEssPanel::hideEvent(QHideEvent* ev)
+{ saveGeometryToSettings(); QWidget::hideEvent(ev); }
+
+} // namespace AetherSDR

--- a/src/gui/StripDeEssPanel.h
+++ b/src/gui/StripDeEssPanel.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;             // reused — generic rotary knob
+class ClientDeEssCurveWidget;
+
+// Floating editor for the client-side de-esser.  Three-column layout
+// inspired by Ableton's Compressor (the de-esser preset), using our
+// actual de-esser parameters:
+//
+//   ┌─ bypass ──────────────────── × ┐
+//   │ ┌──────┐ ┌────────────┐ ┌────┐ │
+//   │ │ FREQ │ │            │ │ AMT│ │
+//   │ │      │ │  bandpass  │ │    │ │
+//   │ │  Q   │ │  response  │ │ ATK│ │
+//   │ │      │ │  + live    │ │    │ │
+//   │ │ THR  │ │  ball      │ │ REL│ │
+//   │ └──────┘ └────────────┘ └────┘ │
+//   └────────────────────────────────┘
+class StripDeEssPanel : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit StripDeEssPanel(AudioEngine* engine, QWidget* parent = nullptr);
+    ~StripDeEssPanel() override;
+
+    void showForTx();
+
+signals:
+    void bypassToggled(bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+    void syncControlsFromEngine();
+
+    void applyFrequency(float hz);
+    void applyQ(float q);
+    void applyThreshold(float db);
+    void applyAmount(float db);
+    void applyAttack(float ms);
+    void applyRelease(float ms);
+
+    AudioEngine*            m_audio{nullptr};
+    ClientDeEssCurveWidget* m_curve{nullptr};
+    QWidget*                m_grBar{nullptr};   // gain-reduction bar below curve
+    ClientCompKnob*         m_freq{nullptr};
+    ClientCompKnob*         m_q{nullptr};
+    ClientCompKnob*         m_threshold{nullptr};
+    ClientCompKnob*         m_amount{nullptr};
+    ClientCompKnob*         m_attack{nullptr};
+    ClientCompKnob*         m_release{nullptr};
+    QPushButton*            m_bypass{nullptr};
+    QTimer*                 m_syncTimer{nullptr};   // mirror engine → knobs
+    bool                    m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/StripEqPanel.cpp
+++ b/src/gui/StripEqPanel.cpp
@@ -1,0 +1,496 @@
+#include "StripEqPanel.h"
+#include "ClientEqEditorCanvas.h"
+#include "ClientEqFftAnalyzer.h"
+#include "ClientEqIconRow.h"
+#include "ClientEqOutputFader.h"
+#include "ClientEqParamRow.h"
+#include "ComboStyle.h"
+#include "EditorFramelessTitleBar.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientEq.h"
+
+#include <QCloseEvent>
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QLabel>
+#include <QMoveEvent>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <vector>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kDefaultWidth  = 900;
+constexpr int kDefaultHeight = 520;
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+// Bypass button visual: unchecked = EQ active (subtle), checked = bypass
+// engaged (amber, signals "this is muting your work").  Plugin convention.
+const QString kBypassStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #0e1b28;"
+    "  color: #8aa8c0;"
+    "  border: 1px solid #243a4e;"
+    "  border-radius: 3px;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 12px;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e;"
+    "  color: #f2c14e;"
+    "  border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+} // namespace
+
+StripEqPanel::StripEqPanel(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent)
+    , m_audio(engine)
+{
+    setWindowTitle("Aetherial Parametric EQ");
+    setStyleSheet(kWindowStyle);
+    resize(kDefaultWidth, kDefaultHeight);
+
+    auto* root = new QVBoxLayout(this);
+    // Margin trimmed to 0 at the top so the frameless title bar hugs
+    // the window edge; sides + bottom keep the original 8 px padding.
+    root->setContentsMargins(8, 0, 8, 8);
+    root->setSpacing(6);
+
+    // Custom 20 px-tall title bar with the active path heading on the
+    // left and the min / max / close trio on the right.  Press-and-drag
+    // anywhere on it starts a window move.  Stored as a QWidget* in the
+    // header to avoid leaking the inline class — cast at use sites.
+    auto* titleBar = new EditorFramelessTitleBar;
+    m_titleBar = titleBar;
+    root->addWidget(titleBar);
+
+    // Interaction hint + filter family + bypass strip.  Path heading
+    // lives in the frameless title bar above instead.
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(8);
+        auto* hint = new QLabel(
+            "Drag peak/shelf = freq + gain · "
+            "drag HP/LP = freq + Q · Shift + drag for Q · "
+            "click icon to cycle type");
+        hint->setStyleSheet("QLabel { color: #506070; font-size: 10px; }");
+        row->addWidget(hint, 1);
+
+        // Smoothing — fractional-octave display smoothing for the FFT
+        // analyzer trace.  Doesn't affect EQ math, just the visual.
+        // Persisted globally (single user preference, shared between RX
+        // and TX editors).
+        auto* smoothingLbl = new QLabel("Smoothing:");
+        smoothingLbl->setStyleSheet(
+            "QLabel { color: #c8d8e8; font-size: 11px; font-weight: bold; }");
+        row->addWidget(smoothingLbl);
+
+        auto* smoothingCombo = new QComboBox;
+        smoothingCombo->addItem("Off (1/96)", 96);
+        smoothingCombo->addItem("1/24",       24);
+        smoothingCombo->addItem("1/12",       12);
+        smoothingCombo->addItem("1/6",         6);
+        smoothingCombo->addItem("1/3",         3);
+        smoothingCombo->setFixedHeight(24);
+        smoothingCombo->setToolTip(
+            "Fractional-octave smoothing applied to the analyzer trace.\n"
+            "Lower fraction = smoother (1/3 = most, 1/96 = off).\n"
+            "Affects display only — EQ math is unchanged.");
+        AetherSDR::applyComboStyle(smoothingCombo);
+
+        const int savedFraction = AppSettings::instance()
+            .value("ClientEqSmoothingFraction", "96").toInt();
+        const int savedIdx = smoothingCombo->findData(savedFraction);
+        smoothingCombo->setCurrentIndex(savedIdx >= 0 ? savedIdx : 0);
+        // Cache the saved fraction on a member so it can be applied to
+        // m_canvas later — the canvas isn't constructed yet at this point
+        // in the toolbar setup.  Pushing to m_canvas here was a no-op
+        // because m_canvas is still nullptr.
+        m_savedSmoothingFraction = savedFraction;
+
+        connect(smoothingCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this, smoothingCombo](int idx) {
+            const int n = smoothingCombo->itemData(idx).toInt();
+            if (m_canvas) m_canvas->setSmoothingOctaveFraction(n);
+            AppSettings::instance().setValue(
+                "ClientEqSmoothingFraction", QString::number(n));
+            AppSettings::instance().save();
+        });
+        row->addWidget(smoothingCombo);
+
+        // Peak Hold — when checked, the analyzer's per-bin peak trace
+        // stops decaying so the highest level seen at each frequency
+        // stays put.  Useful for spotting resonances while tuning.
+        auto* peakHoldBtn = new QPushButton("Peak Hold");
+        peakHoldBtn->setCheckable(true);
+        peakHoldBtn->setFixedHeight(24);
+        peakHoldBtn->setToolTip(
+            "Freeze the analyzer peak-hold trace at its highest level.\n"
+            "Toggle off to resume normal decay.");
+        peakHoldBtn->setStyleSheet(
+            "QPushButton {"
+            "  background: #0e1b28; color: #c8d8e8;"
+            "  border: 1px solid #243a4e; border-radius: 3px;"
+            "  padding: 2px 12px; font-size: 11px; font-weight: bold;"
+            "}"
+            "QPushButton:hover { background: #1a2a3a; }"
+            "QPushButton:checked {"
+            "  background: #c8a040; color: #0a0a18;"
+            "  border-color: #d4b050;"
+            "}"
+            "QPushButton:checked:hover { background: #d4b050; }");
+        connect(peakHoldBtn, &QPushButton::toggled, this, [this](bool on) {
+            if (m_canvas) m_canvas->setPeakHoldFrozen(on);
+        });
+        row->addWidget(peakHoldBtn);
+
+        // Global filter-family selector — applies to HP/LP cascade math.
+        // Shelves and peaks keep their native 2nd-order topology.
+        m_familyCombo = new QComboBox;
+        m_familyCombo->addItem("Butterworth",
+            static_cast<int>(ClientEq::FilterFamily::Butterworth));
+        m_familyCombo->addItem("Chebyshev",
+            static_cast<int>(ClientEq::FilterFamily::Chebyshev));
+        m_familyCombo->addItem("Bessel",
+            static_cast<int>(ClientEq::FilterFamily::Bessel));
+        m_familyCombo->addItem("Elliptic",
+            static_cast<int>(ClientEq::FilterFamily::Elliptic));
+        m_familyCombo->setFixedHeight(24);
+        m_familyCombo->setToolTip(
+            "Filter family for HP / LP cascade math.\n"
+            "• Butterworth — maximally flat passband\n"
+            "• Chebyshev — steeper transition, 1 dB passband ripple\n"
+            "• Bessel — linear phase, gentler rolloff\n"
+            "• Elliptic — steepest transition, ripple in both bands");
+        AetherSDR::applyComboStyle(m_familyCombo);
+        connect(m_familyCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this](int idx) {
+            ClientEq* eq = (m_path == ClientEqApplet::Path::Rx)
+                ? m_audio->clientEqRx() : m_audio->clientEqTx();
+            if (!eq) return;
+            eq->setFilterFamily(static_cast<ClientEq::FilterFamily>(idx));
+            if (m_audio) m_audio->saveClientEqSettings();
+            if (m_canvas) m_canvas->update();
+        });
+        row->addWidget(m_familyCombo);
+
+        // Reset — drops every band back to ClientEq::defaultBand(i),
+        // restores the default 10-band count, and resets the filter
+        // family to Butterworth.  Saves immediately so the wipe
+        // survives a restart.
+        auto* resetBtn = new QPushButton("Reset");
+        resetBtn->setFixedHeight(24);
+        resetBtn->setToolTip("Reset all bands to default values");
+        resetBtn->setStyleSheet(
+            "QPushButton {"
+            "  background: #0e1b28; color: #c8d8e8;"
+            "  border: 1px solid #243a4e; border-radius: 3px;"
+            "  padding: 2px 12px; font-size: 11px; font-weight: bold;"
+            "}"
+            "QPushButton:hover { background: #1a2a3a; }"
+            "QPushButton:pressed { background: #243a4e; }");
+        connect(resetBtn, &QPushButton::clicked, this, [this]() {
+            ClientEq* eq = (m_path == ClientEqApplet::Path::Rx)
+                ? m_audio->clientEqRx() : m_audio->clientEqTx();
+            if (!eq) return;
+            eq->setActiveBandCount(ClientEq::kDefaultBandCount);
+            for (int i = 0; i < ClientEq::kDefaultBandCount; ++i) {
+                eq->setBand(i, ClientEq::defaultBand(i));
+            }
+            eq->setFilterFamily(ClientEq::FilterFamily::Butterworth);
+            if (m_audio) m_audio->saveClientEqSettings();
+
+            if (m_familyCombo) {
+                QSignalBlocker b(m_familyCombo);
+                m_familyCombo->setCurrentIndex(0);   // Butterworth
+            }
+            if (m_canvas)   m_canvas->update();
+            if (m_iconRow)  m_iconRow->update();
+            if (m_paramRow) m_paramRow->update();
+        });
+        row->addWidget(resetBtn);
+
+        // Bypass button moved to the CHAIN widget's single-click
+        // gesture.  Keyboard shortcut retired along with the button.
+
+        root->addLayout(row);
+    }
+
+    // Main body: icon row + canvas + param row stacked vertically, with
+    // the output fader in a sibling column on the right.  The fader spans
+    // the full height of the EQ strip so its meter aligns with the
+    // canvas's visible range.
+    auto* body = new QHBoxLayout;
+    body->setContentsMargins(0, 0, 0, 0);
+    body->setSpacing(8);
+
+    auto* eqColumn = new QVBoxLayout;
+    eqColumn->setContentsMargins(0, 0, 0, 0);
+    eqColumn->setSpacing(6);
+
+    m_iconRow = new ClientEqIconRow;
+    m_iconRow->setAudioEngine(m_audio);
+    eqColumn->addWidget(m_iconRow);
+
+    m_canvas = new ClientEqEditorCanvas;
+    m_canvas->setAudioEngine(m_audio);
+    // Apply the saved smoothing fraction now that the canvas exists.
+    // The combo box already shows the right value from the toolbar build,
+    // but the canvas needed to be constructed before this push could land.
+    m_canvas->setSmoothingOctaveFraction(m_savedSmoothingFraction);
+    eqColumn->addWidget(m_canvas, 1);
+    // Forward cutoff-line drag events as a path-tagged signal so MainWindow
+    // can dispatch to TransmitModel (TX) or the active SliceModel (RX).
+    connect(m_canvas, &ClientEqEditorCanvas::cutoffsDragged,
+            this, [this](int audioLow, int audioHigh) {
+        emit cutoffsDragRequested(m_path, audioLow, audioHigh);
+    });
+
+    m_paramRow = new ClientEqParamRow;
+    eqColumn->addWidget(m_paramRow);
+
+    body->addLayout(eqColumn, 1);
+
+    // Output fader — vertical meter + slider + dB readout on the right.
+    m_outFader = new ClientEqOutputFader;
+    connect(m_outFader, &ClientEqOutputFader::gainChanged,
+            this, [this](float linear) {
+        ClientEq* eq = (m_path == ClientEqApplet::Path::Rx)
+            ? m_audio->clientEqRx() : m_audio->clientEqTx();
+        if (!eq) return;
+        eq->setMasterGain(linear);
+        if (m_audio) m_audio->saveClientEqSettings();
+    });
+    body->addWidget(m_outFader);
+
+    root->addLayout(body, 1);
+
+    // Selection plumbing: any of the three views announcing a selection
+    // change fans out to the other two, plus triggers a paint refresh.
+    connect(m_canvas, &ClientEqCurveWidget::selectedBandChanged,
+            this, &StripEqPanel::syncSelection);
+    connect(m_iconRow, &ClientEqIconRow::bandSelected,
+            this, &StripEqPanel::syncSelection);
+    connect(m_paramRow, &ClientEqParamRow::bandSelected,
+            this, &StripEqPanel::syncSelection);
+
+    // Any canvas-side band mutation refreshes the text-valued widgets
+    // (icon row rebuilds on type / count change; param row updates
+    // numeric display live during drags).
+    connect(m_canvas, &ClientEqCurveWidget::bandsChanged,
+            this, [this]() {
+        if (m_iconRow)  m_iconRow->refresh();
+        if (m_paramRow) {
+            m_paramRow->refresh();
+            m_paramRow->setSelectedBand(m_canvas->selectedBand());
+        }
+    });
+
+    // FFT analyzer ticks on a QTimer while the editor is visible.  Pulls
+    // the most-recent post-EQ samples from AudioEngine, runs the FFT on
+    // the UI thread (microseconds at 256 points), and pushes smoothed
+    // bins into the canvas.  The timer is stopped in hideEvent so it
+    // doesn't burn CPU while the editor is closed.
+    m_fftAnalyzer = std::make_unique<ClientEqFftAnalyzer>();
+    m_fftTimer = new QTimer(this);
+    m_fftTimer->setInterval(40);  // 25 Hz
+    connect(m_fftTimer, &QTimer::timeout,
+            this, &StripEqPanel::tickFftAnalyzer);
+
+    restoreGeometryFromSettings();
+}
+
+StripEqPanel::~StripEqPanel() = default;
+
+void StripEqPanel::tickFftAnalyzer()
+{
+    if (!m_audio || !m_canvas || !m_fftAnalyzer) return;
+
+    std::vector<float> samples(ClientEqFftAnalyzer::kFftSize, 0.0f);
+    bool ok = false;
+    if (m_path == ClientEqApplet::Path::Rx) {
+        ok = m_audio->copyRecentClientEqRxSamples(
+                samples.data(), ClientEqFftAnalyzer::kFftSize);
+    } else {
+        ok = m_audio->copyRecentClientEqTxSamples(
+                samples.data(), ClientEqFftAnalyzer::kFftSize);
+    }
+    if (!ok) return;
+
+    m_fftAnalyzer->update(samples.data(), ClientEqFftAnalyzer::kFftSize);
+
+    ClientEq* eq = (m_path == ClientEqApplet::Path::Rx)
+        ? m_audio->clientEqRx() : m_audio->clientEqTx();
+    const double fs = eq ? eq->sampleRate() : 24000.0;
+    m_canvas->setFftBinsDb(m_fftAnalyzer->magnitudesDb(), fs);
+
+    // Feed the output fader a peak level from the same samples.  Cheap —
+    // one pass over the 2048-sample block while we already have it warm.
+    if (m_outFader) {
+        float peak = 0.0f;
+        for (float s : samples) {
+            peak = std::max(peak, std::fabs(s));
+        }
+        m_outFader->setPeakLinear(peak);
+    }
+}
+
+void StripEqPanel::syncBypassFromEq()
+{
+    // No in-editor bypass control — bypass lives on the CHAIN widget.
+    // Left as a no-op so existing callers compile; the canvas still
+    // recolours itself via its own enabled check.
+}
+
+void StripEqPanel::syncSelection(int idx)
+{
+    if (m_iconRow)  m_iconRow->setSelectedBand(idx);
+    if (m_canvas)   m_canvas->setSelectedBand(idx);
+    if (m_paramRow) m_paramRow->setSelectedBand(idx);
+    // Param row values also move under drags / type cycles, so refresh
+    // display text whenever anything gets selected.
+    if (m_paramRow) m_paramRow->refreshValues();
+}
+
+void StripEqPanel::showForPath(ClientEqApplet::Path path)
+{
+    m_path = path;
+    if (!m_audio || !m_canvas) return;
+
+    ClientEq* eq = (path == ClientEqApplet::Path::Rx)
+        ? m_audio->clientEqRx() : m_audio->clientEqTx();
+    m_canvas->setEq(eq);
+    if (m_iconRow)  m_iconRow->setEq(eq);
+    if (m_paramRow) m_paramRow->setEq(eq);
+    if (m_outFader && eq) m_outFader->setGainLinear(eq->masterGain());
+    if (m_familyCombo && eq) {
+        QSignalBlocker b(m_familyCombo);
+        m_familyCombo->setCurrentIndex(static_cast<int>(eq->filterFamily()));
+    }
+    syncBypassFromEq();
+    // Clear selection on path swap — the previously-selected index
+    // almost certainly doesn't correspond to the other path's bands.
+    syncSelection(-1);
+    const QString title = path == ClientEqApplet::Path::Rx
+        ? QStringLiteral("Aetherial Parametric EQ — RX")
+        : QStringLiteral("Aetherial Parametric EQ — TX");
+    // m_titleBar is always an EditorFramelessTitleBar* — kept as
+    // QWidget* in the header so the inline class stays cpp-only.
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+
+    // Re-apply the cached cutoffs for whichever path we're switching to,
+    // so RX/TX swaps restore the correct dashed guides without waiting
+    // for the next slice/filter event.
+    if (m_canvas) {
+        if (path == ClientEqApplet::Path::Rx)
+            m_canvas->setFilterCutoffs(m_rxFilterLowCutHz, m_rxFilterHighCutHz);
+        else
+            m_canvas->setFilterCutoffs(m_txFilterLowCutHz, m_txFilterHighCutHz);
+    }
+
+    if (!isVisible()) {
+        show();
+    }
+    raise();
+    activateWindow();
+}
+
+void StripEqPanel::setTxFilterCutoffs(int lowHz, int highHz)
+{
+    m_txFilterLowCutHz = lowHz;
+    m_txFilterHighCutHz = highHz;
+    if (m_canvas && m_path == ClientEqApplet::Path::Tx)
+        m_canvas->setFilterCutoffs(lowHz, highHz);
+}
+
+void StripEqPanel::setRxFilterCutoffs(int audioLowHz, int audioHighHz)
+{
+    m_rxFilterLowCutHz = audioLowHz;
+    m_rxFilterHighCutHz = audioHighHz;
+    if (m_canvas && m_path == ClientEqApplet::Path::Rx)
+        m_canvas->setFilterCutoffs(audioLowHz, audioHighHz);
+}
+
+void StripEqPanel::closeEvent(QCloseEvent* ev)
+{
+    saveGeometryToSettings();
+    QWidget::closeEvent(ev);
+}
+
+void StripEqPanel::showEvent(QShowEvent* ev)
+{
+    QWidget::showEvent(ev);
+    if (m_fftAnalyzer) m_fftAnalyzer->reset();
+    if (m_fftTimer && !m_fftTimer->isActive()) m_fftTimer->start();
+}
+
+void StripEqPanel::hideEvent(QHideEvent* ev)
+{
+    QWidget::hideEvent(ev);
+    if (m_fftTimer) m_fftTimer->stop();
+    // Clear the canvas's last FFT snapshot so it doesn't paint stale
+    // energy next time the window opens.
+    if (m_canvas) m_canvas->setFftBinsDb({}, 24000.0);
+}
+
+void StripEqPanel::moveEvent(QMoveEvent* ev)
+{
+    QWidget::moveEvent(ev);
+    if (!m_restoring && isVisible()) saveGeometryToSettings();
+}
+
+void StripEqPanel::resizeEvent(QResizeEvent* ev)
+{
+    QWidget::resizeEvent(ev);
+    if (!m_restoring && isVisible()) saveGeometryToSettings();
+}
+
+void StripEqPanel::saveGeometryToSettings()
+{
+    auto& s = AppSettings::instance();
+    const QRect g = geometry();
+    s.setValue("StripEqPanel_X", QString::number(g.x()));
+    s.setValue("StripEqPanel_Y", QString::number(g.y()));
+    s.setValue("StripEqPanel_W", QString::number(g.width()));
+    s.setValue("StripEqPanel_H", QString::number(g.height()));
+    s.save();
+}
+
+void StripEqPanel::restoreGeometryFromSettings()
+{
+    m_restoring = true;
+    auto& s = AppSettings::instance();
+    const int w = s.value("StripEqPanel_W",
+                          QString::number(kDefaultWidth)).toString().toInt();
+    const int h = s.value("StripEqPanel_H",
+                          QString::number(kDefaultHeight)).toString().toInt();
+    resize(std::max(w, 600), std::max(h, 320));
+
+    // Only honour saved position if it's non-default — otherwise let the
+    // window manager pick a reasonable spawn spot.
+    const QString xs = s.value("StripEqPanel_X", "").toString();
+    const QString ys = s.value("StripEqPanel_Y", "").toString();
+    if (!xs.isEmpty() && !ys.isEmpty()) {
+        move(xs.toInt(), ys.toInt());
+    }
+    m_restoring = false;
+}
+
+} // namespace AetherSDR

--- a/src/gui/StripEqPanel.h
+++ b/src/gui/StripEqPanel.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "ClientEqApplet.h"  // for Path enum
+#include <QWidget>
+#include <memory>
+
+class QComboBox;
+class QLabel;
+class QPushButton;
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientEqEditorCanvas;
+class ClientEqFftAnalyzer;
+class ClientEqIconRow;
+class ClientEqOutputFader;
+class ClientEqParamRow;
+
+// Floating editor window for the client-side parametric EQ. One single
+// instance lives on MainWindow; calling showForPath() swaps its bound
+// ClientEq between RX and TX and raises the window. Geometry persists
+// across shows via AppSettings (`StripEqPanelGeometry` key).
+//
+// Phase B.2 layout: title bar, path-indicator strip, large interactive
+// curve canvas. Phases B.3+ add the filter-type icon row at the top,
+// bottom parameter-text row with per-band columns, master gain knob on
+// the right, and the FFT analyzer overlay inside the canvas.
+class StripEqPanel : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit StripEqPanel(AudioEngine* engine, QWidget* parent = nullptr);
+    ~StripEqPanel() override;
+
+    // Switch the editor to the given path and show / raise the window.
+    // Safe to call whether or not the window is currently visible.
+    void showForPath(ClientEqApplet::Path path);
+
+    // Push the radio's TX low/high filter cutoffs to the canvas as
+    // dashed yellow guide lines.  No-op when the editor's current path
+    // is RX.  Pass 0 for either edge to suppress that guide.
+    void setTxFilterCutoffs(int lowHz, int highHz);
+
+    // Push the active RX slice's filter passband (audio-frequency
+    // domain) to the canvas.  No-op when the editor's current path is TX.
+    // Cached so RX → TX → RX path swaps restore the correct guides.
+    void setRxFilterCutoffs(int audioLowHz, int audioHighHz);
+
+signals:
+    // Fired when the bypass button is toggled in the editor. The docked
+    // applet subscribes so its Enable toggle stays in sync — both widgets
+    // read/write the same ClientEq::enabled flag underneath.
+    void bypassToggled(ClientEqApplet::Path path, bool bypassed);
+
+    // Fired live during a cutoff-line drag.  Audio-domain Hz; MainWindow
+    // converts back to TX-filter writes (path = Tx) or active-slice
+    // filter writes with mode-aware offset reflection (path = Rx).
+    void cutoffsDragRequested(ClientEqApplet::Path path,
+                              int audioLowHz, int audioHighHz);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+
+    // Fans a band-selection change out to icon row, canvas, and param row
+    // so all three views share the same highlighted column / handle.
+    void syncSelection(int idx);
+
+    // Refresh bypass-button state from the bound ClientEq's enabled flag.
+    void syncBypassFromEq();
+
+    // Pull latest post-EQ samples from AudioEngine, run the FFT, push
+    // the smoothed bins into the curve widget. Called by m_fftTimer.
+    void tickFftAnalyzer();
+
+    AudioEngine*               m_audio{nullptr};
+    ClientEqApplet::Path       m_path{ClientEqApplet::Path::Rx};
+    int                        m_txFilterLowCutHz{0};
+    int                        m_txFilterHighCutHz{0};
+    int                        m_rxFilterLowCutHz{0};
+    int                        m_rxFilterHighCutHz{0};
+    int                        m_savedSmoothingFraction{96};
+    // The frameless title bar carries the active path label (e.g.
+    // "Aetherial Parametric EQ — TX").  Held as a void* + cast at use
+    // site to keep the inline EditorFramelessTitleBar class out of the
+    // public header.
+    QWidget*                   m_titleBar{nullptr};
+    QComboBox*                 m_familyCombo{nullptr};
+    QPushButton*               m_bypass{nullptr};
+    ClientEqIconRow*           m_iconRow{nullptr};
+    ClientEqEditorCanvas*      m_canvas{nullptr};
+    ClientEqParamRow*          m_paramRow{nullptr};
+    ClientEqOutputFader*       m_outFader{nullptr};
+    QTimer*                    m_fftTimer{nullptr};
+    std::unique_ptr<ClientEqFftAnalyzer> m_fftAnalyzer;
+    bool                       m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/StripGatePanel.cpp
+++ b/src/gui/StripGatePanel.cpp
@@ -1,0 +1,549 @@
+#include "StripGatePanel.h"
+#include "ClientCompKnob.h"
+#include "ClientGateCurveWidget.h"
+#include "ClientGateLevelView.h"
+#include "EditorFramelessTitleBar.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientGate.h"
+
+#include <QCloseEvent>
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QStackedWidget>
+#include <QHideEvent>
+#include <QLabel>
+#include <QMoveEvent>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kDefaultWidth  = 760;
+constexpr int kDefaultHeight = 380;
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+const QString kBypassStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #0e1b28;"
+    "  color: #8aa8c0;"
+    "  border: 1px solid #243a4e;"
+    "  border-radius: 3px;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 12px;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e;"
+    "  color: #f2c14e;"
+    "  border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+// Flip (Expander/Gate) — two custom checked states instead of the
+// usual idle→active swap: Expander (unchecked) uses the SQL/MIC
+// green palette, Gate (checked) uses the amber palette that marks
+// more-aggressive settings elsewhere in the chain.  The colour
+// itself tells you which mode you're in without reading the label.
+const QString kFlipStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #006040; border: 1px solid #00a060; border-radius: 3px;"
+    "  color: #00ff88; font-size: 10px; font-weight: bold; padding: 3px 6px;"
+    "}"
+    "QPushButton:hover { background: #007050; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e; color: #f2c14e; border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+// Lookahead dropdown values in ms.  0 disables the delay line; 1 and
+// 1.5 ms match Ableton's preset options; 3 / 5 added for users who
+// want more headroom for very fast transients at the cost of latency.
+const QList<float> kLookaheadOptions{ 0.0f, 1.0f, 1.5f, 3.0f, 5.0f };
+
+} // namespace
+
+StripGatePanel::StripGatePanel(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent)
+    , m_audio(engine)
+{
+    setWindowTitle("Aetherial Gate");
+    setStyleSheet(kWindowStyle);
+    resize(kDefaultWidth, kDefaultHeight);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(8, 0, 8, 8);
+    root->setSpacing(6);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    m_titleBar = titleBar;
+    root->addWidget(titleBar);
+
+    // Bypass moved to the CHAIN widget's single-click gesture.
+
+    // ── Main body: left control column + right level view ─────────
+    auto* body = new QHBoxLayout;
+    body->setSpacing(12);
+
+    // Left column: threshold, return, flip/lookahead
+    auto* left = new QVBoxLayout;
+    left->setSpacing(8);
+
+    // Threshold — the single largest control, matches Ableton's big
+    // top-left knob.  -80..0 dB linear.
+    m_threshold = new ClientCompKnob;
+    m_threshold->setLabel("Thresh");
+    m_threshold->setCenterLabelMode(true);
+    m_threshold->setRange(-80.0f, 0.0f);
+    m_threshold->setDefault(-40.0f);
+    m_threshold->setValueFromNorm([](float n) { return -80.0f + n * 80.0f; });
+    m_threshold->setNormFromValue([](float v) { return (v + 80.0f) / 80.0f; });
+    m_threshold->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + " dB";
+    });
+    m_threshold->setFixedSize(76, 76);
+    connect(m_threshold, &ClientCompKnob::valueChanged,
+            this, &StripGatePanel::applyThreshold);
+    left->addWidget(m_threshold, 0, Qt::AlignHCenter);
+
+    // Return — hysteresis, 0..20 dB linear.
+    m_returnKnob = new ClientCompKnob;
+    m_returnKnob->setLabel("Return");
+    m_returnKnob->setCenterLabelMode(true);
+    m_returnKnob->setRange(0.0f, 20.0f);
+    m_returnKnob->setDefault(2.0f);
+    m_returnKnob->setValueFromNorm([](float n) { return n * 20.0f; });
+    m_returnKnob->setNormFromValue([](float v) { return v / 20.0f; });
+    m_returnKnob->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 2) + " dB";
+    });
+    m_returnKnob->setFixedSize(76, 76);
+    connect(m_returnKnob, &ClientCompKnob::valueChanged,
+            this, &StripGatePanel::applyReturn);
+    left->addWidget(m_returnKnob, 0, Qt::AlignHCenter);
+
+    // Graph view toggle — flips the centre stack between the live level
+    // history (default) and the Ableton-Live-style transfer curve from
+    // the docked applet.  Same checkable styling as the Flip button so
+    // the bottom of the column reads as one consistent control bank.
+    m_viewToggle = new QPushButton("Level");   // default = level history
+    m_viewToggle->setCheckable(true);
+    m_viewToggle->setStyleSheet(kFlipStyle);
+    m_viewToggle->setFixedHeight(22);
+    m_viewToggle->setToolTip(
+        "Switch the gate display between the live level history and "
+        "the static transfer-curve view.");
+    connect(m_viewToggle, &QPushButton::toggled, this, [this](bool on) {
+        if (m_viewStack) m_viewStack->setCurrentIndex(on ? 1 : 0);
+        // Label tracks what's currently shown.
+        if (m_viewToggle) m_viewToggle->setText(on ? "Curve" : "Level");
+    });
+    left->addWidget(m_viewToggle);
+
+    // Spacer pushes Peek + Flip to the bottom of the column so the
+    // Threshold/Return knobs stay anchored at the top while the mode
+    // toggle and lookahead picker hug the bottom edge.
+    left->addStretch();
+
+    // Peek (lookahead) row — sits directly above the Flip button.
+    {
+        auto* lookWrap = new QHBoxLayout;
+        lookWrap->setSpacing(4);
+        auto* lookLbl = new QLabel("Peek:");
+        lookWrap->addWidget(lookLbl);
+        m_lookahead = new QComboBox;
+        m_lookahead->setStyleSheet(
+            "QComboBox { padding-left: 0px; padding-right: 0px; }"
+            "QComboBox::drop-down { width: 14px; }");
+        for (float v : kLookaheadOptions) {
+            const QString label = (v <= 0.0f)
+                ? "Off" : (QString::number(v, 'g', 2) + " ms");
+            m_lookahead->addItem(label, v);
+        }
+        connect(m_lookahead,
+                QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this](int i) {
+            if (i < 0 || i >= kLookaheadOptions.size()) return;
+            applyLookahead(kLookaheadOptions[i]);
+        });
+        lookWrap->addWidget(m_lookahead, 1);
+        left->addLayout(lookWrap);
+    }
+
+    // Flip button (Expander ↔ Gate) — bottom-most control.
+    m_flip = new QPushButton("Flip");
+    m_flip->setCheckable(true);
+    m_flip->setStyleSheet(kFlipStyle);
+    m_flip->setFixedHeight(22);
+    m_flip->setToolTip(
+        "Flip between downward Expander (gentle) and Gate (hard) "
+        "modes.  Snaps ratio + floor to preset pairs; other knobs "
+        "stay where you left them.");
+    connect(m_flip, &QPushButton::toggled, this, [this](bool checked) {
+        applyMode(checked ? 1 : 0);
+    });
+    left->addWidget(m_flip);
+
+    body->addLayout(left, 0);
+
+    // Right side: level view + bottom knob row
+    auto* right = new QVBoxLayout;
+    right->setSpacing(8);
+
+    // Stack the level history and the transfer curve so the toggle in
+    // the left column can flip between them in place.
+    m_viewStack = new QStackedWidget;
+    m_levelView = new ClientGateLevelView;
+    m_curveView = new ClientGateCurveWidget;
+    m_viewStack->addWidget(m_levelView);   // index 0 = live history
+    m_viewStack->addWidget(m_curveView);   // index 1 = transfer curve
+    right->addWidget(m_viewStack, 1);
+
+    // Bottom row: Attack, Hold, Release, Floor (small knobs).
+    auto* bottom = new QHBoxLayout;
+    bottom->setSpacing(8);
+
+    auto makeBottomKnob = [](const QString& label) {
+        auto* k = new ClientCompKnob;
+        k->setLabel(label);
+        k->setCenterLabelMode(true);
+        k->setFixedSize(76, 76);
+        return k;
+    };
+
+    // Attack: 0.1..100 ms exponential.
+    m_attack = makeBottomKnob("Attack");
+    m_attack->setRange(0.1f, 100.0f);
+    m_attack->setDefault(0.5f);
+    m_attack->setValueFromNorm([](float n) {
+        return 0.1f * std::pow(1000.0f, n);           // 0.1 → 100
+    });
+    m_attack->setNormFromValue([](float v) {
+        return std::log(std::max(0.1f, v) / 0.1f) / std::log(1000.0f);
+    });
+    m_attack->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 10.0f ? 2 : 1) + " ms";
+    });
+    connect(m_attack, &ClientCompKnob::valueChanged,
+            this, &StripGatePanel::applyAttack);
+    bottom->addWidget(m_attack, 0, Qt::AlignHCenter);
+
+    // Hold: 0..500 ms linear.
+    m_hold = makeBottomKnob("Hold");
+    m_hold->setRange(0.0f, 500.0f);
+    m_hold->setDefault(20.0f);
+    m_hold->setValueFromNorm([](float n) { return n * 500.0f; });
+    m_hold->setNormFromValue([](float v) { return v / 500.0f; });
+    m_hold->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + " ms";
+    });
+    connect(m_hold, &ClientCompKnob::valueChanged,
+            this, &StripGatePanel::applyHold);
+    bottom->addWidget(m_hold, 0, Qt::AlignHCenter);
+
+    // Release: 5..2000 ms exponential.
+    m_release = makeBottomKnob("Release");
+    m_release->setRange(5.0f, 2000.0f);
+    m_release->setDefault(100.0f);
+    m_release->setValueFromNorm([](float n) {
+        return 5.0f * std::pow(400.0f, n);           // 5 → 2000
+    });
+    m_release->setNormFromValue([](float v) {
+        return std::log(std::max(5.0f, v) / 5.0f) / std::log(400.0f);
+    });
+    m_release->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 100.0f ? 1 : 0) + " ms";
+    });
+    connect(m_release, &ClientCompKnob::valueChanged,
+            this, &StripGatePanel::applyRelease);
+    bottom->addWidget(m_release, 0, Qt::AlignHCenter);
+
+    // Floor: -80..0 dB linear.
+    m_floor = makeBottomKnob("Floor");
+    m_floor->setRange(-80.0f, 0.0f);
+    m_floor->setDefault(-15.0f);
+    m_floor->setValueFromNorm([](float n) { return -80.0f + n * 80.0f; });
+    m_floor->setNormFromValue([](float v) { return (v + 80.0f) / 80.0f; });
+    m_floor->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + " dB";
+    });
+    connect(m_floor, &ClientCompKnob::valueChanged,
+            this, &StripGatePanel::applyFloor);
+    bottom->addWidget(m_floor, 0, Qt::AlignHCenter);
+
+    // Ratio tucked in alongside — not in the vanilla Ableton layout,
+    // but necessary because Ableton's Gate is pure-gate and we need
+    // ratio for the expander half of the combined module.  1..10 —
+    // capped below hard-gate ∞:1 so the knob has finer resolution
+    // across the musically useful range.
+    m_ratio = makeBottomKnob("Ratio");
+    m_ratio->setRange(1.0f, 10.0f);
+    m_ratio->setDefault(2.0f);
+    m_ratio->setValueFromNorm([](float n) {
+        return 1.0f + n * 9.0f;                       // linear 1..10
+    });
+    m_ratio->setNormFromValue([](float v) { return (v - 1.0f) / 9.0f; });
+    m_ratio->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 1) + ":1";
+    });
+    connect(m_ratio, &ClientCompKnob::valueChanged,
+            this, &StripGatePanel::applyRatio);
+    bottom->addWidget(m_ratio, 0, Qt::AlignHCenter);
+
+    right->addLayout(bottom);
+
+    body->addLayout(right, 1);
+
+    root->addLayout(body);
+
+    // Bind both views to the gate once so they start polling.
+    if (m_audio && gate()) {
+        m_levelView->setGate(gate());
+        m_curveView->setGate(gate());
+    }
+
+    // Initial sync from the engine state.
+    syncControlsFromEngine();
+
+    // Continuous polling so changes in the docked applet knobs mirror
+    // here live, and vice versa.  30 Hz is cheap — each knob setValue
+    // is a short clamp + repaint when values differ.
+    m_syncTimer = new QTimer(this);
+    m_syncTimer->setInterval(33);
+    connect(m_syncTimer, &QTimer::timeout,
+            this, &StripGatePanel::syncControlsFromEngine);
+}
+
+StripGatePanel::~StripGatePanel() = default;
+
+ClientGate* StripGatePanel::gate() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientGateRx()
+                              : m_audio->clientGateTx();
+}
+
+void StripGatePanel::saveGateSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientGateRxSettings();
+    else                    m_audio->saveClientGateSettings();
+}
+
+void StripGatePanel::showForTx()
+{
+    m_side = Side::Tx;
+    if (gate()) {
+        if (m_levelView) m_levelView->setGate(gate());
+        if (m_curveView) m_curveView->setGate(gate());
+    }
+    const QString title = QString::fromUtf8("Aetherial Gate \xe2\x80\x94 TX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void StripGatePanel::showForRx()
+{
+    m_side = Side::Rx;
+    if (gate()) {
+        if (m_levelView) m_levelView->setGate(gate());
+        if (m_curveView) m_curveView->setGate(gate());
+    }
+    const QString title = QString::fromUtf8("Aetherial Gate \xe2\x80\x94 RX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void StripGatePanel::syncControlsFromEngine()
+{
+    if (!m_audio || !gate()) return;
+    ClientGate* g = gate();
+
+    m_restoring = true;
+
+    {
+        QSignalBlocker b(m_flip);
+        m_flip->setChecked(g->mode() == ClientGate::Mode::Gate);
+        m_flip->setText(g->mode() == ClientGate::Mode::Gate ? "Gate" : "Expander");
+    }
+    {
+        QSignalBlocker b(m_threshold);  m_threshold->setValue(g->thresholdDb());
+    }
+    {
+        QSignalBlocker b(m_returnKnob); m_returnKnob->setValue(g->returnDb());
+    }
+    {
+        QSignalBlocker b(m_ratio);      m_ratio->setValue(g->ratio());
+    }
+    {
+        QSignalBlocker b(m_attack);     m_attack->setValue(g->attackMs());
+    }
+    {
+        QSignalBlocker b(m_hold);       m_hold->setValue(g->holdMs());
+    }
+    {
+        QSignalBlocker b(m_release);    m_release->setValue(g->releaseMs());
+    }
+    {
+        QSignalBlocker b(m_floor);      m_floor->setValue(g->floorDb());
+    }
+    {
+        QSignalBlocker b(m_lookahead);
+        const float la = g->lookaheadMs();
+        int bestIdx = 0;
+        float bestDiff = 1e9f;
+        for (int i = 0; i < kLookaheadOptions.size(); ++i) {
+            const float d = std::fabs(kLookaheadOptions[i] - la);
+            if (d < bestDiff) { bestDiff = d; bestIdx = i; }
+        }
+        m_lookahead->setCurrentIndex(bestIdx);
+    }
+
+    m_restoring = false;
+}
+
+void StripGatePanel::applyThreshold(float db)
+{
+    if (m_restoring || !m_audio) return;
+    gate()->setThresholdDb(db);
+    saveGateSettings();
+    if (m_levelView) m_levelView->update();
+    if (m_curveView) m_curveView->update();
+}
+
+void StripGatePanel::applyReturn(float db)
+{
+    if (m_restoring || !m_audio) return;
+    gate()->setReturnDb(db);
+    saveGateSettings();
+    if (m_levelView) m_levelView->update();
+    if (m_curveView) m_curveView->update();
+}
+
+void StripGatePanel::applyRatio(float ratio)
+{
+    if (m_restoring || !m_audio) return;
+    gate()->setRatio(ratio);
+    saveGateSettings();
+}
+
+void StripGatePanel::applyAttack(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    gate()->setAttackMs(ms);
+    saveGateSettings();
+}
+
+void StripGatePanel::applyHold(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    gate()->setHoldMs(ms);
+    saveGateSettings();
+}
+
+void StripGatePanel::applyRelease(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    gate()->setReleaseMs(ms);
+    saveGateSettings();
+}
+
+void StripGatePanel::applyFloor(float db)
+{
+    if (m_restoring || !m_audio) return;
+    gate()->setFloorDb(db);
+    saveGateSettings();
+}
+
+void StripGatePanel::applyLookahead(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    gate()->setLookaheadMs(ms);
+    saveGateSettings();
+}
+
+void StripGatePanel::applyMode(int modeIdx)
+{
+    if (m_restoring || !m_audio) return;
+    gate()->setMode(
+        modeIdx == 1 ? ClientGate::Mode::Gate : ClientGate::Mode::Expander);
+    saveGateSettings();
+    // Mode snaps ratio + floor; re-sync so the knobs show the new values.
+    syncControlsFromEngine();
+}
+
+// ── Geometry persistence ─────────────────────────────────────────
+
+void StripGatePanel::saveGeometryToSettings()
+{
+    if (m_restoring) return;
+    AppSettings::instance().setValue(
+        "StripGatePanelGeometry", QString::fromLatin1(saveGeometry().toBase64()));
+}
+
+void StripGatePanel::restoreGeometryFromSettings()
+{
+    m_restoring = true;
+    const QString b64 = AppSettings::instance()
+        .value("StripGatePanelGeometry", "").toString();
+    if (!b64.isEmpty()) {
+        restoreGeometry(QByteArray::fromBase64(b64.toLatin1()));
+    }
+    m_restoring = false;
+}
+
+void StripGatePanel::closeEvent(QCloseEvent* ev)
+{
+    saveGeometryToSettings();
+    QWidget::closeEvent(ev);
+}
+
+void StripGatePanel::moveEvent(QMoveEvent* ev)
+{
+    saveGeometryToSettings();
+    QWidget::moveEvent(ev);
+}
+
+void StripGatePanel::resizeEvent(QResizeEvent* ev)
+{
+    saveGeometryToSettings();
+    QWidget::resizeEvent(ev);
+}
+
+void StripGatePanel::showEvent(QShowEvent* ev)
+{
+    QWidget::showEvent(ev);
+}
+
+void StripGatePanel::hideEvent(QHideEvent* ev)
+{
+    saveGeometryToSettings();
+    QWidget::hideEvent(ev);
+}
+
+} // namespace AetherSDR

--- a/src/gui/StripGatePanel.h
+++ b/src/gui/StripGatePanel.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <QWidget>
+
+class QComboBox;
+class QLabel;
+class QPushButton;
+class QStackedWidget;
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;    // reused — generic rotary knob
+class ClientGateLevelView;
+class ClientGateCurveWidget;
+
+// Floating editor for the client-side TX gate / expander — layout
+// modelled on Ableton Live's Gate device.  One instance lives on
+// MainWindow; calling showForTx() raises the window and binds it to
+// AudioEngine::clientGateTx().  Geometry persists via AppSettings
+// (`StripGatePanelGeometry` key).
+//
+// Layout:
+//   ┌─ bypass ──────────────────── × ┐
+//   │ ┌──────┐  ┌──────────────────┐ │
+//   │ │ THR  │  │                  │ │
+//   │ │      │  │   level view     │ │
+//   │ │ RET  │  │   (Ableton-style)│ │
+//   │ │      │  │                  │ │
+//   │ │ Flip │  │                  │ │
+//   │ │ Look │  │                  │ │
+//   │ └──────┘  └──────────────────┘ │
+//   │   [ATK] [HLD] [REL] [FLR]      │
+//   └────────────────────────────────┘
+class StripGatePanel : public QWidget {
+    Q_OBJECT
+
+public:
+    enum class Side { Tx, Rx };
+
+    explicit StripGatePanel(AudioEngine* engine, QWidget* parent = nullptr);
+    ~StripGatePanel() override;
+
+    void showForTx();
+    void showForRx();
+
+signals:
+    // Fired when bypass toggles.  Docked applet subscribes to keep
+    // its Enable button in sync.  side identifies which path (Tx or
+    // Rx) was toggled — both share the editor instance.
+    void bypassToggled(Side side, bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+    void syncControlsFromEngine();
+
+    // Parameter commit — all control signals land here; each writes
+    // the engine + persists via AppSettings.
+    void applyThreshold(float db);
+    void applyReturn(float db);
+    void applyRatio(float ratio);
+    void applyAttack(float ms);
+    void applyHold(float ms);
+    void applyRelease(float ms);
+    void applyFloor(float db);
+    void applyLookahead(float ms);
+    void applyMode(int modeIdx);   // 0=Expander, 1=Gate
+
+    AudioEngine*          m_audio{nullptr};
+    Side                  m_side{Side::Tx};
+    // Side-aware accessor — picks Tx or Rx instance based on m_side.
+    // Saves dispatch logic at every parameter setter.
+    class ClientGate* gate() const;
+    void              saveGateSettings() const;
+    QWidget*              m_titleBar{nullptr};   // EditorFramelessTitleBar*
+    ClientGateLevelView*    m_levelView{nullptr};
+    ClientGateCurveWidget*  m_curveView{nullptr};
+    QStackedWidget*         m_viewStack{nullptr};
+    QPushButton*            m_viewToggle{nullptr};
+    ClientCompKnob*       m_threshold{nullptr};
+    ClientCompKnob*       m_returnKnob{nullptr};
+    ClientCompKnob*       m_ratio{nullptr};
+    ClientCompKnob*       m_attack{nullptr};
+    ClientCompKnob*       m_hold{nullptr};
+    ClientCompKnob*       m_release{nullptr};
+    ClientCompKnob*       m_floor{nullptr};
+    QPushButton*          m_flip{nullptr};
+    QComboBox*            m_lookahead{nullptr};
+    QPushButton*          m_bypass{nullptr};
+    QTimer*               m_syncTimer{nullptr};   // mirror engine → knobs
+    bool                  m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/StripPuduPanel.cpp
+++ b/src/gui/StripPuduPanel.cpp
@@ -1,0 +1,417 @@
+#include "StripPuduPanel.h"
+#include "ClientCompKnob.h"
+#include "EditorFramelessTitleBar.h"
+#include "PooDooLogo.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientPudu.h"
+
+#include <QButtonGroup>
+#include <QCloseEvent>
+#include <QFrame>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QLabel>
+#include <QMoveEvent>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kDefaultWidth  = 640;
+constexpr int kDefaultHeight = 360;
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+const QString kBypassStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #0e1b28; color: #8aa8c0;"
+    "  border: 1px solid #243a4e; border-radius: 3px;"
+    "  font-size: 11px; font-weight: bold; padding: 3px 12px;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e; color: #f2c14e; border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+const QString kModeStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #2a4458; border-radius: 3px;"
+    "  color: #8aa8c0; font-size: 12px; font-weight: bold;"
+    "  padding: 4px 20px; min-width: 34px;"
+    "}"
+    "QPushButton:hover { background: #24384e; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e; color: #f2c14e; border: 1px solid #f2c14e;"
+    "}");
+
+// "|─── text ───|" group label: horizontal line, centred text, horizontal line.
+QWidget* makeBracketLabel(const QString& text)
+{
+    auto* w = new QWidget;
+    auto* h = new QHBoxLayout(w);
+    h->setContentsMargins(0, 0, 0, 0);
+    h->setSpacing(6);
+
+    auto* leftLine = new QFrame;
+    leftLine->setFrameShape(QFrame::HLine);
+    leftLine->setFrameShadow(QFrame::Plain);
+    leftLine->setStyleSheet("QFrame { color: #5a6a7a; }");
+
+    auto* lbl = new QLabel(text);
+    lbl->setStyleSheet("QLabel { color: #c8d8e8; font-weight: bold; "
+                       "font-size: 13px; letter-spacing: 2px; }");
+    lbl->setAlignment(Qt::AlignCenter);
+
+    auto* rightLine = new QFrame;
+    rightLine->setFrameShape(QFrame::HLine);
+    rightLine->setFrameShadow(QFrame::Plain);
+    rightLine->setStyleSheet("QFrame { color: #5a6a7a; }");
+
+    h->addWidget(leftLine, 1);
+    h->addWidget(lbl);
+    h->addWidget(rightLine, 1);
+    return w;
+}
+
+} // namespace
+
+StripPuduPanel::StripPuduPanel(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent)
+    , m_audio(engine)
+{
+    setWindowTitle(QString::fromUtf8("Aetherial Poodoo\xe2\x84\xa2"));
+    setStyleSheet(kWindowStyle);
+    resize(kDefaultWidth, kDefaultHeight);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(12, 0, 12, 10);
+    root->setSpacing(8);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    m_titleBar = titleBar;
+    root->addWidget(titleBar);
+
+    // ── Logo (big in the editor) ────────────────────────────────
+    m_logo = new PooDooLogo;
+    m_logo->setMinimumHeight(80);
+    root->addWidget(m_logo);
+
+    // ── Even / Odd mode toggle — centred in the gap between the
+    // PooDoo™ wordmark and the Poo/Doo knob row.  Aphex generates
+    // even harmonics (asymmetric shape), Behringer generates odd
+    // harmonics (symmetric tanh); labelling by harmonic content is
+    // more descriptive than A/B.
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(6);
+        row->addStretch();
+
+        auto* group = new QButtonGroup(this);
+        group->setExclusive(true);
+        m_modeA = new QPushButton("Even");
+        m_modeA->setCheckable(true);
+        m_modeA->setStyleSheet(kModeStyle);
+        m_modeA->setFixedHeight(24);
+        m_modeA->setToolTip(
+            "Aphex-lineage asymmetric shaping — predominantly even "
+            "harmonics, warmer, diode-style character with Big Bottom "
+            "LF saturation.");
+        group->addButton(m_modeA, 0);
+        row->addWidget(m_modeA);
+
+        m_modeB = new QPushButton("Odd");
+        m_modeB->setCheckable(true);
+        m_modeB->setStyleSheet(kModeStyle);
+        m_modeB->setFixedHeight(24);
+        m_modeB->setToolTip(
+            "Behringer-lineage symmetric tanh shaping — pure odd "
+            "harmonics, brighter / edgier, paired with a feed-forward "
+            "bass compressor.");
+        group->addButton(m_modeB, 1);
+        row->addWidget(m_modeB);
+
+        connect(group, &QButtonGroup::idToggled, this,
+                [this](int id, bool checked) {
+            if (checked) onModeToggled(id);
+        });
+
+        row->addStretch();
+        root->addLayout(row);
+    }
+
+    // Tight 4 px gap between the Even/Odd row and the Poo/Doo bracket
+    // labels below.
+    root->addSpacing(4);
+
+    // ── Knob row: all 6 on one line with Poo | gap | Doo grouping ──
+    //
+    // Grid: row 0 = bracket group labels (|─Poo─| and |─Doo─|),
+    // row 1 = knobs.  Columns 0-2 host Poo; column 3 is a fixed
+    // spacer separating the two groups; columns 4-6 host Doo.
+    {
+        auto* grid = new QGridLayout;
+        grid->setContentsMargins(0, 0, 0, 0);
+        grid->setHorizontalSpacing(12);
+        grid->setVerticalSpacing(4);
+        grid->setColumnMinimumWidth(3, 32);   // gap between Poo and Doo
+
+        grid->addWidget(makeBracketLabel("Poo"), 0, 0, 1, 3);
+        grid->addWidget(makeBracketLabel("Doo"), 0, 4, 1, 3);
+
+        auto makeKnob = [](const QString& label) {
+            auto* k = new ClientCompKnob;
+            k->setLabel(label);
+            k->setCenterLabelMode(true);
+            // Tighter vertical footprint in center-label mode since
+            // the label sits inside the ring now.  Ring + value row.
+            k->setFixedSize(76, 76);
+            return k;
+        };
+
+        m_pooDrive = makeKnob("Drive");
+        m_pooDrive->setRange(0.0f, 24.0f);
+        m_pooDrive->setDefault(6.0f);
+        m_pooDrive->setValueFromNorm([](float n) { return n * 24.0f; });
+        m_pooDrive->setNormFromValue([](float v) { return v / 24.0f; });
+        m_pooDrive->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
+        });
+        connect(m_pooDrive, &ClientCompKnob::valueChanged,
+                this, &StripPuduPanel::applyPooDrive);
+        grid->addWidget(m_pooDrive, 1, 0, Qt::AlignHCenter);
+
+        m_pooTune = makeKnob("Tune");
+        m_pooTune->setRange(50.0f, 160.0f);
+        m_pooTune->setDefault(100.0f);
+        m_pooTune->setValueFromNorm([](float n) { return 50.0f + n * 110.0f; });
+        m_pooTune->setNormFromValue([](float v) { return (v - 50.0f) / 110.0f; });
+        m_pooTune->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 0) + " Hz";
+        });
+        connect(m_pooTune, &ClientCompKnob::valueChanged,
+                this, &StripPuduPanel::applyPooTune);
+        grid->addWidget(m_pooTune, 1, 1, Qt::AlignHCenter);
+
+        m_pooMix = makeKnob("Mix");
+        m_pooMix->setRange(0.0f, 1.0f);
+        m_pooMix->setDefault(0.3f);
+        m_pooMix->setValueFromNorm([](float n) { return n; });
+        m_pooMix->setNormFromValue([](float v) { return v; });
+        m_pooMix->setLabelFormat([](float v) {
+            return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+        });
+        connect(m_pooMix, &ClientCompKnob::valueChanged,
+                this, &StripPuduPanel::applyPooMix);
+        grid->addWidget(m_pooMix, 1, 2, Qt::AlignHCenter);
+
+        m_dooTune = makeKnob("Tune");
+        m_dooTune->setRange(1000.0f, 10000.0f);
+        m_dooTune->setDefault(5000.0f);
+        m_dooTune->setValueFromNorm([](float n) {
+            return 1000.0f * std::pow(10.0f, n);
+        });
+        m_dooTune->setNormFromValue([](float v) {
+            return std::log10(std::max(1000.0f, v) / 1000.0f);
+        });
+        m_dooTune->setLabelFormat([](float v) {
+            return (v >= 1000.0f)
+                ? QString::number(v / 1000.0f, 'f', 1) + " kHz"
+                : QString::number(v, 'f', 0) + " Hz";
+        });
+        connect(m_dooTune, &ClientCompKnob::valueChanged,
+                this, &StripPuduPanel::applyDooTune);
+        grid->addWidget(m_dooTune, 1, 4, Qt::AlignHCenter);
+
+        m_dooHarmonics = makeKnob("Air");
+        m_dooHarmonics->setRange(0.0f, 24.0f);
+        m_dooHarmonics->setDefault(6.0f);
+        m_dooHarmonics->setValueFromNorm([](float n) { return n * 24.0f; });
+        m_dooHarmonics->setNormFromValue([](float v) { return v / 24.0f; });
+        m_dooHarmonics->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 1) + " dB";
+        });
+        connect(m_dooHarmonics, &ClientCompKnob::valueChanged,
+                this, &StripPuduPanel::applyDooHarmonics);
+        grid->addWidget(m_dooHarmonics, 1, 5, Qt::AlignHCenter);
+
+        m_dooMix = makeKnob("Mix");
+        m_dooMix->setRange(0.0f, 1.0f);
+        m_dooMix->setDefault(0.3f);
+        m_dooMix->setValueFromNorm([](float n) { return n; });
+        m_dooMix->setNormFromValue([](float v) { return v; });
+        m_dooMix->setLabelFormat([](float v) {
+            return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+        });
+        connect(m_dooMix, &ClientCompKnob::valueChanged,
+                this, &StripPuduPanel::applyDooMix);
+        grid->addWidget(m_dooMix, 1, 6, Qt::AlignHCenter);
+
+        root->addLayout(grid);
+    }
+
+    // No trailing stretch — let the cell size to the panel's natural
+    // content height instead of growing to fill whatever the grid gives.
+
+    if (m_audio && pudu()) {
+        m_logo->setPudu(pudu());
+    }
+
+    syncControlsFromEngine();
+}
+
+StripPuduPanel::~StripPuduPanel() = default;
+
+ClientPudu* StripPuduPanel::pudu() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientPuduRx()
+                              : m_audio->clientPuduTx();
+}
+
+void StripPuduPanel::savePuduSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientPuduRxSettings();
+    else                    m_audio->saveClientPuduSettings();
+}
+
+void StripPuduPanel::showForTx()
+{
+    m_side = Side::Tx;
+    if (m_logo && pudu()) m_logo->setPudu(pudu());
+    const QString title = QString::fromUtf8("Aetherial Poodoo\xe2\x84\xa2 \xe2\x80\x94 TX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+}
+
+void StripPuduPanel::showForRx()
+{
+    m_side = Side::Rx;
+    if (m_logo && pudu()) m_logo->setPudu(pudu());
+    const QString title = QString::fromUtf8("Aetherial Poodoo\xe2\x84\xa2 \xe2\x80\x94 RX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+}
+
+void StripPuduPanel::syncControlsFromEngine()
+{
+    if (!m_audio || !pudu()) return;
+    ClientPudu* p = pudu();
+    m_restoring = true;
+
+    {
+        const bool isA = (p->mode() == ClientPudu::Mode::Aphex);
+        QSignalBlocker ba(m_modeA);
+        QSignalBlocker bb(m_modeB);
+        m_modeA->setChecked(isA);
+        m_modeB->setChecked(!isA);
+    }
+    { QSignalBlocker b(m_pooDrive);     m_pooDrive->setValue(p->pooDriveDb()); }
+    { QSignalBlocker b(m_pooTune);      m_pooTune->setValue(p->pooTuneHz()); }
+    { QSignalBlocker b(m_pooMix);       m_pooMix->setValue(p->pooMix()); }
+    { QSignalBlocker b(m_dooTune);      m_dooTune->setValue(p->dooTuneHz()); }
+    { QSignalBlocker b(m_dooHarmonics); m_dooHarmonics->setValue(p->dooHarmonicsDb()); }
+    { QSignalBlocker b(m_dooMix);       m_dooMix->setValue(p->dooMix()); }
+
+    m_restoring = false;
+}
+
+void StripPuduPanel::onModeToggled(int id)
+{
+    if (m_restoring || !m_audio) return;
+    pudu()->setMode(
+        id == 1 ? ClientPudu::Mode::Behringer : ClientPudu::Mode::Aphex);
+    savePuduSettings();
+}
+
+void StripPuduPanel::applyPooDrive(float db)
+{
+    if (m_restoring || !m_audio) return;
+    pudu()->setPooDriveDb(db);
+    savePuduSettings();
+}
+void StripPuduPanel::applyPooTune(float hz)
+{
+    if (m_restoring || !m_audio) return;
+    pudu()->setPooTuneHz(hz);
+    savePuduSettings();
+}
+void StripPuduPanel::applyPooMix(float v)
+{
+    if (m_restoring || !m_audio) return;
+    pudu()->setPooMix(v);
+    savePuduSettings();
+}
+void StripPuduPanel::applyDooTune(float hz)
+{
+    if (m_restoring || !m_audio) return;
+    pudu()->setDooTuneHz(hz);
+    savePuduSettings();
+}
+void StripPuduPanel::applyDooHarmonics(float db)
+{
+    if (m_restoring || !m_audio) return;
+    pudu()->setDooHarmonicsDb(db);
+    savePuduSettings();
+}
+void StripPuduPanel::applyDooMix(float v)
+{
+    if (m_restoring || !m_audio) return;
+    pudu()->setDooMix(v);
+    savePuduSettings();
+}
+
+void StripPuduPanel::saveGeometryToSettings()
+{
+    if (m_restoring) return;
+    AppSettings::instance().setValue(
+        "StripPuduPanelGeometry",
+        QString::fromLatin1(saveGeometry().toBase64()));
+}
+
+void StripPuduPanel::restoreGeometryFromSettings()
+{
+    m_restoring = true;
+    const QString b64 = AppSettings::instance()
+        .value("StripPuduPanelGeometry", "").toString();
+    if (!b64.isEmpty()) {
+        restoreGeometry(QByteArray::fromBase64(b64.toLatin1()));
+    }
+    m_restoring = false;
+}
+
+void StripPuduPanel::closeEvent(QCloseEvent* ev)
+{ saveGeometryToSettings(); QWidget::closeEvent(ev); }
+void StripPuduPanel::moveEvent(QMoveEvent* ev)
+{ saveGeometryToSettings(); QWidget::moveEvent(ev); }
+void StripPuduPanel::resizeEvent(QResizeEvent* ev)
+{ saveGeometryToSettings(); QWidget::resizeEvent(ev); }
+void StripPuduPanel::showEvent(QShowEvent* ev)
+{ QWidget::showEvent(ev); }
+void StripPuduPanel::hideEvent(QHideEvent* ev)
+{ saveGeometryToSettings(); QWidget::hideEvent(ev); }
+
+} // namespace AetherSDR

--- a/src/gui/StripPuduPanel.h
+++ b/src/gui/StripPuduPanel.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;
+class PooDooLogo;
+
+// Floating editor for the PUDU exciter.  Same six knobs + A/B toggle
+// + logo as the docked applet, just at larger scale with dedicated
+// geometry persistence.  Keeps the cognitive load low — users don't
+// have to re-learn a separate UI in the floating window.
+class StripPuduPanel : public QWidget {
+    Q_OBJECT
+
+public:
+    enum class Side { Tx, Rx };
+
+    explicit StripPuduPanel(AudioEngine* engine, QWidget* parent = nullptr);
+    ~StripPuduPanel() override;
+
+    void showForTx();
+    void showForRx();
+
+signals:
+    void bypassToggled(Side side, bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+    void syncControlsFromEngine();
+
+    void onModeToggled(int id);
+    void applyPooDrive(float db);
+    void applyPooTune(float hz);
+    void applyPooMix(float v);
+    void applyDooTune(float hz);
+    void applyDooHarmonics(float db);
+    void applyDooMix(float v);
+
+    AudioEngine*    m_audio{nullptr};
+    Side            m_side{Side::Tx};
+    QWidget*        m_titleBar{nullptr};   // EditorFramelessTitleBar*
+    class ClientPudu* pudu() const;
+    void              savePuduSettings() const;
+    PooDooLogo*     m_logo{nullptr};
+    QPushButton*    m_bypass{nullptr};
+    QPushButton*    m_modeA{nullptr};
+    QPushButton*    m_modeB{nullptr};
+    ClientCompKnob* m_pooDrive{nullptr};
+    ClientCompKnob* m_pooTune{nullptr};
+    ClientCompKnob* m_pooMix{nullptr};
+    ClientCompKnob* m_dooTune{nullptr};
+    ClientCompKnob* m_dooHarmonics{nullptr};
+    ClientCompKnob* m_dooMix{nullptr};
+    bool            m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/StripReverbPanel.cpp
+++ b/src/gui/StripReverbPanel.cpp
@@ -1,0 +1,384 @@
+#include "StripReverbPanel.h"
+#include "ClientCompKnob.h"
+#include "EditorFramelessTitleBar.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientReverb.h"
+
+#include <QCloseEvent>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QMoveEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPaintEvent>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+// Visualisation panel between the title bar and the knob row.
+// Draws three layered traces that respond to the reverb knobs:
+//   - Cyan: dry initial sound (amplitude scales inversely with Mix)
+//   - Yellow: first-order reflections (count + spacing track Size,
+//             amplitude decays per reflection scaled by Damping)
+//   - Magenta: reverberant tail (length = Decay, amplitude = Mix,
+//             smoothness/decay-rate = Damping; whole thing shifts
+//             right by PreDelay).
+class GridBox : public QWidget {
+public:
+    explicit GridBox(QWidget* parent = nullptr) : QWidget(parent) {
+        setFixedHeight(138);
+    }
+    void setSize(float v)        { m_size = v;        update(); }
+    void setDecayS(float v)      { m_decayS = v;      update(); }
+    void setDamping(float v)     { m_damping = v;     update(); }
+    void setPreDelayMs(float v)  { m_preDelayMs = v;  update(); }
+    void setMix(float v)         { m_mix = v;         update(); }
+
+protected:
+    void paintEvent(QPaintEvent*) override {
+        QPainter p(this);
+        p.setRenderHint(QPainter::Antialiasing, true);
+        const QRectF r = rect();
+        p.fillRect(r, QColor("#0a1420"));
+
+        // Background grid.
+        const QColor gridColor("#1e3040");
+        const QColor axisColor("#2a4458");
+        p.setPen(QPen(gridColor, 1.0));
+        for (float n : { 0.25f, 0.50f, 0.75f }) {
+            const float x = r.left() + n * r.width();
+            const float y = r.top()  + n * r.height();
+            p.drawLine(QPointF(x, r.top()),    QPointF(x, r.bottom()));
+            p.drawLine(QPointF(r.left(), y),   QPointF(r.right(), y));
+        }
+        p.setPen(QPen(axisColor, 1.0));
+        const float cx = r.left() + 0.5f * r.width();
+        const float cy = r.top()  + 0.5f * r.height();
+        p.drawLine(QPointF(cx, r.top()),    QPointF(cx, r.bottom()));
+        p.drawLine(QPointF(r.left(), cy),   QPointF(r.right(), cy));
+
+        // ── Traces ──
+        // All three layers share the same left start so they overlap,
+        // mirroring the reference visualisation: a single wave packet
+        // entering the room, with reflections and tail rising from the
+        // same arrival point and extending further right.
+        const float w = r.width();
+        const float h = r.height();
+        const float midY  = r.top() + h * 0.5f;
+        const float maxAmp = h * 0.40f;
+        const float xStart = w * 0.04f;
+
+        // PreDelay shifts the wet onset to the right of the dry start
+        // (0..100 ms → 0..12% of width).
+        const float preX = (m_preDelayMs / 100.0f) * w * 0.12f;
+        const float wetStart = xStart + preX;
+
+        // Reverberant tail (magenta) — drawn first so the brighter cyan
+        // and yellow read on top.  Exponentially decaying oscillation,
+        // total length scales with Decay (0.3..5 s → 30%..95% of width).
+        {
+            const float decayNorm = std::clamp(
+                (m_decayS - 0.3f) / (5.0f - 0.3f), 0.0f, 1.0f);
+            const float endX = std::min(
+                wetStart + (0.30f + 0.65f * decayNorm) * (w - wetStart - 4.0f),
+                w - 2.0f);
+            const float tailAmp = m_mix * maxAmp;
+            const float decayK = 2.0f + 4.0f * m_damping;
+            const float cycles = 4.0f + 6.0f * decayNorm;
+            const float freq = cycles * 2.0f * float(M_PI) / (endX - wetStart);
+            QPainterPath path;
+            path.moveTo(wetStart, midY);
+            for (float x = wetStart; x <= endX; x += 1.0f) {
+                const float t = (x - wetStart) / (endX - wetStart);
+                const float env = std::exp(-decayK * t);
+                path.lineTo(x, midY + tailAmp * env * std::sin(freq * (x - wetStart)));
+            }
+            p.setPen(QPen(QColor("#c060e0"), 1.8));
+            p.drawPath(path);
+        }
+
+        // First-order reflections (yellow) — overlap with the tail.
+        // Number = a few short bursts; spacing controlled by Size, each
+        // burst's amplitude attenuated by Damping.
+        {
+            const int   nRefl    = 6;
+            // At Size=1.0 the 6 reflections still span out to ~90% of
+            // the width — spacing tightened from 0.15 to 0.11 to fit the
+            // extra reflection without spilling past the right edge.
+            const float spacing  = (0.04f + m_size * 0.11f) * w;
+            const float reflLen  = std::min(spacing * 0.85f, w * 0.10f);
+            const float dampStep = 1.0f - m_damping * 0.45f;
+            float amp = m_mix * maxAmp * 0.75f;
+            p.setPen(QPen(QColor("#ffd070"), 1.6));
+            for (int i = 0; i < nRefl; ++i) {
+                const float startX = wetStart + i * spacing;
+                const float endX   = std::min(startX + reflLen, w - 2.0f);
+                if (startX >= w - 2.0f || amp < 1.0f) break;
+                const float freq = 3.0f * 2.0f * float(M_PI) / (endX - startX);
+                QPainterPath path;
+                path.moveTo(startX, midY);
+                for (float x = startX; x <= endX; x += 1.0f) {
+                    const float t = x - startX;
+                    path.lineTo(x, midY + amp * std::sin(freq * t));
+                }
+                p.drawPath(path);
+                amp *= dampStep;
+            }
+        }
+
+        // Dry initial sound (cyan) — drawn last so it reads on top.
+        // 8-cycle pure sine across most of the width; constant amplitude
+        // (no envelope), but the *colour* fades from full alpha at the
+        // left to fully transparent at the right via a linear gradient
+        // brush on the pen, so the trace dissolves into the reverb tail.
+        // Amplitude scales inversely with Mix so increasing Mix dims the
+        // dry while the wet rises.
+        {
+            const float dryEnd = xStart + w * 0.92f;
+            const float dryAmp = (1.0f - m_mix * 0.5f) * maxAmp;
+            constexpr float kCycles = 8.0f;
+            const float freq = kCycles * 2.0f * float(M_PI) / (dryEnd - xStart);
+            QPainterPath path;
+            // Sub-pixel sampling for a smooth curve through every cycle.
+            const float step = 0.5f;
+            path.moveTo(xStart, midY);
+            for (float x = xStart; x <= dryEnd; x += step) {
+                const float t = x - xStart;
+                path.lineTo(x, midY + dryAmp * std::sin(freq * t));
+            }
+            QLinearGradient grad(xStart, 0, dryEnd, 0);
+            QColor cyan("#4db8d4");
+            QColor cyanFade = cyan;
+            cyanFade.setAlpha(0);
+            grad.setColorAt(0.0, cyan);
+            grad.setColorAt(1.0, cyanFade);
+            p.setPen(QPen(QBrush(grad), 2.2));
+            p.drawPath(path);
+        }
+    }
+
+private:
+    float m_size{0.5f};
+    float m_decayS{1.2f};
+    float m_damping{0.5f};
+    float m_preDelayMs{20.0f};
+    float m_mix{0.15f};
+};
+
+} // namespace
+
+StripReverbPanel::StripReverbPanel(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent)
+    , m_audio(engine)
+{
+    const QString title = QString::fromUtf8("Aetherial FreeVerb \xe2\x80\x94 TX");
+    setWindowTitle(title);
+    setStyleSheet(kWindowStyle);
+    resize(480, 180);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(16, 0, 16, 14);
+    root->setSpacing(8);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    titleBar->setTitleText(title);
+    root->addWidget(titleBar);
+
+    // Grid panel matching the tube curve widget's visual style — sits
+    // between the title bar and the knob row as a placeholder for any
+    // future visualisation (decay tail, IR, etc.).
+    auto* gridBox = new GridBox;
+    root->addWidget(gridBox, 1);
+
+    auto* row = new QHBoxLayout;
+    row->setSpacing(12);
+    row->addStretch();
+
+    auto makeKnob = [](const QString& label) {
+        auto* k = new ClientCompKnob;
+        k->setLabel(label);
+        k->setCenterLabelMode(true);
+        k->setFixedSize(76, 76);
+        return k;
+    };
+
+    m_size = makeKnob("Size");
+    m_size->setRange(0.0f, 1.0f);
+    m_size->setDefault(0.5f);
+    m_size->setValueFromNorm([](float n) { return n; });
+    m_size->setNormFromValue([](float v) { return v; });
+    m_size->setLabelFormat([](float v) {
+        return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+    });
+    row->addWidget(m_size);
+
+    m_decay = makeKnob("Decay");
+    m_decay->setRange(0.3f, 5.0f);
+    m_decay->setDefault(1.2f);
+    m_decay->setValueFromNorm([](float n) {
+        return 0.3f * std::pow(5.0f / 0.3f, n);
+    });
+    m_decay->setNormFromValue([](float v) {
+        if (v <= 0.3f) return 0.0f;
+        return std::log(v / 0.3f) / std::log(5.0f / 0.3f);
+    });
+    m_decay->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 2) + " s";
+    });
+    row->addWidget(m_decay);
+
+    m_damping = makeKnob("Damp");
+    m_damping->setRange(0.0f, 1.0f);
+    m_damping->setDefault(0.5f);
+    m_damping->setValueFromNorm([](float n) { return n; });
+    m_damping->setNormFromValue([](float v) { return v; });
+    m_damping->setLabelFormat([](float v) {
+        return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+    });
+    row->addWidget(m_damping);
+
+    m_preDly = makeKnob("PreDly");
+    m_preDly->setRange(0.0f, 100.0f);
+    m_preDly->setDefault(20.0f);
+    m_preDly->setValueFromNorm([](float n) { return n * 100.0f; });
+    m_preDly->setNormFromValue([](float v) { return v / 100.0f; });
+    m_preDly->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 0) + " ms";
+    });
+    row->addWidget(m_preDly);
+
+    m_mix = makeKnob("Mix");
+    m_mix->setRange(0.0f, 1.0f);
+    m_mix->setDefault(0.15f);
+    m_mix->setValueFromNorm([](float n) { return n; });
+    m_mix->setNormFromValue([](float v) { return v; });
+    m_mix->setLabelFormat([](float v) {
+        return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+    });
+    row->addWidget(m_mix);
+
+    row->addStretch();
+    root->addLayout(row);
+
+    auto wire = [this, gridBox](ClientCompKnob* k, auto setter, auto vizSetter) {
+        connect(k, &ClientCompKnob::valueChanged, this,
+                [this, setter, vizSetter, gridBox](float v) {
+            if (m_audio && m_audio->clientReverbTx()) {
+                (m_audio->clientReverbTx()->*setter)(v);
+                m_audio->saveClientReverbSettings();
+            }
+            (gridBox->*vizSetter)(v);
+        });
+    };
+    wire(m_size,    &ClientReverb::setSize,        &GridBox::setSize);
+    wire(m_decay,   &ClientReverb::setDecayS,      &GridBox::setDecayS);
+    wire(m_damping, &ClientReverb::setDamping,     &GridBox::setDamping);
+    wire(m_preDly,  &ClientReverb::setPreDelayMs,  &GridBox::setPreDelayMs);
+    wire(m_mix,     &ClientReverb::setMix,         &GridBox::setMix);
+
+    // Seed the viz with current engine values so the traces match
+    // the knob positions at first paint.
+    if (m_audio && m_audio->clientReverbTx()) {
+        auto* rev = m_audio->clientReverbTx();
+        gridBox->setSize       (rev->size());
+        gridBox->setDecayS     (rev->decayS());
+        gridBox->setDamping    (rev->damping());
+        gridBox->setPreDelayMs (rev->preDelayMs());
+        gridBox->setMix        (rev->mix());
+    }
+
+    syncControlsFromEngine();
+
+    m_syncTimer = new QTimer(this);
+    m_syncTimer->setInterval(33);
+    connect(m_syncTimer, &QTimer::timeout,
+            this, &StripReverbPanel::syncControlsFromEngine);
+}
+
+StripReverbPanel::~StripReverbPanel() = default;
+
+void StripReverbPanel::showForTx()
+{
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void StripReverbPanel::syncControlsFromEngine()
+{
+    if (!m_audio || !m_audio->clientReverbTx()) return;
+    ClientReverb* r = m_audio->clientReverbTx();
+    m_restoring = true;
+    if (m_size)    { QSignalBlocker b(m_size);    m_size->setValue(r->size()); }
+    if (m_decay)   { QSignalBlocker b(m_decay);   m_decay->setValue(r->decayS()); }
+    if (m_damping) { QSignalBlocker b(m_damping); m_damping->setValue(r->damping()); }
+    if (m_preDly)  { QSignalBlocker b(m_preDly);  m_preDly->setValue(r->preDelayMs()); }
+    if (m_mix)     { QSignalBlocker b(m_mix);     m_mix->setValue(r->mix()); }
+    m_restoring = false;
+}
+
+void StripReverbPanel::saveGeometryToSettings()
+{
+    auto& s = AppSettings::instance();
+    s.setValue("StripReverbPanelGeometry", saveGeometry().toBase64());
+}
+
+void StripReverbPanel::restoreGeometryFromSettings()
+{
+    auto& s = AppSettings::instance();
+    const QByteArray geom = QByteArray::fromBase64(
+        s.value("StripReverbPanelGeometry", "").toByteArray());
+    if (!geom.isEmpty()) {
+        m_restoring = true;
+        restoreGeometry(geom);
+        m_restoring = false;
+    }
+}
+
+void StripReverbPanel::closeEvent(QCloseEvent* ev)
+{
+    if (m_syncTimer) m_syncTimer->stop();
+    saveGeometryToSettings();
+    QWidget::closeEvent(ev);
+}
+
+void StripReverbPanel::moveEvent(QMoveEvent* ev)
+{
+    QWidget::moveEvent(ev);
+    if (!m_restoring) saveGeometryToSettings();
+}
+
+void StripReverbPanel::resizeEvent(QResizeEvent* ev)
+{
+    QWidget::resizeEvent(ev);
+    if (!m_restoring) saveGeometryToSettings();
+}
+
+void StripReverbPanel::showEvent(QShowEvent* ev)
+{
+    QWidget::showEvent(ev);
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void StripReverbPanel::hideEvent(QHideEvent* ev)
+{
+    QWidget::hideEvent(ev);
+    if (m_syncTimer) m_syncTimer->stop();
+}
+
+} // namespace AetherSDR

--- a/src/gui/StripReverbPanel.h
+++ b/src/gui/StripReverbPanel.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QWidget>
+
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;
+
+// Floating editor for the client-side TX reverb.  Five 76×76 knobs in
+// a single row — Size, Decay, Damping, Pre-delay, Mix.  No preset
+// picker (small room / hall / plate are a future iteration).
+// Geometry persists via AppSettings (`StripReverbPanelGeometry`).
+class StripReverbPanel : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit StripReverbPanel(AudioEngine* engine, QWidget* parent = nullptr);
+    ~StripReverbPanel() override;
+
+    void showForTx();
+
+signals:
+    // Present for API symmetry with the other editors; unused now that
+    // bypass lives on the CHAIN widget.
+    void bypassToggled(bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+    void syncControlsFromEngine();
+
+    AudioEngine*    m_audio{nullptr};
+    ClientCompKnob* m_size{nullptr};
+    ClientCompKnob* m_decay{nullptr};
+    ClientCompKnob* m_damping{nullptr};
+    ClientCompKnob* m_preDly{nullptr};
+    ClientCompKnob* m_mix{nullptr};
+    QTimer*         m_syncTimer{nullptr};
+    bool            m_restoring{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/StripTubePanel.cpp
+++ b/src/gui/StripTubePanel.cpp
@@ -1,0 +1,480 @@
+#include "StripTubePanel.h"
+#include "ClientCompKnob.h"
+#include "ClientLevelMeter.h"
+#include "ClientTubeCurveWidget.h"
+#include "EditorFramelessTitleBar.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/ClientTube.h"
+
+#include <QButtonGroup>
+#include <QCloseEvent>
+#include <QHBoxLayout>
+#include <QHideEvent>
+#include <QLabel>
+#include <QMoveEvent>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kDefaultWidth  = 720;
+constexpr int kDefaultHeight = 360;
+
+constexpr const char* kWindowStyle =
+    "QWidget { background: #08121d; color: #d7e7f2; }"
+    "QLabel  { background: transparent; color: #8aa8c0; font-size: 11px; }";
+
+const QString kBypassStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #0e1b28;"
+    "  color: #8aa8c0;"
+    "  border: 1px solid #243a4e;"
+    "  border-radius: 3px;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 12px;"
+    "}"
+    "QPushButton:hover { background: #1a2a3a; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e;"
+    "  color: #f2c14e;"
+    "  border: 1px solid #f2c14e;"
+    "}"
+    "QPushButton:checked:hover { background: #4a3a1e; }");
+
+const QString kModelStyle = QStringLiteral(
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #2a4458; border-radius: 3px;"
+    "  color: #8aa8c0; font-size: 11px; font-weight: bold;"
+    "  padding: 3px 10px; min-width: 26px;"
+    "}"
+    "QPushButton:hover { background: #24384e; }"
+    "QPushButton:checked {"
+    "  background: #3a2a0e; color: #f2c14e; border: 1px solid #f2c14e;"
+    "}");
+
+} // namespace
+
+StripTubePanel::StripTubePanel(AudioEngine* engine, QWidget* parent)
+    : QWidget(parent)
+    , m_audio(engine)
+{
+    setWindowTitle("Aetherial Dynamic Tube Pre-Amp");
+    setStyleSheet(kWindowStyle);
+    resize(kDefaultWidth, kDefaultHeight);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(8, 0, 8, 8);
+    root->setSpacing(6);
+
+    auto* titleBar = new EditorFramelessTitleBar;
+    m_titleBar = titleBar;
+    root->addWidget(titleBar);
+
+    // Bypass moved to the CHAIN widget's single-click gesture.
+    // Exclusive model group — buttons are created below in the Tone/Bias
+    // row, but the group owner lives here so the change signal can be
+    // wired in one place regardless of button placement.
+    m_modelGroup = new QButtonGroup(this);
+    m_modelGroup->setExclusive(true);
+    connect(m_modelGroup, &QButtonGroup::idToggled, this,
+            [this](int id, bool checked) {
+        if (checked) applyModel(id);
+    });
+
+    auto* body = new QHBoxLayout;
+    body->setSpacing(12);
+
+    // ── Left column: Dry/Wet, Output, Drive ─────────────────────────
+    auto* left = new QVBoxLayout;
+    left->setSpacing(10);
+
+    m_dryWet = new ClientCompKnob;
+    m_dryWet->setLabel("Dry/Wet");
+    m_dryWet->setCenterLabelMode(true);
+    m_dryWet->setRange(0.0f, 1.0f);
+    m_dryWet->setDefault(1.0f);
+    m_dryWet->setValueFromNorm([](float n) { return n; });
+    m_dryWet->setNormFromValue([](float v) { return v; });
+    m_dryWet->setLabelFormat([](float v) {
+        return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+    });
+    m_dryWet->setFixedSize(76, 76);
+    connect(m_dryWet, &ClientCompKnob::valueChanged,
+            this, &StripTubePanel::applyDryWet);
+    left->addWidget(m_dryWet, 0, Qt::AlignHCenter);
+
+    m_output = new ClientCompKnob;
+    m_output->setLabel("Output");
+    m_output->setCenterLabelMode(true);
+    m_output->setRange(-24.0f, 12.0f);
+    m_output->setDefault(0.0f);
+    m_output->setValueFromNorm([](float n) { return -24.0f + n * 36.0f; });
+    m_output->setNormFromValue([](float v) { return (v + 24.0f) / 36.0f; });
+    m_output->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 2) + " dB";
+    });
+    m_output->setFixedSize(76, 76);
+    connect(m_output, &ClientCompKnob::valueChanged,
+            this, &StripTubePanel::applyOutput);
+    left->addWidget(m_output, 0, Qt::AlignHCenter);
+
+    m_drive = new ClientCompKnob;
+    m_drive->setLabel("Drive");
+    m_drive->setCenterLabelMode(true);
+    m_drive->setRange(0.0f, 24.0f);
+    m_drive->setDefault(0.0f);
+    m_drive->setValueFromNorm([](float n) { return n * 24.0f; });
+    m_drive->setNormFromValue([](float v) { return v / 24.0f; });
+    m_drive->setLabelFormat([](float v) {
+        return QString::number(v, 'f', 2) + " dB";
+    });
+    m_drive->setFixedSize(76, 76);
+    connect(m_drive, &ClientCompKnob::valueChanged,
+            this, &StripTubePanel::applyDrive);
+    left->addWidget(m_drive, 0, Qt::AlignHCenter);
+
+    left->addStretch();
+    body->addLayout(left, 0);
+
+    // ── Centre column: curve + model buttons + Tone/Bias ────────────
+    auto* center = new QVBoxLayout;
+    center->setSpacing(6);
+
+    m_curve = new ClientTubeCurveWidget;
+    m_curve->setCompactMode(false);
+    m_curve->setMinimumHeight(180);
+    center->addWidget(m_curve, 1);
+
+    // Model A / B / C selector now lives in the header row so it
+    // doesn't eat vertical space from the curve.  See the header block
+    // above for where the buttons are actually inserted.
+
+    // Tone + Bias row
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(12);
+        row->addStretch();
+
+        m_tone = new ClientCompKnob;
+        m_tone->setLabel("Tone");
+        m_tone->setCenterLabelMode(true);
+        m_tone->setRange(-1.0f, 1.0f);
+        m_tone->setDefault(0.0f);
+        m_tone->setValueFromNorm([](float n) { return -1.0f + n * 2.0f; });
+        m_tone->setNormFromValue([](float v) { return (v + 1.0f) / 2.0f; });
+        m_tone->setLabelFormat([](float v) {
+            return QString::number(v, 'f', 2);
+        });
+        m_tone->setFixedSize(76, 76);
+        connect(m_tone, &ClientCompKnob::valueChanged,
+                this, &StripTubePanel::applyTone);
+        row->addWidget(m_tone, 0, Qt::AlignHCenter);
+
+        // A / B / C model selector — narrow vertical stack sitting
+        // between Tone and Bias.  Buttons live in m_modelGroup created
+        // earlier so the change handler stays wired.
+        {
+            auto* modelCol = new QVBoxLayout;
+            modelCol->setSpacing(3);
+            auto addModelBtn = [&](const QString& label, int idx) {
+                auto* btn = new QPushButton(label);
+                btn->setCheckable(true);
+                btn->setStyleSheet(kModelStyle);
+                btn->setFixedSize(22, 20);
+                m_modelGroup->addButton(btn, idx);
+                modelCol->addWidget(btn);
+                return btn;
+            };
+            m_modelA = addModelBtn("A", 0);
+            m_modelB = addModelBtn("B", 1);
+            m_modelC = addModelBtn("C", 2);
+            row->addLayout(modelCol, 0);
+        }
+
+        m_bias = new ClientCompKnob;
+        m_bias->setLabel("Bias");
+        m_bias->setCenterLabelMode(true);
+        m_bias->setRange(0.0f, 1.0f);
+        m_bias->setDefault(0.0f);
+        m_bias->setValueFromNorm([](float n) { return n; });
+        m_bias->setNormFromValue([](float v) { return v; });
+        m_bias->setLabelFormat([](float v) {
+            return QString::number(static_cast<int>(v * 100.0f + 0.5f)) + " %";
+        });
+        m_bias->setFixedSize(76, 76);
+        connect(m_bias, &ClientCompKnob::valueChanged,
+                this, &StripTubePanel::applyBias);
+        row->addWidget(m_bias, 0, Qt::AlignHCenter);
+
+        row->addStretch();
+        center->addLayout(row);
+    }
+
+    body->addLayout(center, 1);
+
+    // ── Right column: Envelope / Attack / Release ───────────────────
+    auto* right = new QVBoxLayout;
+    right->setSpacing(10);
+
+    m_envelope = new ClientCompKnob;
+    m_envelope->setLabel("Envelope");
+    m_envelope->setCenterLabelMode(true);
+    m_envelope->setRange(-1.0f, 1.0f);
+    m_envelope->setDefault(0.0f);
+    m_envelope->setValueFromNorm([](float n) { return -1.0f + n * 2.0f; });
+    m_envelope->setNormFromValue([](float v) { return (v + 1.0f) / 2.0f; });
+    m_envelope->setLabelFormat([](float v) {
+        const int pct = static_cast<int>(v * 100.0f + (v >= 0 ? 0.5f : -0.5f));
+        return QString::number(pct) + " %";
+    });
+    m_envelope->setFixedSize(76, 76);
+    connect(m_envelope, &ClientCompKnob::valueChanged,
+            this, &StripTubePanel::applyEnvelope);
+    right->addWidget(m_envelope, 0, Qt::AlignHCenter);
+
+    m_attack = new ClientCompKnob;
+    m_attack->setLabel("Attack");
+    m_attack->setCenterLabelMode(true);
+    m_attack->setRange(0.1f, 30.0f);
+    m_attack->setDefault(5.0f);
+    m_attack->setValueFromNorm([](float n) {
+        return 0.1f * std::pow(300.0f, n);
+    });
+    m_attack->setNormFromValue([](float v) {
+        return std::log(std::max(0.1f, v) / 0.1f) / std::log(300.0f);
+    });
+    m_attack->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 10.0f ? 2 : 1) + " ms";
+    });
+    m_attack->setFixedSize(76, 76);
+    connect(m_attack, &ClientCompKnob::valueChanged,
+            this, &StripTubePanel::applyAttack);
+    right->addWidget(m_attack, 0, Qt::AlignHCenter);
+
+    m_release = new ClientCompKnob;
+    m_release->setLabel("Release");
+    m_release->setCenterLabelMode(true);
+    m_release->setRange(10.0f, 500.0f);
+    m_release->setDefault(35.0f);
+    m_release->setValueFromNorm([](float n) {
+        return 10.0f * std::pow(50.0f, n);
+    });
+    m_release->setNormFromValue([](float v) {
+        return std::log(std::max(10.0f, v) / 10.0f) / std::log(50.0f);
+    });
+    m_release->setLabelFormat([](float v) {
+        return QString::number(v, 'f', v < 100.0f ? 2 : 1) + " ms";
+    });
+    m_release->setFixedSize(76, 76);
+    connect(m_release, &ClientCompKnob::valueChanged,
+            this, &StripTubePanel::applyRelease);
+    right->addWidget(m_release, 0, Qt::AlignHCenter);
+
+    right->addStretch();
+    body->addLayout(right, 0);
+
+    // ── Output level meter — far-right column, mirrors EQ editor ────
+    m_outMeter = new ClientLevelMeter;
+    body->addWidget(m_outMeter);
+
+    root->addLayout(body);
+
+    if (m_audio && tube()) {
+        m_curve->setTube(tube());
+    }
+
+    syncControlsFromEngine();
+
+    m_syncTimer = new QTimer(this);
+    m_syncTimer->setInterval(33);
+    connect(m_syncTimer, &QTimer::timeout,
+            this, &StripTubePanel::syncControlsFromEngine);
+}
+
+StripTubePanel::~StripTubePanel() = default;
+
+ClientTube* StripTubePanel::tube() const
+{
+    if (!m_audio) return nullptr;
+    return m_side == Side::Rx ? m_audio->clientTubeRx()
+                              : m_audio->clientTubeTx();
+}
+
+void StripTubePanel::saveTubeSettings() const
+{
+    if (!m_audio) return;
+    if (m_side == Side::Rx) m_audio->saveClientTubeRxSettings();
+    else                    m_audio->saveClientTubeSettings();
+}
+
+void StripTubePanel::showForTx()
+{
+    m_side = Side::Tx;
+    if (m_curve && tube()) m_curve->setTube(tube());
+    const QString title = QString::fromUtf8(
+        "Aetherial Dynamic Tube Pre-Amp \xe2\x80\x94 TX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void StripTubePanel::showForRx()
+{
+    m_side = Side::Rx;
+    if (m_curve && tube()) m_curve->setTube(tube());
+    const QString title = QString::fromUtf8(
+        "Aetherial Dynamic Tube Pre-Amp \xe2\x80\x94 RX");
+    if (m_titleBar)
+        static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
+    setWindowTitle(title);
+    syncControlsFromEngine();
+    restoreGeometryFromSettings();
+    show();
+    raise();
+    activateWindow();
+    if (m_syncTimer) m_syncTimer->start();
+}
+
+void StripTubePanel::syncControlsFromEngine()
+{
+    if (!m_audio || !tube()) return;
+    ClientTube* t = tube();
+    m_restoring = true;
+
+    {
+        const int idx = static_cast<int>(t->model());
+        QPushButton* btn = (idx == 1) ? m_modelB
+                          : (idx == 2) ? m_modelC
+                          : m_modelA;
+        QSignalBlocker b(m_modelGroup);
+        btn->setChecked(true);
+    }
+    { QSignalBlocker b(m_drive);    m_drive->setValue(t->driveDb()); }
+    { QSignalBlocker b(m_bias);     m_bias->setValue(t->biasAmount()); }
+    { QSignalBlocker b(m_tone);     m_tone->setValue(t->tone()); }
+    { QSignalBlocker b(m_output);   m_output->setValue(t->outputGainDb()); }
+    { QSignalBlocker b(m_dryWet);   m_dryWet->setValue(t->dryWet()); }
+    { QSignalBlocker b(m_envelope); m_envelope->setValue(t->envelopeAmount()); }
+    { QSignalBlocker b(m_attack);   m_attack->setValue(t->attackMs()); }
+    { QSignalBlocker b(m_release);  m_release->setValue(t->releaseMs()); }
+
+    if (m_outMeter) m_outMeter->setPeakDb(t->outputPeakDb());
+
+    m_restoring = false;
+}
+
+void StripTubePanel::applyModel(int idx)
+{
+    if (m_restoring || !m_audio) return;
+    tube()->setModel(
+        idx == 1 ? ClientTube::Model::B :
+        idx == 2 ? ClientTube::Model::C :
+                   ClientTube::Model::A);
+    saveTubeSettings();
+    if (m_curve) m_curve->update();
+}
+
+void StripTubePanel::applyDrive(float db)
+{
+    if (m_restoring || !m_audio) return;
+    tube()->setDriveDb(db);
+    saveTubeSettings();
+    if (m_curve) m_curve->update();
+}
+
+void StripTubePanel::applyBias(float v)
+{
+    if (m_restoring || !m_audio) return;
+    tube()->setBiasAmount(v);
+    saveTubeSettings();
+    if (m_curve) m_curve->update();
+}
+
+void StripTubePanel::applyTone(float v)
+{
+    if (m_restoring || !m_audio) return;
+    tube()->setTone(v);
+    saveTubeSettings();
+}
+
+void StripTubePanel::applyOutput(float db)
+{
+    if (m_restoring || !m_audio) return;
+    tube()->setOutputGainDb(db);
+    saveTubeSettings();
+}
+
+void StripTubePanel::applyDryWet(float v)
+{
+    if (m_restoring || !m_audio) return;
+    tube()->setDryWet(v);
+    saveTubeSettings();
+}
+
+void StripTubePanel::applyEnvelope(float v)
+{
+    if (m_restoring || !m_audio) return;
+    tube()->setEnvelopeAmount(v);
+    saveTubeSettings();
+}
+
+void StripTubePanel::applyAttack(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    tube()->setAttackMs(ms);
+    saveTubeSettings();
+}
+
+void StripTubePanel::applyRelease(float ms)
+{
+    if (m_restoring || !m_audio) return;
+    tube()->setReleaseMs(ms);
+    saveTubeSettings();
+}
+
+void StripTubePanel::saveGeometryToSettings()
+{
+    if (m_restoring) return;
+    AppSettings::instance().setValue(
+        "StripTubePanelGeometry",
+        QString::fromLatin1(saveGeometry().toBase64()));
+}
+
+void StripTubePanel::restoreGeometryFromSettings()
+{
+    m_restoring = true;
+    const QString b64 = AppSettings::instance()
+        .value("StripTubePanelGeometry", "").toString();
+    if (!b64.isEmpty()) {
+        restoreGeometry(QByteArray::fromBase64(b64.toLatin1()));
+    }
+    m_restoring = false;
+}
+
+void StripTubePanel::closeEvent(QCloseEvent* ev)
+{ saveGeometryToSettings(); QWidget::closeEvent(ev); }
+void StripTubePanel::moveEvent(QMoveEvent* ev)
+{ saveGeometryToSettings(); QWidget::moveEvent(ev); }
+void StripTubePanel::resizeEvent(QResizeEvent* ev)
+{ saveGeometryToSettings(); QWidget::resizeEvent(ev); }
+void StripTubePanel::showEvent(QShowEvent* ev)
+{ QWidget::showEvent(ev); }
+void StripTubePanel::hideEvent(QHideEvent* ev)
+{ saveGeometryToSettings(); QWidget::hideEvent(ev); }
+
+} // namespace AetherSDR

--- a/src/gui/StripTubePanel.h
+++ b/src/gui/StripTubePanel.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <QWidget>
+
+class QPushButton;
+class QButtonGroup;
+class QTimer;
+
+namespace AetherSDR {
+
+class AudioEngine;
+class ClientCompKnob;         // reused — generic rotary knob
+class ClientLevelMeter;
+class ClientTubeCurveWidget;
+
+// Floating editor for the client-side dynamic tube saturator.
+// Layout mirrors Ableton's Dynamic Tube device:
+//
+//   ┌─ bypass ──────────────────── × ┐
+//   │ ┌──────┐ ┌─────────┐ ┌──────┐ │
+//   │ │DryWet│ │  curve  │ │ ENV  │ │
+//   │ │      │ │         │ │      │ │
+//   │ │ Out  │ │         │ │ ATK  │ │
+//   │ │      │ │ [A B C] │ │      │ │
+//   │ │Drive │ │  Tone   │ │ REL  │ │
+//   │ │      │ │  Bias   │ │      │ │
+//   │ └──────┘ └─────────┘ └──────┘ │
+//   └────────────────────────────────┘
+class StripTubePanel : public QWidget {
+    Q_OBJECT
+
+public:
+    enum class Side { Tx, Rx };
+
+    explicit StripTubePanel(AudioEngine* engine, QWidget* parent = nullptr);
+    ~StripTubePanel() override;
+
+    void showForTx();
+    void showForRx();
+
+signals:
+    void bypassToggled(Side side, bool bypassed);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+    void showEvent(QShowEvent* ev) override;
+    void hideEvent(QHideEvent* ev) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+    void syncControlsFromEngine();
+
+    void applyModel(int idx);   // 0=A, 1=B, 2=C
+    void applyDrive(float db);
+    void applyBias(float v);
+    void applyTone(float v);
+    void applyOutput(float db);
+    void applyDryWet(float v);
+    void applyEnvelope(float v);
+    void applyAttack(float ms);
+    void applyRelease(float ms);
+
+    AudioEngine*           m_audio{nullptr};
+    Side                   m_side{Side::Tx};
+    QWidget*               m_titleBar{nullptr};   // EditorFramelessTitleBar*
+    class ClientTube*      tube() const;
+    void                   saveTubeSettings() const;
+    ClientTubeCurveWidget* m_curve{nullptr};
+    ClientCompKnob*        m_dryWet{nullptr};
+    ClientCompKnob*        m_output{nullptr};
+    ClientCompKnob*        m_drive{nullptr};
+    ClientCompKnob*        m_tone{nullptr};
+    ClientCompKnob*        m_bias{nullptr};
+    ClientCompKnob*        m_envelope{nullptr};
+    ClientCompKnob*        m_attack{nullptr};
+    ClientCompKnob*        m_release{nullptr};
+    ClientLevelMeter*      m_outMeter{nullptr};
+    QPushButton*           m_modelA{nullptr};
+    QPushButton*           m_modelB{nullptr};
+    QPushButton*           m_modelC{nullptr};
+    QButtonGroup*          m_modelGroup{nullptr};
+    QPushButton*           m_bypass{nullptr};
+    QTimer*                m_syncTimer{nullptr};   // mirror engine → knobs
+    bool                   m_restoring{false};
+};
+
+} // namespace AetherSDR


### PR DESCRIPTION
- Aetherial Audio Channel Strip: launch nub (step 1 of #2301)
- Aetherial Audio Channel Strip: nub polish — bare egg glyph
- Channel Strip step 2/7: StripReverbPanel duplicate
- Channel Strip step 2/7: StripPuduPanel duplicate
- Channel Strip step 2/7: StripDeEssPanel duplicate
- Channel Strip step 2/7: StripCompPanel duplicate
- Channel Strip step 2: fix StripCompPanel sed-collateral
- Channel Strip step 2/7: StripGatePanel duplicate
- Channel Strip step 2/7: StripTubePanel duplicate
- Channel Strip step 2/7: StripEqPanel duplicate
- Channel Strip steps 3+4: AetherialAudioStrip window + nub wiring (#2301)
- Channel Strip iteration + TCI default-source fix (#2304)
- Channel Strip presets, master-bypass sync, layout polish
