### PR TITLE
DAX RX: deliver audio via Qt::DirectConnection (#1008)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -11897,9 +11897,16 @@ bool MainWindow::startDax()
         }
     }
 
-    // Wire DAX RX: PanadapterStream routes registered DAX streams here
+    // Wire DAX RX: PanadapterStream routes registered DAX streams here.
+    // Qt::DirectConnection is intentional — feedDaxAudio runs on PanadapterStream's
+    // network thread instead of being queued on the GUI event loop.  That removes
+    // 10–50 ms of variable latency that the main thread was adding under heavy
+    // GUI load (waterfall paints, multiple panadapters).  Requires the DaxBridge
+    // implementations to be safe to call off the GUI thread (PipeWireAudioBridge
+    // was made lock-free / atomic for this in #1008).
     connect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
-            m_daxBridge, &DaxBridge::feedDaxAudio);
+            m_daxBridge, &DaxBridge::feedDaxAudio,
+            Qt::DirectConnection);
 
     // ── DAX IQ stream status + VITA routing ─────────────────────────────
     connect(&m_radioModel, &RadioModel::statusReceived,


### PR DESCRIPTION
## Summary

Wires `PanadapterStream::daxAudioReady → DaxBridge::feedDaxAudio` with `Qt::DirectConnection` so DAX audio frames are delivered on `PanadapterStream`'s network thread instead of being queued through the GUI event loop.

Under heavy GUI load (waterfall paints across multiple panadapters) the queued path was adding 10–50 ms of variable, GUI-correlated latency before samples reached the DAX bridge. DirectConnection removes that hop and produces steadier WSJT-X DT under typical operating conditions.

**Marked draft.** Split out of #2312 at @jensenpat's request so this connection-type change can be exercised in isolation against non-Linux DAX / TCI use cases.

## Dependency / ordering

This PR depends on #2312 for thread-safety on Linux:

- On Linux `DaxBridge` resolves to `PipeWireAudioBridge`. #2312 converts `m_open`, `m_channelGain`, `m_transmitting`, and `m_lastAudioMs` to `std::atomic` and removes all Qt-thread-affine work from `feedDaxAudio`. Without those changes, calling `feedDaxAudio` off the GUI thread races on those fields.
- On macOS `DaxBridge` resolves to `VirtualAudioBridge`. `VirtualAudioBridge::feedDaxAudio` should be reviewed for any Qt-thread-affine state before this lands. I haven't been able to verify on macOS hardware — flagging for a maintainer with a Mac to confirm.
- On Windows DAX is not built (`elif(UNIX)` gate in `CMakeLists.txt`), so this `connect(...)` site isn't compiled.
- TCI is unaffected by this change — TCI server has its own separate `daxAudioReady` connection (see other call sites in `MainWindow.cpp`) and this PR only touches the bridge wire.

Recommended merge order: #2312 first, then this PR.

## Diff

One hunk in `src/gui/MainWindow.cpp::startDax()` — adds `Qt::DirectConnection` to one `connect()` call plus a six-line comment explaining the rationale.

## Test plan

- [x] Builds cleanly on Linux against `upstream/main` (Qt 6.11.0, RelWithDebInfo) — only when stacked with #2312
- [ ] Builds cleanly on macOS — needs maintainer verification
- [ ] No regressions in macOS DAX RX behavior — needs maintainer verification
- [ ] No regressions in TCI RX behavior — TCI uses a separate signal connection, but worth a quick smoke test
- [x] WSJT-X DT under sustained waterfall paint load improves vs. queued connection (Linux, with #2312 stacked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)