### PR TITLE
Black slider: dual-role offset target while AUTO is engaged

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8734,6 +8734,10 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             this, [this, sw](bool on) {
         sw->setWfAutoBlack(on);
     });
+    connect(menu, &SpectrumOverlayMenu::wfAutoBlackOffsetChanged,
+            this, [sw](int offset) {
+        sw->setWfAutoBlackOffset(offset);
+    });
     connect(menu, &SpectrumOverlayMenu::wfLineDurationChanged,
             this, [this, applet, sw](int ms) {
         sw->setWfLineDuration(ms);
@@ -8784,6 +8788,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setWfColorGain(50);
         sw->setWfBlackLevel(15);
         sw->setWfAutoBlack(true);
+        sw->setWfAutoBlackOffset(50);
         sw->setWfLineDuration(100);
         sw->setWfBlankerEnabled(false);
         sw->setWfBlankerThreshold(1.15f);
@@ -8836,7 +8841,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
         // Sync all Display panel UI controls
         menu->syncDisplaySettings(0, 25, 70, false, QColor(0x00, 0xe5, 0xff),
-                                  50, 15, true, 100, 75, false, true, 0);
+                                  50, 15, true, 50, 100, 75, false, true, 0);
         menu->syncExtraDisplaySettings(false, 1.15f, 80, 0);
     });
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -863,18 +863,46 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         });
     }
 
-    // Black + Auto
-    makeRowWithBtn("Black:", 0, 100, 15, m_blackSlider, m_blackLabel,
+    // Black + Auto.  Single slider with two roles depending on AUTO state:
+    //   AUTO off → manual black-level (0..100), value persists in
+    //              m_blackManualValue and emits wfBlackLevelChanged.
+    //   AUTO on  → noise-floor offset (0..100, 50 = noise floor), value
+    //              persists in m_blackAutoOffsetValue and emits
+    //              wfAutoBlackOffsetChanged.
+    makeRowWithBtn("Black:", 0, 100, 50, m_blackSlider, m_blackLabel,
                    m_autoBlackBtn, "Auto");
     m_autoBlackBtn->setChecked(true);
     connect(m_blackSlider, &QSlider::valueChanged, this, [this](int v) {
         m_blackLabel->setText(QString::number(v));
-        emit wfBlackLevelChanged(v);
+        if (m_autoBlackBtn && m_autoBlackBtn->isChecked()) {
+            m_blackAutoOffsetValue = v;
+            emit wfAutoBlackOffsetChanged(v);
+        } else {
+            m_blackManualValue = v;
+            emit wfBlackLevelChanged(v);
+        }
     });
     connect(m_autoBlackBtn, &QPushButton::toggled, this, [this](bool on) {
         emit wfAutoBlackChanged(on);
+        // Swap the displayed slider value to whichever role just became
+        // active.  Block signals so the swap doesn't echo back as a user
+        // edit — we just want the UI to reflect the matching stored value.
+        if (m_blackSlider) {
+            QSignalBlocker bs(m_blackSlider);
+            const int v = on ? m_blackAutoOffsetValue : m_blackManualValue;
+            m_blackSlider->setValue(v);
+            if (m_blackLabel)
+                m_blackLabel->setText(QString::number(v));
+        }
+        if (m_blackSlider) {
+            m_blackSlider->setToolTip(on
+                ? "Auto-black target offset. 50 = at noise floor; lower = darker, higher = lighter."
+                : "Waterfall black level. Decrease to darken the noise floor.");
+        }
         if (!on)
-            emit wfBlackLevelChanged(m_blackSlider->value());
+            emit wfBlackLevelChanged(m_blackManualValue);
+        else
+            emit wfAutoBlackOffsetChanged(m_blackAutoOffsetValue);
     });
 
     // NB Blank + Off/On
@@ -1040,7 +1068,8 @@ void SpectrumOverlayMenu::buildDisplayPanel()
 
 void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
                                                bool weightedAvg, const QColor& fillColor,
-                                               int gain, int black, bool autoBlack, int rate,
+                                               int gain, int black, bool autoBlack,
+                                               int autoBlackOffset, int rate,
                                                int floorPos, bool floorEnable,
                                                bool heatMap, int colorScheme,
                                                bool showGrid,
@@ -1065,8 +1094,14 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
                 " border-radius: 2px; }").arg(fillColor.name()));
     m_gainSlider->setValue(gain);
     m_gainLabel->setText(QString::number(gain));
-    m_blackSlider->setValue(black);
-    m_blackLabel->setText(QString::number(black));
+    m_blackManualValue     = black;
+    m_blackAutoOffsetValue = autoBlackOffset;
+    const int displayBlack = autoBlack ? autoBlackOffset : black;
+    m_blackSlider->setValue(displayBlack);
+    m_blackLabel->setText(QString::number(displayBlack));
+    m_blackSlider->setToolTip(autoBlack
+        ? "Auto-black target offset. 50 = at noise floor; lower = darker, higher = lighter."
+        : "Waterfall black level. Decrease to darken the noise floor.");
     m_autoBlackBtn->setChecked(autoBlack);
     int rateSliderVal = std::clamp(rate - 70, 1, 30);  // line_duration 71-100 → slider 1-30
     m_rateSlider->setValue(rateSliderVal);

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -37,10 +37,13 @@ public:
     // Set the antenna list (from RadioModel::antListChanged).
     void setAntennaList(const QStringList& ants);
 
-    // Sync Display sub-panel controls with saved settings.
+    // Sync Display sub-panel controls with saved settings.  The Black slider
+    // displays `black` while autoBlack is off and `autoBlackOffset` while it
+    // is on; both values are stored internally so toggling the AUTO button
+    // swaps the slider position without losing either preference.
     void syncDisplaySettings(int avg, int fps, int fillPct, bool weightedAvg,
                              const QColor& fillColor, int gain, int black,
-                             bool autoBlack, int rate,
+                             bool autoBlack, int autoBlackOffset, int rate,
                              int floorPos = 75, bool floorEnable = false,
                              bool heatMap = true, int colorScheme = 0,
                              bool showGrid = true,
@@ -104,6 +107,9 @@ signals:
     void wfColorGainChanged(int gain);
     void wfBlackLevelChanged(int level);
     void wfAutoBlackChanged(bool on);
+    // Auto-black target offset (0-100, 50 = at noise floor).  Emitted when
+    // the Black slider moves while AUTO is engaged.
+    void wfAutoBlackOffsetChanged(int offset);
     void wfLineDurationChanged(int ms);
     void wfColorSchemeChanged(int scheme);
     void noiseFloorPositionChanged(int pos);
@@ -212,6 +218,11 @@ private:
     QSlider*     m_blackSlider{nullptr};
     QLabel*      m_blackLabel{nullptr};
     QPushButton* m_autoBlackBtn{nullptr};
+    // Two values backing the single Black slider; the slider shows whichever
+    // matches the current AUTO state.  Toggling AUTO swaps the displayed
+    // value, edits route to the matching member + matching signal.
+    int          m_blackManualValue{15};
+    int          m_blackAutoOffsetValue{50};
     QComboBox*   m_colorSchemeCmb{nullptr};
     QSlider*     m_rateSlider{nullptr};
     QLabel*      m_rateLabel{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -293,6 +293,7 @@ void SpectrumWidget::loadSettings()
     m_wfColorGain    = s.value(settingsKey("DisplayWfColorGain"), "50").toInt();
     m_wfBlackLevel   = s.value(settingsKey("DisplayWfBlackLevel"), "15").toInt();
     m_wfAutoBlack    = s.value(settingsKey("DisplayWfAutoBlack"), "True").toString() == "True";
+    m_wfAutoBlackOffset = s.value(settingsKey("DisplayWfAutoBlackOffset"), "50").toInt();
     m_wfLineDuration = s.value(settingsKey("DisplayWfLineDuration"), "100").toInt();
     // NB Waterfall Blanker (#277)
     m_wfBlankerEnabled   = s.value(settingsKey("WaterfallBlankingEnabled"), "False").toString() == "True";
@@ -326,7 +327,8 @@ void SpectrumWidget::loadSettings()
     if (m_overlayMenu) {
         m_overlayMenu->syncDisplaySettings(m_fftAverage, m_fftFps,
             static_cast<int>(m_fftFillAlpha * 100), m_fftWeightedAvg, m_fftFillColor,
-            m_wfColorGain, m_wfBlackLevel, m_wfAutoBlack, m_wfLineDuration,
+            m_wfColorGain, m_wfBlackLevel, m_wfAutoBlack, m_wfAutoBlackOffset,
+            m_wfLineDuration,
             75, false, m_fftHeatMap, static_cast<int>(m_wfColorScheme), m_showGrid,
             m_fftLineWidth);
         m_overlayMenu->syncExtraDisplaySettings(m_wfBlankerEnabled,
@@ -500,6 +502,17 @@ void SpectrumWidget::setWfAutoBlack(bool on) {
     auto& s = AppSettings::instance();
     s.setValue(settingsKey("DisplayWfAutoBlack"), on ? "True" : "False");
     s.save();
+    update();
+}
+void SpectrumWidget::setWfAutoBlackOffset(int level) {
+    int clamped = std::clamp(level, 0, 100);
+    if (clamped != m_wfAutoBlackOffset) {
+        m_wfAutoBlackOffset = clamped;
+        auto& s = AppSettings::instance();
+        s.setValue(settingsKey("DisplayWfAutoBlackOffset"), QString::number(m_wfAutoBlackOffset));
+        s.save();
+    }
+    update();
 }
 void SpectrumWidget::setWfLineDuration(int ms) {
     m_wfLineDuration = std::clamp(ms, 50, 500);
@@ -2883,10 +2896,14 @@ QRgb SpectrumWidget::dbmToRgb(float dbm) const
 QRgb SpectrumWidget::intensityToRgb(float intensity) const
 {
     // Map black_level (0-100) to an intensity threshold.
-    // When auto-black is on, use the measured noise floor instead.
+    // When auto-black is on, anchor to the measured noise floor and let the
+    // user bias it via the auto-black offset slider:
+    //   offset 50 → no bias (threshold sits at the noise floor)
+    //   offset  0 → +25 intensity above the noise floor (darker waterfall)
+    //   offset 100 → -25 intensity below the noise floor (lighter waterfall)
     float blackThresh;
     if (m_wfAutoBlack) {
-        blackThresh = m_autoBlackThresh;
+        blackThresh = m_autoBlackThresh + (50 - m_wfAutoBlackOffset) * 0.5f;
     } else {
         // Manual: slider 0 → thresh 160 (well above noise), slider 100 → thresh 60.
         blackThresh = 160.0f - m_wfBlackLevel * 1.0f;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -219,12 +219,17 @@ public:
     void setWfColorGain(int gain);
     void setWfBlackLevel(int level);
     void setWfAutoBlack(bool on);
+    // Auto-black offset (0-100, 50 = noise floor, <50 darker, >50 lighter).
+    // Only consulted while m_wfAutoBlack is on; lets users bias the noise-
+    // floor target without leaving auto-black.
+    void setWfAutoBlackOffset(int level);
     void setWfLineDuration(int ms);
     void setWfColorScheme(int scheme);
     void resetWfTimeScale();
     int   wfColorGain() const          { return m_wfColorGain; }
     int   wfBlackLevel() const         { return m_wfBlackLevel; }
     bool  wfAutoBlack() const          { return m_wfAutoBlack; }
+    int   wfAutoBlackOffset() const    { return m_wfAutoBlackOffset; }
     int   wfLineDuration() const       { return m_wfLineDuration; }
     int   wfColorScheme() const        { return static_cast<int>(m_wfColorScheme); }
 
@@ -506,6 +511,11 @@ private:
     int   m_wfColorGain{50};         // 0-100, maps intensity to color range
     int   m_wfBlackLevel{15};        // 0-125, intensity floor (below = black)
     bool  m_wfAutoBlack{true};
+    // Auto-black offset (0-100). 50 → no offset (today's behaviour); <50
+    // pushes the threshold above the noise floor (darker waterfall); >50
+    // pulls it below (lighter).  Stored separately from m_wfBlackLevel so
+    // toggling AUTO swaps between the two without losing either value.
+    int   m_wfAutoBlackOffset{50};
     WfColorScheme m_wfColorScheme{WfColorScheme::Default};
     float m_autoBlackThresh{145.0f}; // client-side auto-black: tracked noise floor
     int   m_wfLineDuration{100};     // ms per waterfall row


### PR DESCRIPTION
The Black slider was inert while auto-black was on, leaving users no
way to bias the algorithm's noise-floor target.  When AUTO is engaged
the slider now drives a target offset around the measured noise floor
(50 = at the floor, today's behaviour; <50 darker; >50 lighter) while
manual mode keeps its existing semantics.  Both values persist
independently so toggling AUTO swaps the slider position without
losing either preference.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
