### PR TITLE
Fix oscillator reference status updates

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3601,37 +3601,90 @@ MainWindow::MainWindow(QWidget* parent)
             m_stationLabel->setText(nick);
     });
 
-    // Frequency reference label from oscillator status (#478)
-    // Show what the radio is actually locked to, not GPS satellite state.
-    connect(&m_radioModel, &RadioModel::infoChanged, this, [this]() {
-        const QString& state = m_radioModel.oscState();
+    auto normalizeOscillatorValue = [](QString value) {
+        value = value.trimmed().toLower();
+        return value == "ext" ? QStringLiteral("external") : value;
+    };
+    auto oscillatorName = [normalizeOscillatorValue](const QString& value, bool compact) {
+        const QString normalized = normalizeOscillatorValue(value);
+        if (normalized == "auto") return QStringLiteral("Auto");
+        if (normalized == "external")
+            return compact ? QStringLiteral("Ext 10M") : QStringLiteral("External 10 MHz");
+        if (normalized == "gpsdo") return QStringLiteral("GPSDO");
+        if (normalized == "tcxo") return QStringLiteral("TCXO");
+        return value.trimmed().isEmpty() ? QStringLiteral("Unknown") : value.toUpper();
+    };
+    auto updateFrequencyReferenceLabel = [this, normalizeOscillatorValue, oscillatorName] {
+        const QString state = normalizeOscillatorValue(m_radioModel.oscState());
+        const QString setting = normalizeOscillatorValue(m_radioModel.oscSetting());
         const bool locked = m_radioModel.oscLocked();
-        if (state == "gpsdo" && locked) {
-            // Don't override — GPS status handler shows satellite count
-        } else if (m_radioModel.extPresent() && (state == "ext" || state == "external")) {
-            m_gpsLabel->setText("Ref: Ext 10M");
-            m_gpsStatusLabel->setText(QString("[%1]").arg(locked ? "Locked" : "Unlocked"));
+
+        QString sourceLabel;
+        QString statusLabel;
+        if (state.isEmpty()) {
+            sourceLabel = QStringLiteral("Ref: --");
+            statusLabel = QStringLiteral("[Waiting]");
+        } else if (state == "gpsdo") {
+            if (locked && (m_radioModel.gpsTracked() > 0 || m_radioModel.gpsVisible() > 0)) {
+                sourceLabel = QStringLiteral("GPS: %1/%2")
+                                  .arg(m_radioModel.gpsTracked())
+                                  .arg(m_radioModel.gpsVisible());
+            } else {
+                sourceLabel = QStringLiteral("Ref: GPSDO");
+            }
+            statusLabel = locked && !m_radioModel.gpsStatus().isEmpty()
+                ? QStringLiteral("[%1]").arg(m_radioModel.gpsStatus())
+                : QStringLiteral("[%1]").arg(locked ? "Locked" : "Unlocked");
+        } else if (state == "external") {
+            sourceLabel = QStringLiteral("Ref: Ext 10M");
+            statusLabel = !m_radioModel.extPresent()
+                ? QStringLiteral("[No 10M]")
+                : QStringLiteral("[%1]").arg(locked ? "Locked" : "Unlocked");
         } else {
-            m_gpsLabel->setText("Ref: TCXO");
-            m_gpsStatusLabel->setText("[Locked]");
+            sourceLabel = QStringLiteral("Ref: %1").arg(oscillatorName(state, true));
+            statusLabel = QStringLiteral("[%1]").arg(locked ? "Locked" : "Unlocked");
         }
-    });
+
+        m_gpsLabel->setText(sourceLabel);
+        m_gpsStatusLabel->setText(statusLabel);
+
+        QString tooltip = QStringLiteral("10 MHz reference\nSetting: %1\nActual: %2\nLock: %3")
+            .arg(oscillatorName(setting, false),
+                 oscillatorName(state, false),
+                 locked ? QStringLiteral("Locked") : QStringLiteral("Unlocked"));
+        if (state == "external") {
+            tooltip += QStringLiteral("\nExternal 10 MHz: %1")
+                .arg(m_radioModel.extPresent() ? QStringLiteral("detected")
+                                                : QStringLiteral("not detected"));
+        }
+        if (state == "gpsdo") {
+            tooltip += QStringLiteral("\nGPS: %1/%2 satellites")
+                .arg(m_radioModel.gpsTracked())
+                .arg(m_radioModel.gpsVisible());
+            if (!m_radioModel.gpsStatus().isEmpty())
+                tooltip += QStringLiteral("\nGPS status: %1").arg(m_radioModel.gpsStatus());
+        }
+        m_gpsLabel->setToolTip(tooltip);
+        m_gpsStatusLabel->setToolTip(tooltip);
+    };
+
+    // Frequency reference label from oscillator status (#478)
+    // Show radio oscillator state immediately; GPS status only adds details.
+    connect(&m_radioModel, &RadioModel::oscillatorChanged, this, updateFrequencyReferenceLabel);
+    updateFrequencyReferenceLabel();
 
     connect(&m_radioModel, &RadioModel::gpsStatusChanged,
-            this, [this](const QString& status, int tracked, int visible,
-                         const QString& grid, const QString& /*alt*/,
+            this, [this, normalizeOscillatorValue, updateFrequencyReferenceLabel](
+                         const QString& /*status*/, int /*tracked*/, int /*visible*/,
+                         const QString& /*grid*/, const QString& /*alt*/,
                          const QString& /*lat*/, const QString& /*lon*/,
                          const QString& utcTime) {
-        // Only show satellite count + lock status when GPSDO is active
-        if (m_radioModel.oscState() == "gpsdo" && m_radioModel.oscLocked()) {
-            m_gpsLabel->setText(QString("GPS: %1/%2").arg(tracked).arg(visible));
-            m_gpsStatusLabel->setText(QString("[%1]").arg(status));
-        }
+        updateFrequencyReferenceLabel();
 
         // Use GPS UTC time only when GPSDO is installed and locked.
         // GPS with no antenna/lock sends stale "00:00:00Z" — fall back to system clock.
         if (!utcTime.isEmpty()
-            && m_radioModel.oscState() == "gpsdo"
+            && normalizeOscillatorValue(m_radioModel.oscState()) == "gpsdo"
             && m_radioModel.oscLocked()) {
             m_gpsTimeLabel->setText(utcTime);
             m_useSystemClock = false;

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -52,6 +52,7 @@
 #include <QHostAddress>
 #include <QDebug>
 #include <QPointer>
+#include <QSignalBlocker>
 
 #include <memory>
 
@@ -72,6 +73,91 @@ static const QString kValueStyle =
 static const QString kEditStyle =
     "QLineEdit { background: #1a2a3a; border: 1px solid #304050; "
     "border-radius: 3px; color: #c8d8e8; font-size: 12px; padding: 2px 4px; }";
+
+static QString normalizedOscillatorValue(QString value)
+{
+    value = value.trimmed().toLower();
+    return value == "ext" ? QStringLiteral("external") : value;
+}
+
+static QString oscillatorSourceLabel(const QString& value)
+{
+    const QString normalized = normalizedOscillatorValue(value);
+    if (normalized == "auto") return QStringLiteral("Auto");
+    if (normalized == "external") return QStringLiteral("External 10 MHz");
+    if (normalized == "gpsdo") return QStringLiteral("GPSDO");
+    if (normalized == "tcxo") return QStringLiteral("TCXO");
+    return value.trimmed().isEmpty() ? QStringLiteral("Unknown") : value.toUpper();
+}
+
+static QString oscillatorStatusText(const RadioModel* model)
+{
+    const QString setting = normalizedOscillatorValue(model->oscSetting());
+    const QString state = normalizedOscillatorValue(model->oscState());
+    if (state.isEmpty())
+        return QStringLiteral("Waiting for oscillator status");
+
+    QString text;
+    if (setting == "auto" && state != "auto") {
+        text = QStringLiteral("Auto -> %1").arg(oscillatorSourceLabel(state));
+    } else if (!setting.isEmpty() && setting != state && state != "auto") {
+        text = QStringLiteral("%1 -> %2")
+                   .arg(oscillatorSourceLabel(setting), oscillatorSourceLabel(state));
+    } else {
+        text = oscillatorSourceLabel(state);
+    }
+
+    text += model->oscLocked() ? QStringLiteral(" Locked")
+                               : QStringLiteral(" Unlocked");
+    if (state == "external" && !model->extPresent())
+        text += QStringLiteral(" (not detected)");
+    return text;
+}
+
+static QString oscillatorStatusColor(const RadioModel* model)
+{
+    if (normalizedOscillatorValue(model->oscState()).isEmpty())
+        return QStringLiteral("#8aa8c0");
+    return model->oscLocked() ? QStringLiteral("#00c040")
+                              : QStringLiteral("#c04040");
+}
+
+static void addOscillatorChoice(QComboBox* combo, const QString& label,
+                                const QString& value)
+{
+    if (combo->findData(value) < 0)
+        combo->addItem(label, value);
+}
+
+static void refreshOscillatorSourceCombo(QComboBox* combo, const RadioModel* model,
+                                         const QString& preferred = {})
+{
+    const QString current = normalizedOscillatorValue(
+        preferred.isEmpty() ? combo->currentData().toString() : preferred);
+    const QString setting = normalizedOscillatorValue(model->oscSetting());
+    const QString state = normalizedOscillatorValue(model->oscState());
+    const bool hasOscillatorStatus = !state.isEmpty();
+
+    auto shouldKeep = [&](const QString& value) {
+        return current == value || setting == value || state == value;
+    };
+
+    combo->clear();
+    addOscillatorChoice(combo, QStringLiteral("Auto"), QStringLiteral("auto"));
+    if (hasOscillatorStatus || model->tcxoPresent() || shouldKeep(QStringLiteral("tcxo")))
+        addOscillatorChoice(combo, QStringLiteral("TCXO"), QStringLiteral("tcxo"));
+    if (model->gpsdoPresent() || shouldKeep(QStringLiteral("gpsdo")))
+        addOscillatorChoice(combo, QStringLiteral("GPSDO"), QStringLiteral("gpsdo"));
+    if (hasOscillatorStatus || model->extPresent() || shouldKeep(QStringLiteral("external")))
+        addOscillatorChoice(combo, QStringLiteral("External 10 MHz"),
+                            QStringLiteral("external"));
+
+    const QString desired = setting.isEmpty() ? current : setting;
+    int idx = combo->findData(desired);
+    if (idx < 0) idx = combo->findData(current);
+    if (idx < 0) idx = combo->findData(QStringLiteral("auto"));
+    if (idx >= 0) combo->setCurrentIndex(idx);
+}
 
 RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
                                    TgxlConnection* tgxl, PgxlConnection* pgxl,
@@ -1474,13 +1560,7 @@ QWidget* RadioSetupDialog::buildRxTab()
 
         auto* srcCmb = new QComboBox;
         AetherSDR::applyComboStyle(srcCmb);
-        srcCmb->addItem("Auto", "auto");
-        if (m_model->tcxoPresent())  srcCmb->addItem("TCXO", "tcxo");
-        if (m_model->gpsdoPresent()) srcCmb->addItem("GPSDO", "gpsdo");
-        if (m_model->extPresent())   srcCmb->addItem("External", "external");
-        // Select current setting
-        int idx = srcCmb->findData(m_model->oscSetting());
-        if (idx >= 0) srcCmb->setCurrentIndex(idx);
+        refreshOscillatorSourceCombo(srcCmb, m_model);
         connect(srcCmb, &QComboBox::currentIndexChanged, this, [this, srcCmb](int i) {
             m_model->sendCommand(
                 "radio oscillator " + srcCmb->itemData(i).toString());
@@ -1488,32 +1568,22 @@ QWidget* RadioSetupDialog::buildRxTab()
         grid->addWidget(srcCmb, 0, 1);
 
         // Lock status
-        auto* lockLbl = new QLabel(
-            m_model->oscState().toUpper() + (m_model->oscLocked() ? " Locked" : " Unlocked"));
-        lockLbl->setStyleSheet(m_model->oscLocked()
-            ? "QLabel { color: #00c040; font-size: 12px; font-weight: bold; }"
-            : "QLabel { color: #c04040; font-size: 12px; font-weight: bold; }");
+        auto* lockLbl = new QLabel(oscillatorStatusText(m_model));
+        lockLbl->setStyleSheet(QStringLiteral(
+            "QLabel { color: %1; font-size: 12px; font-weight: bold; }")
+            .arg(oscillatorStatusColor(m_model)));
         grid->addWidget(lockLbl, 0, 2);
 
         // Live-update oscillator status when radio state changes (#967)
-        connect(m_model, &RadioModel::infoChanged, this, [this, srcCmb, lockLbl] {
-            const QString text = m_model->oscState().toUpper()
-                + (m_model->oscLocked() ? " Locked" : " Unlocked");
-            lockLbl->setText(text);
-            lockLbl->setStyleSheet(m_model->oscLocked()
-                ? "QLabel { color: #00c040; font-size: 12px; font-weight: bold; }"
-                : "QLabel { color: #c04040; font-size: 12px; font-weight: bold; }");
+        connect(m_model, &RadioModel::oscillatorChanged, this, [this, srcCmb, lockLbl] {
+            lockLbl->setText(oscillatorStatusText(m_model));
+            lockLbl->setStyleSheet(QStringLiteral(
+                "QLabel { color: %1; font-size: 12px; font-weight: bold; }")
+                .arg(oscillatorStatusColor(m_model)));
 
-            const QString current = srcCmb->currentData().toString();
+            const QString current = normalizedOscillatorValue(srcCmb->currentData().toString());
             QSignalBlocker blocker(srcCmb);
-            srcCmb->clear();
-            srcCmb->addItem("Auto", "auto");
-            if (m_model->tcxoPresent())  { srcCmb->addItem("TCXO",     "tcxo"); }
-            if (m_model->gpsdoPresent()) { srcCmb->addItem("GPSDO",    "gpsdo"); }
-            if (m_model->extPresent())   { srcCmb->addItem("External", "external"); }
-            int idx = srcCmb->findData(m_model->oscSetting());
-            if (idx < 0) { idx = srcCmb->findData(current); }
-            if (idx >= 0) { srcCmb->setCurrentIndex(idx); }
+            refreshOscillatorSourceCombo(srcCmb, m_model, current);
         });
 
         vbox->addWidget(group);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2878,6 +2878,7 @@ void RadioModel::onStatusReceived(const QString& object,
         if (kvs.contains("gpsdo_present"))m_gpsdoPresent= kvs["gpsdo_present"] == "1";
         if (kvs.contains("tcxo_present")) m_tcxoPresent = kvs["tcxo_present"] == "1";
         if (kvs.contains("gnss_present")) m_gpsdoPresent= m_gpsdoPresent || kvs["gnss_present"] == "1";
+        emit oscillatorChanged();
         emit infoChanged();
         return;
     }

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -354,6 +354,8 @@ signals:
                           const QString& grid, const QString& altitude,
                           const QString& lat, const QString& lon,
                           const QString& utcTime);
+    // Emitted when the radio reports 10 MHz reference oscillator state.
+    void oscillatorChanged();
     // Emitted when network quality assessment changes.
     // quality: "Off", "Excellent", "Very Good", "Good", "Fair", "Poor"
     // pingMs: round-trip time in milliseconds


### PR DESCRIPTION
## Summary

This PR fixes the Radio Setup and status bar handling for FlexRadio 10 MHz reference/oscillator state.

The radio already reports the important clock/reference state through `radio oscillator` TCP status messages, including the desired `setting`, actual `state`, lock status, and presence flags for external 10 MHz, GPSDO/GNSS, and TCXO. AetherSDR was receiving those updates, but the status bar treated GPS status as part of the source-of-truth path for displaying GPSDO. That made the UI vulnerable to event ordering: if GPS status arrived before the oscillator update, or did not arrive again after the oscillator locked to GPSDO, the status bar could stay stuck on the previous/fallback reference label.

## Changes

- Adds a dedicated `RadioModel::oscillatorChanged()` signal emitted when `radio oscillator` status is parsed.
- Updates the status bar to render the current reference immediately from cached oscillator state and lock data.
- Keeps GPS status as supplemental detail only, adding satellite count and GPS status when available instead of deciding the reference source.
- Renames the Radio Setup dropdown item from `External` to `External 10 MHz` to match the FlexLib API description and make the 10 MHz reference option explicit.
- Normalizes `ext`/`external` handling in the UI display paths.
- Preserves currently selected or actual oscillator options in the dropdown even during presence transitions, so the selected/actual source does not disappear if a presence flag temporarily changes.
- Improves status text for resolved automatic references, such as `Auto -> GPSDO Locked`.
- Adds status bar tooltips showing desired setting, actual source, lock state, and GPS/external details.

## Root Cause

AetherSDR already subscribed to and parsed `sub radio all` and `sub gps all`. The issue was not missing meter data: oscillator/reference updates are TCP status updates, not VITA meter packets.

The fragile part was UI event ordering. The status bar deliberately skipped updating when `oscState() == "gpsdo" && oscLocked()` and waited for a later GPS status event to display satellite data. If that later GPS event did not arrive after the oscillator transition, the visible reference label could remain stale.

## User Impact

Operators should now see the reference source update promptly when the radio reports a GPSDO, TCXO, Auto-resolved, or external 10 MHz reference state. External 10 MHz is also more discoverable in Radio Setup because the dropdown now names it directly.

## Validation

- Configured a fresh build directory with `cmake -S . -B build`.
- Built successfully with `env -u CPLUS_INCLUDE_PATH cmake --build build --parallel 22`.
- Ran `ctest --test-dir build --output-on-failure`; all configured tests passed.
- Ran `git diff --check`; clean.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
