### PR TITLE
Quindar tones — Apollo K/BK on PTT engage and disengage (#2262)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,8 @@ set(CORE_SOURCES
     src/core/ClientReverb.cpp
     src/core/ClientFinalLimiter.cpp
     src/core/ClientTxTestTone.cpp
+    src/core/ClientQuindarTone.cpp
+    src/core/QuindarLocalSink.cpp
     src/core/CwSidetoneGenerator.cpp
     src/core/CwSidetoneQAudioSink.cpp
     src/core/CwxLocalKeyer.cpp
@@ -1126,6 +1128,13 @@ add_executable(client_comp_test
 )
 target_include_directories(client_comp_test PRIVATE src)
 
+add_executable(client_quindar_test
+    tests/client_quindar_test.cpp
+    src/core/ClientQuindarTone.cpp
+)
+target_include_directories(client_quindar_test PRIVATE src)
+target_link_libraries(client_quindar_test PRIVATE Qt6::Core)
+
 add_executable(client_gate_test
     tests/client_gate_test.cpp
     src/core/ClientGate.cpp
@@ -1245,6 +1254,7 @@ target_link_libraries(memory_recall_policy_test PRIVATE Qt6::Core)
 add_executable(transmit_model_apd_test
     tests/transmit_model_apd_test.cpp
     src/models/TransmitModel.cpp
+    src/core/ClientQuindarTone.cpp
     src/core/LogManager.cpp
     src/core/AppSettings.cpp
 )
@@ -1280,6 +1290,7 @@ target_link_libraries(midi_settings_test PRIVATE Qt6::Core)
 add_executable(transmit_model_test
     tests/transmit_model_test.cpp
     src/models/TransmitModel.cpp
+    src/core/ClientQuindarTone.cpp
     src/core/AppSettings.cpp
     src/core/LogManager.cpp
 )

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -10,6 +10,8 @@
 #include "ClientReverb.h"
 #include "ClientFinalLimiter.h"
 #include "ClientTxTestTone.h"
+#include "ClientQuindarTone.h"
+#include "QuindarLocalSink.h"
 #include "CwSidetoneGenerator.h"
 #include "CwSidetoneQAudioSink.h"
 #include "CwSidetoneSinkBackend.h"
@@ -208,6 +210,7 @@ AudioEngine::AudioEngine(QObject* parent)
     , m_clientFinalLimiterTx(std::make_unique<ClientFinalLimiter>())
     , m_clientTxTestTone(std::make_unique<ClientTxTestTone>())
     , m_cwSidetone(std::make_unique<CwSidetoneGenerator>(48000))
+    , m_clientQuindarTone(std::make_unique<ClientQuindarTone>())
 {
     // Prepare client DSP at the native 24 kHz rate. Sink resampling is
     // handled separately after EQ — EQ always runs at radio-native rate.
@@ -225,6 +228,7 @@ AudioEngine::AudioEngine(QObject* parent)
     m_clientReverbTx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientFinalLimiterTx->prepare(DEFAULT_SAMPLE_RATE);
     m_clientTxTestTone->prepare(DEFAULT_SAMPLE_RATE);
+    m_clientQuindarTone->prepare(DEFAULT_SAMPLE_RATE);
     loadClientEqSettings();      // restore persisted bands before first audio
     loadClientCompSettings();    // restore persisted comp params + chain order
     loadClientGateSettings();    // restore persisted gate params
@@ -237,6 +241,7 @@ AudioEngine::AudioEngine(QObject* parent)
     loadClientPuduSettings();    // restore persisted PUDU params
     loadClientReverbSettings();  // restore persisted reverb params
     loadClientFinalLimiterSettings();  // restore persisted final-limiter params
+    loadClientQuindarSettings();       // restore persisted Quindar tone params
     loadClientRxChainOrder();    // restore persisted RX chain order (Phase 0+)
 
     // Restore saved audio device selections
@@ -670,6 +675,7 @@ bool AudioEngine::startRxStream()
     // sidetone is disabled — the timer fires but writes silence to a tiny
     // primed buffer; no audible output, no extra CPU on the operator side.
     startSidetoneStream();
+    startQuindarLocalSink();
     emit rxStarted();
     return true;
 }
@@ -677,6 +683,7 @@ bool AudioEngine::startRxStream()
 void AudioEngine::stopRxStream()
 {
     stopSidetoneStream();
+    stopQuindarLocalSink();
     m_rxBuffer.clear();
     m_rxBufferBytes.store(0);
     m_rxBufferSampleRate.store(DEFAULT_SAMPLE_RATE);
@@ -781,6 +788,37 @@ void AudioEngine::stopSidetoneStream()
         m_sidetoneSink.reset();
     }
     if (m_cwSidetone) m_cwSidetone->reset();
+}
+
+bool AudioEngine::startQuindarLocalSink()
+{
+    if (m_quindarLocalSink && m_quindarLocalSink->isRunning()) return true;
+    if (!m_clientQuindarTone) return false;
+
+    QAudioDevice dev = QMediaDevices::defaultAudioOutput();
+    if (!m_outputDevice.isNull()) {
+        const auto outputs = QMediaDevices::audioOutputs();
+        for (const auto& d : outputs) {
+            if (d.id() == m_outputDevice.id()) { dev = m_outputDevice; break; }
+        }
+    }
+
+    if (!m_quindarLocalSink) {
+        m_quindarLocalSink = std::make_unique<QuindarLocalSink>(this);
+    }
+    if (!m_quindarLocalSink->start(dev, m_clientQuindarTone.get())) {
+        m_quindarLocalSink.reset();
+        return false;
+    }
+    return true;
+}
+
+void AudioEngine::stopQuindarLocalSink()
+{
+    if (m_quindarLocalSink) {
+        m_quindarLocalSink->stop();
+        m_quindarLocalSink.reset();
+    }
 }
 
 void AudioEngine::setRxPan(int v)
@@ -2466,6 +2504,53 @@ void AudioEngine::saveClientFinalLimiterSettings() const
         m_clientFinalLimiterTx->dcBlockEnabled() ? QString("True") : QString("False"));
 }
 
+void AudioEngine::loadClientQuindarSettings()
+{
+    if (!m_clientQuindarTone) return;
+    auto& s = AppSettings::instance();
+    m_clientQuindarTone->setEnabled(
+        s.value("QuindarEnabled", "False").toString() == "True");
+    const QString styleStr = s.value("QuindarStyle", "Tone").toString();
+    m_clientQuindarTone->setStyle(styleStr == "Morse"
+        ? ClientQuindarTone::Style::Morse
+        : ClientQuindarTone::Style::Tone);
+    m_clientQuindarTone->setLevelDb(
+        s.value("QuindarLevelDb", "-6.0").toFloat());
+    m_clientQuindarTone->setIntroFreqHz(
+        s.value("QuindarIntroFreqHz", "2525.0").toFloat());
+    m_clientQuindarTone->setOutroFreqHz(
+        s.value("QuindarOutroFreqHz", "2475.0").toFloat());
+    m_clientQuindarTone->setDurationMs(
+        s.value("QuindarDurationMs", "250").toInt());
+    m_clientQuindarTone->setMorseWpm(
+        s.value("QuindarMorseWpm", "45").toInt());
+    m_clientQuindarTone->setMorsePitchHz(
+        s.value("QuindarMorsePitchHz", "750.0").toFloat());
+}
+
+void AudioEngine::saveClientQuindarSettings() const
+{
+    if (!m_clientQuindarTone) return;
+    auto& s = AppSettings::instance();
+    s.setValue("QuindarEnabled",
+        m_clientQuindarTone->isEnabled() ? QString("True") : QString("False"));
+    s.setValue("QuindarStyle",
+        m_clientQuindarTone->style() == ClientQuindarTone::Style::Morse
+            ? QString("Morse") : QString("Tone"));
+    s.setValue("QuindarLevelDb",
+        QString::number(m_clientQuindarTone->levelDb()));
+    s.setValue("QuindarIntroFreqHz",
+        QString::number(m_clientQuindarTone->introFreqHz()));
+    s.setValue("QuindarOutroFreqHz",
+        QString::number(m_clientQuindarTone->outroFreqHz()));
+    s.setValue("QuindarDurationMs",
+        QString::number(m_clientQuindarTone->durationMs()));
+    s.setValue("QuindarMorseWpm",
+        QString::number(m_clientQuindarTone->morseWpm()));
+    s.setValue("QuindarMorsePitchHz",
+        QString::number(m_clientQuindarTone->morsePitchHz()));
+}
+
 static QString wisdomDir()
 {
 #ifdef _WIN32
@@ -3371,6 +3456,19 @@ void AudioEngine::onTxAudioReady()
         for (int i = 0; i < sampleCount; ++i)
             pcm[i] = static_cast<int16_t>(std::clamp(
                 static_cast<int>(pcm[i] * gain), -32768, 32767));
+    }
+
+    // ── Quindar tones (#2262) ───────────────────────────────────────────
+    // Sits AFTER the user DSP chain and PC mic gain but BEFORE the final
+    // brickwall limiter, so the generated tone is unprocessed by Comp/EQ
+    // (no comp pumping, no EQ tilt) but is still bounded by the configured
+    // ceiling.  Driven by TransmitModel's PTT coordinator on phone modes;
+    // the stage replaces samples wholesale during Engaging/Disengaging
+    // phases and is a no-op the rest of the time.
+    if (m_clientQuindarTone) {
+        const int frames = data.size() / static_cast<int>(sizeof(int16_t) * 2);
+        m_clientQuindarTone->process(
+            reinterpret_cast<int16_t*>(data.data()), frames, 2);
     }
 
     // ── Final brickwall limiter (TX tail) ───────────────────────────────

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -41,6 +41,8 @@ class ClientPuduMonitor;
 class ClientReverb;
 class ClientFinalLimiter;
 class ClientTxTestTone;
+class ClientQuindarTone;
+class QuindarLocalSink;
 class CwSidetoneGenerator;
 #ifdef __APPLE__
 class MacNRFilter;
@@ -79,6 +81,8 @@ public:
     // local sidetone for the first time after connect.
     Q_INVOKABLE bool startSidetoneStream();
     Q_INVOKABLE void stopSidetoneStream();
+    Q_INVOKABLE bool startQuindarLocalSink();
+    Q_INVOKABLE void stopQuindarLocalSink();
 
     // TX (microphone) – capture audio and send VITA-49 packets to radio
     Q_INVOKABLE bool startTxStream(const QHostAddress& radioAddress, quint16 radioPort);
@@ -240,6 +244,13 @@ public:
     // runs — useful for setup / calibration.
     ClientTxTestTone* clientTxTestTone() { return m_clientTxTestTone.get(); }
 
+    // Quindar tone generator (#2262).  Sits AFTER the user DSP chain
+    // and PC mic gain but BEFORE the final brickwall limiter, so the
+    // generated tone is unprocessed by Comp/EQ but still bounded by
+    // the configured ceiling.  Driven by the TransmitModel PTT
+    // coordinator on phone modes; bypassed on CW / digital.
+    ClientQuindarTone* clientQuindarTone() { return m_clientQuindarTone.get(); }
+
     // Register a monitor that taps the post-final-limiter int16
     // stream — the exact bytes that get packetised into VITA-49.
     // Mirror of setTxPostDspMonitor but at the chain tail.
@@ -354,6 +365,8 @@ public:
     void saveClientReverbSettings();
     void loadClientFinalLimiterSettings();
     void saveClientFinalLimiterSettings() const;
+    void loadClientQuindarSettings();
+    void saveClientQuindarSettings() const;
 
     // Post-Client-EQ audio tap for the editor's FFT analyzer.  Exposes
     // a rolling mono buffer filled on the audio thread; UI thread copies
@@ -496,6 +509,7 @@ private:
     // disabled by AppSettings["CwSidetoneBackend"]=="QAudioSink"; QAudioSink
     // (push mode, 2 ms timer, 50 ms buffer) otherwise.  See CwSidetoneSinkBackend.h.
     std::unique_ptr<class CwSidetoneSinkBackend> m_sidetoneSink;
+    std::unique_ptr<QuindarLocalSink>            m_quindarLocalSink;
 
     // TX
     QUdpSocket    m_txSocket;
@@ -621,6 +635,7 @@ private:
     std::unique_ptr<ClientReverb> m_clientReverbTx;
     std::unique_ptr<ClientFinalLimiter> m_clientFinalLimiterTx;
     std::unique_ptr<ClientTxTestTone>   m_clientTxTestTone;
+    std::unique_ptr<ClientQuindarTone>  m_clientQuindarTone;
     // Audio-thread-loaded pointer for the post-final-limiter monitor
     // (final-output recording).  Same lock-free atomic pointer pattern
     // as m_txPostDspMonitor.

--- a/src/core/ChannelStripPresets.cpp
+++ b/src/core/ChannelStripPresets.cpp
@@ -504,6 +504,9 @@ QJsonObject ChannelStripPresets::capturePresetJson() const
     // Final brickwall limiter (always present, not in user chain).
     // Test-tone state is intentionally NOT in presets — it's a
     // session-time setup tool, not a "voice mix" parameter.
+    // Quindar tones (#2262) are likewise excluded: they're a PTT-time
+    // stylistic choice, not voice-shaping, and preset recall shouldn't
+    // silently start signing off everyone's transmissions.
     if (auto* lim = m_engine->clientFinalLimiterTx()) {
         QJsonObject o;
         o["enabled"]      = lim->isEnabled();

--- a/src/core/ClientQuindarTone.cpp
+++ b/src/core/ClientQuindarTone.cpp
@@ -1,0 +1,636 @@
+#include "ClientQuindarTone.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr float kTwoPi      = 6.28318530717958647692f;
+constexpr float kEnvRampSec = 0.005f;       // 5 ms cos² ramp at element edges
+
+float dbToLin(float db) noexcept
+{
+    return std::pow(10.0f, db / 20.0f);
+}
+
+// Cos² envelope multiplier.  Returns 0 at frameInRamp = 0, 1 at
+// frameInRamp = rampFrames.  Used at both the leading and trailing
+// edges of every tone or Morse element to avoid key-clicks.
+float cosSquaredRamp(int frameInRamp, int rampFrames) noexcept
+{
+    if (rampFrames <= 0) return 1.0f;
+    if (frameInRamp <= 0) return 0.0f;
+    if (frameInRamp >= rampFrames) return 1.0f;
+    const float t = static_cast<float>(frameInRamp)
+                    / static_cast<float>(rampFrames);
+    // sin² goes 0 → 1 across [0, π/2]; equivalent shape to cos² fade-in.
+    const float s = std::sin(t * 1.57079632679f);
+    return s * s;
+}
+
+float envelopeAt(int phaseFrame, int totalFrames, int rampFrames) noexcept
+{
+    if (totalFrames <= 0) return 0.0f;
+    if (phaseFrame < 0 || phaseFrame >= totalFrames) return 0.0f;
+    const int distFromEnd = totalFrames - 1 - phaseFrame;
+    const float rIn  = cosSquaredRamp(phaseFrame, rampFrames);
+    const float rOut = cosSquaredRamp(distFromEnd, rampFrames);
+    return std::min(rIn, rOut);
+}
+
+int rampFramesFor(double sampleRate) noexcept
+{
+    return std::max(1, static_cast<int>(kEnvRampSec * sampleRate));
+}
+
+} // namespace
+
+ClientQuindarTone::ClientQuindarTone()
+{
+    // Reserve enough capacity that rebuildMorseTables() never has to
+    // reallocate at audio time.  K = 5 segments + trailing silence;
+    // BK = 11 segments + trailing silence.  Round up generously.
+    m_morseIntroTable.reserve(16);
+    m_morseOutroTable.reserve(32);
+}
+
+void ClientQuindarTone::prepare(double sampleRate)
+{
+    m_sampleRate = sampleRate;
+    recacheIfDirty();
+    rebuildMorseTables();
+    reset();
+}
+
+void ClientQuindarTone::setEnabled(bool on) noexcept
+{
+    m_atomics.enabled.store(on, std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+
+bool ClientQuindarTone::isEnabled() const noexcept
+{
+    return m_atomics.enabled.load(std::memory_order_relaxed);
+}
+
+void ClientQuindarTone::setStyle(Style s) noexcept
+{
+    m_atomics.style.store(static_cast<uint8_t>(s), std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+
+ClientQuindarTone::Style ClientQuindarTone::style() const noexcept
+{
+    return static_cast<Style>(m_atomics.style.load(std::memory_order_relaxed));
+}
+
+void ClientQuindarTone::setLevelDb(float db) noexcept
+{
+    m_atomics.levelDb.store(std::clamp(db, -20.0f, 0.0f),
+                            std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+
+float ClientQuindarTone::levelDb() const noexcept
+{
+    return m_atomics.levelDb.load(std::memory_order_relaxed);
+}
+
+void ClientQuindarTone::setIntroFreqHz(float hz) noexcept
+{
+    m_atomics.introFreqHz.store(std::clamp(hz, 400.0f, 3000.0f),
+                                std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+
+float ClientQuindarTone::introFreqHz() const noexcept
+{
+    return m_atomics.introFreqHz.load(std::memory_order_relaxed);
+}
+
+void ClientQuindarTone::setOutroFreqHz(float hz) noexcept
+{
+    m_atomics.outroFreqHz.store(std::clamp(hz, 400.0f, 3000.0f),
+                                std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+
+float ClientQuindarTone::outroFreqHz() const noexcept
+{
+    return m_atomics.outroFreqHz.load(std::memory_order_relaxed);
+}
+
+void ClientQuindarTone::setDurationMs(int ms) noexcept
+{
+    m_atomics.durationMs.store(std::clamp(ms, 100, 500),
+                               std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+
+int ClientQuindarTone::durationMs() const noexcept
+{
+    return m_atomics.durationMs.load(std::memory_order_relaxed);
+}
+
+void ClientQuindarTone::setMorseWpm(int wpm) noexcept
+{
+    m_atomics.morseWpm.store(std::clamp(wpm, 20, 60),
+                             std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+
+int ClientQuindarTone::morseWpm() const noexcept
+{
+    return m_atomics.morseWpm.load(std::memory_order_relaxed);
+}
+
+void ClientQuindarTone::setMorsePitchHz(float hz) noexcept
+{
+    m_atomics.morsePitchHz.store(std::clamp(hz, 400.0f, 1200.0f),
+                                 std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+
+float ClientQuindarTone::morsePitchHz() const noexcept
+{
+    return m_atomics.morsePitchHz.load(std::memory_order_relaxed);
+}
+
+int ClientQuindarTone::currentIntroDurationMs() const noexcept
+{
+    if (style() == Style::Tone) return durationMs();
+    // K = 9 dot-units; one dot = 1200 / WPM ms.
+    const int wpm = morseWpm();
+    return wpm > 0 ? (9 * 1200 / wpm) : 240;
+}
+
+int ClientQuindarTone::currentOutroDurationMs() const noexcept
+{
+    if (style() == Style::Tone) return durationMs();
+    // BK = 21 dot-units (B = 9, gap = 3, K = 9).
+    const int wpm = morseWpm();
+    return wpm > 0 ? (21 * 1200 / wpm) : 560;
+}
+
+void ClientQuindarTone::startIntro() noexcept
+{
+    m_atomics.phase.store(static_cast<uint8_t>(Phase::Engaging),
+                          std::memory_order_release);
+}
+
+void ClientQuindarTone::startOutro() noexcept
+{
+    m_atomics.phase.store(static_cast<uint8_t>(Phase::Disengaging),
+                          std::memory_order_release);
+}
+
+void ClientQuindarTone::forceIdle() noexcept
+{
+    m_atomics.phase.store(static_cast<uint8_t>(Phase::Idle),
+                          std::memory_order_release);
+}
+
+bool ClientQuindarTone::coalesceReEngage() noexcept
+{
+    uint8_t expected = static_cast<uint8_t>(Phase::Disengaging);
+    return m_atomics.phase.compare_exchange_strong(
+        expected, static_cast<uint8_t>(Phase::Live),
+        std::memory_order_acq_rel);
+}
+
+ClientQuindarTone::Phase ClientQuindarTone::phase() const noexcept
+{
+    return static_cast<Phase>(m_atomics.phase.load(std::memory_order_acquire));
+}
+
+void ClientQuindarTone::setPhaseCompleteCallback(PhaseCompleteCallback cb)
+{
+    m_phaseCompleteCb = std::move(cb);
+}
+
+void ClientQuindarTone::recacheIfDirty() noexcept
+{
+    const uint64_t v = m_atomics.version.load(std::memory_order_acquire);
+    if (v == m_cachedVersion) return;
+
+    m_cached.enabled = m_atomics.enabled.load(std::memory_order_relaxed);
+    m_cached.style = static_cast<Style>(
+        m_atomics.style.load(std::memory_order_relaxed));
+    m_cached.ampLin = dbToLin(
+        m_atomics.levelDb.load(std::memory_order_relaxed));
+
+    const float fs = static_cast<float>(std::max(1.0, m_sampleRate));
+    const float introHz = m_atomics.introFreqHz.load(std::memory_order_relaxed);
+    const float outroHz = m_atomics.outroFreqHz.load(std::memory_order_relaxed);
+    const float morseHz = m_atomics.morsePitchHz.load(std::memory_order_relaxed);
+    m_cached.introPhaseInc = kTwoPi * introHz / fs;
+    m_cached.outroPhaseInc = kTwoPi * outroHz / fs;
+    m_cached.morsePhaseInc = kTwoPi * morseHz / fs;
+
+    const int ms = m_atomics.durationMs.load(std::memory_order_relaxed);
+    m_cached.toneFrames = static_cast<int>(
+        static_cast<double>(ms) * m_sampleRate / 1000.0);
+
+    const int wpm = m_atomics.morseWpm.load(std::memory_order_relaxed);
+    const double dotMs = (wpm > 0) ? (1200.0 / wpm) : 26.667;
+    m_cached.morseDotFrames = static_cast<int>(
+        dotMs * m_sampleRate / 1000.0);
+    // K = 9 dot-units, BK = 21 dot-units.
+    m_cached.introMorseFrames = 9  * m_cached.morseDotFrames;
+    m_cached.outroMorseFrames = 21 * m_cached.morseDotFrames;
+
+    rebuildMorseTables();
+    m_cachedVersion = v;
+}
+
+void ClientQuindarTone::rebuildMorseTables() noexcept
+{
+    // K  = dah dit dah                  ( - · - )
+    // BK = dah dit dit dit  +  dah dit dah   ( -··· -·- with inter-letter gap )
+    //
+    // Element timing (units of 1 dot = morseDotFrames):
+    //   dot   = 1u tone
+    //   dash  = 3u tone
+    //   intra-element gap = 1u silence
+    //   inter-letter gap  = 3u silence (only between B and K in BK)
+    //
+    // K timeline (9 units total):
+    //   [3u tone] [1u silence] [1u tone] [1u silence] [3u tone]
+    //
+    // BK timeline (21 units total):
+    //   B = [3u tone] [1u silence] [1u tone] [1u silence] [1u tone]
+    //       [1u silence] [1u tone]                              = 9u
+    //   inter-letter gap                                         = 3u
+    //   K = [3u tone] [1u silence] [1u tone] [1u silence] [3u tone] = 9u
+
+    const int u = m_cached.morseDotFrames;
+    if (u <= 0) {
+        m_morseIntroTable.clear();
+        m_morseOutroTable.clear();
+        return;
+    }
+
+    auto build = [u](std::vector<MorseSegment>& out,
+                     std::initializer_list<std::pair<int, bool>> segs) {
+        out.clear();
+        int frame = 0;
+        for (const auto& [units, toneOn] : segs) {
+            MorseSegment seg;
+            seg.startFrame   = frame;
+            seg.lengthFrames = units * u;
+            seg.toneOn       = toneOn;
+            out.push_back(seg);
+            frame += seg.lengthFrames;
+        }
+    };
+
+    // K = dah  gap dit  gap dah
+    build(m_morseIntroTable, {
+        {3, true}, {1, false}, {1, true}, {1, false}, {3, true},
+    });
+
+    // BK = (dah gap dit gap dit gap dit) gap-letter (dah gap dit gap dah)
+    build(m_morseOutroTable, {
+        {3, true}, {1, false}, {1, true}, {1, false}, {1, true},
+        {1, false}, {1, true},
+        {3, false},                      // inter-letter gap (3u)
+        {3, true}, {1, false}, {1, true}, {1, false}, {3, true},
+    });
+}
+
+void ClientQuindarTone::reset() noexcept
+{
+    m_phaseFrame   = 0;
+    m_sinePhase    = 0.0f;
+    m_currentPhase = Phase::Idle;
+    m_localPhaseFrame   = 0;
+    m_localSinePhase    = 0.0f;
+    m_localCurrentPhase = Phase::Idle;
+}
+
+void ClientQuindarTone::processSidetone(float* stereoOut, int frames,
+                                         double sidetoneSampleRate) noexcept
+{
+    if (!stereoOut || frames <= 0 || sidetoneSampleRate <= 0.0) return;
+    recacheIfDirty();
+    if (!m_cached.enabled) {
+        m_localCurrentPhase = Phase::Idle;
+        m_localPhaseFrame   = 0;
+        m_localSinePhase    = 0.0f;
+        return;
+    }
+
+    const Phase requestedPhase = static_cast<Phase>(
+        m_atomics.phase.load(std::memory_order_acquire));
+
+    // Detect phase transitions on the local side independently of the
+    // TX-path process().  When the TX path advances the atomic phase
+    // (e.g. Engaging → Live), this side picks up the new state on the
+    // next call and resets its local counter so a click-free tone
+    // segment starts at frame 0.
+    if (requestedPhase != m_localCurrentPhase) {
+        m_localCurrentPhase = requestedPhase;
+        m_localPhaseFrame   = 0;
+        m_localSinePhase    = 0.0f;
+    }
+
+    if (m_localCurrentPhase == Phase::Idle
+        || m_localCurrentPhase == Phase::Live) {
+        return;
+    }
+
+    // Recompute per-rate frame counts and phase increments — different
+    // sample rate from the TX path, so we can't reuse m_cached's frame
+    // sizes.  Cheap to do here per block.
+    if (sidetoneSampleRate != m_localSampleRate) {
+        m_localSampleRate = sidetoneSampleRate;
+    }
+
+    const bool isIntro = (m_localCurrentPhase == Phase::Engaging);
+    const Style st     = m_cached.style;
+
+    const int totalFrames = (st == Style::Tone)
+        ? static_cast<int>(static_cast<double>(
+              m_atomics.durationMs.load(std::memory_order_relaxed))
+              * m_localSampleRate / 1000.0)
+        : (isIntro
+            ? static_cast<int>(9  * (1200.0 / m_atomics.morseWpm
+                  .load(std::memory_order_relaxed)) * m_localSampleRate / 1000.0)
+            : static_cast<int>(21 * (1200.0 / m_atomics.morseWpm
+                  .load(std::memory_order_relaxed)) * m_localSampleRate / 1000.0));
+
+    const float toneFreq = isIntro
+        ? m_atomics.introFreqHz.load(std::memory_order_relaxed)
+        : m_atomics.outroFreqHz.load(std::memory_order_relaxed);
+    const float morseFreq = m_atomics.morsePitchHz.load(std::memory_order_relaxed);
+    const float fs        = static_cast<float>(m_localSampleRate);
+    const float phaseInc  = (st == Style::Tone)
+        ? (kTwoPi * toneFreq  / fs)
+        : (kTwoPi * morseFreq / fs);
+
+    const int rampFrames = std::max(1,
+        static_cast<int>(0.005 * m_localSampleRate));
+    const int dotFrames = static_cast<int>(
+        (1200.0 / std::max(1, m_atomics.morseWpm
+            .load(std::memory_order_relaxed))) * m_localSampleRate / 1000.0);
+
+    // Morse element timeline at the local sample rate.  Reuse the
+    // K / BK structure from the TX-path table: same units (1/3/etc)
+    // just scaled to local-rate frames.
+    auto morseEnvelope = [&](int frame) -> float {
+        // K = dah(3)·gap(1)·dit(1)·gap(1)·dah(3)         = 9 units
+        // BK = dah(3)·gap(1)·dit(1)·gap(1)·dit(1)·gap(1)·dit(1)
+        //      ·gap-letter(3)·dah(3)·gap(1)·dit(1)·gap(1)·dah(3)  = 21 units
+        struct Seg { int unitStart; int unitLen; bool toneOn; };
+        static constexpr Seg kK[]  = {
+            {0, 3, true}, {3, 1, false}, {4, 1, true},
+            {5, 1, false}, {6, 3, true}
+        };
+        static constexpr Seg kBK[] = {
+            {0,  3, true},  {3,  1, false}, {4,  1, true},
+            {5,  1, false}, {6,  1, true},  {7,  1, false},
+            {8,  1, true},  {9,  3, false}, {12, 3, true},
+            {15, 1, false}, {16, 1, true},  {17, 1, false},
+            {18, 3, true}
+        };
+        const Seg* table = isIntro ? kK : kBK;
+        const int  count = isIntro
+            ? static_cast<int>(sizeof(kK)  / sizeof(Seg))
+            : static_cast<int>(sizeof(kBK) / sizeof(Seg));
+
+        for (int i = 0; i < count; ++i) {
+            const int segStart = table[i].unitStart * dotFrames;
+            const int segLen   = table[i].unitLen   * dotFrames;
+            if (frame >= segStart && frame < segStart + segLen) {
+                if (!table[i].toneOn) return 0.0f;
+                const int frameInSeg = frame - segStart;
+                const float rIn  = cosSquaredRamp(frameInSeg, rampFrames);
+                const float rOut = cosSquaredRamp(segLen - 1 - frameInSeg,
+                                                   rampFrames);
+                return std::min(rIn, rOut);
+            }
+        }
+        return 0.0f;
+    };
+
+    for (int f = 0; f < frames; ++f) {
+        if (m_localPhaseFrame >= totalFrames) {
+            // Local path mirrors completion but doesn't transition the
+            // atomic — the TX path will do that itself when it consumes
+            // its own frame counter.  Just stop generating samples.
+            m_localCurrentPhase = (m_localCurrentPhase == Phase::Engaging)
+                ? Phase::Live : Phase::Idle;
+            return;
+        }
+
+        float sample = 0.0f;
+        if (st == Style::Tone) {
+            const float env = envelopeAt(m_localPhaseFrame, totalFrames,
+                                          rampFrames);
+            sample = std::sin(m_localSinePhase) * env * m_cached.ampLin;
+        } else {
+            const float env = morseEnvelope(m_localPhaseFrame);
+            if (env > 0.0f) {
+                sample = std::sin(m_localSinePhase) * env * m_cached.ampLin;
+            }
+        }
+        m_localSinePhase += phaseInc;
+        if (m_localSinePhase > kTwoPi) m_localSinePhase -= kTwoPi;
+
+        // Mix additively into stereo output (same sample on both channels).
+        stereoOut[f * 2]     += sample;
+        stereoOut[f * 2 + 1] += sample;
+        ++m_localPhaseFrame;
+    }
+}
+
+float ClientQuindarTone::generateToneSample(int phaseFrame, int totalFrames,
+                                            float phaseInc) noexcept
+{
+    const int rampFrames = rampFramesFor(m_sampleRate);
+    const float env = envelopeAt(phaseFrame, totalFrames, rampFrames);
+    const float s = std::sin(m_sinePhase) * env * m_cached.ampLin;
+    m_sinePhase += phaseInc;
+    if (m_sinePhase > kTwoPi) m_sinePhase -= kTwoPi;
+    return s;
+}
+
+float ClientQuindarTone::generateMorseSample(
+    int phaseFrame,
+    const std::vector<MorseSegment>& table,
+    int /*totalFrames*/) noexcept
+{
+    if (table.empty()) {
+        m_sinePhase += m_cached.morsePhaseInc;
+        if (m_sinePhase > kTwoPi) m_sinePhase -= kTwoPi;
+        return 0.0f;
+    }
+
+    // Find the segment containing phaseFrame.  Linear scan is fine —
+    // tables hold ≤ 13 segments and we hit them in order.
+    const MorseSegment* active = nullptr;
+    for (const auto& seg : table) {
+        if (phaseFrame >= seg.startFrame
+            && phaseFrame < seg.startFrame + seg.lengthFrames) {
+            active = &seg;
+            break;
+        }
+    }
+
+    float sample = 0.0f;
+    if (active && active->toneOn) {
+        const int rampFrames = rampFramesFor(m_sampleRate);
+        const int frameInSeg = phaseFrame - active->startFrame;
+        const float env = envelopeAt(frameInSeg, active->lengthFrames,
+                                     rampFrames);
+        sample = std::sin(m_sinePhase) * env * m_cached.ampLin;
+    }
+    m_sinePhase += m_cached.morsePhaseInc;
+    if (m_sinePhase > kTwoPi) m_sinePhase -= kTwoPi;
+    return sample;
+}
+
+void ClientQuindarTone::process(float* interleaved, int frames, int channels) noexcept
+{
+    if (!interleaved || frames <= 0 || channels < 1 || channels > 2) return;
+    recacheIfDirty();
+
+    if (!m_cached.enabled) {
+        // Disabled — keep phase Idle so coordinator transitions are
+        // benign, but never modify samples.  Force the atomic back to
+        // Idle even if our local cached phase is already Idle, since
+        // the coordinator may have published a non-Idle phase that we
+        // should reflect-and-clear before the next enable.
+        m_currentPhase = Phase::Idle;
+        m_phaseFrame   = 0;
+        m_sinePhase    = 0.0f;
+        m_atomics.phase.store(static_cast<uint8_t>(Phase::Idle),
+                              std::memory_order_release);
+        return;
+    }
+
+    const Phase requestedPhase = static_cast<Phase>(
+        m_atomics.phase.load(std::memory_order_acquire));
+
+    // Phase transition detection — reset frame counter + sine phase
+    // so each phase starts cleanly from t=0 (avoids carry-over click).
+    if (requestedPhase != m_currentPhase) {
+        m_currentPhase = requestedPhase;
+        m_phaseFrame   = 0;
+        m_sinePhase    = 0.0f;
+    }
+
+    if (m_currentPhase == Phase::Idle || m_currentPhase == Phase::Live) {
+        return;
+    }
+
+    const bool isIntro = (m_currentPhase == Phase::Engaging);
+    const Style st     = m_cached.style;
+    const int totalFrames = (st == Style::Tone)
+        ? m_cached.toneFrames
+        : (isIntro ? m_cached.introMorseFrames : m_cached.outroMorseFrames);
+    const float phaseInc = isIntro
+        ? m_cached.introPhaseInc
+        : m_cached.outroPhaseInc;
+    const auto& morseTable = isIntro ? m_morseIntroTable : m_morseOutroTable;
+
+    for (int f = 0; f < frames; ++f) {
+        if (m_phaseFrame >= totalFrames) {
+            // Phase finished — atomic transition to next phase.  Audio
+            // thread is the source of truth for the transition.
+            const Phase next = isIntro ? Phase::Live : Phase::Idle;
+            m_currentPhase = next;
+            m_atomics.phase.store(static_cast<uint8_t>(next),
+                                  std::memory_order_release);
+            if (m_phaseCompleteCb) {
+                // Invoke synchronously — for tests + the
+                // QueuedConnection-based dispatcher in TransmitModel.
+                const Phase finished = isIntro
+                    ? Phase::Engaging : Phase::Disengaging;
+                m_phaseCompleteCb(finished);
+            }
+            // Don't generate further samples this block — let the new
+            // phase (Live or Idle) pass through unchanged.
+            return;
+        }
+
+        const float sample = (st == Style::Tone)
+            ? generateToneSample(m_phaseFrame, totalFrames, phaseInc)
+            : generateMorseSample(m_phaseFrame, morseTable, totalFrames);
+
+        for (int c = 0; c < channels; ++c) {
+            interleaved[f * channels + c] = sample;
+        }
+        ++m_phaseFrame;
+    }
+}
+
+void ClientQuindarTone::process(int16_t* interleaved, int frames, int channels) noexcept
+{
+    if (!interleaved || frames <= 0 || channels < 1 || channels > 2) return;
+    recacheIfDirty();
+
+    if (!m_cached.enabled) {
+        if (m_currentPhase != Phase::Idle) {
+            m_currentPhase = Phase::Idle;
+            m_phaseFrame   = 0;
+            m_sinePhase    = 0.0f;
+            m_atomics.phase.store(static_cast<uint8_t>(Phase::Idle),
+                                  std::memory_order_release);
+        }
+        return;
+    }
+
+    const Phase requestedPhase = static_cast<Phase>(
+        m_atomics.phase.load(std::memory_order_acquire));
+
+    if (requestedPhase != m_currentPhase) {
+        m_currentPhase = requestedPhase;
+        m_phaseFrame   = 0;
+        m_sinePhase    = 0.0f;
+    }
+
+    if (m_currentPhase == Phase::Idle || m_currentPhase == Phase::Live) {
+        return;
+    }
+
+    const bool isIntro = (m_currentPhase == Phase::Engaging);
+    const Style st     = m_cached.style;
+    const int totalFrames = (st == Style::Tone)
+        ? m_cached.toneFrames
+        : (isIntro ? m_cached.introMorseFrames : m_cached.outroMorseFrames);
+    const float phaseInc = isIntro
+        ? m_cached.introPhaseInc
+        : m_cached.outroPhaseInc;
+    const auto& morseTable = isIntro ? m_morseIntroTable : m_morseOutroTable;
+
+    for (int f = 0; f < frames; ++f) {
+        if (m_phaseFrame >= totalFrames) {
+            const Phase next = isIntro ? Phase::Live : Phase::Idle;
+            m_currentPhase = next;
+            m_atomics.phase.store(static_cast<uint8_t>(next),
+                                  std::memory_order_release);
+            if (m_phaseCompleteCb) {
+                const Phase finished = isIntro
+                    ? Phase::Engaging : Phase::Disengaging;
+                m_phaseCompleteCb(finished);
+            }
+            return;
+        }
+
+        const float sample = (st == Style::Tone)
+            ? generateToneSample(m_phaseFrame, totalFrames, phaseInc)
+            : generateMorseSample(m_phaseFrame, morseTable, totalFrames);
+
+        const int16_t s16 = static_cast<int16_t>(std::clamp(
+            sample * 32767.0f, -32768.0f, 32767.0f));
+        for (int c = 0; c < channels; ++c) {
+            interleaved[f * channels + c] = s16;
+        }
+        ++m_phaseFrame;
+    }
+}
+
+} // namespace AetherSDR

--- a/src/core/ClientQuindarTone.h
+++ b/src/core/ClientQuindarTone.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace AetherSDR {
+
+// Apollo-era Quindar tones for MOX/PTT engage and disengage events
+// (#2262).  When enabled and the active TX slice is on a phone mode,
+// this stage:
+//
+//   - inserts a short tone (or Morse "K") at the start of every
+//     transmission ("Engaging" phase),
+//   - inserts a short tone (or Morse "BK") at the end of every
+//     transmission ("Disengaging" phase) and defers the actual
+//     `xmit 0` command until the outro finishes.
+//
+// Two stylistic flavours selected at runtime:
+//
+//   Tone:  2525 Hz / 2475 Hz sine, 250 ms each, 5 ms cos² envelope.
+//          The classic NASA Mission Control sound.
+//   Morse: pre-rendered "K" (intro) and "BK" (outro) at 45 WPM with a
+//          configurable carrier pitch.  Ham-radio convention — K =
+//          "go ahead", BK = "back to you".
+//
+// Inserted in the TX path AFTER the user's DSP chain and PC mic gain
+// but BEFORE the final brickwall limiter, so the tone is unprocessed
+// by Comp/EQ but still bounded by the configured ceiling.  During
+// Engaging/Disengaging the stage REPLACES interleaved samples with
+// the generated audio (it does not sum with mic input).
+//
+// Threading mirrors ClientFinalLimiter / ClientTxTestTone: UI thread
+// writes std::atomic parameters and bumps a version counter; audio
+// thread reads the version once per block and recaches.  No locks,
+// no allocations, no exceptions in the audio path.  Phase transitions
+// (Idle → Engaging → Live → Disengaging → Idle) are atomic so the
+// coordinator on the GUI thread can drive them without races.
+class ClientQuindarTone {
+public:
+    enum class Style : uint8_t { Tone = 0, Morse = 1 };
+    enum class Phase : uint8_t {
+        Idle        = 0,
+        Engaging    = 1,
+        Live        = 2,
+        Disengaging = 3,
+    };
+
+    ClientQuindarTone();
+    ~ClientQuindarTone() = default;
+
+    ClientQuindarTone(const ClientQuindarTone&)            = delete;
+    ClientQuindarTone& operator=(const ClientQuindarTone&) = delete;
+
+    void prepare(double sampleRate);
+
+    // Master enable.  When off, process() is a no-op regardless of
+    // phase — the coordinator should still be able to drive phase
+    // transitions safely (they're inert if the stage is disabled).
+    void  setEnabled(bool on) noexcept;
+    bool  isEnabled() const noexcept;
+
+    void  setStyle(Style s) noexcept;
+    Style style() const noexcept;
+
+    // Output level in dBFS, applied to the generated waveform.
+    // Range [-20, 0] dB.
+    void  setLevelDb(float db) noexcept;
+    float levelDb() const noexcept;
+
+    // Tone-style frequencies (default 2525 / 2475 Hz Apollo Quindar).
+    void  setIntroFreqHz(float hz) noexcept;
+    float introFreqHz() const noexcept;
+    void  setOutroFreqHz(float hz) noexcept;
+    float outroFreqHz() const noexcept;
+    void  setDurationMs(int ms) noexcept;       // 100..500
+    int   durationMs() const noexcept;
+
+    // Morse-style parameters.
+    void  setMorseWpm(int wpm) noexcept;        // 20..60
+    int   morseWpm() const noexcept;
+    void  setMorsePitchHz(float hz) noexcept;   // 400..1200
+    float morsePitchHz() const noexcept;
+
+    // Compute outro duration in ms for the current style + settings.
+    // Used by the PTT coordinator to size the deferred-xmit-0 timer.
+    // For Tone style: durationMs(); for Morse style: BK length at the
+    // current WPM (~560 ms at 45 WPM).
+    int   currentOutroDurationMs() const noexcept;
+    int   currentIntroDurationMs() const noexcept;
+
+    // Phase control — main thread.  Atomic store; audio thread picks
+    // it up on the next block.
+    void  startIntro() noexcept;     // → Engaging
+    void  startOutro() noexcept;     // → Disengaging
+    void  forceIdle() noexcept;      // → Idle (e.g. on disconnect)
+
+    // Coalesce a re-engage during the outro window.  If the current
+    // phase is Disengaging, force back to Live (skipping a fresh
+    // intro so the user doesn't feel an outro+intro dead zone).
+    // No-op otherwise.  Returns true if a coalesce actually happened.
+    bool  coalesceReEngage() noexcept;
+
+    Phase phase() const noexcept;
+
+    // Invoked on the GUI thread (via the supplied dispatcher) when a
+    // phase finishes.  The audio thread sets a "phase done" atomic
+    // flag; the coordinator polls or queues a signal off it.  In
+    // practice TransmitModel uses a QTimer::singleShot for the outro
+    // that's sized from currentOutroDurationMs() rather than relying
+    // on a callback hop, so this hook is mainly for tests + parity
+    // with the spec.
+    using PhaseCompleteCallback = std::function<void(Phase finished)>;
+    void  setPhaseCompleteCallback(PhaseCompleteCallback cb);
+
+    // Audio-thread entry points.  channels must be 1 or 2.  When
+    // phase is Idle or Live, samples pass through unchanged.  When
+    // Engaging or Disengaging, samples are overwritten with the
+    // generated tone/Morse audio.  Phase transitions Engaging → Live
+    // and Disengaging → Idle happen automatically when the configured
+    // duration is consumed.
+    void  process(int16_t* interleaved, int frames, int channels) noexcept;
+    void  process(float*   interleaved, int frames, int channels) noexcept;
+
+    // Local sidetone fill.  Called from the dedicated QuindarLocalSink
+    // each audio block so the operator hears the tone the moment MOX
+    // is hit — Quindar must always be locally audible whenever it's
+    // overlaying the TX stream.  Writes to the stereo float32 output
+    // buffer using independent local-rate phase state (separate from
+    // process(), which runs at the radio's 24 kHz TX rate).  When the
+    // atomic phase is Idle or Live, leaves the buffer as zeros.  Never
+    // mutates the atomic phase — the TX-path process() is the source
+    // of truth for transitions; this path just mirrors them.
+    void  processSidetone(float* stereoOut, int frames,
+                          double sidetoneSampleRate) noexcept;
+
+    void  reset() noexcept;
+
+    double sampleRate() const noexcept { return m_sampleRate; }
+
+private:
+    struct Atomics {
+        std::atomic<bool>     enabled{false};
+        std::atomic<uint8_t>  style{static_cast<uint8_t>(Style::Tone)};
+        std::atomic<float>    levelDb{-6.0f};
+        std::atomic<float>    introFreqHz{2525.0f};
+        std::atomic<float>    outroFreqHz{2475.0f};
+        std::atomic<int>      durationMs{250};
+        std::atomic<int>      morseWpm{45};
+        std::atomic<float>    morsePitchHz{750.0f};
+        std::atomic<uint8_t>  phase{static_cast<uint8_t>(Phase::Idle)};
+        std::atomic<uint64_t> version{0};
+    };
+
+    struct Cached {
+        bool  enabled{false};
+        Style style{Style::Tone};
+        float ampLin{0.5f};
+        float introPhaseInc{0.0f};
+        float outroPhaseInc{0.0f};
+        float morsePhaseInc{0.0f};
+        int   toneFrames{0};         // duration of one tone in frames
+        int   introMorseFrames{0};   // length of "K" element timeline
+        int   outroMorseFrames{0};   // length of "BK" element timeline
+        int   morseDotFrames{0};     // 1200 / WPM ms → frames
+    };
+
+    // Element-table entry for the Morse renderer: a contiguous run of
+    // either tone-on or silence.  Computed once per parameter change.
+    struct MorseSegment {
+        int  startFrame{0};
+        int  lengthFrames{0};
+        bool toneOn{true};
+    };
+
+    void recacheIfDirty() noexcept;
+    void rebuildMorseTables() noexcept;
+
+    // Generate the next sample of an envelope-shaped sine and advance
+    // phase.  `phaseFrame` is the frame index within the active phase
+    // (0-based, monotonic).  Used by both int16 and float paths.
+    float generateToneSample(int phaseFrame, int totalFrames,
+                             float phaseInc) noexcept;
+    float generateMorseSample(int phaseFrame,
+                              const std::vector<MorseSegment>& table,
+                              int totalFrames) noexcept;
+
+    Atomics  m_atomics;
+    Cached   m_cached;
+    uint64_t m_cachedVersion{static_cast<uint64_t>(-1)};
+    double   m_sampleRate{24000.0};
+
+    // Audio-thread state.  Phase frame counter resets on every
+    // phase transition.  Sine phase accumulator is per-phase too —
+    // each phase starts from 0 so there's no carry-over click.
+    int   m_phaseFrame{0};
+    float m_sinePhase{0.0f};
+    Phase m_currentPhase{Phase::Idle};
+
+    // Independent state for the local sidetone mix path — runs on
+    // the sidetone sink thread, not the TX audio thread, so it must
+    // not share counters with process() above.  Reads the same atomic
+    // phase but never writes it.
+    int    m_localPhaseFrame{0};
+    float  m_localSinePhase{0.0f};
+    Phase  m_localCurrentPhase{Phase::Idle};
+    double m_localSampleRate{48000.0};
+
+    // Element tables for Morse "K" (intro) and "BK" (outro), built
+    // once on prepare() and rebuilt whenever WPM changes.  Held in
+    // the cache so the audio thread reads them lock-free between
+    // recacheIfDirty() invocations.  The vectors themselves never
+    // grow at audio time — capacity is reserved up front.
+    std::vector<MorseSegment> m_morseIntroTable;
+    std::vector<MorseSegment> m_morseOutroTable;
+
+    PhaseCompleteCallback m_phaseCompleteCb;
+};
+
+} // namespace AetherSDR

--- a/src/core/QuindarLocalSink.cpp
+++ b/src/core/QuindarLocalSink.cpp
@@ -1,0 +1,115 @@
+#include "QuindarLocalSink.h"
+#include "ClientQuindarTone.h"
+#include "LogManager.h"
+
+#include <QAudioFormat>
+#include <QAudioSink>
+#include <QByteArray>
+#include <QIODevice>
+#include <QMediaDevices>
+#include <QTimer>
+
+namespace AetherSDR {
+
+QuindarLocalSink::QuindarLocalSink(QObject* parent)
+    : QObject(parent)
+{}
+
+QuindarLocalSink::~QuindarLocalSink()
+{
+    stop();
+}
+
+bool QuindarLocalSink::start(const QAudioDevice& device,
+                              ClientQuindarTone* tone)
+{
+    if (m_sink) return true;
+    if (!tone) return false;
+
+    QAudioDevice dev = device.isNull() ? QMediaDevices::defaultAudioOutput()
+                                       : device;
+    if (dev.isNull()) {
+        qCWarning(lcAudio) << "QuindarLocalSink: no audio output device";
+        return false;
+    }
+
+    QAudioFormat fmt;
+    fmt.setSampleRate(48000);
+    fmt.setChannelCount(2);
+    fmt.setSampleFormat(QAudioFormat::Float);
+    if (!dev.isFormatSupported(fmt)) {
+        fmt = dev.preferredFormat();
+        if (fmt.sampleFormat() != QAudioFormat::Float) {
+            fmt.setSampleFormat(QAudioFormat::Float);
+        }
+        fmt.setChannelCount(2);
+    }
+    m_actualRate = fmt.sampleRate();
+
+    m_sink = new QAudioSink(dev, fmt, this);
+    // Match CwSidetoneQAudioSink's 50 ms buffer — required to keep
+    // Pulse/PipeWire push-mode happy.  Net latency ~25 ms; fine for
+    // 250 ms Quindar tones.
+    const int bytesPerFrame = fmt.channelCount() * sizeof(float);
+    m_sink->setBufferSize(50 * fmt.sampleRate() / 1000 * bytesPerFrame);
+    m_device = m_sink->start();
+    if (!m_device) {
+        qCWarning(lcAudio) << "QuindarLocalSink: failed to start sink";
+        delete m_sink;
+        m_sink = nullptr;
+        return false;
+    }
+    m_tone = tone;
+
+    if (!m_timer) {
+        m_timer = new QTimer(this);
+        m_timer->setInterval(10);
+        connect(m_timer, &QTimer::timeout, this,
+                &QuindarLocalSink::onTimerTick);
+    }
+    m_timer->start();
+
+    qCInfo(lcAudio) << "QuindarLocalSink: started"
+                    << "rate=" << m_actualRate
+                    << "buffer=" << m_sink->bufferSize() << "bytes";
+    return true;
+}
+
+void QuindarLocalSink::onTimerTick()
+{
+    if (!m_sink || !m_device || !m_tone) return;
+    const qsizetype freeBytes = m_sink->bytesFree();
+    if (freeBytes <= 0) return;
+    constexpr qsizetype frameBytes = 2 * sizeof(float);
+    const qsizetype byteCount = (freeBytes / frameBytes) * frameBytes;
+    if (byteCount == 0) return;
+
+    QByteArray chunk(byteCount, '\0');
+    const int frames = static_cast<int>(byteCount / frameBytes);
+    auto* buf = reinterpret_cast<float*>(chunk.data());
+
+    // ClientQuindarTone::processSidetone fills the buffer with the
+    // generated Quindar audio when the atomic phase is Engaging or
+    // Disengaging, leaves it as zeros otherwise.  Identical waveform
+    // to what the TX-stream insertion produces, so the operator hears
+    // exactly what the radio is transmitting.
+    m_tone->processSidetone(buf, frames, static_cast<double>(m_actualRate));
+
+    m_device->write(chunk);
+}
+
+void QuindarLocalSink::stop()
+{
+    if (m_timer && m_timer->isActive()) m_timer->stop();
+    if (m_sink) {
+        auto* sink = m_sink;
+        m_sink = nullptr;
+        m_device = nullptr;
+        if (sink->state() != QAudio::StoppedState)
+            sink->stop();
+        delete sink;
+    }
+    m_tone = nullptr;
+}
+
+} // namespace AetherSDR

--- a/src/core/QuindarLocalSink.h
+++ b/src/core/QuindarLocalSink.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <QAudioDevice>
+#include <QObject>
+#include <QPointer>
+
+class QAudioSink;
+class QIODevice;
+class QTimer;
+
+namespace AetherSDR {
+
+class ClientQuindarTone;
+
+// Dedicated local audio sink for Quindar tones (#2262).  Independent
+// of the CW sidetone path because Quindar and CW are mutually exclusive
+// modes — mixing them would conflate two unrelated systems.
+//
+// Lifecycle: started alongside the RX stream so the sink is always
+// primed when the operator hits MOX.  Pulls samples every 10 ms via a
+// push-mode QTimer (matches the CwSidetoneQAudioSink pattern that
+// keeps Pulse/PipeWire pull-mode happy with a moderate buffer).
+//
+// The hard rule: every sample the Quindar tone overlays into the TX
+// stream MUST also play through the local output.  Users must never
+// transmit a sound they aren't hearing themselves.
+class QuindarLocalSink : public QObject {
+    Q_OBJECT
+
+public:
+    explicit QuindarLocalSink(QObject* parent = nullptr);
+    ~QuindarLocalSink() override;
+
+    // Open the audio device, prime the sink, start the push-mode
+    // timer.  Idempotent — safe to call when already running.
+    bool start(const QAudioDevice& device, ClientQuindarTone* tone);
+
+    // Close the device and release library resources.
+    void stop();
+
+    bool isRunning() const { return m_sink != nullptr; }
+    int  actualRateHz() const { return m_actualRate; }
+
+private:
+    void onTimerTick();
+
+    QAudioSink*          m_sink{nullptr};
+    QPointer<QIODevice>  m_device;
+    QTimer*              m_timer{nullptr};
+    ClientQuindarTone*   m_tone{nullptr};
+    int                  m_actualRate{0};
+};
+
+} // namespace AetherSDR

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -619,8 +619,14 @@ void TciServer::onTextMessage(const QString& msg)
                         startTxChrono(ws, trx);
                     } else {
                         if (m_model) {
+                            // Route through the PTT coordinator so
+                            // Quindar tones (#2262) fire on hardware-PTT
+                            // transitions too.  Falls back to setMox()
+                            // for non-phone modes; tone is a no-op when
+                            // disabled.
                             QMetaObject::invokeMethod(m_model, [this]() {
-                                m_model->setTransmit(true);
+                                m_model->transmitModel().requestPttOn(
+                                    TransmitModel::PttSource::TciHardware);
                             }, Qt::QueuedConnection);
                         }
                     }
@@ -628,7 +634,8 @@ void TciServer::onTextMessage(const QString& msg)
                     stopTxChrono();
                     if (m_model) {
                         QMetaObject::invokeMethod(m_model, [this]() {
-                            m_model->setTransmit(false);
+                            m_model->transmitModel().requestPttOff(
+                                TransmitModel::PttSource::TciHardware);
                         }, Qt::QueuedConnection);
                     }
                 }

--- a/src/gui/AetherialAudioStrip.h
+++ b/src/gui/AetherialAudioStrip.h
@@ -69,6 +69,11 @@ public:
     // just nudges the widget to repaint from it.
     void refreshChainPaint();
 
+    // Accessor for the embedded Final Output panel — MainWindow wires
+    // this to TransmitModel::quindarActiveChanged so the QUIN chip
+    // flashes via signal hop instead of a poll.
+    StripFinalOutputPanel* finalOutputPanel() const { return m_finalOutput; }
+
 signals:
     // Re-emitted from the embedded StripEqPanel when the user drags one
     // of the dashed cutoff lines.  MainWindow connects this to the same

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -43,6 +43,7 @@
 #include "ClientPuduEditor.h"
 #include "ClientReverbApplet.h"
 #include "AetherialAudioStrip.h"
+#include "StripFinalOutputPanel.h"
 #include "ClientChainApplet.h"
 #include "core/ClientComp.h"
 #include "core/ClientEq.h"
@@ -955,6 +956,30 @@ MainWindow::MainWindow(QWidget* parent)
     // strip.
     m_finalMonitor = new ClientPuduMonitor(this);
     m_audio->setTxFinalMonitor(m_finalMonitor);
+
+    // Wire the Quindar tone coordinator (#2262).  TransmitModel needs
+    // the DSP module (to drive intro/outro phases) and a TX-mode
+    // getter for the phone-mode gate.  The getter indirection keeps
+    // TransmitModel decoupled from RadioModel for test-build purposes.
+    m_radioModel.transmitModel().setQuindarTone(m_audio->clientQuindarTone());
+    m_radioModel.transmitModel().setTxModeGetter([this]() -> QString {
+        for (auto* s : m_radioModel.slices()) {
+            if (s && s->isTxSlice()) return s->mode();
+        }
+        return QString();
+    });
+    // QUIN chip flash via signal hop — see TransmitModel::quindarActiveChanged.
+    // Strip is created lazily; the lambda checks for existence each fire so
+    // we don't need to re-connect when the strip pops up.
+    connect(&m_radioModel.transmitModel(),
+            &TransmitModel::quindarActiveChanged,
+            this, [this](bool active) {
+        if (m_aetherialStrip) {
+            if (auto* p = m_aetherialStrip->finalOutputPanel())
+                p->setQuindarActive(active);
+        }
+    });
+
     m_networkDiagnosticsHistory = new NetworkDiagnosticsHistory(&m_radioModel, m_audio, this);
 
     // Local CW sidetone — every key source (serial, MIDI, TCI, CWX, HID)

--- a/src/gui/StripFinalOutputPanel.cpp
+++ b/src/gui/StripFinalOutputPanel.cpp
@@ -4,6 +4,7 @@
 #include "EditorFramelessTitleBar.h"
 #include "core/AudioEngine.h"
 #include "core/ClientFinalLimiter.h"
+#include "core/ClientQuindarTone.h"
 #include "core/ClientTxTestTone.h"
 
 #include <QDateTime>
@@ -20,6 +21,7 @@
 #include <QPushButton>
 #include <QSignalBlocker>
 #include <QSlider>
+#include <QSpinBox>
 #include <QTimer>
 #include <QVBoxLayout>
 
@@ -437,6 +439,24 @@ StripFinalOutputPanel::StripFinalOutputPanel(AudioEngine* engine, QWidget* paren
                 this, [this](const QPoint&) { showToneEditor(); });
         col->addWidget(m_toneBtn);
 
+        // Quindar tones (#2262) — Apollo-era K / BK or 2525/2475 Hz
+        // sine on PTT engage/disengage.  Same red-checked styling as
+        // TONE since both make audible sound.  Right-click opens the
+        // style/freq/WPM editor.
+        m_quinBtn = new QPushButton("QUIN", this);
+        m_quinBtn->setCheckable(true);
+        m_quinBtn->setFixedSize(56, 18);
+        m_quinBtn->setStyleSheet(redCheckStyle);
+        m_quinBtn->setToolTip(tr("Quindar tones on PTT engage/disengage. "
+                                 "Right-click for the style/freq/WPM "
+                                 "editor."));
+        connect(m_quinBtn, &QPushButton::toggled,
+                this, &StripFinalOutputPanel::applyQuindarEnabled);
+        m_quinBtn->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(m_quinBtn, &QPushButton::customContextMenuRequested,
+                this, [this](const QPoint&) { showQuindarEditor(); });
+        col->addWidget(m_quinBtn);
+
         // Drop the trailing stretch — the OVR/LIMIT/% column on the
         // far right doesn't have one, so its three chips distribute
         // through the row's full height with extra space between them.
@@ -632,6 +652,12 @@ void StripFinalOutputPanel::syncControlsFromEngine()
             m_toneBtn->setChecked(tone->isEnabled());
         }
     }
+    if (m_quinBtn) {
+        if (auto* q = m_audio->clientQuindarTone()) {
+            QSignalBlocker b(m_quinBtn);
+            m_quinBtn->setChecked(q->isEnabled());
+        }
+    }
     // Seed the clip-count baseline so we don't latch OVR from
     // historical clips on startup or after preset reload.
     m_lastClipCount = lim->clipPreLimiterCount();
@@ -777,6 +803,223 @@ void StripFinalOutputPanel::showToneEditor()
     dlg->show();
 }
 
+void StripFinalOutputPanel::applyQuindarEnabled(bool on)
+{
+    if (!m_audio) return;
+    if (auto* q = m_audio->clientQuindarTone()) {
+        q->setEnabled(on);
+        m_audio->saveClientQuindarSettings();
+    }
+}
+
+void StripFinalOutputPanel::showQuindarEditor()
+{
+    if (!m_audio) return;
+    auto* q = m_audio->clientQuindarTone();
+    if (!q) return;
+
+    auto* dlg = new QDialog(this);
+    dlg->setAttribute(Qt::WA_DeleteOnClose);
+    dlg->setWindowTitle(tr("Quindar Tones"));
+    dlg->setStyleSheet(
+        "QDialog { background: #08121d; }"
+        "QLabel  { color: #c8d8e8; font-size: 11px; }"
+        "QPushButton { background: #1a2230; color: #c8d8e8;"
+        " border: 1px solid #2a3744; border-radius: 3px;"
+        " padding: 4px 12px; font-size: 11px; }"
+        "QPushButton:hover { background: #243042; color: #f2c14e; }"
+        "QPushButton:checked { background: #3a2a0e; color: #f2c14e;"
+        " border: 1px solid #f2c14e; }"
+        "QSlider::groove:horizontal { height: 4px; background: #203040;"
+        " border-radius: 2px; }"
+        "QSlider::sub-page:horizontal { background: #f2c14e;"
+        " border-radius: 2px; }"
+        "QSlider::handle:horizontal { width: 12px; height: 12px;"
+        " margin: -4px 0; background: #c8d8e8; border: 1px solid #f2c14e;"
+        " border-radius: 6px; }"
+        "QSpinBox { background: #1a2230; color: #c8d8e8;"
+        " border: 1px solid #2a3744; border-radius: 2px;"
+        " padding: 1px 4px; font-size: 11px; }");
+
+    auto* outer = new QVBoxLayout(dlg);
+    outer->setContentsMargins(12, 12, 12, 12);
+    outer->setSpacing(10);
+
+    // ── Style segmented control ──
+    auto* styleRow = new QHBoxLayout;
+    styleRow->setSpacing(0);
+    auto* styleLbl = new QLabel(tr("Style"), dlg);
+    styleLbl->setMinimumWidth(48);
+    auto* toneStyleBtn  = new QPushButton(tr("Tone"),  dlg);
+    auto* morseStyleBtn = new QPushButton(tr("Morse"), dlg);
+    toneStyleBtn->setCheckable(true);
+    morseStyleBtn->setCheckable(true);
+    const bool startMorse = (q->style() == ClientQuindarTone::Style::Morse);
+    toneStyleBtn->setChecked(!startMorse);
+    morseStyleBtn->setChecked(startMorse);
+    styleRow->addWidget(styleLbl);
+    styleRow->addWidget(toneStyleBtn);
+    styleRow->addWidget(morseStyleBtn);
+    styleRow->addStretch();
+    outer->addLayout(styleRow);
+
+    auto* form = new QFormLayout;
+    form->setContentsMargins(0, 0, 0, 0);
+    form->setSpacing(8);
+
+    // Level
+    auto* lvlSlider = new QSlider(Qt::Horizontal, dlg);
+    lvlSlider->setRange(-20, 0);
+    lvlSlider->setValue(static_cast<int>(std::round(q->levelDb())));
+    auto* lvlLbl = new QLabel(dlg);
+    lvlLbl->setMinimumWidth(72);
+    lvlLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    lvlLbl->setText(QString::number(q->levelDb(), 'f', 0) + " dBFS");
+    connect(lvlSlider, &QSlider::valueChanged, dlg,
+            [this, lvlLbl](int v) {
+        if (auto* qt = m_audio->clientQuindarTone()) {
+            qt->setLevelDb(static_cast<float>(v));
+            m_audio->saveClientQuindarSettings();
+        }
+        lvlLbl->setText(QString::number(v) + " dBFS");
+    });
+    auto* lvlRow = new QHBoxLayout;
+    lvlRow->addWidget(lvlSlider, 1);
+    lvlRow->addWidget(lvlLbl);
+    form->addRow(tr("Level"), lvlRow);
+
+    // ── Tone fields ──
+    auto* toneIntroSpin  = new QSpinBox(dlg);
+    toneIntroSpin->setRange(2400, 2700);
+    toneIntroSpin->setSuffix(" Hz");
+    toneIntroSpin->setValue(static_cast<int>(std::round(q->introFreqHz())));
+    auto* toneOutroSpin  = new QSpinBox(dlg);
+    toneOutroSpin->setRange(2400, 2700);
+    toneOutroSpin->setSuffix(" Hz");
+    toneOutroSpin->setValue(static_cast<int>(std::round(q->outroFreqHz())));
+    auto* toneDurSpin    = new QSpinBox(dlg);
+    toneDurSpin->setRange(100, 500);
+    toneDurSpin->setSuffix(" ms");
+    toneDurSpin->setValue(q->durationMs());
+    form->addRow(tr("Intro"),    toneIntroSpin);
+    form->addRow(tr("Outro"),    toneOutroSpin);
+    form->addRow(tr("Duration"), toneDurSpin);
+
+    // ── Morse fields ──
+    auto* morseWpmSpin = new QSpinBox(dlg);
+    morseWpmSpin->setRange(20, 60);
+    morseWpmSpin->setSuffix(" WPM");
+    morseWpmSpin->setValue(q->morseWpm());
+    auto* morsePitchSlider = new QSlider(Qt::Horizontal, dlg);
+    morsePitchSlider->setRange(400, 1200);
+    morsePitchSlider->setValue(static_cast<int>(std::round(q->morsePitchHz())));
+    auto* morsePitchLbl = new QLabel(dlg);
+    morsePitchLbl->setMinimumWidth(72);
+    morsePitchLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    morsePitchLbl->setText(QString::number(q->morsePitchHz(), 'f', 0) + " Hz");
+    auto* morsePitchRow = new QHBoxLayout;
+    morsePitchRow->addWidget(morsePitchSlider, 1);
+    morsePitchRow->addWidget(morsePitchLbl);
+    form->addRow(tr("WPM"),   morseWpmSpin);
+    form->addRow(tr("Pitch"), morsePitchRow);
+
+    outer->addLayout(form);
+
+    // ── Test buttons ──
+    auto* testRow = new QHBoxLayout;
+    auto* testIntroBtn = new QPushButton(tr("▶ Test intro"), dlg);
+    auto* testOutroBtn = new QPushButton(tr("▶ Test outro"), dlg);
+    testRow->addWidget(testIntroBtn);
+    testRow->addWidget(testOutroBtn);
+    testRow->addStretch();
+    outer->addLayout(testRow);
+
+    auto* doneBtn = new QPushButton(tr("Done"), dlg);
+    doneBtn->setDefault(true);
+    auto* btnRow = new QHBoxLayout;
+    btnRow->addStretch();
+    btnRow->addWidget(doneBtn);
+    outer->addLayout(btnRow);
+
+    auto refreshFieldsForStyle = [=]() {
+        const bool morse = morseStyleBtn->isChecked();
+        toneIntroSpin->setEnabled(!morse);
+        toneOutroSpin->setEnabled(!morse);
+        toneDurSpin->setEnabled(!morse);
+        morseWpmSpin->setEnabled(morse);
+        morsePitchSlider->setEnabled(morse);
+        morsePitchLbl->setEnabled(morse);
+    };
+    refreshFieldsForStyle();
+
+    auto setStyle = [=](bool morse) {
+        toneStyleBtn->setChecked(!morse);
+        morseStyleBtn->setChecked(morse);
+        if (auto* qt = m_audio->clientQuindarTone()) {
+            qt->setStyle(morse ? ClientQuindarTone::Style::Morse
+                               : ClientQuindarTone::Style::Tone);
+            m_audio->saveClientQuindarSettings();
+        }
+        refreshFieldsForStyle();
+    };
+    connect(toneStyleBtn,  &QPushButton::clicked, dlg, [=]() { setStyle(false); });
+    connect(morseStyleBtn, &QPushButton::clicked, dlg, [=]() { setStyle(true);  });
+
+    connect(toneIntroSpin, QOverload<int>::of(&QSpinBox::valueChanged),
+            dlg, [this](int v) {
+        if (auto* qt = m_audio->clientQuindarTone()) {
+            qt->setIntroFreqHz(static_cast<float>(v));
+            m_audio->saveClientQuindarSettings();
+        }
+    });
+    connect(toneOutroSpin, QOverload<int>::of(&QSpinBox::valueChanged),
+            dlg, [this](int v) {
+        if (auto* qt = m_audio->clientQuindarTone()) {
+            qt->setOutroFreqHz(static_cast<float>(v));
+            m_audio->saveClientQuindarSettings();
+        }
+    });
+    connect(toneDurSpin, QOverload<int>::of(&QSpinBox::valueChanged),
+            dlg, [this](int v) {
+        if (auto* qt = m_audio->clientQuindarTone()) {
+            qt->setDurationMs(v);
+            m_audio->saveClientQuindarSettings();
+        }
+    });
+    connect(morseWpmSpin, QOverload<int>::of(&QSpinBox::valueChanged),
+            dlg, [this](int v) {
+        if (auto* qt = m_audio->clientQuindarTone()) {
+            qt->setMorseWpm(v);
+            m_audio->saveClientQuindarSettings();
+        }
+    });
+    connect(morsePitchSlider, &QSlider::valueChanged, dlg,
+            [this, morsePitchLbl](int v) {
+        if (auto* qt = m_audio->clientQuindarTone()) {
+            qt->setMorsePitchHz(static_cast<float>(v));
+            m_audio->saveClientQuindarSettings();
+        }
+        morsePitchLbl->setText(QString::number(v) + " Hz");
+    });
+
+    // Test buttons drive the DSP module directly without flipping
+    // MOX, so the user can audition the configured tone.  The
+    // dedicated QuindarLocalSink runs on the operator's audio output
+    // device whenever the engine has an RX stream open, so the
+    // audition is audible immediately regardless of TX state.
+    connect(testIntroBtn, &QPushButton::clicked, dlg, [this]() {
+        if (auto* qt = m_audio->clientQuindarTone()) qt->startIntro();
+    });
+    connect(testOutroBtn, &QPushButton::clicked, dlg, [this]() {
+        if (auto* qt = m_audio->clientQuindarTone()) qt->startOutro();
+    });
+
+    connect(doneBtn, &QPushButton::clicked, dlg, &QDialog::accept);
+
+    dlg->resize(380, 280);
+    dlg->show();
+}
+
 void StripFinalOutputPanel::tickMeters()
 {
     if (!m_audio) return;
@@ -881,6 +1124,36 @@ void StripFinalOutputPanel::tickMeters()
                   " font-weight: bold; padding: 1px; }";
         m_limitLed->setStyleSheet(css);
     }
+}
+
+void StripFinalOutputPanel::setQuindarActive(bool active)
+{
+    if (m_quinActive == active) return;
+    m_quinActive = active;
+    if (!m_quinBtn) return;
+
+    // Signal-driven flash — only re-applies the stylesheet when the
+    // active state actually changes (twice per PTT: start of intro,
+    // end of intro = start of Live; same for outro).  No polling.
+    const QString css = active
+        ? "QPushButton {"
+          "  background: #ff3030; color: #ffffff;"
+          "  border: 1px solid #ff8080;"
+          "  border-radius: 3px; font-size: 10px;"
+          "  font-weight: bold; padding: 1px;"
+          "}"
+        : "QPushButton {"
+          "  background: #1a2230; border: 1px solid #2a3744;"
+          "  border-radius: 3px; color: #506070;"
+          "  font-size: 10px; font-weight: bold; padding: 1px;"
+          "}"
+          "QPushButton:hover { color: #c8d8e8; }"
+          "QPushButton:checked {"
+          "  background: #4a1818; color: #ff8080;"
+          "  border: 1px solid #ff4040;"
+          "}"
+          "QPushButton:checked:hover { background: #5a2828; }";
+    m_quinBtn->setStyleSheet(css);
 }
 
 } // namespace AetherSDR

--- a/src/gui/StripFinalOutputPanel.h
+++ b/src/gui/StripFinalOutputPanel.h
@@ -33,6 +33,12 @@ public:
     void showForTx();
     void syncControlsFromEngine();
 
+    // Signal-driven QUIN chip flash (#2262).  MainWindow connects this
+    // slot to TransmitModel::quindarActiveChanged so the chip lights
+    // bright the moment a Quindar tone starts and dims when it ends —
+    // no polling.  `active` true == chip flashes; false == idle styling.
+    void setQuindarActive(bool active);
+
 private:
     void applyEnable(bool on);
     void applyCeiling(float db);
@@ -42,12 +48,16 @@ private:
     void applyTestToneFreq(float hz);
     void applyTestToneLevel(float db);
     void showToneEditor();
+    void applyQuindarEnabled(bool on);
+    void showQuindarEditor();
     void tickMeters();
 
     AudioEngine*    m_audio{nullptr};
     QPushButton*    m_enable{nullptr};
     QPushButton*    m_dcBtn{nullptr};
     QPushButton*    m_toneBtn{nullptr};
+    QPushButton*    m_quinBtn{nullptr};   // Quindar tones (#2262)
+    bool            m_quinActive{false};  // signal-driven flash state
     ClientCompKnob* m_trim{nullptr};
     QWidget*        m_meter{nullptr};
     QLabel*         m_pkValue{nullptr};

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -289,10 +289,16 @@ void TxApplet::buildUI()
             m_model->startTune();
     });
 
-    // MOX button — toggle transmit
+    // MOX button — toggle transmit.  Routes through requestPttOn/Off so
+    // the Quindar tone coordinator (#2262) can run intro/outro tones on
+    // phone modes when enabled.  Falls through to setMox() when Quindar
+    // is disabled or the active TX slice isn't on a phone mode.
     connect(m_moxBtn, &QPushButton::toggled, this, [this](bool on) {
-        if (!m_updatingFromModel && m_model)
-            m_model->setMox(on);
+        if (m_updatingFromModel || !m_model) return;
+        if (on)
+            m_model->requestPttOn(TransmitModel::PttSource::Mox);
+        else
+            m_model->requestPttOff(TransmitModel::PttSource::Mox);
     });
 
     // ATU button — toggle between tune and bypass.

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -1,6 +1,8 @@
 #include "TransmitModel.h"
+#include "core/ClientQuindarTone.h"
 #include "core/LogManager.h"
 #include <QDebug>
+#include <QTimer>
 
 namespace AetherSDR {
 
@@ -726,6 +728,118 @@ ATUStatus TransmitModel::parseAtuTuneStatus(const QString& s)
     if (s == "TUNE_MANUAL_BYPASS") return ATUStatus::ManualBypass;
     qCDebug(lcTransmit) << "TransmitModel: unknown ATU status:" << s;
     return ATUStatus::None;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// PTT request coordinator (#2262 — Quindar tones)
+// ─────────────────────────────────────────────────────────────────────
+
+void TransmitModel::setQuindarTone(ClientQuindarTone* tone)
+{
+    m_quindarTone = tone;
+}
+
+void TransmitModel::setTxModeGetter(TxModeGetter getter)
+{
+    m_txModeGetter = std::move(getter);
+}
+
+bool TransmitModel::isPhoneModeForQuindar() const
+{
+    if (!m_txModeGetter) return false;
+    const QString m = m_txModeGetter();
+    // Phone modes accepted for Quindar: SSB families, AM, FM, FreeDV.
+    // Digital (DIGU/DIGL/RTTY/CW/FT8) intentionally excluded — the
+    // tone would corrupt the digital waveform.
+    return m == "USB" || m == "LSB"
+        || m == "AM"  || m == "FM"  || m == "NFM"
+        || m == "FDV";
+}
+
+void TransmitModel::cancelPendingQuindarOff()
+{
+    if (m_pendingMoxOffTimer) {
+        m_pendingMoxOffTimer->stop();
+        m_pendingMoxOffTimer->deleteLater();
+        m_pendingMoxOffTimer = nullptr;
+    }
+    m_quindarOutroInFlight = false;
+}
+
+void TransmitModel::requestPttOn(PttSource /*source*/)
+{
+    // If Quindar is enabled + phone mode + we have an engine, start
+    // the intro tone alongside MOX so the radio keys up while the
+    // tone plays (the tone gets transmitted as part of the audio).
+    auto* tone = m_quindarTone;
+
+    // Coalesce a re-engage that fires during the outro window — flip
+    // phase back to Live, cancel the pending xmit-0 timer, and skip a
+    // fresh intro so the user doesn't feel an outro+intro dead zone.
+    if (tone && tone->isEnabled()
+        && tone->phase() == ClientQuindarTone::Phase::Disengaging) {
+        if (tone->coalesceReEngage()) {
+            cancelPendingQuindarOff();
+            // Outro flash ends — phase is now back in Live, no tone
+            // playing locally.  MOX is already true (we never sent
+            // xmit 0); just bail.
+            emit quindarActiveChanged(false);
+            return;
+        }
+    }
+
+    if (tone && tone->isEnabled() && isPhoneModeForQuindar()) {
+        tone->startIntro();
+        // Flash the QUIN chip for the intro duration; the audio thread
+        // auto-transitions Engaging → Live when its frame counter
+        // hits the same duration, so we model the visible flash with
+        // a single-shot timer here on the GUI thread.
+        emit quindarActiveChanged(true);
+        const int introMs = std::max(50, tone->currentIntroDurationMs());
+        QTimer::singleShot(introMs, this, [this]() {
+            emit quindarActiveChanged(false);
+        });
+    }
+    setMox(true);
+}
+
+void TransmitModel::requestPttOff(PttSource /*source*/)
+{
+    auto* tone = m_quindarTone;
+
+    // No Quindar, no phone mode, or already shutting down → straight
+    // through.  The phase check is essential — if MOX was never on
+    // (or already off) we shouldn't run an outro.
+    if (!tone || !tone->isEnabled() || !isPhoneModeForQuindar()
+        || tone->phase() == ClientQuindarTone::Phase::Idle
+        || m_quindarOutroInFlight) {
+        cancelPendingQuindarOff();
+        setMox(false);
+        return;
+    }
+
+    // Start the outro and defer xmit 0 by the outro duration so the
+    // tone gets transmitted before the radio unkeys.  Outro duration
+    // is style-dependent and computed from current settings.
+    tone->startOutro();
+    m_quindarOutroInFlight = true;
+    emit quindarActiveChanged(true);
+    const int outroMs = std::max(50, tone->currentOutroDurationMs());
+
+    cancelPendingQuindarOff();
+    m_pendingMoxOffTimer = new QTimer(this);
+    m_pendingMoxOffTimer->setSingleShot(true);
+    m_pendingMoxOffTimer->setInterval(outroMs);
+    connect(m_pendingMoxOffTimer, &QTimer::timeout, this, [this]() {
+        // If a re-engage happened during the outro window the timer
+        // would have been cancelled; if we're here, the outro fully
+        // completed and it's safe to flip MOX off.
+        m_pendingMoxOffTimer = nullptr;
+        m_quindarOutroInFlight = false;
+        emit quindarActiveChanged(false);
+        setMox(false);
+    });
+    m_pendingMoxOffTimer->start();
 }
 
 } // namespace AetherSDR

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -6,6 +6,10 @@
 #include <QString>
 #include <QStringList>
 
+#include <functional>
+
+class QTimer;
+
 namespace AetherSDR {
 
 // ATU tune status values (from FlexLib ATUTuneStatus enum).
@@ -146,6 +150,30 @@ public:
     void toggleTwoToneTune();
     void stopTune();
     void setMox(bool on);
+
+    // PTT request coordinator (#2262) — single entry point for "user
+    // wants to key/unkey".  When Quindar is enabled and the active TX
+    // slice is on a phone mode, runs the engage/disengage tone state
+    // machine before the actual MOX flip; otherwise forwards directly
+    // to setMox().  All UI and TCI hardware-PTT callers should use this
+    // path so Quindar tones happen consistently regardless of source.
+    enum class PttSource : uint8_t {
+        Mox          = 0,   // GUI MOX button
+        TciHardware  = 1,   // TCI radio-direct PTT (e.g. Stream Deck plugin)
+        Footswitch   = 2,   // future: serial-PTT or other hardware path
+    };
+    void requestPttOn(PttSource source);
+    void requestPttOff(PttSource source);
+    // Bindings injected once at MainWindow wire-up.  The coordinator
+    // needs the Quindar DSP module pointer to drive intro/outro
+    // phases, and a callable that returns the active TX slice's mode
+    // string for the phone-mode gate.  The mode-getter indirection
+    // keeps TransmitModel decoupled from RadioModel/SliceModel so the
+    // test executables don't need Qt6::Network linkage.
+    void setQuindarTone(class ClientQuindarTone* tone);
+    using TxModeGetter = std::function<QString()>;
+    void setTxModeGetter(TxModeGetter getter);
+
     void atuStart();
     void atuBypass();
     void setAtuMemories(bool on);
@@ -209,9 +237,23 @@ signals:
     void apdEqualizerResetReceived();
     void maxPowerLevelChanged(int maxWatts);
     void commandReady(const QString& cmd);
+    // Quindar active-phase signal (#2262).  Emitted on the GUI thread
+    // immediately when intro/outro starts and again when each finishes,
+    // sized from the tone's current duration.  Used by the strip's
+    // QUIN chip to flash bright while a tone is playing — replaces an
+    // earlier 30 Hz poll of ClientQuindarTone::phase().
+    void quindarActiveChanged(bool active);
 
 private:
     static ATUStatus parseAtuTuneStatus(const QString& s);
+    bool isPhoneModeForQuindar() const;
+    void cancelPendingQuindarOff();
+
+    // PTT coordinator state (#2262)
+    class ClientQuindarTone* m_quindarTone{nullptr};
+    TxModeGetter             m_txModeGetter;
+    QTimer*                  m_pendingMoxOffTimer{nullptr};
+    bool                     m_quindarOutroInFlight{false};
 
     // APD state
     bool m_apdEnabled{false};

--- a/tests/client_quindar_test.cpp
+++ b/tests/client_quindar_test.cpp
@@ -1,0 +1,376 @@
+// Standalone test harness for ClientQuindarTone DSP (#2262).
+// Build: produced by CMake as `client_quindar_test` target.
+// Run:   ./build/client_quindar_test
+// Exit code 0 on all pass, 1 on any failure.
+
+#include "core/ClientQuindarTone.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using AetherSDR::ClientQuindarTone;
+using Phase = ClientQuindarTone::Phase;
+using Style = ClientQuindarTone::Style;
+
+namespace {
+
+constexpr double kSampleRate = 24000.0;
+constexpr int    kBlockSize  = 128;
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-52s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+// Process the stage in `kBlockSize`-frame chunks until either the
+// stage returns to Idle or `maxFrames` have been processed.  Returns
+// the total interleaved samples produced (frames × 2).
+std::vector<float> runUntilIdle(ClientQuindarTone& q, int maxFrames)
+{
+    std::vector<float> out;
+    out.reserve(static_cast<size_t>(maxFrames) * 2);
+    std::vector<float> block(kBlockSize * 2, 0.0f);
+    int produced = 0;
+    while (produced < maxFrames) {
+        // Reset the block so we can tell whether the stage wrote to
+        // it (Idle is no-op, leaves the block as zeros).
+        std::fill(block.begin(), block.end(), 0.0f);
+        q.process(block.data(), kBlockSize, 2);
+        out.insert(out.end(), block.begin(), block.end());
+        produced += kBlockSize;
+        if (q.phase() == Phase::Idle) break;
+        if (q.phase() == Phase::Live) break;
+    }
+    return out;
+}
+
+float peakAbs(const std::vector<float>& buf)
+{
+    float p = 0.0f;
+    for (float s : buf) p = std::max(p, std::fabs(s));
+    return p;
+}
+
+float rms(const std::vector<float>& buf)
+{
+    if (buf.empty()) return 0.0f;
+    double sumSq = 0.0;
+    for (float s : buf) sumSq += static_cast<double>(s) * s;
+    return static_cast<float>(std::sqrt(sumSq / buf.size()));
+}
+
+// Goertzel algorithm — single-bin energy estimate at `freq` (Hz).
+// Used to verify the dominant frequency of a generated tone block.
+double goertzelEnergy(const float* mono, int frames, double freq)
+{
+    const double w = 2.0 * 3.14159265358979323846 * freq / kSampleRate;
+    const double cw = std::cos(w);
+    double s0 = 0.0, s1 = 0.0, s2 = 0.0;
+    for (int i = 0; i < frames; ++i) {
+        s0 = mono[i] + 2.0 * cw * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    return s1 * s1 + s2 * s2 - 2.0 * cw * s1 * s2;
+}
+
+double monoBand(const std::vector<float>& interleaved, double freq)
+{
+    const int frames = static_cast<int>(interleaved.size() / 2);
+    std::vector<float> mono(frames);
+    for (int i = 0; i < frames; ++i)
+        mono[i] = interleaved[i * 2];
+    return goertzelEnergy(mono.data(), frames, freq);
+}
+
+} // namespace
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+void test_disabledIsBypass()
+{
+    ClientQuindarTone q;
+    q.prepare(kSampleRate);
+    q.setEnabled(false);
+    q.startIntro();
+
+    std::vector<float> block(kBlockSize * 2, 0.123f);
+    q.process(block.data(), kBlockSize, 2);
+
+    bool unchanged = true;
+    for (float s : block) {
+        if (std::fabs(s - 0.123f) > 1e-6f) { unchanged = false; break; }
+    }
+    report("disabled stage is bypass (samples untouched)", unchanged);
+    report("disabled stage forces phase Idle",
+           q.phase() == Phase::Idle);
+}
+
+void test_phaseTransitionsCorrectly()
+{
+    ClientQuindarTone q;
+    q.prepare(kSampleRate);
+    q.setEnabled(true);
+    q.setStyle(Style::Tone);
+    q.setDurationMs(250);
+
+    report("starts in Idle",
+           q.phase() == Phase::Idle);
+
+    q.startIntro();
+    // Run a single block — should observe Engaging.
+    std::vector<float> block(kBlockSize * 2, 0.0f);
+    q.process(block.data(), kBlockSize, 2);
+    report("Idle → Engaging on startIntro",
+           q.phase() == Phase::Engaging);
+
+    // 250 ms at 24 kHz = 6000 frames.  Run enough frames for the
+    // intro to finish — phase should transition to Live.
+    runUntilIdle(q, 8000);
+    report("Engaging → Live after intro duration",
+           q.phase() == Phase::Live);
+
+    q.startOutro();
+    q.process(block.data(), kBlockSize, 2);
+    report("Live → Disengaging on startOutro",
+           q.phase() == Phase::Disengaging);
+
+    runUntilIdle(q, 8000);
+    report("Disengaging → Idle after outro duration",
+           q.phase() == Phase::Idle);
+}
+
+void test_introToneFrequency()
+{
+    ClientQuindarTone q;
+    q.prepare(kSampleRate);
+    q.setEnabled(true);
+    q.setStyle(Style::Tone);
+    q.setIntroFreqHz(2525.0f);
+    q.setOutroFreqHz(2475.0f);
+    q.setLevelDb(0.0f);
+    q.setDurationMs(250);
+    q.startIntro();
+
+    auto out = runUntilIdle(q, 8000);
+
+    const double e2525 = monoBand(out, 2525.0);
+    const double e2475 = monoBand(out, 2475.0);
+    const double e1000 = monoBand(out, 1000.0);
+    char detail[160];
+    std::snprintf(detail, sizeof(detail),
+        "e2525=%.1e e2475=%.1e e1000=%.1e",
+        e2525, e2475, e1000);
+    report("intro tone peaks at 2525 Hz, not 2475 / 1000",
+        e2525 > e2475 * 5.0 && e2525 > e1000 * 5.0, detail);
+}
+
+void test_outroToneFrequency()
+{
+    ClientQuindarTone q;
+    q.prepare(kSampleRate);
+    q.setEnabled(true);
+    q.setStyle(Style::Tone);
+    q.setIntroFreqHz(2525.0f);
+    q.setOutroFreqHz(2475.0f);
+    q.setLevelDb(0.0f);
+    q.setDurationMs(250);
+
+    // Skip intro to Live, then outro.
+    q.startIntro();
+    runUntilIdle(q, 8000);
+    q.startOutro();
+    auto out = runUntilIdle(q, 8000);
+
+    const double e2475 = monoBand(out, 2475.0);
+    const double e2525 = monoBand(out, 2525.0);
+    char detail[160];
+    std::snprintf(detail, sizeof(detail), "e2475=%.1e e2525=%.1e",
+        e2475, e2525);
+    report("outro tone peaks at 2475 Hz, not 2525",
+        e2475 > e2525 * 5.0, detail);
+}
+
+void test_levelMatchesConfiguredDb()
+{
+    // Verify the steady-state amplitude (post-ramp) tracks the
+    // configured level within ~1 dB.  Pick a level that's well
+    // inside the ramp's settled region.
+    ClientQuindarTone q;
+    q.prepare(kSampleRate);
+    q.setEnabled(true);
+    q.setStyle(Style::Tone);
+    q.setLevelDb(-6.0f);
+    q.setDurationMs(250);
+    q.startIntro();
+
+    auto out = runUntilIdle(q, 8000);
+
+    // Expected steady-state peak: 10^(-6/20) ≈ 0.501.
+    const float peak = peakAbs(out);
+    const float expected = std::pow(10.0f, -6.0f / 20.0f);
+    char detail[160];
+    std::snprintf(detail, sizeof(detail),
+        "peak=%.3f expected≈%.3f", peak, expected);
+    report("peak amplitude matches level (-6 dB)",
+        std::fabs(peak - expected) < 0.05f, detail);
+}
+
+void test_envelopeRampPreventsClicks()
+{
+    // The first sample of an intro tone should be (very close to) 0
+    // because of the cos² fade-in.  Without the ramp, sin(0) starts
+    // mid-amplitude * level, producing a step that listeners hear as
+    // a click.
+    ClientQuindarTone q;
+    q.prepare(kSampleRate);
+    q.setEnabled(true);
+    q.setStyle(Style::Tone);
+    q.setLevelDb(0.0f);
+    q.setDurationMs(250);
+    q.startIntro();
+
+    std::vector<float> block(kBlockSize * 2, 0.0f);
+    q.process(block.data(), kBlockSize, 2);
+    char detail[80];
+    std::snprintf(detail, sizeof(detail), "first-sample=%.4f", block[0]);
+    report("first sample of intro is ~0 (cos² fade-in)",
+        std::fabs(block[0]) < 0.01f, detail);
+}
+
+void test_morseKEncodesCorrectElements()
+{
+    ClientQuindarTone q;
+    q.prepare(kSampleRate);
+    q.setEnabled(true);
+    q.setStyle(Style::Morse);
+    q.setMorseWpm(45);
+    q.setMorsePitchHz(750.0f);
+    q.setLevelDb(0.0f);
+    q.startIntro();
+
+    // K = 9 dot-units at 1200/45 ≈ 26.67 ms each → ~240 ms.
+    auto out = runUntilIdle(q, 8000);
+
+    // K should contain non-trivial energy at 750 Hz and very little
+    // at 600/900 Hz (basic sanity that the carrier is the configured
+    // pitch, not at some other harmonic).
+    const double e750 = monoBand(out, 750.0);
+    const double e500 = monoBand(out, 500.0);
+    char detail[160];
+    std::snprintf(detail, sizeof(detail), "e750=%.1e e500=%.1e",
+        e750, e500);
+    report("Morse K carrier energy at configured pitch",
+        e750 > e500 * 4.0, detail);
+
+    // Total duration should fall within a tolerance of the spec.
+    // 9 × 1200/45 ms = 240 ms = 5760 frames.  Allow ±10 % slop.
+    const int produced = static_cast<int>(out.size() / 2);
+    char detail2[160];
+    std::snprintf(detail2, sizeof(detail2), "frames=%d", produced);
+    report("Morse K duration ~240 ms (5760 frames ±15 %)",
+        produced > 4900 && produced < 6700, detail2);
+}
+
+void test_morseBKEncodesCorrectElements()
+{
+    ClientQuindarTone q;
+    q.prepare(kSampleRate);
+    q.setEnabled(true);
+    q.setStyle(Style::Morse);
+    q.setMorseWpm(45);
+    q.setLevelDb(0.0f);
+
+    // Skip to Live then start outro.
+    q.startIntro();
+    runUntilIdle(q, 8000);
+    q.startOutro();
+    auto out = runUntilIdle(q, 16000);
+
+    // BK = 21 dot-units at 1200/45 ≈ 26.67 ms each → ~560 ms.
+    // = 13440 frames at 24 kHz.  Allow ±15 % slop.
+    const int produced = static_cast<int>(out.size() / 2);
+    char detail[160];
+    std::snprintf(detail, sizeof(detail), "frames=%d", produced);
+    report("Morse BK duration ~560 ms (13440 frames ±15 %)",
+        produced > 11400 && produced < 15500, detail);
+}
+
+void test_outroDurationMs()
+{
+    ClientQuindarTone q;
+    q.prepare(kSampleRate);
+
+    // Tone style: outro = durationMs.
+    q.setStyle(Style::Tone);
+    q.setDurationMs(250);
+    char d1[80];
+    const int outroTone = q.currentOutroDurationMs();
+    std::snprintf(d1, sizeof(d1), "got=%d", outroTone);
+    report("Tone outro duration matches durationMs (250)",
+        outroTone == 250, d1);
+
+    // Morse style: 21 × 1200/WPM ms.  At 45 WPM = 560 ms.
+    q.setStyle(Style::Morse);
+    q.setMorseWpm(45);
+    char d2[80];
+    const int outroMorse = q.currentOutroDurationMs();
+    std::snprintf(d2, sizeof(d2), "got=%d", outroMorse);
+    report("Morse outro duration ≈ 560 ms at 45 WPM",
+        outroMorse >= 555 && outroMorse <= 565, d2);
+}
+
+void test_coalesceReEngage()
+{
+    ClientQuindarTone q;
+    q.prepare(kSampleRate);
+    q.setEnabled(true);
+    q.setStyle(Style::Tone);
+    q.setDurationMs(250);
+
+    q.startIntro();
+    runUntilIdle(q, 8000);   // → Live
+    q.startOutro();          // → Disengaging
+    report("phase is Disengaging after startOutro",
+        q.phase() == Phase::Disengaging);
+
+    const bool coalesced = q.coalesceReEngage();
+    report("coalesceReEngage returns true mid-outro", coalesced);
+    report("coalesce flips phase back to Live",
+        q.phase() == Phase::Live);
+
+    // Subsequent coalesce while in Live should be a no-op.
+    const bool noop = q.coalesceReEngage();
+    report("coalesceReEngage is no-op when not Disengaging", !noop);
+}
+
+int main()
+{
+    std::printf("Running ClientQuindarTone test harness…\n\n");
+
+    test_disabledIsBypass();
+    test_phaseTransitionsCorrectly();
+    test_introToneFrequency();
+    test_outroToneFrequency();
+    test_levelMatchesConfiguredDb();
+    test_envelopeRampPreventsClicks();
+    test_morseKEncodesCorrectElements();
+    test_morseBKEncodesCorrectElements();
+    test_outroDurationMs();
+    test_coalesceReEngage();
+
+    std::printf("\n%s — %d failure(s)\n",
+        g_failed == 0 ? "ALL PASS" : "FAIL",
+        g_failed);
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Adds the optional Apollo-era Quindar tones to MOX/PTT on phone modes.
Tone style (default) plays a 2525 Hz sine intro then a 2475 Hz outro,
each 250 ms with a 5 ms cos² ramp; Morse style sends "K" on engage
and "BK" on disengage at a configurable WPM/pitch.  Ships disabled by
default; opt-in via the new QUIN chip in the channel strip's Final
Output Stage panel (right-click for the style/freq/WPM editor).

DSP (`ClientQuindarTone`) is lock-free atomic-driven and inserted
between PC mic gain and the final brickwall limiter, so the tone is
unprocessed by the user's DSP chain but still bounded by the
configured ceiling.  A dedicated `QuindarLocalSink` mirrors the same
audio to the operator's local output device — Quindar must always be
locally audible whenever it's overlaying the TX stream.

`TransmitModel::requestPttOn/Off` is the new single entry point for
PTT requests.  The MOX button and the TCI hardware-PTT path both
route through it; the coordinator runs the engage/disengage state
machine, defers `xmit 0` by the outro duration so the tone actually
makes it on the air, and coalesces a re-engage during the outro
window so the user doesn't feel a dead zone.  CW / digital modes
bypass Quindar entirely via the phone-mode gate.

The QUIN chip flashes bright while a tone is playing — signal-driven
via the new `TransmitModel::quindarActiveChanged` rather than a
polling timer.  Test harness covers phase transitions, frequency
content (Goertzel), Morse K/BK timing, envelope ramp, level matching,
coalesce semantics, and disabled bypass (19 tests, all pass).

Quindar settings are intentionally excluded from Channel Strip
preset capture — they're a PTT-time stylistic choice, not voice
shaping; preset recall shouldn't silently start signing off the
operator's transmissions.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
