### PR TITLE
Fix and trace netCW keying for straight key and iambic CW

### DIFF
--- a/src/core/CwTrace.h
+++ b/src/core/CwTrace.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QtGlobal>
+
+#include <atomic>
+#include <chrono>
+
+namespace AetherSDR {
+
+inline quint64 cwTraceNowMs() noexcept
+{
+    using Clock = std::chrono::steady_clock;
+    static const auto start = Clock::now();
+    return static_cast<quint64>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            Clock::now() - start).count());
+}
+
+inline quint64 nextCwTraceId() noexcept
+{
+    static std::atomic<quint64> next{1};
+    return next.fetch_add(1, std::memory_order_relaxed);
+}
+
+} // namespace AetherSDR

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -29,6 +29,7 @@ Q_LOGGING_CATEGORY(lcMqtt,       "aether.mqtt",        QtWarningMsg)
 Q_LOGGING_CATEGORY(lcRbn,        "aether.rbn",         QtWarningMsg)
 Q_LOGGING_CATEGORY(lcDevices,    "aether.devices",     QtWarningMsg)
 Q_LOGGING_CATEGORY(lcPerf,       "aether.perf",        QtWarningMsg)
+Q_LOGGING_CATEGORY(lcCw,         "aether.cw",          QtWarningMsg)
 
 LogManager::LogManager()
 {
@@ -55,6 +56,7 @@ LogManager::LogManager()
         {"aether.devices",    "Ext Devices",  "Serial port, FlexControl, MIDI, HID encoder"},
         {"aether.perf",       "Performance",  "Render timing and CPU profiling data"},
         {"aether.propforecast", "Propagation",  "Solar and propagation forecast updates"},
+        {"aether.cw",         "CW / netCW",    "CW keying, MIDI paddle, iambic, and netCW timing"},
     };
 
     // QLoggingCategory objects are defined above via Q_LOGGING_CATEGORY macros.

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -30,6 +30,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcMqtt)
 Q_DECLARE_LOGGING_CATEGORY(lcRbn)
 Q_DECLARE_LOGGING_CATEGORY(lcDevices)
 Q_DECLARE_LOGGING_CATEGORY(lcPerf)
+Q_DECLARE_LOGGING_CATEGORY(lcCw)
 
 // Central registry for toggling per-module diagnostic logging at runtime.
 // The Support dialog (Help → Support) uses this to let users enable/disable

--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -1,6 +1,7 @@
 #ifdef HAVE_MIDI
 
 #include "MidiControlManager.h"
+#include "CwTrace.h"
 #include "LogManager.h"
 
 #include <RtMidi.h>
@@ -9,6 +10,21 @@
 #include <cmath>
 
 namespace AetherSDR {
+
+namespace {
+
+QString midiMsgTypeName(MidiBinding::MsgType type)
+{
+    switch (type) {
+    case MidiBinding::CC:        return QStringLiteral("CC");
+    case MidiBinding::NoteOn:    return QStringLiteral("NoteOn");
+    case MidiBinding::NoteOff:   return QStringLiteral("NoteOff");
+    case MidiBinding::PitchBend: return QStringLiteral("PitchBend");
+    }
+    return QStringLiteral("Unknown");
+}
+
+} // namespace
 
 // ── MidiBinding helpers ─────────────────────────────────────────────────────
 
@@ -193,7 +209,7 @@ void MidiControlManager::cancelLearn()
 
 // ── RtMidi callback → Qt main thread ────────────────────────────────────────
 
-void MidiControlManager::rtmidiCallback(double /*deltatime*/,
+void MidiControlManager::rtmidiCallback(double deltatime,
                                          std::vector<unsigned char>* message,
                                          void* userData)
 {
@@ -202,15 +218,31 @@ void MidiControlManager::rtmidiCallback(double /*deltatime*/,
     int status = (*message)[0];
     int data1 = (*message)[1];
     int data2 = message->size() > 2 ? (*message)[2] : 0;
+    const quint64 traceId = nextCwTraceId();
+    const quint64 callbackMs = cwTraceNowMs();
+
+    if (lcCw().isDebugEnabled()) {
+        qCDebug(lcCw).noquote().nospace()
+            << "CW MIDI raw trace=" << traceId
+            << " t=" << callbackMs << "ms"
+            << " status=0x" << QString("%1").arg(status, 2, 16, QChar('0')).toUpper()
+            << " data1=" << data1
+            << " data2=" << data2
+            << " rtDeltaMs=" << QString::number(deltatime * 1000.0, 'f', 3);
+    }
 
     // Bridge to Qt main thread
-    QMetaObject::invokeMethod(self, [self, status, data1, data2]() {
-        self->onMidiMessage(status, data1, data2);
+    QMetaObject::invokeMethod(self, [self, status, data1, data2,
+                                     traceId, callbackMs, deltatime]() {
+        self->onMidiMessage(status, data1, data2, traceId, callbackMs, deltatime);
     }, Qt::QueuedConnection);
 }
 
-void MidiControlManager::onMidiMessage(int status, int data1, int data2)
+void MidiControlManager::onMidiMessage(int status, int data1, int data2,
+                                       quint64 traceId, quint64 midiCallbackMs,
+                                       double rtDeltaSeconds)
 {
+    const quint64 dispatchMs = cwTraceNowMs();
     int channel = status & 0x0F;
     int type = status & 0xF0;
 
@@ -234,6 +266,18 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2)
         normValue = (data1 | (data2 << 7)) / 16383.0f;
     } else {
         return; // ignore other message types
+    }
+
+    if (lcCw().isDebugEnabled()) {
+        qCDebug(lcCw).noquote().nospace()
+            << "CW MIDI dispatch trace=" << traceId
+            << " t=" << dispatchMs << "ms"
+            << " queueLagMs=" << static_cast<qint64>(dispatchMs - midiCallbackMs)
+            << " ch=" << (channel + 1)
+            << " type=" << midiMsgTypeName(msgType)
+            << " number=" << number
+            << " norm=" << QString::number(normValue, 'f', 3)
+            << " rtDeltaMs=" << QString::number(rtDeltaSeconds * 1000.0, 'f', 3);
     }
 
     emit midiActivity(channel, static_cast<int>(msgType), number,
@@ -283,6 +327,7 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2)
     if (it == m_bindingIndex.end()) return;
 
     const auto& binding = m_bindings[it.value()];
+    const bool cwBinding = binding.paramId.startsWith(QStringLiteral("cw."));
 
     // ── Relative knob mode: decode delta and accumulate ────────────────
     if (binding.relative && msgType == MidiBinding::CC) {
@@ -330,9 +375,21 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2)
             scaled = normValue > 0.0f ? 1.0f : 0.0f;
         }
 
+        if (cwBinding && lcCw().isDebugEnabled()) {
+            qCDebug(lcCw).noquote().nospace()
+                << "CW MIDI binding trace=" << traceId
+                << " t=" << cwTraceNowMs() << "ms"
+                << " param=" << binding.paramId
+                << " source=\"" << binding.sourceDisplayName() << "\""
+                << " value=" << QString::number(value, 'f', 3)
+                << " scaled=" << QString::number(scaled, 'f', 3)
+                << " callbackLagMs=" << static_cast<qint64>(cwTraceNowMs() - midiCallbackMs);
+        }
+
         // Don't call setter directly — may be on a worker thread while
         // setters access main-thread objects. Emit signal instead. (#502)
         emit paramAction(binding.paramId, scaled);
+        emit paramActionTrace(binding.paramId, scaled, traceId, midiCallbackMs, dispatchMs);
     }
 
     emit paramValueChanged(binding.paramId, value);

--- a/src/core/MidiControlManager.h
+++ b/src/core/MidiControlManager.h
@@ -98,6 +98,9 @@ signals:
     // Emitted with the final scaled value for MainWindow to dispatch
     // the setter on the main thread. (#502)
     void paramAction(const QString& paramId, float scaledValue);
+    void paramActionTrace(const QString& paramId, float scaledValue,
+                          quint64 traceId, quint64 midiCallbackMs,
+                          quint64 midiDispatchMs);
     // Emitted for relative knobs: accumulated steps with acceleration.
     // Positive = clockwise, negative = counter-clockwise.
     void relativeAction(const QString& paramId, int steps);
@@ -108,7 +111,9 @@ private:
     static void rtmidiCallback(double deltatime,
                                std::vector<unsigned char>* message,
                                void* userData);
-    void onMidiMessage(int status, int data1, int data2);
+    void onMidiMessage(int status, int data1, int data2,
+                       quint64 traceId, quint64 midiCallbackMs,
+                       double rtDeltaSeconds);
 
     std::unique_ptr<RtMidiIn> m_midiIn;
     QString m_portName;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -52,6 +52,7 @@
 #include "core/ClientTube.h"
 #include "core/ClientPudu.h"
 #include "core/ClientReverb.h"
+#include "core/CwTrace.h"
 #include "core/CwSidetoneGenerator.h"
 #include "core/CwxLocalKeyer.h"
 #include "core/IambicKeyer.h"
@@ -1884,8 +1885,21 @@ MainWindow::MainWindow(QWidget* parent)
             // would have produced from a hardware paddle.
             if (m_audio && m_audio->cwSidetone())
                 m_audio->cwSidetone()->setKeyDown(down);
+            const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
+            const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+            if (lcCw().isDebugEnabled()) {
+                const quint64 now = cwTraceNowMs();
+                qCDebug(lcCw).noquote().nospace()
+                    << "CW iambic key-edge trace=" << traceId
+                    << " t=" << now << "ms"
+                    << " sinceMidiMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+                    << " down=" << down;
+            }
             QMetaObject::invokeMethod(this, [this, down]() {
-                m_radioModel.sendCwKeyEdge(down);
+                const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
+                const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+                m_radioModel.sendCwKeyEdge(down, QStringLiteral("midi:iambic-keyer"),
+                                           traceId, sourceMs);
             }, Qt::QueuedConnection);
         });
         m_iambicKeyer->setOnPaddleEvent([this](bool dit, bool dah) {
@@ -1893,8 +1907,23 @@ MainWindow::MainWindow(QWidget* parent)
             // press/release, not one per element, so the radio doesn't
             // thrash through TX/RX gates between dits.
             const bool active = dit || dah;
+            const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
+            const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+            if (lcCw().isDebugEnabled()) {
+                const quint64 now = cwTraceNowMs();
+                qCDebug(lcCw).noquote().nospace()
+                    << "CW iambic paddle-event trace=" << traceId
+                    << " t=" << now << "ms"
+                    << " sinceMidiMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+                    << " dit=" << dit
+                    << " dah=" << dah
+                    << " ptt=" << active;
+            }
             QMetaObject::invokeMethod(this, [this, active]() {
-                m_radioModel.sendCwPtt(active);
+                const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
+                const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+                m_radioModel.sendCwPtt(active, QStringLiteral("midi:iambic-keyer"),
+                                       traceId, sourceMs);
             }, Qt::QueuedConnection);
         });
         // Mode/WPM/start are driven by the radio's iambic state — see
@@ -2804,6 +2833,8 @@ MainWindow::MainWindow(QWidget* parent)
     });
     connect(m_serialPort, &SerialPortController::cwPaddleChanged,
             this, [this](bool dit, bool dah) {
+        m_lastCwMidiTraceId.store(0, std::memory_order_relaxed);
+        m_lastCwMidiSourceMs.store(0, std::memory_order_relaxed);
         // When the local iambic keyer is running, feed it the raw paddle
         // state — it forwards to the radio AND drives the sidetone gate
         // directly.  Otherwise pass straight through to the radio (radio's
@@ -2950,11 +2981,25 @@ MainWindow::MainWindow(QWidget* parent)
     // main-thread dispatch. Param metadata still registered on the manager.
     registerMidiParams();
 
-    // MIDI paramAction signal: dispatches setter on main thread (#502)
-    connect(m_midiControl, &MidiControlManager::paramAction,
-            this, [this](const QString& paramId, float scaledValue) {
+    // MIDI paramActionTrace signal: dispatches setter on main thread (#502)
+    // and carries timing metadata for CW/netCW diagnostics.
+    connect(m_midiControl, &MidiControlManager::paramActionTrace,
+            this, [this](const QString& paramId, float scaledValue,
+                         quint64 traceId, quint64 midiCallbackMs,
+                         quint64 midiDispatchMs) {
         auto it = m_midiSetters.find(paramId);
         if (it == m_midiSetters.end()) return;
+        const quint64 mainMs = cwTraceNowMs();
+        if (paramId.startsWith(QStringLiteral("cw.")) && lcCw().isDebugEnabled()) {
+            qCDebug(lcCw).noquote().nospace()
+                << "CW MIDI main trace=" << traceId
+                << " t=" << mainMs << "ms"
+                << " param=" << paramId
+                << " callbackToMainMs=" << static_cast<qint64>(mainMs - midiCallbackMs)
+                << " dispatchToMainMs=" << static_cast<qint64>(mainMs - midiDispatchMs)
+                << " scaled=" << QString::number(scaledValue, 'f', 3);
+        }
+        m_currentMidiTrace = {paramId, traceId, midiCallbackMs, midiDispatchMs};
         if (scaledValue == -1.0f) {
             // Toggle sentinel: read getter, flip, call setter
             auto git = m_midiGetters.find(paramId);
@@ -2963,6 +3008,7 @@ MainWindow::MainWindow(QWidget* parent)
         } else {
             it.value()(scaledValue);
         }
+        m_currentMidiTrace = {};
     });
 
     // MIDI relativeAction signal: coalesced step-based tuning with acceleration
@@ -12413,7 +12459,21 @@ void MainWindow::registerMidiParams()
         [this]() -> float { return m_radioModel.transmitModel().cwBreakIn() ? 1 : 0; });
 
     reg("cw.key", "CW Key (straight)", "Phone/CW", P::Gate, 0, 1,
-        [this](float v) { m_radioModel.sendCwKey(v > 0.5f); });
+        [this](float v) {
+            const bool down = v > 0.5f;
+            if (lcCw().isDebugEnabled()) {
+                const quint64 now = cwTraceNowMs();
+                qCDebug(lcCw).noquote().nospace()
+                    << "CW MIDI straight-key trace=" << m_currentMidiTrace.traceId
+                    << " t=" << now << "ms"
+                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
+                        ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
+                    << " down=" << down;
+            }
+            m_radioModel.sendCwKey(down, QStringLiteral("midi:cw.key"),
+                                   m_currentMidiTrace.traceId,
+                                   m_currentMidiTrace.callbackMs);
+        });
 
     // Iambic paddle: dit and dah are separate MIDI notes.
     // When the local iambic keyer is running, paddle states feed into it
@@ -12424,10 +12484,26 @@ void MainWindow::registerMidiParams()
         auto dah = std::make_shared<bool>(false);
 
         auto pushPaddle = [this, dit, dah]() {
+            m_lastCwMidiTraceId.store(m_currentMidiTrace.traceId, std::memory_order_relaxed);
+            m_lastCwMidiSourceMs.store(m_currentMidiTrace.callbackMs, std::memory_order_relaxed);
+            if (lcCw().isDebugEnabled()) {
+                const quint64 now = cwTraceNowMs();
+                qCDebug(lcCw).noquote().nospace()
+                    << "CW MIDI paddle trace=" << m_currentMidiTrace.traceId
+                    << " t=" << now << "ms"
+                    << " param=" << m_currentMidiTrace.paramId
+                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
+                        ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
+                    << " dit=" << *dit
+                    << " dah=" << *dah
+                    << " localIambic=" << (m_iambicKeyer && m_iambicKeyer->isRunning());
+            }
             if (m_iambicKeyer && m_iambicKeyer->isRunning()) {
                 m_iambicKeyer->setPaddleState(*dit, *dah);
             } else {
-                m_radioModel.sendCwPaddle(*dit, *dah);
+                m_radioModel.sendCwPaddle(*dit, *dah, QStringLiteral("midi:cw.paddle"),
+                                          m_currentMidiTrace.traceId,
+                                          m_currentMidiTrace.callbackMs);
             }
         };
 
@@ -12447,7 +12523,19 @@ void MainWindow::registerMidiParams()
     }
 
     reg("cw.ptt", "PTT (hold)", "Phone/CW", P::Gate, 0, 1,
-        [this](float v) { m_radioModel.setTransmit(v > 0.5f); });
+        [this](float v) {
+            const bool on = v > 0.5f;
+            if (lcCw().isDebugEnabled()) {
+                const quint64 now = cwTraceNowMs();
+                qCDebug(lcCw).noquote().nospace()
+                    << "CW MIDI ptt trace=" << m_currentMidiTrace.traceId
+                    << " t=" << now << "ms"
+                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
+                        ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
+                    << " mox=" << on;
+            }
+            m_radioModel.setTransmit(on);
+        });
 
     // ── EQ ──────────────────────────────────────────────────────────────
     reg("eq.txEnable", "TX EQ Enable", "EQ", P::Toggle, 0, 1,

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -52,6 +52,7 @@
 #include <QHash>
 #include <QJsonObject>
 #include <QTimer>
+#include <atomic>
 
 class QAbstractSlider;
 
@@ -313,6 +314,15 @@ private:
 #ifdef HAVE_MIDI
     MidiControlManager*  m_midiControl{nullptr};
     void registerMidiParams();
+    struct MidiActionTrace {
+        QString paramId;
+        quint64 traceId{0};
+        quint64 callbackMs{0};
+        quint64 dispatchMs{0};
+    };
+    MidiActionTrace m_currentMidiTrace;
+    std::atomic<quint64> m_lastCwMidiTraceId{0};
+    std::atomic<quint64> m_lastCwMidiSourceMs{0};
     // MIDI param setters indexed by ID — called on main thread from
     // paramAction signal (worker thread cannot call them directly). (#502)
     QHash<QString, std::function<void(float)>> m_midiSetters;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1,6 +1,7 @@
 #include "RadioModel.h"
 #include "core/CommandParser.h"
 #include "core/AppSettings.h"
+#include "core/CwTrace.h"
 #include "core/LogManager.h"
 #include "core/StreamStatus.h"
 #include "core/UdpRegistrationPolicy.h"
@@ -729,7 +730,8 @@ QString RadioModel::audioCompressionParam() const
     return isWan() ? "opus" : "none";
 }
 
-void RadioModel::sendCwKey(bool down)
+void RadioModel::sendCwKey(bool down, const QString& debugSource,
+                           quint64 debugTraceId, quint64 debugSourceMs)
 {
     const bool prev = m_cwKeyActive;
     m_cwKeyActive = down;
@@ -738,14 +740,18 @@ void RadioModel::sendCwKey(bool down)
     // `cw ptt 1` the radio queues key events but doesn't transmit when
     // break_in=0 (the default on most user setups).  Pairing PTT with
     // KEY keys reliably regardless of break-in mode.
-    if (down && !prev) sendNetCwCommand(QStringLiteral("cw ptt 1"));
-    sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0));
-    if (!down && prev) sendNetCwCommand(QStringLiteral("cw ptt 0"));
+    if (down && !prev)
+        sendNetCwCommand(QStringLiteral("cw ptt 1"), debugSource, debugTraceId, debugSourceMs);
+    sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
+                     debugSource, debugTraceId, debugSourceMs);
+    if (!down && prev)
+        sendNetCwCommand(QStringLiteral("cw ptt 0"), debugSource, debugTraceId, debugSourceMs);
     if (prev != down)
         emit cwKeyDownChanged(down);
 }
 
-void RadioModel::sendCwPaddle(bool dit, bool dah)
+void RadioModel::sendCwPaddle(bool dit, bool dah, const QString& debugSource,
+                              quint64 debugTraceId, quint64 debugSourceMs)
 {
     // The radio's CW protocol does NOT accept a 2-arg paddle form like
     // `cw key dit dah` — FlexLib only ever sends `cw key 1` or `cw key 0`
@@ -754,19 +760,23 @@ void RadioModel::sendCwPaddle(bool dit, bool dah)
     // works when the local iambic keyer is disabled.  When the keyer IS
     // running it intercepts upstream and uses sendCwPtt + sendCwKeyEdge
     // directly, bypassing this method.
-    sendCwKey(dit || dah);
+    sendCwKey(dit || dah, debugSource, debugTraceId, debugSourceMs);
 }
 
-void RadioModel::sendCwPtt(bool on)
+void RadioModel::sendCwPtt(bool on, const QString& debugSource,
+                           quint64 debugTraceId, quint64 debugSourceMs)
 {
-    sendNetCwCommand(on ? QStringLiteral("cw ptt 1") : QStringLiteral("cw ptt 0"));
+    sendNetCwCommand(on ? QStringLiteral("cw ptt 1") : QStringLiteral("cw ptt 0"),
+                     debugSource, debugTraceId, debugSourceMs);
 }
 
-void RadioModel::sendCwKeyEdge(bool down)
+void RadioModel::sendCwKeyEdge(bool down, const QString& debugSource,
+                               quint64 debugTraceId, quint64 debugSourceMs)
 {
     const bool prev = m_cwKeyActive;
     m_cwKeyActive = down;
-    sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0));
+    sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
+                     debugSource, debugTraceId, debugSourceMs);
     if (prev != down)
         emit cwKeyDownChanged(down);
 }
@@ -808,12 +818,24 @@ QByteArray RadioModel::buildNetCwPacket(const QByteArray& payload)
     return pkt;
 }
 
-void RadioModel::sendNetCwCommand(const QString& baseCmd)
+void RadioModel::sendNetCwCommand(const QString& baseCmd, const QString& debugSource,
+                                  quint64 debugTraceId, quint64 debugSourceMs)
 {
     if (m_netCwStreamId == 0) {
         // No netcw stream — fall back to TCP immediate
-        sendCmd(baseCmd.contains("cw key") ?
-            QString(baseCmd).replace("cw key", "cw key immediate") : baseCmd);
+        const QString fallbackCmd = baseCmd.contains("cw key")
+            ? QString(baseCmd).replace("cw key", "cw key immediate")
+            : baseCmd;
+        if (lcCw().isDebugEnabled()) {
+            const quint64 now = cwTraceNowMs();
+            qCDebug(lcCw).noquote().nospace()
+                << "CW netcw fallback trace=" << debugTraceId
+                << " t=" << now << "ms"
+                << " sinceSourceMs=" << (debugSourceMs ? static_cast<qint64>(now - debugSourceMs) : -1)
+                << " source=" << (debugSource.isEmpty() ? QStringLiteral("unknown") : debugSource)
+                << " cmd=\"" << fallbackCmd << "\"";
+        }
+        sendCmd(fallbackCmd);
         return;
     }
 
@@ -860,23 +882,59 @@ void RadioModel::sendNetCwCommand(const QString& baseCmd)
     QByteArray packet1 = buildNetCwPacket(payload);
     QByteArray packet2 = buildNetCwPacket(payload);
     QByteArray packet3 = buildNetCwPacket(payload);
+    const quint64 scheduledMs = cwTraceNowMs();
+    const QString source = debugSource.isEmpty() ? QStringLiteral("unknown") : debugSource;
 
-    QMetaObject::invokeMethod(m_panStream, [this, packet0]() {
+    if (lcCw().isDebugEnabled()) {
+        qCDebug(lcCw).noquote().nospace()
+            << "CW netcw schedule trace=" << debugTraceId
+            << " t=" << scheduledMs << "ms"
+            << " sinceSourceMs=" << (debugSourceMs ? static_cast<qint64>(scheduledMs - debugSourceMs) : -1)
+            << " source=" << source
+            << " stream=0x" << QString::number(m_netCwStreamId, 16).toUpper()
+            << " index=" << index
+            << " time=0x" << tsHex
+            << " cmd=\"" << baseCmd << "\""
+            << " payloadBytes=" << payload.size()
+            << " packetBytes=" << packet0.size()
+            << " udpCopies=4 tcpBackstop=1";
+    }
+
+    auto logUdpSend = [debugTraceId, scheduledMs, source](int copy, int delayMs, int bytes) {
+        if (!lcCw().isDebugEnabled())
+            return;
+        const quint64 now = cwTraceNowMs();
+        qCDebug(lcCw).noquote().nospace()
+            << "CW netcw udp-send trace=" << debugTraceId
+            << " t=" << now << "ms"
+            << " source=" << source
+            << " copy=" << copy
+            << " delayMs=" << delayMs
+            << " actualDelayMs=" << static_cast<qint64>(now - scheduledMs)
+            << " timerSlipMs=" << (static_cast<qint64>(now - scheduledMs) - delayMs)
+            << " bytes=" << bytes;
+    };
+
+    QMetaObject::invokeMethod(m_panStream, [this, packet0, logUdpSend]() {
+        logUdpSend(0, 0, packet0.size());
         m_panStream->sendToRadio(packet0);
     }, Qt::QueuedConnection);
 
-    QTimer::singleShot(5, this, [this, packet1]() {
-        QMetaObject::invokeMethod(m_panStream, [this, packet1]() {
+    QTimer::singleShot(5, this, [this, packet1, logUdpSend]() {
+        QMetaObject::invokeMethod(m_panStream, [this, packet1, logUdpSend]() {
+            logUdpSend(1, 5, packet1.size());
             m_panStream->sendToRadio(packet1);
         }, Qt::QueuedConnection);
     });
-    QTimer::singleShot(10, this, [this, packet2]() {
-        QMetaObject::invokeMethod(m_panStream, [this, packet2]() {
+    QTimer::singleShot(10, this, [this, packet2, logUdpSend]() {
+        QMetaObject::invokeMethod(m_panStream, [this, packet2, logUdpSend]() {
+            logUdpSend(2, 10, packet2.size());
             m_panStream->sendToRadio(packet2);
         }, Qt::QueuedConnection);
     });
-    QTimer::singleShot(15, this, [this, packet3]() {
-        QMetaObject::invokeMethod(m_panStream, [this, packet3]() {
+    QTimer::singleShot(15, this, [this, packet3, logUdpSend]() {
+        QMetaObject::invokeMethod(m_panStream, [this, packet3, logUdpSend]() {
+            logUdpSend(3, 15, packet3.size());
             m_panStream->sendToRadio(packet3);
         }, Qt::QueuedConnection);
     });

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -775,16 +775,13 @@ void RadioModel::sendCwKeyEdge(bool down)
 
 QByteArray RadioModel::buildNetCwPacket(const QByteArray& payload)
 {
-    // VITA-49 header (28 bytes) + raw ASCII command payload, no trailing
-    // padding.  FlexLib's NetCWStream.AddTXData ships the payload buffer at
-    // its exact tx_data.Length — so a 57-byte command goes out in an 85-byte
-    // datagram even though packet_size rounds up to a 4-byte boundary.  The
-    // radio uses recv()'s datagram length, not packet_size, to delimit the
-    // command string; trailing zero bytes cause the parser to reject the
-    // packet (no key/PTT change observed and silent error 0x50001000 on TCP).
+    // VITA-49 header (28 bytes) + ASCII command payload.  Working Maestro
+    // captures show the payload null-padded to a 32-bit word boundary; keep
+    // the datagram length consistent with the VRT packet_size field.
     const int payloadBytes = payload.size();
+    const int paddedPayloadBytes = (payloadBytes + 3) & ~3;
     const int packetWords = static_cast<int>(std::ceil(payloadBytes / 4.0) + 7); // 7 header words
-    const int packetBytes = 28 + payloadBytes;  // header + payload, NO padding
+    const int packetBytes = 28 + paddedPayloadBytes;
 
     QByteArray pkt(packetBytes, '\0');
     auto* w = reinterpret_cast<quint32*>(pkt.data());
@@ -821,16 +818,32 @@ void RadioModel::sendNetCwCommand(const QString& baseCmd)
     }
 
     // Build the full command with timing metadata and dedup index
-    // FlexLib format: "cw key 1 time=0x<hex_ms> index=<N> client_handle=0x<handle>"
-    quint64 timeMs = static_cast<quint64>(
-        QDateTime::currentMSecsSinceEpoch() & 0xFFFFFFFF);
+    // FlexLib format: "cw key 1 time=0x<hex_ms> index=<N> client_handle=0x<handle>".
+    // The time value is a 16-bit relative millisecond counter, not an epoch
+    // timestamp.  Flex clients reset it after a short idle gap; the radio
+    // accepts 0x0000 as a timing resync marker.
+    constexpr qint64 kNetCwIdleResetMs = 3000;
+    quint16 timeMs = 0;
+    if (!m_netCwClock.isValid()
+        || m_netCwLastSendMs < 0
+        || (m_netCwClock.elapsed() - m_netCwLastSendMs) > kNetCwIdleResetMs) {
+        if (m_netCwClock.isValid())
+            m_netCwClock.restart();
+        else
+            m_netCwClock.start();
+        m_netCwLastSendMs = 0;
+    } else {
+        const qint64 elapsed = m_netCwClock.elapsed();
+        timeMs = static_cast<quint16>(elapsed & 0xFFFF);
+        m_netCwLastSendMs = elapsed;
+    }
     int index = m_netCwIndex++;
 
     // FlexLib formats hex values UPPERCASE (C# ToString("X")), and the
     // radio's status messages do too (e.g. `S23A59BDF|...`) — the netcw
     // parser appears to be case-sensitive on `client_handle`.  Match that
     // by formatting both hex values uppercase explicitly.
-    const QString tsHex = QString("%1").arg(timeMs, 8, 16, QChar('0')).toUpper();
+    const QString tsHex = QString("%1").arg(timeMs, 4, 16, QChar('0')).toUpper();
     const QString chHex = QString("%1").arg(clientHandle(), 0, 16).toUpper();
     QString fullCmd = QString("%1 time=0x%2 index=%3 client_handle=0x%4")
         .arg(baseCmd, tsHex, QString::number(index), chHex);
@@ -868,14 +881,10 @@ void RadioModel::sendNetCwCommand(const QString& baseCmd)
         }, Qt::QueuedConnection);
     });
 
-    // No TCP fallback when netcw is up.  Radio v4.1.5 rejects every CW
-    // command sent over TCP with 0x50001000 ("command syntax error") —
-    // both the netcw form and `cw key immediate` form — so the fallback
-    // was producing log noise without doing useful work.  The four
-    // redundant UDP sends above are the reliability mechanism.  If
-    // netcw stream creation failed at startup, the early-return path
-    // above falls back to `cw key immediate` over TCP for that case
-    // (no-netcw firmware), which is a separate scenario.
+    // FlexLib sends the same decorated netcw command over TCP after the UDP
+    // copies.  With the 16-bit timestamp format above, the radio can dedupe
+    // by index=N and the TCP path provides a reliable delivery backstop.
+    sendCmd(fullCmd);
 }
 
 void RadioModel::cwAutoTune(int sliceId, bool intermittent)
@@ -1530,6 +1539,8 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                                 if (code == 0) {
                                     m_netCwStreamId = body.trimmed().toUInt(nullptr, 16);
                                     m_netCwIndex = 1;
+                                    m_netCwClock.invalidate();
+                                    m_netCwLastSendMs = -1;
                                     qCDebug(lcProtocol) << "RadioModel: netcw stream created, id:"
                                              << Qt::hex << m_netCwStreamId;
                                 } else {
@@ -1732,6 +1743,8 @@ void RadioModel::onDisconnected()
     m_rxAudio = {};
     m_netCwStreamId = 0;
     m_netCwIndex = 1;
+    m_netCwClock.invalidate();
+    m_netCwLastSendMs = -1;
     m_lineoutGain = 50;
     m_headphoneGain = 50;
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -475,6 +475,8 @@ private:
     // NetCW stream — VITA-49 UDP delivery for low-latency CW keying
     quint32  m_netCwStreamId{0};
     int      m_netCwIndex{1};           // sequential dedup index
+    QElapsedTimer m_netCwClock;          // 16-bit relative ms clock for time=0x....
+    qint64   m_netCwLastSendMs{-1};
     void sendNetCwCommand(const QString& cmd);
     QByteArray buildNetCwPacket(const QByteArray& payload);
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -269,13 +269,17 @@ public:
     bool isWan() const { return m_wanConn != nullptr; }
     void setTransmit(bool tx);
     QString audioCompressionParam() const;        // "none" or "opus" based on settings
-    void sendCwKey(bool down);                    // straight key via netcw stream
-    void sendCwPaddle(bool dit, bool dah);        // iambic paddle via netcw stream
+    void sendCwKey(bool down, const QString& debugSource = {},
+                   quint64 debugTraceId = 0, quint64 debugSourceMs = 0); // straight key via netcw stream
+    void sendCwPaddle(bool dit, bool dah, const QString& debugSource = {},
+                      quint64 debugTraceId = 0, quint64 debugSourceMs = 0); // iambic paddle via netcw stream
     // Lower-level pieces used by the local iambic keyer: PTT and key
     // edges are managed separately so PTT stays asserted across the whole
     // squeeze while key transitions on each element boundary.
-    void sendCwPtt(bool on);
-    void sendCwKeyEdge(bool down);
+    void sendCwPtt(bool on, const QString& debugSource = {},
+                   quint64 debugTraceId = 0, quint64 debugSourceMs = 0);
+    void sendCwKeyEdge(bool down, const QString& debugSource = {},
+                       quint64 debugTraceId = 0, quint64 debugSourceMs = 0);
     void cwAutoTune(int sliceId, bool intermittent); // int=1 start loop, int=0 stop
     void cwAutoTuneOnce(int sliceId);                // one-shot (no int= param)
     void addSlice();           // Create a new slice on the active panadapter
@@ -477,7 +481,8 @@ private:
     int      m_netCwIndex{1};           // sequential dedup index
     QElapsedTimer m_netCwClock;          // 16-bit relative ms clock for time=0x....
     qint64   m_netCwLastSendMs{-1};
-    void sendNetCwCommand(const QString& cmd);
+    void sendNetCwCommand(const QString& cmd, const QString& debugSource = {},
+                          quint64 debugTraceId = 0, quint64 debugSourceMs = 0);
     QByteArray buildNetCwPacket(const QByteArray& payload);
 
     QString     m_name;

--- a/tests/cw_sidetone_test.cpp
+++ b/tests/cw_sidetone_test.cpp
@@ -115,6 +115,7 @@ int main()
         CwSidetoneGenerator gen(48000);
         gen.setEnabled(true);
         gen.setVolume(1.0f);
+        gen.setPan(0.0f);        // test reads L channel only
         gen.setShapingMs(5.0f);  // 5 ms ramp
         gen.setKeyDown(true);
         auto mono = runFrames(gen, 480);  // 10 ms total — first 5 ms is ramp


### PR DESCRIPTION

## Summary

This PR fixes the shared netCW transmit path used by straight key, MIDI/serial paddles, and the local iambic keyer, then adds a focused CW diagnostic trail so we can troubleshoot remaining latency or keying problems from user logs.

The important Morse/API distinction is that Flex does not expose dedicated radio commands for `dit` and `dah`. A dit is a dot-length key-down interval, and a dah is a dash-length key-down interval. Aether generates those timings locally for iambic paddles, then emits ordinary key/PTT edges to the radio:

- `cw key 1/0 ...` for key down/up
- `cw ptt 1/0 ...` for CW transmit PTT on/off
- `cw key immediate 1/0` only as a no-netCW TCP fallback
- `cwx send ...` for radio-side text-to-Morse, which is a different CWX path

So the straight-key and iambic reports converge on one bug surface: `RadioModel::sendNetCwCommand()`. MIDI paddle issues also become observable through the same path once the new `aether.cw` debug category is enabled.

## Root Cause

Aether was sending netCW command timestamps as an 8-digit, epoch-derived 32-bit value:

```text
cw key 1 time=0x12345678 index=N client_handle=0x...
```

The Flex netCW path expects a 16-bit relative millisecond counter instead. Working captures and FlexLib behavior indicate that clients reset the counter after an idle gap, with the first event after idle commonly sent as `time=0x0000` to resync radio-side timing.

Because the timestamp was wrong, the radio could receive UDP packets without accepting them as valid key/PTT timing events, which matches the issue reports: local sidetone works, UDP appears to go out, but the radio never transitions into TX.

There were two related transport mismatches:

- The VITA/netCW datagram was sized to the raw ASCII payload even though the VRT packet size rounded to a 32-bit word boundary. Maestro captures show null padding to the word boundary, so this PR makes packet length and VRT size agree.
- Aether had removed the FlexLib-style TCP send of the same decorated command after UDP delivery. With the corrected timestamp format, the radio can dedupe by `index=N`, so the TCP command is useful again as a reliability backstop rather than just log noise.

## Changes

### netCW keying fix

- Add a small per-radio netCW relative clock using `QElapsedTimer`.
- Emit `time=0x....` as a 4-digit, uppercase, 16-bit millisecond value.
- Reset the netCW clock on stream creation, disconnect, and after a short idle gap.
- Keep the existing redundant UDP sends, with incrementing VITA packet count.
- Restore FlexLib-style TCP delivery after the UDP netCW packets.
- Pad netCW VITA command payloads to a 32-bit word boundary.
- Clarify `cw_sidetone_test` by panning hard-left in the one assertion that measures only the left channel.

### CW/MIDI/netCW diagnostics

- Add a new support-log category: `aether.cw` / `CW / netCW`.
- Add `CwTrace.h`, a tiny steady-clock trace helper for monotonic milliseconds and per-event trace IDs.
- Log raw MIDI callback events, including status/data bytes, RtMidi delta, and callback timestamp.
- Log MIDI dispatch from the RtMidi callback into Qt, including callback-to-dispatch queue lag.
- Log CW MIDI binding resolution (`cw.key`, `cw.dit`, `cw.dah`, `cw.ptt`) with source binding, scaled value, and trace ID.
- Carry trace metadata through MainWindow’s MIDI setter dispatch so CW setters can be correlated with the original controller event.
- Log straight-key MIDI actions and iambic paddle state updates.
- Log local iambic keyer paddle/PTT events and generated key edges.
- Log netCW command scheduling with trace ID, source, index, Flex timestamp, payload size, packet size, UDP copy count, and TCP-backstop status.
- Log each UDP copy send with actual delay and timer slip relative to the intended 0/5/10/15 ms schedule.
- Log no-netCW TCP fallback use with trace/source/timing context.

## How To Use The New Trace Logs

Enable the `CW / netCW` category in Help → Support, reproduce the keying problem, then inspect `aethersdr.log`.

For a healthy straight-key MIDI press, the log should show a chain like:

```text
CW MIDI raw trace=42 ...
CW MIDI dispatch trace=42 queueLagMs=...
CW MIDI binding trace=42 param=cw.key ...
CW MIDI main trace=42 callbackToMainMs=...
CW MIDI straight-key trace=42 down=1
CW netcw schedule trace=42 source=midi:cw.key index=... time=0x.... cmd="cw ptt 1" ...
CW netcw udp-send trace=42 copy=0 delayMs=0 actualDelayMs=...
CW netcw schedule trace=42 source=midi:cw.key index=... time=0x.... cmd="cw key 1" ...
```

For iambic paddles, expect:

```text
CW MIDI binding trace=43 param=cw.dit ...
CW MIDI paddle trace=43 dit=1 dah=0 localIambic=1
CW iambic paddle-event trace=43 ptt=1
CW netcw schedule trace=43 source=midi:iambic-keyer cmd="cw ptt 1" ...
CW iambic key-edge trace=43 down=1
CW netcw schedule trace=43 source=midi:iambic-keyer cmd="cw key 1" ...
```

The main latency fields to look at are:

- `queueLagMs`: RtMidi callback → MIDI manager Qt dispatch
- `callbackToMainMs`: RtMidi callback → MainWindow setter dispatch
- `sinceMidiMs`: original MIDI callback → CW/iambic/netCW point being logged
- `timerSlipMs`: netCW redundant UDP copy timer drift from the intended 0/5/10/15 ms send schedule

This should let us tell whether a user’s issue is controller-side latency, Qt thread handoff latency, local iambic timing, netCW scheduling jitter, or radio-side acceptance/TX behavior.

## User Impact

This should address the active reports where straight key or iambic paddle input produces local sidetone but no RF/TX from the Flex radio. Both straight key and iambic keying now ride the same corrected netCW command path.

The new logging is disabled by default and only activates when the support category is enabled, so normal CW operation should not be noisy. When enabled, it gives us enough timing breadcrumbs to debug user-reported MIDI paddle latency, missed key-up/key-down edges, duplicate PTT/key behavior, and delayed netCW packet sends.

Iambic behavior remains intentionally local for timing: Aether still generates dot/dash cadence in `IambicKeyer`, drives low-latency local sidetone from those generated key edges, and sends normal `cw key` edges to the radio for the RF signal. There are no new dedicated dit/dah radio commands because FlexLib does not appear to provide such a command surface.

## Hardware Validation Notes

This has been validated against the local unit tests and build, but it still needs an on-radio smoke test with a Flex radio:

1. Connect to a radio and verify `stream create netcw` succeeds.
2. Enable Help → Support → `CW / netCW` logging.
3. Try straight key input and confirm the radio enters TX and emits RF.
4. Try MIDI or serial iambic input with local iambic enabled and confirm dot/dash RF follows the local sidetone.
5. Review `aethersdr.log` for the trace chain and timer-slip values.
6. If TX works but the first element clips, the next likely tuning knob is a small PTT lead delay before the first `cw key 1` edge.

## Validation

- `cmake --build build -j8`
- `./build/iambic_keyer_test`
- `./build/cw_sidetone_test`
- `./build/midi_settings_test`
- `./build/transmit_model_test`
- `./build/transmit_model_apd_test`
- `ctest --test-dir build --output-on-failure -j8`
- `git diff --check`

Fixes #2175 #2079 #1413 #2010 #1075 #1989 #1973 #1537 #1075 

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
