### PR TITLE
Fix HGauge tick label and TxApplet value label clipping on HiDPI displays

### DIFF
--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -166,7 +166,8 @@ protected:
             const QFontMetrics fm(tickFont);
             int tw = fm.horizontalAdvance(tick.label);
             // Center label on tick position, clamp to widget bounds
-            int lx = qBound(0, tx - tw / 2, w - tw);
+            // Leave a small right margin so the last tick isn't flush to the edge
+            int lx = qBound(2, tx - tw / 2, w - tw - 4);
             p.drawText(lx, 10, tick.label);
         }
 

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -64,7 +64,7 @@ void TxApplet::buildUI()
     // Body with margins
     auto* body = new QWidget;
     auto* vbox = new QVBoxLayout(body);
-    vbox->setContentsMargins(4, 2, 4, 2);
+    vbox->setContentsMargins(4, 2, 8, 2);
     vbox->setSpacing(2);
 
     // ── Forward Power gauge (0–120 W, red > 100 W) ─────────────────────────
@@ -101,7 +101,7 @@ void TxApplet::buildUI()
 
         m_rfPowerLabel = new QLabel("100");
         m_rfPowerLabel->setStyleSheet("QLabel { color: #c8d8e8; font-size: 10px; }");
-        m_rfPowerLabel->setFixedWidth(22);
+        m_rfPowerLabel->setFixedWidth(30);
         m_rfPowerLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         row->addWidget(m_rfPowerLabel);
         vbox->addLayout(row);
@@ -125,7 +125,7 @@ void TxApplet::buildUI()
 
         m_tunePowerLabel = new QLabel("10");
         m_tunePowerLabel->setStyleSheet("QLabel { color: #c8d8e8; font-size: 10px; }");
-        m_tunePowerLabel->setFixedWidth(22);
+        m_tunePowerLabel->setFixedWidth(30);
         m_tunePowerLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         row->addWidget(m_tunePowerLabel);
         vbox->addLayout(row);


### PR DESCRIPTION
## Summary

Fixes #2345

- Adds a 4px right (and 2px left) margin to the tick label clamp in `HGauge::paintEvent()` so the rightmost label (`120`, `3`) never renders flush to the widget edge
- Increases `TxApplet` RF Power and Tune Pwr value label width from `22px` → `30px`
- Increases `TxApplet` body layout right margin from `4px` → `8px`

## Background

Both issues are caused by layout constants that are just barely sufficient at standard DPI but clip on 4K/HiDPI displays due to font metric differences between platforms. The fixes add breathing room that is harmless at all DPI levels.

Tested on macOS 4K. The `HGauge` fix applies to every gauge in the app — RF Pwr, SWR, and any future gauges that use the same widget.

## Files modified

- `src/gui/HGauge.h`
- `src/gui/TxApplet.cpp`

## Test plan
- [ ] Confirm `120` and `3` tick labels fully visible on HiDPI display
- [ ] Confirm RF Power and Tune Pwr values not clipped at any value (1–100)
- [ ] Confirm no regression on standard DPI (Linux/Windows)