### PR TITLE
Add Spot Lines toggle to SpotHub Display settings

### DIFF
--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1899,6 +1899,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     bool overrideColors   = s.value("IsSpotsOverrideColorsEnabled", "False").toString() == "True";
     bool overrideBg       = s.value("IsSpotsOverrideBackgroundColorsEnabled", "True").toString() == "True";
     bool overrideBgAuto   = s.value("IsSpotsOverrideToAutoBackgroundColorEnabled", "True").toString() == "True";
+    bool spotLines        = s.value("SpotShowLines", "True").toString() == "True";
     int levels            = s.value("SpotsMaxLevel", 3).toInt();
     int position          = s.value("SpotsStartingHeightPercentage", 50).toInt();
     int fontSize          = s.value("SpotFontSize", 16).toInt();
@@ -2167,6 +2168,22 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         save("SpotsBackgroundOpacity", QString::number(v));
     });
     grid->addLayout(opacRow, row++, 1);
+
+    // ── Spot Lines ──────────────────────────────────────────────────────
+    grid->addWidget(new QLabel("Spot Lines:"), row, 0);
+    auto* spotLinesBtn = new QPushButton(spotLines ? "Enabled" : "Disabled");
+    spotLinesBtn->setCheckable(true);
+    spotLinesBtn->setChecked(spotLines);
+    spotLinesBtn->setFixedWidth(80);
+    spotLinesBtn->setToolTip("Show vertical lines from the spectrum up to each spot label.\nDisable during contests to reduce clutter.");
+    spotLinesBtn->setStyleSheet(
+        "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
+        "QPushButton:!checked { background: #603020; }");
+    connect(spotLinesBtn, &QPushButton::toggled, this, [spotLinesBtn, save](bool on) {
+        spotLinesBtn->setText(on ? "Enabled" : "Disabled");
+        save("SpotShowLines", on ? "True" : "False");
+    });
+    grid->addWidget(spotLinesBtn, row++, 1, Qt::AlignLeft);
 
     // ── Total Spots ─────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Total Spots:"), row, 0);

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1899,7 +1899,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     bool overrideColors   = s.value("IsSpotsOverrideColorsEnabled", "False").toString() == "True";
     bool overrideBg       = s.value("IsSpotsOverrideBackgroundColorsEnabled", "True").toString() == "True";
     bool overrideBgAuto   = s.value("IsSpotsOverrideToAutoBackgroundColorEnabled", "True").toString() == "True";
-    bool spotLines        = s.value("SpotShowLines", "True").toString() == "True";
+    bool spotLines        = s.value("IsSpotsLinesEnabled", "True").toString() == "True";
     int levels            = s.value("SpotsMaxLevel", 3).toInt();
     int position          = s.value("SpotsStartingHeightPercentage", 50).toInt();
     int fontSize          = s.value("SpotFontSize", 16).toInt();
@@ -2181,7 +2181,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         "QPushButton:!checked { background: #603020; }");
     connect(spotLinesBtn, &QPushButton::toggled, this, [spotLinesBtn, save](bool on) {
         spotLinesBtn->setText(on ? "Enabled" : "Disabled");
-        save("SpotShowLines", on ? "True" : "False");
+        save("IsSpotsLinesEnabled", on ? "True" : "False");
     });
     grid->addWidget(spotLinesBtn, row++, 1, Qt::AlignLeft);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -914,6 +914,13 @@ MainWindow::MainWindow(QWidget* parent)
         }
         if (s.value("FramelessWindow", "True").toString() == "True")
             setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
+
+        // Migrate spot-lines key renamed in v0.9.7 (SpotShowLines → IsSpotsLinesEnabled).
+        if (s.contains("SpotShowLines") && !s.contains("IsSpotsLinesEnabled")) {
+            s.setValue("IsSpotsLinesEnabled", s.value("SpotShowLines", "True").toString());
+            s.remove("SpotShowLines");
+            s.save();
+        }
     }
 
     applyDarkTheme();
@@ -5344,7 +5351,7 @@ void MainWindow::buildMenuBar()
                 sw->setSpotColor(spotColor);
                 sw->setSpotBgColor(bgColor);
                 sw->setSpotBgOpacity(bgOpacity);
-                sw->setSpotLines(s.value("SpotShowLines", "True").toString() == "True");
+                sw->setSpotShowLines(s.value("IsSpotsLinesEnabled", "True").toString() == "True");
             }
             // Rebuild markers so source-level visibility changes, such as the
             // Memories feed toggle, apply immediately without mutating the cache.
@@ -8712,7 +8719,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setSpotColor(QColor(s.value("SpotsOverrideColor", "#FFFF00").toString()));
         sw->setSpotBgColor(QColor(s.value("SpotsOverrideBgColor", "#000000").toString()));
         sw->setSpotBgOpacity(s.value("SpotsBackgroundOpacity", 48).toInt());
-        sw->setSpotLines(s.value("SpotShowLines", "True").toString() == "True");
+        sw->setSpotShowLines(s.value("IsSpotsLinesEnabled", "True").toString() == "True");
     }
 
     // ── Per-pan display controls (client-side) ───────────────────────────

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5344,6 +5344,7 @@ void MainWindow::buildMenuBar()
                 sw->setSpotColor(spotColor);
                 sw->setSpotBgColor(bgColor);
                 sw->setSpotBgOpacity(bgOpacity);
+                sw->setSpotLines(s.value("SpotShowLines", "True").toString() == "True");
             }
             // Rebuild markers so source-level visibility changes, such as the
             // Memories feed toggle, apply immediately without mutating the cache.
@@ -8711,6 +8712,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setSpotColor(QColor(s.value("SpotsOverrideColor", "#FFFF00").toString()));
         sw->setSpotBgColor(QColor(s.value("SpotsOverrideBgColor", "#000000").toString()));
         sw->setSpotBgOpacity(s.value("SpotsBackgroundOpacity", 48).toInt());
+        sw->setSpotLines(s.value("SpotShowLines", "True").toString() == "True");
     }
 
     // ── Per-pan display controls (client-side) ───────────────────────────

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -914,13 +914,6 @@ MainWindow::MainWindow(QWidget* parent)
         }
         if (s.value("FramelessWindow", "True").toString() == "True")
             setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
-
-        // Migrate spot-lines key renamed in v0.9.7 (SpotShowLines → IsSpotsLinesEnabled).
-        if (s.contains("SpotShowLines") && !s.contains("IsSpotsLinesEnabled")) {
-            s.setValue("IsSpotsLinesEnabled", s.value("SpotShowLines", "True").toString());
-            s.remove("SpotShowLines");
-            s.save();
-        }
     }
 
     applyDarkTheme();

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4737,7 +4737,7 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
         }
 
         // Draw vertical tick line from bottom of spectrum up to the label
-        if (m_spotLines) {
+        if (m_spotShowLines) {
             p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 120), 1, Qt::DotLine));
             p.drawLine(x, specRect.bottom(), x, labelRect.bottom());
         }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4737,8 +4737,10 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
         }
 
         // Draw vertical tick line from bottom of spectrum up to the label
-        p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 120), 1, Qt::DotLine));
-        p.drawLine(x, specRect.bottom(), x, labelRect.bottom());
+        if (m_spotLines) {
+            p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 120), 1, Qt::DotLine));
+            p.drawLine(x, specRect.bottom(), x, labelRect.bottom());
+        }
 
         placed.append(labelRect);
         int mIdx = static_cast<int>(&spot - &m_spotMarkers[0]);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -323,6 +323,8 @@ public:
     void setSpotStartPct(int pct) { m_spotStartPct = pct; update(); }
     void setSpotOverrideColors(bool on) { m_spotOverrideColors = on; update(); }
     void setSpotOverrideBg(bool on) { m_spotOverrideBg = on; update(); }
+    void setSpotLines(bool on) { m_spotLines = on; update(); }
+    bool spotLines() const { return m_spotLines; }
     void setSpotColor(const QColor& c) { m_spotColor = c; update(); }
     void setSpotBgColor(const QColor& c) { m_spotBgColor = c; update(); }
     void setSpotBgOpacity(int pct) { m_spotBgOpacity = pct; update(); }
@@ -691,6 +693,7 @@ private:
     int  m_spotStartPct{50};      // % down from top of spectrum
     bool   m_spotOverrideColors{false};
     bool   m_spotOverrideBg{true};
+    bool   m_spotLines{true};
     QColor m_spotColor{Qt::yellow};
     QColor m_spotBgColor{Qt::black};
     int    m_spotBgOpacity{48};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -323,8 +323,8 @@ public:
     void setSpotStartPct(int pct) { m_spotStartPct = pct; update(); }
     void setSpotOverrideColors(bool on) { m_spotOverrideColors = on; update(); }
     void setSpotOverrideBg(bool on) { m_spotOverrideBg = on; update(); }
-    void setSpotLines(bool on) { m_spotLines = on; update(); }
-    bool spotLines() const { return m_spotLines; }
+    void setSpotShowLines(bool on) { m_spotShowLines = on; update(); }
+    bool spotShowLines() const { return m_spotShowLines; }
     void setSpotColor(const QColor& c) { m_spotColor = c; update(); }
     void setSpotBgColor(const QColor& c) { m_spotBgColor = c; update(); }
     void setSpotBgOpacity(int pct) { m_spotBgOpacity = pct; update(); }
@@ -693,7 +693,7 @@ private:
     int  m_spotStartPct{50};      // % down from top of spectrum
     bool   m_spotOverrideColors{false};
     bool   m_spotOverrideBg{true};
-    bool   m_spotLines{true};
+    bool   m_spotShowLines{true};
     QColor m_spotColor{Qt::yellow};
     QColor m_spotBgColor{Qt::black};
     int    m_spotBgOpacity{48};

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -276,7 +276,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     m_spotLinesToggle->setCheckable(true);
     m_spotLinesToggle->setChecked(m_spotShowLines);
     m_spotLinesToggle->setFixedWidth(80);
-    m_spotLinesToggle->setToolTip("Show vertical lines from the spectrum up to each spot label");
+    m_spotLinesToggle->setToolTip("Show vertical lines from the spectrum up to each spot label.\nDisable during contests to reduce clutter.");
     m_spotLinesToggle->setStyleSheet(
         "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
         "QPushButton:!checked { background: #603020; }");

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -30,6 +30,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     m_spotColor  = QColor(s.value("SpotsOverrideColor", "#FFFF00").toString());
     m_bgColor    = QColor(s.value("SpotsOverrideBgColor", "#000000").toString());
     m_bgOpacity  = s.value("SpotsBackgroundOpacity", 48).toInt();
+    m_spotLines  = s.value("SpotShowLines", "True").toString() == "True";
     // Migrate from old minutes key to new seconds key
     int lifetimeSec = s.value("DxClusterSpotLifetimeSec", 0).toInt();
     if (lifetimeSec <= 0)
@@ -268,6 +269,23 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
         save("SpotsBackgroundOpacity", QString::number(v));
     });
     grid->addLayout(opacRow, row++, 1);
+
+    // ── Spot Lines ──────────────────────────────────────────────────────
+    grid->addWidget(new QLabel("Spot Lines:"), row, 0);
+    m_spotLinesToggle = new QPushButton(m_spotLines ? "Enabled" : "Disabled");
+    m_spotLinesToggle->setCheckable(true);
+    m_spotLinesToggle->setChecked(m_spotLines);
+    m_spotLinesToggle->setFixedWidth(80);
+    m_spotLinesToggle->setToolTip("Show vertical lines from the spectrum up to each spot label");
+    m_spotLinesToggle->setStyleSheet(
+        "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
+        "QPushButton:!checked { background: #603020; }");
+    connect(m_spotLinesToggle, &QPushButton::toggled, this, [this, save](bool on) {
+        m_spotLines = on;
+        m_spotLinesToggle->setText(on ? "Enabled" : "Disabled");
+        save("SpotShowLines", on ? "True" : "False");
+    });
+    grid->addWidget(m_spotLinesToggle, row++, 1, Qt::AlignLeft);
 
     // ── Total Spots ─────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Total Spots:"), row, 0);

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -30,7 +30,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     m_spotColor  = QColor(s.value("SpotsOverrideColor", "#FFFF00").toString());
     m_bgColor    = QColor(s.value("SpotsOverrideBgColor", "#000000").toString());
     m_bgOpacity  = s.value("SpotsBackgroundOpacity", 48).toInt();
-    m_spotLines  = s.value("SpotShowLines", "True").toString() == "True";
+    m_spotShowLines = s.value("IsSpotsLinesEnabled", "True").toString() == "True";
     // Migrate from old minutes key to new seconds key
     int lifetimeSec = s.value("DxClusterSpotLifetimeSec", 0).toInt();
     if (lifetimeSec <= 0)
@@ -272,18 +272,18 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
 
     // ── Spot Lines ──────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Spot Lines:"), row, 0);
-    m_spotLinesToggle = new QPushButton(m_spotLines ? "Enabled" : "Disabled");
+    m_spotLinesToggle = new QPushButton(m_spotShowLines ? "Enabled" : "Disabled");
     m_spotLinesToggle->setCheckable(true);
-    m_spotLinesToggle->setChecked(m_spotLines);
+    m_spotLinesToggle->setChecked(m_spotShowLines);
     m_spotLinesToggle->setFixedWidth(80);
     m_spotLinesToggle->setToolTip("Show vertical lines from the spectrum up to each spot label");
     m_spotLinesToggle->setStyleSheet(
         "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
         "QPushButton:!checked { background: #603020; }");
     connect(m_spotLinesToggle, &QPushButton::toggled, this, [this, save](bool on) {
-        m_spotLines = on;
+        m_spotShowLines = on;
         m_spotLinesToggle->setText(on ? "Enabled" : "Disabled");
-        save("SpotShowLines", on ? "True" : "False");
+        save("IsSpotsLinesEnabled", on ? "True" : "False");
     });
     grid->addWidget(m_spotLinesToggle, row++, 1, Qt::AlignLeft);
 

--- a/src/gui/SpotSettingsDialog.h
+++ b/src/gui/SpotSettingsDialog.h
@@ -48,7 +48,7 @@ private:
     bool   m_overrideColors{false};
     bool   m_overrideBg{true};
     bool   m_overrideBgAutoMode{true};
-    bool   m_spotLines{true};
+    bool   m_spotShowLines{true};
     QColor m_spotColor{Qt::yellow};
     QColor m_bgColor{Qt::black};
     int    m_bgOpacity{48};

--- a/src/gui/SpotSettingsDialog.h
+++ b/src/gui/SpotSettingsDialog.h
@@ -40,6 +40,7 @@ private:
     QPushButton* m_bgColorPickerBtn;
     QSlider*     m_bgOpacitySlider;
     QLabel*      m_bgOpacityValue;
+    QPushButton* m_spotLinesToggle;
     QLabel*      m_totalSpotsLabel;
 
     bool   m_spotsEnabled{true};
@@ -47,6 +48,7 @@ private:
     bool   m_overrideColors{false};
     bool   m_overrideBg{true};
     bool   m_overrideBgAutoMode{true};
+    bool   m_spotLines{true};
     QColor m_spotColor{Qt::yellow};
     QColor m_bgColor{Qt::black};
     int    m_bgOpacity{48};


### PR DESCRIPTION
## Summary

Fixes #2348

- Adds a **Spot Lines: Enabled / Disabled** toggle to the SpotHub → Display tab and the legacy Spot Settings dialog
- When disabled, the vertical dotted lines drawn from the spectrum up to each spot label are hidden
- Setting persists via `AppSettings` key `IsSpotsLinesEnabled`, defaults to `Enabled`, takes effect immediately without a restart
- No behaviour change for existing users

## Background

During contest operation the panadapter can display dozens or hundreds of DX spots simultaneously. Each spot renders a vertical dotted line from the base of the spectrum up to its label. With a full contest band this creates a dense forest of vertical lines that obscures the FFT trace and makes it difficult to read signal activity.

User feedback:
> *"During a contest activity when there are dozens and dozens of spotdx appearing on the Panadapter it is annoying to see the vertical lines under the spotdx. Give an option to remove them."*

The toggle lets contest operators declutter the panadapter without disabling spots entirely — callsigns and frequencies remain visible, the vertical noise is removed.

## Files modified

- `src/gui/SpectrumWidget.h` — `m_spotShowLines` member + `setSpotShowLines()` / `spotShowLines()` accessors (naming follows `setSpotOverrideColors` / `setSpotOverrideBg` convention)
- `src/gui/SpectrumWidget.cpp` — guard `drawLine` with `if (m_spotShowLines)`
- `src/gui/DxClusterDialog.cpp` — Spot Lines toggle row in Display tab, persists as `IsSpotsLinesEnabled`
- `src/gui/SpotSettingsDialog.cpp` — matching toggle in legacy dialog with unified tooltip text
- `src/gui/MainWindow.cpp` — load and apply `IsSpotsLinesEnabled` on startup and live reload

## Test plan
- [ ] Default state: spot lines visible as before — no regression
- [ ] Toggle off in SpotHub → Display: vertical lines hidden, spot labels and callsigns remain
- [ ] Toggle off in Spot Settings dialog: same result
- [ ] Setting persists across application restart
- [ ] Works correctly with multiple panadapters open
- [ ] Confirm with 0 spots, a handful, and a busy contest band