### PR TITLE
Add CW keyboard USB HID and MIDI keying controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1215,6 +1215,15 @@ target_link_libraries(radio_status_ownership_test PRIVATE Qt6::Core)
 enable_testing()
 add_test(NAME radio_status_ownership_test COMMAND radio_status_ownership_test)
 
+add_executable(shortcut_manager_test
+    tests/shortcut_manager_test.cpp
+    src/core/ShortcutManager.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(shortcut_manager_test PRIVATE src)
+target_link_libraries(shortcut_manager_test PRIVATE Qt6::Core Qt6::Widgets)
+add_test(NAME shortcut_manager_test COMMAND shortcut_manager_test)
+
 add_executable(cw_sidetone_test
     tests/cw_sidetone_test.cpp
     src/core/CwSidetoneGenerator.cpp
@@ -1286,6 +1295,7 @@ add_executable(midi_settings_test
 target_compile_definitions(midi_settings_test PRIVATE HAVE_MIDI)
 target_include_directories(midi_settings_test PRIVATE src third_party/rtmidi)
 target_link_libraries(midi_settings_test PRIVATE Qt6::Core)
+add_test(NAME midi_settings_test COMMAND midi_settings_test)
 
 add_executable(transmit_model_test
     tests/transmit_model_test.cpp

--- a/src/core/CwTrace.h
+++ b/src/core/CwTrace.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QtGlobal>
+
+#include <atomic>
+#include <chrono>
+
+namespace AetherSDR {
+
+inline quint64 cwTraceNowMs() noexcept
+{
+    using Clock = std::chrono::steady_clock;
+    static const auto start = Clock::now();
+    return static_cast<quint64>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            Clock::now() - start).count());
+}
+
+inline quint64 nextCwTraceId() noexcept
+{
+    static std::atomic<quint64> next{1};
+    return next.fetch_add(1, std::memory_order_relaxed);
+}
+
+} // namespace AetherSDR

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -29,6 +29,7 @@ Q_LOGGING_CATEGORY(lcMqtt,       "aether.mqtt",        QtWarningMsg)
 Q_LOGGING_CATEGORY(lcRbn,        "aether.rbn",         QtWarningMsg)
 Q_LOGGING_CATEGORY(lcDevices,    "aether.devices",     QtWarningMsg)
 Q_LOGGING_CATEGORY(lcPerf,       "aether.perf",        QtWarningMsg)
+Q_LOGGING_CATEGORY(lcCw,         "aether.cw",          QtWarningMsg)
 
 LogManager::LogManager()
 {
@@ -55,6 +56,7 @@ LogManager::LogManager()
         {"aether.devices",    "Ext Devices",  "Serial port, FlexControl, MIDI, HID encoder"},
         {"aether.perf",       "Performance",  "Render timing and CPU profiling data"},
         {"aether.propforecast", "Propagation",  "Solar and propagation forecast updates"},
+        {"aether.cw",         "CW / netCW",    "CW keying, MIDI paddle, iambic, and netCW timing"},
     };
 
     // QLoggingCategory objects are defined above via Q_LOGGING_CATEGORY macros.

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -30,6 +30,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcMqtt)
 Q_DECLARE_LOGGING_CATEGORY(lcRbn)
 Q_DECLARE_LOGGING_CATEGORY(lcDevices)
 Q_DECLARE_LOGGING_CATEGORY(lcPerf)
+Q_DECLARE_LOGGING_CATEGORY(lcCw)
 
 // Central registry for toggling per-module diagnostic logging at runtime.
 // The Support dialog (Help → Support) uses this to let users enable/disable

--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -24,6 +24,16 @@ QString midiMsgTypeName(MidiBinding::MsgType type)
     return QStringLiteral("Unknown");
 }
 
+bool isCwMomentaryParamId(const QString& paramId)
+{
+    return paramId == QLatin1String("cwkey")
+        || paramId == QLatin1String("cwdit")
+        || paramId == QLatin1String("cwdah")
+        || paramId == QLatin1String("cw.key")
+        || paramId == QLatin1String("cw.dit")
+        || paramId == QLatin1String("cw.dah");
+}
+
 } // namespace
 
 // ── MidiBinding helpers ─────────────────────────────────────────────────────
@@ -327,7 +337,7 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2,
     if (it == m_bindingIndex.end()) return;
 
     const auto& binding = m_bindings[it.value()];
-    const bool cwBinding = binding.paramId.startsWith(QStringLiteral("cw."));
+    const bool cwBinding = isCwMomentaryParamId(binding.paramId);
 
     // ── Relative knob mode: decode delta and accumulate ────────────────
     if (binding.relative && msgType == MidiBinding::CC) {

--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -1,6 +1,7 @@
 #ifdef HAVE_MIDI
 
 #include "MidiControlManager.h"
+#include "CwTrace.h"
 #include "LogManager.h"
 
 #include <RtMidi.h>
@@ -9,6 +10,21 @@
 #include <cmath>
 
 namespace AetherSDR {
+
+namespace {
+
+QString midiMsgTypeName(MidiBinding::MsgType type)
+{
+    switch (type) {
+    case MidiBinding::CC:        return QStringLiteral("CC");
+    case MidiBinding::NoteOn:    return QStringLiteral("NoteOn");
+    case MidiBinding::NoteOff:   return QStringLiteral("NoteOff");
+    case MidiBinding::PitchBend: return QStringLiteral("PitchBend");
+    }
+    return QStringLiteral("Unknown");
+}
+
+} // namespace
 
 // ── MidiBinding helpers ─────────────────────────────────────────────────────
 
@@ -193,7 +209,7 @@ void MidiControlManager::cancelLearn()
 
 // ── RtMidi callback → Qt main thread ────────────────────────────────────────
 
-void MidiControlManager::rtmidiCallback(double /*deltatime*/,
+void MidiControlManager::rtmidiCallback(double deltatime,
                                          std::vector<unsigned char>* message,
                                          void* userData)
 {
@@ -202,15 +218,31 @@ void MidiControlManager::rtmidiCallback(double /*deltatime*/,
     int status = (*message)[0];
     int data1 = (*message)[1];
     int data2 = message->size() > 2 ? (*message)[2] : 0;
+    const quint64 traceId = nextCwTraceId();
+    const quint64 callbackMs = cwTraceNowMs();
+
+    if (lcCw().isDebugEnabled()) {
+        qCDebug(lcCw).noquote().nospace()
+            << "CW MIDI raw trace=" << traceId
+            << " t=" << callbackMs << "ms"
+            << " status=0x" << QString("%1").arg(status, 2, 16, QChar('0')).toUpper()
+            << " data1=" << data1
+            << " data2=" << data2
+            << " rtDeltaMs=" << QString::number(deltatime * 1000.0, 'f', 3);
+    }
 
     // Bridge to Qt main thread
-    QMetaObject::invokeMethod(self, [self, status, data1, data2]() {
-        self->onMidiMessage(status, data1, data2);
+    QMetaObject::invokeMethod(self, [self, status, data1, data2,
+                                     traceId, callbackMs, deltatime]() {
+        self->onMidiMessage(status, data1, data2, traceId, callbackMs, deltatime);
     }, Qt::QueuedConnection);
 }
 
-void MidiControlManager::onMidiMessage(int status, int data1, int data2)
+void MidiControlManager::onMidiMessage(int status, int data1, int data2,
+                                       quint64 traceId, quint64 midiCallbackMs,
+                                       double rtDeltaSeconds)
 {
+    const quint64 dispatchMs = cwTraceNowMs();
     int channel = status & 0x0F;
     int type = status & 0xF0;
 
@@ -234,6 +266,18 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2)
         normValue = (data1 | (data2 << 7)) / 16383.0f;
     } else {
         return; // ignore other message types
+    }
+
+    if (lcCw().isDebugEnabled()) {
+        qCDebug(lcCw).noquote().nospace()
+            << "CW MIDI dispatch trace=" << traceId
+            << " t=" << dispatchMs << "ms"
+            << " queueLagMs=" << static_cast<qint64>(dispatchMs - midiCallbackMs)
+            << " ch=" << (channel + 1)
+            << " type=" << midiMsgTypeName(msgType)
+            << " number=" << number
+            << " norm=" << QString::number(normValue, 'f', 3)
+            << " rtDeltaMs=" << QString::number(rtDeltaSeconds * 1000.0, 'f', 3);
     }
 
     emit midiActivity(channel, static_cast<int>(msgType), number,
@@ -283,6 +327,7 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2)
     if (it == m_bindingIndex.end()) return;
 
     const auto& binding = m_bindings[it.value()];
+    const bool cwBinding = binding.paramId.startsWith(QStringLiteral("cw."));
 
     // ── Relative knob mode: decode delta and accumulate ────────────────
     if (binding.relative && msgType == MidiBinding::CC) {
@@ -330,9 +375,21 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2)
             scaled = normValue > 0.0f ? 1.0f : 0.0f;
         }
 
+        if (cwBinding && lcCw().isDebugEnabled()) {
+            qCDebug(lcCw).noquote().nospace()
+                << "CW MIDI binding trace=" << traceId
+                << " t=" << cwTraceNowMs() << "ms"
+                << " param=" << binding.paramId
+                << " source=\"" << binding.sourceDisplayName() << "\""
+                << " value=" << QString::number(value, 'f', 3)
+                << " scaled=" << QString::number(scaled, 'f', 3)
+                << " callbackLagMs=" << static_cast<qint64>(cwTraceNowMs() - midiCallbackMs);
+        }
+
         // Don't call setter directly — may be on a worker thread while
         // setters access main-thread objects. Emit signal instead. (#502)
         emit paramAction(binding.paramId, scaled);
+        emit paramActionTrace(binding.paramId, scaled, traceId, midiCallbackMs, dispatchMs);
     }
 
     emit paramValueChanged(binding.paramId, value);

--- a/src/core/MidiControlManager.h
+++ b/src/core/MidiControlManager.h
@@ -98,6 +98,9 @@ signals:
     // Emitted with the final scaled value for MainWindow to dispatch
     // the setter on the main thread. (#502)
     void paramAction(const QString& paramId, float scaledValue);
+    void paramActionTrace(const QString& paramId, float scaledValue,
+                          quint64 traceId, quint64 midiCallbackMs,
+                          quint64 midiDispatchMs);
     // Emitted for relative knobs: accumulated steps with acceleration.
     // Positive = clockwise, negative = counter-clockwise.
     void relativeAction(const QString& paramId, int steps);
@@ -108,7 +111,9 @@ private:
     static void rtmidiCallback(double deltatime,
                                std::vector<unsigned char>* message,
                                void* userData);
-    void onMidiMessage(int status, int data1, int data2);
+    void onMidiMessage(int status, int data1, int data2,
+                       quint64 traceId, quint64 midiCallbackMs,
+                       double rtDeltaSeconds);
 
     std::unique_ptr<RtMidiIn> m_midiIn;
     QString m_portName;

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -11,6 +11,21 @@
 
 namespace AetherSDR {
 
+namespace {
+
+QString normalizedMidiParamId(const QString& paramId)
+{
+    if (paramId == QLatin1String("cw.key"))
+        return QStringLiteral("cwkey");
+    if (paramId == QLatin1String("cw.dit"))
+        return QStringLiteral("cwdit");
+    if (paramId == QLatin1String("cw.dah"))
+        return QStringLiteral("cwdah");
+    return paramId;
+}
+
+} // namespace
+
 MidiSettings& MidiSettings::instance()
 {
     static MidiSettings s;
@@ -73,7 +88,7 @@ void MidiSettings::save()
     xml.writeStartElement("Bindings");
     for (const auto& b : bindings) {
         xml.writeStartElement("Binding");
-        xml.writeAttribute("param", b.paramId);
+        xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
         xml.writeAttribute("channel", QString::number(b.channel));
         xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
         xml.writeAttribute("number", QString::number(b.number));
@@ -114,7 +129,7 @@ void MidiSettings::saveBindings(const QVector<MidiBinding>& bindings)
     xml.writeStartElement("Bindings");
     for (const auto& b : bindings) {
         xml.writeStartElement("Binding");
-        xml.writeAttribute("param", b.paramId);
+        xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
         xml.writeAttribute("channel", QString::number(b.channel));
         xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
         xml.writeAttribute("number", QString::number(b.number));
@@ -139,7 +154,7 @@ QVector<MidiBinding> MidiSettings::parseBindingsFromXml(const QString& filePath)
         xml.readNext();
         if (xml.isStartElement() && xml.name() == u"Binding") {
             MidiBinding b;
-            b.paramId  = xml.attributes().value("param").toString();
+            b.paramId  = normalizedMidiParamId(xml.attributes().value("param").toString());
             b.channel  = xml.attributes().value("channel").toInt();
             b.msgType  = static_cast<MidiBinding::MsgType>(
                              xml.attributes().value("type").toInt());
@@ -166,7 +181,7 @@ void MidiSettings::writeBindingsToXml(const QString& filePath,
     xml.writeStartElement("MidiProfile");
     for (const auto& b : bindings) {
         xml.writeStartElement("Binding");
-        xml.writeAttribute("param", b.paramId);
+        xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
         xml.writeAttribute("channel", QString::number(b.channel));
         xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
         xml.writeAttribute("number", QString::number(b.number));

--- a/src/core/ShortcutManager.cpp
+++ b/src/core/ShortcutManager.cpp
@@ -66,7 +66,7 @@ void ShortcutManager::loadBindings()
 {
     auto& s = AppSettings::instance();
     for (auto& a : m_actions) {
-        QString key = QString("Shortcut_%1").arg(a.id);
+        const QString key = QStringLiteral("Shortcut_%1").arg(a.id);
         QString val = s.value(key).toString();
         if (!val.isNull())
             a.currentKey = QKeySequence(val);
@@ -112,8 +112,10 @@ void ShortcutManager::loadBindings()
 void ShortcutManager::saveBindings()
 {
     auto& s = AppSettings::instance();
-    for (const auto& a : m_actions)
-        s.setValue(QString("Shortcut_%1").arg(a.id), a.currentKey.toString());
+    for (const auto& a : m_actions) {
+        const QString key = QStringLiteral("Shortcut_%1").arg(a.id);
+        s.setValue(key, a.currentKey.toString());
+    }
     s.save();
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -111,6 +111,7 @@
 #include <QPropertyAnimation>
 #include <QIcon>
 #include <QKeyEvent>
+#include <QMouseEvent>
 #include <QHelpEvent>
 #include <QWindow>
 #include <QPixmap>
@@ -416,9 +417,22 @@ static QString buildNetworkTooltip(const RadioModel& model)
 static constexpr const char* kPaTempUnitSettingKey = "PaTempDisplayUnit";
 static constexpr int kMemorySpotIdBase = 1000000;
 static constexpr int kPassiveSpotIdBase = 2000000;
+static constexpr const char* kCwStraightKeyActionId = "cwkey";
+static constexpr const char* kCwLeftPaddleActionId = "cwdit";
+static constexpr const char* kCwRightPaddleActionId = "cwdah";
+static constexpr const char* kCwStraightKeyActionName = "Trigger straight key";
+static constexpr const char* kCwLeftPaddleActionName = "Trigger CW Left Paddle";
+static constexpr const char* kCwRightPaddleActionName = "Trigger CW Right Paddle";
 
 static bool s_keyboardShortcutsEnabled = false;
 static bool s_sliderShortcutLeaseActive = false;
+
+static bool isCwMomentaryActionId(const QString& id)
+{
+    return id == QLatin1String(kCwStraightKeyActionId)
+        || id == QLatin1String(kCwLeftPaddleActionId)
+        || id == QLatin1String(kCwRightPaddleActionId);
+}
 
 static int memorySpotId(int memoryIndex)
 {
@@ -492,6 +506,19 @@ static bool shortcutInputCaptured()
 
 static bool shortcutGuard() {
     return s_keyboardShortcutsEnabled && !shortcutInputCaptured();
+}
+
+static QKeySequence shortcutSequenceFromKeyEvent(const QKeyEvent* ev)
+{
+    if (!ev || ev->key() == Qt::Key_unknown)
+        return {};
+
+    const Qt::KeyboardModifiers modifiers =
+        ev->modifiers() & (Qt::ShiftModifier
+                           | Qt::ControlModifier
+                           | Qt::AltModifier
+                           | Qt::MetaModifier);
+    return QKeySequence(static_cast<int>(modifiers) | ev->key());
 }
 
 static QStringList splitClientField(const QString& raw)
@@ -1834,8 +1861,6 @@ MainWindow::MainWindow(QWidget* parent)
         };
         connect(&m_radioModel.transmitModel(), &TransmitModel::phoneStateChanged,
                 this, syncLocalKeyerToRadio);
-        // Initial sync once the radio reports its state.
-        syncLocalKeyerToRadio();
 
         // Mirror the radio's CW state into the local sidetone generator —
         // sidetone enable, volume (mon_gain_cw), and pitch all follow the
@@ -1885,20 +1910,20 @@ MainWindow::MainWindow(QWidget* parent)
             // would have produced from a hardware paddle.
             if (m_audio && m_audio->cwSidetone())
                 m_audio->cwSidetone()->setKeyDown(down);
-            const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
-            const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+            const quint64 traceId = m_lastCwPaddleTraceId.load(std::memory_order_relaxed);
+            const quint64 sourceMs = m_lastCwPaddleSourceMs.load(std::memory_order_relaxed);
             if (lcCw().isDebugEnabled()) {
                 const quint64 now = cwTraceNowMs();
                 qCDebug(lcCw).noquote().nospace()
                     << "CW iambic key-edge trace=" << traceId
                     << " t=" << now << "ms"
-                    << " sinceMidiMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+                    << " sinceSourceMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
                     << " down=" << down;
             }
             QMetaObject::invokeMethod(this, [this, down]() {
-                const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
-                const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
-                m_radioModel.sendCwKeyEdge(down, QStringLiteral("midi:iambic-keyer"),
+                const quint64 traceId = m_lastCwPaddleTraceId.load(std::memory_order_relaxed);
+                const quint64 sourceMs = m_lastCwPaddleSourceMs.load(std::memory_order_relaxed);
+                m_radioModel.sendCwKeyEdge(down, QStringLiteral("cw:iambic-keyer"),
                                            traceId, sourceMs);
             }, Qt::QueuedConnection);
         });
@@ -1907,27 +1932,28 @@ MainWindow::MainWindow(QWidget* parent)
             // press/release, not one per element, so the radio doesn't
             // thrash through TX/RX gates between dits.
             const bool active = dit || dah;
-            const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
-            const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+            const quint64 traceId = m_lastCwPaddleTraceId.load(std::memory_order_relaxed);
+            const quint64 sourceMs = m_lastCwPaddleSourceMs.load(std::memory_order_relaxed);
             if (lcCw().isDebugEnabled()) {
                 const quint64 now = cwTraceNowMs();
                 qCDebug(lcCw).noquote().nospace()
                     << "CW iambic paddle-event trace=" << traceId
                     << " t=" << now << "ms"
-                    << " sinceMidiMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+                    << " sinceSourceMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
                     << " dit=" << dit
                     << " dah=" << dah
                     << " ptt=" << active;
             }
             QMetaObject::invokeMethod(this, [this, active]() {
-                const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
-                const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
-                m_radioModel.sendCwPtt(active, QStringLiteral("midi:iambic-keyer"),
+                const quint64 traceId = m_lastCwPaddleTraceId.load(std::memory_order_relaxed);
+                const quint64 sourceMs = m_lastCwPaddleSourceMs.load(std::memory_order_relaxed);
+                m_radioModel.sendCwPtt(active, QStringLiteral("cw:iambic-keyer"),
                                        traceId, sourceMs);
             }, Qt::QueuedConnection);
         });
-        // Mode/WPM/start are driven by the radio's iambic state — see
-        // syncLocalKeyerToRadio below.
+        // Initial sync after callbacks are installed. Without this, the
+        // default/radio-reported iambic-on state may never emit a change.
+        syncLocalKeyerToRadio();
     }
 
     // TX/RX transition → waterfall tile source switching
@@ -2833,8 +2859,8 @@ MainWindow::MainWindow(QWidget* parent)
     });
     connect(m_serialPort, &SerialPortController::cwPaddleChanged,
             this, [this](bool dit, bool dah) {
-        m_lastCwMidiTraceId.store(0, std::memory_order_relaxed);
-        m_lastCwMidiSourceMs.store(0, std::memory_order_relaxed);
+        m_lastCwPaddleTraceId.store(0, std::memory_order_relaxed);
+        m_lastCwPaddleSourceMs.store(0, std::memory_order_relaxed);
         // When the local iambic keyer is running, feed it the raw paddle
         // state — it forwards to the radio AND drives the sidetone gate
         // directly.  Otherwise pass straight through to the radio (radio's
@@ -2990,7 +3016,7 @@ MainWindow::MainWindow(QWidget* parent)
         auto it = m_midiSetters.find(paramId);
         if (it == m_midiSetters.end()) return;
         const quint64 mainMs = cwTraceNowMs();
-        if (paramId.startsWith(QStringLiteral("cw.")) && lcCw().isDebugEnabled()) {
+        if (isCwMomentaryActionId(paramId) && lcCw().isDebugEnabled()) {
             qCDebug(lcCw).noquote().nospace()
                 << "CW MIDI main trace=" << traceId
                 << " t=" << mainMs << "ms"
@@ -4413,6 +4439,177 @@ void MainWindow::keyReleaseEvent(QKeyEvent* event)
     QMainWindow::keyReleaseEvent(event);
 }
 
+void MainWindow::cancelTransmitFromIndicator()
+{
+    if (!m_radioModel.isConnected()) {
+        statusBar()->showMessage("TX cancel ignored: not connected", 2000);
+        return;
+    }
+
+    const quint32 owner = m_radioModel.txClientHandle();
+    const quint32 ours = m_radioModel.ourClientHandle();
+    if (owner != 0 && ours != 0 && owner != ours
+        && !m_radioModel.transmitModel().isTransmitting()) {
+        statusBar()->showMessage("TX is owned by another station", 2500);
+        return;
+    }
+
+    m_spacePttActive = false;
+    m_cwStraightKeyActive = false;
+    m_cwLeftPaddleActive = false;
+    m_cwRightPaddleActive = false;
+    m_lastCwPaddleTraceId.store(0, std::memory_order_relaxed);
+    m_lastCwPaddleSourceMs.store(0, std::memory_order_relaxed);
+
+    if (m_iambicKeyer && m_iambicKeyer->isRunning()) {
+        m_iambicKeyer->setPaddleState(false, false);
+        m_iambicKeyer->reset();
+    }
+    if (m_audio && m_audio->cwSidetone())
+        m_audio->cwSidetone()->setKeyDown(false);
+
+    const quint64 sourceMs = cwTraceNowMs();
+    const quint64 traceId = nextCwTraceId();
+    const QString source = QStringLiteral("tx-indicator:cancel");
+    m_radioModel.sendCwKey(false, source, traceId, sourceMs);
+    m_radioModel.sendCwPtt(false, source, traceId, sourceMs);
+    m_radioModel.transmitModel().stopTune();
+    m_radioModel.setTransmit(false);
+
+    statusBar()->showMessage("TX cancel requested", 2000);
+}
+
+void MainWindow::setCwStraightKeyState(bool down, const QString& source,
+                                       quint64 traceId, quint64 sourceMs)
+{
+    if (m_cwStraightKeyActive == down)
+        return;
+
+    m_cwStraightKeyActive = down;
+    const QString actionSource = source.isEmpty()
+        ? QStringLiteral("cw:straight-key")
+        : source;
+
+    if (lcCw().isDebugEnabled()) {
+        const quint64 now = cwTraceNowMs();
+        qCDebug(lcCw).noquote().nospace()
+            << "CW action straight-key trace=" << traceId
+            << " t=" << now << "ms"
+            << " sinceSourceMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+            << " source=" << actionSource
+            << " down=" << down;
+    }
+
+    m_radioModel.sendCwKey(down, actionSource, traceId, sourceMs);
+}
+
+void MainWindow::setCwLeftPaddleState(bool down, const QString& source,
+                                      quint64 traceId, quint64 sourceMs)
+{
+    if (m_cwLeftPaddleActive == down)
+        return;
+
+    m_cwLeftPaddleActive = down;
+    pushCwPaddleState(source.isEmpty() ? QStringLiteral("cw:left-paddle") : source,
+                      traceId, sourceMs);
+}
+
+void MainWindow::setCwRightPaddleState(bool down, const QString& source,
+                                       quint64 traceId, quint64 sourceMs)
+{
+    if (m_cwRightPaddleActive == down)
+        return;
+
+    m_cwRightPaddleActive = down;
+    pushCwPaddleState(source.isEmpty() ? QStringLiteral("cw:right-paddle") : source,
+                      traceId, sourceMs);
+}
+
+void MainWindow::pushCwPaddleState(const QString& source,
+                                   quint64 traceId, quint64 sourceMs)
+{
+    const QString actionSource = source.isEmpty()
+        ? QStringLiteral("cw:paddle")
+        : source;
+
+    m_lastCwPaddleTraceId.store(traceId, std::memory_order_relaxed);
+    m_lastCwPaddleSourceMs.store(sourceMs, std::memory_order_relaxed);
+
+    if (lcCw().isDebugEnabled()) {
+        const quint64 now = cwTraceNowMs();
+        qCDebug(lcCw).noquote().nospace()
+            << "CW action paddle trace=" << traceId
+            << " t=" << now << "ms"
+            << " sinceSourceMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+            << " source=" << actionSource
+            << " leftDit=" << m_cwLeftPaddleActive
+            << " rightDah=" << m_cwRightPaddleActive
+            << " localIambic=" << (m_iambicKeyer && m_iambicKeyer->isRunning());
+    }
+
+    if (m_iambicKeyer && m_iambicKeyer->isRunning()) {
+        m_iambicKeyer->setPaddleState(m_cwLeftPaddleActive, m_cwRightPaddleActive);
+    } else {
+        m_radioModel.sendCwPaddle(m_cwLeftPaddleActive, m_cwRightPaddleActive,
+                                  actionSource, traceId, sourceMs);
+    }
+}
+
+bool MainWindow::handleCwMomentaryShortcut(QKeyEvent* keyEvent, QEvent::Type eventType)
+{
+    if (!keyEvent || keyEvent->isAutoRepeat())
+        return false;
+    if (eventType != QEvent::KeyPress && eventType != QEvent::KeyRelease)
+        return false;
+
+    const QKeySequence seq = shortcutSequenceFromKeyEvent(keyEvent);
+    const auto* action = m_shortcutManager.actionForKey(seq);
+    if (!action)
+        return false;
+
+    enum class CwAction { None, StraightKey, LeftPaddle, RightPaddle };
+    CwAction cwAction = CwAction::None;
+    if (action->id == QLatin1String(kCwStraightKeyActionId))
+        cwAction = CwAction::StraightKey;
+    else if (action->id == QLatin1String(kCwLeftPaddleActionId))
+        cwAction = CwAction::LeftPaddle;
+    else if (action->id == QLatin1String(kCwRightPaddleActionId))
+        cwAction = CwAction::RightPaddle;
+    else
+        return false;
+
+    const bool press = eventType == QEvent::KeyPress;
+    const bool currentlyActive =
+        cwAction == CwAction::StraightKey ? m_cwStraightKeyActive :
+        cwAction == CwAction::LeftPaddle ? m_cwLeftPaddleActive :
+                                           m_cwRightPaddleActive;
+
+    if (press && (!m_keyboardShortcutsEnabled || shortcutInputCaptured()))
+        return false;
+    if (!press && !currentlyActive)
+        return m_keyboardShortcutsEnabled && !shortcutInputCaptured();
+
+    const quint64 sourceMs = cwTraceNowMs();
+    const quint64 traceId = nextCwTraceId();
+    const bool down = press;
+
+    switch (cwAction) {
+    case CwAction::StraightKey:
+        setCwStraightKeyState(down, QStringLiteral("keyboard:cwkey"), traceId, sourceMs);
+        break;
+    case CwAction::LeftPaddle:
+        setCwLeftPaddleState(down, QStringLiteral("keyboard:cwdit"), traceId, sourceMs);
+        break;
+    case CwAction::RightPaddle:
+        setCwRightPaddleState(down, QStringLiteral("keyboard:cwdah"), traceId, sourceMs);
+        break;
+    case CwAction::None:
+        break;
+    }
+
+    return true;
+}
+
 void MainWindow::showNetworkDiagnosticsDialog()
 {
     if (!m_networkDiagnosticsDialog) {
@@ -4767,6 +4964,10 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
             }
             return true;
         }
+
+        if (handleCwMomentaryShortcut(ke, event->type()))
+            return true;
+
         if (ke->key() == Qt::Key_Space && !ke->isAutoRepeat()
             && !shortcutInputCaptured()
             && m_radioModel.isConnected()) {
@@ -4928,6 +5129,12 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
     if (obj == m_pgxlIndicator && event->type() == QEvent::MouseButtonPress) {
         // Simple toggle: OPERATE ↔ STANDBY (PGXL has no BYPASS)
         m_radioModel.setAmpOperate(!m_radioModel.ampOperate());
+        return true;
+    }
+    if (obj == m_txIndicator && event->type() == QEvent::MouseButtonPress) {
+        auto* mouseEvent = static_cast<QMouseEvent*>(event);
+        if (mouseEvent->button() == Qt::LeftButton)
+            cancelTransmitFromIndicator();
         return true;
     }
     if (obj == m_panelToggle && event->type() == QEvent::MouseButtonPress) {
@@ -7013,6 +7220,11 @@ void MainWindow::buildUI()
     m_txIndicator = new QLabel("TX");
     m_txIndicator->setFixedSize(36, 36);
     m_txIndicator->setAlignment(Qt::AlignCenter);
+    m_txIndicator->setCursor(Qt::PointingHandCursor);
+    m_txIndicator->setToolTip("Click to cancel TX");
+    m_txIndicator->setAccessibleName("Cancel transmit");
+    m_txIndicator->setAccessibleDescription("Click to send key up, PTT off, Tune off, and MOX off.");
+    m_txIndicator->installEventFilter(this);
     m_txIndicator->setStyleSheet("QLabel { color: rgba(255,255,255,128); font-weight: bold; font-size: 21px; }");
     hbox->addWidget(m_txIndicator);
 
@@ -10489,6 +10701,14 @@ void MainWindow::registerShortcutActions()
             auto& tx = m_radioModel.transmitModel();
             tx.setCwBreakIn(!tx.cwBreakIn());
         });
+    // Momentary CW actions are handled by the app-level event filter so
+    // key release edges reach the netCW path too.
+    m_shortcutManager.registerAction(kCwStraightKeyActionId, kCwStraightKeyActionName, "CW",
+        QKeySequence(), nullptr);
+    m_shortcutManager.registerAction(kCwLeftPaddleActionId, kCwLeftPaddleActionName, "CW",
+        QKeySequence(), nullptr);
+    m_shortcutManager.registerAction(kCwRightPaddleActionId, kCwRightPaddleActionName, "CW",
+        QKeySequence(), nullptr);
 
     // ── EQ ──────────────────────────────────────────────────────────────
     m_shortcutManager.registerAction("tx_eq_toggle", "TX EQ Toggle", "EQ",
@@ -12458,69 +12678,32 @@ void MainWindow::registerMidiParams()
         [this](float v) { m_radioModel.transmitModel().setCwBreakIn(v > 0.5f); },
         [this]() -> float { return m_radioModel.transmitModel().cwBreakIn() ? 1 : 0; });
 
-    reg("cw.key", "CW Key (straight)", "Phone/CW", P::Gate, 0, 1,
+    reg(kCwStraightKeyActionId, kCwStraightKeyActionName, "Phone/CW", P::Gate, 0, 1,
         [this](float v) {
-            const bool down = v > 0.5f;
-            if (lcCw().isDebugEnabled()) {
-                const quint64 now = cwTraceNowMs();
-                qCDebug(lcCw).noquote().nospace()
-                    << "CW MIDI straight-key trace=" << m_currentMidiTrace.traceId
-                    << " t=" << now << "ms"
-                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
-                        ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
-                    << " down=" << down;
-            }
-            m_radioModel.sendCwKey(down, QStringLiteral("midi:cw.key"),
-                                   m_currentMidiTrace.traceId,
-                                   m_currentMidiTrace.callbackMs);
+            setCwStraightKeyState(v > 0.5f, QStringLiteral("midi:cwkey"),
+                                  m_currentMidiTrace.traceId,
+                                  m_currentMidiTrace.callbackMs);
         });
 
-    // Iambic paddle: dit and dah are separate MIDI notes.
+    // Iambic paddle: left and right are separate momentary actions.
     // When the local iambic keyer is running, paddle states feed into it
     // (drives sidetone with sub-5 ms latency, then forwards to radio).
     // Otherwise pass straight to the radio's RF iambic engine.
-    {
-        auto dit = std::make_shared<bool>(false);
-        auto dah = std::make_shared<bool>(false);
+    reg(kCwLeftPaddleActionId, kCwLeftPaddleActionName, "Phone/CW", P::Gate, 0, 1,
+        [this](float v) {
+            setCwLeftPaddleState(v > 0.5f, QStringLiteral("midi:cwdit"),
+                                 m_currentMidiTrace.traceId,
+                                 m_currentMidiTrace.callbackMs);
+        },
+        [this]() -> float { return m_cwLeftPaddleActive ? 1.0f : 0.0f; });
 
-        auto pushPaddle = [this, dit, dah]() {
-            m_lastCwMidiTraceId.store(m_currentMidiTrace.traceId, std::memory_order_relaxed);
-            m_lastCwMidiSourceMs.store(m_currentMidiTrace.callbackMs, std::memory_order_relaxed);
-            if (lcCw().isDebugEnabled()) {
-                const quint64 now = cwTraceNowMs();
-                qCDebug(lcCw).noquote().nospace()
-                    << "CW MIDI paddle trace=" << m_currentMidiTrace.traceId
-                    << " t=" << now << "ms"
-                    << " param=" << m_currentMidiTrace.paramId
-                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
-                        ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
-                    << " dit=" << *dit
-                    << " dah=" << *dah
-                    << " localIambic=" << (m_iambicKeyer && m_iambicKeyer->isRunning());
-            }
-            if (m_iambicKeyer && m_iambicKeyer->isRunning()) {
-                m_iambicKeyer->setPaddleState(*dit, *dah);
-            } else {
-                m_radioModel.sendCwPaddle(*dit, *dah, QStringLiteral("midi:cw.paddle"),
-                                          m_currentMidiTrace.traceId,
-                                          m_currentMidiTrace.callbackMs);
-            }
-        };
-
-        reg("cw.dit", "CW Paddle Dit", "Phone/CW", P::Gate, 0, 1,
-            [dit, pushPaddle](float v) {
-                *dit = (v > 0.5f);
-                pushPaddle();
-            },
-            [dit]() -> float { return *dit ? 1.0f : 0.0f; });
-
-        reg("cw.dah", "CW Paddle Dah", "Phone/CW", P::Gate, 0, 1,
-            [dah, pushPaddle](float v) {
-                *dah = (v > 0.5f);
-                pushPaddle();
-            },
-            [dah]() -> float { return *dah ? 1.0f : 0.0f; });
-    }
+    reg(kCwRightPaddleActionId, kCwRightPaddleActionName, "Phone/CW", P::Gate, 0, 1,
+        [this](float v) {
+            setCwRightPaddleState(v > 0.5f, QStringLiteral("midi:cwdah"),
+                                  m_currentMidiTrace.traceId,
+                                  m_currentMidiTrace.callbackMs);
+        },
+        [this]() -> float { return m_cwRightPaddleActive ? 1.0f : 0.0f; });
 
     reg("cw.ptt", "PTT (hold)", "Phone/CW", P::Gate, 0, 1,
         [this](float v) {
@@ -12530,7 +12713,7 @@ void MainWindow::registerMidiParams()
                 qCDebug(lcCw).noquote().nospace()
                     << "CW MIDI ptt trace=" << m_currentMidiTrace.traceId
                     << " t=" << now << "ms"
-                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
+                    << " sinceSourceMs=" << (m_currentMidiTrace.callbackMs
                         ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
                     << " mox=" << on;
             }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -52,6 +52,7 @@
 #include "core/ClientTube.h"
 #include "core/ClientPudu.h"
 #include "core/ClientReverb.h"
+#include "core/CwTrace.h"
 #include "core/CwSidetoneGenerator.h"
 #include "core/CwxLocalKeyer.h"
 #include "core/IambicKeyer.h"
@@ -1884,8 +1885,21 @@ MainWindow::MainWindow(QWidget* parent)
             // would have produced from a hardware paddle.
             if (m_audio && m_audio->cwSidetone())
                 m_audio->cwSidetone()->setKeyDown(down);
+            const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
+            const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+            if (lcCw().isDebugEnabled()) {
+                const quint64 now = cwTraceNowMs();
+                qCDebug(lcCw).noquote().nospace()
+                    << "CW iambic key-edge trace=" << traceId
+                    << " t=" << now << "ms"
+                    << " sinceMidiMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+                    << " down=" << down;
+            }
             QMetaObject::invokeMethod(this, [this, down]() {
-                m_radioModel.sendCwKeyEdge(down);
+                const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
+                const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+                m_radioModel.sendCwKeyEdge(down, QStringLiteral("midi:iambic-keyer"),
+                                           traceId, sourceMs);
             }, Qt::QueuedConnection);
         });
         m_iambicKeyer->setOnPaddleEvent([this](bool dit, bool dah) {
@@ -1893,8 +1907,23 @@ MainWindow::MainWindow(QWidget* parent)
             // press/release, not one per element, so the radio doesn't
             // thrash through TX/RX gates between dits.
             const bool active = dit || dah;
+            const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
+            const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+            if (lcCw().isDebugEnabled()) {
+                const quint64 now = cwTraceNowMs();
+                qCDebug(lcCw).noquote().nospace()
+                    << "CW iambic paddle-event trace=" << traceId
+                    << " t=" << now << "ms"
+                    << " sinceMidiMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+                    << " dit=" << dit
+                    << " dah=" << dah
+                    << " ptt=" << active;
+            }
             QMetaObject::invokeMethod(this, [this, active]() {
-                m_radioModel.sendCwPtt(active);
+                const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
+                const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+                m_radioModel.sendCwPtt(active, QStringLiteral("midi:iambic-keyer"),
+                                       traceId, sourceMs);
             }, Qt::QueuedConnection);
         });
         // Mode/WPM/start are driven by the radio's iambic state — see
@@ -2804,6 +2833,8 @@ MainWindow::MainWindow(QWidget* parent)
     });
     connect(m_serialPort, &SerialPortController::cwPaddleChanged,
             this, [this](bool dit, bool dah) {
+        m_lastCwMidiTraceId.store(0, std::memory_order_relaxed);
+        m_lastCwMidiSourceMs.store(0, std::memory_order_relaxed);
         // When the local iambic keyer is running, feed it the raw paddle
         // state — it forwards to the radio AND drives the sidetone gate
         // directly.  Otherwise pass straight through to the radio (radio's
@@ -2950,11 +2981,25 @@ MainWindow::MainWindow(QWidget* parent)
     // main-thread dispatch. Param metadata still registered on the manager.
     registerMidiParams();
 
-    // MIDI paramAction signal: dispatches setter on main thread (#502)
-    connect(m_midiControl, &MidiControlManager::paramAction,
-            this, [this](const QString& paramId, float scaledValue) {
+    // MIDI paramActionTrace signal: dispatches setter on main thread (#502)
+    // and carries timing metadata for CW/netCW diagnostics.
+    connect(m_midiControl, &MidiControlManager::paramActionTrace,
+            this, [this](const QString& paramId, float scaledValue,
+                         quint64 traceId, quint64 midiCallbackMs,
+                         quint64 midiDispatchMs) {
         auto it = m_midiSetters.find(paramId);
         if (it == m_midiSetters.end()) return;
+        const quint64 mainMs = cwTraceNowMs();
+        if (paramId.startsWith(QStringLiteral("cw.")) && lcCw().isDebugEnabled()) {
+            qCDebug(lcCw).noquote().nospace()
+                << "CW MIDI main trace=" << traceId
+                << " t=" << mainMs << "ms"
+                << " param=" << paramId
+                << " callbackToMainMs=" << static_cast<qint64>(mainMs - midiCallbackMs)
+                << " dispatchToMainMs=" << static_cast<qint64>(mainMs - midiDispatchMs)
+                << " scaled=" << QString::number(scaledValue, 'f', 3);
+        }
+        m_currentMidiTrace = {paramId, traceId, midiCallbackMs, midiDispatchMs};
         if (scaledValue == -1.0f) {
             // Toggle sentinel: read getter, flip, call setter
             auto git = m_midiGetters.find(paramId);
@@ -2963,6 +3008,7 @@ MainWindow::MainWindow(QWidget* parent)
         } else {
             it.value()(scaledValue);
         }
+        m_currentMidiTrace = {};
     });
 
     // MIDI relativeAction signal: coalesced step-based tuning with acceleration
@@ -12413,7 +12459,21 @@ void MainWindow::registerMidiParams()
         [this]() -> float { return m_radioModel.transmitModel().cwBreakIn() ? 1 : 0; });
 
     reg("cw.key", "CW Key (straight)", "Phone/CW", P::Gate, 0, 1,
-        [this](float v) { m_radioModel.sendCwKey(v > 0.5f); });
+        [this](float v) {
+            const bool down = v > 0.5f;
+            if (lcCw().isDebugEnabled()) {
+                const quint64 now = cwTraceNowMs();
+                qCDebug(lcCw).noquote().nospace()
+                    << "CW MIDI straight-key trace=" << m_currentMidiTrace.traceId
+                    << " t=" << now << "ms"
+                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
+                        ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
+                    << " down=" << down;
+            }
+            m_radioModel.sendCwKey(down, QStringLiteral("midi:cw.key"),
+                                   m_currentMidiTrace.traceId,
+                                   m_currentMidiTrace.callbackMs);
+        });
 
     // Iambic paddle: dit and dah are separate MIDI notes.
     // When the local iambic keyer is running, paddle states feed into it
@@ -12424,10 +12484,26 @@ void MainWindow::registerMidiParams()
         auto dah = std::make_shared<bool>(false);
 
         auto pushPaddle = [this, dit, dah]() {
+            m_lastCwMidiTraceId.store(m_currentMidiTrace.traceId, std::memory_order_relaxed);
+            m_lastCwMidiSourceMs.store(m_currentMidiTrace.callbackMs, std::memory_order_relaxed);
+            if (lcCw().isDebugEnabled()) {
+                const quint64 now = cwTraceNowMs();
+                qCDebug(lcCw).noquote().nospace()
+                    << "CW MIDI paddle trace=" << m_currentMidiTrace.traceId
+                    << " t=" << now << "ms"
+                    << " param=" << m_currentMidiTrace.paramId
+                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
+                        ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
+                    << " dit=" << *dit
+                    << " dah=" << *dah
+                    << " localIambic=" << (m_iambicKeyer && m_iambicKeyer->isRunning());
+            }
             if (m_iambicKeyer && m_iambicKeyer->isRunning()) {
                 m_iambicKeyer->setPaddleState(*dit, *dah);
             } else {
-                m_radioModel.sendCwPaddle(*dit, *dah);
+                m_radioModel.sendCwPaddle(*dit, *dah, QStringLiteral("midi:cw.paddle"),
+                                          m_currentMidiTrace.traceId,
+                                          m_currentMidiTrace.callbackMs);
             }
         };
 
@@ -12447,7 +12523,19 @@ void MainWindow::registerMidiParams()
     }
 
     reg("cw.ptt", "PTT (hold)", "Phone/CW", P::Gate, 0, 1,
-        [this](float v) { m_radioModel.setTransmit(v > 0.5f); });
+        [this](float v) {
+            const bool on = v > 0.5f;
+            if (lcCw().isDebugEnabled()) {
+                const quint64 now = cwTraceNowMs();
+                qCDebug(lcCw).noquote().nospace()
+                    << "CW MIDI ptt trace=" << m_currentMidiTrace.traceId
+                    << " t=" << now << "ms"
+                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
+                        ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
+                    << " mox=" << on;
+            }
+            m_radioModel.setTransmit(on);
+        });
 
     // ── EQ ──────────────────────────────────────────────────────────────
     reg("eq.txEnable", "TX EQ Enable", "EQ", P::Toggle, 0, 1,

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -52,6 +52,7 @@
 #include <QHash>
 #include <QJsonObject>
 #include <QTimer>
+#include <QEvent>
 #include <atomic>
 
 class QAbstractSlider;
@@ -247,6 +248,15 @@ private:
     void clearSwrSweepForBandChange(int sliceId, const QString& panId,
                                     const QString& newBandName);
     SliceModel* swrSweepTargetSlice(int requestedSliceId = -1) const;
+    void setCwStraightKeyState(bool down, const QString& source = {},
+                               quint64 traceId = 0, quint64 sourceMs = 0);
+    void setCwLeftPaddleState(bool down, const QString& source = {},
+                              quint64 traceId = 0, quint64 sourceMs = 0);
+    void setCwRightPaddleState(bool down, const QString& source = {},
+                               quint64 traceId = 0, quint64 sourceMs = 0);
+    void pushCwPaddleState(const QString& source = {},
+                           quint64 traceId = 0, quint64 sourceMs = 0);
+    bool handleCwMomentaryShortcut(QKeyEvent* keyEvent, QEvent::Type eventType);
 
     // Core objects
     RadioDiscovery    m_discovery;
@@ -321,8 +331,6 @@ private:
         quint64 dispatchMs{0};
     };
     MidiActionTrace m_currentMidiTrace;
-    std::atomic<quint64> m_lastCwMidiTraceId{0};
-    std::atomic<quint64> m_lastCwMidiSourceMs{0};
     // MIDI param setters indexed by ID — called on main thread from
     // paramAction signal (worker thread cannot call them directly). (#502)
     QHash<QString, std::function<void(float)>> m_midiSetters;
@@ -417,6 +425,7 @@ private:
     float m_lastPaTempC{0.0f};
     bool m_userDisconnected{false};  // true after explicit disconnect, blocks auto-connect
     QDialog* m_reconnectDlg{nullptr}; // shown on unexpected disconnect, dismissed on reconnect
+    void cancelTransmitFromIndicator();
     class ClientEqEditor* m_clientEqEditor{nullptr}; // lazy — created on first Edit… click
     // Lazy-construct the floating EQ editor on first access, with all
     // bypass-toggled wiring set up once.  Used from every site that
@@ -455,9 +464,14 @@ private:
     QTimer* m_agManualConnectTimer{nullptr}; // deferred AG manual connect — cancelled on disconnect
     class CwxLocalKeyer* m_cwxLocalKeyer{nullptr};  // local Morse keyer for CWX sidetone
     std::unique_ptr<class IambicKeyer> m_iambicKeyer;  // local iambic state machine for paddle sidetone
+    std::atomic<quint64> m_lastCwPaddleTraceId{0};
+    std::atomic<quint64> m_lastCwPaddleSourceMs{0};
     qint64 m_bsConnectGraceUntilMs{0};   // suppress auto-save right after connect
     bool m_keyboardShortcutsEnabled{false}; // global enable for keyboard shortcuts (View menu)
     bool m_spacePttActive{false};          // true while Space is held for PTT
+    bool m_cwStraightKeyActive{false};
+    bool m_cwLeftPaddleActive{false};
+    bool m_cwRightPaddleActive{false};
     QPointer<QAbstractSlider> m_sliderShortcutLease;
     QTimer m_sliderShortcutLeaseTimer;
     struct SwrSweepSample {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -52,6 +52,7 @@
 #include <QHash>
 #include <QJsonObject>
 #include <QTimer>
+#include <atomic>
 
 class QAbstractSlider;
 
@@ -313,6 +314,15 @@ private:
 #ifdef HAVE_MIDI
     MidiControlManager*  m_midiControl{nullptr};
     void registerMidiParams();
+    struct MidiActionTrace {
+        QString paramId;
+        quint64 traceId{0};
+        quint64 callbackMs{0};
+        quint64 dispatchMs{0};
+    };
+    MidiActionTrace m_currentMidiTrace;
+    std::atomic<quint64> m_lastCwMidiTraceId{0};
+    std::atomic<quint64> m_lastCwMidiSourceMs{0};
     // MIDI param setters indexed by ID — called on main thread from
     // paramAction signal (worker thread cannot call them directly). (#502)
     QHash<QString, std::function<void(float)>> m_midiSetters;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1,6 +1,7 @@
 #include "RadioModel.h"
 #include "core/CommandParser.h"
 #include "core/AppSettings.h"
+#include "core/CwTrace.h"
 #include "core/LogManager.h"
 #include "core/StreamStatus.h"
 #include "core/UdpRegistrationPolicy.h"
@@ -729,7 +730,8 @@ QString RadioModel::audioCompressionParam() const
     return isWan() ? "opus" : "none";
 }
 
-void RadioModel::sendCwKey(bool down)
+void RadioModel::sendCwKey(bool down, const QString& debugSource,
+                           quint64 debugTraceId, quint64 debugSourceMs)
 {
     const bool prev = m_cwKeyActive;
     m_cwKeyActive = down;
@@ -738,14 +740,18 @@ void RadioModel::sendCwKey(bool down)
     // `cw ptt 1` the radio queues key events but doesn't transmit when
     // break_in=0 (the default on most user setups).  Pairing PTT with
     // KEY keys reliably regardless of break-in mode.
-    if (down && !prev) sendNetCwCommand(QStringLiteral("cw ptt 1"));
-    sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0));
-    if (!down && prev) sendNetCwCommand(QStringLiteral("cw ptt 0"));
+    if (down && !prev)
+        sendNetCwCommand(QStringLiteral("cw ptt 1"), debugSource, debugTraceId, debugSourceMs);
+    sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
+                     debugSource, debugTraceId, debugSourceMs);
+    if (!down && prev)
+        sendNetCwCommand(QStringLiteral("cw ptt 0"), debugSource, debugTraceId, debugSourceMs);
     if (prev != down)
         emit cwKeyDownChanged(down);
 }
 
-void RadioModel::sendCwPaddle(bool dit, bool dah)
+void RadioModel::sendCwPaddle(bool dit, bool dah, const QString& debugSource,
+                              quint64 debugTraceId, quint64 debugSourceMs)
 {
     // The radio's CW protocol does NOT accept a 2-arg paddle form like
     // `cw key dit dah` — FlexLib only ever sends `cw key 1` or `cw key 0`
@@ -754,19 +760,23 @@ void RadioModel::sendCwPaddle(bool dit, bool dah)
     // works when the local iambic keyer is disabled.  When the keyer IS
     // running it intercepts upstream and uses sendCwPtt + sendCwKeyEdge
     // directly, bypassing this method.
-    sendCwKey(dit || dah);
+    sendCwKey(dit || dah, debugSource, debugTraceId, debugSourceMs);
 }
 
-void RadioModel::sendCwPtt(bool on)
+void RadioModel::sendCwPtt(bool on, const QString& debugSource,
+                           quint64 debugTraceId, quint64 debugSourceMs)
 {
-    sendNetCwCommand(on ? QStringLiteral("cw ptt 1") : QStringLiteral("cw ptt 0"));
+    sendNetCwCommand(on ? QStringLiteral("cw ptt 1") : QStringLiteral("cw ptt 0"),
+                     debugSource, debugTraceId, debugSourceMs);
 }
 
-void RadioModel::sendCwKeyEdge(bool down)
+void RadioModel::sendCwKeyEdge(bool down, const QString& debugSource,
+                               quint64 debugTraceId, quint64 debugSourceMs)
 {
     const bool prev = m_cwKeyActive;
     m_cwKeyActive = down;
-    sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0));
+    sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
+                     debugSource, debugTraceId, debugSourceMs);
     if (prev != down)
         emit cwKeyDownChanged(down);
 }
@@ -808,12 +818,24 @@ QByteArray RadioModel::buildNetCwPacket(const QByteArray& payload)
     return pkt;
 }
 
-void RadioModel::sendNetCwCommand(const QString& baseCmd)
+void RadioModel::sendNetCwCommand(const QString& baseCmd, const QString& debugSource,
+                                  quint64 debugTraceId, quint64 debugSourceMs)
 {
     if (m_netCwStreamId == 0) {
         // No netcw stream — fall back to TCP immediate
-        sendCmd(baseCmd.contains("cw key") ?
-            QString(baseCmd).replace("cw key", "cw key immediate") : baseCmd);
+        const QString fallbackCmd = baseCmd.contains("cw key")
+            ? QString(baseCmd).replace("cw key", "cw key immediate")
+            : baseCmd;
+        if (lcCw().isDebugEnabled()) {
+            const quint64 now = cwTraceNowMs();
+            qCDebug(lcCw).noquote().nospace()
+                << "CW netcw fallback trace=" << debugTraceId
+                << " t=" << now << "ms"
+                << " sinceSourceMs=" << (debugSourceMs ? static_cast<qint64>(now - debugSourceMs) : -1)
+                << " source=" << (debugSource.isEmpty() ? QStringLiteral("unknown") : debugSource)
+                << " cmd=\"" << fallbackCmd << "\"";
+        }
+        sendCmd(fallbackCmd);
         return;
     }
 
@@ -860,23 +882,59 @@ void RadioModel::sendNetCwCommand(const QString& baseCmd)
     QByteArray packet1 = buildNetCwPacket(payload);
     QByteArray packet2 = buildNetCwPacket(payload);
     QByteArray packet3 = buildNetCwPacket(payload);
+    const quint64 scheduledMs = cwTraceNowMs();
+    const QString source = debugSource.isEmpty() ? QStringLiteral("unknown") : debugSource;
 
-    QMetaObject::invokeMethod(m_panStream, [this, packet0]() {
+    if (lcCw().isDebugEnabled()) {
+        qCDebug(lcCw).noquote().nospace()
+            << "CW netcw schedule trace=" << debugTraceId
+            << " t=" << scheduledMs << "ms"
+            << " sinceSourceMs=" << (debugSourceMs ? static_cast<qint64>(scheduledMs - debugSourceMs) : -1)
+            << " source=" << source
+            << " stream=0x" << QString::number(m_netCwStreamId, 16).toUpper()
+            << " index=" << index
+            << " time=0x" << tsHex
+            << " cmd=\"" << baseCmd << "\""
+            << " payloadBytes=" << payload.size()
+            << " packetBytes=" << packet0.size()
+            << " udpCopies=4 tcpBackstop=1";
+    }
+
+    auto logUdpSend = [debugTraceId, scheduledMs, source](int copy, int delayMs, int bytes) {
+        if (!lcCw().isDebugEnabled())
+            return;
+        const quint64 now = cwTraceNowMs();
+        qCDebug(lcCw).noquote().nospace()
+            << "CW netcw udp-send trace=" << debugTraceId
+            << " t=" << now << "ms"
+            << " source=" << source
+            << " copy=" << copy
+            << " delayMs=" << delayMs
+            << " actualDelayMs=" << static_cast<qint64>(now - scheduledMs)
+            << " timerSlipMs=" << (static_cast<qint64>(now - scheduledMs) - delayMs)
+            << " bytes=" << bytes;
+    };
+
+    QMetaObject::invokeMethod(m_panStream, [this, packet0, logUdpSend]() {
+        logUdpSend(0, 0, packet0.size());
         m_panStream->sendToRadio(packet0);
     }, Qt::QueuedConnection);
 
-    QTimer::singleShot(5, this, [this, packet1]() {
-        QMetaObject::invokeMethod(m_panStream, [this, packet1]() {
+    QTimer::singleShot(5, this, [this, packet1, logUdpSend]() {
+        QMetaObject::invokeMethod(m_panStream, [this, packet1, logUdpSend]() {
+            logUdpSend(1, 5, packet1.size());
             m_panStream->sendToRadio(packet1);
         }, Qt::QueuedConnection);
     });
-    QTimer::singleShot(10, this, [this, packet2]() {
-        QMetaObject::invokeMethod(m_panStream, [this, packet2]() {
+    QTimer::singleShot(10, this, [this, packet2, logUdpSend]() {
+        QMetaObject::invokeMethod(m_panStream, [this, packet2, logUdpSend]() {
+            logUdpSend(2, 10, packet2.size());
             m_panStream->sendToRadio(packet2);
         }, Qt::QueuedConnection);
     });
-    QTimer::singleShot(15, this, [this, packet3]() {
-        QMetaObject::invokeMethod(m_panStream, [this, packet3]() {
+    QTimer::singleShot(15, this, [this, packet3, logUdpSend]() {
+        QMetaObject::invokeMethod(m_panStream, [this, packet3, logUdpSend]() {
+            logUdpSend(3, 15, packet3.size());
             m_panStream->sendToRadio(packet3);
         }, Qt::QueuedConnection);
     });

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -775,16 +775,13 @@ void RadioModel::sendCwKeyEdge(bool down)
 
 QByteArray RadioModel::buildNetCwPacket(const QByteArray& payload)
 {
-    // VITA-49 header (28 bytes) + raw ASCII command payload, no trailing
-    // padding.  FlexLib's NetCWStream.AddTXData ships the payload buffer at
-    // its exact tx_data.Length — so a 57-byte command goes out in an 85-byte
-    // datagram even though packet_size rounds up to a 4-byte boundary.  The
-    // radio uses recv()'s datagram length, not packet_size, to delimit the
-    // command string; trailing zero bytes cause the parser to reject the
-    // packet (no key/PTT change observed and silent error 0x50001000 on TCP).
+    // VITA-49 header (28 bytes) + ASCII command payload.  Working Maestro
+    // captures show the payload null-padded to a 32-bit word boundary; keep
+    // the datagram length consistent with the VRT packet_size field.
     const int payloadBytes = payload.size();
+    const int paddedPayloadBytes = (payloadBytes + 3) & ~3;
     const int packetWords = static_cast<int>(std::ceil(payloadBytes / 4.0) + 7); // 7 header words
-    const int packetBytes = 28 + payloadBytes;  // header + payload, NO padding
+    const int packetBytes = 28 + paddedPayloadBytes;
 
     QByteArray pkt(packetBytes, '\0');
     auto* w = reinterpret_cast<quint32*>(pkt.data());
@@ -821,16 +818,32 @@ void RadioModel::sendNetCwCommand(const QString& baseCmd)
     }
 
     // Build the full command with timing metadata and dedup index
-    // FlexLib format: "cw key 1 time=0x<hex_ms> index=<N> client_handle=0x<handle>"
-    quint64 timeMs = static_cast<quint64>(
-        QDateTime::currentMSecsSinceEpoch() & 0xFFFFFFFF);
+    // FlexLib format: "cw key 1 time=0x<hex_ms> index=<N> client_handle=0x<handle>".
+    // The time value is a 16-bit relative millisecond counter, not an epoch
+    // timestamp.  Flex clients reset it after a short idle gap; the radio
+    // accepts 0x0000 as a timing resync marker.
+    constexpr qint64 kNetCwIdleResetMs = 3000;
+    quint16 timeMs = 0;
+    if (!m_netCwClock.isValid()
+        || m_netCwLastSendMs < 0
+        || (m_netCwClock.elapsed() - m_netCwLastSendMs) > kNetCwIdleResetMs) {
+        if (m_netCwClock.isValid())
+            m_netCwClock.restart();
+        else
+            m_netCwClock.start();
+        m_netCwLastSendMs = 0;
+    } else {
+        const qint64 elapsed = m_netCwClock.elapsed();
+        timeMs = static_cast<quint16>(elapsed & 0xFFFF);
+        m_netCwLastSendMs = elapsed;
+    }
     int index = m_netCwIndex++;
 
     // FlexLib formats hex values UPPERCASE (C# ToString("X")), and the
     // radio's status messages do too (e.g. `S23A59BDF|...`) — the netcw
     // parser appears to be case-sensitive on `client_handle`.  Match that
     // by formatting both hex values uppercase explicitly.
-    const QString tsHex = QString("%1").arg(timeMs, 8, 16, QChar('0')).toUpper();
+    const QString tsHex = QString("%1").arg(timeMs, 4, 16, QChar('0')).toUpper();
     const QString chHex = QString("%1").arg(clientHandle(), 0, 16).toUpper();
     QString fullCmd = QString("%1 time=0x%2 index=%3 client_handle=0x%4")
         .arg(baseCmd, tsHex, QString::number(index), chHex);
@@ -868,14 +881,10 @@ void RadioModel::sendNetCwCommand(const QString& baseCmd)
         }, Qt::QueuedConnection);
     });
 
-    // No TCP fallback when netcw is up.  Radio v4.1.5 rejects every CW
-    // command sent over TCP with 0x50001000 ("command syntax error") —
-    // both the netcw form and `cw key immediate` form — so the fallback
-    // was producing log noise without doing useful work.  The four
-    // redundant UDP sends above are the reliability mechanism.  If
-    // netcw stream creation failed at startup, the early-return path
-    // above falls back to `cw key immediate` over TCP for that case
-    // (no-netcw firmware), which is a separate scenario.
+    // FlexLib sends the same decorated netcw command over TCP after the UDP
+    // copies.  With the 16-bit timestamp format above, the radio can dedupe
+    // by index=N and the TCP path provides a reliable delivery backstop.
+    sendCmd(fullCmd);
 }
 
 void RadioModel::cwAutoTune(int sliceId, bool intermittent)
@@ -1530,6 +1539,8 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                                 if (code == 0) {
                                     m_netCwStreamId = body.trimmed().toUInt(nullptr, 16);
                                     m_netCwIndex = 1;
+                                    m_netCwClock.invalidate();
+                                    m_netCwLastSendMs = -1;
                                     qCDebug(lcProtocol) << "RadioModel: netcw stream created, id:"
                                              << Qt::hex << m_netCwStreamId;
                                 } else {
@@ -1732,6 +1743,8 @@ void RadioModel::onDisconnected()
     m_rxAudio = {};
     m_netCwStreamId = 0;
     m_netCwIndex = 1;
+    m_netCwClock.invalidate();
+    m_netCwLastSendMs = -1;
     m_lineoutGain = 50;
     m_headphoneGain = 50;
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -475,6 +475,8 @@ private:
     // NetCW stream — VITA-49 UDP delivery for low-latency CW keying
     quint32  m_netCwStreamId{0};
     int      m_netCwIndex{1};           // sequential dedup index
+    QElapsedTimer m_netCwClock;          // 16-bit relative ms clock for time=0x....
+    qint64   m_netCwLastSendMs{-1};
     void sendNetCwCommand(const QString& cmd);
     QByteArray buildNetCwPacket(const QByteArray& payload);
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -269,13 +269,17 @@ public:
     bool isWan() const { return m_wanConn != nullptr; }
     void setTransmit(bool tx);
     QString audioCompressionParam() const;        // "none" or "opus" based on settings
-    void sendCwKey(bool down);                    // straight key via netcw stream
-    void sendCwPaddle(bool dit, bool dah);        // iambic paddle via netcw stream
+    void sendCwKey(bool down, const QString& debugSource = {},
+                   quint64 debugTraceId = 0, quint64 debugSourceMs = 0); // straight key via netcw stream
+    void sendCwPaddle(bool dit, bool dah, const QString& debugSource = {},
+                      quint64 debugTraceId = 0, quint64 debugSourceMs = 0); // iambic paddle via netcw stream
     // Lower-level pieces used by the local iambic keyer: PTT and key
     // edges are managed separately so PTT stays asserted across the whole
     // squeeze while key transitions on each element boundary.
-    void sendCwPtt(bool on);
-    void sendCwKeyEdge(bool down);
+    void sendCwPtt(bool on, const QString& debugSource = {},
+                   quint64 debugTraceId = 0, quint64 debugSourceMs = 0);
+    void sendCwKeyEdge(bool down, const QString& debugSource = {},
+                       quint64 debugTraceId = 0, quint64 debugSourceMs = 0);
     void cwAutoTune(int sliceId, bool intermittent); // int=1 start loop, int=0 stop
     void cwAutoTuneOnce(int sliceId);                // one-shot (no int= param)
     void addSlice();           // Create a new slice on the active panadapter
@@ -477,7 +481,8 @@ private:
     int      m_netCwIndex{1};           // sequential dedup index
     QElapsedTimer m_netCwClock;          // 16-bit relative ms clock for time=0x....
     qint64   m_netCwLastSendMs{-1};
-    void sendNetCwCommand(const QString& cmd);
+    void sendNetCwCommand(const QString& cmd, const QString& debugSource = {},
+                          quint64 debugTraceId = 0, quint64 debugSourceMs = 0);
     QByteArray buildNetCwPacket(const QByteArray& payload);
 
     QString     m_name;

--- a/tests/cw_sidetone_test.cpp
+++ b/tests/cw_sidetone_test.cpp
@@ -115,6 +115,7 @@ int main()
         CwSidetoneGenerator gen(48000);
         gen.setEnabled(true);
         gen.setVolume(1.0f);
+        gen.setPan(0.0f);        // test reads L channel only
         gen.setShapingMs(5.0f);  // 5 ms ramp
         gen.setKeyDown(true);
         auto mono = runFrames(gen, 480);  // 10 ms total — first 5 ms is ramp

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -60,7 +60,21 @@ int main(int argc, char** argv)
     tuneKnob.number = -1;
     tuneKnob.paramId = "rx.tuneKnob";
 
-    QVector<MidiBinding> saved{afGain, tuneKnob};
+    MidiBinding cwDitLegacy;
+    cwDitLegacy.channel = 0;
+    cwDitLegacy.msgType = MidiBinding::NoteOn;
+    cwDitLegacy.number = 60;
+    cwDitLegacy.paramId = "cw.dit";
+
+    MidiBinding cwDah;
+    cwDah.channel = 0;
+    cwDah.msgType = MidiBinding::NoteOn;
+    cwDah.number = 61;
+    cwDah.paramId = "cwdah";
+
+    QVector<MidiBinding> saved{afGain, tuneKnob, cwDitLegacy, cwDah};
+    QVector<MidiBinding> expected = saved;
+    expected[2].paramId = "cwdit";
 
     auto& settings = MidiSettings::instance();
     settings.setLastDevice("Initial Controller");
@@ -75,12 +89,24 @@ int main(int argc, char** argv)
     bool ok = true;
     ok &= expect(loaded.size() == saved.size(),
                  "preference-only save preserves binding count");
-    if (loaded.size() == saved.size()) {
-        ok &= expect(sameBinding(loaded[0], saved[0]),
-                     "preference-only save preserves first binding");
-        ok &= expect(sameBinding(loaded[1], saved[1]),
-                     "preference-only save preserves second binding");
+    if (loaded.size() == expected.size()) {
+        for (int i = 0; i < expected.size(); ++i) {
+            ok &= expect(sameBinding(loaded[i], expected[i]),
+                         "preference-only save preserves normalized binding");
+        }
     }
+
+    QFile midiFile(configRoot + "/AetherSDR/midi.settings");
+    ok &= expect(midiFile.open(QIODevice::ReadOnly | QIODevice::Text),
+                 "MIDI settings file is written");
+    const QString xml = midiFile.isOpen() ? QString::fromUtf8(midiFile.readAll()) : QString();
+    midiFile.close();
+    ok &= expect(xml.contains(QStringLiteral("param=\"cwdit\"")),
+                 "legacy CW dit MIDI binding saves as cwdit");
+    ok &= expect(xml.contains(QStringLiteral("param=\"cwdah\"")),
+                 "CW dah MIDI binding saves as cwdah");
+    ok &= expect(!xml.contains(QStringLiteral("param=\"cw.dit\"")),
+                 "MIDI settings do not save dotted CW dit ID");
 
     settings.load();
     ok &= expect(settings.lastDevice() == "Renamed Controller",

--- a/tests/shortcut_manager_test.cpp
+++ b/tests/shortcut_manager_test.cpp
@@ -1,0 +1,99 @@
+#include "core/AppSettings.h"
+#include "core/ShortcutManager.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    return condition;
+}
+
+void registerCwActions(ShortcutManager& manager)
+{
+    manager.registerAction(QStringLiteral("cwkey"), QStringLiteral("Trigger straight key"),
+                           QStringLiteral("CW"), QKeySequence(), {});
+    manager.registerAction(QStringLiteral("cwdit"), QStringLiteral("Trigger CW Left Paddle"),
+                           QStringLiteral("CW"), QKeySequence(), {});
+    manager.registerAction(QStringLiteral("cwdah"), QStringLiteral("Trigger CW Right Paddle"),
+                           QStringLiteral("CW"), QKeySequence(), {});
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QTemporaryDir fakeHome(QDir::tempPath() + "/aether-shortcut-manager-test-XXXXXX");
+    if (!fakeHome.isValid()) {
+        std::cerr << "[FAIL] create temporary home\n";
+        return 1;
+    }
+    qputenv("HOME", fakeHome.path().toUtf8());
+    qputenv("CFFIXED_USER_HOME", fakeHome.path().toUtf8());
+    QStandardPaths::setTestModeEnabled(true);
+    QCoreApplication app(argc, argv);
+
+    const QString configRoot =
+        QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+    QDir(configRoot + "/AetherSDR").removeRecursively();
+
+    auto& settings = AppSettings::instance();
+    settings.reset();
+
+    ShortcutManager manager;
+    registerCwActions(manager);
+    manager.loadBindings();
+    manager.setBinding(QStringLiteral("cwkey"), QKeySequence(Qt::Key_F9));
+    manager.setBinding(QStringLiteral("cwdit"), QKeySequence(Qt::Key_F10));
+    manager.setBinding(QStringLiteral("cwdah"), QKeySequence(Qt::Key_F11));
+
+    QFile saved(settings.filePath());
+    bool ok = expect(saved.open(QIODevice::ReadOnly | QIODevice::Text),
+                     "shortcut settings file is written");
+    const QString xml = ok ? QString::fromUtf8(saved.readAll()) : QString();
+    saved.close();
+
+    ok &= expect(xml.contains(QStringLiteral("<Shortcut_cwkey>F9</Shortcut_cwkey>")),
+                 "straight-key shortcut persists as Shortcut_cwkey");
+    ok &= expect(xml.contains(QStringLiteral("<Shortcut_cwdit>F10</Shortcut_cwdit>")),
+                 "dit shortcut persists as Shortcut_cwdit");
+    ok &= expect(xml.contains(QStringLiteral("<Shortcut_cwdah>F11</Shortcut_cwdah>")),
+                 "dah shortcut persists as Shortcut_cwdah");
+    ok &= expect(!xml.contains(QStringLiteral("Shortcut_cw.key")),
+                 "shortcut XML does not use dotted CW IDs");
+    ok &= expect(!xml.contains(QStringLiteral("Shortcut_cw.dit")),
+                 "shortcut XML does not use dotted CW dit ID");
+    ok &= expect(!xml.contains(QStringLiteral("Shortcut_cw.dah")),
+                 "shortcut XML does not use dotted CW dah ID");
+
+    settings.reset();
+    settings.load();
+
+    ShortcutManager restored;
+    registerCwActions(restored);
+    restored.loadBindings();
+
+    const auto* straight = restored.action(QStringLiteral("cwkey"));
+    const auto* dit = restored.action(QStringLiteral("cwdit"));
+    const auto* dah = restored.action(QStringLiteral("cwdah"));
+
+    ok &= expect(straight && straight->currentKey == QKeySequence(Qt::Key_F9),
+                 "straight-key shortcut reloads");
+    ok &= expect(dit && dit->currentKey == QKeySequence(Qt::Key_F10),
+                 "dit shortcut reloads");
+    ok &= expect(dah && dah->currentKey == QKeySequence(Qt::Key_F11),
+                 "dah shortcut reloads");
+
+    QDir(configRoot + "/AetherSDR").removeRecursively();
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

This PR rolls up the CW/netCW work that started from PR #2336 and adds operator-facing keyboard and MIDI controls for manual CW keying.

It includes:

- netCW timing/trace logging from the PR #2336 baseline so CW keying can be reviewed from `aether.cw` logs.
- Keyboard shortcut actions for `Trigger straight key`, `Trigger CW Left Paddle`, and `Trigger CW Right Paddle`.
- Matching MIDI mapping actions using the same names and shared action IDs: `cwkey`, `cwdit`, and `cwdah`.
- Persistence fixes for the new CW keyboard shortcut actions using XML-safe shortcut IDs.
- MIDI settings migration/normalization for legacy dotted CW IDs (`cw.key`, `cw.dit`, `cw.dah`) so older test bindings still load and save back as `cwkey`, `cwdit`, and `cwdah`.
- A clickable red `TX` status badge that acts as an emergency TX cancel control.
- Focused regression coverage for shortcut and MIDI settings persistence.

## CW Keying Behavior

### Trigger straight key

`Trigger straight key` is implemented as a true momentary control. Keyboard press and MIDI gate-on assert the netCW key path; key release and MIDI gate-off release it.

On press, AetherSDR sends:

- `cw ptt 1`
- `cw key 1`

On release, AetherSDR sends:

- `cw key 0`
- `cw ptt 0`

This preserves the required ordering for break-in-off setups where the radio needs explicit netCW PTT around key state.

### Trigger CW Left Paddle / Right Paddle

The left and right paddle controls feed the local iambic keyer when it is running. That keeps sidetone and on-air timing aligned with the configured CW speed, and it emits netCW key edges for generated dits/dahs.

If the local keyer is not running, the paddle path falls back to a direct held-key path so the radio still receives key-down/key-up state.

## MIDI Changes

The MIDI controls now reuse the same CW action IDs and display names as keyboard shortcuts:

- `cwkey` / `Trigger straight key`
- `cwdit` / `Trigger CW Left Paddle`
- `cwdah` / `Trigger CW Right Paddle`

`MidiSettings` normalizes legacy dotted CW param IDs on read and write:

- `cw.key` -> `cwkey`
- `cw.dit` -> `cwdit`
- `cw.dah` -> `cwdah`

This keeps older mappings from being stranded while avoiding dots in saved CW action IDs going forward.

## Keyboard Shortcut Persistence

The original CW shortcut IDs used dots, which produced settings keys like `Shortcut_cw.key`. `AppSettings` intentionally skips invalid XML element names, so those shortcuts were not persisted.

This PR avoids changing the XML/settings handler and instead renames the CW shortcut IDs to XML-safe names:

- `Shortcut_cwkey`
- `Shortcut_cwdit`
- `Shortcut_cwdah`

A new `shortcut_manager_test` verifies that the CW shortcuts save and reload from the database, and that no dotted CW shortcut keys are written.

## TX Cancel Badge

The large red status-bar `TX` indicator is now clickable. Left-clicking it sends a conservative emergency cancel sequence intended for a stuck transmit condition:

- clears Space PTT state
- clears local CW straight-key and paddle state
- resets local iambic paddle memory
- forces sidetone key-up
- sends netCW `cw key 0`
- sends netCW `cw ptt 0`
- sends `transmit tune 0`
- sends `xmit 0`

The handler checks Multi-Flex ownership before acting. If another station owns TX and this client is not locally transmitting, it reports that TX is owned elsewhere instead of pretending this client can cancel another station's transmit.

## netCW Diagnostics

The CW/netCW log path records each stage of MIDI/keyboard input and netCW scheduling, including trace IDs, source labels, timing deltas, VITA stream/index details, UDP copy timing, and TCP fallback/backstop information.

During local on-air testing, the reviewed netCW traces showed:

- straight-key press order: `cw ptt 1 -> cw key 1`
- straight-key release order: `cw key 0 -> cw ptt 0`
- paddle events feeding the local iambic keyer
- WPM changes reflected in generated dit/dah timing
- press-to-netCW scheduling typically at 0-1 ms

## Validation

Built with the project-required 22 parallel jobs:

```bash
env -u CPLUS_INCLUDE_PATH cmake --build build-ninja --parallel 22
```

Ran focused tests:

```bash
ctest --test-dir build-ninja --output-on-failure -R "(shortcut_manager_test|midi_settings_test|radio_status_ownership_test)"
```

Result: 3/3 tests passed.

Also validated manually by @jensenpat:

- keyboard straight key works over the air
- keyboard left/right paddle controls work over the air
- MIDI straight key works over the air
- MIDI left/right paddle controls work over the air
- WPM changes affect generated dits/dahs over the air
- holding straight key keeps the tone active over the air

## Reviewer Notes

The actual netCW UDP datagrams are still sent on the `PanadapterStream` network thread, while timing/scheduling is initiated from `RadioModel`. This PR does not move netCW scheduling to a dedicated high-priority timer thread; it focuses on functional CW controls, persistence, diagnostics, and a practical stuck-TX escape hatch.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
