### PR TITLE
fix(meters): voltage gauge label now shows live radio voltage

### DIFF
--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -50,6 +50,12 @@ public:
         });
     }
 
+    void setLabel(const QString& label) {
+        if (m_label == label) return;
+        m_label = label;
+        update();
+    }
+
     void setValue(float v) {
         if (qFuzzyCompare(m_value, v)) return;
         m_value = v;

--- a/src/gui/MeterApplet.cpp
+++ b/src/gui/MeterApplet.cpp
@@ -48,6 +48,7 @@ void MeterApplet::setMeterModel(MeterModel* model)
             this, [this](float paTemp, float supplyV) {
         m_paTempGauge->setValue(paTemp);
         m_supplyGauge->setValue(supplyV);
+        m_supplyGauge->setLabel(QString("+%1V").arg(supplyV, 0, 'f', 2));
     });
 
     connect(model, &MeterModel::meterUpdated,


### PR DESCRIPTION
The supply voltage HGauge was constructed with a static "+13.8V" label that never updated. The bar fill moved correctly via setValue(), but the centred text always displayed the nominal 13.8 V regardless of actual radio-reported voltage (e.g. 13.28 V).

Added HGauge::setLabel() — a lightweight setter that updates m_label and triggers a repaint only when the string changes. MeterApplet now calls it inside the hwTelemetryChanged handler alongside setValue(), formatting the live voltage as "+XX.XXV" (2 decimal places, matching radio precision).

The static "+13.8V" tick label on the scale is intentional — it marks the nominal target voltage on the bar, not the current reading.