### PR TITLE
Gate compression meter on radio TX state

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1961,6 +1961,9 @@ MainWindow::MainWindow(QWidget* parent)
         // S-Meter: use raw interlock state so Level/Compression modes work
         // during VOX/hardware CW without the effectiveTx power threshold (#877)
         m_appletPanel->sMeterWidget()->setTransmitting(tx);
+        if (!tx) {
+            m_appletPanel->phoneCwApplet()->updateCompression(0.0f);
+        }
         if (tx) {
             m_txIndicator->setStyleSheet(
                 "QLabel { color: white; background: #c03030; font-weight: bold; "
@@ -3077,7 +3080,7 @@ MainWindow::MainWindow(QWidget* parent)
     // ── P/CW applet: mic meters + ALC meter + model ────────────────────────
     // Suppress radio CODEC meters when mic_selection=PC (they just show noise).
     // Client-side metering handles PC mic display below.
-    // Compression gauge: full 20fps meter rate, gated on speech_processor_enable.
+    // Compression gauge: full 20fps meter rate, gated on actual radio TX + PROC.
     {
         connect(&m_radioModel.meterModel(), &MeterModel::micMetersChanged,
                 this, [this](float micLevel, float compLevel, float micPeak, float compPeak) {
@@ -3085,10 +3088,14 @@ MainWindow::MainWindow(QWidget* parent)
             if (m_radioModel.transmitModel().micSelection() != "PC")
                 m_appletPanel->phoneCwApplet()->updateMeters(micLevel, compLevel, micPeak, 0.0f);
 
-            // Compression gauge: full rate (20fps from radio), gated on PROC
+            // Compression has no useful meaning in RX; FLEX-8000 radios can
+            // publish quiescent TX-chain meters there that look fully pegged.
             {
-                float comp = m_radioModel.transmitModel().speechProcessorEnable() ? compPeak : 0.0f;
-                m_appletPanel->phoneCwApplet()->updateCompression(comp);
+                const auto& tx = m_radioModel.transmitModel();
+                const bool showCompression =
+                    m_radioModel.isRadioTransmitting() && tx.speechProcessorEnable();
+                m_appletPanel->phoneCwApplet()->updateCompression(
+                    showCompression ? compPeak : 0.0f);
             }
         });
     }

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -756,8 +756,8 @@ void PhoneCwApplet::updateMeters(float micLevel, float compLevel,
 
 void PhoneCwApplet::updateCompression(float compPeak)
 {
-    // compPeak is raw dBFS from COMPPEAK meter.
-    // Silence (-150) → 0. Speech (-10..+14) → clamp to -25..0 range.
+    // compPeak is the MeterModel-derived compression display dB.
+    // Silence/no compression -> 0. Reduction -> clamp to the -25..0 gauge range.
     float gauge = (compPeak > -30.0f) ? qBound(-25.0f, compPeak, 0.0f) : 0.0f;
     m_compGauge->setValue(gauge);
 }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1702,6 +1702,8 @@ void RadioModel::onDisconnected()
         m_txAudioGate = false;
         emit txAudioGateChanged(false);
     }
+    m_radioTransmitting = false;
+    emit radioTransmittingChanged(false);
     m_transmitModel.setTransmitting(false);
     m_transmitModel.resetState();
     m_meterModel.clear();
@@ -3306,6 +3308,7 @@ void RadioModel::onStatusReceived(const QString& object,
             // Emit raw radio TX state regardless of ownership — used by DAX
             // passthrough when an external app triggers PTT (#752).
             const bool radioTx = (state == "TRANSMITTING");
+            m_radioTransmitting = radioTx;
             emit radioTransmittingChanged(radioTx);
 
             if (!m_txOwnedByUs || (!m_txRequested && !m_cwKeyActive && !m_cwxActive && !m_transmitModel.isTuning())) {

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -83,6 +83,7 @@ public:
     void setAmpOperate(bool on);
     float paTemp()    const { return m_paTemp; }
     float txPower()   const { return m_txPower; }
+    bool  isRadioTransmitting() const { return m_radioTransmitting; }
     QStringList antennaList() const { return m_antList; }
     QString serial()       const;
     QString chassisSerial() const { return m_chassisSerial; }
@@ -533,6 +534,7 @@ private:
     bool        m_cwKeyActive{false}; // true while CW key/paddle is held (#1379)
     bool        m_cwxActive{false};   // true while CWX send is in flight (#2047, #2097)
     bool        m_txAudioGate{false}; // actual TX audio gate state
+    bool        m_radioTransmitting{false}; // raw interlock TX state, any owner
     QStringList m_antList;
 
     QMap<QString, PanadapterModel*> m_panadapters;  // panId → model


### PR DESCRIPTION
## Summary

- Track the raw interlock TX state in `RadioModel` and expose it as the model-owned source of truth.
- Gate the P/CW compression gauge on actual radio TX state plus speech processor enable.
- Clear the compression gauge when the radio leaves TX so RX quiescent TX-chain meter values cannot leave the display pegged.

Fixes #2325 

## Root Cause

FLEX-8000 radios can continue publishing TX-chain compression source meters while the radio is in receive. AetherSDR forwarded the derived compression value whenever PROC was enabled, without checking whether the radio was actually transmitting. In FT8/DIGU receive this could show a full red compression meter even though compression has no meaningful RX value.

## Impact

The P/CW compression gauge now stays at zero during RX and on initial connection/reconnect until the radio reports `TRANSMITTING`. Voice TX with PROC enabled can still show compression, including raw radio TX paths such as VOX or hardware PTT. Digital TX paths that bypass PROC continue to show no compression.

## Validation

- `cmake -B build-ninja -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `env -u CPLUS_INCLUDE_PATH cmake --build build-ninja --parallel 22`
- `ctest --test-dir build-ninja --output-on-failure`
- `./build-ninja/transmit_model_test`

Note: `./build-ninja/meter_model_test` still fails several existing compression derivation assertions on current `main`; this PR does not change `MeterModel` derivation logic.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
