### PR TITLE
Bundle MSVC runtime in Windows portable ZIP

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Create portable ZIP
         run: |
+          # Keep portable ZIP app-local runtime behavior aligned with the installer.
+          Copy-Item -Path installer-runtime\*.dll -Destination deploy\ -Force
           Compress-Archive -Path deploy\* -DestinationPath "AetherSDR-${{ github.ref_name }}-Windows-x64-portable.zip"
 
       - name: Create installer (Inno Setup)


### PR DESCRIPTION
## Summary

- Copy the staged app-local MSVC runtime DLLs into `deploy\` before creating the Windows portable ZIP.
- Keep the installer path unchanged: Inno Setup still receives `VC_RUNTIME_DIR` and installs the staged runtime DLLs from `installer-runtime\`.
- Reference the Windows installer runtime work from #2303 and address the portable ZIP follow-up called out in #2308.

Fixes #2308 

## Motivation

PR #2303 fixed fresh-machine Windows installer launches by staging app-local MSVC CRT DLLs for Inno Setup. The portable ZIP was still created from `deploy\*` only, so it did not explicitly receive the same curated runtime DLLs beside `AetherSDR.exe`.

This change keeps the two distribution paths aligned without bundling or running `vc_redist.x64.exe`.

## Implementation

- Reuse the existing `stage-msvc-runtime.ps1` output.
- Copy only `installer-runtime\*.dll` into `deploy\` immediately before `Compress-Archive`.
- Leave `packaging/windows/installer.iss` unchanged, so the installer continues excluding CRT names from the generic deploy copy and installing runtime DLLs from `VC_RUNTIME_DIR`.

## Validation

- Ran `git diff --check`.
- Did not run a full Windows installer workflow locally; this change is exercised by the GitHub Actions Windows release workflow.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
