### PR TITLE
MidiControlManager: drop dead paramAction signal

### DIFF
--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -388,7 +388,6 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2,
 
         // Don't call setter directly — may be on a worker thread while
         // setters access main-thread objects. Emit signal instead. (#502)
-        emit paramAction(binding.paramId, scaled);
         emit paramActionTrace(binding.paramId, scaled, traceId, midiCallbackMs, dispatchMs);
     }
 

--- a/src/core/MidiControlManager.h
+++ b/src/core/MidiControlManager.h
@@ -95,9 +95,9 @@ signals:
     void portError(const QString& error);
     void midiActivity(int channel, int msgType, int number, int value);
     void paramValueChanged(const QString& paramId, float normalizedValue);
-    // Emitted with the final scaled value for MainWindow to dispatch
-    // the setter on the main thread. (#502)
-    void paramAction(const QString& paramId, float scaledValue);
+    // Emitted with the final scaled value plus trace metadata for
+    // MainWindow to dispatch the setter on the main thread (#502) and
+    // correlate the event for the CW/netCW diagnostic trail (#2336).
     void paramActionTrace(const QString& paramId, float scaledValue,
                           quint64 traceId, quint64 midiCallbackMs,
                           quint64 midiDispatchMs);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -324,7 +324,7 @@ private:
     std::atomic<quint64> m_lastCwMidiTraceId{0};
     std::atomic<quint64> m_lastCwMidiSourceMs{0};
     // MIDI param setters indexed by ID — called on main thread from
-    // paramAction signal (worker thread cannot call them directly). (#502)
+    // paramActionTrace signal (worker thread cannot call them directly). (#502)
     QHash<QString, std::function<void(float)>> m_midiSetters;
     QHash<QString, std::function<float()>>     m_midiGetters;
 #endif


### PR DESCRIPTION
#2336 added paramActionTrace alongside the existing paramAction and
moved MainWindow's connection over to it.  paramAction was still
emitted but had zero remaining consumers.  Drops the redundant signal
declaration + emit, and refreshes the m_midiSetters comment in
MainWindow.h to reference the correct signal.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
