### PR TITLE
Flat design system: Phases 1-4 token layer + UI cleanup

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -162,7 +162,7 @@ private:
 
 AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 {
-    setFixedWidth(260);
+    setFixedWidth(kWidth);
 
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(0, 0, 0, 0);
@@ -393,7 +393,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     auto* container = new QWidget;
     m_stack = new QVBoxLayout(container);
     m_stack->setContentsMargins(0, 0, 0, 0);
-    m_stack->setSpacing(0);
+    m_stack->setSpacing(6);
     m_stack->addStretch();
     m_scrollArea->setWidget(container);
     root->addWidget(m_scrollArea, 1);

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -56,6 +56,10 @@ class AppletPanel : public QWidget {
     Q_OBJECT
 
 public:
+    // Total sidebar width.  Extra space beyond 260px content is natural
+    // clearance from the vertical scrollbar (12px) + padding.
+    static constexpr int kWidth = 280;
+
     explicit AppletPanel(QWidget* parent = nullptr);
 
     void setSlice(SliceModel* slice);

--- a/src/gui/ComboStyle.h
+++ b/src/gui/ComboStyle.h
@@ -27,7 +27,7 @@ inline QString comboArrowPath()
     p.setRenderHint(QPainter::Antialiasing);
     p.setPen(Qt::NoPen);
     // Arrow fill uses the secondary text color
-    p.setBrush(QColor(kTextSecondary.data()));
+    p.setBrush(QColor::fromString(kTextSecondary));
     const QPointF tri[] = {{0, 0}, {8, 0}, {4, 6}};
     p.drawPolygon(tri, 3);
     p.end();

--- a/src/gui/ComboStyle.h
+++ b/src/gui/ComboStyle.h
@@ -9,12 +9,14 @@
 #include <QFile>
 #include <QPixmap>
 #include <QPainter>
+#include "DesignTokens.h"
 
 namespace AetherSDR {
 
 // Generate a small down-arrow PNG (cached in temp dir, created once).
 inline QString comboArrowPath()
 {
+    using namespace DesignTokens;
     static QString path;
     if (!path.isEmpty()) return path;
     path = QDir::temp().filePath("aethersdr_combo_arrow.png");
@@ -24,7 +26,8 @@ inline QString comboArrowPath()
     QPainter p(&pm);
     p.setRenderHint(QPainter::Antialiasing);
     p.setPen(Qt::NoPen);
-    p.setBrush(QColor(0x8a, 0xa8, 0xc0));
+    // Arrow fill uses the secondary text color
+    p.setBrush(QColor(kTextSecondary.data()));
     const QPointF tri[] = {{0, 0}, {8, 0}, {4, 6}};
     p.drawPolygon(tri, 3);
     p.end();
@@ -35,14 +38,15 @@ inline QString comboArrowPath()
 // Standard combo box stylesheet matching the dark theme with painted arrow.
 inline QString comboStyleSheet()
 {
-    return QString(
-        "QComboBox { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050;"
-        " padding: 2px 2px 2px 4px; border-radius: 2px; }"
-        "QComboBox::drop-down { border: none; width: 14px; }"
-        "QComboBox::down-arrow { image: url(%1); width: 8px; height: 6px; }"
-        "QComboBox QAbstractItemView { background: #1a2a3a; color: #c8d8e8;"
-        " selection-background-color: #00b4d8; }")
-        .arg(comboArrowPath());
+    using namespace DesignTokens;
+    auto sheet = QStringLiteral("QComboBox { background: #1a2a3a; color: ") + kTextPrimary
+        + QStringLiteral("; border: 1px solid ") + kBorderControl
+        + QStringLiteral("; padding: 2px 2px 2px 4px; border-radius: 2px; }"
+                         "QComboBox::drop-down { border: none; width: 14px; }"
+                         "QComboBox::down-arrow { image: url(%1); width: 8px; height: 6px; }"
+                         "QComboBox QAbstractItemView { background: #1a2a3a; color: ") + kTextPrimary
+        + QStringLiteral("; selection-background-color: ") + kColorAccent + QStringLiteral("; }");
+    return sheet.arg(comboArrowPath());
 }
 
 // Apply the standard style to a combo box.

--- a/src/gui/DesignTokens.h
+++ b/src/gui/DesignTokens.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QLatin1StringView>
+
+namespace AetherSDR::DesignTokens {
+
+// ── Surfaces ────────────────────────────────────────────────────────────────
+constexpr QLatin1StringView kSurfaceBase   {"#0f0f1a"};
+constexpr QLatin1StringView kSurfacePanel  {"#141422"};
+constexpr QLatin1StringView kSurfaceSunken {"#0a0a14"};
+constexpr QLatin1StringView kSurfaceOverlay{"#1c2030"};
+
+// ── Borders ──────────────────────────────────────────────────────────────────
+constexpr QLatin1StringView kBorderSubtle     {"#1a2535"};
+constexpr QLatin1StringView kBorderControl    {"#253545"};
+constexpr QLatin1StringView kBorderInteractive{"#2a4060"};
+
+// ── Text ──────────────────────────────────────────────────────────────────────
+constexpr QLatin1StringView kTextPrimary   {"#c8d8e8"};
+constexpr QLatin1StringView kTextSecondary {"#7a8fa0"};
+constexpr QLatin1StringView kTextTertiary  {"#404f5e"};
+constexpr QLatin1StringView kTextAccent    {"#00b4d8"};
+
+// ── Semantic ──────────────────────────────────────────────────────────────────
+constexpr QLatin1StringView kColorAccent  {"#00b4d8"};
+constexpr QLatin1StringView kColorDanger  {"#cc3030"};
+constexpr QLatin1StringView kColorWarning {"#d08020"};
+constexpr QLatin1StringView kColorSuccess {"#20a060"};
+
+// ── Control metrics (used in both stylesheets and layout code) ────────────────
+constexpr int kCtrlRadius    = 3;
+constexpr int kCtrlBtnHeight = 22;
+constexpr int kCtrlSliderH   = 4;
+constexpr int kCtrlHandleW   = 10;
+constexpr int kFontSm        = 11;
+constexpr int kFontMd        = 13;
+constexpr int kFontLg        = 16;
+constexpr int kFontFreq      = 22;
+
+} // namespace AetherSDR::DesignTokens

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3875,9 +3875,9 @@ MainWindow::MainWindow(QWidget* parent)
         restoreState(QByteArray::fromBase64(stateB64.toLatin1()));
     // Clear stale splitter state — layout has changed across versions.
     s.remove("SplitterState");
-    // Force 4-pane sizing: CWX=0, DVK=0 (hidden), center=stretch, applet=260px
+    // Force 4-pane sizing: CWX=0, DVK=0 (hidden), center=stretch, applet=panel width
     QTimer::singleShot(0, this, [this]() {
-        m_splitter->setSizes({0, 0, width() - 260, 260});
+        m_splitter->setSizes({0, 0, width() - AppletPanel::kWidth, AppletPanel::kWidth});
     });
 
     // Auto-popup connection dialog if no saved radio
@@ -5590,7 +5590,7 @@ void MainWindow::buildMenuBar()
         m_midiDialog = dlg;
         dlg->show();
     });
-#endif
+#endif  // HAVE_MIDI
 #ifdef HAVE_HIDAPI
 #endif
     auto* spotsAction = settingsMenu->addAction("SpotHub...");
@@ -10137,7 +10137,7 @@ void MainWindow::toggleMinimalMode(bool on)
 
         // Force window to applet width
         setMinimumSize(0, 0);
-        setFixedWidth(260);
+        setFixedWidth(AppletPanel::kWidth);
 
         QByteArray geom = QByteArray::fromBase64(
             s.value("MinimalModeGeometry", "").toByteArray());
@@ -12980,16 +12980,16 @@ void MainWindow::dockAppletPanel()
     m_appletPanel->show();
 
     // Re-apply the canonical 4-slot layout the app uses at startup:
-    // CWX=0, DVK=0, center=stretch, applet=260px.  Using fixed sizes
+    // CWX=0, DVK=0, center=stretch, applet=panel width.  Using fixed sizes
     // instead of saveState()/restoreState() because the saved state
     // is unreliable in the launch-with-float case — saveState() fires
     // at a QTimer::singleShot(0) turn before the splitter has fully
     // laid out, producing captured sizes that don't match the
     // post-show window width.  The splitter isn't user-draggable for
-    // applet width anyway (startup always forces 260), so recomputing
-    // is both simpler and deterministic.
-    const int centerWidth = std::max(400, m_splitter->width() - 260);
-    m_splitter->setSizes({0, 0, centerWidth, 260});
+    // applet width anyway (startup always forces panel width), so
+    // recomputing is both simpler and deterministic.
+    const int centerWidth = std::max(400, m_splitter->width() - AppletPanel::kWidth);
+    m_splitter->setSizes({0, 0, centerWidth, AppletPanel::kWidth});
 
     m_appletPanelFloatWindow->removeEventFilter(this);
     m_appletPanelFloatWindow->deleteLater();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -450,7 +450,7 @@ private:
     // Applet-panel pop-out support (#1713 Phase 6).  When floating,
     // the panel lives inside m_appletPanelFloatWindow and its splitter
     // slot is removed; re-dock appends a fresh slot and re-applies the
-    // canonical {0, 0, width-260, 260} sizing.
+    // canonical {0, 0, width-kWidth, kWidth} sizing.
     QWidget*    m_appletPanelFloatWindow{nullptr};
     QAction*    m_popOutSidebarAction{nullptr};
     void floatAppletPanel();

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1,4 +1,5 @@
 #include "NetworkDiagnosticsDialog.h"
+#include "DesignTokens.h"
 #include "core/AudioEngine.h"
 #include "core/LogManager.h"
 #include "models/RadioModel.h"
@@ -17,7 +18,6 @@
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <QCheckBox>
-#include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPlainTextEdit>
@@ -32,11 +32,6 @@
 #include <QTabWidget>
 #include <QTextCharFormat>
 #include <QVBoxLayout>
-#include <QWindow>
-
-namespace {
-constexpr int kResizeMargin = 6;
-}
 
 namespace AetherSDR {
 
@@ -586,109 +581,23 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     : QDialog(parent), m_model(model), m_audio(audio), m_history(history)
 {
     setWindowTitle("Network Diagnostics");
-    setWindowFlag(Qt::FramelessWindowHint, true);
     setMinimumSize(920, 680);
     resize(980, 760);
-    // Track mouse without buttons pressed so the resize cursor updates
-    // while hovering the bare margin around the dialog body.
-    setMouseTracking(true);
     setStyleSheet(
-        "QDialog { background: #050710; }"
-        "QTabWidget::pane { border: 1px solid #203040; border-radius: 4px; top: -1px; }"
-        "QTabBar::tab { background: #0a0a14; border: 1px solid #203040; "
-        "border-bottom: none; color: #8aa8c0; padding: 7px 12px; }"
-        "QTabBar::tab:selected { color: #c8d8e8; background: #111120; }"
-        "QTabBar::tab:hover { color: #c8d8e8; }"
-        "QGroupBox { border: 1px solid #203040; border-radius: 4px; "
-        "color: #c8d8e8; font-weight: bold; margin-top: 12px; padding-top: 8px; }"
+        "QTabWidget::pane { border: 1px solid " + DesignTokens::kBorderControl + "; border-radius: 4px; top: -1px; }"
+        "QTabBar::tab { background: " + DesignTokens::kSurfaceSunken + "; border: 1px solid " + DesignTokens::kBorderControl + "; "
+        "border-bottom: none; color: " + DesignTokens::kTextSecondary + "; padding: 7px 12px; }"
+        "QTabBar::tab:selected { color: " + DesignTokens::kTextPrimary + "; background: " + DesignTokens::kSurfacePanel + "; }"
+        "QTabBar::tab:hover { color: " + DesignTokens::kTextPrimary + "; }"
+        "QGroupBox { border: 1px solid " + DesignTokens::kBorderControl + "; border-radius: 4px; "
+        "color: " + DesignTokens::kTextPrimary + "; font-weight: bold; margin-top: 12px; padding-top: 8px; }"
         "QGroupBox::title { subcontrol-origin: margin; left: 8px; padding: 0 4px; }"
-        "QLabel { color: #8aa8c0; }"
+        "QLabel { color: " + DesignTokens::kTextSecondary + "; }"
         "QScrollArea { background: transparent; border: none; }"
         "QScrollArea > QWidget > QWidget { background: transparent; }");
 
-    // Outer layout: zero-margin so the title bar runs edge-to-edge.  The
-    // 8 px resize hit zone lives on the bare gap around the inner content
-    // widget (which carries its own padding).
+    // Content area
     auto* root = new QVBoxLayout(this);
-    root->setContentsMargins(0, 0, 0, 0);
-    root->setSpacing(0);
-
-    // ── Custom title bar ─────────────────────────────────────────────
-    // Same chrome family as AetherialAudioStrip / ContainerTitleBar:
-    // 18 px tall, blue-gradient background, 10 px bold title, trio of
-    // window-control buttons at the right.  Built inline so the
-    // gradient + grip glyphs match exactly.
-    {
-        m_titleBar = new QWidget(this);
-        m_titleBar->setFixedHeight(18);
-        m_titleBar->setAttribute(Qt::WA_StyledBackground, true);
-        m_titleBar->setStyleSheet(
-            "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
-            "stop:0 #5a7494, stop:0.5 #384e68, stop:1 #1e2e3e); "
-            "border-bottom: 1px solid #0a1a28; }");
-        m_titleBar->installEventFilter(this);
-
-        auto* tbRow = new QHBoxLayout(m_titleBar);
-        tbRow->setContentsMargins(6, 0, 2, 0);
-        tbRow->setSpacing(4);
-
-        auto* grip = new QLabel(QString::fromUtf8("\xe2\x8b\xae\xe2\x8b\xae"),
-                                m_titleBar);
-        grip->setStyleSheet(
-            "QLabel { background: transparent; color: #a0b4c8;"
-            " font-size: 10px; }");
-        tbRow->addWidget(grip);
-
-        auto* tbTitle = new QLabel("Network Diagnostics", m_titleBar);
-        tbTitle->setStyleSheet(
-            "QLabel { background: transparent; color: #e0ecf4;"
-            " font-size: 10px; font-weight: bold; }");
-        tbRow->addWidget(tbTitle);
-        tbRow->addStretch();
-
-        const QString btnStyle =
-            "QPushButton { background: transparent; border: none;"
-            " color: #c8d8e8; font-size: 11px; font-weight: bold;"
-            " padding: 0px 4px; }"
-            "QPushButton:hover { color: #ffffff; }";
-        const QString closeBtnStyle =
-            "QPushButton { background: transparent; border: none;"
-            " color: #c8d8e8; font-size: 11px; font-weight: bold;"
-            " padding: 0px 4px; }"
-            "QPushButton:hover { color: #ffffff; background: #cc2030; }";
-
-        auto* minBtn = new QPushButton(QString::fromUtf8("\xe2\x80\x94"), m_titleBar);
-        minBtn->setFixedSize(16, 16);
-        minBtn->setCursor(Qt::ArrowCursor);
-        minBtn->setStyleSheet(btnStyle);
-        minBtn->setToolTip("Minimize");
-        connect(minBtn, &QPushButton::clicked, this, &QWidget::showMinimized);
-        tbRow->addWidget(minBtn);
-
-        auto* maxBtn = new QPushButton(QString::fromUtf8("\xe2\x96\xa1"), m_titleBar);
-        maxBtn->setFixedSize(16, 16);
-        maxBtn->setCursor(Qt::ArrowCursor);
-        maxBtn->setStyleSheet(btnStyle);
-        maxBtn->setToolTip("Maximize");
-        connect(maxBtn, &QPushButton::clicked, this, [this]() {
-            if (isMaximized()) showNormal(); else showMaximized();
-        });
-        tbRow->addWidget(maxBtn);
-
-        auto* closeBtn = new QPushButton(QString::fromUtf8("\xc3\x97"), m_titleBar);
-        closeBtn->setFixedSize(16, 16);
-        closeBtn->setCursor(Qt::ArrowCursor);
-        closeBtn->setStyleSheet(closeBtnStyle);
-        closeBtn->setToolTip("Close");
-        connect(closeBtn, &QPushButton::clicked, this, &QDialog::accept);
-        tbRow->addWidget(closeBtn);
-
-        root->addWidget(m_titleBar);
-    }
-
-    // Content area — gets its own layout with 10 px padding so the
-    // resize hit zone (bare ~8 px margin around content) is reachable
-    // on every edge.
     auto* outerContent = new QWidget(this);
     auto* body = new QVBoxLayout(outerContent);
     body->setContentsMargins(10, 8, 10, 10);
@@ -699,16 +608,16 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     // tab bar so the tabs and the dropdown share a single row, eliminating
     // the otherwise-empty band above the tabs.
     auto* rangeLabel = new QLabel("Timeframe");
-    rangeLabel->setStyleSheet("QLabel { color: #8aa8c0; }");
+    rangeLabel->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; }");
     m_rangeCombo = new QComboBox(this);
     m_rangeCombo->setFixedWidth(132);
     m_rangeCombo->setStyleSheet(
-        "QComboBox { background: #0a0a14; border: 1px solid #203040; "
-        "border-radius: 4px; color: #c8d8e8; padding: 3px 8px; }"
-        "QComboBox:hover { border-color: #00b4d8; }"
+        "QComboBox { background: " + DesignTokens::kSurfaceSunken + "; border: 1px solid " + DesignTokens::kBorderControl + "; "
+        "border-radius: 4px; color: " + DesignTokens::kTextPrimary + "; padding: 3px 8px; }"
+        "QComboBox:hover { border-color: " + DesignTokens::kColorAccent + "; }"
         "QComboBox::drop-down { border: none; width: 18px; }"
-        "QComboBox QAbstractItemView { background: #111120; color: #c8d8e8; "
-        "selection-background-color: #00b4d8; selection-color: #000; }");
+        "QComboBox QAbstractItemView { background: " + DesignTokens::kSurfacePanel + "; color: " + DesignTokens::kTextPrimary + "; "
+        "selection-background-color: " + DesignTokens::kColorAccent + "; selection-color: #000; }");
     m_rangeCombo->addItem("1 minute", 60);
     m_rangeCombo->addItem("5 minutes", 5 * 60);
     m_rangeCombo->addItem("15 minutes", 15 * 60);
@@ -764,7 +673,7 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
         l->setMaximumWidth(kValueColumnWidth);
         l->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
         l->setMinimumHeight(l->fontMetrics().height() + 1);
-        l->setStyleSheet("QLabel { color: #c8d8e8; font-weight: bold; }");
+        l->setStyleSheet("QLabel { color: " + DesignTokens::kTextPrimary + "; font-weight: bold; }");
         return l;
     };
 
@@ -775,7 +684,7 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     auto makeNote = [](const QString& text) {
         auto* l = new QLabel(text);
         l->setWordWrap(true);
-        l->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; line-height: 1.2; }");
+        l->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: 11px; line-height: 1.2; }");
         return l;
     };
 
@@ -787,10 +696,10 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
         auto* value = new QLabel("--");
         value->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
         value->setMinimumHeight(value->fontMetrics().height() + 4);
-        value->setStyleSheet("QLabel { color: #c8d8e8; font-weight: bold; font-size: 18px; }");
+        value->setStyleSheet("QLabel { color: " + DesignTokens::kTextPrimary + "; font-weight: bold; font-size: 18px; }");
         auto* hint = new QLabel(subtitle);
         hint->setWordWrap(true);
-        hint->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; }");
+        hint->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: 11px; }");
         layout->addWidget(value);
         layout->addWidget(hint);
         layout->addStretch();
@@ -931,7 +840,7 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     m_droppedLabel->setAlignment(Qt::AlignCenter);
     m_droppedLabel->setWordWrap(true);
     m_droppedLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
-    m_droppedLabel->setStyleSheet("QLabel { color: #c8d8e8; font-weight: bold; }");
+    m_droppedLabel->setStyleSheet("QLabel { color: " + DesignTokens::kTextPrimary + "; font-weight: bold; }");
     dropGrid->addWidget(m_droppedLabel, row++, 0, 1, 2);
 
     // ── Audio Playback group ──────────────────────────────────────────────
@@ -1050,7 +959,7 @@ QWidget* NetworkDiagnosticsDialog::buildLogsTab()
     allCategories->setProperty("logCategory", QStringLiteral("default"));
     allCategories->setChecked(true);
     allCategories->setToolTip("Uncategorized Qt log output");
-    allCategories->setStyleSheet("QCheckBox { color: #c8d8e8; }");
+    allCategories->setStyleSheet("QCheckBox { color: " + DesignTokens::kTextPrimary + "; }");
     filterGrid->addWidget(allCategories, 0, 0);
     m_logCategoryCheckboxes.push_back(allCategories);
     m_visibleLogCategories.insert(QStringLiteral("default"));
@@ -1071,7 +980,7 @@ QWidget* NetworkDiagnosticsDialog::buildLogsTab()
         checkbox->setProperty("logCategory", category.id);
         checkbox->setChecked(true);
         checkbox->setToolTip(QString("%1\nCategory: %2").arg(category.description, category.id));
-        checkbox->setStyleSheet("QCheckBox { color: #c8d8e8; }");
+        checkbox->setStyleSheet("QCheckBox { color: " + DesignTokens::kTextPrimary + "; }");
         m_logCategoryCheckboxes.push_back(checkbox);
         m_visibleLogCategories.insert(category.id);
         filterGrid->addWidget(checkbox, index / kColumns, index % kColumns);
@@ -1106,7 +1015,7 @@ QWidget* NetworkDiagnosticsDialog::buildLogsTab()
     auto* infoRow = new QHBoxLayout;
     m_logPathLabel = new QLabel(page);
     m_logPathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    m_logPathLabel->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; }");
+    m_logPathLabel->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: 11px; }");
     infoRow->addWidget(m_logPathLabel, 1);
 
     m_logLiveToggle = new QPushButton("Live", page);
@@ -1115,9 +1024,11 @@ QWidget* NetworkDiagnosticsDialog::buildLogsTab()
     m_logLiveToggle->setFixedWidth(92);
     m_logLiveToggle->setToolTip("Live follows the newest log output. Turn it off to inspect older lines.");
     m_logLiveToggle->setStyleSheet(
-        "QPushButton { background: #1a2030; color: #c8d8e8; border: 1px solid #203040; "
+        "QPushButton { background: #1a2030; color: " + DesignTokens::kTextPrimary + ";"
+        " border: 1px solid " + DesignTokens::kBorderControl + "; "
         "border-radius: 4px; padding: 3px 8px; }"
-        "QPushButton:checked { background: #00607a; color: #e0f0ff; border-color: #00b4d8; }");
+        "QPushButton:checked { background: " + DesignTokens::kColorAccent + ";"
+        " color: " + DesignTokens::kTextPrimary + "; }");
     connect(m_logLiveToggle, &QPushButton::toggled, this, [this](bool live) {
         setLogFollowLive(live);
     });
@@ -1129,8 +1040,8 @@ QWidget* NetworkDiagnosticsDialog::buildLogsTab()
     m_logViewer->setLineWrapMode(QPlainTextEdit::NoWrap);
     m_logViewer->setMaximumBlockCount(2500);
     m_logViewer->setStyleSheet(
-        "QPlainTextEdit { background: #0a0a14; color: #a0b0c0; "
-        "font-family: monospace; font-size: 11px; border: 1px solid #203040; }");
+        "QPlainTextEdit { background: " + DesignTokens::kSurfaceSunken + "; color: #a0b0c0; "
+        "font-family: monospace; font-size: 11px; border: 1px solid " + DesignTokens::kBorderControl + "; }");
     new LogSyntaxHighlighter(m_logViewer->document());
     layout->addWidget(m_logViewer, 1);
 
@@ -1799,103 +1710,6 @@ void NetworkDiagnosticsDialog::updateCharts()
     m_ratesGraph->setSeries(rateSeries, rangeSeconds);
     m_lossGraph->setSeries(lossSeries, rangeSeconds);
     m_audioGraph->setSeries(audioBufferSeries, rangeSeconds);
-}
-
-// ──────────────────────────────────────────────────────────────────
-// Frameless 8-axis resize + drag-to-move
-// ──────────────────────────────────────────────────────────────────
-
-Qt::Edges NetworkDiagnosticsDialog::edgesAt(const QPoint& pos) const
-{
-    if (isMaximized() || isFullScreen()) {
-        return {};
-    }
-    Qt::Edges edges;
-    if (pos.x() <= kResizeMargin) {
-        edges |= Qt::LeftEdge;
-    } else if (pos.x() >= width() - kResizeMargin) {
-        edges |= Qt::RightEdge;
-    }
-    if (pos.y() <= kResizeMargin) {
-        edges |= Qt::TopEdge;
-    } else if (pos.y() >= height() - kResizeMargin) {
-        edges |= Qt::BottomEdge;
-    }
-    return edges;
-}
-
-void NetworkDiagnosticsDialog::updateResizeCursor(const QPoint& pos)
-{
-    const Qt::Edges edges = edgesAt(pos);
-    Qt::CursorShape shape = Qt::ArrowCursor;
-    if ((edges & (Qt::LeftEdge | Qt::TopEdge))     == (Qt::LeftEdge | Qt::TopEdge)
-        || (edges & (Qt::RightEdge | Qt::BottomEdge)) == (Qt::RightEdge | Qt::BottomEdge)) {
-        shape = Qt::SizeFDiagCursor;
-    } else if ((edges & (Qt::RightEdge | Qt::TopEdge))    == (Qt::RightEdge | Qt::TopEdge)
-        ||     (edges & (Qt::LeftEdge | Qt::BottomEdge)) == (Qt::LeftEdge | Qt::BottomEdge)) {
-        shape = Qt::SizeBDiagCursor;
-    } else if (edges & (Qt::LeftEdge | Qt::RightEdge)) {
-        shape = Qt::SizeHorCursor;
-    } else if (edges & (Qt::TopEdge | Qt::BottomEdge)) {
-        shape = Qt::SizeVerCursor;
-    }
-    setCursor(shape);
-}
-
-void NetworkDiagnosticsDialog::mouseMoveEvent(QMouseEvent* ev)
-{
-    if (!(ev->buttons() & Qt::LeftButton)) {
-        updateResizeCursor(ev->pos());
-    }
-    QDialog::mouseMoveEvent(ev);
-}
-
-void NetworkDiagnosticsDialog::mousePressEvent(QMouseEvent* ev)
-{
-    if (ev->button() == Qt::LeftButton) {
-        const Qt::Edges edges = edgesAt(ev->pos());
-        if (edges) {
-            if (auto* h = windowHandle()) {
-                h->startSystemResize(edges);
-                ev->accept();
-                return;
-            }
-        }
-    }
-    QDialog::mousePressEvent(ev);
-}
-
-void NetworkDiagnosticsDialog::leaveEvent(QEvent* ev)
-{
-    setCursor(Qt::ArrowCursor);
-    QDialog::leaveEvent(ev);
-}
-
-bool NetworkDiagnosticsDialog::eventFilter(QObject* obj, QEvent* ev)
-{
-    // Drag-to-move via the custom title bar.  The trio buttons are
-    // their own QPushButtons that consume the press themselves, so
-    // this only fires on the bare title-bar background.
-    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonPress) {
-        auto* me = static_cast<QMouseEvent*>(ev);
-        if (me->button() == Qt::LeftButton) {
-            if (auto* h = windowHandle()) {
-                h->startSystemMove();
-                me->accept();
-                return true;
-            }
-        }
-    }
-    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonDblClick) {
-        if (isMaximized()) {
-            showNormal();
-        } else {
-            showMaximized();
-        }
-        ev->accept();
-        return true;
-    }
-    return QDialog::eventFilter(obj, ev);
 }
 
 } // namespace AetherSDR

--- a/src/gui/NetworkDiagnosticsDialog.h
+++ b/src/gui/NetworkDiagnosticsDialog.h
@@ -74,15 +74,6 @@ public:
                                       NetworkDiagnosticsHistory* history,
                                       QWidget* parent = nullptr);
 
-protected:
-    // Frameless 8-axis resize: 4 edges + 4 corners.  Hovering the bare
-    // margin around the content updates the cursor; pressing starts a
-    // compositor-managed resize via QWindow::startSystemResize.
-    void mouseMoveEvent(QMouseEvent* ev) override;
-    void mousePressEvent(QMouseEvent* ev) override;
-    void leaveEvent(QEvent* ev) override;
-    bool eventFilter(QObject* obj, QEvent* ev) override;
-
 private:
     struct LogLine {
         QString text;
@@ -103,10 +94,6 @@ private:
     void setLogFollowLive(bool on);
     void setAllLogCategoriesVisible(bool visible);
     int selectedRangeSeconds() const;
-    Qt::Edges edgesAt(const QPoint& pos) const;
-    void updateResizeCursor(const QPoint& pos);
-
-    QWidget* m_titleBar{nullptr};
 
     RadioModel* m_model;
     AudioEngine* m_audio;

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -26,10 +26,6 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
 
-    setStyleSheet(
-        "PanadapterApplet { border: 1px solid " + DesignTokens::kBorderControl + "; "
-        "border-radius: 4px; }");
-
     // ── Title bar ─────────────────────────────────────────────────────────
     m_titleBar = new QWidget;
     m_titleBar->setFixedHeight(16);

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -1,4 +1,5 @@
 #include "PanadapterApplet.h"
+#include "DesignTokens.h"
 #include "GuardedSlider.h"
 #include "SpectrumWidget.h"
 #include "core/AppSettings.h"
@@ -25,13 +26,16 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
 
-    // ── Title bar (16px gradient, matching applet style) ─────────────────
+    setStyleSheet(
+        "PanadapterApplet { border: 1px solid " + DesignTokens::kBorderControl + "; "
+        "border-radius: 4px; }");
+
+    // ── Title bar ─────────────────────────────────────────────────────────
     m_titleBar = new QWidget;
     m_titleBar->setFixedHeight(16);
     m_titleBar->setStyleSheet(
-        "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
-        "stop:0 #3a4a5a, stop:0.5 #2a3a4a, stop:1 #1a2a38); "
-        "border-bottom: 1px solid #0a1a28; }");
+        "QWidget { background: " + DesignTokens::kSurfaceOverlay + "; "
+        "border-bottom: 1px solid " + DesignTokens::kBorderSubtle + "; }");
     m_titleBar->installEventFilter(this);  // drag-to-move when floating
     auto* titleBar = m_titleBar;
 
@@ -45,15 +49,15 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     barLayout->addWidget(grip);
 
     m_titleLabel = new QLabel("Slice A");
-    m_titleLabel->setStyleSheet("QLabel { background: transparent; color: #8aa8c0; "
+    m_titleLabel->setStyleSheet("QLabel { background: transparent; color: " + DesignTokens::kTextSecondary + "; "
                                 "font-size: 10px; font-weight: bold; }");
     barLayout->addWidget(m_titleLabel);
     barLayout->addStretch();
 
-    const QString btnStyle = QStringLiteral(
-        "QPushButton { background: transparent; color: #6a8090; "
-        "border: none; font-size: 9px; padding: 0; }"
-        "QPushButton:hover { color: #c8d8e8; }");
+    const QString btnStyle =
+        QStringLiteral("QPushButton { background: transparent; color: ") + DesignTokens::kTextSecondary +
+        QStringLiteral("; border: none; font-size: 9px; padding: 0; }"
+                       "QPushButton:hover { color: ") + DesignTokens::kTextPrimary + QStringLiteral("; }");
 
     // Pop-out / Dock button (⬈ when docked, ↩ when floating)
     m_popOutBtn = new QPushButton("\u2b08");  // ⬈
@@ -104,7 +108,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_cwPanel->setCursor(Qt::ArrowCursor);  // prevent invisible cursor from native-window parent (#1096)
     m_cwPanel->setFixedHeight(80);
     m_cwPanel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    m_cwPanel->setStyleSheet("QWidget { background: #0a0a14; border-top: 1px solid #203040; }");
+    m_cwPanel->setStyleSheet("QWidget { background: " + DesignTokens::kSurfaceSunken + "; border-top: 1px solid " + DesignTokens::kBorderControl + "; }");
 
     auto* cwLayout = new QVBoxLayout(m_cwPanel);
     cwLayout->setContentsMargins(4, 2, 4, 2);
@@ -114,21 +118,21 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     auto* cwBar = new QHBoxLayout;
     cwBar->setSpacing(6);
     auto* cwTitle = new QLabel("CW");
-    cwTitle->setStyleSheet("QLabel { color: #00b4d8; font-size: 10px; font-weight: bold; background: transparent; }");
+    cwTitle->setStyleSheet("QLabel { color: " + DesignTokens::kColorAccent + "; font-size: 10px; font-weight: bold; background: transparent; }");
     cwBar->addWidget(cwTitle);
     auto* cwHint = new QLabel("(requires PC Audio)");
-    cwHint->setStyleSheet("QLabel { color: #405060; font-size: 9px; background: transparent; }");
+    cwHint->setStyleSheet("QLabel { color: " + DesignTokens::kTextTertiary + "; font-size: 9px; background: transparent; }");
     cwBar->addWidget(cwHint);
 
     m_cwStatsLabel = new QLabel;
-    m_cwStatsLabel->setStyleSheet("QLabel { color: #6a8090; font-size: 10px; background: transparent; }");
+    m_cwStatsLabel->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: 10px; background: transparent; }");
     m_cwStatsLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     m_cwStatsLabel->setFixedWidth(m_cwStatsLabel->fontMetrics().horizontalAdvance("1200 Hz  120 WPM"));
     cwBar->addWidget(m_cwStatsLabel);
 
     // Sensitivity slider — filters low-confidence decodes
     auto* sensLabel = new QLabel("Sens:");
-    sensLabel->setStyleSheet("QLabel { color: #6a8090; font-size: 9px; background: transparent; }");
+    sensLabel->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: 9px; background: transparent; }");
     cwBar->addWidget(sensLabel);
     m_cwSensSlider = new GuardedSlider(Qt::Horizontal);
     m_cwSensSlider->setRange(0, 100);  // 0=show everything, 100=only high confidence
@@ -137,7 +141,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_cwSensSlider->setFixedWidth(60);
     m_cwSensSlider->setStyleSheet(
         "QSlider::groove:horizontal { background: #1a2a3a; height: 4px; border-radius: 2px; }"
-        "QSlider::handle:horizontal { background: #00b4d8; width: 10px; margin: -3px 0; border-radius: 5px; }");
+        "QSlider::handle:horizontal { background: " + DesignTokens::kColorAccent + "; width: 10px; margin: -3px 0; border-radius: 5px; }");
     m_cwCostThreshold = 1.0f - (savedSens / 100.0f) * 0.9f;
     connect(m_cwSensSlider, &QSlider::valueChanged, this, [this](int v) {
         // Map 0-100 slider to 1.0-0.1 cost threshold (inverted: higher sens = lower threshold)
@@ -153,10 +157,10 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_lockPitchBtn->setFixedSize(28, 16);
     m_lockPitchBtn->setToolTip("Lock decoder pitch to current frequency");
     m_lockPitchBtn->setStyleSheet(
-        "QPushButton { background: #1a2a3a; color: #6a8090; border: 1px solid #203040;"
-        " border-radius: 2px; font-size: 8px; padding: 0; }"
-        "QPushButton:checked { color: #00b4d8; border-color: #00b4d8; }"
-        "QPushButton:hover { color: #c8d8e8; }");
+        "QPushButton { background: #1a2a3a; color: " + DesignTokens::kTextSecondary + "; border: 1px solid " + DesignTokens::kBorderControl + ";"
+        " border-radius: " + QString::number(DesignTokens::kCtrlRadius) + "px; font-size: " + QString::number(DesignTokens::kFontSm) + "px; padding: 0; }"
+        "QPushButton:checked { color: " + DesignTokens::kColorAccent + "; border-color: " + DesignTokens::kColorAccent + "; }"
+        "QPushButton:hover { color: " + DesignTokens::kTextPrimary + "; }");
     cwBar->addWidget(m_lockPitchBtn);
 
     // Lock Speed button
@@ -170,10 +174,10 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     // Pitch range sliders — constrain decoder frequency search
     const QString rangeSliderStyle =
         "QSlider::groove:horizontal { background: #1a2a3a; height: 4px; border-radius: 2px; }"
-        "QSlider::handle:horizontal { background: #6a8090; width: 8px; margin: -3px 0; border-radius: 4px; }";
+        "QSlider::handle:horizontal { background: " + DesignTokens::kTextSecondary + "; width: " + QString::number(DesignTokens::kCtrlHandleW) + "px; margin: -3px 0; border-radius: " + QString::number(DesignTokens::kCtrlHandleW / 2) + "px; }";
 
     auto* minLabel = new QLabel("Lo:");
-    minLabel->setStyleSheet("QLabel { color: #6a8090; font-size: 8px; background: transparent; }");
+    minLabel->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: " + QString::number(DesignTokens::kFontSm) + "px; background: transparent; }");
     cwBar->addWidget(minLabel);
 
     m_pitchMinSlider = new GuardedSlider(Qt::Horizontal);
@@ -184,12 +188,12 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_pitchMinSlider->setToolTip("Decoder pitch search minimum (Hz)");
     cwBar->addWidget(m_pitchMinSlider);
     m_pitchMinValLabel = new QLabel(QString::number(m_pitchMinSlider->value()));
-    m_pitchMinValLabel->setStyleSheet("QLabel { color: #6a8090; font-size: 8px; background: transparent; }");
+    m_pitchMinValLabel->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: " + QString::number(DesignTokens::kFontSm) + "px; background: transparent; }");
     m_pitchMinValLabel->setFixedWidth(24);
     cwBar->addWidget(m_pitchMinValLabel);
 
     auto* maxLabel = new QLabel("Hi:");
-    maxLabel->setStyleSheet("QLabel { color: #6a8090; font-size: 8px; background: transparent; }");
+    maxLabel->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: " + QString::number(DesignTokens::kFontSm) + "px; background: transparent; }");
     cwBar->addWidget(maxLabel);
 
     m_pitchMaxSlider = new GuardedSlider(Qt::Horizontal);
@@ -200,7 +204,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_pitchMaxSlider->setToolTip("Decoder pitch search maximum (Hz)");
     cwBar->addWidget(m_pitchMaxSlider);
     m_pitchMaxValLabel = new QLabel(QString::number(m_pitchMaxSlider->value()));
-    m_pitchMaxValLabel->setStyleSheet("QLabel { color: #6a8090; font-size: 8px; background: transparent; }");
+    m_pitchMaxValLabel->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: " + QString::number(DesignTokens::kFontSm) + "px; background: transparent; }");
     m_pitchMaxValLabel->setFixedWidth(24);
     cwBar->addWidget(m_pitchMaxValLabel);
 
@@ -231,10 +235,10 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     cwBar->addStretch();
 
     const QString cwBtnStyle =
-        "QPushButton { background: #1a2a3a; color: #8090a0; border: 1px solid #203040;"
-        " border-radius: 2px; font-size: 9px; font-weight: bold;"
+        "QPushButton { background: #1a2a3a; color: " + DesignTokens::kTextSecondary + "; border: 1px solid " + DesignTokens::kBorderControl + ";"
+        " border-radius: " + QString::number(DesignTokens::kCtrlRadius) + "px; font-size: " + QString::number(DesignTokens::kFontSm) + "px; font-weight: bold;"
         " padding: 1px 6px; }"
-        "QPushButton:hover { color: #c8d8e8; background: #2a3a4a; }";
+        "QPushButton:hover { color: " + DesignTokens::kTextPrimary + "; background: #2a3a4a; }";
 
     auto* copyAllBtn = new QPushButton("CPY ALL");
     copyAllBtn->setToolTip("Copy all decoded text to clipboard");
@@ -264,8 +268,8 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     auto* closeBtn = new QPushButton("\u2715");
     closeBtn->setToolTip("Close CW decoder");
     closeBtn->setStyleSheet(
-        "QPushButton { background: #1a2a3a; color: #8090a0; border: 1px solid #203040;"
-        " border-radius: 2px; font-size: 9px; font-weight: bold;"
+        "QPushButton { background: #1a2a3a; color: " + DesignTokens::kTextSecondary + "; border: 1px solid " + DesignTokens::kBorderControl + ";"
+        " border-radius: " + QString::number(DesignTokens::kCtrlRadius) + "px; font-size: " + QString::number(DesignTokens::kFontSm) + "px; font-weight: bold;"
         " padding: 1px 6px; }"
         "QPushButton:hover { color: #ff6060; background: #2a3a4a; }");
     connect(closeBtn, &QPushButton::clicked, this, [this]() {

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1,4 +1,5 @@
 #include "RxApplet.h"
+#include "DesignTokens.h"
 #include "FilterPassbandWidget.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
@@ -101,23 +102,23 @@ namespace AetherSDR {
 
 // ── Style constants (matching STYLEGUIDE.md) ────────────────────────────────
 
-static constexpr const char* kButtonBase =
-    "QPushButton { background: #1a2a3a; border: 1px solid #205070; "
-    "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; "
+static const QString kButtonBase =
+    "QPushButton { background: #1a2a3a; border: 1px solid " + DesignTokens::kBorderInteractive + "; "
+    "border-radius: 3px; color: " + DesignTokens::kTextPrimary + "; font-size: 10px; font-weight: bold; "
     "padding: 1px 2px; }"
     "QPushButton:hover { background: #204060; }";
 
-static constexpr const char* kSliderStyle =
-    "QSlider::groove:horizontal { height: 4px; background: #203040; border-radius: 2px; }"
+static const QString kSliderStyle =
+    "QSlider::groove:horizontal { height: 4px; background: " + DesignTokens::kBorderControl + "; border-radius: 2px; }"
     "QSlider::handle:horizontal { width: 10px; height: 10px; margin: -3px 0;"
-    "background: #00b4d8; border-radius: 5px; }";
+    "background: " + DesignTokens::kColorAccent + "; border-radius: 5px; }";
 
-static constexpr const char* kDimLabelStyle =
-    "QLabel { color: #8090a0; font-size: 11px; }";
+static const QString kDimLabelStyle =
+    "QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: 11px; }";
 
-static constexpr const char* kInsetValueStyle =
-    "QLabel { font-size: 10px; background: #0a0a18; border: 1px solid #1e2e3e; "
-    "border-radius: 3px; padding: 1px 2px; color: #c8d8e8; }";
+static const QString kInsetValueStyle =
+    "QLabel { font-size: 10px; background: " + DesignTokens::kSurfaceSunken + "; border: 1px solid " + DesignTokens::kBorderSubtle + "; "
+    "border-radius: 3px; padding: 1px 2px; color: " + DesignTokens::kTextPrimary + "; }";
 
 static const QString kBlueActive =
     "QPushButton:checked { background-color: #0070c0; color: #ffffff; "

--- a/src/gui/Theme.h
+++ b/src/gui/Theme.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QString>
+#include "DesignTokens.h"
 
 namespace AetherSDR {
 
@@ -9,69 +10,76 @@ namespace AetherSDR {
 // complete theme instead of falling back to the system palette.
 inline QString darkThemeStylesheet()
 {
-    return QStringLiteral(R"(
-        QWidget {
-            background-color: #0f0f1a;
-            color: #c8d8e8;
-            font-family: "Inter", "Segoe UI", sans-serif;
-            font-size: 13px;
-        }
-        QGroupBox {
-            border: 1px solid #203040;
-            border-radius: 4px;
-            margin-top: 8px;
-            padding-top: 8px;
-        }
-        QGroupBox::title {
-            subcontrol-origin: margin;
-            left: 8px;
-            color: #00b4d8;
-        }
-        QPushButton {
-            background-color: #1a2a3a;
-            border: 1px solid #203040;
-            border-radius: 4px;
-            padding: 4px 10px;
-            color: #c8d8e8;
-        }
-        QPushButton:hover  { background-color: #203040; }
-        QPushButton:pressed { background-color: #00b4d8; color: #000; }
-        QComboBox {
-            background-color: #1a2a3a;
-            border: 1px solid #203040;
-            border-radius: 4px;
-            padding: 3px 6px;
-        }
-        QComboBox::drop-down { border: none; }
-        QListWidget {
-            background-color: #111120;
-            border: 1px solid #203040;
-            alternate-background-color: #161626;
-        }
-        QListWidget::item:selected { background-color: #00b4d8; color: #000; }
-        QSlider::groove:horizontal {
-            height: 4px;
-            background: #203040;
-            border-radius: 2px;
-        }
-        QSlider::handle:horizontal {
-            width: 14px; height: 14px;
-            margin: -5px 0;
-            background: #00b4d8;
-            border-radius: 7px;
-        }
-        QMenuBar { background-color: #0a0a14; }
-        QMenuBar::item:selected { background-color: #1a2a3a; }
-        QMenu { background-color: #111120; border: 1px solid #203040; }
-        QMenu::item:selected { background-color: #00b4d8; color: #000; }
-        QStatusBar { background-color: #0a0a14; border-top: 1px solid #203040; }
-        QProgressBar {
-            background-color: #111120;
-            border: 1px solid #203040;
-            border-radius: 3px;
-        }
-        QSplitter::handle { background-color: #203040; width: 2px; }
-    )");
+    using namespace DesignTokens;
+    const QString hw  = QString::number(kCtrlHandleW);
+    const QString hm  = QString::number(-3);
+    const QString hr  = QString::number(kCtrlHandleW / 2);
+    const QString rad = QString::number(kCtrlRadius);
+
+    return
+        QStringLiteral("QWidget { background-color: ")  + kSurfaceBase
+        + QStringLiteral("; color: ")                    + kTextPrimary
+        + QStringLiteral("; font-family: \"Inter\", \"Segoe UI\", sans-serif; font-size: 13px; }")
+
+        + QStringLiteral("QGroupBox { border: 1px solid ") + kBorderControl
+        + QStringLiteral("; border-radius: ")              + rad
+        + QStringLiteral("px; margin-top: 8px; padding-top: 8px; }")
+
+        + QStringLiteral("QGroupBox::title { subcontrol-origin: margin; left: 8px; color: ")
+        + kTextAccent + QStringLiteral("; }")
+
+        + QStringLiteral("QPushButton { background-color: #1a2a3a; border: 1px solid ")
+        + kBorderControl + QStringLiteral("; border-radius: ") + rad
+        + QStringLiteral("px; padding: 4px 10px; color: ") + kTextPrimary + QStringLiteral("; }")
+
+        + QStringLiteral("QPushButton:hover { background-color: ")  + kSurfaceOverlay
+        + QStringLiteral("; }")
+
+        + QStringLiteral("QPushButton:pressed { background-color: ") + kColorAccent
+        + QStringLiteral("; color: #000; }")
+
+        + QStringLiteral("QComboBox { background-color: #1a2a3a; border: 1px solid ")
+        + kBorderControl + QStringLiteral("; border-radius: ") + rad
+        + QStringLiteral("px; padding: 3px 6px; }")
+
+        + QStringLiteral("QComboBox::drop-down { border: none; }")
+
+        + QStringLiteral("QListWidget { background-color: #111120; border: 1px solid ")
+        + kBorderControl + QStringLiteral("; alternate-background-color: #161626; }")
+
+        + QStringLiteral("QListWidget::item:selected { background-color: ") + kColorAccent
+        + QStringLiteral("; color: #000; }")
+
+        + QStringLiteral("QSlider::groove:horizontal { height: 4px; background: ")
+        + kBorderControl + QStringLiteral("; border-radius: 2px; }")
+
+        + QStringLiteral("QSlider::handle:horizontal { width: ") + hw
+        + QStringLiteral("px; height: ") + hw
+        + QStringLiteral("px; margin: ") + hm
+        + QStringLiteral("px 0; background: ") + kColorAccent
+        + QStringLiteral("; border-radius: ") + hr
+        + QStringLiteral("px; }")
+
+        + QStringLiteral("QMenuBar { background-color: ") + kSurfaceSunken
+        + QStringLiteral("; }")
+
+        + QStringLiteral("QMenuBar::item:selected { background-color: #1a2a3a; }")
+
+        + QStringLiteral("QMenu { background-color: #111120; border: 1px solid ")
+        + kBorderControl + QStringLiteral("; }")
+
+        + QStringLiteral("QMenu::item:selected { background-color: ") + kColorAccent
+        + QStringLiteral("; color: #000; }")
+
+        + QStringLiteral("QStatusBar { background-color: ") + kSurfaceSunken
+        + QStringLiteral("; border-top: 1px solid ") + kBorderControl
+        + QStringLiteral("; }")
+
+        + QStringLiteral("QProgressBar { background-color: #111120; border: 1px solid ")
+        + kBorderControl + QStringLiteral("; border-radius: 3px; }")
+
+        + QStringLiteral("QSplitter::handle { background-color: ")
+        + kBorderControl + QStringLiteral("; width: 2px; }");
 }
 
 } // namespace AetherSDR

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -1,4 +1,5 @@
 #include "TxApplet.h"
+#include "DesignTokens.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "HGauge.h"
@@ -23,7 +24,7 @@ namespace AetherSDR {
 static QLabel* makeIndicator(const QString& text)
 {
     auto* lbl = new QLabel(text);
-    lbl->setStyleSheet("QLabel { color: #405060; font-size: 9px; font-weight: bold; }");
+    lbl->setStyleSheet("QLabel { color: " + DesignTokens::kTextTertiary + "; font-size: 9px; font-weight: bold; }");
     lbl->setAlignment(Qt::AlignCenter);
     return lbl;
 }
@@ -34,16 +35,16 @@ static void setIndicatorActive(QLabel* lbl, bool active, const QColor& color = Q
         lbl->setStyleSheet(
             QString("QLabel { color: %1; font-size: 9px; font-weight: bold; }").arg(color.name()));
     } else {
-        lbl->setStyleSheet("QLabel { color: #405060; font-size: 9px; font-weight: bold; }");
+        lbl->setStyleSheet("QLabel { color: " + DesignTokens::kTextTertiary + "; font-size: 9px; font-weight: bold; }");
     }
 }
 
 // ── Compact slider row: "Label:  [slider] value" ────────────────────────────
 
-static constexpr const char* kSliderStyle =
-    "QSlider::groove:horizontal { height: 4px; background: #203040; border-radius: 2px; }"
+static const QString kSliderStyle =
+    "QSlider::groove:horizontal { height: 4px; background: " + DesignTokens::kBorderControl + "; border-radius: 2px; }"
     "QSlider::handle:horizontal { width: 10px; height: 10px; margin: -3px 0;"
-    "background: #00b4d8; border-radius: 5px; }";
+    "background: " + DesignTokens::kColorAccent + "; border-radius: 5px; }";
 
 // ── TxApplet ────────────────────────────────────────────────────────────────
 
@@ -88,7 +89,7 @@ void TxApplet::buildUI()
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
         auto* label = new QLabel("RF Power:");
-        label->setStyleSheet("QLabel { color: #8aa8c0; font-size: 10px; }");
+        label->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: 10px; }");
         label->setFixedWidth(62);
         row->addWidget(label);
 
@@ -100,8 +101,8 @@ void TxApplet::buildUI()
         row->addWidget(m_rfPowerSlider, 1);
 
         m_rfPowerLabel = new QLabel("100");
-        m_rfPowerLabel->setStyleSheet("QLabel { color: #c8d8e8; font-size: 10px; }");
-        m_rfPowerLabel->setFixedWidth(30);
+        m_rfPowerLabel->setStyleSheet("QLabel { color: " + DesignTokens::kTextPrimary + "; font-size: 10px; }");
+        m_rfPowerLabel->setFixedWidth(22);
         m_rfPowerLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         row->addWidget(m_rfPowerLabel);
         vbox->addLayout(row);
@@ -112,7 +113,7 @@ void TxApplet::buildUI()
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
         auto* label = new QLabel("Tune Pwr:");
-        label->setStyleSheet("QLabel { color: #8aa8c0; font-size: 10px; }");
+        label->setStyleSheet("QLabel { color: " + DesignTokens::kTextSecondary + "; font-size: 10px; }");
         label->setFixedWidth(62);
         row->addWidget(label);
 
@@ -124,8 +125,8 @@ void TxApplet::buildUI()
         row->addWidget(m_tunePowerSlider, 1);
 
         m_tunePowerLabel = new QLabel("10");
-        m_tunePowerLabel->setStyleSheet("QLabel { color: #c8d8e8; font-size: 10px; }");
-        m_tunePowerLabel->setFixedWidth(30);
+        m_tunePowerLabel->setStyleSheet("QLabel { color: " + DesignTokens::kTextPrimary + "; font-size: 10px; }");
+        m_tunePowerLabel->setFixedWidth(22);
         m_tunePowerLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         row->addWidget(m_tunePowerLabel);
         vbox->addLayout(row);
@@ -160,13 +161,15 @@ void TxApplet::buildUI()
         auto* row = new QHBoxLayout;
         row->setSpacing(2);
 
-        const char* btnStyle =
-            "QPushButton { background: #1a3a5a; border: 1px solid #205070; "
-            "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; "
+        const QString btnStyle =
+            "QPushButton { background: #1a3a5a; border: 1px solid " + DesignTokens::kBorderInteractive + "; "
+            "border-radius: 3px; color: " + DesignTokens::kTextPrimary + "; font-size: 10px; font-weight: bold; "
             "padding: 2px; }"
             "QPushButton:hover { background: #204060; }"
             "QPushButton:disabled { background-color: #1a1a2a; color: #556070; "
-            "border: 1px solid #2a3040; }";
+            "border: 1px solid #2a3040; }"
+            "QPushButton[txActive=\"true\"] { background: " + DesignTokens::kColorDanger + "; "
+            "border: 1px solid #ff4444; color: #ffffff; }";
 
         m_tuneBtn = new QPushButton("TUNE");
         m_tuneBtn->setStyleSheet(btnStyle);
@@ -217,8 +220,8 @@ void TxApplet::buildUI()
         m_apdBtn->setAccessibleDescription("Toggle adaptive pre-distortion");
         m_apdBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_apdBtn->setStyleSheet(
-            "QPushButton { background: #1a3a5a; border: 1px solid #205070; "
-            "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; }"
+            "QPushButton { background: #1a3a5a; border: 1px solid " + DesignTokens::kBorderInteractive + "; "
+            "border-radius: 3px; color: " + DesignTokens::kTextPrimary + "; font-size: 10px; font-weight: bold; }"
             "QPushButton:checked { background: #006030; border: 1px solid #008040; color: #fff; }"
             "QPushButton:hover { background: #204060; }");
         row->addWidget(m_apdBtn, 2);  // 40%
@@ -229,7 +232,7 @@ void TxApplet::buildUI()
         inset->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         inset->setObjectName("atuInset");
         inset->setStyleSheet(
-            "#atuInset { background: #0a0a18; border: 1px solid #1e2e3e; border-radius: 3px; }"
+            "#atuInset { background: " + DesignTokens::kSurfaceSunken + "; border: 1px solid " + DesignTokens::kBorderSubtle + "; border-radius: 3px; }"
             "#atuInset QLabel { border: none; background: transparent; }");
         auto* insetLayout = new QHBoxLayout(inset);
         insetLayout->setContentsMargins(4, 0, 4, 0);
@@ -240,7 +243,7 @@ void TxApplet::buildUI()
         m_availInd  = makeIndicator("Avail");
         // Larger font for status words inside the inset
         const QString indStyle =
-            "QLabel { color: #405060; font-size: 11px; font-weight: bold; background: transparent; }";
+            "QLabel { color: " + DesignTokens::kTextTertiary + "; font-size: 11px; font-weight: bold; background: transparent; }";
         m_activeInd->setStyleSheet(indStyle);
         m_calInd->setStyleSheet(indStyle);
         m_availInd->setStyleSheet(indStyle);
@@ -337,36 +340,21 @@ void TxApplet::setTransmitModel(TransmitModel* model)
     // Transmit state changes → update sliders, tune button
     connect(m_model, &TransmitModel::stateChanged, this, &TxApplet::syncFromModel);
 
-    // Tune state → red button
+    // Tune state → red button (via dynamic property, no full stylesheet rebuild)
     connect(m_model, &TransmitModel::tuneChanged, this, [this](bool tuning) {
-        if (tuning) {
-            m_tuneBtn->setStyleSheet(
-                "QPushButton { background: #cc2222; border: 1px solid #ff4444; "
-                "border-radius: 3px; color: #ffffff; font-size: 10px; font-weight: bold; "
-                "padding: 2px; }");
-            m_tuneBtn->setText("TUNING...");
-        } else {
-            m_tuneBtn->setStyleSheet(
-                "QPushButton { background: #1a3a5a; border: 1px solid #205070; "
-                "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; "
-                "padding: 2px; }"
-                "QPushButton:hover { background: #204060; }");
-            m_tuneBtn->setText("TUNE");
-        }
+        m_tuneBtn->setProperty("txActive", tuning);
+        m_tuneBtn->style()->unpolish(m_tuneBtn);
+        m_tuneBtn->style()->polish(m_tuneBtn);
+        m_tuneBtn->setText(tuning ? "TUNING..." : "TUNE");
     });
 
-    // MOX / transmit state → red button
+    // MOX / transmit state → red button (via dynamic property)
     connect(m_model, &TransmitModel::moxChanged, this, [this](bool tx) {
         m_updatingFromModel = true;
         m_moxBtn->setChecked(tx);
-        m_moxBtn->setStyleSheet(tx
-            ? "QPushButton { background: #cc2222; border: 1px solid #ff4444; "
-              "border-radius: 3px; color: #ffffff; font-size: 10px; font-weight: bold; "
-              "padding: 2px; }"
-            : "QPushButton { background: #1a3a5a; border: 1px solid #205070; "
-              "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; "
-              "padding: 2px; }"
-              "QPushButton:hover { background: #204060; }");
+        m_moxBtn->setProperty("txActive", tx);
+        m_moxBtn->style()->unpolish(m_moxBtn);
+        m_moxBtn->style()->polish(m_moxBtn);
         m_updatingFromModel = false;
     });
 

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1,4 +1,5 @@
 #include "VfoWidget.h"
+#include "DesignTokens.h"
 #include "PhaseKnob.h"
 #include "ComboStyle.h"
 #include "GuardedSlider.h"
@@ -502,7 +503,7 @@ void VfoWidget::buildUI()
     m_freqLabel->setStyleSheet("QLabel { background: transparent;"
                                 " border: 1px solid rgba(255,255,255,80);"
                                 " border-radius: 3px;"
-                                " color: #c8d8e8; font-size: 26px; font-weight: bold;"
+                                " color: " + DesignTokens::kTextPrimary + "; font-size: " + QString::number(DesignTokens::kFontFreq) + "px; font-weight: bold;"
                                 " padding: 0 0 0 2px; }");
     m_freqLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     m_freqLabel->installEventFilter(this);
@@ -510,7 +511,7 @@ void VfoWidget::buildUI()
 
     m_freqEdit = new QLineEdit;
     m_freqEdit->setStyleSheet(
-        "QLineEdit { background: #0a0a18; border: 1px solid #00b4d8;"
+        "QLineEdit { background: " + DesignTokens::kSurfaceSunken + "; border: 1px solid " + DesignTokens::kColorAccent + ";"
         " border-radius: 3px; color: #00e5ff; font-size: 22px;"
         " font-weight: bold; padding: 0 2px 0 0; }");
     m_freqEdit->setAlignment(Qt::AlignRight);

--- a/src/gui/containers/ContainerTitleBar.cpp
+++ b/src/gui/containers/ContainerTitleBar.cpp
@@ -1,4 +1,5 @@
 #include "ContainerTitleBar.h"
+#include "gui/DesignTokens.h"
 
 #include <QHBoxLayout>
 #include <QLabel>
@@ -9,18 +10,17 @@ namespace AetherSDR {
 
 namespace {
 
-constexpr const char* kBarStyle =
-    "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
-    "stop:0 #5a7494, stop:0.5 #384e68, stop:1 #1e2e3e); "
-    "border-bottom: 1px solid #0a1a28; }";
+static const QString kBarStyle =
+    "QWidget { background: " + DesignTokens::kSurfaceOverlay + "; "
+    "border-bottom: 1px solid " + DesignTokens::kBorderSubtle + "; }";
 
-constexpr const char* kTitleStyle =
-    "QLabel { background: transparent; color: #e0ecf4; "
+static const QString kTitleStyle =
+    "QLabel { background: transparent; color: " + DesignTokens::kTextPrimary + "; "
     "font-size: 10px; font-weight: bold; }";
 
-constexpr const char* kBtnStyle =
+static const QString kBtnStyle =
     "QPushButton { background: transparent; border: none; "
-    "color: #c8d8e8; font-size: 11px; font-weight: bold; "
+    "color: " + DesignTokens::kTextPrimary + "; font-size: 11px; font-weight: bold; "
     "padding: 0px 4px; } "
     "QPushButton:hover { color: #ffffff; }";
 

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -49,14 +49,9 @@ void ContainerWidget::paintEvent(QPaintEvent* /*event*/)
 {
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing);
-    // Card background
-    QColor bg;
-    bg.setNamedColor(DesignTokens::kSurfacePanel);
-    p.setBrush(bg);
-    // Card border
-    QColor border;
-    border.setNamedColor(DesignTokens::kBorderControl);
-    p.setPen(QPen(border, 1));
+    // Card background + border (use fromString to avoid setNamedColor deprecation)
+    p.setBrush(QColor::fromString(DesignTokens::kSurfacePanel));
+    p.setPen(QPen(QColor::fromString(DesignTokens::kBorderControl), 1));
     p.drawRoundedRect(rect().adjusted(0, 0, -1, -1), 2, 2);
 }
 

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -1,9 +1,12 @@
 #include "ContainerWidget.h"
 #include "ContainerTitleBar.h"
+#include "gui/DesignTokens.h"
 
 #include <QDrag>
 #include <QMimeData>
+#include <QPainter>
 #include <QPixmap>
+#include <QStyleOption>
 #include <QVBoxLayout>
 #include <QWindow>
 
@@ -14,8 +17,13 @@ ContainerWidget::ContainerWidget(const QString& id, const QString& title,
     : QWidget(parent)
     , m_id(id)
 {
+    setAttribute(Qt::WA_StyledBackground, true);
     auto* outer = new QVBoxLayout(this);
-    outer->setContentsMargins(0, 0, 0, 0);
+    // 1px margins reveal the card background + border painted in paintEvent
+    // below the opaque children (TitleBar + Body).  Without this gap the
+    // global QWidget { background-color } from Theme.h makes the body widget
+    // opaque, covering the border entirely.
+    outer->setContentsMargins(1, 1, 1, 1);
     outer->setSpacing(0);
 
     m_titleBar = new ContainerTitleBar(title, this);
@@ -23,7 +31,7 @@ ContainerWidget::ContainerWidget(const QString& id, const QString& title,
 
     m_body = new QWidget(this);
     m_bodyLayout = new QVBoxLayout(m_body);
-    m_bodyLayout->setContentsMargins(0, 0, 0, 0);
+    m_bodyLayout->setContentsMargins(2, 2, 2, 2);
     m_bodyLayout->setSpacing(0);
     outer->addWidget(m_body, 1);
 
@@ -36,6 +44,21 @@ ContainerWidget::ContainerWidget(const QString& id, const QString& title,
 }
 
 ContainerWidget::~ContainerWidget() = default;
+
+void ContainerWidget::paintEvent(QPaintEvent* /*event*/)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+    // Card background
+    QColor bg;
+    bg.setNamedColor(DesignTokens::kSurfacePanel);
+    p.setBrush(bg);
+    // Card border
+    QColor border;
+    border.setNamedColor(DesignTokens::kBorderControl);
+    p.setPen(QPen(border, 1));
+    p.drawRoundedRect(rect().adjusted(0, 0, -1, -1), 2, 2);
+}
 
 void ContainerWidget::setTitle(const QString& title)
 {

--- a/src/gui/containers/ContainerWidget.h
+++ b/src/gui/containers/ContainerWidget.h
@@ -31,6 +31,10 @@ public:
                              QWidget* parent = nullptr);
     ~ContainerWidget() override;
 
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+public:
     // Stable identifier used by the manager for path-based lookup
     // and by persistence to key each container's state.
     QString id() const { return m_id; }


### PR DESCRIPTION
## Summary

Implements RFC #2294 — Flat Design System, Phases 1-4:

- **Phase 1:** New `DesignTokens.h` vocabulary, Theme.h rewritten to use tokens, ComboStyle.h token substitution
- **Phase 2:** PanadapterApplet title bar gradient → flat
- **Phase 3:** RxApplet/TxApplet token substitution + dynamic property pattern for TX active state
- **Phase 4:** ContainerWidget card borders via QPainter, ContainerTitleBar gradient→flat, VfoWidget font tokens, CW panel normalization, AppletPanel spacing/layout fixes (kWidth=280, 6px stack gap), NetworkDiagnosticsDialog native title bar conversion

## Test plan

- [x] Build: `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build build -j$(nproc)`
- [x] Launch without radio — verify all applets render with correct flat colors
- [x] Check button corners (3px radius), slider handles (10px)
- [x] Check title bars are flat (no gradient)
- [x] Check CW decode panel buttons and labels
- [x] Verify sidebar applets have visible card borders with spacing between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)