### PR TITLE
fix(rx-applet): add matching radeActivated guard to mirror VfoWidget

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -394,9 +394,17 @@ void RxApplet::buildUI()
 #ifdef HAVE_RADE
             if (mode == "RADE") {
                 emit radeActivated(true, m_slice ? m_slice->sliceId() : -1);
+                m_radeActive = true;
                 return;
             }
-            emit radeActivated(false, m_slice ? m_slice->sliceId() : -1);
+            // Same guard pattern as VfoWidget (#2026): only emit deactivate
+            // if THIS applet had previously emitted activate. Otherwise a
+            // user swapping USB->LSB on a non-RADE slice would fire a
+            // radeActivated(false) and tear down RADE on a different pan.
+            if (m_radeActive) {
+                emit radeActivated(false, m_slice ? m_slice->sliceId() : -1);
+                m_radeActive = false;
+            }
 #endif
             if (m_slice) m_slice->setMode(mode);
         });

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -394,17 +394,23 @@ void RxApplet::buildUI()
 #ifdef HAVE_RADE
             if (mode == "RADE") {
                 emit radeActivated(true, m_slice ? m_slice->sliceId() : -1);
-                m_radeActive = true;
+                if (m_slice) m_slice->setMode(mode);
                 return;
             }
-            // Same guard pattern as VfoWidget (#2026): only emit deactivate
-            // if THIS applet had previously emitted activate. Otherwise a
-            // user swapping USB->LSB on a non-RADE slice would fire a
-            // radeActivated(false) and tear down RADE on a different pan.
-            if (m_radeActive) {
-                emit radeActivated(false, m_slice ? m_slice->sliceId() : -1);
-                m_radeActive = false;
-            }
+            // Defense-in-depth (matches the spirit of #2026): only emit
+            // deactivate if THIS slice was actually in RADE.  Read
+            // m_slice->mode() BEFORE setMode() runs below so we see the
+            // pre-change mode.  This is correct across:
+            //   - single-instance setSlice() rebind (always reads from the
+            //     bound slice, no leftover flag state)
+            //   - externally activated RADE (via VfoWidget combo, profile
+            //     load on startup, or MainWindow::activateRADE) — the
+            //     slice's mode is "RADE" regardless of how it got there
+            //   - the multi-pan case where the user swaps USB→LSB on a
+            //     non-RADE slice — slice's mode isn't "RADE", so the
+            //     spurious deactivate is suppressed exactly when intended
+            if (m_slice && m_slice->mode() == "RADE")
+                emit radeActivated(false, m_slice->sliceId());
 #endif
             if (m_slice) m_slice->setMode(mode);
         });

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -103,6 +103,11 @@ private:
     TransmitModel* m_txModel{nullptr};
     QStringList m_antList{"ANT1", "ANT2"};   // populated from ant_list key
 
+    // Tracks whether THIS applet last asked MainWindow to activate RADE,
+    // so we don't fire spurious radeActivated(false) on subsequent
+    // non-RADE mode swaps. Same defense-in-depth guard as VfoWidget.
+    bool m_radeActive{false};
+
     // Step sizes (Hz) — per-mode, swapped on mode change
     QVector<int> m_stepSizes{10, 50, 100, 250, 500, 1000, 2500, 5000, 10000};
     int          m_stepIdx{2};          // index into m_stepSizes, default 100 Hz

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -103,11 +103,6 @@ private:
     TransmitModel* m_txModel{nullptr};
     QStringList m_antList{"ANT1", "ANT2"};   // populated from ant_list key
 
-    // Tracks whether THIS applet last asked MainWindow to activate RADE,
-    // so we don't fire spurious radeActivated(false) on subsequent
-    // non-RADE mode swaps. Same defense-in-depth guard as VfoWidget.
-    bool m_radeActive{false};
-
     // Step sizes (Hz) — per-mode, swapped on mode change
     QVector<int> m_stepSizes{10, 50, 100, 250, 500, 1000, 2500, 5000, 10000};
     int          m_stepIdx{2};          // index into m_stepSizes, default 100 Hz


### PR DESCRIPTION
Closes #2062

## Why

`VfoWidget.cpp` was patched in #2026 so its mode-switch lambda only emits `radeActivated(false, ...)` when RADE was actually active on that widget. The matching emit at `RxApplet.cpp:396` stayed unconditional - the same shape as the multi-pan regression #2026 fixed. The MainWindow handler `else if (sliceId == m_radeSliceId) deactivateRADE()` makes today's behavior correct, but the asymmetry is a tripwire: any future softening of the MainWindow guard puts the original bug right back.

## What changes

Defense-in-depth guard on `RxApplet`, mirroring `VfoWidget`:

- `RxApplet.h`: new `bool m_radeActive{false};` private member, with a comment pointing at the `VfoWidget` parallel.
- `RxApplet.cpp` (HAVE_RADE block in the mode-combo lambda):
  - When user picks `RADE`, set `m_radeActive = true` after emitting activate.
  - When user picks any other mode, only emit `radeActivated(false, ...)` if `m_radeActive` is true; clear it on the way out.
- Inline comment in `RxApplet.cpp` cites #2026 so future readers see the pattern.

Net diff: +14 / -1 across the two files.

## Behavior

- **Steady state**: identical. MainWindow keeps the authoritative `m_radeSliceId` check; this just stops shouting `false` from a slice that never said `true`.
- **The case the guard now protects**: user is on slice 0 in RADE, flips slice 1 from USB to LSB. Before this PR, slice 1's RxApplet emitted `radeActivated(false, 1)`; the MainWindow guard ignored it because `1 != m_radeSliceId`. After this PR, the spurious emit doesn't fire at all. If MainWindow ever softens its check, RADE on slice 0 stays up.

## Verification

- Builds in the existing `ghcr.io/ten9876/aethersdr-ci:latest` image (no new `find_package`, no new dependencies, no Dockerfile change needed).
- No new behavior, signals, or public API; the `m_radeActive` field is private and only mutated inside the existing mode-combo lambda.
- Rebased on `upstream/main` at the latest tip before push, signed-off and SSH-signed per branch protection.
