### PR TITLE
fix(tci): prevent crash on quit when TciServer outlives RadioModel (#2385)

### DIFF
--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -2,6 +2,7 @@
 #ifdef HAVE_WEBSOCKETS
 
 #include <QObject>
+#include <QPointer>
 #include <QElapsedTimer>
 #include <QHash>
 #include <QList>
@@ -126,7 +127,7 @@ private:
     void ensureDaxForTci();
     void releaseDaxForTci();
 
-    RadioModel*       m_model;
+    QPointer<RadioModel> m_model;  // QPointer auto-clears when RadioModel is destroyed (#2385)
     AudioEngine*      m_audio{nullptr};
     QWebSocketServer* m_server{nullptr};
     QList<ClientState> m_clients;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3906,6 +3906,21 @@ MainWindow::~MainWindow()
     }
     m_audio = nullptr;
 
+#ifdef HAVE_WEBSOCKETS
+    // TciServer holds a raw RadioModel* and dereferences it in stop() →
+    // releaseDaxForTci(). Qt would delete it as a child of MainWindow during
+    // ~QWidget::deleteChildren(), which runs *after* MainWindow's value members
+    // (including m_radioModel) have already been destroyed — crash on quit
+    // (#2385). Tear it down explicitly here: audio is stopped (no more
+    // daxAudioReady cross-thread signals), m_radioModel is still alive (DAX
+    // stream-remove commands reach the radio), and we null out TciApplet's raw
+    // back-reference first so no dangling pointer remains in the widget tree.
+    if (m_appletPanel && m_appletPanel->tciApplet())
+        m_appletPanel->tciApplet()->setTciServer(nullptr);
+    delete m_tciServer;
+    m_tciServer = nullptr;
+#endif
+
     // Stop external controller thread (#502)
     if (m_extCtrlThread && m_extCtrlThread->isRunning()) {
         // Close serial port on its own thread before stopping it to avoid


### PR DESCRIPTION
## Summary

Fixes #2385

`TciServer` is a QObject child of `MainWindow`, so Qt deletes it during `~QWidget::deleteChildren()` — which runs **after** `MainWindow`'s own value members have destructed, including `m_radioModel`. This meant `stop()` → `releaseDaxForTci()` → `m_model->isConnected()` dereferenced a destroyed object on every clean exit when a radio was connected. `EXC_BAD_ACCESS` at `0x38`, 100% reproducible on quit.

## Fix

**Primary — explicit early teardown in `~MainWindow()`** (`MainWindow.cpp`):

Teardown is placed *after* the audio thread is stopped (no more `daxAudioReady` cross-thread signals), but while `m_radioModel` is still fully alive (DAX `stream remove` commands reach the radio). `TciApplet`'s raw back-reference to `TciServer` is nulled first to prevent a dangling pointer surviving in the widget tree:

```cpp
#ifdef HAVE_WEBSOCKETS
    if (m_appletPanel && m_appletPanel->tciApplet())
        m_appletPanel->tciApplet()->setTciServer(nullptr);
    delete m_tciServer;
    m_tciServer = nullptr;
#endif
```

**Belt-and-braces — `QPointer<RadioModel>` in `TciServer.h`**:

Promotes `m_model` to `QPointer<RadioModel>`. `QPointer` auto-clears when the pointee is destroyed, so the existing `if (!m_model) return;` guard in `releaseDaxForTci()` covers the post-destruct case — a future refactor cannot silently re-introduce the crash.

## Files modified

- `src/core/TciServer.h` — add `#include <QPointer>`, `RadioModel* m_model` → `QPointer<RadioModel> m_model`
- `src/gui/MainWindow.cpp` — explicit `delete m_tciServer` in `~MainWindow()` after audio teardown, with TciApplet back-reference cleared first

## Test plan
- [ ] Build with `HAVE_WEBSOCKETS` defined — no compile errors
- [ ] Connect to radio, quit the application — no crash dialog on macOS
- [ ] Connect with TCI server enabled and a TCI client active, then quit — clean exit
- [ ] Quit without ever connecting to a radio — no regression
- [ ] Quit mid-session with active DAX streams — streams removed cleanly (check radio-side log)

Reported by VU2CPL (Manoj) with full crash report and call stack.