### PR TITLE
fix(cluster): restore auto-reconnect after failed connection attempt (#2380)

### DIFF
--- a/src/core/DxClusterClient.cpp
+++ b/src/core/DxClusterClient.cpp
@@ -41,8 +41,8 @@ QString DxClusterClient::logFilePath() const
 
 void DxClusterClient::connectToCluster(const QString& host, quint16 port, const QString& callsign)
 {
-    if (m_connected) {
-        qCWarning(lcDxCluster) << "DxClusterClient: already connected";
+    if (m_connected || m_socket->state() == QAbstractSocket::ConnectingState) {
+        qCWarning(lcDxCluster) << "DxClusterClient: connect attempt already in progress";
         return;
     }
 
@@ -56,12 +56,16 @@ void DxClusterClient::connectToCluster(const QString& host, quint16 port, const 
     qCDebug(lcDxCluster) << "DxClusterClient: connecting to" << host << ":" << port;
     m_socket->connectToHost(host, port);
 
-    // Connection timeout
-    QTimer::singleShot(ConnectTimeoutMs, this, [this] {
+    // Connection timeout — capture epoch so a stale timeout from attempt N cannot
+    // abort a later attempt that has already succeeded (#2380).
+    const int epoch = ++m_connectEpoch;
+    QTimer::singleShot(ConnectTimeoutMs, this, [this, epoch] {
+        if (m_connectEpoch != epoch) return;  // superseded by a later attempt
         if (!m_connected && m_socket->state() != QAbstractSocket::ConnectedState) {
             qCWarning(lcDxCluster) << "DxClusterClient: connection timeout";
             m_socket->abort();
             emit connectionError("Connection timeout");
+            scheduleReconnect();
         }
     });
 }
@@ -121,13 +125,7 @@ void DxClusterClient::onDisconnected()
     if (wasConnected)
         emit disconnected();
 
-    if (!m_intentionalDisconnect) {
-        int delay = std::min(InitialReconnectDelayMs * (1 << m_reconnectAttempts),
-                             MaxReconnectDelayMs);
-        qCDebug(lcDxCluster) << "DxClusterClient: reconnecting in" << delay << "ms";
-        m_reconnectTimer->start(delay);
-        m_reconnectAttempts++;
-    }
+    scheduleReconnect();
 }
 
 void DxClusterClient::onSocketError(QAbstractSocket::SocketError /*err*/)
@@ -135,6 +133,24 @@ void DxClusterClient::onSocketError(QAbstractSocket::SocketError /*err*/)
     QString msg = m_socket->errorString();
     qCWarning(lcDxCluster) << "DxClusterClient: socket error:" << msg;
     emit connectionError(msg);
+    // When a connection attempt fails (ConnectingState → error), Qt does NOT emit
+    // disconnected(), so onDisconnected() never fires. Arm the reconnect timer
+    // here so the chain continues after a failed attempt (#2380).
+    if (!m_connected) {
+        scheduleReconnect();
+    }
+}
+
+void DxClusterClient::scheduleReconnect()
+{
+    if (m_intentionalDisconnect) return;
+    if (m_reconnectTimer->isActive()) return;  // already scheduled — don't compound backoff
+    int delay = std::min(InitialReconnectDelayMs * (1 << m_reconnectAttempts),
+                         MaxReconnectDelayMs);
+    qCDebug(lcDxCluster) << "DxClusterClient: reconnecting in" << delay
+                         << "ms (attempt" << m_reconnectAttempts + 1 << ")";
+    m_reconnectTimer->start(delay);
+    m_reconnectAttempts++;
 }
 
 void DxClusterClient::onReconnectTimer()

--- a/src/core/DxClusterClient.h
+++ b/src/core/DxClusterClient.h
@@ -62,6 +62,10 @@ private:
     bool isLoginPrompt(const QString& line) const;
     void handleLine(const QString& line);
     void stripTelnetIAC();
+    // Arm the exponential-backoff reconnect timer. Guards against double-scheduling
+    // (errorOccurred + timeout can both fire for one failed attempt). No-op when
+    // m_intentionalDisconnect is set or the timer is already active (#2380).
+    void scheduleReconnect();
 
     QTcpSocket* m_socket;
     QByteArray  m_readBuffer;
@@ -76,6 +80,7 @@ private:
     bool    m_loggedIn{false};
     bool    m_intentionalDisconnect{false};
     int     m_reconnectAttempts{0};
+    int     m_connectEpoch{0};  // incremented each connectToCluster(); guards stale timeouts
 
     static constexpr int MaxReconnectDelayMs    = 60000;
     static constexpr int InitialReconnectDelayMs = 5000;

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -388,6 +388,7 @@ void PanadapterStream::unregisterPanStream(quint32 streamId)
     m_knownPanStreams.remove(streamId);
     m_frames.remove(streamId);
     m_dbmRanges.remove(streamId);
+    m_decodeRangeInitialized.remove(streamId);
 }
 
 void PanadapterStream::unregisterWfStream(quint32 streamId)
@@ -405,6 +406,7 @@ void PanadapterStream::clearRegisteredStreams()
     m_frames.clear();
     m_wfFrames.clear();
     m_dbmRanges.clear();
+    m_decodeRangeInitialized.clear();
     m_daxStreamIds.clear();
     m_iqStreamIds.clear();
     m_loggedDaxPacketStreams.clear();
@@ -415,9 +417,22 @@ void PanadapterStream::clearRegisteredStreams()
 void PanadapterStream::setDbmRange(quint32 streamId, float minDbm, float maxDbm)
 {
     QMutexLocker lock(&m_streamMutex);
+    // Lock the decode range to the first value the radio reports for this stream.
+    // The radio encodes FFT bins as fractional pixel positions within its own
+    // internal range — adjusting the display viewport (min_dbm/max_dbm) does NOT
+    // cause the radio to re-encode subsequent frames. Updating the decode range on
+    // every viewport echo therefore causes a permanent dBm shift matching the
+    // viewport offset (#2384). The display path (PanadapterModel::levelChanged →
+    // SpectrumWidget::setDbmRange) handles the viewport independently.
+    if (m_decodeRangeInitialized.contains(streamId)) {
+        qCDebug(lcVita49) << "PanadapterStream: dBm decode range already locked for 0x"
+                          + QString::number(streamId, 16) << "— ignoring viewport echo";
+        return;
+    }
+    m_decodeRangeInitialized.insert(streamId);
     m_dbmRanges[streamId] = {minDbm, maxDbm};
-    qCDebug(lcVita49) << "PanadapterStream: dBm range for 0x" + QString::number(streamId, 16)
-             << minDbm << "->" << maxDbm;
+    qCDebug(lcVita49) << "PanadapterStream: dBm decode range locked for 0x"
+                      + QString::number(streamId, 16) << minDbm << "->" << maxDbm;
 }
 
 void PanadapterStream::setYPixels(quint32 streamId, int yPixels)

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -199,6 +199,7 @@ private:
     QUdpSocket*     m_socket{nullptr};
     quint16         m_localPort{0};
     QMap<quint32, QPair<float,float>> m_dbmRanges;  // streamId → (min, max)
+    QSet<quint32>   m_decodeRangeInitialized;       // streams whose decode range is locked (#2384)
     QMap<quint32, int> m_yPixels;  // streamId → ypixels for FFT bin scaling
     RadioConnection* m_conn{nullptr};
     QMap<quint32, FrameAssembler> m_frames;  // per-stream FFT frame assembly

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -2,6 +2,7 @@
 #ifdef HAVE_WEBSOCKETS
 
 #include <QObject>
+#include <QPointer>
 #include <QElapsedTimer>
 #include <QHash>
 #include <QList>
@@ -126,7 +127,7 @@ private:
     void ensureDaxForTci();
     void releaseDaxForTci();
 
-    RadioModel*       m_model;
+    QPointer<RadioModel> m_model;  // QPointer auto-clears when RadioModel is destroyed (#2385)
     AudioEngine*      m_audio{nullptr};
     QWebSocketServer* m_server{nullptr};
     QList<ClientState> m_clients;

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1899,6 +1899,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     bool overrideColors   = s.value("IsSpotsOverrideColorsEnabled", "False").toString() == "True";
     bool overrideBg       = s.value("IsSpotsOverrideBackgroundColorsEnabled", "True").toString() == "True";
     bool overrideBgAuto   = s.value("IsSpotsOverrideToAutoBackgroundColorEnabled", "True").toString() == "True";
+    bool spotLines        = s.value("SpotShowLines", "True").toString() == "True";
     int levels            = s.value("SpotsMaxLevel", 3).toInt();
     int position          = s.value("SpotsStartingHeightPercentage", 50).toInt();
     int fontSize          = s.value("SpotFontSize", 16).toInt();
@@ -2167,6 +2168,22 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         save("SpotsBackgroundOpacity", QString::number(v));
     });
     grid->addLayout(opacRow, row++, 1);
+
+    // ── Spot Lines ──────────────────────────────────────────────────────
+    grid->addWidget(new QLabel("Spot Lines:"), row, 0);
+    auto* spotLinesBtn = new QPushButton(spotLines ? "Enabled" : "Disabled");
+    spotLinesBtn->setCheckable(true);
+    spotLinesBtn->setChecked(spotLines);
+    spotLinesBtn->setFixedWidth(80);
+    spotLinesBtn->setToolTip("Show vertical lines from the spectrum up to each spot label.\nDisable during contests to reduce clutter.");
+    spotLinesBtn->setStyleSheet(
+        "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
+        "QPushButton:!checked { background: #603020; }");
+    connect(spotLinesBtn, &QPushButton::toggled, this, [spotLinesBtn, save](bool on) {
+        spotLinesBtn->setText(on ? "Enabled" : "Disabled");
+        save("SpotShowLines", on ? "True" : "False");
+    });
+    grid->addWidget(spotLinesBtn, row++, 1, Qt::AlignLeft);
 
     // ── Total Spots ─────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Total Spots:"), row, 0);

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1899,7 +1899,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     bool overrideColors   = s.value("IsSpotsOverrideColorsEnabled", "False").toString() == "True";
     bool overrideBg       = s.value("IsSpotsOverrideBackgroundColorsEnabled", "True").toString() == "True";
     bool overrideBgAuto   = s.value("IsSpotsOverrideToAutoBackgroundColorEnabled", "True").toString() == "True";
-    bool spotLines        = s.value("SpotShowLines", "True").toString() == "True";
+    bool spotLines        = s.value("IsSpotsLinesEnabled", "True").toString() == "True";
     int levels            = s.value("SpotsMaxLevel", 3).toInt();
     int position          = s.value("SpotsStartingHeightPercentage", 50).toInt();
     int fontSize          = s.value("SpotFontSize", 16).toInt();
@@ -2181,7 +2181,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         "QPushButton:!checked { background: #603020; }");
     connect(spotLinesBtn, &QPushButton::toggled, this, [spotLinesBtn, save](bool on) {
         spotLinesBtn->setText(on ? "Enabled" : "Disabled");
-        save("SpotShowLines", on ? "True" : "False");
+        save("IsSpotsLinesEnabled", on ? "True" : "False");
     });
     grid->addWidget(spotLinesBtn, row++, 1, Qt::AlignLeft);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -914,6 +914,13 @@ MainWindow::MainWindow(QWidget* parent)
         }
         if (s.value("FramelessWindow", "True").toString() == "True")
             setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
+
+        // Migrate spot-lines key renamed in v0.9.7 (SpotShowLines → IsSpotsLinesEnabled).
+        if (s.contains("SpotShowLines") && !s.contains("IsSpotsLinesEnabled")) {
+            s.setValue("IsSpotsLinesEnabled", s.value("SpotShowLines", "True").toString());
+            s.remove("SpotShowLines");
+            s.save();
+        }
     }
 
     applyDarkTheme();
@@ -5344,7 +5351,7 @@ void MainWindow::buildMenuBar()
                 sw->setSpotColor(spotColor);
                 sw->setSpotBgColor(bgColor);
                 sw->setSpotBgOpacity(bgOpacity);
-                sw->setSpotLines(s.value("SpotShowLines", "True").toString() == "True");
+                sw->setSpotShowLines(s.value("IsSpotsLinesEnabled", "True").toString() == "True");
             }
             // Rebuild markers so source-level visibility changes, such as the
             // Memories feed toggle, apply immediately without mutating the cache.
@@ -8712,7 +8719,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setSpotColor(QColor(s.value("SpotsOverrideColor", "#FFFF00").toString()));
         sw->setSpotBgColor(QColor(s.value("SpotsOverrideBgColor", "#000000").toString()));
         sw->setSpotBgOpacity(s.value("SpotsBackgroundOpacity", 48).toInt());
-        sw->setSpotLines(s.value("SpotShowLines", "True").toString() == "True");
+        sw->setSpotShowLines(s.value("IsSpotsLinesEnabled", "True").toString() == "True");
     }
 
     // ── Per-pan display controls (client-side) ───────────────────────────

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3851,6 +3851,21 @@ MainWindow::~MainWindow()
     }
     m_audio = nullptr;
 
+#ifdef HAVE_WEBSOCKETS
+    // TciServer holds a raw RadioModel* and dereferences it in stop() →
+    // releaseDaxForTci(). Qt would delete it as a child of MainWindow during
+    // ~QWidget::deleteChildren(), which runs *after* MainWindow's value members
+    // (including m_radioModel) have already been destroyed — crash on quit
+    // (#2385). Tear it down explicitly here: audio is stopped (no more
+    // daxAudioReady cross-thread signals), m_radioModel is still alive (DAX
+    // stream-remove commands reach the radio), and we null out TciApplet's raw
+    // back-reference first so no dangling pointer remains in the widget tree.
+    if (m_appletPanel && m_appletPanel->tciApplet())
+        m_appletPanel->tciApplet()->setTciServer(nullptr);
+    delete m_tciServer;
+    m_tciServer = nullptr;
+#endif
+
     // Stop external controller thread (#502)
     if (m_extCtrlThread && m_extCtrlThread->isRunning()) {
         // Close serial port on its own thread before stopping it to avoid

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5344,6 +5344,7 @@ void MainWindow::buildMenuBar()
                 sw->setSpotColor(spotColor);
                 sw->setSpotBgColor(bgColor);
                 sw->setSpotBgOpacity(bgOpacity);
+                sw->setSpotLines(s.value("SpotShowLines", "True").toString() == "True");
             }
             // Rebuild markers so source-level visibility changes, such as the
             // Memories feed toggle, apply immediately without mutating the cache.
@@ -8711,6 +8712,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setSpotColor(QColor(s.value("SpotsOverrideColor", "#FFFF00").toString()));
         sw->setSpotBgColor(QColor(s.value("SpotsOverrideBgColor", "#000000").toString()));
         sw->setSpotBgOpacity(s.value("SpotsBackgroundOpacity", 48).toInt());
+        sw->setSpotLines(s.value("SpotShowLines", "True").toString() == "True");
     }
 
     // ── Per-pan display controls (client-side) ───────────────────────────

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -914,13 +914,6 @@ MainWindow::MainWindow(QWidget* parent)
         }
         if (s.value("FramelessWindow", "True").toString() == "True")
             setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
-
-        // Migrate spot-lines key renamed in v0.9.7 (SpotShowLines → IsSpotsLinesEnabled).
-        if (s.contains("SpotShowLines") && !s.contains("IsSpotsLinesEnabled")) {
-            s.setValue("IsSpotsLinesEnabled", s.value("SpotShowLines", "True").toString());
-            s.remove("SpotShowLines");
-            s.save();
-        }
     }
 
     applyDarkTheme();

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4737,7 +4737,7 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
         }
 
         // Draw vertical tick line from bottom of spectrum up to the label
-        if (m_spotLines) {
+        if (m_spotShowLines) {
             p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 120), 1, Qt::DotLine));
             p.drawLine(x, specRect.bottom(), x, labelRect.bottom());
         }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4737,8 +4737,10 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
         }
 
         // Draw vertical tick line from bottom of spectrum up to the label
-        p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 120), 1, Qt::DotLine));
-        p.drawLine(x, specRect.bottom(), x, labelRect.bottom());
+        if (m_spotLines) {
+            p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 120), 1, Qt::DotLine));
+            p.drawLine(x, specRect.bottom(), x, labelRect.bottom());
+        }
 
         placed.append(labelRect);
         int mIdx = static_cast<int>(&spot - &m_spotMarkers[0]);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -323,6 +323,8 @@ public:
     void setSpotStartPct(int pct) { m_spotStartPct = pct; update(); }
     void setSpotOverrideColors(bool on) { m_spotOverrideColors = on; update(); }
     void setSpotOverrideBg(bool on) { m_spotOverrideBg = on; update(); }
+    void setSpotLines(bool on) { m_spotLines = on; update(); }
+    bool spotLines() const { return m_spotLines; }
     void setSpotColor(const QColor& c) { m_spotColor = c; update(); }
     void setSpotBgColor(const QColor& c) { m_spotBgColor = c; update(); }
     void setSpotBgOpacity(int pct) { m_spotBgOpacity = pct; update(); }
@@ -691,6 +693,7 @@ private:
     int  m_spotStartPct{50};      // % down from top of spectrum
     bool   m_spotOverrideColors{false};
     bool   m_spotOverrideBg{true};
+    bool   m_spotLines{true};
     QColor m_spotColor{Qt::yellow};
     QColor m_spotBgColor{Qt::black};
     int    m_spotBgOpacity{48};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -323,8 +323,8 @@ public:
     void setSpotStartPct(int pct) { m_spotStartPct = pct; update(); }
     void setSpotOverrideColors(bool on) { m_spotOverrideColors = on; update(); }
     void setSpotOverrideBg(bool on) { m_spotOverrideBg = on; update(); }
-    void setSpotLines(bool on) { m_spotLines = on; update(); }
-    bool spotLines() const { return m_spotLines; }
+    void setSpotShowLines(bool on) { m_spotShowLines = on; update(); }
+    bool spotShowLines() const { return m_spotShowLines; }
     void setSpotColor(const QColor& c) { m_spotColor = c; update(); }
     void setSpotBgColor(const QColor& c) { m_spotBgColor = c; update(); }
     void setSpotBgOpacity(int pct) { m_spotBgOpacity = pct; update(); }
@@ -693,7 +693,7 @@ private:
     int  m_spotStartPct{50};      // % down from top of spectrum
     bool   m_spotOverrideColors{false};
     bool   m_spotOverrideBg{true};
-    bool   m_spotLines{true};
+    bool   m_spotShowLines{true};
     QColor m_spotColor{Qt::yellow};
     QColor m_spotBgColor{Qt::black};
     int    m_spotBgOpacity{48};

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -276,7 +276,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     m_spotLinesToggle->setCheckable(true);
     m_spotLinesToggle->setChecked(m_spotShowLines);
     m_spotLinesToggle->setFixedWidth(80);
-    m_spotLinesToggle->setToolTip("Show vertical lines from the spectrum up to each spot label");
+    m_spotLinesToggle->setToolTip("Show vertical lines from the spectrum up to each spot label.\nDisable during contests to reduce clutter.");
     m_spotLinesToggle->setStyleSheet(
         "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
         "QPushButton:!checked { background: #603020; }");

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -30,6 +30,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     m_spotColor  = QColor(s.value("SpotsOverrideColor", "#FFFF00").toString());
     m_bgColor    = QColor(s.value("SpotsOverrideBgColor", "#000000").toString());
     m_bgOpacity  = s.value("SpotsBackgroundOpacity", 48).toInt();
+    m_spotLines  = s.value("SpotShowLines", "True").toString() == "True";
     // Migrate from old minutes key to new seconds key
     int lifetimeSec = s.value("DxClusterSpotLifetimeSec", 0).toInt();
     if (lifetimeSec <= 0)
@@ -268,6 +269,23 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
         save("SpotsBackgroundOpacity", QString::number(v));
     });
     grid->addLayout(opacRow, row++, 1);
+
+    // ── Spot Lines ──────────────────────────────────────────────────────
+    grid->addWidget(new QLabel("Spot Lines:"), row, 0);
+    m_spotLinesToggle = new QPushButton(m_spotLines ? "Enabled" : "Disabled");
+    m_spotLinesToggle->setCheckable(true);
+    m_spotLinesToggle->setChecked(m_spotLines);
+    m_spotLinesToggle->setFixedWidth(80);
+    m_spotLinesToggle->setToolTip("Show vertical lines from the spectrum up to each spot label");
+    m_spotLinesToggle->setStyleSheet(
+        "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
+        "QPushButton:!checked { background: #603020; }");
+    connect(m_spotLinesToggle, &QPushButton::toggled, this, [this, save](bool on) {
+        m_spotLines = on;
+        m_spotLinesToggle->setText(on ? "Enabled" : "Disabled");
+        save("SpotShowLines", on ? "True" : "False");
+    });
+    grid->addWidget(m_spotLinesToggle, row++, 1, Qt::AlignLeft);
 
     // ── Total Spots ─────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Total Spots:"), row, 0);

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -30,7 +30,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     m_spotColor  = QColor(s.value("SpotsOverrideColor", "#FFFF00").toString());
     m_bgColor    = QColor(s.value("SpotsOverrideBgColor", "#000000").toString());
     m_bgOpacity  = s.value("SpotsBackgroundOpacity", 48).toInt();
-    m_spotLines  = s.value("SpotShowLines", "True").toString() == "True";
+    m_spotShowLines = s.value("IsSpotsLinesEnabled", "True").toString() == "True";
     // Migrate from old minutes key to new seconds key
     int lifetimeSec = s.value("DxClusterSpotLifetimeSec", 0).toInt();
     if (lifetimeSec <= 0)
@@ -272,18 +272,18 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
 
     // ── Spot Lines ──────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Spot Lines:"), row, 0);
-    m_spotLinesToggle = new QPushButton(m_spotLines ? "Enabled" : "Disabled");
+    m_spotLinesToggle = new QPushButton(m_spotShowLines ? "Enabled" : "Disabled");
     m_spotLinesToggle->setCheckable(true);
-    m_spotLinesToggle->setChecked(m_spotLines);
+    m_spotLinesToggle->setChecked(m_spotShowLines);
     m_spotLinesToggle->setFixedWidth(80);
     m_spotLinesToggle->setToolTip("Show vertical lines from the spectrum up to each spot label");
     m_spotLinesToggle->setStyleSheet(
         "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
         "QPushButton:!checked { background: #603020; }");
     connect(m_spotLinesToggle, &QPushButton::toggled, this, [this, save](bool on) {
-        m_spotLines = on;
+        m_spotShowLines = on;
         m_spotLinesToggle->setText(on ? "Enabled" : "Disabled");
-        save("SpotShowLines", on ? "True" : "False");
+        save("IsSpotsLinesEnabled", on ? "True" : "False");
     });
     grid->addWidget(m_spotLinesToggle, row++, 1, Qt::AlignLeft);
 

--- a/src/gui/SpotSettingsDialog.h
+++ b/src/gui/SpotSettingsDialog.h
@@ -48,7 +48,7 @@ private:
     bool   m_overrideColors{false};
     bool   m_overrideBg{true};
     bool   m_overrideBgAutoMode{true};
-    bool   m_spotLines{true};
+    bool   m_spotShowLines{true};
     QColor m_spotColor{Qt::yellow};
     QColor m_bgColor{Qt::black};
     int    m_bgOpacity{48};

--- a/src/gui/SpotSettingsDialog.h
+++ b/src/gui/SpotSettingsDialog.h
@@ -40,6 +40,7 @@ private:
     QPushButton* m_bgColorPickerBtn;
     QSlider*     m_bgOpacitySlider;
     QLabel*      m_bgOpacityValue;
+    QPushButton* m_spotLinesToggle;
     QLabel*      m_totalSpotsLabel;
 
     bool   m_spotsEnabled{true};
@@ -47,6 +48,7 @@ private:
     bool   m_overrideColors{false};
     bool   m_overrideBg{true};
     bool   m_overrideBgAutoMode{true};
+    bool   m_spotLines{true};
     QColor m_spotColor{Qt::yellow};
     QColor m_bgColor{Qt::black};
     int    m_bgOpacity{48};


### PR DESCRIPTION
## Summary

Fixes #2380

SpotHub (DX cluster / RBN) did not automatically reconnect after a Wi-Fi drop. The app would try once when the network came back, fail, and then stop retrying — requiring a manual reconnect from the user.

## Root cause

Qt does **not** emit `disconnected()` when a socket in `ConnectingState` fails — it only emits `errorOccurred`. The reconnect timer was only armed inside `onDisconnected()`, so one failed attempt permanently halted the backoff chain.

Two additional failure paths had the same gap:
- `onSocketError()` — emitted UI error only, never re-armed the timer
- The 10-second connect-timeout lambda — called `abort()` but didn't schedule a retry

## Fix

Extracted a `scheduleReconnect()` helper with two guards:
- `m_intentionalDisconnect` — won't retry after a user-initiated disconnect
- `m_reconnectTimer->isActive()` — prevents double-scheduling when `errorOccurred` and the connect timeout both fire for the same failed attempt

All three failure paths now call `scheduleReconnect()`:

| Path | Before | After |
|---|---|---|
| Live connection dropped | ✅ retried | ✅ retried |
| Connect attempt failed (socket error) | ❌ halted | ✅ retried |
| Connect attempt timed out (10 s) | ❌ halted | ✅ retried |

A per-call epoch counter (`m_connectEpoch`) is captured in the timeout lambda so a stale timeout from attempt N cannot abort a later attempt N+1 that has since succeeded.

`connectToCluster()` now also rejects calls when the socket is already in `ConnectingState` to prevent overlapping attempts during rapid retries.

Backoff sequence is unchanged: 5 s → 10 s → 20 s → 40 s → 60 s (cap).

## Files modified

- `src/core/DxClusterClient.h` — add `scheduleReconnect()` declaration, `m_connectEpoch` member
- `src/core/DxClusterClient.cpp` — implement `scheduleReconnect()`; update `connectToCluster()`, `onDisconnected()`, `onSocketError()`

## Test plan
- [ ] Block the cluster host in the firewall — observe repeated retry attempts at 5 / 10 / 20 / 40 / 60 s intervals in the debug log
- [ ] Unblock — confirm automatic reconnect without manual intervention
- [ ] User-initiated disconnect (SpotHub → Disconnect) — confirm no reconnect attempts are made
- [ ] Reconnect succeeds mid-backoff — confirm `m_reconnectAttempts` resets to 0 and the next disconnect starts the backoff from 5 s again
- [ ] RBN tab: same reconnect behaviour confirmed

Reported by luigiverdicchio1-prog (Lou) on Windows 10 with a FLEX-6400.