### PR TITLE
Add 'Connect to last radio on start up' opt-out (#2383)

### DIFF
--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -295,6 +295,7 @@ void AppSettings::migrateFromQSettings()
         // No old settings — first launch. Set defaults.
         setValue("ApplicationVersion", QCoreApplication::applicationVersion());
         setValue("AutoConnect", "True");
+        setValue("AutoConnectToLastRadio", "True");
         setValue("StationName", "");
         setValue("GUIClientID", QUuid::createUuid().toString(QUuid::WithoutBraces));
         setValue("IsSingleClickTuneEnabled", "False");
@@ -349,6 +350,8 @@ void AppSettings::migrateFromQSettings()
     // Set defaults for new keys
     setValue("ApplicationVersion", QCoreApplication::applicationVersion());
     setValue("AutoConnect", "True");
+    if (!contains("AutoConnectToLastRadio"))
+        setValue("AutoConnectToLastRadio", "True");
     setValue("StationName", "");
     setValue("GUIClientID", QUuid::createUuid().toString(QUuid::WithoutBraces));
     if (!contains("IsSingleClickTuneEnabled"))

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -530,6 +530,17 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     optionsLayout->addWidget(m_lowBwCheck);
     root->addWidget(m_linkOptionsWidget);
 
+    m_autoConnectCheck = new QCheckBox("Connect to last radio on start up", this);
+    m_autoConnectCheck->setChecked(
+        AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() == "True");
+    m_autoConnectCheck->setStyleSheet(lowBandwidthCheckStyle);
+    connect(m_autoConnectCheck, &QCheckBox::toggled, this, [](bool on) {
+        auto& s = AppSettings::instance();
+        s.setValue("AutoConnectToLastRadio", on ? "True" : "False");
+        s.save();
+    });
+    root->addWidget(m_autoConnectCheck);
+
     // ── Footer ────────────────────────────────────────────────────────────
     auto* footerRow = new QHBoxLayout;
     footerRow->setSpacing(8);

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -130,6 +130,8 @@ private:
     QString      m_manualProfileIp;
     bool         m_manualConnectPending{false};
 
+    QCheckBox*   m_autoConnectCheck{nullptr};
+
     QWidget*     m_linkOptionsWidget{nullptr};
     QLabel*      m_lowBwHintLabel{nullptr};
     QCheckBox*   m_lowBwCheck{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1155,6 +1155,8 @@ MainWindow::MainWindow(QWidget* parent)
     connect(&m_discovery, &RadioDiscovery::radioDiscovered,
             this, [this](const RadioInfo& info) {
         if (m_userDisconnected) return;
+        if (AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() != "True")
+            return;
         const QString lastSerial = AppSettings::instance()
             .value("LastConnectedRadioSerial").toString();
         if (!lastSerial.isEmpty() && info.serial == lastSerial
@@ -3787,17 +3789,23 @@ MainWindow::MainWindow(QWidget* parent)
     if (m_titleBar) m_titleBar->setDiscovering(true);
     m_discovery.startListening();
 
+    const bool autoConnectToLastRadio =
+        AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() == "True";
     const QString startupLastSerial =
         AppSettings::instance().value("LastConnectedRadioSerial").toString();
-    if (!startupLastSerial.isEmpty()) {
+    if (!startupLastSerial.isEmpty() && autoConnectToLastRadio) {
         m_connPanel->setStatusText("Looking for your radio…");
         setPanadapterConnectionAnimation(true, "Looking for your radio…");
+    } else if (!autoConnectToLastRadio) {
+        QTimer::singleShot(0, this, &MainWindow::toggleConnectionDialog);
     }
 
     // Auto-connect to routed radios (probed, not broadcast-discovered)
     connect(m_connPanel, &ConnectionPanel::routedRadioFound,
             this, [this](const RadioInfo& info) {
         if (m_userDisconnected || m_radioModel.isConnected()) return;
+        if (AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() != "True")
+            return;
         const QString lastSerial = AppSettings::instance()
             .value("LastConnectedRadioSerial").toString();
         if (!lastSerial.isEmpty() && info.serial == lastSerial) {
@@ -3820,7 +3828,7 @@ MainWindow::MainWindow(QWidget* parent)
     {
         auto& s = AppSettings::instance();
         const QString routedIp = s.value("LastRoutedRadioIp").toString();
-        if (!routedIp.isEmpty() && !m_userDisconnected) {
+        if (!routedIp.isEmpty() && !m_userDisconnected && autoConnectToLastRadio) {
             m_connPanel->setStatusText("Looking for your radio…");
             setPanadapterConnectionAnimation(true, "Looking for your radio…");
             QTimer::singleShot(500, this, [this, routedIp] {


### PR DESCRIPTION
Adds a checkbox on the connection dialog that controls whether AetherSDR
auto-connects to the last-used radio on startup, on broadcast discovery,
and on routed-radio probe. Defaults to enabled, so existing users keep
current behavior. When disabled, the connection dialog auto-launches at
startup so the user has a clear path to pick a radio manually.

Cherry-picked from PR #2383 (filemakers); accidental Windows build
artifacts, IDE configs, and vendored binaries from that PR are dropped.
The new checkbox reuses the existing lowBandwidthCheckStyle for visual
consistency with the adjacent low-bandwidth checkbox.

Co-Authored-By: filemakers <50511950+filemakers@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
