### PR TITLE
Honor cw break_in setting for keyboard CW keying

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1242,6 +1242,15 @@ target_link_libraries(radio_status_ownership_test PRIVATE Qt6::Core)
 enable_testing()
 add_test(NAME radio_status_ownership_test COMMAND radio_status_ownership_test)
 
+add_executable(shortcut_manager_test
+    tests/shortcut_manager_test.cpp
+    src/core/ShortcutManager.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(shortcut_manager_test PRIVATE src)
+target_link_libraries(shortcut_manager_test PRIVATE Qt6::Core Qt6::Widgets)
+add_test(NAME shortcut_manager_test COMMAND shortcut_manager_test)
+
 add_executable(cw_sidetone_test
     tests/cw_sidetone_test.cpp
     src/core/CwSidetoneGenerator.cpp
@@ -1313,6 +1322,7 @@ add_executable(midi_settings_test
 target_compile_definitions(midi_settings_test PRIVATE HAVE_MIDI)
 target_include_directories(midi_settings_test PRIVATE src third_party/rtmidi)
 target_link_libraries(midi_settings_test PRIVATE Qt6::Core)
+add_test(NAME midi_settings_test COMMAND midi_settings_test)
 
 add_executable(transmit_model_test
     tests/transmit_model_test.cpp

--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -24,6 +24,16 @@ QString midiMsgTypeName(MidiBinding::MsgType type)
     return QStringLiteral("Unknown");
 }
 
+bool isCwMomentaryParamId(const QString& paramId)
+{
+    return paramId == QLatin1String("cwkey")
+        || paramId == QLatin1String("cwdit")
+        || paramId == QLatin1String("cwdah")
+        || paramId == QLatin1String("cw.key")
+        || paramId == QLatin1String("cw.dit")
+        || paramId == QLatin1String("cw.dah");
+}
+
 } // namespace
 
 // ── MidiBinding helpers ─────────────────────────────────────────────────────
@@ -327,7 +337,7 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2,
     if (it == m_bindingIndex.end()) return;
 
     const auto& binding = m_bindings[it.value()];
-    const bool cwBinding = binding.paramId.startsWith(QStringLiteral("cw."));
+    const bool cwBinding = isCwMomentaryParamId(binding.paramId);
 
     // ── Relative knob mode: decode delta and accumulate ────────────────
     if (binding.relative && msgType == MidiBinding::CC) {

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -11,6 +11,21 @@
 
 namespace AetherSDR {
 
+namespace {
+
+QString normalizedMidiParamId(const QString& paramId)
+{
+    if (paramId == QLatin1String("cw.key"))
+        return QStringLiteral("cwkey");
+    if (paramId == QLatin1String("cw.dit"))
+        return QStringLiteral("cwdit");
+    if (paramId == QLatin1String("cw.dah"))
+        return QStringLiteral("cwdah");
+    return paramId;
+}
+
+} // namespace
+
 MidiSettings& MidiSettings::instance()
 {
     static MidiSettings s;
@@ -73,7 +88,7 @@ void MidiSettings::save()
     xml.writeStartElement("Bindings");
     for (const auto& b : bindings) {
         xml.writeStartElement("Binding");
-        xml.writeAttribute("param", b.paramId);
+        xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
         xml.writeAttribute("channel", QString::number(b.channel));
         xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
         xml.writeAttribute("number", QString::number(b.number));
@@ -114,7 +129,7 @@ void MidiSettings::saveBindings(const QVector<MidiBinding>& bindings)
     xml.writeStartElement("Bindings");
     for (const auto& b : bindings) {
         xml.writeStartElement("Binding");
-        xml.writeAttribute("param", b.paramId);
+        xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
         xml.writeAttribute("channel", QString::number(b.channel));
         xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
         xml.writeAttribute("number", QString::number(b.number));
@@ -139,7 +154,7 @@ QVector<MidiBinding> MidiSettings::parseBindingsFromXml(const QString& filePath)
         xml.readNext();
         if (xml.isStartElement() && xml.name() == u"Binding") {
             MidiBinding b;
-            b.paramId  = xml.attributes().value("param").toString();
+            b.paramId  = normalizedMidiParamId(xml.attributes().value("param").toString());
             b.channel  = xml.attributes().value("channel").toInt();
             b.msgType  = static_cast<MidiBinding::MsgType>(
                              xml.attributes().value("type").toInt());
@@ -166,7 +181,7 @@ void MidiSettings::writeBindingsToXml(const QString& filePath,
     xml.writeStartElement("MidiProfile");
     for (const auto& b : bindings) {
         xml.writeStartElement("Binding");
-        xml.writeAttribute("param", b.paramId);
+        xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
         xml.writeAttribute("channel", QString::number(b.channel));
         xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
         xml.writeAttribute("number", QString::number(b.number));

--- a/src/core/ShortcutManager.cpp
+++ b/src/core/ShortcutManager.cpp
@@ -66,7 +66,7 @@ void ShortcutManager::loadBindings()
 {
     auto& s = AppSettings::instance();
     for (auto& a : m_actions) {
-        QString key = QString("Shortcut_%1").arg(a.id);
+        const QString key = QStringLiteral("Shortcut_%1").arg(a.id);
         QString val = s.value(key).toString();
         if (!val.isNull())
             a.currentKey = QKeySequence(val);
@@ -112,8 +112,10 @@ void ShortcutManager::loadBindings()
 void ShortcutManager::saveBindings()
 {
     auto& s = AppSettings::instance();
-    for (const auto& a : m_actions)
-        s.setValue(QString("Shortcut_%1").arg(a.id), a.currentKey.toString());
+    for (const auto& a : m_actions) {
+        const QString key = QStringLiteral("Shortcut_%1").arg(a.id);
+        s.setValue(key, a.currentKey.toString());
+    }
     s.save();
 }
 

--- a/src/gui/KeyboardMapWidget.cpp
+++ b/src/gui/KeyboardMapWidget.cpp
@@ -131,7 +131,7 @@ void KeyboardMapWidget::buildLayout()
     m_keys.append({4.75f, y3, 1, 1, Qt::Key_F, "F", {}});
     m_keys.append({5.75f, y3, 1, 1, Qt::Key_G, "G", {}});
     m_keys.append({6.75f, y3, 1, 1, Qt::Key_H, "H", {}});
-    m_keys.append({7.75f, y3, 1, 1, Qt::Key_I, "J", {}});
+    m_keys.append({7.75f, y3, 1, 1, Qt::Key_J, "J", {}});
     m_keys.append({8.75f, y3, 1, 1, Qt::Key_K, "K", {}});
     m_keys.append({9.75f, y3, 1, 1, Qt::Key_L, "L", {}});
     m_keys.append({10.75f, y3, 1, 1, Qt::Key_Semicolon, ";", ":"});

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -111,6 +111,7 @@
 #include <QPropertyAnimation>
 #include <QIcon>
 #include <QKeyEvent>
+#include <QMouseEvent>
 #include <QHelpEvent>
 #include <QWindow>
 #include <QPixmap>
@@ -417,9 +418,22 @@ static QString buildNetworkTooltip(const RadioModel& model)
 static constexpr const char* kPaTempUnitSettingKey = "PaTempDisplayUnit";
 static constexpr int kMemorySpotIdBase = 1000000;
 static constexpr int kPassiveSpotIdBase = 2000000;
+static constexpr const char* kCwStraightKeyActionId = "cwkey";
+static constexpr const char* kCwLeftPaddleActionId = "cwdit";
+static constexpr const char* kCwRightPaddleActionId = "cwdah";
+static constexpr const char* kCwStraightKeyActionName = "Trigger straight key";
+static constexpr const char* kCwLeftPaddleActionName = "Trigger CW Left Paddle";
+static constexpr const char* kCwRightPaddleActionName = "Trigger CW Right Paddle";
 
 static bool s_keyboardShortcutsEnabled = false;
 static bool s_sliderShortcutLeaseActive = false;
+
+static bool isCwMomentaryActionId(const QString& id)
+{
+    return id == QLatin1String(kCwStraightKeyActionId)
+        || id == QLatin1String(kCwLeftPaddleActionId)
+        || id == QLatin1String(kCwRightPaddleActionId);
+}
 
 static int memorySpotId(int memoryIndex)
 {
@@ -479,11 +493,8 @@ static QPixmap buildBandStackIndicatorPixmap(bool active)
     return pixmap;
 }
 
-static bool shortcutInputCaptured()
+static bool textInputCaptured()
 {
-    if (s_sliderShortcutLeaseActive)
-        return true;
-
     auto* w = QApplication::focusWidget();
     if (!w) return false;
     return qobject_cast<QLineEdit*>(w) || qobject_cast<QTextEdit*>(w)
@@ -491,8 +502,28 @@ static bool shortcutInputCaptured()
         || qobject_cast<QComboBox*>(w);
 }
 
+static bool shortcutInputCaptured()
+{
+    if (s_sliderShortcutLeaseActive)
+        return true;
+    return textInputCaptured();
+}
+
 static bool shortcutGuard() {
     return s_keyboardShortcutsEnabled && !shortcutInputCaptured();
+}
+
+static QKeySequence shortcutSequenceFromKeyEvent(const QKeyEvent* ev)
+{
+    if (!ev || ev->key() == Qt::Key_unknown)
+        return {};
+
+    const Qt::KeyboardModifiers modifiers =
+        ev->modifiers() & (Qt::ShiftModifier
+                           | Qt::ControlModifier
+                           | Qt::AltModifier
+                           | Qt::MetaModifier);
+    return QKeySequence(static_cast<int>(modifiers) | ev->key());
 }
 
 static QStringList splitClientField(const QString& raw)
@@ -1837,8 +1868,6 @@ MainWindow::MainWindow(QWidget* parent)
         };
         connect(&m_radioModel.transmitModel(), &TransmitModel::phoneStateChanged,
                 this, syncLocalKeyerToRadio);
-        // Initial sync once the radio reports its state.
-        syncLocalKeyerToRadio();
 
         // Mirror the radio's CW state into the local sidetone generator —
         // sidetone enable, volume (mon_gain_cw), and pitch all follow the
@@ -1888,49 +1917,48 @@ MainWindow::MainWindow(QWidget* parent)
             // would have produced from a hardware paddle.
             if (m_audio && m_audio->cwSidetone())
                 m_audio->cwSidetone()->setKeyDown(down);
-            const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
-            const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+            const quint64 traceId = m_lastCwPaddleTraceId.load(std::memory_order_relaxed);
+            const quint64 sourceMs = m_lastCwPaddleSourceMs.load(std::memory_order_relaxed);
             if (lcCw().isDebugEnabled()) {
                 const quint64 now = cwTraceNowMs();
                 qCDebug(lcCw).noquote().nospace()
                     << "CW iambic key-edge trace=" << traceId
                     << " t=" << now << "ms"
-                    << " sinceMidiMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+                    << " sinceSourceMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
                     << " down=" << down;
             }
             QMetaObject::invokeMethod(this, [this, down]() {
-                const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
-                const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
-                m_radioModel.sendCwKeyEdge(down, QStringLiteral("midi:iambic-keyer"),
+                const quint64 traceId = m_lastCwPaddleTraceId.load(std::memory_order_relaxed);
+                const quint64 sourceMs = m_lastCwPaddleSourceMs.load(std::memory_order_relaxed);
+                m_radioModel.sendCwKeyEdge(down, QStringLiteral("cw:iambic-keyer"),
                                            traceId, sourceMs);
             }, Qt::QueuedConnection);
         });
         m_iambicKeyer->setOnPaddleEvent([this](bool dit, bool dah) {
-            // PTT engaged for the entire squeeze — one cycle per
-            // press/release, not one per element, so the radio doesn't
-            // thrash through TX/RX gates between dits.
+            // The radio's break-in setting decides whether key edges produce
+            // RF. With break_in=1 (QSK), `cw key 1` from setOnKeyDownChange
+            // triggers TX and break_in_delay holds the relay between
+            // elements. With break_in=0, the operator engages PTT manually
+            // (Space PTT, MOX, hardware PTT) before keying. Either way, the
+            // iambic keyer should not auto-PTT — doing so would override
+            // break-in OFF and force-drop the QSK hang on release.
             const bool active = dit || dah;
-            const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
-            const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
+            const quint64 traceId = m_lastCwPaddleTraceId.load(std::memory_order_relaxed);
+            const quint64 sourceMs = m_lastCwPaddleSourceMs.load(std::memory_order_relaxed);
             if (lcCw().isDebugEnabled()) {
                 const quint64 now = cwTraceNowMs();
                 qCDebug(lcCw).noquote().nospace()
                     << "CW iambic paddle-event trace=" << traceId
                     << " t=" << now << "ms"
-                    << " sinceMidiMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+                    << " sinceSourceMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
                     << " dit=" << dit
                     << " dah=" << dah
-                    << " ptt=" << active;
+                    << " active=" << active;
             }
-            QMetaObject::invokeMethod(this, [this, active]() {
-                const quint64 traceId = m_lastCwMidiTraceId.load(std::memory_order_relaxed);
-                const quint64 sourceMs = m_lastCwMidiSourceMs.load(std::memory_order_relaxed);
-                m_radioModel.sendCwPtt(active, QStringLiteral("midi:iambic-keyer"),
-                                       traceId, sourceMs);
-            }, Qt::QueuedConnection);
         });
-        // Mode/WPM/start are driven by the radio's iambic state — see
-        // syncLocalKeyerToRadio below.
+        // Initial sync after callbacks are installed. Without this, the
+        // default/radio-reported iambic-on state may never emit a change.
+        syncLocalKeyerToRadio();
     }
 
     // TX/RX transition → audio source switching
@@ -2840,8 +2868,8 @@ MainWindow::MainWindow(QWidget* parent)
     });
     connect(m_serialPort, &SerialPortController::cwPaddleChanged,
             this, [this](bool dit, bool dah) {
-        m_lastCwMidiTraceId.store(0, std::memory_order_relaxed);
-        m_lastCwMidiSourceMs.store(0, std::memory_order_relaxed);
+        m_lastCwPaddleTraceId.store(0, std::memory_order_relaxed);
+        m_lastCwPaddleSourceMs.store(0, std::memory_order_relaxed);
         // When the local iambic keyer is running, feed it the raw paddle
         // state — it forwards to the radio AND drives the sidetone gate
         // directly.  Otherwise pass straight through to the radio (radio's
@@ -2997,7 +3025,7 @@ MainWindow::MainWindow(QWidget* parent)
         auto it = m_midiSetters.find(paramId);
         if (it == m_midiSetters.end()) return;
         const quint64 mainMs = cwTraceNowMs();
-        if (paramId.startsWith(QStringLiteral("cw.")) && lcCw().isDebugEnabled()) {
+        if (isCwMomentaryActionId(paramId) && lcCw().isDebugEnabled()) {
             qCDebug(lcCw).noquote().nospace()
                 << "CW MIDI main trace=" << traceId
                 << " t=" << mainMs << "ms"
@@ -4431,6 +4459,177 @@ void MainWindow::keyReleaseEvent(QKeyEvent* event)
     QMainWindow::keyReleaseEvent(event);
 }
 
+void MainWindow::cancelTransmitFromIndicator()
+{
+    if (!m_radioModel.isConnected()) {
+        statusBar()->showMessage("TX cancel ignored: not connected", 2000);
+        return;
+    }
+
+    const quint32 owner = m_radioModel.txClientHandle();
+    const quint32 ours = m_radioModel.ourClientHandle();
+    if (owner != 0 && ours != 0 && owner != ours
+        && !m_radioModel.transmitModel().isTransmitting()) {
+        statusBar()->showMessage("TX is owned by another station", 2500);
+        return;
+    }
+
+    m_spacePttActive = false;
+    m_cwStraightKeyActive = false;
+    m_cwLeftPaddleActive = false;
+    m_cwRightPaddleActive = false;
+    m_lastCwPaddleTraceId.store(0, std::memory_order_relaxed);
+    m_lastCwPaddleSourceMs.store(0, std::memory_order_relaxed);
+
+    if (m_iambicKeyer && m_iambicKeyer->isRunning()) {
+        m_iambicKeyer->setPaddleState(false, false);
+        m_iambicKeyer->reset();
+    }
+    if (m_audio && m_audio->cwSidetone())
+        m_audio->cwSidetone()->setKeyDown(false);
+
+    const quint64 sourceMs = cwTraceNowMs();
+    const quint64 traceId = nextCwTraceId();
+    const QString source = QStringLiteral("tx-indicator:cancel");
+    m_radioModel.sendCwKey(false, source, traceId, sourceMs);
+    m_radioModel.sendCwPtt(false, source, traceId, sourceMs);
+    m_radioModel.transmitModel().stopTune();
+    m_radioModel.setTransmit(false);
+
+    statusBar()->showMessage("TX cancel requested", 2000);
+}
+
+void MainWindow::setCwStraightKeyState(bool down, const QString& source,
+                                       quint64 traceId, quint64 sourceMs)
+{
+    if (m_cwStraightKeyActive == down)
+        return;
+
+    m_cwStraightKeyActive = down;
+    const QString actionSource = source.isEmpty()
+        ? QStringLiteral("cw:straight-key")
+        : source;
+
+    if (lcCw().isDebugEnabled()) {
+        const quint64 now = cwTraceNowMs();
+        qCDebug(lcCw).noquote().nospace()
+            << "CW action straight-key trace=" << traceId
+            << " t=" << now << "ms"
+            << " sinceSourceMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+            << " source=" << actionSource
+            << " down=" << down;
+    }
+
+    m_radioModel.sendCwKey(down, actionSource, traceId, sourceMs);
+}
+
+void MainWindow::setCwLeftPaddleState(bool down, const QString& source,
+                                      quint64 traceId, quint64 sourceMs)
+{
+    if (m_cwLeftPaddleActive == down)
+        return;
+
+    m_cwLeftPaddleActive = down;
+    pushCwPaddleState(source.isEmpty() ? QStringLiteral("cw:left-paddle") : source,
+                      traceId, sourceMs);
+}
+
+void MainWindow::setCwRightPaddleState(bool down, const QString& source,
+                                       quint64 traceId, quint64 sourceMs)
+{
+    if (m_cwRightPaddleActive == down)
+        return;
+
+    m_cwRightPaddleActive = down;
+    pushCwPaddleState(source.isEmpty() ? QStringLiteral("cw:right-paddle") : source,
+                      traceId, sourceMs);
+}
+
+void MainWindow::pushCwPaddleState(const QString& source,
+                                   quint64 traceId, quint64 sourceMs)
+{
+    const QString actionSource = source.isEmpty()
+        ? QStringLiteral("cw:paddle")
+        : source;
+
+    m_lastCwPaddleTraceId.store(traceId, std::memory_order_relaxed);
+    m_lastCwPaddleSourceMs.store(sourceMs, std::memory_order_relaxed);
+
+    if (lcCw().isDebugEnabled()) {
+        const quint64 now = cwTraceNowMs();
+        qCDebug(lcCw).noquote().nospace()
+            << "CW action paddle trace=" << traceId
+            << " t=" << now << "ms"
+            << " sinceSourceMs=" << (sourceMs ? static_cast<qint64>(now - sourceMs) : -1)
+            << " source=" << actionSource
+            << " leftDit=" << m_cwLeftPaddleActive
+            << " rightDah=" << m_cwRightPaddleActive
+            << " localIambic=" << (m_iambicKeyer && m_iambicKeyer->isRunning());
+    }
+
+    if (m_iambicKeyer && m_iambicKeyer->isRunning()) {
+        m_iambicKeyer->setPaddleState(m_cwLeftPaddleActive, m_cwRightPaddleActive);
+    } else {
+        m_radioModel.sendCwPaddle(m_cwLeftPaddleActive, m_cwRightPaddleActive,
+                                  actionSource, traceId, sourceMs);
+    }
+}
+
+bool MainWindow::handleCwMomentaryShortcut(QKeyEvent* keyEvent, QEvent::Type eventType)
+{
+    if (!keyEvent || keyEvent->isAutoRepeat())
+        return false;
+    if (eventType != QEvent::KeyPress && eventType != QEvent::KeyRelease)
+        return false;
+
+    const QKeySequence seq = shortcutSequenceFromKeyEvent(keyEvent);
+    const auto* action = m_shortcutManager.actionForKey(seq);
+    if (!action)
+        return false;
+
+    enum class CwAction { None, StraightKey, LeftPaddle, RightPaddle };
+    CwAction cwAction = CwAction::None;
+    if (action->id == QLatin1String(kCwStraightKeyActionId))
+        cwAction = CwAction::StraightKey;
+    else if (action->id == QLatin1String(kCwLeftPaddleActionId))
+        cwAction = CwAction::LeftPaddle;
+    else if (action->id == QLatin1String(kCwRightPaddleActionId))
+        cwAction = CwAction::RightPaddle;
+    else
+        return false;
+
+    const bool press = eventType == QEvent::KeyPress;
+    const bool currentlyActive =
+        cwAction == CwAction::StraightKey ? m_cwStraightKeyActive :
+        cwAction == CwAction::LeftPaddle ? m_cwLeftPaddleActive :
+                                           m_cwRightPaddleActive;
+
+    if (press && (!m_keyboardShortcutsEnabled || textInputCaptured()))
+        return false;
+    if (!press && !currentlyActive)
+        return m_keyboardShortcutsEnabled && !textInputCaptured();
+
+    const quint64 sourceMs = cwTraceNowMs();
+    const quint64 traceId = nextCwTraceId();
+    const bool down = press;
+
+    switch (cwAction) {
+    case CwAction::StraightKey:
+        setCwStraightKeyState(down, QStringLiteral("keyboard:cwkey"), traceId, sourceMs);
+        break;
+    case CwAction::LeftPaddle:
+        setCwLeftPaddleState(down, QStringLiteral("keyboard:cwdit"), traceId, sourceMs);
+        break;
+    case CwAction::RightPaddle:
+        setCwRightPaddleState(down, QStringLiteral("keyboard:cwdah"), traceId, sourceMs);
+        break;
+    case CwAction::None:
+        break;
+    }
+
+    return true;
+}
+
 void MainWindow::showNetworkDiagnosticsDialog()
 {
     if (!m_networkDiagnosticsDialog) {
@@ -4785,8 +4984,12 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
             }
             return true;
         }
+
+        if (handleCwMomentaryShortcut(ke, event->type()))
+            return true;
+
         if (ke->key() == Qt::Key_Space && !ke->isAutoRepeat()
-            && !shortcutInputCaptured()
+            && !textInputCaptured()
             && m_radioModel.isConnected()) {
             if (m_keyboardShortcutsEnabled) {
                 if (event->type() == QEvent::KeyPress && !m_spacePttActive) {
@@ -4946,6 +5149,12 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
     if (obj == m_pgxlIndicator && event->type() == QEvent::MouseButtonPress) {
         // Simple toggle: OPERATE ↔ STANDBY (PGXL has no BYPASS)
         m_radioModel.setAmpOperate(!m_radioModel.ampOperate());
+        return true;
+    }
+    if (obj == m_txIndicator && event->type() == QEvent::MouseButtonPress) {
+        auto* mouseEvent = static_cast<QMouseEvent*>(event);
+        if (mouseEvent->button() == Qt::LeftButton)
+            cancelTransmitFromIndicator();
         return true;
     }
     if (obj == m_panelToggle && event->type() == QEvent::MouseButtonPress) {
@@ -7041,6 +7250,11 @@ void MainWindow::buildUI()
     m_txIndicator = new QLabel("TX");
     m_txIndicator->setFixedSize(36, 36);
     m_txIndicator->setAlignment(Qt::AlignCenter);
+    m_txIndicator->setCursor(Qt::PointingHandCursor);
+    m_txIndicator->setToolTip("Click to cancel TX");
+    m_txIndicator->setAccessibleName("Cancel transmit");
+    m_txIndicator->setAccessibleDescription("Click to send key up, PTT off, Tune off, and MOX off.");
+    m_txIndicator->installEventFilter(this);
     m_txIndicator->setStyleSheet("QLabel { color: rgba(255,255,255,128); font-weight: bold; font-size: 21px; }");
     hbox->addWidget(m_txIndicator);
 
@@ -10478,6 +10692,14 @@ void MainWindow::registerShortcutActions()
             auto& tx = m_radioModel.transmitModel();
             tx.setCwBreakIn(!tx.cwBreakIn());
         });
+    // Momentary CW actions are handled by the app-level event filter so
+    // key release edges reach the netCW path too.
+    m_shortcutManager.registerAction(kCwStraightKeyActionId, kCwStraightKeyActionName, "CW",
+        QKeySequence(), nullptr);
+    m_shortcutManager.registerAction(kCwLeftPaddleActionId, kCwLeftPaddleActionName, "CW",
+        QKeySequence(), nullptr);
+    m_shortcutManager.registerAction(kCwRightPaddleActionId, kCwRightPaddleActionName, "CW",
+        QKeySequence(), nullptr);
 
     // ── EQ ──────────────────────────────────────────────────────────────
     m_shortcutManager.registerAction("tx_eq_toggle", "TX EQ Toggle", "EQ",
@@ -12454,69 +12676,32 @@ void MainWindow::registerMidiParams()
         [this](float v) { m_radioModel.transmitModel().setCwBreakIn(v > 0.5f); },
         [this]() -> float { return m_radioModel.transmitModel().cwBreakIn() ? 1 : 0; });
 
-    reg("cw.key", "CW Key (straight)", "Phone/CW", P::Gate, 0, 1,
+    reg(kCwStraightKeyActionId, kCwStraightKeyActionName, "Phone/CW", P::Gate, 0, 1,
         [this](float v) {
-            const bool down = v > 0.5f;
-            if (lcCw().isDebugEnabled()) {
-                const quint64 now = cwTraceNowMs();
-                qCDebug(lcCw).noquote().nospace()
-                    << "CW MIDI straight-key trace=" << m_currentMidiTrace.traceId
-                    << " t=" << now << "ms"
-                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
-                        ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
-                    << " down=" << down;
-            }
-            m_radioModel.sendCwKey(down, QStringLiteral("midi:cw.key"),
-                                   m_currentMidiTrace.traceId,
-                                   m_currentMidiTrace.callbackMs);
+            setCwStraightKeyState(v > 0.5f, QStringLiteral("midi:cwkey"),
+                                  m_currentMidiTrace.traceId,
+                                  m_currentMidiTrace.callbackMs);
         });
 
-    // Iambic paddle: dit and dah are separate MIDI notes.
+    // Iambic paddle: left and right are separate momentary actions.
     // When the local iambic keyer is running, paddle states feed into it
     // (drives sidetone with sub-5 ms latency, then forwards to radio).
     // Otherwise pass straight to the radio's RF iambic engine.
-    {
-        auto dit = std::make_shared<bool>(false);
-        auto dah = std::make_shared<bool>(false);
+    reg(kCwLeftPaddleActionId, kCwLeftPaddleActionName, "Phone/CW", P::Gate, 0, 1,
+        [this](float v) {
+            setCwLeftPaddleState(v > 0.5f, QStringLiteral("midi:cwdit"),
+                                 m_currentMidiTrace.traceId,
+                                 m_currentMidiTrace.callbackMs);
+        },
+        [this]() -> float { return m_cwLeftPaddleActive ? 1.0f : 0.0f; });
 
-        auto pushPaddle = [this, dit, dah]() {
-            m_lastCwMidiTraceId.store(m_currentMidiTrace.traceId, std::memory_order_relaxed);
-            m_lastCwMidiSourceMs.store(m_currentMidiTrace.callbackMs, std::memory_order_relaxed);
-            if (lcCw().isDebugEnabled()) {
-                const quint64 now = cwTraceNowMs();
-                qCDebug(lcCw).noquote().nospace()
-                    << "CW MIDI paddle trace=" << m_currentMidiTrace.traceId
-                    << " t=" << now << "ms"
-                    << " param=" << m_currentMidiTrace.paramId
-                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
-                        ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
-                    << " dit=" << *dit
-                    << " dah=" << *dah
-                    << " localIambic=" << (m_iambicKeyer && m_iambicKeyer->isRunning());
-            }
-            if (m_iambicKeyer && m_iambicKeyer->isRunning()) {
-                m_iambicKeyer->setPaddleState(*dit, *dah);
-            } else {
-                m_radioModel.sendCwPaddle(*dit, *dah, QStringLiteral("midi:cw.paddle"),
-                                          m_currentMidiTrace.traceId,
-                                          m_currentMidiTrace.callbackMs);
-            }
-        };
-
-        reg("cw.dit", "CW Paddle Dit", "Phone/CW", P::Gate, 0, 1,
-            [dit, pushPaddle](float v) {
-                *dit = (v > 0.5f);
-                pushPaddle();
-            },
-            [dit]() -> float { return *dit ? 1.0f : 0.0f; });
-
-        reg("cw.dah", "CW Paddle Dah", "Phone/CW", P::Gate, 0, 1,
-            [dah, pushPaddle](float v) {
-                *dah = (v > 0.5f);
-                pushPaddle();
-            },
-            [dah]() -> float { return *dah ? 1.0f : 0.0f; });
-    }
+    reg(kCwRightPaddleActionId, kCwRightPaddleActionName, "Phone/CW", P::Gate, 0, 1,
+        [this](float v) {
+            setCwRightPaddleState(v > 0.5f, QStringLiteral("midi:cwdah"),
+                                  m_currentMidiTrace.traceId,
+                                  m_currentMidiTrace.callbackMs);
+        },
+        [this]() -> float { return m_cwRightPaddleActive ? 1.0f : 0.0f; });
 
     reg("cw.ptt", "PTT (hold)", "Phone/CW", P::Gate, 0, 1,
         [this](float v) {
@@ -12526,7 +12711,7 @@ void MainWindow::registerMidiParams()
                 qCDebug(lcCw).noquote().nospace()
                     << "CW MIDI ptt trace=" << m_currentMidiTrace.traceId
                     << " t=" << now << "ms"
-                    << " sinceMidiMs=" << (m_currentMidiTrace.callbackMs
+                    << " sinceSourceMs=" << (m_currentMidiTrace.callbackMs
                         ? static_cast<qint64>(now - m_currentMidiTrace.callbackMs) : -1)
                     << " mox=" << on;
             }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -52,6 +52,7 @@
 #include <QHash>
 #include <QJsonObject>
 #include <QTimer>
+#include <QEvent>
 #include <atomic>
 
 class QAbstractSlider;
@@ -247,6 +248,15 @@ private:
     void clearSwrSweepForBandChange(int sliceId, const QString& panId,
                                     const QString& newBandName);
     SliceModel* swrSweepTargetSlice(int requestedSliceId = -1) const;
+    void setCwStraightKeyState(bool down, const QString& source = {},
+                               quint64 traceId = 0, quint64 sourceMs = 0);
+    void setCwLeftPaddleState(bool down, const QString& source = {},
+                              quint64 traceId = 0, quint64 sourceMs = 0);
+    void setCwRightPaddleState(bool down, const QString& source = {},
+                               quint64 traceId = 0, quint64 sourceMs = 0);
+    void pushCwPaddleState(const QString& source = {},
+                           quint64 traceId = 0, quint64 sourceMs = 0);
+    bool handleCwMomentaryShortcut(QKeyEvent* keyEvent, QEvent::Type eventType);
 
     // Core objects
     RadioDiscovery    m_discovery;
@@ -321,8 +331,6 @@ private:
         quint64 dispatchMs{0};
     };
     MidiActionTrace m_currentMidiTrace;
-    std::atomic<quint64> m_lastCwMidiTraceId{0};
-    std::atomic<quint64> m_lastCwMidiSourceMs{0};
     // MIDI param setters indexed by ID — called on main thread from
     // paramActionTrace signal (worker thread cannot call them directly). (#502)
     QHash<QString, std::function<void(float)>> m_midiSetters;
@@ -417,6 +425,7 @@ private:
     float m_lastPaTempC{0.0f};
     bool m_userDisconnected{false};  // true after explicit disconnect, blocks auto-connect
     QDialog* m_reconnectDlg{nullptr}; // shown on unexpected disconnect, dismissed on reconnect
+    void cancelTransmitFromIndicator();
     class ClientEqEditor* m_clientEqEditor{nullptr}; // lazy — created on first Edit… click
     // Lazy-construct the floating EQ editor on first access, with all
     // bypass-toggled wiring set up once.  Used from every site that
@@ -455,9 +464,14 @@ private:
     QTimer* m_agManualConnectTimer{nullptr}; // deferred AG manual connect — cancelled on disconnect
     class CwxLocalKeyer* m_cwxLocalKeyer{nullptr};  // local Morse keyer for CWX sidetone
     std::unique_ptr<class IambicKeyer> m_iambicKeyer;  // local iambic state machine for paddle sidetone
+    std::atomic<quint64> m_lastCwPaddleTraceId{0};
+    std::atomic<quint64> m_lastCwPaddleSourceMs{0};
     qint64 m_bsConnectGraceUntilMs{0};   // suppress auto-save right after connect
     bool m_keyboardShortcutsEnabled{false}; // global enable for keyboard shortcuts (View menu)
     bool m_spacePttActive{false};          // true while Space is held for PTT
+    bool m_cwStraightKeyActive{false};
+    bool m_cwLeftPaddleActive{false};
+    bool m_cwRightPaddleActive{false};
     QPointer<QAbstractSlider> m_sliderShortcutLease;
     QTimer m_sliderShortcutLeaseTimer;
     struct SwrSweepSample {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -735,17 +735,14 @@ void RadioModel::sendCwKey(bool down, const QString& debugSource,
 {
     const bool prev = m_cwKeyActive;
     m_cwKeyActive = down;
-    // PTT-then-Key on press, Key-then-unPTT on release.  Per FlexLib's
-    // CWPTT + CWKey pair (Radio.cs:8890–8965): without an explicit
-    // `cw ptt 1` the radio queues key events but doesn't transmit when
-    // break_in=0 (the default on most user setups).  Pairing PTT with
-    // KEY keys reliably regardless of break-in mode.
-    if (down && !prev)
-        sendNetCwCommand(QStringLiteral("cw ptt 1"), debugSource, debugTraceId, debugSourceMs);
+    // Send only the key edge — the radio's break-in setting decides whether
+    // it transmits.  With break_in=1 (QSK), `cw key 1` triggers TX and
+    // break_in_delay holds the relay between elements.  With break_in=0,
+    // the radio queues the key but doesn't transmit until the operator
+    // explicitly asserts CW PTT (Space PTT, MOX, or hardware PTT) — the
+    // standard semi-break-in workflow per FlexLib Radio.cs:8890–8965.
     sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
                      debugSource, debugTraceId, debugSourceMs);
-    if (!down && prev)
-        sendNetCwCommand(QStringLiteral("cw ptt 0"), debugSource, debugTraceId, debugSourceMs);
     if (prev != down)
         emit cwKeyDownChanged(down);
 }

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -60,7 +60,21 @@ int main(int argc, char** argv)
     tuneKnob.number = -1;
     tuneKnob.paramId = "rx.tuneKnob";
 
-    QVector<MidiBinding> saved{afGain, tuneKnob};
+    MidiBinding cwDitLegacy;
+    cwDitLegacy.channel = 0;
+    cwDitLegacy.msgType = MidiBinding::NoteOn;
+    cwDitLegacy.number = 60;
+    cwDitLegacy.paramId = "cw.dit";
+
+    MidiBinding cwDah;
+    cwDah.channel = 0;
+    cwDah.msgType = MidiBinding::NoteOn;
+    cwDah.number = 61;
+    cwDah.paramId = "cwdah";
+
+    QVector<MidiBinding> saved{afGain, tuneKnob, cwDitLegacy, cwDah};
+    QVector<MidiBinding> expected = saved;
+    expected[2].paramId = "cwdit";
 
     auto& settings = MidiSettings::instance();
     settings.setLastDevice("Initial Controller");
@@ -75,12 +89,24 @@ int main(int argc, char** argv)
     bool ok = true;
     ok &= expect(loaded.size() == saved.size(),
                  "preference-only save preserves binding count");
-    if (loaded.size() == saved.size()) {
-        ok &= expect(sameBinding(loaded[0], saved[0]),
-                     "preference-only save preserves first binding");
-        ok &= expect(sameBinding(loaded[1], saved[1]),
-                     "preference-only save preserves second binding");
+    if (loaded.size() == expected.size()) {
+        for (int i = 0; i < expected.size(); ++i) {
+            ok &= expect(sameBinding(loaded[i], expected[i]),
+                         "preference-only save preserves normalized binding");
+        }
     }
+
+    QFile midiFile(configRoot + "/AetherSDR/midi.settings");
+    ok &= expect(midiFile.open(QIODevice::ReadOnly | QIODevice::Text),
+                 "MIDI settings file is written");
+    const QString xml = midiFile.isOpen() ? QString::fromUtf8(midiFile.readAll()) : QString();
+    midiFile.close();
+    ok &= expect(xml.contains(QStringLiteral("param=\"cwdit\"")),
+                 "legacy CW dit MIDI binding saves as cwdit");
+    ok &= expect(xml.contains(QStringLiteral("param=\"cwdah\"")),
+                 "CW dah MIDI binding saves as cwdah");
+    ok &= expect(!xml.contains(QStringLiteral("param=\"cw.dit\"")),
+                 "MIDI settings do not save dotted CW dit ID");
 
     settings.load();
     ok &= expect(settings.lastDevice() == "Renamed Controller",

--- a/tests/shortcut_manager_test.cpp
+++ b/tests/shortcut_manager_test.cpp
@@ -1,0 +1,99 @@
+#include "core/AppSettings.h"
+#include "core/ShortcutManager.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    return condition;
+}
+
+void registerCwActions(ShortcutManager& manager)
+{
+    manager.registerAction(QStringLiteral("cwkey"), QStringLiteral("Trigger straight key"),
+                           QStringLiteral("CW"), QKeySequence(), {});
+    manager.registerAction(QStringLiteral("cwdit"), QStringLiteral("Trigger CW Left Paddle"),
+                           QStringLiteral("CW"), QKeySequence(), {});
+    manager.registerAction(QStringLiteral("cwdah"), QStringLiteral("Trigger CW Right Paddle"),
+                           QStringLiteral("CW"), QKeySequence(), {});
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QTemporaryDir fakeHome(QDir::tempPath() + "/aether-shortcut-manager-test-XXXXXX");
+    if (!fakeHome.isValid()) {
+        std::cerr << "[FAIL] create temporary home\n";
+        return 1;
+    }
+    qputenv("HOME", fakeHome.path().toUtf8());
+    qputenv("CFFIXED_USER_HOME", fakeHome.path().toUtf8());
+    QStandardPaths::setTestModeEnabled(true);
+    QCoreApplication app(argc, argv);
+
+    const QString configRoot =
+        QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+    QDir(configRoot + "/AetherSDR").removeRecursively();
+
+    auto& settings = AppSettings::instance();
+    settings.reset();
+
+    ShortcutManager manager;
+    registerCwActions(manager);
+    manager.loadBindings();
+    manager.setBinding(QStringLiteral("cwkey"), QKeySequence(Qt::Key_F9));
+    manager.setBinding(QStringLiteral("cwdit"), QKeySequence(Qt::Key_F10));
+    manager.setBinding(QStringLiteral("cwdah"), QKeySequence(Qt::Key_F11));
+
+    QFile saved(settings.filePath());
+    bool ok = expect(saved.open(QIODevice::ReadOnly | QIODevice::Text),
+                     "shortcut settings file is written");
+    const QString xml = ok ? QString::fromUtf8(saved.readAll()) : QString();
+    saved.close();
+
+    ok &= expect(xml.contains(QStringLiteral("<Shortcut_cwkey>F9</Shortcut_cwkey>")),
+                 "straight-key shortcut persists as Shortcut_cwkey");
+    ok &= expect(xml.contains(QStringLiteral("<Shortcut_cwdit>F10</Shortcut_cwdit>")),
+                 "dit shortcut persists as Shortcut_cwdit");
+    ok &= expect(xml.contains(QStringLiteral("<Shortcut_cwdah>F11</Shortcut_cwdah>")),
+                 "dah shortcut persists as Shortcut_cwdah");
+    ok &= expect(!xml.contains(QStringLiteral("Shortcut_cw.key")),
+                 "shortcut XML does not use dotted CW IDs");
+    ok &= expect(!xml.contains(QStringLiteral("Shortcut_cw.dit")),
+                 "shortcut XML does not use dotted CW dit ID");
+    ok &= expect(!xml.contains(QStringLiteral("Shortcut_cw.dah")),
+                 "shortcut XML does not use dotted CW dah ID");
+
+    settings.reset();
+    settings.load();
+
+    ShortcutManager restored;
+    registerCwActions(restored);
+    restored.loadBindings();
+
+    const auto* straight = restored.action(QStringLiteral("cwkey"));
+    const auto* dit = restored.action(QStringLiteral("cwdit"));
+    const auto* dah = restored.action(QStringLiteral("cwdah"));
+
+    ok &= expect(straight && straight->currentKey == QKeySequence(Qt::Key_F9),
+                 "straight-key shortcut reloads");
+    ok &= expect(dit && dit->currentKey == QKeySequence(Qt::Key_F10),
+                 "dit shortcut reloads");
+    ok &= expect(dah && dah->currentKey == QKeySequence(Qt::Key_F11),
+                 "dah shortcut reloads");
+
+    QDir(configRoot + "/AetherSDR").removeRecursively();
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Cherry-picks @jensenpat's CW keyboard + MIDI controls work from PR #2361 onto a clean base, plus three follow-up fixes that came out of testing the cherry-pick locally.

## Commits squashed in

- **Add CW keyboard and MIDI controls (#2361)** — cherry-pick of jensenpat's third commit only; the netCW timing/trace work from his first two commits is already on main via #2336. The 3-way merge cleanly resolved the `m_lastCwPaddle*`/`m_lastCwMidi*` atomic naming overlap by adopting the more descriptive `_Paddle*` names everywhere — option 2 from the original review.
- **KeyboardMapWidget: fix J tile mapping to Qt::Key_I** — pre-existing one-character typo in the on-screen keyboard widget; the J tile was bound to `Qt::Key_I`, so binding a shortcut to J in the editor selected I instead.
- **MainWindow: don't block CW/Space PTT shortcuts during slider lease** — clicking the CW delay slider triggered `s_sliderShortcutLeaseActive` which blocked the momentary CW key handler and Space PTT for 2+ seconds. Splits the helper: `textInputCaptured()` for actual text widgets only, `shortcutInputCaptured()` keeps the slider-lease check for the QShortcut dispatch path.
- **Honor cw break_in setting for keyboard CW keying** — `RadioModel::sendCwKey` and the iambic keyer's onPaddleEvent both wrapped each key in a `cw ptt 1`...`cw ptt 0` envelope. That made break-in OFF a no-op (auto-PTT forced TX anyway) and killed the QSK hang time with break-in ON. Strips the auto-PTT in both paths so the radio's break-in setting decides TX behavior, matching SmartSDR.

## Verification

- Build clean on Linux (RelWithDebInfo).
- `shortcut_manager_test`, `midi_settings_test`, `radio_status_ownership_test` all pass.
- Hardware tested by @ten9876 against FLEX-8600 fw 4.1.5: keyboard straight key, MIDI straight key, paddle keys, break-in OFF blocks auto-PTT, break-in ON honors `break_in_delay`, slider drag no longer freezes CW shortcuts.

Closes #2361.

Co-authored-by: jensenpat <patjensen@gmail.com>
Co-authored-by: Codex <noreply@openai.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>