### PR TITLE
fix(cluster): restore auto-reconnect after failed connection attempt (#2380)

### DIFF
--- a/src/core/DxClusterClient.cpp
+++ b/src/core/DxClusterClient.cpp
@@ -41,8 +41,8 @@ QString DxClusterClient::logFilePath() const
 
 void DxClusterClient::connectToCluster(const QString& host, quint16 port, const QString& callsign)
 {
-    if (m_connected) {
-        qCWarning(lcDxCluster) << "DxClusterClient: already connected";
+    if (m_connected || m_socket->state() == QAbstractSocket::ConnectingState) {
+        qCWarning(lcDxCluster) << "DxClusterClient: connect attempt already in progress";
         return;
     }
 
@@ -56,12 +56,16 @@ void DxClusterClient::connectToCluster(const QString& host, quint16 port, const 
     qCDebug(lcDxCluster) << "DxClusterClient: connecting to" << host << ":" << port;
     m_socket->connectToHost(host, port);
 
-    // Connection timeout
-    QTimer::singleShot(ConnectTimeoutMs, this, [this] {
+    // Connection timeout — capture epoch so a stale timeout from attempt N cannot
+    // abort a later attempt that has already succeeded (#2380).
+    const int epoch = ++m_connectEpoch;
+    QTimer::singleShot(ConnectTimeoutMs, this, [this, epoch] {
+        if (m_connectEpoch != epoch) return;  // superseded by a later attempt
         if (!m_connected && m_socket->state() != QAbstractSocket::ConnectedState) {
             qCWarning(lcDxCluster) << "DxClusterClient: connection timeout";
             m_socket->abort();
             emit connectionError("Connection timeout");
+            scheduleReconnect();
         }
     });
 }
@@ -121,13 +125,7 @@ void DxClusterClient::onDisconnected()
     if (wasConnected)
         emit disconnected();
 
-    if (!m_intentionalDisconnect) {
-        int delay = std::min(InitialReconnectDelayMs * (1 << m_reconnectAttempts),
-                             MaxReconnectDelayMs);
-        qCDebug(lcDxCluster) << "DxClusterClient: reconnecting in" << delay << "ms";
-        m_reconnectTimer->start(delay);
-        m_reconnectAttempts++;
-    }
+    scheduleReconnect();
 }
 
 void DxClusterClient::onSocketError(QAbstractSocket::SocketError /*err*/)
@@ -135,6 +133,24 @@ void DxClusterClient::onSocketError(QAbstractSocket::SocketError /*err*/)
     QString msg = m_socket->errorString();
     qCWarning(lcDxCluster) << "DxClusterClient: socket error:" << msg;
     emit connectionError(msg);
+    // When a connection attempt fails (ConnectingState → error), Qt does NOT emit
+    // disconnected(), so onDisconnected() never fires. Arm the reconnect timer
+    // here so the chain continues after a failed attempt (#2380).
+    if (!m_connected) {
+        scheduleReconnect();
+    }
+}
+
+void DxClusterClient::scheduleReconnect()
+{
+    if (m_intentionalDisconnect) return;
+    if (m_reconnectTimer->isActive()) return;  // already scheduled — don't compound backoff
+    int delay = std::min(InitialReconnectDelayMs * (1 << m_reconnectAttempts),
+                         MaxReconnectDelayMs);
+    qCDebug(lcDxCluster) << "DxClusterClient: reconnecting in" << delay
+                         << "ms (attempt" << m_reconnectAttempts + 1 << ")";
+    m_reconnectTimer->start(delay);
+    m_reconnectAttempts++;
 }
 
 void DxClusterClient::onReconnectTimer()

--- a/src/core/DxClusterClient.h
+++ b/src/core/DxClusterClient.h
@@ -62,6 +62,10 @@ private:
     bool isLoginPrompt(const QString& line) const;
     void handleLine(const QString& line);
     void stripTelnetIAC();
+    // Arm the exponential-backoff reconnect timer. Guards against double-scheduling
+    // (errorOccurred + timeout can both fire for one failed attempt). No-op when
+    // m_intentionalDisconnect is set or the timer is already active (#2380).
+    void scheduleReconnect();
 
     QTcpSocket* m_socket;
     QByteArray  m_readBuffer;
@@ -76,6 +80,7 @@ private:
     bool    m_loggedIn{false};
     bool    m_intentionalDisconnect{false};
     int     m_reconnectAttempts{0};
+    int     m_connectEpoch{0};  // incremented each connectToCluster(); guards stale timeouts
 
     static constexpr int MaxReconnectDelayMs    = 60000;
     static constexpr int InitialReconnectDelayMs = 5000;


### PR DESCRIPTION
## Summary

Cherry-picks @M7HNF-Ian's cluster auto-reconnect fix from PR #2388 onto a clean base. The rest of his branch contained already-merged commits (#2349 Spot Lines toggle and #2386 TCI crash fix), the rejected #2387 spectrum fix, and two drive-by spots-naming refinements that belong in their own focused PR.

Closes #2380.

## Bug

SpotHub (DX cluster / RBN) didn't automatically reconnect after a Wi-Fi drop or any failed connection attempt. The app would try once when the network came back, fail, and stop retrying — requiring a manual reconnect.

## Root cause

Qt's `QAbstractSocket` only emits `disconnected()` on a Connected → Unconnected transition. When a socket fails during `ConnectingState` (host blocked, refused, or timed out), Qt emits `errorOccurred` but **not** `disconnected`. The reconnect timer was only armed inside `onDisconnected()`, so a single failed connect attempt permanently halted the backoff chain. Two additional failure paths had the same gap: `onSocketError()` emitted the UI error only and never re-armed the timer, and the 10-second connect-timeout lambda called `abort()` without scheduling a retry.

## Fix

Extracts a `scheduleReconnect()` helper called from all three failure paths, with two guards — `m_intentionalDisconnect` (don't override user-initiated disconnect) and `m_reconnectTimer->isActive()` (prevents double-scheduling when `errorOccurred` and the connect timeout both fire for the same failed attempt). A per-call epoch counter captured by the timeout lambda ensures a stale timeout from attempt N cannot abort a later attempt N+1 that has since succeeded. `connectToCluster()` also now rejects calls when the socket is already in `ConnectingState` to prevent overlapping attempts during rapid retries.

Backoff sequence unchanged: 5 s → 10 s → 20 s → 40 s → 60 s (cap).

## Hardware-validated

@ten9876 tested against a real cluster on FLEX-8600 fw 4.1.5: firewall-block triggers retries at the expected intervals; unblock mid-backoff connects without manual intervention; user-initiated disconnect doesn't auto-retry; backoff resets on successful reconnect.

Reported by luigiverdicchio1-prog (Lou) on Windows 10 with a FLEX-6400.

Co-authored-by: Ian M7HNF <idimmock@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>