### PR TITLE
ci: cache Windows third-party deps (Opus, FFTW, hidapi, DeepFilterNet)

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -30,16 +30,52 @@ jobs:
       - name: Install Ninja, Inno Setup, and LLVM
         run: choco install ninja innosetup llvm -y
 
+      # Each third-party dep is cached against the hash of its setup
+      # script (which pins the version), so cache invalidates the moment
+      # we bump a version.  Skips the upstream download + build entirely
+      # on cache hit.
+      - name: Cache Opus
+        uses: actions/cache@v4
+        id: cache-opus
+        with:
+          path: third_party/opus
+          key: opus-${{ runner.os }}-${{ hashFiles('setup-opus.ps1') }}
+
       - name: Setup Opus (SmartLink audio codec)
+        if: steps.cache-opus.outputs.cache-hit != 'true'
         run: .\setup-opus.ps1
 
+      - name: Cache FFTW3
+        uses: actions/cache@v4
+        id: cache-fftw
+        with:
+          path: third_party/fftw3
+          key: fftw-${{ runner.os }}-${{ hashFiles('setup-fftw.ps1') }}
+
       - name: Setup FFTW3 float (NR4 dependency)
+        if: steps.cache-fftw.outputs.cache-hit != 'true'
         run: .\setup-fftw.ps1
 
+      - name: Cache hidapi
+        uses: actions/cache@v4
+        id: cache-hidapi
+        with:
+          path: third_party/hidapi
+          key: hidapi-${{ runner.os }}-${{ hashFiles('setup-hidapi.ps1') }}
+
       - name: Setup hidapi (USB HID device support)
+        if: steps.cache-hidapi.outputs.cache-hit != 'true'
         run: .\setup-hidapi.ps1
 
+      - name: Cache DeepFilterNet3
+        uses: actions/cache@v4
+        id: cache-deepfilter
+        with:
+          path: third_party/deepfilter
+          key: deepfilter-${{ runner.os }}-${{ hashFiles('setup-deepfilter.ps1') }}
+
       - name: Setup DeepFilterNet3 (DFNR)
+        if: steps.cache-deepfilter.outputs.cache-hit != 'true'
         run: .\setup-deepfilter.ps1
 
       - name: Configure


### PR DESCRIPTION
The Windows installer workflow re-downloaded and rebuilt all four
third-party deps from upstream mirrors on every release tag — exposing
the build to whatever flaky download host was having a bad day. The
v0.9.7 build hit exactly this on a transient Opus mirror timeout
("connected party did not properly respond after a period of time")
and required a manual rerun.

Adds actions/cache@v4 wrappers around each of the four setup steps,
keyed on the hash of the setup script (which pins the dep version).
Cache invalidates the moment we bump a version. Skips the upstream
download + build entirely on cache hit. First successful run after
merge populates each cache; subsequent runs resolve in seconds and
are immune to upstream availability.

The existing in-script "skip if marker file exists" guards stay as
a belt-and-braces against partial cache restores.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
