### PR TITLE
ci: mirror Opus download to GitHub Releases with retry/fallback

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -30,16 +30,52 @@ jobs:
       - name: Install Ninja, Inno Setup, and LLVM
         run: choco install ninja innosetup llvm -y
 
+      # Each third-party dep is cached against the hash of its setup
+      # script (which pins the version), so cache invalidates the moment
+      # we bump a version.  Skips the upstream download + build entirely
+      # on cache hit.
+      - name: Cache Opus
+        uses: actions/cache@v4
+        id: cache-opus
+        with:
+          path: third_party/opus
+          key: opus-${{ runner.os }}-${{ hashFiles('setup-opus.ps1') }}
+
       - name: Setup Opus (SmartLink audio codec)
+        if: steps.cache-opus.outputs.cache-hit != 'true'
         run: .\setup-opus.ps1
 
+      - name: Cache FFTW3
+        uses: actions/cache@v4
+        id: cache-fftw
+        with:
+          path: third_party/fftw3
+          key: fftw-${{ runner.os }}-${{ hashFiles('setup-fftw.ps1') }}
+
       - name: Setup FFTW3 float (NR4 dependency)
+        if: steps.cache-fftw.outputs.cache-hit != 'true'
         run: .\setup-fftw.ps1
 
+      - name: Cache hidapi
+        uses: actions/cache@v4
+        id: cache-hidapi
+        with:
+          path: third_party/hidapi
+          key: hidapi-${{ runner.os }}-${{ hashFiles('setup-hidapi.ps1') }}
+
       - name: Setup hidapi (USB HID device support)
+        if: steps.cache-hidapi.outputs.cache-hit != 'true'
         run: .\setup-hidapi.ps1
 
+      - name: Cache DeepFilterNet3
+        uses: actions/cache@v4
+        id: cache-deepfilter
+        with:
+          path: third_party/deepfilter
+          key: deepfilter-${{ runner.os }}-${{ hashFiles('setup-deepfilter.ps1') }}
+
       - name: Setup DeepFilterNet3 (DFNR)
+        if: steps.cache-deepfilter.outputs.cache-hit != 'true'
         run: .\setup-deepfilter.ps1
 
       - name: Configure

--- a/setup-opus.ps1
+++ b/setup-opus.ps1
@@ -15,9 +15,16 @@
 
 $ErrorActionPreference = "Stop"
 
-# Opus 1.5.2 prebuilt from xiph.org (Windows x64 MSVC)
+# Opus 1.5.2 source.  Primary mirror is GitHub Releases (Microsoft CDN,
+# essentially never down); xiph.org is the official upstream and serves
+# the same tarball but has been intermittently unreachable from GitHub-
+# hosted Windows runners.  Try GitHub first, fall back to xiph, retry
+# each with backoff before failing the build.
 $OpusVersion = "1.5.2"
-$OpusSrcUrl  = "https://downloads.xiph.org/releases/opus/opus-${OpusVersion}.tar.gz"
+$OpusSrcUrls = @(
+    "https://github.com/xiph/opus/releases/download/v${OpusVersion}/opus-${OpusVersion}.tar.gz",
+    "https://downloads.xiph.org/releases/opus/opus-${OpusVersion}.tar.gz"
+)
 $OutDir      = "third_party\opus"
 $TarFile     = "third_party\opus-${OpusVersion}.tar.gz"
 $VsVars      = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
@@ -41,8 +48,27 @@ New-Item -ItemType Directory -Force -Path "$OutDir\bin" | Out-Null
 
 # ── Download source for headers ──────────────────────────────────────────
 if (-not (Test-Path $TarFile)) {
-    Write-Host "Downloading Opus ${OpusVersion} source..." -ForegroundColor Cyan
-    Invoke-WebRequest -Uri $OpusSrcUrl -OutFile $TarFile
+    $downloaded = $false
+    foreach ($url in $OpusSrcUrls) {
+        for ($attempt = 1; $attempt -le 3; $attempt++) {
+            Write-Host "Downloading Opus ${OpusVersion} from $url (attempt $attempt/3)..." -ForegroundColor Cyan
+            try {
+                Invoke-WebRequest -Uri $url -OutFile $TarFile -TimeoutSec 60
+                $downloaded = $true
+                break
+            } catch {
+                Write-Warning "Download failed: $_"
+                if ($attempt -lt 3) {
+                    Start-Sleep -Seconds (5 * $attempt)
+                }
+            }
+        }
+        if ($downloaded) { break }
+    }
+    if (-not $downloaded) {
+        Write-Error "All Opus download attempts failed (tried $($OpusSrcUrls.Count) mirrors x 3 retries)"
+        exit 1
+    }
 }
 
 # ── Extract headers ──────────────────────────────────────────────────────


### PR DESCRIPTION
- ci: cache Windows third-party deps (Opus, FFTW, hidapi, DeepFilterNet)
- ci: mirror Opus download to GitHub Releases with retry/fallback
