### PR TITLE
ci: scope CodeQL to first-party sources

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,22 @@
+name: AetherSDR CodeQL configuration
+
+# Restrict analysis to AetherSDR's own first-party C++ sources.  Vendored
+# upstream deps and build-time-extracted source trees are out of scope —
+# their security posture is the responsibility of upstream, and scanning
+# them inflates alert noise that masks signal in our own code.
+
+paths-ignore:
+  # ExternalProject extracts upstream sources here at build time
+  # (Opus 1.5.2 from xiph.org, etc.).  Not committed, not ours.
+  - 'build/**'
+
+  # Vendored dependencies — opus-rade, mosquitto, ggmorse, libmspack,
+  # rnnoise, deepfilter, fftw3, libspecbleach, r8brain, radae, rtmidi.
+  # Treat as binary-equivalent black boxes for security analysis.
+  - 'third_party/**'
+
+  # Test harnesses — not shipped, run locally + in CI.
+  - 'tests/**'
+
+  # Auto-generated source from CHANGELOG.md by scripts/gen_whatsnew.py.
+  - 'src/generated/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Configure
         run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo


### PR DESCRIPTION
CodeQL was scanning every C++ file the build pulled in — including the
Opus 1.5.2 source ExternalProject extracts into build/ and every
vendored dep under third_party/.  31 of 55 high-severity alerts at the
time of this change came from those locations.  Their security posture
is upstream's responsibility, and the noise was masking signal in our
own code.

Adds .github/codeql/codeql-config.yml with paths-ignore covering:
- build/** (build-time-extracted upstream sources)
- third_party/** (vendored deps)
- tests/** (not shipped)
- src/generated/** (auto-generated from CHANGELOG.md)

Wires the config via the init step's config-file parameter.  No change
to the build step or query suite — same C++ analysis, just scoped.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
