### PR TITLE
ci: speed up macOS Intel build with pinned Qt + ccache

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,22 @@
+name: AetherSDR CodeQL configuration
+
+# Restrict analysis to AetherSDR's own first-party C++ sources.  Vendored
+# upstream deps and build-time-extracted source trees are out of scope —
+# their security posture is the responsibility of upstream, and scanning
+# them inflates alert noise that masks signal in our own code.
+
+paths-ignore:
+  # ExternalProject extracts upstream sources here at build time
+  # (Opus 1.5.2 from xiph.org, etc.).  Not committed, not ours.
+  - 'build/**'
+
+  # Vendored dependencies — opus-rade, mosquitto, ggmorse, libmspack,
+  # rnnoise, deepfilter, fftw3, libspecbleach, r8brain, radae, rtmidi.
+  # Treat as binary-equivalent black boxes for security analysis.
+  - 'third_party/**'
+
+  # Test harnesses — not shipped, run locally + in CI.
+  - 'tests/**'
+
+  # Auto-generated source from CHANGELOG.md by scripts/gen_whatsnew.py.
+  - 'src/generated/**'

--- a/.github/workflows/build-macos-qt.yml
+++ b/.github/workflows/build-macos-qt.yml
@@ -1,0 +1,72 @@
+name: Build macOS Qt (Intel deps)
+
+# One-time builder for the macOS Intel Qt6 deployment-target-13 toolchain.
+# macos-dmg.yml's Intel matrix entry needs Qt with QMAKE_MACOSX_DEPLOYMENT_TARGET
+# set to 13.0; Homebrew's Qt targets the host OS, so we build our own.  Without
+# this artifact, every Intel release rebuilds Qt from source (~27 min) — and
+# GitHub Actions cache eviction means even the cache-restore path is unreliable.
+#
+# Trigger this manually when bumping Qt version.  Uploads the built Qt tree
+# as a tarball to a fixed-tag GitHub release; macos-dmg.yml downloads it from
+# there.  GitHub's CDN doesn't evict release assets, so this fixes the
+# "missed cache → 27 min Qt rebuild" failure mode permanently.
+
+on:
+  workflow_dispatch:
+    inputs:
+      qt_version:
+        description: 'Qt version (e.g. 6.7.3)'
+        required: true
+        default: '6.7.3'
+      deploy_target:
+        description: 'macOS deployment target (e.g. 13.0)'
+        required: true
+        default: '13.0'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: macos-15-intel
+    steps:
+      - name: Install build deps
+        run: brew install ninja autoconf automake libtool
+
+      - name: Build Qt from source
+        run: |
+          set -e
+          QT_VERSION="${{ inputs.qt_version }}"
+          DEPLOY_TARGET="${{ inputs.deploy_target }}"
+
+          git clone --depth 1 --branch v${QT_VERSION} https://code.qt.io/qt/qt5.git qt-src
+          cd qt-src
+          perl init-repository --module-subset=qtbase,qtmultimedia,qtwebsockets,qtserialport,qtshadertools
+          cd ..
+
+          mkdir qt-build && cd qt-build
+          ../qt-src/configure -prefix $PWD/../qt-install \
+            -release -opensource -confirm-license \
+            -nomake examples -nomake tests \
+            QMAKE_MACOSX_DEPLOYMENT_TARGET=${DEPLOY_TARGET} \
+            -- -DCMAKE_OSX_DEPLOYMENT_TARGET=${DEPLOY_TARGET}
+          cmake --build . --parallel $(sysctl -n hw.ncpu)
+          cmake --install .
+
+      - name: Package Qt install tree
+        run: |
+          tar -czf qt-${{ inputs.qt_version }}-macos-intel-deploy${{ inputs.deploy_target }}.tar.gz qt-install
+          ls -lh qt-*.tar.gz
+
+      - name: Publish to deps release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="deps-qt-${{ inputs.qt_version }}-macos-intel"
+          # Replace any existing release for this Qt version (rebuilds the
+          # tarball with whatever updated build flags this workflow run has).
+          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+          gh release create "$TAG" \
+            --title "macOS Intel Qt ${{ inputs.qt_version }} (deploy ${{ inputs.deploy_target }})" \
+            --notes "Pre-built Qt ${{ inputs.qt_version }} for macOS Intel runners, deployment target ${{ inputs.deploy_target }}.  Consumed by macos-dmg.yml.  Rebuild via the Build macOS Qt (Intel deps) workflow when bumping Qt." \
+            qt-${{ inputs.qt_version }}-macos-intel-deploy${{ inputs.deploy_target }}.tar.gz

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Configure
         run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -38,16 +38,28 @@ jobs:
             brew install fftw portaudio hidapi
           fi
 
-      - name: Restore Qt cache (Intel only)
+      - name: Download pre-built Qt (Intel only)
         if: matrix.label == 'intel'
-        id: qt-cache
-        uses: actions/cache@v5
-        with:
-          path: qt-install
-          key: qt-6.7.3-macos-intel-deploy13
+        id: qt-download
+        run: |
+          # Pull the pinned Qt tarball produced by build-macos-qt.yml.
+          # GitHub's release CDN doesn't evict, so this hits reliably
+          # regardless of how long since the last release build.  If the
+          # tarball is missing (Qt version bumped without re-running the
+          # builder workflow), fall back to from-source.
+          URL="https://github.com/${{ github.repository }}/releases/download/deps-qt-6.7.3-macos-intel/qt-6.7.3-macos-intel-deploy13.0.tar.gz"
+          if curl -sL --fail -o qt-install.tar.gz "$URL"; then
+            tar -xzf qt-install.tar.gz
+            rm qt-install.tar.gz
+            echo "downloaded=true" >> "$GITHUB_OUTPUT"
+            echo "Pre-built Qt downloaded ($(du -sh qt-install | cut -f1))"
+          else
+            echo "downloaded=false" >> "$GITHUB_OUTPUT"
+            echo "Pre-built Qt not available at $URL — falling back to from-source build (~27 min).  Run the Build macOS Qt (Intel deps) workflow to populate this asset."
+          fi
 
-      - name: Build Qt from source (Intel only, cache miss)
-        if: matrix.label == 'intel' && steps.qt-cache.outputs.cache-hit != 'true'
+      - name: Build Qt from source (Intel only, fallback)
+        if: matrix.label == 'intel' && steps.qt-download.outputs.downloaded != 'true'
         run: |
           git clone --depth 1 --branch v6.7.3 https://code.qt.io/qt/qt5.git qt-src
           cd qt-src
@@ -80,6 +92,12 @@ jobs:
       - name: Setup DeepFilterNet3 (DFNR)
         run: bash setup-deepfilter.sh
 
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ccache-macos-${{ matrix.label }}
+          max-size: 500M
+
       - name: Configure
         run: |
           if [ "${{ matrix.label }}" = "intel" ]; then
@@ -97,6 +115,8 @@ jobs:
           fi
           cmake -B build -G "Unix Makefiles" \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_OSX_DEPLOYMENT_TARGET="$DEPLOY_TARGET" \
             -DCMAKE_PREFIX_PATH="$QT_PREFIX;$(brew --prefix)" \
             -DMQTT_TLS=OFF \


### PR DESCRIPTION
- ci: scope CodeQL to first-party sources
- ci: speed up macOS Intel build with pinned Qt + ccache
