### PR TITLE
ci: bump Qt to 6.8.3 LTS across all release workflows

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -48,17 +48,17 @@ jobs:
             qt6-shader-baker qt6-shadertools-dev \
             libhidapi-dev portaudio19-dev libfftw3-dev
 
-      - name: Install Qt 6.7 via aqtinstall (x86_64)
+      - name: Install Qt 6.8 LTS via aqtinstall (x86_64)
         if: matrix.use_aqt == true
         run: |
           pip3 install aqtinstall
-          aqt install-qt linux desktop 6.7.3 linux_gcc_64 \
+          aqt install-qt linux desktop 6.8.3 linux_gcc_64 \
             -m qtmultimedia qtwebsockets qtserialport qtshadertools \
             --outputdir ${{ github.workspace }}/Qt
-          echo "Qt6_DIR=${{ github.workspace }}/Qt/6.7.3/gcc_64/lib/cmake/Qt6" >> $GITHUB_ENV
-          echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/Qt/6.7.3/gcc_64" >> $GITHUB_ENV
-          echo "PATH=${{ github.workspace }}/Qt/6.7.3/gcc_64/bin:$PATH" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${{ github.workspace }}/Qt/6.7.3/gcc_64/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "Qt6_DIR=${{ github.workspace }}/Qt/6.8.3/gcc_64/lib/cmake/Qt6" >> $GITHUB_ENV
+          echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/Qt/6.8.3/gcc_64" >> $GITHUB_ENV
+          echo "PATH=${{ github.workspace }}/Qt/6.8.3/gcc_64/bin:$PATH" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${{ github.workspace }}/Qt/6.8.3/gcc_64/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Setup DeepFilterNet3 (DFNR)
         run: bash setup-deepfilter.sh
@@ -67,7 +67,7 @@ jobs:
         run: |
           CMAKE_EXTRA=""
           if [ "${{ matrix.use_aqt }}" = "true" ]; then
-            CMAKE_EXTRA="-DCMAKE_PREFIX_PATH=${{ github.workspace }}/Qt/6.7.3/gcc_64"
+            CMAKE_EXTRA="-DCMAKE_PREFIX_PATH=${{ github.workspace }}/Qt/6.8.3/gcc_64"
           fi
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
@@ -97,7 +97,7 @@ jobs:
 
           # Bundle Qt6 multimedia backend plugin
           if [ "${{ matrix.use_aqt }}" = "true" ]; then
-            QT_PLUGIN_PATH=${{ github.workspace }}/Qt/6.7.3/gcc_64/plugins
+            QT_PLUGIN_PATH=${{ github.workspace }}/Qt/6.8.3/gcc_64/plugins
           else
             QT_PLUGIN_PATH=$(qmake6 -query QT_INSTALL_PLUGINS 2>/dev/null || echo "/usr/lib/$(uname -m)-linux-gnu/qt6/plugins")
           fi
@@ -125,7 +125,7 @@ jobs:
           EXTRA_QT_PLUGINS: multimedia
         run: |
           if [ "${{ matrix.use_aqt }}" = "true" ]; then
-            export QMAKE=${{ github.workspace }}/Qt/6.7.3/gcc_64/bin/qmake
+            export QMAKE=${{ github.workspace }}/Qt/6.8.3/gcc_64/bin/qmake
           else
             export QMAKE=$(which qmake6 2>/dev/null || which qmake)
           fi

--- a/.github/workflows/build-macos-qt.yml
+++ b/.github/workflows/build-macos-qt.yml
@@ -15,9 +15,9 @@ on:
   workflow_dispatch:
     inputs:
       qt_version:
-        description: 'Qt version (e.g. 6.7.3)'
+        description: 'Qt version (e.g. 6.8.3)'
         required: true
-        default: '6.7.3'
+        default: '6.8.3'
       deploy_target:
         description: 'macOS deployment target (e.g. 13.0)'
         required: true

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -47,7 +47,7 @@ jobs:
           # regardless of how long since the last release build.  If the
           # tarball is missing (Qt version bumped without re-running the
           # builder workflow), fall back to from-source.
-          URL="https://github.com/${{ github.repository }}/releases/download/deps-qt-6.7.3-macos-intel/qt-6.7.3-macos-intel-deploy13.0.tar.gz"
+          URL="https://github.com/${{ github.repository }}/releases/download/deps-qt-6.8.3-macos-intel/qt-6.8.3-macos-intel-deploy13.0.tar.gz"
           if curl -sL --fail -o qt-install.tar.gz "$URL"; then
             tar -xzf qt-install.tar.gz
             rm qt-install.tar.gz
@@ -61,7 +61,7 @@ jobs:
       - name: Build Qt from source (Intel only, fallback)
         if: matrix.label == 'intel' && steps.qt-download.outputs.downloaded != 'true'
         run: |
-          git clone --depth 1 --branch v6.7.3 https://code.qt.io/qt/qt5.git qt-src
+          git clone --depth 1 --branch v6.8.3 https://code.qt.io/qt/qt5.git qt-src
           cd qt-src
           perl init-repository --module-subset=qtbase,qtmultimedia,qtwebsockets,qtserialport,qtshadertools
           cd ..

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Qt6
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.7.*'
+          version: '6.8.*'
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2019_64'


### PR DESCRIPTION
CI was already running Qt 6.8.3 (per ci.yml comment "matches what
community Windows builders are running and exposes Qt 6.8.x MOC
volume"), but every release workflow shipped 6.7.3 — Linux AppImage,
Windows installer, macOS Intel from-source, plus the Apple Silicon
DMG drifted with whatever Homebrew qt@6 happens to be that day.
Result: CI tested one version, users got another, and Apple Silicon
could differ from Intel within the same release.

Aligns all release workflows to 6.8.3 LTS:

- appimage.yml: aqt install pin + 6 path references → 6.8.3
- windows-installer.yml: install-qt-action wildcard → 6.8.*
- macos-dmg.yml: pinned-Qt download URL + from-source branch → 6.8.3
- build-macos-qt.yml: workflow_dispatch defaults → 6.8.3

Apple Silicon still uses Homebrew qt@6 (no Homebrew minor-version pin
mechanism; brew always serves a current-ish Qt 6.x).  In practice
brew's qt@6 is 6.8.x or 6.9.x, so it stays close to what we ship on
the other platforms — the major drift was Intel + AppImage being a
year and a half behind.

After this lands: re-run the Build macOS Qt (Intel deps) workflow
once to populate the deps-qt-6.8.3-macos-intel release; subsequent
release-tag builds skip the 27-min from-source Qt step.

Risks (small but worth flagging):
- Wayland behavior tightened in 6.8 — exercise the spectrum widget
- AppImage size grows ~15-20 MB
- QRhi backend changes — exercise multi-pan + waterfall thoroughly
- macOS deployment target stays at 13.0 (Qt 6.8 still supports it)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
