### PR TITLE
AetherDSP: dialog chrome refit, VFO DSP buttons, DSP slider stack fix

### DIFF
--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -1,8 +1,17 @@
 #include "AetherDspDialog.h"
 #include "AetherDspWidget.h"
 
+#include <QEvent>
+#include <QHBoxLayout>
 #include <QLabel>
+#include <QMouseEvent>
+#include <QPushButton>
 #include <QVBoxLayout>
+#include <QWindow>
+
+namespace {
+constexpr int kResizeMargin = 12;
+}
 
 namespace AetherSDR {
 
@@ -10,19 +19,102 @@ AetherDspDialog::AetherDspDialog(AudioEngine* audio, QWidget* parent)
     : QDialog(parent)
 {
     setWindowTitle("AetherDSP Settings");
-    setMinimumSize(420, 380);
+    setWindowFlag(Qt::FramelessWindowHint, true);
+    setMouseTracking(true);
     setStyleSheet("QDialog { background: #0f0f1a; color: #c8d8e8; }");
 
+    // Outer layout: zero-margin so the title bar runs edge-to-edge.  The
+    // 6 px resize hit zone lives on the bare gap around the inner content
+    // widget (which carries its own padding).
     auto* root = new QVBoxLayout(this);
-    auto* title = new QLabel("AetherDSP Settings");
-    title->setAlignment(Qt::AlignCenter);
-    title->setStyleSheet(
-        "QLabel { font-size: 16px; font-weight: bold; color: #c8d8e8; }");
-    root->addWidget(title);
-    root->addSpacing(4);
+    root->setContentsMargins(0, 0, 0, 0);
+    root->setSpacing(0);
+
+    // ── Custom title bar ─────────────────────────────────────────────
+    // Same chrome family as NetworkDiagnosticsDialog / AetherialAudioStrip:
+    // 18 px tall, blue-gradient background, 10 px bold title, trio of
+    // window-control buttons at the right.
+    {
+        m_titleBar = new QWidget(this);
+        m_titleBar->setFixedHeight(18);
+        m_titleBar->setAttribute(Qt::WA_StyledBackground, true);
+        m_titleBar->setStyleSheet(
+            "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
+            "stop:0 #5a7494, stop:0.5 #384e68, stop:1 #1e2e3e); "
+            "border-bottom: 1px solid #0a1a28; }");
+        m_titleBar->installEventFilter(this);
+
+        auto* tbRow = new QHBoxLayout(m_titleBar);
+        tbRow->setContentsMargins(6, 0, 2, 0);
+        tbRow->setSpacing(4);
+
+        auto* grip = new QLabel(QString::fromUtf8("\xe2\x8b\xae\xe2\x8b\xae"),
+                                m_titleBar);
+        grip->setStyleSheet(
+            "QLabel { background: transparent; color: #a0b4c8;"
+            " font-size: 10px; }");
+        tbRow->addWidget(grip);
+
+        auto* tbTitle = new QLabel("AetherDSP Settings", m_titleBar);
+        tbTitle->setStyleSheet(
+            "QLabel { background: transparent; color: #e0ecf4;"
+            " font-size: 10px; font-weight: bold; }");
+        tbRow->addWidget(tbTitle);
+        tbRow->addStretch();
+
+        const QString btnStyle =
+            "QPushButton { background: transparent; border: none;"
+            " color: #c8d8e8; font-size: 11px; font-weight: bold;"
+            " padding: 0px 4px; }"
+            "QPushButton:hover { color: #ffffff; }";
+        const QString closeBtnStyle =
+            "QPushButton { background: transparent; border: none;"
+            " color: #c8d8e8; font-size: 11px; font-weight: bold;"
+            " padding: 0px 4px; }"
+            "QPushButton:hover { color: #ffffff; background: #cc2030; }";
+
+        auto* minBtn = new QPushButton(QString::fromUtf8("\xe2\x80\x94"), m_titleBar);
+        minBtn->setFixedSize(16, 16);
+        minBtn->setCursor(Qt::ArrowCursor);
+        minBtn->setStyleSheet(btnStyle);
+        minBtn->setToolTip("Minimize");
+        connect(minBtn, &QPushButton::clicked, this, &QWidget::showMinimized);
+        tbRow->addWidget(minBtn);
+
+        auto* maxBtn = new QPushButton(QString::fromUtf8("\xe2\x96\xa1"), m_titleBar);
+        maxBtn->setFixedSize(16, 16);
+        maxBtn->setCursor(Qt::ArrowCursor);
+        maxBtn->setStyleSheet(btnStyle);
+        maxBtn->setToolTip("Maximize");
+        connect(maxBtn, &QPushButton::clicked, this, [this]() {
+            if (isMaximized()) showNormal(); else showMaximized();
+        });
+        tbRow->addWidget(maxBtn);
+
+        auto* closeBtn = new QPushButton(QString::fromUtf8("\xc3\x97"), m_titleBar);
+        closeBtn->setFixedSize(16, 16);
+        closeBtn->setCursor(Qt::ArrowCursor);
+        closeBtn->setStyleSheet(closeBtnStyle);
+        closeBtn->setToolTip("Close");
+        connect(closeBtn, &QPushButton::clicked, this, &QDialog::accept);
+        tbRow->addWidget(closeBtn);
+
+        root->addWidget(m_titleBar);
+    }
+
+    // Content area — 6 px padding on every side keeps the resize hit zone
+    // reachable while the widget carries its own internal margins.
+    auto* content = new QWidget(this);
+    auto* body = new QVBoxLayout(content);
+    body->setContentsMargins(6, 6, 6, 6);
+    body->setSpacing(0);
 
     m_widget = new AetherDspWidget(audio, this);
-    root->addWidget(m_widget);
+    // Scale all internal fonts up to 13 px to match the VFO DSP toggle
+    // row.  Applet path leaves this off and renders at the original sizes.
+    m_widget->setDialogMode(true);
+    body->addWidget(m_widget);
+    root->addWidget(content, 1);
 
     // Forward every parameter-change signal so existing connections to
     // AetherDspDialog::* keep working unchanged.
@@ -70,6 +162,91 @@ void AetherDspDialog::syncFromEngine()
 void AetherDspDialog::selectTab(const QString& name)
 {
     if (m_widget) m_widget->selectTab(name);
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Frameless 8-axis resize + drag-to-move
+// ──────────────────────────────────────────────────────────────────
+
+Qt::Edges AetherDspDialog::edgesAt(const QPoint& pos) const
+{
+    if (isMaximized() || isFullScreen()) return {};
+    Qt::Edges edges;
+    if (pos.x() <= kResizeMargin)              edges |= Qt::LeftEdge;
+    else if (pos.x() >= width() - kResizeMargin) edges |= Qt::RightEdge;
+    if (pos.y() <= kResizeMargin)              edges |= Qt::TopEdge;
+    else if (pos.y() >= height() - kResizeMargin) edges |= Qt::BottomEdge;
+    return edges;
+}
+
+void AetherDspDialog::updateResizeCursor(const QPoint& pos)
+{
+    const Qt::Edges edges = edgesAt(pos);
+    Qt::CursorShape shape = Qt::ArrowCursor;
+    if ((edges & (Qt::LeftEdge | Qt::TopEdge))     == (Qt::LeftEdge | Qt::TopEdge)
+        || (edges & (Qt::RightEdge | Qt::BottomEdge)) == (Qt::RightEdge | Qt::BottomEdge)) {
+        shape = Qt::SizeFDiagCursor;
+    } else if ((edges & (Qt::RightEdge | Qt::TopEdge))    == (Qt::RightEdge | Qt::TopEdge)
+        ||     (edges & (Qt::LeftEdge | Qt::BottomEdge)) == (Qt::LeftEdge | Qt::BottomEdge)) {
+        shape = Qt::SizeBDiagCursor;
+    } else if (edges & (Qt::LeftEdge | Qt::RightEdge)) {
+        shape = Qt::SizeHorCursor;
+    } else if (edges & (Qt::TopEdge | Qt::BottomEdge)) {
+        shape = Qt::SizeVerCursor;
+    }
+    setCursor(shape);
+}
+
+void AetherDspDialog::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (!(ev->buttons() & Qt::LeftButton))
+        updateResizeCursor(ev->pos());
+    QDialog::mouseMoveEvent(ev);
+}
+
+void AetherDspDialog::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() == Qt::LeftButton) {
+        const Qt::Edges edges = edgesAt(ev->pos());
+        if (edges) {
+            if (auto* h = windowHandle()) {
+                h->startSystemResize(edges);
+                ev->accept();
+                return;
+            }
+        }
+    }
+    QDialog::mousePressEvent(ev);
+}
+
+void AetherDspDialog::leaveEvent(QEvent* ev)
+{
+    setCursor(Qt::ArrowCursor);
+    QDialog::leaveEvent(ev);
+}
+
+bool AetherDspDialog::eventFilter(QObject* obj, QEvent* ev)
+{
+    // Drag-to-move via the custom title bar.  The trio buttons are their
+    // own QPushButtons that consume the press themselves, so this only
+    // fires on the bare title-bar background.
+    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonPress) {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (me->button() == Qt::LeftButton) {
+            if (auto* h = windowHandle()) {
+                h->startSystemMove();
+                me->accept();
+                return true;
+            }
+        }
+    }
+    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonDblClick) {
+        if (isMaximized()) showNormal();
+        else               showMaximized();
+        ev->accept();
+        return true;
+    }
+    return QDialog::eventFilter(obj, ev);
 }
 
 } // namespace AetherSDR

--- a/src/gui/AetherDspDialog.h
+++ b/src/gui/AetherDspDialog.h
@@ -2,6 +2,9 @@
 
 #include <QDialog>
 
+class QEvent;
+class QMouseEvent;
+
 namespace AetherSDR {
 
 class AudioEngine;
@@ -51,8 +54,20 @@ signals:
     void nr4MaskingDepthChanged(float value);
     void nr4SuppressionChanged(float value);
 
+protected:
+    // Frameless 8-axis resize + drag-to-move (same pattern as
+    // NetworkDiagnosticsDialog and the AetherialAudioStrip).
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void leaveEvent(QEvent* ev) override;
+    bool eventFilter(QObject* obj, QEvent* ev) override;
+
 private:
+    Qt::Edges edgesAt(const QPoint& pos) const;
+    void updateResizeCursor(const QPoint& pos);
+
     AetherDspWidget* m_widget{nullptr};
+    QWidget*         m_titleBar{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/AetherDspWidget.cpp
+++ b/src/gui/AetherDspWidget.cpp
@@ -3,6 +3,9 @@
 #include "core/AppSettings.h"
 #include "GuardedSlider.h"
 
+#include <QRegularExpression>
+#include <QSet>
+
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QGridLayout>
@@ -337,6 +340,60 @@ void AetherDspWidget::setCompactMode(bool on)
     }
     if (m_dfnrAttenLabel) m_dfnrAttenLabel->setFixedWidth(valWidth);
     if (m_dfnrBetaLabel)  m_dfnrBetaLabel->setFixedWidth(valWidth);
+}
+
+void AetherDspWidget::setDialogMode(bool on)
+{
+    if (!on) return;  // applet path is the default; one-way switch for the dialog
+
+    // Dialog-tuned toggle style — same colour palette as kToggleStyle but
+    // 13 px font + 2px 4px padding to match the VFO DSP toggle row exactly.
+    static const QString kDialogToggleStyle = QStringLiteral(
+        "QPushButton { background: #1a2a3a; border: 1px solid #205070;"
+        "  border-radius: 3px; color: #c8d8e8; font-size: 13px;"
+        "  font-weight: bold; padding: 2px 4px; margin: 0px; }"
+        "QPushButton:hover { background: #204060; }"
+        "QPushButton:checked { background: #0070c0; color: #ffffff;"
+        "  border: 1px solid #0090e0; }"
+        "QPushButton:disabled { background: #0e1822; color: #4a5868;"
+        "  border: 1px solid #1a2838; }");
+
+    // Bump every existing inline `font-size: Npx` declaration in the
+    // widget-level + label/radio/check stylesheets up to 13 px to match
+    // the toggle font.  Buttons get the explicit kDialogToggleStyle below.
+    static const QRegularExpression kFontSizeRe(
+        QStringLiteral("font-size:\\s*\\d+px"));
+    const QString kFontReplacement = QStringLiteral("font-size: 13px");
+
+    auto bumpFonts = [&](QWidget* w) {
+        QString s = w->styleSheet();
+        if (s.isEmpty()) return;
+        s.replace(kFontSizeRe, kFontReplacement);
+        w->setStyleSheet(s);
+    };
+
+    // Set of top-row DSP-selector buttons (NR2/NR4/MNR/DFNR/RN2/BNR)
+    // — they get a slightly tighter 60×24 footprint to fit six in a row
+    // without forcing the dialog to grow wider.  All other toggle buttons
+    // (Gain Method, NPE Method) take the standard 70×26.
+    QSet<QPushButton*> topRow;
+    for (auto* b : m_dspBtns) if (b) topRow.insert(b);
+
+    bumpFonts(this);
+    for (auto* btn : findChildren<QPushButton*>()) {
+        // The toggle buttons (NR2/NR4/MNR/DFNR/RN2/BNR + Gain Method +
+        // NPE Method) are all setCheckable(true).  ResetIconButton is the
+        // only non-checkable QPushButton in the widget — easy to exclude.
+        if (!btn->isCheckable()) continue;
+        btn->setStyleSheet(kDialogToggleStyle);
+        const QSize sz = topRow.contains(btn) ? QSize(60, 24) : QSize(70, 26);
+        btn->setMinimumSize(sz);
+        btn->setMaximumSize(sz);
+        btn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    }
+    for (auto* lbl : findChildren<QLabel*>())       bumpFonts(lbl);
+    for (auto* rb  : findChildren<QRadioButton*>()) bumpFonts(rb);
+    for (auto* cb  : findChildren<QCheckBox*>())    bumpFonts(cb);
 }
 
 void AetherDspWidget::setNr2Available(bool available, const QString& tooltip)

--- a/src/gui/AetherDspWidget.h
+++ b/src/gui/AetherDspWidget.h
@@ -45,6 +45,11 @@ public:
     // The Settings-menu dialog leaves this off and renders at full size.
     void setCompactMode(bool on);
 
+    // Scale every child QPushButton / QLabel font to 13 px to match the
+    // VFO DSP toggle row.  The applet path leaves this off; only the
+    // Settings-menu AetherDspDialog calls it.
+    void setDialogMode(bool on);
+
     // Disable the NR2 selector button when compressed (Opus / SmartLink)
     // audio is active — NR2 amplifies codec artifacts (#1597).
     void setNr2Available(bool available, const QString& tooltip);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9823,6 +9823,27 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     });
 #endif
 
+    // AetherDSP button on the per-slice DSP tab — same entry point as the
+    // Settings menu action and the RX chain double-click; reuses the
+    // existing modeless m_dspDialog when one is already open.
+    connect(w, &VfoWidget::aetherDspRequested, this, [this] {
+        if (m_dspDialog) {
+            m_dspDialog->raise();
+            m_dspDialog->activateWindow();
+            return;
+        }
+        auto* dlg = new AetherDspDialog(m_audio, this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        if (auto* dspWidget = dlg->widget()) wireAetherDspWidget(dspWidget);
+        m_dspDialog = dlg;
+        dlg->show();
+    });
+
+    // AetherVoice button on the per-slice DSP tab — toggles the Aetherial
+    // Audio Channel Strip, matching the existing menu / chain entry points.
+    connect(w, &VfoWidget::aetherVoiceRequested,
+            this, &MainWindow::toggleAetherialStrip);
+
     // Per-slice VFO marker style (#1526): push user's saved line thickness and
     // filter-edge visibility preferences to this slice's overlay whenever they
     // change. Also fires once on setSlice() below to apply loaded defaults.

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1003,6 +1003,29 @@ void VfoWidget::buildTabContent()
         m_anftBtn->setAccessibleName("FFT notch filter");
         m_apfBtn->hide();  // only visible in CW mode
 
+        // Client-side AetherDSP launcher — same kDspToggle styling and
+        // single-cell width as the radio-side toggles, but non-checkable.
+        // Placed by relayoutDspGrid() at the end of the radio-side toggle list.
+        m_aetherDspBtn = new QPushButton("ADSP");
+        m_aetherDspBtn->setCheckable(false);
+        m_aetherDspBtn->setMinimumHeight(22);
+        m_aetherDspBtn->setStyleSheet(kDspToggle);
+        m_aetherDspBtn->setAccessibleName("AetherDSP Settings");
+        m_aetherDspBtn->setToolTip("Open AetherDSP Settings (client-side NR2 / NR4 / DFNR / RN2 / BNR / MNR)");
+        connect(m_aetherDspBtn, &QPushButton::clicked, this,
+                &VfoWidget::aetherDspRequested);
+
+        // AetherVoice launcher — opens the Aetherial Audio Channel Strip.
+        // 2 columns wide (cols 2-3 of the same row that hosts ADSP).
+        m_aetherVoiceBtn = new QPushButton("AetherVoice");
+        m_aetherVoiceBtn->setCheckable(false);
+        m_aetherVoiceBtn->setMinimumHeight(22);
+        m_aetherVoiceBtn->setStyleSheet(kDspToggle);
+        m_aetherVoiceBtn->setAccessibleName("Aetherial Audio Channel Strip");
+        m_aetherVoiceBtn->setToolTip("Open Aetherial Audio Channel Strip — unified TX DSP suite");
+        connect(m_aetherVoiceBtn, &QPushButton::clicked, this,
+                &VfoWidget::aetherVoiceRequested);
+
         // Radio-side DSP buttons only \u2014 client-side modules (NR2 / NR4 /
         // MNR / BNR / DFNR / RN2) live in the spectrum overlay menu and
         // the AetherDSP applet; users toggle them there to keep the VFO
@@ -2585,16 +2608,31 @@ void VfoWidget::setSlice(SliceModel* slice)
             m_updatingFromModel = false;
         });
     };
-    connectDsp(&SliceModel::nbChanged,  m_nbBtn);
-    connectDsp(&SliceModel::nrChanged,  m_nrBtn);
-    connectDsp(&SliceModel::anfChanged, m_anfBtn);
-    connectDsp(&SliceModel::nrlChanged, m_nrlBtn);
-    connectDsp(&SliceModel::nrsChanged, m_nrsBtn);
-    connectDsp(&SliceModel::rnnChanged, m_rnnBtn);
-    connectDsp(&SliceModel::nrfChanged, m_nrfBtn);
-    connectDsp(&SliceModel::anflChanged, m_anflBtn);
-    connectDsp(&SliceModel::anftChanged, m_anftBtn);
-    connectDsp(&SliceModel::apfChanged, m_apfBtn);
+    // Leveled variant — also push/pop the shared DSP-level slider stack
+    // when state changes arrive from the radio.  Without this the slider
+    // is missing on launch for any DSP enabled in the radio's saved
+    // profile until the user manually toggles it (#startup-slider).
+    auto connectLeveledDsp = [this](auto signal, QPushButton* btn,
+                                    DspLevelTarget tag) {
+        connect(m_slice, signal, this, [this, btn, tag](bool on) {
+            m_updatingFromModel = true;
+            QSignalBlocker sb(btn);
+            btn->setChecked(on);
+            m_updatingFromModel = false;
+            if (on) pushDspLevelTarget(tag);
+            else    popDspLevelTarget(tag);
+        });
+    };
+    connectLeveledDsp(&SliceModel::nbChanged,   m_nbBtn,   LvlNB);
+    connectLeveledDsp(&SliceModel::nrChanged,   m_nrBtn,   LvlNR);
+    connectLeveledDsp(&SliceModel::anfChanged,  m_anfBtn,  LvlAnf);
+    connectLeveledDsp(&SliceModel::nrlChanged,  m_nrlBtn,  LvlNrl);
+    connectLeveledDsp(&SliceModel::nrsChanged,  m_nrsBtn,  LvlNrs);
+    connectDsp(&SliceModel::rnnChanged, m_rnnBtn);     // toggle-only, no level
+    connectLeveledDsp(&SliceModel::nrfChanged,  m_nrfBtn,  LvlNrf);
+    connectLeveledDsp(&SliceModel::anflChanged, m_anflBtn, LvlAnfl);
+    connectDsp(&SliceModel::anftChanged, m_anftBtn);   // toggle-only, no level
+    connectDsp(&SliceModel::apfChanged, m_apfBtn);     // own level row
     connect(m_slice, &SliceModel::apfLevelChanged, this, [this](int v) {
         m_updatingFromModel = true;
         m_apfSlider->setValue(v);
@@ -3036,6 +3074,10 @@ void VfoWidget::relayoutDspGrid()
                           m_nrsBtn, m_rnnBtn, m_nrfBtn, m_anflBtn, m_anftBtn};
     for (auto* btn : all)
         m_dspGrid->removeWidget(btn);
+    if (m_aetherDspBtn)
+        m_dspGrid->removeWidget(m_aetherDspBtn);
+    if (m_aetherVoiceBtn)
+        m_dspGrid->removeWidget(m_aetherVoiceBtn);
 
     // Re-add only non-hidden buttons in 4-column rows
     int col = 0, row = 0;
@@ -3044,6 +3086,15 @@ void VfoWidget::relayoutDspGrid()
             m_dspGrid->addWidget(btn, row, col);
             if (++col >= 4) { col = 0; ++row; }
         }
+    }
+    // Client-side launchers: ADSP (1 col) + AetherVoice (2 cols spanning
+    // the rightmost 2 columns) live on the same row.  If ADSP would land
+    // beyond col 1, wrap the pair to a fresh row first so AetherVoice
+    // always occupies cols 2-3.
+    if (m_aetherDspBtn && m_aetherVoiceBtn) {
+        if (col > 1) { col = 0; ++row; }
+        m_dspGrid->addWidget(m_aetherDspBtn, row, col);
+        m_dspGrid->addWidget(m_aetherVoiceBtn, row, 2, 1, 2);
     }
 }
 

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -88,6 +88,8 @@ Q_SIGNALS:
 #endif
     void recordToggled(bool on);
     void playToggled(bool on);
+    void aetherDspRequested();     // user clicked the ADSP button on the DSP tab
+    void aetherVoiceRequested();   // user clicked the AetherVoice button on the DSP tab
     void splitToggled();
     void swapRequested();
     void autotuneRequested(bool intermittent);  // CW auto-tune: false=stop, true=loop
@@ -238,6 +240,8 @@ private:
     QPushButton* m_anflBtn{nullptr};
     QPushButton* m_anftBtn{nullptr};
     QPushButton* m_apfBtn{nullptr};
+    QPushButton* m_aetherDspBtn{nullptr};    // launches AetherDSP Settings dialog
+    QPushButton* m_aetherVoiceBtn{nullptr};  // toggles Aetherial Audio Channel Strip
 
     // Shared DSP-level row at the bottom of the DSP grid: one slider whose
     // target switches based on which leveled DSP the user most recently


### PR DESCRIPTION
Three threads of work bundled together — they all touch the per-slice
DSP path on the VFO, the launchers in the DSP grid, and the floating
AetherDSP Settings dialog.

VFO DSP grid additions
- New ADSP button (1 col) and AetherVoice button (2 cols) at the end of
  the per-slice DSP grid.  ADSP click opens the existing AetherDSP
  Settings dialog (same entry point as Settings menu and the RX chain
  double-click); AetherVoice click toggles the Aetherial Audio Channel
  Strip.  relayoutDspGrid() places the pair on the same row, wrapping
  as a unit when there's no room for ADSP at col 0/1 so AetherVoice
  always lands at cols 2-3.
- Wired through new VfoWidget signals aetherDspRequested() and
  aetherVoiceRequested(), connected in MainWindow::wireVfoWidget.

DSP-level slider stack: fix missing slider on launch
- The leveled DSP toggles (NR / NB / ANF / NRL / NRS / NRF / ANFL) push
  onto a target stack so the shared 4th-row slider re-targets the most
  recently activated DSP.  User clicks already pushed correctly, but
  state changes arriving from radio status (profile load, reconnect)
  went through a QSignalBlocker'd path that suppressed the toggled()
  signal — so the stack stayed empty on launch and the slider was
  hidden until the user manually toggled the DSP off and back on.
  Adds a connectLeveledDsp helper that mirrors the user-click stack
  push/pop on every state change from the slice model.  RNN / ANFT /
  APF stay on connectDsp (toggle-only or own dedicated row).

AetherDSP Settings dialog refit
- Frameless window with the standard 18 px gradient title bar (matches
  NetworkDiagnosticsDialog and AetherialAudioStrip): grip glyph, bold
  title, min/max/close trio, drag-to-move via startSystemMove,
  double-click to maximize.
- 8-axis resize via startSystemResize on a 12 px hit zone with
  SizeFDiag/BDiag/Hor/Ver cursor feedback.
- Minimum-size restriction removed; dialog can shrink as far as Qt's
  content reflow allows.
- New AetherDspWidget::setDialogMode(true) — applet path leaves it off,
  dialog calls it after construction.  Bumps every inline font-size to
  13 px to match the VFO DSP toggle row, applies a parallel
  kDialogToggleStyle to all checkable buttons, and pins their
  geometry: 60×24 for the top-row DSP selector (NR2/NR4/MNR/DFNR/RN2/
  BNR — six fit without forcing the dialog wider) and 70×26 for the
  Gain Method and NPE Method rows.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
