### PR TITLE
Guard audio callbacks during shutdown

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1966,7 +1966,9 @@ MainWindow::MainWindow(QWidget* parent)
             this, [this](bool tx) {
         // Keep TX audio source strictly aligned with the local MOX edge for all
         // modes (SSB + DAX). Waiting for interlock introduces audible lag.
-        m_audio->setTransmitting(tx);
+        if (m_audio) {
+            m_audio->setTransmitting(tx);
+        }
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
         if (m_daxBridge)
             m_daxBridge->setTransmitting(tx);
@@ -1974,7 +1976,9 @@ MainWindow::MainWindow(QWidget* parent)
 
 #ifdef HAVE_RADE
         if (m_radeSliceId >= 0 && m_radeEngine && m_radeEngine->isActive()) {
-            m_audio->setRadeMode(tx);
+            if (m_audio) {
+                m_audio->setRadeMode(tx);
+            }
             if (!tx) {
                 m_radeEngine->resetTx();
             }
@@ -1991,7 +1995,9 @@ MainWindow::MainWindow(QWidget* parent)
     connect(&m_radioModel, &RadioModel::txAudioGateChanged,
             this, [this](bool tx) {
         if (!tx) {
-            m_audio->setTransmitting(false);
+            if (m_audio) {
+                m_audio->setTransmitting(false);
+            }
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
             if (m_daxBridge)
                 m_daxBridge->setTransmitting(false);
@@ -2005,7 +2011,9 @@ MainWindow::MainWindow(QWidget* parent)
     // Multi-Flex TX from other clients.
     connect(&m_radioModel, &RadioModel::radioTransmittingChanged,
             this, [this](bool tx) {
-        m_audio->setRadioTransmitting(tx);
+        if (m_audio) {
+            m_audio->setRadioTransmitting(tx);
+        }
         // Waterfall freeze/unfreeze: gate on the actual interlock TRANSMITTING
         // state, not the MOX edge. moxChanged fires the instant the user releases
         // PTT, but the radio keeps streaming TX-contaminated tiles/FFT for the


### PR DESCRIPTION
## Summary
- Prevent shutdown-time TX state callbacks from dereferencing `m_audio` after the audio worker has already been torn down.
- Keep the existing waterfall/status updates running while skipping only audio-specific work when `m_audio` is null.

## Crash
The reported macOS crash happened while exiting the app. During `MainWindow` teardown the audio worker is stopped and `m_audio` is set to `nullptr`. Later in member destruction, `WanConnection::~WanConnection()` disconnects the TLS socket, which emits `disconnected`, drives `RadioModel::onDisconnected()`, and emits `radioTransmittingChanged(false)` / related TX reset signals. The connected `MainWindow` lambdas still ran and called methods such as `m_audio->setRadioTransmitting(tx)`, so the app entered `AudioEngine::setRadioTransmitting()` with an invalid/null `this` pointer and crashed on the atomic exchange shown in the report.

## Fix
Add null guards around the audio calls in the TX-state callbacks (`moxChanged`, `txAudioGateChanged`, and `radioTransmittingChanged`). This preserves the existing shutdown order, object ownership, signal routing, and non-audio UI updates, while avoiding calls into the audio worker after it has been destroyed.

## Verification
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build`
- `git diff --check`
