### PR TITLE
fix(spot): defer socket construction to SpotClients thread (Windows crash)

### DIFF
--- a/src/core/DxClusterClient.cpp
+++ b/src/core/DxClusterClient.cpp
@@ -11,9 +11,17 @@ namespace AetherSDR {
 
 DxClusterClient::DxClusterClient(QObject* parent)
     : QObject(parent)
-    , m_socket(new QTcpSocket(this))
-    , m_reconnectTimer(new QTimer(this))
 {
+    // Socket and timer are created in initialize() on the SpotClients thread (#1929).
+}
+
+void DxClusterClient::initialize()
+{
+    if (m_socket) return;  // already initialized
+
+    m_socket = new QTcpSocket(this);
+    m_reconnectTimer = new QTimer(this);
+
     connect(m_socket, &QTcpSocket::connected,    this, &DxClusterClient::onConnected);
     connect(m_socket, &QTcpSocket::disconnected, this, &DxClusterClient::onDisconnected);
     connect(m_socket, &QTcpSocket::readyRead,    this, &DxClusterClient::onReadyRead);
@@ -27,9 +35,9 @@ DxClusterClient::DxClusterClient(QObject* parent)
 DxClusterClient::~DxClusterClient()
 {
     m_intentionalDisconnect = true;
-    m_reconnectTimer->stop();
+    if (m_reconnectTimer) m_reconnectTimer->stop();
     m_logFile.close();
-    if (m_socket->state() != QAbstractSocket::UnconnectedState)
+    if (m_socket && m_socket->state() != QAbstractSocket::UnconnectedState)
         m_socket->abort();
 }
 

--- a/src/core/DxClusterClient.h
+++ b/src/core/DxClusterClient.h
@@ -43,6 +43,15 @@ public:
     QString logFilePath() const;
     void setLogFileName(const QString& name) { m_logFileName = name; }
 
+public slots:
+    // Defer socket + timer construction to the worker thread (#1929). On Windows,
+    // QTcpSocket creates a QSocketNotifier whose Win32 message-loop affinity is
+    // bound to the *construction* thread, not the QObject's current thread. If
+    // we new the socket on the main thread and then moveToThread() to SpotClients,
+    // socket events delivered during a disconnect cascade trip QCoreApplication's
+    // cross-thread sendEvent assert. Construct on the SpotClients thread instead.
+    void initialize();
+
 signals:
     void connected();
     void disconnected();
@@ -67,9 +76,9 @@ private:
     // m_intentionalDisconnect is set or the timer is already active (#2380).
     void scheduleReconnect();
 
-    QTcpSocket* m_socket;
+    QTcpSocket* m_socket{nullptr};
     QByteArray  m_readBuffer;
-    QTimer*     m_reconnectTimer;
+    QTimer*     m_reconnectTimer{nullptr};
     QFile       m_logFile;
 
     QString m_logFileName{"dxcluster.log"};

--- a/src/core/FreeDvClient.cpp
+++ b/src/core/FreeDvClient.cpp
@@ -14,11 +14,19 @@ namespace AetherSDR {
 
 FreeDvClient::FreeDvClient(QObject* parent)
     : QObject(parent)
-    , m_ws(new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this))
-    , m_pingTimer(new QTimer(this))
-    , m_reconnectTimer(new QTimer(this))
-    , m_snrTimer(new QTimer(this))
 {
+    // WebSocket + timers are created in initialize() on the SpotClients thread (#1929).
+}
+
+void FreeDvClient::initialize()
+{
+    if (m_ws) return;
+
+    m_ws = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
+    m_pingTimer = new QTimer(this);
+    m_reconnectTimer = new QTimer(this);
+    m_snrTimer = new QTimer(this);
+
     m_pingTimer->setSingleShot(false);
     m_reconnectTimer->setSingleShot(true);
     m_snrTimer->setSingleShot(false);
@@ -81,10 +89,10 @@ void FreeDvClient::startConnection()
 void FreeDvClient::stopConnection()
 {
     m_intentionalDisconnect = true;
-    m_pingTimer->stop();
-    m_reconnectTimer->stop();
+    if (m_pingTimer) m_pingTimer->stop();
+    if (m_reconnectTimer) m_reconnectTimer->stop();
 
-    if (m_ws->state() != QAbstractSocket::UnconnectedState)
+    if (m_ws && m_ws->state() != QAbstractSocket::UnconnectedState)
         m_ws->close();
 
     m_connected.store(false);

--- a/src/core/FreeDvClient.h
+++ b/src/core/FreeDvClient.h
@@ -41,6 +41,10 @@ signals:
     void rawLineReceived(const QString& line);
 
 public slots:
+    // Defer QWebSocket + timer construction to the worker thread (#1929) —
+    // see DxClusterClient::initialize().
+    void initialize();
+
     // Station reporting — call from RADE activate/deactivate paths.
     // All methods are safe to call from any thread via queued connection.
     void enableReporting(const QString& callsign, const QString& grid,
@@ -86,10 +90,10 @@ private:
     void sendEvent(const QString& name, const QJsonObject& data);
     void sendInitialFreqChange();
 
-    QWebSocket*  m_ws;
-    QTimer*      m_pingTimer;
-    QTimer*      m_reconnectTimer;
-    QTimer*      m_snrTimer;
+    QWebSocket*  m_ws{nullptr};
+    QTimer*      m_pingTimer{nullptr};
+    QTimer*      m_reconnectTimer{nullptr};
+    QTimer*      m_snrTimer{nullptr};
     QFile        m_logFile;
 
     QHash<QString, StationInfo> m_stations;  // sid → station info

--- a/src/core/PotaClient.cpp
+++ b/src/core/PotaClient.cpp
@@ -15,9 +15,15 @@ namespace AetherSDR {
 
 PotaClient::PotaClient(QObject* parent)
     : QObject(parent)
-    , m_nam(new QNetworkAccessManager(this))
-    , m_pollTimer(new QTimer(this))
 {
+    // QNAM and poll timer are created in initialize() on the SpotClients thread (#1929).
+}
+
+void PotaClient::initialize()
+{
+    if (m_nam) return;
+    m_nam = new QNetworkAccessManager(this);
+    m_pollTimer = new QTimer(this);
     m_pollTimer->setSingleShot(false);
     connect(m_pollTimer, &QTimer::timeout, this, &PotaClient::onPollTimer);
 }

--- a/src/core/PotaClient.h
+++ b/src/core/PotaClient.h
@@ -25,6 +25,11 @@ public:
 
     QString logFilePath() const;
 
+public slots:
+    // Defer QNetworkAccessManager + timer construction to the worker thread (#1929) —
+    // see DxClusterClient::initialize().
+    void initialize();
+
 signals:
     void started();
     void stopped();
@@ -37,8 +42,8 @@ private slots:
     void onPollTimer();
 
 private:
-    QNetworkAccessManager* m_nam;
-    QTimer*     m_pollTimer;
+    QNetworkAccessManager* m_nam{nullptr};
+    QTimer*     m_pollTimer{nullptr};
     QFile       m_logFile;
     QSet<int>   m_seenSpotIds;   // track spotId to only emit new spots
     std::atomic<bool> m_polling{false};

--- a/src/core/SpotCollectorClient.cpp
+++ b/src/core/SpotCollectorClient.cpp
@@ -11,8 +11,14 @@ namespace AetherSDR {
 
 SpotCollectorClient::SpotCollectorClient(QObject* parent)
     : QObject(parent)
-    , m_socket(new QUdpSocket(this))
 {
+    // Socket is created in initialize() on the SpotClients thread (#1929).
+}
+
+void SpotCollectorClient::initialize()
+{
+    if (m_socket) return;
+    m_socket = new QUdpSocket(this);
     connect(m_socket, &QUdpSocket::readyRead, this, &SpotCollectorClient::onReadyRead);
 }
 

--- a/src/core/SpotCollectorClient.h
+++ b/src/core/SpotCollectorClient.h
@@ -24,6 +24,10 @@ public:
 
     QString logFilePath() const;
 
+public slots:
+    // Defer socket construction to the worker thread (#1929) — see DxClusterClient::initialize().
+    void initialize();
+
 signals:
     void listening();
     void stopped();
@@ -36,7 +40,7 @@ private slots:
 private:
     bool parseDxSpotLine(const QString& line, DxSpot& spot) const;
 
-    QUdpSocket* m_socket;
+    QUdpSocket* m_socket{nullptr};
     QFile       m_logFile;
     quint16     m_port{9999};
     std::atomic<bool> m_listening{false};

--- a/src/core/WsjtxClient.cpp
+++ b/src/core/WsjtxClient.cpp
@@ -13,8 +13,14 @@ namespace AetherSDR {
 
 WsjtxClient::WsjtxClient(QObject* parent)
     : QObject(parent)
-    , m_socket(new QUdpSocket(this))
 {
+    // Socket is created in initialize() on the SpotClients thread (#1929).
+}
+
+void WsjtxClient::initialize()
+{
+    if (m_socket) return;
+    m_socket = new QUdpSocket(this);
     connect(m_socket, &QUdpSocket::readyRead, this, &WsjtxClient::onReadyRead);
 }
 

--- a/src/core/WsjtxClient.h
+++ b/src/core/WsjtxClient.h
@@ -26,6 +26,10 @@ public:
 
     QString logFilePath() const;
 
+public slots:
+    // Defer socket construction to the worker thread (#1929) — see DxClusterClient::initialize().
+    void initialize();
+
 signals:
     void listening();
     void stopped();
@@ -48,7 +52,7 @@ private:
     void parseDecode(QDataStream& ds);
     QString extractCallsign(const QString& message) const;
 
-    QUdpSocket* m_socket;
+    QUdpSocket* m_socket{nullptr};
     QFile       m_logFile;
     QHostAddress m_bindAddr;
     bool        m_isMulticast{false};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1384,6 +1384,26 @@ MainWindow::MainWindow(QWidget* parent)
 #endif
     m_spotThread->start();
 
+    // Construct each client's sockets/timers on the SpotClients thread (#1929).
+    // On Windows, QTcpSocket / QUdpSocket / QWebSocket bind their internal
+    // QSocketNotifier to the construction thread's Win32 message loop, so
+    // creating them on the main thread before moveToThread() trips a
+    // cross-thread sendEvent assert when socket events fire on disconnect.
+    QMetaObject::invokeMethod(m_dxCluster, &DxClusterClient::initialize,
+                              Qt::QueuedConnection);
+    QMetaObject::invokeMethod(m_rbnClient, &DxClusterClient::initialize,
+                              Qt::QueuedConnection);
+    QMetaObject::invokeMethod(m_wsjtxClient, &WsjtxClient::initialize,
+                              Qt::QueuedConnection);
+    QMetaObject::invokeMethod(m_spotCollectorClient, &SpotCollectorClient::initialize,
+                              Qt::QueuedConnection);
+    QMetaObject::invokeMethod(m_potaClient, &PotaClient::initialize,
+                              Qt::QueuedConnection);
+#ifdef HAVE_WEBSOCKETS
+    QMetaObject::invokeMethod(m_freedvClient, &FreeDvClient::initialize,
+                              Qt::QueuedConnection);
+#endif
+
     // ── HF Propagation Forecast ────────────────────────────────────────────
     m_propForecast = new PropForecastClient(this);
     connect(m_propForecast, &PropForecastClient::forecastUpdated,


### PR DESCRIPTION
## Summary
- Fixes the cross-thread `QCoreApplication::sendEvent` assertion that crashes AetherSDR on Windows when the radio TCP connection drops while DX Cluster / RBN / WSJT-X / SpotCollector / POTA / FreeDV clients are running on the `SpotClients` worker thread.
- Each spot client previously constructed its `QTcpSocket` / `QUdpSocket` / `QWebSocket` (and associated timers / `QNetworkAccessManager`) in its constructor on the main thread, then `moveToThread()`'d to `SpotClients`. On Windows the internal `QSocketNotifier` keeps Win32 message-loop affinity to the *construction* thread, so socket events delivered during a disconnect cascade trip the cross-thread assert.
- New `initialize()` slot on each client constructs sockets/timers; `MainWindow` invokes it via `Qt::QueuedConnection` after `moveToThread()` so the internal notifiers bind to `SpotClients`.

Closes #1929
Closes #2418 (kn7k's v0.9.7 overnight crash matched the same code path — duplicate of #1929 per support-bundle analysis).

## Test plan
- [x] Builds clean (`cmake --build build -j`)
- [ ] Linux smoke: app launches, DX cluster auto-connect works, radio disconnect/reconnect doesn't regress
- [ ] Windows smoke (per repro in #1929): launch with DX cluster auto-connect, let radio drop TCP, verify no `ASSERT failure in QCoreApplication::sendEvent` and no crash dialog
- [ ] WSJT-X / SpotCollector / POTA / FreeDV start/stop cycles still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)