### PR TITLE
[codex] Stabilize MIDI jog-wheel VFO tuning

### DIFF
--- a/resources/help/configuring-aethersdr-controls.md
+++ b/resources/help/configuring-aethersdr-controls.md
@@ -400,6 +400,12 @@ Examples include:
 
 For endless rotary encoders, turn on the **Relative** checkbox for that binding. This is especially useful for the `VFO Tune Knob` target.
 
+When you use **Learn** on `VFO Tune Knob` with a MIDI CC control, AetherSDR enables relative mode automatically. Older bindings still work if they were saved before this behavior was added.
+
+For `VFO Tune Knob`, each relative encoder pulse maps to one selected radio step. Use the radio step-size control for coarse or fine tuning.
+
+For slider and knob targets, Learn ignores touch-only NoteOn messages and waits for movement data.
+
 For sliders, leave **Relative** off and use normal absolute mode.
 
 Use **Invert** if the control moves the opposite way from what feels natural.

--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -34,6 +34,21 @@ bool isCwMomentaryParamId(const QString& paramId)
         || paramId == QLatin1String("cw.dah");
 }
 
+bool isVfoTuneKnobParamId(const QString& paramId)
+{
+    return paramId == QLatin1String("rx.tuneKnob");
+}
+
+bool isUnitRelativeCcPulse(int value)
+{
+    return value == 1 || value == 127;
+}
+
+int relativeCcDelta(int value)
+{
+    return (value < 64) ? value : (value - 128);
+}
+
 } // namespace
 
 // ── MidiBinding helpers ─────────────────────────────────────────────────────
@@ -67,7 +82,9 @@ MidiControlManager::MidiControlManager(QObject* parent)
         openPortByName(m_portName);
     });
 
-    // Coalesce relative knob events every 20ms with acceleration
+    // Coalesce relative knob events every 20ms. Some generic relative controls
+    // use density-based acceleration below, but VFO tune pulses are passed
+    // through exactly so controller detents map to radio step increments.
     m_relativeTimer->setInterval(20);
     connect(m_relativeTimer, &QTimer::timeout, this, &MidiControlManager::flushRelativeAccum);
 }
@@ -296,6 +313,16 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2,
     // MIDI Learn mode — capture this message as a binding
     if (m_learning) {
         if (msgType == MidiBinding::NoteOff) return; // ignore NoteOff during learn
+        const MidiParam* learnParam = findParam(m_learnParamId);
+        if (learnParam
+            && learnParam->type == MidiParamType::Slider
+            && msgType != MidiBinding::CC
+            && msgType != MidiBinding::PitchBend) {
+            // Touch-sensitive sliders/knobs can emit a NoteOn before their
+            // movement CC.  Slider targets need continuous input, so wait for
+            // the actual movement message instead of binding the touch sensor.
+            return;
+        }
 
         MidiBinding binding;
         binding.channel = channel;
@@ -303,6 +330,8 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2,
         binding.number = (msgType == MidiBinding::PitchBend) ? -1 : data1;
         binding.paramId = m_learnParamId;
         binding.inverted = false;
+        binding.relative = isVfoTuneKnobParamId(binding.paramId)
+                           && msgType == MidiBinding::CC;
 
         addBinding(binding);
         m_learning = false;
@@ -339,22 +368,37 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2,
     const auto& binding = m_bindings[it.value()];
     const bool cwBinding = isCwMomentaryParamId(binding.paramId);
 
+    if (isVfoTuneKnobParamId(binding.paramId)
+        && msgType != MidiBinding::CC
+        && msgType != MidiBinding::PitchBend) {
+        return;
+    }
+
     // ── Relative knob mode: decode delta and accumulate ────────────────
     if (binding.relative && msgType == MidiBinding::CC) {
         // Relative CC encoding (two's complement style):
         // 1-63 = clockwise (1=slow, 63=fast)
         // 65-127 = counter-clockwise (127=-1, 126=-2)
-        int delta = (data2 < 64) ? data2 : (data2 - 128);
+        int delta = relativeCcDelta(data2);
         if (binding.inverted) delta = -delta;
 
-        auto& accum = m_relativeAccum[binding.paramId];
-        accum.steps += delta;
-        accum.eventCount++;
-        accum.lastEventMs = QDateTime::currentMSecsSinceEpoch();
+        accumulateRelativeStep(binding.paramId, delta);
 
-        if (!m_relativeTimer->isActive())
-            m_relativeTimer->start();
+        emit paramValueChanged(binding.paramId, delta > 0 ? 1.0f : 0.0f);
+        return;
+    }
 
+    // Existing VFO tune bindings learned before relative mode could treat
+    // common endless-encoder pulses (1 / 127) as absolute endpoints, turning a
+    // single detent into roughly +/-63 tuning steps.  Decode those unit pulses
+    // as relative even if the saved binding did not mark the control relative.
+    if (!binding.relative
+        && isVfoTuneKnobParamId(binding.paramId)
+        && msgType == MidiBinding::CC
+        && isUnitRelativeCcPulse(data2)) {
+        int delta = relativeCcDelta(data2);
+        if (binding.inverted) delta = -delta;
+        accumulateRelativeStep(binding.paramId, delta);
         emit paramValueChanged(binding.paramId, delta > 0 ? 1.0f : 0.0f);
         return;
     }
@@ -404,11 +448,23 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2,
     emit paramValueChanged(binding.paramId, value);
 }
 
-// ── Relative knob coalescing with acceleration ─────────────────────────────
-// Called every 20ms. Batches accumulated steps and applies acceleration:
-//   Slow  (≤2 events/window): ÷2 rate — halve steps for fine tuning
+// ── Relative knob coalescing ───────────────────────────────────────────────
+// Called every 20ms. VFO tuning is emitted as exact accumulated detents.
+// Other relative controls keep the legacy density-based acceleration:
+//   Slow  (≤2 events/window): ÷2 rate — halve steps for fine control
 //   Medium (3-6):              1:1 — normal rate
-//   Fast   (>6):               4× — multiply steps for rapid band scanning
+//   Fast   (>6):               4× — multiply steps for rapid changes
+
+void MidiControlManager::accumulateRelativeStep(const QString& paramId, int delta)
+{
+    auto& accum = m_relativeAccum[paramId];
+    accum.steps += delta;
+    accum.eventCount++;
+    accum.lastEventMs = QDateTime::currentMSecsSinceEpoch();
+
+    if (!m_relativeTimer->isActive())
+        m_relativeTimer->start();
+}
 
 void MidiControlManager::flushRelativeAccum()
 {
@@ -422,16 +478,18 @@ void MidiControlManager::flushRelativeAccum()
         if (a.steps != 0) {
             int steps = a.steps;
 
-            // Apply acceleration based on event density in this 20ms window
-            if (a.eventCount <= 2) {
-                // Slow: halve steps (skip if only 1 step and alternating)
-                if (steps == 1 || steps == -1) {
-                    static int slowDivider = 0;
-                    if (++slowDivider % 2 == 0) steps = 0;
+            if (!isVfoTuneKnobParamId(it.key())) {
+                // Apply acceleration based on event density in this 20ms window
+                if (a.eventCount <= 2) {
+                    // Slow: halve steps (skip if only 1 step and alternating)
+                    if (steps == 1 || steps == -1) {
+                        static int slowDivider = 0;
+                        if (++slowDivider % 2 == 0) steps = 0;
+                    }
+                } else if (a.eventCount > 6) {
+                    // Fast: 4× acceleration
+                    steps *= 4;
                 }
-            } else if (a.eventCount > 6) {
-                // Fast: 4× acceleration
-                steps *= 4;
             }
             // Medium (3-6 events): 1:1, no change
 

--- a/src/core/MidiControlManager.h
+++ b/src/core/MidiControlManager.h
@@ -137,6 +137,7 @@ private:
     };
     QHash<QString, RelativeAccum> m_relativeAccum; // paramId → accum
     QTimer* m_relativeTimer{nullptr};
+    void accumulateRelativeStep(const QString& paramId, int delta);
     void flushRelativeAccum();
 };
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3011,6 +3011,11 @@ MainWindow::MainWindow(QWidget* parent)
 #ifdef HAVE_MIDI
     m_midiControl = new MidiControlManager;
     m_midiControl->moveToThread(m_extCtrlThread);
+    m_midiTuneIdleTimer.setSingleShot(true);
+    m_midiTuneIdleTimer.setInterval(250);
+    connect(&m_midiTuneIdleTimer, &QTimer::timeout, this, [this] {
+        m_midiTuneTargetMhz = -1.0;
+    });
 
     // Register MIDI params — setters/getters stored on MainWindow for
     // main-thread dispatch. Param metadata still registered on the manager.
@@ -3046,19 +3051,36 @@ MainWindow::MainWindow(QWidget* parent)
         m_currentMidiTrace = {};
     });
 
-    // MIDI relativeAction signal: coalesced step-based tuning with acceleration
+    // MIDI relativeAction signal: coalesced step-based tuning. VFO tune knob
+    // steps are exact detents; controller-side jog speed is not multiplied here.
     connect(m_midiControl, &MidiControlManager::relativeAction,
             this, [this](const QString& paramId, int steps) {
         if (paramId == "rx.tuneKnob") {
             auto* s = activeSlice();
-            if (!s || s->isLocked()) return;
+            if (!s || s->isLocked()) {
+                m_midiTuneTargetMhz = -1.0;
+                m_midiTuneIdleTimer.stop();
+                return;
+            }
             int stepHz = s->stepHz();
             if (stepHz <= 0) return;  // radio hasn't sent step yet
-            // Snap to step grid: round current freq to nearest step, then offset
-            long long curHz = static_cast<long long>(std::round(s->frequency() * 1e6));
-            long long snapped = ((curHz + stepHz / 2) / stepHz) * stepHz;
-            double newMhz = (snapped + steps * stepHz) / 1e6;
-            applyTuneRequest(s, newMhz, TuneIntent::IncrementalTune, "midi-relative");
+            // Keep an in-flight target while the wheel is moving.  Radio
+            // RF_frequency echoes can lag behind command sends; using the echo
+            // as the next base makes rapid MIDI tuning jump backward/forward.
+            if (m_midiTuneTargetMhz < 0.0
+                || (!m_midiTuneIdleTimer.isActive()
+                    && std::abs(m_midiTuneTargetMhz - s->frequency()) > 0.001)) {
+                const long long curHz =
+                    static_cast<long long>(std::round(s->frequency() * 1e6));
+                const long long snapped =
+                    ((curHz + stepHz / 2) / stepHz) * stepHz;
+                m_midiTuneTargetMhz = snapped / 1e6;
+            }
+            m_midiTuneTargetMhz += steps * stepHz / 1e6;
+            if (spectrum()) spectrum()->setVfoFrequency(m_midiTuneTargetMhz);
+            m_midiTuneIdleTimer.start();
+            applyTuneRequest(s, m_midiTuneTargetMhz, TuneIntent::IncrementalTune,
+                             "midi-relative");
         }
     });
 
@@ -12587,8 +12609,8 @@ void MainWindow::registerMidiParams()
 
     // rx.tuneKnob: bind a relative MIDI knob for VFO tuning.
     // Set the binding to "relative" mode in MIDI Mapping dialog.
-    // Steps are coalesced every 20ms with acceleration:
-    //   Slow spin → ½ rate (fine tuning), Fast spin → 4× (band scanning)
+    // Steps are coalesced every 20ms, but each controller detent remains one
+    // radio step to avoid jumpy jog-wheel behavior.
     reg("rx.tuneKnob", "VFO Tune Knob", "RX", P::Slider, 0, 127,
         [this](float v) {
             // Absolute fallback (non-relative bindings): center=64

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -323,6 +323,8 @@ private:
 #endif
 #ifdef HAVE_MIDI
     MidiControlManager*  m_midiControl{nullptr};
+    QTimer               m_midiTuneIdleTimer;
+    double               m_midiTuneTargetMhz{-1.0};
     void registerMidiParams();
     struct MidiActionTrace {
         QString paramId;


### PR DESCRIPTION
## Summary

Fixes #2421.

This stabilizes MIDI `VFO Tune Knob` behavior for touch-sensitive DJ controllers such as the Hercules DJControl Starlight. The fix keeps the existing radio command path (`slice tune <id> <freq> autopan=0`) but corrects how MIDI learn and MIDI relative tuning compute the target before that command is issued.

## Root Cause

The Starlight jog wheel emits two different kinds of events:

- a touch `NoteOn` before wheel movement
- relative CC pulses for movement (`1` one direction, `127` the other)

AetherSDR could learn the touch sensor instead of the movement CC, which made press/release look like VFO commands. Separately, relative tuning based each new target on `SliceModel::frequency()`, which can be rewritten by delayed radio `RF_frequency` echoes while tune commands are still in flight.

That combination made the wheel feel jumpy: the app could bind to the wrong source, interpret relative pulses as absolute endpoints, or base the next step on stale radio state.

## What Changed

- Slider-style MIDI learn now ignores touch-only `NoteOn` events and waits for continuous movement data (`CC` or `PitchBend`).
- Learned `VFO Tune Knob` CC bindings default to relative mode.
- Existing non-relative VFO bindings that emit common `1`/`127` relative pulses are handled as relative pulses for backward compatibility.
- VFO Tune Knob detents are emitted exactly, without MIDI-side acceleration or halving.
- MainWindow keeps a short-lived MIDI tune target while the wheel is active, so repeated pulses build from local intent instead of delayed radio echo.
- The MIDI control help text now documents the learn behavior and VFO detent semantics.

## User Impact

Operators using touch-sensitive MIDI controllers should be able to map jog wheels to `VFO Tune Knob` without accidental large jumps. Existing bad touch-sensor bindings should be ignored at runtime, but users should still re-learn the VFO control by rotating the wheel so the saved binding points at the movement CC.

## Validation

- Captured live Starlight MIDI messages with a small RtMidi probe on macOS/CoreMIDI.
- Confirmed jog movement emits relative CC pulses and touch emits NoteOn events.
- Built the app:

```bash
cmake --build build --target AetherSDR -j4
```

- Ran the MIDI settings regression test:

```bash
ctest --test-dir build -R midi_settings_test --output-on-failure
```

## Follow-up

A separate enhancement could combine Starlight coarse/fine CC pairs for 14-bit slider resolution, but that is intentionally out of scope for this VFO jog-wheel fix.
