### PR TITLE
feat(s-history): S-History v2 — voice signal detection, QRM classification, CNN classifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,8 @@ set(CORE_SOURCES
     src/core/SpecbleachFilter.cpp
     src/core/CwDecoder.cpp
     src/core/VoiceSignalDetector.cpp
+    src/core/SpectrogramBuffer.cpp
+    src/core/SignalClassifier.cpp
     src/core/Resampler.cpp
     src/core/NvidiaBnrFilter.cpp
     src/core/DeepFilterFilter.cpp
@@ -892,6 +894,41 @@ else()
     message(STATUS "hidapi not found — USB HID encoder support disabled")
 endif()
 
+# ONNX Runtime — optional CNN signal classifier for S-History v2
+# Windows: run setup-onnxruntime.ps1 first to download prebuilt DLLs
+# Linux:   apt install libonnxruntime-dev  (or build from source)
+# macOS:   brew install onnxruntime
+if(WIN32)
+    set(ORT_ROOT "${CMAKE_SOURCE_DIR}/third_party/onnxruntime")
+    if(EXISTS "${ORT_ROOT}/include/onnxruntime_cxx_api.h")
+        set(ORT_FOUND TRUE)
+        set(ORT_INCLUDE_DIRS "${ORT_ROOT}/include")
+        set(ORT_LIBRARIES "${ORT_ROOT}/lib/onnxruntime.lib")
+        file(GLOB ORT_DLLS "${ORT_ROOT}/bin/*.dll")
+    else()
+        message(STATUS "ONNX Runtime not found — CNN signal classifier disabled. "
+                       "Run setup-onnxruntime.ps1 to enable.")
+    endif()
+else()
+    if(PkgConfig_FOUND)
+        pkg_check_modules(ORT libonnxruntime)
+    endif()
+    if(NOT ORT_FOUND)
+        find_library(ORT_LIB onnxruntime)
+        find_path(ORT_INC onnxruntime_cxx_api.h)
+        if(ORT_LIB AND ORT_INC)
+            set(ORT_FOUND TRUE)
+            set(ORT_LIBRARIES ${ORT_LIB})
+            set(ORT_INCLUDE_DIRS ${ORT_INC})
+        endif()
+    endif()
+endif()
+if(ORT_FOUND)
+    message(STATUS "ONNX Runtime found — CNN signal classifier enabled")
+else()
+    message(STATUS "ONNX Runtime not found — CNN signal classifier disabled")
+endif()
+
 if(PORTAUDIO_FOUND)
     target_sources(AetherSDR PRIVATE src/core/CwSidetonePortAudioSink.cpp)
     target_compile_definitions(AetherSDR PRIVATE HAVE_PORTAUDIO)
@@ -912,6 +949,20 @@ if(FFTW3_FOUND)
                 "${FFTW3_DLL}" "$<TARGET_FILE_DIR:AetherSDR>"
             COMMENT "Copying libfftw3-3.dll to build directory"
         )
+    endif()
+endif()
+
+if(ORT_FOUND)
+    target_compile_definitions(AetherSDR PRIVATE HAVE_ONNX)
+    target_include_directories(AetherSDR PRIVATE ${ORT_INCLUDE_DIRS})
+    target_link_libraries(AetherSDR PRIVATE ${ORT_LIBRARIES})
+    if(WIN32 AND ORT_DLLS)
+        foreach(_ort_dll IN LISTS ORT_DLLS)
+            add_custom_command(TARGET AetherSDR POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${_ort_dll}" "$<TARGET_FILE_DIR:AetherSDR>"
+                COMMENT "Copying ONNX Runtime DLL to build directory")
+        endforeach()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,7 @@ set(CORE_SOURCES
     src/core/RNNoiseFilter.cpp
     src/core/SpecbleachFilter.cpp
     src/core/CwDecoder.cpp
+    src/core/VoiceSignalDetector.cpp
     src/core/Resampler.cpp
     src/core/NvidiaBnrFilter.cpp
     src/core/DeepFilterFilter.cpp

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -117,7 +117,24 @@ Bundled at third_party/deepfilter/
   Source:  https://github.com/Rikorose/DeepFilterNet
 
 
-11. FFTW3 — Fast Fourier Transform Library
+11. ONNX Runtime — Neural Network Inference Engine (optional)
+--------------------------------------------------------------
+Pre-built binaries at third_party/onnxruntime/ (Windows only; optional feature).
+Loaded at runtime for the S-History CNN signal classifier (S_History_v2-AI).
+Only present when setup-onnxruntime.ps1 has been run.
+
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  License: MIT
+  Source:  https://github.com/microsoft/onnxruntime
+
+  Note: the tools/train_classifier.py training script requires PyTorch
+  (BSD-3-Clause, https://pytorch.org/) as a separate installation.
+  PyTorch is a build tool only — it is not linked into or distributed
+  with AetherSDR.  The trained .onnx model file produced by the script
+  is entirely the user's own work.
+
+
+12. FFTW3 — Fast Fourier Transform Library
 --------------------------------------------
 Pre-built binaries at third_party/fftw3/ (Windows only; Linux uses system pkg)
 

--- a/setup-onnxruntime.ps1
+++ b/setup-onnxruntime.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+    Download ONNX Runtime prebuilt binaries for Windows x64.
+
+.DESCRIPTION
+    Downloads the official ONNX Runtime 1.18.x prebuilt release from GitHub
+    and places headers / import library / DLL in third_party/onnxruntime/
+    ready for CMake (find_library / find_path).
+
+    Required only for the S_History_v2-AI CNN signal classifier.
+    AetherSDR compiles and runs without it — ONNX is an optional enhancement.
+
+.EXAMPLE
+    .\setup-onnxruntime.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+
+$OrtVersion = "1.18.1"
+$OrtUrl     = "https://github.com/microsoft/onnxruntime/releases/download/v${OrtVersion}/onnxruntime-win-x64-${OrtVersion}.zip"
+$OutDir     = "third_party\onnxruntime"
+$ZipFile    = "third_party\onnxruntime-win-x64-${OrtVersion}.zip"
+
+# ── Check if already set up ──────────────────────────────────────────────
+if (Test-Path "$OutDir\lib\onnxruntime.lib") {
+    Write-Host "ONNX Runtime already set up in $OutDir" -ForegroundColor Green
+    exit 0
+}
+
+# ── Create directories ───────────────────────────────────────────────────
+New-Item -ItemType Directory -Force -Path "third_party" | Out-Null
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+New-Item -ItemType Directory -Force -Path "$OutDir\include" | Out-Null
+New-Item -ItemType Directory -Force -Path "$OutDir\lib" | Out-Null
+New-Item -ItemType Directory -Force -Path "$OutDir\bin" | Out-Null
+
+# ── Download ─────────────────────────────────────────────────────────────
+if (-not (Test-Path $ZipFile)) {
+    Write-Host "Downloading ONNX Runtime ${OrtVersion} prebuilt package..." -ForegroundColor Cyan
+    Invoke-WebRequest -Uri $OrtUrl -OutFile $ZipFile
+}
+
+# ── Extract ──────────────────────────────────────────────────────────────
+Write-Host "Extracting..." -ForegroundColor Cyan
+$tempDir = "third_party\onnxruntime-temp"
+if (Test-Path $tempDir) { Remove-Item -Recurse -Force $tempDir }
+Expand-Archive -Path $ZipFile -DestinationPath $tempDir -Force
+
+$srcDir = Get-ChildItem "$tempDir\onnxruntime-win-x64-*" -Directory | Select-Object -First 1
+if (-not $srcDir) {
+    Write-Error "Could not find extracted onnxruntime directory in $tempDir"
+    exit 1
+}
+
+# ── Copy headers ─────────────────────────────────────────────────────────
+# ONNX Runtime packages keep headers directly in include/
+Copy-Item "$($srcDir.FullName)\include\*" "$OutDir\include\" -Recurse -Force
+
+# ── Copy lib / DLL ───────────────────────────────────────────────────────
+# The prebuilt package puts .lib and .dll together in lib/
+$libFile = Get-ChildItem "$($srcDir.FullName)\lib" -Filter "onnxruntime.lib" | Select-Object -First 1
+$dllFiles = Get-ChildItem "$($srcDir.FullName)\lib" -Filter "*.dll"
+
+if (-not $libFile) {
+    Write-Error "onnxruntime.lib not found in extracted package"
+    exit 1
+}
+
+Copy-Item $libFile.FullName "$OutDir\lib\onnxruntime.lib"
+foreach ($dll in $dllFiles) {
+    Copy-Item $dll.FullName "$OutDir\bin\$($dll.Name)"
+}
+
+# ── Cleanup ──────────────────────────────────────────────────────────────
+Remove-Item -Recurse -Force $tempDir
+Remove-Item -Force $ZipFile
+
+Write-Host "ONNX Runtime ${OrtVersion} ready in $OutDir" -ForegroundColor Green
+Write-Host "  Headers: $OutDir\include\"
+Write-Host "  Lib:     $OutDir\lib\onnxruntime.lib"
+Write-Host "  DLLs:    $OutDir\bin\"
+Write-Host ""
+Write-Host "Re-run CMake to pick up ONNX Runtime:" -ForegroundColor Yellow
+Write-Host "  cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo"

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -30,6 +30,7 @@ Q_LOGGING_CATEGORY(lcRbn,        "aether.rbn",         QtWarningMsg)
 Q_LOGGING_CATEGORY(lcDevices,    "aether.devices",     QtWarningMsg)
 Q_LOGGING_CATEGORY(lcPerf,       "aether.perf",        QtWarningMsg)
 Q_LOGGING_CATEGORY(lcCw,         "aether.cw",          QtWarningMsg)
+Q_LOGGING_CATEGORY(lcSHistory,  "aether.shistory",    QtWarningMsg)
 
 LogManager::LogManager()
 {
@@ -57,6 +58,7 @@ LogManager::LogManager()
         {"aether.perf",       "Performance",  "Render timing and CPU profiling data"},
         {"aether.propforecast", "Propagation",  "Solar and propagation forecast updates"},
         {"aether.cw",         "CW / netCW",    "CW keying, MIDI paddle, iambic, and netCW timing"},
+        {"aether.shistory",   "S History",     "Past-Signals voice detection: noise floor, region width, band-plan filter"},
     };
 
     // QLoggingCategory objects are defined above via Q_LOGGING_CATEGORY macros.

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -31,6 +31,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcRbn)
 Q_DECLARE_LOGGING_CATEGORY(lcDevices)
 Q_DECLARE_LOGGING_CATEGORY(lcPerf)
 Q_DECLARE_LOGGING_CATEGORY(lcCw)
+Q_DECLARE_LOGGING_CATEGORY(lcSHistory)
 
 // Central registry for toggling per-module diagnostic logging at runtime.
 // The Support dialog (Help → Support) uses this to let users enable/disable

--- a/src/core/SignalClassifier.cpp
+++ b/src/core/SignalClassifier.cpp
@@ -1,0 +1,88 @@
+#include "SignalClassifier.h"
+#include "LogManager.h"
+
+#include <QFile>
+
+namespace AetherSDR {
+
+SignalClassifier::SignalClassifier()
+#ifdef HAVE_ONNX
+    : m_env(ORT_LOGGING_LEVEL_WARNING, "AetherSDR")
+    , m_memInfo(Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault))
+#endif
+{
+#ifdef HAVE_ONNX
+    m_sessionOpts.SetIntraOpNumThreads(1);
+    m_sessionOpts.SetGraphOptimizationLevel(ORT_ENABLE_BASIC);
+#endif
+}
+
+SignalClassifier::~SignalClassifier() = default;
+
+bool SignalClassifier::loadModel(const QString& path)
+{
+#ifdef HAVE_ONNX
+    if (!QFile::exists(path)) {
+        qCWarning(lcSHistory, "SignalClassifier: model file not found: %s",
+                  qPrintable(path));
+        return false;
+    }
+    try {
+#ifdef Q_OS_WIN
+        const std::wstring wpath = path.toStdWString();
+        m_session = std::make_unique<Ort::Session>(m_env, wpath.c_str(), m_sessionOpts);
+#else
+        m_session = std::make_unique<Ort::Session>(m_env, path.toUtf8().constData(),
+                                                   m_sessionOpts);
+#endif
+        m_loaded = true;
+        qCInfo(lcSHistory, "SignalClassifier: model loaded from %s", qPrintable(path));
+        return true;
+    } catch (const Ort::Exception& ex) {
+        qCWarning(lcSHistory, "SignalClassifier: failed to load model: %s", ex.what());
+        return false;
+    }
+#else
+    Q_UNUSED(path)
+    return false;
+#endif
+}
+
+ClassifierResult SignalClassifier::classify(const QVector<float>& patch,
+                                             int timeFrames, int freqBins) const
+{
+    ClassifierResult res;
+#ifdef HAVE_ONNX
+    if (!m_loaded || !m_session) { return res; }
+    if (patch.size() != timeFrames * freqBins) { return res; }
+
+    try {
+        // Shape: [N=1, C=1, H=timeFrames, W=freqBins]
+        const std::array<int64_t, 4> shape{1, 1, timeFrames, freqBins};
+        Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
+            m_memInfo,
+            const_cast<float*>(patch.constData()),
+            static_cast<size_t>(patch.size()),
+            shape.data(), shape.size());
+
+        const char* inputNames[]  = {"input"};
+        const char* outputNames[] = {"output"};
+
+        auto outputs = m_session->Run(Ort::RunOptions{nullptr},
+                                      inputNames, &inputTensor, 1,
+                                      outputNames, 1);
+
+        const float* data = outputs[0].GetTensorData<float>();
+        res.voiceProb   = data[0];
+        res.carrierProb = data[1];
+        res.valid       = true;
+    } catch (const Ort::Exception& ex) {
+        qCWarning(lcSHistory, "SignalClassifier: inference error: %s", ex.what());
+    }
+#else
+    Q_UNUSED(patch); Q_UNUSED(timeFrames); Q_UNUSED(freqBins);
+#endif
+    return res;
+}
+
+} // namespace AetherSDR

--- a/src/core/SignalClassifier.h
+++ b/src/core/SignalClassifier.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <QVector>
+#include <QString>
+#include <memory>
+
+#ifdef HAVE_ONNX
+#include <onnxruntime_cxx_api.h>
+#endif
+
+namespace AetherSDR {
+
+// Result from the spectrogram CNN classifier.
+struct ClassifierResult {
+    float voiceProb{0.5f};    // probability [0,1] that the signal is voice/SSB
+    float carrierProb{0.5f};  // probability [0,1] that it is a narrow carrier/digital
+    bool  valid{false};       // false when ONNX is absent or model not loaded
+};
+
+// Thin wrapper around an ONNX Runtime inference session.
+// Compiled out entirely when HAVE_ONNX is not defined.
+// Input:  flat float array of shape [1, 1, timeFrames, freqBins] (NCHW)
+// Output: 2-class softmax [voiceProb, carrierProb]
+class SignalClassifier {
+public:
+    SignalClassifier();
+    ~SignalClassifier();
+
+    // Load model from disk.  Returns false (and logs) on error.
+    bool loadModel(const QString& path);
+    bool isLoaded() const { return m_loaded; }
+
+    // Run inference.  patch must have timeFrames × freqBins elements.
+    ClassifierResult classify(const QVector<float>& patch,
+                              int timeFrames, int freqBins) const;
+
+private:
+    bool m_loaded{false};
+#ifdef HAVE_ONNX
+    Ort::Env         m_env;
+    Ort::SessionOptions m_sessionOpts;
+    std::unique_ptr<Ort::Session> m_session;
+    Ort::MemoryInfo  m_memInfo;
+#endif
+};
+
+} // namespace AetherSDR

--- a/src/core/SpectrogramBuffer.cpp
+++ b/src/core/SpectrogramBuffer.cpp
@@ -1,0 +1,83 @@
+#include "SpectrogramBuffer.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+void SpectrogramBuffer::push(const QVector<float>& binsDbm,
+                              double centerMhz, double bandwidthMhz)
+{
+    if (binsDbm.isEmpty() || bandwidthMhz <= 0.0) { return; }
+    Frame& f    = m_frames[m_head];
+    f.bins        = binsDbm;
+    f.centerMhz   = centerMhz;
+    f.bandwidthMhz = bandwidthMhz;
+    m_head = (m_head + 1) % kMaxFrames;
+    if (m_count < kMaxFrames) { ++m_count; }
+}
+
+QVector<float> SpectrogramBuffer::extractPatch(double sigFreqMhz,
+                                                double freqWidthMhz) const
+{
+    if (m_count < kMaxFrames) { return {}; }
+
+    // Use 2× signal width as the extraction window so the patch captures
+    // enough spectral context for the CNN to detect boundary shape.
+    const double halfWin = std::max(freqWidthMhz, 0.003) * 1.0;  // ± 1× width
+
+    QVector<float> patch;
+    patch.resize(kMaxFrames * kPatchFreqBins, 0.0f);
+
+    // Iterate frames oldest → newest
+    for (int fi = 0; fi < kMaxFrames; ++fi) {
+        const int idx = (m_head + fi) % kMaxFrames;  // m_head is next-write, so oldest is m_head
+        const Frame& fr = m_frames[idx];
+        if (fr.bins.isEmpty() || fr.bandwidthMhz <= 0.0) { continue; }
+
+        const int   N        = fr.bins.size();
+        const double startMhz = fr.centerMhz - fr.bandwidthMhz / 2.0;
+        const double hzPerBin = fr.bandwidthMhz * 1.0e6 / N;
+
+        // Resample N input bins into kPatchFreqBins output bins
+        // covering [sigFreqMhz - halfWin, sigFreqMhz + halfWin].
+        const double winStartMhz = sigFreqMhz - halfWin;
+        const double winEndMhz   = sigFreqMhz + halfWin;
+
+        for (int pb = 0; pb < kPatchFreqBins; ++pb) {
+            const double fMhz = winStartMhz +
+                (pb + 0.5) / kPatchFreqBins * (winEndMhz - winStartMhz);
+            const double srcBinF = (fMhz - startMhz) / fr.bandwidthMhz * N - 0.5;
+            const int    b0      = static_cast<int>(std::floor(srcBinF));
+            const int    b1      = b0 + 1;
+            const float  t       = static_cast<float>(srcBinF - b0);
+            float val = 0.0f;
+            if (b0 >= 0 && b1 < N) {
+                val = fr.bins[b0] * (1.0f - t) + fr.bins[b1] * t;
+            } else if (b0 >= 0 && b0 < N) {
+                val = fr.bins[b0];
+            } else if (b1 >= 0 && b1 < N) {
+                val = fr.bins[b1];
+            }
+            patch[fi * kPatchFreqBins + pb] = val;
+        }
+    }
+
+    // Normalize to [0, 1] using the patch min/max
+    float minV = patch[0], maxV = patch[0];
+    for (float v : patch) {
+        minV = std::min(minV, v);
+        maxV = std::max(maxV, v);
+    }
+    const float range = maxV - minV;
+    if (range > 0.5f) {
+        for (float& v : patch) { v = (v - minV) / range; }
+    } else {
+        // Flat patch — no signal content; zero it so CNN returns ~0.5
+        patch.fill(0.0f);
+    }
+
+    return patch;
+}
+
+} // namespace AetherSDR

--- a/src/core/SpectrogramBuffer.h
+++ b/src/core/SpectrogramBuffer.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QVector>
+#include <array>
+
+namespace AetherSDR {
+
+// Circular ring buffer of the last N FFT frames for one panadapter.
+// Used by the CNN signal classifier to extract per-signal spectrogram patches.
+// All methods are called on the main thread (FFT callback) — no locking needed.
+class SpectrogramBuffer {
+public:
+    static constexpr int kMaxFrames    = 32;  // time axis of the patch
+    static constexpr int kPatchFreqBins = 64; // freq axis after resampling
+
+    // Append one FFT frame.  Older frames roll off automatically.
+    void push(const QVector<float>& binsDbm,
+              double centerMhz, double bandwidthMhz);
+
+    // Extract a normalized [0, 1] float patch of shape [kMaxFrames × kPatchFreqBins]
+    // centred on sigFreqMhz and spanning freqWidthMhz (padded to 2× signal width).
+    // Rows are ordered oldest → newest.
+    // Returns an empty vector when fewer than kMaxFrames frames have been pushed.
+    QVector<float> extractPatch(double sigFreqMhz, double freqWidthMhz) const;
+
+    int frameCount() const { return m_count; }
+
+private:
+    struct Frame {
+        QVector<float> bins;
+        double centerMhz{0};
+        double bandwidthMhz{0};
+    };
+
+    // Ring buffer: m_head is the index of the *next* slot to write.
+    std::array<Frame, kMaxFrames> m_frames{};
+    int m_head{0};
+    int m_count{0};
+};
+
+} // namespace AetherSDR

--- a/src/core/SpectrogramBuffer.h
+++ b/src/core/SpectrogramBuffer.h
@@ -7,7 +7,9 @@ namespace AetherSDR {
 
 // Circular ring buffer of the last N FFT frames for one panadapter.
 // Used by the CNN signal classifier to extract per-signal spectrogram patches.
-// All methods are called on the main thread (FFT callback) — no locking needed.
+// PanadapterStream::spectrumReady is emitted on the network thread and delivered
+// to MainWindow via Qt::AutoConnection (queued), so push() and extractPatch()
+// run on the GUI thread — no locking needed.
 class SpectrogramBuffer {
 public:
     static constexpr int kMaxFrames    = 32;  // time axis of the patch

--- a/src/core/VoiceSignalDetector.cpp
+++ b/src/core/VoiceSignalDetector.cpp
@@ -1,0 +1,283 @@
+#include "VoiceSignalDetector.h"
+#include "LogManager.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+    // Minimum width for a detected region to be considered a voice signal.
+    constexpr double kVoiceMinHz = 1800.0;
+
+    // Upper bound for voice signals.  Regions wider than this cannot be voice —
+    // they are wideband interference (OTH radar, broadcast splatter, etc.) and
+    // are emitted as a single QRM entry at the region centre rather than being
+    // split into multiple 2.7 kHz voice chunks.
+    constexpr double kVoiceMaxHz = 8000.0;
+
+    // Region boundary: bins at least this far above the EMA floor are included
+    // in the contiguous-region scan.  6 dB keeps the region edges accurate.
+    constexpr float kThresholdDb = 6.0f;
+
+    // Minimum peak above the EMA floor for a region to be REPORTED.
+    // A region can be found at 6 dB but only shown when its peak is ≥ 8 dB —
+    // this filters broad noise bumps that barely exceed the boundary threshold
+    // while retaining weak-but-genuine voice signals that have a clear peak.
+    constexpr float kMinPeakAboveFloorDb = 10.0f;
+
+    // Percentile used for noise floor.  10th is more robust on crowded bands.
+    constexpr int kNoisePctile = 10;
+
+    // Gap-fill window: max of this many Hz either side of each bin.
+    // Bridges the natural gaps in SSB speech without merging narrow digital signals
+    // (CW ~50 Hz, FT8 ~50 Hz) whose expanded footprint still falls under kVoiceMinHz.
+    constexpr double kFillHz = 400.0;
+}
+
+bool isVoiceSegmentLabel(const QString& label)
+{
+    return label.contains(QStringLiteral("PHONE"))  ||
+           label.contains(QStringLiteral("SSB"))    ||
+           label.contains(QStringLiteral("USB"))    ||
+           label.contains(QStringLiteral("AM"))     ||
+           label.contains(QStringLiteral("FM/RPT"));
+}
+
+QVector<DetectedVoiceSignal> detectVoiceSignals(
+    const QVector<float>& binsDbm,
+    double centerMhz,
+    double bandwidthMhz,
+    const QVector<QPair<double, double>>& voiceRangesMhz,
+    float rollingNoiseFloorDbm,
+    const QString& sliceMode)
+{
+    QVector<DetectedVoiceSignal> results;
+    const int N = binsDbm.size();
+    if (N < 20 || bandwidthMhz <= 0.0) { return results; }
+
+    const double hzPerBin = bandwidthMhz * 1.0e6 / N;
+    const double startMhz = centerMhz - bandwidthMhz / 2.0;
+
+    // ── Noise floor ───────────────────────────────────────────────────────
+    // Prefer caller-supplied rolling average (EMA across ~10 frames) over the
+    // per-frame 10th-percentile estimate.  The rolling average is less inflated
+    // by transient QRM so the +3 dB threshold reliably rejects noise bumps.
+    float noiseFloor;
+    if (rollingNoiseFloorDbm > -500.0f) {
+        noiseFloor = rollingNoiseFloorDbm;
+    } else {
+        QVector<float> sorted = binsDbm;
+        std::sort(sorted.begin(), sorted.end());
+        noiseFloor = sorted[N * kNoisePctile / 100];
+    }
+    const float threshold = noiseFloor + kThresholdDb;
+
+    qCDebug(lcSHistory,
+        "S-History: center=%.3f MHz  bw=%.3f MHz  bins=%d  hz/bin=%.1f  "
+        "noise=%.1f dBm  thr=%.1f dBm  ranges=%d",
+        centerMhz, bandwidthMhz, N, hzPerBin,
+        static_cast<double>(noiseFloor), static_cast<double>(threshold),
+        static_cast<int>(voiceRangesMhz.size()));
+
+    // ── Voice-range mask ──────────────────────────────────────────────────
+    QVector<bool> inVoice(N, voiceRangesMhz.isEmpty());
+    if (!voiceRangesMhz.isEmpty()) {
+        for (int j = 0; j < N; ++j) {
+            const double f = startMhz + (j + 0.5) / N * bandwidthMhz;
+            for (const auto& r : voiceRangesMhz) {
+                if (f >= r.first && f <= r.second) { inVoice[j] = true; break; }
+            }
+        }
+    }
+
+    // ── Sliding-max fill ──────────────────────────────────────────────────
+    // SSB speech has natural spectral gaps (unvoiced consonants, pauses).
+    // A sliding max across ±kFillHz bridges those gaps so the contiguous-
+    // region detector sees the full 2-3 kHz footprint instead of fragments.
+    // Narrow digital signals (CW, FT8) expand by ≤ 2×kFillHz, keeping
+    // their total below kVoiceMinHz when kFillHz < (kVoiceMinHz / 2).
+    const int fillBins = std::max(1, static_cast<int>(kFillHz / hzPerBin));
+    QVector<float> filled(N);
+    for (int j = 0; j < N; ++j) {
+        float mx = binsDbm[j];
+        for (int k = 1; k <= fillBins; ++k) {
+            if (j - k >= 0) { mx = std::max(mx, binsDbm[j - k]); }
+            if (j + k <  N) { mx = std::max(mx, binsDbm[j + k]); }
+        }
+        filled[j] = mx;
+    }
+
+    // ── Contiguous-region detection on the filled spectrum ────────────────
+    // The inVoice mask is applied at REGION level for voice-width signals only.
+    // Narrow carriers (QRM tones) are scanned across the full visible spectrum
+    // because interference does not respect band-plan boundaries.
+    int i = 0;
+    while (i < N) {
+        if (filled[i] < threshold) { ++i; continue; }
+
+        const int start = i;
+        while (i < N && filled[i] >= threshold) { ++i; }
+        const int end = i - 1;
+
+        const double widthHz = (end - start + 1) * hzPerBin;
+        const bool   isNarrow = (widthHz < kVoiceMinHz);
+
+        // Voice-width signals: honour the band-plan voice allocation filter.
+        // Narrow carrier QRM bypasses it — it can sit anywhere in the pan.
+        if (!isNarrow) {
+            bool anyInVoice = false;
+            for (int j = start; j <= end && !anyInVoice; ++j) { anyInVoice = inVoice[j]; }
+            if (!anyInVoice) {
+                qCDebug(lcSHistory,
+                    "  region @ %.4f MHz: width=%.0f Hz — outside voice allocation, skipped",
+                    startMhz + (start / static_cast<double>(N)) * bandwidthMhz, widthHz);
+                continue;
+            }
+        }
+
+        // Use caller-supplied slice mode when it is USB or LSB; otherwise fall
+        // back to the energy-asymmetry heuristic (useful for AM/FM pans).
+        const bool callerKnowsMode = (sliceMode == QStringLiteral("USB") ||
+                                      sliceMode == QStringLiteral("LSB"));
+        QString mode;
+        if (callerKnowsMode) {
+            mode = sliceMode;
+        } else {
+            float lowerE = 0.0f, upperE = 0.0f;
+            const int mid = (start + end) / 2;
+            for (int j = start; j <= mid; ++j) { lowerE += binsDbm[j] - noiseFloor; }
+            for (int j = mid+1; j <= end; ++j) { upperE += binsDbm[j] - noiseFloor; }
+            mode = (lowerE >= upperE) ? QStringLiteral("USB") : QStringLiteral("LSB");
+        }
+
+        // tryAppend: check peak, compute frequency, emit a DetectedVoiceSignal.
+        // For narrow regions (< kVoiceMinHz) the frequency is placed at the
+        // peak bin — the 400 Hz fill boundary is off by ±fillHz so using the
+        // mode edge would misplace the QRM marker by several hundred Hz.
+        // For voice-width regions the mode edge (USB=left, LSB=right) is used.
+        auto tryAppend = [&](int lo, int hi, bool isUsb) {
+            if (lo > hi) { return; }
+            const auto peakIt = std::max_element(binsDbm.constBegin() + lo,
+                                                 binsDbm.constBegin() + hi + 1);
+            const float pk = *peakIt;
+            if (pk < noiseFloor + kMinPeakAboveFloorDb) {
+                qCDebug(lcSHistory,
+                    "  sub-region @ %.4f MHz: peak=%.1f dBm — rejected (< floor+%.0f dB)",
+                    startMhz + (lo / static_cast<double>(N)) * bandwidthMhz,
+                    static_cast<double>(pk),
+                    static_cast<double>(kMinPeakAboveFloorDb));
+                return;
+            }
+            const double segWidthHz = (hi - lo + 1) * hzPerBin;
+            double fMhz;
+            if (segWidthHz < kVoiceMinHz) {
+                // Narrow carrier / QRM tone: use peak bin for accuracy.
+                const int peakBin = static_cast<int>(peakIt - binsDbm.constBegin());
+                fMhz = startMhz + (peakBin + 0.5) / N * bandwidthMhz;
+            } else {
+                fMhz = isUsb
+                    ? startMhz + (lo + 0.5) / N * bandwidthMhz
+                    : startMhz + (hi + 0.5) / N * bandwidthMhz;
+            }
+            qCDebug(lcSHistory,
+                "  DETECTED: %.4f MHz  %s  peak=%.1f dBm (%s)  width=%.0f Hz%s",
+                fMhz, qPrintable(mode),
+                static_cast<double>(pk), qPrintable(sLabel(pk)),
+                static_cast<double>(segWidthHz),
+                segWidthHz < kVoiceMinHz ? " [narrow/QRM candidate]" : "");
+            results.append({fMhz, pk, mode, segWidthHz});
+        };
+
+        const bool isUsb = (mode == QStringLiteral("USB"));
+        if (isNarrow) {
+            // Narrow carrier (continuous tone, staggered OFDM QRM, etc.).
+            // Report as a single entry without 2.7 kHz voice splitting.
+            tryAppend(start, end, isUsb);
+        } else if (widthHz > kVoiceMaxHz) {
+            // Wideband interference (OTH radar, broadcast splatter, etc.).
+            // Too wide to be voice — emit ONE entry at the region centre so it
+            // is tracked as a single QRM source rather than exploding into many
+            // 2.7 kHz voice chunks that clutter the panadapter.
+            const float pk = *std::max_element(binsDbm.constBegin() + start,
+                                               binsDbm.constBegin() + end + 1);
+            if (pk >= noiseFloor + kMinPeakAboveFloorDb) {
+                const int   centerBin = (start + end) / 2;
+                const double fMhz = startMhz + (centerBin + 0.5) / N * bandwidthMhz;
+                qCDebug(lcSHistory,
+                    "  WIDEBAND: %.4f MHz  peak=%.1f dBm (%s)  width=%.0f Hz [QRM candidate]",
+                    fMhz, static_cast<double>(pk), qPrintable(sLabel(pk)), widthHz);
+                results.append({fMhz, pk, mode, widthHz});
+            }
+        } else {
+            // Voice-width signal (1.8–8 kHz).
+            // Natural SSB rolloff: USB is strongest on the left (carrier edge) and
+            // weakens toward the right; LSB is the mirror.  A single station, even
+            // a wide one, becomes ONE marker.  A second marker is only emitted when
+            // there is a genuine secondary station: a valley followed by a new peak
+            // rising ≥ kSplitValleyDb above the valley floor.
+            constexpr float kSplitValleyDb = 8.0f;
+
+            // Fill-corrected carrier-edge boundaries.
+            const int adjLo = isUsb ? std::min(start + fillBins, end) : start;
+            const int adjHi = isUsb ? end : std::max(end - fillBins, start);
+
+            // Locate the primary (global) peak.
+            const auto primIt  = std::max_element(binsDbm.constBegin() + adjLo,
+                                                   binsDbm.constBegin() + adjHi + 1);
+            const int  primBin = static_cast<int>(primIt - binsDbm.constBegin());
+
+            // Search for a valley + secondary peak on the far side of the primary.
+            const int sLo = isUsb ? (primBin + 1) : adjLo;
+            const int sHi = isUsb ? adjHi          : (primBin > adjLo ? primBin - 1 : adjLo);
+
+            int splitAt = -1;
+            if (sLo < sHi) {
+                const auto valleyIt  = std::min_element(binsDbm.constBegin() + sLo,
+                                                         binsDbm.constBegin() + sHi + 1);
+                const int   valleyBin = static_cast<int>(valleyIt - binsDbm.constBegin());
+                const float valleyDb  = *valleyIt;
+
+                const int p2Lo = isUsb ? (valleyBin + 1) : sLo;
+                const int p2Hi = isUsb ? sHi : (valleyBin > sLo ? valleyBin - 1 : sLo);
+                if (p2Lo <= p2Hi) {
+                    const float p2Peak = *std::max_element(binsDbm.constBegin() + p2Lo,
+                                                            binsDbm.constBegin() + p2Hi + 1);
+                    if (p2Peak >= valleyDb + kSplitValleyDb) {
+                        splitAt = valleyBin;
+                    }
+                }
+            }
+
+            if (splitAt < 0) {
+                // Single station: one marker at the carrier edge.
+                tryAppend(adjLo, adjHi, isUsb);
+            } else if (isUsb) {
+                tryAppend(adjLo, splitAt - 1, true);
+                tryAppend(splitAt + 1, adjHi, true);
+            } else {
+                tryAppend(splitAt + 1, adjHi, false);
+                tryAppend(adjLo, splitAt - 1, false);
+            }
+        }
+    }
+
+    if (results.isEmpty()) {
+        qCDebug(lcSHistory, "  no voice-width signals found in this frame");
+    }
+
+    return results;
+}
+
+QString sLabel(float dbm)
+{
+    if (dbm >= -73.0f) {
+        const int plus = static_cast<int>(std::ceil(dbm + 73.0f));
+        return plus > 0 ? QString("S9+%1").arg(plus) : QStringLiteral("S9");
+    }
+    int sNum = static_cast<int>(std::ceil((dbm + 127.0f) / 6.0f));
+    sNum = std::clamp(sNum, 0, 9);
+    return QString("S%1").arg(sNum);
+}
+
+} // namespace AetherSDR

--- a/src/core/VoiceSignalDetector.h
+++ b/src/core/VoiceSignalDetector.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <QVector>
+#include <QString>
+#include <QPair>
+
+namespace AetherSDR {
+
+// A voice-bandwidth SSB signal detected in a single FFT frame.
+struct DetectedVoiceSignal {
+    double  freqMhz;   // carrier edge frequency (left for USB, right for LSB)
+    float   peakDbm;   // loudest bin within the region
+    QString mode;      // "USB" or "LSB"
+    double  widthHz;   // detected bandwidth (useful for QRM notch width)
+};
+
+// Returns true if a band-plan segment label designates a voice allocation
+// (PHONE, SSB, USB, AM, FM/RPT).
+bool isVoiceSegmentLabel(const QString& label);
+
+// Scan FFT bins (in dBm) for contiguous regions ≥1.8 kHz wide and ≥6 dB above
+// the stable noise floor.  Each detected region is capped at 2.7 kHz (one SSB
+// channel); wider regions are split and the overflow is emitted as a second
+// marker only if it also has a qualifying peak.
+//
+// voiceRangesMhz: if non-empty, only scan bins whose frequency falls inside one
+// of these {lowMhz, highMhz} ranges (derived from the active band plan's voice
+// segments).  Pass an empty vector to scan the full pan bandwidth.
+//
+// rollingNoiseFloorDbm: caller-supplied stable noise floor (e.g. EMA across
+// recent frames).  When > -500 dBm it is used directly; otherwise the function
+// falls back to the per-frame 10th-percentile estimate.
+//
+// sliceMode: "USB" or "LSB" from the active slice.  When supplied, it overrides
+// the internal energy-asymmetry heuristic so markers always match the operator's
+// current mode.  Pass an empty string to use the heuristic (e.g. for AM/FM pans).
+//
+// Returns one entry per detected signal (primary + optional secondary per region).
+QVector<DetectedVoiceSignal> detectVoiceSignals(
+    const QVector<float>& binsDbm,
+    double centerMhz,
+    double bandwidthMhz,
+    const QVector<QPair<double, double>>& voiceRangesMhz = {},
+    float rollingNoiseFloorDbm = -1000.0f,
+    const QString& sliceMode = {});
+
+// Format a peak-dBm value as an S-meter label, rounded UP to the next unit.
+// Scale: S9 = -73 dBm, 6 dB/S-unit.  Examples: -85 → "S8", -63 → "S9+10".
+QString sLabel(float dbm);
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2116,6 +2116,13 @@ MainWindow::MainWindow(QWidget* parent)
                             e.peakDbm = sig.peakDbm;
                             e.freqMhz = sig.freqMhz;
                         }
+                        // Voice over QRM: if this entry is already QRM-classified
+                        // and the current detection is voice-width, flag for double
+                        // marking so both a red QRM and a gold voice marker appear.
+                        if (e.suspectQrm
+                                && sig.widthHz >= 1800.0 && sig.widthHz <= 8000.0) {
+                            e.voiceOverQrmLastMs = now;
+                        }
                         found = true;
                         break;
                     }
@@ -13018,6 +13025,7 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
     constexpr qint64 kNarrowQrmGateMs   = 6000;  // narrow/wideband: show QRM after 6 s
     constexpr int    kNarrowQrmHitsNeeded = 105; // ~70% of 25 fps × 6 s = 150 frames
     constexpr qint64 kVoiceToQrmMs      = 120000;
+    constexpr qint64 kHideAfterMs       = 30000; // past-signals history window
 
     const qint64 now           = QDateTime::currentMSecsSinceEpoch();
     auto&        entries       = m_sHistoryData[panId];
@@ -13074,7 +13082,6 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
         e.suspectQrm = currentlyActive && qrmQualified && !hasVoiceGap;
 
         // Hide visible markers absent for 30 seconds (the "past signals" history window).
-        constexpr qint64 kHideAfterMs = 30000;
         if (e.visible && !currentlyActive && (now - e.lastSeenMs) > kHideAfterMs) {
             e.visible = false;
             e.qualifyStartMs = 0;
@@ -13127,6 +13134,25 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
             comment,
             e.lastSeenMs
         });
+
+        // Double mark: voice operator detected on top of a QRM-classified entry.
+        // Emit an additional gold voice marker so the operator can see both the
+        // interference AND the person trying to work through it simultaneously.
+        // The voice marker ages out independently (30 s after last voice-width hit).
+        if (isQrm && (now - e.voiceOverQrmLastMs) < kHideAfterMs) {
+            markers.append({
+                -1,
+                AetherSDR::sLabel(e.peakDbm),
+                roundToHundredHz(e.freqMhz),
+                QStringLiteral("#FFFF00"),
+                e.mode,
+                QColor(255, 200, 0),
+                QStringLiteral("SHistory"),
+                {},
+                QStringLiteral("Voice on QRM ch, width=%1 Hz").arg(e.widthHz, 0, 'f', 0),
+                e.voiceOverQrmLastMs
+            });
+        }
     }
     sw->setSHistoryMarkers(markers);
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2043,139 +2043,7 @@ MainWindow::MainWindow(QWidget* parent)
     });
     // ── S History Markers — tap into FFT frames for voice signal detection ──
     connect(m_radioModel.panStream(), &PanadapterStream::spectrumReady,
-            this, [this](quint32 streamId, const QVector<float>& bins) {
-        if (!m_sHistoryEnabled && !m_sHistoryQrmEnabled) return;
-        // Build voice-only frequency ranges from the active band plan once per frame
-        QVector<QPair<double, double>> voiceRanges;
-        if (m_bandPlanMgr) {
-            for (const auto& seg : m_bandPlanMgr->segments()) {
-                if (AetherSDR::isVoiceSegmentLabel(seg.label))
-                    voiceRanges.append({seg.lowMhz, seg.highMhz});
-            }
-        }
-        const qint64 now = QDateTime::currentMSecsSinceEpoch();
-        for (auto* pan : m_radioModel.panadapters()) {
-            if (pan->panStreamId() != streamId) continue;
-
-            const QString panId = pan->panId();
-            auto& state = m_sHistoryPanState[panId];
-            // Only reset on a genuine band change (centre shifts by >500 kHz).
-            // Zoom (bandwidth change) must NOT clear markers — the operator
-            // zooms in to inspect signals that are already marked.
-            const bool bandChanged =
-                std::abs(state.centerMhz - pan->centerMhz()) > 0.5;
-            state.centerMhz    = pan->centerMhz();
-            state.bandwidthMhz = pan->bandwidthMhz();
-            if (bandChanged) {
-                state.suppressUntilMs = now + 10000;
-                m_sHistoryData.remove(panId);
-                m_spectrogramBuffers.remove(panId);  // old frames are for a different band
-            }
-
-            // Read the noise floor that the spectrum widget has already measured
-            // from this pan's live FFT stream — no hardcoded dBm, adapts to the
-            // current band, antenna, and preamp setup automatically.
-            SpectrumWidget* sw = m_panStack->spectrum(pan->panId());
-            const float noiseFloor = sw ? sw->noiseFloorDbm() : -1000.0f;
-
-            // Use the active slice mode so USB pans only show USB markers and
-            // LSB pans only show LSB markers — no more double-marking one signal.
-            QString sliceMode;
-            for (auto* slice : m_radioModel.slices()) {
-                if (slice && slice->panId() == pan->panId()) {
-                    sliceMode = slice->mode();
-                    break;
-                }
-            }
-
-            // Push this frame into the spectrogram buffer for CNN classification.
-            m_spectrogramBuffers[panId].push(bins, pan->centerMhz(), pan->bandwidthMhz());
-
-            const auto detected =
-                AetherSDR::detectVoiceSignals(bins, pan->centerMhz(), pan->bandwidthMhz(),
-                                              voiceRanges, noiseFloor, sliceMode);
-            auto& entries = m_sHistoryData[panId];
-            for (const auto& sig : detected) {
-                bool found = false;
-                for (auto& e : entries) {
-                    // Merge window: 2 kHz for voice signals — large enough to absorb
-                    // frame-to-frame edge jitter (bin quantisation + ±400 Hz gap-fill
-                    // ≈ up to ~700 Hz shift), small enough to stay below the minimum
-                    // SSB channel spacing of 2.7 kHz so adjacent stations get their
-                    // own entries.  Half the signal width for wideband QRM so
-                    // frame-to-frame centre drift doesn't create duplicates.
-                    const double mergeHz = (sig.widthHz > 8000.0)
-                        ? sig.widthHz / 2.0 : 2000.0;
-                    if (std::abs(e.freqMhz - sig.freqMhz) < mergeHz / 1e6) {
-                        e.lastSeenMs = now;
-                        e.hitTimestamps.append(now);
-                        // Track widest detection: a signal can look narrow when weak
-                        // but wider at peak — the widest seen determines classification.
-                        e.widthHz = std::max(e.widthHz, sig.widthHz);
-                        if (sig.peakDbm > e.peakDbm) {
-                            e.peakDbm = sig.peakDbm;
-                            e.freqMhz = sig.freqMhz;
-                        }
-                        // Voice over QRM: if this entry is already QRM-classified
-                        // and the current detection is voice-width, flag for double
-                        // marking so both a red QRM and a gold voice marker appear.
-                        if (e.suspectQrm
-                                && sig.widthHz >= 1800.0 && sig.widthHz <= 8000.0) {
-                            e.voiceOverQrmLastMs = now;
-                        }
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found) {
-                    SHistoryEntry newEntry;
-                    newEntry.freqMhz       = sig.freqMhz;
-                    newEntry.peakDbm       = sig.peakDbm;
-                    newEntry.mode          = sig.mode;
-                    newEntry.firstDetectedMs = now;
-                    newEntry.lastSeenMs    = now;
-                    newEntry.widthHz       = sig.widthHz;
-                    newEntry.hitTimestamps = {now};
-                    newEntry.lastGapMs     = now;  // treat appearance as a gap reset
-                    entries.append(std::move(newEntry));
-                }
-            }
-            // CNN classification for borderline-width entries (1800–2500 Hz).
-            // Runs only when the model is loaded; gracefully skipped otherwise.
-            if (m_signalClassifier.isLoaded()) {
-                auto& buf = m_spectrogramBuffers[panId];
-                if (buf.frameCount() >= AetherSDR::SpectrogramBuffer::kMaxFrames) {
-                    for (auto& e : entries) {
-                        if (e.widthHz >= 1800.0 && e.widthHz <= 2500.0) {
-                            // Extract a 2× signal-width patch centred on this entry
-                            const double patchWidthMhz = e.widthHz * 2.0 / 1.0e6;
-                            const QVector<float> patch =
-                                buf.extractPatch(e.freqMhz, patchWidthMhz);
-                            if (!patch.isEmpty()) {
-                                const AetherSDR::ClassifierResult res =
-                                    m_signalClassifier.classify(
-                                        patch,
-                                        AetherSDR::SpectrogramBuffer::kMaxFrames,
-                                        AetherSDR::SpectrogramBuffer::kPatchFreqBins);
-                                if (res.valid) {
-                                    // EMA α = 0.15 — gradual update, resilient to
-                                    // single-frame misclassification
-                                    constexpr float kAlpha = 0.15f;
-                                    e.carrierScore = e.carrierScore * (1.0f - kAlpha)
-                                                   + res.carrierProb * kAlpha;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Always rebuild so hit-window expiry hides markers promptly
-            // even when nothing was detected this frame.
-            rebuildSHistoryForPan(panId);
-            break;
-        }
-    });
+            this, &MainWindow::onSpectrumReadyForSHistory);
 
     connect(m_radioModel.panStream(), &PanadapterStream::waterfallRowReady,
             this, [this](quint32 streamId, const QVector<float>& bins,
@@ -2479,6 +2347,9 @@ MainWindow::MainWindow(QWidget* parent)
             }
         }
         m_panStack->removePanadapter(panId);
+        m_sHistoryData.remove(panId);
+        m_sHistoryPanState.remove(panId);
+        m_spectrogramBuffers.remove(panId);
         qDebug() << "MainWindow: removed panadapter applet for" << panId;
 
         // Rearrange remaining pans to a sensible layout
@@ -13023,7 +12894,11 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
     constexpr int    kMinHits           = 1;
     constexpr qint64 kQualifyMs         = 3000;  // 3-second streak before showing
     constexpr qint64 kNarrowQrmGateMs   = 6000;  // narrow/wideband: show QRM after 6 s
-    constexpr int    kNarrowQrmHitsNeeded = 105; // ~70% of 25 fps × 6 s = 150 frames
+    // Require 70% frame occupancy over 6 s, derived from observed fps rather than
+    // the old hard-coded 105 (which assumed 25 fps and broke at 10 fps or 60 fps).
+    const float observedFps = m_sHistoryPanState.value(panId).fpsEwma;
+    const int   kNarrowQrmHitsNeeded = static_cast<int>(
+        std::clamp(observedFps * (kNarrowQrmGateMs / 1000.0f) * 0.70f, 30.0f, 500.0f));
     constexpr qint64 kVoiceToQrmMs      = 120000;
     constexpr qint64 kHideAfterMs       = 30000; // past-signals history window
 
@@ -13176,6 +13051,157 @@ void MainWindow::expireSHistoryMarkers()
         if (!entries.isEmpty()) {
             rebuildSHistoryForPan(it.key());
         }
+    }
+}
+
+void MainWindow::onSpectrumReadyForSHistory(quint32 streamId, const QVector<float>& bins)
+{
+    if (!m_sHistoryEnabled && !m_sHistoryQrmEnabled) return;
+
+    // Build voice-only frequency ranges from the active band plan once per frame
+    QVector<QPair<double, double>> voiceRanges;
+    if (m_bandPlanMgr) {
+        for (const auto& seg : m_bandPlanMgr->segments()) {
+            if (AetherSDR::isVoiceSegmentLabel(seg.label))
+                voiceRanges.append({seg.lowMhz, seg.highMhz});
+        }
+    }
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    for (auto* pan : m_radioModel.panadapters()) {
+        if (pan->panStreamId() != streamId) continue;
+
+        const QString panId = pan->panId();
+        auto& state = m_sHistoryPanState[panId];
+        // Only reset on a genuine band change (centre shifts by >500 kHz).
+        // Zoom (bandwidth change) must NOT clear markers — the operator
+        // zooms in to inspect signals that are already marked.
+        const bool bandChanged =
+            std::abs(state.centerMhz - pan->centerMhz()) > 0.5;
+        state.centerMhz    = pan->centerMhz();
+        state.bandwidthMhz = pan->bandwidthMhz();
+        // Track observed frame rate (EWMA) so QRM hit thresholds adapt to
+        // actual pan fps rather than assuming 25 fps.
+        if (state.lastFrameMs > 0) {
+            const float dtSec = static_cast<float>(now - state.lastFrameMs) / 1000.0f;
+            if (dtSec > 0.0f && dtSec < 1.0f) {  // ignore stale gaps (pan was paused)
+                constexpr float kFpsAlpha = 0.05f;
+                state.fpsEwma = state.fpsEwma * (1.0f - kFpsAlpha)
+                              + (1.0f / dtSec) * kFpsAlpha;
+            }
+        }
+        state.lastFrameMs = now;
+        if (bandChanged) {
+            state.suppressUntilMs = now + 10000;
+            m_sHistoryData.remove(panId);
+            m_spectrogramBuffers.remove(panId);  // old frames are for a different band
+        }
+
+        // Read the noise floor that the spectrum widget has already measured
+        // from this pan's live FFT stream — no hardcoded dBm, adapts to the
+        // current band, antenna, and preamp setup automatically.
+        SpectrumWidget* sw = m_panStack->spectrum(pan->panId());
+        const float noiseFloor = sw ? sw->noiseFloorDbm() : -1000.0f;
+
+        // Use the active slice mode so USB pans only show USB markers and
+        // LSB pans only show LSB markers — no more double-marking one signal.
+        QString sliceMode;
+        for (auto* slice : m_radioModel.slices()) {
+            if (slice && slice->panId() == pan->panId()) {
+                sliceMode = slice->mode();
+                break;
+            }
+        }
+
+        // Push this frame into the spectrogram buffer for CNN classification.
+        auto& bufPtr = m_spectrogramBuffers[panId];
+        if (!bufPtr) { bufPtr = std::make_shared<AetherSDR::SpectrogramBuffer>(); }
+        bufPtr->push(bins, pan->centerMhz(), pan->bandwidthMhz());
+
+        const auto detected =
+            AetherSDR::detectVoiceSignals(bins, pan->centerMhz(), pan->bandwidthMhz(),
+                                          voiceRanges, noiseFloor, sliceMode);
+        auto& entries = m_sHistoryData[panId];
+        for (const auto& sig : detected) {
+            bool found = false;
+            for (auto& e : entries) {
+                // Merge window: 2 kHz for voice signals — large enough to absorb
+                // frame-to-frame edge jitter (bin quantisation + ±400 Hz gap-fill
+                // ≈ up to ~700 Hz shift), small enough to stay below the minimum
+                // SSB channel spacing of 2.7 kHz so adjacent stations get their
+                // own entries.  Half the signal width for wideband QRM so
+                // frame-to-frame centre drift doesn't create duplicates.
+                const double mergeHz = (sig.widthHz > 8000.0)
+                    ? sig.widthHz / 2.0 : 2000.0;
+                if (std::abs(e.freqMhz - sig.freqMhz) < mergeHz / 1e6) {
+                    e.lastSeenMs = now;
+                    e.hitTimestamps.append(now);
+                    // Track widest detection: a signal can look narrow when weak
+                    // but wider at peak — the widest seen determines classification.
+                    e.widthHz = std::max(e.widthHz, sig.widthHz);
+                    if (sig.peakDbm > e.peakDbm) {
+                        e.peakDbm = sig.peakDbm;
+                        e.freqMhz = sig.freqMhz;
+                    }
+                    // Voice over QRM: if this entry is already QRM-classified
+                    // and the current detection is voice-width, flag for double
+                    // marking so both a red QRM and a gold voice marker appear.
+                    if (e.suspectQrm
+                            && sig.widthHz >= 1800.0 && sig.widthHz <= 8000.0) {
+                        e.voiceOverQrmLastMs = now;
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                SHistoryEntry newEntry;
+                newEntry.freqMhz         = sig.freqMhz;
+                newEntry.peakDbm         = sig.peakDbm;
+                newEntry.mode            = sig.mode;
+                newEntry.firstDetectedMs = now;
+                newEntry.lastSeenMs      = now;
+                newEntry.widthHz         = sig.widthHz;
+                newEntry.hitTimestamps   = {now};
+                newEntry.lastGapMs       = now;  // treat appearance as a gap reset
+                entries.append(std::move(newEntry));
+            }
+        }
+        // CNN classification for borderline-width entries (1800–2500 Hz).
+        // Runs only when the model is loaded; gracefully skipped otherwise.
+        if (m_signalClassifier.isLoaded()) {
+            const auto cit = m_spectrogramBuffers.constFind(panId);
+            AetherSDR::SpectrogramBuffer* buf = (cit != m_spectrogramBuffers.constEnd()) ? cit->get() : nullptr;
+            if (buf != nullptr) {
+                if (buf->frameCount() >= AetherSDR::SpectrogramBuffer::kMaxFrames) {
+                    for (auto& e : entries) {
+                        if (e.widthHz >= 1800.0 && e.widthHz <= 2500.0) {
+                            const double patchWidthMhz = e.widthHz * 2.0 / 1.0e6;
+                            const QVector<float> patch =
+                                buf->extractPatch(e.freqMhz, patchWidthMhz);
+                            if (!patch.isEmpty()) {
+                                const AetherSDR::ClassifierResult res =
+                                    m_signalClassifier.classify(
+                                        patch,
+                                        AetherSDR::SpectrogramBuffer::kMaxFrames,
+                                        AetherSDR::SpectrogramBuffer::kPatchFreqBins);
+                                if (res.valid) {
+                                    // EMA α = 0.15 — gradual update, resilient to
+                                    // single-frame misclassification
+                                    constexpr float kAlpha = 0.15f;
+                                    e.carrierScore = e.carrierScore * (1.0f - kAlpha)
+                                                   + res.carrierProb * kAlpha;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Always rebuild so hit-window expiry hides markers promptly
+        // even when nothing was detected this frame.
+        rebuildSHistoryForPan(panId);
+        break;
     }
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -174,6 +174,8 @@
 #include <sys/resource.h>
 #endif
 #include <QLocale>
+#include <QFile>
+#include <QStandardPaths>
 
 namespace AetherSDR {
 
@@ -2042,7 +2044,7 @@ MainWindow::MainWindow(QWidget* parent)
     // ── S History Markers — tap into FFT frames for voice signal detection ──
     connect(m_radioModel.panStream(), &PanadapterStream::spectrumReady,
             this, [this](quint32 streamId, const QVector<float>& bins) {
-        if (!m_sHistoryEnabled) return;
+        if (!m_sHistoryEnabled && !m_sHistoryQrmEnabled) return;
         // Build voice-only frequency ranges from the active band plan once per frame
         QVector<QPair<double, double>> voiceRanges;
         if (m_bandPlanMgr) {
@@ -2067,6 +2069,7 @@ MainWindow::MainWindow(QWidget* parent)
             if (bandChanged) {
                 state.suppressUntilMs = now + 10000;
                 m_sHistoryData.remove(panId);
+                m_spectrogramBuffers.remove(panId);  // old frames are for a different band
             }
 
             // Read the noise floor that the spectrum widget has already measured
@@ -2084,6 +2087,9 @@ MainWindow::MainWindow(QWidget* parent)
                     break;
                 }
             }
+
+            // Push this frame into the spectrogram buffer for CNN classification.
+            m_spectrogramBuffers[panId].push(bins, pan->centerMhz(), pan->bandwidthMhz());
 
             const auto detected =
                 AetherSDR::detectVoiceSignals(bins, pan->centerMhz(), pan->bandwidthMhz(),
@@ -2127,6 +2133,36 @@ MainWindow::MainWindow(QWidget* parent)
                     entries.append(std::move(newEntry));
                 }
             }
+            // CNN classification for borderline-width entries (1800–2500 Hz).
+            // Runs only when the model is loaded; gracefully skipped otherwise.
+            if (m_signalClassifier.isLoaded()) {
+                auto& buf = m_spectrogramBuffers[panId];
+                if (buf.frameCount() >= AetherSDR::SpectrogramBuffer::kMaxFrames) {
+                    for (auto& e : entries) {
+                        if (e.widthHz >= 1800.0 && e.widthHz <= 2500.0) {
+                            // Extract a 2× signal-width patch centred on this entry
+                            const double patchWidthMhz = e.widthHz * 2.0 / 1.0e6;
+                            const QVector<float> patch =
+                                buf.extractPatch(e.freqMhz, patchWidthMhz);
+                            if (!patch.isEmpty()) {
+                                const AetherSDR::ClassifierResult res =
+                                    m_signalClassifier.classify(
+                                        patch,
+                                        AetherSDR::SpectrogramBuffer::kMaxFrames,
+                                        AetherSDR::SpectrogramBuffer::kPatchFreqBins);
+                                if (res.valid) {
+                                    // EMA α = 0.15 — gradual update, resilient to
+                                    // single-frame misclassification
+                                    constexpr float kAlpha = 0.15f;
+                                    e.carrierScore = e.carrierScore * (1.0f - kAlpha)
+                                                   + res.carrierProb * kAlpha;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             // Always rebuild so hit-window expiry hides markers promptly
             // even when nothing was detected this frame.
             rebuildSHistoryForPan(panId);
@@ -6088,7 +6124,10 @@ void MainWindow::buildMenuBar()
 
     m_sHistoryEnabled =
         AppSettings::instance().value("SHistoryMarkersEnabled", "False").toString() == "True";
-    auto* sHistoryAct = viewMenu->addAction("S History Markers");
+    m_sHistoryQrmEnabled =
+        AppSettings::instance().value("SHistoryQrmEnabled", "False").toString() == "True";
+
+    auto* sHistoryAct = viewMenu->addAction("Signal History Markers");
     sHistoryAct->setCheckable(true);
     sHistoryAct->setChecked(m_sHistoryEnabled);
     connect(sHistoryAct, &QAction::toggled, this, [this](bool on) {
@@ -6097,9 +6136,33 @@ void MainWindow::buildMenuBar()
         AppSettings::instance().save();
         for (auto* a : m_panStack->allApplets()) {
             a->spectrumWidget()->setShowSHistory(on);
-            if (!on) a->spectrumWidget()->setSHistoryMarkers({});
         }
-        if (!on) { m_sHistoryData.clear(); m_sHistoryPanState.clear(); }
+        if (!on && !m_sHistoryQrmEnabled) {
+            m_sHistoryData.clear();
+            m_sHistoryPanState.clear();
+            for (auto* a : m_panStack->allApplets()) {
+                a->spectrumWidget()->setSHistoryMarkers({});
+            }
+        }
+    });
+
+    auto* qrmHistoryAct = viewMenu->addAction("QRM History Markers");
+    qrmHistoryAct->setCheckable(true);
+    qrmHistoryAct->setChecked(m_sHistoryQrmEnabled);
+    connect(qrmHistoryAct, &QAction::toggled, this, [this](bool on) {
+        m_sHistoryQrmEnabled = on;
+        AppSettings::instance().setValue("SHistoryQrmEnabled", on ? "True" : "False");
+        AppSettings::instance().save();
+        for (auto* a : m_panStack->allApplets()) {
+            a->spectrumWidget()->setShowSHistoryQrm(on);
+        }
+        if (!on && !m_sHistoryEnabled) {
+            m_sHistoryData.clear();
+            m_sHistoryPanState.clear();
+            for (auto* a : m_panStack->allApplets()) {
+                a->spectrumWidget()->setSHistoryMarkers({});
+            }
+        }
     });
 
     // UI Scale submenu — sets QT_SCALE_FACTOR, applies on restart
@@ -7178,6 +7241,23 @@ void MainWindow::buildUI()
     connect(m_sHistoryExpireTimer, &QTimer::timeout,
             this, &MainWindow::expireSHistoryMarkers);
     m_sHistoryExpireTimer->start();
+
+    // CNN signal classifier — load model from next to the executable or ~/.config/AetherSDR/
+    {
+        const QString exeDir  = QCoreApplication::applicationDirPath();
+        const QString cfgDir  = QStandardPaths::writableLocation(
+                                    QStandardPaths::AppConfigLocation);
+        const QString modelFile = QStringLiteral("signal_classifier.onnx");
+        QString modelPath;
+        if (QFile::exists(exeDir + QLatin1Char('/') + modelFile)) {
+            modelPath = exeDir + QLatin1Char('/') + modelFile;
+        } else if (QFile::exists(cfgDir + QLatin1Char('/') + modelFile)) {
+            modelPath = cfgDir + QLatin1Char('/') + modelFile;
+        }
+        if (!modelPath.isEmpty()) {
+            m_signalClassifier.loadModel(modelPath);
+        }
+    }
 }
 
 // ─── Theme ────────────────────────────────────────────────────────────────────
@@ -8901,7 +8981,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
     // ── S History Markers ─────────────────────────────────────────────────
     sw->setShowSHistory(m_sHistoryEnabled);
-    if (m_sHistoryEnabled) {
+    sw->setShowSHistoryQrm(m_sHistoryQrmEnabled);
+    if (m_sHistoryEnabled || m_sHistoryQrmEnabled) {
         // Seed a 10-second warmup so QRM classification can establish a
         // baseline before any markers appear on the newly-wired pan.
         auto& ps = m_sHistoryPanState[applet->panId()];
@@ -12970,7 +13051,12 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
         //   True narrow (< 1.8 kHz) / wideband (> 8 kHz): QRM after 6 s of
         //   continuous presence with no gap (checked via lastGapMs so gaps that
         //   age out of the 15 s timestamp window are still honoured).
-        const bool isVoiceWidth = (e.widthHz >= 1800.0 && e.widthHz <= 8000.0);
+        // CNN override: if carrierScore > 0.70, treat as narrow carrier even if
+        // width falls in the voice range.  Threshold is conservative to avoid
+        // mis-classifying real voice.  Has no effect when ONNX is absent (score stays 0.5).
+        const bool cnnSaysCarrier = (e.carrierScore > 0.70f);
+        const bool isVoiceWidth   = !cnnSaysCarrier
+                                    && (e.widthHz >= 1800.0 && e.widthHz <= 8000.0);
         bool qrmQualified;
         if (isVoiceWidth) {
             qrmQualified = (now - e.lastGapMs) >= kVoiceToQrmMs;
@@ -13047,7 +13133,7 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
 
 void MainWindow::expireSHistoryMarkers()
 {
-    if (!m_sHistoryEnabled) return;
+    if (!m_sHistoryEnabled && !m_sHistoryQrmEnabled) return;
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
     constexpr qint64 kLifetimeMs = 60000;  // entries live 60 s; visible for 30 s
     for (auto it = m_sHistoryData.begin(); it != m_sHistoryData.end(); ++it) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -11,6 +11,7 @@
 #include "PanLayoutDialog.h"
 #include "core/CommandParser.h"
 #include "core/LogManager.h"
+#include "core/VoiceSignalDetector.h"
 #include "core/MemoryRecallPolicy.h"
 #include "core/StreamStatus.h"
 #include "models/PanadapterModel.h"
@@ -2038,6 +2039,101 @@ MainWindow::MainWindow(QWidget* parent)
             finishPanadapterConnectionAnimation();
         }
     });
+    // ── S History Markers — tap into FFT frames for voice signal detection ──
+    connect(m_radioModel.panStream(), &PanadapterStream::spectrumReady,
+            this, [this](quint32 streamId, const QVector<float>& bins) {
+        if (!m_sHistoryEnabled) return;
+        // Build voice-only frequency ranges from the active band plan once per frame
+        QVector<QPair<double, double>> voiceRanges;
+        if (m_bandPlanMgr) {
+            for (const auto& seg : m_bandPlanMgr->segments()) {
+                if (AetherSDR::isVoiceSegmentLabel(seg.label))
+                    voiceRanges.append({seg.lowMhz, seg.highMhz});
+            }
+        }
+        const qint64 now = QDateTime::currentMSecsSinceEpoch();
+        for (auto* pan : m_radioModel.panadapters()) {
+            if (pan->panStreamId() != streamId) continue;
+
+            const QString panId = pan->panId();
+            auto& state = m_sHistoryPanState[panId];
+            // Only reset on a genuine band change (centre shifts by >500 kHz).
+            // Zoom (bandwidth change) must NOT clear markers — the operator
+            // zooms in to inspect signals that are already marked.
+            const bool bandChanged =
+                std::abs(state.centerMhz - pan->centerMhz()) > 0.5;
+            state.centerMhz    = pan->centerMhz();
+            state.bandwidthMhz = pan->bandwidthMhz();
+            if (bandChanged) {
+                state.suppressUntilMs = now + 10000;
+                m_sHistoryData.remove(panId);
+            }
+
+            // Read the noise floor that the spectrum widget has already measured
+            // from this pan's live FFT stream — no hardcoded dBm, adapts to the
+            // current band, antenna, and preamp setup automatically.
+            SpectrumWidget* sw = m_panStack->spectrum(pan->panId());
+            const float noiseFloor = sw ? sw->noiseFloorDbm() : -1000.0f;
+
+            // Use the active slice mode so USB pans only show USB markers and
+            // LSB pans only show LSB markers — no more double-marking one signal.
+            QString sliceMode;
+            for (auto* slice : m_radioModel.slices()) {
+                if (slice && slice->panId() == pan->panId()) {
+                    sliceMode = slice->mode();
+                    break;
+                }
+            }
+
+            const auto detected =
+                AetherSDR::detectVoiceSignals(bins, pan->centerMhz(), pan->bandwidthMhz(),
+                                              voiceRanges, noiseFloor, sliceMode);
+            auto& entries = m_sHistoryData[panId];
+            for (const auto& sig : detected) {
+                bool found = false;
+                for (auto& e : entries) {
+                    // Merge window: 2 kHz for voice signals — large enough to absorb
+                    // frame-to-frame edge jitter (bin quantisation + ±400 Hz gap-fill
+                    // ≈ up to ~700 Hz shift), small enough to stay below the minimum
+                    // SSB channel spacing of 2.7 kHz so adjacent stations get their
+                    // own entries.  Half the signal width for wideband QRM so
+                    // frame-to-frame centre drift doesn't create duplicates.
+                    const double mergeHz = (sig.widthHz > 8000.0)
+                        ? sig.widthHz / 2.0 : 2000.0;
+                    if (std::abs(e.freqMhz - sig.freqMhz) < mergeHz / 1e6) {
+                        e.lastSeenMs = now;
+                        e.hitTimestamps.append(now);
+                        // Track widest detection: a signal can look narrow when weak
+                        // but wider at peak — the widest seen determines classification.
+                        e.widthHz = std::max(e.widthHz, sig.widthHz);
+                        if (sig.peakDbm > e.peakDbm) {
+                            e.peakDbm = sig.peakDbm;
+                            e.freqMhz = sig.freqMhz;
+                        }
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    SHistoryEntry newEntry;
+                    newEntry.freqMhz       = sig.freqMhz;
+                    newEntry.peakDbm       = sig.peakDbm;
+                    newEntry.mode          = sig.mode;
+                    newEntry.firstDetectedMs = now;
+                    newEntry.lastSeenMs    = now;
+                    newEntry.widthHz       = sig.widthHz;
+                    newEntry.hitTimestamps = {now};
+                    newEntry.lastGapMs     = now;  // treat appearance as a gap reset
+                    entries.append(std::move(newEntry));
+                }
+            }
+            // Always rebuild so hit-window expiry hides markers promptly
+            // even when nothing was detected this frame.
+            rebuildSHistoryForPan(panId);
+            break;
+        }
+    });
+
     connect(m_radioModel.panStream(), &PanadapterStream::waterfallRowReady,
             this, [this](quint32 streamId, const QVector<float>& bins,
                          double low, double high, quint32 tc) {
@@ -5990,6 +6086,22 @@ void MainWindow::buildMenuBar()
         AppSettings::instance().save();
     });
 
+    m_sHistoryEnabled =
+        AppSettings::instance().value("SHistoryMarkersEnabled", "False").toString() == "True";
+    auto* sHistoryAct = viewMenu->addAction("S History Markers");
+    sHistoryAct->setCheckable(true);
+    sHistoryAct->setChecked(m_sHistoryEnabled);
+    connect(sHistoryAct, &QAction::toggled, this, [this](bool on) {
+        m_sHistoryEnabled = on;
+        AppSettings::instance().setValue("SHistoryMarkersEnabled", on ? "True" : "False");
+        AppSettings::instance().save();
+        for (auto* a : m_panStack->allApplets()) {
+            a->spectrumWidget()->setShowSHistory(on);
+            if (!on) a->spectrumWidget()->setSHistoryMarkers({});
+        }
+        if (!on) { m_sHistoryData.clear(); m_sHistoryPanState.clear(); }
+    });
+
     // UI Scale submenu — sets QT_SCALE_FACTOR, applies on restart
     auto* scaleMenu = viewMenu->addMenu("UI Scale");
     int savedScale = AppSettings::instance().value("UiScalePercent", "100").toInt();
@@ -7059,6 +7171,13 @@ void MainWindow::buildUI()
 
     statusBar()->addWidget(container, 1);
     updateBandStackIndicator();
+
+    // S History Markers expiry — sweeps stale detections once per second
+    m_sHistoryExpireTimer = new QTimer(this);
+    m_sHistoryExpireTimer->setInterval(1000);
+    connect(m_sHistoryExpireTimer, &QTimer::timeout,
+            this, &MainWindow::expireSHistoryMarkers);
+    m_sHistoryExpireTimer->start();
 }
 
 // ─── Theme ────────────────────────────────────────────────────────────────────
@@ -8778,6 +8897,19 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setSpotBgColor(QColor(s.value("SpotsOverrideBgColor", "#000000").toString()));
         sw->setSpotBgOpacity(s.value("SpotsBackgroundOpacity", 48).toInt());
         sw->setSpotShowLines(s.value("IsSpotsLinesEnabled", "True").toString() == "True");
+    }
+
+    // ── S History Markers ─────────────────────────────────────────────────
+    sw->setShowSHistory(m_sHistoryEnabled);
+    if (m_sHistoryEnabled) {
+        // Seed a 10-second warmup so QRM classification can establish a
+        // baseline before any markers appear on the newly-wired pan.
+        auto& ps = m_sHistoryPanState[applet->panId()];
+        if (ps.suppressUntilMs == 0) {
+            ps.suppressUntilMs = QDateTime::currentMSecsSinceEpoch() + 10000;
+        }
+        if (m_sHistoryData.contains(applet->panId()))
+            rebuildSHistoryForPan(applet->panId());
     }
 
     // ── Per-pan display controls (client-side) ───────────────────────────
@@ -12786,6 +12918,153 @@ void MainWindow::dockAppletPanel()
     m_appletPanelFloatWindow->removeEventFilter(this);
     m_appletPanelFloatWindow->deleteLater();
     m_appletPanelFloatWindow = nullptr;
+}
+
+static double roundToHundredHz(double freqMhz)
+{
+    return std::round(freqMhz * 10000.0) / 10000.0;
+}
+
+void MainWindow::rebuildSHistoryForPan(const QString& panId)
+{
+    auto* sw = m_panStack->spectrum(panId);
+    if (!sw) return;
+
+    constexpr qint64 kQrmWindowMs       = 15000; // timestamp retention window
+    constexpr qint64 kHitWindowMs       = 1000;
+    constexpr int    kMinHits           = 1;
+    constexpr qint64 kQualifyMs         = 3000;  // 3-second streak before showing
+    constexpr qint64 kNarrowQrmGateMs   = 6000;  // narrow/wideband: show QRM after 6 s
+    constexpr int    kNarrowQrmHitsNeeded = 105; // ~70% of 25 fps × 6 s = 150 frames
+    constexpr qint64 kVoiceToQrmMs      = 120000;
+
+    const qint64 now           = QDateTime::currentMSecsSinceEpoch();
+    auto&        entries       = m_sHistoryData[panId];
+    const qint64 suppressUntil = m_sHistoryPanState.value(panId).suppressUntilMs;
+
+    for (auto& e : entries) {
+        // Keep 30 s of timestamps for QRM assessment.
+        e.hitTimestamps.erase(
+            std::remove_if(e.hitTimestamps.begin(), e.hitTimestamps.end(),
+                [now](qint64 t) { return (now - t) > kQrmWindowMs; }),
+            e.hitTimestamps.end());
+
+        // How many hits in the last 1 second (display gate).
+        const int recentHits1s = static_cast<int>(std::count_if(
+            e.hitTimestamps.constBegin(), e.hitTimestamps.constEnd(),
+            [now](qint64 t) { return (now - t) <= kHitWindowMs; }));
+        const bool currentlyActive = (recentHits1s >= kMinHits);
+
+        // Detect any gap > 1 s in the retained timestamp window.
+        bool hasVoiceGap = false;
+        constexpr qint64 kMaxQrmGapMs = 1000;
+        for (int ti = 1; ti < e.hitTimestamps.size() && !hasVoiceGap; ++ti) {
+            if ((e.hitTimestamps[ti] - e.hitTimestamps[ti - 1]) > kMaxQrmGapMs) {
+                hasVoiceGap = true;
+            }
+        }
+        if (hasVoiceGap) { e.lastGapMs = now; }
+
+        // QRM classification:
+        //   Voice-width (≥1.8 kHz, ≤8 kHz): require 2 unbroken minutes.
+        //   True narrow (< 1.8 kHz) / wideband (> 8 kHz): QRM after 6 s of
+        //   continuous presence with no gap (checked via lastGapMs so gaps that
+        //   age out of the 15 s timestamp window are still honoured).
+        const bool isVoiceWidth = (e.widthHz >= 1800.0 && e.widthHz <= 8000.0);
+        bool qrmQualified;
+        if (isVoiceWidth) {
+            qrmQualified = (now - e.lastGapMs) >= kVoiceToQrmMs;
+        } else {
+            const int hitsIn6s = static_cast<int>(std::count_if(
+                e.hitTimestamps.constBegin(), e.hitTimestamps.constEnd(),
+                [now](qint64 t) { return (now - t) <= kNarrowQrmGateMs; }));
+            // Use lastGapMs so gaps that fell out of the 15 s window still
+            // prevent a voice-like signal from being misclassified as QRM.
+            const bool noRecentGap = (now - e.lastGapMs) >= kNarrowQrmGateMs;
+            qrmQualified = (now - e.firstDetectedMs) >= kNarrowQrmGateMs
+                           && noRecentGap
+                           && (hitsIn6s >= kNarrowQrmHitsNeeded);
+        }
+        e.suspectQrm = currentlyActive && qrmQualified && !hasVoiceGap;
+
+        // Hide visible markers absent for 30 seconds (the "past signals" history window).
+        constexpr qint64 kHideAfterMs = 30000;
+        if (e.visible && !currentlyActive && (now - e.lastSeenMs) > kHideAfterMs) {
+            e.visible = false;
+            e.qualifyStartMs = 0;
+        }
+
+        if (!e.visible) {
+            // < 1800 Hz: narrow carrier — QRM-only
+            // 1800–8000 Hz: voice path (includes the 1800–2300 Hz borderline zone)
+            // > 8000 Hz: wideband interference — QRM-only
+            const bool isNarrowCarrier   = (e.widthHz < 1800.0);
+            const bool isWidebandCarrier = (e.widthHz > 8000.0);
+            if (isNarrowCarrier || isWidebandCarrier) {
+                if (e.suspectQrm) { e.visible = true; }
+            } else if (currentlyActive) {
+                if (e.qualifyStartMs == 0) { e.qualifyStartMs = now; }
+                // Confirmed voice re-qualifies in 2 s; new signals need 3 s.
+                const qint64 requiredMs = e.confirmedVoice ? 2000LL : kQualifyMs;
+                if ((now - e.qualifyStartMs) >= requiredMs && now >= suppressUntil) {
+                    e.visible = true;
+                    if (!e.suspectQrm) { e.confirmedVoice = true; }
+                }
+            } else if ((now - e.lastSeenMs) > 3000) {
+                // Reset streak only after 3 s of no detections — inter-word pauses
+                // and brief FFT gaps don't restart the qualify clock.
+                e.qualifyStartMs = 0;
+            }
+        }
+    }
+
+    QVector<SpectrumWidget::SpotMarker> markers;
+    for (const auto& e : entries) {
+        if (!e.visible) { continue; }
+        const bool isQrm = e.suspectQrm;
+        const QString label = isQrm
+            ? (QStringLiteral("QRM") + AetherSDR::sLabel(e.peakDbm).mid(1))
+            : AetherSDR::sLabel(e.peakDbm);
+        const QString color = isQrm ? QStringLiteral("#FF0000") : QStringLiteral("#FFFF00");
+        const QString comment = isQrm
+            ? QStringLiteral("QRM width=%1 Hz").arg(e.widthHz, 0, 'f', 0)
+            : QStringLiteral("Voice width=%1 Hz").arg(e.widthHz, 0, 'f', 0);
+        markers.append({
+            -1,
+            label,
+            roundToHundredHz(e.freqMhz),
+            color,
+            e.mode,
+            QColor(isQrm ? 255 : 255, isQrm ? 0 : 200, 0),
+            isQrm ? QStringLiteral("QRM") : QStringLiteral("SHistory"),
+            {},
+            comment,
+            e.lastSeenMs
+        });
+    }
+    sw->setSHistoryMarkers(markers);
+}
+
+void MainWindow::expireSHistoryMarkers()
+{
+    if (!m_sHistoryEnabled) return;
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    constexpr qint64 kLifetimeMs = 60000;  // entries live 60 s; visible for 30 s
+    for (auto it = m_sHistoryData.begin(); it != m_sHistoryData.end(); ++it) {
+        auto& entries = it.value();
+        entries.erase(
+            std::remove_if(entries.begin(), entries.end(),
+                [now](const SHistoryEntry& e) {
+                    return (now - e.lastSeenMs) > kLifetimeMs;
+                }),
+            entries.end());
+        // Rebuild unconditionally: hit-window timestamps age out every second
+        // even when no new detections arrive, which hides markers whose peaks
+        // have fallen below the 25% threshold.
+        if (!entries.isEmpty()) {
+            rebuildSHistoryForPan(it.key());
+        }
+    }
 }
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -12892,7 +12892,8 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
     constexpr qint64 kQrmWindowMs       = 15000; // timestamp retention window
     constexpr qint64 kHitWindowMs       = 1000;
     constexpr int    kMinHits           = 1;
-    constexpr qint64 kQualifyMs         = 3000;  // 3-second streak before showing
+    constexpr qint64 kQualifyMs         = 3000;  // min age before a new signal becomes visible
+    constexpr int    kQualifyMinHits    = 3;     // min detections within kQualifyMs to qualify
     constexpr qint64 kNarrowQrmGateMs   = 6000;  // narrow/wideband: show QRM after 6 s
     // Require 70% frame occupancy over 6 s, derived from observed fps rather than
     // the old hard-coded 105 (which assumed 25 fps and broke at 10 fps or 60 fps).
@@ -12959,7 +12960,6 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
         // Hide visible markers absent for 30 seconds (the "past signals" history window).
         if (e.visible && !currentlyActive && (now - e.lastSeenMs) > kHideAfterMs) {
             e.visible = false;
-            e.qualifyStartMs = 0;
         }
 
         if (!e.visible) {
@@ -12971,17 +12971,21 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
             if (isNarrowCarrier || isWidebandCarrier) {
                 if (e.suspectQrm) { e.visible = true; }
             } else if (currentlyActive) {
-                if (e.qualifyStartMs == 0) { e.qualifyStartMs = now; }
-                // Confirmed voice re-qualifies in 2 s; new signals need 3 s.
+                // Qualify by total age since first detection, not streak length.
+                // Bursty signals (pileups, intermittent operators) qualify as soon
+                // as they have been known for kQualifyMs AND have accumulated at
+                // least kQualifyMinHits detections in that window.  This rejects
+                // transient noise that appears once and disappears while still
+                // allowing intermittent but real signals (pileups, bursty digital).
                 const qint64 requiredMs = e.confirmedVoice ? 2000LL : kQualifyMs;
-                if ((now - e.qualifyStartMs) >= requiredMs && now >= suppressUntil) {
+                const int hitsInQualify = static_cast<int>(std::count_if(
+                    e.hitTimestamps.constBegin(), e.hitTimestamps.constEnd(),
+                    [now, requiredMs](qint64 t) { return (now - t) <= requiredMs; }));
+                const bool enoughHits = e.confirmedVoice || (hitsInQualify >= kQualifyMinHits);
+                if ((now - e.firstDetectedMs) >= requiredMs && enoughHits && now >= suppressUntil) {
                     e.visible = true;
                     if (!e.suspectQrm) { e.confirmedVoice = true; }
                 }
-            } else if ((now - e.lastSeenMs) > 3000) {
-                // Reset streak only after 3 s of no detections — inter-word pauses
-                // and brief FFT gaps don't restart the qualify clock.
-                e.qualifyStartMs = 0;
             }
         }
     }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -293,6 +293,38 @@ private:
     };
     QHash<QString, SpotDedup> m_spotDedup;
 
+    // S History Markers — auto-detected voice signals per panadapter
+    struct SHistoryEntry {
+        double          freqMhz;
+        float           peakDbm;
+        QString         mode;
+        qint64          firstDetectedMs{0};
+        qint64          lastSeenMs;
+        double          widthHz{0.0};
+        bool            suspectQrm{false};
+        // Hit timestamps for the last 10 seconds. Used to detect both
+        // qualification streaks and QRM persistence (>90% occupancy).
+        QVector<qint64> hitTimestamps;
+        // Qualification streak: set when the entry first starts qualifying;
+        // cleared if the signal vanishes completely (no hits for >1 s).
+        // Once the streak reaches 3 s the marker becomes visible.
+        qint64          qualifyStartMs{0};
+        bool            visible{false};
+        bool            confirmedVoice{false}; // true once shown as a gold voice marker
+        qint64          lastGapMs{0};          // last time a ≥1 s gap was detected (epoch ms)
+    };
+    struct SHistoryPanState {
+        double centerMhz{0.0};
+        double bandwidthMhz{0.0};
+        qint64 suppressUntilMs{0};
+    };
+    QHash<QString, QVector<SHistoryEntry>> m_sHistoryData;  // panId → entries
+    QHash<QString, SHistoryPanState> m_sHistoryPanState;
+    QTimer* m_sHistoryExpireTimer{nullptr};
+    bool    m_sHistoryEnabled{false};
+    void rebuildSHistoryForPan(const QString& panId);
+    void expireSHistoryMarkers();
+
     // Batched spot add commands (flushed 1/sec)
     QStringList m_spotCmdBatch;
     int m_nextPassiveSpotId{-2000000};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -301,7 +301,7 @@ private:
         float           peakDbm;
         QString         mode;
         qint64          firstDetectedMs{0};
-        qint64          lastSeenMs;
+        qint64          lastSeenMs{0};
         double          widthHz{0.0};
         bool            suspectQrm{false};
         // Hit timestamps for the last 10 seconds. Used to detect both
@@ -326,6 +326,8 @@ private:
         double centerMhz{0.0};
         double bandwidthMhz{0.0};
         qint64 suppressUntilMs{0};
+        qint64 lastFrameMs{0};
+        float  fpsEwma{25.0f};  // EWMA of observed frames/sec; starts at 25 fps
     };
     QHash<QString, QVector<SHistoryEntry>> m_sHistoryData;  // panId → entries
     QHash<QString, SHistoryPanState> m_sHistoryPanState;
@@ -334,8 +336,11 @@ private:
     bool    m_sHistoryQrmEnabled{false};
     void rebuildSHistoryForPan(const QString& panId);
     void expireSHistoryMarkers();
-    // Per-pan spectrogram ring buffer for CNN classification
-    QHash<QString, AetherSDR::SpectrogramBuffer> m_spectrogramBuffers;
+    void onSpectrumReadyForSHistory(quint32 streamId, const QVector<float>& bins);
+    // Per-pan spectrogram ring buffer for CNN classification.
+    // shared_ptr so QHash COW can copy the pointer on detach without deep-copying
+    // the 32-frame ring buffer (unique_ptr is non-copyable, which breaks QHash::operator[]).
+    QHash<QString, std::shared_ptr<AetherSDR::SpectrogramBuffer>> m_spectrogramBuffers;
     AetherSDR::SignalClassifier m_signalClassifier;
 
     // Batched spot add commands (flushed 1/sec)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -38,6 +38,8 @@
 #include "core/HidEncoderManager.h"
 #endif
 #include "core/ShortcutManager.h"
+#include "core/SpectrogramBuffer.h"
+#include "core/SignalClassifier.h"
 #include "core/TgxlConnection.h"
 #include "core/PgxlConnection.h"
 #include "core/DxccColorProvider.h"
@@ -312,6 +314,9 @@ private:
         bool            visible{false};
         bool            confirmedVoice{false}; // true once shown as a gold voice marker
         qint64          lastGapMs{0};          // last time a ≥1 s gap was detected (epoch ms)
+        // CNN classifier: exponential moving average of carrier probability.
+        // 0.0 = strongly voice, 1.0 = strongly carrier. 0.5 = unknown (ONNX absent).
+        float           carrierScore{0.5f};
     };
     struct SHistoryPanState {
         double centerMhz{0.0};
@@ -322,8 +327,12 @@ private:
     QHash<QString, SHistoryPanState> m_sHistoryPanState;
     QTimer* m_sHistoryExpireTimer{nullptr};
     bool    m_sHistoryEnabled{false};
+    bool    m_sHistoryQrmEnabled{false};
     void rebuildSHistoryForPan(const QString& panId);
     void expireSHistoryMarkers();
+    // Per-pan spectrogram ring buffer for CNN classification
+    QHash<QString, AetherSDR::SpectrogramBuffer> m_spectrogramBuffers;
+    AetherSDR::SignalClassifier m_signalClassifier;
 
     // Batched spot add commands (flushed 1/sec)
     QStringList m_spotCmdBatch;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -317,6 +317,10 @@ private:
         // CNN classifier: exponential moving average of carrier probability.
         // 0.0 = strongly voice, 1.0 = strongly carrier. 0.5 = unknown (ONNX absent).
         float           carrierScore{0.5f};
+        // Last time a voice-width (1.8–8 kHz) signal was detected while this
+        // entry was already QRM-classified.  Drives the "voice over QRM"
+        // double-marker — shows both a red QRM marker and a gold voice marker.
+        qint64          voiceOverQrmLastMs{0};
     };
     struct SHistoryPanState {
         double centerMhz{0.0};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -307,10 +307,6 @@ private:
         // Hit timestamps for the last 10 seconds. Used to detect both
         // qualification streaks and QRM persistence (>90% occupancy).
         QVector<qint64> hitTimestamps;
-        // Qualification streak: set when the entry first starts qualifying;
-        // cleared if the signal vanishes completely (no hits for >1 s).
-        // Once the streak reaches 3 s the marker becomes visible.
-        qint64          qualifyStartMs{0};
         bool            visible{false};
         bool            confirmedVoice{false}; // true once shown as a gold voice marker
         qint64          lastGapMs{0};          // last time a ≥1 s gap was detected (epoch ms)

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4706,14 +4706,17 @@ int SpectrumWidget::tnfAtPixel(int x, int preferredId) const
 
 void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
 {
-    // Merge DX spots (gated by m_showSpots) and S-history markers (gated by m_showSHistory).
-    // S-History markers are suppressed when a DX spot is active within 3 kHz — the spot
-    // takes priority and carries richer callsign/DXCC information.
+    // Merge DX spots, Signal History markers, and QRM History markers.
+    // Each category is gated by its own flag.  S-History markers within 3 kHz of
+    // an active DX spot are suppressed — the spot carries richer callsign/DXCC info.
     QVector<SpotMarker> allMarkers;
     if (m_showSpots) { allMarkers = m_spotMarkers; }
-    if (m_showSHistory) {
-        constexpr double kSpotOverrideMhz = 0.003;  // 3 kHz proximity threshold
+    if (m_showSHistory || m_showSHistoryQrm) {
+        constexpr double kSpotOverrideMhz = 0.003;
         for (const auto& sh : m_sHistoryMarkers) {
+            const bool isQrm = (sh.source == QStringLiteral("QRM"));
+            if (isQrm  && !m_showSHistoryQrm) { continue; }
+            if (!isQrm && !m_showSHistory)    { continue; }
             bool masked = false;
             for (const auto& sp : m_spotMarkers) {
                 if (std::abs(sh.freqMhz - sp.freqMhz) < kSpotOverrideMhz) {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1356,6 +1356,34 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
     }
     m_bins = binsDbm;
 
+    // ── Live noise floor measurement (two-pass trimmed mean) ─────────────
+    // Same technique as the waterfall auto-black: compute the mean of ALL bins,
+    // then average only the bins at-or-below that mean.  Signal peaks inflate
+    // the first-pass mean and therefore exclude themselves from the second pass,
+    // leaving only the "consistently low, close-in-value" noise bins — exactly
+    // the flat green line a human eye reads as the noise floor on the scope.
+    // This is robust even on a very crowded band (40-50% bins occupied).
+    if (!binsDbm.isEmpty()) {
+        // Pass 1 — overall mean (sampled every 4th bin for speed)
+        float sum = 0.0f;
+        int   cnt = 0;
+        for (int j = 0; j < binsDbm.size(); j += 4) { sum += binsDbm[j]; ++cnt; }
+        const float mean = sum / cnt;
+
+        // Pass 2 — average only noise bins (≤ mean), which excludes signal peaks
+        float noiseSum = 0.0f;
+        int   noiseCnt = 0;
+        for (int j = 0; j < binsDbm.size(); j += 4) {
+            if (binsDbm[j] <= mean) { noiseSum += binsDbm[j]; ++noiseCnt; }
+        }
+        const float frameFloor = (noiseCnt > 0) ? noiseSum / noiseCnt : mean;
+
+        constexpr float kAlpha = 0.05f;  // ~20-frame window ≈ 0.8 s at 25 fps
+        m_measuredNoiseFloorDbm = (m_measuredNoiseFloorDbm <= -500.0f)
+            ? frameFloor
+            : m_measuredNoiseFloorDbm * (1.0f - kAlpha) + frameFloor * kAlpha;
+    }
+
     // Noise floor auto-adjust: every 10 frames, measure noise floor and
     // adjust min_dbm so it sits at the user's chosen position.
     if (m_noiseFloorEnable && !m_transmitting && !m_smoothed.isEmpty()) {
@@ -3388,7 +3416,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             drawFreqScale(p, QRect(0, specH + DIVIDER_H, w, FREQ_SCALE_H));
             drawTimeScale(p, wfRect);
             drawTnfMarkers(p, specRect);
-            if (m_showSpots)
+            if (m_showSpots || m_showSHistory)
                 drawSpotMarkers(p, specRect);
             drawSwrSweep(p, specRect);
             drawSliceMarkers(p, specRect, wfRect);
@@ -3931,7 +3959,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         drawWaterfall(p, wfRect);
         drawTimeScale(p, wfRect);
         drawTnfMarkers(p, specRect);
-        if (m_showSpots) drawSpotMarkers(p, specRect);
+        if (m_showSpots || m_showSHistory) drawSpotMarkers(p, specRect);
         drawSwrSweep(p, specRect);
         drawSliceMarkers(p, specRect, wfRect);
         drawOffScreenSlices(p, specRect);
@@ -4461,6 +4489,12 @@ void SpectrumWidget::setSpotMarkers(const QVector<SpotMarker>& markers)
     markOverlayDirty();
 }
 
+void SpectrumWidget::setSHistoryMarkers(const QVector<SpotMarker>& markers)
+{
+    m_sHistoryMarkers = markers;
+    markOverlayDirty();
+}
+
 void SpectrumWidget::setSwrSweepPoints(const QVector<SwrSweepPoint>& points,
                                        bool running,
                                        double currentFreqMhz,
@@ -4672,7 +4706,25 @@ int SpectrumWidget::tnfAtPixel(int x, int preferredId) const
 
 void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
 {
-    if (m_spotMarkers.isEmpty()) return;
+    // Merge DX spots (gated by m_showSpots) and S-history markers (gated by m_showSHistory).
+    // S-History markers are suppressed when a DX spot is active within 3 kHz — the spot
+    // takes priority and carries richer callsign/DXCC information.
+    QVector<SpotMarker> allMarkers;
+    if (m_showSpots) { allMarkers = m_spotMarkers; }
+    if (m_showSHistory) {
+        constexpr double kSpotOverrideMhz = 0.003;  // 3 kHz proximity threshold
+        for (const auto& sh : m_sHistoryMarkers) {
+            bool masked = false;
+            for (const auto& sp : m_spotMarkers) {
+                if (std::abs(sh.freqMhz - sp.freqMhz) < kSpotOverrideMhz) {
+                    masked = true;
+                    break;
+                }
+            }
+            if (!masked) { allMarkers.append(sh); }
+        }
+    }
+    if (allMarkers.isEmpty()) return;
 
     QFont spotFont = p.font();
     spotFont.setPixelSize(m_spotFontSize);
@@ -4695,9 +4747,10 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
     QMap<int, QVector<SpotMarker>> overflowGroups;
     constexpr int ClusterBinWidth = 40;  // pixels — spots within this range cluster together
 
-    for (const auto& spot : m_spotMarkers) {
+    int mIdx = 0;
+    for (const auto& spot : allMarkers) {
         const int x = mhzToX(spot.freqMhz);
-        if (x < 0 || x > width()) continue;
+        if (x < 0 || x > width()) { ++mIdx; continue; }
 
         // Color priority: override → DXCC → spot-provided → default cyan
         QColor col(0x00, 0xb4, 0xd8);  // default cyan
@@ -4733,6 +4786,7 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
         if (labelRect.bottom() > maxBottom) {
             int bin = x / ClusterBinWidth;
             overflowGroups[bin].append(spot);
+            ++mIdx;
             continue;
         }
 
@@ -4743,8 +4797,11 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
         }
 
         placed.append(labelRect);
-        int mIdx = static_cast<int>(&spot - &m_spotMarkers[0]);
         m_spotClickRects.append({labelRect, spot.freqMhz, mIdx});
+
+        // QRM markers draw at 30% opacity (70% transparent)
+        const bool isQrm = (spot.source == QStringLiteral("QRM"));
+        if (isQrm) { p.setOpacity(0.3); }
 
         // Background pill — only draw when override background is enabled (#768)
         if (m_spotOverrideBg) {
@@ -4759,6 +4816,9 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
         // Text
         p.setPen(col);
         p.drawText(labelRect, Qt::AlignCenter, label);
+
+        if (isQrm) { p.setOpacity(1.0); }
+        ++mIdx;
     }
 
     // Draw cluster badges for overflow groups

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -324,8 +324,10 @@ public:
 
     void setShowSpots(bool on) { m_showSpots = on; update(); }
     bool showSpots() const { return m_showSpots; }
-    void setShowSHistory(bool on) { m_showSHistory = on; update(); }
-    bool showSHistory() const { return m_showSHistory; }
+    void setShowSHistory(bool on)    { m_showSHistory = on;    update(); }
+    bool showSHistory() const         { return m_showSHistory; }
+    void setShowSHistoryQrm(bool on) { m_showSHistoryQrm = on; update(); }
+    bool showSHistoryQrm() const      { return m_showSHistoryQrm; }
     void setSHistoryMarkers(const QVector<SpotMarker>& markers);
     void setSpotFontSize(int px) { m_spotFontSize = px; update(); }
     void setSpotMaxLevels(int n) { m_spotMaxLevels = n; update(); }
@@ -702,6 +704,7 @@ private:
     QVector<SpotCluster> m_spotClusters;
     bool m_showSpots{true};
     bool m_showSHistory{false};
+    bool m_showSHistoryQrm{false};
     QVector<SpotMarker> m_sHistoryMarkers;
     int  m_spotFontSize{16};
     int  m_spotMaxLevels{3};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -97,6 +97,12 @@ public:
     void setNoiseFloorPosition(int pos) { m_noiseFloorPosition = pos; }
     void setNoiseFloorEnable(bool on)   { m_noiseFloorEnable = on; }
 
+    // Two-pass trimmed-mean noise floor from live FFT bins (dBm), EMA-smoothed.
+    // Pass 1 computes the overall mean; pass 2 averages only bins ≤ mean so
+    // signal peaks exclude themselves, leaving the flat noise baseline.
+    // Reflects the current band, antenna and preamp — no hardcoded dBm value.
+    float noiseFloorDbm() const { return m_measuredNoiseFloorDbm; }
+
     // (getters for display settings are below with their members)
 
     // Set the VFO frequency (draws the orange VFO marker).
@@ -318,6 +324,9 @@ public:
 
     void setShowSpots(bool on) { m_showSpots = on; update(); }
     bool showSpots() const { return m_showSpots; }
+    void setShowSHistory(bool on) { m_showSHistory = on; update(); }
+    bool showSHistory() const { return m_showSHistory; }
+    void setSHistoryMarkers(const QVector<SpotMarker>& markers);
     void setSpotFontSize(int px) { m_spotFontSize = px; update(); }
     void setSpotMaxLevels(int n) { m_spotMaxLevels = n; update(); }
     void setSpotStartPct(int pct) { m_spotStartPct = pct; update(); }
@@ -481,6 +490,10 @@ private:
 
     float m_refLevel{-50.0f};       // top of display (dBm)
     float m_dynamicRange{100.0f};   // dB range shown in spectrum (-50 to -150)
+
+    // Two-pass trimmed-mean noise floor (dBm), EMA-smoothed across ~20 frames.
+    // -1000 = cold start (not yet measured).
+    float m_measuredNoiseFloorDbm{-1000.0f};
 
     // Noise floor auto-adjust
     bool  m_noiseFloorEnable{false};
@@ -688,6 +701,8 @@ private:
 
     QVector<SpotCluster> m_spotClusters;
     bool m_showSpots{true};
+    bool m_showSHistory{false};
+    QVector<SpotMarker> m_sHistoryMarkers;
     int  m_spotFontSize{16};
     int  m_spotMaxLevels{3};
     int  m_spotStartPct{50};      // % down from top of spectrum

--- a/tools/train_classifier.py
+++ b/tools/train_classifier.py
@@ -1,0 +1,264 @@
+"""
+Signal classifier training script for AetherSDR S-History v2.
+
+Trains a small 2D CNN on synthetic spectrogram patches to distinguish:
+  Class 0 — voice/SSB  (1.8–3.3 kHz wide, time-varying amplitude with gaps)
+  Class 1 — carrier    (narrow tone < 600 Hz, or digital flat-top < 1.5 kHz)
+
+Exports the trained model to ONNX (opset 12) for use by SignalClassifier.cpp.
+
+Requirements:
+    pip install torch numpy onnx
+
+Usage:
+    python tools/train_classifier.py [--output signal_classifier.onnx] [--epochs 40]
+"""
+
+import argparse
+import math
+import random
+import struct
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+# ── Patch dimensions (must match SpectrogramBuffer constants) ────────────────
+TIME_FRAMES  = 32
+FREQ_BINS    = 64
+NOISE_DB     = -120.0   # synthetic noise floor
+SIGNAL_DB    = -80.0    # rough signal level above floor
+
+
+# ── Synthetic data generation ────────────────────────────────────────────────
+
+def _gaussian_blob(bins: int, center_frac: float, width_frac: float) -> np.ndarray:
+    """1-D Gaussian shape spanning [0,1] freq axis."""
+    x = np.linspace(0.0, 1.0, bins)
+    sigma = width_frac / 3.0
+    return np.exp(-0.5 * ((x - center_frac) / sigma) ** 2)
+
+
+def _voice_patch(rng: random.Random, time: int, freq: int) -> np.ndarray:
+    """
+    Synthetic SSB/voice: 1.8–3.3 kHz width (14–26% of a 12 kHz pan),
+    time-varying amplitude with speech-like envelope + inter-word gaps.
+    """
+    patch = np.full((time, freq), NOISE_DB, dtype=np.float32)
+
+    # Random width 14–26 % of the patch freq window
+    w_frac = rng.uniform(0.14, 0.26)
+    c_frac = rng.uniform(w_frac / 2 + 0.05, 1.0 - w_frac / 2 - 0.05)
+    freq_shape = _gaussian_blob(freq, c_frac, w_frac)
+
+    # Speech-like amplitude envelope: semi-random bursts with 0-4 gaps
+    amp = np.zeros(time, dtype=np.float32)
+    gaps = sorted(rng.sample(range(2, time - 2), k=min(4, rng.randint(0, 4))))
+    t = 0
+    in_gap = False
+    while t < time:
+        if t in gaps:
+            in_gap = not in_gap
+        if not in_gap:
+            amp[t] = rng.uniform(0.5, 1.0)
+        t += 1
+
+    signal_range = SIGNAL_DB - NOISE_DB  # dB above noise
+    for ti in range(time):
+        row_db = NOISE_DB + amp[ti] * signal_range * freq_shape
+        # Add per-bin jitter to simulate spectral texture of speech
+        jitter = np.array([rng.gauss(0.0, 2.0) for _ in range(freq)], dtype=np.float32)
+        patch[ti] = row_db + jitter
+
+    return patch
+
+
+def _carrier_patch(rng: random.Random, time: int, freq: int) -> np.ndarray:
+    """
+    Synthetic narrow carrier or digital signal: < 600 Hz (< 5% of the patch),
+    constant amplitude (CW beacon, OFDM pilot, FSK carrier).
+    """
+    patch = np.full((time, freq), NOISE_DB, dtype=np.float32)
+
+    carrier_type = rng.choice(["tone", "fsk", "digital"])
+    if carrier_type == "tone":
+        w_frac = rng.uniform(0.01, 0.04)  # very narrow tone
+    elif carrier_type == "fsk":
+        w_frac = rng.uniform(0.04, 0.10)  # narrow FSK
+    else:
+        w_frac = rng.uniform(0.08, 0.18)  # flat digital (PSK/OFDM) < voice min
+
+    c_frac = rng.uniform(w_frac / 2 + 0.05, 1.0 - w_frac / 2 - 0.05)
+
+    if carrier_type == "digital":
+        # Flat rectangular top — characteristic of PSK/OFDM
+        freq_shape = np.zeros(freq, dtype=np.float32)
+        lo = max(0, int((c_frac - w_frac / 2) * freq))
+        hi = min(freq, int((c_frac + w_frac / 2) * freq))
+        freq_shape[lo:hi] = 1.0
+    else:
+        freq_shape = _gaussian_blob(freq, c_frac, w_frac)
+
+    signal_range = SIGNAL_DB - NOISE_DB
+    amp = rng.uniform(0.7, 1.0)  # carriers are steady
+    for ti in range(time):
+        # Small amplitude variation (fading) but no speech gaps
+        amp_t = amp + rng.gauss(0.0, 0.03)
+        row_db = NOISE_DB + amp_t * signal_range * freq_shape
+        jitter = np.array([rng.gauss(0.0, 0.5) for _ in range(freq)], dtype=np.float32)
+        patch[ti] = row_db + jitter
+
+    return patch
+
+
+def make_dataset(n_samples: int, seed: int = 42):
+    rng = random.Random(seed)
+    X, y = [], []
+    for _ in range(n_samples // 2):
+        X.append(_voice_patch(rng, TIME_FRAMES, FREQ_BINS))
+        y.append(0)  # voice
+        X.append(_carrier_patch(rng, TIME_FRAMES, FREQ_BINS))
+        y.append(1)  # carrier
+
+    X = np.stack(X, axis=0)[:, np.newaxis, :, :]  # [N, 1, T, F]
+    y = np.array(y, dtype=np.int64)
+
+    # Normalize each patch to [0, 1]
+    mn = X.min(axis=(2, 3), keepdims=True)
+    mx = X.max(axis=(2, 3), keepdims=True)
+    rng_val = np.where(mx - mn > 0.5, mx - mn, 1.0)
+    X = (X - mn) / rng_val
+
+    return X.astype(np.float32), y
+
+
+# ── Model ────────────────────────────────────────────────────────────────────
+
+class SignalCNN(nn.Module):
+    """
+    Small 2-D CNN for spectrogram patch classification.
+    Input:  [N, 1, 32, 64]  (NCHW — 1 channel, 32 time frames, 64 freq bins)
+    Output: [N, 2]           (voice probability, carrier probability)
+    """
+    def __init__(self):
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(1, 8, kernel_size=3, padding=1),
+            nn.BatchNorm2d(8),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(2, 2),                     # → [8, 16, 32]
+
+            nn.Conv2d(8, 16, kernel_size=3, padding=1),
+            nn.BatchNorm2d(16),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(2, 2),                     # → [16, 8, 16]
+
+            nn.AdaptiveAvgPool2d((4, 4)),            # → [16, 4, 4] = 256
+        )
+        self.classifier = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(256, 64),
+            nn.ReLU(inplace=True),
+            nn.Dropout(0.3),
+            nn.Linear(64, 2),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.classifier(self.features(x))
+
+
+# ── Training ─────────────────────────────────────────────────────────────────
+
+def train(args):
+    print(f"Generating {args.samples} synthetic patches …")
+    X, y = make_dataset(args.samples, seed=args.seed)
+
+    # 80/20 train/val split
+    split = int(len(X) * 0.8)
+    idx = np.random.RandomState(args.seed).permutation(len(X))
+    train_idx, val_idx = idx[:split], idx[split:]
+
+    X_tr = torch.from_numpy(X[train_idx])
+    y_tr = torch.from_numpy(y[train_idx])
+    X_va = torch.from_numpy(X[val_idx])
+    y_va = torch.from_numpy(y[val_idx])
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Training on {device} for {args.epochs} epochs …")
+
+    model = SignalCNN().to(device)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.parameters(), lr=1e-3)
+    scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=args.epochs)
+
+    bs = 64
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        perm = torch.randperm(len(X_tr))
+        total_loss = 0.0
+        for i in range(0, len(X_tr), bs):
+            idx_b = perm[i:i + bs]
+            xb, yb = X_tr[idx_b].to(device), y_tr[idx_b].to(device)
+            optimizer.zero_grad()
+            loss = criterion(model(xb), yb)
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item() * len(idx_b)
+        scheduler.step()
+
+        if epoch % 5 == 0 or epoch == args.epochs:
+            model.eval()
+            with torch.no_grad():
+                logits = model(X_va.to(device))
+                preds  = logits.argmax(dim=1).cpu()
+                acc    = (preds == y_va).float().mean().item()
+            print(f"  Epoch {epoch:3d}  loss={total_loss/len(X_tr):.4f}  val_acc={acc:.3f}")
+
+    return model
+
+
+# ── ONNX export ──────────────────────────────────────────────────────────────
+
+def export_onnx(model: torch.nn.Module, output_path: str):
+    model.eval()
+    dummy = torch.zeros(1, 1, TIME_FRAMES, FREQ_BINS)
+    # Wrap with softmax so output is directly [voiceProb, carrierProb]
+    class WithSoftmax(nn.Module):
+        def __init__(self, base):
+            super().__init__()
+            self.base = base
+        def forward(self, x):
+            return torch.softmax(self.base(x), dim=1)
+
+    export_model = WithSoftmax(model)
+    torch.onnx.export(
+        export_model, dummy, output_path,
+        input_names=["input"],
+        output_names=["output"],
+        dynamic_axes={"input": {0: "batch"}},
+        opset_version=12,
+    )
+    print(f"Model exported → {output_path}")
+    print(f"  Input:  [N, 1, {TIME_FRAMES}, {FREQ_BINS}]  (NCHW, float32, normalised [0,1])")
+    print(f"  Output: [N, 2]  — [voice_prob, carrier_prob]  (softmax, sums to 1)")
+    print()
+    print("Place signal_classifier.onnx next to the AetherSDR executable")
+    print("or in ~/.config/AetherSDR/ to enable CNN-assisted classification.")
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train AetherSDR signal classifier")
+    parser.add_argument("--output",  default="signal_classifier.onnx",
+                        help="Output ONNX model path (default: signal_classifier.onnx)")
+    parser.add_argument("--epochs",  type=int, default=40,
+                        help="Training epochs (default: 40)")
+    parser.add_argument("--samples", type=int, default=8000,
+                        help="Total training samples (half voice, half carrier; default: 8000)")
+    parser.add_argument("--seed",    type=int, default=42)
+    args = parser.parse_args()
+
+    model = train(args)
+    export_onnx(model, args.output)


### PR DESCRIPTION
## Summary

Implements the **S-History / Past Signals** feature — a real-time voice signal detector and history display for each panadapter, with optional AI-assisted classification via ONNX Runtime.

### What's included

**Core detection (VoiceSignalDetector)**
- FFT bin scanner with sliding-max gap-fill (±400 Hz) to bridge inter-word pauses in SSB speech
- Contiguous-region detection with 6 dB edge / 10 dB peak thresholds above the EMA noise floor
- Voice-width classification (1.8–8 kHz = voice, <1.8 kHz = narrow QRM, >8 kHz = wideband QRM)
- Valley-split logic to separate two overlapping stations on the same channel

**Signal history and QRM classification (MainWindow / SHistoryEntry)**
- Per-entry qualify gate: first seen ≥ 3 s ago AND ≥ 3 detections — handles bursty/intermittent signals (pileups, intermittent operators) without requiring a continuous streak
- Voice QRM: signal must be unbroken for 2 minutes before being reclassified from gold (voice) to red (QRM)
- Narrow/wideband QRM: 6-second continuous presence gate, FPS-derived hit threshold (EWMA of actual pan frame rate — adapts from 10 fps to 60+ fps automatically)
- 30-second history window: markers remain visible 30 s after last detection
- Double-marker: when a voice-width signal is detected on top of an already-QRM-classified entry, a second gold marker is emitted alongside the red QRM marker
- Pan-removal cleanup: per-pan maps erased when a panadapter is removed

**CNN signal classifier (optional, SignalClassifier / SpectrogramBuffer)**
- SpectrogramBuffer: per-pan circular ring buffer of the last 32 FFT frames
- SignalClassifier: ONNX Runtime inference wrapper — classifies borderline-width signals (1800–2500 Hz) as voice vs. carrier using a spectrogram patch
- EMA of classifier output (α = 0.15) per entry — resilient to single-frame misclassification
- Entire CNN path compiles out cleanly when ONNX Runtime is not present (#ifdef HAVE_ONNX)
- setup-onnxruntime.ps1 script to download and stage pre-built ONNX Runtime 1.18.1 (Windows)
- 	ools/train_classifier.py — synthetic-data training script for the spectrogram CNN (PyTorch, not linked into the binary)

**Attribution**
- ONNX Runtime (MIT, Microsoft) added to THIRD_PARTY_LICENSES

### Commits
| Hash | Description |
|------|-------------|
|  220828 | feat: initial S-History detector and panadapter markers |
| 67e1212 | feat: Spectrogram CNN classifier (ONNX Runtime, optional) |
| 65029e8 | feat: double-mark voice signals on QRM channels |
| 6e27977 | docs: ONNX Runtime attribution |
| 2943c12 | refactor: extract spectrumReady lambda → named method; fix QHash<unique_ptr> build error |
| c4b2be5 | fix: qualify bursty signals by age+hits rather than continuous streak |

## Test plan
- [ ] Build without ONNX Runtime (setup-onnxruntime.ps1 not run) — CNN path compiles out, all S-History markers work normally
- [ ] Build with ONNX Runtime — classifier loads from exe dir or ~/.config/AetherSDR/
- [ ] Enable S-History, tune to a phone band with activity — gold voice markers appear after ~3 s
- [ ] Leave a persistent carrier on screen — marker transitions from gold to red QRM after 2 minutes
- [ ] Narrow carrier (RTTY, CW) — red QRM marker appears after 6 s of continuous presence
- [ ] Verify bursty/intermittent signal (pileup, FT8 on phone band) — marker appears after first active frame once signal is ≥ 3 s old
- [ ] Remove a panadapter — re-add it — no stale markers from prior pan
- [ ] Zoom in on a signal — existing markers are preserved (no band-change clear on zoom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)