### PR TITLE
fix(cw): optimistic-update cwDelay to prevent delay slider reset

### DIFF
--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -651,6 +651,10 @@ void TransmitModel::setCwBreakIn(bool on)
 void TransmitModel::setCwDelay(int ms)
 {
     ms = qBound(0, ms, 2000);
+    if (m_cwDelay != ms) {
+        m_cwDelay = ms;
+        emit phoneStateChanged();
+    }
     emit commandReady(QString("cw break_in_delay %1").arg(ms));
 }
 


### PR DESCRIPTION
setCwDelay() was the only CW setter that did not cache its value into m_cwDelay before emitting the command.  The radio boots with break_in_delay=5 (its saved QSK state), so m_cwDelay stayed at 5 after the user moved the slider.  Any subsequent phoneStateChanged emission (e.g. from sidetone or speed adjustment) triggered syncCwFromModel(), which read the stale m_cwDelay=5 and snapped the Delay slider back, silently clobbering the user's setting and potentially enabling QSK mode on amplifiers that cannot tolerate it.

Apply the same optimistic-update pattern used by setCwBreakIn(), setCwIambic(), and setCwIambicMode(): write m_cwDelay = ms and emit phoneStateChanged() before sending the radio command.  When the radio echoes break_in_delay back via status, applyStatus() writes the same value (no-op) and the slider remains at the user's chosen position.