### PR TITLE
fix: hardware PTT into radio drives PC mic audio (#2373, fixes #2200)

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1764,6 +1764,7 @@ void RadioModel::onDisconnected()
     m_txRequested = false;
     m_cwKeyActive = false;
     m_cwxActive = false;
+    m_lastInterlockSource.clear();
     if (m_txAudioGate) {
         m_txAudioGate = false;
         emit txAudioGateChanged(false);
@@ -3370,6 +3371,15 @@ void RadioModel::onStatusReceived(const QString& object,
         // Parse interlock timing fields into TransmitModel (#498)
         m_transmitModel.applyInterlockStatus(kvs);
 
+        // Track PTT source (#2373). The radio reports source=SW for software
+        // MOX/CAT/xmit, and source=MIC|ACC|RCA for hardware-keyed PTT (mic
+        // PTT line, footswitch via ACC, RCA TXREQ). Field is not always
+        // present on every interlock status update, so persist the last
+        // seen value. Matches FlexLib v4.2.18 ParsePTTSource (Radio.cs:7932).
+        if (kvs.contains("source")) {
+            m_lastInterlockSource = kvs["source"].toUpper();
+        }
+
         if (kvs.contains("state")) {
             const QString state = kvs["state"].toUpper();
 
@@ -3379,7 +3389,21 @@ void RadioModel::onStatusReceived(const QString& object,
             m_radioTransmitting = radioTx;
             emit radioTransmittingChanged(radioTx);
 
-            if (!m_txOwnedByUs || (!m_txRequested && !m_cwKeyActive && !m_cwxActive && !m_transmitModel.isTuning())) {
+            // Hardware PTT into the radio (mic PTT line, ACC footswitch, RCA
+            // TXREQ) keys the radio without us calling setTransmit(), so
+            // m_txRequested stays false. Treat hardware sources as a
+            // legitimate "we own this TX" path alongside CW key, CWX, and
+            // tune. SW source still requires m_txRequested so the optimistic
+            // local-unkey behaviour from the TX_SYNC_FIX_REPORT is preserved
+            // (a stale state=TRANSMITTING after setTransmit(false) on SW
+            // source still falls through to the force-off branch).
+            const bool hardwarePtt = (m_lastInterlockSource == "MIC"
+                                      || m_lastInterlockSource == "ACC"
+                                      || m_lastInterlockSource == "RCA");
+
+            if (!m_txOwnedByUs ||
+                (!m_txRequested && !m_cwKeyActive && !m_cwxActive
+                 && !m_transmitModel.isTuning() && !hardwarePtt)) {
                 // Another client owns TX, or local unkey requested:
                 // force local TX/audio gate off through all interlock states.
                 m_transmitModel.setTransmitting(false);
@@ -3408,6 +3432,15 @@ void RadioModel::onStatusReceived(const QString& object,
                     m_txAudioGate = false;
                     emit txAudioGateChanged(false);
                 }
+            }
+
+            // Clear persisted PTT source once interlock confirms we're fully
+            // out of TX, so a stale hardware-PTT source can't outlive the
+            // actual key release if a later status update omits source=.
+            // (#2373)
+            if (state != "TRANSMITTING" && !state.contains("REQUESTED")
+                && !state.contains("DELAY")) {
+                m_lastInterlockSource.clear();
             }
         }
         // Emit TX ownership state for title bar indicator

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -542,6 +542,12 @@ private:
     bool        m_cwxActive{false};   // true while CWX send is in flight (#2047, #2097)
     bool        m_txAudioGate{false}; // actual TX audio gate state
     bool        m_radioTransmitting{false}; // raw interlock TX state, any owner
+    QString     m_lastInterlockSource;   // last seen interlock source= (#2373)
+                                         // SW/MIC/ACC/RCA/TUNE per FlexLib
+                                         // v4.2.18 ParsePTTSource. Persists
+                                         // across status updates that omit
+                                         // the field; cleared on non-TX
+                                         // interlock states and on disconnect.
     QStringList m_antList;
 
     QMap<QString, PanadapterModel*> m_panadapters;  // panId → model


### PR DESCRIPTION
## Summary

Fixes [#2373](https://github.com/ten9876/AetherSDR/issues/2373) (hardware PTT into radio doesn't drive forward RF when `mic_selection=PC`) and the duplicate [#2200](https://github.com/ten9876/AetherSDR/issues/2200) (Jerry KE9U's external PTT on FLEX-8400M).

When the user keyed the radio's hardware PTT (mic-line PTT, footswitch into ACC, RCA TXREQ), the carrier came up but no PC mic audio modulated it. The gate at `RadioModel.cpp:3382` forced `TransmitModel::setTransmitting(false)` whenever `m_txRequested` was false — even when the radio reported our client handle as the TX owner. `moxChanged(false)` propagated to `AudioEngine::setTransmitting(false)`, gating the mic capture path.

## Root cause

```cpp
if (!m_txOwnedByUs || (!m_txRequested && !m_cwKeyActive && !m_cwxActive && !m_transmitModel.isTuning())) {
    m_transmitModel.setTransmitting(false);
    if (m_txAudioGate) { m_txAudioGate = false; emit txAudioGateChanged(false); }
}
```

The bypasses (`m_cwKeyActive`, `m_cwxActive`, `isTuning()`) cover the existing non-`m_txRequested` TX paths, but hardware-keyed PTT had no such bypass. Effectively a latent bug: the PC-mic-with-hardware-PTT combination has likely never worked through this branch.

## Fix

Parse the radio's interlock `source=` field (`SW`/`MIC`/`ACC`/`RCA`/`TUNE` per FlexLib v4.2.18 [`ParsePTTSource`](https://github.com/flexradio/SmartSdrLib/blob/main/FlexLib/Radio.cs#L7932)), persist it across status updates that omit it, and add `MIC|ACC|RCA` to the bypass list:

```cpp
const bool hardwarePtt = (m_lastInterlockSource == "MIC"
                          || m_lastInterlockSource == "ACC"
                          || m_lastInterlockSource == "RCA");
if (!m_txOwnedByUs ||
    (!m_txRequested && !m_cwKeyActive && !m_cwxActive
     && !m_transmitModel.isTuning() && !hardwarePtt)) {
    // force off
}
```

`SW` source still requires `m_txRequested`, so the optimistic local-unkey behaviour from [`docs/TX_SYNC_FIX_REPORT.md`](docs/TX_SYNC_FIX_REPORT.md) is preserved — a stale `state=TRANSMITTING` after `setTransmit(false)` on SW source still falls through to the force-off branch (no SSB unkey-tail regression).

`m_lastInterlockSource` is cleared on:
- Disconnect (alongside the other TX flags)
- Interlock confirming a non-TX state (`RECEIVE`/`READY`/`NOT_READY`) — so a stale hardware source can't outlive the actual key release if a later status update omits `source=`.

## Validation against FlexLib v4.2.18

Validated against `/Users/patj/aether/FlexLib_API_v4.2.18.41174` reference docs:

- **`source=` field exists**: `Radio.cs:7932-7944` `ParsePTTSource` parses exactly these five values. Confirmed.
- **FlexLib's MOX gate**: `Radio.cs:7577` is `IsInterlockMox(state) && ShouldUpdateMoxOrTuneState(handle)`. `IsInterlockMox` accepts `Transmitting | PTTRequested | UnkeyRequested`. **FlexLib has no `m_txRequested` analogue** — it doesn't do AetherSDR's optimistic-off, so it doesn't need to distinguish SW from hardware sources for the gate.
- **Why we still need the `source` distinction**: AetherSDR diverges from FlexLib intentionally (per `TX_SYNC_FIX_REPORT.md`) for SSB unkey responsiveness. The `m_txRequested` flag is what guards optimistic-off — we can't drop it. The `source` field is exactly the right primitive to apply optimistic-off only to SW source while accepting interlock as authoritative for hardware sources.

## Timing / ordering preserved

The user explicitly asked that this not adversely impact panadapter/waterfall timing. Verified:

- **`radioTransmittingChanged`** is emitted at [`RadioModel.cpp:3380`](src/models/RadioModel.cpp#L3380) **unconditionally**, **before** any gate logic. This is what drives waterfall freeze, S-Meter mode, and the TX status indicator at [`MainWindow.cpp:2006-2024`](src/gui/MainWindow.cpp#L2006). The fix touches only the gate at line 3382 and below — `radioTransmittingChanged` emit timing is byte-identical to pre-fix behaviour.
- **`moxChanged` → `AudioEngine::setTransmitting`** ([`MainWindow.cpp:1965-1986`](src/gui/MainWindow.cpp#L1965)) now correctly fires `true` when hardware PTT keys the radio, so PC mic audio enables. This is the intended new behaviour.
- **`txAudioGateChanged`** remains a TX-OFF-only fallback at [`MainWindow.cpp:1991-2000`](src/gui/MainWindow.cpp#L1991) (the report explicitly warns against reintroducing TX-on wait-for-interlock for SSB).

## Acceptance criteria coverage (from issue [#2373](https://github.com/ten9876/AetherSDR/issues/2373))

- [x] `TransmitModel::isTransmitting()` returns true when radio reports our handle + TRANSMITTING with hardware source
- [x] `AetherialAudioStrip` TX indicator and Chain applet TX endpoint pulse (driven off `moxChanged`)
- [x] Forward RF appears (audio gate opens via `moxChanged` → `AudioEngine::setTransmitting(true)`)
- [x] MOX path unchanged (source=SW + `m_txRequested=true` → existing accept path)
- [x] Multi-Flex correctness (`!m_txOwnedByUs` outer check unchanged, hardwarePtt only relaxes the inner condition)
- [x] SSB local-unkey race protection preserved (SW source still gated on `m_txRequested`)

## Files changed

- `src/models/RadioModel.h` — add `m_lastInterlockSource` member
- `src/models/RadioModel.cpp` — parse `source=`, add `hardwarePtt` bypass, clear on non-TX/disconnect

40 insertions, 1 deletion. No protocol changes, no new dependencies.

## Test plan

- [ ] Hardware mic PTT with `mic_selection=PC` produces forward RF and lit Aetherial Audio TX indicator (primary acceptance — issues [#2200](https://github.com/ten9876/AetherSDR/issues/2200), [#2373](https://github.com/ten9876/AetherSDR/issues/2373))
- [ ] Footswitch via ACC TXREQ produces forward RF + audio
- [ ] RCA TXREQ produces forward RF + audio
- [ ] MOX button still works (no regression on SW path)
- [ ] CW key, CWX, TUNE still work (no regression on existing bypasses)
- [ ] SSB local unkey tail still immediate (no regression on optimistic-off)
- [ ] When another client owns TX (`!m_txOwnedByUs`), local indicators stay dim, no audio flows (Multi-Flex)
- [ ] Waterfall freeze/unfreeze timing unchanged on local MOX (sanity check that #2368 wasn't disturbed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)