### PR TITLE
fix: UI scale not applied on Windows; reset to 100% ignored on all platforms

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -204,8 +204,7 @@ int main(int argc, char* argv[])
 #elif defined(Q_OS_WIN)
         // On Windows, QStandardPaths::ConfigLocation maps to %APPDATA% — match that here
         // since QStandardPaths isn't available before QApplication.
-        QString settingsPath = QDir::fromNativeSeparators(
-                                   QString::fromLocal8Bit(qgetenv("APPDATA")))
+        QString settingsPath = QDir::fromNativeSeparators(qEnvironmentVariable("APPDATA"))
                                + "/AetherSDR/AetherSDR.settings";
 #else
         QString settingsPath = QDir::homePath() + "/.config/AetherSDR/AetherSDR.settings";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,6 +201,12 @@ int main(int argc, char* argv[])
     {
 #ifdef Q_OS_MAC
         QString settingsPath = QDir::homePath() + "/Library/Preferences/AetherSDR/AetherSDR.settings";
+#elif defined(Q_OS_WIN)
+        // On Windows, QStandardPaths::ConfigLocation maps to %APPDATA% — match that here
+        // since QStandardPaths isn't available before QApplication.
+        QString settingsPath = QDir::fromNativeSeparators(
+                                   QString::fromLocal8Bit(qgetenv("APPDATA")))
+                               + "/AetherSDR/AetherSDR.settings";
 #else
         QString settingsPath = QDir::homePath() + "/.config/AetherSDR/AetherSDR.settings";
 #endif
@@ -215,7 +221,9 @@ int main(int argc, char* argv[])
                 int end = data.indexOf('<', idx);
                 if (end > idx) {
                     int pct = data.mid(idx, end - idx).trimmed().toInt();
-                    if (pct > 0 && pct != 100)
+                    // Always set — even at 100% — so a restarted child process
+                    // overrides any QT_SCALE_FACTOR it inherited from its parent.
+                    if (pct > 0)
                         qputenv("QT_SCALE_FACTOR", QByteArray::number(pct / 100.0, 'f', 2));
                 }
             }


### PR DESCRIPTION
## Summary

- **Windows (broken entirely):** `main.cpp` was reading the settings file from `~/.config/AetherSDR/` before `QApplication` exists, but `AppSettings` on Windows writes to `%APPDATA%/AetherSDR/` via `QStandardPaths::ConfigLocation`. The file was never found, so `QT_SCALE_FACTOR` was never set — UI Scale did nothing on Windows. Fixed by adding a `Q_OS_WIN` branch that reads from `%APPDATA%`.
- **All platforms (reset to 100% silently ignored):** When restarting after resetting scale to 100%, the child process inherits `QT_SCALE_FACTOR` from the parent's environment. The old guard `pct != 100` skipped the `qputenv` call, so the inherited value persisted. Fixed by always writing `QT_SCALE_FACTOR` (including `"1.00"`) to guarantee the inherited value is overridden.

## Out of scope

macOS Retina compounding (`QT_SCALE_FACTOR` × `devicePixelRatio`) is a known follow-on issue — at non-100% scales on Retina Macs the factor doubles up. Tracked separately.

## Test plan

- [ ] **Windows:** set UI Scale to 125%, restart — window should be visibly larger; reset to 100%, restart — should return to normal size
- [ ] **Linux:** change scale, restart — confirm scale applies; reset to 100% from a scaled session, restart — confirm it returns to 1x
- [ ] **macOS:** basic smoke — scale changes should apply (Retina compounding is a known separate issue, not a regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)