### PR TITLE
Fix VFO filter width indicator showing 0.1 kHz too low (#2197)

### DIFF
--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -78,6 +78,10 @@ signals:
 public:
     void setInitialStepSize(int hz);
 
+    // Mode-aware filter width formatter, shared with VfoWidget so the two
+    // filter readouts stay in sync (#794, #1225, #2197).
+    static QString formatFilterWidth(int lo, int hi, const QString& mode = QString());
+
 protected:
     bool eventFilter(QObject* obj, QEvent* ev) override;
 
@@ -96,7 +100,6 @@ private:
     void updateOffsetDirButtons();
     void applyOffsetDir(const QString& dir);
     static QString formatHz(int hz);
-    static QString formatFilterWidth(int lo, int hi, const QString& mode = QString());
     static QString formatStepLabel(int hz);
 
     SliceModel* m_slice{nullptr};

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2,6 +2,7 @@
 #include "PhaseKnob.h"
 #include "ComboStyle.h"
 #include "GuardedSlider.h"
+#include "RxApplet.h"
 #include "SliceColorManager.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
@@ -3019,14 +3020,10 @@ void VfoWidget::updateFreqLabel()
 void VfoWidget::updateFilterLabel()
 {
     if (!m_slice) return;
-    // Always show the filter width (hi - lo), matching the filter preset
-    // buttons. Previously showed the edge value for USB/LSB, which
-    // disagreed with the highlighted button by ~100 Hz (#1225).
-    int w = m_slice->filterHigh() - m_slice->filterLow();
-    if (w >= 1000)
-        m_filterWidthLbl->setText(QString("%1K").arg(w / 1000.0, 0, 'f', 1));
-    else
-        m_filterWidthLbl->setText(QString::number(w));
+    // Single source of truth with the RX applet's filter readout to keep both
+    // labels in sync — they previously drifted (#794, #1225, #2197).
+    m_filterWidthLbl->setText(RxApplet::formatFilterWidth(
+        m_slice->filterLow(), m_slice->filterHigh(), m_slice->mode()));
 }
 
 void VfoWidget::relayoutDspGrid()


### PR DESCRIPTION
Closes #2197

## Summary

- `VfoWidget::updateFilterLabel()` computed `filterHigh - filterLow`, which for SSB/digital modes is ~100 Hz less than the nominal preset width because of the intentional low-cut (e.g. USB `lo=95, hi=2800` → "2.7K" displayed for what is actually a "2.8K" filter).
- The RX applet's filter readout already uses a mode-aware formatter, `RxApplet::formatFilterWidth()`. Promote it to public and have `VfoWidget` call it directly so the two labels share one source of truth.

## Why a shared call instead of duplicating the logic

The same drift caused [#794](https://github.com/ten9876/AetherSDR/issues/794), [#1225](https://github.com/ten9876/AetherSDR/issues/1225), and now [#2197](https://github.com/ten9876/AetherSDR/issues/2197). [PR #881](https://github.com/ten9876/AetherSDR/pull/881) made both readouts mode-aware in the same commit, then [61251e9](https://github.com/ten9876/AetherSDR/commit/61251e9) reverted only the VFO side to "match the buttons" — but the buttons were already mode-aware, so the revert created the opposite imbalance reported here. Calling one shared function is the smallest change that prevents the next swap.

## Test plan

- [ ] USB 2.8K preset → both VFO label and RX applet label read "2.8K" (was "2.7K" / "2.8K")
- [ ] LSB 2.7K preset → both read "2.7K"
- [ ] CW 500 preset → both read "500"
- [ ] AM 6.0K preset → both read "6.0K"
- [ ] FM (no presets) → both readouts behave consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)