### PR TITLE
fix(filter): mode-correct widen/narrow shortcuts on MIDI controllers for LSB (#2208)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10632,17 +10632,16 @@ void MainWindow::registerShortcutActions()
         });
 
     // ── Filter ──────────────────────────────────────────────────────────
+    // Step through the per-mode preset list via RxApplet so LSB/CWL/DIGL/RTTY
+    // get the correct edge moved (issue #2208 — naive +/-100 Hz on the upper
+    // edge collapsed the passband on lower-sideband modes).
     m_shortcutManager.registerAction("filter_widen", "Filter Widen", "Filter",
         QKeySequence(), [this]() {
-            auto* s = activeSlice();
-            if (!s) return;
-            s->setFilterWidth(s->filterLow(), s->filterHigh() + 100);
+            if (auto* rx = m_appletPanel->rxApplet()) rx->stepFilterWidth(+1);
         });
     m_shortcutManager.registerAction("filter_narrow", "Filter Narrow", "Filter",
         QKeySequence(), [this]() {
-            auto* s = activeSlice();
-            if (!s) return;
-            s->setFilterWidth(s->filterLow(), std::max(s->filterLow() + 50, s->filterHigh() - 100));
+            if (auto* rx = m_appletPanel->rxApplet()) rx->stepFilterWidth(-1);
         });
 
     // ── Tuning ──────────────────────────────────────────────────────────

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -29,7 +29,9 @@
 #include <QKeyEvent>
 #include <QDoubleSpinBox>
 #include <QDir>
+#include <algorithm>
 #include <cmath>
+#include <limits>
 
 // Slider that resets to a default value on double-click.
 // Extends GuardedSlider for controls-lock support (#745).
@@ -1539,6 +1541,23 @@ void RxApplet::applyFilterPreset(int widthHz)
     }
 
     m_slice->setFilterWidth(lo, hi);
+}
+
+void RxApplet::stepFilterWidth(int direction)
+{
+    if (!m_slice || m_filterWidths.isEmpty() || direction == 0) return;
+
+    const int currentWidth = m_slice->filterHigh() - m_slice->filterLow();
+    int idx = 0;
+    int bestDist = std::numeric_limits<int>::max();
+    for (int i = 0; i < m_filterWidths.size(); ++i) {
+        const int dist = std::abs(currentWidth - m_filterWidths[i]);
+        if (dist < bestDist) { bestDist = dist; idx = i; }
+    }
+    const int next = std::clamp(idx + (direction > 0 ? 1 : -1),
+                                0, static_cast<int>(m_filterWidths.size()) - 1);
+    if (next == idx && bestDist == 0) return;
+    applyFilterPreset(m_filterWidths[next]);
 }
 
 void RxApplet::updateFilterButtons()

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -47,6 +47,11 @@ public:
     void cycleStepUp();
     void cycleStepDown();
 
+    // Step the active slice's RX passband through the per-mode filter preset
+    // list. direction = +1 widens, -1 narrows. Routes through applyFilterPreset
+    // so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB) get mode-correct edge geometry.
+    void stepFilterWidth(int direction);
+
     // Connect to transmit model for QSK (break_in) indicator.
     void setTransmitModel(class TransmitModel* txModel);
 


### PR DESCRIPTION
## Summary
- Fixes #2208 — the `filter_widen` / `filter_narrow` shortcuts (also bound to the existing `global.filterWiden` / `global.filterNarrow` MIDI actions) only adjusted the upper passband edge by ±100 Hz. On LSB, CWL, DIGL, and RTTY the upper edge is fixed near 0 Hz, so "widen" actually collapsed the passband.
- Adds `RxApplet::stepFilterWidth(int direction)` that walks the active mode's existing per-mode filter-preset list and routes through `applyFilterPreset()`, which already handles mode-correct edge geometry for USB/LSB/DIGU/DIGL/RTTY/CW/AM/SAM/FM.
- Re-points both shortcuts at the new method. No new MIDI actions, no new settings, no protocol changes.

## Scope note
The original issue also requested an absolute CC→bandwidth mapping and a relative encoder variant. Those are deliberately out of scope here — this PR only fixes the existing controls so widen/narrow does the right thing on lower-sideband modes. The absolute / relative variants can be a follow-up.

## Test plan
- [ ] Build cleanly on macOS (verified locally).
- [ ] On USB: widen → next preset wider (e.g. 2400 → 2700 Hz). Narrow → previous preset.
- [ ] On LSB: widen actually widens the passband (low edge moves more negative) instead of collapsing it.
- [ ] On CW: widen → next CW preset (symmetric around carrier).
- [ ] On DIGL: widen → next preset, edges placed using `diglOffset` for narrow widths.
- [ ] Trigger via MIDI Learn'd `global.filterWiden` / `global.filterNarrow` and confirm same mode-correct behavior.
- [ ] At the widest preset, further widen is a no-op (clamped). At the narrowest, further narrow is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)