### PR TITLE
fix: PGXL OPERATE/STANDBY button stays stuck on OPERATE after entering Standby

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2803,12 +2803,23 @@ MainWindow::MainWindow(QWidget* parent)
         else
             setIndicatorHtml(m_pgxlIndicator, "AMP", "STANDBY", "#404858");
     };
-    connect(&m_radioModel, &RadioModel::ampStateChanged, this, updatePgxlStyle);
+    connect(&m_radioModel, &RadioModel::ampStateChanged, this, [this, updatePgxlStyle]() {
+        updatePgxlStyle();
+        // Sync the AmpApplet button — the direct PGXL TCP path may not deliver
+        // a state update fast enough, leaving the button stuck on the old state.
+        // RadioModel is authoritative; use it to keep the button consistent.
+        m_appletPanel->ampApplet()->setState(
+            m_radioModel.ampOperate() ? QStringLiteral("OPERATE") : QStringLiteral("STANDBY"));
+    });
 
     connect(&m_radioModel, &RadioModel::amplifierChanged, this, [this, updatePgxlStyle](bool present) {
         m_pgxlIndicator->setVisible(present);
         m_appletPanel->setAmpVisible(present);
-        if (present) updatePgxlStyle();
+        if (present) {
+            updatePgxlStyle();
+            m_appletPanel->ampApplet()->setState(
+                m_radioModel.ampOperate() ? QStringLiteral("OPERATE") : QStringLiteral("STANDBY"));
+        }
     });
     connect(&m_radioModel.meterModel(), &MeterModel::ampMetersChanged,
             this, [this](float fwdPwr, float swr, float temp) {


### PR DESCRIPTION
## Summary

- The AmpApplet OPERATE/STANDBY button was only updated via the direct PGXL TCP path (`PgxlConnection::statusUpdated`). When that path lagged or hadn't yet delivered an update, the button remained stuck green/OPERATE even after the amp entered STANDBY.
- Because the click handler reads `m_operateBtn->text()` to decide toggle direction, a stuck OPERATE button emitted `operateToggled(false)` → `operate=0` on click — sending another standby command instead of returning to OPERATE.
- Fix: wire `RadioModel::ampStateChanged` (the authoritative path) to also call `AmpApplet::setState()`, keeping the button in sync regardless of whether the direct TCP path delivers the update first. Same fix applied to `amplifierChanged` for initial amp detection.

## Test plan

- [ ] Connect with PGXL present and in OPERATE — button shows green OPERATE
- [ ] Click button → amp goes to STANDBY → button switches to grey STANDBY
- [ ] Click button again → amp returns to OPERATE → button switches back to green OPERATE
- [ ] Put amp in STANDBY via SmartSDR (external client) — AetherSDR button should update to grey STANDBY
- [ ] Verify PGXL indicator label also tracks correctly in all transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)