### PR TITLE
fix(strip): cap initial Channel Strip height on sub-4K displays

### DIFF
--- a/src/gui/AetherialAudioStrip.cpp
+++ b/src/gui/AetherialAudioStrip.cpp
@@ -1,5 +1,8 @@
 #include "AetherialAudioStrip.h"
 
+#include <QGuiApplication>
+#include <QScreen>
+
 #include "AetherDspWidget.h"
 #include "StripChainWidget.h"
 #include "StripRxChainWidget.h"
@@ -78,7 +81,17 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
     // panel grid below the chain row scrolls vertically when the
     // window is shorter than the natural content height.
     setMinimumSize(1140, 900);
-    resize(1140, 1620);
+    // The strip's natural content is ~1620 px tall and assumes a 4K
+    // (or larger) display.  On 1080p / 1440p, opening at 1620 puts the
+    // bottom edge offscreen with the resize grip unreachable.  Cap to
+    // 960 on anything below ~4K so the bottom stays grabbable; users
+    // can grow the window manually after open.
+    int initialHeight = 1620;
+    if (auto* screen = QGuiApplication::primaryScreen()) {
+        if (screen->availableGeometry().height() < 2000)
+            initialHeight = 960;
+    }
+    resize(1140, initialHeight);
 
     // Track mouse without buttons pressed so the resize cursor updates
     // while hovering the bare margin around the embedded grid.


### PR DESCRIPTION
The Aetherial Audio Channel Strip's natural content height is ~1620 px
and was opening at that on every display.  On 1080p the bottom edge
landed offscreen, and since users couldn't grab the bottom of the
window there was no obvious way to resize it back into view.

Query QGuiApplication::primaryScreen()->availableGeometry().height()
at construction time and cap the initial height to 960 px when the
available height is under ~4K (2000 px threshold catches 1080p / 1440p
/ 1600p; 4K and 5K still get the natural 1620).  The minimum size of
1140×900 is unchanged, so users on small displays can still grow the
window manually — the cap only affects first-open height.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
