### PR TITLE
ci: fix Windows installer Qt arch for 6.8 LTS (win64_msvc2022_64)

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -24,7 +24,8 @@ jobs:
           version: '6.8.*'
           host: 'windows'
           target: 'desktop'
-          arch: 'win64_msvc2019_64'
+          # Qt 6.8 LTS dropped MSVC 2019 builds — arch must be msvc2022.
+          arch: 'win64_msvc2022_64'
           modules: 'qtmultimedia qtserialport qtwebsockets qtshadertools'
 
       - name: Install Ninja, Inno Setup, and LLVM


### PR DESCRIPTION
The v0.9.8 release tag triggered the Windows Installer workflow which
failed during 'Install Qt6' with:

  ERROR : The packages ['qt_base', 'qtmultimedia', 'qtserialport',
  'qtshadertools', 'qtwebsockets'] were not found while parsing XML
  of package information!

aqtinstall couldn't find the requested arch 'win64_msvc2019_64' for
Qt 6.8.3.  Qt 6.8 LTS dropped the MSVC 2019 build channel — the only
supported Windows arch for 6.8.x is 'win64_msvc2022_64'.

This is the same failure mode that hit v0.9.7's first tag attempt;
the recipe matches: fix workflow + move tag forward to a commit that
includes the fix.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
