### PR TITLE
fix(windows): correct settings path so UI scaling works on Windows

### DIFF
--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -43,9 +43,10 @@ void AppSettings::migrateSettingsPath()
     if (QFile::exists(m_filePath))
         return;  // already at the correct location
 
-#ifdef Q_OS_WIN
-    // Before this fix, ConfigLocation on Windows Qt 6 resolved to
-    // %LOCALAPPDATA%/AetherSDR/AetherSDR (OrgName/AppName), so appending
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    // On Windows and macOS, Qt 6's ConfigLocation resolves to AppConfigLocation
+    // (%LOCALAPPDATA%/AetherSDR/AetherSDR on Windows,
+    //  ~/Library/Preferences/AetherSDR/AetherSDR on macOS), so appending
     // "/AetherSDR" produced a triple-nested path. Move the file if found there.
     const QString oldPath =
         QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation)

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -21,11 +21,43 @@ AppSettings& AppSettings::instance()
 
 AppSettings::AppSettings()
 {
+    // GenericConfigLocation gives a plain base dir (no org/app suffix) on all
+    // platforms: ~/.config on Linux/macOS, %LOCALAPPDATA% on Windows.
+    // ConfigLocation on Windows Qt 6 resolves to AppConfigLocation
+    // (%LOCALAPPDATA%/OrgName/AppName), so appending "/AetherSDR" produces a
+    // triple-nested path. GenericConfigLocation avoids this and stays consistent
+    // with the log-dir path used in main.cpp.
     const QString configDir =
-        QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
+        QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
         + "/AetherSDR";
     QDir().mkpath(configDir);
     m_filePath = configDir + "/AetherSDR.settings";
+
+    migrateSettingsPath();
+}
+
+// ─── Path migration ───────────────────────────────────────────────────────────
+
+void AppSettings::migrateSettingsPath()
+{
+    if (QFile::exists(m_filePath))
+        return;  // already at the correct location
+
+#ifdef Q_OS_WIN
+    // Before this fix, ConfigLocation on Windows Qt 6 resolved to
+    // %LOCALAPPDATA%/AetherSDR/AetherSDR (OrgName/AppName), so appending
+    // "/AetherSDR" produced a triple-nested path. Move the file if found there.
+    const QString oldPath =
+        QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation)
+        + "/AetherSDR/AetherSDR.settings";
+    if (QFile::exists(oldPath)) {
+        if (QFile::rename(oldPath, m_filePath)) {
+            qDebug() << "AppSettings: migrated settings from" << oldPath << "to" << m_filePath;
+        } else {
+            qWarning() << "AppSettings: failed to migrate from" << oldPath << "to" << m_filePath;
+        }
+    }
+#endif
 }
 
 // ─── Load ─────────────────────────────────────────────────────────────────────

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -7,7 +7,8 @@
 namespace AetherSDR {
 
 // XML-based application settings, structured to match SmartSDR's SSDR.settings.
-// Stored at ~/.config/AetherSDR/AetherSDR.settings.
+// Stored at ~/.config/AetherSDR/AetherSDR.settings (Linux/macOS) or
+// %LOCALAPPDATA%/AetherSDR/AetherSDR.settings (Windows).
 //
 // Usage:
 //   auto& s = AppSettings::instance();
@@ -57,6 +58,10 @@ private:
     ~AppSettings() = default;
     AppSettings(const AppSettings&) = delete;
     AppSettings& operator=(const AppSettings&) = delete;
+
+    // One-time path migration: on Windows, Qt 6's ConfigLocation produced a
+    // triple-nested path. Move the file to the correct GenericConfigLocation.
+    void migrateSettingsPath();
 
     QString m_filePath;
     QMap<QString, QString> m_settings;          // top-level key=value

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -202,9 +202,11 @@ int main(int argc, char* argv[])
 #ifdef Q_OS_MAC
         QString settingsPath = QDir::homePath() + "/Library/Preferences/AetherSDR/AetherSDR.settings";
 #elif defined(Q_OS_WIN)
-        // On Windows, QStandardPaths::ConfigLocation maps to %APPDATA% — match that here
-        // since QStandardPaths isn't available before QApplication.
-        QString settingsPath = QDir::fromNativeSeparators(qEnvironmentVariable("APPDATA"))
+        // Qt 6 maps QStandardPaths::ConfigLocation to %LOCALAPPDATA% on Windows
+        // (changed from %APPDATA% in Qt 5). AppSettings uses ConfigLocation, so
+        // we must read from the same base. QStandardPaths isn't available before
+        // QApplication, so fall back to the env var directly.
+        QString settingsPath = QDir::fromNativeSeparators(qEnvironmentVariable("LOCALAPPDATA"))
                                + "/AetherSDR/AetherSDR.settings";
 #else
         QString settingsPath = QDir::homePath() + "/.config/AetherSDR/AetherSDR.settings";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -202,10 +202,9 @@ int main(int argc, char* argv[])
 #ifdef Q_OS_MAC
         QString settingsPath = QDir::homePath() + "/Library/Preferences/AetherSDR/AetherSDR.settings";
 #elif defined(Q_OS_WIN)
-        // Qt 6 maps QStandardPaths::ConfigLocation to %LOCALAPPDATA% on Windows
-        // (changed from %APPDATA% in Qt 5). AppSettings uses ConfigLocation, so
-        // we must read from the same base. QStandardPaths isn't available before
-        // QApplication, so fall back to the env var directly.
+        // AppSettings uses GenericConfigLocation (%LOCALAPPDATA%) + "/AetherSDR".
+        // QStandardPaths isn't available before QApplication, so we reproduce
+        // the path manually using the LOCALAPPDATA env var.
         QString settingsPath = QDir::fromNativeSeparators(qEnvironmentVariable("LOCALAPPDATA"))
                                + "/AetherSDR/AetherSDR.settings";
 #else


### PR DESCRIPTION
## Summary

- `QStandardPaths::ConfigLocation` on Windows Qt 6 resolves to `AppConfigLocation` (`%LOCALAPPDATA%/OrgName/AppName`). AppSettings was appending `/AetherSDR` on top of that, producing a triple-nested path: `%LOCALAPPDATA%\AetherSDR\AetherSDR\AetherSDR\AetherSDR.settings`
- `main.cpp` read `UiScalePercent` from `%LOCALAPPDATA%\AetherSDR\AetherSDR.settings` (two levels up), never found the value, and never set `QT_SCALE_FACTOR` — so UI scaling had zero effect on Windows despite the setting being saved correctly
- Switch `AppSettings` to `GenericConfigLocation` (`%LOCALAPPDATA%` on Windows, `~/.config` on Linux/macOS — no org/app suffix), consistent with the log-dir path already used in `main.cpp`
- Add a one-time `migrateSettingsPath()` that moves the file from the old triple-nested path on first launch so existing Windows users don't lose their settings

## How it was diagnosed

Confirmed the actual settings file location on a Windows machine:
```
%LOCALAPPDATA%\AetherSDR\AetherSDR\AetherSDR\AetherSDR.settings  <- where AppSettings wrote
%LOCALAPPDATA%\AetherSDR\AetherSDR.settings                       <- where main.cpp read
```
The file contained `<UiScalePercent>175</UiScalePercent>` -- proving the setting was saved, just never read back by main.cpp at startup.

## Test plan

- [ ] Build and run on Windows -- change UI scale, restart, confirm the window actually resizes
- [ ] Verify existing Windows settings are migrated (old triple-nested file disappears, new path has the settings)
- [ ] Confirm Linux behavior is unchanged (path stays `~/.config/AetherSDR/AetherSDR.settings`)

Generated with [Claude Code](https://claude.com/claude-code)