### PR TITLE
fix(amp): forward radio amplifier telemetry to AmpApplet (id, vac, meffa, temp)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2788,6 +2788,24 @@ MainWindow::MainWindow(QWidget* parent)
     connect(&m_pgxlConn, &PgxlConnection::connected, this, [this]() {
         qDebug() << "PGXL direct connection established, version:" << m_pgxlConn.version();
     });
+    // Radio amplifier status → AmpApplet telemetry (fallback + parallel path).
+    // The radio proxies PGXL telemetry fields (id, vac, meffa, temp, state) in its
+    // amplifier status messages. This ensures the applet updates even when the direct
+    // PGXL TCP connection isn't established, and stays in sync when both paths are active.
+    connect(&m_radioModel, &RadioModel::ampTelemetryUpdated,
+            this, [this](const QMap<QString, QString>& kvs) {
+        auto* amp = m_appletPanel->ampApplet();
+        if (kvs.contains("temp"))
+            amp->setTemp(kvs["temp"].toFloat());
+        if (kvs.contains("id"))
+            amp->setDrainCurrent(kvs["id"].toFloat());
+        if (kvs.contains("vac"))
+            amp->setMainsVoltage(kvs["vac"].toInt());
+        if (kvs.contains("state"))
+            amp->setState(kvs["state"]);
+        if (kvs.contains("meffa"))
+            amp->setMeff(kvs["meffa"]);
+    });
     // OPERATE button → PGXL standby/operate command via radio amplifier API
     connect(m_appletPanel->ampApplet(), &AmpApplet::operateToggled, this, [this](bool on) {
         if (!m_radioModel.ampHandle().isEmpty())

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2788,12 +2788,16 @@ MainWindow::MainWindow(QWidget* parent)
     connect(&m_pgxlConn, &PgxlConnection::connected, this, [this]() {
         qDebug() << "PGXL direct connection established, version:" << m_pgxlConn.version();
     });
-    // Radio amplifier status → AmpApplet telemetry (fallback + parallel path).
+    // Radio amplifier status → AmpApplet telemetry (fallback path).
     // The radio proxies PGXL telemetry fields (id, vac, meffa, temp, state) in its
-    // amplifier status messages. This ensures the applet updates even when the direct
-    // PGXL TCP connection isn't established, and stays in sync when both paths are active.
+    // amplifier status messages, so the applet keeps updating even when the direct
+    // PGXL TCP connection isn't established.  When direct TCP IS connected, that
+    // path is faster and higher-precision (the radio rebroadcast may round/lag),
+    // so we skip the radio fallback to avoid display jitter from two paths
+    // alternately writing slightly-different values.
     connect(&m_radioModel, &RadioModel::ampTelemetryUpdated,
             this, [this](const QMap<QString, QString>& kvs) {
+        if (m_pgxlConn.isConnected()) return;
         auto* amp = m_appletPanel->ampApplet();
         if (kvs.contains("temp"))
             amp->setTemp(kvs["temp"].toFloat());

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3238,6 +3238,10 @@ void RadioModel::onStatusReceived(const QString& object,
                         emit ampStateChanged();
                     }
                 }
+                // Forward the full KVS so the GUI can update telemetry fields
+                // (id/drain current, vac/mains voltage, meffa, temp) without
+                // requiring a direct PGXL TCP connection.
+                emit ampTelemetryUpdated(kvs);
             }
         }
         return;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -341,6 +341,9 @@ signals:
     // Emitted when a power amplifier (e.g. PGXL) is detected or lost.
     void amplifierChanged(bool present);
     void ampStateChanged();   // amplifier operate/bypass changed
+    // Raw KVS from the radio's amplifier status message (id, vac, meffa, temp, state, …).
+    // Emitted on every update so the GUI can refresh telemetry without a direct PGXL connection.
+    void ampTelemetryUpdated(const QMap<QString, QString>& kvs);
     void memoryChanged(int index);
     void memoryRemoved(int index);
     void memoriesCleared();


### PR DESCRIPTION
## Summary

- `RadioModel`'s amplifier status handler only extracted `state` from the radio's `S<handle>|amplifier ...` KVS, silently dropping `id` (drain current), `vac` (mains voltage), `meffa`, and `temp`
- Those fields were only reaching `AmpApplet` via the direct PGXL TCP connection — meaning any setup where that connection wasn't established (no IP in amplifier status, network path blocked, or radio-only path) showed `Amps: 0.0A` and a stale `MEffA` label permanently
- Add `ampTelemetryUpdated(const QMap<QString,QString>& kvs)` signal to `RadioModel`, emitted on every matching amplifier handle update
- Wire it in `MainWindow` with the same field mapping already used for `PgxlConnection::statusUpdated` — both paths now update `AmpApplet` independently

## How it was diagnosed

The PGXL controller app showed `Id 3` (3A drain current) while `AmpApplet` showed `Amps: 0.0A`. Tracing the signal path: `PgxlConnection::statusUpdated` correctly forwards `id`/`meffa`/`vac` to the applet, but the radio's own amplifier status messages (which proxy the same telemetry) were only processed for the `state` field in `RadioModel` — everything else was dropped before reaching the GUI.

## Test plan

- [ ] Connect with PGXL via radio only (no direct TCP) — confirm Amps and MEffA update during transmit
- [ ] Connect with both radio and direct PGXL TCP — confirm both paths stay consistent
- [ ] Confirm Fwd Pwr / SWR / Temp gauges still update (unaffected path via `MeterModel::ampMetersChanged`)

Generated with [Claude Code](https://claude.com/claude-code)