### PR TITLE
fix(midi): Toggle params revert on release; add modeUp/Down; expand category filter

### DIFF
--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -413,13 +413,12 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2,
 
         // For toggles: use > 0.5 threshold; for triggers: only fire on > 0.5
         if (param->type == MidiParamType::Toggle) {
-            // NoteOn = toggle (sentinel -1 tells MainWindow to flip current state)
-            // CC = direct threshold
-            if (msgType == MidiBinding::NoteOn) {
-                scaled = -1.0f;  // sentinel: MainWindow reads getter and toggles (#502)
-            } else {
-                scaled = (value > 0.5f) ? 1.0f : 0.0f;
-            }
+            // Toggle on any rising edge (NoteOn press, CC value > 0.5).
+            // Silently ignore falling edges (NoteOff, NoteOn vel=0, CC=0)
+            // so the control doesn't revert to off the moment the button
+            // is released.
+            if (value < 0.5f) return;
+            scaled = -1.0f;  // sentinel: MainWindow reads getter and flips (#502)
         } else if (param->type == MidiParamType::Trigger) {
             if (value < 0.5f) return; // only fire on press, not release
             scaled = 1.0f;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -13058,6 +13058,27 @@ void MainWindow::registerMidiParams()
     reg("global.bandDown", "Band Down", "Global", P::Trigger, 0, 1,
         [cycleBand](float) { cycleBand(-1); });
 
+    // ── Mode Up / Down (cycle through the mode list above) ───────────
+    static constexpr int kModeCount =
+        static_cast<int>(sizeof(kModes) / sizeof(const char*));
+    auto cycleMode = [this, fireShortcut](int direction) {
+        // Find current mode index from the active slice; if no match, start at 0.
+        int currentIdx = 0;
+        if (auto* s = activeSlice()) {
+            const QString curMode = s->mode().toUpper();
+            for (int i = 0; i < kModeCount; ++i) {
+                if (curMode == QLatin1String(kModes[i])) { currentIdx = i; break; }
+            }
+        }
+        const int next = (currentIdx + direction + kModeCount) % kModeCount;
+        const QString idShort = QString("mode_%1").arg(QString(kModes[next]).toLower());
+        fireShortcut(idShort.toUtf8().constData());
+    };
+    reg("global.modeUp", "Mode Up", "Global", P::Trigger, 0, 1,
+        [cycleMode](float) { cycleMode(+1); });
+    reg("global.modeDown", "Mode Down", "Global", P::Trigger, 0, 1,
+        [cycleMode](float) { cycleMode(-1); });
+
     // ── Slice / display / filter / DSP triggers (mirror keyboard) ──────
     reg("global.splitToggle", "Split Toggle", "Slice", P::Trigger, 0, 1,
         [fireShortcut](float) { fireShortcut("split_toggle"); });

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -140,7 +140,9 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         auto* addRow = new QHBoxLayout;
         m_categoryCombo = new QComboBox;
         m_categoryCombo->setStyleSheet(kComboStyle);
-        m_categoryCombo->addItems({"All", "RX", "TX", "Phone/CW", "EQ", "Global"});
+        m_categoryCombo->addItems({"All", "RX", "TX", "Phone/CW", "EQ",
+                                   "Global", "Mode", "Band", "Filter",
+                                   "Slice", "Display", "Frequency"});
         addRow->addWidget(m_categoryCombo);
 
         m_paramCombo = new QComboBox;


### PR DESCRIPTION
## Summary

- **Toggle params behaved as momentary** (squelch, NB, NR, ANF, mute, tune lock — any `P::Toggle` param). Root cause: the NoteOff-fallthrough path in `MidiControlManager::onMidiMessage`, designed for Gate/CW params, was also matching Toggle NoteOn bindings on button release, emitting `scaled=0.0f` and reverting the state. CC-mapped toggles had the same problem (directly followed the CC value). Fix: for `MidiParamType::Toggle`, ignore any falling edge (`value < 0.5f`) and always use the `-1.0f` toggle sentinel on rising edges, regardless of message type.

- **`global.modeUp` / `global.modeDown` were not implemented.** Added both as `P::Trigger` / category `"Global"` params in `registerMidiParams()`. They cycle through the same 12-entry `kModes[]` array used by the individual mode triggers, reading the active slice's current mode to find the starting index.

- **MIDI Mapping Dialog category filter was missing six entries.** Mode, Band, Filter, Slice, Display, and Frequency params existed and worked once bound, but couldn't be found by filtering — users had to scroll through "All". Added all six categories to the combo.

## Test plan

- [ ] Map a MIDI button (NoteOn/NoteOff) to Squelch Enable — single press toggles on, second press toggles off, no revert on release
- [ ] Map a CC button (127 while held / 0 on release) to Squelch Enable — same toggle behaviour expected
- [ ] Confirm NB, NR, ANF, Audio Mute, Tune Lock all toggle correctly under the same conditions
- [ ] Map a button to Mode Up / Mode Down — verify cycling USB→LSB→CW→… and wrap-around
- [ ] Open MIDI Mapping Dialog — confirm Mode/Band/Filter/Slice/Display/Frequency appear in the category dropdown and filter correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)