### PR TITLE
Make popout windows follow frameless setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,6 +536,7 @@ set(GUI_SOURCES
     src/gui/DxClusterDialog.cpp
     src/gui/CwxPanel.cpp
     src/gui/BandStackPanel.cpp
+    src/gui/FramelessWindowTitleBar.cpp
     src/gui/FramelessResizer.cpp
     src/gui/PanFloatingWindow.cpp
     src/gui/DvkPanel.cpp

--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -162,9 +162,8 @@ void AetherDspDialog::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = Qt::Dialog;
-    if (on)
-        flags |= Qt::FramelessWindowHint;
+    Qt::WindowFlags flags = windowFlags();
+    flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);
     if (m_titleBar)

--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -162,7 +162,7 @@ void AetherDspDialog::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = windowFlags();
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);

--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -1,5 +1,6 @@
 #include "AetherDspDialog.h"
 #include "AetherDspWidget.h"
+#include "core/AppSettings.h"
 
 #include <QEvent>
 #include <QHBoxLayout>
@@ -19,7 +20,6 @@ AetherDspDialog::AetherDspDialog(AudioEngine* audio, QWidget* parent)
     : QDialog(parent)
 {
     setWindowTitle("AetherDSP Settings");
-    setWindowFlag(Qt::FramelessWindowHint, true);
     setMouseTracking(true);
     setStyleSheet("QDialog { background: #0f0f1a; color: #c8d8e8; }");
 
@@ -152,6 +152,25 @@ AetherDspDialog::AetherDspDialog(AudioEngine* audio, QWidget* parent)
             this,    &AetherDspDialog::nr4MaskingDepthChanged);
     connect(m_widget, &AetherDspWidget::nr4SuppressionChanged,
             this,    &AetherDspDialog::nr4SuppressionChanged);
+
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+}
+
+void AetherDspDialog::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = Qt::Dialog;
+    if (on)
+        flags |= Qt::FramelessWindowHint;
+    setWindowFlags(flags);
+    setGeometry(geom);
+    if (m_titleBar)
+        m_titleBar->setVisible(on);
+    if (wasVisible)
+        show();
 }
 
 void AetherDspDialog::syncFromEngine()
@@ -170,6 +189,7 @@ void AetherDspDialog::selectTab(const QString& name)
 
 Qt::Edges AetherDspDialog::edgesAt(const QPoint& pos) const
 {
+    if (!(windowFlags() & Qt::FramelessWindowHint)) return {};
     if (isMaximized() || isFullScreen()) return {};
     Qt::Edges edges;
     if (pos.x() <= kResizeMargin)              edges |= Qt::LeftEdge;

--- a/src/gui/AetherDspDialog.h
+++ b/src/gui/AetherDspDialog.h
@@ -20,6 +20,8 @@ class AetherDspDialog : public QDialog {
 public:
     explicit AetherDspDialog(AudioEngine* audio, QWidget* parent = nullptr);
 
+    void setFramelessMode(bool on);
+
     // Sync UI from current AudioEngine state.
     void syncFromEngine();
 

--- a/src/gui/AetherialAudioStrip.cpp
+++ b/src/gui/AetherialAudioStrip.cpp
@@ -695,10 +695,8 @@ void AetherialAudioStrip::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = Qt::Window;
-    if (on) {
-        flags |= Qt::FramelessWindowHint;
-    }
+    Qt::WindowFlags flags = windowFlags();
+    flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);
     if (m_titleBar) {

--- a/src/gui/AetherialAudioStrip.cpp
+++ b/src/gui/AetherialAudioStrip.cpp
@@ -695,7 +695,7 @@ void AetherialAudioStrip::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = windowFlags();
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Window;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);

--- a/src/gui/AetherialAudioStrip.cpp
+++ b/src/gui/AetherialAudioStrip.cpp
@@ -62,7 +62,7 @@ constexpr int kResizeMargin = 6;
 }
 
 AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
-    : QWidget(parent, Qt::Window | Qt::FramelessWindowHint)
+    : QWidget(parent, Qt::Window)
     , m_audio(engine)
     , m_presets(new ChannelStripPresets(engine, this))
 {
@@ -188,6 +188,7 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
     auto* body = new QVBoxLayout(content);
     body->setContentsMargins(8, 0, 8, 8);
     body->setSpacing(8);
+    m_bodyLayout = body;
     root->addWidget(content, 1);
 
     // Top: horizontal CHAIN strip + record/play buttons inline at the
@@ -671,6 +672,8 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
     }
 
     restoreGeometryFromSettings();
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
 
     // Restore last selected mode (#2425).  Default = TX so users on
     // upgrade keep the existing behaviour.  Toggling the button fires
@@ -686,6 +689,28 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
 }
 
 AetherialAudioStrip::~AetherialAudioStrip() = default;
+
+void AetherialAudioStrip::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = Qt::Window;
+    if (on) {
+        flags |= Qt::FramelessWindowHint;
+    }
+    setWindowFlags(flags);
+    setGeometry(geom);
+    if (m_titleBar) {
+        m_titleBar->setVisible(on);
+    }
+    if (m_bodyLayout) {
+        m_bodyLayout->setContentsMargins(8, on ? 0 : 8, 8, 8);
+    }
+    if (wasVisible) {
+        show();
+    }
+}
 
 void AetherialAudioStrip::setTxFilterCutoffs(int lowHz, int highHz)
 {
@@ -822,6 +847,8 @@ void AetherialAudioStrip::hideEvent(QHideEvent* ev)
 
 Qt::Edges AetherialAudioStrip::edgesAt(const QPoint& pos) const
 {
+    if (!(windowFlags() & Qt::FramelessWindowHint))
+        return {};
     if (isMaximized() || isFullScreen())
         return {};
 

--- a/src/gui/AetherialAudioStrip.h
+++ b/src/gui/AetherialAudioStrip.h
@@ -9,6 +9,7 @@ class QPushButton;
 class QComboBox;
 class QLabel;
 class QStackedWidget;
+class QVBoxLayout;
 
 namespace AetherSDR {
 
@@ -46,6 +47,8 @@ class AetherialAudioStrip : public QWidget {
 public:
     explicit AetherialAudioStrip(AudioEngine* engine, QWidget* parent = nullptr);
     ~AetherialAudioStrip() override;
+
+    void setFramelessMode(bool on);
 
     // Forward radio TX filter cutoffs to the embedded EQ canvas so the
     // dashed yellow filter-edge guide lines render here too.  MainWindow
@@ -170,6 +173,7 @@ private:
     AudioEngine*         m_audio{nullptr};
     ChannelStripPresets* m_presets{nullptr};
     QWidget*             m_titleBar{nullptr};   // custom inline ContainerTitleBar-styled bar
+    QVBoxLayout*         m_bodyLayout{nullptr};
     QLabel*              m_titleLbl{nullptr};   // title text — toggles "— TX" / "— RX" suffix
     StripChainWidget*    m_chain{nullptr};
     StripRxChainWidget*  m_chainRx{nullptr};

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -661,7 +661,7 @@ void ConnectionPanel::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = windowFlags();
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -661,9 +661,8 @@ void ConnectionPanel::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = Qt::Dialog;
-    if (on)
-        flags |= Qt::FramelessWindowHint;
+    Qt::WindowFlags flags = windowFlags();
+    flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);
     if (m_titleBar)

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -1,6 +1,8 @@
 #include "ConnectionPanel.h"
 #include "core/AppSettings.h"
 #include "core/NetworkPathResolver.h"
+#include "FramelessResizer.h"
+#include "FramelessWindowTitleBar.h"
 
 #include <QAbstractItemView>
 #include <QFormLayout>
@@ -220,9 +222,20 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
         "QCheckBox::indicator:checked { border: 2px solid #8cc8ff; background: #2f71b6; }"
         "QCheckBox::indicator:disabled { border-color: #405262; background: #10161d; }";
 
-    auto* root = new QVBoxLayout(this);
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    auto* titleBar = new FramelessWindowTitleBar(QStringLiteral("Connect to Radio"), this);
+    m_titleBar = titleBar;
+    outer->addWidget(titleBar);
+
+    auto* content = new QWidget(this);
+    auto* root = new QVBoxLayout(content);
     root->setContentsMargins(12, 12, 12, 12);
     root->setSpacing(10);
+    m_rootLayout = root;
+    outer->addWidget(content, 1);
 
     auto* titleLabel = new QLabel("Connect to a Radio", this);
     titleLabel->setStyleSheet(
@@ -638,6 +651,27 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     updateLocalPageState();
     updateSmartLinkUi();
     updateManualAdvancedVisibility();
+    FramelessResizer::install(this);
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+}
+
+void ConnectionPanel::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = Qt::Dialog;
+    if (on)
+        flags |= Qt::FramelessWindowHint;
+    setWindowFlags(flags);
+    setGeometry(geom);
+    if (m_titleBar)
+        m_titleBar->setVisible(on);
+    if (m_rootLayout)
+        m_rootLayout->setContentsMargins(12, on ? 10 : 12, 12, 12);
+    if (wasVisible)
+        show();
 }
 
 void ConnectionPanel::setConnected(bool connected)

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -15,6 +15,8 @@
 #include <QStackedWidget>
 #include <QToolButton>
 
+class QVBoxLayout;
+
 namespace AetherSDR {
 
 // Novice-first dialog for local, SmartLink, and manual/VPN radio connections.
@@ -24,6 +26,7 @@ class ConnectionPanel : public QWidget {
 public:
     explicit ConnectionPanel(QWidget* parent = nullptr);
 
+    void setFramelessMode(bool on);
     void setConnected(bool connected);
     void setStatusText(const QString& text);
     void probeRadio(const QString& ip);
@@ -86,6 +89,9 @@ private:
     void setManualMessage(const QString& text, bool error = false);
     QString formatLocalRadioLabel(const RadioInfo& radio) const;
     QString formatWanRadioLabel(const WanRadioInfo& radio) const;
+
+    QWidget*     m_titleBar{nullptr};
+    QVBoxLayout* m_rootLayout{nullptr};
 
     QButtonGroup* m_modeButtons{nullptr};
     QStackedWidget* m_modeStack{nullptr};

--- a/src/gui/EditorFramelessTitleBar.cpp
+++ b/src/gui/EditorFramelessTitleBar.cpp
@@ -10,6 +10,7 @@ namespace AetherSDR {
 EditorFramelessTitleBar::EditorFramelessTitleBar(QWidget* parent)
     : QWidget(parent)
 {
+    setObjectName(QStringLiteral("editorFramelessTitleBar"));
     setFixedHeight(20);
     setStyleSheet("background: #08121d;");
 

--- a/src/gui/FramelessWindowTitleBar.cpp
+++ b/src/gui/FramelessWindowTitleBar.cpp
@@ -1,0 +1,132 @@
+#include "FramelessWindowTitleBar.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMouseEvent>
+#include <QPushButton>
+#include <QWindow>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr const char* kBarStyle =
+    "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
+    "stop:0 #5a7494, stop:0.5 #384e68, stop:1 #1e2e3e); "
+    "border-bottom: 1px solid #0a1a28; }";
+
+constexpr const char* kTitleStyle =
+    "QLabel { background: transparent; color: #e0ecf4;"
+    " font-size: 10px; font-weight: bold; }";
+
+constexpr const char* kButtonStyle =
+    "QPushButton { background: transparent; border: none;"
+    " color: #c8d8e8; font-size: 11px; font-weight: bold;"
+    " padding: 0px 4px; }"
+    "QPushButton:hover { color: #ffffff; }";
+
+constexpr const char* kCloseButtonStyle =
+    "QPushButton { background: transparent; border: none;"
+    " color: #c8d8e8; font-size: 11px; font-weight: bold;"
+    " padding: 0px 4px; }"
+    "QPushButton:hover { color: #ffffff; background: #cc2030; }";
+
+}
+
+FramelessWindowTitleBar::FramelessWindowTitleBar(const QString& title, QWidget* parent)
+    : QWidget(parent)
+{
+    setFixedHeight(18);
+    setAttribute(Qt::WA_StyledBackground, true);
+    setStyleSheet(kBarStyle);
+
+    auto* row = new QHBoxLayout(this);
+    row->setContentsMargins(6, 0, 2, 0);
+    row->setSpacing(4);
+
+    auto* grip = new QLabel(QString::fromUtf8("\xe2\x8b\xae\xe2\x8b\xae"), this);
+    grip->setStyleSheet(
+        "QLabel { background: transparent; color: #a0b4c8; font-size: 10px; }");
+    row->addWidget(grip);
+
+    m_titleLabel = new QLabel(title, this);
+    m_titleLabel->setStyleSheet(kTitleStyle);
+    row->addWidget(m_titleLabel);
+    row->addStretch();
+
+    auto* minButton = new QPushButton(QString::fromUtf8("\xe2\x80\x94"), this);
+    minButton->setFixedSize(16, 16);
+    minButton->setCursor(Qt::ArrowCursor);
+    minButton->setStyleSheet(kButtonStyle);
+    minButton->setToolTip("Minimize");
+    connect(minButton, &QPushButton::clicked, this, [this] {
+        if (auto* w = window())
+            w->showMinimized();
+    });
+    row->addWidget(minButton);
+
+    auto* maxButton = new QPushButton(QString::fromUtf8("\xe2\x96\xa1"), this);
+    maxButton->setFixedSize(16, 16);
+    maxButton->setCursor(Qt::ArrowCursor);
+    maxButton->setStyleSheet(kButtonStyle);
+    maxButton->setToolTip("Maximize");
+    connect(maxButton, &QPushButton::clicked, this, [this] {
+        if (auto* w = window()) {
+            if (w->isMaximized()) {
+                w->showNormal();
+            } else {
+                w->showMaximized();
+            }
+        }
+    });
+    row->addWidget(maxButton);
+
+    auto* closeButton = new QPushButton(QString::fromUtf8("\xc3\x97"), this);
+    closeButton->setFixedSize(16, 16);
+    closeButton->setCursor(Qt::ArrowCursor);
+    closeButton->setStyleSheet(kCloseButtonStyle);
+    closeButton->setToolTip("Close");
+    connect(closeButton, &QPushButton::clicked, this, [this] {
+        if (auto* w = window())
+            w->close();
+    });
+    row->addWidget(closeButton);
+}
+
+void FramelessWindowTitleBar::setTitleText(const QString& title)
+{
+    if (m_titleLabel)
+        m_titleLabel->setText(title);
+}
+
+void FramelessWindowTitleBar::mousePressEvent(QMouseEvent* event)
+{
+    if (event->button() == Qt::LeftButton) {
+        if (auto* w = window()) {
+            if (auto* h = w->windowHandle()) {
+                h->startSystemMove();
+                event->accept();
+                return;
+            }
+        }
+    }
+    QWidget::mousePressEvent(event);
+}
+
+void FramelessWindowTitleBar::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    if (event->button() == Qt::LeftButton) {
+        if (auto* w = window()) {
+            if (w->isMaximized()) {
+                w->showNormal();
+            } else {
+                w->showMaximized();
+            }
+            event->accept();
+            return;
+        }
+    }
+    QWidget::mouseDoubleClickEvent(event);
+}
+
+} // namespace AetherSDR

--- a/src/gui/FramelessWindowTitleBar.h
+++ b/src/gui/FramelessWindowTitleBar.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+
+namespace AetherSDR {
+
+class FramelessWindowTitleBar : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit FramelessWindowTitleBar(const QString& title, QWidget* parent = nullptr);
+
+    void setTitleText(const QString& title);
+
+protected:
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
+
+private:
+    QLabel* m_titleLabel{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4109,10 +4109,8 @@ void setEditorFramelessMode(QWidget* editor, bool on)
 
     const QRect geom = editor->geometry();
     const bool wasVisible = editor->isVisible();
-    Qt::WindowFlags flags = Qt::Window;
-    if (on) {
-        flags |= Qt::FramelessWindowHint;
-    }
+    Qt::WindowFlags flags = editor->windowFlags();
+    flags.setFlag(Qt::FramelessWindowHint, on);
     editor->setWindowFlags(flags);
     editor->setGeometry(geom);
 
@@ -4132,10 +4130,8 @@ void setDialogFramelessMode(QDialog* dialog, bool on)
 
     const QRect geom = dialog->geometry();
     const bool wasVisible = dialog->isVisible();
-    Qt::WindowFlags flags = Qt::Dialog;
-    if (on) {
-        flags |= Qt::FramelessWindowHint;
-    }
+    Qt::WindowFlags flags = dialog->windowFlags();
+    flags.setFlag(Qt::FramelessWindowHint, on);
     dialog->setWindowFlags(flags);
     dialog->setGeometry(geom);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -98,6 +98,7 @@
 #include "AetherDspWidget.h"
 #include "ClientRxDspApplet.h"
 #include "DspParamPopup.h"
+#include "FramelessWindowTitleBar.h"
 
 #include <algorithm>
 #include <cmath>
@@ -150,7 +151,7 @@
 #include <QPlainTextEdit>
 #include <QSpinBox>
 #include <QComboBox>
-#include <QProgressDialog>
+#include <QProgressBar>
 #include <QThread>
 #include <QToolTip>
 #include "core/AppSettings.h"
@@ -4098,10 +4099,43 @@ MainWindow::~MainWindow()
 #endif
 }
 
+namespace {
+
+void setEditorFramelessMode(QWidget* editor, bool on)
+{
+    if (!editor) {
+        return;
+    }
+
+    const QRect geom = editor->geometry();
+    const bool wasVisible = editor->isVisible();
+    Qt::WindowFlags flags = Qt::Window;
+    if (on) {
+        flags |= Qt::FramelessWindowHint;
+    }
+    editor->setWindowFlags(flags);
+    editor->setGeometry(geom);
+
+    if (auto* titleBar = editor->findChild<QWidget*>("editorFramelessTitleBar")) {
+        titleBar->setVisible(on);
+    }
+    if (wasVisible) {
+        editor->show();
+    }
+}
+
+bool framelessWindowEnabled()
+{
+    return AppSettings::instance().value("FramelessWindow", "True").toString() == "True";
+}
+
+}
+
 ClientEqEditor* MainWindow::ensureClientEqEditor()
 {
     if (!m_clientEqEditor) {
         m_clientEqEditor = new ClientEqEditor(m_audio, this);
+        setEditorFramelessMode(m_clientEqEditor, framelessWindowEnabled());
         connect(m_clientEqEditor, &ClientEqEditor::bypassToggled,
                 this, [this](ClientEqApplet::Path path, bool bypassed) {
             if (!m_appletPanel) return;
@@ -4205,6 +4239,7 @@ ClientGateEditor* MainWindow::ensureClientGateEditor()
 {
     if (!m_clientGateEditor) {
         m_clientGateEditor = new ClientGateEditor(m_audio, this);
+        setEditorFramelessMode(m_clientGateEditor, framelessWindowEnabled());
         connect(m_clientGateEditor, &ClientGateEditor::bypassToggled,
                 this, [this](ClientGateEditor::Side side, bool bypassed) {
             if (!m_appletPanel) return;
@@ -4228,6 +4263,7 @@ ClientCompEditor* MainWindow::ensureClientCompEditor()
 {
     if (!m_clientCompEditor) {
         m_clientCompEditor = new ClientCompEditor(m_audio, this);
+        setEditorFramelessMode(m_clientCompEditor, framelessWindowEnabled());
         connect(m_clientCompEditor, &ClientCompEditor::bypassToggled,
                 this, [this](ClientCompEditor::Side side, bool bypassed) {
             if (!m_appletPanel) return;
@@ -4251,6 +4287,7 @@ ClientTubeEditor* MainWindow::ensureClientTubeEditor()
 {
     if (!m_clientTubeEditor) {
         m_clientTubeEditor = new ClientTubeEditor(m_audio, this);
+        setEditorFramelessMode(m_clientTubeEditor, framelessWindowEnabled());
         connect(m_clientTubeEditor, &ClientTubeEditor::bypassToggled,
                 this, [this](ClientTubeEditor::Side side, bool bypassed) {
             if (!m_appletPanel) return;
@@ -4274,6 +4311,7 @@ ClientPuduEditor* MainWindow::ensureClientPuduEditor()
 {
     if (!m_clientPuduEditor) {
         m_clientPuduEditor = new ClientPuduEditor(m_audio, this);
+        setEditorFramelessMode(m_clientPuduEditor, framelessWindowEnabled());
         connect(m_clientPuduEditor, &ClientPuduEditor::bypassToggled,
                 this, [this](ClientPuduEditor::Side side, bool bypassed) {
             if (!m_appletPanel) return;
@@ -6642,10 +6680,11 @@ void MainWindow::buildUI()
 
     auto* splitter = m_splitter;
 
-    // Connection panel — modeless dialog with standard decorations (#560, #574)
+    // Connection panel — modeless dialog; follows View -> Frameless Window.
     m_connPanel = new ConnectionPanel(this);
-    m_connPanel->setWindowFlags(Qt::Dialog);
     m_connPanel->setWindowTitle("Connect to Radio");
+    m_connPanel->setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
     m_connPanel->setMinimumSize(640, 580);
     m_connPanel->resize(760, 660);
     m_connPanel->hide();
@@ -9999,22 +10038,49 @@ void MainWindow::updateNr2Availability()
 void MainWindow::enableNr2WithWisdom()
 {
     if (AudioEngine::needsWisdomGeneration()) {
-        auto* dlg = new QProgressDialog(
-            "Optimizing FFT plans for NR2...\n\n"
-            "This window will automatically close when wisdom generation is complete.",
-            QString(), 0, 100, this);
+        const bool frameless =
+            AppSettings::instance().value("FramelessWindow", "True").toString() == "True";
+
+        auto* dlg = new QDialog(this);
         dlg->setWindowTitle("AetherSDR — FFTW Wisdom");
+        if (frameless)
+            dlg->setWindowFlag(Qt::FramelessWindowHint, true);
         dlg->setWindowModality(Qt::ApplicationModal);
-        dlg->setMinimumDuration(0);
-        dlg->setAutoClose(false);
-        dlg->setAutoReset(false);
-        dlg->setCancelButton(nullptr);
         dlg->setMinimumWidth(500);
         dlg->setStyleSheet(
+            "QDialog { background: #050710; }"
+            "QLabel { color: #8aa8c0; background: transparent; }"
             "QProgressBar { text-align: center; font-size: 13px;"
             " font-weight: bold; color: #c8d8e8;"
-            " background: #1a2a3a; border: 1px solid #2e4e6e; border-radius: 3px; }"
+            " background: #0a0a14; border: 1px solid #203040; border-radius: 3px; }"
             "QProgressBar::chunk { background: #00b4d8; }");
+
+        auto* root = new QVBoxLayout(dlg);
+        root->setContentsMargins(0, 0, 0, 0);
+        root->setSpacing(0);
+
+        auto* titleBar = new FramelessWindowTitleBar(QStringLiteral("AetherSDR — FFTW Wisdom"), dlg);
+        titleBar->setVisible(frameless);
+        root->addWidget(titleBar);
+
+        auto* content = new QWidget(dlg);
+        auto* body = new QVBoxLayout(content);
+        body->setContentsMargins(10, frameless ? 8 : 10, 10, 10);
+        body->setSpacing(10);
+
+        auto* label = new QLabel(
+            "Optimizing FFT plans for NR2...\n\n"
+            "This window will automatically close when wisdom generation is complete.",
+            content);
+        label->setWordWrap(true);
+        body->addWidget(label);
+
+        auto* progress = new QProgressBar(content);
+        progress->setRange(0, 100);
+        progress->setValue(0);
+        body->addWidget(progress);
+        root->addWidget(content);
+
         dlg->show();
 
         auto* breathe = new QPropertyAnimation(dlg, "windowOpacity", dlg);
@@ -10024,27 +10090,27 @@ void MainWindow::enableNr2WithWisdom()
         breathe->setEndValue(1.0);
         breathe->setLoopCount(-1);
 
-        auto* thread = QThread::create([this, dlg, breathe]() {
-            AudioEngine::generateWisdom([dlg, breathe](int step, int total, const std::string& desc) {
+        auto* thread = QThread::create([dlg, breathe, label, progress]() {
+            AudioEngine::generateWisdom([dlg, breathe, label, progress](int step, int total, const std::string& desc) {
                 int pct = total > 0 ? (step * 100 / total) : 0;
                 QString d = QString::fromStdString(desc);
-                QMetaObject::invokeMethod(dlg, [dlg, breathe, pct, d]() {
+                QMetaObject::invokeMethod(dlg, [breathe, label, progress, pct, d]() {
                     if (!d.isEmpty()) {
-                        dlg->setLabelText(d + "\n\n"
+                        label->setText(d + "\n\n"
                             "This window will automatically close when wisdom generation is complete.");
-                        if (dlg->value() >= 90 && breathe->state() != QAbstractAnimation::Running)
+                        if (progress->value() >= 90 && breathe->state() != QAbstractAnimation::Running)
                             breathe->start();
                     } else {
-                        dlg->setValue(pct);
+                        progress->setValue(pct);
                     }
                 });
             });
         });
-        connect(thread, &QThread::finished, this, [this, dlg, breathe, thread]() {
+        connect(thread, &QThread::finished, this, [this, dlg, breathe, progress, label, thread]() {
             breathe->stop();
             dlg->setWindowOpacity(1.0);
-            dlg->setValue(100);
-            dlg->setLabelText("Wisdom generation complete!");
+            progress->setValue(100);
+            label->setText("Wisdom generation complete!");
             QTimer::singleShot(800, this, [this, dlg, thread]() {
                 dlg->close();
                 dlg->deleteLater();
@@ -10152,6 +10218,21 @@ void MainWindow::setFramelessWindow(bool on)
     if (m_panStack) m_panStack->setFramelessMode(on);
     if (m_appletPanel && m_appletPanel->containerManager())
         m_appletPanel->containerManager()->setFramelessMode(on);
+    if (m_connPanel)
+        m_connPanel->setFramelessMode(on);
+    if (auto* dlg = qobject_cast<NetworkDiagnosticsDialog*>(m_networkDiagnosticsDialog))
+        dlg->setFramelessMode(on);
+    if (auto* dlg = qobject_cast<RadioSetupDialog*>(m_radioSetupDialog))
+        dlg->setFramelessMode(on);
+    if (auto* dlg = qobject_cast<AetherDspDialog*>(m_dspDialog))
+        dlg->setFramelessMode(on);
+    if (m_aetherialStrip)
+        m_aetherialStrip->setFramelessMode(on);
+    setEditorFramelessMode(m_clientEqEditor, on);
+    setEditorFramelessMode(m_clientCompEditor, on);
+    setEditorFramelessMode(m_clientGateEditor, on);
+    setEditorFramelessMode(m_clientTubeEditor, on);
+    setEditorFramelessMode(m_clientPuduEditor, on);
 }
 
 void MainWindow::toggleAetherialStrip()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4109,7 +4109,7 @@ void setEditorFramelessMode(QWidget* editor, bool on)
 
     const QRect geom = editor->geometry();
     const bool wasVisible = editor->isVisible();
-    Qt::WindowFlags flags = editor->windowFlags();
+    Qt::WindowFlags flags = (editor->windowFlags() & ~Qt::WindowType_Mask) | Qt::Window;
     flags.setFlag(Qt::FramelessWindowHint, on);
     editor->setWindowFlags(flags);
     editor->setGeometry(geom);
@@ -4130,7 +4130,7 @@ void setDialogFramelessMode(QDialog* dialog, bool on)
 
     const QRect geom = dialog->geometry();
     const bool wasVisible = dialog->isVisible();
-    Qt::WindowFlags flags = dialog->windowFlags();
+    Qt::WindowFlags flags = (dialog->windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     dialog->setWindowFlags(flags);
     dialog->setGeometry(geom);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4124,6 +4124,29 @@ void setEditorFramelessMode(QWidget* editor, bool on)
     }
 }
 
+void setDialogFramelessMode(QDialog* dialog, bool on)
+{
+    if (!dialog) {
+        return;
+    }
+
+    const QRect geom = dialog->geometry();
+    const bool wasVisible = dialog->isVisible();
+    Qt::WindowFlags flags = Qt::Dialog;
+    if (on) {
+        flags |= Qt::FramelessWindowHint;
+    }
+    dialog->setWindowFlags(flags);
+    dialog->setGeometry(geom);
+
+    if (auto* titleBar = dialog->findChild<QWidget*>("editorFramelessTitleBar")) {
+        titleBar->setVisible(on);
+    }
+    if (wasVisible) {
+        dialog->show();
+    }
+}
+
 bool framelessWindowEnabled()
 {
     return AppSettings::instance().value("FramelessWindow", "True").toString() == "True";
@@ -10222,6 +10245,8 @@ void MainWindow::setFramelessWindow(bool on)
         m_connPanel->setFramelessMode(on);
     if (auto* dlg = qobject_cast<NetworkDiagnosticsDialog*>(m_networkDiagnosticsDialog))
         dlg->setFramelessMode(on);
+    if (auto* dlg = qobject_cast<PropDashboardDialog*>(m_propDashboardDialog))
+        dlg->setFramelessMode(on);
     if (auto* dlg = qobject_cast<RadioSetupDialog*>(m_radioSetupDialog))
         dlg->setFramelessMode(on);
     if (auto* dlg = qobject_cast<AetherDspDialog*>(m_dspDialog))
@@ -10233,6 +10258,11 @@ void MainWindow::setFramelessWindow(bool on)
     setEditorFramelessMode(m_clientGateEditor, on);
     setEditorFramelessMode(m_clientTubeEditor, on);
     setEditorFramelessMode(m_clientPuduEditor, on);
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        if (widget && widget->objectName() == "quindarToneEditor") {
+            setDialogFramelessMode(qobject_cast<QDialog*>(widget), on);
+        }
+    }
 }
 
 void MainWindow::toggleAetherialStrip()

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1042,10 +1042,8 @@ void NetworkDiagnosticsDialog::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = Qt::Dialog;
-    if (on) {
-        flags |= Qt::FramelessWindowHint;
-    }
+    Qt::WindowFlags flags = windowFlags();
+    flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);
     if (m_titleBar) {

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1042,7 +1042,7 @@ void NetworkDiagnosticsDialog::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = windowFlags();
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1,4 +1,5 @@
 #include "NetworkDiagnosticsDialog.h"
+#include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/LogManager.h"
 #include "models/RadioModel.h"
@@ -586,7 +587,6 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     : QDialog(parent), m_model(model), m_audio(audio), m_history(history)
 {
     setWindowTitle("Network Diagnostics");
-    setWindowFlag(Qt::FramelessWindowHint, true);
     setMinimumSize(920, 680);
     resize(980, 760);
     // Track mouse without buttons pressed so the resize cursor updates
@@ -693,6 +693,7 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     auto* body = new QVBoxLayout(outerContent);
     body->setContentsMargins(10, 8, 10, 10);
     body->setSpacing(8);
+    m_bodyLayout = body;
     root->addWidget(outerContent, 1);
 
     // Timeframe selector lives in the top-right corner of the QTabWidget's
@@ -1031,6 +1032,31 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     m_logRefreshTimer.start(500);
     initializeLogTail();
     refresh();
+
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+}
+
+void NetworkDiagnosticsDialog::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = Qt::Dialog;
+    if (on) {
+        flags |= Qt::FramelessWindowHint;
+    }
+    setWindowFlags(flags);
+    setGeometry(geom);
+    if (m_titleBar) {
+        m_titleBar->setVisible(on);
+    }
+    if (m_bodyLayout) {
+        m_bodyLayout->setContentsMargins(10, on ? 8 : 10, 10, 10);
+    }
+    if (wasVisible) {
+        show();
+    }
 }
 
 QWidget* NetworkDiagnosticsDialog::buildLogsTab()
@@ -1807,6 +1833,9 @@ void NetworkDiagnosticsDialog::updateCharts()
 
 Qt::Edges NetworkDiagnosticsDialog::edgesAt(const QPoint& pos) const
 {
+    if (!(windowFlags() & Qt::FramelessWindowHint)) {
+        return {};
+    }
     if (isMaximized() || isFullScreen()) {
         return {};
     }

--- a/src/gui/NetworkDiagnosticsDialog.h
+++ b/src/gui/NetworkDiagnosticsDialog.h
@@ -14,6 +14,7 @@
 class QCheckBox;
 class QPlainTextEdit;
 class QPushButton;
+class QVBoxLayout;
 
 namespace AetherSDR {
 
@@ -73,6 +74,7 @@ public:
                                       AudioEngine* audio,
                                       NetworkDiagnosticsHistory* history,
                                       QWidget* parent = nullptr);
+    void setFramelessMode(bool on);
 
 protected:
     // Frameless 8-axis resize: 4 edges + 4 corners.  Hovering the bare
@@ -107,6 +109,7 @@ private:
     void updateResizeCursor(const QPoint& pos);
 
     QWidget* m_titleBar{nullptr};
+    QVBoxLayout* m_bodyLayout{nullptr};
 
     RadioModel* m_model;
     AudioEngine* m_audio;

--- a/src/gui/PropDashboardDialog.cpp
+++ b/src/gui/PropDashboardDialog.cpp
@@ -1,4 +1,7 @@
 #include "PropDashboardDialog.h"
+#include "core/AppSettings.h"
+#include "FramelessResizer.h"
+#include "FramelessWindowTitleBar.h"
 
 #include <QColor>
 #include <QDateTime>
@@ -382,9 +385,20 @@ PropDashboardDialog::PropDashboardDialog(PropForecastClient* client, QWidget* pa
 
     m_nam = new QNetworkAccessManager(this);
 
-    auto* root = new QVBoxLayout(this);
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    auto* titleBar = new FramelessWindowTitleBar(QStringLiteral("HF Propagation Dashboard"), this);
+    m_titleBar = titleBar;
+    outer->addWidget(titleBar);
+
+    auto* bodyWidget = new QWidget(this);
+    auto* root = new QVBoxLayout(bodyWidget);
     root->setContentsMargins(10, 10, 10, 10);
     root->setSpacing(10);
+    m_bodyLayout = root;
+    outer->addWidget(bodyWidget, 1);
 
     auto* scroll = new QScrollArea(this);
     scroll->setWidgetResizable(true);
@@ -817,6 +831,32 @@ PropDashboardDialog::PropDashboardDialog(PropForecastClient* client, QWidget* pa
         fetchImages();
     });
     m_refreshTimer.start();
+
+    FramelessResizer::install(this);
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+}
+
+void PropDashboardDialog::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = Qt::Dialog;
+    if (on) {
+        flags |= Qt::FramelessWindowHint;
+    }
+    setWindowFlags(flags);
+    setGeometry(geom);
+    if (m_titleBar) {
+        m_titleBar->setVisible(on);
+    }
+    if (m_bodyLayout) {
+        m_bodyLayout->setContentsMargins(10, on ? 8 : 10, 10, 10);
+    }
+    if (wasVisible) {
+        show();
+    }
 }
 
 void PropDashboardDialog::fetchImages()

--- a/src/gui/PropDashboardDialog.cpp
+++ b/src/gui/PropDashboardDialog.cpp
@@ -842,7 +842,7 @@ void PropDashboardDialog::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = windowFlags();
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);

--- a/src/gui/PropDashboardDialog.cpp
+++ b/src/gui/PropDashboardDialog.cpp
@@ -842,10 +842,8 @@ void PropDashboardDialog::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = Qt::Dialog;
-    if (on) {
-        flags |= Qt::FramelessWindowHint;
-    }
+    Qt::WindowFlags flags = windowFlags();
+    flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);
     if (m_titleBar) {

--- a/src/gui/PropDashboardDialog.h
+++ b/src/gui/PropDashboardDialog.h
@@ -10,6 +10,7 @@
 
 class QNetworkAccessManager;
 class QFrame;
+class QVBoxLayout;
 
 namespace AetherSDR {
 
@@ -18,6 +19,7 @@ class PropDashboardDialog : public QDialog {
 
 public:
     explicit PropDashboardDialog(PropForecastClient* client, QWidget* parent = nullptr);
+    void setFramelessMode(bool on);
 
 private:
     bool eventFilter(QObject* obj, QEvent* ev) override;
@@ -29,6 +31,8 @@ private:
     static QString kpColor(double kp);
 
     PropForecastClient* m_client;
+    QWidget* m_titleBar{nullptr};
+    QVBoxLayout* m_bodyLayout{nullptr};
     QNetworkAccessManager* m_nam{nullptr};
     QTimer m_refreshTimer;
 

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -256,7 +256,7 @@ void RadioSetupDialog::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = windowFlags();
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1,4 +1,6 @@
 #include "RadioSetupDialog.h"
+#include "FramelessResizer.h"
+#include "FramelessWindowTitleBar.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "SliceColorManager.h"
@@ -169,7 +171,19 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
     setMinimumSize(820, 620);
     setStyleSheet("QDialog { background: #0f0f1a; }");
 
-    auto* layout = new QVBoxLayout(this);
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    auto* titleBar = new FramelessWindowTitleBar(QStringLiteral("Radio Setup"), this);
+    m_titleBar = titleBar;
+    outer->addWidget(titleBar);
+
+    auto* bodyWidget = new QWidget(this);
+    auto* layout = new QVBoxLayout(bodyWidget);
+    layout->setContentsMargins(9, 9, 9, 9);
+    m_bodyLayout = layout;
+    outer->addWidget(bodyWidget, 1);
 
     auto* tabs = new QTabWidget;
     m_tabs = tabs;
@@ -231,6 +245,28 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
         .value("RadioSetupDialogGeometry", "").toString();
     if (!geomB64.isEmpty())
         restoreGeometry(QByteArray::fromBase64(geomB64.toLatin1()));
+
+    FramelessResizer::install(this);
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+}
+
+void RadioSetupDialog::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = Qt::Dialog;
+    if (on)
+        flags |= Qt::FramelessWindowHint;
+    setWindowFlags(flags);
+    setGeometry(geom);
+    if (m_titleBar)
+        m_titleBar->setVisible(on);
+    if (m_bodyLayout)
+        m_bodyLayout->setContentsMargins(9, on ? 7 : 9, 9, 9);
+    if (wasVisible)
+        show();
 }
 
 void RadioSetupDialog::closeEvent(QCloseEvent* event)

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -256,9 +256,8 @@ void RadioSetupDialog::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = Qt::Dialog;
-    if (on)
-        flags |= Qt::FramelessWindowHint;
+    Qt::WindowFlags flags = windowFlags();
+    flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     setGeometry(geom);
     if (m_titleBar)

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -11,6 +11,7 @@ class QGroupBox;
 class QProgressBar;
 class QPushButton;
 class QComboBox;
+class QVBoxLayout;
 
 namespace AetherSDR {
 
@@ -33,6 +34,7 @@ public:
                               PgxlConnection* pgxl = nullptr,
                               AntennaGeniusModel* ag = nullptr,
                               QWidget* parent = nullptr);
+    void setFramelessMode(bool on);
     void selectTab(const QString& tabName);
 
 signals:
@@ -67,6 +69,8 @@ private:
     TgxlConnection*    m_tgxl{nullptr};
     PgxlConnection*    m_pgxl{nullptr};
     AntennaGeniusModel* m_ag{nullptr};
+    QWidget*     m_titleBar{nullptr};
+    QVBoxLayout* m_bodyLayout{nullptr};
     QTabWidget*  m_tabs{nullptr};
 
     // Radio tab fields

--- a/src/gui/StripFinalOutputPanel.cpp
+++ b/src/gui/StripFinalOutputPanel.cpp
@@ -2,6 +2,7 @@
 
 #include "ClientCompKnob.h"
 #include "EditorFramelessTitleBar.h"
+#include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/ClientFinalLimiter.h"
 #include "core/ClientQuindarTone.h"
@@ -821,10 +822,16 @@ void StripFinalOutputPanel::showQuindarEditor()
 
     auto* dlg = new QDialog(this);
     dlg->setAttribute(Qt::WA_DeleteOnClose);
-    // Frameless chrome with the same draggable title bar the rest of
-    // the strip's editors use.  Fixed-size dialog — no resize grip
-    // needed since all controls fit at a single layout.
-    dlg->setWindowFlags(dlg->windowFlags() | Qt::FramelessWindowHint);
+    dlg->setObjectName("quindarToneEditor");
+    const bool frameless = AppSettings::instance()
+                               .value("FramelessWindow", "True")
+                               .toString()
+                           == "True";
+    // Custom chrome uses the same draggable title bar as the rest of
+    // the strip's editors when frameless windows are enabled.
+    if (frameless) {
+        dlg->setWindowFlags(dlg->windowFlags() | Qt::FramelessWindowHint);
+    }
     dlg->setWindowTitle(tr("Quindar Tones"));
     dlg->setStyleSheet(
         "QDialog { background: #08121d; }"
@@ -857,7 +864,9 @@ void StripFinalOutputPanel::showQuindarEditor()
     // ContainerTitleBar has float/close signals tied to
     // ContainerWidget lifecycle that don't apply to a modal dialog.
     auto* titleBar = new QWidget(dlg);
+    titleBar->setObjectName("editorFramelessTitleBar");
     titleBar->setFixedHeight(18);
+    titleBar->setVisible(frameless);
     titleBar->setAttribute(Qt::WA_StyledBackground, true);
     titleBar->setStyleSheet(
         "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"


### PR DESCRIPTION
## Summary

Fixes inconsistent frameless-window behavior across modeless popout windows. Before this change, several popouts either did not support the View -> Frameless Window setting at all, or were hardcoded frameless and stayed frameless after the setting was disabled. This left windows such as Network Diagnostics, HF Propagation Dashboard, and Aetherial Audio out of sync with the main window and Radio Setup.

This PR makes the frameless setting consistently apply when popouts are created and when the View-menu toggle changes at runtime.

## What changed

- Added a shared Network Diagnostics-style frameless title bar helper so popout chrome uses the same 18 px gradient title bar, grip glyph, and min/max/close trio.
- Added frameless-mode support to Connect, Radio Setup, AetherDSP settings, Network Diagnostics, and HF Propagation Dashboard popouts.
- Replaced the FFTW wisdom QProgressDialog with a frameless-aware dialog using the same popout chrome.
- Updated Network Diagnostics so it reads AppSettings("FramelessWindow") instead of always forcing Qt::FramelessWindowHint.
- Updated Aetherial Audio and its lazy-created stage editor popouts so they follow the setting on creation and update while already open.
- Updated the Quindar tone editor so it respects the frameless setting and syncs if the setting changes while it is open.
- Propagated MainWindow::setFramelessWindow() to active popout windows, including panadapter/app-container popouts, Connect, Radio Setup, Network Diagnostics, HF Propagation Dashboard, AetherDSP, Aetherial Audio, Aetherial stage editors, and the Quindar tone editor.

## Verification

Built successfully on macOS with:

```bash
cmake --build /private/tmp/aethersdr-frameless-build -j8
```

Existing unrelated compiler warnings remain in MainWindow.cpp and other files.
