### PR TITLE
Fix ShackSwitch button stale visibility in top-right tray

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -760,11 +760,15 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         m_appletOrder.append(entry);
     }
 
-    // ShackSwitch applet — shown instead of/alongside AG for ShackSwitch devices
+    // ShackSwitch applet — shown instead of/alongside AG for ShackSwitch devices.
+    // Button starts hidden (mirroring AG) and is shown only when a ShackSwitch
+    // is actually connected or discovered, so a fresh install with no SS
+    // configured does not display a stray SS button in the top right.
     m_ssApplet = new ShackSwitchApplet;
     {
         auto entry = makeEntry("SS", "ShackSwitch", m_ssApplet, false, btnRow1, btnLayout1);
         m_ssBtn = entry.btn;
+        if (m_ssBtn) m_ssBtn->hide();
         m_appletOrder.append(entry);
     }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3752,6 +3752,24 @@ MainWindow::MainWindow(QWidget* parent)
         }
     });
 
+    // On disconnect, if the device that was connected was a ShackSwitch and
+    // there is no longer a saved SS_ManualIp (e.g. the user cleared it via
+    // the Peripherals tab), hide the SS button. A UDP-discovered SS will
+    // re-show the button via deviceDiscovered if the hardware is still
+    // broadcasting. The model never emits presenceChanged(false) on simple
+    // disconnect, so this handler is needed to bridge the gap.
+    connect(&m_antennaGenius, &AntennaGeniusModel::disconnected,
+            this, [this]() {
+        const AgDeviceInfo& dev = m_antennaGenius.connectedDevice();
+        const bool wasSS = AntennaGeniusModel::isShackSwitch(dev);
+        if (!wasSS) return;
+        const QString ssIp =
+            AppSettings::instance().value("SS_ManualIp", "").toString();
+        if (ssIp.isEmpty()) {
+            m_appletPanel->setShackSwitchVisible(false);
+        }
+    });
+
     // ── 8-channel CAT: rigctld + PTY (A-H, each bound to a slice) ────────────
     {
         static const char kLetters[] = "ABCDEFGH";

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -270,6 +270,10 @@ void RadioSetupDialog::setFramelessMode(bool on)
 
 void RadioSetupDialog::closeEvent(QCloseEvent* event)
 {
+    // Persist any uncommitted "user cleared IP" edits in the Peripherals
+    // tab before saving + closing.
+    for (const auto& saver : m_peripheralRowSavers)
+        saver();
     AppSettings::instance().setValue("RadioSetupDialogGeometry",
         QString::fromLatin1(saveGeometry().toBase64()));
     AppSettings::instance().save();
@@ -3748,11 +3752,33 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
 
         connect(btn, &QPushButton::clicked, this,
                 [=, &settings]() {
+            QString ip = ipEdit->text().trimmed();
             if (isConnectedFn()) {
+                // If the user cleared the IP field before clicking, wipe
+                // the saved manual IP/port FIRST — the disconnect signal
+                // fires synchronously and downstream handlers (e.g. SS
+                // button visibility) read these settings to decide
+                // whether to keep showing the device. Clearing after the
+                // disconnect would leave the button visible.
+                if (ip.isEmpty()) {
+                    settings.remove(ipKey);
+                    settings.remove(portKey);
+                    settings.save();
+                }
                 disconnectFn();
             } else {
-                QString ip = ipEdit->text().trimmed();
-                if (ip.isEmpty()) return;
+                if (ip.isEmpty()) {
+                    // Empty IP while disconnected: if a manual IP was saved
+                    // previously, treat this click as "save back to default"
+                    // — clear the persisted manual IP/port so the device
+                    // stops auto-connecting.
+                    if (!settings.value(ipKey, "").toString().isEmpty()) {
+                        settings.remove(ipKey);
+                        settings.remove(portKey);
+                        settings.save();
+                    }
+                    return;
+                }
                 int port = portSpin->value();
                 // Save to settings
                 settings.setValue(ipKey, ip);
@@ -3771,6 +3797,26 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
                 ? "QLabel { color: #00e060; font-size: 11px; }"
                 : "QLabel { color: #8aa8c0; font-size: 11px; }");
         };
+
+        // Save-on-close: if the user has cleared the IP field and closes
+        // the dialog without clicking Connect/Disconnect, treat that as
+        // "wipe the saved manual IP/port". A non-empty edit still requires
+        // an explicit Connect click so a partially-typed IP cannot leak in.
+        m_peripheralRowSavers.append([ipEdit, ipKey, portKey, &settings,
+                                      isConnectedFn, disconnectFn]() {
+            if (!ipEdit) return;
+            const QString ip = ipEdit->text().trimmed();
+            if (!ip.isEmpty()) return;
+            const QString savedIp = settings.value(ipKey, "").toString();
+            if (savedIp.isEmpty()) return;
+            // The user cleared a previously-saved IP. If still connected
+            // (e.g. auto-connect ran at startup), disconnect first so
+            // downstream visibility handlers see the cleared settings.
+            settings.remove(ipKey);
+            settings.remove(portKey);
+            settings.save();
+            if (isConnectedFn()) disconnectFn();
+        });
 
         return updateState;
     };

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -2,6 +2,7 @@
 
 #include <QDialog>
 #include <QHash>
+#include <QVector>
 #include <functional>
 
 class QTabWidget;
@@ -105,6 +106,13 @@ private:
     // External APD tab (visible only when the radio reports apd configurable=1)
     int                       m_apdTabIndex{-1};
     QHash<QString, QComboBox*> m_apdSamplerCombos;
+
+    // Peripherals tab — savers run on dialog close to persist field edits
+    // that the user did not commit via the row's Connect/Disconnect button.
+    // Currently only used to honour "user cleared IP and closed dialog"
+    // → wipe the saved manual IP/port. New-IP edits still require an
+    // explicit Connect click so an unfinished value cannot leak in.
+    QVector<std::function<void()>> m_peripheralRowSavers;
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Summary

The SS button in the AppletPanel top-right tray could remain visible in three scenarios where no ShackSwitch was actually present:

1. **Fresh install / no SS configured** — `m_ssBtn` had no `hide()` after creation (unlike `m_agBtn` at the same site), so the button was always shown at startup regardless of whether a SS device existed or was configured.
2. **User cleared `SS_ManualIp` via the Peripherals tab** — the row's Connect handler bailed early on empty input, so the saved IP could only be overwritten with another IP, never wiped.
3. **User edited the IP field and closed the dialog without clicking the row button** — IP edits were only persisted via Connect/Disconnect, so a clear-and-close did nothing.

## Changes

| File | Change |
|---|---|
| `src/gui/AppletPanel.cpp` | Hide `m_ssBtn` on creation, mirroring `m_agBtn`. UDP discovery and the connected signal still re-show it when a real SS is detected. |
| `src/gui/RadioSetupDialog.cpp` | Generalise the row Connect/Disconnect handler so an empty-IP click clears the persisted `ipKey`/`portKey`. Settings are wiped *before* `disconnectFn()` so downstream visibility handlers see the cleared state. Add a closeEvent saver list — each peripheral row registers a saver that treats \"cleared previously-saved IP\" as an implicit clear on dialog close. Non-empty edits still require an explicit Connect click. |
| `src/gui/RadioSetupDialog.h` | Add `m_peripheralRowSavers` member + `<QVector>` include. |
| `src/gui/MainWindow.cpp` | New `disconnected`-signal handler hides the SS button when the disconnecting device was a ShackSwitch and no `SS_ManualIp` remains. `presenceChanged(false)` is never emitted on a normal disconnect, so this bridges the gap. |

The empty-IP-clear behaviour is generic across all four Peripherals rows (TGXL, PGXL, AG, SS), not just ShackSwitch.

## Test plan

- [x] Fresh launch with no SS configured → SS button hidden
- [x] `SS_ManualIp` set → auto-connect on radio connect → SS button shows
- [x] UDP-discovered SS (real Uno Q hardware broadcasting `name=ShackSwitch`) → SS button appears within ~5s
- [x] Clear IP field, click Disconnect → settings wiped, button hidden, no auto-reconnect on next launch
- [x] Clear IP field, close dialog without clicking → settings still wiped (close-event saver path)
- [x] Edit IP to a new value, close dialog without clicking → no persist (still requires explicit Connect)
- [x] Build clean on Windows (Qt 6.10.3 + MSVC), Linux (Qt 6.2.4), macOS (Qt 6.11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)