### PR TITLE
Auto_Squelch_AGC: noise floor tracking, AGC-aware squelch, RX panel controls

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8078,6 +8078,13 @@ void MainWindow::onSliceAdded(SliceModel* s)
         sw->setShowTxInWaterfall(
             m_radioModel.transmitModel().showTxInWaterfall());
 
+    // Squelch state → squelch line on the spectrum owning this slice
+    connect(s, &SliceModel::squelchChanged, this, [this, s](bool on, int level) {
+        if (s->sliceId() != m_activeSliceId) return;
+        if (auto* sw = spectrumForSlice(s))
+            sw->setSquelchLine(on, level);
+    });
+
     // Connect slice state changes → spectrum overlay updates
     connect(s, &SliceModel::frequencyChanged, this, [this, s](double mhz) {
         // Don't snap overlay back to stale radio-confirmed freq during active
@@ -8669,6 +8676,9 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
 
         sw->overlayMenu()->setSlice(s);
 
+        // Sync squelch threshold line to the newly active slice
+        sw->setSquelchLine(s->squelchOn(), s->squelchLevel());
+
         // Sync step size from the new active slice
         if (s->stepHz() > 0) {
             sw->setStepSize(s->stepHz());
@@ -9115,6 +9125,29 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setNoiseFloorPosition);
     connect(menu, &SpectrumOverlayMenu::noiseFloorEnableChanged,
             sw, &SpectrumWidget::setNoiseFloorEnable);
+
+    // Squelch overlay: menu → radio squelch + visual line on spectrum
+    connect(menu, &SpectrumOverlayMenu::squelchEnableChanged, this, [this, sw](bool on) {
+        auto* s = activeSlice();
+        if (!s) return;
+        s->setSquelch(on, s->squelchLevel());
+        sw->setSquelchLine(on, s->squelchLevel());
+    });
+    connect(menu, &SpectrumOverlayMenu::squelchLevelChanged, this, [this, sw](int level) {
+        auto* s = activeSlice();
+        if (!s) return;
+        s->setSquelch(s->squelchOn(), level);
+        sw->setSquelchLine(s->squelchOn(), level);
+    });
+    connect(menu, &SpectrumOverlayMenu::squelchAutoChanged,
+            sw, &SpectrumWidget::setAutoSquelchEnable);
+    // Auto-squelch suggestion: apply to radio and update visual line
+    connect(sw, &SpectrumWidget::autoSquelchLevelSuggested, this, [this, sw](int level) {
+        auto* s = activeSlice();
+        if (!s) return;
+        s->setSquelch(s->squelchOn(), level);
+        sw->setSquelchLine(s->squelchOn(), level);
+    });
 
     // Pop out / dock panadapter
     connect(sw, &SpectrumWidget::popOutRequested, this, [this, applet](bool popOut) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2523,6 +2523,18 @@ MainWindow::MainWindow(QWidget* parent)
     for (auto* a : m_panStack->allApplets()) a->spectrumWidget()->setStepSize(savedStep);
     m_appletPanel->rxApplet()->setInitialStepSize(savedStep);
 
+    // ── RxApplet squelch controls → primary SpectrumWidget ─────────────────
+    {
+        RxApplet* rx  = m_appletPanel->rxApplet();
+        SpectrumWidget* mainSw = m_panApplet->spectrumWidget();
+        connect(rx, &RxApplet::noiseFloorEnableChanged,
+                mainSw, &SpectrumWidget::setNoiseFloorEnable);
+        connect(rx, &RxApplet::sqlAutoChanged,
+                mainSw, &SpectrumWidget::setAutoSquelchEnable);
+        connect(rx, &RxApplet::squelchStateChanged,
+                mainSw, &SpectrumWidget::setSquelchLine);
+    }
+
     // ── Antenna list from radio → applet panel ─────────────────────────────
     connect(&m_radioModel, &RadioModel::antListChanged,
             m_appletPanel, &AppletPanel::setAntennaList);
@@ -9123,24 +9135,11 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setFftLineWidth);
     connect(menu, &SpectrumOverlayMenu::noiseFloorPositionChanged,
             sw, &SpectrumWidget::setNoiseFloorPosition);
-    connect(menu, &SpectrumOverlayMenu::noiseFloorEnableChanged,
-            sw, &SpectrumWidget::setNoiseFloorEnable);
+    connect(menu, &SpectrumOverlayMenu::autoSqlMarginDbChanged,
+            sw, &SpectrumWidget::setAutoSqlMarginDb);
+    sw->setAutoSqlMarginDb(
+        AppSettings::instance().value("AutoSqlMarginDb", "10").toInt());
 
-    // Squelch overlay: menu → radio squelch + visual line on spectrum
-    connect(menu, &SpectrumOverlayMenu::squelchEnableChanged, this, [this, sw](bool on) {
-        auto* s = activeSlice();
-        if (!s) return;
-        s->setSquelch(on, s->squelchLevel());
-        sw->setSquelchLine(on, s->squelchLevel());
-    });
-    connect(menu, &SpectrumOverlayMenu::squelchLevelChanged, this, [this, sw](int level) {
-        auto* s = activeSlice();
-        if (!s) return;
-        s->setSquelch(s->squelchOn(), level);
-        sw->setSquelchLine(s->squelchOn(), level);
-    });
-    connect(menu, &SpectrumOverlayMenu::squelchAutoChanged,
-            sw, &SpectrumWidget::setAutoSquelchEnable);
     // Auto-squelch suggestion: apply to radio and update visual line
     connect(sw, &SpectrumWidget::autoSquelchLevelSuggested, this, [this, sw](int level) {
         auto* s = activeSlice();

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -751,6 +751,8 @@ void RxApplet::buildUI()
 
         connect(m_sqlBtn, &QPushButton::toggled, this, [this](bool on) {
             if (m_slice) m_slice->setSquelch(on, m_sqlSlider->value());
+            if (!on && m_sqlAutoBtn && m_sqlAutoBtn->isChecked())
+                m_sqlAutoBtn->setChecked(false);  // turning off squelch also disables auto-squelch
         });
         connect(m_sqlSlider, &QSlider::valueChanged, this, [this](int v) {
             if (m_slice && m_sqlBtn->isChecked())

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -773,6 +773,8 @@ void RxApplet::buildUI()
             emit noiseFloorEnableChanged(on);
             emit sqlAutoChanged(on);
             m_sqlSlider->setEnabled(!on);
+            if (on && m_sqlBtn && !m_sqlBtn->isChecked())
+                m_sqlBtn->setChecked(true);  // enabling auto SQL implicitly enables the gate
         });
 
         rightCol->addLayout(row2);

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -759,6 +759,25 @@ void RxApplet::buildUI()
         rightCol->addLayout(row);
     }
 
+    // Auto SQL button (enables noise floor measurement + auto-squelch)
+    {
+        auto* row2 = new QHBoxLayout;
+        row2->setSpacing(4);
+
+        m_sqlAutoBtn = mkToggle("Auto SQL");
+        m_sqlAutoBtn->setStyleSheet(QString(kButtonBase) + kGreenActive + kDisabledBtn);
+        row2->addWidget(m_sqlAutoBtn);
+        row2->addStretch();
+
+        connect(m_sqlAutoBtn, &QPushButton::toggled, this, [this](bool on) {
+            emit noiseFloorEnableChanged(on);
+            emit sqlAutoChanged(on);
+            m_sqlSlider->setEnabled(!on);
+        });
+
+        rightCol->addLayout(row2);
+    }
+
     // AGC mode + threshold (wrapped in container for FM hide)
     {
         m_agcContainer = new QWidget;
@@ -922,6 +941,9 @@ void RxApplet::buildUI()
     m_afSlider->setToolTip("Audio output volume for this slice.");
     m_sqlBtn->setToolTip("Squelch gate \u2014 silences audio when the signal drops below the threshold.");
     m_sqlSlider->setToolTip("Squelch threshold. Increase to require a stronger signal before audio opens.");
+    m_sqlAutoBtn->setToolTip(
+        "Auto Squelch \u2014 measures the noise floor and automatically sets the\n"
+        "squelch threshold just above it. Slider becomes read-only while active.");
     m_agcCombo->setToolTip("AGC speed. Slow resists pumping on quiet bands; Fast tracks rapid signal changes.");
     m_agcTSlider->setToolTip(QString("AGC Threshold: %1").arg(m_agcTSlider->value()));
     m_ritOnBtn->setToolTip("Receive Incremental Tuning \u2014 offsets the receive frequency without moving transmit.");
@@ -1372,6 +1394,7 @@ void RxApplet::connectSlice(SliceModel* s)
         if (m_sqlBtn->isEnabled())
             m_sqlBtn->setChecked(on);
         m_sqlSlider->setValue(level);
+        emit squelchStateChanged(on, level);
     });
 
     // DSP toggles removed — use VFO DSP tab or spectrum overlay

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -74,6 +74,12 @@ signals:
     void afGainChanged(int value);
     // Emitted when the user changes the tuning step size (Hz).
     void stepSizeChanged(int hz);
+    // Emitted when Auto SQL button is toggled — enables noise floor measurement
+    // and auto-squelch on the associated SpectrumWidget.
+    void noiseFloorEnableChanged(bool on);
+    void sqlAutoChanged(bool on);
+    // Relays the radio's squelch state echo so MainWindow can sync the visual line.
+    void squelchStateChanged(bool on, int level);
 
 #ifdef HAVE_RADE
     // Emitted when user selects/deselects RADE digital voice mode
@@ -177,6 +183,7 @@ private:
     // Squelch
     QPushButton* m_sqlBtn{nullptr};
     QSlider*     m_sqlSlider{nullptr};
+    QPushButton* m_sqlAutoBtn{nullptr};   // "Auto SQL" — enables floor measurement + auto-squelch
     bool         m_savedSquelchOn{false};
 
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -478,17 +478,8 @@ void SpectrumOverlayMenu::setSlice(SliceModel* slice)
     // AetherDSP applet (client-side) — those widgets own their own slice
     // bindings.
 
-    connect(m_slice, &SliceModel::squelchChanged, this, [this](bool on, int level) {
-        syncSquelchState(on, level, m_sqlAutoBtn ? m_sqlAutoBtn->isChecked() : false);
-    });
-
     syncAntPanel();
     syncDaxPanel();
-
-    // Sync current squelch state from the new slice
-    if (m_sqlEnableBtn && m_floorSlider)
-        syncSquelchState(m_slice->squelchOn(), m_slice->squelchLevel(),
-                         m_sqlAutoBtn ? m_sqlAutoBtn->isChecked() : false);
 }
 
 void SpectrumOverlayMenu::syncAntPanel()
@@ -1107,8 +1098,6 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     if (m_freqGridSpacingCmb) m_freqGridSpacingCmb->setToolTip("Frequency grid line spacing. Auto adapts to the current span.");
     if (m_colorSchemeCmb) m_colorSchemeCmb->setToolTip("Selects the waterfall color palette.");
     if (m_bgOpacitySlider) m_bgOpacitySlider->setToolTip("Opacity of the background image overlay.");
-    if (m_floorEnableBtn) m_floorEnableBtn->setToolTip("Shows a noise floor reference line on the spectrum display.");
-    if (m_floorSlider) m_floorSlider->setToolTip("Radio squelch level (0-100). 0 = off (noise passes), raise to gate above the noise floor.");
 
     m_displayPanel->adjustSize();
 }
@@ -1154,17 +1143,6 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
     m_rateSlider->setValue(rateSliderVal);
     m_rateLabel->setText(QString::number(rateSliderVal));
 
-    if (m_floorSlider) {
-        // m_floorSlider is the radio squelch level control; its value is
-        // initialized from the slice in syncSquelchState() — do NOT overwrite
-        // it here with the visual noise-floor position (floorPos).
-        QSignalBlocker be(m_floorEnableBtn);
-        m_floorEnableBtn->setChecked(floorEnable);
-        m_floorEnableBtn->setText(floorEnable ? "On" : "Off");
-        m_floorSlider->setEnabled(floorEnable);
-        if (m_sqlEnableBtn) m_sqlEnableBtn->setEnabled(floorEnable);
-        if (m_sqlAutoBtn)   m_sqlAutoBtn->setEnabled(floorEnable);
-    }
     if (m_heatMapBtn) {
         QSignalBlocker bh(m_heatMapBtn);
         m_heatMapBtn->setChecked(heatMap);
@@ -1212,22 +1190,6 @@ void SpectrumOverlayMenu::syncExtraDisplaySettings(bool blankerOn, float blanker
         m_bgOpacitySlider->setValue(bgOpacity);
         if (m_bgOpacityLabel)
             m_bgOpacityLabel->setText(QString::number(bgOpacity));
-    }
-}
-
-void SpectrumOverlayMenu::syncSquelchState(bool enabled, int level, bool autoMode)
-{
-    if (!m_sqlEnableBtn || !m_floorSlider) return;
-    {
-        QSignalBlocker b1(*m_sqlEnableBtn), b2(*m_floorSlider);
-        m_sqlEnableBtn->setChecked(enabled);
-        m_sqlEnableBtn->setText(enabled ? "On" : "Off");
-        m_floorLabel->setText(QString::number(level));
-        m_floorSlider->setValue(level);  // always update, not just when enabled
-    }
-    if (m_sqlAutoBtn) {
-        QSignalBlocker b(*m_sqlAutoBtn);
-        m_sqlAutoBtn->setChecked(autoMode);
     }
 }
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1,4 +1,5 @@
 #include "SpectrumOverlayMenu.h"
+#include "core/AppSettings.h"
 #include "DspParamPopup.h"
 #include "MemoryBrowsePanel.h"
 #include "SpectrumWidget.h"
@@ -914,61 +915,40 @@ void SpectrumOverlayMenu::buildDisplayPanel()
             emit wfAutoBlackOffsetChanged(m_blackAutoOffsetValue);
     });
 
-    // ── Floor / Squelch rows ──────────────────────────────────────────────
-    // Row 1 — Floor enable + squelch level slider (slider 0-100 = radio squelch).
-    //   Slider zero corresponds visually to the measured noise floor line on screen.
-    makeRowWithBtn("Floor:", 0, 100, 0, m_floorSlider, m_floorLabel,
-                   m_floorEnableBtn, "Off");
-    m_floorEnableBtn->setToolTip(
-        "Show noise floor reference line on the spectrum.\n"
-        "The line represents the averaged noise floor; slider 0 = at the floor.");
-    m_floorSlider->setToolTip("Squelch threshold — 0 = at noise floor, raise to gate above it.");
-    m_floorSlider->setEnabled(false);
-    connect(m_floorEnableBtn, &QPushButton::toggled, this, [this](bool on) {
-        m_floorEnableBtn->setText(on ? "On" : "Off");
-        if (m_floorSlider)    m_floorSlider->setEnabled(on);
-        if (m_sqlEnableBtn)   m_sqlEnableBtn->setEnabled(on);
-        if (m_sqlAutoBtn)     m_sqlAutoBtn->setEnabled(on);
-        emit noiseFloorEnableChanged(on);
-    });
-    connect(m_floorSlider, &QSlider::valueChanged, this, [this](int v) {
-        m_floorLabel->setText(QString::number(v));
-        emit squelchLevelChanged(v);
-    });
+    // Floor / Squelch controls have moved to the RX applet left panel.
+    // The "Auto SQL" button there enables both noise floor measurement and
+    // auto-squelch in one toggle.
 
-    // Row 2 — SQL enable + Auto buttons (no slider, sits under row 1).
+    // Auto SQL Margin: how far above the noise floor the auto-squelch threshold sits.
     {
-        ++row;  // blank label col
-        auto* sqlLbl = new QLabel("SQL:");
-        sqlLbl->setStyleSheet(labelStyle);
-        grid->addWidget(sqlLbl, row, 0);
+        const int saved = AppSettings::instance().value("AutoSqlMarginDb", "10").toInt();
+        auto* lbl = new QLabel("SQL Margin:");
+        lbl->setStyleSheet(labelStyle);
+        grid->addWidget(lbl, row, 0);
 
-        m_sqlEnableBtn = new QPushButton("Off");
-        m_sqlEnableBtn->setCheckable(true);
-        m_sqlEnableBtn->setFixedSize(36, 18);
-        m_sqlEnableBtn->setStyleSheet(btnStyle);
-        m_sqlEnableBtn->setToolTip("Enable squelch on the active slice at the floor threshold.");
-        m_sqlEnableBtn->setEnabled(false);
-        grid->addWidget(m_sqlEnableBtn, row, 1);
+        m_autoSqlMarginSlider = new QSlider(Qt::Horizontal);
+        m_autoSqlMarginSlider->setRange(5, 20);
+        m_autoSqlMarginSlider->setValue(saved);
+        m_autoSqlMarginSlider->setToolTip(
+            "Auto-squelch margin: dBm above the measured noise floor where the\n"
+            "squelch threshold is set. Increase on noisier/bursty bands (e.g. 40m),\n"
+            "decrease on quieter bands (e.g. 17m). Default 10 dBm.");
+        m_autoSqlMarginSlider->setStyleSheet(sliderStyle);
+        grid->addWidget(m_autoSqlMarginSlider, row, 1, 1, 2);
 
-        m_sqlAutoBtn = new QPushButton("Auto");
-        m_sqlAutoBtn->setCheckable(true);
-        m_sqlAutoBtn->setFixedSize(36, 18);
-        m_sqlAutoBtn->setStyleSheet(btnStyle);
-        m_sqlAutoBtn->setToolTip(
-            "Auto-squelch: continuously sets the threshold to 0.5 dB above the\n"
-            "peak noise floor. Disable to lock the threshold manually.");
-        m_sqlAutoBtn->setEnabled(false);
-        grid->addWidget(m_sqlAutoBtn, row, 2);
-
+        m_autoSqlMarginLabel = new QLabel(QString("%1 dB").arg(saved));
+        m_autoSqlMarginLabel->setStyleSheet(valStyle);
+        m_autoSqlMarginLabel->setFixedWidth(32);
+        m_autoSqlMarginLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        grid->addWidget(m_autoSqlMarginLabel, row, 3);
         ++row;
 
-        connect(m_sqlEnableBtn, &QPushButton::toggled, this, [this](bool on) {
-            m_sqlEnableBtn->setText(on ? "On" : "Off");
-            emit squelchEnableChanged(on);
-        });
-        connect(m_sqlAutoBtn, &QPushButton::toggled, this, [this](bool on) {
-            emit squelchAutoChanged(on);
+        connect(m_autoSqlMarginSlider, &QSlider::valueChanged, this, [this](int v) {
+            m_autoSqlMarginLabel->setText(QString("%1 dB").arg(v));
+            auto& s = AppSettings::instance();
+            s.setValue("AutoSqlMarginDb", QString::number(v));
+            s.save();
+            emit autoSqlMarginDbChanged(v);
         });
     }
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -477,8 +477,17 @@ void SpectrumOverlayMenu::setSlice(SliceModel* slice)
     // AetherDSP applet (client-side) — those widgets own their own slice
     // bindings.
 
+    connect(m_slice, &SliceModel::squelchChanged, this, [this](bool on, int level) {
+        syncSquelchState(on, level, m_sqlAutoBtn ? m_sqlAutoBtn->isChecked() : false);
+    });
+
     syncAntPanel();
     syncDaxPanel();
+
+    // Sync current squelch state from the new slice
+    if (m_sqlEnableBtn && m_floorSlider)
+        syncSquelchState(m_slice->squelchOn(), m_slice->squelchLevel(),
+                         m_sqlAutoBtn ? m_sqlAutoBtn->isChecked() : false);
 }
 
 void SpectrumOverlayMenu::syncAntPanel()
@@ -905,6 +914,64 @@ void SpectrumOverlayMenu::buildDisplayPanel()
             emit wfAutoBlackOffsetChanged(m_blackAutoOffsetValue);
     });
 
+    // ── Floor / Squelch rows ──────────────────────────────────────────────
+    // Row 1 — Floor enable + squelch level slider (slider 0-100 = radio squelch).
+    //   Slider zero corresponds visually to the measured noise floor line on screen.
+    makeRowWithBtn("Floor:", 0, 100, 0, m_floorSlider, m_floorLabel,
+                   m_floorEnableBtn, "Off");
+    m_floorEnableBtn->setToolTip(
+        "Show noise floor reference line on the spectrum.\n"
+        "The line represents the averaged noise floor; slider 0 = at the floor.");
+    m_floorSlider->setToolTip("Squelch threshold — 0 = at noise floor, raise to gate above it.");
+    m_floorSlider->setEnabled(false);
+    connect(m_floorEnableBtn, &QPushButton::toggled, this, [this](bool on) {
+        m_floorEnableBtn->setText(on ? "On" : "Off");
+        if (m_floorSlider)    m_floorSlider->setEnabled(on);
+        if (m_sqlEnableBtn)   m_sqlEnableBtn->setEnabled(on);
+        if (m_sqlAutoBtn)     m_sqlAutoBtn->setEnabled(on);
+        emit noiseFloorEnableChanged(on);
+    });
+    connect(m_floorSlider, &QSlider::valueChanged, this, [this](int v) {
+        m_floorLabel->setText(QString::number(v));
+        emit squelchLevelChanged(v);
+    });
+
+    // Row 2 — SQL enable + Auto buttons (no slider, sits under row 1).
+    {
+        ++row;  // blank label col
+        auto* sqlLbl = new QLabel("SQL:");
+        sqlLbl->setStyleSheet(labelStyle);
+        grid->addWidget(sqlLbl, row, 0);
+
+        m_sqlEnableBtn = new QPushButton("Off");
+        m_sqlEnableBtn->setCheckable(true);
+        m_sqlEnableBtn->setFixedSize(36, 18);
+        m_sqlEnableBtn->setStyleSheet(btnStyle);
+        m_sqlEnableBtn->setToolTip("Enable squelch on the active slice at the floor threshold.");
+        m_sqlEnableBtn->setEnabled(false);
+        grid->addWidget(m_sqlEnableBtn, row, 1);
+
+        m_sqlAutoBtn = new QPushButton("Auto");
+        m_sqlAutoBtn->setCheckable(true);
+        m_sqlAutoBtn->setFixedSize(36, 18);
+        m_sqlAutoBtn->setStyleSheet(btnStyle);
+        m_sqlAutoBtn->setToolTip(
+            "Auto-squelch: continuously sets the threshold to 0.5 dB above the\n"
+            "peak noise floor. Disable to lock the threshold manually.");
+        m_sqlAutoBtn->setEnabled(false);
+        grid->addWidget(m_sqlAutoBtn, row, 2);
+
+        ++row;
+
+        connect(m_sqlEnableBtn, &QPushButton::toggled, this, [this](bool on) {
+            m_sqlEnableBtn->setText(on ? "On" : "Off");
+            emit squelchEnableChanged(on);
+        });
+        connect(m_sqlAutoBtn, &QPushButton::toggled, this, [this](bool on) {
+            emit squelchAutoChanged(on);
+        });
+    }
+
     // NB Blank + Off/On
     makeRowWithBtn("NB Blank:", 5, 95, 15, m_wfBlankerThreshSlider, m_wfBlankerThreshLabel,
                    m_wfBlankerBtn, "Off");
@@ -1162,6 +1229,23 @@ void SpectrumOverlayMenu::syncExtraDisplaySettings(bool blankerOn, float blanker
         m_bgOpacitySlider->setValue(bgOpacity);
         if (m_bgOpacityLabel)
             m_bgOpacityLabel->setText(QString::number(bgOpacity));
+    }
+}
+
+void SpectrumOverlayMenu::syncSquelchState(bool enabled, int level, bool autoMode)
+{
+    if (!m_sqlEnableBtn || !m_floorSlider) return;
+    {
+        QSignalBlocker b1(*m_sqlEnableBtn), b2(*m_floorSlider);
+        m_sqlEnableBtn->setChecked(enabled);
+        m_sqlEnableBtn->setText(enabled ? "On" : "Off");
+        m_floorLabel->setText(QString::number(level));
+        if (m_floorSlider->isEnabled())
+            m_floorSlider->setValue(level);
+    }
+    if (m_sqlAutoBtn) {
+        QSignalBlocker b(*m_sqlAutoBtn);
+        m_sqlAutoBtn->setChecked(autoMode);
     }
 }
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1128,7 +1128,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     if (m_colorSchemeCmb) m_colorSchemeCmb->setToolTip("Selects the waterfall color palette.");
     if (m_bgOpacitySlider) m_bgOpacitySlider->setToolTip("Opacity of the background image overlay.");
     if (m_floorEnableBtn) m_floorEnableBtn->setToolTip("Shows a noise floor reference line on the spectrum display.");
-    if (m_floorSlider) m_floorSlider->setToolTip("Vertical position of the noise floor reference line.");
+    if (m_floorSlider) m_floorSlider->setToolTip("Radio squelch level (0-100). 0 = off (noise passes), raise to gate above the noise floor.");
 
     m_displayPanel->adjustSize();
 }
@@ -1175,12 +1175,15 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
     m_rateLabel->setText(QString::number(rateSliderVal));
 
     if (m_floorSlider) {
-        QSignalBlocker bf(m_floorSlider), be(m_floorEnableBtn);
-        m_floorSlider->setValue(floorPos);
-        m_floorLabel->setText(QString::number(floorPos));
+        // m_floorSlider is the radio squelch level control; its value is
+        // initialized from the slice in syncSquelchState() — do NOT overwrite
+        // it here with the visual noise-floor position (floorPos).
+        QSignalBlocker be(m_floorEnableBtn);
         m_floorEnableBtn->setChecked(floorEnable);
         m_floorEnableBtn->setText(floorEnable ? "On" : "Off");
         m_floorSlider->setEnabled(floorEnable);
+        if (m_sqlEnableBtn) m_sqlEnableBtn->setEnabled(floorEnable);
+        if (m_sqlAutoBtn)   m_sqlAutoBtn->setEnabled(floorEnable);
     }
     if (m_heatMapBtn) {
         QSignalBlocker bh(m_heatMapBtn);
@@ -1240,8 +1243,7 @@ void SpectrumOverlayMenu::syncSquelchState(bool enabled, int level, bool autoMod
         m_sqlEnableBtn->setChecked(enabled);
         m_sqlEnableBtn->setText(enabled ? "On" : "Off");
         m_floorLabel->setText(QString::number(level));
-        if (m_floorSlider->isEnabled())
-            m_floorSlider->setValue(level);
+        m_floorSlider->setValue(level);  // always update, not just when enabled
     }
     if (m_sqlAutoBtn) {
         QSignalBlocker b(*m_sqlAutoBtn);

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -52,8 +52,6 @@ public:
     void syncExtraDisplaySettings(bool blankerOn, float blankerThresh,
                                   int bgOpacity,
                                   int freqGridSpacingKhz = 0);
-    // Sync squelch state from an external source (sidebar, model change).
-    void syncSquelchState(bool enabled, int level, bool autoMode);
 
     // Set the panadapter ID this overlay belongs to (for +RX routing).
     void setPanId(const QString& id) { m_panId = id; }
@@ -115,11 +113,6 @@ signals:
     void wfLineDurationChanged(int ms);
     void wfColorSchemeChanged(int scheme);
     void noiseFloorPositionChanged(int pos);
-    void noiseFloorEnableChanged(bool on);
-    // Squelch controls mirrored from the floor panel
-    void squelchEnableChanged(bool on);
-    void squelchLevelChanged(int level);   // 0-100 radio units
-    void squelchAutoChanged(bool on);
     // Auto-squelch margin: dBm above 20th-pct noise floor (5-20 dBm)
     void autoSqlMarginDbChanged(int dBm);
     // Emitted when user selects a band from the sub-panel.
@@ -238,12 +231,6 @@ private:
     QPushButton* m_wfBlankerBtn{nullptr};
     QSlider*     m_wfBlankerThreshSlider{nullptr};
     QLabel*      m_wfBlankerThreshLabel{nullptr};
-    QSlider*     m_floorSlider{nullptr};
-    QLabel*      m_floorLabel{nullptr};
-    QPushButton* m_floorEnableBtn{nullptr};   // enables noise floor measurement
-    QPushButton* m_sqlEnableBtn{nullptr};     // enables radio squelch
-    QPushButton* m_sqlAutoBtn{nullptr};       // enables auto-squelch
-
     QSlider*     m_autoSqlMarginSlider{nullptr};
     QLabel*      m_autoSqlMarginLabel{nullptr};
     QComboBox*   m_freqGridSpacingCmb{nullptr};

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -52,6 +52,8 @@ public:
     void syncExtraDisplaySettings(bool blankerOn, float blankerThresh,
                                   int bgOpacity,
                                   int freqGridSpacingKhz = 0);
+    // Sync squelch state from an external source (sidebar, model change).
+    void syncSquelchState(bool enabled, int level, bool autoMode);
 
     // Set the panadapter ID this overlay belongs to (for +RX routing).
     void setPanId(const QString& id) { m_panId = id; }
@@ -114,6 +116,10 @@ signals:
     void wfColorSchemeChanged(int scheme);
     void noiseFloorPositionChanged(int pos);
     void noiseFloorEnableChanged(bool on);
+    // Squelch controls mirrored from the floor panel
+    void squelchEnableChanged(bool on);
+    void squelchLevelChanged(int level);   // 0-100 radio units
+    void squelchAutoChanged(bool on);
     // Emitted when user selects a band from the sub-panel.
     void bandSelected(const QString& bandName, double freqMhz, const QString& mode);
     // Emitted when user clicks XVTR button to open Radio Setup XVTR tab.
@@ -232,7 +238,9 @@ private:
     QLabel*      m_wfBlankerThreshLabel{nullptr};
     QSlider*     m_floorSlider{nullptr};
     QLabel*      m_floorLabel{nullptr};
-    QPushButton* m_floorEnableBtn{nullptr};
+    QPushButton* m_floorEnableBtn{nullptr};   // enables noise floor measurement
+    QPushButton* m_sqlEnableBtn{nullptr};     // enables radio squelch
+    QPushButton* m_sqlAutoBtn{nullptr};       // enables auto-squelch
 
     QComboBox*   m_freqGridSpacingCmb{nullptr};
     QSlider*     m_bgOpacitySlider{nullptr};

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -120,6 +120,8 @@ signals:
     void squelchEnableChanged(bool on);
     void squelchLevelChanged(int level);   // 0-100 radio units
     void squelchAutoChanged(bool on);
+    // Auto-squelch margin: dBm above 20th-pct noise floor (5-20 dBm)
+    void autoSqlMarginDbChanged(int dBm);
     // Emitted when user selects a band from the sub-panel.
     void bandSelected(const QString& bandName, double freqMhz, const QString& mode);
     // Emitted when user clicks XVTR button to open Radio Setup XVTR tab.
@@ -242,6 +244,8 @@ private:
     QPushButton* m_sqlEnableBtn{nullptr};     // enables radio squelch
     QPushButton* m_sqlAutoBtn{nullptr};       // enables auto-squelch
 
+    QSlider*     m_autoSqlMarginSlider{nullptr};
+    QLabel*      m_autoSqlMarginLabel{nullptr};
     QComboBox*   m_freqGridSpacingCmb{nullptr};
     QSlider*     m_bgOpacitySlider{nullptr};
     QLabel*      m_bgOpacityLabel{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1415,11 +1415,22 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
             float sample     = sorted[n / 5];              // 20th percentile — floor ref
             float peakSample = sorted[std::min(n * 19 / 20, n - 1)]; // 95th percentile — for auto-SQL
 
-            // Heavy EWMA (α=0.05 ≈ 20-sample window) prevents jumping.
-            if (m_noiseFloorDbm <= -200.0f)
+            // Signal-presence gate: if the spread between 80th and 20th
+            // percentile exceeds 15 dBm a signal is riding the band.  Freeze
+            // the floor EWMA so AGC-induced apparent dips don't drag the
+            // auto-squelch threshold down mid-transmission.
+            const float p80    = sorted[std::min(n * 4 / 5, n - 1)];
+            const bool signalPresent = (p80 - sample) > 15.0f;
+
+            // Asymmetric EWMA: rise fast (band got noisier → raise threshold
+            // quickly to protect ears), fall slowly (apparent drop may just be
+            // AGC reacting to a signal — don't chase it down).
+            if (m_noiseFloorDbm <= -200.0f) {
                 m_noiseFloorDbm = sample;
-            else
-                m_noiseFloorDbm = 0.05f * sample + 0.95f * m_noiseFloorDbm;
+            } else if (!signalPresent) {
+                const float alpha = (sample > m_noiseFloorDbm) ? 0.15f : 0.02f;
+                m_noiseFloorDbm = alpha * sample + (1.0f - alpha) * m_noiseFloorDbm;
+            }
 
             if (m_noiseFloorPeakDbm <= -200.0f)
                 m_noiseFloorPeakDbm = peakSample;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -558,8 +558,16 @@ void SpectrumWidget::setSquelchLine(bool visible, int level)
 void SpectrumWidget::setAutoSquelchEnable(bool on)
 {
     m_autoSquelchEnabled = on;
-    if (!on)
-        m_noiseFloorPeakDbm = -999.0f;
+    if (!on) {
+        m_noiseFloorPeakDbm    = -999.0f;
+        m_lastAutoSquelchLevel = -1;
+    }
+}
+
+void SpectrumWidget::setAutoSqlMarginDb(int dBm)
+{
+    m_autoSqlMarginDb      = std::clamp(dBm, 5, 20);
+    m_lastAutoSquelchLevel = -1;  // force re-emit with new margin
 }
 
 void SpectrumWidget::setWfColorScheme(int scheme) {
@@ -1418,14 +1426,24 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
             else
                 m_noiseFloorPeakDbm = 0.05f * peakSample + 0.95f * m_noiseFloorPeakDbm;
 
-            // Auto-squelch: suggest a radio level 0.5 dBm above the peak floor.
-            if (m_autoSquelchEnabled && m_noiseFloorPeakDbm > -200.0f) {
-                const float minDbm    = m_refLevel - m_dynamicRange;
-                const float targetDbm = m_noiseFloorPeakDbm + 0.5f;
+            // Auto-squelch: suggest a level m_autoSqlMarginDb dBm above the
+            // 20th-percentile noise floor (default 10 dBm, user-adjustable via
+            // Display > SQL Margin).  The 20th-pct EWMA sits below the audible
+            // gate point — atmospheric QRN is bursty and the EWMA lags.
+            // The radio maps squelch_level 0-100 to a fixed absolute dBm scale
+            // (~-160 to -60 dBm, 1 dBm per unit): level = targetDbm - kSqlMinDbm.
+            // Deduplicate: only emit when the integer level changes so we don't
+            // flood the radio with identical commands on every FFT frame.
+            if (m_autoSquelchEnabled && m_noiseFloorDbm > -200.0f) {
+                constexpr float kSqlMinDbm = -160.0f;
+                const float targetDbm = m_noiseFloorDbm + static_cast<float>(m_autoSqlMarginDb);
                 const int level = std::clamp(
-                    static_cast<int>((targetDbm - minDbm) / m_dynamicRange * 100.0f + 0.5f),
+                    static_cast<int>(targetDbm - kSqlMinDbm + 0.5f),
                     1, 100);
-                emit autoSquelchLevelSuggested(level);
+                if (level != m_lastAutoSquelchLevel) {
+                    m_lastAutoSquelchLevel = level;
+                    emit autoSquelchLevelSuggested(level);
+                }
             }
 
             markOverlayDirty();
@@ -5423,10 +5441,14 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
     }
 
     // ── Squelch threshold overlay line (solid yellow) ─────────────────────
-    // Position maps radio squelch 0-100 linearly across the display dBm range.
+    // The radio maps squelch_level 0-100 to a fixed absolute dBm scale:
+    // approximately -160 dBm (level 0, no squelch) to -60 dBm (level 100,
+    // maximum squelch), 1 dBm per unit.  This is independent of the display
+    // range, so the line correctly tracks the actual gate position regardless
+    // of zoom level or refLevel setting.
     if (m_squelchLineVisible && m_squelchLevel > 0) {
-        const float minDbm     = m_refLevel - m_dynamicRange;
-        const float squelchDbm = minDbm + (m_squelchLevel / 100.0f) * m_dynamicRange;
+        constexpr float kSqlMinDbm = -160.0f;
+        const float squelchDbm = kSqlMinDbm + static_cast<float>(m_squelchLevel);
         const float norm       = (m_refLevel - squelchDbm) / m_dynamicRange;
         const int sy = specRect.top()
                        + static_cast<int>(std::clamp(norm, 0.0f, 1.0f) * specRect.height());

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -313,6 +313,9 @@ void SpectrumWidget::loadSettings()
     m_wfColorScheme  = static_cast<WfColorScheme>(
         std::clamp(s.value(settingsKey("DisplayWfColorScheme"), "0").toInt(),
                    0, static_cast<int>(WfColorScheme::Count) - 1));
+    m_noiseFloorPosition = std::clamp(
+        s.value(settingsKey("DisplayNoiseFloorPosition"), "85").toInt(), 0, 100);
+    m_noiseFloorEnable   = s.value(settingsKey("DisplayNoiseFloorEnable"), "False").toString() == "True";
     m_singleClickTune = s.value("SingleClickTune", "False").toString() == "True";
     m_showTuneGuides  = s.value("ShowTuneGuides", "False").toString() == "True";
     m_extendedFrequencyLine = s.value("ExtendedFrequencyLine", "False").toString() == "True";
@@ -329,7 +332,8 @@ void SpectrumWidget::loadSettings()
             static_cast<int>(m_fftFillAlpha * 100), m_fftWeightedAvg, m_fftFillColor,
             m_wfColorGain, m_wfBlackLevel, m_wfAutoBlack, m_wfAutoBlackOffset,
             m_wfLineDuration,
-            75, false, m_fftHeatMap, static_cast<int>(m_wfColorScheme), m_showGrid,
+            m_noiseFloorPosition, m_noiseFloorEnable,
+            m_fftHeatMap, static_cast<int>(m_wfColorScheme), m_showGrid,
             m_fftLineWidth);
         m_overlayMenu->syncExtraDisplaySettings(m_wfBlankerEnabled,
             m_wfBlankerThreshold, m_bgOpacity, m_freqGridSpacingKhz);
@@ -521,6 +525,41 @@ void SpectrumWidget::setWfLineDuration(int ms) {
     s.save();
     // Re-calibrate the time scale for the new rate
     resetWfTimeScale();
+}
+
+void SpectrumWidget::setNoiseFloorPosition(int pos)
+{
+    m_noiseFloorPosition = std::clamp(pos, 0, 100);
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("DisplayNoiseFloorPosition"), QString::number(m_noiseFloorPosition));
+    s.save();
+}
+void SpectrumWidget::setNoiseFloorEnable(bool on)
+{
+    m_noiseFloorEnable = on;
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("DisplayNoiseFloorEnable"), on ? "True" : "False");
+    s.save();
+    if (!on) {
+        m_noiseFloorFrameCount = 0;
+        m_noiseFloorDbm      = -999.0f;  // reset so next enable starts fresh
+        m_noiseFloorPeakDbm  = -999.0f;
+    }
+    markOverlayDirty();
+}
+
+void SpectrumWidget::setSquelchLine(bool visible, int level)
+{
+    m_squelchLineVisible = visible;
+    m_squelchLevel = qBound(0, level, 100);
+    markOverlayDirty();
+}
+
+void SpectrumWidget::setAutoSquelchEnable(bool on)
+{
+    m_autoSquelchEnabled = on;
+    if (!on)
+        m_noiseFloorPeakDbm = -999.0f;
 }
 
 void SpectrumWidget::setWfColorScheme(int scheme) {
@@ -1356,40 +1395,40 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
     }
     m_bins = binsDbm;
 
-    // Noise floor auto-adjust: every 10 frames, measure noise floor and
-    // adjust min_dbm so it sits at the user's chosen position.
+    // Noise floor line: every 10 frames sample percentile bins from the smoothed
+    // spectrum, EWMA-smooth to keep the overlay stable.  Display range unchanged.
     if (m_noiseFloorEnable && !m_transmitting && !m_smoothed.isEmpty()) {
         if (++m_noiseFloorFrameCount >= 10) {
             m_noiseFloorFrameCount = 0;
 
-            // Compute noise floor as 20th percentile of smoothed bins
             QVector<float> sorted = m_smoothed;
             std::sort(sorted.begin(), sorted.end());
-            int idx = sorted.size() / 5;  // 20th percentile
-            float noiseFloor = sorted[idx];
+            const int n = sorted.size();
+            float sample     = sorted[n / 5];              // 20th percentile — floor ref
+            float peakSample = sorted[std::min(n * 19 / 20, n - 1)]; // 95th percentile — for auto-SQL
 
-            // Position: 0 = noise at top, 100 = noise at bottom
-            // noiseFloor should appear at (position/100) of the way down
-            float frac = m_noiseFloorPosition / 100.0f;
-            // noiseFloor maps to frac in the display:
-            //   frac = (refLevel - noiseFloor) / dynamicRange
-            //   => dynamicRange = (refLevel - noiseFloor) / frac
-            // Keep refLevel (max_dbm) fixed, adjust min_dbm
-            if (frac > 0.05f && frac < 0.95f) {
-                float newRange = (m_refLevel - noiseFloor) / frac;
-                newRange = std::clamp(newRange, 20.0f, 150.0f);
-                float newMin = m_refLevel - newRange;
-                // Only adjust if change is significant (> 1 dB)
-                float currentMin = m_refLevel - m_dynamicRange;
-                if (std::abs(newMin - currentMin) > 1.0f) {
-                    // Optimistic update: suppress re-firing on subsequent FFT frames
-                    // while waiting for the radio to confirm and echo the new range.
-                    // Without this, every FFT frame would re-emit until the echo-back
-                    // arrives, producing a burst of identical display pan set commands.
-                    m_dynamicRange = newRange;
-                    emit dbmRangeChangeRequested(newMin, m_refLevel);
-                }
+            // Heavy EWMA (α=0.05 ≈ 20-sample window) prevents jumping.
+            if (m_noiseFloorDbm <= -200.0f)
+                m_noiseFloorDbm = sample;
+            else
+                m_noiseFloorDbm = 0.05f * sample + 0.95f * m_noiseFloorDbm;
+
+            if (m_noiseFloorPeakDbm <= -200.0f)
+                m_noiseFloorPeakDbm = peakSample;
+            else
+                m_noiseFloorPeakDbm = 0.05f * peakSample + 0.95f * m_noiseFloorPeakDbm;
+
+            // Auto-squelch: suggest a radio level 0.5 dBm above the peak floor.
+            if (m_autoSquelchEnabled && m_noiseFloorPeakDbm > -200.0f) {
+                const float minDbm    = m_refLevel - m_dynamicRange;
+                const float targetDbm = m_noiseFloorPeakDbm + 0.5f;
+                const int level = std::clamp(
+                    static_cast<int>((targetDbm - minDbm) / m_dynamicRange * 100.0f + 0.5f),
+                    1, 100);
+                emit autoSquelchLevelSuggested(level);
             }
+
+            markOverlayDirty();
         }
     }
 
@@ -5361,6 +5400,50 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
         if (!so.isActive) drawOne(so);
     for (const auto& so : m_sliceOverlays)
         if (so.isActive) drawOne(so);
+
+    // ── Noise floor overlay line (dashed amber reference) ────────────────
+    if (m_noiseFloorEnable && m_noiseFloorDbm > -500.0f) {
+        const float norm = (m_refLevel - m_noiseFloorDbm) / m_dynamicRange;
+        const int y = specRect.top()
+                      + static_cast<int>(std::clamp(norm, 0.0f, 1.0f) * specRect.height());
+
+        QPen floorPen(QColor(0xFF, 0xA0, 0x20, 200), 1, Qt::DashLine);
+        floorPen.setDashPattern({6, 4});
+        p.setPen(floorPen);
+        p.drawLine(specRect.left(), y, specRect.right(), y);
+
+        QFont f = p.font();
+        f.setPixelSize(9);
+        f.setBold(true);
+        p.setFont(f);
+        p.setPen(QColor(0xFF, 0xA0, 0x20, 220));
+        const QString lbl = QString("Floor %1 dBm").arg(static_cast<int>(m_noiseFloorDbm));
+        const int lblW = p.fontMetrics().horizontalAdvance(lbl);
+        p.drawText(specRect.right() - lblW - 4, y - 2, lbl);
+    }
+
+    // ── Squelch threshold overlay line (solid yellow) ─────────────────────
+    // Position maps radio squelch 0-100 linearly across the display dBm range.
+    if (m_squelchLineVisible && m_squelchLevel > 0) {
+        const float minDbm     = m_refLevel - m_dynamicRange;
+        const float squelchDbm = minDbm + (m_squelchLevel / 100.0f) * m_dynamicRange;
+        const float norm       = (m_refLevel - squelchDbm) / m_dynamicRange;
+        const int sy = specRect.top()
+                       + static_cast<int>(std::clamp(norm, 0.0f, 1.0f) * specRect.height());
+
+        p.setPen(QPen(QColor(0xFF, 0xFF, 0x00, 200), 1.5f, Qt::SolidLine));
+        p.drawLine(specRect.left(), sy, specRect.right(), sy);
+
+        QFont sf = p.font();
+        sf.setPixelSize(9);
+        sf.setBold(true);
+        p.setFont(sf);
+        p.setPen(QColor(0xFF, 0xFF, 0x00, 220));
+        const QString slbl = QString("SQL %1").arg(m_squelchLevel);
+        const int slblW = p.fontMetrics().horizontalAdvance(slbl);
+        p.drawText(specRect.left() + 4, sy - 2, slbl);
+        (void)slblW;
+    }
 }
 
 // ─── Frequency scale bar ──────────────────────────────────────────────────────

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -94,8 +94,16 @@ public:
     void setDbmRange(float minDbm, float maxDbm);
 
     // Noise floor auto-adjust: position (0=top, 100=bottom), enable on/off.
-    void setNoiseFloorPosition(int pos) { m_noiseFloorPosition = pos; }
-    void setNoiseFloorEnable(bool on)   { m_noiseFloorEnable = on; }
+    // Persisted to AppSettings; call setNoiseFloorEnable(true) to activate.
+    void setNoiseFloorPosition(int pos);
+    void setNoiseFloorEnable(bool on);
+
+    // Squelch threshold overlay line.  Call setSquelchLine(true, level) to show
+    // a solid yellow line at the radio squelch level (0-100 → full dBm range).
+    void setSquelchLine(bool visible, int level);
+    // When enabled, emits autoSquelchLevelSuggested() each measurement cycle
+    // with a level 0.5 dBm above the 95th-percentile smoothed noise.
+    void setAutoSquelchEnable(bool on);
 
     // (getters for display settings are below with their members)
 
@@ -388,6 +396,8 @@ signals:
                           const QString& comment, int lifetimeSec,
                           bool forwardToCluster);
     void spotRemoveRequested(int spotIndex);
+    // Auto-squelch computed a new suggested level (0-100 radio units).
+    void autoSquelchLevelSuggested(int level);
 
 protected:
 #ifdef AETHER_GPU_SPECTRUM
@@ -482,10 +492,17 @@ private:
     float m_refLevel{-50.0f};       // top of display (dBm)
     float m_dynamicRange{100.0f};   // dB range shown in spectrum (-50 to -150)
 
-    // Noise floor auto-adjust
+    // Noise floor overlay line
     bool  m_noiseFloorEnable{false};
-    int   m_noiseFloorPosition{75};  // 0=top, 100=bottom
+    int   m_noiseFloorPosition{85};  // reserved for future squelch-offset use
     int   m_noiseFloorFrameCount{0};
+    float m_noiseFloorDbm{-999.0f};     // EWMA 20th-percentile; -999 = unmeasured
+    float m_noiseFloorPeakDbm{-999.0f}; // EWMA 95th-percentile for auto-squelch
+
+    // Squelch threshold overlay line
+    bool  m_squelchLineVisible{false};
+    int   m_squelchLevel{0};          // 0-100 radio squelch units
+    bool  m_autoSquelchEnabled{false};
 
     // Tuning step size for click-snap and wheel scroll (Hz)
     int m_stepHz{100};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -104,6 +104,8 @@ public:
     // When enabled, emits autoSquelchLevelSuggested() each measurement cycle
     // with a level 0.5 dBm above the 95th-percentile smoothed noise.
     void setAutoSquelchEnable(bool on);
+    // Margin above the 20th-pct noise floor for auto-squelch suggestion (5-20 dBm).
+    void setAutoSqlMarginDb(int dBm);
 
     // (getters for display settings are below with their members)
 
@@ -503,6 +505,8 @@ private:
     bool  m_squelchLineVisible{false};
     int   m_squelchLevel{0};          // 0-100 radio squelch units
     bool  m_autoSquelchEnabled{false};
+    int   m_autoSqlMarginDb{10};      // dBm above 20th-pct floor; user-tunable via Display tab
+    int   m_lastAutoSquelchLevel{-1}; // dedup — only emit when level changes
 
     // Tuning step size for click-snap and wheel scroll (Hz)
     int m_stepHz{100};


### PR DESCRIPTION
## Summary

- **Auto SQL button** in the RX Controls panel: single toggle that enables noise floor measurement, sets the squelch threshold just above the floor, and automatically enables the radio squelch gate
- **AGC-aware asymmetric EWMA**: floor rises fast (α=0.15, ~3 s) when band gets noisier; falls slowly (α=0.02, ~25 s) so AGC-induced apparent dips during a QSO do not drag the auto-squelch threshold down
- **Signal-presence gate**: freezes floor tracking when 80th–20th percentile spread exceeds 15 dBm — AGC gain reduction during a strong signal no longer lowers the threshold mid-transmission
- **Correct squelch threshold line**: fixed display formula to use the radio fixed absolute dBm scale (-160 + level) rather than display-relative — line now tracks the actual gate position regardless of zoom/refLevel
- **SQL Margin slider** in Display tab (5–20 dB, default 10): user-tunable dBm margin above the noise floor; persisted via AppSettings key AutoSqlMarginDb
- **Squelch controls moved** from Display overlay popup to RX Controls panel; dead signals, members, and syncSquelchState() removed from SpectrumOverlayMenu
- **Rollback point**: commit 23a5607 tagged pre-agc-autosquelch

## Test plan

- [ ] Enable Auto SQL on 40m — squelch gate should close on noise floor, open on signals
- [ ] Verify yellow threshold line position matches actual gate point (adjust SQL Margin if needed)
- [ ] Confirm AGC (Slow/Med/Fast) does not cause threshold to chase down during a strong signal
- [ ] Verify Auto SQL button also enables SQL button automatically
- [ ] Check SQL Margin slider in Display tab persists across restarts
- [ ] Rollback test: `git reset --hard 23a5607` restores pre-AGC behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)