### PR TITLE
fix(audio): restore L-R pan on Windows 48kHz resampler path (#2403)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -849,12 +849,44 @@ static void applyRxPanInPlace(float* stereo, int nFrames, int pan)
 }
 
 // Resample 24kHz stereo float32 → 48kHz stereo float32 via r8brain.
+// L and R are processed through separate Resampler instances so that any
+// per-channel difference (radio-applied audio_pan) is preserved.
+// processStereoToStereo() collapses L+R to mono — do NOT use it here.
 QByteArray AudioEngine::resampleStereo(const QByteArray& pcm)
 {
     if (!m_rxResampler)
         m_rxResampler = std::make_unique<Resampler>(24000, 48000);
+    if (!m_rxResamplerR)
+        m_rxResamplerR = std::make_unique<Resampler>(24000, 48000);
+
+    const int frames = pcm.size() / (2 * static_cast<int>(sizeof(float)));
+    if (frames <= 0) return {};
+
     const auto* src = reinterpret_cast<const float*>(pcm.constData());
-    return m_rxResampler->processStereoToStereo(src, pcm.size() / (2 * static_cast<int>(sizeof(float))));
+
+    std::vector<float> lBuf(frames), rBuf(frames);
+    for (int i = 0; i < frames; ++i) {
+        lBuf[i] = src[2 * i];
+        rBuf[i] = src[2 * i + 1];
+    }
+
+    QByteArray lOut = m_rxResampler->process(lBuf.data(), frames);
+    QByteArray rOut = m_rxResamplerR->process(rBuf.data(), frames);
+
+    const int outFrames = lOut.size() / static_cast<int>(sizeof(float));
+    const int rFrames   = rOut.size() / static_cast<int>(sizeof(float));
+    const int commonFrames = std::min(outFrames, rFrames);
+    if (commonFrames <= 0) return {};
+
+    QByteArray result(commonFrames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto*       dst  = reinterpret_cast<float*>(result.data());
+    const auto* lSrc = reinterpret_cast<const float*>(lOut.constData());
+    const auto* rSrc = reinterpret_cast<const float*>(rOut.constData());
+    for (int i = 0; i < commonFrames; ++i) {
+        dst[2 * i]     = lSrc[i];
+        dst[2 * i + 1] = rSrc[i];
+    }
+    return result;
 }
 
 void AudioEngine::feedAudioData(const QByteArray& pcm)

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -583,8 +583,9 @@ private:
     std::atomic<int>   m_rxBufferCapMs{200}; // RX buffer cap in ms (#1505)
     std::atomic<bool>  m_muted{false};
     bool  m_resampleTo48k{false};      // RX: upsample 24kHz → 48kHz output
-    std::unique_ptr<Resampler> m_rxResampler;      // 24k stereo → 48k stereo (lazy init)
-    std::unique_ptr<Resampler> m_radeRxResampler;  // separate 24k→48k for RADE decoded speech
+    std::unique_ptr<Resampler> m_rxResampler;       // 24k→48k for L channel (lazy init)
+    std::unique_ptr<Resampler> m_rxResamplerR;      // 24k→48k for R channel — kept in sync with m_rxResampler
+    std::unique_ptr<Resampler> m_radeRxResampler;   // separate 24k→48k for RADE decoded speech
     std::unique_ptr<CwSidetoneGenerator> m_cwSidetone;  // local CW sidetone, mixed into RX drain
     bool  m_txNeedsResample{false};      // TX: input rate != 24kHz, needs resampling
     bool  m_txInputMono{false};          // TX: input device is mono


### PR DESCRIPTION
 ## Summary
                                                                                                                          - `processStereoToStereo()` collapses L+R to mono then duplicates both channels — it was designed for mono-source
  audio, not true stereo.                                                                                                 - Commit 029613c made 48kHz the Windows default (to fix WASAPI artefacts), routing all non-NR RX audio through
  `resampleStereo()` → `processStereoToStereo()`, which destroyed the radio's VITA-49 per-channel pan encoding.           - Result: both channels always equal → slider had no effect; centre was louder than extremes because panned audio was   being averaged to mono.
  - Fix: added `m_rxResamplerR` (a second independent r8brain instance) and rewrote `resampleStereo()` to deinterleave,   resample L and R separately, then reinterleave — preserving the radio-applied `audio_pan` through the upsample.
  - `processStereoToStereo()` is unchanged; TciServer DAX TX and RADE callers correctly want mono-collapse.             
  ## Test plan                                                                                                          
  - [ ] Move L-R pan slider to left limit — audio heard in left speaker only                                              - [ ] Move L-R pan slider to right limit — audio heard in right speaker only                                            - [ ] Centre position (50) — equal volume in both channels, no loudness change vs. before
  - [ ] Verify with NR2/RN2/NR4/DFNR enabled — pan still applies correctly (existing path, no regression)                 - [ ] Windows only — Linux/macOS unaffected (24kHz path, `m_resampleTo48k = false`)                                                                                                                                                             Fixes #2403                                                                                                                                                                                                                                     🤖 Generated with [Claude Code](https://claude.com/claude-code)                                                                                                                                     

commit 029613c flipped the Windows RX sink preference to 48kHz to avoid WASAPI artefacts. All non-NR audio now passes through resampleStereo(), which called processStereoToStereo() — a helper that collapses L+R to mono then duplicates both channels. This destroyed the radio-applied audio_pan encoding in the VITA-49 stereo stream, so the slider had no effect (both channels always equal, centre sounded louder than extremes).

Fix: process L and R through separate Resampler instances (m_rxResampler and new m_rxResamplerR) so per-channel amplitude differences are preserved through the upsample. processStereoToStereo() is unchanged — other callers (TciServer DAX TX, RADE) intentionally want mono-collapse.

Fixes #2403