### PR TITLE
Preserve restored panadapter FPS on startup

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -11711,8 +11711,6 @@ void MainWindow::createPansSequentially(const QString& layoutId, int total,
                 // Configure the pan
                 m_radioModel.sendCommand(
                     QString("display pan set %1 xpixels=1024 ypixels=700").arg(panId));
-                m_radioModel.sendCommand(
-                    QString("display pan set %1 fps=25").arg(panId));
             }
 
             // Create next pan after a brief delay

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1044,7 +1044,7 @@ void RadioModel::createPanadapter()
             ensureOwnedPanadapter(panId);
             QTimer::singleShot(200, this, [this, panId]() {
                 sendCmd(QString("display pan set %1 xpixels=1024 ypixels=700").arg(panId));
-                sendCmd(QString("display pan set %1 fps=25 min_dbm=-130 max_dbm=-40").arg(panId));
+                sendCmd(QString("display pan set %1 min_dbm=-130 max_dbm=-40").arg(panId));
             });
         }
     };
@@ -3872,10 +3872,10 @@ void RadioModel::configurePan()
     emit panDimensionsNeeded(m_activePanId);
 
     sendCmd(
-        QString("display pan set %1 fps=25 min_dbm=-130 max_dbm=-40").arg(m_activePanId),
+        QString("display pan set %1 min_dbm=-130 max_dbm=-40").arg(m_activePanId),
         [](int code, const QString&) {
             if (code != 0)
-                qCWarning(lcProtocol) << "RadioModel: display pan set fps/average/dbm failed, code" << Qt::hex << code;
+                qCWarning(lcProtocol) << "RadioModel: display pan set dBm failed, code" << Qt::hex << code;
         });
 }
 


### PR DESCRIPTION
## Summary

- Remove hardcoded `fps=25` from automatic panadapter startup/configuration setup while preserving the existing dimension and dBm setup commands.
- Stop layout-created pan setup from sending a standalone `display pan set <panId> fps=25` after pan dimensions are applied.
- Leave the explicit Display Settings Reset path unchanged so it still resets `DisplayFftFps` to `25` and sends `fps=25` by user action.

## Root Cause

AetherSDR could correctly restore a saved `DisplayFftFps` value such as `30`, then later automatic pan setup paths sent `display pan set ... fps=25`, which FlexRadio treats as the authoritative panadapter FPS setter. That later command overrode the restored setting and caused the live FPS to settle back near 25.

## Validation

- Confirmed in the local FlexLib API dump that `Panadapter.FPS` sends `display pan set 0x<streamId> fps=<value>`.
- Ran `rg -n "display pan set .*fps=25|fps=25 min_dbm" src/gui src/models`; the only remaining match is the explicit Display Settings Reset command in `src/gui/MainWindow.cpp`.
- Built with `env -u CPLUS_INCLUDE_PATH cmake --build build-ninja --parallel 22`.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
