### PR TITLE
Fix TCI volume / drive / rx_volume command dispatch (#1764)

### DIFF
--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -1,5 +1,6 @@
 #ifdef HAVE_WEBSOCKETS
 #include "TciProtocol.h"
+#include "AppSettings.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
@@ -189,6 +190,7 @@ QString TciProtocol::generateInitBurst()
 QString TciProtocol::handleCommand(const QString& cmd)
 {
     m_pendingNotification.clear();
+    m_pendingMasterVolume = -1;
 
     if (cmd.isEmpty()) return {};
 
@@ -204,9 +206,14 @@ QString TciProtocol::handleCommand(const QString& cmd)
         for (auto& a : args) a = a.trimmed();
     }
 
-    // Determine if this is a set (has args beyond trx) or get (trx only or no args)
-    // TCI convention: get has 1 arg (trx), set has 2+ args
-    bool isSet = false;
+    // Determine if this is a set or get. TCI convention is: 0-1 args = GET
+    // (no args, or trx index only), 2+ args = SET (trx index + value(s)).
+    // Computed once up front so all dispatched commands see the correct
+    // value — the previous implementation only set this AFTER the first
+    // dispatch block, leaving early-dispatched commands (rx_volume,
+    // cw_keyer_speed, mon_volume, rx_mute, rx_balance, …) with isSet=false
+    // forever and silently treating SETs as GETs. See issue #1764.
+    bool isSet = (args.size() >= 2);
 
     // Commands with special handling
     if (name == "start")            return cmdStart();
@@ -246,8 +253,8 @@ QString TciProtocol::handleCommand(const QString& cmd)
     if (name == "if_limits")        return QStringLiteral("if_limits:-10000,10000;");
     if (name == "vfo_lock")         return cmdLock(args, isSet);  // alias
 
-    // Bidirectional commands: get if 0-1 args, set if 2+
-    isSet = (args.size() >= 2);
+    // Bidirectional commands — isSet was already computed at the top of
+    // this function, so the dispatch is uniform from here on.
 
     if (name == "vfo")              return cmdVfo(args, isSet);
     if (name == "modulation")       return cmdModulation(args, isSet);
@@ -439,16 +446,21 @@ QString TciProtocol::cmdTune(const QStringList& args, bool isSet)
 
 // ── DRIVE: get/set RF power ────────────────────────────────────────────────
 
-QString TciProtocol::cmdDrive(const QStringList& args, bool isSet)
+// DRIVE and TUNE_DRIVE are global commands per the TCI v2.0 spec — they have
+// no TRX prefix. Spec form: `drive;` for GET, `drive:N;` for SET. The
+// dispatcher's isSet heuristic (args.size() >= 2) is wrong for globals
+// (treats `drive:50;` as a GET). We override here: any args at all = SET,
+// no args = GET. We also accept the legacy TRX-prefixed form `drive:0,N;`
+// for backward compatibility — when 2+ args arrive, we take args[1] as the
+// value and ignore the trx index (drive is global anyway).
+QString TciProtocol::cmdDrive(const QStringList& args, bool /*isSet*/)
 {
-    if (!isSet) {
+    if (args.isEmpty()) {
         int pwr = m_model ? m_model->transmitModel().rfPower() : 0;
         return QStringLiteral("drive:%1;").arg(pwr);
     }
-
-    if (args.isEmpty()) return {};
     bool ok;
-    int pwr = args[0].toInt(&ok);
+    int pwr = args[args.size() == 1 ? 0 : 1].toInt(&ok);
     if (!ok) return {};
     QMetaObject::invokeMethod(m_model, [this, pwr]() {
         m_model->transmitModel().setRfPower(pwr);
@@ -460,16 +472,14 @@ QString TciProtocol::cmdDrive(const QStringList& args, bool isSet)
 
 // ── TUNE_DRIVE: get/set tune power ─────────────────────────────────────────
 
-QString TciProtocol::cmdTuneDrive(const QStringList& args, bool isSet)
+QString TciProtocol::cmdTuneDrive(const QStringList& args, bool /*isSet*/)
 {
-    if (!isSet) {
+    if (args.isEmpty()) {
         int pwr = m_model ? m_model->transmitModel().tunePower() : 0;
         return QStringLiteral("tune_drive:%1;").arg(pwr);
     }
-
-    if (args.isEmpty()) return {};
     bool ok;
-    int pwr = args[0].toInt(&ok);
+    int pwr = args[args.size() == 1 ? 0 : 1].toInt(&ok);
     if (!ok) return {};
     QMetaObject::invokeMethod(m_model, [this, pwr]() {
         m_model->transmitModel().setTunePower(pwr);
@@ -735,28 +745,40 @@ QString TciProtocol::cmdSqlLevel(const QStringList& args, bool isSet)
 
 // ── Volume / Mute ──────────────────────────────────────────────────────────
 
-QString TciProtocol::cmdVolume(const QStringList& args, bool isSet)
+// VOLUME is a GLOBAL command per TCI v2.0 spec — it controls the master
+// output level the operator hears, not a per-slice audio gain. This
+// matches the title bar's master volume slider in the GUI. Per-receiver
+// volume goes through the separate `rx_volume` command (cmdRxVolume).
+//
+// Spec form:  GET = `volume;`  (no args)
+//             SET = `volume:N;` (1 arg, 0-100)
+//
+// We also accept the legacy TRX-prefixed form `volume:trx,N;` for
+// backward compatibility — the trx is ignored since master volume is
+// global. Old clients that previously sent this form to set per-slice
+// gain were silently broken (the SET path mixed up vol and trx
+// indices) — those clients should migrate to `rx_volume:trx,N;`.
+//
+// For SET, we don't directly call AudioEngine here — TciProtocol owns
+// only the RadioModel, not AudioEngine. Instead we stash the requested
+// level in m_pendingMasterVolume; TciServer reads it after handleCommand
+// and forwards the request to MainWindow via signal, mirroring the path
+// taken by the title bar's masterVolumeChanged signal.
+QString TciProtocol::cmdVolume(const QStringList& args, bool /*isSet*/)
 {
-    if (!isSet) {
-        // Volume is per-slice audioGain in FlexRadio (0-100)
-        if (!args.isEmpty()) {
-            int trx = args[0].toInt();
-            auto* s = sliceForTrx(trx);
-            if (s) return QStringLiteral("volume:%1;")
-                              .arg(static_cast<int>(s->audioGain()));
-        }
-        return {};
+    if (args.isEmpty()) {
+        // GET — current master volume from saved settings (the same value
+        // the title bar slider reads on startup).
+        int pct = AppSettings::instance()
+                      .value("MasterVolume", "100").toInt();
+        return QStringLiteral("volume:%1;").arg(pct);
     }
 
-    if (args.isEmpty()) return {};
-    int vol = args[0].toInt();
-    // Apply to the specified trx slice, or first slice as fallback
-    auto* s = sliceForTrx(args.size() > 1 ? args[0].toInt() : 0);
-    if (s) {
-        float gain = static_cast<float>(vol);
-        QMetaObject::invokeMethod(s, [s, gain]() { s->setAudioGain(gain); },
-                                  Qt::QueuedConnection);
-    }
+    // SET — accept either spec form (1 arg) or legacy trx-prefixed (2+ args).
+    int vol = args[args.size() == 1 ? 0 : 1].toInt();
+    if (vol < 0)   vol = 0;
+    if (vol > 100) vol = 100;
+    m_pendingMasterVolume = vol;
 
     m_pendingNotification = QStringLiteral("volume:%1;").arg(vol);
     return {};

--- a/src/core/TciProtocol.h
+++ b/src/core/TciProtocol.h
@@ -27,6 +27,13 @@ public:
     // Returns empty if no broadcast needed.
     QString pendingNotification();
 
+    // After handleCommand(), if the command was a master-volume SET, this
+    // returns the requested level (0-100). -1 means no master-volume change
+    // was requested. The TciServer reads this to forward the request to
+    // MainWindow (which owns the AudioEngine + RadioModel-lineout path).
+    // Per TCI v2.0 spec, `volume:N;` is the global master volume command.
+    int pendingMasterVolume() const { return m_pendingMasterVolume; }
+
 private:
     // Command handlers — return response string or empty
     QString cmdVfo(const QStringList& args, bool isSet);
@@ -107,6 +114,7 @@ private:
 
     RadioModel* m_model;
     QString     m_pendingNotification;
+    int         m_pendingMasterVolume{-1};   // -1 = no change requested
     bool        m_started{false};  // client sent START
 };
 

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -248,6 +248,13 @@ quint16 TciServer::port() const
     return m_server ? m_server->serverPort() : 0;
 }
 
+void TciServer::broadcastMasterVolume(int pct)
+{
+    if (pct < 0)   pct = 0;
+    if (pct > 100) pct = 100;
+    broadcast(QStringLiteral("volume:%1;").arg(pct));
+}
+
 void TciServer::setTxGain(float gain)
 {
     const float clamped = std::clamp(gain, 0.0f, 1.0f);
@@ -552,6 +559,14 @@ void TciServer::onTextMessage(const QString& msg)
                     cs.socket->sendTextMessage(notification);
             }
         }
+
+        // Master volume SET — TciProtocol owns only RadioModel, so it can't
+        // touch AudioEngine directly. It stashes the requested level and we
+        // forward to MainWindow via signal, mirroring the title bar slider's
+        // signal path. The notification (`volume:N;`) was already echoed
+        // above to the requesting client and broadcast to others.
+        int mvol = client.protocol->pendingMasterVolume();
+        if (mvol >= 0) emit masterVolumeRequested(mvol);
 
         // Start/stop TX_CHRONO when a TCI client sets trx state.
         // WSJT-X only sends TX audio in response to TX_CHRONO (type=3) frames.
@@ -1154,6 +1169,16 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
         const int trx = TciProtocol::tciTrxForSlice(m_model,slice);
         broadcast(QStringLiteral("lock:%1,%2;")
                       .arg(trx).arg(locked ? "true" : "false"));
+    });
+
+    // Per-slice audioGain → `rx_volume:trx,N;` broadcast. Without this,
+    // a GUI change to a slice's audio level was invisible to TCI clients;
+    // remote controllers would drift out of sync. Part of issue #1764 fix.
+    connect(slice, &SliceModel::audioGainChanged, this, [this, slice](float gain) {
+        if (m_clients.isEmpty()) return;
+        const int trx = TciProtocol::tciTrxForSlice(m_model, slice);
+        broadcast(QStringLiteral("rx_volume:%1,%2;")
+                      .arg(trx).arg(static_cast<int>(gain)));
     });
 }
 

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -41,6 +41,12 @@ public:
 
     void setAudioEngine(AudioEngine* audio) { m_audio = audio; }
 
+    // Broadcast a master-volume change to all connected TCI clients. Called
+    // by MainWindow whenever the GUI master volume slider moves so remote
+    // controllers (e.g. aether_pad) stay in sync. Idempotent — clients
+    // re-applying the value they just sent is harmless.
+    void broadcastMasterVolume(int pct);
+
     // TCI TX gain (0.0–1.0). Applied to outbound TX audio from WSJT-X/JTDX
     // before the radio.  Decoupled from DaxTxGain (#1627) — the DAX bridge
     // and TCI maintain independent gain settings.  Persists to TciTxGain.
@@ -70,6 +76,11 @@ signals:
     void clientCountChanged(int count);
     void rxLevel(int channel, float rms);  // 1-based channel, RMS of TCI-gained RX audio
     void txLevel(float rms);                // RMS of post-gain TCI TX audio
+    // Emitted when a TCI client sends `volume:N;` (master volume SET).
+    // MainWindow handles it by calling the same path as the title bar
+    // master volume slider — m_audio->setRxVolume() (or lineout when PC
+    // audio is off) plus persistence to AppSettings.
+    void masterVolumeRequested(int pct);
 
 private slots:
     void onNewConnection();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2563,16 +2563,11 @@ MainWindow::MainWindow(QWidget* parent)
             m_radioModel.removeRxAudioStream();
         }
     });
-    connect(m_titleBar, &TitleBar::masterVolumeChanged, this, [this](int pct) {
-        bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
-        if (pcAudio)
-            m_audio->setRxVolume(pct / 100.0f);
-        else
-            m_radioModel.setLineoutGain(pct);
-        auto& s = AppSettings::instance();
-        s.setValue("MasterVolume", QString::number(pct));
-        s.save();
-    });
+    // Master volume — title bar slider routes through applyMasterVolume()
+    // so the TCI `volume:N;` command (#1764) can hit the same code path
+    // when m_tciServer is created later in this constructor.
+    connect(m_titleBar, &TitleBar::masterVolumeChanged,
+            this, &MainWindow::applyMasterVolume);
     connect(m_titleBar, &TitleBar::headphoneVolumeChanged,
             &m_radioModel, &RadioModel::setHeadphoneGain);
     connect(m_titleBar, &TitleBar::lineoutMuteChanged, this, [this](bool muted) {
@@ -3746,6 +3741,16 @@ MainWindow::MainWindow(QWidget* parent)
             m_appletPanel->tciApplet(), &TciApplet::setTciRxLevel);
     connect(m_tciServer, &TciServer::txLevel,
             m_appletPanel->tciApplet(), &TciApplet::setTciTxLevel);
+
+    // TCI `volume:N;` master-volume SET → mirror on the title bar slider
+    // and route through the same applyMasterVolume() slot the slider uses
+    // (audio path + persistence + broadcast back to other TCI clients).
+    // See issue #1764 — no master-volume TCI hook existed before.
+    connect(m_tciServer, &TciServer::masterVolumeRequested,
+            this, [this](int pct) {
+        if (m_titleBar) m_titleBar->setMasterVolume(pct);
+        applyMasterVolume(pct);
+    });
 
     // Wire slice state changes -> TCI broadcasts. TCI receivers are contiguous
     // indexes within our owned slice list; Flex slice ids can be non-zero when
@@ -8079,6 +8084,23 @@ bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPan
     if (!repeaterFixup.isEmpty())
         m_radioModel.sendCommand(repeaterFixup);
     return true;
+}
+
+void MainWindow::applyMasterVolume(int pct)
+{
+    if (pct < 0)   pct = 0;
+    if (pct > 100) pct = 100;
+    bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+    if (pcAudio)
+        m_audio->setRxVolume(pct / 100.0f);
+    else
+        m_radioModel.setLineoutGain(pct);
+    auto& s = AppSettings::instance();
+    s.setValue("MasterVolume", QString::number(pct));
+    s.save();
+#ifdef HAVE_WEBSOCKETS
+    if (m_tciServer) m_tciServer->broadcastMasterVolume(pct);
+#endif
 }
 
 void MainWindow::onSliceAdded(SliceModel* s)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -112,6 +112,13 @@ private slots:
     void onSliceAdded(SliceModel* slice);
     void onSliceRemoved(int id);
 
+    // Master volume — single entry point used by both the title bar slider
+    // (TitleBar::masterVolumeChanged) and TCI clients (TciServer::
+    // masterVolumeRequested) so the audio path, persistence, and TCI
+    // broadcast all stay in lockstep regardless of which UI changed it.
+    // See issue #1764.
+    void applyMasterVolume(int pct);
+
 private:
     enum class TuneIntent {
         IncrementalTune,


### PR DESCRIPTION
Closes #1764.

Resolves long-standing TCI bugs where `DRIVE`, `VOLUME` and `RX_VOLUME` SET commands had no effect on the radio. Diagnosed independently while building a standalone TCI control surface (aether_pad on Arduino Giga R1) — sending `volume:N;` from the pad caused the displayed value to flicker but the actual audio never moved. Tracing through `TciProtocol.cpp` confirmed the same five issues the existing #1764 triage flagged.

## What's fixed

1. **`isSet` was initialised to `false` and only assigned its real value AFTER the first dispatch block.**
   Every command dispatched in lines 211–247 (`rx_volume`, `cw_keyer_speed`, `mon_volume`, `rx_mute`, `rx_balance`, `mon_enable`, `rx_nb_param`, `rx_bin_enable`, `rx_anc_enable`, `rx_dse_enable`, `rx_nf_enable`, `digl_offset`, `digu_offset`, `vfo_lock`) silently took the GET path forever, ignoring client SET values.
   Fix: compute `isSet = (args.size() >= 2)` once at the top of `handleCommand`.

2. **`cmdDrive` / `cmdTuneDrive` read power from `args[0]` (the trx index) instead of `args[1]`** — `drive:0,50;` set power to 0. DRIVE is a global command per TCI v2.0; rewritten to treat any args as SET, take `args[0]` as the value (or `args[1]` for legacy trx-prefixed form).

3. **`cmdVolume` confused vol and trx indices and applied to per-slice gain instead of the master output the operator hears.** Per spec, `volume:N;` is GLOBAL master volume.
   Rewritten as a global master-volume command with proper plumbing to `AudioEngine::setRxVolume()` (or `RadioModel::setLineoutGain` when PC audio is off) — the same path the title bar slider uses. `TciProtocol` doesn't own `AudioEngine`, so the requested level is stashed in a new `m_pendingMasterVolume` member; `TciServer` reads it after `handleCommand` and emits `masterVolumeRequested(int)` for `MainWindow` to handle. `applyMasterVolume()` factored into a private slot shared by both the title bar slider and the new TCI signal.

4. **GUI master-volume changes were invisible to TCI clients.** `applyMasterVolume()` now calls `TciServer::broadcastMasterVolume(pct)` so remote controllers stay in sync when the operator drags the title bar slider.

5. **Per-slice `audioGainChanged` was never broadcast.** `TciServer::wireSlice()` now emits `rx_volume:trx,N;` on slice audio-gain changes — GUI changes reach connected TCI clients.

## Files

| File | Change |
|---|---|
| `src/core/TciProtocol.h` | Add `pendingMasterVolume()` accessor and `m_pendingMasterVolume` member |
| `src/core/TciProtocol.cpp` | Compute `isSet` once at top; rewrite `cmdDrive`/`cmdTuneDrive`/`cmdVolume` per TCI v2.0 spec |
| `src/core/TciServer.h` | Add `masterVolumeRequested(int)` signal + `broadcastMasterVolume(int)` method |
| `src/core/TciServer.cpp` | Forward `pendingMasterVolume` to MainWindow via signal; broadcast `rx_volume` on slice gain changes; implement `broadcastMasterVolume` |
| `src/gui/MainWindow.h` | Add `applyMasterVolume(int)` private slot |
| `src/gui/MainWindow.cpp` | Factor master-volume logic into `applyMasterVolume()`; wire title bar + TCI signals through it; broadcast on every change |

## Test plan

- [x] `volume:N;` from a TCI client moves the title bar slider AND changes audible output (via either AudioEngine or radio lineout depending on `PcAudioEnabled`)
- [x] Dragging the title bar slider broadcasts `volume:N;` to all connected TCI clients
- [x] `rx_volume:trx,N;` continues to control per-slice audio gain (was already working post-dispatch fix)
- [x] GUI changes to slice audio gain emit `rx_volume:trx,N;` to TCI clients
- [x] `drive:N;` (1 arg, spec form) AND `drive:0,N;` (legacy trx-prefixed) both correctly set TX power
- [x] `tune_drive:N;` same — both 1-arg and 2-arg forms accepted
- [x] Build clean on Windows (Qt 6.10.3 + MSVC), Linux (Qt 6.2.4), macOS (Qt 6.11)
- [x] End-to-end verified with aether_pad — bidirectional sync, audio actually changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)