### PR TITLE
Reassert desired panadapter and waterfall display rates

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2401,6 +2401,11 @@ MainWindow::MainWindow(QWidget* parent)
             QObject::disconnect(it.value());
             m_panFpsReconcileConnections.erase(it);
         }
+        if (auto it = m_wfLineDurationReconcileConnections.find(panId);
+            it != m_wfLineDurationReconcileConnections.end()) {
+            QObject::disconnect(it.value());
+            m_wfLineDurationReconcileConnections.erase(it);
+        }
         if (auto it = m_panFpsReconcile.find(panId);
             it != m_panFpsReconcile.end()) {
             if (it->timer) {
@@ -2408,6 +2413,14 @@ MainWindow::MainWindow(QWidget* parent)
                 it->timer->deleteLater();
             }
             m_panFpsReconcile.erase(it);
+        }
+        if (auto it = m_wfLineDurationReconcile.find(panId);
+            it != m_wfLineDurationReconcile.end()) {
+            if (it->timer) {
+                it->timer->stop();
+                it->timer->deleteLater();
+            }
+            m_wfLineDurationReconcile.erase(it);
         }
 
         // Disconnect all signals from the dying applet's widgets to prevent
@@ -7874,6 +7887,11 @@ void MainWindow::onConnectionStateChanged(bool connected)
             QObject::disconnect(it.value());
         }
         m_panFpsReconcileConnections.clear();
+        for (auto it = m_wfLineDurationReconcileConnections.begin();
+             it != m_wfLineDurationReconcileConnections.end(); ++it) {
+            QObject::disconnect(it.value());
+        }
+        m_wfLineDurationReconcileConnections.clear();
         for (auto it = m_panFpsReconcile.begin();
              it != m_panFpsReconcile.end(); ++it) {
             if (it->timer) {
@@ -7882,6 +7900,14 @@ void MainWindow::onConnectionStateChanged(bool connected)
             }
         }
         m_panFpsReconcile.clear();
+        for (auto it = m_wfLineDurationReconcile.begin();
+             it != m_wfLineDurationReconcile.end(); ++it) {
+            if (it->timer) {
+                it->timer->stop();
+                it->timer->deleteLater();
+            }
+        }
+        m_wfLineDurationReconcile.clear();
 
         // Clear spectrum/waterfall so the display doesn't look frozen
         for (auto* applet : m_panStack->allApplets())
@@ -9131,6 +9157,85 @@ void MainWindow::schedulePanFpsReconcile(const QString& panId, int reportedFps)
     state.timer->start();
 }
 
+void MainWindow::scheduleWaterfallLineDurationReconcile(const QString& panId, int reportedMs)
+{
+    if (panId.isEmpty() || reportedMs <= 0)
+        return;
+
+    auto* pan = m_radioModel.panadapter(panId);
+    if (!pan)
+        return;
+
+    auto& state = m_wfLineDurationReconcile[panId];
+    if (!state.spectrum) {
+        if (auto* applet = m_panStack->panadapter(panId))
+            state.spectrum = applet->spectrumWidget();
+    }
+
+    auto* sw = state.spectrum.data();
+    if (!sw)
+        return;
+
+    const int desiredMs = sw->wfLineDuration();
+    if (desiredMs <= 0)
+        return;
+    if (desiredMs == reportedMs) {
+        if (state.timer)
+            state.timer->stop();
+        state.lastSentMs = 0;
+        state.lastSentDesired = -1;
+        return;
+    }
+
+    if (!state.timer) {
+        state.timer = new QTimer(this);
+        state.timer->setSingleShot(true);
+        state.timer->setInterval(300);
+        connect(state.timer, &QTimer::timeout, this, [this, panId]() {
+            auto it = m_wfLineDurationReconcile.find(panId);
+            if (it == m_wfLineDurationReconcile.end())
+                return;
+
+            auto* pan = m_radioModel.panadapter(panId);
+            auto* sw = it->spectrum.data();
+            if (!sw) {
+                if (auto* applet = m_panStack->panadapter(panId)) {
+                    sw = applet->spectrumWidget();
+                    it->spectrum = sw;
+                }
+            }
+            if (!pan || !sw)
+                return;
+
+            const QString wfId = pan->waterfallId();
+            const int reported = pan->waterfallLineDuration();
+            const int desired = sw->wfLineDuration();
+            if (wfId.isEmpty() || reported <= 0 || desired <= 0 || reported == desired)
+                return;
+
+            constexpr qint64 kCooldownMs = 5000;
+            const qint64 now = QDateTime::currentMSecsSinceEpoch();
+            if (it->lastSentDesired == desired
+                && it->lastSentMs > 0
+                && now - it->lastSentMs < kCooldownMs) {
+                return;
+            }
+
+            qCDebug(lcProtocol).noquote().nospace()
+                << "MainWindow: reasserting waterfall rate pan=" << panId
+                << " waterfall=" << wfId
+                << " reported_line_duration=" << reported
+                << " desired_line_duration=" << desired;
+            m_radioModel.sendCommand(
+                QString("display panafall set %1 line_duration=%2").arg(wfId).arg(desired));
+            it->lastSentMs = now;
+            it->lastSentDesired = desired;
+        });
+    }
+
+    state.timer->start();
+}
+
 void MainWindow::wirePanadapter(PanadapterApplet* applet)
 {
     auto* sw = applet->spectrumWidget();
@@ -9204,6 +9309,22 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                 schedulePanFpsReconcile(panId, fps);
             }));
         schedulePanFpsReconcile(applet->panId(), pan->fps());
+
+        auto oldWfLineDurationConnection =
+            m_wfLineDurationReconcileConnections.take(applet->panId());
+        if (oldWfLineDurationConnection)
+            QObject::disconnect(oldWfLineDurationConnection);
+
+        auto& wfLineDurationState = m_wfLineDurationReconcile[applet->panId()];
+        wfLineDurationState.spectrum = sw;
+        m_wfLineDurationReconcileConnections.insert(
+            applet->panId(),
+            connect(pan, &PanadapterModel::waterfallLineDurationReported,
+                    this, [this, panId = applet->panId()](int ms) {
+                scheduleWaterfallLineDurationReconcile(panId, ms);
+            }));
+        scheduleWaterfallLineDurationReconcile(applet->panId(),
+                                               pan->waterfallLineDuration());
     }
 
     // ── Debounced resize → re-push xpixels/ypixels to the radio (#1511) ───

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2396,6 +2396,20 @@ MainWindow::MainWindow(QWidget* parent)
 
     connect(&m_radioModel, &RadioModel::panadapterRemoved,
             this, [this](const QString& panId) {
+        if (auto it = m_panFpsReconcileConnections.find(panId);
+            it != m_panFpsReconcileConnections.end()) {
+            QObject::disconnect(it.value());
+            m_panFpsReconcileConnections.erase(it);
+        }
+        if (auto it = m_panFpsReconcile.find(panId);
+            it != m_panFpsReconcile.end()) {
+            if (it->timer) {
+                it->timer->stop();
+                it->timer->deleteLater();
+            }
+            m_panFpsReconcile.erase(it);
+        }
+
         // Disconnect all signals from the dying applet's widgets to prevent
         // dangling pointer crashes in wirePanadapter lambdas (#242)
         if (auto* applet = m_panStack->panadapter(panId)) {
@@ -7855,6 +7869,20 @@ void MainWindow::onConnectionStateChanged(bool connected)
         audioStopRx();
         audioStopTx();
 
+        for (auto it = m_panFpsReconcileConnections.begin();
+             it != m_panFpsReconcileConnections.end(); ++it) {
+            QObject::disconnect(it.value());
+        }
+        m_panFpsReconcileConnections.clear();
+        for (auto it = m_panFpsReconcile.begin();
+             it != m_panFpsReconcile.end(); ++it) {
+            if (it->timer) {
+                it->timer->stop();
+                it->timer->deleteLater();
+            }
+        }
+        m_panFpsReconcile.clear();
+
         // Clear spectrum/waterfall so the display doesn't look frozen
         for (auto* applet : m_panStack->allApplets())
             applet->spectrumWidget()->clearDisplay();
@@ -9026,6 +9054,83 @@ void MainWindow::routeCwDecoderOutput()
     }
 }
 
+void MainWindow::schedulePanFpsReconcile(const QString& panId, int reportedFps)
+{
+    if (panId.isEmpty() || reportedFps <= 0)
+        return;
+
+    auto* pan = m_radioModel.panadapter(panId);
+    if (!pan)
+        return;
+
+    auto& state = m_panFpsReconcile[panId];
+    if (!state.spectrum) {
+        if (auto* applet = m_panStack->panadapter(panId))
+            state.spectrum = applet->spectrumWidget();
+    }
+
+    auto* sw = state.spectrum.data();
+    if (!sw)
+        return;
+
+    const int desiredFps = sw->fftFps();
+    if (desiredFps <= 0)
+        return;
+    if (desiredFps == reportedFps) {
+        if (state.timer)
+            state.timer->stop();
+        state.lastSentMs = 0;
+        state.lastSentDesired = -1;
+        return;
+    }
+
+    if (!state.timer) {
+        state.timer = new QTimer(this);
+        state.timer->setSingleShot(true);
+        state.timer->setInterval(300);
+        connect(state.timer, &QTimer::timeout, this, [this, panId]() {
+            auto it = m_panFpsReconcile.find(panId);
+            if (it == m_panFpsReconcile.end())
+                return;
+
+            auto* pan = m_radioModel.panadapter(panId);
+            auto* sw = it->spectrum.data();
+            if (!sw) {
+                if (auto* applet = m_panStack->panadapter(panId)) {
+                    sw = applet->spectrumWidget();
+                    it->spectrum = sw;
+                }
+            }
+            if (!pan || !sw)
+                return;
+
+            const int reported = pan->fps();
+            const int desired = sw->fftFps();
+            if (reported <= 0 || desired <= 0 || reported == desired)
+                return;
+
+            constexpr qint64 kCooldownMs = 5000;
+            const qint64 now = QDateTime::currentMSecsSinceEpoch();
+            if (it->lastSentDesired == desired
+                && it->lastSentMs > 0
+                && now - it->lastSentMs < kCooldownMs) {
+                return;
+            }
+
+            qCDebug(lcProtocol).noquote().nospace()
+                << "MainWindow: reasserting panadapter FPS pan=" << panId
+                << " reported=" << reported
+                << " desired=" << desired;
+            m_radioModel.sendCommand(
+                QString("display pan set %1 fps=%2").arg(panId).arg(desired));
+            it->lastSentMs = now;
+            it->lastSentDesired = desired;
+        });
+    }
+
+    state.timer->start();
+}
+
 void MainWindow::wirePanadapter(PanadapterApplet* applet)
 {
     auto* sw = applet->spectrumWidget();
@@ -9085,6 +9190,20 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         //      update pan A's dBm scale.
         connect(pan, &PanadapterModel::levelChanged,
                 sw, &SpectrumWidget::setDbmRange);
+
+        auto oldFpsConnection = m_panFpsReconcileConnections.take(applet->panId());
+        if (oldFpsConnection)
+            QObject::disconnect(oldFpsConnection);
+
+        auto& fpsState = m_panFpsReconcile[applet->panId()];
+        fpsState.spectrum = sw;
+        m_panFpsReconcileConnections.insert(
+            applet->panId(),
+            connect(pan, &PanadapterModel::fpsReported,
+                    this, [this, panId = applet->panId()](int fps) {
+                schedulePanFpsReconcile(panId, fps);
+            }));
+        schedulePanFpsReconcile(applet->panId(), pan->fps());
     }
 
     // ── Debounced resize → re-push xpixels/ypixels to the radio (#1511) ───
@@ -11711,8 +11830,6 @@ void MainWindow::createPansSequentially(const QString& layoutId, int total,
                 // Configure the pan
                 m_radioModel.sendCommand(
                     QString("display pan set %1 xpixels=1024 ypixels=700").arg(panId));
-                m_radioModel.sendCommand(
-                    QString("display pan set %1 fps=25").arg(panId));
             }
 
             // Create next pan after a brief delay

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -166,6 +166,7 @@ private:
     void disableSplit();
     void wirePanadapter(PanadapterApplet* applet);
     void schedulePanFpsReconcile(const QString& panId, int reportedFps);
+    void scheduleWaterfallLineDurationReconcile(const QString& panId, int reportedMs);
     void reassertUnmutedSliceAudioForPan(const QString& panId);
     void setActivePanApplet(PanadapterApplet* applet);
     void routeCwDecoderOutput();  // wire CW decoder to the pan owning the active slice
@@ -516,6 +517,14 @@ private:
     };
     QHash<QString, PanFpsReconcileState> m_panFpsReconcile;
     QHash<QString, QMetaObject::Connection> m_panFpsReconcileConnections;
+    struct WaterfallLineDurationReconcileState {
+        QTimer* timer{nullptr};
+        QPointer<SpectrumWidget> spectrum;
+        qint64 lastSentMs{0};
+        int lastSentDesired{-1};
+    };
+    QHash<QString, WaterfallLineDurationReconcileState> m_wfLineDurationReconcile;
+    QHash<QString, QMetaObject::Connection> m_wfLineDurationReconcileConnections;
     QTimer* m_layoutRestoreTimer{nullptr}; // debounced layout rearrange after pans added on connect
     QTimer* m_heartbeatMissTimer{nullptr}; // fires every 1.5s to detect missed discovery beats
     QTimer* m_bsExpiryTimer{nullptr};    // band-stack bookmark auto-expiry, started on connect only (#1471)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -165,6 +165,7 @@ private:
     void updateSplitState();
     void disableSplit();
     void wirePanadapter(PanadapterApplet* applet);
+    void schedulePanFpsReconcile(const QString& panId, int reportedFps);
     void reassertUnmutedSliceAudioForPan(const QString& panId);
     void setActivePanApplet(PanadapterApplet* applet);
     void routeCwDecoderOutput();  // wire CW decoder to the pan owning the active slice
@@ -507,6 +508,14 @@ private:
     void dockAppletPanel();
     bool m_displaySettingsPushed{false};  // one-shot: push saved display settings after pan created
     bool m_applyingLayout{false};        // true during layout tear-down/recreate — suppresses panadapterAdded handler
+    struct PanFpsReconcileState {
+        QTimer* timer{nullptr};
+        QPointer<SpectrumWidget> spectrum;
+        qint64 lastSentMs{0};
+        int lastSentDesired{-1};
+    };
+    QHash<QString, PanFpsReconcileState> m_panFpsReconcile;
+    QHash<QString, QMetaObject::Connection> m_panFpsReconcileConnections;
     QTimer* m_layoutRestoreTimer{nullptr}; // debounced layout rearrange after pans added on connect
     QTimer* m_heartbeatMissTimer{nullptr}; // fires every 1.5s to detect missed discovery beats
     QTimer* m_bsExpiryTimer{nullptr};    // band-stack bookmark auto-expiry, started on connect only (#1471)

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -131,6 +131,18 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
 
 void PanadapterModel::applyWaterfallStatus(const QMap<QString, QString>& kvs)
 {
+    if (kvs.contains("line_duration")) {
+        bool ok = false;
+        const int ms = kvs["line_duration"].toInt(&ok);
+        if (ok) {
+            if (ms != m_waterfallLineDuration) {
+                m_waterfallLineDuration = ms;
+                emit waterfallLineDurationChanged(m_waterfallLineDuration);
+            }
+            emit waterfallLineDurationReported(ms);
+        }
+    }
+
     // Waterfall status shares center/bandwidth with pan — sync if present
     if (kvs.contains("center") || kvs.contains("bandwidth")) {
         bool changed = false;

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -94,6 +94,17 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
             emit wideChanged(m_wideActive);
         }
     }
+    if (kvs.contains("fps")) {
+        bool ok = false;
+        const int fps = kvs["fps"].toInt(&ok);
+        if (ok) {
+            if (fps != m_fps) {
+                m_fps = fps;
+                emit fpsChanged(m_fps);
+            }
+            emit fpsReported(fps);
+        }
+    }
     if (kvs.contains("ant_list")) {
         QStringList ants = kvs["ant_list"].split(',', Qt::SkipEmptyParts);
         if (ants != m_antList) {

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -40,6 +40,7 @@ public:
     int wnbLevel() const { return m_wnbLevel; }
     bool wideActive() const { return m_wideActive; }
     int fps() const { return m_fps; }
+    int waterfallLineDuration() const { return m_waterfallLineDuration; }
     QString preamp() const { return m_preamp; }
     void setPreamp(const QString& pre) {
         // Preamp is internal state only — no UI listeners. Do not emit
@@ -70,6 +71,8 @@ signals:
     void wideChanged(bool active);
     void fpsChanged(int fps);
     void fpsReported(int fps);
+    void waterfallLineDurationChanged(int ms);
+    void waterfallLineDurationReported(int ms);
     void waterfallIdChanged(const QString& wfId);
     void daxiqChannelChanged(int channel);
 
@@ -90,6 +93,7 @@ private:
     bool        m_wideActive{false};
     int         m_wnbLevel{50};
     int         m_fps{-1};
+    int         m_waterfallLineDuration{-1};
     QString     m_preamp;
     int         m_daxiqChannel{0};
     bool        m_resized{false};

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -39,6 +39,7 @@ public:
     bool wnbActive() const { return m_wnbActive; }
     int wnbLevel() const { return m_wnbLevel; }
     bool wideActive() const { return m_wideActive; }
+    int fps() const { return m_fps; }
     QString preamp() const { return m_preamp; }
     void setPreamp(const QString& pre) {
         // Preamp is internal state only — no UI listeners. Do not emit
@@ -67,6 +68,8 @@ signals:
     void rfGainInfoChanged(int low, int high, int step);
     void wnbChanged(bool active, int level);
     void wideChanged(bool active);
+    void fpsChanged(int fps);
+    void fpsReported(int fps);
     void waterfallIdChanged(const QString& wfId);
     void daxiqChannelChanged(int channel);
 
@@ -86,6 +89,7 @@ private:
     bool        m_wnbActive{false};
     bool        m_wideActive{false};
     int         m_wnbLevel{50};
+    int         m_fps{-1};
     QString     m_preamp;
     int         m_daxiqChannel{0};
     bool        m_resized{false};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1044,7 +1044,7 @@ void RadioModel::createPanadapter()
             ensureOwnedPanadapter(panId);
             QTimer::singleShot(200, this, [this, panId]() {
                 sendCmd(QString("display pan set %1 xpixels=1024 ypixels=700").arg(panId));
-                sendCmd(QString("display pan set %1 fps=25 min_dbm=-130 max_dbm=-40").arg(panId));
+                sendCmd(QString("display pan set %1 min_dbm=-130 max_dbm=-40").arg(panId));
             });
         }
     };
@@ -3872,10 +3872,10 @@ void RadioModel::configurePan()
     emit panDimensionsNeeded(m_activePanId);
 
     sendCmd(
-        QString("display pan set %1 fps=25 min_dbm=-130 max_dbm=-40").arg(m_activePanId),
+        QString("display pan set %1 min_dbm=-130 max_dbm=-40").arg(m_activePanId),
         [](int code, const QString&) {
             if (code != 0)
-                qCWarning(lcProtocol) << "RadioModel: display pan set fps/average/dbm failed, code" << Qt::hex << code;
+                qCWarning(lcProtocol) << "RadioModel: display pan set dbm failed, code" << Qt::hex << code;
         });
 }
 


### PR DESCRIPTION
## Summary

This PR fixes radio-restored display-rate drift for both panadapter FFT FPS and waterfall `Rate:` / `line_duration`.

Aether has app/user desired display settings, for example:

- Panadapter FFT FPS: `DisplayFftFps` / `SpectrumWidget::fftFps()`, often 30 FPS.
- Waterfall `Rate:` slider: `DisplayWfLineDuration` / `SpectrumWidget::wfLineDuration()`, defaulting to 100 ms.

The Flex radio can later restore persisted band/display state and report values such as:

- `display pan ... fps=25`
- `display waterfall ... line_duration=80`

Before this PR, those radio-restored values could silently override the radio-side display behavior while Aether's UI still showed the desired values. This PR treats Aether's persisted/widget settings as the desired truth and reconciles owned radio display status back to those settings after a short debounce.

## User-Facing Behavior

The waterfall control in Aether's panadapter overlay is labeled `Rate:`, not `line_duration`.

Current mapping:

- UI label: `Rate:`
- persisted setting: `DisplayWfLineDuration`
- widget API: `SpectrumWidget::wfLineDuration()` / `setWfLineDuration(int)`
- radio status/command field: `line_duration`
- slider range: `1..30`
- command value: `line_duration = slider + 70`
- default/max `Rate: 30` maps to `line_duration=100`

With desired `Rate: 30` / `DisplayWfLineDuration=100`, if the radio restores `line_duration=80` after a band/display-state transition, Aether now reasserts:

```text
display panafall set <waterfall_id> line_duration=100
```

## Root Cause

Aether's UI and settings kept the desired values, but the radio can restore persisted display state after common operating actions. Those restores arrive through normal radio status messages, not necessarily through Aether's centralized tuning policy.

This means drift can happen on paths such as:

- band jumps
- go-to frequency
- spots
- memories
- shortcuts
- pan scrolling/dragging across band/display-state boundaries
- radio-side persisted band/display state restores

The old code did not track the radio-reported display FPS or waterfall line duration separately enough to reconcile those radio-side restores back to Aether's desired settings.

## What Changed

### Panadapter FPS Reconciliation

- `PanadapterModel` now tracks the latest radio-reported `fps`.
- It emits:
  - `fpsChanged(int)` only when the reported value changes.
  - `fpsReported(int)` for every valid `fps=` status, including repeated restore bursts.
- `MainWindow::wirePanadapter()` wires each owned panadapter to `schedulePanFpsReconcile()`.
- If the radio-reported FPS differs from `sw->fftFps()`, Aether debounces for 300 ms, re-checks state, then sends:

```text
display pan set <pan_id> fps=<desired>
```

### Waterfall Rate / Line Duration Reconciliation

- `PanadapterModel::applyWaterfallStatus()` now tracks the latest radio-reported `line_duration`.
- It emits:
  - `waterfallLineDurationChanged(int)` only when the reported value changes.
  - `waterfallLineDurationReported(int)` for every valid `line_duration=` status, including repeated restore bursts.
- `MainWindow::wirePanadapter()` wires each owned panadapter to `scheduleWaterfallLineDurationReconcile()`.
- If the radio-reported waterfall line duration differs from `sw->wfLineDuration()`, Aether debounces for 300 ms, re-checks state, validates the waterfall ID, then sends:

```text
display panafall set <waterfall_id> line_duration=<desired>
```

### Debounce, Cooldown, And Cleanup

- Both reconcile paths use per-pan state.
- Both paths debounce briefly to absorb startup and drag/status bursts.
- Both paths use a 5 s same-desired cooldown to avoid command spam if the radio keeps refusing or repeatedly restoring a value.
- Both paths clear their cooldown guard when the radio reports the desired matching value, so a later fresh restore is corrected promptly.
- Timers and signal connections are cleaned up when a panadapter is removed.
- Reconcile state is cleared on disconnect.

### Removed Non-Reset Hardcoded FPS Sends

This PR also removes the remaining non-reset hardcoded `fps=25` display setup sends:

- `RadioModel::createPanadapter()` no longer sends `fps=25` while configuring dimensions/dBm.
- `RadioModel::configurePan()` no longer sends `fps=25` while configuring dimensions/dBm.
- Multi-pan layout creation no longer sends `fps=25` after `display panafall create`.

The explicit display-settings reset path still sends and persists `fps=25`, because in that case 25 is the app/user desired reset value.

## Important Behavioral Guarantees

- Aether's persisted/widget values are the desired truth.
- Radio-restored `fps=25` is not adopted into `DisplayFftFps`.
- Radio-restored `line_duration=80` is not adopted into `DisplayWfLineDuration`.
- Explicit user changes still win.
  - If the user sets FPS to 25, desired FPS becomes 25 and no 30 FPS reassert occurs.
  - If the user moves the `Rate:` slider so desired line duration becomes 80, desired line duration becomes 80 and no 100 ms reassert occurs.
- Multiple panadapters are reconciled independently.
- Slice/tune/pan command ordering is otherwise unchanged.
- Logging is low-noise and only occurs when Aether actually reasserts:
  - `MainWindow: reasserting panadapter FPS ...`
  - `MainWindow: reasserting waterfall rate ...`

## Evidence From Logs

Fresh long-run evidence showed the waterfall sibling of the original FPS bug:

- `20:44:38.308` go-to 28 MHz / 10m
- `20:44:38.469` radio reports `fps=25` and `line_duration=80`
- `20:44:38.796` Aether reasserts pan FPS to 30
- no `display panafall set ... line_duration=100` follows
- perf stays degraded at approximately `wfFps=12-13 wfLineMs=80`

Restart evidence showed the expected recovery behavior:

- radio briefly reports 10m `line_duration=80`
- startup display setup sends `display panafall set ... line_duration=100`
- radio echoes `line_duration=100`
- waterfall returns to approximately 25 FPS

This PR brings that restart-only recovery behavior into normal runtime reconciliation.

## Flex API Check

Checked the downloaded FlexLib v4.2.18.41174 API files:

- `Panadapter.cs`
  - `Panadapter.FPS` sends `display pan set 0x<stream> fps=<value>`.
  - panadapter status `fps=<value>` updates the internal FPS property and raises `FPS` changed.

- `Waterfall.cs`
  - `Waterfall.FallLineDurationMs` sends `display panafall set 0x<stream> line_duration=<value>`.
  - waterfall status `line_duration=<value>` updates the internal line-duration property and raises `FallLineDurationMs` changed.

That matches this PR's approach: reconcile display-rate commands independently from slice/tune/pan movement behavior.

## Validation

Built successfully with the required AetherSDR build command:

```sh
env -u CPLUS_INCLUDE_PATH cmake --build build-ninja --parallel 22
```

Also ran:

```sh
git diff --check
```

No whitespace errors were reported.

## Expected Runtime Verification

With desired FFT FPS of 30 and desired waterfall `Rate: 30` / `DisplayWfLineDuration=100`:

1. Startup should still send desired display settings through the existing display setup paths.
2. If the radio later reports `display pan ... fps=25` for an owned pan, Aether should send `display pan set <pan_id> fps=30` shortly after status settles.
3. If the radio later reports `display waterfall ... line_duration=80` for an owned waterfall, Aether should send `display panafall set <waterfall_id> line_duration=100` shortly after status settles.
4. If the radio already reports the desired values, Aether should not send repeated commands.
5. If the user explicitly changes FPS or `Rate:`, reconciliation should use the new desired values.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
