### PR TITLE
fix(protocol): send client program/low_bw_connect before client gui

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1231,10 +1231,6 @@ void RadioModel::onConnected()
     // Delay network monitor until after client gui registration
     // (pings sent before registration cause "Malformed command" on WAN)
 
-    // Send low bandwidth flag before GUI registration (matches FlexLib order)
-    if (AppSettings::instance().value("LowBandwidthConnect", "False").toString() == "True")
-        sendCmd("client low_bw_connect");
-
     // Register as GUI client FIRST — required before subscriptions,
     // especially on WAN/SmartLink where the radio is stricter.
     const QString clientId = AppSettings::instance().value("GUIClientID").toString();
@@ -1327,6 +1323,18 @@ void RadioModel::handleForcedClientDisconnect()
 
 void RadioModel::registerAsGuiClient(const QString& clientId)
 {
+    // Match FlexLib connect-sequence ordering (Radio.cs:2230-2247):
+    //   client program <name>  →  client low_bw_connect  →  client gui
+    // The radio's protocol state machine requires client identity (program)
+    // BEFORE accepting client-mode configuration (low_bw_connect), and the
+    // bandwidth mode must be set BEFORE GUI registration so it is baked
+    // into the client session.  Sending these out of order — as we did
+    // previously — caused the radio to silently ignore low_bw_connect
+    // (#2447: "Low Bandwidth checkbox doesn't do anything meaningful").
+    sendCmd("client program AetherSDR");
+    if (AppSettings::instance().value("LowBandwidthConnect", "False").toString() == "True")
+        sendCmd("client low_bw_connect");
+
     sendCmd(QString("client gui %1").arg(clientId), [this](int code, const QString& body) {
         if (code != 0) {
             qCWarning(lcProtocol) << "RadioModel: client gui failed, code" << Qt::hex << code;
@@ -1339,7 +1347,6 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
             qCDebug(lcProtocol) << "RadioModel: saved GUIClientID:" << body.trimmed();
         }
 
-        sendCmd("client program AetherSDR");
         QString station = AppSettings::instance().value("StationName", "").toString();
         if (station.isEmpty()) {
             station = QSysInfo::machineHostName();


### PR DESCRIPTION
Users reported the View → Connect → "Use low bandwidth mode" checkbox
had no observable effect on stream sizes when connecting via SmartLink
(#2447 and similar reports).  Tracing the connect sequence against
FlexLib reference (Radio.cs:2230-2247) revealed the wrong send order:

  AetherSDR (before):
    1. client low_bw_connect       ← sent right after TCP V/H exchange,
                                     before any client identity
    2. client ip                   (WAN only)
    3. client gui <uuid>
    4. client program AetherSDR    ← sent inside the gui reply handler,
                                     after registration

  FlexLib (canonical):
    1. client program <name>       ← identifies the client first
    2. (cond) client start_persistence off
    3. client low_bw_connect       ← AFTER program, BEFORE gui
    4. client gui [<uuid>]

The radio's protocol state machine requires client identity before
accepting client-mode commands, and the bandwidth mode must be set
before GUI registration so it is baked into the client session.  When
sent first, low_bw_connect arrives at an unauthenticated context that
gets superseded by the subsequent client gui registration — silently
dropped.

Move client program AetherSDR + (conditional) client low_bw_connect to
fire before client gui inside registerAsGuiClient.  Drop the early
sendCmd at onConnected and the duplicate program send from the gui
reply handler.  Other client config (station, send_reduced_bw_dax,
enforce_network_mtu) stays in the reply handler — those don't depend
on the program/low_bw ordering.

Comment cross-references the FlexLib source so the next maintainer
isn't tempted to "tidy up" the order.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
