### PR TITLE
fix(rade): guard RxApplet radeActivated(false) emit to match VfoWidget pattern

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -12794,6 +12794,7 @@ void MainWindow::activateRADE(int sliceId)
         m_audio->setPcMicGain(gain);
     }
     m_appletPanel->phoneCwApplet()->setRadeActive(true);
+    m_appletPanel->rxApplet()->setRadeActive(true);
 
     // Start mic capture if not already running
     if (!m_audio->isTxStreaming()) {
@@ -12845,6 +12846,7 @@ void MainWindow::deactivateRADE()
     m_audio->setRadeMode(false);
     m_audio->clearTxAccumulators();  // flush stale RADE modem data
     m_appletPanel->phoneCwApplet()->setRadeActive(false);
+    m_appletPanel->rxApplet()->setRadeActive(false);
     // For hardware mics, reset to full gain — the radio controls hardware levels.
     // PC mic keeps its PcMicGain so SSB sessions are unaffected.
     if (m_radioModel.transmitModel().micSelection() != "PC") {

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -398,7 +398,8 @@ void RxApplet::buildUI()
                 emit radeActivated(true, m_slice ? m_slice->sliceId() : -1);
                 return;
             }
-            emit radeActivated(false, m_slice ? m_slice->sliceId() : -1);
+            if (m_radeActive)
+                emit radeActivated(false, m_slice ? m_slice->sliceId() : -1);
 #endif
             if (m_slice) m_slice->setMode(mode);
         });
@@ -2009,6 +2010,10 @@ bool RxApplet::eventFilter(QObject* obj, QEvent* ev)
     }
     return QWidget::eventFilter(obj, ev);
 }
+
+#ifdef HAVE_RADE
+void RxApplet::setRadeActive(bool on) { m_radeActive = on; }
+#endif
 
 } // namespace AetherSDR
 #include "moc_GuardedSlider.cpp"

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -82,6 +82,9 @@ signals:
 
 public:
     void setInitialStepSize(int hz);
+#ifdef HAVE_RADE
+    void setRadeActive(bool on);
+#endif
 
     // Mode-aware filter width formatter, shared with VfoWidget so the two
     // filter readouts stay in sync (#794, #1225, #2197).
@@ -195,6 +198,10 @@ private:
     QPushButton* m_xitPlus{nullptr};
 
     static constexpr int RIT_STEP_HZ = 10;
+
+#ifdef HAVE_RADE
+    bool m_radeActive{false};
+#endif
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Summary

Closes #2062.

PR #2026 guarded `VfoWidget`'s unconditional `emit radeActivated(false, ...)` with `if (m_radeActive)` to prevent a multi-pan regression where changing mode on *any* slice would spuriously deactivate RADE on a *different* slice. `RxApplet` had the identical pattern and was not updated in the same PR.

This PR closes the asymmetry:

- **`RxApplet.h`** — adds `bool m_radeActive{false}` (private, `#ifdef HAVE_RADE`) and `void setRadeActive(bool on)` (public, `#ifdef HAVE_RADE`), mirroring `VfoWidget` and `PhoneCwApplet`
- **`RxApplet.cpp`** — guards `emit radeActivated(false, ...)` with `if (m_radeActive)`; adds one-line setter implementation
- **`MainWindow.cpp`** — wires `rxApplet()->setRadeActive(true/false)` in `activateRADE()`/`deactivateRADE()`, alongside the existing `phoneCwApplet()->setRadeActive()` calls

The `MainWindow` handler's `sliceId == m_radeSliceId` guard remains load-bearing and prevents any behavioral regression. This change is pure defense-in-depth: a future refactor that removes that guard would otherwise reintroduce the multi-pan RADE-teardown bug via the `RxApplet` path.

## Changes

| File | Change |
|------|--------|
| `src/gui/RxApplet.h` | +`setRadeActive(bool)` (public), +`m_radeActive{false}` (private) |
| `src/gui/RxApplet.cpp` | guard false-emit; add setter impl |
| `src/gui/MainWindow.cpp` | wire setter in `activateRADE` / `deactivateRADE` |

**Lines changed:** +14 / -1

## Test plan

- [ ] Build succeeds with `HAVE_RADE` defined (confirmed locally on Windows)
- [ ] Build succeeds without `HAVE_RADE` (all new code is gated)
- [ ] Activate RADE on slice A in a multi-slice layout; change mode on slice B — RADE on slice A must remain active
- [ ] Deactivate RADE on slice A — confirm clean teardown (no assertion, no double-deactivate)
- [ ] Single-slice layout: normal RADE activate/deactivate cycle unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)