### PR TITLE
fix(freedv): make Station Msg field live-update the reporter without restart

### DIFF
--- a/src/core/FreeDvClient.cpp
+++ b/src/core/FreeDvClient.cpp
@@ -486,6 +486,13 @@ void FreeDvClient::disableReporting()
     m_myMessage.clear();
 }
 
+void FreeDvClient::updateMessage(const QString& message)
+{
+    m_myMessage = message;
+    if (!m_reportingEnabled || !m_connected.load() || m_myCallsign.isEmpty()) return;
+    sendEvent("message_update", QJsonObject{{"message", message}});
+}
+
 void FreeDvClient::reportFreqChange(double freqMhz)
 {
     m_myFreqMhz = freqMhz;

--- a/src/core/FreeDvClient.h
+++ b/src/core/FreeDvClient.h
@@ -54,6 +54,7 @@ public slots:
 
     void reportFreqChange(double freqMhz);
     void reportTxState(bool transmitting);
+    void updateMessage(const QString& message);
 
     // Feed live SNR from RADEEngine::snrChanged — throttled to 1 s by internal timer.
     void updateRxSnr(float snrDb);

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1698,8 +1698,10 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
         "QLineEdit { background: #1a1a2e; color: #c8d8e8; border: 1px solid #203040; padding: 3px; }");
     connect(m_fdvMessageEdit, &QLineEdit::editingFinished, this, [this] {
         auto& as = AppSettings::instance();
-        as.setValue("FreeDvMyMessage", m_fdvMessageEdit->text().trimmed());
+        QString msg = m_fdvMessageEdit->text().trimmed();
+        as.setValue("FreeDvMyMessage", msg);
         as.save();
+        emit fdvMessageChanged(msg);
     });
     reportLayout->addWidget(m_fdvMessageEdit, frow, 1);
     frow++;

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1701,7 +1701,7 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
         QString msg = m_fdvMessageEdit->text().trimmed();
         as.setValue("FreeDvMyMessage", msg);
         as.save();
-        emit fdvMessageChanged(msg);
+        emit freedvMessageChanged(msg);
     });
     reportLayout->addWidget(m_fdvMessageEdit, frow, 1);
     frow++;

--- a/src/gui/DxClusterDialog.h
+++ b/src/gui/DxClusterDialog.h
@@ -108,6 +108,7 @@ signals:
     void freedvStartRequested();
     void freedvStopRequested();
     void freedvReportingToggled(bool enabled);
+    void fdvMessageChanged(const QString& message);
 #endif
     void wsjtxSpotFiltered(const DxSpot& spot);  // WSJT-X spot after filter+color
     void tuneRequested(double freqMhz, const QString& spotMode, const QString& comment);

--- a/src/gui/DxClusterDialog.h
+++ b/src/gui/DxClusterDialog.h
@@ -108,7 +108,7 @@ signals:
     void freedvStartRequested();
     void freedvStopRequested();
     void freedvReportingToggled(bool enabled);
-    void fdvMessageChanged(const QString& message);
+    void freedvMessageChanged(const QString& message);
 #endif
     void wsjtxSpotFiltered(const DxSpot& spot);  // WSJT-X spot after filter+color
     void tuneRequested(double freqMhz, const QString& spotMode, const QString& comment);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5891,6 +5891,10 @@ void MainWindow::buildMenuBar()
                 this, [this] { QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->startConnection(); }); });
         connect(dlg, &DxClusterDialog::freedvStopRequested,
                 this, [this] { QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->stopConnection(); }); });
+        connect(dlg, &DxClusterDialog::fdvMessageChanged,
+                this, [this](const QString& msg) {
+            QMetaObject::invokeMethod(m_freedvClient, [this, msg] { m_freedvClient->updateMessage(msg); });
+        });
 #ifdef HAVE_RADE
         connect(dlg, &DxClusterDialog::freedvReportingToggled,
                 this, [this](bool on) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5891,7 +5891,7 @@ void MainWindow::buildMenuBar()
                 this, [this] { QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->startConnection(); }); });
         connect(dlg, &DxClusterDialog::freedvStopRequested,
                 this, [this] { QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->stopConnection(); }); });
-        connect(dlg, &DxClusterDialog::fdvMessageChanged,
+        connect(dlg, &DxClusterDialog::freedvMessageChanged,
                 this, [this](const QString& msg) {
             QMetaObject::invokeMethod(m_freedvClient, [this, msg] { m_freedvClient->updateMessage(msg); });
         });


### PR DESCRIPTION
## Summary

Fixes #2340.

The **Station Msg** line edit on the SpotHub → FreeDV tab saves its value to `AppSettings` on `editingFinished`, but edits never reached the running `FreeDvClient` — `m_myMessage` was only assigned inside `enableReporting()` at RADE activation time. Restarting the app worked because `enableReporting()` re-reads `AppSettings` on the next activation.

This PR makes the field live for any session where RADE is currently active and connected to qso.freedv.org, without changing behavior for sessions where it isn't.

## Changes

| File | Change |
|------|--------|
| `src/core/FreeDvClient.h` | Add `updateMessage(const QString&)` to public slots |
| `src/core/FreeDvClient.cpp` | Implement it: update `m_myMessage`, send `message_update` if connected + reporting |
| `src/gui/DxClusterDialog.h` | Add `fdvMessageChanged(const QString&)` signal (inside `#ifdef HAVE_WEBSOCKETS`) |
| `src/gui/DxClusterDialog.cpp` | Emit `fdvMessageChanged` from the `editingFinished` lambda after saving to settings |
| `src/gui/MainWindow.cpp` | Wire signal → `QMetaObject::invokeMethod` to cross main→spot-thread boundary |

**Lines changed:** +15 / -1

## Design notes

- `updateMessage` follows the exact same guard pattern as `reportFreqChange`: `!m_reportingEnabled || !m_connected.load() || m_myCallsign.isEmpty()` → no-op. Safe to call at any time.
- Threading: `FreeDvClient` lives on `m_spotThread`. The dialog signal goes through `MainWindow` + `QMetaObject::invokeMethod`, matching the established `freedvStartRequested`/`freedvStopRequested` pattern — no direct cross-thread call from the dialog.
- `AppSettings` save is preserved, so the value is still picked up correctly by `enableReporting()` on the next RADE activation when not currently reporting.
- The new signal is inside `#ifdef HAVE_WEBSOCKETS` (not `#ifdef HAVE_RADE`) — the FreeDV Reporter tab exists independent of RADE being compiled in.

## Test plan

- [ ] Build succeeds with `HAVE_WEBSOCKETS` defined
- [ ] Build succeeds without `HAVE_WEBSOCKETS` (all new dialog/MainWindow code is gated)
- [ ] Connect to qso.freedv.org, activate RADE → station appears on map
- [ ] Edit Station Msg field and press Tab/Enter — message updates on the map without restart
- [ ] Edit the field while not connected or not reporting — no crash, no error; value is persisted to settings and appears on next activation
- [ ] Restart app — previously saved message is still shown in the field and sent on next activation (AppSettings path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)