### PR TITLE
Clamp reported slice capacity to model limit

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -15,6 +15,7 @@
 #include "core/MemoryRecallPolicy.h"
 #include "core/StreamStatus.h"
 #include "models/PanadapterModel.h"
+#include "models/RadioStatusOwnership.h"
 #include "SpectrumWidget.h"
 #ifdef AETHER_GPU_SPECTRUM
 #include <QRhiWidget>
@@ -11979,11 +11980,7 @@ void MainWindow::createPansSequentially(const QString& layoutId, int total,
                 showPanadapterSliceCapacityMessage();
                 return;
             }
-            const auto kvs = CommandParser::parseKVs(body);
-            QString panId;
-            if (kvs.contains("pan"))       panId = kvs["pan"];
-            else if (kvs.contains("id"))   panId = kvs["id"];
-            else                           panId = body.trimmed();
+            const QString panId = RadioStatusOwnership::parsePanafallCreatePanId(body);
 
             qDebug() << "applyPanLayout: created pan" << (created + 1) << "of" << total
                      << "id:" << panId;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -107,26 +107,14 @@ QString hexCode(int value)
 
 QString normalizePanadapterId(QString text)
 {
-    text = text.trimmed();
-    if (text.isEmpty())
-        return QString();
-
-    if (text.startsWith(QStringLiteral("0x"), Qt::CaseInsensitive))
-        text = text.mid(2);
-
-    bool ok = false;
-    const quint32 id = text.toUInt(&ok, 16);
-    return ok ? hexId(id) : text;
+    const QString trimmed = text.trimmed();
+    const QString normalized = RadioStatusOwnership::normalizedFlexId(trimmed);
+    return normalized.isEmpty() ? trimmed : normalized;
 }
 
 QString parsePanadapterCreateId(const QString& body)
 {
-    const QMap<QString, QString> kvs = CommandParser::parseKVs(body);
-    if (kvs.contains(QStringLiteral("pan")))
-        return normalizePanadapterId(kvs.value(QStringLiteral("pan")));
-    if (kvs.contains(QStringLiteral("id")))
-        return normalizePanadapterId(kvs.value(QStringLiteral("id")));
-    return normalizePanadapterId(body);
+    return RadioStatusOwnership::parsePanafallCreatePanId(body);
 }
 
 struct StreamObjectParts {
@@ -3513,9 +3501,25 @@ void RadioModel::handleRadioStatus(const QMap<QString, QString>& kvs)
     if (kvs.contains("model"))    { m_model = kvs["model"]; m_maxSlices = maxSlicesForModel(m_model); changed = true; }
     if (kvs.contains("slices")) {
         // slices=N reports available (unused) slots; total capacity = open + available
-        int available = kvs["slices"].toInt();
-        int total = m_slices.size() + available;
-        if (total > m_maxSlices) m_maxSlices = total;
+        const int available = kvs["slices"].toInt();
+        const int currentSliceCount = static_cast<int>(m_slices.size());
+        const int modelLimit = m_model.isEmpty() ? 0 : maxSlicesForModel(m_model);
+        const int reportedTotal = currentSliceCount + available;
+        if (modelLimit > 0 && reportedTotal > modelLimit) {
+            qCWarning(lcProtocol) << "RadioModel: ignoring impossible slice capacity"
+                                  << reportedTotal << "for model" << m_model
+                                  << "limit" << modelLimit
+                                  << "current slices" << currentSliceCount
+                                  << "reported available" << available;
+        }
+        const int updatedMax = RadioStatusOwnership::boundedSliceCapacity(
+            modelLimit,
+            m_maxSlices,
+            currentSliceCount,
+            available);
+        if (updatedMax != m_maxSlices) {
+            m_maxSlices = updatedMax;
+        }
         changed = true;
     }
     if (kvs.contains("callsign")) { m_callsign = kvs["callsign"]; changed = true; }

--- a/src/models/RadioStatusOwnership.h
+++ b/src/models/RadioStatusOwnership.h
@@ -6,6 +6,7 @@
 #include <QMap>
 #include <QString>
 
+#include <algorithm>
 #include <utility>
 
 namespace AetherSDR::RadioStatusOwnership {
@@ -23,9 +24,39 @@ inline QString streamCommandId(quint32 value)
         : QString::number(value, 16).rightJustified(8, QLatin1Char('0'));
 }
 
+inline QString normalizedFlexId(QString text)
+{
+    text = text.trimmed();
+    if (text.isEmpty()) {
+        return QString();
+    }
+
+    if (text.startsWith(QStringLiteral("0x"), Qt::CaseInsensitive)) {
+        text = text.mid(2);
+    }
+
+    bool ok = false;
+    const quint32 id = text.toUInt(&ok, 16);
+    return ok ? hexId(id) : QString();
+}
+
 inline quint32 parseFlexId(QString text)
 {
     return parseStatusHandle(std::move(text));
+}
+
+inline QString parsePanafallCreatePanId(const QString& body)
+{
+    const QMap<QString, QString> kvs = CommandParser::parseKVs(body);
+    if (kvs.contains(QStringLiteral("pan"))) {
+        return normalizedFlexId(kvs.value(QStringLiteral("pan")));
+    }
+    if (kvs.contains(QStringLiteral("id"))) {
+        return normalizedFlexId(kvs.value(QStringLiteral("id")));
+    }
+
+    const QStringList parts = body.trimmed().split(QLatin1Char(','));
+    return parts.isEmpty() ? QString() : normalizedFlexId(parts.constFirst());
 }
 
 struct StreamObjectParts {
@@ -122,6 +153,24 @@ inline quint32 parseCreateResponseStreamId(const QString& body)
     if (kvs.contains(QStringLiteral("id")))
         return parseStreamId(kvs.value(QStringLiteral("id")));
     return parseStreamId(body);
+}
+
+inline int boundedSliceCapacity(int modelLimit,
+                                int currentMax,
+                                int currentSliceCount,
+                                int reportedAvailableSlices)
+{
+    if (modelLimit <= 0) {
+        return currentMax;
+    }
+    const int clampedCurrentMax = std::min(currentMax, modelLimit);
+
+    if (reportedAvailableSlices < 0) {
+        return clampedCurrentMax;
+    }
+
+    const int reportedTotal = currentSliceCount + reportedAvailableSlices;
+    return std::min(modelLimit, std::max(clampedCurrentMax, reportedTotal));
 }
 
 inline RemoteAudioRxAction applyRemoteAudioRxStatus(RemoteAudioRxTracking& state,

--- a/tests/radio_status_ownership_test.cpp
+++ b/tests/radio_status_ownership_test.cpp
@@ -263,6 +263,35 @@ void testCreateResponseParsing()
           "numeric-only keyed create response stream id parses as hex");
     check(streamCommandId(0x0400000A) == QStringLiteral("0400000a"),
           "stream command id is normalized for stream remove");
+    check(parsePanafallCreatePanId(QStringLiteral("0x40000000,0x42000000"))
+              == QStringLiteral("0x40000000"),
+          "panafall create comma response returns only the pan id");
+    check(parsePanafallCreatePanId(QStringLiteral("40000000,0x42000000"))
+              == QStringLiteral("0x40000000"),
+          "panafall create bare comma response normalizes only the pan id");
+    check(parsePanafallCreatePanId(QStringLiteral("pan=0x40000001 waterfall=0x42000001"))
+              == QStringLiteral("0x40000001"),
+          "panafall create keyed response returns pan id");
+}
+
+void testBoundedSliceCapacity()
+{
+    check(boundedSliceCapacity(8, 8, 8, 2) == 8,
+          "slice capacity does not inflate above model limit");
+    check(boundedSliceCapacity(8, 10, 8, 2) == 8,
+          "stale inflated slice capacity is clamped back to model limit");
+    check(boundedSliceCapacity(8, 10, 1, 2) == 8,
+          "stale inflated slice capacity is clamped when reported total is below model limit");
+    check(boundedSliceCapacity(8, 10, 1, -1) == 8,
+          "stale inflated slice capacity is clamped when reported availability is invalid");
+    check(boundedSliceCapacity(4, 10, 1, 2) == 4,
+          "slice capacity clamps to lower model limits");
+    check(boundedSliceCapacity(8, 4, 3, 5) == 8,
+          "reported available slices can raise capacity up to model limit");
+    check(boundedSliceCapacity(4, 4, 1, -1) == 4,
+          "negative reported slice availability is ignored");
+    check(boundedSliceCapacity(0, 4, 8, 2) == 4,
+          "slice capacity does not change before model limit is known");
 }
 
 } // namespace
@@ -277,6 +306,7 @@ int main()
     testDaxTxPolicy();
     testUdpRegistrationPolicy();
     testCreateResponseParsing();
+    testBoundedSliceCapacity();
 
     if (failures) {
         std::printf("\n%d failure(s)\n", failures);


### PR DESCRIPTION
## Summary
- Clamp radio-reported slice availability to the known receiver capacity for the connected model.
- Parse display panafall create responses as pan/waterfall pairs and keep only the pan ID for panadapter commands.
- Add regression coverage for generic model limits, stale inflated capacity values, invalid reported availability, and comma-separated panafall create responses.

## Bugs addressed
AetherSDR could calculate receiver capacity as local slice count plus the radio reported available slice count and allow that value to exceed the connected model supported receiver count. That could enable impossible panadapter/slice layouts on any radio family when stale or cross-client status made the local count inconsistent.

AetherSDR could also treat a comma-separated display panafall create response such as 0x40000000,0x42000000 as one panadapter ID. That created local panadapter entries with invalid IDs, so they never received spectrum/waterfall data and could not be removed with display pan remove.

## Fix
The model now bounds reported slice capacity by the connected radio model known receiver limit and clamps previously inflated local values back down once that limit is known. Panadapter creation now normalizes Flex IDs and extracts only the pan ID from keyed, bare, and comma-separated panafall create responses before configuring, adding slices to, or removing panadapters.

## Testing
- cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
- cmake --build build --target radio_status_ownership_test
- ./build/radio_status_ownership_test
- cmake --build build --target AetherSDR