### PR TITLE
Add buffered async file logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1282,6 +1282,9 @@ add_executable(ole_compound_file_test
 )
 target_include_directories(ole_compound_file_test PRIVATE src)
 target_link_libraries(ole_compound_file_test PRIVATE Qt6::Core mspack_static)
+if(UNIX)
+    target_link_libraries(ole_compound_file_test PRIVATE pthread)
+endif()
 
 add_executable(xvtr_policy_test
     tests/xvtr_policy_test.cpp
@@ -1336,6 +1339,9 @@ add_executable(meter_model_test
 )
 target_include_directories(meter_model_test PRIVATE src)
 target_link_libraries(meter_model_test PRIVATE Qt6::Core)
+if(UNIX)
+    target_link_libraries(meter_model_test PRIVATE pthread)
+endif()
 set_target_properties(meter_model_test PROPERTIES AUTOMOC ON)
 
 add_executable(memory_recall_policy_test
@@ -1355,6 +1361,9 @@ add_executable(transmit_model_apd_test
 )
 target_include_directories(transmit_model_apd_test PRIVATE src)
 target_link_libraries(transmit_model_apd_test PRIVATE Qt6::Core Qt6::Test)
+if(UNIX)
+    target_link_libraries(transmit_model_apd_test PRIVATE pthread)
+endif()
 set_target_properties(transmit_model_apd_test PROPERTIES AUTOMOC ON)
 
 # Help guide search tests - needs QApplication + Widgets.
@@ -1393,6 +1402,9 @@ add_executable(transmit_model_test
 )
 target_include_directories(transmit_model_test PRIVATE src)
 target_link_libraries(transmit_model_test PRIVATE Qt6::Core)
+if(UNIX)
+    target_link_libraries(transmit_model_test PRIVATE pthread)
+endif()
 
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,6 +462,7 @@ set(CORE_SOURCES
     src/core/NvidiaBnrFilter.cpp
     src/core/DeepFilterFilter.cpp
     src/core/RADEEngine.cpp
+    src/core/AsyncLogWriter.cpp
     src/core/LogManager.cpp
     src/core/ShortcutManager.cpp
     src/core/SupportBundle.cpp
@@ -1275,6 +1276,7 @@ add_executable(ole_compound_file_test
     tests/ole_compound_file_test.cpp
     src/core/OleCompoundFile.cpp
     src/core/CabExtractor.cpp
+    src/core/AsyncLogWriter.cpp
     src/core/LogManager.cpp
     src/core/AppSettings.cpp
 )
@@ -1328,6 +1330,7 @@ target_link_libraries(cwx_panel_test PRIVATE
 add_executable(meter_model_test
     tests/meter_model_test.cpp
     src/models/MeterModel.cpp
+    src/core/AsyncLogWriter.cpp
     src/core/LogManager.cpp
     src/core/AppSettings.cpp
 )
@@ -1346,6 +1349,7 @@ add_executable(transmit_model_apd_test
     tests/transmit_model_apd_test.cpp
     src/models/TransmitModel.cpp
     src/core/ClientQuindarTone.cpp
+    src/core/AsyncLogWriter.cpp
     src/core/LogManager.cpp
     src/core/AppSettings.cpp
 )
@@ -1384,6 +1388,7 @@ add_executable(transmit_model_test
     src/models/TransmitModel.cpp
     src/core/ClientQuindarTone.cpp
     src/core/AppSettings.cpp
+    src/core/AsyncLogWriter.cpp
     src/core/LogManager.cpp
 )
 target_include_directories(transmit_model_test PRIVATE src)

--- a/src/core/AsyncLogWriter.cpp
+++ b/src/core/AsyncLogWriter.cpp
@@ -1,0 +1,449 @@
+#include "AsyncLogWriter.h"
+
+#include <QDir>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QFileInfo>
+#include <QRegularExpression>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <utility>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr qsizetype kMaxQueueEntries = 8192;
+constexpr qsizetype kHighPriorityReserveEntries = 1024;
+constexpr qsizetype kHardMaxQueueEntries = kMaxQueueEntries + kHighPriorityReserveEntries;
+constexpr qsizetype kMaxBatchEntries = 256;
+constexpr int kFlushIntervalMs = 250;
+
+bool isDebugOrInfo(QtMsgType type)
+{
+    return type == QtDebugMsg || type == QtInfoMsg;
+}
+
+QString labelForType(QtMsgType type)
+{
+    switch (type) {
+    case QtDebugMsg:
+        return QStringLiteral("DBG");
+    case QtWarningMsg:
+        return QStringLiteral("WRN");
+    case QtCriticalMsg:
+        return QStringLiteral("CRT");
+    case QtFatalMsg:
+        return QStringLiteral("FTL");
+    case QtInfoMsg:
+        return QStringLiteral("INF");
+    }
+    return QStringLiteral("???");
+}
+
+QString redactPii(const QString& msg)
+{
+    QString out = msg;
+
+    // IPv4 addresses: 192.168.50.121 -> *.*.*. 121 (keep last octet).
+    // The word boundary skips v/V-prefixed version strings; the ver=
+    // lookbehind and trailing digit check skip firmware/software versions
+    // with build numbers such as software_ver=4.2.18.41174.
+    static const QRegularExpression* ipRe = new QRegularExpression(
+        R"((?<!ver=)\b(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.((?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d))(?!\d))");
+    out.replace(*ipRe, QStringLiteral("*.*.*. \\1"));
+
+    // Radio serial: 4424-1213-8600-7836 -> ****-****-****-7836
+    static const QRegularExpression* serialRe = new QRegularExpression(
+        R"(\d{4}-\d{4}-\d{4}-(\d{4}))");
+    out.replace(*serialRe, QStringLiteral("****-****-****-\\1"));
+
+    // Auth0 tokens (long base64 strings after id_token or token)
+    static const QRegularExpression* tokenRe = new QRegularExpression(
+        R"((id_token[= :]|token[= :])\s*([A-Za-z0-9_\-\.]{20})[A-Za-z0-9_\-\.]+)");
+    out.replace(*tokenRe, QStringLiteral("\\1 \\2...REDACTED"));
+
+    // MAC addresses: 00-1C-2D-05-37-2A -> **-**-**-**-**-2A
+    //                00:1C:2D:05:37:2A -> **:**:**:**:**:2A
+    static const QRegularExpression* macRe = new QRegularExpression(
+        R"(([0-9A-Fa-f]{2})([:-])([0-9A-Fa-f]{2})\2([0-9A-Fa-f]{2})\2([0-9A-Fa-f]{2})\2([0-9A-Fa-f]{2})\2([0-9A-Fa-f]{2}))");
+    out.replace(*macRe, QStringLiteral("**\\2**\\2**\\2**\\2**\\2\\7"));
+
+    return out;
+}
+
+QByteArray formatLine(QtMsgType type,
+                      const QTime& timestamp,
+                      const QString& category,
+                      const QString& message)
+{
+    const QString safeMsg = redactPii(message);
+    return QString("[%1] %2 %3: %4\n")
+        .arg(timestamp.toString(QStringLiteral("HH:mm:ss.zzz")),
+             labelForType(type),
+             category,
+             safeMsg)
+        .toUtf8();
+}
+
+} // namespace
+
+AsyncLogWriter::AsyncLogWriter() = default;
+
+AsyncLogWriter::~AsyncLogWriter()
+{
+    shutdown();
+}
+
+bool AsyncLogWriter::start(const QString& path, bool mirrorToStderr)
+{
+    shutdown();
+
+    std::promise<bool> opened;
+    std::future<bool> openedFuture = opened.get_future();
+
+    {
+        std::lock_guard lock(m_mutex);
+        m_filePath = path;
+        m_mirrorToStderr = mirrorToStderr;
+        m_started = true;
+        m_accepting = false;
+        m_stopping = false;
+        m_queue.clear();
+        m_counters = Counters{};
+        m_pendingDroppedDebugInfo = 0;
+        m_pendingDroppedHighPriority = 0;
+    }
+
+    m_worker = std::thread(&AsyncLogWriter::run, this, std::move(opened));
+    const bool ok = openedFuture.get();
+    if (!ok) {
+        if (m_worker.joinable())
+            m_worker.join();
+        std::lock_guard lock(m_mutex);
+        m_started = false;
+        m_accepting = false;
+        m_stopping = false;
+        return false;
+    }
+
+    {
+        std::lock_guard lock(m_mutex);
+        m_accepting = true;
+    }
+    m_cv.notify_one();
+    return true;
+}
+
+void AsyncLogWriter::shutdown()
+{
+    std::shared_ptr<SyncPoint> sync;
+    {
+        std::lock_guard lock(m_mutex);
+        if (!m_started)
+            return;
+
+        m_accepting = false;
+        m_stopping = true;
+        sync = std::make_shared<SyncPoint>();
+        QueueItem item;
+        item.kind = ItemKind::Stop;
+        item.sync = sync;
+        m_queue.push_back(std::move(item));
+    }
+    m_cv.notify_one();
+
+    {
+        std::unique_lock lock(sync->mutex);
+        sync->cv.wait(lock, [&] { return sync->done; });
+    }
+
+    if (m_worker.joinable())
+        m_worker.join();
+
+    std::lock_guard lock(m_mutex);
+    m_started = false;
+    m_stopping = false;
+    m_queue.clear();
+}
+
+bool AsyncLogWriter::isRunning() const
+{
+    std::lock_guard lock(m_mutex);
+    return m_started && !m_stopping;
+}
+
+void AsyncLogWriter::enqueue(QtMsgType type,
+                             const QTime& timestamp,
+                             const QString& category,
+                             const QString& message)
+{
+    {
+        std::lock_guard lock(m_mutex);
+        if (!m_started || !m_accepting)
+            return;
+
+        if (m_queue.size() >= kMaxQueueEntries) {
+            if (isDebugOrInfo(type)) {
+                ++m_counters.droppedDebugInfoLines;
+                ++m_pendingDroppedDebugInfo;
+                m_cv.notify_one();
+                return;
+            }
+
+            auto dropIt = std::find_if(m_queue.begin(), m_queue.end(),
+                [](const QueueItem& item) {
+                    return item.kind == ItemKind::Log && isDebugOrInfo(item.log.type);
+                });
+            if (dropIt != m_queue.end()) {
+                m_queue.erase(dropIt);
+                ++m_counters.droppedDebugInfoLines;
+                ++m_pendingDroppedDebugInfo;
+            } else if (m_queue.size() >= kHardMaxQueueEntries) {
+                ++m_counters.droppedHighPriorityLines;
+                ++m_pendingDroppedHighPriority;
+                m_cv.notify_one();
+                return;
+            }
+        }
+
+        QueueItem item;
+        item.kind = ItemKind::Log;
+        item.log.type = type;
+        item.log.timestamp = timestamp;
+        item.log.category = category;
+        item.log.message = message;
+        m_queue.push_back(std::move(item));
+
+        ++m_counters.queuedLines;
+        m_counters.maxQueueDepth = std::max<quint64>(m_counters.maxQueueDepth, m_queue.size());
+    }
+    m_cv.notify_one();
+}
+
+void AsyncLogWriter::flush()
+{
+    enqueueControlAndWait(ItemKind::Flush);
+}
+
+void AsyncLogWriter::clearLog()
+{
+    enqueueControlAndWait(ItemKind::Clear);
+}
+
+AsyncLogWriter::Counters AsyncLogWriter::counters() const
+{
+    std::lock_guard lock(m_mutex);
+    return m_counters;
+}
+
+bool AsyncLogWriter::enqueueControlAndWait(ItemKind kind)
+{
+    std::shared_ptr<SyncPoint> sync;
+    {
+        std::lock_guard lock(m_mutex);
+        if (!m_started || m_stopping)
+            return false;
+
+        sync = std::make_shared<SyncPoint>();
+        QueueItem item;
+        item.kind = kind;
+        item.sync = sync;
+        m_queue.push_back(std::move(item));
+        m_counters.maxQueueDepth = std::max<quint64>(m_counters.maxQueueDepth, m_queue.size());
+    }
+    m_cv.notify_one();
+
+    std::unique_lock lock(sync->mutex);
+    sync->cv.wait(lock, [&] { return sync->done; });
+    return true;
+}
+
+void AsyncLogWriter::markDone(const std::shared_ptr<SyncPoint>& sync)
+{
+    if (!sync)
+        return;
+
+    {
+        std::lock_guard lock(sync->mutex);
+        sync->done = true;
+    }
+    sync->cv.notify_all();
+}
+
+void AsyncLogWriter::run(std::promise<bool> opened)
+{
+    QString path;
+    bool mirrorToStderr = false;
+    {
+        std::lock_guard lock(m_mutex);
+        path = m_filePath;
+        mirrorToStderr = m_mirrorToStderr;
+    }
+
+    QDir().mkpath(QFileInfo(path).absolutePath());
+
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        opened.set_value(false);
+        return;
+    }
+    file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+    opened.set_value(true);
+
+    QByteArray buffer;
+    qsizetype bufferedLineCount = 0;
+    bool hasUnflushedWrites = false;
+    QElapsedTimer flushTimer;
+    flushTimer.start();
+
+    auto recordWritten = [this](qsizetype count) {
+        if (count <= 0)
+            return;
+        std::lock_guard lock(m_mutex);
+        m_counters.writtenLines += static_cast<quint64>(count);
+    };
+
+    auto flushBuffer = [&]() {
+        if (buffer.isEmpty())
+            return;
+        if (file.write(buffer) >= 0) {
+            recordWritten(bufferedLineCount);
+            hasUnflushedWrites = true;
+        }
+        buffer.clear();
+        bufferedLineCount = 0;
+    };
+
+    auto makeDropSummary = [](QtMsgType type, const QString& message) {
+        QueueItem item;
+        item.kind = ItemKind::Log;
+        item.log.type = type;
+        item.log.timestamp = QTime::currentTime();
+        item.log.category = QStringLiteral("aether.logging");
+        item.log.message = message;
+        return item;
+    };
+
+    bool stop = false;
+    while (!stop) {
+        std::deque<QueueItem> batch;
+        bool timedOut = false;
+        {
+            std::unique_lock lock(m_mutex);
+            timedOut = !m_cv.wait_for(lock, std::chrono::milliseconds(kFlushIntervalMs), [&] {
+                return !m_queue.empty()
+                    || m_pendingDroppedDebugInfo > 0
+                    || m_pendingDroppedHighPriority > 0;
+            });
+
+            while (!m_queue.empty() && batch.size() < kMaxBatchEntries) {
+                batch.push_back(std::move(m_queue.front()));
+                m_queue.pop_front();
+            }
+
+            const quint64 droppedDebugInfo = std::exchange(m_pendingDroppedDebugInfo, 0);
+            const quint64 droppedHighPriority = std::exchange(m_pendingDroppedHighPriority, 0);
+            if (droppedDebugInfo > 0) {
+                batch.push_back(makeDropSummary(
+                    QtWarningMsg,
+                    QStringLiteral("Logging dropped debug/info lines count=%1 due_to=queue_full")
+                        .arg(droppedDebugInfo)));
+            }
+            if (droppedHighPriority > 0) {
+                batch.push_back(makeDropSummary(
+                    QtCriticalMsg,
+                    QStringLiteral("Logging dropped warning/critical/fatal lines count=%1 due_to=queue_full")
+                        .arg(droppedHighPriority)));
+            }
+
+            if (!batch.empty()) {
+                m_counters.maxBatchSize = std::max<quint64>(m_counters.maxBatchSize, batch.size());
+            }
+        }
+
+        bool flushAfterBatch = false;
+        for (QueueItem& item : batch) {
+            switch (item.kind) {
+            case ItemKind::Log: {
+                const QByteArray line = formatLine(item.log.type,
+                                                   item.log.timestamp,
+                                                   item.log.category,
+                                                   item.log.message);
+                buffer.append(line);
+                ++bufferedLineCount;
+                if (mirrorToStderr) {
+                    fwrite(line.constData(), 1, static_cast<size_t>(line.size()), stderr);
+                }
+                if (!isDebugOrInfo(item.log.type))
+                    flushAfterBatch = true;
+                break;
+            }
+            case ItemKind::Flush:
+                flushBuffer();
+                if (hasUnflushedWrites) {
+                    file.flush();
+                    if (mirrorToStderr)
+                        fflush(stderr);
+                    hasUnflushedWrites = false;
+                    flushTimer.restart();
+                }
+                markDone(item.sync);
+                break;
+            case ItemKind::Clear:
+                flushBuffer();
+                if (hasUnflushedWrites) {
+                    file.flush();
+                    hasUnflushedWrites = false;
+                    flushTimer.restart();
+                }
+                file.resize(0);
+                file.seek(0);
+                markDone(item.sync);
+                break;
+            case ItemKind::Stop:
+                flushBuffer();
+                if (hasUnflushedWrites) {
+                    file.flush();
+                    if (mirrorToStderr)
+                        fflush(stderr);
+                    hasUnflushedWrites = false;
+                }
+                markDone(item.sync);
+                stop = true;
+                break;
+            }
+        }
+
+        if (flushAfterBatch) {
+            flushBuffer();
+            if (hasUnflushedWrites) {
+                file.flush();
+                if (mirrorToStderr)
+                    fflush(stderr);
+                hasUnflushedWrites = false;
+                flushTimer.restart();
+            }
+        } else if (timedOut || flushTimer.elapsed() >= kFlushIntervalMs) {
+            flushBuffer();
+            if (hasUnflushedWrites) {
+                file.flush();
+                if (mirrorToStderr)
+                    fflush(stderr);
+                hasUnflushedWrites = false;
+                flushTimer.restart();
+            }
+        } else if (bufferedLineCount >= kMaxBatchEntries) {
+            flushBuffer();
+        }
+    }
+
+    flushBuffer();
+    if (hasUnflushedWrites)
+        file.flush();
+    file.close();
+}
+
+} // namespace AetherSDR

--- a/src/core/AsyncLogWriter.h
+++ b/src/core/AsyncLogWriter.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <QTime>
+#include <QString>
+#include <QtLogging>
+
+#include <condition_variable>
+#include <deque>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+namespace AetherSDR {
+
+class AsyncLogWriter {
+public:
+    struct Counters {
+        quint64 queuedLines{0};
+        quint64 writtenLines{0};
+        quint64 droppedDebugInfoLines{0};
+        quint64 droppedHighPriorityLines{0};
+        quint64 maxQueueDepth{0};
+        quint64 maxBatchSize{0};
+    };
+
+    AsyncLogWriter();
+    ~AsyncLogWriter();
+
+    AsyncLogWriter(const AsyncLogWriter&) = delete;
+    AsyncLogWriter& operator=(const AsyncLogWriter&) = delete;
+
+    bool start(const QString& path, bool mirrorToStderr);
+    void shutdown();
+
+    bool isRunning() const;
+
+    void enqueue(QtMsgType type,
+                 const QTime& timestamp,
+                 const QString& category,
+                 const QString& message);
+
+    void flush();
+    void clearLog();
+
+    Counters counters() const;
+
+private:
+    struct LogMessage {
+        QtMsgType type{QtDebugMsg};
+        QTime timestamp;
+        QString category;
+        QString message;
+    };
+
+    enum class ItemKind {
+        Log,
+        Flush,
+        Clear,
+        Stop,
+    };
+
+    struct SyncPoint {
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool done{false};
+    };
+
+    struct QueueItem {
+        ItemKind kind{ItemKind::Log};
+        LogMessage log;
+        std::shared_ptr<SyncPoint> sync;
+    };
+
+    void run(std::promise<bool> opened);
+    bool enqueueControlAndWait(ItemKind kind);
+    void markDone(const std::shared_ptr<SyncPoint>& sync);
+
+    mutable std::mutex m_mutex;
+    std::condition_variable m_cv;
+    std::deque<QueueItem> m_queue;
+    std::thread m_worker;
+
+    QString m_filePath;
+    bool m_mirrorToStderr{false};
+    bool m_started{false};
+    bool m_accepting{false};
+    bool m_stopping{false};
+
+    Counters m_counters;
+    quint64 m_pendingDroppedDebugInfo{0};
+    quint64 m_pendingDroppedHighPriority{0};
+};
+
+} // namespace AetherSDR

--- a/src/core/AsyncLogWriter.h
+++ b/src/core/AsyncLogWriter.h
@@ -2,7 +2,7 @@
 
 #include <QTime>
 #include <QString>
-#include <QtLogging>
+#include <QtCore/qlogging.h>
 
 #include <condition_variable>
 #include <deque>

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -4,7 +4,9 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QMutexLocker>
 #include <QStandardPaths>
+#include <QTime>
 
 namespace AetherSDR {
 
@@ -67,8 +69,11 @@ LogManager::LogManager()
 
 LogManager& LogManager::instance()
 {
-    static LogManager mgr;
-    return mgr;
+    // The Qt message handler can still be invoked during late teardown on
+    // some platforms. Keep the manager alive for process lifetime and shut
+    // down the writer explicitly from main().
+    static LogManager* mgr = new LogManager;
+    return *mgr;
 }
 
 bool LogManager::isEnabled(const QString& id) const
@@ -113,8 +118,44 @@ void LogManager::applyFilterRules()
     QLoggingCategory::setFilterRules(rules.join('\n'));
 }
 
+bool LogManager::startLogging(const QString& path, bool mirrorToStderr)
+{
+    if (!m_writer.start(path, mirrorToStderr))
+        return false;
+
+    setActiveLogFilePath(path);
+    return true;
+}
+
+void LogManager::shutdownLogging()
+{
+    m_writer.shutdown();
+}
+
+void LogManager::enqueueMessage(QtMsgType type, const QMessageLogContext& ctx, const QString& msg)
+{
+    const QString category = (ctx.category && *ctx.category)
+        ? QString::fromUtf8(ctx.category)
+        : QStringLiteral("default");
+
+    m_writer.enqueue(type, QTime::currentTime(), category, msg);
+    if (type == QtFatalMsg)
+        m_writer.flush();
+}
+
+void LogManager::flushLog() const
+{
+    m_writer.flush();
+}
+
+AsyncLogWriter::Counters LogManager::logCounters() const
+{
+    return m_writer.counters();
+}
+
 QString LogManager::logFilePath() const
 {
+    QMutexLocker locker(&m_pathMutex);
     if (!m_activeLogFilePath.isEmpty()) {
         return m_activeLogFilePath;
     }
@@ -124,17 +165,24 @@ QString LogManager::logFilePath() const
 
 void LogManager::setActiveLogFilePath(const QString& path)
 {
+    QMutexLocker locker(&m_pathMutex);
     m_activeLogFilePath = path;
 }
 
 qint64 LogManager::logFileSize() const
 {
+    flushLog();
     QFileInfo fi(logFilePath());
     return fi.exists() ? fi.size() : 0;
 }
 
 void LogManager::clearLog()
 {
+    if (m_writer.isRunning()) {
+        m_writer.clearLog();
+        return;
+    }
+
     QFile f(logFilePath());
     if (f.open(QIODevice::WriteOnly | QIODevice::Truncate))
         f.close();

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include "AsyncLogWriter.h"
+
 #include <QObject>
 #include <QList>
 #include <QString>
 #include <QLoggingCategory>
+#include <QMutex>
 
 namespace AetherSDR {
 
@@ -60,6 +63,12 @@ public:
     void setAllEnabled(bool on);
 
     // Log file management
+    bool startLogging(const QString& path, bool mirrorToStderr);
+    void shutdownLogging();
+    void enqueueMessage(QtMsgType type, const QMessageLogContext& ctx, const QString& msg);
+    void flushLog() const;
+    AsyncLogWriter::Counters logCounters() const;
+
     QString logFilePath() const;
     void setActiveLogFilePath(const QString& path);
     qint64 logFileSize() const;
@@ -77,7 +86,9 @@ private:
     void applyFilterRules();
 
     QList<Category> m_categories;
+    mutable QMutex m_pathMutex;
     QString m_activeLogFilePath;
+    mutable AsyncLogWriter m_writer;
 };
 
 } // namespace AetherSDR

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -7,6 +7,7 @@
 #include <QString>
 #include <QLoggingCategory>
 #include <QMutex>
+#include <QtCore/qlogging.h>
 
 namespace AetherSDR {
 

--- a/src/core/SupportBundle.cpp
+++ b/src/core/SupportBundle.cpp
@@ -50,6 +50,7 @@ SupportBundle::RadioInfo SupportBundle::collectRadioInfo(const RadioModel* model
 QString SupportBundle::createBundle(const RadioInfo& radio)
 {
     auto& logMgr = LogManager::instance();
+    logMgr.flushLog();
 
     // Create temp directory for bundle contents
     QTemporaryDir tmpDir;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,10 +11,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QDateTime>
-#include <QMutex>
-#include <QMutexLocker>
 #include <QStandardPaths>
-#include <QRegularExpression>
 
 #ifdef _WIN32
 #include <io.h>
@@ -58,90 +55,9 @@ static int aetherTolerantX11ErrorHandler(AetherX11Display*, AetherX11ErrorEvent*
 }
 #endif  // __linux__
 
-static QFile* s_logFile = nullptr;
-
-static QMutex* logMutex()
-{
-    // qInstallMessageHandler callbacks can arrive concurrently from any Qt
-    // thread; leak this intentionally so shutdown logging cannot outlive it.
-    static QMutex* mutex = new QMutex;
-    return mutex;
-}
-
-// Redact PII from log messages before writing to file.
-// Patterns: IP addresses, radio serial numbers, Auth0 tokens, MAC addresses.
-//
-// Regex objects are heap-allocated (intentional leak) so they survive static
-// destruction order during abnormal teardown.  Without this, crash cleanup
-// invokes the message handler from dying threads after the function-local
-// statics are destroyed, producing "invalid QRegularExpression" errors (#1233).
-static QString redactPii(const QString& msg)
-{
-    QString out = msg;
-
-    // IPv4 addresses: 192.168.50.121 → *.*.*. 121 (keep last octet)
-    // Negative lookbehind/lookahead skip 4-component version strings:
-    //   "0.9.2.1"            — quoted (Qt qDebug output)
-    //   v0.9.2.1             — v-prefixed
-    //   software_ver=4.2.18.41174  — protocol field with trailing build number
-    //   firmware_ver=…       — same shape
-    // The trailing (?![\d"]) handles the build-number case where the 4th
-    // captured "octet" is part of a longer number (e.g. 41174 → matches as
-    // 411 with 74 dangling, which is the bug we're fixing).
-    static const QRegularExpression* ipRe = new QRegularExpression(
-        R"((?<!ver=)(?<![v"])(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?![\d"]))");
-    out.replace(*ipRe, QStringLiteral("*.*.*. \\4"));
-
-    // Radio serial: 4424-1213-8600-7836 → ****-****-****-7836
-    static const QRegularExpression* serialRe = new QRegularExpression(
-        R"(\d{4}-\d{4}-\d{4}-(\d{4}))");
-    out.replace(*serialRe, QStringLiteral("****-****-****-\\1"));
-
-    // Auth0 tokens (long base64 strings after id_token or token)
-    static const QRegularExpression* tokenRe = new QRegularExpression(
-        R"((id_token[= :]|token[= :])\s*([A-Za-z0-9_\-\.]{20})[A-Za-z0-9_\-\.]+)");
-    out.replace(*tokenRe, QStringLiteral("\\1 \\2...REDACTED"));
-
-    // MAC addresses: 00-1C-2D-05-37-2A → **-**-**-**-**-2A
-    static const QRegularExpression* macRe = new QRegularExpression(
-        R"(([0-9A-Fa-f]{2})-([0-9A-Fa-f]{2})-([0-9A-Fa-f]{2})-([0-9A-Fa-f]{2})-([0-9A-Fa-f]{2})-([0-9A-Fa-f]{2}))");
-    out.replace(*macRe, QStringLiteral("**-**-**-**-**-\\6"));
-
-    return out;
-}
-
 static void messageHandler(QtMsgType type, const QMessageLogContext& ctx, const QString& msg)
 {
-    static const char* labels[] = {"DBG", "WRN", "CRT", "FTL", "INF"};
-    const char* label = (type <= QtInfoMsg) ? labels[type] : "???";
-    const QString category = (ctx.category && *ctx.category)
-        ? QString::fromUtf8(ctx.category)
-        : QStringLiteral("default");
-
-    const QString safeMsg = redactPii(msg);
-    const QString line = QString("[%1] %2 %3: %4\n")
-        .arg(QDateTime::currentDateTime().toString("HH:mm:ss.zzz"), label, category, safeMsg);
-    const QByteArray lineBytes = line.toUtf8();
-
-    // File write is the only thing that needs the mutex — QFile is not
-    // thread-safe (PR #2284 added this serialization to fix concurrent-write
-    // corruption).
-    {
-        QMutexLocker locker(logMutex());
-        if (s_logFile && s_logFile->isOpen()) {
-            s_logFile->write(lineBytes);
-            s_logFile->flush();
-        }
-    }
-
-    // Skip stderr when it's a pipe to a non-draining parent (Stream Deck
-    // "Run Command", systemd user services, GUI launchers).  Once the
-    // ~64 KB pipe buffer fills, a blocking write would lock up the app.
-    // The fprintf is outside the log mutex so even an unexpected stall
-    // here can't block other threads' log calls.
-    static const bool stderrIsTty = isatty(fileno(stderr));
-    if (stderrIsTty)
-        fprintf(stderr, "%s", lineBytes.constData());
+    AetherSDR::LogManager::instance().enqueueMessage(type, ctx, msg);
 }
 
 int main(int argc, char* argv[])
@@ -261,11 +177,13 @@ int main(int argc, char* argv[])
         }
     }
 
-    s_logFile = new QFile(logPath);
-    if (s_logFile->open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
-        // Restrict log file to owner-only (may contain session identifiers)
-        s_logFile->setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
-        AetherSDR::LogManager::instance().setActiveLogFilePath(logPath);
+    // Skip stderr when it's a pipe to a non-draining parent (Stream Deck
+    // "Run Command", systemd user services, GUI launchers).  Once the
+    // ~64 KB pipe buffer fills, a blocking write could lock up the logger.
+    static const bool stderrIsTty = isatty(fileno(stderr));
+
+    auto& logManager = AetherSDR::LogManager::instance();
+    if (logManager.startLogging(logPath, stderrIsTty)) {
         qInstallMessageHandler(messageHandler);
 
         // Symlink aethersdr.log → latest timestamped file (for Support dialog)
@@ -274,8 +192,6 @@ int main(int argc, char* argv[])
         QFile::link(logPath, symlink);
     } else {
         fprintf(stderr, "Warning: could not open log file %s\n", logPath.toLocal8Bit().constData());
-        delete s_logFile;
-        s_logFile = nullptr;
     }
 
     // Use Fusion style as a clean cross-platform base
@@ -293,8 +209,15 @@ int main(int argc, char* argv[])
 
     qDebug() << "Starting AetherSDR" << app.applicationVersion();
 
-    AetherSDR::MainWindow window;
-    window.show();
+    int exitCode = 0;
+    {
+        AetherSDR::MainWindow window;
+        window.show();
+        exitCode = app.exec();
+    }
 
-    return app.exec();
+    qInstallMessageHandler(nullptr);
+    logManager.shutdownLogging();
+
+    return exitCode;
 }


### PR DESCRIPTION
## Summary

Implements the first foundation milestone for lower-overhead AetherSDR logging from issue #2471.

- Adds `AsyncLogWriter`, a dedicated logging thread owned by `LogManager`.
- Keeps the Qt message-handler producer path small: timestamp, type, category, raw message, enqueue, return.
- Moves log formatting, PII redaction, stderr mirroring, and file I/O onto the logging thread.
- Uses a bounded queue with debug/info drops first and a later coalesced drop summary line.
- Batches file writes and flushes periodically, on shutdown, and after warning/critical/fatal batches.
- Preserves the existing line shape, category filtering, timestamped active log file, and `aethersdr.log` latest-log symlink behavior.
- Makes `clearLog()` deterministic by sending a writer-thread clear command that drains prior writes, truncates the active file, then resumes subsequent writes.
- Flushes pending async log data before support bundle log collection.

## Notes

This intentionally does not add event classification, a new taxonomy, or UI settings. It also does not touch radio command ordering, timers, slice behavior, panadapter behavior, or command sequencing code.

The redaction logic is preserved and carried forward onto the writer thread, with a small tightening for quoted IPv4 addresses and colon-separated MAC addresses observed during runtime verification.

## Validation

- Built exactly with:
  - `env -u CPLUS_INCLUDE_PATH cmake --build build-ninja --parallel 22`
- Ran registered tests:
  - `ctest --test-dir build-ninja --output-on-failure`
- Launched the built macOS app bundle offscreen and verified:
  - timestamped logs are created in the same config log directory
  - `aethersdr.log` points to the latest timestamped log
  - default discovery/connection/protocol debug lines still appear
  - log format remains `[HH:mm:ss.zzz] DBG aether.protocol: message`
  - runtime logs redact IPv4 addresses, radio serial numbers, and MAC addresses
- Ran a throwaway `AsyncLogWriter` probe to verify:
  - token redaction
  - IPv4/serial/MAC redaction
  - `clearLog()` truncates prior buffered writes and preserves subsequent writes

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
