### PR TITLE
Add FPS meters and performance telemetry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,7 @@ set(CORE_SOURCES
     src/core/IambicKeyer.cpp
     src/core/SpectralNR.cpp
     src/core/PanadapterStream.cpp
+    src/core/PerfTelemetry.cpp
     src/core/RigctlProtocol.cpp
     src/core/RigctlPty.cpp
     src/core/SmartLinkClient.cpp

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -1,6 +1,7 @@
 #include "PanadapterStream.h"
 #include "LogManager.h"
 #include "OpusCodec.h"
+#include "PerfTelemetry.h"
 #include "RadioConnection.h"
 
 #include <QNetworkDatagram>
@@ -429,9 +430,19 @@ void PanadapterStream::setYPixels(quint32 streamId, int yPixels)
 
 void PanadapterStream::onDatagramReady()
 {
+    auto& perf = PerfTelemetry::instance();
+    const bool perfEnabled = perf.enabled();
+    const qint64 batchStartNs = perfEnabled ? PerfTelemetry::nowNs() : 0;
+    int batchDatagrams = 0;
+    qint64 batchBytes = 0;
+
     while (m_socket && m_socket->hasPendingDatagrams()) {
         const QNetworkDatagram dg = m_socket->receiveDatagram();
         if (!dg.isNull()) {
+            const QByteArray payload = dg.data();
+            const int payloadBytes = payload.size();
+            batchDatagrams++;
+            batchBytes += payloadBytes;
             if (!m_hasReceivedPacket) {
                 m_hasReceivedPacket = true;
                 if (m_routedPrimeTimer) {
@@ -450,7 +461,7 @@ void PanadapterStream::onDatagramReady()
             // Stop the rapid udp_register timer and switch to ping keepalive.
             if (m_isWanMode && !m_wanRegistered) {
                 qCDebug(lcVita49) << "PanadapterStream: WAN — first VITA-49 packet received!"
-                         << dg.data().size() << "bytes from"
+                         << payloadBytes << "bytes from"
                          << dg.senderAddress().toString() << ":" << dg.senderPort()
                          << "— UDP registration confirmed";
                 m_wanRegistered = true;
@@ -461,9 +472,14 @@ void PanadapterStream::onDatagramReady()
                     m_wanPingTimer->start(5000);
                 }
             }
-            m_totalRxBytes.fetch_add(dg.data().size());
-            processDatagram(dg.data());
+            m_totalRxBytes.fetch_add(payloadBytes);
+            processDatagram(payload);
         }
+    }
+
+    if (perfEnabled && batchDatagrams > 0) {
+        perf.recordUdpBatch(batchDatagrams, batchBytes,
+                            static_cast<double>(PerfTelemetry::nowNs() - batchStartNs) / 1000000.0);
     }
 }
 
@@ -547,6 +563,7 @@ void PanadapterStream::processDatagram(const QByteArray& data)
 
     // Per-category byte/packet/sequence tracking.
     // Only track owned/routed streams — skip uncategorized packets. (#455)
+    bool sequenceError = false;
     if (cat != CatCount) {
         QMutexLocker statsLock(&m_statsMutex);
         m_catStats[cat].bytes += data.size();
@@ -556,6 +573,7 @@ void PanadapterStream::processDatagram(const QByteArray& data)
         if (stats.lastSeq >= 0) {
             const int expected = (stats.lastSeq + 1) & 0x0F;
             if (vitaSeq != expected) {
+                sequenceError = true;
                 stats.errorCount++;
                 m_catStats[cat].errors++;
             }
@@ -580,6 +598,12 @@ void PanadapterStream::processDatagram(const QByteArray& data)
                 m_audioPacketTimerStarted = true;
             }
         }
+    }
+    if ((cat == CatFFT || cat == CatWaterfall) && PerfTelemetry::instance().enabled()) {
+        PerfTelemetry::instance().recordStreamPacket(
+            cat == CatWaterfall ? PerfTelemetry::FrameKind::Waterfall
+                                : PerfTelemetry::FrameKind::Panadapter,
+            sequenceError);
     }
 
     if (daxChannel >= 0) {
@@ -696,8 +720,11 @@ void PanadapterStream::decodeFFT(const uchar* raw, int totalBytes, bool hasTrail
 
     // Per-stream frame assembly
     auto& frame = m_frames[streamId];
-    if (frameIndex != frame.frameIndex)
+    if (frameIndex != frame.frameIndex) {
+        if (frame.totalBins > 0 && !frame.isComplete())
+            PerfTelemetry::instance().recordFrameRestart(PerfTelemetry::FrameKind::Panadapter);
         frame.reset(frameIndex, totalBins);
+    }
 
     if (startBin + numBins > static_cast<quint16>(frame.buf.size()))
         return;
@@ -726,7 +753,8 @@ void PanadapterStream::decodeFFT(const uchar* raw, int totalBytes, bool hasTrail
     for (int i = 0; i < count; ++i)
         bins[i] = maxDbm - (static_cast<float>(frame.buf[i]) / (yPix - 1.0f)) * range;
 
-    emit spectrumReady(streamId, bins);
+    const qint64 emittedNs = PerfTelemetry::instance().enabled() ? PerfTelemetry::nowNs() : 0;
+    emit spectrumReady(streamId, bins, emittedNs);
 }
 
 // ─── Waterfall tile decode ───────────────────────────────────────────────────
@@ -798,8 +826,11 @@ void PanadapterStream::decodeWaterfallTile(const uchar* raw, int totalBytes, boo
     // ── Waterfall frame assembly ─────────────────────────────────────────
     // Start a new frame if timecode changed
     auto& wfFrame = m_wfFrames[streamId];
-    if (timecode != wfFrame.timecode)
+    if (timecode != wfFrame.timecode) {
+        if (wfFrame.totalBins > 0 && !wfFrame.isComplete())
+            PerfTelemetry::instance().recordFrameRestart(PerfTelemetry::FrameKind::Waterfall);
         wfFrame.reset(timecode, totalBinsInFrame, lowFreqMhz, binBwMhz, autoBlack);
+    }
 
     // Copy this fragment's bins into the assembly buffer.
     // Only process the first row (height is typically 1).
@@ -819,7 +850,9 @@ void PanadapterStream::decodeWaterfallTile(const uchar* raw, int totalBytes, boo
 
     const double frameHighMhz = wfFrame.lowFreqMhz + wfFrame.binBwMhz * wfFrame.totalBins;
     emit waterfallAutoBlackLevel(streamId, wfFrame.autoBlack);
-    emit waterfallRowReady(streamId, wfFrame.buf, wfFrame.lowFreqMhz, frameHighMhz, wfFrame.timecode);
+    const qint64 emittedNs = PerfTelemetry::instance().enabled() ? PerfTelemetry::nowNs() : 0;
+    emit waterfallRowReady(streamId, wfFrame.buf, wfFrame.lowFreqMhz, frameHighMhz,
+                           wfFrame.timecode, emittedNs);
 }
 
 // ─── Audio decode ─────────────────────────────────────────────────────────────

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -97,11 +97,11 @@ public:
 signals:
     void daxAudioReady(int channel, const QByteArray& pcm);
     void iqDataReady(int channel, const QByteArray& rawPayload, int sampleRate);
-    void spectrumReady(quint32 streamId, const QVector<float>& binsDbm);
+    void spectrumReady(quint32 streamId, const QVector<float>& binsDbm, qint64 emittedNs);
     // One row of waterfall data (intensity values, Width bins).
     void waterfallRowReady(quint32 streamId, const QVector<float>& binsDbm,
                            double lowFreqMhz, double highFreqMhz,
-                           quint32 timecode);
+                           quint32 timecode, qint64 emittedNs);
     // Emitted once per waterfall tile with the radio's computed auto black level.
     void waterfallAutoBlackLevel(quint32 streamId, quint32 autoBlack);
     // Raw PCM payload (header stripped) from IF-Data (audio) VITA-49 packets.

--- a/src/core/PerfTelemetry.cpp
+++ b/src/core/PerfTelemetry.cpp
@@ -1,0 +1,600 @@
+#include "PerfTelemetry.h"
+#include "LogManager.h"
+
+#include <QLoggingCategory>
+#include <QMutexLocker>
+#include <QStringList>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <utility>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr qint64 kSummaryIntervalNs = 1000000000LL;
+constexpr double kHeartbeatIntervalMs = 50.0;
+constexpr double kUiLagStallMs = 50.0;
+constexpr double kDragUiLagStallMs = 33.0;
+constexpr double kFrameAgeStallMs = 100.0;
+constexpr double kPanUpdateStallMs = 8.0;
+constexpr double kWaterfallUpdateStallMs = 12.0;
+constexpr double kRenderStallMs = 16.0;
+constexpr double kUdpDrainStallMs = 8.0;
+constexpr double kInputStallMs = 16.0;
+
+QString frameKindName(PerfTelemetry::FrameKind kind)
+{
+    return kind == PerfTelemetry::FrameKind::Waterfall
+        ? QStringLiteral("waterfall")
+        : QStringLiteral("panadapter");
+}
+
+} // namespace
+
+PerfTelemetry& PerfTelemetry::instance()
+{
+    static PerfTelemetry telemetry;
+    return telemetry;
+}
+
+qint64 PerfTelemetry::nowNs()
+{
+    using Clock = std::chrono::steady_clock;
+    static const Clock::time_point start = Clock::now();
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() - start).count();
+}
+
+bool PerfTelemetry::enabled() const
+{
+    return lcPerf().isDebugEnabled();
+}
+
+bool PerfTelemetry::beginRecord(qint64 now)
+{
+    if (!enabled()) {
+        m_wasEnabled.store(false, std::memory_order_relaxed);
+        return false;
+    }
+
+    if (!m_wasEnabled.exchange(true, std::memory_order_relaxed)) {
+        QMutexLocker lock(&m_mutex);
+        resetWindowLocked(now);
+        m_lastHeartbeatNs = 0;
+    }
+
+    return true;
+}
+
+void PerfTelemetry::resetWindowLocked(qint64 now)
+{
+    m_window = Window{};
+    m_window.dragSeen = m_dragActive.load(std::memory_order_relaxed);
+    m_windowStartNs = now;
+}
+
+double PerfTelemetry::nsToMs(qint64 ns)
+{
+    return static_cast<double>(ns) / 1000000.0;
+}
+
+QString PerfTelemetry::msValue(double value)
+{
+    return QString::number(value, 'f', 1);
+}
+
+QString PerfTelemetry::pctValue(int errors, int packets)
+{
+    if (packets <= 0)
+        return QStringLiteral("0.00");
+    return QString::number((100.0 * static_cast<double>(errors)) / static_cast<double>(packets), 'f', 2);
+}
+
+QString PerfTelemetry::keyValue(const QString& key, const QString& value)
+{
+    return QStringLiteral("%1=%2").arg(key, value);
+}
+
+QString PerfTelemetry::keyValue(const QString& key, int value)
+{
+    return QStringLiteral("%1=%2").arg(key).arg(value);
+}
+
+QString PerfTelemetry::keyValue(const QString& key, qint64 value)
+{
+    return QStringLiteral("%1=%2").arg(key).arg(value);
+}
+
+QString PerfTelemetry::keyValueMs(const QString& key, double value)
+{
+    return keyValue(key, msValue(value));
+}
+
+double PerfTelemetry::percentile95(QVector<double> values)
+{
+    if (values.isEmpty())
+        return 0.0;
+    std::sort(values.begin(), values.end());
+    const int index = qBound(0, static_cast<int>(std::ceil(values.size() * 0.95)) - 1, values.size() - 1);
+    return values.at(index);
+}
+
+void PerfTelemetry::logStall(const QStringList& fields)
+{
+    if (!lcPerf().isDebugEnabled())
+        return;
+    QStringList line;
+    line.reserve(fields.size() + 1);
+    line << QStringLiteral("PerfStall");
+    line << fields;
+    qCDebug(lcPerf).noquote() << line.join(QLatin1Char(' '));
+}
+
+void PerfTelemetry::recordUdpBatch(int datagrams, qint64 bytes, double drainMs)
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.udpBatches++;
+        m_window.udpDatagrams += datagrams;
+        m_window.udpBytes += bytes;
+        m_window.udpMaxDatagramsPerBatch = std::max(m_window.udpMaxDatagramsPerBatch, datagrams);
+        m_window.udpDrainMaxMs = std::max(m_window.udpDrainMaxMs, drainMs);
+    }
+
+    if (drainMs > kUdpDrainStallMs) {
+        logStall({
+            keyValue(QStringLiteral("kind"), QStringLiteral("udpDrain")),
+            keyValue(QStringLiteral("drainMs"), msValue(drainMs)),
+            keyValue(QStringLiteral("datagrams"), datagrams),
+            keyValue(QStringLiteral("bytes"), bytes)
+        });
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordStreamPacket(FrameKind kind, bool sequenceError)
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        if (kind == FrameKind::Waterfall) {
+            m_window.waterfallPackets++;
+            if (sequenceError)
+                m_window.waterfallErrors++;
+        } else {
+            m_window.fftPackets++;
+            if (sequenceError)
+                m_window.fftErrors++;
+        }
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordFrameRestart(FrameKind kind)
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        if (kind == FrameKind::Waterfall)
+            m_window.waterfallFrameRestarts++;
+        else
+            m_window.fftFrameRestarts++;
+    }
+
+    logStall({
+        keyValue(QStringLiteral("kind"), QStringLiteral("frameRestart")),
+        keyValue(QStringLiteral("stream"), frameKindName(kind))
+    });
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordFrameAge(FrameKind kind, double ageMs)
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        QVector<double>& samples = kind == FrameKind::Waterfall
+            ? m_window.waterfallAgeMs
+            : m_window.panAgeMs;
+        samples.append(ageMs);
+    }
+
+    if (ageMs > kFrameAgeStallMs) {
+        logStall({
+            keyValue(QStringLiteral("kind"), QStringLiteral("frameAge")),
+            keyValue(QStringLiteral("stream"), frameKindName(kind)),
+            keyValue(QStringLiteral("ageMs"), msValue(ageMs))
+        });
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordPanFrame()
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.panFrames++;
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordWaterfallNativeRows(int rows)
+{
+    if (rows <= 0)
+        return;
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.waterfallFrames += rows;
+        m_window.waterfallNativeRows += rows;
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordWaterfallFallbackRows(int rows)
+{
+    if (rows <= 0)
+        return;
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.waterfallFrames += rows;
+        m_window.waterfallFallbackRows += rows;
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordWaterfallVisibleRows(int rows)
+{
+    if (rows <= 0)
+        return;
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.waterfallVisibleRows += rows;
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordWaterfallRebuild()
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.waterfallRebuilds++;
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::setWaterfallLineDurationMs(int ms)
+{
+    m_waterfallLineDurationMs.store(ms, std::memory_order_relaxed);
+}
+
+void PerfTelemetry::recordPanCenterCommand()
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.panCenterCommands++;
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordPanUpdate(double updateMs)
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.panUpdateMs.append(updateMs);
+    }
+
+    if (updateMs > kPanUpdateStallMs) {
+        logStall({
+            keyValue(QStringLiteral("kind"), QStringLiteral("updateSpectrum")),
+            keyValue(QStringLiteral("durationMs"), msValue(updateMs))
+        });
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordWaterfallUpdate(double updateMs)
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.waterfallUpdateMs.append(updateMs);
+    }
+
+    if (updateMs > kWaterfallUpdateStallMs) {
+        logStall({
+            keyValue(QStringLiteral("kind"), QStringLiteral("updateWaterfallRow")),
+            keyValue(QStringLiteral("durationMs"), msValue(updateMs))
+        });
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordRender(double renderMs)
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.renderMs.append(renderMs);
+    }
+
+    if (renderMs > kRenderStallMs) {
+        logStall({
+            keyValue(QStringLiteral("kind"), QStringLiteral("render")),
+            keyValue(QStringLiteral("durationMs"), msValue(renderMs))
+        });
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordGpuUpload(GpuUploadKind kind)
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.gpuUploads++;
+        switch (kind) {
+        case GpuUploadKind::WaterfallFull:
+            m_window.gpuWaterfallFullUploads++;
+            break;
+        case GpuUploadKind::WaterfallIncremental:
+            m_window.gpuWaterfallIncrementalUploads++;
+            break;
+        case GpuUploadKind::Overlay:
+            m_window.gpuOverlayUploads++;
+            break;
+        }
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordUiHeartbeat()
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    double lagMs = 0.0;
+    const bool dragActive = m_dragActive.load(std::memory_order_relaxed);
+    {
+        QMutexLocker lock(&m_mutex);
+        if (m_lastHeartbeatNs > 0) {
+            const double gapMs = nsToMs(now - m_lastHeartbeatNs);
+            lagMs = std::max(0.0, gapMs - kHeartbeatIntervalMs);
+            m_window.uiLagMaxMs = std::max(m_window.uiLagMaxMs, lagMs);
+        }
+        m_lastHeartbeatNs = now;
+        m_window.dragSeen = m_window.dragSeen || dragActive;
+    }
+
+    if (lagMs > kUiLagStallMs || (dragActive && lagMs > kDragUiLagStallMs)) {
+        logStall({
+            keyValue(QStringLiteral("kind"), QStringLiteral("uiHeartbeat")),
+            keyValue(QStringLiteral("lagMs"), msValue(lagMs)),
+            keyValue(QStringLiteral("drag"), dragActive ? 1 : 0)
+        });
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::setDragActive(bool active)
+{
+    m_dragActive.store(active, std::memory_order_relaxed);
+
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.dragSeen = m_window.dragSeen || active;
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordMouseMoveGap(double gapMs)
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.mouseMoveGapMaxMs = std::max(m_window.mouseMoveGapMaxMs, gapMs);
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordInputEvent(const char* kind, double durationMs)
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.inputMs.append(durationMs);
+    }
+
+    if (durationMs > kInputStallMs) {
+        logStall({
+            keyValue(QStringLiteral("kind"), QStringLiteral("input")),
+            keyValue(QStringLiteral("event"), QString::fromLatin1(kind ? kind : "unknown")),
+            keyValue(QStringLiteral("durationMs"), msValue(durationMs)),
+            keyValue(QStringLiteral("drag"), m_dragActive.load(std::memory_order_relaxed) ? 1 : 0)
+        });
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordSHistoryProcessed(double durationMs)
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.shistoryProcessed++;
+        m_window.shistoryMs.append(durationMs);
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::recordSHistorySkipped()
+{
+    const qint64 now = nowNs();
+    if (!beginRecord(now))
+        return;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        m_window.shistorySkipped++;
+    }
+
+    maybeLogSummary(now);
+}
+
+void PerfTelemetry::maybeLogSummary(qint64 now)
+{
+    Window window;
+    qint64 elapsedNs = 0;
+    bool shouldLog = false;
+
+    {
+        QMutexLocker lock(&m_mutex);
+        if (m_windowStartNs == 0)
+            m_windowStartNs = now;
+
+        elapsedNs = now - m_windowStartNs;
+        if (elapsedNs < kSummaryIntervalNs)
+            return;
+
+        window = std::move(m_window);
+        window.dragSeen = window.dragSeen || m_dragActive.load(std::memory_order_relaxed);
+        resetWindowLocked(now);
+        shouldLog = true;
+    }
+
+    if (!shouldLog)
+        return;
+
+    const double seconds = std::max(0.001, static_cast<double>(elapsedNs) / 1000000000.0);
+    const double panFps = static_cast<double>(window.panFrames) / seconds;
+    const double panCenterCommandRate = static_cast<double>(window.panCenterCommands) / seconds;
+    const double waterfallFps = static_cast<double>(window.waterfallFrames) / seconds;
+    const double rxKbps = (static_cast<double>(window.udpBytes) * 8.0) / seconds / 1000.0;
+    const int waterfallLineDurationMs = m_waterfallLineDurationMs.load(std::memory_order_relaxed);
+
+    QStringList fields;
+    fields.reserve(45);
+    fields << QStringLiteral("PerfSummary")
+           << keyValueMs(QStringLiteral("uiLagMaxMs"), window.uiLagMaxMs)
+           << keyValue(QStringLiteral("drag"), window.dragSeen ? 1 : 0)
+           << keyValue(QStringLiteral("panFps"), QString::number(panFps, 'f', 1))
+           << keyValue(QStringLiteral("panCenterCmds"), window.panCenterCommands)
+           << keyValue(QStringLiteral("panCenterCmdRate"), QString::number(panCenterCommandRate, 'f', 1))
+           << keyValueMs(QStringLiteral("panAgeP95Ms"), percentile95(std::move(window.panAgeMs)))
+           << keyValueMs(QStringLiteral("panUpdateP95Ms"), percentile95(std::move(window.panUpdateMs)))
+           << keyValue(QStringLiteral("wfFps"), QString::number(waterfallFps, 'f', 1))
+           << keyValue(QStringLiteral("wfLineMs"), waterfallLineDurationMs)
+           << keyValueMs(QStringLiteral("wfAgeP95Ms"), percentile95(std::move(window.waterfallAgeMs)))
+           << keyValueMs(QStringLiteral("wfUpdateP95Ms"), percentile95(std::move(window.waterfallUpdateMs)))
+           << keyValueMs(QStringLiteral("renderP95Ms"), percentile95(std::move(window.renderMs)))
+           << keyValue(QStringLiteral("gpuUploads"), window.gpuUploads)
+           << keyValue(QStringLiteral("gpuWfFull"), window.gpuWaterfallFullUploads)
+           << keyValue(QStringLiteral("gpuWfRows"), window.gpuWaterfallIncrementalUploads)
+           << keyValue(QStringLiteral("gpuOverlay"), window.gpuOverlayUploads)
+           << keyValue(QStringLiteral("udpBatches"), window.udpBatches)
+           << keyValue(QStringLiteral("udpDgrams"), window.udpDatagrams)
+           << keyValue(QStringLiteral("udpBatchMax"), window.udpMaxDatagramsPerBatch)
+           << keyValueMs(QStringLiteral("udpDrainMaxMs"), window.udpDrainMaxMs)
+           << keyValue(QStringLiteral("rxKbps"), QString::number(rxKbps, 'f', 1))
+           << keyValue(QStringLiteral("fftLossPct"), pctValue(window.fftErrors, window.fftPackets))
+           << keyValue(QStringLiteral("wfLossPct"), pctValue(window.waterfallErrors, window.waterfallPackets))
+           << keyValueMs(QStringLiteral("shistoryP95Ms"), percentile95(std::move(window.shistoryMs)))
+           << keyValue(QStringLiteral("shistoryProcessed"), window.shistoryProcessed)
+           << keyValue(QStringLiteral("shistorySkipped"), window.shistorySkipped)
+           << keyValue(QStringLiteral("wfNative"), window.waterfallNativeRows)
+           << keyValue(QStringLiteral("wfFallback"), window.waterfallFallbackRows)
+           << keyValue(QStringLiteral("wfRebuilds"), window.waterfallRebuilds)
+           << keyValue(QStringLiteral("wfVisibleRows"), window.waterfallVisibleRows)
+           << keyValueMs(QStringLiteral("mouseGapMaxMs"), window.mouseMoveGapMaxMs)
+           << keyValueMs(QStringLiteral("inputP95Ms"), percentile95(std::move(window.inputMs)))
+           << keyValue(QStringLiteral("fftRestarts"), window.fftFrameRestarts)
+           << keyValue(QStringLiteral("wfRestarts"), window.waterfallFrameRestarts);
+
+    qCDebug(lcPerf).noquote() << fields.join(QLatin1Char(' '));
+}
+
+} // namespace AetherSDR

--- a/src/core/PerfTelemetry.h
+++ b/src/core/PerfTelemetry.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <QMutex>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+#include <QtGlobal>
+
+#include <atomic>
+
+namespace AetherSDR {
+
+class PerfTelemetry final {
+public:
+    enum class FrameKind {
+        Panadapter,
+        Waterfall
+    };
+
+    enum class GpuUploadKind {
+        WaterfallFull,
+        WaterfallIncremental,
+        Overlay
+    };
+
+    static PerfTelemetry& instance();
+    static qint64 nowNs();
+
+    bool enabled() const;
+
+    void recordUdpBatch(int datagrams, qint64 bytes, double drainMs);
+    void recordStreamPacket(FrameKind kind, bool sequenceError);
+    void recordFrameRestart(FrameKind kind);
+    void recordFrameAge(FrameKind kind, double ageMs);
+
+    void recordPanFrame();
+    void recordWaterfallNativeRows(int rows);
+    void recordWaterfallFallbackRows(int rows);
+    void recordWaterfallVisibleRows(int rows = 1);
+    void recordWaterfallRebuild();
+    void setWaterfallLineDurationMs(int ms);
+
+    void recordPanCenterCommand();
+    void recordPanUpdate(double updateMs);
+    void recordWaterfallUpdate(double updateMs);
+    void recordRender(double renderMs);
+    void recordGpuUpload(GpuUploadKind kind);
+
+    void recordUiHeartbeat();
+    void setDragActive(bool active);
+    void recordMouseMoveGap(double gapMs);
+    void recordInputEvent(const char* kind, double durationMs);
+
+    void recordSHistoryProcessed(double durationMs);
+    void recordSHistorySkipped();
+
+private:
+    PerfTelemetry() = default;
+
+    struct Window {
+        qint64 udpBytes{0};
+        int udpBatches{0};
+        int udpDatagrams{0};
+        int udpMaxDatagramsPerBatch{0};
+        double udpDrainMaxMs{0.0};
+
+        int fftPackets{0};
+        int fftErrors{0};
+        int waterfallPackets{0};
+        int waterfallErrors{0};
+        int fftFrameRestarts{0};
+        int waterfallFrameRestarts{0};
+
+        int panFrames{0};
+        int panCenterCommands{0};
+        int waterfallFrames{0};
+        int waterfallNativeRows{0};
+        int waterfallFallbackRows{0};
+        int waterfallVisibleRows{0};
+        int waterfallRebuilds{0};
+
+        int gpuUploads{0};
+        int gpuWaterfallFullUploads{0};
+        int gpuWaterfallIncrementalUploads{0};
+        int gpuOverlayUploads{0};
+
+        int shistoryProcessed{0};
+        int shistorySkipped{0};
+
+        bool dragSeen{false};
+        double uiLagMaxMs{0.0};
+        double mouseMoveGapMaxMs{0.0};
+
+        QVector<double> panAgeMs;
+        QVector<double> waterfallAgeMs;
+        QVector<double> panUpdateMs;
+        QVector<double> waterfallUpdateMs;
+        QVector<double> renderMs;
+        QVector<double> inputMs;
+        QVector<double> shistoryMs;
+    };
+
+    bool beginRecord(qint64 nowNs);
+    void maybeLogSummary(qint64 nowNs);
+    void resetWindowLocked(qint64 nowNs);
+
+    static double percentile95(QVector<double> values);
+    static double nsToMs(qint64 ns);
+    static QString msValue(double value);
+    static QString pctValue(int errors, int packets);
+    static QString keyValue(const QString& key, const QString& value);
+    static QString keyValue(const QString& key, int value);
+    static QString keyValue(const QString& key, qint64 value);
+    static QString keyValueMs(const QString& key, double value);
+    static void logStall(const QStringList& fields);
+
+    mutable QMutex m_mutex;
+    Window m_window;
+    qint64 m_windowStartNs{0};
+    qint64 m_lastHeartbeatNs{0};
+    std::atomic_bool m_wasEnabled{false};
+    std::atomic_bool m_dragActive{false};
+    std::atomic<int> m_waterfallLineDurationMs{0};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -11,6 +11,7 @@
 #include "PanLayoutDialog.h"
 #include "core/CommandParser.h"
 #include "core/LogManager.h"
+#include "core/PerfTelemetry.h"
 #include "core/VoiceSignalDetector.h"
 #include "core/MemoryRecallPolicy.h"
 #include "core/StreamStatus.h"
@@ -954,6 +955,12 @@ MainWindow::MainWindow(QWidget* parent)
     }
 
     applyDarkTheme();
+
+    m_perfHeartbeatTimer.setInterval(50);
+    connect(&m_perfHeartbeatTimer, &QTimer::timeout, this, [] {
+        PerfTelemetry::instance().recordUiHeartbeat();
+    });
+    m_perfHeartbeatTimer.start();
 
     // Audio worker thread (#502) — AudioEngine runs on its own thread so
     // audio processing never competes with paintEvent for main thread CPU.
@@ -2084,7 +2091,12 @@ MainWindow::MainWindow(QWidget* parent)
     // ── Panadapter stream → spectrum widget ───────────────────────────────
     // Route FFT/waterfall data to the correct SpectrumWidget by stream ID
     connect(m_radioModel.panStream(), &PanadapterStream::spectrumReady,
-            this, [this](quint32 streamId, const QVector<float>& bins) {
+            this, [this](quint32 streamId, const QVector<float>& bins, qint64 emittedNs) {
+        if (emittedNs > 0) {
+            PerfTelemetry::instance().recordFrameAge(
+                PerfTelemetry::FrameKind::Panadapter,
+                static_cast<double>(PerfTelemetry::nowNs() - emittedNs) / 1000000.0);
+        }
         for (auto* pan : m_radioModel.panadapters()) {
             if (pan->panStreamId() == streamId) {
                 if (auto* sw = m_panStack->spectrum(pan->panId())) {
@@ -2106,7 +2118,12 @@ MainWindow::MainWindow(QWidget* parent)
 
     connect(m_radioModel.panStream(), &PanadapterStream::waterfallRowReady,
             this, [this](quint32 streamId, const QVector<float>& bins,
-                         double low, double high, quint32 tc) {
+                         double low, double high, quint32 tc, qint64 emittedNs) {
+        if (emittedNs > 0) {
+            PerfTelemetry::instance().recordFrameAge(
+                PerfTelemetry::FrameKind::Waterfall,
+                static_cast<double>(PerfTelemetry::nowNs() - emittedNs) / 1000000.0);
+        }
         for (auto* pan : m_radioModel.panadapters()) {
             if (pan->wfStreamId() == streamId) {
                 const double panCenter = pan->centerMhz();
@@ -6552,6 +6569,22 @@ void MainWindow::buildMenuBar()
             for (PanadapterApplet* applet : m_panStack->allApplets()) {
                 applet->spectrumWidget()->setPropForecast(-1, -1, -1);
             }
+        }
+    });
+
+    auto* fpsMetersAct = viewMenu->addAction("FPS Meters");
+    fpsMetersAct->setCheckable(true);
+    fpsMetersAct->setShortcut(QKeySequence("Ctrl+F"));
+    fpsMetersAct->setChecked(
+        AppSettings::instance().value("DisplayFpsMeters", "False").toString() == "True");
+    connect(fpsMetersAct, &QAction::toggled, this, [this](bool on) {
+        AppSettings::instance().setValue("DisplayFpsMeters", on ? "True" : "False");
+        AppSettings::instance().save();
+        if (!m_panStack)
+            return;
+        for (PanadapterApplet* applet : m_panStack->allApplets()) {
+            if (auto* sw = applet->spectrumWidget())
+                sw->setShowFpsMeters(on);
         }
     });
 
@@ -13899,9 +13932,17 @@ void MainWindow::expireSHistoryMarkers()
     }
 }
 
-void MainWindow::onSpectrumReadyForSHistory(quint32 streamId, const QVector<float>& bins)
+void MainWindow::onSpectrumReadyForSHistory(quint32 streamId, const QVector<float>& bins, qint64 emittedNs)
 {
-    if (!m_sHistoryEnabled && !m_sHistoryQrmEnabled) return;
+    Q_UNUSED(emittedNs);
+    const bool perfEnabled = PerfTelemetry::instance().enabled();
+    const qint64 perfStartNs = perfEnabled ? PerfTelemetry::nowNs() : 0;
+
+    if (!m_sHistoryEnabled && !m_sHistoryQrmEnabled) {
+        if (perfEnabled)
+            PerfTelemetry::instance().recordSHistorySkipped();
+        return;
+    }
 
     // Build voice-only frequency ranges from the active band plan once per frame
     QVector<QPair<double, double>> voiceRanges;
@@ -13912,8 +13953,10 @@ void MainWindow::onSpectrumReadyForSHistory(quint32 streamId, const QVector<floa
         }
     }
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    bool processedFrame = false;
     for (auto* pan : m_radioModel.panadapters()) {
         if (pan->panStreamId() != streamId) continue;
+        processedFrame = true;
 
         const QString panId = pan->panId();
         auto& state = m_sHistoryPanState[panId];
@@ -14047,6 +14090,15 @@ void MainWindow::onSpectrumReadyForSHistory(quint32 streamId, const QVector<floa
         // even when nothing was detected this frame.
         rebuildSHistoryForPan(panId);
         break;
+    }
+
+    if (perfEnabled) {
+        if (processedFrame) {
+            PerfTelemetry::instance().recordSHistoryProcessed(
+                static_cast<double>(PerfTelemetry::nowNs() - perfStartNs) / 1000000.0);
+        } else {
+            PerfTelemetry::instance().recordSHistorySkipped();
+        }
     }
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -351,7 +351,7 @@ private:
     bool    m_sHistoryQrmEnabled{false};
     void rebuildSHistoryForPan(const QString& panId);
     void expireSHistoryMarkers();
-    void onSpectrumReadyForSHistory(quint32 streamId, const QVector<float>& bins);
+    void onSpectrumReadyForSHistory(quint32 streamId, const QVector<float>& bins, qint64 emittedNs);
     // Per-pan spectrogram ring buffer for CNN classification.
     // shared_ptr so QHash COW can copy the pointer on detach without deep-copying
     // the 32-frame ring buffer (unique_ptr is non-copyable, which breaks QHash::operator[]).
@@ -457,6 +457,7 @@ private:
     QLabel* m_supplyVoltLabel{nullptr};
     QLabel* m_networkLabel{nullptr};
     QTimer m_networkTooltipRefreshTimer;
+    QTimer m_perfHeartbeatTimer;
     QLabel* m_tgxlSeparator{nullptr};
     QLabel* m_tgxlIndicator{nullptr};
     QLabel* m_pgxlSeparator{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -41,6 +41,7 @@
 #include <QTimeZone>
 #include <QElapsedTimer>
 #include "core/LogManager.h"
+#include "core/PerfTelemetry.h"
 #include <algorithm>
 #include <cmath>
 #include <cstring>
@@ -74,6 +75,87 @@ static bool spotMarkersVisuallyEqual(const QVector<SpectrumWidget::SpotMarker>& 
     }
 
     return true;
+}
+
+class PerfInputScope {
+public:
+    explicit PerfInputScope(const char* kind)
+        : m_kind(kind),
+          m_enabled(PerfTelemetry::instance().enabled()),
+          m_startNs(m_enabled ? PerfTelemetry::nowNs() : 0)
+    {
+    }
+
+    ~PerfInputScope()
+    {
+        if (!m_enabled)
+            return;
+        PerfTelemetry::instance().recordInputEvent(
+            m_kind,
+            static_cast<double>(PerfTelemetry::nowNs() - m_startNs) / 1000000.0);
+    }
+
+private:
+    const char* m_kind;
+    bool m_enabled;
+    qint64 m_startNs;
+};
+
+class PerfUpdateScope {
+public:
+    enum class Kind {
+        Panadapter,
+        Waterfall
+    };
+
+    explicit PerfUpdateScope(Kind kind)
+        : m_kind(kind),
+          m_enabled(PerfTelemetry::instance().enabled()),
+          m_startNs(m_enabled ? PerfTelemetry::nowNs() : 0)
+    {
+    }
+
+    ~PerfUpdateScope()
+    {
+        if (!m_enabled)
+            return;
+        const double durationMs = static_cast<double>(PerfTelemetry::nowNs() - m_startNs) / 1000000.0;
+        if (m_kind == Kind::Waterfall)
+            PerfTelemetry::instance().recordWaterfallUpdate(durationMs);
+        else
+            PerfTelemetry::instance().recordPanUpdate(durationMs);
+    }
+
+private:
+    Kind m_kind;
+    bool m_enabled;
+    qint64 m_startNs;
+};
+
+template <typename F>
+class ScopeExit {
+public:
+    explicit ScopeExit(F&& fn)
+        : m_fn(std::forward<F>(fn))
+    {
+    }
+
+    ~ScopeExit()
+    {
+        m_fn();
+    }
+
+    ScopeExit(const ScopeExit&) = delete;
+    ScopeExit& operator=(const ScopeExit&) = delete;
+
+private:
+    F m_fn;
+};
+
+template <typename F>
+ScopeExit<F> makeScopeExit(F&& fn)
+{
+    return ScopeExit<F>(std::forward<F>(fn));
 }
 
 static QString formatFlagFrequency(double freqMhz)
@@ -218,6 +300,12 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
             markOverlayDirty();
     });
 
+    m_fpsMeterTimer = new QTimer(this);
+    m_fpsMeterTimer->setInterval(1000);
+    connect(m_fpsMeterTimer, &QTimer::timeout, this, [this]() {
+        updateFpsMeterValues();
+    });
+
     // Load display settings (panIndex 0 by default — loadSettings() can be
     // called again after setPanIndex() for multi-pan)
     loadSettings();
@@ -319,6 +407,7 @@ void SpectrumWidget::loadSettings()
     m_wfAutoBlack    = s.value(settingsKey("DisplayWfAutoBlack"), "True").toString() == "True";
     m_wfAutoBlackOffset = s.value(settingsKey("DisplayWfAutoBlackOffset"), "50").toInt();
     m_wfLineDuration = s.value(settingsKey("DisplayWfLineDuration"), "100").toInt();
+    PerfTelemetry::instance().setWaterfallLineDurationMs(m_wfLineDuration);
     // NB Waterfall Blanker (#277)
     m_wfBlankerEnabled   = s.value(settingsKey("WaterfallBlankingEnabled"), "False").toString() == "True";
     m_wfBlankerMode      = s.value(settingsKey("WaterfallBlankingMode"), "0").toInt();
@@ -334,6 +423,8 @@ void SpectrumWidget::loadSettings()
     m_showGrid       = s.value(settingsKey("DisplayShowGrid"), "True").toString() == "True";
     m_freqGridSpacingKhz = s.value(settingsKey("DisplayFreqGridSpacing"), "0").toInt();
     m_fftLineWidth   = s.value(settingsKey("DisplayFftLineWidth"), "2.0").toFloat();
+    applyFpsMeterVisibility(
+        s.value("DisplayFpsMeters", "False").toString() == "True");
     m_wfColorScheme  = static_cast<WfColorScheme>(
         std::clamp(s.value(settingsKey("DisplayWfColorScheme"), "0").toInt(),
                    0, static_cast<int>(WfColorScheme::Count) - 1));
@@ -436,6 +527,79 @@ void SpectrumWidget::setFreqGridSpacing(int khz) {
     s.setValue(settingsKey("DisplayFreqGridSpacing"), QString::number(khz));
     s.save();
     markOverlayDirty();
+}
+void SpectrumWidget::setShowFpsMeters(bool on) {
+    applyFpsMeterVisibility(on);
+    auto& s = AppSettings::instance();
+    s.setValue("DisplayFpsMeters", on ? "True" : "False");
+    s.save();
+
+    // Keep FPS meters global across docked and sibling panadapters.
+    if (QWidget* top = window()) {
+        const auto siblings = top->findChildren<SpectrumWidget*>();
+        for (SpectrumWidget* sw : siblings) {
+            if (sw != this)
+                sw->applyFpsMeterVisibility(on);
+        }
+    }
+}
+void SpectrumWidget::applyFpsMeterVisibility(bool on) {
+    m_showFpsMeters = on;
+    resetFpsMeterWindow();
+    if (m_fpsMeterTimer) {
+        if (on)
+            m_fpsMeterTimer->start();
+        else
+            m_fpsMeterTimer->stop();
+    }
+    markOverlayDirty();
+}
+void SpectrumWidget::resetFpsMeterWindow() {
+    m_panadapterFrameCount = 0;
+    m_waterfallFrameCount = 0;
+    m_panadapterFps = 0.0;
+    m_waterfallFps = 0.0;
+    m_fpsMeterWindow.restart();
+}
+void SpectrumWidget::updateFpsMeterValues() {
+    if (!m_showFpsMeters)
+        return;
+    if (!m_fpsMeterWindow.isValid()) {
+        resetFpsMeterWindow();
+        return;
+    }
+    const qint64 elapsedMs = m_fpsMeterWindow.elapsed();
+    if (elapsedMs <= 0)
+        return;
+
+    const double scale = 1000.0 / static_cast<double>(elapsedMs);
+    m_panadapterFps = m_panadapterFrameCount * scale;
+    m_waterfallFps = m_waterfallFrameCount * scale;
+    m_panadapterFrameCount = 0;
+    m_waterfallFrameCount = 0;
+    m_fpsMeterWindow.restart();
+    markOverlayDirty();
+}
+void SpectrumWidget::recordPanadapterFrame() {
+    if (m_showFpsMeters)
+        ++m_panadapterFrameCount;
+}
+void SpectrumWidget::recordWaterfallFrame(int rows) {
+    if (m_showFpsMeters && rows > 0)
+        m_waterfallFrameCount += rows;
+}
+bool SpectrumWidget::anyDragActive() const {
+    return m_draggingDivider
+        || m_draggingBandwidth
+        || m_draggingPan
+        || m_draggingFilter != FilterEdge::None
+        || m_draggingVfo
+        || m_draggingDbm
+        || m_draggingTimeScale
+        || m_draggingTnfId >= 0;
+}
+void SpectrumWidget::publishPerfDragState() const {
+    PerfTelemetry::instance().setDragActive(anyDragActive());
 }
 void SpectrumWidget::setShowTuneGuides(bool on) {
     m_showTuneGuides = on;
@@ -540,6 +704,7 @@ void SpectrumWidget::setWfAutoBlackOffset(int level) {
 }
 void SpectrumWidget::setWfLineDuration(int ms) {
     m_wfLineDuration = std::clamp(ms, 50, 500);
+    PerfTelemetry::instance().setWaterfallLineDurationMs(m_wfLineDuration);
     auto& s = AppSettings::instance();
     s.setValue(settingsKey("DisplayWfLineDuration"), QString::number(m_wfLineDuration));
     s.save();
@@ -685,6 +850,8 @@ void SpectrumWidget::appendVisibleRow(const QRgb* rowData)
     m_wfWriteRow = (m_wfWriteRow - 1 + h) % h;
     auto* row = reinterpret_cast<QRgb*>(m_waterfall.bits() + m_wfWriteRow * m_waterfall.bytesPerLine());
     std::memcpy(row, rowData, m_waterfall.width() * sizeof(QRgb));
+    if (PerfTelemetry::instance().enabled())
+        PerfTelemetry::instance().recordWaterfallVisibleRows();
 }
 
 void SpectrumWidget::appendHistoryRow(const QRgb* rowData, qint64 timestampMs)
@@ -740,6 +907,8 @@ void SpectrumWidget::rebuildWaterfallViewport()
 #ifdef AETHER_GPU_SPECTRUM
     m_wfTexFullUpload = true;
 #endif
+    if (PerfTelemetry::instance().enabled())
+        PerfTelemetry::instance().recordWaterfallRebuild();
     update();
 }
 
@@ -1369,6 +1538,13 @@ void SpectrumWidget::setSliceInfo(int sliceId, bool isTxSlice)
 
 void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
 {
+    PerfUpdateScope perfScope(PerfUpdateScope::Kind::Panadapter);
+    if (!binsDbm.isEmpty()) {
+        recordPanadapterFrame();
+        if (PerfTelemetry::instance().enabled())
+            PerfTelemetry::instance().recordPanFrame();
+    }
+
     // Forward to GPU renderer (#502)
 
 
@@ -1488,6 +1664,7 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
                                         double lowFreqMhz, double highFreqMhz,
                                         quint32 timecode)
 {
+    PerfUpdateScope perfScope(PerfUpdateScope::Kind::Waterfall);
     // Native waterfall tiles carry intensity values (int16/128.0f, ~96-120 on HF).
     if (binsIntensity.isEmpty()) return;
 
@@ -1667,6 +1844,9 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
         }
     }
     m_prevTileScanline = scanline;
+    recordWaterfallFrame(rowsToPush);
+    if (PerfTelemetry::instance().enabled())
+        PerfTelemetry::instance().recordWaterfallNativeRows(rowsToPush);
 
     update();
 }
@@ -1762,6 +1942,10 @@ static double snapToStep(double mhz, int stepHz)
 
 void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
 {
+    PerfInputScope perfScope("mousePress");
+    const auto dragStatePublisher = makeScopeExit([this] { publishPerfDragState(); });
+    (void)dragStatePublisher;
+
     const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
     const int contentH = height() - chromeH;
     const int specH = static_cast<int>(contentH * m_spectrumFrac);
@@ -2213,6 +2397,18 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
 
 void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
 {
+    PerfInputScope perfScope("mouseMove");
+    if (PerfTelemetry::instance().enabled()) {
+        const qint64 nowNs = PerfTelemetry::nowNs();
+        if (m_lastMouseMoveNs > 0) {
+            PerfTelemetry::instance().recordMouseMoveGap(
+                static_cast<double>(nowNs - m_lastMouseMoveNs) / 1000000.0);
+        }
+        m_lastMouseMoveNs = nowNs;
+    }
+    const auto dragStatePublisher = makeScopeExit([this] { publishPerfDragState(); });
+    (void)dragStatePublisher;
+
     const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
     const int contentH = height() - chromeH;
     const int specH = static_cast<int>(contentH * m_spectrumFrac);
@@ -2537,6 +2733,10 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
 
 void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
 {
+    PerfInputScope perfScope("mouseRelease");
+    const auto dragStatePublisher = makeScopeExit([this] { publishPerfDragState(); });
+    (void)dragStatePublisher;
+
     if (m_draggingTnfId >= 0) {
         m_draggingTnfId = -1;
         setSpectrumCursor(Qt::CrossCursor);
@@ -2805,6 +3005,8 @@ bool SpectrumWidget::event(QEvent* ev)
 
 void SpectrumWidget::wheelEvent(QWheelEvent* ev)
 {
+    PerfInputScope perfScope("wheel");
+
     // Skip scroll on the divider + freq scale bar.
     const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
     const int contentH2 = height() - chromeH;
@@ -3013,9 +3215,73 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins, int destWidth,
     } else {
         rebuildWaterfallViewport();
     }
+    recordWaterfallFrame();
+    if (PerfTelemetry::instance().enabled())
+        PerfTelemetry::instance().recordWaterfallFallbackRows(1);
 }
 
 // ─── Paint ────────────────────────────────────────────────────────────────────
+
+void SpectrumWidget::drawFpsMeters(QPainter& p, const QRect& specRect, const QRect& wfRect)
+{
+    if (!m_showFpsMeters)
+        return;
+
+    p.save();
+    QFont f = p.font();
+    f.setPointSize(9);
+    f.setBold(true);
+    p.setFont(f);
+    const QFontMetrics fm(f);
+
+    auto drawMeter = [&](const QRect& area, const QString& name, double fps,
+                         bool bottomAligned, int bottomInset, int rightInset) {
+        if (area.width() < 56 || area.height() < 18)
+            return;
+
+        const QString label = QString("%1 %2 FPS").arg(name).arg(fps, 0, 'f', 1);
+        const int padX = 6;
+        const int padY = 3;
+        const int boxW = fm.horizontalAdvance(label) + padX * 2;
+        const int boxH = fm.height() + padY * 2;
+        if (area.width() < boxW + rightInset + 12 || area.height() < boxH + 8)
+            return;
+
+        const int plotRight = area.right() - rightInset;
+        int x = plotRight - boxW - 8;
+        int y = bottomAligned ? area.bottom() - boxH - bottomInset : area.top() + 6;
+        if (x + boxW > plotRight - 4)
+            x = plotRight - boxW - 4;
+        if (x < area.left() + 4)
+            x = area.left() + 4;
+        if (y + boxH > area.bottom() - 4)
+            y = area.bottom() - boxH - 4;
+        if (y < area.top() + 4)
+            y = area.top() + 4;
+
+        const QRect box(x, y, boxW, boxH);
+        p.setRenderHint(QPainter::Antialiasing, true);
+        const QRectF frame = QRectF(box).adjusted(0.5, 0.5, -0.5, -0.5);
+        p.setPen(Qt::NoPen);
+        p.setBrush(QColor(0x0f, 0x0f, 0x1a, 210));
+        p.drawRoundedRect(frame, 3.0, 3.0);
+        p.setBrush(Qt::NoBrush);
+        p.setPen(QPen(QColor(255, 255, 255, 170), 1.0));
+        p.drawRoundedRect(frame, 3.0, 3.0);
+        p.setRenderHint(QPainter::Antialiasing, false);
+        p.setPen(QColor(0x9c, 0xee, 0xff));
+        p.drawText(box.left() + padX,
+                   box.top() + padY + fm.ascent(),
+                   label);
+    };
+
+    const int panBottomInset = (m_bandPlanFontSize > 0)
+        ? m_bandPlanFontSize + 12
+        : 6;
+    drawMeter(specRect, QStringLiteral("PAN"), m_panadapterFps, true, panBottomInset, DBM_STRIP_W);
+    drawMeter(wfRect, QStringLiteral("WF"), m_waterfallFps, true, 6, waterfallStripWidth());
+    p.restore();
+}
 
 #ifdef AETHER_GPU_SPECTRUM
 
@@ -3262,6 +3528,8 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
         QImage rgba = m_waterfall.convertToFormat(QImage::Format_RGBA8888);
         QRhiTextureSubresourceUploadDescription desc(rgba);
         batch->uploadTexture(m_wfGpuTex, QRhiTextureUploadEntry(0, 0, desc));
+        if (PerfTelemetry::instance().enabled())
+            PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::WaterfallFull);
     }
 
     cb->resourceUpdate(batch);
@@ -3306,6 +3574,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     const int w = width();
     const int h = height();
     if (w <= 0 || h <= FREQ_SCALE_H + DIVIDER_H + 2) return;
+    const bool perfEnabled = PerfTelemetry::instance().enabled();
+    const qint64 perfStartNs = perfEnabled ? PerfTelemetry::nowNs() : 0;
 
     const int chromeH = FREQ_SCALE_H + DIVIDER_H;
     const int contentH = h - chromeH;
@@ -3354,6 +3624,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             QImage rgba = m_waterfall.convertToFormat(QImage::Format_RGBA8888);
             QRhiTextureSubresourceUploadDescription desc(rgba);
             batch->uploadTexture(m_wfGpuTex, QRhiTextureUploadEntry(0, 0, desc));
+            if (perfEnabled)
+                PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::WaterfallFull);
             m_wfLastUploadedRow = m_wfWriteRow;
             m_wfTexFullUpload = false;
         } else if (m_wfWriteRow != m_wfLastUploadedRow) {
@@ -3386,6 +3658,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             if (!entries.isEmpty()) {
                 uploadDesc.setEntries(entries.begin(), entries.end());
                 batch->uploadTexture(m_wfGpuTex, uploadDesc);
+                if (perfEnabled) {
+                    PerfTelemetry::instance().recordGpuUpload(
+                        PerfTelemetry::GpuUploadKind::WaterfallIncremental);
+                }
             }
             m_wfLastUploadedRow = m_wfWriteRow;
         }
@@ -3457,6 +3733,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             drawSwrSweep(p, specRect);
             drawSliceMarkers(p, specRect, wfRect);
             drawOffScreenSlices(p, specRect);
+            drawFpsMeters(p, specRect, wfRect);
 
             // WNB / RF gain / Prop forecast indicators (top-right of spectrum)
             {
@@ -3603,6 +3880,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         if (m_overlayNeedsUpload) {
             QRhiTextureSubresourceUploadDescription ovDesc(m_overlayStatic);
             batch->uploadTexture(m_ovGpuTex, QRhiTextureUploadEntry(0, 0, ovDesc));
+            if (perfEnabled)
+                PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::Overlay);
             m_overlayNeedsUpload = false;
         }
 
@@ -3890,6 +4169,11 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             }
         }
     }
+
+    if (perfEnabled) {
+        PerfTelemetry::instance().recordRender(
+            static_cast<double>(PerfTelemetry::nowNs() - perfStartNs) / 1000000.0);
+    }
 }
 
 void SpectrumWidget::render(QRhiCommandBuffer* cb)
@@ -4000,6 +4284,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         drawSliceMarkers(p, specRect, wfRect);
         drawOffScreenSlices(p, specRect);
         drawConnectionAnimation(p, specRect);
+        drawFpsMeters(p, specRect, wfRect);
     }
 
     // Reposition all VFO widgets — deconflict flags so they fly away from each other
@@ -4228,7 +4513,10 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         p.drawText(lx + 4, ly + fm.ascent() + 2, label);
     }
 
-    qCDebug(lcPerf) << "paintEvent:" << static_cast<int>(frameTimer.elapsed()) << "ms";
+    if (PerfTelemetry::instance().enabled()) {
+        PerfTelemetry::instance().recordRender(
+            static_cast<double>(frameTimer.nsecsElapsed()) / 1000000.0);
+    }
 }
 
 #endif // AETHER_GPU_SPECTRUM

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -188,6 +188,8 @@ public:
     void setSingleClickTune(bool on) { m_singleClickTune = on; }
     void setShowCursorFreq(bool on) { m_showCursorFreq = on; update(); }
     bool showCursorFreq() const { return m_showCursorFreq; }
+    void setShowFpsMeters(bool on);
+    bool showFpsMeters() const { return m_showFpsMeters; }
     void setShowTuneGuides(bool on);
     bool showTuneGuides() const { return m_showTuneGuides; }
     void setExtendedFrequencyLine(bool on);
@@ -440,6 +442,7 @@ private:
     void updateTrackedCursorState(const QPoint& localPos, bool insideWidget);
     void updateTnfHoverPopup();
     void drawWaterfall(QPainter& p, const QRect& r);
+    void drawFpsMeters(QPainter& p, const QRect& specRect, const QRect& wfRect);
     void positionZoomButtons();
     void drawFreqScale(QPainter& p, const QRect& r);
     void drawDbmScale(QPainter& p, const QRect& specRect);
@@ -457,6 +460,13 @@ private:
     int maxWaterfallHistoryOffsetRows() const;
     int historyRowIndexForAge(int ageRows) const;
     QString pausedTimeLabelForAge(int ageRows) const;
+    void applyFpsMeterVisibility(bool on);
+    void resetFpsMeterWindow();
+    void updateFpsMeterValues();
+    void recordPanadapterFrame();
+    void recordWaterfallFrame(int rows = 1);
+    bool anyDragActive() const;
+    void publishPerfDragState() const;
 
     // Helper: find overlay index for a sliceId, or -1.
     int overlayIndex(int sliceId) const;
@@ -686,6 +696,16 @@ private:
     int      m_wfAvgTarget{1};   // how many tiles to average into one row
     int      m_wfAvgCount{0};    // tiles accumulated so far
     QVector<float> m_wfAvgBins;  // accumulated intensity values
+
+    // Lightweight diagnostics overlay toggled from View -> FPS Meters.
+    bool m_showFpsMeters{false};
+    QTimer* m_fpsMeterTimer{nullptr};
+    QElapsedTimer m_fpsMeterWindow;
+    int m_panadapterFrameCount{0};
+    int m_waterfallFrameCount{0};
+    double m_panadapterFps{0.0};
+    double m_waterfallFps{0.0};
+    qint64 m_lastMouseMoveNs{0};
 
     // ── TNF markers ────────────────────────────────────────────────────
     QVector<TnfMarker> m_tnfMarkers;

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -1,4 +1,5 @@
 #include "PanadapterModel.h"
+#include "core/PerfTelemetry.h"
 #include <QDebug>
 
 namespace AetherSDR {
@@ -135,6 +136,7 @@ void PanadapterModel::applyWaterfallStatus(const QMap<QString, QString>& kvs)
         bool ok = false;
         const int ms = kvs["line_duration"].toInt(&ok);
         if (ok) {
+            PerfTelemetry::instance().setWaterfallLineDurationMs(ms);
             if (ms != m_waterfallLineDuration) {
                 m_waterfallLineDuration = ms;
                 emit waterfallLineDurationChanged(m_waterfallLineDuration);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3,6 +3,7 @@
 #include "core/AppSettings.h"
 #include "core/CwTrace.h"
 #include "core/LogManager.h"
+#include "core/PerfTelemetry.h"
 #include "core/StreamStatus.h"
 #include "core/UdpRegistrationPolicy.h"
 #include "RadioStatusOwnership.h"
@@ -2503,6 +2504,13 @@ void RadioModel::logRemoteAudioRxSummary(const QString& reason) const
 
 quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
 {
+    auto& perf = PerfTelemetry::instance();
+    if (perf.enabled()
+        && command.startsWith(QStringLiteral("display pan set "))
+        && command.contains(QStringLiteral(" center="))) {
+        perf.recordPanCenterCommand();
+    }
+
     if (m_wanConn)
         return m_wanConn->sendCommand(command, std::move(cb));
 


### PR DESCRIPTION
## Summary

Adds the FPS meter UI and low-overhead performance telemetry work on a clean branch based on `origin/main`.

- Adds Ctrl+F / View menu toggle for persisted panadapter and waterfall FPS meters.
- Draws PAN/WF FPS badges inside their respective panes, positioned left of the scale bars with a subtle white border.
- Adds `PerfTelemetry` behind the existing `aether.perf` category, emitting compact `PerfSummary` lines and thresholded `PerfStall` events only when Performance logging is enabled.
- Instruments pan/waterfall frame age, update/render timing, UDP drain health, packet loss/restarts, GPU upload pressure, interaction timing, and S-history processing cost.
- Extends pan/waterfall frame signals with network emit timestamps for UI backlog/age correlation.

## Scope Notes

This PR intentionally excludes the already-submitted display-rate reconciliation and async logging work. It is based on current `origin/main`, which already contains PR #2465, and does not include the async logging PR #2478 files or `LogManager` changes.

## Validation

- Configured clean worktree with:
  - `cmake -S . -B build-ninja -G Ninja`
- Built exactly with:
  - `env -u CPLUS_INCLUDE_PATH cmake --build build-ninja --parallel 22`
- Ran registered tests:
  - `ctest --test-dir build-ninja --output-on-failure`
- Confirmed PR diff is limited to FPS meter/telemetry files and does not include async logging files.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
