### PR TITLE
feat(gui): show Connected Stations dialog when multiFLEX is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,6 +521,7 @@ set(GUI_SOURCES
     src/gui/MainWindow.cpp
     src/gui/ConnectionPanel.cpp
     src/gui/ClientDisconnectDialog.cpp
+    src/gui/ConnectedStationsDialog.cpp
     src/gui/SpectrumWidget.cpp
     src/gui/SpectrumOverlayMenu.cpp
     src/gui/SliceColorManager.cpp

--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -111,7 +111,8 @@ RadioInfo RadioDiscovery::parseDiscoveryPacket(const QByteArray& data) const
         else if (key == "status")  info.status  = value;
         else if (key == "nickname") info.nickname = value;
         else if (key == "callsign") info.callsign = value;
-        else if (key == "inuse")   info.inUse   = (value == "1");
+        else if (key == "inuse")       info.inUse           = (value == "1");
+        else if (key == "mf_enable")   info.multiFlexEnabled = (value != "0");
         else if (key == "max_licensed_version") info.maxLicensedVersion = value.toInt();
         else if (key == "is_system_model") info.isSystemModel = (value == "1");
         else if (key == "turf_region")     info.turfRegion    = value;

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -61,6 +61,7 @@ struct RadioInfo {
     QString status;         // "Available" | "In_Use" | etc.
     int maxLicensedVersion{0};
     bool inUse{false};
+    bool multiFlexEnabled{true}; // mf_enable from discovery; true = multi-client allowed
     bool isRouted{false};
     bool isSystemModel{false};
     QString turfRegion;

--- a/src/gui/ConnectedStationsDialog.cpp
+++ b/src/gui/ConnectedStationsDialog.cpp
@@ -1,0 +1,225 @@
+#include "ConnectedStationsDialog.h"
+
+#include <QApplication>
+#include <QButtonGroup>
+#include <QCursor>
+#include <QFrame>
+#include <QGuiApplication>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QScreen>
+#include <QShowEvent>
+#include <QVBoxLayout>
+#include <QWindow>
+
+namespace AetherSDR {
+
+namespace {
+
+const char* kStyle =
+    "QDialog { background: #0f0f1a; }"
+    "QFrame#radioSection {"
+    "  background: #121220;"
+    "  border-bottom: 1px solid #1e2840;"
+    "}"
+    "QFrame#stationsSection {"
+    "  background: #0f0f1a;"
+    "}"
+    "QLabel#sectionHeader {"
+    "  color: #ffffff;"
+    "  font-size: 13px;"
+    "  font-weight: bold;"
+    "  background: transparent;"
+    "}"
+    "QLabel#radioModel {"
+    "  color: #e0eaf8;"
+    "  font-size: 14px;"
+    "  font-weight: bold;"
+    "  background: transparent;"
+    "}"
+    "QLabel#radioStation {"
+    "  color: #00b4d8;"
+    "  font-size: 12px;"
+    "  background: transparent;"
+    "}"
+    "QLabel#infoLabel {"
+    "  color: #8aa8c0;"
+    "  font-size: 11px;"
+    "  background: transparent;"
+    "}"
+    "QFrame#stationRow {"
+    "  background: #171728;"
+    "  border: 1px solid #1e2840;"
+    "  border-radius: 3px;"
+    "}"
+    "QFrame#stationRow:hover {"
+    "  background: #1a2035;"
+    "  border-color: #304060;"
+    "}"
+    "QRadioButton {"
+    "  color: #c8d8e8;"
+    "  background: transparent;"
+    "  spacing: 8px;"
+    "}"
+    "QRadioButton::indicator { width: 14px; height: 14px; }"
+    "QRadioButton::indicator:checked { color: #00b4d8; }"
+    "QPushButton {"
+    "  background: #1a2a3a;"
+    "  border: 1px solid #304050;"
+    "  border-radius: 3px;"
+    "  color: #c8d8e8;"
+    "  padding: 6px 16px;"
+    "}"
+    "QPushButton:hover { background: #203040; border-color: #00b4d8; }"
+    "QPushButton:pressed { background: #102030; }"
+    "QPushButton#disconnectButton {"
+    "  background: #c0392b;"
+    "  border-color: #e74c3c;"
+    "  color: #ffffff;"
+    "  font-weight: bold;"
+    "}"
+    "QPushButton#disconnectButton:hover { background: #e74c3c; }"
+    "QPushButton#disconnectButton:disabled {"
+    "  background: #2a1a1a;"
+    "  border-color: #3a2a2a;"
+    "  color: #604040;"
+    "}"
+    "QPushButton#cancelButton { color: #8aa8c0; }";
+
+} // namespace
+
+ConnectedStationsDialog::ConnectedStationsDialog(const RadioMeta& radio,
+                                                 const QList<Client>& clients,
+                                                 QWidget* parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("Connected Stations"));
+    setModal(true);
+    setWindowModality(Qt::ApplicationModal);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    setSizeGripEnabled(false);
+    setStyleSheet(kStyle);
+
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    // ── Radio section ──────────────────────────────────────────────────────
+    auto* radioFrame = new QFrame(this);
+    radioFrame->setObjectName("radioSection");
+    auto* radioLayout = new QVBoxLayout(radioFrame);
+    radioLayout->setContentsMargins(18, 14, 18, 14);
+    radioLayout->setSpacing(4);
+
+    auto* radioHeader = new QLabel(tr("Radio"), radioFrame);
+    radioHeader->setObjectName("sectionHeader");
+    radioLayout->addWidget(radioHeader);
+
+    auto* radioModel = new QLabel(radio.model, radioFrame);
+    radioModel->setObjectName("radioModel");
+    radioLayout->addWidget(radioModel);
+
+    const QString stationLine = QStringList({radio.nickname, radio.callsign})
+                                    .join(QStringLiteral("   "))
+                                    .trimmed();
+    if (!stationLine.isEmpty()) {
+        auto* radioStation = new QLabel(stationLine, radioFrame);
+        radioStation->setObjectName("radioStation");
+        radioLayout->addWidget(radioStation);
+    }
+
+    outer->addWidget(radioFrame);
+
+    // ── Connected Stations section ─────────────────────────────────────────
+    auto* stationsFrame = new QFrame(this);
+    stationsFrame->setObjectName("stationsSection");
+    auto* stationsLayout = new QVBoxLayout(stationsFrame);
+    stationsLayout->setContentsMargins(18, 14, 18, 18);
+    stationsLayout->setSpacing(10);
+
+    auto* stationsHeader = new QLabel(tr("Connected Stations"), stationsFrame);
+    stationsHeader->setObjectName("sectionHeader");
+    stationsLayout->addWidget(stationsHeader);
+
+    auto* infoLabel = new QLabel(
+        tr("multiFLEX is disabled on this radio. Select a station to disconnect "
+           "before connecting AetherSDR."),
+        stationsFrame);
+    infoLabel->setObjectName("infoLabel");
+    infoLabel->setWordWrap(true);
+    stationsLayout->addWidget(infoLabel);
+
+    auto* group = new QButtonGroup(this);
+    auto* disconnectBtn = new QPushButton(tr("Disconnect Station"), stationsFrame);
+    disconnectBtn->setObjectName("disconnectButton");
+    disconnectBtn->setEnabled(false);
+    disconnectBtn->setCursor(Qt::PointingHandCursor);
+    disconnectBtn->setMinimumHeight(32);
+
+    for (const Client& client : clients) {
+        auto* rowFrame = new QFrame(stationsFrame);
+        rowFrame->setObjectName("stationRow");
+        auto* rowLayout = new QHBoxLayout(rowFrame);
+        rowLayout->setContentsMargins(10, 6, 10, 6);
+
+        QString label = client.program.trimmed();
+        const QString station = client.station.trimmed();
+        if (!station.isEmpty() && station != label)
+            label = label.isEmpty() ? station : QStringLiteral("%1: %2").arg(label, station);
+        if (label.isEmpty())
+            label = QStringLiteral("client 0x%1").arg(client.handle, 8, 16, QChar('0')).toUpper();
+
+        auto* rb = new QRadioButton(label, rowFrame);
+        group->addButton(rb, static_cast<int>(client.handle));
+        rowLayout->addWidget(rb);
+        stationsLayout->addWidget(rowFrame);
+
+        connect(rb, &QRadioButton::toggled, this, [disconnectBtn, handle = client.handle](bool checked) {
+            if (checked)
+                disconnectBtn->setEnabled(true);
+            Q_UNUSED(handle)
+        });
+    }
+
+    connect(disconnectBtn, &QPushButton::clicked, this, [this, group] {
+        const int id = group->checkedId();
+        if (id > 0) {
+            m_selectedHandle = static_cast<quint32>(id);
+            accept();
+        }
+    });
+
+    auto* cancelBtn = new QPushButton(tr("Cancel"), stationsFrame);
+    cancelBtn->setObjectName("cancelButton");
+    cancelBtn->setCursor(Qt::PointingHandCursor);
+    cancelBtn->setMinimumHeight(32);
+    connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
+
+    stationsLayout->addWidget(disconnectBtn);
+    stationsLayout->addWidget(cancelBtn);
+    outer->addWidget(stationsFrame);
+
+    resize(380, sizeHint().height());
+}
+
+void ConnectedStationsDialog::showEvent(QShowEvent* event)
+{
+    QDialog::showEvent(event);
+
+    QScreen* screen = nullptr;
+    if (parentWidget() && parentWidget()->windowHandle())
+        screen = parentWidget()->windowHandle()->screen();
+    if (!screen)
+        screen = QGuiApplication::screenAt(QCursor::pos());
+    if (!screen)
+        screen = QGuiApplication::primaryScreen();
+    if (!screen)
+        return;
+
+    const QRect area = screen->availableGeometry();
+    move(area.center() - rect().center());
+}
+
+} // namespace AetherSDR

--- a/src/gui/ConnectedStationsDialog.cpp
+++ b/src/gui/ConnectedStationsDialog.cpp
@@ -172,21 +172,23 @@ ConnectedStationsDialog::ConnectedStationsDialog(const RadioMeta& radio,
             label = QStringLiteral("client 0x%1").arg(client.handle, 8, 16, QChar('0')).toUpper();
 
         auto* rb = new QRadioButton(label, rowFrame);
-        group->addButton(rb, static_cast<int>(client.handle));
+        // Store the full quint32 handle as a property — avoids the truncation /
+        // sign-bit ambiguity that arises when casting to QButtonGroup's int id.
+        rb->setProperty("handle", QVariant::fromValue(client.handle));
+        group->addButton(rb);
         rowLayout->addWidget(rb);
         stationsLayout->addWidget(rowFrame);
 
-        connect(rb, &QRadioButton::toggled, this, [disconnectBtn, handle = client.handle](bool checked) {
+        connect(rb, &QRadioButton::toggled, this, [disconnectBtn](bool checked) {
             if (checked)
                 disconnectBtn->setEnabled(true);
-            Q_UNUSED(handle)
         });
     }
 
     connect(disconnectBtn, &QPushButton::clicked, this, [this, group] {
-        const int id = group->checkedId();
-        if (id > 0) {
-            m_selectedHandle = static_cast<quint32>(id);
+        QAbstractButton* checked = group->checkedButton();
+        if (checked) {
+            m_selectedHandle = checked->property("handle").value<quint32>();
             accept();
         }
     });

--- a/src/gui/ConnectedStationsDialog.h
+++ b/src/gui/ConnectedStationsDialog.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QDialog>
+#include <QList>
+#include <QString>
+
+namespace AetherSDR {
+
+// Shown when multiFLEX is disabled and another client is already connected.
+// Mirrors the SmartSDR "Connected Stations" dialog: lists connected stations
+// and lets the user disconnect one before proceeding.
+class ConnectedStationsDialog : public QDialog {
+public:
+    struct Client {
+        quint32 handle{0};
+        QString program;
+        QString station;
+    };
+
+    struct RadioMeta {
+        QString model;
+        QString nickname;
+        QString callsign;
+    };
+
+    explicit ConnectedStationsDialog(const RadioMeta& radio,
+                                     const QList<Client>& clients,
+                                     QWidget* parent = nullptr);
+
+    // Returns the handle the user chose to disconnect, or 0 if cancelled.
+    quint32 selectedHandle() const { return m_selectedHandle; }
+
+protected:
+    void showEvent(QShowEvent* event) override;
+
+private:
+    quint32 m_selectedHandle{0};
+};
+
+} // namespace AetherSDR

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -1352,6 +1352,7 @@ void ConnectionPanel::probeRadio(const QString& ip)
 
         // Build RadioInfo from collected status and emit the connect signal.
         auto finishProbe = [this, sock, trimmedIp, bindSettings, version, statusLines, localSrc] {
+            sock->disconnectFromHost();
             sock->deleteLater();
 
             RadioInfo info;

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -4,6 +4,8 @@
 #include "FramelessResizer.h"
 #include "FramelessWindowTitleBar.h"
 
+#include <memory>
+
 #include <QAbstractItemView>
 #include <QFormLayout>
 #include <QFrame>
@@ -1335,57 +1337,137 @@ void ConnectionPanel::probeRadio(const QString& ip)
     });
 
     connect(sock, &QTcpSocket::connected, this, [this, sock, trimmedIp, bindSettings] {
-        auto* buffer = new QByteArray;
+        // Shared state across readyRead calls and the peek timer.
+        auto buffer      = std::make_shared<QByteArray>();
+        auto version     = std::make_shared<QString>();
+        auto statusLines = std::make_shared<QStringList>();
+        auto localSrc    = std::make_shared<QHostAddress>();
+        auto seenHandle  = std::make_shared<bool>(false);
+
+        // Fired 400 ms after H is received; by then the radio has sent
+        // its full radio + client status burst in response to our subs.
+        auto* peekTimer = new QTimer(sock);
+        peekTimer->setSingleShot(true);
+        peekTimer->setInterval(400);
+
+        // Build RadioInfo from collected status and emit the connect signal.
+        auto finishProbe = [this, sock, trimmedIp, bindSettings, version, statusLines, localSrc] {
+            sock->deleteLater();
+
+            RadioInfo info;
+            info.address  = QHostAddress(trimmedIp);
+            info.port     = 4992;
+            info.version  = *version;
+            info.status   = QStringLiteral("Available");
+            info.model    = QStringLiteral("FLEX");
+            info.name     = QStringLiteral("FLEX");
+            info.serial   = trimmedIp;
+            info.isRouted = true;
+            info.bindSettings       = bindSettings;
+            info.sessionBindAddress = *localSrc;
+
+            // Parse S-type status lines collected during the peek window.
+            for (const QString& line : *statusLines) {
+                // S<handle>|<object> [key=val ...]
+                const int pipeIdx = line.indexOf('|');
+                if (pipeIdx < 0)
+                    continue;
+                const QString body = line.mid(pipeIdx + 1);
+
+                if (body.startsWith(QStringLiteral("radio "))) {
+                    const QStringList parts = body.mid(6).split(' ', Qt::SkipEmptyParts);
+                    for (const QString& part : parts) {
+                        const int eq = part.indexOf('=');
+                        if (eq < 0)
+                            continue;
+                        const QString key = part.left(eq);
+                        const QString val = part.mid(eq + 1);
+                        if (key == QStringLiteral("mf_enable")) {
+                            info.multiFlexEnabled = (val != QStringLiteral("0"));
+                        } else if (key == QStringLiteral("model") && !val.isEmpty()) {
+                            info.model = val;
+                            info.name  = val;
+                        } else if (key == QStringLiteral("nickname") && !val.isEmpty()) {
+                            info.nickname = val;
+                        } else if (key == QStringLiteral("callsign") && !val.isEmpty()) {
+                            info.callsign = val;
+                        }
+                    }
+                } else if (body.startsWith(QStringLiteral("client 0x"))
+                           && body.contains(QStringLiteral("connected"))) {
+                    // "client 0x<handle> connected program=... station=..."
+                    const QStringList tokens = body.split(' ', Qt::SkipEmptyParts);
+                    if (tokens.size() >= 3 && tokens[2] == QStringLiteral("connected")) {
+                        bool ok = false;
+                        const quint32 handle = tokens[1].toUInt(&ok, 16);
+                        if (!ok || handle == 0)
+                            continue;
+                        QString program;
+                        QString station;
+                        for (int i = 3; i < tokens.size(); ++i) {
+                            const int eq = tokens[i].indexOf('=');
+                            if (eq < 0)
+                                continue;
+                            const QString key = tokens[i].left(eq);
+                            const QString val = tokens[i].mid(eq + 1);
+                            if (key == QStringLiteral("program"))
+                                program = val;
+                            else if (key == QStringLiteral("station"))
+                                station = val;
+                        }
+                        info.guiClientHandles.append(QString::number(handle, 16).toUpper());
+                        info.guiClientPrograms.append(program);
+                        info.guiClientStations.append(station);
+                    }
+                }
+            }
+
+            saveManualProfile(trimmedIp, bindSettings, *localSrc);
+            rememberManualIp(trimmedIp);
+
+            m_manualConnectBtn->setText(QStringLiteral("Connect by IP"));
+            updateActionState();
+
+            if (m_manualConnectPending) {
+                saveLowBandwidthPreference(m_lowBwCheck->isChecked());
+                setManualMessage(
+                    QStringLiteral("Found a radio at %1. Connecting now…").arg(trimmedIp));
+                m_manualConnectPending = false;
+                emit connectRequested(info);
+            } else {
+                setManualMessage(
+                    QStringLiteral("Found a radio at %1 and saved the path for later.")
+                        .arg(trimmedIp));
+                emit routedRadioFound(info);
+            }
+        };
+
+        connect(peekTimer, &QTimer::timeout, this, [finishProbe] { finishProbe(); });
+
         connect(sock, &QTcpSocket::readyRead, this,
-                [this, sock, trimmedIp, bindSettings, buffer] {
+                [sock, buffer, version, statusLines, localSrc, seenHandle, peekTimer] {
             buffer->append(sock->readAll());
 
-            QString version;
             while (buffer->contains('\n')) {
                 const int idx = buffer->indexOf('\n');
                 const QString line = QString::fromUtf8(buffer->left(idx)).trimmed();
                 buffer->remove(0, idx + 1);
 
                 if (line.startsWith('V')) {
-                    version = line.mid(1);
-                } else if (line.startsWith('H')) {
-                    const QHostAddress localSource = sock->localAddress();
-                    sock->disconnectFromHost();
-                    sock->deleteLater();
-                    delete buffer;
-
-                    RadioInfo info;
-                    info.address = QHostAddress(trimmedIp);
-                    info.port = 4992;
-                    info.version = version;
-                    info.status = "Available";
-                    info.model = "FLEX";
-                    info.name = "FLEX";
-                    info.serial = trimmedIp;
-                    info.isRouted = true;
-                    info.bindSettings = bindSettings;
-                    info.sessionBindAddress = localSource;
-
-                    saveManualProfile(trimmedIp, bindSettings, info.sessionBindAddress);
-                    rememberManualIp(trimmedIp);
-
-                    m_manualConnectBtn->setText("Connect by IP");
-                    updateActionState();
-
-                    if (m_manualConnectPending) {
-                        saveLowBandwidthPreference(m_lowBwCheck->isChecked());
-                        setManualMessage(
-                            QStringLiteral("Found a radio at %1. Connecting now…").arg(trimmedIp));
-                        m_manualConnectPending = false;
-                        emit connectRequested(info);
-                    } else {
-                        setManualMessage(
-                            QStringLiteral("Found a radio at %1 and saved the path for later.")
-                                .arg(trimmedIp));
-                        emit routedRadioFound(info);
-                    }
-
-                    return;
+                    *version = line.mid(1);
+                } else if (line.startsWith('H') && !*seenHandle) {
+                    *seenHandle = true;
+                    *localSrc   = sock->localAddress();
+                    // Ask the radio for its current state before we commit
+                    // to a real connection. This lets us populate mf_enable
+                    // and connected client info even when there's no discovery
+                    // broadcast (direct IP / VPN / routed path).
+                    sock->write("C1|sub radio all\n");
+                    sock->write("C2|sub client all\n");
+                    sock->flush();
+                    peekTimer->start();
+                } else if (line.startsWith('S') && *seenHandle) {
+                    statusLines->append(line);
                 }
             }
         });

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5,6 +5,7 @@
 #include "ConnectionPanel.h"
 #include "Theme.h"
 #include "ClientDisconnectDialog.h"
+#include "ConnectedStationsDialog.h"
 #include "TitleBar.h"
 #include "PanadapterApplet.h"
 #include "PanadapterStack.h"
@@ -632,6 +633,37 @@ bool MainWindow::confirmClientSlotAvailability(const RadioInfo& info,
         disconnectHandles->clear();
 
     const auto clients = buildDisconnectClients(info);
+
+    // When multiFLEX is disabled, any connected client blocks us — show the
+    // Connected Stations dialog so the user can disconnect them first.
+    if (!info.multiFlexEnabled && !clients.isEmpty()) {
+        ConnectedStationsDialog::RadioMeta meta;
+        meta.model    = info.model;
+        meta.nickname = info.nickname;
+        meta.callsign = info.callsign;
+
+        QList<ConnectedStationsDialog::Client> sdClients;
+        for (const auto& c : clients) {
+            ConnectedStationsDialog::Client sc;
+            sc.handle  = c.handle;
+            sc.program = c.program;
+            sc.station = c.station;
+            sdClients.append(sc);
+        }
+
+        ConnectedStationsDialog dialog(meta, sdClients, this);
+        if (dialog.exec() != QDialog::Accepted)
+            return false;
+
+        const quint32 handle = dialog.selectedHandle();
+        if (handle == 0)
+            return false;
+
+        if (disconnectHandles)
+            *disconnectHandles = {handle};
+        return true;
+    }
+
     const int maxSlices = RadioModel::maxSlicesForModel(info.model);
     if (clients.isEmpty() || clients.size() < maxSlices)
         return true;
@@ -652,6 +684,37 @@ bool MainWindow::confirmClientSlotAvailability(const WanRadioInfo& info,
         disconnectHandles->clear();
 
     const auto clients = buildDisconnectClients(info);
+
+    // licensedClients == 1 means the radio's multiFLEX license allows only one
+    // simultaneous client — effectively mf_enable=0 from the SmartLink perspective.
+    if (info.licensedClients <= 1 && !clients.isEmpty()) {
+        ConnectedStationsDialog::RadioMeta meta;
+        meta.model    = info.model;
+        meta.nickname = info.nickname;
+        meta.callsign = info.callsign;
+
+        QList<ConnectedStationsDialog::Client> sdClients;
+        for (const auto& c : clients) {
+            ConnectedStationsDialog::Client sc;
+            sc.handle  = c.handle;
+            sc.program = c.program;
+            sc.station = c.station;
+            sdClients.append(sc);
+        }
+
+        ConnectedStationsDialog dialog(meta, sdClients, this);
+        if (dialog.exec() != QDialog::Accepted)
+            return false;
+
+        const quint32 handle = dialog.selectedHandle();
+        if (handle == 0)
+            return false;
+
+        if (disconnectHandles)
+            *disconnectHandles = {handle};
+        return true;
+    }
+
     const int maxSlices = RadioModel::maxSlicesForModel(info.model);
     if (clients.isEmpty() || clients.size() < maxSlices)
         return true;
@@ -1704,6 +1767,42 @@ MainWindow::MainWindow(QWidget* parent)
         m_connPanel->setStatusText("Disconnected by another client");
         setPanadapterConnectionAnimation(false);
         showForcedDisconnectDialog(wasWan, radioInfo, wanInfo);
+    });
+    connect(&m_radioModel, &RadioModel::multiFlexConflictDetected, this, [this] {
+        ConnectedStationsDialog::RadioMeta meta;
+        meta.model    = m_radioModel.model();
+        meta.nickname = m_radioModel.nickname();
+        meta.callsign = m_radioModel.callsign();
+
+        QList<ConnectedStationsDialog::Client> sdClients;
+        const quint32 ours = m_radioModel.ourClientHandle();
+        for (auto it = m_radioModel.clientInfoMap().cbegin();
+             it != m_radioModel.clientInfoMap().cend(); ++it) {
+            if (it.key() == ours)
+                continue;
+            ConnectedStationsDialog::Client c;
+            c.handle  = it.key();
+            c.program = it->program;
+            c.station = it->station;
+            sdClients.append(c);
+        }
+
+        ConnectedStationsDialog* dlg = new ConnectedStationsDialog(meta, sdClients, this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        connect(dlg, &QDialog::accepted, this, [this, dlg] {
+            const quint32 handle = dlg->selectedHandle();
+            if (handle != 0)
+                m_radioModel.resolveMultiFlexConflict(handle);
+            else
+                m_radioModel.cancelMultiFlexConflict();
+        });
+        connect(dlg, &QDialog::rejected, this, [this] {
+            m_userDisconnected = true;
+            m_connPanel->setStatusText("Connection canceled");
+            setPanadapterConnectionAnimation(false);
+            m_radioModel.cancelMultiFlexConflict();
+        });
+        dlg->show();
     });
     connect(&m_radioModel, &RadioModel::sliceAdded,
             this, &MainWindow::onSliceAdded);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -687,7 +687,13 @@ bool MainWindow::confirmClientSlotAvailability(const WanRadioInfo& info,
 
     // licensedClients == 1 means the radio's multiFLEX license allows only one
     // simultaneous client — effectively mf_enable=0 from the SmartLink perspective.
+    // WanRadioInfo defaults to 1 when licensed_clients is absent from the SmartLink
+    // response (older firmware, partial parse), so this gate is fail-safe: it blocks
+    // rather than allows.  Log when we hit the default so field reports are diagnosable.
     if (info.licensedClients <= 1 && !clients.isEmpty()) {
+        if (info.licensedClients == 1)
+            qCWarning(lcGui) << "MainWindow: WAN licensedClients=1 (may be default) — "
+                                "showing conflict dialog as a precaution";
         ConnectedStationsDialog::RadioMeta meta;
         meta.model    = info.model;
         meta.nickname = info.nickname;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1324,6 +1324,15 @@ void RadioModel::peekForMultiFlexConflictThen(std::function<void()> continuation
                     }
                 }
 
+                // If the map is still empty (only our own handle or nothing) after
+                // waiting for the burst, the radio either hasn't sent any client
+                // status yet or the burst arrived after the window closed.  Log so
+                // field reports of missed conflicts are diagnosable.  The connection
+                // proceeds — the alternative is a hang, which is worse than a miss.
+                if (m_clientInfoMap.isEmpty() || (m_clientInfoMap.size() == 1 && m_clientInfoMap.contains(ours2)))
+                    qCWarning(lcProtocol) << "RadioModel: peek window closed with no client status received —"
+                                            " conflict detection may have been missed (busy radio or lossy LAN)";
+
                 if (!m_multiFlexEnabled && hasOthers) {
                     qCDebug(lcProtocol) << "RadioModel: multiFLEX disabled, other clients present — pausing connection";
                     emit multiFlexConflictDetected();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1239,12 +1239,17 @@ void RadioModel::onConnected()
         if (m_wanConn) {
             // On WAN: wait for client ip response before sending client gui.
             // The radio needs time after wan validate to accept GUI registration.
+            // multiFLEX conflict on WAN is caught pre-connection via licensedClients.
             sendCmd("client ip", [this, clientId](int, const QString& body) {
                 qCDebug(lcProtocol) << "RadioModel: client ip ->" << body.trimmed();
                 registerAsGuiClient(clientId);
             });
         } else {
-            registerAsGuiClient(clientId);
+            // On LAN: peek at radio/client status before sending client gui so we
+            // can detect a multiFLEX conflict regardless of what discovery provided.
+            peekForMultiFlexConflictThen([this, clientId] {
+                registerAsGuiClient(clientId);
+            });
         }
     });
 }
@@ -1289,6 +1294,82 @@ void RadioModel::disconnectPendingClientsThen(std::function<void()> continuation
     };
 
     (*step)();
+}
+
+void RadioModel::peekForMultiFlexConflictThen(std::function<void()> continuation)
+{
+    m_multiFlexContinuation = continuation;
+
+    // Evict stale entries pre-populated from discovery or a previous session.
+    // We rebuild the map from scratch using only what the radio confirms via
+    // sub client all below, so we never show phantom handles in the dialog.
+    const quint32 ours = clientHandle();
+    for (auto it = m_clientInfoMap.begin(); it != m_clientInfoMap.end(); ) {
+        it = (it.key() != ours) ? m_clientInfoMap.erase(it) : std::next(it);
+    }
+    m_clientStations.clear();
+
+    // Subscribe to radio and client topics early — before client gui — to get
+    // mf_enable and the live connected-client list directly from the radio.
+    // 400 ms is enough for the radio's status burst to arrive on a LAN path.
+    sendCmd("sub radio all", [this](int, const QString&) {
+        sendCmd("sub client all", [this](int, const QString&) {
+            QTimer::singleShot(400, this, [this] {
+                const quint32 ours2 = clientHandle();
+                bool hasOthers = false;
+                for (auto it = m_clientInfoMap.cbegin(); it != m_clientInfoMap.cend(); ++it) {
+                    if (it.key() != ours2) {
+                        hasOthers = true;
+                        break;
+                    }
+                }
+
+                if (!m_multiFlexEnabled && hasOthers) {
+                    qCDebug(lcProtocol) << "RadioModel: multiFLEX disabled, other clients present — pausing connection";
+                    emit multiFlexConflictDetected();
+                    return;
+                }
+
+                // No conflict — proceed with registration.
+                if (m_multiFlexContinuation) {
+                    auto cont = std::move(m_multiFlexContinuation);
+                    m_multiFlexContinuation = nullptr;
+                    cont();
+                }
+            });
+        });
+    });
+}
+
+void RadioModel::resolveMultiFlexConflict(quint32 handle)
+{
+    // Move the continuation out so peekForMultiFlexConflictThen can safely
+    // re-assign m_multiFlexContinuation without trampling over it.
+    auto continuation = std::move(m_multiFlexContinuation);
+    m_multiFlexContinuation = nullptr;
+
+    const QString cmd = QString("client disconnect 0x%1").arg(handle, 0, 16);
+    qCDebug(lcProtocol) << "RadioModel: resolving multiFLEX conflict, disconnecting" << Qt::hex << handle;
+    sendCmd(cmd, [this, continuation = std::move(continuation)](int code, const QString& body) mutable {
+        if (code != 0)
+            qCWarning(lcProtocol) << "RadioModel: conflict client disconnect failed:" << body.trimmed();
+        // After eviction, re-run the full peek rather than jumping straight to the
+        // continuation. This catches any remaining clients (e.g., two sessions, or
+        // a stale handle that hadn't been cleaned up yet) and re-shows the dialog if
+        // needed, preventing phantom slices from a partially-disconnected session.
+        QTimer::singleShot(250, this, [this, continuation = std::move(continuation)]() mutable {
+            peekForMultiFlexConflictThen(std::move(continuation));
+        });
+    });
+}
+
+void RadioModel::cancelMultiFlexConflict()
+{
+    m_multiFlexContinuation = nullptr;
+    m_intentionalDisconnect = true;
+    QMetaObject::invokeMethod(m_connection, [conn = m_connection] {
+        conn->disconnectFromRadio();
+    });
 }
 
 void RadioModel::handleForcedClientDisconnect()

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -265,6 +265,11 @@ public:
     void connectToRadio(const RadioInfo& info);
     void connectViaWan(WanConnection* wan, const QString& publicIp, quint16 udpPort);
     void setPendingClientDisconnects(const QList<quint32>& handles);
+    // Called by MainWindow in response to multiFlexConflictDetected().
+    // Disconnects handle and resumes the connection sequence.
+    void resolveMultiFlexConflict(quint32 handle);
+    // Called by MainWindow when the user cancels the conflict dialog.
+    void cancelMultiFlexConflict();
     void disconnectFromRadio();
     void forceDisconnect();  // Close TCP but allow auto-reconnect
     bool isWan() const { return m_wanConn != nullptr; }
@@ -348,6 +353,10 @@ signals:
     void memoryRemoved(int index);
     void memoriesCleared();
     void audioOutputChanged();
+    // Emitted when multiFLEX is disabled and another client is already connected,
+    // detected post-TCP-connect before client gui is sent. MainWindow should show
+    // ConnectedStationsDialog and call resolveMultiFlexConflict() or cancelMultiFlexConflict().
+    void multiFlexConflictDetected();
     // Emitted when TX ownership changes in Multi-Flex (another client transmitting)
     void txOwnerChanged(bool ownedByUs, const QString& otherStation);
     // Emitted when the set of other connected clients changes.
@@ -428,6 +437,10 @@ private:
     void configureWaterfall();
     void registerAsGuiClient(const QString& clientId);
     void disconnectPendingClientsThen(std::function<void()> continuation);
+    // LAN-only: subscribe to radio+client topics early, wait 400 ms for
+    // the radio status burst, then check for a multiFLEX conflict before
+    // sending client gui. Calls continuation() if no conflict is found.
+    void peekForMultiFlexConflictThen(std::function<void()> continuation);
     void handleForcedClientDisconnect();
     void applyKnownGuiClients(const QStringList& handles,
                               const QStringList& programs,
@@ -679,6 +692,7 @@ private:
     int                m_rttyMarkDefault{2125};
     quint32            m_txClientHandle{0};  // handle of the client that owns TX
     QMap<quint32, ClientInfo> m_clientInfoMap; // handle → full client info
+    std::function<void()> m_multiFlexContinuation; // saved continuation during conflict pause
     QMap<quint32, QString> m_clientStations;   // handle → station name (legacy, kept in sync)
     QList<quint32> m_pendingClientDisconnects; // handles chosen before connecting
     QSet<quint32> m_announcedClientConnections; // client login notices shown this session


### PR DESCRIPTION
## Summary

When a FlexRadio has multiFLEX disabled (`mf_enable=0`) and another client (e.g. SmartSDR) is already connected, AetherSDR previously hung: the pre-connection slot-count check passed (`1 client < 8 max slices`), a second session was silently established, the radio spawned a duplicate slice on the SmartSDR side, and AetherSDR's connection state machine stalled with no recovery path.

This PR adds a **Connected Stations dialog** — mirroring SmartSDR's behaviour — across all four connection paths, with fixes for stale-handle duplicates and phantom slices.

---

## Problem

The pre-connection gate in `confirmClientSlotAvailability` only blocked when the number of connected clients **equalled or exceeded** the hardware slice limit. With multiFLEX disabled, even a single connected client blocks a second, but `1 < 8` passed silently. Additionally, `mf_enable` was not surfaced at connection time for:
- **LAN auto-discovery** — the radio does not always include `mf_enable` in its UDP broadcast
- **LAN direct IP** — the probe socket read only `V`+`H`, discarding all status info
- **SmartLink/WAN** — the `WanRadioInfo` overload had no multiFLEX check

Secondary bugs found during testing:
- The conflict dialog **showed duplicate station entries** due to stale handles pre-populated from `lastRadioInfo` (a prior-session snapshot) that were never removed when the live `sub client all` response arrived
- **Two slices appeared** after disconnecting only one of the duplicated handles, because the phantom handle's slices persisted through `registerAsGuiClient`

---

## Solution

### 1. `ConnectedStationsDialog` (new)

`src/gui/ConnectedStationsDialog` is a new modal dialog styled to match the AetherSDR dark theme. It shows:
- A **Radio** section with model, nickname, and callsign
- A **Connected Stations** section listing each conflicting client as a selectable row
- A red **Disconnect Station** button (enabled on selection) and a **Cancel** button

### 2. Discovery broadcast — parse `mf_enable`

`RadioInfo` gains a `multiFlexEnabled` field (default `true`). `RadioDiscovery::parseDiscoveryPacket` maps the `mf_enable` key from the UDP broadcast to that field. `confirmClientSlotAvailability(RadioInfo)` checks `!info.multiFlexEnabled && !clients.isEmpty()` before the existing slice-count path.

### 3. Direct IP probe — subscribe before disconnecting

`ConnectionPanel::probeRadio` previously disconnected the probe socket immediately after reading `H`. It now sends `C1|sub radio all\n` + `C2|sub client all\n`, waits 400 ms for the radio's status burst, parses `mf_enable`, `model`, `nickname`, `callsign`, and all `client 0x<handle> connected` entries into `RadioInfo`, then disconnects and emits `connectRequested`. This also fixes the `model="FLEX"` placeholder that direct-IP connections previously showed everywhere.

### 4. LAN post-connection peek — `peekForMultiFlexConflictThen`

For LAN connections where the discovery broadcast may omit `mf_enable`, `RadioModel::onConnected` inserts a new step between `disconnectPendingClientsThen` and `registerAsGuiClient`:

1. Purge all non-self entries from `m_clientInfoMap` and `m_clientStations` (eliminates stale pre-populated handles)
2. Send `sub radio all` + `sub client all` (both work before `client gui` on LAN)
3. Wait 400 ms for the radio's status burst
4. If `m_multiFlexEnabled == false` and other clients are present → emit `multiFlexConflictDetected()` and pause
5. `MainWindow` shows `ConnectedStationsDialog` using live `clientInfoMap()` data
6. On accept → `resolveMultiFlexConflict(handle)`: send `client disconnect 0x<handle>`, wait 250 ms, then **re-run the full peek** with the saved continuation rather than calling it directly — catches any remaining clients and re-shows the dialog if needed
7. On cancel → `cancelMultiFlexConflict()`: intentional disconnect

The re-peek in step 6 also fixes the two-slice bug: connection only reaches `registerAsGuiClient` once the peek confirms zero conflicting clients remain.

On WAN the peek is skipped; multiFLEX is enforced via `licensedClients` instead.

### 5. SmartLink/WAN — `licensedClients` check

`WanRadioInfo.licensedClients` (populated from the SmartLink server's `licensed_clients` field) encodes the multiFLEX license: `1` means single-client only. `confirmClientSlotAvailability(WanRadioInfo)` now checks `info.licensedClients <= 1 && !clients.isEmpty()` and shows `ConnectedStationsDialog`. On accept the handle goes into `setPendingClientDisconnects` → `disconnectPendingClientsThen` sends `client disconnect` as the first command after the WAN TCP session is established.

---

## Files changed

| File | Change |
|---|---|
| `src/core/RadioDiscovery.h` | Add `multiFlexEnabled` to `RadioInfo` |
| `src/core/RadioDiscovery.cpp` | Parse `mf_enable` from UDP discovery packet |
| `src/gui/ConnectedStationsDialog.h/.cpp` | New dialog |
| `src/gui/ConnectionPanel.cpp` | Extend probe to subscribe and collect radio/client status |
| `src/gui/MainWindow.cpp` | `confirmClientSlotAvailability` gates for LAN + WAN; wire `multiFlexConflictDetected` signal |
| `src/models/RadioModel.h` | New signal + public/private methods + `m_multiFlexContinuation` member |
| `src/models/RadioModel.cpp` | `peekForMultiFlexConflictThen`, `resolveMultiFlexConflict`, `cancelMultiFlexConflict` |
| `CMakeLists.txt` | Add `ConnectedStationsDialog.cpp` to `GUI_SOURCES` |

---

## Test scenarios covered

| Scenario | Before | After |
|---|---|---|
| LAN auto-discovery, `mf_enable` in broadcast | ❌ hung | ✅ dialog shown pre-connect |
| LAN auto-discovery, `mf_enable` absent from broadcast | ❌ hung | ✅ dialog shown post-connect via peek |
| LAN direct IP / VPN | ❌ hung | ✅ dialog shown pre-connect via probe subscribe |
| SmartLink / WAN | ❌ hung | ✅ dialog shown pre-connect via `licensedClients` |
| Reconnect: stale handles from `lastRadioInfo` | ❌ duplicate stations in dialog | ✅ map purged before peek |
| Two apparent stations, disconnect one | ❌ two slices in Aether | ✅ re-peek after disconnect confirms clean before proceeding |

🤖 Generated with [Claude Code](https://claude.com/claude-code)