### PR TITLE
fix(audio): do not restore per-slice audio mute state on reconnect

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -951,6 +951,16 @@ MainWindow::MainWindow(QWidget* parent)
         }
         if (s.value("FramelessWindow", "True").toString() == "True")
             setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
+
+        // One-shot migration: remove persisted per-slice audio mute state.
+        // The radio does not persist audio_mute, so restoring it from
+        // AppSettings caused Slice A to start muted on every reconnect.
+        if (!s.contains("SliceAudioMutedMigratedV0999")) {
+            for (const QChar letter : {'A', 'B', 'C', 'D'})
+                s.remove(QString("SliceAudioMuted_%1").arg(letter));
+            s.setValue("SliceAudioMutedMigratedV0999", "True");
+            s.save();
+        }
     }
 
     applyDarkTheme();
@@ -10398,24 +10408,6 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
         if (sliceId == m_activeSliceId)
             m_audio->setRxPan(v);
     });
-
-    // Per-slice AF mute persistence (#1560): save state to AppSettings on each
-    // toggle so it survives the session; restore it once the slice is ready
-    // (the radio does not persist audio_mute between client connections).
-    // Use the user-visible slice letter (A/B/C/D) as the key so the saved state
-    // survives sessions where the radio assigns different numeric IDs (#1560).
-    const QChar sliceLetter = QChar('A' + sliceId);
-    connect(w, &VfoWidget::audioMuteToggled, this, [this, sliceLetter](bool on) {
-        AppSettings::instance().setValue(
-            QString("SliceAudioMuted_%1").arg(sliceLetter), on ? "True" : "False");
-    });
-    {
-        bool savedMute = AppSettings::instance()
-            .value(QString("SliceAudioMuted_%1").arg(sliceLetter), "False")
-            .toString() == "True";
-        if (savedMute)
-            s->setAudioMute(true);  // send audio_mute=1 to radio for this slice
-    }
 
     // Wire slice data into widget
     w->setSlice(s);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -956,7 +956,10 @@ MainWindow::MainWindow(QWidget* parent)
         // The radio does not persist audio_mute, so restoring it from
         // AppSettings caused Slice A to start muted on every reconnect.
         if (!s.contains("SliceAudioMutedMigratedV0999")) {
-            for (const QChar letter : {'A', 'B', 'C', 'D'})
+            // Cover A-H for FLEX-6700/M owners — the now-removed setter
+            // computed QChar('A' + sliceId) for sliceId 0..7, so 8-slice
+            // radios could have left up to eight orphan keys behind.
+            for (const QChar letter : {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'})
                 s.remove(QString("SliceAudioMuted_%1").arg(letter));
             s.setValue("SliceAudioMutedMigratedV0999", "True");
             s.save();


### PR DESCRIPTION
## Problem

On startup, when connecting to the radio, Slice A's audio was muted — even though the user never explicitly muted it. This happened silently on every reconnect if the slice had been muted in a prior session.

## Root Cause

`wireVfoWidget()` (MainWindow.cpp) implemented per-slice audio mute persistence introduced in #1560:

1. **Save**: Every time the user clicked the AF mute button, `SliceAudioMuted_A` (or B/C/D) was written to `AppSettings`.
2. **Restore**: When a slice was wired after each new connection, the saved value was read back and `s->setAudioMute(true)` was called — sending `slice set 0 audio_mute=1` to the radio immediately after connect.

The timing issue: the radio sends `audio_mute=0` in the initial slice status message (fresh connections are always unmuted on the radio side), but AetherSDR was immediately overriding that with the persisted muted state. This violated the **radio-authoritative settings policy** in CLAUDE.md: the radio does not persist `audio_mute` across client connections, so neither should AetherSDR.

## Fix

- **Removed** the `audioMuteToggled` save connection — `SliceAudioMuted_*` keys are no longer written.
- **Removed** the restore block — no client-side mute is applied during `wireVfoWidget()`.
- **Added** a one-time migration (`SliceAudioMutedMigratedV0999`) that clears any `SliceAudioMuted_A/B/C/D` keys existing installs may have accumulated, so users are not stuck in a muted state after upgrading.

Slice audio mute is now fully radio-authoritative: the value from the radio's initial status message is used as-is. Since the radio starts slices unmuted on fresh connections, Slice A will always be audible when connecting.

## Impact

- Slice A no longer starts muted on connect/reconnect.
- Users who manually muted a slice will need to re-mute after reconnecting (consistent with SmartSDR behavior — the radio itself does not persist this state).
- All four slice letters (A/B/C/D) are affected the same way.

## Testing

1. Connect to radio — confirm Slice A audio is not muted.
2. Mute Slice A, disconnect, reconnect — confirm Slice A is unmuted on reconnect.
3. Confirm the AF mute button still works (mutes the radio's audio stream) for the current session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)