### PR TITLE
fix(ui): switch container pop-out glyph to ⧉ at larger size for discoverability

### DIFF
--- a/src/gui/containers/ContainerTitleBar.cpp
+++ b/src/gui/containers/ContainerTitleBar.cpp
@@ -34,6 +34,16 @@ constexpr const char* kPinBtnStyle =
     "QPushButton:hover { color: #ffffff; } "
     "QPushButton:checked { color: #ffd166; }";
 
+// Float-toggle button gets a larger font-size than its siblings so
+// the ⧉ glyph reads clearly at small sizes — at 11px the two-square
+// detail blurs together. The button box is bumped to 18×18 to fit the
+// taller glyph without clipping.
+constexpr const char* kFloatBtnStyle =
+    "QPushButton { background: transparent; border: none; "
+    "color: #c8d8e8; font-size: 15px; font-weight: bold; "
+    "padding: 0px 4px; } "
+    "QPushButton:hover { color: #ffffff; }";
+
 constexpr int kDragThresholdPx = 6;
 
 } // namespace
@@ -76,9 +86,9 @@ ContainerTitleBar::ContainerTitleBar(const QString& title, QWidget* parent)
             });
     layout->addWidget(m_pinBtn);
 
-    m_floatBtn = new QPushButton(QString::fromUtf8("\xe2\x9a\x8a"));  // ⚊ single line
-    m_floatBtn->setStyleSheet(kBtnStyle);
-    m_floatBtn->setFixedSize(16, 16);
+    m_floatBtn = new QPushButton(QString::fromUtf8("\xe2\xa7\x89"));  // ⧉ two joined squares (#2430 follow-up)
+    m_floatBtn->setStyleSheet(kFloatBtnStyle);
+    m_floatBtn->setFixedSize(18, 18);
     m_floatBtn->setToolTip("Pop out into a floating window");
     m_floatBtn->setCursor(Qt::ArrowCursor);
     connect(m_floatBtn, &QPushButton::clicked,
@@ -108,10 +118,13 @@ QString ContainerTitleBar::title() const
 void ContainerTitleBar::setFloatingState(bool isFloating)
 {
     m_isFloating = isFloating;
-    // "↙" when floating (to dock) / "⚊" when docked (to float).
+    // "↙" when floating (to dock) / "⧉" when docked (to float).
+    // Single-line "⚊" was unclear; the double-square "⧉" is the
+    // canonical "open in new window" affordance and reads as pop-out
+    // at a glance.
     m_floatBtn->setText(isFloating
         ? QString::fromUtf8("\xe2\x86\x99")
-        : QString::fromUtf8("\xe2\x9a\x8a"));
+        : QString::fromUtf8("\xe2\xa7\x89"));
     m_floatBtn->setToolTip(isFloating
         ? "Return to panel"
         : "Pop out into a floating window");


### PR DESCRIPTION
The "pop out into floating window" button on every container title bar
was rendered with ⚊ (U+268A, single horizontal line) at 11px font.
Multiple users reported it as unclear — the glyph reads more like a
collapse / minimize affordance than a pop-out, hurting feature
discoverability.

Switch to ⧉ (U+29C9 TWO JOINED SQUARES), the canonical "open in new
window" symbol used widely across desktop and web UIs (browser tabs,
file managers, IDEs).  At the existing 11px font the two-square detail
blurs together, so this also bumps the float button to its own
kFloatBtnStyle at 15px font in an 18×18 box — siblings (pin, minimize,
close) keep their 11px / 16×16 sizing.

The "return to panel" state retains ↙ since that's a distinct action
(undock) and the arrow-into-corner direction still reads cleanly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
