### PR TITLE
fix(cwx): release TX when CWX queue drains — fixes stuck-in-TX after macro

### DIFF
--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -143,6 +143,11 @@ void CwxModel::applyStatus(const QMap<QString, QString>& kvs)
                 int stop  = parts[1].toInt(&ok2);
                 if (ok1 && ok2) emit erased(start, stop);
             }
+        } else if (key == "queue") {
+            // Empty queue= means the radio's CWX buffer has drained.
+            // Signal RadioModel to release MOX (required when sync_cwx=1).
+            if (val.isEmpty() || val == "0")
+                emit queueEmpty();
         } else if (key.startsWith("macro") && key.length() > 5) {
             bool ok;
             int idx = key.mid(5).toInt(&ok);

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -49,6 +49,7 @@ signals:
     // self-contained even if speed changes mid-transmission.
     void transmissionRequested(const QString& text, int wpm);
     void transmissionCancelled();        // erase / clearBuffer / interrupt
+    void queueEmpty();                   // radio CWX buffer drained — TX teardown required
 
 private:
     int     m_speed{20};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -337,6 +337,15 @@ RadioModel::RadioModel(QObject* parent)
             m_cwxActive = false;
         sendCmd(cmd);
     });
+    // When the radio signals its CWX buffer is drained, release TX. (#2450)
+    // The radio's break-in timer fires but sync_cwx=1 still requires an
+    // explicit xmit 0 from the client — without it the radio holds TX for
+    // its full hardware interlock timeout (~60 s).
+    connect(&m_cwxModel, &CwxModel::queueEmpty, this, [this]() {
+        if (!m_cwxActive) return;
+        m_cwxActive = false;
+        m_transmitModel.setMox(false);
+    });
     connect(&m_dvkModel, &DvkModel::commandReady, this, [this](const QString& cmd){
         sendCmd(cmd);
     });


### PR DESCRIPTION
## Summary

- `CwxModel::applyStatus()` never handled the `queue=` status key the radio sends when its CWX buffer empties
- With `sync_cwx=1` the radio expects an explicit `xmit 0` from the client after macro completion; without it the radio held TX until its ~60 s hardware interlock watchdog fired
- Added `queueEmpty()` signal to `CwxModel`, fired when `queue=` arrives empty
- `RadioModel` connects to it: clears `m_cwxActive` and calls `setMox(false)` → sends `xmit 0`, returning the radio to RX immediately

## Root cause chain

1. User fires CWX macro → `m_cwxActive = true`
2. Radio transmits CW, sends `S<handle>|cwx queue=` when buffer drains
3. `applyStatus()` had no `queue` handler — `m_cwxActive` stayed `true`
4. Interlock handler guards on `!m_cwxActive` → never forced TX off
5. Radio held TX waiting for `xmit 0` → self-recovered via ~60 s hardware watchdog

## Tested

- Verified on FLEX-8600 fw 4.2.18.41174: relay clicks back to RX immediately after last tone, TX light clears, interlock state returns to READY
- QSK + Break-In enabled, macro sent via CWX window Send button and Fx key — both paths clean

## Fixes / closes

- Fixes #2450 — CWX macro TX stuck >60 s before returning to RX
- Fixes #2306 — RX audio lost after CWX macro/send (stuck `m_cwxActive` also prevented `m_txAudioGate` from clearing, silencing RX audio post-TX)

## Test plan

- [ ] Connect to any FLEX radio with CW slice, QSK + Break-In enabled
- [ ] Send a CWX macro via Send button
- [ ] Send a CWX macro via Fx key
- [ ] Confirm radio returns to RX immediately after last character — no 60 s delay
- [ ] Confirm RX audio resumes normally (regression check for #2306)
- [ ] Confirm ESC / clearBuffer mid-macro still works (clears `m_cwxActive` via `cwx clear` path, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)