### PR TITLE
fix(dsp): disable NR4 button when libspecbleach unavailable (Windows)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -2878,7 +2878,7 @@ void AudioEngine::setNr4NoiseEstimationMethod(int m) { if (m_nr4) m_nr4->setNois
 void AudioEngine::setNr4MaskingDepth(float v) { if (m_nr4) m_nr4->setMaskingDepth(v); }
 void AudioEngine::setNr4SuppressionStrength(float v) { if (m_nr4) m_nr4->setSuppressionStrength(v); }
 #else // !HAVE_SPECBLEACH — stubs
-void AudioEngine::setNr4Enabled(bool) {}
+void AudioEngine::setNr4Enabled(bool on) { if (on) emit nr4EnabledChanged(false); }
 void AudioEngine::setNr4ReductionAmount(float) {}
 void AudioEngine::setNr4SmoothingFactor(float) {}
 void AudioEngine::setNr4WhiteningFactor(float) {}

--- a/src/gui/AetherDspWidget.cpp
+++ b/src/gui/AetherDspWidget.cpp
@@ -178,6 +178,15 @@ AetherDspWidget::AetherDspWidget(AudioEngine* audio, QWidget* parent)
             b->setToolTip("MNR is only available on macOS.");
         }
 #endif
+        // NR4 (libspecbleach spectral NR) requires clang-cl on Windows to
+        // compile its C99 VLAs — disabled when LLVM is not installed.
+#ifndef HAVE_SPECBLEACH
+        if (i == NR4) {
+            b->setEnabled(false);
+            b->setToolTip("NR4 requires LLVM (clang-cl) on Windows.\n"
+                          "Install LLVM from llvm.org and rebuild to enable NR4.");
+        }
+#endif
         // BNR (NVIDIA GPU neural denoising) is gated at compile time
         // by HAVE_BNR — VfoWidget hides its button entirely; here we
         // keep the slot visible so the 6-button row stays balanced and


### PR DESCRIPTION
Fixes #2484.

## Root cause

On Windows, `libspecbleach` uses C99 VLAs that MSVC cannot compile.
CMakeLists.txt gates `HAVE_SPECBLEACH` on finding `clang-cl` from LLVM —
when LLVM is not installed, `HAVE_SPECBLEACH` is never defined and the
`#else` stub runs:

```cpp
void AudioEngine::setNr4Enabled(bool) {}   // ← before fix
```

The stub silently discarded the enable call without updating `m_nr4Enabled`
and without emitting `nr4EnabledChanged`.  So when the user pressed NR4:

1. Qt auto-checked the button (it is `setCheckable(true)`)
2. `setNr4Enabled(true)` was queued on the audio thread and ran the stub
3. `m_nr4Enabled` stayed `false`; no signal fired
4. `isAdspBypassed()` still returned `true` → ADSP tile stayed grey

This did not affect Linux (specbleach always built) or macOS.

## Fix

**`AetherDspWidget.cpp`** — disable the NR4 selector button behind
`#ifndef HAVE_SPECBLEACH` with a tooltip directing Windows users to
install LLVM for clang-cl support.  Mirrors the existing patterns for
BNR (`#ifndef HAVE_BNR`) and MNR (`#ifndef Q_OS_MAC`).

**`AudioEngine.cpp`** — change the stub to emit `nr4EnabledChanged(false)`
when called with `true`, so the button reverts to unchecked if the gate
is ever bypassed (e.g. via the ADSP bypass-restore path).

## Test plan

- [ ] Windows build **without** LLVM: NR4 button is dimmed and shows tooltip; ADSP tile unaffected
- [ ] Windows build **with** LLVM (`clang-cl` found): NR4 button is enabled and works as before
- [ ] Linux/macOS: NR4 button unchanged, ADSP tile updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)