### PR TITLE
feat(memory): frameless chrome on Memory Channels dialog

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -57,6 +57,11 @@ constexpr qint64 kScopeEmitMinIntervalMs = 25;  // ~40 fps, per RX/TX source
 // to draw on every frame.  ~120 Hz max — emissions over the strip
 // widget's repaint rate are simply ignored by the panel.
 constexpr qint64 kTxPostChainEmitMinIntervalMs = 8;
+// RX strip-panel mirror — same 8 ms throttle so the strip's "Aetherial
+// Waveform — RX" panel sees one emission per audio callback (no dropped
+// blocks).  The shared scopeSamplesReady throttle stays at 25 ms for
+// the floating WaveApplet which doesn't need this fidelity.
+constexpr qint64 kRxPostChainEmitMinIntervalMs = 8;
 
 bool devicePresent(const QList<QAudioDevice>& devices, const QAudioDevice& target)
 {
@@ -183,6 +188,47 @@ void AudioEngine::emitTxPostChainScopeFromInt16Stereo(const QByteArray& pcm,
     else
         m_lastTxPostChainScopeEmit.start();
     emit txPostChainScopeReady(m_scopeTxPostChainScratch,
+                               sampleRate > 0 ? sampleRate : DEFAULT_SAMPLE_RATE);
+}
+
+void AudioEngine::emitRxPostChainScopeFromFloat32Stereo(const QByteArray& pcm,
+                                                         int sampleRate)
+{
+    // RX-side mirror of emitTxPostChainScopeFromInt16Stereo.  Same
+    // float32-stereo → mono-float collapse as emitScopeFromFloat32Stereo,
+    // but uses a dedicated 8 ms throttle and emits on rxPostChainScopeReady
+    // so the channel strip's RX scope tracks wall clock at short windows.
+    const int floatSamples = pcm.size() / static_cast<int>(sizeof(float));
+    if (floatSamples <= 0)
+        return;
+
+    if (m_lastRxPostChainScopeEmit.isValid()
+        && m_lastRxPostChainScopeEmit.elapsed() < kRxPostChainEmitMinIntervalMs)
+        return;
+
+    const bool stereo = (floatSamples % 2) == 0;
+    const int monoSamples = stereo ? floatSamples / 2 : floatSamples;
+    m_scopeRxPostChainScratch.resize(monoSamples * static_cast<int>(sizeof(float)));
+
+    const auto* src = reinterpret_cast<const float*>(pcm.constData());
+    auto* dst = reinterpret_cast<float*>(m_scopeRxPostChainScratch.data());
+    if (stereo) {
+        for (int i = 0; i < monoSamples; ++i) {
+            const float avg = (src[i * 2] + src[i * 2 + 1]) * 0.5f;
+            dst[i] = std::clamp(std::isfinite(avg) ? avg : 0.0f, -1.0f, 1.0f);
+        }
+    } else {
+        for (int i = 0; i < monoSamples; ++i) {
+            const float s = src[i];
+            dst[i] = std::clamp(std::isfinite(s) ? s : 0.0f, -1.0f, 1.0f);
+        }
+    }
+
+    if (m_lastRxPostChainScopeEmit.isValid())
+        m_lastRxPostChainScopeEmit.restart();
+    else
+        m_lastRxPostChainScopeEmit.start();
+    emit rxPostChainScopeReady(m_scopeRxPostChainScratch,
                                sampleRate > 0 ? sampleRate : DEFAULT_SAMPLE_RATE);
 }
 
@@ -995,6 +1041,7 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
         }
         m_rxBuffer.append(*output);
         emitScopeFromFloat32Stereo(*output, scopeSampleRate, false);
+        emitRxPostChainScopeFromFloat32Stereo(*output, scopeSampleRate);
         updateRxBufferStats();
     };
 
@@ -3123,6 +3170,7 @@ void AudioEngine::processBnr(const QByteArray& stereoPcm)
             const QByteArray& output = m_resampleTo48k ? resampleStereo(chunk) : chunk;
             m_rxBuffer.append(output);
             emitScopeFromFloat32Stereo(output, scopeSampleRate, false);
+            emitRxPostChainScopeFromFloat32Stereo(output, scopeSampleRate);
             updateRxBufferStats();
         }
         emit levelChanged(computeRMS(chunk));

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -449,6 +449,12 @@ signals:
     // "Waveform CE-SSB" panel listens to so the operator sees the
     // actual transmitted envelope.
     void txPostChainScopeReady(const QByteArray& monoFloat32Pcm, int sampleRate);
+    // Mirror of txPostChainScopeReady for the RX side: high-rate emit
+    // (~125 Hz, no sample loss across audio callbacks) so the channel
+    // strip's "Aetherial Waveform — RX" panel sees a wall-clock-accurate
+    // scope.  The shared scopeSamplesReady throttles at 25 ms which made
+    // the strip's RX scroll lag wall clock at short time-window settings.
+    void rxPostChainScopeReady(const QByteArray& monoFloat32Pcm, int sampleRate);
     void radioTransmittingChanged(bool tx);
     void mutedChanged(bool muted);                          // local audio output mute state
     void txBypassChanged(bool on);                          // master TX BYPASS state
@@ -470,6 +476,7 @@ private:
     void emitScopeFromFloat32Stereo(const QByteArray& pcm, int sampleRate, bool tx);
     void emitScopeFromInt16Stereo(const QByteArray& pcm, int sampleRate, bool tx);
     void emitTxPostChainScopeFromInt16Stereo(const QByteArray& pcm, int sampleRate);
+    void emitRxPostChainScopeFromFloat32Stereo(const QByteArray& pcm, int sampleRate);
     QByteArray resampleStereo(const QByteArray& pcm);
     void processNr2(const QByteArray& stereoPcm);
     void updateRxBufferStats();
@@ -571,9 +578,11 @@ private:
     QElapsedTimer m_lastRxScopeEmit;
     QElapsedTimer m_lastTxScopeEmit;
     QElapsedTimer m_lastTxPostChainScopeEmit;
+    QElapsedTimer m_lastRxPostChainScopeEmit;
     QByteArray    m_scopeRxScratch;
     QByteArray    m_scopeTxScratch;
     QByteArray    m_scopeTxPostChainScratch;
+    QByteArray    m_scopeRxPostChainScratch;
 
     QAudioDevice m_outputDevice;
     QAudioDevice m_inputDevice;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1151,9 +1151,19 @@ MainWindow::MainWindow(QWidget* parent)
             this, &MainWindow::advanceSwrSweep);
 
     if (auto* wave = m_appletPanel ? m_appletPanel->waveApplet() : nullptr) {
-        connect(m_audio, &AudioEngine::scopeSamplesReady,
-                wave, &WaveApplet::appendScopeSamples,
-                Qt::QueuedConnection);
+        // Use the dedicated high-rate post-chain feeds (8 ms throttle,
+        // one emit per audio callback) instead of the shared 25 ms
+        // scopeSamplesReady so the applet's scroll tracks wall clock at
+        // short time-window settings.  Each side-specific signal lacks
+        // the tx flag, so the lambdas reintroduce it.
+        connect(m_audio, &AudioEngine::txPostChainScopeReady,
+                wave, [wave](const QByteArray& mono, int sr) {
+            wave->appendScopeSamples(mono, sr, /*tx=*/true);
+        }, Qt::QueuedConnection);
+        connect(m_audio, &AudioEngine::rxPostChainScopeReady,
+                wave, [wave](const QByteArray& mono, int sr) {
+            wave->appendScopeSamples(mono, sr, /*tx=*/false);
+        }, Qt::QueuedConnection);
         connect(m_audio, &AudioEngine::radioTransmittingChanged,
                 wave, &WaveApplet::setTransmitting,
                 Qt::QueuedConnection);
@@ -10782,6 +10792,8 @@ void MainWindow::setFramelessWindow(bool on)
     if (auto* dlg = qobject_cast<AetherDspDialog*>(m_dspDialog))
         dlg->setFramelessMode(on);
     if (auto* dlg = qobject_cast<DxClusterDialog*>(m_spotHubDialog))
+        dlg->setFramelessMode(on);
+    if (auto* dlg = qobject_cast<MemoryDialog*>(m_memoryDialog))
         dlg->setFramelessMode(on);
     if (m_aetherialStrip)
         m_aetherialStrip->setFramelessMode(on);

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -1,4 +1,6 @@
 #include "MemoryDialog.h"
+#include "FramelessResizer.h"
+#include "FramelessWindowTitleBar.h"
 #include "MemoryCommands.h"
 #include "core/AppSettings.h"
 #include "core/MemoryCsvCompat.h"
@@ -227,7 +229,21 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     setWindowTitle("Memory Channels");
     resize(1000, 500);
 
-    auto* root = new QVBoxLayout(this);
+    // Outer layout hosts the frameless title bar + content area.  The
+    // existing dialog body layout (search row, table, buttons) lives
+    // inside `content` so flipping frameless on/off only adjusts the
+    // title bar's visibility and outer margin.
+    m_outerLayout = new QVBoxLayout(this);
+    m_outerLayout->setSpacing(0);
+    m_outerLayout->setContentsMargins(0, 0, 0, 0);
+
+    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("Memory Channels"), this);
+    m_outerLayout->addWidget(m_titleBar);
+
+    auto* content = new QWidget(this);
+    m_outerLayout->addWidget(content, 1);
+
+    auto* root = new QVBoxLayout(content);
 
     // ── Search + profile filter ──────────────────────────────────────────
     auto* filterRow = new QHBoxLayout;
@@ -372,6 +388,29 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     // new memories created via Add will populate the table immediately.
     populateTable();
 
+    // 8-axis edge resize for the frameless mode.
+    FramelessResizer::install(this);
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+}
+
+void MemoryDialog::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
+    flags.setFlag(Qt::FramelessWindowHint, on);
+    setWindowFlags(flags);
+    setGeometry(geom);
+
+    if (m_titleBar)
+        m_titleBar->setVisible(on);
+    if (m_outerLayout)
+        m_outerLayout->setContentsMargins(0, 0, 0, 0);
+
+    if (wasVisible)
+        show();
 }
 
 void MemoryDialog::closeEvent(QCloseEvent* event)

--- a/src/gui/MemoryDialog.h
+++ b/src/gui/MemoryDialog.h
@@ -13,6 +13,7 @@ class QComboBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
+class QVBoxLayout;
 
 namespace AetherSDR {
 
@@ -23,6 +24,12 @@ class MemoryDialog : public QDialog {
 
 public:
     explicit MemoryDialog(RadioModel* model, QWidget* parent = nullptr);
+
+    // Toggle frameless chrome at runtime — mirrors the SpotHub /
+    // RadioSetup pattern.  Snapshots geometry + visibility, flips
+    // Qt::FramelessWindowHint, restores.  Called by MainWindow when
+    // the global View → Frameless Window setting changes.
+    void setFramelessMode(bool on);
 
 Q_SIGNALS:
     void memoryActivated(int memoryIndex);
@@ -66,6 +73,12 @@ private:
     bool m_inlineEditMode{false};
     int m_sortColumn{2};
     Qt::SortOrder m_sortOrder{Qt::AscendingOrder};
+
+    // Frameless chrome (mirrors SpotHub / RadioSetup): custom title
+    // bar at the top, FramelessResizer on the body for 8-axis edge
+    // resize.
+    QWidget*     m_titleBar{nullptr};
+    QVBoxLayout* m_outerLayout{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/StripWaveformPanel.cpp
+++ b/src/gui/StripWaveformPanel.cpp
@@ -132,12 +132,14 @@ StripWaveformPanel::StripWaveformPanel(AudioEngine* engine, QWidget* parent)
             if (m_side != Side::Tx || !m_waveform) return;
             m_waveform->appendScopeSamples(mono, sr, /*tx=*/true);
         });
-        // RX-side tap: post-Pudu output (#2425) — the exact bytes
-        // about to hit the local audio sink.  scopeSamplesReady fires
-        // for both sides; filter on tx=false to take only RX.
-        connect(m_audio, &AudioEngine::scopeSamplesReady,
-                m_waveform, [this](const QByteArray& mono, int sr, bool tx) {
-            if (m_side != Side::Rx || tx || !m_waveform) return;
+        // RX-side tap: dedicated rxPostChainScopeReady — same 8 ms
+        // throttle as the TX-side feed so the strip's RX scroll tracks
+        // wall clock at short windows.  The shared scopeSamplesReady
+        // signal that the floating WaveApplet uses keeps its 25 ms
+        // throttle, so both consumers get what they need.
+        connect(m_audio, &AudioEngine::rxPostChainScopeReady,
+                m_waveform, [this](const QByteArray& mono, int sr) {
+            if (m_side != Side::Rx || !m_waveform) return;
             m_waveform->appendScopeSamples(mono, sr, /*tx=*/false);
         });
     }

--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -147,10 +147,14 @@ WaveApplet::WaveApplet(QWidget* parent)
     // One-time migration from the previous "TimeWindowSec" key (1–20 s
     // linear) to the new "TimeWindowMs" discrete-step storage.  Existing
     // users keep their value, snapped to the nearest available step.
+    // Remove the old key + save so the legacy entry doesn't linger in
+    // AetherSDR.settings forever (CLAUDE.md migration pattern).
     if (settings.contains("WaveApplet_TimeWindowSec")
         && !settings.contains("WaveApplet_TimeWindowMs")) {
         const int legacySec = settings.value("WaveApplet_TimeWindowSec", 1).toInt();
         settings.setValue("WaveApplet_TimeWindowMs", QString::number(legacySec * 1000));
+        settings.remove("WaveApplet_TimeWindowSec");
+        settings.save();
     }
     const int windowMs = settings.value(
         "WaveApplet_TimeWindowMs",

--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -26,6 +26,34 @@ constexpr int kDefaultZoomPercent = 170;
 constexpr int kMinFps = 5;
 constexpr int kMaxFps = 30;
 constexpr int kDefaultFps = 24;
+// Discrete window steps for the WaveApplet drawer's "Window" slider.
+// First three notches give sub-second detail (240 ms, 480 ms, 1 s); the
+// rest are 1-second increments out to 10 s.  Index-based so each notch
+// is a deliberate stop, not a free-scrub through ms-resolution values.
+const QVector<int>& windowStepsMs()
+{
+    static const QVector<int> kSteps = {
+        240, 480, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000
+    };
+    return kSteps;
+}
+constexpr int kDefaultWindowStepIdx = 2;  // 1 s
+QString formatWindow(int ms)
+{
+    return ms < 1000 ? QStringLiteral("%1 ms").arg(ms)
+                     : QStringLiteral("%1 s").arg(ms / 1000);
+}
+int closestStepIdx(int targetMs)
+{
+    const auto& steps = windowStepsMs();
+    int bestIdx = 0;
+    int bestDelta = std::abs(steps[0] - targetMs);
+    for (int i = 1; i < steps.size(); ++i) {
+        const int d = std::abs(steps[i] - targetMs);
+        if (d < bestDelta) { bestDelta = d; bestIdx = i; }
+    }
+    return bestIdx;
+}
 
 const QString kSliderStyle =
     "QSlider::groove:horizontal { height: 4px; background: #203040; border-radius: 2px; }"
@@ -116,6 +144,26 @@ WaveApplet::WaveApplet(QWidget* parent)
     m_waveform->setRefreshRateHz(refreshRate);
     updateRefreshLabel();
 
+    // One-time migration from the previous "TimeWindowSec" key (1–20 s
+    // linear) to the new "TimeWindowMs" discrete-step storage.  Existing
+    // users keep their value, snapped to the nearest available step.
+    if (settings.contains("WaveApplet_TimeWindowSec")
+        && !settings.contains("WaveApplet_TimeWindowMs")) {
+        const int legacySec = settings.value("WaveApplet_TimeWindowSec", 1).toInt();
+        settings.setValue("WaveApplet_TimeWindowMs", QString::number(legacySec * 1000));
+    }
+    const int windowMs = settings.value(
+        "WaveApplet_TimeWindowMs",
+        windowStepsMs()[kDefaultWindowStepIdx]).toInt();
+    const int windowIdx = closestStepIdx(windowMs);
+    const int snappedMs = windowStepsMs()[windowIdx];
+    {
+        QSignalBlocker block(m_windowSlider);
+        m_windowSlider->setValue(windowIdx);
+    }
+    m_waveform->setZoomWindowMs(snappedMs);
+    updateWindowLabel();
+
     setSettingsExpanded(true);
     setMinimumHeight(minimumSizeHint().height());
 
@@ -146,10 +194,6 @@ QSize WaveApplet::minimumSizeHint() const
 void WaveApplet::buildSettingsDrawer()
 {
     m_settingsDrawer = new QFrame(this);
-    m_settingsDrawer->setObjectName("WaveSettingsDrawer");
-    m_settingsDrawer->setStyleSheet(
-        "QFrame#WaveSettingsDrawer { background-color: #0f1a24; "
-        "border: 1px solid #20384d; border-radius: 3px; }");
 
     auto* drawer = new QVBoxLayout(m_settingsDrawer);
     drawer->setContentsMargins(5, 4, 5, 5);
@@ -246,6 +290,40 @@ void WaveApplet::buildSettingsDrawer()
 
         drawer->addLayout(row);
     }
+
+    {
+        auto* row = new QHBoxLayout;
+        row->setSpacing(5);
+        row->addWidget(makeSettingLabel("Window:", m_settingsDrawer));
+
+        m_windowSlider = new GuardedSlider(Qt::Horizontal, m_settingsDrawer);
+        m_windowSlider->setRange(0, windowStepsMs().size() - 1);
+        m_windowSlider->setSingleStep(1);
+        m_windowSlider->setPageStep(1);
+        m_windowSlider->setTickPosition(QSlider::NoTicks);
+        m_windowSlider->setStyleSheet(kSliderStyle);
+        m_windowSlider->setToolTip(
+            "Time window. Steps: 240 ms, 480 ms, 1 s, then 1-second "
+            "increments to 10 s.");
+        row->addWidget(m_windowSlider, 1);
+
+        m_windowValue = new QLabel(m_settingsDrawer);
+        m_windowValue->setFixedWidth(48);
+        m_windowValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        m_windowValue->setStyleSheet("QLabel { color: #c8d8e8; font-size: 10px; }");
+        row->addWidget(m_windowValue);
+
+        connect(m_windowSlider, &QSlider::valueChanged, this, [this](int idx) {
+            const int ms = windowStepsMs().value(idx, 1000);
+            m_waveform->setZoomWindowMs(ms);
+            updateWindowLabel();
+            auto& settings = AppSettings::instance();
+            settings.setValue("WaveApplet_TimeWindowMs", QString::number(ms));
+            settings.save();
+        });
+
+        drawer->addLayout(row);
+    }
 }
 
 void WaveApplet::setSettingsExpanded(bool expanded)
@@ -277,6 +355,14 @@ void WaveApplet::updateRefreshLabel()
     if (!m_refreshSlider || !m_refreshValue)
         return;
     m_refreshValue->setText(QStringLiteral("%1 fps").arg(m_refreshSlider->value()));
+}
+
+void WaveApplet::updateWindowLabel()
+{
+    if (!m_windowSlider || !m_windowValue)
+        return;
+    const int ms = windowStepsMs().value(m_windowSlider->value(), 1000);
+    m_windowValue->setText(formatWindow(ms));
 }
 
 void WaveApplet::appendScopeSamples(const QByteArray& monoFloat32Pcm,

--- a/src/gui/WaveApplet.h
+++ b/src/gui/WaveApplet.h
@@ -30,14 +30,17 @@ private:
     void setSettingsExpanded(bool expanded);
     void updateZoomLabel();
     void updateRefreshLabel();
+    void updateWindowLabel();
 
     WaveformWidget* m_waveform{nullptr};
     QFrame* m_settingsDrawer{nullptr};
     GuardedComboBox* m_viewCombo{nullptr};
     GuardedSlider* m_zoomSlider{nullptr};
     GuardedSlider* m_refreshSlider{nullptr};
+    GuardedSlider* m_windowSlider{nullptr};
     QLabel* m_zoomValue{nullptr};
     QLabel* m_refreshValue{nullptr};
+    QLabel* m_windowValue{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/WaveformWidget.cpp
+++ b/src/gui/WaveformWidget.cpp
@@ -26,7 +26,11 @@ constexpr int kMinSampleRate = 8000;
 constexpr int kMaxSampleRate = 192000;
 constexpr int kNoAudioTimeoutMs = 1000;
 constexpr int kMinWindowMs = 40;
-constexpr int kMaxWindowMs = 240;
+// Lifted from 240 ms to 20 s so the WaveApplet drawer's "Window" slider
+// (1–20 s, matches StripWaveformPanel) can take effect.  ensureCapacity
+// scales the ring buffer to fit the current window, so larger values
+// only allocate when the user picks them.
+constexpr int kMaxWindowMs = 20000;
 constexpr int kMinRefreshRateHz = 5;
 constexpr int kMaxRefreshRateHz = 30;
 constexpr double kPi = 3.14159265358979323846;
@@ -306,8 +310,15 @@ const WaveformWidget::RingBuffer& WaveformWidget::activeBuffer() const
 void WaveformWidget::ensureCapacity(RingBuffer& buffer, int sampleRate)
 {
     const int rate = sanitizeSampleRate(sampleRate);
-    const int capacity = std::max(kDefaultSampleRate, rate);
-    if (buffer.samples.size() == capacity) {
+    // Size the ring to hold the current window plus 1 s headroom.  Floor
+    // at 1 s so a freshly-applied small window doesn't truncate samples
+    // that arrived just before the change.  Round up to 4096-sample
+    // chunks so a slider drag doesn't realloc on every notch.
+    const int windowSamples = static_cast<int>(
+        static_cast<int64_t>(rate) * std::max(1000, m_windowMs) / 1000);
+    const int needed   = std::max(rate, windowSamples) + rate;
+    const int capacity = ((needed + 4095) / 4096) * 4096;
+    if (buffer.samples.size() >= capacity) {
         buffer.sampleRate = rate;
         return;
     }


### PR DESCRIPTION
## Summary

Two unrelated UI improvements bundled into one ship.

### Waveform — wall-clock-accurate scope feeds + applet polish

- New `AudioEngine::rxPostChainScopeReady` signal mirroring the existing
  `txPostChainScopeReady`: 8 ms throttle, dedicated scratch + emit. The
  channel-strip RX panel and the floating WaveApplet both subscribe to
  the new dedicated TX/RX feeds instead of the shared 25 ms
  `scopeSamplesReady`. Fixes the visible RX-vs-TX scroll-rate mismatch
  at short window settings (RX was dropping ~60% of audio callbacks).
- WaveApplet drawer Window slider — 12 discrete steps:
  240 ms, 480 ms, 1 s, then 1-second increments to 10 s. Default 1 s.
  One-time migration `WaveApplet_TimeWindowSec` → `_TimeWindowMs`.
- WaveformWidget `kMaxWindowMs` lifted from 240 ms → 20 s; ring buffer
  `ensureCapacity` sizes by current window + 1 s headroom in 4096-sample
  chunks (was a fixed 1 s).
- Drop the WaveApplet drawer's #0f1a24 panel chrome — it was the only
  applet with its own background frame.

### Memory Channels — frameless chrome

- Wrap the dialog body in the standard `FramelessWindowTitleBar` +
  content layout used by SpotHub, RadioSetup, NetworkDiagnostics, etc.
- `FramelessResizer::install()` provides 8-axis edge resize.
- Hooks into `MainWindow::setFramelessWindow()` so View → Frameless
  Window flips this dialog with the rest.

## Test plan

- [ ] Channel strip Aetherial Waveform — TX and RX scroll at the same rate at 1 s
- [ ] WaveApplet Window slider notches: 240/480/1000/2000…10000 ms
- [ ] Old `WaveApplet_TimeWindowSec` setting migrates to ms on first launch
- [ ] WaveApplet drawer matches the visual style of DSP/MIC applets (no panel frame)
- [ ] Memory Channels: title bar present when frameless, hidden when not
- [ ] Memory Channels: 8-axis edge resize works; geometry preserved across toggle
- [ ] View → Frameless Window flips the Memory dialog along with the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)