### PR TITLE
fix(xvtr): use status index not order for Flex band-stack key (#2342)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10133,9 +10133,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         //   - Native bands are displayed as "20m", "630m", etc., but Flex
         //     expects bare keys such as "20" and "630".
         //   - XVTR names are user labels such as "2m" or "70cm"; do not strip
-        //     those into native-band keys. Flex expects `X<order>`, where
-        //     `order` is the radio's XVTR setup order, not the xvtr status
-        //     object index, RF frequency, or display name.
+        //     those into native-band keys. Flex expects `X<index>`, where
+        //     `index` is the xvtr status-object number from `xvtr <n>` messages
+        //     (0-based), not the radio's 1-based setup-order field (#2342).
         //   - WWV / GEN use numeric band-stack slots 33 / 34 from SmartSDR
         //     capture history (#1540/#1211).
         //

--- a/src/models/XvtrPolicy.cpp
+++ b/src/models/XvtrPolicy.cpp
@@ -63,15 +63,7 @@ BandStackKeyResult resolveBandStackKey(const QString& bandName,
         if (!xvtr.isValid || xvtr.name != bandName)
             continue;
 
-        if (xvtr.order < 0) {
-            return {
-                {},
-                QString("XVTR %1 has no setup order; cannot form Flex band= key")
-                    .arg(bandName)
-            };
-        }
-
-        return {QString("X%1").arg(xvtr.order), {}};
+        return {QString("X%1").arg(xvtr.index), {}};
     }
 
     return {

--- a/tests/xvtr_policy_test.cpp
+++ b/tests/xvtr_policy_test.cpp
@@ -75,7 +75,7 @@ void expectRange(const char* label, const XvtrPolicy::WaterfallTileRange& range,
            detailFor(range));
 }
 
-void testBandStackKeysUseFlexOrder()
+void testBandStackKeysUseFlexIndex()
 {
     const QVector<XvtrPolicy::Transverter> xvtrs = {
         xvtr(12, 3, "2m",    144.0, 28.0),
@@ -86,9 +86,9 @@ void testBandStackKeysUseFlexOrder()
     expectBandKey("native HF strips UI suffix", "20m", xvtrs, "20");
     expectBandKey("native utility slot WWV", "WWV", xvtrs, "33");
     expectBandKey("native utility slot GEN", "GEN", xvtrs, "34");
-    expectBandKey("XVTR 2m uses setup order, not status index", "2m", xvtrs, "X3");
-    expectBandKey("XVTR 70cm uses setup order, not RF frequency", "70cm", xvtrs, "X7");
-    expectBandKey("XVTR 1.2G uses setup order", "1.2G", xvtrs, "X9");
+    expectBandKey("XVTR 2m uses status index, not setup order", "2m", xvtrs, "X12");
+    expectBandKey("XVTR 70cm uses status index, not RF frequency", "70cm", xvtrs, "X4");
+    expectBandKey("XVTR 1.2G uses status index", "1.2G", xvtrs, "X1");
 }
 
 void testBandStackKeysRefuseGuesses()
@@ -98,8 +98,9 @@ void testBandStackKeysRefuseGuesses()
         xvtr(3,  5, "70cm", 432.0, 28.0, false),
     };
 
-    expectUnsupportedBand("XVTR with missing order is refused",
-                          "2m", xvtrs, "has no setup order");
+    // order=-1 is irrelevant now — index is always valid; key is X2
+    expectBandKey("XVTR with no order field uses index",
+                  "2m", xvtrs, "X2");
     expectUnsupportedBand("invalid XVTR entry is ignored",
                           "70cm", xvtrs, "has no Flex display pan band= mapping");
     expectUnsupportedBand("unknown band does not use freq/mode fallback",
@@ -210,7 +211,7 @@ void testXvtrWaterfallGuardrails()
 
 int main()
 {
-    testBandStackKeysUseFlexOrder();
+    testBandStackKeysUseFlexIndex();
     testBandStackKeysRefuseGuesses();
     testHfWaterfallDoesNotShiftWhenTileLagsByOneSpan();
     testXvtrWaterfallMapsIfToRfBands();


### PR DESCRIPTION
Fixes #2342

## Root cause

`XvtrPolicy::resolveBandStackKey` was returning `X<order>` for XVTR band buttons, but the Flex radio expects `X<index>` — where `index` is the 0-based number from `xvtr <n>` status messages. The radio's `order` field is 1-based (SmartSDR labels them "Transverter 1, 2, 3"), so every button was shifted by +1:

| Button | index | order | Was sending | Radio tuned to |
|--------|-------|-------|-------------|----------------|
| 144 MHz | 0 | 1 | `band=X1` | 432 MHz ❌ |
| 432 MHz | 1 | 2 | `band=X2` | 70 MHz ❌ |
| 70 MHz  | 2 | 3 | `band=X3` | (no match) ❌ |

This regression was introduced in PR #1887 which swapped the pcap-verified `X<index>` (from PR #1615) for `X<order>` without new pcap evidence.

## Changes

- `src/models/XvtrPolicy.cpp` — revert `xvtr.order` → `xvtr.index`; drop the now-unnecessary `order < 0` guard
- `src/gui/MainWindow.cpp` — update the maintainer comment to reflect `X<index>`
- `tests/xvtr_policy_test.cpp` — update assertions to `X<index>` values; rename test; update the "missing order" case (order is now irrelevant for key resolution)

## Test plan

- [ ] `./build/xvtr_policy_test` — all 21 tests pass ✅
- [ ] On radio: XVTR band buttons select the correct band (144 MHz button → 144 MHz, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)