### PR TITLE
fix(gui): fix slice reduction crash, float/dock GPU corruption, and exit crash (#2495)

### DIFF
--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -790,16 +790,36 @@ void PanadapterStack::setFramelessMode(bool on)
 void PanadapterStack::prepareShutdown()
 {
     saveFloatingState();
+
+    // Explicitly delete floating windows rather than calling close().
+    // close() without WA_DeleteOnClose only hides the window, leaving it alive
+    // as a Qt::Window child of MainWindow.  When MainWindow's QWidget::~QWidget()
+    // later tears down its QRhi, Qt fires the QRhiWidgetPrivate cleanup callbacks
+    // for those still-parented-but-hidden floating windows in an order that can
+    // invalidate QRhiWidgetPrivate before the callback returns → crash at 0x1e2.
+    // Deleting fw explicitly runs QRhiWidget::~QRhiWidget() → removeCleanupCallback
+    // while the QRhi is still valid, so no stale callbacks remain when MainWindow
+    // tears down (#2495 exit crash on macOS).
+    const QList<QString> floatingIds = m_floatingWindows.keys();
+    for (const QString& panId : floatingIds) {
+        PanFloatingWindow* fw = m_floatingWindows.take(panId);
+        if (!fw) continue;
+        fw->saveWindowGeometry();
+        if (PanadapterApplet* applet = fw->applet()) {
+            if (SpectrumWidget* sw = applet->spectrumWidget()) {
+                sw->hide();
+                sw->resetGpuResources();
+            }
+        }
+        m_pans.remove(panId);
+        delete fw;
+    }
+
     for (auto* applet : m_pans) {
         if (auto* sw = applet ? applet->spectrumWidget() : nullptr) {
             sw->hide();
             sw->resetGpuResources();
         }
-    }
-    for (auto* fw : m_floatingWindows) {
-        fw->saveWindowGeometry();
-        fw->setShuttingDown(true);
-        fw->close();
     }
 }
 

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -193,6 +193,40 @@ void PanadapterStack::equalizeSizes()
 
 void PanadapterStack::rearrangeLayout(const QString& layoutId)
 {
+    // Dock any floating pans first.  m_pans always contains every applet
+    // including those currently in a PanFloatingWindow (floatPanadapter
+    // never removes from m_pans), so the reparent loop below would yank
+    // a floating applet out of its native window via setParent(nullptr),
+    // bypassing the GPU-reset path that float/dock use.  The QRhiWidget
+    // would stay bound to the floating window's HWND/NSView — the next
+    // render produces a black surface and the next input event into it
+    // crashes (#2495).  Stale entries would also remain in
+    // m_floatingWindows, permanently blocking future float requests.
+    QList<SpectrumWidget*> rebound;
+    if (!m_floatingWindows.isEmpty()) {
+        const QList<QString> floatingIds = m_floatingWindows.keys();
+        for (const QString& panId : floatingIds) {
+            PanFloatingWindow* fw = m_floatingWindows.take(panId);
+            if (!fw) continue;
+            fw->saveWindowGeometry();
+            PanadapterApplet* applet = fw->applet();
+            if (auto* sw = applet ? applet->spectrumWidget() : nullptr) {
+                sw->hide();
+                sw->resetGpuResources();
+                rebound.append(sw);
+            }
+            applet = fw->takeApplet();
+            fw->hide();
+            fw->deleteLater();
+            if (applet) {
+                applet->setFloatingState(false);
+                applet->spectrumWidget()->setFloating(false);
+            }
+            emit panDocked(panId);
+        }
+        saveFloatingState();
+    }
+
     // Collect applets in order
     QList<PanadapterApplet*> applets = m_pans.values();
     if (applets.isEmpty()) return;
@@ -325,8 +359,18 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
             m_splitter->addWidget(a);
     }
 
-    // Defer equalize until the new splitter has been laid out by Qt
-    QTimer::singleShot(0, this, [this]() { equalizeSizes(); });
+    // Defer equalize until the new splitter has been laid out by Qt.
+    // Re-show + refresh GPU surfaces for any spectrum widgets that came
+    // out of a floating window, so they bind to the new top-level window
+    // before the first render (mirrors the dockPanadapter() refresh dance).
+    QTimer::singleShot(0, this, [this, rebound]() {
+        for (auto* sw : rebound) {
+            if (!sw) continue;
+            sw->show();
+            refreshAfterReparent(sw);
+        }
+        equalizeSizes();
+    });
 }
 
 void PanadapterStack::removeAll()

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -9,6 +9,7 @@
 #include <QLayout>
 #include <QStringList>
 #include <QVBoxLayout>
+#include <QPointer>
 #include <QTimer>
 #include <QWindow>
 
@@ -202,7 +203,7 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
     // render produces a black surface and the next input event into it
     // crashes (#2495).  Stale entries would also remain in
     // m_floatingWindows, permanently blocking future float requests.
-    QList<SpectrumWidget*> rebound;
+    QList<QPointer<SpectrumWidget>> rebound;
     if (!m_floatingWindows.isEmpty()) {
         const QList<QString> floatingIds = m_floatingWindows.keys();
         for (const QString& panId : floatingIds) {
@@ -364,7 +365,7 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
     // out of a floating window, so they bind to the new top-level window
     // before the first render (mirrors the dockPanadapter() refresh dance).
     QTimer::singleShot(0, this, [this, rebound]() {
-        for (auto* sw : rebound) {
+        for (SpectrumWidget* sw : rebound) {
             if (!sw) continue;
             sw->show();
             refreshAfterReparent(sw);

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -815,11 +815,22 @@ void PanadapterStack::prepareShutdown()
         delete fw;
     }
 
-    for (auto* applet : m_pans) {
-        if (auto* sw = applet ? applet->spectrumWidget() : nullptr) {
+    // Explicitly delete docked applets so ~QRhiWidget() runs (and calls
+    // removeCleanupCallback) while MainWindow's QRhi is still alive.
+    // If we leave applets alive, Qt's destructor chain for QWidget destroys
+    // the QRhi *before* ~QObject()::deleteChildren() deletes the child
+    // SpectrumWidgets — QRhi::runCleanup() then fires against QRhiWidgetPrivate
+    // objects that are still live but have internal Qt fields in a stale state
+    // → crash at $0_cleanup +24 on exit (#2495 macOS).
+    const QList<QString> dockedIds = m_pans.keys();
+    for (const QString& panId : dockedIds) {
+        PanadapterApplet* applet = m_pans.take(panId);
+        if (!applet) continue;
+        if (SpectrumWidget* sw = applet->spectrumWidget()) {
             sw->hide();
             sw->resetGpuResources();
         }
+        delete applet;
     }
 }
 


### PR DESCRIPTION
Closes #2495

## Root causes found (3 separate crashes, all in `PanadapterStack`)

### Crash 1 — Windows/Linux: black panadapter after layout rearrange, then crash
**Root cause:** `rearrangeLayout()` called `setParent(nullptr)` on floating applets directly, bypassing the `floatPanadapter`/`dockPanadapter` GPU-reset path. The `QRhiWidget` stayed bound to the floating window's HWND/NSView; the next render produced a black surface and the next input event into it crashed.  `m_floatingWindows` also kept stale entries, permanently blocking future float requests.

**Fix:** `rearrangeLayout()` now docks all floating pans first (via the safe dock sequence: `hide` → `resetGpuResources` → `takeApplet` → `deleteLater` on the window) before tearing down the splitter.

### Crash 2 — macOS: async UAF in `$_67` lambda (waterfallAutoBlackLevel)
**Root cause:** Same as Crash 1 but on macOS Metal. The corrupted `SpectrumWidget` survived long enough for the next `waterfallAutoBlackLevel` VITA-49 event to fire the `MainWindow::$_67` lambda, which called `spectrum(panId)->wfAutoBlack()` on the already-corrupt widget → UAF crash at `0xffff000000000132`.

**Fix:** Covered by the same rearrange fix above. `QPointer<SpectrumWidget>` hardening (commit `3d872ab`) added to the deferred `QTimer::singleShot` refresh lambda so a pan removed between rearrange and timer fire doesn't dangle.

### Crash 3 — macOS: exit crash in `QRhiWidgetPrivate::ensureRhi()::$_0`
**Root cause:** Qt's destructor chain fires `QRhi::~QRhi()` (via `QWidget::destroy()`) **before** `QObject::~QObject()::deleteChildren()` deletes child `SpectrumWidget`s. `QRhi::runCleanup()` then invokes the `QRhiWidgetPrivate` cleanup callbacks against objects whose internal Qt fields (`colorTexture`, `renderTarget`, `renderPassDescriptor`) may be in a partially-reset state after a float→dock→reparent cycle — crash at `$_0::operator()+24` with a stale field pointer (`far=0x5d5332`, `far=0x1e2` pattern on macOS ARM64).

Two sub-paths fixed:
- **Floating windows** (`commit 2f9e6d7`): `prepareShutdown()` was using `fw->close()` which only hides (no `WA_DeleteOnClose`). Changed to explicit `delete fw`, which runs `~QRhiWidget()` → `removeCleanupCallback` while the QRhi is still alive.
- **Docked pans** (`commit 64a2593`): `prepareShutdown()` now explicitly `delete`s every docked `PanadapterApplet` (after `hide` + `resetGpuResources`). `~QRhiWidget()` → `removeCleanupCallback` runs while MainWindow's QRhi is alive. The callback list is empty when `~QWidget()` fires `QRhi::~QRhi()` on exit — no stale callbacks, no crash.

## Commits
| SHA | Description |
|-----|-------------|
| `ad55131` | dock floating pans before layout rearrange (Crash 1 + 2) |
| `3d872ab` | `QPointer` hardening for deferred SpectrumWidget refresh |
| `2f9e6d7` | explicit `delete fw` in `prepareShutdown` (Crash 3 — floating) |
| `64a2593` | explicit `delete applet` in `prepareShutdown` (Crash 3 — docked) |

## Test plan
- [ ] Float a pan, do a layout rearrange (2v, 2h, 2x2) — no black surface, no crash
- [ ] Float a pan, click dock — no crash on subsequent interaction
- [ ] Float a pan, quit — no exit crash (`QRhiWidgetPrivate::ensureRhi()::$_0` gone)
- [ ] Float two pans, quit — same
- [ ] Dock all pans, quit — clean exit
- [ ] Slice reduction (remove a slice while a pan is floating) — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)