### PR TITLE
feat(cat): Implement extended CAT controls for CW and loggers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1332,6 +1332,15 @@ target_link_libraries(cwx_panel_test PRIVATE
     Qt6::Core Qt6::Widgets
 )
 
+add_executable(cwx_model_queue_test
+    tests/cwx_model_queue_test.cpp
+    src/models/CwxModel.cpp
+    src/models/CwxModel.h
+)
+target_include_directories(cwx_model_queue_test PRIVATE src)
+target_link_libraries(cwx_model_queue_test PRIVATE Qt6::Core)
+add_test(NAME cwx_model_queue_test COMMAND cwx_model_queue_test)
+
 add_executable(meter_model_test
     tests/meter_model_test.cpp
     src/models/MeterModel.cpp

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -608,8 +608,6 @@ QString RigctlProtocol::cmdGetVfoInfo(const QString& arg)
     }
 
     auto* rxSlice = currentSlice();
-    if (m_catSplitEnabled)
-        ensureCatSplitTxSlice(false);
     auto* txSlice = findTxSlice();
     const bool wantsTxVfo = isTxVfoToken(requested);
     const bool split = m_catSplitEnabled || (rxSlice && txSlice && txSlice != rxSlice);
@@ -769,8 +767,6 @@ SliceModel* RigctlProtocol::findTxSlice() const
 QString RigctlProtocol::cmdGetSplitVfo()
 {
     auto* rxSlice = currentSlice();
-    if (m_catSplitEnabled)
-        ensureCatSplitTxSlice(false);
     auto* txSlice = findTxSlice();
     bool split = m_catSplitEnabled || (rxSlice && txSlice && rxSlice != txSlice);
     // Report TX VFO as VFOB when split (TX on a different slice), VFOA otherwise.
@@ -816,7 +812,7 @@ QString RigctlProtocol::cmdSetSplitVfo(const QString& args)
 
 QString RigctlProtocol::cmdGetSplitFreq()
 {
-    auto* txSlice = m_catSplitEnabled ? ensureCatSplitTxSlice(false) : findTxSlice();
+    auto* txSlice = findTxSlice();
     long long hz = 0;
     if (txSlice) {
         hz = static_cast<long long>(std::round(txSlice->frequency() * 1e6));
@@ -857,7 +853,7 @@ QString RigctlProtocol::cmdSetSplitFreq(const QString& args)
 
 QString RigctlProtocol::cmdGetSplitMode()
 {
-    auto* txSlice = m_catSplitEnabled ? ensureCatSplitTxSlice(false) : findTxSlice();
+    auto* txSlice = findTxSlice();
     if (!txSlice && !m_catSplitEnabled) return rprt(-1);
     auto* rxSlice = currentSlice();
     if (!txSlice && !rxSlice) return rprt(-1);

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -3,21 +3,25 @@
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
 
+#include <QByteArray>
 #include <QLocale>
 #include <QMetaObject>
 #include <QStringList>
 #include <QtGlobal>
 
+#include <cmath>
+
 namespace AetherSDR {
 
 namespace {
 
-constexpr quint64 kRigLevelRfPower           = (1ULL << 13);
+constexpr quint64 kRigLevelRfPower           = (1ULL << 12);
 constexpr quint64 kRigLevelKeyspd            = (1ULL << 14);
 constexpr quint64 kRigLevelSwr               = (1ULL << 28);
 constexpr quint64 kRigLevelRfPowerMeter      = (1ULL << 32);
 constexpr quint64 kRigLevelRfPowerMeterWatts = (1ULL << 39);
 constexpr qint64  kTxMeterFreshMs            = 1500;
+constexpr int     kHamlibSmartSdrSliceAModel = 23005;
 constexpr quint64 kRigGetLevelMask = kRigLevelRfPower
                                    | kRigLevelKeyspd
                                    | kRigLevelSwr
@@ -25,6 +29,30 @@ constexpr quint64 kRigGetLevelMask = kRigLevelRfPower
                                    | kRigLevelRfPowerMeterWatts;
 constexpr quint64 kRigSetLevelMask = kRigLevelRfPower
                                    | kRigLevelKeyspd;
+
+QStringList rigModeTokens()
+{
+    return {
+        QStringLiteral("USB"),
+        QStringLiteral("LSB"),
+        QStringLiteral("CW"),
+        QStringLiteral("CWR"),
+        QStringLiteral("AM"),
+        QStringLiteral("FM"),
+        QStringLiteral("RTTY"),
+        QStringLiteral("AMS"),
+        QStringLiteral("PKTUSB"),
+        QStringLiteral("PKTLSB"),
+    };
+}
+
+QStringList rigVfoTokens()
+{
+    return {
+        QStringLiteral("VFOA"),
+        QStringLiteral("VFOB"),
+    };
+}
 
 QStringList rigGetLevelTokens()
 {
@@ -43,6 +71,17 @@ QStringList rigSetLevelTokens()
         QStringLiteral("RFPOWER"),
         QStringLiteral("KEYSPD"),
     };
+}
+
+quint32 hamlibCrc32(const QByteArray& data)
+{
+    quint32 crc = 0xffffffffU;
+    for (const uchar byte : data) {
+        crc ^= byte;
+        for (int bit = 0; bit < 8; ++bit)
+            crc = (crc & 1U) ? (crc >> 1) ^ 0xedb88320U : (crc >> 1);
+    }
+    return ~crc;
 }
 
 QString formatRigLevelValue(double value)
@@ -119,6 +158,38 @@ SliceModel* RigctlProtocol::currentSlice() const
     }
     // Fallback to first slice
     return slices.isEmpty() ? nullptr : slices.first();
+}
+
+SliceModel* RigctlProtocol::sliceForVfo(const QString& vfo) const
+{
+    auto* current = currentSlice();
+    const QString token = vfo.trimmed().toUpper();
+    if (token.isEmpty() || token == "VFOA" || token == "VFO"
+        || token == "CURRVFO" || token == "MAIN" || token == "RX") {
+        return current;
+    }
+
+    if (token == "VFOB" || token == "SUB" || token == "TX") {
+        auto* tx = findTxSlice();
+        if (tx && (token == "TX" || tx != current))
+            return tx;
+
+        if (!m_model || !m_model->isConnected())
+            return current;
+
+        const int preferredOtherSlice = (m_sliceIndex == 0) ? 1 : 0;
+        for (auto* s : m_model->slices()) {
+            if (s && s->sliceId() == preferredOtherSlice)
+                return s;
+        }
+        for (auto* s : m_model->slices()) {
+            if (s && s != current)
+                return s;
+        }
+        return current;
+    }
+
+    return nullptr;
 }
 
 QString RigctlProtocol::rprt(int code) const
@@ -198,9 +269,12 @@ QString RigctlProtocol::processCommand(const QString& cmd)
         if (name == "set_mode")       return cmdSetMode(args);
         if (name == "get_vfo")        return cmdGetVfo();
         if (name == "set_vfo")        return cmdSetVfo(args);
+        if (name == "get_vfo_info")   return cmdGetVfoInfo(args);
+        if (name == "get_vfo_list")   return cmdGetVfoList();
         if (name == "get_ptt")        return cmdGetPtt();
         if (name == "set_ptt")        return cmdSetPtt(args);
         if (name == "get_info")       return cmdGetInfo();
+        if (name == "get_rig_info")   return cmdGetRigInfo();
         if (name == "get_split_vfo")  return cmdGetSplitVfo();
         if (name == "set_split_vfo")  return cmdSetSplitVfo(args);
         if (name == "get_split_freq") return cmdGetSplitFreq();
@@ -209,6 +283,10 @@ QString RigctlProtocol::processCommand(const QString& cmd)
         if (name == "set_split_mode") return cmdSetSplitMode(args);
         if (name == "get_level")      return cmdGetLevel(args);
         if (name == "set_level")      return cmdSetLevel(args);
+        if (name == "set_func")       return cmdSetFunc(args);
+        if (name == "vfo_op")         return cmdVfoOp(args);
+        if (name == "set_trn")        return cmdSetTrn(args);
+        if (name == "get_trn")        return cmdGetTrn();
         if (name == "dump_state")     return cmdDumpState();
         if (name == "quit")           return {};  // caller handles disconnect
         if (name == "chk_vfo")        return QStringLiteral("0\n");  // VFO mode disabled
@@ -229,6 +307,9 @@ QString RigctlProtocol::processCommand(const QString& cmd)
     case 'M': return cmdSetMode(args);
     case 'v': return cmdGetVfo();
     case 'V': return cmdSetVfo(args);
+    case 'G': return cmdVfoOp(args);
+    case 'A': return cmdSetTrn(args);
+    case 'a': return cmdGetTrn();
     case 't': return cmdGetPtt();
     case 'T': return cmdSetPtt(args);
     case '_': return cmdGetInfo();
@@ -297,13 +378,20 @@ QString RigctlProtocol::cmdGetMode()
 
 QString RigctlProtocol::cmdSetMode(const QString& args)
 {
-    auto* slice = currentSlice();
-    if (!slice) return rprt(-8);
-
     QStringList parts = args.split(' ', Qt::SkipEmptyParts);
     if (parts.isEmpty()) return rprt(-1);
 
     QString hamlibMode = parts[0].toUpper();
+    if (hamlibMode == "?") {
+        const QString supported = rigModeTokens().join(' ');
+        if (m_extended)
+            return QStringLiteral("set_mode:\nModes: %1\n").arg(supported) + rprt(0);
+        return supported + "\n";
+    }
+
+    auto* slice = currentSlice();
+    if (!slice) return rprt(-8);
+
     QString sdrMode = hamlibToSmartSDR(hamlibMode);
 
     QMetaObject::invokeMethod(slice, [slice, sdrMode]() {
@@ -367,9 +455,64 @@ QString RigctlProtocol::cmdSetVfo(const QString& arg)
     // by the VFO command.  WSJT-X sends "V VFOB" during init which would
     // otherwise force all instances onto Slice B (#1621).
     QString vfo = arg.trimmed().toUpper();
+    if (vfo == "?") {
+        const QString supported = rigVfoTokens().join(' ');
+        if (m_extended)
+            return QStringLiteral("set_vfo:\nVFO: %1\n").arg(supported) + rprt(0);
+        return supported + "\n";
+    }
     if (vfo == "VFOA" || vfo == "MAIN" || vfo == "VFOB" || vfo == "SUB")
         return rprt(0);
     return rprt(-1);
+}
+
+QString RigctlProtocol::cmdGetVfoInfo(const QString& arg)
+{
+    const QString requested = arg.trimmed().isEmpty()
+        ? QStringLiteral("VFOA")
+        : arg.trimmed().toUpper();
+
+    if (requested == "?") {
+        const QString supported = rigVfoTokens().join(' ');
+        if (m_extended)
+            return QStringLiteral("get_vfo_info:\nVFO: %1\n").arg(supported) + rprt(0);
+        return supported + "\n";
+    }
+
+    auto* slice = sliceForVfo(requested);
+    if (!slice) return rprt(-1);
+
+    const auto hz = static_cast<long long>(std::round(slice->frequency() * 1e6));
+    const QString mode = smartsdrToHamlib(slice->mode());
+    const int width = qAbs(slice->filterHigh() - slice->filterLow());
+    auto* rxSlice = currentSlice();
+    auto* txSlice = findTxSlice();
+    const bool split = rxSlice && txSlice && txSlice != rxSlice;
+    constexpr int satMode = 0;
+
+    if (m_extended) {
+        return QStringLiteral("get_vfo_info:\nFreq: %1\nMode: %2\nWidth: %3\nSplit: %4\nSatMode: %5\n")
+            .arg(hz)
+            .arg(mode)
+            .arg(width)
+            .arg(split ? 1 : 0)
+            .arg(satMode)
+            + rprt(0);
+    }
+    return QStringLiteral("%1\n%2\n%3\n%4\n%5\n")
+        .arg(hz)
+        .arg(mode)
+        .arg(width)
+        .arg(split ? 1 : 0)
+        .arg(satMode);
+}
+
+QString RigctlProtocol::cmdGetVfoList()
+{
+    const QString supported = rigVfoTokens().join(' ');
+    if (m_extended)
+        return QStringLiteral("get_vfo_list:\nVFOs: %1\n").arg(supported) + rprt(0);
+    return supported + "\n";
 }
 
 QString RigctlProtocol::cmdGetPtt()
@@ -408,6 +551,50 @@ QString RigctlProtocol::cmdGetInfo()
         return QStringLiteral("AetherSDR\n");
     return QStringLiteral("%1 %2 v%3\n")
         .arg(m_model->name(), m_model->model(), m_model->version());
+}
+
+QString RigctlProtocol::cmdGetRigInfo()
+{
+    auto formatVfoLine = [](const QString& vfoName, SliceModel* slice, bool rx, bool tx) {
+        const auto hz = slice
+            ? static_cast<long long>(std::round(slice->frequency() * 1e6))
+            : 0LL;
+        const QString mode = slice ? RigctlProtocol::smartsdrToHamlib(slice->mode())
+                                   : QStringLiteral("None");
+        const int width = slice ? qAbs(slice->filterHigh() - slice->filterLow()) : 0;
+        return QStringLiteral("VFO=%1 Freq=%2 Mode=%3 Width=%4 RX=%5 TX=%6\n")
+            .arg(vfoName)
+            .arg(hz)
+            .arg(mode)
+            .arg(width)
+            .arg(rx ? 1 : 0)
+            .arg(tx ? 1 : 0);
+    };
+
+    auto* vfoA = sliceForVfo(QStringLiteral("VFOA"));
+    auto* vfoB = sliceForVfo(QStringLiteral("VFOB"));
+    auto* txSlice = findTxSlice();
+    const bool split = vfoA && txSlice && txSlice != vfoA;
+    constexpr int satMode = 0;
+
+    QString body;
+    body += formatVfoLine(QStringLiteral("VFOA"), vfoA, true, !split);
+    body += formatVfoLine(QStringLiteral("VFOB"), vfoB, false, split);
+    body += QStringLiteral("Split=%1 SatMode=%2\n").arg(split ? 1 : 0).arg(satMode);
+    body += QStringLiteral("Rig=%1\n").arg(
+        (m_model && !m_model->model().trimmed().isEmpty())
+            ? m_model->model().trimmed()
+            : QStringLiteral("AetherSDR"));
+    body += QStringLiteral("App=AetherSDR\n");
+    body += QStringLiteral("Version=20241103 1.1.0\n");
+    body += QStringLiteral("Model=%1\n").arg(kHamlibSmartSdrSliceAModel + qBound(0, m_sliceIndex, 7));
+
+    const quint32 crc = hamlibCrc32(body.toUtf8());
+    body += QStringLiteral("CRC=0x%1\n").arg(crc, 8, 16, QLatin1Char('0'));
+
+    if (m_extended)
+        return QStringLiteral("get_rig_info:\n") + body + rprt(0);
+    return body;
 }
 
 // Find the TX slice (may differ from the RX slice in split mode)
@@ -590,6 +777,57 @@ QString RigctlProtocol::cmdSetLevel(const QString& args)
         return rprt(0);
     }
     return rprt(-11);  // RIG_ENAVAIL
+}
+
+QString RigctlProtocol::cmdSetFunc(const QString& args)
+{
+    const QString func = args.section(' ', 0, 0).trimmed().toUpper();
+    if (func.isEmpty())
+        return rprt(-1);
+    if (func == "?") {
+        if (m_extended)
+            return QStringLiteral("set_func:\nFunctions: \n") + rprt(0);
+        return QStringLiteral("\n");
+    }
+    return rprt(-11);  // RIG_ENAVAIL
+}
+
+QString RigctlProtocol::cmdVfoOp(const QString& args)
+{
+    const QString op = args.section(' ', 0, 0).trimmed().toUpper();
+    if (op.isEmpty())
+        return rprt(-1);
+    if (op == "?") {
+        if (m_extended)
+            return QStringLiteral("vfo_op:\nMem/VFO Ops: \n") + rprt(0);
+        return QStringLiteral("\n");
+    }
+    return rprt(-11);  // RIG_ENAVAIL
+}
+
+QString RigctlProtocol::cmdSetTrn(const QString& args)
+{
+    const QString trn = args.section(' ', 0, 0).trimmed().toUpper();
+    if (trn.isEmpty())
+        return rprt(-1);
+    if (trn == "?") {
+        if (m_extended)
+            return QStringLiteral("set_trn:\nTransceive: 0\n") + rprt(0);
+        return QStringLiteral("0\n");
+    }
+
+    bool ok = false;
+    const int mode = trn.toInt(&ok);
+    if (!ok)
+        return rprt(-1);
+    return mode == 0 ? rprt(0) : rprt(-11);
+}
+
+QString RigctlProtocol::cmdGetTrn()
+{
+    if (m_extended)
+        return QStringLiteral("get_trn:\nTransceive: 0\n") + rprt(0);
+    return QStringLiteral("0\n");
 }
 
 QString RigctlProtocol::cmdDumpState()

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -4,12 +4,15 @@
 #include "models/TransmitModel.h"
 
 #include <QByteArray>
+#include <QHash>
 #include <QLocale>
 #include <QMetaObject>
 #include <QStringList>
+#include <QTimer>
 #include <QtGlobal>
 
 #include <cmath>
+#include <memory>
 
 namespace AetherSDR {
 
@@ -90,6 +93,67 @@ QString formatRigLevelValue(double value)
     if (text == "-0" || text == "-0.0")
         text = "0";
     return text;
+}
+
+const QHash<QChar, QString>& morseTable()
+{
+    static const QHash<QChar, QString> table = {
+        {'A', ".-"},    {'B', "-..."},  {'C', "-.-."},  {'D', "-.."},
+        {'E', "."},     {'F', "..-."},  {'G', "--."},   {'H', "...."},
+        {'I', ".."},    {'J', ".---"},  {'K', "-.-"},   {'L', ".-.."},
+        {'M', "--"},    {'N', "-."},    {'O', "---"},   {'P', ".--."},
+        {'Q', "--.-"},  {'R', ".-."},   {'S', "..."},   {'T', "-"},
+        {'U', "..-"},   {'V', "...-"},  {'W', ".--"},   {'X', "-..-"},
+        {'Y', "-.--"},  {'Z', "--.."},
+        {'0', "-----"}, {'1', ".----"}, {'2', "..---"}, {'3', "...--"},
+        {'4', "....-"}, {'5', "....."}, {'6', "-...."}, {'7', "--..."},
+        {'8', "---.."}, {'9', "----."},
+        {'.', ".-.-.-"},{',', "--..--"},{'?', "..--.."},{'\'',".----."},
+        {'!', "-.-.--"},{'/', "-..-."}, {'(', "-.--."}, {')', "-.--.-"},
+        {'&', ".-..."}, {':', "---..."},{';', "-.-.-."},{'=', "-...-"},
+        {'+', ".-.-."}, {'-', "-....-"},{'_', "..--.-"},{'"', ".-..-."},
+        {'$', "...-..-"},{'@', ".--.-."},
+    };
+    return table;
+}
+
+int estimateMorseDurationMs(const QString& text, int wpm)
+{
+    const int clampedWpm = qBound(5, wpm, 100);
+    const int unitMs = qMax(1, qRound(1200.0 / clampedWpm));
+    const auto& table = morseTable();
+    int units = 0;
+    bool firstChar = true;
+
+    for (const QChar raw : text.toUpper()) {
+        if (raw.isSpace() || raw == QChar(0x7f)) {
+            if (units > 0)
+                units += 7;
+            firstChar = true;
+            continue;
+        }
+
+        const auto it = table.find(raw);
+        if (it == table.end()) {
+            if (units > 0)
+                units += 7;
+            firstChar = true;
+            continue;
+        }
+
+        if (!firstChar)
+            units += 3;
+        firstChar = false;
+
+        const QString& pattern = it.value();
+        for (int i = 0; i < pattern.size(); ++i) {
+            if (i > 0)
+                units += 1;
+            units += (pattern[i] == '.') ? 1 : 3;
+        }
+    }
+
+    return units * unitMs + 500;
 }
 
 } // namespace
@@ -195,6 +259,51 @@ SliceModel* RigctlProtocol::sliceForVfo(const QString& vfo) const
 QString RigctlProtocol::rprt(int code) const
 {
     return QStringLiteral("RPRT %1\n").arg(code);
+}
+
+void RigctlProtocol::scheduleMorseAck(const QString& text)
+{
+    if (!m_model || !m_asyncResponder)
+        return;
+
+    auto* cwx = &m_model->cwxModel();
+    const int targetIndex = cwx->sentIndex() + text.size();
+    const int timeoutMs = estimateMorseDurationMs(text, cwx->speed());
+    const auto responder = m_asyncResponder;
+
+    auto pending = std::make_shared<bool>(true);
+    m_asyncResponsePending = pending;
+    auto sentConn = std::make_shared<QMetaObject::Connection>();
+    auto erasedConn = std::make_shared<QMetaObject::Connection>();
+    auto cancelConn = std::make_shared<QMetaObject::Connection>();
+    auto finish = [pending, responder, sentConn, erasedConn, cancelConn]() mutable {
+        if (!*pending)
+            return;
+        *pending = false;
+        QObject::disconnect(*sentConn);
+        QObject::disconnect(*erasedConn);
+        QObject::disconnect(*cancelConn);
+        responder(QStringLiteral("RPRT 0\n"));
+    };
+
+    *sentConn = QObject::connect(cwx, &CwxModel::charSent, cwx,
+        [targetIndex, finish](int index) mutable {
+            if (index >= targetIndex)
+                finish();
+        });
+    *erasedConn = QObject::connect(cwx, &CwxModel::erased, cwx,
+        [targetIndex, finish](int, int stop) mutable {
+            if (stop >= targetIndex)
+                finish();
+        });
+    *cancelConn = QObject::connect(cwx, &CwxModel::transmissionCancelled, cwx,
+        [finish]() mutable {
+            finish();
+        });
+
+    QTimer::singleShot(timeoutMs, cwx, [finish]() mutable {
+        finish();
+    });
 }
 
 // ── Main entry point ────────────────────────────────────────────────────────
@@ -480,7 +589,7 @@ QString RigctlProtocol::cmdGetVfoInfo(const QString& arg)
     if (requested == "?") {
         const QString supported = rigVfoTokens().join(' ');
         if (m_extended)
-            return QStringLiteral("get_vfo_info:\nVFO: %1\n").arg(supported) + rprt(0);
+            return QStringLiteral("get_vfo_info: ?\n%1\n").arg(supported) + rprt(0);
         return supported + "\n";
     }
 
@@ -496,9 +605,8 @@ QString RigctlProtocol::cmdGetVfoInfo(const QString& arg)
     constexpr int satMode = 0;
 
     if (m_extended) {
-        // MacLoggerDX sends +\get_vfo_info but parses the payload as the
-        // five positional values from Hamlib's non-extended response.
-        return QStringLiteral("get_vfo_info:\n%1\n%2\n%3\n%4\n%5\n")
+        return QStringLiteral("get_vfo_info: %1\nFreq: %2\nMode: %3\nWidth: %4\nSplit: %5\nSatMode: %6\n")
+            .arg(requested)
             .arg(hz)
             .arg(mode)
             .arg(width)
@@ -555,9 +663,15 @@ QString RigctlProtocol::cmdSetPtt(const QString& arg)
 QString RigctlProtocol::cmdGetInfo()
 {
     if (!m_model || !m_model->isConnected())
-        return QStringLiteral("AetherSDR\n");
-    return QStringLiteral("%1 %2 v%3\n")
+        return m_extended
+            ? QStringLiteral("get_info:\nInfo: AetherSDR\n") + rprt(0)
+            : QStringLiteral("AetherSDR\n");
+
+    const QString info = QStringLiteral("%1 %2 v%3")
         .arg(m_model->name(), m_model->model(), m_model->version());
+    if (m_extended)
+        return QStringLiteral("get_info:\nInfo: %1\n").arg(info) + rprt(0);
+    return info + QChar('\n');
 }
 
 QString RigctlProtocol::cmdGetRigInfo()
@@ -920,17 +1034,23 @@ QString RigctlProtocol::cmdSendMorse(const QString& text)
         m_pendingMorseLine = true;
         return {};
     }
-    QMetaObject::invokeMethod(m_model, [this, text]() {
-        m_model->cwxModel().send(text);
+    const bool asyncAck = static_cast<bool>(m_asyncResponder);
+    if (asyncAck)
+        scheduleMorseAck(text);
+
+    auto* model = m_model;
+    QMetaObject::invokeMethod(model, [model, text]() {
+        model->cwxModel().send(text);
     }, Qt::QueuedConnection);
-    return rprt(0);
+    return asyncAck ? QString() : rprt(0);
 }
 
 QString RigctlProtocol::cmdStopMorse()
 {
     if (!m_model) return rprt(-1);
-    QMetaObject::invokeMethod(m_model, [this]() {
-        m_model->cwxModel().clearBuffer();
+    auto* model = m_model;
+    QMetaObject::invokeMethod(model, [model]() {
+        model->cwxModel().clearBuffer();
     }, Qt::QueuedConnection);
     return rprt(0);
 }

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -258,7 +258,8 @@ SliceModel* RigctlProtocol::ensureCatSplitTxSlice(bool createIfMissing)
     if (txSlice) {
         m_catSplitCreatePending = false;
         m_catSplitTxSliceId = txSlice->sliceId();
-        txSlice->setTxSlice(true);
+        if (!txSlice->isTxSlice())
+            txSlice->setTxSlice(true);
         applyPendingSplitSettings(txSlice);
         return txSlice;
     }

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -25,6 +25,7 @@ constexpr quint64 kRigLevelRfPowerMeter      = (1ULL << 32);
 constexpr quint64 kRigLevelRfPowerMeterWatts = (1ULL << 39);
 constexpr qint64  kTxMeterFreshMs            = 1500;
 constexpr int     kHamlibSmartSdrSliceAModel = 23005;
+constexpr int     kMorseCompletionGraceMs    = 350;
 constexpr quint64 kRigGetLevelMask = kRigLevelRfPower
                                    | kRigLevelKeyspd
                                    | kRigLevelSwr
@@ -267,7 +268,7 @@ void RigctlProtocol::scheduleMorseAck(const QString& text)
         return;
 
     auto* cwx = &m_model->cwxModel();
-    const int targetIndex = cwx->sentIndex() + text.size();
+    const int expectedChars = text.size();
     const int timeoutMs = estimateMorseDurationMs(text, cwx->speed());
     const auto responder = m_asyncResponder;
 
@@ -285,16 +286,21 @@ void RigctlProtocol::scheduleMorseAck(const QString& text)
         QObject::disconnect(*cancelConn);
         responder(QStringLiteral("RPRT 0\n"));
     };
+    m_completeAsyncResponse = finish;
 
+    auto sentCount = std::make_shared<int>(0);
     *sentConn = QObject::connect(cwx, &CwxModel::charSent, cwx,
-        [targetIndex, finish](int index) mutable {
-            if (index >= targetIndex)
-                finish();
+        [cwx, expectedChars, sentCount, finish](int) mutable {
+            ++(*sentCount);
+            if (*sentCount >= expectedChars) {
+                QTimer::singleShot(kMorseCompletionGraceMs, cwx, [finish]() mutable {
+                    finish();
+                });
+            }
         });
     *erasedConn = QObject::connect(cwx, &CwxModel::erased, cwx,
-        [targetIndex, finish](int, int stop) mutable {
-            if (stop >= targetIndex)
-                finish();
+        [finish](int, int) mutable {
+            finish();
         });
     *cancelConn = QObject::connect(cwx, &CwxModel::transmissionCancelled, cwx,
         [finish]() mutable {
@@ -304,6 +310,12 @@ void RigctlProtocol::scheduleMorseAck(const QString& text)
     QTimer::singleShot(timeoutMs, cwx, [finish]() mutable {
         finish();
     });
+}
+
+void RigctlProtocol::completePendingAsyncResponse()
+{
+    if (hasPendingAsyncResponse() && m_completeAsyncResponse)
+        m_completeAsyncResponse();
 }
 
 // ── Main entry point ────────────────────────────────────────────────────────
@@ -1048,6 +1060,7 @@ QString RigctlProtocol::cmdSendMorse(const QString& text)
 QString RigctlProtocol::cmdStopMorse()
 {
     if (!m_model) return rprt(-1);
+    completePendingAsyncResponse();
     auto* model = m_model;
     QMetaObject::invokeMethod(model, [model]() {
         model->cwxModel().clearBuffer();

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -1,4 +1,5 @@
 #include "RigctlProtocol.h"
+#include "models/CwxModel.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
@@ -102,6 +103,14 @@ QString formatRigLevelValue(double value)
 RigctlProtocol::RigctlProtocol(RadioModel* model)
     : m_model(model)
 {}
+
+RigctlProtocol::~RigctlProtocol()
+{
+    // Cancel any in-flight wait_morse so the queueEmpty lambda doesn't
+    // fire after this protocol (and its write callback's captured socket)
+    // have been destroyed.
+    QObject::disconnect(m_pendingMorseConn);
+}
 
 // ── Mode conversion tables ──────────────────────────────────────────────────
 // SmartSDR mode names observed on FLEX-8600 fw v1.4.0.0.
@@ -1133,6 +1142,16 @@ QString RigctlProtocol::cmdSendMorse(const QString& text)
 QString RigctlProtocol::cmdStopMorse()
 {
     if (!m_model) return rprt(-1);
+
+    // If wait_morse is blocked, resolve it immediately — CW is being
+    // cancelled, so "done" is the right answer.
+    if (m_pendingMorseConn) {
+        QObject::disconnect(m_pendingMorseConn);
+        m_pendingMorseConn = {};
+        if (m_writeCallback)
+            m_writeCallback(rprt(0));
+    }
+
     auto* model = m_model;
     QMetaObject::invokeMethod(model, [model]() {
         model->cwxModel().clearBuffer();
@@ -1143,7 +1162,28 @@ QString RigctlProtocol::cmdStopMorse()
 QString RigctlProtocol::cmdWaitMorse()
 {
     if (!m_model) return rprt(-1);
-    return rprt(0);
+
+    // If no CWX is in flight, or we have no async write path, respond
+    // immediately — there is nothing to wait for.
+    if (!m_model->isCwxActive() || !m_writeCallback)
+        return rprt(0);
+
+    // CWX is active: block the response until the radio drains its CWX
+    // queue (queueEmpty fires when the radio sends "cwx queue=").
+    // Use the model as context so Qt auto-disconnects if RadioModel goes
+    // away before the CW completes. SingleShotConnection fires once then
+    // removes itself.
+    QObject::disconnect(m_pendingMorseConn);
+    auto cb = m_writeCallback;
+    m_pendingMorseConn = QObject::connect(
+        &m_model->cwxModel(), &CwxModel::queueEmpty,
+        m_model, [this, cb]() mutable {
+            m_pendingMorseConn = {};
+            cb(rprt(0));
+        },
+        Qt::SingleShotConnection
+    );
+    return {};  // no immediate response — deferred via write callback
 }
 
 QString RigctlProtocol::cmdSetKeySpeed(const QString& arg)

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -54,6 +54,11 @@ QStringList rigVfoTokens()
     };
 }
 
+bool isTxVfoToken(const QString& token)
+{
+    return token == "VFOB" || token == "SUB" || token == "TX";
+}
+
 QStringList rigGetLevelTokens()
 {
     return {
@@ -169,7 +174,12 @@ SliceModel* RigctlProtocol::sliceForVfo(const QString& vfo) const
         return current;
     }
 
-    if (token == "VFOB" || token == "SUB" || token == "TX") {
+    if (isTxVfoToken(token)) {
+        if (m_catSplitEnabled) {
+            if (auto* tx = findCatSplitTxSlice())
+                return tx;
+        }
+
         auto* tx = findTxSlice();
         if (tx && (token == "TX" || tx != current))
             return tx;
@@ -195,6 +205,118 @@ SliceModel* RigctlProtocol::sliceForVfo(const QString& vfo) const
 QString RigctlProtocol::rprt(int code) const
 {
     return QStringLiteral("RPRT %1\n").arg(code);
+}
+
+double RigctlProtocol::defaultSplitTxFrequencyMhz(const SliceModel* rxSlice) const
+{
+    if (!rxSlice)
+        return 0.0;
+
+    const QString mode = rxSlice->mode().toUpper();
+    const bool isCw = (mode == "CW" || mode == "CWL");
+    return rxSlice->frequency() + (isCw ? 0.001 : 0.005);
+}
+
+SliceModel* RigctlProtocol::findCatSplitTxSlice() const
+{
+    if (!m_model)
+        return nullptr;
+
+    if (m_catSplitTxSliceId >= 0) {
+        if (auto* tracked = m_model->slice(m_catSplitTxSliceId))
+            return tracked;
+    }
+
+    auto* rxSlice = (m_catSplitRxSliceId >= 0) ? m_model->slice(m_catSplitRxSliceId) : nullptr;
+    if (!rxSlice)
+        rxSlice = currentSlice();
+    for (auto* s : m_model->slices()) {
+        if (s && s != rxSlice && s->isTxSlice())
+            return s;
+    }
+
+    const int preferredOtherSlice = (m_sliceIndex == 0) ? 1 : 0;
+    for (auto* s : m_model->slices()) {
+        if (s && s != rxSlice && s->sliceId() == preferredOtherSlice)
+            return s;
+    }
+
+    for (auto* s : m_model->slices()) {
+        if (s && s != rxSlice)
+            return s;
+    }
+
+    return nullptr;
+}
+
+SliceModel* RigctlProtocol::ensureCatSplitTxSlice(bool createIfMissing)
+{
+    if (!m_catSplitEnabled || !m_model || !m_model->isConnected())
+        return nullptr;
+
+    auto* txSlice = findCatSplitTxSlice();
+    if (txSlice) {
+        m_catSplitCreatePending = false;
+        m_catSplitTxSliceId = txSlice->sliceId();
+        txSlice->setTxSlice(true);
+        applyPendingSplitSettings(txSlice);
+        return txSlice;
+    }
+
+    if (createIfMissing && !m_catSplitCreatePending) {
+        const double initialFreq = m_hasPendingSplitFreq
+            ? m_pendingSplitFreqMhz
+            : defaultSplitTxFrequencyMhz(currentSlice());
+        requestCatSplitSlice(initialFreq);
+    }
+
+    return nullptr;
+}
+
+void RigctlProtocol::applyPendingSplitSettings(SliceModel* txSlice)
+{
+    if (!txSlice)
+        return;
+
+    if (m_hasPendingSplitFreq) {
+        txSlice->setFrequency(m_pendingSplitFreqMhz);
+        m_hasPendingSplitFreq = false;
+    }
+
+    if (!m_pendingSplitMode.isEmpty()) {
+        txSlice->setMode(m_pendingSplitMode);
+        m_pendingSplitMode.clear();
+    }
+}
+
+void RigctlProtocol::requestCatSplitSlice(double initialFreqMhz)
+{
+    if (!m_model)
+        return;
+
+    auto* rxSlice = currentSlice();
+    if (!rxSlice)
+        return;
+
+    if (m_model->slices().size() >= m_model->maxSlices())
+        return;
+
+    QString panId = rxSlice->panId();
+    if (panId.isEmpty())
+        panId = m_model->panId();
+    if (panId.isEmpty())
+        return;
+
+    if (initialFreqMhz <= 0.0)
+        initialFreqMhz = defaultSplitTxFrequencyMhz(rxSlice);
+    if (initialFreqMhz <= 0.0)
+        return;
+
+    m_catSplitCreatePending = true;
+    m_catSplitOwnsTxSlice = true;
+    m_model->sendCommand(QStringLiteral("slice create pan=%1 freq=%2")
+        .arg(panId)
+        .arg(initialFreqMhz, 0, 'f', 6));
 }
 
 // ── Main entry point ────────────────────────────────────────────────────────
@@ -484,16 +606,36 @@ QString RigctlProtocol::cmdGetVfoInfo(const QString& arg)
         return supported + "\n";
     }
 
-    auto* slice = sliceForVfo(requested);
-    if (!slice) return rprt(-1);
-
-    const auto hz = static_cast<long long>(std::round(slice->frequency() * 1e6));
-    const QString mode = smartsdrToHamlib(slice->mode());
-    const int width = qAbs(slice->filterHigh() - slice->filterLow());
     auto* rxSlice = currentSlice();
+    if (m_catSplitEnabled)
+        ensureCatSplitTxSlice(false);
     auto* txSlice = findTxSlice();
-    const bool split = rxSlice && txSlice && txSlice != rxSlice;
+    const bool wantsTxVfo = isTxVfoToken(requested);
+    const bool split = m_catSplitEnabled || (rxSlice && txSlice && txSlice != rxSlice);
     constexpr int satMode = 0;
+
+    long long hz = 0;
+    QString mode;
+    int width = 0;
+
+    if (wantsTxVfo && m_catSplitEnabled && !txSlice) {
+        if (!rxSlice) return rprt(-1);
+        const double freqMhz = m_hasPendingSplitFreq
+            ? m_pendingSplitFreqMhz
+            : defaultSplitTxFrequencyMhz(rxSlice);
+        hz = static_cast<long long>(std::round(freqMhz * 1e6));
+        mode = m_pendingSplitMode.isEmpty()
+            ? smartsdrToHamlib(rxSlice->mode())
+            : smartsdrToHamlib(m_pendingSplitMode);
+        width = qAbs(rxSlice->filterHigh() - rxSlice->filterLow());
+    } else {
+        auto* slice = sliceForVfo(requested);
+        if (!slice) return rprt(-1);
+
+        hz = static_cast<long long>(std::round(slice->frequency() * 1e6));
+        mode = smartsdrToHamlib(slice->mode());
+        width = qAbs(slice->filterHigh() - slice->filterLow());
+    }
 
     if (m_extended) {
         return QStringLiteral("get_vfo_info: %1\nFreq: %2\nMode: %3\nWidth: %4\nSplit: %5\nSatMode: %6\n")
@@ -613,6 +755,11 @@ QString RigctlProtocol::cmdGetRigInfo()
 SliceModel* RigctlProtocol::findTxSlice() const
 {
     if (!m_model) return nullptr;
+    if (m_catSplitEnabled) {
+        if (auto* tx = findCatSplitTxSlice())
+            return tx;
+        return nullptr;
+    }
     for (auto* s : m_model->slices())
         if (s->isTxSlice()) return s;
     return nullptr;
@@ -621,8 +768,10 @@ SliceModel* RigctlProtocol::findTxSlice() const
 QString RigctlProtocol::cmdGetSplitVfo()
 {
     auto* rxSlice = currentSlice();
+    if (m_catSplitEnabled)
+        ensureCatSplitTxSlice(false);
     auto* txSlice = findTxSlice();
-    bool split = (rxSlice && txSlice && rxSlice != txSlice);
+    bool split = m_catSplitEnabled || (rxSlice && txSlice && rxSlice != txSlice);
     // Report TX VFO as VFOB when split (TX on a different slice), VFOA otherwise.
     // The actual slice is resolved internally — the VFO label is only for the client.
     const QString txVfo = split ? "VFOB" : "VFOA";
@@ -637,20 +786,49 @@ QString RigctlProtocol::cmdSetSplitVfo(const QString& args)
     QStringList parts = args.split(' ', Qt::SkipEmptyParts);
     if (parts.isEmpty()) return rprt(-1);
     bool enable = (parts[0] == "1");
-    if (!enable) {
+    if (enable) {
+        m_catSplitEnabled = true;
+        if (auto* s = currentSlice())
+            m_catSplitRxSliceId = s->sliceId();
+        // MacLoggerDX sends set_split_vfo, set_freq, then set_split_freq as a
+        // burst.  Claim an existing VFOB immediately, but defer creating a new
+        // slice until set_split_freq so the slice is born on the requested TX
+        // frequency instead of a temporary default offset.
+        ensureCatSplitTxSlice(false);
+    } else {
         // Disable split — move TX back to our slice
+        if (m_catSplitOwnsTxSlice && m_catSplitTxSliceId >= 0 && m_model)
+            m_model->sendCommand(QStringLiteral("slice remove %1").arg(m_catSplitTxSliceId));
         if (auto* s = currentSlice())
             s->setTxSlice(true);
+        m_catSplitEnabled = false;
+        m_catSplitCreatePending = false;
+        m_catSplitOwnsTxSlice = false;
+        m_hasPendingSplitFreq = false;
+        m_catSplitRxSliceId = -1;
+        m_catSplitTxSliceId = -1;
+        m_pendingSplitFreqMhz = 0.0;
+        m_pendingSplitMode.clear();
     }
-    // Enabling split requires a second slice — handled by MainWindow's split logic
     return rprt(0);
 }
 
 QString RigctlProtocol::cmdGetSplitFreq()
 {
-    auto* txSlice = findTxSlice();
-    if (!txSlice) return rprt(-1);
-    long long hz = static_cast<long long>(std::round(txSlice->frequency() * 1e6));
+    auto* txSlice = m_catSplitEnabled ? ensureCatSplitTxSlice(false) : findTxSlice();
+    long long hz = 0;
+    if (txSlice) {
+        hz = static_cast<long long>(std::round(txSlice->frequency() * 1e6));
+    } else if (m_catSplitEnabled) {
+        auto* rxSlice = currentSlice();
+        if (!rxSlice) return rprt(-1);
+        const double freqMhz = m_hasPendingSplitFreq
+            ? m_pendingSplitFreqMhz
+            : defaultSplitTxFrequencyMhz(rxSlice);
+        hz = static_cast<long long>(std::round(freqMhz * 1e6));
+    } else {
+        return rprt(-1);
+    }
     if (m_extended)
         return QString("get_split_freq:\nTX Frequency: %1\n").arg(hz) + rprt(0);
     return QString("%1\n").arg(hz);
@@ -658,26 +836,41 @@ QString RigctlProtocol::cmdGetSplitFreq()
 
 QString RigctlProtocol::cmdSetSplitFreq(const QString& args)
 {
-    auto* txSlice = findTxSlice();
-    if (!txSlice) return rprt(-1);
     bool ok;
     double hz = args.trimmed().toDouble(&ok);
     if (!ok) return rprt(-1);
+
+    if (m_catSplitEnabled) {
+        m_pendingSplitFreqMhz = hz / 1e6;
+        m_hasPendingSplitFreq = true;
+        if (auto* txSlice = ensureCatSplitTxSlice(true))
+            applyPendingSplitSettings(txSlice);
+        return rprt(0);
+    }
+
+    auto* txSlice = findTxSlice();
+    if (!txSlice) return rprt(-1);
     txSlice->setFrequency(hz / 1e6);
     return rprt(0);
 }
 
 QString RigctlProtocol::cmdGetSplitMode()
 {
-    auto* txSlice = findTxSlice();
-    if (!txSlice) return rprt(-1);
-    const QString mode = txSlice->mode();
+    auto* txSlice = m_catSplitEnabled ? ensureCatSplitTxSlice(false) : findTxSlice();
+    if (!txSlice && !m_catSplitEnabled) return rprt(-1);
+    auto* rxSlice = currentSlice();
+    if (!txSlice && !rxSlice) return rprt(-1);
+
+    const QString mode = txSlice
+        ? txSlice->mode()
+        : (m_pendingSplitMode.isEmpty() ? rxSlice->mode() : m_pendingSplitMode);
     // Map FlexRadio mode to Hamlib mode string
     QString hMode = mode;
     if (mode == "DIGU") hMode = "PKTUSB";
     else if (mode == "DIGL") hMode = "PKTLSB";
     else if (mode == "SAM") hMode = "AMS";
-    int passband = txSlice->filterHigh() - txSlice->filterLow();
+    const auto* widthSlice = txSlice ? txSlice : rxSlice;
+    int passband = widthSlice->filterHigh() - widthSlice->filterLow();
     if (m_extended)
         return QString("get_split_mode:\nTX Mode: %1\nTX Passband: %2\n").arg(hMode).arg(passband) + rprt(0);
     return QString("%1\n%2\n").arg(hMode).arg(passband);
@@ -685,14 +878,22 @@ QString RigctlProtocol::cmdGetSplitMode()
 
 QString RigctlProtocol::cmdSetSplitMode(const QString& args)
 {
-    auto* txSlice = findTxSlice();
-    if (!txSlice) return rprt(-1);
     QStringList parts = args.split(' ', Qt::SkipEmptyParts);
     if (parts.isEmpty()) return rprt(-1);
     QString mode = parts[0];
     if (mode == "PKTUSB") mode = "DIGU";
     else if (mode == "PKTLSB") mode = "DIGL";
     else if (mode == "AMS") mode = "SAM";
+
+    if (m_catSplitEnabled) {
+        m_pendingSplitMode = mode;
+        if (auto* txSlice = ensureCatSplitTxSlice(true))
+            applyPendingSplitSettings(txSlice);
+        return rprt(0);
+    }
+
+    auto* txSlice = findTxSlice();
+    if (!txSlice) return rprt(-1);
     txSlice->setMode(mode);
     return rprt(0);
 }

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -210,19 +210,21 @@ QString RigctlProtocol::handleLine(const QString& line)
     if (trimmed.isEmpty())
         return {};
 
-    // Check for extended mode prefix
-    if (!trimmed.isEmpty() && (trimmed[0] == '+' || trimmed[0] == ';')) {
-        if (trimmed[0] == '+') {
-            m_extended = true;
-            trimmed = trimmed.mid(1);
-        }
+    const bool savedExtended = m_extended;
+    bool commandExtended = false;
+
+    // Hamlib's leading '+' requests extended response framing for this
+    // command only; it is reset after the response is emitted.
+    if (!trimmed.isEmpty() && trimmed[0] == '+') {
+        commandExtended = true;
+        m_extended = true;
+        trimmed = trimmed.mid(1);
     }
 
     // Pipe separator mode: '|' splits commands and implies extended responses
     // joined by '|' instead of newlines (standard rigctld wire protocol).
     const bool pipeMode = trimmed.contains('|');
     if (pipeMode) {
-        const bool savedExtended = m_extended;
         m_extended = true;
 
         QStringList cmds = trimmed.split('|', Qt::SkipEmptyParts);
@@ -246,6 +248,8 @@ QString RigctlProtocol::handleLine(const QString& line)
     for (const auto& cmd : cmds) {
         response += processCommand(cmd.trimmed());
     }
+    if (commandExtended)
+        m_extended = savedExtended;
     return response;
 }
 
@@ -290,8 +294,9 @@ QString RigctlProtocol::processCommand(const QString& cmd)
         if (name == "dump_state")     return cmdDumpState();
         if (name == "quit")           return {};  // caller handles disconnect
         if (name == "chk_vfo")        return QStringLiteral("0\n");  // VFO mode disabled
-        if (name == "send_morse")    return cmdSendMorse(args);
-        if (name == "stop_morse")    return cmdStopMorse();
+        if (name == "send_morse")     return cmdSendMorse(args);
+        if (name == "stop_morse")     return cmdStopMorse();
+        if (name == "wait_morse")     return cmdWaitMorse();
 
         return rprt(-4);  // RIG_EINVAL
     }
@@ -491,7 +496,9 @@ QString RigctlProtocol::cmdGetVfoInfo(const QString& arg)
     constexpr int satMode = 0;
 
     if (m_extended) {
-        return QStringLiteral("get_vfo_info:\nFreq: %1\nMode: %2\nWidth: %3\nSplit: %4\nSatMode: %5\n")
+        // MacLoggerDX sends +\get_vfo_info but parses the payload as the
+        // five positional values from Hamlib's non-extended response.
+        return QStringLiteral("get_vfo_info:\n%1\n%2\n%3\n%4\n%5\n")
             .arg(hz)
             .arg(mode)
             .arg(width)
@@ -913,9 +920,8 @@ QString RigctlProtocol::cmdSendMorse(const QString& text)
         m_pendingMorseLine = true;
         return {};
     }
-    QString cmd = QString("cwx send \"%1\"").arg(text);
-    QMetaObject::invokeMethod(m_model, [this, cmd]() {
-        m_model->sendCmdPublic(cmd, nullptr);
+    QMetaObject::invokeMethod(m_model, [this, text]() {
+        m_model->cwxModel().send(text);
     }, Qt::QueuedConnection);
     return rprt(0);
 }
@@ -924,8 +930,14 @@ QString RigctlProtocol::cmdStopMorse()
 {
     if (!m_model) return rprt(-1);
     QMetaObject::invokeMethod(m_model, [this]() {
-        m_model->sendCmdPublic("cwx clear", nullptr);
+        m_model->cwxModel().clearBuffer();
     }, Qt::QueuedConnection);
+    return rprt(0);
+}
+
+QString RigctlProtocol::cmdWaitMorse()
+{
+    if (!m_model) return rprt(-1);
     return rprt(0);
 }
 

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -4,15 +4,12 @@
 #include "models/TransmitModel.h"
 
 #include <QByteArray>
-#include <QHash>
 #include <QLocale>
 #include <QMetaObject>
 #include <QStringList>
-#include <QTimer>
 #include <QtGlobal>
 
 #include <cmath>
-#include <memory>
 
 namespace AetherSDR {
 
@@ -25,7 +22,6 @@ constexpr quint64 kRigLevelRfPowerMeter      = (1ULL << 32);
 constexpr quint64 kRigLevelRfPowerMeterWatts = (1ULL << 39);
 constexpr qint64  kTxMeterFreshMs            = 1500;
 constexpr int     kHamlibSmartSdrSliceAModel = 23005;
-constexpr int     kMorseCompletionGraceMs    = 350;
 constexpr quint64 kRigGetLevelMask = kRigLevelRfPower
                                    | kRigLevelKeyspd
                                    | kRigLevelSwr
@@ -94,67 +90,6 @@ QString formatRigLevelValue(double value)
     if (text == "-0" || text == "-0.0")
         text = "0";
     return text;
-}
-
-const QHash<QChar, QString>& morseTable()
-{
-    static const QHash<QChar, QString> table = {
-        {'A', ".-"},    {'B', "-..."},  {'C', "-.-."},  {'D', "-.."},
-        {'E', "."},     {'F', "..-."},  {'G', "--."},   {'H', "...."},
-        {'I', ".."},    {'J', ".---"},  {'K', "-.-"},   {'L', ".-.."},
-        {'M', "--"},    {'N', "-."},    {'O', "---"},   {'P', ".--."},
-        {'Q', "--.-"},  {'R', ".-."},   {'S', "..."},   {'T', "-"},
-        {'U', "..-"},   {'V', "...-"},  {'W', ".--"},   {'X', "-..-"},
-        {'Y', "-.--"},  {'Z', "--.."},
-        {'0', "-----"}, {'1', ".----"}, {'2', "..---"}, {'3', "...--"},
-        {'4', "....-"}, {'5', "....."}, {'6', "-...."}, {'7', "--..."},
-        {'8', "---.."}, {'9', "----."},
-        {'.', ".-.-.-"},{',', "--..--"},{'?', "..--.."},{'\'',".----."},
-        {'!', "-.-.--"},{'/', "-..-."}, {'(', "-.--."}, {')', "-.--.-"},
-        {'&', ".-..."}, {':', "---..."},{';', "-.-.-."},{'=', "-...-"},
-        {'+', ".-.-."}, {'-', "-....-"},{'_', "..--.-"},{'"', ".-..-."},
-        {'$', "...-..-"},{'@', ".--.-."},
-    };
-    return table;
-}
-
-int estimateMorseDurationMs(const QString& text, int wpm)
-{
-    const int clampedWpm = qBound(5, wpm, 100);
-    const int unitMs = qMax(1, qRound(1200.0 / clampedWpm));
-    const auto& table = morseTable();
-    int units = 0;
-    bool firstChar = true;
-
-    for (const QChar raw : text.toUpper()) {
-        if (raw.isSpace() || raw == QChar(0x7f)) {
-            if (units > 0)
-                units += 7;
-            firstChar = true;
-            continue;
-        }
-
-        const auto it = table.find(raw);
-        if (it == table.end()) {
-            if (units > 0)
-                units += 7;
-            firstChar = true;
-            continue;
-        }
-
-        if (!firstChar)
-            units += 3;
-        firstChar = false;
-
-        const QString& pattern = it.value();
-        for (int i = 0; i < pattern.size(); ++i) {
-            if (i > 0)
-                units += 1;
-            units += (pattern[i] == '.') ? 1 : 3;
-        }
-    }
-
-    return units * unitMs + 500;
 }
 
 } // namespace
@@ -260,62 +195,6 @@ SliceModel* RigctlProtocol::sliceForVfo(const QString& vfo) const
 QString RigctlProtocol::rprt(int code) const
 {
     return QStringLiteral("RPRT %1\n").arg(code);
-}
-
-void RigctlProtocol::scheduleMorseAck(const QString& text)
-{
-    if (!m_model || !m_asyncResponder)
-        return;
-
-    auto* cwx = &m_model->cwxModel();
-    const int expectedChars = text.size();
-    const int timeoutMs = estimateMorseDurationMs(text, cwx->speed());
-    const auto responder = m_asyncResponder;
-
-    auto pending = std::make_shared<bool>(true);
-    m_asyncResponsePending = pending;
-    auto sentConn = std::make_shared<QMetaObject::Connection>();
-    auto erasedConn = std::make_shared<QMetaObject::Connection>();
-    auto cancelConn = std::make_shared<QMetaObject::Connection>();
-    auto finish = [pending, responder, sentConn, erasedConn, cancelConn]() mutable {
-        if (!*pending)
-            return;
-        *pending = false;
-        QObject::disconnect(*sentConn);
-        QObject::disconnect(*erasedConn);
-        QObject::disconnect(*cancelConn);
-        responder(QStringLiteral("RPRT 0\n"));
-    };
-    m_completeAsyncResponse = finish;
-
-    auto sentCount = std::make_shared<int>(0);
-    *sentConn = QObject::connect(cwx, &CwxModel::charSent, cwx,
-        [cwx, expectedChars, sentCount, finish](int) mutable {
-            ++(*sentCount);
-            if (*sentCount >= expectedChars) {
-                QTimer::singleShot(kMorseCompletionGraceMs, cwx, [finish]() mutable {
-                    finish();
-                });
-            }
-        });
-    *erasedConn = QObject::connect(cwx, &CwxModel::erased, cwx,
-        [finish](int, int) mutable {
-            finish();
-        });
-    *cancelConn = QObject::connect(cwx, &CwxModel::transmissionCancelled, cwx,
-        [finish]() mutable {
-            finish();
-        });
-
-    QTimer::singleShot(timeoutMs, cwx, [finish]() mutable {
-        finish();
-    });
-}
-
-void RigctlProtocol::completePendingAsyncResponse()
-{
-    if (hasPendingAsyncResponse() && m_completeAsyncResponse)
-        m_completeAsyncResponse();
 }
 
 // ── Main entry point ────────────────────────────────────────────────────────
@@ -1046,21 +925,16 @@ QString RigctlProtocol::cmdSendMorse(const QString& text)
         m_pendingMorseLine = true;
         return {};
     }
-    const bool asyncAck = static_cast<bool>(m_asyncResponder);
-    if (asyncAck)
-        scheduleMorseAck(text);
-
     auto* model = m_model;
     QMetaObject::invokeMethod(model, [model, text]() {
         model->cwxModel().send(text);
     }, Qt::QueuedConnection);
-    return asyncAck ? QString() : rprt(0);
+    return rprt(0);
 }
 
 QString RigctlProtocol::cmdStopMorse()
 {
     if (!m_model) return rprt(-1);
-    completePendingAsyncResponse();
     auto* model = m_model;
     QMetaObject::invokeMethod(model, [model]() {
         model->cwxModel().clearBuffer();

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -40,9 +40,12 @@ private:
     QString cmdSetMode(const QString& args);
     QString cmdGetVfo();
     QString cmdSetVfo(const QString& arg);
+    QString cmdGetVfoInfo(const QString& arg);
+    QString cmdGetVfoList();
     QString cmdGetPtt();
     QString cmdSetPtt(const QString& arg);
     QString cmdGetInfo();
+    QString cmdGetRigInfo();
     QString cmdGetSplitVfo();
     QString cmdSetSplitVfo(const QString& args);
     QString cmdGetSplitFreq();
@@ -51,6 +54,10 @@ private:
     QString cmdSetSplitMode(const QString& args);
     QString cmdGetLevel(const QString& arg);
     QString cmdSetLevel(const QString& args);
+    QString cmdSetFunc(const QString& args);
+    QString cmdVfoOp(const QString& args);
+    QString cmdSetTrn(const QString& args);
+    QString cmdGetTrn();
     QString cmdDumpState();
     QString cmdSendMorse(const QString& text);  // b <text> / \send_morse
     QString cmdStopMorse();                     // \stop_morse
@@ -58,6 +65,7 @@ private:
 
     // Helpers
     SliceModel* currentSlice() const;
+    SliceModel* sliceForVfo(const QString& vfo) const;
     SliceModel* findTxSlice() const;
     QString rprt(int code) const;
 

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -3,6 +3,10 @@
 #include <QString>
 #include <QMap>
 
+#include <functional>
+#include <memory>
+#include <utility>
+
 namespace AetherSDR {
 
 class RadioModel;
@@ -14,6 +18,13 @@ class SliceModel;
 class RigctlProtocol {
 public:
     explicit RigctlProtocol(RadioModel* model);
+
+    using AsyncResponder = std::function<void(const QString&)>;
+    void setAsyncResponder(AsyncResponder responder) { m_asyncResponder = std::move(responder); }
+    bool hasPendingAsyncResponse() const
+    {
+        return m_asyncResponsePending && *m_asyncResponsePending;
+    }
 
     // Process one command line (may contain ';' or '|'-separated batch commands).
     // '|' separator enables extended responses joined by '|' (rigctld pipe mode).
@@ -69,6 +80,7 @@ private:
     SliceModel* sliceForVfo(const QString& vfo) const;
     SliceModel* findTxSlice() const;
     QString rprt(int code) const;
+    void scheduleMorseAck(const QString& text);
 
     // Mode conversion tables
     static QString smartsdrToHamlib(const QString& mode);
@@ -82,6 +94,8 @@ private:
     // The next line is consumed verbatim as the morse text. Hamlib spec
     // allows this two-line form and Not1MM contest CW relies on it.
     bool m_pendingMorseLine{false};
+    AsyncResponder m_asyncResponder;
+    std::shared_ptr<bool> m_asyncResponsePending;
 };
 
 } // namespace AetherSDR

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -1,7 +1,10 @@
 #pragma once
 
-#include <QString>
 #include <QMap>
+#include <QMetaObject>
+#include <QString>
+
+#include <functional>
 
 namespace AetherSDR {
 
@@ -14,6 +17,12 @@ class SliceModel;
 class RigctlProtocol {
 public:
     explicit RigctlProtocol(RadioModel* model);
+    ~RigctlProtocol();
+
+    // Called once by the server/PTY to give us a direct-write path for
+    // deferred responses (e.g. wait_morse blocking until CWX drains).
+    void setWriteCallback(std::function<void(const QString&)> fn)
+        { m_writeCallback = std::move(fn); }
 
     // Process one command line (may contain ';' or '|'-separated batch commands).
     // '|' separator enables extended responses joined by '|' (rigctld pipe mode).
@@ -95,6 +104,11 @@ private:
     // The next line is consumed verbatim as the morse text. Hamlib spec
     // allows this two-line form and Not1MM contest CW relies on it.
     bool m_pendingMorseLine{false};
+    // Callback for deferred writes (set once by server/PTY on creation).
+    std::function<void(const QString&)> m_writeCallback;
+    // Active Qt connection for a deferred wait_morse response.
+    // Disconnected in the destructor and cancelled by stop_morse.
+    QMetaObject::Connection m_pendingMorseConn;
 };
 
 } // namespace AetherSDR

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -68,6 +68,11 @@ private:
     SliceModel* currentSlice() const;
     SliceModel* sliceForVfo(const QString& vfo) const;
     SliceModel* findTxSlice() const;
+    SliceModel* findCatSplitTxSlice() const;
+    SliceModel* ensureCatSplitTxSlice(bool createIfMissing);
+    void applyPendingSplitSettings(SliceModel* txSlice);
+    void requestCatSplitSlice(double initialFreqMhz);
+    double defaultSplitTxFrequencyMhz(const SliceModel* rxSlice) const;
     QString rprt(int code) const;
 
     // Mode conversion tables
@@ -78,6 +83,14 @@ private:
     RadioModel* m_model;
     int  m_sliceIndex{0};
     bool m_extended{false};
+    bool m_catSplitEnabled{false};
+    bool m_catSplitCreatePending{false};
+    bool m_catSplitOwnsTxSlice{false};
+    bool m_hasPendingSplitFreq{false};
+    int m_catSplitRxSliceId{-1};
+    int m_catSplitTxSliceId{-1};
+    double m_pendingSplitFreqMhz{0.0};
+    QString m_pendingSplitMode;
     // Set when a bare `b` / `\send_morse` arrives without inline text.
     // The next line is consumed verbatim as the morse text. Hamlib spec
     // allows this two-line form and Not1MM contest CW relies on it.

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -81,6 +81,7 @@ private:
     SliceModel* findTxSlice() const;
     QString rprt(int code) const;
     void scheduleMorseAck(const QString& text);
+    void completePendingAsyncResponse();
 
     // Mode conversion tables
     static QString smartsdrToHamlib(const QString& mode);
@@ -96,6 +97,7 @@ private:
     bool m_pendingMorseLine{false};
     AsyncResponder m_asyncResponder;
     std::shared_ptr<bool> m_asyncResponsePending;
+    std::function<void()> m_completeAsyncResponse;
 };
 
 } // namespace AetherSDR

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -3,10 +3,6 @@
 #include <QString>
 #include <QMap>
 
-#include <functional>
-#include <memory>
-#include <utility>
-
 namespace AetherSDR {
 
 class RadioModel;
@@ -18,13 +14,6 @@ class SliceModel;
 class RigctlProtocol {
 public:
     explicit RigctlProtocol(RadioModel* model);
-
-    using AsyncResponder = std::function<void(const QString&)>;
-    void setAsyncResponder(AsyncResponder responder) { m_asyncResponder = std::move(responder); }
-    bool hasPendingAsyncResponse() const
-    {
-        return m_asyncResponsePending && *m_asyncResponsePending;
-    }
 
     // Process one command line (may contain ';' or '|'-separated batch commands).
     // '|' separator enables extended responses joined by '|' (rigctld pipe mode).
@@ -80,8 +69,6 @@ private:
     SliceModel* sliceForVfo(const QString& vfo) const;
     SliceModel* findTxSlice() const;
     QString rprt(int code) const;
-    void scheduleMorseAck(const QString& text);
-    void completePendingAsyncResponse();
 
     // Mode conversion tables
     static QString smartsdrToHamlib(const QString& mode);
@@ -95,9 +82,6 @@ private:
     // The next line is consumed verbatim as the morse text. Hamlib spec
     // allows this two-line form and Not1MM contest CW relies on it.
     bool m_pendingMorseLine{false};
-    AsyncResponder m_asyncResponder;
-    std::shared_ptr<bool> m_asyncResponsePending;
-    std::function<void()> m_completeAsyncResponse;
 };
 
 } // namespace AetherSDR

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -61,6 +61,7 @@ private:
     QString cmdDumpState();
     QString cmdSendMorse(const QString& text);  // b <text> / \send_morse
     QString cmdStopMorse();                     // \stop_morse
+    QString cmdWaitMorse();                     // \wait_morse
     QString cmdSetKeySpeed(const QString& arg); // \set_level KEYSPD <wpm>
 
     // Helpers

--- a/src/core/RigctlPty.cpp
+++ b/src/core/RigctlPty.cpp
@@ -3,6 +3,7 @@
 #include "RigctlProtocol.h"
 #include "models/RadioModel.h"
 
+#include <QPointer>
 #include <QSocketNotifier>
 
 #ifndef _WIN32
@@ -68,6 +69,13 @@ bool RigctlPty::start()
     // Set up protocol handler
     m_protocol = new RigctlProtocol(m_model);
     m_protocol->setSliceIndex(m_sliceIndex);
+    QPointer<RigctlPty> self(this);
+    m_protocol->setAsyncResponder([self](const QString& response) {
+        if (!self || self->m_masterFd < 0 || response.isEmpty())
+            return;
+        const QByteArray data = response.toUtf8();
+        ::write(self->m_masterFd, data.constData(), data.size());
+    });
 
     // Watch for data on the master FD
     m_notifier = new QSocketNotifier(m_masterFd, QSocketNotifier::Read, this);

--- a/src/core/RigctlPty.cpp
+++ b/src/core/RigctlPty.cpp
@@ -3,7 +3,6 @@
 #include "RigctlProtocol.h"
 #include "models/RadioModel.h"
 
-#include <QPointer>
 #include <QSocketNotifier>
 
 #ifndef _WIN32
@@ -69,13 +68,6 @@ bool RigctlPty::start()
     // Set up protocol handler
     m_protocol = new RigctlProtocol(m_model);
     m_protocol->setSliceIndex(m_sliceIndex);
-    QPointer<RigctlPty> self(this);
-    m_protocol->setAsyncResponder([self](const QString& response) {
-        if (!self || self->m_masterFd < 0 || response.isEmpty())
-            return;
-        const QByteArray data = response.toUtf8();
-        ::write(self->m_masterFd, data.constData(), data.size());
-    });
 
     // Watch for data on the master FD
     m_notifier = new QSocketNotifier(m_masterFd, QSocketNotifier::Read, this);

--- a/src/core/RigctlPty.cpp
+++ b/src/core/RigctlPty.cpp
@@ -69,6 +69,15 @@ bool RigctlPty::start()
     m_protocol = new RigctlProtocol(m_model);
     m_protocol->setSliceIndex(m_sliceIndex);
 
+    // Give the protocol a write path for deferred responses (e.g. wait_morse).
+    // Capture masterFd by value; stop() sets m_masterFd=-1 which is harmless
+    // since the protocol is deleted in stop() before the fd is closed.
+    int masterFd = m_masterFd;
+    m_protocol->setWriteCallback([masterFd](const QString& r) {
+        QByteArray data = r.toUtf8();
+        ::write(masterFd, data.constData(), data.size());
+    });
+
     // Watch for data on the master FD
     m_notifier = new QSocketNotifier(m_masterFd, QSocketNotifier::Read, this);
     connect(m_notifier, &QSocketNotifier::activated, this, &RigctlPty::onDataReady);

--- a/src/core/RigctlServer.cpp
+++ b/src/core/RigctlServer.cpp
@@ -3,6 +3,9 @@
 #include "RigctlProtocol.h"
 #include "models/RadioModel.h"
 
+#include <QMetaObject>
+#include <QPointer>
+
 namespace AetherSDR {
 
 RigctlServer::RigctlServer(RadioModel* model, QObject* parent)
@@ -78,6 +81,22 @@ void RigctlServer::onNewConnection()
         socket->setSocketOption(QAbstractSocket::LowDelayOption, 1);  // TCP_NODELAY
         auto* protocol = new RigctlProtocol(m_model);
         protocol->setSliceIndex(m_sliceIndex);
+        QPointer<RigctlServer> self(this);
+        QPointer<QTcpSocket> socketPtr(socket);
+        protocol->setAsyncResponder([self, socketPtr](const QString& response) {
+            if (!socketPtr || response.isEmpty())
+                return;
+            if (socketPtr->state() != QAbstractSocket::ConnectedState)
+                return;
+            qCDebug(lcCat) << "rigctld async resp:" << response.left(60).trimmed();
+            socketPtr->write(response.toUtf8());
+            if (self) {
+                QMetaObject::invokeMethod(self, [self, socketPtr]() {
+                    if (self && socketPtr)
+                        self->processClientData(socketPtr);
+                }, Qt::QueuedConnection);
+            }
+        });
 
         ClientState cs;
         cs.socket = socket;
@@ -97,6 +116,13 @@ void RigctlServer::onClientData()
     auto* socket = qobject_cast<QTcpSocket*>(sender());
     if (!socket) return;
 
+    processClientData(socket);
+}
+
+void RigctlServer::processClientData(QTcpSocket* socket)
+{
+    if (!socket) return;
+
     // Find the client state
     int idx = -1;
     for (int i = 0; i < m_clients.size(); ++i) {
@@ -105,10 +131,16 @@ void RigctlServer::onClientData()
     if (idx < 0) return;
 
     auto& cs = m_clients[idx];
+    if (cs.protocol->hasPendingAsyncResponse())
+        return;
+
     cs.buffer.append(socket->readAll());
 
     // Process complete lines
     while (true) {
+        if (cs.protocol->hasPendingAsyncResponse())
+            return;
+
         int nlPos = cs.buffer.indexOf('\n');
         if (nlPos < 0) break;
 
@@ -127,6 +159,9 @@ void RigctlServer::onClientData()
             qCDebug(lcCat) << "rigctld cmd:" << trimmed
                      << "-> resp:" << response.left(60).trimmed();
             socket->write(response.toUtf8());
+        } else if (cs.protocol->hasPendingAsyncResponse()) {
+            qCDebug(lcCat) << "rigctld cmd:" << trimmed << "-> async resp pending";
+            return;
         }
     }
 }

--- a/src/core/RigctlServer.cpp
+++ b/src/core/RigctlServer.cpp
@@ -74,6 +74,17 @@ quint16 RigctlServer::port() const
     return m_server ? m_server->serverPort() : 0;
 }
 
+bool RigctlServer::canProcessWhileAsyncPending(const QString& line)
+{
+    QString trimmed = line.trimmed();
+    while (trimmed.startsWith('+'))
+        trimmed = trimmed.mid(1).trimmed();
+
+    return trimmed == "q"
+        || trimmed == "\\quit"
+        || trimmed == "\\stop_morse";
+}
+
 void RigctlServer::onNewConnection()
 {
     while (m_server->hasPendingConnections()) {
@@ -131,24 +142,23 @@ void RigctlServer::processClientData(QTcpSocket* socket)
     if (idx < 0) return;
 
     auto& cs = m_clients[idx];
-    if (cs.protocol->hasPendingAsyncResponse())
-        return;
-
     cs.buffer.append(socket->readAll());
 
     // Process complete lines
     while (true) {
-        if (cs.protocol->hasPendingAsyncResponse())
-            return;
-
         int nlPos = cs.buffer.indexOf('\n');
         if (nlPos < 0) break;
 
         QString line = QString::fromUtf8(cs.buffer.left(nlPos));
+        QString trimmed = line.trimmed();
+        if (cs.protocol->hasPendingAsyncResponse()
+            && !canProcessWhileAsyncPending(trimmed)) {
+            return;
+        }
+
         cs.buffer.remove(0, nlPos + 1);
 
         // Check for quit
-        QString trimmed = line.trimmed();
         if (trimmed == "q" || trimmed == "\\quit") {
             socket->disconnectFromHost();
             return;

--- a/src/core/RigctlServer.cpp
+++ b/src/core/RigctlServer.cpp
@@ -3,6 +3,8 @@
 #include "RigctlProtocol.h"
 #include "models/RadioModel.h"
 
+#include <QPointer>
+
 namespace AetherSDR {
 
 RigctlServer::RigctlServer(RadioModel* model, QObject* parent)
@@ -78,6 +80,15 @@ void RigctlServer::onNewConnection()
         socket->setSocketOption(QAbstractSocket::LowDelayOption, 1);  // TCP_NODELAY
         auto* protocol = new RigctlProtocol(m_model);
         protocol->setSliceIndex(m_sliceIndex);
+
+        // Give the protocol a safe write path for deferred responses
+        // (e.g. wait_morse). QPointer guards against use-after-free if
+        // the socket is destroyed before queueEmpty fires.
+        QPointer<QTcpSocket> safeSocket = socket;
+        protocol->setWriteCallback([safeSocket](const QString& r) {
+            if (safeSocket)
+                safeSocket->write(r.toUtf8());
+        });
 
         ClientState cs;
         cs.socket = socket;

--- a/src/core/RigctlServer.cpp
+++ b/src/core/RigctlServer.cpp
@@ -3,9 +3,6 @@
 #include "RigctlProtocol.h"
 #include "models/RadioModel.h"
 
-#include <QMetaObject>
-#include <QPointer>
-
 namespace AetherSDR {
 
 RigctlServer::RigctlServer(RadioModel* model, QObject* parent)
@@ -74,17 +71,6 @@ quint16 RigctlServer::port() const
     return m_server ? m_server->serverPort() : 0;
 }
 
-bool RigctlServer::canProcessWhileAsyncPending(const QString& line)
-{
-    QString trimmed = line.trimmed();
-    while (trimmed.startsWith('+'))
-        trimmed = trimmed.mid(1).trimmed();
-
-    return trimmed == "q"
-        || trimmed == "\\quit"
-        || trimmed == "\\stop_morse";
-}
-
 void RigctlServer::onNewConnection()
 {
     while (m_server->hasPendingConnections()) {
@@ -92,22 +78,6 @@ void RigctlServer::onNewConnection()
         socket->setSocketOption(QAbstractSocket::LowDelayOption, 1);  // TCP_NODELAY
         auto* protocol = new RigctlProtocol(m_model);
         protocol->setSliceIndex(m_sliceIndex);
-        QPointer<RigctlServer> self(this);
-        QPointer<QTcpSocket> socketPtr(socket);
-        protocol->setAsyncResponder([self, socketPtr](const QString& response) {
-            if (!socketPtr || response.isEmpty())
-                return;
-            if (socketPtr->state() != QAbstractSocket::ConnectedState)
-                return;
-            qCDebug(lcCat) << "rigctld async resp:" << response.left(60).trimmed();
-            socketPtr->write(response.toUtf8());
-            if (self) {
-                QMetaObject::invokeMethod(self, [self, socketPtr]() {
-                    if (self && socketPtr)
-                        self->processClientData(socketPtr);
-                }, Qt::QueuedConnection);
-            }
-        });
 
         ClientState cs;
         cs.socket = socket;
@@ -150,15 +120,10 @@ void RigctlServer::processClientData(QTcpSocket* socket)
         if (nlPos < 0) break;
 
         QString line = QString::fromUtf8(cs.buffer.left(nlPos));
-        QString trimmed = line.trimmed();
-        if (cs.protocol->hasPendingAsyncResponse()
-            && !canProcessWhileAsyncPending(trimmed)) {
-            return;
-        }
-
         cs.buffer.remove(0, nlPos + 1);
 
         // Check for quit
+        QString trimmed = line.trimmed();
         if (trimmed == "q" || trimmed == "\\quit") {
             socket->disconnectFromHost();
             return;
@@ -169,9 +134,6 @@ void RigctlServer::processClientData(QTcpSocket* socket)
             qCDebug(lcCat) << "rigctld cmd:" << trimmed
                      << "-> resp:" << response.left(60).trimmed();
             socket->write(response.toUtf8());
-        } else if (cs.protocol->hasPendingAsyncResponse()) {
-            qCDebug(lcCat) << "rigctld cmd:" << trimmed << "-> async resp pending";
-            return;
         }
     }
 }

--- a/src/core/RigctlServer.h
+++ b/src/core/RigctlServer.h
@@ -39,6 +39,8 @@ private slots:
     void onClientDisconnected();
 
 private:
+    void processClientData(QTcpSocket* socket);
+
     struct ClientState {
         QTcpSocket*     socket{nullptr};
         RigctlProtocol* protocol{nullptr};

--- a/src/core/RigctlServer.h
+++ b/src/core/RigctlServer.h
@@ -40,7 +40,6 @@ private slots:
 
 private:
     void processClientData(QTcpSocket* socket);
-    static bool canProcessWhileAsyncPending(const QString& line);
 
     struct ClientState {
         QTcpSocket*     socket{nullptr};

--- a/src/core/RigctlServer.h
+++ b/src/core/RigctlServer.h
@@ -40,6 +40,7 @@ private slots:
 
 private:
     void processClientData(QTcpSocket* socket);
+    static bool canProcessWhileAsyncPending(const QString& line);
 
     struct ClientState {
         QTcpSocket*     socket{nullptr};

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -84,6 +84,7 @@ public:
     float paTemp()    const { return m_paTemp; }
     float txPower()   const { return m_txPower; }
     bool  isRadioTransmitting() const { return m_radioTransmitting; }
+    bool  isCwxActive()         const { return m_cwxActive; }
     QStringList antennaList() const { return m_antList; }
     QString serial()       const;
     QString chassisSerial() const { return m_chassisSerial; }

--- a/tests/cwx_model_queue_test.cpp
+++ b/tests/cwx_model_queue_test.cpp
@@ -1,0 +1,247 @@
+// CwxModel queue-drain signal tests.
+// Covers the queueEmpty path that wait_morse and the #2450 TX-release fix
+// both depend on.
+// Run: ./build/cwx_model_queue_test
+
+#include "models/CwxModel.h"
+
+#include <QCoreApplication>
+#include <QMap>
+#include <QStringList>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void check(bool ok, const char* name)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) ++g_failed;
+}
+
+// ── queueEmpty signal ────────────────────────────────────────────────────────
+
+void testQueueEmptyOnEmptyValue()
+{
+    CwxModel model;
+    int fired = 0;
+    QObject::connect(&model, &CwxModel::queueEmpty, [&]() { ++fired; });
+
+    model.applyStatus({{"queue", ""}});
+    check(fired == 1, "queueEmpty fires when queue= has empty value");
+}
+
+void testQueueEmptyOnZeroValue()
+{
+    CwxModel model;
+    int fired = 0;
+    QObject::connect(&model, &CwxModel::queueEmpty, [&]() { ++fired; });
+
+    model.applyStatus({{"queue", "0"}});
+    check(fired == 1, "queueEmpty fires when queue=0");
+}
+
+void testQueueEmptyNotFiredOnNonEmptyQueue()
+{
+    CwxModel model;
+    int fired = 0;
+    QObject::connect(&model, &CwxModel::queueEmpty, [&]() { ++fired; });
+
+    model.applyStatus({{"queue", "3"}});
+    check(fired == 0, "queueEmpty does NOT fire when queue=3 (items pending)");
+}
+
+void testQueueEmptyNotFiredOnNonQueueKey()
+{
+    CwxModel model;
+    int fired = 0;
+    QObject::connect(&model, &CwxModel::queueEmpty, [&]() { ++fired; });
+
+    model.applyStatus({{"wpm", "20"}, {"sent", "5"}});
+    check(fired == 0, "queueEmpty does NOT fire on unrelated status keys");
+}
+
+void testQueueEmptyFiresOnlyForEmptyAmongMixedKeys()
+{
+    CwxModel model;
+    int fired = 0;
+    QObject::connect(&model, &CwxModel::queueEmpty, [&]() { ++fired; });
+
+    model.applyStatus({{"wpm", "20"}, {"queue", ""}, {"sent", "2"}});
+    check(fired == 1, "queueEmpty fires exactly once in a mixed-key applyStatus");
+}
+
+void testQueueEmptyMultipleUpdates()
+{
+    CwxModel model;
+    int fired = 0;
+    QObject::connect(&model, &CwxModel::queueEmpty, [&]() { ++fired; });
+
+    model.applyStatus({{"queue", ""}});
+    model.applyStatus({{"queue", "0"}});
+    check(fired == 2, "queueEmpty fires independently on each drain status");
+}
+
+// ── send() / block counter ───────────────────────────────────────────────────
+
+void testSendEmitsCommandReady()
+{
+    CwxModel model;
+    QStringList cmds;
+    QObject::connect(&model, &CwxModel::commandReady,
+                     [&](const QString& cmd) { cmds << cmd; });
+
+    model.send("CQ");
+    check(cmds.size() == 1, "send() emits exactly one commandReady");
+    check(cmds[0].startsWith("cwx send"), "commandReady starts with 'cwx send'");
+    check(cmds[0].contains("\"CQ\""), "commandReady includes the CW text");
+}
+
+void testSendBlockCounterIncrements()
+{
+    CwxModel model;
+    QStringList cmds;
+    QObject::connect(&model, &CwxModel::commandReady,
+                     [&](const QString& cmd) { cmds << cmd; });
+
+    model.send("DE");
+    model.send("W1AW");
+    check(cmds.size() == 2, "two sends emit two commands");
+    // Command format: "cwx send \"TEXT\" N" — block number is the last token
+    int n0 = cmds[0].split(' ').last().toInt();
+    int n1 = cmds[1].split(' ').last().toInt();
+    check(n0 >= 1,         "first block number is >= 1");
+    check(n1 == n0 + 1,    "block counter increments by 1 per send()");
+}
+
+void testSendEmptyIsNoop()
+{
+    CwxModel model;
+    int cmdCount = 0;
+    QObject::connect(&model, &CwxModel::commandReady,
+                     [&](const QString&) { ++cmdCount; });
+
+    model.send("");
+    check(cmdCount == 0, "send(\"\") emits no commandReady");
+}
+
+void testSendSpaceEncodedAsDel()
+{
+    CwxModel model;
+    QStringList cmds;
+    QObject::connect(&model, &CwxModel::commandReady,
+                     [&](const QString& cmd) { cmds << cmd; });
+
+    model.send("CQ CQ");
+    check(!cmds.isEmpty(), "send with space emits command");
+    // Command format: cwx send "CQ\x7fCQ" N — check the quoted payload only
+    int qStart = cmds[0].indexOf('"');
+    int qEnd   = cmds[0].lastIndexOf('"');
+    const QString encoded = (qStart >= 0 && qEnd > qStart)
+        ? cmds[0].mid(qStart + 1, qEnd - qStart - 1) : QString{};
+    check(encoded.contains(QChar(0x7f)), "space encoded as DEL (0x7f) in payload");
+    check(!encoded.contains(' '),        "no bare space in quoted payload");
+}
+
+// ── clearBuffer ──────────────────────────────────────────────────────────────
+
+void testClearBufferEmitsCommandAndCancellation()
+{
+    CwxModel model;
+    QStringList cmds;
+    int cancelled = 0;
+    QObject::connect(&model, &CwxModel::commandReady,
+                     [&](const QString& cmd) { cmds << cmd; });
+    QObject::connect(&model, &CwxModel::transmissionCancelled,
+                     [&]() { ++cancelled; });
+
+    model.clearBuffer();
+    check(cmds.size() == 1 && cmds[0] == "cwx clear",
+          "clearBuffer() sends 'cwx clear' command");
+    check(cancelled == 1, "clearBuffer() emits transmissionCancelled");
+}
+
+// ── speed / delay ────────────────────────────────────────────────────────────
+
+void testSetSpeedClamped()
+{
+    CwxModel model;
+    QStringList cmds;
+    QObject::connect(&model, &CwxModel::commandReady,
+                     [&](const QString& cmd) { cmds << cmd; });
+
+    model.setSpeed(3);    // below minimum (5)
+    model.setSpeed(200);  // above maximum (100)
+    check(cmds.size() == 2, "setSpeed sends two commands even when clamped");
+    check(cmds[0].endsWith("5"),   "speed clamped to 5 at low end");
+    check(cmds[1].endsWith("100"), "speed clamped to 100 at high end");
+}
+
+void testApplyStatusWpm()
+{
+    CwxModel model;
+    int speedSignals = 0;
+    QObject::connect(&model, &CwxModel::speedChanged,
+                     [&](int) { ++speedSignals; });
+
+    model.applyStatus({{"wpm", "25"}});
+    check(speedSignals == 1, "applyStatus wpm=25 fires speedChanged");
+    check(model.speed() == 25, "speed() returns 25 after applyStatus");
+}
+
+void testApplyStatusWpmNoDuplicateSignal()
+{
+    CwxModel model;
+    model.applyStatus({{"wpm", "20"}});
+
+    int speedSignals = 0;
+    QObject::connect(&model, &CwxModel::speedChanged,
+                     [&](int) { ++speedSignals; });
+
+    model.applyStatus({{"wpm", "20"}});  // same value
+    check(speedSignals == 0, "applyStatus with same wpm does not fire speedChanged");
+}
+
+// ── charSent ─────────────────────────────────────────────────────────────────
+
+void testApplyStatusSentIndex()
+{
+    CwxModel model;
+    int lastSent = -1;
+    QObject::connect(&model, &CwxModel::charSent,
+                     [&](int idx) { lastSent = idx; });
+
+    model.applyStatus({{"sent", "7"}});
+    check(lastSent == 7, "applyStatus sent=7 fires charSent(7)");
+    check(model.sentIndex() == 7, "sentIndex() == 7 after applyStatus");
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    testQueueEmptyOnEmptyValue();
+    testQueueEmptyOnZeroValue();
+    testQueueEmptyNotFiredOnNonEmptyQueue();
+    testQueueEmptyNotFiredOnNonQueueKey();
+    testQueueEmptyFiresOnlyForEmptyAmongMixedKeys();
+    testQueueEmptyMultipleUpdates();
+    testSendEmitsCommandReady();
+    testSendBlockCounterIncrements();
+    testSendEmptyIsNoop();
+    testSendSpaceEncodedAsDel();
+    testClearBufferEmitsCommandAndCancellation();
+    testSetSpeedClamped();
+    testApplyStatusWpm();
+    testApplyStatusWpmNoDuplicateSignal();
+    testApplyStatusSentIndex();
+
+    std::printf("\n%s — %d test(s) failed\n",
+                g_failed == 0 ? "PASSED" : "FAILED", g_failed);
+    return g_failed ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- Merges PR #2485 (CAT MacLoggerDX rigctld commands) onto current `main` (which includes the #2450 CWX queue-drain TX-release fix)
- Fixes the root cause of stuck TX when using MacLoggerDX CW via CAT: `wait_morse` was returning `RPRT 0` immediately, so MacLoggerDX sent PTT-off while CW was still transmitting

## Root cause chain

1. MacLoggerDX sequence: `set_ptt 1` → `send_morse <call>` → `wait_morse` → `set_ptt 0`
2. Old `wait_morse` returned `RPRT 0` immediately → MacLoggerDX sent `set_ptt 0` mid-CW
3. Pre-#2450: no `queue=` handler → `m_cwxActive` stayed true → radio held TX for ~60 s hardware watchdog
4. Post-#2450 (in main): TX correctly releases via `queueEmpty()` → `xmit 0`, BUT CW still got cut short because `set_ptt 0` arrived mid-transmission

## What changed

Added a deferred write-callback mechanism to `RigctlProtocol`:

- **`setWriteCallback(fn)`** — called once at client connection time (TCP path uses `QPointer<QTcpSocket>` for socket lifetime safety; PTY path captures the master fd)
- **`cmdWaitMorse()`** — if `m_cwxActive` is true, holds the `RPRT 0` response via `Qt::SingleShotConnection` on `CwxModel::queueEmpty`; fires when the radio confirms its CWX buffer has drained; if CWX is already idle, responds immediately
- **`cmdStopMorse()`** — if a `wait_morse` is pending, cancels the connection and fires `RPRT 0` for it before returning its own `RPRT 0` (correct two-response pairing)
- **Destructor** — `QObject::disconnect(m_pendingMorseConn)` ensures client disconnect can never call into a freed socket
- **`RadioModel::isCwxActive()`** — minimal read accessor for `m_cwxActive`, used by the protocol to decide whether to defer

## Test plan

- [ ] Connect MacLoggerDX via CAT/rigctld (TCP port 4532 or PTY symlink)
- [ ] Set CW mode on slice, enable QSK / Break-In
- [ ] Send a CW call via MacLoggerDX → confirm CW plays fully (not cut short)
- [ ] Confirm TX releases immediately after last element (relay click to RX, no 60 s hang)
- [ ] Send multiple CW calls in sequence → all complete cleanly
- [ ] Mid-macro ESC / `\stop_morse` → TX releases promptly
- [ ] CWX panel Send button still works (regression check — unrelated path)
- [ ] `set_ptt 1` / `set_ptt 0` still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)