### PR TITLE
feat(strip): rebuild RX output panel + canonical meter ballistics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,13 @@ Some radio commands lack status echo (e.g. `tnf remove`). Update the local
 model optimistically. **File a GitHub issue** tagged `protocol` + `upstream`
 for each missing status echo — optimistic updates break Multi-Flex.
 
+### Meter Smoothing — use MeterSmoother
+
+Every meter / level-bar / GR readout in the GUI must drive its display
+value through `MeterSmoother` (`src/gui/MeterSmoother.h`). Don't write
+new envelope-follower code or copy smoothing logic from other widgets
+— `MeterSmoother`'s header has the API and a usage example.
+
 ---
 
 ## Multi-Panadapter Support

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1039,6 +1039,17 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
             }
             output = &boosted;
         }
+        QByteArray trimmed;
+        const float trimDb = m_rxOutputTrimDb.load();
+        if (std::fabs(trimDb) > 0.01f) {
+            const float gain = std::pow(10.0f, trimDb / 20.0f);
+            trimmed.resize(output->size());
+            const auto* src = reinterpret_cast<const float*>(output->constData());
+            auto* dst = reinterpret_cast<float*>(trimmed.data());
+            const int nSamples = output->size() / static_cast<int>(sizeof(float));
+            for (int i = 0; i < nSamples; ++i) dst[i] = src[i] * gain;
+            output = &trimmed;
+        }
         m_rxBuffer.append(*output);
         emitScopeFromFloat32Stereo(*output, scopeSampleRate, false);
         emitRxPostChainScopeFromFloat32Stereo(*output, scopeSampleRate);
@@ -3167,10 +3178,22 @@ void AudioEngine::processBnr(const QByteArray& stereoPcm)
 
         if (m_audioDevice && m_audioDevice->isOpen()) {
             const int scopeSampleRate = m_resampleTo48k ? 48000 : DEFAULT_SAMPLE_RATE;
-            const QByteArray& output = m_resampleTo48k ? resampleStereo(chunk) : chunk;
-            m_rxBuffer.append(output);
-            emitScopeFromFloat32Stereo(output, scopeSampleRate, false);
-            emitRxPostChainScopeFromFloat32Stereo(output, scopeSampleRate);
+            const QByteArray& resampled = m_resampleTo48k ? resampleStereo(chunk) : chunk;
+            const QByteArray* output = &resampled;
+            QByteArray trimmed;
+            const float trimDb = m_rxOutputTrimDb.load();
+            if (std::fabs(trimDb) > 0.01f) {
+                const float gain = std::pow(10.0f, trimDb / 20.0f);
+                trimmed.resize(resampled.size());
+                const auto* src = reinterpret_cast<const float*>(resampled.constData());
+                auto* dst = reinterpret_cast<float*>(trimmed.data());
+                const int nSamples = resampled.size() / static_cast<int>(sizeof(float));
+                for (int i = 0; i < nSamples; ++i) dst[i] = src[i] * gain;
+                output = &trimmed;
+            }
+            m_rxBuffer.append(*output);
+            emitScopeFromFloat32Stereo(*output, scopeSampleRate, false);
+            emitRxPostChainScopeFromFloat32Stereo(*output, scopeSampleRate);
             updateRxBufferStats();
         }
         emit levelChanged(computeRMS(chunk));

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -98,6 +98,12 @@ public:
     void  setRxVolume(float v);
     void  setRxBoost(bool on) { m_rxBoost.store(on); }
     bool  rxBoost() const { return m_rxBoost.load(); }
+    // Final post-DSP linear gain on the RX path (-12..+12 dB).  Applied
+    // after the optional soft-knee BOOST so the strip's RX output meter
+    // (which taps post-trim) reads what hits the speakers.  Mirrors
+    // ClientFinalLimiter::outputTrimDb on the TX side.
+    void  setRxOutputTrimDb(float db) { m_rxOutputTrimDb.store(db); }
+    float rxOutputTrimDb() const { return m_rxOutputTrimDb.load(); }
 
     // Client-side RX pan (0=full-left, 50=centre, 100=full-right).
     // Normally the radio handles panning, but client-side NR mono-mixes
@@ -588,6 +594,7 @@ private:
     QAudioDevice m_inputDevice;
     std::atomic<float> m_rxVolume{1.0f};
     std::atomic<bool>  m_rxBoost{false};  // 50% software gain boost (#1445)
+    std::atomic<float> m_rxOutputTrimDb{0.0f};  // ±12 dB linear trim, post-boost
     std::atomic<int>   m_rxPan{50};       // 0=left, 50=centre, 100=right (#1460)
     std::atomic<int>   m_rxBufferCapMs{200}; // RX buffer cap in ms (#1505)
     std::atomic<bool>  m_muted{false};

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -467,7 +467,8 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // the right path.
     auto makeEntry = [&](const QString& id, const QString& label,
                          QWidget* contentOrContainer, bool defaultOn,
-                         QWidget* rowParent, QHBoxLayout* rowLayout) -> AppletEntry {
+                         QWidget* rowParent, QHBoxLayout* rowLayout,
+                         const QString& buttonText = QString()) -> AppletEntry {
         ContainerWidget* c =
             qobject_cast<ContainerWidget*>(contentOrContainer);
         if (!c) {
@@ -477,7 +478,11 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
         QPushButton* btn = nullptr;
         if (rowLayout) {
-            btn = new QPushButton(id, rowParent);
+            // buttonText overrides the ID-as-label default — used to
+            // shorten visual labels (e.g. PHNE → PHN, WAVE → WAV) while
+            // keeping the persistence key (Applet_<ID>) stable.
+            btn = new QPushButton(buttonText.isEmpty() ? id : buttonText,
+                                  rowParent);
             btn->setCheckable(true);
             rowLayout->addWidget(btn);
         }
@@ -637,7 +642,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_appletOrder.append(makeEntry("TX", "TX Controls", m_txApplet, true, btnRow1, btnLayout1));
 
     m_phoneApplet = new PhoneApplet;
-    m_appletOrder.append(makeEntry("PHNE", "Phone", m_phoneApplet, true, btnRow1, btnLayout1));
+    m_appletOrder.append(makeEntry("PHNE", "Phone", m_phoneApplet, true, btnRow1, btnLayout1, "PHN"));
 
     m_phoneCwApplet = new PhoneCwApplet;
     m_appletOrder.append(makeEntry("P/CW", "Phone/CW", m_phoneCwApplet, true, btnRow1, btnLayout1));
@@ -646,7 +651,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_appletOrder.append(makeEntry("EQ", "Equalizer", m_eqApplet, true, btnRow1, btnLayout1));
 
     m_waveApplet = new WaveApplet;
-    m_appletOrder.append(makeEntry("WAVE", "Waveform", m_waveApplet, true, btnRow1, btnLayout1));
+    m_appletOrder.append(makeEntry("WAVE", "Waveform", m_waveApplet, true, btnRow1, btnLayout1, "WAV"));
 
     // CEQ and CMP intentionally have no toggle button in the tray —
     // their visibility follows DSP bypass state, driven externally

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1052,6 +1052,8 @@ MainWindow::MainWindow(QWidget* parent)
     m_audio = new AudioEngine;  // no parent — will be moved to thread
     m_audio->setRxBoost(
         AppSettings::instance().value("AudioBoost", "False").toString() == "True");
+    m_audio->setRxOutputTrimDb(
+        AppSettings::instance().value("RxOutputTrimDb", "0.0").toFloat());
     m_audio->setRxBufferCapMs(
         AppSettings::instance().value("AudioBufferMs", "200").toInt());
     m_audio->moveToThread(m_audioThread);

--- a/src/gui/StripFinalOutputPanel.cpp
+++ b/src/gui/StripFinalOutputPanel.cpp
@@ -2,6 +2,7 @@
 
 #include "ClientCompKnob.h"
 #include "EditorFramelessTitleBar.h"
+#include "MeterSmoother.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/ClientFinalLimiter.h"
@@ -46,7 +47,10 @@ constexpr const char* kWindowStyle =
 
 constexpr float kMeterMinDb = -60.0f;
 constexpr float kMeterMaxDb =   0.0f;
-constexpr int   kMeterIntervalMs = 33;   // ~30 Hz visual refresh
+// Use the project-canonical MeterSmoother poll rate so this panel's
+// ballistics match every other meter in the app (ClientCompMeter,
+// HGauge, etc.).
+constexpr int   kMeterIntervalMs = kMeterSmootherIntervalMs;
 
 float dbToRatio(float db)
 {
@@ -614,11 +618,12 @@ StripFinalOutputPanel::StripFinalOutputPanel(AudioEngine* engine, QWidget* paren
     // Initial values from engine.
     syncControlsFromEngine();
 
-    // 30 Hz meter polling.
+    // 120 Hz MeterSmoother polling (project-canonical rate).
     m_meterTimer = new QTimer(this);
     m_meterTimer->setInterval(kMeterIntervalMs);
     connect(m_meterTimer, &QTimer::timeout,
             this, &StripFinalOutputPanel::tickMeters);
+    m_animClock.start();
     m_meterTimer->start();
 }
 
@@ -1107,8 +1112,6 @@ void StripFinalOutputPanel::tickMeters()
     auto* lim = m_audio->clientFinalLimiterTx();
     if (!lim) return;
 
-    // Smoothed peak readings — fast attack, slower decay so transient
-    // peaks register but the bar doesn't jitter.
     const float inPeak   = lim->inputPeakDb();
     const float outPeak  = lim->outputPeakDb();
     const float outRms   = lim->outputRmsDb();
@@ -1117,19 +1120,34 @@ void StripFinalOutputPanel::tickMeters()
     const float activity = lim->limiterActivityPct();
     const quint64 clipCount = lim->clipPreLimiterCount();
 
-    // Cheap one-pole towards the latest reading; identical attack/decay
-    // is fine here since the limiter publishes block-peak values that
-    // are already conservative.
-    constexpr float kAlphaUp   = 0.55f;
-    constexpr float kAlphaDown = 0.10f;
-    auto blend = [&](float& state, float target) {
-        const float a = (target > state) ? kAlphaUp : kAlphaDown;
-        state += a * (target - state);
+    // Feed the smoothers in normalised [0, 1] space — setTarget every
+    // tick with the latest accessor value, no "only rise" guard.  The
+    // smoother's asymmetric attack/release does the right thing on
+    // its own (matches ClientCompMeter, ClientCompApplet, etc.).
+    // GR is mapped via -gr/30 so a 30 dB cut reads as a full bar
+    // (matches the existing red-fill overlay scale in HorizMeter).
+    auto dbRatio = [](float db) {
+        if (db <= kMeterMinDb) return 0.0f;
+        if (db >= kMeterMaxDb) return 1.0f;
+        return (db - kMeterMinDb) / (kMeterMaxDb - kMeterMinDb);
     };
-    blend(m_inPeakDb,  inPeak);
-    blend(m_outPeakDb, outPeak);
-    blend(m_outRmsDb,  outRms);
-    blend(m_grDb,      gr);
+    m_inPeakSmooth.setTarget(dbRatio(inPeak));
+    m_outPeakSmooth.setTarget(dbRatio(outPeak));
+    m_outRmsSmooth.setTarget(dbRatio(outRms));
+    m_grSmooth.setTarget(std::clamp(-gr / 30.0f, 0.0f, 1.0f));
+
+    const qint64 dt = m_animClock.restart();
+    m_inPeakSmooth.tick(dt);
+    m_outPeakSmooth.tick(dt);
+    m_outRmsSmooth.tick(dt);
+    m_grSmooth.tick(dt);
+
+    constexpr float kRange = kMeterMaxDb - kMeterMinDb;
+    m_inPeakDb  = kMeterMinDb + m_inPeakSmooth.value()  * kRange;
+    m_outPeakDb = kMeterMinDb + m_outPeakSmooth.value() * kRange;
+    m_outRmsDb  = kMeterMinDb + m_outRmsSmooth.value()  * kRange;
+    m_grDb      = -m_grSmooth.value() * 30.0f;
+
     m_active = active;
 
     // OVR latch — clip count is monotonic; any increase since last

--- a/src/gui/StripFinalOutputPanel.h
+++ b/src/gui/StripFinalOutputPanel.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <QElapsedTimer>
 #include <QWidget>
+
+#include "MeterSmoother.h"
 
 class QLabel;
 class QPushButton;
@@ -68,7 +71,16 @@ private:
     QLabel*         m_limitLed{nullptr};
     QLabel*         m_activityLbl{nullptr};
     QTimer*         m_meterTimer{nullptr};
+    QElapsedTimer   m_animClock;
 
+    // Project-canonical MeterSmoother ballistics — 30 ms attack /
+    // 180 ms release at 120 Hz polling.  Targets normalised to [0, 1]
+    // via dbToRatio(); m_*Db members hold the post-smoother dB values
+    // for label readouts and HorizMeter rendering.
+    MeterSmoother m_inPeakSmooth;
+    MeterSmoother m_outPeakSmooth;
+    MeterSmoother m_outRmsSmooth;
+    MeterSmoother m_grSmooth;        // GR is positive-going; target = -gr/30 clamped to [0, 1]
     float    m_inPeakDb{-120.0f};
     float    m_outPeakDb{-120.0f};
     float    m_outRmsDb{-120.0f};

--- a/src/gui/StripRxOutputPanel.cpp
+++ b/src/gui/StripRxOutputPanel.cpp
@@ -1,10 +1,16 @@
 #include "StripRxOutputPanel.h"
 
+#include "ClientCompKnob.h"
 #include "EditorFramelessTitleBar.h"
+#include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 
+#include <QDateTime>
+#include <QFontMetrics>
+#include <QGridLayout>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QLinearGradient>
 #include <QPainter>
 #include <QPushButton>
 #include <QTimer>
@@ -19,88 +25,134 @@ namespace {
 // bar on transparent background, dark inner fill.
 constexpr const char* kWindowStyle =
     "AetherSDR--StripRxOutputPanel { background: #0e1b28;"
-    " border: 1px solid #2a3a4a; border-radius: 4px; }";
+    " border: 1px solid #2a3a4a; border-radius: 4px; }"
+    "QLabel { background: transparent; color: #8aa8c0; font-size: 11px; }";
 
-// dBFS → 0..1 fraction across the meter using a fixed -60..0 range.
-float dbToFrac(float db)
+constexpr float kMeterMinDb = -60.0f;
+constexpr float kMeterMaxDb =   0.0f;
+
+float dbToRatio(float db)
 {
-    if (db < -60.0f) return 0.0f;
-    if (db > 0.0f)   return 1.0f;
-    return (db + 60.0f) / 60.0f;
+    if (db <= kMeterMinDb) return 0.0f;
+    if (db >= kMeterMaxDb) return 1.0f;
+    return (db - kMeterMinDb) / (kMeterMaxDb - kMeterMinDb);
 }
 
-// Horizontal peak / RMS bar — single child widget that draws itself
-// from m_peakDb / m_rmsDb on the parent.  No internal state.
-class PeakBar : public QWidget {
+// RX-side gradient meter — visual mirror of the TX HorizMeter (gradient
+// fill, dB tick scale, peak-hold hairline) minus the limiter-specific
+// bits (no ceiling drag handle, no GR overlay, no input-peak backdrop,
+// no LIMIT band).  Single child widget; reads m_peak / m_rms on the
+// parent through references so it has no internal state of its own.
+//
+// Bar gradient renders RMS (the slow, average-loudness reading), with
+// a thin white hairline drawn at the bar's leading edge so the eye
+// gets a precise level tick where the colour fades.  The cyan hairline
+// holds the highest raw peak in the trailing 1.5 s window — the only
+// visual indicator of instantaneous peaks.
+class RxGradientMeter : public QWidget {
 public:
-    PeakBar(const float& peak, const float& rms, QWidget* parent)
+    RxGradientMeter(const float& peak, const float& rms, QWidget* parent)
         : QWidget(parent), m_peak(peak), m_rms(rms)
     {
-        setMinimumHeight(14);
+        // Match the TX meter's geometry: 22 px header (unused on RX —
+        // no ceiling handle / value text) + 28 px bar + 22 px tick
+        // label band underneath.
+        setMinimumHeight(72);
+        setMinimumWidth(180);
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     }
 
-protected:
-    void paintEvent(QPaintEvent*) override
-    {
-        QPainter p(this);
-        p.setRenderHint(QPainter::Antialiasing, false);
-        const QRectF r = rect();
-
-        // Background trough.
-        p.setPen(QPen(QColor("#2a3a4a"), 1));
-        p.setBrush(QColor("#0a141e"));
-        p.drawRect(r.adjusted(0.5, 0.5, -0.5, -0.5));
-
-        // Three-zone fill: green / amber / red bands at fixed dB
-        // breakpoints (-60..-12 green, -12..-3 amber, -3..0 red).
-        const float fracPeak = dbToFrac(m_peak);
-        const QRectF inner = r.adjusted(1, 1, -1, -1);
-        const qreal w = inner.width() * fracPeak;
-        if (w > 0.0) {
-            const qreal greenEnd = inner.width() * dbToFrac(-12.0f);
-            const qreal amberEnd = inner.width() * dbToFrac(-3.0f);
-            QRectF fill(inner.left(), inner.top(), w, inner.height());
-            p.setPen(Qt::NoPen);
-            // Green band.
-            p.setBrush(QColor("#3a8a4a"));
-            p.drawRect(QRectF(fill.left(), fill.top(),
-                              std::min<qreal>(w, greenEnd), fill.height()));
-            // Amber band.
-            if (w > greenEnd) {
-                p.setBrush(QColor("#c89030"));
-                p.drawRect(QRectF(fill.left() + greenEnd, fill.top(),
-                                  std::min<qreal>(w - greenEnd,
-                                                  amberEnd - greenEnd),
-                                  fill.height()));
-            }
-            // Red band.
-            if (w > amberEnd) {
-                p.setBrush(QColor("#c83030"));
-                p.drawRect(QRectF(fill.left() + amberEnd, fill.top(),
-                                  w - amberEnd, fill.height()));
+    void notePeak(float rawPeakDb) {
+        const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+        if (rawPeakDb > m_holdDb || nowMs >= m_holdUntilMs) {
+            if (rawPeakDb > m_holdDb) {
+                m_holdDb = rawPeakDb;
+                m_holdUntilMs = nowMs + 1500;
+            } else {
+                m_holdDb = rawPeakDb;
             }
         }
+    }
 
-        // RMS tick — vertical line over the peak bar at the RMS dBFS
-        // position.  Always drawn so the user can see the relationship
-        // between peak (instantaneous) and RMS (moving average).
-        const float fracRms = dbToFrac(m_rms);
-        if (fracRms > 0.0f) {
-            const qreal x = inner.left() + inner.width() * fracRms;
+protected:
+    QRectF barRect() const {
+        return QRectF(rect().left() + 1, rect().top() + 22,
+                      rect().width() - 2, 28 - 2);
+    }
+
+    void paintEvent(QPaintEvent*) override {
+        QPainter p(this);
+        p.setRenderHint(QPainter::Antialiasing, true);
+        const QRectF r = barRect();
+
+        // Track background.
+        p.setPen(QPen(QColor("#1a2a3a"), 1));
+        p.setBrush(QColor("#0a0e16"));
+        p.drawRoundedRect(r, 3, 3);
+
+        // RMS bar — gradient green → amber → red across the full
+        // track, plus a thin white tick at the bar's leading edge so
+        // the eye gets a precise level indicator where the colour fades.
+        const float rmsFrac = dbToRatio(m_rms);
+        if (rmsFrac > 0.0f) {
+            QLinearGradient g(r.left(), 0, r.right(), 0);
+            g.setColorAt(0.00, QColor("#30c060"));
+            g.setColorAt(dbToRatio(-12.0f), QColor("#a0c030"));
+            g.setColorAt(dbToRatio(-3.0f),  QColor("#d49030"));
+            g.setColorAt(1.00, QColor("#c03030"));
+            QRectF outR = r;
+            outR.setWidth(rmsFrac * r.width());
+            p.setPen(Qt::NoPen);
+            p.setBrush(g);
+            p.drawRoundedRect(outR, 3, 3);
+            // Leading-edge tick — sits at the right edge of the fill so
+            // the bar visually "follows" the line as RMS moves.
+            const double rx = r.left() + rmsFrac * r.width();
             p.setPen(QPen(QColor("#e0e0e0"), 1.5));
-            p.drawLine(QPointF(x, inner.top()),
-                       QPointF(x, inner.bottom()));
+            p.drawLine(QPointF(rx, r.top() + 1), QPointF(rx, r.bottom() - 1));
+        }
+
+        // Peak-hold hairline — light cyan line at the highest raw
+        // block peak in the last 1.5 s window.  The only visual cue
+        // for instantaneous peaks; trails the bar's leading edge as
+        // audio quiets so the operator can see headroom usage.
+        if (m_holdDb > -100.0f) {
+            const double hx = r.left() + dbToRatio(m_holdDb) * r.width();
+            p.setPen(QPen(QColor("#a0e0ff"), 2.0));
+            p.drawLine(QPointF(hx, r.top() + 1), QPointF(hx, r.bottom() - 1));
+        }
+
+        // dB scale — tick marks every 12 dB, labels in the band below.
+        QFont tickFont = p.font();
+        tickFont.setPointSize(7);
+        tickFont.setBold(true);
+        p.setFont(tickFont);
+        const QFontMetrics tickFm(tickFont);
+        for (int db = -60; db <= 0; db += 12) {
+            const double tickX = r.left()
+                + dbToRatio(static_cast<float>(db)) * r.width();
+            p.setPen(QPen(QColor("#a0b4c8"), 1.2));
+            p.drawLine(QPointF(tickX, r.bottom() - 4),
+                       QPointF(tickX, r.bottom() + 4));
+            const QString lbl = (db == 0) ? "0" : QString::number(db);
+            const int lblW = tickFm.horizontalAdvance(lbl);
+            double lblX = tickX - lblW / 2.0 - 1;
+            const double minX = rect().left() + 2;
+            const double maxX = rect().right() - 2 - (lblW + 2);
+            if (lblX < minX) lblX = minX;
+            if (lblX > maxX) lblX = maxX;
+            const QRectF labelR(lblX, r.bottom() + 5, lblW + 2, 12);
+            p.setPen(QColor("#7f93a5"));
+            p.drawText(labelR, Qt::AlignCenter, lbl);
         }
     }
 
 private:
     const float& m_peak;
     const float& m_rms;
+    float  m_holdDb{-120.0f};
+    qint64 m_holdUntilMs{0};
 };
-
-constexpr int kDecayIntervalMs = 33;       // ~30 Hz repaint
-constexpr float kDecayPerTickDb = 1.5f;    // peak falls 1.5 dB per tick
 
 } // namespace
 
@@ -115,7 +167,7 @@ StripRxOutputPanel::StripRxOutputPanel(AudioEngine* engine, QWidget* parent)
     setStyleSheet(kWindowStyle);
 
     auto* root = new QVBoxLayout(this);
-    root->setContentsMargins(8, 0, 8, 8);
+    root->setContentsMargins(8, 0, 8, 0);
     root->setSpacing(6);
 
     auto* titleBar = new EditorFramelessTitleBar;
@@ -124,80 +176,147 @@ StripRxOutputPanel::StripRxOutputPanel(AudioEngine* engine, QWidget* parent)
     titleBar->setStyleSheet("background: transparent;");
     m_titleBar = titleBar;
     root->addWidget(titleBar);
+    // 10 px breathing room between the title and the controls row —
+    // matches the TX panel spacing so the two panels read as a pair.
+    root->addSpacing(10);
 
-    // Peak / RMS readout row.
-    auto* readoutRow = new QHBoxLayout;
-    readoutRow->setContentsMargins(0, 0, 0, 0);
-    readoutRow->setSpacing(8);
+    // Main row: Trim knob | gradient meter | PK/RMS/CRST readouts | MUTE/BOOST chips
+    auto* row = new QHBoxLayout;
+    row->setSpacing(8);
 
-    auto makeReadout = [&](const QString& label) {
+    // Trim — final post-DSP RX gain stage.  Mirrors the TX panel's
+    // post-limiter trim knob: 76×76 px, ±12 dB range, default 0 dB,
+    // centre-label readout in dB.
+    m_trim = new ClientCompKnob;
+    m_trim->setLabel("Trim");
+    m_trim->setCenterLabelMode(true);
+    m_trim->setRange(-12.0f, 12.0f);
+    m_trim->setDefault(0.0f);
+    m_trim->setLabelFormat([](float v) {
+        return (v >= 0.0f ? "+" : "") + QString::number(v, 'f', 1) + " dB";
+    });
+    m_trim->setFixedSize(76, 76);
+    if (m_audio) m_trim->setValue(m_audio->rxOutputTrimDb());
+    connect(m_trim, &ClientCompKnob::valueChanged, this, [this](float db) {
+        if (!m_audio) return;
+        m_audio->setRxOutputTrimDb(db);
+        auto& s = AppSettings::instance();
+        s.setValue("RxOutputTrimDb", QString::number(db, 'f', 1));
+        s.save();
+    });
+    row->addWidget(m_trim);
+
+    auto* meter = new RxGradientMeter(m_peakDb, m_rmsDb, this);
+    m_meter = meter;
+    row->addWidget(meter, 1);
+
+    // Numeric readouts column — PK / RMS / CRST.  Mirrors the TX panel's
+    // styling: 9 px muted-blue tag labels, 11 px bold values, cyan PK,
+    // green RMS, white CRST.
+    {
+        const QString labelCss =
+            "QLabel { color: #506070; font-size: 9px; font-weight: bold;"
+            " padding: 0; }";
+        const QString valCssCyan =
+            "QLabel { color: #56ccf2; font-size: 11px; font-weight: bold;"
+            " padding: 0; }";
+        const QString valCssGreen =
+            "QLabel { color: #6fcf97; font-size: 11px; font-weight: bold;"
+            " padding: 0; }";
+        const QString valCssWhite =
+            "QLabel { color: #d7e7f2; font-size: 11px; font-weight: bold;"
+            " padding: 0; }";
+
+        auto* readGrid = new QGridLayout;
+        readGrid->setHorizontalSpacing(4);
+        readGrid->setVerticalSpacing(0);
+        readGrid->setContentsMargins(0, 0, 0, 0);
+
+        auto addRow = [&](int r, const QString& tag, const QString& valCss,
+                          QLabel*& outVal) {
+            auto* lbl = new QLabel(tag, this);
+            lbl->setStyleSheet(labelCss);
+            lbl->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+            outVal = new QLabel(QString::fromUtf8("-\xe2\x88\x9e"), this);
+            outVal->setStyleSheet(valCss);
+            outVal->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+            outVal->setMinimumWidth(44);
+            readGrid->addWidget(lbl,    r, 0);
+            readGrid->addWidget(outVal, r, 1);
+        };
+        addRow(0, "PK",   valCssCyan,  m_peakLbl);
+        addRow(1, "RMS",  valCssGreen, m_rmsLbl);
+        addRow(2, "CRST", valCssWhite, m_crestLbl);
+
+        auto* readWrap = new QWidget(this);
+        readWrap->setLayout(readGrid);
+        readWrap->setFixedWidth(80);
+        readWrap->setAttribute(Qt::WA_StyledBackground, false);
+        readWrap->setStyleSheet("background: transparent;");
+        row->addWidget(readWrap);
+    }
+
+    // MUTE / BOOST chip column on the far right — sized + placed to
+    // match the TX panel's OVR/LIMIT/Lim% chip column so the two
+    // panels' right edges share a visual rhythm.
+    {
+        const QString muteStyle =
+            "QPushButton {"
+            "  background: #1a2230; border: 1px solid #2a3744;"
+            "  border-radius: 3px; color: #506070;"
+            "  font-size: 10px; font-weight: bold; padding: 1px;"
+            "}"
+            "QPushButton:hover { color: #c8d8e8; }"
+            "QPushButton:checked {"
+            "  background: #4a1818; color: #ff8080;"
+            "  border: 1px solid #ff4040;"
+            "}"
+            "QPushButton:checked:hover { background: #5a2828; }";
+        const QString boostStyle =
+            "QPushButton {"
+            "  background: #1a2230; border: 1px solid #2a3744;"
+            "  border-radius: 3px; color: #506070;"
+            "  font-size: 10px; font-weight: bold; padding: 1px;"
+            "}"
+            "QPushButton:hover { color: #c8d8e8; }"
+            "QPushButton:checked {"
+            "  background: #1a4a2a; color: #80ff80;"
+            "  border: 1px solid #40c060;"
+            "}"
+            "QPushButton:checked:hover { background: #285a38; }";
+
         auto* col = new QVBoxLayout;
         col->setContentsMargins(0, 0, 0, 0);
-        col->setSpacing(0);
-        auto* hdr = new QLabel(label, this);
-        hdr->setStyleSheet(
-            "QLabel { background: transparent; color: #8aa8c0;"
-            " font-size: 10px; font-weight: bold; }");
-        hdr->setAlignment(Qt::AlignCenter);
-        auto* val = new QLabel("-∞", this);
-        val->setStyleSheet(
-            "QLabel { background: transparent; color: #c8d8e8;"
-            " font-size: 13px; font-weight: bold; }");
-        val->setAlignment(Qt::AlignCenter);
-        val->setMinimumWidth(56);
-        col->addWidget(hdr);
-        col->addWidget(val);
-        readoutRow->addLayout(col);
-        return val;
-    };
-    m_peakLbl = makeReadout(QStringLiteral("PK"));
-    m_rmsLbl  = makeReadout(QStringLiteral("RMS"));
+        col->setSpacing(2);
 
-    readoutRow->addStretch(1);
+        m_muteBtn = new QPushButton(QStringLiteral("MUTE"), this);
+        m_muteBtn->setCheckable(true);
+        m_muteBtn->setFixedSize(56, 18);
+        m_muteBtn->setStyleSheet(muteStyle);
+        m_muteBtn->setToolTip(tr("Mute local audio output."));
+        if (m_audio) m_muteBtn->setChecked(m_audio->isMuted());
+        connect(m_muteBtn, &QPushButton::toggled, this, [this](bool on) {
+            if (m_audio) m_audio->setMuted(on);
+        });
+        col->addWidget(m_muteBtn);
 
-    // MUTE / BOOST toggles on the right.
-    const QString btnStyle =
-        "QPushButton { background: #1a2a3a; border: 1px solid #2a4458;"
-        "  border-radius: 3px; color: #c8d8e8;"
-        "  font-size: 11px; font-weight: bold; padding: 3px 10px; }"
-        "QPushButton:hover { background: #243a52; border-color: #4a7090; }"
-        "QPushButton:checked { background: #c83030; color: #ffffff;"
-        "  border-color: #ff5050; }";
-    const QString boostStyle =
-        "QPushButton { background: #1a2a3a; border: 1px solid #2a4458;"
-        "  border-radius: 3px; color: #c8d8e8;"
-        "  font-size: 11px; font-weight: bold; padding: 3px 10px; }"
-        "QPushButton:hover { background: #243a52; border-color: #4a7090; }"
-        "QPushButton:checked { background: #1a6030; color: #ffffff;"
-        "  border-color: #20a040; }";
+        m_boostBtn = new QPushButton(QStringLiteral("BOOST"), this);
+        m_boostBtn->setCheckable(true);
+        m_boostBtn->setFixedSize(56, 18);
+        m_boostBtn->setStyleSheet(boostStyle);
+        m_boostBtn->setToolTip(
+            tr("Soft-knee tanh boost on the RX output (~2× gain on quiet "
+               "passages, no hard clipping on loud ones)."));
+        if (m_audio) m_boostBtn->setChecked(m_audio->rxBoost());
+        connect(m_boostBtn, &QPushButton::toggled, this, [this](bool on) {
+            if (m_audio) m_audio->setRxBoost(on);
+        });
+        col->addWidget(m_boostBtn);
 
-    m_muteBtn = new QPushButton(QStringLiteral("MUTE"), this);
-    m_muteBtn->setCheckable(true);
-    m_muteBtn->setStyleSheet(btnStyle);
-    m_muteBtn->setToolTip(tr("Mute local audio output."));
-    if (m_audio) m_muteBtn->setChecked(m_audio->isMuted());
-    connect(m_muteBtn, &QPushButton::toggled, this, [this](bool on) {
-        if (m_audio) m_audio->setMuted(on);
-    });
-    readoutRow->addWidget(m_muteBtn);
+        row->addLayout(col);
+    }
 
-    m_boostBtn = new QPushButton(QStringLiteral("BOOST"), this);
-    m_boostBtn->setCheckable(true);
-    m_boostBtn->setStyleSheet(boostStyle);
-    m_boostBtn->setToolTip(
-        tr("Soft-knee tanh boost on the RX output (~2× gain on quiet "
-           "passages, no hard clipping on loud ones)."));
-    if (m_audio) m_boostBtn->setChecked(m_audio->rxBoost());
-    connect(m_boostBtn, &QPushButton::toggled, this, [this](bool on) {
-        if (m_audio) m_audio->setRxBoost(on);
-    });
-    readoutRow->addWidget(m_boostBtn);
-
-    root->addLayout(readoutRow);
-
-    // Peak meter bar.
-    m_meter = new PeakBar(m_peakDb, m_rmsDb, this);
-    root->addWidget(m_meter);
+    root->addLayout(row);
 
     // Wire scope-tap → meter.  scopeSamplesReady fires for both sides;
     // RX path filters tx=false.  Cross-thread queued connection — the
@@ -208,29 +327,22 @@ StripRxOutputPanel::StripRxOutputPanel(AudioEngine* engine, QWidget* parent)
                 Qt::QueuedConnection);
     }
 
-    // Decay timer keeps the bar alive between scope updates and gives
-    // the peak indicator a smooth fall when audio drops.
-    m_decayTimer = new QTimer(this);
-    m_decayTimer->setInterval(kDecayIntervalMs);
-    connect(m_decayTimer, &QTimer::timeout,
+    // 120 Hz animation tick — kMeterSmootherIntervalMs is the project's
+    // canonical poll rate so this panel's ballistics match every other
+    // meter in the app.
+    m_animTimer = new QTimer(this);
+    m_animTimer->setInterval(kMeterSmootherIntervalMs);
+    connect(m_animTimer, &QTimer::timeout,
             this, &StripRxOutputPanel::tick);
-    m_decayTimer->start();
+    m_animClock.start();
+    m_animTimer->start();
 }
 
 StripRxOutputPanel::~StripRxOutputPanel() = default;
 
 void StripRxOutputPanel::showForRx()
 {
-    if (m_audio) {
-        if (m_muteBtn) {
-            QSignalBlocker b(m_muteBtn);
-            m_muteBtn->setChecked(m_audio->isMuted());
-        }
-        if (m_boostBtn) {
-            QSignalBlocker b(m_boostBtn);
-            m_boostBtn->setChecked(m_audio->rxBoost());
-        }
-    }
+    syncControlsFromEngine();
     show();
     raise();
     activateWindow();
@@ -246,6 +358,10 @@ void StripRxOutputPanel::syncControlsFromEngine()
     if (m_boostBtn) {
         QSignalBlocker b(m_boostBtn);
         m_boostBtn->setChecked(m_audio->rxBoost());
+    }
+    if (m_trim) {
+        QSignalBlocker b(m_trim);
+        m_trim->setValue(m_audio->rxOutputTrimDb());
     }
 }
 
@@ -272,30 +388,55 @@ void StripRxOutputPanel::onScopeSamples(const QByteArray& monoFloat32,
     const float blockRmsDb  = blockRms > 0.0f
         ? 20.0f * std::log10(blockRms) : kFloor;
 
-    // Peak holds the higher of stored vs. block — decay is in tick().
-    if (blockPeakDb > m_peakDb) m_peakDb = blockPeakDb;
-    // RMS uses a one-pole smoother so the readout doesn't jitter.
-    constexpr float kRmsAlpha = 0.4f;
-    m_rmsDb = kRmsAlpha * blockRmsDb + (1.0f - kRmsAlpha) * m_rmsDb;
+    // Feed the smoothers in normalised [0, 1] space.  setTarget on
+    // every block — the smoother's asymmetric attack/release does
+    // the right thing on its own (matches ClientCompMeter,
+    // ClientCompApplet, etc.).  Brief peaks that get smoothed away
+    // are still captured on the hairline via notePeak() below.
+    m_peakSmooth.setTarget(dbToRatio(blockPeakDb));
+    m_rmsSmooth.setTarget(dbToRatio(blockRmsDb));
+
+    // Feed the raw block-peak into the meter's hold tracker so single
+    // brief peaks register on the hairline before they decay out.
+    if (m_meter) {
+        static_cast<RxGradientMeter*>(m_meter)->notePeak(blockPeakDb);
+    }
 }
 
 void StripRxOutputPanel::tick()
 {
-    // Decay the peak indicator at ~kDecayPerTickDb per tick.  RMS
-    // tracks via the smoother so it doesn't need decay here.
-    constexpr float kFloor = -120.0f;
-    if (m_peakDb > kFloor) {
-        m_peakDb -= kDecayPerTickDb;
-        if (m_peakDb < kFloor) m_peakDb = kFloor;
-    }
+    // Advance both smoothers by the wall-clock elapsed since the last
+    // tick — MeterSmoother integrates over real time so the animation
+    // is timer-jitter-tolerant.
+    const qint64 dt = m_animClock.restart();
+    m_peakSmooth.tick(dt);
+    m_rmsSmooth.tick(dt);
+
+    // Map the smoothers' [0, 1] display values back to dB for the
+    // labels and the gradient bar.  A ratio of 0 maps to -60 dB which
+    // the formatter prints as "-∞".
+    constexpr float kRange = kMeterMaxDb - kMeterMinDb;
+    m_peakDb = kMeterMinDb + m_peakSmooth.value() * kRange;
+    m_rmsDb  = kMeterMinDb + m_rmsSmooth.value()  * kRange;
 
     // Update text readouts and repaint the bar.
     auto fmt = [](float db) -> QString {
-        if (db <= -60.0f) return QStringLiteral("-∞");
-        return QString::number(db, 'f', 1) + QStringLiteral(" dB");
+        if (db <= -60.0f) return QString::fromUtf8("-\xe2\x88\x9e");
+        return QString::number(db, 'f', 1);
     };
     if (m_peakLbl) m_peakLbl->setText(fmt(m_peakDb));
     if (m_rmsLbl)  m_rmsLbl->setText(fmt(m_rmsDb));
+    if (m_crestLbl) {
+        // Crest factor (peak − RMS) — only meaningful when both readings
+        // are above the noise floor; show "--" otherwise so the user
+        // doesn't read a misleading 60 dB value while idle.
+        if (m_peakDb > -60.0f && m_rmsDb > -60.0f) {
+            const float crest = m_peakDb - m_rmsDb;
+            m_crestLbl->setText(QString::number(crest, 'f', 1));
+        } else {
+            m_crestLbl->setText("--");
+        }
+    }
     if (m_meter)   m_meter->update();
 }
 

--- a/src/gui/StripRxOutputPanel.h
+++ b/src/gui/StripRxOutputPanel.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <QElapsedTimer>
 #include <QWidget>
+
+#include "MeterSmoother.h"
 
 class QLabel;
 class QPushButton;
@@ -9,6 +12,7 @@ class QTimer;
 namespace AetherSDR {
 
 class AudioEngine;
+class ClientCompKnob;
 
 // "Aetherial Output — RX" — RX-side counterpart of the TX
 // `StripFinalOutputPanel`.  Sits at the very end of the RX panel grid,
@@ -45,19 +49,26 @@ private:
     void tick();
 
     AudioEngine*  m_audio{nullptr};
-    QWidget*      m_titleBar{nullptr};   // EditorFramelessTitleBar*
-    QPushButton*  m_muteBtn{nullptr};
-    QPushButton*  m_boostBtn{nullptr};
-    QWidget*      m_meter{nullptr};      // peak bar widget (paint event)
-    QLabel*       m_peakLbl{nullptr};
-    QLabel*       m_rmsLbl{nullptr};
-    QTimer*       m_decayTimer{nullptr};
+    QWidget*        m_titleBar{nullptr};   // EditorFramelessTitleBar*
+    ClientCompKnob* m_trim{nullptr};
+    QPushButton*    m_muteBtn{nullptr};
+    QPushButton*    m_boostBtn{nullptr};
+    QWidget*        m_meter{nullptr};      // gradient bar widget (paint event)
+    QLabel*         m_peakLbl{nullptr};
+    QLabel*         m_rmsLbl{nullptr};
+    QLabel*         m_crestLbl{nullptr};
+    QTimer*         m_animTimer{nullptr};
+    QElapsedTimer   m_animClock;
 
-    // Peak/RMS state (dBFS).  Updated from the audio thread via
-    // scopeSamplesReady (queued cross-thread).  Decayed by m_decayTimer
-    // so the displayed reading falls smoothly when audio stops.
-    float         m_peakDb{-120.0f};
-    float         m_rmsDb{-120.0f};
+    // Project-canonical MeterSmoother ballistics — 30 ms attack /
+    // 180 ms release at 120 Hz polling.  Targets are normalised
+    // [0, 1] via dbToRatio(); m_peakDb / m_rmsDb are derived back to
+    // dB for the readout labels and as references into the gradient
+    // meter widget.
+    MeterSmoother   m_peakSmooth;
+    MeterSmoother   m_rmsSmooth;
+    float           m_peakDb{-120.0f};
+    float           m_rmsDb{-120.0f};
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
RX panel rebuild — now mirrors the TX final-output panel's visual
language: gradient bar (green → amber → red), dB tick scale at every
12 dB step, RMS-driven fill with a thin white leading-edge tick, and
a cyan peak-hold hairline for the trailing 1.5 s window.  Stacked
PK/RMS/CRST readouts on the right, MUTE/BOOST chip column on the
far right, and a 76×76 px Trim knob (±12 dB, post-DSP) to the left
of the meter.  AudioEngine grows setRxOutputTrimDb plumbing applied
inline in both RX emit paths; persisted as RxOutputTrimDb, loaded
at engine construction.

Meter smoothing — both TX and RX panels migrated off ad-hoc alpha
blenders onto the project-canonical MeterSmoother (30 ms attack /
180 ms release at 120 Hz polling).  Targets normalised to [0, 1]
via dbToRatio; setTarget on every tick, no "only rise" guard (which
caused the bar to stick at the high water mark on RX).  Display
values converted back to dB for labels and rendering.

CLAUDE.md — new "Meter Smoothing" entry under Key Implementation
Patterns directing all new meter UIs to MeterSmoother.

AppletPanel — shorten PHN/WAV button labels (was PHNE/WAVE) so the
top button row stops clipping; ID strings unchanged so existing
settings keys / saved layouts continue to work.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
