### PR TITLE
docs: 1.0 release prep — sweep stale references across key docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 Replicate the **Windows-only FlexRadio SmartSDR client** (written in C#) as a
 **Linux-native C++ application** using Qt6 and C++20. The aim is to mirror the
 look, feel, and every function SmartSDR is capable of. The reference radio is a
-**FLEX-8600 running firmware 4.1.5**, which speaks **SmartSDR protocol v1.4.0.0**.
+**FLEX-8600 running firmware 4.2.18**, which speaks **SmartSDR protocol v1.4.0.0**.
 
 ## AI Agent Guidelines
 
@@ -135,7 +135,7 @@ key=value pairs by locating the last space before the first `=` sign.
 7. `stream create type=remote_audio_rx compression=none` → radio starts sending
    VITA-49 audio to our UDP port
 
-### Firmware v1.4.0.0 Quirks
+### Protocol / Firmware Quirks (v1.4.0.0 protocol on fw 4.x)
 
 - `client set udpport` returns `0x50001000` — use the one-byte UDP packet method
 - `client set enforce_local_ptt=1` returns `0x50001000` — correct command is `client set local_ptt=1`; the radio echoes a full `connected` status to ALL clients updating their `local_ptt` field when ownership changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ changes.
 |--------|-----------|
 | **Main** | GUI rendering, RadioModel, all sub-models, user input |
 | **Connection** | RadioConnection (TCP 4992 I/O) |
-| **Audio** | AudioEngine (RX/TX audio, NR2/RN2/BNR DSP) |
+| **Audio** | AudioEngine (RX/TX audio; NR2/RN2/NR4/DFNR/BNR/MNR DSP) |
 | **Network** | PanadapterStream (VITA-49 UDP parsing) |
 | **ExtControllers** | FlexControl, MIDI, SerialPort |
 | **Spot** | DX Cluster, RBN, WSJT-X, POTA, FreeDV clients |
@@ -156,7 +156,10 @@ Features gated behind compile-time flags:
 | `HAVE_KEYCHAIN` | `Qt6Keychain` | SmartLink credential persistence |
 | `HAVE_MIDI` | Bundled RtMidi | MIDI controller mapping |
 | `HAVE_RADE` | Bundled RADE/Opus | FreeDV digital voice |
+| `HAVE_SPECBLEACH` | libspecbleach (clang-cl on Win) | NR4 spectral noise reduction |
+| `HAVE_DFNR` | Bundled DeepFilterNet3 | DFNR neural noise reduction |
 | `HAVE_BNR` | NVIDIA NIM container | GPU noise removal |
+| `HAVE_MQTT` | Bundled libmosquitto | MQTT applet |
 
 Use `#ifdef HAVE_*` guards. Features must degrade gracefully when unavailable.
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ AetherSDR brings FlexRadio operation to Linux without Wine or virtual machines. 
 - **Multi-slice operation** — color-coded VFO overlays, independent TX assignment, diversity mode with ESC beamforming
 - **Multi-panadapter** — up to 8 pans (FLEX-6700) with 6 layout options, detachable pop-out windows, per-pan display controls, native VITA-49 waterfall tiles
 - **Full RX/TX controls** — filter presets, custom filter edges, AGC, DSP, EQ, mic/compression gauges, ATU, TUNE/MOX
-- **Aetherial Audio Channel Strip** — unified TX DSP suite (gate, EQ, compressor, de-esser, tube, AetherVoice exciter, Freeverb, brickwall limiter) with savable preset library
-- **Client-side noise reduction** — NR2 (spectral), RN2 (RNNoise neural), BNR (NVIDIA GPU AI denoiser)
+- **Aetherial Audio Channel Strip** — unified RX **and** TX DSP suite (gate, EQ, compressor, de-esser, tube, AetherVoice exciter, Freeverb on TX, plus brickwall limiter on TX / output trim on RX) with savable preset library and a wall-clock-accurate scope on each side
+- **Client-side noise reduction** — NR2 (spectral), RN2 (RNNoise neural), NR4 (libspecbleach), DFNR (DeepFilterNet3 neural), BNR (NVIDIA GPU AI denoiser), MNR (macOS MMSE-Wiener)
 - **AetherSweep** — in-panadapter SWR analyzer with log scale, threshold-band shading, interpolated bandwidth at SWR ≤ 1.5 / 2.0
 - **Network Diagnostics** — per-metric trend graphs, packet loss / RTT / jitter metrics, live log tail
 - **Memory channels + profiles** — memory bank with quick-recall, global / mic / TX profile management synced with the radio
@@ -51,7 +51,7 @@ AetherSDR brings FlexRadio operation to Linux without Wine or virtual machines. 
 
 ## Supported Radios
 
-Works with any FlexRadio transceiver: FLEX-6300, 6400, 6400M, 6500, 6600, 6600M, 6700, 8400, 8400M, 8600, 8600M, Aurora (AU-510, AU-520), and ML- / CL- / RT-series. Active test target is FLEX-8600 firmware 4.1.5 (SmartSDR protocol v1.4.0.0); v3.x firmware likely works but is not tested.
+Works with any FlexRadio transceiver: FLEX-6300, 6400, 6400M, 6500, 6600, 6600M, 6700, 8400, 8400M, 8600, 8600M, Aurora (AU-510, AU-520), and ML- / CL- / RT-series. Active test target is FLEX-8600 firmware 4.2.18 (SmartSDR protocol v1.4.0.0); earlier 4.x firmware works; v3.x is unsupported.
 
 ---
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -218,6 +218,39 @@ Reusable widget from `src/gui/HGauge.h`.
 - **Bar fill:** cyan `#00b4d8`, range 0-255
 - **Value text:** 28px wide, right-aligned
 
+### MeterSmoother (Meter Ballistics)
+
+Every meter / level-bar / GR readout drives its display value through
+`MeterSmoother` (`src/gui/MeterSmoother.h`) so the whole interface reads as
+one consistent instrument.
+
+- **Attack:** 30 ms · **Release:** 180 ms · **Poll rate:** 120 Hz
+  (`kMeterSmootherIntervalMs` = 8 ms)
+- **Domain:** normalised `[0, 1]` — callers map physical units (dBFS,
+  dB of GR, etc.) to a fraction before `setTarget()`
+- **Driving timer:** `QTimer` + `QElapsedTimer` per the header's usage
+  example; `tick(elapsedMs)` integrates over wall clock so timer
+  jitter doesn't change the perceived ballistic
+
+Don't roll your own envelope follower or copy ad-hoc smoothing constants
+from another widget. If a meter genuinely needs different ballistics
+(e.g. a slower release for a specialised GR bar), opt into different
+constants via `MeterSmoother::Ballistics`.
+
+### ClientCompKnob (Rotary Knob)
+
+Reusable knob widget from `src/gui/ClientCompKnob.h` used throughout the
+TX/RX DSP chain editors and the Aetherial Audio Channel Strip.
+
+- **Standard size:** 76×76 px (channel-strip / editor); 38×48 px on
+  applet tiles for compact mode
+- **Center label:** enable via `setCenterLabelMode(true)` to render the
+  numeric value inside the dial; otherwise the value renders below
+- **Range:** `setRange(min, max)` + `setDefault(v)`; double-click resets
+  to default
+- **Format:** `setLabelFormat([](float v){ return ...; })` for
+  unit-suffixed display (`"+3.0 dB"`, `"15 ms"`, etc.)
+
 ---
 
 ## Layout

--- a/docs/VERIFYING-RELEASES.md
+++ b/docs/VERIFYING-RELEASES.md
@@ -74,7 +74,7 @@ without an EV code signing certificate. To verify the download:
 ```powershell
 # Install Gpg4win from https://gpg4win.org/
 gpg --import RELEASE-SIGNING-KEY.pub.asc
-gpg --verify AetherSDR-Setup-v0.7.12.exe.asc AetherSDR-Setup-v0.7.12.exe
+gpg --verify AetherSDR-Setup-vX.Y.Z.exe.asc AetherSDR-Setup-vX.Y.Z.exe
 ```
 
 ## Commit Signing

--- a/docs/architecture-pipelines.md
+++ b/docs/architecture-pipelines.md
@@ -8,7 +8,7 @@ thread safety, signal routing, or data flow issues.
 Multi-thread architecture — up to 11 threads depending on features enabled:
 - **Main thread**: GUI rendering (paintEvent), RadioModel + all sub-models, user input
 - **Connection thread**: RadioConnection (TCP 4992 I/O, kernel TCP_INFO RTT)
-- **Audio thread**: AudioEngine (RX/TX audio, NR2/RN2 DSP, QAudioSink/Source)
+- **Audio thread**: AudioEngine (RX/TX audio; NR2/RN2/NR4/DFNR/BNR/MNR DSP, QAudioSink/Source)
 - **Network thread**: PanadapterStream (VITA-49 UDP parsing, FFT/waterfall/meter demux)
 - **ExtControllers thread**: FlexControl, MIDI, SerialPort (USB/serial I/O, RtMidi callbacks)
 - **Spot thread**: DxCluster, RBN, WSJT-X, POTA, FreeDV spot clients

--- a/resources/help/aethersdr-help.md
+++ b/resources/help/aethersdr-help.md
@@ -168,7 +168,7 @@ Default applet order is:
 - `TUN`
 - `AMP`
 - `TX`
-- `PHNE`
+- `PHN`
 - `P/CW`
 - `EQ`
 - `DIGI`
@@ -207,7 +207,7 @@ The TX applet is the main transmit command surface. It includes:
 
 Before transmitting, this is the applet that should match your intention.
 
-### `PHNE`
+### `PHN`
 
 The Phone applet is focused on voice-mode shaping and behavior:
 
@@ -428,8 +428,8 @@ Work outward from the slice:
 5. if using Opus compression (SmartLink/WAN), disable client-side spectral
    noise reduction (NR2). NR2's noise estimator cannot distinguish Opus
    codec artifacts from real noise, which causes rasping distortion.
-   Use RNNoise (RN2), NR4 (specbleach), or DFNR instead — these
-   neural/spectral filters handle lossy audio gracefully.
+   Use RNNoise (RN2), NR4 (specbleach), MNR, BNR, or DFNR instead —
+   these neural/spectral filters handle lossy audio gracefully.
 
 ### When the display feels cluttered
 

--- a/resources/help/getting-started.md
+++ b/resources/help/getting-started.md
@@ -91,7 +91,7 @@ Common applets include:
 - `TUN`: tuner controls when supported hardware is present
 - `AMP`: amplifier controls when supported hardware is present
 - `TX`: transmit power, profiles, ATU, TUNE, and MOX
-- `PHNE`: voice-specific transmit shaping
+- `PHN`: voice-specific transmit shaping
 - `P/CW`: microphone controls in phone modes and keyer controls in CW modes
 - `EQ`: transmit and receive equalization
 - `DIGI`: CAT, DAX, TTY, and TCI controls for software integration

--- a/resources/help/understanding-noise-cancellation.md
+++ b/resources/help/understanding-noise-cancellation.md
@@ -112,6 +112,7 @@ client-side mode can be active at a time.
 | NR2 | Spectral NR | Statistical DSP | 6 parameters | CPU | Fine-tuned control over SSB noise |
 | RN2 | RNNoise | Neural network | None | CPU | Quick cleanup, no fuss |
 | NR4 | SpecBleach | Advanced spectral | 7 parameters | CPU | Stubborn broadband noise |
+| MNR | Apple MMSE-Wiener | Statistical DSP | 1 slider | CPU (macOS only) | macOS users wanting a native option |
 | BNR | NVIDIA Maxine | AI (cloud/GPU) | 1 slider | RTX GPU | Maximum quality with NVIDIA hardware |
 | DFNR | DeepFilterNet3 | AI (local) | 2 parameters | CPU | Best all-around AI denoising |
 
@@ -128,7 +129,7 @@ operation. They work by identifying and preserving human speech while removing
 everything else — which is exactly the wrong thing to do when the signal you
 want is a CW tone or a digital mode like FT8, JS8Call, or RTTY.
 
-For this reason, most client-side modes (NR2, RN2, BNR, and DFNR)
+For this reason, the client-side modes (NR2, RN2, NR4, MNR, BNR, and DFNR)
 automatically disable themselves when you switch to CW, CWL, or a digital
 mode. This is intentional — do not try to force them on. Running voice-optimized
 noise reduction on non-voice signals can distort the audio, confuse decoding
@@ -189,6 +190,29 @@ the noise.
 automatically.
 
 **Recommendation:** RN2 is a great starting point if you are new to noise reduction or just want cleaner audio without learning what all the knobs do. If it is clipping weak signals or the audio sounds slightly muffled on very noisy bands, try DFNR or NR2 instead.
+
+---
+
+### MNR — Apple MMSE-Wiener (macOS only)
+
+MNR is a macOS-only spectral noise reducer that uses Apple's vDSP framework
+to run an MMSE (Minimum Mean-Square Error) Wiener filter natively on the
+operating system's optimised math libraries. It is mathematically related
+to NR2 — both descend from the Ephraim-Malah family — but takes advantage
+of macOS's hand-tuned implementation so it costs almost nothing on Apple
+Silicon.
+
+MNR exists for Mac users who want a no-fuss native option without
+installing GPU drivers (BNR) or compiling extra libraries (DFNR / NR4).
+It handles general HF SSB noise well; for tougher conditions or weak-DX
+work, DFNR remains the best all-around choice on macOS too.
+
+**Available tunables:**
+- **Strength** — A single slider (0–100%) controlling how aggressively
+  the Wiener filter cuts noise. Default 100%; lower for lighter touch.
+
+**Recommendation:** macOS users start here for the simplest setup; switch
+to DFNR for tougher noise.
 
 ---
 
@@ -284,7 +308,7 @@ gradually — over-processing can make voices sound robotic or hollow.
 
 ## Where to Find the Controls
 
-- **Quick toggle:** The DSP buttons on the VFO bar (NR2, RN2, BNR, NR4, DFNR)
+- **Quick toggle:** The DSP buttons on the VFO bar (NR2, RN2, NR4, MNR, BNR, DFNR)
 - **Overlay panel:** Right-click the spectrum display, open the DSP panel
 - **Full settings:** Settings menu → AetherDSP Settings (or right-click any DSP applet)
 - **Right-click shortcut:** Right-click the NR2 button on the VFO bar for a quick parameter popup


### PR DESCRIPTION
Audit pass before the 1.0 release.  Touches user-facing in-app help,
top-level project docs, and the dev architecture references that
CLAUDE.md / CONTRIBUTING.md point at.

- Reference firmware bumped 4.1.5 → 4.2.18 in README + CLAUDE (matches
  what recent PRs are testing on).  Misleading "Firmware v1.4.0.0
  Quirks" subheading in CLAUDE.md clarified — protocol = v1.4.0.0,
  firmware = v4.x.
- NR backend list across README / CONTRIBUTING / architecture-pipelines
  / understanding-noise-cancellation.md now lists all six client-side
  modes (NR2/RN2/NR4/MNR/BNR/DFNR) instead of only NR2/RN2/BNR.  New
  MNR section in the noise-cancellation help doc matching the house
  style of existing per-mode sections.
- README's Channel Strip highlight reflects 0.9.8's RX-side parity
  with TX (was TX-only language).
- CONTRIBUTING.md HAVE_* table grew three rows (HAVE_SPECBLEACH,
  HAVE_DFNR, HAVE_MQTT) — significant user-facing flags that were
  missing from the curated list.
- STYLEGUIDE.md gains MeterSmoother and ClientCompKnob entries under
  Components, capturing today's "all meters use MeterSmoother" rule
  and the project-canonical knob widget.
- aethersdr-help.md + getting-started.md PHNE → PHN to match today's
  applet button rename.
- VERIFYING-RELEASES.md stale v0.7.12 filename example replaced with
  vX.Y.Z placeholder.

Version stays at 0.9.8 — bump goes in the final 1.0 ship per the
established release pattern.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
