### PR TITLE
fix(rade): maintain AudioEngine RADE mode on PTT release to fix mic metering

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2136,9 +2136,6 @@ MainWindow::MainWindow(QWidget* parent)
 
 #ifdef HAVE_RADE
         if (m_radeSliceId >= 0 && m_radeEngine && m_radeEngine->isActive()) {
-            if (m_audio) {
-                m_audio->setRadeMode(tx);
-            }
             if (!tx) {
                 m_radeEngine->resetTx();
             }


### PR DESCRIPTION
### **The Problem**
After transmitting in RADE mode, the **Microphone Level Meter** in the P/CW Applet stops deflecting during receive. The meter only recovers if the user toggles the slice mode (e.g., from RADE to USB and back) or restarts the RADE session.

### **The Origin**
The regression originates from commit `e884d8c7` ("RADE: Fix issues with transmit"), which introduced `m_audio->setRadeMode(tx)` into the `moxChanged` handler. This logic incorrectly tied the overall RADE engine state to the transient PTT state. 

When `tx` becomes `false` (on PTT release), RADE mode is disabled in the `AudioEngine`. Because `AudioEngine::onTxAudioReady()` depends on the `m_radeMode` flag to calculate and emit `pcMicLevelChanged` signals, the UI is starved of metering data as soon as the transmission ends. Subsequent work in `fcbba80d` added null-guards to this block but preserved the underlying logic error.

### **The Fix**
This PR removes the `m_audio->setRadeMode(tx)` call from the `moxChanged` handler. 

**Why this is correct:**
1.  **Correct State Ownership:** `AudioEngine` RADE mode should persist as long as a RADE session is active on a slice. This state is already correctly managed by `activateRADE()` and `updateDaxTxMode()`. 
2.  **Uninterrupted Metering:** By maintaining the mode during receive, the client-side microphone metering remains active. This allows operators to verify their "Mic Gain" levels and background noise floor even when not currently transmitting.
3.  **Preserved Teardown:**
    *   PTT-release cleanup (modem reset) is still handled by `m_radeEngine->resetTx()`.
    *   Full RADE session teardown is still handled correctly by `deactivateRADE()`, which calls `setRadeMode(false)`.

### **Validation**
- Verified that the Mic Level meter continues to deflect during RX after a RADE transmission ends.
- Verified that `setRadeMode` transitions still occur correctly when switching modes or closing the RADE session.
- Confirmed that the `m_audio` null-safety added in later commits is not compromised by this change.