### PR TITLE
feat(mainwindow): add 8-axis edge resize to the frameless main window

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -102,6 +102,7 @@
 #include "AetherDspWidget.h"
 #include "ClientRxDspApplet.h"
 #include "DspParamPopup.h"
+#include "FramelessResizer.h"
 #include "FramelessWindowTitleBar.h"
 
 #include <algorithm>
@@ -1022,6 +1023,15 @@ MainWindow::MainWindow(QWidget* parent)
         }
         if (s.value("FramelessWindow", "True").toString() == "True")
             setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
+
+        // 8-axis edge resize for frameless mode — same install pattern
+        // as the floating dialogs (SpotHub, RadioSetup, MemoryDialog).
+        // Filter sits on the native QWindow so it doesn't compete with
+        // the TitleBar's drag-to-move handler (the 6 px resize margin
+        // is well clear of the 18+ px title-bar height).  Stays
+        // installed across frameless toggles — when the system frame is
+        // back on, the platform owns resize and our filter no-ops.
+        FramelessResizer::install(this);
 
         // One-shot migration: remove persisted per-slice audio mute state.
         // The radio does not persist audio_mute, so restoring it from


### PR DESCRIPTION
The main window had Qt::FramelessWindowHint set (default since the
v0.8.23 migration) but no FramelessResizer install — so users on
the frameless variant couldn't resize from the window edges.  Every
floating dialog (SpotHub, RadioSetup, NetworkDiagnostics, Memory
Channels, etc.) already had it; the main window was the lone
holdout.

Drop a single FramelessResizer::install(this) call in the ctor right
after the frameless flag is applied.  Same compositor-managed
QWindow::startSystemResize() path used elsewhere — works on X11,
Wayland, macOS, and Windows.  The 6 px edge margin is well clear of
the TitleBar's 18+ px drag-to-move strip so the two don't fight.
Stays installed across View → Frameless Window toggles; when the
system frame is back, the platform owns resize and the filter no-ops.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
