### PR TITLE
Fix DAX IQ silently broken on Windows / non-PipeWire Linux

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3994,6 +3994,58 @@ MainWindow::MainWindow(QWidget* parent)
     // TCI audio (WSJT-X) should enable PC Audio manually. (#1071)
 #endif
 
+    // ── DAX IQ wiring on platforms without an audio bridge ──────────────
+    //
+    // Same class of bug as #1820 (RADE RX on Windows): startDax() is
+    // compiled out on platforms without an audio bridge (Windows, Linux
+    // without PipeWire), so the DAX IQ stream-status registration handler
+    // that lives inside it never runs.  As a result PanadapterStream sees
+    // the inbound VITA-49 IQ packets but never knows what channel to
+    // route them to — iqDataReady never fires, the GUI applet meter
+    // shows nothing, and TCI clients get no IQ frames.
+    //
+    // Mirror just the IQ-side wiring here (the audio-bridge wiring
+    // genuinely needs the bridge so we leave that gated).  On Mac /
+    // PipeWire builds startDax() does the same wiring lazily when DAX
+    // audio is toggled, so we skip this block to avoid double-connection.
+#if !defined(Q_OS_MAC) && !defined(HAVE_PIPEWIRE)
+    if (m_appletPanel && m_appletPanel->daxIqApplet() && m_radioModel.panStream()) {
+        connect(&m_radioModel, &RadioModel::statusReceived,
+                this, [this](const QString& obj, const QMap<QString,QString>& kvs) {
+            if (!obj.startsWith("stream ")) return;
+            const QStringList parts = obj.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+            if (parts.size() < 2) return;
+            bool ok = false;
+            quint32 streamId = parts[1].toUInt(&ok, 0);
+            if (!ok) return;
+            const bool removed = parts.contains(QStringLiteral("removed"))
+                              || kvs.contains(QStringLiteral("removed"));
+            if (removed) {
+                m_radioModel.panStream()->unregisterIqStream(streamId);
+                m_radioModel.daxIqModel().handleStreamRemoved(streamId);
+                return;
+            }
+            if (kvs.value("type") != "dax_iq") return;
+            if (!streamStatusBelongsToUs(kvs, m_radioModel.ourClientHandle())) return;
+            m_radioModel.daxIqModel().applyStreamStatus(streamId, kvs);
+            int ch = kvs.value("daxiq_channel").toInt();
+            if (streamId && ch >= 1 && ch <= 4)
+                m_radioModel.panStream()->registerIqStream(streamId, ch);
+        });
+
+        connect(m_radioModel.panStream(), &PanadapterStream::iqDataReady,
+                &m_radioModel.daxIqModel(), &DaxIqModel::feedRawIqPacket);
+        connect(&m_radioModel.daxIqModel(), &DaxIqModel::iqLevelReady,
+                m_appletPanel->daxIqApplet(), &DaxIqApplet::setDaxIqLevel);
+        connect(m_appletPanel->daxIqApplet(), &DaxIqApplet::iqEnableRequested,
+                &m_radioModel.daxIqModel(), &DaxIqModel::createStream);
+        connect(m_appletPanel->daxIqApplet(), &DaxIqApplet::iqDisableRequested,
+                &m_radioModel.daxIqModel(), &DaxIqModel::removeStream);
+        connect(m_appletPanel->daxIqApplet(), &DaxIqApplet::iqRateChanged,
+                &m_radioModel.daxIqModel(), &DaxIqModel::setSampleRate);
+    }
+#endif
+
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
     // DAX enable button in DaxApplet → start/stop DAX bridge
     connect(m_appletPanel->daxApplet(), &DaxApplet::daxToggled,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4023,10 +4023,21 @@ MainWindow::MainWindow(QWidget* parent)
             if (removed) {
                 m_radioModel.panStream()->unregisterIqStream(streamId);
                 m_radioModel.daxIqModel().handleStreamRemoved(streamId);
+                qCDebug(lcDax) << "MainWindow: unregistered removed DAX IQ stream"
+                               << "0x" + QString::number(streamId, 16);
                 return;
             }
             if (kvs.value("type") != "dax_iq") return;
-            if (!streamStatusBelongsToUs(kvs, m_radioModel.ourClientHandle())) return;
+            if (!streamStatusBelongsToUs(kvs, m_radioModel.ourClientHandle())) {
+                qCDebug(lcDax) << "MainWindow: ignoring DAX IQ stream for another client"
+                                << "stream=0x" + QString::number(streamId, 16)
+                                << "owner=" << kvs.value("client_handle");
+                return;
+            }
+            qCDebug(lcDax) << "MainWindow: DAX IQ stream status" << obj
+                           << "keys=" << kvs.keys()
+                           << "ch=" << kvs.value("daxiq_channel")
+                           << "ip=" << kvs.value("ip");
             m_radioModel.daxIqModel().applyStreamStatus(streamId, kvs);
             int ch = kvs.value("daxiq_channel").toInt();
             if (streamId && ch >= 1 && ch <= 4)


### PR DESCRIPTION
## Symptom

DAX IQ has never delivered samples to consumer code on Windows or Linux-without-PipeWire — neither the GUI's `DaxIqApplet` level meter nor any TCI IQ client receives any data, even though stream creation succeeds and the radio sends UDP packets that `PanadapterStream` observably receives.

Confirmed on Flex 6700 / Windows 11 / `main@dfd47a8`:

- Toggle DAX IQ channel 1 "On" in DaxIqApplet → no level on the meter
- Send `iq_start:0;` from a TCI client → 0 bytes / 0 frames received

Yet AE's own log (with `DAX`, `Protocol/Status`, `Connection/Commands`, `VITA-49` modules enabled in Support & Diagnostics) clearly shows:

```
TX: "C140|stream create type=dax_iq daxiq_channel=1"
DBG aether.vita49: PanadapterStream: new stream 4128 bytes streamId=0x20000000
RX: "stream 0x20000000 type=dax_iq daxiq_channel=1 pan=0x40000000 ... active=1"
DBG aether.dax: RadioModel: DAX stream status stream=0x20000000 type=dax_iq ours=1
```

So the radio creates the stream and `PanadapterStream` receives the VITA-49 packets. But `iqDataReady` never fires — there is **no** `PanadapterStream: registered IQ stream 0xNNNNNNNN` log line, only `registered pan stream` and `registered wf stream` for the panadapter and waterfall respectively.

## Root cause

Same class of bug as #1820 (RADE RX on Windows).

The DAX IQ stream-status registration handler — the code that calls `panStream->registerIqStream(streamId, ch)` when the radio confirms a stream — lives inside `MainWindow::startDax()`, which is gated:

```cpp
#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
bool MainWindow::startDax() { ... }
#endif
```

On Windows / non-PipeWire Linux, `startDax()` is compiled out entirely. Without `registerIqStream`, `PanadapterStream` receives the inbound VITA-49 IQ packets but has no channel→streamId mapping for them. `iqDataReady` doesn't fire. The GUI level meter stays silent (no `DaxIqModel::feedRawIqPacket`), and `TciServer::onIqDataReady` (which is connected unconditionally) never sees a single frame.

## Fix

Mirror just the IQ-side wiring outside the audio-bridge gate. The DAX RX (audio) wiring genuinely needs the bridge so it stays gated as-is. The DAX IQ wiring is independent of the audio bridge — pure `connect()` calls between `RadioModel`, `PanadapterStream`, `DaxIqModel`, and `DaxIqApplet`, all of which exist on every platform.

The new block is conditional on `#if !defined(Q_OS_MAC) && !defined(HAVE_PIPEWIRE)` so we don't double-connect on platforms where `startDax()` still does the wiring lazily when DAX audio is toggled.

## Test plan

Verified across all three build targets:

| Platform | Build | Code path | Result |
|---|---|---|---|
| Windows 11 (Qt 6.10.3, MSVC) | ✅ clean | Fix active | Real-world: TCI IQ client captured 2813 frames in 30s after `iq_start:0;` |
| macOS Apple Silicon (Qt 6.11.0) | ✅ clean (529 targets) | Fix gated out, existing `startDax()` unchanged | No behavior change |
| Ubuntu 22.04 / R620 (Qt 6.2.4, PulseAudio) | ✅ clean (520 targets) | Fix active — same bug applies | Should fix Linux/PulseAudio users alongside Windows |

The Linux box's CMake configure prints `Linux DAX bridge enabled (PulseAudio pipe modules)` confirming `HAVE_PIPEWIRE` is undefined there too, so this PR closes the registration gap on **two** platforms at once, not just Windows.

## Separate observation, not part of this PR

After this fix, IQ frames flow end-to-end (verified via TCI client receiving binary frames matching `TciAudioHeader` with `type=0`). However, the *contents* of those frames during my testing were zero-padded — 11 MB WAV file with all-zero samples even though frame headers and counts are correct.

The radio's stream status reports `endpoint_type=Display` and `client_gui_handle == client_handle`, suggesting the radio distinguishes between Display-endpoint streams (panadapter spectrum data, what AE-as-a-GUI-client gets) and DAX-endpoint streams (raw IQ samples, what SmartSDR's separate DAX-IQ utility gets via a different client identity). If that's the case, AE may need a different code path to negotiate a DAX endpoint — but that's out of scope for this PR and probably worth a separate discussion.

This PR fixes the registration gap so that **whatever** AE eventually does deliver gets routed to consumers (GUI applet + TCI clients). The empty-payload issue, if it's real, is downstream.

## Diff summary

- One file changed (`src/gui/MainWindow.cpp`)
- ~52 lines added, 0 removed
- No platform-specific APIs introduced
- Direct mirror of the #1820 fix pattern (the audio analog) for the IQ side

73 de G0JKN & Claude (AI dev partner)
