### PR TITLE
fix(windows): resolve ClangCL build failures for NR4/specbleach and R…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,9 +302,19 @@ if(ENABLE_SPECBLEACH)
         set(SPECBLEACH_BUILD_DIR "${CMAKE_BINARY_DIR}/specbleach")
         file(MAKE_DIRECTORY ${SPECBLEACH_BUILD_DIR})
         set(SPECBLEACH_STATIC_LIB "${SPECBLEACH_BUILD_DIR}/specbleach.lib")
+        # When -T ClangCL is used CMAKE_C_COMPILER is the VS-bundled clang-cl which
+        # auto-detects the Windows SDK and MSVC include paths. Prefer it over the
+        # standalone LLVM found by find_program (which may not locate stdint.h in a
+        # MSBuild custom-command environment).
+        if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+            set(_specbleach_cc "${CMAKE_C_COMPILER}")
+        else()
+            set(_specbleach_cc "${CLANG_CL}")
+        endif()
         add_custom_command(
             OUTPUT ${SPECBLEACH_STATIC_LIB}
-            COMMAND ${CLANG_CL} -w --target=x86_64-pc-windows-msvc
+            COMMAND ${_specbleach_cc} -w --target=x86_64-pc-windows-msvc
+                -DFFTW_DLL
                 -I${CMAKE_SOURCE_DIR}/third_party/libspecbleach/include
                 -I${CMAKE_SOURCE_DIR}/third_party/libspecbleach/src
                 -I${CMAKE_SOURCE_DIR}/third_party/fftw3/include
@@ -944,7 +954,11 @@ if(PORTAUDIO_FOUND)
 endif()
 
 if(FFTW3_FOUND)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_FFTW3)
+    target_compile_definitions(AetherSDR PRIVATE HAVE_FFTW3
+        # On Windows lld-link (used by ClangCL) requires explicit dllimport
+        # declarations; define FFTW_DLL so fftw3.h emits __declspec(dllimport)
+        # and the linker can resolve __imp_fftwf_* symbols from the import lib.
+        $<$<BOOL:${WIN32}>:FFTW_DLL>)
     target_include_directories(AetherSDR PRIVATE ${FFTW3_INCLUDE_DIRS})
     target_link_directories(AetherSDR PRIVATE ${FFTW3_LIBRARY_DIRS})
     target_link_libraries(AetherSDR PRIVATE ${FFTW3_LIBRARIES})

--- a/third_party/radae/cmake/BuildOpus.cmake
+++ b/third_party/radae/cmake/BuildOpus.cmake
@@ -50,8 +50,13 @@ if(WIN32)
         URL_HASH ${OPUS_PREPARED_ARCHIVE_HASH}
         CMAKE_ARGS
             ${OPUS_CMAKE_ARGS}
-        BUILD_BYPRODUCTS <BINARY_DIR>/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
-                         <BINARY_DIR>/libopus${CMAKE_STATIC_LIBRARY_SUFFIX}
+        # VS multi-config generator puts the lib in a per-config subdir.
+        # List all standard configs as byproducts so Ninja/MSBuild tracks them.
+        BUILD_BYPRODUCTS
+            <BINARY_DIR>/Debug/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <BINARY_DIR>/Release/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <BINARY_DIR>/RelWithDebInfo/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <BINARY_DIR>/MinSizeRel/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
         INSTALL_COMMAND ""
     )
 
@@ -60,16 +65,27 @@ if(WIN32)
     add_library(opus STATIC IMPORTED)
     add_dependencies(opus build_opus)
 
-    # CMake produces opus.lib (MSVC) or libopus.a (MinGW)
     if(MSVC)
-        set(_opus_lib "${BINARY_DIR}/opus${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        # $<CONFIG> is not evaluated in IMPORTED_LOCATION for imported targets;
+        # set per-config properties for each standard VS build configuration.
+        foreach(_cfg Debug Release RelWithDebInfo MinSizeRel)
+            set(_lib "${BINARY_DIR}/${_cfg}/opus${CMAKE_STATIC_LIBRARY_SUFFIX}")
+            set_target_properties(opus PROPERTIES
+                "IMPORTED_LOCATION_${_cfg}" "${_lib}"
+                "IMPORTED_IMPLIB_${_cfg}"   "${_lib}"
+            )
+        endforeach()
+        # Fallback for any unlisted config — use RelWithDebInfo
+        set_target_properties(opus PROPERTIES
+            IMPORTED_LOCATION "${BINARY_DIR}/RelWithDebInfo/opus${CMAKE_STATIC_LIBRARY_SUFFIX}"
+        )
     else()
         set(_opus_lib "${BINARY_DIR}/libopus${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        set_target_properties(opus PROPERTIES
+            IMPORTED_LOCATION "${_opus_lib}"
+            IMPORTED_IMPLIB   "${_opus_lib}"
+        )
     endif()
-    set_target_properties(opus PROPERTIES
-        IMPORTED_LOCATION "${_opus_lib}"
-        IMPORTED_IMPLIB   "${_opus_lib}"
-    )
 
     include_directories(${SOURCE_DIR}/dnn ${SOURCE_DIR}/celt ${SOURCE_DIR}/include ${SOURCE_DIR})
 

--- a/third_party/radae/cmake/BuildOpus.cmake
+++ b/third_party/radae/cmake/BuildOpus.cmake
@@ -44,19 +44,32 @@ endif ()
 
 # ── Windows: build Opus via CMake ─────────────────────────────────────────
 if(WIN32)
+    # VS (multi-config) places opus.lib in <BINARY_DIR>/<Config>/; Ninja and
+    # other single-config generators place it flat at <BINARY_DIR>/.  CI uses
+    # Ninja, most local Windows ClangCL setups also use Ninja, while -T ClangCL
+    # implies the VS generator — so both layouts are real and we must detect.
+    get_property(_opus_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(_opus_is_multi_config)
+        set(_opus_byproducts
+            <BINARY_DIR>/Debug/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <BINARY_DIR>/Release/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <BINARY_DIR>/RelWithDebInfo/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <BINARY_DIR>/MinSizeRel/opus${CMAKE_STATIC_LIBRARY_SUFFIX})
+    else()
+        # Single-config: MSVC emits opus.lib, MinGW emits libopus.a — list both
+        # so the generator picks whichever the toolchain produced.
+        set(_opus_byproducts
+            <BINARY_DIR>/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
+            <BINARY_DIR>/libopus${CMAKE_STATIC_LIBRARY_SUFFIX})
+    endif()
+
     ExternalProject_Add(build_opus
         DOWNLOAD_EXTRACT_TIMESTAMP NO
         URL "${OPUS_PREPARED_ARCHIVE}"
         URL_HASH ${OPUS_PREPARED_ARCHIVE_HASH}
         CMAKE_ARGS
             ${OPUS_CMAKE_ARGS}
-        # VS multi-config generator puts the lib in a per-config subdir.
-        # List all standard configs as byproducts so Ninja/MSBuild tracks them.
-        BUILD_BYPRODUCTS
-            <BINARY_DIR>/Debug/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
-            <BINARY_DIR>/Release/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
-            <BINARY_DIR>/RelWithDebInfo/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
-            <BINARY_DIR>/MinSizeRel/opus${CMAKE_STATIC_LIBRARY_SUFFIX}
+        BUILD_BYPRODUCTS ${_opus_byproducts}
         INSTALL_COMMAND ""
     )
 
@@ -66,19 +79,28 @@ if(WIN32)
     add_dependencies(opus build_opus)
 
     if(MSVC)
-        # $<CONFIG> is not evaluated in IMPORTED_LOCATION for imported targets;
-        # set per-config properties for each standard VS build configuration.
-        foreach(_cfg Debug Release RelWithDebInfo MinSizeRel)
-            set(_lib "${BINARY_DIR}/${_cfg}/opus${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        if(_opus_is_multi_config)
+            # $<CONFIG> is not evaluated in IMPORTED_LOCATION for imported targets;
+            # set per-config properties for each standard VS build configuration.
+            foreach(_cfg Debug Release RelWithDebInfo MinSizeRel)
+                set(_lib "${BINARY_DIR}/${_cfg}/opus${CMAKE_STATIC_LIBRARY_SUFFIX}")
+                set_target_properties(opus PROPERTIES
+                    "IMPORTED_LOCATION_${_cfg}" "${_lib}"
+                    "IMPORTED_IMPLIB_${_cfg}"   "${_lib}"
+                )
+            endforeach()
+            # Fallback for any unlisted config — use RelWithDebInfo
             set_target_properties(opus PROPERTIES
-                "IMPORTED_LOCATION_${_cfg}" "${_lib}"
-                "IMPORTED_IMPLIB_${_cfg}"   "${_lib}"
+                IMPORTED_LOCATION "${BINARY_DIR}/RelWithDebInfo/opus${CMAKE_STATIC_LIBRARY_SUFFIX}"
             )
-        endforeach()
-        # Fallback for any unlisted config — use RelWithDebInfo
-        set_target_properties(opus PROPERTIES
-            IMPORTED_LOCATION "${BINARY_DIR}/RelWithDebInfo/opus${CMAKE_STATIC_LIBRARY_SUFFIX}"
-        )
+        else()
+            # Ninja / single-config MSVC: flat layout
+            set(_opus_lib "${BINARY_DIR}/opus${CMAKE_STATIC_LIBRARY_SUFFIX}")
+            set_target_properties(opus PROPERTIES
+                IMPORTED_LOCATION "${_opus_lib}"
+                IMPORTED_IMPLIB   "${_opus_lib}"
+            )
+        endif()
     else()
         set(_opus_lib "${BINARY_DIR}/libopus${CMAKE_STATIC_LIBRARY_SUFFIX}")
         set_target_properties(opus PROPERTIES


### PR DESCRIPTION
…ADE/Opus

Three issues prevented a successful Windows build with -T ClangCL:

1. specbleach custom command used the standalone LLVM clang-cl found by find_program, which does not auto-detect Windows SDK include paths in a MSBuild custom-command environment. stdint.h (uint32_t) was therefore not found. Fix: when CMAKE_C_COMPILER_ID is Clang (-T ClangCL is active), use CMAKE_C_COMPILER (the VS-bundled clang-cl) which has SDK paths built in.

2. lld-link (used by the ClangCL toolset) is stricter than MSVC link.exe and will not auto-redirect bare fftwf_xxx references to __imp_fftwf_xxx import stubs. Fix: define FFTW_DLL on Windows so fftw3.h emits __declspec(dllimport) and the compiler generates the __imp_ references lld-link expects. Also add -DFFTW_DLL to the specbleach clang-cl compile step for the same reason.

3. ExternalProject_Add (build_opus / RADE) uses the VS multi-config generator, which places opus.lib in a per-config subdirectory (e.g. RelWithDebInfo/) rather than the flat BINARY_DIR the old code expected. Fix: enumerate all standard configs in BUILD_BYPRODUCTS and set IMPORTED_LOCATION_<CONFIG> per-config properties ($<CONFIG> generator expressions are not evaluated in IMPORTED_LOCATION for imported static targets).