### PR TITLE
Fix memory recall radio state sync

### DIFF
--- a/src/core/MemoryRecallPolicy.cpp
+++ b/src/core/MemoryRecallPolicy.cpp
@@ -31,6 +31,13 @@ double memoryRepeaterTxOffsetFreq(const MemoryEntry& memory)
     return 0.0;
 }
 
+QString buildMemoryRecallRetuneCommand(int sliceId, const MemoryEntry& memory)
+{
+    if (sliceId < 0 || memory.freq <= 0.0)
+        return {};
+    return QString("slice tune %1 %2 autopan=0").arg(sliceId).arg(memory.freq, 0, 'f', 6);
+}
+
 QString buildMemoryRecallSliceFixupCommand(int sliceId, const MemoryEntry& memory)
 {
     QStringList fields;

--- a/src/core/MemoryRecallPolicy.h
+++ b/src/core/MemoryRecallPolicy.h
@@ -5,6 +5,7 @@
 namespace AetherSDR {
 
 double memoryRepeaterTxOffsetFreq(const MemoryEntry& memory);
+QString buildMemoryRecallRetuneCommand(int sliceId, const MemoryEntry& memory);
 QString buildMemoryRecallSliceFixupCommand(int sliceId, const MemoryEntry& memory);
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -211,7 +211,14 @@ constexpr int kSwrSweepMaxPoints = 260;
 constexpr int kSwrSweepMinPowerW = 1;
 constexpr int kSwrSweepDefaultPowerW = 1;
 constexpr int kSwrSweepMaxPowerW = 10;
+constexpr double kMemoryRevealTargetToleranceMhz = 0.000001;
 constexpr const char* kSwrSweepPowerSettingKey = "SwrSweepPowerWatts";
+
+bool memoryRevealTargetMatches(double actualMhz, double targetMhz)
+{
+    return targetMhz <= 0.0
+        || std::abs(actualMhz - targetMhz) <= kMemoryRevealTargetToleranceMhz;
+}
 
 int panCountForLayoutId(const QString& layoutId)
 {
@@ -8308,19 +8315,63 @@ bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPan
     if (!slice)
         return false;
 
+    const double memoryFreqMhz = it->freq;
+    const bool hasMemoryFrequency = memoryFreqMhz > 0.0;
+    const QString slicePanId = slice->panId();
+
+    if (hasMemoryFrequency) {
+        const QString memoryBand = BandSettings::bandForFrequency(memoryFreqMhz);
+        const QString currentBand = BandSettings::bandForFrequency(slice->frequency());
+        if (memoryBand != currentBand) {
+            const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
+            const auto stackKeyResult = XvtrPolicy::resolveBandStackKey(memoryBand, xvtrs);
+            if (stackKeyResult.isSupported()) {
+                qCDebug(lcProtocol).noquote().nospace()
+                    << "MainWindow: memory recall preselecting band stack memory="
+                    << memoryIndex
+                    << " pan=" << slicePanId
+                    << " from_band=" << currentBand
+                    << " to_band=" << memoryBand
+                    << " key=" << stackKeyResult.key;
+                clearSwrSweepForBandChange(-1, slicePanId, memoryBand);
+                m_bandSettings.setCurrentBand(memoryBand);
+                m_radioModel.sendCommand(
+                    QString("display pan set %1 band=%2").arg(slicePanId, stackKeyResult.key));
+                QTimer::singleShot(300, this, [this, slicePanId]() {
+                    reassertUnmutedSliceAudioForPan(slicePanId);
+                });
+            } else {
+                qCWarning(lcProtocol).noquote().nospace()
+                    << "MainWindow: memory recall cannot preselect band stack memory="
+                    << memoryIndex
+                    << " band=" << memoryBand
+                    << " reason=" << stackKeyResult.unsupportedReason
+                    << " available_xvtrs=" << xvtrListSummary(xvtrs);
+            }
+        }
+    }
+
     m_pendingMemoryRevealSliceId = sliceId;
+    m_pendingMemoryRevealTargetMhz = hasMemoryFrequency ? memoryFreqMhz : 0.0;
     m_radioModel.sendCommand(QString("memory apply %1").arg(memoryIndex));
+    const QString retuneCommand =
+        AetherSDR::buildMemoryRecallRetuneCommand(sliceId, it.value());
+    if (!retuneCommand.isEmpty())
+        m_radioModel.sendCommand(retuneCommand);
     QTimer::singleShot(750, this, [this, sliceId]() {
         if (m_pendingMemoryRevealSliceId != sliceId)
             return;
+        const double targetMhz = m_pendingMemoryRevealTargetMhz;
         m_pendingMemoryRevealSliceId = -1;
+        m_pendingMemoryRevealTargetMhz = 0.0;
         if (auto* pendingSlice = m_radioModel.slice(sliceId)) {
+            const double revealMhz = targetMhz > 0.0 ? targetMhz : pendingSlice->frequency();
             const TuneCenteringResult result =
-                revealFrequencyIfNeeded(pendingSlice, pendingSlice->frequency(),
+                revealFrequencyIfNeeded(pendingSlice, revealMhz,
                                         TuneIntent::CommandedTargetCenter,
                                         "memory-apply-timeout");
             logTunePolicyDecision("memory-apply-timeout", TuneIntent::CommandedTargetCenter,
-                                  pendingSlice->frequency(), pendingSlice->frequency(),
+                                  pendingSlice->frequency(), revealMhz,
                                   result);
         }
     });
@@ -8533,11 +8584,24 @@ void MainWindow::onSliceAdded(SliceModel* s)
         m_updatingFromModel = false;
 
         if (memoryRevealPending) {
-            m_pendingMemoryRevealSliceId = -1;
-            const TuneCenteringResult result =
-                revealFrequencyIfNeeded(s, mhz, TuneIntent::CommandedTargetCenter, "memory-apply");
-            logTunePolicyDecision("memory-apply", TuneIntent::CommandedTargetCenter,
-                                  mhz, mhz, result);
+            const double targetMhz = m_pendingMemoryRevealTargetMhz;
+            if (memoryRevealTargetMatches(mhz, targetMhz)) {
+                m_pendingMemoryRevealSliceId = -1;
+                m_pendingMemoryRevealTargetMhz = 0.0;
+                const double revealMhz = targetMhz > 0.0 ? targetMhz : mhz;
+                const TuneCenteringResult result =
+                    revealFrequencyIfNeeded(s, revealMhz,
+                                            TuneIntent::CommandedTargetCenter,
+                                            "memory-apply");
+                logTunePolicyDecision("memory-apply", TuneIntent::CommandedTargetCenter,
+                                      mhz, revealMhz, result);
+            } else {
+                qCDebug(lcProtocol).noquote().nospace()
+                    << "MainWindow: deferring memory reveal for intermediate echo slice="
+                    << s->sliceId()
+                    << " echo_mhz=" << QString::number(mhz, 'f', 6)
+                    << " target_mhz=" << QString::number(targetMhz, 'f', 6);
+            }
         }
 
         if (s->isTxSlice() || s->sliceId() == m_swrSweep.sliceId) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -478,6 +478,7 @@ private:
     int  m_splitRxSliceId{-1};
     int  m_splitTxSliceId{-1};
     int  m_pendingMemoryRevealSliceId{-1};
+    double m_pendingMemoryRevealTargetMhz{0.0};
     int  m_pendingSpectrumTargetSliceId{-1};
 
     // Guard: set true while updating controls from the model so shared tune

--- a/tests/memory_recall_policy_test.cpp
+++ b/tests/memory_recall_policy_test.cpp
@@ -26,6 +26,10 @@ int main()
     up.toneValue = 88.5;
     ok &= expect(AetherSDR::memoryRepeaterTxOffsetFreq(up) == 0.1,
                  "up repeater offset produces positive tx_offset_freq");
+    up.freq = 146.52;
+    ok &= expect(AetherSDR::buildMemoryRecallRetuneCommand(3, up)
+                     == "slice tune 3 146.520000 autopan=0",
+                 "memory recall retunes slice without autopan");
     ok &= expect(AetherSDR::buildMemoryRecallSliceFixupCommand(3, up)
                      == "slice set 3 repeater_offset_dir=up fm_repeater_offset_freq=0.100000 "
                         "tx_offset_freq=0.100000 fm_tone_mode=ctcss_tx fm_tone_value=88.5",
@@ -60,6 +64,8 @@ int main()
                  "tone value can be fixed up even when tone mode is absent");
 
     AetherSDR::MemoryEntry empty;
+    ok &= expect(AetherSDR::buildMemoryRecallRetuneCommand(2, empty).isEmpty(),
+                 "memory without frequency does not emit retune command");
     ok &= expect(AetherSDR::buildMemoryRecallSliceFixupCommand(2, empty).isEmpty(),
                  "memory without repeater or tone details does not emit a fixup command");
 


### PR DESCRIPTION
## Summary

Fixes memory recall paths that could leave the panadapter band stack and actual slice tuner state out of sync when recalling memories across bands or shortly after a band change.

Fixes #2357 and #2377 

## Root Cause

Memory recall previously relied on `memory apply <idx>` plus a later frequency echo to center the target. That skipped the explicit panadapter band-stack transition that normal band-button selection performs, so cross-band memories could leave waterfall, antenna/BPF routing, and USB/CAT band state on the previous band until the user pressed Band manually.

Separately, on the reported Flex 8400 firmware path, `memory apply` could report the memory frequency while the actual receiver did not fully retune until a small wheel movement sent `slice tune ... autopan=0`.

## What Changed

- Before `memory apply`, cross-band memory recall now sends `display pan set <pan> band=<key>` using the same XVTR-aware band-stack key resolver as the band menu.
- After `memory apply`, memory recall now sends an explicit `slice tune <slice> <memoryFreq> autopan=0` so the radio tuner re-honors the intended memory frequency without letting the radio perform its own pan recenter.
- The pending memory reveal now tracks the intended target frequency, so an intermediate band-stack frequency echo cannot consume the existing commanded-center reveal before the memory target arrives.
- Added focused coverage for the memory recall retune command builder.

## User Impact

Recalling a memory across bands should now behave like a coherent band-stack transition followed by a precise memory tune: waterfall stays live, CAT/amp band state updates promptly, and audio should match the displayed slice frequency without requiring a mouse-wheel twitch.

## Validation

Built and tested locally:

```sh
env -u CPLUS_INCLUDE_PATH cmake --build build-ninja --target AetherSDR memory_recall_policy_test --parallel 22
./build-ninja/memory_recall_policy_test
```

Live-radio scenarios verified by @jensenpat:

- 40m to 80m memory recall keeps waterfall/audio/CAT coherent.
- 80m memory recall after selecting 80m via Band works without a wheel twitch.
- Same-band memory recall remains stable.
- 80m to 40m reverse cross-band recall works.
- Panadapter memory overlay recall path works.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
