### PR TITLE
fix(gui): freeze waterfall blanker across TX to kill 10–18 s post-TX smear

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1780,8 +1780,15 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
         }
     }
 
-    // NB Waterfall Blanker (#277) — suppress impulse rows
-    if (m_wfBlankerEnabled) {
+    // NB Waterfall Blanker (#277) — suppress impulse rows.
+    // Skip entirely during TX: with show-tx-in-waterfall enabled, TX-era tiles
+    // flow through and would otherwise poison the rolling baseline.  Post-TX,
+    // real RX rows would then read as huge "impulses" against the suppressed
+    // TX-era baseline, causing the blanker to substitute m_wfLastGoodRow (a
+    // TX-era scanline) for ~10–18 s while baseline slowly re-converges —
+    // visible as a frozen, striped waterfall.  Freezing the ring across TX
+    // means post-TX rows are compared against the pre-TX baseline instead.
+    if (m_wfBlankerEnabled && !m_transmitting) {
         float rowSum = 0.0f;
         const int binCount = binsIntensity.size();
         for (int i = 0; i < binCount; ++i)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -356,6 +356,7 @@ public:
             m_wfPrevTimecodeMs = 0;
             m_txEndMs = QDateTime::currentMSecsSinceEpoch(); // post-TX blanking (#2117)
             m_wfBlankerRingCount = 0;                        // reset stale blanker baseline
+            m_wfLastGoodRow.clear();                          // forget any TX-era last-good scanline
         }
         m_transmitting = tx;
     }


### PR DESCRIPTION
The client-side waterfall blanker's 8-row rolling baseline ran every tile
regardless of TX state.  With show-tx-in-waterfall enabled, TX-era tiles
(low/different content) poisoned the baseline.  Post-TX, real RX rows
read as huge impulses against that suppressed baseline → the blanker
substituted m_wfLastGoodRow (a TX-era scanline) row after row, producing
a frozen, vertically-striped waterfall for 10–18 s while the baseline
slowly re-converged via the min(rowMean, baseline*1.05) clamp.

Skip the blanker entirely while m_transmitting is true so the ring keeps
its pre-TX baseline across the cycle.  Also clear m_wfLastGoodRow on
TX-end so any impulse that does fire in the first few post-TX tiles
can't paint a stale TX-era scanline.

Appeared as Linux-only because WaterfallBlankingEnabled is a per-machine
AppSettings value — Mac/Windows hadn't enabled it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
