### PR TITLE
docs(756): Document Qt 6.7+ requirement for GPU rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ option(AETHER_GPU_SPECTRUM "Enable QRhi GPU spectrum rendering" ON)
 if(AETHER_GPU_SPECTRUM)
     if(Qt6_VERSION VERSION_LESS "6.7")
         set(AETHER_GPU_SPECTRUM OFF)
-        message(STATUS "GPU spectrum rendering disabled (requires Qt 6.7+, found ${Qt6_VERSION})")
+        message(STATUS "GPU spectrum rendering disabled (requires Qt 6.7+, found ${Qt6_VERSION} — pass -DCMAKE_PREFIX_PATH=/path/to/Qt/6.7.x/gcc_64 to use a newer Qt installation)")
     else()
         find_package(Qt6 REQUIRED COMPONENTS ShaderTools)
         # Qt6GuiPrivate provides QRhi headers needed for GPU rendering.

--- a/README.md
+++ b/README.md
@@ -69,29 +69,7 @@ Pre-built binaries are available from [Releases](https://github.com/ten9876/Aeth
 
 ---
 
-
-### Qt 6.7+ for GPU Spectrum Rendering
-
-GPU-accelerated spectrum/waterfall rendering requires Qt 6.7 or greater. If your distribution ships with an older version (e.g., Ubuntu 24.04, Debian 12, or Mint 21-22 include Qt 6.4.2), the build system automatically disables GPU rendering and falls back to the CPU-based `QPainter` path.
-
-To use GPU acceleration on these systems, you must install Qt 6.7+ manually:
-
-1. **Option 1: Using PPA (Ubuntu/Mint)**
-   You may be able to use the `kubuntu-backports` PPA to obtain a newer Qt version.
-
-2. **Option 2: Using the Qt Online Installer**
-   Install the newer Qt version into your home directory (e.g., `~/Qt/6.7.3/gcc_64`). Because CMake often defaults to the system-provided Qt, you must explicitly point CMake to the newer version using the `-DCMAKE_PREFIX_PATH` flag:
-
-   ```bash
-   cmake -B build -G Ninja \
-       -DCMAKE_PREFIX_PATH="$HOME/Qt/6.7.3/gcc_64" \
-       -DCMAKE_BUILD_TYPE=RelWithDebInfo
-   ```
-
-*Note: Ensure you have installed the necessary development headers (e.g., `qt6-base-private-dev` equivalent for your installed Qt version).*
-
-### Building from Source
-
+## Building from Source
 
 ### Dependencies
 
@@ -160,6 +138,28 @@ cmake --build build -j$(nproc)
 
 RADE-enabled builds use a vendored Opus snapshot, so no additional Opus download
 is required during configure or build.
+
+### Qt 6.7+ for GPU Spectrum Rendering
+
+GPU-accelerated spectrum/waterfall rendering requires Qt 6.7 or greater. If your distribution ships with an older version (e.g., Ubuntu 24.04, Debian 12, or Mint 21–22 include Qt 6.4.2), the build system automatically disables GPU rendering and falls back to the CPU-based `QPainter` path. (Release binaries ship Qt 6.8.3 LTS; the 6.7 floor is the source-build minimum for QRhi.)
+
+To use GPU acceleration on these systems, install Qt 6.7+ manually:
+
+1. **Option 1: Using a PPA (Ubuntu/Mint)**
+   The `kubuntu-backports` PPA may provide a newer Qt — verify the version it ships before relying on it.
+
+2. **Option 2: Using the Qt Online Installer**
+   Install Qt into your home directory (e.g., `~/Qt/6.8.3/gcc_64`). Because CMake otherwise defaults to the system-provided Qt, point it at the newer install with `-DCMAKE_PREFIX_PATH`:
+
+   ```bash
+   cmake -B build -G Ninja \
+       -DCMAKE_PREFIX_PATH="$HOME/Qt/6.8.3/gcc_64" \
+       -DCMAKE_BUILD_TYPE=RelWithDebInfo
+   ```
+
+   Make sure the `qtshadertools` and `qt5compat` (or equivalent) modules are selected in the Qt Online Installer along with `qtbase`.
+
+*Note: GPU rendering also needs the private QtGui headers (`qt6-base-private-dev` on Debian-family, included by default in the Qt Online Installer).*
 
 ### Install (optional, Linux)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,29 @@ Pre-built binaries are available from [Releases](https://github.com/ten9876/Aeth
 
 ---
 
-## Building from Source
+
+### Qt 6.7+ for GPU Spectrum Rendering
+
+GPU-accelerated spectrum/waterfall rendering requires Qt 6.7 or greater. If your distribution ships with an older version (e.g., Ubuntu 24.04, Debian 12, or Mint 21-22 include Qt 6.4.2), the build system automatically disables GPU rendering and falls back to the CPU-based `QPainter` path.
+
+To use GPU acceleration on these systems, you must install Qt 6.7+ manually:
+
+1. **Option 1: Using PPA (Ubuntu/Mint)**
+   You may be able to use the `kubuntu-backports` PPA to obtain a newer Qt version.
+
+2. **Option 2: Using the Qt Online Installer**
+   Install the newer Qt version into your home directory (e.g., `~/Qt/6.7.3/gcc_64`). Because CMake often defaults to the system-provided Qt, you must explicitly point CMake to the newer version using the `-DCMAKE_PREFIX_PATH` flag:
+
+   ```bash
+   cmake -B build -G Ninja \
+       -DCMAKE_PREFIX_PATH="$HOME/Qt/6.7.3/gcc_64" \
+       -DCMAKE_BUILD_TYPE=RelWithDebInfo
+   ```
+
+*Note: Ensure you have installed the necessary development headers (e.g., `qt6-base-private-dev` equivalent for your installed Qt version).*
+
+### Building from Source
+
 
 ### Dependencies
 


### PR DESCRIPTION
### Description
This PR addresses issue #756 by improving discoverability and guidance for users building AetherSDR on Linux distributions (such as Ubuntu 24.04, Debian 12, or Mint 21-22) that ship with older versions of Qt (e.g., 6.4.2).

As noted in the issue, GPU-accelerated spectrum/waterfall rendering requires Qt 6.7+. Without clear guidance, users on these systems may be confused as to why GPU rendering is automatically disabled by the build system.

### Changes
1.  **README.md**: Added a new subsection under "Building from Source" titled "Qt 6.7+ for GPU Spectrum Rendering." This documents:
    *   Why GPU rendering is disabled on older systems.
    *   The requirement for manual Qt 6.7+ installation via the Qt Online Installer or PPA.
    *   The necessary CMAKE_PREFIX_PATH flag to correctly point CMake to the newer Qt installation.
2.  **CMakeLists.txt**: Updated the status message for when GPU rendering is disabled. It now explicitly directs users to pass the -DCMAKE_PREFIX_PATH flag if they wish to use a newer, manually installed Qt version.

### Impact
This improves the "out-of-the-box" experience for source-build users on older Linux distributions by clarifying the prerequisite for GPU acceleration and providing an actionable path to resolve it.

Closes #756
