### PR TITLE
feat(gui): move Add Memory action into MemoryBrowsePanel, drop slice-letter badge

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8326,12 +8326,6 @@ void MainWindow::refreshMemoryBrowsePanel()
             continue;
         if (auto* menu = applet->spectrumWidget()->overlayMenu()) {
             menu->setMemories(m_radioModel.memories());
-            // Update the MEM button badge showing which slice save/recall
-            // will target on this pan — makes the fallback slice visible
-            // when the active slice is on a different pan (#1781).
-            auto* target = preferredMemorySlice(menu->panId());
-            menu->setMemoryTargetSliceLetter(
-                target ? QChar('A' + (target->sliceId() & 3)) : QChar());
         }
     }
 }

--- a/src/gui/MemoryBrowsePanel.cpp
+++ b/src/gui/MemoryBrowsePanel.cpp
@@ -7,6 +7,7 @@
 #include <QAbstractItemView>
 #include <QHeaderView>
 #include <QLabel>
+#include <QPushButton>
 #include <QTableWidgetItem>
 #include <QTableWidget>
 #include <QVBoxLayout>
@@ -29,12 +30,12 @@ QString displayMemoryName(const MemoryEntry& memory)
 MemoryBrowsePanel::MemoryBrowsePanel(QWidget* parent)
     : QWidget(parent)
 {
-    setFixedSize(252, 430);
+    setFixedSize(252, 460);
     setStyleSheet("background: rgba(15, 15, 26, 220); border: 1px solid #304050; border-radius: 3px;");
 
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(3, 3, 3, 3);
-    root->setSpacing(0);
+    root->setSpacing(4);
 
     m_emptyLabel = new QLabel("No memories are available yet.", this);
     m_emptyLabel->setAlignment(Qt::AlignCenter);
@@ -70,6 +71,22 @@ MemoryBrowsePanel::MemoryBrowsePanel(QWidget* parent)
         "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }");
     root->addWidget(m_table, 1);
     m_table->hide();
+
+    // "MEM+" button anchored at the bottom of the panel — outside the
+    // scrolling table so it stays visible regardless of scroll position.
+    // Style matches the spectrum overlay menu buttons it replaces.
+    m_addBtn = new QPushButton(QStringLiteral("Add Memory"), this);
+    m_addBtn->setFixedHeight(22);
+    m_addBtn->setStyleSheet(
+        "QPushButton { background: rgba(20, 30, 45, 240); "
+        "border: 1px solid rgba(255, 255, 255, 40); border-radius: 2px; "
+        "color: #c8d8e8; font-size: 11px; font-weight: bold; }"
+        "QPushButton:hover { background: rgba(0, 112, 192, 180); "
+        "border: 1px solid #0090e0; }");
+    m_addBtn->setToolTip("Save the current slice on this panadapter as a memory.");
+    root->addWidget(m_addBtn, 0);
+    connect(m_addBtn, &QPushButton::clicked, this,
+            &MemoryBrowsePanel::quickAddRequested);
 
     connect(m_table, &QTableWidget::cellClicked, this, [this](int row, int) {
         auto* indexItem = m_table->item(row, 0);

--- a/src/gui/MemoryBrowsePanel.h
+++ b/src/gui/MemoryBrowsePanel.h
@@ -5,6 +5,7 @@
 #include <QWidget>
 
 class QLabel;
+class QPushButton;
 class QTableWidget;
 
 namespace AetherSDR {
@@ -20,6 +21,7 @@ public:
 
 signals:
     void memoryActivated(int memoryIndex);
+    void quickAddRequested();
 
 private:
     void populateTable();
@@ -29,6 +31,7 @@ private:
     QMap<int, MemoryEntry> m_memories;
     QLabel* m_emptyLabel{nullptr};
     QTableWidget* m_table{nullptr};
+    QPushButton* m_addBtn{nullptr};
     int m_highlightedMemoryIndex{-1};
 };
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -116,9 +116,9 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
         {"Band",      0, nullptr},   // 2 — toggleBandPanel
         {"ANT",       1, nullptr},   // 3 — toggleAntPanel
         {"Display",   4, nullptr},   // 4 — toggleDisplayPanel
-        {QStringLiteral("MEM\u25b8"), 5, nullptr},   // 6 — toggleMemoryPanel
-        {"MEM+",      6, nullptr},   // 7 — quickAddMemoryRequested
-        {"DAX",       3, nullptr},   // 8 — toggleDaxPanel
+        {"Memory",    5, nullptr},   // 6 — toggleMemoryPanel
+        // MEM+ moved into MemoryBrowsePanel (bottom button — doesn't scroll).
+        {"DAX",       3, nullptr},   // 6 — toggleDaxPanel
     };
 
     for (const auto& def : defs) {
@@ -133,11 +133,6 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleDisplayPanel);
         else if (def.specialIdx == 5)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleMemoryPanel);
-        else if (def.specialIdx == 6)
-            connect(btn, &QPushButton::clicked, this, [this]() {
-                hideAllSubPanels();
-                emit quickAddMemoryRequested(m_panId);
-            });
         else if (def.text == "+RX")
             connect(btn, &QPushButton::clicked, this, [this]() { emit addRxClicked(m_panId); });
         else if (def.sig)
@@ -146,14 +141,13 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
     }
 
     // Menu button tooltips
-    if (m_menuBtns.size() >= 8) {
+    if (m_menuBtns.size() >= 7) {
         m_menuBtns[kBtnAddRx]->setToolTip("Add a new receive slice on this panadapter.");
         m_menuBtns[kBtnAddTnf]->setToolTip("Add a tracking notch filter at the current frequency.");
         m_menuBtns[kBtnBand]->setToolTip("Open band selector.");
         m_menuBtns[kBtnAnt]->setToolTip("Open antenna and RF gain controls.");
         m_menuBtns[kBtnDisplay]->setToolTip("Open panadapter and waterfall display settings.");
         m_menuBtns[kBtnMemoryBrowse]->setToolTip("Browse saved memories for quick recall.");
-        m_menuBtns[kBtnMemoryAdd]->setToolTip("Save the current slice on this panadapter as a memory.");
         m_menuBtns[kBtnDax]->setToolTip("Open DAX audio routing channel selector.");
     }
 
@@ -186,17 +180,6 @@ void SpectrumOverlayMenu::setMemories(const QMap<int, MemoryEntry>& memories)
 {
     if (m_memoryPanel)
         m_memoryPanel->setMemories(memories);
-}
-
-void SpectrumOverlayMenu::setMemoryTargetSliceLetter(QChar letter)
-{
-    if (m_menuBtns.size() <= kBtnMemoryAdd) return;
-    const QString browseBase = QStringLiteral("MEM\u25b8");
-    const QString addBase    = QStringLiteral("MEM+");
-    const bool hasTarget = letter.isLetter();
-    const QString suffix = hasTarget ? QString(QChar(' ')) + letter.toUpper() : QString();
-    m_menuBtns[kBtnMemoryBrowse]->setText(browseBase + suffix);
-    m_menuBtns[kBtnMemoryAdd]->setText(addBase + suffix);
 }
 
 // ── Band sub-panel ────────────────────────────────────────────────────────────
@@ -566,6 +549,10 @@ void SpectrumOverlayMenu::buildMemoryPanel()
         hideAllSubPanels();
         emit memoryActivated(memoryIndex, m_panId);
     });
+    connect(m_memoryPanel, &MemoryBrowsePanel::quickAddRequested, this, [this]() {
+        hideAllSubPanels();
+        emit quickAddMemoryRequested(m_panId);
+    });
 }
 
 void SpectrumOverlayMenu::toggleMemoryPanel()
@@ -605,7 +592,7 @@ void SpectrumOverlayMenu::hideAllSubPanels()
     m_memoryPanelVisible = false;
     if (m_memoryPanel) m_memoryPanel->hide();
     for (int idx : {kBtnBand, kBtnAnt, kBtnDisplay,
-                    kBtnMemoryBrowse, kBtnMemoryAdd, kBtnDax}) {
+                    kBtnMemoryBrowse, kBtnDax}) {
         if (idx >= 0 && idx < m_menuBtns.size())
             m_menuBtns[idx]->setStyleSheet(kMenuBtnNormal);
     }

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -72,11 +72,6 @@ public:
     // side DSP lives on VfoWidget only, client-side DSP lives on the
     // AetherDSP applet only.
 
-    // Show the target slice letter ('A'-'D') on the MEM buttons so users
-    // know which slice will be saved/recalled.  Pass a null QChar to clear
-    // the badge (no slice on this pan).
-    void setMemoryTargetSliceLetter(QChar letter);
-
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
     void wheelEvent(QWheelEvent* event) override { event->accept(); }
@@ -160,8 +155,7 @@ private:
     static constexpr int kBtnAnt = 3;
     static constexpr int kBtnDisplay = 4;
     static constexpr int kBtnMemoryBrowse = 5;
-    static constexpr int kBtnMemoryAdd = 6;
-    static constexpr int kBtnDax = 7;
+    static constexpr int kBtnDax = 6;
 
     QPushButton* m_toggleBtn{nullptr};
     QVector<QPushButton*> m_menuBtns;


### PR DESCRIPTION
The "MEM+" button lived in the spectrum overlay's vertical button stack
next to "MEM▸".  Move the action inside the floating MemoryBrowsePanel
as a fixed bottom button so it stays visible regardless of list
scroll position, and rename the browse button to plain "Memory".

Also drop the slice-letter badge ("Memory A", "MEM+ A") that previously
suffixed both buttons — visually cluttered without much payoff, and the
underlying preferredMemorySlice computation that drove it is preserved
for the actual save/recall logic that still needs it.

- MemoryBrowsePanel grows ~30 px to fit the Add Memory button below the
  table; button styled to match the spectrum-overlay button family.
- New MemoryBrowsePanel::quickAddRequested() signal forwarded by
  SpectrumOverlayMenu to the existing quickAddMemoryRequested signal,
  so MainWindow's save flow is unchanged.
- setMemoryTargetSliceLetter() removed from SpectrumOverlayMenu and its
  one MainWindow caller (the slice-letter UI badge update — #1781).
- kBtnMemoryAdd constant removed; kBtnDax renumbered 7→6.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
