### PR TITLE
feat(gui): redraw status-bar +PAN icon as a jagged FFT trace

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -953,6 +953,17 @@ void AppletPanel::setPooDooActiveSide(PooDooSide side)
     }
 }
 
+void AppletPanel::setScrollBarOnLeft(bool onLeft)
+{
+    if (!m_scrollArea) return;
+    // Flip the QScrollArea's layout direction — vertical scroll bar moves
+    // to the opposite edge.  Force the inner content widget back to LTR
+    // so the applets themselves don't mirror.
+    m_scrollArea->setLayoutDirection(onLeft ? Qt::RightToLeft : Qt::LeftToRight);
+    if (auto* content = m_scrollArea->widget())
+        content->setLayoutDirection(Qt::LeftToRight);
+}
+
 void AppletPanel::resetOrder()
 {
     // Reorder m_appletOrder to match kDefaultOrder

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -131,6 +131,13 @@ public:
     // Reset applet order to default
     void resetOrder();
 
+    // Move the vertical scroll bar to the left edge of the panel.  When the
+    // applet panel is docked on the left side of the panadapter, this puts
+    // the scroll bar against the window edge rather than against the
+    // waterfall.  Inner content stays LTR — only the scroll-area direction
+    // flips.
+    void setScrollBarOnLeft(bool onLeft);
+
     // Show / hide an applet by ID — used to drive visibility from
     // external state (e.g. the CHAIN widget mirrors DSP bypass onto
     // CEQ and CMP tile visibility).  No-op for unknown IDs.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5630,20 +5630,6 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
             cancelTransmitFromIndicator();
         return true;
     }
-    if (obj == m_panelToggle && event->type() == QEvent::MouseButtonPress) {
-        bool visible = m_appletPanel->isVisible();
-        m_appletPanel->setVisible(!visible);
-        m_panelToggle->setStyleSheet(!visible
-            ? "QLabel { color: rgba(255,255,255,128); font-weight: bold; font-size: 22px; }"
-            : "QLabel { color: #404858; font-weight: bold; font-size: 22px; }");
-        AppSettings::instance().setValue("AppletPanelVisible", !visible ? "True" : "False");
-        AppSettings::instance().save();
-        if (m_panelVisAction) {
-            QSignalBlocker sb(m_panelVisAction);
-            m_panelVisAction->setChecked(!visible);
-        }
-        return true;
-    }
     if (obj == m_addPanLabel && event->type() == QEvent::MouseButtonPress) {
         if (!m_radioModel.isConnected()) return true;
         int maxPans = m_radioModel.maxPanadapters();
@@ -6617,12 +6603,7 @@ void MainWindow::buildMenuBar()
     m_panelVisAction->setChecked(
         AppSettings::instance().value("AppletPanelVisible", "True").toString() == "True");
     connect(m_panelVisAction, &QAction::toggled, this, [this](bool on) {
-        m_appletPanel->setVisible(on);
-        m_panelToggle->setStyleSheet(on
-            ? "QLabel { color: rgba(255,255,255,128); font-weight: bold; font-size: 22px; }"
-            : "QLabel { color: #404858; font-weight: bold; font-size: 22px; }");
-        AppSettings::instance().setValue("AppletPanelVisible", on ? "True" : "False");
-        AppSettings::instance().save();
+        setAppletPanelVisible(on);
     });
 
     // Pop out the whole applet panel into its own window (#1713 Phase 6).
@@ -6640,9 +6621,14 @@ void MainWindow::buildMenuBar()
         AppSettings::instance().setValue(
             "AppletPanelFloating", floating ? "True" : "False");
         AppSettings::instance().save();
+        if (m_titleBar)
+            m_titleBar->setAppletFloating(floating);
     });
     if (m_popOutSidebarAction->isChecked()) {
-        QTimer::singleShot(0, this, [this]() { floatAppletPanel(); });
+        QTimer::singleShot(0, this, [this]() {
+            floatAppletPanel();
+            if (m_titleBar) m_titleBar->setAppletFloating(true);
+        });
     }
 
     viewMenu->addSeparator();
@@ -7056,6 +7042,28 @@ void MainWindow::buildUI()
     connect(m_titleBar, &TitleBar::minimalModeWindowedExitRequested, this, [this]() {
         toggleMinimalMode(false);
     });
+    // Title-bar dock-side click: clicking the active-side icon hides the
+    // applet panel; clicking the inactive-side icon moves it there (and
+    // shows it if hidden).
+    auto handleDockClick = [this](bool wantLeft) {
+        const bool dockedLeft = AppSettings::instance()
+            .value("AppletPanelDockedLeft", "False").toString() == "True";
+        const bool visible = m_appletPanel && m_appletPanel->isVisible();
+        if (visible && dockedLeft == wantLeft) {
+            setAppletPanelVisible(false);
+        } else {
+            if (!visible) setAppletPanelVisible(true);
+            if (dockedLeft != wantLeft) setAppletPanelDockedLeft(wantLeft);
+        }
+    };
+    connect(m_titleBar, &TitleBar::dockAppletLeftRequested,  this, [handleDockClick]() { handleDockClick(true);  });
+    connect(m_titleBar, &TitleBar::dockAppletRightRequested, this, [handleDockClick]() { handleDockClick(false); });
+    // Pop-out icon: route through the existing View-menu toggle so all
+    // three controls (icon, menu, Ctrl+Shift+S) stay in sync.
+    connect(m_titleBar, &TitleBar::popOutAppletRequested, this, [this]() {
+        if (m_popOutSidebarAction)
+            m_popOutSidebarAction->toggle();
+    });
 
     m_splitter = new QSplitter(Qt::Horizontal, this);
     m_splitter->setHandleWidth(0);
@@ -7414,6 +7422,16 @@ void MainWindow::buildUI()
     if (AppSettings::instance().value("AppletPanelVisible", "True").toString() != "True")
         m_appletPanel->hide();
 
+    // Restore applet panel dock side ("AppletPanelDockedLeft" — defaults right).
+    {
+        const bool dockedLeft =
+            AppSettings::instance().value("AppletPanelDockedLeft", "False").toString() == "True";
+        if (dockedLeft)
+            setAppletPanelDockedLeft(true);
+        else if (m_titleBar)
+            m_titleBar->setAppletDockState(m_appletPanel->isVisible(), false);
+    }
+
     // ── Status bar (SmartSDR-style, double height) ─────────────────────
     statusBar()->setFixedHeight(46);
     statusBar()->setSizeGripEnabled(false);
@@ -7457,22 +7475,32 @@ void MainWindow::buildUI()
     m_connStatusLabel->hide();
 
     // ── Left section ─────────────────────────────────────────────────────
-    // +PAN icon: mini spectrum with + overlay
+    // +PAN icon: jagged FFT-spectrum trace with multiple sharp peaks
+    // (matching the SSDR visual language) plus a "+" overlay.
     {
         QPixmap pm(36, 28);
         pm.fill(Qt::transparent);
         QPainter pp(&pm);
         pp.setRenderHint(QPainter::Antialiasing);
-        // Spectrum line — flat noise floor with two signal peaks
-        pp.setPen(QPen(QColor(255, 255, 255, 128), 1.8));
+
+        const QColor stroke(255, 255, 255, 210);
+
+        // Polyline: noise floor at y=22, multiple peaks of varying height,
+        // with extra detail between peaks for the "real FFT" texture.
+        pp.setPen(QPen(stroke, 1.6));
         const QPointF pts[] = {
-            {0,22}, {4,21}, {7,20}, {9,14}, {10,7}, {11,14}, {13,20},
-            {16,21}, {18,20}, {20,10}, {21,4}, {22,10}, {24,20},
-            {27,21}, {30,22}
+            { 0, 22}, { 1, 21}, { 2, 22}, { 3, 19}, { 4, 22},   // floor + small peak
+            { 5, 21}, { 6, 18}, { 7, 12}, { 8, 17}, { 9, 22},   // tall peak
+            {10, 21}, {11, 22}, {12, 16}, {13, 22},             // medium peak
+            {14, 21}, {15, 19}, {16, 22},                       // ripple
+            {17, 20}, {18, 12}, {19,  4}, {20, 11}, {21, 21},   // tallest peak
+            {22, 22}, {23, 21}, {24, 17}, {25, 22},             // medium peak
+            {26, 21}, {27, 22}, {28, 18}, {29, 22}, {30, 22}    // small peak + floor
         };
-        pp.drawPolyline(pts, 15);
-        // + sign in upper-right
-        pp.setPen(QPen(QColor(255, 255, 255, 200), 2.2));
+        pp.drawPolyline(pts, sizeof(pts) / sizeof(pts[0]));
+
+        // "+" sign in upper-right.
+        pp.setPen(QPen(stroke, 2.2));
         pp.drawLine(30, 4, 30, 14);   // vertical
         pp.drawLine(25, 9, 35, 9);    // horizontal
         pp.end();
@@ -7496,19 +7524,6 @@ void MainWindow::buildUI()
         hbox->addWidget(addPanBtn);
         m_addPanLabel = addPanBtn;
     }
-
-    hbox->addSpacing(8);
-
-    bool panelVis = AppSettings::instance().value("AppletPanelVisible", "True").toString() == "True";
-    m_panelToggle = new QLabel(QString::fromUtf8("\xe2\x98\xb0"));  // ☰ hamburger
-    m_panelToggle->setStyleSheet(panelVis
-        ? "QLabel { color: rgba(255,255,255,128); font-weight: bold; font-size: 22px; }"
-        : "QLabel { color: #404858; font-weight: bold; font-size: 22px; }");
-    m_panelToggle->setAlignment(Qt::AlignBottom);
-    m_panelToggle->setCursor(Qt::PointingHandCursor);
-    m_panelToggle->setToolTip("Toggle applet panel");
-    m_panelToggle->installEventFilter(this);
-    hbox->addWidget(m_panelToggle);
 
     hbox->addSpacing(8);
 
@@ -10884,6 +10899,80 @@ void MainWindow::stepUiScale(int direction)
         applyUiScale(best);
 }
 
+void MainWindow::setAppletPanelDockedLeft(bool left)
+{
+    if (!m_splitter || !m_appletPanel || !m_panStack)
+        return;
+
+    // Move m_appletPanel either before m_panStack (left dock) or to the end
+    // (right dock).  insertWidget()/addWidget() on an already-attached child
+    // reparents it to the new index without destroy/recreate.
+    if (left) {
+        const int panIdx = m_splitter->indexOf(m_panStack);
+        if (panIdx < 0) return;
+        m_splitter->insertWidget(panIdx, m_appletPanel);
+    } else {
+        m_splitter->addWidget(m_appletPanel);
+    }
+
+    // Re-apply stretch/collapse rules by widget identity (indices shifted).
+    for (int i = 0; i < m_splitter->count(); ++i) {
+        QWidget* w = m_splitter->widget(i);
+        m_splitter->setStretchFactor(i, w == m_panStack ? 1 : 0);
+        m_splitter->setCollapsible(i, false);
+    }
+
+    // QSplitter's per-index size array does NOT follow widgets when they
+    // move — applet's slot inherits panstack's old (huge) width, which
+    // setFixedWidth(260) then visibly caps but leaves the remainder as
+    // an unallocated blank strip.  Reassign sizes by widget identity using
+    // the panel's actual maximum width (== fixed width).
+    const int total = m_splitter->width();
+    if (total > 0) {
+        const int appletW = m_appletPanel->maximumWidth();
+        const int centerW = qMax(200, total - appletW);
+        QList<int> newSizes(m_splitter->count(), 0);
+        for (int i = 0; i < m_splitter->count(); ++i) {
+            QWidget* w = m_splitter->widget(i);
+            if (w == m_panStack)         newSizes[i] = centerW;
+            else if (w == m_appletPanel) newSizes[i] = appletW;
+        }
+        m_splitter->setSizes(newSizes);
+    }
+
+    // Scroll bar to the outside edge: against the window edge when docked
+    // left, default position (right of the panel) when docked right.
+    m_appletPanel->setScrollBarOnLeft(left);
+
+    AppSettings::instance().setValue("AppletPanelDockedLeft", left ? "True" : "False");
+    AppSettings::instance().save();
+
+    if (m_titleBar)
+        m_titleBar->setAppletDockState(m_appletPanel->isVisible(), left);
+}
+
+void MainWindow::setAppletPanelVisible(bool visible)
+{
+    if (!m_appletPanel) return;
+
+    // AppletPanel::setFixedWidth(260) means Qt restores the same width on
+    // un-hide automatically — the splitter just shrinks PanStack (stretch=1)
+    // by 260 and gives the slot back to the applet.
+    m_appletPanel->setVisible(visible);
+
+    AppSettings::instance().setValue("AppletPanelVisible", visible ? "True" : "False");
+    AppSettings::instance().save();
+    if (m_panelVisAction) {
+        QSignalBlocker sb(m_panelVisAction);
+        m_panelVisAction->setChecked(visible);
+    }
+    if (m_titleBar) {
+        const bool dockedLeft = AppSettings::instance()
+            .value("AppletPanelDockedLeft", "False").toString() == "True";
+        m_titleBar->setAppletDockState(visible, dockedLeft);
+    }
+}
+
 void MainWindow::setFramelessWindow(bool on)
 {
     auto& s = AppSettings::instance();
@@ -13928,7 +14017,11 @@ void MainWindow::floatAppletPanel()
     if (!m_appletPanel || !m_splitter) return;
     if (m_appletPanelFloatWindow) return;  // already floating
 
-    m_appletPanelFloatWindow = new QWidget(nullptr, Qt::Window);
+    const bool frameless = framelessWindowEnabled();
+    Qt::WindowFlags flags = Qt::Window;
+    if (frameless) flags |= Qt::FramelessWindowHint;
+
+    m_appletPanelFloatWindow = new QWidget(nullptr, flags);
     m_appletPanelFloatWindow->setWindowTitle("AetherSDR — Applet Panel");
     m_appletPanelFloatWindow->setAttribute(Qt::WA_DeleteOnClose, false);
     m_appletPanelFloatWindow->setAttribute(Qt::WA_StyledBackground, true);
@@ -13936,9 +14029,25 @@ void MainWindow::floatAppletPanel()
     auto* layout = new QVBoxLayout(m_appletPanelFloatWindow);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
+
+    // Project frameless title bar (drag-to-move, double-click maximize,
+    // min/max/close trio).  Only added when frameless is on; the system
+    // frame supplies its own title bar in non-frameless mode.
+    if (frameless) {
+        auto* titleBar = new FramelessWindowTitleBar(
+            QStringLiteral("AetherSDR — Applet Panel"),
+            m_appletPanelFloatWindow);
+        layout->addWidget(titleBar);
+    }
+
     m_appletPanel->setParent(m_appletPanelFloatWindow);
     layout->addWidget(m_appletPanel);
     m_appletPanel->show();
+
+    // 8-axis edge resize for the frameless variant — same install pattern
+    // as the floating dialogs and the main window.  The resizer no-ops
+    // when the system frame is on, so installing unconditionally is safe.
+    FramelessResizer::install(m_appletPanelFloatWindow);
     // Qt auto-redistributes remaining splitter slots once the panel
     // is reparented out; we don't need to touch the sizes manually.
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -208,6 +208,17 @@ private:
     // to AppSettings("FramelessWindow"). When on, users move/close the
     // window via keyboard shortcuts or taskbar.
     void setFramelessWindow(bool on);
+
+    // Reorder the main splitter so the applet panel sits on the left or
+    // right of the panadapter stack.  Wired from the dock-side icons in
+    // the title bar and persisted via "AppletPanelDockedLeft".
+    void setAppletPanelDockedLeft(bool left);
+
+    // Show/hide the applet panel — single source of truth that updates the
+    // status-bar ☰ toggle, the View menu action, the title-bar dock icons,
+    // and the persisted "AppletPanelVisible" setting.
+    void setAppletPanelVisible(bool visible);
+
     void showMemoryDialog();
     void showQuickAddMemoryDialog(const QString& preferredPanId = {});
     void updateKeyerAvailability(const QString& mode);
@@ -441,7 +452,6 @@ private:
     // Status bar labels (SmartSDR-style)
     QLabel* m_connStatusLabel{nullptr};   // hidden, used for connection state logic
     QLabel* m_addPanLabel{nullptr};
-    QLabel* m_panelToggle{nullptr};
     QAction* m_panelVisAction{nullptr};
     QLabel* m_tnfIndicator{nullptr};
     QLabel* m_cwxIndicator{nullptr};

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -4,6 +4,8 @@
 
 #include <QFrame>
 #include <QHBoxLayout>
+#include <QPainter>
+#include <QPixmap>
 #include <QVBoxLayout>
 #include <QDialog>
 #include <QMouseEvent>
@@ -30,6 +32,61 @@ namespace AetherSDR {
 
 namespace {
 constexpr const char* kTitleDragHandleProperty = "aetherTitleDragHandle";
+
+// Build a 16×18 dock-side indicator: hollow rectangle (the main window)
+// with a thin shaded strip flush against one inner wall, representing
+// the applet panel docked on that side.  Visual language matches the
+// pop-out icon's thin-strip-as-panel motif.
+QPixmap buildDockSideIcon(bool fillLeft, bool active)
+{
+    QPixmap pm(16, 18);
+    pm.fill(Qt::transparent);
+    QPainter p(&pm);
+    p.setRenderHint(QPainter::Antialiasing, false);
+    const QColor stroke(active ? QColor(255, 255, 255, 230)
+                                : QColor(138, 168, 192, 200));
+    p.setPen(QPen(stroke, 1));
+    p.setBrush(Qt::NoBrush);
+    // Outline 13×14: columns 1 and 14, rows 2 and 16.  Interior 12×13.
+    p.drawRect(1, 2, 13, 14);
+    // Shaded strip 4 px wide, spanning top-to-bottom of the outer rect
+    // (rows 3–15 = full interior height), flush against the chosen wall:
+    //   left  = cols 2–5
+    //   right = cols 10–13
+    if (fillLeft)
+        p.fillRect(2,  3, 4, 13, stroke);
+    else
+        p.fillRect(10, 3, 4, 13, stroke);
+    p.end();
+    return pm;
+}
+
+// Build a 16×18 pop-out indicator: hollow square (the main waterfall
+// window) on the left, with a smaller filled rectangle to its right
+// representing the applet panel detached into its own window.  The
+// filled area is 25% of the hollow square's interior so the relative
+// sizing reads as "small floating window".
+QPixmap buildPopOutIcon(bool active)
+{
+    QPixmap pm(16, 18);
+    pm.fill(Qt::transparent);
+    QPainter p(&pm);
+    p.setRenderHint(QPainter::Antialiasing, false);
+    const QColor stroke(active ? QColor(255, 255, 255, 230)
+                                : QColor(138, 168, 192, 200));
+    p.setPen(QPen(stroke, 1));
+    p.setBrush(Qt::NoBrush);
+    // Main-window hollow rect on the left.  Same vertical extent as the
+    // dock-side icons (rows 2–16, 14 tall outline) so all three icons line
+    // up; horizontally narrower since the popped-out strip lives outside.
+    p.drawRect(1, 2, 8, 14);
+    // Popped-out applet — 4 px wide strip spanning the full top-to-bottom
+    // height of the outer hollow rect (rows 3–15).  Positioned outside the
+    // hollow with a 2 px gap (columns 10 and 11) so the detachment reads.
+    p.fillRect(12, 3, 4, 13, stroke);
+    p.end();
+    return pm;
+}
 }
 
 TitleBar::TitleBar(QWidget* parent)
@@ -295,6 +352,51 @@ TitleBar::TitleBar(QWidget* parent)
         "QLabel { color: #8aa8c0; font-size: 18px; padding: 0 10px; "
         "border-radius: 4px; }"
         "QLabel:hover { color: #ffffff; background: #cc2030; }");
+    const QString dockLblStyle = QStringLiteral(
+        "QLabel { padding: 0 6px; border-radius: 4px; }"
+        "QLabel:hover { background: #203040; }");
+
+    // Dock-side selectors (applet panel left vs right of the panadapter).
+    // Click is wired via eventFilter() like the min/max/close trio.
+    m_dockLeftLbl = new QLabel;
+    m_dockLeftLbl->setFixedHeight(24);
+    m_dockLeftLbl->setAlignment(Qt::AlignCenter);
+    m_dockLeftLbl->setCursor(Qt::PointingHandCursor);
+    m_dockLeftLbl->setToolTip("Dock applet panel to the left of the panadapter");
+    m_dockLeftLbl->setStyleSheet(dockLblStyle);
+    m_dockLeftLbl->setPixmap(buildDockSideIcon(/*fillLeft=*/true, /*active=*/false));
+    m_dockLeftLbl->installEventFilter(this);
+    m_hbox->addWidget(m_dockLeftLbl);
+
+    m_dockRightLbl = new QLabel;
+    m_dockRightLbl->setFixedHeight(24);
+    m_dockRightLbl->setAlignment(Qt::AlignCenter);
+    m_dockRightLbl->setCursor(Qt::PointingHandCursor);
+    m_dockRightLbl->setToolTip("Dock applet panel to the right of the panadapter");
+    m_dockRightLbl->setStyleSheet(dockLblStyle);
+    m_dockRightLbl->setPixmap(buildDockSideIcon(/*fillLeft=*/false, /*active=*/true));
+    m_dockRightLbl->installEventFilter(this);
+    m_hbox->addWidget(m_dockRightLbl);
+
+    m_popOutLbl = new QLabel;
+    m_popOutLbl->setFixedHeight(24);
+    m_popOutLbl->setAlignment(Qt::AlignCenter);
+    m_popOutLbl->setCursor(Qt::PointingHandCursor);
+    m_popOutLbl->setToolTip("Pop the applet panel out into its own window");
+    m_popOutLbl->setStyleSheet(dockLblStyle);
+    m_popOutLbl->setPixmap(buildPopOutIcon(/*active=*/false));
+    m_popOutLbl->installEventFilter(this);
+    m_hbox->addWidget(m_popOutLbl);
+
+    m_hbox->addSpacing(4);
+
+    auto* dockSep = new QFrame;
+    dockSep->setFixedSize(1, 20);
+    dockSep->setStyleSheet("QFrame { background: #304050; border: none; }");
+    markDragHandle(dockSep);
+    m_hbox->addWidget(dockSep);
+
+    m_hbox->addSpacing(4);
 
     m_minimizeLbl = new QLabel(QString::fromUtf8("\xe2\x80\x94"));  // — em dash
     m_minimizeLbl->setFixedHeight(24);
@@ -494,9 +596,35 @@ bool TitleBar::eventFilter(QObject* obj, QEvent* ev)
                 if (auto* w = window()) w->close();
                 return true;
             }
+            if (obj == m_dockLeftLbl) {
+                emit dockAppletLeftRequested();
+                return true;
+            }
+            if (obj == m_dockRightLbl) {
+                emit dockAppletRightRequested();
+                return true;
+            }
+            if (obj == m_popOutLbl) {
+                emit popOutAppletRequested();
+                return true;
+            }
         }
     }
     return QWidget::eventFilter(obj, ev);
+}
+
+void TitleBar::setAppletFloating(bool floating)
+{
+    if (m_popOutLbl)
+        m_popOutLbl->setPixmap(buildPopOutIcon(floating));
+}
+
+void TitleBar::setAppletDockState(bool visible, bool left)
+{
+    if (m_dockLeftLbl)
+        m_dockLeftLbl->setPixmap(buildDockSideIcon(true,  visible &&  left));
+    if (m_dockRightLbl)
+        m_dockRightLbl->setPixmap(buildDockSideIcon(false, visible && !left));
 }
 
 void TitleBar::updateMaximizeIcon()

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -32,6 +32,15 @@ public:
     void setMinimalMode(bool on);
     void setBlinkEnabled(bool enabled); // Toggle heartbeat animation on/off
 
+    // Reflect applet-panel state on the dock-side icons:
+    //  - visible=false: both icons dim (no active side).
+    //  - visible=true:  the icon matching `left` is highlighted.
+    void setAppletDockState(bool visible, bool left);
+
+    // Highlight the pop-out icon when the applet panel is floating in its
+    // own Qt::Window.
+    void setAppletFloating(bool floating);
+
 signals:
     void pcAudioToggled(bool on);
     void masterVolumeChanged(int pct);
@@ -44,6 +53,11 @@ signals:
     // Emitted when the blink setting changes (e.g. via right-click) so the
     // View menu checkbox can stay in sync.
     void blinkEnabledChanged(bool enabled);
+    // Dock-side selectors — applet panel left vs right of the panadapter.
+    void dockAppletLeftRequested();
+    void dockAppletRightRequested();
+    // Toggle applet panel between docked and floating-window mode.
+    void popOutAppletRequested();
 
 public:
     // Open the feature-request dialog.  Wired from Help → Submit your idea…
@@ -75,6 +89,9 @@ private:
     QLabel*      m_minimizeLbl{nullptr};
     QLabel*      m_maximizeLbl{nullptr};
     QLabel*      m_closeLbl{nullptr};
+    QLabel*      m_dockLeftLbl{nullptr};
+    QLabel*      m_dockRightLbl{nullptr};
+    QLabel*      m_popOutLbl{nullptr};
     bool         m_minimalMode{false};
     bool         m_windowMoveActive{false};
     bool         m_windowMoveUsesSystem{false};


### PR DESCRIPTION
- feat(gui): float popped-out applet panel as a frameless project window
- feat(gui): redraw status-bar +PAN icon as a jagged FFT trace
