### PR TITLE
fix(shistory): improve voice signal carrier frequency detection

### DIFF
--- a/src/core/VoiceSignalDetector.cpp
+++ b/src/core/VoiceSignalDetector.cpp
@@ -21,10 +21,10 @@ namespace {
     constexpr float kThresholdDb = 6.0f;
 
     // Minimum peak above the EMA floor for a region to be REPORTED.
-    // A region can be found at 6 dB but only shown when its peak is ≥ 8 dB —
+    // A region can be found at 6 dB but only shown when its peak is ≥ 13 dB —
     // this filters broad noise bumps that barely exceed the boundary threshold
     // while retaining weak-but-genuine voice signals that have a clear peak.
-    constexpr float kMinPeakAboveFloorDb = 10.0f;
+    constexpr float kMinPeakAboveFloorDb = 13.0f;
 
     // Percentile used for noise floor.  10th is more robust on crowded bands.
     constexpr int kNoisePctile = 10;
@@ -50,8 +50,7 @@ QVector<DetectedVoiceSignal> detectVoiceSignals(
     double bandwidthMhz,
     const QVector<QPair<double, double>>& voiceRangesMhz,
     float rollingNoiseFloorDbm,
-    const QString& sliceMode,
-    float softEdgeDb)
+    const QString& sliceMode)
 {
     QVector<DetectedVoiceSignal> results;
     const int N = binsDbm.size();
@@ -171,48 +170,46 @@ QVector<DetectedVoiceSignal> detectVoiceSignals(
                 return;
             }
             const double segWidthHz = (hi - lo + 1) * hzPerBin;
+            // For all voice-width signals (not QRM/wideband) place the marker
+            // at the peak bin.  USB voice energy is concentrated on the left
+            // (near the carrier); LSB on the right.  The peak bin therefore
+            // naturally lands on the carrier side without any edge-walk
+            // heuristic, and it marks the visually brightest point of the
+            // signal on the waterfall — the most intuitive reference for the
+            // operator.  The fill extension (kFillHz) can push the 6 dB edge
+            // 200–400 Hz past the actual signal, which the peak bin avoids.
+            // QRM/wideband paths are unaffected (they use their own placement).
+            const int peakBin = static_cast<int>(peakIt - binsDbm.constBegin());
+            const double rawFreqMhz = startMhz + (peakBin + 0.5) / N * bandwidthMhz;
             double fMhz;
             if (segWidthHz < kVoiceMinHz) {
-                // Narrow carrier / QRM tone: use peak bin for accuracy.
-                const int peakBin = static_cast<int>(peakIt - binsDbm.constBegin());
-                fMhz = startMhz + (peakBin + 0.5) / N * bandwidthMhz;
+                // Narrow carrier / QRM tone: use raw peak bin — QRM tones live
+                // anywhere and kHz snapping would misplace them.
+                fMhz = rawFreqMhz;
             } else {
-                int edge = isUsb ? lo : hi;
-                if (softEdgeDb >= 0.0f) {
-                    // Slope-based edge walk.  Starting from the 6 dB region
-                    // boundary, walk outward (toward the carrier) on raw
-                    // unfilled bins using the softer noiseFloor+softEdgeDb
-                    // threshold.  Require kStopBins consecutive sub-threshold
-                    // bins to terminate so isolated noise gaps in the voice
-                    // rolloff don't end the walk prematurely.  Then roll back
-                    // to the last above-threshold bin so the reported edge
-                    // sits at the lowest visible voice energy — typically
-                    // 100–200 Hz nearer to the carrier than the 6 dB edge.
-                    const float softThr = noiseFloor + softEdgeDb;
-                    constexpr int kStopBins = 3;
-                    int below = 0;
-                    int b     = edge;
-                    while (true) {
-                        const int next = isUsb ? b - 1 : b + 1;
-                        if (next < 0 || next >= N) { break; }
-                        if (binsDbm[next] < softThr) {
-                            ++below;
-                            if (below >= kStopBins) {
-                                edge = isUsb ? (b + (kStopBins - 1))
-                                             : (b - (kStopBins - 1));
-                                edge = std::clamp(edge, 0, N - 1);
-                                break;
-                            }
-                        } else {
-                            below = 0;
-                        }
-                        b = next;
-                    }
-                    if (below < kStopBins) {
-                        edge = std::clamp(b, 0, N - 1);
-                    }
+                // Voice-width: snap toward the carrier side.
+                // USB carriers are to the LEFT (lower frequency) of the energy
+                // peak, so we floor to the kHz below; LSB carriers are to the
+                // RIGHT, so we ceil.  Ham operators operate on round kHz values,
+                // and the peak typically sits 300–1200 Hz inside the passband,
+                // so the 1200 Hz guard catches the common case correctly.
+                //
+                // Known limitation: if peak energy lands >1000 Hz above a
+                // kHz-aligned USB carrier (e.g. wide TX EQ, peak at +1500 Hz),
+                // floor snaps to the kHz just below the peak rather than the
+                // carrier's kHz, and the 500 Hz snapOff passes the guard —
+                // resulting in a 1 kHz high report.  A passband-bias approach
+                // fixes that range but breaks peaks <700 Hz from the carrier,
+                // which is the more common case on typical SSB audio.
+                const double snapped = isUsb
+                    ? std::floor(rawFreqMhz * 1000.0) / 1000.0
+                    : std::ceil (rawFreqMhz * 1000.0) / 1000.0;
+                const double snapOffHz = std::abs(rawFreqMhz - snapped) * 1.0e6;
+                if (snapOffHz <= 1200.0) {
+                    fMhz = snapped;
+                } else {
+                    fMhz = std::round(rawFreqMhz * 10000.0) / 10000.0; // 100 Hz
                 }
-                fMhz = startMhz + (edge + 0.5) / N * bandwidthMhz;
             }
             qCDebug(lcSHistory,
                 "  DETECTED: %.4f MHz  %s  peak=%.1f dBm (%s)  width=%.0f Hz%s",

--- a/src/core/VoiceSignalDetector.h
+++ b/src/core/VoiceSignalDetector.h
@@ -35,14 +35,6 @@ bool isVoiceSegmentLabel(const QString& label);
 // the internal energy-asymmetry heuristic so markers always match the operator's
 // current mode.  Pass an empty string to use the heuristic (e.g. for AM/FM pans).
 //
-// softEdgeDb: when >= 0, refines the carrier-side edge of voice-width regions
-// by walking outward from the 6 dB region boundary using this softer
-// (noise floor + softEdgeDb) threshold, until 3 consecutive bins fall below
-// the threshold.  This pulls the marker closer to the carrier than the main
-// region threshold allows, at the cost of a small amount of extra compute per
-// detected region.  Pass < 0 to disable the refinement (the historical
-// behaviour: marker sits exactly at the 6 dB region edge).
-//
 // Returns one entry per detected signal (primary + optional secondary per region).
 QVector<DetectedVoiceSignal> detectVoiceSignals(
     const QVector<float>& binsDbm,
@@ -50,8 +42,7 @@ QVector<DetectedVoiceSignal> detectVoiceSignals(
     double bandwidthMhz,
     const QVector<QPair<double, double>>& voiceRangesMhz = {},
     float rollingNoiseFloorDbm = -1000.0f,
-    const QString& sliceMode = {},
-    float softEdgeDb = -1.0f);
+    const QString& sliceMode = {});
 
 // Format a peak-dBm value as an S-meter label, rounded UP to the next unit.
 // Scale: S9 = -73 dBm, 6 dB/S-unit.  Examples: -85 → "S8", -63 → "S9+10".

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2434,34 +2434,6 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         });
         shGrid->addLayout(qrmRow, shr++, 1);
 
-        // Edge Threshold — softer noise-above-floor cutoff used by the slope
-        // edge walk to refine the carrier-side mode edge.  Lower values pull
-        // the marker closer to the carrier (more aggressive).  Steps in
-        // 0.5 dB increments via a 10× int slider.
-        const int edgeDbInt = static_cast<int>(std::lround(
-            AppSettings::instance().value("SHistorySoftEdgeDb", "3.0").toFloat() * 10.0f));
-        shGrid->addWidget(new QLabel("Edge Threshold:"), shr, 0);
-        auto* edgeRow = new QHBoxLayout;
-        auto* edgeSlider = new GuardedSlider(Qt::Horizontal);
-        edgeSlider->setRange(10, 100);  // 1.0–10.0 dB in 0.1 dB units
-        edgeSlider->setSingleStep(5);   // snap-feel: 0.5 dB notches
-        edgeSlider->setValue(std::clamp(edgeDbInt, 10, 100));
-        edgeSlider->setToolTip(
-            "Threshold above noise floor for the slope edge walk that\n"
-            "refines the SHistory carrier-side edge.  Lower = closer to\n"
-            "the carrier but more sensitive to noise.  Default 3.0 dB.");
-        auto* edgeValue = new QLabel(QString::number(edgeSlider->value() / 10.0, 'f', 1) + " dB");
-        edgeValue->setFixedWidth(56);
-        edgeValue->setAlignment(Qt::AlignRight);
-        edgeRow->addWidget(edgeSlider);
-        edgeRow->addWidget(edgeValue);
-        connect(edgeSlider, &QSlider::valueChanged, this, [edgeValue, save](int v) {
-            const double db = v / 10.0;
-            edgeValue->setText(QString::number(db, 'f', 1) + " dB");
-            save("SHistorySoftEdgeDb", QString::number(db, 'f', 1));
-        });
-        shGrid->addLayout(edgeRow, shr++, 1);
-
         // Marker colour swatches — mirrors the DXCC swatch pattern in the
         // left column.  Two pickers: Signals (voice) and QRM.
         QColor signalsColor(AppSettings::instance()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -14400,15 +14400,9 @@ void MainWindow::onSpectrumReadyForSHistory(quint32 streamId, const QVector<floa
         if (!bufPtr) { bufPtr = std::make_shared<AetherSDR::SpectrogramBuffer>(); }
         bufPtr->push(bins, pan->centerMhz(), pan->bandwidthMhz());
 
-        // SpotHub Display tab → Signal History → "Edge Threshold" slider.
-        // Negative = disabled (use historical 6 dB edge); >= 0 enables slope-
-        // based edge walk at noise floor + this many dB.  Default 3 dB.
-        const float softEdgeDb = AppSettings::instance()
-            .value("SHistorySoftEdgeDb", "3.0").toFloat();
         const auto detected =
             AetherSDR::detectVoiceSignals(bins, pan->centerMhz(), pan->bandwidthMhz(),
-                                          voiceRanges, noiseFloor, sliceMode,
-                                          softEdgeDb);
+                                          voiceRanges, noiseFloor, sliceMode);
         auto& entries = m_sHistoryData[panId];
         for (const auto& sig : detected) {
             bool found = false;


### PR DESCRIPTION
## Summary

- **Peak-bin placement**: replaces the slope-based edge-walk with a direct peak-bin approach. The peak bin naturally lands near the carrier edge (USB energy concentrates at the left/carrier side; LSB at the right).
- **Directional kHz snapping**: USB floors to the nearest kHz below the peak (carrier is always left of energy); LSB ceils to the nearest kHz above. 1200 Hz guard covers typical SSB passband peak positions; falls back to 100 Hz rounding for off-kHz stations.
- **Raised minimum peak threshold**: `kMinPeakAboveFloorDb` 10 → 13 dB to suppress ghost detections from broadband propagation noise bumps that clear the 6 dB region boundary but have no genuine signal peak.

## Test plan

- [ ] Tune to a known USB station (e.g. 14.175.000) — S-History marker should appear at the round kHz carrier frequency, not mid-passband
- [ ] Verify LSB stations snap to the kHz to the right of the energy peak
- [ ] Confirm QRM/narrow carrier markers are unaffected (still use raw peak bin, no kHz snap)
- [ ] Check busy band (20m phone) — ghost S4 detections from propagation noise should be absent or significantly reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)