### PR TITLE
fix(gui): rewire ALC gauge to SW ALC meter; mirror across Phone + CW panels

### DIFF
--- a/docs/flex-meter-learnings.md
+++ b/docs/flex-meter-learnings.md
@@ -122,7 +122,8 @@ reason.
 |---|---:|---:|---|
 | `MICPEAK` | 40 | 40 | Codec hardware mic peak |
 | `MIC` | 20 | 20 | Codec hardware mic average |
-| `HWALC` | 20 | 20 | Hardware ALC input |
+| `HWALC` | 20 | 20 | External Hardware ALC RCA voltage — zero without an external HWALC connection.  Used by SliceTroubleshootingDialog telemetry only; do **not** drive UI ALC gauges from this meter. |
+| `ALC` | 20 | 20 | Post-software-ALC SSB peak (dBFS).  This is the meter that drives the in-app ALC gauges (mirrored across Phone and CW panels). |
 | `FWDPWR` | 20 | 20 | Forward RF power |
 | `REFPWR` | 20 | 20 | Reflected RF power |
 | `SWR` | 20 | 20 | RF SWR |

--- a/docs/tx-audio-signal-path.md
+++ b/docs/tx-audio-signal-path.md
@@ -181,7 +181,10 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 │  PATEMP (meter 11)          │  ◄── "PA Temperature" (degC)
 │  src=TX-, fps=0             │
 │  HWALC (meter 3)            │  ◄── "Voltage at Hardware ALC RCA Plug" (dBFS)
-│  src=TX-, fps=20            │
+│  src=TX-, fps=20            │      Permanently 0 without an external HWALC
+│  ALC   (meter 33)           │      connection.  Telemetry-only consumer.
+│  src=TX-, fps=20            │  ◄── "Post-software-ALC SSB peak" (dBFS).
+│                             │      Drives the Phone + CW panel ALC gauges.
 └─────────┬───────────────────┘
           │
           ▼
@@ -194,7 +197,8 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 |----|--------|------|------|-----|-------------|-------------------|
 | 1 | COD- | MICPEAK | dBFS | 40 | Hardware mic peak level | P/CW mic gauge (BAL/LINE/ACC) |
 | 2 | COD- | MIC | dBFS | 20 | Hardware mic average level | P/CW mic gauge (BAL/LINE/ACC) |
-| 3 | TX- | HWALC | dBFS | 20 | HW ALC voltage | P/CW ALC indicator |
+| 3 | TX- | HWALC | dBFS | 20 | External HWALC RCA voltage (zero without external connection) | SliceTroubleshootingDialog telemetry only |
+| 33 | TX- | ALC | dBFS | 20 | Post-software-ALC SSB peak | P/CW ALC gauge (Phone + CW panels, mirrored) |
 | 8 | TX- | FWDPWR | dBm | 20 | Forward power | TX applet, S-Meter power, Tuner |
 | 9 | TX- | REFPWR | dBm | 20 | Reflected power | — |
 | 10 | TX- | SWR | SWR | 20 | Standing wave ratio | TX applet, Tuner |

--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -78,6 +78,13 @@ public:
     }
 
     void setReversed(bool rev) { m_reversed = rev; update(); }
+    // Anchor the fill bar to the right edge instead of the left.  Unlike
+    // setReversed (which also inverts the value mapping for compression-
+    // style gauges), this just mirrors the fill direction — min still
+    // means empty, max still means full, but the bar grows leftward from
+    // the right edge.  Used for the ALC gauge so the bar tracks the scale
+    // in the natural direction.
+    void setFillFromRight(bool on) { m_fillFromRight = on; update(); }
 
     void setRange(float min, float max, float redStart,
                   const QVector<Tick>& ticks, float yellowStart = std::numeric_limits<float>::quiet_NaN()) {
@@ -113,6 +120,14 @@ protected:
             int revFillW = barW - fillW;
             if (revFillW > 0)
                 p.fillRect(barX + fillW + 1, barY + 1, revFillW - 2, barH - 2, QColor(0xff, 0x44, 0x44));
+        } else if (m_fillFromRight) {
+            // Mirrored fill — same min=empty/max=full mapping as the
+            // normal mode, but the bar grows from the right edge inward.
+            // Single color (red); zone-based tinting doesn't translate
+            // cleanly to this orientation.
+            if (fillW > 0)
+                p.fillRect(barX + barW - fillW + 1, barY + 1, fillW - 2, barH - 2,
+                           QColor(0xcc, 0x33, 0x33));
         } else {
             // Normal: three zones cyan → yellow → red
             int yellowX = static_cast<int>(((m_yellowStart - m_min) / (m_max - m_min)) * barW);
@@ -194,6 +209,7 @@ private:
     float m_peakValue{0.0f};
     bool  m_peakEnabled{false};
     bool  m_reversed{false};
+    bool  m_fillFromRight{false};
     QString m_label, m_unit;
     QVector<Tick> m_ticks;
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3492,7 +3492,7 @@ MainWindow::MainWindow(QWidget* parent)
             }
         });
     }
-    connect(&m_radioModel.meterModel(), &MeterModel::alcChanged,
+    connect(&m_radioModel.meterModel(), &MeterModel::swAlcChanged,
             m_appletPanel->phoneCwApplet(), &PhoneCwApplet::updateAlc);
     // Client-side PC mic metering — radio CODEC meters only see hardware mics.
     // Apply VU-style ballistics: fast attack, slow decay (~20 dB/sec).

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -147,6 +147,17 @@ void PhoneCwApplet::buildPhonePanel()
     m_compGauge->setAccessibleName("Compression gauge");
     m_compGauge->setAccessibleDescription("Speech compression amount in dB");
     vbox->addWidget(m_compGauge);
+
+    // ── ALC gauge (post-SW-ALC SSB-peak, dBFS) ──────────────────────────
+    // Mirrored in m_cwPanel; both gauges read from MeterModel::swAlcChanged
+    // so SSB operators watching mic gain see the same indicator CW
+    // operators use to verify clean keying envelope shape.
+    m_alcGaugePhone = new HGauge(-20.0f, 0.0f, -3.0f, "ALC", "dBFS",
+        {{-20, "-20"}, {-15, "-15"}, {-10, "-10"}, {-5, "-5"}, {0, "0"}});
+    m_alcGaugePhone->setFillFromRight(true);  // empty at -20, fills leftward toward 0
+    m_alcGaugePhone->setAccessibleName("ALC gauge (Phone)");
+    m_alcGaugePhone->setAccessibleDescription("Automatic level control — post-software-ALC SSB peak (dBFS)");
+    vbox->addWidget(m_alcGaugePhone);
     vbox->addSpacing(4);
 
     // ── Mic profile dropdown ─────────────────────────────────────────────
@@ -358,12 +369,16 @@ void PhoneCwApplet::buildCwPanel()
     vbox->setContentsMargins(4, 2, 4, 6);
     vbox->setSpacing(4);
 
-    // ── ALC gauge (0–100) ────────────────────────────────────────────────
-    m_alcGauge = new HGauge(0.0f, 100.0f, 80.0f, "ALC", "",
-        {{0, "0"}, {25, "25"}, {50, "50"}, {75, "75"}, {100, "100"}});
-    m_alcGauge->setAccessibleName("ALC gauge");
-    m_alcGauge->setAccessibleDescription("Automatic level control meter");
-    vbox->addWidget(m_alcGauge);
+    // ── ALC gauge (post-SW-ALC SSB-peak, dBFS) ──────────────────────────
+    // Mirrors the Phone-panel ALC gauge — both read from the same
+    // MeterModel::swAlcChanged source.  Range covers normal operating
+    // window (-20…0 dBFS); excessive ALC pins at 0.
+    m_alcGaugeCw = new HGauge(-20.0f, 0.0f, -3.0f, "ALC", "dBFS",
+        {{-20, "-20"}, {-15, "-15"}, {-10, "-10"}, {-5, "-5"}, {0, "0"}});
+    m_alcGaugeCw->setFillFromRight(true);  // empty at -20, fills leftward toward 0
+    m_alcGaugeCw->setAccessibleName("ALC gauge (CW)");
+    m_alcGaugeCw->setAccessibleDescription("Automatic level control — post-software-ALC SSB peak (dBFS)");
+    vbox->addWidget(m_alcGaugeCw);
     vbox->addSpacing(2);
 
     // All left-side labels/buttons share the same width so sliders align.
@@ -813,7 +828,11 @@ void PhoneCwApplet::updateCompression(float compPeak)
 
 void PhoneCwApplet::updateAlc(float alc)
 {
-    m_alcGauge->setValue(alc);
+    // Single source (MeterModel::swAlcChanged) → both panel mirrors.
+    // HGauge clamps to its construction range, so values outside [-20, 0]
+    // pin at the appropriate end.
+    if (m_alcGaugePhone) m_alcGaugePhone->setValue(alc);
+    if (m_alcGaugeCw)    m_alcGaugeCw->setValue(alc);
 }
 
 bool PhoneCwApplet::eventFilter(QObject* obj, QEvent* ev)

--- a/src/gui/PhoneCwApplet.h
+++ b/src/gui/PhoneCwApplet.h
@@ -87,9 +87,14 @@ private:
     QSlider*     m_monSlider{nullptr};
     QLabel*      m_monLabel{nullptr};
 
-    // ── CW sub-panel widgets ─────────────────────────────────────────────
+    // ── ALC gauges (mirrored across both Phone and CW panels) ───────────
+    // Both gauges read from the same MeterModel::swAlcChanged source so
+    // operators see the post-software-ALC SSB peak (dBFS) in whichever
+    // panel is active for the current mode.
+    HGauge*      m_alcGaugePhone{nullptr};
+    HGauge*      m_alcGaugeCw{nullptr};
 
-    HGauge*      m_alcGauge{nullptr};
+    // ── CW sub-panel widgets ─────────────────────────────────────────────
 
     QSlider*     m_delaySlider{nullptr};
     QLineEdit*   m_delayEdit{nullptr};

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -122,7 +122,9 @@ void MeterModel::defineMeter(const MeterDef& def)
     else if (def.name == "COMP")
         m_compLevelIdx = def.index;
     else if (def.name == "HWALC")
-        m_alcIdx = def.index;
+        m_hwAlcIdx = def.index;
+    else if (def.name == "ALC")
+        m_swAlcIdx = def.index;
     else if (def.source != "AMP" && def.name == "PATEMP")
         m_paTempIdx = def.index;
     else if (def.name == "+13.8A")
@@ -226,7 +228,8 @@ void MeterModel::removeMeter(int index)
     if (index == m_micPeakIdx)   m_micPeakIdx = -1;
     if (index == m_micLevelIdx)  m_micLevelIdx = -1;
     if (index == m_compLevelIdx) m_compLevelIdx = -1;
-    if (index == m_alcIdx)       m_alcIdx = -1;
+    if (index == m_hwAlcIdx)     m_hwAlcIdx = -1;
+    if (index == m_swAlcIdx)     m_swAlcIdx = -1;
     if (index == m_paTempIdx)    m_paTempIdx = -1;
     if (index == m_supplyIdx)    m_supplyIdx = -1;
     if (index == m_ampFwdPwrIdx) m_ampFwdPwrIdx = -1;
@@ -285,7 +288,8 @@ void MeterModel::clear()
     m_micPeakIdx = -1;
     m_micLevelIdx = -1;
     m_compLevelIdx = -1;
-    m_alcIdx = -1;
+    m_hwAlcIdx = -1;
+    m_swAlcIdx = -1;
     m_paTempIdx = -1;
     m_supplyIdx = -1;
     m_ampFwdPwrIdx = -1;
@@ -309,7 +313,8 @@ void MeterModel::clear()
     clearCompressionState();
     m_micLevel = -50.0f;
     m_compLevel = 0.0f;
-    m_alc = 0.0f;
+    m_hwAlc = 0.0f;
+    m_swAlc = 0.0f;
     m_paTemp = 0.0f;
     m_supplyVolts = 0.0f;
     m_ampFwdPwr = 0.0f;
@@ -593,7 +598,8 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
     // sLevelChanged is emitted per-slice inline in the loop below
     bool txChanged = false;
     bool micChanged = false;
-    bool alcChanged = false;
+    bool hwAlcChangedFlag = false;
+    bool swAlcChangedFlag = false;
     bool hwChanged = false;
     bool ampChanged = false;
     bool tgxlChanged = false;
@@ -679,9 +685,12 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
         } else if (idx == m_compLevelIdx) {
             m_compLevel = v;
             micChanged = true;
-        } else if (idx == m_alcIdx) {
-            m_alc = v;
-            alcChanged = true;
+        } else if (idx == m_hwAlcIdx) {
+            m_hwAlc = v;
+            hwAlcChangedFlag = true;
+        } else if (idx == m_swAlcIdx) {
+            m_swAlc = v;
+            swAlcChangedFlag = true;
         } else if (idx == m_paTempIdx) {
             m_paTemp = v;
             hwChanged = true;
@@ -717,8 +726,10 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
         emit txMetersChanged(m_fwdPower, m_swr);
     if (micChanged)
         emit micMetersChanged(m_micLevel, m_compLevel, m_micPeak, m_compPeak);
-    if (alcChanged)
-        emit this->alcChanged(m_alc);
+    if (hwAlcChangedFlag)
+        emit this->hwAlcChanged(m_hwAlc);
+    if (swAlcChangedFlag)
+        emit this->swAlcChanged(m_swAlc);
     if (hwChanged)
         emit hwTelemetryChanged(m_paTemp, m_supplyVolts);
     if (ampChanged)

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -101,8 +101,15 @@ public:
     float micLevel() const { return m_micLevel; }
     float compLevel() const { return m_compLevel; }
 
-    // Convenience: ALC level (0–100 scale, from TX "HWALC" meter).
-    float alc() const { return m_alc; }
+    // Convenience: external Hardware ALC RCA jack voltage (dBFS, from TX
+    // "HWALC" meter).  Permanently zero unless an external Hardware ALC
+    // connection is wired into the radio's HWALC RCA — kept around for
+    // SliceTroubleshootingDialog telemetry; not what users normally watch.
+    float hwAlc() const { return m_hwAlc; }
+    // Convenience: post-software-ALC SSB-peak meter (dBFS, from TX "ALC").
+    // This is the indicator users actually want — moves with voice peaks
+    // and CW keying envelope.  Drives the ALC gauges in the Phone/CW applet.
+    float swAlc() const { return m_swAlc; }
 
     // Convenience: PA heatsink temperature (°C).
     float paTemp() const { return m_paTemp; }
@@ -126,8 +133,11 @@ signals:
     void micMetersChanged(float micLevel, float compLevel,
                           float micPeak, float compPeak);
 
-    // Emitted when ALC meter changes (0–100 scale).
-    void alcChanged(float alc);
+    // Emitted when the external Hardware ALC RCA voltage changes (dBFS).
+    void hwAlcChanged(float dbfs);
+    // Emitted when the post-software-ALC SSB-peak meter changes (dBFS).
+    // Drives the in-app ALC gauges; fires during voice peaks and CW keying.
+    void swAlcChanged(float dbfs);
 
     // Emitted when hardware telemetry meters change (PA temp, supply voltage).
     void hwTelemetryChanged(float paTemp, float supplyVolts);
@@ -177,7 +187,8 @@ private:
     int m_micPeakIdx{-1};    // "COD-" / "MICPEAK" (hardware mic)
     int m_micLevelIdx{-1};   // "COD-" / "MIC" (hardware mic RX level)
     int m_compLevelIdx{-1};  // "TX" / "COMP" (instantaneous)
-    int m_alcIdx{-1};        // "TX" / "HWALC"
+    int m_hwAlcIdx{-1};      // "TX" / "HWALC" — external RCA jack voltage
+    int m_swAlcIdx{-1};      // "TX" / "ALC"   — post-software-ALC SSB peak
     int m_paTempIdx{-1};     // "RAD" / "PATEMP"
     int m_supplyIdx{-1};     // "RAD" / "+13.8A" (supply voltage, point A = before fuse)
     int m_ampFwdPwrIdx{-1};  // "AMP" / "FWD" (PGXL)
@@ -215,7 +226,8 @@ private:
     QString m_lastCompressionSummaryReason;
     float m_micLevel{-50.0f};
     float m_compLevel{0.0f};
-    float m_alc{0.0f};
+    float m_hwAlc{0.0f};
+    float m_swAlc{0.0f};
     float m_paTemp{0.0f};
     float m_supplyVolts{0.0f};
     float m_ampFwdPwr{0.0f};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -4420,7 +4420,10 @@ QJsonObject RadioModel::troubleshootingSnapshot() const
     telemetry["supply_volts"] = m_meterModel.supplyVolts();
     telemetry["tx_forward_power_w"] = m_meterModel.fwdPower();
     telemetry["tx_swr"] = m_meterModel.swr();
-    telemetry["alc"] = m_meterModel.alc();
+    // SliceTroubleshootingDialog renders this with the literal label
+    // "HWALC", so keep it pointed at the external Hardware ALC RCA voltage
+    // (m_hwAlc) — the gauge in the Phone/CW applet now uses swAlc().
+    telemetry["alc"] = m_meterModel.hwAlc();
     telemetry["mic_level_dbfs"] = m_meterModel.micLevel();
     telemetry["mic_peak_dbfs"] = m_meterModel.micPeak();
     telemetry["comp_level_db"] = m_meterModel.compLevel();


### PR DESCRIPTION
The ALC gauge in the Phone/CW applet was wired to the TX HWALC meter,
which measures voltage at the radio's external Hardware ALC RCA jack.
Without an external PA driving that jack, HWALC is permanently zero,
so the gauge always read empty regardless of actual ALC activity.  The
gauge was also only built into m_cwPanel (visible in CW mode only) and
scaled 0–100 instead of dBFS — both inconsistent with the meter's real
range and with the operator's most useful viewing mode (Phone, where
SSB voice peaks drive the meter most actively).

Closes #2543.

MeterModel changes:
- Track the TX "ALC" meter separately from "HWALC".  New m_swAlcIdx
  and m_swAlc; new swAlcChanged(dbfs) signal.
- Rename existing HWALC plumbing for clarity: m_alcIdx → m_hwAlcIdx,
  m_alc → m_hwAlc, alcChanged → hwAlcChanged.  HWALC stays alive for
  SliceTroubleshootingDialog telemetry; not surfaced in any gauge.

PhoneCwApplet changes:
- Split single m_alcGauge into m_alcGaugePhone + m_alcGaugeCw.  Both
  read from the same swAlcChanged source so the readings stay in
  lockstep regardless of mode.  Range -20…0 dBFS with ticks every 5 dB.
- Phone gauge inserted below the Compression gauge (visual rhythm
  matches Level / Compression / ALC stack).
- updateAlc(float) drives both.

HGauge changes:
- New setFillFromRight(bool) mode.  Distinct from setReversed (which
  inverts the value mapping for compression-style gauges where max
  compression should appear "full"); setFillFromRight keeps the
  natural value mapping (min = empty, max = full) but anchors the
  fill bar to the right edge instead of the left.  Used by the ALC
  gauges so the bar grows leftward from 0 dBFS as ALC activity rises.

MainWindow wiring:
- Connection switched from MeterModel::alcChanged (HWALC) to the new
  swAlcChanged signal.

Telemetry:
- RadioModel::buildSliceTroubleshootingTelemetry kept on hwAlc() — the
  dialog's display label literally says "HWALC", so the value source is
  preserved.

Docs:
- tx-audio-signal-path.md and flex-meter-learnings.md updated to
  distinguish HWALC (telemetry-only) from ALC (drives both gauges),
  and to document that HWALC is permanently zero without an external
  HWALC RCA connection.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
