### PR TITLE
perf(gui): cache axis labels as QStaticText in DSP curve widgets

### DIFF
--- a/src/gui/ClientCompCurveWidget.cpp
+++ b/src/gui/ClientCompCurveWidget.cpp
@@ -61,6 +61,7 @@ void ClientCompCurveWidget::setCompactMode(bool on)
 {
     if (on == m_compact) return;
     m_compact = on;
+    m_labelsDirty = true;  // font px size flips 9 ↔ 7
     update();
 }
 
@@ -145,18 +146,41 @@ void ClientCompCurveWidget::drawGrid(QPainter& p, const QRectF& r) const
     f.setPixelSize(m_compact ? 7 : 9);
     p.setFont(f);
 
-    for (float db : kMajorTicks) {
+    // Rebuild the QStaticText cache on first paint or after a compact-
+    // mode flip — strings come from kMajorTicks (compile-time constant),
+    // so the HarfBuzz shape pass runs once per (label, font) pair.
+    if (m_labelsDirty) {
+        m_axisLabels.clear();
+        m_axisLabels.reserve(static_cast<int>(std::size(kMajorTicks)));
+        for (float db : kMajorTicks) {
+            QStaticText st(QString::number(static_cast<int>(db)));
+            st.setPerformanceHint(QStaticText::AggressiveCaching);
+            m_axisLabels.append(std::move(st));
+        }
+        m_labelsDirty = false;
+    }
+
+    // drawStaticText interprets QPointF as the top-left of the text rect
+    // (drawText interprets it as the baseline) — subtract the font ascent
+    // from the y-coord to preserve the prior visual position.
+    const qreal ascent = p.fontMetrics().ascent();
+
+    for (size_t i = 0; i < std::size(kMajorTicks); ++i) {
+        const float db = kMajorTicks[i];
         const float x = dbToX(db);
         p.drawLine(QPointF(x, r.top()), QPointF(x, r.bottom()));
         const float y = dbToY(db);
         p.drawLine(QPointF(r.left(), y), QPointF(r.right(), y));
 
         if (!m_compact && db != 0.0f && db != kMinDb) {
+            // prepare() with the painter's actual transform avoids a
+            // first-paint rebuild on HiDPI displays.
+            m_axisLabels[i].prepare(p.transform(), f);
             p.setPen(kAxisLabelColor);
-            p.drawText(QPointF(x + 2.0f, r.bottom() - 2.0f),
-                       QString::number(static_cast<int>(db)));
-            p.drawText(QPointF(r.left() + 2.0f, y - 2.0f),
-                       QString::number(static_cast<int>(db)));
+            p.drawStaticText(QPointF(x + 2.0f, r.bottom() - 2.0f - ascent),
+                             m_axisLabels[i]);
+            p.drawStaticText(QPointF(r.left() + 2.0f, y - 2.0f - ascent),
+                             m_axisLabels[i]);
             p.setPen(majorPen);
         }
     }

--- a/src/gui/ClientCompCurveWidget.h
+++ b/src/gui/ClientCompCurveWidget.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QStaticText>
+#include <QVector>
 #include <QWidget>
 
 class QTimer;
@@ -73,6 +75,14 @@ protected:
     ClientComp* m_comp{nullptr};
     bool        m_compact{false};
     float       m_lastInputDb{-120.0f};   // smoothed ball position
+
+    // Cached axis labels — one QStaticText per kMajorTicks entry so the
+    // HarfBuzz shaper runs once per (string, font) pair instead of every
+    // 33 ms paint.  Mutable because drawGrid() is const but the cache is
+    // hidden state, not part of the widget's logical model.  Rebuilt on
+    // first paint and on compact-mode flip (font px size changes 7 ↔ 9).
+    mutable QVector<QStaticText> m_axisLabels;
+    mutable bool                 m_labelsDirty{true};
 };
 
 } // namespace AetherSDR

--- a/src/gui/ClientDeEssCurveWidget.cpp
+++ b/src/gui/ClientDeEssCurveWidget.cpp
@@ -132,18 +132,40 @@ void ClientDeEssCurveWidget::paintEvent(QPaintEvent*)
         p.drawLine(QPointF(r.left(), y), QPointF(r.right(), y));
     }
     p.setPen(QPen(kGridMajorColor, 1.0));
-    for (float f : kFreqMajor) {
-        const float x = hzToX(f);
-        p.drawLine(QPointF(x, r.top()), QPointF(x, r.bottom()));
-        if (!m_compact) {
-            p.setPen(kAxisLabelColor);
-            QFont font = p.font();
-            font.setPixelSize(8);
-            p.setFont(font);
+    QFont font = p.font();
+    font.setPixelSize(8);
+    p.setFont(font);
+
+    // Build the QStaticText cache once — font is fixed at 8 px regardless
+    // of compact mode, so this set never needs invalidation after the
+    // first paint.  Labels follow kFreqMajor: "100", "500", "1k", etc.
+    if (m_labelsDirty) {
+        m_axisLabels.clear();
+        m_axisLabels.reserve(static_cast<int>(std::size(kFreqMajor)));
+        for (float f : kFreqMajor) {
             const QString lbl = (f >= 1000.0f)
                 ? QString::number(int(f / 1000.0f)) + "k"
                 : QString::number(int(f));
-            p.drawText(QPointF(x + 2.0f, r.bottom() - 2.0f), lbl);
+            QStaticText st(lbl);
+            st.setPerformanceHint(QStaticText::AggressiveCaching);
+            m_axisLabels.append(std::move(st));
+        }
+        m_labelsDirty = false;
+    }
+
+    // drawStaticText anchors at top-left, drawText at the baseline —
+    // subtract ascent so the visual position matches the prior render.
+    const qreal ascent = p.fontMetrics().ascent();
+
+    for (size_t i = 0; i < std::size(kFreqMajor); ++i) {
+        const float f = kFreqMajor[i];
+        const float x = hzToX(f);
+        p.drawLine(QPointF(x, r.top()), QPointF(x, r.bottom()));
+        if (!m_compact) {
+            m_axisLabels[i].prepare(p.transform(), font);
+            p.setPen(kAxisLabelColor);
+            p.drawStaticText(QPointF(x + 2.0f, r.bottom() - 2.0f - ascent),
+                             m_axisLabels[i]);
             p.setPen(QPen(kGridMajorColor, 1.0));
         }
     }

--- a/src/gui/ClientDeEssCurveWidget.h
+++ b/src/gui/ClientDeEssCurveWidget.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QStaticText>
+#include <QVector>
 #include <QWidget>
 
 class QTimer;
@@ -48,6 +50,13 @@ private:
     QTimer*      m_pollTimer{nullptr};
     bool         m_compact{false};
     float        m_lastScDb{-120.0f};   // smoothed sidechain ball dB
+
+    // Cached axis labels — one QStaticText per kFreqMajor entry.  Font
+    // is fixed at 8 px regardless of compact mode (compact gates label-
+    // draw entirely), so the cache is built once and never invalidated
+    // beyond the initial dirty flag.
+    mutable QVector<QStaticText> m_axisLabels;
+    mutable bool                 m_labelsDirty{true};
 };
 
 } // namespace AetherSDR

--- a/src/gui/ClientGateCurveWidget.cpp
+++ b/src/gui/ClientGateCurveWidget.cpp
@@ -58,6 +58,7 @@ void ClientGateCurveWidget::setCompactMode(bool on)
 {
     if (on == m_compact) return;
     m_compact = on;
+    m_labelsDirty = true;  // font px size flips 9 ↔ 7
     update();
 }
 
@@ -146,18 +147,33 @@ void ClientGateCurveWidget::drawGrid(QPainter& p, const QRectF& r) const
     f.setPixelSize(m_compact ? 7 : 9);
     p.setFont(f);
 
-    for (float db : kMajorTicks) {
+    if (m_labelsDirty) {
+        m_axisLabels.clear();
+        m_axisLabels.reserve(static_cast<int>(std::size(kMajorTicks)));
+        for (float db : kMajorTicks) {
+            QStaticText st(QString::number(static_cast<int>(db)));
+            st.setPerformanceHint(QStaticText::AggressiveCaching);
+            m_axisLabels.append(std::move(st));
+        }
+        m_labelsDirty = false;
+    }
+
+    const qreal ascent = p.fontMetrics().ascent();
+
+    for (size_t i = 0; i < std::size(kMajorTicks); ++i) {
+        const float db = kMajorTicks[i];
         const float x = dbToX(db);
         p.drawLine(QPointF(x, r.top()), QPointF(x, r.bottom()));
         const float y = dbToY(db);
         p.drawLine(QPointF(r.left(), y), QPointF(r.right(), y));
 
         if (!m_compact && db != 0.0f && db != kMinDb) {
+            m_axisLabels[i].prepare(p.transform(), f);
             p.setPen(kAxisLabelColor);
-            p.drawText(QPointF(x + 2.0f, r.bottom() - 2.0f),
-                       QString::number(static_cast<int>(db)));
-            p.drawText(QPointF(r.left() + 2.0f, y - 2.0f),
-                       QString::number(static_cast<int>(db)));
+            p.drawStaticText(QPointF(x + 2.0f, r.bottom() - 2.0f - ascent),
+                             m_axisLabels[i]);
+            p.drawStaticText(QPointF(r.left() + 2.0f, y - 2.0f - ascent),
+                             m_axisLabels[i]);
             p.setPen(majorPen);
         }
     }

--- a/src/gui/ClientGateCurveWidget.h
+++ b/src/gui/ClientGateCurveWidget.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QStaticText>
+#include <QVector>
 #include <QWidget>
 
 class QTimer;
@@ -53,6 +55,12 @@ protected:
     ClientGate* m_gate{nullptr};
     bool        m_compact{false};
     float       m_lastInputDb{-120.0f};
+
+    // Cached axis labels — one QStaticText per kMajorTicks entry.  See
+    // ClientCompCurveWidget for the same pattern; mutable because
+    // drawGrid() is const but the cache is hidden state.
+    mutable QVector<QStaticText> m_axisLabels;
+    mutable bool                 m_labelsDirty{true};
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
The Comp / Gate / DeEss curve widgets were re-shaping their axis labels
through HarfBuzz on every paint at 30 Hz.  Profile sampling on macOS
showed ~5% of main-thread cycles in QTextEngine::shapeText →
hb_shape_full → hb_shape_plan_execute purely for labels whose strings
("0", "-12", "-24", "100", "1k", …) come from compile-time constant
arrays and never change.

Fix: cache one QStaticText per label with AggressiveCaching, swap each
QPainter::drawText call for drawStaticText, prepare() per paint with
the painter's actual transform so HiDPI displays don't trigger a
first-paint rebuild.  The cache is rebuilt only when the font px size
changes — which only happens on Comp/Gate setCompactMode(7 ↔ 9 px).
DeEss keeps its font fixed at 8 px and gates label-draw entirely on
m_compact, so its cache is built once and never invalidated.

Verified with perf record on Linux — with all three DSP curve tiles
visible, the previously-dominant curve-widget paint frames have
dropped to zero in the sample (below the 0.3% threshold), and the
hottest remaining shapeText caller is now a Qt button-style path
(drawItemText) at 0.67%, unrelated to anything fixed here.  The
predicted ~5% main-thread CPU win is real and measurable.

drawStaticText anchors at top-left while drawText anchors at the
baseline; the y-coord is adjusted by -fontMetrics().ascent() so the
visual position is byte-identical to the prior render.

Tube curve widget left untouched — it has no drawText calls (verified
with grep), so there's nothing to cache there.

Closes #2546.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
