### PR TITLE
fix(tci): prevent remote_audio_rx stream on TCI autostart if PC audio is disabled (#1137)

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2541,9 +2541,7 @@ bool RadioModel::handleRemoteAudioRxStreamStatus(const QString& object,
     }
 
     const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
-    const bool autoStartTci = AppSettings::instance().value("AutoStartTCI", "False").toString() == "True";
-    const bool streamNeeded = pcAudio || autoStartTci;
-    if (!streamNeeded && m_rxAudio.streamId != 0
+    if (!pcAudio && m_rxAudio.streamId != 0
         && (action == RadioStatusOwnership::RemoteAudioRxAction::Adopted
             || action == RadioStatusOwnership::RemoteAudioRxAction::Updated)) {
         qCDebug(lcProtocol) << "RadioModel: removing restored remote_audio_rx because PC audio is disabled";
@@ -4320,7 +4318,6 @@ QJsonObject RadioModel::troubleshootingSnapshot() const
     radio["audio_outputs"] = audioOutputs;
 
     const bool pcAudioSetting = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
-    const bool autoStartTci = AppSettings::instance().value("AutoStartTCI", "False").toString() == "True";
     QJsonObject remoteAudioRx;
     remoteAudioRx["stream_id"] = m_rxAudio.streamId == 0
         ? QJsonValue()
@@ -4333,13 +4330,10 @@ QJsonObject RadioModel::troubleshootingSnapshot() const
     remoteAudioRx["owned_by_us"] = m_rxAudio.clientHandle != 0 && m_rxAudio.clientHandle == ourClientHandle();
     remoteAudioRx["compression"] = m_rxAudio.compression;
     remoteAudioRx["pc_audio_setting"] = pcAudioSetting;
-    remoteAudioRx["auto_start_tci"] = autoStartTci;
-    remoteAudioRx["stream_expected"] = pcAudioSetting || autoStartTci;
+    remoteAudioRx["stream_expected"] = pcAudioSetting;
     remoteAudioRx["routing_note"] = pcAudioSetting
         ? QStringLiteral("PC Audio is enabled; an owned remote_audio_rx stream should exist and the local RX sink should be running.")
-        : (autoStartTci
-               ? QStringLiteral("PC Audio is disabled, but AutoStartTCI requires remote_audio_rx for TCI audio while the local RX sink stays off.")
-               : QStringLiteral("PC Audio and AutoStartTCI are disabled; no remote_audio_rx stream is expected."));
+        : QStringLiteral("PC Audio is disabled; no remote_audio_rx stream is expected. TCI clients route audio via DAX, not via remote_audio_rx (#1137).");
     radio["remote_audio_rx"] = remoteAudioRx;
 
     QJsonObject filterSharpness;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1670,10 +1670,9 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                                 sendCmd(cmd);
                         }
 
-                        // Create remote_audio_rx if PC Audio is on OR TCI autostart
-                        // is enabled. Defer briefly so SmartConnect/restored stream
-                        // status can be adopted before we ask the radio for another
-                        // stream. (#1014, #1051, #2037)
+                        // Create remote_audio_rx if PC Audio is enabled. Defer briefly so
+                        // SmartConnect/restored stream status can be adopted before
+                        // we ask the radio for another stream. (#1014, #1051, #1137, #2037)
                         scheduleRxAudioStreamEnsure(QStringLiteral("connect"));
 
                         // Do not claim a dax_tx stream at GUI attach time. SmartSDR DAX
@@ -2470,9 +2469,8 @@ void RadioModel::removeRxAudioStream()
 void RadioModel::scheduleRxAudioStreamEnsure(const QString& reason)
 {
     const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
-    const bool autoStartTci = AppSettings::instance().value("AutoStartTCI", "False").toString() == "True";
-    if (!pcAudio && !autoStartTci) {
-        qCDebug(lcProtocol) << "RadioModel: PC audio disabled, no TCI — skipping remote_audio_rx";
+    if (!pcAudio) {
+        qCDebug(lcProtocol) << "RadioModel: PC audio disabled — skipping remote_audio_rx";
         if (m_rxAudio.streamId != 0) {
             qCDebug(lcProtocol) << "RadioModel: removing unexpected owned remote_audio_rx while PC audio is disabled";
             removeRxAudioStream();
@@ -2484,12 +2482,11 @@ void RadioModel::scheduleRxAudioStreamEnsure(const QString& reason)
     logRemoteAudioRxSummary(QStringLiteral("ensure scheduled: ") + reason);
     QTimer::singleShot(350, this, [this, reason]() {
         const bool pcAudioNow = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
-        const bool autoStartTciNow = AppSettings::instance().value("AutoStartTCI", "False").toString() == "True";
         if (!isConnected()) {
             logRemoteAudioRxSummary(QStringLiteral("ensure canceled: disconnected"));
             return;
         }
-        if (!pcAudioNow && !autoStartTciNow) {
+        if (!pcAudioNow) {
             logRemoteAudioRxSummary(QStringLiteral("ensure canceled: no longer needed"));
             return;
         }


### PR DESCRIPTION
### **The Problem**
When `AutoStartTCI` is enabled, the radio automatically forces a `remote_audio_rx` stream upon connection, even if the user has explicitly set **PC Audio** to `Disabled` (`PcAudioEnabled=False`). 

In the FlexRadio protocol, the `remote_audio_rx` stream redirects all audio to the client, which suppresses the radio's hardware speakers. Users who rely on TCI for digital modes (e.g., WSJT-X) often prefer to use the radio’s local hardware monitoring/speakers and do not want their audio redirected to the PC.

This PR addresses **issue #1137**.

### **The Fix**
Modified `RadioModel::scheduleRxAudioStreamEnsure` to decouple the `remote_audio_rx` stream creation from the `AutoStartTCI` setting. 

**Why this is correct:**
1.  **Respects User Intent:** The creation of the `remote_audio_rx` stream is now solely gated by `PcAudioEnabled`. If PC Audio is disabled, the system will no longer force this stream, regardless of whether TCI is auto-starting or not.
2.  **Modernizes Workflow:** TCI integrations now rely on DAX streams for audio exchange. The `remote_audio_rx` stream is a legacy mechanism; forcing it on TCI startup was an incorrect architectural assumption that led to the unwanted muting of radio hardware.
3.  **Reduces Unwanted Side Effects:** This change ensures AetherSDR remains "polite" regarding radio hardware state, preventing unwanted suppression of speaker output when the user is simply connecting a digital-mode application.

### **Validation**
- Verified that with `PcAudioEnabled=False` and `AutoStartTCI=True`, the `remote_audio_rx` stream is no longer created upon radio connection.
- Verified that toggling `PcAudioEnabled=True` still correctly triggers the creation of the `remote_audio_rx` stream as expected.
- Confirmed that this change does not impact TCI connection stability or DAX stream registration.