### PR TITLE
build(macos): generate AetherSDR.icns at build time via CMake

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -74,21 +74,6 @@ jobs:
           cmake --build . --parallel $(sysctl -n hw.ncpu)
           cmake --install .
 
-      - name: Generate .icns from PNG
-        run: |
-          mkdir -p AetherSDR.iconset
-          sips -z 16 16     docs/logo-circle.png --out AetherSDR.iconset/icon_16x16.png
-          sips -z 32 32     docs/logo-circle.png --out AetherSDR.iconset/icon_16x16@2x.png
-          sips -z 32 32     docs/logo-circle.png --out AetherSDR.iconset/icon_32x32.png
-          sips -z 64 64     docs/logo-circle.png --out AetherSDR.iconset/icon_32x32@2x.png
-          sips -z 128 128   docs/logo-circle.png --out AetherSDR.iconset/icon_128x128.png
-          sips -z 256 256   docs/logo-circle.png --out AetherSDR.iconset/icon_128x128@2x.png
-          sips -z 256 256   docs/logo-circle.png --out AetherSDR.iconset/icon_256x256.png
-          sips -z 512 512   docs/logo-circle.png --out AetherSDR.iconset/icon_256x256@2x.png
-          sips -z 512 512   docs/logo-circle.png --out AetherSDR.iconset/icon_512x512.png
-          sips -z 768 768   docs/logo-circle.png --out AetherSDR.iconset/icon_512x512@2x.png
-          iconutil -c icns AetherSDR.iconset -o docs/AetherSDR.icns
-
       - name: Setup DeepFilterNet3 (DFNR)
         run: bash setup-deepfilter.sh
 
@@ -288,7 +273,7 @@ jobs:
           # Layout: app (left) + Applications link (right), PKG below Applications
           create-dmg \
             --volname "AetherSDR" \
-            --volicon "docs/AetherSDR.icns" \
+            --volicon "build/AetherSDR.icns" \
             --background "docs/logo-invert.png" \
             --window-pos 200 120 \
             --window-size 600 400 \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,12 +748,32 @@ if(APPLE)
     )
     target_link_libraries(AetherSDR PRIVATE "-framework AVFoundation" "-framework Accelerate")
     target_sources(AetherSDR PRIVATE src/core/MacNRFilter.cpp)
-    set(MACOSX_ICON "${CMAKE_SOURCE_DIR}/docs/AetherSDR.icns")
-    if(EXISTS "${MACOSX_ICON}")
-        target_sources(AetherSDR PRIVATE "${MACOSX_ICON}")
-        set_source_files_properties("${MACOSX_ICON}" PROPERTIES
-            MACOSX_PACKAGE_LOCATION "Resources")
-    endif()
+
+    # Generate AetherSDR.icns at build time from docs/logo-circle.png so local
+    # builds get an app icon without any extra setup (sips and iconutil are
+    # part of macOS).
+    set(ICON_SOURCE "${CMAKE_SOURCE_DIR}/docs/logo-circle.png")
+    set(ICNS_PATH "${CMAKE_BINARY_DIR}/AetherSDR.icns")
+    set(ICONSET_PATH "${CMAKE_BINARY_DIR}/AetherSDR.iconset")
+    add_custom_command(
+        OUTPUT "${ICNS_PATH}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${ICONSET_PATH}"
+        COMMAND sips -z 16  16  "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_16x16.png"
+        COMMAND sips -z 32  32  "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_16x16@2x.png"
+        COMMAND sips -z 32  32  "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_32x32.png"
+        COMMAND sips -z 64  64  "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_32x32@2x.png"
+        COMMAND sips -z 128 128 "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_128x128.png"
+        COMMAND sips -z 256 256 "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_128x128@2x.png"
+        COMMAND sips -z 256 256 "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_256x256.png"
+        COMMAND sips -z 512 512 "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_256x256@2x.png"
+        COMMAND sips -z 512 512 "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_512x512.png"
+        COMMAND sips -z 768 768 "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_512x512@2x.png"
+        COMMAND iconutil -c icns "${ICONSET_PATH}" -o "${ICNS_PATH}"
+        DEPENDS "${ICON_SOURCE}"
+        COMMENT "Generating AetherSDR.icns"
+    )
+    target_sources(AetherSDR PRIVATE "${ICNS_PATH}")
+    set_source_files_properties("${ICNS_PATH}" PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 elseif(WIN32)
     # Windows application icon (taskbar, Start Menu, Alt-Tab)
     set(WIN_RC "${CMAKE_SOURCE_DIR}/docs/AetherSDR.rc")


### PR DESCRIPTION
## Summary

Local `cmake` builds on macOS were producing an `.app` bundle with no icon. The `.icns` was generated only by the `macos-dmg.yml` CI workflow and never committed, so the `if(EXISTS docs/AetherSDR.icns)` guard in CMakeLists silently skipped the missing file on every developer's machine.

This PR moves the `sips` + `iconutil` generation into CMake itself via `add_custom_command`, sourced from `docs/logo-circle.png`. macOS ships both tools by default, so there's no new build dependency. The redundant manual step in `macos-dmg.yml` is dropped, and `create-dmg --volicon` now points at the CMake-produced `build/AetherSDR.icns`.

Local and CI builds now go through the same code path.

## Changes

- **`CMakeLists.txt`** — replace the `if(EXISTS .icns)` guard with an `add_custom_command` that produces `build/AetherSDR.icns` from `docs/logo-circle.png` at build time. CMake bundles it into `Contents/Resources/` via `MACOSX_PACKAGE_LOCATION`.
- **`.github/workflows/macos-dmg.yml`** — remove the manual `Generate .icns from PNG` step (now redundant); update `--volicon` to reference `build/AetherSDR.icns`.

## Verified

- `cmake -B build && cmake --build build -j10` on macOS arm64 produces:
  - `build/AetherSDR.app/Contents/Resources/AetherSDR.icns` (634 KB)
  - `Info.plist` `CFBundleIconFile` → `AetherSDR.icns`
- App launches and shows the correct icon in the Dock.

## Test plan

- [ ] CI macOS DMG workflow produces a signed/notarized DMG with both the app icon and DMG volume icon intact
- [ ] Local `cmake --build build` on macOS produces an `.app` with the icon visible in Finder/Dock

🤖 Generated with [Claude Code](https://claude.com/claude-code)