### PR TITLE
fix(gui): honor protocol-supplied spot background_color when override is off (#2550)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9856,7 +9856,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             if (m_dxccProvider.isEnabled() && spot.source != "Memory")
                 dxccCol = m_dxccProvider.colorForSpot(spot.callsign, spot.rxFreqMhz, spot.mode);
             markers.append({spot.index, spot.callsign, spot.rxFreqMhz, spot.color, spot.mode,
-                            dxccCol, spot.source, spot.spotterCallsign, spot.comment, tsMs});
+                            dxccCol, spot.source, spot.spotterCallsign, spot.comment, tsMs,
+                            spot.backgroundColor});
         }
         swGuard->setSpotMarkers(markers);
     };
@@ -14325,7 +14326,8 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
             isQrm ? QStringLiteral("QRM") : QStringLiteral("SHistory"),
             {},
             comment,
-            e.lastSeenMs
+            e.lastSeenMs,
+            {}
         });
 
         // Double mark: voice operator detected on top of a QRM-classified entry.
@@ -14343,7 +14345,8 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
                 QStringLiteral("SHistory"),
                 {},
                 QStringLiteral("Voice on QRM ch, width=%1 Hz").arg(e.widthHz, 0, 'f', 0),
-                e.voiceOverQrmLastMs
+                e.voiceOverQrmLastMs,
+                {}
             });
         }
     }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -72,6 +72,7 @@ static bool spotMarkersVisuallyEqual(const QVector<SpectrumWidget::SpotMarker>& 
         if (a.callsign != b.callsign
             || std::abs(a.freqMhz - b.freqMhz) > kFrequencyEpsilonMhz
             || a.color != b.color
+            || a.backgroundColor != b.backgroundColor
             || a.dxccColor != b.dxccColor
             || a.source != b.source) {
             return false;
@@ -5186,7 +5187,11 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
         const bool isQrm = (spot.source == QStringLiteral("QRM"));
         if (isQrm) { p.setOpacity(0.3); }
 
-        // Background pill — only draw when override background is enabled (#768)
+        // Background pill — local Override Background color wins when on
+        // (#768).  When off, fall through to the protocol-supplied
+        // `background_color` field if the spot carries one (#2550).  The
+        // #AARRGGBB form encodes alpha directly so no separate opacity
+        // multiplier is applied — the upstream tool's choice is honored.
         if (m_spotOverrideBg) {
             int bgAlpha = m_spotBgOpacity * 255 / 100;
             QColor bgCol = m_spotBgColor;
@@ -5194,6 +5199,14 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
             p.setPen(Qt::NoPen);
             p.setBrush(bgCol);
             p.drawRoundedRect(labelRect, 3, 3);
+        } else if (!spot.backgroundColor.isEmpty()
+                   && spot.backgroundColor.startsWith('#')) {
+            QColor bgCol(spot.backgroundColor);
+            if (bgCol.isValid()) {
+                p.setPen(Qt::NoPen);
+                p.setBrush(bgCol);
+                p.drawRoundedRect(labelRect, 3, 3);
+            }
         }
 
         // Text

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -307,6 +307,9 @@ public:
         QString spotterCallsign;
         QString comment;
         qint64  timestampMs{0};
+        // Protocol-supplied pill color (#AARRGGBB). Honored only when
+        // Override Background is off — see drawSpotMarkers().
+        QString backgroundColor;
     };
     void setSpotMarkers(const QVector<SpotMarker>& markers);
 


### PR DESCRIPTION
SpotData::backgroundColor was parsed from the FlexLib protocol and
stored in the model, but dropped at the model→view boundary: the
SpotMarker render struct didn't carry the field, the converter at
MainWindow:9858 silently discarded it, and drawSpotMarkers() only drew
the pill from the local Override Background color.

Result: third-party spot sources (wave-flex-integrator, SpotCollector)
that encode priority / worked-before / DXCC-need via background_color
were rendered with no pill at all whenever the user turned Override
Background off — which is the user-facing "use radio-provided color"
state.

Adds backgroundColor to SpotMarker (end of struct, so SHistory/QRM
brace-inits stay positionally correct), forwards it from the converter,
adds an else-branch in drawSpotMarkers() that draws the pill from the
spot's #AARRGGBB field when override is off, and updates
spotMarkersVisuallyEqual so pill-color transitions trigger a repaint.

Override Background ON behavior is unchanged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
