### PR TITLE
fix(gui): hide dock-side icons and separator in minimal mode

### DIFF
--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -390,11 +390,11 @@ TitleBar::TitleBar(QWidget* parent)
 
     m_hbox->addSpacing(4);
 
-    auto* dockSep = new QFrame;
-    dockSep->setFixedSize(1, 20);
-    dockSep->setStyleSheet("QFrame { background: #304050; border: none; }");
-    markDragHandle(dockSep);
-    m_hbox->addWidget(dockSep);
+    m_dockSep = new QFrame;
+    m_dockSep->setFixedSize(1, 20);
+    m_dockSep->setStyleSheet("QFrame { background: #304050; border: none; }");
+    markDragHandle(m_dockSep);
+    m_hbox->addWidget(m_dockSep);
 
     m_hbox->addSpacing(4);
 
@@ -1036,6 +1036,12 @@ void TitleBar::setMinimalMode(bool on)
     m_hpSlider->setVisible(!on);
     m_masterLabel->setVisible(!on);
     m_hpLabel->setVisible(!on);
+    // Dock-side selectors lose meaning in minimal mode — no panel
+    // layout to dock or pop out of.
+    if (m_dockLeftLbl)  m_dockLeftLbl->setVisible(!on);
+    if (m_dockRightLbl) m_dockRightLbl->setVisible(!on);
+    if (m_popOutLbl)    m_popOutLbl->setVisible(!on);
+    if (m_dockSep)      m_dockSep->setVisible(!on);
     // Don't touch m_otherTxLabel or m_mfBtn — their visibility is
     // managed by setOtherClientTx() and setMultiFlexStatus() respectively
     updateMaximizeIcon();

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -5,6 +5,7 @@
 class QPushButton;
 class QSlider;
 class QLabel;
+class QFrame;
 class QMenuBar;
 class QHBoxLayout;
 class QTimer;
@@ -92,6 +93,7 @@ private:
     QLabel*      m_dockLeftLbl{nullptr};
     QLabel*      m_dockRightLbl{nullptr};
     QLabel*      m_popOutLbl{nullptr};
+    QFrame*      m_dockSep{nullptr};
     bool         m_minimalMode{false};
     bool         m_windowMoveActive{false};
     bool         m_windowMoveUsesSystem{false};


### PR DESCRIPTION
The three dock-side selectors (left dock, right dock, pop-out) and the
vertical separator that follows them lose their meaning in minimal mode
— there's no panel layout to dock to or pop out of when the spectrum is
hidden. They were left visible cluttering the narrow title strip.

Promotes the previously-local dockSep frame to a member and hides all
four widgets alongside the existing non-essential controls in
setMinimalMode().

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
