### PR TITLE
fix(cat): make set_split_vfo / tx_enable idempotent to stop radio TX watchdog

### DIFF
--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -439,8 +439,12 @@ QString RigctlProtocol::cmdSetSplitVfo(const QString& args)
     if (parts.isEmpty()) return rprt(-1);
     bool enable = (parts[0] == "1");
     if (!enable) {
-        // Disable split — move TX back to our slice
-        if (auto* s = currentSlice())
+        // Disable split — move TX back to our slice (idempotent).
+        // Hamlib clients (VARA/VARAC/N1MM) poll this every ~3s; without the
+        // isTxSlice() guard the radio gets bombarded with `slice set N tx=1`
+        // commands, which appears to interfere with radio-side TX state
+        // tracking and causes spurious unkey after ~1s during PTT.
+        if (auto* s = currentSlice(); s && !s->isTxSlice())
             s->setTxSlice(true);
     }
     // Enabling split requires a second slice — handled by MainWindow's split logic

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -406,7 +406,7 @@ QString TciProtocol::cmdTxEnable(const QStringList& args)
 
     if (enable) {
         auto* s = sliceForTrx(trx);
-        if (s) {
+        if (s && !s->isTxSlice()) {
             QMetaObject::invokeMethod(s, [s]() {
                 s->setTxSlice(true);
             }, Qt::QueuedConnection);


### PR DESCRIPTION
## Summary

Digital-mode software (VARA HF / VARAC / WSJT-X / N1MM / fldigi) over rigctld is currently unusable on FLEX-8600 fw 4.1.5: PTT engages and the carrier comes up, but the radio drops back to RX after roughly 1 second even though the client is still asserting PTT and pushing dax_tx audio. This PR fixes that.

## Root Cause

`RigctlProtocol::cmdSetSplitVfo` and `TciProtocol::cmdTxEnable` both called `setTxSlice(true)` unconditionally, emitting `slice set <N> tx=1` to the radio every time the protocol handler ran — even when the slice was already the TX slice. The matching code in `cmdSetPtt` correctly guards with `!isTxSlice()`; only these two paths were missing the guard.

Hamlib-based contest loggers and digital-mode software poll `set_split_vfo` every ~3 s as part of their state-sync loop. AetherSDR exposes **8 CAT channels** (`kCatChannels = 8`, RigctlServer + RigctlPty), so a single polling client multiplied by all the channels it touches produces a burst of identical `slice set 0 tx=1` commands. Connection logs show them stacked at the same millisecond:

```
[07:04:32.299] TX: \"C77|slice set 0 tx=1\"
[07:04:32.299] TX: \"C78|slice set 0 tx=1\"
[07:04:32.299] TX: \"C79|slice set 0 tx=1\"
[07:04:32.299] TX: \"C80|slice set 0 tx=1\"
[07:04:35.312] TX: \"C84|slice set 0 tx=1\"     ← next poll, ~3 s later
[07:04:35.312] TX: \"C85|slice set 0 tx=1\"
[07:04:35.312] TX: \"C86|slice set 0 tx=1\"
[07:04:35.312] TX: \"C87|slice set 0 tx=1\"
```

This sustained spam interferes with the radio's internal TX-state tracking. When PTT subsequently engages, the radio firmware decides the stream is unhealthy and forces an `UNKEY_REQUESTED` roughly 1 s into the transmission:

```
[06:58:05.634] TX: \"C108|xmit 1\"
[06:58:05.666] RX: \"interlock state=PTT_REQUESTED source=SW\"
[06:58:05.666] RX: \"interlock state=TRANSMITTING source=SW\"
[06:58:05.832] sendToRadio #1800 bytes=284 sent=284 streamId=0x84000000   ← DAX audio flowing
[06:58:06.062] RX: \"interlock state=TRANSMITTING\"
[06:58:07.031] sendToRadio #2000 bytes=284 sent=284 streamId=0x84000000
[06:58:08.094] sendToRadio #2200 bytes=284 sent=284 streamId=0x84000000
[06:58:08.453] RX: \"interlock state=UNKEY_REQUESTED\"   ← radio unkeys itself after ~2.8s
[06:58:10.363] TX: \"C172|xmit 0\"                       ← client only sees CAT release here
```

The hamlib client (VARAC in this case) is still holding PTT — the radio gave up on its own.

## Diagnosis Path

The symptom (\"PTT cut after 1 s\") naturally suggests DAX TX audio path, packet format, network timing, or firmware watchdog. We ruled all of those out with targeted instrumentation:

| Check | Result |
|---|---|
| `xmit 1` reaches radio, radio enters `state=TRANSMITTING` | ✓ |
| `m_radioTransmitting` flips true via `radioTransmittingChanged` | ✓ |
| `m_daxTxMode` true in DIGU mode | ✓ |
| `feedDaxTxAudio` receives audio throughout TX window | ✓ |
| `sendToRadio` emits packets with correct stream ID (0x84000000) and size (284 B) | ✓ |
| `QUdpSocket::writeDatagram` returns `sent=284` (no kernel drop) | ✓ |
| **Radio still issues `UNKEY_REQUESTED` ~1 s after PTT** | ✗ |

A counter-experiment confirmed direction: gating dax_tx packets so they only flow during `m_radioTransmitting=true` made the radio unkey in **127 ms** instead of ~1 s — the radio wants a continuous packet stream, so packet flow isn't the trigger. The trigger is the CAT command spam: with the CAT service disabled entirely, PTT holds for the full transmission duration with the same DAX path, same firmware, same VARA build.

## Fix

Add the same `!isTxSlice()` idempotency check that `cmdSetPtt` already has:

```cpp
// RigctlProtocol::cmdSetSplitVfo — before
if (auto* s = currentSlice())
    s->setTxSlice(true);

// after
if (auto* s = currentSlice(); s && !s->isTxSlice())
    s->setTxSlice(true);
```

`TciProtocol::cmdTxEnable` gets the same treatment. When the slice is already the TX slice, the command is a no-op anyway; sending it again costs a TCP round-trip and apparently provokes firmware-side TX-state churn.

The first non-redundant call still goes through — e.g. on actual split disable, after slice teardown, or after profile-global load (the original `#145` re-claim case is preserved in `MainWindow.cpp:8598`).

## Why This Was a Deep Bug

- The symptom (PTT drops mid-transmission) points at the TX/DAX subsystem, not the rigctld split-vfo handler.
- The buggy code path is functionally correct in isolation — it sets the TX slice, which is what `set_split_vfo 0 VFOA` requests.
- The matching `cmdSetPtt` has the guard, so the pattern was known; only this one handler missed it.
- Single-client / quick-PTT testing doesn't reproduce it. It needs (a) a long-running hamlib client that polls split state, (b) multiple CAT channels active, and (c) a long enough PTT to cross the firmware's watchdog window.
- v0.8.20 has the same un-guarded code, but doesn't exhibit the symptom in our setup — the radio's TX-state tracking has apparently become more sensitive between firmware patch levels, or other command-stream changes since v0.8.20 push the radio over the threshold.

## Test Plan

- [x] Connect to FLEX-8600 fw 4.1.5.39794 on macOS (Apple Silicon, fw / hardware unchanged from v0.8.20)
- [x] Mode: DIGU; mic_selection=PC; DAX bridge enabled
- [x] VARA HF v4.9.0 (audio source) + VARAC (rigctld CAT) running
- [x] **Before fix**: PTT engages → carrier appears → radio unkeys after ~1–3 s with VARAC still asserting PTT
- [x] **After fix**: PTT holds for the full transmission until VARAC releases
- [x] Verified `slice set 0 tx=1` no longer spammed every 3 s in the connection log
- [ ] Reviewer to verify on other rigctld clients (N1MM, WSJT-X, fldigi) — same code path
- [ ] Reviewer to verify TCI path on Windows / Linux (TciProtocol fix is parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)