### PR TITLE
Fix intermittent frameless title-bar drag on macOS

### DIFF
--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -1,5 +1,6 @@
 #include "AetherDspDialog.h"
 #include "AetherDspWidget.h"
+#include "FramelessMoveHelper.h"
 #include "core/AppSettings.h"
 
 #include <QEvent>
@@ -246,18 +247,19 @@ void AetherDspDialog::leaveEvent(QEvent* ev)
 
 bool AetherDspDialog::eventFilter(QObject* obj, QEvent* ev)
 {
+    if (obj == m_titleBar && ev->type() == QEvent::MouseMove) {
+        return FramelessMoveHelper::move(m_titleBar, static_cast<QMouseEvent*>(ev));
+    }
+    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonRelease) {
+        return FramelessMoveHelper::finish(m_titleBar, static_cast<QMouseEvent*>(ev));
+    }
+
     // Drag-to-move via the custom title bar.  The trio buttons are their
     // own QPushButtons that consume the press themselves, so this only
     // fires on the bare title-bar background.
     if (obj == m_titleBar && ev->type() == QEvent::MouseButtonPress) {
         auto* me = static_cast<QMouseEvent*>(ev);
-        if (me->button() == Qt::LeftButton) {
-            if (auto* h = windowHandle()) {
-                h->startSystemMove();
-                me->accept();
-                return true;
-            }
-        }
+        return FramelessMoveHelper::start(m_titleBar, me);
     }
     if (obj == m_titleBar && ev->type() == QEvent::MouseButtonDblClick) {
         if (isMaximized()) showNormal();

--- a/src/gui/AetherialAudioStrip.cpp
+++ b/src/gui/AetherialAudioStrip.cpp
@@ -4,6 +4,7 @@
 #include <QScreen>
 
 #include "AetherDspWidget.h"
+#include "FramelessMoveHelper.h"
 #include "StripChainWidget.h"
 #include "StripRxChainWidget.h"
 #include "ClientEqApplet.h"
@@ -911,19 +912,20 @@ void AetherialAudioStrip::leaveEvent(QEvent* ev)
 
 bool AetherialAudioStrip::eventFilter(QObject* obj, QEvent* ev)
 {
+    if (obj == m_titleBar && ev->type() == QEvent::MouseMove) {
+        return FramelessMoveHelper::move(m_titleBar, static_cast<QMouseEvent*>(ev));
+    }
+    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonRelease) {
+        return FramelessMoveHelper::finish(m_titleBar, static_cast<QMouseEvent*>(ev));
+    }
+
     // Drag-to-move via the custom title bar.  The trio buttons are
     // independent QPushButtons that consume the press themselves, so
     // this only fires on the bare title-bar background between the
     // title text and the trio.
     if (obj == m_titleBar && ev->type() == QEvent::MouseButtonPress) {
         auto* me = static_cast<QMouseEvent*>(ev);
-        if (me->button() == Qt::LeftButton) {
-            if (auto* h = windowHandle()) {
-                h->startSystemMove();
-                me->accept();
-                return true;
-            }
-        }
+        return FramelessMoveHelper::start(m_titleBar, me);
     }
     if (obj == m_titleBar && ev->type() == QEvent::MouseButtonDblClick) {
         if (isMaximized()) showNormal();

--- a/src/gui/EditorFramelessTitleBar.cpp
+++ b/src/gui/EditorFramelessTitleBar.cpp
@@ -1,9 +1,9 @@
 #include "EditorFramelessTitleBar.h"
+#include "FramelessMoveHelper.h"
 
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMouseEvent>
-#include <QWindow>
 
 namespace AetherSDR {
 
@@ -77,27 +77,34 @@ void EditorFramelessTitleBar::setControlsVisible(bool on)
 
 void EditorFramelessTitleBar::mousePressEvent(QMouseEvent* ev)
 {
-    if (ev->button() == Qt::LeftButton) {
-        if (auto* w = window()) {
-            if (auto* h = w->windowHandle()) {
-                h->startSystemMove();
-                ev->accept();
-                return;
-            }
-        }
+    if (FramelessMoveHelper::start(this, ev)) {
+        return;
     }
     QWidget::mousePressEvent(ev);
+}
+
+void EditorFramelessTitleBar::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (FramelessMoveHelper::move(this, ev)) {
+        return;
+    }
+    QWidget::mouseMoveEvent(ev);
+}
+
+void EditorFramelessTitleBar::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (FramelessMoveHelper::finish(this, ev)) {
+        return;
+    }
+    QWidget::mouseReleaseEvent(ev);
 }
 
 void EditorFramelessTitleBar::mouseDoubleClickEvent(QMouseEvent* ev)
 {
     if (ev->button() == Qt::LeftButton) {
-        if (auto* w = window()) {
-            if (w->isMaximized()) w->showNormal();
-            else                  w->showMaximized();
-            ev->accept();
-            return;
-        }
+        FramelessMoveHelper::toggleMaximized(this);
+        ev->accept();
+        return;
     }
     QWidget::mouseDoubleClickEvent(ev);
 }

--- a/src/gui/EditorFramelessTitleBar.h
+++ b/src/gui/EditorFramelessTitleBar.h
@@ -11,9 +11,9 @@ namespace AetherSDR {
 // Each editor sets Qt::FramelessWindowHint at construction and adds
 // this widget at the very top of its layout.  Behaviour:
 //
-//  - Press-and-drag anywhere on the bar starts a compositor-managed
-//    window move via QWindow::startSystemMove() — same pattern as
-//    the main window's TitleBar.
+//  - Press-and-drag anywhere on the bar moves the window.  macOS uses
+//    a manual move path because repeated QWindow::startSystemMove()
+//    calls can be refused for several seconds after a move completes.
 //  - Double-click toggles maximize.
 //  - The trio at the right (— □ ✕) wires to showMinimized /
 //    showMaximized / close on the host window via an installed event
@@ -34,6 +34,8 @@ public:
 
 protected:
     void mousePressEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
     void mouseDoubleClickEvent(QMouseEvent* ev) override;
     bool eventFilter(QObject* obj, QEvent* ev) override;
 

--- a/src/gui/FramelessMoveHelper.h
+++ b/src/gui/FramelessMoveHelper.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <QMouseEvent>
+#include <QPoint>
+#include <QWidget>
+#include <QWindow>
+
+namespace AetherSDR::FramelessMoveHelper {
+
+namespace Detail {
+
+constexpr const char* kActiveProperty = "_aetherManualWindowMoveActive";
+constexpr const char* kPressGlobalProperty = "_aetherManualWindowMovePressGlobal";
+constexpr const char* kStartPosProperty = "_aetherManualWindowMoveStartPos";
+
+inline void startManualMove(QWidget* handle, QWidget* window, QMouseEvent* ev)
+{
+    handle->setProperty(kActiveProperty, true);
+    handle->setProperty(kPressGlobalProperty, ev->globalPosition().toPoint());
+    handle->setProperty(kStartPosProperty, window->pos());
+    handle->grabMouse();
+    ev->accept();
+}
+
+inline bool manualMoveActive(QWidget* handle)
+{
+    return handle && handle->property(kActiveProperty).toBool();
+}
+
+} // namespace Detail
+
+inline bool start(QWidget* handle, QMouseEvent* ev)
+{
+    if (!handle || !ev || ev->button() != Qt::LeftButton) {
+        return false;
+    }
+
+    QWidget* window = handle->window();
+    if (!window) {
+        return false;
+    }
+
+#ifndef Q_OS_MAC
+    if (QWindow* windowHandle = window->windowHandle()) {
+        if (windowHandle->startSystemMove()) {
+            ev->accept();
+            return true;
+        }
+    }
+#endif
+
+    Detail::startManualMove(handle, window, ev);
+    return true;
+}
+
+inline bool finish(QWidget* handle, QMouseEvent* ev)
+{
+    if (!Detail::manualMoveActive(handle)) {
+        return false;
+    }
+
+    handle->setProperty(Detail::kActiveProperty, false);
+    handle->releaseMouse();
+    if (ev) {
+        ev->accept();
+    }
+    return true;
+}
+
+inline bool move(QWidget* handle, QMouseEvent* ev)
+{
+    if (!Detail::manualMoveActive(handle) || !ev) {
+        return false;
+    }
+
+    if (!(ev->buttons() & Qt::LeftButton)) {
+        return finish(handle, ev);
+    }
+
+    QWidget* window = handle->window();
+    if (window) {
+        const QPoint pressGlobal =
+            handle->property(Detail::kPressGlobalProperty).toPoint();
+        const QPoint startPos =
+            handle->property(Detail::kStartPosProperty).toPoint();
+        window->move(startPos + ev->globalPosition().toPoint() - pressGlobal);
+    }
+
+    ev->accept();
+    return true;
+}
+
+inline void toggleMaximized(QWidget* handle)
+{
+    if (!handle) {
+        return;
+    }
+
+    QWidget* window = handle->window();
+    if (!window) {
+        return;
+    }
+
+    if (window->isMaximized()) {
+        window->showNormal();
+    } else {
+        window->showMaximized();
+    }
+}
+
+} // namespace AetherSDR::FramelessMoveHelper

--- a/src/gui/FramelessWindowTitleBar.cpp
+++ b/src/gui/FramelessWindowTitleBar.cpp
@@ -1,10 +1,10 @@
 #include "FramelessWindowTitleBar.h"
+#include "FramelessMoveHelper.h"
 
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMouseEvent>
 #include <QPushButton>
-#include <QWindow>
 
 namespace AetherSDR {
 
@@ -101,30 +101,34 @@ void FramelessWindowTitleBar::setTitleText(const QString& title)
 
 void FramelessWindowTitleBar::mousePressEvent(QMouseEvent* event)
 {
-    if (event->button() == Qt::LeftButton) {
-        if (auto* w = window()) {
-            if (auto* h = w->windowHandle()) {
-                h->startSystemMove();
-                event->accept();
-                return;
-            }
-        }
+    if (FramelessMoveHelper::start(this, event)) {
+        return;
     }
     QWidget::mousePressEvent(event);
+}
+
+void FramelessWindowTitleBar::mouseMoveEvent(QMouseEvent* event)
+{
+    if (FramelessMoveHelper::move(this, event)) {
+        return;
+    }
+    QWidget::mouseMoveEvent(event);
+}
+
+void FramelessWindowTitleBar::mouseReleaseEvent(QMouseEvent* event)
+{
+    if (FramelessMoveHelper::finish(this, event)) {
+        return;
+    }
+    QWidget::mouseReleaseEvent(event);
 }
 
 void FramelessWindowTitleBar::mouseDoubleClickEvent(QMouseEvent* event)
 {
     if (event->button() == Qt::LeftButton) {
-        if (auto* w = window()) {
-            if (w->isMaximized()) {
-                w->showNormal();
-            } else {
-                w->showMaximized();
-            }
-            event->accept();
-            return;
-        }
+        FramelessMoveHelper::toggleMaximized(this);
+        event->accept();
+        return;
     }
     QWidget::mouseDoubleClickEvent(event);
 }

--- a/src/gui/FramelessWindowTitleBar.h
+++ b/src/gui/FramelessWindowTitleBar.h
@@ -16,6 +16,8 @@ public:
 
 protected:
     void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;
 
 private:

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1,4 +1,5 @@
 #include "NetworkDiagnosticsDialog.h"
+#include "FramelessMoveHelper.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/LogManager.h"
@@ -1900,18 +1901,19 @@ void NetworkDiagnosticsDialog::leaveEvent(QEvent* ev)
 
 bool NetworkDiagnosticsDialog::eventFilter(QObject* obj, QEvent* ev)
 {
+    if (obj == m_titleBar && ev->type() == QEvent::MouseMove) {
+        return FramelessMoveHelper::move(m_titleBar, static_cast<QMouseEvent*>(ev));
+    }
+    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonRelease) {
+        return FramelessMoveHelper::finish(m_titleBar, static_cast<QMouseEvent*>(ev));
+    }
+
     // Drag-to-move via the custom title bar.  The trio buttons are
     // their own QPushButtons that consume the press themselves, so
     // this only fires on the bare title-bar background.
     if (obj == m_titleBar && ev->type() == QEvent::MouseButtonPress) {
         auto* me = static_cast<QMouseEvent*>(ev);
-        if (me->button() == Qt::LeftButton) {
-            if (auto* h = windowHandle()) {
-                h->startSystemMove();
-                me->accept();
-                return true;
-            }
-        }
+        return FramelessMoveHelper::start(m_titleBar, me);
     }
     if (obj == m_titleBar && ev->type() == QEvent::MouseButtonDblClick) {
         if (isMaximized()) {

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -1,4 +1,5 @@
 #include "PanadapterApplet.h"
+#include "FramelessMoveHelper.h"
 #include "GuardedSlider.h"
 #include "SpectrumWidget.h"
 #include "core/AppSettings.h"
@@ -385,20 +386,20 @@ void PanadapterApplet::clearCwText()
 
 bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
 {
+    if (obj == m_titleBar && m_isFloating && ev->type() == QEvent::MouseMove) {
+        return FramelessMoveHelper::move(m_titleBar, static_cast<QMouseEvent*>(ev));
+    }
+    if (obj == m_titleBar && m_isFloating && ev->type() == QEvent::MouseButtonRelease) {
+        return FramelessMoveHelper::finish(m_titleBar, static_cast<QMouseEvent*>(ev));
+    }
+
     // Title-bar drag in floating mode → move the OS window via Qt 6's
-    // cross-platform startSystemMove.  Frameless pop-outs have no native
+    // cross-platform move helper.  Frameless pop-outs have no native
     // title bar, so the applet's own title strip becomes the drag handle.
     if (obj == m_titleBar && m_isFloating
         && ev->type() == QEvent::MouseButtonPress) {
         auto* me = static_cast<QMouseEvent*>(ev);
-        if (me->button() == Qt::LeftButton) {
-            if (auto* w = window()) {
-                if (auto* h = w->windowHandle()) {
-                    h->startSystemMove();
-                    return true;
-                }
-            }
-        }
+        return FramelessMoveHelper::start(m_titleBar, me);
     }
     if (ev->type() == QEvent::MouseButtonPress)
         emit activated(m_panId);

--- a/src/gui/StripFinalOutputPanel.cpp
+++ b/src/gui/StripFinalOutputPanel.cpp
@@ -2,6 +2,7 @@
 
 #include "ClientCompKnob.h"
 #include "EditorFramelessTitleBar.h"
+#include "FramelessMoveHelper.h"
 #include "MeterSmoother.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
@@ -899,22 +900,22 @@ void StripFinalOutputPanel::showQuindarEditor()
     connect(tbCloseBtn, &QPushButton::clicked, dlg, &QDialog::accept);
     tbLayout->addWidget(tbCloseBtn);
 
-    // Drag-to-move via QWindow::startSystemMove() — same pattern as
-    // EditorFramelessTitleBar elsewhere in the strip.  Single inline
-    // event filter installed on the bar + label so a left-press
-    // anywhere on the title (not the close button) starts a
-    // compositor-managed window move.
+    // Drag-to-move via the shared frameless move helper.  Single inline
+    // event filter installed on the bar + label so a left-press anywhere
+    // on the title (not the close button) moves the dialog.
     struct MoveFilter : public QObject {
         QWidget* host;
         explicit MoveFilter(QWidget* h) : QObject(h), host(h) {}
         bool eventFilter(QObject* /*o*/, QEvent* ev) override {
+            if (ev->type() == QEvent::MouseMove) {
+                return FramelessMoveHelper::move(host, static_cast<QMouseEvent*>(ev));
+            }
+            if (ev->type() == QEvent::MouseButtonRelease) {
+                return FramelessMoveHelper::finish(host, static_cast<QMouseEvent*>(ev));
+            }
             if (ev->type() == QEvent::MouseButtonPress) {
                 auto* me = static_cast<QMouseEvent*>(ev);
-                if (me->button() == Qt::LeftButton && host && host->window()) {
-                    if (auto* w = host->window()->windowHandle())
-                        w->startSystemMove();
-                    return true;
-                }
+                return FramelessMoveHelper::start(host, me);
             }
             return false;
         }

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -468,8 +468,10 @@ bool TitleBar::startWindowMove(QMouseEvent* ev, bool useSystemMove)
     m_windowMoveStartPos = w->pos();
 
     if (useSystemMove) {
+#ifndef Q_OS_MAC
         if (auto* h = w->windowHandle())
             m_windowMoveUsesSystem = h->startSystemMove();
+#endif
     }
 
     // Manual-move path: when a child-widget eventFilter consumes the press

--- a/src/gui/containers/ContainerTitleBar.cpp
+++ b/src/gui/containers/ContainerTitleBar.cpp
@@ -1,10 +1,13 @@
 #include "ContainerTitleBar.h"
+#include "gui/FramelessMoveHelper.h"
 
 #include <QHBoxLayout>
+#include <QGuiApplication>
 #include <QLabel>
 #include <QMouseEvent>
 #include <QPushButton>
 #include <QSignalBlocker>
+#include <QTimer>
 
 namespace AetherSDR {
 
@@ -153,6 +156,11 @@ void ContainerTitleBar::setCloseButtonVisible(bool visible)
 void ContainerTitleBar::mousePressEvent(QMouseEvent* ev)
 {
     if (ev->button() != Qt::LeftButton) { QWidget::mousePressEvent(ev); return; }
+    if (m_isFloating) {
+        FramelessMoveHelper::start(this, ev);
+        setCursor(Qt::ClosedHandCursor);
+        return;
+    }
     m_pressed = true;
     m_pressPos = ev->globalPosition().toPoint();
     setCursor(Qt::ClosedHandCursor);
@@ -161,6 +169,9 @@ void ContainerTitleBar::mousePressEvent(QMouseEvent* ev)
 
 void ContainerTitleBar::mouseMoveEvent(QMouseEvent* ev)
 {
+    if (m_isFloating && FramelessMoveHelper::move(this, ev)) {
+        return;
+    }
     if (!m_pressed || !(ev->buttons() & Qt::LeftButton)) {
         QWidget::mouseMoveEvent(ev);
         return;
@@ -173,6 +184,25 @@ void ContainerTitleBar::mouseMoveEvent(QMouseEvent* ev)
     emit dragStartRequested(g);
     m_pressed = false;
     setCursor(Qt::OpenHandCursor);
+}
+
+void ContainerTitleBar::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (m_isFloating) {
+        FramelessMoveHelper::finish(this, ev);
+        setCursor(Qt::OpenHandCursor);
+        return;
+    }
+    QWidget::mouseReleaseEvent(ev);
+    if (ev->button() == Qt::LeftButton) {
+        QTimer::singleShot(0, this, [this]() {
+            if (!m_isFloating && m_pressed
+                && !(QGuiApplication::mouseButtons() & Qt::LeftButton)) {
+                m_pressed = false;
+                setCursor(Qt::OpenHandCursor);
+            }
+        });
+    }
 }
 
 } // namespace AetherSDR

--- a/src/gui/containers/ContainerTitleBar.h
+++ b/src/gui/containers/ContainerTitleBar.h
@@ -49,6 +49,7 @@ signals:
 protected:
     void mousePressEvent(QMouseEvent* ev) override;
     void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
 
 private:
     QLabel*      m_titleLabel{nullptr};


### PR DESCRIPTION
## Summary
- add a shared frameless window move helper for custom title bars
- use a manual top-level widget move path on macOS instead of relying on repeated QWindow::startSystemMove() calls
- keep the native startSystemMove() path on non-macOS platforms, with a manual fallback when Qt refuses the native move request

## Bug
On macOS, frameless windows could intermittently stop responding to title-bar drag attempts. A user could successfully drag a frameless window once, then immediately trying to drag it again would do nothing for roughly 5-10 seconds before it began working again.

The click position within the title bar was not the trigger. The issue was that several custom title bars called QWindow::startSystemMove() on mouse press, consumed the event, and did not check or recover when Qt/macOS did not actually enter a native move operation. When that native move handoff stalled or was refused, the mouse press was swallowed and there was no manual drag fallback, making the title bar feel dead until the platform state recovered.

## Fix
This PR centralizes frameless title-bar movement in FramelessMoveHelper:

- macOS always uses a manual move path: record the initial global mouse position and window position on press, move the top-level widget on mouse move, and release the mouse grab on button release.
- Linux/Windows still try QWindow::startSystemMove() first so compositor/window-manager managed moves remain unchanged there.
- If startSystemMove() returns false on non-macOS platforms, the helper falls back to the same manual movement path.

The main TitleBar already had a manual fallback, so this PR disables the macOS native move handoff there and applies the same helper behavior to the reusable frameless title bars and custom frameless dialog/pop-out title bars.

## Testing
- Built successfully on macOS with: cmake --build build
- Launched the rebuilt app from the CLI and verified repeated frameless title-bar drags no longer enter the temporary non-draggable state.