### PR TITLE
Fix HID-enabled build automoc registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -904,7 +904,9 @@ if(HIDAPI_FOUND)
     target_compile_definitions(AetherSDR PRIVATE HAVE_HIDAPI)
     target_sources(AetherSDR PRIVATE
         src/core/HidEncoderManager.cpp
-        src/core/HidDeviceParser.cpp)
+        src/core/HidEncoderManager.h
+        src/core/HidDeviceParser.cpp
+        src/core/HidDeviceParser.h)
     set(HIDAPI_NORMALIZED_INCLUDE_DIRS ${HIDAPI_INCLUDE_DIRS})
     foreach(hidapi_dir IN LISTS HIDAPI_INCLUDE_DIRS)
         if(EXISTS "${hidapi_dir}/hidapi.h")


### PR DESCRIPTION
## Summary
- include the HID headers in the conditional hidapi target source list
- ensure Qt AUTOMOC sees HidEncoderManager.h when HAVE_HIDAPI is enabled
- fixes HID-enabled builds that currently fail at link time with missing HidEncoderManager Qt meta-object/signal symbols

## Bug
AetherSDR builds normally when hidapi is not installed because the HID encoder code is skipped. After installing the optional hidapi dependency, CMake enables HAVE_HIDAPI and compiles HidEncoderManager.cpp.

HidEncoderManager inherits QObject and uses Q_OBJECT/signals in HidEncoderManager.h. Qt must run MOC on that header to generate the class meta-object, signal methods, and vtable-related code. The current hidapi-enabled target_sources() block only lists the .cpp files, so AUTOMOC does not reliably scan HidEncoderManager.h.

That causes the HID-enabled build to compile but fail during the final app link with missing symbols such as:

- AetherSDR::HidEncoderManager::staticMetaObject
- AetherSDR::HidEncoderManager::buttonPressed(...)
- AetherSDR::HidEncoderManager::connectionChanged(...)
- vtable for AetherSDR::HidEncoderManager

## Fix
Add the HID headers to the same conditional target_sources() block used when HIDAPI_FOUND is true:

- src/core/HidEncoderManager.h
- src/core/HidDeviceParser.h

The key file is HidEncoderManager.h because it contains Q_OBJECT. Listing it as a target source lets Qt AUTOMOC generate the missing meta-object/signal code. HidDeviceParser.h is included alongside its matching .cpp for consistency.

## Testing
Configured and built on macOS with optional hidapi installed:

- cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
- cmake --build build

CMake reported:

- hidapi found — USB HID encoder support enabled

The app linked successfully after this change.