### PR TITLE
Fix macOS iconset 512@2x generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -767,7 +767,7 @@ if(APPLE)
         COMMAND sips -z 256 256 "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_256x256.png"
         COMMAND sips -z 512 512 "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_256x256@2x.png"
         COMMAND sips -z 512 512 "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_512x512.png"
-        COMMAND sips -z 768 768 "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_512x512@2x.png"
+        COMMAND sips -z 1024 1024 "${ICON_SOURCE}" --out "${ICONSET_PATH}/icon_512x512@2x.png"
         COMMAND iconutil -c icns "${ICONSET_PATH}" -o "${ICNS_PATH}"
         DEPENDS "${ICON_SOURCE}"
         COMMENT "Generating AetherSDR.icns"


### PR DESCRIPTION
## Summary
- Update the macOS build-time iconset generation so icon_512x512@2x.png is emitted at 1024x1024 pixels.
- Keep the change narrowly scoped to the existing AetherSDR.icns custom command in CMakeLists.txt.

## Bug
The macOS icon generation rule created AetherSDR.iconset/icon_512x512@2x.png with sips -z 768 768. In an Apple .iconset, the 512x512@2x asset represents a 512 point Retina icon and must be 1024x1024 pixels. Because the generated file size did not match the filename convention, iconutil could reject the generated AetherSDR.iconset when producing AetherSDR.icns.

## Fix
Changed only the icon_512x512@2x.png sips invocation from 768x768 to 1024x1024, matching iconutil's expected dimensions for that iconset slot.

## Verification
- cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
- cmake --build build --target AetherSDR.icns
- sips -g pixelWidth -g pixelHeight build/AetherSDR.iconset/icon_512x512@2x.png

The icon target completed successfully, iconutil produced build/AetherSDR.icns, and the generated icon_512x512@2x.png reports pixelWidth 1024 and pixelHeight 1024. The app was not run.