### PR TITLE
Add frameless support for popout dialogs

### DIFF
--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -165,11 +165,15 @@ void AetherDspDialog::setFramelessMode(bool on)
     Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
-    setGeometry(geom);
-    if (m_titleBar)
+    if (wasVisible) {
+        setGeometry(geom);
+    }
+    if (m_titleBar) {
         m_titleBar->setVisible(on);
-    if (wasVisible)
+    }
+    if (wasVisible) {
         show();
+    }
 }
 
 void AetherDspDialog::syncFromEngine()

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2544,15 +2544,20 @@ void DxClusterDialog::setFramelessMode(bool on)
     Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
-    setGeometry(geom);
+    if (wasVisible) {
+        setGeometry(geom);
+    }
 
-    if (m_titleBar)
+    if (m_titleBar) {
         m_titleBar->setVisible(on);
-    if (m_outerLayout)
+    }
+    if (m_outerLayout) {
         m_outerLayout->setContentsMargins(0, 0, 0, 0);
+    }
 
-    if (wasVisible)
+    if (wasVisible) {
         show();
+    }
 }
 
 void DxClusterDialog::setTotalSpots(int count)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4464,7 +4464,9 @@ void setDialogFramelessMode(QDialog* dialog, bool on)
     Qt::WindowFlags flags = (dialog->windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     dialog->setWindowFlags(flags);
-    dialog->setGeometry(geom);
+    if (wasVisible) {
+        dialog->setGeometry(geom);
+    }
 
     if (auto* titleBar = dialog->findChild<QWidget*>("editorFramelessTitleBar")) {
         titleBar->setVisible(on);
@@ -6045,6 +6047,7 @@ void MainWindow::buildMenuBar()
         auto* dlg = new MidiMappingDialog(m_midiControl, this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         m_midiDialog = dlg;
+        dlg->setFramelessMode(framelessWindowEnabled());
         dlg->show();
     });
 #endif
@@ -6201,14 +6204,33 @@ void MainWindow::buildMenuBar()
             statusBar()->showMessage("Not connected to radio", 3000);
             return;
         }
+        if (m_txBandDialog) {
+            m_txBandDialog->raise();
+            m_txBandDialog->activateWindow();
+            return;
+        }
         auto* dlg = new QDialog(this);
         dlg->setWindowTitle(QString("TX Band Settings (Current TX Profile: %1)")
             .arg(m_radioModel.transmitModel().activeProfile()));
         dlg->setMinimumSize(700, 450);
         dlg->setStyleSheet("QDialog { background: #0f0f1a; }");
         dlg->setAttribute(Qt::WA_DeleteOnClose);
+        m_txBandDialog = dlg;
 
-        auto* vb = new QVBoxLayout(dlg);
+        auto* outer = new QVBoxLayout(dlg);
+        outer->setContentsMargins(0, 0, 0, 0);
+        outer->setSpacing(0);
+
+        auto* titleBar = new FramelessWindowTitleBar(dlg->windowTitle(), dlg);
+        titleBar->setObjectName(QStringLiteral("framelessWindowTitleBar"));
+        outer->addWidget(titleBar);
+
+        auto* bodyWidget = new QWidget(dlg);
+        auto* vb = new QVBoxLayout(bodyWidget);
+        vb->setContentsMargins(9, 9, 9, 9);
+        vb->setSpacing(9);
+        outer->addWidget(bodyWidget, 1);
+
         auto* gridContainer = new QWidget;
         gridContainer->setStyleSheet("background: #506070;");
         auto* headerGrid = new QGridLayout(gridContainer);
@@ -6308,6 +6330,8 @@ void MainWindow::buildMenuBar()
 
         vb->addWidget(gridContainer);
         vb->addStretch();
+        FramelessResizer::install(dlg);
+        setDialogFramelessMode(dlg, framelessWindowEnabled());
         dlg->show();
     });
 
@@ -11054,6 +11078,14 @@ void MainWindow::setFramelessWindow(bool on)
         dlg->setFramelessMode(on);
     if (auto* dlg = qobject_cast<MemoryDialog*>(m_memoryDialog))
         dlg->setFramelessMode(on);
+#ifdef HAVE_MIDI
+    if (auto* dlg = qobject_cast<MidiMappingDialog*>(m_midiDialog)) {
+        dlg->setFramelessMode(on);
+    }
+#endif
+    if (m_txBandDialog) {
+        setDialogFramelessMode(m_txBandDialog, on);
+    }
     if (m_reconnectDlg && m_reconnectDlg->findChild<QWidget*>("framelessWindowTitleBar")) {
         setDialogFramelessMode(m_reconnectDlg, on);
     }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -434,6 +434,7 @@ private:
     QPointer<QDialog> m_radioSetupDialog;
     QPointer<QDialog> m_networkDiagnosticsDialog;
     QPointer<QDialog> m_propDashboardDialog;
+    QPointer<QDialog> m_txBandDialog;
     QPointer<QDialog> m_memoryDialog;
     QPointer<WhatsNewDialog> m_whatsNewDialog;
     QPointer<QDialog> m_dspDialog;

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -402,15 +402,20 @@ void MemoryDialog::setFramelessMode(bool on)
     Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
-    setGeometry(geom);
+    if (wasVisible) {
+        setGeometry(geom);
+    }
 
-    if (m_titleBar)
+    if (m_titleBar) {
         m_titleBar->setVisible(on);
-    if (m_outerLayout)
+    }
+    if (m_outerLayout) {
         m_outerLayout->setContentsMargins(0, 0, 0, 0);
+    }
 
-    if (wasVisible)
+    if (wasVisible) {
         show();
+    }
 }
 
 void MemoryDialog::closeEvent(QCloseEvent* event)

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -1,6 +1,9 @@
 #ifdef HAVE_MIDI
 
 #include "MidiMappingDialog.h"
+#include "FramelessResizer.h"
+#include "FramelessWindowTitleBar.h"
+#include "core/AppSettings.h"
 #include "core/MidiControlManager.h"
 #include "core/MidiSettings.h"
 
@@ -13,6 +16,7 @@
 #include <QLineEdit>
 #include <QInputDialog>
 #include <QMessageBox>
+#include <QRect>
 
 namespace AetherSDR {
 
@@ -41,8 +45,19 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
     setMinimumSize(700, 550);
     setStyleSheet("QDialog { background: #0f0f1a; }");
 
-    auto* root = new QVBoxLayout(this);
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("MIDI Controller Mapping"), this);
+    outer->addWidget(m_titleBar);
+
+    auto* bodyWidget = new QWidget(this);
+    auto* root = new QVBoxLayout(bodyWidget);
+    root->setContentsMargins(9, 9, 9, 9);
     root->setSpacing(8);
+    m_bodyLayout = root;
+    outer->addWidget(bodyWidget, 1);
 
     // ── Device section ──────────────────────────────────────────────────
     {
@@ -264,6 +279,33 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
 
     if (m_manager->isOpen()) {
         m_connectBtn->setText("Disconnect");
+    }
+
+    FramelessResizer::install(this);
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+}
+
+void MidiMappingDialog::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
+    flags.setFlag(Qt::FramelessWindowHint, on);
+    setWindowFlags(flags);
+    if (wasVisible) {
+        setGeometry(geom);
+    }
+
+    if (m_titleBar) {
+        m_titleBar->setVisible(on);
+    }
+    if (m_bodyLayout) {
+        m_bodyLayout->setContentsMargins(9, on ? 7 : 9, 9, 9);
+    }
+    if (wasVisible) {
+        show();
     }
 }
 

--- a/src/gui/MidiMappingDialog.h
+++ b/src/gui/MidiMappingDialog.h
@@ -8,6 +8,8 @@
 #include <QLabel>
 #include <QPushButton>
 
+class QVBoxLayout;
+
 namespace AetherSDR {
 
 class MidiControlManager;
@@ -21,6 +23,7 @@ class MidiMappingDialog : public QDialog {
 
 public:
     explicit MidiMappingDialog(MidiControlManager* manager, QWidget* parent = nullptr);
+    void setFramelessMode(bool on);
 
 private:
     void refreshPortList();
@@ -37,6 +40,8 @@ private:
     QComboBox*    m_paramCombo;
     QComboBox*    m_categoryCombo;
     QComboBox*    m_profileCombo;
+    QWidget*      m_titleBar{nullptr};
+    QVBoxLayout*  m_bodyLayout{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/MultiFlexDialog.cpp
+++ b/src/gui/MultiFlexDialog.cpp
@@ -1,10 +1,14 @@
 #include "MultiFlexDialog.h"
+#include "FramelessResizer.h"
+#include "FramelessWindowTitleBar.h"
+#include "core/AppSettings.h"
 #include "models/RadioModel.h"
 
 #include <QBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
 #include <QPushButton>
+#include <QRect>
 #include <QTableWidget>
 
 namespace AetherSDR {
@@ -29,8 +33,19 @@ MultiFlexDialog::MultiFlexDialog(RadioModel* model, QWidget* parent)
     resize(600, 320);
     setStyleSheet(kDialogStyle);
 
-    auto* root = new QVBoxLayout(this);
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("multiFLEX Dashboard"), this);
+    outer->addWidget(m_titleBar);
+
+    auto* bodyWidget = new QWidget(this);
+    auto* root = new QVBoxLayout(bodyWidget);
+    root->setContentsMargins(9, 9, 9, 9);
     root->setSpacing(10);
+    m_bodyLayout = root;
+    outer->addWidget(bodyWidget, 1);
 
     // Title
     auto* title = new QLabel("multiFLEX Stations");
@@ -91,6 +106,33 @@ MultiFlexDialog::MultiFlexDialog(RadioModel* model, QWidget* parent)
     connect(m_table, &QTableWidget::itemSelectionChanged, this, [this]() { refresh(); });
 
     refresh();
+
+    FramelessResizer::install(this);
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+}
+
+void MultiFlexDialog::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
+    flags.setFlag(Qt::FramelessWindowHint, on);
+    setWindowFlags(flags);
+    if (wasVisible) {
+        setGeometry(geom);
+    }
+
+    if (m_titleBar) {
+        m_titleBar->setVisible(on);
+    }
+    if (m_bodyLayout) {
+        m_bodyLayout->setContentsMargins(9, on ? 7 : 9, 9, 9);
+    }
+    if (wasVisible) {
+        show();
+    }
 }
 
 void MultiFlexDialog::refresh()

--- a/src/gui/MultiFlexDialog.h
+++ b/src/gui/MultiFlexDialog.h
@@ -2,6 +2,7 @@
 
 #include <QDialog>
 
+class QVBoxLayout;
 class QTableWidget;
 class QPushButton;
 class QLabel;
@@ -14,6 +15,7 @@ class MultiFlexDialog : public QDialog {
     Q_OBJECT
 public:
     explicit MultiFlexDialog(RadioModel* model, QWidget* parent = nullptr);
+    void setFramelessMode(bool on);
 
 private:
     void refresh();
@@ -23,6 +25,8 @@ private:
     QPushButton* m_enableBtn;
     QLabel* m_pttLabel;
     QPushButton* m_pttBtn;
+    QWidget* m_titleBar{nullptr};
+    QVBoxLayout* m_bodyLayout{nullptr};
     bool m_refreshing{false};
 };
 

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1045,7 +1045,9 @@ void NetworkDiagnosticsDialog::setFramelessMode(bool on)
     Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
-    setGeometry(geom);
+    if (wasVisible) {
+        setGeometry(geom);
+    }
     if (m_titleBar) {
         m_titleBar->setVisible(on);
     }

--- a/src/gui/PanLayoutDialog.cpp
+++ b/src/gui/PanLayoutDialog.cpp
@@ -1,4 +1,7 @@
 #include "PanLayoutDialog.h"
+#include "FramelessResizer.h"
+#include "FramelessWindowTitleBar.h"
+#include "core/AppSettings.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -6,6 +9,8 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QPainter>
+#include <QRect>
+#include <QSize>
 
 namespace AetherSDR {
 
@@ -111,13 +116,27 @@ PanLayoutDialog::PanLayoutDialog(int maxPans, const QString& currentLayout,
     setStyleSheet("QDialog { background: #0f0f1a; }"
                   "QLabel { color: #c8d8e8; }");
     setFixedSize(560, 520);
+    FramelessResizer::install(this);
     buildUI(maxPans, currentLayout);
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
 }
 
 void PanLayoutDialog::buildUI(int maxPans, const QString& currentLayout)
 {
-    auto* vbox = new QVBoxLayout(this);
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("Panadapter Layout"), this);
+    outer->addWidget(m_titleBar);
+
+    auto* bodyWidget = new QWidget(this);
+    auto* vbox = new QVBoxLayout(bodyWidget);
+    vbox->setContentsMargins(9, 9, 9, 9);
     vbox->setSpacing(8);
+    m_bodyLayout = vbox;
+    outer->addWidget(bodyWidget, 1);
 
     auto* title = new QLabel("Choose panadapter layout:");
     title->setStyleSheet("QLabel { color: #8aa8c0; font-size: 13px; font-weight: bold; }");
@@ -179,6 +198,31 @@ void PanLayoutDialog::buildUI(int maxPans, const QString& currentLayout)
         "QPushButton:hover { background: #204060; }");
     connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
     vbox->addWidget(cancelBtn, 0, Qt::AlignCenter);
+}
+
+void PanLayoutDialog::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+    const QSize targetSize(560, on ? 538 : 520);
+
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
+    flags.setFlag(Qt::FramelessWindowHint, on);
+    setWindowFlags(flags);
+    setFixedSize(targetSize);
+    if (wasVisible) {
+        setGeometry(QRect(geom.topLeft(), targetSize));
+    }
+
+    if (m_titleBar) {
+        m_titleBar->setVisible(on);
+    }
+    if (m_bodyLayout) {
+        m_bodyLayout->setContentsMargins(9, on ? 7 : 9, 9, 9);
+    }
+    if (wasVisible) {
+        show();
+    }
 }
 
 } // namespace AetherSDR

--- a/src/gui/PanLayoutDialog.h
+++ b/src/gui/PanLayoutDialog.h
@@ -4,6 +4,9 @@
 #include <QString>
 #include <QVector>
 
+class QVBoxLayout;
+class QWidget;
+
 namespace AetherSDR {
 
 // Layout ID encoding:
@@ -35,10 +38,13 @@ public:
                              QWidget* parent = nullptr);
 
     QString selectedLayout() const { return m_selected; }
+    void setFramelessMode(bool on);
 
 private:
     void buildUI(int maxPans, const QString& currentLayout);
     QString m_selected;
+    QWidget* m_titleBar{nullptr};
+    QVBoxLayout* m_bodyLayout{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/ProfileManagerDialog.cpp
+++ b/src/gui/ProfileManagerDialog.cpp
@@ -1,4 +1,7 @@
 #include "ProfileManagerDialog.h"
+#include "FramelessResizer.h"
+#include "FramelessWindowTitleBar.h"
+#include "core/AppSettings.h"
 #include "models/RadioModel.h"
 #include "models/TransmitModel.h"
 
@@ -11,6 +14,7 @@
 #include <QCheckBox>
 #include <QLabel>
 #include <QMessageBox>
+#include <QRect>
 
 namespace AetherSDR {
 
@@ -41,7 +45,19 @@ ProfileManagerDialog::ProfileManagerDialog(RadioModel* model, QWidget* parent)
     setMinimumSize(460, 400);
     setStyleSheet(kDialogStyle);
 
-    auto* root = new QVBoxLayout(this);
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("Profile Manager"), this);
+    outer->addWidget(m_titleBar);
+
+    auto* bodyWidget = new QWidget(this);
+    auto* root = new QVBoxLayout(bodyWidget);
+    root->setContentsMargins(9, 9, 9, 9);
+    root->setSpacing(9);
+    m_bodyLayout = root;
+    outer->addWidget(bodyWidget, 1);
 
     m_tabs = new QTabWidget;
 
@@ -76,6 +92,10 @@ ProfileManagerDialog::ProfileManagerDialog(RadioModel* model, QWidget* parent)
     closeRow->addWidget(closeBtn);
     root->addLayout(closeRow);
 
+    FramelessResizer::install(this);
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+
     // Listen for profile list updates
     connect(model, &RadioModel::globalProfilesChanged, this, [this] {
         refreshTab("global");
@@ -86,6 +106,29 @@ ProfileManagerDialog::ProfileManagerDialog(RadioModel* model, QWidget* parent)
     connect(&model->transmitModel(), &TransmitModel::micProfileListChanged, this, [this] {
         refreshTab("mic");
     });
+}
+
+void ProfileManagerDialog::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
+    flags.setFlag(Qt::FramelessWindowHint, on);
+    setWindowFlags(flags);
+    if (wasVisible) {
+        setGeometry(geom);
+    }
+
+    if (m_titleBar) {
+        m_titleBar->setVisible(on);
+    }
+    if (m_bodyLayout) {
+        m_bodyLayout->setContentsMargins(9, on ? 7 : 9, 9, 9);
+    }
+    if (wasVisible) {
+        show();
+    }
 }
 
 QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,

--- a/src/gui/ProfileManagerDialog.h
+++ b/src/gui/ProfileManagerDialog.h
@@ -3,6 +3,7 @@
 #include <QDialog>
 #include <QMap>
 
+class QVBoxLayout;
 class QTabWidget;
 class QLineEdit;
 class QListWidget;
@@ -18,6 +19,7 @@ class ProfileManagerDialog : public QDialog {
 
 public:
     explicit ProfileManagerDialog(RadioModel* model, QWidget* parent = nullptr);
+    void setFramelessMode(bool on);
 
 private:
     QWidget* buildProfileTab(const QString& type, const QStringList& profiles,
@@ -27,6 +29,8 @@ private:
 
     RadioModel* m_model;
     QTabWidget* m_tabs;
+    QWidget* m_titleBar{nullptr};
+    QVBoxLayout* m_bodyLayout{nullptr};
 
     // Per-tab widgets (indexed by type: "global", "transmit", "mic")
     struct TabWidgets {


### PR DESCRIPTION
## Summary
- Add frameless-window support to Panadapter Layout, MIDI Controller Mapping, multiFLEX Dashboard, TX Band Settings, and Profile Manager.
- Reuse the existing shared frameless title bar and resizer helpers so these popouts follow the global Frameless Window setting.
- Keep TX Band Settings modeless and raise the existing window instead of creating duplicates.

## Bug
Some dialogs that already supported frameless mode restored their geometry while still hidden during construction. On Qt/macOS this can preserve the pre-show default position, causing dialogs to open in the top-left corner instead of letting Qt place them normally.

## Fix
- Only restore geometry after toggling Qt::FramelessWindowHint when the dialog was already visible.
- Preserve geometry for runtime Frameless Window toggles, but let first-open dialogs use normal Qt placement.
- Apply that placement fix to Network Diagnostics, AetherDSP Settings, Memory Channels, SpotHub, and the newly updated popouts.

## Verification
- cmake --build build