### PR TITLE
[ux] Add PC Audio device selection tooltip

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -325,6 +325,7 @@ AudioEngine::AudioEngine(QObject* parent)
                 m_outputDevice = QAudioDevice{};
             }
         }
+        emit outputDeviceChanged();
         if (!m_audioSink) return;
         qCWarning(lcAudio) << "AudioEngine: audio output device list changed, restarting RX (#1361)";
         QMetaObject::invokeMethod(this, [this]() {
@@ -332,6 +333,16 @@ AudioEngine::AudioEngine(QObject* parent)
             stopRxStream();
             startRxStream();
         }, Qt::QueuedConnection);
+    });
+    connect(m_mediaDevices, &QMediaDevices::audioInputsChanged, this, [this]() {
+        if (!m_inputDevice.isNull()) {
+            const auto inputs = QMediaDevices::audioInputs();
+            if (!devicePresent(inputs, m_inputDevice)) {
+                qCWarning(lcAudio) << "AudioEngine: selected input device is no longer available, falling back to the system default";
+                m_inputDevice = QAudioDevice{};
+            }
+        }
+        emit inputDeviceChanged();
     });
 #endif
 
@@ -3952,6 +3963,8 @@ void AudioEngine::setOutputDevice(const QAudioDevice& dev)
         stopRxStream();
         startRxStream();
     }
+
+    emit outputDeviceChanged();
 }
 
 void AudioEngine::setInputDevice(const QAudioDevice& dev)
@@ -3971,6 +3984,8 @@ void AudioEngine::setInputDevice(const QAudioDevice& dev)
         stopTxStream();
         startTxStream(addr, port);
     }
+
+    emit inputDeviceChanged();
 }
 
 #ifdef Q_OS_MAC

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -463,6 +463,8 @@ signals:
     void rxPostChainScopeReady(const QByteArray& monoFloat32Pcm, int sampleRate);
     void radioTransmittingChanged(bool tx);
     void mutedChanged(bool muted);                          // local audio output mute state
+    void inputDeviceChanged();
+    void outputDeviceChanged();
     void txBypassChanged(bool on);                          // master TX BYPASS state
     void rxBypassChanged(bool on);                          // master RX BYPASS state
     // Fired by saveClientReverbSettings() after any reverb param

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -159,6 +159,7 @@
 #include <QProgressBar>
 #include <QThread>
 #include <QToolTip>
+#include <QMediaDevices>
 #include "core/AppSettings.h"
 #include "core/SpotCommandPolicy.h"
 #include "core/SpotModeResolver.h"
@@ -5888,6 +5889,32 @@ void MainWindow::setPaTempDisplayUnit(bool useFahrenheit)
 // ─── Audio thread helpers (#502) ─────────────────────────────────────────────
 // These invoke AudioEngine methods on the audio worker thread.
 
+void MainWindow::updatePcAudioTooltip()
+{
+    if (!m_titleBar || !m_audio)
+        return;
+
+    auto describeDevice = [](const QAudioDevice& selected,
+                             const QAudioDevice& defaultDevice) {
+        const bool usingDefault = selected.isNull();
+        const QAudioDevice device = usingDefault ? defaultDevice : selected;
+        const QString name = device.description().trimmed();
+
+        if (device.isNull() || name.isEmpty())
+            return MainWindow::tr("Unavailable");
+
+        return usingDefault
+            ? MainWindow::tr("%1 (system default)").arg(name)
+            : name;
+    };
+
+    const QAudioDevice inputDevice = m_audio->inputDevice();
+    const QAudioDevice outputDevice = m_audio->outputDevice();
+    m_titleBar->setPcAudioDevices(
+        describeDevice(inputDevice, QMediaDevices::defaultAudioInput()),
+        describeDevice(outputDevice, QMediaDevices::defaultAudioOutput()));
+}
+
 void MainWindow::audioStartRx()
 {
     QMetaObject::invokeMethod(m_audio, &AudioEngine::startRxStream);
@@ -7024,6 +7051,11 @@ void MainWindow::buildUI()
     m_titleBar = new TitleBar(this);
     // Embed the menu bar into the title bar (left side)
     m_titleBar->setMenuBar(menuBar());
+    updatePcAudioTooltip();
+    connect(m_audio, &AudioEngine::inputDeviceChanged,
+            this, &MainWindow::updatePcAudioTooltip, Qt::QueuedConnection);
+    connect(m_audio, &AudioEngine::outputDeviceChanged,
+            this, &MainWindow::updatePcAudioTooltip, Qt::QueuedConnection);
     connect(m_titleBar, &TitleBar::multiFlexClicked, this, [this] {
         MultiFlexDialog dlg(&m_radioModel, this);
         dlg.exec();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -146,6 +146,7 @@ private:
     void audioStopRx();
     void audioStartTx(const QHostAddress& addr, quint16 port);
     void audioStopTx();
+    void updatePcAudioTooltip();
     SliceModel* activeSlice() const;
     static const char* tuneIntentName(TuneIntent intent);
     bool panFollowEnabled() const;

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -221,7 +221,8 @@ TitleBar::TitleBar(QWidget* parent)
     bool pcOn = s.value("PcAudioEnabled", "True").toString() == "True";
     m_pcBtn->setChecked(pcOn);
     m_pcBtn->setAccessibleName("PC Audio");
-    m_pcBtn->setAccessibleDescription("Toggle PC audio input for microphone");
+    m_pcBtn->setAccessibleDescription("Toggle PC audio receive playback");
+    updatePcAudioToolTip();
 
     auto updatePcStyle = [this]() {
         m_pcBtn->setStyleSheet(m_pcBtn->isChecked()
@@ -705,6 +706,33 @@ void TitleBar::setPcAudioEnabled(bool on)
         : "QPushButton { background: #1a2a3a; color: #607080; border: 1px solid #304050; "
           "border-radius: 3px; font-size: 10px; font-weight: bold; }"
           "QPushButton:hover { background: #243848; }");
+}
+
+void TitleBar::setPcAudioDevices(const QString& inputDevice, const QString& outputDevice)
+{
+    m_pcAudioInputDevice = inputDevice.trimmed();
+    m_pcAudioOutputDevice = outputDevice.trimmed();
+    updatePcAudioToolTip();
+}
+
+void TitleBar::updatePcAudioToolTip()
+{
+    if (!m_pcBtn)
+        return;
+
+    const QString input = m_pcAudioInputDevice.isEmpty()
+        ? tr("Unavailable")
+        : m_pcAudioInputDevice;
+    const QString output = m_pcAudioOutputDevice.isEmpty()
+        ? tr("Unavailable")
+        : m_pcAudioOutputDevice;
+
+    m_pcBtn->setToolTip(
+        tr("Routes radio receive audio through this computer.\n"
+           "PC mic transmit uses the selected input device.\n"
+           "Input: %1\n"
+           "Output: %2")
+            .arg(input, output));
 }
 
 void TitleBar::setLineoutMuted(bool muted)

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QString>
 #include <QWidget>
 
 class QPushButton;
@@ -22,6 +23,7 @@ public:
     void setMenuBar(QMenuBar* mb);
 
     void setPcAudioEnabled(bool on);
+    void setPcAudioDevices(const QString& inputDevice, const QString& outputDevice);
     void setLineoutMuted(bool muted);
     void setMasterVolume(int pct);
     void setHeadphoneVolume(int pct);
@@ -72,6 +74,7 @@ private:
     bool finishWindowMove(QMouseEvent* ev);
     void handleTitleDoubleClick(QMouseEvent* ev);
     void showFeatureRequestDialogImpl();
+    void updatePcAudioToolTip();
     QHBoxLayout* m_hbox{nullptr};
     QMenuBar*    m_menuBar{nullptr};
     QLabel*      m_appNameLabel{nullptr};
@@ -108,6 +111,8 @@ private:
     bool         m_alarmRed{false};
     bool         m_blinkEnabled{true};  // persisted via AppSettings "HeartbeatBlinkEnabled"
     bool         m_discovering{false};  // solid amber while waiting for connection
+    QString      m_pcAudioInputDevice;
+    QString      m_pcAudioOutputDevice;
 
 protected:
     // Drag-to-move + double-click-to-maximize for frameless main window.


### PR DESCRIPTION

<img width="1292" height="586" alt="Untitled" src="https://github.com/user-attachments/assets/1d263522-77f1-4c44-a788-76c5a3c68625" />

## Summary

- Adds a multiline PC Audio button tooltip that explains the local receive playback path and PC mic input usage.
- Shows the current PC Audio input and output devices, marking each as the system default when no explicit selection is saved.
- Wires `AudioEngine` device-change notifications into the title bar so the tooltip refreshes after Radio Setup changes and device fallback events.

## Why

The PC Audio button previously exposed only the toggle state. Operators had to open Radio Setup to confirm which computer input/output devices AetherSDR was using, which made quick audio routing checks slower than they needed to be.

## Testing

- `cmake --build build -j 8`
- `ctest --test-dir build -j 8 --output-on-failure`

## Built App

- `/private/tmp/AetherSDR-pc-audio-tooltip-devices/build/AetherSDR.app`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
