### PR TITLE
feat: make Profile Manager non-modal and persist geometry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,15 @@ audio payload, meter data — see `docs/vita49-format.md`.
 
 ## Key Implementation Patterns
 
+### Adding or converting a dialog
+
+See **[`docs/dialog-patterns.md`](docs/dialog-patterns.md)** before writing
+or modifying a `QDialog`. It documents the canonical
+lazy-construct + non-modal + geometry-persist + frameless-chrome pattern,
+the common pitfalls that have hit real PRs, and the existing dialogs to
+use as reference. Tracked for cleanup in #2605 (`PersistentDialog` base
+class).
+
 ### Settings Persistence (AppSettings — NOT QSettings)
 
 **IMPORTANT:** Do NOT use `QSettings` anywhere in AetherSDR. All client-side

--- a/docs/dialog-patterns.md
+++ b/docs/dialog-patterns.md
@@ -1,0 +1,255 @@
+# AetherSDR Dialog Patterns
+
+When you add a new dialog to AetherSDR — or convert an existing modal one to
+non-modal — there's a canonical pattern that the project's existing dialogs
+follow. This doc captures it in one place so contributors (human or agent)
+don't have to reverse-engineer it from 8+ existing dialogs.
+
+Long-term, the [`PersistentDialog` base class issue (#2605)](https://github.com/ten9876/AetherSDR/issues/2605)
+will collapse this boilerplate into a parent class with `bodyWidget()`. Until
+then, every new dialog needs to wire these pieces by hand.
+
+## The four concerns every persistent dialog handles
+
+A persistent dialog in AetherSDR is **non-modal**, **lazy-constructed**,
+**geometry-persistent**, and **frameless-chrome-aware**. Skip any of the four
+and the dialog will misbehave in a predictable way.
+
+| Concern | Why | Symptom if skipped |
+|---|---|---|
+| Non-modal + lazy-construct | Operator should keep the dialog open while interacting with the radio | Modal dialog blocks tuning |
+| `WA_DeleteOnClose` + `QPointer` slot | Dialog instance ownership; survive close + re-open without leaks | Stack-allocated dialog leaks on each open; or stale pointer crash |
+| Geometry persistence (base64) | Restore last-known position on next launch | Dialog opens at default OS position every time |
+| Frameless chrome integration | Respect the global `FramelessWindow` setting | Double-title-bar visual (native + custom), or wrong chrome on toggle |
+
+## The canonical pattern
+
+### 1. Header — derive from `QDialog`, declare the slot fields
+
+```cpp
+class FooDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit FooDialog(...args..., QWidget* parent = nullptr);
+    void setFramelessMode(bool on);
+
+protected:
+    void closeEvent(QCloseEvent* event) override;
+    void moveEvent(QMoveEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
+
+private:
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
+
+    // ... actual dialog state members ...
+
+    QWidget*     m_titleBar{nullptr};
+    QVBoxLayout* m_bodyLayout{nullptr};
+    bool         m_restoringGeometry{false};
+};
+```
+
+Forward-declare `class QCloseEvent;`, `class QMoveEvent;`, `class QResizeEvent;`,
+`class QVBoxLayout;` in the header rather than `#include`ing the Qt headers.
+Include the events in the `.cpp` where they're used.
+
+### 2. Constructor — embed the frameless title bar, restore geometry
+
+```cpp
+FooDialog::FooDialog(...args..., QWidget* parent)
+    : QDialog(parent), ...
+{
+    setWindowTitle("Foo");
+    setMinimumSize(WIDTH, HEIGHT);
+    setStyleSheet(kDialogStyle);
+
+    // Outer layout wraps the frameless title bar + body widget.  Body
+    // widget contains the actual dialog content.
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("Foo"), this);
+    outer->addWidget(m_titleBar);
+
+    auto* bodyWidget = new QWidget(this);
+    auto* root = new QVBoxLayout(bodyWidget);
+    root->setContentsMargins(9, 9, 9, 9);
+    root->setSpacing(9);
+    m_bodyLayout = root;
+    outer->addWidget(bodyWidget, 1);
+
+    // ... build dialog content inside `root` ...
+
+    // Frameless chrome support — must be wired up before first show()
+    FramelessResizer::install(this);
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+
+    // Restore geometry from last session (after content built so initial
+    // size is sensible for first-launch users).
+    restoreGeometryFromSettings();
+}
+```
+
+### 3. `setFramelessMode` — toggle the frameless chrome
+
+This is the same shape for every dialog, only the title and key change:
+
+```cpp
+void FooDialog::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
+    flags.setFlag(Qt::FramelessWindowHint, on);
+    setWindowFlags(flags);
+    // Restore geometry ONLY when the dialog was already visible (runtime
+    // toggle).  On first open (wasVisible=false), let Qt place normally.
+    if (wasVisible) setGeometry(geom);
+
+    if (m_titleBar) m_titleBar->setVisible(on);
+    if (m_bodyLayout) m_bodyLayout->setContentsMargins(9, on ? 7 : 9, 9, 9);
+    if (wasVisible) show();
+}
+```
+
+The `if (wasVisible) setGeometry(geom)` guard is critical on macOS — without
+it, first-open dialogs land at the top-left corner because the geometry
+captured during construction is the pre-show default position. See PR #2580.
+
+### 4. Geometry persistence — base64 + move/resize/close
+
+`AppSettings` serializes via XML, so binary `QByteArray` values from
+`saveGeometry()` need base64 encoding to round-trip. The project's existing
+`MainWindowGeometry` / `MainWindowState` use this same pattern.
+
+```cpp
+void FooDialog::saveGeometryToSettings()
+{
+    auto& s = AppSettings::instance();
+    s.setValue("FooDialogGeometry", saveGeometry().toBase64());
+}
+
+void FooDialog::restoreGeometryFromSettings()
+{
+    const QString geomB64 = AppSettings::instance()
+        .value("FooDialogGeometry").toString();
+    if (geomB64.isEmpty()) return;
+    m_restoringGeometry = true;
+    restoreGeometry(QByteArray::fromBase64(geomB64.toLatin1()));
+    m_restoringGeometry = false;
+}
+
+void FooDialog::closeEvent(QCloseEvent* event)
+{
+    saveGeometryToSettings();
+    AppSettings::instance().save();   // flush to disk on close
+    QDialog::closeEvent(event);
+}
+
+void FooDialog::moveEvent(QMoveEvent* event)
+{
+    QDialog::moveEvent(event);
+    if (!m_restoringGeometry) saveGeometryToSettings();
+}
+
+void FooDialog::resizeEvent(QResizeEvent* event)
+{
+    QDialog::resizeEvent(event);
+    if (!m_restoringGeometry) saveGeometryToSettings();
+}
+```
+
+Two details worth understanding:
+
+- **`m_restoringGeometry` guard.** `restoreGeometry()` triggers move/resize
+  events as Qt repositions the window. Without the guard, those events would
+  immediately call `saveGeometryToSettings()` and overwrite the freshly-loaded
+  value with the dialog's current (default) position.
+- **Save on move/resize is in-memory only; close-time save flushes to disk.**
+  `AppSettings::setValue` updates the in-memory store; `save()` writes the
+  XML file. The move/resize saves keep the in-memory store current so a
+  crash or force-quit preserves the last-known position. The close-time
+  `save()` is the canonical persistence point.
+
+### 5. MainWindow wiring — lazy-construct + raise on re-invoke
+
+In `MainWindow.cpp::buildMenuBar()`:
+
+```cpp
+auto* action = menu->addAction("Foo...");
+connect(action, &QAction::triggered, this, [this] {
+    if (!m_fooDialog) {
+        auto* dlg = new FooDialog(...args..., this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        dlg->setFramelessMode(framelessWindowEnabled());
+        m_fooDialog = dlg;
+    }
+    m_fooDialog->show();
+    m_fooDialog->raise();
+    m_fooDialog->activateWindow();
+});
+```
+
+In `MainWindow.h`:
+
+```cpp
+class FooDialog;   // forward-declare in namespace AetherSDR
+...
+QPointer<FooDialog> m_fooDialog;
+```
+
+The `QPointer` slot auto-nulls when `WA_DeleteOnClose` destroys the dialog.
+Next menu click sees `m_fooDialog == nullptr` and constructs a fresh one
+(which then restores geometry from AppSettings).
+
+### 6. Runtime frameless toggle propagation
+
+In `MainWindow.cpp::setFramelessWindow(bool on)`:
+
+```cpp
+if (m_fooDialog)
+    m_fooDialog->setFramelessMode(on);
+```
+
+This propagates the View → Use Frameless Windows toggle to already-open
+instances of the dialog. There's currently one line per dialog in
+`setFramelessWindow()` — the `PersistentDialog` refactor in #2605 will
+replace these with a single `QSet<QPointer<PersistentDialog>>` walk.
+
+## Existing dialogs that follow this pattern (look at these for reference)
+
+- `src/gui/NetworkDiagnosticsDialog.{h,cpp}` — most complete reference, has all the patterns
+- `src/gui/MemoryDialog.{h,cpp}`
+- `src/gui/AetherDspDialog.{h,cpp}`
+- `src/gui/DxClusterDialog.{h,cpp}` (SpotHub)
+- `src/gui/MultiFlexDialog.{h,cpp}`
+- `src/gui/MidiMappingDialog.{h,cpp}`
+- `src/gui/PanLayoutDialog.{h,cpp}`
+- `src/gui/ProfileManagerDialog.{h,cpp}` — most recent example; has the move/resize event saving
+
+## Common pitfalls
+
+These are the issues that have hit real PRs in the project's history.
+Listing them so they don't bite the next contributor.
+
+| Pitfall | Wrong | Right | Surfaced in |
+|---|---|---|---|
+| AppSettings is a reference, not a pointer | `AppSettings::instance()->value(...)` | `AppSettings::instance().value(...)` | #2591 |
+| AppSettings serializes XML, binary needs base64 | `setValue("Geom", saveGeometry())` | `setValue("Geom", saveGeometry().toBase64())` | #2591 |
+| Include path uses `core/` prefix | `#include "AppSettings.h"` | `#include "core/AppSettings.h"` | #2591 |
+| Restore at construction triggers move/resize | Save unconditionally on every move/resize | Guard with `m_restoringGeometry` | #2592 |
+| First-open `setGeometry(geom)` on macOS captures pre-show position | `setGeometry(geom)` unconditionally | `if (wasVisible) setGeometry(geom)` | #2580 |
+| QDialog::show() is non-modal by default | `setModal(false)` + `setWindowModality(Qt::NonModal)` (both redundant) | omit both | #2592 |
+| Frameless chrome must be set up before first show | Skip `setFramelessMode(framelessWindowEnabled())` on construct | Call it in the ctor after `FramelessResizer::install(this)` | #2591, #2592 |
+| Runtime toggle needs explicit propagation | Forget to wire into `MainWindow::setFramelessWindow()` | Add `if (m_fooDialog) m_fooDialog->setFramelessMode(on);` | #2591 |
+| Include heavy Qt event headers in `.h` | `#include <QCloseEvent>` in the header | Forward-declare in `.h`, include in `.cpp` | #2591 |
+
+## See also
+
+- `CLAUDE.md` — project-wide AI agent guidelines including settings persistence
+- `docs/architecture-pipelines.md` — broader project architecture overview
+- Issue #2605 — `PersistentDialog` base class proposal that will eliminate this boilerplate

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6579,9 +6579,16 @@ void MainWindow::buildMenuBar()
     // ── Profiles menu ──────────────────────────────────────────────────────
     m_profilesMenu = menuBar()->addMenu("&Profiles");
     auto* profileMgrAct = m_profilesMenu->addAction("Profile Manager...");
-    connect(profileMgrAct, &QAction::triggered, this, [this] {
-        ProfileManagerDialog dlg(&m_radioModel, this);
-        dlg.exec();
+        connect(profileMgrAct, &QAction::triggered, this, [this] {
+        if (!m_profileManagerDialog) {
+            auto* dlg = new ProfileManagerDialog(&m_radioModel, this);
+            dlg->setAttribute(Qt::WA_DeleteOnClose);
+            dlg->setModal(false);
+            m_profileManagerDialog = dlg;
+        }
+        m_profileManagerDialog->show();
+        m_profileManagerDialog->raise();
+        m_profileManagerDialog->activateWindow();
     });
     auto* profileImportExportAct = m_profilesMenu->addAction("Import/Export Profiles...");
     connect(profileImportExportAct, &QAction::triggered, this, [this] {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -437,6 +437,7 @@ private:
     QPointer<QDialog> m_memoryDialog;
     QPointer<WhatsNewDialog> m_whatsNewDialog;
     QPointer<QDialog> m_dspDialog;
+    QPointer<ProfileManagerDialog> m_profileManagerDialog;
 #ifdef HAVE_MIDI
     QPointer<QDialog> m_midiDialog;
 #endif

--- a/src/gui/ProfileManagerDialog.cpp
+++ b/src/gui/ProfileManagerDialog.cpp
@@ -6,6 +6,8 @@
 #include "models/TransmitModel.h"
 
 #include <QCloseEvent>
+#include <QMoveEvent>
+#include <QResizeEvent>
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -107,13 +109,7 @@ ProfileManagerDialog::ProfileManagerDialog(RadioModel* model, QWidget* parent)
     connect(&model->transmitModel(), &TransmitModel::micProfileListChanged, this, [this] {
         refreshTab("mic");
     });
-    // Geometry persistence — AppSettings serializes via XML strings, so
-    // window geometry round-trips through base64 to preserve binary data.
-    // Matches the project convention used by MainWindow{Geometry,State}.
-    const QString geomB64 = AppSettings::instance()
-        .value("ProfileManagerDialogGeometry").toString();
-    if (!geomB64.isEmpty())
-        restoreGeometry(QByteArray::fromBase64(geomB64.toLatin1()));
+    restoreGeometryFromSettings();
 }
 
 void ProfileManagerDialog::setFramelessMode(bool on)
@@ -312,12 +308,49 @@ void ProfileManagerDialog::refreshTab(const QString& type)
     }
 }
 
-void ProfileManagerDialog::closeEvent(QCloseEvent* event)
+// Geometry persistence — AppSettings serializes via XML strings, so window
+// geometry round-trips through base64 to preserve binary data.  Matches the
+// project convention used by MainWindow{Geometry,State}.  Save fires on
+// close (guaranteed persistence on clean exit) AND on each move/resize
+// (crash-resilient: if AetherSDR is force-quit, the last known position is
+// already in AppSettings).
+void ProfileManagerDialog::saveGeometryToSettings()
 {
     auto& s = AppSettings::instance();
     s.setValue("ProfileManagerDialogGeometry", saveGeometry().toBase64());
-    s.save();
+}
+
+void ProfileManagerDialog::restoreGeometryFromSettings()
+{
+    const QString geomB64 = AppSettings::instance()
+        .value("ProfileManagerDialogGeometry").toString();
+    if (geomB64.isEmpty()) return;
+    // Restore triggers move/resize events; flag those as restore-driven so
+    // they don't immediately overwrite the value we just loaded.
+    m_restoringGeometry = true;
+    restoreGeometry(QByteArray::fromBase64(geomB64.toLatin1()));
+    m_restoringGeometry = false;
+}
+
+void ProfileManagerDialog::closeEvent(QCloseEvent* event)
+{
+    saveGeometryToSettings();
+    // Flush to disk on close.  Move/resize saves are in-memory only; the
+    // close-time save is the canonical persistence point.
+    AppSettings::instance().save();
     QDialog::closeEvent(event);
+}
+
+void ProfileManagerDialog::moveEvent(QMoveEvent* event)
+{
+    QDialog::moveEvent(event);
+    if (!m_restoringGeometry) saveGeometryToSettings();
+}
+
+void ProfileManagerDialog::resizeEvent(QResizeEvent* event)
+{
+    QDialog::resizeEvent(event);
+    if (!m_restoringGeometry) saveGeometryToSettings();
 }
 
 } // namespace AetherSDR

--- a/src/gui/ProfileManagerDialog.cpp
+++ b/src/gui/ProfileManagerDialog.cpp
@@ -1,7 +1,7 @@
 #include "ProfileManagerDialog.h"
 #include "models/RadioModel.h"
 #include "models/TransmitModel.h"
-
+#include "AppSettings.h"
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -86,6 +86,7 @@ ProfileManagerDialog::ProfileManagerDialog(RadioModel* model, QWidget* parent)
     connect(&model->transmitModel(), &TransmitModel::micProfileListChanged, this, [this] {
         refreshTab("mic");
     });
+    restoreGeometry(AppSettings::instance()->value("ProfileManagerDialogGeometry").toByteArray());
 }
 
 QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,
@@ -259,6 +260,11 @@ void ProfileManagerDialog::refreshTab(const QString& type)
         if (p == active)
             tw.list->setCurrentItem(item);
     }
+}
+
+void ProfileManagerDialog::closeEvent(QCloseEvent *event) {
+    AppSettings::instance()->setValue("ProfileManagerDialogGeometry", saveGeometry());
+    QDialog::closeEvent(event);
 }
 
 } // namespace AetherSDR

--- a/src/gui/ProfileManagerDialog.h
+++ b/src/gui/ProfileManagerDialog.h
@@ -2,7 +2,7 @@
 
 #include <QDialog>
 #include <QMap>
-
+#include <QCloseEvent>
 class QTabWidget;
 class QLineEdit;
 class QListWidget;
@@ -25,6 +25,10 @@ private:
     QWidget* buildAutoSaveTab();
     void refreshTab(const QString& type);
 
+protected:
+    void closeEvent(QCloseEvent *event) override;
+
+private:
     RadioModel* m_model;
     QTabWidget* m_tabs;
 

--- a/src/gui/ProfileManagerDialog.h
+++ b/src/gui/ProfileManagerDialog.h
@@ -4,6 +4,8 @@
 #include <QMap>
 
 class QCloseEvent;
+class QMoveEvent;
+class QResizeEvent;
 class QVBoxLayout;
 class QTabWidget;
 class QLineEdit;
@@ -24,12 +26,16 @@ public:
 
 protected:
     void closeEvent(QCloseEvent* event) override;
+    void moveEvent(QMoveEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
 private:
     QWidget* buildProfileTab(const QString& type, const QStringList& profiles,
                              const QString& active);
     QWidget* buildAutoSaveTab();
     void refreshTab(const QString& type);
+    void saveGeometryToSettings();
+    void restoreGeometryFromSettings();
 
     RadioModel* m_model;
     QTabWidget* m_tabs;
@@ -47,6 +53,11 @@ private:
     QMap<QString, TabWidgets> m_tabWidgets;
 
     QCheckBox* m_autoSaveTx{nullptr};
+
+    // Set during restoreGeometry() so the move/resize callbacks the
+    // restore triggers don't immediately overwrite the just-loaded
+    // value.  Cleared when restore completes.
+    bool m_restoringGeometry{false};
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
Overview:
This PR converts the Profile Manager from a modal dialog to a persistent, non-modal window. This allows users to interact with the radio (tune, adjust settings) while keeping the management tool open.

Changes:

MainWindow: Replaced QDialog::exec() with a non-modal show() pattern. Used QPointer to manage the dialog instance and prevent duplicate windows.

Window Management: Added Qt::WA_DeleteOnClose and setModal(false) to allow independent operation from the main UI.

Geometry Persistence: Implemented saveGeometry and restoreGeometry using AppSettings. The Profile Manager will now remember its last position and size across sessions.

Fixes:
Closes #2574