### PR TITLE
Keep FFT scale aligned during dBm drag

### DIFF
--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -9,6 +9,7 @@
 #include <QStringList>
 #include <QtEndian>
 #include <QSet>
+#include <cmath>
 #include <cstring>
 
 namespace AetherSDR {
@@ -389,6 +390,7 @@ void PanadapterStream::unregisterPanStream(quint32 streamId)
     m_knownPanStreams.remove(streamId);
     m_frames.remove(streamId);
     m_dbmRanges.remove(streamId);
+    m_pendingDbmRanges.remove(streamId);
 }
 
 void PanadapterStream::unregisterWfStream(quint32 streamId)
@@ -406,6 +408,7 @@ void PanadapterStream::clearRegisteredStreams()
     m_frames.clear();
     m_wfFrames.clear();
     m_dbmRanges.clear();
+    m_pendingDbmRanges.clear();
     m_daxStreamIds.clear();
     m_iqStreamIds.clear();
     m_loggedDaxPacketStreams.clear();
@@ -413,9 +416,29 @@ void PanadapterStream::clearRegisteredStreams()
     qCDebug(lcVita49) << "PanadapterStream: cleared all registered streams";
 }
 
-void PanadapterStream::setDbmRange(quint32 streamId, float minDbm, float maxDbm)
+void PanadapterStream::setDbmRange(quint32 streamId, float minDbm, float maxDbm, bool waitForEcho)
 {
     QMutexLocker lock(&m_streamMutex);
+    if (waitForEcho) {
+        m_pendingDbmRanges[streamId] = {minDbm, maxDbm};
+        m_dbmRanges[streamId] = {minDbm, maxDbm};
+        qCDebug(lcVita49) << "PanadapterStream: pending dBm range for 0x" + QString::number(streamId, 16)
+                 << minDbm << "->" << maxDbm;
+        return;
+    } else {
+        const auto pendingIt = m_pendingDbmRanges.constFind(streamId);
+        if (pendingIt != m_pendingDbmRanges.constEnd()) {
+            const bool matchesPending = std::abs(minDbm - pendingIt->first) < 0.01f
+                && std::abs(maxDbm - pendingIt->second) < 0.01f;
+            if (!matchesPending) {
+                qCDebug(lcVita49) << "PanadapterStream: ignored stale dBm range for 0x"
+                         + QString::number(streamId, 16)
+                         << minDbm << "->" << maxDbm;
+                return;
+            }
+            m_pendingDbmRanges.remove(streamId);
+        }
+    }
     m_dbmRanges[streamId] = {minDbm, maxDbm};
     qCDebug(lcVita49) << "PanadapterStream: dBm range for 0x" + QString::number(streamId, 16)
              << minDbm << "->" << maxDbm;

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -67,7 +67,7 @@ public:
     bool    isRunning() const;
 
     // Update the dBm range used to scale incoming FFT bins for a specific stream.
-    void setDbmRange(quint32 streamId, float minDbm, float maxDbm);
+    void setDbmRange(quint32 streamId, float minDbm, float maxDbm, bool waitForEcho = false);
     // Update the ypixels used to scale FFT bin values for a specific stream.
     // The radio encodes FFT bins as pixel Y positions (0 = top/max_dbm,
     // ypixels-1 = bottom/min_dbm), NOT as 0-65535 uint16 range.
@@ -199,6 +199,7 @@ private:
     QUdpSocket*     m_socket{nullptr};
     quint16         m_localPort{0};
     QMap<quint32, QPair<float,float>> m_dbmRanges;  // streamId → (min, max)
+    QMap<quint32, QPair<float,float>> m_pendingDbmRanges;  // streamId → pending echoed range
     QMap<quint32, int> m_yPixels;  // streamId → ypixels for FFT bin scaling
     RadioConnection* m_conn{nullptr};
     QMap<quint32, FrameAssembler> m_frames;  // per-stream FFT frame assembly

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2388,7 +2388,12 @@ MainWindow::MainWindow(QWidget* parent)
                 connect(pan, &PanadapterModel::infoChanged,
                         sw, &SpectrumWidget::setFrequencyRange);
                 connect(pan, &PanadapterModel::levelChanged,
-                        sw, &SpectrumWidget::setDbmRange);
+                        sw, [sw](float minDbm, float maxDbm) {
+                    if (sw->isDraggingDbmScale()) {
+                        return;
+                    }
+                    sw->setDbmRange(minDbm, maxDbm);
+                });
                 connect(pan, &PanadapterModel::wideChanged,
                         sw, &SpectrumWidget::setWideActive);
                 sw->setWideActive(pan->wideActive());
@@ -9625,6 +9630,31 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     auto* sw = applet->spectrumWidget();
     auto* menu = sw->overlayMenu();
 
+    struct PendingDbmRange {
+        bool active{false};
+        float minDbm{0.0f};
+        float maxDbm{0.0f};
+    };
+    auto pendingDbm = std::make_shared<PendingDbmRange>();
+    auto dbmMatches = [](float leftMin, float leftMax, float rightMin, float rightMax) {
+        return std::abs(leftMin - rightMin) < 0.01f
+            && std::abs(leftMax - rightMax) < 0.01f;
+    };
+    auto setStreamDbmRange = [this, applet](float minDbm, float maxDbm, bool waitForEcho = false) {
+        if (auto* pan = m_radioModel.panadapter(applet->panId())) {
+            if (pan->panStreamId()) {
+                m_radioModel.panStream()->setDbmRange(pan->panStreamId(), minDbm, maxDbm, waitForEcho);
+            }
+        }
+    };
+    auto sendDbmRangeCommand = [this, applet](float minDbm, float maxDbm) {
+        m_radioModel.sendCommand(
+            QString("display pan set %1 min_dbm=%2 max_dbm=%3")
+                .arg(applet->panId())
+                .arg(static_cast<double>(minDbm), 0, 'f', 2)
+                .arg(static_cast<double>(maxDbm), 0, 'f', 2));
+    };
+
     // Guard: wirePanadapter() is called once at startup (for m_panApplet) and
     // again from panadapterAdded for the same widget.  Without these disconnects
     // every sw/menu/applet → this signal would be connected twice, causing each
@@ -9678,7 +9708,19 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         //   b) in multi-pan setups, a level update on pan B doesn't incorrectly
         //      update pan A's dBm scale.
         connect(pan, &PanadapterModel::levelChanged,
-                sw, &SpectrumWidget::setDbmRange);
+                sw, [sw, pendingDbm, dbmMatches, setStreamDbmRange](float minDbm, float maxDbm) {
+            if (pendingDbm->active) {
+                if (!dbmMatches(minDbm, maxDbm, pendingDbm->minDbm, pendingDbm->maxDbm)) {
+                    setStreamDbmRange(pendingDbm->minDbm, pendingDbm->maxDbm, true);
+                    return;
+                }
+                pendingDbm->active = false;
+            }
+            if (sw->isDraggingDbmScale()) {
+                return;
+            }
+            sw->setDbmRange(minDbm, maxDbm);
+        });
 
         auto oldFpsConnection = m_panFpsReconcileConnections.take(applet->panId());
         if (oldFpsConnection)
@@ -9789,13 +9831,22 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             this, [this](int lo, int hi) {
         if (auto* s = activeSlice()) s->setFilterWidth(lo, hi);
     });
+
     connect(sw, &SpectrumWidget::dbmRangeChangeRequested,
-            this, [this, applet](float minDbm, float maxDbm) {
-        m_radioModel.sendCommand(
-            QString("display pan set %1 min_dbm=%2 max_dbm=%3")
-                .arg(applet->panId())
-                .arg(static_cast<double>(minDbm), 0, 'f', 2)
-                .arg(static_cast<double>(maxDbm), 0, 'f', 2));
+            this, [pendingDbm, setStreamDbmRange, sendDbmRangeCommand](float minDbm, float maxDbm) {
+        pendingDbm->active = true;
+        pendingDbm->minDbm = minDbm;
+        pendingDbm->maxDbm = maxDbm;
+        setStreamDbmRange(minDbm, maxDbm, true);
+        sendDbmRangeCommand(minDbm, maxDbm);
+    });
+    connect(sw, &SpectrumWidget::dbmRangeDragFinished,
+            this, [pendingDbm, setStreamDbmRange, sendDbmRangeCommand](float minDbm, float maxDbm) {
+        pendingDbm->active = true;
+        pendingDbm->minDbm = minDbm;
+        pendingDbm->maxDbm = maxDbm;
+        setStreamDbmRange(minDbm, maxDbm, true);
+        sendDbmRangeCommand(minDbm, maxDbm);
     });
 
     // ── TNF signals ──────────────────────────────────────────────────────

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -56,6 +56,7 @@ QSoundEffect* SpectrumWidget::s_starstruckSound = nullptr;
 static const QColor kAetherBrandBlue(0x00, 0xb4, 0xd8);
 static const QColor kAetherBrandGreen(0x20, 0xc0, 0x60);
 static const QColor kConnectionTextColor(0xd8, 0xe6, 0xf0);
+static constexpr float kMinDisplayDbm = -180.0f;
 
 static bool spotMarkersVisuallyEqual(const QVector<SpectrumWidget::SpotMarker>& lhs,
                                      const QVector<SpectrumWidget::SpotMarker>& rhs)
@@ -1411,11 +1412,22 @@ void SpectrumWidget::setSpectrumFrac(float f)
 
 void SpectrumWidget::setDbmRange(float minDbm, float maxDbm)
 {
+    if (m_pendingDbmRangeEcho) {
+        const bool matchesPending = std::abs(minDbm - m_pendingMinDbm) < 0.01f
+            && std::abs(maxDbm - m_pendingMaxDbm) < 0.01f;
+        if (!matchesPending) {
+            return;
+        }
+        m_pendingDbmRangeEcho = false;
+    }
+
+    const float clampedMinDbm = std::max(minDbm, kMinDisplayDbm);
     float ref = maxDbm;
-    float dyn = maxDbm - minDbm;
+    float dyn = std::max(10.0f, maxDbm - clampedMinDbm);
     if (ref == m_refLevel && dyn == m_dynamicRange) return;
     m_refLevel     = ref;
     m_dynamicRange = dyn;
+    m_resetFftSmoothingOnNextFrame = true;
     markOverlayDirty();
 }
 
@@ -1550,16 +1562,42 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
             PerfTelemetry::instance().recordPanFrame();
     }
 
-    // Forward to GPU renderer (#502)
-
-
-    if (m_smoothed.size() != binsDbm.size())
-        m_smoothed = binsDbm;
-    else {
-        for (int i = 0; i < binsDbm.size(); ++i)
-            m_smoothed[i] = SMOOTH_ALPHA * binsDbm[i] + (1.0f - SMOOTH_ALPHA) * m_smoothed[i];
+    QVector<float> adjustedBins;
+    const QVector<float>* spectrumBins = &binsDbm;
+    if (m_holdFftUpdatesAfterDbmRelease > 0 && m_dbmReleasePreviewOffset != 0.0f) {
+        --m_holdFftUpdatesAfterDbmRelease;
+        if (!m_bins.isEmpty() && m_bins.size() == binsDbm.size()) {
+            QVector<float> deltas;
+            const int step = qMax(1, binsDbm.size() / 256);
+            deltas.reserve((binsDbm.size() + step - 1) / step);
+            for (int i = 0; i < binsDbm.size(); i += step) {
+                deltas.append(binsDbm[i] - m_bins[i]);
+            }
+            std::sort(deltas.begin(), deltas.end());
+            const float frameOffset = deltas[deltas.size() / 2];
+            const float tolerance = qMax(1.5f, std::abs(m_dbmReleasePreviewOffset) * 0.35f);
+            if (std::abs(frameOffset - m_dbmReleasePreviewOffset) <= tolerance) {
+                adjustedBins = binsDbm;
+                for (float& bin : adjustedBins) {
+                    bin -= m_dbmReleasePreviewOffset;
+                }
+                spectrumBins = &adjustedBins;
+            }
+        }
+    } else if (m_holdFftUpdatesAfterDbmRelease > 0) {
+        --m_holdFftUpdatesAfterDbmRelease;
     }
-    m_bins = binsDbm;
+
+    if (m_resetFftSmoothingOnNextFrame) {
+        m_smoothed = *spectrumBins;
+        m_resetFftSmoothingOnNextFrame = false;
+    } else if (m_smoothed.size() != spectrumBins->size()) {
+        m_smoothed = *spectrumBins;
+    } else {
+        for (int i = 0; i < spectrumBins->size(); ++i)
+            m_smoothed[i] = SMOOTH_ALPHA * (*spectrumBins)[i] + (1.0f - SMOOTH_ALPHA) * m_smoothed[i];
+    }
+    m_bins = *spectrumBins;
 
     // ── Live noise floor measurement (two-pass trimmed mean) ─────────────
     // Same technique as the waterfall auto-black: compute the mean of ALL bins,
@@ -1568,18 +1606,18 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
     // leaving only the "consistently low, close-in-value" noise bins — exactly
     // the flat green line a human eye reads as the noise floor on the scope.
     // This is robust even on a very crowded band (40-50% bins occupied).
-    if (!binsDbm.isEmpty()) {
+    if (!spectrumBins->isEmpty()) {
         // Pass 1 — overall mean (sampled every 4th bin for speed)
         float sum = 0.0f;
         int   cnt = 0;
-        for (int j = 0; j < binsDbm.size(); j += 4) { sum += binsDbm[j]; ++cnt; }
+        for (int j = 0; j < spectrumBins->size(); j += 4) { sum += (*spectrumBins)[j]; ++cnt; }
         const float mean = sum / cnt;
 
         // Pass 2 — average only noise bins (≤ mean), which excludes signal peaks
         float noiseSum = 0.0f;
         int   noiseCnt = 0;
-        for (int j = 0; j < binsDbm.size(); j += 4) {
-            if (binsDbm[j] <= mean) { noiseSum += binsDbm[j]; ++noiseCnt; }
+        for (int j = 0; j < spectrumBins->size(); j += 4) {
+            if ((*spectrumBins)[j] <= mean) { noiseSum += (*spectrumBins)[j]; ++noiseCnt; }
         }
         const float frameFloor = (noiseCnt > 0) ? noiseSum / noiseCnt : mean;
 
@@ -1611,7 +1649,8 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
             if (frac > 0.05f && frac < 0.95f) {
                 float newRange = (m_refLevel - noiseFloor) / frac;
                 newRange = std::clamp(newRange, 20.0f, 150.0f);
-                float newMin = m_refLevel - newRange;
+                float newMin = std::max(m_refLevel - newRange, kMinDisplayDbm);
+                newRange = m_refLevel - newMin;
                 // Only adjust if change is significant (> 1 dB)
                 float currentMin = m_refLevel - m_dynamicRange;
                 if (std::abs(newMin - currentMin) > 1.0f) {
@@ -1636,7 +1675,7 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
         // keeps scrolling regardless).
         bool freeze = !m_showTxInWaterfall && m_hasTxSlice;
         if (!freeze && !m_waterfall.isNull())
-            pushWaterfallRow(binsDbm, m_waterfall.width());
+            pushWaterfallRow(*spectrumBins, m_waterfall.width());
     } else {
         // Suppress post-TX transient noise rows (#2117).  The receiver AGC
         // needs ~400 ms to settle after TX→RX; discard waterfall data during
@@ -1658,7 +1697,7 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
                 }
             }
             if (!m_hasNativeWaterfall && !m_waterfall.isNull())
-                pushWaterfallRow(binsDbm, m_waterfall.width());
+                pushWaterfallRow(*spectrumBins, m_waterfall.width());
         }
     }
 
@@ -2090,7 +2129,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         if (mx >= stripX) {
             // Arrow row (side by side: left = up, right = down)
             if (y < DBM_ARROW_H) {
-                const float bottom = m_refLevel - m_dynamicRange;
+                const float bottom = std::max(m_refLevel - m_dynamicRange, kMinDisplayDbm);
                 if (mx < stripX + DBM_STRIP_W / 2) {
                     // Up arrow: raise ref level by 10 dB, keep bottom fixed
                     m_refLevel += 10.0f;
@@ -2497,8 +2536,8 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         // Convert pixel drag to dB: full FFT height = full dynamic range
         const float deltaDb = (static_cast<float>(dy) / specH) * m_dynamicRange;
         m_refLevel = m_dbmDragStartRef + deltaDb;
+        m_refLevel = std::max(m_refLevel, kMinDisplayDbm + m_dynamicRange);
         markOverlayDirty();
-        emit dbmRangeChangeRequested(m_refLevel - m_dynamicRange, m_refLevel);
         ev->accept();
         return;
     }
@@ -2775,8 +2814,15 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
         return;
     }
     if (m_draggingDbm) {
+        m_pendingDbmRangeEcho = true;
+        m_pendingMinDbm = m_refLevel - m_dynamicRange;
+        m_pendingMaxDbm = m_refLevel;
+        m_dbmReleasePreviewOffset = m_refLevel - m_dbmDragStartRef;
+        m_holdFftUpdatesAfterDbmRelease = 10;
         m_draggingDbm = false;
         setSpectrumCursor(Qt::CrossCursor);
+        m_resetFftSmoothingOnNextFrame = true;
+        emit dbmRangeDragFinished(m_pendingMinDbm, m_pendingMaxDbm);
         ev->accept();
         return;
     }

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -116,6 +116,7 @@ public:
     float spectrumFrac()  const { return m_spectrumFrac; }
     float refLevel()      const { return m_refLevel; }
     float dynamicRange()  const { return m_dynamicRange; }
+    bool isDraggingDbmScale() const { return m_draggingDbm; }
     double centerMhz()    const { return m_centerMhz; }
     double bandwidthMhz() const { return m_bandwidthMhz; }
 
@@ -392,6 +393,7 @@ signals:
     void filterChangeRequested(int lowHz, int highHz);
     // Emitted when the user adjusts the dBm scale (drag or arrows).
     void dbmRangeChangeRequested(float minDbm, float maxDbm);
+    void dbmRangeDragFinished(float minDbm, float maxDbm);
     // TNF signals
     void tnfCreateRequested(double freqMhz);
     void tnfMoveRequested(int id, double newFreqMhz);
@@ -516,6 +518,12 @@ private:
 
     float m_refLevel{-50.0f};       // top of display (dBm)
     float m_dynamicRange{100.0f};   // dB range shown in spectrum (-50 to -150)
+    bool  m_resetFftSmoothingOnNextFrame{false};
+    bool  m_pendingDbmRangeEcho{false};
+    int   m_holdFftUpdatesAfterDbmRelease{0};
+    float m_dbmReleasePreviewOffset{0.0f};
+    float m_pendingMinDbm{0.0f};
+    float m_pendingMaxDbm{0.0f};
 
     // Two-pass trimmed-mean noise floor (dBm), EMA-smoothed across ~20 frames.
     // -1000 = cold start (not yet measured).

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3923,6 +3923,8 @@ void RadioModel::handlePanadapterStatus(const QString& panId, const QMap<QString
     // Delegate to the specific PanadapterModel, not just the active one
     auto* pan = m_panadapters.value(panId, nullptr);
     if (!pan) pan = activePanadapter();  // fallback
+    const float previousMinDbm = pan ? pan->minDbm() : 0.0f;
+    const float previousMaxDbm = pan ? pan->maxDbm() : 0.0f;
     if (pan) {
         pan->applyPanStatus(kvs);
     }
@@ -3932,10 +3934,14 @@ void RadioModel::handlePanadapterStatus(const QString& panId, const QMap<QString
         if (pan) emit panadapterInfoChanged(pan->centerMhz(), pan->bandwidthMhz());
     }
     if (kvs.contains("min_dbm") || kvs.contains("max_dbm")) {
-        const float minDbm = kvs.value("min_dbm", "-130").toFloat();
-        const float maxDbm = kvs.value("max_dbm", "-20").toFloat();
+        const float minDbm = pan ? pan->minDbm() : kvs.value("min_dbm", "-130").toFloat();
+        const float maxDbm = pan ? pan->maxDbm() : kvs.value("max_dbm", "-20").toFloat();
         if (pan) {
-            m_panStream->setDbmRange(pan->panStreamId(), minDbm, maxDbm);
+            const bool levelChanged = (pan->minDbm() != previousMinDbm)
+                || (pan->maxDbm() != previousMaxDbm);
+            if (levelChanged) {
+                m_panStream->setDbmRange(pan->panStreamId(), minDbm, maxDbm);
+            }
         }
         emit panadapterLevelChanged(minDbm, maxDbm);
     }


### PR DESCRIPTION
## Summary

This updates the spectrum dBm-scale drag path so the on-screen scale, FFT line rendering, and FFT stream dBm conversion stay coordinated while the user drags the right-side dBm scale. It also clamps the lower display limit to `-180 dBm`, matching the floor observed in SmartSDR-style behavior.

## Bug

Dragging the right-side dBm scale updated the widget's displayed dBm range immediately, but FFT frames were still decoded through the panadapter stream's previous dBm range until the radio echoed the new `min_dbm`/`max_dbm` values. That created visible mismatch between the right-side scale and the FFT line. Fast drags and mouse release made the race more obvious: stale radio echoes or FFT frames could briefly render with an old range, causing the line to jump or overshoot.

## Fix

- Keep dBm drag movement local while the mouse is down so fast dragging does not spam `display pan set` commands.
- Send the final `min_dbm`/`max_dbm` command only when the drag finishes.
- Update `PanadapterStream` with pending dBm ranges and ignore stale nonmatching echo-backs while waiting for the requested final range.
- Route per-pan `levelChanged` updates through guarded lambdas so stale or cross-pan updates do not overwrite an in-flight user drag.
- Reset FFT smoothing when the dBm range changes so range transitions do not blend old and new display mappings.
- Add a bounded post-release render correction for FFT frames that are still shifted by the drag delta.
- Clamp the lower dBm display limit to `-180 dBm` for direct range changes, drag, arrow adjustment, and noise-floor auto-adjust.

## Testing

- `cmake --build build`

