### PR TITLE
fix(tci): spec/impl compliance + RF2K-S amplifier interop

### DIFF
--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -91,7 +91,14 @@ QString TciProtocol::generateInitBurst()
     int trxCount = slices.size();
     if (trxCount < 1) trxCount = 1;
     burst += QStringLiteral("trx_count:%1;").arg(trxCount);
-    burst += QStringLiteral("channel_count:1;");
+    // `channels_count` (plural).  The TCI Protocol PDF spec lists this
+    // as `CHANNEL_COUNT` (singular), but the reference implementation
+    // (ars-ka0s/eesdr-tci on PyPI, used as the basis for many TCI
+    // clients including the RF2K-S amplifier firmware) only recognises
+    // the plural form — a singular-form command raises ValueError on
+    // the client and aborts handshake parsing.  Implementation wins
+    // over the PDF.
+    burst += QStringLiteral("channels_count:1;");
 
     // Identify as SunSDR2DX so strict TCI clients (notably RF2K-S amps)
     // that whitelist Expert Electronics device names accept the server.

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -135,6 +135,16 @@ QString TciProtocol::generateInitBurst()
             burst += QStringLiteral("xit_offset:%1,%2;")
                          .arg(trx).arg(static_cast<int>(s->xitFreq()));
 
+            // Split — explicitly false so single-VFO operation is signalled.
+            // The RF2K-S TCI client uses `split_enable:0,false;` as the
+            // signal that VFO 0 is the active VFO; without ever receiving
+            // it, its `currentPosition` stays None and get_frequency()
+            // returns None, causing the amp to fall back to UNIV and show
+            // "No TCI available" regardless of how many `vfo:` events it
+            // receives.  (Source: rf-kit-gui_v198/operational_interface/
+            // tciSupport.py, SplitThreadSafeValue.get() + extract_current_vfo.)
+            burst += QStringLiteral("split_enable:%1,false;").arg(trx);
+
             // Lock
             burst += QStringLiteral("lock:%1,%2;")
                          .arg(trx).arg(s->isLocked() ? "true" : "false");

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -79,25 +79,32 @@ SliceModel* TciProtocol::sliceForTrx(int trx) const
 QString TciProtocol::generateInitBurst()
 {
     QString burst;
-    burst += QStringLiteral("protocol:ExpertSDR3,1.5;");
-    burst += QStringLiteral("device:%1;").arg(
-        m_model ? m_model->name() + " " + m_model->model()
-                : QStringLiteral("AetherSDR"));
-    burst += QStringLiteral("receive_only:false;");
 
-    // Count TRXs based on owned slices and expose them as contiguous TCI
-    // receivers (0..N-1). Flex slice ids may start at 1 when another client
-    // owns slice 0, but TCI clients use indexes within the advertised count.
+    // ── Phase 1: Initialization commands (spec section 4.1) ───────────
+    // Sent in spec order, terminated by READY.  Strict clients (notably
+    // RF2K-S amps) treat anything before READY that isn't one of the 9
+    // listed init commands as malformed and refuse to engage.
+    burst += QStringLiteral("vfo_limits:1000,75000000;");
+    burst += QStringLiteral("if_limits:-48000,48000;");
+
     const auto slices = m_model ? m_model->slices() : QList<SliceModel*>{};
     int trxCount = slices.size();
     if (trxCount < 1) trxCount = 1;
     burst += QStringLiteral("trx_count:%1;").arg(trxCount);
-    burst += QStringLiteral("channels_count:1;");
+    burst += QStringLiteral("channel_count:1;");
 
-    // Modulations list
+    // Identify as SunSDR2DX so strict TCI clients (notably RF2K-S amps)
+    // that whitelist Expert Electronics device names accept the server.
+    burst += QStringLiteral("device:SunSDR2DX;");
+    burst += QStringLiteral("receive_only:false;");
     burst += QStringLiteral("modulations_list:usb,lsb,cw,cwr,am,sam,fm,nfm,digu,digl,rtty;");
+    burst += QStringLiteral("protocol:ExpertSDR2,1.9;");
+    burst += QStringLiteral("ready;");
 
-    // Per-slice state
+    // ── Phase 2: Current state notifications ──────────────────────────
+    // After READY these are plain event notifications, indistinguishable
+    // from the events fired by a live tuning operation.  All current TCI
+    // clients (WSJT-X, JTDX, aether_pad) should process them identically.
     if (m_model) {
         for (auto* s : slices) {
             int trx = tciTrxForSlice(m_model, s);
@@ -167,10 +174,12 @@ QString TciProtocol::generateInitBurst()
         burst += QStringLiteral("trx:%1,%2;").arg(txTrx).arg(isTx ? "true" : "false");
     }
 
+    // ── Phase 3: Audio / IQ stream configuration ──────────────────────
+    // After READY and after current state — these are clients-of-audio
+    // concerns (WSJT-X), and irrelevant to control-only clients like
+    // amplifiers.  Sending them post-READY keeps strict amp clients
+    // happy without breaking WSJT-X's TX audio FIFO setup.
     burst += QStringLiteral("audio_samplerate:48000;");
-    // Stream negotiation — required for WSJT-X to initialize its TCI TX
-    // audio FIFO. Without these, readAudioData() returns all zeros.
-    // Matches Thetis TCI server init burst. — confirmed via Thetis source
     burst += QStringLiteral("audio_stream_sample_type:float32;");
     burst += QStringLiteral("audio_stream_channels:2;");
     burst += QStringLiteral("audio_stream_samples:2048;");
@@ -180,7 +189,6 @@ QString TciProtocol::generateInitBurst()
     // audio_start:0 back to request RX audio streaming.
     burst += QStringLiteral("audio_start;");
     burst += QStringLiteral("start;");
-    burst += QStringLiteral("ready;");
 
     return burst;
 }


### PR DESCRIPTION
## Summary

Three commits that bring AetherSDR's TCI server into alignment with the published TCI Protocol spec **and** the reference Python implementation (`ars-ka0s/eesdr-tci`), and unlock RF2K-S amplifier support along the way. All existing clients (WSJT-X, JTDX, TCI Monitor, third-party TCI consumers) continue to work; only the init-burst content and structure changes.

Closes the protocol-side of the work requested in #2589 / #1902 (RF2K-S amplifier integration).

## Commits

### 1. `1220ba7` — spec-compliant init burst

Six issues, all from comparing AetherSDR's emitted burst against TCI Protocol spec v2.0 (Expert Electronics, Jan 2024) §4.1:

- Protocol identity was `ExpertSDR3,1.5;`; strict clients written for the earlier ExpertSDR2 generation reject that string. Changed to `ExpertSDR2,1.9;`.
- Device string used `name + \" \" + model`, producing a leading space when name was empty (typical Flex connection: `device: FLEX-6700;`). Spec disallows surrounding whitespace.
- `FLEX-6700` is not an Expert Electronics product; some strict clients whitelist Expert hardware names. Changed to `device:SunSDR2DX;`.
- `vfo_limits` and `if_limits` were missing entirely — both are spec-mandated init commands.
- `PROTOCOL` was emitted first; spec lists it as the 8th of 9 init commands, immediately followed by `READY`.
- The burst interleaved non-init commands (`vfo:`, `modulation:`, `audio_*`, etc.) into the init phase before `READY`. Strict clients reading sequentially treat that as a malformed handshake.

Restructured into three phases: **init commands → `READY` → current state notifications → audio/IQ config → `START`**.

### 2. `75ea988` — `channels_count` is plural (impl wins over spec PDF)

The PDF spec says `CHANNEL_COUNT` (singular) at §4.1. The reference Python implementation `ars-ka0s/eesdr-tci` only recognises **`CHANNELS_COUNT`** (plural) — singular is rejected by the parser's command-name whitelist. RF2K-S firmware (and likely most other clients) was built against the implementation, not the PDF. Restored the plural spelling.

### 3. `2d6725e` — emit `split_enable` to satisfy RF2K-S frequency gating

The actual blocker for RF2K-S amplifier interop. The RF2K-S TCI client (`rf-kit-gui_v198/operational_interface/tciSupport.py`) stores `vfo:` event frequencies into a `SplitThreadSafeValue`, but only returns a usable frequency from `get_frequency()` once `currentPosition` has been set. `currentPosition` is only set by `set_active_position()`, which is only called when a `split_enable:N,false|true;` event arrives.

Without that event the amp's TCI client receives our frequency, stores it, then refuses to surface it — the RFKIT main controller falls back to UNIV and shows \"No TCI available\" forever. Adding `split_enable:<trx>,false;` to the per-slice notifications flips the gate.

## Test plan

- [x] Build clean on Windows MSVC (`build.bat`, full link)
- [x] WSJT-X TCI connection: still receives full state, TX audio FIFO initialises (no behavioural change)
- [x] JTDX TCI connection: still working
- [x] TCI Monitor (`nigelfenton/tci-monitor`): receives all events, parses correctly
- [x] aether_pad (`nigelfenton/aether-pad`): VFO tracking still works
- [x] **RF2K-S amplifier (firmware G198C267)**: front panel transitions from \"No TCI available\" → active TCI mode; band display and segment frequency follow AetherSDR's VFO across band boundaries; no TX required (previously the amp had to be transmitting for its internal RF pickoff to estimate frequency)

## Discovery notes

The RF2K-S fix took some doing — the amp's TCI client is fully passive (sends nothing back, no logs externally visible) and the front panel's \"No TCI available\" label gives no detail about *what* is unavailable. The answer was eventually found by reading the amp's RPi-hosted Python source via the embedded VNC interface. The `tciSupport.py` decision tree made the missing `split_enable:` event obvious in retrospect, but it took working through the rest of the burst's spec-compliance gaps first to confirm those weren't the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)