### PR TITLE
[mac] Fix macOS Bluetooth headset mic capture rate

### DIFF
--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -275,7 +275,10 @@ flowchart TD
 `AudioEngine::startTxStream()` negotiates PC mic capture as Int16:
 
 - The requested format starts as 24 kHz, stereo, Int16.
-- macOS prefers sample rates in this order: 48 kHz, 44.1 kHz, then 24 kHz.
+- macOS prefers sample rates in this order for general devices: 48 kHz,
+  44.1 kHz, then 24 kHz. For Bluetooth headset inputs that CoreAudio reports
+  as native 8, 16, or 24 kHz-only, AetherSDR opens the mic at that native rate
+  first and then uses its normal radio-native conversion when needed.
 - Linux and other non-Windows platforms prefer 24 kHz, then 48 kHz, then
   44.1 kHz.
 - Stereo is tried before mono for each sample rate.

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -34,6 +34,11 @@
 #endif
 #include "Resampler.h"
 
+#ifdef Q_OS_MAC
+#include <CoreAudio/CoreAudio.h>
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
 #include <cmath>
 #include <limits>
 #include <QIODevice>
@@ -45,6 +50,7 @@
 #include <QThread>
 #include <algorithm>
 #include <cstring>
+#include <optional>
 
 namespace AetherSDR {
 
@@ -73,6 +79,163 @@ bool devicePresent(const QList<QAudioDevice>& devices, const QAudioDevice& targe
         return device.id() == target.id();
     });
 }
+
+#ifdef Q_OS_MAC
+AudioObjectPropertyAddress macAudioAddress(AudioObjectPropertySelector selector,
+                                           AudioObjectPropertyScope scope = kAudioObjectPropertyScopeGlobal)
+{
+    return AudioObjectPropertyAddress{selector, scope, kAudioObjectPropertyElementMain};
+}
+
+template <typename T>
+std::optional<T> readMacAudioScalar(AudioObjectID object,
+                                    AudioObjectPropertySelector selector,
+                                    AudioObjectPropertyScope scope = kAudioObjectPropertyScopeGlobal)
+{
+    AudioObjectPropertyAddress address = macAudioAddress(selector, scope);
+    if (!AudioObjectHasProperty(object, &address)) {
+        return std::nullopt;
+    }
+
+    T value{};
+    UInt32 size = sizeof(value);
+    const OSStatus status = AudioObjectGetPropertyData(object, &address, 0, nullptr, &size, &value);
+    if (status != noErr || size != sizeof(value)) {
+        return std::nullopt;
+    }
+
+    return value;
+}
+
+template <typename T>
+QList<T> readMacAudioArray(AudioObjectID object,
+                           AudioObjectPropertySelector selector,
+                           AudioObjectPropertyScope scope = kAudioObjectPropertyScopeGlobal)
+{
+    AudioObjectPropertyAddress address = macAudioAddress(selector, scope);
+    if (!AudioObjectHasProperty(object, &address)) {
+        return {};
+    }
+
+    UInt32 size = 0;
+    OSStatus status = AudioObjectGetPropertyDataSize(object, &address, 0, nullptr, &size);
+    if (status != noErr || size == 0 || (size % sizeof(T)) != 0) {
+        return {};
+    }
+
+    QList<T> values(size / sizeof(T));
+    status = AudioObjectGetPropertyData(object, &address, 0, nullptr, &size, values.data());
+    if (status != noErr) {
+        return {};
+    }
+
+    values.resize(size / sizeof(T));
+    return values;
+}
+
+std::optional<AudioDeviceID> macAudioDeviceForUid(const QByteArray& uid)
+{
+    if (uid.isEmpty()) {
+        return std::nullopt;
+    }
+
+    CFStringRef uidString = CFStringCreateWithBytes(kCFAllocatorDefault,
+                                                    reinterpret_cast<const UInt8*>(uid.constData()),
+                                                    uid.size(),
+                                                    kCFStringEncodingUTF8,
+                                                    false);
+    if (!uidString) {
+        return std::nullopt;
+    }
+
+    AudioDeviceID deviceId = kAudioObjectUnknown;
+    AudioValueTranslation translation{};
+    translation.mInputData = &uidString;
+    translation.mInputDataSize = sizeof(uidString);
+    translation.mOutputData = &deviceId;
+    translation.mOutputDataSize = sizeof(deviceId);
+
+    AudioObjectPropertyAddress address = macAudioAddress(kAudioHardwarePropertyDeviceForUID);
+    UInt32 size = sizeof(translation);
+    const OSStatus status = AudioObjectGetPropertyData(kAudioObjectSystemObject,
+                                                       &address,
+                                                       0,
+                                                       nullptr,
+                                                       &size,
+                                                       &translation);
+    CFRelease(uidString);
+
+    if (status != noErr || deviceId == kAudioObjectUnknown) {
+        return std::nullopt;
+    }
+
+    return deviceId;
+}
+
+bool isMacBluetoothLowRate(int rate)
+{
+    return rate == 8000 || rate == 16000 || rate == AudioEngine::DEFAULT_SAMPLE_RATE;
+}
+
+std::optional<int> macBluetoothNativeInputRate(const QAudioDevice& qtDevice)
+{
+    const auto deviceId = macAudioDeviceForUid(qtDevice.id());
+    if (!deviceId) {
+        return std::nullopt;
+    }
+
+    const auto transport = readMacAudioScalar<UInt32>(*deviceId, kAudioDevicePropertyTransportType);
+    if (!transport
+        || (*transport != kAudioDeviceTransportTypeBluetooth
+            && *transport != kAudioDeviceTransportTypeBluetoothLE)) {
+        return std::nullopt;
+    }
+
+    bool hasHighRate = false;
+    int exactLowRate = 0;
+    const QList<AudioValueRange> nominalRanges = readMacAudioArray<AudioValueRange>(
+        *deviceId,
+        kAudioDevicePropertyAvailableNominalSampleRates);
+    for (const AudioValueRange& range : nominalRanges) {
+        if ((range.mMinimum <= 44100.0 && range.mMaximum >= 44100.0)
+            || (range.mMinimum <= 48000.0 && range.mMaximum >= 48000.0)) {
+            hasHighRate = true;
+        }
+
+        const int minRate = static_cast<int>(std::lround(range.mMinimum));
+        const int maxRate = static_cast<int>(std::lround(range.mMaximum));
+        if (minRate == maxRate && isMacBluetoothLowRate(minRate)) {
+            exactLowRate = std::max(exactLowRate, minRate);
+        }
+    }
+
+    if (hasHighRate) {
+        return std::nullopt;
+    }
+
+    const auto nominalRate = readMacAudioScalar<Float64>(*deviceId, kAudioDevicePropertyNominalSampleRate);
+    const int roundedNominal = nominalRate ? static_cast<int>(std::lround(*nominalRate)) : 0;
+    if (isMacBluetoothLowRate(roundedNominal)) {
+        return roundedNominal;
+    }
+
+    if (exactLowRate > 0) {
+        return exactLowRate;
+    }
+
+    return std::nullopt;
+}
+
+QList<int> macTxInputRateCandidates(const QAudioDevice& qtDevice)
+{
+    QList<int> rates;
+    if (const auto nativeRate = macBluetoothNativeInputRate(qtDevice)) {
+        rates << *nativeRate;
+    }
+    rates << 48000 << 44100 << AudioEngine::DEFAULT_SAMPLE_RATE;
+    return rates;
+}
+#endif
 }
 
 void AudioEngine::emitScopeFromFloat32Stereo(const QByteArray& pcm,
@@ -3383,13 +3546,14 @@ bool AudioEngine::startTxStream(const QHostAddress& radioAddress, quint16 radioP
         << dev.minimumChannelCount() << "-" << dev.maximumChannelCount() << "ch";
 
     // Negotiate the best sample rate for TX mic input.
-    // macOS: prefer 48kHz — Core Audio claims 24kHz support but its internal
-    // resampler produces gravelly artifacts at non-standard rates. Let r8brain
-    // handle the 48k→24k conversion instead (clean 2:1 integer-ratio downsample).
+    // macOS: prefer 48kHz for general devices, but open Bluetooth headset
+    // inputs at their HAL-native low rate when CoreAudio reports no high-rate
+    // capture mode. That avoids a hidden native->48k conversion before the
+    // app's normal radio-native conversion.
     // Linux/Windows: prefer 24kHz (radio native — no resampling needed).
     bool formatFound = false;
 #ifdef Q_OS_MAC
-    constexpr int rates[] = {48000, 44100, 24000};
+    const QList<int> rates = macTxInputRateCandidates(dev);
 #else
     constexpr int rates[] = {24000, 48000, 44100};
 #endif
@@ -3417,7 +3581,7 @@ bool AudioEngine::startTxStream(const QHostAddress& radioAddress, quint16 radioP
 
     if (!formatFound) {
         qCWarning(lcAudio) << "AudioEngine: input device supports no usable format"
-            << "(tried 24/48/44.1 kHz, stereo and mono)";
+            << "(tried preferred platform rates, stereo and mono)";
         return false;
     }
 
@@ -3432,7 +3596,7 @@ bool AudioEngine::startTxStream(const QHostAddress& radioAddress, quint16 radioP
 
     // Create polyphase resampler for high-quality rate conversion
     if (m_txNeedsResample)
-        m_txResampler = std::make_unique<Resampler>(m_txInputRate, 24000, 16384);
+        m_txResampler = std::make_unique<Resampler>(m_txInputRate, DEFAULT_SAMPLE_RATE, 16384);
     else
         m_txResampler.reset();
 


### PR DESCRIPTION
## Summary

Fixes macOS Bluetooth headset microphone crackling by opening Bluetooth voice-input devices at their CoreAudio HAL-native capture rate when the HAL reports no high-rate input mode.

The final patch is intentionally small:

- Add a macOS-only CoreAudio query that resolves the selected Qt input device UID to a HAL `AudioDeviceID`.
- Detect Bluetooth/Bluetooth LE inputs whose available nominal sample rates are only low voice rates: 8 kHz, 16 kHz, or 24 kHz.
- Put that native low rate first in TX mic negotiation, then fall back to the existing macOS order of 48 kHz, 44.1 kHz, and 24 kHz.
- Keep normal USB/built-in/high-rate devices on the existing 48 kHz-preferred macOS path.
- Document the Bluetooth native-rate behavior in the audio pipeline docs.

Closes #2600. 

## Root Cause

We originally suspected the Aetherial/Pudu recorder playback path because the crackle was easy to hear when playing back DSP recorder captures through Bluetooth headsets. That turned out to be incomplete: after changing recorder playback policy, AirPods Pro still crackled.

The useful signal came from comparing macOS CoreAudio HAL state against the Qt-selected capture format. On failing Bluetooth headset runs, CoreAudio reported the headset microphone as a low-rate Bluetooth voice input, while AetherSDR/Qt opened the device at 48 kHz. That forced a duplicate hidden Bluetooth-native-to-48 kHz conversion before AetherSDR's own 48 kHz-to-24 kHz TX conversion.

The clean runs all avoided that hidden conversion:

- AirPods Pro: HAL exposed only 24 kHz input, and opening at 24 kHz produced clean audio.
- soundcore Life Q20: HAL exposed only 16 kHz input, and opening at 16 kHz then using AetherSDR's 16 kHz-to-24 kHz resampler produced clean audio.
- soundcore Liberty 5: same 16 kHz native path as the Q20, also clean.

So the fix is to trust the HAL-native low-rate Bluetooth capture profile instead of forcing those devices through the general macOS 48 kHz-preferred path.

## Device Findings

| Device | Before | After | Result |
|---|---|---|---|
| AirPods Pro | HAL native 24 kHz, app opened 48 kHz, app resampled 48 -> 24 kHz | App opened 24 kHz, no app resample | Clear |
| soundcore Life Q20 | HAL native 16 kHz, app opened 48 kHz, app resampled 48 -> 24 kHz | App opened 16 kHz, app resampled 16 -> 24 kHz | Clear |
| soundcore Liberty 5 | Not tested before fix | App opened 16 kHz, app resampled 16 -> 24 kHz | Clear |
| Studio Display Microphone | HAL supports high-rate USB input, app opened 48 kHz | Unchanged | Clean control path |
| Wired USB headset | USB path, no Bluetooth voice-profile conversion | Unchanged | Clean per manual report |

## Implementation Notes

- The CoreAudio code is compiled only on macOS.
- It uses `kAudioHardwarePropertyDeviceForUID` to resolve Qt's `QAudioDevice::id()` to the HAL device.
- It checks `kAudioDevicePropertyTransportType`, `kAudioDevicePropertyAvailableNominalSampleRates`, and `kAudioDevicePropertyNominalSampleRate`.
- It only changes rate ordering for Bluetooth/Bluetooth LE devices that do not advertise 44.1 kHz or 48 kHz capture.
- If HAL lookup fails, or if the device advertises high-rate capture, the existing macOS rate order is preserved.

## Validation

- `git diff --check`
- `cmake --build build -j8`
- `./build/tx_mic_channel_normalizer_test`
- Manual macOS Bluetooth headset validation:
  - AirPods Pro clear after opening at native 24 kHz.
  - soundcore Life Q20 clear after opening at native 16 kHz.
  - soundcore Liberty 5 clear after opening at native 16 kHz.

## Risk

Low-to-moderate, isolated to macOS TX mic input format negotiation.

The main behavior change is limited to Bluetooth/Bluetooth LE input devices that HAL reports as low-rate-only voice capture devices. General macOS devices, USB devices, and devices with advertised 44.1/48 kHz capture support continue to follow the existing preference for 48 kHz first.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
