### PR TITLE
[feature] Add local antenna display names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,6 +511,7 @@ endif()
 
 set(MODEL_SOURCES
     src/models/RadioModel.cpp
+    src/models/AntennaAliasStore.cpp
     src/models/SliceModel.cpp
     src/models/PanadapterModel.cpp
     src/models/MeterModel.cpp
@@ -1362,6 +1363,17 @@ add_executable(shortcut_manager_test
 target_include_directories(shortcut_manager_test PRIVATE src)
 target_link_libraries(shortcut_manager_test PRIVATE Qt6::Core Qt6::Widgets)
 add_test(NAME shortcut_manager_test COMMAND shortcut_manager_test)
+
+add_executable(antenna_alias_test
+    tests/antenna_alias_test.cpp
+    src/models/AntennaAliasStore.cpp
+    src/models/SliceModel.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(antenna_alias_test PRIVATE src)
+target_link_libraries(antenna_alias_test PRIVATE Qt6::Core)
+set_target_properties(antenna_alias_test PROPERTIES AUTOMOC ON)
+add_test(NAME antenna_alias_test COMMAND antenna_alias_test)
 
 add_executable(cw_sidetone_test
     tests/cw_sidetone_test.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3190,6 +3190,7 @@ MainWindow::MainWindow(QWidget* parent)
             m_appletPanel->txApplet(), &TxApplet::setTransmitting);
     m_appletPanel->txApplet()->setTransmitModel(&m_radioModel.transmitModel());
     m_appletPanel->txApplet()->setTunerModel(&m_radioModel.tunerModel());
+    m_appletPanel->rxApplet()->setRadioModel(&m_radioModel);
     m_appletPanel->rxApplet()->setTransmitModel(&m_radioModel.transmitModel());
 
     // Hide APD row on radios that don't support it
@@ -10007,6 +10008,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     // Set panId on the overlay menu so +RX routes to the correct pan
     menu->setPanId(applet->panId());
     menu->setMemories(m_radioModel.memories());
+    menu->setRadioModel(&m_radioModel);
 
     // Antenna list → this overlay menu (per-pan, mirrors VfoWidget pattern) (#1260)
     connect(&m_radioModel, &RadioModel::antListChanged,
@@ -11160,6 +11162,7 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     });
 
     // Wire slice data into widget
+    w->setRadioModel(&m_radioModel);
     w->setSlice(s);
     w->setAntennaList(m_radioModel.antennaList());
     w->setTransmitModel(&m_radioModel.transmitModel());

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -51,6 +51,7 @@
 #include <QStackedWidget>
 #include <QPlainTextEdit>
 #include <QSplitter>
+#include <QScrollArea>
 #include <QHostAddress>
 #include <QDebug>
 #include <QPointer>
@@ -210,6 +211,7 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
     addDeferred("TX",          [this] { return buildTxTab(); });
     addDeferred("Phone/CW",   [this] { return buildPhoneCwTab(); });
     addDeferred("RX",          [this] { return buildRxTab(); });
+    addDeferred("Antennas",    [this] { return buildAntennaNamesTab(); });
     addDeferred("Filters",     [this] { return buildFiltersTab(); });
     addDeferred("XVTR",        [this] { return buildXvtrTab(); });
     // External APD tab (#2186) — only present on radios that report
@@ -2521,6 +2523,150 @@ QWidget* RadioSetupDialog::buildXvtrTab()
     xvtrTabs->addTab(addPage, "+");
 
     vbox->addWidget(xvtrTabs);
+    return page;
+}
+
+QWidget* RadioSetupDialog::buildAntennaNamesTab()
+{
+    auto* page = new QWidget;
+    auto* vbox = new QVBoxLayout(page);
+    vbox->setSpacing(8);
+
+    // Model header
+    {
+        auto* hdr = new QHBoxLayout;
+        hdr->addStretch(1);
+        auto* modelLbl = new QLabel(m_model->model());
+        modelLbl->setStyleSheet("QLabel { color: #00c8ff; font-size: 20px; font-weight: bold; }");
+        hdr->addWidget(modelLbl);
+        vbox->addLayout(hdr);
+    }
+
+    auto* group = new QGroupBox("Antenna Names");
+    group->setStyleSheet(kGroupStyle);
+    auto* groupLayout = new QVBoxLayout(group);
+    groupLayout->setSpacing(6);
+
+    auto* rowsWidget = new QWidget;
+    rowsWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
+    auto* grid = new QGridLayout(rowsWidget);
+    grid->setContentsMargins(8, 2, 8, 2);
+    grid->setHorizontalSpacing(8);
+    grid->setVerticalSpacing(4);
+    grid->setAlignment(Qt::AlignTop);
+    grid->setColumnStretch(1, 1);
+    grid->setColumnStretch(2, 1);
+
+    auto* scroll = new QScrollArea;
+    scroll->setWidgetResizable(true);
+    scroll->setFrameShape(QFrame::NoFrame);
+    scroll->setStyleSheet("QScrollArea { background: transparent; border: none; }");
+    scroll->setWidget(rowsWidget);
+    groupLayout->addWidget(scroll);
+    vbox->addWidget(group, 1);
+
+    // Antenna display names are intentionally local to AetherSDR. FlexLib exposes
+    // canonical RX/TX antenna lists and rxant/txant setters, but no verified
+    // writable display-name API; radio commands must keep using ANT1/XVTR/etc.
+    auto refresh = std::make_shared<std::function<void()>>();
+    auto scheduleRefresh = [this, refresh] {
+        QTimer::singleShot(0, this, [refresh] {
+            if (*refresh)
+                (*refresh)();
+        });
+    };
+
+    auto wireSlice = [this, scheduleRefresh](SliceModel* slice) {
+        if (!slice)
+            return;
+        connect(slice, &SliceModel::rxAntennaChanged, this,
+                [scheduleRefresh](const QString&) { scheduleRefresh(); });
+        connect(slice, &SliceModel::txAntennaChanged, this,
+                [scheduleRefresh](const QString&) { scheduleRefresh(); });
+        connect(slice, &SliceModel::rxAntennaListChanged, this,
+                [scheduleRefresh](const QStringList&) { scheduleRefresh(); });
+        connect(slice, &SliceModel::txAntennaListChanged, this,
+                [scheduleRefresh](const QStringList&) { scheduleRefresh(); });
+    };
+
+    *refresh = [this, grid] {
+        while (QLayoutItem* item = grid->takeAt(0)) {
+            if (QWidget* w = item->widget())
+                w->deleteLater();
+            delete item;
+        }
+
+        auto addHeader = [grid](const QString& text, int col) {
+            auto* lbl = new QLabel(text);
+            lbl->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; font-weight: bold; }");
+            grid->addWidget(lbl, 0, col);
+        };
+        addHeader("Port", 0);
+        addHeader("Custom name", 1);
+        addHeader("Preview", 2);
+
+        const QStringList tokens = m_model->knownAntennaTokens();
+        if (tokens.isEmpty()) {
+            auto* empty = new QLabel("Waiting for antenna ports from the radio.");
+            empty->setStyleSheet("QLabel { color: #607080; font-size: 12px; padding: 8px; }");
+            grid->addWidget(empty, 1, 0, 1, 4);
+            return;
+        }
+
+        int row = 1;
+        for (const QString& token : tokens) {
+            auto* port = new QLabel(token);
+            port->setStyleSheet(kValueStyle);
+            grid->addWidget(port, row, 0);
+
+            auto* edit = new QLineEdit(m_model->antennaAlias(token));
+            edit->setMaxLength(16);
+            edit->setStyleSheet(kEditStyle);
+            edit->setPlaceholderText(token);
+            grid->addWidget(edit, row, 1);
+
+            const bool disambiguate =
+                m_model->antennaAliasNeedsDisambiguation(token, tokens);
+            auto* preview = new QLabel(m_model->antennaDisplayName(token, disambiguate));
+            preview->setStyleSheet(kLabelStyle);
+            grid->addWidget(preview, row, 2);
+
+            auto* clearBtn = new QPushButton("Clear");
+            clearBtn->setStyleSheet(
+                "QPushButton { background: #1a2a3a; border: 1px solid #304050; "
+                "border-radius: 3px; color: #c8d8e8; font-size: 11px; "
+                "font-weight: bold; padding: 3px 10px; }"
+                "QPushButton:hover { background: #203040; }");
+            grid->addWidget(clearBtn, row, 3);
+
+            connect(edit, &QLineEdit::textChanged, this,
+                    [preview, token](const QString& text) {
+                const QString alias = text.trimmed();
+                preview->setText(alias.isEmpty() ? token : alias);
+            });
+            connect(edit, &QLineEdit::editingFinished, this, [this, edit, token] {
+                m_model->setAntennaAlias(token, edit->text());
+            });
+            connect(clearBtn, &QPushButton::clicked, this, [this, edit, token] {
+                edit->clear();
+                m_model->clearAntennaAlias(token);
+            });
+            ++row;
+        }
+    };
+
+    for (SliceModel* slice : m_model->slices())
+        wireSlice(slice);
+    connect(m_model, &RadioModel::sliceAdded, this,
+            [wireSlice, scheduleRefresh](SliceModel* slice) {
+        wireSlice(slice);
+        scheduleRefresh();
+    });
+    connect(m_model, &RadioModel::antListChanged, this,
+            [scheduleRefresh](const QStringList&) { scheduleRefresh(); });
+    connect(m_model, &RadioModel::antennaAliasesChanged, this, scheduleRefresh);
+
+    (*refresh)();
     return page;
 }
 

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -56,6 +56,7 @@ private:
     QWidget* buildAudioTab();
     QWidget* buildFiltersTab();
     QWidget* buildXvtrTab();
+    QWidget* buildAntennaNamesTab();
     QWidget* buildApdTab();
     void     refreshApdSamplerCombo(const QString& txAnt);
     QWidget* buildUsbCablesTab();

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -3,6 +3,7 @@
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "SliceColorManager.h"
+#include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
 
@@ -24,6 +25,7 @@
 #include <QFormLayout>
 #include "core/AppSettings.h"
 #include <QAction>
+#include <QFontMetrics>
 #include <QPainter>
 #include <QWheelEvent>
 #include <QKeyEvent>
@@ -136,6 +138,16 @@ static const QString kDisabledBtn =
 static const QString kAmberActive =
     "QPushButton:checked { background-color: #604000; color: #ffb800; "
     "border: 1px solid #906000; }";
+
+static bool likelyTxAntennaFallbackToken(const QString& token)
+{
+    const QString upper = token.toUpper();
+    if (upper.startsWith(QStringLiteral("RX")))
+        return false;
+    return upper.startsWith(QStringLiteral("ANT"))
+        || upper.startsWith(QStringLiteral("TX"))
+        || upper == QStringLiteral("XVTR");
+}
 
 
 // ── Per-mode filter widths and step sizes (from SmartSDR) ─────────────────────
@@ -298,15 +310,21 @@ void RxApplet::buildUI()
         connect(m_rxAntBtn, &QPushButton::clicked, this, [this] {
             QMenu menu(this);
             const QString cur = m_slice ? m_slice->rxAntenna() : "";
-            for (const QString& ant : m_antList) {
-                QAction* act = menu.addAction(ant);
+            const QStringList options = m_slice && !m_slice->rxAntennaList().isEmpty()
+                ? m_slice->rxAntennaList()
+                : m_antList;
+            for (const QString& ant : options) {
+                QAction* act = menu.addAction(antennaMenuLabel(ant, options));
+                act->setData(ant);
                 act->setCheckable(true);
                 act->setChecked(ant == cur);
+                act->setToolTip(ant);
+                act->setStatusTip(ant);
             }
             const QAction* sel = menu.exec(
                 m_rxAntBtn->mapToGlobal(QPoint(0, m_rxAntBtn->height())));
             if (sel && m_slice)
-                m_slice->setRxAntenna(sel->text());
+                m_slice->setRxAntenna(sel->data().toString());
         });
         row->addWidget(m_rxAntBtn);
 
@@ -320,17 +338,19 @@ void RxApplet::buildUI()
         connect(m_txAntBtn, &QPushButton::clicked, this, [this] {
             QMenu menu(this);
             const QString cur = m_slice ? m_slice->txAntenna() : "";
-            for (const QString& ant : m_antList) {
-                if (ant.startsWith("RX", Qt::CaseInsensitive))
-                    continue;  // skip RX-only antenna ports
-                QAction* act = menu.addAction(ant);
+            const QStringList options = txAntennaOptions();
+            for (const QString& ant : options) {
+                QAction* act = menu.addAction(antennaMenuLabel(ant, options));
+                act->setData(ant);
                 act->setCheckable(true);
                 act->setChecked(ant == cur);
+                act->setToolTip(ant);
+                act->setStatusTip(ant);
             }
             const QAction* sel = menu.exec(
                 m_txAntBtn->mapToGlobal(QPoint(0, m_txAntBtn->height())));
             if (sel && m_slice)
-                m_slice->setTxAntenna(sel->text());
+                m_slice->setTxAntenna(sel->data().toString());
         });
         row->addWidget(m_txAntBtn);
 
@@ -1216,11 +1236,20 @@ void RxApplet::setAntennaList(const QStringList& ants)
 {
     if (ants.isEmpty()) return;
     m_antList = ants;
-    // Update button labels if the current antenna is still valid
-    if (m_slice) {
-        m_rxAntBtn->setText(m_slice->rxAntenna());
-        m_txAntBtn->setText(m_slice->txAntenna());
+    updateAntennaButtons();
+}
+
+void RxApplet::setRadioModel(RadioModel* radioModel)
+{
+    if (m_radioModel)
+        disconnect(m_radioModel, &RadioModel::antennaAliasesChanged,
+                   this, &RxApplet::updateAntennaButtons);
+    m_radioModel = radioModel;
+    if (m_radioModel) {
+        connect(m_radioModel, &RadioModel::antennaAliasesChanged,
+                this, &RxApplet::updateAntennaButtons);
     }
+    updateAntennaButtons();
 }
 
 void RxApplet::setTransmitModel(TransmitModel* txModel)
@@ -1238,6 +1267,71 @@ void RxApplet::setTransmitModel(TransmitModel* txModel)
         QSignalBlocker b(m_qskBtn);
         m_qskBtn->setChecked(m_txModel->cwBreakIn());
     });
+}
+
+QString RxApplet::antennaMenuLabel(const QString& token,
+                                   const QStringList& options) const
+{
+    if (!m_radioModel)
+        return token;
+    return m_radioModel->antennaDisplayName(
+        token, m_radioModel->antennaAliasNeedsDisambiguation(token, options));
+}
+
+QStringList RxApplet::txAntennaOptions() const
+{
+    QStringList options;
+    auto append = [&options](const QString& token) {
+        if (!token.isEmpty() && !options.contains(token))
+            options.append(token);
+    };
+
+    if (m_slice && !m_slice->txAntennaList().isEmpty()) {
+        for (const QString& ant : m_slice->txAntennaList())
+            append(ant);
+        append(m_slice->txAntenna());
+        return options;
+    }
+
+    for (const QString& ant : m_antList) {
+        if (likelyTxAntennaFallbackToken(ant))
+            append(ant);
+    }
+    if (m_slice)
+        append(m_slice->txAntenna());
+    return options;
+}
+
+void RxApplet::updateAntennaButton(QPushButton* button, const QString& token, bool tx)
+{
+    if (!button)
+        return;
+
+    const QString shortLabel = m_radioModel
+        ? m_radioModel->antennaShortDisplayName(token, 6)
+        : token;
+    const QFontMetrics fm(button->font());
+    constexpr int kMinWidth = 30;
+    constexpr int kMaxWidth = 58;
+    constexpr int kPad = 8;
+    const QString text = fm.elidedText(shortLabel, Qt::ElideRight, kMaxWidth - kPad);
+    button->setText(text);
+    button->setFixedWidth(qBound(kMinWidth, fm.horizontalAdvance(text) + kPad, kMaxWidth));
+
+    const QString full = m_radioModel
+        ? m_radioModel->antennaDisplayName(token, !m_radioModel->antennaAlias(token).isEmpty())
+        : token;
+    button->setToolTip(QStringLiteral("%1 antenna port: %2")
+                           .arg(tx ? QStringLiteral("Transmit") : QStringLiteral("Receive"),
+                                full));
+}
+
+void RxApplet::updateAntennaButtons()
+{
+    if (!m_slice)
+        return;
+    updateAntennaButton(m_rxAntBtn, m_slice->rxAntenna(), false);
+    updateAntennaButton(m_txAntBtn, m_slice->txAntenna(), true);
 }
 
 void RxApplet::connectSlice(SliceModel* s)
@@ -1266,16 +1360,18 @@ void RxApplet::connectSlice(SliceModel* s)
     });
 
     // RX antenna
-    m_rxAntBtn->setText(s->rxAntenna());
+    updateAntennaButton(m_rxAntBtn, s->rxAntenna(), false);
     connect(s, &SliceModel::rxAntennaChanged, this, [this](const QString& ant) {
-        m_rxAntBtn->setText(ant);
+        updateAntennaButton(m_rxAntBtn, ant, false);
     });
 
     // TX antenna
-    m_txAntBtn->setText(s->txAntenna());
+    updateAntennaButton(m_txAntBtn, s->txAntenna(), true);
     connect(s, &SliceModel::txAntennaChanged, this, [this](const QString& ant) {
-        m_txAntBtn->setText(ant);
+        updateAntennaButton(m_txAntBtn, ant, true);
     });
+    connect(s, &SliceModel::txAntennaListChanged,
+            this, [this](const QStringList&) { updateAntennaButtons(); });
 
     // Filter width label
     m_filterWidthLbl->setText(formatFilterWidth(s->filterLow(), s->filterHigh(), s->mode()));

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -21,6 +21,7 @@ class QToolButton;
 namespace AetherSDR {
 
 class SliceModel;
+class RadioModel;
 
 // RX Applet — controls for a single receive slice.
 //
@@ -54,6 +55,7 @@ public:
 
     // Connect to transmit model for QSK (break_in) indicator.
     void setTransmitModel(class TransmitModel* txModel);
+    void setRadioModel(class RadioModel* radioModel);
 
     // Set the available antenna list (from ant_list in panadapter status).
     void setAntennaList(const QStringList& ants);
@@ -98,6 +100,10 @@ private:
     void buildUI();
     void connectSlice(SliceModel* s);
     void disconnectSlice(SliceModel* s);
+    void updateAntennaButton(QPushButton* button, const QString& token, bool tx);
+    void updateAntennaButtons();
+    QStringList txAntennaOptions() const;
+    QString antennaMenuLabel(const QString& token, const QStringList& options) const;
 
     void applyFilterPreset(int widthHz);
     void updateFilterButtons();
@@ -113,6 +119,7 @@ private:
 
     SliceModel* m_slice{nullptr};
     TransmitModel* m_txModel{nullptr};
+    RadioModel* m_radioModel{nullptr};
     QStringList m_antList{"ANT1", "ANT2"};   // populated from ant_list key
 
     // Step sizes (Hz) — per-mode, swapped on mode change

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -273,9 +273,14 @@ void SpectrumOverlayMenu::buildAntPanel()
     antRow->addWidget(m_rxAntCmb, 1);
     vbox->addLayout(antRow);
 
-    connect(m_rxAntCmb, &QComboBox::currentTextChanged,
-            this, [this](const QString& ant) {
-        if (!m_updatingFromModel && m_slice && !ant.isEmpty())
+    connect(m_rxAntCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, [this](int index) {
+        if (m_updatingFromModel || !m_slice || index < 0)
+            return;
+        QString ant = m_rxAntCmb->itemData(index).toString();
+        if (ant.isEmpty())
+            ant = m_rxAntCmb->itemText(index);
+        if (!ant.isEmpty())
             m_slice->setRxAntenna(ant);
     });
 
@@ -427,12 +432,51 @@ void SpectrumOverlayMenu::buildAntPanel()
 void SpectrumOverlayMenu::setAntennaList(const QStringList& ants)
 {
     m_antList = ants;
+    refreshAntennaCombo();
+}
+
+void SpectrumOverlayMenu::setRadioModel(RadioModel* model)
+{
+    if (m_radioModel)
+        disconnect(m_radioModel, &RadioModel::antennaAliasesChanged,
+                   this, &SpectrumOverlayMenu::refreshAntennaCombo);
+    m_radioModel = model;
+    if (m_radioModel) {
+        connect(m_radioModel, &RadioModel::antennaAliasesChanged,
+                this, &SpectrumOverlayMenu::refreshAntennaCombo);
+    }
+    refreshAntennaCombo();
+}
+
+void SpectrumOverlayMenu::refreshAntennaCombo()
+{
+    if (!m_rxAntCmb)
+        return;
+    const QString cur = m_slice ? m_slice->rxAntenna()
+                                : m_rxAntCmb->currentData().toString();
     QSignalBlocker sb(m_rxAntCmb);
-    QString cur = m_rxAntCmb->currentText();
     m_rxAntCmb->clear();
-    m_rxAntCmb->addItems(ants);
-    if (ants.contains(cur))
-        m_rxAntCmb->setCurrentText(cur);
+    for (const QString& ant : m_antList) {
+        const bool disambiguate = m_radioModel
+            && m_radioModel->antennaAliasNeedsDisambiguation(ant, m_antList);
+        const QString label = m_radioModel
+            ? m_radioModel->antennaDisplayName(ant, disambiguate)
+            : ant;
+        m_rxAntCmb->addItem(label, ant);
+    }
+    setRxAntennaComboToken(cur);
+}
+
+void SpectrumOverlayMenu::setRxAntennaComboToken(const QString& token)
+{
+    if (!m_rxAntCmb)
+        return;
+    for (int i = 0; i < m_rxAntCmb->count(); ++i) {
+        if (m_rxAntCmb->itemData(i).toString() == token) {
+            m_rxAntCmb->setCurrentIndex(i);
+            return;
+        }
+    }
 }
 
 void SpectrumOverlayMenu::setSlice(SliceModel* slice)
@@ -444,7 +488,7 @@ void SpectrumOverlayMenu::setSlice(SliceModel* slice)
 
     connect(m_slice, &SliceModel::rxAntennaChanged, this, [this](const QString& ant) {
         m_updatingFromModel = true;
-        m_rxAntCmb->setCurrentText(ant);
+        setRxAntennaComboToken(ant);
         m_updatingFromModel = false;
     });
 
@@ -469,7 +513,7 @@ void SpectrumOverlayMenu::syncAntPanel()
 {
     if (!m_slice) return;
     m_updatingFromModel = true;
-    m_rxAntCmb->setCurrentText(m_slice->rxAntenna());
+    setRxAntennaComboToken(m_slice->rxAntenna());
     {
         QSignalBlocker sb(m_rfGainSlider);
         m_rfGainSlider->setValue(static_cast<int>(m_slice->rfGain()));

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -36,6 +36,7 @@ public:
 
     // Set the antenna list (from RadioModel::antListChanged).
     void setAntennaList(const QStringList& ants);
+    void setRadioModel(RadioModel* model);
 
     // Sync Display sub-panel controls with saved settings.  The Black slider
     // displays `black` while autoBlack is off and `autoBlackOffset` while it
@@ -150,6 +151,8 @@ private:
     void hideAllSubPanels();
     void showBandPanelAt(const QPoint& pos);
     void syncAntPanel();
+    void refreshAntennaCombo();
+    void setRxAntennaComboToken(const QString& token);
 
     static constexpr int kBtnAddRx = 0;
     static constexpr int kBtnAddTnf = 1;
@@ -237,6 +240,7 @@ private:
     QLabel*      m_autoSqlMarginLabel{nullptr};
 
     QStringList  m_antList;
+    RadioModel*  m_radioModel{nullptr};
     QPointer<SliceModel> m_slice;
     bool         m_updatingFromModel{false};
     int          m_lastEmittedRfGain{INT_MIN};  // dedupe rfgain emits across drag snap ticks (#1498)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -4,6 +4,7 @@
 #include "GuardedSlider.h"
 #include "RxApplet.h"
 #include "SliceColorManager.h"
+#include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
 #include "core/AppSettings.h"
@@ -27,6 +28,7 @@
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QFormLayout>
+#include <QFontMetrics>
 #include <QSignalBlocker>
 #include <QDir>
 #include <QFile>
@@ -183,6 +185,16 @@ static const QString kSliderStyle =
 static const QString kLabelStyle =
     "QLabel { background: transparent; border: none; color: #8aa8c0; font-size: 13px; }";
 
+static bool likelyTxAntennaFallbackToken(const QString& token)
+{
+    const QString upper = token.toUpper();
+    if (upper.startsWith(QStringLiteral("RX")))
+        return false;
+    return upper.startsWith(QStringLiteral("ANT"))
+        || upper.startsWith(QStringLiteral("TX"))
+        || upper == QStringLiteral("XVTR");
+}
+
 // ── Construction ──────────────────────────────────────────────────────────────
 
 VfoWidget::VfoWidget(QWidget* parent)
@@ -335,13 +347,19 @@ void VfoWidget::buildUI()
     connect(m_rxAntBtn, &QPushButton::clicked, this, [this] {
         if (!m_slice) return;
         QMenu menu(this);
-        for (const QString& ant : m_antList) {
-            auto* act = menu.addAction(ant);
+        const QStringList options = !m_slice->rxAntennaList().isEmpty()
+            ? m_slice->rxAntennaList()
+            : m_antList;
+        for (const QString& ant : options) {
+            auto* act = menu.addAction(antennaMenuLabel(ant, options));
+            act->setData(ant);
             act->setCheckable(true);
             act->setChecked(ant == m_slice->rxAntenna());
+            act->setToolTip(ant);
+            act->setStatusTip(ant);
         }
         if (auto* sel = menu.exec(m_rxAntBtn->mapToGlobal(QPoint(0, m_rxAntBtn->height()))))
-            m_slice->setRxAntenna(sel->text());
+            m_slice->setRxAntenna(sel->data().toString());
     });
     hdr->addWidget(m_rxAntBtn);
 
@@ -351,15 +369,17 @@ void VfoWidget::buildUI()
     connect(m_txAntBtn, &QPushButton::clicked, this, [this] {
         if (!m_slice) return;
         QMenu menu(this);
-        for (const QString& ant : m_antList) {
-            if (ant.startsWith("RX", Qt::CaseInsensitive))
-                continue;  // skip RX-only antenna ports
-            auto* act = menu.addAction(ant);
+        const QStringList options = txAntennaOptions();
+        for (const QString& ant : options) {
+            auto* act = menu.addAction(antennaMenuLabel(ant, options));
+            act->setData(ant);
             act->setCheckable(true);
             act->setChecked(ant == m_slice->txAntenna());
+            act->setToolTip(ant);
+            act->setStatusTip(ant);
         }
         if (auto* sel = menu.exec(m_txAntBtn->mapToGlobal(QPoint(0, m_txAntBtn->height()))))
-            m_slice->setTxAntenna(sel->text());
+            m_slice->setTxAntenna(sel->data().toString());
     });
     hdr->addWidget(m_txAntBtn);
 
@@ -2522,11 +2542,13 @@ void VfoWidget::setSlice(SliceModel* slice)
     });
     // Antennas
     connect(m_slice, &SliceModel::rxAntennaChanged, this, [this](const QString& ant) {
-        m_updatingFromModel = true; m_rxAntBtn->setText(ant); m_updatingFromModel = false;
+        m_updatingFromModel = true; updateAntennaButton(m_rxAntBtn, ant, false); m_updatingFromModel = false;
     });
     connect(m_slice, &SliceModel::txAntennaChanged, this, [this](const QString& ant) {
-        m_updatingFromModel = true; m_txAntBtn->setText(ant); m_updatingFromModel = false;
+        m_updatingFromModel = true; updateAntennaButton(m_txAntBtn, ant, true); m_updatingFromModel = false;
     });
+    connect(m_slice, &SliceModel::txAntennaListChanged,
+            this, [this](const QStringList&) { updateAntennaButtons(); });
     // TX slice — toggle between red (active TX) and grey (clickable to set TX)
     connect(m_slice, &SliceModel::txSliceChanged, this, [this](bool tx) {
         updateTxBadgeStyle(tx);
@@ -2874,8 +2896,8 @@ void VfoWidget::syncFromSlice()
     if (!m_slice) return;
     m_updatingFromModel = true;
 
-    m_rxAntBtn->setText(m_slice->rxAntenna());
-    m_txAntBtn->setText(m_slice->txAntenna());
+    updateAntennaButton(m_rxAntBtn, m_slice->rxAntenna(), false);
+    updateAntennaButton(m_txAntBtn, m_slice->txAntenna(), true);
     updateTxBadgeStyle(m_slice->isTxSlice());
     {
         QSignalBlocker b(m_lockVfoBtn);
@@ -3637,11 +3659,90 @@ void VfoWidget::saveFilterPresets()
 void VfoWidget::setAntennaList(const QStringList& ants)
 {
     m_antList = ants;
+    updateAntennaButtons();
 }
 
 void VfoWidget::setTransmitModel(TransmitModel* txModel)
 {
     m_txModel = txModel;
+}
+
+void VfoWidget::setRadioModel(RadioModel* radioModel)
+{
+    if (m_radioModel)
+        disconnect(m_radioModel, &RadioModel::antennaAliasesChanged,
+                   this, &VfoWidget::updateAntennaButtons);
+    m_radioModel = radioModel;
+    if (m_radioModel) {
+        connect(m_radioModel, &RadioModel::antennaAliasesChanged,
+                this, &VfoWidget::updateAntennaButtons);
+    }
+    updateAntennaButtons();
+}
+
+QString VfoWidget::antennaMenuLabel(const QString& token,
+                                    const QStringList& options) const
+{
+    if (!m_radioModel)
+        return token;
+    return m_radioModel->antennaDisplayName(
+        token, m_radioModel->antennaAliasNeedsDisambiguation(token, options));
+}
+
+QStringList VfoWidget::txAntennaOptions() const
+{
+    QStringList options;
+    auto append = [&options](const QString& token) {
+        if (!token.isEmpty() && !options.contains(token))
+            options.append(token);
+    };
+
+    if (m_slice && !m_slice->txAntennaList().isEmpty()) {
+        for (const QString& ant : m_slice->txAntennaList())
+            append(ant);
+        append(m_slice->txAntenna());
+        return options;
+    }
+
+    for (const QString& ant : m_antList) {
+        if (likelyTxAntennaFallbackToken(ant))
+            append(ant);
+    }
+    if (m_slice)
+        append(m_slice->txAntenna());
+    return options;
+}
+
+void VfoWidget::updateAntennaButton(QPushButton* button, const QString& token, bool tx)
+{
+    if (!button)
+        return;
+
+    const QString shortLabel = m_radioModel
+        ? m_radioModel->antennaShortDisplayName(token, 6)
+        : token;
+    const QFontMetrics fm(button->font());
+    constexpr int kMinWidth = 34;
+    constexpr int kMaxWidth = 66;
+    constexpr int kPad = 12;
+    const QString text = fm.elidedText(shortLabel, Qt::ElideRight, kMaxWidth - kPad);
+    button->setText(text);
+    button->setFixedWidth(qBound(kMinWidth, fm.horizontalAdvance(text) + kPad, kMaxWidth));
+
+    const QString full = m_radioModel
+        ? m_radioModel->antennaDisplayName(token, !m_radioModel->antennaAlias(token).isEmpty())
+        : token;
+    button->setToolTip(QStringLiteral("%1 antenna port: %2")
+                           .arg(tx ? QStringLiteral("Transmit") : QStringLiteral("Receive"),
+                                full));
+}
+
+void VfoWidget::updateAntennaButtons()
+{
+    if (!m_slice)
+        return;
+    updateAntennaButton(m_rxAntBtn, m_slice->rxAntenna(), false);
+    updateAntennaButton(m_txAntBtn, m_slice->txAntenna(), true);
 }
 
 bool VfoWidget::eventFilter(QObject* obj, QEvent* event)

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -24,6 +24,7 @@ namespace AetherSDR {
 
 class SliceModel;
 class TransmitModel;
+class RadioModel;
 class PhaseKnob;
 
 // Floating VFO info panel attached to the VFO marker on the spectrum display.
@@ -40,6 +41,7 @@ public:
     void setSlice(SliceModel* slice);
     void setAntennaList(const QStringList& ants);
     void setTransmitModel(TransmitModel* txModel);
+    void setRadioModel(RadioModel* radioModel);
     void setSignalLevel(float dbm);
 
     // Split mode: call whenever TX assignment or active slice changes.
@@ -131,10 +133,15 @@ private:
     void applyFilterPreset(int widthHz);
     void saveFilterPresets();
     void updateAgcSliderFromSlice();
+    void updateAntennaButton(QPushButton* button, const QString& token, bool tx);
+    void updateAntennaButtons();
+    QStringList txAntennaOptions() const;
+    QString antennaMenuLabel(const QString& token, const QStringList& options) const;
     static QString formatFilterLabel(int hz);
 
     SliceModel*    m_slice{nullptr};
     TransmitModel* m_txModel{nullptr};
+    RadioModel*    m_radioModel{nullptr};
     QStringList    m_antList;
     bool           m_updatingFromModel{false};
     bool           m_lastOnLeft{true};

--- a/src/models/AntennaAliasStore.cpp
+++ b/src/models/AntennaAliasStore.cpp
@@ -1,0 +1,95 @@
+#include "AntennaAliasStore.h"
+#include "core/AppSettings.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace AetherSDR {
+
+namespace {
+
+QString encodedKeyPart(const QString& value)
+{
+    const QByteArray hex = value.toUtf8().toHex();
+    return hex.isEmpty() ? QStringLiteral("default") : QString::fromLatin1(hex);
+}
+
+} // namespace
+
+QString AntennaAliasStore::settingsKeyForRadio(const QString& radioKey)
+{
+    return QStringLiteral("AntennaAliases_%1").arg(encodedKeyPart(radioKey));
+}
+
+QMap<QString, QString> AntennaAliasStore::load(const QString& radioKey)
+{
+    QMap<QString, QString> aliases;
+    const QString raw = AppSettings::instance()
+        .value(settingsKeyForRadio(radioKey), QString()).toString();
+    if (raw.trimmed().isEmpty())
+        return aliases;
+
+    QJsonParseError error;
+    const QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8(), &error);
+    if (error.error != QJsonParseError::NoError || !doc.isObject())
+        return aliases;
+
+    const QJsonObject obj = doc.object();
+    for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
+        const QString alias = it.value().toString().trimmed();
+        if (!alias.isEmpty())
+            aliases.insert(it.key(), alias);
+    }
+    return aliases;
+}
+
+void AntennaAliasStore::save(const QString& radioKey,
+                             const QMap<QString, QString>& aliases)
+{
+    QJsonObject obj;
+    for (auto it = aliases.constBegin(); it != aliases.constEnd(); ++it) {
+        const QString alias = it.value().trimmed();
+        if (!it.key().isEmpty() && !alias.isEmpty())
+            obj.insert(it.key(), alias);
+    }
+
+    auto& settings = AppSettings::instance();
+    const QString key = settingsKeyForRadio(radioKey);
+    if (obj.isEmpty()) {
+        settings.remove(key);
+    } else {
+        settings.setValue(key, QString::fromUtf8(
+            QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    }
+    settings.save();
+}
+
+QString AntennaAliasStore::alias(const QMap<QString, QString>& aliases,
+                                 const QString& token)
+{
+    return aliases.value(token).trimmed();
+}
+
+QString AntennaAliasStore::displayName(const QMap<QString, QString>& aliases,
+                                       const QString& token,
+                                       bool includeTokenForDisambiguation)
+{
+    const QString a = alias(aliases, token);
+    if (a.isEmpty())
+        return token;
+    if (includeTokenForDisambiguation)
+        return QStringLiteral("%1 (%2)").arg(a, token);
+    return a;
+}
+
+QString AntennaAliasStore::shortDisplayName(const QMap<QString, QString>& aliases,
+                                            const QString& token,
+                                            int maxChars)
+{
+    const QString label = displayName(aliases, token);
+    if (maxChars > 0 && label.size() > maxChars)
+        return label.left(maxChars);
+    return label;
+}
+
+} // namespace AetherSDR

--- a/src/models/AntennaAliasStore.h
+++ b/src/models/AntennaAliasStore.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QMap>
+#include <QString>
+
+namespace AetherSDR {
+
+class AntennaAliasStore {
+public:
+    static QString settingsKeyForRadio(const QString& radioKey);
+    static QMap<QString, QString> load(const QString& radioKey);
+    static void save(const QString& radioKey, const QMap<QString, QString>& aliases);
+
+    static QString alias(const QMap<QString, QString>& aliases,
+                         const QString& token);
+    static QString displayName(const QMap<QString, QString>& aliases,
+                               const QString& token,
+                               bool includeTokenForDisambiguation = false);
+    static QString shortDisplayName(const QMap<QString, QString>& aliases,
+                                    const QString& token,
+                                    int maxChars = 6);
+};
+
+} // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1,4 +1,5 @@
 #include "RadioModel.h"
+#include "AntennaAliasStore.h"
 #include "BandSettings.h"
 #include "core/CommandParser.h"
 #include "core/AppSettings.h"
@@ -73,6 +74,12 @@ bool statusFlagSet(const QMap<QString, QString>& kvs, const QString& key)
     const QString value = kvs.value(key).trimmed();
     return value == QStringLiteral("1")
         || value.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0;
+}
+
+void appendUniqueAntennaToken(QStringList& tokens, const QString& token)
+{
+    if (!token.isEmpty() && !tokens.contains(token))
+        tokens.append(token);
 }
 
 QString cleanClientText(QString value)
@@ -498,6 +505,129 @@ int RadioModel::activeTxSliceNum() const
     return -1;
 }
 
+QString RadioModel::antennaAliasRadioKey() const
+{
+    QString key = m_chassisSerial.trimmed();
+    if (key.isEmpty())
+        key = serial().trimmed();
+    if (key.isEmpty())
+        key = m_model.trimmed();
+    if (key.isEmpty())
+        key = m_name.trimmed();
+    if (key.isEmpty())
+        key = m_nickname.trimmed();
+    return key.isEmpty() ? QStringLiteral("unconnected") : key;
+}
+
+bool RadioModel::reloadAntennaAliases() const
+{
+    const QString key = antennaAliasRadioKey();
+    if (key == m_antennaAliasRadioKey)
+        return false;
+
+    const QMap<QString, QString> aliases = AntennaAliasStore::load(key);
+    const bool changed = aliases != m_antennaAliases
+        || key != m_antennaAliasRadioKey;
+    m_antennaAliasRadioKey = key;
+    m_antennaAliases = aliases;
+    return changed;
+}
+
+QString RadioModel::antennaAlias(const QString& token) const
+{
+    reloadAntennaAliases();
+    return AntennaAliasStore::alias(m_antennaAliases, token);
+}
+
+QString RadioModel::antennaDisplayName(const QString& token,
+                                       bool includeTokenForDisambiguation) const
+{
+    reloadAntennaAliases();
+    return AntennaAliasStore::displayName(
+        m_antennaAliases, token, includeTokenForDisambiguation);
+}
+
+QString RadioModel::antennaShortDisplayName(const QString& token, int maxChars) const
+{
+    reloadAntennaAliases();
+    return AntennaAliasStore::shortDisplayName(m_antennaAliases, token, maxChars);
+}
+
+QMap<QString, QString> RadioModel::antennaAliases() const
+{
+    reloadAntennaAliases();
+    return m_antennaAliases;
+}
+
+bool RadioModel::antennaAliasNeedsDisambiguation(const QString& token,
+                                                 const QStringList& tokens) const
+{
+    reloadAntennaAliases();
+    const QString a = AntennaAliasStore::alias(m_antennaAliases, token);
+    if (a.isEmpty())
+        return false;
+
+    int count = 0;
+    for (const QString& other : tokens) {
+        if (AntennaAliasStore::alias(m_antennaAliases, other) == a)
+            ++count;
+    }
+    return count > 1;
+}
+
+void RadioModel::setAntennaAlias(const QString& token, const QString& alias)
+{
+    if (token.isEmpty())
+        return;
+    reloadAntennaAliases();
+
+    const QString trimmedAlias = alias.trimmed();
+    if (trimmedAlias.isEmpty()) {
+        clearAntennaAlias(token);
+        return;
+    }
+
+    if (m_antennaAliases.value(token) == trimmedAlias)
+        return;
+
+    m_antennaAliases.insert(token, trimmedAlias);
+    AntennaAliasStore::save(m_antennaAliasRadioKey, m_antennaAliases);
+    emit antennaAliasesChanged();
+}
+
+void RadioModel::clearAntennaAlias(const QString& token)
+{
+    if (token.isEmpty())
+        return;
+    reloadAntennaAliases();
+    if (!m_antennaAliases.remove(token))
+        return;
+
+    AntennaAliasStore::save(m_antennaAliasRadioKey, m_antennaAliases);
+    emit antennaAliasesChanged();
+}
+
+QStringList RadioModel::knownAntennaTokens() const
+{
+    reloadAntennaAliases();
+    QStringList tokens;
+    for (const QString& ant : m_antList)
+        appendUniqueAntennaToken(tokens, ant);
+    for (SliceModel* s : m_slices) {
+        if (!s)
+            continue;
+        appendUniqueAntennaToken(tokens, s->rxAntenna());
+        appendUniqueAntennaToken(tokens, s->txAntenna());
+        for (const QString& ant : s->rxAntennaList())
+            appendUniqueAntennaToken(tokens, ant);
+        for (const QString& ant : s->txAntennaList())
+            appendUniqueAntennaToken(tokens, ant);
+    }
+    for (auto it = m_antennaAliases.constBegin(); it != m_antennaAliases.constEnd(); ++it)
+        appendUniqueAntennaToken(tokens, it.key());
+    return tokens;
+}
+
 SliceModel* RadioModel::txSlice() const
 {
     for (auto* s : m_slices) {
@@ -682,6 +812,8 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     m_model   = info.model;
     m_version = info.version;
     m_maxSlices = maxSlicesForModel(m_model);
+    if (reloadAntennaAliases())
+        emit antennaAliasesChanged();
     setKnownGuiClients(info.guiClientHandles,
                        info.guiClientPrograms,
                        info.guiClientStations,
@@ -1837,6 +1969,8 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                         qCDebug(lcProtocol) << "RadioModel: info — callsign:" << m_callsign
                                  << "region:" << m_region << "options:" << m_radioOptions;
                         emit infoChanged();
+                        if (reloadAntennaAliases())
+                            emit antennaAliasesChanged();
                     });
 
                 sendCmd("slice list",

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -85,6 +85,16 @@ public:
     float txPower()   const { return m_txPower; }
     bool  isRadioTransmitting() const { return m_radioTransmitting; }
     QStringList antennaList() const { return m_antList; }
+    QString antennaAlias(const QString& token) const;
+    QString antennaDisplayName(const QString& token,
+                               bool includeTokenForDisambiguation = false) const;
+    QString antennaShortDisplayName(const QString& token, int maxChars = 6) const;
+    QMap<QString, QString> antennaAliases() const;
+    bool antennaAliasNeedsDisambiguation(const QString& token,
+                                         const QStringList& tokens) const;
+    void setAntennaAlias(const QString& token, const QString& alias);
+    void clearAntennaAlias(const QString& token);
+    QStringList knownAntennaTokens() const;
     QString serial()       const;
     QString chassisSerial() const { return m_chassisSerial; }
     QString callsign()     const { return m_callsign; }
@@ -344,6 +354,8 @@ signals:
     void panDimensionsNeeded(const QString& panId);
     // Emitted when the radio reports its antenna list (e.g. "ANT1,ANT2,RX_A,RX_B").
     void antListChanged(QStringList ants);
+    // Local AetherSDR display aliases changed. The radio still uses canonical tokens.
+    void antennaAliasesChanged();
     // Emitted when a power amplifier (e.g. PGXL) is detected or lost.
     void amplifierChanged(bool present);
     void ampStateChanged();   // amplifier operate/bypass changed
@@ -465,6 +477,8 @@ private:
     void updateStreamFilters();
     void handleGpsStatus(const QString& rawBody);
     void emitOtherClientsChanged();
+    QString antennaAliasRadioKey() const;
+    bool reloadAntennaAliases() const;
 
     // Standalone mode: create a panadapter then attach a slice to it.
     void createDefaultSlice(const QString& freqMhz = "14.225000",
@@ -574,6 +588,8 @@ private:
                                          // the field; cleared on non-TX
                                          // interlock states and on disconnect.
     QStringList m_antList;
+    mutable QString m_antennaAliasRadioKey;
+    mutable QMap<QString, QString> m_antennaAliases;
 
     QMap<QString, PanadapterModel*> m_panadapters;  // panId → model
     QString m_activePanId;       // currently active panadapter

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -3,6 +3,21 @@
 
 namespace AetherSDR {
 
+namespace {
+
+QStringList splitAntennaList(const QString& value)
+{
+    QStringList result;
+    for (QString token : value.split(',', Qt::SkipEmptyParts)) {
+        token = token.trimmed();
+        if (!token.isEmpty())
+            result.append(token);
+    }
+    return result;
+}
+
+} // namespace
+
 SliceModel::SliceModel(int id, QObject* parent)
     : QObject(parent), m_id(id)
 {}
@@ -605,6 +620,21 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
     }
 
     // Slice control state
+    if (kvs.contains("ant_list") || kvs.contains("rx_ant_list")) {
+        const QString raw = kvs.value("rx_ant_list", kvs.value("ant_list"));
+        const QStringList ants = splitAntennaList(raw);
+        if (ants != m_rxAntennaList) {
+            m_rxAntennaList = ants;
+            emit rxAntennaListChanged(m_rxAntennaList);
+        }
+    }
+    if (kvs.contains("tx_ant_list")) {
+        const QStringList ants = splitAntennaList(kvs["tx_ant_list"]);
+        if (ants != m_txAntennaList) {
+            m_txAntennaList = ants;
+            emit txAntennaListChanged(m_txAntennaList);
+        }
+    }
     if (kvs.contains("rxant")) {
         m_rxAntenna = kvs["rxant"];
         emit rxAntennaChanged(m_rxAntenna);

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QMap>
 
 namespace AetherSDR {
@@ -39,6 +40,8 @@ public:
     // Getters — RX DSP state
     QString rxAntenna()   const { return m_rxAntenna; }
     QString txAntenna()   const { return m_txAntenna; }
+    QStringList rxAntennaList() const { return m_rxAntennaList; }
+    QStringList txAntennaList() const { return m_txAntennaList; }
     bool    isLocked()    const { return m_locked; }
     bool    qskOn()       const { return m_qsk; }
     bool    nbOn()        const { return m_nb; }
@@ -176,6 +179,8 @@ signals:
     void audioPanChanged(int pan);
     void rxAntennaChanged(const QString& ant);
     void txAntennaChanged(const QString& ant);
+    void rxAntennaListChanged(const QStringList& ants);
+    void txAntennaListChanged(const QStringList& ants);
     void lockedChanged(bool locked);
     void qskChanged(bool on);
     void nbChanged(bool on);
@@ -246,6 +251,8 @@ private:
     // Slice control state
     QString m_rxAntenna{"ANT1"};
     QString m_txAntenna{"ANT1"};
+    QStringList m_rxAntennaList;
+    QStringList m_txAntennaList;
     bool    m_locked{false};
     bool    m_qsk{false};
     bool    m_audioMute{false};

--- a/tests/antenna_alias_test.cpp
+++ b/tests/antenna_alias_test.cpp
@@ -1,0 +1,91 @@
+#include "core/AppSettings.h"
+#include "models/AntennaAliasStore.h"
+#include "models/SliceModel.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    return condition;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QTemporaryDir fakeHome(QDir::tempPath() + "/aether-antenna-alias-test-XXXXXX");
+    if (!fakeHome.isValid()) {
+        std::cerr << "[FAIL] create temporary home\n";
+        return 1;
+    }
+    qputenv("HOME", fakeHome.path().toUtf8());
+    qputenv("CFFIXED_USER_HOME", fakeHome.path().toUtf8());
+    QStandardPaths::setTestModeEnabled(true);
+    QCoreApplication app(argc, argv);
+
+    const QString configRoot =
+        QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+    QDir(configRoot + "/AetherSDR").removeRecursively();
+
+    auto& settings = AppSettings::instance();
+    settings.reset();
+
+    const QString radioKey = QStringLiteral("serial-123");
+    QMap<QString, QString> aliases;
+    aliases.insert(QStringLiteral("ANT1"), QStringLiteral("YAGI"));
+    aliases.insert(QStringLiteral("ANT2"), QStringLiteral("YAGI"));
+    aliases.insert(QStringLiteral("RX_A"), QStringLiteral("BVRG"));
+    AntennaAliasStore::save(radioKey, aliases);
+
+    bool ok = true;
+    QFile saved(settings.filePath());
+    ok &= expect(saved.open(QIODevice::ReadOnly | QIODevice::Text),
+                 "alias settings file is written");
+    const QString xml = ok ? QString::fromUtf8(saved.readAll()) : QString();
+    saved.close();
+    ok &= expect(xml.contains(QStringLiteral("AntennaAliases_")),
+                 "aliases persist under an XML-safe per-radio key");
+
+    settings.reset();
+    settings.load();
+    const auto restored = AntennaAliasStore::load(radioKey);
+    ok &= expect(restored.value(QStringLiteral("ANT1")) == QStringLiteral("YAGI"),
+                 "ANT1 alias round-trips");
+    ok &= expect(AntennaAliasStore::displayName(restored, QStringLiteral("RX_A"))
+                     == QStringLiteral("BVRG"),
+                 "alias display name replaces canonical token");
+    ok &= expect(AntennaAliasStore::displayName(restored, QStringLiteral("RX_B"))
+                     == QStringLiteral("RX_B"),
+                 "empty alias falls back to canonical token");
+    ok &= expect(AntennaAliasStore::displayName(restored, QStringLiteral("ANT1"), true)
+                     == QStringLiteral("YAGI (ANT1)"),
+                 "duplicate alias can be disambiguated with canonical token");
+
+    SliceModel slice(3);
+    QStringList commands;
+    QObject::connect(&slice, &SliceModel::commandReady,
+                     [&commands](const QString& cmd) { commands.append(cmd); });
+    slice.applyStatus({{QStringLiteral("tx_ant_list"), QStringLiteral("ANT1,ANT2,XVTR")}});
+    ok &= expect(slice.txAntennaList() == QStringList({QStringLiteral("ANT1"),
+                                                       QStringLiteral("ANT2"),
+                                                       QStringLiteral("XVTR")}),
+                 "slice parses tx_ant_list");
+
+    slice.setTxAntenna(QStringLiteral("XVTR"));
+    ok &= expect(commands == QStringList({QStringLiteral("slice set 3 txant=XVTR")}),
+                 "slice TX antenna command keeps canonical token");
+
+    QDir(configRoot + "/AetherSDR").removeRecursively();
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION

<img width="1710" height="789" alt="Screenshot 2026-05-12 at 9 54 29 PM" src="https://github.com/user-attachments/assets/c425099a-8d42-4d88-9e4d-08878bd3b4bd" />

## Summary

- Add local per-radio display aliases for FlexRadio antenna ports, stored in AetherSDR settings and keyed by chassis serial/serial/model fallback.
- Add a Radio Setup > Antennas tab for editing canonical ports such as ANT1, ANT2, RX_A, XVTR, XVTA, and future radio-reported tokens.
- Make RX/VFO/spectrum overlay antenna selectors alias-aware while preserving canonical tokens in QAction/QComboBox data and radio commands.
- Parse per-slice `tx_ant_list` and use it for TX-capable antenna selectors, with conservative fallback filtering for older radios.
- Add an antenna alias test covering persistence, fallback display, duplicate-alias disambiguation, `tx_ant_list` parsing, and canonical TX command output.

## Notes

I checked the local FlexLib 4.2.18 reference before implementing storage. FlexLib exposes canonical RX/TX antenna lists and `rxant`/`txant` setters, but I did not find a reliable writable antenna display-name or label API, so these names are intentionally local to AetherSDR. The radio protocol still sends exact canonical antenna tokens only.

Duplicate aliases are disambiguated in chooser labels when needed, while compact antenna badges use a short alias with canonical-token tooltips/status tips.

## Validation

- `cmake --build build -j8`
- `ctest --test-dir build --output-on-failure -j8`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
