### PR TITLE
Fix tooltip overlap on spot labels

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2975,11 +2975,8 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
                                 if (sm.timestampMs > 0)
                                     tip += QString("<br>Spotted: %1 UTC").arg(
                                         QDateTime::fromMSecsSinceEpoch(sm.timestampMs, QTimeZone::utc()).toString("yyyy-MM-dd HH:mm:ss"));
-                                        QToolTip::showText(
-                                            ev->globalPosition().toPoint() + QPoint(16, 4),
-                                            tip,
-                                        this
-                                        );                            
+                                QToolTip::showText(ev->globalPosition().toPoint() + QPoint(16, 4), tip, this);
+                            }
                             spotHover = true;
                             break;
                         }
@@ -3022,12 +3019,8 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         for (const auto& spot : spots) {
             const int sx = mhzToX(spot.freqMhz);
             if (std::abs(mx2 - sx) <= 5) {
-                QToolTip::showText(
-                ev->globalPosition().toPoint() + QPoint(16, 4),
-                tip,
-                this
-                );                    
-                        QString("%1 MHz — %2")
+                QToolTip::showText(ev->globalPosition().toPoint() + QPoint(16, 4),
+                    QString("%1 MHz — %2")
                         .arg(spot.freqMhz, 0, 'f', 3)
                         .arg(spot.label),
                     this);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2975,8 +2975,11 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
                                 if (sm.timestampMs > 0)
                                     tip += QString("<br>Spotted: %1 UTC").arg(
                                         QDateTime::fromMSecsSinceEpoch(sm.timestampMs, QTimeZone::utc()).toString("yyyy-MM-dd HH:mm:ss"));
-                                QToolTip::showText(ev->globalPosition().toPoint(), tip, this);
-                            }
+                                        QToolTip::showText(
+                                            ev->globalPosition().toPoint() + QPoint(16, 4),
+                                            tip,
+                                        this
+                                        );                            
                             spotHover = true;
                             break;
                         }
@@ -3019,8 +3022,12 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         for (const auto& spot : spots) {
             const int sx = mhzToX(spot.freqMhz);
             if (std::abs(mx2 - sx) <= 5) {
-                QToolTip::showText(ev->globalPosition().toPoint(),
-                    QString("%1 MHz — %2")
+                QToolTip::showText(
+                ev->globalPosition().toPoint() + QPoint(16, 4),
+                tip,
+                this
+                );                    
+                        QString("%1 MHz — %2")
                         .arg(spot.freqMhz, 0, 'f', 3)
                         .arg(spot.label),
                     this);


### PR DESCRIPTION
## Fix Implemented

Added a cursor offset to both `QToolTip::showText()` call sites in `SpectrumWidget.cpp` to prevent tooltips from rendering directly over spot labels.

### Changes

* Applied `QPoint(16, 4)` offset to DX spot tooltip
* Applied `QPoint(16, 4)` offset to band plan tooltip

### Result

Tooltips now appear offset from the cursor, keeping spot labels visible and clickable during hover interactions.

Fixes #2623