### PR TITLE
Fix RADE receive audio on macOS by enabling DAX stream lifecycle

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -13608,13 +13608,7 @@ void MainWindow::activateRADE(int sliceId)
     connect(m_radeEngine, &RADEEngine::rxSpeechReady,
             m_audio, &AudioEngine::feedDecodedSpeech, Qt::QueuedConnection);
 
-    // On platforms without a DAX audio bridge (Windows, Linux without PipeWire),
-    // startDax() is not compiled in so no dax_rx stream is ever created. RADE
-    // needs those VITA-49 IF audio packets regardless of whether a DAX bridge
-    // is in use — create the stream directly so feedRxAudio() gets called.
-    // If TCI already created a stream for this channel, reuse it rather than
-    // creating a duplicate (which would cause RADEEngine to receive double audio).
-#if !defined(Q_OS_MAC) && !defined(HAVE_PIPEWIRE)
+    // If TCI or another path already registered a stream — RADE rides it.
     {
         SliceModel* radeSlice = m_radioModel.slice(sliceId);
         int daxCh = radeSlice ? radeSlice->daxChannel() : 0;
@@ -13648,7 +13642,6 @@ void MainWindow::activateRADE(int sliceId)
                        << "has no DAX channel assigned — RX audio will not flow";
         }
     }
-#endif
 
     // Restore client-side mic gain for RADE. The radio's mic input is unused in
     // RADE mode so PcMicGain applies regardless of the current mic_selection.
@@ -13724,7 +13717,6 @@ void MainWindow::deactivateRADE()
                    m_radeEngine, nullptr);
         disconnect(m_radeEngine, &RADEEngine::rxSpeechReady,
                    m_audio, nullptr);
-#if !defined(Q_OS_MAC) && !defined(HAVE_PIPEWIRE)
         if (m_radeDaxStreamId) {
             // Only send stream remove if TCI has no active clients. If TCI is
             // connected it may have borrowed this stream — removing it would
@@ -13732,7 +13724,8 @@ void MainWindow::deactivateRADE()
             // that case. TODO: replace with proper ref-counting in PanadapterStream
             // so any creator/borrower can safely release independently (#stream-lifecycle).
             bool tciActive = m_tciServer && m_tciServer->clientCount() > 0;
-            if (!tciActive) {
+            bool daxBridgeActive = (m_daxBridge != nullptr);
+            if (!tciActive && !daxBridgeActive) {
                 m_radioModel.panStream()->unregisterDaxStream(m_radeDaxStreamId);
                 if (m_radioModel.isConnected()) {
                     m_radioModel.sendCommand(
@@ -13743,7 +13736,6 @@ void MainWindow::deactivateRADE()
             m_radeDaxStreamId = 0;
         }
         disconnect(m_radeDaxStreamConn);
-#endif
         // Stop on the worker thread, then shut down the thread
         QMetaObject::invokeMethod(m_radeEngine, &RADEEngine::stop,
                                   Qt::BlockingQueuedConnection);


### PR DESCRIPTION
This PR resolves issue #2627, where RADE receive audio was non-functional on macOS due to restrictive platform-specific guards in the DAX stream management logic. Previously, the code assumed that the DAX audio bridge (e.g., the macOS HAL plugin) would handle stream registration; however, when the bridge is inactive, the radio never receives the required stream create command, leaving the RADE engine without input.

### Changes
- Removed #if !defined(Q_OS_MAC) && !defined(HAVE_PIPEWIRE) platform guards from ctivateRADE() and deactivateRADE().
- Unified the stream creation logic, ensuring the dax_rx stream is created/reused consistently across all platforms.
- Implemented defensive teardown logic in deactivateRADE(): the stream is now only removed if neither a TCI client nor a DAX bridge is currently utilizing it.

### Testing Performed
- **Test Case 1 (macOS, no DAX/HAL)**: Verified through simulated environment by ensuring no HAL plugin was loaded. Confirmed RADE activation triggers a stream create type=dax_rx dax_channel=N command, verified via QDebug log output from MainWindow.cpp indicating successful registration.
- **Test Case 2 (macOS, with DAX/HAL)**: Verified that when the DAX bridge is active (and thus m_daxBridge is non-null), the teardown logic correctly skips the stream remove command, preventing conflict with the bridge-managed stream lifecycle.
- **Test Case 3 (Regression)**: Conducted code path analysis for Windows and Linux to ensure that removing the guards does not result in duplicate streams, relying on the existing stream check (using daxStreamIdForChannel) to maintain idempotent stream management.
- **Test Case 4 (TCI Interop)**: Verified logic by ensuring that when 	ciServer->clientCount() > 0, the stream remove command is bypassed, leaving the TCI client's stream state intact.