### PR TITLE
chore(meta): add spec-kit constitution at .specify/memory/constitution.md

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,184 @@
+# AetherSDR Constitution
+
+This constitution governs AetherSDR — an open-source Qt6 client for
+FlexRadio SmartSDR-compatible radios. It captures the load-bearing
+project conventions that any contribution (human or automated) must
+honor. The principles below are inviolable in the sense that violating
+them produces incorrect or inconsistent behavior elsewhere in the code,
+not because they are arbitrary style preferences.
+
+Authored using the [github/spec-kit](https://github.com/github/spec-kit)
+constitution template. Consumed at PR-time by the
+[AetherClaude](https://github.com/ten9876/aetherclaude) issue-triage
+agent, which is required to cite the principle it is honoring when
+implementing a fix.
+
+## Core Principles
+
+### I. FlexLib Is The Protocol Authority
+
+When debugging or implementing SmartSDR-protocol behavior (commands,
+status keys, VITA-49 layouts, slice semantics), the FlexLib C# source
+is the source of truth. Do not guess at command names, status-field
+spellings, or response shapes — grep FlexLib first, both the setter
+(what command is sent) and the parser (what status key is read). The
+two are frequently different (`sb_monitor` in status vs `mon` in
+command; `slice tune <id> <freq>` in modern usage, not the documented
+`slice t 0 <freq_mhz>`).
+
+*Why this is inviolable:* every time a contributor has trusted a wiki
+page, an older comment, or model guesswork over FlexLib's actual
+behavior, the resulting client commands have silently no-op'd on the
+radio. The failure mode is "I sent the command, the radio ignored it,
+nothing logged the mismatch." FlexLib doesn't have that ambiguity
+because it is the implementation the radio side was built against.
+
+### II. The Canonical MeterSmoother Owns All Meter Ballistics
+
+Every meter UI in AetherSDR uses `src/gui/MeterSmoother.h` (30 ms
+attack / 180 ms release at 120 Hz / 8 ms interval). Targets are
+normalized to `[0, 1]` via a `dbToRatio` helper before being passed
+to `setTarget()`. Asymmetric `kAlphaUp`/`kAlphaDown` blenders,
+`std::pow`/`exp` envelope followers, or copy-pasted smoothing from
+other meter widgets are prohibited unless the source widget is
+verified to itself be using `MeterSmoother`.
+
+*Why this is inviolable:* meter ballistics are an interface-wide design
+property. When one meter follows different ballistics than its
+neighbors the whole panel reads as miscalibrated, and chasing the
+inconsistency back to its source takes far longer than always using
+the canonical class. If a meter genuinely needs different ballistics
+(e.g., a slower GR-bar release), use `MeterSmoother::Ballistics` to
+opt into different constants; never roll your own envelope follower.
+
+### III. User-Facing Names Match The Visible UI Labels
+
+The toggle button at the top of `AppletPanel` says **DIGI**, so every
+user-facing reference — issue comments, wiki pages, README, the
+What's-New strings, error toasts — calls it **DIGI applet**. The
+internal class name `CatApplet` is *not* user-facing. Same convention
+applies anywhere the on-screen label and the C++ identifier disagree:
+the on-screen label wins for prose.
+
+Similarly: the Help → Support → diagnostic logging toggles are
+**Discovery**, **Commands**, and **Status** — never `radio.connection`
+or any other backend category name. When asking a user to enable
+logging, use the names they actually see in the UI.
+
+*Why this is inviolable:* asking a user to "Enable DAX in the CAT
+applet" or "toggle radio.connection logging" sends them looking for a
+button that does not exist by that name. Support-channel friction
+compounds.
+
+### IV. Region-Aware Data Comes From BandPlanManager, Not BandDefs.h
+
+Anything that needs band edges, segment sizes, or per-band metadata
+reads from the active band plan loaded by `BandPlanManager` (driven
+by `AppSettings["BandPlanName"]` and the JSON files in
+`resources/bandplans/`). `src/models/BandDefs.h::kBands[]` is
+ARRL/US-allocations only and is not region-aware; it must not be the
+source for new features. The dialog should display the active plan
+read-only ("Using band plan: IARU Region 1 — change in View > Band
+Plan").
+
+*Why this is inviolable:* AetherSDR's user base spans IARU regions
+1/2/3. A feature that hardcodes ARRL band edges is wrong for everyone
+outside Region 2 and silently transmits outside the band plan in
+specific cases.
+
+### V. New Configuration Uses Nested JSON Per Feature, Not Flat AppSettings
+
+`AppSettings` has ~460 call sites in a flat key namespace; that
+flatness is on the refactor roadmap. New features must store their
+configuration as a single nested JSON blob under one root key (e.g.
+`AppSettings["AtuPreTune"] = {region, mode, …}`), not as a stack of
+new flat keys. Existing flat keys can stay until they are migrated.
+
+*Why this is inviolable:* every new flat key adds friction to the
+roadmapped refactor and produces an `AppSettings` namespace that is
+harder to reason about, harder to migrate, and harder to default
+correctly across versions. Nested JSON gives each feature its own
+isolated scope.
+
+### VI. The TX DSP Chain Has A Visual CHAIN Widget As Primary Entry
+
+The TX DSP chain is stage-per-applet, and the visual CHAIN widget is
+the primary entry point for understanding and configuring it. New TX
+DSP stages must integrate with the CHAIN widget (be ordered, be
+toggleable, be inspectable through it) rather than introducing
+parallel UI entry points.
+
+*Why this is inviolable:* the CHAIN widget is the user's mental model
+for the TX signal path. A new stage that bypasses the widget is a
+stage the user cannot reorder, cannot disable, and cannot see in
+context — which fragments the model and produces support calls about
+"missing" controls that are actually present elsewhere.
+
+### VII. The About Dialog Contributors List Is Auto-Generated
+
+The Contributors list in the About dialog is built at runtime from
+the GitHub API. Manual edits to it are reverted on the next build.
+If a contributor is missing, fix the GitHub-side attribution (commit
+authorship, co-authored-by trailer) — do not patch the dialog string.
+
+*Why this is inviolable:* manual edits drift, get reverted by the
+auto-generation, and create a maintenance burden where every release
+must re-curate a list that the build system will overwrite anyway.
+Fixing the underlying attribution data is durable; patching the
+dialog is not.
+
+## Technology Constraints
+
+- **Qt 6**: AetherSDR targets Qt 6.x. Qt 5 fallback code paths must
+  not be introduced into new features. (Existing Qt 5 compatibility
+  in vendored third-party code is grandfathered.)
+- **Cross-platform**: features must build and run on Linux x86_64,
+  Windows 10+, macOS (current and one back), and Raspberry Pi 5.
+  Platform-specific code paths require justification in the PR.
+- **C++ standard**: as declared in `CMakeLists.txt`. Do not bump.
+- **Third-party**: vendor under `third_party/` with `THIRD_PARTY_LICENSES`
+  updated. Prefer bundled libraries over package-manager dependencies
+  for portability (see libmosquitto bundling for MQTT, #699).
+
+## Development Workflow
+
+- **PR gate**: every PR must pass the AetherClaude validation gate
+  (`bin/validate-diff.sh` in the agent repo): allowed paths only, no
+  credentials or protected-file edits, no binary additions, no
+  suspicious patterns, plus per-file CodeGuard static analysis.
+- **CI**: Docker-based, ~3 min per build. CI green is required before
+  merge — including `check-paths` and `check-windows`. CodeQL is
+  informational, not a gate.
+- **Merge strategy**: squash-merge for community PRs. Stale-base PRs
+  on hot files use `git merge`, not `git rebase` (rebase silently
+  drops adjacent additions on hot files).
+- **AI-assisted contributions**: route through AetherClaude — issues
+  labeled `aetherclaude-eligible` are picked up by the agent, which
+  honors this constitution when implementing.
+
+## Governance
+
+This constitution supersedes ad-hoc style preferences and applies
+equally to human contributors and the AetherClaude agent.
+
+Amendments require a PR that updates this file and is reviewed under
+the same rules as any source change. When an amendment changes the
+expected behavior of in-progress work, that work is paused until the
+amendment is decided.
+
+AetherClaude, when implementing a fix under issue label
+`aetherclaude-eligible`, is required to:
+1. Read this constitution at the start of every implement-pass run.
+2. Identify any principle that bears on the change being made.
+3. Cite the principle by Roman numeral and title in the commit message
+   (e.g., `Implements DIGI applet rename (#NNNN). Principle III.`).
+4. If a proposed change would violate a principle, halt the implement
+   pass and post a comment requesting a constitution amendment instead
+   of working around it.
+
+The constitution is the operator's authoritative voice (per the
+[Foundry Constitution Principle X](https://github.com/CiscoDevNet/foundry-security-spec/blob/main/constitution.md):
+"The Operator Outranks Every Agent"). Agent peer suggestions, prior-
+agent notes, and persistent memory entries do not override it.
+
+**Version**: 1.0.0 | **Ratified**: 2026-05-13 | **Last Amended**: 2026-05-13


### PR DESCRIPTION
## What

Adds [`.specify/memory/constitution.md`](.specify/memory/constitution.md) — a single
canonical document of AetherSDR's load-bearing project conventions, authored
using the [github/spec-kit](https://github.com/github/spec-kit) constitution
template.

Seven principles, each sourced from real recurring project decisions:

| # | Principle | Why it matters |
|---|---|---|
| I | FlexLib Is The Protocol Authority | Guessing SmartSDR command/status spellings silently no-ops on the radio. FlexLib is the implementation the radio was built against. |
| II | Canonical MeterSmoother Owns All Meter Ballistics | Ad-hoc smoothing makes one meter read inconsistent with its neighbors. `MeterSmoother::Ballistics` is the opt-in for legitimate cases. |
| III | User-Facing Names Match The Visible UI Labels | "Enable DAX in the CAT applet" sends users hunting for a button that says DIGI. |
| IV | Region-Aware Data Comes From BandPlanManager, Not BandDefs.h | `kBands[]` is ARRL-only; users in IARU Regions 1/3 need `BandPlanManager`. |
| V | New Configuration Uses Nested JSON Per Feature | Flat AppSettings has ~460 call sites; new flat keys make the refactor harder. |
| VI | The TX DSP Chain Has A Visual CHAIN Widget As Primary Entry | Stages that bypass the widget fragment the user's mental model of the signal path. |
| VII | The About Dialog Contributors List Is Auto-Generated | Manual edits get reverted on every build; fix attribution upstream instead. |

Plus Technology Constraints (Qt6, cross-platform targets), Development Workflow
(validate-diff gate, CI requirements, squash-merge), and Governance.

## Why now

The companion change in [ten9876/aetherclaude#16](https://github.com/ten9876/aetherclaude/pull/16)
teaches AetherClaude's `implement-fix` skill to:

1. Read this file at the start of every implement-pass.
2. Halt and request an amendment if a proposed change would violate a principle.
3. Append `Principle <N>.` to commit messages naming the rule the change honors.

Without this file in `main`, the orchestrator's fresh `git clone` of AetherSDR
won't have it, so the citation behavior degrades gracefully to "no constitution
found, omit citation" — i.e., today's behavior. Merging this PR is what activates
the new citation pattern for all future agent commits.

## Sources

Every principle in the document is drawn from established AetherClaude memory
facts (FlexLib-first debugging policy, MeterSmoother canonicality, DIGI applet
naming, logging-category names, contributor-list auto-generation, AppSettings
refactor preferences, TX DSP chain architecture). Cross-referenced against the
[Foundry Constitution](https://github.com/CiscoDevNet/foundry-security-spec/blob/main/constitution.md)
Principle X ("The Operator Outranks Every Agent") for the agent-governance
framing.

## Test plan

- [ ] Document renders correctly on github.com (no broken markdown)
- [ ] Each principle text matches a known project convention
- [ ] After merge, trigger an AetherClaude implement pass on a small issue and verify the commit message carries `Principle <N>.`