### PR TITLE
[feature] Implement FlexRadio profile import/export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,17 @@ jobs:
         with:
           arch: x64
 
+      - name: Install zlib via vcpkg
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
+          $triplet = "x64-windows"
+          & "$vcpkgRoot\vcpkg.exe" install "zlib:$triplet"
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "VCPKG_TARGET_TRIPLET=$triplet" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "CMAKE_TOOLCHAIN_FILE=$vcpkgRoot\scripts\buildsystems\vcpkg.cmake" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       # Verify sccache can actually compile through the backend.  GitHub
       # Actions Cache occasionally has outages; when that happens, sccache's
       # GHA backend can't read/write and every compile through sccache
@@ -128,7 +139,9 @@ jobs:
           $cargs = @(
             "-B","build","-G","Ninja",
             "-DCMAKE_BUILD_TYPE=Release",
-            "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded"
+            "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded",
+            "-DCMAKE_TOOLCHAIN_FILE=$env:CMAKE_TOOLCHAIN_FILE",
+            "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TARGET_TRIPLET"
           )
           if ($launcher) {
             $cargs += "-DCMAKE_C_COMPILER_LAUNCHER=sccache"

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -31,6 +31,16 @@ jobs:
       - name: Install Ninja, Inno Setup, and LLVM
         run: choco install ninja innosetup llvm -y
 
+      - name: Install zlib via vcpkg
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          if (-not $vcpkgRoot) { $vcpkgRoot = "C:\vcpkg" }
+          $triplet = "x64-windows"
+          & "$vcpkgRoot\vcpkg.exe" install "zlib:$triplet"
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "VCPKG_TARGET_TRIPLET=$triplet" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "CMAKE_TOOLCHAIN_FILE=$vcpkgRoot\scripts\buildsystems\vcpkg.cmake" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       # Each third-party dep is cached against the hash of its setup
       # script (which pins the version), so cache invalidates the moment
       # we bump a version.  Skips the upstream download + build entirely
@@ -81,7 +91,7 @@ jobs:
 
       - name: Configure
         run: |
-          cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DMQTT_TLS=OFF
+          cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DMQTT_TLS=OFF -DCMAKE_TOOLCHAIN_FILE="$env:CMAKE_TOOLCHAIN_FILE" -DVCPKG_TARGET_TRIPLET="$env:VCPKG_TARGET_TRIPLET"
 
       - name: Build Opus (RADE dependency)
         # ExternalProject dependency ordering via BUILD_BYPRODUCTS is correct,
@@ -105,6 +115,10 @@ jobs:
           }
           if (Test-Path "third_party\hidapi\bin\hidapi.dll") {
             copy third_party\hidapi\bin\hidapi.dll deploy\
+          }
+          $zlibBin = Join-Path $env:VCPKG_ROOT "installed\$env:VCPKG_TARGET_TRIPLET\bin"
+          if (Test-Path $zlibBin) {
+            Get-ChildItem $zlibBin -Filter "zlib*.dll" | Copy-Item -Destination deploy\ -Force
           }
           if (Test-Path "third_party\deepfilter\lib\windows-x86_64\deepfilter.dll") {
             copy third_party\deepfilter\lib\windows-x86_64\deepfilter.dll deploy\

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ find_package(Qt6 6.2 REQUIRED COMPONENTS
     Multimedia
     Test
 )
+find_package(ZLIB REQUIRED)
 option(REQUIRE_SERIALPORT "Fail if Qt6 SerialPort is not found (use for release builds)" OFF)
 # Note: on Windows the SerialPortController uses raw Win32 WaitCommEvent for
 # DSR/CTS edge detection (FTDI VCP drivers don't refresh
@@ -460,6 +461,7 @@ set(CORE_SOURCES
     src/core/PgxlConnection.cpp
     src/core/FirmwareUploader.cpp
     src/core/DvkWavTransfer.cpp
+    src/core/ProfileTransfer.cpp
     src/core/QsoRecorder.cpp
     src/core/FirmwareStager.cpp
     src/core/OleCompoundFile.cpp
@@ -562,6 +564,7 @@ set(GUI_SOURCES
     src/gui/AmpApplet.cpp
     src/gui/MeterApplet.cpp
     src/gui/ProfileManagerDialog.cpp
+    src/gui/ProfileImportExportDialog.cpp
     src/gui/PanadapterApplet.cpp
     src/gui/PanadapterStack.cpp
     src/gui/PanLayoutDialog.cpp
@@ -799,6 +802,7 @@ target_link_libraries(AetherSDR PRIVATE
     Qt6::Widgets
     Qt6::Network
     Qt6::Multimedia
+    ZLIB::ZLIB
     ${CMAKE_DL_LIBS}   # dlopen/dlsym for tolerant X11 error handler (#1839)
 )
 
@@ -1262,6 +1266,13 @@ target_include_directories(tx_mic_channel_normalizer_test PRIVATE
 )
 target_link_libraries(tx_mic_channel_normalizer_test PRIVATE Qt6::Core)
 add_test(NAME tx_mic_channel_normalizer_test COMMAND tx_mic_channel_normalizer_test)
+
+add_executable(profile_transfer_test
+    tests/profile_transfer_test.cpp
+)
+target_include_directories(profile_transfer_test PRIVATE src)
+target_link_libraries(profile_transfer_test PRIVATE Qt6::Core)
+add_test(NAME profile_transfer_test COMMAND profile_transfer_test)
 
 add_executable(client_gate_test
     tests/client_gate_test.cpp

--- a/docs/profile-import-export-manual-checklist.md
+++ b/docs/profile-import-export-manual-checklist.md
@@ -1,0 +1,17 @@
+# Profile Import/Export Manual Integration Checklist
+
+Use this checklist with real FlexRadio hardware before release because the
+database package transfer is radio-side behavior.
+
+- Export profiles-only from a FLEX-6000 v4.x radio and verify the resulting
+  `.ssdr_cfg` imports in SmartSDR for Windows.
+- Export a `.ssdr_cfg` package from SmartSDR for Windows and import it into
+  AetherSDR.
+- Import a package containing same-name profiles and confirm the destructive
+  replacement warning appears before upload.
+- Export on older firmware if available, especially v2.x and v3.x.
+- Cancel an active export and confirm no partial `.ssdr_cfg` is committed.
+- Force a failed import upload and confirm the UI reports failure rather than
+  success, then refreshes profile lists when the radio recovers.
+- Try SmartLink/WAN and confirm unsupported transfer directions are disabled
+  with a clear explanation.

--- a/resources/help/aethersdr-help.md
+++ b/resources/help/aethersdr-help.md
@@ -64,7 +64,9 @@ This is the operational configuration menu. It contains most dialogs that affect
 This menu manages operating profiles.
 
 - `Profile Manager...` is the main profile dialog.
-- `Import/Export Profiles...` is reserved for profile transfer workflows.
+- `Import/Export Profiles...` creates and restores SmartSDR-compatible `.ssdr_cfg` radio database packages. Export defaults to Global, TX, and MIC profiles, with optional Memories, Preferences, TNF, XVTR, and USB Cables. Import can replace same-name profiles, including defaults; export a backup first before restoring a package.
+- `.ssdr_cfg` packages are firmware-sensitive. Avoid importing packages from newer firmware into older radio firmware. Packages that include Preferences may close or reopen slices, panadapters, and other persisted radio resources.
+- Profile database transfer requires a direct LAN connection in this build; SmartLink/WAN import/export is disabled with an explanatory message.
 - Below the separator, global profiles are listed dynamically and can be loaded directly.
 
 ### `View`

--- a/src/core/ProfileTransfer.cpp
+++ b/src/core/ProfileTransfer.cpp
@@ -1,0 +1,998 @@
+#include "ProfileTransfer.h"
+
+#include "LogManager.h"
+#include "../models/MemoryEntry.h"
+#include "../models/RadioModel.h"
+#include "../models/TransmitModel.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QHostAddress>
+#include <QMap>
+#include <QSaveFile>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QTimer>
+#include <QSet>
+
+#include <zlib.h>
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+namespace {
+
+struct ZipEntryData {
+    QString name;
+    QByteArray data;
+};
+
+quint16 readLe16(const QByteArray& bytes, qsizetype offset)
+{
+    if (offset < 0 || offset + 2 > bytes.size())
+        return 0;
+    const auto* p = reinterpret_cast<const uchar*>(bytes.constData() + offset);
+    return quint16(p[0]) | (quint16(p[1]) << 8);
+}
+
+quint32 readLe32(const QByteArray& bytes, qsizetype offset)
+{
+    if (offset < 0 || offset + 4 > bytes.size())
+        return 0;
+    const auto* p = reinterpret_cast<const uchar*>(bytes.constData() + offset);
+    return quint32(p[0]) | (quint32(p[1]) << 8) | (quint32(p[2]) << 16) | (quint32(p[3]) << 24);
+}
+
+void appendLe16(QByteArray& out, quint16 value)
+{
+    out.append(char(value & 0xff));
+    out.append(char((value >> 8) & 0xff));
+}
+
+void appendLe32(QByteArray& out, quint32 value)
+{
+    out.append(char(value & 0xff));
+    out.append(char((value >> 8) & 0xff));
+    out.append(char((value >> 16) & 0xff));
+    out.append(char((value >> 24) & 0xff));
+}
+
+bool inflateRawDeflate(const QByteArray& compressed, qsizetype expectedSize,
+                       QByteArray* out, QString* error)
+{
+    if (expectedSize < 0) {
+        *error = QStringLiteral("Invalid ZIP entry size.");
+        return false;
+    }
+
+    out->resize(expectedSize);
+    z_stream stream{};
+    stream.next_in = reinterpret_cast<Bytef*>(const_cast<char*>(compressed.constData()));
+    stream.avail_in = static_cast<uInt>(compressed.size());
+    stream.next_out = reinterpret_cast<Bytef*>(out->data());
+    stream.avail_out = static_cast<uInt>(out->size());
+
+    int rc = inflateInit2(&stream, -MAX_WBITS);
+    if (rc != Z_OK) {
+        *error = QStringLiteral("Could not initialize ZIP inflater.");
+        return false;
+    }
+
+    rc = inflate(&stream, Z_FINISH);
+    inflateEnd(&stream);
+    if (rc != Z_STREAM_END || stream.total_out != static_cast<uLong>(expectedSize)) {
+        *error = QStringLiteral("Could not decompress ZIP entry.");
+        return false;
+    }
+    return true;
+}
+
+QMap<QString, QByteArray> readZipEntries(const QByteArray& zip, QString* error)
+{
+    QMap<QString, QByteArray> entries;
+    if (zip.size() < 22 || !zip.startsWith("PK")) {
+        *error = QStringLiteral("Package is not a ZIP-format .ssdr_cfg file.");
+        return entries;
+    }
+
+    const qsizetype minEocd = 22;
+    const qsizetype searchStart = std::max<qsizetype>(0, zip.size() - 65557);
+    qsizetype eocd = -1;
+    for (qsizetype i = zip.size() - minEocd; i >= searchStart; --i) {
+        if (readLe32(zip, i) == 0x06054b50) {
+            eocd = i;
+            break;
+        }
+        if (i == 0)
+            break;
+    }
+    if (eocd < 0) {
+        *error = QStringLiteral("Could not find ZIP central directory.");
+        return entries;
+    }
+
+    const quint16 entryCount = readLe16(zip, eocd + 10);
+    const quint32 centralDirSize = readLe32(zip, eocd + 12);
+    const quint32 centralDirOffset = readLe32(zip, eocd + 16);
+    if (centralDirOffset + centralDirSize > quint32(zip.size())) {
+        *error = QStringLiteral("ZIP central directory is outside the package.");
+        return entries;
+    }
+
+    qsizetype offset = centralDirOffset;
+    for (quint16 i = 0; i < entryCount; ++i) {
+        if (offset + 46 > zip.size() || readLe32(zip, offset) != 0x02014b50) {
+            *error = QStringLiteral("Invalid ZIP central directory entry.");
+            entries.clear();
+            return entries;
+        }
+
+        const quint16 method = readLe16(zip, offset + 10);
+        const quint32 expectedCrc = readLe32(zip, offset + 16);
+        const quint32 compressedSize = readLe32(zip, offset + 20);
+        const quint32 uncompressedSize = readLe32(zip, offset + 24);
+        const quint16 nameLen = readLe16(zip, offset + 28);
+        const quint16 extraLen = readLe16(zip, offset + 30);
+        const quint16 commentLen = readLe16(zip, offset + 32);
+        const quint32 localOffset = readLe32(zip, offset + 42);
+
+        if (offset + 46 + nameLen + extraLen + commentLen > zip.size()
+            || localOffset + 30 > quint32(zip.size())
+            || readLe32(zip, localOffset) != 0x04034b50) {
+            *error = QStringLiteral("Invalid ZIP entry header.");
+            entries.clear();
+            return entries;
+        }
+
+        const QString name = QString::fromUtf8(zip.constData() + offset + 46, nameLen);
+        const quint16 localNameLen = readLe16(zip, localOffset + 26);
+        const quint16 localExtraLen = readLe16(zip, localOffset + 28);
+        const quint32 dataOffset = localOffset + 30 + localNameLen + localExtraLen;
+        if (dataOffset + compressedSize > quint32(zip.size())) {
+            *error = QStringLiteral("ZIP entry data is outside the package.");
+            entries.clear();
+            return entries;
+        }
+
+        const QByteArray compressed = zip.mid(dataOffset, compressedSize);
+        QByteArray data;
+        if (method == 0) {
+            data = compressed;
+        } else if (method == 8) {
+            if (!inflateRawDeflate(compressed, uncompressedSize, &data, error)) {
+                entries.clear();
+                return entries;
+            }
+        } else {
+            *error = QStringLiteral("Unsupported ZIP compression method %1.").arg(method);
+            entries.clear();
+            return entries;
+        }
+
+        const quint32 actualCrc = crc32(0L, reinterpret_cast<const Bytef*>(data.constData()), data.size());
+        if (actualCrc != expectedCrc) {
+            *error = QStringLiteral("ZIP entry checksum mismatch.");
+            entries.clear();
+            return entries;
+        }
+
+        entries.insert(name, data);
+        offset += 46 + nameLen + extraLen + commentLen;
+    }
+
+    return entries;
+}
+
+QByteArray writeStoredZip(const QList<ZipEntryData>& entries)
+{
+    QByteArray out;
+    QByteArray centralDir;
+    for (const ZipEntryData& entry : entries) {
+        const QByteArray name = entry.name.toUtf8();
+        const QByteArray& data = entry.data;
+        const quint32 localOffset = out.size();
+        const quint32 checksum = crc32(0L, reinterpret_cast<const Bytef*>(data.constData()), data.size());
+
+        appendLe32(out, 0x04034b50);
+        appendLe16(out, 20);
+        appendLe16(out, 0);
+        appendLe16(out, 0);
+        appendLe16(out, 0);
+        appendLe16(out, 0);
+        appendLe32(out, checksum);
+        appendLe32(out, data.size());
+        appendLe32(out, data.size());
+        appendLe16(out, name.size());
+        appendLe16(out, 0);
+        out += name;
+        out += data;
+
+        appendLe32(centralDir, 0x02014b50);
+        appendLe16(centralDir, 20);
+        appendLe16(centralDir, 20);
+        appendLe16(centralDir, 0);
+        appendLe16(centralDir, 0);
+        appendLe16(centralDir, 0);
+        appendLe16(centralDir, 0);
+        appendLe32(centralDir, checksum);
+        appendLe32(centralDir, data.size());
+        appendLe32(centralDir, data.size());
+        appendLe16(centralDir, name.size());
+        appendLe16(centralDir, 0);
+        appendLe16(centralDir, 0);
+        appendLe16(centralDir, 0);
+        appendLe16(centralDir, 0);
+        appendLe32(centralDir, 0);
+        appendLe32(centralDir, localOffset);
+        centralDir += name;
+    }
+
+    const quint32 centralDirOffset = out.size();
+    out += centralDir;
+    appendLe32(out, 0x06054b50);
+    appendLe16(out, 0);
+    appendLe16(out, 0);
+    appendLe16(out, entries.size());
+    appendLe16(out, entries.size());
+    appendLe32(out, centralDir.size());
+    appendLe32(out, centralDirOffset);
+    appendLe16(out, 0);
+    return out;
+}
+
+QByteArray prepareDatabaseImportPayload(const QByteArray& ssdrCfg, bool* repackaged,
+                                        QString* error)
+{
+    *repackaged = false;
+    const QMap<QString, QByteArray> entries = readZipEntries(ssdrCfg, error);
+    if (entries.isEmpty())
+        return {};
+
+    const QByteArray flexPayload = entries.value(QStringLiteral("flex_payload"));
+    const QByteArray metaData = entries.value(QStringLiteral("meta_data"));
+    const QByteArray metaSubset = entries.value(QStringLiteral("meta_subset"));
+
+    if (flexPayload.isEmpty()) {
+        *error = QStringLiteral("The .ssdr_cfg package does not contain flex_payload.");
+        return {};
+    }
+    if (!metaSubset.isEmpty())
+        return ssdrCfg;
+    if (metaData.isEmpty()) {
+        *error = QStringLiteral("The .ssdr_cfg package does not contain meta_data.");
+        return {};
+    }
+
+    *repackaged = true;
+    return writeStoredZip({
+        {QStringLiteral("meta_subset"), metaData},
+        {QStringLiteral("flex_payload"), flexPayload},
+    });
+}
+
+} // namespace
+
+ProfileTransfer::ProfileTransfer(RadioModel* model, QObject* parent)
+    : QObject(parent), m_model(model)
+{
+    m_timeout = new QTimer(this);
+    m_timeout->setSingleShot(true);
+    connect(m_timeout, &QTimer::timeout, this, &ProfileTransfer::handleTimeout);
+
+    m_idleTimer = new QTimer(this);
+    m_idleTimer->setSingleShot(true);
+    connect(m_idleTimer, &QTimer::timeout, this, [this] {
+        if (!m_busy)
+            return;
+        fail(QStringLiteral("Transfer timed out while waiting for data."));
+    });
+
+    m_overallTimer = new QTimer(this);
+    m_overallTimer->setSingleShot(true);
+    connect(m_overallTimer, &QTimer::timeout, this, [this] {
+        if (!m_busy)
+            return;
+        fail(QStringLiteral("Profile database transfer timed out."));
+    });
+
+    if (m_model) {
+        connect(m_model, &RadioModel::profileDatabaseImportingChanged, this, [this](bool importing) {
+            if (m_phase == Phase::WaitingForImport && !importing)
+                scheduleImportCompletion();
+        });
+    }
+}
+
+ProfileTransfer::~ProfileTransfer()
+{
+    if (m_busy)
+        cleanup();
+}
+
+void ProfileTransfer::exportDatabase(const ExportSelection& selection, const QString& destinationPath)
+{
+    QString error;
+    if (!validateCommonPreconditions(Operation::ExportDatabase, &error)) {
+        emit failed(Operation::ExportDatabase, error);
+        return;
+    }
+    if (!validateExportDestination(destinationPath, &error)) {
+        emit failed(Operation::ExportDatabase, error);
+        return;
+    }
+
+    ExportSelection expanded = expandSelection(selection);
+    if (!validateExportSelection(expanded, &error)) {
+        emit failed(Operation::ExportDatabase, error);
+        return;
+    }
+
+    const QByteArray metaSubset = buildMetaSubset(expanded);
+    if (metaSubset.isEmpty()) {
+        emit failed(Operation::ExportDatabase,
+                    QStringLiteral("Profile export selection produced an empty SmartSDR meta_subset file."));
+        return;
+    }
+
+    begin(Operation::ExportDatabase, Phase::UploadMetaSubset);
+    m_path = destinationPath;
+
+    qCInfo(lcProtocol).noquote()
+        << "ProfileTransfer: export requested"
+        << QStringLiteral("meta_subset_bytes=%1").arg(metaSubset.size());
+    emit progress(QStringLiteral("Sending export selection to radio..."), 0, metaSubset.size());
+    requestUploadPort(metaSubset, QStringLiteral("db_meta_subset"));
+}
+
+void ProfileTransfer::importDatabase(const QString& ssdrCfgPath)
+{
+    QString error;
+    if (!validateCommonPreconditions(Operation::ImportDatabase, &error)) {
+        emit failed(Operation::ImportDatabase, error);
+        return;
+    }
+    if (!validateImportFile(ssdrCfgPath, &error)) {
+        emit failed(Operation::ImportDatabase, error);
+        return;
+    }
+
+    QFile file(ssdrCfgPath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        emit failed(Operation::ImportDatabase,
+                    QStringLiteral("Cannot open import package: %1").arg(file.errorString()));
+        return;
+    }
+    const QByteArray payload = file.readAll();
+    if (payload.size() != file.size()) {
+        emit failed(Operation::ImportDatabase,
+                    QStringLiteral("Could not read the complete .ssdr_cfg package."));
+        return;
+    }
+    bool repackaged = false;
+    const QByteArray importPayload = prepareDatabaseImportPayload(payload, &repackaged, &error);
+    if (importPayload.isEmpty()) {
+        emit failed(Operation::ImportDatabase, error);
+        return;
+    }
+
+    begin(Operation::ImportDatabase, Phase::UploadImport);
+    m_path = ssdrCfgPath;
+
+    qCInfo(lcProtocol).noquote()
+        << "ProfileTransfer: import requested"
+        << QStringLiteral("package_bytes=%1").arg(payload.size())
+        << QStringLiteral("upload_bytes=%1").arg(importPayload.size())
+        << QStringLiteral("repackaged=%1").arg(repackaged ? 1 : 0);
+    emit progress(QStringLiteral("Requesting database import upload port..."), 0, importPayload.size());
+    requestUploadPort(importPayload, QStringLiteral("db_import"));
+}
+
+void ProfileTransfer::cancel()
+{
+    if (!m_busy)
+        return;
+
+    m_cancelled = true;
+    const Operation op = m_operation;
+    qCInfo(lcProtocol) << "ProfileTransfer: cancelled";
+    cleanup();
+    emit failed(op, QStringLiteral("Profile transfer cancelled."));
+}
+
+void ProfileTransfer::begin(Operation operation, Phase phase)
+{
+    m_operation = operation;
+    m_phase = phase;
+    m_busy = true;
+    m_cancelled = false;
+    m_usedFallbackPort = false;
+    m_downloadFinalized = false;
+    m_importCompletionScheduled = false;
+    m_bytesDone = 0;
+    m_bytesQueued = 0;
+    m_bytesTotal = 0;
+    m_uploadPort = 0;
+    m_overallTimer->start(kOverallTimeoutMs);
+    emit started(operation);
+}
+
+void ProfileTransfer::fail(const QString& error)
+{
+    if (!m_busy && !m_cancelled)
+        return;
+
+    const Operation op = m_operation;
+    qCWarning(lcProtocol) << "ProfileTransfer failed:" << error;
+    cleanup();
+    emit failed(op, error);
+}
+
+void ProfileTransfer::finish(QString path)
+{
+    const Operation op = m_operation;
+    cleanup();
+    emit finished(op, path);
+}
+
+void ProfileTransfer::cleanup()
+{
+    m_timeout->stop();
+    m_idleTimer->stop();
+    m_overallTimer->stop();
+
+    if (m_socket) {
+        m_socket->abort();
+        m_socket->deleteLater();
+        m_socket = nullptr;
+    }
+    if (m_server) {
+        m_server->close();
+        m_server->deleteLater();
+        m_server = nullptr;
+    }
+    if (m_saveFile) {
+        m_saveFile->cancelWriting();
+        m_saveFile->deleteLater();
+        m_saveFile = nullptr;
+    }
+
+    m_uploadPayload.clear();
+    m_path.clear();
+    m_bytesDone = 0;
+    m_bytesQueued = 0;
+    m_bytesTotal = 0;
+    m_uploadPort = 0;
+    m_busy = false;
+    m_cancelled = false;
+    m_usedFallbackPort = false;
+    m_downloadFinalized = false;
+    m_importCompletionScheduled = false;
+    m_phase = Phase::Idle;
+}
+
+ExportSelection ProfileTransfer::expandSelection(ExportSelection selection) const
+{
+    if (!m_model)
+        return selection;
+
+    if (selection.globalProfiles && selection.globalProfileNames.isEmpty())
+        selection.globalProfileNames = m_model->globalProfiles();
+    if (selection.txProfiles && selection.txProfileNames.isEmpty())
+        selection.txProfileNames = m_model->transmitModel().profileList();
+    if (selection.micProfiles && selection.micProfileNames.isEmpty())
+        selection.micProfileNames = m_model->transmitModel().micProfileList();
+
+    if (selection.memories && selection.memoryGroups.isEmpty()) {
+        QSet<QString> seen;
+        for (auto it = m_model->memories().cbegin(); it != m_model->memories().cend(); ++it) {
+            const MemoryEntry& memory = it.value();
+            const QString key = memory.owner + QChar(0x1f) + memory.group;
+            if (seen.contains(key))
+                continue;
+            seen.insert(key);
+            selection.memoryGroups.append({memory.owner, memory.group});
+        }
+    }
+
+    return selection;
+}
+
+bool ProfileTransfer::validateCommonPreconditions(Operation operation, QString* error) const
+{
+    if (m_busy) {
+        *error = QStringLiteral("A profile transfer is already in progress.");
+        return false;
+    }
+    if (!m_model || !m_model->isConnected()) {
+        *error = QStringLiteral("Connect to a FlexRadio before importing or exporting profiles.");
+        return false;
+    }
+    if (m_model->isWan()) {
+        *error = operation == Operation::ExportDatabase
+            ? QStringLiteral("SmartLink/WAN profile export is not supported because the radio must connect back to this client for the database download.")
+            : QStringLiteral("SmartLink/WAN profile import is not enabled in this build; use a direct LAN connection for database transfers.");
+        return false;
+    }
+    if (m_model->isProfileTransferBlocked()) {
+        *error = QStringLiteral("Stop MOX, TUNE, PTT, or active transmit before importing or exporting radio profiles.");
+        return false;
+    }
+    if (m_model->radioAddress().isNull()) {
+        *error = QStringLiteral("The connected radio address is unavailable.");
+        return false;
+    }
+    return true;
+}
+
+bool ProfileTransfer::validateExportSelection(const ExportSelection& selection, QString* error) const
+{
+    if (!selection.anySelected()) {
+        *error = QStringLiteral("Select at least one radio database category to export.");
+        return false;
+    }
+    return true;
+}
+
+bool ProfileTransfer::validateExportDestination(const QString& path, QString* error) const
+{
+    const QFileInfo info(path);
+    if (path.trimmed().isEmpty()) {
+        *error = QStringLiteral("Choose a destination .ssdr_cfg file.");
+        return false;
+    }
+    if (info.suffix().compare(QStringLiteral("ssdr_cfg"), Qt::CaseInsensitive) != 0) {
+        *error = QStringLiteral("SmartSDR profile backups must use the .ssdr_cfg extension.");
+        return false;
+    }
+    const QDir dir = info.absoluteDir();
+    if (!dir.exists() && !QDir().mkpath(dir.absolutePath())) {
+        *error = QStringLiteral("Cannot create the export directory.");
+        return false;
+    }
+    return true;
+}
+
+bool ProfileTransfer::validateImportFile(const QString& path, QString* error) const
+{
+    const QFileInfo info(path);
+    if (!info.exists() || !info.isFile()) {
+        *error = QStringLiteral("Choose a readable .ssdr_cfg package to import.");
+        return false;
+    }
+    if (info.suffix().compare(QStringLiteral("ssdr_cfg"), Qt::CaseInsensitive) != 0) {
+        *error = QStringLiteral("Only SmartSDR .ssdr_cfg packages can be imported.");
+        return false;
+    }
+    if (info.size() <= 0) {
+        *error = QStringLiteral("The selected .ssdr_cfg package is empty.");
+        return false;
+    }
+    if (info.size() > kMaxImportSize) {
+        *error = QStringLiteral("The selected .ssdr_cfg package is larger than the safety limit.");
+        return false;
+    }
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        *error = QStringLiteral("Cannot read the import package: %1").arg(file.errorString());
+        return false;
+    }
+    return true;
+}
+
+void ProfileTransfer::requestUploadPort(const QByteArray& payload, const QString& uploadKind)
+{
+    m_uploadPayload = payload;
+    m_bytesDone = 0;
+    m_bytesQueued = 0;
+    m_bytesTotal = payload.size();
+    m_usedFallbackPort = false;
+
+    const QString command = QStringLiteral("file upload %1 %2").arg(payload.size()).arg(uploadKind);
+    qCInfo(lcProtocol).noquote()
+        << "ProfileTransfer: command"
+        << command;
+    m_timeout->start(kCommandTimeoutMs);
+    m_model->requestFileUploadPort(payload.size(), uploadKind,
+        [this](int code, const QString& body) {
+            onUploadPortReceived(code, body);
+        });
+}
+
+void ProfileTransfer::onUploadPortReceived(int code, const QString& body)
+{
+    if (m_cancelled || !m_busy)
+        return;
+
+    m_timeout->stop();
+    if (code != 0) {
+        fail(QStringLiteral("Radio rejected the file upload request (error 0x%1).")
+                 .arg(code, 0, 16));
+        return;
+    }
+
+    const auto parsedPort = parseTransferPort(body);
+    const quint16 port = parsedPort.value_or(kDefaultUploadPort);
+    connectUploadSocket(port);
+}
+
+void ProfileTransfer::connectUploadSocket(quint16 port)
+{
+    if (m_socket) {
+        m_socket->abort();
+        m_socket->deleteLater();
+        m_socket = nullptr;
+    }
+
+    m_uploadPort = port;
+    m_socket = new QTcpSocket(this);
+    connect(m_socket, &QTcpSocket::connected, this, &ProfileTransfer::onUploadConnected);
+    connect(m_socket, &QTcpSocket::bytesWritten, this, &ProfileTransfer::onUploadBytesWritten);
+    connect(m_socket, &QTcpSocket::disconnected, this, &ProfileTransfer::onUploadDisconnected);
+    connect(m_socket, &QTcpSocket::errorOccurred, this, [this] { onUploadError(); });
+
+    emit progress(QStringLiteral("Connecting to radio upload port %1...").arg(port),
+                  m_bytesDone, m_bytesTotal);
+    qCInfo(lcProtocol) << "ProfileTransfer: connecting to upload port" << port;
+
+    QTimer::singleShot(200, this, [this, port] {
+        if (!m_busy || m_cancelled || !m_socket)
+            return;
+        m_socket->connectToHost(m_model->radioAddress(), port);
+    });
+    m_timeout->start(kConnectTimeoutMs);
+}
+
+void ProfileTransfer::tryFallbackUploadPort()
+{
+    if (m_usedFallbackPort) {
+        fail(QStringLiteral("Cannot connect to the radio transfer port."));
+        return;
+    }
+    m_usedFallbackPort = true;
+    emit progress(QStringLiteral("Trying fallback transfer port %1...").arg(kFallbackTransferPort),
+                  m_bytesDone, m_bytesTotal);
+    connectUploadSocket(kFallbackTransferPort);
+}
+
+void ProfileTransfer::onUploadConnected()
+{
+    if (m_cancelled || !m_busy)
+        return;
+
+    m_timeout->stop();
+    resetIdleTimer();
+    emit progress(m_phase == Phase::UploadMetaSubset
+                      ? QStringLiteral("Uploading export selection...")
+                      : QStringLiteral("Uploading SmartSDR database package..."),
+                  m_bytesDone, m_bytesTotal);
+    sendNextUploadChunk();
+}
+
+void ProfileTransfer::sendNextUploadChunk()
+{
+    if (!m_socket || m_cancelled)
+        return;
+
+    const qint64 remaining = m_uploadPayload.size() - m_bytesQueued;
+    if (remaining <= 0)
+        return;
+
+    const qint64 toSend = qMin<qint64>(kUploadChunkSize, remaining);
+    const qint64 written = m_socket->write(m_uploadPayload.constData() + m_bytesQueued, toSend);
+    if (written < 0)
+        onUploadError();
+    else
+        m_bytesQueued += written;
+}
+
+void ProfileTransfer::onUploadBytesWritten(qint64 bytes)
+{
+    if (m_cancelled || !m_busy)
+        return;
+
+    resetIdleTimer();
+    m_bytesDone += bytes;
+    emit progress(m_phase == Phase::UploadMetaSubset
+                      ? QStringLiteral("Uploading export selection...")
+                      : QStringLiteral("Uploading SmartSDR database package..."),
+                  m_bytesDone, m_bytesTotal);
+
+    if (m_bytesDone >= m_bytesTotal) {
+        qCInfo(lcProtocol) << "ProfileTransfer: upload complete" << m_bytesDone << "bytes";
+        m_idleTimer->stop();
+        m_socket->flush();
+        m_socket->disconnectFromHost();
+        return;
+    }
+
+    if (m_bytesQueued < m_bytesTotal)
+        sendNextUploadChunk();
+}
+
+void ProfileTransfer::onUploadDisconnected()
+{
+    if (m_cancelled || !m_busy)
+        return;
+
+    if (m_bytesDone < m_bytesTotal) {
+        fail(QStringLiteral("Radio closed the upload connection before the transfer completed."));
+        return;
+    }
+
+    if (m_socket) {
+        m_socket->deleteLater();
+        m_socket = nullptr;
+    }
+    m_uploadPayload.clear();
+
+    if (m_phase == Phase::UploadMetaSubset) {
+        emit progress(QStringLiteral("Waiting for the radio to prepare the database package..."), 0, 0);
+        QTimer::singleShot(kMetaSubsetSettleMs, this, [this] {
+            if (!m_busy || m_cancelled)
+                return;
+            requestPackageDownload();
+        });
+        return;
+    }
+
+    if (m_phase == Phase::UploadImport) {
+        waitForImportCompletion();
+        return;
+    }
+}
+
+void ProfileTransfer::onUploadError()
+{
+    if (m_cancelled || !m_busy)
+        return;
+
+    if (m_bytesDone == 0 && m_uploadPort != kFallbackTransferPort) {
+        tryFallbackUploadPort();
+        return;
+    }
+
+    const QString err = m_socket ? m_socket->errorString() : QStringLiteral("Unknown socket error");
+    fail(QStringLiteral("Upload failed: %1").arg(err));
+}
+
+void ProfileTransfer::requestPackageDownload()
+{
+    if (!m_busy)
+        return;
+
+    m_phase = Phase::DownloadPackage;
+    m_bytesDone = 0;
+    m_bytesTotal = 0;
+    emit progress(QStringLiteral("Requesting SmartSDR database package..."), 0, 0);
+    qCInfo(lcProtocol) << "ProfileTransfer: command file download db_package";
+
+    m_timeout->start(kCommandTimeoutMs);
+    m_model->requestFileDownloadPort(QStringLiteral("db_package"),
+        [this](int code, const QString& body) {
+            onDownloadPortReceived(code, body);
+        });
+}
+
+void ProfileTransfer::onDownloadPortReceived(int code, const QString& body)
+{
+    if (m_cancelled || !m_busy)
+        return;
+
+    m_timeout->stop();
+    if (code != 0) {
+        fail(QStringLiteral("Radio rejected the database download request (error 0x%1).")
+                 .arg(code, 0, 16));
+        return;
+    }
+
+    const auto parsedPort = parseTransferPort(body);
+    const quint16 port = parsedPort.value_or(kFallbackTransferPort);
+    startDownloadServer(port);
+}
+
+void ProfileTransfer::startDownloadServer(quint16 port)
+{
+    QString error;
+    if (!validateExportDestination(m_path, &error)) {
+        fail(error);
+        return;
+    }
+
+    m_saveFile = new QSaveFile(m_path, this);
+    if (!m_saveFile->open(QIODevice::WriteOnly)) {
+        fail(QStringLiteral("Cannot create export file: %1").arg(m_saveFile->errorString()));
+        return;
+    }
+
+    m_server = new QTcpServer(this);
+    connect(m_server, &QTcpServer::newConnection, this, &ProfileTransfer::onDownloadConnection);
+    if (!m_server->listen(QHostAddress::Any, port)) {
+        fail(QStringLiteral("Cannot listen for the radio database download on port %1: %2")
+                 .arg(port)
+                 .arg(m_server->errorString()));
+        return;
+    }
+
+    qCInfo(lcProtocol) << "ProfileTransfer: listening for database package on port" << port;
+    emit progress(QStringLiteral("Waiting for radio database download on port %1...").arg(port), 0, 0);
+    m_timeout->start(kConnectTimeoutMs);
+}
+
+void ProfileTransfer::onDownloadConnection()
+{
+    if (m_cancelled || !m_busy)
+        return;
+
+    m_timeout->stop();
+    m_socket = m_server->nextPendingConnection();
+    if (!m_socket)
+        return;
+    m_server->close();
+
+    connect(m_socket, &QTcpSocket::readyRead, this, &ProfileTransfer::onDownloadReadyRead);
+    connect(m_socket, &QTcpSocket::disconnected, this, &ProfileTransfer::onDownloadDisconnected);
+    connect(m_socket, &QTcpSocket::errorOccurred, this, [this] { onDownloadError(); });
+
+    resetIdleTimer();
+    emit progress(QStringLiteral("Receiving SmartSDR database package..."), 0, 0);
+}
+
+void ProfileTransfer::onDownloadReadyRead()
+{
+    if (m_cancelled || !m_saveFile || !m_socket)
+        return;
+
+    resetIdleTimer();
+    const QByteArray chunk = m_socket->readAll();
+    if (chunk.isEmpty())
+        return;
+
+    const qint64 written = m_saveFile->write(chunk);
+    if (written != chunk.size()) {
+        fail(QStringLiteral("Could not write the complete export package: %1")
+                 .arg(m_saveFile->errorString()));
+        return;
+    }
+    m_bytesDone += written;
+    emit progress(QStringLiteral("Receiving SmartSDR database package..."), m_bytesDone, 0);
+}
+
+void ProfileTransfer::onDownloadDisconnected()
+{
+    if (m_cancelled || !m_busy || m_downloadFinalized)
+        return;
+
+    m_downloadFinalized = true;
+    m_idleTimer->stop();
+    if (m_bytesDone <= 0) {
+        fail(QStringLiteral("Radio sent an empty database package."));
+        return;
+    }
+
+    QString error;
+    if (!commitExportFile(&error)) {
+        fail(error);
+        return;
+    }
+
+    qCInfo(lcProtocol) << "ProfileTransfer: export complete" << m_bytesDone << "bytes";
+    emit progress(QStringLiteral("Export complete."), m_bytesDone, m_bytesDone);
+    const QString finishedPath = m_path;
+    finish(finishedPath);
+}
+
+void ProfileTransfer::onDownloadError()
+{
+    if (m_cancelled || !m_busy)
+        return;
+
+    if (m_socket && m_socket->error() == QAbstractSocket::RemoteHostClosedError && m_bytesDone > 0) {
+        onDownloadDisconnected();
+        return;
+    }
+
+    const QString err = m_socket ? m_socket->errorString() : QStringLiteral("Unknown socket error");
+    fail(QStringLiteral("Database download failed: %1").arg(err));
+}
+
+void ProfileTransfer::waitForImportCompletion()
+{
+    m_phase = Phase::WaitingForImport;
+    m_idleTimer->stop();
+    emit progress(QStringLiteral("Import sent; waiting for radio to apply the database..."),
+                  m_bytesDone, m_bytesTotal);
+
+    if (m_model && m_model->profileDatabaseImporting()) {
+        m_timeout->start(kOverallTimeoutMs / 2);
+        return;
+    }
+
+    scheduleImportCompletion();
+}
+
+void ProfileTransfer::scheduleImportCompletion()
+{
+    if (!m_busy || m_importCompletionScheduled)
+        return;
+
+    m_importCompletionScheduled = true;
+    m_timeout->stop();
+    QTimer::singleShot(kImportSettleMs, this, [this] {
+        if (!m_busy || m_cancelled)
+            return;
+        completeImport();
+    });
+}
+
+void ProfileTransfer::completeImport()
+{
+    if (!m_busy)
+        return;
+
+    m_timeout->stop();
+    if (m_model)
+        m_model->refreshProfiles();
+    emit progress(QStringLiteral("Import complete. Refreshing profile lists..."),
+                  m_bytesTotal, m_bytesTotal);
+    finish(m_path);
+}
+
+void ProfileTransfer::resetIdleTimer()
+{
+    if (m_idleTimer)
+        m_idleTimer->start(kIdleTimeoutMs);
+}
+
+void ProfileTransfer::handleTimeout()
+{
+    if (!m_busy)
+        return;
+
+    switch (m_phase) {
+    case Phase::UploadMetaSubset:
+    case Phase::UploadImport:
+        if (!m_socket || m_socket->state() != QAbstractSocket::ConnectedState)
+            tryFallbackUploadPort();
+        else
+            fail(QStringLiteral("Timed out while uploading to the radio."));
+        break;
+    case Phase::DownloadPackage:
+        fail(QStringLiteral("Timed out waiting for the radio database download."));
+        break;
+    case Phase::WaitingForImport:
+        scheduleImportCompletion();
+        break;
+    case Phase::Idle:
+        break;
+    }
+}
+
+bool ProfileTransfer::commitExportFile(QString* error)
+{
+    if (!m_saveFile) {
+        *error = QStringLiteral("Export file is not open.");
+        return false;
+    }
+
+    if (!m_saveFile->commit()) {
+        *error = QStringLiteral("Could not finalize export package: %1").arg(m_saveFile->errorString());
+        return false;
+    }
+    m_saveFile->deleteLater();
+    m_saveFile = nullptr;
+
+    QFile file(m_path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        *error = QStringLiteral("Could not verify exported package.");
+        return false;
+    }
+    const QByteArray magic = file.read(4);
+    if (magic.size() >= 2 && magic.left(2) != "PK") {
+        qCWarning(lcProtocol) << "ProfileTransfer: exported package does not start with ZIP magic";
+    }
+    return true;
+}
+
+} // namespace AetherSDR

--- a/src/core/ProfileTransfer.h
+++ b/src/core/ProfileTransfer.h
@@ -1,0 +1,299 @@
+#pragma once
+
+#include <QObject>
+#include <QByteArray>
+#include <QList>
+#include <QRegularExpression>
+#include <QString>
+#include <QStringList>
+#include <QVersionNumber>
+
+#include <optional>
+
+class QFile;
+class QSaveFile;
+class QTcpServer;
+class QTcpSocket;
+class QTimer;
+
+namespace AetherSDR {
+
+class RadioModel;
+
+struct MemoryGroupSelection {
+    QString owner;
+    QString group;
+};
+
+struct ExportSelection {
+    bool globalProfiles{true};
+    bool txProfiles{true};
+    bool micProfiles{true};
+    bool memories{false};
+    bool preferences{false};
+    bool tnf{false};
+    bool xvtr{false};
+    bool usbCables{false};
+
+    QStringList globalProfileNames;
+    QStringList txProfileNames;
+    QStringList micProfileNames;
+    QList<MemoryGroupSelection> memoryGroups;
+
+    bool anySelected() const
+    {
+        return globalProfiles || txProfiles || micProfiles || memories
+            || preferences || tnf || xvtr || usbCables;
+    }
+};
+
+inline QString cleanMetaSubsetToken(QString token)
+{
+    token.replace(QLatin1Char('\r'), QLatin1Char(' '));
+    token.replace(QLatin1Char('\n'), QLatin1Char(' '));
+    token.replace(QLatin1Char('^'), QLatin1Char(' '));
+    return token.trimmed();
+}
+
+inline QString cleanMemoryToken(QString token)
+{
+    token = cleanMetaSubsetToken(std::move(token));
+    token.replace(QLatin1Char(' '), QChar(0x7f));
+    return token;
+}
+
+inline void appendProfileSubsetLine(QByteArray& out, const char* tag, const QStringList& names)
+{
+    out += tag;
+    out += '^';
+    for (const QString& rawName : names) {
+        const QString name = cleanMetaSubsetToken(rawName);
+        if (name.isEmpty())
+            continue;
+        out += name.toUtf8();
+        out += '^';
+    }
+    out += "\r\n";
+}
+
+inline QByteArray buildMetaSubset(const ExportSelection& selection)
+{
+    QByteArray out;
+
+    if (selection.globalProfiles)
+        appendProfileSubsetLine(out, "GLOBAL_PROFILES", selection.globalProfileNames);
+    if (selection.txProfiles)
+        appendProfileSubsetLine(out, "HW_PROFILES", selection.txProfileNames);
+    if (selection.micProfiles)
+        appendProfileSubsetLine(out, "MIC_PROFILES", selection.micProfileNames);
+    if (selection.memories) {
+        out += "MEMORIES^";
+        for (const MemoryGroupSelection& memory : selection.memoryGroups) {
+            const QString owner = cleanMemoryToken(memory.owner);
+            const QString group = cleanMemoryToken(memory.group);
+            if (owner.isEmpty() && group.isEmpty())
+                continue;
+            out += owner.toUtf8();
+            out += '|';
+            out += group.toUtf8();
+            out += '^';
+        }
+        out += "\r\n";
+    }
+    if (selection.preferences) {
+        out += "BAND_PERSISTENCE^\r\n";
+        out += "MODE_PERSISTENCE^\r\n";
+        out += "GLOBAL_PERSISTENCE^\r\n";
+    }
+    if (selection.tnf)
+        out += "TNFS^\r\n";
+    if (selection.xvtr)
+        out += "XVTRS^\r\n";
+    if (selection.usbCables)
+        out += "USB_CABLES^\r\n";
+
+    return out;
+}
+
+inline QVersionNumber parseSmartSdrVersionFromFilename(const QString& fileName)
+{
+    static const QRegularExpression re(
+        QStringLiteral(R"((?:ASDR|SSDR)_Config_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}_v(\d+(?:\.\d+){1,3})\.ssdr_cfg$)"),
+        QRegularExpression::CaseInsensitiveOption);
+    const auto match = re.match(fileName);
+    if (!match.hasMatch())
+        return {};
+    return QVersionNumber::fromString(match.captured(1));
+}
+
+inline QVersionNumber parseFirmwareVersion(const QString& text)
+{
+    static const QRegularExpression re(QStringLiteral(R"((\d+(?:\.\d+){0,3}))"));
+    const auto match = re.match(text);
+    if (!match.hasMatch())
+        return {};
+    return QVersionNumber::fromString(match.captured(1));
+}
+
+inline int compareFirmwareVersions(const QString& lhs, const QString& rhs)
+{
+    const QVersionNumber left = parseFirmwareVersion(lhs);
+    const QVersionNumber right = parseFirmwareVersion(rhs);
+    if (left.isNull() || right.isNull())
+        return 0;
+
+    const int cmp = QVersionNumber::compare(left.normalized(), right.normalized());
+    if (cmp < 0)
+        return -1;
+    if (cmp > 0)
+        return 1;
+    return 0;
+}
+
+inline std::optional<quint16> parseTransferPort(const QString& replyBody)
+{
+    const QString trimmed = replyBody.trimmed();
+
+    static const QRegularExpression keyedRe(
+        QStringLiteral(R"((?:^|[\s,;|])(?:port|transfer_port|tcp_port)\s*[=:]?\s*(\d{2,5})(?=$|[^\d]))"),
+        QRegularExpression::CaseInsensitiveOption);
+    const auto keyed = keyedRe.match(trimmed);
+    if (keyed.hasMatch()) {
+        bool ok = false;
+        const int port = keyed.captured(1).toInt(&ok);
+        if (ok && port > 0 && port <= 65535)
+            return static_cast<quint16>(port);
+    }
+
+    bool bareOk = false;
+    const int barePort = trimmed.toInt(&bareOk);
+    if (bareOk && barePort > 0 && barePort <= 65535)
+        return static_cast<quint16>(barePort);
+
+    static const QRegularExpression endpointRe(QStringLiteral(R"(:(\d{2,5})(?=$|[^\d]))"));
+    const auto endpoint = endpointRe.match(trimmed);
+    if (endpoint.hasMatch()) {
+        bool ok = false;
+        const int port = endpoint.captured(1).toInt(&ok);
+        if (ok && port > 0 && port <= 65535)
+            return static_cast<quint16>(port);
+    }
+
+    static const QRegularExpression re(QStringLiteral(R"((?:^|[^\d])(\d{2,5})(?:[^\d]|$))"));
+    auto it = re.globalMatch(trimmed);
+    std::optional<quint16> lastPort;
+    while (it.hasNext()) {
+        const auto match = it.next();
+        bool ok = false;
+        const int port = match.captured(1).toInt(&ok);
+        if (ok && port > 0 && port <= 65535)
+            lastPort = static_cast<quint16>(port);
+    }
+    return lastPort;
+}
+
+class ProfileTransfer : public QObject {
+    Q_OBJECT
+
+public:
+    enum class Operation {
+        ExportDatabase,
+        ImportDatabase
+    };
+
+    explicit ProfileTransfer(RadioModel* model, QObject* parent = nullptr);
+    ~ProfileTransfer() override;
+
+    bool isBusy() const { return m_busy; }
+
+    void exportDatabase(const ExportSelection& selection, const QString& destinationPath);
+    void importDatabase(const QString& ssdrCfgPath);
+    void cancel();
+
+signals:
+    void started(AetherSDR::ProfileTransfer::Operation operation);
+    void progress(QString status, qint64 bytesDone, qint64 bytesTotal);
+    void finished(AetherSDR::ProfileTransfer::Operation operation, QString path);
+    void failed(AetherSDR::ProfileTransfer::Operation operation, QString error);
+
+private:
+    enum class Phase {
+        Idle,
+        UploadMetaSubset,
+        DownloadPackage,
+        UploadImport,
+        WaitingForImport
+    };
+
+    void begin(Operation operation, Phase phase);
+    void fail(const QString& error);
+    void finish(QString path);
+    void cleanup();
+
+    ExportSelection expandSelection(ExportSelection selection) const;
+    bool validateCommonPreconditions(Operation operation, QString* error) const;
+    bool validateExportSelection(const ExportSelection& selection, QString* error) const;
+    bool validateExportDestination(const QString& path, QString* error) const;
+    bool validateImportFile(const QString& path, QString* error) const;
+
+    void requestUploadPort(const QByteArray& payload, const QString& uploadKind);
+    void onUploadPortReceived(int code, const QString& body);
+    void connectUploadSocket(quint16 port);
+    void tryFallbackUploadPort();
+    void onUploadConnected();
+    void sendNextUploadChunk();
+    void onUploadBytesWritten(qint64 bytes);
+    void onUploadDisconnected();
+    void onUploadError();
+
+    void requestPackageDownload();
+    void onDownloadPortReceived(int code, const QString& body);
+    void startDownloadServer(quint16 port);
+    void onDownloadConnection();
+    void onDownloadReadyRead();
+    void onDownloadDisconnected();
+    void onDownloadError();
+
+    void waitForImportCompletion();
+    void scheduleImportCompletion();
+    void completeImport();
+    void resetIdleTimer();
+    void handleTimeout();
+    bool commitExportFile(QString* error);
+
+    RadioModel* m_model{nullptr};
+    Operation m_operation{Operation::ExportDatabase};
+    Phase m_phase{Phase::Idle};
+    bool m_busy{false};
+    bool m_cancelled{false};
+    bool m_usedFallbackPort{false};
+    bool m_downloadFinalized{false};
+    bool m_importCompletionScheduled{false};
+
+    QByteArray m_uploadPayload;
+    QString m_path;
+    qint64 m_bytesDone{0};
+    qint64 m_bytesQueued{0};
+    qint64 m_bytesTotal{0};
+    quint16 m_uploadPort{0};
+
+    QTcpSocket* m_socket{nullptr};
+    QTcpServer* m_server{nullptr};
+    QSaveFile* m_saveFile{nullptr};
+    QTimer* m_timeout{nullptr};
+    QTimer* m_idleTimer{nullptr};
+    QTimer* m_overallTimer{nullptr};
+
+    static constexpr int kUploadChunkSize = 64 * 1024;
+    static constexpr int kCommandTimeoutMs = 10000;
+    static constexpr int kConnectTimeoutMs = 10000;
+    static constexpr int kIdleTimeoutMs = 30000;
+    static constexpr int kOverallTimeoutMs = 180000;
+    static constexpr int kMetaSubsetSettleMs = 5000;
+    static constexpr int kImportSettleMs = 5000;
+    static constexpr quint16 kDefaultUploadPort = 4995;
+    static constexpr quint16 kFallbackTransferPort = 42607;
+    static constexpr qint64 kMaxImportSize = 250LL * 1024LL * 1024LL;
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -79,6 +79,7 @@
 #include "AmpApplet.h"
 #include "MeterApplet.h"
 #include "ProfileManagerDialog.h"
+#include "ProfileImportExportDialog.h"
 #include "SupportDialog.h"
 #include "SliceTroubleshootingDialog.h"
 #include "ShortcutDialog.h"
@@ -6884,7 +6885,15 @@ void MainWindow::buildMenuBar()
     });
     auto* profileImportExportAct = m_profilesMenu->addAction("Import/Export Profiles...");
     connect(profileImportExportAct, &QAction::triggered, this, [this] {
-        // TODO: open import/export dialog
+        if (!m_profileImportExportDialog) {
+            auto* dlg = new ProfileImportExportDialog(&m_radioModel, this);
+            dlg->setAttribute(Qt::WA_DeleteOnClose);
+            dlg->setFramelessMode(framelessWindowEnabled());
+            m_profileImportExportDialog = dlg;
+        }
+        m_profileImportExportDialog->show();
+        m_profileImportExportDialog->raise();
+        m_profileImportExportDialog->activateWindow();
     });
     m_profilesMenu->addSeparator();
 
@@ -11474,6 +11483,8 @@ void MainWindow::setFramelessWindow(bool on)
         dlg->setFramelessMode(on);
     if (m_profileManagerDialog)
         m_profileManagerDialog->setFramelessMode(on);
+    if (m_profileImportExportDialog)
+        m_profileImportExportDialog->setFramelessMode(on);
 #ifdef HAVE_MIDI
     if (auto* dlg = qobject_cast<MidiMappingDialog*>(m_midiDialog)) {
         dlg->setFramelessMode(on);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -76,6 +76,7 @@ class BandPlanManager;
 class NetworkDiagnosticsHistory;
 class WhatsNewDialog;
 class ProfileManagerDialog;
+class ProfileImportExportDialog;
 class CwxPanel;
 class DvkPanel;
 #ifdef HAVE_RADE
@@ -460,6 +461,7 @@ private:
     QPointer<WhatsNewDialog> m_whatsNewDialog;
     QPointer<QDialog> m_dspDialog;
     QPointer<ProfileManagerDialog> m_profileManagerDialog;
+    QPointer<ProfileImportExportDialog> m_profileImportExportDialog;
 #ifdef HAVE_MIDI
     QPointer<QDialog> m_midiDialog;
 #endif

--- a/src/gui/ProfileImportExportDialog.cpp
+++ b/src/gui/ProfileImportExportDialog.cpp
@@ -1,0 +1,535 @@
+#include "ProfileImportExportDialog.h"
+
+#include "FramelessResizer.h"
+#include "FramelessWindowTitleBar.h"
+#include "core/AppSettings.h"
+#include "models/RadioModel.h"
+#include "models/TransmitModel.h"
+
+#include <QCloseEvent>
+#include <QCheckBox>
+#include <QDateTime>
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QRegularExpression>
+#include <QSignalBlocker>
+#include <QStandardPaths>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+namespace {
+
+static const QString kDialogStyle =
+    "QDialog { background: #0f0f1a; color: #c8d8e8; }"
+    "QTabWidget::pane { border: 1px solid #203040; background: #0f0f1a; }"
+    "QTabBar::tab { background: #1a2a3a; color: #8898a8; padding: 6px 14px;"
+    "  border: 1px solid #203040; border-bottom: none; border-top-left-radius: 4px;"
+    "  border-top-right-radius: 4px; margin-right: 2px; }"
+    "QTabBar::tab:selected { background: #0f0f1a; color: #c8d8e8; }"
+    "QGroupBox { border: 1px solid #203040; border-radius: 4px; margin-top: 10px;"
+    "  padding: 10px 8px 8px 8px; color: #c8d8e8; }"
+    "QGroupBox::title { subcontrol-origin: margin; left: 8px; padding: 0 4px; }"
+    "QLineEdit { background: #0a0a18; border: 1px solid #1e2e3e; border-radius: 3px;"
+    "  padding: 4px 6px; color: #c8d8e8; }"
+    "QPushButton { background: #1a2a3a; border: 1px solid #203040;"
+    "  border-radius: 3px; padding: 4px 12px; color: #c8d8e8; }"
+    "QPushButton:hover { background: #2a3a4a; }"
+    "QPushButton:disabled { color: #607080; background: #101824; }"
+    "QCheckBox { color: #c8d8e8; spacing: 8px; }"
+    "QCheckBox::indicator { width: 16px; height: 16px;"
+    "  border: 1px solid #406080; border-radius: 3px; background: #0a0a18; }"
+    "QCheckBox::indicator:checked { background: #00b4d8; }"
+    "QProgressBar { background: #0a0a18; border: 1px solid #1e2e3e; border-radius: 3px;"
+    "  color: #c8d8e8; text-align: center; }"
+    "QProgressBar::chunk { background: #00b4d8; }";
+
+QString profileTransferDirectory()
+{
+    auto& settings = AppSettings::instance();
+    const QString saved = settings.value(QStringLiteral("ProfileImportExportPath"), QString()).toString();
+    if (!saved.isEmpty() && QDir(saved).exists())
+        return saved;
+
+    const QString docs = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    if (!docs.isEmpty())
+        return docs;
+    return QDir::homePath();
+}
+
+void rememberProfileTransferDirectory(const QString& path)
+{
+    const QFileInfo info(path);
+    if (!info.absolutePath().isEmpty())
+        AppSettings::instance().setValue(QStringLiteral("ProfileImportExportPath"), info.absolutePath());
+}
+
+QString sanitizedVersion(QString version)
+{
+    version = version.trimmed();
+    version.replace(QRegularExpression(QStringLiteral(R"([^A-Za-z0-9_.-])")), QStringLiteral("_"));
+    return version;
+}
+
+} // namespace
+
+ProfileImportExportDialog::ProfileImportExportDialog(RadioModel* model, QWidget* parent)
+    : QDialog(parent), m_model(model)
+{
+    setWindowTitle(QStringLiteral("Import/Export Profiles"));
+    setMinimumSize(560, 430);
+    setStyleSheet(kDialogStyle);
+
+    auto* outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("Import/Export Profiles"), this);
+    outer->addWidget(m_titleBar);
+
+    auto* body = new QWidget(this);
+    m_bodyLayout = new QVBoxLayout(body);
+    m_bodyLayout->setContentsMargins(9, 9, 9, 9);
+    m_bodyLayout->setSpacing(9);
+    outer->addWidget(body, 1);
+
+    m_transfer = new ProfileTransfer(model, this);
+    m_tabs = new QTabWidget(this);
+    m_tabs->addTab(buildExportPage(), QStringLiteral("Export"));
+    m_tabs->addTab(buildImportPage(), QStringLiteral("Import"));
+    m_bodyLayout->addWidget(m_tabs, 1);
+
+    m_statusLabel = new QLabel(this);
+    m_statusLabel->setWordWrap(true);
+    m_statusLabel->setStyleSheet(QStringLiteral("QLabel { color: #9fb0c0; }"));
+    m_bodyLayout->addWidget(m_statusLabel);
+
+    m_progress = new QProgressBar(this);
+    m_progress->setRange(0, 100);
+    m_progress->setValue(0);
+    m_bodyLayout->addWidget(m_progress);
+
+    auto* buttonRow = new QHBoxLayout;
+    buttonRow->addStretch();
+    m_cancelButton = new QPushButton(QStringLiteral("Cancel"), this);
+    m_cancelButton->setEnabled(false);
+    m_closeButton = new QPushButton(QStringLiteral("Close"), this);
+    buttonRow->addWidget(m_cancelButton);
+    buttonRow->addWidget(m_closeButton);
+    m_bodyLayout->addLayout(buttonRow);
+
+    connect(m_cancelButton, &QPushButton::clicked, m_transfer, &ProfileTransfer::cancel);
+    connect(m_closeButton, &QPushButton::clicked, this, &QDialog::accept);
+
+    connect(m_transfer, &ProfileTransfer::started, this, [this](ProfileTransfer::Operation) {
+        setTransferring(true);
+    });
+    connect(m_transfer, &ProfileTransfer::progress, this,
+            [this](const QString& status, qint64 done, qint64 total) {
+        setStatus(status);
+        if (total > 0) {
+            m_progress->setRange(0, 100);
+            m_progress->setValue(static_cast<int>((done * 100) / total));
+        } else {
+            m_progress->setRange(0, 0);
+        }
+    });
+    connect(m_transfer, &ProfileTransfer::finished, this,
+            [this](ProfileTransfer::Operation operation, const QString& path) {
+        setTransferring(false);
+        m_progress->setRange(0, 100);
+        m_progress->setValue(100);
+        const QString message = operation == ProfileTransfer::Operation::ExportDatabase
+            ? QStringLiteral("Export complete. The radio created the backup package and AetherSDR saved it.")
+            : QStringLiteral("Import sent. The radio accepted the package and profile lists are being refreshed.");
+        setStatus(message);
+        rememberProfileTransferDirectory(path);
+        QMessageBox::information(this, windowTitle(), message);
+    });
+    connect(m_transfer, &ProfileTransfer::failed, this,
+            [this](ProfileTransfer::Operation, const QString& error) {
+        setTransferring(false);
+        m_progress->setRange(0, 100);
+        m_progress->setValue(0);
+        setStatus(error);
+        QMessageBox::warning(this, windowTitle(), error);
+    });
+
+    if (m_model) {
+        connect(m_model, &RadioModel::connectionStateChanged, this, [this](bool) { updateControls(); });
+        connect(m_model, &RadioModel::radioTransmittingChanged, this, [this](bool) { updateControls(); });
+        connect(m_model, &RadioModel::infoChanged, this, [this] {
+            if (m_exportPath && m_exportPath->text().isEmpty())
+                m_exportPath->setText(defaultExportPath());
+            updateControls();
+        });
+        connect(&m_model->transmitModel(), &TransmitModel::moxChanged, this, [this](bool) { updateControls(); });
+        connect(&m_model->transmitModel(), &TransmitModel::tuneChanged, this, [this](bool) { updateControls(); });
+    }
+
+    FramelessResizer::install(this);
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+    updateControls();
+}
+
+void ProfileImportExportDialog::setFramelessMode(bool on)
+{
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
+    flags.setFlag(Qt::FramelessWindowHint, on);
+    setWindowFlags(flags);
+    if (wasVisible)
+        setGeometry(geom);
+
+    if (m_titleBar)
+        m_titleBar->setVisible(on);
+    if (m_bodyLayout)
+        m_bodyLayout->setContentsMargins(9, on ? 7 : 9, 9, 9);
+    if (wasVisible)
+        show();
+}
+
+void ProfileImportExportDialog::closeEvent(QCloseEvent* event)
+{
+    if (m_transfer && m_transfer->isBusy()) {
+        const auto choice = QMessageBox::question(
+            this, windowTitle(),
+            QStringLiteral("A profile transfer is still running. Cancel it and close this window?"));
+        if (choice != QMessageBox::Yes) {
+            event->ignore();
+            return;
+        }
+        m_transfer->cancel();
+    }
+    QDialog::closeEvent(event);
+}
+
+QWidget* ProfileImportExportDialog::buildExportPage()
+{
+    auto* page = new QWidget(this);
+    auto* root = new QVBoxLayout(page);
+    root->setSpacing(10);
+
+    auto* intro = new QLabel(
+        QStringLiteral("Export is radio-driven: AetherSDR tells the radio which categories you selected, then saves the .ssdr_cfg backup package the radio creates. The package is not edited locally."),
+        page);
+    intro->setWordWrap(true);
+    intro->setStyleSheet(QStringLiteral("QLabel { color: #9fb0c0; }"));
+    root->addWidget(intro);
+
+    auto* options = new QGroupBox(QStringLiteral("Radio Database Categories"), page);
+    auto* grid = new QGridLayout(options);
+    grid->setColumnStretch(0, 1);
+    grid->setColumnStretch(1, 1);
+
+    m_selectAllExport = new QCheckBox(QStringLiteral("Select All"), options);
+    m_globalProfiles = new QCheckBox(QStringLiteral("Global Profiles"), options);
+    m_txProfiles = new QCheckBox(QStringLiteral("TX Profiles"), options);
+    m_micProfiles = new QCheckBox(QStringLiteral("MIC Profiles"), options);
+    m_memories = new QCheckBox(QStringLiteral("Memories"), options);
+    m_preferences = new QCheckBox(QStringLiteral("Preferences"), options);
+    m_tnf = new QCheckBox(QStringLiteral("TNF"), options);
+    m_xvtr = new QCheckBox(QStringLiteral("XVTR"), options);
+    m_usbCables = new QCheckBox(QStringLiteral("USB Cables"), options);
+
+    m_globalProfiles->setChecked(true);
+    m_txProfiles->setChecked(true);
+    m_micProfiles->setChecked(true);
+
+    grid->addWidget(m_selectAllExport, 0, 0, 1, 2);
+    grid->addWidget(m_globalProfiles, 1, 0);
+    grid->addWidget(m_txProfiles, 1, 1);
+    grid->addWidget(m_micProfiles, 2, 0);
+    grid->addWidget(m_memories, 2, 1);
+    grid->addWidget(m_preferences, 3, 0);
+    grid->addWidget(m_tnf, 3, 1);
+    grid->addWidget(m_xvtr, 4, 0);
+    grid->addWidget(m_usbCables, 4, 1);
+    root->addWidget(options);
+
+    auto* fileGroup = new QGroupBox(QStringLiteral("Destination"), page);
+    auto* fileRow = new QHBoxLayout(fileGroup);
+    m_exportPath = new QLineEdit(defaultExportPath(), fileGroup);
+    auto* browse = new QPushButton(QStringLiteral("Browse..."), fileGroup);
+    fileRow->addWidget(m_exportPath, 1);
+    fileRow->addWidget(browse);
+    root->addWidget(fileGroup);
+
+    auto* actionRow = new QHBoxLayout;
+    actionRow->addStretch();
+    m_exportButton = new QPushButton(QStringLiteral("Export"), page);
+    actionRow->addWidget(m_exportButton);
+    root->addLayout(actionRow);
+    root->addStretch();
+
+    const auto optionChanged = [this] {
+        updateSelectAllFromOptions();
+        updateControls();
+    };
+    for (QCheckBox* box : {m_globalProfiles, m_txProfiles, m_micProfiles, m_memories,
+                           m_preferences, m_tnf, m_xvtr, m_usbCables}) {
+        connect(box, &QCheckBox::toggled, this, optionChanged);
+    }
+    connect(m_selectAllExport, &QCheckBox::toggled, this, [this](bool checked) {
+        const QSignalBlocker blocker(m_selectAllExport);
+        for (QCheckBox* box : {m_globalProfiles, m_txProfiles, m_micProfiles, m_memories,
+                               m_preferences, m_tnf, m_xvtr, m_usbCables}) {
+            box->setChecked(checked);
+        }
+        updateControls();
+    });
+    connect(browse, &QPushButton::clicked, this, &ProfileImportExportDialog::chooseExportPath);
+    connect(m_exportPath, &QLineEdit::textChanged, this, [this] { updateControls(); });
+    connect(m_exportButton, &QPushButton::clicked, this, &ProfileImportExportDialog::startExport);
+
+    updateSelectAllFromOptions();
+    return page;
+}
+
+QWidget* ProfileImportExportDialog::buildImportPage()
+{
+    auto* page = new QWidget(this);
+    auto* root = new QVBoxLayout(page);
+    root->setSpacing(10);
+
+    auto* intro = new QLabel(
+        QStringLiteral("Import is radio-driven too: AetherSDR uploads the .ssdr_cfg package, then the radio unpacks it and applies the database contents."),
+        page);
+    intro->setWordWrap(true);
+    intro->setStyleSheet(QStringLiteral("QLabel { color: #9fb0c0; }"));
+    root->addWidget(intro);
+
+    auto* fileGroup = new QGroupBox(QStringLiteral("Configuration Package"), page);
+    auto* fileRow = new QHBoxLayout(fileGroup);
+    m_importPath = new QLineEdit(fileGroup);
+    auto* browse = new QPushButton(QStringLiteral("Browse..."), fileGroup);
+    fileRow->addWidget(m_importPath, 1);
+    fileRow->addWidget(browse);
+    root->addWidget(fileGroup);
+
+    auto* actionRow = new QHBoxLayout;
+    actionRow->addStretch();
+    m_importButton = new QPushButton(QStringLiteral("Import"), page);
+    actionRow->addWidget(m_importButton);
+    root->addLayout(actionRow);
+    root->addStretch();
+
+    connect(browse, &QPushButton::clicked, this, &ProfileImportExportDialog::chooseImportPath);
+    connect(m_importPath, &QLineEdit::textChanged, this, [this] { updateControls(); });
+    connect(m_importButton, &QPushButton::clicked, this, &ProfileImportExportDialog::startImport);
+    return page;
+}
+
+ExportSelection ProfileImportExportDialog::currentExportSelection() const
+{
+    ExportSelection selection;
+    selection.globalProfiles = m_globalProfiles && m_globalProfiles->isChecked();
+    selection.txProfiles = m_txProfiles && m_txProfiles->isChecked();
+    selection.micProfiles = m_micProfiles && m_micProfiles->isChecked();
+    selection.memories = m_memories && m_memories->isChecked();
+    selection.preferences = m_preferences && m_preferences->isChecked();
+    selection.tnf = m_tnf && m_tnf->isChecked();
+    selection.xvtr = m_xvtr && m_xvtr->isChecked();
+    selection.usbCables = m_usbCables && m_usbCables->isChecked();
+    return selection;
+}
+
+QString ProfileImportExportDialog::defaultExportPath() const
+{
+    return QDir(profileTransferDirectory()).filePath(defaultExportFileName());
+}
+
+QString ProfileImportExportDialog::defaultExportFileName() const
+{
+    const QString timestamp = QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd_HH-mm-ss"));
+    const QString version = m_model ? sanitizedVersion(m_model->softwareVersion()) : QString();
+    if (version.isEmpty())
+        return QStringLiteral("ASDR_Config_%1.ssdr_cfg").arg(timestamp);
+    return QStringLiteral("ASDR_Config_%1_v%2.ssdr_cfg").arg(timestamp, version);
+}
+
+bool ProfileImportExportDialog::canTransfer(QString* reason) const
+{
+    if (!m_model || !m_model->isConnected()) {
+        if (reason)
+            *reason = QStringLiteral("Connect to a FlexRadio before importing or exporting profiles.");
+        return false;
+    }
+    if (m_model->isWan()) {
+        if (reason)
+            *reason = QStringLiteral("SmartLink/WAN database transfer is disabled. Use a direct LAN connection.");
+        return false;
+    }
+    if (m_model->isProfileTransferBlocked()) {
+        if (reason)
+            *reason = QStringLiteral("Stop MOX, TUNE, PTT, or active transmit before importing or exporting.");
+        return false;
+    }
+    if (reason)
+        reason->clear();
+    return true;
+}
+
+bool ProfileImportExportDialog::confirmImport()
+{
+    QString versionLine;
+    const QFileInfo info(m_importPath->text());
+    const QVersionNumber exportVersion = parseSmartSdrVersionFromFilename(info.fileName());
+    const QString radioVersion = m_model ? m_model->softwareVersion() : QString();
+    if (exportVersion.isNull()) {
+        versionLine = QStringLiteral("The package firmware version cannot be verified from the filename.");
+    } else if (!radioVersion.trimmed().isEmpty()
+               && compareFirmwareVersions(exportVersion.toString(), radioVersion) > 0) {
+        versionLine = QStringLiteral("This package appears to be from newer firmware (%1) than the connected radio (%2).")
+            .arg(exportVersion.toString(), radioVersion);
+    } else if (!radioVersion.trimmed().isEmpty()) {
+        versionLine = QStringLiteral("Package firmware version: %1. Connected radio firmware: %2.")
+            .arg(exportVersion.toString(), radioVersion);
+    }
+
+    QMessageBox box(this);
+    box.setIcon(QMessageBox::Warning);
+    box.setWindowTitle(QStringLiteral("Confirm Profile Import"));
+    box.setText(QStringLiteral("Import this .ssdr_cfg backup to the radio?"));
+    box.setInformativeText(
+        QStringLiteral("AetherSDR will upload the backup package, but the radio does the actual import. AetherSDR does not rewrite the database inside the package.\n\n"
+                       "Profiles, memories, and other included settings can replace matching items already on the radio, including defaults.\n"
+                       "Packages from newer firmware may fail or leave the radio database in an unexpected state.\n"
+                       "Packages that include Preferences can close or reopen slices, panadapters, and other saved radio state.\n\n"
+                       "Export a backup first if you have not already done so.\n%1")
+            .arg(versionLine));
+    auto* importButton = box.addButton(QStringLiteral("Import"), QMessageBox::DestructiveRole);
+    auto* backupButton = canTransfer() && m_transfer && !m_transfer->isBusy()
+        ? box.addButton(QStringLiteral("Export Backup First"), QMessageBox::ActionRole)
+        : nullptr;
+    box.addButton(QMessageBox::Cancel);
+    box.exec();
+
+    if (box.clickedButton() == backupButton) {
+        m_tabs->setCurrentIndex(0);
+        startExport();
+        return false;
+    }
+    return box.clickedButton() == importButton;
+}
+
+void ProfileImportExportDialog::chooseExportPath()
+{
+    QString initial = m_exportPath ? m_exportPath->text() : defaultExportPath();
+    if (initial.trimmed().isEmpty())
+        initial = defaultExportPath();
+    const QString path = QFileDialog::getSaveFileName(
+        this, QStringLiteral("Export Profile Backup"),
+        initial, QStringLiteral("Profile Backup (*.ssdr_cfg)"));
+    if (path.isEmpty())
+        return;
+    m_exportPath->setText(path.endsWith(QStringLiteral(".ssdr_cfg"), Qt::CaseInsensitive)
+                              ? path
+                              : path + QStringLiteral(".ssdr_cfg"));
+}
+
+void ProfileImportExportDialog::chooseImportPath()
+{
+    const QString path = QFileDialog::getOpenFileName(
+        this, QStringLiteral("Import Profile Backup"),
+        profileTransferDirectory(), QStringLiteral("Profile Backup (*.ssdr_cfg)"));
+    if (path.isEmpty())
+        return;
+    m_importPath->setText(path);
+}
+
+void ProfileImportExportDialog::startExport()
+{
+    if (!m_exportPath || m_exportPath->text().trimmed().isEmpty())
+        m_exportPath->setText(defaultExportPath());
+    rememberProfileTransferDirectory(m_exportPath->text());
+    m_transfer->exportDatabase(currentExportSelection(), m_exportPath->text());
+}
+
+void ProfileImportExportDialog::startImport()
+{
+    if (!m_importPath || m_importPath->text().trimmed().isEmpty()) {
+        chooseImportPath();
+        if (!m_importPath || m_importPath->text().trimmed().isEmpty())
+            return;
+    }
+    rememberProfileTransferDirectory(m_importPath->text());
+    if (!confirmImport())
+        return;
+    m_transfer->importDatabase(m_importPath->text());
+}
+
+void ProfileImportExportDialog::setTransferring(bool transferring)
+{
+    const bool controlsEnabled = !transferring;
+    for (QCheckBox* box : {m_selectAllExport, m_globalProfiles, m_txProfiles, m_micProfiles,
+                           m_memories, m_preferences, m_tnf, m_xvtr, m_usbCables}) {
+        if (box)
+            box->setEnabled(controlsEnabled);
+    }
+    if (m_exportPath)
+        m_exportPath->setEnabled(controlsEnabled);
+    if (m_importPath)
+        m_importPath->setEnabled(controlsEnabled);
+    if (m_cancelButton)
+        m_cancelButton->setEnabled(transferring);
+    if (m_closeButton)
+        m_closeButton->setEnabled(!transferring);
+    updateControls();
+}
+
+void ProfileImportExportDialog::updateControls()
+{
+    QString reason;
+    const bool transferable = canTransfer(&reason);
+    const bool busy = m_transfer && m_transfer->isBusy();
+    const bool exportHasPath = m_exportPath && !m_exportPath->text().trimmed().isEmpty();
+    const bool importHasPath = m_importPath && !m_importPath->text().trimmed().isEmpty();
+    const bool exportHasSelection = currentExportSelection().anySelected();
+
+    if (m_exportButton)
+        m_exportButton->setEnabled(!busy && transferable && exportHasPath && exportHasSelection);
+    if (m_importButton)
+        m_importButton->setEnabled(!busy && transferable && importHasPath);
+
+    if (busy)
+        return;
+
+    if (!reason.isEmpty())
+        setStatus(reason);
+    else
+        setStatus(QStringLiteral("Ready. Import and export are radio-driven; AetherSDR handles the .ssdr_cfg transfer."));
+}
+
+void ProfileImportExportDialog::updateSelectAllFromOptions()
+{
+    if (!m_selectAllExport)
+        return;
+    const bool allSelected =
+        m_globalProfiles->isChecked() && m_txProfiles->isChecked() && m_micProfiles->isChecked()
+        && m_memories->isChecked() && m_preferences->isChecked() && m_tnf->isChecked()
+        && m_xvtr->isChecked() && m_usbCables->isChecked();
+    const QSignalBlocker blocker(m_selectAllExport);
+    m_selectAllExport->setChecked(allSelected);
+}
+
+void ProfileImportExportDialog::setStatus(const QString& text)
+{
+    if (m_statusLabel)
+        m_statusLabel->setText(text);
+}
+
+} // namespace AetherSDR

--- a/src/gui/ProfileImportExportDialog.h
+++ b/src/gui/ProfileImportExportDialog.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <QDialog>
+#include <QPointer>
+
+#include "core/ProfileTransfer.h"
+
+class QCheckBox;
+class QLabel;
+class QLineEdit;
+class QProgressBar;
+class QPushButton;
+class QTabWidget;
+class QVBoxLayout;
+
+namespace AetherSDR {
+
+class FramelessWindowTitleBar;
+class ProfileTransfer;
+class RadioModel;
+
+class ProfileImportExportDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ProfileImportExportDialog(RadioModel* model, QWidget* parent = nullptr);
+
+    void setFramelessMode(bool on);
+
+protected:
+    void closeEvent(QCloseEvent* event) override;
+
+private:
+    QWidget* buildExportPage();
+    QWidget* buildImportPage();
+    ExportSelection currentExportSelection() const;
+    QString defaultExportPath() const;
+    QString defaultExportFileName() const;
+    bool canTransfer(QString* reason = nullptr) const;
+    bool confirmImport();
+
+    void chooseExportPath();
+    void chooseImportPath();
+    void startExport();
+    void startImport();
+    void setTransferring(bool transferring);
+    void updateControls();
+    void updateSelectAllFromOptions();
+    void setStatus(const QString& text);
+
+    RadioModel* m_model{nullptr};
+    ProfileTransfer* m_transfer{nullptr};
+
+    FramelessWindowTitleBar* m_titleBar{nullptr};
+    QVBoxLayout* m_bodyLayout{nullptr};
+    QTabWidget* m_tabs{nullptr};
+
+    QCheckBox* m_selectAllExport{nullptr};
+    QCheckBox* m_globalProfiles{nullptr};
+    QCheckBox* m_txProfiles{nullptr};
+    QCheckBox* m_micProfiles{nullptr};
+    QCheckBox* m_memories{nullptr};
+    QCheckBox* m_preferences{nullptr};
+    QCheckBox* m_tnf{nullptr};
+    QCheckBox* m_xvtr{nullptr};
+    QCheckBox* m_usbCables{nullptr};
+
+    QLineEdit* m_exportPath{nullptr};
+    QLineEdit* m_importPath{nullptr};
+    QLabel* m_statusLabel{nullptr};
+    QProgressBar* m_progress{nullptr};
+    QPushButton* m_exportButton{nullptr};
+    QPushButton* m_importButton{nullptr};
+    QPushButton* m_cancelButton{nullptr};
+    QPushButton* m_closeButton{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2231,6 +2231,14 @@ void RadioModel::onDisconnected()
     }
     m_radioTransmitting = false;
     emit radioTransmittingChanged(false);
+    if (m_profileDatabaseImporting) {
+        m_profileDatabaseImporting = false;
+        emit profileDatabaseImportingChanged(false);
+    }
+    if (m_profileDatabaseExporting) {
+        m_profileDatabaseExporting = false;
+        emit profileDatabaseExportingChanged(false);
+    }
     m_transmitModel.setTransmitting(false);
     m_transmitModel.resetState();
     m_meterModel.clear();
@@ -2728,6 +2736,43 @@ void RadioModel::sendCommand(const QString& cmd)
 void RadioModel::sendCmdPublic(const QString& cmd, ResponseCallback cb)
 {
     sendCmd(cmd, cb);
+}
+
+void RadioModel::requestFileUploadPort(qint64 size, const QString& uploadKind,
+                                        ResponseCallback cb)
+{
+    qCInfo(lcProtocol).noquote()
+        << "RadioModel: file upload requested"
+        << QStringLiteral("kind=%1").arg(uploadKind)
+        << QStringLiteral("bytes=%1").arg(size);
+    sendCmd(QStringLiteral("file upload %1 %2").arg(size).arg(uploadKind), cb);
+}
+
+void RadioModel::requestFileDownloadPort(const QString& downloadKind, ResponseCallback cb)
+{
+    qCInfo(lcProtocol).noquote()
+        << "RadioModel: file download requested"
+        << QStringLiteral("kind=%1").arg(downloadKind);
+    sendCmd(QStringLiteral("file download %1").arg(downloadKind), cb);
+}
+
+void RadioModel::refreshProfiles()
+{
+    sendCmd(QStringLiteral("profile global info"));
+    sendCmd(QStringLiteral("profile global list"));
+    sendCmd(QStringLiteral("profile global current"));
+    sendCmd(QStringLiteral("profile tx list"));
+    sendCmd(QStringLiteral("profile tx current"));
+    sendCmd(QStringLiteral("profile mic list"));
+    sendCmd(QStringLiteral("profile mic current"));
+}
+
+bool RadioModel::isProfileTransferBlocked() const
+{
+    return m_radioTransmitting
+        || m_txRequested
+        || m_transmitModel.isMox()
+        || m_transmitModel.isTuning();
 }
 
 void RadioModel::requestLocalPtt()
@@ -4500,9 +4545,22 @@ void RadioModel::handleProfileStatus(const QString& object,
     // Profile list/current with space-containing names are handled by
     // handleProfileStatusRaw() via onMessageReceived().  This fallback
     // handles any remaining profile status keys that don't have spaces
-    // (e.g. "profile all unsaved_changes_tx=0").
+    // (e.g. "profile importing=1", "profile exporting=0").
     Q_UNUSED(object);
-    Q_UNUSED(kvs);
+    if (kvs.contains(QStringLiteral("importing"))) {
+        const bool importing = kvs.value(QStringLiteral("importing")) == QLatin1String("1");
+        if (m_profileDatabaseImporting != importing) {
+            m_profileDatabaseImporting = importing;
+            emit profileDatabaseImportingChanged(importing);
+        }
+    }
+    if (kvs.contains(QStringLiteral("exporting"))) {
+        const bool exporting = kvs.value(QStringLiteral("exporting")) == QLatin1String("1");
+        if (m_profileDatabaseExporting != exporting) {
+            m_profileDatabaseExporting = exporting;
+            emit profileDatabaseExportingChanged(exporting);
+        }
+    }
 }
 
 void RadioModel::handleProfileStatusRaw(const QString& profileType,
@@ -4517,6 +4575,23 @@ void RadioModel::handleProfileStatusRaw(const QString& profileType,
 
     const QString key = rawBody.left(eq).trimmed();
     const QString val = rawBody.mid(eq + 1).trimmed();
+
+    if (key == QLatin1String("importing")) {
+        const bool importing = val == QLatin1String("1");
+        if (m_profileDatabaseImporting != importing) {
+            m_profileDatabaseImporting = importing;
+            emit profileDatabaseImportingChanged(importing);
+        }
+        return;
+    }
+    if (key == QLatin1String("exporting")) {
+        const bool exporting = val == QLatin1String("1");
+        if (m_profileDatabaseExporting != exporting) {
+            m_profileDatabaseExporting = exporting;
+            emit profileDatabaseExportingChanged(exporting);
+        }
+        return;
+    }
 
     if (profileType == "tx") {
         if (key == "list") {

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -402,6 +402,8 @@ signals:
     void interlockNotificationRequested(const QString& message);
     // Emitted when global profile list or active profile changes.
     void globalProfilesChanged();
+    void profileDatabaseImportingChanged(bool importing);
+    void profileDatabaseExportingChanged(bool exporting);
     // Emitted on each successful ping response from the radio.
     void pingReceived();
     // Generic status relay — for dialogs that need to listen for specific objects.
@@ -421,6 +423,14 @@ public:
 
     // Send a command with a response callback (for firmware uploader, etc.)
     void sendCmdPublic(const QString& cmd, std::function<void(int code, const QString& body)> cb);
+    void requestFileUploadPort(qint64 size, const QString& uploadKind,
+                               std::function<void(int code, const QString& body)> cb);
+    void requestFileDownloadPort(const QString& downloadKind,
+                                 std::function<void(int code, const QString& body)> cb);
+    void refreshProfiles();
+    bool isProfileTransferBlocked() const;
+    bool profileDatabaseImporting() const { return m_profileDatabaseImporting; }
+    bool profileDatabaseExporting() const { return m_profileDatabaseExporting; }
 
     // Radio software version string (from discovery broadcast, e.g. "4.1.5")
     QString softwareVersion() const { return m_version; }
@@ -692,6 +702,8 @@ private:
     QMap<int, MemoryEntry> m_memories;
     QStringList m_globalProfiles;
     QString     m_activeGlobalProfile;
+    bool        m_profileDatabaseImporting{false};
+    bool        m_profileDatabaseExporting{false};
     RadioStatusOwnership::RemoteAudioRxTracking m_rxAudio;
     struct DaxStreamDebugState {
         QString type;

--- a/tests/profile_transfer_test.cpp
+++ b/tests/profile_transfer_test.cpp
@@ -1,0 +1,103 @@
+#include "core/ProfileTransfer.h"
+
+#include <QByteArray>
+#include <QString>
+
+#include <iostream>
+
+namespace {
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition)
+        std::cerr << "FAIL: " << message << '\n';
+    return condition;
+}
+
+} // namespace
+
+int main()
+{
+    bool ok = true;
+
+    AetherSDR::ExportSelection profilesOnly;
+    profilesOnly.globalProfiles = true;
+    profilesOnly.txProfiles = true;
+    profilesOnly.micProfiles = true;
+    profilesOnly.globalProfileNames = {QStringLiteral("Morning"), QStringLiteral("Contest")};
+    profilesOnly.txProfileNames = {QStringLiteral("Ragchew")};
+    profilesOnly.micProfileNames = {QStringLiteral("Studio Mic")};
+    QByteArray expectedProfilesOnly =
+        "GLOBAL_PROFILES^Morning^Contest^\r\n"
+        "HW_PROFILES^Ragchew^\r\n"
+        "MIC_PROFILES^Studio Mic^\r\n";
+    ok &= expect(AetherSDR::buildMetaSubset(profilesOnly) == expectedProfilesOnly,
+                 "profiles-only meta_subset matches SmartSDR caret format");
+
+    AetherSDR::ExportSelection selectAll = profilesOnly;
+    selectAll.memories = true;
+    selectAll.preferences = true;
+    selectAll.tnf = true;
+    selectAll.xvtr = true;
+    selectAll.usbCables = true;
+    selectAll.memoryGroups = {{QStringLiteral("Owner Name"), QStringLiteral("Group A")}};
+    QByteArray expectedAll =
+        expectedProfilesOnly
+        + QByteArray("MEMORIES^Owner") + char(0x7f) + "Name|Group" + char(0x7f) + "A^\r\n"
+        + QByteArray("BAND_PERSISTENCE^\r\n"
+                     "MODE_PERSISTENCE^\r\n"
+                     "GLOBAL_PERSISTENCE^\r\n"
+                     "TNFS^\r\n"
+                     "XVTRS^\r\n"
+                     "USB_CABLES^\r\n");
+    ok &= expect(AetherSDR::buildMetaSubset(selectAll) == expectedAll,
+                 "select-all meta_subset includes memories, persistence, TNF, XVTR, and USB cables");
+
+    AetherSDR::ExportSelection noPreferences = selectAll;
+    noPreferences.preferences = false;
+    const QByteArray noPreferencesBytes = AetherSDR::buildMetaSubset(noPreferences);
+    ok &= expect(!noPreferencesBytes.contains("BAND_PERSISTENCE"),
+                 "select-all-except-preferences omits band persistence");
+    ok &= expect(!noPreferencesBytes.contains("MODE_PERSISTENCE"),
+                 "select-all-except-preferences omits mode persistence");
+    ok &= expect(!noPreferencesBytes.contains("GLOBAL_PERSISTENCE"),
+                 "select-all-except-preferences omits global persistence");
+    ok &= expect(noPreferencesBytes.contains("TNFS^\r\n")
+                 && noPreferencesBytes.contains("XVTRS^\r\n")
+                 && noPreferencesBytes.contains("USB_CABLES^\r\n"),
+                 "select-all-except-preferences keeps the other selected categories");
+
+    const QVersionNumber parsed =
+        AetherSDR::parseSmartSdrVersionFromFilename(
+            QStringLiteral("ASDR_Config_2026-05-13_10-30-00_v4.1.5.123.ssdr_cfg"));
+    ok &= expect(!parsed.isNull() && parsed.toString() == QStringLiteral("4.1.5.123"),
+                 "AetherSDR filename version parser extracts firmware version");
+    const QVersionNumber legacyParsed =
+        AetherSDR::parseSmartSdrVersionFromFilename(
+            QStringLiteral("SSDR_Config_2026-05-13_10-30-00_v3.7.9.ssdr_cfg"));
+    ok &= expect(!legacyParsed.isNull() && legacyParsed.toString() == QStringLiteral("3.7.9"),
+                 "SmartSDR filename version parser still accepts legacy export names");
+    ok &= expect(AetherSDR::parseSmartSdrVersionFromFilename(
+                     QStringLiteral("backup.ssdr_cfg")).isNull(),
+                 "SmartSDR filename version parser tolerates absent version");
+    ok &= expect(AetherSDR::compareFirmwareVersions(QStringLiteral("4.1.5"),
+                                                     QStringLiteral("4.0.9")) > 0,
+                 "firmware comparison detects newer version");
+    ok &= expect(AetherSDR::compareFirmwareVersions(QStringLiteral("3.7.9"),
+                                                     QStringLiteral("4.0.0")) < 0,
+                 "firmware comparison detects older version");
+    ok &= expect(AetherSDR::compareFirmwareVersions(QStringLiteral("4.1.5"),
+                                                     QStringLiteral("4.1.5.0")) == 0,
+                 "firmware comparison normalizes equivalent versions");
+
+    ok &= expect(AetherSDR::parseTransferPort(QStringLiteral("4995")).value_or(0) == 4995,
+                 "port parser accepts bare command reply body");
+    ok &= expect(AetherSDR::parseTransferPort(QStringLiteral("port=42607")).value_or(0) == 42607,
+                 "port parser accepts key-value command reply body");
+    ok &= expect(AetherSDR::parseTransferPort(QStringLiteral("endpoint=192.168.1.10:4995")).value_or(0) == 4995,
+                 "port parser prefers endpoint port over IP address octets");
+    ok &= expect(!AetherSDR::parseTransferPort(QStringLiteral("no usable port")).has_value(),
+                 "port parser rejects replies without a valid TCP port");
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION

<img width="606" height="600" alt="Screenshot 2026-05-13 at 6 13 44 PM" src="https://github.com/user-attachments/assets/6343d7f3-66bd-45e7-9b9a-196a42a425d5" />

## Summary

Adds SmartSDR-compatible profile import/export for AetherSDR using the FlexRadio radio-side database transfer flow.

- Replaces the empty Profiles -> Import/Export Profiles... action with a non-modal import/export dialog.
- Adds an async `ProfileTransfer` backend for `.ssdr_cfg` export/import using FlexRadio `file upload` / `file download` database package commands.
- Builds SmartSDR-compatible `meta_subset` requests for selected categories: Global Profiles, TX Profiles, MIC Profiles, Memories, Preferences, TNF, XVTR, and USB Cables.
- Imports `.ssdr_cfg` backup packages by preparing the import manifest wrapper expected by the radio while leaving the radio database payload untouched.
- Adds version-risk and destructive-import warnings, transfer cancel/timeout handling, and profile refresh after import.
- Updates help text and adds a manual integration checklist.

## Why

The previous menu entry was a TODO, and the closed JSON/name-list approach would not produce or restore real SmartSDR-compatible backups. SmartSDR profile backup/restore is a radio database package transfer; this implementation lets the radio create and apply those packages instead of parsing or rewriting the database locally.

Fixes #1415. Addresses duplicate reports #2319, #2581, and #2625.

## Validation

- Built locally with `cmake --build build -j8`.
- Ran `ctest --test-dir build -R profile_transfer_test --output-on-failure`.
- Live-tested export/import with a radio: select-all export produced a zipped `.ssdr_cfg` containing `flex_payload`, `memories.csv`, and `meta_data`; import flow restored the tested package after switching to the SmartSDR-style import wrapper.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
