### PR TITLE
refactor(gui): remove dead startSystemMove branch in ContainerWidget (#2601)

### DIFF
--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -5,7 +5,6 @@
 #include <QMimeData>
 #include <QPixmap>
 #include <QVBoxLayout>
-#include <QWindow>
 
 namespace AetherSDR {
 
@@ -144,18 +143,6 @@ void ContainerWidget::onTitleBarClose()
 void ContainerWidget::onTitleBarDragStart(const QPoint& /*globalPos*/)
 {
     if (!m_titleBar) return;
-
-    // Floating window: title-bar drag moves the OS window via the Qt 6
-    // cross-platform primitive that hands the move off to the compositor.
-    // (Pop-out windows are frameless — no native title bar to grab.)
-    if (m_dockMode == DockMode::Floating) {
-        if (auto* w = window()) {
-            if (auto* h = w->windowHandle()) {
-                h->startSystemMove();
-                return;
-            }
-        }
-    }
 
     // MIME type is shared with AppletDropArea's drag-reorder handling.
     auto* drag = new QDrag(m_titleBar);


### PR DESCRIPTION
## Summary
Removes the unreachable `startSystemMove()` branch from `ContainerWidget::onTitleBarDragStart()` per option (a) in #2601, plus the now-unused `<QWindow>` include.

## Why
- PR #2576 centralized frameless title-bar move handling in `FramelessMoveHelper`; this was the one stray raw-primitive caller left behind.
- The branch has **no `Q_OS_MAC` guard and no fallback** if `startSystemMove()` refuses — both of which would reproduce the macOS 5–10s dead-zone bug class that #2576 just fixed.
- It is currently unreachable (state-machine trace in #2601: `ContainerTitleBar::mousePressEvent` early-returns when `m_isFloating == true` and never sets `m_pressed`, so `dragStartRequested` is never emitted in floating mode). Easier to delete than guard.

## Scope
- **13 lines deleted, 0 added**, in `src/gui/containers/ContainerWidget.cpp` only
- No protocol / persistence / UX change
- Function declaration in `ContainerWidget.h` and call sites are untouched — only the inner dead branch and its dead `<QWindow>` include go away

## If floating-mode container drag returns
The correct integration point is `FramelessMoveHelper`, consistent with every other title bar after #2576 — not the bare `QWindow::startSystemMove` primitive this PR removes.

## Test plan
- [x] Local incremental `ninja -C build` clean on Linux (Nobara 43, Qt 6.10.3, gcc 15.2.1) — rebuilds `AetherSDR` + the three `container_*_test` targets without errors
- [ ] Docked-mode applet drag-to-reorder still works (untouched codepath — floating-mode branch was unreachable so no behavioral change expected)

Closes #2601

---

73, Ozy **K6OZY**  
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent, on Linux dev stack (`nobara-dell`).