### PR TITLE
fix(rade): guard m_daxBridge ref in deactivateRADE() for Windows/no-PipeWire

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -13832,7 +13832,10 @@ void MainWindow::deactivateRADE()
             // that case. TODO: replace with proper ref-counting in PanadapterStream
             // so any creator/borrower can safely release independently (#stream-lifecycle).
             bool tciActive = m_tciServer && m_tciServer->clientCount() > 0;
-            bool daxBridgeActive = (m_daxBridge != nullptr);
+            bool daxBridgeActive = false;
+#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
+            daxBridgeActive = (m_daxBridge != nullptr);
+#endif
             if (!tciActive && !daxBridgeActive) {
                 m_radioModel.panStream()->unregisterDaxStream(m_radeDaxStreamId);
                 if (m_radioModel.isConnected()) {


### PR DESCRIPTION
## Summary

Fixes the Windows (and Linux-without-PipeWire) build break introduced by #2633.

`m_daxBridge` is declared only inside `#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)` in `MainWindow.h`. PR #2633 added an unconditional reference to it in `deactivateRADE()`:

```cpp
// Before — breaks Windows/Linux-no-PipeWire:
bool daxBridgeActive = (m_daxBridge != nullptr);
```

This PR gates that assignment behind the same preprocessor guard:

```cpp
bool daxBridgeActive = false;
#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
daxBridgeActive = (m_daxBridge != nullptr);
#endif
```

The macOS fix from #2633 is fully preserved — on macOS/PipeWire, `daxBridgeActive` is still set from the live pointer so `stream remove` is correctly skipped when the bridge is active. On Windows/Linux-no-PipeWire, `daxBridgeActive` stays `false` (no bridge on those platforms), so `stream remove` is issued as expected.

Fix shape was identified by aethersdr-agent in the #2633 review.

## Files changed

| File | Change |
|------|--------|
| `src/gui/MainWindow.cpp` | Wrap `daxBridgeActive` assignment in `#if defined(Q_OS_MAC) \|\| defined(HAVE_PIPEWIRE)` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)