### PR TITLE
fix(waterfall): smooth TX render — integrate FFT frames, suppress native tiles during TX

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2141,9 +2141,14 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
 
     if (m_waterfall.isNull()) return;
 
-    // Freeze waterfall during TX if show-tx-in-waterfall is off and this pan
-    // contains the TX slice. Non-TX pans keep scrolling in multi-pan.
-    if (m_transmitting && !m_showTxInWaterfall && m_hasTxSlice) return;
+    // Skip native tile updates entirely during TX on the TX-bearing pan.
+    // The FFT-derived path (pushWaterfallRow) is the authoritative TX render
+    // source while transmitting — letting both paths run causes the visible
+    // row to advance at ~2× the FFT cadence, producing alternating "data"
+    // and "stale tile" rows that read visually as horizontal black gaps
+    // between colored rows (#2666 follow-up). Non-TX pans in multi-pan
+    // continue to update normally.
+    if (m_transmitting && m_hasTxSlice) return;
 
     // Suppress post-TX transient noise rows (#2117). The receiver AGC needs
     // ~400 ms to settle after TX→RX; discard waterfall data during that
@@ -3736,12 +3741,22 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins, int destWidth,
     const int h = m_waterfall.height();
     if (h <= 1) return;
 
-    // Throttle FFT-derived rows to the radio's line_duration cadence so the
-    // TX waterfall (and the RX FFT-fallback path) scroll at the same rate as
-    // RX native tiles. FFT frames arrive at the panadapter fps (e.g. 25),
-    // which is ~2.5× faster than the default 100 ms/row line_duration; without
-    // this gate, TX scrolls visibly faster than RX (#2666). Native RX tiles
-    // bypass this path entirely via updateWaterfallRow().
+    // Pace FFT-derived rows to the radio's line_duration cadence so the TX
+    // waterfall (and the RX FFT-fallback path) scroll at the same rate as RX
+    // native tiles. FFT frames arrive at the panadapter fps (e.g. 25), which
+    // is ~2.5× faster than the default 100 ms/row line_duration. Rather than
+    // drop the intermediate frames — which produced visible black gaps
+    // between rows — accumulate them and write an averaged row each window
+    // (#2666 + smoothness follow-up). Native RX tiles bypass this path
+    // entirely via updateWaterfallRow().
+    if (m_fftAccum.size() != bins.size()) {
+        m_fftAccum.assign(bins.size(), 0.0f);
+        m_fftAccumCount = 0;
+    }
+    for (int i = 0; i < bins.size(); ++i)
+        m_fftAccum[i] += bins[i];
+    ++m_fftAccumCount;
+
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
     if (m_lastFftRowMs != 0 && (now - m_lastFftRowMs) < m_wfLineDuration)
         return;
@@ -3750,12 +3765,22 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins, int destWidth,
     Q_UNUSED(tileLowMhz);
     Q_UNUSED(tileHighMhz);
 
+    const float invCount = m_fftAccumCount > 0
+        ? 1.0f / static_cast<float>(m_fftAccumCount)
+        : 1.0f;
+    const int accumSize = m_fftAccum.size();
+
     QVector<QRgb> scanline(destWidth, qRgb(0, 0, 0));
     for (int x = 0; x < destWidth; ++x) {
-        const int binIdx = x * bins.size() / destWidth;
-        const float dbm = (binIdx >= 0 && binIdx < bins.size()) ? bins[binIdx] : m_wfMinDbm;
+        const int binIdx = x * accumSize / destWidth;
+        const float dbm = (binIdx >= 0 && binIdx < accumSize)
+            ? m_fftAccum[binIdx] * invCount
+            : m_wfMinDbm;
         scanline[x] = dbmToRgb(dbm);
     }
+
+    std::fill(m_fftAccum.begin(), m_fftAccum.end(), 0.0f);
+    m_fftAccumCount = 0;
 
     appendHistoryRow(scanline.constData(), QDateTime::currentMSecsSinceEpoch());
     if (m_wfLive) {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -397,6 +397,8 @@ public:
         if (tx && !m_transmitting) {
             m_preTxAutoBlack = m_autoBlackThresh;  // save before TX
             m_lastFftRowMs = 0;  // (#2666) first TX row scrolls immediately
+            std::fill(m_fftAccum.begin(), m_fftAccum.end(), 0.0f);
+            m_fftAccumCount = 0;
         }
         if (!tx && m_transmitting) {
             m_autoBlackThresh = m_preTxAutoBlack;  // restore after TX
@@ -687,6 +689,12 @@ private:
     // FFT-fallback path after native tiles time out) scrolls at the same
     // line_duration cadence as RX native tiles (#2666).
     qint64 m_lastFftRowMs{0};
+    // Accumulator for FFT-derived rows so we average all frames within the
+    // line_duration window instead of dropping the intermediates. Without
+    // this, the TX waterfall paints in discrete stripes with visible black
+    // gaps between rows (#2666 follow-up).
+    QVector<float> m_fftAccum;
+    int            m_fftAccumCount{0};
 
     // Waterfall colour range for FFT-derived fallback (dBm).
     float m_wfMinDbm{-130.0f};


### PR DESCRIPTION
PR #2667's line_duration throttle of pushWaterfallRow stopped the TX
waterfall from scrolling too fast but introduced visible horizontal
black gaps between colored rows.  Two distinct root causes; both
fixed:

1. The throttle dropped ~60% of incoming FFT frames.  Adjacent painted
   rows were temporally non-contiguous — any FFT-frame variation
   (carrier modulation, brief silence) painted a row with very
   different content from its neighbor.  Replaced the drop-frames
   throttle with a per-bin accumulator that sums every frame within
   the line_duration window and writes the averaged row at the
   correct cadence.  Uses all data instead of discarding it.

2. updateWaterfallRow (native tile path) continued firing during TX
   when show-tx-in-waterfall was ON — only suppressed when it was
   OFF.  Result: native tiles wrote nearly-black rows (RX is
   desensitized during TX) at the same time pushWaterfallRow wrote
   colored FFT rows, advancing the visible scroll at 2× the FFT
   cadence and producing the visible alternating gaps.  Now the FFT
   path is the sole row source for the TX-bearing pan during TX.
   Non-TX pans in multi-pan continue normal native-tile updates.

Closes the regression reported with screenshot showing dotted column
of TX carrier with black gaps between dots.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
