### PR TITLE
refactor(gui): migrate 7 dialogs to PersistentDialog base class (#2672). Principle III.

### DIFF
--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -1,113 +1,16 @@
 #include "AetherDspDialog.h"
 #include "AetherDspWidget.h"
-#include "FramelessMoveHelper.h"
-#include "core/AppSettings.h"
 
-#include <QEvent>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QMouseEvent>
-#include <QPushButton>
 #include <QVBoxLayout>
-#include <QWindow>
-
-namespace {
-constexpr int kResizeMargin = 12;
-}
 
 namespace AetherSDR {
 
 AetherDspDialog::AetherDspDialog(AudioEngine* audio, QWidget* parent)
-    : QDialog(parent)
+    : PersistentDialog("AetherDSP Settings", "AetherDspDialogGeometry", parent)
 {
-    setWindowTitle("AetherDSP Settings");
-    setMouseTracking(true);
     setStyleSheet("QDialog { background: #0f0f1a; color: #c8d8e8; }");
 
-    // Outer layout: zero-margin so the title bar runs edge-to-edge.  The
-    // 6 px resize hit zone lives on the bare gap around the inner content
-    // widget (which carries its own padding).
-    auto* root = new QVBoxLayout(this);
-    root->setContentsMargins(0, 0, 0, 0);
-    root->setSpacing(0);
-
-    // ── Custom title bar ─────────────────────────────────────────────
-    // Same chrome family as NetworkDiagnosticsDialog / AetherialAudioStrip:
-    // 18 px tall, blue-gradient background, 10 px bold title, trio of
-    // window-control buttons at the right.
-    {
-        m_titleBar = new QWidget(this);
-        m_titleBar->setFixedHeight(18);
-        m_titleBar->setAttribute(Qt::WA_StyledBackground, true);
-        m_titleBar->setStyleSheet(
-            "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
-            "stop:0 #5a7494, stop:0.5 #384e68, stop:1 #1e2e3e); "
-            "border-bottom: 1px solid #0a1a28; }");
-        m_titleBar->installEventFilter(this);
-
-        auto* tbRow = new QHBoxLayout(m_titleBar);
-        tbRow->setContentsMargins(6, 0, 2, 0);
-        tbRow->setSpacing(4);
-
-        auto* grip = new QLabel(QString::fromUtf8("\xe2\x8b\xae\xe2\x8b\xae"),
-                                m_titleBar);
-        grip->setStyleSheet(
-            "QLabel { background: transparent; color: #a0b4c8;"
-            " font-size: 10px; }");
-        tbRow->addWidget(grip);
-
-        auto* tbTitle = new QLabel("AetherDSP Settings", m_titleBar);
-        tbTitle->setStyleSheet(
-            "QLabel { background: transparent; color: #e0ecf4;"
-            " font-size: 10px; font-weight: bold; }");
-        tbRow->addWidget(tbTitle);
-        tbRow->addStretch();
-
-        const QString btnStyle =
-            "QPushButton { background: transparent; border: none;"
-            " color: #c8d8e8; font-size: 11px; font-weight: bold;"
-            " padding: 0px 4px; }"
-            "QPushButton:hover { color: #ffffff; }";
-        const QString closeBtnStyle =
-            "QPushButton { background: transparent; border: none;"
-            " color: #c8d8e8; font-size: 11px; font-weight: bold;"
-            " padding: 0px 4px; }"
-            "QPushButton:hover { color: #ffffff; background: #cc2030; }";
-
-        auto* minBtn = new QPushButton(QString::fromUtf8("\xe2\x80\x94"), m_titleBar);
-        minBtn->setFixedSize(16, 16);
-        minBtn->setCursor(Qt::ArrowCursor);
-        minBtn->setStyleSheet(btnStyle);
-        minBtn->setToolTip("Minimize");
-        connect(minBtn, &QPushButton::clicked, this, &QWidget::showMinimized);
-        tbRow->addWidget(minBtn);
-
-        auto* maxBtn = new QPushButton(QString::fromUtf8("\xe2\x96\xa1"), m_titleBar);
-        maxBtn->setFixedSize(16, 16);
-        maxBtn->setCursor(Qt::ArrowCursor);
-        maxBtn->setStyleSheet(btnStyle);
-        maxBtn->setToolTip("Maximize");
-        connect(maxBtn, &QPushButton::clicked, this, [this]() {
-            if (isMaximized()) showNormal(); else showMaximized();
-        });
-        tbRow->addWidget(maxBtn);
-
-        auto* closeBtn = new QPushButton(QString::fromUtf8("\xc3\x97"), m_titleBar);
-        closeBtn->setFixedSize(16, 16);
-        closeBtn->setCursor(Qt::ArrowCursor);
-        closeBtn->setStyleSheet(closeBtnStyle);
-        closeBtn->setToolTip("Close");
-        connect(closeBtn, &QPushButton::clicked, this, &QDialog::accept);
-        tbRow->addWidget(closeBtn);
-
-        root->addWidget(m_titleBar);
-    }
-
-    // Content area — 6 px padding on every side keeps the resize hit zone
-    // reachable while the widget carries its own internal margins.
-    auto* content = new QWidget(this);
-    auto* body = new QVBoxLayout(content);
-    body->setContentsMargins(6, 6, 6, 6);
+    auto* body = new QVBoxLayout(bodyWidget());
     body->setSpacing(0);
 
     m_widget = new AetherDspWidget(audio, this);
@@ -115,7 +18,6 @@ AetherDspDialog::AetherDspDialog(AudioEngine* audio, QWidget* parent)
     // row.  Applet path leaves this off and renders at the original sizes.
     m_widget->setDialogMode(true);
     body->addWidget(m_widget);
-    root->addWidget(content, 1);
 
     // Forward every parameter-change signal so existing connections to
     // AetherDspDialog::* keep working unchanged.
@@ -153,28 +55,6 @@ AetherDspDialog::AetherDspDialog(AudioEngine* audio, QWidget* parent)
             this,    &AetherDspDialog::nr4MaskingDepthChanged);
     connect(m_widget, &AetherDspWidget::nr4SuppressionChanged,
             this,    &AetherDspDialog::nr4SuppressionChanged);
-
-    setFramelessMode(
-        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
-}
-
-void AetherDspDialog::setFramelessMode(bool on)
-{
-    const QRect geom = geometry();
-    const bool wasVisible = isVisible();
-
-    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
-    flags.setFlag(Qt::FramelessWindowHint, on);
-    setWindowFlags(flags);
-    if (wasVisible) {
-        setGeometry(geom);
-    }
-    if (m_titleBar) {
-        m_titleBar->setVisible(on);
-    }
-    if (wasVisible) {
-        show();
-    }
 }
 
 void AetherDspDialog::syncFromEngine()
@@ -185,93 +65,6 @@ void AetherDspDialog::syncFromEngine()
 void AetherDspDialog::selectTab(const QString& name)
 {
     if (m_widget) m_widget->selectTab(name);
-}
-
-// ──────────────────────────────────────────────────────────────────
-// Frameless 8-axis resize + drag-to-move
-// ──────────────────────────────────────────────────────────────────
-
-Qt::Edges AetherDspDialog::edgesAt(const QPoint& pos) const
-{
-    if (!(windowFlags() & Qt::FramelessWindowHint)) return {};
-    if (isMaximized() || isFullScreen()) return {};
-    Qt::Edges edges;
-    if (pos.x() <= kResizeMargin)              edges |= Qt::LeftEdge;
-    else if (pos.x() >= width() - kResizeMargin) edges |= Qt::RightEdge;
-    if (pos.y() <= kResizeMargin)              edges |= Qt::TopEdge;
-    else if (pos.y() >= height() - kResizeMargin) edges |= Qt::BottomEdge;
-    return edges;
-}
-
-void AetherDspDialog::updateResizeCursor(const QPoint& pos)
-{
-    const Qt::Edges edges = edgesAt(pos);
-    Qt::CursorShape shape = Qt::ArrowCursor;
-    if ((edges & (Qt::LeftEdge | Qt::TopEdge))     == (Qt::LeftEdge | Qt::TopEdge)
-        || (edges & (Qt::RightEdge | Qt::BottomEdge)) == (Qt::RightEdge | Qt::BottomEdge)) {
-        shape = Qt::SizeFDiagCursor;
-    } else if ((edges & (Qt::RightEdge | Qt::TopEdge))    == (Qt::RightEdge | Qt::TopEdge)
-        ||     (edges & (Qt::LeftEdge | Qt::BottomEdge)) == (Qt::LeftEdge | Qt::BottomEdge)) {
-        shape = Qt::SizeBDiagCursor;
-    } else if (edges & (Qt::LeftEdge | Qt::RightEdge)) {
-        shape = Qt::SizeHorCursor;
-    } else if (edges & (Qt::TopEdge | Qt::BottomEdge)) {
-        shape = Qt::SizeVerCursor;
-    }
-    setCursor(shape);
-}
-
-void AetherDspDialog::mouseMoveEvent(QMouseEvent* ev)
-{
-    if (!(ev->buttons() & Qt::LeftButton))
-        updateResizeCursor(ev->pos());
-    QDialog::mouseMoveEvent(ev);
-}
-
-void AetherDspDialog::mousePressEvent(QMouseEvent* ev)
-{
-    if (ev->button() == Qt::LeftButton) {
-        const Qt::Edges edges = edgesAt(ev->pos());
-        if (edges) {
-            if (auto* h = windowHandle()) {
-                h->startSystemResize(edges);
-                ev->accept();
-                return;
-            }
-        }
-    }
-    QDialog::mousePressEvent(ev);
-}
-
-void AetherDspDialog::leaveEvent(QEvent* ev)
-{
-    setCursor(Qt::ArrowCursor);
-    QDialog::leaveEvent(ev);
-}
-
-bool AetherDspDialog::eventFilter(QObject* obj, QEvent* ev)
-{
-    if (obj == m_titleBar && ev->type() == QEvent::MouseMove) {
-        return FramelessMoveHelper::move(m_titleBar, static_cast<QMouseEvent*>(ev));
-    }
-    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonRelease) {
-        return FramelessMoveHelper::finish(m_titleBar, static_cast<QMouseEvent*>(ev));
-    }
-
-    // Drag-to-move via the custom title bar.  The trio buttons are their
-    // own QPushButtons that consume the press themselves, so this only
-    // fires on the bare title-bar background.
-    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonPress) {
-        auto* me = static_cast<QMouseEvent*>(ev);
-        return FramelessMoveHelper::start(m_titleBar, me);
-    }
-    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonDblClick) {
-        if (isMaximized()) showNormal();
-        else               showMaximized();
-        ev->accept();
-        return true;
-    }
-    return QDialog::eventFilter(obj, ev);
 }
 
 } // namespace AetherSDR

--- a/src/gui/AetherDspDialog.h
+++ b/src/gui/AetherDspDialog.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <QDialog>
-
-class QEvent;
-class QMouseEvent;
+#include "PersistentDialog.h"
 
 namespace AetherSDR {
 
@@ -14,13 +11,11 @@ class AetherDspWidget;
 // Accessible from Settings menu and "AetherDSP Settings..." in right-click
 // popups.  All values persist via AppSettings (PascalCase keys).  The same
 // widget body is also embedded in ClientRxDspApplet for in-chain access.
-class AetherDspDialog : public QDialog {
+class AetherDspDialog : public PersistentDialog {
     Q_OBJECT
 
 public:
     explicit AetherDspDialog(AudioEngine* audio, QWidget* parent = nullptr);
-
-    void setFramelessMode(bool on);
 
     // Sync UI from current AudioEngine state.
     void syncFromEngine();
@@ -56,20 +51,8 @@ signals:
     void nr4MaskingDepthChanged(float value);
     void nr4SuppressionChanged(float value);
 
-protected:
-    // Frameless 8-axis resize + drag-to-move (same pattern as
-    // NetworkDiagnosticsDialog and the AetherialAudioStrip).
-    void mousePressEvent(QMouseEvent* ev) override;
-    void mouseMoveEvent(QMouseEvent* ev) override;
-    void leaveEvent(QEvent* ev) override;
-    bool eventFilter(QObject* obj, QEvent* ev) override;
-
 private:
-    Qt::Edges edgesAt(const QPoint& pos) const;
-    void updateResizeCursor(const QPoint& pos);
-
     AetherDspWidget* m_widget{nullptr};
-    QWidget*         m_titleBar{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1,6 +1,4 @@
 #include "DxClusterDialog.h"
-#include "FramelessResizer.h"
-#include "FramelessWindowTitleBar.h"
 #include "GuardedSlider.h"
 #include "core/DxClusterClient.h"
 #include "core/AppSettings.h"
@@ -244,7 +242,8 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
                                    RadioModel* radioModel,
                                    DxccColorProvider* dxccProvider,
                                    QWidget* parent)
-    : QDialog(parent), m_client(clusterClient), m_rbnClient(rbnClient),
+    : PersistentDialog("SpotHub", "DxClusterDialogGeometry", parent),
+      m_client(clusterClient), m_rbnClient(rbnClient),
       m_wsjtxClient(wsjtxClient), m_spotCollectorClient(spotCollectorClient),
       m_potaClient(potaClient),
 #ifdef HAVE_WEBSOCKETS
@@ -252,26 +251,12 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
 #endif
       m_radioModel(radioModel), m_dxccProvider(dxccProvider)
 {
-    setWindowTitle("SpotHub");
     setMinimumSize(680, 560);
     resize(760, 640);
 
-    // Outer layout hosts the frameless title bar + content area.  The
-    // content area in turn carries the QTabWidget with the existing
-    // body padding, so flipping frameless on/off only adjusts the
-    // outer's top margin and the title bar's visibility.
-    m_outerLayout = new QVBoxLayout(this);
-    m_outerLayout->setSpacing(0);
-    m_outerLayout->setContentsMargins(0, 0, 0, 0);
-
-    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("SpotHub"), this);
-    m_outerLayout->addWidget(m_titleBar);
-
-    auto* content = new QWidget(this);
-    auto* root = new QVBoxLayout(content);
+    auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(0);
     root->setContentsMargins(4, 4, 4, 4);
-    m_outerLayout->addWidget(content, 1);
 
     auto* tabs = new QTabWidget;
     tabs->setStyleSheet(
@@ -292,11 +277,6 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
     buildDisplayTab(tabs);
 
     root->addWidget(tabs);
-
-    // 8-axis edge resize for the frameless mode.
-    FramelessResizer::install(this);
-    setFramelessMode(
-        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
 
     // ── Spot batch timer (1/sec flush) ──────────────────────────────────
     m_spotBatchTimer = new QTimer(this);
@@ -2554,30 +2534,6 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     layout->addStretch();
 
     tabs->addTab(page, "Display");
-}
-
-void DxClusterDialog::setFramelessMode(bool on)
-{
-    const QRect geom = geometry();
-    const bool wasVisible = isVisible();
-
-    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
-    flags.setFlag(Qt::FramelessWindowHint, on);
-    setWindowFlags(flags);
-    if (wasVisible) {
-        setGeometry(geom);
-    }
-
-    if (m_titleBar) {
-        m_titleBar->setVisible(on);
-    }
-    if (m_outerLayout) {
-        m_outerLayout->setContentsMargins(0, 0, 0, 0);
-    }
-
-    if (wasVisible) {
-        show();
-    }
 }
 
 void DxClusterDialog::setTotalSpots(int count)

--- a/src/gui/DxClusterDialog.h
+++ b/src/gui/DxClusterDialog.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <QDialog>
+#include "PersistentDialog.h"
+
 #include <QAbstractTableModel>
 #include <QSortFilterProxyModel>
 #include <QSet>
@@ -22,7 +23,6 @@ class QCheckBox;
 class QPlainTextEdit;
 class QTabWidget;
 class QTableView;
-class QVBoxLayout;
 
 namespace AetherSDR {
 
@@ -77,7 +77,7 @@ private:
 
 // ── Dialog ──────────────────────────────────────────────────────────────────
 
-class DxClusterDialog : public QDialog {
+class DxClusterDialog : public PersistentDialog {
     Q_OBJECT
 
 public:
@@ -93,11 +93,6 @@ public:
 
     void updateStatus();
     void setTotalSpots(int count);
-
-    // Toggle frameless chrome at runtime.  Snapshots geometry + visibility,
-    // flips Qt::FramelessWindowHint, restores.  Called by MainWindow when
-    // the global View → Frameless Window setting changes.
-    void setFramelessMode(bool on);
 
 signals:
     void connectRequested(const QString& host, quint16 port, const QString& callsign);
@@ -143,14 +138,6 @@ private:
     void loadLogFiles(const QString& clusterLog, const QString& rbnLog,
                       const QString& wsjtxLog, const QString& potaLog,
                       const QString& freedvLog = {});
-
-    // Frameless chrome (mirrors ConnectionPanel / NetworkDiagnosticsDialog
-    // pattern): custom 18 px title bar at the top, FramelessResizer on
-    // the body for 8-axis edge resize.  m_outerLayout's top margin is
-    // adjusted in setFramelessMode so the tab strip doesn't double-pad
-    // when the system frame returns.
-    QWidget*              m_titleBar{nullptr};
-    QVBoxLayout*          m_outerLayout{nullptr};
 
     DxClusterClient*      m_client;
     DxClusterClient*      m_rbnClient;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4810,6 +4810,16 @@ ClientPuduEditor* MainWindow::ensureClientPuduEditor()
     return m_clientPuduEditor;
 }
 
+AetherDspDialog* MainWindow::ensureAetherDspDialog()
+{
+    const bool wasFresh = !m_dspDialog;
+    showOrRaisePersistent(m_dspDialog, m_audio);
+    if (wasFresh && m_dspDialog) {
+        if (auto* w = m_dspDialog->widget()) wireAetherDspWidget(w);
+    }
+    return m_dspDialog.data();
+}
+
 void MainWindow::wireAetherDspWidget(AetherDspWidget* w)
 {
     if (!w || !m_audio) return;
@@ -5241,17 +5251,8 @@ bool MainWindow::handleCwMomentaryShortcut(QKeyEvent* keyEvent, QEvent::Type eve
 
 void MainWindow::showNetworkDiagnosticsDialog()
 {
-    if (!m_networkDiagnosticsDialog) {
-        auto* dlg = new NetworkDiagnosticsDialog(&m_radioModel, m_audio, m_networkDiagnosticsHistory, this);
-        dlg->setAttribute(Qt::WA_DeleteOnClose);
-        dlg->setModal(false);
-        dlg->setWindowModality(Qt::NonModal);
-        m_networkDiagnosticsDialog = dlg;
-    }
-
-    m_networkDiagnosticsDialog->show();
-    m_networkDiagnosticsDialog->raise();
-    m_networkDiagnosticsDialog->activateWindow();
+    showOrRaisePersistent(m_networkDiagnosticsDialog,
+                          &m_radioModel, m_audio, m_networkDiagnosticsHistory);
 }
 
 QJsonObject MainWindow::buildControlDevicesSnapshot() const
@@ -5832,26 +5833,19 @@ void MainWindow::toggleConnectionDialog()
 
 void MainWindow::showMemoryDialog()
 {
-    if (m_memoryDialog) {
-        m_memoryDialog->show();
-        m_memoryDialog->raise();
-        m_memoryDialog->activateWindow();
-        return;
+    const bool wasFresh = !m_memoryDialog;
+    showOrRaisePersistent(m_memoryDialog, &m_radioModel);
+    if (wasFresh && m_memoryDialog) {
+        connect(m_memoryDialog.data(), &MemoryDialog::memoryActivated,
+                this, [this](int memoryIndex) { activateMemorySpot(memoryIndex); });
+        connect(m_memoryDialog.data(), &QObject::destroyed, this, [this] {
+            if (m_shuttingDown)
+                return;
+            auto& s = AppSettings::instance();
+            s.setValue("MemoryDialogOpen", "False");
+            s.save();
+        });
     }
-
-    auto* dlg = new MemoryDialog(&m_radioModel, this);
-    dlg->setAttribute(Qt::WA_DeleteOnClose);
-    connect(dlg, &MemoryDialog::memoryActivated,
-            this, [this](int memoryIndex) { activateMemorySpot(memoryIndex); });
-    connect(dlg, &QObject::destroyed, this, [this] {
-        if (m_shuttingDown)
-            return;
-        auto& s = AppSettings::instance();
-        s.setValue("MemoryDialogOpen", "False");
-        s.save();
-    });
-    m_memoryDialog = dlg;
-    dlg->show();
 }
 
 SliceModel* MainWindow::preferredMemorySlice(const QString& preferredPanId) const
@@ -6336,36 +6330,22 @@ void MainWindow::buildMenuBar()
 #ifdef HAVE_MIDI
     auto* midiAction = settingsMenu->addAction("MIDI Mapping...");
     connect(midiAction, &QAction::triggered, this, [this] {
-        if (m_midiDialog) {
-            m_midiDialog->raise();
-            m_midiDialog->activateWindow();
-            return;
-        }
-        auto* dlg = new MidiMappingDialog(m_midiControl, this);
-        dlg->setAttribute(Qt::WA_DeleteOnClose);
-        m_midiDialog = dlg;
-        dlg->setFramelessMode(framelessWindowEnabled());
-        dlg->show();
+        showOrRaisePersistent(m_midiDialog, m_midiControl);
     });
 #endif
 #ifdef HAVE_HIDAPI
 #endif
     auto* spotsAction = settingsMenu->addAction("SpotHub...");
     connect(spotsAction, &QAction::triggered, this, [this] {
-        // Raise existing dialog if already open
-        if (m_spotHubDialog) {
-            m_spotHubDialog->raise();
-            m_spotHubDialog->activateWindow();
-            return;
-        }
-        auto* dlg = new DxClusterDialog(m_dxCluster, m_rbnClient, m_wsjtxClient,
-                            m_spotCollectorClient, m_potaClient,
+        const bool wasFresh = !m_spotHubDialog;
+        showOrRaisePersistent(m_spotHubDialog, m_dxCluster, m_rbnClient, m_wsjtxClient,
+                              m_spotCollectorClient, m_potaClient,
 #ifdef HAVE_WEBSOCKETS
-                            m_freedvClient,
+                              m_freedvClient,
 #endif
-                            &m_radioModel, &m_dxccProvider, this);
-        dlg->setAttribute(Qt::WA_DeleteOnClose);
-        m_spotHubDialog = dlg;
+                              &m_radioModel, &m_dxccProvider);
+        if (!wasFresh || !m_spotHubDialog) return;
+        auto* dlg = m_spotHubDialog.data();
         dlg->setTotalSpots(m_radioModel.spotModel().spots().size());
         // Live preview: refresh spots on every display settings change
         auto refreshSpots = [this]() {
@@ -6494,7 +6474,6 @@ void MainWindow::buildMenuBar()
                 sl->setMode(radioMode);
         });
         connect(dlg, &QDialog::finished, this, refreshSpots);  // refresh on close
-        dlg->show();
     });
     auto* multiFlexAction = settingsMenu->addAction("multiFLEX...");
     auto openMultiFlex = [this] {
@@ -6741,16 +6720,7 @@ void MainWindow::buildMenuBar()
     auto* dspAction = settingsMenu->addAction("AetherDSP Settings...");
     dspAction->setMenuRole(QAction::NoRole);        // prevent macOS auto-reparenting (#883)
     connect(dspAction, &QAction::triggered, this, [this] {
-        if (m_dspDialog) {
-            m_dspDialog->raise();
-            m_dspDialog->activateWindow();
-            return;
-        }
-        auto* dlg = new AetherDspDialog(m_audio, this);
-        dlg->setAttribute(Qt::WA_DeleteOnClose);
-        if (auto* w = dlg->widget()) wireAetherDspWidget(w);
-        m_dspDialog = dlg;
-        dlg->show();
+        ensureAetherDspDialog();
     });
     // RX chain DSP tile double-click also opens the full AetherDSP
     // Settings dialog — same entry point as the Settings menu action.
@@ -11232,16 +11202,7 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     // Settings menu action and the RX chain double-click; reuses the
     // existing modeless m_dspDialog when one is already open.
     connect(w, &VfoWidget::aetherDspRequested, this, [this] {
-        if (m_dspDialog) {
-            m_dspDialog->raise();
-            m_dspDialog->activateWindow();
-            return;
-        }
-        auto* dlg = new AetherDspDialog(m_audio, this);
-        dlg->setAttribute(Qt::WA_DeleteOnClose);
-        if (auto* dspWidget = dlg->widget()) wireAetherDspWidget(dspWidget);
-        m_dspDialog = dlg;
-        dlg->show();
+        ensureAetherDspDialog();
     });
 
     // AetherVoice button on the per-slice DSP tab — toggles the Aetherial
@@ -11569,17 +11530,9 @@ void MainWindow::setFramelessWindow(bool on)
         m_appletPanel->containerManager()->setFramelessMode(on);
     if (m_connPanel)
         m_connPanel->setFramelessMode(on);
-    if (auto* dlg = qobject_cast<NetworkDiagnosticsDialog*>(m_networkDiagnosticsDialog))
-        dlg->setFramelessMode(on);
     if (auto* dlg = qobject_cast<PropDashboardDialog*>(m_propDashboardDialog))
         dlg->setFramelessMode(on);
     if (auto* dlg = qobject_cast<RadioSetupDialog*>(m_radioSetupDialog))
-        dlg->setFramelessMode(on);
-    if (auto* dlg = qobject_cast<AetherDspDialog*>(m_dspDialog))
-        dlg->setFramelessMode(on);
-    if (auto* dlg = qobject_cast<DxClusterDialog*>(m_spotHubDialog))
-        dlg->setFramelessMode(on);
-    if (auto* dlg = qobject_cast<MemoryDialog*>(m_memoryDialog))
         dlg->setFramelessMode(on);
     // Profile Import/Export hasn't been migrated to PersistentDialog yet
     // (#2605 follow-up), so it still needs an explicit cast.  Profile
@@ -11587,11 +11540,6 @@ void MainWindow::setFramelessWindow(bool on)
     // below.
     if (m_profileImportExportDialog)
         m_profileImportExportDialog->setFramelessMode(on);
-#ifdef HAVE_MIDI
-    if (auto* dlg = qobject_cast<MidiMappingDialog*>(m_midiDialog)) {
-        dlg->setFramelessMode(on);
-    }
-#endif
     if (m_txBandDialog) {
         setDialogFramelessMode(m_txBandDialog, on);
     }
@@ -11716,18 +11664,7 @@ void MainWindow::toggleAetherialStrip()
         // ADSP launcher tile → open / focus the AetherDsp Settings
         // dialog, same as the Settings menu action.
         connect(m_aetherialStrip, &AetherialAudioStrip::rxDspEditRequested,
-                this, [this]() {
-            if (m_dspDialog) {
-                m_dspDialog->raise();
-                m_dspDialog->activateWindow();
-                return;
-            }
-            auto* dlg = new AetherDspDialog(m_audio, this);
-            dlg->setAttribute(Qt::WA_DeleteOnClose);
-            if (auto* w = dlg->widget()) wireAetherDspWidget(w);
-            m_dspDialog = dlg;
-            dlg->show();
-        });
+                this, [this]() { ensureAetherDspDialog(); });
         // PUDU monitor record / play — same toggle logic as the docked
         // ClientChainApplet.
         connect(m_aetherialStrip, &AetherialAudioStrip::monitorRecordClicked,
@@ -12528,71 +12465,7 @@ void MainWindow::showNr2ParamPopup(const QPoint& globalPos)
         });
 
     popup->finalize(
-        [this]() {
-            // Open AetherDSP Settings dialog
-            if (m_dspDialog) {
-                m_dspDialog->raise();
-                m_dspDialog->activateWindow();
-                return;
-            }
-            auto* dlg = new AetherDspDialog(m_audio, this);
-            dlg->setAttribute(Qt::WA_DeleteOnClose);
-            connect(dlg, &AetherDspDialog::nr2GainMaxChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainMax(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr2GainSmoothChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainSmooth(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr2QsppChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2Qspp(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr2GainMethodChanged, this, [this](int m) {
-                QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2GainMethod(m); });
-            });
-            connect(dlg, &AetherDspDialog::nr2NpeMethodChanged, this, [this](int m) {
-                QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2NpeMethod(m); });
-            });
-            connect(dlg, &AetherDspDialog::nr2AeFilterChanged, this, [this](bool on) {
-                QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr2AeFilter(on); });
-            });
-            // Wire NR4 parameter signals
-            connect(dlg, &AetherDspDialog::nr4ReductionChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4ReductionAmount(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4SmoothingChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4SmoothingFactor(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4WhiteningChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4WhiteningFactor(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4AdaptiveNoiseChanged, this, [this](bool on) {
-                QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr4AdaptiveNoise(on); });
-            });
-            connect(dlg, &AetherDspDialog::nr4NoiseMethodChanged, this, [this](int m) {
-                QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr4NoiseEstimationMethod(m); });
-            });
-            connect(dlg, &AetherDspDialog::nr4MaskingDepthChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4MaskingDepth(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4SuppressionChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4SuppressionStrength(v); });
-            });
-            connect(dlg, &AetherDspDialog::dfnrAttenLimitChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrAttenLimit(v); });
-            });
-            connect(dlg, &AetherDspDialog::dfnrPostFilterBetaChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrPostFilterBeta(v); });
-            });
-            // Wire MNR enable / strength signals
-            connect(dlg, &AetherDspDialog::mnrEnabledChanged, this, [this](bool on) {
-                QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setMnrEnabled(on); });
-            });
-            connect(dlg, &AetherDspDialog::mnrStrengthChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setMnrStrength(v); });
-            });
-            m_dspDialog = dlg;
-            dlg->show();
-        },
+        [this]() { ensureAetherDspDialog(); },
         nullptr  // Reset handled by individual control resetters
     );
 
@@ -12657,70 +12530,7 @@ void MainWindow::showNr4ParamPopup(const QPoint& globalPos)
         });
 
     popup->finalize(
-        [this]() {
-            // Open AetherDSP Settings dialog (NR4 tab)
-            if (m_dspDialog) {
-                m_dspDialog->raise();
-                m_dspDialog->activateWindow();
-                return;
-            }
-            auto* dlg = new AetherDspDialog(m_audio, this);
-            dlg->setAttribute(Qt::WA_DeleteOnClose);
-            connect(dlg, &AetherDspDialog::nr2GainMaxChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainMax(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr2GainSmoothChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainSmooth(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr2QsppChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2Qspp(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr2GainMethodChanged, this, [this](int m) {
-                QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2GainMethod(m); });
-            });
-            connect(dlg, &AetherDspDialog::nr2NpeMethodChanged, this, [this](int m) {
-                QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2NpeMethod(m); });
-            });
-            connect(dlg, &AetherDspDialog::nr2AeFilterChanged, this, [this](bool on) {
-                QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr2AeFilter(on); });
-            });
-            connect(dlg, &AetherDspDialog::nr4ReductionChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4ReductionAmount(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4SmoothingChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4SmoothingFactor(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4WhiteningChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4WhiteningFactor(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4AdaptiveNoiseChanged, this, [this](bool on) {
-                QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr4AdaptiveNoise(on); });
-            });
-            connect(dlg, &AetherDspDialog::nr4NoiseMethodChanged, this, [this](int m) {
-                QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr4NoiseEstimationMethod(m); });
-            });
-            connect(dlg, &AetherDspDialog::nr4MaskingDepthChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4MaskingDepth(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4SuppressionChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4SuppressionStrength(v); });
-            });
-            connect(dlg, &AetherDspDialog::dfnrAttenLimitChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrAttenLimit(v); });
-            });
-            connect(dlg, &AetherDspDialog::dfnrPostFilterBetaChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrPostFilterBeta(v); });
-            });
-            // Wire MNR enable / strength signals
-            connect(dlg, &AetherDspDialog::mnrEnabledChanged, this, [this](bool on) {
-                QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setMnrEnabled(on); });
-            });
-            connect(dlg, &AetherDspDialog::mnrStrengthChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setMnrStrength(v); });
-            });
-            m_dspDialog = dlg;
-            dlg->show();
-        },
+        [this]() { ensureAetherDspDialog(); },
         nullptr  // Reset handled by individual control resetters
     );
 
@@ -12755,71 +12565,7 @@ void MainWindow::showDfnrParamPopup(const QPoint& globalPos)
         });
 
     popup->finalize(
-        [this]() {
-            // Open AetherDSP Settings dialog (DFNR tab)
-            if (m_dspDialog) {
-                m_dspDialog->raise();
-                m_dspDialog->activateWindow();
-                return;
-            }
-            auto* dlg = new AetherDspDialog(m_audio, this);
-            dlg->setAttribute(Qt::WA_DeleteOnClose);
-            connect(dlg, &AetherDspDialog::dfnrAttenLimitChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrAttenLimit(v); });
-            });
-            connect(dlg, &AetherDspDialog::dfnrPostFilterBetaChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrPostFilterBeta(v); });
-            });
-            // Wire NR2/NR4 signals too (shared dialog)
-            connect(dlg, &AetherDspDialog::nr2GainMaxChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainMax(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr2GainSmoothChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainSmooth(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr2QsppChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2Qspp(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr2GainMethodChanged, this, [this](int m) {
-                QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2GainMethod(m); });
-            });
-            connect(dlg, &AetherDspDialog::nr2NpeMethodChanged, this, [this](int m) {
-                QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2NpeMethod(m); });
-            });
-            connect(dlg, &AetherDspDialog::nr2AeFilterChanged, this, [this](bool on) {
-                QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr2AeFilter(on); });
-            });
-            connect(dlg, &AetherDspDialog::nr4ReductionChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4ReductionAmount(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4SmoothingChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4SmoothingFactor(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4WhiteningChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4WhiteningFactor(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4AdaptiveNoiseChanged, this, [this](bool on) {
-                QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr4AdaptiveNoise(on); });
-            });
-            connect(dlg, &AetherDspDialog::nr4NoiseMethodChanged, this, [this](int m) {
-                QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr4NoiseEstimationMethod(m); });
-            });
-            connect(dlg, &AetherDspDialog::nr4MaskingDepthChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4MaskingDepth(v); });
-            });
-            connect(dlg, &AetherDspDialog::nr4SuppressionChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr4SuppressionStrength(v); });
-            });
-            // Wire MNR enable / strength signals
-            connect(dlg, &AetherDspDialog::mnrEnabledChanged, this, [this](bool on) {
-                QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setMnrEnabled(on); });
-            });
-            connect(dlg, &AetherDspDialog::mnrStrengthChanged, this, [this](float v) {
-                QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setMnrStrength(v); });
-            });
-            m_dspDialog = dlg;
-            dlg->show();
-        },
+        [this]() { ensureAetherDspDialog(); },
         nullptr
     );
 
@@ -12828,48 +12574,9 @@ void MainWindow::showDfnrParamPopup(const QPoint& globalPos)
 
 void MainWindow::showMnrSettings()
 {
-    if (m_dspDialog) {
-        m_dspDialog->raise();
-        m_dspDialog->activateWindow();
-        if (auto* d = qobject_cast<AetherDspDialog*>(m_dspDialog))
-            d->selectTab("MNR");
-        return;
+    if (auto* dlg = ensureAetherDspDialog()) {
+        dlg->selectTab("MNR");
     }
-    auto* dlg = new AetherDspDialog(m_audio, this);
-    dlg->setAttribute(Qt::WA_DeleteOnClose);
-    connect(dlg, &AetherDspDialog::mnrEnabledChanged, this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setMnrEnabled(on); });
-    });
-    connect(dlg, &AetherDspDialog::mnrStrengthChanged, this, [this](float v) {
-        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setMnrStrength(v); });
-    });
-    connect(dlg, &AetherDspDialog::nr2GainMaxChanged, this, [this](float v) {
-        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainMax(v); });
-    });
-    connect(dlg, &AetherDspDialog::nr2GainSmoothChanged, this, [this](float v) {
-        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainSmooth(v); });
-    });
-    connect(dlg, &AetherDspDialog::nr2QsppChanged, this, [this](float v) {
-        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2Qspp(v); });
-    });
-    connect(dlg, &AetherDspDialog::nr2GainMethodChanged, this, [this](int m) {
-        QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2GainMethod(m); });
-    });
-    connect(dlg, &AetherDspDialog::nr2NpeMethodChanged, this, [this](int m) {
-        QMetaObject::invokeMethod(m_audio, [this, m]() { m_audio->setNr2NpeMethod(m); });
-    });
-    connect(dlg, &AetherDspDialog::nr2AeFilterChanged, this, [this](bool on) {
-        QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setNr2AeFilter(on); });
-    });
-    connect(dlg, &AetherDspDialog::dfnrAttenLimitChanged, this, [this](float v) {
-        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrAttenLimit(v); });
-    });
-    connect(dlg, &AetherDspDialog::dfnrPostFilterBetaChanged, this, [this](float v) {
-        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrPostFilterBeta(v); });
-    });
-    m_dspDialog = dlg;
-    dlg->selectTab("MNR");
-    dlg->show();
 }
 
 void MainWindow::applyPanLayout(const QString& layoutId)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -80,6 +80,11 @@ class NetworkDiagnosticsHistory;
 class WhatsNewDialog;
 class ProfileManagerDialog;
 class ProfileImportExportDialog;
+class NetworkDiagnosticsDialog;
+class MemoryDialog;
+class AetherDspDialog;
+class DxClusterDialog;
+class MidiMappingDialog;
 class CwxPanel;
 class DvkPanel;
 #ifdef HAVE_RADE
@@ -241,6 +246,13 @@ private:
     // Example: showOrRaisePersistent(m_profileManagerDialog, &m_radioModel);
     template <class T, class... Args>
     void showOrRaisePersistent(QPointer<T>& slot, Args&&... ctorArgs);
+
+    // Create-or-raise helper for the AetherDSP Settings dialog.  Centralizes
+    // the ~17 audio-parameter signal connections that every call site was
+    // duplicating; on first construction wires them once, on subsequent calls
+    // just raises the existing instance.  Returns nullptr only if construction
+    // failed (e.g. allocation failure).
+    AetherDspDialog* ensureAetherDspDialog();
 
     // Reorder the main splitter so the applet panel sits on the left or
     // right of the panadapter stack.  Wired from the dock-side icons in
@@ -475,18 +487,18 @@ private:
     AppletPanel*     m_appletPanel{nullptr};
 
     // Modeless dialogs
-    QPointer<QDialog> m_spotHubDialog;
+    QPointer<DxClusterDialog> m_spotHubDialog;
     QPointer<QDialog> m_radioSetupDialog;
-    QPointer<QDialog> m_networkDiagnosticsDialog;
+    QPointer<NetworkDiagnosticsDialog> m_networkDiagnosticsDialog;
     QPointer<QDialog> m_propDashboardDialog;
     QPointer<QDialog> m_txBandDialog;
-    QPointer<QDialog> m_memoryDialog;
+    QPointer<MemoryDialog> m_memoryDialog;
     QPointer<WhatsNewDialog> m_whatsNewDialog;
-    QPointer<QDialog> m_dspDialog;
+    QPointer<AetherDspDialog> m_dspDialog;
     QPointer<ProfileManagerDialog> m_profileManagerDialog;
     QPointer<ProfileImportExportDialog> m_profileImportExportDialog;
 #ifdef HAVE_MIDI
-    QPointer<QDialog> m_midiDialog;
+    QPointer<MidiMappingDialog> m_midiDialog;
 #endif
 
     // Tracks every PersistentDialog created via showOrRaisePersistent() so

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -1,8 +1,5 @@
 #include "MemoryDialog.h"
-#include "FramelessResizer.h"
-#include "FramelessWindowTitleBar.h"
 #include "MemoryCommands.h"
-#include "core/AppSettings.h"
 #include "core/MemoryCsvCompat.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
@@ -224,26 +221,12 @@ static const QStringList COLUMNS = {
 };
 
 MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
-    : QDialog(parent), m_model(model)
+    : PersistentDialog("Memory Channels", "MemoryDialogGeometry", parent),
+      m_model(model)
 {
-    setWindowTitle("Memory Channels");
     resize(1000, 500);
 
-    // Outer layout hosts the frameless title bar + content area.  The
-    // existing dialog body layout (search row, table, buttons) lives
-    // inside `content` so flipping frameless on/off only adjusts the
-    // title bar's visibility and outer margin.
-    m_outerLayout = new QVBoxLayout(this);
-    m_outerLayout->setSpacing(0);
-    m_outerLayout->setContentsMargins(0, 0, 0, 0);
-
-    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("Memory Channels"), this);
-    m_outerLayout->addWidget(m_titleBar);
-
-    auto* content = new QWidget(this);
-    m_outerLayout->addWidget(content, 1);
-
-    auto* root = new QVBoxLayout(content);
+    auto* root = new QVBoxLayout(bodyWidget());
 
     // ── Search + profile filter ──────────────────────────────────────────
     auto* filterRow = new QHBoxLayout;
@@ -387,40 +370,6 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     // If cache is empty, memories may not have been pushed yet. As a fallback,
     // new memories created via Add will populate the table immediately.
     populateTable();
-
-    // 8-axis edge resize for the frameless mode.
-    FramelessResizer::install(this);
-    setFramelessMode(
-        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
-}
-
-void MemoryDialog::setFramelessMode(bool on)
-{
-    const QRect geom = geometry();
-    const bool wasVisible = isVisible();
-
-    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
-    flags.setFlag(Qt::FramelessWindowHint, on);
-    setWindowFlags(flags);
-    if (wasVisible) {
-        setGeometry(geom);
-    }
-
-    if (m_titleBar) {
-        m_titleBar->setVisible(on);
-    }
-    if (m_outerLayout) {
-        m_outerLayout->setContentsMargins(0, 0, 0, 0);
-    }
-
-    if (wasVisible) {
-        show();
-    }
-}
-
-void MemoryDialog::closeEvent(QCloseEvent* event)
-{
-    QDialog::closeEvent(event);
 }
 
 void MemoryDialog::keyPressEvent(QKeyEvent* event)
@@ -512,7 +461,7 @@ bool MemoryDialog::eventFilter(QObject* watched, QEvent* event)
 
 void MemoryDialog::showEvent(QShowEvent* event)
 {
-    QDialog::showEvent(event);
+    PersistentDialog::showEvent(event);
     if (m_searchEdit)
         m_searchEdit->setFocus(Qt::OtherFocusReason);
 }

--- a/src/gui/MemoryDialog.h
+++ b/src/gui/MemoryDialog.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <QDialog>
-#include <QCloseEvent>
+#include "PersistentDialog.h"
+
 #include <QEvent>
 #include <QKeyEvent>
 #include <QShowEvent>
@@ -13,29 +13,21 @@ class QComboBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
-class QVBoxLayout;
 
 namespace AetherSDR {
 
 class RadioModel;
 
-class MemoryDialog : public QDialog {
+class MemoryDialog : public PersistentDialog {
     Q_OBJECT
 
 public:
     explicit MemoryDialog(RadioModel* model, QWidget* parent = nullptr);
 
-    // Toggle frameless chrome at runtime — mirrors the SpotHub /
-    // RadioSetup pattern.  Snapshots geometry + visibility, flips
-    // Qt::FramelessWindowHint, restores.  Called by MainWindow when
-    // the global View → Frameless Window setting changes.
-    void setFramelessMode(bool on);
-
 Q_SIGNALS:
     void memoryActivated(int memoryIndex);
 
 protected:
-    void closeEvent(QCloseEvent* event) override;
     bool eventFilter(QObject* watched, QEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void showEvent(QShowEvent* event) override;
@@ -73,12 +65,6 @@ private:
     bool m_inlineEditMode{false};
     int m_sortColumn{2};
     Qt::SortOrder m_sortOrder{Qt::AscendingOrder};
-
-    // Frameless chrome (mirrors SpotHub / RadioSetup): custom title
-    // bar at the top, FramelessResizer on the body for 8-axis edge
-    // resize.
-    QWidget*     m_titleBar{nullptr};
-    QVBoxLayout* m_outerLayout{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -1,9 +1,6 @@
 #ifdef HAVE_MIDI
 
 #include "MidiMappingDialog.h"
-#include "FramelessResizer.h"
-#include "FramelessWindowTitleBar.h"
-#include "core/AppSettings.h"
 #include "core/MidiControlManager.h"
 #include "core/MidiSettings.h"
 
@@ -16,7 +13,6 @@
 #include <QLineEdit>
 #include <QInputDialog>
 #include <QMessageBox>
-#include <QRect>
 
 namespace AetherSDR {
 
@@ -39,25 +35,14 @@ static const QString kBtnStyle =
     "QPushButton:disabled { background: #404060; color: #808080; }";
 
 MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* parent)
-    : QDialog(parent), m_manager(manager)
+    : PersistentDialog("MIDI Controller Mapping", "MidiMappingDialogGeometry", parent),
+      m_manager(manager)
 {
-    setWindowTitle("MIDI Controller Mapping");
     setMinimumSize(700, 550);
     setStyleSheet("QDialog { background: #0f0f1a; }");
 
-    auto* outer = new QVBoxLayout(this);
-    outer->setContentsMargins(0, 0, 0, 0);
-    outer->setSpacing(0);
-
-    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("MIDI Controller Mapping"), this);
-    outer->addWidget(m_titleBar);
-
-    auto* bodyWidget = new QWidget(this);
-    auto* root = new QVBoxLayout(bodyWidget);
-    root->setContentsMargins(9, 9, 9, 9);
+    auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(8);
-    m_bodyLayout = root;
-    outer->addWidget(bodyWidget, 1);
 
     // ── Device section ──────────────────────────────────────────────────
     {
@@ -279,33 +264,6 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
 
     if (m_manager->isOpen()) {
         m_connectBtn->setText("Disconnect");
-    }
-
-    FramelessResizer::install(this);
-    setFramelessMode(
-        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
-}
-
-void MidiMappingDialog::setFramelessMode(bool on)
-{
-    const QRect geom = geometry();
-    const bool wasVisible = isVisible();
-
-    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
-    flags.setFlag(Qt::FramelessWindowHint, on);
-    setWindowFlags(flags);
-    if (wasVisible) {
-        setGeometry(geom);
-    }
-
-    if (m_titleBar) {
-        m_titleBar->setVisible(on);
-    }
-    if (m_bodyLayout) {
-        m_bodyLayout->setContentsMargins(9, on ? 7 : 9, 9, 9);
-    }
-    if (wasVisible) {
-        show();
     }
 }
 

--- a/src/gui/MidiMappingDialog.h
+++ b/src/gui/MidiMappingDialog.h
@@ -2,13 +2,12 @@
 
 #ifdef HAVE_MIDI
 
-#include <QDialog>
+#include "PersistentDialog.h"
+
 #include <QTableWidget>
 #include <QComboBox>
 #include <QLabel>
 #include <QPushButton>
-
-class QVBoxLayout;
 
 namespace AetherSDR {
 
@@ -18,12 +17,11 @@ class MidiControlManager;
 // controller bindings. Opened from Settings → MIDI Mapping.
 // Shows device selector, binding table with Learn mode, and profile
 // save/load. All bindings stored in ~/.config/AetherSDR/midi.settings.
-class MidiMappingDialog : public QDialog {
+class MidiMappingDialog : public PersistentDialog {
     Q_OBJECT
 
 public:
     explicit MidiMappingDialog(MidiControlManager* manager, QWidget* parent = nullptr);
-    void setFramelessMode(bool on);
 
 private:
     void refreshPortList();
@@ -40,8 +38,6 @@ private:
     QComboBox*    m_paramCombo;
     QComboBox*    m_categoryCombo;
     QComboBox*    m_profileCombo;
-    QWidget*      m_titleBar{nullptr};
-    QVBoxLayout*  m_bodyLayout{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/MultiFlexDialog.cpp
+++ b/src/gui/MultiFlexDialog.cpp
@@ -1,14 +1,10 @@
 #include "MultiFlexDialog.h"
-#include "FramelessResizer.h"
-#include "FramelessWindowTitleBar.h"
-#include "core/AppSettings.h"
 #include "models/RadioModel.h"
 
 #include <QBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
 #include <QPushButton>
-#include <QRect>
 #include <QTableWidget>
 
 namespace AetherSDR {
@@ -26,26 +22,15 @@ static const char* kDialogStyle =
     "  border: 1px solid #203040; padding: 6px; font-weight: bold; }";
 
 MultiFlexDialog::MultiFlexDialog(RadioModel* model, QWidget* parent)
-    : QDialog(parent), m_model(model)
+    : PersistentDialog("multiFLEX Dashboard", "MultiFlexDialogGeometry", parent),
+      m_model(model)
 {
-    setWindowTitle("multiFLEX Dashboard");
     setMinimumSize(550, 280);
     resize(600, 320);
     setStyleSheet(kDialogStyle);
 
-    auto* outer = new QVBoxLayout(this);
-    outer->setContentsMargins(0, 0, 0, 0);
-    outer->setSpacing(0);
-
-    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("multiFLEX Dashboard"), this);
-    outer->addWidget(m_titleBar);
-
-    auto* bodyWidget = new QWidget(this);
-    auto* root = new QVBoxLayout(bodyWidget);
-    root->setContentsMargins(9, 9, 9, 9);
+    auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(10);
-    m_bodyLayout = root;
-    outer->addWidget(bodyWidget, 1);
 
     // Title
     auto* title = new QLabel("multiFLEX Stations");
@@ -106,33 +91,6 @@ MultiFlexDialog::MultiFlexDialog(RadioModel* model, QWidget* parent)
     connect(m_table, &QTableWidget::itemSelectionChanged, this, [this]() { refresh(); });
 
     refresh();
-
-    FramelessResizer::install(this);
-    setFramelessMode(
-        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
-}
-
-void MultiFlexDialog::setFramelessMode(bool on)
-{
-    const QRect geom = geometry();
-    const bool wasVisible = isVisible();
-
-    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
-    flags.setFlag(Qt::FramelessWindowHint, on);
-    setWindowFlags(flags);
-    if (wasVisible) {
-        setGeometry(geom);
-    }
-
-    if (m_titleBar) {
-        m_titleBar->setVisible(on);
-    }
-    if (m_bodyLayout) {
-        m_bodyLayout->setContentsMargins(9, on ? 7 : 9, 9, 9);
-    }
-    if (wasVisible) {
-        show();
-    }
 }
 
 void MultiFlexDialog::refresh()

--- a/src/gui/MultiFlexDialog.h
+++ b/src/gui/MultiFlexDialog.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <QDialog>
+#include "PersistentDialog.h"
 
-class QVBoxLayout;
 class QTableWidget;
 class QPushButton;
 class QLabel;
@@ -11,11 +10,10 @@ namespace AetherSDR {
 
 class RadioModel;
 
-class MultiFlexDialog : public QDialog {
+class MultiFlexDialog : public PersistentDialog {
     Q_OBJECT
 public:
     explicit MultiFlexDialog(RadioModel* model, QWidget* parent = nullptr);
-    void setFramelessMode(bool on);
 
 private:
     void refresh();
@@ -25,8 +23,6 @@ private:
     QPushButton* m_enableBtn;
     QLabel* m_pttLabel;
     QPushButton* m_pttBtn;
-    QWidget* m_titleBar{nullptr};
-    QVBoxLayout* m_bodyLayout{nullptr};
     bool m_refreshing{false};
 };
 

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1,6 +1,4 @@
 #include "NetworkDiagnosticsDialog.h"
-#include "FramelessMoveHelper.h"
-#include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/LogManager.h"
 #include "models/RadioModel.h"
@@ -11,7 +9,6 @@
 
 #include <QComboBox>
 #include <QDateTime>
-#include <QEvent>
 #include <QFileInfo>
 #include <QFont>
 #include <QFrame>
@@ -19,7 +16,6 @@
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <QCheckBox>
-#include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPlainTextEdit>
@@ -34,11 +30,6 @@
 #include <QTabWidget>
 #include <QTextCharFormat>
 #include <QVBoxLayout>
-#include <QWindow>
-
-namespace {
-constexpr int kResizeMargin = 6;
-}
 
 namespace AetherSDR {
 
@@ -585,14 +576,11 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
                                                    AudioEngine* audio,
                                                    NetworkDiagnosticsHistory* history,
                                                    QWidget* parent)
-    : QDialog(parent), m_model(model), m_audio(audio), m_history(history)
+    : PersistentDialog("Network Diagnostics", "NetworkDiagnosticsDialogGeometry", parent),
+      m_model(model), m_audio(audio), m_history(history)
 {
-    setWindowTitle("Network Diagnostics");
     setMinimumSize(920, 680);
     resize(980, 760);
-    // Track mouse without buttons pressed so the resize cursor updates
-    // while hovering the bare margin around the dialog body.
-    setMouseTracking(true);
     setStyleSheet(
         "QDialog { background: #050710; }"
         "QTabWidget::pane { border: 1px solid #203040; border-radius: 4px; top: -1px; }"
@@ -607,95 +595,8 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
         "QScrollArea { background: transparent; border: none; }"
         "QScrollArea > QWidget > QWidget { background: transparent; }");
 
-    // Outer layout: zero-margin so the title bar runs edge-to-edge.  The
-    // 8 px resize hit zone lives on the bare gap around the inner content
-    // widget (which carries its own padding).
-    auto* root = new QVBoxLayout(this);
-    root->setContentsMargins(0, 0, 0, 0);
-    root->setSpacing(0);
-
-    // ── Custom title bar ─────────────────────────────────────────────
-    // Same chrome family as AetherialAudioStrip / ContainerTitleBar:
-    // 18 px tall, blue-gradient background, 10 px bold title, trio of
-    // window-control buttons at the right.  Built inline so the
-    // gradient + grip glyphs match exactly.
-    {
-        m_titleBar = new QWidget(this);
-        m_titleBar->setFixedHeight(18);
-        m_titleBar->setAttribute(Qt::WA_StyledBackground, true);
-        m_titleBar->setStyleSheet(
-            "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
-            "stop:0 #5a7494, stop:0.5 #384e68, stop:1 #1e2e3e); "
-            "border-bottom: 1px solid #0a1a28; }");
-        m_titleBar->installEventFilter(this);
-
-        auto* tbRow = new QHBoxLayout(m_titleBar);
-        tbRow->setContentsMargins(6, 0, 2, 0);
-        tbRow->setSpacing(4);
-
-        auto* grip = new QLabel(QString::fromUtf8("\xe2\x8b\xae\xe2\x8b\xae"),
-                                m_titleBar);
-        grip->setStyleSheet(
-            "QLabel { background: transparent; color: #a0b4c8;"
-            " font-size: 10px; }");
-        tbRow->addWidget(grip);
-
-        auto* tbTitle = new QLabel("Network Diagnostics", m_titleBar);
-        tbTitle->setStyleSheet(
-            "QLabel { background: transparent; color: #e0ecf4;"
-            " font-size: 10px; font-weight: bold; }");
-        tbRow->addWidget(tbTitle);
-        tbRow->addStretch();
-
-        const QString btnStyle =
-            "QPushButton { background: transparent; border: none;"
-            " color: #c8d8e8; font-size: 11px; font-weight: bold;"
-            " padding: 0px 4px; }"
-            "QPushButton:hover { color: #ffffff; }";
-        const QString closeBtnStyle =
-            "QPushButton { background: transparent; border: none;"
-            " color: #c8d8e8; font-size: 11px; font-weight: bold;"
-            " padding: 0px 4px; }"
-            "QPushButton:hover { color: #ffffff; background: #cc2030; }";
-
-        auto* minBtn = new QPushButton(QString::fromUtf8("\xe2\x80\x94"), m_titleBar);
-        minBtn->setFixedSize(16, 16);
-        minBtn->setCursor(Qt::ArrowCursor);
-        minBtn->setStyleSheet(btnStyle);
-        minBtn->setToolTip("Minimize");
-        connect(minBtn, &QPushButton::clicked, this, &QWidget::showMinimized);
-        tbRow->addWidget(minBtn);
-
-        auto* maxBtn = new QPushButton(QString::fromUtf8("\xe2\x96\xa1"), m_titleBar);
-        maxBtn->setFixedSize(16, 16);
-        maxBtn->setCursor(Qt::ArrowCursor);
-        maxBtn->setStyleSheet(btnStyle);
-        maxBtn->setToolTip("Maximize");
-        connect(maxBtn, &QPushButton::clicked, this, [this]() {
-            if (isMaximized()) showNormal(); else showMaximized();
-        });
-        tbRow->addWidget(maxBtn);
-
-        auto* closeBtn = new QPushButton(QString::fromUtf8("\xc3\x97"), m_titleBar);
-        closeBtn->setFixedSize(16, 16);
-        closeBtn->setCursor(Qt::ArrowCursor);
-        closeBtn->setStyleSheet(closeBtnStyle);
-        closeBtn->setToolTip("Close");
-        connect(closeBtn, &QPushButton::clicked, this, &QDialog::accept);
-        tbRow->addWidget(closeBtn);
-
-        root->addWidget(m_titleBar);
-    }
-
-    // Content area — gets its own layout with 10 px padding so the
-    // resize hit zone (bare ~8 px margin around content) is reachable
-    // on every edge.
-    auto* outerContent = new QWidget(this);
-    auto* body = new QVBoxLayout(outerContent);
-    body->setContentsMargins(10, 8, 10, 10);
+    auto* body = new QVBoxLayout(bodyWidget());
     body->setSpacing(8);
-    m_bodyLayout = body;
-    root->addWidget(outerContent, 1);
 
     // Timeframe selector lives in the top-right corner of the QTabWidget's
     // tab bar so the tabs and the dropdown share a single row, eliminating
@@ -1033,31 +934,6 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     m_logRefreshTimer.start(500);
     initializeLogTail();
     refresh();
-
-    setFramelessMode(
-        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
-}
-
-void NetworkDiagnosticsDialog::setFramelessMode(bool on)
-{
-    const QRect geom = geometry();
-    const bool wasVisible = isVisible();
-
-    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
-    flags.setFlag(Qt::FramelessWindowHint, on);
-    setWindowFlags(flags);
-    if (wasVisible) {
-        setGeometry(geom);
-    }
-    if (m_titleBar) {
-        m_titleBar->setVisible(on);
-    }
-    if (m_bodyLayout) {
-        m_bodyLayout->setContentsMargins(10, on ? 8 : 10, 10, 10);
-    }
-    if (wasVisible) {
-        show();
-    }
 }
 
 QWidget* NetworkDiagnosticsDialog::buildLogsTab()
@@ -1826,107 +1702,6 @@ void NetworkDiagnosticsDialog::updateCharts()
     m_ratesGraph->setSeries(rateSeries, rangeSeconds);
     m_lossGraph->setSeries(lossSeries, rangeSeconds);
     m_audioGraph->setSeries(audioBufferSeries, rangeSeconds);
-}
-
-// ──────────────────────────────────────────────────────────────────
-// Frameless 8-axis resize + drag-to-move
-// ──────────────────────────────────────────────────────────────────
-
-Qt::Edges NetworkDiagnosticsDialog::edgesAt(const QPoint& pos) const
-{
-    if (!(windowFlags() & Qt::FramelessWindowHint)) {
-        return {};
-    }
-    if (isMaximized() || isFullScreen()) {
-        return {};
-    }
-    Qt::Edges edges;
-    if (pos.x() <= kResizeMargin) {
-        edges |= Qt::LeftEdge;
-    } else if (pos.x() >= width() - kResizeMargin) {
-        edges |= Qt::RightEdge;
-    }
-    if (pos.y() <= kResizeMargin) {
-        edges |= Qt::TopEdge;
-    } else if (pos.y() >= height() - kResizeMargin) {
-        edges |= Qt::BottomEdge;
-    }
-    return edges;
-}
-
-void NetworkDiagnosticsDialog::updateResizeCursor(const QPoint& pos)
-{
-    const Qt::Edges edges = edgesAt(pos);
-    Qt::CursorShape shape = Qt::ArrowCursor;
-    if ((edges & (Qt::LeftEdge | Qt::TopEdge))     == (Qt::LeftEdge | Qt::TopEdge)
-        || (edges & (Qt::RightEdge | Qt::BottomEdge)) == (Qt::RightEdge | Qt::BottomEdge)) {
-        shape = Qt::SizeFDiagCursor;
-    } else if ((edges & (Qt::RightEdge | Qt::TopEdge))    == (Qt::RightEdge | Qt::TopEdge)
-        ||     (edges & (Qt::LeftEdge | Qt::BottomEdge)) == (Qt::LeftEdge | Qt::BottomEdge)) {
-        shape = Qt::SizeBDiagCursor;
-    } else if (edges & (Qt::LeftEdge | Qt::RightEdge)) {
-        shape = Qt::SizeHorCursor;
-    } else if (edges & (Qt::TopEdge | Qt::BottomEdge)) {
-        shape = Qt::SizeVerCursor;
-    }
-    setCursor(shape);
-}
-
-void NetworkDiagnosticsDialog::mouseMoveEvent(QMouseEvent* ev)
-{
-    if (!(ev->buttons() & Qt::LeftButton)) {
-        updateResizeCursor(ev->pos());
-    }
-    QDialog::mouseMoveEvent(ev);
-}
-
-void NetworkDiagnosticsDialog::mousePressEvent(QMouseEvent* ev)
-{
-    if (ev->button() == Qt::LeftButton) {
-        const Qt::Edges edges = edgesAt(ev->pos());
-        if (edges) {
-            if (auto* h = windowHandle()) {
-                h->startSystemResize(edges);
-                ev->accept();
-                return;
-            }
-        }
-    }
-    QDialog::mousePressEvent(ev);
-}
-
-void NetworkDiagnosticsDialog::leaveEvent(QEvent* ev)
-{
-    setCursor(Qt::ArrowCursor);
-    QDialog::leaveEvent(ev);
-}
-
-bool NetworkDiagnosticsDialog::eventFilter(QObject* obj, QEvent* ev)
-{
-    if (obj == m_titleBar && ev->type() == QEvent::MouseMove) {
-        return FramelessMoveHelper::move(m_titleBar, static_cast<QMouseEvent*>(ev));
-    }
-    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonRelease) {
-        return FramelessMoveHelper::finish(m_titleBar, static_cast<QMouseEvent*>(ev));
-    }
-
-    // Drag-to-move via the custom title bar.  The trio buttons are
-    // their own QPushButtons that consume the press themselves, so
-    // this only fires on the bare title-bar background.
-    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonPress) {
-        auto* me = static_cast<QMouseEvent*>(ev);
-        return FramelessMoveHelper::start(m_titleBar, me);
-    }
-    if (obj == m_titleBar && ev->type() == QEvent::MouseButtonDblClick) {
-        if (isMaximized()) {
-            showNormal();
-        } else {
-            showMaximized();
-        }
-        ev->accept();
-        return true;
-    }
-    return QDialog::eventFilter(obj, ev);
 }
 
 } // namespace AetherSDR

--- a/src/gui/NetworkDiagnosticsDialog.h
+++ b/src/gui/NetworkDiagnosticsDialog.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "PersistentDialog.h"
 #include "core/PanadapterStream.h"
 
 #include <QComboBox>
-#include <QDialog>
 #include <QFile>
 #include <QLabel>
 #include <QObject>
@@ -14,7 +14,6 @@
 class QCheckBox;
 class QPlainTextEdit;
 class QPushButton;
-class QVBoxLayout;
 
 namespace AetherSDR {
 
@@ -66,7 +65,7 @@ private:
     qint64 m_lastCatBytes[PanadapterStream::CatCount]{};
 };
 
-class NetworkDiagnosticsDialog : public QDialog {
+class NetworkDiagnosticsDialog : public PersistentDialog {
     Q_OBJECT
 
 public:
@@ -74,16 +73,6 @@ public:
                                       AudioEngine* audio,
                                       NetworkDiagnosticsHistory* history,
                                       QWidget* parent = nullptr);
-    void setFramelessMode(bool on);
-
-protected:
-    // Frameless 8-axis resize: 4 edges + 4 corners.  Hovering the bare
-    // margin around the content updates the cursor; pressing starts a
-    // compositor-managed resize via QWindow::startSystemResize.
-    void mouseMoveEvent(QMouseEvent* ev) override;
-    void mousePressEvent(QMouseEvent* ev) override;
-    void leaveEvent(QEvent* ev) override;
-    bool eventFilter(QObject* obj, QEvent* ev) override;
 
 private:
     struct LogLine {
@@ -105,11 +94,6 @@ private:
     void setLogFollowLive(bool on);
     void setAllLogCategoriesVisible(bool visible);
     int selectedRangeSeconds() const;
-    Qt::Edges edgesAt(const QPoint& pos) const;
-    void updateResizeCursor(const QPoint& pos);
-
-    QWidget* m_titleBar{nullptr};
-    QVBoxLayout* m_bodyLayout{nullptr};
 
     RadioModel* m_model;
     AudioEngine* m_audio;

--- a/src/gui/PanLayoutDialog.cpp
+++ b/src/gui/PanLayoutDialog.cpp
@@ -1,7 +1,4 @@
 #include "PanLayoutDialog.h"
-#include "FramelessResizer.h"
-#include "FramelessWindowTitleBar.h"
-#include "core/AppSettings.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -110,33 +107,20 @@ private:
 
 PanLayoutDialog::PanLayoutDialog(int maxPans, const QString& currentLayout,
                                  QWidget* parent)
-    : QDialog(parent)
+    : PersistentDialog("Panadapter Layout", /*geomKey*/ QString(), parent)
 {
-    setWindowTitle("Panadapter Layout");
     setStyleSheet("QDialog { background: #0f0f1a; }"
                   "QLabel { color: #c8d8e8; }");
-    setFixedSize(560, 520);
-    FramelessResizer::install(this);
+    // Fixed-size grid of thumbnails — body content is the same regardless of
+    // chrome state; the dialog wraps it.  Modal dialog; no geometry persist.
+    bodyWidget()->setFixedSize(560, 502);
     buildUI(maxPans, currentLayout);
-    setFramelessMode(
-        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
 }
 
 void PanLayoutDialog::buildUI(int maxPans, const QString& currentLayout)
 {
-    auto* outer = new QVBoxLayout(this);
-    outer->setContentsMargins(0, 0, 0, 0);
-    outer->setSpacing(0);
-
-    m_titleBar = new FramelessWindowTitleBar(QStringLiteral("Panadapter Layout"), this);
-    outer->addWidget(m_titleBar);
-
-    auto* bodyWidget = new QWidget(this);
-    auto* vbox = new QVBoxLayout(bodyWidget);
-    vbox->setContentsMargins(9, 9, 9, 9);
+    auto* vbox = new QVBoxLayout(bodyWidget());
     vbox->setSpacing(8);
-    m_bodyLayout = vbox;
-    outer->addWidget(bodyWidget, 1);
 
     auto* title = new QLabel("Choose panadapter layout:");
     title->setStyleSheet("QLabel { color: #8aa8c0; font-size: 13px; font-weight: bold; }");
@@ -198,31 +182,6 @@ void PanLayoutDialog::buildUI(int maxPans, const QString& currentLayout)
         "QPushButton:hover { background: #204060; }");
     connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
     vbox->addWidget(cancelBtn, 0, Qt::AlignCenter);
-}
-
-void PanLayoutDialog::setFramelessMode(bool on)
-{
-    const QRect geom = geometry();
-    const bool wasVisible = isVisible();
-    const QSize targetSize(560, on ? 538 : 520);
-
-    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
-    flags.setFlag(Qt::FramelessWindowHint, on);
-    setWindowFlags(flags);
-    setFixedSize(targetSize);
-    if (wasVisible) {
-        setGeometry(QRect(geom.topLeft(), targetSize));
-    }
-
-    if (m_titleBar) {
-        m_titleBar->setVisible(on);
-    }
-    if (m_bodyLayout) {
-        m_bodyLayout->setContentsMargins(9, on ? 7 : 9, 9, 9);
-    }
-    if (wasVisible) {
-        show();
-    }
 }
 
 } // namespace AetherSDR

--- a/src/gui/PanLayoutDialog.h
+++ b/src/gui/PanLayoutDialog.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <QDialog>
+#include "PersistentDialog.h"
+
 #include <QString>
 #include <QVector>
 
-class QVBoxLayout;
 class QWidget;
 
 namespace AetherSDR {
@@ -30,7 +30,7 @@ struct PanLayout {
     QVector<QVector<int>> rows;
 };
 
-class PanLayoutDialog : public QDialog {
+class PanLayoutDialog : public PersistentDialog {
     Q_OBJECT
 
 public:
@@ -38,13 +38,10 @@ public:
                              QWidget* parent = nullptr);
 
     QString selectedLayout() const { return m_selected; }
-    void setFramelessMode(bool on);
 
 private:
     void buildUI(int maxPans, const QString& currentLayout);
     QString m_selected;
-    QWidget* m_titleBar{nullptr};
-    QVBoxLayout* m_bodyLayout{nullptr};
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
Lands the six follow-up migrations the issue tracked plus the
PanLayoutDialog modal special case.  Net: −1102 / +98 lines.

Dialogs migrated:
  PanLayoutDialog          modal fixed-size, no persist key
  MultiFlexDialog          modal, gains FooDialogGeometry
  MidiMappingDialog        non-modal, FramelessWindowTitleBar swap
  MemoryDialog             non-modal, showEvent kept for search focus
  AetherDspDialog          hand-rolled chrome + drag handlers deleted
  NetworkDiagnosticsDialog hand-rolled chrome + 8-axis resize deleted
  DxClusterDialog          tabbed dialog, signal wiring guarded by
                           wasFresh-pattern

Each migration replaces:
  * setFramelessMode() / closeEvent / moveEvent / resizeEvent overrides
  * FramelessResizer::install + manual setFramelessMode(AppSettings…)
    in the ctor
  * Hand-rolled m_titleBar / m_outerLayout / m_bodyLayout members
  * (AetherDsp / NetworkDiag) the entire ~70-line hand-rolled title
    bar widget tree plus FramelessMoveHelper eventFilter cases

…with a single base-class ctor call carrying the title and
"FooDialogGeometry" key.  All six previously-non-persistent dialogs
gain geometry persistence (correction posted to the issue: NONE of
them currently persisted geometry, despite the table claiming four
did — the `geometry()` calls in setFramelessMode were in-process
preservation across frameless toggle, not disk-backed restore).

MainWindow changes:
  * QPointer<QDialog> members re-typed to concrete dialog classes so
    showOrRaisePersistent template binds correctly
  * 6 qobject_cast branches in setFramelessWindow deleted —
    m_persistentDialogs registry now auto-propagates the frameless
    toggle on every PersistentDialog-derived instance
  * NEW ensureAetherDspDialog() helper consolidates 7 duplicated
    AetherDspDialog construct sites — each had been re-pasting the
    same ~17 signal connections wiring NR2/NR4/DFNR/MNR parameter
    changes back to AudioEngine.  Now a single call site.

Verified locally on Linux: open each dialog → resize → close →
restart → reopen — geometry restores per dialog.  Toggle View →
Frameless Window → chrome flips on all of them without losing
geometry.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
