### PR TITLE
fix(interlock): suppress amp/tuner popup during normal TX (gate on tx_allowed)

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3961,14 +3961,28 @@ void RadioModel::onStatusReceived(const QString& object,
                 m_interlockNotificationArmedUntilMs = 0;
                 m_interlockNotificationSource = TransmitModel::PttSource::Mox;
             } else if (interlockNotificationArmed()) {
-                const QString message = radioInterlockNotificationMessage(kvs);
-                if (!message.isEmpty()) {
-                    emitInterlockNotification(
-                        message,
-                        QStringLiteral("radio:%1:%2")
-                            .arg(state, kvs.value(QStringLiteral("reason")).toUpper()));
-                    m_interlockNotificationArmedUntilMs = 0;
-                    m_interlockNotificationSource = TransmitModel::PttSource::Mox;
+                // The radio reports interlock state as a sequence: PTT_REQUESTED
+                // (with reason=AMP:TG while it waits for the amp/tuner relay
+                // chain to settle) → TRANSMITTING (reason cleared, tx_allowed=1)
+                // → UNKEY_REQUESTED (reason=AMP:TG again on the way back to
+                // RECEIVE).  The PTT_REQUESTED / UNKEY_REQUESTED states are
+                // transitional — TX is proceeding, not blocked.  The radio
+                // tells us this explicitly via tx_allowed=1.  Only fire the
+                // user-facing popup when the radio says TX is actually denied
+                // (tx_allowed=0), which is the only case where the operator
+                // needs to do something about the interlock.
+                const QString txAllowed = kvs.value(QStringLiteral("tx_allowed"));
+                const bool txDenied = (txAllowed == QStringLiteral("0"));
+                if (txDenied) {
+                    const QString message = radioInterlockNotificationMessage(kvs);
+                    if (!message.isEmpty()) {
+                        emitInterlockNotification(
+                            message,
+                            QStringLiteral("radio:%1:%2")
+                                .arg(state, kvs.value(QStringLiteral("reason")).toUpper()));
+                        m_interlockNotificationArmedUntilMs = 0;
+                        m_interlockNotificationSource = TransmitModel::PttSource::Mox;
+                    }
                 }
             }
         }


### PR DESCRIPTION
The radio reports interlock state as a sequence on every TX:

  state=PTT_REQUESTED   reason=AMP:TG  tx_allowed=1   ← settling, TX permitted
  state=TRANSMITTING    reason=        tx_allowed=1   ← TX engaged
  state=UNKEY_REQUESTED reason=AMP:TG  tx_allowed=1   ← settling on unkey
  state=READY           reason=        tx_allowed=1

PTT_REQUESTED and UNKEY_REQUESTED carry reason=AMP:TG while the radio
waits for the amp/tuner relay chain to settle — these are transitional
states during normal TX, not interlock blocks.  The radio tells us
explicitly via tx_allowed=1 that TX is permitted; tx_allowed=0 is the
only case where the operator actually needs to do something.

The popup gate was firing on any non-READY/RECEIVE state with a known
reason, so users with a TGXL/PGXL in OPERATE saw the "Amplifier
interlock is blocking transmit. (AMP:TG)" toast every single time they
keyed.  Now it gates on tx_allowed=0 so the popup only fires when the
radio actually denies TX — which is the only case where it carries
useful information.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
