### PR TITLE
fix(spectrum): restore 3 s auto-hide for SQL threshold line (manual mode)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -316,6 +316,17 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         markOverlayDirty();
     });
 
+    // SQL threshold line auto-hide (manual SQL only — see setSquelchLine).
+    // Shows for 3 s on enable or slider movement; slider re-adjust resets it.
+    // Auto SQL pins the line at the tracked level so the timer is skipped.
+    m_squelchLineHideTimer = new QTimer(this);
+    m_squelchLineHideTimer->setSingleShot(true);
+    m_squelchLineHideTimer->setInterval(3000);
+    connect(m_squelchLineHideTimer, &QTimer::timeout, this, [this]() {
+        m_squelchLineVisible = false;
+        markOverlayDirty();
+    });
+
     m_connectionAnimationTimer = new QTimer(this);
     m_connectionAnimationTimer->setInterval(40);
     connect(m_connectionAnimationTimer, &QTimer::timeout, this, [this]() {
@@ -1079,6 +1090,15 @@ void SpectrumWidget::setSquelchLine(bool visible, int level)
     m_squelchLineVisible = visible;
     m_squelchLevel       = level;
     markOverlayDirty();
+    // Manual SQL: 3 s auto-hide; each slider adjustment restarts the timer.
+    // Auto SQL: line stays pinned to the tracked floor level — no timer.
+    if (m_squelchLineHideTimer) {
+        if (visible && !m_autoSquelchEnabled) {
+            m_squelchLineHideTimer->start();
+        } else {
+            m_squelchLineHideTimer->stop();
+        }
+    }
 }
 
 void SpectrumWidget::drawAutoSqlFloor(QPainter& p, const QRect& specRect)
@@ -1103,6 +1123,10 @@ void SpectrumWidget::setAutoSquelchEnable(bool on)
     m_autoSquelchEnabled   = on;
     m_sqlNoiseFloorDbm     = -999.0f;  // cold-start the floor EWMA on each enable
     m_lastAutoSquelchLevel = -1;
+    if (on && m_squelchLineHideTimer) {
+        // Auto pins the line — cancel any pending manual auto-hide.
+        m_squelchLineHideTimer->stop();
+    }
 }
 
 void SpectrumWidget::setAutoSqlMarginDb(int dBm)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -638,6 +638,7 @@ private:
     // Squelch threshold overlay line
     bool  m_squelchLineVisible{false};
     int   m_squelchLevel{0};             // 0-100 radio squelch_level units
+    QTimer* m_squelchLineHideTimer{nullptr}; // auto-hides yellow line 3 s after enable/adjust (manual SQL only)
     bool  m_autoSquelchEnabled{false};
     float m_sqlNoiseFloorDbm{-999.0f};  // auto-squelch own two-pass trimmed-mean EWMA
     // dBm above noise floor for auto-squelch suggestion (5-20, default 10)


### PR DESCRIPTION
The yellow SQL threshold line overlay had no auto-hide logic on main —
once enabled it stayed visible until the user disabled SQL.  An earlier
WIP commit (b4944310, never merged) implemented the intended 3 s
auto-hide; this lands that work.

Wiring:
- New singleShot QTimer (3000 ms) clears m_squelchLineVisible and marks
  the overlay dirty on timeout.
- setSquelchLine(true, level) starts the timer when manual SQL is on.
  Each level adjustment restarts it so dragging the slider keeps the
  line visible.
- Auto SQL pins the line at the tracked floor level — setSquelchLine
  skips starting the timer when m_autoSquelchEnabled is true, and
  setAutoSquelchEnable(true) cancels any in-flight timer.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
