### PR TITLE
fix(gui): apply wasVisible-guard to four remaining setGeometry sites (#2646)

### DIFF
--- a/src/gui/AetherialAudioStrip.cpp
+++ b/src/gui/AetherialAudioStrip.cpp
@@ -699,7 +699,9 @@ void AetherialAudioStrip::setFramelessMode(bool on)
     Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Window;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
-    setGeometry(geom);
+    if (wasVisible) {
+        setGeometry(geom);
+    }
     if (m_titleBar) {
         m_titleBar->setVisible(on);
     }

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -666,7 +666,8 @@ void ConnectionPanel::setFramelessMode(bool on)
     Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
-    setGeometry(geom);
+    if (wasVisible)
+        setGeometry(geom);
     if (m_titleBar)
         m_titleBar->setVisible(on);
     if (m_rootLayout)

--- a/src/gui/containers/FloatingContainerWindow.cpp
+++ b/src/gui/containers/FloatingContainerWindow.cpp
@@ -160,7 +160,7 @@ void FloatingContainerWindow::setFramelessMode(bool on)
         flags &= ~Qt::FramelessWindowHint;
     }
     setWindowFlags(flags);
-    setGeometry(geom);
+    if (wasVisible) setGeometry(geom);
     if (wasVisible) show();
 }
 
@@ -177,7 +177,7 @@ void FloatingContainerWindow::setAlwaysOnTop(bool on)
         flags &= ~Qt::WindowStaysOnTopHint;
     }
     setWindowFlags(flags);
-    setGeometry(geom);
+    if (wasVisible) setGeometry(geom);
     if (wasVisible) show();
 }
 


### PR DESCRIPTION
PRs #2580 and #2635 (closing #2603) applied the
`if (wasVisible) setGeometry(geom)` guard across most
`setFramelessMode(bool)` implementations.  Four sites with the same
code-shape were missed by both passes — fix listed in #2646:

1. ConnectionPanel::setFramelessMode
2. AetherialAudioStrip::setFramelessMode
3. FloatingContainerWindow::setFramelessMode
4. FloatingContainerWindow::setAlwaysOnTop

All four captured `wasVisible` and `geom` early but called
`setGeometry(geom)` unconditionally after `setWindowFlags(flags)`.
On a cold-launched (never-shown) instance, `geom` is the default
top-left rect and the unconditional `setGeometry` clobbers Qt's
normal placement, leaving the window stuck at (0,0) on first show.

Closes #2646.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
