### PR TITLE
test(atu): lock IARU R1 reference table for computeCenters() (#2648)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1394,6 +1394,16 @@ target_link_libraries(antenna_alias_test PRIVATE Qt6::Core)
 set_target_properties(antenna_alias_test PROPERTIES AUTOMOC ON)
 add_test(NAME antenna_alias_test COMMAND antenna_alias_test)
 
+# Pure-math test for the ATU pre-tune center-frequency calculator.
+# Locks in the IARU R1 reference table from issue #2624 so future edits
+# to computeCenters() can't silently regress the per-band point counts.
+add_executable(atu_pretune_centers_test
+    tests/atu_pretune_centers_test.cpp
+)
+target_include_directories(atu_pretune_centers_test PRIVATE src)
+target_link_libraries(atu_pretune_centers_test PRIVATE Qt6::Core)
+add_test(NAME atu_pretune_centers_test COMMAND atu_pretune_centers_test)
+
 add_executable(cw_sidetone_test
     tests/cw_sidetone_test.cpp
     src/core/CwSidetoneGenerator.cpp

--- a/src/gui/AtuPreTuneCenters.h
+++ b/src/gui/AtuPreTuneCenters.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QVector>
+
+namespace AetherSDR {
+
+// Pure-math helper: generates evenly-spaced sweep center frequencies (MHz)
+// for an ATU pre-tune across [lowMhz, highMhz] using segmentKhz-wide
+// segments.  Header-only so the unit test can include this directly
+// without dragging in the dialog (#2648).
+//
+// Centers are evenly-spaced starting at lowMhz + seg/2.  Each segment of
+// width segMhz fits inside the band when center + seg/2 <= highMhz; we
+// keep adding centers while this holds.  If room remains at the top
+// after the regular loop, an extra clamped center is appended at
+// highMhz - seg/2 so the band end isn't left uncovered.  This matches
+// the per-band counts in the IARU R1 reference table in issue #2624.
+//
+// Edge cases:
+//   * segmentKhz <= 0 or highMhz <= lowMhz → empty result.
+//   * (highMhz - lowMhz) < segMhz → empty (single segment cannot fit).
+inline QVector<double> computeCenters(double lowMhz, double highMhz, int segmentKhz)
+{
+    QVector<double> out;
+    if (segmentKhz <= 0 || highMhz <= lowMhz) return out;
+    const double segMhz = segmentKhz / 1000.0;
+    const double half = segMhz / 2.0;
+    const double firstCenter = lowMhz + half;
+    const double lastAllowedCenter = highMhz - half;
+    if (lastAllowedCenter < firstCenter - 1e-9) return out;
+
+    constexpr double kEps = 1e-9;
+    for (double f = firstCenter; f <= lastAllowedCenter + kEps; f += segMhz) {
+        out.append(f);
+    }
+    if (!out.isEmpty() && out.last() < lastAllowedCenter - kEps) {
+        out.append(lastAllowedCenter);
+    }
+    return out;
+}
+
+} // namespace AetherSDR

--- a/src/gui/AtuPreTuneDialog.cpp
+++ b/src/gui/AtuPreTuneDialog.cpp
@@ -1,4 +1,5 @@
 #include "AtuPreTuneDialog.h"
+#include "AtuPreTuneCenters.h"
 #include "FramelessWindowTitleBar.h"
 #include "FramelessResizer.h"
 #include "core/AppSettings.h"
@@ -69,31 +70,8 @@ constexpr int kPerPointTimeoutMs = 30 * 1000;
 constexpr int kSettleMs = 300;
 constexpr int kMaxConsecutiveFailBypass = 3;
 
-// Centers are evenly-spaced starting at band_low + seg/2. We keep adding
-// while the full tune segment fits inside the band (center + seg/2 <= high).
-// If room remains at the top after the regular loop, an extra clamped center
-// is appended at high - seg/2 so the band end isn't left uncovered.  This
-// matches the reference counts in the issue's IARU R1 table. (#2624)
-QVector<double> computeCenters(double lowMhz, double highMhz, int segmentKhz)
-{
-    QVector<double> out;
-    if (segmentKhz <= 0 || highMhz <= lowMhz) return out;
-    const double segMhz = segmentKhz / 1000.0;
-    const double half = segMhz / 2.0;
-    const double firstCenter = lowMhz + half;
-    const double lastAllowedCenter = highMhz - half;
-    if (lastAllowedCenter < firstCenter - 1e-9) return out;
-
-    constexpr double kEps = 1e-9;
-    for (double f = firstCenter; f <= lastAllowedCenter + kEps; f += segMhz) {
-        out.append(f);
-    }
-    if (!out.isEmpty() && out.last() < lastAllowedCenter - kEps) {
-        out.append(lastAllowedCenter);
-    }
-    return out;
-}
-
+// computeCenters() is now in AtuPreTuneCenters.h (header-only) so the
+// unit test can exercise it without dragging in this dialog. (#2648)
 int pointsForRange(double lowMhz, double highMhz, int segmentKhz)
 {
     return computeCenters(lowMhz, highMhz, segmentKhz).size();

--- a/tests/atu_pretune_centers_test.cpp
+++ b/tests/atu_pretune_centers_test.cpp
@@ -1,0 +1,96 @@
+// Unit test for computeCenters() — pure-math helper that drives the ATU
+// pre-tune sweep.  Reference oracle is the IARU Region 1 per-band point
+// count table from issue #2624.  Closes #2648.
+
+#include "gui/AtuPreTuneCenters.h"
+
+#include <QVector>
+
+#include <cmath>
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_pass = 0;
+int g_fail = 0;
+
+bool expect(bool condition, const char* label)
+{
+    if (condition) {
+        std::cout << "[ OK ] " << label << '\n';
+        ++g_pass;
+    } else {
+        std::cout << "[FAIL] " << label << '\n';
+        ++g_fail;
+    }
+    return condition;
+}
+
+bool nearlyEqual(double a, double b, double tol = 1e-4)
+{
+    return std::abs(a - b) < tol;
+}
+
+} // namespace
+
+int main()
+{
+    // ── IARU R1 reference table (issue #2624) ─────────────────────────
+    // Band         low        high      seg_kHz  expected_points
+    expect(computeCenters(1.800, 2.000, 9).size() == 23,
+           "160m IARU R1 (1.800-2.000, 9 kHz)  → 23 points");
+    expect(computeCenters(3.500, 3.800, 9).size() == 34,
+           "80m IARU R1  (3.500-3.800, 9 kHz)  → 34 points");
+    expect(computeCenters(5.3515, 5.3665, 9).size() == 2,
+           "60m IARU R1  (5.3515-5.3665, 9 kHz)→ 2 points");
+    expect(computeCenters(7.000, 7.200, 25).size() == 8,
+           "40m IARU R1  (7.000-7.200, 25 kHz) → 8 points");
+    expect(computeCenters(10.100, 10.150, 25).size() == 2,
+           "30m IARU R1  (10.100-10.150, 25 kHz)→ 2 points");
+    expect(computeCenters(14.000, 14.350, 51).size() == 7,
+           "20m IARU R1  (14.000-14.350, 51 kHz)→ 7 points");
+    expect(computeCenters(18.068, 18.168, 51).size() == 2,
+           "17m IARU R1  (18.068-18.168, 51 kHz)→ 2 points");
+    expect(computeCenters(21.000, 21.450, 75).size() == 6,
+           "15m IARU R1  (21.000-21.450, 75 kHz)→ 6 points");
+    expect(computeCenters(24.890, 24.990, 75).size() == 2,
+           "12m IARU R1  (24.890-24.990, 75 kHz)→ 2 points");
+    expect(computeCenters(28.000, 29.700, 75).size() == 23,
+           "10m IARU R1  (28.000-29.700, 75 kHz)→ 23 points");
+    expect(computeCenters(50.000, 52.000, 101).size() == 20,
+           "6m IARU R1   (50.000-52.000, 101 kHz)→ 20 points");
+
+    // ── First-center spacing (verifies half-segment offset) ───────────
+    const auto m160 = computeCenters(1.800, 2.000, 9);
+    expect(!m160.isEmpty() && nearlyEqual(m160.first(), 1.8045),
+           "160m first center = 1.8045 MHz (low + 9/2 kHz)");
+    const auto m40 = computeCenters(7.000, 7.200, 25);
+    expect(!m40.isEmpty() && nearlyEqual(m40.first(), 7.0125),
+           "40m first center  = 7.0125 MHz (low + 25/2 kHz)");
+
+    // ── Last-segment clamp (extra center if room at the top) ──────────
+    // 60m IARU R1 spans 15 kHz with 9 kHz segments — 1 even-stride
+    // center at 5.35600, then a clamped center at high - 9/2 = 5.36200.
+    const auto m60 = computeCenters(5.3515, 5.3665, 9);
+    expect(m60.size() == 2 && nearlyEqual(m60.last(), 5.3620),
+           "60m clamp last center to high - seg/2 (5.3620 MHz)");
+
+    // ── Edge cases ────────────────────────────────────────────────────
+    expect(computeCenters(0.0, 0.0, 9).isEmpty(),
+           "zero range returns empty");
+    expect(computeCenters(2.0, 1.5, 9).isEmpty(),
+           "high < low returns empty");
+    expect(computeCenters(1.800, 2.000, 0).isEmpty(),
+           "segmentKhz=0 returns empty");
+    expect(computeCenters(1.800, 2.000, -9).isEmpty(),
+           "segmentKhz<0 returns empty");
+    expect(computeCenters(14.000, 14.001, 51).isEmpty(),
+           "range smaller than one segment returns empty");
+    expect(computeCenters(14.000, 14.051, 51).size() == 1,
+           "range exactly one segment wide → 1 center (no clamp duplicate)");
+
+    std::cout << '\n' << g_pass << " passed, " << g_fail << " failed\n";
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
`computeCenters(double lowMhz, double highMhz, int segmentKhz)` is the
pure-math kernel that drives the ATU pre-tune sweep — it generates the
evenly-spaced tune centers for each selected band.  It had no test
coverage; the IARU R1 per-band point counts from issue #2624 (160m=23,
80m=34, 60m=2, 40m=8, 30m=2, 20m=7, 17m=2, 15m=6, 12m=2, 10m=23,
6m=20 — 129 total) were verified by hand at PR-review time and would
silently regress on a rounding/clamping change.

Lift `computeCenters` out of `AtuPreTuneDialog.cpp`'s anonymous
namespace into a header-only free function (`AtuPreTuneCenters.h`) so
the test can include it without dragging in the dialog.
`AtuPreTuneDialog.cpp` keeps using it via the new include — same
implementation, same behavior, but now reachable from tests.

`tests/atu_pretune_centers_test.cpp` exercises:
  * All 11 IARU R1 reference points (band, range, segment, expected
    point count).
  * First-center spacing (`low + seg/2`) — guards the half-segment
    offset.
  * Last-segment clamp (`high - seg/2`) — guards the "extra center if
    room at the top" path that produces #2624's expected 60m count.
  * Edge cases: zero range, inverted range, segmentKhz ≤ 0,
    sub-segment range (returns empty), exactly-one-segment range
    (returns 1, no duplicate clamp).

Registered as `atu_pretune_centers_test` in CMakeLists.txt next to the
existing `*_test` executables; runs via `ctest -R atu_pretune`.  20
assertions; passes locally.

Closes #2648.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
