### PR TITLE
[wave] Restore WAVE TX scope for digital audio

### DIFF
--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -262,7 +262,7 @@ flowchart TD
     P --> Q["Quindar tone insertion"]
     Q --> R["ClientFinalLimiter"]
     R --> S["Final monitor tap"]
-    S --> T["txPostChainScopeReady<br/>average L/R"]
+    S --> T["txPostChainScopeReady<br/>average L/R<br/>voice post-limiter"]
     T --> U["PC mic meter<br/>canonical stereo frame level"]
     U --> V["scopeSamplesReady<br/>average L/R"]
     V --> W{"Opus enabled?"}
@@ -551,7 +551,9 @@ Local/client taps:
 - `scopeSamplesReady` is a shared local scope signal. Stereo sources are
   converted to mono by averaging L/R.
 - `txPostChainScopeReady` is taken after the PC mic voice final limiter and
-  converts stereo to mono by averaging L/R.
+  converts stereo to mono by averaging L/R. DAX/TCI and RADE also emit this
+  high-rate TX scope from their pre-packetization bypass audio so the WAVE
+  display continues to show digital-mode transmit waveforms.
 - `rxPostChainScopeReady` is taken after the RX client strip, optional RX
   upsampling, RX boost, and RX output trim on the non-BNR path. For BNR it is
   taken after BNR output resampling and trim. In both cases it is before speaker
@@ -641,7 +643,8 @@ Radio-provided taps:
 | `AudioEngine::scopeSamplesReady`, TX voice | `AudioEngine::emitScopeFromInt16Stereo()` | Post PC mic meter, before packetization | Average L/R | float PCM scope samples, sample rate |
 | `AudioEngine::scopeSamplesReady`, TX DAX | `AudioEngine::emitScopeFromFloat32Stereo()` | In `feedDaxTxAudio()` before route packetization | Average L/R | float PCM scope samples, sample rate |
 | `AudioEngine::scopeSamplesReady`, RX | `AudioEngine::emitScopeFromFloat32Stereo()` | In `writeAudio()` or BNR output path near RX buffering | Average L/R | float PCM scope samples, sample rate |
-| `AudioEngine::txPostChainScopeReady` | `AudioEngine::emitTxPostChainScopeFromInt16Stereo()` | Post final limiter and final monitor tap | Average L/R | float PCM scope samples, sample rate |
+| `AudioEngine::txPostChainScopeReady`, TX voice | `AudioEngine::emitTxPostChainScopeFromInt16Stereo()` | Post final limiter and final monitor tap | Average L/R | float PCM scope samples, sample rate |
+| `AudioEngine::txPostChainScopeReady`, TX DAX/TCI/RADE | `AudioEngine::emitTxPostChainScopeFromFloat32Stereo()` | Pre-packetization digital bypass audio | Average L/R | float PCM scope samples, sample rate |
 | `AudioEngine::rxPostChainScopeReady` | `AudioEngine::emitRxPostChainScopeFromFloat32Stereo()` | Non-BNR: after RX strip, upsample, boost, and trim; BNR: after BNR resample/trim; before buffer append | Average L/R | float PCM scope samples, sample rate |
 | RX EQ analyzer | `AudioEngine::tapClientEqRxStereo()` | After RX EQ, before RX Gate/Comp/DeEss/Tube/PUDU | Average L/R | float mono analyzer samples |
 | TX EQ analyzer | `AudioEngine::tapClientEqTxInt16()` / `tapClientEqTxFloat32()` | After TX EQ or EQ bypass inside TX strip | Average L/R for stereo | float mono analyzer samples |

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -316,11 +316,10 @@ void AudioEngine::emitScopeFromInt16Stereo(const QByteArray& pcm,
 void AudioEngine::emitTxPostChainScopeFromInt16Stereo(const QByteArray& pcm,
                                                       int sampleRate)
 {
-    // Same int16-stereo → mono-float collapse as emitScopeFromInt16Stereo,
-    // but reuses the TX scratch and emits on the dedicated
-    // txPostChainScopeReady signal so consumers (channel-strip waveform
-    // panel) see exactly the post-DSP-chain audio without competing
-    // with the floating Waveform applet's main TX/RX feed.
+    // Same int16-stereo -> mono-float collapse as emitScopeFromInt16Stereo,
+    // but emits on the dedicated high-rate TX scope used by the waveform
+    // displays. PC mic voice reaches this point after the user DSP chain,
+    // PC mic gain, and final limiter.
     const int intSamples = pcm.size() / static_cast<int>(sizeof(int16_t));
     if (intSamples <= 0)
         return;
@@ -344,6 +343,43 @@ void AudioEngine::emitTxPostChainScopeFromInt16Stereo(const QByteArray& pcm,
     } else {
         for (int i = 0; i < monoSamples; ++i)
             dst[i] = std::clamp(src[i] / 32768.0f, -1.0f, 1.0f);
+    }
+
+    if (m_lastTxPostChainScopeEmit.isValid())
+        m_lastTxPostChainScopeEmit.restart();
+    else
+        m_lastTxPostChainScopeEmit.start();
+    emit txPostChainScopeReady(m_scopeTxPostChainScratch,
+                               sampleRate > 0 ? sampleRate : DEFAULT_SAMPLE_RATE);
+}
+
+void AudioEngine::emitTxPostChainScopeFromFloat32Stereo(const QByteArray& pcm,
+                                                        int sampleRate)
+{
+    const int floatSamples = pcm.size() / static_cast<int>(sizeof(float));
+    if (floatSamples <= 0)
+        return;
+
+    if (m_lastTxPostChainScopeEmit.isValid()
+        && m_lastTxPostChainScopeEmit.elapsed() < kTxPostChainEmitMinIntervalMs)
+        return;
+
+    const bool stereo = (floatSamples % 2) == 0;
+    const int monoSamples = stereo ? floatSamples / 2 : floatSamples;
+    m_scopeTxPostChainScratch.resize(monoSamples * static_cast<int>(sizeof(float)));
+
+    const auto* src = reinterpret_cast<const float*>(pcm.constData());
+    auto* dst = reinterpret_cast<float*>(m_scopeTxPostChainScratch.data());
+    if (stereo) {
+        for (int i = 0; i < monoSamples; ++i) {
+            const float avg = (src[i * 2] + src[i * 2 + 1]) * 0.5f;
+            dst[i] = std::clamp(std::isfinite(avg) ? avg : 0.0f, -1.0f, 1.0f);
+        }
+    } else {
+        for (int i = 0; i < monoSamples; ++i) {
+            const float s = src[i];
+            dst[i] = std::clamp(std::isfinite(s) ? s : 0.0f, -1.0f, 1.0f);
+        }
     }
 
     if (m_lastTxPostChainScopeEmit.isValid())
@@ -4233,8 +4269,10 @@ void AudioEngine::sendModemTxAudio(const QByteArray& float32pcm)
 {
     if (m_txStreamId == 0) return;
 
-    if (m_radioTransmitting)
+    if (m_radioTransmitting) {
+        emitTxPostChainScopeFromFloat32Stereo(float32pcm, DEFAULT_SAMPLE_RATE);
         emitScopeFromFloat32Stereo(float32pcm, DEFAULT_SAMPLE_RATE, true);
+    }
 
     m_txFloatAccumulator.append(float32pcm);
 
@@ -4333,8 +4371,10 @@ void AudioEngine::feedDaxTxAudio(const QByteArray& inPcm)
 
     const bool daxAudioWillTransmit = m_radioTransmitting
         && (!m_daxTxUseRadioRoute || !(m_transmitting && !m_daxTxMode));
-    if (daxAudioWillTransmit)
+    if (daxAudioWillTransmit) {
+        emitTxPostChainScopeFromFloat32Stereo(float32pcm, DEFAULT_SAMPLE_RATE);
         emitScopeFromFloat32Stereo(float32pcm, DEFAULT_SAMPLE_RATE, true);
+    }
 
     if (!m_daxTxUseRadioRoute) {
         // Low-latency route: keep radio on mic path (dax=0) and packetize

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -472,12 +472,10 @@ signals:
 
     void pcMicLevelChanged(float peakDbfs, float avgDbfs);  // client-side PC mic metering
     void scopeSamplesReady(const QByteArray& monoFloat32Pcm, int sampleRate, bool tx);
-    // Emitted on every TX block AFTER everything the strip can do to
-    // the audio: user DSP chain, PC mic gain, and the final brickwall
-    // limiter.  This is the exact int16 stream that gets packetised
-    // into VITA-49 and sent to the radio — what the strip's
-    // "Waveform CE-SSB" panel listens to so the operator sees the
-    // actual transmitted envelope.
+    // Emitted on the local TX audio that will feed the radio. For PC mic
+    // voice this is after the strip, PC mic gain, and final limiter; for
+    // DAX/TCI/RADE digital bypasses this is the pre-packetization waveform
+    // because those paths intentionally skip the voice chain.
     void txPostChainScopeReady(const QByteArray& monoFloat32Pcm, int sampleRate);
     // Mirror of txPostChainScopeReady for the RX side: high-rate emit
     // (~125 Hz, no sample loss across audio callbacks) so the channel
@@ -508,6 +506,7 @@ private:
     void emitScopeFromFloat32Stereo(const QByteArray& pcm, int sampleRate, bool tx);
     void emitScopeFromInt16Stereo(const QByteArray& pcm, int sampleRate, bool tx);
     void emitTxPostChainScopeFromInt16Stereo(const QByteArray& pcm, int sampleRate);
+    void emitTxPostChainScopeFromFloat32Stereo(const QByteArray& pcm, int sampleRate);
     void emitRxPostChainScopeFromFloat32Stereo(const QByteArray& pcm, int sampleRate);
     QByteArray resampleStereo(const QByteArray& pcm);
     void processNr2(const QByteArray& stereoPcm);

--- a/src/gui/StripWaveform.cpp
+++ b/src/gui/StripWaveform.cpp
@@ -870,8 +870,10 @@ void StripWaveform::drawNoAudio(QPainter& painter,
     f.setPointSizeF(std::max(8.0, f.pointSizeF() - 1.0));
     painter.setFont(f);
     painter.setPen(kMutedLabel);
-    painter.drawText(plotRect, Qt::AlignCenter,
-                     QStringLiteral("no %1 audio").arg(source));
+    const QString message = source == QStringLiteral("RX")
+        ? QStringLiteral("Enable PC Audio")
+        : QStringLiteral("no %1 audio").arg(source);
+    painter.drawText(plotRect, Qt::AlignCenter, message);
     painter.restore();
 }
 

--- a/src/gui/StripWaveformPanel.cpp
+++ b/src/gui/StripWaveformPanel.cpp
@@ -125,8 +125,8 @@ StripWaveformPanel::StripWaveformPanel(AudioEngine* engine, QWidget* parent)
     applyViewMode();
 
     if (m_audio) {
-        // TX-side tap: post-final-limiter — the exact bytes packetised
-        // for VITA-49.  Fires only when the user is transmitting.
+        // TX-side tap: post-final-limiter for PC mic voice, and the
+        // pre-packetization bypass waveform for digital TX paths.
         connect(m_audio, &AudioEngine::txPostChainScopeReady,
                 m_waveform, [this](const QByteArray& mono, int sr) {
             if (m_side != Side::Tx || !m_waveform) return;
@@ -135,8 +135,7 @@ StripWaveformPanel::StripWaveformPanel(AudioEngine* engine, QWidget* parent)
         // RX-side tap: dedicated rxPostChainScopeReady — same 8 ms
         // throttle as the TX-side feed so the strip's RX scroll tracks
         // wall clock at short windows.  The shared scopeSamplesReady
-        // signal that the floating WaveApplet uses keeps its 25 ms
-        // throttle, so both consumers get what they need.
+        // signal keeps its 25 ms throttle for lower-rate consumers.
         connect(m_audio, &AudioEngine::rxPostChainScopeReady,
                 m_waveform, [this](const QByteArray& mono, int sr) {
             if (m_side != Side::Rx || !m_waveform) return;

--- a/src/gui/WaveformWidget.cpp
+++ b/src/gui/WaveformWidget.cpp
@@ -865,8 +865,10 @@ void WaveformWidget::drawNoAudio(QPainter& painter,
     f.setPointSizeF(std::max(8.0, f.pointSizeF() - 1.0));
     painter.setFont(f);
     painter.setPen(kMutedLabel);
-    painter.drawText(plotRect, Qt::AlignCenter,
-                     QStringLiteral("no %1 audio").arg(source));
+    const QString message = source == QStringLiteral("RX")
+        ? QStringLiteral("Enable PC Audio")
+        : QStringLiteral("no %1 audio").arg(source);
+    painter.drawText(plotRect, Qt::AlignCenter, message);
     painter.restore();
 }
 


### PR DESCRIPTION
## Summary

- Restore the high-rate WAVE TX scope feed for digital transmit bypass paths, including DAX/TCI and RADE, so FT8, Winlink, and other external TX audio sources show waveform activity again.
- Keep SSB phone waveform monitoring on the existing post-final-limiter voice tap.
- Change the RX waveform empty-state text from the generic no-audio message to `Enable PC Audio`.
- Update the audio pipeline documentation to describe the shared high-rate TX scope behavior for voice and digital paths.

## Root Cause

Recent WAVE wiring moved the display to `txPostChainScopeReady`, but DAX/TCI transmit audio intentionally bypasses the voice chain and continued to emit only the older shared `scopeSamplesReady` signal. That left digital-mode TX audio packetizing normally while the WAVE display had no high-rate TX samples to render.

## Validation

- `cmake --build build -j22`
- `ctest --test-dir build --output-on-failure -j22` (7/7 passed)

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
