### PR TITLE
feat(swr): license confirmation modal for Antenna SWR Sweep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,6 +582,7 @@ set(GUI_SOURCES
     src/gui/TunerApplet.cpp
     src/gui/TxApplet.cpp
     src/gui/AtuPreTuneDialog.cpp
+    src/gui/SwrSweepLicenseDialog.cpp
     src/gui/PhoneCwApplet.cpp
     src/gui/PhoneApplet.cpp
     src/gui/EqApplet.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -74,6 +74,7 @@
 #include "PropDashboardDialog.h"
 #include "MemoryCommands.h"
 #include "MemoryDialog.h"
+#include "SwrSweepLicenseDialog.h"
 #include "DxClusterDialog.h"
 #include "CwxPanel.h"
 #include "DvkPanel.h"
@@ -13046,6 +13047,14 @@ void MainWindow::startSwrSweep(int requestedSliceId, int sweepPowerWatts)
     if (sweepFreqs.size() > kSwrSweepMaxPoints) {
         QMessageBox::warning(this, tr("SWR Sweep"),
                              tr("This band would need too many sweep points for one fast pass."));
+        return;
+    }
+
+    // License gate.  First-press shows a modal disclaimer; subsequent
+    // presses are silent once the user ticks "Remember my answer" and
+    // accepts.  Placed after all preconditions clear so the dialog only
+    // fires when an actual transmission would follow.
+    if (!SwrSweepLicenseDialog::confirm(this)) {
         return;
     }
 

--- a/src/gui/SwrSweepLicenseDialog.cpp
+++ b/src/gui/SwrSweepLicenseDialog.cpp
@@ -1,0 +1,101 @@
+#include "SwrSweepLicenseDialog.h"
+#include "core/AppSettings.h"
+
+#include <QCheckBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr const char* kSettingsKey = "SwrSweepLicenseConfirmed";
+
+constexpr const char* kDisclaimerText =
+    "<b>Operator Responsibility:</b> The Antenna SWR Sweep transmits a "
+    "1&nbsp;W tune carrier at multiple frequencies across the current TX "
+    "band.  You must ensure that your transmissions do not interfere with "
+    "other radio traffic — always verify that the band is clear before "
+    "starting, and never run an unattended sweep unless you fully "
+    "understand its behavior, failure modes, and risks.  You are "
+    "responsible for compliance with your license class and local "
+    "regulations.";
+
+} // namespace
+
+SwrSweepLicenseDialog::SwrSweepLicenseDialog(QWidget* parent)
+    // Empty geomKey — modal one-shot, no need to persist geometry.
+    : PersistentDialog("Antenna SWR Sweep — License Confirmation",
+                       /*geomKey*/ QString(), parent)
+{
+    setModal(true);
+    setMinimumSize(520, 240);
+    setStyleSheet("QDialog { background: #0f0f1a; color: #c8d8e8; }");
+
+    auto* root = new QVBoxLayout(bodyWidget());
+    root->setSpacing(14);
+
+    auto* disclaimer = new QLabel(kDisclaimerText);
+    disclaimer->setWordWrap(true);
+    disclaimer->setTextFormat(Qt::RichText);
+    disclaimer->setStyleSheet(
+        "QLabel { color: #c8d8e8; font-size: 12px; line-height: 1.4; }");
+    root->addWidget(disclaimer);
+
+    m_rememberCheck = new QCheckBox("Remember my answer");
+    m_rememberCheck->setStyleSheet(
+        "QCheckBox { color: #8aa8c0; font-size: 11px; }"
+        "QCheckBox::indicator { width: 14px; height: 14px;"
+        " border: 1px solid #406080; border-radius: 2px; background: #0a0a18; }"
+        "QCheckBox::indicator:checked { background: #00b4d8; }");
+    root->addWidget(m_rememberCheck);
+
+    auto* btnRow = new QHBoxLayout;
+    btnRow->setSpacing(8);
+    btnRow->addStretch();
+
+    auto* cancelBtn = new QPushButton("Cancel");
+    cancelBtn->setStyleSheet(
+        "QPushButton { background: #1a2a3a; color: #c8d8e8; "
+        "border: 1px solid #304050; border-radius: 3px;"
+        " padding: 6px 16px; font-size: 11px; }"
+        "QPushButton:hover { background: #203040; border-color: #0090e0; }");
+    connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
+    btnRow->addWidget(cancelBtn);
+
+    auto* acceptBtn = new QPushButton("I am licensed to use this feature");
+    acceptBtn->setDefault(true);
+    acceptBtn->setStyleSheet(
+        "QPushButton { background: #00b4d8; color: #0f0f1a; font-weight: bold;"
+        " border: 1px solid #008ba8; border-radius: 3px;"
+        " padding: 6px 16px; font-size: 11px; }"
+        "QPushButton:hover { background: #00c8f0; }"
+        "QPushButton:default { border: 2px solid #00f0ff; }");
+    connect(acceptBtn, &QPushButton::clicked, this, &QDialog::accept);
+    btnRow->addWidget(acceptBtn);
+
+    root->addStretch();
+    root->addLayout(btnRow);
+}
+
+bool SwrSweepLicenseDialog::confirm(QWidget* parent)
+{
+    auto& s = AppSettings::instance();
+    if (s.value(kSettingsKey, "False").toString() == "True") {
+        return true;
+    }
+
+    SwrSweepLicenseDialog dlg(parent);
+    if (dlg.exec() != QDialog::Accepted) {
+        return false;
+    }
+    if (dlg.m_rememberCheck && dlg.m_rememberCheck->isChecked()) {
+        s.setValue(kSettingsKey, "True");
+        s.save();
+    }
+    return true;
+}
+
+} // namespace AetherSDR

--- a/src/gui/SwrSweepLicenseDialog.h
+++ b/src/gui/SwrSweepLicenseDialog.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "PersistentDialog.h"
+
+class QCheckBox;
+
+namespace AetherSDR {
+
+// Modal license-confirmation dialog gating the Antenna SWR sweep.
+//
+// First time the user hits Start Sweep, this dialog appears with an
+// operator-responsibility disclaimer (mirrors the ATU Band Pre-Tune
+// disclaimer) and two buttons: "I am licensed to use this feature"
+// and "Cancel".  A "Remember my answer" checkbox persists the
+// confirmation to AppSettings under SwrSweepLicenseConfirmed so
+// subsequent presses go straight to the sweep without the popup.
+//
+// Use the static confirm() helper at the call site — it handles the
+// AppSettings short-circuit, the modal exec(), and the persistence
+// write so callers don't need to manage any of that themselves.
+class SwrSweepLicenseDialog : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    explicit SwrSweepLicenseDialog(QWidget* parent = nullptr);
+
+    // True when the user has either previously confirmed (with the
+    // remember-my-answer checkbox) or just confirmed in this session.
+    // Returns false if the user cancels.  Safe to call repeatedly.
+    static bool confirm(QWidget* parent = nullptr);
+
+private:
+    QCheckBox* m_rememberCheck{nullptr};
+};
+
+} // namespace AetherSDR


### PR DESCRIPTION
First-press Start Sweep now opens a modal dialog with an
operator-responsibility disclaimer (adapted from the ATU Band
Pre-Tune wording) and two buttons:

  * "I am licensed to use this feature" — proceeds with the sweep
  * "Cancel" — aborts

A "Remember my answer" checkbox persists the confirmation to
AppSettings under SwrSweepLicenseConfirmed, so subsequent presses go
straight to the sweep without the popup.  Defaults to unchecked so
the operator must explicitly opt into silence.

New SwrSweepLicenseDialog class with a static `confirm(parent)`
helper that handles the AppSettings short-circuit, modal exec(), and
persistence write in one call:

  if (!SwrSweepLicenseDialog::confirm(this)) return;

Placed in MainWindow::startSwrSweep after all preconditions clear,
just before sweep-state initialization — so users hitting "select TX
slice" or "disable split" errors don't see the disclaimer until
they've cleared those hurdles and a real transmission is imminent.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
