### PR TITLE
feat(display): Spectrum overlay Display panel reorder + SQL Margin → RX Applet

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10405,10 +10405,13 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         if (auto* s = activeSlice()) s->setSquelch(true, level);
         sw->setSquelchLine(true, level);
     });
-    // SQL Margin overlay control → spectrum widget + persist
-    connect(menu, &SpectrumOverlayMenu::autoSqlMarginDbChanged,
+    // Auto-squelch margin: now driven by the RX Applet's SQL slider when
+    // SQL mode is Auto (instead of a separate slider in the Display
+    // overlay).  The slider repurposes itself in Auto mode to set the
+    // dB margin above the measured noise floor; manual mode is unchanged.
+    connect(m_appletPanel->rxApplet(), &RxApplet::autoSqlMarginDbChanged,
             sw, &SpectrumWidget::setAutoSqlMarginDb);
-    // Initialize SQL Margin from AppSettings for this pan's spectrum widget
+    // Initialize from AppSettings for this pan's spectrum widget.
     {
         auto& s = AppSettings::instance();
         int margin = std::clamp(s.value("AutoSqlMarginDb", "10").toInt(), 5, 20);
@@ -10599,6 +10602,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         s.setValue(sw->settingsKey("BackgroundImage"),            ":/bg-default.jpg");
         s.setValue(sw->settingsKey("BackgroundOpacity"),          "80");
         s.setValue(sw->settingsKey("DisplayFreqGridSpacing"),     "0");
+        s.setValue(sw->settingsKey("DisplayNoiseFloorEnable"),    "False");
+        s.setValue(sw->settingsKey("DisplayNoiseFloorPosition"),  "75");
         s.save();
 
         // Sync all Display panel UI controls
@@ -11059,6 +11064,14 @@ MainWindow::TuneCenteringResult MainWindow::panFollowVfo(
 void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
 {
     const int sliceId = s->sliceId();
+
+    // Bidirectional SQL sync — the VfoWidget mirrors the RxApplet's 3-way
+    // SQL state (Off / Manual / Auto), the manual-level cache, and the
+    // Auto dB margin.  RxApplet is the source of truth; VfoWidget pipes
+    // its own button + slider events through RxApplet so persistence,
+    // algorithm enable/disable, and the manual cache stay in one place.
+    if (m_appletPanel && m_appletPanel->rxApplet())
+        w->setRxApplet(m_appletPanel->rxApplet());
 
     // Note: w->setSlice(s) is called at the end of this method (line ~1895)
 

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -242,6 +242,14 @@ static QPushButton* mkRight(QWidget* parent = nullptr) { return new TriBtn(TriBt
 RxApplet::RxApplet(QWidget* parent) : QWidget(parent)
 {
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    // Recall the last user-chosen Manual squelch threshold from prior
+    // sessions.  Auto mode clobbers the slice's squelchLevel with
+    // algorithm-suggested values, so the radio can't be relied on to
+    // preserve the operator's manual preference across mode cycles or
+    // launches — we persist it client-side.
+    m_sqlManualLevel = std::clamp(
+        AppSettings::instance().value("LastManualSquelchLevel", "20").toInt(),
+        0, 100);
     buildUI();
 }
 
@@ -794,8 +802,28 @@ void RxApplet::buildUI()
         connect(m_sqlBtn, &QPushButton::clicked,
                 this, &RxApplet::cycleSqlMode);
         connect(m_sqlSlider, &QSlider::valueChanged, this, [this](int v) {
-            if (m_slice && m_sqlMode == SqlMode::Manual)
-                m_slice->setSquelch(true, v);
+            if (m_sqlMode == SqlMode::Manual) {
+                // Cache the user's chosen manual level so re-entering
+                // Manual from Auto/Off restores it, and persist it so the
+                // choice survives launch (the slice's squelchLevel gets
+                // clobbered by Auto's algorithm pushes and can no longer
+                // be trusted as the manual baseline).
+                m_sqlManualLevel = v;
+                auto& s = AppSettings::instance();
+                s.setValue("LastManualSquelchLevel", QString::number(v));
+                s.save();
+                if (m_slice)
+                    m_slice->setSquelch(true, v);
+            } else if (m_sqlMode == SqlMode::Auto) {
+                // Auto SQL: slider sets the dB margin above the measured
+                // noise floor (5–20 dB).  Persist + broadcast so every
+                // pan's auto-squelch algorithm picks up the new margin
+                // and the suggested level recomputes on the next FFT.
+                auto& s = AppSettings::instance();
+                s.setValue("AutoSqlMarginDb", QString::number(v));
+                s.save();
+                emit autoSqlMarginDbChanged(v);
+            }
         });
         rightCol->addLayout(row);
     }
@@ -1074,8 +1102,49 @@ void RxApplet::applySqlModeVisuals()
             + kDisabledBtn);
         break;
     }
-    // Slider is the threshold input; only meaningful in Manual mode.
-    if (m_sqlSlider) m_sqlSlider->setEnabled(m_sqlMode == SqlMode::Manual);
+    // Slider has two distinct roles depending on mode:
+    //   Manual: threshold input (0–100, squelch_level units).
+    //   Auto:   dB margin above measured noise floor (5–20).
+    //   Off:    disabled.
+    // Switching modes resizes the slider's range and restores the
+    // appropriate value (live squelch_level for Manual, persisted
+    // AutoSqlMarginDb for Auto).  Signals are blocked during the swap
+    // so the resize doesn't fire a phantom valueChanged into either path.
+    if (m_sqlSlider) {
+        QSignalBlocker b(m_sqlSlider);
+        switch (m_sqlMode) {
+        case SqlMode::Manual: {
+            m_sqlSlider->setRange(0, 100);
+            // Restore the cached manual level — slice->squelchLevel() may
+            // hold a stale Auto-algorithm value that doesn't represent the
+            // user's chosen manual threshold.
+            m_sqlSlider->setValue(m_sqlManualLevel);
+            m_sqlSlider->setEnabled(true);
+            m_sqlSlider->setToolTip(
+                "Squelch threshold (0–100). Increase to require a stronger "
+                "signal before audio opens.");
+            break;
+        }
+        case SqlMode::Auto: {
+            m_sqlSlider->setRange(5, 20);
+            const int margin = std::clamp(
+                AppSettings::instance().value("AutoSqlMarginDb", "10").toInt(),
+                5, 20);
+            m_sqlSlider->setValue(margin);
+            m_sqlSlider->setEnabled(true);
+            m_sqlSlider->setToolTip(
+                "Auto SQL margin (5–20 dB). dB above the measured noise "
+                "floor where the squelch gate opens.");
+            break;
+        }
+        case SqlMode::Off:
+            m_sqlSlider->setEnabled(false);
+            m_sqlSlider->setToolTip(
+                "Squelch threshold. Increase to require a stronger signal "
+                "before audio opens.");
+            break;
+        }
+    }
 }
 
 void RxApplet::cycleSqlMode()
@@ -1087,6 +1156,53 @@ void RxApplet::cycleSqlMode()
     setSqlMode(next, /*propagateToRadio=*/true);
 }
 
+// ── Cross-widget SQL drivers (for VfoWidget mirroring) ──────────────────
+//
+// VfoWidget hosts a second SQL button+slider that must show the same
+// mode and value as the one in RxApplet.  These helpers let it pipe its
+// own user events through RxApplet's existing state machine so all the
+// persistence (AppSettings LastManualSquelchLevel / AutoSqlMarginDb),
+// algorithm enable/disable, and the manual-level cache live in exactly
+// one place.  RxApplet emits sqlModeChanged / autoSqlMarginDbChanged
+// back so VfoWidget can refresh its UI.
+
+void RxApplet::cycleSqlModeExternal()
+{
+    cycleSqlMode();
+}
+
+int RxApplet::autoSqlMarginDb() const
+{
+    return std::clamp(
+        AppSettings::instance().value("AutoSqlMarginDb", "10").toInt(), 5, 20);
+}
+
+void RxApplet::setSqlSliderValueExternal(int v)
+{
+    if (m_sqlMode == SqlMode::Manual) {
+        m_sqlManualLevel = v;
+        auto& s = AppSettings::instance();
+        s.setValue("LastManualSquelchLevel", QString::number(v));
+        s.save();
+        if (m_slice)
+            m_slice->setSquelch(true, v);
+        if (m_sqlSlider) {
+            QSignalBlocker b(m_sqlSlider);
+            m_sqlSlider->setValue(v);
+        }
+    } else if (m_sqlMode == SqlMode::Auto) {
+        auto& s = AppSettings::instance();
+        s.setValue("AutoSqlMarginDb", QString::number(v));
+        s.save();
+        emit autoSqlMarginDbChanged(v);
+        if (m_sqlSlider) {
+            QSignalBlocker b(m_sqlSlider);
+            m_sqlSlider->setValue(v);
+        }
+    }
+    // Off: ignored — slider is disabled on both UIs.
+}
+
 void RxApplet::setSqlMode(SqlMode m, bool propagateToRadio)
 {
     if (m == m_sqlMode) return;
@@ -1094,6 +1210,11 @@ void RxApplet::setSqlMode(SqlMode m, bool propagateToRadio)
     const bool nowAuto = (m == SqlMode::Auto);
     m_sqlMode = m;
     applySqlModeVisuals();
+
+    // Notify any mirroring UI (VfoWidget's SQL button + slider) so it can
+    // refresh label / color / slider role to match.  Fires before the
+    // radio-push below so listeners see the new mode before any echo.
+    emit sqlModeChanged(static_cast<int>(m));
 
     // Auto state is client-side only; tell the spectrum-side algorithm to
     // start or stop driving the level.
@@ -1551,6 +1672,14 @@ void RxApplet::connectSlice(SliceModel* s)
     // re-enter Auto on the new slice with one click if they want.
     {
         QSignalBlocker b1(m_sqlBtn), b2(m_sqlSlider);
+        // Do NOT overwrite m_sqlManualLevel from the slice here — the
+        // slice's squelchLevel may have been clobbered by Auto-mode
+        // algorithm pushes in the prior session, and we want to keep the
+        // user's persisted manual choice as the source of truth across
+        // launches.  The slider value is still visually set to the
+        // slice's current state below; applySqlModeVisuals (via the
+        // setSqlMode call) will overwrite that with m_sqlManualLevel
+        // when entering Manual.
         m_sqlSlider->setValue(s->squelchLevel());
         setSqlMode(s->squelchOn() ? SqlMode::Manual : SqlMode::Off,
                    /*propagateToRadio=*/false);
@@ -1568,7 +1697,26 @@ void RxApplet::connectSlice(SliceModel* s)
 
     connect(s, &SliceModel::squelchChanged, this, [this](bool on, int level) {
         QSignalBlocker b1(m_sqlBtn), b2(m_sqlSlider);
-        m_sqlSlider->setValue(level);
+        // In Auto mode the slider represents the operator-chosen dB margin,
+        // NOT the algorithm-suggested threshold — skip the value update so
+        // the algorithm's tick-by-tick setSquelch echoes don't overwrite
+        // the user's margin choice.  The spectrum-side yellow SQL line
+        // still tracks `level` via setSquelchLine.
+        if (m_sqlMode != SqlMode::Auto) {
+            m_sqlSlider->setValue(level);
+            // Keep the Manual-level cache in sync with external squelch
+            // changes (TCI client, radio panel knob) so a later Manual
+            // re-entry restores the up-to-date value, not a stale one.
+            // Persist too so launch-time recall reflects the most recent
+            // manual threshold regardless of who set it.
+            if (m_sqlMode == SqlMode::Manual) {
+                m_sqlManualLevel = level;
+                auto& settings = AppSettings::instance();
+                settings.setValue("LastManualSquelchLevel",
+                                  QString::number(level));
+                settings.save();
+            }
+        }
         // Auto drives setSquelch every algorithm tick; don't demote out of
         // Auto when the echo arrives with squelch-on.  Only flip the mode
         // when the radio reports squelch-off (operator hit it from somewhere
@@ -1903,8 +2051,9 @@ void RxApplet::updateModeSettings(const QString& mode)
                         || mode == "RTTY"
                         || mode == "CW" || mode == "CWL");
     m_sqlBtn->setEnabled(!sqlDisabled);
-    // Slider enabled only in Manual mode AND mode allows squelch.
-    m_sqlSlider->setEnabled(!sqlDisabled && m_sqlMode == SqlMode::Manual);
+    // Slider enabled when the mode allows squelch AND we're not in SqlMode::Off.
+    // Manual mode = threshold input; Auto mode = dB margin input.
+    m_sqlSlider->setEnabled(!sqlDisabled && m_sqlMode != SqlMode::Off);
     if (sqlDisabled && m_slice) {
         if (m_slice->squelchOn() || m_sqlMode == SqlMode::Auto) {
             m_savedSquelchOn = true;

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -39,11 +39,32 @@ class RxApplet : public QWidget {
     Q_OBJECT
 
 public:
+    // 3-way squelch state.  Off → Manual → Auto cycle on SQL button click.
+    // Mirrored by VfoWidget's SQL button via the sqlModeChanged signal so
+    // both UI surfaces present the same state and value.
+    enum class SqlMode : uint8_t { Off, Manual, Auto };
+
     explicit RxApplet(QWidget* parent = nullptr);
 
     // Attach to a slice; pass nullptr to detach.
     void setSlice(SliceModel* slice);
     void setAfGain(int pct);
+
+    // Cross-widget access for the bidirectional SQL sync with VfoWidget.
+    // VfoWidget mirrors mode + value via these methods; RxApplet stays the
+    // source of truth for SqlMode, the manual-level cache, and the
+    // AutoSqlMarginDb persistence.
+    SqlMode sqlMode() const { return m_sqlMode; }
+    int     sqlManualLevel() const { return m_sqlManualLevel; }
+    int     autoSqlMarginDb() const;
+    // Externally cycle the mode (Off → Manual → Auto → Off) — same path the
+    // RxApplet's own SQL button takes.  Emits sqlModeChanged.
+    void    cycleSqlModeExternal();
+    // Programmatic slider drag from another UI surface.  Branches by mode
+    // exactly like the in-applet slider does: Manual writes the slice and
+    // persists m_sqlManualLevel; Auto writes AppSettings AutoSqlMarginDb
+    // and emits autoSqlMarginDbChanged.  Off is a no-op.
+    void    setSqlSliderValueExternal(int v);
     void syncStepFromSlice(int stepHz, const QVector<int>& stepList);
     void cycleStepUp();
     void cycleStepDown();
@@ -78,6 +99,17 @@ signals:
     void stepSizeChanged(int hz);
     // Emitted when Auto SQL tracking is toggled.
     void sqlAutoChanged(bool on);
+    // Emitted on every SQL mode transition (Off / Manual / Auto), so any
+    // mirroring UI (e.g. VfoWidget's SQL button + slider) can refresh its
+    // label, color, and slider role.  Carries the new SqlMode value as an
+    // int so the header doesn't need to leak the enum to listeners that
+    // don't care about the symbolic names.
+    void sqlModeChanged(int mode);
+    // Emitted when the user adjusts the SQL slider while SQL mode is Auto.
+    // Carries the new dB margin above the measured noise floor.  Routes to
+    // every SpectrumWidget's setAutoSqlMarginDb().  Replaces the standalone
+    // "Auto SQL ∆" slider that used to live in the Display overlay menu.
+    void autoSqlMarginDbChanged(int dB);
     // Emitted when the radio reports a squelch state change (for spectrum line).
     void squelchStateChanged(bool on, int level);
 
@@ -190,11 +222,16 @@ private:
     // change with the mode ("SQL"/"AUTO"; base/green/amber).  Auto mode
     // emits sqlAutoChanged(true) so MainWindow's spectrum-side algorithm
     // takes over driving the squelch level; Manual mode uses the slider.
-    enum class SqlMode : uint8_t { Off, Manual, Auto };
+    // SqlMode is declared in the public section above so VfoWidget can mirror.
     QPushButton* m_sqlBtn{nullptr};
     QSlider*     m_sqlSlider{nullptr};
     SqlMode      m_sqlMode{SqlMode::Off};
     bool         m_savedSquelchOn{false};
+    // Last user-chosen Manual squelch level (0–100).  Auto mode overwrites
+    // the slice's squelchLevel with algorithm-suggested values every FFT
+    // tick, so we cache the manual value separately and restore it when
+    // the user comes back to Manual.  Seeded from the slice on first attach.
+    int          m_sqlManualLevel{20};
 
     void applySqlModeVisuals();
     void cycleSqlMode();

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -791,17 +791,61 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         ++row;
     };
 
+    // ── Toggle button row ─────────────────────────────────────────────────
+    {
+        auto* toggleRow = new QWidget;
+        // The Display panel's QWidget { border: 1px solid } cascades to this
+        // QWidget container and would otherwise draw a 1 px frame around the
+        // whole Heat Map / Grid / Wt Avg row.  Override locally.
+        toggleRow->setStyleSheet("QWidget { border: none; background: transparent; }");
+        auto* toggleLayout = new QHBoxLayout(toggleRow);
+        toggleLayout->setContentsMargins(0, 2, 0, 2);
+        toggleLayout->setSpacing(3);
+
+        // Use the shared btnStyle so Heat Map / Grid / Wt Avg get the same
+        // 1 px frame (blue unchecked, green checked) as the FFT Floor "Auto"
+        // button and the other row-end action buttons.  The toggleRow
+        // QWidget container itself is borderless (see setStyleSheet above)
+        // so the panel's cascading frame doesn't draw a box around the
+        // whole row.
+        auto makeToggle = [&](const QString& text, QPushButton*& btn, bool checked = false) {
+            btn = new QPushButton(text);
+            btn->setCheckable(true);
+            btn->setChecked(checked);
+            btn->setStyleSheet(btnStyle);
+            btn->setFixedHeight(20);
+            toggleLayout->addWidget(btn);
+        };
+
+        makeToggle("Heat Map", m_heatMapBtn);
+        makeToggle("Grid", m_showGridBtn, true);
+        makeToggle("Wt Avg", m_weightedAvgBtn);
+
+        grid->addWidget(toggleRow, row, 0, 1, 4);
+        ++row;
+
+        connect(m_heatMapBtn, &QPushButton::toggled, this, [this](bool on) {
+            emit fftHeatMapChanged(on);
+        });
+        connect(m_showGridBtn, &QPushButton::toggled, this, [this](bool on) {
+            emit showGridChanged(on);
+        });
+        connect(m_weightedAvgBtn, &QPushButton::toggled, this, [this](bool on) {
+            emit fftWeightedAverageChanged(on);
+        });
+    }
+
     // ── Sliders ───────────────────────────────────────────────────────────
 
     // AVG
-    makeRow("AVG:", 0, 100, 0, m_avgSlider, m_avgLabel);
+    makeRow("FFT AVG:", 0, 100, 0, m_avgSlider, m_avgLabel);
     connect(m_avgSlider, &QSlider::valueChanged, this, [this](int v) {
         m_avgLabel->setText(QString::number(v));
         emit fftAverageChanged(v);
     });
 
     // FPS
-    makeRow("FPS:", 5, 30, 25, m_fpsSlider, m_fpsLabel);
+    makeRow("FFT FPS:", 5, 30, 25, m_fpsSlider, m_fpsLabel);
     connect(m_fpsSlider, &QSlider::valueChanged, this, [this](int v) {
         m_fpsLabel->setText(QString::number(v));
         emit fftFpsChanged(v);
@@ -809,7 +853,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
 
     // Line Width
     {
-        auto* lbl = new QLabel("Line Width:");
+        auto* lbl = new QLabel("FFT Line:");
         lbl->setStyleSheet(labelStyle);
         grid->addWidget(lbl, row, 0);
 
@@ -835,23 +879,9 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         });
     }
 
-    // Gain
-    makeRow("Gain:", 0, 100, 50, m_gainSlider, m_gainLabel);
-    connect(m_gainSlider, &QSlider::valueChanged, this, [this](int v) {
-        m_gainLabel->setText(QString::number(v));
-        emit wfColorGainChanged(v);
-    });
-
-    // Rate
-    makeRow("Rate:", 1, 30, 15, m_rateSlider, m_rateLabel);
-    connect(m_rateSlider, &QSlider::valueChanged, this, [this](int v) {
-        m_rateLabel->setText(QString::number(v));
-        emit wfLineDurationChanged(v + 70);
-    });
-
     // Fill: color picker button + slider
     {
-        auto* lbl = new QLabel("Fill:");
+        auto* lbl = new QLabel("FFT Fill:");
         lbl->setStyleSheet(labelStyle);
         grid->addWidget(lbl, row, 0);
 
@@ -895,13 +925,40 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         });
     }
 
+    // ── Noise Floor reference line ────────────────────────────────────────
+    makeRowWithBtn("FFT Floor:", 1, 99, 75, m_floorSlider, m_floorLabel,
+                   m_floorEnableBtn, "Auto");
+    m_floorSlider->setEnabled(false);
+    connect(m_floorEnableBtn, &QPushButton::toggled, this, [this](bool on) {
+        m_floorSlider->setEnabled(on);
+        emit noiseFloorEnableChanged(on);
+    });
+    connect(m_floorSlider, &QSlider::valueChanged, this, [this](int v) {
+        m_floorLabel->setText(QString::number(v));
+        emit noiseFloorPositionChanged(v);
+    });
+
+    // NB Blank + Off/On
+    makeRowWithBtn("NB Blank:", 5, 95, 15, m_wfBlankerThreshSlider, m_wfBlankerThreshLabel,
+                   m_wfBlankerBtn, "Off");
+    m_wfBlankerBtn->setToolTip("Suppress impulse noise stripes in waterfall");
+    connect(m_wfBlankerBtn, &QPushButton::toggled, this, [this](bool on) {
+        m_wfBlankerBtn->setText(on ? "On" : "Off");
+        emit wfBlankerEnabledChanged(on);
+    });
+    connect(m_wfBlankerThreshSlider, &QSlider::valueChanged, this, [this](int v) {
+        float t = 1.0f + v / 100.0f;
+        m_wfBlankerThreshLabel->setText(QString::number(t, 'f', 2));
+        emit wfBlankerThresholdChanged(t);
+    });
+
     // Black + Auto.  Single slider with two roles depending on AUTO state:
     //   AUTO off → manual black-level (0..100), value persists in
     //              m_blackManualValue and emits wfBlackLevelChanged.
     //   AUTO on  → noise-floor offset (0..100, 50 = noise floor), value
     //              persists in m_blackAutoOffsetValue and emits
     //              wfAutoBlackOffsetChanged.
-    makeRowWithBtn("Black:", 0, 100, 50, m_blackSlider, m_blackLabel,
+    makeRowWithBtn("Black Level:", 0, 100, 50, m_blackSlider, m_blackLabel,
                    m_autoBlackBtn, "Auto");
     m_autoBlackBtn->setChecked(true);
     connect(m_blackSlider, &QSlider::valueChanged, this, [this](int v) {
@@ -937,18 +994,18 @@ void SpectrumOverlayMenu::buildDisplayPanel()
             emit wfAutoBlackOffsetChanged(m_blackAutoOffsetValue);
     });
 
-    // NB Blank + Off/On
-    makeRowWithBtn("NB Blank:", 5, 95, 15, m_wfBlankerThreshSlider, m_wfBlankerThreshLabel,
-                   m_wfBlankerBtn, "Off");
-    m_wfBlankerBtn->setToolTip("Suppress impulse noise stripes in waterfall");
-    connect(m_wfBlankerBtn, &QPushButton::toggled, this, [this](bool on) {
-        m_wfBlankerBtn->setText(on ? "On" : "Off");
-        emit wfBlankerEnabledChanged(on);
+    // Gain
+    makeRow("WtrFall Gain:", 0, 100, 50, m_gainSlider, m_gainLabel);
+    connect(m_gainSlider, &QSlider::valueChanged, this, [this](int v) {
+        m_gainLabel->setText(QString::number(v));
+        emit wfColorGainChanged(v);
     });
-    connect(m_wfBlankerThreshSlider, &QSlider::valueChanged, this, [this](int v) {
-        float t = 1.0f + v / 100.0f;
-        m_wfBlankerThreshLabel->setText(QString::number(t, 'f', 2));
-        emit wfBlankerThresholdChanged(t);
+
+    // Rate
+    makeRow("WtrFall Rate:", 1, 30, 15, m_rateSlider, m_rateLabel);
+    connect(m_rateSlider, &QSlider::valueChanged, this, [this](int v) {
+        m_rateLabel->setText(QString::number(v));
+        emit wfLineDurationChanged(v + 70);
     });
 
     // BG Opacity
@@ -994,68 +1051,6 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         });
         grid->addWidget(clearBtn, row, 3);
         ++row;
-    }
-
-    // ── Toggle button row ─────────────────────────────────────────────────
-    {
-        auto* toggleRow = new QWidget;
-        auto* toggleLayout = new QHBoxLayout(toggleRow);
-        toggleLayout->setContentsMargins(0, 2, 0, 2);
-        toggleLayout->setSpacing(3);
-
-        auto makeToggle = [&](const QString& text, QPushButton*& btn, bool checked = false) {
-            btn = new QPushButton(text);
-            btn->setCheckable(true);
-            btn->setChecked(checked);
-            btn->setStyleSheet(btnStyle);
-            btn->setFixedHeight(20);
-            toggleLayout->addWidget(btn);
-        };
-
-        makeToggle("Heat Map", m_heatMapBtn);
-        makeToggle("Grid", m_showGridBtn, true);
-        makeToggle("Wt Avg", m_weightedAvgBtn);
-
-        grid->addWidget(toggleRow, row, 0, 1, 4);
-        ++row;
-
-        connect(m_heatMapBtn, &QPushButton::toggled, this, [this](bool on) {
-            emit fftHeatMapChanged(on);
-        });
-        connect(m_showGridBtn, &QPushButton::toggled, this, [this](bool on) {
-            emit showGridChanged(on);
-        });
-        connect(m_weightedAvgBtn, &QPushButton::toggled, this, [this](bool on) {
-            emit fftWeightedAverageChanged(on);
-        });
-    }
-
-    // ── Noise Floor reference line ────────────────────────────────────────
-    makeRowWithBtn("Floor:", 1, 99, 75, m_floorSlider, m_floorLabel,
-                   m_floorEnableBtn, "Off");
-    m_floorSlider->setEnabled(false);
-    connect(m_floorEnableBtn, &QPushButton::toggled, this, [this](bool on) {
-        m_floorEnableBtn->setText(on ? "On" : "Off");
-        m_floorSlider->setEnabled(on);
-        emit noiseFloorEnableChanged(on);
-    });
-    connect(m_floorSlider, &QSlider::valueChanged, this, [this](int v) {
-        m_floorLabel->setText(QString::number(v));
-        emit noiseFloorPositionChanged(v);
-    });
-
-    // ── Auto-squelch margin ───────────────────────────────────────────────
-    {
-        auto& s = AppSettings::instance();
-        int savedMargin = std::clamp(s.value("AutoSqlMarginDb", "10").toInt(), 5, 20);
-        makeRow("SQL Margin:", 5, 20, savedMargin, m_autoSqlMarginSlider, m_autoSqlMarginLabel);
-        connect(m_autoSqlMarginSlider, &QSlider::valueChanged, this, [this](int v) {
-            m_autoSqlMarginLabel->setText(QString::number(v));
-            auto& s2 = AppSettings::instance();
-            s2.setValue("AutoSqlMarginDb", QString::number(v));
-            s2.save();
-            emit autoSqlMarginDbChanged(v);
-        });
     }
 
     // ── Freq Grid Spacing dropdown (#1390) ──────────────────────────────
@@ -1122,7 +1117,6 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     if (m_bgOpacitySlider) m_bgOpacitySlider->setToolTip("Opacity of the background image overlay.");
     if (m_floorEnableBtn) m_floorEnableBtn->setToolTip("Shows a noise floor reference line on the spectrum display.");
     if (m_floorSlider) m_floorSlider->setToolTip("Vertical position of the noise floor reference line (% from top).");
-    if (m_autoSqlMarginSlider) m_autoSqlMarginSlider->setToolTip("Auto-squelch margin in dBm above the measured noise floor.");
 
     m_displayPanel->adjustSize();
 }
@@ -1173,7 +1167,6 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
         m_floorSlider->setValue(floorPos);
         m_floorLabel->setText(QString::number(floorPos));
         m_floorEnableBtn->setChecked(floorEnable);
-        m_floorEnableBtn->setText(floorEnable ? "On" : "Off");
         m_floorSlider->setEnabled(floorEnable);
     }
     if (m_heatMapBtn) {

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -110,8 +110,6 @@ signals:
     void wfColorSchemeChanged(int scheme);
     void noiseFloorPositionChanged(int pos);
     void noiseFloorEnableChanged(bool on);
-    // Emitted when the auto-squelch margin slider changes (dBm above noise floor).
-    void autoSqlMarginDbChanged(int dBm);
     // Emitted when user selects a band from the sub-panel.
     void bandSelected(const QString& bandName, double freqMhz, const QString& mode);
     // Emitted when user clicks XVTR button to open Radio Setup XVTR tab.
@@ -236,8 +234,6 @@ private:
     QComboBox*   m_freqGridSpacingCmb{nullptr};
     QSlider*     m_bgOpacitySlider{nullptr};
     QLabel*      m_bgOpacityLabel{nullptr};
-    QSlider*     m_autoSqlMarginSlider{nullptr};
-    QLabel*      m_autoSqlMarginLabel{nullptr};
 
     QStringList  m_antList;
     RadioModel*  m_radioModel{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -459,6 +459,13 @@ void SpectrumWidget::loadSettings()
     m_showGrid       = s.value(settingsKey("DisplayShowGrid"), "True").toString() == "True";
     m_freqGridSpacingKhz = s.value(settingsKey("DisplayFreqGridSpacing"), "0").toInt();
     m_fftLineWidth   = s.value(settingsKey("DisplayFftLineWidth"), "2.0").toFloat();
+    m_noiseFloorEnable   = s.value(settingsKey("DisplayNoiseFloorEnable"), "False").toString() == "True";
+    m_noiseFloorPosition = std::clamp(
+        s.value(settingsKey("DisplayNoiseFloorPosition"), "75").toInt(), 1, 99);
+    // Match the enable-time fresh-frame seed used by setNoiseFloorEnable so a
+    // restored Floor=on locks onto the current floor without smoothing from a
+    // stale value.
+    m_noiseFloorFreshFrameCount = m_noiseFloorEnable ? 5 : 0;
     applyFpsMeterVisibility(
         s.value("DisplayFpsMeters", "False").toString() == "True");
     m_wfColorScheme  = static_cast<WfColorScheme>(
@@ -480,11 +487,15 @@ void SpectrumWidget::loadSettings()
             static_cast<int>(m_fftFillAlpha * 100), m_fftWeightedAvg, m_fftFillColor,
             m_wfColorGain, m_wfBlackLevel, m_wfAutoBlack, m_wfAutoBlackOffset,
             m_wfLineDuration,
-            75, false, m_fftHeatMap, static_cast<int>(m_wfColorScheme), m_showGrid,
+            m_noiseFloorPosition, m_noiseFloorEnable,
+            m_fftHeatMap, static_cast<int>(m_wfColorScheme), m_showGrid,
             m_fftLineWidth);
         m_overlayMenu->syncExtraDisplaySettings(m_wfBlankerEnabled,
             m_wfBlankerThreshold, m_bgOpacity, m_freqGridSpacingKhz);
     }
+    // Refresh the noise-floor target so the slider position takes effect
+    // even when the overlay menu is built but not yet shown.
+    refreshNoiseFloorTarget();
 }
 
 VfoWidget* SpectrumWidget::addVfoWidget(int sliceId)
@@ -534,6 +545,23 @@ void SpectrumWidget::setFftAverage(int frames) {
     m_fftAverage = frames;
     auto& s = AppSettings::instance();
     s.setValue(settingsKey("DisplayFftAverage"), QString::number(frames));
+    s.save();
+}
+void SpectrumWidget::setNoiseFloorPosition(int pos) {
+    m_noiseFloorPosition = pos;
+    refreshNoiseFloorTarget();
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("DisplayNoiseFloorPosition"), QString::number(pos));
+    s.save();
+}
+void SpectrumWidget::setNoiseFloorEnable(bool on) {
+    m_noiseFloorEnable = on;
+    resetNoiseFloorBaseline();
+    // Five fresh frames after enable so we lock onto the current
+    // floor without smoothing from a stale value.
+    m_noiseFloorFreshFrameCount = on ? 5 : 0;
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("DisplayNoiseFloorEnable"), on ? "True" : "False");
     s.save();
 }
 void SpectrumWidget::setFftWeightedAvg(bool on) {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -98,17 +98,10 @@ public:
     void setDbmRange(float minDbm, float maxDbm);
 
     // Noise floor auto-adjust: position (0=top, 100=bottom), enable on/off.
-    void setNoiseFloorPosition(int pos) {
-        m_noiseFloorPosition = pos;
-        refreshNoiseFloorTarget();
-    }
-    void setNoiseFloorEnable(bool on) {
-        m_noiseFloorEnable = on;
-        resetNoiseFloorBaseline();
-        // Five fresh frames after enable so we lock onto the current
-        // floor without smoothing from a stale value.
-        m_noiseFloorFreshFrameCount = on ? 5 : 0;
-    }
+    // Both setters persist to AppSettings (per-pan keys DisplayNoiseFloor*)
+    // so the state and value survive launch.
+    void setNoiseFloorPosition(int pos);
+    void setNoiseFloorEnable(bool on);
 
     // Two-pass trimmed-mean noise floor from live FFT bins (dBm), EMA-smoothed.
     // Pass 1 computes the overall mean; pass 2 averages only bins ≤ mean so

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -791,11 +791,11 @@ void VfoWidget::buildTabContent()
         m_sqlSlider->setValue(20);
         m_sqlSlider->setStyleSheet(kSliderStyle);
         sqlRow->addWidget(m_sqlSlider, 1);
-        auto* sqlVal = new QLabel("20");
-        sqlVal->setStyleSheet(kLabelStyle);
-        sqlVal->setFixedWidth(20);
-        sqlVal->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        sqlRow->addWidget(sqlVal);
+        m_sqlValueLbl = new QLabel("20");
+        m_sqlValueLbl->setStyleSheet(kLabelStyle);
+        m_sqlValueLbl->setFixedWidth(20);
+        m_sqlValueLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        sqlRow->addWidget(m_sqlValueLbl);
         vb->addLayout(sqlRow);
 
         // AGC-T row: mode combo + threshold slider
@@ -962,14 +962,31 @@ void VfoWidget::buildTabContent()
                                      : QString::fromUtf8("\xF0\x9F\x94\x8A"));
             if (!m_updatingFromModel) emit audioMuteToggled(on);  // (#1560)
         });
-        connect(m_sqlBtn, &QPushButton::toggled, this, [this](bool on) {
-            if (!m_updatingFromModel && m_slice)
-                m_slice->setSquelch(on, m_sqlSlider->value());
+        // SQL button: when wired to an RxApplet (the normal case in
+        // MainWindow), delegate the 3-way mode cycle to RxApplet so both
+        // UIs share Off / Manual / Auto state.  Standalone fallback
+        // (no RxApplet — e.g. tests) keeps the original 2-state toggle.
+        // We turn off Qt's built-in checkable behavior in setRxApplet
+        // so the click handler can drive the cycle explicitly.
+        connect(m_sqlBtn, &QPushButton::clicked, this, [this]() {
+            if (m_rxApplet) {
+                m_rxApplet->cycleSqlModeExternal();
+            } else if (!m_updatingFromModel && m_slice) {
+                m_slice->setSquelch(m_sqlBtn->isChecked(),
+                                    m_sqlSlider->value());
+            }
         });
-        connect(m_sqlSlider, &QSlider::valueChanged, this, [this, sqlVal](int v) {
-            sqlVal->setText(QString::number(v));
-            if (!m_updatingFromModel && m_slice)
+        connect(m_sqlSlider, &QSlider::valueChanged, this, [this](int v) {
+            if (m_sqlValueLbl) m_sqlValueLbl->setText(QString::number(v));
+            if (m_updatingFromModel) return;
+            if (m_rxApplet) {
+                // Routes through RxApplet's Manual/Auto branching so the
+                // manual cache, AppSettings persistence, and spectrum-side
+                // margin broadcast all happen exactly once and in one place.
+                m_rxApplet->setSqlSliderValueExternal(v);
+            } else if (m_slice) {
                 m_slice->setSquelch(m_sqlBtn->isChecked(), v);
+            }
         });
         connect(m_agcCmb, &QComboBox::currentTextChanged, this, [this](const QString& text) {
             if (!m_updatingFromModel && m_slice) {
@@ -2705,12 +2722,23 @@ void VfoWidget::setSlice(SliceModel* slice)
         m_apfValueLbl->setText(QString::number(v));
         m_updatingFromModel = false;
     });
-    // Squelch
+    // Squelch.  When mirrored against an RxApplet, the slider represents
+    // the operator-chosen dB margin in Auto mode (NOT the algorithm-
+    // suggested level), so skip the value update when m_sqlMode is Auto.
+    // The 3-way button visuals are driven separately via syncSqlVisuals
+    // on sqlModeChanged — we don't need to touch the button here.
     connect(m_slice, &SliceModel::squelchChanged, this, [this](bool on, int level) {
         m_updatingFromModel = true;
-        if (m_sqlBtn->isEnabled())
-            m_sqlBtn->setChecked(on);
-        m_sqlSlider->setValue(level);
+        if (m_rxApplet) {
+            const bool inAuto =
+                (m_rxApplet->sqlMode() == RxApplet::SqlMode::Auto);
+            if (!inAuto)
+                m_sqlSlider->setValue(level);
+        } else {
+            if (m_sqlBtn->isEnabled())
+                m_sqlBtn->setChecked(on);
+            m_sqlSlider->setValue(level);
+        }
         m_updatingFromModel = false;
     });
     // AGC
@@ -3707,6 +3735,93 @@ void VfoWidget::setAntennaList(const QStringList& ants)
 void VfoWidget::setTransmitModel(TransmitModel* txModel)
 {
     m_txModel = txModel;
+}
+
+void VfoWidget::setRxApplet(RxApplet* rx)
+{
+    if (m_rxApplet == rx) return;
+    m_rxApplet = rx;
+    if (!rx) return;
+
+    // Take the SQL button out of Qt's built-in checkable behavior — the
+    // 3-way cycle is driven by clicked()'s explicit call to RxApplet.
+    if (m_sqlBtn) {
+        m_sqlBtn->setCheckable(false);
+        m_sqlBtn->setChecked(false);
+    }
+
+    // Refresh visuals whenever the RxApplet's mode changes, and once now
+    // so the freshly-wired widget shows the current shared state.
+    connect(rx, &RxApplet::sqlModeChanged, this, [this](int) {
+        syncSqlVisuals();
+    });
+    // Auto-margin updates come from RxApplet (or any sibling VfoWidget
+    // mirroring it) — reflect them in the slider when we're in Auto mode.
+    connect(rx, &RxApplet::autoSqlMarginDbChanged, this, [this](int dB) {
+        if (!m_rxApplet || !m_sqlSlider) return;
+        if (m_rxApplet->sqlMode() != RxApplet::SqlMode::Auto) return;
+        QSignalBlocker b(m_sqlSlider);
+        m_sqlSlider->setValue(dB);
+        if (m_sqlValueLbl) m_sqlValueLbl->setText(QString::number(dB));
+    });
+    syncSqlVisuals();
+}
+
+void VfoWidget::syncSqlVisuals()
+{
+    if (!m_rxApplet || !m_sqlBtn || !m_sqlSlider) return;
+    const auto mode = m_rxApplet->sqlMode();
+    // Match RxApplet's three button styles + label so the two surfaces
+    // read identically.
+    switch (mode) {
+    case RxApplet::SqlMode::Off:
+        m_sqlBtn->setText("SQL");
+        m_sqlBtn->setStyleSheet(QString(kDspToggle) + kDisabledBtn);
+        break;
+    case RxApplet::SqlMode::Manual:
+        m_sqlBtn->setText("SQL");
+        m_sqlBtn->setStyleSheet(
+            "QPushButton { background: #006040; color: #00ff88; "
+            "border: 1px solid #00a060; border-radius: 3px; "
+            "font-size: 10px; font-weight: bold; padding: 1px 2px; }"
+            "QPushButton:hover { background: #007050; }"
+            + kDisabledBtn);
+        break;
+    case RxApplet::SqlMode::Auto:
+        m_sqlBtn->setText("AUTO");
+        m_sqlBtn->setStyleSheet(
+            "QPushButton { background: #604000; color: #ffb800; "
+            "border: 1px solid #906000; border-radius: 3px; "
+            "font-size: 10px; font-weight: bold; padding: 1px 2px; }"
+            "QPushButton:hover { background: #705000; }"
+            + kDisabledBtn);
+        break;
+    }
+    // Slider swaps role between Manual (0–100 squelch_level) and Auto
+    // (5–20 dB margin).  Block signals during the swap so the resize
+    // doesn't fire a phantom valueChanged.
+    QSignalBlocker b(m_sqlSlider);
+    switch (mode) {
+    case RxApplet::SqlMode::Manual: {
+        m_sqlSlider->setRange(0, 100);
+        m_sqlSlider->setValue(m_rxApplet->sqlManualLevel());
+        m_sqlSlider->setEnabled(true);
+        if (m_sqlValueLbl)
+            m_sqlValueLbl->setText(QString::number(m_sqlSlider->value()));
+        break;
+    }
+    case RxApplet::SqlMode::Auto: {
+        m_sqlSlider->setRange(5, 20);
+        m_sqlSlider->setValue(m_rxApplet->autoSqlMarginDb());
+        m_sqlSlider->setEnabled(true);
+        if (m_sqlValueLbl)
+            m_sqlValueLbl->setText(QString::number(m_sqlSlider->value()));
+        break;
+    }
+    case RxApplet::SqlMode::Off:
+        m_sqlSlider->setEnabled(false);
+        break;
+    }
 }
 
 void VfoWidget::setRadioModel(RadioModel* radioModel)

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -26,6 +26,7 @@ class SliceModel;
 class TransmitModel;
 class RadioModel;
 class PhaseKnob;
+class RxApplet;
 
 // Floating VFO info panel attached to the VFO marker on the spectrum display.
 // Shows slice info (antennas, frequency, signal level, filter width, TX/SPLIT)
@@ -42,6 +43,11 @@ public:
     void setAntennaList(const QStringList& ants);
     void setTransmitModel(TransmitModel* txModel);
     void setRadioModel(RadioModel* radioModel);
+    // Wire the SQL button + slider as a mirror of the RxApplet's 3-way
+    // SQL UI (Off / Manual / Auto, manual-level cache, Auto margin).
+    // Without this call, the SQL row still functions but in the old
+    // 2-state on/off mode against the slice's squelchLevel only.
+    void setRxApplet(RxApplet* rx);
     void setSignalLevel(float dbm);
 
     // Split mode: call whenever TX assignment or active slice changes.
@@ -209,7 +215,13 @@ private:
     QWidget*     m_escMeterBar{nullptr};
     float        m_escLevelDbm{-130.0f};
     QPushButton* m_sqlBtn{nullptr};
+    QPointer<RxApplet> m_rxApplet;       // source-of-truth for 3-way SQL state
+    QLabel*      m_sqlValueLbl{nullptr}; // captured during buildUI() for syncSqlVisuals
     bool         m_savedSquelchOn{false};
+    // Apply the current SqlMode from m_rxApplet to the VfoWidget's SQL
+    // button label/style and slider range/value.  Called on rxApplet's
+    // sqlModeChanged signal and once after setRxApplet().
+    void syncSqlVisuals();
 public:
     void setDiversityAllowed(bool allowed);
     void setSmartSdrPlus(bool has);


### PR DESCRIPTION
A focused UX pass on the spectrum overlay's Display panel plus a
related refactor of the auto-squelch margin onto the RX Applet's
existing SQL slider.

Display panel — rename, reorder, persist
----------------------------------------
* Row labels renamed for clarity on what each one drives:
    AVG         → FFT AVG
    FPS         → FFT FPS
    Line Width  → FFT Line
    Fill        → FFT Fill
    Gain        → WtrFall Gain
    Rate        → WtrFall Rate
    Black       → Black Level
    Floor       → FFT Floor

* Row order rearranged to group FFT-side controls above waterfall-side:
    Heat Map / Grid / Wt Avg   ← moved to top
    FFT AVG / FPS / Line / Fill / Floor
    NB Blank
    Black Level
    WtrFall Gain / WtrFall Rate
    BG Opacity / Background
    Grid (kHz) / Scheme / Reset to Defaults

* FFT Floor button label is now "Auto" (matches Black Level's pattern);
  checked state still indicates the reference line is active.

* FFT Floor state + position now persist to AppSettings
  (DisplayNoiseFloorEnable / DisplayNoiseFloorPosition, per-pan via
  settingsKey).  Reset-to-Defaults writes the defaults
  alongside every other Display key.

* The Heat Map / Grid / Wt Avg row had a stray 1 px frame around it —
  the Display panel's QWidget stylesheet was cascading.  Override on
  the row container only.  Buttons themselves keep the standard
  btnStyle frame to match FFT Floor's Auto button visually.

Auto-squelch margin moved to RX Applet
--------------------------------------
* Removed the "Auto SQL ∆" slider from the Display overlay (it was
  the standalone control for AutoSqlMarginDb).

* RX Applet's SQL slider is now dual-role:
    Off    → disabled
    Manual → 0–100 squelch_level (existing)
    Auto   → 5–20 dB margin above the measured noise floor

  Mode transitions swap the slider's range/value and tooltip with
  signals blocked so the resize doesn't fire a phantom valueChanged.

* New AppSettings key LastManualSquelchLevel persists the manual
  level across launches and across Manual↔Auto↔Off cycles within a
  session.  Auto-mode algorithm pushes overwrite the slice's
  squelchLevel; the cache + persistence layer protects the user's
  manual choice from being clobbered.

VFO widget ↔ RX Applet bidirectional SQL sync
---------------------------------------------
* RxApplet exposes SqlMode publicly + emits sqlModeChanged on every
  transition.  VfoWidget mirrors mode, slider range, slider value,
  and button label/style from RxApplet (the source of truth).

* VfoWidget's SQL button cycles through Off / Manual / Auto by
  delegating to RxApplet::cycleSqlModeExternal().  Slider drags
  pipe through RxApplet::setSqlSliderValueExternal() so persistence,
  manual cache, and the autoSqlMarginDbChanged broadcast happen
  exactly once in one place.

* Slice's squelchChanged → in Auto mode skip the slider value
  update on both surfaces (otherwise the algorithm's per-tick level
  pushes would overwrite the operator-chosen margin).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
