### PR TITLE
feat(spots): user-configurable Smart Spot Filter match window (#2609)

### DIFF
--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -33,6 +33,26 @@
 
 namespace AetherSDR {
 
+// GuardedSlider variant that resets to a stored default on left
+// double-click.  Used for the Filter Match Window slider (#2609) so
+// the operator can snap back to the 1 kHz default without dragging.
+class ResetOnDoubleClickSlider : public GuardedSlider {
+public:
+    using GuardedSlider::GuardedSlider;
+    void setResetValue(int v) { m_resetValue = v; }
+protected:
+    void mouseDoubleClickEvent(QMouseEvent* ev) override {
+        if (ev->button() == Qt::LeftButton) {
+            setValue(m_resetValue);
+            ev->accept();
+            return;
+        }
+        GuardedSlider::mouseDoubleClickEvent(ev);
+    }
+private:
+    int m_resetValue{0};
+};
+
 // Shared DSP-style toggle for every checkable button in SpotHub
 // (matches kDspToggle in VfoWidget.cpp so the chrome reads the same as
 // the NB / NR / ANF buttons in the VFO panel).  Dark inset by default,
@@ -2522,6 +2542,40 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
             emit smartSpotDelayChanged(v);
         });
         shGrid->addLayout(ssDelRow, shr++, 1);
+
+        // Smart Spot Filter — Match window (100–5000 Hz). (#2609)
+        // Uses ResetOnDoubleClickSlider so a left double-click snaps the
+        // value back to the 1 kHz default without dragging.
+        const int ssMatch = AppSettings::instance()
+            .value("SmartSpotFilterMatchHz", 1000).toInt();
+        shGrid->addWidget(new QLabel("Filter Match Window:"), shr, 0);
+        auto* ssMatchRow = new QHBoxLayout;
+        auto* ssMatchSlider = new ResetOnDoubleClickSlider(Qt::Horizontal);
+        ssMatchSlider->setRange(100, 5000);
+        ssMatchSlider->setSingleStep(50);
+        ssMatchSlider->setPageStep(500);
+        ssMatchSlider->setValue(std::clamp(ssMatch, 100, 5000));
+        ssMatchSlider->setResetValue(1000);
+        ssMatchSlider->setToolTip(
+            "± frequency window around each S-History voice detection\n"
+            "that counts as a match with a DX-cluster spot.\n"
+            "Tight (100–500 Hz): fewer false confirms on crowded phone\n"
+            "  bands where spots are stacked close.\n"
+            "Default (1000 Hz): SSB voice / typical cluster spot precision.\n"
+            "Loose (2000–5000 Hz): tolerates cluster ops who spot the QRG\n"
+            "  they tuned through rather than the precise carrier.\n"
+            "Double-click to reset to 1000 Hz.");
+        auto* ssMatchValue = new QLabel(QString("± %1 Hz").arg(ssMatchSlider->value()));
+        ssMatchValue->setFixedWidth(60);
+        ssMatchValue->setAlignment(Qt::AlignRight);
+        ssMatchRow->addWidget(ssMatchSlider);
+        ssMatchRow->addWidget(ssMatchValue);
+        connect(ssMatchSlider, &QSlider::valueChanged, this, [this, ssMatchValue, save](int v) {
+            ssMatchValue->setText(QString("± %1 Hz").arg(v));
+            save("SmartSpotFilterMatchHz", QString::number(v));
+            emit smartSpotMatchHzChanged(v);
+        });
+        shGrid->addLayout(ssMatchRow, shr++, 1);
 
         rightCol->addLayout(shGrid);
         rightCol->addStretch();

--- a/src/gui/DxClusterDialog.h
+++ b/src/gui/DxClusterDialog.h
@@ -123,6 +123,10 @@ signals:
     void sHistoryQrmToggled(bool on);
     void smartSpotOpacityChanged(int pct);
     void smartSpotDelayChanged(int seconds);
+    // Match window between a DX-cluster spot and an S-History voice
+    // detection (Hz, 100–5000).  Wired through MainWindow to every pan's
+    // SpectrumWidget::setSmartSpotFilterMatchHz(). (#2609)
+    void smartSpotMatchHzChanged(int hz);
 
 private:
     void buildClusterTab(QTabWidget* tabs);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6392,6 +6392,11 @@ void MainWindow::buildMenuBar()
             for (auto* a : m_panStack->allApplets())
                 a->spectrumWidget()->setSmartSpotFilterDelayS(seconds);
         });
+        connect(dlg, &DxClusterDialog::smartSpotMatchHzChanged, this,
+                [this](int hz) {
+            for (auto* a : m_panStack->allApplets())
+                a->spectrumWidget()->setSmartSpotFilterMatchHz(hz);
+        });
         connect(dlg, &DxClusterDialog::connectRequested,
                 this, [this](const QString& host, quint16 port, const QString& call) {
             QMetaObject::invokeMethod(m_dxCluster, [=] { m_dxCluster->connectToCluster(host, port, call); });
@@ -10101,6 +10106,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         AppSettings::instance().value("SmartSpotFilterOpacity", 80).toInt());
     sw->setSmartSpotFilterDelayS(
         AppSettings::instance().value("SmartSpotFilterDelayS", 30).toInt());
+    sw->setSmartSpotFilterMatchHz(
+        AppSettings::instance().value("SmartSpotFilterMatchHz", 1000).toInt());
 
     // Apply current prop forecast state to this (possibly new) panadapter
     if (m_propForecast) {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -5746,13 +5746,15 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
                                    mu.contains("JS8")  || mu.contains("PSK") ||
                                    mu.contains("RTTY") || mu.contains("WSPR");
             if (!isDigital) {
-                constexpr double kMatchMhz = 0.001; // ±1 kHz of detected signal start
+                // ±N Hz of detected signal start — user-configurable via the
+                // "Filter Match Window" slider in SpotHub Display. (#2609)
+                const double matchMhz = m_smartSpotFilterMatchHz / 1.0e6;
                 constexpr qint64 kConfirmGraceMs = 120000; // 2 min grace after last confirmation
                 const QString spotKey = spot.callsign + QChar('@') +
                                         QString::number(qRound(spot.freqMhz * 1000.0));
                 bool matched = false;
                 for (double shFreq : sHistVoiceFreqs) {
-                    if (std::abs(spot.freqMhz - shFreq) <= kMatchMhz) {
+                    if (std::abs(spot.freqMhz - shFreq) <= matchMhz) {
                         matched = true;
                         break;
                     }

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -370,6 +370,13 @@ public:
     bool smartSpotFilter() const     { return m_smartSpotFilter; }
     void setSmartSpotFilterOpacity(int pct) { m_smartSpotFilterOpacity = std::clamp(pct, 0, 100); update(); }
     void setSmartSpotFilterDelayS(int s)    { m_smartSpotFilterDelayS  = std::max(0, s); }
+    // Match window between a DX-cluster spot and an S-History voice
+    // detection (Hz, clamped to 100–5000).  ±this many Hz around each
+    // S-History center counts as a match.  Tight = fewer false confirms
+    // on crowded phone bands; loose = better tolerance for cluster
+    // operators who spot the QRG they tuned through rather than the
+    // exact carrier.  (#2609)
+    void setSmartSpotFilterMatchHz(int hz)  { m_smartSpotFilterMatchHz = std::clamp(hz, 100, 5000); }
     // When on, click-to-tune on a SHistory/QRM marker rounds the target to
     // the nearest multiple of stepSize().  Compensates for the inherent
     // detector edge-bin imprecision (typically 100–300 Hz off carrier).
@@ -869,6 +876,7 @@ private:
     qint64 m_smartSpotFilterEnabledMs{0};
     int    m_smartSpotFilterOpacity{80};
     int    m_smartSpotFilterDelayS{30};
+    int    m_smartSpotFilterMatchHz{1000};  // ±Hz to count as a spot↔S-History match (#2609)
     QHash<QString, qint64> m_spotConfirmedMs; // key = callsign@freqKHz → last confirmed ms
     QVector<SpotMarker> m_sHistoryMarkers;
     int  m_spotFontSize{16};


### PR DESCRIPTION
The Smart Spot Filter's match window between a DX-cluster spot and an
S-History voice detection was hardcoded to ±1 kHz.  That default works
well for SSB voice, but band conditions and operator tuning habits vary
— tight (±200 Hz) reads better on crowded 20 m phone, loose (±2–3 kHz)
tolerates cluster ops who spot the QRG they tuned through rather than
the precise carrier.

* New "Filter Match Window" slider in SpotHub → Display → Signal
  History (100–5000 Hz, default 1000, persisted as
  SmartSpotFilterMatchHz).  Left-double-click resets to 1000 Hz —
  same affordance the operator gets on the AGC/Black-Level pattern.

* `constexpr double kMatchMhz = 0.001` in `drawSpotMarkers()` is now
  derived from the new `m_smartSpotFilterMatchHz` member, set via
  `SpectrumWidget::setSmartSpotFilterMatchHz(int hz)`.  Default
  preserves the prior behavior — zero-risk on upgrade.

* `DxClusterDialog::smartSpotMatchHzChanged(int hz)` signal wired in
  MainWindow to broadcast to every pan's spectrum widget, alongside
  the existing Opacity and Delay broadcasts.  AppSettings load in
  `wirePanadapter()` so freshly-attached pans pick up the saved value.

* Small `ResetOnDoubleClickSlider` subclass in DxClusterDialog.cpp
  scopes the double-click-reset to this one slider (Opacity and
  Delay sliders unchanged).

Closes #2609.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
