### PR TITLE
fix(dx-cluster): strip non-printable control chars from cluster console lines

### DIFF
--- a/src/core/DxClusterClient.cpp
+++ b/src/core/DxClusterClient.cpp
@@ -208,6 +208,29 @@ void DxClusterClient::onReadyRead()
         QString line = QString::fromLatin1(m_readBuffer.left(idx)).trimmed();
         m_readBuffer.remove(0, idx + 1);
 
+        // Strip non-printable control characters that some DX cluster
+        // software appends to spot lines (BEL 0x07 as a TTY alert is the
+        // most common, but C1 controls in 0x80–0x9F have also been seen
+        // in the wild).  trimmed() above only handles ASCII whitespace,
+        // so these otherwise render as missing-glyph boxes in the
+        // console and contaminate spot.comment captured by the regex in
+        // handleLine().  Keep TAB (0x09); drop everything else in
+        // {0x00–0x1F, 0x7F–0x9F}.
+        auto isControl = [](QChar c) {
+            const ushort u = c.unicode();
+            if (u == '\t') return false;
+            return u < 0x20 || (u >= 0x7F && u <= 0x9F);
+        };
+        if (std::any_of(line.cbegin(), line.cend(), isControl)) {
+            QString cleaned;
+            cleaned.reserve(line.size());
+            for (QChar c : line) {
+                if (!isControl(c))
+                    cleaned.append(c);
+            }
+            line = cleaned;
+        }
+
         if (line.isEmpty()) continue;
 
         // Write to log file


### PR DESCRIPTION
DXSpider and AR-Cluster traditionally append a BEL (0x07) plus CRLF to
each spot line so a TTY beeps on alert.  `QString::trimmed()` strips
the CRLF but leaves the BEL in place — Qt's text renderer shows it as
a missing-glyph box (`▢`) trailing every spot in the Cluster Console.
Some clusters also send characters in the C1 control range (0x80–0x9F
in Latin-1 → Unicode U+0080–U+009F) which have no glyphs and render
the same way.  Beyond the visual noise, the leftover bytes also
contaminate `spot.comment` captured by the regex in handleLine(),
poisoning downstream display.

Strip all non-printable control characters at the source in
`DxClusterClient::onReadyRead()` so the console, log file, and
spot-parser regex all see clean text:

  * 0x00–0x1F (except TAB 0x09)
  * 0x7F (DEL)
  * 0x80–0x9F (C1 controls)

TAB is preserved because some cluster banners use it for column
alignment.  Filter runs once per line and only allocates the cleaned
QString when a control char is actually present (std::any_of fast
path), so the no-op cost on typical lines is near-zero.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
