### PR TITLE
[xvtr] Fix XVTR waterfall offset matching for unvalidated profiles (1.2GHz)

### DIFF
--- a/src/models/XvtrPolicy.cpp
+++ b/src/models/XvtrPolicy.cpp
@@ -93,7 +93,7 @@ WaterfallTileMatch matchWaterfallTileTransverterOffset(double lowMhz, double hig
     match.observedOffsetMhz = panCenterMhz - tileCenter(lowMhz, highMhz);
     match.toleranceMhz = std::max(bw, 0.25);
     for (const auto& xvtr : xvtrs) {
-        if (!xvtr.isValid || xvtr.rfFreqMhz <= 0.0 || xvtr.ifFreqMhz <= 0.0)
+        if (xvtr.rfFreqMhz <= 0.0 || xvtr.ifFreqMhz <= 0.0)
             continue;
 
         const double expectedOffset = xvtr.rfFreqMhz - xvtr.ifFreqMhz;

--- a/tests/xvtr_policy_test.cpp
+++ b/tests/xvtr_policy_test.cpp
@@ -187,14 +187,23 @@ void testXvtrWaterfallMapsIfToRfBands()
 
 void testXvtrWaterfallGuardrails()
 {
-    const QVector<XvtrPolicy::Transverter> invalidXvtr = {
+    const QVector<XvtrPolicy::Transverter> unvalidatedXvtr = {
         xvtr(12, 3, "2m", 144.0, 28.0, false),
     };
 
-    const auto invalid = XvtrPolicy::mapWaterfallTileRange(
-        28.125, 28.625, 144.375, invalidXvtr, false);
-    expectRange("invalid XVTR does not trigger IF/RF waterfall shift",
-                invalid, 28.125, 28.625, false);
+    const auto unvalidated = XvtrPolicy::mapWaterfallTileRange(
+        28.125, 28.625, 144.375, unvalidatedXvtr, false);
+    expectRange("unvalidated XVTR with RF/IF offset maps waterfall range",
+                unvalidated, 144.125, 144.625, true);
+
+    const QVector<XvtrPolicy::Transverter> missingIfXvtr = {
+        xvtr(12, 3, "2m", 144.0, 0.0, false),
+    };
+
+    const auto missingIf = XvtrPolicy::mapWaterfallTileRange(
+        28.125, 28.625, 144.375, missingIfXvtr, false);
+    expectRange("XVTR without IF frequency does not shift waterfall range",
+                missingIf, 28.125, 28.625, false);
 
     const auto antennaFallback = XvtrPolicy::mapWaterfallTileRange(
         28.125, 28.625, 144.375, {}, true);


### PR DESCRIPTION
## Summary

Fixes #1928 by relaxing the XVTR validity gate only for passive waterfall IF/RF offset matching.

## Root Cause

When a transverter panadapter is active, the pan center is reported in RF space while native VITA waterfall tiles can arrive in IF space. Aether maps those tile ranges back into RF space when the observed offset matches a configured XVTR RF/IF offset.

That match was also requiring `xvtr.isValid == true`. Some radios or status flows may omit `is_valid`, and Aether defaults the field to false. In that case the renderer skipped a legitimate RF/IF offset match, left the tile in IF coordinates, and the waterfall row could render with no visible signal pixels.

## Changes

- Removed the `isValid` requirement from `matchWaterfallTileTransverterOffset` while keeping the RF/IF sanity checks and offset tolerance match.
- Left the `isValid` gate in `resolveBandStackKey`, where it still protects command formation for Flex band-stack keys.
- Added regression coverage for an unvalidated XVTR entry with valid RF/IF frequencies still mapping the waterfall range, plus a guardrail for missing IF frequency.

## Validation

- `./build-ninja/xvtr_policy_test`
- `cmake --build build-ninja --target AetherSDR --parallel 22`

Built app: `/Users/patj/Documents/AetherSDR/.worktrees/issue-1928-transverter-waterfall/build-ninja/AetherSDR.app`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat