### PR TITLE
[spots] Fix spot auto-mode slice routing

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10678,7 +10678,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // no longer changes mode on click, so auto-mode is the only path.
         if (AppSettings::instance().value("SpotAutoSwitchMode", "True").toString() != "True")
             return;
-        auto* s = activeSlice();
+        auto* s = preferredMemorySlice(applet->panId());
         if (!s) return;
 
         // FreeDV spots imply RADE — activate the RADE engine on this slice


### PR DESCRIPTION
## Summary

Fixes #2359 by routing spot-click auto-mode changes to the slice on the clicked panadapter instead of whichever slice is globally active.

## Root Cause

Regular spot clicks already send `spot trigger <id> pan=<panId>` to the radio, so the radio-side tune action is scoped to the panadapter where the spot was clicked. The client-side auto-mode follow-up still looked up `activeSlice()`, which can remain on another pan after idle time. In a two-slice setup, clicking a CW spot on slice B's pan could therefore change slice A from SSB to CW while slice A's frequency stayed put.

## Changes

- Updated the spot-trigger handler in `MainWindow::wirePanadapter` to resolve the auto-mode target through `preferredMemorySlice(applet->panId())`.
- This matches the adjacent memory-spot path and keeps the common same-pan case unchanged.

## Validation

- `cmake --build build --parallel 22`
- `ctest --test-dir build --output-on-failure --parallel 22` - 8/8 tests passed

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
