### PR TITLE
Fix FFT floor lock edge cases

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10052,7 +10052,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         bool active{false};
         float minDbm{0.0f};
         float maxDbm{0.0f};
+        qint64 requestedMs{0};
     };
+    constexpr qint64 kDbmRangePendingTimeoutMs = 2000;
     auto pendingDbm = std::make_shared<PendingDbmRange>();
     auto dbmMatches = [](float leftMin, float leftMax, float rightMin, float rightMax) {
         return std::abs(leftMin - rightMin) < 0.01f
@@ -10139,10 +10141,19 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                 sw, [sw, pendingDbm, dbmMatches, setStreamDbmRange](float minDbm, float maxDbm) {
             if (pendingDbm->active) {
                 if (!dbmMatches(minDbm, maxDbm, pendingDbm->minDbm, pendingDbm->maxDbm)) {
-                    setStreamDbmRange(pendingDbm->minDbm, pendingDbm->maxDbm, true);
-                    return;
+                    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+                    if (pendingDbm->requestedMs > 0
+                        && nowMs - pendingDbm->requestedMs > kDbmRangePendingTimeoutMs) {
+                        pendingDbm->active = false;
+                        pendingDbm->requestedMs = 0;
+                    } else {
+                        setStreamDbmRange(pendingDbm->minDbm, pendingDbm->maxDbm, true);
+                        return;
+                    }
+                } else {
+                    pendingDbm->active = false;
+                    pendingDbm->requestedMs = 0;
                 }
-                pendingDbm->active = false;
             }
             if (sw->isDraggingDbmScale()) {
                 return;
@@ -10265,6 +10276,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         pendingDbm->active = true;
         pendingDbm->minDbm = minDbm;
         pendingDbm->maxDbm = maxDbm;
+        pendingDbm->requestedMs = QDateTime::currentMSecsSinceEpoch();
         setStreamDbmRange(minDbm, maxDbm, true);
         sendDbmRangeCommand(minDbm, maxDbm);
     });
@@ -10273,6 +10285,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         pendingDbm->active = true;
         pendingDbm->minDbm = minDbm;
         pendingDbm->maxDbm = maxDbm;
+        pendingDbm->requestedMs = QDateTime::currentMSecsSinceEpoch();
         setStreamDbmRange(minDbm, maxDbm, true);
         sendDbmRangeCommand(minDbm, maxDbm);
     });
@@ -10392,6 +10405,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setNoiseFloorPosition);
     connect(menu, &SpectrumOverlayMenu::noiseFloorEnableChanged,
             sw, &SpectrumWidget::setNoiseFloorEnable);
+    connect(sw, &SpectrumWidget::noiseFloorPositionResolved,
+            menu, &SpectrumOverlayMenu::syncNoiseFloorPosition);
 
     // ── Auto-squelch wiring ───────────────────────────────────────────────
     // RxApplet signals → per-pan spectrum widget
@@ -11233,6 +11248,13 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     connect(s, &SliceModel::audioPanChanged, this, [this, sliceId](int v) {
         if (sliceId == m_activeSliceId)
             m_audio->setRxPan(v);
+    });
+    connect(s, &SliceModel::rxAntennaChanged, this, [this, sliceId](const QString&) {
+        if (auto* sl = m_radioModel.slice(sliceId)) {
+            if (auto* sw = spectrumForSlice(sl)) {
+                sw->reacquireNoiseFloorLock();
+            }
+        }
     });
 
     // Wire slice data into widget

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1163,6 +1163,18 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
     }
 }
 
+void SpectrumOverlayMenu::syncNoiseFloorPosition(int pos)
+{
+    if (!m_floorSlider) return;
+
+    const int clamped = std::clamp(pos, 1, 99);
+    QSignalBlocker block(m_floorSlider);
+    m_floorSlider->setValue(clamped);
+    if (m_floorLabel) {
+        m_floorLabel->setText(QString::number(clamped));
+    }
+}
+
 void SpectrumOverlayMenu::syncExtraDisplaySettings(bool blankerOn, float blankerThresh,
                                                     int bgOpacity,
                                                     int freqGridSpacingKhz)

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -63,6 +63,7 @@ public:
     void setWnbState(bool on, int level);
     void setRfGain(int gain);
     void setRfGainRange(int low, int high, int step);
+    void syncNoiseFloorPosition(int pos);
 
     // Populate XVTR band sub-panel
     struct XvtrBand { QString name; double rfFreqMhz; };

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -57,6 +57,7 @@ static const QColor kAetherBrandBlue(0x00, 0xb4, 0xd8);
 static const QColor kAetherBrandGreen(0x20, 0xc0, 0x60);
 static const QColor kConnectionTextColor(0xd8, 0xe6, 0xf0);
 static constexpr float kMinDisplayDbm = -180.0f;
+static constexpr qint64 kDbmRangeEchoTimeoutMs = 2000;
 
 static bool spotMarkersVisuallyEqual(const QVector<SpectrumWidget::SpotMarker>& lhs,
                                      const QVector<SpectrumWidget::SpotMarker>& rhs)
@@ -548,21 +549,55 @@ void SpectrumWidget::setFftAverage(int frames) {
     s.save();
 }
 void SpectrumWidget::setNoiseFloorPosition(int pos) {
-    m_noiseFloorPosition = pos;
+    m_noiseFloorPosition = std::clamp(pos, 1, 99);
+    m_pendingDbmRangeEcho = false;
+    m_pendingDbmRangeEchoStartMs = 0;
     refreshNoiseFloorTarget();
+    if (m_noiseFloorEnable) {
+        if (!m_noiseFloorBaselineValid && (!m_smoothed.isEmpty() || !m_bins.isEmpty())) {
+            const QVector<float>& baselineBins = !m_smoothed.isEmpty() ? m_smoothed : m_bins;
+            const float baselineDbm = estimateNoiseFloorDbm(baselineBins);
+            if (baselineDbm > -500.0f) {
+                m_noiseFloorBaselineDbm = baselineDbm;
+                m_noiseFloorBaselineValid = true;
+                m_noiseFloorLastSampleMs = QDateTime::currentMSecsSinceEpoch();
+                m_noiseFloorCandidateValid = false;
+                m_noiseFloorCandidateFrames = 0;
+            }
+        }
+        applyNoiseFloorAutoAdjust(QDateTime::currentMSecsSinceEpoch());
+    }
     auto& s = AppSettings::instance();
-    s.setValue(settingsKey("DisplayNoiseFloorPosition"), QString::number(pos));
+    s.setValue(settingsKey("DisplayNoiseFloorPosition"), QString::number(m_noiseFloorPosition));
     s.save();
 }
 void SpectrumWidget::setNoiseFloorEnable(bool on) {
+    m_pendingDbmRangeEcho = false;
+    m_pendingDbmRangeEchoStartMs = 0;
+    if (on) {
+        captureNoiseFloorTargetFromCurrentScale(true);
+    }
     m_noiseFloorEnable = on;
     resetNoiseFloorBaseline();
     // Five fresh frames after enable so we lock onto the current
     // floor without smoothing from a stale value.
     m_noiseFloorFreshFrameCount = on ? 5 : 0;
+    if (on) {
+        refreshNoiseFloorTarget();
+    }
     auto& s = AppSettings::instance();
     s.setValue(settingsKey("DisplayNoiseFloorEnable"), on ? "True" : "False");
     s.save();
+}
+void SpectrumWidget::reacquireNoiseFloorLock() {
+    if (!m_noiseFloorEnable) return;
+    m_pendingDbmRangeEcho = false;
+    m_pendingDbmRangeEchoStartMs = 0;
+    resetNoiseFloorBaseline();
+    // Antenna changes can take several FFT frames to settle after the
+    // slice command, so keep cold-acquiring long enough to catch the new floor.
+    m_noiseFloorFreshFrameCount = 30;
+    m_measuredNoiseFloorDbm = -1000.0f;
 }
 void SpectrumWidget::setFftWeightedAvg(bool on) {
     m_fftWeightedAvg = on;
@@ -823,22 +858,64 @@ void SpectrumWidget::resetNoiseFloorBaseline()
     m_noiseFloorCandidateStartMs = 0;
     m_noiseFloorCandidateFrames = 0;
     m_noiseFloorFreshFrameCount = m_noiseFloorEnable ? 5 : 0;
+    m_pendingDbmRangeEcho = false;
+    m_pendingDbmRangeEchoStartMs = 0;
 }
 
-void SpectrumWidget::refreshNoiseFloorTarget()
+void SpectrumWidget::refreshNoiseFloorTarget(bool captureCurrentScale)
 {
-    // Target frac comes from the slider (0=top, 100=bottom).  We
-    // capture it here so subsequent baseline movement steers m_refLevel
-    // toward keeping the floor at that fraction.
+    if (captureCurrentScale) {
+        captureNoiseFloorTargetFromCurrentScale(true);
+    }
+
     if (m_noiseFloorEnable) {
         m_noiseFloorTargetFrac = std::clamp(m_noiseFloorPosition / 100.0f, 0.02f, 0.98f);
         m_noiseFloorTargetValid = true;
-        m_noiseFloorLastMotionMs = QDateTime::currentMSecsSinceEpoch();
+        if (m_noiseFloorLastMotionMs <= 0) {
+            m_noiseFloorLastMotionMs = QDateTime::currentMSecsSinceEpoch() - 100;
+        }
         m_noiseFloorLastCommandMs = 0;
         m_noiseFloorLastCommandRef = m_refLevel;
     } else {
         m_noiseFloorTargetValid = false;
     }
+}
+
+bool SpectrumWidget::captureNoiseFloorTargetFromCurrentScale(bool notify)
+{
+    if (m_dynamicRange <= 0.0f) {
+        return false;
+    }
+
+    float baselineDbm = -1000.0f;
+    if (!m_smoothed.isEmpty() || !m_bins.isEmpty()) {
+        const QVector<float>& baselineBins = !m_smoothed.isEmpty() ? m_smoothed : m_bins;
+        baselineDbm = estimateNoiseFloorDbm(baselineBins);
+    }
+    if (baselineDbm <= -500.0f && m_noiseFloorBaselineValid) {
+        baselineDbm = m_noiseFloorBaselineDbm;
+    }
+    if (baselineDbm <= -500.0f && m_measuredNoiseFloorDbm > -500.0f) {
+        baselineDbm = m_measuredNoiseFloorDbm;
+    }
+    if (baselineDbm <= -500.0f) {
+        return false;
+    }
+
+    const float targetFrac = std::clamp((m_refLevel - baselineDbm) / m_dynamicRange,
+                                        0.02f,
+                                        0.98f);
+    const int newPosition = std::clamp(
+        static_cast<int>(std::lround(targetFrac * 100.0f)),
+        1,
+        99);
+
+    m_noiseFloorTargetFrac = targetFrac;
+    m_noiseFloorPosition = newPosition;
+    if (notify) {
+        emit noiseFloorPositionResolved(newPosition);
+    }
+    return true;
 }
 
 void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool forceBaseline)
@@ -849,6 +926,12 @@ void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
     if (frameFloor <= -500.0f || m_dynamicRange <= 0.0f) return;
 
     const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    if (m_pendingDbmRangeEcho
+        && m_pendingDbmRangeEchoStartMs > 0
+        && nowMs - m_pendingDbmRangeEchoStartMs > kDbmRangeEchoTimeoutMs) {
+        m_pendingDbmRangeEcho = false;
+        m_pendingDbmRangeEchoStartMs = 0;
+    }
 
     if (!m_noiseFloorBaselineValid || m_noiseFloorLastSampleMs <= 0 || forceBaseline) {
         // Cold-acquire: force the baseline to this frame's reading.
@@ -1892,9 +1975,14 @@ void SpectrumWidget::setDbmRange(float minDbm, float maxDbm)
         const bool matchesPending = std::abs(minDbm - m_pendingMinDbm) < 0.01f
             && std::abs(maxDbm - m_pendingMaxDbm) < 0.01f;
         if (!matchesPending) {
-            return;
+            const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+            if (m_pendingDbmRangeEchoStartMs <= 0
+                || nowMs - m_pendingDbmRangeEchoStartMs <= kDbmRangeEchoTimeoutMs) {
+                return;
+            }
         }
         m_pendingDbmRangeEcho = false;
+        m_pendingDbmRangeEchoStartMs = 0;
     }
 
     const float clampedMinDbm = std::max(minDbm, kMinDisplayDbm);
@@ -2619,7 +2707,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
                     m_refLevel = bottom + m_dynamicRange;
                 }
                 markOverlayDirty();
-                refreshNoiseFloorTarget();
+                refreshNoiseFloorTarget(true);
                 emit dbmRangeChangeRequested(bottom, m_refLevel);
                 ev->accept();
                 return;
@@ -3295,6 +3383,7 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
     }
     if (m_draggingDbm) {
         m_pendingDbmRangeEcho = true;
+        m_pendingDbmRangeEchoStartMs = QDateTime::currentMSecsSinceEpoch();
         m_pendingMinDbm = m_refLevel - m_dynamicRange;
         m_pendingMaxDbm = m_refLevel;
         m_dbmReleasePreviewOffset = m_refLevel - m_dbmDragStartRef;
@@ -3302,7 +3391,7 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
         m_draggingDbm = false;
         setSpectrumCursor(Qt::CrossCursor);
         m_resetFftSmoothingOnNextFrame = true;
-        refreshNoiseFloorTarget();
+        refreshNoiseFloorTarget(true);
         emit dbmRangeDragFinished(m_pendingMinDbm, m_pendingMaxDbm);
         ev->accept();
         return;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -97,7 +97,7 @@ public:
     // Update the dBm range used for the waterfall colour map and spectrum Y axis.
     void setDbmRange(float minDbm, float maxDbm);
 
-    // Noise floor auto-adjust: position (0=top, 100=bottom), enable on/off.
+    // Noise floor auto-adjust: position (1=top, 99=bottom), enable on/off.
     // Both setters persist to AppSettings (per-pan keys DisplayNoiseFloor*)
     // so the state and value survive launch.
     void setNoiseFloorPosition(int pos);
@@ -622,7 +622,7 @@ private:
 
     // Noise floor auto-adjust
     bool  m_noiseFloorEnable{false};
-    int   m_noiseFloorPosition{75};  // 0=top, 100=bottom
+    int   m_noiseFloorPosition{75};  // 1=top, 99=bottom
     int   m_noiseFloorFrameCount{0};
     // Noise-floor auto-adjust state machine (per-frame baseline tracker
     // with asymmetric smoothing + transient rejection — keeps the floor

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -102,6 +102,7 @@ public:
     // so the state and value survive launch.
     void setNoiseFloorPosition(int pos);
     void setNoiseFloorEnable(bool on);
+    void reacquireNoiseFloorLock();
 
     // Two-pass trimmed-mean noise floor from live FFT bins (dBm), EMA-smoothed.
     // Pass 1 computes the overall mean; pass 2 averages only bins ≤ mean so
@@ -173,7 +174,13 @@ public:
     int  rfGainValue() const { return m_rfGainValue; }
     bool wideActive()  const { return m_wideActive; }
     void setWnbActive(bool on) { m_wnbActive = on; markOverlayDirty(); }
-    void setRfGain(int gain) { m_rfGainValue = gain; markOverlayDirty(); }
+    void setRfGain(int gain) {
+        if (m_rfGainValue != gain) {
+            m_rfGainValue = gain;
+            reacquireNoiseFloorLock();
+        }
+        markOverlayDirty();
+    }
     void setWideActive(bool on) {
         if (m_wideActive != on) {
             m_wideActive = on;
@@ -442,6 +449,7 @@ signals:
     // Emitted when the user adjusts the dBm scale (drag or arrows).
     void dbmRangeChangeRequested(float minDbm, float maxDbm);
     void dbmRangeDragFinished(float minDbm, float maxDbm);
+    void noiseFloorPositionResolved(int pos);
     // TNF signals
     void tnfCreateRequested(double freqMhz);
     void tnfMoveRequested(int id, double newFreqMhz);
@@ -560,9 +568,10 @@ private:
     // band switch, manual dBm drag) so the next frame re-acquires
     // rather than smooths from a stale value.
     void resetNoiseFloorBaseline();
-    // Re-capture the target frac (m_noiseFloorPosition) — called when
-    // the user changes the position slider or finishes a dBm drag.
-    void refreshNoiseFloorTarget();
+    // Re-capture the target frac. Slider changes use m_noiseFloorPosition;
+    // manual dBm-scale changes can capture the floor's current screen position.
+    void refreshNoiseFloorTarget(bool captureCurrentScale = false);
+    bool captureNoiseFloorTargetFromCurrentScale(bool notify);
 
     // Helper: find overlay index for a sliceId, or -1.
     int overlayIndex(int sliceId) const;
@@ -601,6 +610,7 @@ private:
     float m_dynamicRange{100.0f};   // dB range shown in spectrum (-50 to -150)
     bool  m_resetFftSmoothingOnNextFrame{false};
     bool  m_pendingDbmRangeEcho{false};
+    qint64 m_pendingDbmRangeEchoStartMs{0};
     int   m_holdFftUpdatesAfterDbmRelease{0};
     float m_dbmReleasePreviewOffset{0.0f};
     float m_pendingMinDbm{0.0f};


### PR DESCRIPTION
## Summary

Fixes several FFT Floor lock edge cases so the displayed spectrum floor and Display menu controls stay in sync.

- Sync the FFT Floor slider when the user manually moves the spectrum dBm position.
- Capture the current spectrum floor position when enabling FFT Floor Auto, so enabling the lock does not jump the display.
- Make FFT Floor slider changes immediately update the lock target and drive the display adjustment.
- Reacquire the floor baseline after RX antenna and RF gain/preamp changes.
- Clear or expire stale pending dBm-range echo state so slider, zoom, enable/disable, and input-change sequences do not leave the lock paused.

## Testing

- Built successfully with:

  ```sh
  cmake --build build -j4
  ```

- Manually verified:
  - dragging the spectrum dBm position updates the FFT Floor slider
  - dragging the FFT Floor slider moves the locked spectrum position
  - enabling/disabling FFT Floor Auto preserves the current position
  - zooming and changing antennas no longer break the lock