### PR TITLE
chore(repo): refresh in-repo URLs to aethersdr/AetherSDR org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: "💡 AI-Assisted Feature Request (Recommended)"
-    url: https://github.com/ten9876/AetherSDR/blob/main/CONTRIBUTING.md#ai-assisted-feature-requests
+    url: https://github.com/aethersdr/AetherSDR/blob/main/CONTRIBUTING.md#ai-assisted-feature-requests
     about: "Use Claude.ai (free) to help you write a well-structured feature request. Issues created with AI assistance are prioritized — see our contributing guide for the prompt."
   - name: "📋 RFC — is your change significant? Read this first"
-    url: https://github.com/ten9876/AetherSDR/blob/main/GOVERNANCE.md#rfc-process
+    url: https://github.com/aethersdr/AetherSDR/blob/main/GOVERNANCE.md#rfc-process
     about: "UX changes, new dependencies, architecture changes, and platform-specific native integration require an approved RFC before a PR will be accepted."
   - name: "💬 Discussions"
-    url: https://github.com/ten9876/AetherSDR/discussions
+    url: https://github.com/aethersdr/AetherSDR/discussions
     about: "Ask questions, share ideas, or show your setup"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -12,7 +12,7 @@ body:
         ### How to create a great feature request in 2 minutes:
 
         1. Go to [claude.ai](https://claude.ai) (free) or any AI assistant
-        2. Paste the prompt from our [Contributing Guide](https://github.com/ten9876/AetherSDR/blob/main/CONTRIBUTING.md#ai-assisted-feature-requests)
+        2. Paste the prompt from our [Contributing Guide](https://github.com/aethersdr/AetherSDR/blob/main/CONTRIBUTING.md#ai-assisted-feature-requests)
         3. Describe your idea in plain English — the AI will structure it with protocol hints and implementation details
         4. Paste the AI's output into the form below
 

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -8,7 +8,7 @@ body:
         ## Before you write any code
 
         Some changes require an approved RFC before a PR will be accepted.
-        See [GOVERNANCE.md](https://github.com/ten9876/AetherSDR/blob/main/GOVERNANCE.md#rfc-process)
+        See [GOVERNANCE.md](https://github.com/aethersdr/AetherSDR/blob/main/GOVERNANCE.md#rfc-process)
         for the full list, which includes:
 
         - Visual design changes (colors, fonts, layout, theme)
@@ -26,7 +26,7 @@ body:
     attributes:
       label: Preflight
       options:
-        - label: "I have read [GOVERNANCE.md](https://github.com/ten9876/AetherSDR/blob/main/GOVERNANCE.md) and confirmed this change requires an RFC"
+        - label: "I have read [GOVERNANCE.md](https://github.com/aethersdr/AetherSDR/blob/main/GOVERNANCE.md) and confirmed this change requires an RFC"
           required: true
         - label: "I have searched existing issues and this RFC has not been proposed before"
           required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -29,4 +29,4 @@ Original text courtesy of the [Speak Up! project](http://web.archive.org/web/201
 
 ## Questions?
 
-If you have questions, feel free to [contact us](mailto:info@aethersdr.com) or open a [GitHub Discussion](https://github.com/ten9876/AetherSDR/discussions).
+If you have questions, feel free to [contact us](mailto:info@aethersdr.com) or open a [GitHub Discussion](https://github.com/aethersdr/AetherSDR/discussions).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ the RFC process for significant changes.
 
 ## Quick Start
 
-1. Browse [open issues](https://github.com/ten9876/AetherSDR/issues) —
+1. Browse [open issues](https://github.com/aethersdr/AetherSDR/issues) —
    issues labeled `good first issue` are great starting points.
 2. Fork the repo and create a feature branch from `main`.
 3. Implement the fix or feature (one issue per PR).
@@ -22,7 +22,7 @@ the RFC process for significant changes.
 ## Reporting Bugs
 
 - Use the **lightbulb button** in AetherSDR's title bar for AI-assisted bug
-  reports, or open a [GitHub issue](https://github.com/ten9876/AetherSDR/issues/new) directly.
+  reports, or open a [GitHub issue](https://github.com/aethersdr/AetherSDR/issues/new) directly.
 - Include: OS/distro, AetherSDR version, radio model, firmware version.
 - Attach logs (`~/.config/AetherSDR/aethersdr.log`) or use Help → Support → Send to Support.
 - Check existing issues first to avoid duplicates.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 **A Linux-native client for FlexRadio Systems transceivers**
 
-[![CI](https://github.com/ten9876/AetherSDR/actions/workflows/ci.yml/badge.svg)](https://github.com/ten9876/AetherSDR/actions/workflows/ci.yml)
+[![CI](https://github.com/aethersdr/AetherSDR/actions/workflows/ci.yml/badge.svg)](https://github.com/aethersdr/AetherSDR/actions/workflows/ci.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://en.cppreference.com/w/cpp/20)
 [![Qt6](https://img.shields.io/badge/Qt-6-green.svg)](https://www.qt.io/)
-[![Signed Commits](https://img.shields.io/badge/commits-GPG%20signed-brightgreen?logo=gnuprivacyguard)](https://github.com/ten9876/AetherSDR/commits/main)
+[![Signed Commits](https://img.shields.io/badge/commits-GPG%20signed-brightgreen?logo=gnuprivacyguard)](https://github.com/aethersdr/AetherSDR/commits/main)
 
 AetherSDR brings FlexRadio operation to Linux without Wine or virtual machines. Built from the ground up with Qt6 and C++20, it speaks the SmartSDR protocol natively and aims to replicate the full SmartSDR experience.
 
-**Current version: 26.5.1** — first stable, 1.0-equivalent release. Versioning moves to CalVer (`YY.M.patch`). | [Download](https://github.com/ten9876/AetherSDR/releases/latest) | [Discussions](https://github.com/ten9876/AetherSDR/discussions) | [What's New](https://github.com/ten9876/AetherSDR/releases)
+**Current version: 26.5.1** — first stable, 1.0-equivalent release. Versioning moves to CalVer (`YY.M.patch`). | [Download](https://github.com/aethersdr/AetherSDR/releases/latest) | [Discussions](https://github.com/aethersdr/AetherSDR/discussions) | [What's New](https://github.com/aethersdr/AetherSDR/releases)
 
 > **Cross-platform downloads available:** Linux AppImage, macOS universal DMG, Windows installer and portable ZIP.
 > Linux is the primary supported platform. macOS and Windows builds are provided as a courtesy.
@@ -83,7 +83,7 @@ MIDI, Stream Deck/StreamController plugins, and generic USB-serial adapters:
 
 ## Download
 
-Pre-built binaries are available from [Releases](https://github.com/ten9876/AetherSDR/releases/latest):
+Pre-built binaries are available from [Releases](https://github.com/aethersdr/AetherSDR/releases/latest):
 
 | Platform | Download | Notes |
 |----------|----------|-------|
@@ -155,7 +155,7 @@ brew install qt@6 ninja cmake pkgconf autoconf automake libtool \
 ### Build & Run
 
 ```bash
-git clone https://github.com/ten9876/AetherSDR.git
+git clone https://github.com/aethersdr/AetherSDR.git
 cd AetherSDR
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build -j$(nproc)
@@ -200,7 +200,7 @@ sudo cmake --install build
 - [ ] CW ultimatic keyer mode (#416)
 - [ ] Native DAX audio channels on Windows
 
-See the full [issue tracker](https://github.com/ten9876/AetherSDR/issues) for all planned features.
+See the full [issue tracker](https://github.com/aethersdr/AetherSDR/issues) for all planned features.
 
 ---
 
@@ -219,7 +219,7 @@ PRs, bug reports, and feature requests welcome! See [CONTRIBUTING.md](CONTRIBUTI
 Linux and Windows binaries are GPG-signed. macOS artifacts are Apple notarized. Each release includes `.asc` signatures and `SHA256SUMS.txt`.
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/ten9876/AetherSDR/main/docs/RELEASE-SIGNING-KEY.pub.asc | gpg --import
+curl -sSL https://raw.githubusercontent.com/aethersdr/AetherSDR/main/docs/RELEASE-SIGNING-KEY.pub.asc | gpg --import
 gpg --verify AetherSDR-vX.Y.Z-x86_64.AppImage.asc AetherSDR-vX.Y.Z-x86_64.AppImage
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability in AetherSDR, please report it
 **privately** rather than opening a public issue.
 
 **Email:** Send details to the repository owner via GitHub private messaging,
-or use [GitHub's private vulnerability reporting](https://github.com/ten9876/AetherSDR/security/advisories/new).
+or use [GitHub's private vulnerability reporting](https://github.com/aethersdr/AetherSDR/security/advisories/new).
 
 Please include:
 - A description of the vulnerability

--- a/docs/AetherClaude-Skills-Plan.md
+++ b/docs/AetherClaude-Skills-Plan.md
@@ -82,7 +82,7 @@ and fills in variables (issue number, PR number, author, etc.).
 
 ## Skill 1: Community PR Review
 
-**Trigger:** New PR opened on `ten9876/AetherSDR` (polled every 30 min)
+**Trigger:** New PR opened on `aethersdr/AetherSDR` (polled every 30 min)
 
 **Skip if:**
 - PR author is `ten9876` (maintainer) or `AetherClaude` (self)
@@ -164,7 +164,7 @@ Fastest possible response time.
 - Issue is assigned to someone (they're working on it)
 
 **What it does:**
-1. Search API: `repo:ten9876/AetherSDR is:issue is:open updated:<30_DAYS_AGO`
+1. Search API: `repo:aethersdr/AetherSDR is:issue is:open updated:<30_DAYS_AGO`
 2. For each stale issue:
    a. Read the issue body and all comments
    b. Feed to Claude Code for context-aware triage
@@ -203,7 +203,7 @@ or via a labeled issue (`release-notes-draft`)
 **What it does:**
 1. Find the latest release tag: `git describe --tags --abbrev=0`
 2. List all merged PRs since that tag:
-   `gh pr list --repo ten9876/AetherSDR --state merged --search "merged:>DATE"`
+   `gh pr list --repo aethersdr/AetherSDR --state merged --search "merged:>DATE"`
 3. For each PR, extract: number, title, author, labels
 4. Feed the list to Claude Code with instructions to:
    a. Group by category (Bug Fix, Feature, Enhancement, Internal)
@@ -271,7 +271,7 @@ operations
 **What it does:**
 1. Extract key terms from the new issue title and body
 2. Search existing open AND closed issues via `search_issues` MCP operation:
-   `repo:ten9876/AetherSDR is:issue "keyword1" "keyword2"`
+   `repo:aethersdr/AetherSDR is:issue "keyword1" "keyword2"`
 3. If candidates found (>0 results with different issue numbers):
    a. Feed the new issue + candidates to Claude Code
    b. Claude Code determines if any are true duplicates

--- a/docs/VERIFYING-RELEASES.md
+++ b/docs/VERIFYING-RELEASES.md
@@ -23,7 +23,7 @@ Linux and source artifacts.
 From the repository:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/ten9876/AetherSDR/main/docs/RELEASE-SIGNING-KEY.pub.asc | gpg --import
+curl -sSL https://raw.githubusercontent.com/aethersdr/AetherSDR/main/docs/RELEASE-SIGNING-KEY.pub.asc | gpg --import
 ```
 
 Or from keys.openpgp.org:

--- a/docs/dialog-patterns.md
+++ b/docs/dialog-patterns.md
@@ -5,7 +5,7 @@ non-modal — there's a canonical pattern that the project's existing dialogs
 follow. This doc captures it in one place so contributors (human or agent)
 don't have to reverse-engineer it from 8+ existing dialogs.
 
-Long-term, the [`PersistentDialog` base class issue (#2605)](https://github.com/ten9876/AetherSDR/issues/2605)
+Long-term, the [`PersistentDialog` base class issue (#2605)](https://github.com/aethersdr/AetherSDR/issues/2605)
 will collapse this boilerplate into a parent class with `bodyWidget()`. Until
 then, every new dialog needs to wire these pieces by hand.
 

--- a/docs/tci-discovery.md
+++ b/docs/tci-discovery.md
@@ -1,7 +1,7 @@
 # TCI Peripheral Discovery — mDNS Service Schema
 
-_Proposed in [#2502](https://github.com/ten9876/AetherSDR/issues/2502) as
-a follow-up to [#2456](https://github.com/ten9876/AetherSDR/pull/2456).
+_Proposed in [#2502](https://github.com/aethersdr/AetherSDR/issues/2502) as
+a follow-up to [#2456](https://github.com/aethersdr/AetherSDR/pull/2456).
 This document defines the discovery contract; the Qt-side browse
 implementation lives in a separate change._
 

--- a/docs/tci-receivers.md
+++ b/docs/tci-receivers.md
@@ -1,6 +1,6 @@
 # TCI Receiver Index Policy
 
-_Changed in [e49875b2](https://github.com/ten9876/AetherSDR/commit/e49875b2) (#2140)._
+_Changed in [e49875b2](https://github.com/aethersdr/AetherSDR/commit/e49875b2) (#2140)._
 
 ## Overview
 

--- a/plugins/elgato-aethersdr/README.md
+++ b/plugins/elgato-aethersdr/README.md
@@ -7,7 +7,7 @@ Works with the **official Elgato Stream Deck app** on macOS and Windows.
 ## Installation
 
 1. Enable TCI in AetherSDR: **Settings > Autostart TCI with AetherSDR**
-2. Download `com.aethersdr.radio.streamDeckPlugin` from the [latest release](https://github.com/ten9876/AetherSDR/releases/latest)
+2. Download `com.aethersdr.radio.streamDeckPlugin` from the [latest release](https://github.com/aethersdr/AetherSDR/releases/latest)
 3. Double-click the file — the Elgato app installs it automatically
 4. Drag AetherSDR actions onto your Stream Deck buttons
 

--- a/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/manifest.json
+++ b/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/manifest.json
@@ -5,7 +5,7 @@
   "Name": "AetherSDR",
   "Description": "Full AetherSDR radio control via TCI — 43 actions for FlexRadio TX, bands, modes, DSP, audio, and DVK.",
   "Author": "AetherSDR",
-  "URL": "https://github.com/ten9876/AetherSDR",
+  "URL": "https://github.com/aethersdr/AetherSDR",
   "Icon": "imgs/plugin-icon",
   "CodePath": "plugin.js",
   "Category": "AetherSDR",

--- a/resources/help/contributing-to-aethersdr.md
+++ b/resources/help/contributing-to-aethersdr.md
@@ -36,7 +36,7 @@ Those are exactly the kinds of observations that make the software safer and eas
 
 GitHub:
 
-[https://github.com/ten9876/AetherSDR](https://github.com/ten9876/AetherSDR)
+[https://github.com/aethersdr/AetherSDR](https://github.com/aethersdr/AetherSDR)
 
 This is the main place for issues, discussions, releases, and pull requests.
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7314,8 +7314,8 @@ void MainWindow::buildMenuBar()
             "Licensed under "
             "<a href='https://www.gnu.org/licenses/gpl-3.0.html' style='color:#00b4d8;'>GPLv3</a></p>"
             "<p style='font-size:11px;'>"
-            "<a href='https://github.com/ten9876/AetherSDR' style='color:#00b4d8;'>"
-            "github.com/ten9876/AetherSDR</a></p>"
+            "<a href='https://github.com/aethersdr/AetherSDR' style='color:#00b4d8;'>"
+            "github.com/aethersdr/AetherSDR</a></p>"
             "<p style='font-size:10px; color:#6a8090;'>"
             "SmartSDR protocol &copy; FlexRadio Systems</p>"
             "<p style='font-size:10px; color:#6a8090;'>"
@@ -7341,7 +7341,7 @@ void MainWindow::buildMenuBar()
         // Fetch live contributor list from GitHub API
         auto* nam = new QNetworkAccessManager(dlg);
         auto* reply = nam->get(QNetworkRequest(
-            QUrl("https://api.github.com/repos/ten9876/AetherSDR/contributors")));
+            QUrl("https://api.github.com/repos/aethersdr/AetherSDR/contributors")));
         connect(reply, &QNetworkReply::finished, dlg, [contribLabel, reply] {
             reply->deleteLater();
             if (reply->error() != QNetworkReply::NoError) return;

--- a/src/gui/SupportDialog.cpp
+++ b/src/gui/SupportDialog.cpp
@@ -168,14 +168,14 @@ void SupportDialog::buildUI()
         // Diagnostic prompt for AI
         static const QString kPromptTemplate =
             "I'm experiencing an issue with AetherSDR, a Linux/macOS/Windows SDR client\n"
-            "for FlexRadio transceivers (https://github.com/ten9876/AetherSDR).\n\n"
+            "for FlexRadio transceivers (https://github.com/aethersdr/AetherSDR).\n\n"
             "My system:\n"
             "- AetherSDR version: %1\n"
             "- Qt version: %2\n"
             "- OS: %3\n"
             "- Radio: %4\n\n"
             "Before writing the bug report, please read the AetherSDR project context at\n"
-            "https://raw.githubusercontent.com/ten9876/AetherSDR/main/CLAUDE.md\n"
+            "https://raw.githubusercontent.com/aethersdr/AetherSDR/main/CLAUDE.md\n"
             "for architecture overview, data flow, protocol details, and known issues.\n\n"
             "Based on my description below, write a complete GitHub bug report.\n"
             "Do NOT ask me follow-up questions — just write the best report you can\n"
@@ -251,7 +251,7 @@ void SupportDialog::buildUI()
             QDesktopServices::openUrl(QUrl("https://www.perplexity.ai/"));
             openedLLM = true;
         } else if (clicked == issueBtn) {
-            QUrl url("https://github.com/ten9876/AetherSDR/issues/new");
+            QUrl url("https://github.com/aethersdr/AetherSDR/issues/new");
             QUrlQuery query;
             query.addQueryItem("labels", "bug");
             url.setQuery(query);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -787,7 +787,7 @@ void TitleBar::showFeatureRequestDialog()
     // Version check guard (#486) — warn if not on latest release
     auto* nam = new QNetworkAccessManager(this);
     auto* reply = nam->get(QNetworkRequest(
-        QUrl("https://api.github.com/repos/ten9876/AetherSDR/releases/latest")));
+        QUrl("https://api.github.com/repos/aethersdr/AetherSDR/releases/latest")));
     connect(reply, &QNetworkReply::finished, this, [this, reply, nam] {
         reply->deleteLater();
         nam->deleteLater();
@@ -819,12 +819,12 @@ void TitleBar::showFeatureRequestDialogImpl()
     static const QString kPrompt =
         "IMPORTANT — before doing anything else, fetch the complete list of open\n"
         "issues by reading pages sequentially until you get fewer than 100 results:\n"
-        "  Page 1: https://github.com/ten9876/AetherSDR/issues?state=open&per_page=100&page=1\n"
-        "  Page 2: https://github.com/ten9876/AetherSDR/issues?state=open&per_page=100&page=2\n"
+        "  Page 1: https://github.com/aethersdr/AetherSDR/issues?state=open&per_page=100&page=1\n"
+        "  Page 2: https://github.com/aethersdr/AetherSDR/issues?state=open&per_page=100&page=2\n"
         "  ... continue until a page returns fewer than 100 issues.\n"
         "Do NOT rely on cached or training data for the issue list.\n\n"
         "Also fetch CLAUDE.md fresh (do not use cached versions):\n"
-        "  https://raw.githubusercontent.com/ten9876/AetherSDR/main/CLAUDE.md\n\n"
+        "  https://raw.githubusercontent.com/aethersdr/AetherSDR/main/CLAUDE.md\n\n"
         "I want to report an issue or request a feature for AetherSDR, a Linux-native\n"
         "Qt6/C++20 client for FlexRadio transceivers. It uses the FlexLib API over TCP/UDP.\n\n"
         "DUPLICATE CHECK — this is mandatory. Search the fetched issue list for keywords\n"
@@ -938,7 +938,7 @@ void TitleBar::showFeatureRequestDialogImpl()
         "QPushButton:hover { background: #00c8f0; }");
     connect(submitBtn, &QPushButton::clicked, dlg, [dlg] {
         QDesktopServices::openUrl(QUrl(
-            "https://github.com/ten9876/AetherSDR/issues/new?template=feature_request.yml"));
+            "https://github.com/aethersdr/AetherSDR/issues/new?template=feature_request.yml"));
         QTimer::singleShot(500, dlg, &QDialog::close);
     });
     btnRow2->addWidget(submitBtn);
@@ -950,7 +950,7 @@ void TitleBar::showFeatureRequestDialogImpl()
         "QPushButton:hover { background: #dd5050; }");
     connect(bugBtn, &QPushButton::clicked, dlg, [dlg] {
         QDesktopServices::openUrl(QUrl(
-            "https://github.com/ten9876/AetherSDR/issues/new?template=bug_report.yml"));
+            "https://github.com/aethersdr/AetherSDR/issues/new?template=bug_report.yml"));
         QTimer::singleShot(500, dlg, &QDialog::close);
     });
     btnRow2->addWidget(bugBtn);

--- a/src/gui/WhatsNewDialog.cpp
+++ b/src/gui/WhatsNewDialog.cpp
@@ -138,7 +138,7 @@ void WhatsNewDialog::buildUI(const QString& lastSeenVersion,
             "font-size: 14px; border-radius: 18px; padding: 0 32px; }"
             "QPushButton:hover { background: #28c050; }");
         connect(upgradeBtn, &QPushButton::clicked, this, [this] {
-            QDesktopServices::openUrl(QUrl("https://github.com/ten9876/AetherSDR/releases/latest"));
+            QDesktopServices::openUrl(QUrl("https://github.com/aethersdr/AetherSDR/releases/latest"));
             close();
         });
         btnRow->addWidget(upgradeBtn);


### PR DESCRIPTION
## Summary

Refreshes every in-repo \`ten9876/AetherSDR\` URL reference to point at \`aethersdr/AetherSDR\` following the **2026-05-16** repo move from Jeremy's personal account to the org account.

GitHub serves a redirect from the old URL so existing binaries / external links keep working, but the new URL is the canonical one — and the runtime About-dialog contributors fetch, support-dialog issue links, etc. should match.

## What's in this PR

- **README** badges, download links, clone instruction, raw-tarball URL
- **CONTRIBUTING / CODE_OF_CONDUCT / SECURITY** external links
- **.github/ISSUE_TEMPLATE/*** doc URLs
- **Runtime UI surfaces:**
  - About dialog hyperlink + contributors API URL (\`MainWindow.cpp\`)
  - TitleBar links (\`TitleBar.cpp\`)
  - WhatsNewDialog releases-page URL
  - SupportDialog issue-file link
- **Docs**: \`tci-discovery\`, \`tci-receivers\`, \`dialog-patterns\`, \`VERIFYING-RELEASES\`, \`AetherClaude-Skills-Plan\`, \`plugins/elgato/README\`, \`resources/help\`
- **Stream Deck plugin** manifest URL

## Intentionally untouched

- **\`@ten9876\` GitHub-username mentions** in \`CONTRIBUTING.md\` / \`GOVERNANCE.md\` — Jeremy's account is still \`ten9876\`, only the repo owner changed.
- **\`login == "ten9876"\` filter** in the About-dialog contributors loop — that's the user-login filter, still correct.
- **\`ten9876/aetherclaude\`** reference in \`.specify/memory/constitution.md\` — different repo, not affected.
- **\`CHANGELOG.md\`** historical release-compare URLs — frozen artifacts of past releases.
- **\`.github/workflows/*.yml\`** GHCR image references (\`ghcr.io/ten9876/aethersdr-ci:latest\`) — image is still under the old GHCR namespace and the workflows track that. Separate concern once/if the image gets republished under \`aethersdr/aethersdr-ci\`.

## Test plan

- [x] \`cmake --build build --target AetherSDR\` — clean
- [ ] About dialog → "github.com/aethersdr/AetherSDR" link present and clickable
- [ ] About dialog Contributors list populates (live fetch against new URL)
- [ ] TitleBar "Bug Report" / "Feature Request" buttons open the new issue URL
- [ ] WhatsNewDialog "Open Latest Release" opens the new releases URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)