### PR TITLE
Fix spot tooltips disappearing near waterfall edge (#2553)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -3079,6 +3079,8 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
     ev->accept();
 }
 
+static QString spotMarkerTooltip(const SpectrumWidget::SpotMarker& sm);
+
 void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
 {
     PerfInputScope perfScope("mouseMove");
@@ -3375,27 +3377,19 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
                         if (hr.rect.contains(pos)) {
                             setSpectrumCursor(Qt::PointingHandCursor);
                             foundCursor = true;
-                            // Show spot tooltip
                             if (hr.markerIndex >= 0 && hr.markerIndex < m_spotMarkers.size()) {
-                                const auto& sm = m_spotMarkers[hr.markerIndex];
-                                QString tip = QString("<b>%1</b>  %2 MHz")
-                                    .arg(sm.callsign)
-                                    .arg(sm.freqMhz, 0, 'f', 4);
-                                if (!sm.source.isEmpty())
-                                    tip += QString("<br>Source: %1").arg(sm.source);
-                                if (!sm.spotterCallsign.isEmpty())
-                                    tip += QString("<br>Spotter: %1").arg(sm.spotterCallsign);
-                                if (!sm.comment.isEmpty())
-                                    tip += QString("<br>%1").arg(sm.comment);
-                                if (sm.timestampMs > 0)
-                                    tip += QString("<br>Spotted: %1 UTC").arg(
-                                        QDateTime::fromMSecsSinceEpoch(sm.timestampMs, QTimeZone::utc()).toString("yyyy-MM-dd HH:mm:ss"));
-                                QToolTip::showText(ev->globalPosition().toPoint() + QPoint(0, 20), tip, this, hr.rect);
+                                m_hoveredSpotKey = hr.callsign + QChar('@')
+                                    + QString::number(qRound(hr.freqMhz * 1000.0));
+                                QToolTip::showText(ev->globalPosition().toPoint() + QPoint(0, 20),
+                                                   spotMarkerTooltip(m_spotMarkers[hr.markerIndex]),
+                                                   this, hr.rect);
                             }
                             spotHover = true;
                             break;
                         }
                     }
+                    if (!spotHover)
+                        m_hoveredSpotKey.clear();
                     if (!foundCursor) {
                         for (const auto& cluster : m_spotClusters) {
                             if (cluster.rect.contains(pos)) {
@@ -3670,6 +3664,7 @@ void SpectrumWidget::mouseDoubleClickEvent(QMouseEvent* ev)
 void SpectrumWidget::leaveEvent(QEvent* event)
 {
     QWidget::leaveEvent(event);
+    m_hoveredSpotKey.clear();
     updateTrackedCursorState(QPoint(-1, -1), false);
 }
 
@@ -5820,6 +5815,21 @@ int SpectrumWidget::tnfAtPixel(int x, int preferredId) const
 
 // ─── VFO marker (filter passband + tuned frequency line) ──────────────────────
 
+static QString spotMarkerTooltip(const SpectrumWidget::SpotMarker& sm)
+{
+    QString tip = QString("<b>%1</b>  %2 MHz").arg(sm.callsign).arg(sm.freqMhz, 0, 'f', 4);
+    if (!sm.source.isEmpty())
+        tip += QString("<br>Source: %1").arg(sm.source);
+    if (!sm.spotterCallsign.isEmpty())
+        tip += QString("<br>Spotter: %1").arg(sm.spotterCallsign);
+    if (!sm.comment.isEmpty())
+        tip += QString("<br>%1").arg(sm.comment);
+    if (sm.timestampMs > 0)
+        tip += QString("<br>Spotted: %1 UTC").arg(
+            QDateTime::fromMSecsSinceEpoch(sm.timestampMs, QTimeZone::utc()).toString("yyyy-MM-dd HH:mm:ss"));
+    return tip;
+}
+
 void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
 {
     // Merge DX spots, Signal History markers, and QRM History markers.
@@ -5978,7 +5988,7 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
         }
 
         placed.append(labelRect);
-        m_spotClickRects.append({labelRect, spot.freqMhz, mIdx});
+        m_spotClickRects.append({labelRect, spot.freqMhz, mIdx, spot.callsign});
 
         // Background pill — local Override Background color wins when on
         // (#768).  When off, fall through to the protocol-supplied
@@ -6060,6 +6070,31 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
     }
 
     p.setFont(QFont());  // restore default
+
+    // Re-show tooltip for the hovered spot after every rect rebuild. Without
+    // this, the jitter in spot label positions (collision-nudge cascade) causes
+    // Qt to hide the tooltip each repaint because the registered rect shifts
+    // slightly. Called via QueuedConnection because drawSpotMarkers runs on the
+    // render thread; QToolTip must be touched on the main thread. (#2553)
+    if (!m_hoveredSpotKey.isEmpty() && !m_tooltipRefreshPending) {
+        m_tooltipRefreshPending = true;
+        QMetaObject::invokeMethod(this, [this]() {
+            m_tooltipRefreshPending = false;
+            if (m_hoveredSpotKey.isEmpty()) return;
+            const QPoint cursorPos = QCursor::pos();
+            for (const auto& hr : m_spotClickRects) {
+                const QString key = hr.callsign + QChar('@')
+                    + QString::number(qRound(hr.freqMhz * 1000.0));
+                if (key != m_hoveredSpotKey) continue;
+                if (!hr.rect.contains(mapFromGlobal(cursorPos))) continue;
+                if (hr.markerIndex >= 0 && hr.markerIndex < m_spotMarkers.size())
+                    QToolTip::showText(cursorPos + QPoint(0, 20),
+                                       spotMarkerTooltip(m_spotMarkers[hr.markerIndex]),
+                                       this, hr.rect);
+                break;
+            }
+        }, Qt::QueuedConnection);
+    }
 }
 
 void SpectrumWidget::drawSwrSweep(QPainter& p, const QRect& specRect)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -371,7 +371,7 @@ public:
                            const QString& sourceLabel = {});
     void clearSwrSweepPoints();
 
-    void setShowSpots(bool on) { m_showSpots = on; update(); }
+    void setShowSpots(bool on) { m_showSpots = on; m_hoveredSpotKey.clear(); update(); }
     bool showSpots() const { return m_showSpots; }
     void setShowSHistory(bool on)    { m_showSHistory = on;    update(); }
     bool showSHistory() const         { return m_showSHistory; }
@@ -891,8 +891,11 @@ private:
         QRect rect;
         double freqMhz;
         int markerIndex;  // index into m_spotMarkers for tooltip data
+        QString callsign; // stable hover key (index can go stale on list rebuild)
     };
     QVector<SpotHitRect> m_spotClickRects;
+    QString m_hoveredSpotKey;          // callsign@freqKHz, empty when no spot hovered
+    bool    m_tooltipRefreshPending{false}; // guards against duplicate queued refreshes
 
     QVector<SpotCluster> m_spotClusters;
     bool m_showSpots{true};


### PR DESCRIPTION
## Summary
- Spot label rects shift slightly each repaint due to the collision-nudge
  cascade. Qt hides the tooltip whenever its registered rect changes,
  and without a subsequent mouseMoveEvent (mouse is stationary), it stays
  hidden.
- Track the hovered spot by callsign@freqKHz key (stable across list
  rebuilds) rather than array index.
- After each drawSpotMarkers() rect rebuild, post a queued main-thread
  call that re-shows the tooltip if the cursor is still inside the
  freshly-computed rect for the hovered spot.
- Extract tooltip text into spotMarkerTooltip() so mouseMoveEvent and
  the refresh path stay in sync.

## Test plan
- [ ] Hover a spot near the left/right edge of the panadapter — tooltip
      should persist without flickering during active FFT updates
- [ ] Hover a spot in a crowded cluster — tooltip persists
- [ ] Move mouse off the spot — tooltip hides normally
- [ ] Toggle spots off while hovering — tooltip hides, no crash on
      re-enable