### PR TITLE
fix(layout): second size-setter also clobbered left-dock startup (#2704)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4406,9 +4406,27 @@ MainWindow::MainWindow(QWidget* parent)
         restoreState(QByteArray::fromBase64(stateB64.toLatin1()));
     // Clear stale splitter state — layout has changed across versions.
     s.remove("SplitterState");
-    // Force 4-pane sizing: CWX=0, DVK=0 (hidden), center=stretch, applet=260px
+    // Force 4-pane sizing: CWX=0, DVK=0 (hidden), applet=260px, center=stretch.
+    // Assign by widget identity rather than fixed slot index — buildUI may
+    // have called setAppletPanelDockedLeft() which swaps m_panStack and
+    // m_appletPanel in the splitter.  Hard-coding "size at index 2 = center,
+    // size at index 3 = applet" silently mis-allocates on left-dock startup
+    // (panstack squeezed to the right edge with a wide empty slot in the
+    // middle).  PR #2733 fixed setAppletPanelDockedLeft itself but this
+    // deferred resizer overwrites its work — same fix shape, second site. (#2704)
     QTimer::singleShot(0, this, [this]() {
-        m_splitter->setSizes({0, 0, width() - 260, 260});
+        if (!m_splitter || !m_appletPanel || !m_panStack) return;
+        const int total = m_splitter->width();
+        if (total <= 0) return;
+        const int appletW = m_appletPanel->maximumWidth();
+        const int centerW = qMax(400, total - appletW);
+        QList<int> sizes(m_splitter->count(), 0);
+        for (int i = 0; i < m_splitter->count(); ++i) {
+            QWidget* w = m_splitter->widget(i);
+            if (w == m_panStack)         sizes[i] = centerW;
+            else if (w == m_appletPanel) sizes[i] = appletW;
+        }
+        m_splitter->setSizes(sizes);
     });
 
     // Auto-popup connection dialog if no saved radio


### PR DESCRIPTION
## Summary

Reopens #2704.  PR #2733 fixed \`setAppletPanelDockedLeft\` itself but the panstack-vanished-on-left-dock-startup bug came back: a **second** size-setter at \`MainWindow.cpp:4410\` (a deferred \`QTimer::singleShot(0, …)\` queued after geometry restore) hard-codes slot indices and clobbers whatever \`setAppletPanelDockedLeft\` did during buildUI.

## Root cause

The QTimer was written assuming the right-dock default ordering \`[cwx, dvk, panStack, appletPanel]\` and assigns:

\`\`\`cpp
m_splitter->setSizes({0, 0, width() - 260, 260});
//                     ^   ^   ^^^^^^^^^^^   ^^^
//                     |   |   intended      intended
//                     |   |   for panStack  for appletPanel
//                     |   |
//                     +---+ cwx + dvk (hidden)
\`\`\`

When buildUI ran \`setAppletPanelDockedLeft(true)\` (restoring \`AppletPanelDockedLeft=True\` from settings), the splitter order was swapped to \`[cwx, dvk, appletPanel, panStack]\`.  The QTimer then dumped the wide slot on appletPanel (which has \`setFixedWidth(260)\`, so the surplus appears as a visible gap) and the narrow slot on panstack (squeezed to ~260 px on the right edge).

## Reported symptom

User-supplied screenshot in #2704: window starts with applet panel docked left, large dark gap in the middle, sliver-wide panadapter on the right edge.

## Fix

Mirrors the pattern PR #2733 applied to \`setAppletPanelDockedLeft\` itself — assign splitter sizes by **widget identity** rather than fixed slot index:

\`\`\`cpp
QList<int> sizes(m_splitter->count(), 0);
for (int i = 0; i < m_splitter->count(); ++i) {
    QWidget* w = m_splitter->widget(i);
    if (w == m_panStack)         sizes[i] = centerW;
    else if (w == m_appletPanel) sizes[i] = appletW;
}
m_splitter->setSizes(sizes);
\`\`\`

Now correct regardless of which side the user has the applet panel docked on at startup.

## Test plan

- [x] Build clean (\`cmake --build build --target AetherSDR\`)
- [x] Manually verified by maintainer (KK7GWY) on local build: dock applet panel left, restart, applet panel renders left of a properly-sized panstack with no gap.
- [ ] Right-dock startup still works correctly (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)