### PR TITLE
ci: post-merge guard + drop stale-branch pre-merge enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,14 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  # Post-merge guard. We dropped the "Require branches up to date before
+  # merging" branch-protection bit because it forced a CI rerun on every
+  # PR whenever main moved (~15–25 min × N stale PRs per batch day).
+  # The trade-off is: CI now runs on the merged commit itself, so any
+  # semantic conflict that slipped past three-way merge surfaces on main
+  # within ~10 min and triggers normal failure notifications.
+  push:
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,16 @@ on:
       - 'LICENSE'
       - '.gitignore'
       - '.github/**'
+  # Post-merge guard — paired with ci.yml's push:main trigger; same
+  # paths-ignore rules apply so docs/CI-only merges don't burn 23 min.
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/**'
   schedule:
     - cron: '0 6 * * 1'  # weekly Monday 06:00 UTC
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,6 +225,39 @@ Draft status carries different meaning depending on who opened the PR:
 Triage scripts and review agents should include bot drafts in their
 sweep and skip only human drafts.
 
+### Stale-branch policy
+
+We **do not** require PR branches to be up to date with `main` before
+merging. The reasoning:
+
+- Squash-merge already runs a fresh three-way merge against `main`, so
+  textual conflicts are caught at merge time regardless of branch age.
+- Forcing every PR to rebase after every other merge cost ~15–25 min
+  of CI per stale PR per batch day, which adds up fast when AetherClaude
+  is processing a queue of triaged issues.
+- Post-merge CI on `main` runs on every commit (see
+  [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and
+  [`.github/workflows/codeql.yml`](.github/workflows/codeql.yml)), so
+  semantic conflicts that slip through three-way merge are caught on
+  the merged result within ~10 min.
+
+### Recovering from a red main
+
+If post-merge CI on `main` fails after a merge:
+
+1. Check the failing workflow run linked from the email/GitHub
+   notification. Identify the offending merge commit.
+2. **Prefer fix-forward** if the issue is small (one or two file edits):
+   open a normal PR titled `fix(ci): repair main after <SHA>` and let
+   it land through the usual flow.
+3. **Use revert** if fix-forward isn't obvious or the regression is
+   broad: `git revert -m 1 <merge-sha>` on a new branch, push, open a
+   PR, merge. Never force-push `main`.
+4. For agent-authored regressions: re-open the source issue, remove
+   the `aetherclaude-eligible` label, then re-add it. The orchestrator's
+   State Override C (`failed` → `implement` re-entry) creates a fresh
+   worktree from current `main` and retries the implementation.
+
 ## What We Will Not Accept
 
 - **Wine/Crossover workarounds.** The goal is fully native.


### PR DESCRIPTION
## Summary

- Adds `push: main` trigger to `ci.yml` and `codeql.yml` — every merged commit gets standalone CI (~10 min). This is the safety net.
- Documents the new policy in `CONTRIBUTING.md` (\"Stale-branch policy\" + \"Recovering from a red main\" runbook).
- **Follow-up after merge:** I will flip `strict=false` on the `main` branch-protection rule via `gh api PATCH`. That removes the \"Require branches up to date before merging\" requirement which was forcing every queued PR to burn a full CI rerun whenever main moved.

## Why

When AetherClaude processes a batch of triaged issues, PRs are created in close succession. As earlier ones merge, every remaining PR goes `BEHIND` and needs `gh pr update-branch` before auto-merge can fire. That kicks off another full CI cycle (~15–25 min × N stale PRs). Over a busy day that's hours of redundant compute, just to verify \"this exact SHA built green against post-merge tip\" — a guarantee the squash three-way merge already approximates.

The post-merge `push: main` trigger replaces pre-merge prevention with post-merge detection. If a semantic conflict slips through three-way merge, we know within ~10 min and fix-forward / revert via the documented runbook.

## Test plan

- [ ] CI builds green on this PR (pull_request trigger still wired)
- [ ] After merge: confirm a workflow run appears under `push: main`
- [ ] After merge: run `gh api -X PATCH .../branches/main/protection/required_status_checks -F strict=false` and confirm the next queued PR no longer goes `BEHIND`

🤖 Generated with [Claude Code](https://claude.com/claude-code)