### PR TITLE
feat(cwx): add right-click context menu to CWX history bubbles

### DIFF
--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -14,6 +14,8 @@
 #include <QKeyEvent>
 #include <QPainter>
 #include <QScrollBar>
+#include <QContextMenuEvent>
+#include <QMenu>
 #include <QShortcut>
 #include <QSignalBlocker>
 #include <QTimer>
@@ -28,6 +30,8 @@ public:
     {
         recalcSize();
     }
+
+    QString text() const { return m_text; }
 
     void resizeEvent(QResizeEvent*) override { recalcSize(); }
 
@@ -417,6 +421,7 @@ void CwxPanel::sendBuffer()
         // Add painted bubble to history scroll area
         QString ts = QDateTime::currentDateTime().toString("HH:mm:ss");
         auto* bubble = new CwxBubble(text, ts, m_historyContainer);
+        bubble->installEventFilter(this);
         m_historyLayout->addWidget(bubble);
         // Keep scrolled to bottom
         QTimer::singleShot(10, this, [this]() {
@@ -479,5 +484,51 @@ bool AetherSDR::CwxPanel::eventFilter(QObject* obj, QEvent* event)
             return true;
         }
     }
+    // Context menu on history bubbles
+    if (auto* bubble = dynamic_cast<CwxBubble*>(obj)) {
+        if (event->type() == QEvent::ContextMenu) {
+            auto* ce = static_cast<QContextMenuEvent*>(event);
+            QMenu menu(this);
+            menu.setStyleSheet(
+                "QMenu { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050; }"
+                "QMenu::item:selected { background: #00b4d8; color: #000; }");
+            QAction* resendAction = menu.addAction("Resend");
+            menu.addSeparator();
+            QAction* clearAction  = menu.addAction("Clear History");
+            QAction* chosen = menu.exec(ce->globalPos());
+            if (chosen == resendAction) {
+                resendText(bubble->text());
+            } else if (chosen == clearAction) {
+                clearHistory();
+            }
+            return true;
+        }
+    }
+
     return QWidget::eventFilter(obj, event);
+}
+
+void AetherSDR::CwxPanel::resendText(const QString& text)
+{
+    if (!m_model || !m_historyLayout || text.isEmpty()) { return; }
+    QString ts = QDateTime::currentDateTime().toString("HH:mm:ss");
+    auto* bubble = new CwxBubble(text, ts, m_historyContainer);
+    bubble->installEventFilter(this);
+    m_historyLayout->addWidget(bubble);
+    QTimer::singleShot(10, this, [this]() {
+        auto* sb = m_historyScroll->verticalScrollBar();
+        sb->setValue(sb->maximum());
+    });
+    m_model->send(text);
+}
+
+void AetherSDR::CwxPanel::clearHistory()
+{
+    if (!m_historyLayout) { return; }
+    // Index 0 is the stretch spacer added in buildSendView(); indices 1+ are bubbles.
+    while (m_historyLayout->count() > 1) {
+        QLayoutItem* item = m_historyLayout->takeAt(1);
+        delete item->widget();
+        delete item;
+    }
 }

--- a/src/gui/CwxPanel.h
+++ b/src/gui/CwxPanel.h
@@ -55,6 +55,8 @@ private:
     void showSendView();
     void showSetupView();
     void sendBuffer();
+    void resendText(const QString& text);
+    void clearHistory();
     void onKeyPress(const QString& text);
 
     CwxModel*       m_model{nullptr};


### PR DESCRIPTION
## Summary

- Right-clicking any message bubble in the CWX history panel now shows a context menu with two actions: **Resend** and **Clear History**
- **Resend** re-queues the bubble's text via `CwxModel::send()`, creating a new history entry with a fresh timestamp — matching SmartSDR CWX behavior
- **Clear History** removes all bubble widgets from the history scroll area, leaving the layout's stretch spacer intact

## Implementation

`CwxBubble` gains a `text()` accessor. `CwxPanel::eventFilter()` is extended to intercept `QEvent::ContextMenu` on bubble objects via `dynamic_cast` (same translation unit — no `Q_OBJECT` / MOC change needed). Each bubble receives `installEventFilter(this)` on creation, covering both the normal `sendBuffer()` path and the new `resendText()` path.

No changes to `CwxModel` or any other file.

## Behavior note

**Resend carries no mode guard**, consistent with the existing `sendBuffer()` / Send button path which also sends unconditionally. Whether `cwx send` should be blocked outside CW/CWL modes is an open question that applies equally to *all* CWX send paths. This is intentionally deferred — it can be addressed holistically in a future CWX improvements pass rather than introduced inconsistently on this path alone.

## Test plan

- [ ] Right-click a history bubble → context menu appears with Resend and Clear History
- [ ] Resend → new bubble added to history with current timestamp; message queued to radio
- [ ] Clear History → all bubbles removed; history area is empty
- [ ] Right-click with no history present → no crash (no bubbles = no event filter targets)
- [ ] Normal send (Enter / Send button) still works and bubbles remain right-clickable after Resend

🤖 Generated with [Claude Code](https://claude.com/claude-code)