### PR TITLE
fix(cwx): insert CharGap between live-mode Pending entries in CwxLocalKeyer

### DIFF
--- a/src/core/CwxLocalKeyer.cpp
+++ b/src/core/CwxLocalKeyer.cpp
@@ -108,6 +108,15 @@ void CwxLocalKeyer::scheduleNext()
             }
             return;
         }
+        // In live mode each keystroke arrives as a separate Pending entry.
+        // encode() always starts with firstChar=true so it never prepends a
+        // CharGap for the transition between entries. The last element of any
+        // encoded character is always Dit or Dah, leaving m_currentlyDown=true
+        // here; without an explicit gap the key stays down continuously and
+        // adjacent characters merge into undecodable noise (#2473).
+        if (m_currentlyDown) {
+            m_elements.enqueue(Element::CharGap);
+        }
         const Pending p = m_queue.dequeue();
         encode(p.text, p.wpm);
         if (m_elements.isEmpty()) {


### PR DESCRIPTION
## Summary

Fixes garbled local sidetone when typing characters quickly in CWX live mode. Closes #2473.

**Confirmed via second receiver:** over-the-air CW is correct. The radio's CWX buffer queues and times characters properly. The bug is client-side only — the local sidetone keyer was merging adjacent characters into undecodable noise.

## Root cause

In live mode, each keystroke calls `CwxModel::sendChar()` → `CwxLocalKeyer::start(ch, wpm)`, enqueuing a separate `Pending` entry per character. When `scheduleNext()` exhausts the current character's elements and dequeues the next `Pending`, it calls `encode()` with `firstChar = true` — so no `CharGap` is prepended for the transition.

The last element of any encoded character is always Dit or Dah, leaving `m_currentlyDown = true` at the boundary. The guard `if (keyDownNext != m_currentlyDown)` never fires, so the key stays continuously down and adjacent characters merge. Example — `K` → `7`:

| Element | Duration |
|---|---|
| K final Dah | 3 units |
| ~~CharGap~~ ← **missing** | ~~3 units~~ |
| 7 first Dah | 3 units (merged — 6u continuous key-down) |

Typing slowly is unaffected because the keyer fully drains between characters (`m_running = false` at the next `start()` call, no boundary transition occurs).

## Fix

In `scheduleNext()`, before dequeuing the next `Pending` entry, enqueue a `CharGap` if `m_currentlyDown` is true:

```cpp
if (m_currentlyDown) {
    m_elements.enqueue(Element::CharGap);
}
```

This keys the tone down, waits the standard 3-unit inter-character silence, then begins the next character's elements normally.

**Buffer mode is unaffected:** a full-string transmission is a single `Pending` entry — the queue boundary is never crossed and `encode()` handles all internal `CharGap`s via its own `firstChar` logic.

## Test plan

- [ ] Live mode — type a callsign quickly: sidetone should be clean, correctly spaced Morse
- [ ] Live mode — type slowly (one char at a time, spaced apart): still correct, no spurious leading gap on first character
- [ ] Buffer mode (Enter / Send): no change in behavior
- [ ] ESC / clearBuffer during live typing: stop fires immediately, no leftover gap elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)