### PR TITLE
feat(bands): surface 4m/2m on FLEX-6500/6700 via ModelCapabilities (#695)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,6 +527,7 @@ endif()
 
 set(MODEL_SOURCES
     src/models/RadioModel.cpp
+    src/models/ModelCapabilities.cpp
     src/models/AntennaAliasStore.cpp
     src/models/SliceModel.cpp
     src/models/PanadapterModel.cpp
@@ -1290,6 +1291,14 @@ add_executable(packet_loss_concealment_test
 target_include_directories(packet_loss_concealment_test PRIVATE src)
 target_link_libraries(packet_loss_concealment_test PRIVATE Qt6::Core)
 add_test(NAME packet_loss_concealment_test COMMAND packet_loss_concealment_test)
+
+add_executable(model_capabilities_test
+    tests/model_capabilities_test.cpp
+    src/models/ModelCapabilities.cpp
+)
+target_include_directories(model_capabilities_test PRIVATE src)
+target_link_libraries(model_capabilities_test PRIVATE Qt6::Core)
+add_test(NAME model_capabilities_test COMMAND model_capabilities_test)
 
 add_executable(client_quindar_test
     tests/client_quindar_test.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8346,7 +8346,9 @@ void MainWindow::onConnectionStateChanged(bool connected)
         }
 #endif
         // Populate XVTR bands after radio status settles, and refresh
-        // whenever XVTR config changes (add/remove/rename). (#571)
+        // whenever XVTR config changes (add/remove/rename). (#571)  Also
+        // pushes the radio's built-in transverter capabilities so the
+        // band menu surfaces 4m/2m on FLEX-6500 / FLEX-6700 (#695).
         auto refreshXvtr = [this]() {
             if (!m_radioModel.isConnected()) return;
             QVector<SpectrumOverlayMenu::XvtrBand> xvtrBands;
@@ -8354,8 +8356,12 @@ void MainWindow::onConnectionStateChanged(bool connected)
                 if (x.isValid)
                     xvtrBands.append({x.name, x.rfFreq});
             }
-            for (auto* applet : m_panStack->allApplets())
-                applet->spectrumWidget()->overlayMenu()->setXvtrBands(xvtrBands);
+            const ModelCapabilities caps = m_radioModel.capabilities();
+            for (auto* applet : m_panStack->allApplets()) {
+                auto* menu = applet->spectrumWidget()->overlayMenu();
+                menu->setRadioCapabilities(caps);
+                menu->setXvtrBands(xvtrBands);
+            }
         };
         QTimer::singleShot(2000, this, refreshXvtr);
         connect(&m_radioModel, &RadioModel::infoChanged, this, refreshXvtr);

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -90,7 +90,17 @@ static constexpr BandGridEntry BAND_GRID[] = {
     {"2200", "2200m", 0.1375, "CW"},    // 13
     {"630",  "630m",  0.475,  "CW"},    // 14
     {"XVTR", "",      0.0,    ""},      // 15
+    // Built-in transverter bands — appended at the end so HF/utility
+    // indices stay stable.  Surfaced conditionally via the radio's
+    // ModelCapabilities (#695).
+    {"4",    "4m",   70.200,  "USB"},   // 16 — FLEX-6500 (Region 1) + FLEX-6700
+    {"2",    "2m",  144.200,  "USB"},   // 17 — FLEX-6700
 };
+
+// Indices into BAND_GRID for the built-in transverter bands.  Used by
+// the conditional VHF row in setXvtrBands().
+constexpr int kBandIdx4m = 16;
+constexpr int kBandIdx2m = 17;
 
 SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
     : QWidget(parent)
@@ -1252,8 +1262,23 @@ void SpectrumOverlayMenu::setRfGainRange(int low, int high, int step)
             .arg(low).arg(high > 0 ? "+" : "").arg(high).arg(step));
 }
 
+void SpectrumOverlayMenu::setRadioCapabilities(ModelCapabilities caps)
+{
+    if (m_radioCapabilities.has4Meters == caps.has4Meters
+        && m_radioCapabilities.has2Meters == caps.has2Meters) {
+        return;  // No change — skip the rebuild.
+    }
+    m_radioCapabilities = caps;
+    // Delegate to setXvtrBands which already handles the full rebuild;
+    // pass the cached XVTR list so we don't lose configured external
+    // transverters when the model capability flags change.
+    setXvtrBands(m_lastXvtrBands);
+}
+
 void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
 {
+    m_lastXvtrBands = bands;
+
     const bool bandPanelWasVisible = m_bandPanel && m_bandPanel->isVisible();
     const QPoint bandPanelPos = m_bandPanel ? m_bandPanel->pos()
                                             : QPoint(x() + width(), y());
@@ -1304,23 +1329,40 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
         {9, 10, -1},    // 10, 6
     };
 
+    auto makeBandBtn = [&](int idx) {
+        auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
+        btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
+        btn->setStyleSheet(bandBtnStyle);
+        const QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
+        const double  freq = BAND_GRID[idx].freqMhz;
+        const QString mode = QString::fromLatin1(BAND_GRID[idx].mode);
+        connect(btn, &QPushButton::clicked, this, [this, bandName, freq, mode]() {
+            hideAllSubPanels();
+            emit bandSelected(bandName, freq, mode);
+        });
+        return btn;
+    };
+
     int row = 0;
     for (int r = 0; r < 4; ++r) {
         for (int col = 0; col < 3; ++col) {
             int idx = hfLayout[r][col];
             if (idx < 0) continue;
-            auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
-            btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-            btn->setStyleSheet(bandBtnStyle);
-            QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
-            double freq = BAND_GRID[idx].freqMhz;
-            QString mode = QString::fromLatin1(BAND_GRID[idx].mode);
-            connect(btn, &QPushButton::clicked, this, [this, bandName, freq, mode]() {
-                hideAllSubPanels();
-                emit bandSelected(bandName, freq, mode);
-            });
-            grid->addWidget(btn, row, col);
+            grid->addWidget(makeBandBtn(idx), row, col);
         }
+        ++row;
+    }
+
+    // Built-in transverter bands (4m / 2m) — surfaced for radios that
+    // report the corresponding capability flag (FLEX-6500 Region 1: 4m;
+    // FLEX-6700: 4m + 2m).  Styled identically to HF bands per #695
+    // (these are native radio hardware, not user-configured XVTRs).
+    if (m_radioCapabilities.has4Meters || m_radioCapabilities.has2Meters) {
+        int col = 0;
+        if (m_radioCapabilities.has4Meters)
+            grid->addWidget(makeBandBtn(kBandIdx4m), row, col++);
+        if (m_radioCapabilities.has2Meters)
+            grid->addWidget(makeBandBtn(kBandIdx2m), row, col++);
         ++row;
     }
 

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -68,6 +68,12 @@ public:
     // Populate XVTR band sub-panel
     struct XvtrBand { QString name; double rfFreqMhz; };
     void setXvtrBands(const QVector<XvtrBand>& bands);
+
+    // Surface the connected radio's built-in transverter bands (4m on
+    // FLEX-6500 Region 1, 4m + 2m on FLEX-6700) in the band menu.  Pass
+    // a default-constructed value when disconnected — the conditional
+    // VHF row will disappear.  Triggers a band-panel rebuild. (#695)
+    void setRadioCapabilities(ModelCapabilities caps);
     void syncDaxIqChannel(int channel);
     // DSP button accessors and the DSP sub-panel were removed — radio-
     // side DSP lives on VfoWidget only, client-side DSP lives on the
@@ -169,6 +175,13 @@ private:
     QWidget* m_xvtrPanel{nullptr};
     bool m_xvtrPanelVisible{false};
     QVector<QPushButton*> m_xvtrBandBtns;
+
+    // Cached state for band-panel rebuilds — setXvtrBands() and
+    // setRadioCapabilities() each store their argument and trigger
+    // a rebuild so either input changing produces a correct panel
+    // without the caller needing to re-supply the other half. (#695)
+    QVector<XvtrBand>  m_lastXvtrBands;
+    ModelCapabilities  m_radioCapabilities;
 
     // ANT sub-panel
     QWidget*     m_antPanel{nullptr};

--- a/src/models/ModelCapabilities.cpp
+++ b/src/models/ModelCapabilities.cpp
@@ -1,0 +1,53 @@
+#include "ModelCapabilities.h"
+
+namespace AetherSDR {
+
+namespace {
+
+struct Entry {
+    const char* model;       // FlexLib model-string key
+    ModelCapabilities caps;
+};
+
+// Mirrors FlexLib/ModelInfo.cs Has4Meters / Has2Meters columns.  Keep
+// this table in sync with FlexLib when Flex ships a new model — the
+// tests/model_capabilities_test harness will fail loudly if a flag
+// drifts away from the upstream source.
+//
+// Ordering matters: capabilitiesFor() returns the first substring
+// match, so longer/suffix variants (FLEX-6400M, FLEX-6700R) must come
+// before their base model (FLEX-6400, FLEX-6700) so that an exact
+// "FLEX-6700R" status string doesn't match "FLEX-6700" first.
+constexpr Entry kTable[] = {
+    {"FLEX-6300",  {false, false}},
+    {"FLEX-6400M", {false, false}},
+    {"FLEX-6400",  {false, false}},
+    {"FLEX-6500",  {true,  false}},  // Region 1 4m mod
+    {"FLEX-6600M", {false, false}},
+    {"FLEX-6600",  {false, false}},
+    {"FLEX-6700R", {false, false}},  // Receive-only, per FlexLib
+    {"FLEX-6700",  {true,  true }},  // Both built-in
+    {"FLEX-8400M", {false, false}},
+    {"FLEX-8400",  {false, false}},
+    {"FLEX-8600M", {false, false}},
+    {"FLEX-8600",  {false, false}},
+    {"AU-520",     {false, false}},
+    {"ML-380",     {false, false}},
+    {"CL-200",     {false, false}},
+    {"RT-100",     {false, false}},
+};
+
+} // namespace
+
+ModelCapabilities capabilitiesFor(const QString& model)
+{
+    for (const auto& entry : kTable) {
+        if (model.contains(QString::fromLatin1(entry.model),
+                           Qt::CaseInsensitive)) {
+            return entry.caps;
+        }
+    }
+    return {};
+}
+
+} // namespace AetherSDR

--- a/src/models/ModelCapabilities.h
+++ b/src/models/ModelCapabilities.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+// Per-model feature flags mirroring FlexLib/ModelInfo.cs (Has2Meters,
+// Has4Meters, ...).  Authority for any UI surface that varies by model
+// capability — the band selector in the Spectrum Overlay Band menu is
+// the first consumer (#695), additional flags should be added here as
+// more `model.contains("6700")`-style checks get migrated.
+struct ModelCapabilities {
+    bool has4Meters{false};  // Built-in 70 MHz transverter (FLEX-6500 Region 1, FLEX-6700)
+    bool has2Meters{false};  // Built-in 144 MHz transverter (FLEX-6700)
+};
+
+// Returns capabilities for the given model string.  Uses substring match
+// (case-insensitive) so vendor suffixes like "FLEX-6700/A" still resolve
+// to the 6700 entry.  Unknown models default to all-false — forward-
+// compatible for radios released after this build.
+ModelCapabilities capabilitiesFor(const QString& model);
+
+} // namespace AetherSDR

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -20,6 +20,7 @@
 #include "DaxIqModel.h"
 #include "NavtexModel.h"
 #include "MemoryEntry.h"
+#include "ModelCapabilities.h"
 #include "RadioStatusOwnership.h"
 
 #include <QObject>
@@ -131,6 +132,14 @@ public:
     // Max slices reported by radio
     int maxSlices() const { return m_maxSlices; }
     static int maxSlicesForModel(const QString& model);
+
+    // Per-model feature flags from the central ModelCapabilities table.
+    // First consumer is the band selector (#695); future model-conditional
+    // UI should pull from here rather than adding more model.contains()
+    // checks.
+    ModelCapabilities capabilities() const {
+        return capabilitiesFor(m_model);
+    }
 
     // Returns true for BigBend/DragonFire-platform radios (8400, 8600,
     // AU-series, ML-series, CL-series, RT-series) that support the extended

--- a/tests/model_capabilities_test.cpp
+++ b/tests/model_capabilities_test.cpp
@@ -1,0 +1,100 @@
+// Verifies the per-model feature-flag table in ModelCapabilities mirrors
+// FlexLib/ModelInfo.cs row-for-row for Has4Meters / Has2Meters (#695).
+// Catches drift if FlexLib ever flips a flag — re-sync the C++ table
+// and update this test together.
+
+#include "models/ModelCapabilities.h"
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    return condition;
+}
+
+} // namespace
+
+int main()
+{
+    int failures = 0;
+
+    // Exact model strings from FlexLib/ModelInfo.cs.  Expected flags
+    // copied directly from that file's Has4Meters / Has2Meters columns.
+    struct Row { const char* model; bool has4m; bool has2m; };
+    constexpr Row kExpected[] = {
+        {"FLEX-6300",  false, false},
+        {"FLEX-6400",  false, false},
+        {"FLEX-6400M", false, false},
+        {"FLEX-6500",  true,  false},
+        {"FLEX-6600",  false, false},
+        {"FLEX-6600M", false, false},
+        {"FLEX-6700",  true,  true },
+        {"FLEX-6700R", false, false},
+        {"FLEX-8400",  false, false},
+        {"FLEX-8400M", false, false},
+        {"FLEX-8600",  false, false},
+        {"FLEX-8600M", false, false},
+        {"AU-520",     false, false},
+        {"ML-380",     false, false},
+        {"CL-200",     false, false},
+        {"RT-100",     false, false},
+    };
+
+    for (const auto& row : kExpected) {
+        const ModelCapabilities caps = capabilitiesFor(QString::fromLatin1(row.model));
+        if (!expect(caps.has4Meters == row.has4m,
+                    (std::string(row.model) + ": has4Meters").c_str()))
+            ++failures;
+        if (!expect(caps.has2Meters == row.has2m,
+                    (std::string(row.model) + ": has2Meters").c_str()))
+            ++failures;
+    }
+
+    // Substring match — vendor suffixes like "FLEX-6700/A" should still
+    // resolve to the 6700 row.
+    {
+        const auto caps = capabilitiesFor(QStringLiteral("FLEX-6700/A"));
+        if (!expect(caps.has4Meters && caps.has2Meters,
+                    "FLEX-6700/A resolves to 6700 row"))
+            ++failures;
+    }
+
+    // Case-insensitive — the model string the radio reports is upper-
+    // case today but downstream code shouldn't have to rely on that.
+    {
+        const auto caps = capabilitiesFor(QStringLiteral("flex-6700"));
+        if (!expect(caps.has4Meters && caps.has2Meters,
+                    "lowercase model resolves to 6700 row"))
+            ++failures;
+    }
+
+    // Unknown model — default-init capabilities, no UI surfaces.
+    // Forward-compat for radios released after this build.
+    {
+        const auto caps = capabilitiesFor(QStringLiteral("FLEX-9999"));
+        if (!expect(!caps.has4Meters && !caps.has2Meters,
+                    "Unknown model returns default-false capabilities"))
+            ++failures;
+    }
+
+    // Empty / disconnected state should not crash and should return
+    // default capabilities.
+    {
+        const auto caps = capabilitiesFor(QString());
+        if (!expect(!caps.has4Meters && !caps.has2Meters,
+                    "Empty model string returns default-false capabilities"))
+            ++failures;
+    }
+
+    if (failures == 0) {
+        std::cout << "\nAll model-capability tests passed.\n";
+        return 0;
+    }
+    std::cout << "\n" << failures << " test(s) failed.\n";
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements [the plan posted to #695](https://github.com/aethersdr/AetherSDR/issues/695#issuecomment-4468088524).

FLEX-6500 (Region 1 mod) has a built-in 4m transverter; FLEX-6700 has both 4m and 2m. These are native radio hardware, not user-configurable XVTRs — click the band button and tune, no XVTR-tab setup required.

## Changes

- `src/models/ModelCapabilities.{h,cpp}` — table mirroring FlexLib `ModelInfo.cs` (`Has4Meters`, `Has2Meters`). Substring-matching lookup with R-variants ordered before base models so `FLEX-6700R` doesn't accidentally claim 6700 caps. Unknown models default to all-false (forward-compat).
- `RadioModel::capabilities()` — thin accessor.
- `SpectrumOverlayMenu` — new `setRadioCapabilities()` slot caches flags and triggers band-panel rebuild; existing `setXvtrBands()` path inserts a conditional 4m/2m row between HF and user-XVTR rows, styled identically to HF bands.
- `MainWindow::refreshXvtr` lambda now pushes both caps and XVTR list on every `infoChanged`, so capability changes on (re)connect propagate to all open panadapter menus.
- `tests/model_capabilities_test` — 36 assertions verifying table against FlexLib row-for-row + substring/case-insensitive/unknown-model behavior. **All passing locally.**

## Scope

Intentionally narrow: only the 2m/4m checks migrate into `ModelCapabilities`. Existing `model.contains(\"6700\")` checks for slice count, dual-SCU, has-loop-B stay where they are — can be opportunistically migrated in follow-ups.

## Test plan

- [x] Local build clean (395/395)
- [x] \`./build/model_capabilities_test\` — all 36 assertions pass
- [ ] Manual on FLEX-6700: Band menu shows 4m + 2m row between 6m and WWV; click 2m tunes to 144.200 USB; click 4m tunes to 70.200 USB. Verify no XVTR config required.
- [ ] Manual on FLEX-6500: only 4m appears.
- [ ] Manual on FLEX-6400/6600: no change to band menu.

Fixes #695. Thanks @Juanjo-EA1CJ for the original report and @wb8cxo for the correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)