### PR TITLE
Make VirtualAudioBridge thread-safe for DAX RX DirectConnection (#2486)

### DIFF
--- a/src/core/VirtualAudioBridge.cpp
+++ b/src/core/VirtualAudioBridge.cpp
@@ -1,6 +1,7 @@
 #include "VirtualAudioBridge.h"
 #include "LogManager.h"
 
+#include <QDateTime>
 #include <QTimer>
 
 #include <fcntl.h>
@@ -87,7 +88,7 @@ static bool openShmSegment(const char* name, int& fd, DaxShmBlock*& block)
 
 bool VirtualAudioBridge::open()
 {
-    if (m_open) return true;
+    if (m_open.load(std::memory_order_acquire)) return true;
 
     // Open 4 RX shared memory segments
     for (int i = 0; i < NUM_CHANNELS; ++i) {
@@ -144,7 +145,7 @@ bool VirtualAudioBridge::open()
     });
     m_txPollTimer->start();
 
-    m_open = true;
+    m_open.store(true, std::memory_order_release);
     qCInfo(lcDax) << "VirtualAudioBridge: opened 4 RX + 1 TX shared memory segments";
     return true;
 }
@@ -156,7 +157,7 @@ void VirtualAudioBridge::close()
         delete m_silenceTimer;
         m_silenceTimer = nullptr;
     }
-    m_transmitting = false;
+    m_transmitting.store(false, std::memory_order_release);
 
     if (m_txPollTimer) {
         m_txPollTimer->stop();
@@ -185,12 +186,12 @@ void VirtualAudioBridge::close()
         m_txShmFd = -1;
     }
 
-    m_open = false;
+    m_open.store(false, std::memory_order_release);
 }
 
 void VirtualAudioBridge::setTransmitting(bool tx)
 {
-    m_transmitting = tx;
+    m_transmitting.store(tx, std::memory_order_release);
 
     if (tx) {
         // Start a timer that feeds silence into all RX shared memory channels
@@ -209,12 +210,35 @@ void VirtualAudioBridge::setTransmitting(bool tx)
     // NOTE: we do NOT stop the silence timer on TX→RX here.
     // The radio hasn't resumed DAX RX audio yet at this point — the
     // interlock is still transitioning (UNKEY_REQUESTED → READY).
-    // The timer is stopped in feedDaxAudio() when real audio arrives.
+    // The timer self-stops on its next tick in feedSilenceToAllChannels()
+    // once m_lastAudioMs indicates real audio has arrived.
 }
 
 void VirtualAudioBridge::feedSilenceToAllChannels()
 {
-    if (!m_open) return;
+    if (!m_open.load(std::memory_order_acquire)) return;
+
+    // Self-stop: if real DAX RX audio arrived in the last 50 ms, the radio
+    // has resumed sending — drop the silence fill and snap each channel's
+    // read position to the writer so the modem hears real audio immediately
+    // (otherwise the HAL plugin would drain ~TX-duration of accumulated
+    // silence first).  This logic used to live in feedDaxAudio() but had to
+    // move here so the audio fast path can run on PanadapterStream's network
+    // thread under Qt::DirectConnection without touching QTimer (QTimer is
+    // thread-affine to the GUI thread).
+    const qint64 nowMs  = QDateTime::currentMSecsSinceEpoch();
+    const qint64 lastMs = m_lastAudioMs.load(std::memory_order_relaxed);
+    if (lastMs != 0 && (nowMs - lastMs) < 50) {
+        m_silenceTimer->stop();
+        m_transmitting.store(false, std::memory_order_release);
+        for (int i = 0; i < NUM_CHANNELS; ++i) {
+            if (m_blocks[i] && m_blocks[i]->active) {
+                const uint32_t wp = m_blocks[i]->writePos.load(std::memory_order_acquire);
+                m_blocks[i]->readPos.store(wp, std::memory_order_release);
+            }
+        }
+        return;
+    }
 
     // Compute the exact number of stereo samples needed based on elapsed
     // wall-clock time since the last tick.  This eliminates cumulative drift
@@ -242,29 +266,20 @@ void VirtualAudioBridge::feedSilenceToAllChannels()
 
 void VirtualAudioBridge::feedDaxAudio(int channel, const QByteArray& pcm)
 {
+    // This slot may run on PanadapterStream's network thread via
+    // Qt::DirectConnection — keep it lock-free and free of Qt-thread-affine
+    // calls.  The silence-timer stop and ring-buffer readPos snap that used
+    // to live here have moved to feedSilenceToAllChannels (GUI-thread tick),
+    // which observes m_lastAudioMs to decide when to self-stop.
     if (channel < 1 || channel > NUM_CHANNELS) return;
 
     auto* block = m_blocks[channel - 1];
     if (!block) return;
 
-    // Real DAX audio has arrived from the radio — stop the silence fill timer.
-    // This bridges the gap between "we asked radio to stop TX" and "radio
-    // actually resumed sending RX audio".
-    if (m_silenceTimer && m_silenceTimer->isActive()) {
-        m_silenceTimer->stop();
-        m_transmitting = false;
-
-        // Skip all buffered silence so the modem hears real audio immediately.
-        // During TX, the silence timer accumulated samples in the ring buffer.
-        // Without this reset, the HAL plugin would read through all that silence
-        // before reaching real audio — causing a perceivable delay after TX.
-        for (int i = 0; i < NUM_CHANNELS; ++i) {
-            if (m_blocks[i] && m_blocks[i]->active) {
-                uint32_t wp = m_blocks[i]->writePos.load(std::memory_order_relaxed);
-                m_blocks[i]->readPos.store(wp, std::memory_order_release);
-            }
-        }
-    }
+    // Note "real audio just arrived" so the GUI-thread silence timer can
+    // stop itself on its next tick.  No locks, no Qt API touched here.
+    m_lastAudioMs.store(QDateTime::currentMSecsSinceEpoch(),
+                        std::memory_order_relaxed);
 
     // Input: float32 stereo PCM @ 24 kHz from the radio (native DAX rate).
     //        After the float32 migration (502b934, b0c49d7), both PCC_IF_NARROW
@@ -274,7 +289,7 @@ void VirtualAudioBridge::feedDaxAudio(int channel, const QByteArray& pcm)
     const auto* samples = reinterpret_cast<const float*>(pcm.constData());
     const int numSamples = pcm.size() / static_cast<int>(sizeof(float));  // total float count (L,R,L,R,...)
 
-    const float chGain = m_channelGain[channel - 1];
+    const float chGain = m_channelGain[channel - 1].load(std::memory_order_relaxed);
     auto& stats = m_rxTiming[channel - 1];
     if (!stats.windowElapsed.isValid())
         stats.windowElapsed.start();

--- a/src/core/VirtualAudioBridge.h
+++ b/src/core/VirtualAudioBridge.h
@@ -41,14 +41,15 @@ public:
 
     bool open();
     void close();
-    bool isOpen() const { return m_open; }
+    bool isOpen() const { return m_open.load(std::memory_order_acquire); }
 
     // DAX output gain (0.0–1.0). Default 0.25 (≈ -12 dB) to avoid
     // overloading digital-mode software like WSJT-X.
     void setGain(float g) { m_gain = std::clamp(g, 0.0f, 1.0f); }
     void setChannelGain(int channel, float g) {
         if (channel >= 1 && channel <= NUM_CHANNELS)
-            m_channelGain[channel - 1] = std::clamp(g, 0.0f, 1.0f);
+            m_channelGain[channel - 1].store(std::clamp(g, 0.0f, 1.0f),
+                                             std::memory_order_relaxed);
     }
     void setTxGain(float g) { m_txGain = std::clamp(g, 0.0f, 1.0f); }
     float gain() const { return m_gain; }
@@ -80,9 +81,14 @@ private:
         uint32_t peakBacklogSamples{0};
     };
 
-    bool m_open{false};
-    float m_gain{0.5f};  // -6 dB default
-    float m_channelGain[NUM_CHANNELS]{0.5f, 0.5f, 0.5f, 0.5f};
+    // m_open and m_channelGain are read on PanadapterStream's network thread
+    // when feedDaxAudio runs via Qt::DirectConnection (the cross-platform DAX
+    // RX fast path) and written from the GUI thread (open()/close(),
+    // DaxApplet slider).  std::atomic gives the formal happens-before guarantee
+    // that plain bool/float load/store would lack on weakly-ordered archs.
+    std::atomic_bool m_open{false};
+    float m_gain{0.5f};  // -6 dB default — GUI-only
+    std::atomic<float> m_channelGain[NUM_CHANNELS]{0.5f, 0.5f, 0.5f, 0.5f};
     float m_txGain{0.5f};
 
     // RX channels (radio → apps)
@@ -98,9 +104,20 @@ private:
     static QString shmName(int channel);
     void logRxTimingSummary(int channel, DaxShmBlock* block, RxTimingStats& stats);
 
-    bool     m_transmitting{false};
+    std::atomic_bool m_transmitting{false};
     QTimer*  m_silenceTimer{nullptr};
     QElapsedTimer m_silenceElapsed;   // tracks wall-clock time for accurate silence fill
+
+    // Wall-clock timestamp (ms) of the most recent real DAX RX packet on any
+    // channel.  Written lock-free from the audio fast path (feedDaxAudio,
+    // potentially on PanadapterStream's network thread); read by the
+    // GUI-thread silence timer to decide when to self-stop.  Replaces the
+    // old in-feedDaxAudio QTimer::stop() which was unsafe to call cross-thread.
+    std::atomic<qint64> m_lastAudioMs{0};
+
+    // Best-effort diagnostics — currently only touched by feedDaxAudio /
+    // logRxTimingSummary on the same thread.  If a future GUI-thread
+    // inspector reads these, expect torn 64-bit values; atomic-ify then.
     RxTimingStats m_rxTiming[NUM_CHANNELS];
 };
 


### PR DESCRIPTION
## Summary

Fixes #2486

### What was changed

Mirrors the PipeWireAudioBridge thread-safety pattern (#2312) on the macOS audio bridge so PanadapterStream::daxAudioReady → feedDaxAudio can ship cross-platform under Qt::DirectConnection (unblocks #2318).

- `m_open`, `m_transmitting`, `m_channelGain` converted to `std::atomic` so reads on PanadapterStream's network thread are correctly synchronised with GUI-thread writes (open/close, DaxApplet slider)
- Cross-thread `QTimer::stop()` in `feedDaxAudio` replaced with an atomic `m_lastAudioMs` flag
- Silence-stop / readPos-snap cleanup moved into the GUI-thread `feedSilenceToAllChannels` tick

### Recovery note

This PR is being opened manually. The aetherclaude orchestrator (trace 5a19c310) pushed the signed commit at 15:18 PDT but was SIGTERM'd by a deploy.sh race before it could create the PR. Root cause + fix shipped as a follow-up to scripts/deploy.sh; this branch's commit is the orchestrator's own work, unmodified.

---
Generated by AetherClaude (automated agent for AetherSDR) — PR creation completed manually after orchestrator interrupt.