### PR TITLE
fix: parse hex meter num field and handle M-prefix radio messages

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1978,6 +1978,8 @@ MainWindow::MainWindow(QWidget* parent)
             QString("%1 supports a maximum of %2 slices across all connected clients")
                 .arg(model).arg(limit), 4000);
     });
+    connect(&m_radioModel, &RadioModel::radioMessageReceived,
+            this, &MainWindow::onRadioMessage);
     connect(&m_radioModel.spotModel(), &SpotModel::spotsCleared,
             this, &MainWindow::rebuildMemorySpotFeed);
 
@@ -8671,6 +8673,12 @@ void MainWindow::onConnectionError(const QString& msg)
     statusBar()->showMessage("Connection error: " + msg, 5000);
     if (!m_reconnectDlg)
         setPanadapterConnectionAnimation(false);
+}
+
+void MainWindow::onRadioMessage(const QString& text)
+{
+    qCInfo(lcGui) << "Radio M-message:" << text;
+    QMessageBox::warning(this, tr("Radio"), text);
 }
 
 void MainWindow::setPanadapterConnectionAnimation(bool visible, const QString& label)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -122,6 +122,7 @@ private slots:
     // Radio/connection events
     void onConnectionStateChanged(bool connected);
     void onConnectionError(const QString& msg);
+    void onRadioMessage(const QString& text);
     void onSliceAdded(SliceModel* slice);
     void onSliceRemoved(int id);
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2710,6 +2710,12 @@ void RadioModel::handleMemoryStatus(int index, const QMap<QString, QString>& kvs
 
 void RadioModel::onMessageReceived(const ParsedMessage& msg)
 {
+    if (msg.type == MessageType::Message) {
+        qCWarning(lcProtocol) << "Radio M-message:" << msg.object;
+        emit radioMessageReceived(msg.object);
+        return;
+    }
+
     // Meter status uses '#' as KV separator (not spaces), so the normal
     // parseKVs() in CommandParser doesn't handle it.  We intercept the raw
     // status line here and parse it ourselves.
@@ -4380,7 +4386,7 @@ void RadioModel::handleMeterStatus(const QString& rawBody)
         MeterDef def;
         def.index = it.key();
         if (fields.contains("src"))  def.source      = fields["src"];
-        if (fields.contains("num"))  def.sourceIndex  = fields["num"].toInt();
+        if (fields.contains("num"))  def.sourceIndex  = fields["num"].toInt(nullptr, 0);
         if (fields.contains("nam"))  def.name         = fields["nam"];
         if (fields.contains("unit")) def.unit         = fields["unit"];
         if (fields.contains("low"))  def.low          = fields["low"].toDouble();

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -432,6 +432,9 @@ signals:
     void pingReceived();
     // Generic status relay — for dialogs that need to listen for specific objects.
     void statusReceived(const QString& object, const QMap<QString, QString>& kvs);
+    // Emitted when the radio sends an M-prefix informational or warning message
+    // (e.g. FreeDV waveform conflict warnings). Text is plain, ready for display.
+    void radioMessageReceived(const QString& text);
 
 public:
     // Send a raw command to the radio (for dialogs that need direct protocol access).


### PR DESCRIPTION
## Summary

- **Hex meter `num` parse fix** — `RadioModel::handleMeterStatus` used `.toInt()` without a base argument, silently returning 0 for hex values like `0x3B26ABBA` from `EXT_WVF` meters (e.g. FreeDV_SNR). Changed to `.toInt(nullptr, 0)` for auto-base detection.

- **M-prefix message handler** — M-prefix radio messages (e.g. FreeDV Docker waveform conflict warnings) were fully parsed by `CommandParser` but silently discarded in `RadioModel::onMessageReceived` due to the `MessageType::Status`-only guard. They are now logged via `qCWarning(lcProtocol)` and surfaced to the user as a `QMessageBox::warning` dialog in `MainWindow`. Wire format confirmed from pcap capture: plain text body, no KV structure.

## Test plan

- [x] Connect to radio with FreeDV waveform running, single slice in FDVU — no dialog appears (normal operation)
- [x] Switch a second slice to FDVU — `QMessageBox::warning` appears with: *"Only one FDVU or FDVL slice can be active at a time. Non-TX slices have been set to USB and/or LSB."*
- [ ] Confirm `qCWarning(lcProtocol)` log entry for the M-message
- [ ] Confirm FreeDV_SNR meter `num` field parses non-zero (verify via debug log that `sourceIndex` is non-zero for `EXT_WVF` meters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)