### PR TITLE
feat: store tx_slice_mode from transmit status in TransmitModel

### DIFF
--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -30,6 +30,7 @@ void TransmitModel::resetState()
     m_memoriesEnabled = false;
     m_usingMemory = false;
     m_showTxInWaterfall = false;
+    m_txSliceMode.clear();
 
     emit apdStateChanged();
     emit moxChanged(false);
@@ -219,6 +220,10 @@ void TransmitModel::applyTransmitStatus(const QMap<QString, QString>& kvs)
     if (kvs.contains("show_tx_in_waterfall")) {
         bool v = kvs["show_tx_in_waterfall"] == "1";
         if (m_showTxInWaterfall != v) { m_showTxInWaterfall = v; changed = true; }
+    }
+    if (kvs.contains("tx_slice_mode")) {
+        QString v = kvs["tx_slice_mode"];
+        if (m_txSliceMode != v) { m_txSliceMode = v; changed = true; emit txSliceModeChanged(v); }
     }
 
     if (changed) emit stateChanged();

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -98,7 +98,8 @@ public:
     int     rcaTxReqPolarity() const { return m_rcaTxReqPolarity; }
     int     maxPowerLevel()  const { return m_maxPowerLevel; }
     void    setMaxPowerLevel(int w) { if (m_maxPowerLevel != w) { m_maxPowerLevel = w; emit maxPowerLevelChanged(w); } }
-    QString tuneMode()       const { return m_tuneMode; }
+    QString tuneMode()        const { return m_tuneMode; }
+    QString txSliceMode()     const { return m_txSliceMode; }
     bool    showTxInWaterfall() const { return m_showTxInWaterfall; }
 
     // ── APD getters ─────────────────────────────────────────────────────────
@@ -252,6 +253,9 @@ signals:
     void apdSamplerChanged(const QString& txAnt);
     void apdEqualizerResetReceived();
     void maxPowerLevelChanged(int maxWatts);
+    // Emitted when the radio reports the TX slice mode (e.g. "FDVU", "FDVL", "USB").
+    // Value is empty string until the first transmit status is received.
+    void txSliceModeChanged(const QString& mode);
     void commandReady(const QString& cmd);
     void pttBlocked(const QString& message);
     // Quindar active-phase signal (#2262).  Emitted on the GUI thread
@@ -338,6 +342,7 @@ private:
     int     m_rcaTxReqPolarity{0};
     int     m_maxPowerLevel{100};
     QString m_tuneMode{"single_tone"};
+    QString m_txSliceMode;   // empty until first transmit status; "FDVU", "FDVL", "USB", etc.
     bool    m_showTxInWaterfall{false};
 
     // ATU state


### PR DESCRIPTION
## Background

When the active TX slice switches to a FreeDV mode, the radio broadcasts:

```
transmit tx_slice_mode=FDVU
```

This key arrives via the existing `object == "transmit"` → `applyTransmitStatus()` route in `RadioModel` alongside all other transmit keys (`rfpower`, `tunepower`, `tune_mode`, etc.). Prior to this PR, it was silently dropped — confirmed by grepping the entire codebase for `tx_slice_mode`, which returned zero results. Storing it is the correct data-layer fix that enables any future TX status indicator (e.g. a "FreeDV TX" chip in the panadapter overlay or TX applet) to consume it without revisiting `TransmitModel`.

## Summary

- Added `m_txSliceMode` member to `TransmitModel` (empty until first transmit status received)
- Added `txSliceMode()` getter
- Added `txSliceModeChanged(const QString& mode)` signal, emitted immediately on change — consistent with the `maxPowerLevelChanged` and `txFilterCutoffChanged` pattern rather than batched into `stateChanged`, so consumers that specifically care about FreeDV TX mode get a targeted signal
- `tx_slice_mode` parsed in `applyTransmitStatus()` alongside `tune_mode` and `show_tx_in_waterfall`
- Cleared in `resetState()` on disconnect so a stale `"FDVU"` value does not persist if the user reconnects to a radio without the FreeDV waveform installed

No UI surface is added in this PR.

## Test plan

- [ ] Connect to radio with FreeDV waveform running, switch active slice to FDVU — confirm `txSliceModeChanged("FDVU")` fires (verify via temporary `qCDebug` in `applyTransmitStatus`)
- [ ] Switch slice back to USB — confirm `txSliceModeChanged("USB")` fires
- [ ] Disconnect and reconnect — confirm `txSliceMode()` returns empty string after `resetState()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)