### PR TITLE
feat(gui): FreeDV sync/SNR indicator in VFO widget for FDVU/FDVL slices

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9218,6 +9218,12 @@ void MainWindow::onSliceAdded(SliceModel* s)
                     QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setDfnrEnabled(false); });
             }
         }
+#ifdef HAVE_RADE
+        if (mode.startsWith("FDV"))
+            activateFdvDisplay(s->sliceId());
+        else if (m_fdvDisplaySliceId == s->sliceId())
+            deactivateFdvDisplay();
+#endif
     });
 
     // Update RTTY mark/space lines on spectrum when mark/shift changes
@@ -9266,6 +9272,12 @@ void MainWindow::onSliceAdded(SliceModel* s)
 
     // NR2/RN2/RADE are now wired permanently in wireVfoWidget — no
     // special handling needed here for active slice timing.
+
+#ifdef HAVE_RADE
+    // Reconnect scenario: slice may already be in FDVU/FDVL when AetherSDR connects
+    if (s->mode().startsWith("FDV"))
+        activateFdvDisplay(s->sliceId());
+#endif
 
     // Show DIV button on dual-SCU radios
     {
@@ -9362,6 +9374,9 @@ void MainWindow::onSliceRemoved(int id)
     // If the RADE slice was closed, deactivate RADE
     if (id == m_radeSliceId)
         deactivateRADE();
+    // If the FreeDV display slice was closed, deactivate the FDV display
+    if (id == m_fdvDisplaySliceId)
+        deactivateFdvDisplay();
 #endif
 
     // If the split TX slice was closed, disable split
@@ -13763,6 +13778,90 @@ void MainWindow::onRadeSliceModeChanged(const QString& mode)
     // if the mode leaves that family so audio_mute is always restored.
     if (mode != "DIGU" && mode != "DIGL")
         deactivateRADE();
+}
+
+void MainWindow::activateFdvDisplay(int sliceId)
+{
+    if (m_fdvDisplaySliceId == sliceId)
+        return;
+
+    if (m_fdvDisplaySliceId >= 0)
+        deactivateFdvDisplay();
+
+    m_fdvDisplaySliceId = sliceId;
+
+    auto* s = m_radioModel.slice(sliceId);
+    if (!s) return;
+
+    if (auto* sw = spectrumForSlice(s)) {
+        if (auto* vfo = sw->vfoWidget(sliceId)) {
+            vfo->setRadeActive(true, QStringLiteral("FreeDV"));
+            vfo->setRadeSynced(false);
+        }
+    }
+
+    m_fdvSnrMeterIndex = m_radioModel.meterModel()
+                             .findMeter("EXT_WVF", "FreeDV_SNR");
+
+    connect(&m_radioModel.meterModel(), &MeterModel::meterUpdated,
+            this, &MainWindow::onFdvMeterUpdated,
+            Qt::UniqueConnection);
+    connect(&m_radioModel, &RadioModel::metersChanged,
+            this, &MainWindow::onFdvMetersChanged,
+            Qt::UniqueConnection);
+
+    m_fdvSynced = false;
+    qCInfo(lcGui) << "MainWindow: FreeDV display activated on slice" << sliceId;
+}
+
+void MainWindow::deactivateFdvDisplay()
+{
+    if (m_fdvDisplaySliceId < 0)
+        return;
+
+    if (auto* s = m_radioModel.slice(m_fdvDisplaySliceId)) {
+        if (auto* sw = spectrumForSlice(s)) {
+            if (auto* vfo = sw->vfoWidget(m_fdvDisplaySliceId))
+                vfo->setRadeActive(false);
+        }
+    }
+
+    disconnect(&m_radioModel.meterModel(), &MeterModel::meterUpdated,
+               this, &MainWindow::onFdvMeterUpdated);
+    disconnect(&m_radioModel, &RadioModel::metersChanged,
+               this, &MainWindow::onFdvMetersChanged);
+
+    m_fdvDisplaySliceId = -1;
+    m_fdvSnrMeterIndex  = -1;
+    m_fdvSynced         = false;
+    qCInfo(lcGui) << "MainWindow: FreeDV display deactivated";
+}
+
+void MainWindow::onFdvMeterUpdated(int index, float value)
+{
+    if (index != m_fdvSnrMeterIndex || m_fdvDisplaySliceId < 0)
+        return;
+
+    auto* s = m_radioModel.slice(m_fdvDisplaySliceId);
+    if (!s) return;
+    auto* sw = spectrumForSlice(s);
+    if (!sw) return;
+    auto* vfo = sw->vfoWidget(m_fdvDisplaySliceId);
+    if (!vfo) return;
+
+    const bool synced = (value > -98.9f);
+    if (synced != m_fdvSynced) {
+        m_fdvSynced = synced;
+        vfo->setRadeSynced(synced);
+    }
+    if (synced)
+        vfo->setRadeSnr(value);
+}
+
+void MainWindow::onFdvMetersChanged()
+{
+    m_fdvSnrMeterIndex = m_radioModel.meterModel()
+                             .findMeter("EXT_WVF", "FreeDV_SNR");
 }
 
 void MainWindow::startFreeDvReporting(int sliceId)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -713,6 +713,14 @@ private:
     void onRadeSliceModeChanged(const QString& mode);
     void startFreeDvReporting(int sliceId);
     void stopFreeDvReporting(int sliceId);
+    // FreeDV Docker waveform sync/SNR display state
+    int  m_fdvDisplaySliceId{-1};
+    int  m_fdvSnrMeterIndex{-1};
+    bool m_fdvSynced{false};
+    void activateFdvDisplay(int sliceId);
+    void deactivateFdvDisplay();
+    void onFdvMeterUpdated(int index, float value);
+    void onFdvMetersChanged();
 #endif
 
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -3996,8 +3996,9 @@ bool VfoWidget::eventFilter(QObject* obj, QEvent* event)
 // ── RADE status indicator ─────────────────────────────────────────────────
 
 #ifdef HAVE_RADE
-void VfoWidget::setRadeActive(bool on)
+void VfoWidget::setRadeActive(bool on, const QString& label)
 {
+    m_radeLabel = label;
     m_radeActive = on;
     if (m_radeStatusLabel) {
         m_radeStatusLabel->setVisible(on);
@@ -4024,7 +4025,7 @@ void VfoWidget::setRadeSynced(bool synced)
     if (!m_radeActive) return;
     const QString led = synced ? "<font color='#00ff88'>\u25CF</font>"
                                : "<font color='#505050'>\u25CB</font>";
-    m_radeStatusLabel->setText("RADE " + led);
+    m_radeStatusLabel->setText(m_radeLabel + " " + led);
     if (!synced) {
         m_radeSnrLabel->setStyleSheet(
             "QLabel { color: #8090a0; font-size: 10px;"

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -84,7 +84,7 @@ public:
     void setCollapsed(bool collapsed);
 
 #ifdef HAVE_RADE
-    void setRadeActive(bool on);
+    void setRadeActive(bool on, const QString& label = QStringLiteral("RADE"));
     void setRadeSynced(bool synced);
     void setRadeSnr(float snrDb);
     void setRadeFreqOffset(float hz);
@@ -353,6 +353,7 @@ private:
     QLabel*  m_radeSnrLabel{nullptr};       // "12dB" or "---"
     QLabel*  m_radeOffsetLabel{nullptr};    // "+125Hz" — hidden when no data
     bool     m_radeActive{false};
+    QString  m_radeLabel{"RADE"};          // badge prefix: "RADE" or "FreeDV"
 #endif
 
     static constexpr int WIDGET_W = 252;


### PR DESCRIPTION
## Summary

When a slice enters FDVU or FDVL mode (FreeDV Docker waveform, firmware v4.2.18+), the VFO widget now shows a live sync/SNR status panel — reusing the existing RADE sync LED and SNR display infrastructure.

- **Badge label** displays "FreeDV" instead of "RADE"
- **Sync LED** (green = synced, grey = not synced) driven by `FreeDV_SNR` meter (`EXT_WVF` source) using the SNR == -99 sentinel
- **SNR dB readout** shown while synced (yellow <5 dB, green ≥5 dB); "---" while not synced
- Callsign and freq-offset fields intentionally left blank (waveform does not provide them via the meter bus)
- Activates/deactivates on mode change (FDVU/FDVL ↔ anything else), slice removal, and reconnect
- Handles waveform restarts: re-resolves the dynamic `FreeDV_SNR` meter index on `RadioModel::metersChanged`

## Implementation

**`VfoWidget`** — `setRadeActive(bool on, const QString& label = "RADE")`: optional label parameter so all existing RADE callers are unaffected.

**`MainWindow`** — new private methods `activateFdvDisplay`, `deactivateFdvDisplay`, `onFdvMeterUpdated`, `onFdvMetersChanged` (all inside `#ifdef HAVE_RADE`). Hooked into the existing `modeChanged` lambda in `onSliceAdded`, `onSliceRemoved`, and after `wireVfoWidget` for the reconnect scenario.

## Test plan

- [x] Connect to radio with FreeDV Docker waveform installed
- [x] Set a slice to FDVU — confirm "FreeDV ○" badge appears in VFO widget
- [ ] With waveform synced to a station — confirm LED turns green and SNR dB updates
- [ ] Verify SNR text is yellow below 5 dB and green at 5 dB and above
- [x] Change slice back to USB — confirm FreeDV panel hides
- [x] Close the FDVU slice — confirm no crash, panel gone
- [x] Disconnect and reconnect with a slice already in FDVU — confirm panel appears on reconnect

> **Draft:** Opened as draft pending live FreeDV traffic test to verify sync LED and SNR meter flow end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)