### PR TITLE
feat(gui): Waveforms dialog under File menu for WFP status and management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,7 @@ set(GUI_SOURCES
     src/gui/SpotSettingsDialog.cpp
     src/gui/AetherDspDialog.cpp
     src/gui/AetherDspWidget.cpp
+    src/gui/WaveformsDialog.cpp
     src/gui/ClientRxDspApplet.cpp
     src/gui/DspParamPopup.cpp
     src/gui/DxClusterDialog.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -107,6 +107,7 @@
 #endif
 #include "AetherDspDialog.h"
 #include "AetherDspWidget.h"
+#include "WaveformsDialog.h"
 #include "ClientRxDspApplet.h"
 #include "DspParamPopup.h"
 #include "FramelessResizer.h"
@@ -6242,6 +6243,14 @@ void MainWindow::resetMissingAudioDevicesToDefault(bool resetInput,
 void MainWindow::buildMenuBar()
 {
     auto* fileMenu = menuBar()->addMenu("&File");
+
+    auto* waveformsAct = fileMenu->addAction("Waveforms...");
+    waveformsAct->setMenuRole(QAction::NoRole);
+    connect(waveformsAct, &QAction::triggered, this, [this] {
+        showOrRaisePersistent(m_waveformsDialog, &m_radioModel.flexWaveformModel());
+    });
+
+    fileMenu->addSeparator();
     auto* quitAct = fileMenu->addAction("&Quit");
     quitAct->setShortcut(QKeySequence::Quit);
     connect(quitAct, &QAction::triggered, qApp, &QApplication::quit);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -83,6 +83,7 @@ class ProfileImportExportDialog;
 class NetworkDiagnosticsDialog;
 class MemoryDialog;
 class AetherDspDialog;
+class WaveformsDialog;
 class DxClusterDialog;
 class Ax25HfPacketDecodeDialog;
 class MidiMappingDialog;
@@ -498,6 +499,7 @@ private:
     QPointer<Ax25HfPacketDecodeDialog> m_ax25HfPacketDecodeDialog;
     QPointer<WhatsNewDialog> m_whatsNewDialog;
     QPointer<AetherDspDialog> m_dspDialog;
+    QPointer<WaveformsDialog> m_waveformsDialog;
     QPointer<ProfileManagerDialog> m_profileManagerDialog;
     QPointer<ProfileImportExportDialog> m_profileImportExportDialog;
 #ifdef HAVE_MIDI

--- a/src/gui/WaveformsDialog.cpp
+++ b/src/gui/WaveformsDialog.cpp
@@ -1,0 +1,156 @@
+#include "WaveformsDialog.h"
+#include "models/FlexWaveformModel.h"
+
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+WaveformsDialog::WaveformsDialog(FlexWaveformModel* model, QWidget* parent)
+    : PersistentDialog(tr("Waveforms"), QStringLiteral("WaveformsDialogGeometry"), parent)
+    , m_model(model)
+{
+    setMinimumSize(440, 200);
+
+    auto* root = new QVBoxLayout(bodyWidget());
+    root->setSpacing(8);
+    root->setContentsMargins(10, 8, 10, 10);
+
+    // ── WFP status bar ────────────────────────────────────────────────────────
+    auto* statusFrame = new QFrame;
+    statusFrame->setFrameShape(QFrame::StyledPanel);
+    auto* statusRow = new QHBoxLayout(statusFrame);
+    statusRow->setContentsMargins(8, 4, 8, 4);
+
+    m_statusLabel = new QLabel;
+    m_statusLabel->setTextFormat(Qt::RichText);
+    statusRow->addWidget(m_statusLabel);
+    statusRow->addStretch();
+
+    root->addWidget(statusFrame);
+
+    // ── Waveform list (scrollable) ────────────────────────────────────────────
+    auto* scroll = new QScrollArea;
+    scroll->setWidgetResizable(true);
+    scroll->setFrameShape(QFrame::NoFrame);
+
+    m_listContainer = new QWidget;
+    m_listLayout = new QVBoxLayout(m_listContainer);
+    m_listLayout->setSpacing(4);
+    m_listLayout->setContentsMargins(0, 0, 0, 0);
+    m_listLayout->addStretch();
+
+    scroll->setWidget(m_listContainer);
+    root->addWidget(scroll, 1);
+
+    // ── Wire model signals ────────────────────────────────────────────────────
+    connect(m_model, &FlexWaveformModel::wfpStatusChanged,
+            this, &WaveformsDialog::refreshStatus);
+    connect(m_model, &FlexWaveformModel::waveformsChanged,
+            this, &WaveformsDialog::refreshWaveformList);
+
+    refreshStatus();
+    refreshWaveformList();
+}
+
+void WaveformsDialog::refreshStatus()
+{
+    const QString powerColor = m_model->wfpPowered() ? QStringLiteral("#00ff88")
+                                                      : QStringLiteral("#505050");
+    const QString readyColor = m_model->wfpReady()   ? QStringLiteral("#00ff88")
+                                                      : QStringLiteral("#505050");
+    const QString powerText  = m_model->wfpPowered() ? tr("ON")  : tr("OFF");
+    const QString readyText  = m_model->wfpReady()   ? tr("READY") : tr("NOT READY");
+
+    QString ip = m_model->wfpIpAddress();
+    if (ip.isEmpty())
+        ip = QStringLiteral("--");
+
+    m_statusLabel->setText(
+        QStringLiteral("WFP:&nbsp;&nbsp;"
+                       "<font color='%1'>&#9679;</font> %2"
+                       "&nbsp;&nbsp;&nbsp;"
+                       "<font color='%3'>&#9679;</font> %4"
+                       "&nbsp;&nbsp;&nbsp;"
+                       "IP: %5")
+            .arg(powerColor, powerText, readyColor, readyText, ip));
+}
+
+void WaveformsDialog::refreshWaveformList()
+{
+    // Remove all items except the trailing stretch
+    while (m_listLayout->count() > 1) {
+        QLayoutItem* item = m_listLayout->takeAt(0);
+        if (QWidget* w = item->widget())
+            w->deleteLater();
+        delete item;
+    }
+
+    const QList<FlexWaveformEntry>& waveforms = m_model->waveforms();
+
+    if (waveforms.isEmpty()) {
+        auto* placeholder = new QLabel(tr("No waveforms installed"));
+        placeholder->setAlignment(Qt::AlignCenter);
+        placeholder->setStyleSheet(QStringLiteral("color: #8090a0;"));
+        m_listLayout->insertWidget(0, placeholder);
+        return;
+    }
+
+    for (const FlexWaveformEntry& entry : waveforms) {
+        const QString name    = entry.name;
+        const bool isContainer = entry.isContainer;
+
+        auto* row = new QFrame;
+        row->setFrameShape(QFrame::StyledPanel);
+        auto* rowLayout = new QHBoxLayout(row);
+        rowLayout->setContentsMargins(8, 4, 8, 4);
+        rowLayout->setSpacing(8);
+
+        // Name + version
+        auto* nameLabel = new QLabel(
+            QStringLiteral("<b>%1</b> %2").arg(name, entry.version));
+        nameLabel->setTextFormat(Qt::RichText);
+        rowLayout->addWidget(nameLabel, 1);
+
+        // Type badge
+        const QString badgeText  = isContainer ? tr("Container") : tr("Waveform");
+        auto* typeLabel = new QLabel(
+            QStringLiteral("<font color='#8090a0'>[%1]</font>").arg(badgeText));
+        typeLabel->setTextFormat(Qt::RichText);
+        rowLayout->addWidget(typeLabel);
+
+        // Restart button
+        auto* restartBtn = new QPushButton(tr("Restart"));
+        restartBtn->setFixedWidth(70);
+        connect(restartBtn, &QPushButton::clicked, this, [this, name]() {
+            m_model->requestRestart(name);
+        });
+        rowLayout->addWidget(restartBtn);
+
+        // Remove / Uninstall button
+        const QString removeLabel = isContainer ? tr("Remove") : tr("Uninstall");
+        auto* removeBtn = new QPushButton(removeLabel);
+        removeBtn->setFixedWidth(70);
+        connect(removeBtn, &QPushButton::clicked, this, [this, name, isContainer]() {
+            const QString question = isContainer
+                ? tr("Remove the Docker container \"%1\" from the radio?").arg(name)
+                : tr("Uninstall the waveform \"%1\" from the radio?").arg(name);
+            if (QMessageBox::question(this, tr("Confirm"), question) != QMessageBox::Yes)
+                return;
+            if (isContainer)
+                m_model->requestRemoveContainer(name);
+            else
+                m_model->requestUninstall(name);
+        });
+        rowLayout->addWidget(removeBtn);
+
+        m_listLayout->insertWidget(m_listLayout->count() - 1, row);
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/WaveformsDialog.h
+++ b/src/gui/WaveformsDialog.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "PersistentDialog.h"
+
+class QLabel;
+class QVBoxLayout;
+
+namespace AetherSDR {
+
+class FlexWaveformModel;
+
+// Non-modal dialog for WFP status and waveform management (File → Waveforms).
+// Mirrors the SmartSDR File → Waveforms panel: shows WFP power/ready/IP at the
+// top and one row per installed waveform with Restart and Remove/Uninstall
+// buttons.  Connects directly to FlexWaveformModel signals so it stays live
+// without any MainWindow involvement in refresh.
+class WaveformsDialog : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    explicit WaveformsDialog(FlexWaveformModel* model, QWidget* parent = nullptr);
+
+private:
+    void refreshStatus();
+    void refreshWaveformList();
+
+    FlexWaveformModel* m_model;
+    QLabel*            m_statusLabel{nullptr};
+    QWidget*           m_listContainer{nullptr};
+    QVBoxLayout*       m_listLayout{nullptr};
+};
+
+} // namespace AetherSDR


### PR DESCRIPTION
## Summary

Surfaces the data already collected by `FlexWaveformModel` (merged in #2759) in a non-modal, geometry-persistent dialog at **File → Waveforms**, mirroring SmartSDR's layout and location.

- **WFP status bar** at the top: power indicator (●), ready indicator (●), and IP address — all live-updating via `FlexWaveformModel::wfpStatusChanged`
- **Waveform list**: one row per installed waveform or Docker container, with name, version, and type badge — live-updating via `FlexWaveformModel::waveformsChanged`
- **Restart** button per row — fire-and-forget, no confirmation; sends `waveform restart <name>`
- **Remove** (container) / **Uninstall** (legacy .wfp) button per row — `QMessageBox::question` confirmation before sending `waveform remove_container <name>` or `waveform uninstall <name>`
- Install omitted intentionally — Docker containers are managed at the radio/firmware level, not from the client

## Implementation

`WaveformsDialog` inherits `PersistentDialog` (geometry-persist + frameless-chrome handling) and takes a `FlexWaveformModel*` in its constructor. No refresh logic in `MainWindow` — the dialog wires `FlexWaveformModel` signals directly. `showOrRaisePersistent` handles lazy-construct, raise-if-open, and frameless toggle registration automatically.

## Test plan

- [x] **File → Waveforms** opens dialog; re-triggering raises it rather than opening a second
- [x] WFP status shows correct power/ready state and IP address
- [x] `freedv-flex` (or other container) appears in the list with version and `[Container]` badge
- [ ] **Restart** sends `waveform restart freedv-flex` — visible in radio log
- [ ] **Remove** → cancel → no command sent; **Remove** → confirm → sends `waveform remove_container freedv-flex`
- [ ] Disconnect from radio → list empties, status clears (driven by `FlexWaveformModel::clear()`)
- [x] Frameless mode toggle applies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)