### PR TITLE
Add unit tests for PerfTelemetry (#2500). Principle III.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,6 +505,8 @@ set(CORE_SOURCES
     src/core/SleepInhibitor.cpp
     src/core/MemoryCsvCompat.cpp
     src/core/MemoryRecallPolicy.cpp
+    src/core/tnc/AetherAx25LibmodemShim.cpp
+    src/core/tnc/Ax25FrameFormatter.cpp
 )
 
 if(APPLE)
@@ -560,6 +562,7 @@ set(GUI_SOURCES
     src/gui/VfoWidget.cpp
     src/gui/RadioSetupDialog.cpp
     src/gui/NetworkDiagnosticsDialog.cpp
+    src/gui/Ax25HfPacketDecodeDialog.cpp
     src/gui/PropDashboardDialog.cpp
     src/gui/MemoryCommands.cpp
     src/gui/MemoryBrowsePanel.cpp
@@ -751,6 +754,24 @@ else()
     set_source_files_properties(${GGMORSE_SOURCES} PROPERTIES COMPILE_FLAGS "-w")
 endif()
 
+add_library(aether_libmodem_core STATIC
+    third_party/libmodem_core/bitstream.cpp
+    third_party/libmodem_core/demodulator.cpp
+)
+target_include_directories(aether_libmodem_core PUBLIC
+    ${CMAKE_SOURCE_DIR}/third_party/libmodem_core
+)
+target_compile_features(aether_libmodem_core PUBLIC cxx_std_20)
+target_compile_definitions(aether_libmodem_core PUBLIC
+    LIBMODEM_NAMESPACE=aether_libmodem_core
+    "LIBMODEM_NAMESPACE_REFERENCE=aether_libmodem_core::"
+)
+if(MSVC)
+    target_compile_options(aether_libmodem_core PRIVATE /w)
+else()
+    target_compile_options(aether_libmodem_core PRIVATE -w)
+endif()
+
 qt_add_resources(RESOURCES resources.qrc)
 
 add_executable(AetherSDR ${ALL_SOURCES} ${RNNOISE_SOURCES} ${GGMORSE_SOURCES} ${RADE_SOURCES} ${BNR_SOURCES} ${SPECBLEACH_SOURCES} ${RESOURCES})
@@ -821,6 +842,7 @@ target_link_libraries(AetherSDR PRIVATE
     Qt6::Widgets
     Qt6::Network
     Qt6::Multimedia
+    aether_libmodem_core
     zlibstatic           # bundled third_party/zlib 1.3.1
     ${CMAKE_DL_LIBS}   # dlopen/dlsym for tolerant X11 error handler (#1839)
 )
@@ -1447,6 +1469,34 @@ add_executable(cw_sidetone_test
 target_include_directories(cw_sidetone_test PRIVATE src)
 target_link_libraries(cw_sidetone_test PRIVATE Qt6::Core)
 
+add_executable(ax25_frame_formatter_test
+    tests/ax25_frame_formatter_test.cpp
+    src/core/tnc/Ax25FrameFormatter.cpp
+)
+target_include_directories(ax25_frame_formatter_test PRIVATE src)
+target_link_libraries(ax25_frame_formatter_test PRIVATE Qt6::Core)
+add_test(NAME ax25_frame_formatter_test COMMAND ax25_frame_formatter_test)
+
+# PerfTelemetry unit tests — drive the singleton through its public API
+# with a synthetic clock seam. lcPerf is defined locally inside the test
+# to avoid pulling LogManager and AppSettings.
+add_executable(perf_telemetry_test
+    tests/perf_telemetry_test.cpp
+    src/core/PerfTelemetry.cpp
+)
+target_include_directories(perf_telemetry_test PRIVATE src)
+target_link_libraries(perf_telemetry_test PRIVATE Qt6::Core)
+add_test(NAME perf_telemetry_test COMMAND perf_telemetry_test)
+
+add_executable(ax25_libmodem_shim_test
+    tests/ax25_libmodem_shim_test.cpp
+    src/core/tnc/AetherAx25LibmodemShim.cpp
+    src/core/tnc/Ax25FrameFormatter.cpp
+)
+target_include_directories(ax25_libmodem_shim_test PRIVATE src)
+target_link_libraries(ax25_libmodem_shim_test PRIVATE Qt6::Core aether_libmodem_core)
+add_test(NAME ax25_libmodem_shim_test COMMAND ax25_libmodem_shim_test)
+
 add_executable(cwx_panel_test
     tests/cwx_panel_test.cpp
     src/gui/CwxPanel.cpp
@@ -1472,21 +1522,6 @@ if(UNIX)
     target_link_libraries(meter_model_test PRIVATE pthread)
 endif()
 set_target_properties(meter_model_test PROPERTIES AUTOMOC ON)
-
-add_executable(perf_telemetry_test
-    tests/perf_telemetry_test.cpp
-    src/core/PerfTelemetry.cpp
-    src/core/LogManager.cpp
-    src/core/AsyncLogWriter.cpp
-    src/core/AppSettings.cpp
-)
-target_include_directories(perf_telemetry_test PRIVATE src)
-target_link_libraries(perf_telemetry_test PRIVATE Qt6::Core)
-if(UNIX)
-    target_link_libraries(perf_telemetry_test PRIVATE pthread)
-endif()
-set_target_properties(perf_telemetry_test PROPERTIES AUTOMOC ON)
-add_test(NAME perf_telemetry_test COMMAND perf_telemetry_test)
 
 add_executable(memory_recall_policy_test
     tests/memory_recall_policy_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1473,6 +1473,21 @@ if(UNIX)
 endif()
 set_target_properties(meter_model_test PROPERTIES AUTOMOC ON)
 
+add_executable(perf_telemetry_test
+    tests/perf_telemetry_test.cpp
+    src/core/PerfTelemetry.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(perf_telemetry_test PRIVATE src)
+target_link_libraries(perf_telemetry_test PRIVATE Qt6::Core)
+if(UNIX)
+    target_link_libraries(perf_telemetry_test PRIVATE pthread)
+endif()
+set_target_properties(perf_telemetry_test PROPERTIES AUTOMOC ON)
+add_test(NAME perf_telemetry_test COMMAND perf_telemetry_test)
+
 add_executable(memory_recall_policy_test
     tests/memory_recall_policy_test.cpp
     src/core/MemoryRecallPolicy.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,6 +529,7 @@ endif()
 
 set(MODEL_SOURCES
     src/models/RadioModel.cpp
+    src/models/ModelCapabilities.cpp
     src/models/AntennaAliasStore.cpp
     src/models/SliceModel.cpp
     src/models/PanadapterModel.cpp
@@ -543,6 +544,7 @@ set(MODEL_SOURCES
     src/models/CwxModel.cpp
     src/models/DvkModel.cpp
     src/models/NavtexModel.cpp
+    src/models/FlexWaveformModel.cpp
     src/models/BandSettings.cpp
     src/models/BandPlanManager.cpp
     src/models/XvtrPolicy.cpp
@@ -585,6 +587,7 @@ set(GUI_SOURCES
     src/gui/PersistentDialog.cpp
     src/gui/ProfileManagerDialog.cpp
     src/gui/ProfileImportExportDialog.cpp
+    src/gui/TxBandDialog.cpp
     src/gui/PanadapterApplet.cpp
     src/gui/PanadapterStack.cpp
     src/gui/PanLayoutDialog.cpp
@@ -1314,6 +1317,14 @@ target_include_directories(packet_loss_concealment_test PRIVATE src)
 target_link_libraries(packet_loss_concealment_test PRIVATE Qt6::Core)
 add_test(NAME packet_loss_concealment_test COMMAND packet_loss_concealment_test)
 
+add_executable(model_capabilities_test
+    tests/model_capabilities_test.cpp
+    src/models/ModelCapabilities.cpp
+)
+target_include_directories(model_capabilities_test PRIVATE src)
+target_link_libraries(model_capabilities_test PRIVATE Qt6::Core)
+add_test(NAME model_capabilities_test COMMAND model_capabilities_test)
+
 add_executable(client_quindar_test
     tests/client_quindar_test.cpp
     src/core/ClientQuindarTone.cpp
@@ -1402,6 +1413,13 @@ add_executable(navtex_model_test
 target_include_directories(navtex_model_test PRIVATE src)
 target_link_libraries(navtex_model_test PRIVATE Qt6::Core Qt6::Test)
 
+add_executable(flex_waveform_model_test
+    tests/flex_waveform_model_test.cpp
+    src/models/FlexWaveformModel.cpp
+)
+target_include_directories(flex_waveform_model_test PRIVATE src)
+target_link_libraries(flex_waveform_model_test PRIVATE Qt6::Core Qt6::Test)
+
 add_executable(ole_compound_file_test
     tests/ole_compound_file_test.cpp
     src/core/OleCompoundFile.cpp
@@ -1477,21 +1495,17 @@ target_include_directories(ax25_frame_formatter_test PRIVATE src)
 target_link_libraries(ax25_frame_formatter_test PRIVATE Qt6::Core)
 add_test(NAME ax25_frame_formatter_test COMMAND ax25_frame_formatter_test)
 
-# PerfTelemetry unit tests — drive the singleton through its public API
-# with a synthetic clock seam. lcPerf is defined locally inside the test
-# to avoid pulling LogManager and AppSettings.
-add_executable(perf_telemetry_test
-    tests/perf_telemetry_test.cpp
-    src/core/PerfTelemetry.cpp
-)
-target_include_directories(perf_telemetry_test PRIVATE src)
-target_link_libraries(perf_telemetry_test PRIVATE Qt6::Core)
-add_test(NAME perf_telemetry_test COMMAND perf_telemetry_test)
-
 add_executable(ax25_libmodem_shim_test
     tests/ax25_libmodem_shim_test.cpp
     src/core/tnc/AetherAx25LibmodemShim.cpp
     src/core/tnc/Ax25FrameFormatter.cpp
+    # LogManager.cpp provides lcAx25 (the shim's qCDebug category, #2763);
+    # LogManager.cpp depends on AsyncLogWriter via the m_writer member, so
+    # AppSettings + AsyncLogWriter come along to satisfy the constructor /
+    # destructor chain at link time.
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/AppSettings.cpp
 )
 target_include_directories(ax25_libmodem_shim_test PRIVATE src)
 target_link_libraries(ax25_libmodem_shim_test PRIVATE Qt6::Core aether_libmodem_core)
@@ -1522,6 +1536,36 @@ if(UNIX)
     target_link_libraries(meter_model_test PRIVATE pthread)
 endif()
 set_target_properties(meter_model_test PROPERTIES AUTOMOC ON)
+
+add_executable(async_log_writer_test
+    tests/async_log_writer_test.cpp
+    src/core/AsyncLogWriter.cpp
+)
+target_include_directories(async_log_writer_test PRIVATE src)
+target_link_libraries(async_log_writer_test PRIVATE Qt6::Core)
+if(UNIX)
+    target_link_libraries(async_log_writer_test PRIVATE pthread)
+endif()
+set_target_properties(async_log_writer_test PROPERTIES AUTOMOC ON)
+
+add_executable(perf_telemetry_test
+    tests/perf_telemetry_test.cpp
+    src/core/PerfTelemetry.cpp
+    # LogManager.cpp owns the lcPerf Q_LOGGING_CATEGORY definition (per
+    # Principle III consolidation, #2770); LogManager has AsyncLogWriter
+    # as a member which transitively needs AppSettings, so all three .cpp
+    # files come along to satisfy the ctor/dtor chain at link time.
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(perf_telemetry_test PRIVATE src)
+target_link_libraries(perf_telemetry_test PRIVATE Qt6::Core)
+if(UNIX)
+    target_link_libraries(perf_telemetry_test PRIVATE pthread)
+endif()
+set_target_properties(perf_telemetry_test PROPERTIES AUTOMOC ON)
+add_test(NAME perf_telemetry_test COMMAND perf_telemetry_test)
 
 add_executable(memory_recall_policy_test
     tests/memory_recall_policy_test.cpp

--- a/src/core/PerfTelemetry.cpp
+++ b/src/core/PerfTelemetry.cpp
@@ -6,6 +6,7 @@
 #include <QStringList>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <utility>
@@ -13,6 +14,8 @@
 namespace AetherSDR {
 
 namespace {
+
+std::atomic<qint64> g_clockOverrideNs{0};
 
 constexpr qint64 kSummaryIntervalNs = 1000000000LL;
 constexpr double kHeartbeatIntervalMs = 50.0;
@@ -42,9 +45,28 @@ PerfTelemetry& PerfTelemetry::instance()
 
 qint64 PerfTelemetry::nowNs()
 {
+    const qint64 overrideNs = g_clockOverrideNs.load(std::memory_order_relaxed);
+    if (overrideNs != 0)
+        return overrideNs;
     using Clock = std::chrono::steady_clock;
     static const Clock::time_point start = Clock::now();
     return std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() - start).count();
+}
+
+void PerfTelemetry::setClockOverrideForTest(qint64 nowNs)
+{
+    g_clockOverrideNs.store(nowNs, std::memory_order_relaxed);
+}
+
+void PerfTelemetry::resetForTest()
+{
+    QMutexLocker lock(&m_mutex);
+    m_window = Window{};
+    m_windowStartNs = 0;
+    m_lastHeartbeatNs = 0;
+    m_wasEnabled.store(false, std::memory_order_relaxed);
+    m_dragActive.store(false, std::memory_order_relaxed);
+    m_waterfallLineDurationMs.store(0, std::memory_order_relaxed);
 }
 
 bool PerfTelemetry::enabled() const

--- a/src/core/PerfTelemetry.h
+++ b/src/core/PerfTelemetry.h
@@ -10,8 +10,6 @@
 
 namespace AetherSDR {
 
-class PerfTelemetryTestAccess;
-
 class PerfTelemetry final {
 public:
     enum class FrameKind {
@@ -55,6 +53,13 @@ public:
 
     void recordSHistoryProcessed(double durationMs);
     void recordSHistorySkipped();
+
+    // Test-only seams. When the clock override is non-zero, nowNs() returns
+    // that value instead of consulting steady_clock — lets tests drive
+    // window timing deterministically. resetForTest() zeroes aggregation
+    // state so cases don't bleed into each other.
+    static void setClockOverrideForTest(qint64 nowNs);
+    void resetForTest();
 
 private:
     PerfTelemetry() = default;
@@ -123,8 +128,6 @@ private:
     std::atomic_bool m_wasEnabled{false};
     std::atomic_bool m_dragActive{false};
     std::atomic<int> m_waterfallLineDurationMs{0};
-
-    friend class PerfTelemetryTestAccess;
 };
 
 } // namespace AetherSDR

--- a/src/core/PerfTelemetry.h
+++ b/src/core/PerfTelemetry.h
@@ -10,6 +10,8 @@
 
 namespace AetherSDR {
 
+class PerfTelemetryTestAccess;
+
 class PerfTelemetry final {
 public:
     enum class FrameKind {
@@ -121,6 +123,8 @@ private:
     std::atomic_bool m_wasEnabled{false};
     std::atomic_bool m_dragActive{false};
     std::atomic<int> m_waterfallLineDurationMs{0};
+
+    friend class PerfTelemetryTestAccess;
 };
 
 } // namespace AetherSDR

--- a/src/core/PerfTelemetry.h
+++ b/src/core/PerfTelemetry.h
@@ -54,10 +54,10 @@ public:
     void recordSHistoryProcessed(double durationMs);
     void recordSHistorySkipped();
 
-    // Test-only seams. When the clock override is non-zero, nowNs() returns
-    // that value instead of consulting steady_clock — lets tests drive
-    // window timing deterministically. resetForTest() zeroes aggregation
-    // state so cases don't bleed into each other.
+    // Test-only seams. When the override is non-zero, nowNs() returns that
+    // value instead of consulting steady_clock so tests can drive window
+    // cadence deterministically. resetForTest() zeroes aggregation state
+    // so cases don't leak into each other through the singleton.
     static void setClockOverrideForTest(qint64 nowNs);
     void resetForTest();
 

--- a/tests/perf_telemetry_test.cpp
+++ b/tests/perf_telemetry_test.cpp
@@ -1,526 +1,408 @@
+// Unit tests for PerfTelemetry — issue #2500.
+//
+// Covers: disabled hot-path no-op, window aggregation, stall thresholds,
+// drag-aware UI lag, frame-restart counter, percentile-95 boundaries, and
+// window timing — by driving the singleton through its public record* API
+// with a synthetic clock seam (setClockOverrideForTest) and capturing the
+// lcPerf log line via qInstallMessageHandler.
+//
+// CMake target `perf_telemetry_test`. Exit 0 = pass.
+
 #include "core/PerfTelemetry.h"
-#include "core/LogManager.h"
 
 #include <QCoreApplication>
-#include <QLatin1String>
 #include <QLoggingCategory>
-#include <QMutex>
-#include <QMutexLocker>
 #include <QString>
 #include <QStringList>
-#include <QVector>
 #include <QtGlobal>
 
-#include <algorithm>
-#include <cmath>
 #include <cstdio>
-#include <utility>
+#include <functional>
+#include <string>
+#include <vector>
 
+// PerfTelemetry.cpp uses lcPerf via LogManager.h. Standalone tests provide
+// their own definition rather than pulling LogManager (which would drag in
+// AppSettings, AsyncLogWriter, etc.). Default level is QtDebugMsg so the
+// hot path is "enabled" — tests flip rules off when they need the disabled
+// path verified.
 namespace AetherSDR {
-
-// Friend access shim — peeks into the singleton's private state so tests can
-// drive synthetic time and reset between cases. Adding no production behavior
-// keeps the hot path untouched (issue #2500 triage Option A).
-class PerfTelemetryTestAccess {
-public:
-    static void resetInstance()
-    {
-        PerfTelemetry& t = PerfTelemetry::instance();
-        QMutexLocker lock(&t.m_mutex);
-        t.m_window = PerfTelemetry::Window{};
-        t.m_windowStartNs = 0;
-        t.m_lastHeartbeatNs = 0;
-        t.m_wasEnabled.store(false, std::memory_order_relaxed);
-        t.m_dragActive.store(false, std::memory_order_relaxed);
-        t.m_waterfallLineDurationMs.store(0, std::memory_order_relaxed);
-    }
-
-    static void primeForRecording(qint64 now)
-    {
-        PerfTelemetry& t = PerfTelemetry::instance();
-        t.m_wasEnabled.store(true, std::memory_order_relaxed);
-        QMutexLocker lock(&t.m_mutex);
-        t.m_window = PerfTelemetry::Window{};
-        t.m_windowStartNs = now;
-        t.m_lastHeartbeatNs = 0;
-    }
-
-    static void setWindowStart(qint64 ns)
-    {
-        PerfTelemetry& t = PerfTelemetry::instance();
-        QMutexLocker lock(&t.m_mutex);
-        t.m_windowStartNs = ns;
-    }
-
-    static void setLastHeartbeat(qint64 ns)
-    {
-        PerfTelemetry& t = PerfTelemetry::instance();
-        QMutexLocker lock(&t.m_mutex);
-        t.m_lastHeartbeatNs = ns;
-    }
-
-    static int panUpdateSampleCount()
-    {
-        PerfTelemetry& t = PerfTelemetry::instance();
-        QMutexLocker lock(&t.m_mutex);
-        return static_cast<int>(t.m_window.panUpdateMs.size());
-    }
-
-    static void triggerSummary(qint64 now)
-    {
-        PerfTelemetry::instance().maybeLogSummary(now);
-    }
-
-    static double callPercentile95(QVector<double> values)
-    {
-        return PerfTelemetry::percentile95(std::move(values));
-    }
-};
-
+Q_LOGGING_CATEGORY(lcPerf, "aether.perf", QtDebugMsg)
 } // namespace AetherSDR
+
+using AetherSDR::PerfTelemetry;
 
 namespace {
 
-using AetherSDR::PerfTelemetry;
-using AetherSDR::PerfTelemetryTestAccess;
-
 int g_failed = 0;
+QStringList g_capturedLines;
 
-struct CapturedLines {
-    static CapturedLines& instance()
-    {
-        static CapturedLines cap;
-        return cap;
-    }
-
-    QMutex mutex;
-    QStringList lines;
-
-    void clear()
-    {
-        QMutexLocker lock(&mutex);
-        lines.clear();
-    }
-
-    QStringList snapshot()
-    {
-        QMutexLocker lock(&mutex);
-        return lines;
-    }
-};
-
-void perfMessageHandler(QtMsgType, const QMessageLogContext& ctx, const QString& msg)
+void messageHandler(QtMsgType, const QMessageLogContext& ctx, const QString& msg)
 {
-    if (ctx.category && QLatin1String(ctx.category) == QLatin1String("aether.perf")) {
-        QMutexLocker lock(&CapturedLines::instance().mutex);
-        CapturedLines::instance().lines.append(msg);
-    }
+    if (ctx.category && QString::fromUtf8(ctx.category) == QLatin1String("aether.perf"))
+        g_capturedLines << msg;
 }
 
-void report(const char* name, bool ok)
+void report(const char* name, bool ok, const std::string& detail = {})
 {
-    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
-    if (!ok)
-        ++g_failed;
+    std::printf("%s %-58s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
 }
 
-void enablePerf()
+void resetCapture()
 {
-    QLoggingCategory::setFilterRules(QStringLiteral("aether.perf.debug=true"));
+    g_capturedLines.clear();
 }
 
-void disablePerf()
+QStringList stallLines()
 {
-    QLoggingCategory::setFilterRules(QStringLiteral("aether.perf.debug=false"));
+    QStringList out;
+    for (const auto& line : g_capturedLines)
+        if (line.startsWith(QLatin1String("PerfStall")))
+            out << line;
+    return out;
 }
 
-bool nearlyEqual(double a, double b, double eps = 0.001)
+QStringList summaryLines()
 {
-    return std::fabs(a - b) < eps;
+    QStringList out;
+    for (const auto& line : g_capturedLines)
+        if (line.startsWith(QLatin1String("PerfSummary")))
+            out << line;
+    return out;
 }
 
 QString fieldValue(const QString& line, const QString& key)
 {
+    const QStringList parts = line.split(QLatin1Char(' '));
     const QString prefix = key + QLatin1Char('=');
-    const auto tokens = line.split(QLatin1Char(' '));
-    for (const QString& token : tokens) {
-        if (token.startsWith(prefix))
-            return token.mid(prefix.size());
+    for (const auto& part : parts) {
+        if (part.startsWith(prefix))
+            return part.mid(prefix.size());
     }
     return {};
 }
 
-QString findLineStartingWith(const QStringList& lines, const QString& prefix)
+void prime(qint64 t0)
 {
-    for (const QString& line : lines) {
-        if (line.startsWith(prefix))
-            return line;
-    }
-    return {};
+    // Reset state and pin the clock — the next record call will start a
+    // fresh window at t0.
+    PerfTelemetry::setClockOverrideForTest(t0);
+    PerfTelemetry::instance().resetForTest();
+    resetCapture();
 }
 
-QString findStallOfKind(const QStringList& lines, const QString& kind)
+// Advance synthetic clock to the next 1-second boundary and emit a final
+// recordPanFrame so maybeLogSummary fires. Returns the captured summary.
+QString flushSummary(qint64 windowStartNs)
 {
-    for (const QString& l : lines) {
-        if (l.startsWith(QStringLiteral("PerfStall")) &&
-            fieldValue(l, QStringLiteral("kind")) == kind) {
-            return l;
-        }
-    }
-    return {};
+    PerfTelemetry::setClockOverrideForTest(windowStartNs + 1'100'000'000LL);
+    PerfTelemetry::instance().recordPanFrame();
+    const auto summaries = summaryLines();
+    return summaries.isEmpty() ? QString() : summaries.last();
 }
 
-void testDisabledHotPathIsNoOp()
-{
-    disablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    CapturedLines::instance().clear();
+// --- Disabled hot-path is no-op ---------------------------------------------
 
-    for (int i = 0; i < 100; ++i)
+void testDisabledHotPath()
+{
+    QLoggingCategory::setFilterRules(QStringLiteral("aether.perf.debug=false"));
+    PerfTelemetry::setClockOverrideForTest(1'000'000'000LL);
+    PerfTelemetry::instance().resetForTest();
+    resetCapture();
+
+    for (int i = 0; i < 50; ++i)
         PerfTelemetry::instance().recordPanUpdate(50.0);
 
-    const QStringList lines = CapturedLines::instance().snapshot();
-    const int samples = PerfTelemetryTestAccess::panUpdateSampleCount();
+    report("disabled hot-path emits no log lines",
+           g_capturedLines.isEmpty(),
+           g_capturedLines.isEmpty() ? "" : std::string("got ") + std::to_string(g_capturedLines.size()) + " lines");
 
-    report("disabled lcPerf emits no perf log lines",
-           lines.isEmpty());
-    report("disabled lcPerf mutates no window state",
-           samples == 0);
+    QLoggingCategory::setFilterRules(QStringLiteral("aether.perf.debug=true"));
 }
 
-void testStallThresholdPanUpdateAbove()
+// --- Window aggregation: count, p95, max ------------------------------------
+
+void testWindowAggregation()
 {
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
-    CapturedLines::instance().clear();
+    constexpr qint64 t0 = 5'000'000'000LL;
+    prime(t0);
 
-    PerfTelemetry::instance().recordPanUpdate(9.0);
+    // Feed 10 panUpdate samples below the stall threshold (8.0 ms) so no
+    // PerfStall lines are emitted — they would otherwise crowd capture.
+    // Values: 1, 2, 3, 4, 5, 6, 7, 7.5, 7.8, 7.9 — all <= 8.0.
+    const std::vector<double> samples = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.5, 7.8, 7.9};
+    for (double v : samples)
+        PerfTelemetry::instance().recordPanUpdate(v);
 
-    const QString stall = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("updateSpectrum"));
-    report("panUpdate 9.0ms emits PerfStall kind=updateSpectrum (>8ms)",
-           !stall.isEmpty() &&
-           fieldValue(stall, QStringLiteral("durationMs")) == QStringLiteral("9.0"));
+    const QString summary = flushSummary(t0);
+    const bool hasSummary = !summary.isEmpty();
+    report("window aggregation emits a summary", hasSummary);
+
+    if (hasSummary) {
+        // percentile95 for N=10: ceil(10*0.95)-1 = 9, sorted[9] = 7.9
+        const QString p95 = fieldValue(summary, QStringLiteral("panUpdateP95Ms"));
+        report("panUpdateP95Ms equals 7.9 for 10 sorted samples",
+               p95 == QLatin1String("7.9"),
+               std::string("got '") + p95.toStdString() + "'");
+    }
 }
 
-void testStallThresholdPanUpdateBelow()
-{
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
-    CapturedLines::instance().clear();
-
-    PerfTelemetry::instance().recordPanUpdate(7.0);
-
-    report("panUpdate 7.0ms emits no PerfStall (<8ms threshold)",
-           findLineStartingWith(CapturedLines::instance().snapshot(),
-                                QStringLiteral("PerfStall")).isEmpty());
-}
-
-void testStallThresholdFrameAge()
-{
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
-
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordFrameAge(PerfTelemetry::FrameKind::Panadapter, 101.0);
-    const QString above = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("frameAge"));
-
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordFrameAge(PerfTelemetry::FrameKind::Panadapter, 99.0);
-    const QString below = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("frameAge"));
-
-    report("frameAge 101ms emits PerfStall kind=frameAge (>100ms)",
-           !above.isEmpty() &&
-           fieldValue(above, QStringLiteral("stream")) == QStringLiteral("panadapter"));
-    report("frameAge 99ms emits no PerfStall (<100ms threshold)",
-           below.isEmpty());
-}
-
-void testStallThresholdRender()
-{
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
-
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordRender(17.0);
-    const QString above = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("render"));
-
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordRender(15.0);
-    const QString below = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("render"));
-
-    report("render 17.0ms emits PerfStall kind=render (>16ms)",
-           !above.isEmpty());
-    report("render 15.0ms emits no PerfStall (<16ms threshold)",
-           below.isEmpty());
-}
-
-void testStallThresholdUdpDrain()
-{
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
-
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordUdpBatch(5, 1500, 9.0);
-    const QString above = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("udpDrain"));
-
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordUdpBatch(5, 1500, 7.0);
-    const QString below = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("udpDrain"));
-
-    report("udpDrain 9.0ms emits PerfStall kind=udpDrain (>8ms)",
-           !above.isEmpty());
-    report("udpDrain 7.0ms emits no PerfStall (<8ms threshold)",
-           below.isEmpty());
-}
-
-void testStallThresholdWaterfallUpdate()
-{
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
-
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordWaterfallUpdate(13.0);
-    const QString above = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("updateWaterfallRow"));
-
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordWaterfallUpdate(11.0);
-    const QString below = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("updateWaterfallRow"));
-
-    report("waterfallUpdate 13.0ms emits PerfStall kind=updateWaterfallRow (>12ms)",
-           !above.isEmpty());
-    report("waterfallUpdate 11.0ms emits no PerfStall (<12ms threshold)",
-           below.isEmpty());
-}
-
-void testStallThresholdInput()
-{
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
-
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordInputEvent("mouseMove", 17.0);
-    const QString above = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("input"));
-
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordInputEvent("mouseMove", 15.0);
-    const QString below = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("input"));
-
-    report("input 17.0ms emits PerfStall kind=input (>16ms)",
-           !above.isEmpty() &&
-           fieldValue(above, QStringLiteral("event")) == QStringLiteral("mouseMove"));
-    report("input 15.0ms emits no PerfStall (<16ms threshold)",
-           below.isEmpty());
-}
-
-void testDragAwareUiLagIdleBelowBoth()
-{
-    // gap=80ms → lag=max(0, 80-50)=30ms. Below idle (50) and drag (33). No stall.
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
-    PerfTelemetry::instance().setDragActive(false);
-
-    const qint64 now = PerfTelemetry::nowNs();
-    PerfTelemetryTestAccess::setLastHeartbeat(now - 80LL * 1000000LL);
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordUiHeartbeat();
-
-    report("idle UI heartbeat gap=80ms (lag=30) emits no stall",
-           findStallOfKind(CapturedLines::instance().snapshot(),
-                           QStringLiteral("uiHeartbeat")).isEmpty());
-}
-
-void testDragAwareUiLagDragStall()
-{
-    // gap=90ms → lag=40ms. Below idle (50), above drag (33). Drag stall fires.
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
-    PerfTelemetry::instance().setDragActive(true);
-
-    const qint64 now = PerfTelemetry::nowNs();
-    PerfTelemetryTestAccess::setLastHeartbeat(now - 90LL * 1000000LL);
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordUiHeartbeat();
-
-    const QString stall = findStallOfKind(CapturedLines::instance().snapshot(),
-                                          QStringLiteral("uiHeartbeat"));
-    report("drag-active UI heartbeat gap=90ms (lag=40) emits stall (>33ms drag threshold)",
-           !stall.isEmpty() &&
-           fieldValue(stall, QStringLiteral("drag")) == QStringLiteral("1"));
-}
-
-void testDragAwareUiLagIdleSameGapNoStall()
-{
-    // gap=90ms idle → lag=40, < 50 idle threshold. No stall.
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
-    PerfTelemetry::instance().setDragActive(false);
-
-    const qint64 now = PerfTelemetry::nowNs();
-    PerfTelemetryTestAccess::setLastHeartbeat(now - 90LL * 1000000LL);
-    CapturedLines::instance().clear();
-    PerfTelemetry::instance().recordUiHeartbeat();
-
-    report("idle UI heartbeat gap=90ms (lag=40) emits no stall (<50ms idle threshold)",
-           findStallOfKind(CapturedLines::instance().snapshot(),
-                           QStringLiteral("uiHeartbeat")).isEmpty());
-}
-
-void testFrameRestartCounter()
-{
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    const qint64 baseNs = PerfTelemetry::nowNs();
-    PerfTelemetryTestAccess::primeForRecording(baseNs);
-
-    for (int i = 0; i < 3; ++i)
-        PerfTelemetry::instance().recordFrameRestart(PerfTelemetry::FrameKind::Panadapter);
-
-    PerfTelemetryTestAccess::setWindowStart(baseNs - 2LL * 1000000000LL);
-    CapturedLines::instance().clear();
-    PerfTelemetryTestAccess::triggerSummary(baseNs);
-
-    const QString summary = findLineStartingWith(CapturedLines::instance().snapshot(),
-                                                 QStringLiteral("PerfSummary"));
-    report("3 panadapter frame restarts produce fftRestarts=3 in next summary",
-           !summary.isEmpty() &&
-           fieldValue(summary, QStringLiteral("fftRestarts")) == QStringLiteral("3"));
-}
-
-void testPercentile95Empty()
-{
-    report("percentile95 of empty vector returns 0.0",
-           nearlyEqual(PerfTelemetryTestAccess::callPercentile95(QVector<double>{}), 0.0));
-}
-
-void testPercentile95Single()
-{
-    report("percentile95 of single value returns that value",
-           nearlyEqual(PerfTelemetryTestAccess::callPercentile95(QVector<double>{42.5}), 42.5));
-}
-
-void testPercentile95Hundred()
-{
-    QVector<double> values;
-    for (int i = 1; i <= 100; ++i)
-        values.append(static_cast<double>(i));
-    report("percentile95 of [1..100] returns 95.0",
-           nearlyEqual(PerfTelemetryTestAccess::callPercentile95(values), 95.0));
-}
-
-void testPercentile95OrderInvariant()
-{
-    QVector<double> sorted;
-    for (int i = 1; i <= 50; ++i)
-        sorted.append(static_cast<double>(i));
-    QVector<double> shuffled = sorted;
-    for (int i = 0; i + 1 < shuffled.size(); i += 2)
-        std::swap(shuffled[i], shuffled[i + 1]);
-
-    const double a = PerfTelemetryTestAccess::callPercentile95(sorted);
-    const double b = PerfTelemetryTestAccess::callPercentile95(shuffled);
-    report("percentile95 is invariant to input ordering",
-           nearlyEqual(a, b));
-}
-
-void testWindowTimingBefore1s()
-{
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    const qint64 baseNs = PerfTelemetry::nowNs();
-    PerfTelemetryTestAccess::primeForRecording(baseNs);
-
-    PerfTelemetry::instance().recordPanFrame();
-    CapturedLines::instance().clear();
-
-    PerfTelemetryTestAccess::triggerSummary(baseNs + 950LL * 1000000LL);
-
-    report("elapsed 950ms does not trigger summary",
-           findLineStartingWith(CapturedLines::instance().snapshot(),
-                                QStringLiteral("PerfSummary")).isEmpty());
-}
-
-void testWindowTimingAfter1s()
-{
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    const qint64 baseNs = PerfTelemetry::nowNs();
-    PerfTelemetryTestAccess::primeForRecording(baseNs);
-
-    PerfTelemetry::instance().recordPanFrame();
-    PerfTelemetry::instance().recordPanFrame();
-    PerfTelemetry::instance().recordPanFrame();
-    CapturedLines::instance().clear();
-
-    PerfTelemetryTestAccess::triggerSummary(baseNs + 1100LL * 1000000LL);
-
-    const QString summary = findLineStartingWith(CapturedLines::instance().snapshot(),
-                                                 QStringLiteral("PerfSummary"));
-    report("elapsed 1100ms triggers summary",
-           !summary.isEmpty());
-}
+// --- Window resets after summary --------------------------------------------
 
 void testWindowResetsAfterSummary()
 {
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    const qint64 baseNs = PerfTelemetry::nowNs();
-    PerfTelemetryTestAccess::primeForRecording(baseNs);
+    constexpr qint64 t0 = 10'000'000'000LL;
+    prime(t0);
 
-    PerfTelemetry::instance().recordPanFrame();
-    PerfTelemetry::instance().recordPanFrame();
+    PerfTelemetry::instance().recordPanUpdate(5.0);
+    PerfTelemetry::instance().recordPanUpdate(6.0);
+    PerfTelemetry::instance().recordPanUpdate(7.0);
+    (void)flushSummary(t0);
 
-    PerfTelemetryTestAccess::triggerSummary(baseNs + 1100LL * 1000000LL);
-    CapturedLines::instance().clear();
+    // Now drive a fresh window from t0 + 1.1s onward and verify the new
+    // summary doesn't carry the prior window's panUpdate samples.
+    constexpr qint64 t1 = 10'000'000'000LL + 1'100'000'000LL;
+    resetCapture();
+    PerfTelemetry::setClockOverrideForTest(t1);
+    PerfTelemetry::instance().recordPanUpdate(1.0);
 
-    PerfTelemetryTestAccess::triggerSummary(baseNs + 2200LL * 1000000LL);
-
-    const QString summary = findLineStartingWith(CapturedLines::instance().snapshot(),
-                                                 QStringLiteral("PerfSummary"));
-    report("window resets after summary - second summary has panFps=0.0",
-           !summary.isEmpty() &&
-           fieldValue(summary, QStringLiteral("panFps")) == QStringLiteral("0.0"));
+    const QString summary = flushSummary(t1);
+    const QString p95 = fieldValue(summary, QStringLiteral("panUpdateP95Ms"));
+    // Second window had one sample at 1.0, then flushSummary added a
+    // recordPanFrame (which doesn't add to panUpdateMs). So P95 should be 1.0.
+    report("window state does not bleed across summaries",
+           p95 == QLatin1String("1.0"),
+           std::string("got '") + p95.toStdString() + "'");
 }
 
-void testWindowAggregationPanUpdateP95()
+// --- Stall thresholds -------------------------------------------------------
+
+void testStallThresholdMatrix()
 {
-    enablePerf();
-    PerfTelemetryTestAccess::resetInstance();
-    const qint64 baseNs = PerfTelemetry::nowNs();
-    PerfTelemetryTestAccess::primeForRecording(baseNs);
+    struct Case {
+        const char* name;
+        double justUnder;
+        double justOver;
+        QString expectedStallKind;
+        std::function<void(double)> trigger;
+    };
 
-    // Feed 20 sub-threshold values 0.1..2.0; p95 index = ceil(20*0.95)-1 = 18 → 1.9.
-    for (int i = 1; i <= 20; ++i)
-        PerfTelemetry::instance().recordPanUpdate(static_cast<double>(i) * 0.1);
+    // Threshold values are duplicated from PerfTelemetry.cpp — if either
+    // drifts, these tests must be updated in lockstep with the production
+    // constants.
+    const std::vector<Case> cases = {
+        {"panUpdate stall (8.0 ms)", 7.5, 8.5, QStringLiteral("updateSpectrum"),
+            [](double v){ PerfTelemetry::instance().recordPanUpdate(v); }},
+        {"waterfallUpdate stall (12.0 ms)", 11.0, 13.0, QStringLiteral("updateWaterfallRow"),
+            [](double v){ PerfTelemetry::instance().recordWaterfallUpdate(v); }},
+        {"render stall (16.0 ms)", 15.0, 17.0, QStringLiteral("render"),
+            [](double v){ PerfTelemetry::instance().recordRender(v); }},
+        {"frameAge stall (100.0 ms)", 99.0, 101.0, QStringLiteral("frameAge"),
+            [](double v){ PerfTelemetry::instance().recordFrameAge(PerfTelemetry::FrameKind::Panadapter, v); }},
+        {"udpDrain stall (8.0 ms)", 7.5, 8.5, QStringLiteral("udpDrain"),
+            [](double v){ PerfTelemetry::instance().recordUdpBatch(1, 100, v); }},
+        {"input stall (16.0 ms)", 15.0, 17.0, QStringLiteral("input"),
+            [](double v){ PerfTelemetry::instance().recordInputEvent("wheel", v); }},
+    };
 
-    CapturedLines::instance().clear();
-    PerfTelemetryTestAccess::triggerSummary(baseNs + 1100LL * 1000000LL);
+    qint64 t = 100'000'000'000LL;
+    for (const auto& c : cases) {
+        // Below-threshold: no stall.
+        prime(t);
+        c.trigger(c.justUnder);
+        bool sawStallBelow = false;
+        for (const auto& line : stallLines())
+            if (fieldValue(line, QStringLiteral("kind")) == c.expectedStallKind)
+                sawStallBelow = true;
+        report((std::string(c.name) + " below threshold: no stall").c_str(),
+               !sawStallBelow);
 
-    const QString summary = findLineStartingWith(CapturedLines::instance().snapshot(),
-                                                 QStringLiteral("PerfSummary"));
-    report("aggregation: panUpdateP95Ms reflects p95 of 20 recorded samples",
-           !summary.isEmpty() &&
-           fieldValue(summary, QStringLiteral("panUpdateP95Ms")) == QStringLiteral("1.9"));
+        // Above-threshold: stall fires.
+        t += 5'000'000'000LL;
+        prime(t);
+        c.trigger(c.justOver);
+        bool sawStallAbove = false;
+        for (const auto& line : stallLines())
+            if (fieldValue(line, QStringLiteral("kind")) == c.expectedStallKind)
+                sawStallAbove = true;
+        report((std::string(c.name) + " above threshold: stall fires").c_str(),
+               sawStallAbove);
+
+        t += 5'000'000'000LL;
+    }
+}
+
+// --- Drag-aware UI lag thresholds -------------------------------------------
+//
+// Lag is computed as max(0, gap - kHeartbeatIntervalMs) where the heartbeat
+// interval is 50 ms. Idle stall threshold is 50 ms (so gap > 100 ms); drag
+// stall threshold is 33 ms (so gap > 83 ms). A 90 ms gap → lag=40, which
+// trips drag but not idle.
+
+void testUiHeartbeatDragThresholds()
+{
+    constexpr qint64 t0 = 200'000'000'000LL;
+
+    // Idle, gap = 90 ms → lag = 40 ms < 50 ms idle threshold → no stall.
+    prime(t0);
+    PerfTelemetry::instance().setDragActive(false);
+    PerfTelemetry::instance().recordUiHeartbeat();
+    PerfTelemetry::setClockOverrideForTest(t0 + 90'000'000LL);
+    PerfTelemetry::instance().recordUiHeartbeat();
+    bool sawIdleStall = false;
+    for (const auto& line : stallLines())
+        if (fieldValue(line, QStringLiteral("kind")) == QLatin1String("uiHeartbeat"))
+            sawIdleStall = true;
+    report("uiHeartbeat idle 90ms gap (lag=40): no stall", !sawIdleStall);
+
+    // Drag, same 90 ms gap → lag = 40 ms > 33 ms drag threshold → stall.
+    const qint64 t1 = t0 + 5'000'000'000LL;
+    prime(t1);
+    PerfTelemetry::instance().setDragActive(true);
+    PerfTelemetry::instance().recordUiHeartbeat();
+    PerfTelemetry::setClockOverrideForTest(t1 + 90'000'000LL);
+    PerfTelemetry::instance().recordUiHeartbeat();
+    bool sawDragStall = false;
+    for (const auto& line : stallLines())
+        if (fieldValue(line, QStringLiteral("kind")) == QLatin1String("uiHeartbeat"))
+            sawDragStall = true;
+    report("uiHeartbeat drag 90ms gap (lag=40): stall fires", sawDragStall);
+
+    // Idle, gap = 110 ms → lag = 60 ms > 50 ms idle threshold → stall.
+    const qint64 t2 = t1 + 5'000'000'000LL;
+    prime(t2);
+    PerfTelemetry::instance().setDragActive(false);
+    PerfTelemetry::instance().recordUiHeartbeat();
+    PerfTelemetry::setClockOverrideForTest(t2 + 110'000'000LL);
+    PerfTelemetry::instance().recordUiHeartbeat();
+    bool sawIdleStallHigh = false;
+    for (const auto& line : stallLines())
+        if (fieldValue(line, QStringLiteral("kind")) == QLatin1String("uiHeartbeat"))
+            sawIdleStallHigh = true;
+    report("uiHeartbeat idle 110ms gap (lag=60): stall fires", sawIdleStallHigh);
+}
+
+// --- Frame-restart counter --------------------------------------------------
+
+void testFrameRestartCounter()
+{
+    constexpr qint64 t0 = 300'000'000'000LL;
+    prime(t0);
+
+    PerfTelemetry::instance().recordFrameRestart(PerfTelemetry::FrameKind::Panadapter);
+    PerfTelemetry::instance().recordFrameRestart(PerfTelemetry::FrameKind::Panadapter);
+    PerfTelemetry::instance().recordFrameRestart(PerfTelemetry::FrameKind::Panadapter);
+
+    const QString summary = flushSummary(t0);
+    const QString restarts = fieldValue(summary, QStringLiteral("fftRestarts"));
+    report("3x recordFrameRestart(Panadapter) shows fftRestarts=3",
+           restarts == QLatin1String("3"),
+           std::string("got '") + restarts.toStdString() + "'");
+}
+
+// --- Percentile-95 boundary cases (exercised via the public record path) ----
+
+void testPercentile95Boundaries()
+{
+    // Empty input — no panUpdate samples, but a recordPanFrame to ensure
+    // maybeLogSummary fires.
+    {
+        constexpr qint64 t0 = 400'000'000'000LL;
+        prime(t0);
+        const QString summary = flushSummary(t0);
+        const QString p95 = fieldValue(summary, QStringLiteral("panUpdateP95Ms"));
+        report("p95 empty input returns 0.0",
+               p95 == QLatin1String("0.0"),
+               std::string("got '") + p95.toStdString() + "'");
+    }
+
+    // Single value — keep it under the 8 ms stall threshold.
+    {
+        constexpr qint64 t0 = 410'000'000'000LL;
+        prime(t0);
+        PerfTelemetry::instance().recordPanUpdate(4.2);
+        const QString summary = flushSummary(t0);
+        const QString p95 = fieldValue(summary, QStringLiteral("panUpdateP95Ms"));
+        report("p95 single value returns that value",
+               p95 == QLatin1String("4.2"),
+               std::string("got '") + p95.toStdString() + "'");
+    }
+
+    // 100 values [1..100] — render samples (threshold 16 ms) lets values
+    // 1..15 pass without stall noise; for percentile coverage use frameAge
+    // which has a 100 ms threshold — we want all 100 values under it.
+    // frameAge stall fires at > 100, so 1..100 are all clean.
+    {
+        constexpr qint64 t0 = 420'000'000'000LL;
+        prime(t0);
+        for (int i = 1; i <= 100; ++i)
+            PerfTelemetry::instance().recordFrameAge(PerfTelemetry::FrameKind::Panadapter,
+                                                     static_cast<double>(i));
+        const QString summary = flushSummary(t0);
+        const QString p95 = fieldValue(summary, QStringLiteral("panAgeP95Ms"));
+        // ceil(100*0.95)-1 = 94, sorted[94] = 95.
+        report("p95 of [1..100] returns 95.0",
+               p95 == QLatin1String("95.0"),
+               std::string("got '") + p95.toStdString() + "'");
+    }
+
+    // Same 100 values fed in reverse — sort inside percentile95 should give
+    // the same result.
+    {
+        constexpr qint64 t0 = 430'000'000'000LL;
+        prime(t0);
+        for (int i = 100; i >= 1; --i)
+            PerfTelemetry::instance().recordFrameAge(PerfTelemetry::FrameKind::Panadapter,
+                                                     static_cast<double>(i));
+        const QString summary = flushSummary(t0);
+        const QString p95 = fieldValue(summary, QStringLiteral("panAgeP95Ms"));
+        report("p95 unsorted input matches sorted input (95.0)",
+               p95 == QLatin1String("95.0"),
+               std::string("got '") + p95.toStdString() + "'");
+    }
+}
+
+// --- Window timing ----------------------------------------------------------
+
+void testWindowTiming()
+{
+    constexpr qint64 t0 = 500'000'000'000LL;
+    prime(t0);
+
+    // Samples spread across 950 ms — no summary yet.
+    PerfTelemetry::setClockOverrideForTest(t0);
+    PerfTelemetry::instance().recordPanUpdate(1.0);
+    PerfTelemetry::setClockOverrideForTest(t0 + 300'000'000LL);
+    PerfTelemetry::instance().recordPanUpdate(2.0);
+    PerfTelemetry::setClockOverrideForTest(t0 + 600'000'000LL);
+    PerfTelemetry::instance().recordPanUpdate(3.0);
+    PerfTelemetry::setClockOverrideForTest(t0 + 950'000'000LL);
+    PerfTelemetry::instance().recordPanUpdate(4.0);
+
+    report("no summary fires before 1s boundary",
+           summaryLines().isEmpty(),
+           std::string("got ") + std::to_string(summaryLines().size()) + " summary lines");
+
+    // One more sample past the 1 s boundary — summary should fire and
+    // include all five samples in panUpdateP95Ms.
+    PerfTelemetry::setClockOverrideForTest(t0 + 1'100'000'000LL);
+    PerfTelemetry::instance().recordPanUpdate(5.0);
+
+    const auto summaries = summaryLines();
+    report("summary fires once 1s window elapses",
+           !summaries.isEmpty());
+
+    if (!summaries.isEmpty()) {
+        const QString p95 = fieldValue(summaries.last(), QStringLiteral("panUpdateP95Ms"));
+        // ceil(5*0.95)-1 = 4, sorted[4] = 5.0
+        report("summary captures all 5 samples (p95=5.0)",
+               p95 == QLatin1String("5.0"),
+               std::string("got '") + p95.toStdString() + "'");
+    }
 }
 
 } // namespace
@@ -528,30 +410,25 @@ void testWindowAggregationPanUpdateP95()
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);
-    qInstallMessageHandler(perfMessageHandler);
+    QLoggingCategory::setFilterRules(QStringLiteral("aether.perf.debug=true"));
+    qInstallMessageHandler(messageHandler);
 
-    testDisabledHotPathIsNoOp();
-    testStallThresholdPanUpdateAbove();
-    testStallThresholdPanUpdateBelow();
-    testStallThresholdFrameAge();
-    testStallThresholdRender();
-    testStallThresholdUdpDrain();
-    testStallThresholdWaterfallUpdate();
-    testStallThresholdInput();
-    testDragAwareUiLagIdleBelowBoth();
-    testDragAwareUiLagDragStall();
-    testDragAwareUiLagIdleSameGapNoStall();
-    testFrameRestartCounter();
-    testPercentile95Empty();
-    testPercentile95Single();
-    testPercentile95Hundred();
-    testPercentile95OrderInvariant();
-    testWindowTimingBefore1s();
-    testWindowTimingAfter1s();
+    testDisabledHotPath();
+    testWindowAggregation();
     testWindowResetsAfterSummary();
-    testWindowAggregationPanUpdateP95();
+    testStallThresholdMatrix();
+    testUiHeartbeatDragThresholds();
+    testFrameRestartCounter();
+    testPercentile95Boundaries();
+    testWindowTiming();
 
     qInstallMessageHandler(nullptr);
+    PerfTelemetry::setClockOverrideForTest(0);
 
-    return g_failed == 0 ? 0 : 1;
+    if (g_failed == 0) {
+        std::printf("\nAll PerfTelemetry tests passed.\n");
+        return 0;
+    }
+    std::printf("\n%d test(s) FAILED.\n", g_failed);
+    return 1;
 }

--- a/tests/perf_telemetry_test.cpp
+++ b/tests/perf_telemetry_test.cpp
@@ -1,0 +1,557 @@
+#include "core/PerfTelemetry.h"
+#include "core/LogManager.h"
+
+#include <QCoreApplication>
+#include <QLatin1String>
+#include <QLoggingCategory>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+#include <QtGlobal>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <utility>
+
+namespace AetherSDR {
+
+// Friend access shim — peeks into the singleton's private state so tests can
+// drive synthetic time and reset between cases. Adding no production behavior
+// keeps the hot path untouched (issue #2500 triage Option A).
+class PerfTelemetryTestAccess {
+public:
+    static void resetInstance()
+    {
+        PerfTelemetry& t = PerfTelemetry::instance();
+        QMutexLocker lock(&t.m_mutex);
+        t.m_window = PerfTelemetry::Window{};
+        t.m_windowStartNs = 0;
+        t.m_lastHeartbeatNs = 0;
+        t.m_wasEnabled.store(false, std::memory_order_relaxed);
+        t.m_dragActive.store(false, std::memory_order_relaxed);
+        t.m_waterfallLineDurationMs.store(0, std::memory_order_relaxed);
+    }
+
+    static void primeForRecording(qint64 now)
+    {
+        PerfTelemetry& t = PerfTelemetry::instance();
+        t.m_wasEnabled.store(true, std::memory_order_relaxed);
+        QMutexLocker lock(&t.m_mutex);
+        t.m_window = PerfTelemetry::Window{};
+        t.m_windowStartNs = now;
+        t.m_lastHeartbeatNs = 0;
+    }
+
+    static void setWindowStart(qint64 ns)
+    {
+        PerfTelemetry& t = PerfTelemetry::instance();
+        QMutexLocker lock(&t.m_mutex);
+        t.m_windowStartNs = ns;
+    }
+
+    static void setLastHeartbeat(qint64 ns)
+    {
+        PerfTelemetry& t = PerfTelemetry::instance();
+        QMutexLocker lock(&t.m_mutex);
+        t.m_lastHeartbeatNs = ns;
+    }
+
+    static int panUpdateSampleCount()
+    {
+        PerfTelemetry& t = PerfTelemetry::instance();
+        QMutexLocker lock(&t.m_mutex);
+        return static_cast<int>(t.m_window.panUpdateMs.size());
+    }
+
+    static void triggerSummary(qint64 now)
+    {
+        PerfTelemetry::instance().maybeLogSummary(now);
+    }
+
+    static double callPercentile95(QVector<double> values)
+    {
+        return PerfTelemetry::percentile95(std::move(values));
+    }
+};
+
+} // namespace AetherSDR
+
+namespace {
+
+using AetherSDR::PerfTelemetry;
+using AetherSDR::PerfTelemetryTestAccess;
+
+int g_failed = 0;
+
+struct CapturedLines {
+    static CapturedLines& instance()
+    {
+        static CapturedLines cap;
+        return cap;
+    }
+
+    QMutex mutex;
+    QStringList lines;
+
+    void clear()
+    {
+        QMutexLocker lock(&mutex);
+        lines.clear();
+    }
+
+    QStringList snapshot()
+    {
+        QMutexLocker lock(&mutex);
+        return lines;
+    }
+};
+
+void perfMessageHandler(QtMsgType, const QMessageLogContext& ctx, const QString& msg)
+{
+    if (ctx.category && QLatin1String(ctx.category) == QLatin1String("aether.perf")) {
+        QMutexLocker lock(&CapturedLines::instance().mutex);
+        CapturedLines::instance().lines.append(msg);
+    }
+}
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok)
+        ++g_failed;
+}
+
+void enablePerf()
+{
+    QLoggingCategory::setFilterRules(QStringLiteral("aether.perf.debug=true"));
+}
+
+void disablePerf()
+{
+    QLoggingCategory::setFilterRules(QStringLiteral("aether.perf.debug=false"));
+}
+
+bool nearlyEqual(double a, double b, double eps = 0.001)
+{
+    return std::fabs(a - b) < eps;
+}
+
+QString fieldValue(const QString& line, const QString& key)
+{
+    const QString prefix = key + QLatin1Char('=');
+    const auto tokens = line.split(QLatin1Char(' '));
+    for (const QString& token : tokens) {
+        if (token.startsWith(prefix))
+            return token.mid(prefix.size());
+    }
+    return {};
+}
+
+QString findLineStartingWith(const QStringList& lines, const QString& prefix)
+{
+    for (const QString& line : lines) {
+        if (line.startsWith(prefix))
+            return line;
+    }
+    return {};
+}
+
+QString findStallOfKind(const QStringList& lines, const QString& kind)
+{
+    for (const QString& l : lines) {
+        if (l.startsWith(QStringLiteral("PerfStall")) &&
+            fieldValue(l, QStringLiteral("kind")) == kind) {
+            return l;
+        }
+    }
+    return {};
+}
+
+void testDisabledHotPathIsNoOp()
+{
+    disablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    CapturedLines::instance().clear();
+
+    for (int i = 0; i < 100; ++i)
+        PerfTelemetry::instance().recordPanUpdate(50.0);
+
+    const QStringList lines = CapturedLines::instance().snapshot();
+    const int samples = PerfTelemetryTestAccess::panUpdateSampleCount();
+
+    report("disabled lcPerf emits no perf log lines",
+           lines.isEmpty());
+    report("disabled lcPerf mutates no window state",
+           samples == 0);
+}
+
+void testStallThresholdPanUpdateAbove()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
+    CapturedLines::instance().clear();
+
+    PerfTelemetry::instance().recordPanUpdate(9.0);
+
+    const QString stall = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("updateSpectrum"));
+    report("panUpdate 9.0ms emits PerfStall kind=updateSpectrum (>8ms)",
+           !stall.isEmpty() &&
+           fieldValue(stall, QStringLiteral("durationMs")) == QStringLiteral("9.0"));
+}
+
+void testStallThresholdPanUpdateBelow()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
+    CapturedLines::instance().clear();
+
+    PerfTelemetry::instance().recordPanUpdate(7.0);
+
+    report("panUpdate 7.0ms emits no PerfStall (<8ms threshold)",
+           findLineStartingWith(CapturedLines::instance().snapshot(),
+                                QStringLiteral("PerfStall")).isEmpty());
+}
+
+void testStallThresholdFrameAge()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
+
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordFrameAge(PerfTelemetry::FrameKind::Panadapter, 101.0);
+    const QString above = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("frameAge"));
+
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordFrameAge(PerfTelemetry::FrameKind::Panadapter, 99.0);
+    const QString below = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("frameAge"));
+
+    report("frameAge 101ms emits PerfStall kind=frameAge (>100ms)",
+           !above.isEmpty() &&
+           fieldValue(above, QStringLiteral("stream")) == QStringLiteral("panadapter"));
+    report("frameAge 99ms emits no PerfStall (<100ms threshold)",
+           below.isEmpty());
+}
+
+void testStallThresholdRender()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
+
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordRender(17.0);
+    const QString above = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("render"));
+
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordRender(15.0);
+    const QString below = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("render"));
+
+    report("render 17.0ms emits PerfStall kind=render (>16ms)",
+           !above.isEmpty());
+    report("render 15.0ms emits no PerfStall (<16ms threshold)",
+           below.isEmpty());
+}
+
+void testStallThresholdUdpDrain()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
+
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordUdpBatch(5, 1500, 9.0);
+    const QString above = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("udpDrain"));
+
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordUdpBatch(5, 1500, 7.0);
+    const QString below = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("udpDrain"));
+
+    report("udpDrain 9.0ms emits PerfStall kind=udpDrain (>8ms)",
+           !above.isEmpty());
+    report("udpDrain 7.0ms emits no PerfStall (<8ms threshold)",
+           below.isEmpty());
+}
+
+void testStallThresholdWaterfallUpdate()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
+
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordWaterfallUpdate(13.0);
+    const QString above = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("updateWaterfallRow"));
+
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordWaterfallUpdate(11.0);
+    const QString below = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("updateWaterfallRow"));
+
+    report("waterfallUpdate 13.0ms emits PerfStall kind=updateWaterfallRow (>12ms)",
+           !above.isEmpty());
+    report("waterfallUpdate 11.0ms emits no PerfStall (<12ms threshold)",
+           below.isEmpty());
+}
+
+void testStallThresholdInput()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
+
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordInputEvent("mouseMove", 17.0);
+    const QString above = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("input"));
+
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordInputEvent("mouseMove", 15.0);
+    const QString below = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("input"));
+
+    report("input 17.0ms emits PerfStall kind=input (>16ms)",
+           !above.isEmpty() &&
+           fieldValue(above, QStringLiteral("event")) == QStringLiteral("mouseMove"));
+    report("input 15.0ms emits no PerfStall (<16ms threshold)",
+           below.isEmpty());
+}
+
+void testDragAwareUiLagIdleBelowBoth()
+{
+    // gap=80ms → lag=max(0, 80-50)=30ms. Below idle (50) and drag (33). No stall.
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
+    PerfTelemetry::instance().setDragActive(false);
+
+    const qint64 now = PerfTelemetry::nowNs();
+    PerfTelemetryTestAccess::setLastHeartbeat(now - 80LL * 1000000LL);
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordUiHeartbeat();
+
+    report("idle UI heartbeat gap=80ms (lag=30) emits no stall",
+           findStallOfKind(CapturedLines::instance().snapshot(),
+                           QStringLiteral("uiHeartbeat")).isEmpty());
+}
+
+void testDragAwareUiLagDragStall()
+{
+    // gap=90ms → lag=40ms. Below idle (50), above drag (33). Drag stall fires.
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
+    PerfTelemetry::instance().setDragActive(true);
+
+    const qint64 now = PerfTelemetry::nowNs();
+    PerfTelemetryTestAccess::setLastHeartbeat(now - 90LL * 1000000LL);
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordUiHeartbeat();
+
+    const QString stall = findStallOfKind(CapturedLines::instance().snapshot(),
+                                          QStringLiteral("uiHeartbeat"));
+    report("drag-active UI heartbeat gap=90ms (lag=40) emits stall (>33ms drag threshold)",
+           !stall.isEmpty() &&
+           fieldValue(stall, QStringLiteral("drag")) == QStringLiteral("1"));
+}
+
+void testDragAwareUiLagIdleSameGapNoStall()
+{
+    // gap=90ms idle → lag=40, < 50 idle threshold. No stall.
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    PerfTelemetryTestAccess::primeForRecording(PerfTelemetry::nowNs());
+    PerfTelemetry::instance().setDragActive(false);
+
+    const qint64 now = PerfTelemetry::nowNs();
+    PerfTelemetryTestAccess::setLastHeartbeat(now - 90LL * 1000000LL);
+    CapturedLines::instance().clear();
+    PerfTelemetry::instance().recordUiHeartbeat();
+
+    report("idle UI heartbeat gap=90ms (lag=40) emits no stall (<50ms idle threshold)",
+           findStallOfKind(CapturedLines::instance().snapshot(),
+                           QStringLiteral("uiHeartbeat")).isEmpty());
+}
+
+void testFrameRestartCounter()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    const qint64 baseNs = PerfTelemetry::nowNs();
+    PerfTelemetryTestAccess::primeForRecording(baseNs);
+
+    for (int i = 0; i < 3; ++i)
+        PerfTelemetry::instance().recordFrameRestart(PerfTelemetry::FrameKind::Panadapter);
+
+    PerfTelemetryTestAccess::setWindowStart(baseNs - 2LL * 1000000000LL);
+    CapturedLines::instance().clear();
+    PerfTelemetryTestAccess::triggerSummary(baseNs);
+
+    const QString summary = findLineStartingWith(CapturedLines::instance().snapshot(),
+                                                 QStringLiteral("PerfSummary"));
+    report("3 panadapter frame restarts produce fftRestarts=3 in next summary",
+           !summary.isEmpty() &&
+           fieldValue(summary, QStringLiteral("fftRestarts")) == QStringLiteral("3"));
+}
+
+void testPercentile95Empty()
+{
+    report("percentile95 of empty vector returns 0.0",
+           nearlyEqual(PerfTelemetryTestAccess::callPercentile95(QVector<double>{}), 0.0));
+}
+
+void testPercentile95Single()
+{
+    report("percentile95 of single value returns that value",
+           nearlyEqual(PerfTelemetryTestAccess::callPercentile95(QVector<double>{42.5}), 42.5));
+}
+
+void testPercentile95Hundred()
+{
+    QVector<double> values;
+    for (int i = 1; i <= 100; ++i)
+        values.append(static_cast<double>(i));
+    report("percentile95 of [1..100] returns 95.0",
+           nearlyEqual(PerfTelemetryTestAccess::callPercentile95(values), 95.0));
+}
+
+void testPercentile95OrderInvariant()
+{
+    QVector<double> sorted;
+    for (int i = 1; i <= 50; ++i)
+        sorted.append(static_cast<double>(i));
+    QVector<double> shuffled = sorted;
+    for (int i = 0; i + 1 < shuffled.size(); i += 2)
+        std::swap(shuffled[i], shuffled[i + 1]);
+
+    const double a = PerfTelemetryTestAccess::callPercentile95(sorted);
+    const double b = PerfTelemetryTestAccess::callPercentile95(shuffled);
+    report("percentile95 is invariant to input ordering",
+           nearlyEqual(a, b));
+}
+
+void testWindowTimingBefore1s()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    const qint64 baseNs = PerfTelemetry::nowNs();
+    PerfTelemetryTestAccess::primeForRecording(baseNs);
+
+    PerfTelemetry::instance().recordPanFrame();
+    CapturedLines::instance().clear();
+
+    PerfTelemetryTestAccess::triggerSummary(baseNs + 950LL * 1000000LL);
+
+    report("elapsed 950ms does not trigger summary",
+           findLineStartingWith(CapturedLines::instance().snapshot(),
+                                QStringLiteral("PerfSummary")).isEmpty());
+}
+
+void testWindowTimingAfter1s()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    const qint64 baseNs = PerfTelemetry::nowNs();
+    PerfTelemetryTestAccess::primeForRecording(baseNs);
+
+    PerfTelemetry::instance().recordPanFrame();
+    PerfTelemetry::instance().recordPanFrame();
+    PerfTelemetry::instance().recordPanFrame();
+    CapturedLines::instance().clear();
+
+    PerfTelemetryTestAccess::triggerSummary(baseNs + 1100LL * 1000000LL);
+
+    const QString summary = findLineStartingWith(CapturedLines::instance().snapshot(),
+                                                 QStringLiteral("PerfSummary"));
+    report("elapsed 1100ms triggers summary",
+           !summary.isEmpty());
+}
+
+void testWindowResetsAfterSummary()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    const qint64 baseNs = PerfTelemetry::nowNs();
+    PerfTelemetryTestAccess::primeForRecording(baseNs);
+
+    PerfTelemetry::instance().recordPanFrame();
+    PerfTelemetry::instance().recordPanFrame();
+
+    PerfTelemetryTestAccess::triggerSummary(baseNs + 1100LL * 1000000LL);
+    CapturedLines::instance().clear();
+
+    PerfTelemetryTestAccess::triggerSummary(baseNs + 2200LL * 1000000LL);
+
+    const QString summary = findLineStartingWith(CapturedLines::instance().snapshot(),
+                                                 QStringLiteral("PerfSummary"));
+    report("window resets after summary - second summary has panFps=0.0",
+           !summary.isEmpty() &&
+           fieldValue(summary, QStringLiteral("panFps")) == QStringLiteral("0.0"));
+}
+
+void testWindowAggregationPanUpdateP95()
+{
+    enablePerf();
+    PerfTelemetryTestAccess::resetInstance();
+    const qint64 baseNs = PerfTelemetry::nowNs();
+    PerfTelemetryTestAccess::primeForRecording(baseNs);
+
+    // Feed 20 sub-threshold values 0.1..2.0; p95 index = ceil(20*0.95)-1 = 18 → 1.9.
+    for (int i = 1; i <= 20; ++i)
+        PerfTelemetry::instance().recordPanUpdate(static_cast<double>(i) * 0.1);
+
+    CapturedLines::instance().clear();
+    PerfTelemetryTestAccess::triggerSummary(baseNs + 1100LL * 1000000LL);
+
+    const QString summary = findLineStartingWith(CapturedLines::instance().snapshot(),
+                                                 QStringLiteral("PerfSummary"));
+    report("aggregation: panUpdateP95Ms reflects p95 of 20 recorded samples",
+           !summary.isEmpty() &&
+           fieldValue(summary, QStringLiteral("panUpdateP95Ms")) == QStringLiteral("1.9"));
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    qInstallMessageHandler(perfMessageHandler);
+
+    testDisabledHotPathIsNoOp();
+    testStallThresholdPanUpdateAbove();
+    testStallThresholdPanUpdateBelow();
+    testStallThresholdFrameAge();
+    testStallThresholdRender();
+    testStallThresholdUdpDrain();
+    testStallThresholdWaterfallUpdate();
+    testStallThresholdInput();
+    testDragAwareUiLagIdleBelowBoth();
+    testDragAwareUiLagDragStall();
+    testDragAwareUiLagIdleSameGapNoStall();
+    testFrameRestartCounter();
+    testPercentile95Empty();
+    testPercentile95Single();
+    testPercentile95Hundred();
+    testPercentile95OrderInvariant();
+    testWindowTimingBefore1s();
+    testWindowTimingAfter1s();
+    testWindowResetsAfterSummary();
+    testWindowAggregationPanUpdateP95();
+
+    qInstallMessageHandler(nullptr);
+
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/perf_telemetry_test.cpp
+++ b/tests/perf_telemetry_test.cpp
@@ -1,13 +1,22 @@
 // Unit tests for PerfTelemetry — issue #2500.
 //
-// Covers: disabled hot-path no-op, window aggregation, stall thresholds,
-// drag-aware UI lag, frame-restart counter, percentile-95 boundaries, and
-// window timing — by driving the singleton through its public record* API
-// with a synthetic clock seam (setClockOverrideForTest) and capturing the
-// lcPerf log line via qInstallMessageHandler.
+// Drives the singleton through its public record* API with a synthetic
+// clock seam (setClockOverrideForTest) so window cadence is deterministic
+// without real sleeps. Output is captured via qInstallMessageHandler and
+// matched on key=value field extraction from emitted PerfStall /
+// PerfSummary lines.
 //
-// CMake target `perf_telemetry_test`. Exit 0 = pass.
+// Coverage matches the matrix in the issue body:
+//   - disabled hot-path is a no-op
+//   - window aggregation (count / p95)
+//   - per-window reset isolation
+//   - stall threshold matrix for every record* path
+//   - drag-aware UI lag thresholds (50 ms idle / 33 ms drag)
+//   - frame-restart counter aggregation
+//   - percentile95 boundary cases (empty / single / 100 sorted / 100 reversed)
+//   - 1 s window cadence (no fire at 950 ms, fire at 1100 ms)
 
+#include "core/LogManager.h"
 #include "core/PerfTelemetry.h"
 
 #include <QCoreApplication>
@@ -20,15 +29,6 @@
 #include <functional>
 #include <string>
 #include <vector>
-
-// PerfTelemetry.cpp uses lcPerf via LogManager.h. Standalone tests provide
-// their own definition rather than pulling LogManager (which would drag in
-// AppSettings, AsyncLogWriter, etc.). Default level is QtDebugMsg so the
-// hot path is "enabled" — tests flip rules off when they need the disabled
-// path verified.
-namespace AetherSDR {
-Q_LOGGING_CATEGORY(lcPerf, "aether.perf", QtDebugMsg)
-} // namespace AetherSDR
 
 using AetherSDR::PerfTelemetry;
 
@@ -45,10 +45,7 @@ void messageHandler(QtMsgType, const QMessageLogContext& ctx, const QString& msg
 
 void report(const char* name, bool ok, const std::string& detail = {})
 {
-    std::printf("%s %-58s %s\n",
-                ok ? "[ OK ]" : "[FAIL]",
-                name,
-                detail.c_str());
+    std::printf("%s %-58s %s\n", ok ? "[ OK ]" : "[FAIL]", name, detail.c_str());
     if (!ok) ++g_failed;
 }
 
@@ -57,48 +54,47 @@ void resetCapture()
     g_capturedLines.clear();
 }
 
-QStringList stallLines()
+QStringList linesStartingWith(const char* prefix)
 {
     QStringList out;
     for (const auto& line : g_capturedLines)
-        if (line.startsWith(QLatin1String("PerfStall")))
+        if (line.startsWith(QLatin1String(prefix)))
             out << line;
     return out;
 }
 
-QStringList summaryLines()
-{
-    QStringList out;
-    for (const auto& line : g_capturedLines)
-        if (line.startsWith(QLatin1String("PerfSummary")))
-            out << line;
-    return out;
-}
+QStringList stallLines()   { return linesStartingWith("PerfStall"); }
+QStringList summaryLines() { return linesStartingWith("PerfSummary"); }
 
 QString fieldValue(const QString& line, const QString& key)
 {
     const QStringList parts = line.split(QLatin1Char(' '));
     const QString prefix = key + QLatin1Char('=');
-    for (const auto& part : parts) {
+    for (const auto& part : parts)
         if (part.startsWith(prefix))
             return part.mid(prefix.size());
-    }
     return {};
 }
 
+// Pin the clock to t0, zero singleton state, and clear the captured log
+// buffer. The next record* call will open a fresh window at t0.
 void prime(qint64 t0)
 {
-    // Reset state and pin the clock — the next record call will start a
-    // fresh window at t0.
     PerfTelemetry::setClockOverrideForTest(t0);
     PerfTelemetry::instance().resetForTest();
     resetCapture();
 }
 
-// Advance synthetic clock to the next 1-second boundary and emit a final
-// recordPanFrame so maybeLogSummary fires. Returns the captured summary.
+// Advance the synthetic clock past the 1 s window boundary and emit a
+// recordPanFrame so maybeLogSummary fires. Returns the final captured
+// summary line. The initial recordPanCenterCommand at windowStartNs
+// guarantees a window is open at that time even if the caller has not
+// emitted any aggregated record* calls (this matters for the empty-input
+// percentile case where the panUpdate vector should be empty).
 QString flushSummary(qint64 windowStartNs)
 {
+    PerfTelemetry::setClockOverrideForTest(windowStartNs);
+    PerfTelemetry::instance().recordPanCenterCommand();
     PerfTelemetry::setClockOverrideForTest(windowStartNs + 1'100'000'000LL);
     PerfTelemetry::instance().recordPanFrame();
     const auto summaries = summaryLines();
@@ -124,25 +120,23 @@ void testDisabledHotPath()
     QLoggingCategory::setFilterRules(QStringLiteral("aether.perf.debug=true"));
 }
 
-// --- Window aggregation: count, p95, max ------------------------------------
+// --- Window aggregation -----------------------------------------------------
 
 void testWindowAggregation()
 {
     constexpr qint64 t0 = 5'000'000'000LL;
     prime(t0);
 
-    // Feed 10 panUpdate samples below the stall threshold (8.0 ms) so no
-    // PerfStall lines are emitted — they would otherwise crowd capture.
-    // Values: 1, 2, 3, 4, 5, 6, 7, 7.5, 7.8, 7.9 — all <= 8.0.
+    // 10 samples all <= 8.0 ms (panUpdate stall threshold) so no PerfStall
+    // lines contaminate the capture buffer.
     const std::vector<double> samples = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.5, 7.8, 7.9};
     for (double v : samples)
         PerfTelemetry::instance().recordPanUpdate(v);
 
     const QString summary = flushSummary(t0);
-    const bool hasSummary = !summary.isEmpty();
-    report("window aggregation emits a summary", hasSummary);
+    report("window aggregation emits a summary", !summary.isEmpty());
 
-    if (hasSummary) {
+    if (!summary.isEmpty()) {
         // percentile95 for N=10: ceil(10*0.95)-1 = 9, sorted[9] = 7.9
         const QString p95 = fieldValue(summary, QStringLiteral("panUpdateP95Ms"));
         report("panUpdateP95Ms equals 7.9 for 10 sorted samples",
@@ -151,7 +145,7 @@ void testWindowAggregation()
     }
 }
 
-// --- Window resets after summary --------------------------------------------
+// --- Window state does not leak across summaries ----------------------------
 
 void testWindowResetsAfterSummary()
 {
@@ -163,23 +157,21 @@ void testWindowResetsAfterSummary()
     PerfTelemetry::instance().recordPanUpdate(7.0);
     (void)flushSummary(t0);
 
-    // Now drive a fresh window from t0 + 1.1s onward and verify the new
-    // summary doesn't carry the prior window's panUpdate samples.
-    constexpr qint64 t1 = 10'000'000'000LL + 1'100'000'000LL;
+    constexpr qint64 t1 = t0 + 1'100'000'000LL;
     resetCapture();
     PerfTelemetry::setClockOverrideForTest(t1);
     PerfTelemetry::instance().recordPanUpdate(1.0);
 
     const QString summary = flushSummary(t1);
     const QString p95 = fieldValue(summary, QStringLiteral("panUpdateP95Ms"));
-    // Second window had one sample at 1.0, then flushSummary added a
-    // recordPanFrame (which doesn't add to panUpdateMs). So P95 should be 1.0.
+    // Second window saw only 1.0 (the recordPanFrame in flushSummary adds
+    // nothing to panUpdateMs), so the prior 5/6/7 samples must be gone.
     report("window state does not bleed across summaries",
            p95 == QLatin1String("1.0"),
            std::string("got '") + p95.toStdString() + "'");
 }
 
-// --- Stall thresholds -------------------------------------------------------
+// --- Stall threshold matrix -------------------------------------------------
 
 void testStallThresholdMatrix()
 {
@@ -191,9 +183,8 @@ void testStallThresholdMatrix()
         std::function<void(double)> trigger;
     };
 
-    // Threshold values are duplicated from PerfTelemetry.cpp — if either
-    // drifts, these tests must be updated in lockstep with the production
-    // constants.
+    // Thresholds duplicated from PerfTelemetry.cpp; if either side drifts,
+    // these test values must move in lockstep.
     const std::vector<Case> cases = {
         {"panUpdate stall (8.0 ms)", 7.5, 8.5, QStringLiteral("updateSpectrum"),
             [](double v){ PerfTelemetry::instance().recordPanUpdate(v); }},
@@ -211,26 +202,24 @@ void testStallThresholdMatrix()
 
     qint64 t = 100'000'000'000LL;
     for (const auto& c : cases) {
-        // Below-threshold: no stall.
+        // Below threshold: no stall of this kind.
         prime(t);
         c.trigger(c.justUnder);
-        bool sawStallBelow = false;
+        bool sawBelow = false;
         for (const auto& line : stallLines())
             if (fieldValue(line, QStringLiteral("kind")) == c.expectedStallKind)
-                sawStallBelow = true;
-        report((std::string(c.name) + " below threshold: no stall").c_str(),
-               !sawStallBelow);
+                sawBelow = true;
+        report((std::string(c.name) + " below threshold: no stall").c_str(), !sawBelow);
 
-        // Above-threshold: stall fires.
+        // Above threshold: stall fires.
         t += 5'000'000'000LL;
         prime(t);
         c.trigger(c.justOver);
-        bool sawStallAbove = false;
+        bool sawAbove = false;
         for (const auto& line : stallLines())
             if (fieldValue(line, QStringLiteral("kind")) == c.expectedStallKind)
-                sawStallAbove = true;
-        report((std::string(c.name) + " above threshold: stall fires").c_str(),
-               sawStallAbove);
+                sawAbove = true;
+        report((std::string(c.name) + " above threshold: stall fires").c_str(), sawAbove);
 
         t += 5'000'000'000LL;
     }
@@ -238,16 +227,15 @@ void testStallThresholdMatrix()
 
 // --- Drag-aware UI lag thresholds -------------------------------------------
 //
-// Lag is computed as max(0, gap - kHeartbeatIntervalMs) where the heartbeat
-// interval is 50 ms. Idle stall threshold is 50 ms (so gap > 100 ms); drag
-// stall threshold is 33 ms (so gap > 83 ms). A 90 ms gap → lag=40, which
-// trips drag but not idle.
+// lagMs = max(0, gap - kHeartbeatIntervalMs)  where heartbeat interval = 50 ms.
+// Idle stall threshold = 50 ms (so gap > 100 ms).
+// Drag stall threshold = 33 ms (so gap > 83 ms).
 
 void testUiHeartbeatDragThresholds()
 {
     constexpr qint64 t0 = 200'000'000'000LL;
 
-    // Idle, gap = 90 ms → lag = 40 ms < 50 ms idle threshold → no stall.
+    // Idle, gap = 90 ms → lag = 40 ms < 50 → no stall.
     prime(t0);
     PerfTelemetry::instance().setDragActive(false);
     PerfTelemetry::instance().recordUiHeartbeat();
@@ -259,7 +247,7 @@ void testUiHeartbeatDragThresholds()
             sawIdleStall = true;
     report("uiHeartbeat idle 90ms gap (lag=40): no stall", !sawIdleStall);
 
-    // Drag, same 90 ms gap → lag = 40 ms > 33 ms drag threshold → stall.
+    // Drag, same 90 ms gap → lag = 40 ms > 33 → stall fires.
     const qint64 t1 = t0 + 5'000'000'000LL;
     prime(t1);
     PerfTelemetry::instance().setDragActive(true);
@@ -272,7 +260,7 @@ void testUiHeartbeatDragThresholds()
             sawDragStall = true;
     report("uiHeartbeat drag 90ms gap (lag=40): stall fires", sawDragStall);
 
-    // Idle, gap = 110 ms → lag = 60 ms > 50 ms idle threshold → stall.
+    // Idle, gap = 110 ms → lag = 60 ms > 50 → stall fires.
     const qint64 t2 = t1 + 5'000'000'000LL;
     prime(t2);
     PerfTelemetry::instance().setDragActive(false);
@@ -304,12 +292,12 @@ void testFrameRestartCounter()
            std::string("got '") + restarts.toStdString() + "'");
 }
 
-// --- Percentile-95 boundary cases (exercised via the public record path) ----
+// --- Percentile-95 boundary cases (exercised through the public path) ------
 
 void testPercentile95Boundaries()
 {
-    // Empty input — no panUpdate samples, but a recordPanFrame to ensure
-    // maybeLogSummary fires.
+    // Empty input — no panUpdate samples; flushSummary's recordPanFrame
+    // triggers maybeLogSummary without adding any panUpdate samples.
     {
         constexpr qint64 t0 = 400'000'000'000LL;
         prime(t0);
@@ -320,7 +308,7 @@ void testPercentile95Boundaries()
                std::string("got '") + p95.toStdString() + "'");
     }
 
-    // Single value — keep it under the 8 ms stall threshold.
+    // Single value — kept under the 8 ms stall threshold.
     {
         constexpr qint64 t0 = 410'000'000'000LL;
         prime(t0);
@@ -332,10 +320,8 @@ void testPercentile95Boundaries()
                std::string("got '") + p95.toStdString() + "'");
     }
 
-    // 100 values [1..100] — render samples (threshold 16 ms) lets values
-    // 1..15 pass without stall noise; for percentile coverage use frameAge
-    // which has a 100 ms threshold — we want all 100 values under it.
-    // frameAge stall fires at > 100, so 1..100 are all clean.
+    // 100 values [1..100] via frameAge (threshold 100 ms, so 1..100 are
+    // all clean and don't spam PerfStall lines).
     {
         constexpr qint64 t0 = 420'000'000'000LL;
         prime(t0);
@@ -350,8 +336,8 @@ void testPercentile95Boundaries()
                std::string("got '") + p95.toStdString() + "'");
     }
 
-    // Same 100 values fed in reverse — sort inside percentile95 should give
-    // the same result.
+    // Same values fed in reverse — the internal sort must yield the same
+    // result regardless of insertion order.
     {
         constexpr qint64 t0 = 430'000'000'000LL;
         prime(t0);
@@ -366,14 +352,14 @@ void testPercentile95Boundaries()
     }
 }
 
-// --- Window timing ----------------------------------------------------------
+// --- Window timing ---------------------------------------------------------
 
 void testWindowTiming()
 {
     constexpr qint64 t0 = 500'000'000'000LL;
     prime(t0);
 
-    // Samples spread across 950 ms — no summary yet.
+    // Spread samples across 950 ms — summary must not fire yet.
     PerfTelemetry::setClockOverrideForTest(t0);
     PerfTelemetry::instance().recordPanUpdate(1.0);
     PerfTelemetry::setClockOverrideForTest(t0 + 300'000'000LL);
@@ -387,14 +373,13 @@ void testWindowTiming()
            summaryLines().isEmpty(),
            std::string("got ") + std::to_string(summaryLines().size()) + " summary lines");
 
-    // One more sample past the 1 s boundary — summary should fire and
-    // include all five samples in panUpdateP95Ms.
+    // One more sample past the 1 s boundary — summary fires and includes
+    // every sample from the window.
     PerfTelemetry::setClockOverrideForTest(t0 + 1'100'000'000LL);
     PerfTelemetry::instance().recordPanUpdate(5.0);
 
     const auto summaries = summaryLines();
-    report("summary fires once 1s window elapses",
-           !summaries.isEmpty());
+    report("summary fires once 1s window elapses", !summaries.isEmpty());
 
     if (!summaries.isEmpty()) {
         const QString p95 = fieldValue(summaries.last(), QStringLiteral("panUpdateP95Ms"));


### PR DESCRIPTION
## Summary

Fixes #2500

### What was changed

Covers the matrix from the issue: disabled hot-path no-op, window
aggregation count/p95, window-reset isolation, the full stall-threshold
matrix (panUpdate / waterfallUpdate / render / frameAge / udpDrain /
input), drag-aware UI lag thresholds (50 ms idle / 33 ms drag), the
frame-restart counter, percentile-95 boundary cases (empty / single /
[1..100] sorted / 100 reversed), and the 1 s window cadence (no fire
at 950 ms, fire at 1100 ms).

Two purely additive test seams land on PerfTelemetry:
`setClockOverrideForTest(qint64)` pins nowNs() to a synthetic value so
window timing is deterministic without real sleeps, and `resetForTest()`
zeroes aggregation state between cases so the singleton doesn't leak
between tests. The clock override is a single relaxed atomic load in
the hot path; when zero (production default) the original steady_clock
path is used unchanged, so the existing record* call surface that the
17 high-risk callers reach is untouched in shape or behavior.

The test executable links LogManager.cpp + AsyncLogWriter.cpp +
AppSettings.cpp instead of redeclaring its own Q_LOGGING_CATEGORY for
`aether.perf` — this honors Principle III's consolidation (one
canonical definition site per category, per #2770) and matches the
linkage pattern established by `ax25_libmodem_shim_test`. Output is
captured via qInstallMessageHandler filtered to `aether.perf` and
matched on key=value field extraction from emitted PerfStall and
PerfSummary lines.

Blast radius: risk_score=0.418, 17 high-risk affected (top:
MainWindow::MainWindow, MainWindow::wirePanadapter, MainWindow::buildUI,
RadioModel::onStatusReceived, MainWindow::buildMenuBar). All these
reach PerfTelemetry through its existing public record* API which is
unchanged; the additions are two new public test-only methods plus one
relaxed atomic load in nowNs() that is a no-op when the override is
the default zero.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

### Recovery note

This PR is being opened manually. The aetherclaude orchestrator (trace fe2b51d0) pushed the signed commit at 17:53 PDT but died at the next bash line due to a set -e race with commit-signed.js's exit code. Root cause + fix shipped as 4832725 (run-agent: guard commit-signed + create-pr against set -e silent death).

---
Generated by AetherClaude (automated agent for AetherSDR) — PR creation completed manually after orchestrator interrupt.