### PR TITLE
Add ctrl-drag waterfall rate control

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10595,14 +10595,17 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             this, [sw](int offset) {
         sw->setWfAutoBlackOffset(offset);
     });
-    connect(menu, &SpectrumOverlayMenu::wfLineDurationChanged,
-            this, [this, applet, sw](int ms) {
+    const auto applyWaterfallLineDuration = [this, applet, sw](int ms) {
         sw->setWfLineDuration(ms);
         auto* pan = m_radioModel.panadapter(applet->panId());
         if (pan && !pan->waterfallId().isEmpty())
             m_radioModel.sendCommand(
                 QString("display panafall set %1 line_duration=%2").arg(pan->waterfallId()).arg(ms));
-    });
+    };
+    connect(menu, &SpectrumOverlayMenu::wfLineDurationChanged,
+            this, applyWaterfallLineDuration);
+    connect(sw, &SpectrumWidget::waterfallLineDurationChangeRequested,
+            this, applyWaterfallLineDuration);
     // NB Waterfall Blanker (#277)
     connect(menu, &SpectrumOverlayMenu::wfBlankerEnabledChanged,
             sw, &SpectrumWidget::setWfBlankerEnabled);

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -20,10 +20,28 @@
 #include <QFrame>
 #include <QColorDialog>
 
+#include <algorithm>
+
 namespace AetherSDR {
 
 static constexpr int BTN_W = 68;
 static constexpr int BTN_H = 22;
+static constexpr int WF_RATE_SLIDER_MIN = 1;
+static constexpr int WF_RATE_SLIDER_MAX = 30;
+static constexpr int WF_LINE_DURATION_OFFSET = 70;
+
+static int lineDurationToRateSliderValue(int lineDuration)
+{
+    return std::clamp(lineDuration - WF_LINE_DURATION_OFFSET,
+                      WF_RATE_SLIDER_MIN,
+                      WF_RATE_SLIDER_MAX);
+}
+
+static int rateSliderValueToLineDuration(int sliderValue)
+{
+    return std::clamp(sliderValue, WF_RATE_SLIDER_MIN, WF_RATE_SLIDER_MAX)
+        + WF_LINE_DURATION_OFFSET;
+}
 
 // Band button size (slightly smaller for the grid)
 static constexpr int BAND_BTN_W = 48;
@@ -987,10 +1005,12 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     });
 
     // Rate
-    makeRow("WtrFall Rate:", 1, 30, 15, m_rateSlider, m_rateLabel);
+    makeRow("WtrFall Rate:", WF_RATE_SLIDER_MIN, WF_RATE_SLIDER_MAX,
+            lineDurationToRateSliderValue(85), m_rateSlider, m_rateLabel);
     connect(m_rateSlider, &QSlider::valueChanged, this, [this](int v) {
+        const int lineDurationMs = rateSliderValueToLineDuration(v);
         m_rateLabel->setText(QString::number(v));
-        emit wfLineDurationChanged(v + 70);
+        emit wfLineDurationChanged(lineDurationMs);
     });
 
     // BG Opacity
@@ -1095,7 +1115,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     m_gainSlider->setToolTip("Waterfall color gain. Higher values brighten weak signals.");
     m_blackSlider->setToolTip("Waterfall black level. Decrease to darken the noise floor.");
     if (m_autoBlackBtn) m_autoBlackBtn->setToolTip("Automatically adjusts the waterfall black level to match the current noise floor.");
-    m_rateSlider->setToolTip("Waterfall line duration. Higher values scroll faster.");
+    m_rateSlider->setToolTip("Waterfall line duration. Higher values scroll slower.");
     if (m_wfBlankerThreshSlider) m_wfBlankerThreshSlider->setToolTip("Waterfall noise blanking threshold. Higher values blank more aggressively.");
     if (m_freqGridSpacingCmb) m_freqGridSpacingCmb->setToolTip("Frequency grid line spacing. Auto adapts to the current span.");
     if (m_colorSchemeCmb) m_colorSchemeCmb->setToolTip("Selects the waterfall color palette.");
@@ -1143,9 +1163,7 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
         ? "Auto-black target offset. 50 = at noise floor; lower = darker, higher = lighter."
         : "Waterfall black level. Decrease to darken the noise floor.");
     m_autoBlackBtn->setChecked(autoBlack);
-    int rateSliderVal = std::clamp(rate - 70, 1, 30);  // line_duration 71-100 → slider 1-30
-    m_rateSlider->setValue(rateSliderVal);
-    m_rateLabel->setText(QString::number(rateSliderVal));
+    syncWfLineDuration(rate);
 
     if (m_floorSlider) {
         QSignalBlocker bf(m_floorSlider), be(m_floorEnableBtn);
@@ -1184,6 +1202,18 @@ void SpectrumOverlayMenu::syncNoiseFloorPosition(int pos)
     if (m_floorLabel) {
         m_floorLabel->setText(QString::number(clamped));
     }
+}
+
+void SpectrumOverlayMenu::syncWfLineDuration(int rate)
+{
+    if (!m_rateSlider || !m_rateLabel) {
+        return;
+    }
+
+    QSignalBlocker blocker(m_rateSlider);
+    const int sliderValue = lineDurationToRateSliderValue(rate);
+    m_rateSlider->setValue(sliderValue);
+    m_rateLabel->setText(QString::number(sliderValue));
 }
 
 void SpectrumOverlayMenu::syncExtraDisplaySettings(bool blankerOn, float blankerThresh,

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -49,6 +49,7 @@ public:
                              bool heatMap = true, int colorScheme = 0,
                              bool showGrid = true,
                              float lineWidth = 2.0f);
+    void syncWfLineDuration(int rate);
     // Sync blanker/cursor/opacity controls not covered by syncDisplaySettings.
     void syncExtraDisplaySettings(bool blankerOn, float blankerThresh,
                                   int bgOpacity,

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -58,6 +58,10 @@ static const QColor kAetherBrandBlue(0x00, 0xb4, 0xd8);
 static const QColor kAetherBrandGreen(0x20, 0xc0, 0x60);
 static const QColor kConnectionTextColor(0xd8, 0xe6, 0xf0);
 static constexpr float kMinDisplayDbm = -180.0f;
+static constexpr int kWaterfallLineDurationMinMs = 50;
+static constexpr int kWaterfallLineDurationMaxMs = 500;
+static constexpr int kWaterfallUiRateMinMs = 71;
+static constexpr int kWaterfallUiRateMaxMs = 100;
 
 static bool spotMarkersVisuallyEqual(const QVector<SpectrumWidget::SpotMarker>& lhs,
                                      const QVector<SpectrumWidget::SpotMarker>& rhs)
@@ -443,7 +447,9 @@ void SpectrumWidget::loadSettings()
     m_wfBlackLevel   = s.value(settingsKey("DisplayWfBlackLevel"), "15").toInt();
     m_wfAutoBlack    = s.value(settingsKey("DisplayWfAutoBlack"), "True").toString() == "True";
     m_wfAutoBlackOffset = s.value(settingsKey("DisplayWfAutoBlackOffset"), "50").toInt();
-    m_wfLineDuration = s.value(settingsKey("DisplayWfLineDuration"), "100").toInt();
+    m_wfLineDuration = std::clamp(s.value(settingsKey("DisplayWfLineDuration"), "100").toInt(),
+                                  kWaterfallLineDurationMinMs,
+                                  kWaterfallLineDurationMaxMs);
     PerfTelemetry::instance().setWaterfallLineDurationMs(m_wfLineDuration);
     // NB Waterfall Blanker (#277)
     m_wfBlankerEnabled   = s.value(settingsKey("WaterfallBlankingEnabled"), "False").toString() == "True";
@@ -816,6 +822,7 @@ bool SpectrumWidget::anyDragActive() const {
         || m_draggingDbm
         || m_draggingDbmRange
         || m_draggingTimeScale
+        || m_draggingTimeScaleRate
         || m_draggingTnfId >= 0;
 }
 void SpectrumWidget::publishPerfDragState() const {
@@ -1192,15 +1199,27 @@ void SpectrumWidget::setWfAutoBlackOffset(int level) {
     update();
 }
 void SpectrumWidget::setWfLineDuration(int ms) {
-    m_wfLineDuration = std::clamp(ms, 50, 500);
+    const int clamped = std::clamp(ms, kWaterfallLineDurationMinMs, kWaterfallLineDurationMaxMs);
+    if (m_wfLineDuration == clamped) {
+        if (m_overlayMenu) {
+            m_overlayMenu->syncWfLineDuration(m_wfLineDuration);
+        }
+        return;
+    }
+
+    m_wfLineDuration = clamped;
     PerfTelemetry::instance().setWaterfallLineDurationMs(m_wfLineDuration);
     auto& s = AppSettings::instance();
     s.setValue(settingsKey("DisplayWfLineDuration"), QString::number(m_wfLineDuration));
     s.save();
+    if (m_overlayMenu) {
+        m_overlayMenu->syncWfLineDuration(m_wfLineDuration);
+    }
     // Re-calibrate the time scale for the new rate
     resetWfTimeScale();
     // (#2666) Apply the new cadence to FFT-derived rows on the next frame
     m_lastFftRowMs = 0;
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setSquelchLine(bool visible, int level)
@@ -1307,7 +1326,9 @@ void SpectrumWidget::resetWfTimeScale() {
 
 int SpectrumWidget::waterfallHistoryCapacityRows() const
 {
-    const int msPerRow = std::max(1, m_wfLineDuration);
+    // Size for the fastest accepted line duration so rate changes do not
+    // resize the buffer and discard existing history.
+    const int msPerRow = kWaterfallLineDurationMinMs;
     return static_cast<int>((kWaterfallHistoryMs + msPerRow - 1) / msPerRow);
 }
 
@@ -2323,14 +2344,15 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
         m_txEndMs = 0;
     }
 
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+
     // Derive ms-per-row by measuring wall-clock / timecode delta.
     // Collect data for the first 50 tiles to converge, then lock the value.
     // Only re-measure when the user changes the waterfall rate slider
     // (which calls resetWfTimeScale()).
     if (!m_wfTimeScaleLocked) {
-        const qint64 now = QDateTime::currentMSecsSinceEpoch();
         if (timecode > 0 && m_wfPrevTimecode > 0 && timecode > m_wfPrevTimecode && m_wfPrevTimecodeMs > 0) {
-            const float wallDelta = static_cast<float>(now - m_wfPrevTimecodeMs);
+            const float wallDelta = static_cast<float>(nowMs - m_wfPrevTimecodeMs);
             const float tcDelta = static_cast<float>(timecode - m_wfPrevTimecode);
             if (tcDelta > 0 && wallDelta > 0) {
                 const float measured = wallDelta / tcDelta;
@@ -2342,7 +2364,7 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
         }
         if (timecode > 0) {
             m_wfPrevTimecode = timecode;
-            m_wfPrevTimecodeMs = now;
+            m_wfPrevTimecodeMs = nowMs;
         }
     }
 
@@ -2380,17 +2402,16 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
         }
     }
 
-    // One pixel row per tile — scroll speed determined by tile arrival rate.
-    int rowsToPush = 1;
-
     m_hasNativeWaterfall = true;
-    m_lastNativeTileMs = QDateTime::currentMSecsSinceEpoch();
+    m_lastNativeTileMs = nowMs;
 
     const int destWidth = m_waterfall.width();
     if (destWidth <= 0) return;
 
     const int h = m_waterfall.height();
     if (h <= 1) return;
+
+    int rowsToPush = 1;
     rowsToPush = std::min(rowsToPush, h - 1);
 
     // Render the tile row into a temporary scanline.
@@ -2462,7 +2483,6 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
 
     // Write rows into history + visible viewport.
     const bool canInterp = (m_prevTileScanline.size() == destWidth && rowsToPush > 1);
-    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
     for (int r = 0; r < rowsToPush; ++r) {
         QVector<QRgb> interpolatedRow(destWidth, qRgb(0, 0, 0));
         if (canInterp) {
@@ -2676,28 +2696,51 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         return;
     }
 
-    // Left-click in waterfall area → start pan drag (tune on double-click only)
+    // Left-click in waterfall area -> start pan drag (tune on double-click only)
     const int wfY = scaleY + FREQ_SCALE_H;
-    if (y >= wfY && ev->button() == Qt::LeftButton) {
+    if (y >= wfY) {
         const QRect wfRect(0, wfY, width(), height() - wfY);
         const QRect timeScaleRect = waterfallTimeScaleRect(wfRect);
         const QPoint pos = ev->position().toPoint();
-
-        if (timeScaleRect.contains(pos)) {
-            m_draggingTimeScale = true;
+        const Qt::KeyboardModifiers modifiers =
+            ev->modifiers() | QGuiApplication::keyboardModifiers();
+#ifdef Q_OS_MAC
+        const bool rateModifier = modifiers.testFlag(Qt::ControlModifier)
+            || modifiers.testFlag(Qt::MetaModifier);
+        const bool rateClick = rateModifier
+            && (ev->button() == Qt::LeftButton || ev->button() == Qt::RightButton);
+#else
+        const bool rateModifier = modifiers.testFlag(Qt::ControlModifier);
+        const bool rateClick = rateModifier && ev->button() == Qt::LeftButton;
+#endif
+        if (rateClick && timeScaleRect.contains(pos)) {
+            m_draggingTimeScaleRate = true;
             m_timeScaleDragStartY = y;
-            m_timeScaleDragStartOffsetRows = m_wfHistoryOffsetRows;
+            m_timeScaleDragStartLineDuration = std::clamp(m_wfLineDuration,
+                                                          kWaterfallUiRateMinMs,
+                                                          kWaterfallUiRateMaxMs);
             setSpectrumCursor(Qt::SizeVerCursor);
             ev->accept();
             return;
         }
 
-        m_draggingPan = true;
-        m_panDragStartX = static_cast<int>(ev->position().x());
-        m_panDragStartCenter = m_centerMhz;
-        setSpectrumCursor(Qt::ClosedHandCursor);
-        ev->accept();
-        return;
+        if (ev->button() == Qt::LeftButton) {
+            if (timeScaleRect.contains(pos)) {
+                m_draggingTimeScale = true;
+                m_timeScaleDragStartY = y;
+                m_timeScaleDragStartOffsetRows = m_wfHistoryOffsetRows;
+                setSpectrumCursor(Qt::SizeVerCursor);
+                ev->accept();
+                return;
+            }
+
+            m_draggingPan = true;
+            m_panDragStartX = static_cast<int>(ev->position().x());
+            m_panDragStartCenter = m_centerMhz;
+            setSpectrumCursor(Qt::ClosedHandCursor);
+            ev->accept();
+            return;
+        }
     }
 
     // Left-click on off-screen slice indicator → absorb or switch slice
@@ -3184,6 +3227,28 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         return;
     }
 
+    if (m_draggingTimeScaleRate) {
+        const int wfY = specH + DIVIDER_H + FREQ_SCALE_H;
+        const QRect wfRect(0, wfY, width(), height() - wfY);
+        const QRect timeScaleRect = waterfallTimeScaleRect(wfRect);
+        const int dragHeight = std::max(1, timeScaleRect.height());
+        const int dy = m_timeScaleDragStartY - y;
+        const int rangeMs = kWaterfallUiRateMaxMs - kWaterfallUiRateMinMs;
+        const int deltaMs = static_cast<int>(
+            std::round((static_cast<double>(dy) / dragHeight) * rangeMs));
+        const int newMs = std::clamp(m_timeScaleDragStartLineDuration + deltaMs,
+                                     kWaterfallUiRateMinMs,
+                                     kWaterfallUiRateMaxMs);
+
+        if (newMs != m_wfLineDuration) {
+            emit waterfallLineDurationChangeRequested(newMs);
+        }
+
+        setSpectrumCursor(Qt::SizeVerCursor);
+        ev->accept();
+        return;
+    }
+
     if (m_draggingTimeScale) {
         const int wfY = specH + DIVIDER_H + FREQ_SCALE_H;
         const QRect wfRect(0, wfY, width(), height() - wfY);
@@ -3485,6 +3550,12 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
     }
     if (m_draggingTimeScale) {
         m_draggingTimeScale = false;
+        setSpectrumCursor(Qt::CrossCursor);
+        ev->accept();
+        return;
+    }
+    if (m_draggingTimeScaleRate) {
+        m_draggingTimeScaleRate = false;
         setSpectrumCursor(Qt::CrossCursor);
         ev->accept();
         return;
@@ -6813,9 +6884,9 @@ void SpectrumWidget::drawTimeScale(QPainter& p, const QRect& wfRect)
     p.setPen(m_wfLive ? QColor(0xb0, 0xb0, 0xb0) : Qt::white);
     p.drawText(liveRect, Qt::AlignCenter, "LIVE");
 
-    // Total time depth: use ms-per-row derived from radio tile timecodes.
-    // This is the radio's own clock — stable and accurate to actual scroll rate.
-    const float msPerRow = m_wfMsPerRow > 0 ? m_wfMsPerRow : 100.0f;
+    // Total time depth follows the visible row duration, including client-side
+    // pacing for native waterfall tiles.
+    const float msPerRow = static_cast<float>(std::max(1, m_wfLineDuration));
     const QRect labelRect = strip.adjusted(0, 4, 0, 0);
     const float totalSec = labelRect.height() * msPerRow / 1000.0f;
     if (totalSec <= 0) return;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -464,6 +464,7 @@ signals:
     void dbmRangeChangeRequested(float minDbm, float maxDbm);
     void dbmRangeDragFinished(float minDbm, float maxDbm);
     void noiseFloorPositionResolved(int pos);
+    void waterfallLineDurationChangeRequested(int ms);
     // TNF signals
     void tnfCreateRequested(double freqMhz);
     void tnfMoveRequested(int id, double newFreqMhz);
@@ -727,8 +728,10 @@ private:
     int    m_wfHistoryOffsetRows{0};
     bool   m_wfLive{true};
     bool   m_draggingTimeScale{false};
+    bool   m_draggingTimeScaleRate{false};
     int    m_timeScaleDragStartY{0};
     int    m_timeScaleDragStartOffsetRows{0};
+    int    m_timeScaleDragStartLineDuration{100};
     static constexpr qint64 kWaterfallHistoryMs = 20LL * 60LL * 1000LL;
 
     // True once we receive native waterfall tile data (PCC 0x8004).
@@ -861,11 +864,6 @@ private:
     int      m_wfCalibrationCount{0};  // tiles measured so far
     bool     m_wfTimeScaleLocked{false};
 
-
-    // Client-side row averaging (Rate slider)
-    int      m_wfAvgTarget{1};   // how many tiles to average into one row
-    int      m_wfAvgCount{0};    // tiles accumulated so far
-    QVector<float> m_wfAvgBins;  // accumulated intensity values
 
     // Lightweight diagnostics overlay toggled from View -> FPS Meters.
     bool m_showFpsMeters{false};


### PR DESCRIPTION
## Summary
- Add Ctrl-drag support on the waterfall time scale to adjust waterfall refresh rate/vertical scale directly from the display.
- Keep the Display Settings waterfall rate slider synchronized in both directions with the display drag gesture.
- Clamp the waterfall line duration to the radio-supported 71-100 ms range and preserve history scrolling behavior while changing rates.

## Validation
- cmake --build build