### PR TITLE
feat(spectrum): pan-follow-VFO triggers off flag outer edge (#2761)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10888,7 +10888,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 }
 
 MainWindow::TuneCenteringResult MainWindow::revealFrequencyIfNeeded(
-    SliceModel* slice, double mhz, TuneIntent intent, const char* source)
+    SliceModel* slice, double mhz, TuneIntent intent, const char* source,
+    double leftFlagEdgeOffsetMhz, double rightFlagEdgeOffsetMhz)
 {
     TuneCenteringResult result;
     if (!slice)
@@ -10961,19 +10962,33 @@ MainWindow::TuneCenteringResult MainWindow::revealFrequencyIfNeeded(
         return center + direction * cappedDeltaMhz;
     };
 
-    if (mhz > center + triggerDistanceFromCenter) {
-        const double settleCenterTarget = mhz - settleDistanceFromCenter;
+    // The IncrementalTune trigger compares the *outer edge of the VFO flag*
+    // (mhz ± flag-width-in-MHz) against the pan boundary, so the flag panel
+    // never clips the pan edge.  Non-flag callers pass 0.0 for both offsets
+    // and effectiveLeftMhz / effectiveRightMhz collapse back to mhz —
+    // preserving the original slice-frequency comparison.  Clamp the offsets
+    // so neither effective edge crosses the *other* trigger boundary at very
+    // narrow panadapters (avoids the trigger oscillating around the slice).
+    // (#2761)
+    const double safeOffsetCap = std::max(0.0, triggerDistanceFromCenter * 0.95);
+    const double clampedRightOffset = std::min(rightFlagEdgeOffsetMhz, safeOffsetCap);
+    const double clampedLeftOffset  = std::min(leftFlagEdgeOffsetMhz,  safeOffsetCap);
+    const double effectiveLeftMhz   = incremental ? mhz - clampedLeftOffset  : mhz;
+    const double effectiveRightMhz  = incremental ? mhz + clampedRightOffset : mhz;
+
+    if (effectiveRightMhz > center + triggerDistanceFromCenter) {
+        const double settleCenterTarget = effectiveRightMhz - settleDistanceFromCenter;
         if (incremental && stepMhz > 0.0) {
-            const double triggerBoundaryCenter = mhz - triggerDistanceFromCenter;
+            const double triggerBoundaryCenter = effectiveRightMhz - triggerDistanceFromCenter;
             result.newCenterMhz =
                 incrementalFollowCenter(triggerBoundaryCenter, settleCenterTarget);
         } else {
             result.newCenterMhz = settleCenterTarget;
         }
-    } else if (mhz < center - triggerDistanceFromCenter) {
-        const double settleCenterTarget = mhz + settleDistanceFromCenter;
+    } else if (effectiveLeftMhz < center - triggerDistanceFromCenter) {
+        const double settleCenterTarget = effectiveLeftMhz + settleDistanceFromCenter;
         if (incremental && stepMhz > 0.0) {
-            const double triggerBoundaryCenter = mhz + triggerDistanceFromCenter;
+            const double triggerBoundaryCenter = effectiveLeftMhz + triggerDistanceFromCenter;
             result.newCenterMhz =
                 incrementalFollowCenter(triggerBoundaryCenter, settleCenterTarget);
         } else {
@@ -11008,7 +11023,40 @@ MainWindow::TuneCenteringResult MainWindow::panFollowVfo(
     // Incremental tuning uses a trigger margin and a slightly wider settle
     // margin so the slice glides back into a comfortable visible area without
     // dead-centering or waiting until it actually crosses the pan edge.
-    return revealFrequencyIfNeeded(s, mhz, TuneIntent::IncrementalTune, source);
+    //
+    // Per #2761, when this slice has a visible VFO flag, the trigger compares
+    // against the *outer edge of the flag* rather than the slice frequency
+    // itself — so the flag panel doesn't clip the pan edge before the pan
+    // starts to scroll.  Split pairs (LockLeft + LockRight rendered on the
+    // same marker) extend the trigger on *both* sides; single-flag slices
+    // extend only on the side the flag currently renders on.  Non-flagged
+    // and compact-mode slices fall through to the original slice-frequency
+    // comparison (both offsets stay 0.0).
+    double leftFlagOffsetMhz  = 0.0;
+    double rightFlagOffsetMhz = 0.0;
+    if (auto* sw = spectrumForSlice(s)) {
+        if (auto* vfo = sw->vfoWidget(s->sliceId())) {
+            const double bw = sw->bandwidthMhz();
+            const int specW = sw->width();
+            if (bw > 0.0 && specW > 0 && !vfo->isCollapsed()) {
+                const double mhzPerPixel = bw / static_cast<double>(specW);
+                const double flagWidthMhz =
+                    static_cast<double>(vfo->width()) * mhzPerPixel;
+                if (sw->sliceHasSplitPartner(s->sliceId())) {
+                    // Split pair: LockLeft + LockRight, flags on both sides.
+                    leftFlagOffsetMhz  = flagWidthMhz;
+                    rightFlagOffsetMhz = flagWidthMhz;
+                } else if (vfo->onLeft()) {
+                    leftFlagOffsetMhz  = flagWidthMhz;
+                } else {
+                    rightFlagOffsetMhz = flagWidthMhz;
+                }
+            }
+        }
+    }
+
+    return revealFrequencyIfNeeded(s, mhz, TuneIntent::IncrementalTune, source,
+                                   leftFlagOffsetMhz, rightFlagOffsetMhz);
 }
 
 void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -180,8 +180,16 @@ private:
                           TuneIntent intent, const char* source);
     void applyPanRangeRequest(const QString& panId, double centerMhz,
                               double bandwidthMhz, const char* source);
+    // leftFlagEdgeOffsetMhz / rightFlagEdgeOffsetMhz extend the trigger
+    // comparison out to the VFO flag's outer edges so the flag panel never
+    // clips a pan edge.  Only IncrementalTune consumes the offsets; other
+    // intents (CommandedTargetCenter, RevealOffscreen) ignore them.  Default
+    // 0.0 preserves the original slice-frequency comparison for non-flag
+    // callers.  See #2761 + panFollowVfo() for the integration site.
     TuneCenteringResult revealFrequencyIfNeeded(SliceModel* slice, double mhz,
-                                                TuneIntent intent, const char* source);
+                                                TuneIntent intent, const char* source,
+                                                double leftFlagEdgeOffsetMhz = 0.0,
+                                                double rightFlagEdgeOffsetMhz = 0.0);
     void logTunePolicyDecision(const char* source, TuneIntent intent,
                                double oldFreqMhz, double newFreqMhz,
                                const TuneCenteringResult& result) const;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -420,6 +420,15 @@ VfoWidget* SpectrumWidget::vfoWidget(int sliceId) const
     return m_vfoWidgets.value(sliceId, nullptr);
 }
 
+bool SpectrumWidget::sliceHasSplitPartner(int sliceId) const
+{
+    for (const auto& so : m_sliceOverlays) {
+        if (so.sliceId == sliceId)
+            return so.splitPartnerId >= 0;
+    }
+    return false;
+}
+
 QString SpectrumWidget::settingsKey(const QString& base) const
 {
     if (m_panIndex == 0)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -176,6 +176,11 @@ public:
     VfoWidget* addVfoWidget(int sliceId);
     void       removeVfoWidget(int sliceId);
     void       setActiveVfoWidget(int sliceId);
+    // True if the slice has a split partner whose own VFO flag is rendered on
+    // the opposite side via LockLeft / LockRight.  panFollowVfo() uses this
+    // to extend the pan-follow trigger on both sides so neither flag clips
+    // the pan edge (#2761).
+    bool sliceHasSplitPartner(int sliceId) const;
 
     // WNB and RF gain state for on-screen indicators.
     bool wnbActive()   const { return m_wnbActive; }

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -83,6 +83,12 @@ public:
     bool isCollapsed() const { return m_collapsed; }
     void setCollapsed(bool collapsed);
 
+    // Which side of the slice marker the flag panel is currently rendered on.
+    // Tracked by updatePosition() via m_lastOnLeft.  Used by panFollowVfo()
+    // to extend the pan-follow trigger to the flag's outer edge — single-side
+    // for non-split slices, both-sides for split pairs (#2761).
+    bool onLeft() const { return m_lastOnLeft; }
+
 #ifdef HAVE_RADE
     void setRadeActive(bool on, const QString& label = QStringLiteral("RADE"));
     void setRadeSynced(bool synced);


### PR DESCRIPTION
## Summary

Implements [the plan from #2761](https://github.com/aethersdr/AetherSDR/issues/2761).  Replaces incomplete agent attempt #2778 (which committed the API surface without the implementation wiring).

When a slice tunes near a pan edge, the existing **Pan Follows VFO** machinery slides the pan center so the slice stays visible.  But the VFO flag panel hanging off the slice marker is fixed-width — the slice can be well inside the trigger boundary while the flag panel is already clipping the pan edge.  Split pairs (LockLeft + LockRight on the same marker, #2663 / #2744) are particularly affected: PR #2744 intentionally accepted that the outward-facing flag clips and documented \"the user pans toward center to read it\" as the workaround.

This change removes that workaround by treating the **flag's outer edge** as the trigger reference, not the slice frequency.

## What changes

- \`revealFrequencyIfNeeded\` gains \`leftFlagEdgeOffsetMhz\` / \`rightFlagEdgeOffsetMhz\` defaulted to \`0.0\`.  Only consumed on the \`IncrementalTune\` path — \`CommandedTargetCenter\` / \`RevealOffscreen\` ignore them.
- Offsets are clamped to 95% of \`triggerDistanceFromCenter\` so tiny panadapters where flag-width > trigger-margin don't oscillate the pan around the slice.
- \`panFollowVfo\` now computes flag-width-in-MHz from the bound \`VfoWidget\` (\`width() * (bandwidthMhz / specPixelW)\`) and threads it through:
  - **Split pair** (\`SpectrumWidget::sliceHasSplitPartner\` returns true): both offsets non-zero — extends the trigger on both sides since LockLeft + LockRight flags render on both sides simultaneously.
  - **Single-flag slice**: only the side where the flag currently renders (per \`VfoWidget::onLeft()\`).
  - **Collapsed / compact-mode flag**: both offsets stay 0.0 — compact mode doesn't render a wide flag.

## Files

| File | Change |
|---|---|
| \`src/gui/MainWindow.h\` | \`revealFrequencyIfNeeded\` signature + comment |
| \`src/gui/MainWindow.cpp\` | Implementation: clamp + apply offsets in the trigger comparison; \`panFollowVfo\` computes offsets from VfoWidget state |
| \`src/gui/SpectrumWidget.h\` | \`sliceHasSplitPartner(int)\` accessor |
| \`src/gui/SpectrumWidget.cpp\` | \`sliceHasSplitPartner\` implementation (scans \`m_sliceOverlays\` for the slice + checks \`splitPartnerId\`) |
| \`src/gui/VfoWidget.h\` | \`onLeft()\` accessor exposing the existing \`m_lastOnLeft\` state set by \`updatePosition\` |

Net: **85 insertions / 9 deletions** across 5 files.

## Local verification

- [x] Build clean (\`cmake --build build --target AetherSDR\`) — 401/401 link, only pre-existing warnings
- [x] Test-target link audit: none of the touched headers are linked by isolated test targets — the new \`onLeft()\` accessor and \`sliceHasSplitPartner()\` accessor are GUI-only and only consumed from MainWindow.cpp.  No CMakeLists changes needed.

## Test plan (manual, post-merge)

- [ ] Tune a slice toward a pan edge with a wide VFO flag visible — pan should slide *before* the flag clips
- [ ] In split mode (LockLeft + LockRight on the same marker) — pan should slide before *either* flag clips
- [ ] Non-flag callers (Memory recall, click-to-tune absolute jump) — no behavior change (CommandedTargetCenter ignores the offsets)
- [ ] Compact-mode (collapsed) flag — falls back to original slice-frequency comparison
- [ ] Toggle \`View → Pan Follows VFO\` off — pan does not slide at all (existing override preserved)

## Closes

- Closes #2761
- Closes-as-replacement for #2778 (incomplete recovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)