### PR TITLE
fix(protocol): respect M-message severity so Info notices don't pop modals

### DIFF
--- a/src/core/CommandParser.cpp
+++ b/src/core/CommandParser.cpp
@@ -99,7 +99,15 @@ ParsedMessage CommandParser::parseLine(const QString& rawLine)
         {
             const int pipe = body.indexOf('|');
             if (pipe >= 0) {
+                // The number before the '|' is hex.  Bits 24-25 encode
+                // severity (Info=0, Warning=1, Error=2, Fatal=3) per
+                // FlexLib Radio.cs:4498-4516; the remaining bits are an
+                // opaque message id.  Reuse the same field as 'handle' to
+                // keep the struct stable — readers that want the severity
+                // use msg.severity, readers that need the raw id still
+                // get it from msg.handle.
                 msg.handle = body.left(pipe).toUInt(nullptr, 16);
+                msg.severity = static_cast<MessageSeverity>((msg.handle >> 24) & 0x3);
                 msg.object = body.mid(pipe + 1);
             }
         }

--- a/src/core/CommandParser.h
+++ b/src/core/CommandParser.h
@@ -8,12 +8,15 @@
 namespace AetherSDR {
 
 // Message types in the SmartSDR TCP protocol:
-//   V<version>           – version announcement
-//   H<handle>            – client handle assignment
-//   C<seq>|<command>     – command (client → radio)
-//   R<seq>|<code>|<msg>  – response (radio → client)
-//   S<handle>|<status>   – status update (radio → client)
-//   M<handle>|<message>  – informational message
+//   V<version>             – version announcement
+//   H<handle>              – client handle assignment
+//   C<seq>|<command>       – command (client → radio)
+//   R<seq>|<code>|<msg>    – response (radio → client)
+//   S<handle>|<status>     – status update (radio → client)
+//   M<8-hex-digits>|<text> – informational/warning/error/fatal message
+//                            (high 2 bits of the hex number encode severity —
+//                             see MessageSeverity below; per FlexLib
+//                             Radio.cs:4498-4516)
 
 enum class MessageType {
     Version,
@@ -24,6 +27,17 @@ enum class MessageType {
     Unknown
 };
 
+// M-prefix severity, extracted from bits 24-25 of the message number per
+// FlexLib's `(num >> 24) & 0x3`.  Info messages (e.g. "Client connected
+// from IP …") are expected to be logged silently; Warning and above
+// surface to the user.
+enum class MessageSeverity {
+    Info    = 0,
+    Warning = 1,
+    Error   = 2,
+    Fatal   = 3
+};
+
 struct ParsedMessage {
     MessageType type{MessageType::Unknown};
     quint32 sequence{0};         // for R messages
@@ -32,6 +46,7 @@ struct ParsedMessage {
     QString object;              // e.g. "slice 0"
     QString raw;                 // full raw line
     QMap<QString, QString> kvs;  // parsed key=value pairs from status/response body
+    MessageSeverity severity{MessageSeverity::Info};  // for M messages only
 };
 
 // Stateless parser for SmartSDR TCP lines.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8546,10 +8546,34 @@ void MainWindow::onConnectionError(const QString& msg)
         setPanadapterConnectionAnimation(false);
 }
 
-void MainWindow::onRadioMessage(const QString& text)
+void MainWindow::onRadioMessage(const QString& text, MessageSeverity severity)
 {
-    qCInfo(lcGui) << "Radio M-message:" << text;
-    QMessageBox::warning(this, tr("Radio"), text);
+    // Info messages (e.g. "Client connected from IP …") are routine multi-
+    // client notices that the radio sends on every connect / disconnect —
+    // they're documented as silent-log in SmartSDR.  Show a status-bar
+    // toast instead of a modal popup so the operator notices without an
+    // interruptive dialog.  Warnings, errors, and fatals are user-actionable
+    // and continue to surface as modal QMessageBox to preserve PR #2771's
+    // intent for FreeDV/ATU/interlock conflicts.  See #2785 for context.
+    switch (severity) {
+    case MessageSeverity::Info:
+        qCInfo(lcGui) << "Radio M-message [Info]:" << text;
+        if (statusBar())
+            statusBar()->showMessage(text, 5000);
+        break;
+    case MessageSeverity::Warning:
+        qCWarning(lcGui) << "Radio M-message [Warning]:" << text;
+        QMessageBox::warning(this, tr("Radio"), text);
+        break;
+    case MessageSeverity::Error:
+        qCCritical(lcGui) << "Radio M-message [Error]:" << text;
+        QMessageBox::critical(this, tr("Radio — Error"), text);
+        break;
+    case MessageSeverity::Fatal:
+        qCCritical(lcGui) << "Radio M-message [Fatal]:" << text;
+        QMessageBox::critical(this, tr("Radio — Fatal"), text);
+        break;
+    }
 }
 
 void MainWindow::setPanadapterConnectionAnimation(bool visible, const QString& label)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -4,6 +4,7 @@
 #include "models/BandSettings.h"
 #include "models/AntennaGeniusModel.h"
 #include "core/AppSettings.h"
+#include "core/CommandParser.h"   // MessageSeverity for onRadioMessage slot
 #include "core/RadioDiscovery.h"
 #include "core/AudioEngine.h"
 #include "core/RigctlServer.h"
@@ -126,7 +127,7 @@ private slots:
     // Radio/connection events
     void onConnectionStateChanged(bool connected);
     void onConnectionError(const QString& msg);
-    void onRadioMessage(const QString& text);
+    void onRadioMessage(const QString& text, MessageSeverity severity);
     void onSliceAdded(SliceModel* slice);
     void onSliceRemoved(int id);
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2716,8 +2716,23 @@ void RadioModel::handleMemoryStatus(int index, const QMap<QString, QString>& kvs
 void RadioModel::onMessageReceived(const ParsedMessage& msg)
 {
     if (msg.type == MessageType::Message) {
-        qCWarning(lcProtocol) << "Radio M-message:" << msg.object;
-        emit radioMessageReceived(msg.object);
+        // Log everything to the protocol channel at the matching level so the
+        // diagnostic trail is uniform.  The user-facing decision (silent log,
+        // warning dialog, error dialog) is made in MainWindow::onRadioMessage
+        // based on the same severity, so the two paths can't disagree.
+        switch (msg.severity) {
+        case MessageSeverity::Info:
+            qCInfo(lcProtocol) << "Radio M-message [Info]:" << msg.object;
+            break;
+        case MessageSeverity::Warning:
+            qCWarning(lcProtocol) << "Radio M-message [Warning]:" << msg.object;
+            break;
+        case MessageSeverity::Error:
+        case MessageSeverity::Fatal:
+            qCCritical(lcProtocol) << "Radio M-message [Error/Fatal]:" << msg.object;
+            break;
+        }
+        emit radioMessageReceived(msg.object, msg.severity);
         return;
     }
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/CommandParser.h"   // MessageSeverity for radioMessageReceived
 #include "core/RadioConnection.h"
 #include "core/WanConnection.h"
 #include "core/PanadapterStream.h"
@@ -434,9 +435,12 @@ signals:
     void pingReceived();
     // Generic status relay — for dialogs that need to listen for specific objects.
     void statusReceived(const QString& object, const QMap<QString, QString>& kvs);
-    // Emitted when the radio sends an M-prefix informational or warning message
-    // (e.g. FreeDV waveform conflict warnings). Text is plain, ready for display.
-    void radioMessageReceived(const QString& text);
+    // Emitted when the radio sends an M-prefix informational, warning, error,
+    // or fatal message.  Severity comes from the high bits of the message
+    // number per FlexLib Radio.cs:4498-4516.  MainWindow uses it to decide
+    // log-only vs. modal-dialog surfacing — Info-severity messages like
+    // "Client connected from IP …" must NOT pop a dialog (#2785).
+    void radioMessageReceived(const QString& text, MessageSeverity severity);
 
 public:
     // Send a raw command to the radio (for dialogs that need direct protocol access).


### PR DESCRIPTION
## Summary

PR #2771 (merged today) added user-facing dialogs for M-prefix radio messages.  In practice the radio sends an **Info-severity** M-message on every client connect/disconnect (\"Client connected from IP …\" etc.) — routine multi-client notices that SmartSDR silently logs.  AetherSDR was popping a modal warning dialog on every connect as a result.

The fix extracts the severity bits that FlexLib documents but AetherSDR's parser was discarding, then surfaces messages appropriately by severity.

## Root cause

FlexLib's wire format ([Radio.cs:4498-4516](https://github.com/FlexRadioSystems/FlexLib/blob/main/FlexLib/Radio.cs#L4498)) encodes severity in bits 24-25 of the M-message number:

\`\`\`
M<8-hex-digits>|<text>
        └── (num >> 24) & 0x3 → Info=0, Warning=1, Error=2, Fatal=3
\`\`\`

AetherSDR's \`CommandParser\` was extracting the handle as a single hex value but **discarding the severity bits**.  PR #2771's MainWindow handler then treated all M-messages identically as \`QMessageBox::warning\`.

## What changes

- \`CommandParser\`: new \`MessageSeverity\` enum + \`severity\` field on \`ParsedMessage\`; \`'M':\` case now extracts \`(handle >> 24) & 0x3\` into it
- \`RadioModel::radioMessageReceived\` signal extended to \`(QString, MessageSeverity)\`
- \`RadioModel::onMessageReceived\` logs at the matching protocol level (\`qCInfo\` / \`qCWarning\` / \`qCCritical\`) — log path and UI path now both switch on the same enum so they can't disagree
- \`MainWindow::onRadioMessage\` switches on severity:

| Severity | Behavior |
|---|---|
| **Info** | \`statusBar()->showMessage(text, 5000)\` — 5-second toast, no modal |
| **Warning** | \`QMessageBox::warning\` (PR #2771's intent preserved) |
| **Error** | \`QMessageBox::critical\` with \"Radio — Error\" title |
| **Fatal** | \`QMessageBox::critical\` with \"Radio — Fatal\" title |

## Behavior changes

- \"Client connected from IP …\" → status-bar toast (was modal popup) ✅
- \"Client disconnected from IP …\" → status-bar toast (was modal popup) ✅
- FreeDV mode-conflict warning from #2771 — unchanged, still modal ✅
- Future ATU / interlock / calibration errors — modal with \"Error\"/\"Fatal\" title prefix instead of \"Radio\" generic

## Test plan

- [x] Local build clean (402/402 link, only pre-existing warnings)
- [x] Connect to FLEX-8400 — IP notice appears in status bar for 5 seconds, no modal interrupts connection flow.  **Confirmed by @ten9876.**
- [ ] Trigger a Warning-severity M-message (e.g. set two slices to FDVU when FreeDV is running) — modal warning still appears
- [ ] No regression in other M-message consumers (none exist in current codebase per grep)

## Files

| File | Change |
|---|---|
| \`src/core/CommandParser.h\` | \`MessageSeverity\` enum + \`ParsedMessage::severity\` field + protocol-format comment refresh |
| \`src/core/CommandParser.cpp\` | Extract severity bits in the \`'M':\` case |
| \`src/models/RadioModel.h\` | Signal signature + \`CommandParser.h\` include |
| \`src/models/RadioModel.cpp\` | Switch on severity for log level; emit with severity |
| \`src/gui/MainWindow.h\` | Slot signature + \`CommandParser.h\` include |
| \`src/gui/MainWindow.cpp\` | Switch on severity for log + dialog/toast |

Net: **83 insertions / 16 deletions** across 6 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)