### PR TITLE
Fix panadapter layout/floating persistence + macOS GPU lifecycle (rfoust/#2780)

### DIFF
--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -10,6 +10,7 @@
 #include <QStringList>
 #include <QtEndian>
 #include <QSet>
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 
@@ -18,6 +19,7 @@ namespace AetherSDR {
 namespace {
 
 constexpr QAbstractSocket::BindMode kLanVitaBindMode = QAbstractSocket::DontShareAddress;
+constexpr float kMinSpectrumDbm = -180.0f;
 
 QHostAddress chooseLanBindAddress(RadioConnection* conn,
                                   QString* chosenReason,
@@ -430,6 +432,9 @@ void PanadapterStream::clearRegisteredStreams()
 
 void PanadapterStream::setDbmRange(quint32 streamId, float minDbm, float maxDbm, bool waitForEcho)
 {
+    minDbm = std::max(minDbm, kMinSpectrumDbm);
+    maxDbm = std::max(maxDbm, minDbm + 10.0f);
+
     QMutexLocker lock(&m_streamMutex);
     if (waitForEcho) {
         m_pendingDbmRanges[streamId] = {minDbm, maxDbm};
@@ -795,12 +800,19 @@ void PanadapterStream::decodeFFT(const uchar* raw, int totalBytes, bool hasTrail
     }
     auto [minDbm, maxDbm] = dbmRange;
     const float range = maxDbm - minDbm;
+    if (range <= 0.0f) return;
+
     const int   count = frame.buf.size();
     QVector<float> bins(count);
 
-    const float yPix = static_cast<float>(yPixVal);
-    for (int i = 0; i < count; ++i)
-        bins[i] = maxDbm - (static_cast<float>(frame.buf[i]) / (yPix - 1.0f)) * range;
+    const float yPix = static_cast<float>(std::max(yPixVal, 2));
+
+    for (int i = 0; i < count; ++i) {
+        const float pixel = std::clamp(
+            static_cast<float>(frame.buf[i]), 0.0f, yPix - 1.0f);
+        const float dbm = maxDbm - (pixel / (yPix - 1.0f)) * range;
+        bins[i] = std::clamp(dbm, minDbm, maxDbm);
+    }
 
     const qint64 emittedNs = PerfTelemetry::instance().enabled() ? PerfTelemetry::nowNs() : 0;
     emit spectrumReady(streamId, bins, emittedNs);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -205,6 +205,13 @@ constexpr double kSpectrumClickEdgeMarginFrac = 0.05;
 constexpr int kPanFollowAnimationDurationMs = 110;
 constexpr int kSliderShortcutLeaseMs = 2000;
 constexpr int kPanadapterSliceCapacityStatusMs = 4000;
+constexpr int kDefaultPanXpixels = 1024;
+constexpr int kDefaultPanYpixels = 700;
+constexpr int kMinPanXpixels = 100;
+constexpr int kMinPanYpixels = 20;
+constexpr int kMinRadioPanYpixels = 100;
+constexpr qint64 kPanLayoutRestoreWaitingForFirstPan = -1;
+constexpr int kPanLayoutRestoreWindowMs = 5000;
 constexpr qint64 kXvtrWaterfallDecisionLogIntervalMs = 20000;
 constexpr double kSwrSweepStepMhz = 0.020;
 constexpr double kSwrSweepEdgeGuardMhz = 0.005;
@@ -294,6 +301,49 @@ int panCountForLayoutId(const QString& layoutId)
         {"2x2", 4}, {"4v", 4}, {"3h2", 5}, {"2x3", 6}, {"4h3", 7}, {"2x4", 8}
     };
     return kPanCounts.value(layoutId, 1);
+}
+
+QString defaultPanLayoutForCount(int panCount)
+{
+    static const QMap<int, QString> kDefaultLayouts = {
+        {1, QStringLiteral("1")},
+        {2, QStringLiteral("2v")},
+        {3, QStringLiteral("2h1")},
+        {4, QStringLiteral("2x2")},
+        {5, QStringLiteral("3h2")},
+        {6, QStringLiteral("2x3")},
+        {7, QStringLiteral("4h3")},
+        {8, QStringLiteral("2x4")}
+    };
+    return kDefaultLayouts.value(panCount, QStringLiteral("1"));
+}
+
+int panXpixelsFor(const SpectrumWidget* spectrum)
+{
+    if (!spectrum || spectrum->width() < kMinPanXpixels) {
+        return kDefaultPanXpixels;
+    }
+    return spectrum->width();
+}
+
+int panYpixelsFor(const SpectrumWidget* spectrum)
+{
+    if (!spectrum) {
+        return kDefaultPanYpixels;
+    }
+
+    const int ypix = spectrum->spectrumPixelHeight();
+    if (ypix < kMinPanYpixels) {
+        return kDefaultPanYpixels;
+    }
+    return std::max(ypix, kMinRadioPanYpixels);
+}
+
+bool panPixelDimensionsReady(const SpectrumWidget* spectrum)
+{
+    return spectrum
+        && spectrum->width() >= kMinPanXpixels
+        && spectrum->spectrumPixelHeight() >= kMinPanYpixels;
 }
 
 QVector<XvtrPolicy::Transverter> xvtrPolicyBandsFrom(
@@ -2322,6 +2372,9 @@ MainWindow::MainWindow(QWidget* parent)
     // Route FFT/waterfall data to the correct SpectrumWidget by stream ID
     connect(m_radioModel.panStream(), &PanadapterStream::spectrumReady,
             this, [this](quint32 streamId, const QVector<float>& bins, qint64 emittedNs) {
+        if (m_shuttingDown || !m_panStack) {
+            return;
+        }
         if (emittedNs > 0) {
             PerfTelemetry::instance().recordFrameAge(
                 PerfTelemetry::FrameKind::Panadapter,
@@ -2349,6 +2402,9 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_radioModel.panStream(), &PanadapterStream::waterfallRowReady,
             this, [this](quint32 streamId, const QVector<float>& bins,
                          double low, double high, quint32 tc, qint64 emittedNs) {
+        if (m_shuttingDown || !m_panStack) {
+            return;
+        }
         if (emittedNs > 0) {
             PerfTelemetry::instance().recordFrameAge(
                 PerfTelemetry::FrameKind::Waterfall,
@@ -2398,6 +2454,9 @@ MainWindow::MainWindow(QWidget* parent)
     });
     connect(m_radioModel.panStream(), &PanadapterStream::waterfallAutoBlackLevel,
             this, [this](quint32 streamId, quint32 autoBlack) {
+        if (m_shuttingDown || !m_panStack) {
+            return;
+        }
         for (auto* pan : m_radioModel.panadapters()) {
             if (pan->wfStreamId() == streamId) {
                 if (auto* sw = m_panStack->spectrum(pan->panId())) {
@@ -2457,6 +2516,9 @@ MainWindow::MainWindow(QWidget* parent)
     // ── Multi-panadapter lifecycle ──────────────────────────────────────────
     connect(&m_radioModel, &RadioModel::panadapterAdded,
             this, [this](PanadapterModel* pan) {
+        if (m_shuttingDown || !m_panStack || !pan) {
+            return;
+        }
         // During layout application, applyLayout/createPansSequentially handles
         // applet creation and wiring — don't duplicate here.
         if (m_applyingLayout) return;
@@ -2515,20 +2577,20 @@ MainWindow::MainWindow(QWidget* parent)
 
         // Push display dimensions to the radio so it sends full-size FFT bins.
         // Without this, the radio uses xpixels=50 ypixels=20 (default) and
-        // FFT data is essentially empty/unusable. Use actual widget dimensions
-        // for 1:1 bin-to-pixel mapping (matches SmartSDR behavior from pcap).
+        // FFT data is essentially empty/unusable. Use widget width and the
+        // actual FFT pane height for 1:1 bin-to-pixel mapping.
         auto* sw = applet->spectrumWidget();
-        int xpix = sw ? sw->width() : 1024;
-        int ypix = sw ? sw->height() : 700;
-        if (xpix < 100) xpix = 1024;  // widget may not be laid out yet
-        if (ypix < 100) ypix = 700;
+        const int xpix = panXpixelsFor(sw);
+        const int ypix = panYpixelsFor(sw);
         m_radioModel.sendCommand(
             QString("display pan set %1 xpixels=%2 ypixels=%3")
                 .arg(pan->panId()).arg(xpix).arg(ypix));
 
         // Tell PanadapterStream the ypixels for FFT bin→dBm conversion
-        if (pan->panStreamId())
+        if (pan->panStreamId()) {
             m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+            sw->prepareForFftScaleChange();
+        }
 
         qDebug() << "MainWindow: added panadapter applet for" << pan->panId();
 
@@ -2539,7 +2601,9 @@ MainWindow::MainWindow(QWidget* parent)
             m_layoutRestoreTimer->setSingleShot(true);
             m_layoutRestoreTimer->setInterval(1000);
             connect(m_layoutRestoreTimer, &QTimer::timeout, this, [this]() {
-                m_layoutRestoreTimer->setProperty("fired", true);
+                if (m_shuttingDown || !m_panStack) {
+                    return;
+                }
                 // The radio restores pans from the GUIClientID session.
                 // Accept whatever the radio gives and arrange based on count.
                 const int panCount = m_panStack->count();
@@ -2547,18 +2611,13 @@ MainWindow::MainWindow(QWidget* parent)
                     // Pick a layout based on the number of pans the radio restored
                     const QString saved = AppSettings::instance()
                         .value("PanadapterLayout", "1").toString();
-                    // Only rearrange if the saved layout matches the pan count
-                    static const QMap<QString, int> layoutPanCount = {
-                        {"1", 1}, {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"3v", 3}, {"2x2", 4}, {"4v", 4}
-                    };
-                    if (layoutPanCount.value(saved, 1) == panCount)
-                        m_panStack->rearrangeLayout(saved);
-                    else if (panCount == 2)
-                        m_panStack->rearrangeLayout("2v");  // default 2-pan to vertical
-                    else if (panCount == 3)
-                        m_panStack->rearrangeLayout("2h1"); // default 3-pan
-                    else if (panCount >= 4)
-                        m_panStack->rearrangeLayout("2x2"); // default 4-pan
+                    const QString layoutId = panCountForLayoutId(saved) == panCount
+                        ? saved
+                        : defaultPanLayoutForCount(panCount);
+                    const QString floatingPanIds = AppSettings::instance()
+                        .value("FloatingPanIds", "").toString();
+                    m_panStack->rearrangeLayout(layoutId);
+                    AppSettings::instance().setValue("FloatingPanIds", floatingPanIds);
 
                     // Optimistically set local yPixels immediately so FFT frames
                     // arriving before the radio echoes back use correct scaling (#1511).
@@ -2566,25 +2625,32 @@ MainWindow::MainWindow(QWidget* parent)
                         auto* s = a->spectrumWidget();
                         auto* p = m_radioModel.panadapter(a->panId());
                         if (!s || !p || !p->panStreamId()) continue;
-                        int y = s->height();
-                        if (y >= 100)
-                            m_radioModel.panStream()->setYPixels(p->panStreamId(), y);
+                        if (panPixelDimensionsReady(s)) {
+                            m_radioModel.panStream()->setYPixels(
+                                p->panStreamId(), panYpixelsFor(s));
+                            s->prepareForFftScaleChange();
+                        }
                     }
 
                     // Defensive re-push xpixels for all pans after layout settles.
                     // Covers race where radio hadn't finished pan init when first push arrived.
                     QTimer::singleShot(500, this, [this]() {
+                        if (m_shuttingDown || !m_panStack) {
+                            return;
+                        }
                         for (auto* applet : m_panStack->allApplets()) {
                             auto* sw = applet->spectrumWidget();
                             auto* pan = m_radioModel.panadapter(applet->panId());
                             if (!sw || !pan) continue;
-                            int xpix = qMax(sw->width(), 1024);
-                            int ypix = qMax(sw->height(), 200);
+                            const int xpix = panXpixelsFor(sw);
+                            const int ypix = panYpixelsFor(sw);
                             m_radioModel.sendCommand(
                                 QString("display pan set %1 xpixels=%2 ypixels=%3")
                                     .arg(pan->panId()).arg(xpix).arg(ypix));
-                            if (pan->panStreamId())
+                            if (pan->panStreamId()) {
                                 m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+                                sw->prepareForFftScaleChange();
+                            }
                         }
                     });
                 }
@@ -2594,48 +2660,59 @@ MainWindow::MainWindow(QWidget* parent)
                 m_panStack->restoreFloatingState();
             });
         }
-        if (!m_layoutRestoreTimer->property("fired").toBool()) {
+        const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+        if (m_layoutRestoreUntilMs == kPanLayoutRestoreWaitingForFirstPan) {
+            m_layoutRestoreUntilMs = nowMs + kPanLayoutRestoreWindowMs;
+        }
+        if (nowMs <= m_layoutRestoreUntilMs) {
             m_layoutRestoreTimer->start();
         }
     });
     // Re-push xpixels/ypixels when the radio requests it (profile change, reconnect, etc.)
     connect(&m_radioModel, &RadioModel::panDimensionsNeeded,
             this, [this](const QString& panId) {
+        if (m_shuttingDown || !m_panStack) {
+            return;
+        }
         auto* applet = m_panStack->panadapter(panId);
         if (!applet) return;
         auto* sw = applet->spectrumWidget();
         auto* pan = m_radioModel.panadapter(panId);
         if (!sw || !pan) return;
-        int xpix = sw->width();
-        int ypix = sw->height();
-        if (xpix < 100) xpix = 1024;
-        if (ypix < 100) ypix = 700;
+        const int xpix = panXpixelsFor(sw);
+        const int ypix = panYpixelsFor(sw);
         m_radioModel.sendCommand(
             QString("display pan set %1 xpixels=%2 ypixels=%3")
                 .arg(panId).arg(xpix).arg(ypix));
-        if (pan->panStreamId())
+        if (pan->panStreamId()) {
             m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+            sw->prepareForFftScaleChange();
+        }
     });
 
 #ifdef Q_OS_MAC
     auto repushPanDimensions = [this]() {
         QTimer::singleShot(200, this, [this]() {
+            if (m_shuttingDown || !m_panStack) {
+                return;
+            }
             for (auto* applet : m_panStack->allApplets()) {
                 auto* sw = applet->spectrumWidget();
                 auto* pan = m_radioModel.panadapter(applet->panId());
                 if (!sw || !pan) {
                     continue;
                 }
-                const int xpix = sw->width();
-                const int ypix = sw->height();
-                if (xpix < 100 || ypix < 100) {
+                if (!panPixelDimensionsReady(sw)) {
                     continue;
                 }
+                const int xpix = panXpixelsFor(sw);
+                const int ypix = panYpixelsFor(sw);
                 m_radioModel.sendCommand(
                     QString("display pan set %1 xpixels=%2 ypixels=%3")
                         .arg(pan->panId()).arg(xpix).arg(ypix));
                 if (pan->panStreamId()) {
                     m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+                    sw->prepareForFftScaleChange();
                 }
             }
         });
@@ -2648,6 +2725,9 @@ MainWindow::MainWindow(QWidget* parent)
 
     connect(&m_radioModel, &RadioModel::panadapterRemoved,
             this, [this](const QString& panId) {
+        if (m_shuttingDown || !m_panStack) {
+            return;
+        }
         if (auto it = m_panFpsReconcileConnections.find(panId);
             it != m_panFpsReconcileConnections.end()) {
             QObject::disconnect(it.value());
@@ -2690,14 +2770,13 @@ MainWindow::MainWindow(QWidget* parent)
         m_spectrogramBuffers.remove(panId);
         qDebug() << "MainWindow: removed panadapter applet for" << panId;
 
-        // Rearrange remaining pans to a sensible layout
+        // Rearrange remaining pans to a sensible layout. Do not persist this
+        // fallback: a temporary resource-shortage session must not overwrite
+        // the user's saved multi-pan layout.
         int remaining = m_panStack->count();
-        if (remaining == 1)
-            AppSettings::instance().setValue("PanadapterLayout", "1");
-        else if (remaining == 2)
-            m_panStack->rearrangeLayout("2v");
-        else if (remaining == 3)
-            m_panStack->rearrangeLayout("2h1");
+        if (remaining > 1) {
+            m_panStack->rearrangeLayout(defaultPanLayoutForCount(remaining));
+        }
     });
 
     // ── Per-panadapter signal wiring (extracted for multi-pan support) ──────
@@ -4460,6 +4539,9 @@ MainWindow::MainWindow(QWidget* parent)
 
 MainWindow::~MainWindow()
 {
+    qApp->removeEventFilter(this);
+    preparePanadapterUiForShutdown();
+
 #ifdef HAVE_RADE
     if (m_radeSliceId >= 0)
         deactivateRADE();
@@ -4575,6 +4657,54 @@ MainWindow::~MainWindow()
 #ifdef HAVE_HIDAPI
     m_hidEncoder = nullptr;
 #endif
+}
+
+void MainWindow::preparePanadapterUiForShutdown()
+{
+    if (m_panadapterUiPreparedForShutdown) {
+        return;
+    }
+
+    m_panadapterUiPreparedForShutdown = true;
+    m_shuttingDown = true;
+
+    if (m_sHistoryExpireTimer) {
+        m_sHistoryExpireTimer->stop();
+        QObject::disconnect(m_sHistoryExpireTimer, nullptr, this, nullptr);
+    }
+    m_sHistoryData.clear();
+    m_sHistoryPanState.clear();
+    m_spectrogramBuffers.clear();
+
+    if (m_layoutRestoreTimer) {
+        m_layoutRestoreTimer->stop();
+    }
+    m_layoutRestoreUntilMs = 0;
+
+    if (m_panStack) {
+        m_panStack->setShuttingDown(true);
+    }
+
+    if (auto* stream = m_radioModel.panStream()) {
+        QObject::disconnect(stream, nullptr, this, nullptr);
+    }
+
+    const QList<SpectrumWidget*> spectra = findChildren<SpectrumWidget*>();
+    for (SpectrumWidget* spectrum : spectra) {
+        if (spectrum) {
+            spectrum->prepareForShutdown();
+        }
+    }
+
+    if (m_panStack) {
+        m_panStack->prepareShutdown();
+    }
+    m_panApplet = nullptr;
+    m_cwDecoderApplet = nullptr;
+
+    if (m_appletPanel && m_appletPanel->containerManager()) {
+        m_appletPanel->containerManager()->prepareShutdown();
+    }
 }
 
 namespace {
@@ -4956,11 +5086,7 @@ void MainWindow::changeEvent(QEvent* event)
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
-    m_shuttingDown = true;
-    m_panStack->prepareShutdown();
-    if (m_appletPanel && m_appletPanel->containerManager()) {
-        m_appletPanel->containerManager()->prepareShutdown();
-    }
+    preparePanadapterUiForShutdown();
     auto& s = AppSettings::instance();
     s.setValue("MainWindowGeometry", saveGeometry().toBase64());
     s.setValue("MainWindowState",   saveState().toBase64());
@@ -5569,6 +5695,16 @@ void MainWindow::releaseSliderShortcutLease(bool clearFocus)
 
 bool MainWindow::eventFilter(QObject* obj, QEvent* event)
 {
+    if (obj == qApp && event->type() == QEvent::Quit) {
+        if (!m_shuttingDown) {
+            if (m_panStack) {
+                m_panStack->setShuttingDown(true);
+            }
+            QTimer::singleShot(0, this, [this]() { close(); });
+            return true;
+        }
+    }
+
     if (auto* slider = qobject_cast<QAbstractSlider*>(obj)) {
         if (event->type() == QEvent::MouseButtonPress
             || event->type() == QEvent::MouseButtonDblClick) {
@@ -6246,7 +6382,13 @@ void MainWindow::buildMenuBar()
     fileMenu->addSeparator();
     auto* quitAct = fileMenu->addAction("&Quit");
     quitAct->setShortcut(QKeySequence::Quit);
-    connect(quitAct, &QAction::triggered, qApp, &QApplication::quit);
+    quitAct->setMenuRole(QAction::QuitRole);
+    connect(quitAct, &QAction::triggered, this, [this]() {
+        if (m_panStack) {
+            m_panStack->setShuttingDown(true);
+        }
+        close();
+    });
 
     // ── Settings menu ──────────────────────────────────────────────────────
     auto* settingsMenu = menuBar()->addMenu("&Settings");
@@ -6254,66 +6396,67 @@ void MainWindow::buildMenuBar()
     auto* radioSetup = settingsMenu->addAction("Radio Setup...");
     radioSetup->setMenuRole(QAction::PreferencesRole);  // macOS: appears in app menu as Preferences (#883, #1013)
     connect(radioSetup, &QAction::triggered, this, [this] {
-        // Snapshot compression setting before dialog opens.  The dialog is
-        // constructed lazily and destroys itself on close (WA_DeleteOnClose
-        // via showOrRaisePersistent), so each fresh open captures the
-        // current value — matching the pre-migration behavior (#2769).
-        const QString prevComp = m_radioModel.audioCompressionParam();
-        const bool wasFresh = !m_radioSetupDialog;
-        showOrRaisePersistent(m_radioSetupDialog, &m_radioModel, m_audio,
-                              &m_tgxlConn, &m_pgxlConn, &m_antennaGenius);
-        if (wasFresh && m_radioSetupDialog) {
-            auto* dlg = m_radioSetupDialog.data();
-            connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
-                    m_txBandAction, &QAction::trigger);
-#ifdef HAVE_SERIALPORT
-            connect(dlg, &RadioSetupDialog::serialSettingsChanged, this, [this]() {
-                QMetaObject::invokeMethod(m_serialPort, [this] { m_serialPort->loadSettings(); });
-            });
-#endif
-            // Toggle of SliceLetterDisplay → repaint every slice-letter widget
-            // by re-emitting letterChanged on each slice (#2606).
-            connect(dlg, &RadioSetupDialog::sliceLetterDisplayModeChanged,
-                    this, [this]() {
-                for (auto* s : m_radioModel.slices())
-                    s->emitLetterRefresh();
-            });
-            connect(dlg, &QDialog::finished, this, [this, prevComp]() {
-#ifdef HAVE_SERIALPORT
-                // Re-load serial port settings if changed (on worker thread)
-                QMetaObject::invokeMethod(m_serialPort, [this] { m_serialPort->loadSettings(); });
-                // Re-check FlexControl open/close state
-                auto& fcs = AppSettings::instance();
-                bool fcOpen = fcs.value("FlexControlOpen", "False").toString() == "True";
-                QString fcPort = fcs.value("FlexControlPort").toString();
-                bool fcInvert = fcs.value("FlexControlInvertDir", "False").toString() == "True";
-                QMetaObject::invokeMethod(m_flexControl, [this, fcOpen, fcPort, fcInvert] {
-                    if (fcOpen) {
-                        if (!m_flexControl->isOpen() && !fcPort.isEmpty())
-                            m_flexControl->open(fcPort);
-                    } else {
-                        if (m_flexControl->isOpen()) m_flexControl->close();
-                    }
-                    m_flexControl->setInvertDirection(fcInvert);
-                });
-#endif
-                // Re-evaluate CW decode panel and TX tap from the dialog's
-                // RX/TX toggles, plus run state vs current slice mode (#2417).
-                refreshCwDecodeState();
-
-                // If audio compression changed, recreate the RX audio stream
-                QString newComp = m_radioModel.audioCompressionParam();
-                if (newComp != prevComp && m_radioModel.isConnected()) {
-                    qDebug() << "MainWindow: audio compression changed from" << prevComp
-                             << "to" << newComp << "— recreating audio stream";
-                    m_radioModel.removeRxAudioStream();
-                    QTimer::singleShot(500, this, [this]() {
-                        m_radioModel.createRxAudioStream();
-                    });
-                    updateNr2Availability();  // Disable NR2 if switching to Opus (#1597)
-                }
-            });
+        if (m_radioSetupDialog) {
+            m_radioSetupDialog->raise();
+            m_radioSetupDialog->activateWindow();
+            return;
         }
+        // Snapshot compression setting before dialog opens
+        QString prevComp = m_radioModel.audioCompressionParam();
+
+        auto* dlg = new RadioSetupDialog(&m_radioModel, m_audio, &m_tgxlConn, &m_pgxlConn, &m_antennaGenius, this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        m_radioSetupDialog = dlg;
+        connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
+                m_txBandAction, &QAction::trigger);
+#ifdef HAVE_SERIALPORT
+        connect(dlg, &RadioSetupDialog::serialSettingsChanged, this, [this]() {
+            QMetaObject::invokeMethod(m_serialPort, [this] { m_serialPort->loadSettings(); });
+        });
+#endif
+        // Toggle of SliceLetterDisplay → repaint every slice-letter widget
+        // by re-emitting letterChanged on each slice (#2606).
+        connect(dlg, &RadioSetupDialog::sliceLetterDisplayModeChanged,
+                this, [this]() {
+            for (auto* s : m_radioModel.slices())
+                s->emitLetterRefresh();
+        });
+        connect(dlg, &QDialog::finished, this, [this, prevComp]() {
+#ifdef HAVE_SERIALPORT
+            // Re-load serial port settings if changed (on worker thread)
+            QMetaObject::invokeMethod(m_serialPort, [this] { m_serialPort->loadSettings(); });
+            // Re-check FlexControl open/close state
+            auto& fcs = AppSettings::instance();
+            bool fcOpen = fcs.value("FlexControlOpen", "False").toString() == "True";
+            QString fcPort = fcs.value("FlexControlPort").toString();
+            bool fcInvert = fcs.value("FlexControlInvertDir", "False").toString() == "True";
+            QMetaObject::invokeMethod(m_flexControl, [this, fcOpen, fcPort, fcInvert] {
+                if (fcOpen) {
+                    if (!m_flexControl->isOpen() && !fcPort.isEmpty())
+                        m_flexControl->open(fcPort);
+                } else {
+                    if (m_flexControl->isOpen()) m_flexControl->close();
+                }
+                m_flexControl->setInvertDirection(fcInvert);
+            });
+#endif
+            // Re-evaluate CW decode panel and TX tap from the dialog's
+            // RX/TX toggles, plus run state vs current slice mode (#2417).
+            refreshCwDecodeState();
+
+            // If audio compression changed, recreate the RX audio stream
+            QString newComp = m_radioModel.audioCompressionParam();
+            if (newComp != prevComp && m_radioModel.isConnected()) {
+                qDebug() << "MainWindow: audio compression changed from" << prevComp
+                         << "to" << newComp << "— recreating audio stream";
+                m_radioModel.removeRxAudioStream();
+                QTimer::singleShot(500, this, [this]() {
+                    m_radioModel.createRxAudioStream();
+                });
+                updateNr2Availability();  // Disable NR2 if switching to Opus (#1597)
+            }
+        });
+        dlg->show();
     });
 
     auto* chooseRadio = settingsMenu->addAction("Connect to Radio...");
@@ -8111,11 +8254,13 @@ void MainWindow::applyDarkTheme()
 
 void MainWindow::onConnectionStateChanged(bool connected)
 {
+    if (m_shuttingDown) {
+        return;
+    }
+
     m_connPanel->setConnected(connected);
     if (connected) {
-        if (m_layoutRestoreTimer) {
-            m_layoutRestoreTimer->setProperty("fired", false);
-        }
+        m_layoutRestoreUntilMs = kPanLayoutRestoreWaitingForFirstPan;
         m_radioInfoLabel->setText(m_radioModel.model());
         m_radioVersionLabel->setText(m_radioModel.version());
         m_stationLabel->setText(m_radioModel.nickname());
@@ -8181,18 +8326,22 @@ void MainWindow::onConnectionStateChanged(bool connected)
                 BandStackSettings::instance().save();
             }
         }
-        // Apply saved UI preferences to the panel
-        m_panStack->bandStackPanel()->setGrouped(
-            BandStackSettings::instance().groupByBand());
-        m_panStack->bandStackPanel()->setAutoExpiryMinutes(expiryMin);
-        m_panStack->bandStackPanel()->setAutoSaveDwellSeconds(
-            BandStackSettings::instance().autoSaveDwellSeconds());
+        BandStackPanel* bandStackPanel =
+            m_panStack ? m_panStack->bandStackPanel() : nullptr;
+        if (bandStackPanel) {
+            // Apply saved UI preferences to the panel
+            bandStackPanel->setGrouped(BandStackSettings::instance().groupByBand());
+            bandStackPanel->setAutoExpiryMinutes(expiryMin);
+            bandStackPanel->setAutoSaveDwellSeconds(
+                BandStackSettings::instance().autoSaveDwellSeconds());
+        }
 
         // 5-second grace window after connect — suppresses an auto-save fire
         // while the radio finishes pushing initial slice/pan state.
         m_bsConnectGraceUntilMs = QDateTime::currentMSecsSinceEpoch() + 5000;
-        m_panStack->bandStackPanel()->loadBookmarks(
-            m_radioModel.serial(), m_bandPlanMgr);
+        if (bandStackPanel) {
+            bandStackPanel->loadBookmarks(m_radioModel.serial(), m_bandPlanMgr);
+        }
         refreshMemoryBrowsePanel();
         updateBandStackIndicator();
 
@@ -8248,7 +8397,9 @@ void MainWindow::onConnectionStateChanged(bool connected)
         // pushes the radio's built-in transverter capabilities so the
         // band menu surfaces 4m/2m on FLEX-6500 / FLEX-6700 (#695).
         auto refreshXvtr = [this]() {
-            if (!m_radioModel.isConnected()) return;
+            if (m_shuttingDown || !m_panStack || !m_radioModel.isConnected()) {
+                return;
+            }
             QVector<SpectrumOverlayMenu::XvtrBand> xvtrBands;
             for (const auto& x : m_radioModel.xvtrList()) {
                 if (x.isValid)
@@ -8374,6 +8525,10 @@ void MainWindow::onConnectionStateChanged(bool connected)
             }
         }
     } else {
+        if (m_layoutRestoreTimer) {
+            m_layoutRestoreTimer->stop();
+        }
+        m_layoutRestoreUntilMs = 0;
         if (m_appletPanel) {
             m_appletPanel->clearSliceButtons();
         }
@@ -8405,12 +8560,16 @@ void MainWindow::onConnectionStateChanged(bool connected)
         m_radioVersionLabel->setText("");
         m_stationLabel->setText("N0CALL");
         m_tnfIndicator->setStyleSheet("QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
-        m_panStack->bandStackPanel()->clear();
+        if (auto* bandStackPanel = m_panStack ? m_panStack->bandStackPanel() : nullptr) {
+            bandStackPanel->clear();
+        }
         if (m_bsExpiryTimer && m_bsExpiryTimer->isActive())
             m_bsExpiryTimer->stop();
         if (m_bsAutoSaveTimer && m_bsAutoSaveTimer->isActive())
             m_bsAutoSaveTimer->stop();
-        m_panStack->setBandStackVisible(false);
+        if (m_panStack) {
+            m_panStack->setBandStackVisible(false);
+        }
         refreshMemoryBrowsePanel();
         updateBandStackIndicator();
         m_tgxlIndicator->setVisible(false);
@@ -8456,8 +8615,13 @@ void MainWindow::onConnectionStateChanged(bool connected)
         m_wfLineDurationReconcile.clear();
 
         // Clear spectrum/waterfall so the display doesn't look frozen
-        for (auto* applet : m_panStack->allApplets())
-            applet->spectrumWidget()->clearDisplay();
+        if (m_panStack) {
+            for (auto* applet : m_panStack->allApplets()) {
+                if (applet && applet->spectrumWidget()) {
+                    applet->spectrumWidget()->clearDisplay();
+                }
+            }
+        }
 
         setPanadapterConnectionAnimation(!m_userDisconnected, "Reconnecting to radio…");
 
@@ -10179,7 +10343,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
     // ── Debounced resize → re-push xpixels/ypixels to the radio (#1511) ───
     // When the layout changes (e.g. adding a second pan, splitting, resizing),
-    // the widget dimensions change but the radio keeps encoding FFT bins to the
+    // the FFT pane dimensions change but the radio keeps encoding FFT bins to the
     // old yPixels scale.  This causes a ~5 dB noise-floor offset until restart.
     // A 300ms debounce avoids flooding the radio during animated resizes.
     {
@@ -10191,15 +10355,21 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         connect(resizeTimer, &QTimer::timeout,
                 this, [this, applet, sw]() {
             auto* pan = m_radioModel.panadapter(applet->panId());
-            if (!pan || !sw) return;
-            int xpix = sw->width();
-            int ypix = sw->height();
-            if (xpix < 100 || ypix < 100) return;
+            if (!pan || !sw) {
+                return;
+            }
+            if (!panPixelDimensionsReady(sw)) {
+                return;
+            }
+            const int xpix = panXpixelsFor(sw);
+            const int ypix = panYpixelsFor(sw);
             m_radioModel.sendCommand(
                 QString("display pan set %1 xpixels=%2 ypixels=%3")
                     .arg(pan->panId()).arg(xpix).arg(ypix));
-            if (pan->panStreamId())
+            if (pan->panStreamId()) {
                 m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+                sw->prepareForFftScaleChange();
+            }
         });
     }
 
@@ -14666,6 +14836,7 @@ void MainWindow::applySHistoryEnabled(bool on)
     m_sHistoryEnabled = on;
     AppSettings::instance().setValue("SHistoryMarkersEnabled", on ? "True" : "False");
     AppSettings::instance().save();
+    if (m_shuttingDown || !m_panStack) return;
     for (auto* a : m_panStack->allApplets()) {
         a->spectrumWidget()->setShowSHistory(on);
     }
@@ -14683,6 +14854,7 @@ void MainWindow::applySHistoryQrmEnabled(bool on)
     m_sHistoryQrmEnabled = on;
     AppSettings::instance().setValue("SHistoryQrmEnabled", on ? "True" : "False");
     AppSettings::instance().save();
+    if (m_shuttingDown || !m_panStack) return;
     for (auto* a : m_panStack->allApplets()) {
         a->spectrumWidget()->setShowSHistoryQrm(on);
     }
@@ -14697,6 +14869,7 @@ void MainWindow::applySHistoryQrmEnabled(bool on)
 
 void MainWindow::rebuildSHistoryForPan(const QString& panId)
 {
+    if (m_shuttingDown || !m_panStack) return;
     auto* sw = m_panStack->spectrum(panId);
     if (!sw) return;
 
@@ -14860,6 +15033,7 @@ void MainWindow::rebuildSHistoryForPan(const QString& panId)
 
 void MainWindow::expireSHistoryMarkers()
 {
+    if (m_shuttingDown || !m_panStack) return;
     if (!m_sHistoryEnabled && !m_sHistoryQrmEnabled) return;
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
     // Per-tick read keeps the slider live — fires once a second, AppSettings
@@ -14890,7 +15064,7 @@ void MainWindow::onSpectrumReadyForSHistory(quint32 streamId, const QVector<floa
     const bool perfEnabled = PerfTelemetry::instance().enabled();
     const qint64 perfStartNs = perfEnabled ? PerfTelemetry::nowNs() : 0;
 
-    if (!m_sHistoryEnabled && !m_sHistoryQrmEnabled) {
+    if (m_shuttingDown || !m_panStack || (!m_sHistoryEnabled && !m_sHistoryQrmEnabled)) {
         if (perfEnabled)
             PerfTelemetry::instance().recordSHistorySkipped();
         return;
@@ -14939,7 +15113,8 @@ void MainWindow::onSpectrumReadyForSHistory(quint32 streamId, const QVector<floa
         // Read the noise floor that the spectrum widget has already measured
         // from this pan's live FFT stream — no hardcoded dBm, adapts to the
         // current band, antenna, and preamp setup automatically.
-        SpectrumWidget* sw = m_panStack->spectrum(pan->panId());
+        auto* panStack = m_panStack;
+        SpectrumWidget* sw = panStack ? panStack->spectrum(pan->panId()) : nullptr;
         const float noiseFloor = sw ? sw->noiseFloorDbm() : -1000.0f;
 
         // Use the active slice mode so USB pans only show USB markers and

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -81,7 +81,6 @@ class NetworkDiagnosticsHistory;
 class WhatsNewDialog;
 class ProfileManagerDialog;
 class ProfileImportExportDialog;
-class RadioSetupDialog;
 class NetworkDiagnosticsDialog;
 class MemoryDialog;
 class PropDashboardDialog;
@@ -504,7 +503,7 @@ private:
 
     // Modeless dialogs
     QPointer<DxClusterDialog> m_spotHubDialog;
-    QPointer<RadioSetupDialog> m_radioSetupDialog;
+    QPointer<QDialog> m_radioSetupDialog;
     QPointer<NetworkDiagnosticsDialog> m_networkDiagnosticsDialog;
     QPointer<PropDashboardDialog> m_propDashboardDialog;
     QPointer<TxBandDialog> m_txBandDialog;
@@ -583,6 +582,8 @@ private:
     // helpers do not echo model-driven changes back to the radio.
     bool m_updatingFromModel{false};
     bool m_shuttingDown{false};
+    bool m_panadapterUiPreparedForShutdown{false};
+    void preparePanadapterUiForShutdown();
     void toggleConnectionDialog();
     bool m_useSystemClock{true};     // true when no GPS installed
     bool m_paTempUseFahrenheit{true};
@@ -638,6 +639,7 @@ private:
     QHash<QString, WaterfallLineDurationReconcileState> m_wfLineDurationReconcile;
     QHash<QString, QMetaObject::Connection> m_wfLineDurationReconcileConnections;
     QTimer* m_layoutRestoreTimer{nullptr}; // debounced layout rearrange after pans added on connect
+    qint64 m_layoutRestoreUntilMs{0};
     QTimer* m_heartbeatMissTimer{nullptr}; // fires every 1.5s to detect missed discovery beats
     QTimer* m_bsExpiryTimer{nullptr};    // band-stack bookmark auto-expiry, started on connect only (#1471)
     QTimer* m_bsAutoSaveTimer{nullptr};  // band-stack dwell auto-save (single-shot per dwell window)

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -13,9 +13,10 @@
 #include <QTimer>
 #include <QWindow>
 
-// After reparenting a QRhiWidget to a different top-level window,
-// tear down old GPU pipelines and force a fresh initialize() cycle
-// so the Metal/Vulkan surface binds to the new window.
+// After moving a QRhiWidget between top-level windows, force a fresh initialize()
+// cycle so Metal binds to the new NSView. The backing-store notification is sent
+// before the actual reparent; sending it again here can make QRhiWidget remove a
+// stale cleanup callback from the wrong QRhi during startup floating restore.
 static void refreshAfterReparent(AetherSDR::SpectrumWidget* sw)
 {
     if (!sw) return;
@@ -37,6 +38,30 @@ static void refreshAfterReparent(AetherSDR::SpectrumWidget* sw)
 }
 
 namespace AetherSDR {
+
+namespace {
+
+static const QMap<QString, int> kLayoutPanCount = {
+    {"1", 1}, {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"3v", 3},
+    {"2x2", 4}, {"4v", 4}, {"3h2", 5}, {"2x3", 6}, {"4h3", 7}, {"2x4", 8}
+};
+
+QString defaultDockedLayoutForCount(int panCount)
+{
+    static const QMap<int, QString> kDefaultLayouts = {
+        {1, QStringLiteral("1")},
+        {2, QStringLiteral("2v")},
+        {3, QStringLiteral("2h1")},
+        {4, QStringLiteral("2x2")},
+        {5, QStringLiteral("3h2")},
+        {6, QStringLiteral("2x3")},
+        {7, QStringLiteral("4h3")},
+        {8, QStringLiteral("2x4")}
+    };
+    return kDefaultLayouts.value(panCount, QStringLiteral("1"));
+}
+
+} // namespace
 
 PanadapterStack::PanadapterStack(QWidget* parent)
     : QWidget(parent)
@@ -63,6 +88,8 @@ void PanadapterStack::setBandStackVisible(bool visible)
 
 PanadapterApplet* PanadapterStack::addPanadapter(const QString& panId)
 {
+    m_seenPanIds.insert(panId);
+
     if (m_pans.contains(panId))
         return m_pans[panId];
 
@@ -129,6 +156,8 @@ void PanadapterStack::rekey(const QString& oldId, const QString& newId)
 {
     if (auto* applet = m_pans.take(oldId)) {
         m_pans[newId] = applet;
+        m_seenPanIds.remove(oldId);
+        m_seenPanIds.insert(newId);
         if (m_activePanId == oldId)
             m_activePanId = newId;
     }
@@ -204,6 +233,15 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
     // crashes (#2495).  Stale entries would also remain in
     // m_floatingWindows, permanently blocking future float requests.
     QList<QPointer<SpectrumWidget>> rebound;
+    auto appendRebound = [&rebound](SpectrumWidget* sw) {
+        if (!sw) return;
+        for (SpectrumWidget* existing : rebound) {
+            if (existing == sw) {
+                return;
+            }
+        }
+        rebound.append(sw);
+    };
     if (!m_floatingWindows.isEmpty()) {
         const QList<QString> floatingIds = m_floatingWindows.keys();
         for (const QString& panId : floatingIds) {
@@ -213,8 +251,9 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
             PanadapterApplet* applet = fw->applet();
             if (auto* sw = applet ? applet->spectrumWidget() : nullptr) {
                 sw->hide();
+                sw->prepareForTopLevelChange();
                 sw->resetGpuResources();
-                rebound.append(sw);
+                appendRebound(sw);
             }
             applet = fw->takeApplet();
             fw->hide();
@@ -232,9 +271,18 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
     QList<PanadapterApplet*> applets = m_pans.values();
     if (applets.isEmpty()) return;
 
-    // Remove all applets from current splitter (don't delete them)
-    for (auto* a : applets)
+    // Remove all applets from current splitter (don't delete them).  setParent()
+    // can temporarily change the QRhiWidget's top-level window, so give Qt a
+    // chance to unregister the old backing-store callback before the move.
+    for (auto* a : applets) {
+        if (auto* sw = a ? a->spectrumWidget() : nullptr) {
+            sw->hide();
+            sw->prepareForTopLevelChange();
+            sw->resetGpuResources();
+            appendRebound(sw);
+        }
         a->setParent(nullptr);
+    }
 
     // Hide + remove old splitter from layout, defer deletion
     m_splitter->hide();
@@ -367,8 +415,8 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
     QTimer::singleShot(0, this, [this, rebound]() {
         for (SpectrumWidget* sw : rebound) {
             if (!sw) continue;
-            sw->show();
             refreshAfterReparent(sw);
+            sw->show();
         }
         equalizeSizes();
     });
@@ -410,21 +458,9 @@ void PanadapterStack::rebuildDockedSplitter()
     newSplitter->setChildrenCollapsible(false);
     layout()->addWidget(newSplitter);
 
-    static const QMap<QString, int> layoutPanCount = {
-        {"1", 1}, {"2v", 2}, {"2h", 2}, {"2h1", 3}, {"12h", 3}, {"3v", 3},
-        {"2x2", 4}, {"4v", 4}, {"3h2", 5}, {"2x3", 6}, {"4h3", 7}, {"2x4", 8}
-    };
     QString layoutId = AppSettings::instance().value("PanadapterLayout", "1").toString();
-    if (layoutPanCount.value(layoutId, -1) != docked.size()) {
-        if (docked.size() == 2) {
-            layoutId = QStringLiteral("2v");
-        } else if (docked.size() == 3) {
-            layoutId = QStringLiteral("2h1");
-        } else if (docked.size() == 4) {
-            layoutId = QStringLiteral("2x2");
-        } else {
-            layoutId = QStringLiteral("1");
-        }
+    if (!m_floatingWindows.isEmpty() || kLayoutPanCount.value(layoutId, -1) != docked.size()) {
+        layoutId = defaultDockedLayoutForCount(docked.size());
     }
 
     auto makeSplitter = [](Qt::Orientation orientation) {
@@ -669,6 +705,7 @@ void PanadapterStack::floatPanadapter(const QString& panId)
     // destruction can corrupt the main window's NSResponder chain (#1344).
     SpectrumWidget* sw = applet->spectrumWidget();
     sw->hide();
+    sw->prepareForTopLevelChange();
     sw->resetGpuResources();
 
     // Reparent directly from splitter into the floating window — never through
@@ -722,6 +759,7 @@ void PanadapterStack::dockPanadapter(const QString& panId)
     SpectrumWidget* sw = applet ? applet->spectrumWidget() : nullptr;
     if (sw) {
         sw->hide();
+        sw->prepareForTopLevelChange();
         sw->resetGpuResources();
     }
 
@@ -787,8 +825,21 @@ void PanadapterStack::setFramelessMode(bool on)
     }
 }
 
+void PanadapterStack::setShuttingDown(bool on)
+{
+    for (auto* fw : m_floatingWindows) {
+        fw->setShuttingDown(on);
+    }
+}
+
 void PanadapterStack::prepareShutdown()
 {
+    if (m_shutdownPrepared) {
+        return;
+    }
+    m_shutdownPrepared = true;
+
+    setShuttingDown(true);
     saveFloatingState();
 
     // Explicitly delete floating windows rather than calling close().
@@ -807,8 +858,7 @@ void PanadapterStack::prepareShutdown()
         fw->saveWindowGeometry();
         if (PanadapterApplet* applet = fw->applet()) {
             if (SpectrumWidget* sw = applet->spectrumWidget()) {
-                sw->hide();
-                sw->resetGpuResources();
+                sw->prepareForShutdown();
             }
         }
         m_pans.remove(panId);
@@ -827,8 +877,7 @@ void PanadapterStack::prepareShutdown()
         PanadapterApplet* applet = m_pans.take(panId);
         if (!applet) continue;
         if (SpectrumWidget* sw = applet->spectrumWidget()) {
-            sw->hide();
-            sw->resetGpuResources();
+            sw->prepareForShutdown();
         }
         delete applet;
     }
@@ -837,8 +886,17 @@ void PanadapterStack::prepareShutdown()
 void PanadapterStack::saveFloatingState() const
 {
     QStringList ids;
+    const QString saved =
+        AppSettings::instance().value("FloatingPanIds", "").toString();
+    for (const QString& id : saved.split(',', Qt::SkipEmptyParts)) {
+        if (!m_seenPanIds.contains(id) && !ids.contains(id)) {
+            ids << id;
+        }
+    }
     for (const QString& id : m_floatingWindows.keys()) {
-        ids << id;
+        if (!ids.contains(id)) {
+            ids << id;
+        }
     }
     AppSettings::instance().setValue("FloatingPanIds", ids.join(','));
     AppSettings::instance().save();

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 #include <QMap>
+#include <QSet>
 #include <QSplitter>
 
 namespace AetherSDR {
@@ -55,6 +56,7 @@ public:
 
     // Follow the main-window frameless setting for all active floating windows.
     void setFramelessMode(bool on);
+    void setShuttingDown(bool on);
 
     // Persist / restore which pans are currently floating (AppSettings key
     // "FloatingPanIds").  saveFloatingState is called automatically on every
@@ -77,7 +79,10 @@ private:
     QSplitter* m_splitter{nullptr};
     QMap<QString, PanadapterApplet*> m_pans;
     QMap<QString, PanFloatingWindow*> m_floatingWindows;
+    // Preserve floating state for restored pans that were unavailable this run.
+    QSet<QString> m_seenPanIds;
     QString m_activePanId;
+    bool m_shutdownPrepared{false};
 };
 
 } // namespace AetherSDR

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -30,9 +30,11 @@
 #include <QVBoxLayout>
 #include <QWidgetAction>
 #include <QApplication>
+#include <QCoreApplication>
 #include <QGuiApplication>
 #include <QClipboard>
 #include <QDesktopServices>
+#include <QEvent>
 #include <QStringList>
 #include <QUrl>
 #include "core/AppSettings.h"
@@ -413,6 +415,48 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
             this, [this]() { markOverlayDirty(); });
 }
 
+SpectrumWidget::~SpectrumWidget()
+{
+    prepareForShutdown();
+}
+
+void SpectrumWidget::prepareForTopLevelChange()
+{
+#ifdef AETHER_GPU_SPECTRUM
+#ifdef Q_OS_MAC
+    // QRhiWidget registers a cleanup callback with the current top-level
+    // backing-store QRhi. Direct splitter/floating-window reparenting can miss
+    // Qt's internal notification, leaving the old QRhi with a stale callback.
+    QEvent event(QEvent::WindowAboutToChangeInternal);
+    QCoreApplication::sendEvent(this, &event);
+#endif
+#endif
+}
+
+void SpectrumWidget::prepareForShutdown()
+{
+    if (m_shutdownPrepared) {
+        return;
+    }
+    m_shutdownPrepared = true;
+
+    prepareForTopLevelChange();
+    setUpdatesEnabled(false);
+    hide();
+
+#ifdef AETHER_GPU_SPECTRUM
+#ifndef Q_OS_LINUX
+    releaseResources();
+#endif
+#ifdef Q_OS_MAC
+    // Drop the native child window while its parent backing store is still
+    // alive, so any remaining platform resources are gone before QWidgetWindow
+    // destruction runs on app exit.
+    destroy(true, true);
+#endif
+#endif
+}
+
 // ── Multi-VfoWidget management ────────────────────────────────────────────────
 
 VfoWidget* SpectrumWidget::vfoWidget(int sliceId) const
@@ -583,9 +627,6 @@ void SpectrumWidget::setNoiseFloorPosition(int pos) {
 void SpectrumWidget::setNoiseFloorEnable(bool on) {
     m_pendingDbmRangeEcho = false;
     m_pendingDbmRangeEchoStartMs = 0;
-    if (on) {
-        captureNoiseFloorTargetFromCurrentScale(true);
-    }
     m_noiseFloorEnable = on;
     resetNoiseFloorBaseline();
     // Five fresh frames after enable so we lock onto the current
@@ -610,6 +651,20 @@ void SpectrumWidget::reacquireNoiseFloorLock() {
     m_noiseFloorFreshFrameCount = 30;
     m_measuredNoiseFloorDbm = -1000.0f;
 }
+
+void SpectrumWidget::prepareForFftScaleChange()
+{
+    m_resetFftSmoothingOnNextFrame = true;
+    if (!m_noiseFloorEnable) return;
+
+    constexpr qint64 kScaleSettleMs = 750;
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    m_noiseFloorScaleSettlingUntilMs =
+        std::max(m_noiseFloorScaleSettlingUntilMs, nowMs + kScaleSettleMs);
+    m_noiseFloorCandidateValid = false;
+    m_noiseFloorCandidateFrames = 0;
+}
+
 void SpectrumWidget::setFftWeightedAvg(bool on) {
     m_fftWeightedAvg = on;
     auto& s = AppSettings::instance();
@@ -745,6 +800,13 @@ void SpectrumWidget::updateFpsMeterLabels() {
     positionFpsMeterLabels();
 }
 
+int SpectrumWidget::spectrumPixelHeight() const
+{
+    const int chromeH = FREQ_SCALE_H + DIVIDER_H;
+    const int contentH = std::max(0, height() - chromeH);
+    return std::max(1, static_cast<int>(contentH * m_spectrumFrac));
+}
+
 void SpectrumWidget::positionFpsMeterLabels() {
     if (!m_panFpsMeterLabel || !m_wfFpsMeterLabel) {
         return;
@@ -767,7 +829,7 @@ void SpectrumWidget::positionFpsMeterLabels() {
         return;
     }
 
-    const int specH = static_cast<int>(contentH * m_spectrumFrac);
+    const int specH = spectrumPixelHeight();
     const int wfY = specH + DIVIDER_H + FREQ_SCALE_H;
     const QRect specRect(0, 0, width(), specH);
     const QRect wfRect(0, wfY, width(), height() - wfY);
@@ -865,6 +927,7 @@ void SpectrumWidget::resetNoiseFloorBaseline()
     m_noiseFloorLastMotionMs = nowMs - 100;
     m_noiseFloorLastCommandMs = 0;
     m_noiseFloorLastCommandRef = m_refLevel;
+    m_noiseFloorScaleSettlingUntilMs = 0;
     m_noiseFloorCandidateValid = false;
     m_noiseFloorCandidateDbm = -1000.0f;
     m_noiseFloorCandidateStartMs = 0;
@@ -874,10 +937,10 @@ void SpectrumWidget::resetNoiseFloorBaseline()
     m_pendingDbmRangeEchoStartMs = 0;
 }
 
-void SpectrumWidget::refreshNoiseFloorTarget(bool captureCurrentScale)
+void SpectrumWidget::refreshNoiseFloorTarget(bool captureCurrentScale, bool persistCapture)
 {
     if (captureCurrentScale) {
-        captureNoiseFloorTargetFromCurrentScale(true);
+        captureNoiseFloorTargetFromCurrentScale(true, persistCapture);
     }
 
     if (m_noiseFloorEnable) {
@@ -893,7 +956,7 @@ void SpectrumWidget::refreshNoiseFloorTarget(bool captureCurrentScale)
     }
 }
 
-bool SpectrumWidget::captureNoiseFloorTargetFromCurrentScale(bool notify)
+bool SpectrumWidget::captureNoiseFloorTargetFromCurrentScale(bool notify, bool persist)
 {
     if (m_dynamicRange <= 0.0f) {
         qDebug() << "SpectrumWidget: noise-floor capture skipped — "
@@ -928,6 +991,11 @@ bool SpectrumWidget::captureNoiseFloorTargetFromCurrentScale(bool notify)
 
     m_noiseFloorTargetFrac = targetFrac;
     m_noiseFloorPosition = newPosition;
+    if (persist) {
+        auto& s = AppSettings::instance();
+        s.setValue(settingsKey("DisplayNoiseFloorPosition"), QString::number(m_noiseFloorPosition));
+        s.save();
+    }
     if (notify) {
         emit noiseFloorPositionResolved(newPosition);
     }
@@ -938,9 +1006,6 @@ void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
 {
     if (!m_noiseFloorEnable || m_transmitting || bins.isEmpty()) return;
 
-    const float frameFloor = estimateNoiseFloorDbm(bins);
-    if (frameFloor <= -500.0f || m_dynamicRange <= 0.0f) return;
-
     const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
     if (m_pendingDbmRangeEcho
         && m_pendingDbmRangeEchoStartMs > 0
@@ -948,6 +1013,17 @@ void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
         m_pendingDbmRangeEcho = false;
         m_pendingDbmRangeEchoStartMs = 0;
     }
+    if (m_pendingDbmRangeEcho) return;
+
+    if (m_noiseFloorScaleSettlingUntilMs > nowMs) return;
+    if (m_noiseFloorScaleSettlingUntilMs > 0) {
+        m_noiseFloorScaleSettlingUntilMs = 0;
+        m_noiseFloorCandidateValid = false;
+        m_noiseFloorCandidateFrames = 0;
+    }
+
+    const float frameFloor = estimateNoiseFloorDbm(bins);
+    if (frameFloor <= -500.0f || m_dynamicRange <= 0.0f) return;
 
     if (!m_noiseFloorBaselineValid || m_noiseFloorLastSampleMs <= 0 || forceBaseline) {
         // Cold-acquire: force the baseline to this frame's reading.
@@ -1096,6 +1172,10 @@ void SpectrumWidget::sendNoiseFloorRangeCommand(qint64 nowMs, bool force)
 
     m_noiseFloorLastCommandMs = nowMs;
     m_noiseFloorLastCommandRef = m_refLevel;
+    m_pendingDbmRangeEcho = true;
+    m_pendingDbmRangeEchoStartMs = nowMs;
+    m_pendingMinDbm = m_refLevel - m_dynamicRange;
+    m_pendingMaxDbm = m_refLevel;
     emit dbmRangeChangeRequested(m_refLevel - m_dynamicRange, m_refLevel);
 }
 
@@ -1736,7 +1816,9 @@ void SpectrumWidget::resetGpuResources()
     releaseResources();
 #endif
 #endif
-    update();
+    if (!m_shutdownPrepared) {
+        update();
+    }
 }
 
 void SpectrumWidget::reprojectWaterfall(double oldCenterMhz, double oldBandwidthMhz,
@@ -1982,6 +2064,9 @@ void SpectrumWidget::setSpectrumFrac(float f)
     s.setValue(settingsKey("SpectrumSplitRatio"), QString::number(m_spectrumFrac, 'f', 3));
     s.save();
     positionFpsMeterLabels();
+    if (width() >= 100 && spectrumPixelHeight() >= 20) {
+        emit dimensionsChanged(width(), spectrumPixelHeight());
+    }
     markOverlayDirty();
 }
 
@@ -2165,31 +2250,7 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
             PerfTelemetry::instance().recordPanFrame();
     }
 
-    QVector<float> adjustedBins;
     const QVector<float>* spectrumBins = &binsDbm;
-    if (m_holdFftUpdatesAfterDbmRelease > 0 && m_dbmReleasePreviewOffset != 0.0f) {
-        --m_holdFftUpdatesAfterDbmRelease;
-        if (!m_bins.isEmpty() && m_bins.size() == binsDbm.size()) {
-            QVector<float> deltas;
-            const int step = qMax(1, binsDbm.size() / 256);
-            deltas.reserve((binsDbm.size() + step - 1) / step);
-            for (int i = 0; i < binsDbm.size(); i += step) {
-                deltas.append(binsDbm[i] - m_bins[i]);
-            }
-            std::sort(deltas.begin(), deltas.end());
-            const float frameOffset = deltas[deltas.size() / 2];
-            const float tolerance = qMax(1.5f, std::abs(m_dbmReleasePreviewOffset) * 0.35f);
-            if (std::abs(frameOffset - m_dbmReleasePreviewOffset) <= tolerance) {
-                adjustedBins = binsDbm;
-                for (float& bin : adjustedBins) {
-                    bin -= m_dbmReleasePreviewOffset;
-                }
-                spectrumBins = &adjustedBins;
-            }
-        }
-    } else if (m_holdFftUpdatesAfterDbmRelease > 0) {
-        --m_holdFftUpdatesAfterDbmRelease;
-    }
 
     if (m_resetFftSmoothingOnNextFrame) {
         m_smoothed = *spectrumBins;
@@ -2769,7 +2830,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
                         m_refLevel = bottom + m_dynamicRange;
                     }
                     markOverlayDirty();
-                    refreshNoiseFloorTarget(true);
+                    refreshNoiseFloorTarget(true, true);
                     emit dbmRangeChangeRequested(bottom, m_refLevel);
                     ev->accept();
                     return;
@@ -3472,22 +3533,22 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
         auto& s = AppSettings::instance();
         s.setValue(settingsKey("SpectrumSplitRatio"), QString::number(m_spectrumFrac, 'f', 3));
         s.save();
+        if (width() >= 100 && spectrumPixelHeight() >= 20) {
+            emit dimensionsChanged(width(), spectrumPixelHeight());
+        }
         ev->accept();
         return;
     }
     if (m_draggingDbm || m_draggingDbmRange) {
-        const bool rangeDrag = m_draggingDbmRange;
         m_pendingDbmRangeEcho = true;
         m_pendingDbmRangeEchoStartMs = QDateTime::currentMSecsSinceEpoch();
         m_pendingMinDbm = m_refLevel - m_dynamicRange;
         m_pendingMaxDbm = m_refLevel;
-        m_dbmReleasePreviewOffset = rangeDrag ? 0.0f : m_refLevel - m_dbmDragStartRef;
-        m_holdFftUpdatesAfterDbmRelease = rangeDrag ? 0 : 10;
         m_draggingDbm = false;
         m_draggingDbmRange = false;
         setSpectrumCursor(Qt::CrossCursor);
         m_resetFftSmoothingOnNextFrame = true;
-        refreshNoiseFloorTarget(true);
+        refreshNoiseFloorTarget(true, true);
         emit dbmRangeDragFinished(m_pendingMinDbm, m_pendingMaxDbm);
         ev->accept();
         return;
@@ -3883,8 +3944,9 @@ void SpectrumWidget::resizeEvent(QResizeEvent* ev)
     positionInterlockNotification();
 
     // Notify MainWindow so it can re-push xpixels/ypixels to the radio (#1511)
-    if (width() >= 100 && height() >= 100)
-        emit dimensionsChanged(width(), height());
+    if (width() >= 100 && spectrumPixelHeight() >= 20) {
+        emit dimensionsChanged(width(), spectrumPixelHeight());
+    }
 }
 
 void SpectrumWidget::positionZoomButtons()
@@ -4940,6 +5002,9 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
 
 void SpectrumWidget::render(QRhiCommandBuffer* cb)
 {
+    if (m_shutdownPrepared) {
+        return;
+    }
     if (!m_rhiInitialized) {
         initialize(cb);
         if (!m_rhiInitialized) return;
@@ -6780,19 +6845,26 @@ void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
     const float bottomDbm = m_refLevel - m_dynamicRange;
     const float firstLabel = std::ceil(bottomDbm / stepDb) * stepDb;
 
+    auto drawTickLabel = [&](float dbm, int y, int textBaseline) {
+        p.setPen(QColor(0x50, 0x70, 0x80));
+        p.drawLine(stripX, y, stripX + 4, y);
+
+        const QString label = QString::number(static_cast<int>(std::lround(dbm)));
+        p.setPen(QColor(0x80, 0xa0, 0xb0));
+        p.drawText(stripX + 6, textBaseline, label);
+    };
+
     for (float dbm = firstLabel; dbm <= m_refLevel; dbm += stepDb) {
         const float frac = (m_refLevel - dbm) / m_dynamicRange;
         const int y = specRect.top() + static_cast<int>(frac * specRect.height());
         if (y < labelTop || y > specRect.bottom() - 5) continue;
 
-        // Tick mark
-        p.setPen(QColor(0x50, 0x70, 0x80));
-        p.drawLine(stripX, y, stripX + 4, y);
+        drawTickLabel(dbm, y, y + fm.ascent() / 2);
+    }
 
-        // Label
-        const QString label = QString::number(static_cast<int>(dbm));
-        p.setPen(QColor(0x80, 0xa0, 0xb0));
-        p.drawText(stripX + 6, y + fm.ascent() / 2, label);
+    const int bottomY = specRect.bottom();
+    if (bottomY >= labelTop) {
+        drawTickLabel(bottomDbm, bottomY, bottomY - 2);
     }
 }
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -75,6 +75,7 @@ class SpectrumWidget : public SPECTRUM_BASE_CLASS {
 
 public:
     explicit SpectrumWidget(QWidget* parent = nullptr);
+    ~SpectrumWidget() override;
 
     // Per-pan settings persistence
     void setPanIndex(int idx) { m_panIndex = idx; }
@@ -83,11 +84,14 @@ public:
     void loadSettings();
 
     QSize sizeHint() const override { return {800, 300}; }
+    int spectrumPixelHeight() const;
 
     // Set the frequency range covered by this panadapter.
     void setFrequencyRange(double centerMhz, double bandwidthMhz);
     void clearDisplay();  // blank spectrum and waterfall on disconnect
     void resetGpuResources();  // tear down GPU pipelines for reparenting (#1240)
+    void prepareForTopLevelChange(); // unregister QRhiWidget from the current backing-store QRhi
+    void prepareForShutdown(); // tear down QRhi/native resources before QWidget backing store destruction
     void setConnectionAnimationVisible(bool on, const QString& label = {});
     void showInterlockNotification(const QString& message, int durationMs = 5000);
 
@@ -110,6 +114,7 @@ public:
     // so the state and value survive launch.
     void setNoiseFloorPosition(int pos);
     void setNoiseFloorEnable(bool on);
+    void prepareForFftScaleChange();
     void reacquireNoiseFloorLock();
 
     // Two-pass trimmed-mean noise floor from live FFT bins (dBm), EMA-smoothed.
@@ -481,7 +486,8 @@ signals:
     void sliceTuneRequested(int sliceId, double freqMhz);
     void popOutRequested(bool popOut);  // true=float, false=dock
     void sliceTxRequested(int sliceId);
-    // Emitted on resize so MainWindow can re-push xpixels/ypixels to the radio (#1511)
+    // Emitted when FFT bin-mapping dimensions change so MainWindow can re-push
+    // xpixels/ypixels to the radio (#1511).
     void dimensionsChanged(int w, int h);
     // Spot signals
     void spotAddRequested(double freqMhz, const QString& callsign,
@@ -587,10 +593,10 @@ private:
     // band switch, manual dBm drag) so the next frame re-acquires
     // rather than smooths from a stale value.
     void resetNoiseFloorBaseline();
-    // Re-capture the target frac. Slider changes use m_noiseFloorPosition;
-    // manual dBm-scale changes can capture the floor's current screen position.
-    void refreshNoiseFloorTarget(bool captureCurrentScale = false);
-    bool captureNoiseFloorTargetFromCurrentScale(bool notify);
+    // Re-capture the target frac. Explicit user changes (slider/right dBm bar)
+    // can persist; startup/enable/layout refreshes only rebuild transient state.
+    void refreshNoiseFloorTarget(bool captureCurrentScale = false, bool persistCapture = false);
+    bool captureNoiseFloorTargetFromCurrentScale(bool notify, bool persist);
 
     // Helper: find overlay index for a sliceId, or -1.
     int overlayIndex(int sliceId) const;
@@ -609,6 +615,7 @@ private:
 
     QVector<float> m_bins;       // raw FFT frame (dBm)
     QVector<float> m_smoothed;   // exponential-smoothed for visual stability
+    bool m_shutdownPrepared{false};
 
     double m_centerMhz{14.225};
     double m_bandwidthMhz{0.200};
@@ -630,8 +637,6 @@ private:
     bool  m_resetFftSmoothingOnNextFrame{false};
     bool  m_pendingDbmRangeEcho{false};
     qint64 m_pendingDbmRangeEchoStartMs{0};
-    int   m_holdFftUpdatesAfterDbmRelease{0};
-    float m_dbmReleasePreviewOffset{0.0f};
     float m_pendingMinDbm{0.0f};
     float m_pendingMaxDbm{0.0f};
 
@@ -654,6 +659,7 @@ private:
     qint64 m_noiseFloorLastSampleMs{0};
     qint64 m_noiseFloorLastMotionMs{0};
     qint64 m_noiseFloorLastCommandMs{0};
+    qint64 m_noiseFloorScaleSettlingUntilMs{0};
     float  m_noiseFloorLastCommandRef{-1000.0f};
     bool   m_noiseFloorCandidateValid{false};
     float  m_noiseFloorCandidateDbm{-1000.0f};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -25,6 +25,8 @@ namespace AetherSDR {
 
 namespace {
 
+constexpr int kMinUsablePanYpixels = 100;
+
 QJsonArray toJsonArray(const QStringList& values)
 {
     QJsonArray array;
@@ -4495,8 +4497,9 @@ void RadioModel::handlePanadapterStatus(const QString& panId, const QMap<QString
     // load) and re-request correct dimensions from MainWindow.
     if (kvs.contains("y_pixels") && pan) {
         int yPix = kvs["y_pixels"].toInt();
-        if (yPix > 0)
+        if (yPix > kMinUsablePanYpixels) {
             m_panStream->setYPixels(pan->panStreamId(), yPix);
+        }
     }
     if ((kvs.contains("x_pixels") || kvs.contains("y_pixels")) && pan) {
         int xPix = kvs.value("x_pixels", "0").toInt();


### PR DESCRIPTION
## Summary

Cherry-pick of @rfoust's panadapter persistence and macOS GPU lifecycle work from PR #2780, applied cleanly onto current main with the stale-snapshot reverts left out.

## Why a cherry-pick rather than merge of #2780

PR #2780 was based on commit \`a0512d99\` (PR #2772 merge), and its single Codex-generated commit included **stale-snapshot content for files outside the intended scope**.  Squash-merging #2780 as-is would have silently reverted two recently-landed PRs:

- **PR #2770** (\`aether.ax25\` Q_LOGGING_CATEGORY consolidation) — \`AetherAx25LibmodemShim.cpp\`, \`Ax25HfPacketDecodeDialog.cpp\`, plus the test-target linkage in \`CMakeLists.txt\`
- **PR #2772** (RadioSetupDialog → PersistentDialog migration) — \`RadioSetupDialog.{cpp,h}\`

Verified by three-way merge dry run: post-merge state showed \`class RadioSetupDialog : public QDialog\` (pre-#2772) and 5 occurrences of \`lcAetherAx25Shim\` (pre-#2770).

The actual panadapter work in PR #2780 is real and valuable, so this PR extracts it onto a fresh branch from current main and skips the unintentional reverts.

## What's in this PR (= the intended scope of #2780)

Cherry-picked verbatim from #2780:

| File | Change |
|---|---|
| \`src/gui/MainWindow.{cpp,h}\` | Persist/restore PanadapterLayout + FloatingPanIds; expand layout count handling from 4 to 8 pans; preserve unseen floating IDs across reconnect |
| \`src/gui/PanadapterStack.{cpp,h}\` | Sensible-fallback docked-splitter layouts when some pans are floating or saved layout count mismatches |
| \`src/gui/SpectrumWidget.{cpp,h}\` | macOS QRhiWidget lifecycle: \`WindowAboutToChangeInternal\` before reparent; QRhi resource release during shutdown while parent backing stores are valid; guarded late callbacks; auto FFT floor relock after geometry/ypixels changes |
| \`src/core/PanadapterStream.cpp\` | Defensive dBm-range clamping (-180 floor, ≥10 dB span); FFT decode clamps pixel input and dbm output to range |
| \`src/models/RadioModel.cpp\` | Use actual FFT pane height for radio \`ypixels\` rather than total widget height |

Net: **+548 / -215** across 8 files.

## What was NOT cherry-picked (stale-snapshot reverts)

| File | Reason |
|---|---|
| \`CMakeLists.txt\` | -7 lines reverting #2770's test-target linkage I added to fix the link error |
| \`src/core/tnc/AetherAx25LibmodemShim.cpp\` | Robbie's content has local \`Q_LOGGING_CATEGORY(lcAetherAx25Shim, ...)\` — pre-#2770. Main has the consolidated \`lcAx25\` from LogManager |
| \`src/gui/Ax25HfPacketDecodeDialog.cpp\` | Same pattern — \`lcAetherAx25Dialog\` local, pre-#2770 |
| \`src/gui/RadioSetupDialog.{cpp,h}\` | Robbie's diff was **100% pure revert** of #2772 — no new content, no panadapter-related additions.  Confirmed by inspecting the full \`git diff a0512d99..e72d7e48 -- RadioSetupDialog.cpp\` output |

## Attribution

Commit author is set to **Robbie Foust** so his contribution shows in \`git log\` and the contributor stats.  PR #2780 is being reset to **Draft** (not closed) so Robbie has a clean reference point + can update with fresh work if he wants.

## Test plan

- [x] Local build clean (402/402 link, only pre-existing warnings)
- [x] Three-way merge dry-run against current main: clean
- [ ] Manual on Linux: multi-pan layout, detached panadapter, restart, confirm layout + detached state restore
- [ ] Manual on macOS GPU build: two detached panadapter windows, Cmd-Q, restart, confirm both restore without the QRhi cleanup callback crash
- [ ] Manual: detach/redock panadapter and confirm auto FFT floor relocks

## Cross-references

- Replaces #2780 (will be set to Draft after this PR opens)
- Same stale-snapshot pattern as aetherclaude #34 (Claude Code), but from OpenAI Codex this time — worth a heads-up to whoever's watching agent-output quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)