### PR TITLE
fix(tx): move two-tone selector to TUNE-button right-click + drop persistence

### DIFF
--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1015,7 +1015,16 @@ QWidget* RadioSetupDialog::buildTxTab()
         vbox->addWidget(group);
     }
 
-    // Max Power / Tune Mode / Show TX in Waterfall
+    // Max Power / Show TX in Waterfall / Slice-TX Follow
+    //
+    // Tune Mode (single_tone / two_tone) used to live here too but was
+    // removed — it persisted "Two Tone" across restarts as if it were a
+    // normal operating mode, which surprised users who hit the regular
+    // Tune button later and got an unexpected 2-tone test.  Tune Mode is
+    // now a transient one-shot, surfaced via the TUNE button's right-
+    // click menu in TxApplet ("Mono Tone" / "Two Tone").  Picking either
+    // sets the radio's tune_mode for the next tune cycle only; nothing
+    // is written to AppSettings.
     {
         auto* grid = new QGridLayout;
         grid->setSpacing(6);
@@ -1041,28 +1050,9 @@ QWidget* RadioSetupDialog::buildTxTab()
                 QString("transmit set max_power_level=%1").arg(val));
         });
 
-        auto* tmLbl = new QLabel("Tune Mode:");
-        tmLbl->setStyleSheet(kLabelStyle);
-        grid->addWidget(tmLbl, 1, 0);
-        auto* tmCmb = new QComboBox;
-        tmCmb->addItems({"Single Tone", "Two Tone"});
-        // Seed from the persisted preference (#2696) — the radio drops
-        // tune_mode across power cycles, so the saved value is the user's
-        // intent and matches what the connect-time resend asks the radio
-        // for. Falls back to single_tone if AppSettings is empty.
-        const QString seedMode = TransmitModel::savedTuneMode();
-        tmCmb->setCurrentText(seedMode == "single_tone" ? "Single Tone" : "Two Tone");
-        AetherSDR::applyComboStyle(tmCmb);
-        connect(tmCmb, &QComboBox::currentTextChanged, this, [this](const QString& text) {
-            QString mode = (text == "Single Tone") ? "single_tone" : "two_tone";
-            TransmitModel::saveTuneMode(mode);
-            m_model->sendCommand("transmit set tune_mode=" + mode);
-        });
-        grid->addWidget(tmCmb, 1, 1);
-
         auto* swLbl = new QLabel("Show TX in Waterfall:");
         swLbl->setStyleSheet(kLabelStyle);
-        grid->addWidget(swLbl, 2, 0);
+        grid->addWidget(swLbl, 1, 0);
         auto* swBtn = new QPushButton(tx.showTxInWaterfall() ? "Enabled" : "Disabled");
         swBtn->setCheckable(true);
         swBtn->setChecked(tx.showTxInWaterfall());
@@ -1077,12 +1067,12 @@ QWidget* RadioSetupDialog::buildTxTab()
             m_model->sendCommand(
                 QString("transmit set show_tx_in_waterfall=%1").arg(on ? 1 : 0));
         });
-        grid->addWidget(swBtn, 2, 1);
+        grid->addWidget(swBtn, 1, 1);
 
         // Slice–TX Follow Mode (#441, #1351) — mutually exclusive toggles
         auto* followLbl = new QLabel("Slice/TX Follow:");
         followLbl->setStyleSheet(kLabelStyle);
-        grid->addWidget(followLbl, 3, 0);
+        grid->addWidget(followLbl, 2, 0);
 
         const QString kFollowBtnStyle =
             "QPushButton { background: #1a2a3a; border: 1px solid #304050; "
@@ -1110,7 +1100,7 @@ QWidget* RadioSetupDialog::buildTxTab()
         followRow->addWidget(tfBtn);
         followRow->addWidget(afBtn);
         followRow->addStretch(1);
-        grid->addLayout(followRow, 3, 1);
+        grid->addLayout(followRow, 2, 1);
 
         // Mutual exclusion: enabling one disables the other
         connect(tfBtn, &QPushButton::toggled, this, [tfBtn, afBtn](bool on) {

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -209,6 +209,11 @@ void TxApplet::buildUI()
         m_tuneBtn->setFixedHeight(22);
         m_tuneBtn->setAccessibleName("Tune");
         m_tuneBtn->setAccessibleDescription("Start or stop tune carrier");
+        // Right-click picks the carrier shape (Mono Tone / Two Tone) for
+        // the next tune cycle.  Transient one-shot — no AppSettings write.
+        m_tuneBtn->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(m_tuneBtn, &QPushButton::customContextMenuRequested,
+                this, &TxApplet::showTuneContextMenu);
         row->addWidget(m_tuneBtn);
 
         m_moxBtn = new QPushButton("MOX");
@@ -595,6 +600,41 @@ void TxApplet::showAtuContextMenu(const QPoint& pos)
             this, &TxApplet::confirmAndClearAtuMemories);
 
     menu.exec(m_atuBtn->mapToGlobal(pos));
+}
+
+void TxApplet::showTuneContextMenu(const QPoint& pos)
+{
+    if (!m_model) return;
+
+    QMenu menu(m_tuneBtn);
+
+    // Reflect the radio's current tune_mode in the check marks so the user
+    // can see what the next Tune press will do.  Selecting either entry is
+    // a one-shot — the radio's tune_mode lives in volatile state and reverts
+    // to single_tone on its own across power cycles; AetherSDR does not
+    // persist the choice in AppSettings.
+    const QString current = m_model->tuneMode();
+
+    auto* mono = menu.addAction("Mono Tone");
+    mono->setCheckable(true);
+    mono->setChecked(current != QStringLiteral("two_tone"));
+    mono->setToolTip("Next Tune press transmits a single carrier (normal Tune).");
+    connect(mono, &QAction::triggered, this, [this]() {
+        if (m_model)
+            m_model->setTuneMode(QStringLiteral("single_tone"));
+    });
+
+    auto* two = menu.addAction("Two Tone");
+    two->setCheckable(true);
+    two->setChecked(current == QStringLiteral("two_tone"));
+    two->setToolTip("Next Tune press transmits a two-tone test signal\n"
+                    "(for IMD / linearity measurement).");
+    connect(two, &QAction::triggered, this, [this]() {
+        if (m_model)
+            m_model->setTuneMode(QStringLiteral("two_tone"));
+    });
+
+    menu.exec(m_tuneBtn->mapToGlobal(pos));
 }
 
 void TxApplet::openPreTuneDialog()

--- a/src/gui/TxApplet.h
+++ b/src/gui/TxApplet.h
@@ -62,6 +62,11 @@ private:
     void showAtuContextMenu(const QPoint& pos);
     void openPreTuneDialog();
     void confirmAndClearAtuMemories();
+    // Right-click menu on the TUNE button — picks the carrier shape for
+    // the *next* tune cycle: "Mono Tone" (single_tone) or "Two Tone".
+    // Nothing is persisted — selecting Two Tone is a transient one-shot
+    // and the radio reverts to single_tone on its own across power cycles.
+    void showTuneContextMenu(const QPoint& pos);
 
     TransmitModel* m_model{nullptr};
     RadioModel*       m_radioModel{nullptr};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1842,10 +1842,6 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
     sendCmd("sub slice all", [this](int, const QString&) {
       sendCmd("sub pan all", [this](int, const QString&) {
       sendCmd("sub tx all", [this](int, const QString&) {
-        // Re-apply persisted Tune Mode preference (#2696). The radio resets
-        // tune_mode to "single_tone" on every power-cycle and only AetherSDR
-        // remembers the user's choice; mirrors the met_in_rx resend below.
-        sendCmd("transmit set tune_mode=" + TransmitModel::savedTuneMode());
         sendCmd("sub atu all", [this](int, const QString&) {
         sendCmd("sub amplifier all", [this](int, const QString&) {
           sendCmd("sub meter all", [this](int, const QString&) {

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -1,10 +1,7 @@
 #include "TransmitModel.h"
-#include "core/AppSettings.h"
 #include "core/ClientQuindarTone.h"
 #include "core/LogManager.h"
 #include <QDebug>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QTimer>
 
 namespace AetherSDR {
@@ -391,30 +388,6 @@ void TransmitModel::setTuneMode(const QString& mode)
     emit commandReady("transmit set tune_mode=" + mode);
 }
 
-// Tune-mode persistence (#2696). Stored as a JSON blob under the
-// "RadioTxSetup" AppSettings key so future TX-tab settings can share the
-// same root (Principle V: nested JSON per feature, not flat keys).
-QString TransmitModel::savedTuneMode()
-{
-    const QString blob =
-        AppSettings::instance().value("RadioTxSetup", "{}").toString();
-    const QJsonObject obj = QJsonDocument::fromJson(blob.toUtf8()).object();
-    const QString mode = obj.value("tuneMode").toString();
-    return (mode == "two_tone") ? mode : QStringLiteral("single_tone");
-}
-
-void TransmitModel::saveTuneMode(const QString& mode)
-{
-    if (mode != "single_tone" && mode != "two_tone")
-        return;
-    const QString blob =
-        AppSettings::instance().value("RadioTxSetup", "{}").toString();
-    QJsonObject obj = QJsonDocument::fromJson(blob.toUtf8()).object();
-    obj["tuneMode"] = mode;
-    AppSettings::instance().setValue("RadioTxSetup",
-        QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
-}
-
 void TransmitModel::startTune(PttSource source)
 {
     if (!runPttPreflight(source, false))
@@ -436,11 +409,12 @@ void TransmitModel::toggleTwoToneTune()
 {
     if (isTuning()) {
         stopTune();
-        // Restore the user's saved preference so the next regular Tune press
-        // isn't surprised by sticky two-tone state on the radio, *and* so a
-        // user whose persistent choice is Two Tone isn't silently reverted
-        // by the shortcut (#2696).
-        setTuneMode(savedTuneMode());
+        // Revert to single_tone after a two-tone shortcut session so the
+        // next regular Tune press isn't surprised by sticky two-tone state
+        // on the radio.  Tune mode is no longer persisted; selecting "Two
+        // Tone" is now a transient one-shot via the TUNE button's right-
+        // click menu in TxApplet.
+        setTuneMode(QStringLiteral("single_tone"));
     } else {
         startTwoToneTune();
     }

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -160,14 +160,6 @@ public:
     void setRfPower(int power);
     void setTunePower(int power);
     void setTuneMode(const QString& mode);
-
-    // Tune-mode preference is persisted client-side (#2696). The radio drops
-    // tune_mode to "single_tone" across power cycles, so the user's choice is
-    // cached in AppSettings under the "RadioTxSetup" nested-JSON blob and
-    // re-applied on every connect (mirrors the met_in_rx resend pattern).
-    // Returns "single_tone" or "two_tone".
-    static QString savedTuneMode();
-    static void saveTuneMode(const QString& mode);
     void startTune(PttSource source = PttSource::Tune);
     void startTwoToneTune(PttSource source = PttSource::Tune);
     void toggleTwoToneTune();


### PR DESCRIPTION
## Summary

Two-Tone Tune is a transient TEST mode, but AetherSDR was treating it as a persistent operating preference.  The Tune Mode combo in **Radio Setup → TX** wrote \`two_tone\` into AppSettings, and the connect-time resend (#2696) re-applied it on every reconnect.  A user who ran *one* two-tone test ever could later press the regular Tune button — for ATU calibration, dummy-load check, signal-report tune — and get an unexpected two-tone signal instead of a single carrier.

This rewires the selector to match the actual on-radio behavior: a one-shot mode pick for the *next* tune cycle, surfaced where the TUNE button lives.

## Changes

### Persistence removed

- Drop \`TransmitModel::savedTuneMode()\` / \`saveTuneMode()\` and their AppSettings I/O.  The \`RadioTxSetup\` namespace is left in place for future TX-tab settings; harmless leftover \`tuneMode\` keys in users' configs will be ignored.
- Drop the connect-time \`transmit set tune_mode=<saved>\` resend in \`RadioModel::registerAsGuiClient\`.  The radio's own \`single_tone\` default after power-cycle is correct.
- \`TransmitModel::toggleTwoToneTune()\` (the #1995 keyboard-shortcut path) now reverts to literal \`single_tone\` on stop instead of reading saved-mode.

### UI moved to a context menu

- Remove the **Tune Mode** combo from Radio Setup → TX.  Renumber the remaining grid rows (Max Power=0, Show TX in Waterfall=1, Slice/TX Follow=2).
- Add a right-click context menu on the **TUNE** button in \`TxApplet\` with two checkable entries:
  - **Mono Tone** — \`transmit set tune_mode=single_tone\` (default; reflects radio state)
  - **Two Tone** — \`transmit set tune_mode=two_tone\` (transient, for IMD/linearity tests)
- Each entry is checkable and reflects the model's current \`tuneMode()\` so users can see what the next Tune press will do.  Selecting an entry sends to the radio; no AppSettings write.

Wiring + style mirrors the existing ATU button right-click pattern (#2624).

## ATU and TGXL autotune are intentionally NOT changed

\`atu start\` (FlexLib \`Radio.cs:11041-11044\`) is a separate protocol command that doesn't honor \`tune_mode\`.  Two-tone + ATU isn't a thing on Flex hardware — the autotuner's L/C sweep needs a steady single-tone carrier for impedance measurement, and SmartSDR doesn't expose a two-tone-with-ATU mode either.  Same reasoning for \`tgxl autotune\`.

## Test plan

- [x] Local build clean (46/46 incremental link after rebase onto current main)
- [x] Right-click TUNE → menu shows \"Mono Tone\" (checked by default) + \"Two Tone\"
- [x] Pick \"Two Tone\" → next TUNE press transmits 2-tone test
- [x] Pick \"Mono Tone\" → next TUNE press transmits single carrier
- [x] Restart AetherSDR → mode reverts to single (no AppSettings persistence)
- [x] Radio Setup → TX no longer shows a Tune Mode combo; remaining controls (Max Power, Show TX in Waterfall, Slice/TX Follow) reflow correctly
- [x] Keyboard shortcut \"Two-Tone Tune\" (\`#1995\`) still works — single press starts 2-tone tune, second press stops + reverts to single

## Files

| File | Change |
|---|---|
| \`src/gui/RadioSetupDialog.cpp\` | Drop Tune Mode combo + renumber grid rows |
| \`src/gui/TxApplet.{cpp,h}\` | New \`showTuneContextMenu()\` slot, customContextMenuRequested wiring on \`m_tuneBtn\` |
| \`src/models/TransmitModel.{cpp,h}\` | Drop \`savedTuneMode\` / \`saveTuneMode\` + JSON/AppSettings includes |
| \`src/models/RadioModel.cpp\` | Drop the connect-time resend |

Net: **65 insertions / 68 deletions** across 6 files — slightly fewer lines than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)