### PR TITLE
fix(ax25): render em-dash correctly in AetherModem Experimental banner

### DIFF
--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -488,8 +488,13 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(10);
 
+    // Em-dash is — (U+2014).  Don't use the byte-escape \xE2\x80\x94 form
+    // here — inside QStringLiteral the literal expands to a UTF-16 (u"...")
+    // string where each \xXX is a single char16_t code unit, not a byte of a
+    // multi-byte UTF-8 sequence.  Three separate code units (0x00E2, 0x0080,
+    // 0x0094) render as "â" + two control glyphs, which is what shipped.
     auto* experimentalBanner = new QLabel(
-        QStringLiteral("<b>Experimental \xE2\x80\x94 Phase 0 receive-only.</b> "
+        QStringLiteral("<b>Experimental — Phase 0 receive-only.</b> "
                        "300 baud HF only. HDLC timing is first-pass and "
                        "may produce noisy rejects on weak HF signals."),
         bodyWidget());


### PR DESCRIPTION
## Summary

The AetherModem Experimental banner shipped with garbled characters where an em-dash should be:

> **Experimental â<square><square> Phase 0 receive-only.**

instead of:

> **Experimental — Phase 0 receive-only.**

## Root cause

\`Ax25HfPacketDecodeDialog.cpp:492\` used UTF-8 **byte escapes** inside a \`QStringLiteral\`:

\`\`\`cpp
QStringLiteral(\"<b>Experimental \\xE2\\x80\\x94 Phase 0 receive-only.</b> \" ...)
\`\`\`

\`QStringLiteral\` expands to a UTF-16 (\`u\"...\"\`) string at compile time.  Inside a \`u\"...\"\` literal, **each \`\\xXX\` byte escape is interpreted as one \`char16_t\` code unit, not as one byte of a multi-byte UTF-8 sequence.**  So \`\\xE2\\x80\\x94\` produces three separate UTF-16 code units (0x00E2, 0x0080, 0x0094), which render as \`â\` + two control glyphs.

## Fix

Replace the byte escapes with the literal em-dash character — the file becomes UTF-8 (was pure ASCII) and \`QStringLiteral\` emits a single \`u\\u2014\` code unit.  Added an inline comment block explaining the trap so future contributors don't hit the same bug.

## Codebase audit

Grepped for other UTF-8 byte-escape patterns in QString contexts:

| Location | Pattern | Status |
|---|---|---|
| \`Ax25HfPacketDecodeDialog.cpp:492\` (em-dash) | \`QStringLiteral(\"...\\xE2\\x80\\x94...\")\` | **BROKEN** — fixed by this PR |
| \`KeyboardMapWidget.cpp:161,180-182\` (▲◀▼▶ arrows) | \`\"...\\xE2\\x96\\xB2...\"\` → \`QString label\` field | OK — implicit \`QString::fromUtf8\` |
| \`RxApplet.cpp:725,733,734,…\` (🔊 🔇 emoji) | \`QString::fromUtf8(\"\\xF0\\x9F\\x94...\")\` | OK — explicit \`fromUtf8\` |

The trap is specifically \`QStringLiteral\` because it routes through \`u\"\"\` / UTF-16, not \`const char*\` / UTF-8.

## Test plan

- [x] Local build clean
- [x] AetherModem dialog banner renders the em-dash glyph correctly
- [x] Confirmed by @ten9876

🤖 Generated with [Claude Code](https://claude.com/claude-code)