### PR TITLE
Extend panadapter startup layout restore window

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -211,7 +211,7 @@ constexpr int kMinPanXpixels = 100;
 constexpr int kMinPanYpixels = 20;
 constexpr int kMinRadioPanYpixels = 100;
 constexpr qint64 kPanLayoutRestoreWaitingForFirstPan = -1;
-constexpr int kPanLayoutRestoreWindowMs = 5000;
+constexpr int kPanLayoutRestoreWindowMs = 30000;
 constexpr qint64 kXvtrWaterfallDecisionLogIntervalMs = 20000;
 constexpr double kSwrSweepStepMhz = 0.020;
 constexpr double kSwrSweepEdgeGuardMhz = 0.005;
@@ -2607,7 +2607,7 @@ MainWindow::MainWindow(QWidget* parent)
                 // The radio restores pans from the GUIClientID session.
                 // Accept whatever the radio gives and arrange based on count.
                 const int panCount = m_panStack->count();
-                if (panCount > 1) {
+                if (!m_suppressStartupPanLayoutRearrange && panCount > 1) {
                     // Pick a layout based on the number of pans the radio restored
                     const QString saved = AppSettings::instance()
                         .value("PanadapterLayout", "1").toString();
@@ -5946,6 +5946,7 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
                 showPanadapterSliceCapacityMessage();
                 return true;
             }
+            m_suppressStartupPanLayoutRearrange = true;
             auto& s = AppSettings::instance();
             s.setValue("PanadapterLayout", layoutId);
             s.save();
@@ -8260,6 +8261,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
 
     m_connPanel->setConnected(connected);
     if (connected) {
+        m_suppressStartupPanLayoutRearrange = false;
         m_layoutRestoreUntilMs = kPanLayoutRestoreWaitingForFirstPan;
         m_radioInfoLabel->setText(m_radioModel.model());
         m_radioVersionLabel->setText(m_radioModel.version());
@@ -8528,6 +8530,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
         if (m_layoutRestoreTimer) {
             m_layoutRestoreTimer->stop();
         }
+        m_suppressStartupPanLayoutRearrange = false;
         m_layoutRestoreUntilMs = 0;
         if (m_appletPanel) {
             m_appletPanel->clearSliceButtons();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -640,6 +640,9 @@ private:
     QHash<QString, QMetaObject::Connection> m_wfLineDurationReconcileConnections;
     QTimer* m_layoutRestoreTimer{nullptr}; // debounced layout rearrange after pans added on connect
     qint64 m_layoutRestoreUntilMs{0};
+    // User layout choices should suppress startup rearrange, but still allow
+    // the pending timer to restore saved floating pan windows.
+    bool m_suppressStartupPanLayoutRearrange{false};
     QTimer* m_heartbeatMissTimer{nullptr}; // fires every 1.5s to detect missed discovery beats
     QTimer* m_bsExpiryTimer{nullptr};    // band-stack bookmark auto-expiry, started on connect only (#1471)
     QTimer* m_bsAutoSaveTimer{nullptr};  // band-stack dwell auto-save (single-shot per dwell window)


### PR DESCRIPTION
## Summary

Extend the startup panadapter layout restore window from 5 seconds to 30 seconds, and cancel pending startup restore when the user explicitly changes the panadapter layout.

## Why

Panadapter layout restore is debounced while restored panadapter status arrives from the radio during startup/reconnect. The previous 5-second window could expire before all restored panadapter data arrived, causing docked panadapters to remain in the default arrangement instead of the saved `PanadapterLayout`.

Because 30 seconds is a wider startup window, user-initiated layout changes now stop the pending startup restore so the automatic restore cannot override an explicit user choice.

## Changes

- Increase `kPanLayoutRestoreWindowMs` from `5000` ms to `30000` ms.
- Stop `m_layoutRestoreTimer` and clear `m_layoutRestoreUntilMs` before applying a user-selected panadapter layout.
- No persistence format changes.
- No radio-side panadapter state changes.

## Test Plan

- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build --parallel`
- Manual follow-up: start with a saved docked multi-pan layout and confirm the layout restores after slow radio panadapter status arrival.
- Manual follow-up: during startup, change panadapter layout and confirm the user-selected layout is not overwritten by delayed startup restore.
