### PR TITLE
fix(libmodem_core): qualify member access with this-> for gcc 11 two-phase lookup

### DIFF
--- a/third_party/libmodem_core/bitstream.h
+++ b/third_party/libmodem_core/bitstream.h
@@ -189,9 +189,9 @@ public:
 
     template<class V>
         requires std::constructible_from<typename Container::value_type, V>
-    constexpr traits_back_insert_iterator& operator=(V&& v) noexcept(noexcept(Traits::push_back(*container, typename Container::value_type(std::forward<V>(v)))))
+    constexpr traits_back_insert_iterator& operator=(V&& v) noexcept(noexcept(Traits::push_back(*this->container, typename Container::value_type(std::forward<V>(v)))))
     {
-        Traits::push_back(*container, typename Container::value_type(std::forward<V>(v)));
+        Traits::push_back(*this->container, typename Container::value_type(std::forward<V>(v)));
         return *this;
     }
 


### PR DESCRIPTION
The AppImage CI build (ubuntu-22.04 native runner, stock gcc 11.4)
failed on third_party/libmodem_core/bitstream.h:192 with:

  error: 'container' was not declared in this scope; did you mean 'Container'?

inside the noexcept(noexcept(...)) clause of traits_back_insert_iterator::operator=.
Stricter compilers require explicit this->container qualification for
template class member access in the function signature; the existing
unqualified form passed on newer gcc (our Docker CI image) but not gcc 11.

Adds this-> on both call sites (the noexcept clause and the function
body, for consistency). Pure portability fix — zero user-visible change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
