### PR TITLE
fix(win): prevent process lingering in Task Manager after close

### DIFF
--- a/src/core/MqttClient.cpp
+++ b/src/core/MqttClient.cpp
@@ -42,6 +42,7 @@ MqttClient::~MqttClient()
     disconnect();
 #ifdef HAVE_MQTT
     if (m_mosq) {
+        mosquitto_loop_stop(m_mosq, true);  // force-stop thread before destroy
         mosquitto_destroy(m_mosq);
         m_mosq = nullptr;
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -11916,6 +11916,8 @@ void MainWindow::toggleAetherialStrip()
         // Override the parent-window relationship so the strip behaves as
         // an independent window (own taskbar entry, raisable separately).
         m_aetherialStrip->setWindowFlag(Qt::Window, true);
+        // Secondary window — must not gate quitOnLastWindowClosed on Windows.
+        m_aetherialStrip->setAttribute(Qt::WA_QuitOnClose, false);
         // Seed the embedded EQ with the current TX filter cutoff values
         // so the dashed yellow guide lines render immediately rather than
         // waiting for the next txFilterCutoffChanged signal.
@@ -14853,6 +14855,7 @@ void MainWindow::floatAppletPanel()
     m_appletPanelFloatWindow = new QWidget(nullptr, flags);
     m_appletPanelFloatWindow->setWindowTitle("AetherSDR — Applet Panel");
     m_appletPanelFloatWindow->setAttribute(Qt::WA_DeleteOnClose, false);
+    m_appletPanelFloatWindow->setAttribute(Qt::WA_QuitOnClose, false);
     m_appletPanelFloatWindow->setAttribute(Qt::WA_StyledBackground, true);
     m_appletPanelFloatWindow->setStyleSheet(darkThemeStylesheet());
     auto* layout = new QVBoxLayout(m_appletPanelFloatWindow);


### PR DESCRIPTION
On Windows 11, the AetherSDR process could remain visible in Task Manager indefinitely after the main window was closed. Three independent root causes were identified.

──────────────────────────────────────────────────────────────────────────── Root cause 1 — AetherialAudioStrip blocks quitOnLastWindowClosed ──────────────────────────────────────────────────────────────────────────── `m_aetherialStrip` is created with `parent=MainWindow` but then given the `Qt::Window` flag so it appears as an independent taskbar entry. Qt 6 treats any widget carrying `Qt::Window` as a top-level window for the purpose of `QApplication::quitOnLastWindowClosed`. The attribute `WA_QuitOnClose` defaults to `true` on every widget.

Consequence: if the strip is visible when the user closes the main window, `QApplication` sees a second visible top-level window with `WA_QuitOnClose` set and refuses to emit `lastWindowClosed`. `app.exec()` never returns, `~MainWindow()` never runs, and the process hangs forever.

Fix: set `WA_QuitOnClose = false` on `m_aetherialStrip` immediately after the `Qt::Window` flag is applied. The strip is a secondary, inspector-style window and must not control application lifetime.

──────────────────────────────────────────────────────────────────────────── Root cause 2 — floated applet-panel window lacks WA_QuitOnClose = false ──────────────────────────────────────────────────────────────────────────── `m_appletPanelFloatWindow` is created with `parent = nullptr` (a genuine top-level window). `WA_QuitOnClose` was never set to `false` on it, so if a close-event ordering quirk (e.g. the float window's native WM_DESTROY arrives before MainWindow's hide completes) caused it to be the apparent "last window", Qt could fail to call `quit()`. `FloatingContainerWindow` already sets this attribute; the applet-panel float window was the only top-level secondary window that did not.

Fix: add `setAttribute(Qt::WA_QuitOnClose, false)` alongside the existing `WA_DeleteOnClose = false` in `floatAppletPanel()`. This matches the pattern used by all other secondary/floating windows in the codebase.

──────────────────────────────────────────────────────────────────────────── Root cause 3 — MqttClient destroys mosquitto while loop thread still runs ──────────────────────────────────────────────────────────────────────────── `MqttClient::disconnect()` contains a `#ifndef Q_OS_WIN` guard that skips `mosquitto_loop_stop()` on Windows. The guard was presumably added to avoid a deadlock in the `force=false` (graceful) stop path, where the loop thread tries to deliver a callback to the Qt main thread while the main thread is already blocked waiting for the stop to complete.

The destructor calls `disconnect()` (which on Windows leaves the background network thread running) and then immediately calls `mosquitto_destroy()`. The libmosquitto documentation explicitly states that `mosquitto_loop_stop()` must be called before `mosquitto_destroy()`. Violating this contract on Windows can leave the thread in an undefined state — holding a WINSOCK handle or a Windows timer — that prevents `ExitProcess()` from completing cleanly (or at all).

Fix: add `mosquitto_loop_stop(m_mosq, true)` (force=true, safe on any thread) between the `disconnect()` call and `mosquitto_destroy()` in the destructor. The `force=true` variant does not attempt a graceful handshake with the loop thread and therefore cannot deadlock; it is the same path used by `connectToBroker()` when reinitialising the client. The `#ifndef Q_OS_WIN` guard in `disconnect()` is left in place — that code path handles user-initiated disconnect during a session and has different threading constraints.

──────────────────────────────────────────────────────────────────────────── Files changed
──────────────────────────────────────────────────────────────────────────── src/core/MqttClient.cpp
  — ~MqttClient(): add mosquitto_loop_stop(m_mosq, true) before destroy

src/gui/MainWindow.cpp
  — toggleAetherialStrip(): set WA_QuitOnClose=false on m_aetherialStrip
  — floatAppletPanel(): set WA_QuitOnClose=false on m_appletPanelFloatWindow

──────────────────────────────────────────────────────────────────────────── Testing notes
──────────────────────────────────────────────────────────────────────────── To reproduce the original bug:
  1. Open AetherSDR on Windows 11.
  2. Open the Aetherial Audio Strip (egg-nub button) — ensures root cause 1. OR pop out the applet panel (View → Pop Out Applet Panel) — root cause 2. OR connect to an MQTT broker in the MQTT applet — root cause 3.
  3. Close the main window.
  4. Observe Task Manager: process should exit within ~1 second.

Before this fix: process remains in Task Manager indefinitely.
After this fix: process exits promptly on close.