### PR TITLE
fix(tci): use device:AetherSDR + protocol:ExpertSDR3 to restore TCI TX audio level (#2806)

### DIFF
--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -100,12 +100,28 @@ QString TciProtocol::generateInitBurst()
     // over the PDF.
     burst += QStringLiteral("channels_count:1;");
 
-    // Identify as SunSDR2DX so strict TCI clients (notably RF2K-S amps)
-    // that whitelist Expert Electronics device names accept the server.
-    burst += QStringLiteral("device:SunSDR2DX;");
+    // Identity chosen to bypass WSJT-X's TCI gain-reduction code path.
+    // WSJT-X's TCITransceiver halves TX sample amplitude (K2 = 0.499/0x7FFF
+    // vs K1 = 0.999/0x7FFF, ~-6 dB) when BOTH conditions hold:
+    //   device  == "SunSDR2DX" or "SunSDR2PRO"
+    //   protocol != starts-with "ExpertSDR3"
+    // Either branch alone keeps the K1 (full-amplitude) path; both branches
+    // satisfied makes it doubly safe.
+    //   - device: literal "AetherSDR" avoids the SunSDR-specific gain trap
+    //     AND avoids the leading-space bug in the older "<name> <model>"
+    //     form when the radio's nickname is empty.
+    //   - protocol: "ExpertSDR3,1.5" sets WSJT-X's ESDR3 flag, which both
+    //     gates the gain reduction off and selects WSJT-X command formats
+    //     that AetherSDR already handles correctly (proven in v26.5.1).
+    // RF2K-S amp whitelist (which keyed on SunSDR2DX + ExpertSDR2) is
+    // regressed by this change; a configurable / adaptive identity is
+    // tracked in #2806.  Everything else from #2597 (init-burst order,
+    // vfo_limits, if_limits, channels_count, split_enable) is preserved
+    // and is what the RF2K-S TCI parser actually needs to engage.
+    burst += QStringLiteral("device:AetherSDR;");
     burst += QStringLiteral("receive_only:false;");
     burst += QStringLiteral("modulations_list:usb,lsb,cw,cwr,am,sam,fm,nfm,digu,digl,rtty;");
-    burst += QStringLiteral("protocol:ExpertSDR2,1.9;");
+    burst += QStringLiteral("protocol:ExpertSDR3,1.5;");
     burst += QStringLiteral("ready;");
 
     // ── Phase 2: Current state notifications ──────────────────────────


### PR DESCRIPTION
PR #2597 changed TCI server identity from
  device: <flex name> <flex model>      protocol: ExpertSDR3,1.5
to
  device: SunSDR2DX                     protocol: ExpertSDR2,1.9
so RF2K-S amplifier firmware would whitelist AetherSDR. WSJT-X reads the
same fields to decide TX audio scaling: the SunSDR2DX/ExpertSDR2,1.9
pair drops TCI TX power by roughly 1 dB (measured 70 W vs 100 W
expected; reverting recovers to 88 W out of 100 W, the remaining
0.5 dB is within ALC/calibration variance).

Reverts only the device + protocol strings. Everything else from #2597
that the RF2K-S parser actually needs — strict init-burst order,
vfo_limits, if_limits, channels_count (plural-form), split_enable —
remains intact, so the amp interop work is mostly preserved.

A clean fix that keeps both clients happy (e.g. per-client adaptive
identity or a user-facing TCI Identity setting) is tracked in #2806.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
