### PR TITLE
Fix RADE selecting DIGU on 40m from RxApplet mode combo

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -427,7 +427,6 @@ void RxApplet::buildUI()
 #ifdef HAVE_RADE
             if (mode == "RADE") {
                 emit radeActivated(true, m_slice ? m_slice->sliceId() : -1);
-                if (m_slice) m_slice->setMode(mode);
                 return;
             }
             // "RADE" is client-side only — the radio echoes back the real mode


### PR DESCRIPTION
## Summary

- `RxApplet`'s mode combo handler called `m_slice->setMode("RADE")` after emitting `radeActivated(true, ...)`, sending the unknown mode string "RADE" to the radio and immediately triggering `onRadeSliceModeChanged("RADE")` → `deactivateRADE()`.
- Depending on how radio firmware handles the unknown mode, the slice could land in DIGU instead of the DIGL correctly computed by `activateRADE()`'s kBands lookup, producing the user-reported symptom of RADE selecting DIGU on 40m.
- Fixes alignment with `VfoWidget`, which has always correctly returned after emitting `radeActivated` without calling `setMode`. RADE is client-side only; the actual DIGL/DIGU assignment happens inside `activateRADE()` before the watchdog connection is made.

## Root Cause

`RxApplet.cpp:430` (removed):
```cpp
if (m_slice) m_slice->setMode(mode);  // mode == "RADE" — sent to radio, triggers deactivation
```

The comment at line 433 already stated *"RADE is client-side only — the radio echoes back the real mode (DIGL/DIGU) immediately, so mode() == 'RADE' is never true in steady state"* — the removed line was directly contradicting that invariant.

## Test Plan

- [x] Select "RADE" from the RxApplet mode combo on 40m → verify radio mode = DIGL, RADE engine active
- [x] Select "RADE" from the RxApplet mode combo on 20m → verify radio mode = DIGU, RADE engine active
- [x] RADE watchdog still fires: force slice to USB while RADE active → verify clean deactivation
- [x] Selecting a non-RADE mode from RxApplet combo still deactivates RADE correctly
- [x] VfoWidget quick-mode button and FreeDV spot click paths unaffected (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)