### PR TITLE
feat(audio): RN2 (RNNoise) toggle on Aetherial Tube Pre-Amp TX (#2813)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -48,6 +48,8 @@
 #include <QDir>
 #include <QtEndian>
 #include <QThread>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <algorithm>
 #include <cstring>
 #include <optional>
@@ -567,6 +569,7 @@ AudioEngine::AudioEngine(QObject* parent)
     loadClientFinalLimiterSettings();  // restore persisted final-limiter params
     loadClientQuindarSettings();       // restore persisted Quindar tone params
     loadClientRxChainOrder();    // restore persisted RX chain order (Phase 0+)
+    loadAetherialTubePreampTxSettings(); // restore TX mic pre-amp toggles (#2813)
 
     // Restore saved audio device selections
     auto& s = AppSettings::instance();
@@ -3001,6 +3004,40 @@ void AudioEngine::saveClientFinalLimiterSettings() const
         m_clientFinalLimiterTx->dcBlockEnabled() ? QString("True") : QString("False"));
 }
 
+// Aetherial Tube Pre-Amp TX — nested-JSON persistence (Principle V).
+// One AppSettings key holds a JSON object so future mic-preamp toggles
+// (high-pass, phase invert, polarity, etc.) can be added without further
+// migration.  Shape today: {"rn2": bool}.  (#2813)
+
+void AudioEngine::loadAetherialTubePreampTxSettings()
+{
+    auto& s = AppSettings::instance();
+    const QString raw = s.value("AetherialTubePreampTx", "{}").toString();
+    QJsonParseError err;
+    const auto doc = QJsonDocument::fromJson(raw.toUtf8(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        // Bad JSON — treat as empty, all defaults off.
+        return;
+    }
+    const auto obj = doc.object();
+    if (obj.value("rn2").toBool(false)) {
+        // Route through the setter so the lazy-allocation + signal
+        // emission both happen exactly as on a user toggle.
+        setRn2TxEnabled(true);
+    }
+}
+
+void AudioEngine::saveAetherialTubePreampTxSettings() const
+{
+    QJsonObject obj;
+    obj["rn2"] = m_rn2TxEnabled.load();
+    const QString raw = QString::fromUtf8(
+        QJsonDocument(obj).toJson(QJsonDocument::Compact));
+    auto& s = AppSettings::instance();
+    s.setValue("AetherialTubePreampTx", raw);
+    s.save();
+}
+
 void AudioEngine::loadClientQuindarSettings()
 {
     if (!m_clientQuindarTone) return;
@@ -3267,6 +3304,34 @@ void AudioEngine::setRn2Enabled(bool on)
     }
     qCDebug(lcAudio) << "AudioEngine: RN2 (RNNoise)" << (on ? "enabled" : "disabled");
     emit rn2EnabledChanged(on);
+}
+
+// ─── RN2 — TX path (mic pre-amp) ──────────────────────────────────────────────
+// Mirrors the RX RN2 setter above (lazy-alloc under m_dspMutex, atomic guard
+// for the audio-thread read).  No mutual-exclusion with other TX-side NR
+// because there is none — RN2 is the only neural denoiser on the mic path
+// today.  Persistence is via the AetherialTubePreampTx nested-JSON key.
+
+void AudioEngine::setRn2TxEnabled(bool on)
+{
+    if (m_rn2TxEnabled.load() == on) return;
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    if (on) {
+        m_rn2Tx = std::make_unique<RNNoiseFilter>();
+        if (!m_rn2Tx->isValid()) {
+            qCWarning(lcAudio) << "AudioEngine: RN2 TX rnnoise_create() failed — disabling";
+            m_rn2Tx.reset();
+            emit rn2TxEnabledChanged(false);
+            return;
+        }
+        m_rn2TxEnabled.store(true);
+    } else {
+        m_rn2TxEnabled.store(false);
+        m_rn2Tx.reset();
+    }
+    saveAetherialTubePreampTxSettings();
+    qCDebug(lcAudio) << "AudioEngine: RN2 TX (RNNoise mic pre-amp)" << (on ? "enabled" : "disabled");
+    emit rn2TxEnabledChanged(on);
 }
 
 // ─── BNR (NVIDIA NIM GPU noise removal) ──────────────────────────────────────
@@ -3983,6 +4048,39 @@ void AudioEngine::onTxAudioReady()
     // DAX TX mode: VirtualAudioBridge handles TX audio via feedDaxTxAudio().
     // Don't send mic audio — it would conflict with the DAX stream.
     if (m_daxTxMode) return;
+
+    // ── RN2 mic pre-amp (TX neural denoiser) ─────────────────────
+    // Runs strictly on the voice path — both digital-mode early-returns
+    // above (m_radeMode, m_daxTxMode) skip this hook so RN2 is guaranteed
+    // never to touch RADE / DAX / TCI / RTTY / FT8 / FDV audio.  Placed
+    // BEFORE the test tone + user DSP chain so any downstream gate /
+    // comp / EQ / saturator processes denoised audio rather than
+    // amplifying the noise floor.
+    //
+    // RNNoiseFilter::process() takes / returns 24 kHz duplicated-stereo
+    // FLOAT32 (despite its header comment claiming int16).  At this
+    // point in the flow `data` is 24 kHz duplicated-stereo int16, so we
+    // convert in → process → convert out.  Conversion is in-place over
+    // pre-sized scratch buffers — no per-block heap traffic after the
+    // first call.  (#2813)
+    if (m_rn2TxEnabled.load() && m_rn2Tx && m_rn2Tx->isValid()) {
+        const auto* i16 = reinterpret_cast<const int16_t*>(data.constData());
+        const int samples = data.size() / static_cast<int>(sizeof(int16_t));
+        m_rn2TxF32In.resize(samples * static_cast<int>(sizeof(float)));
+        auto* fin = reinterpret_cast<float*>(m_rn2TxF32In.data());
+        for (int i = 0; i < samples; ++i) fin[i] = i16[i] / 32768.0f;
+
+        m_rn2TxF32In = m_rn2Tx->process(m_rn2TxF32In);
+
+        const int outSamples = m_rn2TxF32In.size() / static_cast<int>(sizeof(float));
+        const auto* fout = reinterpret_cast<const float*>(m_rn2TxF32In.constData());
+        data.resize(outSamples * static_cast<int>(sizeof(int16_t)));
+        auto* i16Out = reinterpret_cast<int16_t*>(data.data());
+        for (int i = 0; i < outSamples; ++i) {
+            const float clamped = std::clamp(fout[i] * 32768.0f, -32768.0f, 32767.0f);
+            i16Out[i] = static_cast<int16_t>(clamped);
+        }
+    }
 
     // ── Client-side TX DSP: compressor + parametric EQ ──────────────────
     // Runs after mic capture and resample, before PC mic gain / metering /

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -165,6 +165,13 @@ public:
     Q_INVOKABLE void setRn2Enabled(bool on);
     bool rn2Enabled() const { return m_rn2Enabled.load(); }
 
+    // Client-side RN2 — TX path (mic pre-amp).  Runs on the voice path
+    // in onTxAudioReady() AFTER the RADE/DAX early-returns, so digital
+    // modes never see RN2.  Separate instance + atomic from m_rn2 so
+    // RX and TX can be toggled independently.  (#2813)
+    Q_INVOKABLE void setRn2TxEnabled(bool on);
+    bool rn2TxEnabled() const { return m_rn2TxEnabled.load(); }
+
     // Client-side NR4 (libspecbleach spectral noise reduction)
     Q_INVOKABLE void setNr4Enabled(bool on);
     bool nr4Enabled() const { return m_nr4Enabled.load(); }
@@ -387,6 +394,11 @@ public:
     void saveClientReverbSettings();
     void loadClientFinalLimiterSettings();
     void saveClientFinalLimiterSettings() const;
+    // Aetherial Tube Pre-Amp TX state — nested-JSON shape under one key
+    // so future mic-preamp toggles (high-pass, phase invert, etc.) can
+    // land without further migration.  Today: {"rn2": bool}.  (#2813)
+    void loadAetherialTubePreampTxSettings();
+    void saveAetherialTubePreampTxSettings() const;
     void loadClientQuindarSettings();
     void saveClientQuindarSettings() const;
 
@@ -466,6 +478,7 @@ signals:
     void nr4EnabledChanged(bool on);
     void mnrEnabledChanged(bool on);
     void rn2EnabledChanged(bool on);
+    void rn2TxEnabledChanged(bool on);   // RN2 on the TX mic pre-amp (#2813)
     void bnrEnabledChanged(bool on);
     void bnrConnectionChanged(bool connected);
     void dfnrEnabledChanged(bool on);
@@ -687,6 +700,15 @@ private:
     // Client-side RN2 (RNNoise)
     std::unique_ptr<RNNoiseFilter> m_rn2;
     std::atomic<bool> m_rn2Enabled{false};
+
+    // Client-side RN2 — TX path (mic pre-amp).  Lazy-allocated under
+    // m_dspMutex on toggle-on, freed on toggle-off.  Mirrors the RX
+    // RN2 ownership pattern above.  (#2813)
+    std::unique_ptr<RNNoiseFilter> m_rn2Tx;
+    std::atomic<bool> m_rn2TxEnabled{false};
+    // Scratch buffer for int16 ↔ float32 conversion around RN2 TX.
+    // Audio-thread only — grows once to steady state, then alloc-free.
+    QByteArray m_rn2TxF32In;
 
     // Client-side BNR (NVIDIA NIM)
     std::unique_ptr<NvidiaBnrFilter> m_bnr;

--- a/src/core/RNNoiseFilter.h
+++ b/src/core/RNNoiseFilter.h
@@ -10,8 +10,8 @@ namespace AetherSDR {
 class Resampler;
 
 // Client-side RNN noise suppression using Mozilla/Xiph RNNoise.
-// Processes 24kHz stereo Int16 audio by upsampling to 48kHz mono,
-// running RNNoise, and downsampling back to 24kHz stereo.
+// Processes 24kHz duplicated-stereo FLOAT32 audio by upsampling to
+// 48kHz mono, running RNNoise, and downsampling back to 24kHz stereo.
 //
 // RNNoise requires 48kHz mono float input in 480-sample (10ms) frames.
 
@@ -20,8 +20,10 @@ public:
     RNNoiseFilter();
     ~RNNoiseFilter();
 
-    // Process a block of 24kHz stereo Int16 PCM.
-    // Returns the processed block (same format, same size).
+    // Process a block of 24kHz duplicated-stereo FLOAT32 PCM (NOT int16
+    // — the original comment lied; callers must pass float32 sample
+    // pairs interleaved as L,R,L,R,... with each sample in [-1.0, 1.0]).
+    // Returns the processed block in the same format and frame count.
     QByteArray process(const QByteArray& pcm24kStereo);
 
     // Returns true if rnnoise_create() succeeded.

--- a/src/gui/StripTubePanel.cpp
+++ b/src/gui/StripTubePanel.cpp
@@ -283,8 +283,41 @@ StripTubePanel::StripTubePanel(AudioEngine* engine, QWidget* parent)
     body->addLayout(right, 0);
 
     // ── Output level meter — far-right column, mirrors EQ editor ────
+    // In the strip, the TX-side instance shortens the meter and tucks
+    // a small RN2 toggle directly beneath it.  RX-side keeps the
+    // default full-height meter (no button).  (#2813)
     m_outMeter = new ClientLevelMeter;
-    body->addWidget(m_outMeter);
+
+    m_rn2Btn = new QPushButton("RN2", this);
+    m_rn2Btn->setCheckable(true);
+    // Match the A/B/C model-button footprint so the toggle visually
+    // belongs to the same family of compact panel buttons.  (#2813)
+    m_rn2Btn->setFixedSize(22, 20);
+    m_rn2Btn->setVisible(false);  // flipped on by showForTx()
+    m_rn2Btn->setToolTip(tr(
+        "Toggle RNNoise neural denoiser on the mic input.  Runs before "
+        "any DSP chain stage so noise is suppressed before it can be "
+        "amplified by gate / compressor / saturator.  Voice modes only — "
+        "digital modes (RADE, DAX, RTTY, FT8, FDV, CW) bypass this stage."));
+    // Reuse the A/B/C model-button stylesheet so all four compact
+    // buttons in this panel share one visual idiom.  (#2813)
+    m_rn2Btn->setStyleSheet(kModelStyle);
+    connect(m_rn2Btn, &QPushButton::toggled, this, [this](bool on) {
+        if (m_audio) m_audio->setRn2TxEnabled(on);
+        // Direct setter call is the single source of truth — engine
+        // emits rn2TxEnabledChanged for any cross-widget observer.
+    });
+
+    // Meter stretches to fill all available vertical space; RN2 button
+    // sits flush at the bottom, horizontally centered.  Stretch factor 1
+    // on the meter, 0 on the button so the meter absorbs all surplus
+    // height when the panel grows.  (#2813)
+    auto* meterCol = new QVBoxLayout;
+    meterCol->setContentsMargins(0, 0, 0, 0);
+    meterCol->setSpacing(4);
+    meterCol->addWidget(m_outMeter, 1);
+    meterCol->addWidget(m_rn2Btn, 0, Qt::AlignHCenter);
+    body->addLayout(meterCol);
 
     root->addLayout(body);
 
@@ -325,6 +358,16 @@ void StripTubePanel::showForTx()
     if (m_titleBar)
         static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
     setWindowTitle(title);
+    // RN2 toggle is TX-only.  Meter keeps its default Expanding policy
+    // so it absorbs all column height except the 20 px the RN2 button
+    // plus the 4 px gap occupy at the bottom.  (#2813)
+    if (m_rn2Btn) {
+        m_rn2Btn->setVisible(true);
+        if (m_audio) {
+            QSignalBlocker block(m_rn2Btn);
+            m_rn2Btn->setChecked(m_audio->rn2TxEnabled());
+        }
+    }
     syncControlsFromEngine();
     restoreGeometryFromSettings();
     show();
@@ -342,6 +385,10 @@ void StripTubePanel::showForRx()
     if (m_titleBar)
         static_cast<EditorFramelessTitleBar*>(m_titleBar)->setTitleText(title);
     setWindowTitle(title);
+    // RX side has its own RN2 toggle elsewhere (AetherDspWidget /
+    // ClientRxChainWidget).  Hide our copy — meter keeps its default
+    // Expanding policy so it fills the full column.  (#2813)
+    if (m_rn2Btn) m_rn2Btn->setVisible(false);
     syncControlsFromEngine();
     restoreGeometryFromSettings();
     show();

--- a/src/gui/StripTubePanel.h
+++ b/src/gui/StripTubePanel.h
@@ -81,6 +81,11 @@ private:
     ClientCompKnob*        m_attack{nullptr};
     ClientCompKnob*        m_release{nullptr};
     ClientLevelMeter*      m_outMeter{nullptr};
+    // TX mic pre-amp RN2 toggle.  Created in ctor as hidden; flipped
+    // visible (and m_outMeter is shortened) only when showForTx() runs.
+    // RX side keeps the full-height meter and no RN2 control here —
+    // RX already has its own RN2 toggle elsewhere.  (#2813)
+    QPushButton*           m_rn2Btn{nullptr};
     QPushButton*           m_modelA{nullptr};
     QPushButton*           m_modelB{nullptr};
     QPushButton*           m_modelC{nullptr};


### PR DESCRIPTION
Adds a TX-side neural denoiser toggle to the Aetherial Audio Channel
Strip mic pre-amp area.  Operators with noisy shacks (HVAC, fan,
keyboard, kids, HF QRM bleeding into the mic) can now denoise their
mic at the input — before any gate / compressor / EQ / saturator can
amplify the noise floor.

Architecture:
  - New atomic m_rn2TxEnabled + std::unique_ptr<RNNoiseFilter> m_rn2Tx
    in AudioEngine, lazy-allocated under m_dspMutex on toggle-on,
    freed on toggle-off.  Mirrors the existing RX RN2 ownership.
  - Hook in onTxAudioReady() lives AFTER the m_radeMode and
    m_daxTxMode early-returns, so RN2 is structurally guaranteed
    never to touch digital-mode TX paths (RADE / DAX / TCI /
    RTTY / FT8 / FDV).  Voice modes only.
  - RNNoiseFilter::process() actually takes float32 stereo (the
    pre-existing header comment claiming int16 was wrong — also
    fixed in this commit so the next developer doesn't get burned).
    The hook converts int16 → float32 into a pre-sized scratch
    buffer, processes, converts back to int16 with saturation.
    No per-block heap allocation after first frame.

UI:
  - StripTubePanel now hosts a small RN2 toggle in its meter column,
    sized 22x20 to match the existing A/B/C model buttons and styled
    with kModelStyle so all four compact buttons share one idiom.
  - StripTubePanel is dual-side (TX + RX strip instances + standalone
    editor).  The toggle is created hidden in the ctor; showForTx()
    flips it visible, showForRx() keeps it hidden.  RX side already
    has its own RN2 toggle elsewhere (AetherDspWidget); no duplication.
  - Meter retains its default Expanding height policy; the toggle
    sits flush at the bottom of the column with the meter absorbing
    all surplus space (stretch=1 vs stretch=0).

Persistence (Principle V):
  - New AppSettings key "AetherialTubePreampTx" holds a JSON object:
    {"rn2": bool}.  Nested shape leaves room for future mic-preamp
    toggles (high-pass, phase invert, polarity) without further
    migration.

No mutual-exclusion with other TX-side NR: AetherSDR has no other
neural denoiser on the TX mic path today (NR2/NR4/BNR/DFNR/MNR are
RX-only), so RN2 TX is the sole TX-side NR and needs no exclusion
logic.  If a second TX denoiser lands later, the pattern's there to
extend.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
