### PR TITLE
fix(vfo): VFO Mode tab filter buttons spread apart when RADE active

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1897,6 +1897,10 @@ void VfoWidget::showTab(int index)
         m_tabBtns[index]->setStyleSheet(kTabLblActive);
         m_tabStack->setCurrentIndex(index);
         m_tabStack->show();
+        // QSW::sizeHint() is max of all pages; restrict to current page to prevent cross-tab inflation.
+        for (int i = 0; i < m_tabStack->count(); ++i)
+            m_tabStack->widget(i)->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+        m_tabStack->currentWidget()->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     }
     adjustSize();
 }


### PR DESCRIPTION
## Problem

When RADE mode is engaged (slice → DIGU/DIGL), the filter preset buttons
in the VFO Mode tab appear with a visible gap between the mode-combo row
and the first filter row. The same artifact occurs in CW (APF control
visible) and RTTY (mark/shift control visible) modes. Consistently
reproduced by collapsing the Mode tab and re-expanding it while RADE is
active; also visible on initial tab open after RADE activation.

Two independent users reported RADE on 40m selecting DIGU instead of
DIGL — while that was a separate bug (PR #2811), this layout regression
shares the RADE activation path and was masked by it in reproduction.

## Root cause

`QStackedWidget::sizeHint()` returns the **maximum** height of all its
pages. In DIGU/DIGL mode, `m_digContainer` (the DIG offset control)
becomes visible in the DSP tab, making it ~44 px taller than the Mode
tab. The Mode tab page was allocated the DSP tab's height, and the
VBox inside it distributed the surplus between the mode-combo row and
the filter grid — producing the gap.

The bug was latent since 3bde94fc (v0.2.0, `m_digContainer` added).
It became consistently visible in 5813dccb (PR #2660), which added
`resize(sizeHint())` to `setRadeActive()`, explicitly triggering the
inflated layout on every RADE activation.

## Fix

In `showTab()`, immediately after `setCurrentIndex()`, mark all
non-current pages `QSizePolicy::Ignored` and the current page
`QSizePolicy::Preferred`. `QStackedLayout::sizeHint()` skips Ignored
pages, so the stack now reports only the active page's natural height.
`adjustSize()` then sizes the VfoWidget exactly to the open tab's
content with no cross-tab inflation.

This is the idiomatic Qt pattern for variable-height tab-like widgets.
The policy is re-applied on every tab switch, so each tab gets its own
correct height as the user navigates between them.

## Test plan

- [ ] Activate RADE on 40m (DIGL) — verify Mode tab filter buttons are
      compact with no gap between mode-combo row and filter rows
- [ ] Activate RADE on 20m (DIGU) — same
- [ ] Collapse Mode tab, re-expand — layout should remain compact
- [ ] Switch to DSP tab — VfoWidget grows to fit DSP controls
- [ ] Switch back to Mode tab — VfoWidget shrinks back, no gap
- [ ] CW mode: Mode tab should be compact (APF row in DSP no longer
      inflates Mode tab)
- [ ] AM/USB/LSB: unaffected (DSP and Mode tabs similar height)

🤖 Generated with [Claude Code](https://claude.com/claude-code)