### PR TITLE
fix: extend FDVU/FDVL coverage to all FreeDV mode-string checks

### DIFF
--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -39,6 +39,7 @@ QString TciProtocol::smartsdrToTci(const QString& mode)
         {"DFM",  "fm"},    {"FDM",  "fm"},
         {"DIGU", "digu"},  {"DIGL", "digl"},
         {"RTTY", "rtty"},  {"FDV",  "digu"},
+        {"FDVU", "digu"},  {"FDVL", "digl"},
     };
     return map.value(mode.toUpper(), "usb");
 }

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -618,7 +618,9 @@ void TciServer::onTextMessage(const QString& msg)
                     return m == QStringLiteral("DIGU")
                         || m == QStringLiteral("DIGL")
                         || m == QStringLiteral("RTTY")
-                        || m == QStringLiteral("FDV");
+                        || m == QStringLiteral("FDV")
+                        || m == QStringLiteral("FDVU")
+                        || m == QStringLiteral("FDVL");
                 }();
                 const bool wantDax = source == QStringLiteral("dax")
                                   || source == QStringLiteral("tci")

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -2023,9 +2023,9 @@ QString RxApplet::formatHz(int hz)
 QString RxApplet::formatFilterWidth(int lo, int hi, const QString& mode)
 {
     int w;
-    if (mode == "USB" || mode == "DIGU" || mode == "FDV" || mode == "NT")
+    if (mode == "USB" || mode == "DIGU" || mode == "FDV" || mode == "FDVU" || mode == "NT")
         w = hi;
-    else if (mode == "LSB" || mode == "DIGL")
+    else if (mode == "LSB" || mode == "DIGL" || mode == "FDVL")
         w = std::abs(lo);
     else
         w = hi - lo;
@@ -2079,8 +2079,10 @@ void RxApplet::applyFilterPreset(int widthHz)
         // Double-sideband: split width equally around carrier
         lo = -(widthHz / 2);
         hi =  (widthHz / 2);
+    } else if (mode == "FDVL") {
+        lo = -widthHz; hi = -95;
     } else {
-        // USB, FDV, etc. — low cut at 95 Hz to reject carrier/hum
+        // USB, FDVU, FDV, etc. — low cut at 95 Hz to reject carrier/hum
         lo = 95;
         hi = widthHz;
     }

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -3724,8 +3724,10 @@ void VfoWidget::applyFilterPreset(int widthHz)
     } else if (mode == "AM" || mode == "SAM" || mode == "DSB"
                || mode == "FM" || mode == "NFM" || mode == "DFM") {
         lo = -(widthHz / 2); hi = (widthHz / 2);
+    } else if (mode == "FDVL") {
+        lo = -widthHz; hi = -95;
     } else {
-        // USB/FDV/etc: low cut at 95 Hz to reject carrier/hum
+        // USB/FDVU/FDV/etc: low cut at 95 Hz to reject carrier/hum
         lo = 95; hi = widthHz;
     }
     m_slice->setFilterWidth(lo, hi);

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -560,9 +560,10 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
 
         // Radio sometimes sends wrong-polarity filter offsets after session
         // restore (e.g. negative offsets for USB/DIGU). Normalize based on mode.
-        const bool isUsbFamily = (m_mode == "USB" || m_mode == "DIGU" || m_mode == "FDV"
+        const bool isUsbFamily = (m_mode == "USB" || m_mode == "DIGU"
+                                  || m_mode == "FDV" || m_mode == "FDVU"
                                   || m_mode == "NT");  // NAVTEX: USB-family digital (v4.2.18)
-        const bool isLsbFamily = (m_mode == "LSB" || m_mode == "DIGL");
+        const bool isLsbFamily = (m_mode == "LSB" || m_mode == "DIGL" || m_mode == "FDVL");
         if (isUsbFamily && m_filterLow < 0 && m_filterHigh <= 0) {
             // Flip: -2700,0 → 0,2700
             int w = std::abs(m_filterLow);

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -785,7 +785,7 @@ bool TransmitModel::isPhoneModeForQuindar() const
     // tone would corrupt the digital waveform.
     return m == "USB" || m == "LSB"
         || m == "AM"  || m == "FM"  || m == "NFM"
-        || m == "FDV";
+        || m == "FDV" || m == "FDVU" || m == "FDVL";
 }
 
 bool TransmitModel::runPttPreflight(PttSource source, bool resyncMoxOnBlock)


### PR DESCRIPTION
## Summary

Closes #2818.

The FlexRadio FreeDV waveform plugin registers exactly two mode strings with the radio: \`FDVU\` (FreeDV-USB, underlayer DIGU) and \`FDVL\` (FreeDV-LSB, underlayer DIGL). Seven call sites across five files tested only for the bare string \`"FDV"\`, which the radio never sends for a FreeDV slice. Every \`"FDV"\` equality check in the affected code is dead. The result is that filter preset commands, filter width display, TCI mode mapping, DAX audio routing, and TX Quindar-tone gating all fall through to wrong defaults for any FreeDV slice.

## Evidence

**Internal (AetherSDR codebase):** \`TransmitModel.h\` already documents the correct strings in two places:
- Line 248: \`// Emitted when the radio reports the TX slice mode (e.g. "FDVU", "FDVL", "USB").\`
- Line 337: \`// empty until first transmit status; "FDVU", "FDVL", "USB", etc.\`

The comments know the truth; the logic in five files does not.

**External (freedv-gui waveform source):** \`src/integrations/flex/FlexTcpTask.cpp\` contains exactly two \`createWaveform_\` calls (lines 157–158):
\`\`\`cpp
createWaveform_("FreeDV-USB", "FDVU", "DIGU");
createWaveform_("FreeDV-LSB", "FDVL", "DIGL");
\`\`\`
No other FreeDV mode is registered. \`FDVM\` is not present in the waveform registration and is excluded from this fix.

## Changes

**\`SliceModel.cpp\` — filter polarity normalization after profile recall**

The radio occasionally sends wrong-polarity filter offsets after a session restore (observed most reliably after a Maestro hardware controller triggers a profile recall). The normalizer flips them back based on mode family. \`FDVU\` was absent from the USB family; \`FDVL\` was absent from the LSB family entirely, so polarity flips never fired for FreeDV slices.

**\`RxApplet.cpp\` \`formatFilterWidth\` — displayed passband width**

The width label for upper-sideband modes shows \`hi\`; for lower-sideband it shows \`abs(lo)\`. FDVU/FDVL fell to the \`else\` branch (\`hi - lo\`, i.e. full passband), producing a ~150 Hz display error.

**\`RxApplet.cpp\` and \`VfoWidget.cpp\` \`applyFilterPreset\` — filter preset commands**

FDVL had no explicit branch in either function and fell to the final \`else\` (USB family: \`lo=95, hi=widthHz\`). Every filter preset button press while in FDVL mode sent the radio an inverted passband — positive offsets for a lower-sideband mode. Fixed by adding an explicit \`FDVL\` branch matching the LSB convention (\`lo=-widthHz, hi=-95\`).

**\`TransmitModel.cpp\` \`isPhoneModeForQuindar\`**

This is an inclusion list: returning \`true\` means Quindar courtesy tones are played at TX start/end. The original code already included \`"FDV"\` (dead string) with a comment explicitly listing FreeDV as a phone mode for Quindar. \`FDVU\` and \`FDVL\` are added here to restore that same treatment for the real mode strings the radio actually sends — consistent with the original author's stated intent. Whether Quindar-for-FreeDV is correct behavior at the audio-chain level (i.e., whether tones are injected before or after the FreeDV encoder) is a pre-existing design question outside this PR's scope.

**\`TciProtocol.cpp\` — SmartSDR-to-TCI mode map**

The most severe mapping error: both \`FDVU\` and \`FDVL\` were absent from the table. \`map.value(mode.toUpper(), "usb")\` silently mapped both to TCI mode \`"usb"\` — FDVL was handed to TCI clients as upper-sideband. Added \`FDVU → "digu"\` and \`FDVL → "digl"\`.

**\`TciServer.cpp\` \`isDigitalMode\` — DAX/TCI audio routing**

\`isDigitalMode\` controls whether a TX request without an explicit \`source=\` routes through DAX/TCI audio or direct radio audio. FDVU/FDVL were not matched, so FreeDV TX fell back to direct radio audio unless \`source=dax\` was explicitly specified.

## What is not changed

Existing \`"FDV"\` equality checks are preserved unchanged (not removed). While the Flex waveform plugin never sends bare \`"FDV"\`, removing these checks is a separate cleanup and outside the scope of this fix.

## Test plan

- [ ] Set a slice to FDVU; press each filter preset button — confirm \`filter_lo=95\`, \`filter_hi=W\`
- [ ] Set a slice to FDVL; press each filter preset button — confirm \`filter_lo=-W\`, \`filter_hi=-95\`
- [ ] Set a slice to FDVL; verify the filter width label shows \`abs(lo)\` Hz, not \`hi-lo\` Hz
- [ ] Set a slice to FDVU; verify the filter width label shows \`hi\` Hz
- [ ] With a Maestro, perform a profile recall while in FDVU or FDVL — confirm filter offsets are not inverted after restore
- [ ] Verify TCI clients receive \`digu\` for an FDVU slice and \`digl\` for an FDVL slice
- [ ] Confirm DAX/TCI audio routing engages automatically for FDVU/FDVL TX without an explicit \`source=dax\`
- [ ] Confirm Quindar tones are not audible in the FDVU/FDVL TX audio path

🤖 Generated with [Claude Code](https://claude.com/claude-code)