### PR TITLE
feat(models): add RadioModel::autoSaveChanged signal, wire ProfileManagerDialog

### DIFF
--- a/src/gui/ProfileManagerDialog.cpp
+++ b/src/gui/ProfileManagerDialog.cpp
@@ -222,14 +222,7 @@ QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,
                     box.exec();
                     if (box.clickedButton() == enableBtn) {
                         m_model->sendCommand("profile autosave on");
-                        // Keep the sibling Auto-Save tab checkbox in sync —
-                        // RadioModel has no autoSaveChanged signal, so the
-                        // checkbox would otherwise read stale until the
-                        // dialog is reopened.
-                        if (m_autoSaveTx) {
-                            QSignalBlocker block(m_autoSaveTx);
-                            m_autoSaveTx->setChecked(true);
-                        }
+                        // autoSaveChanged signal will update m_autoSaveTx automatically.
                     }
                     return;
                 }
@@ -295,6 +288,12 @@ QWidget* ProfileManagerDialog::buildAutoSaveTab()
 
     connect(m_autoSaveTx, &QCheckBox::toggled, this, [this](bool on) {
         m_model->sendCommand(QString("profile autosave %1").arg(on ? "on" : "off"));
+    });
+
+    connect(m_model, &RadioModel::autoSaveChanged, this, [this](bool on) {
+        if (!m_autoSaveTx) { return; }
+        QSignalBlocker block(m_autoSaveTx);
+        m_autoSaveTx->setChecked(on);
     });
 
     vbox->addWidget(m_autoSaveTx);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -4182,7 +4182,11 @@ void RadioModel::handleRadioStatus(const QMap<QString, QString>& kvs)
         changed = true;
     }
     if (kvs.contains("auto_save")) {
-        m_autoSave = kvs["auto_save"] == "1";
+        const bool newAutoSave = kvs["auto_save"] == "1";
+        if (m_autoSave != newAutoSave) {
+            m_autoSave = newAutoSave;
+            emit autoSaveChanged(newAutoSave);
+        }
         changed = true;
     }
     if (kvs.contains("freq_error_ppb")) {

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -429,6 +429,8 @@ signals:
     void interlockNotificationRequested(const QString& message);
     // Emitted when global profile list or active profile changes.
     void globalProfilesChanged();
+    // Emitted when the radio reports a change to the global Auto-Save setting.
+    void autoSaveChanged(bool autoSave);
     void profileDatabaseImportingChanged(bool importing);
     void profileDatabaseExportingChanged(bool exporting);
     // Emitted on each successful ping response from the radio.


### PR DESCRIPTION
## Summary

- Adds `RadioModel::autoSaveChanged(bool)` signal, emitted once per state change when the radio reports `auto_save` in a status message
- Wires `ProfileManagerDialog` to the new signal so `m_autoSaveTx` stays in sync regardless of which client mutated Auto-Save (TCI, profile load, second SmartSDR instance)
- Removes the manual `setChecked(true)` hack added in #2790 — the radio's status echo now drives the update

## Test plan
- [ ] Enable Auto-Save via the warning dialog — checkbox on the Auto-Save tab updates correctly
- [ ] Disable Auto-Save from another SmartSDR client — AetherSDR's checkbox updates on the next radio status echo
- [ ] No regression on the existing #2790 warning-dialog path (inline Enable Auto-Save still works)

Closes #2794

🤖 Generated with [Claude Code](https://claude.com/claude-code)