### PR TITLE
fix(wave): persist WaveApplet drawer collapsed state across restarts

### DIFF
--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -168,7 +168,9 @@ WaveApplet::WaveApplet(QWidget* parent)
     m_waveform->setZoomWindowMs(snappedMs);
     updateWindowLabel();
 
-    setSettingsExpanded(true);
+    const bool drawerExpanded =
+        settings.value("WaveApplet_DrawerExpanded", "True").toString() == "True";
+    setSettingsExpanded(drawerExpanded);
     setMinimumHeight(minimumSizeHint().height());
 
     connect(m_waveform, &WaveformWidget::settingsDrawerToggleRequested,
@@ -340,6 +342,9 @@ void WaveApplet::setSettingsExpanded(bool expanded)
         return;
 
     m_settingsDrawer->setVisible(expanded);
+    auto& settings = AppSettings::instance();
+    settings.setValue("WaveApplet_DrawerExpanded", expanded ? "True" : "False");
+    settings.save();
     setMinimumHeight(minimumSizeHint().height());
     updateGeometry();
     adjustSize();


### PR DESCRIPTION
After double-clicking the Waveform applet to hide the View/Zoom/FPS/Window controls, restarting AetherSDR would re-open the drawer and restore the taller expanded size — ignoring both the collapsed state and the compacted height the user had arranged.

──────────────────────────────────────────────────────────────────────────── Root cause
──────────────────────────────────────────────────────────────────────────── `WaveApplet::WaveApplet()` ended with a hardcoded `setSettingsExpanded(true)` regardless of any saved state. Additionally, `setSettingsExpanded()` never wrote the new state to `AppSettings`, so there was nothing to restore even if the read-side had been wired up.

The compact height is fully derived from `sizeHint()` / `minimumSizeHint()`, which already account for drawer visibility — so no separate height key is needed. Restoring the drawer state at startup is sufficient to restore the correct size.

──────────────────────────────────────────────────────────────────────────── Fix
──────────────────────────────────────────────────────────────────────────── `setSettingsExpanded()`: write `WaveApplet_DrawerExpanded` ("True"/"False") to `AppSettings` and call `save()` whenever the drawer is toggled.

Constructor: read `WaveApplet_DrawerExpanded` (default "True" so existing users whose setting file predates this fix start expanded as before) and pass the result to `setSettingsExpanded()` instead of the hardcoded `true`.

──────────────────────────────────────────────────────────────────────────── Files changed
──────────────────────────────────────────────────────────────────────────── src/gui/WaveApplet.cpp
  — setSettingsExpanded(): save WaveApplet_DrawerExpanded on every toggle
  — WaveApplet(): read saved drawer state instead of hardcoding expanded

──────────────────────────────────────────────────────────────────────────── Testing notes
────────────────────────────────────────────────────────────────────────────
1. Open AetherSDR; confirm the Waveform applet starts with controls visible.
2. Double-click the applet body to collapse the drawer.
3. Resize the applet to the desired compact height.
4. Restart AetherSDR.
5. Expected: drawer remains hidden; applet height matches the collapsed size.
6. Re-expand with another double-click; restart again.
7. Expected: drawer is open on next launch.