### PR TITLE
fix(tci): emit vfo: after band-change slice recreate (closes #2824)

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -17,6 +17,7 @@
 #include <QWebSocket>
 #include <QStringList>
 #include <QTimer>
+#include <QPointer>
 #include <QtEndian>
 #include <algorithm>
 #include <cmath>
@@ -1181,6 +1182,32 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
         const int trx = TciProtocol::tciTrxForSlice(m_model, slice);
         broadcast(QStringLiteral("rx_volume:%1,%2;")
                       .arg(trx).arg(static_cast<int>(gain)));
+    });
+
+    // State sync on (re)wire, deferred. A Flex band change (display pan set
+    // band=) tears down and recreates the slice, so wireSlice() runs again for
+    // the new slice. The handlers above only fire on *subsequent* changes; if
+    // the radio's restored band frequency equals the recreated slice's init
+    // value no frequencyChanged fires and the new band's vfo: is never
+    // announced to TCI clients (silent for 160/80/60/17/10m; #2824).
+    //
+    // Pushing immediately is wrong: the recreated slice briefly holds an
+    // intermediate frequency before the radio restores the band-stack value
+    // (slices settle in ~250-340 ms observed), so an immediate push emits a
+    // transient wrong vfo:. Defer ~400 ms and read the *settled* frequency so
+    // every band announces exactly one correct vfo:. QPointer guards rapid
+    // band changes that destroy the slice before the timer fires (the new
+    // slice schedules its own deferred push, so the final band still wins).
+    QPointer<SliceModel> guard(slice);
+    QTimer::singleShot(400, this, [this, guard]() {
+        if (!guard || m_clients.isEmpty()) return;
+        SliceModel* s = guard;
+        const int trx = TciProtocol::tciTrxForSlice(m_model, s);
+        const double mhz = s->frequency();
+        if (mhz > 0.0) {
+            long long hz = static_cast<long long>(std::round(mhz * 1e6));
+            broadcast(QStringLiteral("vfo:%1,0,%2;").arg(trx).arg(hz));
+        }
     });
 }
 


### PR DESCRIPTION
A Flex band change (display pan `set band=`) tears down and recreates the slice. `TciServer::wireSlice()` only connected change-signal handlers, so a `vfo:` was broadcast only on a *subsequent* `SliceModel::frequencyChanged`. For bands whose radio-restored band-stack frequency equals the recreated slice's initialization value (deterministically 160/80/60/17/10 m on a FLEX-6700) no `frequencyChanged` ever fired, so the new band's frequency was never announced to TCI clients — amplifiers / loggers / WSJT-X stayed on the previous band's frequency. `mode`/`filter` still differed across the recreate so `modulation:`/`rx_filter_band:` were emitted, masking the gap.

Add a deferred (~400 ms) state push at the end of `wireSlice` that reads the settled slice frequency and broadcasts one `vfo:`. The delay lets the radio restore the band-stack frequency first (slices observed to settle in ~250-340 ms) so the announced value is the final one, not a transient intermediate. A `QPointer` guards rapid band changes that destroy the slice before the timer fires; the replacement slice schedules its own push so the final band still wins. Normal in-slice tuning is unchanged — the existing `frequencyChanged` handler path is untouched and this push only runs on slice (re)wire.

**Files touched:** `src/core/TciServer.cpp` only (+27).

**Closes #2824.**

### Cross-platform build verified 2026-05-17
- Windows — Qt 6.10.3 / MSVC ✓
- macOS — Qt 6.11 / Apple Silicon ✓
- Linux — Qt 6.4 ✓

### On-radio validation
Original development validation (FLEX-6700): full 160-6 m sweep + return — every band emits exactly one correct `vfo:`, no wrong-frequency transient, no duplicate. RF2K-S amplifier follows all bands. WSJT-X v3.0.0 regression pass (band changes + 20 m FT8 decode) unaffected.

Independent re-validation 2026-05-17 on a clean upstream build (v26.5.2.1, FLEX-6700): band-stack changes across the affected subset (160/80/60/17/10 m) plus 40/20 m controls each emitted exactly one correct `vfo:`, no transient wrong frequency, no duplicate. RF2K-S amplifier and a ShackSwitch 1×4 antenna switch both auto-followed every band correctly. TCI Monitor log captured. Normal in-band tuning unaffected.

73, Nigel G0JKN & Claude
