### PR TITLE
feat(net): adaptive frame-rate throttle + graceful reconnect under congestion

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2575,13 +2575,15 @@ MainWindow::MainWindow(QWidget* parent)
             if (!sw) return;  // pan not yet available
             m_displaySettingsPushed = true;
             m_radioModel.setPanAverage(sw->fftAverage());
-            m_radioModel.setPanFps(sw->fftFps());
+            if (!m_adaptiveThrottleActive)
+                m_radioModel.setPanFps(sw->fftFps());
             m_radioModel.setPanWeightedAverage(sw->fftWeightedAvg());
             m_radioModel.setWaterfallColorGain(sw->wfColorGain());
             m_radioModel.setWaterfallBlackLevel(sw->wfBlackLevel());
             m_radioModel.setWaterfallAutoBlack(sw->wfAutoBlack());
             int rate = sw->wfLineDuration();
-            m_radioModel.setWaterfallLineDuration(rate);
+            if (!m_adaptiveThrottleActive)
+                m_radioModel.setWaterfallLineDuration(rate);
             // Restore saved WNB and RF gain
             auto& s = AppSettings::instance();
             bool wnbOn = s.value(sw->settingsKey("DisplayWnbEnabled"), "False").toString() == "True";
@@ -2600,10 +2602,12 @@ MainWindow::MainWindow(QWidget* parent)
             int bgOpacity = s.value(sw->settingsKey("BackgroundOpacity"), "80").toInt();
             sw->setBackgroundOpacity(bgOpacity);
             // Nudge rate to force waterfall tile re-sync
-            QTimer::singleShot(500, this, [this, rate]() {
-                m_radioModel.setWaterfallLineDuration(rate + 1);
-                m_radioModel.setWaterfallLineDuration(rate);
-            });
+            if (!m_adaptiveThrottleActive) {
+                QTimer::singleShot(500, this, [this, rate]() {
+                    m_radioModel.setWaterfallLineDuration(rate + 1);
+                    m_radioModel.setWaterfallLineDuration(rate);
+                });
+            }
         }
     });
     // NOTE: panadapterLevelChanged → spectrum()::setDbmRange has been removed.
@@ -4413,10 +4417,54 @@ MainWindow::MainWindow(QWidget* parent)
         if (quality == "Fair") color = "#cc9900";
         else if (quality == "Poor") color = "#cc3333";
         else if (quality == "Good") color = "#00b4d8";
+        // Append fps cap so users understand why moving the fps slider has no effect.
+        // Show "(restoring)" during the min-dwell hold so testers can distinguish
+        // stuck throttle from a deliberate stability wait.
+        const bool dwellPending = m_adaptiveFpsCap > 0 && m_radioModel.pendingThrottleLift();
+        const QString capSuffix = m_adaptiveFpsCap > 0
+            ? (dwellPending
+               ? QStringLiteral(" · %1 fps cap (restoring)").arg(m_adaptiveFpsCap)
+               : QStringLiteral(" · %1 fps cap").arg(m_adaptiveFpsCap))
+            : QString();
         m_networkLabel->setText(QString("[<span style='color:%1'>%2</span>]")
-            .arg(color, quality));
+            .arg(color, quality + capSuffix));
         Q_UNUSED(pingMs);
-        m_networkLabel->setToolTip(buildNetworkTooltip(m_radioModel));
+        QString tooltip = buildNetworkTooltip(m_radioModel);
+        if (m_adaptiveFpsCap > 0) {
+            const QString throttleMsg = dwellPending
+                ? QStringLiteral("Adaptive throttle holding for link stability — restoring shortly\n\n")
+                : QString("Adaptive throttle active: %1 fps cap\n\n").arg(m_adaptiveFpsCap);
+            tooltip.prepend(throttleMsg);
+        }
+        m_networkLabel->setToolTip(tooltip);
+    });
+
+    connect(&m_radioModel, &RadioModel::adaptiveThrottleChanged,
+            this, [this](bool active, int fpsCap) {
+        m_adaptiveThrottleActive = active;
+        m_adaptiveFpsCap = active ? fpsCap : 0;
+        if (!active) {
+            // Throttle lifted — push each pan's user-configured fps back to the radio.
+            // The reconcile timers are suppressed while throttle is active, so they
+            // won't have done this automatically.
+            if (!m_panStack) return;
+            for (auto* applet : m_panStack->allApplets()) {
+                if (!applet) continue;
+                auto* sw = applet->spectrumWidget();
+                if (!sw) continue;
+                const QString panId = applet->panId();
+                const int userFps = sw->fftFps();
+                if (userFps > 0)
+                    m_radioModel.sendCommand(
+                        QString("display pan set %1 fps=%2").arg(panId).arg(userFps));
+                const int userWfMs = sw->wfLineDuration();
+                auto* pan = m_radioModel.panadapter(panId);
+                if (pan && !pan->waterfallId().isEmpty() && userWfMs > 0)
+                    m_radioModel.sendCommand(
+                        QString("display panafall set %1 line_duration=%2")
+                            .arg(pan->waterfallId()).arg(userWfMs));
+            }
+        }
     });
 
     connect(&m_radioModel.meterModel(), &MeterModel::hwTelemetryChanged,
@@ -8725,6 +8773,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
             }
         }
         m_wfLineDurationReconcile.clear();
+        m_adaptiveThrottleActive = false;
 
         // Clear spectrum/waterfall so the display doesn't look frozen
         if (m_panStack) {
@@ -10153,6 +10202,15 @@ void MainWindow::schedulePanFpsReconcile(const QString& panId, int reportedFps)
 {
     if (panId.isEmpty() || reportedFps <= 0)
         return;
+    // While adaptive throttle is active the radio fps is intentionally below the
+    // user's desired value. Don't fight the throttle — MainWindow restores fps
+    // when adaptiveThrottleChanged(false) fires.
+    if (m_adaptiveThrottleActive) {
+        qCDebug(lcProtocol).noquote().nospace()
+            << "MainWindow: fps reconcile suppressed for pan=" << panId
+            << " reported=" << reportedFps << " (adaptive throttle active)";
+        return;
+    }
 
     auto* pan = m_radioModel.panadapter(panId);
     if (!pan)
@@ -10230,6 +10288,12 @@ void MainWindow::scheduleWaterfallLineDurationReconcile(const QString& panId, in
 {
     if (panId.isEmpty() || reportedMs <= 0)
         return;
+    if (m_adaptiveThrottleActive) {
+        qCDebug(lcProtocol).noquote().nospace()
+            << "MainWindow: wf line_duration reconcile suppressed for pan=" << panId
+            << " reported=" << reportedMs << "ms (adaptive throttle active)";
+        return;
+    }
 
     auto* pan = m_radioModel.panadapter(panId);
     if (!pan)
@@ -10752,7 +10816,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     connect(menu, &SpectrumOverlayMenu::fftFpsChanged,
             this, [this, applet, sw](int v) {
-        sw->setFftFps(v);
+        sw->setFftFps(v);  // always update restore target for when throttle lifts
+        if (m_adaptiveThrottleActive)
+            return;
         m_radioModel.sendCommand(
             QString("display pan set %1 fps=%2").arg(applet->panId()).arg(v));
     });
@@ -10789,7 +10855,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setWfAutoBlackOffset(offset);
     });
     const auto applyWaterfallLineDuration = [this, applet, sw](int ms) {
-        sw->setWfLineDuration(ms);
+        sw->setWfLineDuration(ms);  // always update restore target for when throttle lifts
+        if (m_adaptiveThrottleActive)
+            return;
         auto* pan = m_radioModel.panadapter(applet->panId());
         if (pan && !pan->waterfallId().isEmpty())
             m_radioModel.sendCommand(
@@ -10853,11 +10921,16 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setNoiseFloorPosition(75);
         sw->setFreqGridSpacing(0);  // Auto (#1390)
 
-        // Radio commands for radio-authoritative display settings
+        // Radio commands for radio-authoritative display settings.
+        // fps and line_duration are suppressed while adaptive throttle is active
+        // so the reset doesn't fight the congestion-aware cap. The SpectrumWidget
+        // values above (sw->setFftFps / sw->setWfLineDuration) are already updated,
+        // so they become the new restore targets when the throttle lifts.
         m_radioModel.sendCommand(
             QString("display pan set %1 average=0").arg(applet->panId()));
-        m_radioModel.sendCommand(
-            QString("display pan set %1 fps=25").arg(applet->panId()));
+        if (!m_adaptiveThrottleActive)
+            m_radioModel.sendCommand(
+                QString("display pan set %1 fps=25").arg(applet->panId()));
         m_radioModel.sendCommand(
             QString("display pan set %1 weighted_average=0").arg(applet->panId()));
         auto* pan = m_radioModel.panadapter(applet->panId());
@@ -10866,8 +10939,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                 QString("display panafall set %1 color_gain=50").arg(pan->waterfallId()));
             m_radioModel.sendCommand(
                 QString("display panafall set %1 black_level=15").arg(pan->waterfallId()));
-            m_radioModel.sendCommand(
-                QString("display panafall set %1 line_duration=100").arg(pan->waterfallId()));
+            if (!m_adaptiveThrottleActive)
+                m_radioModel.sendCommand(
+                    QString("display panafall set %1 line_duration=100").arg(pan->waterfallId()));
         }
 
         // Persist all defaults to AppSettings

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8774,6 +8774,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
         }
         m_wfLineDurationReconcile.clear();
         m_adaptiveThrottleActive = false;
+        m_adaptiveFpsCap = 0;  // clear cap alongside throttle flag — see #2829 review
 
         // Clear spectrum/waterfall so the display doesn't look frozen
         if (m_panStack) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -640,6 +640,8 @@ private:
     };
     QHash<QString, PanFpsReconcileState> m_panFpsReconcile;
     QHash<QString, QMetaObject::Connection> m_panFpsReconcileConnections;
+    bool m_adaptiveThrottleActive{false}; // fps/wf reconcile suppressed while true
+    int  m_adaptiveFpsCap{0};             // current cap (> 0 when throttle active); shown in network label
     struct WaterfallLineDurationReconcileState {
         QTimer* timer{nullptr};
         QPointer<SpectrumWidget> spectrum;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2379,6 +2379,11 @@ void RadioModel::startNetworkMonitor()
     m_maxPingRtt = 0;
     m_pingMissCount = 0;
     m_pingDisconnectTriggered = false;
+    m_pendingThrottleLift = false;
+    // Safety: ensure MainWindow's m_adaptiveThrottleActive is cleared even if
+    // the connectionStateChanged(false) path was somehow skipped.  Pans are not
+    // yet rebuilt at this point so the fps-restore loop in the handler is a no-op.
+    emit adaptiveThrottleChanged(false, 0);
 
     // RTT is read from kernel TCP_INFO (smoothed RTT from TCP ACK timing),
     // completely independent of Qt event loop buffering. Falls back to
@@ -2400,14 +2405,18 @@ void RadioModel::startNetworkMonitor()
             return;
         }
         ++m_pingMissCount;
-        if (m_pingMissCount >= PING_MISS_DISCONNECT) {
+        const int missThreshold = (m_netState == NetState::Poor)
+                                      ? PING_MISS_DISCONNECT_POOR
+                                      : PING_MISS_DISCONNECT;
+        if (m_pingMissCount >= missThreshold) {
             if (m_pingDisconnectTriggered)
                 return;
 
             m_pingDisconnectTriggered = true;
             m_pingTimer.stop();
-            qDebug() << "RadioModel:" << PING_MISS_DISCONNECT
-                     << "consecutive pings unanswered — forcing disconnect";
+            qCDebug(lcProtocol) << "RadioModel:" << missThreshold
+                                << "consecutive pings unanswered — forcing disconnect"
+                                << "(state:" << static_cast<int>(m_netState) << ")";
             forceDisconnect();
             return;
         }
@@ -2439,8 +2448,25 @@ void RadioModel::evaluateNetworkQuality()
                              ? (targetScore <= 45.0 ? 0.45 : 0.30)
                              : 0.12;
     m_networkQualityScore += (targetScore - m_networkQualityScore) * alpha;
+    const NetState prevState = m_netState;
     m_netState = networkStateForScore(m_networkQualityScore, m_netState);
     if (ping > m_maxPingRtt) m_maxPingRtt = ping;
+
+    if (m_netState != prevState)
+        applyAdaptiveFrameRate(m_netState, prevState);
+
+    // Fire a deferred throttle lift once the min-dwell has elapsed and the
+    // state has not re-entered a throttled tier since the engage.
+    if (m_pendingThrottleLift
+            && m_netState != NetState::Good
+            && m_netState != NetState::Fair
+            && m_netState != NetState::Poor) {
+        if (QDateTime::currentMSecsSinceEpoch() - m_lastThrottleEngageMs >= THROTTLE_MIN_DWELL_MS) {
+            m_pendingThrottleLift = false;
+            qCDebug(lcProtocol) << "RadioModel: deferred adaptive throttle lift firing after min-dwell";
+            emit adaptiveThrottleChanged(false, 0);
+        }
+    }
 
     static const char* names[] = {"Off", "Excellent", "Very Good", "Good", "Fair", "Poor"};
     emit networkQualityChanged(names[static_cast<int>(m_netState)], ping);
@@ -2562,6 +2588,83 @@ RadioModel::NetState RadioModel::networkStateForScore(double score, NetState cur
     if (score >= 45.0)
         return NetState::Fair;
     return NetState::Poor;
+}
+
+// Single source of truth for the state→fps-cap mapping.
+// currentAdaptiveFpsCap(), applyAdaptiveFrameRate(), and any future
+// callers must all go through here so adding a new tier (e.g. Critical=2)
+// never silently diverges between code paths.
+int RadioModel::fpsCapForState(NetState s)
+{
+    switch (s) {
+    case NetState::Poor: return 4;
+    case NetState::Fair: return 8;
+    case NetState::Good: return 15;
+    default:             return 0;
+    }
+}
+
+int RadioModel::currentAdaptiveFpsCap() const
+{
+    return fpsCapForState(m_netState);
+}
+
+
+int RadioModel::adaptiveWfMsForCap(int fpsCap) const
+{
+    if (fpsCap <= 0)  return 0;
+    if (fpsCap <= 4)  return 500;
+    if (fpsCap <= 8)  return 250;
+    if (fpsCap <= 15) return 150;
+    return 0;
+}
+
+void RadioModel::sendAdaptiveCapToPan(const QString& panId, int fpsCap)
+{
+    if (panId.isEmpty() || fpsCap <= 0) return;
+    auto* pan = m_panadapters.value(panId, nullptr);
+    if (!pan) return;
+    sendCommand(QString("display pan set %1 fps=%2").arg(panId).arg(fpsCap));
+    if (!pan->waterfallId().isEmpty())
+        sendCommand(QString("display panafall set %1 line_duration=%2")
+                        .arg(pan->waterfallId()).arg(adaptiveWfMsForCap(fpsCap)));
+}
+
+void RadioModel::applyAdaptiveFrameRate(NetState newState, NetState oldState)
+{
+    const int newCap = fpsCapForState(newState);
+    const int oldCap = fpsCapForState(oldState);
+    if (newCap == oldCap)
+        return;
+
+    const bool throttling = (newCap > 0);
+
+    if (throttling) {
+        m_lastThrottleEngageMs = QDateTime::currentMSecsSinceEpoch();
+        m_pendingThrottleLift = false;
+        qCDebug(lcProtocol) << "RadioModel: adaptive throttle engaged — fps cap"
+                            << newCap << "/ wf line" << adaptiveWfMsForCap(newCap) << "ms";
+        for (auto it = m_panadapters.cbegin(); it != m_panadapters.cend(); ++it)
+            sendAdaptiveCapToPan(it.key(), newCap);
+        emit adaptiveThrottleChanged(throttling, newCap);
+    } else {
+        // Min-dwell guard: if we just engaged, don't lift yet — let the link
+        // stabilise before restoring full fps. evaluateNetworkQuality() will
+        // fire the deferred lift once THROTTLE_MIN_DWELL_MS has elapsed.
+        if (QDateTime::currentMSecsSinceEpoch() - m_lastThrottleEngageMs < THROTTLE_MIN_DWELL_MS) {
+            m_pendingThrottleLift = true;
+            qCDebug(lcProtocol) << "RadioModel: adaptive throttle lift deferred"
+                                << "(min-dwell not reached)";
+            return;
+        }
+        m_pendingThrottleLift = false;
+        qCDebug(lcProtocol) << "RadioModel: adaptive throttle lifted — signalling fps restore";
+        // Intentionally no fps push here — RadioModel doesn't own the user-configured
+        // fps (that lives in each SpectrumWidget). MainWindow restores it via
+        // adaptiveThrottleChanged(false, 0). A headless consumer connecting to
+        // RadioModel without MainWindow receives the engage but must handle restore itself.
+        emit adaptiveThrottleChanged(false, 0);
+    }
 }
 
 bool RadioModel::usesRemoteNetworkThresholds() const
@@ -3105,6 +3208,23 @@ PanadapterModel* RadioModel::ensureOwnedPanadapter(const QString& panId)
     m_panadapters[normalizedPanId] = pan;
     if (m_activePanId.isEmpty())
         m_activePanId = normalizedPanId;
+
+    // Apply active throttle cap immediately — applyAdaptiveFrameRate only fires
+    // on tier transitions, so a pan opened mid-throttle would run at the radio
+    // default (~25 fps) until the next state change.
+    const int activeCap = currentAdaptiveFpsCap();
+    if (activeCap > 0) {
+        qCDebug(lcProtocol) << "RadioModel: applying active throttle cap" << activeCap
+                            << "to newly-claimed pan" << normalizedPanId;
+        sendAdaptiveCapToPan(normalizedPanId, activeCap);
+        // waterfallId may not be assigned yet (arrives in a subsequent status
+        // message) — re-apply the cap once it lands.
+        connect(pan, &PanadapterModel::waterfallIdChanged,
+                this, [this, normalizedPanId]() {
+            const int cap = currentAdaptiveFpsCap();
+            if (cap > 0) sendAdaptiveCapToPan(normalizedPanId, cap);
+        });
+    }
 
     connect(pan, &PanadapterModel::waterfallIdChanged,
             this, &RadioModel::updateStreamFilters);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -441,6 +441,10 @@ signals:
     void autoSaveChanged(bool autoSave);
     // Emitted on each successful ping response from the radio.
     void pingReceived();
+    // Emitted when adaptive frame-rate throttling engages or lifts.
+    // active=true: all pans are being throttled to fpsCap fps to reduce UDP load.
+    // active=false: throttle lifted; receivers should restore user-configured fps.
+    void adaptiveThrottleChanged(bool active, int fpsCap);
     // Generic status relay — for dialogs that need to listen for specific objects.
     void statusReceived(const QString& object, const QMap<QString, QString>& kvs);
     // Emitted when the radio sends an M-prefix informational, warning, error,
@@ -799,8 +803,12 @@ private:
     void evaluateNetworkQuality();
     void resetNetworkHealthSamples();
     void recordNetworkHealthSample(int currentErrors, int currentPackets);
-
     enum class NetState { Off, Excellent, VeryGood, Good, Fair, Poor };
+    void applyAdaptiveFrameRate(NetState newState, NetState oldState);
+    static int fpsCapForState(NetState s);  // single source of truth; see obs. 1 in PR review
+    int  currentAdaptiveFpsCap() const;
+    int  adaptiveWfMsForCap(int fpsCap) const;
+    void sendAdaptiveCapToPan(const QString& panId, int fpsCap);
     double networkQualityTargetScore(int pingMs) const;
     NetState networkStateForScore(double score, NetState currentState) const;
     bool usesRemoteNetworkThresholds() const;
@@ -829,7 +837,19 @@ private:
     NetState      m_netState{NetState::Off};
     int           m_pingMissCount{0};          // consecutive unanswered pings
     bool          m_pingDisconnectTriggered{false};
-    static constexpr int PING_MISS_DISCONNECT = 5; // force disconnect after 5 missed pings (~5s)
+    // Normal: disconnect after 5 unanswered pings (~5 s).
+    // Poor: allow 15 (~15 s) — adaptive throttle has already cut UDP load, so
+    // brief TCP stalls are more likely to be transient congestion than a dead link.
+    static constexpr int PING_MISS_DISCONNECT      = 5;
+    static constexpr int PING_MISS_DISCONNECT_POOR = 15;
+    // Minimum time at a throttled state before the throttle is allowed to lift.
+    // Prevents Good<->VeryGood oscillation: reducing fps lowers UDP load which
+    // improves the score, which would immediately lift the throttle and restart
+    // the cycle. 5 s of hysteresis breaks the loop without delaying recovery
+    // on a genuinely improving link.
+    static constexpr qint64 THROTTLE_MIN_DWELL_MS = 5000;
+    qint64 m_lastThrottleEngageMs{0};   // QDateTime::currentMSecsSinceEpoch() at last engage
+    bool   m_pendingThrottleLift{false}; // lift deferred by min-dwell; fired in evaluateNetworkQuality()
 
     // Network diagnostics — byte counters for rate calculation
 
@@ -837,6 +857,7 @@ public:
     // Network diagnostics getters
     int     lastPingRtt()      const { return m_lastPingRtt; }
     int     maxPingRtt()       const { return m_maxPingRtt; }
+    bool    pendingThrottleLift() const { return m_pendingThrottleLift; }
     QString networkQuality()   const;
     int     packetLossWindowSeconds() const { return NETWORK_LOSS_WINDOW_SAMPLES; }
     int     packetLossWindowDrops() const { return m_packetLossWindowErrors; }


### PR DESCRIPTION
Under severe network congestion AetherSDR would drop out after only 5 missed pings (~5 s) even when the link was merely congested, not dead. The disconnect then tore down all panadapters and required a full state rebuild. SSDR avoids this by progressively reducing the FFT/waterfall frame rate to shed UDP load, and by tolerating more missed pings before declaring the link dead.

Part 1 - Adaptive frame-rate throttling

When the existing network quality score transitions between tiers, a new RadioModel::applyAdaptiveFrameRate() method sends updated fps and waterfall line_duration commands to ALL owned panadapters (not just the active one):

  NetState::Good  -> 15 fps / 150 ms wf
  NetState::Fair  ->  8 fps / 250 ms wf
  NetState::Poor  ->  4 fps / 500 ms wf
  VeryGood/Excellent -> restore (signal to MainWindow; see Part 3)

Tied into evaluateNetworkQuality() immediately after each state transition, so throttling engages before pings start failing.

Part 2 - Extended ping miss threshold in Poor state

The forced-disconnect threshold is now state-aware:

  Normal (Excellent through Fair): 5 consecutive missed pings (~5 s) - unchanged
  Poor: 15 consecutive missed pings (~15 s)

By the time the link is rated Poor the adaptive throttle has already cut UDP load significantly, so TCP keepalives are more likely to succeed. The longer window gives the link time to recover without triggering a full teardown.

Part 3 - fps/waterfall restore on throttle lift + reconcile suppression

RadioModel emits adaptiveThrottleChanged(bool active, int fpsCap) on every engage/lift event. MainWindow connects this signal:
- active=true: sets m_adaptiveThrottleActive, causing schedulePanFpsReconcile and scheduleWaterfallLineDurationReconcile to return early so they don't fight the throttle.
- active=false: iterates all PanadapterApplets and pushes each SpectrumWidget's user-configured fftFps() / wfLineDuration() back to the radio. Flag is also cleared on disconnect so it doesn't leak across sessions.

Files changed:
  src/models/RadioModel.h  - applyAdaptiveFrameRate() decl, PING_MISS_DISCONNECT_POOR=15, adaptiveThrottleChanged signal src/models/RadioModel.cpp - applyAdaptiveFrameRate() impl, state-aware ping threshold, hook into evaluateNetworkQuality()
  src/gui/MainWindow.h     - m_adaptiveThrottleActive flag
  src/gui/MainWindow.cpp   - connect adaptiveThrottleChanged, suppress reconcile, restore fps on lift, clear flag on disconnect