### PR TITLE
fix: route native 4m/2m band selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,6 +559,7 @@ set(GUI_SOURCES
     src/gui/ConnectedStationsDialog.cpp
     src/gui/SpectrumWidget.cpp
     src/gui/SpectrumOverlayMenu.cpp
+    src/gui/FrequencyEntryParser.cpp
     src/gui/SliceColorManager.cpp
     src/gui/SliceLabel.cpp
     src/gui/VfoWidget.cpp
@@ -1453,6 +1454,14 @@ add_executable(xvtr_policy_test
 )
 target_include_directories(xvtr_policy_test PRIVATE src)
 target_link_libraries(xvtr_policy_test PRIVATE Qt6::Core)
+
+add_executable(frequency_entry_parser_test
+    tests/frequency_entry_parser_test.cpp
+    src/gui/FrequencyEntryParser.cpp
+)
+target_include_directories(frequency_entry_parser_test PRIVATE src)
+target_link_libraries(frequency_entry_parser_test PRIVATE Qt6::Core)
+add_test(NAME frequency_entry_parser_test COMMAND frequency_entry_parser_test)
 
 add_executable(radio_status_ownership_test
     tests/radio_status_ownership_test.cpp

--- a/src/gui/FrequencyEntryParser.cpp
+++ b/src/gui/FrequencyEntryParser.cpp
@@ -1,0 +1,36 @@
+#include "FrequencyEntryParser.h"
+
+namespace AetherSDR::FrequencyEntryParser {
+
+QString normalizedMhzText(const QString& text)
+{
+    QString clean = text.trimmed();
+    const int firstDot = clean.indexOf(QLatin1Char('.'));
+    if (firstDot >= 0) {
+        const QString beforeDot = clean.left(firstDot);
+        const QString afterDot = clean.mid(firstDot + 1).remove(QLatin1Char('.'));
+        clean = beforeDot + QLatin1Char('.') + afterDot;
+    }
+    return clean;
+}
+
+bool isExplicitMhzEntry(const QString& rawText, const QString& normalizedText)
+{
+    const int dot = normalizedText.indexOf(QLatin1Char('.'));
+    if (dot < 0) {
+        return false;
+    }
+
+    // Display-style entries are already MHz.kHz.Hz, even when the current
+    // slice is not yet on an XVTR/high-frequency band.
+    if (rawText.count(QLatin1Char('.')) >= 2) {
+        return true;
+    }
+
+    // Single-dot entries with a normal MHz field are explicit MHz. Preserve
+    // the historic HF shortcut where `14225.0` means 14.225 MHz by treating
+    // five-plus leading digits as kHz-style input.
+    return dot <= 4;
+}
+
+} // namespace AetherSDR::FrequencyEntryParser

--- a/src/gui/FrequencyEntryParser.h
+++ b/src/gui/FrequencyEntryParser.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR::FrequencyEntryParser {
+
+QString normalizedMhzText(const QString& text);
+bool isExplicitMhzEntry(const QString& rawText, const QString& normalizedText);
+
+} // namespace AetherSDR::FrequencyEntryParser

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2979,6 +2979,14 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_appletPanel->rxApplet(), &RxApplet::afGainChanged, this, [this](int v) {
         if (auto* s = activeSlice()) s->setAudioGain(v);
     });
+    connect(m_appletPanel->rxApplet(), &RxApplet::directEntryCommitted,
+            this, [this](double mhz, const QString& source) {
+        if (auto* s = activeSlice()) {
+            const QByteArray sourceUtf8 = source.toUtf8();
+            applyTuneRequest(s, mhz, TuneIntent::CommandedTargetCenter,
+                             sourceUtf8.constData());
+        }
+    });
 
     // ── Slice tab toggle: click A/B/C/D → switch active slice (#1278) ──
     connect(m_appletPanel->rxApplet(), &RxApplet::sliceActivationRequested,
@@ -8556,7 +8564,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
             QVector<SpectrumOverlayMenu::XvtrBand> xvtrBands;
             for (const auto& x : m_radioModel.xvtrList()) {
                 if (x.isValid)
-                    xvtrBands.append({x.name, x.rfFreq});
+                    xvtrBands.append({x.name, x.rfFreq, QString("X%1").arg(x.index)});
             }
             const ModelCapabilities caps = m_radioModel.capabilities();
             for (auto* applet : m_panStack->allApplets()) {
@@ -9040,7 +9048,8 @@ bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPan
         const QString currentBand = BandSettings::bandForFrequency(slice->frequency());
         if (memoryBand != currentBand) {
             const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
-            const auto stackKeyResult = XvtrPolicy::resolveBandStackKey(memoryBand, xvtrs);
+            const auto stackKeyResult =
+                XvtrPolicy::resolveBandStackKey(memoryBand, xvtrs, m_radioModel.capabilities());
             if (stackKeyResult.isSupported()) {
                 qCDebug(lcProtocol).noquote().nospace()
                     << "MainWindow: memory recall preselecting band stack memory="
@@ -9761,6 +9770,59 @@ void MainWindow::mirrorDiversityChildFrequency(SliceModel* slice, double mhz)
     }
 }
 
+MainWindow::BandStackPreselectResult MainWindow::preselectBandStackForTune(
+    SliceModel* slice, double mhz, const char* source)
+{
+    if (!slice || slice->panId().isEmpty())
+        return BandStackPreselectResult::NotNeeded;
+    if (mhz <= 54.0 && slice->frequency() <= 54.0)
+        return BandStackPreselectResult::NotNeeded;
+
+    const QString targetBand = BandSettings::bandForFrequency(mhz);
+    const QString currentBand = BandSettings::bandForFrequency(slice->frequency());
+    if (targetBand == currentBand)
+        return BandStackPreselectResult::NotNeeded;
+
+    const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
+    const auto stackKeyResult =
+        XvtrPolicy::resolveBandStackKey(targetBand, xvtrs, m_radioModel.capabilities());
+    if (!stackKeyResult.isSupported()) {
+        QString unsupportedReason = stackKeyResult.unsupportedReason;
+        if (mhz > 54.0 && xvtrs.isEmpty()) {
+            unsupportedReason =
+                QString("Band %1 requires a configured XVTR before Aether can tune it.")
+                    .arg(targetBand);
+        }
+        qCWarning(lcProtocol).noquote().nospace()
+            << "MainWindow: direct tune cannot preselect band stack source="
+            << (source ? source : "(unknown)")
+            << " pan=" << slice->panId()
+            << " from_band=" << currentBand
+            << " to_band=" << targetBand
+            << " freq_mhz=" << QString::number(mhz, 'f', 6)
+            << " reason=" << unsupportedReason
+            << " available_xvtrs=" << xvtrListSummary(xvtrs);
+        statusBar()->showMessage(unsupportedReason, 5000);
+        return BandStackPreselectResult::Unsupported;
+    }
+
+    qCDebug(lcProtocol).noquote().nospace()
+        << "MainWindow: direct tune preselecting band stack source="
+        << (source ? source : "(unknown)")
+        << " pan=" << slice->panId()
+        << " from_band=" << currentBand
+        << " to_band=" << targetBand
+        << " key=" << stackKeyResult.key;
+    clearSwrSweepForBandChange(-1, slice->panId(), targetBand);
+    m_bandSettings.setCurrentBand(targetBand);
+    m_radioModel.sendCommand(
+        QString("display pan set %1 band=%2").arg(slice->panId(), stackKeyResult.key));
+    QTimer::singleShot(300, this, [this, panId = slice->panId()]() {
+        reassertUnmutedSliceAudioForPan(panId);
+    });
+    return BandStackPreselectResult::Selected;
+}
+
 void MainWindow::applyTuneRequest(SliceModel* slice, double mhz,
                                   TuneIntent intent, const char* source)
 {
@@ -9782,6 +9844,42 @@ void MainWindow::applyTuneRequest(SliceModel* slice, double mhz,
 
     if (slice->sliceId() == m_activeSliceId && sw)
         sw->setVfoFrequency(mhz);
+
+    const BandStackPreselectResult bandPreselect =
+        (intent == TuneIntent::CommandedTargetCenter)
+            ? preselectBandStackForTune(slice, mhz, source)
+            : BandStackPreselectResult::NotNeeded;
+    if (bandPreselect == BandStackPreselectResult::Unsupported) {
+        if (slice->sliceId() == m_activeSliceId && sw)
+            sw->setVfoFrequency(oldFreqMhz);
+        return;
+    }
+
+    if (bandPreselect == BandStackPreselectResult::Selected) {
+        const int sliceId = slice->sliceId();
+        const QString sourceName = QString::fromUtf8(source ? source : "");
+        QTimer::singleShot(250, this, [this, sliceId, mhz, sourceName, oldFreqMhz]() {
+            auto* pendingSlice = m_radioModel.slice(sliceId);
+            if (!pendingSlice || pendingSlice->isLocked() || m_swrSweep.running)
+                return;
+            if (pendingSlice->sliceId() == m_activeSliceId) {
+                if (auto* pendingSw = spectrumForSlice(pendingSlice))
+                    pendingSw->setVfoFrequency(mhz);
+            }
+            pendingSlice->tuneAndRecenter(mhz);
+            mirrorDiversityChildFrequency(pendingSlice, mhz);
+
+            const QByteArray sourceUtf8 = sourceName.toUtf8();
+            const char* delayedSource = sourceUtf8.constData();
+            const TuneCenteringResult result =
+                revealFrequencyIfNeeded(pendingSlice, mhz,
+                                        TuneIntent::CommandedTargetCenter,
+                                        delayedSource);
+            logTunePolicyDecision(delayedSource, TuneIntent::CommandedTargetCenter,
+                                  oldFreqMhz, mhz, result);
+        });
+        return;
+    }
 
     slice->setFrequency(mhz);
     mirrorDiversityChildFrequency(slice, mhz);
@@ -11155,7 +11253,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
     // ── Band selection ───────────────────────────────────────────────────
     connect(menu, &SpectrumOverlayMenu::bandSelected,
-            this, [this, applet](const QString& bandName, double freqMhz, const QString& mode) {
+            this, [this, applet](const QString& bandName, double freqMhz, const QString& mode,
+                                 const QString& stackKeyHint) {
         qDebug() << "MainWindow: switching to band" << bandName
                  << "freq:" << freqMhz << "mode:" << mode;
 
@@ -11179,15 +11278,25 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         //     (0-based), not the radio's 1-based setup-order field (#2342).
         //   - WWV / GEN use numeric band-stack slots 33 / 34 from SmartSDR
         //     capture history (#1540/#1211).
+        //   - Built-in 4m / 2m hardware bands use bare keys "4" / "2" only
+        //     when the connected model reports those capabilities.
+        //   - Configured XVTR buttons also pass explicit X<n> keys so a
+        //     user XVTR named "4m" can still be selected on a radio that
+        //     also has native 4m hardware.
         //
-        // If no exact mapping exists, refuse the band change and leave the
+        // If no supported mapping exists, refuse the band change and leave the
         // current slice/pan state untouched. Guessing is worse than failing
         // visibly because a wrong tune destroys the very band-stack state this
         // path exists to preserve.
         const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
-        const auto stackKeyResult = XvtrPolicy::resolveBandStackKey(bandName, xvtrs);
-        const QString stackKey = stackKeyResult.key;
-        QString unsupportedBandReason = stackKeyResult.unsupportedReason;
+        QString stackKey = stackKeyHint;
+        QString unsupportedBandReason;
+        if (stackKey.isEmpty()) {
+            const auto stackKeyResult =
+                XvtrPolicy::resolveBandStackKey(bandName, xvtrs, m_radioModel.capabilities());
+            stackKey = stackKeyResult.key;
+            unsupportedBandReason = stackKeyResult.unsupportedReason;
+        }
 
         if (stackKey.isEmpty()) {
             qCWarning(lcProtocol).noquote().nospace()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -147,6 +147,12 @@ private:
         RevealOffscreen,
     };
 
+    enum class BandStackPreselectResult {
+        NotNeeded,
+        Selected,
+        Unsupported,
+    };
+
     struct TuneCenteringResult {
         double oldCenterMhz{0.0};
         double newCenterMhz{0.0};
@@ -178,6 +184,8 @@ private:
     SliceModel* activeSlice() const;
     static const char* tuneIntentName(TuneIntent intent);
     bool panFollowEnabled() const;
+    BandStackPreselectResult preselectBandStackForTune(SliceModel* slice, double mhz,
+                                                       const char* source);
     void applyTuneRequest(SliceModel* slice, double mhz,
                           TuneIntent intent, const char* source);
     void applyPanRangeRequest(const QString& panId, double centerMhz,

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1,5 +1,6 @@
 #include "RxApplet.h"
 #include "FilterPassbandWidget.h"
+#include "FrequencyEntryParser.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "SliceColorManager.h"
@@ -465,16 +466,14 @@ void RxApplet::buildUI()
         connect(m_freqEdit, &QLineEdit::returnPressed, this, [this] {
             const QString text = m_freqEdit->text().trimmed();
             if (!text.isEmpty() && m_slice) {
-                QString clean = text;
-                int firstDot = clean.indexOf('.');
-                if (firstDot >= 0) {
-                    clean = clean.left(firstDot) + "." + clean.mid(firstDot + 1).remove('.');
-                }
+                QString clean = FrequencyEntryParser::normalizedMhzText(text);
                 bool ok = false;
                 double freqMhz = clean.toDouble(&ok);
+                const bool explicitMhzEntry = FrequencyEntryParser::isExplicitMhzEntry(text, clean);
                 const bool onXvtr = m_slice &&
                     (m_slice->rxAntenna().startsWith("XVT") || m_slice->frequency() > 54.0);
-                const double maxMhz = onXvtr ? 50000.0 : 54.0;
+                const bool highExplicitMhzEntry = ok && explicitMhzEntry && freqMhz > 54.0;
+                const double maxMhz = (onXvtr || highExplicitMhzEntry) ? 50000.0 : 54.0;
                 if (onXvtr) {
                     // 3-digit-band convenience (2m/70cm): 1446 → 144.6.
                     // Skip for 23cm/microwave — 1296 means 1296 MHz.
@@ -487,12 +486,12 @@ void RxApplet::buildUI()
                             freqMhz = clean.toDouble(&ok);
                         }
                     }
-                } else {
+                } else if (!highExplicitMhzEntry) {
                     if (ok && freqMhz > 54000.0) freqMhz /= 1e6;
                     else if (ok && freqMhz > 54.0) freqMhz /= 1e3;
                 }
                 if (ok && freqMhz >= 0.001 && freqMhz <= maxMhz)
-                    m_slice->tuneAndRecenter(freqMhz);
+                    emit directEntryCommitted(freqMhz, QStringLiteral("rx-direct-entry"));
             }
             m_freqStack->setCurrentIndex(0);
         });

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -112,6 +112,7 @@ signals:
     void autoSqlMarginDbChanged(int dB);
     // Emitted when the radio reports a squelch state change (for spectrum line).
     void squelchStateChanged(bool on, int level);
+    void directEntryCommitted(double mhz, const QString& source);
 
 #ifdef HAVE_RADE
     // Emitted when user selects/deselects RADE digital voice mode

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1469,9 +1469,10 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
         btn->setStyleSheet(xvtrBtnStyle);
         const double freq = bands[i].rfFreqMhz;
         const QString name = bands[i].name;
-        connect(btn, &QPushButton::clicked, this, [this, name, freq]() {
+        const QString stackKey = bands[i].stackKey;
+        connect(btn, &QPushButton::clicked, this, [this, name, freq, stackKey]() {
             hideAllSubPanels();
-            emit bandSelected(name, freq, "USB");
+            emit bandSelected(name, freq, "USB", stackKey);
         });
         grid->addWidget(btn, row + i / 3, i % 3);
         m_xvtrBandBtns.append(btn);
@@ -1561,8 +1562,9 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
 
         const double freq = xvtr.rfFreqMhz;
         const QString name = xvtr.name;
-        connect(btn, &QPushButton::clicked, this, [this, name, freq]() {
-            emit bandSelected(name, freq, "FM");
+        const QString stackKey = xvtr.stackKey;
+        connect(btn, &QPushButton::clicked, this, [this, name, freq, stackKey]() {
+            emit bandSelected(name, freq, "FM", stackKey);
             m_xvtrPanel->hide();
             m_xvtrPanelVisible = false;
         });

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -68,7 +68,7 @@ public:
     void syncNoiseFloorPosition(int pos);
 
     // Populate XVTR band sub-panel
-    struct XvtrBand { QString name; double rfFreqMhz; };
+    struct XvtrBand { QString name; double rfFreqMhz; QString stackKey; };
     void setXvtrBands(const QVector<XvtrBand>& bands);
 
     // Surface the connected radio's built-in transverter bands (4m on
@@ -118,8 +118,11 @@ signals:
     void wfColorSchemeChanged(int scheme);
     void noiseFloorPositionChanged(int pos);
     void noiseFloorEnableChanged(bool on);
-    // Emitted when user selects a band from the sub-panel.
-    void bandSelected(const QString& bandName, double freqMhz, const QString& mode);
+    // Emitted when user selects a band from the sub-panel.  stackKeyHint is
+    // populated only when the clicked control already knows the exact Flex
+    // band-stack key, such as a configured XVTR button.
+    void bandSelected(const QString& bandName, double freqMhz, const QString& mode,
+                      const QString& stackKeyHint = {});
     // Emitted when user clicks XVTR button to open Radio Setup XVTR tab.
     void xvtrSetupRequested();
     // Emitted when WNB toggle changes.

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1,6 +1,7 @@
 #include "VfoWidget.h"
 #include "PhaseKnob.h"
 #include "ComboStyle.h"
+#include "FrequencyEntryParser.h"
 #include "GuardedSlider.h"
 #include "RxApplet.h"
 #include "SliceColorManager.h"
@@ -571,21 +572,16 @@ void VfoWidget::buildUI()
             double freqMhz = 0.0;
 
             // Try parsing as MHz (e.g. "14.225", "14.225.000", "14225", "14225.0")
-            QString clean = text;
-            // Handle "14.225.000" format — remove dots beyond the first
-            int firstDot = clean.indexOf('.');
-            if (firstDot >= 0) {
-                QString beforeDot = clean.left(firstDot);
-                QString afterDot = clean.mid(firstDot + 1).remove('.');
-                clean = beforeDot + "." + afterDot;
-            }
+            QString clean = FrequencyEntryParser::normalizedMhzText(text);
             freqMhz = clean.toDouble(&ok);
+            const bool explicitMhzEntry = FrequencyEntryParser::isExplicitMhzEntry(text, clean);
 
             // If value looks like Hz or kHz (> 54 MHz is out of HF range)
             // Context-aware parsing: on XVTR bands, accept higher freqs
             const bool onXvtr = m_slice &&
                 (m_slice->rxAntenna().startsWith("XVT") || m_slice->frequency() > 54.0);
-            const double maxMhz = onXvtr ? 50000.0 : 54.0;
+            const bool highExplicitMhzEntry = ok && explicitMhzEntry && freqMhz > 54.0;
+            const double maxMhz = (onXvtr || highExplicitMhzEntry) ? 50000.0 : 54.0;
 
             if (onXvtr) {
                 // 3-digit-band convenience: on 2m/70cm a bare integer like
@@ -602,7 +598,7 @@ void VfoWidget::buildUI()
                         freqMhz = clean.toDouble(&ok);
                     }
                 }
-            } else {
+            } else if (!highExplicitMhzEntry) {
                 // HF: 14225 = kHz, 14225000 = Hz
                 if (ok && freqMhz > 54000.0)
                     freqMhz /= 1e6;

--- a/src/models/XvtrPolicy.cpp
+++ b/src/models/XvtrPolicy.cpp
@@ -9,24 +9,30 @@ namespace AetherSDR::XvtrPolicy {
 
 namespace {
 
-bool isNativeBandKey(const QString& key)
+bool isNativeBandKey(const QString& key, ModelCapabilities caps)
 {
-    static const QSet<QString> kNativeBandKeys = {
+    static const QSet<QString> kAlwaysNativeBandKeys = {
         QStringLiteral("160"), QStringLiteral("80"), QStringLiteral("60"),
         QStringLiteral("40"),  QStringLiteral("30"), QStringLiteral("20"),
         QStringLiteral("17"),  QStringLiteral("15"), QStringLiteral("12"),
         QStringLiteral("10"),  QStringLiteral("6"),
         QStringLiteral("2200"), QStringLiteral("630")
     };
-    return kNativeBandKeys.contains(key);
+    if (kAlwaysNativeBandKeys.contains(key))
+        return true;
+    if (caps.has4Meters && key == QLatin1String("4"))
+        return true;
+    if (caps.has2Meters && key == QLatin1String("2"))
+        return true;
+    return false;
 }
 
-QString normalizedNativeBandKey(const QString& bandName)
+QString normalizedNativeBandKey(const QString& bandName, ModelCapabilities caps)
 {
     QString key = bandName;
     if (key.endsWith('m') && key.length() > 1) {
         const QString stripped = key.chopped(1);
-        if (isNativeBandKey(stripped))
+        if (isNativeBandKey(stripped, caps))
             key = stripped;
     }
     return key;
@@ -45,15 +51,16 @@ double tileCenter(double lowMhz, double highMhz)
 } // namespace
 
 BandStackKeyResult resolveBandStackKey(const QString& bandName,
-                                       const QVector<Transverter>& xvtrs)
+                                       const QVector<Transverter>& xvtrs,
+                                       ModelCapabilities caps)
 {
     static const QMap<QString, int> kNumericBandSlots = {
         { QStringLiteral("WWV"), 33 },
         { QStringLiteral("GEN"), 34 },
     };
 
-    const QString radioKey = normalizedNativeBandKey(bandName);
-    if (isNativeBandKey(radioKey))
+    const QString radioKey = normalizedNativeBandKey(bandName, caps);
+    if (isNativeBandKey(radioKey, caps))
         return {radioKey, {}};
 
     if (kNumericBandSlots.contains(bandName))

--- a/src/models/XvtrPolicy.h
+++ b/src/models/XvtrPolicy.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ModelCapabilities.h"
+
 #include <QString>
 #include <QVector>
 
@@ -38,7 +40,8 @@ struct WaterfallTileMatch {
 };
 
 BandStackKeyResult resolveBandStackKey(const QString& bandName,
-                                       const QVector<Transverter>& xvtrs);
+                                       const QVector<Transverter>& xvtrs,
+                                       ModelCapabilities caps = {});
 
 bool isWaterfallTileOutsidePan(double lowMhz, double highMhz, double panCenterMhz);
 

--- a/tests/frequency_entry_parser_test.cpp
+++ b/tests/frequency_entry_parser_test.cpp
@@ -1,0 +1,62 @@
+#include "gui/FrequencyEntryParser.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-72s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+void expectExplicitMhz(const char* label, const QString& text, bool expected)
+{
+    const QString clean = FrequencyEntryParser::normalizedMhzText(text);
+    const bool actual = FrequencyEntryParser::isExplicitMhzEntry(text, clean);
+    report(label,
+           actual == expected,
+           QStringLiteral("text=%1 clean=%2 actual=%3")
+               .arg(text, clean)
+               .arg(actual ? QStringLiteral("true") : QStringLiteral("false"))
+               .toStdString());
+}
+
+void expectNormalized(const char* label, const QString& text, const QString& expected)
+{
+    const QString actual = FrequencyEntryParser::normalizedMhzText(text);
+    report(label,
+           actual == expected,
+           QStringLiteral("text=%1 actual=%2 expected=%3")
+               .arg(text, actual, expected)
+               .toStdString());
+}
+
+} // namespace
+
+int main()
+{
+    expectNormalized("display-style entry keeps first MHz dot",
+                     QStringLiteral("440.100.000"),
+                     QStringLiteral("440.100000"));
+    expectExplicitMhz("14.225.000 is explicit MHz", QStringLiteral("14.225.000"), true);
+    expectExplicitMhz("144.200.000 is explicit MHz", QStringLiteral("144.200.000"), true);
+    expectExplicitMhz("440.100.000 is explicit MHz", QStringLiteral("440.100.000"), true);
+    expectExplicitMhz("14.225 is explicit MHz", QStringLiteral("14.225"), true);
+    expectExplicitMhz("144.200 is explicit MHz", QStringLiteral("144.200"), true);
+    expectExplicitMhz("440.100 is explicit MHz", QStringLiteral("440.100"), true);
+    expectExplicitMhz("14225.0 keeps legacy kHz-style parse",
+                      QStringLiteral("14225.0"), false);
+    expectExplicitMhz("14225 has no explicit MHz marker",
+                      QStringLiteral("14225"), false);
+
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/xvtr_policy_test.cpp
+++ b/tests/xvtr_policy_test.cpp
@@ -42,9 +42,10 @@ std::string detailFor(const XvtrPolicy::WaterfallTileRange& range)
 
 void expectBandKey(const char* label, const QString& bandName,
                    const QVector<XvtrPolicy::Transverter>& xvtrs,
-                   const QString& expectedKey)
+                   const QString& expectedKey,
+                   ModelCapabilities caps = {})
 {
-    const auto result = XvtrPolicy::resolveBandStackKey(bandName, xvtrs);
+    const auto result = XvtrPolicy::resolveBandStackKey(bandName, xvtrs, caps);
     report(label,
            result.isSupported() && result.key == expectedKey,
            QStringLiteral("key=%1 reason=%2")
@@ -105,6 +106,22 @@ void testBandStackKeysRefuseGuesses()
                           "70cm", xvtrs, "has no Flex display pan band= mapping");
     expectUnsupportedBand("unknown band does not use freq/mode fallback",
                           "1.2G", xvtrs, "has no Flex display pan band= mapping");
+}
+
+void testBandStackKeysUseNativeVhfOnlyWhenCapable()
+{
+    const QVector<XvtrPolicy::Transverter> xvtrs = {
+        xvtr(12, 3, "2m", 144.0, 28.0),
+    };
+
+    expectBandKey("FLEX-6700 native 2m strips UI suffix",
+                  "2m", {}, "2", {false, true});
+    expectBandKey("FLEX-6500/6700 native 4m strips UI suffix",
+                  "4m", {}, "4", {true, false});
+    expectBandKey("native 2m wins over same-named XVTR on capable radio",
+                  "2m", xvtrs, "2", {false, true});
+    expectBandKey("without 2m capability, same-named XVTR still resolves",
+                  "2m", xvtrs, "X12");
 }
 
 void testHfWaterfallDoesNotShiftWhenTileLagsByOneSpan()
@@ -222,6 +239,7 @@ int main()
 {
     testBandStackKeysUseFlexIndex();
     testBandStackKeysRefuseGuesses();
+    testBandStackKeysUseNativeVhfOnlyWhenCapable();
     testHfWaterfallDoesNotShiftWhenTileLagsByOneSpan();
     testXvtrWaterfallMapsIfToRfBands();
     testXvtrWaterfallGuardrails();


### PR DESCRIPTION
## Summary

Fixes FLEX-6500/6700 built-in 4m/2m band routing and direct frequency entry above 54 MHz.

- Teach `XvtrPolicy` to resolve `4m -> band=4` and `2m -> band=2` only when `ModelCapabilities` reports native 4m/2m support.
- Preserve user-configured XVTR behavior on other radios, including XVTRs named `2m` or `4m`.
- Make configured XVTR buttons carry their exact `X<n>` stack key so native 4m does not shadow a user XVTR named `4m`.
- Centralize direct-entry MHz detection in `FrequencyEntryParser` so the VFO widget and RX applet keep the same parsing rules.
- Treat display-style direct entries such as `144.200.000` and `440.100.000` as MHz and preselect the proper band stack before tuning above 54 MHz.
- Route RX applet direct-entry through the same `MainWindow` tune policy as the VFO widget.

## Notes

The FLEX-6700 SmartSDR wire capture in #695 confirms native keys `band=4` for 4m and `band=2` for 2m. I did not add a native 440/70cm key; direct 440 MHz still requires a radio-reported configured XVTR.

## Verification

- `cmake --build build --parallel`
- `./build/xvtr_policy_test`
- `./build/frequency_entry_parser_test`
- `ctest --test-dir build -R "model_capabilities_test|frequency_entry_parser_test" --output-on-failure`
- `git diff --check`