### PR TITLE
feat(slice): add cycle_tx_slice shortcut action for FlexKnob/MIDI/keyboard

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -12514,6 +12514,16 @@ void MainWindow::registerShortcutActions()
                 disableSplit();
             }
         });
+    m_shortcutManager.registerAction("cycle_tx_slice", "Cycle TX Slice", "Slice",
+        QKeySequence(), [this]() {
+            const auto slices = m_radioModel.slices();
+            if (slices.size() <= 1) return;
+            int txIdx = 0;
+            for (int i = 0; i < slices.size(); ++i) {
+                if (slices[i]->isTxSlice()) { txIdx = i; break; }
+            }
+            slices[(txIdx + 1) % slices.size()]->setTxSlice(true);
+        });
 
     // ── Filter ──────────────────────────────────────────────────────────
     // Step through the per-mode preset list via RxApplet so LSB/CWL/DIGL/RTTY


### PR DESCRIPTION
Registers a new ShortcutManager action "cycle_tx_slice" in the Slice category with no default key binding.  On each invocation the action advances the TX-designated slice one position forward through the currently-open owned-slice list (wrapping from last back to first).

--- How it works ---

SliceModel::setTxSlice(true) sends "slice set N tx=1" to the radio. The FLEX firmware handles exclusive TX assignment server-side: marking slice N as TX causes the radio to clear tx=0 on every other slice and broadcast the updated state to all connected clients.  No client-side cleanup of the old TX slice is required.

The action is a no-op when only one slice is open (nothing to cycle to).

--- Intended use cases ---

* FlexKnob (FlexControl) programmable button — bind via the FlexControl binding dialog.  Common workflow: operator running two slices (e.g. DIGU on 40 m for FT8 + SSB on 20 m for phone) and wants a single physical button to hand off TX between them without reaching for the mouse.

* MIDI controller — bind via the MIDI binding dialog.  Same operator workflow; foot-switch or panel button.

* Keyboard — optionally assign a key in ShortcutDialog for keyboard- centric operators.

--- Design notes ---

Cycles in owned-slice-list order (the order slices were created / the order RadioModel::slices() returns them), which is deterministic and predictable.  With two slices this is effectively a toggle.  With three or more it advances A→B→C→A.  Split mode is not blocked; calling setTxSlice on either split leg is valid protocol.

@AetherClaude any worries for the larger slice selection radios like the 6700?