### PR TITLE
[ux] Suppress interlock error dialogs

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8819,9 +8819,13 @@ void MainWindow::onRadioMessage(const QString& text, MessageSeverity severity)
     // client notices that the radio sends on every connect / disconnect —
     // they're documented as silent-log in SmartSDR.  Show a status-bar
     // toast instead of a modal popup so the operator notices without an
-    // interruptive dialog.  Warnings, errors, and fatals are user-actionable
-    // and continue to surface as modal QMessageBox to preserve PR #2771's
-    // intent for FreeDV/ATU/interlock conflicts.  See #2785 for context.
+    // interruptive dialog.  Interlock M-messages are log-only here because
+    // the interlock status path already surfaces actionable TX blocks over
+    // the panadapter/waterfall.  Other warnings, errors, and fatals are
+    // user-actionable and continue to surface as modal QMessageBox to preserve
+    // PR #2771's intent for FreeDV/ATU conflicts.  See #2785 for context.
+    const bool interlockMessage = text.contains(QStringLiteral("interlock"),
+                                                Qt::CaseInsensitive);
     switch (severity) {
     case MessageSeverity::Info:
         qCInfo(lcGui) << "Radio M-message [Info]:" << text;
@@ -8830,14 +8834,20 @@ void MainWindow::onRadioMessage(const QString& text, MessageSeverity severity)
         break;
     case MessageSeverity::Warning:
         qCWarning(lcGui) << "Radio M-message [Warning]:" << text;
+        if (interlockMessage)
+            break;
         QMessageBox::warning(this, tr("Radio"), text);
         break;
     case MessageSeverity::Error:
         qCCritical(lcGui) << "Radio M-message [Error]:" << text;
+        if (interlockMessage)
+            break;
         QMessageBox::critical(this, tr("Radio — Error"), text);
         break;
     case MessageSeverity::Fatal:
         qCCritical(lcGui) << "Radio M-message [Fatal]:" << text;
+        if (interlockMessage)
+            break;
         QMessageBox::critical(this, tr("Radio — Fatal"), text);
         break;
     }


### PR DESCRIPTION

<img width="1464" height="1523" alt="IMG_2049" src="https://github.com/user-attachments/assets/5ca58f8b-3caf-4c37-bff0-00b8b0824beb" />

## Summary
- Suppress generic modal dialogs for interlock radio M-messages in the main radio message handler.
- Leave the existing interlock panadapter/waterfall notification path as the operator-facing surface for TX interlock blocks.
- Preserve modal dialogs for non-interlock warning/error/fatal radio messages.

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build --parallel 22`
- Launched `/Users/patj/Documents/AetherSDR/.worktrees/interlock-modal-suppression/build/AetherSDR.app`
- `git diff --check`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat