### PR TITLE
[regression] Restore XVTR validity guard for waterfall remapping

### DIFF
--- a/src/models/XvtrPolicy.cpp
+++ b/src/models/XvtrPolicy.cpp
@@ -93,7 +93,7 @@ WaterfallTileMatch matchWaterfallTileTransverterOffset(double lowMhz, double hig
     match.observedOffsetMhz = panCenterMhz - tileCenter(lowMhz, highMhz);
     match.toleranceMhz = std::max(bw, 0.25);
     for (const auto& xvtr : xvtrs) {
-        if (xvtr.rfFreqMhz <= 0.0 || xvtr.ifFreqMhz <= 0.0)
+        if (!xvtr.isValid || xvtr.rfFreqMhz <= 0.0 || xvtr.ifFreqMhz <= 0.0)
             continue;
 
         const double expectedOffset = xvtr.rfFreqMhz - xvtr.ifFreqMhz;

--- a/tests/xvtr_policy_test.cpp
+++ b/tests/xvtr_policy_test.cpp
@@ -187,14 +187,14 @@ void testXvtrWaterfallMapsIfToRfBands()
 
 void testXvtrWaterfallGuardrails()
 {
-    const QVector<XvtrPolicy::Transverter> unvalidatedXvtr = {
+    const QVector<XvtrPolicy::Transverter> invalidXvtr = {
         xvtr(12, 3, "2m", 144.0, 28.0, false),
     };
 
-    const auto unvalidated = XvtrPolicy::mapWaterfallTileRange(
-        28.125, 28.625, 144.375, unvalidatedXvtr, false);
-    expectRange("unvalidated XVTR with RF/IF offset maps waterfall range",
-                unvalidated, 144.125, 144.625, true);
+    const auto invalid = XvtrPolicy::mapWaterfallTileRange(
+        28.125, 28.625, 144.375, invalidXvtr, false);
+    expectRange("invalid XVTR does not trigger IF/RF waterfall shift",
+                invalid, 28.125, 28.625, false);
 
     const QVector<XvtrPolicy::Transverter> missingIfXvtr = {
         xvtr(12, 3, "2m", 144.0, 0.0, false),


### PR DESCRIPTION
## Summary

Restore the XVTR validity guard before waterfall IF/RF offset remapping.

## Root Cause

PR #2709 allowed waterfall tile ranges to be remapped when a transverter entry had matching RF/IF frequencies even if the XVTR entry was not marked valid. That widened the passive waterfall remap path beyond the set of confirmed radio XVTR profiles and could shift ordinary waterfall rows incorrectly.

## Changes

- Require `xvtr.isValid` before `matchWaterfallTileTransverterOffset` accepts an RF/IF offset match.
- Keep the existing RF and IF frequency guardrails in place.
- Update XVTR policy coverage so invalid XVTR entries no longer authorize IF/RF waterfall shifts.

## Validation

- `./build-ninja/xvtr_policy_test`
- `cmake --build build-ninja --target AetherSDR --parallel 22`
- Launched the built app from `build-ninja/AetherSDR.app`

Built app: `/Users/patj/Documents/AetherSDR/.worktrees/revert-pr-2709-xvtr-waterfall/build-ninja/AetherSDR.app`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
