### PR TITLE
fix(midi): MIDI tx.mox toggle reads isTransmitting() not isMox()

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -14623,7 +14623,7 @@ void MainWindow::registerMidiParams()
 
     reg("tx.mox", "MOX", "TX", P::Toggle, 0, 1,
         [this](float v) { m_radioModel.setTransmit(v > 0.5f); },
-        [this]() -> float { return m_radioModel.transmitModel().isMox() ? 1 : 0; });
+        [this]() -> float { return m_radioModel.transmitModel().isTransmitting() ? 1 : 0; });
 
     reg("tx.tune", "TUNE", "TX", P::Toggle, 0, 1,
         [this](float v) {


### PR DESCRIPTION
Fixes #2858

## Root Cause
The MIDI toggle sentinel reads the getter, flips it, then calls the setter. The `tx.mox` getter used `transmitModel().isMox()` which reads `m_mox`. Per the SmartSDR protocol spec (v1.4.0.0), **the radio never sends `mox=` in transmit status messages**, so `m_mox` is always `false`. The getter therefore always returns 0, the toggle always computes 1, and `setTransmit(true)` is called on every press — stuck in TX on Linux/Pi.

## Fix
One-line change: `tx.mox` MIDI getter changed from `isMox()` to `isTransmitting()`. `isTransmitting()` is set optimistically by `setTransmit()` the moment the command is sent, so it correctly reflects toggle state immediately.

The FlexControl path at MainWindow.cpp:3545 already used `isTransmitting()` correctly — this brings the MIDI path into line.

## Test Plan
- [ ] MIDI button mapped to MOX: press once → TX on, press again → TX off
- [ ] Verified on Linux/Pi where `isMox()` was always `false`
- [ ] No regression on Windows FlexControl toggle path