### PR TITLE
fix(rade): restore slice state when RADE engine fails to start

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -13878,6 +13878,7 @@ void MainWindow::activateRADE(int sliceId)
             break;
         }
     }
+    const QString prevMode = s->mode();
     s->setMode(mode);
     if (mode == "DIGL")
         s->setFilterWidth(-3500, 0);
@@ -13911,7 +13912,10 @@ void MainWindow::activateRADE(int sliceId)
         ok = m_radeEngine->start();
     }, Qt::BlockingQueuedConnection);
     if (!ok) {
-        qWarning() << "MainWindow: failed to start RADE engine";
+        qCWarning(lcRade) << "MainWindow: RADE engine failed to start — restoring slice state";
+        deactivateRADE();
+        if (auto* sl = m_radioModel.slice(sliceId))
+            sl->setMode(prevMode);
         return;
     }
     m_radioModel.setDigitalVoiceTxSlice(sliceId);


### PR DESCRIPTION
## Summary

When `RADEEngine::start()` fails (e.g. `rade_open()` or `lpcnet_encoder_create()` returns null), `activateRADE()` previously returned bare without cleanup, leaving the slice in a broken half-initialized state:

- Mode stuck at DIGU/DIGL — not reverted
- `audio_mute=1` sent to radio — not restored
- `m_radeSliceId` set — not cleared
- `m_radeEngine` allocated with a running idle thread — not torn down
- `m_digitalVoiceTxSliceId` **never** set (that line comes after `start()`)

The practical result: every PTT attempt hit the DIGU/DIGL voice transmit guard (`localPttInterlockMessage` / `radioInterlockNotificationMessage BAD_MODE`) with no user-visible indication of why, and no recovery path short of manually changing the slice mode.

## Changes

**`src/gui/MainWindow.cpp` — `activateRADE()` only**

- Save `prevMode = s->mode()` before `setMode(DIGU/DIGL)` so the failure path can restore it.
- On `!ok`: call `deactivateRADE()` instead of bare `return`. `deactivateRADE()` already handles null `m_rade` safely — `RADEEngine::stop()` returns immediately on `if (!m_rade) return`, so the blocking invocation is near-zero cost. It restores `audio_mute` via `m_radePrevMute`, clears `m_radeSliceId`, and tears down the engine and thread cleanly.
- After `deactivateRADE()`, restore `prevMode` so the slice returns to its pre-RADE mode rather than stranding the user in DIGU/DIGL.
- Change `qWarning()` → `qCWarning(lcRade)` so the failure is visible in the `aether.rade` support bundle category where it is actionable.

## Relation to issue #2856

This fix was identified while triaging [#2856](https://github.com/ten9876/AetherSDR/issues/2856) (RADE unusable on FLEX-6400M fw 4.13 — "cannot transmit in DIGI mode"). The stranded-state symptom described there is consistent with this code path. However, we cannot confirm this is the root cause of #2856 — RADE engine startup succeeds in our test environment (Windows, FLEX-8400, fw 4.2.x) and the reporter has not yet provided a support bundle with RADE logging enabled. **Do not close #2856 based on this PR.** That issue remains open awaiting the reporter's log.

This cleanup gap is a latent bug independently of #2856 and warrants fixing regardless of what the reporter's bundle ultimately shows.

## Test plan

- [x] Happy path: connect to radio, select RADE normally — no behavior change, waveform and RF output confirmed
- [x] Failure simulation: temporarily returned `false` from `RADEEngine::start()`, selected RADE — slice mode reverted to pre-RADE mode, audio unmuted, no transmit block, `aether.rade` log shows `RADE engine failed to start — restoring slice state`
- [x] Re-entry after failure: selected RADE a second time immediately after a failed attempt — clean re-entry with no leftover state from the first attempt

🤖 Generated with [Claude Code](https://claude.ai/claude-code)