### PR TITLE
Sync panadapter RX antenna status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1310,6 +1310,18 @@ target_include_directories(slice_model_letter_test PRIVATE src)
 target_link_libraries(slice_model_letter_test PRIVATE Qt6::Core Qt6::Test)
 add_test(NAME slice_model_letter_test COMMAND slice_model_letter_test)
 
+add_executable(panadapter_model_rx_antenna_test
+    tests/panadapter_model_rx_antenna_test.cpp
+    src/models/PanadapterModel.cpp
+    src/core/PerfTelemetry.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(panadapter_model_rx_antenna_test PRIVATE src)
+target_link_libraries(panadapter_model_rx_antenna_test PRIVATE Qt6::Core Qt6::Test)
+add_test(NAME panadapter_model_rx_antenna_test COMMAND panadapter_model_rx_antenna_test)
+
 add_executable(packet_loss_concealment_test
     tests/packet_loss_concealment_test.cpp
     src/core/PacketLossConcealment.cpp

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -304,13 +304,19 @@ void SpectrumOverlayMenu::buildAntPanel()
 
     connect(m_rxAntCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, [this](int index) {
-        if (m_updatingFromModel || !m_slice || index < 0)
+        if (m_updatingFromModel || index < 0)
             return;
         QString ant = m_rxAntCmb->itemData(index).toString();
         if (ant.isEmpty())
             ant = m_rxAntCmb->itemText(index);
-        if (!ant.isEmpty())
+        if (ant.isEmpty())
+            return;
+        if (m_radioModel && !m_panId.isEmpty()) {
+            m_radioModel->sendCommand(
+                QStringLiteral("display pan set %1 rxant=%2").arg(m_panId, ant));
+        } else if (m_slice) {
             m_slice->setRxAntenna(ant);
+        }
     });
 
     // RF Gain row
@@ -355,7 +361,7 @@ void SpectrumOverlayMenu::buildAntPanel()
         if (!m_updatingFromModel && snapped != m_lastEmittedRfGain) {
             m_lastEmittedRfGain = snapped;
             emit rfGainChanged(snapped);
-            if (m_slice)
+            if ((!m_radioModel || m_panId.isEmpty()) && m_slice)
                 m_slice->setRfGain(static_cast<float>(snapped));
         }
     });
@@ -421,7 +427,7 @@ void SpectrumOverlayMenu::buildAntPanel()
     });
 
     // ANT panel tooltips
-    m_rxAntCmb->setToolTip("Select the receive antenna port for this slice.");
+    m_rxAntCmb->setToolTip("Select the receive antenna port for this panadapter.");
     m_rfGainSlider->setToolTip("Adjusts receiver IF gain. Lower values reduce strong-signal overload.");
     m_wnbBtn->setToolTip("Wideband noise blanker \u2014 suppresses correlated impulse noise across the full panadapter bandwidth.");
     m_wnbSlider->setToolTip("Adjusts WNB threshold. Higher values blank more aggressively.");
@@ -438,25 +444,72 @@ void SpectrumOverlayMenu::setAntennaList(const QStringList& ants)
     refreshAntennaCombo();
 }
 
+void SpectrumOverlayMenu::setPanId(const QString& id)
+{
+    if (m_panId == id)
+        return;
+    m_panId = id;
+    wirePanadapterRxAntenna();
+    refreshAntennaCombo();
+}
+
 void SpectrumOverlayMenu::setRadioModel(RadioModel* model)
 {
     if (m_radioModel)
         disconnect(m_radioModel, &RadioModel::antennaAliasesChanged,
                    this, &SpectrumOverlayMenu::refreshAntennaCombo);
+    if (m_panRxAntennaConnection) {
+        disconnect(m_panRxAntennaConnection);
+        m_panRxAntennaConnection = {};
+    }
+    m_panadapter = nullptr;
     m_radioModel = model;
     if (m_radioModel) {
         connect(m_radioModel, &RadioModel::antennaAliasesChanged,
                 this, &SpectrumOverlayMenu::refreshAntennaCombo);
     }
+    wirePanadapterRxAntenna();
     refreshAntennaCombo();
+}
+
+void SpectrumOverlayMenu::wirePanadapterRxAntenna()
+{
+    if (m_panRxAntennaConnection) {
+        disconnect(m_panRxAntennaConnection);
+        m_panRxAntennaConnection = {};
+    }
+    m_panadapter = nullptr;
+
+    if (!m_radioModel || m_panId.isEmpty())
+        return;
+
+    m_panadapter = m_radioModel->panadapter(m_panId);
+    if (!m_panadapter)
+        return;
+
+    m_panRxAntennaConnection =
+        connect(m_panadapter, &PanadapterModel::rxAntennaChanged,
+                this, [this](const QString& ant) {
+        m_updatingFromModel = true;
+        setRxAntennaComboToken(ant);
+        m_updatingFromModel = false;
+    });
+}
+
+QString SpectrumOverlayMenu::currentRxAntennaToken() const
+{
+    if (m_panadapter && !m_panadapter->rxAntenna().isEmpty())
+        return m_panadapter->rxAntenna();
+    if (m_slice)
+        return m_slice->rxAntenna();
+    return m_rxAntCmb ? m_rxAntCmb->currentData().toString() : QString();
 }
 
 void SpectrumOverlayMenu::refreshAntennaCombo()
 {
     if (!m_rxAntCmb)
         return;
-    const QString cur = m_slice ? m_slice->rxAntenna()
-                                : m_rxAntCmb->currentData().toString();
+    const QString cur = currentRxAntennaToken();
     QSignalBlocker sb(m_rxAntCmb);
     m_rxAntCmb->clear();
     for (const QString& ant : m_antList) {
@@ -490,12 +543,16 @@ void SpectrumOverlayMenu::setSlice(SliceModel* slice)
     if (!m_slice) return;
 
     connect(m_slice, &SliceModel::rxAntennaChanged, this, [this](const QString& ant) {
+        if (m_panadapter && !m_panadapter->rxAntenna().isEmpty())
+            return;
         m_updatingFromModel = true;
         setRxAntennaComboToken(ant);
         m_updatingFromModel = false;
     });
 
     connect(m_slice, &SliceModel::rfGainChanged, this, [this](float gain) {
+        if (m_panadapter)
+            return;
         m_updatingFromModel = true;
         QSignalBlocker sb(m_rfGainSlider);
         m_rfGainSlider->setValue(static_cast<int>(gain));
@@ -514,14 +571,16 @@ void SpectrumOverlayMenu::setSlice(SliceModel* slice)
 
 void SpectrumOverlayMenu::syncAntPanel()
 {
-    if (!m_slice) return;
+    if (!m_slice && !m_panadapter) return;
     m_updatingFromModel = true;
-    setRxAntennaComboToken(m_slice->rxAntenna());
+    setRxAntennaComboToken(currentRxAntennaToken());
+    const int gain = m_panadapter ? m_panadapter->rfGain()
+                                  : static_cast<int>(m_slice->rfGain());
     {
         QSignalBlocker sb(m_rfGainSlider);
-        m_rfGainSlider->setValue(static_cast<int>(m_slice->rfGain()));
+        m_rfGainSlider->setValue(gain);
     }
-    m_rfGainLabel->setText(QString("%1 dB").arg(static_cast<int>(m_slice->rfGain())));
+    m_rfGainLabel->setText(QString("%1 dB").arg(gain));
     m_updatingFromModel = false;
 }
 

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -56,7 +56,7 @@ public:
                                   int freqGridSpacingKhz = 0);
 
     // Set the panadapter ID this overlay belongs to (for +RX routing).
-    void setPanId(const QString& id) { m_panId = id; }
+    void setPanId(const QString& id);
     QString panId() const { return m_panId; }
 
     // Connect/disconnect the ANT panel to a slice model.
@@ -139,6 +139,8 @@ signals:
 
 private:
     QString m_panId;
+    QPointer<PanadapterModel> m_panadapter;
+    QMetaObject::Connection m_panRxAntennaConnection;
     void toggle();
     void updateLayout();
     void toggleBandPanel();
@@ -155,8 +157,10 @@ private:
     void hideAllSubPanels();
     void showBandPanelAt(const QPoint& pos);
     void syncAntPanel();
+    void wirePanadapterRxAntenna();
     void refreshAntennaCombo();
     void setRxAntennaComboToken(const QString& token);
+    QString currentRxAntennaToken() const;
 
     static constexpr int kBtnAddRx = 0;
     static constexpr int kBtnAddTnf = 1;

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -113,6 +113,13 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
             emit antListChanged(m_antList);
         }
     }
+    if (kvs.contains("rxant")) {
+        const QString ant = kvs["rxant"];
+        if (ant != m_rxAntenna) {
+            m_rxAntenna = ant;
+            emit rxAntennaChanged(m_rxAntenna);
+        }
+    }
     if (kvs.contains("waterfall")) {
         setWaterfallId(kvs["waterfall"]);
     }

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -31,6 +31,7 @@ public:
     float minDbm() const { return m_minDbm; }
     float maxDbm() const { return m_maxDbm; }
     QStringList antList() const { return m_antList; }
+    QString rxAntenna() const { return m_rxAntenna; }
     int rfGain() const { return m_rfGain; }
     int rfGainLow() const { return m_rfGainLow; }
     int rfGainHigh() const { return m_rfGainHigh; }
@@ -65,6 +66,7 @@ signals:
     void infoChanged(double centerMhz, double bandwidthMhz);
     void levelChanged(float minDbm, float maxDbm);
     void antListChanged(const QStringList& ants);
+    void rxAntennaChanged(const QString& ant);
     void rfGainChanged(int gain);
     void rfGainInfoChanged(int low, int high, int step);
     void wnbChanged(bool active, int level);
@@ -85,6 +87,7 @@ private:
     float       m_minDbm{-130.0f};
     float       m_maxDbm{-40.0f};
     QStringList m_antList;
+    QString     m_rxAntenna;
     int         m_rfGain{0};
     int         m_rfGainLow{-8};
     int         m_rfGainHigh{32};

--- a/tests/panadapter_model_rx_antenna_test.cpp
+++ b/tests/panadapter_model_rx_antenna_test.cpp
@@ -1,0 +1,65 @@
+#include "models/PanadapterModel.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QString>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+
+#define EXPECT_EQ(actual, expected) do { \
+    auto a_ = (actual); auto e_ = (expected); \
+    if (a_ != e_) { \
+        const QString a_str = QString("%1").arg(a_); \
+        const QString e_str = QString("%1").arg(e_); \
+        std::fprintf(stderr, "FAIL %s:%d  expected %s, got %s\n", \
+                     __FILE__, __LINE__, \
+                     e_str.toUtf8().constData(), \
+                     a_str.toUtf8().constData()); \
+        ++g_failures; \
+    } \
+} while (0)
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    PanadapterModel pan(QStringLiteral("0x40000000"));
+    QSignalSpy spy(&pan, &PanadapterModel::rxAntennaChanged);
+
+    pan.applyPanStatus({{QStringLiteral("rxant"), QStringLiteral("ANT1")}});
+    EXPECT_EQ(pan.rxAntenna(), QStringLiteral("ANT1"));
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("ANT1"));
+
+    pan.applyPanStatus({{QStringLiteral("rxant"), QStringLiteral("ANT1")}});
+    EXPECT_EQ(spy.count(), 0);
+
+    pan.applyPanStatus({{QStringLiteral("rxant"), QStringLiteral("RX_A")}});
+    EXPECT_EQ(pan.rxAntenna(), QStringLiteral("RX_A"));
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("RX_A"));
+
+    QSignalSpy gainSpy(&pan, &PanadapterModel::rfGainChanged);
+    pan.applyPanStatus({{QStringLiteral("rfgain"), QStringLiteral("20")}});
+    EXPECT_EQ(pan.rfGain(), 20);
+    EXPECT_EQ(gainSpy.count(), 1);
+    EXPECT_EQ(gainSpy.takeFirst().at(0).toInt(), 20);
+
+    pan.applyPanStatus({{QStringLiteral("rfgain"), QStringLiteral("20")}});
+    EXPECT_EQ(gainSpy.count(), 0);
+
+    pan.applyPanStatus({{QStringLiteral("rfgain"), QStringLiteral("-8")}});
+    EXPECT_EQ(pan.rfGain(), -8);
+    EXPECT_EQ(gainSpy.count(), 1);
+    EXPECT_EQ(gainSpy.takeFirst().at(0).toInt(), -8);
+
+    if (g_failures == 0) {
+        std::printf("panadapter_model_rx_antenna_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("panadapter_model_rx_antenna_test: %d failure(s)\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Summary:
- track panadapter rxant status and drive overlay antenna selection from radio echo
- send overlay RX antenna changes with display pan set, matching FlexLib panadapter behavior
- keep overlay RF gain panadapter-authoritative and cover rxant/rfgain status in a focused test

Verification:
- cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
- cmake --build build -j8
- ctest --test-dir build -R panadapter_model_rx_antenna_test --output-on-failure