### PR TITLE
fix: clamp panadapter center to prevent spectrum left edge below 0 Hz (#783)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9747,6 +9747,8 @@ void MainWindow::applyPanRangeRequest(const QString& panId, double centerMhz,
     if (panId.isEmpty() || bandwidthMhz <= 0.0)
         return;
 
+    centerMhz = std::max(centerMhz, bandwidthMhz / 2.0);
+
     auto* pan = m_radioModel.panadapter(panId);
     const QString centerStr = QString::number(centerMhz, 'f', 6);
     const QString bandwidthStr = QString::number(bandwidthMhz, 'f', 6);
@@ -10507,6 +10509,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     connect(sw, &SpectrumWidget::centerChangeRequested,
             this, [this, applet](double center) {
+        if (const auto* pan = m_radioModel.panadapter(applet->panId()))
+            center = std::max(center, pan->bandwidthMhz() / 2.0);
         m_radioModel.sendCommand(
             QString("display pan set %1 center=%2").arg(applet->panId()).arg(center, 0, 'f', 6));
     });
@@ -12569,6 +12573,7 @@ void MainWindow::registerShortcutActions()
         if (factor < 1.0) {
             newCenter = s->frequency();
         }
+        newCenter = std::max(newCenter, newBw / 2.0);
 
         sw->setFrequencyRange(newCenter, newBw);
         // Keep keyboard zoom on the same combined pan-range path as trackpad /

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -405,6 +405,7 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
             if (ao)
                 newCenter = ao->freqMhz;
         }
+        newCenter = std::max(newCenter, newBw / 2.0);
 
         reprojectWaterfall(m_centerMhz, m_bandwidthMhz, newCenter, newBw);
         if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, newCenter, newBw)) {
@@ -3443,7 +3444,8 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         const double scale = std::pow(2.0, static_cast<double>(-dx) / (width() / 4.0));
         const double newBw = std::clamp(m_bwDragStartBw * scale, m_minBwMhz, m_maxBwMhz);
         const double mouseXFrac = static_cast<double>(m_bwDragStartX) / width() - 0.5;
-        const double zoomCenter = m_bwDragAnchorMhz - mouseXFrac * newBw;
+        const double zoomCenter = std::max(m_bwDragAnchorMhz - mouseXFrac * newBw,
+                                           newBw / 2.0);
         reprojectWaterfall(m_centerMhz, m_bandwidthMhz, zoomCenter, newBw);
         if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, zoomCenter, newBw)) {
             m_bins.clear();
@@ -3492,7 +3494,8 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         const int dx = static_cast<int>(ev->position().x()) - m_panDragStartX;
         // Dragging right moves the view right → center shifts left
         const double deltaMhz = -(static_cast<double>(dx) / width()) * m_bandwidthMhz;
-        const double newCenter = m_panDragStartCenter + deltaMhz;
+        const double newCenter = std::max(m_panDragStartCenter + deltaMhz,
+                                          m_bandwidthMhz / 2.0);
         reprojectWaterfall(m_centerMhz, m_bandwidthMhz, newCenter, m_bandwidthMhz);
         m_centerMhz = newCenter;
         markOverlayDirty();
@@ -3960,7 +3963,8 @@ bool SpectrumWidget::event(QEvent* ev)
             // Anchor: keep the frequency under the cursor at the same pixel.
             const double mouseXFrac = ge->position().x() / width() - 0.5;
             const double anchorMhz = m_centerMhz + mouseXFrac * m_bandwidthMhz;
-            const double newCenter = anchorMhz - mouseXFrac * newBw;
+            const double newCenter = std::max(anchorMhz - mouseXFrac * newBw,
+                                              newBw / 2.0);
             reprojectWaterfall(m_centerMhz, m_bandwidthMhz, newCenter, newBw);
             if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, newCenter, newBw)) {
                 m_bins.clear();


### PR DESCRIPTION
## Summary

Fixes #783 — at MW/LW frequencies the spectrum waterfall could display a left edge below 0 Hz when dragging, zooming, or keyboard-navigating the panadapter.

**Root cause:** No lower-bound clamp existed on the panadapter center frequency. The left edge is `center − bandwidth/2`; when center drops below `bandwidth/2`, the left edge goes negative, displaying sub-zero spectrum that doesn't physically exist.

**Fix:** Apply `center = std::max(center, bandwidth / 2.0)` at every code path that writes a new center value — both to `SpectrumWidget`'s local state and to the radio command.

### Seven fix sites

**`src/gui/SpectrumWidget.cpp`**
1. `emitZoom` lambda — zoom-in/out buttons, clamp `newCenter` after VFO-centering branch
2. BW drag `mouseMoveEvent` — clamp `zoomCenter` (anchor-anchored center) after computing from drag position
3. Pan drag `mouseMoveEvent` — clamp `newCenter` before `m_centerMhz =` and `emit centerChangeRequested`
4. `NativeGesture` pinch zoom — clamp `newCenter` after anchor calculation

**`src/gui/MainWindow.cpp`**
5. `applyPanRangeRequest` — clamp `centerMhz` (passed by value) immediately after the null-guard; this is the central choke point for all `frequencyRangeChangeRequested` paths and keyboard zoom
6. `zoomActivePanadapter` lambda — clamp `newCenter` before `sw->setFrequencyRange()` to avoid a visual desync before the radio round-trip; `applyPanRangeRequest` (site 5) also clamps, providing defense-in-depth
7. `centerChangeRequested` handler — pan drag bypasses `applyPanRangeRequest` and sends directly to the radio; fetch bandwidth from the pan model and clamp before the `sendCommand`

No upper-bound clamp is applied — the radio enforces its own band limits.

### Out-of-scope observation

During testing on a FLEX-8400, the waterfall displays solid red (out-of-band indicator) below approximately 200 kHz even after this fix. This appears to be model-specific hardware behavior — other Flex models may allow the receiver to tune lower. The red waterfall in that region is the radio correctly reporting no valid spectrum data, not a client-side rendering bug. This is left for a future investigation scoped to that model's receive floor.

## Test plan

- [ ] Set slice to 1.0 MHz AM (MW), narrow panadapter to 3 MHz bandwidth → zoom out: left edge stops at 0 Hz
- [ ] Pan drag left past 0 Hz at 0.5 MHz → spectrum stops scrolling at the 0 Hz boundary
- [ ] Keyboard `[` zoom-out at 160m (1.8 MHz) until left edge would go below 0 Hz → clamps cleanly
- [ ] Trackpad/NativeGesture pinch-zoom out at LW → same
- [ ] Normal HF operation (14 MHz, 20 MHz BW) → no regression in zoom or pan behavior
- [ ] Multi-panadapter: each pan is independently clamped (bandwidth fetched per-pan from model)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)