### PR TITLE
fix: restore mute_local_audio_when_remote push — hardware audio silent in multi-client (#1110)

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2870,6 +2870,12 @@ void RadioModel::createRxAudioStream()
     m_rxAudio.createPending = true;
     m_rxAudio.removeRequested = false;
     logRemoteAudioRxSummary(QStringLiteral("create requested"));
+    // Push our mute preference before opening the stream. Firmware defaults
+    // mute_local_audio_when_remote=1, silencing hardware outputs whenever any
+    // remote_audio_rx stream exists. Overriding here covers multi-client
+    // scenarios where another client (e.g. SmartSDR) has set it to 1. (#1069)
+    sendCmd(QString("radio set mute_local_audio_when_remote=%1")
+                .arg(m_muteLocalWhenRemote ? 1 : 0));
     sendCmd(QString("stream create type=remote_audio_rx compression=%1").arg(audioCompressionParam()),
         [this](int code, const QString& body) {
             m_rxAudio.createPending = false;
@@ -2920,6 +2926,11 @@ void RadioModel::removeRxAudioStream()
     }
 
     const quint32 streamId = m_rxAudio.streamId;
+    // Reassert our mute preference when tearing down. If another client's
+    // stream remains open after ours is removed, this prevents the global
+    // mute_local_audio_when_remote from silencing hardware outputs. (#1110)
+    sendCmd(QString("radio set mute_local_audio_when_remote=%1")
+                .arg(m_muteLocalWhenRemote ? 1 : 0));
     sendCmd(QString("stream remove %1").arg(RadioStatusOwnership::hexId(streamId)));
     qCDebug(lcProtocol) << "RadioModel: removed remote_audio_rx stream"
                         << RadioStatusOwnership::hexId(streamId);


### PR DESCRIPTION
## Summary

Fixes #1110 — when SmartSDR is running alongside AetherSDR with "Radio Audio" disabled, toggling PC Audio in AetherSDR produces no hardware speaker/headphone output.

**Root cause:** `radio set mute_local_audio_when_remote=1` is a global radio-wide flag. When SmartSDR sets it, and SmartSDR's own `remote_audio_rx` stream remains open, the firmware keeps hardware outputs muted regardless of AetherSDR's stream state. AetherSDR must push its own preference to override.

**Regression history:** The fix was already implemented in PR #1069 (commit `8435a475`). It was accidentally deleted 22 minutes later by commit `d0d4d500` ("Fix logging checkboxes not persisting across restarts"), which touched `RadioModel.cpp` for an unrelated change and dropped the 5 added lines — almost certainly a bad rebase/cherry-pick artifact. `main` has been without the fix ever since.

## Changes — `src/models/RadioModel.cpp` only

**Change 1 — `createRxAudioStream()` (line ~2872):** Restore the accidentally deleted push of `radio set mute_local_audio_when_remote=<pref>` immediately before the `stream create` command. This covers a fresh AetherSDR launch where it must override the global mute before opening its stream.

**Change 2 — `removeRxAudioStream()` (line ~2922):** Add the same push before `stream remove`. This covers the exact failure path the reporter described: AetherSDR tears down its stream while SmartSDR's stream stays open. At that point the global mute remains in effect and hardware outputs stay silent. Pushing the preference at teardown forces the radio to honour AetherSDR's setting (default: don't mute) even though another stream is still present.

In both cases the value pushed is `m_muteLocalWhenRemote` — not hardcoded — so users who explicitly enable "Mute local audio when remote" via Radio Setup → RX continue to get the behaviour they selected.

## Test plan

- [ ] macOS: SmartSDR running with Radio Audio OFF → launch AetherSDR → hardware speaker/headphone audio present without touching SmartSDR
- [ ] Click AetherSDR PC Audio OFF (stream removal path) → hardware audio stays active while SmartSDR's stream remains open
- [ ] Click AetherSDR PC Audio ON (stream creation path) → PC audio returns, hardware outputs unaffected
- [ ] Single-client (no SmartSDR) → no regression in PC audio toggle behaviour
- [ ] Radio Setup → RX "Mute local audio when remote" enabled → hardware muting still works correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)