### PR TITLE
feat(spectrum): Ctrl+wheel zoom anchored on cursor frequency (#1518)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4071,6 +4071,30 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
     }
     if (steps == 0) { ev->ignore(); return; }
 
+    // Ctrl+wheel → zoom bandwidth anchored on the frequency under the cursor.
+    // Mirrors the pinch-to-zoom gesture and the Ctrl-drag convention used on
+    // the dBm scale strip (PR #2717) and waterfall time scale (PR #2783).
+    if (ev->modifiers() & Qt::ControlModifier) {
+        const double factor  = (steps > 0) ? (1.0 / 1.5) : 1.5;
+        const double newBw   = std::clamp(m_bandwidthMhz * factor, m_minBwMhz, m_maxBwMhz);
+        if (qFuzzyCompare(newBw, m_bandwidthMhz)) { ev->accept(); return; }
+        const double mouseXFrac = ev->position().x() / width() - 0.5;
+        const double anchorMhz  = m_centerMhz + mouseXFrac * m_bandwidthMhz;
+        const double newCenter  = std::max(anchorMhz - mouseXFrac * newBw, newBw / 2.0);
+        reprojectWaterfall(m_centerMhz, m_bandwidthMhz, newCenter, newBw);
+        if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, newCenter, newBw)) {
+            m_bins.clear();
+            m_smoothed.clear();
+        }
+        m_centerMhz    = newCenter;
+        m_bandwidthMhz = newBw;
+        resetNoiseFloorBaseline();
+        markOverlayDirty();
+        emit frequencyRangeChangeRequested(newCenter, newBw);
+        ev->accept();
+        return;
+    }
+
     const auto* ao = activeOverlay();
     const double vfoMhz = ao ? ao->freqMhz : m_centerMhz;
     // Snap the base frequency to the step grid first, then add the delta.


### PR DESCRIPTION
## Summary

- Ctrl+wheel now zooms the panadapter bandwidth in/out by ×1.5 per scroll step,
  anchoring on the frequency under the mouse cursor.
- Plain wheel scroll is unchanged — it continues to tune the VFO.

## Implementation

Single change in `SpectrumWidget::wheelEvent`: after the debounce/step
calculation, an early branch catches `Qt::ControlModifier` and runs the
cursor-anchored zoom, then returns before the existing VFO tune path.

The zoom math mirrors the existing NativeGesture pinch-to-zoom exactly:

```cpp
const double mouseXFrac = ev->position().x() / width() - 0.5;
const double anchorMhz  = m_centerMhz + mouseXFrac * m_bandwidthMhz;
const double newCenter  = std::max(anchorMhz - mouseXFrac * newBw, newBw / 2.0);
```

The `std::max(..., newBw / 2.0)` clamp prevents the left edge from going
below 0 Hz, consistent with PR #2867.

## UX consistency note

The existing `+`/`−` zoom buttons use a different anchor policy: zoom-in
re-centers on the active VFO frequency (added in #1932 to prevent repeated
clicks pushing the slice off-screen), zoom-out keeps the pan center fixed.
That behavior makes sense for a discrete click where the cursor position
carries no intent.

Ctrl+wheel is a continuous, cursor-positioned interaction — the user is
looking at a specific part of the spectrum when they scroll. Cursor-anchored
zoom is therefore the correct policy here, matching the NativeGesture
pinch-to-zoom and every major spectrum/map application that implements
scroll-to-zoom. The button inconsistency is deliberate and acceptable.

Ctrl is already the modifier used for dBm-scale drag (PR #2717) and
waterfall time-scale drag (PR #2783), so Ctrl+wheel is consistent with
the existing convention of Ctrl = “modify the view, not the VFO.”

## Testing

- Scroll wheel without Ctrl: VFO tunes as before, no regression.
- Ctrl+scroll up: bandwidth narrows, cursor frequency stays fixed.
- Ctrl+scroll down: bandwidth widens, cursor frequency stays fixed.
- Ctrl+scroll at band edge: 0 Hz clamp prevents left edge going negative.
- Ctrl+scroll at BW limits: clamped to `m_minBwMhz`/`m_maxBwMhz`, no crash.
- Pinch-to-zoom: unaffected.

Fixes #1518