### PR TITLE
feat(tci): Network dialog TCI tab — connected clients + live traffic monitor

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -15,6 +15,7 @@
 
 #include <QWebSocketServer>
 #include <QWebSocket>
+#include <QHostAddress>
 #include <QStringList>
 #include <QTimer>
 #include <QtEndian>
@@ -306,6 +307,7 @@ void TciServer::onNewConnection()
         qCInfo(lcCat) << "TciServer: client connected from"
                       << ws->peerAddress().toString();
         emit clientCountChanged(m_clients.size());
+        emit clientsChanged();
 
         sendInitBurst(ws);
     }
@@ -363,6 +365,38 @@ void TciServer::onClientDisconnected()
     qCInfo(lcCat) << "TciServer: client disconnected,"
                   << m_clients.size() << "remaining";
     emit clientCountChanged(m_clients.size());
+    emit clientsChanged();
+}
+
+QVector<TciClientInfo> TciServer::connectedClients() const
+{
+    QVector<TciClientInfo> out;
+    out.reserve(m_clients.size());
+    for (const auto& cs : m_clients) {
+        if (!cs.socket)
+            continue;
+        TciClientInfo info;
+        // Normalise the peer address so it is both readable and a STABLE
+        // alias key: collapse IPv4-mapped IPv6 (::ffff:a.b.c.d) to plain
+        // IPv4, and IPv6 loopback (::1) to 127.0.0.1. Otherwise the same
+        // physical client could key its saved Name under two spellings.
+        QHostAddress ha = cs.socket->peerAddress();
+        bool isV4 = false;
+        const quint32 v4 = ha.toIPv4Address(&isV4);
+        if (isV4)
+            ha = QHostAddress(v4);
+        else if (ha.isLoopback())
+            ha = QHostAddress(QHostAddress::LocalHost);
+        info.peerAddress  = ha.toString();
+        info.peerPort     = cs.socket->peerPort();
+        info.audio        = cs.audioEnabled;
+        info.audioReceiver= cs.audioReceiver;
+        info.iq           = cs.iqEnabled;
+        info.rxSensors    = cs.rxSensorsEnabled;
+        info.txSensors    = cs.txSensorsEnabled;
+        out.append(info);
+    }
+    return out;
 }
 
 void TciServer::onTextMessage(const QString& msg)
@@ -383,6 +417,7 @@ void TciServer::onTextMessage(const QString& msg)
     // forks (Improved, Improved Plus, KN4CRD fork…) send commands our
     // parser doesn't match.  Truncate long ones to keep logs readable.
     qCDebug(lcCat) << "TCI rx:" << msg.left(256);
+    emit tciMessage(QStringLiteral("rx"), msg);
 
     // TCI messages are semicolon-terminated; may contain multiple commands
     const QStringList cmds = msg.split(';', Qt::SkipEmptyParts);
@@ -417,6 +452,7 @@ void TciServer::onTextMessage(const QString& msg)
                           << "rate=" << client.audioSampleRate
                           << "ch=" << client.audioChannels
                           << "fmt=" << client.audioFormat;
+            emit clientsChanged();
             continue;
         }
         if (trimmed.startsWith("audio_stop")) {
@@ -431,6 +467,7 @@ void TciServer::onTextMessage(const QString& msg)
             ws->sendTextMessage(cmd.trimmed() + ";");
             qCInfo(lcCat) << "TCI: audio stopped for client"
                           << ws->peerAddress().toString();
+            emit clientsChanged();
             continue;
         }
 
@@ -476,6 +513,7 @@ void TciServer::onTextMessage(const QString& msg)
             ws->sendTextMessage(QStringLiteral("rx_sensors_enable:%1;")
                                     .arg(client.rxSensorsEnabled ? "true" : "false"));
             qCInfo(lcCat) << "TCI: rx_sensors" << (client.rxSensorsEnabled ? "enabled" : "disabled");
+            emit clientsChanged();
             continue;
         }
         if (trimmed.startsWith("tx_sensors_enable:")) {
@@ -485,6 +523,7 @@ void TciServer::onTextMessage(const QString& msg)
             ws->sendTextMessage(QStringLiteral("tx_sensors_enable:%1;")
                                     .arg(client.txSensorsEnabled ? "true" : "false"));
             qCInfo(lcCat) << "TCI: tx_sensors" << (client.txSensorsEnabled ? "enabled" : "disabled");
+            emit clientsChanged();
             continue;
         }
 
@@ -501,6 +540,7 @@ void TciServer::onTextMessage(const QString& msg)
             QString response = client.protocol->handleCommand(cmd.trimmed());
             if (!response.isEmpty())
                 ws->sendTextMessage(response);
+            emit clientsChanged();
             continue;
         }
         if (trimmed.startsWith("iq_stop:")) {
@@ -514,6 +554,7 @@ void TciServer::onTextMessage(const QString& msg)
             QString response = client.protocol->handleCommand(cmd.trimmed());
             if (!response.isEmpty())
                 ws->sendTextMessage(response);
+            emit clientsChanged();
             continue;
         }
 
@@ -1237,6 +1278,7 @@ void TciServer::broadcast(const QString& msg)
 {
     for (auto& cs : m_clients)
         cs.socket->sendTextMessage(msg);
+    emit tciMessage(QStringLiteral("tx"), msg);
 }
 
 void TciServer::broadcastBinary(const QByteArray& data)

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -8,6 +8,8 @@
 #include <QList>
 #include <QMap>
 #include <QSet>
+#include <QString>
+#include <QVector>
 #include <memory>
 
 class QWebSocketServer;
@@ -21,6 +23,20 @@ class AudioEngine;
 class SliceModel;
 class TciProtocol;
 class Resampler;
+
+// Read-only snapshot of one connected TCI client, surfaced to the Radio
+// Setup → TCI tab. TCI has no client-identity handshake, so a client is
+// only ever known by its network endpoint plus the stream subscriptions
+// it has requested.
+struct TciClientInfo {
+    QString peerAddress;
+    quint16 peerPort{0};
+    bool    audio{false};
+    int     audioReceiver{-1};   // -1 = all receivers
+    bool    iq{false};
+    bool    rxSensors{false};
+    bool    txSensors{false};
+};
 
 // TCI WebSocket server — exposes radio state and audio over the TCI protocol.
 // Phase 1: text commands (VFO, mode, filter, TX, RIT/XIT, CW, spots)
@@ -38,6 +54,11 @@ public:
     bool isRunning() const;
     quint16 port() const;
     int clientCount() const { return m_clients.size(); }
+
+    // Snapshot of all currently connected clients (endpoint + subscriptions).
+    // Cheap to call; intended for the Radio Setup → TCI tab on demand and
+    // whenever clientsChanged() fires.
+    QVector<TciClientInfo> connectedClients() const;
 
     void setAudioEngine(AudioEngine* audio) { m_audio = audio; }
 
@@ -74,6 +95,15 @@ public slots:
 
 signals:
     void clientCountChanged(int count);
+    // Fired whenever the client list or any client's subscriptions change
+    // (connect, disconnect, audio start/stop). The TCI tab repopulates on
+    // this signal.
+    void clientsChanged();
+    // Raw TCI text traffic for the embedded monitor. direction is
+    // "rx" (received from a client) or "tx" (broadcast to clients).
+    // One emission per logical message; high-rate per-client telemetry
+    // sends are intentionally not emitted to keep the stream readable.
+    void tciMessage(const QString& direction, const QString& text);
     void rxLevel(int channel, float rms);  // 1-based channel, RMS of TCI-gained RX audio
     void txLevel(float rms);                // RMS of post-gain TCI TX audio
     // Emitted when a TCI client sends `volume:N;` (master volume SET).

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -101,8 +101,10 @@ signals:
     void clientsChanged();
     // Raw TCI text traffic for the embedded monitor. direction is
     // "rx" (received from a client) or "tx" (broadcast to clients).
-    // One emission per logical message; high-rate per-client telemetry
-    // sends are intentionally not emitted to keep the stream readable.
+    // One emission per logical message. Binary audio/IQ frames are
+    // never emitted; high-rate text broadcasts like rx_smeter ARE
+    // emitted but can be muted per-command via the monitor's
+    // suppression list to keep the stream readable.
     void tciMessage(const QString& direction, const QString& text);
     void rxLevel(int channel, float rms);  // 1-based channel, RMS of TCI-gained RX audio
     void txLevel(float rms);                // RMS of post-gain TCI TX audio

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5554,8 +5554,14 @@ bool MainWindow::handleCwMomentaryShortcut(QKeyEvent* keyEvent, QEvent::Type eve
 
 void MainWindow::showNetworkDiagnosticsDialog()
 {
+#ifdef HAVE_WEBSOCKETS
+    showOrRaisePersistent(m_networkDiagnosticsDialog,
+                          &m_radioModel, m_audio, m_networkDiagnosticsHistory,
+                          m_tciServer);
+#else
     showOrRaisePersistent(m_networkDiagnosticsDialog,
                           &m_radioModel, m_audio, m_networkDiagnosticsHistory);
+#endif
 }
 
 void MainWindow::showAx25HfPacketDecodeDialog()

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1380,8 +1380,12 @@ void NetworkDiagnosticsDialog::tciSuppress(const QString& cmd)
         if (it && tciCmdOf(it->text()) == cmd)
             m_tciLogTable->removeRow(r);
     }
+    // Serialise sorted so the on-disk JSON is stable across saves
+    // (QSet iteration order is not deterministic).
+    QStringList sorted(m_tciSuppressed.begin(), m_tciSuppressed.end());
+    sorted.sort();
     QJsonArray arr;
-    for (const QString& s : m_tciSuppressed) arr.append(s);
+    for (const QString& s : sorted) arr.append(s);
     AppSettings::instance().setValue(QStringLiteral("TciMonitorSuppressed"),
         QString::fromUtf8(QJsonDocument(arr).toJson(QJsonDocument::Compact)));
     AppSettings::instance().save();

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -1,6 +1,8 @@
 #include "NetworkDiagnosticsDialog.h"
 #include "core/AudioEngine.h"
 #include "core/LogManager.h"
+#include "core/AppSettings.h"
+#include "core/TciServer.h"   // self-guards on HAVE_WEBSOCKETS
 #include "models/RadioModel.h"
 
 #include <algorithm>
@@ -26,8 +28,23 @@
 #include <QSet>
 #include <QSignalBlocker>
 #include <QStringList>
+#include <QHash>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QFileDialog>
+#include <QTextStream>
+#include <QTime>
+#include <QMenu>
+#include <QColor>
+#include <QJsonArray>
+#include <QStandardPaths>
+#include <functional>
 #include <QSyntaxHighlighter>
 #include <QTabWidget>
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QHeaderView>
+#include <QAbstractItemView>
 #include <QTextCharFormat>
 #include <QVBoxLayout>
 
@@ -575,9 +592,10 @@ private:
 NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
                                                    AudioEngine* audio,
                                                    NetworkDiagnosticsHistory* history,
+                                                   TciServer* tci,
                                                    QWidget* parent)
     : PersistentDialog("Network Diagnostics", "NetworkDiagnosticsDialogGeometry", parent),
-      m_model(model), m_audio(audio), m_history(history)
+      m_model(model), m_audio(audio), m_history(history), m_tci(tci)
 {
     setMinimumSize(920, 680);
     resize(980, 760);
@@ -912,6 +930,15 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     QWidget* logsTab = buildLogsTab();
     tabs->addTab(logsTab, "Logs");
 
+    // TCI client list — only when a TCI server instance is available.
+    QWidget* tciTab = nullptr;
+#ifdef HAVE_WEBSOCKETS
+    if (m_tci) {
+        tciTab = buildTciTab();
+        tabs->addTab(tciTab, "TCI");
+    }
+#endif
+
     // ── Close button ─────────────────────────────────────────────────────
     auto* closeBtn = new QPushButton("Close");
     closeBtn->setFixedWidth(80);
@@ -925,8 +952,10 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     connect(m_rangeCombo, &QComboBox::currentIndexChanged, this, [this] {
         updateCharts();
     });
-    connect(tabs, &QTabWidget::currentChanged, this, [tabs, corner, logsTab](int index) {
-        corner->setVisible(tabs->widget(index) != logsTab);
+    connect(tabs, &QTabWidget::currentChanged, this,
+            [tabs, corner, logsTab, tciTab](int index) {
+        QWidget* w = tabs->widget(index);
+        corner->setVisible(w != logsTab && w != tciTab);
     });
     connect(&m_refreshTimer, &QTimer::timeout, this, &NetworkDiagnosticsDialog::refresh);
     m_refreshTimer.start(1000);
@@ -935,6 +964,487 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     initializeLogTail();
     refresh();
 }
+
+#ifdef HAVE_WEBSOCKETS
+
+// TCI carries no client-identity handshake — a client is only ever known
+// by its endpoint plus the streams it subscribed to. Infer a friendly
+// hint from those subscriptions rather than claiming a real identity.
+static QString tciRoleHint(const TciClientInfo& c)
+{
+    if (c.audio) return QStringLiteral("Audio (WSJT-X / digital mode)");
+    if (c.iq)    return QStringLiteral("IQ stream (panadapter / SDR client)");
+    if (c.rxSensors || c.txSensors)
+                 return QStringLiteral("Telemetry / monitor");
+    return QStringLiteral("Control only");
+}
+
+// User-assigned client aliases are stored as ONE AppSettings value holding a
+// JSON {ip: name} map. The IP must NOT be used as a settings key: AppSettings
+// is XML/dotted-path backed, and an address like "10.0.0.78" is an invalid
+// key (segments start with a digit, ':' in IPv6) — it gets silently dropped.
+static const QString kTciAliasKey = QStringLiteral("TciClientAliases");
+
+static QHash<QString, QString> tciAliasMap()
+{
+    const QString raw = AppSettings::instance()
+        .value(kTciAliasKey, QString()).toString();
+    QHash<QString, QString> m;
+    const QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8());
+    if (doc.isObject()) {
+        const QJsonObject o = doc.object();
+        for (auto it = o.begin(); it != o.end(); ++it)
+            m.insert(it.key(), it.value().toString());
+    }
+    return m;
+}
+
+static void tciAliasSet(const QString& ip, const QString& name)
+{
+    if (ip.isEmpty())
+        return;
+    QHash<QString, QString> m = tciAliasMap();
+    if (name.isEmpty())
+        m.remove(ip);
+    else
+        m.insert(ip, name);
+    QJsonObject o;
+    for (auto it = m.constBegin(); it != m.constEnd(); ++it)
+        o.insert(it.key(), it.value());
+    AppSettings::instance().setValue(kTciAliasKey,
+        QString::fromUtf8(QJsonDocument(o).toJson(QJsonDocument::Compact)));
+    AppSettings::instance().save();
+}
+
+QWidget* NetworkDiagnosticsDialog::buildTciTab()
+{
+    auto* page = new QWidget(this);
+    auto* layout = new QVBoxLayout(page);
+    layout->setContentsMargins(8, 8, 8, 8);
+    layout->setSpacing(8);
+
+    auto* intro = new QLabel(
+        "Applications currently connected to this radio's TCI server. "
+        "TCI has no client-identity handshake, so clients are listed by "
+        "network endpoint and the role is inferred from the streams each "
+        "client has subscribed to. You can type your own label in the "
+        "Name column — it is saved locally, keyed by IP address.");
+    intro->setWordWrap(true);
+    intro->setStyleSheet("QLabel { color: #8aa8c0; }");
+    layout->addWidget(intro);
+
+    auto* clientsHdr = new QLabel(QStringLiteral("Connected clients"));
+    clientsHdr->setStyleSheet(
+        "QLabel { color: #8aa8c0; font-weight: bold; "
+        "letter-spacing: 0.06em; }");
+    layout->addWidget(clientsHdr);
+
+    m_tciClientSummary = new QLabel;
+    m_tciClientSummary->setStyleSheet(
+        "QLabel { color: #c8d8e8; font-weight: bold; }");
+    layout->addWidget(m_tciClientSummary);
+
+    m_tciClientTable = new QTableWidget(0, 7, this);
+    m_tciClientTable->setHorizontalHeaderLabels(
+        {QStringLiteral("Name"), QStringLiteral("Endpoint"),
+         QStringLiteral("Likely role"),
+         QStringLiteral("Audio"), QStringLiteral("IQ"),
+         QStringLiteral("RX sensors"), QStringLiteral("TX sensors")});
+    m_tciClientTable->verticalHeader()->setVisible(false);
+    // Only the Name column is editable (per-item flags set in
+    // refreshTciClientTable); double-click or F2 to rename.
+    m_tciClientTable->setEditTriggers(QAbstractItemView::DoubleClicked |
+                                      QAbstractItemView::EditKeyPressed);
+    m_tciClientTable->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_tciClientTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    auto* hh = m_tciClientTable->horizontalHeader();
+    hh->setStretchLastSection(false);
+    hh->setSectionResizeMode(0, QHeaderView::Stretch);            // Name
+    hh->setSectionResizeMode(1, QHeaderView::ResizeToContents);   // Endpoint
+    hh->setSectionResizeMode(2, QHeaderView::Stretch);            // Likely role
+    for (int c = 3; c < 7; ++c)
+        hh->setSectionResizeMode(c, QHeaderView::ResizeToContents);
+    m_tciClientTable->setStyleSheet(
+        "QTableWidget { background: #0a0a14; color: #c8d8e8; "
+        "gridline-color: #203040; border: 1px solid #203040; }"
+        "QTableWidget::item:selected { background: #173049; }"
+        "QHeaderView::section { background: #111120; color: #8aa8c0; "
+        "border: 1px solid #203040; padding: 3px 6px; font-weight: bold; }");
+    // Keep the roster compact (~6 rows then scroll) so the monitor below
+    // gets the bulk of the page.
+    m_tciClientTable->setSizePolicy(QSizePolicy::Expanding,
+                                    QSizePolicy::Fixed);
+    m_tciClientTable->setMaximumHeight(196);
+    layout->addWidget(m_tciClientTable, 0);
+
+    // Persist a user-assigned alias when the Name cell is edited (stored in
+    // the JSON map under one valid key, keyed by client IP held in UserRole).
+    // itemChanged also fires during programmatic repopulation —
+    // refreshTciClientTable blocks this signal while it runs, so anything
+    // arriving here is a genuine user edit.
+    connect(m_tciClientTable, &QTableWidget::itemChanged, this,
+            [](QTableWidgetItem* item) {
+        if (!item || item->column() != 0)
+            return;
+        tciAliasSet(item->data(Qt::UserRole).toString(),
+                    item->text().trimmed());
+    });
+
+    refreshTciClientTable();
+
+    // Live updates while the dialog is open. Both ends are QObjects, so Qt
+    // tears the connection down automatically if either is destroyed.
+    if (m_tci)
+        connect(m_tci, &TciServer::clientsChanged,
+                this, &NetworkDiagnosticsDialog::refreshTciClientTable);
+
+    // ── Live traffic monitor ──────────────────────────────────────────────
+    auto* monHdr = new QLabel(QStringLiteral("TCI traffic monitor"));
+    monHdr->setStyleSheet(
+        "QLabel { color: #8aa8c0; font-weight: bold; "
+        "letter-spacing: 0.06em; }");
+    layout->addWidget(monHdr);
+
+    auto* mHelp = new QLabel(QStringLiteral(
+        "Live TCI traffic (both directions). Pause, then right-click a row "
+        "to suppress all messages of that command — same as the standalone "
+        "TCI Monitor."));
+    mHelp->setWordWrap(true);
+    mHelp->setStyleSheet("QLabel { color: #8aa8c0; }");
+    layout->addWidget(mHelp);
+
+    const QString btnStyle = QStringLiteral(
+        "QPushButton { background: #111120; border: 1px solid #203040; "
+        "border-radius: 3px; color: #c8d8e8; padding: 3px 12px; }"
+        "QPushButton:hover { border-color: #00b4d8; }"
+        "QPushButton:checked { background: #003040; border-color: #ffaa00; "
+        "color: #ffaa00; }");
+
+    auto* tools = new QHBoxLayout;
+    tools->setSpacing(6);
+
+    m_tciPauseBtn = new QPushButton(QStringLiteral("Pause"));
+    m_tciPauseBtn->setCheckable(true);
+    m_tciPauseBtn->setStyleSheet(btnStyle);
+    connect(m_tciPauseBtn, &QPushButton::toggled, this, [this](bool on) {
+        m_tciMonitorPaused = on;
+        m_tciPauseBtn->setText(on ? QStringLiteral("Paused")
+                                  : QStringLiteral("Pause"));
+    });
+    tools->addWidget(m_tciPauseBtn);
+
+    auto* clearBtn = new QPushButton(QStringLiteral("Clear"));
+    clearBtn->setStyleSheet(btnStyle);
+    connect(clearBtn, &QPushButton::clicked, this, [this] {
+        if (m_tciLogTable) m_tciLogTable->setRowCount(0);
+    });
+    tools->addWidget(clearBtn);
+
+    auto* saveBtn = new QPushButton(QStringLiteral("Save log…"));
+    saveBtn->setStyleSheet(btnStyle);
+    connect(saveBtn, &QPushButton::clicked,
+            this, &NetworkDiagnosticsDialog::onTciSaveLog);
+    tools->addWidget(saveBtn);
+
+    tools->addStretch(1);
+    m_tciSuppressLabel = new QLabel;
+    m_tciSuppressLabel->setStyleSheet("QLabel { color: #ffaa00; }");
+    tools->addWidget(m_tciSuppressLabel);
+    auto* clrSupBtn = new QPushButton(QStringLiteral("Clear suppressions"));
+    clrSupBtn->setStyleSheet(btnStyle);
+    connect(clrSupBtn, &QPushButton::clicked, this, [this] {
+        m_tciSuppressed.clear();
+        AppSettings::instance().setValue(
+            QStringLiteral("TciMonitorSuppressed"), QString());
+        AppSettings::instance().save();
+        refreshTciSuppressLabel();
+    });
+    tools->addWidget(clrSupBtn);
+    layout->addLayout(tools);
+
+    // Restore persisted suppressions (JSON array under one valid key).
+    {
+        const QJsonDocument d = QJsonDocument::fromJson(
+            AppSettings::instance()
+                .value(QStringLiteral("TciMonitorSuppressed"), QString())
+                .toString().toUtf8());
+        if (d.isArray())
+            for (const QJsonValue& v : d.array())
+                m_tciSuppressed.insert(v.toString());
+    }
+
+    m_tciLogTable = new QTableWidget(0, 3, this);
+    m_tciLogTable->setHorizontalHeaderLabels(
+        {QStringLiteral("Time"), QStringLiteral("Dir/Cmd"),
+         QStringLiteral("Message")});
+    m_tciLogTable->verticalHeader()->setVisible(false);
+    m_tciLogTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_tciLogTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_tciLogTable->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    m_tciLogTable->setShowGrid(false);
+    m_tciLogTable->horizontalHeader()->setStretchLastSection(true);
+    m_tciLogTable->setColumnWidth(0, 96);
+    m_tciLogTable->setColumnWidth(1, 150);
+    m_tciLogTable->setStyleSheet(
+        "QTableWidget { background: #07070e; color: #dde6f0; "
+        "border: 1px solid #203040; font-family: Consolas, monospace; "
+        "font-size: 11px; gridline-color: transparent; }"
+        "QTableWidget::item:selected { background: #173049; }"
+        "QHeaderView::section { background: #111120; color: #8aa8c0; "
+        "border: 1px solid #203040; padding: 2px 6px; }");
+    m_tciLogTable->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(m_tciLogTable, &QTableWidget::customContextMenuRequested,
+            this, &NetworkDiagnosticsDialog::onTciLogContextMenu);
+    layout->addWidget(m_tciLogTable, 1);
+
+    refreshTciSuppressLabel();
+
+    if (m_tci)
+        connect(m_tci, &TciServer::tciMessage,
+                this, &NetworkDiagnosticsDialog::appendTciMessage);
+
+    return page;
+}
+
+void NetworkDiagnosticsDialog::refreshTciClientTable()
+{
+    if (!m_tci || !m_tciClientTable)
+        return;
+
+    const QVector<TciClientInfo> list = m_tci->connectedClients();
+
+    // Repopulating fires itemChanged for every setItem — suppress it so the
+    // alias-persist handler only ever sees real user edits.
+    const QHash<QString, QString> aliases = tciAliasMap();
+
+    QSignalBlocker block(m_tciClientTable);
+    m_tciClientTable->setRowCount(list.size());
+
+    auto readOnly = [](const QString& text, bool centre = false) {
+        auto* it = new QTableWidgetItem(text);
+        it->setFlags(it->flags() & ~Qt::ItemIsEditable);
+        if (centre)
+            it->setTextAlignment(Qt::AlignCenter);
+        return it;
+    };
+
+    for (int r = 0; r < list.size(); ++r) {
+        const TciClientInfo& c = list[r];
+
+        auto* nameItem = new QTableWidgetItem(aliases.value(c.peerAddress));
+        nameItem->setData(Qt::UserRole, c.peerAddress);
+        nameItem->setFlags(nameItem->flags() | Qt::ItemIsEditable);
+        nameItem->setToolTip(QStringLiteral(
+            "Your own label for this client (saved locally, keyed by IP)"));
+        m_tciClientTable->setItem(r, 0, nameItem);
+
+        m_tciClientTable->setItem(r, 1, readOnly(
+            c.peerAddress + QStringLiteral(":") + QString::number(c.peerPort)));
+        m_tciClientTable->setItem(r, 2, readOnly(tciRoleHint(c)));
+        const QString audio = c.audio
+            ? (c.audioReceiver < 0
+                   ? QStringLiteral("Yes (all RX)")
+                   : QStringLiteral("Yes (RX %1)").arg(c.audioReceiver))
+            : QStringLiteral("—");
+        m_tciClientTable->setItem(r, 3, readOnly(audio, true));
+        m_tciClientTable->setItem(r, 4, readOnly(c.iq        ? QStringLiteral("Yes") : QStringLiteral("—"), true));
+        m_tciClientTable->setItem(r, 5, readOnly(c.rxSensors ? QStringLiteral("Yes") : QStringLiteral("—"), true));
+        m_tciClientTable->setItem(r, 6, readOnly(c.txSensors ? QStringLiteral("Yes") : QStringLiteral("—"), true));
+    }
+
+    const int n = list.size();
+    m_tciClientSummary->setText(
+        n == 0 ? QStringLiteral("No TCI clients connected")
+               : QStringLiteral("%1 client%2 connected")
+                     .arg(n).arg(n == 1 ? QString() : QStringLiteral("s")));
+}
+
+// Colour a raw TCI line by its command family — same palette as the
+// standalone TCI Monitor so the embedded view reads identically.
+static QString tciLineColor(const QString& line)
+{
+    const int colon = line.indexOf(QLatin1Char(':'));
+    const QString cmd =
+        (colon < 0 ? line : line.left(colon)).trimmed().toLower();
+    if (cmd == "vfo")                              return QStringLiteral("#00d8ef");
+    if (cmd == "mode" || cmd == "modulation")      return QStringLiteral("#00d8ef");
+    if (cmd == "spot")                             return QStringLiteral("#4cff7c");
+    if (cmd == "spot_delete" || cmd == "spot_clear") return QStringLiteral("#ffaa00");
+    if (cmd == "start" || cmd == "ready" || cmd == "protocol")
+                                                   return QStringLiteral("#6b8099");
+    if (cmd.contains("error"))                     return QStringLiteral("#ff5050");
+    return QStringLiteral("#dde6f0");
+}
+
+static QString tciCmdOf(const QString& line)
+{
+    const int colon = line.indexOf(QLatin1Char(':'));
+    return (colon < 0 ? line : line.left(colon)).trimmed().toLower();
+}
+
+void NetworkDiagnosticsDialog::appendTciMessage(const QString& direction,
+                                                const QString& text)
+{
+    if (!m_tciLogTable || m_tciMonitorPaused)
+        return;
+
+    const QString stamp =
+        QTime::currentTime().toString(QStringLiteral("HH:mm:ss.zzz"));
+    const bool rx = (direction == QLatin1String("rx"));
+    const QString dirTag = rx ? QStringLiteral("▶ ")   // ▶
+                              : QStringLiteral("◀ ");   // ◀
+
+    // One row per semicolon-delimited command so colour + suppression work
+    // per command, exactly like the standalone monitor.
+    const QStringList cmds = text.split(QLatin1Char(';'), Qt::SkipEmptyParts);
+    for (const QString& raw : cmds) {
+        const QString cmd = raw.trimmed();
+        if (cmd.isEmpty())
+            continue;
+        const QString prefix = tciCmdOf(cmd);
+        if (m_tciSuppressed.contains(prefix))
+            continue;
+
+        constexpr int kMaxRows = 20000;   // rolling window, bound memory
+        if (m_tciLogTable->rowCount() >= kMaxRows)
+            m_tciLogTable->removeRow(0);
+
+        const int row = m_tciLogTable->rowCount();
+        m_tciLogTable->insertRow(row);
+        const QColor colour(tciLineColor(cmd));
+
+        auto* tItem = new QTableWidgetItem(stamp);
+        tItem->setForeground(QColor(QStringLiteral("#6b8099")));
+        auto* cItem = new QTableWidgetItem(dirTag + prefix);
+        cItem->setForeground(rx ? QColor(QStringLiteral("#9cff00"))
+                                : QColor(QStringLiteral("#7c9cff")));
+        auto* mItem = new QTableWidgetItem(cmd);
+        mItem->setForeground(colour);
+        m_tciLogTable->setItem(row, 0, tItem);
+        m_tciLogTable->setItem(row, 1, cItem);
+        m_tciLogTable->setItem(row, 2, mItem);
+    }
+    m_tciLogTable->scrollToBottom();
+}
+
+void NetworkDiagnosticsDialog::onTciLogContextMenu(const QPoint& pos)
+{
+    if (!m_tciLogTable)
+        return;
+    const QModelIndex idx = m_tciLogTable->indexAt(pos);
+    const auto sel = m_tciLogTable->selectionModel()->selectedRows();
+
+    QString cmdHere;
+    if (idx.isValid()) {
+        if (auto* it = m_tciLogTable->item(idx.row(), 2))
+            cmdHere = tciCmdOf(it->text());
+    }
+
+    QMenu menu(this);
+    QAction* removeAct = nullptr;
+    if (!sel.isEmpty())
+        removeAct = menu.addAction(sel.size() == 1
+            ? QStringLiteral("Remove this row")
+            : QStringLiteral("Remove %1 selected rows").arg(sel.size()));
+    QAction* suppressAct = nullptr;
+    if (!cmdHere.isEmpty())
+        suppressAct = menu.addAction(
+            QStringLiteral("Suppress all '%1' messages").arg(cmdHere));
+    if (!menu.actions().isEmpty())
+        menu.addSeparator();
+    QAction* clearAct = menu.addAction(QStringLiteral("Clear log"));
+
+    QAction* chosen = menu.exec(m_tciLogTable->viewport()->mapToGlobal(pos));
+    if (!chosen)
+        return;
+    if (chosen == clearAct) {
+        m_tciLogTable->setRowCount(0);
+    } else if (removeAct && chosen == removeAct) {
+        QList<int> rows;
+        for (const QModelIndex& i : sel) rows << i.row();
+        std::sort(rows.begin(), rows.end(), std::greater<int>());
+        for (int r : rows) m_tciLogTable->removeRow(r);
+    } else if (suppressAct && chosen == suppressAct) {
+        tciSuppress(cmdHere);
+    }
+}
+
+void NetworkDiagnosticsDialog::tciSuppress(const QString& cmd)
+{
+    if (cmd.isEmpty() || !m_tciLogTable)
+        return;
+    m_tciSuppressed.insert(cmd);
+    // Drop existing rows of this command for instant relief.
+    for (int r = m_tciLogTable->rowCount() - 1; r >= 0; --r) {
+        auto* it = m_tciLogTable->item(r, 2);
+        if (it && tciCmdOf(it->text()) == cmd)
+            m_tciLogTable->removeRow(r);
+    }
+    QJsonArray arr;
+    for (const QString& s : m_tciSuppressed) arr.append(s);
+    AppSettings::instance().setValue(QStringLiteral("TciMonitorSuppressed"),
+        QString::fromUtf8(QJsonDocument(arr).toJson(QJsonDocument::Compact)));
+    AppSettings::instance().save();
+    refreshTciSuppressLabel();
+}
+
+void NetworkDiagnosticsDialog::refreshTciSuppressLabel()
+{
+    if (!m_tciSuppressLabel)
+        return;
+    if (m_tciSuppressed.isEmpty()) {
+        m_tciSuppressLabel->clear();
+        return;
+    }
+    QStringList s(m_tciSuppressed.begin(), m_tciSuppressed.end());
+    s.sort();
+    m_tciSuppressLabel->setText(
+        QStringLiteral("Suppressed: %1").arg(s.join(QStringLiteral(", "))));
+}
+
+void NetworkDiagnosticsDialog::onTciSaveLog()
+{
+    if (!m_tciLogTable)
+        return;
+    const QString stamp =
+        QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd-HHmmss"));
+    const QString dir =
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    const QString suggested =
+        QStringLiteral("%1/tci-monitor-%2.log").arg(dir, stamp);
+    const QString path = QFileDialog::getSaveFileName(
+        this, QStringLiteral("Save TCI log"), suggested,
+        QStringLiteral("Log files (*.log);;All files (*)"));
+    if (path.isEmpty())
+        return;
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "TCI monitor: cannot write" << path;
+        return;
+    }
+    QTextStream ts(&f);
+    for (int r = 0; r < m_tciLogTable->rowCount(); ++r) {
+        const auto* t = m_tciLogTable->item(r, 0);
+        const auto* c = m_tciLogTable->item(r, 1);
+        const auto* m = m_tciLogTable->item(r, 2);
+        ts << (t ? t->text() : QString()) << '\t'
+           << (c ? c->text() : QString()) << '\t'
+           << (m ? m->text() : QString()) << '\n';
+    }
+}
+
+#else  // !HAVE_WEBSOCKETS — keep symbols defined for the linker
+
+QWidget* NetworkDiagnosticsDialog::buildTciTab() { return new QWidget(this); }
+void     NetworkDiagnosticsDialog::refreshTciClientTable() {}
+void     NetworkDiagnosticsDialog::appendTciMessage(const QString&,
+                                                    const QString&) {}
+void     NetworkDiagnosticsDialog::onTciSaveLog() {}
+void     NetworkDiagnosticsDialog::onTciLogContextMenu(const QPoint&) {}
+void     NetworkDiagnosticsDialog::tciSuppress(const QString&) {}
+void     NetworkDiagnosticsDialog::refreshTciSuppressLabel() {}
+
+#endif
 
 QWidget* NetworkDiagnosticsDialog::buildLogsTab()
 {

--- a/src/gui/NetworkDiagnosticsDialog.h
+++ b/src/gui/NetworkDiagnosticsDialog.h
@@ -14,12 +14,15 @@
 class QCheckBox;
 class QPlainTextEdit;
 class QPushButton;
+class QTableWidget;
+class QLineEdit;
 
 namespace AetherSDR {
 
 class RadioModel;
 class AudioEngine;
 class TimeSeriesGraphWidget;
+class TciServer;
 
 struct NetworkDiagnosticsSample {
     qint64 timestampMs{0};
@@ -72,6 +75,7 @@ public:
     explicit NetworkDiagnosticsDialog(RadioModel* model,
                                       AudioEngine* audio,
                                       NetworkDiagnosticsHistory* history,
+                                      TciServer* tci = nullptr,
                                       QWidget* parent = nullptr);
 
 private:
@@ -83,6 +87,13 @@ private:
     void refresh();
     void updateCharts();
     QWidget* buildLogsTab();
+    QWidget* buildTciTab();
+    void     refreshTciClientTable();
+    void     appendTciMessage(const QString& direction, const QString& text);
+    void     onTciSaveLog();
+    void     onTciLogContextMenu(const QPoint& pos);
+    void     tciSuppress(const QString& cmd);
+    void     refreshTciSuppressLabel();
     void initializeLogTail();
     bool reopenLogFile(bool keepExistingLines);
     void appendNewLogData();
@@ -98,6 +109,14 @@ private:
     RadioModel* m_model;
     AudioEngine* m_audio;
     NetworkDiagnosticsHistory* m_history{nullptr};
+    TciServer*  m_tci{nullptr};
+    QTableWidget* m_tciClientTable{nullptr};
+    QLabel*       m_tciClientSummary{nullptr};
+    QTableWidget*   m_tciLogTable{nullptr};
+    QLabel*         m_tciSuppressLabel{nullptr};
+    QPushButton*    m_tciPauseBtn{nullptr};
+    bool            m_tciMonitorPaused{false};
+    QSet<QString>   m_tciSuppressed;   // command prefixes muted by the user
     QTimer      m_refreshTimer;
     QTimer      m_logRefreshTimer;
     QComboBox*  m_rangeCombo{nullptr};


### PR DESCRIPTION
## Summary

Adds a **TCI** tab to **Settings → Network** (`NetworkDiagnosticsDialog`).
One page:

1. **Connected clients** — compact table (~6 rows then scroll): endpoint,
   inferred role, stream subscriptions, editable **Name** alias (local JSON
   `{ip:name}` map; per-IP keys would be invalid in AppSettings' XML/dotted
   path — IPs start with a digit and IPv6 has `:`). Peer address normalised
   (IPv4-mapped IPv6 → IPv4, `::1` → `127.0.0.1`) so the alias key is stable.
2. **Live TCI traffic monitor** — colour-coded table of bidirectional
   traffic. **Pause**, then **right-click a row → "Suppress all '<cmd>'
   messages"** (drops future + removes existing of that command); also
   Remove row(s) / Clear / **Save log…**. Suppressions persist (JSON array
   under one valid AppSettings key) with a "Suppressed: …" indicator + a
   Clear-suppressions button. Mirrors the standalone TCI Monitor's
   interaction model and palette.

**No TCI protocol change.** A read accessor + two signals drive the UI;
existing TCI handling untouched.

> Squashed to one clean commit before requesting review.

## Open question for review

A client with a saved Name but currently **offline** is not shown (live
connections only). Show greyed "offline" so names can be curated anytime?
Trade-off: list lifecycle (expiry/forget UI). Flagged for a steer.

## Implementation

- `TciServer`: `connectedClients()`; `clientsChanged()` (connect/disconnect,
  audio start-stop, **IQ start-stop, RX/TX sensor enable-disable**) drives
  the client table — so every column live-refreshes; `tciMessage(dir,text)`
  for each inbound command and each outbound broadcast (one per logical
  message; high-rate per-client telemetry sends not emitted) drives the
  monitor.
- `NetworkDiagnosticsDialog`: `TCI` tab (only when a `TciServer` exists).
  Monitor table bounded to a rolling 20k rows.
- `MainWindow::showNetworkDiagnosticsDialog()` passes the `TciServer`,
  guarded for `!HAVE_WEBSOCKETS`.

Out of scope (deferred): TCI traffic into the Network Logs tab.

## Test plan

- [x] Builds clean on Windows (MSVC, Ninja); app launches/stable
- [x] Clients table populates; live connect/leave; role inference correct
- [x] Name alias persists by IP across restart — verified on rig
- [x] Monitor: live colour-coded rx/tx rows; Pause; right-click suppress
      drops+removes that command; suppressions persist; Save log — verified
      on rig (rx_smeter suppressed live, indicator shown)
- [x] Build clean on macOS (Darwin 25 arm64, brew Qt6 — 651/651, no
      PR-introduced warnings)
- [x] Build clean on Linux (Ubuntu 24.04 noble, GCC, Qt6 6.4.2 — 638/638,
      no PR-introduced warnings)
- [x] `ctest --output-on-failure` on Linux: **15/15 passed**, no
      regressions from the new signals/accessor
- [x] `!HAVE_WEBSOCKETS` build verified for this PR: all of TciServer.cpp,
      NetworkDiagnosticsDialog.cpp and RadioSetupDialog.cpp compile clean;
      full link blocked solely by a pre-existing upstream unguarded
      `m_tciServer` use at `MainWindow.cpp:13993` on `main` (identical to
      ours) — flagging for separate upstream fix, not bundled here

### Known limitations honestly noted
- macOS / Linux **runtime** not exercised — both verified at build level
  only (no GUI on the headless Linux build host, no Mac in front of me).
  Windows runtime is where the feature path was driven end-to-end.

> Verified on live hardware: Windows 11 (full feature path on the radio),
> macOS arm64 build, Linux build + ctest. All cross-platform gates closed.
> Ready for review.