### PR TITLE
fix(applet-panel): sync title-bar icons on float; restore persisted side on re-dock (#2896)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -11844,8 +11844,18 @@ void MainWindow::toggleAppletPanelFloating(bool floating)
     AppSettings::instance().setValue(
         "AppletPanelFloating", floating ? "True" : "False");
     AppSettings::instance().save();
-    if (m_titleBar)
+    if (m_titleBar) {
         m_titleBar->setAppletFloating(floating);
+        // While floating, the panel lives in its own window — neither
+        // dock-side icon should remain illuminated.  When re-docking,
+        // dockAppletPanel restores the persisted side and re-syncs the
+        // dock-side icon via setAppletPanelDockedLeft.
+        if (floating) {
+            const bool dockedLeft = AppSettings::instance()
+                .value("AppletPanelDockedLeft", "False").toString() == "True";
+            m_titleBar->setAppletDockState(false, dockedLeft);
+        }
+    }
 }
 
 void MainWindow::setFramelessWindow(bool on)
@@ -14957,6 +14967,17 @@ void MainWindow::dockAppletPanel()
     // is both simpler and deterministic.
     const int centerWidth = std::max(400, m_splitter->width() - 260);
     m_splitter->setSizes({0, 0, centerWidth, 260});
+
+    // Restore the user's last-known dock side and re-sync the title-bar
+    // icon.  addWidget above places the panel in the right slot; if the
+    // user last had it docked left, setAppletPanelDockedLeft moves it
+    // back, re-applies sizes by widget identity, and updates the dock-
+    // side icon.  Calling it for right-dock is a no-op for layout but
+    // still re-syncs the icon, which would otherwise stay stuck on the
+    // pre-float side highlight.
+    const bool dockedLeft = AppSettings::instance()
+        .value("AppletPanelDockedLeft", "False").toString() == "True";
+    setAppletPanelDockedLeft(dockedLeft);
 
     m_appletPanelFloatWindow->removeEventFilter(this);
     m_appletPanelFloatWindow->deleteLater();


### PR DESCRIPTION
## Summary

Two related fixes to the applet-panel title-bar state machine that the
#2584 PR didn't cover.

## Why

- **X1** — `toggleAppletPanelFloating()` updates the pop-out icon but
  never un-illuminates the dock-side icons when the panel floats. Result:
  LEFT/RIGHT and pop-out are lit simultaneously.
- **X2** — `dockAppletPanel()` always appends the applet to the splitter
  (right slot) and doesn't re-apply the persisted `AppletPanelDockedLeft`
  side, nor re-sync the dock-side icon. Result: pop-out → re-dock loses
  the user's prior side and leaves the icon stuck.

## Scope

- 22 lines added across two functions in `src/gui/MainWindow.cpp`
- No protocol / persistence-format / UX-behavior change beyond the fix
- No new signals, no model changes, no test impact

## Test plan

Verified manually on Linux (Nobara 43, Qt 6.10.3):

- [x] Local incremental `ninja -C build` clean
- [x] **T5 (X1)** — panel docked LEFT → click pop-out → only pop-out icon lit
- [x] **T6 (X2)** — float from LEFT → click pop-out to re-dock → panel
      returns to LEFT, LEFT icon lit, pop-out off
- [x] **Regression** — default RIGHT-dock → pop-out twice → cleanly
      re-docks RIGHT, icons synced, no orphan window

Closes #2896

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent, on Linux dev stack (`nobara-dell`).