### PR TITLE
[bug] Route CW sidetone to selected audio output

### DIFF
--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -221,6 +221,12 @@ is `PC`, `MainWindow` immediately re-arms PC mic capture by restarting the local
 `QAudioSource` on the selected device. The radio mic source is not toggled and
 no hardware-mic fallback route is used.
 
+If AetherSDR is following the system default input or output, a default-device
+change also restarts the affected local audio path even when no device was
+removed. This keeps existing `QAudioSource`/`QAudioSink` handles, the CW
+sidetone sink, and the title-bar PC audio labels aligned with the OS-selected
+endpoint.
+
 The same local re-arm applies when an input device is removed while PC mic
 capture is active. If the selected input disappeared, the selection is cleared
 so `AudioEngine::startTxStream()` opens the current system default. If AetherSDR
@@ -237,6 +243,14 @@ CW sidetone and Quindar local monitor output are independent local paths:
 - `QuindarLocalSink` is a separate 48 kHz stereo float32 local sink. It calls
   `ClientQuindarTone::processSidetone()` so the operator hears the local
   Quindar tones corresponding to TX tone insertion.
+
+The sidetone backend is opened against the same PC output selection as RX audio.
+When the operator has selected a specific output, the PortAudio backend maps the
+Qt device name to a PortAudio output; if that mapping is missing or ambiguous,
+startup falls back to the Qt `QAudioSink` backend so the sidetone routes to the
+selected device instead of PortAudio's default. When AetherSDR follows the
+system default, the sidetone backend is restarted whenever Qt reports that the
+default output changed.
 
 Neither path is mixed into `m_rxBuffer`. They are local monitor outputs, not
 radio audio streams.

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1049,6 +1049,8 @@ bool AudioEngine::startSidetoneStream()
     if (!m_outputDevice.isNull()) {
         const auto outputs = QMediaDevices::audioOutputs();
         for (const auto& d : outputs) {
+            // Use the freshly enumerated Qt device object so backend-specific
+            // handles follow the selected endpoint after hotplug/default churn.
             if (d.id() == m_outputDevice.id()) { dev = d; break; }
         }
         if (dev.id() != m_outputDevice.id()) {

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1049,7 +1049,10 @@ bool AudioEngine::startSidetoneStream()
     if (!m_outputDevice.isNull()) {
         const auto outputs = QMediaDevices::audioOutputs();
         for (const auto& d : outputs) {
-            if (d.id() == m_outputDevice.id()) { dev = m_outputDevice; break; }
+            if (d.id() == m_outputDevice.id()) { dev = d; break; }
+        }
+        if (dev.id() != m_outputDevice.id()) {
+            qCWarning(lcAudio) << "AudioEngine: saved sidetone output device is unavailable, using the system default output instead";
         }
     }
 

--- a/src/core/CwSidetonePortAudioSink.cpp
+++ b/src/core/CwSidetonePortAudioSink.cpp
@@ -31,20 +31,23 @@ PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
     }
 
     PaDeviceIndex partialMatch = paNoDevice;
+    QString partialMatchName;
     bool partialMatchAmbiguous = false;
     for (PaDeviceIndex i = 0; i < count; ++i) {
         const PaDeviceInfo* info = Pa_GetDeviceInfo(i);
         if (!info || info->maxOutputChannels <= 0 || !info->name)
             continue;
 
+        const QString rawName = QString::fromUtf8(info->name);
         const QString candidate =
-            normalizedDeviceName(QString::fromUtf8(info->name));
+            normalizedDeviceName(rawName);
         if (candidate == target)
             return i;
 
         if (candidate.contains(target) || target.contains(candidate)) {
             if (partialMatch == paNoDevice) {
                 partialMatch = i;
+                partialMatchName = rawName;
             } else {
                 partialMatchAmbiguous = true;
             }
@@ -58,6 +61,13 @@ PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
         return paNoDevice;
     }
 
+    if (partialMatch != paNoDevice) {
+        qCWarning(lcAudio) << "CwSidetonePortAudioSink: selected Qt output device"
+                           << device.description()
+                           << "partially matched PortAudio output"
+                           << partialMatchName
+                           << "by name substring";
+    }
     return partialMatch;
 }
 
@@ -135,9 +145,9 @@ bool CwSidetonePortAudioSink::start(const QAudioDevice& device,
         return false;
     }
     if (!device.isNull()) {
-        qCInfo(lcAudio) << "CwSidetonePortAudioSink: matched selected Qt output"
-                        << device.description()
-                        << "to PortAudio device" << devInfo->name;
+        qCWarning(lcAudio) << "CwSidetonePortAudioSink: matched selected Qt output"
+                           << device.description()
+                           << "to PortAudio output" << devInfo->name;
     }
 
     // Prefer 48 kHz; fall back to the device's native rate only if the

--- a/src/core/CwSidetonePortAudioSink.cpp
+++ b/src/core/CwSidetonePortAudioSink.cpp
@@ -4,54 +4,65 @@
 
 #include <portaudio.h>
 
+#include <QString>
+
 #include <cstring>
 
 namespace AetherSDR {
 
-CwSidetonePortAudioSink::CwSidetonePortAudioSink() = default;
+namespace {
 
-CwSidetonePortAudioSink::~CwSidetonePortAudioSink()
+QString normalizedDeviceName(QString name)
 {
-    stop();
-    if (m_paInitialized) {
-        Pa_Terminate();
-        m_paInitialized = false;
-    }
+    return name.simplified().toCaseFolded();
 }
 
-bool CwSidetonePortAudioSink::start(const QAudioDevice& /*device*/,
-                                    int desiredRateHz,
-                                    CwSidetoneGenerator* generator)
+PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
 {
-    if (m_stream) return true;
-    if (!generator) return false;
+    const QString target = normalizedDeviceName(device.description());
+    if (target.isEmpty())
+        return paNoDevice;
 
-    if (!m_paInitialized) {
-        const PaError err = Pa_Initialize();
-        if (err != paNoError) {
-            qCWarning(lcAudio) << "CwSidetonePortAudioSink: Pa_Initialize failed —"
-                               << Pa_GetErrorText(err);
-            return false;
-        }
-        m_paInitialized = true;
+    const PaDeviceIndex count = Pa_GetDeviceCount();
+    if (count < 0) {
+        qCWarning(lcAudio) << "CwSidetonePortAudioSink: Pa_GetDeviceCount failed —"
+                           << Pa_GetErrorText(count);
+        return paNoDevice;
     }
 
-    // We deliberately don't try to map QAudioDevice → PortAudio device
-    // index.  The two libraries enumerate differently (Qt names devices
-    // by Pulse/PipeWire/CoreAudio descriptor, PortAudio by host-API
-    // index), and PortAudio's default-output choice tracks the OS's
-    // default-sink setting reliably on every supported platform.  If a
-    // user reports that sidetone goes to the wrong device we'll add a
-    // mapping pass; until then `paNoDevice → use default` is the right
-    // call.
-    //
-    // Linux exception: PipeWire's ALSA compatibility shim (the `default`
-    // ALSA device on a PipeWire system) silently breaks callback-mode
-    // streams — Pa_OpenStream returns success but the audio thread never
-    // schedules the callback.  PipeWire's JACK shim (`pipewire-jack`),
-    // which is what professional audio apps use, exposes the same physical
-    // device at the native sample rate with reliable callbacks.  Prefer
-    // the JACK host API on Linux when available.
+    PaDeviceIndex partialMatch = paNoDevice;
+    bool partialMatchAmbiguous = false;
+    for (PaDeviceIndex i = 0; i < count; ++i) {
+        const PaDeviceInfo* info = Pa_GetDeviceInfo(i);
+        if (!info || info->maxOutputChannels <= 0 || !info->name)
+            continue;
+
+        const QString candidate =
+            normalizedDeviceName(QString::fromUtf8(info->name));
+        if (candidate == target)
+            return i;
+
+        if (candidate.contains(target) || target.contains(candidate)) {
+            if (partialMatch == paNoDevice) {
+                partialMatch = i;
+            } else {
+                partialMatchAmbiguous = true;
+            }
+        }
+    }
+
+    if (partialMatchAmbiguous) {
+        qCWarning(lcAudio) << "CwSidetonePortAudioSink: selected Qt output device"
+                           << device.description()
+                           << "matched multiple PortAudio outputs";
+        return paNoDevice;
+    }
+
+    return partialMatch;
+}
+
+PaDeviceIndex defaultPortAudioOutputDevice()
+{
     PaDeviceIndex devIdx = paNoDevice;
 #ifdef Q_OS_LINUX
     {
@@ -71,6 +82,48 @@ bool CwSidetonePortAudioSink::start(const QAudioDevice& /*device*/,
 #endif
     if (devIdx == paNoDevice)
         devIdx = Pa_GetDefaultOutputDevice();
+    return devIdx;
+}
+
+} // namespace
+
+CwSidetonePortAudioSink::CwSidetonePortAudioSink() = default;
+
+CwSidetonePortAudioSink::~CwSidetonePortAudioSink()
+{
+    stop();
+    if (m_paInitialized) {
+        Pa_Terminate();
+        m_paInitialized = false;
+    }
+}
+
+bool CwSidetonePortAudioSink::start(const QAudioDevice& device,
+                                    int desiredRateHz,
+                                    CwSidetoneGenerator* generator)
+{
+    if (m_stream) return true;
+    if (!generator) return false;
+
+    if (!m_paInitialized) {
+        const PaError err = Pa_Initialize();
+        if (err != paNoError) {
+            qCWarning(lcAudio) << "CwSidetonePortAudioSink: Pa_Initialize failed —"
+                               << Pa_GetErrorText(err);
+            return false;
+        }
+        m_paInitialized = true;
+    }
+
+    PaDeviceIndex devIdx = device.isNull()
+        ? defaultPortAudioOutputDevice()
+        : findPortAudioOutputDevice(device);
+    if (!device.isNull() && devIdx == paNoDevice) {
+        qCWarning(lcAudio) << "CwSidetonePortAudioSink: selected Qt output device"
+                           << device.description()
+                           << "was not found in PortAudio; falling back to QAudioSink";
+        return false;
+    }
     if (devIdx == paNoDevice) {
         qCWarning(lcAudio) << "CwSidetonePortAudioSink: no default output device";
         return false;
@@ -80,6 +133,11 @@ bool CwSidetonePortAudioSink::start(const QAudioDevice& /*device*/,
     if (!devInfo) {
         qCWarning(lcAudio) << "CwSidetonePortAudioSink: Pa_GetDeviceInfo returned null";
         return false;
+    }
+    if (!device.isNull()) {
+        qCInfo(lcAudio) << "CwSidetonePortAudioSink: matched selected Qt output"
+                        << device.description()
+                        << "to PortAudio device" << devInfo->name;
     }
 
     // Prefer 48 kHz; fall back to the device's native rate only if the

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6376,6 +6376,8 @@ void MainWindow::setupAudioDeviceChangeMonitor()
 {
     m_knownAudioInputIds = audioDeviceIds(QMediaDevices::audioInputs());
     m_knownAudioOutputIds = audioDeviceIds(QMediaDevices::audioOutputs());
+    m_knownDefaultAudioInputId = QMediaDevices::defaultAudioInput().id();
+    m_knownDefaultAudioOutputId = QMediaDevices::defaultAudioOutput().id();
 
     m_audioDeviceChangeTimer.setSingleShot(true);
     m_audioDeviceChangeTimer.setInterval(750);
@@ -6408,6 +6410,10 @@ void MainWindow::handleAudioDeviceListChanged()
 
     const QList<QAudioDevice> inputDevices = QMediaDevices::audioInputs();
     const QList<QAudioDevice> outputDevices = QMediaDevices::audioOutputs();
+    const QAudioDevice defaultInput = QMediaDevices::defaultAudioInput();
+    const QAudioDevice defaultOutput = QMediaDevices::defaultAudioOutput();
+    const QByteArray currentDefaultInputId = defaultInput.id();
+    const QByteArray currentDefaultOutputId = defaultOutput.id();
     const QList<QByteArray> currentInputIds = audioDeviceIds(inputDevices);
     const QList<QByteArray> currentOutputIds = audioDeviceIds(outputDevices);
     const QList<QByteArray> addedInputIds =
@@ -6421,6 +6427,12 @@ void MainWindow::handleAudioDeviceListChanged()
 
     m_knownAudioInputIds = currentInputIds;
     m_knownAudioOutputIds = currentOutputIds;
+    const bool defaultInputChanged =
+        currentDefaultInputId != m_knownDefaultAudioInputId;
+    const bool defaultOutputChanged =
+        currentDefaultOutputId != m_knownDefaultAudioOutputId;
+    m_knownDefaultAudioInputId = currentDefaultInputId;
+    m_knownDefaultAudioOutputId = currentDefaultOutputId;
 
     const QAudioDevice currentInput = m_audio->inputDevice();
     const QAudioDevice currentOutput = m_audio->outputDevice();
@@ -6429,9 +6441,9 @@ void MainWindow::handleAudioDeviceListChanged()
     const bool resetOutputToDefault =
         !currentOutput.isNull() && !audioDevicePresent(outputDevices, currentOutput);
     const bool defaultInputNeedsRestart =
-        currentInput.isNull() && !removedInputIds.isEmpty();
+        currentInput.isNull() && (!removedInputIds.isEmpty() || defaultInputChanged);
     const bool defaultOutputNeedsRestart =
-        currentOutput.isNull() && !removedOutputIds.isEmpty();
+        currentOutput.isNull() && (!removedOutputIds.isEmpty() || defaultOutputChanged);
     const bool resetInput = resetInputToDefault || defaultInputNeedsRestart;
     const bool resetOutput = resetOutputToDefault || defaultOutputNeedsRestart;
     const bool reinitializePcInput = resetInput

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -364,6 +364,8 @@ private:
     QTimer            m_audioDeviceChangeTimer;
     QList<QByteArray> m_knownAudioInputIds;
     QList<QByteArray> m_knownAudioOutputIds;
+    QByteArray        m_knownDefaultAudioInputId;
+    QByteArray        m_knownDefaultAudioOutputId;
     bool              m_audioDeviceDialogOpen{false};
     NetworkDiagnosticsHistory* m_networkDiagnosticsHistory{nullptr};
     QsoRecorder*      m_qsoRecorder{nullptr};


### PR DESCRIPTION
## Summary

Fix CW sidetone routing so the local sidetone sink follows AetherSDR's selected PC audio output instead of silently drifting to whatever PortAudio considers the default output.

## Root Cause

The Qt sidetone fallback already accepted a `QAudioDevice`, but the PortAudio sidetone backend ignored the selected Qt device and always opened PortAudio's default output. That meant users who selected a non-default PC audio output in preferences, or who accepted a new output device from the audio device dialog, could still have CW sidetone routed to the wrong physical endpoint.

There was a second related default-following gap: when AetherSDR was configured to follow the system default output, the audio monitor only restarted local audio paths when device IDs were added/removed. If the OS changed the default output without removing the previous device, an existing RX/sidetone sink could stay bound to the old endpoint.

## Changes

- Map selected Qt output device names to PortAudio output devices for the CW sidetone backend.
- Treat missing or ambiguous PortAudio mappings as a backend failure so `AudioEngine` falls back to the Qt `QAudioSink` sidetone path on the selected device.
- Log selected-device, partial-match, ambiguity, and fallback routing decisions with `qCWarning` so support bundles capture the sidetone route without refactoring global logging behavior.
- Keep the existing low-latency PortAudio default/JACK behavior when AetherSDR is following the system default and PortAudio can match that default output.
- Pass the current Qt output device object into the sidetone backend startup path instead of letting PortAudio choose independently.
- Track Qt default input/output IDs in `MainWindow` and restart default-following local audio paths when the OS default changes, even when no device was removed.
- Document the default-device restart behavior and sidetone backend routing/fallback behavior in `docs/audio-pipeline.md`.

## User Impact

Switching PC audio output from app settings or from the new audio-device dialog now restarts CW sidetone on the same output device as RX audio. Users following the OS default output also get a restart when the OS changes that default, keeping sidetone, RX audio, and the title-bar PC audio labels aligned.

## Validation

Local macOS validation:

- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build --parallel 22`
- `cmake --build build --target AetherSDR --parallel 22`
- `./build/cw_sidetone_test`
- `git diff --check`

Built app: `build/AetherSDR.app`

Windows validation by @nigelfenton:

- Environment: Windows 11, Flex 6700, paddle on the radio's HWCW key jack.
- PC audio endpoints present: `TOSHIBA-TV (NVIDIA HDMI)`, `Headphones (Realtek(R) Audio)`, USB Audio, Oculus Virtual, and FlexRadio DAX cables.
- Built clean with MSVC, filling the skipped `check-windows` CI gap; no errors or new warnings on the four source files this PR touches.
- Explicit-output bug-fix test:
  - AetherSDR PC audio output set to `Headphones (Realtek(R) Audio)`.
  - Windows default playback set to `TOSHIBA-TV (NVIDIA HDMI)`.
  - Local CW sidetone via the CWX panel stayed on the Realtek headphones; the TV stayed silent.
- Hotplug test:
  - Plugging Realtek headphones in mid-session opened the Audio Device Detected dialog.
  - Accepting the dialog moved both RX audio and CW sidetone to the new device cleanly.
- Explicit selection vs OS default test:
  - While AetherSDR was explicitly set to Realtek, changing the Windows default back to TOSHIBA-TV did not restart or reroute AetherSDR audio.
  - CW sidetone correctly stayed on Realtek.
- Not exercised on Nigel's machine: partial-match and ambiguity branches of `findPortAudioOutputDevice`; his Realtek mapping was unambiguous.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
