### PR TITLE
fix(aetherial): clarify BYPASS tooltip — Final Output Stage stays active (#2891)

### DIFF
--- a/src/gui/AetherialAudioStrip.cpp
+++ b/src/gui/AetherialAudioStrip.cpp
@@ -304,8 +304,8 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
             "}"
             "QPushButton:checked:hover { background: #5a4a28; }");
         m_bypassBtn->setToolTip(
-            tr("Disable every stage in the active chain.  Click again "
-               "to restore the stages that were on before."));
+            tr("Bypass every stage in the active chain except the Final Output "
+               "Stage (Trim, LIM, DC).  Click again to restore."));
         connect(m_bypassBtn, &QPushButton::toggled,
                 this, &AetherialAudioStrip::onBypassToggled);
         // Initial visual state from engine, then keep it in lock-step


### PR DESCRIPTION
## Summary

Fixes a misleading user-facing string on the Aetherial channel strip BYPASS button. The tooltip claimed BYPASS would "Disable every stage in the active chain", but the implementation only toggles the seven DSP chain stages (GATE, EQ, DESS, COMP, TUBE, EVO, VERB). The Final Output Stage (Trim, LIM, DC) continues to process the signal regardless — Trim in particular is applied unconditionally on every sample.

## Why

The underlying architecture (chain = bypassable, Final Output Stage = always on) is a reasonable design choice, but the tooltip didn't reflect it. As the reporter noted in #2891, toggling BYPASS while Trim was set to a non-zero value still changed the output level — surprising behavior given the original wording.

This PR updates the tooltip to accurately describe scope:

> Bypass every stage in the active chain except the Final Output Stage (Trim, LIM, DC). Click again to restore.

Changes:
- "Disable" → "Bypass" (matches the button label and the actual operation; chain is bypassed, not disabled).
- Names the Final Output Stage components (Trim, LIM, DC) explicitly so the user knows exactly what survives the toggle.
- Keeps the "Click again to restore" semantic — the chain returns to its prior per-stage state.

## Scope

- 2 lines changed in `src/gui/AetherialAudioStrip.cpp:307-308`
- No behavior change — string only
- No protocol / persistence / API / radio-side change

## Verification

**Linux (`nobara-dell` — Nobara 43, Qt 6.10.3, gcc 15.2.1):**
- [x] Incremental `ninja -C build` clean.
- [x] Launched `./build/AetherSDR` on Plasma Wayland session, hovered the BYPASS button on the Aetherial channel strip — confirmed new tooltip text renders correctly: *"Bypass every stage in the active chain except the Final Output Stage (Trim, LIM, DC). Click again to restore."* No truncation, no encoding issue.

**macOS (M2 Apple Silicon, macOS 26.4.1, Qt 6.9.3 via Homebrew):**
- [x] Native build from source — `cmake -B build -GNinja -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt -DCMAKE_BUILD_TYPE=Release && ninja -C build -j 8` produced `build/AetherSDR.app` bundle clean (650 targets).
- [x] Launched `AetherSDR.app`, hovered BYPASS button — tooltip renders correctly on macOS as well.

Closes #2891

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent. Linux + macOS validation pair (`nobara-dell` + M2 MacBook Pro).
