### PR TITLE
feat(spothub): raise DX Spots Levels slider cap 10 → 15 (#2890)

### DIFF
--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2081,7 +2081,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     grid->addWidget(new QLabel("Levels:"), row, 0);
     auto* levelsRow = new QHBoxLayout;
     auto* levelsSlider = new GuardedSlider(Qt::Horizontal);
-    levelsSlider->setRange(1, 10);
+    levelsSlider->setRange(1, 15);
     levelsSlider->setValue(levels);
     auto* levelsValue = new QLabel(QString::number(levels));
     levelsValue->setFixedWidth(24);


### PR DESCRIPTION
## Summary

Raise the **SpotHub Display → Levels** slider's upper bound from 10 to 15. Lets users opting into more vertical headroom on tall displays stack more callsign labels before the per-X "+N" overflow badge takes over.

## Why

The 10-level cap was inherited from SmartSDR. On tall (4K / vertical-orientation / multi-monitor) displays there is plenty of room to stack more spot labels, and contest reporters consistently ask for more visible callsigns before overflow collapsing kicks in. The reporter in #2890 specifically called for 15.

The underlying rendering is already level-agnostic:

- `SpectrumWidget::drawSpots()` uses a label-collision walker that nudges down per-label and falls into the per-X overflow group once `m_spotMaxLevels` is exhausted (`maxBottom = startY + (th + kSpotLabelGap) * m_spotMaxLevels`).
- The `+N` overflow badge already aggregates the leftover spots regardless of cap value.
- The setting is persisted as `SpotsMaxLevel` in `AppSettings` and re-applied to every Panorama applet via `setSpotMaxLevels(int)`.

So this PR is purely a UI clamp change — no settings migration, no rendering changes, no behavior diff for users who don't touch the slider.

## Scope

- 1 line changed in `src/gui/DxClusterDialog.cpp:2084` (`setRange(1, 10)` → `setRange(1, 15)`)
- Default value (3) unchanged
- Existing user prefs at 1..10 stay valid
- No protocol / persistence / radio-side change

## Verification

**Linux (`nobara-dell` — Nobara 43, Qt 6.10.3, gcc 15.2.1):**
- [x] Incremental `ninja -C build` clean.
- [x] Launched `./build/AetherSDR` on Plasma Wayland session → Settings → SpotHub → **Display** tab → confirmed the Levels slider drags to 15 (no clamp at 10). Slider value label updates correctly through the new range.

**macOS (M2 Apple Silicon, macOS 26.4.1, Qt 6.9.3 via Homebrew):**
- [x] Native build from source — `cmake -B build -GNinja -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt -DCMAKE_BUILD_TYPE=Release && ninja -C build -j 8` produced `build/AetherSDR.app` bundle clean.
- [x] Launched `AetherSDR.app` (connected to a real Flex 6700 with active DX cluster feed) → SpotHub Display tab → confirmed the Levels slider drags 1→15 and the Panorama renders additional rows correctly. No clamp, no visual artifacts at the new upper bound.

Closes #2890

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent. Linux + macOS validation pair (`nobara-dell` + M2 MacBook Pro).
