### PR TITLE
feat(radiomodel): add autoSaveChanged(bool) signal; remove manual UI sync in ProfileManagerDialog (#2794)

### DIFF
--- a/src/gui/ProfileManagerDialog.cpp
+++ b/src/gui/ProfileManagerDialog.cpp
@@ -221,15 +221,10 @@ QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,
                     box.setDefaultButton(enableBtn);
                     box.exec();
                     if (box.clickedButton() == enableBtn) {
+                        // The sibling Auto-Save tab checkbox is wired to
+                        // RadioModel::autoSaveChanged below, so the radio's
+                        // confirmation of auto_save=1 will sync it.
                         m_model->sendCommand("profile autosave on");
-                        // Keep the sibling Auto-Save tab checkbox in sync —
-                        // RadioModel has no autoSaveChanged signal, so the
-                        // checkbox would otherwise read stale until the
-                        // dialog is reopened.
-                        if (m_autoSaveTx) {
-                            QSignalBlocker block(m_autoSaveTx);
-                            m_autoSaveTx->setChecked(true);
-                        }
                     }
                     return;
                 }
@@ -295,6 +290,17 @@ QWidget* ProfileManagerDialog::buildAutoSaveTab()
 
     connect(m_autoSaveTx, &QCheckBox::toggled, this, [this](bool on) {
         m_model->sendCommand(QString("profile autosave %1").arg(on ? "on" : "off"));
+    });
+
+    // React to Auto-Save flips that originate outside this checkbox —
+    // the Profile Manager "Enable Auto-Save" affirmation, TCI clients,
+    // profile load, or remote SmartSDR clients all flip auto_save via
+    // the radio.  QSignalBlocker prevents the resulting setChecked from
+    // bouncing back into ::toggled and re-issuing the radio command.
+    connect(m_model, &RadioModel::autoSaveChanged, this, [this](bool on) {
+        if (!m_autoSaveTx) return;
+        QSignalBlocker block(m_autoSaveTx);
+        m_autoSaveTx->setChecked(on);
     });
 
     vbox->addWidget(m_autoSaveTx);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -4182,8 +4182,12 @@ void RadioModel::handleRadioStatus(const QMap<QString, QString>& kvs)
         changed = true;
     }
     if (kvs.contains("auto_save")) {
-        m_autoSave = kvs["auto_save"] == "1";
-        changed = true;
+        const bool newAutoSave = kvs["auto_save"] == "1";
+        if (m_autoSave != newAutoSave) {
+            m_autoSave = newAutoSave;
+            emit autoSaveChanged(newAutoSave);
+            changed = true;
+        }
     }
     if (kvs.contains("freq_error_ppb")) {
         m_freqErrorPpb = kvs["freq_error_ppb"].toInt();

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -431,6 +431,14 @@ signals:
     void globalProfilesChanged();
     void profileDatabaseImportingChanged(bool importing);
     void profileDatabaseExportingChanged(bool exporting);
+
+    // Emitted when the radio reports a change to the global Auto-Save
+    // profile setting (radio status field "auto_save").  UI consumers
+    // should react via this signal rather than polling autoSave() — the
+    // value can be flipped by the Auto-Save tab, the Profile Manager
+    // "Enable Auto-Save" affirmation, TCI clients, profile load, and
+    // other connected SmartSDR clients.
+    void autoSaveChanged(bool autoSave);
     // Emitted on each successful ping response from the radio.
     void pingReceived();
     // Generic status relay — for dialogs that need to listen for specific objects.


### PR DESCRIPTION
## Summary

Adds the missing `RadioModel::autoSaveChanged(bool)` signal called out in #2794, then removes the manual `QSignalBlocker` UI-sync code in `ProfileManagerDialog` that previously papered over its absence. Wires the dialog's Auto-Save tab checkbox to the new signal so flips originating outside the checkbox (Profile Manager "Enable Auto-Save" affirmation, TCI clients, profile load, remote SmartSDR clients) propagate automatically.

## Why

PR #2790 added an inline "Enable Auto-Save" affirmation to the existing-profile warning in `ProfileManagerDialog`. Because `RadioModel` had no `autoSaveChanged` signal at the time, the dialog manually toggled the sibling checkbox via `QSignalBlocker` every time the affirmation fired. The in-code comment in that block explicitly flagged the gap:

```cpp
// Keep the sibling Auto-Save tab checkbox in sync —
// RadioModel has no autoSaveChanged signal, so the
// checkbox would otherwise read stale until the
// dialog is reopened.
```

This works for the one path through the dialog, but four other paths can flip `auto_save` independently — and any future consumer (status-bar indicator, TCI broadcast, settings export) had no way to observe the state change other than polling `autoSave()` or assuming the dialog was the only mutator.

Closing the gap surfaces Auto-Save through the same signal pattern as the rest of `RadioModel`'s status fields.

## Changes

### `src/models/RadioModel.h`
- Add `void autoSaveChanged(bool autoSave)` to the signals block, alongside `globalProfilesChanged` / `profileDatabaseImportingChanged` / `profileDatabaseExportingChanged` — the natural neighbourhood for profile-state signals.
- Comment lists the four upstream sources that can flip `auto_save`.

### `src/models/RadioModel.cpp` (`auto_save` parse branch, ~line 4184)
- Compare the incoming value against `m_autoSave` before assigning.
- Emit `autoSaveChanged(newAutoSave)` only on actual transition.
- Gate `changed = true` on the same condition — drops the minor side bug where every radio status frame containing `auto_save` (regardless of value) marked the model dirty.

### `src/gui/ProfileManagerDialog.cpp`
- Drop the manual `QSignalBlocker block(m_autoSaveTx); m_autoSaveTx->setChecked(true);` block that fired after the "Enable Auto-Save" affirmation. The radio's confirmation of `auto_save=1` now fires `autoSaveChanged`, which the dialog handles below.
- Wire `RadioModel::autoSaveChanged` to a lambda that uses `QSignalBlocker` on `m_autoSaveTx` before `setChecked`, per the project's GUI ↔ model echo-loop rule (CLAUDE.md). The blocker prevents `QCheckBox::toggled` from re-issuing `profile autosave on/off` to the radio.

## Behavioural impact

- The Profile Manager "Enable Auto-Save" affirmation now flips the Auto-Save tab checkbox a few milliseconds later (after radio confirmation) instead of optimistically/immediately. For a sub-frame status round-trip this is below human perception.
- Future consumers can connect to `autoSaveChanged` instead of polling `autoSave()` — the original ask in #2794.

## Scope

- 3 files, +28 / −10 lines:
  - `src/models/RadioModel.h` — signal declaration + comment
  - `src/models/RadioModel.cpp` — parse-branch refactor
  - `src/gui/ProfileManagerDialog.cpp` — remove manual sync, wire new signal
- No protocol change, no persistence change, no radio-side command change

## Verification

**Linux (`nobara-dell` — Nobara 43, Qt 6.10.3, gcc 15.2.1):**
- [x] Incremental `ninja -C build` clean — header change triggered `moc` regeneration for `RadioModel` + dependent recompilation; link succeeded.
- [x] Launched `./build/AetherSDR` on Plasma Wayland session — Profile Manager opens, Auto-Save tab present, direct toggle of the "Auto-save profile changes" checkbox works both directions without runtime signal-connect errors or crash. (No radio-side propagation testable on this host — nobara-dell has no LAN reach to Ozy's Flex 6700.)

**macOS (M2 Apple Silicon, macOS 26.4.1, Qt 6.9.3 via Homebrew) — connected to real Flex 6700:**
- [x] Native build from source — `cmake -B build -GNinja -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt -DCMAKE_BUILD_TYPE=Release && ninja -C build -j 8` produced `build/AetherSDR.app` bundle clean (650 targets, 42 MB binary).
- [x] Launched `AetherSDR.app` against a live Flex 6700. Profile Manager opens cleanly. Auto-Save tab checkbox reflects the radio's actual `auto_save` setting on connect.
- [x] Direct toggle of the Auto-Save checkbox: clean OFF → ON → OFF, single `profile autosave on/off` command emitted per toggle as observed on the radio side; no rapid-fire echo or repeated commands (the new `QSignalBlocker`-wrapped connect to `RadioModel::autoSaveChanged` prevents the back-loop).
- [x] **External-source flip — the key signal test.** Ran official SmartSDR v4.2.18 (Apple Silicon arm64) alongside AetherSDR, both connected to the same Flex 6700. Toggled Auto-Save from SmartSDR → AetherSDR's Auto-Save checkbox updated in **real time** via the new `autoSaveChanged` signal, with no user interaction in AetherSDR. End-to-end signal propagation confirmed against real radio + real cross-client flip.

Closes #2794

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent. Linux + macOS validation pair (`nobara-dell` + M2 MacBook Pro running SmartSDR v4.2.18 alongside).
