### PR TITLE
CODEOWNERS: expand @jensenpat scope + lock policy/governance + signing key

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,16 +33,14 @@ src/core/AudioEngine.cpp     @ten9876 @jensenpat
 src/core/PanadapterStream.h  @ten9876 @jensenpat
 src/core/PanadapterStream.cpp @ten9876 @jensenpat
 
-# Build & CI infrastructure
+# Build configuration
 CMakeLists.txt               @ten9876 @jensenpat
-.github/workflows/           @ten9876 @jensenpat
 
 # Security tooling & agent configuration
 .github/codeql/              @ten9876 @jensenpat
 .claude/commands/            @ten9876 @jensenpat
 
-# ── Tier 4: project policy & cryptographic anchors — maintainer-only ───────
-# Governance, contributor guidance, agent rules, and access policy.
+# ── Tier 4: project policy — maintainer-only ──────────────────────────────
 CLAUDE.md                    @ten9876
 CONTRIBUTING.md              @ten9876
 GOVERNANCE.md                @ten9876
@@ -51,6 +49,8 @@ SECURITY.md                  @ten9876
 LICENSE                      @ten9876
 .github/CODEOWNERS           @ten9876
 
-# Release signing key — supply-chain critical. Overrides the tier-2 docs/
-# pattern so the bot cannot approve a key swap.
+# CI runtime — release artifacts, registry pushes, GITHUB_TOKEN scopes.
+.github/workflows/           @ten9876
+
+# Release signing key — overrides the tier-2 docs/ pattern.
 docs/RELEASE-SIGNING-KEY.pub.asc  @ten9876

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,10 @@
 # AetherSDR CODEOWNERS
 #
-# Three tiers, last-matching-pattern wins:
+# Four tiers, last-matching-pattern wins:
 #   1. Broad default — jensenpat + maintainer
 #   2. Mechanical/safe paths — also approvable by @AetherClaude (machine user)
-#   3. Maintainer-only — direction-impacting paths reserved to @ten9876
+#   3. Architecture & infrastructure — jensenpat + maintainer (no bot approval)
+#   4. Project policy — reserved to @ten9876
 #
 # Self-approval is hard-blocked by GitHub regardless of CODEOWNERS membership,
 # so a contributor cannot approve their own PR even on paths they own.
@@ -19,22 +20,24 @@ docs/                        @ten9876 @jensenpat @AetherClaude
 .github/docker/              @ten9876 @jensenpat @AetherClaude
 .github/ISSUE_TEMPLATE/      @ten9876 @jensenpat @AetherClaude
 
-# ── Tier 3: maintainer-only — direction, architecture, project policy ──────
+# ── Tier 3: architecture & infrastructure — bot cannot approve ─────────────
 # Visual/UX direction (per CLAUDE.md "AI Agent Boundaries")
-src/gui/MainWindow.h         @ten9876
-src/gui/MainWindow.cpp       @ten9876
+src/gui/MainWindow.h         @ten9876 @jensenpat
+src/gui/MainWindow.cpp       @ten9876 @jensenpat
 
 # Architecture — central state, threading, protocol bedrock
-src/core/RadioModel.h        @ten9876
-src/core/RadioModel.cpp      @ten9876
-src/core/AudioEngine.h       @ten9876
-src/core/AudioEngine.cpp     @ten9876
-src/core/PanadapterStream.h  @ten9876
-src/core/PanadapterStream.cpp @ten9876
+src/models/RadioModel.h      @ten9876 @jensenpat
+src/models/RadioModel.cpp    @ten9876 @jensenpat
+src/core/AudioEngine.h       @ten9876 @jensenpat
+src/core/AudioEngine.cpp     @ten9876 @jensenpat
+src/core/PanadapterStream.h  @ten9876 @jensenpat
+src/core/PanadapterStream.cpp @ten9876 @jensenpat
 
-# Build, project policy, and infrastructure
-CMakeLists.txt               @ten9876
+# Build & CI infrastructure
+CMakeLists.txt               @ten9876 @jensenpat
+.github/workflows/           @ten9876 @jensenpat
+
+# ── Tier 4: project policy — maintainer-only ───────────────────────────────
 CLAUDE.md                    @ten9876
 CONTRIBUTING.md              @ten9876
 .github/CODEOWNERS           @ten9876
-.github/workflows/           @ten9876

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,20 @@ src/core/PanadapterStream.cpp @ten9876 @jensenpat
 CMakeLists.txt               @ten9876 @jensenpat
 .github/workflows/           @ten9876 @jensenpat
 
-# ── Tier 4: project policy — maintainer-only ───────────────────────────────
+# Security tooling & agent configuration
+.github/codeql/              @ten9876 @jensenpat
+.claude/commands/            @ten9876 @jensenpat
+
+# ── Tier 4: project policy & cryptographic anchors — maintainer-only ───────
+# Governance, contributor guidance, agent rules, and access policy.
 CLAUDE.md                    @ten9876
 CONTRIBUTING.md              @ten9876
+GOVERNANCE.md                @ten9876
+CODE_OF_CONDUCT.md           @ten9876
+SECURITY.md                  @ten9876
+LICENSE                      @ten9876
 .github/CODEOWNERS           @ten9876
+
+# Release signing key — supply-chain critical. Overrides the tier-2 docs/
+# pattern so the bot cannot approve a key swap.
+docs/RELEASE-SIGNING-KEY.pub.asc  @ten9876


### PR DESCRIPTION
## Summary

Three commits restructuring `.github/CODEOWNERS`:

- Expand @jensenpat's review scope to cover application architecture.
- Tighten approval scope on the files that define project policy, security policy, and release trust.
- Address review feedback on tier placement.

---

## Commit 1 — `dee3805` — expand @jensenpat to architecture + infra

Three related changes:

### 1.1 Expand @jensenpat's approval scope

Adds @jensenpat to the previously maintainer-only tier covering architecture and CI infrastructure: `MainWindow.{h,cpp}`, `AudioEngine.{h,cpp}`, `PanadapterStream.{h,cpp}`, `RadioModel.{h,cpp}`, `CMakeLists.txt`. Pair review now applies on those paths.

### 1.2 Fix RadioModel paths

The previous tier-3 entry referenced `src/core/RadioModel.{h,cpp}`, but the file actually lives at **`src/models/RadioModel.{h,cpp}`**. The old pattern didn't match anything on disk, so RadioModel PRs were silently falling through to tier 1. Path corrected.

### 1.3 Split tier 3 into two tiers

Old tier 3 mixed architecture with project policy. Restructured into:
- **Tier 3** — architecture & infrastructure (jensenpat + maintainer, no bot).
- **Tier 4** — project policy (maintainer-only).

---

## Commit 2 — `54e00f9` — explicit entries for governance + key

### 2.1 New tier-4 entries

| File | Reason |
|---|---|
| `GOVERNANCE.md` | Defines project authority. |
| `SECURITY.md` | Vulnerability disclosure channel. |
| `CODE_OF_CONDUCT.md` | Community policy. |
| `LICENSE` | Legal foundation. |
| `docs/RELEASE-SIGNING-KEY.pub.asc` | Release-signing public key. Explicit entry overrides the tier-2 `docs/` pattern via last-match. |

### 2.2 New tier-3 entries

| File | Reason |
|---|---|
| `.github/codeql/` | Static-analysis configuration. Previously fell through to tier 1. |
| `.claude/commands/` | Bot triage policy. |

### 2.3 Intentionally not raised

`README.md`, `CHANGELOG.md`, `STYLEGUIDE.md`, `RECENTER.md`, `THIRD_PARTY_LICENSES` stay at their current tiers — contributor-edited or mechanically derived.

---

## Commit 3 — `78c0a50` — keep `.github/workflows/` at tier 4

Per [@aethersdr-agent[bot]'s review](https://github.com/aethersdr/AetherSDR/pull/2915#pullrequestreview-4337646394): workflow runtime handles release artifacts, registry pushes, and runs with `GITHUB_TOKEN` scopes. Returning approval scope on `.github/workflows/` to maintainer-only and dropping it out of tier 3.

`CMakeLists.txt`, `.github/codeql/`, and `.claude/commands/` remain at tier 3 — configuration rather than runtime.

Inline tier-4 comments also trimmed to the bare functional explanation.

---

## End state — who can approve what

- **Tier 1** (broad default) — maintainer + jensenpat — unchanged.
- **Tier 2** (mechanical/safe) — + bot — unchanged.
- **Tier 3** (architecture, build config, static-analysis config, agent config) — jensenpat + maintainer, **no bot**.
- **Tier 4** (governance, security policy, license, signing key, **workflows**, CODEOWNERS itself) — **maintainer-only**.

After merge, @jensenpat can approve PRs on every path *except* the tier-4 set.

## Test plan

- [ ] Open a trivial PR touching `src/core/AudioEngine.cpp` — confirm @jensenpat is eligible.
- [ ] Open a trivial PR touching `src/models/RadioModel.cpp` — confirm tier-3 reviewers are requested (validates the 1.2 path fix).
- [ ] Open a trivial PR touching `CLAUDE.md`, `GOVERNANCE.md`, or `SECURITY.md` — confirm only @ten9876 is requested.
- [ ] Open a trivial PR touching `docs/RELEASE-SIGNING-KEY.pub.asc` — confirm only @ten9876 is requested.
- [ ] Open a trivial PR touching `.github/workflows/sanitizers.yml` — confirm only @ten9876 is requested (commit 3 verification).
- [ ] Open a trivial PR touching `.github/codeql/codeql-config.yml` — confirm tier-3 reviewers are requested.

https://claude.ai/code/session_01PSLHgUjYZsq67v3Fz4peAE