### PR TITLE
ci: least-privilege GITHUB_TOKEN scopes on ci.yml and codeql.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ on:
   push:
     branches: [main]
 
+# Least-privilege GITHUB_TOKEN. CI only needs to read repo contents to
+# build and test — no writes, no token-bearing API calls. Any future job
+# that needs more (e.g. publishing a comment) must opt in at the job level.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,12 +25,26 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # weekly Monday 06:00 UTC
 
+# Workflow-level least-privilege GITHUB_TOKEN. CodeQL's official guidance
+# (https://github.com/github/codeql-action#permissions) is:
+#   actions: read           — needed by the CodeQL action to inspect this
+#                              workflow's metadata for category info.
+#   contents: read          — needed by actions/checkout to fetch the repo.
+#   security-events: write  — needed by the analyze step to upload SARIF.
+# Previously the block sat at job level and declared only
+# `security-events: write`, which (per GitHub's "specify any → unspecified
+# default to none" rule) dropped contents and actions to none. It worked
+# only because the repo is public; tightening to documented scopes makes
+# the intent explicit and survives a hypothetical visibility change.
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     runs-on: ubuntu-latest
     container: ghcr.io/ten9876/aethersdr-ci:latest
-    permissions:
-      security-events: write
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Brings `ci.yml` and `codeql.yml` in line with every other workflow in this repo by declaring an explicit workflow-level `permissions:` block.

| Workflow | Scopes |
|---|---|
| `ci.yml` | `contents: read` |
| `codeql.yml` | `actions: read`, `contents: read`, `security-events: write` |

## codeql.yml note

The previous declaration sat at the job level and contained only `security-events: write`. Per GitHub's documented behavior — unspecified scopes default to `none` once any permission is set — lifting to the workflow level with the scope set in [github/codeql-action's README](https://github.com/github/codeql-action#permissions) makes the intent explicit and matches how the other workflows in this repo are structured.

## Followups

Tracked separately, each landing in its own PR:

- ⬜ Pin `ghcr.io/ten9876/aethersdr-ci` to a `sha256:` digest.
- ⬜ Pin third-party GitHub Actions to commit SHA.

## Test plan

- [ ] CI passes on this PR.
- [ ] CodeQL passes on this PR.
- [ ] Workflow run summary shows the declared `GITHUB_TOKEN Permissions` scope set.

https://claude.ai/code/session_01PSLHgUjYZsq67v3Fz4peAE