### PR TITLE
ci: auto-pin aethersdr-ci image digest in ci.yml + codeql.yml

### DIFF
--- a/.github/workflows/docker-ci-image.yml
+++ b/.github/workflows/docker-ci-image.yml
@@ -12,6 +12,15 @@ permissions:
   packages: write       # docker/build-push-action: push the image
   pull-requests: write  # peter-evans/create-pull-request: open the bump PR
 
+# Serialize concurrent runs so a Dockerfile push that lands during a
+# manual workflow_dispatch doesn't race on the auto-PR branch.
+# cancel-in-progress: false — never kill a run that may already be
+# mid-publish to the registry; let the second run queue and overwrite
+# the auto-PR with its newer digest.
+concurrency:
+  group: docker-ci-image
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-ci-image.yml
+++ b/.github/workflows/docker-ci-image.yml
@@ -8,7 +8,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  packages: write
+  contents: write       # peter-evans/create-pull-request: push the bump branch
+  packages: write       # docker/build-push-action: push the image
+  pull-requests: write  # peter-evans/create-pull-request: open the bump PR
 
 jobs:
   build:
@@ -25,8 +27,62 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7
         with:
           context: .github/docker
           push: true
           tags: ghcr.io/ten9876/aethersdr-ci:latest
+
+      - name: Update workflow consumers to new digest
+        id: pin
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          if [ -z "$DIGEST" ]; then
+            echo "::error::docker/build-push-action did not return a digest"
+            exit 1
+          fi
+          # Rewrite any existing reference (digest form OR tag form) to the
+          # newly published digest. Idempotent both ways: re-runs producing
+          # the same digest leave the files unchanged, and the bootstrap
+          # run swaps the legacy ":latest" reference cleanly.
+          # The `[ -f ]` guard lets the loop run cleanly even if a consumer
+          # file isn't on main yet (e.g. sanitizers.yml until PR #2866 lands).
+          for f in .github/workflows/ci.yml \
+                   .github/workflows/codeql.yml \
+                   .github/workflows/sanitizers.yml; do
+            [ -f "$f" ] || continue
+            sed -i -E \
+              "s#(ghcr\.io/ten9876/aethersdr-ci)(@sha256:[a-f0-9]+|:[A-Za-z0-9._-]+)#\1@${DIGEST}#g" \
+              "$f"
+          done
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Pinned workflow consumers to ${DIGEST}"
+          git diff --stat .github/workflows/
+
+      - name: Open PR to bump pinned digest
+        if: steps.pin.outputs.digest != ''
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
+        with:
+          branch: ci-image/digest-bump
+          delete-branch: true
+          commit-message: "ci: pin aethersdr-ci to ${{ steps.pin.outputs.digest }}"
+          title: "ci: pin aethersdr-ci image to latest build"
+          body: |
+            Automated update from `docker-ci-image.yml` after building and
+            publishing a new CI image from the current
+            `.github/docker/Dockerfile`.
+
+            Updates the `ghcr.io/ten9876/aethersdr-ci` reference in
+            `ci.yml`, `codeql.yml`, and `sanitizers.yml` (where present) to:
+
+                ${{ steps.pin.outputs.digest }}
+
+            The image is still tagged `:latest` at the registry; pinning the
+            workflow consumers by digest gives each CI run a reproducible,
+            immutable reference even if the `:latest` tag is republished later.
+
+            Review the linked Dockerfile change(s) and the resulting digest
+            before merging.
+          labels: ci


### PR DESCRIPTION
## Summary

Adds an auto-pin mechanism to `docker-ci-image.yml`. After it publishes a new CI image, it captures the sha256 digest from `docker/build-push-action`'s output and opens an auto-PR that rewrites the `ghcr.io/ten9876/aethersdr-ci` reference in `ci.yml` and `codeql.yml` from the tag form (`:latest`) to the digest form (`@sha256:…`). Each CI run then consumes a reproducible, immutable reference.

Mirrors the existing auto-PR pattern from `update-rnnoise.yml`:
- `peter-evans/create-pull-request@v8`
- `branch: ci-image/digest-bump`, `delete-branch: true`
- `labels: ci`

## Permissions

Extended from `packages: write` to also include:

| Scope | Reason |
|---|---|
| `contents: write` | `peter-evans/create-pull-request` needs to push the bump branch. |
| `pull-requests: write` | …and open the PR. |
| `packages: write` | (unchanged — image push.) |

## Idempotency

The `sed` rewrites cover both forms:

```
ghcr.io/ten9876/aethersdr-ci@sha256:<hex>   ← digest form
ghcr.io/ten9876/aethersdr-ci:<tag>          ← tag form (anything matching [A-Za-z0-9._-]+)
```

So:
- **First run** (against the current `:latest` references) swaps in the new digest.
- **Re-runs producing the same digest** leave the files unchanged; `peter-evans/create-pull-request` declines to open a PR when there's no diff.
- **Re-runs producing a new digest** cleanly replace the previous one.

## Scope

This PR adds the mechanism only — it does **not** modify `ci.yml` or `codeql.yml`. After merge, one `workflow_dispatch` run on **Build CI Docker Image** produces the bootstrap PR that lands the first pinned digest.

## Followups

Tracked separately:
- ⬜ Pin third-party GitHub Actions to commit SHA (item 3 of the supply-chain triplet).

## Test plan

- [ ] Merge this PR.
- [ ] Manually trigger **Actions → Build CI Docker Image → Run workflow** on `main`.
- [ ] Confirm the workflow:
  - [ ] Publishes the image and reports a non-empty digest output.
  - [ ] Logs a `git diff --stat` showing rewritten lines in `ci.yml` and `codeql.yml`.
  - [ ] Opens a PR on branch `ci-image/digest-bump` with title "ci: pin aethersdr-ci image to latest build", labeled `ci`.
- [ ] Verify the auto-PR's diff: both files reference `ghcr.io/ten9876/aethersdr-ci@sha256:<the digest reported by the workflow>`.
- [ ] Merge the auto-PR; subsequent CI runs should use the pinned digest.

https://claude.ai/code/session_01PSLHgUjYZsq67v3Fz4peAE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSLHgUjYZsq67v3Fz4peAE)_