### PR TITLE
ci: pin all third-party action references by commit SHA

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install system dependencies
         run: |
@@ -137,13 +137,13 @@ jobs:
             --output appimage
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: AppImage-${{ matrix.arch }}
           path: AetherSDR-*.AppImage
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3
         with:
           files: AetherSDR-*.AppImage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     container: ghcr.io/ten9876/aethersdr-ci:latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Setup DeepFilterNet3 (DFNR)
         run: bash setup-deepfilter.sh
@@ -35,8 +35,8 @@ jobs:
     outputs:
       build-changed: ${{ steps.filter.outputs.build }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
         id: filter
         with:
           filters: |
@@ -64,10 +64,10 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730  # v4.3.1
         with:
           # 6.8.3 matches what community Windows builders are running and
           # exposes Qt 6.8.x MOC volume so we catch issues like #1910 (MSVC
@@ -77,7 +77,7 @@ jobs:
           cache: true
 
       - name: Cache FFTW3
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: third_party/fftw3
           key: ${{ runner.os }}-fftw3-3.3.5-${{ hashFiles('setup-fftw.ps1') }}
@@ -94,7 +94,7 @@ jobs:
         run: .\setup-deepfilter.ps1
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e  # v0.0.10
 
       # CMAKE_CXX_COMPILER_LAUNCHER is honoured by Ninja and Make
       # generators, NOT by the Visual Studio / MSBuild generator that
@@ -103,7 +103,7 @@ jobs:
       # puts the MSVC toolchain on PATH (cl.exe, link.exe, etc.) so
       # Ninja can find them.
       - name: Setup MSVC environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
         with:
           arch: x64
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,13 +37,13 @@ jobs:
         language: [cpp]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Fix git ownership for container
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7c1e4cf0b20d7c1872b26569c00ba908797a59bf  # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -55,4 +55,4 @@ jobs:
         run: cmake --build build -j$(nproc)
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7c1e4cf0b20d7c1872b26569c00ba908797a59bf  # v4

--- a/.github/workflows/docker-ci-image.yml
+++ b/.github/workflows/docker-ci-image.yml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7
         with:
           context: .github/docker
           push: true

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           clean: false  # skip post-run cleanup — Intel Qt source build creates huge tree
 
@@ -78,7 +78,7 @@ jobs:
         run: bash setup-deepfilter.sh
 
       - name: Set up ccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: hendrikmuhs/ccache-action@77c3f8fd59034e6f3d5c58867ded0185b48d534f  # v1
         with:
           key: ccache-macos-${{ matrix.label }}
           max-size: 500M
@@ -323,13 +323,13 @@ jobs:
           echo "Notarization and stapling complete"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: macOS-DMG-${{ matrix.label }}
           path: AetherSDR-*.dmg
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3
         with:
           files: AetherSDR-*.dmg

--- a/.github/workflows/sign-release.yml
+++ b/.github/workflows/sign-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Determine tag
         id: tag

--- a/.github/workflows/streamdeck-plugins.yml
+++ b/.github/workflows/streamdeck-plugins.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Package Elgato plugin
         run: |

--- a/.github/workflows/update-rnnoise.yml
+++ b/.github/workflows/update-rnnoise.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Get current bundled commit
         id: current
@@ -90,7 +90,7 @@ jobs:
 
       - name: Create pull request
         if: steps.check.outputs.skip == 'false'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
         with:
           commit-message: "Update bundled RNNoise to ${{ steps.upstream.outputs.sha }}"
           title: "Update bundled RNNoise"

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
 
       - name: Install Qt6
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730  # v4.3.1
         with:
           version: '6.8.*'
           host: 'windows'
@@ -39,7 +39,7 @@ jobs:
       # we bump a version.  Skips the upstream download + build entirely
       # on cache hit.
       - name: Cache Opus
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: cache-opus
         with:
           path: third_party/opus
@@ -50,7 +50,7 @@ jobs:
         run: .\setup-opus.ps1
 
       - name: Cache FFTW3
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: cache-fftw
         with:
           path: third_party/fftw3
@@ -61,7 +61,7 @@ jobs:
         run: .\setup-fftw.ps1
 
       - name: Cache hidapi
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: cache-hidapi
         with:
           path: third_party/hidapi
@@ -72,7 +72,7 @@ jobs:
         run: .\setup-hidapi.ps1
 
       - name: Cache DeepFilterNet3
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: cache-deepfilter
         with:
           path: third_party/deepfilter
@@ -140,7 +140,7 @@ jobs:
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAPP_VERSION=$version "/DVC_RUNTIME_DIR=$runtimeDir" packaging\windows\installer.iss
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: Windows-Installer
           path: |
@@ -149,7 +149,7 @@ jobs:
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3
         with:
           files: |
             AetherSDR-*.zip


### PR DESCRIPTION
## Summary

Pins every `uses:` reference in `.github/workflows/` from a major-version tag (`@v4`, `@v7`, etc.) to the immutable commit SHA the tag currently resolves to, with the version string preserved as a trailing comment.

Format:
```yaml
uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
```

Dependabot already watches the `github-actions` ecosystem weekly (`.github/dependabot.yml`) and supports this format natively — it bumps the SHA *and* the version comment in a single PR when a new release lands.

## Resolved at this commit

| Action | Was | Now |
|---|---|---|
| `actions/cache` | `@v5` | `@27d5ce7…` |
| `actions/checkout` | `@v6` | `@de0fac2…` |
| `actions/upload-artifact` | `@v7` | `@043fb46…` |
| `docker/build-push-action` | `@v7` | `@bcafcac…` |
| `docker/login-action` | `@v4` | `@4907a6d…` |
| `dorny/paths-filter` | `@v4` | `@fbd0ab8…` |
| `github/codeql-action` | `@v4` | `@7c1e4cf…` (both `init` and `analyze`) |
| `hendrikmuhs/ccache-action` | `@v1` | `@77c3f8f…` |
| `ilammy/msvc-dev-cmd` | `@v1` | `@0b201ec…` |
| `jurplel/install-qt-action` | `@v4` | `@48d3ad6…` *(see note)* |
| `mozilla-actions/sccache-action` | `@v0.0.10` | `@1583d6b…` |
| `peter-evans/create-pull-request` | `@v8` | `@5f6978f…` |
| `softprops/action-gh-release` | `@v3` | `@b430933…` |

### jurplel/install-qt-action note

This action doesn't publish a moving `v4` major tag — only specific patch tags (`v4.0.0` … `v4.3.1`). Pinned to the latest v4 release (`v4.3.1` → `48d3ad6`) and the version comment reflects that. Dependabot will bump it like the others when a v4.4 or v5 ships.

## Files changed

9 workflows, 34 lines each side of the diff:

```
appimage.yml             |  6 +++---
ci.yml                   | 16 ++++++++--------
codeql.yml               |  6 +++---
docker-ci-image.yml      |  6 +++---
macos-dmg.yml            |  8 ++++----
sign-release.yml         |  2 +-
streamdeck-plugins.yml   |  2 +-
update-rnnoise.yml       |  4 ++--
windows-installer.yml    | 18 +++++++++---------
```

## Test plan

- [ ] CI passes on this PR (validates every pinned action still resolves and runs cleanly).
- [ ] Confirm no `uses:` line in `.github/workflows/` is left with a major-version tag or branch ref: `grep -hE "uses: [^@]+@(v[0-9]|main|master)" .github/workflows/*.yml | grep -v "@[0-9a-f]\{40\}"` returns nothing.
- [ ] Open the first dependabot bump after merge and confirm it updates both the SHA *and* the trailing `# vN` comment in lockstep.

## Closes the supply-chain triplet

- ✅ #2916 — least-privilege `GITHUB_TOKEN` on `ci.yml`/`codeql.yml`.
- ✅ #2918 — auto-pin `aethersdr-ci` image digest via `docker-ci-image.yml`.
- ✅ This PR — pin all third-party action references by SHA.

https://claude.ai/code/session_01PSLHgUjYZsq67v3Fz4peAE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSLHgUjYZsq67v3Fz4peAE)_