### PR TITLE
[controllers] Light FlexControl LEDs for active buttons

### DIFF
--- a/src/core/FlexControlManager.cpp
+++ b/src/core/FlexControlManager.cpp
@@ -44,7 +44,7 @@ bool FlexControlManager::open(const QString& portName)
     m_port.setStopBits(QSerialPort::OneStop);
     m_port.setFlowControl(QSerialPort::NoFlowControl);
 
-    if (!m_port.open(QIODevice::ReadOnly)) {
+    if (!m_port.open(QIODevice::ReadWrite)) {
         qCWarning(lcDevices) << "FlexControlManager: failed to open" << portName
                    << m_port.errorString();
         return false;
@@ -52,6 +52,7 @@ bool FlexControlManager::open(const QString& portName)
 
     m_buffer.clear();
     qCDebug(lcDevices) << "FlexControlManager: opened" << portName;
+    writeLedState();
     emit connectionChanged(true);
     return true;
 }
@@ -59,10 +60,24 @@ bool FlexControlManager::open(const QString& portName)
 void FlexControlManager::close()
 {
     if (!m_port.isOpen()) return;
+    writeLedCommand(0);
+    m_port.waitForBytesWritten(50);
     m_port.close();
     m_buffer.clear();
     qCDebug(lcDevices) << "FlexControlManager: closed";
     emit connectionChanged(false);
+}
+
+void FlexControlManager::setActiveLedButton(int button)
+{
+    if (button < 1 || button > 3)
+        button = 0;
+
+    if (m_activeLedButton == button)
+        return;
+
+    m_activeLedButton = button;
+    writeLedState();
 }
 
 void FlexControlManager::onReadyRead()
@@ -120,6 +135,31 @@ void FlexControlManager::processCommand(const QByteArray& cmd)
         // Init/reset — log and ignore
         qCDebug(lcDevices) << "FlexControlManager: device reset" << cmd;
     }
+}
+
+void FlexControlManager::writeLedState()
+{
+    writeLedCommand(m_activeLedButton);
+}
+
+void FlexControlManager::writeLedCommand(int button)
+{
+    if (!m_port.isOpen() || !m_port.isWritable())
+        return;
+
+    QByteArray cmd("I000;");
+    if (button >= 1 && button <= 3)
+        cmd[button] = '1';
+
+    const qint64 written = m_port.write(cmd);
+    if (written != cmd.size()) {
+        qCWarning(lcDevices) << "FlexControlManager: failed to write LED command"
+                             << cmd << m_port.errorString();
+        return;
+    }
+
+    qCDebug(lcDevices) << "FlexControlManager: LED command" << cmd;
+    m_port.flush();
 }
 
 } // namespace AetherSDR

--- a/src/core/FlexControlManager.h
+++ b/src/core/FlexControlManager.h
@@ -20,6 +20,7 @@ namespace AetherSDR {
 //   X2S;    — button 2 tap
 //   X3S;    — button 3 tap
 //   X4S;    — knob button tap
+//   I100;   — host sets button 1 LED on (Ixyz; = buttons 1/2/3)
 //   F0304;  — device init/reset
 class FlexControlManager : public QObject {
     Q_OBJECT
@@ -37,6 +38,7 @@ public:
     static QString detectPort();
 
     void setInvertDirection(bool invert) { m_invertDirection = invert; }
+    void setActiveLedButton(int button);
 
     static constexpr quint16 VendorId  = 0x2192;
     static constexpr quint16 ProductId = 0x0010;
@@ -53,10 +55,13 @@ private slots:
 
 private:
     void processCommand(const QByteArray& cmd);
+    void writeLedState();
+    void writeLedCommand(int button);
 
     QSerialPort m_port;
     QByteArray  m_buffer;
     bool        m_invertDirection{false};
+    int         m_activeLedButton{0};
 };
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3521,6 +3521,20 @@ MainWindow::MainWindow(QWidget* parent)
 
     connect(m_flexControl, &FlexControlManager::buttonPressed,
             this, [this](int button, int action) {
+        auto setFlexControlLed = [this](int activeButton) {
+            if (!m_flexControl)
+                return;
+            QMetaObject::invokeMethod(m_flexControl,
+                                      [manager = m_flexControl, activeButton] {
+                manager->setActiveLedButton(activeButton);
+            });
+        };
+
+        if (button >= 1 && button <= 3)
+            setFlexControlLed(button);
+        else if (button == 4)
+            setFlexControlLed(0);
+
         // Knob press while wheel function is active → return to frequency mode (#1354)
         if (button == 4 && action == 0 && m_flexWheelMode != FlexWheelMode::Frequency) {
             m_flexWheelMode = FlexWheelMode::Frequency;


### PR DESCRIPTION
## Summary
- Add FlexControl LED writes using the documented `Ixyz;` command.
- Light the pressed side-button LED and clear LEDs when the knob button is pressed.
- Clear FlexControl LEDs when the serial connection closes.

Fixes #2908

## Tests
- `cmake --build build --parallel 22`
- `ctest --test-dir build --output-on-failure -j22`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat