### PR TITLE
[ux] Add audio device prompt suppression controls

### DIFF
--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -209,6 +209,15 @@ When at least one new device appears, AetherSDR shows a selection dialog with
 the current input/output highlighted, newly detected devices marked, and system
 defaults available as explicit choices.
 
+The dialog includes a "Don't ask me again" checkbox. Checking it persists
+`SuppressAudioDeviceNotifications=True` in `AppSettings`; future device-add
+events skip the selection dialog while preserving the existing fallback to
+system default when a selected device disappears.
+
+The same setting is exposed in Radio Setup > Audio > PC Audio Devices as
+"Prompt on Audio Device Changes"; that checkbox is checked when notifications
+are enabled and unchecked when the suppression setting is active.
+
 Accepting the dialog queues `AudioEngine::setInputDevice()` and
 `AudioEngine::setOutputDevice()` onto the audio worker thread. Those setters are
 the only place that persists the chosen device IDs and restarts the affected

--- a/src/gui/AudioDeviceChangeDialog.cpp
+++ b/src/gui/AudioDeviceChangeDialog.cpp
@@ -5,6 +5,7 @@
 
 #include <QAudioDevice>
 #include <QColor>
+#include <QCheckBox>
 #include <QFrame>
 #include <QFont>
 #include <QHBoxLayout>
@@ -37,6 +38,11 @@ const char* kDialogStyle =
     "QLabel#title { color: #ffffff; background: transparent; font-size: 18px; font-weight: bold; }"
     "QLabel#body { color: #c8d8e8; background: transparent; }"
     "QLabel#sectionLabel { color: #00b4d8; background: transparent; font-weight: bold; }"
+    "QCheckBox { color: #c8d8e8; spacing: 8px; }"
+    "QCheckBox::indicator { width: 16px; height: 16px;"
+    "  border: 1px solid #304050; border-radius: 3px; background: #0a0a14; }"
+    "QCheckBox::indicator:hover { border-color: #00b4d8; }"
+    "QCheckBox::indicator:checked { background: #00b4d8; border-color: #00c8f0; }"
     "QListWidget {"
     "  background: #0a0a14;"
     "  border: 1px solid #304050;"
@@ -299,6 +305,11 @@ AudioDeviceChangeDialog::AudioDeviceChangeDialog(
     buttonRow->setContentsMargins(0, 4, 0, 0);
     buttonRow->setSpacing(8);
 
+    m_dontAskAgainCheck = new QCheckBox(tr("Don't ask me again"), content);
+    m_dontAskAgainCheck->setCursor(Qt::PointingHandCursor);
+    buttonRow->addWidget(m_dontAskAgainCheck);
+    buttonRow->addStretch(1);
+
     auto* cancel = new QPushButton(tr("Cancel"), content);
     cancel->setObjectName("cancelButton");
     cancel->setCursor(Qt::PointingHandCursor);
@@ -375,6 +386,11 @@ QAudioDevice AudioDeviceChangeDialog::selectedInputDevice() const
 QAudioDevice AudioDeviceChangeDialog::selectedOutputDevice() const
 {
     return selectedDevice(m_outputList, m_outputDevices);
+}
+
+bool AudioDeviceChangeDialog::dontAskAgainChecked() const
+{
+    return m_dontAskAgainCheck && m_dontAskAgainCheck->isChecked();
 }
 
 } // namespace AetherSDR

--- a/src/gui/AudioDeviceChangeDialog.h
+++ b/src/gui/AudioDeviceChangeDialog.h
@@ -6,6 +6,7 @@
 #include <QList>
 
 class QListWidget;
+class QCheckBox;
 class QVBoxLayout;
 class QWidget;
 
@@ -23,6 +24,7 @@ public:
 
     QAudioDevice selectedInputDevice() const;
     QAudioDevice selectedOutputDevice() const;
+    bool dontAskAgainChecked() const;
     void setFramelessMode(bool on);
 
 private:
@@ -33,6 +35,7 @@ private:
     QVBoxLayout* m_bodyLayout{nullptr};
     QListWidget* m_inputList{nullptr};
     QListWidget* m_outputList{nullptr};
+    QCheckBox* m_dontAskAgainCheck{nullptr};
     QList<QAudioDevice> m_inputDevices;
     QList<QAudioDevice> m_outputDevices;
 };

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -227,6 +227,8 @@ constexpr int kSwrSweepTuneStopTimeoutMs = 1800;
 constexpr int kSwrSweepTgxlRestoreTimeoutMs = 3500;
 constexpr int kSwrSweepMaxPoints = 260;
 constexpr double kMemoryRevealTargetToleranceMhz = 0.000001;
+constexpr const char* kSuppressAudioDeviceNotificationsKey =
+    "SuppressAudioDeviceNotifications";
 
 QList<QByteArray> audioDeviceIds(const QList<QAudioDevice>& devices)
 {
@@ -6456,6 +6458,18 @@ void MainWindow::handleAudioDeviceListChanged()
         return;
     }
 
+    const bool suppressAudioDeviceNotifications =
+        AppSettings::instance()
+            .value(kSuppressAudioDeviceNotificationsKey, "False")
+            .toString() == "True";
+    if (suppressAudioDeviceNotifications) {
+        if (resetInput || resetOutput)
+            resetMissingAudioDevicesToDefault(resetInput,
+                                              resetOutput,
+                                              reinitializePcInput);
+        return;
+    }
+
     m_audioDeviceDialogOpen = true;
     AudioDeviceChangeDialog dialog(inputDevices,
                                    outputDevices,
@@ -6466,6 +6480,12 @@ void MainWindow::handleAudioDeviceListChanged()
                                    this);
     const int result = dialog.exec();
     m_audioDeviceDialogOpen = false;
+
+    if (dialog.dontAskAgainChecked()) {
+        auto& settings = AppSettings::instance();
+        settings.setValue(kSuppressAudioDeviceNotificationsKey, "True");
+        settings.save();
+    }
 
     if (result == QDialog::Accepted) {
         const QAudioDevice selectedInput = dialog.selectedInputDevice();

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -76,6 +76,9 @@ static const QString kEditStyle =
     "QLineEdit { background: #1a2a3a; border: 1px solid #304050; "
     "border-radius: 3px; color: #c8d8e8; font-size: 12px; padding: 2px 4px; }";
 
+static constexpr const char* kSuppressAudioDeviceNotificationsKey =
+    "SuppressAudioDeviceNotifications";
+
 static QString normalizedOscillatorValue(QString value)
 {
     value = value.trimmed().toLower();
@@ -1888,6 +1891,21 @@ QWidget* RadioSetupDialog::buildAudioTab()
     outRow->addWidget(outLabel);
     outRow->addWidget(outCombo, 1);
     pcLayout->addLayout(outRow);
+
+    auto* promptCheck = new QCheckBox("Prompt on Audio Device Changes");
+    promptCheck->setStyleSheet("QCheckBox { color: #c8d8e8; font-size: 11px; }");
+    promptCheck->setToolTip("Show the Audio Device Detected dialog when a new PC audio device appears.");
+    const bool suppressAudioDeviceNotifications =
+        AppSettings::instance()
+            .value(kSuppressAudioDeviceNotificationsKey, "False")
+            .toString() == "True";
+    promptCheck->setChecked(!suppressAudioDeviceNotifications);
+    connect(promptCheck, &QCheckBox::toggled, this, [](bool on) {
+        auto& s = AppSettings::instance();
+        s.setValue(kSuppressAudioDeviceNotificationsKey, on ? "False" : "True");
+        s.save();
+    });
+    pcLayout->addWidget(promptCheck);
 
     // Wire device changes to AudioEngine
     if (m_audio) {


### PR DESCRIPTION
## Summary

- Add a `Don't ask me again` checkbox to the Audio Device Detected dialog.
- Persist that choice as `SuppressAudioDeviceNotifications=True` in `AppSettings` so future new-device notifications can be permanently suppressed.
- Respect the persisted suppression setting in the audio device hotplug flow while preserving the existing fallback that resets missing selected devices to the system default.
- Add an inverse-linked `Prompt on Audio Device Changes` checkbox in Radio Setup > Audio > PC Audio Devices so users can re-enable or disable prompting from settings.
- Document both controls in the audio pipeline hotplug section.

## Behavior Notes

The dialog-level checkbox is intentionally one-way from the prompt itself: checking `Don't ask me again` suppresses future new audio device prompts whether the current dialog is accepted or canceled. The Radio Setup checkbox is the user-facing toggle for changing that preference later: checked means prompts are enabled; unchecked means `SuppressAudioDeviceNotifications=True` is active.

The suppression gate only bypasses new-device selection prompts. Removal handling is left intact, so if the selected input or output disappears, AetherSDR still clears that stale selection and falls back to the current system default as before.

## Validation

- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build -j22`
  - Passed after rerunning the macOS app build outside the sandbox for `iconutil`, per project build guidance.
- `ctest --test-dir build --output-on-failure -j22`
  - 15/15 tests passed.
- Manually verified by @jensenpat in the built app.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
