### PR TITLE
fix(audio): silent SSB/voice TX on macOS — honour mic native rate + start capture for remote_audio_tx

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -234,6 +234,17 @@ QList<int> macTxInputRateCandidates(const QAudioDevice& qtDevice)
     if (const auto nativeRate = macBluetoothNativeInputRate(qtDevice)) {
         rates << *nativeRate;
     }
+    // Try the device's preferred (native) rate FIRST. CoreAudio reports
+    // isFormatSupported(48000)==true for many capture devices that actually
+    // run at a lower native rate (e.g. USB webcam mics at 16 kHz). Opening
+    // QAudioSource at 48 kHz then "succeeds" (state=Active, no error) but the
+    // device delivers zero samples — processedUSecs stays 0 and TX is silent.
+    // Honouring the device's preferred rate avoids that dead-stream trap and
+    // lets the existing resampler convert to 24 kHz radio-native.
+    const int preferredRate = qtDevice.preferredFormat().sampleRate();
+    if (preferredRate > 0 && !rates.contains(preferredRate)) {
+        rates << preferredRate;
+    }
     rates << 48000 << 44100 << AudioEngine::DEFAULT_SAMPLE_RATE;
     return rates;
 }

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -95,6 +95,10 @@ public:
     quint32 txStreamId() const { return m_txStreamId; }
     // Set the remote audio TX stream ID (for voice TX and VOX monitoring)
     void setRemoteTxStreamId(quint32 id) { m_remoteTxStreamId = id; }
+    quint32 remoteTxStreamId() const { return m_remoteTxStreamId; }
+    // True when either TX stream (dax_tx or remote_audio_tx) is assigned —
+    // mic capture should run if any TX route to the radio exists.
+    bool hasAnyTxStream() const { return m_txStreamId != 0 || m_remoteTxStreamId != 0; }
 
     float rxVolume() const  { return m_rxVolume.load(); }
     void  setRxVolume(float v);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2188,8 +2188,13 @@ MainWindow::MainWindow(QWidget* parent)
             // Restore PC mic gain from client-side settings
             int gain = AppSettings::instance().value("PcMicGain", 100).toInt();
             m_audio->setPcMicGain(gain);
-            // Only start if TX stream ID is already assigned (avoid streamId=0)
-            if (!m_audio->isTxStreaming() && m_audio->txStreamId() != 0) {
+            // Only start if a TX stream is already assigned (avoid streamId=0).
+            // Voice TX (USB/LSB/AM/FM) flows over remote_audio_tx, NOT dax_tx —
+            // gating solely on txStreamId() (the dax_tx id) meant that when no
+            // DAX bridge was running, switching mic_selection to PC for plain
+            // SSB never started mic capture, so onTxAudioReady never fired and
+            // there was no modulating audio. Accept either stream.
+            if (!m_audio->isTxStreaming() && m_audio->hasAnyTxStream()) {
                 audioStartTx(m_radioModel.radioAddress(), 4991);
             }
         } else {


### PR DESCRIPTION
## Summary

On macOS, USB/LSB/AM/FM **voice** TX produced no modulating audio (carrier up, dead air) even though DAX digital-mode TX worked fine. Two independent defects stacked together; both are fixed here.

## Defect 1 — mic capture never started without a dax_tx stream

`MainWindow`'s `mic_selection` handler only started `QAudioSource` capture when `m_audio->txStreamId() != 0`:

```cpp
if (!m_audio->isTxStreaming() && m_audio->txStreamId() != 0) {
    audioStartTx(...);
}
```

`txStreamId()` is the **dax_tx** stream id. Voice TX flows over **remote_audio_tx** (Opus), a different stream. When no DAX bridge is running there is no dax_tx stream, so switching `mic_selection` to PC for plain SSB never started mic capture — `onTxAudioReady()` never fired and the radio received no PC audio.

`onTxAudioReady()` itself already accepts either stream (`if (m_txStreamId == 0 && m_remoteTxStreamId == 0) return;`), so only the capture-start gate was wrong.

**Fix:** add `AudioEngine::hasAnyTxStream()` (dax_tx **or** remote_audio_tx) and gate capture start on that.

## Defect 2 — QAudioSource opened at 48 kHz on a 16 kHz-native device

`macTxInputRateCandidates()` tried `48000` first. macOS CoreAudio reports `isFormatSupported(48000) == true` for many capture devices that actually run at a lower native rate (e.g. USB webcam mics at 16 kHz). `QAudioSource` then "opens" successfully — `state=Active`, `error=NoError` — but the device delivers **zero samples**:

- `QAudioSource::processedUSecs()` stays `0`
- the push-mode `QBuffer` write position never advances (`pos()` stuck at `0`)
- TX is silent

**Fix:** query `QAudioDevice::preferredFormat().sampleRate()` and try it first. The existing resampler converts the device-native rate to 24 kHz radio-native. `48000/44100/24000` remain as fallbacks for devices that report no usable preferred rate.

## Diagnosis

Instrumented the TX path on the affected machine:

| Probe | Observation |
|---|---|
| `onTxAudioReady()` entry | fired continuously, but `m_micBuffer->pos()` stuck at `0` |
| `QAudioSource` health @1s | `state=Active error=NoError processedUSecs=0` |
| `system_profiler SPAudioDataType` | affected mic (`4K SlimFit Cam`) `Current SampleRate: 16000` |

`processedUSecs=0` with `state=Active` is the tell-tale of CoreAudio accepting a format the device can't actually source.

## Test plan

- [x] macOS + FLEX-8600 fw 4.x, mic_selection=PC, USB/LSB
- [x] 16 kHz USB webcam mic — voice TX now modulates (resampled 16→24 kHz)
- [x] 48 kHz USB audio interface — unchanged, still works
- [x] DAX digital-mode TX (VARA) — unaffected (separate dax_tx path)
- [ ] Reviewer: Linux/Windows regression check — `macTxInputRateCandidates()` is `#ifdef Q_OS_MAC`; the `hasAnyTxStream()` gate change is cross-platform and should be verified on a Windows/Linux voice TX setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)