### PR TITLE
docs: add "How AetherSDR Is Built" README section (#2933, PR 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ AetherSDR brings FlexRadio operation to Linux without Wine or virtual machines. 
 
 ---
 
+## How AetherSDR Is Built
+
+AetherSDR is developed using an AI-augmented open-source workflow:
+
+- **Project lead (Jeremy KK7GWY) + a core contributor team** working primarily through Claude Code and a mix of AI development tools — every commit goes through the merge gate; nothing reaches `main` without human review
+- **[AetherClaude](https://github.com/aethersdr/aetherclaude) orchestrator bot** auto-triages incoming issues, drafts implementation plans, and produces PRs for issues labelled `aetherclaude-eligible`
+- **Contributors use a mix of AI tools** (Codex, Copilot, Cursor, Gemini, Aider) — the project's [Constitution](CONSTITUTION.md) (14 principles, structured per [Cisco's Foundry Constitution](https://github.com/CiscoDevNet/foundry-security-spec) spec) codifies the conventions every contributor and every AI tool follows
+- **Branch protection enforces signed commits, CI green, and CODEOWNERS review** — every change goes through the same gate regardless of which AI tool (or human) produced it
+- **At active pace: ~50 PRs per week, ~15,000–30,000 lifetime downloads, ≥6 distinct AI tools touching the codebase**
+
+See [`AGENTS.md`](AGENTS.md) for the canonical project guide that every AI assistant reads first, and [`CONSTITUTION.md`](CONSTITUTION.md) for the principles that gate the contribution model.
+
+The full list of code contributors is auto-generated from GitHub commit attribution — see the [Contributors graph](https://github.com/aethersdr/AetherSDR/graphs/contributors).
+
+---
+
 ## Supported Hardware
 
 Works with any FlexRadio transceiver, including:


### PR DESCRIPTION
Cleanup PR 2 of 9 from the repo-structure-cleanup tracking issue
(#2933). Makes the AI-augmented development model visible from the
first README view — highest-impact change in the cleanup sweep for
portfolio / hiring-manager skim.

New section inserted between Highlights and Supported Hardware. The
section calls out:

- Project lead (Jeremy KK7GWY) + core contributor team working
  primarily through Claude Code and a mix of AI development tools
- AetherClaude orchestrator bot for issue triage + aetherclaude-eligible
  PR generation
- Contributors using their own AI tools (Codex, Copilot, Cursor,
  Gemini, Aider) all bound by the Constitution
- Branch protection gating every change regardless of AI tool
- Quantitative footprint (~50 PRs/week, lifetime downloads,
  ≥6 AI tools)
- Pointers to AGENTS.md and CONSTITUTION.md as authoritative sources

 The merge-gate signal is
"human review" rather than "maintainer review" so the phrase still
holds when additional collaborators gain merge authority in the future.

Auto-generated contributors graph is linked at the bottom of the
section so the team has explicit visibility without the README needing
to maintain a hand-curated list — consistent with Constitution
Principle VII (auto-generated About > Contributors list).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
