### PR TITLE
fix(security): plug VITA-49 waterfall heap OOB write (GHSA-7gvg-x594-pprq). Principle VIII.

### DIFF
--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -885,9 +885,15 @@ void PanadapterStream::decodeWaterfallTile(const uchar* raw, int totalBytes, boo
     }
 
     // ── Waterfall frame assembly ─────────────────────────────────────────
-    // Start a new frame if timecode changed
+    // Start a new frame if timecode changed OR if totalBinsInFrame changed.
+    // Without the totalBins check, a spoofed packet that reuses a timecode
+    // with an inflated totalBinsInFrame leaves wfFrame.buf undersized
+    // relative to the bounds calculation below, and the inner write loop
+    // then writes past the buffer's end with attacker-chosen bytes.
+    // See GHSA-7gvg-x594-pprq.
     auto& wfFrame = m_wfFrames[streamId];
-    if (timecode != wfFrame.timecode) {
+    if (timecode != wfFrame.timecode
+        || totalBinsInFrame != wfFrame.totalBins) {
         if (wfFrame.totalBins > 0 && !wfFrame.isComplete())
             PerfTelemetry::instance().recordFrameRestart(PerfTelemetry::FrameKind::Waterfall);
         wfFrame.reset(timecode, totalBinsInFrame, lowFreqMhz, binBwMhz, autoBlack);
@@ -899,6 +905,12 @@ void PanadapterStream::decodeWaterfallTile(const uchar* raw, int totalBytes, boo
     const int binsToRead = qMin(static_cast<int>(tileWidth),
                                 static_cast<int>(totalBinsInFrame) - static_cast<int>(firstBinIndex));
     if (binsToRead <= 0) return;
+
+    // Defense in depth: even with the reset condition above, validate that
+    // the upper write index fits the buffer.  Guards against any future
+    // refactor that breaks the wfFrame.buf.size() <-> wfFrame.totalBins
+    // invariant.  GHSA-7gvg-x594-pprq.
+    if (firstBinIndex + binsToRead > wfFrame.buf.size()) return;
 
     for (int i = 0; i < binsToRead; ++i) {
         const auto raw16 = static_cast<qint16>(qFromBigEndian<quint16>(tilePayload + i * 2));


### PR DESCRIPTION
Closes [draft] security advisory GHSA-7gvg-x594-pprq.

## The bug

PanadapterStream::decodeWaterfallTile sized the per-stream
WaterfallFrame::buf only on timecode change — wfFrame.reset(...) was
called from inside the `if (timecode != wfFrame.timecode)` branch.
A subsequent packet bearing the same timecode but a LARGER
totalBinsInFrame did not trigger a reset, leaving wfFrame.buf at the
prior packet's smaller size while the bounds calculation
(binsToRead = qMin(tileWidth, totalBinsInFrame - firstBinIndex))
used the new, larger totalBinsInFrame.  The inner loop then wrote
wfFrame.buf[firstBinIndex + i] past the buffer's allocation with
attacker-chosen offsets and values.

Both firstBinIndex and the written values are attacker-controlled.
Heap corruption with plausible RCE depending on heap layout; minimum
impact is a reliable crash.  No authentication on the VITA-49 UDP
ingress, so any LAN-attached attacker or — with appropriate
tooling — any on-path WAN attacker can trigger it.

## The fix

Two layers of defense:

1. Expanded the reset condition to also fire when totalBinsInFrame
   changes, not just on timecode change.  This restores the
   invariant wfFrame.buf.size() == wfFrame.totalBins after every
   accepted packet, which is the structural fix.

2. Added a bounds check immediately before the inner write loop:
   `if (firstBinIndex + binsToRead > wfFrame.buf.size()) return;`
   This is redundant given layer 1 but cheap (one branch) and
   guards against any future refactor that breaks the
   buf.size() <-> totalBins invariant.

## Trade-offs

- An attacker sending mutated totalBinsInFrame still causes a
  buf.resize() per packet.  totalBinsInFrame is a quint16 so the
  resize is capped at 65535 floats (256 KB) per call.  Acceptable.
- Legitimate radio behavior that legitimately changes
  totalBinsInFrame mid-timecode (e.g., during a pan-width change)
  now drops accumulated partial-frame assembly.  This is the same
  behavior already applied on timecode changes, and the right call
  — assembly across an inconsistent totalBins is undefined-behavior
  territory.
- PerfTelemetry::recordFrameRestart() still fires on the reset, so
  any unusual rate of resets remains visible to the existing
  dashboards.

## Verification

- Local build clean.
- Manual smoke test on live radio: spectrum + waterfall render
  normally, no regressions on pan resize / zoom / multi-pan.

Per Principle VIII (Evidence Over Assertion): the squash-merge
re-runs CI on main with this exact diff.  A regression test
specifically covering the GHSA-7gvg-x594-pprq exploit sequence is
queued as a follow-up — the priority of this commit is closing the
window in shipped builds first.

## Disclosure timeline

Advisory was filed in DRAFT state at 2026-05-22 alongside H1/H2/M2/
M3/M4 from the same audit cycle.  Once this fix lands on `main` and
ships in a release, the advisory PATCH to state=published will list
this commit as the fix reference.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
