### PR TITLE
[ux] Add drag value popups for slider controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,6 +574,7 @@ set(GUI_SOURCES
     src/gui/AetherDspWidget.cpp
     src/gui/WaveformsDialog.cpp
     src/gui/ClientRxDspApplet.cpp
+    src/gui/DragValuePopup.cpp
     src/gui/DspParamPopup.cpp
     src/gui/DxClusterDialog.cpp
     src/gui/DxClusterStartupCommandsDialog.cpp

--- a/src/gui/DragValuePopup.cpp
+++ b/src/gui/DragValuePopup.cpp
@@ -1,0 +1,121 @@
+#include "DragValuePopup.h"
+
+#include <QGuiApplication>
+#include <QLabel>
+#include <QPainter>
+#include <QPainterPath>
+#include <QScreen>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <algorithm>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kMinWidth = 58;
+constexpr int kMinHeight = 46;
+constexpr int kAnchorGap = 16;
+constexpr int kScreenMargin = 8;
+
+} // namespace
+
+DragValuePopup::DragValuePopup(QWidget* parent)
+    : QWidget(parent, Qt::ToolTip | Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint)
+{
+    setObjectName(QStringLiteral("DragValuePopup"));
+    setAttribute(Qt::WA_TransparentForMouseEvents);
+    setAttribute(Qt::WA_ShowWithoutActivating);
+    setAttribute(Qt::WA_TranslucentBackground);
+    setFocusPolicy(Qt::NoFocus);
+    setStyleSheet(
+        "QWidget#DragValuePopup { background: transparent; border: none; }"
+        "QLabel#DragValuePopupLabel { color: #f4fbff; background: transparent;"
+        " border: none; border-radius: 0; padding: 0; margin: 0;"
+        " font-size: 20px; font-weight: 800; }");
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(10, 6, 10, 7);
+    layout->setSpacing(0);
+
+    m_label = new QLabel(this);
+    m_label->setObjectName(QStringLiteral("DragValuePopupLabel"));
+    m_label->setAlignment(Qt::AlignCenter);
+    m_label->setFrameShape(QFrame::NoFrame);
+    m_label->setLineWidth(0);
+    m_label->setMidLineWidth(0);
+    m_label->setMinimumSize(kMinWidth - 20, kMinHeight - 13);
+    layout->addWidget(m_label);
+
+    m_hideTimer = new QTimer(this);
+    m_hideTimer->setSingleShot(true);
+    connect(m_hideTimer, &QTimer::timeout, this, &QWidget::hide);
+}
+
+void DragValuePopup::showValue(const QPoint& globalAnchor, const QString& text)
+{
+    if (text.isEmpty()) {
+        hideNow();
+        return;
+    }
+
+    m_hideTimer->stop();
+    m_label->setText(text);
+    adjustSize();
+    resize(sizeHint().expandedTo(QSize(kMinWidth, kMinHeight)));
+    move(positionForAnchor(globalAnchor));
+
+    if (!isVisible())
+        show();
+    raise();
+}
+
+void DragValuePopup::linger(int msec)
+{
+    if (isVisible())
+        m_hideTimer->start(msec);
+}
+
+void DragValuePopup::hideNow()
+{
+    m_hideTimer->stop();
+    hide();
+}
+
+QPoint DragValuePopup::positionForAnchor(const QPoint& globalAnchor) const
+{
+    QScreen* screen = QGuiApplication::screenAt(globalAnchor);
+    if (!screen)
+        screen = QGuiApplication::primaryScreen();
+
+    const QRect bounds = screen
+        ? screen->availableGeometry().adjusted(kScreenMargin, kScreenMargin,
+                                               -kScreenMargin, -kScreenMargin)
+        : QRect(globalAnchor - QPoint(400, 300), QSize(800, 600));
+
+    QPoint pos(globalAnchor.x() - width() / 2,
+               globalAnchor.y() - height() - kAnchorGap);
+
+    if (pos.y() < bounds.top())
+        pos.setY(globalAnchor.y() + kAnchorGap);
+
+    pos.setX(std::clamp(pos.x(), bounds.left(), bounds.right() - width() + 1));
+    pos.setY(std::clamp(pos.y(), bounds.top(), bounds.bottom() - height() + 1));
+    return pos;
+}
+
+void DragValuePopup::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    const QRectF r = rect().adjusted(1, 1, -1, -1);
+    QPainterPath path;
+    path.addRoundedRect(r, 5, 5);
+
+    p.fillPath(path, QColor(8, 14, 24, 236));
+    p.setPen(QPen(QColor(0, 180, 216, 210), 1.2));
+    p.drawPath(path);
+}
+
+} // namespace AetherSDR

--- a/src/gui/DragValuePopup.h
+++ b/src/gui/DragValuePopup.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <QPoint>
+#include <QString>
+#include <QWidget>
+
+class QLabel;
+class QTimer;
+
+namespace AetherSDR {
+
+// Small floating readout shown while a value control is being dragged.
+// This deliberately avoids QToolTip so the lifetime, position, and styling
+// are consistent across macOS, Windows, and Linux window managers.
+class DragValuePopup : public QWidget {
+public:
+    explicit DragValuePopup(QWidget* parent = nullptr);
+
+    void showValue(const QPoint& globalAnchor, const QString& text);
+    void linger(int msec = 450);
+    void hideNow();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+private:
+    QPoint positionForAnchor(const QPoint& globalAnchor) const;
+
+    QLabel* m_label{nullptr};
+    QTimer* m_hideTimer{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/EqApplet.cpp
+++ b/src/gui/EqApplet.cpp
@@ -249,6 +249,11 @@ void EqApplet::buildUI()
             auto* slider = new GuardedSlider(Qt::Vertical);
             slider->setRange(-10, 10);
             slider->setValue(0);
+            slider->setDragValueFormatter([](int v) {
+                return QStringLiteral("%1%2 dB")
+                    .arg(v > 0 ? QStringLiteral("+") : QString())
+                    .arg(v);
+            });
             slider->setTickPosition(QSlider::NoTicks);
             slider->setStyleSheet(kVSliderStyle);
             slider->setFixedHeight(100);

--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -1,11 +1,17 @@
 #pragma once
 
+#include "DragValuePopup.h"
+
 #include <QSlider>
 #include <QComboBox>
 #include <QAbstractItemView>
 #include <QLabel>
 #include <QMouseEvent>
+#include <QStyle>
+#include <QStyleOptionSlider>
 #include <QWheelEvent>
+#include <functional>
+#include <utility>
 
 // Global lock for sidebar controls — when locked, sliders, combo boxes,
 // and scrollable labels ignore wheel/mouse events so the user can scroll
@@ -25,13 +31,57 @@ private:
 // parent scroll area handle them.
 class GuardedSlider : public QSlider {
 public:
-    using QSlider::QSlider;
+    using DragValueFormatter = std::function<QString(int)>;
+
+    explicit GuardedSlider(QWidget* parent = nullptr)
+        : QSlider(parent)
+    {
+    }
+
+    explicit GuardedSlider(Qt::Orientation orientation, QWidget* parent = nullptr)
+        : QSlider(orientation, parent)
+    {
+    }
+
+    void setDragValueFormatter(DragValueFormatter formatter) {
+        m_dragValueFormatter = std::move(formatter);
+    }
+
+    void setDragValuePopupEnabled(bool enabled) {
+        m_dragValuePopupEnabled = enabled;
+        if (!enabled && m_dragValuePopup)
+            m_dragValuePopup->hideNow();
+    }
+
     void mousePressEvent(QMouseEvent* ev) override {
         if (ControlsLock::isLocked()) {
             ev->ignore();
             return;
         }
         QSlider::mousePressEvent(ev);
+        if (ev->button() == Qt::LeftButton) {
+            m_dragValueActive = true;
+            showDragValuePopup(ev->globalPosition().toPoint());
+        }
+    }
+    void mouseMoveEvent(QMouseEvent* ev) override {
+        if (ControlsLock::isLocked()) {
+            ev->ignore();
+            return;
+        }
+        QSlider::mouseMoveEvent(ev);
+        if (m_dragValueActive || isSliderDown())
+            showDragValuePopup(ev->globalPosition().toPoint());
+    }
+    void mouseReleaseEvent(QMouseEvent* ev) override {
+        const bool wasActive = m_dragValueActive;
+        QSlider::mouseReleaseEvent(ev);
+        if (wasActive && ev->button() == Qt::LeftButton) {
+            showDragValuePopup(ev->globalPosition().toPoint());
+            m_dragValueActive = false;
+            if (m_dragValuePopup)
+                m_dragValuePopup->linger();
+        }
     }
     void wheelEvent(QWheelEvent* ev) override {
         if (ControlsLock::isLocked()) {
@@ -45,6 +95,37 @@ public:
             setValue(value() + (delta > 0 ? singleStep() : -singleStep()));
         ev->accept();
     }
+
+private:
+    QString dragValueText() const {
+        if (m_dragValueFormatter)
+            return m_dragValueFormatter(value());
+        return QString::number(value());
+    }
+
+    QPoint dragValueAnchor(const QPoint& fallbackGlobal) const {
+        QStyleOptionSlider opt;
+        initStyleOption(&opt);
+        const QRect handle = style()->subControlRect(
+            QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
+        if (handle.isValid())
+            return mapToGlobal(handle.center());
+        return fallbackGlobal;
+    }
+
+    void showDragValuePopup(const QPoint& fallbackGlobal) {
+        if (!m_dragValuePopupEnabled)
+            return;
+        if (!m_dragValuePopup)
+            m_dragValuePopup = new AetherSDR::DragValuePopup(this);
+        m_dragValuePopup->showValue(dragValueAnchor(fallbackGlobal),
+                                    dragValueText());
+    }
+
+    DragValueFormatter m_dragValueFormatter;
+    AetherSDR::DragValuePopup* m_dragValuePopup{nullptr};
+    bool m_dragValuePopupEnabled{true};
+    bool m_dragValueActive{false};
 };
 
 // QComboBox subclass that only responds to wheel events when the dropdown

--- a/src/gui/MeterSlider.h
+++ b/src/gui/MeterSlider.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "DragValuePopup.h"
 #include "MeterSmoother.h"
 
 #include <QElapsedTimer>
@@ -9,6 +10,8 @@
 #include <QWidget>
 #include <algorithm>
 #include <cmath>
+#include <functional>
+#include <utility>
 
 namespace AetherSDR {
 
@@ -21,6 +24,8 @@ class MeterSlider : public QWidget {
     Q_OBJECT
 
 public:
+    using DragValueFormatter = std::function<QString(float)>;
+
     explicit MeterSlider(QWidget* parent = nullptr)
         : QWidget(parent)
     {
@@ -39,6 +44,16 @@ public:
 
     float gain() const { return m_gain; }
     float level() const { return m_smooth.value(); }
+
+    void setDragValueFormatter(DragValueFormatter formatter) {
+        m_dragValueFormatter = std::move(formatter);
+    }
+
+    void setDragValuePopupEnabled(bool enabled) {
+        m_dragValuePopupEnabled = enabled;
+        if (!enabled && m_dragValuePopup)
+            m_dragValuePopup->hideNow();
+    }
 
     void setGain(float g) {
         g = std::clamp(g, 0.0f, 1.0f);
@@ -127,17 +142,33 @@ protected:
         if (e->button() == Qt::LeftButton) {
             m_dragging = true;
             updateGainFromMouse(e->pos().x());
+            showDragValuePopup(e->globalPosition().toPoint());
+            e->accept();
+            return;
         }
+        QWidget::mousePressEvent(e);
     }
 
     void mouseMoveEvent(QMouseEvent* e) override {
-        if (m_dragging)
+        if (m_dragging) {
             updateGainFromMouse(e->pos().x());
+            showDragValuePopup(e->globalPosition().toPoint());
+            e->accept();
+            return;
+        }
+        QWidget::mouseMoveEvent(e);
     }
 
     void mouseReleaseEvent(QMouseEvent* e) override {
-        if (e->button() == Qt::LeftButton)
+        if (m_dragging && e->button() == Qt::LeftButton) {
+            showDragValuePopup(e->globalPosition().toPoint());
             m_dragging = false;
+            if (m_dragValuePopup)
+                m_dragValuePopup->linger();
+            e->accept();
+            return;
+        }
+        QWidget::mouseReleaseEvent(e);
     }
 
 private:
@@ -151,10 +182,38 @@ private:
         }
     }
 
+    QString dragValueText() const {
+        if (m_dragValueFormatter)
+            return m_dragValueFormatter(m_gain);
+        return QStringLiteral("%1%").arg(std::lround(m_gain * 100.0f));
+    }
+
+    QPoint dragValueAnchor(const QPoint& fallbackGlobal) const {
+        const int margin = 1;
+        const int barW = width() - 2 * margin;
+        if (barW <= 0)
+            return fallbackGlobal;
+        int thumbX = margin + static_cast<int>(m_gain * barW);
+        thumbX = std::clamp(thumbX, margin, margin + barW);
+        return mapToGlobal(QPoint(thumbX, height() / 2));
+    }
+
+    void showDragValuePopup(const QPoint& fallbackGlobal) {
+        if (!m_dragValuePopupEnabled)
+            return;
+        if (!m_dragValuePopup)
+            m_dragValuePopup = new DragValuePopup(this);
+        m_dragValuePopup->showValue(dragValueAnchor(fallbackGlobal),
+                                    dragValueText());
+    }
+
     float         m_gain{0.5f};
     MeterSmoother m_smooth;
     QTimer        m_animTimer;
     QElapsedTimer m_animElapsed;
+    DragValueFormatter m_dragValueFormatter;
+    DragValuePopup* m_dragValuePopup{nullptr};
+    bool          m_dragValuePopupEnabled{true};
     bool          m_dragging{false};
 };
 

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -58,6 +58,11 @@ static constexpr const char* kSliderStyle =
     "QSlider::handle:horizontal { width: 10px; height: 10px; margin: -3px 0;"
     "background: #00b4d8; border-radius: 5px; }";
 
+static QString percentText(int value)
+{
+    return QStringLiteral("%1%").arg(value);
+}
+
 static const QString kGreenActive =
     "QPushButton:checked { background-color: #006040; color: #00ff88; "
     "border: 1px solid #00a060; }";
@@ -115,6 +120,7 @@ void PhoneApplet::buildUI()
 
         m_amCarrierSlider = new GuardedSlider(Qt::Horizontal);
         m_amCarrierSlider->setRange(0, 100);
+        static_cast<GuardedSlider*>(m_amCarrierSlider)->setDragValueFormatter(percentText);
         m_amCarrierSlider->setAccessibleName("AM carrier level");
         m_amCarrierSlider->setAccessibleDescription("AM carrier power level, 0 to 100 percent");
         m_amCarrierSlider->setStyleSheet(kSliderStyle);
@@ -155,6 +161,7 @@ void PhoneApplet::buildUI()
 
         m_voxLevelSlider = new GuardedSlider(Qt::Horizontal);
         m_voxLevelSlider->setRange(0, 100);
+        static_cast<GuardedSlider*>(m_voxLevelSlider)->setDragValueFormatter(percentText);
         m_voxLevelSlider->setAccessibleName("VOX level");
         m_voxLevelSlider->setAccessibleDescription("VOX activation threshold");
         m_voxLevelSlider->setStyleSheet(kSliderStyle);
@@ -238,6 +245,7 @@ void PhoneApplet::buildUI()
 
         m_dexpSlider = new GuardedSlider(Qt::Horizontal);
         m_dexpSlider->setRange(0, 100);
+        static_cast<GuardedSlider*>(m_dexpSlider)->setDragValueFormatter(percentText);
         m_dexpSlider->setAccessibleName("DEXP threshold");
         m_dexpSlider->setAccessibleDescription("Downward expander gate threshold");
         m_dexpSlider->setStyleSheet(kSliderStyle);

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -105,6 +105,19 @@ namespace AetherSDR {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+static QString percentText(int value)
+{
+    return QStringLiteral("%1%").arg(value);
+}
+
+static QString panText(int value)
+{
+    if (value == 50)
+        return QStringLiteral("C");
+    return QStringLiteral("%1%2").arg(value < 50 ? QStringLiteral("L") : QStringLiteral("R"))
+                                .arg(std::abs(value - 50));
+}
+
 // ── Style constants (matching docs/applet-style-guide.md) ──────────────────
 
 static constexpr const char* kButtonBase =
@@ -738,6 +751,7 @@ void RxApplet::buildUI()
         m_afSlider = new GuardedSlider(Qt::Horizontal);
         m_afSlider->setRange(0, 100);
         m_afSlider->setValue(70);
+        static_cast<GuardedSlider*>(m_afSlider)->setDragValueFormatter(percentText);
         m_afSlider->setStyleSheet(kSliderStyle);
         row->addWidget(m_afSlider, 1);
 
@@ -760,6 +774,7 @@ void RxApplet::buildUI()
         m_panSlider = new CenterMarkSlider(50, Qt::Horizontal);
         m_panSlider->setRange(0, 100);
         m_panSlider->setValue(50);
+        static_cast<GuardedSlider*>(m_panSlider)->setDragValueFormatter(panText);
         m_panSlider->setStyleSheet(kSliderStyle);
         row->addWidget(m_panSlider, 1);
 
@@ -789,6 +804,11 @@ void RxApplet::buildUI()
         m_sqlSlider = new GuardedSlider(Qt::Horizontal);
         m_sqlSlider->setRange(0, 100);
         m_sqlSlider->setValue(20);
+        static_cast<GuardedSlider*>(m_sqlSlider)->setDragValueFormatter([this](int v) {
+            if (m_sqlMode == SqlMode::Auto)
+                return QStringLiteral("%1 dB").arg(v);
+            return QString::number(v);
+        });
         m_sqlSlider->setStyleSheet(kSliderStyle);
         row->addWidget(m_sqlSlider, 1);
 

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -50,6 +50,11 @@ static constexpr const char* kSliderStyle =
     "QSlider::handle:horizontal { width: 10px; height: 10px; margin: -3px 0;"
     "background: #00b4d8; border-radius: 5px; }";
 
+static QString wattsText(int value)
+{
+    return QStringLiteral("%1 W").arg(value);
+}
+
 // ── TxApplet ────────────────────────────────────────────────────────────────
 
 TxApplet::TxApplet(QWidget* parent)
@@ -129,6 +134,7 @@ void TxApplet::buildUI()
 
         m_rfPowerSlider = new GuardedSlider(Qt::Horizontal);
         m_rfPowerSlider->setRange(0, 100);
+        static_cast<GuardedSlider*>(m_rfPowerSlider)->setDragValueFormatter(wattsText);
         m_rfPowerSlider->setStyleSheet(kSliderStyle);
         m_rfPowerSlider->setAccessibleName("RF power");
         m_rfPowerSlider->setAccessibleDescription("Transmit RF power level, 0 to 100 watts");
@@ -153,6 +159,7 @@ void TxApplet::buildUI()
 
         m_tunePowerSlider = new GuardedSlider(Qt::Horizontal);
         m_tunePowerSlider->setRange(0, 100);
+        static_cast<GuardedSlider*>(m_tunePowerSlider)->setDragValueFormatter(wattsText);
         m_tunePowerSlider->setStyleSheet(kSliderStyle);
         m_tunePowerSlider->setAccessibleName("Tune power");
         m_tunePowerSlider->setAccessibleDescription("Tune carrier power level, 0 to 100 watts");


### PR DESCRIPTION
 
<img width="237" height="206" alt="image" src="https://github.com/user-attachments/assets/4301e3ba-88cf-4559-ab3b-1750b4b1ee5b" />

## Summary
This PR adds a shared, high-contrast drag value popup for AetherSDR slider controls. When a user holds and drags a slider or meter-slider gain strip, the app now shows a large floating numeric readout anchored near the thumb, then keeps it visible briefly after release.

The result is a much more confident control surface: users can adjust RF power, tune power, audio gain, pan, squelch, EQ bands, phone controls, and DAX/TCI meter-slider gain without hunting for tiny inline labels or trying to infer the value from thumb position alone.

## Why this matters
AetherSDR has a dense, powerful UI with many compact controls. That density is great for radio operation, but it also means small value labels can be easy to miss while the mouse is moving. The new popup makes the value the visual focus at exactly the moment the user is changing it.

This is especially helpful for visually impaired users and anyone operating on small screens, remote desktops, low-contrast displays, or high-DPI setups. The popup uses large, bold, high-contrast text and follows the slider handle, making adjustments easier to read without forcing the user to shift attention across the pane. It turns "did I land on 70 or 80?" into an immediate, readable confirmation.

The short post-release hang time is intentional. The value now lingers for 450 ms after release, giving users a moment to absorb and remember the setting they just chose before the UI settles back down. That small pause makes repetitive applet navigation feel less slippery and more deliberate.

## Implementation
- Adds `DragValuePopup`, a custom QWidget-based popup instead of relying on platform tooltips.
- Integrates the popup globally through `GuardedSlider`, covering the common slider path across applets, VFO controls, setup panes, DSP panes, spot/DX settings, and other compact controls.
- Integrates the same popup into `MeterSlider`, covering the DAX/TCI combined meter + gain strips.
- Adds formatter hooks so controls can present readable units, including watts, percent, dB, and pan direction.
- Uses style-aware handle positioning so the popup anchors to the actual slider thumb.
- Keeps the popup transparent to mouse events and non-activating so dragging remains smooth.
- Explicitly isolates popup styling from parent pane styles, preventing inherited borders from display/antenna panes.

## User impact
This makes slider-driven operation much easier to navigate:
- RF/tune power changes are easier to verify at a glance.
- Applet controls provide immediate confirmation while dragging.
- DAX/TCI meter-slider gain changes now have a readable numeric value.
- EQ and DSP-style controls are less dependent on small inline labels.
- Users get a short memory cue after release, helping them retain the exact setting they just adjusted.

## Validation
- Built with:
  `cmake --build build --target AetherSDR -j22`
- Deployed the built macOS app bundle to the remote test Mac:
  `patj@mac.jensencloud.net:/Users/patj/Desktop/AetherSDR.app`
- Manually tested slider popups across applet controls, title bar audio, VFO slice controls, DAX/TCI meter sliders, spectrum overlay panes, DSP popups/settings, Phone/CW controls, spot/DX settings, and radio setup controls.
- Verified the display/antenna pane inherited-border issue is handled by isolating the popup and label styles.
- `git diff --check` passed.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
