### PR TITLE
docs(agents): mandate rebase onto upstream/main before every PR push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,13 @@ for that before the next CI run can use it.
 branch, pushes, opens a PR with auto-squash-merge enabled. Commit freely
 locally, then ship once.
 
+**PR branch hygiene — mandatory before every push:** Always rebase each PR
+branch onto `upstream/main` (ten9876/AetherSDR) before pushing or
+force-pushing. `git rebase upstream/main` on the PR branch, then
+`git push origin <branch> --force-with-lease`. This keeps diffs clean
+(commits already on upstream are automatically skipped), resolves scope-creep
+review comments, and keeps the PR title honest about what actually changed.
+
 Branch protection: signed commits required on main, CI must pass, CODEOWNERS
 review required, branches auto-delete after merge.
 


### PR DESCRIPTION
## Summary

- Adds a **PR branch hygiene** rule to `AGENTS.md`: always `git rebase upstream/main` before pushing a PR branch, then `git push --force-with-lease`

## Why

PR #2859 (MIDI MOX fix) had a stale base — the QSO MIDI commit from #2845 (already merged on upstream/main) still appeared in the diff, making the PR look like 47+/1- when the intended change was 1+/1-. A rebase fixed it immediately, but the rule wasn't documented. This prevents the same issue on future PRs.

## No code changes

Documentation only — `AGENTS.md` updated with a "PR branch hygiene — mandatory before every push" block under the CI/CD section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)