### PR TITLE
fix(smartlink): TOFU cert fingerprint pin for WAN connections (GHSA-wfx7-w6p8-4jr2 phase 1)

### DIFF
--- a/src/core/WanConnection.cpp
+++ b/src/core/WanConnection.cpp
@@ -1,10 +1,52 @@
 #include "WanConnection.h"
+#include "AppSettings.h"
 #include "LogManager.h"
+#include <QCryptographicHash>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QSslCertificate>
 #include <QSslConfiguration>
 
 namespace AetherSDR {
 
 static constexpr int HEARTBEAT_INTERVAL_MS = 10000; // 10s ping (same as FlexLib)
+
+namespace {
+
+// TOFU cert-pin cache.  Stored as a JSON object in AppSettings under the
+// key "SmartLinkCertFingerprintCache": { "<host>": "<sha256-hex>", … }.
+// See GHSA-wfx7-w6p8-4jr2 — WAN TLS still uses VerifyNone (radio is
+// self-signed), but we silently capture each host's cert fingerprint on
+// first connect and log a warning if it changes.  Phase 1 is warn-only;
+// no user prompt, no enforcement.
+constexpr const char* kCertCacheKey = "SmartLinkCertFingerprintCache";
+
+QJsonObject loadCertCache()
+{
+    const QByteArray json = AppSettings::instance().value(kCertCacheKey).toByteArray();
+    if (json.isEmpty()) return {};
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(json, &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) return {};
+    return doc.object();
+}
+
+QString loadStoredFingerprint(const QString& host)
+{
+    return loadCertCache().value(host).toString();
+}
+
+void storeFingerprint(const QString& host, const QString& fingerprintHex)
+{
+    QJsonObject obj = loadCertCache();
+    obj[host] = fingerprintHex;
+    AppSettings::instance().setValue(
+        kCertCacheKey,
+        QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+} // namespace
 
 WanConnection::WanConnection(QObject* parent)
     : QObject(parent)
@@ -38,11 +80,17 @@ void WanConnection::connectToRadio(const QString& host, quint16 tlsPort,
     m_wanHandle = wanHandle;
     m_validated = false;
     m_handle    = 0;
+    m_host      = host;
+    m_expectedFingerprintHex = loadStoredFingerprint(host);
 
-    qCDebug(lcSmartLink) << "WanConnection: TLS connecting to" << host << ":" << tlsPort;
+    qCDebug(lcSmartLink) << "WanConnection: TLS connecting to" << host << ":" << tlsPort
+                         << (m_expectedFingerprintHex.isEmpty()
+                                ? "(no prior cert pin)"
+                                : "(prior cert pin loaded)");
 
-    // Radio uses self-signed certificate — disable verification
-    // (matches FlexLib TlsCommandCommunication: validate_cert=false)
+    // Radio uses self-signed certificate — VerifyNone is still required to
+    // complete the handshake.  The TOFU fingerprint check in onTlsConnected
+    // is what catches MITM; see GHSA-wfx7-w6p8-4jr2.
     QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
     sslConfig.setPeerVerifyMode(QSslSocket::VerifyNone);
     m_socket.setSslConfiguration(sslConfig);
@@ -94,6 +142,30 @@ quint32 WanConnection::sendCommand(const QString& command, ResponseCallback call
 void WanConnection::onTlsConnected()
 {
     qCDebug(lcSmartLink) << "WanConnection: TLS handshake complete";
+
+    // TOFU cert-pin check (GHSA-wfx7-w6p8-4jr2 phase 1, warn-only).
+    const QSslCertificate cert = m_socket.peerCertificate();
+    if (!cert.isNull()) {
+        const QString fpHex = QString::fromLatin1(
+            cert.digest(QCryptographicHash::Sha256).toHex());
+        if (m_expectedFingerprintHex.isEmpty()) {
+            storeFingerprint(m_host, fpHex);
+            m_expectedFingerprintHex = fpHex;
+            qCInfo(lcSmartLink) << "WanConnection: pinned cert fingerprint for"
+                                << m_host << "(first-use TOFU; sha256=" << fpHex << ")";
+        } else if (m_expectedFingerprintHex != fpHex) {
+            qCWarning(lcSmartLink)
+                << "WanConnection: cert fingerprint MISMATCH for" << m_host
+                << "— expected" << m_expectedFingerprintHex
+                << "got" << fpHex
+                << "— possible MITM, radio replaced, or firmware update."
+                << "Phase 1 is warn-only; connection proceeds. See GHSA-wfx7-w6p8-4jr2.";
+        } else {
+            qCDebug(lcSmartLink) << "WanConnection: cert fingerprint matches stored pin for" << m_host;
+        }
+    } else {
+        qCWarning(lcSmartLink) << "WanConnection: peer presented no certificate; skipping TOFU check";
+    }
 
     // Send wan validate as a proper command (C<seq>|wan validate handle=...)
     // FlexLib uses SendCommand() for this, not raw write.

--- a/src/core/WanConnection.h
+++ b/src/core/WanConnection.h
@@ -74,6 +74,11 @@ private:
     quint32 m_lastPingSeq{0};
     QElapsedTimer m_pingStopwatch;
 
+    // TOFU cert pin (GHSA-wfx7-w6p8-4jr2 phase 1).  Captured on first
+    // connect to a given host; subsequent connects warn on mismatch.
+    QString m_host;
+    QString m_expectedFingerprintHex;
+
     QMap<quint32, ResponseCallback> m_pendingCallbacks;
 };
 


### PR DESCRIPTION
WAN (SmartLink) TLS still calls QSslSocket::VerifyNone — the radio's
self-signed cert leaves no chain to validate against — but that means
any MITM on the path between AetherSDR and the radio can intercept all
commands and audio.  Realistic exposures: hotel/coffee-shop WiFi with
a TLS proxy, malicious ISP, BGP hijack.  An attacker who proxies the
session can also issue CAT commands under the operator's authenticated
session (TX on, freq/mode/power change) — FCC-relevant for a licensed
station.

Phase 1 introduces TOFU (Trust On First Use) fingerprint capture:

- On every WAN connect, compute SHA-256 of the presented cert.
- Persist per-host fingerprints as a JSON object in AppSettings under
  the key "SmartLinkCertFingerprintCache" (one nested value, not a
  flat namespace per-host — matches the AppSettings refactor direction).
- First connect to a host: qCInfo + persist.
- Subsequent matching connect: qCDebug (silent in non-debug builds).
- Mismatch: qCWarning naming both fingerprints and the advisory ID.

Phase 1 is **warn-only** — no UI dialog, no enforcement, no disconnect.
This deploys the capture path so we have real-world data (legitimate
firmware-update rotations, radio replacements) before phase 2 adds the
enforcement + "Forget cert" Settings UI.

The TOFU check lives in onTlsConnected (after handshake completes, when
peerCertificate() is populated), not in onSslErrors — onSslErrors stays
unchanged as the "ignore self-signed" path.

Local build verified (cmake --build … --target AetherSDR exits 0).
Not functionally tested via a live SmartLink connect — the operator
cannot trigger SmartLink while on-network with the radio.  Change is
additive: existing LAN connection path is unaffected, new WAN code
runs after a successful TLS handshake so it cannot block connection
establishment, and the worst-case observable effect is one extra
qCInfo log line on first WAN connect.

Phase 2 (next release) adds: mismatch dialog, "Forget radio certificate"
Settings button, and optional disconnect-on-reject.

Principle I.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
