### PR TITLE
fix(cat): cap CAT/TCI server buffers + max-clients (GHSA-7w4w-wfqm-wh93 phase 1)

### DIFF
--- a/src/core/RigctlServer.cpp
+++ b/src/core/RigctlServer.cpp
@@ -5,6 +5,16 @@
 
 namespace AetherSDR {
 
+namespace {
+// Server-side caps closing the unbounded-read / unbounded-client surface
+// flagged in GHSA-7w4w-wfqm-wh93 (M2).  Rigctld commands top out around a
+// few dozen bytes; 64 KiB is wildly generous and still forbids a slow-byte
+// OOM attacker.  Eight concurrent clients covers WSJT-X + logger + a few
+// spares while preventing fd-exhaustion.
+constexpr int kMaxBufferBytes = 64 * 1024;
+constexpr int kMaxClients     = 8;
+}
+
 RigctlServer::RigctlServer(RadioModel* model, QObject* parent)
     : QObject(parent)
     , m_model(model)
@@ -75,6 +85,17 @@ void RigctlServer::onNewConnection()
 {
     while (m_server->hasPendingConnections()) {
         auto* socket = m_server->nextPendingConnection();
+
+        // Refuse new connections once at-capacity (GHSA-7w4w-wfqm-wh93).
+        if (m_clients.size() >= kMaxClients) {
+            qCWarning(lcCat) << "RigctlServer: refusing connection from"
+                             << socket->peerAddress().toString()
+                             << "— at max-clients cap (" << kMaxClients << ")";
+            socket->disconnectFromHost();
+            socket->deleteLater();
+            continue;
+        }
+
         socket->setSocketOption(QAbstractSocket::LowDelayOption, 1);  // TCP_NODELAY
         auto* protocol = new RigctlProtocol(m_model);
         protocol->setSliceIndex(m_sliceIndex);
@@ -106,6 +127,18 @@ void RigctlServer::onClientData()
 
     auto& cs = m_clients[idx];
     cs.buffer.append(socket->readAll());
+
+    // Cap the per-client buffer: an attacker that drips bytes without ever
+    // sending '\n' would otherwise grow this to multi-GB and OOM the
+    // process.  See GHSA-7w4w-wfqm-wh93.  Legitimate rigctld commands are
+    // tens of bytes, so 64 KiB without a newline is unambiguously hostile.
+    if (cs.buffer.size() > kMaxBufferBytes) {
+        qCWarning(lcCat) << "RigctlServer: client" << socket->peerAddress().toString()
+                         << "exceeded" << kMaxBufferBytes
+                         << "byte buffer without newline — disconnecting";
+        socket->disconnectFromHost();
+        return;
+    }
 
     // Process complete lines
     while (true) {

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -26,6 +26,17 @@
 
 namespace AetherSDR {
 
+namespace {
+// Server-side caps closing the unbounded-frame / unbounded-client surface
+// flagged in GHSA-7w4w-wfqm-wh93 (M2).  QWebSocket message/frame sizes
+// default to 1 GiB in Qt6 — wildly more than any legitimate TCI command
+// or audio frame.  64 KiB easily covers the largest legitimate TCI text
+// command and is enforced at the framing layer.  Eight concurrent clients
+// matches the rigctld cap.
+constexpr qint64 kMaxWsMessageBytes = 64 * 1024;
+constexpr int    kMaxClients        = 8;
+}
+
 // ── TCI binary audio frame header (per ExpertSDR3 TCI spec v2.0) ────────
 // 9 × uint32 = 36 bytes, followed by sample payload
 // TCI audio header: 16 × uint32 = 64 bytes
@@ -289,6 +300,24 @@ void TciServer::onNewConnection()
 {
     while (m_server->hasPendingConnections()) {
         auto* ws = m_server->nextPendingConnection();
+
+        // Refuse new connections once at-capacity (GHSA-7w4w-wfqm-wh93).
+        if (m_clients.size() >= kMaxClients) {
+            qCWarning(lcCat) << "TciServer: refusing connection from"
+                             << ws->peerAddress().toString()
+                             << "— at max-clients cap (" << kMaxClients << ")";
+            ws->close(QWebSocketProtocol::CloseCodeTooMuchData,
+                      QStringLiteral("server at max-clients cap"));
+            ws->deleteLater();
+            continue;
+        }
+
+        // Cap per-message and per-frame size to refuse OOM-by-huge-frame
+        // (GHSA-7w4w-wfqm-wh93).  Qt6 default is 1 GiB per message; legit
+        // TCI text commands and audio frames are well under 64 KiB.
+        ws->setMaxAllowedIncomingMessageSize(kMaxWsMessageBytes);
+        ws->setMaxAllowedIncomingFrameSize(kMaxWsMessageBytes);
+
         auto* protocol = new TciProtocol(m_model);
 
         ClientState cs;


### PR DESCRIPTION
Both servers previously had two OOM exposure paths reachable by any LAN
peer (rigctld on QHostAddress::AnyIPv4, TCI on QHostAddress::Any, no
auth handshake on either):

1. Unbounded per-client read buffer.  RigctlServer appended readAll()
   into cs.buffer with no size check; a peer dripping bytes without
   ever sending '\n' grew the buffer until QByteArray refused to allocate.
   TCI's equivalent surface is QWebSocket's 1 GiB default per-message
   limit — same OOM end-state via a single huge frame.

2. Unbounded concurrent connections.  Both servers appended to
   m_clients unconditionally; 10k+ concurrent connects exhausts file
   descriptors then heap on per-client overhead.

Phase 1 caps both at the framing layer:

- RigctlServer: kMaxBufferBytes = 64 KiB.  Buffer overflow without a
  newline disconnects the client with a warning log.  Legitimate
  rigctld commands are tens of bytes.
- TciServer: per-socket setMaxAllowedIncomingMessageSize and
  setMaxAllowedIncomingFrameSize = 64 KiB applied to each accepted
  QWebSocket (the setters live on QWebSocket, not QWebSocketServer).
- Both: kMaxClients = 8.  Excess connects refused with
  disconnectFromHost / WebSocket CloseCodeTooMuchData and a warning.

What Phase 1 does NOT include (Phase 2, separate PR): "Restrict
CAT/TCI servers to localhost" toggle in Radio Setup → CAT.  Loopback
binding eliminates the LAN exposure entirely for the common WSJT-X-
on-same-machine setup but breaks the WSJT-X-on-other-host case
without an opt-in.

Verified with a clean local Release build (cmake --build … --target
AetherSDR exits 0).  Functional behavior under cap is unchanged;
nothing legitimate gets close to either threshold.

Principle I.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
