### PR TITLE
feat(tci): add tx_gain command + ALC field in tx_sensors

### DIFF
--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -233,6 +233,7 @@ QString TciProtocol::handleCommand(const QString& cmd)
 {
     m_pendingNotification.clear();
     m_pendingMasterVolume = -1;
+    m_pendingTxGain = -1;
 
     if (cmd.isEmpty()) return {};
 
@@ -326,6 +327,7 @@ QString TciProtocol::handleCommand(const QString& cmd)
     // AetherSDR extensions (not in TCI v2.0 spec)
     if (name == "rx_record")        return cmdRxRecord(args, isSet);
     if (name == "rx_play")          return cmdRxPlay(args, isSet);
+    if (name == "tx_gain")          return cmdTxGain(args, isSet);
 
     // Unknown command — ignore silently per TCI spec
     return {};
@@ -528,6 +530,28 @@ QString TciProtocol::cmdTuneDrive(const QStringList& args, bool /*isSet*/)
     }, Qt::QueuedConnection);
 
     m_pendingNotification = QStringLiteral("tune_drive:%1;").arg(pwr);
+    return {};
+}
+
+// ── TX_GAIN: get/set TCI TX audio gain (AetherSDR extension) ────────────────
+
+// tx_gain is an AetherSDR extension — not in the TCI v2.0 spec. It controls
+// TciServer's outbound TX gain (m_txGain), applied to WSJT-X/JTDX audio before
+// the radio. Global command, 0-100 (percent of unity), matching the
+// drive/tune_drive convention. Like cmdVolume, TciProtocol cannot reach
+// TciServer directly, so a SET stashes the value in m_pendingTxGain and
+// TciServer applies it via setTxGain() after handleCommand() returns.
+QString TciProtocol::cmdTxGain(const QStringList& args, bool /*isSet*/)
+{
+    if (args.isEmpty()) {
+        // GET — current TCI TX gain (0-100). TciServer persists the 0.0-1.0
+        // value to TciTxGain whenever it changes.
+        float g = AppSettings::instance().value("TciTxGain", "1.00").toFloat();
+        return QStringLiteral("tx_gain:%1;").arg(qBound(0, qRound(g * 100.0f), 100));
+    }
+    int pct = qBound(0, args[args.size() == 1 ? 0 : 1].toInt(), 100);
+    m_pendingTxGain = pct;
+    m_pendingNotification = QStringLiteral("tx_gain:%1;").arg(pct);
     return {};
 }
 

--- a/src/core/TciProtocol.h
+++ b/src/core/TciProtocol.h
@@ -34,6 +34,12 @@ public:
     // Per TCI v2.0 spec, `volume:N;` is the global master volume command.
     int pendingMasterVolume() const { return m_pendingMasterVolume; }
 
+    // After handleCommand(), if the command was a `tx_gain:N;` SET, this
+    // returns the requested TCI TX gain (0-100); -1 means no change. TciServer
+    // reads it and applies it via setTxGain() — TciProtocol can't reach
+    // TciServer directly (same pattern as pendingMasterVolume).
+    int pendingTxGain() const { return m_pendingTxGain; }
+
 private:
     // Command handlers — return response string or empty
     QString cmdVfo(const QStringList& args, bool isSet);
@@ -42,6 +48,7 @@ private:
     QString cmdTune(const QStringList& args, bool isSet);
     QString cmdDrive(const QStringList& args, bool isSet);
     QString cmdTuneDrive(const QStringList& args, bool isSet);
+    QString cmdTxGain(const QStringList& args, bool isSet);
     QString cmdRitEnable(const QStringList& args, bool isSet);
     QString cmdXitEnable(const QStringList& args, bool isSet);
     QString cmdRitOffset(const QStringList& args, bool isSet);
@@ -115,6 +122,7 @@ private:
     RadioModel* m_model;
     QString     m_pendingNotification;
     int         m_pendingMasterVolume{-1};   // -1 = no change requested
+    int         m_pendingTxGain{-1};         // -1 = no change requested
     bool        m_started{false};  // client sent START
 };
 

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -98,6 +98,10 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 this, [this](float micLevel, float, float, float) {
             m_cachedMicLevel = micLevel;
         });
+        connect(&m_model->meterModel(), &MeterModel::swAlcChanged,
+                this, [this](float dbfs) {
+            m_cachedAlc = dbfs;
+        });
     }
 
     // Capture DAX RX stream creation responses so we can register them
@@ -583,6 +587,11 @@ void TciServer::onTextMessage(const QString& msg)
         // above to the requesting client and broadcast to others.
         int mvol = client.protocol->pendingMasterVolume();
         if (mvol >= 0) emit masterVolumeRequested(mvol);
+
+        // tx_gain SET — same pattern: TciProtocol can't reach TciServer, so it
+        // stashes the 0-100 value and we apply it here via setTxGain().
+        int txg = client.protocol->pendingTxGain();
+        if (txg >= 0) setTxGain(txg / 100.0f);
 
         // Start/stop TX_CHRONO when a TCI client sets trx state.
         // WSJT-X only sends TX audio in response to TX_CHRONO (type=3) frames.
@@ -1467,13 +1476,16 @@ void TciServer::broadcastStatus()
             }
         }
         if (cs.txSensorsEnabled && m_model->transmitModel().isTransmitting()) {
-            // tx_sensors:trx,mic_dbm,fwd_watts,peak_watts,swr
+            // tx_sensors:trx,mic_dbm,fwd_watts,peak_watts,swr,alc_dbfs
+            // alc_dbfs (trailing field, AetherSDR extension) is the SW-ALC
+            // peak; index-based parsers safely ignore the extra field.
             cs.socket->sendTextMessage(
-                QStringLiteral("tx_sensors:0,%1,%2,%3,%4;")
+                QStringLiteral("tx_sensors:0,%1,%2,%3,%4,%5;")
                     .arg(m_cachedMicLevel, 0, 'f', 1)
                     .arg(m_cachedFwdPower, 0, 'f', 1)
                     .arg(m_cachedFwdPower, 0, 'f', 1)  // peak ≈ avg for now
-                    .arg(m_cachedSwr, 0, 'f', 1));
+                    .arg(m_cachedSwr, 0, 'f', 1)
+                    .arg(m_cachedAlc, 0, 'f', 1));
         }
     }
 

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -178,6 +178,7 @@ private:
     float             m_cachedFwdPower{0};
     float             m_cachedSwr{1.0f};
     float             m_cachedMicLevel{-50.0f};
+    float             m_cachedAlc{0.0f};       // SW-ALC peak, dBFS
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Summary

Two small TCI-layer additions that give external tooling the hooks to characterise TX drive — sweeping drive against forward power and ALC. (Motivating use: finding the WSJT-X digital-mode drive sweet spot — maximum clean output with ALC held near zero.)

## Changes

**`tx_gain` TCI command** — AetherSDR extension (not TCI v2.0 spec), range `0-100`. Gets/sets `TciServer`'s outbound TX gain (`m_txGain`), applied to WSJT-X/JTDX audio before the radio. GET reads the persisted `TciTxGain`; SET stashes a pending value that `TciServer` applies via `setTxGain()` after `handleCommand()` — the same indirection `cmdVolume` uses, since `TciProtocol` has no `TciServer` handle. Makes the TX-drive level scriptable.

**`alc` field in `tx_sensors`** — appends a trailing `alc_dbfs` field (SW-ALC peak, from `MeterModel::swAlcChanged`) to the periodic `tx_sensors` broadcast. Trailing position is backward compatible — index-based parsers ignore the extra field.

## Verification

- Builds clean (`647/647`) on Linux / Qt 6.4.2.
- Binary launches and runs.
- **Runtime-verified on live RF** (FlexRadio): a calibration harness exercised both hooks across a full TX-drive sweep — `tx_gain` SET/GET and the `tx_sensors` `alc` field. See the verification comment below for evidence.

## Test plan
- [x] Compiles + links clean
- [x] Binary launches
- [x] `tx_gain;` GET / `tx_gain:N;` SET round-trip over a TCI client
- [x] `alc` field seen in `tx_sensors` during TX
