### PR TITLE
fix(support-bundle): redact radio serial + IP in radio-info.json (GHSA-ccrg-j8cp-qhc4)

### DIFF
--- a/src/core/AsyncLogWriter.cpp
+++ b/src/core/AsyncLogWriter.cpp
@@ -43,6 +43,10 @@ QString labelForType(QtMsgType type)
     return QStringLiteral("???");
 }
 
+} // namespace (anonymous)
+
+// Public so SupportBundle and other callers can scrub PII the same way
+// log lines are scrubbed.  Declared in AsyncLogWriter.h.
 QString redactPii(const QString& msg)
 {
     QString out = msg;
@@ -73,6 +77,8 @@ QString redactPii(const QString& msg)
 
     return out;
 }
+
+namespace {
 
 QByteArray formatLine(QtMsgType type,
                       const QTime& timestamp,

--- a/src/core/AsyncLogWriter.h
+++ b/src/core/AsyncLogWriter.h
@@ -14,6 +14,14 @@
 
 namespace AetherSDR {
 
+// Apply log-style PII redaction (IPv4 → *.*.*.X, radio serial →
+// ****-****-****-XXXX, Auth0 tokens, MAC addresses).  Defined in
+// AsyncLogWriter.cpp; thread-safe (pure function over local copies of
+// static const QRegularExpressions).  Used by AsyncLogWriter for every
+// log line and by SupportBundle to scrub radio-info.json fields per
+// the operator-PII redaction policy (GHSA-ccrg-j8cp-qhc4).
+QString redactPii(const QString& msg);
+
 class AsyncLogWriter {
 public:
     struct Counters {

--- a/src/core/SupportBundle.cpp
+++ b/src/core/SupportBundle.cpp
@@ -1,5 +1,6 @@
 #include "SupportBundle.h"
 #include "AppSettings.h"
+#include "AsyncLogWriter.h"  // redactPii — GHSA-ccrg-j8cp-qhc4
 #include "LogManager.h"
 #include "models/RadioModel.h"
 
@@ -99,11 +100,16 @@ QString SupportBundle::createBundle(const RadioInfo& radio)
         obj["connected"] = radio.connected;
         if (radio.connected) {
             obj["model"]           = radio.model;
-            obj["serial"]          = radio.serial;
+            // Serial and IP are PII per project policy — redact to match
+            // the form used in logs (****-****-****-XXXX, *.*.*. XXX) so
+            // support recipients can correlate but never see the cleartext
+            // values.  Callsign is FCC public record; leave as-is.
+            // See GHSA-ccrg-j8cp-qhc4.
+            obj["serial"]          = redactPii(radio.serial);
             obj["firmware"]        = radio.firmware;
             obj["protocolVersion"] = radio.protocolVersion;
             obj["callsign"]        = radio.callsign;
-            obj["ip"]              = radio.ip;
+            obj["ip"]              = redactPii(radio.ip);
         }
         QFile f(tmp + "/radio-info.json");
         if (f.open(QIODevice::WriteOnly))


### PR DESCRIPTION
The support bundle's radio-info.json wrote radio.serial and radio.ip
verbatim, contradicting our own redact-PII policy (logs scrub IPs and
serials; bundles meant to be mailed to support should too).

SupportBundle had its own keyword-based stripper for settings.xml
(token/password/secret/auth0/refresh) but it never touched the JSON
files, so the leak slipped past on every bundle.

This fix:

1. Exposes the canonical AetherSDR::redactPii() (formerly in an
   anonymous namespace in AsyncLogWriter.cpp) via AsyncLogWriter.h.
   formatLine() stays internal in the anon namespace; redactPii moves
   to the AetherSDR namespace so SupportBundle can call it.

2. Applies redactPii() to radio.serial (→ ****-****-****-XXXX) and
   radio.ip (→ *.*.*. XXX) at the point they're written into
   radio-info.json.  Last-4 of the serial and last octet of the IP
   are preserved so support recipients can correlate but never see the
   cleartext values.

3. Leaves radio.callsign alone — callsigns are FCC public record, not
   PII in the ham radio context.

4. Leaves the live ~/.config/AetherSDR/AetherSDR.settings file alone;
   redaction applies only to the bundle's copy of derived data, not
   the operator's working settings (which need real values to connect
   to the radio).

5. Leaves the existing settings.xml keyword stripper alone — separate
   concern, separate audit if it needs tightening.

Verified with a clean local Release build (cmake --build … --target
AetherSDR exits 0).  Functionally testable: open the next-generated
support bundle and confirm radio-info.json shows redacted values.

Principle I.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
