### PR TITLE
fix(security): MQTT password via QKeychain + AppSettings file perms 0600 (GHSA-mmqp-cm4w-cvpp)

### DIFF
--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -254,10 +254,21 @@ void AppSettings::save()
         const QString bakPath = m_filePath + ".bak";
         QFile::remove(bakPath);
         QFile::rename(m_filePath, bakPath);
+        // Tighten the backup the same way as the live file — see below.
+        QFile::setPermissions(bakPath,
+                              QFileDevice::ReadOwner | QFileDevice::WriteOwner);
     }
     if (!QFile::rename(tmpPath, m_filePath)) {
         qWarning() << "AppSettings: atomic rename failed from" << tmpPath << "to" << m_filePath;
+        return;
     }
+
+    // Restrict permissions to owner read/write (mode 0600).  Default umask
+    // leaves these XML files world-readable, exposing MQTT broker creds,
+    // SmartLink email, radio nicknames, etc.  Matches AsyncLogWriter
+    // precedent.  See GHSA-mmqp-cm4w-cvpp (L5).
+    QFile::setPermissions(m_filePath,
+                          QFileDevice::ReadOwner | QFileDevice::WriteOwner);
 }
 
 void AppSettings::reset()

--- a/src/gui/MqttApplet.cpp
+++ b/src/gui/MqttApplet.cpp
@@ -1,5 +1,6 @@
 #include "MqttApplet.h"
 #include "core/AppSettings.h"
+#include "core/LogManager.h"
 #include "core/MqttClient.h"
 
 #include <QVBoxLayout>
@@ -18,7 +19,19 @@
 #include <QDialogButtonBox>
 #include <QMenu>
 
+#ifdef HAVE_KEYCHAIN
+#include <qt6keychain/keychain.h>
+#endif
+
 namespace AetherSDR {
+
+// Keychain identifiers for the MQTT broker password.  See
+// GHSA-mmqp-cm4w-cvpp — previously stored as plaintext in
+// ~/.config/AetherSDR/AetherSDR.settings (default umask 0644, world-
+// readable on most Linux systems).
+static constexpr const char* kKeychainService = "AetherSDR";
+static constexpr const char* kKeychainKey     = "mqtt_password";
+static constexpr const char* kLegacySetting   = "MqttPass";
 
 static const QString kLabelStyle =
     "QLabel { color: #8090a0; font-size: 10px; background: transparent; }";
@@ -79,7 +92,12 @@ void MqttApplet::buildUI()
     addRow(0, "Host:", m_hostEdit, "MqttHost", "localhost");
     addRow(1, "Port:", m_portEdit, "MqttPort", "1883");
     addRow(2, "User:", m_userEdit, "MqttUser", "");
-    addRow(3, "Pass:", m_passEdit, "MqttPass", "", true);
+    // Password is not stored in AppSettings (see GHSA-mmqp-cm4w-cvpp).
+    // addRow with an empty default leaves the QLineEdit empty; we
+    // populate it asynchronously from the keychain below, and migrate
+    // any legacy plaintext value found in AppSettings on first launch.
+    addRow(3, "Pass:", m_passEdit, QStringLiteral("MqttPass_unused"), QString(), true);
+    loadPasswordFromKeychain();
 
     auto* topicLbl = new QLabel("Topics:");
     topicLbl->setStyleSheet(kLabelStyle);
@@ -195,7 +213,10 @@ void MqttApplet::buildUI()
             ss.setValue("MqttHost",   m_hostEdit->text().trimmed());
             ss.setValue("MqttPort",   m_portEdit->text().trimmed());
             ss.setValue("MqttUser",   m_userEdit->text().trimmed());
-            ss.setValue("MqttPass",   m_passEdit->text().trimmed());
+            // Password lives in QKeychain — see GHSA-mmqp-cm4w-cvpp.
+            // Belt-and-braces: ensure no legacy plaintext entry survives.
+            ss.remove(kLegacySetting);
+            savePasswordToKeychain(m_passEdit->text().trimmed());
             ss.setValue("MqttTopics", m_topicsEdit->text().trimmed());
             ss.setValue("MqttTls",    m_tlsCheck->isChecked() ? "True" : "False");
             ss.setValue("MqttCaFile", m_caFileEdit->text().trimmed());
@@ -427,6 +448,104 @@ void MqttApplet::loadButtons()
             obj["payload"].toString()
         });
     }
+}
+
+// ── Keychain-backed password persistence (GHSA-mmqp-cm4w-cvpp) ──────────────
+
+void MqttApplet::loadPasswordFromKeychain()
+{
+#ifdef HAVE_KEYCHAIN
+    auto& s = AppSettings::instance();
+    const QString legacy = s.value(kLegacySetting).toString();
+    if (!legacy.isEmpty()) {
+        // First-launch migration on an upgraded install.  Populate the
+        // UI immediately so the user doesn't see an empty field, write
+        // the value to the keychain, then strip the plaintext entry
+        // from AppSettings.  Keychain failure leaves the plaintext in
+        // place — better that than losing the user's credentials.
+        m_passEdit->setText(legacy);
+        auto* job = new QKeychain::WritePasswordJob(QLatin1String(kKeychainService));
+        job->setAutoDelete(true);
+        job->setKey(QLatin1String(kKeychainKey));
+        job->setTextData(legacy);
+        connect(job, &QKeychain::Job::finished, this, [](QKeychain::Job* j) {
+            if (j->error() != QKeychain::NoError) {
+                qCWarning(lcMqtt) << "MqttApplet: keychain migration write failed:"
+                                  << j->errorString()
+                                  << "— legacy plaintext entry preserved for retry";
+                return;
+            }
+            AppSettings::instance().remove(kLegacySetting);
+            AppSettings::instance().save();
+            qCInfo(lcMqtt) << "MqttApplet: migrated MQTT password to keychain"
+                           << "(legacy plaintext entry removed)";
+        });
+        job->start();
+        return;
+    }
+
+    auto* job = new QKeychain::ReadPasswordJob(QLatin1String(kKeychainService));
+    job->setAutoDelete(true);
+    job->setKey(QLatin1String(kKeychainKey));
+    connect(job, &QKeychain::Job::finished, this, [this](QKeychain::Job* j) {
+        if (!m_passEdit) return;  // applet may have been destroyed mid-flight
+        if (j->error() == QKeychain::NoError) {
+            auto* read = static_cast<QKeychain::ReadPasswordJob*>(j);
+            m_passEdit->setText(read->textData());
+        } else if (j->error() != QKeychain::EntryNotFound) {
+            qCWarning(lcMqtt) << "MqttApplet: keychain read failed:" << j->errorString();
+        }
+    });
+    job->start();
+#else
+    // Keychain not available at build time.  Fall back to reading the
+    // legacy plaintext setting if it exists, with a warning.  This keeps
+    // the applet usable on builds that opt out of Qt6Keychain at the
+    // cost of leaving the password readable on disk (the bug this fix
+    // is meant to address).
+    auto& s = AppSettings::instance();
+    const QString legacy = s.value(kLegacySetting).toString();
+    if (!legacy.isEmpty()) {
+        qCWarning(lcMqtt) << "MqttApplet: HAVE_KEYCHAIN not set — MQTT password "
+                             "remains in plaintext AppSettings";
+        m_passEdit->setText(legacy);
+    }
+#endif
+}
+
+void MqttApplet::savePasswordToKeychain(const QString& password)
+{
+#ifdef HAVE_KEYCHAIN
+    if (password.isEmpty()) {
+        // Empty password = user cleared the field.  Drop any keychain
+        // entry so the next load doesn't surprise them with a stale value.
+        auto* job = new QKeychain::DeletePasswordJob(QLatin1String(kKeychainService));
+        job->setAutoDelete(true);
+        job->setKey(QLatin1String(kKeychainKey));
+        connect(job, &QKeychain::Job::finished, this, [](QKeychain::Job* j) {
+            if (j->error() != QKeychain::NoError
+                && j->error() != QKeychain::EntryNotFound) {
+                qCWarning(lcMqtt) << "MqttApplet: keychain delete failed:" << j->errorString();
+            }
+        });
+        job->start();
+        return;
+    }
+    auto* job = new QKeychain::WritePasswordJob(QLatin1String(kKeychainService));
+    job->setAutoDelete(true);
+    job->setKey(QLatin1String(kKeychainKey));
+    job->setTextData(password);
+    connect(job, &QKeychain::Job::finished, this, [](QKeychain::Job* j) {
+        if (j->error() != QKeychain::NoError)
+            qCWarning(lcMqtt) << "MqttApplet: keychain save failed:" << j->errorString();
+    });
+    job->start();
+#else
+    qCWarning(lcMqtt) << "MqttApplet: HAVE_KEYCHAIN not set — falling back to "
+                         "plaintext AppSettings for MQTT password";
+    AppSettings::instance().setValue(kLegacySetting, password);
+    AppSettings::instance().save();
+#endif
 }
 
 } // namespace AetherSDR

--- a/src/gui/MqttApplet.h
+++ b/src/gui/MqttApplet.h
@@ -57,6 +57,12 @@ private:
     void addButton();
     void removeButton(int index);
 
+    // MQTT broker password lives in QKeychain rather than AppSettings
+    // (GHSA-mmqp-cm4w-cvpp).  Both calls are async and no-op on builds
+    // without HAVE_KEYCHAIN defined.
+    void loadPasswordFromKeychain();
+    void savePasswordToKeychain(const QString& password);
+
     MqttClient* m_client{nullptr};
     QLineEdit*   m_hostEdit{nullptr};
     QLineEdit*   m_portEdit{nullptr};


### PR DESCRIPTION
Two coupled findings from the 2026-05-09 audit (M3 + L5):

M3 — MQTT broker password was stored plaintext in ~/.config/AetherSDR/
AetherSDR.settings (default umask 0644, world-readable on most Linux
systems).  Other accounts on the same machine could lift the password
and connect to the user's broker — for a station-automation MQTT setup
that may control rotators, amplifier PTT lockout, etc., that's real
exposure.

L5 — AppSettings.cpp's atomic save never tightened the file mode after
rename(), so the same file (which also contains SmartLink email, radio
nicknames, and other operator metadata) was world-readable as a class.
AsyncLogWriter already does setPermissions(ReadOwner|WriteOwner) on its
log files; AppSettings was the outlier.

This fix:

1. Moves MqttPass to QKeychain using the same pattern SmartLinkClient
   already uses for the refresh token (service "AetherSDR", key
   "mqtt_password").  Async load on applet open, async save on user
   click, async delete when the user clears the field.

2. Migrates existing plaintext entries on first launch: if MqttPass is
   present in AppSettings, populate the UI from it, write it to the
   keychain, and only remove the plaintext entry if the keychain write
   succeeded.  Keychain failure leaves the plaintext in place for
   retry — better than losing the user's credentials.

3. Tightens AppSettings file permissions to mode 0600 on every save
   (live file + .bak backup).  Matches the AsyncLogWriter precedent.

4. Falls back to plaintext AppSettings on builds without HAVE_KEYCHAIN,
   with a qCWarning explaining the security regression.  Real builds
   on Linux/Windows/macOS all link Qt6Keychain so this branch is dead
   in practice; the guard keeps the build green on stripped-down
   environments.

Verified:
- Local Release build (cmake --build … --target AetherSDR exits 0).
- Live run with the M3 binary tightened the settings file from
  -rw-r--r-- to -rw------- on first save.
- Live run with empty MQTT password exercised the DeletePasswordJob
  branch without errors.
- HAVE_KEYCHAIN compiled in: nm shows QKeychain::ReadPasswordJob,
  WritePasswordJob, DeletePasswordJob symbols in the binary.
- Migration path not functionally tested (operator had no legacy
  MqttPass entry); code follows the SmartLink refresh-token pattern
  which has been live for months.

Principle I.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
