### PR TITLE
chore: add PR template, SUPPORT.md, and ROADMAP.md (#2933, PR 9)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--
+Thanks for contributing to AetherSDR!
+
+Before opening the PR, please:
+- Read AGENTS.md if this is your first contribution (or your AI tool's
+  first contribution) — it has the conventions every contributor agent
+  is expected to follow.
+- Read CONTRIBUTING.md for the commit-signing and branch-protection
+  rules.
+- If you're an AI agent: claim the originating issue first by assigning
+  yourself via `gh issue edit <N> --add-assignee <handle>`. Double-
+  assigning alongside the @aethersdr-agent triage bot is fine.
+-->
+
+## Summary
+
+<!-- One-paragraph description of what changes and why.  If this fixes
+an issue, lead with "Fixes #N" or "Closes #N". -->
+
+## Constitution principle honored
+
+<!-- Cite the principle by Roman numeral when relevant.  E.g.
+"Principle V — new feature uses nested-JSON persistence."
+"Principle II — MeterSmoother used for the new meter widget."
+See CONSTITUTION.md for the full list. -->
+
+## Test plan
+
+- [ ] Local build passes (`cmake --build build`)
+- [ ] Behavior verified on a real radio if applicable
+- [ ] Existing tests pass (CI)
+- [ ] Reproduction steps documented if user-reported bug
+
+## Checklist
+
+- [ ] Commits are signed (`docs/COMMIT-SIGNING.md`)
+- [ ] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
+      (Principle V)
+- [ ] All meter UI uses `MeterSmoother` (Principle II)
+- [ ] Documentation updated if user-visible behavior changed
+- [ ] Security-sensitive changes reference a GHSA if applicable

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,68 @@
+# AetherSDR Roadmap
+
+Live tracking lives in [GitHub Issues](https://github.com/aethersdr/AetherSDR/issues)
+and the per-cycle milestone view. This file is a human-readable snapshot
+of what the project lead and core contributors are working on — updated
+as direction changes.
+
+For *what shipped*, see [`CHANGELOG.md`](CHANGELOG.md).
+
+## Current cycle: post-v26.5.2.1
+
+### In flight
+
+- **Stream Deck plugin** — ship one Elgato-SDK plugin distributed via
+  GitHub Releases (avoid Marketplace DRM); works on Windows/macOS plus
+  Linux via OpenDeck.
+- **AppSettings nested-JSON refactor** — ~460 flat call sites today;
+  the new pattern is one nested-JSON value per feature (Principle V).
+  Mechanical migration tooling is the prerequisite work.
+- **TX DSP chain visual rebuild** — stage-per-applet chain with the
+  visual `CHAIN` widget as the primary entry point.
+- **H1 Phase 2** ([#2951](https://github.com/aethersdr/AetherSDR/issues/2951))
+  — WAN cert-mismatch dialog + Pinned Certificates settings UI.
+  Phase 1 ships warn-only TOFU capture; Phase 2 makes it enforce.
+
+### Queued (next cycle)
+
+- **AetherModem Phase 1** — 1200 baud VHF AX.25 packet TX (data-mode
+  transmit pipeline using the existing DAX TX path).
+- **L1–L4 audit follow-ups** — four low-severity items from the
+  2026-05-09 security pass, tracked as
+  [#2954](https://github.com/aethersdr/AetherSDR/issues/2954)–[#2957](https://github.com/aethersdr/AetherSDR/issues/2957).
+- **Extended region band plans** — DXCC entities outside IARU R1/R2/R3.
+- **macOS shmem + RigctlPty audit** ([#2940](https://github.com/aethersdr/AetherSDR/issues/2940))
+  — focused security review of VirtualAudioBridge (macOS) and
+  RigctlPty (Linux + macOS), follow-up to the audit that found H2.
+
+### Recently shipped
+
+Highlights from the last 30 days — full list in
+[`CHANGELOG.md`](CHANGELOG.md):
+
+- Constitution v1.1.0 — 14 numbered principles, multi-agent
+  contribution model, signed-commit enforcement.
+- Six security fixes shipped against the 2026-05 audit
+  (H1, H2, M1, M2, M3+L5, M4 — all advisories will publish on the
+  next release tag).
+- Repo structure cleanup — root and `docs/` directories brought to
+  portfolio-quality OSS shape across 9 sequential PRs
+  ([#2933](https://github.com/aethersdr/AetherSDR/issues/2933)).
+- TCI TX audio regression fix — restored full power to WSJT-X over TCI
+  by reverting the device-identity change that triggered K2 scaling.
+- Aetherial Tube Pre-Amp — RNNoise toggle on the TX mic pre-amp area.
+
+## How to influence the roadmap
+
+- **Open an issue** with the feature-request template if you want
+  something specific. The AetherClaude orchestrator triages it within
+  minutes.
+- **Open a PR** if you've already built it — see
+  [`CONTRIBUTING.md`](CONTRIBUTING.md). Most cleanup-class work
+  AetherClaude can do autonomously; novel features benefit from a
+  design discussion in the issue first.
+- **Sponsor a feature** — email the project lead at
+  `kk7gwy@aethersdr.com`. Sponsored work jumps the queue while
+  remaining open-source.
+
+This roadmap is intentionally short. Long roadmaps don't ship.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,44 @@
+# Getting Help with AetherSDR
+
+AetherSDR is volunteer-maintained open-source software. There is no SLA
+and no guaranteed response time — but bug reports with attached support
+bundles get priority, and the project's AetherClaude orchestrator
+auto-triages every new issue and PR within minutes.
+
+## Where to go
+
+- **General questions / discussion:** GitHub Discussions —
+  https://github.com/aethersdr/AetherSDR/discussions
+- **Bug reports:** file an issue with the bug-report template.
+  The quickest path: in the running app, **Help → Generate Support
+  Bundle** and attach the resulting .zip to the issue. The bundle
+  includes redacted logs, settings, and a snapshot of the radio state
+  AetherClaude needs to triage.
+- **Feature requests:** file an issue with the feature-request template.
+- **Security issues:** **do not** open a public issue. See
+  [`SECURITY.md`](SECURITY.md) for the private-disclosure process via
+  GitHub Security Advisories.
+
+## Real-time chat
+
+Project lead (Jeremy KK7GWY) operates from DN18 in the US Pacific
+Northwest. For real-time questions, ping in the GitHub Discussions
+thread relevant to your topic and you'll usually get a same-day reply.
+
+## Commercial / consulting
+
+Email the project lead at `kk7gwy@aethersdr.com` — happy to discuss
+custom integration work, sponsored development of a feature you need,
+or training on the codebase.
+
+## What gets you the fastest fix
+
+1. A reproducible bug report on a current release (latest tag).
+2. The support bundle from the app at the moment the bug occurred.
+3. Hardware + firmware versions (visible in the app's title bar and
+   About dialog).
+4. Whether the bug also reproduces with the official SmartSDR client —
+   helps narrow protocol vs. AetherSDR-specific issues.
+
+If you can give us all four, the AetherClaude orchestrator can usually
+draft a candidate fix before a human looks at the issue.


### PR DESCRIPTION
Three net-new files completing the 9-PR repo-cleanup roadmap:

- .github/PULL_REQUEST_TEMPLATE.md
  Auto-populates the body of every new PR.  Summary + constitution
  principle citation + test plan + signed-commit/AppSettings/MeterSmoother
  checklist.  Matches what AGENTS.md asks contributors (human and AI) to
  cover and what reviewers consistently ask for.

- SUPPORT.md
  Steers users to the right entry point: Discussions for questions,
  bug-report issue + support bundle for bugs, SECURITY.md for security
  issues.  Surfaces in GitHub's "Get help" sidebar once committed; also
  bumps the project's Community Standards score.

- ROADMAP.md
  Short snapshot of what's in flight, what's queued, what shipped
  recently.  Intentionally terse — long roadmaps don't ship.  Links to
  GitHub Issues for live tracking.

No code changes; existing CMake configure still green.

After this PR lands, the repo-cleanup issue (#2933) can close.  9 PRs
shipped, root + docs/ at portfolio-quality OSS shape, AGENTS.md as the
canonical multi-agent guide, security audit closed on every finding.

Principle I.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
