### PR TITLE
chore(a11y): hint credential fields for OS password managers (SmartLink + MQTT)

### DIFF
--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -384,9 +384,22 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     loginLayout->setContentsMargins(0, 0, 0, 0);
     loginLayout->setHorizontalSpacing(8);
     loginLayout->setVerticalSpacing(6);
+    // Accessibility + password-manager hints.  macOS Passwords, Windows
+    // Authenticator, and KDE Wallet read the OS accessibility tree to
+    // associate credential fields; the objectName + accessibleName +
+    // accessibleDescription tuple is what they look for.  m_loginForm
+    // is named so the password manager can scope the credential pair
+    // ("SmartLink login form" vs "MQTT login form").
+    m_loginForm->setObjectName(QStringLiteral("smartlinkLoginForm"));
+    m_loginForm->setAccessibleName(tr("SmartLink account login"));
+
     m_emailEdit = new QLineEdit(m_loginForm);
     m_emailEdit->setStyleSheet(editStyle);
     m_emailEdit->setPlaceholderText("flexradio account email");
+    m_emailEdit->setObjectName(QStringLiteral("smartlinkEmail"));
+    m_emailEdit->setAccessibleName(tr("SmartLink account email"));
+    m_emailEdit->setAccessibleDescription(
+        tr("FlexRadio account email address used to sign in to SmartLink"));
     QString storedEmail = AppSettings::instance().value("SmartLinkEmail").toString();
     if (!storedEmail.isEmpty())
         m_emailEdit->setText(QString::fromUtf8(QByteArray::fromBase64(storedEmail.toUtf8())));
@@ -394,6 +407,10 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     m_passwordEdit->setStyleSheet(editStyle);
     m_passwordEdit->setEchoMode(QLineEdit::Password);
     m_passwordEdit->setPlaceholderText("password");
+    m_passwordEdit->setObjectName(QStringLiteral("smartlinkPassword"));
+    m_passwordEdit->setAccessibleName(tr("SmartLink account password"));
+    m_passwordEdit->setAccessibleDescription(
+        tr("FlexRadio account password used to sign in to SmartLink"));
     loginLayout->addRow("Email:", m_emailEdit);
     loginLayout->addRow("Password:", m_passwordEdit);
     m_loginBtn = new QPushButton("Sign In", m_loginForm);

--- a/src/gui/MqttApplet.cpp
+++ b/src/gui/MqttApplet.cpp
@@ -58,28 +58,48 @@ void MqttApplet::buildUI()
     header->setStyleSheet("QLabel { color: #c8d8e8; font-size: 11px; font-weight: bold; }");
     vbox->addWidget(header);
 
-    // Broker settings grid
+    // Broker settings grid.  Accessibility hints (objectName +
+    // accessibleName + accessibleDescription) help macOS Passwords,
+    // Windows Authenticator, and KDE Wallet associate user/pass fields
+    // when offering autofill.  No-op on platforms / password managers
+    // that don't read the accessibility tree.
     auto* grid = new QGridLayout;
     grid->setSpacing(2);
     grid->setContentsMargins(0, 0, 0, 0);
 
+    setObjectName(QStringLiteral("mqttLoginForm"));
+    setAccessibleName(tr("MQTT broker connection"));
+
     auto& s = AppSettings::instance();
 
     auto addRow = [&](int row, const QString& label, QLineEdit*& edit,
-                      const QString& key, const QString& def, bool password = false) {
+                      const QString& key, const QString& def,
+                      const QString& objName, const QString& a11yName,
+                      const QString& a11yDesc, bool password = false) {
         auto* lbl = new QLabel(label);
         lbl->setStyleSheet(kLabelStyle);
         grid->addWidget(lbl, row, 0);
         edit = new QLineEdit(s.value(key, def).toString());
         edit->setStyleSheet(kEditStyle);
         if (password) { edit->setEchoMode(QLineEdit::Password); }
+        if (!objName.isEmpty())  edit->setObjectName(objName);
+        if (!a11yName.isEmpty()) edit->setAccessibleName(a11yName);
+        if (!a11yDesc.isEmpty()) edit->setAccessibleDescription(a11yDesc);
         grid->addWidget(edit, row, 1);
     };
 
-    addRow(0, "Host:", m_hostEdit, "MqttHost", "localhost");
-    addRow(1, "Port:", m_portEdit, "MqttPort", "1883");
-    addRow(2, "User:", m_userEdit, "MqttUser", "");
-    addRow(3, "Pass:", m_passEdit, "MqttPass", "", true);
+    addRow(0, "Host:", m_hostEdit, "MqttHost", "localhost",
+           QStringLiteral("mqttHost"), tr("MQTT broker host"),
+           tr("Hostname or IP address of the MQTT broker"));
+    addRow(1, "Port:", m_portEdit, "MqttPort", "1883",
+           QStringLiteral("mqttPort"), tr("MQTT broker port"),
+           tr("TCP port for the MQTT broker (1883 plaintext, 8883 TLS)"));
+    addRow(2, "User:", m_userEdit, "MqttUser", "",
+           QStringLiteral("mqttUsername"), tr("MQTT broker username"),
+           tr("Username for MQTT broker authentication"));
+    addRow(3, "Pass:", m_passEdit, "MqttPass", "",
+           QStringLiteral("mqttPassword"), tr("MQTT broker password"),
+           tr("Password for MQTT broker authentication"), true);
 
     auto* topicLbl = new QLabel("Topics:");
     topicLbl->setStyleSheet(kLabelStyle);


### PR DESCRIPTION
Adds objectName + accessibleName + accessibleDescription tuples to the
SmartLink login fields (ConnectionPanel) and MQTT broker fields
(MqttApplet) so OS-level password managers can associate them when
offering autofill:

- macOS Passwords (Sequoia and later) reads these via NSAccessibility
- Windows Authenticator reads them via UIAutomation
- KDE Wallet reads them via Qt accessibility / AT-SPI

Parent group names (smartlinkLoginForm, mqttLoginForm) let the
password manager scope each credential pair so it can offer the right
saved entry rather than blending them.

QLineEdit::Password echo mode already sets the password role
automatically — these annotations primarily benefit the username,
host, and port fields which previously had no role information.

Does NOT help Proton Pass on Linux (no native-app autofill integration
on that platform today) or Bitwarden/1Password native apps (they only
autofill into browser extensions).  Zero-cost on those setups.

No code path change.  Local Release build clean.

Principle I.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
