### PR TITLE
fix(audio): persist BYPASS state via active flag (#2892)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -2121,7 +2121,7 @@ QVector<AudioEngine::TxChainStage> AudioEngine::txChainStages() const
 
 bool AudioEngine::isTxBypassed() const
 {
-    return !m_txBypassSnapshot.isEmpty();
+    return m_txBypassActive;
 }
 
 void AudioEngine::setTxBypassed(bool on)
@@ -2214,12 +2214,13 @@ void AudioEngine::setTxBypassed(bool on)
         m_txBypassSnapshot.clear();
     }
 
+    m_txBypassActive = on;
     emit txBypassChanged(on);
 }
 
 bool AudioEngine::isRxBypassed() const
 {
-    return !m_rxBypassSnapshot.isEmpty();
+    return m_rxBypassActive;
 }
 
 void AudioEngine::setRxBypassed(bool on)
@@ -2304,6 +2305,7 @@ void AudioEngine::setRxBypassed(bool on)
         m_rxBypassSnapshot.clear();
     }
 
+    m_rxBypassActive = on;
     emit rxBypassChanged(on);
 }
 

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -764,18 +764,22 @@ private:
     // implementations today, so the others are no-op pass-throughs.
     std::atomic<uint64_t> m_txChainPacked{0};
     // Master-bypass snapshot — the stages that were enabled at the
-    // moment setTxBypassed(true) was called.  Lives on the engine so
-    // both the Chain applet and the channel-strip BYPASS buttons
-    // share one source of truth.  Empty ⇒ not bypassed.
+    // moment setTxBypassed(true) was called.  Used solely to restore
+    // exactly that set when bypass is released; m_txBypassActive is
+    // the source of truth for "currently bypassed" (see issue #2892:
+    // clicking BYPASS when all stages are already disabled yields an
+    // empty snapshot, so the snapshot alone cannot represent state).
     QVector<TxChainStage> m_txBypassSnapshot;
+    bool m_txBypassActive{false};
     // RX chain — same packing convention.  RxChainStage::None terminates
     // the list.  Phase 0 dispatcher iterates this but every stage is a
     // no-op until its DSP class lands in a later phase.
     std::atomic<uint64_t> m_rxChainPacked{0};
-    // RX bypass snapshot — sibling of m_txBypassSnapshot.  Empty ⇒ not
-    // bypassed; non-empty ⇒ holds the stages that were enabled when
-    // bypass engaged so we can restore exactly that set on un-bypass.
+    // RX bypass snapshot — sibling of m_txBypassSnapshot.  Used solely
+    // to restore the stages that were enabled when bypass engaged;
+    // m_rxBypassActive is the source of truth for "currently bypassed".
     QVector<RxChainStage> m_rxBypassSnapshot;
+    bool m_rxBypassActive{false};
     // Scratch buffer for in-place EQ on the RX path (avoids per-call alloc).
     QByteArray m_clientEqRxScratch;
     QByteArray m_clientEqTxScratch;


### PR DESCRIPTION
## Summary

`AudioEngine::isTxBypassed()` and `isRxBypassed()` returned
`!m_txBypassSnapshot.isEmpty()`, conflating "no bypass engaged" with "bypass
engaged while every chain stage was already disabled." When BYPASS is clicked
in the latter state, the snapshot stays empty, so the getter returns `false`
moments after `setTxBypassed(true)` was called.

`AetherialAudioStrip.cpp:257-258` re-reads `isTxBypassed()` / `isRxBypassed()`
on every TX/RX side-toggle to resync the BYPASS button's checked state. The
stale `false` unchecks the button and the engine's view of bypass silently
desynchronises from the GUI.

## Why

This is exactly the failure reported in #2892 by @TnxQSO-Admin: BYPASS engages,
user switches the strip TX→RX→TX (or the inverse), and the BYPASS button
spontaneously unchecks. The reporter's root-cause analysis pinpointed the
empty-snapshot edge case and recommended dedicated bool members as the source
of truth — this PR implements that recommendation.

The fix also covers the restart variant the issue body mentions: when a prior
session ended with bypass engaged, all stages were persisted as disabled. The
next BYPASS click in a fresh session hits the same empty-snapshot case; with
the flag, the button now stays checked.

## Scope

- `src/core/AudioEngine.h` — declare `bool m_txBypassActive{false}` and
  `bool m_rxBypassActive{false}` alongside the existing snapshot vectors;
  comments updated to clarify the new division of responsibility.
- `src/core/AudioEngine.cpp` — getters return the flag; setters assign the
  flag before `emit`. The snapshot retains its restore role unchanged — it
  still records which stages were enabled at the moment of bypass so we can
  re-enable exactly that set on release.

+14 / -8 lines. No protocol, persistence, or UX change; no signal-emission
change beyond timing the flag write before the emit.

## Test plan

- [x] Local incremental `ninja -C build` clean on Linux (Nobara 43, Qt 6.10.3, gcc 15.2.1)
- [x] Bug reproduced on baseline `upstream/main` (`b9df0b3`) against a FLEX-6700 — TX side, all stages off, click BYPASS, switch RX, switch back to TX → BYPASS unchecks itself
- [x] Fix verified against the same FLEX-6700, same repro steps — BYPASS stays checked across the TX/RX/TX cycle
- [ ] Mac smoke — open to running this on macOS if requested

Closes #2892

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent, on Linux dev stack (`nobara-dell`).
