### PR TITLE
[ux] Add multiFLEX dashboard disconnect controls

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -981,13 +981,31 @@ bool MainWindow::confirmClientSlotAvailability(const WanRadioInfo& info,
     return !dialog.selectedHandles().isEmpty();
 }
 
-void MainWindow::disconnectWanRadioClients(const WanRadioInfo& info)
+bool MainWindow::sendWanRadioClientDisconnects(const QString& serial,
+                                               const QList<quint32>& handles)
 {
     if (!m_smartLink.isConnected()) {
         m_connPanel->setStatusText("SmartLink is not connected");
-        return;
+        statusBar()->showMessage("SmartLink is not connected.", 4000);
+        return false;
     }
 
+    if (serial.trimmed().isEmpty()) {
+        m_connPanel->setStatusText("SmartLink radio serial unavailable");
+        return false;
+    }
+
+    if (handles.isEmpty()) {
+        m_connPanel->setStatusText("No remote clients to disconnect");
+        return false;
+    }
+
+    m_smartLink.disconnectRadioClients(serial, handles);
+    return true;
+}
+
+void MainWindow::disconnectWanRadioClients(const WanRadioInfo& info)
+{
     const auto clients = buildDisconnectClients(info);
     if (clients.isEmpty()) {
         m_connPanel->setStatusText("No remote clients to disconnect");
@@ -1006,9 +1024,43 @@ void MainWindow::disconnectWanRadioClients(const WanRadioInfo& info)
     if (handles.isEmpty())
         return;
 
-    m_smartLink.disconnectRadioClients(info.serial, handles);
-    m_connPanel->setStatusText("Disconnect request sent");
-    statusBar()->showMessage("Remote client disconnect request sent through SmartLink.", 4000);
+    if (sendWanRadioClientDisconnects(info.serial, handles)) {
+        m_connPanel->setStatusText("Disconnect request sent");
+        statusBar()->showMessage("Remote client disconnect request sent through SmartLink.", 4000);
+    }
+}
+
+void MainWindow::showMultiFlexDialog()
+{
+    MultiFlexDialog dlg(&m_radioModel, this);
+    connect(&dlg, &MultiFlexDialog::disconnectClientRequested,
+            this, &MainWindow::handleMultiFlexClientDisconnect);
+    dlg.exec();
+}
+
+void MainWindow::handleMultiFlexClientDisconnect(quint32 handle, const QString& displayName)
+{
+    if (handle == 0 || handle == m_radioModel.ourClientHandle())
+        return;
+
+    QString name = cleanClientDisplayText(displayName);
+    if (name.isEmpty())
+        name = QString("client 0x%1").arg(handle, 8, 16, QChar('0')).toUpper();
+
+    if (m_radioModel.isWan()) {
+        const QString serial = !m_pendingWanRadio.serial.isEmpty()
+            ? m_pendingWanRadio.serial
+            : m_radioModel.serial();
+        if (sendWanRadioClientDisconnects(serial, {handle})) {
+            m_connPanel->setStatusText("Disconnect request sent");
+            statusBar()->showMessage(
+                QString("SmartLink disconnect request sent for %1.").arg(name), 4000);
+        }
+        return;
+    }
+
+    if (m_radioModel.disconnectClient(handle))
+        statusBar()->showMessage(QString("Disconnect request sent for %1.").arg(name), 4000);
 }
 
 void MainWindow::startWanRadioConnect(const WanRadioInfo& info, bool promptForClientSlots)
@@ -1053,7 +1105,7 @@ void MainWindow::startWanRadioConnect(const WanRadioInfo& info, bool promptForCl
         m_smartLink.requestConnect(serial, udpPort);
     };
     if (!disconnectHandles.isEmpty()) {
-        m_smartLink.disconnectRadioClients(info.serial, disconnectHandles);
+        sendWanRadioClientDisconnects(info.serial, disconnectHandles);
         QTimer::singleShot(350, this, requestSmartLinkConnect);
     } else {
         requestSmartLinkConnect();
@@ -6881,11 +6933,8 @@ void MainWindow::buildMenuBar()
         connect(dlg, &QDialog::finished, this, refreshSpots);  // refresh on close
     });
     auto* multiFlexAction = settingsMenu->addAction("multiFLEX...");
-    auto openMultiFlex = [this] {
-        MultiFlexDialog dlg(&m_radioModel, this);
-        dlg.exec();
-    };
-    connect(multiFlexAction, &QAction::triggered, this, openMultiFlex);
+    connect(multiFlexAction, &QAction::triggered,
+            this, &MainWindow::showMultiFlexDialog);
     // m_titleBar connect deferred — see after TitleBar creation (~line 2530)
     m_txBandAction = settingsMenu->addAction("TX Band Settings...");
     m_txBandAction->setMenuRole(QAction::NoRole);   // prevent macOS auto-reparenting (#883)
@@ -7631,10 +7680,8 @@ void MainWindow::buildUI()
             this, &MainWindow::updatePcAudioTooltip, Qt::QueuedConnection);
     connect(m_audio, &AudioEngine::outputDeviceChanged,
             this, &MainWindow::updatePcAudioTooltip, Qt::QueuedConnection);
-    connect(m_titleBar, &TitleBar::multiFlexClicked, this, [this] {
-        MultiFlexDialog dlg(&m_radioModel, this);
-        dlg.exec();
-    });
+    connect(m_titleBar, &TitleBar::multiFlexClicked,
+            this, &MainWindow::showMultiFlexDialog);
     connect(m_titleBar, &TitleBar::minimalModeRequested, this, [this]() {
         toggleMinimalMode(!m_minimalMode);
         if (m_minimalModeAction) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -317,8 +317,11 @@ private:
     void showAx25HfPacketDecodeDialog();
     QJsonObject buildControlDevicesSnapshot() const;
     void showPropDashboard();
+    void showMultiFlexDialog();
+    void handleMultiFlexClientDisconnect(quint32 handle, const QString& displayName);
     bool confirmClientSlotAvailability(const RadioInfo& info, QList<quint32>* disconnectHandles);
     bool confirmClientSlotAvailability(const WanRadioInfo& info, QList<quint32>* disconnectHandles);
+    bool sendWanRadioClientDisconnects(const QString& serial, const QList<quint32>& handles);
     void disconnectWanRadioClients(const WanRadioInfo& info);
     void startWanRadioConnect(const WanRadioInfo& info, bool promptForClientSlots = true);
     void requestWanReconnect();

--- a/src/gui/MultiFlexDialog.cpp
+++ b/src/gui/MultiFlexDialog.cpp
@@ -124,6 +124,17 @@ void MultiFlexDialog::refresh()
     const auto& infoMap = m_model->clientInfoMap();
     const quint32 ourHandle = m_model->ourClientHandle();
 
+    // Drop pending-disconnect entries whose handle has actually left the
+    // client list — the radio has confirmed the eviction, so a fresh
+    // future appearance (impossible today but defensive) gets a normal
+    // button again.
+    for (auto it = m_pendingDisconnects.begin(); it != m_pendingDisconnects.end(); ) {
+        if (!infoMap.contains(*it))
+            it = m_pendingDisconnects.erase(it);
+        else
+            ++it;
+    }
+
     // Build local TX info override from our own slices (ClientInfo may not
     // have TX data if slice status arrived before client connected status)
     QString ourTxAnt;
@@ -211,14 +222,18 @@ void MultiFlexDialog::refresh()
         actionItem->setData(Qt::UserRole, handle);
         m_table->setItem(row, 4, actionItem);
         if (!isUs) {
-            auto* disconnectBtn = new QPushButton("Disconnect", m_table);
+            const bool pending = m_pendingDisconnects.contains(handle);
+            auto* disconnectBtn = new QPushButton(
+                pending ? "Disconnecting" : "Disconnect", m_table);
             disconnectBtn->setObjectName("disconnectClientButton");
             disconnectBtn->setCursor(Qt::PointingHandCursor);
             disconnectBtn->setFixedWidth(kDisconnectButtonWidth);
+            disconnectBtn->setEnabled(!pending);
             connect(disconnectBtn, &QPushButton::clicked,
                     this, [this, disconnectBtn, handle, displayName]() {
                 disconnectBtn->setEnabled(false);
                 disconnectBtn->setText("Disconnecting");
+                m_pendingDisconnects.insert(handle);
                 emit disconnectClientRequested(handle, displayName);
             });
             m_table->setCellWidget(row, 4, disconnectBtn);

--- a/src/gui/MultiFlexDialog.cpp
+++ b/src/gui/MultiFlexDialog.cpp
@@ -5,7 +5,9 @@
 #include <QHeaderView>
 #include <QLabel>
 #include <QPushButton>
+#include <QSignalBlocker>
 #include <QTableWidget>
+#include <QTableWidgetItem>
 
 namespace AetherSDR {
 
@@ -15,18 +17,25 @@ static const char* kDialogStyle =
     "QPushButton { background: #1a2a3a; border: 1px solid #304050; "
     "  border-radius: 3px; color: #c8d8e8; padding: 6px 20px; font-weight: bold; }"
     "QPushButton:hover { background: #203040; border-color: #00b4d8; }"
+    "QPushButton#disconnectClientButton { background: #3a1a22; border-color: #7a2836; "
+    "  color: #ffd6d6; padding: 4px 12px; }"
+    "QPushButton#disconnectClientButton:hover { background: #4a202a; border-color: #d84a5f; }"
+    "QPushButton#disconnectClientButton:disabled { background: #24242e; border-color: #404050; color: #8a8a94; }"
     "QTableWidget { background: #0f0f1a; color: #c8d8e8; "
     "  gridline-color: #203040; border: 1px solid #304050; }"
     "QTableWidget::item { padding: 4px 8px; }"
     "QHeaderView::section { background: #1a2a3a; color: #8aa8c0; "
     "  border: 1px solid #203040; padding: 6px; font-weight: bold; }";
 
+constexpr int kDisconnectActionColumnWidth = 144;
+constexpr int kDisconnectButtonWidth = 128;
+
 MultiFlexDialog::MultiFlexDialog(RadioModel* model, QWidget* parent)
     : PersistentDialog("multiFLEX Dashboard", "MultiFlexDialogGeometry", parent),
       m_model(model)
 {
-    setMinimumSize(550, 280);
-    resize(600, 320);
+    setMinimumSize(680, 280);
+    resize(760, 320);
     setStyleSheet(kDialogStyle);
 
     auto* root = new QVBoxLayout(bodyWidget());
@@ -52,13 +61,16 @@ MultiFlexDialog::MultiFlexDialog(RadioModel* model, QWidget* parent)
 
     // Client table
     m_table = new QTableWidget;
-    m_table->setColumnCount(4);
-    m_table->setHorizontalHeaderLabels({"LOCAL PTT", "STATION", "TX ANT", "TX FREQ (MHz)"});
+    m_table->setColumnCount(5);
+    m_table->setHorizontalHeaderLabels({"LOCAL PTT", "STATION", "TX ANT", "TX FREQ (MHz)", ""});
     m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
     m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
     m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
     m_table->horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
+    m_table->horizontalHeader()->setSectionResizeMode(4, QHeaderView::Fixed);
+    m_table->setColumnWidth(4, kDisconnectActionColumnWidth);
     m_table->verticalHeader()->setVisible(false);
+    m_table->verticalHeader()->setDefaultSectionSize(36);
     m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
     root->addWidget(m_table);
@@ -133,6 +145,7 @@ void MultiFlexDialog::refresh()
     }
 
     // Populate table
+    m_table->clearContents();
     m_table->setRowCount(infoMap.size());
 
     bool weHavePtt = false;
@@ -162,9 +175,15 @@ void MultiFlexDialog::refresh()
         m_table->setItem(row, 0, pttItem);
 
         // STATION — program: station
-        QString displayName = info.program;
-        if (!info.station.isEmpty() && info.station != info.program)
-            displayName = info.program + ": " + info.station;
+        const QString program = info.program.trimmed();
+        const QString station = info.station.trimmed();
+        QString displayName = program;
+        if (!program.isEmpty() && !station.isEmpty() && station != program)
+            displayName = program + ": " + station;
+        else if (!station.isEmpty())
+            displayName = station;
+        if (displayName.trimmed().isEmpty())
+            displayName = QString("client 0x%1").arg(handle, 8, 16, QChar('0')).toUpper();
         auto* stationItem = new QTableWidgetItem(displayName);
         stationItem->setTextAlignment(Qt::AlignCenter);
         if (isUs)
@@ -187,6 +206,23 @@ void MultiFlexDialog::refresh()
         auto* freqItem = new QTableWidgetItem(freq);
         freqItem->setTextAlignment(Qt::AlignCenter);
         m_table->setItem(row, 3, freqItem);
+
+        auto* actionItem = new QTableWidgetItem;
+        actionItem->setData(Qt::UserRole, handle);
+        m_table->setItem(row, 4, actionItem);
+        if (!isUs) {
+            auto* disconnectBtn = new QPushButton("Disconnect", m_table);
+            disconnectBtn->setObjectName("disconnectClientButton");
+            disconnectBtn->setCursor(Qt::PointingHandCursor);
+            disconnectBtn->setFixedWidth(kDisconnectButtonWidth);
+            connect(disconnectBtn, &QPushButton::clicked,
+                    this, [this, disconnectBtn, handle, displayName]() {
+                disconnectBtn->setEnabled(false);
+                disconnectBtn->setText("Disconnecting");
+                emit disconnectClientRequested(handle, displayName);
+            });
+            m_table->setCellWidget(row, 4, disconnectBtn);
+        }
 
         ++row;
     }

--- a/src/gui/MultiFlexDialog.h
+++ b/src/gui/MultiFlexDialog.h
@@ -2,6 +2,8 @@
 
 #include "PersistentDialog.h"
 
+#include <QString>
+
 class QTableWidget;
 class QPushButton;
 class QLabel;
@@ -14,6 +16,9 @@ class MultiFlexDialog : public PersistentDialog {
     Q_OBJECT
 public:
     explicit MultiFlexDialog(RadioModel* model, QWidget* parent = nullptr);
+
+signals:
+    void disconnectClientRequested(quint32 handle, const QString& displayName);
 
 private:
     void refresh();

--- a/src/gui/MultiFlexDialog.h
+++ b/src/gui/MultiFlexDialog.h
@@ -2,6 +2,7 @@
 
 #include "PersistentDialog.h"
 
+#include <QSet>
 #include <QString>
 
 class QTableWidget;
@@ -29,6 +30,12 @@ private:
     QLabel* m_pttLabel;
     QPushButton* m_pttBtn;
     bool m_refreshing{false};
+    // Handles the user has clicked Disconnect for but the radio has not
+    // yet evicted from the client list.  Keeps the row's button in the
+    // disabled "Disconnecting" state across refresh() rebuilds so a
+    // second click can't queue a duplicate disconnect for a handle
+    // already on its way out.
+    QSet<quint32> m_pendingDisconnects;
 };
 
 } // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -905,6 +905,15 @@ void RadioModel::setPendingClientDisconnects(const QList<quint32>& handles)
     }
 }
 
+bool RadioModel::disconnectClient(quint32 handle)
+{
+    if (handle == 0 || handle == clientHandle())
+        return false;
+
+    disconnectClientHandlesThen({handle});
+    return true;
+}
+
 void RadioModel::setKnownGuiClients(const QStringList& handles,
                                     const QStringList& programs,
                                     const QStringList& stations,
@@ -1663,26 +1672,38 @@ void RadioModel::onConnected()
 
 void RadioModel::disconnectPendingClientsThen(std::function<void()> continuation)
 {
+    const QList<quint32> handles = m_pendingClientDisconnects;
+    m_pendingClientDisconnects.clear();
+    disconnectClientHandlesThen(handles, std::move(continuation));
+}
+
+void RadioModel::disconnectClientHandlesThen(const QList<quint32>& requestedHandles,
+                                             std::function<void()> continuation)
+{
     QList<quint32> handles;
     const quint32 ours = clientHandle();
-    for (quint32 handle : m_pendingClientDisconnects) {
+    for (quint32 handle : requestedHandles) {
         if (handle != 0 && handle != ours && !handles.contains(handle))
             handles.append(handle);
     }
-    m_pendingClientDisconnects.clear();
-
     if (handles.isEmpty()) {
-        continuation();
+        if (continuation)
+            continuation();
         return;
     }
 
     auto remaining = std::make_shared<QList<quint32>>(handles);
+    auto completion = std::make_shared<std::function<void()>>(std::move(continuation));
     auto step = std::make_shared<std::function<void()>>();
-    *step = [this, remaining, continuation, step]() mutable {
+    *step = [this, remaining, completion, step]() mutable {
         if (remaining->isEmpty()) {
-            QTimer::singleShot(250, this, [continuation]() mutable {
-                continuation();
-            });
+            if (*completion) {
+                QTimer::singleShot(250, this, [completion]() mutable {
+                    auto continuation = std::move(*completion);
+                    if (continuation)
+                        continuation();
+                });
+            }
             return;
         }
 
@@ -1768,18 +1789,14 @@ void RadioModel::resolveMultiFlexConflict(quint32 handle)
     auto continuation = std::move(m_multiFlexContinuation);
     m_multiFlexContinuation = nullptr;
 
-    const QString cmd = QString("client disconnect 0x%1").arg(handle, 0, 16);
     qCDebug(lcProtocol) << "RadioModel: resolving multiFLEX conflict, disconnecting" << Qt::hex << handle;
-    sendCmd(cmd, [this, continuation = std::move(continuation)](int code, const QString& body) mutable {
-        if (code != 0)
-            qCWarning(lcProtocol) << "RadioModel: conflict client disconnect failed:" << body.trimmed();
+    disconnectClientHandlesThen({handle}, [this, continuation = std::move(continuation)]() mutable {
         // After eviction, re-run the full peek rather than jumping straight to the
         // continuation. This catches any remaining clients (e.g., two sessions, or
         // a stale handle that hadn't been cleaned up yet) and re-shows the dialog if
         // needed, preventing phantom slices from a partially-disconnected session.
-        QTimer::singleShot(250, this, [this, continuation = std::move(continuation)]() mutable {
+        if (continuation)
             peekForMultiFlexConflictThen(std::move(continuation));
-        });
     });
 }
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -298,6 +298,7 @@ public:
     void connectToRadio(const RadioInfo& info);
     void connectViaWan(WanConnection* wan, const QString& publicIp, quint16 udpPort);
     void setPendingClientDisconnects(const QList<quint32>& handles);
+    bool disconnectClient(quint32 handle);
     // Called by MainWindow in response to multiFlexConflictDetected().
     // Disconnects handle and resumes the connection sequence.
     void resolveMultiFlexConflict(quint32 handle);
@@ -526,6 +527,8 @@ private:
                                   const QString& source,
                                   const QString& station,
                                   const QString& program);
+    void disconnectClientHandlesThen(const QList<quint32>& handles,
+                                     std::function<void()> continuation = {});
 
     // Route command to active connection (LAN or WAN)
     using ResponseCallback = RadioConnection::ResponseCallback;


### PR DESCRIPTION

<img width="806" height="366" alt="image" src="https://github.com/user-attachments/assets/55e4fa0b-bf99-43c4-baf3-5cf7321c8593" />

## Summary

Adds per-client disconnect controls to the multiFLEX dashboard so the operator can gracefully disconnect other logged-in radio clients without leaving the dashboard.

## What Changed

- Added a dedicated action column to the multiFLEX station table with a `Disconnect` button for every connected client except the current AetherSDR client.
- Routed dashboard disconnect clicks through `MainWindow`, keeping connection-specific behavior out of `MultiFlexDialog`.
- Reused the existing SmartLink remote-client disconnect path by centralizing SmartLink handle dispatch in `sendWanRadioClientDisconnects()`.
- Added a shared `RadioModel::disconnectClient()` / `disconnectClientHandlesThen()` LAN command path so dashboard disconnects, pre-connect slot eviction, and multiFLEX conflict resolution all use the same `client disconnect 0x...` sequencing.
- Gave the dashboard action column and button stable widths so the full `Disconnect` label fits.

## Why

The dashboard already shows connected multiFLEX clients, but disconnecting another client required going through the network connect dialog flow. Operators need the same graceful disconnect capability directly beside each non-current logged-in radio, and it needs to work consistently whether the active connection is local LAN or SmartLink.

## Behavior

- LAN connections send the normal radio `client disconnect` command for the selected handle.
- SmartLink connections send the existing `application disconnect_users serial=... handle=...` request through `SmartLinkClient`, matching the network connect dialog's remote-client disconnect behavior.
- The current client never gets a disconnect button and is ignored defensively if requested.
- The UI disables the clicked button and changes its label while the disconnect request is being sent.

## Validation

- `git diff --check`
- `cmake --build build -j22`
- Built app deployed to the remote test Mac Desktop with `$deploy-aethersdr-test-build`, including quarantine xattr clearing.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
