### PR TITLE
fix(audio): suppress mic capture while TCI client feeds TX audio

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -3963,6 +3963,17 @@ void AudioEngine::stopTxStream()
 
 void AudioEngine::onTxAudioReady()
 {
+    // If a TCI client is actively feeding TX audio (binary frames via
+    // TciServer → feedDaxTxAudio), step the local mic capture aside.
+    // Both producers emit txPacketReady; the higher-rate mic stream would
+    // otherwise drown out the TCI tone — particularly visible on macOS,
+    // where the default CoreAudio input is a real webcam mic that
+    // produces continuous ambient packets. The 200 ms window comfortably
+    // covers the 50 ms TCI frame cadence.
+    if (m_tciAudioTimer.isValid()
+        && m_tciAudioTimer.elapsed() < kTciAudioActiveWindowMs) {
+        return;
+    }
 #ifdef Q_OS_MAC
     if (!m_micBuffer || !m_audioSource) return;
     if (m_audioSource->state() == QAudio::StoppedState) return;
@@ -4462,6 +4473,11 @@ void AudioEngine::setDaxTxUseRadioRoute(bool on)
 void AudioEngine::feedDaxTxAudio(const QByteArray& inPcm)
 {
     if (m_txStreamId == 0 || inPcm.isEmpty()) return;
+
+    // Mark TCI as the active TX-audio source. While this timer is fresh,
+    // onTxAudioReady() suppresses the local mic capture path so the two
+    // packet producers don't collide on the same UDP path to the radio.
+    m_tciAudioTimer.start();
 
     // Client-side TX DSP (compressor + EQ) is intentionally NOT
     // applied here.  This path is fed exclusively by TCI and DAX

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -822,6 +822,15 @@ private:
     QElapsedTimer m_lastAudioFeedTime;
     static constexpr qint64 kAudioLivenessTimeoutMs = 15000;
 
+    // TCI client active-audio gate: started on every feedDaxTxAudio() frame
+    // so onTxAudioReady() can step the local mic capture aside while a TCI
+    // client is feeding TX audio. Otherwise both paths emit txPacketReady
+    // concurrently and the higher-rate mic stream drowns out the TCI tone
+    // — most visible on macOS, where the default CoreAudio input is a real
+    // webcam mic that produces continuous ambient packets.
+    QElapsedTimer m_tciAudioTimer;
+    static constexpr qint64 kTciAudioActiveWindowMs = 200;
+
     // Stale session watchdog: detects when audio data is being written but
     // processedUSecs() hasn't advanced, indicating the WASAPI session is
     // silently discarding audio (e.g. after Teams/Zoom reconfigures the


### PR DESCRIPTION
## Problem

When a slice's `mic_selection=PC` AND a TCI client (TCI Monitor, WSJT-X, JTDX) is sending binary TX audio, two packet producers compete for the same UDP path to the radio:

- `AudioEngine::onTxAudioReady` — local mic capture via `QAudioSource` → emits `txPacketReady`
- `AudioEngine::feedDaxTxAudio` — TCI binary audio → emits `txPacketReady`

If the host's default audio input is a real microphone producing samples (the common case on macOS where CoreAudio defaults to a webcam mic), the mic-derived packets (~5 ms cadence) drown out the TCI tone (~50 ms cadence).

## End-to-end symptom

A TCI client's calibration sweep keys the radio, `tx_sensors` flows back — **but ALC stays pinned at the host mic's noise floor regardless of `tx_gain`, and forward power stays at ~0 W.**

Caught while building a TX-drive calibration panel against AetherSDR on macOS:

- **Mic permission denied** (terminal-launched AE, no TCC grant): no audio at all reached the modulator → clean `-150 dBFS` across the whole sweep.
- **Mic permission granted** (normal launch): ALC pinned at `~-38 dBFS` — exactly the level of room ambient picked up by the webcam mic. Coughing produced fwd-power spikes that confirmed mic-derived packets were reaching the modulator while TCI packets were being lost in the stream.

Linux escapes this only by accident — on hosts with no usable default audio input, `QAudioSource` produces silence so there's no competition.

## Fix

`feedDaxTxAudio` stamps a `QElapsedTimer` on every frame. In `onTxAudioReady`, if that timer is fresh (< 200 ms, comfortably wider than the 50 ms TCI cadence), early-return so the mic samples are dropped while TCI audio is flowing. No platform branch — correct on every host.

When the TCI client stops sending audio (timer goes stale), the mic-capture path resumes normally.

## Verified

- **macOS** (Mac mini Apple Silicon, Qt 6.11): mic suppression eliminates the false TCI baseline; calibration sweep then produces a clean monotonic ALC-vs-`tx_gain` curve into a Flex 6300.
- **Linux** (Ubuntu 24.04, Qt 6.4.2): no behavior change (no real mic samples to suppress on the test rig).
- **Windows** (Qt 6.10.3): builds clean; equivalent behavior expected (same code path, no platform branches).

## Notes

Draft for now — opened so it doesn't disappear into a personal fork branch. Happy to ready-for-review once reviewers want a look. The TX-drive calibration tool that surfaced this is a separate standalone (TCI Monitor — github.com/nigelfenton/tci-monitor) and is **not** being proposed for inclusion in AetherSDR.