### PR TITLE
chore(about): surface git short SHA under version in About dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -784,6 +784,27 @@ qt_add_resources(RESOURCES resources/resources.qrc)
 
 add_executable(AetherSDR ${ALL_SOURCES} ${RNNOISE_SOURCES} ${GGMORSE_SOURCES} ${RADE_SOURCES} ${BNR_SOURCES} ${SPECBLEACH_SOURCES} ${RESOURCES})
 
+# Capture the git short SHA at configure time and surface it in the About
+# dialog so dev/test builds are identifiable.  Falls back to "unknown" for
+# source-tarball builds where .git is absent.
+find_package(Git QUIET)
+set(AETHER_GIT_SHA "unknown")
+if(Git_FOUND)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE _aether_git_sha_out
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _aether_git_sha_rv
+    )
+    if(_aether_git_sha_rv EQUAL 0 AND NOT "${_aether_git_sha_out}" STREQUAL "")
+        set(AETHER_GIT_SHA "${_aether_git_sha_out}")
+    endif()
+endif()
+target_compile_definitions(AetherSDR PRIVATE AETHER_GIT_SHA="${AETHER_GIT_SHA}")
+message(STATUS "Build SHA: ${AETHER_GIT_SHA}")
+
 # Windows: GUI app (no console window) + icon resource
 if(WIN32)
     set_target_properties(AetherSDR PROPERTIES WIN32_EXECUTABLE TRUE)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7941,10 +7941,17 @@ void MainWindow::buildMenuBar()
         vbox->addWidget(iconLbl);
 
         // Header
+        // The git SHA captured at CMake configure time identifies the build —
+        // useful when bug-reporting against a dev/test build that doesn't
+        // correspond to a tagged release.  See CMakeLists.txt for the capture.
+#ifndef AETHER_GIT_SHA
+#define AETHER_GIT_SHA "unknown"
+#endif
         auto* header = new QLabel(QString(
             "<div style='text-align:center;'>"
             "<h2 style='margin-bottom:2px; color:#c8d8e8;'>AetherSDR</h2>"
-            "<p style='margin-top:0; color:#8aa8c0;'>v%1</p>"
+            "<p style='margin-top:0; color:#8aa8c0;'>v%1<br>"
+            "<span style='font-size:10px; color:#6a8090;'>(%4)</span></p>"
             "<p style='color:#c8d8e8;'>Linux-native SmartSDR-compatible client<br>"
             "for FlexRadio transceivers.</p>"
             "<p style='font-size:11px; color:#6a8090;'>"
@@ -7952,7 +7959,8 @@ void MainWindow::buildMenuBar()
             "Compiled: %3</p>"
             "</div>")
             .arg(QCoreApplication::applicationVersion(), qVersion(),
-                 QStringLiteral(__DATE__)));
+                 QStringLiteral(__DATE__),
+                 QStringLiteral(AETHER_GIT_SHA)));
         header->setAlignment(Qt::AlignCenter);
         header->setWordWrap(true);
         vbox->addWidget(header);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7952,7 +7952,7 @@ void MainWindow::buildMenuBar()
             "<h2 style='margin-bottom:2px; color:#c8d8e8;'>AetherSDR</h2>"
             "<p style='margin-top:0; color:#8aa8c0;'>v%1<br>"
             "<span style='font-size:10px; color:#6a8090;'>(%4)</span></p>"
-            "<p style='color:#c8d8e8;'>Linux-native SmartSDR-compatible client<br>"
+            "<p style='margin-top:8px; color:#c8d8e8;'>Linux-native SmartSDR-compatible client<br>"
             "for FlexRadio transceivers.</p>"
             "<p style='font-size:11px; color:#6a8090;'>"
             "Built with Qt %2 &middot; C++20<br>"


### PR DESCRIPTION
Captures the git short SHA at CMake configure time via execute_process
and surfaces it under the version string in the About dialog.  Useful
when bug-reporting against a dev/test build that doesn't correspond to
a tagged release — operators can quote both \`v26.5.2.1\` AND the build
SHA so triagers know exactly which commit they're looking at.

Layout (in the About dialog):

  AetherSDR
  v26.5.2.1
  (4f1b3993)        ← new, small + dim
  Linux-native ...

Implementation notes:

- CMakeLists.txt uses \`find_package(Git QUIET)\` + \`execute_process\` to
  capture \`git rev-parse --short HEAD\`.  Falls back to \"unknown\" for
  source-tarball builds where .git is absent or git is unavailable.
  Status line at configure time prints \"Build SHA: <sha>\" so the
  capture is visible during CMake setup.
- \`target_compile_definitions(AetherSDR PRIVATE AETHER_GIT_SHA=\"<sha>\")\`
  exposes the value to C++ as a string literal.
- About dialog includes a \`#ifndef AETHER_GIT_SHA\` guard so the file
  still builds if anyone compiles outside CMake (defaults to "unknown").

Limitations:

- SHA is captured at CMake configure time, not at build time.  A dev
  build run after a new commit without re-configuring CMake will show
  the previous SHA.  Solution: \`cmake --fresh\` or delete CMakeCache.txt
  when a fresh SHA matters.  Acceptable tradeoff for the simplicity of
  this approach vs. add_custom_command-based regeneration on every build.
- No \"-dirty\" marker for uncommitted working-tree changes.  Could be
  added later via \`git status --porcelain\` if useful.

Verified locally: \`cmake -B build\` prints \`Build SHA: 4f1b3993\`
(matches origin/main HEAD); built binary contains the updated About
dialog HTML template with the new (%4) format slot.

Principle I.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
