### PR TITLE
[codex] Left-align RX controls slice tabs

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1287,8 +1287,9 @@ void RxApplet::setMaxSlices(int maxSlices)
         // no-op if already here; otherwise it reparents from m_headerRow.
         layout->addWidget(m_muteAllBtn);
         targetLayout = layout;
-        // Button is now the last item; insert slice buttons before it.
-        insertIdx = layout->count() - 1;
+        // Insert slice buttons before the stretch so receiver letters stay
+        // left-aligned and the mute-all speaker stays right-aligned.
+        insertIdx = 0;
         m_sliceTabRow->setVisible(true);
         m_muteAllBtn->show();
     }


### PR DESCRIPTION
## Summary
- Keep the RX Controls slice receiver buttons left-aligned in the overflow slice-tab row.
- Leave the mute-all speaker button right-aligned by inserting slice buttons before the row stretch.

## Root cause
The overflow slice-tab row had a stretch at the left edge, then inserted slice buttons after it and before the mute-all speaker button. That pushed the receiver letters right next to the speaker icon.

## Validation
- `git diff --check`
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build -j8`
- `git -c gpg.ssh.allowedSignersFile=/private/tmp/aethersdr_allowed_signers log --show-signature -1 --format=fuller`
