### PR TITLE
[meters] Gate ALC gauge to active radio transmit

### DIFF
--- a/docs/architecture/flex-meter-learnings.md
+++ b/docs/architecture/flex-meter-learnings.md
@@ -24,6 +24,13 @@ Related implementation context lives in [`tx-audio-signal-path.md`](tx-audio-sig
   is not, by itself, the SmartSDR compression display value.
 - The AetherSDR P/CW compression gauge is reversed: `0 dB` means no visible
   compression and `-25 dB` means full-scale/heavy compression.
+- `met_in_rx=1` means the radio is allowed to publish TX-chain/mic metering
+  during receive. It does not mean RF is keyed, and neither do `slice tx=1` or
+  TX stream `tx=1`; those identify the selected TX slice or stream direction.
+- UI meters that represent active TX-chain output, including compression and
+  software ALC, should be gated by the raw radio interlock state
+  `TRANSMITTING` (`RadioModel::isRadioTransmitting()`), not by slice `tx=1`,
+  `met_in_rx`, stream presence, or local optimistic MOX intent.
 
 ## Compression Formulas
 
@@ -106,6 +113,39 @@ indexes were last-match-wins, so a multi-slice 6600 session could bind to the
 highest-numbered slice's `SC_MIC` / `COMPPEAK` pair while the VITA meter stream
 was publishing values for a different active TX slice.
 
+## ALC vs. HWALC and RX Gating
+
+Flex exposes at least two ALC-looking concepts:
+
+- `HWALC` is the external Hardware ALC RCA voltage. It is useful telemetry for
+  diagnostics, but it is normally zero unless the radio has an external HWALC
+  connection. It should not drive the operator-facing ALC gauge.
+- `ALC` is the post-software-ALC SSB peak in the TX chain. This is the meter
+  users expect to see on the Phone/CW ALC gauges.
+
+The important display rule is that `ALC` is still a TX-chain meter. On captured
+FLEX-8000 sessions, with `met_in_rx=1` and PC mic streaming active while the
+operator was not transmitting, the radio defined and updated TX-chain meters in
+RX. Some of those quiescent values can sit near `0 dBFS`; if the UI blindly
+maps them into the `-20..0 dBFS` ALC range, the gauge pins full red while the
+radio is receiving.
+
+AetherSDR therefore initializes and resets the P/CW ALC gauges to the empty
+floor (`-20 dBFS`) and only displays `TX-/ALC` samples while the radio
+interlock reports actual RF transmit (`state=TRANSMITTING`). This is the same
+class of guard as the compression gauge: TX-chain samples may exist in RX, but
+they are not an active TX warning until the radio is keyed.
+
+Do not use these as an ALC display gate:
+
+- `slice ... tx=1`: selected TX slice, not PTT.
+- `stream ... type=dax_tx ... tx=1`: TX-direction stream, not PTT.
+- `stream create type=remote_audio_tx`: mic stream setup for PC audio,
+  VOX, and `met_in_rx`, not PTT.
+- `met_in_rx=1`: request for TX-chain metering during receive, not PTT.
+- local optimistic `TransmitModel::isTransmitting()` alone: useful for edge
+  alignment, but it can be true before RF is confirmed.
+
 ## Diagnostic Logging
 
 Enable `Meters` in Help > Support to capture compression diagnostics. The log
@@ -122,8 +162,8 @@ reason.
 |---|---:|---:|---|
 | `MICPEAK` | 40 | 40 | Codec hardware mic peak |
 | `MIC` | 20 | 20 | Codec hardware mic average |
-| `HWALC` | 20 | 20 | External Hardware ALC RCA voltage — zero without an external HWALC connection.  Used by SliceTroubleshootingDialog telemetry only; do **not** drive UI ALC gauges from this meter. |
-| `ALC` | 20 | 20 | Post-software-ALC SSB peak (dBFS).  This is the meter that drives the in-app ALC gauges (mirrored across Phone and CW panels). |
+| `HWALC` | 20 | 20 | External Hardware ALC RCA voltage — zero without an external HWALC connection. Used by SliceTroubleshootingDialog telemetry only; do **not** drive UI ALC gauges from this meter. |
+| `ALC` | 20 | 20 | Post-software-ALC SSB peak (dBFS). This is the meter that drives the in-app ALC gauges, but only while the radio interlock reports `TRANSMITTING`. |
 | `FWDPWR` | 20 | 20 | Forward RF power |
 | `REFPWR` | 20 | 20 | Reflected RF power |
 | `SWR` | 20 | 20 | RF SWR |
@@ -134,7 +174,7 @@ reason.
 | `AFTEREQ` | 20 | Not present | 8000 compression reference |
 | `COMPPEAK` | 20 | 20 | Processor/clipper-stage tap |
 | `SC_FILT_1` | 20 | 10 | Post TX filter 1 |
-| `ALC` | 10 | 10 | SW ALC / SSB peak |
+| `ALC` | 10 | 10 | SW ALC / SSB peak. Observed FPS varies by manifest; match by source/name and keep the UI gated on actual radio TX. |
 | `RM_TX_AGC` | 10 | Not seen | Present in 8000 captures |
 | `PRE_WAVE_AGC` | Not seen | 10 | Present in 6600 manifest |
 | `SC_FILT_2` | 10 | 10 | Post TX filter 2 |

--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -70,6 +70,15 @@ public:
         }
     }
 
+    void setValueImmediate(float v) {
+        if (m_animTimer.isActive()) m_animTimer.stop();
+        m_value = v;
+        m_smooth.setTarget(
+            qBound(0.0f, (v - m_min) / (m_max - m_min), 1.0f));
+        m_smooth.snapToTarget();
+        update();
+    }
+
     void setPeakValue(float v) {
         if (qFuzzyCompare(m_peakValue, v)) return;
         m_peakValue = v;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2601,6 +2601,7 @@ MainWindow::MainWindow(QWidget* parent)
         m_appletPanel->sMeterWidget()->setTransmitting(tx);
         if (!tx) {
             m_appletPanel->phoneCwApplet()->updateCompression(0.0f);
+            m_appletPanel->phoneCwApplet()->updateAlc(-20.0f);
         }
         if (tx) {
             m_txIndicator->setStyleSheet(
@@ -3898,7 +3899,12 @@ MainWindow::MainWindow(QWidget* parent)
         });
     }
     connect(&m_radioModel.meterModel(), &MeterModel::swAlcChanged,
-            m_appletPanel->phoneCwApplet(), &PhoneCwApplet::updateAlc);
+            this, [this](float alc) {
+        // FLEX-8000 TX-chain meters can publish quiescent RX values near 0 dBFS.
+        // Only show SW ALC while the radio interlock says RF is actually keyed.
+        m_appletPanel->phoneCwApplet()->updateAlc(
+            m_radioModel.isRadioTransmitting() ? alc : -20.0f);
+    });
     // Client-side PC mic metering — radio CODEC meters only see hardware mics.
     // Apply VU-style ballistics: fast attack, slow decay (~20 dB/sec).
     {

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -99,6 +99,8 @@ static constexpr const char* kInsetEditStyle =
     "border-radius: 3px; padding: 1px 2px; color: #c8d8e8; }"
     "QLineEdit:focus { border: 1px solid #00b4d8; }";
 
+static constexpr float kAlcGaugeFloorDbfs = -20.0f;
+
 
 // ── PhoneCwApplet ────────────────────────────────────────────────────────────
 
@@ -152,9 +154,10 @@ void PhoneCwApplet::buildPhonePanel()
     // Mirrored in m_cwPanel; both gauges read from MeterModel::swAlcChanged
     // so SSB operators watching mic gain see the same indicator CW
     // operators use to verify clean keying envelope shape.
-    m_alcGaugePhone = new HGauge(-20.0f, 0.0f, -3.0f, "ALC", "dBFS",
+    m_alcGaugePhone = new HGauge(kAlcGaugeFloorDbfs, 0.0f, -3.0f, "ALC", "dBFS",
         {{-20, "-20"}, {-15, "-15"}, {-10, "-10"}, {-5, "-5"}, {0, "0"}});
     m_alcGaugePhone->setFillFromRight(true);  // empty at -20, fills leftward toward 0
+    m_alcGaugePhone->setValueImmediate(kAlcGaugeFloorDbfs);
     m_alcGaugePhone->setAccessibleName("ALC gauge (Phone)");
     m_alcGaugePhone->setAccessibleDescription("Automatic level control — post-software-ALC SSB peak (dBFS)");
     vbox->addWidget(m_alcGaugePhone);
@@ -373,9 +376,10 @@ void PhoneCwApplet::buildCwPanel()
     // Mirrors the Phone-panel ALC gauge — both read from the same
     // MeterModel::swAlcChanged source.  Range covers normal operating
     // window (-20…0 dBFS); excessive ALC pins at 0.
-    m_alcGaugeCw = new HGauge(-20.0f, 0.0f, -3.0f, "ALC", "dBFS",
+    m_alcGaugeCw = new HGauge(kAlcGaugeFloorDbfs, 0.0f, -3.0f, "ALC", "dBFS",
         {{-20, "-20"}, {-15, "-15"}, {-10, "-10"}, {-5, "-5"}, {0, "0"}});
     m_alcGaugeCw->setFillFromRight(true);  // empty at -20, fills leftward toward 0
+    m_alcGaugeCw->setValueImmediate(kAlcGaugeFloorDbfs);
     m_alcGaugeCw->setAccessibleName("ALC gauge (CW)");
     m_alcGaugeCw->setAccessibleDescription("Automatic level control — post-software-ALC SSB peak (dBFS)");
     vbox->addWidget(m_alcGaugeCw);


### PR DESCRIPTION
## Summary

This PR fixes the Phone/CW ALC gauge appearing fully red while the operator is receiving.

The ALC gauge is driven from the radio's software ALC TX-chain meter, which is the correct meter for operator-facing ALC. The bug was that AetherSDR accepted that meter unconditionally. On FLEX-8000 sessions with `met_in_rx=1`, the radio can publish TX-chain meter samples during receive, and quiescent RX-time `TX-/ALC` values may sit near `0 dBFS`. Because the gauge range is `-20..0 dBFS`, those RX-time samples pin the ALC bar full red even though RF transmit is not active.

## Changes

- Add `HGauge::setValueImmediate()` so horizontal gauges can be initialized/reset to a known value without animating from the default `0` target.
- Initialize both Phone and CW ALC gauges at the empty floor (`-20 dBFS`) instead of the implicit `0 dBFS` full-scale value.
- Gate software ALC display on the raw radio interlock transmit state via `RadioModel::isRadioTransmitting()`.
- Clear the ALC gauge back to `-20 dBFS` when raw radio TX ends, even if no later ALC packet arrives.
- Update `docs/architecture/flex-meter-learnings.md` with the `ALC` vs `HWALC` distinction and the new RX-gating rule.

## Root Cause

`TX-/ALC` is the right operator-facing ALC meter, but it is still a TX-chain meter. With `met_in_rx=1`, TX-chain metering can exist during RX. The UI treated those samples as active transmit-state ALC and also let the gauge default to `0 dBFS`, so the visual started and remained at the full red end of the range.

This PR intentionally does not gate on `slice tx=1`, TX stream `tx=1`, remote-audio TX stream presence, or local optimistic MOX intent. Those indicate selected TX slice, stream direction, stream setup, or local edge intent. The display gate is the raw radio interlock state `TRANSMITTING`.

## Validation

- `env -u CPLUS_INCLUDE_PATH cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `env -u CPLUS_INCLUDE_PATH cmake --build build --parallel 22`
- `ctest --test-dir build --output-on-failure -j22` passed: 18/18
- Deployed the resulting macOS app bundle to `patj@mac.jensencloud.net:/Users/patj/Desktop/AetherSDR.app` and cleared quarantine for live testing.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
