### PR TITLE
fix(audio): default client TX final limiter to off so AetherSDR matches SmartSDR drive level

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -3149,8 +3149,16 @@ void AudioEngine::loadClientFinalLimiterSettings()
 {
     if (!m_clientFinalLimiterTx) return;
     auto& s = AppSettings::instance();
+    // Default OFF: SmartSDR has no client-side brickwall limiter, so a fresh
+    // install with the limiter on at a -1 dBFS ceiling produces noticeably
+    // less forward power than SmartSDR for the same mic level (radio's SW ALC
+    // sees ~1 dB less peak to set its working point off of).  The limiter is
+    // still available for users who want headroom protection when running
+    // hot Comp/Tube/PUDU/Reverb settings — they can flip LIM on in the
+    // Aetherial Final Output Stage panel.  Existing users whose setting was
+    // already persisted keep their previous behavior.
     m_clientFinalLimiterTx->setEnabled(
-        s.value("ClientFinalLimiterTxEnabled", "True").toString() == "True");
+        s.value("ClientFinalLimiterTxEnabled", "False").toString() == "True");
     m_clientFinalLimiterTx->setCeilingDb(
         s.value("ClientFinalLimiterTxCeilingDb", "-1.0").toFloat());
     m_clientFinalLimiterTx->setOutputTrimDb(


### PR DESCRIPTION
The ClientFinalLimiter at the tail of the PC mic voice TX chain has
been enabled-by-default with a -1.0 dBFS ceiling. SmartSDR has no
equivalent client-side brickwall — it sends mic audio essentially raw
and lets the radio's SW ALC set the working point off the natural
voice peaks.

The mismatch shows up as 'less forward power from AetherSDR than from
SmartSDR' on user reports: peaks above -1 dBFS get pulled down before
the radio sees them, the radio's SC_MIC (#26) reads ~1 dB lower than
SmartSDR's, SW ALC works off a lower reference, and average drive
falls accordingly.

Default the limiter to off so a fresh install matches SmartSDR's
drive level. Users who want headroom protection — most relevant when
running hot Comp/Tube/PUDU/Reverb on the AetherialAudio chain — can
still flip LIM on in the Aetherial Final Output Stage panel at the
bottom of the channel strip. Existing users whose setting was already
persisted keep their previous behavior unchanged (AppSettings::value
returns the persisted value, not the new default).

DAX/TCI and RADE TX paths were already bypassing the limiter, so
digital-mode drive is unaffected by this change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
