### PR TITLE
[meters] Use direct COMPPEAK readings for the compression meter

### DIFF
--- a/docs/architecture/flex-meter-learnings.md
+++ b/docs/architecture/flex-meter-learnings.md
@@ -1,8 +1,8 @@
 # FlexRadio Meter Learnings
 
 This document captures the working conclusions from AetherSDR compression
-meter debugging across FLEX-8000 series radios and a FLEX-6600. It is meant to
-record capture-backed behavior, not API guesses.
+meter debugging across FLEX-6000 and FLEX-8000 family radios. It records the
+behavior we are matching, and the parts we intentionally are not deriving.
 
 Related implementation context lives in [`tx-audio-signal-path.md`](tx-audio-signal-path.md).
 
@@ -10,20 +10,19 @@ Related implementation context lives in [`tx-audio-signal-path.md`](tx-audio-sig
 
 - Match meters by `source` and `name`, not by numeric ID. Flex meter IDs are
   assigned per session and differ by platform.
+- Use the active-slice TX `COMPPEAK` meter directly for compression across
+  model families. Do not derive compression from `AFTEREQ`, `SC_MIC`, `CODEC`,
+  local PC mic audio, or any other fallback source.
 - Compression TX-chain meters are repeated per active slice on multi-slice
-  radios. Track `COMPPEAK`, `AFTEREQ`, and `SC_MIC` by active slice. Some
-  radios expose distinct TX waveform `sourceIndex` values, while 8000-series
-  captures can repeat `TX- num=0` blocks after each `SLC` slice block.
-- Do not synthesize compression when required radio meters are unavailable. A
-  missing compression input should make the compression meter unavailable, not
-  approximate a value from local mic audio.
-- This work preserves the existing Phone/CW gauge presentation. Availability is
-  tracked in `MeterModel`; the UI still receives `0 dB` when no valid
-  compression pair is available, rather than adding new N/A rendering.
-- `COMPPEAK` is a dBFS signal-level tap near the speech processor/clipper. It
-  is not, by itself, the SmartSDR compression display value.
-- The AetherSDR P/CW compression gauge is reversed: `0 dB` means no visible
-  compression and `-25 dB` means full-scale/heavy compression.
+  radios. AetherSDR resolves `COMPPEAK` by active TX slice before accepting a
+  sample.
+- `MeterModel` stores compression as a positive radio-provided amount:
+  `0 dB` means none, `25 dB` means full-scale/heavy compression.
+- The Phone/CW compression gauge and the TX S-meter compression face are
+  visually reversed: they display the stored `0..25 dB` amount as `0..-25 dB`.
+- Compression visibility is a UI/radio-state decision, not a meter derivation.
+  The P/CW compression gauge is fed with `0 dB` unless the radio is
+  transmitting and the speech processor is enabled.
 - `met_in_rx=1` means the radio is allowed to publish TX-chain/mic metering
   during receive. It does not mean RF is keyed, and neither do `slice tx=1` or
   TX stream `tx=1`; those identify the selected TX slice or stream direction.
@@ -32,86 +31,53 @@ Related implementation context lives in [`tx-audio-signal-path.md`](tx-audio-sig
   `TRANSMITTING` (`RadioModel::isRadioTransmitting()`), not by slice `tx=1`,
   `met_in_rx`, stream presence, or local optimistic MOX intent.
 
-## Compression Formulas
+## Direct COMPPEAK Model
 
-### FLEX-8000 Series
-
-The 8000-series model validated against SmartSDR uses `AFTEREQ` and
-`COMPPEAK`:
-
-```text
-compression_lift_db = max(0, COMPPEAK - AFTEREQ)
-display_db = -clamp(compression_lift_db, 0, 25)
-```
-
-`AFTEREQ` is the processor input reference after the TX equalizer. `COMPPEAK`
-is the processor/clipper-stage tap. Both meters advertise `20 fps`, so the two
-inputs are naturally well matched for a derived compression display.
-
-If either meter is missing, AetherSDR should not show a derived compression
-value.
-
-### FLEX-6600 / 6000-Series Evidence
-
-The captured FLEX-6600 manifest does not expose `AFTEREQ`. The relevant TX
-meters observed were:
-
-- `CODEC` as TX meter `21`
-- `SC_MIC` as TX meter `22`
-- `COMPPEAK` as TX meter `23`
-
-The strongest candidate formula is:
+AetherSDR treats the active-slice `COMPPEAK` sample as the compression value
+supplied by the radio. Adjacent TX audio meters are still valuable for
+diagnostics, but they are not compression inputs.
 
 ```text
-compression_lift_db = max(0, COMPPEAK - SC_MIC)
-display_db = -clamp(compression_lift_db, 0, 25)
+compression_db = clamp(COMPPEAK, 0, 25)
+pcw_gauge_db = -compression_db
 ```
 
-Why this is the current model:
+Earlier derivation attempts paired `COMPPEAK` with adjacent TX audio meters and
+then mapped the result into the reversed `0..-25 dB` gauge range. That masked
+strong rows where `COMPPEAK` moved positive, because a positive sample was
+effectively displayed as no compression. The current model keeps the radio
+sample positive in `MeterModel` and reverses only at the visible gauge.
 
-- Raw `COMPPEAK` does not behave like the SmartSDR compression display. In
-  strong RF-output rows it often goes positive and would clamp to `0 dB`, just
-  when compression should be visible.
-- The opposite direction, `SC_MIC - COMPPEAK`, was effectively dead in the
-  user captures and stayed at `0 dB`.
-- `CODEC` is a plausible alternate reference, but in the 6600 captures it was
-  consistently about 3 dB lower than `SC_MIC`, which would make
-  `COMPPEAK - CODEC` read slightly heavier. `SC_MIC` is the better named
-  pre-processor mic-chain reference.
-
-The remaining engineering caution is timing. On the 6600, `SC_MIC` advertises
-`10 fps` while `COMPPEAK` advertises `20 fps`. AetherSDR guards the derived
-6600 compression value by requiring the reference sample and `COMPPEAK` sample
-to be close in time before marking the compression meter available.
+If no active-slice `COMPPEAK` meter exists, or if the active `COMPPEAK` meter
+has not produced data, `MeterModel` marks compression unavailable and keeps the
+value at `0 dB`. It does not synthesize a value from local audio activity.
 
 ## Multi-Slice Meter Resolution
 
-FLEX radios can repeat the TX waveform meter block once per active slice. In a
-captured FLEX-6600 four-slice manifest, `SC_MIC` / `COMPPEAK` appeared as
-`22/23`, `44/45`, `66/67`, and `88/89`. Those numeric IDs are not stable API
+FLEX radios can expose one TX waveform meter block per active slice. In a
+captured FLEX-6600 four-slice manifest, `COMPPEAK` appeared in repeated TX
+blocks such as `23`, `45`, `67`, and `89`. Those numeric IDs are not stable API
 contracts; they are manifest slots for that session.
 
-AetherSDR stores compression meter IDs by explicit TX waveform `sourceIndex`
-when the manifest provides one. In 8000-series captures where repeated TX
+AetherSDR stores `COMPPEAK` meter IDs by explicit TX waveform `sourceIndex`
+when the manifest provides one. In 8000-style captures where repeated TX
 blocks all report `num=0`, AetherSDR keys those block-local meters to the most
-recent `SLC` slice context from the manifest. The formula remains
-family-specific by available meter name: use active-slice `AFTEREQ` when
-present, otherwise active-slice `SC_MIC`, paired with active-slice `COMPPEAK`.
+recent `SLC` slice context from the manifest. Runtime updates then resolve the
+active TX slice to the correct manifest meter ID.
 
 The implementation intentionally derives a slice/source key and then looks up
-the manifest IDs for that key. It does not calculate the final meter IDs
-directly.
+the manifest ID for that key. It does not calculate final meter IDs directly.
 
-| Radio family / manifest shape | Slice/source resolution | Reference meter | Compression meter | Gauge formula |
+| Radio family / manifest shape | Slice/source resolution | Compression meter | Model value | UI gauge value |
 |---|---|---|---|---|
-| FLEX-6600 / 6000-style explicit TX source | `txBase = min(TX sourceIndex >= 8) - min(SLC sourceIndex)`, then `activeTxSource = txBase + activeTxSlice` | `SC_MIC` at `activeTxSource` | `COMPPEAK` at `activeTxSource` | `-clamp(max(0, COMPPEAK - SC_MIC), 0, 25)` |
-| FLEX-8000-style explicit TX source | Same explicit TX-source lookup when the manifest provides per-slice TX source indices | `AFTEREQ` at `activeTxSource` | `COMPPEAK` at `activeTxSource` | `-clamp(max(0, COMPPEAK - AFTEREQ), 0, 25)` |
-| FLEX-8000-style repeated `TX- num=0` blocks | Use the most recent `SLC` source index as manifest context, then resolve by `activeTxSlice` at runtime | `AFTEREQ` mapped to `activeTxSlice` | `COMPPEAK` mapped to `activeTxSlice` | `-clamp(max(0, COMPPEAK - AFTEREQ), 0, 25)` |
+| FLEX-6000-style explicit TX source | `txBase = min(TX sourceIndex >= 8) - min(SLC sourceIndex)`, then `activeTxSource = txBase + activeTxSlice` | `COMPPEAK` at `activeTxSource` | `clamp(COMPPEAK, 0, 25)` | `-modelValue` |
+| FLEX-8000-style explicit TX source | Same explicit TX-source lookup when the manifest provides per-slice TX source indices | `COMPPEAK` at `activeTxSource` | `clamp(COMPPEAK, 0, 25)` | `-modelValue` |
+| FLEX-8000-style repeated `TX- num=0` blocks | Use the most recent `SLC` source index as manifest context, then resolve by `activeTxSlice` at runtime | `COMPPEAK` mapped to `activeTxSlice` | `clamp(COMPPEAK, 0, 25)` | `-modelValue` |
 
-Issue #2040 describes the 6600 failure mode this avoids: the old scalar
-indexes were last-match-wins, so a multi-slice 6600 session could bind to the
-highest-numbered slice's `SC_MIC` / `COMPPEAK` pair while the VITA meter stream
-was publishing values for a different active TX slice.
+Issue #2040 describes the 6600 failure mode this avoids: the old scalar meter
+index approach was last-match-wins, so a multi-slice session could bind to the
+highest-numbered slice's compression meter while the VITA meter stream was
+publishing values for a different active TX slice.
 
 ## ALC vs. HWALC and RX Gating
 
@@ -149,12 +115,14 @@ Do not use these as an ALC display gate:
 ## Diagnostic Logging
 
 Enable `Meters` in Help > Support to capture compression diagnostics. The log
-emits a `compression meter map` row for each discovered `COMPPEAK`, `AFTEREQ`,
-or `SC_MIC` meter, then throttles live `compression summary` rows to twice per
-second unless the state changes. The summary includes active TX slice,
-waveform `sourceIndex`, selected reference meter, reference and `COMPPEAK`
-values, sample skew, computed lift, displayed gauge value, and availability
-reason.
+emits a `compression meter map` row for each discovered `COMPPEAK` meter, then
+throttles live `compression summary` rows to twice per second unless the state
+changes. The summary includes active TX slice, resolved TX waveform
+`sourceIndex`, whether the implicit slice map was used, `COMPPEAK` meter ID,
+the raw converted `COMPPEAK` sample, displayed model value, and availability.
+
+`AFTEREQ` and `SC_MIC` are no longer logged as compression map participants
+because they do not drive the compression display.
 
 ## Meter FPS Comparison
 
@@ -170,9 +138,9 @@ reason.
 | `PATEMP` | 0 | 0 | PA temperature |
 | `CODEC` | 10 | 10 | TX codec/mic-chain level |
 | `TXAGC` | 10 | Not seen | Present in 8000 captures |
-| `SC_MIC` | 10 | 10 | TX mic-chain tap; 6600 compression reference when `AFTEREQ` is absent |
-| `AFTEREQ` | 20 | Not present | 8000 compression reference |
-| `COMPPEAK` | 20 | 20 | Processor/clipper-stage tap |
+| `SC_MIC` | 10 | 10 | TX mic-chain tap; diagnostic/level-path context, not a compression fallback |
+| `AFTEREQ` | 20 | Not present | Post-EQ tap; diagnostic context, not a compression input |
+| `COMPPEAK` | 20 | 20 | Radio-provided compression value used by AetherSDR |
 | `SC_FILT_1` | 20 | 10 | Post TX filter 1 |
 | `ALC` | 10 | 10 | SW ALC / SSB peak. Observed FPS varies by manifest; match by source/name and keep the UI gated on actual radio TX. |
 | `RM_TX_AGC` | 10 | Not seen | Present in 8000 captures |
@@ -187,15 +155,13 @@ reason.
 
 ## P/CW Level Meter
 
-The P/CW level meter is intentionally separate from the compression derivation.
-The FPS-testing experiment that drove voice/CW level strictly from `SC_MIC` was
+The P/CW level meter is intentionally separate from compression. The
+FPS-testing experiment that drove voice/CW level strictly from `SC_MIC` was
 backed out. Current behavior keeps the existing UI path: hardware mic meters
-for hardware inputs, and client-side PC metering for PC audio. The Phone/CW
-level gauge and `HGauge`/`MeterSmoother` dampening are not changed by the
-compression work.
+for hardware inputs, and client-side PC metering for PC audio.
 
-`SC_MIC` is used as a 6000-series compression reference only when `AFTEREQ` is
-not present. It is not used as a strict replacement for the P/CW level meter.
+Changing compression to direct `COMPPEAK` does not alter the Phone/CW level
+gauge, `HGauge`, `SMeterWidget`, or `MeterSmoother` level dampening behavior.
 
 ### Level Meter During Receive
 
@@ -228,8 +194,3 @@ compression gauge.
 The current implementation does not add special UI behavior for two-tone tune;
 this note records why future work should be careful not to derive compression
 from local mic activity during radio-generated test tones.
-
-## Open Questions
-
-- Confirm the 6600 scale against SmartSDR with a capture that includes the
-  visible SmartSDR Comp reading at the same time as `SC_MIC` and `COMPPEAK`.

--- a/docs/architecture/tx-audio-signal-path.md
+++ b/docs/architecture/tx-audio-signal-path.md
@@ -118,7 +118,7 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 ┌─────────────────────────────┐
 │  Equalizer (8-band)         │  ◄── "eq txsc" command
 │  AFTEREQ (meter 27)         │  ◄── "Signal strength after the EQ"
-│  src=TX-, fps=20            │      Compression reference tap
+│  src=TX-, fps=20            │      Post-EQ diagnostic tap
 └─────────┬───────────────────┘
           │
           ▼
@@ -126,7 +126,7 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 │  Speech Processor           │  ◄── "transmit set speech_processor_enable/level"
 │  (Compander + Clipper)      │
 │  COMPPEAK (meter 28)        │  ◄── "Signal strength before CLIPPER (Compression)"
-│  src=TX-, fps=20            │      Paired with AFTEREQ for compression gauge
+│  src=TX-, fps=20            │      Compression gauge input
 └─────────┬───────────────────┘
           │
           ▼
@@ -218,9 +218,9 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
 | 11 | TX- | PATEMP | degC | 0 | PA temperature | Status bar |
 | 24 | TX- | CODEC | dBFS | 10 | CODEC output (post mic gain) | — |
 | 25 | TX- | TXAGC | dBFS | 10 | Post AGC/fixed gain | — |
-| 26 | TX- | SC_MIC | dBFS | 10 | MIC output (PC audio entry point) | P/CW mic gauge (PC mic); 6000-series compression reference |
-| 27 | TX- | AFTEREQ | dBFS | 20 | Post equalizer / processor input reference | 8000-series compression derivation |
-| 28 | TX- | COMPPEAK | dBFS | 20 | Processor/clipper-stage level tap | P/CW compression derivation |
+| 26 | TX- | SC_MIC | dBFS | 10 | MIC output (PC audio entry point) | P/CW mic gauge (PC mic); diagnostics |
+| 27 | TX- | AFTEREQ | dBFS | 20 | Post equalizer / processor input tap | Diagnostics |
+| 28 | TX- | COMPPEAK | dB | 20 | Radio-provided compression amount | P/CW compression gauge |
 | 29 | TX- | SC_FILT_1 | dBFS | 20 | Post TX filter 1 | — |
 | 30 | TX- | ALC | dBFS | 10 | Post SW ALC (SSB peak) | P/CW ALC indicator |
 | 31 | TX- | RM_TX_AGC | dBFS | 10 | Post remote TX AGC | — |
@@ -247,21 +247,21 @@ PC Mic Audio (Opus via remote_audio_tx) — arrives with client-side
   active slice. AetherSDR resolves compression meters through the active TX
   slice. FLEX-6600 captures expose distinct TX waveform `sourceIndex` values,
   while FLEX-8000 captures can repeat `TX- num=0` blocks after each `SLC`
-  slice block. In both cases `COMPPEAK` is paired with the matching `AFTEREQ`
-  or `SC_MIC` from the same slice. The code derives the active TX source or
-  implicit slice context first, then looks up the manifest IDs for that slice;
+  slice block. In both cases the active slice selects the matching `COMPPEAK`
+  meter directly. The code derives the active TX source or implicit slice
+  context first, then looks up the manifest ID for that slice;
   it never assumes fixed IDs like `22/23`.
-- **Compression meter input**: AetherSDR derives the compression gauge from
-  radio-provided TX meters only. FLEX-8000 series radios use
-  `max(0, COMPPEAK - AFTEREQ)`. 6000-series radios that do not expose `AFTEREQ`
-  use `max(0, COMPPEAK - SC_MIC)`. `COMPPEAK` is a dBFS level tap, not a
-  ready-to-display gain-reduction meter. If the required pair is missing or not
-  fresh enough, `MeterModel` marks the compression value unavailable and emits
-  `0 dB` to preserve the existing gauge presentation; it does not fall back to
-  local PC mic level or a raw `COMPPEAK` display.
+- **Compression meter input**: AetherSDR uses the radio-provided active-slice
+  `COMPPEAK` meter directly across model families. `MeterModel` clamps it to
+  `0..25 dB` as a radio-provided compression amount; the Phone/CW and TX
+  S-meter gauge faces display that amount as `0..-25 dB`. If active-slice
+  `COMPPEAK` is missing or has not produced data, `MeterModel` marks the
+  compression value unavailable and emits `0 dB` to preserve the existing gauge
+  presentation; it does not fall back to local PC mic level, `AFTEREQ`,
+  `SC_MIC`, or `CODEC`.
 - **P/CW level display**: The Phone/CW level meter UI and smoothing are
-  unchanged by the compression derivation. `AFTEREQ` and `SC_MIC` are used only
-  as compression reference taps.
+  unchanged by direct `COMPPEAK` compression handling. `AFTEREQ` and `SC_MIC`
+  remain TX audio-path context, not compression inputs.
 - **Unit conversion**: dBm meters (FWDPWR) need watts = 10^(dBm/10)/1000.
   SWR is raw. degC/degF use raw/64.0f. Volts/Amps use raw/1024.0f.
 

--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -10,6 +10,7 @@
 #include <QVector>
 #include <cmath>
 #include <limits>
+#include <utility>
 
 namespace AetherSDR {
 
@@ -86,7 +87,19 @@ public:
         update();
     }
 
-    void setReversed(bool rev) { m_reversed = rev; update(); }
+    void setReversed(bool rev) {
+        if (m_reversed == rev) return;
+        m_reversed = rev;
+
+        // In reversed gauges, visible fill increases as the normalized target
+        // decreases. Swap the current time constants so custom ballistics are
+        // preserved while increasing fill still uses attack and falling fill
+        // still uses release.
+        MeterSmoother::Ballistics ballistics = m_smooth.ballistics();
+        std::swap(ballistics.attackSeconds, ballistics.releaseSeconds);
+        m_smooth.setBallistics(ballistics);
+        update();
+    }
     // Anchor the fill bar to the right edge instead of the left.  Unlike
     // setReversed (which also inverts the value mapping for compression-
     // style gauges), this just mirrors the fill direction — min still

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -834,10 +834,10 @@ void PhoneCwApplet::applyLevelMeterReceiveGate()
 
 void PhoneCwApplet::updateCompression(float compPeak)
 {
-    // compPeak is the MeterModel-derived compression display dB.
-    // Silence/no compression -> 0. Reduction -> clamp to the -25..0 gauge range.
-    float gauge = (compPeak > -30.0f) ? qBound(-25.0f, compPeak, 0.0f) : 0.0f;
-    m_compGauge->setValue(gauge);
+    // MeterModel exposes COMPPEAK as a positive 0..25 dB compression amount.
+    // The P/CW gauge face is reversed: 0 = none, -25 = full.
+    const float compressionDb = qBound(0.0f, compPeak, 25.0f);
+    m_compGauge->setValue(-compressionDb);
 }
 
 void PhoneCwApplet::updateAlc(float alc)

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -96,9 +96,8 @@ void SMeterWidget::setMicMeters(float micLevel, float compLevel, float micPeak, 
     Q_UNUSED(micLevel);
     Q_UNUSED(compLevel);
     m_micLevel = micPeak;
-    // compPeak is raw dBFS from COMPPEAK. Silence gate at -30.
-    const float comp = (compPeak > -30.0f) ? qBound(-25.0f, compPeak, 0.0f) : 0.0f;
-    m_compLevel = comp;
+    // MeterModel normalizes COMPPEAK to a 0..25 dB compression amount.
+    m_compLevel = qBound(0.0f, compPeak, 25.0f);
 
     updateNeedleTarget();
 
@@ -269,8 +268,8 @@ float SMeterWidget::txValueToFraction(float value) const
         // -40 to +5
         return qBound(0.0f, (value + 40.0f) / 45.0f, 1.0f);
     case TxMode::Compression:
-        // Gain reduction: 0 = none, -25 = heavy compression
-        return qBound(0.0f, (value + 25.0f) / 25.0f, 1.0f);
+        // Compression: 0 = none, 25 = heavy compression
+        return qBound(0.0f, value / 25.0f, 1.0f);
     }
     return 0.0f;
 }
@@ -500,9 +499,9 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         break;
     }
     case TxMode::Compression: {
-        // -25 to 0, ticks at -25, -20, -15, -10, -5, 0.  All default color.
-        for (int db : {-25, -20, -15, -10, -5, 0}) {
-            const float frac = (db + 25.0f) / 25.0f;
+        // Visible face is 0 to -25 dB, while the stored value is 0..25.
+        for (int db : {0, -5, -10, -15, -20, -25}) {
+            const float frac = -db / 25.0f;
             drawInsideTick(frac, QString::number(db), blueColor, whiteColor, true);
         }
         break;
@@ -609,7 +608,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         case TxMode::Power:       valText = QString("%1 W").arg(m_txPower, 0, 'f', 0); break;
         case TxMode::SWR:         valText = QString("%1").arg(m_txSwr, 0, 'f', 1); break;
         case TxMode::Level:       valText = QString("%1 dB").arg(m_micLevel, 0, 'f', 0); break;
-        case TxMode::Compression: valText = QString("%1 dB").arg(m_compLevel, 0, 'f', 0); break;
+        case TxMode::Compression: valText = QString("%1 dB").arg(-m_compLevel, 0, 'f', 0); break;
         }
         p.setPen(QColor(0xc8, 0xd8, 0xe8));
         p.drawText(w - vfm.horizontalAdvance(valText) - 6, topY, valText);

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -10,19 +10,15 @@ namespace AetherSDR {
 
 namespace {
 
-constexpr qint64 kCompressionReferenceMaxSkewMs = 250;
 constexpr qint64 kCompressionSummaryLogIntervalMs = 500;
 constexpr int kMinTxWaveformSourceIndex = 8;
 
-float compressionReductionForGauge(float referenceDbfs, float compPeakDbfs)
+float compressionValueForGauge(float compPeakDb)
 {
-    // COMPPEAK is a dBFS level tap at the speech processor/clipper stage.
-    // SmartSDR-style compression tracks the lift from the model-specific
-    // processor reference tap to COMPPEAK.
-    // The gauge is reversed and uses negative values internally:
-    //   0 = none, -25 = heavy.
-    const float reduction = qMax(0.0f, compPeakDbfs - referenceDbfs);
-    return -qBound(0.0f, reduction, 25.0f);
+    // The radio reports COMPPEAK directly as the compression amount.
+    // Keep the model value positive (0 = none, 25 = heavy) and let widgets
+    // adapt it to their visible meter face.
+    return qBound(0.0f, compPeakDb, 25.0f);
 }
 
 QJsonObject meterToJson(const MeterDef& def, bool hasValue, float value)
@@ -105,18 +101,6 @@ void MeterModel::defineMeter(const MeterDef& def)
         else
             m_compPeakIdxBySlice[implicitTxWaveformSliceIndex()] = def.index;
     }
-    else if (isTxWaveformMeter(def) && def.name == "AFTEREQ") {
-        if (hasExplicitTxWaveformSourceIndex(def))
-            m_afterEqIdxByTxSource[def.sourceIndex] = def.index;
-        else
-            m_afterEqIdxBySlice[implicitTxWaveformSliceIndex()] = def.index;
-    }
-    else if (isTxWaveformMeter(def) && def.name == "SC_MIC") {
-        if (hasExplicitTxWaveformSourceIndex(def))
-            m_scMicIdxByTxSource[def.sourceIndex] = def.index;
-        else
-            m_scMicIdxBySlice[implicitTxWaveformSliceIndex()] = def.index;
-    }
     else if (def.name == "MIC")
         m_micLevelIdx = def.index;
     else if (def.name == "COMP")
@@ -154,8 +138,7 @@ void MeterModel::defineMeter(const MeterDef& def)
     qCDebug(lcMeters) << "MeterModel: defined meter" << def.index
              << def.source << def.sourceIndex << def.name
              << def.unit << "[" << def.low << "->" << def.high << "]";
-    if (isTxWaveformMeter(def)
-        && (def.name == "COMPPEAK" || def.name == "AFTEREQ" || def.name == "SC_MIC")) {
+    if (isTxWaveformMeter(def) && def.name == "COMPPEAK") {
         logCompressionMeterMap(def);
     }
 }
@@ -191,38 +174,6 @@ void MeterModel::removeMeter(int index)
             ++it;
         }
     }
-    for (auto it = m_afterEqIdxByTxSource.begin(); it != m_afterEqIdxByTxSource.end(); ) {
-        if (it.value() == index) {
-            it = m_afterEqIdxByTxSource.erase(it);
-            compressionMapChanged = true;
-        } else {
-            ++it;
-        }
-    }
-    for (auto it = m_afterEqIdxBySlice.begin(); it != m_afterEqIdxBySlice.end(); ) {
-        if (it.value() == index) {
-            it = m_afterEqIdxBySlice.erase(it);
-            compressionMapChanged = true;
-        } else {
-            ++it;
-        }
-    }
-    for (auto it = m_scMicIdxByTxSource.begin(); it != m_scMicIdxByTxSource.end(); ) {
-        if (it.value() == index) {
-            it = m_scMicIdxByTxSource.erase(it);
-            compressionMapChanged = true;
-        } else {
-            ++it;
-        }
-    }
-    for (auto it = m_scMicIdxBySlice.begin(); it != m_scMicIdxBySlice.end(); ) {
-        if (it.value() == index) {
-            it = m_scMicIdxBySlice.erase(it);
-            compressionMapChanged = true;
-        } else {
-            ++it;
-        }
-    }
     if (index == m_fwdPwrIdx)   m_fwdPwrIdx = -1;
     if (index == m_swrIdx)      m_swrIdx = -1;
     if (index == m_micPeakIdx)   m_micPeakIdx = -1;
@@ -249,7 +200,7 @@ void MeterModel::removeMeter(int index)
     recomputeSourceIndexMins();
     if (compressionMapChanged) {
         clearCompressionState();
-        updateCompressionReduction();
+        logCompressionSummary("meter-removed", true);
     }
 }
 
@@ -274,11 +225,7 @@ void MeterModel::clear()
     m_sLevelIdxBySlice.clear();
     m_escLevelIdxBySlice.clear();
     m_compPeakIdxByTxSource.clear();
-    m_afterEqIdxByTxSource.clear();
-    m_scMicIdxByTxSource.clear();
     m_compPeakIdxBySlice.clear();
-    m_afterEqIdxBySlice.clear();
-    m_scMicIdxBySlice.clear();
     m_minSliceSourceIndex = -1;
     m_minTxWaveformSourceIndex = -1;
     m_manifestSliceContext = -1;
@@ -337,14 +284,8 @@ void MeterModel::clearCompressionState()
 {
     m_compPeak = 0.0f;
     m_hasCompPeakValue = false;
-    m_afterEqLevel = -150.0f;
-    m_scMicLevel = -150.0f;
-    m_compPeakLevel = -150.0f;
-    m_hasAfterEqLevel = false;
-    m_hasScMicLevel = false;
+    m_compPeakLevel = 0.0f;
     m_hasCompPeakLevel = false;
-    m_afterEqUpdatedMs = 0;
-    m_scMicUpdatedMs = 0;
     m_compPeakUpdatedMs = 0;
     m_lastCompressionSummaryLogMs = 0;
     m_lastCompressionSummaryReason.clear();
@@ -413,94 +354,6 @@ int MeterModel::compPeakIndexForActiveTxSlice() const
     return m_compPeakIdxBySlice.value(m_activeTxSlice, -1);
 }
 
-int MeterModel::afterEqIndexForActiveTxSlice() const
-{
-    const int txSource = activeTxWaveformSourceIndex();
-    if (txSource >= 0 && m_afterEqIdxByTxSource.contains(txSource))
-        return m_afterEqIdxByTxSource.value(txSource);
-    return m_afterEqIdxBySlice.value(m_activeTxSlice, -1);
-}
-
-int MeterModel::scMicIndexForActiveTxSlice() const
-{
-    const int txSource = activeTxWaveformSourceIndex();
-    if (txSource >= 0 && m_scMicIdxByTxSource.contains(txSource))
-        return m_scMicIdxByTxSource.value(txSource);
-    return m_scMicIdxBySlice.value(m_activeTxSlice, -1);
-}
-
-void MeterModel::updateCompressionReduction()
-{
-    if (!m_hasCompPeakLevel) {
-        m_compPeak = 0.0f;
-        m_hasCompPeakValue = false;
-        logCompressionSummary("missing-comppeak");
-        return;
-    }
-
-    float referenceLevel = 0.0f;
-    qint64 referenceUpdatedMs = 0;
-
-    // Flex meter manifests differ by radio family:
-    // - FLEX-8000 series exposes TX/AFTEREQ at 20 fps. Captures against
-    //   SmartSDR show this is the post-EQ processor input reference, so the
-    //   compression display is the lift from AFTEREQ to TX/COMPPEAK.
-    // - FLEX-6600 captures do not expose AFTEREQ. The best matching reference
-    //   is TX/SC_MIC at 10 fps, with TX/COMPPEAK still at 20 fps. That mixed
-    //   cadence can compare a fresh COMPPEAK against a stale SC_MIC sample, so
-    //   compressionSamplesFresh() gates the derived 6000-series value. If an
-    //   8000-style AFTEREQ exists, prefer it over SC_MIC.
-    const int afterEqIdx = afterEqIndexForActiveTxSlice();
-    const int scMicIdx = scMicIndexForActiveTxSlice();
-
-    if (afterEqIdx >= 0) {
-        if (!m_hasAfterEqLevel) {
-            m_compPeak = 0.0f;
-            m_hasCompPeakValue = false;
-            logCompressionSummary("missing-aftereq");
-            return;
-        }
-        referenceLevel = m_afterEqLevel;
-        referenceUpdatedMs = m_afterEqUpdatedMs;
-    } else if (scMicIdx >= 0) {
-        if (!m_hasScMicLevel) {
-            m_compPeak = 0.0f;
-            m_hasCompPeakValue = false;
-            logCompressionSummary("missing-scmic");
-            return;
-        }
-        referenceLevel = m_scMicLevel;
-        referenceUpdatedMs = m_scMicUpdatedMs;
-    } else {
-        m_compPeak = 0.0f;
-        m_hasCompPeakValue = false;
-        logCompressionSummary("missing-reference");
-        return;
-    }
-
-    if (!compressionSamplesFresh(referenceUpdatedMs)) {
-        m_compPeak = 0.0f;
-        m_hasCompPeakValue = false;
-        logCompressionSummary("stale-reference");
-        return;
-    }
-
-    m_compPeak = compressionReductionForGauge(referenceLevel, m_compPeakLevel);
-    m_hasCompPeakValue = true;
-    logCompressionSummary("ok");
-}
-
-bool MeterModel::compressionSamplesFresh(qint64 referenceUpdatedMs) const
-{
-    if (m_compPeakUpdatedMs <= 0 || referenceUpdatedMs <= 0)
-        return false;
-
-    const qint64 skewMs = m_compPeakUpdatedMs > referenceUpdatedMs
-        ? m_compPeakUpdatedMs - referenceUpdatedMs
-        : referenceUpdatedMs - m_compPeakUpdatedMs;
-    return skewMs <= kCompressionReferenceMaxSkewMs;
-}
-
 void MeterModel::logCompressionMeterMap(const MeterDef& def) const
 {
     if (!lcMeters().isDebugEnabled())
@@ -534,29 +387,6 @@ void MeterModel::logCompressionSummary(const char* reason, bool force)
     m_lastCompressionSummaryLogMs = now;
     m_lastCompressionSummaryReason = reasonText;
 
-    const int afterEqIdx = afterEqIndexForActiveTxSlice();
-    const int scMicIdx = scMicIndexForActiveTxSlice();
-    const bool useAfterEq = afterEqIdx >= 0;
-    const bool useScMic = !useAfterEq && scMicIdx >= 0;
-    const QString referenceName = useAfterEq
-        ? QStringLiteral("AFTEREQ")
-        : (useScMic ? QStringLiteral("SC_MIC") : QStringLiteral("none"));
-    const int referenceIdx = useAfterEq ? afterEqIdx : (useScMic ? scMicIdx : -1);
-    const float referenceDbfs = useAfterEq ? m_afterEqLevel : (useScMic ? m_scMicLevel : 0.0f);
-    const bool hasReference = useAfterEq ? m_hasAfterEqLevel : (useScMic && m_hasScMicLevel);
-    const qint64 referenceUpdatedMs = useAfterEq ? m_afterEqUpdatedMs : (useScMic ? m_scMicUpdatedMs : 0);
-
-    qint64 skewMs = -1;
-    if (m_compPeakUpdatedMs > 0 && referenceUpdatedMs > 0) {
-        skewMs = m_compPeakUpdatedMs > referenceUpdatedMs
-            ? m_compPeakUpdatedMs - referenceUpdatedMs
-            : referenceUpdatedMs - m_compPeakUpdatedMs;
-    }
-
-    const float liftDb = (m_hasCompPeakLevel && hasReference)
-        ? qMax(0.0f, m_compPeakLevel - referenceDbfs)
-        : 0.0f;
-
     qCDebug(lcMeters) << "MeterModel: compression summary"
                       << "reason" << reasonText
                       << "activeSlice" << m_activeTxSlice
@@ -565,16 +395,9 @@ void MeterModel::logCompressionSummary(const char* reason, bool force)
                       << "usingImplicitSliceMap"
                       << (!m_compPeakIdxByTxSource.contains(activeTxWaveformSourceIndex())
                           && m_compPeakIdxBySlice.contains(m_activeTxSlice))
-                      << "reference" << referenceName
-                      << "referenceId" << referenceIdx
-                      << "referenceDbfs" << referenceDbfs
-                      << "hasReference" << hasReference
                       << "compPeakId" << compPeakIndexForActiveTxSlice()
-                      << "compPeakDbfs" << m_compPeakLevel
+                      << "compPeakDb" << m_compPeakLevel
                       << "hasCompPeak" << m_hasCompPeakLevel
-                      << "skewMs" << skewMs
-                      << "fresh" << compressionSamplesFresh(referenceUpdatedMs)
-                      << "liftDb" << liftDb
                       << "displayDb" << m_compPeak
                       << "available" << m_hasCompPeakValue;
 }
@@ -593,8 +416,6 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
     const int n = qMin(ids.size(), vals.size());
     const qint64 packetUpdatedMs = QDateTime::currentMSecsSinceEpoch();
     const int activeCompPeakIdx = compPeakIndexForActiveTxSlice();
-    const int activeAfterEqIdx = afterEqIndexForActiveTxSlice();
-    const int activeScMicIdx = scMicIndexForActiveTxSlice();
     // sLevelChanged is emitted per-slice inline in the loop below
     bool txChanged = false;
     bool fwdInstantChanged = false;
@@ -661,25 +482,12 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
             m_micPeak = v;
             micChanged = true;
         } else if (idx == activeCompPeakIdx) {
-            // COMPPEAK is a dBFS level tap. Pair it with AFTEREQ on 8000
-            // series radios, or SC_MIC on 6000-series radios that do not
-            // expose AFTEREQ.
             m_compPeakLevel = v;
             m_hasCompPeakLevel = true;
             m_compPeakUpdatedMs = packetUpdatedMs;
-            updateCompressionReduction();
-            micChanged = true;
-        } else if (idx == activeAfterEqIdx) {
-            m_afterEqLevel = v;
-            m_hasAfterEqLevel = true;
-            m_afterEqUpdatedMs = packetUpdatedMs;
-            updateCompressionReduction();
-            micChanged = true;
-        } else if (idx == activeScMicIdx) {
-            m_scMicLevel = v;
-            m_hasScMicLevel = true;
-            m_scMicUpdatedMs = packetUpdatedMs;
-            updateCompressionReduction();
+            m_compPeak = compressionValueForGauge(v);
+            m_hasCompPeakValue = true;
+            logCompressionSummary("ok");
             micChanged = true;
         } else if (idx == m_micLevelIdx) {
             m_micLevel = v;

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -50,8 +50,8 @@ public:
     // Clear all meter definitions and cached values on disconnect/reconnect.
     void clear();
 
-    // Track which radio slice currently owns TX. Compression TX-chain meters
-    // are repeated per slice, so MeterModel must resolve COMPPEAK/reference
+    // Track which radio slice currently owns TX. Compression TX-chain
+    // COMPPEAK meters are repeated per slice, so MeterModel must resolve
     // indexes against this slice instead of using last-match-wins globals.
     void setActiveTxSlice(int sliceIndex);
 
@@ -92,7 +92,7 @@ public:
     qint64 tgxlSwrUpdatedAtMs() const { return m_lastTgxlSwrUpdateMs; }
     bool hasRecentTxMeters(qint64 maxAgeMs) const;
 
-    // Convenience: mic peak level (dBFS) and derived compression reduction (dB).
+    // Convenience: mic peak level (dBFS) and radio-provided compression (dB).
     float micPeak()  const { return m_micPeak; }
     float compPeak() const { return m_compPeak; }
     bool hasCompressionMeterValue() const { return m_hasCompPeakValue; }
@@ -165,10 +165,6 @@ private:
     int txWaveformBase() const;
     int activeTxWaveformSourceIndex() const;
     int compPeakIndexForActiveTxSlice() const;
-    int afterEqIndexForActiveTxSlice() const;
-    int scMicIndexForActiveTxSlice() const;
-    void updateCompressionReduction();
-    bool compressionSamplesFresh(qint64 referenceUpdatedMs) const;
     void logCompressionMeterMap(const MeterDef& def) const;
     void logCompressionSummary(const char* reason, bool force = false);
 
@@ -179,11 +175,7 @@ private:
     QMap<int, int> m_sLevelIdxBySlice;  // sliceIndex → meter index for "SLC"/"LEVEL"
     QMap<int, int> m_escLevelIdxBySlice; // sliceIndex → meter index for "SLC"/"ESC"
     QMap<int, int> m_compPeakIdxByTxSource; // TX waveform sourceIndex → "COMPPEAK"
-    QMap<int, int> m_afterEqIdxByTxSource;  // TX waveform sourceIndex → "AFTEREQ"
-    QMap<int, int> m_scMicIdxByTxSource;    // TX waveform sourceIndex → "SC_MIC"
     QMap<int, int> m_compPeakIdxBySlice;    // active slice → "COMPPEAK" for TX blocks with num=0
-    QMap<int, int> m_afterEqIdxBySlice;     // active slice → "AFTEREQ" for TX blocks with num=0
-    QMap<int, int> m_scMicIdxBySlice;       // active slice → "SC_MIC" for TX blocks with num=0
     int m_minSliceSourceIndex{-1};
     int m_minTxWaveformSourceIndex{-1};
     int m_manifestSliceContext{-1};
@@ -217,16 +209,10 @@ private:
     qint64 m_lastFwdPowerUpdateMs{0};
     qint64 m_lastSwrUpdateMs{0};
     float m_micPeak{-50.0f};
-    float m_compPeak{0.0f};       // derived compression reduction for the reversed gauge
+    float m_compPeak{0.0f};       // radio-provided compression amount, 0..25 dB
     bool m_hasCompPeakValue{false};
-    float m_afterEqLevel{-150.0f};
-    float m_scMicLevel{-150.0f};
-    float m_compPeakLevel{-150.0f};
-    bool m_hasAfterEqLevel{false};
-    bool m_hasScMicLevel{false};
+    float m_compPeakLevel{0.0f};  // last raw converted COMPPEAK sample
     bool m_hasCompPeakLevel{false};
-    qint64 m_afterEqUpdatedMs{0};
-    qint64 m_scMicUpdatedMs{0};
     qint64 m_compPeakUpdatedMs{0};
     qint64 m_lastCompressionSummaryLogMs{0};
     QString m_lastCompressionSummaryReason;

--- a/tests/meter_model_test.cpp
+++ b/tests/meter_model_test.cpp
@@ -1,7 +1,6 @@
 #include "models/MeterModel.h"
 
 #include <QCoreApplication>
-#include <QThread>
 #include <QVector>
 
 #include <cmath>
@@ -29,7 +28,7 @@ qint16 rawDb(float db)
     return static_cast<qint16>(std::lround(db * 128.0f));
 }
 
-MeterDef txMeter(int index, const QString& name, const QString& unit = QStringLiteral("dBFS"),
+MeterDef txMeter(int index, const QString& name, const QString& unit = QStringLiteral("dB"),
                  int sourceIndex = 8)
 {
     MeterDef def;
@@ -38,8 +37,8 @@ MeterDef txMeter(int index, const QString& name, const QString& unit = QStringLi
     def.sourceIndex = sourceIndex;
     def.name = name;
     def.unit = unit;
-    def.low = -150.0;
-    def.high = 20.0;
+    def.low = 0.0;
+    def.high = 25.0;
     return def;
 }
 
@@ -56,273 +55,155 @@ MeterDef slcMeter(int index, int sliceIndex)
     return def;
 }
 
+// These tests keep active-slice routing and direct COMPPEAK coverage. They
+// intentionally do not preserve the old AFTEREQ/SC_MIC derivation cases:
+// adjacent TX audio meters are diagnostics only and must not synthesize
+// compression when COMPPEAK is absent.
 void testAdjacentMetersDoNotSynthesizeCompression()
 {
     MeterModel model;
+    model.defineMeter(slcMeter(10, 0));
     model.defineMeter(txMeter(22, "SC_MIC", "dBFS"));
+    model.defineMeter(txMeter(27, "AFTEREQ", "dBFS"));
+    model.setActiveTxSlice(0);
 
-    model.updateValues({22}, {rawDb(-10.0f)});
+    model.updateValues({22, 27}, {rawDb(-10.0f), rawDb(-12.0f)});
 
     report("adjacent TX audio meters do not synthesize compression",
            !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
 }
 
-void testCompPeakRequiresAfterEq()
+void testCompPeakDirectlyExposesCompression()
 {
     MeterModel model;
+    model.defineMeter(slcMeter(10, 0));
     model.defineMeter(txMeter(28, "COMPPEAK"));
+    model.setActiveTxSlice(0);
 
-    model.updateValues({28}, {rawDb(-40.0f)});
+    model.updateValues({28}, {rawDb(12.5f)});
 
-    report("COMPPEAK alone does not expose compression",
-           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+    report("COMPPEAK directly exposes radio compression",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 12.5f));
 }
 
-void testAfterEqRequiresCompPeak()
+void testCompPeakClampsToGaugeRange()
 {
     MeterModel model;
-    model.defineMeter(txMeter(27, "AFTEREQ"));
-
-    model.updateValues({27}, {rawDb(-60.0f)});
-
-    report("AFTEREQ alone does not expose compression",
-           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
-}
-
-void testCompPeakMinusAfterEqDrivesGauge()
-{
-    MeterModel model;
-    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(slcMeter(10, 0));
     model.defineMeter(txMeter(28, "COMPPEAK"));
+    model.setActiveTxSlice(0);
 
-    model.updateValues({27, 28}, {rawDb(-60.0f), rawDb(-40.0f)});
+    model.updateValues({28}, {rawDb(40.0f)});
+    const bool clampsHigh = model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 25.0f);
 
-    report("COMPPEAK minus AFTEREQ maps to negative gauge value",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+    model.updateValues({28}, {rawDb(-6.0f)});
+    const bool clampsLow = model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f);
+
+    report("direct COMPPEAK clamps to the compression gauge range",
+           clampsHigh && clampsLow);
 }
 
-void testCompPeakMinusScMicDrivesGaugeWhenAfterEqMissing()
-{
-    MeterModel model;
-    model.defineMeter(txMeter(22, "SC_MIC"));
-    model.defineMeter(txMeter(23, "COMPPEAK"));
-
-    model.updateValues({22, 23}, {rawDb(-42.0f), rawDb(-22.0f)});
-
-    report("COMPPEAK minus SC_MIC maps 6000-series compression",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
-}
-
-void testActiveTxSliceSelects6000CompressionPair()
+void testActiveTxSliceSelectsCompPeak()
 {
     MeterModel model;
     model.defineMeter(slcMeter(15, 0));
-    model.defineMeter(txMeter(22, "SC_MIC", "dBFS", 8));
-    model.defineMeter(txMeter(23, "COMPPEAK", "dBFS", 8));
+    model.defineMeter(txMeter(23, "COMPPEAK", "dB", 8));
     model.defineMeter(slcMeter(37, 1));
-    model.defineMeter(txMeter(44, "SC_MIC", "dBFS", 9));
-    model.defineMeter(txMeter(45, "COMPPEAK", "dBFS", 9));
+    model.defineMeter(txMeter(45, "COMPPEAK", "dB", 9));
 
     model.setActiveTxSlice(0);
-    model.updateValues({22, 23}, {rawDb(-42.0f), rawDb(-22.0f)});
-    report("active TX slice 0 uses its 6000-series compression pair",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+    model.updateValues({23}, {rawDb(12.0f)});
+    report("active TX slice 0 uses its COMPPEAK meter",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 12.0f));
 
-    model.updateValues({44, 45}, {rawDb(-80.0f), rawDb(-40.0f)});
-    report("inactive 6000-series compression pair is ignored",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+    model.updateValues({45}, {rawDb(20.0f)});
+    report("inactive COMPPEAK meter is ignored",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 12.0f));
 
     model.setActiveTxSlice(1);
     report("changing active TX slice clears stale compression",
            !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
 
-    model.updateValues({44, 45}, {rawDb(-80.0f), rawDb(-40.0f)});
-    report("active TX slice 1 uses its 6000-series compression pair",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -25.0f));
+    model.updateValues({45}, {rawDb(20.0f)});
+    report("active TX slice 1 uses its COMPPEAK meter",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 20.0f));
 }
 
-void testActiveTxSliceSelects8000CompressionPair()
-{
-    MeterModel model;
-    model.defineMeter(slcMeter(21, 0));
-    model.defineMeter(txMeter(27, "AFTEREQ", "dBFS", 8));
-    model.defineMeter(txMeter(28, "COMPPEAK", "dBFS", 8));
-    model.defineMeter(slcMeter(43, 1));
-    model.defineMeter(txMeter(49, "AFTEREQ", "dBFS", 9));
-    model.defineMeter(txMeter(50, "COMPPEAK", "dBFS", 9));
-
-    model.setActiveTxSlice(1);
-    model.updateValues({27, 28}, {rawDb(-80.0f), rawDb(-40.0f)});
-    report("inactive 8000-series compression pair is ignored",
-           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
-
-    model.updateValues({49, 50}, {rawDb(-30.0f), rawDb(-15.0f)});
-    report("active TX slice 1 uses its 8000-series compression pair",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -15.0f));
-}
-
-void testZeroSource8000MetersUseSliceContext()
+void testZeroSourceCompPeakUsesSliceContext()
 {
     MeterModel model;
     model.defineMeter(slcMeter(14, 0));
-    model.defineMeter(txMeter(19, "AFTEREQ", "dBFS", 0));
-    model.defineMeter(txMeter(20, "COMPPEAK", "dBFS", 0));
+    model.defineMeter(txMeter(20, "COMPPEAK", "dB", 0));
     model.defineMeter(slcMeter(32, 1));
-    model.defineMeter(txMeter(43, "AFTEREQ", "dBFS", 0));
-    model.defineMeter(txMeter(44, "COMPPEAK", "dBFS", 0));
+    model.defineMeter(txMeter(44, "COMPPEAK", "dB", 0));
 
     model.setActiveTxSlice(1);
-    model.updateValues({19, 20}, {rawDb(-80.0f), rawDb(-40.0f)});
-    report("inactive zero-source 8000 compression pair is ignored",
+    model.updateValues({20}, {rawDb(8.0f)});
+    report("inactive zero-source COMPPEAK meter is ignored",
            !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
 
-    model.updateValues({43, 44}, {rawDb(-30.0f), rawDb(-15.0f)});
-    report("zero-source 8000 compression pair follows active slice context",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -15.0f));
+    model.updateValues({44}, {rawDb(15.0f)});
+    report("zero-source COMPPEAK meter follows active slice context",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 15.0f));
 }
 
 void testSparseSliceIdsUseManifestDerivedWaveformBase()
 {
     MeterModel model;
     model.defineMeter(slcMeter(37, 1));
-    model.defineMeter(txMeter(44, "SC_MIC", "dBFS", 9));
-    model.defineMeter(txMeter(45, "COMPPEAK", "dBFS", 9));
+    model.defineMeter(txMeter(45, "COMPPEAK", "dB", 9));
 
     model.setActiveTxSlice(1);
-    model.updateValues({44, 45}, {rawDb(-42.0f), rawDb(-22.0f)});
+    model.updateValues({45}, {rawDb(18.0f)});
 
     report("sparse slice IDs use manifest-derived TX waveform base",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 18.0f));
 }
 
-void testScMicCompressionDerivationIsOrderIndependent()
+void testAfterEqAndScMicDoNotAffectCompression()
 {
     MeterModel model;
-    model.defineMeter(txMeter(22, "SC_MIC"));
-    model.defineMeter(txMeter(23, "COMPPEAK"));
-
-    model.updateValues({23}, {rawDb(-22.0f)});
-    model.updateValues({22}, {rawDb(-42.0f)});
-
-    report("SC_MIC compression derivation is order independent",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
-}
-
-void testAfterEqPreferredOverScMicWhenBothAreDefined()
-{
-    MeterModel model;
-    model.defineMeter(txMeter(22, "SC_MIC"));
-    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(slcMeter(10, 0));
+    model.defineMeter(txMeter(22, "SC_MIC", "dBFS"));
+    model.defineMeter(txMeter(27, "AFTEREQ", "dBFS"));
     model.defineMeter(txMeter(28, "COMPPEAK"));
+    model.setActiveTxSlice(0);
 
-    model.updateValues({22, 27, 28}, {rawDb(-80.0f), rawDb(-20.0f), rawDb(-10.0f)});
+    model.updateValues({22, 27, 28}, {rawDb(-80.0f), rawDb(-40.0f), rawDb(7.0f)});
 
-    report("AFTEREQ is preferred over SC_MIC when both are present",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -10.0f));
-}
-
-void testAfterEqDefinitionDoesNotFallbackToScMicWithoutAfterEqValue()
-{
-    MeterModel model;
-    model.defineMeter(txMeter(22, "SC_MIC"));
-    model.defineMeter(txMeter(27, "AFTEREQ"));
-    model.defineMeter(txMeter(28, "COMPPEAK"));
-
-    model.updateValues({22, 28}, {rawDb(-80.0f), rawDb(-40.0f)});
-
-    report("AFTEREQ definition requires AFTEREQ data and does not fallback",
-           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
-}
-
-void testCompPeakAndAfterEqAreOrderIndependent()
-{
-    MeterModel model;
-    model.defineMeter(txMeter(27, "AFTEREQ"));
-    model.defineMeter(txMeter(28, "COMPPEAK"));
-
-    model.updateValues({28}, {rawDb(-40.0f)});
-    model.updateValues({27}, {rawDb(-60.0f)});
-
-    report("compression derivation is order independent",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
-}
-
-void testNoStageLiftShowsNoCompression()
-{
-    MeterModel model;
-    model.defineMeter(txMeter(27, "AFTEREQ"));
-    model.defineMeter(txMeter(28, "COMPPEAK"));
-
-    model.updateValues({27, 28}, {rawDb(-30.0f), rawDb(-45.0f)});
-
-    report("COMPPEAK below AFTEREQ shows no compression",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
-}
-
-void testDerivedCompressionClampsToGaugeRange()
-{
-    MeterModel model;
-    model.defineMeter(txMeter(27, "AFTEREQ"));
-    model.defineMeter(txMeter(28, "COMPPEAK"));
-
-    model.updateValues({27, 28}, {rawDb(-80.0f), rawDb(-40.0f)});
-
-    report("derived compression clamps to the compression gauge range",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -25.0f));
-}
-
-void testStaleScMicReferenceDoesNotDriveCompression()
-{
-    MeterModel model;
-    model.defineMeter(txMeter(22, "SC_MIC"));
-    model.defineMeter(txMeter(23, "COMPPEAK"));
-
-    model.updateValues({22}, {rawDb(-42.0f)});
-    QThread::msleep(300);
-    model.updateValues({23}, {rawDb(-22.0f)});
-
-    report("stale SC_MIC reference does not drive compression",
-           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
-
-    model.updateValues({22}, {rawDb(-42.0f)});
-    report("fresh SC_MIC reference restores compression",
-           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), -20.0f));
+    report("AFTEREQ and SC_MIC do not derive or override direct COMPPEAK",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 7.0f));
 }
 
 void testRemovingCompPeakMarksCompressionUnavailable()
 {
     MeterModel model;
-    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(slcMeter(10, 0));
     model.defineMeter(txMeter(28, "COMPPEAK"));
-    model.updateValues({27, 28}, {rawDb(-60.0f), rawDb(-40.0f)});
+    model.setActiveTxSlice(0);
+
+    model.updateValues({28}, {rawDb(10.0f)});
     model.removeMeter(28);
 
     report("removing COMPPEAK marks compression unavailable",
            !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
 }
 
-void testRemovingAfterEqMarksCompressionUnavailable()
+void testRemovingAdjacentMetersDoesNotClearCompPeak()
 {
     MeterModel model;
-    model.defineMeter(txMeter(27, "AFTEREQ"));
+    model.defineMeter(slcMeter(10, 0));
+    model.defineMeter(txMeter(22, "SC_MIC", "dBFS"));
+    model.defineMeter(txMeter(27, "AFTEREQ", "dBFS"));
     model.defineMeter(txMeter(28, "COMPPEAK"));
-    model.updateValues({27, 28}, {rawDb(-60.0f), rawDb(-40.0f)});
+    model.setActiveTxSlice(0);
+
+    model.updateValues({28}, {rawDb(11.0f)});
+    model.removeMeter(22);
     model.removeMeter(27);
 
-    report("removing AFTEREQ marks compression unavailable",
-           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
-}
-
-void testRemovingScMicMarks6000CompressionUnavailable()
-{
-    MeterModel model;
-    model.defineMeter(txMeter(22, "SC_MIC"));
-    model.defineMeter(txMeter(23, "COMPPEAK"));
-    model.updateValues({22, 23}, {rawDb(-42.0f), rawDb(-22.0f)});
-    model.removeMeter(22);
-
-    report("removing SC_MIC marks 6000-series compression unavailable",
-           !model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 0.0f));
+    report("removing adjacent TX audio meters does not clear COMPPEAK",
+           model.hasCompressionMeterValue() && nearlyEqual(model.compPeak(), 11.0f));
 }
 
 } // namespace
@@ -332,24 +213,14 @@ int main(int argc, char** argv)
     QCoreApplication app(argc, argv);
 
     testAdjacentMetersDoNotSynthesizeCompression();
-    testCompPeakRequiresAfterEq();
-    testAfterEqRequiresCompPeak();
-    testCompPeakMinusAfterEqDrivesGauge();
-    testCompPeakMinusScMicDrivesGaugeWhenAfterEqMissing();
-    testActiveTxSliceSelects6000CompressionPair();
-    testActiveTxSliceSelects8000CompressionPair();
-    testZeroSource8000MetersUseSliceContext();
+    testCompPeakDirectlyExposesCompression();
+    testCompPeakClampsToGaugeRange();
+    testActiveTxSliceSelectsCompPeak();
+    testZeroSourceCompPeakUsesSliceContext();
     testSparseSliceIdsUseManifestDerivedWaveformBase();
-    testScMicCompressionDerivationIsOrderIndependent();
-    testAfterEqPreferredOverScMicWhenBothAreDefined();
-    testAfterEqDefinitionDoesNotFallbackToScMicWithoutAfterEqValue();
-    testCompPeakAndAfterEqAreOrderIndependent();
-    testNoStageLiftShowsNoCompression();
-    testDerivedCompressionClampsToGaugeRange();
-    testStaleScMicReferenceDoesNotDriveCompression();
+    testAfterEqAndScMicDoNotAffectCompression();
     testRemovingCompPeakMarksCompressionUnavailable();
-    testRemovingAfterEqMarksCompressionUnavailable();
-    testRemovingScMicMarks6000CompressionUnavailable();
+    testRemovingAdjacentMetersDoesNotClearCompPeak();
 
     return g_failed == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

This updates the compression meter path to use the radio-provided active-slice `COMPPEAK` meter directly across model families.

Key changes:
- Resolve `COMPPEAK` per active TX slice, including explicit TX source indices and repeated `TX- num=0` meter blocks.
- Remove `AFTEREQ` / `SC_MIC` compression derivation and any adjacent-meter fallback behavior.
- Keep `MeterModel` compression as a positive `0..25 dB` amount, then adapt the visible Phone/CW and TX S-meter faces to the existing `0..-25 dB` presentation.
- Preserve the existing visible gate: the Phone/CW compression meter is shown only during radio TX with PROC enabled.
- Fix reversed `HGauge` ballistics so compression onset uses fast attack and compression release uses slower decay.
- Refresh compression meter docs and tests around direct `COMPPEAK`, active-slice routing, and no synthetic compression from adjacent TX audio meters.

## Details

`MeterModel` now caches and accepts only active-slice `COMPPEAK` for compression. The model clamps the value to the meter range and emits availability only after the selected `COMPPEAK` meter has produced data.

The prior derivation path could mask strong positive `COMPPEAK` samples by mapping them through the visible reversed range too early. The updated model keeps the radio-provided compression amount positive internally and reverses only at the visible gauge surface.

The Phone/CW applet and TX S-meter now consume the positive model value and handle the visible reversed scale locally. This keeps the model representation simple while preserving the existing meter face.

The reversed gauge smoothing bug was fixed in `HGauge`: reversed meters now swap their current attack/release time constants so increasing visible fill moves quickly and falling fill decays more slowly without resetting custom ballistics to defaults.

## Review Follow-Up

- Rebased onto current `upstream/main`; GitHub now reports the PR as mergeable.
- Resolved the meter learnings doc conflict by preserving the direct `COMPPEAK` model plus the ALC RX-gating and level-meter receive notes from main.
- Updated the `COMPPEAK` unit in the TX audio signal path table to `dB` compression amount.
- Added a meter-model test note explaining why adjacent-meter derivation coverage was intentionally removed.

## Testing

- `env -u CPLUS_INCLUDE_PATH cmake --build build --parallel 22`
- `ctest --test-dir build --output-on-failure -j22`
- `./build/meter_model_test`
- Deploy skill upload completed, but replacing `/Users/patj/Desktop/AetherSDR.app` was blocked by macOS with `Operation not permitted` on the existing bundle.
- Deployed the built app to `/Users/patj/Downloads/AetherSDR-pr3005-0f8a932.app` on the test Mac and cleared quarantine.
- Manual validation from the earlier test build: compression meter shows live data and tracks TX across multiple slices.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
