### PR TITLE
[ux] Align Radio Setup microphone controls

### DIFF
--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1466,39 +1466,39 @@ QWidget* RadioSetupDialog::buildPhoneCwTab()
     {
         auto* group = new QGroupBox("Microphone");
         group->setStyleSheet(kGroupStyle);
-        auto* gvb = new QVBoxLayout(group);
-        gvb->setSpacing(4);
+        auto* grid = new QGridLayout(group);
+        grid->setHorizontalSpacing(8);
+        grid->setVerticalSpacing(6);
+        grid->setColumnStretch(2, 1);
 
-        // BIAS / +20dB row
-        auto* row1 = new QHBoxLayout;
-        row1->setSpacing(4);
+        constexpr int kMicControlButtonWidth = 104;
+        auto addMicRow = [&](int row, const QString& labelText, QPushButton* button) {
+            auto* label = new QLabel(labelText);
+            label->setStyleSheet(kLabelStyle);
+            label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+            button->setMinimumWidth(kMicControlButtonWidth);
+            button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+            grid->addWidget(label, row, 0);
+            grid->addWidget(button, row, 1);
+        };
+
         auto* biasBtn = mkTogBtn("BIAS", tx.micBias());
         connect(biasBtn, &QPushButton::toggled, this, [this](bool on) {
             m_model->transmitModel().setMicBias(on);
         });
-        row1->addWidget(biasBtn);
         auto* boostBtn = mkTogBtn("+20dB", tx.micBoost());
         connect(boostBtn, &QPushButton::toggled, this, [this](bool on) {
             m_model->transmitModel().setMicBoost(on);
         });
-        row1->addWidget(boostBtn);
-        row1->addStretch(1);
-        gvb->addLayout(row1);
-
-        // Meter in RX
-        auto* row2 = new QHBoxLayout;
-        row2->setSpacing(4);
-        auto* metBtn = mkTogBtn("Enabled", tx.metInRx());
+        auto* metBtn = mkTogBtn(tx.metInRx() ? "Enabled" : "Disabled", tx.metInRx());
         connect(metBtn, &QPushButton::toggled, this, [this, metBtn](bool on) {
             metBtn->setText(on ? "Enabled" : "Disabled");
             m_model->sendCommand(QString("transmit set met_in_rx=%1").arg(on ? 1 : 0));
         });
-        row2->addWidget(metBtn);
-        auto* metLbl = new QLabel("Enable/Disable the Level Meter During Receive");
-        metLbl->setStyleSheet(kLabelStyle);
-        row2->addWidget(metLbl);
-        row2->addStretch(1);
-        gvb->addLayout(row2);
+
+        addMicRow(0, "Mic Bias Voltage:", biasBtn);
+        addMicRow(1, "Mic +20 dB Boost:", boostBtn);
+        addMicRow(2, "Level Meter During Receive:", metBtn);
 
         vbox->addWidget(group);
     }


### PR DESCRIPTION
## Summary

This cleans up the Microphone section of the Radio Setup Phone/CW tab.

The existing controls worked, but the section used two loose horizontal rows: BIAS and +20dB sat without labels, while the level-meter toggle used a long inline sentence. This made the section harder to scan and left the buttons visually misaligned.

## Changes

- Convert the Microphone group to a compact grid with aligned labels and a fixed-width button column.
- Add explicit labels for each microphone control:
  - `Mic Bias Voltage:`
  - `Mic +20 dB Boost:`
  - `Level Meter During Receive:`
- Keep the existing `BIAS`, `+20dB`, and `Enabled` / `Disabled` button text.
- Initialize the level-meter button text from the current `met_in_rx` state so it displays `Disabled` correctly when the dialog opens.

## Behavior Notes

This is a UX-only cleanup. It does not change the commands sent by the buttons, the level-meter display gate, or the startup persistence behavior for `met_in_rx`.

The Level Meter During Receive button still sends the same `transmit set met_in_rx=0|1` command. Persistence/startup behavior is intentionally left for the separate meter-toggle work.

## Validation

- `git diff --check`
- `env -u CPLUS_INCLUDE_PATH cmake --build build -j22`
- Built macOS app bundle at `build/AetherSDR.app`
- Uploaded test build to the remote test Mac as `/Users/patj/Desktop/AetherSDR-radio-settings-mic-cleanup.app` and cleared quarantine

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
