### PR TITLE
fix(flexcontrol): close serial port synchronously on shutdown to release Windows COM handle

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4857,6 +4857,20 @@ MainWindow::~MainWindow()
 #ifdef HAVE_SERIALPORT
         QMetaObject::invokeMethod(m_serialPort, [this] { m_serialPort->close(); },
                                   Qt::BlockingQueuedConnection);
+        // FlexControlManager owns its own QSerialPort.  Close it
+        // synchronously on the ExtControllers thread before tearing the
+        // thread down — otherwise on Windows the OS handle for the
+        // FlexController COM port stays held by the zombie AetherSDR.exe
+        // process (deleteLater's DeferredDelete event isn't guaranteed
+        // to fire before the worker thread's event loop exits via quit).
+        // Other clients of the same port (e.g. SmartSDR's Tuning Knob
+        // serial open) then fail until the user kills AetherSDR.exe via
+        // TaskManager.  Same pattern as the m_midiControl /
+        // m_hidEncoder closes below.
+        if (m_flexControl) {
+            QMetaObject::invokeMethod(m_flexControl, &FlexControlManager::close,
+                                      Qt::BlockingQueuedConnection);
+        }
 #endif
 #ifdef HAVE_MIDI
         if (m_midiControl) {


### PR DESCRIPTION
Reported by Stig Rasmussen on Windows 11: closing AetherSDR leaves
AetherSDR.exe in TaskManager holding COM7 (the FlexController port).
SmartSDR can't open the Tuning Knob serial until the user kills the
zombie AetherSDR.exe.

~MainWindow's ExtControllers-thread shutdown synchronously closes
m_serialPort, m_midiControl, and m_hidEncoder via
QMetaObject::invokeMethod(..., Qt::BlockingQueuedConnection) before
calling quit() on the worker thread.  m_flexControl was the outlier
— it only got deleteLater(), relying on ~FlexControlManager to call
close() once the DeferredDelete event fired.

On Windows that ordering isn't guaranteed.  quit() and DeferredDelete
are both posted to the same event queue; if the worker thread's
event loop processes quit first (e.g. because the thread was busy
in onReadyRead when deleteLater fired), ~FlexControlManager never
runs, m_port.close() never runs, and the Win32 file handle for COM7
stays held by the AetherSDR.exe process until OS process cleanup —
which doesn't complete because the process is still alive on the
unfinished thread.  SmartSDR's open then fails with 'cannot be opened
— some other function may be using it'.

Add the missing synchronous close for m_flexControl, matching the
existing pattern used by m_serialPort / m_midiControl / m_hidEncoder.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
