### PR TITLE
fix(about): hoist AETHER_GIT_SHA fallback, clarify CMake status, add About-dialog tooltip (#2991)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -794,7 +794,11 @@ if(Git_FOUND)
     endif()
 endif()
 target_compile_definitions(AetherSDR PRIVATE AETHER_GIT_SHA="${AETHER_GIT_SHA}")
-message(STATUS "Build SHA: ${AETHER_GIT_SHA}")
+if(Git_FOUND AND _aether_git_sha_rv EQUAL 0 AND NOT "${_aether_git_sha_out}" STREQUAL "")
+    message(STATUS "Build SHA: ${AETHER_GIT_SHA}")
+else()
+    message(STATUS "Build SHA: ${AETHER_GIT_SHA} (git unavailable or not a git checkout)")
+endif()
 
 # Windows: GUI app (no console window) + icon resource
 if(WIN32)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -196,6 +196,15 @@
 #include <QFile>
 #include <QStandardPaths>
 
+// CMake captures the short git SHA at configure time and passes it as a
+// preprocessor definition (see CMakeLists.txt).  Defaulted to "unknown" so
+// non-CMake builds (e.g. raw clang invocations during local experiments)
+// still compile.  See issue #2991 for the rationale on hoisting this to
+// file scope rather than the inline definition inside buildMenuBar().
+#ifndef AETHER_GIT_SHA
+#define AETHER_GIT_SHA "unknown"
+#endif
+
 namespace AetherSDR {
 
 namespace {
@@ -8022,10 +8031,8 @@ void MainWindow::buildMenuBar()
         // Header
         // The git SHA captured at CMake configure time identifies the build —
         // useful when bug-reporting against a dev/test build that doesn't
-        // correspond to a tagged release.  See CMakeLists.txt for the capture.
-#ifndef AETHER_GIT_SHA
-#define AETHER_GIT_SHA "unknown"
-#endif
+        // correspond to a tagged release.  See CMakeLists.txt for the capture
+        // and the file-top #define for the non-CMake-build fallback.
         auto* header = new QLabel(QString(
             "<div style='text-align:center;'>"
             "<h2 style='margin-bottom:2px; color:#c8d8e8;'>AetherSDR</h2>"
@@ -8042,6 +8049,15 @@ void MainWindow::buildMenuBar()
                  QStringLiteral(AETHER_GIT_SHA)));
         header->setAlignment(Qt::AlignCenter);
         header->setWordWrap(true);
+        // Tooltip explains the staleness possibility — the SHA is baked at
+        // CMake configure time, so a dev who runs `cmake --build` after a
+        // new commit without re-configuring sees the previous SHA here.
+        // Re-running `cmake --fresh` (or deleting CMakeCache.txt) captures
+        // the current HEAD.
+        header->setToolTip(
+            QStringLiteral("Build identity. SHA is captured at CMake "
+                           "configure time — re-run `cmake -B build` after "
+                           "a new commit if you need the current value."));
         vbox->addWidget(header);
 
         // Separator


### PR DESCRIPTION
Closes #2991. Three small polish items from the PR #2988 review.

## Changes

### 1. Move `#ifndef AETHER_GIT_SHA` to file scope

Previously the fallback definition lived inside `buildMenuBar()`'s About-dialog lambda body, which leaked the macro into the rest of the translation unit after that function. Conventional file-top placement (after system includes, before `namespace AetherSDR`) puts the fallback where future readers look first and avoids the leak.

### 2. Clarify CMake configure-time status line

When git is unavailable or the source tree isn't a git checkout, the status line now reads:

```
-- Build SHA: unknown (git unavailable or not a git checkout)
```

Makes the unknown-SHA case visually unambiguous in tarball-source builds.

### 3. Add About-dialog tooltip

Explains the staleness possibility — the SHA is baked at CMake configure time, so a developer who runs `cmake --build` after a new commit without re-configuring sees the previous SHA. Tooltip points at `cmake -B build` (or `cmake --fresh`) to capture the current HEAD.

## Test plan

- [x] Builds clean
- [x] Re-configure shows `Build SHA: <sha>` for normal builds
- [ ] Verify status line says `(git unavailable or not a git checkout)` for a non-git tarball build (deferred — no easy local repro)
- [ ] Hover the version block in Help → About, confirm tooltip displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)