### PR TITLE
fix(gui): tighten GuardedSlider member types, extract EQ formatter + linger constant (#2987)

### DIFF
--- a/src/gui/DragValuePopup.h
+++ b/src/gui/DragValuePopup.h
@@ -14,10 +14,16 @@ namespace AetherSDR {
 // are consistent across macOS, Windows, and Linux window managers.
 class DragValuePopup : public QWidget {
 public:
+    // Brief "memory cue" duration after the user releases the slider.  Long
+    // enough to register visually, short enough not to obscure subsequent
+    // interaction.  PR #2944 review settled on 450 ms after testing 250 ms
+    // (too fleeting), 450 ms (right), and 750 ms (felt sluggish).
+    static constexpr int kDefaultLingerMs = 450;
+
     explicit DragValuePopup(QWidget* parent = nullptr);
 
     void showValue(const QPoint& globalAnchor, const QString& text);
-    void linger(int msec = 450);
+    void linger(int msec = kDefaultLingerMs);
     void hideNow();
 
 protected:

--- a/src/gui/EqApplet.cpp
+++ b/src/gui/EqApplet.cpp
@@ -82,6 +82,16 @@ static constexpr const char* kVSliderStyle =
     "QSlider::handle:vertical { height: 10px; width: 16px; margin: 0 -6px;"
     "background: #00b4d8; border-radius: 5px; }";
 
+// Drag-popup formatter for EQ band sliders.  Matches the file-scope
+// free-function shape used by the other applets (wattsText, percentText,
+// panText) so the EQ sliders read consistently with neighbouring code.
+static QString dbWithSignText(int v)
+{
+    return QStringLiteral("%1%2 dB")
+        .arg(v > 0 ? QStringLiteral("+") : QString())
+        .arg(v);
+}
+
 // ── EqApplet ────────────────────────────────────────────────────────────────
 
 EqApplet::EqApplet(QWidget* parent)
@@ -249,11 +259,7 @@ void EqApplet::buildUI()
             auto* slider = new GuardedSlider(Qt::Vertical);
             slider->setRange(-10, 10);
             slider->setValue(0);
-            slider->setDragValueFormatter([](int v) {
-                return QStringLiteral("%1%2 dB")
-                    .arg(v > 0 ? QStringLiteral("+") : QString())
-                    .arg(v);
-            });
+            slider->setDragValueFormatter(dbWithSignText);
             slider->setTickPosition(QSlider::NoTicks);
             slider->setStyleSheet(kVSliderStyle);
             slider->setFixedHeight(100);

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -120,7 +120,7 @@ void PhoneApplet::buildUI()
 
         m_amCarrierSlider = new GuardedSlider(Qt::Horizontal);
         m_amCarrierSlider->setRange(0, 100);
-        static_cast<GuardedSlider*>(m_amCarrierSlider)->setDragValueFormatter(percentText);
+        m_amCarrierSlider->setDragValueFormatter(percentText);
         m_amCarrierSlider->setAccessibleName("AM carrier level");
         m_amCarrierSlider->setAccessibleDescription("AM carrier power level, 0 to 100 percent");
         m_amCarrierSlider->setStyleSheet(kSliderStyle);
@@ -161,7 +161,7 @@ void PhoneApplet::buildUI()
 
         m_voxLevelSlider = new GuardedSlider(Qt::Horizontal);
         m_voxLevelSlider->setRange(0, 100);
-        static_cast<GuardedSlider*>(m_voxLevelSlider)->setDragValueFormatter(percentText);
+        m_voxLevelSlider->setDragValueFormatter(percentText);
         m_voxLevelSlider->setAccessibleName("VOX level");
         m_voxLevelSlider->setAccessibleDescription("VOX activation threshold");
         m_voxLevelSlider->setStyleSheet(kSliderStyle);
@@ -245,7 +245,7 @@ void PhoneApplet::buildUI()
 
         m_dexpSlider = new GuardedSlider(Qt::Horizontal);
         m_dexpSlider->setRange(0, 100);
-        static_cast<GuardedSlider*>(m_dexpSlider)->setDragValueFormatter(percentText);
+        m_dexpSlider->setDragValueFormatter(percentText);
         m_dexpSlider->setAccessibleName("DEXP threshold");
         m_dexpSlider->setAccessibleDescription("Downward expander gate threshold");
         m_dexpSlider->setStyleSheet(kSliderStyle);

--- a/src/gui/PhoneApplet.h
+++ b/src/gui/PhoneApplet.h
@@ -5,6 +5,7 @@
 class QPushButton;
 class QLabel;
 class QSlider;
+class GuardedSlider;
 class ScrollableLabel;
 
 namespace AetherSDR {
@@ -35,12 +36,12 @@ private:
     TransmitModel* m_model{nullptr};
 
     // AM Carrier
-    QSlider* m_amCarrierSlider{nullptr};
+    GuardedSlider* m_amCarrierSlider{nullptr};
     QLabel*  m_amCarrierLabel{nullptr};
 
     // VOX
     QPushButton* m_voxBtn{nullptr};
-    QSlider*     m_voxLevelSlider{nullptr};
+    GuardedSlider* m_voxLevelSlider{nullptr};
     QLabel*      m_voxLevelLabel{nullptr};
 
     // VOX delay
@@ -49,7 +50,7 @@ private:
 
     // DEXP (non-functional on fw v1.4.0.0 — see GitHub issue)
     QPushButton* m_dexpBtn{nullptr};
-    QSlider*     m_dexpSlider{nullptr};
+    GuardedSlider* m_dexpSlider{nullptr};
     QLabel*      m_dexpLabel{nullptr};
 
     // TX filter

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -134,7 +134,7 @@ void TxApplet::buildUI()
 
         m_rfPowerSlider = new GuardedSlider(Qt::Horizontal);
         m_rfPowerSlider->setRange(0, 100);
-        static_cast<GuardedSlider*>(m_rfPowerSlider)->setDragValueFormatter(wattsText);
+        m_rfPowerSlider->setDragValueFormatter(wattsText);
         m_rfPowerSlider->setStyleSheet(kSliderStyle);
         m_rfPowerSlider->setAccessibleName("RF power");
         m_rfPowerSlider->setAccessibleDescription("Transmit RF power level, 0 to 100 watts");
@@ -159,7 +159,7 @@ void TxApplet::buildUI()
 
         m_tunePowerSlider = new GuardedSlider(Qt::Horizontal);
         m_tunePowerSlider->setRange(0, 100);
-        static_cast<GuardedSlider*>(m_tunePowerSlider)->setDragValueFormatter(wattsText);
+        m_tunePowerSlider->setDragValueFormatter(wattsText);
         m_tunePowerSlider->setStyleSheet(kSliderStyle);
         m_tunePowerSlider->setAccessibleName("Tune power");
         m_tunePowerSlider->setAccessibleDescription("Tune carrier power level, 0 to 100 watts");

--- a/src/gui/TxApplet.h
+++ b/src/gui/TxApplet.h
@@ -8,6 +8,7 @@ class QPushButton;
 class QLabel;
 class QSlider;
 class QComboBox;
+class GuardedSlider;
 
 namespace AetherSDR {
 
@@ -85,8 +86,8 @@ private:
     QWidget* m_swrGauge{nullptr};
 
     // Sliders
-    QSlider* m_rfPowerSlider{nullptr};
-    QSlider* m_tunePowerSlider{nullptr};
+    GuardedSlider* m_rfPowerSlider{nullptr};
+    GuardedSlider* m_tunePowerSlider{nullptr};
     QLabel*  m_rfPowerLabel{nullptr};
     QLabel*  m_tunePowerLabel{nullptr};
 


### PR DESCRIPTION
Closes #2987. Three polish items from the PR #2944 (DragValuePopup) review.

## 1. Tighten slider member types

`TxApplet` and `PhoneApplet` declared their sliders as `QSlider*` for historical reasons but constructed them as `GuardedSlider`, forcing `static_cast<GuardedSlider*>(...)->setDragValueFormatter(...)` at every call site. Member type is now `GuardedSlider*` so the formatter calls resolve directly:

- `TxApplet.{h,cpp}`: `m_rfPowerSlider`, `m_tunePowerSlider`
- `PhoneApplet.{h,cpp}`: `m_amCarrierSlider`, `m_voxLevelSlider`, `m_dexpSlider`

Forward declarations in the headers go in the global namespace where `GuardedSlider` actually lives, not under `namespace AetherSDR`. (First attempt had them inside the namespace, which silently created an ODR-incompatible second type — caught by the compiler.)

## 2. Extract `dbWithSignText` helper in EqApplet.cpp

The EQ band sliders' drag-popup formatter was an inline lambda; other applets use file-scope free functions for the same pattern. Lifted to a named helper for consistency:

```cpp
static QString dbWithSignText(int v)
{
    return QStringLiteral("%1%2 dB")
        .arg(v > 0 ? QStringLiteral("+") : QString())
        .arg(v);
}
```

## 3. Name the DragValuePopup linger duration

The 450 ms "memory cue" was baked into the default-argument literal in `DragValuePopup.h`. Promoted to `kDefaultLingerMs` constexpr with a comment recording the testing rationale so the value is findable without spelunking PR #2944's body.

## Test plan

- [x] Builds clean
- [ ] Verify drag-popup readouts still appear correctly on RF Power, Tune Pwr, AM Carrier, VOX Level, DEXP, EQ bands (no behavior change expected — pure type/constant refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)