### PR TITLE
fix(flexcontrol): consolidate WheelMasterAf into WheelVolume (#2986)

### DIFF
--- a/src/gui/FlexControlDialog.cpp
+++ b/src/gui/FlexControlDialog.cpp
@@ -232,8 +232,7 @@ const FlexActionDef kFlexActions[] = {
     {"SegmentZoom", "Segment Zoom"},
     {"WheelRit", "RIT (Receive Incremental Tuning)"},
     {"WheelXit", "XIT (Transmit Incremental Tuning)"},
-    {"WheelVolume", "Slice AF"},
-    {"WheelMasterAf", "Master AF"},
+    {"WheelVolume", "Master Volume"},
     {"WheelHeadphoneVolume", "Headphone Volume"},
     {"WheelAgcT", "AGCT (Automatic Gain Control Threshold)"},
     {"WheelApf", "APF (Audio Peaking Filter)"},
@@ -352,10 +351,14 @@ bool isWheelActionId(const QString& actionId)
     // active-slice advance, split, and macros should not leave an Aux mode on.
     return actionId == QLatin1String("WheelFrequency")
         || actionId == QLatin1String("WheelVolume")
+        // "WheelMasterAf" is the legacy alias for WheelVolume (see #2986
+        // and flexWheelModeForAction in MainWindow.cpp).  Recognized here
+        // so saved bindings made before consolidation still register as
+        // wheel actions in this predicate.
+        || actionId == QLatin1String("WheelMasterAf")
         || actionId == QLatin1String("WheelPower")
         || actionId == QLatin1String("WheelRit")
         || actionId == QLatin1String("WheelXit")
-        || actionId == QLatin1String("WheelMasterAf")
         || actionId == QLatin1String("WheelHeadphoneVolume")
         || actionId == QLatin1String("WheelAgcT")
         || actionId == QLatin1String("WheelApf")

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -334,7 +334,9 @@ bool flexWheelModeForAction(const QString& actionName, FlexWheelMode& mode)
     } else if (actionName == QLatin1String("WheelXit")) {
         mode = FlexWheelMode::Xit;
     } else if (actionName == QLatin1String("WheelMasterAf")) {
-        mode = FlexWheelMode::MasterAf;
+        // Back-compat for saved FlexControl bindings made before #2986
+        // consolidation.  Routes to the same Volume mode (master volume).
+        mode = FlexWheelMode::Volume;
     } else if (actionName == QLatin1String("WheelHeadphoneVolume")) {
         mode = FlexWheelMode::HeadphoneVolume;
     } else if (actionName == QLatin1String("WheelAgcT")) {
@@ -5924,9 +5926,6 @@ void MainWindow::handleFlexControlTuneSteps(int steps)
     case FlexWheelMode::Xit:
         applyFlexControlWheelAction(QStringLiteral("WheelXit"), steps);
         break;
-    case FlexWheelMode::MasterAf:
-        applyFlexControlWheelAction(QStringLiteral("WheelMasterAf"), steps);
-        break;
     case FlexWheelMode::HeadphoneVolume:
         applyFlexControlWheelAction(QStringLiteral("WheelHeadphoneVolume"), steps);
         break;
@@ -6112,16 +6111,11 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
             const int hz = std::clamp(s->xitFreq() + steps * 10, -9999, 9999);
             s->setXit(true, hz);
         }
-    } else if (actionId == "WheelVolume") {
+    } else if (actionId == "WheelVolume" || actionId == "WheelMasterAf") {
         // Route to master volume to match SmartSDR behavior (#2921).
-        // Identical body to WheelMasterAf below; see #2986 for the
-        // consolidation follow-up tracking removal of one of these.
-        const int current = AppSettings::instance().value("MasterVolume", "100").toInt();
-        const int next = std::clamp(current + steps * 2, 0, 100);
-        if (m_titleBar)
-            m_titleBar->setMasterVolume(next);
-        applyMasterVolume(next);
-    } else if (actionId == "WheelMasterAf") {
+        // "WheelMasterAf" is the legacy action name from #2888; accepted
+        // here for back-compat with saved FlexControl bindings made
+        // before the #2986 consolidation but routes to the same code path.
         const int current = AppSettings::instance().value("MasterVolume", "100").toInt();
         const int next = std::clamp(current + steps * 2, 0, 100);
         if (m_titleBar)
@@ -6203,7 +6197,6 @@ QJsonObject MainWindow::buildControlDevicesSnapshot() const
         case FlexWheelMode::Power:     return QStringLiteral("Power");
         case FlexWheelMode::Rit:       return QStringLiteral("Rit");
         case FlexWheelMode::Xit:       return QStringLiteral("Xit");
-        case FlexWheelMode::MasterAf:  return QStringLiteral("MasterAf");
         case FlexWheelMode::HeadphoneVolume:
             return QStringLiteral("HeadphoneVolume");
         case FlexWheelMode::AgcT:      return QStringLiteral("AgcT");

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -107,13 +107,19 @@ using DaxBridge = PipeWireAudioBridge;
 class VfoWidget;
 
 // Wheel mode for FlexControl: determines what the encoder knob adjusts.
+//
+// MasterAf was previously a separate enum value that routed identically
+// to Volume (see issue #2986).  PR #2925 changed Volume to route to
+// master-volume as well, making the two modes byte-identical.  MasterAf
+// was removed; the "WheelMasterAf" action string is still accepted in
+// flexWheelModeForAction() and mapped to Volume so saved FlexControl
+// button bindings keep working.
 enum class FlexWheelMode {
     Frequency,
     Volume,
     Power,
     Rit,
     Xit,
-    MasterAf,
     HeadphoneVolume,
     AgcT,
     Apf,

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4060,7 +4060,7 @@ QWidget* RadioSetupDialog::buildSerialTab()
             "ToggleAgc", "VolumeUp", "VolumeDown",
             "WheelFrequency", "WheelVolume", "WheelPower",
             "WheelRit", "WheelXit",
-            "WheelMasterAf", "WheelHeadphoneVolume",
+            "WheelHeadphoneVolume",
             "WheelAgcT", "WheelApf", "WheelCwSpeed",
             "ClearRit", "ClearXit", "ToggleApf",
             "CwxF1", "CwxF2", "CwxF3", "CwxF4",


### PR DESCRIPTION
Closes #2986. PR #2925 made `FlexWheelMode::Volume` route to master volume (matching SmartSDR per #2921). PR #2888 had previously added a separate `FlexWheelMode::MasterAf` for master volume. After #2925 the two modes were byte-identical — same dispatcher case, same display entry, same code path. This PR collapses them.

## Changes

- **Drop `FlexWheelMode::MasterAf` enum value** and the corresponding switch case in `handleFlexControlTuneSteps` + `flexWheelModeName` mapping.
- **Fold `WheelMasterAf` into `WheelVolume`** branch in `applyFlexControlWheelAction` via short-circuit OR — body lives once.
- **Keep accepting `"WheelMasterAf"` as a string alias** in:
  - `flexWheelModeForAction` — maps to `FlexWheelMode::Volume`
  - `FlexControlDialog::isWheelAction` predicate — same back-compat
  
  This preserves saved FlexControl bindings that picked "WheelMasterAf" before the consolidation.
  
- **Remove `WheelMasterAf` from the Radio Setup dropdown** so new bindings only see the canonical `WheelVolume`.
- **Relabel `WheelVolume` from "Slice AF" to "Master Volume"** in FlexControlDialog's display map — "Slice AF" was the pre-#2925 description and is now misleading (the action no longer touches slice gain).

## Behavior

- Users with existing "WheelMasterAf" bindings: continue working unchanged (back-compat alias path).
- New users: see one option instead of two identical-behavior choices.
- No-binding behavior unchanged.

## Test plan

- [x] Builds clean
- [ ] Run with a FlexController hardware setup, confirm wheel-volume mode still adjusts master volume
- [ ] Verify a previously-saved "WheelMasterAf" binding still works (back-compat alias)
- [ ] Verify the Radio Setup dropdown no longer lists WheelMasterAf

🤖 Generated with [Claude Code](https://claude.com/claude-code)