### PR TITLE
feat(gui): expose single-click discrimination interval as user setting (#3009)

### DIFF
--- a/src/gui/ClientChainWidget.cpp
+++ b/src/gui/ClientChainWidget.cpp
@@ -1,4 +1,5 @@
 #include "ClientChainWidget.h"
+#include "InteractionSettings.h"
 #include "core/ClientComp.h"
 #include "core/ClientEq.h"
 #include "core/ClientGate.h"
@@ -592,7 +593,7 @@ void ClientChainWidget::mouseReleaseEvent(QMouseEvent* ev)
     if (m_boxes[idx].isEndpoint) return;
     m_pendingClickIdx = idx;
     if (m_clickTimer) {
-        m_clickTimer->start(QApplication::doubleClickInterval());
+        m_clickTimer->start(clickDiscriminationIntervalMs());
     }
     ev->accept();
 }

--- a/src/gui/ClientRxChainWidget.cpp
+++ b/src/gui/ClientRxChainWidget.cpp
@@ -1,5 +1,6 @@
 #include "ClientRxChainWidget.h"
 
+#include "InteractionSettings.h"
 #include "core/AppSettings.h"
 #include "core/ClientComp.h"
 #include "core/ClientDeEss.h"
@@ -429,7 +430,7 @@ void ClientRxChainWidget::mouseReleaseEvent(QMouseEvent* ev)
     if (!clickableStage && !clickableDsp) return;
     m_pendingClickIdx = idx;
     if (m_clickTimer)
-        m_clickTimer->start(QApplication::doubleClickInterval());
+        m_clickTimer->start(clickDiscriminationIntervalMs());
 }
 
 void ClientRxChainWidget::mouseDoubleClickEvent(QMouseEvent* ev)

--- a/src/gui/InteractionSettings.h
+++ b/src/gui/InteractionSettings.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "core/AppSettings.h"
+
+#include <QApplication>
+
+namespace AetherSDR {
+
+// Centralized accessor for the "click-discrimination interval" — the time
+// AetherSDR waits after a single click on a widget that has double-click
+// semantics before firing the single-click action.  Several widgets defer
+// their single-click handler by this interval so a double click within the
+// window can override it (e.g. RxApplet's slice-mute button: single click
+// mutes this slice, double click mutes all owned slices).
+//
+// Default is the platform's QApplication::doubleClickInterval() (typically
+// 400 ms on Linux, 500 ms on Windows, system-configurable on macOS).  Users
+// can override it via Radio Setup → Behavior to trade off single-click
+// latency vs. double-click registration reliability.  A value of 0 disables
+// the defer entirely — single-click actions fire instantly, and double-click
+// affordances become unreachable on widgets that use this knob.
+//
+// All call sites should read the value at click time rather than caching it
+// at construction so changes via Settings propagate without an app restart.
+inline int clickDiscriminationIntervalMs()
+{
+    auto& s = AppSettings::instance();
+    bool ok = false;
+    const int v = s.value("ClickDiscriminationIntervalMs",
+                          QApplication::doubleClickInterval()).toInt(&ok);
+    if (!ok || v < 0)
+        return QApplication::doubleClickInterval();
+    return v;
+}
+
+} // namespace AetherSDR

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -6,6 +6,7 @@
 #include "models/RadioModel.h"
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
+#include <QApplication>
 #include <QSysInfo>
 #include "core/AudioEngine.h"
 #ifdef HAVE_SERIALPORT
@@ -4707,6 +4708,81 @@ QWidget* RadioSetupDialog::buildUiEnhancementsTab()
         syncModeRadios(pMgr->useCustomColors());
         refreshAllBtns();
     });
+
+    // ── Single-click delay group (#3009) ────────────────────────────────────
+    // Several widgets (slice-mute button, RX chain stages, waveform widgets)
+    // defer the single-click action by this interval so a double click can
+    // override it.  Default is the platform's QApplication::doubleClickInterval
+    // (typically 400 ms on Linux, 500 ms on Windows).  Power users who never
+    // double-click can set this to 0 for instant single-click response;
+    // double-click affordances become unreachable in that case but the
+    // mute-all keyboard shortcut still works for the most common use.
+    {
+        auto* clickGrp = new QGroupBox("Single-click delay");
+        clickGrp->setStyleSheet(kGroupStyle);
+        auto* clickLayout = new QVBoxLayout(clickGrp);
+        clickLayout->setSpacing(8);
+
+        auto* row = new QHBoxLayout;
+        row->setSpacing(8);
+
+        auto* clickLabel = new QLabel("Delay (ms):");
+        clickLabel->setStyleSheet("QLabel { color: #c8d8e8; font-size: 12px; }");
+        row->addWidget(clickLabel);
+
+        auto& s = AppSettings::instance();
+        const int platformDefault = QApplication::doubleClickInterval();
+        const int current = s.value("ClickDiscriminationIntervalMs",
+                                     platformDefault).toInt();
+
+        auto* clickSpin = new QSpinBox;
+        clickSpin->setRange(0, 1000);
+        clickSpin->setSingleStep(50);
+        clickSpin->setSuffix(" ms");
+        clickSpin->setValue(qBound(0, current, 1000));
+        clickSpin->setFixedWidth(110);
+        clickSpin->setStyleSheet(
+            "QSpinBox { background: #1a2230; color: #c8d8e8; "
+            "border: 1px solid #304050; border-radius: 3px; padding: 2px 4px; }");
+        row->addWidget(clickSpin);
+
+        auto* resetBtn = new QPushButton("Reset");
+        resetBtn->setStyleSheet(
+            "QPushButton { background: #1a2230; color: #c8d8e8; "
+            "border: 1px solid #304050; border-radius: 3px; padding: 4px 12px; }"
+            "QPushButton:hover { border-color: #60a0c0; }");
+        resetBtn->setToolTip(QString("Reset to platform default (%1 ms)")
+                             .arg(platformDefault));
+        row->addWidget(resetBtn);
+
+        row->addStretch();
+        clickLayout->addLayout(row);
+
+        auto* clickDesc = new QLabel(QString(
+            "Time AetherSDR waits after a single click on a widget that "
+            "also has a double-click action (e.g. the slice mute button) "
+            "before firing the single-click. The platform default is "
+            "%1 ms. Set to 0 to fire single-click actions instantly — "
+            "this also disables the double-click affordances on those "
+            "widgets.").arg(platformDefault));
+        clickDesc->setStyleSheet("QLabel { color: #7090a0; font-size: 11px; }");
+        clickDesc->setWordWrap(true);
+        clickLayout->addWidget(clickDesc);
+
+        connect(clickSpin, QOverload<int>::of(&QSpinBox::valueChanged),
+                this, [](int v) {
+            auto& s = AppSettings::instance();
+            s.setValue("ClickDiscriminationIntervalMs", QString::number(v));
+            s.save();
+        });
+        connect(resetBtn, &QPushButton::clicked, this,
+                [clickSpin, platformDefault]() {
+            clickSpin->setValue(platformDefault);
+            // valueChanged handler above persists the value.
+        });
+
+        vbox->addWidget(clickGrp);
+    }
 
     return page;
 }

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -3,6 +3,7 @@
 #include "FrequencyEntryParser.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
+#include "InteractionSettings.h"
 #include "SliceColorManager.h"
 #include "SliceLabel.h"
 #include "models/RadioModel.h"
@@ -762,7 +763,7 @@ void RxApplet::buildUI()
             if (m_slice) m_slice->setAudioMute(!m_slice->audioMute());
         });
         connect(m_muteBtn, &QPushButton::clicked, this, [this]() {
-            m_muteClickTimer->start(QApplication::doubleClickInterval());
+            m_muteClickTimer->start(clickDiscriminationIntervalMs());
         });
         m_muteBtn->installEventFilter(this);
         row->addWidget(m_muteBtn);

--- a/src/gui/StripChainWidget.cpp
+++ b/src/gui/StripChainWidget.cpp
@@ -1,4 +1,5 @@
 #include "StripChainWidget.h"
+#include "InteractionSettings.h"
 #include "core/ClientComp.h"
 #include "core/ClientEq.h"
 #include "core/ClientGate.h"
@@ -592,7 +593,7 @@ void StripChainWidget::mouseReleaseEvent(QMouseEvent* ev)
     if (m_boxes[idx].isEndpoint) return;
     m_pendingClickIdx = idx;
     if (m_clickTimer) {
-        m_clickTimer->start(QApplication::doubleClickInterval());
+        m_clickTimer->start(clickDiscriminationIntervalMs());
     }
     ev->accept();
 }

--- a/src/gui/StripRxChainWidget.cpp
+++ b/src/gui/StripRxChainWidget.cpp
@@ -1,4 +1,5 @@
 #include "StripRxChainWidget.h"
+#include "InteractionSettings.h"
 #include "core/ClientComp.h"
 #include "core/ClientDeEss.h"
 #include "core/ClientEq.h"
@@ -495,7 +496,7 @@ void StripRxChainWidget::mouseReleaseEvent(QMouseEvent* ev)
     if (kind != TileKind::Stage && kind != TileKind::StatusAdsp) return;
     m_pendingClickIdx = idx;
     if (m_clickTimer) {
-        m_clickTimer->start(QApplication::doubleClickInterval());
+        m_clickTimer->start(clickDiscriminationIntervalMs());
     }
     ev->accept();
 }

--- a/src/gui/StripWaveform.cpp
+++ b/src/gui/StripWaveform.cpp
@@ -1,5 +1,6 @@
 #include "StripWaveform.h"
 
+#include "InteractionSettings.h"
 #include "core/AppSettings.h"
 
 #include <QApplication>
@@ -87,7 +88,8 @@ StripWaveform::StripWaveform(QWidget* parent)
     setToolTip("Click to pause/resume waveform capture; double-click for WAVE settings");
 
     m_clickTimer.setSingleShot(true);
-    m_clickTimer.setInterval(QApplication::doubleClickInterval());
+    // Interval read at click time from clickDiscriminationIntervalMs() so
+    // a user-adjusted Radio Setup value propagates without an app restart.
     connect(&m_clickTimer, &QTimer::timeout, this, [this]() {
         setPaused(!m_paused);
     });
@@ -283,7 +285,7 @@ void StripWaveform::mouseReleaseEvent(QMouseEvent* event)
         if (m_ignoreNextRelease) {
             m_ignoreNextRelease = false;
         } else if (!m_clickTimer.isActive()) {
-            m_clickTimer.start();
+            m_clickTimer.start(clickDiscriminationIntervalMs());
         }
         event->accept();
         return;

--- a/src/gui/WaveformWidget.cpp
+++ b/src/gui/WaveformWidget.cpp
@@ -1,5 +1,6 @@
 #include "WaveformWidget.h"
 
+#include "InteractionSettings.h"
 #include "core/AppSettings.h"
 
 #include <QApplication>
@@ -84,7 +85,8 @@ WaveformWidget::WaveformWidget(QWidget* parent)
     setToolTip("Click to pause/resume waveform capture; double-click for WAVE settings");
 
     m_clickTimer.setSingleShot(true);
-    m_clickTimer.setInterval(QApplication::doubleClickInterval());
+    // Interval read at click time from clickDiscriminationIntervalMs() so
+    // a user-adjusted Radio Setup value propagates without an app restart.
     connect(&m_clickTimer, &QTimer::timeout, this, [this]() {
         setPaused(!m_paused);
     });
@@ -277,7 +279,7 @@ void WaveformWidget::mouseReleaseEvent(QMouseEvent* event)
         if (m_ignoreNextRelease) {
             m_ignoreNextRelease = false;
         } else if (!m_clickTimer.isActive()) {
-            m_clickTimer.start();
+            m_clickTimer.start(clickDiscriminationIntervalMs());
         }
         event->accept();
         return;


### PR DESCRIPTION
Closes #3009.

Several widgets (slice mute button, RX chain stages, waveform widgets) defer the single-click action by `QApplication::doubleClickInterval()` (~400 ms on Linux) so a double-click can override it. Power users wanted instant single-click; users with slower input wanted longer windows. This PR makes the interval a project-wide AppSettings key with a UI surface.

## Changes

### `src/gui/InteractionSettings.h` (new)
Inline accessor `clickDiscriminationIntervalMs()` reads AppSettings key `ClickDiscriminationIntervalMs`, falls back to platform default if missing/malformed/negative. `0` is honoured and means "fire single-click instantly" (also disables the double-click affordances on widgets that use this gate).

### Migrated 7 call sites
- `RxApplet.cpp` (slice mute button — #3006)
- `StripRxChainWidget.cpp`
- `ClientRxChainWidget.cpp`
- `ClientChainWidget.cpp`
- `StripChainWidget.cpp`
- `WaveformWidget.cpp` — also dropped construction-time cache; reads at click time
- `StripWaveform.cpp` — same

The two waveform widgets previously called `QTimer::setInterval()` at construction. Switching to `start(clickDiscriminationIntervalMs())` at click time means a user-adjusted Radio Setup value propagates without an app restart.

### UI surface
New "Single-click delay" group in **Radio Setup → Themes** tab (which is `buildUiEnhancementsTab()` internally). 0-1000 ms QSpinBox defaulted to platform value, Reset button restores platform default, descriptive label explains the 0 = instant-single-click semantics.

## Test plan

- [x] Builds clean
- [ ] Open Radio Setup → Themes, verify "Single-click delay" group renders with platform default
- [ ] Set delay to 100, click slice mute button — verify ~100 ms perceived latency
- [ ] Set delay to 0, click slice mute button — verify instant response
- [ ] Set delay to 0, double-click slice mute button — verify the double-click action no longer fires (both clicks fire single-click toggles)
- [ ] Click Reset, verify spinbox returns to platform default

🤖 Generated with [Claude Code](https://claude.com/claude-code)