### PR TITLE
fix(gui): FDX indicator ignores radio rejection. Principle IX.

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6648,10 +6648,17 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
     }
     if (obj == m_fdxIndicator && event->type() == QEvent::MouseButtonPress) {
         bool on = !m_radioModel.fullDuplexEnabled();
-        m_radioModel.sendCommand(QString("radio set full_duplex_enabled=%1").arg(on ? 1 : 0));
-        // Optimistic update — radio accepts this command (R|0) but doesn't
-        // echo back a status update with the new value.
-        m_radioModel.setFullDuplex(on);
+        m_radioModel.sendCmdPublic(
+            QString("radio set full_duplex_enabled=%1").arg(on ? 1 : 0),
+            [this, on](int code, const QString& body) {
+                if (code != 0) {
+                    showPanadapterInterlockNotification(
+                        QString("FDX not available: %1").arg(body.trimmed()));
+                    return;
+                }
+                // Radio accepted; no status echo follows, so apply manually.
+                m_radioModel.setFullDuplex(on);
+            });
         return true;
     }
     if (obj == m_bandStackIndicator && event->type() == QEvent::MouseButtonPress) {


### PR DESCRIPTION
## Summary

Fixes #2912

On single-CPU FLEX-8400 and other hardware running firmware 4.2,
`radio set full_duplex_enabled=1` returns a non-zero result code when
FDX is unavailable. The FDX click handler was using `sendCommand()`
(fire-and-forget) followed by an immediate `setFullDuplex(on)`, so the
indicator turned blue while the radio was silently rejecting the command.

Switch to `sendCmdPublic()` with a callback:
- **On success** (`code == 0`): call `setFullDuplex(on)`. The radio does
  not echo a status update when FDX succeeds, so the manual call remains
  necessary.
- **On failure** (`code != 0`): call `showPanadapterInterlockNotification()`
  with the radio's error body. The indicator stays in its prior state.
  The 5-second panadapter toast is already used for PTT/interlock
  rejections — consistent UX, no new dialog.

One file changed, ~10 lines: `src/gui/MainWindow.cpp` (FDX event filter
block). No model, protocol, or threading changes.

## Constitution principle honored

**Principle IX — Surface Only What Survives.** The UI was surfacing a
state change (FDX enabled) that had not survived radio validation. The
fix gates the indicator update on a confirmed `code == 0` response,
so only state the radio accepted reaches the display.

## Test plan

- [x] Local build passes (MinGW GCC 13.1.0, Qt 6.11.0, clean compile)
- [x] Toggle FDX on a FLEX-8400 fw 4.2 — indicator stays grey, panadapter
      toast shows "FDX not available: Full Duplex not Available" (verified
      on real radio — NF0T)
- [ ] Toggle FDX on a radio/firmware where it is supported — indicator
      turns blue normally (no regression)
- [ ] Existing tests pass (CI)

## Checklist

- [ ] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls
- [x] No meter UI changes
- [x] No user-visible documentation changes required (behavior change is the fix)
- [x] No security-sensitive changes