### PR TITLE
refactor(slice): centralize LOCKED tune-feedback timer in SliceModel

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -157,8 +157,6 @@ static const QString kAmberActive =
     "QPushButton:checked { background-color: #604000; color: #ffb800; "
     "border: 1px solid #906000; }";
 
-static constexpr int kLockedFrequencyFeedbackMs = 500;
-
 static bool likelyTxAntennaFallbackToken(const QString& token)
 {
     const QString upper = token.toUpper();
@@ -270,9 +268,6 @@ RxApplet::RxApplet(QWidget* parent) : QWidget(parent)
     m_sqlManualLevel = std::clamp(
         AppSettings::instance().value("LastManualSquelchLevel", "20").toInt(),
         0, 100);
-    m_lockedFrequencyTimer.setSingleShot(true);
-    connect(&m_lockedFrequencyTimer, &QTimer::timeout,
-            this, &RxApplet::clearLockedFrequencyFeedback);
     buildUI();
 }
 
@@ -1571,10 +1566,10 @@ void RxApplet::updateSliceButtons(const QList<SliceModel*>& slices, int activeSl
 
 void RxApplet::setSlice(SliceModel* slice)
 {
-    clearLockedFrequencyFeedback();
     if (m_slice) disconnectSlice(m_slice);
     m_slice = slice;
     if (m_slice) connectSlice(m_slice);
+    updateFreqLabel();
 }
 
 void RxApplet::setAntennaList(const QStringList& ants)
@@ -1745,8 +1740,6 @@ void RxApplet::connectSlice(SliceModel* s)
             m_freqEdit->setText(QString::number(s->frequency(), 'f', 6));
             m_freqStack->setCurrentIndex(0);
             m_freqEdit->clearFocus();
-        } else if (!locked) {
-            clearLockedFrequencyFeedback();
         }
     });
 
@@ -1849,8 +1842,18 @@ void RxApplet::connectSlice(SliceModel* s)
     connect(s, &SliceModel::frequencyChanged, this, [this](double) {
         updateFreqLabel();
     });
-    connect(s, &SliceModel::tuneBlockedByLock,
-            this, &RxApplet::showLockedFrequencyFeedback);
+    // Blocked tune: cancel any in-flight direct-entry (widget-local side
+    // effect), then let lockedFeedbackActiveChanged drive the LOCKED repaint
+    // (single source of truth in SliceModel — see #2983).
+    connect(s, &SliceModel::tuneBlockedByLock, this, [this] {
+        if (m_freqStack && m_freqStack->currentIndex() == 1) {
+            m_freqEdit->setText(QString::number(m_slice->frequency(), 'f', 6));
+            m_freqStack->setCurrentIndex(0);
+            m_freqEdit->clearFocus();
+        }
+    });
+    connect(s, &SliceModel::lockedFeedbackActiveChanged,
+            this, [this](bool) { updateFreqLabel(); });
 
     // ── Filter ─────────────────────────────────────────────────────────────
     updateFilterButtons();
@@ -2660,7 +2663,7 @@ void RxApplet::updateFreqLabel()
     if (!m_slice)
         return;
 
-    if (m_showingLockedFrequencyFeedback) {
+    if (m_slice->isLockedFeedbackActive()) {
         m_freqLabel->setText(QStringLiteral("LOCKED"));
         return;
     }
@@ -2673,32 +2676,6 @@ void RxApplet::updateFreqLabel()
         .arg(mhzPart)
         .arg(khzPart, 3, 10, QChar('0'))
         .arg(hzPart, 3, 10, QChar('0')));
-}
-
-void RxApplet::showLockedFrequencyFeedback()
-{
-    if (!m_slice || !m_slice->isLocked())
-        return;
-
-    if (m_freqStack && m_freqStack->currentIndex() == 1) {
-        m_freqEdit->setText(QString::number(m_slice->frequency(), 'f', 6));
-        m_freqStack->setCurrentIndex(0);
-        m_freqEdit->clearFocus();
-    }
-
-    m_showingLockedFrequencyFeedback = true;
-    updateFreqLabel();
-    m_lockedFrequencyTimer.start(kLockedFrequencyFeedbackMs);
-}
-
-void RxApplet::clearLockedFrequencyFeedback()
-{
-    if (!m_showingLockedFrequencyFeedback)
-        return;
-
-    m_lockedFrequencyTimer.stop();
-    m_showingLockedFrequencyFeedback = false;
-    updateFreqLabel();
 }
 
 void RxApplet::refreshAllMutedDim()

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -140,8 +140,6 @@ private:
     void updateAntennaButton(QPushButton* button, const QString& token, bool tx);
     void updateAntennaButtons();
     void updateFreqLabel();
-    void showLockedFrequencyFeedback();
-    void clearLockedFrequencyFeedback();
     QStringList txAntennaOptions() const;
     QString antennaMenuLabel(const QString& token, const QStringList& options) const;
 
@@ -203,8 +201,6 @@ private:
     QLabel*      m_freqLabel{nullptr};     // frequency readout e.g. "14.289.510"
     QLineEdit*   m_freqEdit{nullptr};
     QStackedWidget* m_freqStack{nullptr};
-    QTimer       m_lockedFrequencyTimer;
-    bool         m_showingLockedFrequencyFeedback{false};
 
     // Filter presets (Hz widths) — per-mode, swapped on mode change
     QVector<int>            m_filterWidths{1800, 2100, 2400, 2700, 3300, 6000};

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -203,8 +203,6 @@ static const QString kSliderStyle =
 static const QString kLabelStyle =
     "QLabel { background: transparent; border: none; color: #8aa8c0; font-size: 13px; }";
 
-static constexpr int kLockedFrequencyFeedbackMs = 500;
-
 static bool likelyTxAntennaFallbackToken(const QString& token)
 {
     const QString upper = token.toUpper();
@@ -233,9 +231,6 @@ VfoWidget::VfoWidget(QWidget* parent)
     m_signalMeterAnimation.setTimerType(Qt::PreciseTimer);
     m_signalMeterAnimation.setInterval(kSignalMeterAnimationIntervalMs);
     connect(&m_signalMeterAnimation, &QTimer::timeout, this, &VfoWidget::animateSignalMeter);
-    m_lockedFrequencyTimer.setSingleShot(true);
-    connect(&m_lockedFrequencyTimer, &QTimer::timeout,
-            this, &VfoWidget::clearLockedFrequencyFeedback);
 
     buildUI();
 
@@ -2507,11 +2502,13 @@ void VfoWidget::setSlice(SliceModel* slice)
 {
     qDebug() << "VfoWidget::setSlice:" << (slice ? slice->sliceId() : -1)
              << "old:" << (m_slice ? m_slice->sliceId() : -1);
-    clearLockedFrequencyFeedback();
     if (m_slice)
         m_slice->disconnect(this);
     m_slice = slice;
-    if (!m_slice) return;
+    if (!m_slice) {
+        updateFreqLabel();
+        return;
+    }
 
     // Load per-slice display prefs now that we know the slice ID, then push
     // them out so the SpectrumWidget's overlay picks up the saved style. This
@@ -2521,8 +2518,14 @@ void VfoWidget::setSlice(SliceModel* slice)
 
     // Frequency
     connect(m_slice, &SliceModel::frequencyChanged, this, [this](double) { updateFreqLabel(); });
-    connect(m_slice, &SliceModel::tuneBlockedByLock,
-            this, &VfoWidget::showLockedFrequencyFeedback);
+    // Blocked tune: cancel any in-flight direct-entry (widget-local side
+    // effect), then let lockedFeedbackActiveChanged drive the LOCKED repaint.
+    connect(m_slice, &SliceModel::tuneBlockedByLock, this, [this] {
+        if (m_freqStack && m_freqStack->currentIndex() == 1)
+            cancelDirectEntry();
+    });
+    connect(m_slice, &SliceModel::lockedFeedbackActiveChanged,
+            this, [this](bool) { updateFreqLabel(); });
 
     // Per-client letter — refresh the slice badge when index_letter arrives
     // or changes (Multi-Flex sessions, see #2606).
@@ -2884,9 +2887,8 @@ void VfoWidget::setSlice(SliceModel* slice)
         m_lockVfoBtn->setText(locked ? "\xF0\x9F\x94\x92" : "\xF0\x9F\x94\x93");
         if (locked) {
             cancelDirectEntry();
-        } else {
-            clearLockedFrequencyFeedback();
         }
+        // Unlock clears the LOCKED overlay centrally in SliceModel (#2983).
     });
 
     // Restore collapsed state from AppSettings
@@ -3189,7 +3191,7 @@ void VfoWidget::syncFromSlice()
 void VfoWidget::updateFreqLabel()
 {
     if (!m_slice) return;
-    if (m_showingLockedFrequencyFeedback) {
+    if (m_slice->isLockedFeedbackActive()) {
         m_freqLabel->setText(QStringLiteral("LOCKED"));
         if (m_collapsed && m_collapsedFreqLabel) {
             m_collapsedFreqLabel->setText(QStringLiteral("LOCKED"));
@@ -3213,29 +3215,6 @@ void VfoWidget::updateFreqLabel()
         m_collapsedFreqLabel->setText(freqText);
         m_collapsedFreqLabel->adjustSize();
     }
-}
-
-void VfoWidget::showLockedFrequencyFeedback()
-{
-    if (!m_slice || !m_slice->isLocked())
-        return;
-
-    if (m_freqStack && m_freqStack->currentIndex() == 1)
-        cancelDirectEntry();
-
-    m_showingLockedFrequencyFeedback = true;
-    updateFreqLabel();
-    m_lockedFrequencyTimer.start(kLockedFrequencyFeedbackMs);
-}
-
-void VfoWidget::clearLockedFrequencyFeedback()
-{
-    if (!m_showingLockedFrequencyFeedback)
-        return;
-
-    m_lockedFrequencyTimer.stop();
-    m_showingLockedFrequencyFeedback = false;
-    updateFreqLabel();
 }
 
 void VfoWidget::updateFilterLabel()

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -145,8 +145,6 @@ private:
     void updateTxBadgeStyle(bool isTx);
     void showTab(int index);
     void updateFreqLabel();
-    void showLockedFrequencyFeedback();
-    void clearLockedFrequencyFeedback();
     bool cancelDirectEntry();
     void updateFilterLabel();
     void updateModeTab();
@@ -202,8 +200,6 @@ private:
     QLabel* m_freqLabel{nullptr};
     QLineEdit* m_freqEdit{nullptr};
     QStackedWidget* m_freqStack{nullptr};
-    QTimer m_lockedFrequencyTimer;
-    bool m_showingLockedFrequencyFeedback{false};
     QLabel* m_dbmLabel{nullptr};
     QString m_directEntrySource{"vfo-direct-entry"};
 

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -20,7 +20,19 @@ QStringList splitAntennaList(const QString& value)
 
 SliceModel::SliceModel(int id, QObject* parent)
     : QObject(parent), m_id(id)
-{}
+{
+    m_lockedFeedbackTimer.setSingleShot(true);
+    m_lockedFeedbackTimer.setInterval(kLockedFeedbackMs);
+    connect(&m_lockedFeedbackTimer, &QTimer::timeout,
+            this, [this] { setLockedFeedbackActive(false); });
+}
+
+void SliceModel::setLockedFeedbackActive(bool on)
+{
+    if (m_lockedFeedbackActive == on) return;
+    m_lockedFeedbackActive = on;
+    emit lockedFeedbackActiveChanged(on);
+}
 
 // ─── Setters ──────────────────────────────────────────────────────────────────
 
@@ -98,13 +110,21 @@ void SliceModel::setLocked(bool locked)
     // FlexAPI: "slice lock <id>" / "slice unlock <id>"
     sendCommand(locked ? QString("slice lock %1").arg(m_id)
                        : QString("slice unlock %1").arg(m_id));
+    if (!locked) {
+        m_lockedFeedbackTimer.stop();
+        setLockedFeedbackActive(false);
+    }
     emit lockedChanged(locked);
 }
 
 void SliceModel::notifyTuneBlockedByLock()
 {
-    if (m_locked)
-        emit tuneBlockedByLock();
+    if (!m_locked) return;
+    emit tuneBlockedByLock();
+    // Sustained 500ms gate so every consumer (VFO, RX applet, future
+    // status-bar / spectrum / hardware LED) repaints from one source.
+    setLockedFeedbackActive(true);
+    m_lockedFeedbackTimer.start();
 }
 
 void SliceModel::setQsk(bool on)
@@ -698,6 +718,10 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
     // Status key is "lock" (not "locked") per FlexAPI
     if (kvs.contains("lock")) {
         m_locked = kvs["lock"] == "1";
+        if (!m_locked) {
+            m_lockedFeedbackTimer.stop();
+            setLockedFeedbackActive(false);
+        }
         emit lockedChanged(m_locked);
     }
     if (kvs.contains("qsk")) {

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QStringList>
 #include <QMap>
+#include <QTimer>
 
 namespace AetherSDR {
 
@@ -126,6 +127,15 @@ public:
     void setTxAntenna(const QString& ant);
     void setLocked(bool locked);
     void notifyTuneBlockedByLock();
+
+    // Centralized 500ms "LOCKED" visual-feedback gate (see #2983).
+    // Widgets that render a sustained LOCKED overlay connect to
+    // lockedFeedbackActiveChanged() and read isLockedFeedbackActive() in
+    // their repaint paths. Widgets that only need a one-shot reaction to a
+    // blocked tune attempt (e.g. cancel direct-entry, status-bar message)
+    // continue to use tuneBlockedByLock().
+    bool isLockedFeedbackActive() const { return m_lockedFeedbackActive; }
+    static constexpr int kLockedFeedbackMs = 500;
     void setQsk(bool on);
     void setNb(bool on);
     void setNr(bool on);
@@ -199,6 +209,7 @@ signals:
     void txAntennaListChanged(const QStringList& ants);
     void lockedChanged(bool locked);
     void tuneBlockedByLock();
+    void lockedFeedbackActiveChanged(bool active);
     void qskChanged(bool on);
     void nbChanged(bool on);
     void nrChanged(bool on);
@@ -337,6 +348,13 @@ private:
     bool    m_recordOn{false};
     bool    m_playOn{false};
     bool    m_playEnabled{false};
+
+    // Centralized LOCKED feedback gate — single source of truth for
+    // widgets rendering the "LOCKED" overlay after a blocked tune (#2983).
+    QTimer  m_lockedFeedbackTimer;
+    bool    m_lockedFeedbackActive{false};
+
+    void setLockedFeedbackActive(bool on);
 
     void sendCommand(const QString& cmd);
 


### PR DESCRIPTION
## Summary

Implements #2983. Moves the 500ms LOCKED visual-feedback gate from per-widget timers in `VfoWidget` and `RxApplet` to a single `QTimer` in `SliceModel`.

Before: each widget had its own `m_lockedFrequencyTimer` + `m_showingLockedFrequencyFeedback` bool. Two timers, two state mirrors, same UX concept.

After: one timer + one bool on `SliceModel`. New signal `lockedFeedbackActiveChanged(bool)` drives repaint; the existing `tuneBlockedByLock()` keeps its one-shot semantics for per-event side effects (cancel direct-entry, future status-bar ack — see #2984). `setLocked(false)` and `applyStatus("lock=0")` both clear feedback centrally.

## Why this is worth doing

- One state variable for "is feedback active" — no risk of widgets drifting out of sync.
- Future consumers (spectrum-widget VFO marker, hardware controller LED, status bar) connect to one signal, not two.
- Simpler clean-up: `setSlice()` no longer needs to manually clear per-widget state when swapping slices.

## Stats

- 6 files changed, **+73 / -83**
- Drops 2 `QTimer` members + 2 mirrored `bool` flags + 2 `static constexpr` 500ms constants across the widget pair.
- Adds 1 `QTimer` + 1 `bool` + 1 `kLockedFeedbackMs` on `SliceModel`.

## Test plan

- [x] Clean build (680 targets, 0 warnings)
- [x] Full test suite passes (18/18)
- [ ] Manual: lock slice via RX applet ⇒ scroll-wheel tune ⇒ both VFO and RX freq label show "LOCKED" together for 500ms, then both clear.
- [ ] Manual: lock slice ⇒ keyboard/MIDI tune ⇒ same as above.
- [ ] Manual: lock slice ⇒ blocked tune ⇒ unlock immediately ⇒ overlay clears immediately (doesn't sit for the remainder of 500ms).
- [ ] Manual: VFO direct-entry open ⇒ blocked tune attempt ⇒ direct-entry cancels, LOCKED shows.

Closes #2983.

🤖 Generated with [Claude Code](https://claude.com/claude-code)