### PR TITLE
refactor(band-plan): share contiguous-regions walker for ATU + SWR sweep

### DIFF
--- a/src/gui/AtuPreTuneDialog.cpp
+++ b/src/gui/AtuPreTuneDialog.cpp
@@ -77,55 +77,34 @@ int pointsForRange(double lowMhz, double highMhz, int segmentKhz)
     return computeCenters(lowMhz, highMhz, segmentKhz).size();
 }
 
-// Walk the matching segments per contiguous region so discrete-channel
-// bands (US 60m: 6 USB channels at 2.8 kHz each, separated by ~30 kHz of
-// gap) generate one tune-center per legal channel instead of stepping
-// across illegal gaps and triggering radio-side out-of-band rejections.
-// Continuous bands (single segment, or contiguous segments) collapse into
-// one [min, max] region and use the original even-stride walk. (#2647)
+// Walk each contiguous region from BandPlanManager (which already merges
+// adjacent segments — see #2822) and produce tune centers per region. On
+// discrete-channel bands (US 60m: 5 USB channels at 2.8 kHz each separated
+// by tens of kHz of gap) this generates one tune-center per legal channel
+// instead of stepping across illegal gaps and triggering radio-side
+// out-of-band rejections. On continuous bands the merge collapses to a
+// single [min, max] region and the walk degenerates to the original
+// even-stride walk. (#2647)
 QVector<double> computeCentersForBand(
-    const QVector<BandPlanManager::Segment>& segments,
+    const BandPlanManager& bandPlan,
     double searchLowMhz, double searchHighMhz, int segmentKhz)
 {
     QVector<double> out;
     if (segmentKhz <= 0) return out;
 
-    // Pass 1: collect matching segments (midpoint in search window).
-    struct Region { double lo; double hi; };
-    QVector<Region> regions;
-    for (const auto& seg : segments) {
-        const double mid = (seg.lowMhz + seg.highMhz) / 2.0;
-        if (mid >= searchLowMhz && mid <= searchHighMhz) {
-            regions.append({seg.lowMhz, seg.highMhz});
-        }
-    }
+    const auto regions = bandPlan.contiguousRegionsForBand(searchLowMhz, searchHighMhz);
     if (regions.isEmpty()) return out;
 
-    // Pass 2: sort and merge contiguous regions (treat adjacent or
-    // overlapping segments as one continuous range).
-    std::sort(regions.begin(), regions.end(),
-              [](const Region& a, const Region& b) { return a.lo < b.lo; });
-    QVector<Region> merged;
-    merged.append(regions.front());
-    constexpr double kAdjacencyEpsMhz = 1.0e-6;  // 1 Hz
-    for (int i = 1; i < regions.size(); ++i) {
-        if (regions[i].lo <= merged.last().hi + kAdjacencyEpsMhz) {
-            merged.last().hi = std::max(merged.last().hi, regions[i].hi);
-        } else {
-            merged.append(regions[i]);
-        }
-    }
-
-    // Pass 3: per merged region, walk centers.  If a region is narrower
-    // than one full tune segment (e.g. US 60m's 2.8 kHz channel vs 9 kHz
-    // segment), emit a single midpoint so the ATU still tunes that
-    // channel; computeCenters() returns empty for narrow ranges.
+    // If a region is narrower than one full tune segment (e.g. US 60m's
+    // 2.8 kHz channel vs 9 kHz segment), emit a single midpoint so the
+    // ATU still tunes that channel; computeCenters() returns empty for
+    // narrow ranges.
     const double segMhz = segmentKhz / 1000.0;
-    for (const auto& r : merged) {
-        if (r.hi - r.lo < segMhz) {
-            out.append((r.lo + r.hi) / 2.0);
+    for (const auto& r : regions) {
+        if (r.highMhz - r.lowMhz < segMhz) {
+            out.append((r.lowMhz + r.highMhz) / 2.0);
         } else {
-            out.append(computeCenters(r.lo, r.hi, segmentKhz));
+            out.append(computeCenters(r.lowMhz, r.highMhz, segmentKhz));
         }
     }
     return out;
@@ -356,7 +335,7 @@ void AtuPreTuneDialog::populateBands()
         // (US 60m) get one center per legal channel instead of stepping
         // across illegal gaps. (#2647)  Display low/high still show the
         // envelope so the operator sees the band's overall coverage.
-        row.centers = computeCentersForBand(segments,
+        row.centers = computeCentersForBand(*m_bandPlan,
                                             spec.searchLowMhz,
                                             spec.searchHighMhz,
                                             row.segmentKhz);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -14288,21 +14288,20 @@ void MainWindow::startSwrSweep(int requestedSliceId, int sweepPowerWatts)
     // sweep transmits outside the user's region (e.g. past 7.200 MHz on
     // 40 m for IARU R1) and trips the radio's interlock.  Mirrors the
     // pattern used by AtuPreTuneDialog::recomputeBands. (#2800)
+    //
+    // Today the SWR sweep treats the band as a single contiguous range —
+    // discrete-channel bands like US 60 m are hard-blocked above. We use
+    // contiguousRegionsForBand() (#2822) and union the regions so a
+    // future enhancement can walk each region individually without
+    // touching the per-region calculation.
     double effectiveLow = band.lowMhz;
     double effectiveHigh = band.highMhz;
     if (m_bandPlanMgr) {
-        double planLow = std::numeric_limits<double>::infinity();
-        double planHigh = -std::numeric_limits<double>::infinity();
-        for (const auto& seg : m_bandPlanMgr->segments()) {
-            const double mid = (seg.lowMhz + seg.highMhz) / 2.0;
-            if (mid >= band.lowMhz && mid <= band.highMhz) {
-                planLow = std::min(planLow, seg.lowMhz);
-                planHigh = std::max(planHigh, seg.highMhz);
-            }
-        }
-        if (std::isfinite(planLow) && std::isfinite(planHigh) && planHigh > planLow) {
-            effectiveLow = std::max(effectiveLow, planLow);
-            effectiveHigh = std::min(effectiveHigh, planHigh);
+        const auto regions =
+            m_bandPlanMgr->contiguousRegionsForBand(band.lowMhz, band.highMhz);
+        if (!regions.isEmpty()) {
+            effectiveLow = std::max(effectiveLow, regions.first().lowMhz);
+            effectiveHigh = std::min(effectiveHigh, regions.last().highMhz);
         }
     }
 

--- a/src/models/BandPlanManager.cpp
+++ b/src/models/BandPlanManager.cpp
@@ -7,6 +7,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 
+#include <algorithm>
+
 namespace AetherSDR {
 
 BandPlanManager::BandPlanManager(QObject* parent)
@@ -60,6 +62,33 @@ QStringList BandPlanManager::availablePlans() const
     for (const auto& p : m_plans)
         names << p.name;
     return names;
+}
+
+QVector<BandPlanManager::Region>
+BandPlanManager::contiguousRegionsForBand(double searchLowMhz,
+                                         double searchHighMhz) const
+{
+    QVector<Region> regions;
+    for (const auto& seg : m_segments) {
+        const double mid = (seg.lowMhz + seg.highMhz) / 2.0;
+        if (mid >= searchLowMhz && mid <= searchHighMhz)
+            regions.append({seg.lowMhz, seg.highMhz});
+    }
+    if (regions.isEmpty()) return regions;
+
+    std::sort(regions.begin(), regions.end(),
+              [](const Region& a, const Region& b) { return a.lowMhz < b.lowMhz; });
+    QVector<Region> merged;
+    merged.append(regions.front());
+    constexpr double kAdjacencyEpsMhz = 1.0e-6;  // 1 Hz
+    for (int i = 1; i < regions.size(); ++i) {
+        if (regions[i].lowMhz <= merged.last().highMhz + kAdjacencyEpsMhz) {
+            merged.last().highMhz = std::max(merged.last().highMhz, regions[i].highMhz);
+        } else {
+            merged.append(regions[i]);
+        }
+    }
+    return merged;
 }
 
 bool BandPlanManager::loadPlanFromJson(const QString& path, PlanData& out)

--- a/src/models/BandPlanManager.h
+++ b/src/models/BandPlanManager.h
@@ -27,6 +27,18 @@ public:
         QString label;
     };
 
+    // A contiguous, gap-free [low, high] band region produced by merging the
+    // active plan's segments. Discrete-channel bands (e.g. US 60 m: 5
+    // channels separated by tens of kHz of regulatory gap) collapse to one
+    // Region per legal channel; continuous bands collapse to a single
+    // Region spanning the band's regulatory edges. Consumers that need
+    // gap-aware TX walking (ATU pre-tune, SWR sweep) read these instead of
+    // a naive min/max across segments(). (#2822)
+    struct Region {
+        double lowMhz;
+        double highMhz;
+    };
+
     explicit BandPlanManager(QObject* parent = nullptr);
 
     // Load all bundled plans from Qt resources
@@ -40,6 +52,14 @@ public:
 
     // Available plans (display names)
     QStringList availablePlans() const;
+
+    // Walk the active plan's segments whose midpoint falls inside
+    // [searchLowMhz, searchHighMhz], sort by low edge, and merge adjacent
+    // or overlapping segments (1 Hz adjacency tolerance) into contiguous
+    // regions. Returns regions sorted by ascending lowMhz. Empty if no
+    // segment matches. (#2822)
+    QVector<Region> contiguousRegionsForBand(double searchLowMhz,
+                                             double searchHighMhz) const;
 
 signals:
     void planChanged();


### PR DESCRIPTION
## Summary

Closes #2822. Extracts the segment-collect + sort-and-merge contiguous-region computation from `AtuPreTuneDialog`'s private `computeCentersForBand()` into a public `BandPlanManager::contiguousRegionsForBand(low, high)` so the same discrete-channel awareness is available to other band-plan-aware features.

## What the helper does

For a `[searchLow, searchHigh]` window, returns the active plan's matching segments merged into contiguous `[low, high]` regions (1 Hz adjacency tolerance), sorted by ascending low edge.

- **Continuous bands** (40 m, 20 m, etc.) → one region spanning the band's regulatory edges.
- **Discrete-channel bands** (US 60 m: 5 USB channels at 2.8 kHz each separated by tens of kHz of gap) → one region per legal channel.

## Call sites

- `AtuPreTuneDialog::recomputeBands` now delegates region math to the helper. Per-region center walk + narrow-region midpoint fallback (US 60 m's 2.8 kHz channel vs 9 kHz segment) preserved verbatim.
- `MainWindow::startSwrSweep` replaces its ad-hoc `min(lowMhz)` / `max(highMhz)` walk with `contiguousRegionsForBand() + first.lowMhz / last.highMhz`. Envelope is identical because regions are sorted by low edge after merge — the first region's low IS the global min, the last region's high IS the global max.

## What this does NOT change

The 60 m channelized hard-block in `startSwrSweep` stays intact. The issue's stretch goal (walk each region individually for true discrete-channel SWR sweeping) needs on-air safety review and was explicitly out of scope for this mechanical refactor.

## Stats

- 4 files, **+79 / -52**
- Drops a private 50-line helper, adds a 20-line public method.
- 18/18 tests pass (no test changes — the math hasn't changed, only its location).

## Test plan

- [x] Clean build, 0 warnings
- [x] `atu_pretune_centers_test` still green
- [ ] Manual: ATU Pre-Tune sweep on US 60 m — still emits 5 tune centers, one per channel
- [ ] Manual: ATU Pre-Tune sweep on IARU R1 40 m — still narrows to 7.000–7.200 MHz envelope
- [ ] Manual: SWR sweep on IARU R1 40 m — still narrows to plan's edges, completes successfully
- [ ] Manual: SWR sweep on US 60 m — still blocked with the channelized-band warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)