### PR TITLE
feat(gui): status-bar toast on blocked tune via locked slice

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9873,6 +9873,16 @@ void MainWindow::onSliceAdded(SliceModel* s)
     };
     connect(s, &SliceModel::modeChanged, this, updateDaxTxMode);
     connect(s, &SliceModel::txSliceChanged, this, updateDaxTxMode);
+
+    // Status-bar toast on the first blocked tune of a sustained sequence.
+    // Driven by SliceModel's lockedFeedbackActiveChanged (false→true edge),
+    // which gives natural dedup — a stuck MIDI knob or held keyboard arrow
+    // generates one toast, not one per event. The on-screen LOCKED overlay
+    // on the VFO/RX freq label handles the per-event visual feedback. (#2984)
+    connect(s, &SliceModel::lockedFeedbackActiveChanged, this, [this](bool active) {
+        if (active)
+            statusBar()->showMessage(tr("Slice is locked — unlock to tune."), 3000);
+    });
     updateDaxTxMode();  // set initial state from current TX slice mode
 
     // Push overlay for this slice to the spectrum widget


### PR DESCRIPTION
## Summary

Implements #2984. Wires `MainWindow::onSliceAdded()` to the new `SliceModel::lockedFeedbackActiveChanged` signal (from #2983 / #3017) so a 3-second status-bar message fires on the first blocked tune of a sustained sequence:

> Slice is locked — unlock to tune.

## Why this is the option-2 path

The issue listed two approaches: per-path latches in `nudgeFreq` / `rx.tuneKnob` / HID coalesce, or driving the message off a single SliceModel signal. With #2983 landed, the signal route is one connection, automatic dedup (only fires on the false→true edge), and naturally covers every current and future blocked-tune entry point — no per-call-site latch state.

## Dedup behavior

`lockedFeedbackActiveChanged(true)` fires once when the LOCKED feedback gate goes active. The 500 ms timer in SliceModel keeps the gate active across rapid repeated blocked attempts (stuck MIDI knob, held arrow key), so a burst gives **one toast at the start**, not one per event. When the timer expires without another block, the gate clears; the next blocked attempt re-triggers a fresh toast.

## Scope

- 1 file, +10 / -0
- No new state in MainWindow
- Same message for keyboard / MIDI / HID / wheel / direct-entry / band-shortcut paths — operator knows which input they used; the message just surfaces the lock cause
- Matches the existing memory-recall lock toast pattern in MainWindow.cpp

## Test plan

- [x] Clean build, 0 warnings
- [ ] Manual: lock slice, scroll-wheel tune ⇒ LOCKED overlay shows AND status-bar toast appears
- [ ] Manual: lock slice, hold keyboard right-arrow for 2s ⇒ overlay shows continuously, ONE toast at start (not spammed)
- [ ] Manual: lock slice, spin MIDI tune knob ⇒ same as above
- [ ] Manual: unlock slice, scroll-tune ⇒ no toast (gate didn't activate)

Closes #2984.

🤖 Generated with [Claude Code](https://claude.com/claude-code)