### PR TITLE
fix(applet-panel): prevent right-side clipping of applet content when scrollbar is visible

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -390,7 +390,21 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     connect(m_scrollDimTimer, &QTimer::timeout, this,
             [this]() { setScrollHandleActive(false); });
 
-    auto* container = new QWidget;
+    // Override sizeHint/minimumSizeHint so QScrollArea::setWidgetResizable
+    // always sizes this container to the viewport width rather than "sticking"
+    // at the AppletPanel's fixed width (260px).  Without this, the VBox layout's
+    // sizeHint stays at 260px after the initial layout pass, and the 12px
+    // scrollbar track (always visible) pushes the viewport to 248px — but Qt
+    // keeps the container at max(248, sizeHint=260)=260px, silently clipping
+    // the right 12px of every applet header (including the × close button).
+    struct FlexContainer : QWidget {
+        using QWidget::QWidget;
+        QSize sizeHint() const override
+            { return QSize(0, QWidget::sizeHint().height()); }
+        QSize minimumSizeHint() const override
+            { return QSize(0, QWidget::minimumSizeHint().height()); }
+    };
+    auto* container = new FlexContainer;
     m_stack = new QVBoxLayout(container);
     m_stack->setContentsMargins(0, 0, 0, 0);
     m_stack->setSpacing(0);


### PR DESCRIPTION
Fixes #3022 (regression of #1948).

## Summary

- The always-visible 12 px QSS scrollbar track (introduced in `60c291b`) reduces the scroll area viewport to 248 px, but `QScrollArea::setWidgetResizable` kept the content container at 260 px because the VBox layout's `sizeHint()` was stuck at the AppletPanel's fixed width from the initial layout pass — silently clipping the right 12 px of every applet header and control.
- Fix: replace the plain `QWidget` scroll container with a local `FlexContainer` subclass that returns `width = 0` from `sizeHint()` / `minimumSizeHint()`, so `setWidgetResizable` always sizes it to the actual viewport width. Height hints are forwarded to the base class unchanged, preserving correct vertical scroll behaviour.

## Test plan

- [x] Enable a small set of applets (no scrollbar visible) — × and ⧉ buttons fully visible in all title bars
- [x] Enable enough applets to overflow the panel — scrollbar appears, all content scrolls correctly, buttons remain visible
- [x] Toggle applet panel between left-docked and right-docked — no truncation in either position
- [x] Verified on macOS (overlay scrollbars) ✅
- [x] Verified on Linux / Raspberry Pi 5 (non-overlay scrollbars) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)