### PR TITLE
feat(audio): v26.5.3 — PAPR processor, split-band de-esser, peak hold

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(AetherSDR VERSION 26.5.2.1 LANGUAGES C CXX)
+project(AetherSDR VERSION 26.5.3 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -437,6 +437,7 @@ set(CORE_SOURCES
     src/core/ClientPudu.cpp
     src/core/ClientPuduMonitor.cpp
     src/core/ClientReverb.cpp
+    src/core/ClientPhaseRotator.cpp
     src/core/ClientFinalLimiter.cpp
     src/core/ClientTxTestTone.cpp
     src/core/ClientQuindarTone.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1311,6 +1311,7 @@ set_target_properties(client_eq_smoothing_test PROPERTIES AUTOMOC ON)
 add_executable(client_comp_test
     tests/client_comp_test.cpp
     src/core/ClientComp.cpp
+    src/core/ClientPhaseRotator.cpp
 )
 target_include_directories(client_comp_test PRIVATE src)
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1779,7 +1779,12 @@ void AudioEngine::applyClientEqTxFloat32(QByteArray& float32)
 
 void AudioEngine::applyClientCompTxInt16(QByteArray& int16stereo)
 {
-    if (!m_clientCompTx || !m_clientCompTx->isEnabled()) return;
+    if (!m_clientCompTx) return;
+    const bool compOn   = m_clientCompTx->isEnabled();
+    const bool driveOn  = m_clientCompTx->driveDb() > 0.0f;
+    const bool phaseOn  = m_clientCompTx->phaseRotatorStages() > 0;
+    const bool limOn    = m_clientCompTx->limiterEnabled();
+    if (!compOn && !driveOn && !phaseOn && !limOn) return;
     if (int16stereo.isEmpty()) return;
 
     const int samples = int16stereo.size() / static_cast<int>(sizeof(int16_t));
@@ -1802,7 +1807,16 @@ void AudioEngine::applyClientCompTxInt16(QByteArray& int16stereo)
 
 void AudioEngine::applyClientCompTxFloat32(QByteArray& float32)
 {
-    if (!m_clientCompTx || !m_clientCompTx->isEnabled()) return;
+    if (!m_clientCompTx) return;
+    // Drive and Phase (#2887) and the brickwall limiter inside the comp
+    // are useful even when the comp curve itself is bypassed, so the
+    // dispatch only short-circuits when none of the four sub-stages
+    // need to run.
+    const bool compOn   = m_clientCompTx->isEnabled();
+    const bool driveOn  = m_clientCompTx->driveDb() > 0.0f;
+    const bool phaseOn  = m_clientCompTx->phaseRotatorStages() > 0;
+    const bool limOn    = m_clientCompTx->limiterEnabled();
+    if (!compOn && !driveOn && !phaseOn && !limOn) return;
     if (float32.isEmpty()) return;
     const int samples  = float32.size() / static_cast<int>(sizeof(float));
     const int channels = (samples % 2 == 0) ? 2 : 1;
@@ -2608,6 +2622,10 @@ void AudioEngine::loadClientCompSettings()
         s.value("ClientCompTxLimEnabled", "True").toString() == "True");
     m_clientCompTx->setLimiterCeilingDb(
         s.value("ClientCompTxLimCeilingDb", "-1.0").toFloat());
+    m_clientCompTx->setDriveDb(
+        s.value("ClientCompTxDriveDb", "0.0").toFloat());
+    m_clientCompTx->setPhaseRotatorStages(
+        s.value("ClientCompTxPhaseRotatorStages", "0").toInt());
 
     // Load the generalised chain — stored as a comma-separated list of
     // stage names (e.g. "Gate,Eq,DeEss,Comp,Tube,Enh").  Migrate from
@@ -2661,6 +2679,10 @@ void AudioEngine::saveClientCompSettings() const
     s.setValue("ClientCompTxLimEnabled",  toBool(m_clientCompTx->limiterEnabled()));
     s.setValue("ClientCompTxLimCeilingDb",
                QString::number(m_clientCompTx->limiterCeilingDb()));
+    s.setValue("ClientCompTxDriveDb",
+               QString::number(m_clientCompTx->driveDb()));
+    s.setValue("ClientCompTxPhaseRotatorStages",
+               QString::number(m_clientCompTx->phaseRotatorStages()));
     // Chain stages persist as a comma-separated name list — already
     // written live by setTxChainStages() but re-emitted here so a
     // saveClientCompSettings() call dumps everything in sync.
@@ -2841,6 +2863,8 @@ void AudioEngine::loadClientDeEssSettings()
         s.value("ClientDeEssTxAttackMs", "1.0").toFloat());
     m_clientDeEssTx->setReleaseMs(
         s.value("ClientDeEssTxReleaseMs", "100.0").toFloat());
+    m_clientDeEssTx->setSlopeStages(
+        s.value("ClientDeEssTxSlopeStages", "2").toInt());
 }
 
 void AudioEngine::saveClientDeEssSettings() const
@@ -2862,6 +2886,8 @@ void AudioEngine::saveClientDeEssSettings() const
         QString::number(m_clientDeEssTx->attackMs()));
     s.setValue("ClientDeEssTxReleaseMs",
         QString::number(m_clientDeEssTx->releaseMs()));
+    s.setValue("ClientDeEssTxSlopeStages",
+        QString::number(m_clientDeEssTx->slopeStages()));
 }
 
 void AudioEngine::loadClientDeEssRxSettings()
@@ -2882,6 +2908,8 @@ void AudioEngine::loadClientDeEssRxSettings()
         s.value("ClientDeEssRxAttackMs", "1.0").toFloat());
     m_clientDeEssRx->setReleaseMs(
         s.value("ClientDeEssRxReleaseMs", "100.0").toFloat());
+    m_clientDeEssRx->setSlopeStages(
+        s.value("ClientDeEssRxSlopeStages", "2").toInt());
 }
 
 void AudioEngine::saveClientDeEssRxSettings() const
@@ -2903,6 +2931,8 @@ void AudioEngine::saveClientDeEssRxSettings() const
         QString::number(m_clientDeEssRx->attackMs()));
     s.setValue("ClientDeEssRxReleaseMs",
         QString::number(m_clientDeEssRx->releaseMs()));
+    s.setValue("ClientDeEssRxSlopeStages",
+        QString::number(m_clientDeEssRx->slopeStages()));
 }
 
 void AudioEngine::loadClientTubeSettings()

--- a/src/core/ClientComp.cpp
+++ b/src/core/ClientComp.cpp
@@ -1,5 +1,7 @@
 #include "ClientComp.h"
 
+#include "ClientPhaseRotator.h"
+
 #include <algorithm>
 #include <cmath>
 
@@ -28,13 +30,26 @@ float coeffFromMs(float ms, double sampleRate) noexcept
 
 } // namespace
 
-ClientComp::ClientComp() = default;
+ClientComp::ClientComp()
+    : m_phaseRotator(std::make_unique<ClientPhaseRotator>())
+{
+    // Phase rotator stays internally "always enabled" — its stages
+    // count gates whether it does anything (0 = pass-through). Drive
+    // is owned by ClientComp; the rotator runs unconditionally and is
+    // followed by the drive gain before the comp curve sees the signal.
+    m_phaseRotator->setEnabled(true);
+    m_phaseRotator->setStages(0);
+}
+
+ClientComp::~ClientComp() = default;
 
 void ClientComp::prepare(double sampleRate)
 {
     m_sampleRate = sampleRate;
     m_envLin     = 0.0f;
     m_limEnvLin  = 0.0f;
+
+    if (m_phaseRotator) m_phaseRotator->prepare(sampleRate);
 
     // Bump version so recacheIfDirty rebuilds coefficients on first block.
     m_atomics.version.fetch_add(1, std::memory_order_release);
@@ -122,6 +137,24 @@ void ClientComp::setLimiterCeilingDb(float db) noexcept
 float ClientComp::limiterCeilingDb() const noexcept
 { return m_atomics.limCeilingDb.load(std::memory_order_relaxed); }
 
+void ClientComp::setDriveDb(float db) noexcept
+{
+    m_atomics.driveDb.store(std::clamp(db, 0.0f, 18.0f),
+                            std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+float ClientComp::driveDb() const noexcept
+{ return m_atomics.driveDb.load(std::memory_order_relaxed); }
+
+void ClientComp::setPhaseRotatorStages(int stages) noexcept
+{
+    m_atomics.phaseRotatorStages.store(std::clamp(stages, 0, 6),
+                                       std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+int ClientComp::phaseRotatorStages() const noexcept
+{ return m_atomics.phaseRotatorStages.load(std::memory_order_relaxed); }
+
 void ClientComp::reset() noexcept
 {
     m_envLin = 0.0f;
@@ -162,6 +195,13 @@ void ClientComp::recacheIfDirty() noexcept
     // Limiter ballistics: very fast attack, moderately fast release.
     m_cached.limAttackCoeff  = coeffFromMs(0.1f, m_sampleRate);
     m_cached.limReleaseCoeff = coeffFromMs(50.0f, m_sampleRate);
+
+    m_cached.driveLin = dbToLin(
+        m_atomics.driveDb.load(std::memory_order_relaxed));
+    m_cached.phaseRotatorStages =
+        m_atomics.phaseRotatorStages.load(std::memory_order_relaxed);
+    if (m_phaseRotator)
+        m_phaseRotator->setStages(m_cached.phaseRotatorStages);
 }
 
 float ClientComp::staticCurveGainDb(float envDb) const noexcept
@@ -198,6 +238,24 @@ void ClientComp::process(float* interleaved, int frames, int channels) noexcept
     recacheIfDirty();
     const bool enabled = m_atomics.enabled.load(std::memory_order_acquire);
 
+    // Pre-comp PAPR shaping (#2887). The rotator runs first to
+    // symmetrize asymmetric voice peaks; the drive gain then pushes
+    // more material across the threshold so the existing comp curve
+    // engages harder and the brickwall limiter below contains the
+    // resulting hot peaks. These run independent of the comp's enabled
+    // flag — they're a useful pair even when the comp curve itself is
+    // bypassed (Drive + Limiter alone is the simplest broadcast PAPR
+    // setup). Their work happens *before* the input peak meter so the
+    // GR readout reflects the comp's workload at the boosted level.
+    if (m_cached.phaseRotatorStages > 0 && m_phaseRotator) {
+        m_phaseRotator->process(interleaved, frames, channels);
+    }
+    if (m_cached.driveLin != 1.0f) {
+        const float gain = m_cached.driveLin;
+        const int n = frames * channels;
+        for (int i = 0; i < n; ++i) interleaved[i] *= gain;
+    }
+
     float inPeakLin  = 0.0f;
     float outPeakLin = 0.0f;
     float worstGrDb  = 0.0f;  // most negative (largest reduction)
@@ -230,7 +288,14 @@ void ClientComp::process(float* interleaved, int frames, int channels) noexcept
             const float envDb = linToDb(std::max(m_envLin, 1e-6f));
             const float gainDb = staticCurveGainDb(envDb);
             if (gainDb < worstGrDb) worstGrDb = gainDb;
-            gainLin = dbToLin(gainDb) * makeup;
+            // Auto-makeup tracks Drive (#2887). Without this, dialing
+            // Drive up makes the comp do more GR than the fixed Makeup
+            // can compensate, and net RMS DROPS. Linking the post-curve
+            // gain to Drive matches the broadcast-Optimod model: Drive
+            // pushes more material into the curve AND adds equal gain
+            // back at the output, so the user's fixed Makeup setting
+            // stays a clean "post-everything trim" knob.
+            gainLin = dbToLin(gainDb) * makeup * m_cached.driveLin;
         }
         l *= gainLin;
         r *= gainLin;

--- a/src/core/ClientComp.h
+++ b/src/core/ClientComp.h
@@ -2,8 +2,11 @@
 
 #include <atomic>
 #include <cstdint>
+#include <memory>
 
 namespace AetherSDR {
+
+class ClientPhaseRotator;
 
 // Client-side TX dynamics processor — the foundation of the Pro-XL-style
 // compression chain (#1661).  Phase 1 scope: core feed-forward compressor
@@ -22,7 +25,7 @@ namespace AetherSDR {
 class ClientComp {
 public:
     ClientComp();
-    ~ClientComp() = default;
+    ~ClientComp();
 
     ClientComp(const ClientComp&)            = delete;
     ClientComp& operator=(const ClientComp&) = delete;
@@ -54,6 +57,20 @@ public:
     void  setLimiterCeilingDb(float db) noexcept;
     float limiterCeilingDb() const noexcept;
 
+    // Pre-comp Drive (#2887). Linear gain in dB applied BEFORE the
+    // compressor sees the signal. Pushes more material across the
+    // threshold so the comp engages harder, raising RMS while the
+    // existing limiter holds peaks. 0 dB = bypass.
+    void  setDriveDb(float db) noexcept;          // 0 .. 18 dB
+    float driveDb() const noexcept;
+
+    // Pre-comp phase rotator (#2887). Cascade of N second-order all-pass
+    // filters at staggered audio centres — symmetrizes asymmetric voice
+    // peaks so the harder compression and downstream limiting don't
+    // sound trashy. 0 = off (bypass), 4 = broadcast default, 6 = max.
+    void  setPhaseRotatorStages(int stages) noexcept;
+    int   phaseRotatorStages() const noexcept;
+
     // Audio thread — process in place.  channels must be 1 or 2.
     void process(float* interleaved, int frames, int channels) noexcept;
 
@@ -82,6 +99,8 @@ private:
         std::atomic<float>    makeupDb{0.0f};
         std::atomic<bool>     limEnabled{true};
         std::atomic<float>    limCeilingDb{-1.0f};
+        std::atomic<float>    driveDb{0.0f};
+        std::atomic<int>      phaseRotatorStages{0};
         std::atomic<uint64_t> version{0};
     };
 
@@ -96,6 +115,8 @@ private:
         float limCeilingLin{0.891f};       // 10^(-1/20)
         float limAttackCoeff{0.0f};
         float limReleaseCoeff{0.0f};
+        float driveLin{1.0f};              // 10^(driveDb / 20)
+        int   phaseRotatorStages{0};
     };
 
     // Meter snapshots — atomic stores on the audio thread after each
@@ -124,6 +145,11 @@ private:
     // the peak (average of log|sin|), which is wrong for a peak compressor.
     float    m_envLin{0.0f};
     float    m_limEnvLin{0.0f};       // limiter envelope (linear)
+
+    // Pre-compressor phase rotator (#2887). Owned here so the comp's
+    // Drive + Phase + threshold + ratio + ceiling all act as a single
+    // PAPR-reducing block on the chain's COMP card.
+    std::unique_ptr<ClientPhaseRotator> m_phaseRotator;
 };
 
 } // namespace AetherSDR

--- a/src/core/ClientDeEss.cpp
+++ b/src/core/ClientDeEss.cpp
@@ -131,11 +131,22 @@ void ClientDeEss::setReleaseMs(float ms) noexcept
 float ClientDeEss::releaseMs() const noexcept
 { return m_atomics.releaseMs.load(std::memory_order_relaxed); }
 
+void ClientDeEss::setSlopeStages(int stages) noexcept
+{
+    m_atomics.slopeStages.store(std::clamp(stages, 1, kMaxSlopeStages),
+                                std::memory_order_relaxed);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+int ClientDeEss::slopeStages() const noexcept
+{ return m_atomics.slopeStages.load(std::memory_order_relaxed); }
+
 void ClientDeEss::reset() noexcept
 {
     m_envLin = 0.0f;
-    m_bpL = {};
-    m_bpR = {};
+    for (int i = 0; i < kMaxSlopeStages; ++i) {
+        m_bpL[i] = {};
+        m_bpR[i] = {};
+    }
 }
 
 float ClientDeEss::inputPeakDb() const noexcept
@@ -164,6 +175,9 @@ void ClientDeEss::recacheIfDirty() noexcept
         m_atomics.attackMs.load(std::memory_order_relaxed), m_sampleRate);
     m_cached.releaseCoeff = coeffFromMs(
         m_atomics.releaseMs.load(std::memory_order_relaxed), m_sampleRate);
+    m_cached.slopeStages = std::clamp(
+        m_atomics.slopeStages.load(std::memory_order_relaxed),
+        1, kMaxSlopeStages);
 }
 
 float ClientDeEss::staticCurveGainDb(float envDb) const noexcept
@@ -203,11 +217,22 @@ void ClientDeEss::process(float* interleaved, int frames, int channels) noexcept
         const float inAbs = std::max(std::fabs(l), std::fabs(r));
         if (inAbs > inPeakLin) inPeakLin = inAbs;
 
-        // Sidechain: run the full signal through the bandpass filter
-        // per channel.  The filters stay live even when disabled so
-        // their state is warm if the user toggles enable.
-        const float scL = processBiquad(l, bp, m_bpL);
-        const float scR = (channels == 2) ? processBiquad(r, bp, m_bpR) : scL;
+        // Sidechain: cascade N bandpass biquads per channel where N
+        // is the user-selectable slope-stage count (1..kMaxSlopeStages).
+        // Each stage adds 12 dB/oct of rolloff, so the de-esser
+        // notch can be dialled from broad (1 stage, 12 dB/oct) to
+        // surgical (4 stages, 48 dB/oct). Filters stay live even
+        // when disabled so their state is warm if the user toggles
+        // enable.
+        float scL = l;
+        float scR = (channels == 2) ? r : l;
+        const int stages = m_cached.slopeStages;
+        for (int s = 0; s < stages; ++s) {
+            scL = processBiquad(scL, bp, m_bpL[s]);
+            if (channels == 2)
+                scR = processBiquad(scR, bp, m_bpR[s]);
+        }
+        if (channels != 2) scR = scL;
         const float scAbs = std::max(std::fabs(scL), std::fabs(scR));
         if (scAbs > scPeakLin) scPeakLin = scAbs;
 
@@ -223,8 +248,21 @@ void ClientDeEss::process(float* interleaved, int frames, int channels) noexcept
             gainLin = dbToLin(gainDb);
         }
 
-        l *= gainLin;
-        r *= gainLin;
+        // Split-band de-essing: only attenuate the sibilant band
+        // (the bandpass output), leave lows + mids untouched. The
+        // bandpass is a constant-0-dB-peak filter, so subtracting
+        // bp*(1-gain) from the full signal reduces only the 4-8 kHz
+        // slice by the gain amount. The original broadband-attenuate
+        // implementation pulled the whole signal down on sibilance,
+        // crashing RMS during S-heavy phrases.
+        //   output = full + bp * (gain - 1)
+        // gain = 1  → output = full       (no change, perfect pass-through)
+        // gain = 0.5→ output = full - 0.5*bp (HF band reduced by 6 dB)
+        if (enabled && gainLin < 0.9999f) {
+            const float scGainDelta = gainLin - 1.0f;
+            l += scL * scGainDelta;
+            r += scR * scGainDelta;
+        }
         interleaved[f * channels] = l;
         if (channels == 2) interleaved[f * channels + 1] = r;
     }

--- a/src/core/ClientDeEss.h
+++ b/src/core/ClientDeEss.h
@@ -54,6 +54,16 @@ public:
     void  setReleaseMs(float ms) noexcept;           // 10..500 ms
     float releaseMs() const noexcept;
 
+    // Sidechain / split-band filter slope (#2887). Each cascade stage
+    // adds 12 dB/oct of rolloff, so the user-facing values are:
+    //   1 → 12 dB/oct,  2 → 24 dB/oct,
+    //   3 → 36 dB/oct,  4 → 48 dB/oct.
+    // Higher slope = narrower effective notch around the centre
+    // frequency = de-esser hits sibilants without eating mids.
+    static constexpr int kMaxSlopeStages = 4;
+    void  setSlopeStages(int stages) noexcept;       // 1..4
+    int   slopeStages() const noexcept;
+
     // Audio thread — process in place.  channels must be 1 or 2.
     void process(float* interleaved, int frames, int channels) noexcept;
 
@@ -86,6 +96,7 @@ private:
         std::atomic<float>    amountDb{-6.0f};
         std::atomic<float>    attackMs{1.0f};
         std::atomic<float>    releaseMs{100.0f};
+        std::atomic<int>      slopeStages{2};   // default 24 dB/oct
         std::atomic<uint64_t> version{0};
     };
 
@@ -95,6 +106,7 @@ private:
         float amountDb{-6.0f};       // negative — max attenuation
         float attackCoeff{0.0f};
         float releaseCoeff{0.0f};
+        int   slopeStages{2};
     };
 
     struct Meters {
@@ -113,8 +125,13 @@ private:
 
     // Audio-thread state — accessed only from process().
     uint64_t m_lastVersion{0};
-    BiquadState m_bpL{};
-    BiquadState m_bpR{};
+    // Up to kMaxSlopeStages cascaded bandpass biquads per channel.
+    // Each stage adds 12 dB/oct of rolloff outside the band, so the
+    // user can dial the de-esser between a wide (12 dB/oct) and a
+    // surgical (48 dB/oct) sibilant cut without touching Q. Peak
+    // remains 0 dB at centre frequency at any stage count.
+    BiquadState m_bpL[kMaxSlopeStages]{};
+    BiquadState m_bpR[kMaxSlopeStages]{};
     float m_envLin{0.0f};
 };
 

--- a/src/core/ClientPhaseRotator.cpp
+++ b/src/core/ClientPhaseRotator.cpp
@@ -1,0 +1,151 @@
+#include "ClientPhaseRotator.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+constexpr float kMinusInfDb = -120.0f;
+
+float linToDb(float lin) noexcept
+{
+    if (lin <= 1e-7f) return kMinusInfDb;
+    return 20.0f * std::log10(lin);
+}
+} // namespace
+
+ClientPhaseRotator::ClientPhaseRotator()
+{
+    designSections();
+}
+
+void ClientPhaseRotator::prepare(double sampleRate)
+{
+    m_sampleRate = sampleRate > 0.0 ? sampleRate : 24000.0;
+    designSections();
+    reset();
+}
+
+void ClientPhaseRotator::setEnabled(bool on) noexcept
+{
+    m_atomics.enabled.store(on, std::memory_order_release);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+
+bool ClientPhaseRotator::isEnabled() const noexcept
+{
+    return m_atomics.enabled.load(std::memory_order_acquire);
+}
+
+void ClientPhaseRotator::setStages(int stages) noexcept
+{
+    const int clamped = std::clamp(stages, 0, kMaxStages);
+    m_atomics.stages.store(clamped, std::memory_order_release);
+    m_atomics.version.fetch_add(1, std::memory_order_release);
+}
+
+int ClientPhaseRotator::stages() const noexcept
+{
+    return m_atomics.stages.load(std::memory_order_acquire);
+}
+
+float ClientPhaseRotator::inputPosPeakDb()  const noexcept { return m_meters.inPosDb.load(std::memory_order_relaxed); }
+float ClientPhaseRotator::inputNegPeakDb()  const noexcept { return m_meters.inNegDb.load(std::memory_order_relaxed); }
+float ClientPhaseRotator::outputPosPeakDb() const noexcept { return m_meters.outPosDb.load(std::memory_order_relaxed); }
+float ClientPhaseRotator::outputNegPeakDb() const noexcept { return m_meters.outNegDb.load(std::memory_order_relaxed); }
+
+void ClientPhaseRotator::reset() noexcept
+{
+    for (auto& s : m_sections) {
+        s.x1[0] = s.x1[1] = 0.0f;
+        s.x2[0] = s.x2[1] = 0.0f;
+        s.y1[0] = s.y1[1] = 0.0f;
+        s.y2[0] = s.y2[1] = 0.0f;
+    }
+}
+
+void ClientPhaseRotator::designSections() noexcept
+{
+    // Second-order all-pass coefficients per RBJ cookbook, but the
+    // canonical AP form whose magnitude is exactly 1 at every frequency.
+    // For a centre frequency f0 and Q, the pole/zero pair sits on a
+    // common radius with mirrored arguments — the standard analog-to-
+    // digital bilinear-transform derivation gives:
+    //   w0 = 2π f0 / fs
+    //   alpha = sin(w0) / (2 Q)
+    //   a0 = 1 + alpha,  a1 = -2 cos(w0),  a2 = 1 - alpha
+    //   b0 = a2,         b1 = a1,          b2 = a0
+    // After normalising by a0, the all-pass numerator coefficients equal
+    // the reversed denominator coefficients — which is the standard form
+    // captured in the AllPass struct comment.
+    const double fs = m_sampleRate > 0.0 ? m_sampleRate : 24000.0;
+    for (int i = 0; i < kMaxStages; ++i) {
+        const double f0 = kCentreHz[i];
+        const double w0 = 2.0 * M_PI * f0 / fs;
+        const double alpha = std::sin(w0) / (2.0 * kQ);
+        const double a0 = 1.0 + alpha;
+        const double a1 = -2.0 * std::cos(w0);
+        const double a2 = 1.0 - alpha;
+        m_sections[i].a1 = static_cast<float>(a1 / a0);
+        m_sections[i].a2 = static_cast<float>(a2 / a0);
+    }
+}
+
+void ClientPhaseRotator::recacheIfDirty() noexcept
+{
+    const uint64_t v = m_atomics.version.load(std::memory_order_acquire);
+    if (v == m_lastVersion) return;
+    m_cachedStages = std::clamp(m_atomics.stages.load(std::memory_order_acquire),
+                                0, kMaxStages);
+    m_lastVersion = v;
+}
+
+void ClientPhaseRotator::process(float* interleaved, int frames, int channels) noexcept
+{
+    if (!isEnabled() || frames <= 0 || channels < 1 || channels > 2) return;
+    recacheIfDirty();
+    if (m_cachedStages <= 0) return;
+
+    // Block-level peak tracking, signed — record max positive sample and
+    // most negative sample at both input and output. Asymmetry meter
+    // visualises peakPos vs |peakNeg|; phase rotation should make those
+    // values converge.
+    float inPos = 0.0f, inNeg = 0.0f, outPos = 0.0f, outNeg = 0.0f;
+
+    for (int i = 0; i < frames; ++i) {
+        for (int ch = 0; ch < channels; ++ch) {
+            const float x = interleaved[i * channels + ch];
+            if (x > inPos)  inPos = x;
+            if (x < inNeg)  inNeg = x;
+
+            float v = x;
+            for (int s = 0; s < m_cachedStages; ++s) {
+                auto& f = m_sections[s];
+                // Direct Form I all-pass:
+                //   y[n] = a2*x[n] + a1*x[n-1] + x[n-2] - a1*y[n-1] - a2*y[n-2]
+                const float y = f.a2 * v
+                              + f.a1 * f.x1[ch]
+                              +        f.x2[ch]
+                              - f.a1 * f.y1[ch]
+                              - f.a2 * f.y2[ch];
+                f.x2[ch] = f.x1[ch];
+                f.x1[ch] = v;
+                f.y2[ch] = f.y1[ch];
+                f.y1[ch] = y;
+                v = y;
+            }
+            interleaved[i * channels + ch] = v;
+
+            if (v > outPos) outPos = v;
+            if (v < outNeg) outNeg = v;
+        }
+    }
+
+    m_meters.inPosDb.store(linToDb(inPos),         std::memory_order_relaxed);
+    m_meters.inNegDb.store(linToDb(-inNeg),        std::memory_order_relaxed);
+    m_meters.outPosDb.store(linToDb(outPos),       std::memory_order_relaxed);
+    m_meters.outNegDb.store(linToDb(-outNeg),      std::memory_order_relaxed);
+}
+
+} // namespace AetherSDR

--- a/src/core/ClientPhaseRotator.cpp
+++ b/src/core/ClientPhaseRotator.cpp
@@ -82,7 +82,8 @@ void ClientPhaseRotator::designSections() noexcept
     const double fs = m_sampleRate > 0.0 ? m_sampleRate : 24000.0;
     for (int i = 0; i < kMaxStages; ++i) {
         const double f0 = kCentreHz[i];
-        const double w0 = 2.0 * M_PI * f0 / fs;
+        constexpr double kPi = 3.14159265358979323846;
+        const double w0 = 2.0 * kPi * f0 / fs;
         const double alpha = std::sin(w0) / (2.0 * kQ);
         const double a0 = 1.0 + alpha;
         const double a1 = -2.0 * std::cos(w0);

--- a/src/core/ClientPhaseRotator.h
+++ b/src/core/ClientPhaseRotator.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+
+namespace AetherSDR {
+
+// PAPR-reduction phase rotator — TX DSP chain stage (#2887).
+//
+// Voice is asymmetric: glottal pulses produce peaks taller in one polarity
+// than the other. A compressor sees those tall peaks and pulls average gain
+// down to clamp them. Cascading several second-order all-pass sections at
+// staggered audio frequencies decorrelates the harmonic phase alignment
+// that creates those tall peaks — peak amplitude drops 2–3 dB with no
+// perceived loudness loss, so the compressor downstream has less to clamp
+// and average TX power can run hotter. Standard broadcast technique
+// (Optimod, Orban) adopted by Thetis for amateur SSB.
+//
+// Topology: cascade of N second-order all-pass (Direct Form I) filters at
+// fixed staggered centre frequencies. All-pass means unit magnitude at
+// every frequency (no spectral colouration) and only the phase response
+// is rotated, decorrelating the constructive peak alignment.
+//
+// Default centres (300/700/1500/2500 Hz with optional 1000/2000 Hz add)
+// are picked to cover the speech formant range without bunching.
+//
+// Thread model mirrors ClientGate: UI thread writes via set*() which
+// update atomics + bump a version counter; the audio thread reads the
+// version once per block and recaches. No locks, no allocations in
+// process(), no exceptions.
+class ClientPhaseRotator {
+public:
+    static constexpr int kMaxStages = 6;
+    static constexpr int kDefaultStages = 4;
+
+    ClientPhaseRotator();
+    ~ClientPhaseRotator() = default;
+
+    ClientPhaseRotator(const ClientPhaseRotator&)            = delete;
+    ClientPhaseRotator& operator=(const ClientPhaseRotator&) = delete;
+
+    // Main thread — call before first process() and on sample-rate change.
+    void prepare(double sampleRate);
+
+    // Main thread — global enable / bypass. Lock-free.
+    void setEnabled(bool on) noexcept;
+    bool isEnabled() const noexcept;
+
+    // Number of cascaded all-pass sections.  Clamped to [0, kMaxStages].
+    // 0 = pass-through. Higher counts give more peak reduction at the
+    // cost of more phase rotation; 4 is the broadcast default.
+    void setStages(int stages) noexcept;
+    int  stages() const noexcept;
+
+    // Audio thread — process in place.  channels must be 1 or 2.
+    void process(float* interleaved, int frames, int channels) noexcept;
+
+    // Audio thread — flush filter state (e.g. on TX start).
+    void reset() noexcept;
+
+    // UI thread — read-only snapshots of detector state for asymmetry
+    // visualisation (peak+ / peak-) sampled per block.
+    float inputPosPeakDb() const noexcept;
+    float inputNegPeakDb() const noexcept;
+    float outputPosPeakDb() const noexcept;
+    float outputNegPeakDb() const noexcept;
+
+    double sampleRate() const noexcept { return m_sampleRate; }
+
+private:
+    // Second-order all-pass section (Direct Form I).
+    // Transfer function: H(z) = (a2 + a1 z^-1 + z^-2) / (1 + a1 z^-1 + a2 z^-2)
+    // where a1, a2 are derived from centre frequency f0 and Q.
+    struct AllPass {
+        float a1{0.0f};
+        float a2{0.0f};
+        // Per-channel delay lines (x[n-1], x[n-2], y[n-1], y[n-2]).
+        float x1[2]{0.0f, 0.0f};
+        float x2[2]{0.0f, 0.0f};
+        float y1[2]{0.0f, 0.0f};
+        float y2[2]{0.0f, 0.0f};
+    };
+
+    void designSections() noexcept;
+    void recacheIfDirty() noexcept;
+
+    struct Atomics {
+        std::atomic<bool>     enabled{false};
+        std::atomic<int>      stages{kDefaultStages};
+        std::atomic<uint64_t> version{0};
+    };
+
+    struct Meters {
+        std::atomic<float> inPosDb{-120.0f};
+        std::atomic<float> inNegDb{-120.0f};
+        std::atomic<float> outPosDb{-120.0f};
+        std::atomic<float> outNegDb{-120.0f};
+    };
+
+    double   m_sampleRate{24000.0};
+    Atomics  m_atomics;
+    Meters   m_meters;
+
+    // Audio-thread cache, refreshed on version bump.
+    uint64_t m_lastVersion{0};
+    int      m_cachedStages{kDefaultStages};
+
+    // Six fixed staggered centre frequencies, Hz.  The cached stage count
+    // selects how many of these participate (always from index 0 up).
+    static constexpr float kCentreHz[kMaxStages] = {
+        300.0f, 700.0f, 1500.0f, 2500.0f, 1000.0f, 2000.0f
+    };
+    static constexpr float kQ = 0.5f;
+
+    std::array<AllPass, kMaxStages> m_sections;
+};
+
+} // namespace AetherSDR

--- a/src/gui/ClientCompMeter.cpp
+++ b/src/gui/ClientCompMeter.cpp
@@ -62,6 +62,22 @@ void ClientCompMeter::setLabel(const QString& label)
     update();
 }
 
+void ClientCompMeter::setTickSide(TickSide s)
+{
+    if (s == m_tickSide) return;
+    m_tickSide = s;
+    updateGeometry();
+    update();
+}
+
+void ClientCompMeter::setShowValueLabel(bool on)
+{
+    if (on == m_showValueLabel) return;
+    m_showValueLabel = on;
+    updateGeometry();
+    update();
+}
+
 void ClientCompMeter::setLimiterCeilingDb(float db)
 {
     if (std::fabs(db - m_ceilingDb) < 0.01f) return;
@@ -127,23 +143,46 @@ void ClientCompMeter::setValueDb(float db)
 void ClientCompMeter::paintEvent(QPaintEvent*)
 {
     QPainter p(this);
-    p.setRenderHint(QPainter::Antialiasing, true);
+    p.setRenderHint(QPainter::Antialiasing, false);
+    p.setRenderHint(QPainter::TextAntialiasing, true);
 
     const int w = width();
     const int h = height();
     const int labelH = m_label.isEmpty() ? 0 : 12;
-    const QRectF bar(2.0, labelH + 2.0, w - 4.0, h - labelH - 4.0);
+    // Carve out room for an optional bottom value readout (mirrors the
+    // THRESH fader's "-16.3 dB" footer).
+    const int valueH = m_showValueLabel ? 14 : 0;
+
+    // Tick column reservation (mirrors the THRESH fader). The bar
+    // shifts toward the opposite side to leave room for tick labels
+    // + the short tick-mark lines.
+    constexpr int kTickColW = 22;
+    constexpr int kTickGap  = 2;
+    const int leftPad  = (m_tickSide == TickSide::Left)  ? kTickColW + kTickGap : 2;
+    const int rightPad = (m_tickSide == TickSide::Right) ? kTickColW + kTickGap : 2;
+    const QRectF bar(leftPad,
+                     labelH + 2.0,
+                     std::max(1, w - leftPad - rightPad),
+                     std::max(1, h - labelH - 4 - valueH));
 
     if (!m_label.isEmpty()) {
         QFont f = p.font();
         f.setPixelSize(9);
         f.setBold(true);
         p.setFont(f);
-        p.setPen(kLabelColor);
+        // Amber matches the THRESH fader's label colour so the paired
+        // meters read as one consistent strip header.
+        p.setPen(QColor("#e8a540"));
         p.drawText(QRectF(0, 0, w, labelH), Qt::AlignCenter, m_label);
     }
 
     p.fillRect(bar, kBarBg);
+    // Border matches the THRESH fader so the paired meters read as
+    // one visual idiom across the comp editor.
+    p.setPen(QPen(QColor("#243a4e"), 1));
+    p.setBrush(Qt::NoBrush);
+    p.drawRect(QRectF(bar.left(), bar.top(),
+                      bar.width() - 1, bar.height() - 1));
 
     if (m_mode == Mode::Level) {
         const float fillH = m_smooth.value() * bar.height();
@@ -213,6 +252,94 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
             p.setPen(QPen(kPeakLine, 1.0));
             p.drawLine(QPointF(bar.left(), y), QPointF(bar.right(), y));
         }
+    }
+
+    // Tick column (#2887, matching THRESH fader). Labels + short
+    // horizontal stub lines into the bar so the eye links the number
+    // to the position on the scale.
+    if (m_tickSide != TickSide::None) {
+        QFont f = p.font();
+        f.setPixelSize(9);
+        // The header label above set bold=true on the painter font;
+        // explicitly clear it here so the tick labels render in the
+        // same regular weight as the THRESH fader's tick column.
+        f.setBold(false);
+        p.setFont(f);
+        const QFontMetrics fm(f);
+
+        struct Tick { float db; const char* label; };
+        // Level: 0 / -12 / -24 / -36 / -48 (matches THRESH fader).
+        // GR: 0 / -5 / -10 / -15 / -20 (matches GR display range).
+        static constexpr Tick kLevelTicks[] = {
+            {   0.0f,  "0" }, { -12.0f, "-12" }, { -24.0f, "-24" },
+            { -36.0f, "-36" }, { -48.0f, "-48" }
+        };
+        static constexpr Tick kGrTicks[] = {
+            {   0.0f,  "0"  }, {  -5.0f,  "-5"  }, { -10.0f, "-10" },
+            { -15.0f, "-15" }, { -20.0f, "-20" }
+        };
+        const Tick* ticks = (m_mode == Mode::Level) ? kLevelTicks : kGrTicks;
+        const int   nTicks = 5;
+        const float minDb = (m_mode == Mode::Level) ? kLevelMinDb : -kGrMaxMag;
+        const float maxDb = (m_mode == Mode::Level) ? kLevelMaxDb :        0.0f;
+
+        const int textRight = (m_tickSide == TickSide::Left)
+            ? leftPad - kTickGap - 1
+            : w - 2;
+        const bool tickLeft = (m_tickSide == TickSide::Left);
+
+        for (int i = 0; i < nTicks; ++i) {
+            const float norm = (ticks[i].db - minDb) / (maxDb - minDb);
+            const int y = static_cast<int>(bar.bottom() - norm * bar.height());
+
+            p.setPen(QColor("#7f93a5"));
+            const QString s = QString::fromLatin1(ticks[i].label);
+            const int tw = fm.horizontalAdvance(s);
+            const int ty = std::clamp(y + fm.ascent() / 2 - 1,
+                                      static_cast<int>(bar.top()) + fm.ascent() - 1,
+                                      static_cast<int>(bar.bottom()) - 1);
+            if (tickLeft) {
+                p.drawText(textRight - tw, ty, s);
+                p.setPen(QColor("#405060"));
+                p.drawLine(textRight, y,
+                           static_cast<int>(bar.left()) - 1, y);
+            } else {
+                // Right side — labels grow from the bar outward.
+                const int textLeft = static_cast<int>(bar.right()) + kTickGap + 1;
+                p.drawText(textLeft, ty, s);
+                p.setPen(QColor("#405060"));
+                p.drawLine(static_cast<int>(bar.right()), y,
+                           textLeft - 1, y);
+            }
+        }
+    }
+
+    // Numeric value footer (#2887, matching THRESH fader's "-16.3 dB"
+    // styling: 10 px bold, light text). Right-anchored with a fixed
+    // pad so the digits don't wander left/right as the value's digit
+    // count changes — the " dB" suffix stays pinned at the right edge.
+    // The text itself is re-formatted only every ~200 ms so the
+    // numbers are readable while the bar above continues to animate
+    // at the full 125 Hz smoother rate.
+    if (m_showValueLabel) {
+        if (!m_valueLabelClock.isValid()
+            || m_valueLabelClock.elapsed() >= kMeterReadoutUpdateMs
+            || m_cachedValueText.isEmpty()) {
+            m_cachedValueText = (m_currentDb <= -100.0f)
+                ? QStringLiteral("-∞ dB")
+                : QString::asprintf("%+.1f dB", m_currentDb);
+            m_valueLabelClock.restart();
+        }
+        QFont f = p.font();
+        f.setPixelSize(10);
+        f.setBold(true);
+        p.setFont(f);
+        p.setPen(QColor("#e8e8e8"));
+        constexpr int kFooterRightPad = 3;
+        const QRectF footer(0, h - valueH,
+                            w - kFooterRightPad, valueH);
+        p.drawText(footer, Qt::AlignRight | Qt::AlignVCenter,
+                   m_cachedValueText);
     }
 }
 

--- a/src/gui/ClientCompMeter.h
+++ b/src/gui/ClientCompMeter.h
@@ -4,6 +4,7 @@
 
 #include <QWidget>
 #include <QElapsedTimer>
+#include <QString>
 #include <QTimer>
 
 namespace AetherSDR {
@@ -25,10 +26,25 @@ class ClientCompMeter : public QWidget {
 public:
     enum class Mode { Level, GainReduction };
 
+    // Optional scale-tick rendering side. Matches the THRESH fader's
+    // tick layout so paired meters in the compressor editor read as
+    // one consistent vocabulary. None preserves the original compact
+    // bar-only style for places that still use it.
+    enum class TickSide { None, Left, Right };
+
     explicit ClientCompMeter(QWidget* parent = nullptr);
 
     void setMode(Mode m);
     Mode mode() const { return m_mode; }
+
+    // Show dB ticks on the chosen side of the bar (mirrors the THRESH
+    // fader's tick column). Level mode uses 0/-12/-24/-36/-48; GR
+    // uses 0/-5/-10/-15/-20.
+    void setTickSide(TickSide s);
+
+    // Show the current dB value as a bottom-aligned numeric label
+    // (mirrors the "-16.3 dB" footer on the THRESH fader).
+    void setShowValueLabel(bool on);
 
     // Feed the latest dB value.  Bar fill smoothly animates toward
     // the new value; peak-hold line still jumps instantly to any
@@ -69,6 +85,19 @@ private:
     // Optional limiter overlay state — Level mode only.
     float m_ceilingDb{1.0f};      // >0 means "no overlay"
     float m_limGrDb{0.0f};        // 0 means "no limiting this frame"
+
+    // THRESH-style scale chrome (off by default to preserve existing
+    // usage in other surfaces).
+    TickSide m_tickSide{TickSide::None};
+    bool     m_showValueLabel{false};
+
+    // Cached value-label text + throttle clock so the footer dB
+    // readout only re-formats at the project-canonical 10 Hz
+    // (kMeterReadoutUpdateMs in MeterSmoother.h) instead of the
+    // 125 Hz paint cadence. Keeps the digits readable without
+    // slowing the bar.
+    QString       m_cachedValueText;
+    QElapsedTimer m_valueLabelClock;
 };
 
 } // namespace AetherSDR

--- a/src/gui/ClientCompThresholdFader.cpp
+++ b/src/gui/ClientCompThresholdFader.cpp
@@ -221,7 +221,7 @@ void ClientCompThresholdFader::paintEvent(QPaintEvent*)
 
     // dB scale on the left.
     QFont f = p.font();
-    f.setPixelSize(8);
+    f.setPixelSize(9);
     p.setFont(f);
     const QFontMetrics fm(f);
     const int textRight = kLabelColW - 2;

--- a/src/gui/ClientLevelMeter.cpp
+++ b/src/gui/ClientLevelMeter.cpp
@@ -1,5 +1,7 @@
 #include "ClientLevelMeter.h"
 
+#include "MeterSmoother.h"
+
 #include <QFontMetrics>
 #include <QLabel>
 #include <QLinearGradient>
@@ -137,17 +139,24 @@ void ClientLevelMeter::paintEvent(QPaintEvent*)
         p.drawLine(textRight, y, barLeft - 1, y);
     }
 
-    // Numeric readout below the strip.
+    // Numeric readout below the strip.  Re-formatted at the project-
+    // canonical 10 Hz cadence so digits stay readable while the bar
+    // animates every paint.
+    if (!m_readoutClock.isValid()
+        || m_readoutClock.elapsed() >= kMeterReadoutUpdateMs
+        || m_cachedReadout.isEmpty()) {
+        m_cachedReadout = (m_smoothedPeak <= kMeterMinDb + 0.5f)
+            ? QStringLiteral("-inf")
+            : QString::asprintf("%+.1f dB", m_smoothedPeak);
+        m_readoutClock.restart();
+    }
     QFont vf = p.font();
     vf.setPixelSize(10);
     vf.setBold(true);
     p.setFont(vf);
     p.setPen(QColor("#d7e7f2"));
-    const QString readout = (m_smoothedPeak <= kMeterMinDb + 0.5f)
-        ? QStringLiteral("-inf")
-        : QString::asprintf("%+.1f dB", m_smoothedPeak);
     p.drawText(QRect(0, height() - botLabelH, width(), botLabelH),
-               Qt::AlignCenter, readout);
+               Qt::AlignCenter, m_cachedReadout);
 }
 
 } // namespace AetherSDR

--- a/src/gui/ClientLevelMeter.h
+++ b/src/gui/ClientLevelMeter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QElapsedTimer>
+#include <QString>
 #include <QWidget>
 
 class QLabel;
@@ -34,6 +36,12 @@ protected:
 private:
     QString m_headerText{"OUT"};
     float   m_smoothedPeak{-120.0f};
+
+    // Numeric readout throttling — re-format the dB text only at
+    // kMeterReadoutUpdateMs (10 Hz) so the digits are eye-readable
+    // while the bar above continues to animate every paint.
+    QString       m_cachedReadout;
+    QElapsedTimer m_readoutClock;
 
     static constexpr float kMeterMinDb = -60.0f;
     static constexpr float kMeterMaxDb =   0.0f;

--- a/src/gui/MeterSmoother.h
+++ b/src/gui/MeterSmoother.h
@@ -110,4 +110,13 @@ private:
 // smoothly, cheap enough to run on every active meter simultaneously.
 constexpr int kMeterSmootherIntervalMs = 8;
 
+// Recommended cadence for *numeric* meter readouts (dB labels next to
+// or beneath a bar meter).  100 ms = 10 Hz is the eye-readable sweet
+// spot — fast enough to feel live as a knob is turned, slow enough
+// that digits actually settle.  Use this for QLabel::setText (or the
+// cached drawText pattern in ClientCompMeter) so every numeric meter
+// readout across the app updates in lockstep.  The bar fill itself
+// should continue to animate at kMeterSmootherIntervalMs.
+constexpr int kMeterReadoutUpdateMs = 100;
+
 } // namespace AetherSDR

--- a/src/gui/StripCompPanel.cpp
+++ b/src/gui/StripCompPanel.cpp
@@ -183,12 +183,18 @@ StripCompPanel::StripCompPanel(AudioEngine* engine, QWidget* parent)
             m_grMeter = new ClientCompMeter;
             m_grMeter->setMode(ClientCompMeter::Mode::GainReduction);
             m_grMeter->setLabel("GR");
-            m_grMeter->setMinimumWidth(20);
+            m_grMeter->setTickSide(ClientCompMeter::TickSide::Left);
+            m_grMeter->setShowValueLabel(true);
+            // Match THRESH fader's compact width — tick column + bar
+            // is roughly 22 + 16 = 38 px, plus padding.
+            m_grMeter->setFixedWidth(42);
 
             m_outputMeter = new ClientCompMeter;
             m_outputMeter->setMode(ClientCompMeter::Mode::Level);
             m_outputMeter->setLabel("Out");
-            m_outputMeter->setMinimumWidth(20);
+            m_outputMeter->setTickSide(ClientCompMeter::TickSide::Right);
+            m_outputMeter->setShowValueLabel(true);
+            m_outputMeter->setFixedWidth(42);
 
             col->addWidget(m_grMeter, 1);
             body->addLayout(col);
@@ -231,6 +237,44 @@ StripCompPanel::StripCompPanel(AudioEngine* engine, QWidget* parent)
             });
             m_makeup->setFixedSize(76, 76);
             col->addWidget(m_makeup);
+
+            // Pre-comp PAPR controls (#2887). Drive pushes more material
+            // across the threshold so the comp engages harder; Phase
+            // rotates voice peaks to be more symmetric so the harder
+            // compression doesn't sound trashy. Together they raise RMS
+            // without exceeding the ceiling.
+            m_drive = new ClientCompKnob;
+            m_drive->setCenterLabelMode(true);
+            m_drive->setLabel("Drive");
+            m_drive->setRange(0.0f, 18.0f);
+            m_drive->setDefault(0.0f);
+            m_drive->setLabelFormat([](float v) {
+                return "+" + QString::number(v, 'f', 1) + " dB";
+            });
+            m_drive->setFixedSize(76, 76);
+            m_drive->setToolTip(
+                "Pre-comp drive (#2887). Linear gain before the threshold "
+                "so the compressor engages harder and average power lifts. "
+                "Pair with Phase to keep peaks clean as drive increases.");
+            col->addWidget(m_drive);
+
+            m_phase = new ClientCompKnob;
+            m_phase->setCenterLabelMode(true);
+            m_phase->setLabel("Phase");
+            m_phase->setRange(0.0f, 6.0f);
+            m_phase->setDefault(0.0f);
+            m_phase->setLabelFormat([](float v) {
+                const int stages = static_cast<int>(std::round(v));
+                return (stages == 0) ? QString("Off")
+                                     : QString::number(stages) + " stg";
+            });
+            m_phase->setFixedSize(76, 76);
+            m_phase->setToolTip(
+                "Pre-comp phase rotator (#2887). All-pass cascade that "
+                "symmetrizes asymmetric voice peaks before compression. "
+                "0 = off, 4 = broadcast default.");
+            col->addWidget(m_phase);
+
             col->addStretch();
             body->addLayout(col);
         }
@@ -264,6 +308,10 @@ StripCompPanel::StripCompPanel(AudioEngine* engine, QWidget* parent)
             this, &StripCompPanel::applyLimiterCeiling);
     connect(m_limiterEnable, &QPushButton::toggled,
             this, &StripCompPanel::applyLimiterEnabled);
+    connect(m_drive, &ClientCompKnob::valueChanged,
+            this, &StripCompPanel::applyDrive);
+    connect(m_phase, &ClientCompKnob::valueChanged,
+            this, &StripCompPanel::applyPhase);
 
     syncControlsFromEngine();
 
@@ -333,6 +381,8 @@ void StripCompPanel::syncControlsFromEngine()
     QSignalBlocker bm(m_makeup);
     QSignalBlocker bce(m_ceiling);
     QSignalBlocker ble(m_limiterEnable);
+    QSignalBlocker bdv(m_drive);
+    QSignalBlocker bph(m_phase);
 
     m_ratio->setValue(c->ratio());
     m_attack->setValue(c->attackMs());
@@ -341,6 +391,8 @@ void StripCompPanel::syncControlsFromEngine()
     m_makeup->setValue(c->makeupDb());
     m_ceiling->setValue(c->limiterCeilingDb());
     m_limiterEnable->setChecked(c->limiterEnabled());
+    m_drive->setValue(c->driveDb());
+    m_phase->setValue(static_cast<float>(c->phaseRotatorStages()));
     if (m_threshFader) m_threshFader->setThresholdDb(c->thresholdDb());
     if (m_canvas) m_canvas->update();
 }
@@ -375,6 +427,8 @@ void StripCompPanel::tickMeters()
     if (m_knee)    { QSignalBlocker b(m_knee);    m_knee->setValue(c->kneeDb()); }
     if (m_makeup)  { QSignalBlocker b(m_makeup);  m_makeup->setValue(c->makeupDb()); }
     if (m_ceiling) { QSignalBlocker b(m_ceiling); m_ceiling->setValue(c->limiterCeilingDb()); }
+    if (m_drive)   { QSignalBlocker b(m_drive);   m_drive->setValue(c->driveDb()); }
+    if (m_phase)   { QSignalBlocker b(m_phase);   m_phase->setValue(static_cast<float>(c->phaseRotatorStages())); }
     if (m_threshFader) {
         QSignalBlocker b(m_threshFader);
         m_threshFader->setThresholdDb(c->thresholdDb());
@@ -433,6 +487,20 @@ void StripCompPanel::applyKnee(float db)
     if (auto* c = comp()) c->setKneeDb(db);
     saveCompSettings();
     if (m_canvas) m_canvas->update();
+}
+
+void StripCompPanel::applyDrive(float db)
+{
+    if (!m_audio) return;
+    if (auto* c = comp()) c->setDriveDb(db);
+    saveCompSettings();
+}
+
+void StripCompPanel::applyPhase(float stages)
+{
+    if (!m_audio) return;
+    if (auto* c = comp()) c->setPhaseRotatorStages(static_cast<int>(std::round(stages)));
+    saveCompSettings();
 }
 
 void StripCompPanel::applyMakeup(float db)

--- a/src/gui/StripCompPanel.h
+++ b/src/gui/StripCompPanel.h
@@ -78,6 +78,8 @@ private:
     void applyMakeup(float db);
     void applyLimiterEnabled(bool on);
     void applyLimiterCeiling(float db);
+    void applyDrive(float db);
+    void applyPhase(float stages);
 
     AudioEngine*             m_audio{nullptr};
     Side                     m_side{Side::Tx};
@@ -91,6 +93,8 @@ private:
     ClientCompKnob*          m_knee{nullptr};
     ClientCompKnob*          m_makeup{nullptr};
     ClientCompKnob*          m_ceiling{nullptr};
+    ClientCompKnob*          m_drive{nullptr};
+    ClientCompKnob*          m_phase{nullptr};
     ClientCompThresholdFader* m_threshFader{nullptr};
     ClientCompMeter*         m_grMeter{nullptr};
     ClientCompMeter*         m_outputMeter{nullptr};

--- a/src/gui/StripDeEssPanel.cpp
+++ b/src/gui/StripDeEssPanel.cpp
@@ -188,7 +188,37 @@ StripDeEssPanel::StripDeEssPanel(AudioEngine* engine, QWidget* parent)
             this, &StripDeEssPanel::applyThreshold);
     left->addWidget(m_threshold, 0, Qt::AlignHCenter);
 
+    // Stretch pushes the slope button below to the bottom of the
+    // column so it lines up with the bottom edge of the curve area.
     left->addStretch();
+
+    // Slope-stage cycle button (#2887) anchored to the bottom of
+    // the left knob column. Click cycles 12 → 24 → 36 → 48 dB/oct
+    // (1 to 4 cascaded bandpass biquads). Higher slope = narrower
+    // notch around the sibilant frequency = less mid-band collateral
+    // on Ess-heavy phrases. Dimensions match the LIMIT button in
+    // the comp panel.
+    m_slopeBtn = new QPushButton("24 dB/oct");
+    m_slopeBtn->setFixedHeight(22);
+    m_slopeBtn->setMinimumWidth(76);
+    m_slopeBtn->setMaximumWidth(76);
+    m_slopeBtn->setCursor(Qt::PointingHandCursor);
+    m_slopeBtn->setStyleSheet(
+        "QPushButton { background: #1a2230; border: 1px solid #2a3744;"
+        " border-radius: 3px; color: #b0c4d6; font-size: 11px;"
+        " font-weight: bold; padding: 1px; }"
+        "QPushButton:hover { background: #243044; color: #e8e8e8; }"
+        "QPushButton:pressed { background: #2a3a52; }");
+    m_slopeBtn->setToolTip(tr(
+        "Sidechain / notch filter slope.\n\n"
+        "Each click steps through 12 → 24 → 36 → 48 dB/oct (1 to 4 "
+        "cascaded bandpass biquads). Higher slope narrows the band "
+        "the de-esser acts on, so sibilants get cut without "
+        "collateral attenuation of the mid speech band."));
+    connect(m_slopeBtn, &QPushButton::clicked,
+            this, &StripDeEssPanel::cycleSlope);
+    left->addWidget(m_slopeBtn, 0, Qt::AlignHCenter);
+
     body->addLayout(left, 0);
 
     // Center: sidechain bandpass response curve (bigger than the
@@ -203,9 +233,11 @@ StripDeEssPanel::StripDeEssPanel(AudioEngine* engine, QWidget* parent)
     m_curve->setCompactMode(false);
     m_curve->setMinimumHeight(140);
     centre->addWidget(m_curve, 1);
+
     auto* grBar = new DeEssGrBar;
     m_grBar = grBar;
     centre->addWidget(grBar);
+
     body->addLayout(centre, 1);
 
     // Right column: Amount / Attack / Release
@@ -344,10 +376,33 @@ void StripDeEssPanel::syncControlsFromEngine()
     { QSignalBlocker b(m_attack);    m_attack->setValue(d->attackMs()); }
     { QSignalBlocker b(m_release);   m_release->setValue(d->releaseMs()); }
 
+    refreshSlopeButton();
+
     if (auto* bar = static_cast<DeEssGrBar*>(m_grBar))
         bar->setGrDb(d->gainReductionDb());
 
     m_restoring = false;
+}
+
+void StripDeEssPanel::refreshSlopeButton()
+{
+    if (!m_slopeBtn) return;
+    const int stages = (m_audio && deEss())
+        ? std::clamp(deEss()->slopeStages(),
+                     1, ClientDeEss::kMaxSlopeStages)
+        : 2;
+    m_slopeBtn->setText(QString::number(stages * 12) + " dB/oct");
+}
+
+void StripDeEssPanel::cycleSlope()
+{
+    if (m_restoring || !m_audio || !deEss()) return;
+    int next = deEss()->slopeStages() + 1;
+    if (next > ClientDeEss::kMaxSlopeStages) next = 1;
+    deEss()->setSlopeStages(next);
+    saveDeEssSettings();
+    refreshSlopeButton();
+    if (m_curve) m_curve->update();
 }
 
 void StripDeEssPanel::applyFrequency(float hz)

--- a/src/gui/StripDeEssPanel.h
+++ b/src/gui/StripDeEssPanel.h
@@ -60,6 +60,8 @@ private:
     void applyAmount(float db);
     void applyAttack(float ms);
     void applyRelease(float ms);
+    void cycleSlope();
+    void refreshSlopeButton();
 
     // Side-aware accessors so the panel binds to either TX or RX
     // ClientDeEss without duplicating the entire control surface.
@@ -78,6 +80,7 @@ private:
     ClientCompKnob*         m_attack{nullptr};
     ClientCompKnob*         m_release{nullptr};
     QPushButton*            m_bypass{nullptr};
+    QPushButton*            m_slopeBtn{nullptr};    // cycling 12/24/36/48 dB/oct
     QTimer*                 m_syncTimer{nullptr};   // mirror engine → knobs
     bool                    m_restoring{false};
 };

--- a/src/gui/StripFinalOutputPanel.cpp
+++ b/src/gui/StripFinalOutputPanel.cpp
@@ -611,6 +611,43 @@ StripFinalOutputPanel::StripFinalOutputPanel(AudioEngine* engine, QWidget* paren
             "time — back off upstream gain)."));
         col->addWidget(m_activityLbl);
 
+        // Peak-hold toggle (#2887). When green, the PK/RMS/GR/CRST
+        // numeric readouts track the worst-case value seen since hold
+        // engaged so the operator can read off the max over a TX
+        // burst without having to watch the live meter the whole time.
+        // Click again to release; the held maxima reset on engage.
+        m_holdBtn = new QPushButton("HOLD", this);
+        m_holdBtn->setCheckable(true);
+        m_holdBtn->setFixedSize(56, 18);
+        m_holdBtn->setCursor(Qt::PointingHandCursor);
+        m_holdBtn->setFlat(true);
+        m_holdBtn->setStyleSheet(
+            "QPushButton { background: #1a2230; border: 1px solid #2a3744;"
+            " border-radius: 3px; color: #506070; font-size: 10px;"
+            " font-weight: bold; padding: 1px; }"
+            "QPushButton:hover { color: #c8d8e8; }"
+            "QPushButton:checked { background: #183020; border: 1px solid #2eb872;"
+            " color: #2eb872; }"
+            "QPushButton:checked:hover { color: #6ffaa9; }");
+        m_holdBtn->setToolTip(tr(
+            "Peak-hold. When engaged (green), the PK / RMS / GR / CRST "
+            "readouts latch their worst-case value since this button was "
+            "clicked. Click again to release and reset.\n\n"
+            "Use it to capture the peaks of a TX burst without staring "
+            "at the live meter."));
+        connect(m_holdBtn, &QPushButton::toggled, this, [this](bool on) {
+            m_holdEnabled = on;
+            // Engaging hold resets the latches to the current live
+            // values; releasing leaves them at whatever they reached.
+            if (on) {
+                m_holdPkDb    = m_outPeakDb;
+                m_holdRmsDb   = m_outRmsDb;
+                m_holdGrDb    = m_grDb;
+                m_holdCrestDb = m_outPeakDb - m_outRmsDb;
+            }
+        });
+        col->addWidget(m_holdBtn);
+
         row->addLayout(col);
     }
 
@@ -1164,12 +1201,33 @@ void StripFinalOutputPanel::tickMeters()
         if (v <= -100.0f) return QString("-∞");
         return QString::number(v, 'f', 1);
     };
-    if (m_pkValue)    m_pkValue->setText(fmtDb(m_outPeakDb));
-    if (m_rmsValue)   m_rmsValue->setText(fmtDb(m_outRmsDb));
-    if (m_grValue)    m_grValue->setText(fmtDb(m_grDb));
-    if (m_crestValue) {
-        const float crest = m_outPeakDb - m_outRmsDb;
-        m_crestValue->setText(QString::number(crest, 'f', 1));
+    // Peak-hold latches worst-case-since-engaged (#2887). PK / RMS
+    // hold the MAX; GR holds the most-negative (largest reduction).
+    // CRST always tracks live so the operator can see adjustments
+    // land in real time — latching a single-transient worst-instant
+    // value clamps CRST at an unrepresentative number that never
+    // updates while the user is tuning. The held PK/RMS/GR remain
+    // useful as reference points for the burst.
+    const float liveCrest = m_outPeakDb - m_outRmsDb;
+    if (m_holdEnabled) {
+        if (m_outPeakDb > m_holdPkDb)  m_holdPkDb  = m_outPeakDb;
+        if (m_outRmsDb  > m_holdRmsDb) m_holdRmsDb = m_outRmsDb;
+        if (m_grDb      < m_holdGrDb)  m_holdGrDb  = m_grDb;
+    }
+    const float showPk    = m_holdEnabled ? m_holdPkDb  : m_outPeakDb;
+    const float showRms   = m_holdEnabled ? m_holdRmsDb : m_outRmsDb;
+    const float showGr    = m_holdEnabled ? m_holdGrDb  : m_grDb;
+
+    // Throttle text updates to the project-canonical 10 Hz readout
+    // cadence (kMeterReadoutUpdateMs) so digits are readable while
+    // the bars below them animate smoothly at the underlying 125 Hz
+    // smoother rate.
+    if (nowMs - m_lastReadoutUpdateMs >= kMeterReadoutUpdateMs) {
+        m_lastReadoutUpdateMs = nowMs;
+        if (m_pkValue)    m_pkValue->setText(fmtDb(showPk));
+        if (m_rmsValue)   m_rmsValue->setText(fmtDb(showRms));
+        if (m_grValue)    m_grValue->setText(fmtDb(showGr));
+        if (m_crestValue) m_crestValue->setText(QString::number(liveCrest, 'f', 1));
     }
 
     // OVR + LIMIT styling.

--- a/src/gui/StripFinalOutputPanel.h
+++ b/src/gui/StripFinalOutputPanel.h
@@ -70,6 +70,7 @@ private:
     QWidget*        m_ovrLed{nullptr};
     QLabel*         m_limitLed{nullptr};
     QLabel*         m_activityLbl{nullptr};
+    QPushButton*    m_holdBtn{nullptr};   // Peak-hold toggle (#2887)
     QTimer*         m_meterTimer{nullptr};
     QElapsedTimer   m_animClock;
 
@@ -89,6 +90,24 @@ private:
     quint64  m_lastClipCount{0};
     qint64   m_ovrLatchUntilMs{0};
     bool     m_limitFlashOn{false};   // toggled each tick while active
+
+    // Throttle the numeric PK / RMS / GR / CRST text labels to the
+    // project-canonical 10 Hz readout cadence (kMeterReadoutUpdateMs
+    // in MeterSmoother.h) so the operator can actually read them.
+    // The bar animations continue to tick at the full 125 Hz
+    // MeterSmoother rate; only the QLabel::setText calls are gated.
+    qint64   m_lastReadoutUpdateMs{0};
+
+    // Peak-hold (#2887). When enabled, the PK/RMS/GR/CRST readouts
+    // track the worst-case value seen since hold was engaged so the
+    // operator can read off the max over a TX burst without having
+    // to watch the live meter the whole time. Click HOLD to engage;
+    // click again to release (resets the held maxima).
+    bool     m_holdEnabled{false};
+    float    m_holdPkDb{-120.0f};
+    float    m_holdRmsDb{-120.0f};
+    float    m_holdGrDb{0.0f};
+    float    m_holdCrestDb{0.0f};
 };
 
 } // namespace AetherSDR

--- a/src/gui/StripRxOutputPanel.cpp
+++ b/src/gui/StripRxOutputPanel.cpp
@@ -419,22 +419,29 @@ void StripRxOutputPanel::tick()
     m_peakDb = kMeterMinDb + m_peakSmooth.value() * kRange;
     m_rmsDb  = kMeterMinDb + m_rmsSmooth.value()  * kRange;
 
-    // Update text readouts and repaint the bar.
-    auto fmt = [](float db) -> QString {
-        if (db <= -60.0f) return QString::fromUtf8("-\xe2\x88\x9e");
-        return QString::number(db, 'f', 1);
-    };
-    if (m_peakLbl) m_peakLbl->setText(fmt(m_peakDb));
-    if (m_rmsLbl)  m_rmsLbl->setText(fmt(m_rmsDb));
-    if (m_crestLbl) {
-        // Crest factor (peak − RMS) — only meaningful when both readings
-        // are above the noise floor; show "--" otherwise so the user
-        // doesn't read a misleading 60 dB value while idle.
-        if (m_peakDb > -60.0f && m_rmsDb > -60.0f) {
-            const float crest = m_peakDb - m_rmsDb;
-            m_crestLbl->setText(QString::number(crest, 'f', 1));
-        } else {
-            m_crestLbl->setText("--");
+    // Update text readouts and repaint the bar. Text labels are
+    // throttled to the project-canonical 10 Hz cadence so the digits
+    // stay readable; the bar keeps animating every tick.
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    if (nowMs - m_lastReadoutUpdateMs >= kMeterReadoutUpdateMs) {
+        m_lastReadoutUpdateMs = nowMs;
+        auto fmt = [](float db) -> QString {
+            if (db <= -60.0f) return QString::fromUtf8("-\xe2\x88\x9e");
+            return QString::number(db, 'f', 1);
+        };
+        if (m_peakLbl) m_peakLbl->setText(fmt(m_peakDb));
+        if (m_rmsLbl)  m_rmsLbl->setText(fmt(m_rmsDb));
+        if (m_crestLbl) {
+            // Crest factor (peak − RMS) — only meaningful when both
+            // readings are above the noise floor; show "--" otherwise
+            // so the user doesn't read a misleading 60 dB value while
+            // idle.
+            if (m_peakDb > -60.0f && m_rmsDb > -60.0f) {
+                const float crest = m_peakDb - m_rmsDb;
+                m_crestLbl->setText(QString::number(crest, 'f', 1));
+            } else {
+                m_crestLbl->setText("--");
+            }
         }
     }
     if (m_meter)   m_meter->update();

--- a/src/gui/StripRxOutputPanel.h
+++ b/src/gui/StripRxOutputPanel.h
@@ -69,6 +69,11 @@ private:
     MeterSmoother   m_rmsSmooth;
     float           m_peakDb{-120.0f};
     float           m_rmsDb{-120.0f};
+
+    // Throttle the PK / RMS / CRST QLabel updates to the project-
+    // canonical 10 Hz cadence (kMeterReadoutUpdateMs) so the digits
+    // are readable while the bar continues to animate every tick.
+    qint64          m_lastReadoutUpdateMs{0};
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Summary

Three threads landed together. The de-esser fix is the **release-critical** part (multiple operators reporting RMS / forward-power loss vs SmartSDR — root-caused to this stage). The PAPR processor (#2887) and the meter-UI polish came along for the ride during the same bench session.

Bumps version to **26.5.3**.

## The de-esser bug (release-critical)

`ClientDeEss::process()` was applying its sidechain-derived gain reduction to the **full signal** every time HF energy crossed threshold:

```cpp
// OLD — broadband attenuation when sibilance triggers:
l *= gainLin;
r *= gainLin;
```

So every S / T / F phoneme pulled lows and mids down alongside the highs, crashing RMS. SmartSDR doesn't have this stage at all, which is why operators saw lower average power on AetherSDR than SmartSDR at the same drive setting (Antonio D'Arpino's report on the AetherSDR Users Group, plus matching symptoms from others).

**Fix**: split-band topology — `output = full + bandpass × (gain − 1)`. The bandpass acts as both the sidechain detector and the slice to attenuate; lows and mids pass through unchanged.

Also adds:
- **Cascaded biquads** (1–4 stages) so the user can dial slope from 12 → 24 → 36 → 48 dB/oct via a new toggle in the de-esser panel. Default 24 dB/oct (2 stages). Narrower notch = less mid-band collateral on Ess-heavy phrases.
- AppSettings persistence: `ClientDeEssTxSlopeStages` / `ClientDeEssRxSlopeStages`.

## PAPR processor (#2887)

New **ClientPhaseRotator** module — cascade of all-pass biquads that symmetrizes asymmetric voice peaks before downstream compression/limiting, so the clipping work produces primarily odd-order (musical) harmonics instead of even-order (buzzy) ones.

Embedded inside **ClientComp** as a private member, exposed via two new controls in the comp panel:

- **Drive** (0..18 dB) — pre-gain into the comp threshold. Pushes more material across the curve so the comp engages harder, lifting RMS.
- **Phase** (0..6 stages) — pre-comp rotator stage count.

The per-sample gain auto-tracks Drive (`gainLin = curve × makeup × driveLin`), so Drive doesn't fight the comp's natural GR response — same model as broadcast Optimod. Drive and Phase apply regardless of the comp's chain-bypass state.

Bench result: with Drive +9 dB / Phase 4 stg, CRST drops from ~12 dB to ~8 dB cleanly, peaks pegged at the limiter ceiling, no audible squash.

## UI polish

- **Comp GR + Out meters** — now render THRESH-style tick columns (Left/Right) and a right-anchored dB-value footer, so all three vertical meters in the comp editor read with one visual vocabulary.
- **Final Output Stage peak-hold toggle** — latches PK/RMS/GR worst-case-since-engaged for capturing burst maxima. CRST always tracks live so adjustments visibly land in real time.
- **10 Hz numeric-readout throttle** — new shared `kMeterReadoutUpdateMs` constant in `MeterSmoother.h`. Applied to Final Output Stage, comp GR/Out meters, Tube OUT meter, and RX chain output stage. Bars still animate at 125 Hz, only text setText is gated to 10 Hz so digits are readable.

## Stats

- 22 files changed, +898 / −50
- 2 new source files (`ClientPhaseRotator.{h,cpp}`)
- DSP changes covered by manual hardware test (Jeremy KK7GWY's bench)
- No new tests added for the new DSPs — should follow up in a Phase 2 PR

## Test plan

- [x] Clean build, 0 errors
- [x] Manual: Drive 0..+18 dB lifts RMS as expected, GR meter responds
- [x] Manual: Phase toggle audibly clean under heavy Drive
- [x] Manual: De-esser no longer crashes RMS on sibilant phrases
- [x] Manual: Slope toggle cycles 12 → 24 → 36 → 48 dB/oct
- [x] Manual: Peak hold latches worst-case; CRST tracks live
- [x] Manual: Meter readouts readable at 10 Hz, bars smooth at 125 Hz
- [ ] CI: build, check-paths, check-windows green before merge

## Operator workaround for pre-v26.5.3 builds

For anyone on v26.5.2 hitting the de-esser bug: **disable the DESS card** in the channel strip CHAIN row (single click to bypass). Forward power should recover immediately. v26.5.3 makes the fix permanent.

Closes #2887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)