### PR TITLE
feat(smartlink): enforce TLS cert pin on mismatch + Pinned Certs UI

### DIFF
--- a/src/core/WanConnection.cpp
+++ b/src/core/WanConnection.cpp
@@ -2,9 +2,11 @@
 #include "AppSettings.h"
 #include "LogManager.h"
 #include <QCryptographicHash>
+#include <QDateTime>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>
+#include <QJsonValue>
 #include <QSslCertificate>
 #include <QSslConfiguration>
 
@@ -22,13 +24,23 @@ static constexpr int kMaxReadBuffer = 16 * 1024 * 1024;
 
 namespace {
 
-// TOFU cert-pin cache.  Stored as a JSON object in AppSettings under the
-// key "SmartLinkCertFingerprintCache": { "<host>": "<sha256-hex>", … }.
-// See GHSA-wfx7-w6p8-4jr2 — WAN TLS still uses VerifyNone (radio is
-// self-signed), but we silently capture each host's cert fingerprint on
-// first connect and log a warning if it changes.  Phase 1 is warn-only;
-// no user prompt, no enforcement.
+// TOFU cert-pin cache.  Stored as a JSON object in AppSettings under
+// the key "SmartLinkCertFingerprintCache".  See GHSA-wfx7-w6p8-4jr2.
+//
+// Phase 1 shape (warn-only): { "<host>": "<sha256-hex>", ... }
+// Phase 2 shape (#2951, enforcement): {
+//     "<host>": { "fp": "<sha256-hex>", "pinnedAt": "<iso8601>" },
+//     ...
+// }
+//
+// Cache reader handles both shapes so upgrades don't lose existing
+// pins; the writer always emits Phase 2 shape.
 constexpr const char* kCertCacheKey = "SmartLinkCertFingerprintCache";
+
+struct PinEntry {
+    QString fingerprintHex;
+    QString pinnedAtIso;   // empty for Phase 1 entries (no timestamp recorded)
+};
 
 QJsonObject loadCertCache()
 {
@@ -40,21 +52,69 @@ QJsonObject loadCertCache()
     return doc.object();
 }
 
+PinEntry pinEntryFromValue(const QJsonValue& v)
+{
+    PinEntry e{};
+    if (v.isString()) {
+        // Phase 1 string-only entry — no timestamp available.
+        e.fingerprintHex = v.toString();
+    } else if (v.isObject()) {
+        const QJsonObject obj = v.toObject();
+        e.fingerprintHex = obj.value(QStringLiteral("fp")).toString();
+        e.pinnedAtIso    = obj.value(QStringLiteral("pinnedAt")).toString();
+    }
+    return e;
+}
+
 QString loadStoredFingerprint(const QString& host)
 {
-    return loadCertCache().value(host).toString();
+    return pinEntryFromValue(loadCertCache().value(host)).fingerprintHex;
 }
 
 void storeFingerprint(const QString& host, const QString& fingerprintHex)
 {
     QJsonObject obj = loadCertCache();
-    obj[host] = fingerprintHex;
+    QJsonObject entry;
+    entry[QStringLiteral("fp")] = fingerprintHex;
+    entry[QStringLiteral("pinnedAt")] =
+        QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
+    obj[host] = entry;
     AppSettings::instance().setValue(
         kCertCacheKey,
         QJsonDocument(obj).toJson(QJsonDocument::Compact));
 }
 
 } // namespace
+
+// File-scope helpers exposed for the Pinned Certs UI (#2951).
+namespace WanCertCache {
+QVector<PinnedCertInfo> listPinnedCerts()
+{
+    QVector<PinnedCertInfo> out;
+    const QJsonObject obj = loadCertCache();
+    out.reserve(obj.size());
+    for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
+        const PinEntry e = pinEntryFromValue(it.value());
+        if (!e.fingerprintHex.isEmpty())
+            out.append({it.key(), e.fingerprintHex, e.pinnedAtIso});
+    }
+    return out;
+}
+
+void forgetPinnedCert(const QString& host)
+{
+    QJsonObject obj = loadCertCache();
+    obj.remove(host);
+    AppSettings::instance().setValue(
+        kCertCacheKey,
+        QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+void forgetAllPinnedCerts()
+{
+    AppSettings::instance().setValue(kCertCacheKey, QByteArray());
+}
+} // namespace WanCertCache
 
 WanConnection::WanConnection(QObject* parent)
     : QObject(parent)
@@ -119,6 +179,8 @@ void WanConnection::disconnectFromRadio()
     m_handle     = 0;
     m_connected  = false;
     m_validated  = false;
+    m_awaitingCertDecision   = false;
+    m_presentedFingerprintHex.clear();
 }
 
 // ─── Command dispatch ────────────────────────────────────────────────────────
@@ -152,40 +214,95 @@ void WanConnection::onTlsConnected()
 {
     qCDebug(lcSmartLink) << "WanConnection: TLS handshake complete";
 
-    // TOFU cert-pin check (GHSA-wfx7-w6p8-4jr2 phase 1, warn-only).
+    // TOFU cert-pin check (GHSA-wfx7-w6p8-4jr2 phase 2, enforced).
     const QSslCertificate cert = m_socket.peerCertificate();
-    if (!cert.isNull()) {
-        const QString fpHex = QString::fromLatin1(
-            cert.digest(QCryptographicHash::Sha256).toHex());
-        if (m_expectedFingerprintHex.isEmpty()) {
-            storeFingerprint(m_host, fpHex);
-            m_expectedFingerprintHex = fpHex;
-            qCInfo(lcSmartLink) << "WanConnection: pinned cert fingerprint for"
-                                << m_host << "(first-use TOFU; sha256=" << fpHex << ")";
-        } else if (m_expectedFingerprintHex != fpHex) {
-            qCWarning(lcSmartLink)
-                << "WanConnection: cert fingerprint MISMATCH for" << m_host
-                << "— expected" << m_expectedFingerprintHex
-                << "got" << fpHex
-                << "— possible MITM, radio replaced, or firmware update."
-                << "Phase 1 is warn-only; connection proceeds. See GHSA-wfx7-w6p8-4jr2.";
-        } else {
-            qCDebug(lcSmartLink) << "WanConnection: cert fingerprint matches stored pin for" << m_host;
-        }
-    } else {
+    if (cert.isNull()) {
         qCWarning(lcSmartLink) << "WanConnection: peer presented no certificate; skipping TOFU check";
+        sendWanValidate();
+        return;
     }
 
+    const QString fpHex = QString::fromLatin1(
+        cert.digest(QCryptographicHash::Sha256).toHex());
+    if (m_expectedFingerprintHex.isEmpty()) {
+        // First-use TOFU pin — silent, matches Phase 1 behaviour.
+        storeFingerprint(m_host, fpHex);
+        m_expectedFingerprintHex = fpHex;
+        qCInfo(lcSmartLink) << "WanConnection: pinned cert fingerprint for"
+                            << m_host << "(first-use TOFU; sha256=" << fpHex << ")";
+        sendWanValidate();
+        return;
+    }
+
+    if (m_expectedFingerprintHex == fpHex) {
+        qCDebug(lcSmartLink) << "WanConnection: cert fingerprint matches stored pin for" << m_host;
+        sendWanValidate();
+        return;
+    }
+
+    // Mismatch — Phase 2 holds the handshake. Do NOT send wan validate.
+    // The UI will catch certFingerprintMismatch, show a modal, and call
+    // either acceptPresentedCert() or rejectPresentedCert(). Until then
+    // the radio sees an open TLS channel but no authenticated session.
+    qCWarning(lcSmartLink)
+        << "WanConnection: cert fingerprint MISMATCH for" << m_host
+        << "— expected" << m_expectedFingerprintHex
+        << "got" << fpHex
+        << "— possible MITM, radio replaced, or firmware update."
+        << "Phase 2: handshake paused pending operator decision. See GHSA-wfx7-w6p8-4jr2.";
+    m_presentedFingerprintHex = fpHex;
+    m_awaitingCertDecision = true;
+    emit certFingerprintMismatch(m_host, m_expectedFingerprintHex, fpHex);
+}
+
+void WanConnection::sendWanValidate()
+{
     // Send wan validate as a proper command (C<seq>|wan validate handle=...)
     // FlexLib uses SendCommand() for this, not raw write.
     const quint32 seq = m_seqCounter.fetch_add(1);
-    const QByteArray data = CommandParser::buildCommand(seq, QString("wan validate handle=%1").arg(m_wanHandle));
+    const QByteArray data = CommandParser::buildCommand(
+        seq, QString("wan validate handle=%1").arg(m_wanHandle));
     qCDebug(lcSmartLink) << "WAN TX: C" << seq << "|wan validate handle=***REDACTED***";
     m_socket.write(data);
     m_validated = true;
-
+    m_awaitingCertDecision = false;
+    m_presentedFingerprintHex.clear();
     // The radio will now send V<version>\n then H<handle>\n
     // just like a LAN connection. processLine() handles it.
+}
+
+void WanConnection::acceptPresentedCert()
+{
+    if (!m_awaitingCertDecision) {
+        qCWarning(lcSmartLink) << "WanConnection::acceptPresentedCert: no pending decision; ignoring";
+        return;
+    }
+    if (m_presentedFingerprintHex.isEmpty()) {
+        qCWarning(lcSmartLink) << "WanConnection::acceptPresentedCert: no presented fingerprint cached; ignoring";
+        m_awaitingCertDecision = false;
+        return;
+    }
+    storeFingerprint(m_host, m_presentedFingerprintHex);
+    m_expectedFingerprintHex = m_presentedFingerprintHex;
+    qCInfo(lcSmartLink) << "WanConnection: operator accepted new cert pin for" << m_host
+                        << "sha256=" << m_presentedFingerprintHex;
+    sendWanValidate();
+}
+
+void WanConnection::rejectPresentedCert()
+{
+    if (!m_awaitingCertDecision) {
+        qCWarning(lcSmartLink) << "WanConnection::rejectPresentedCert: no pending decision; ignoring";
+        return;
+    }
+    qCWarning(lcSmartLink) << "WanConnection: operator rejected new cert pin for" << m_host
+                           << "expected=" << m_expectedFingerprintHex
+                           << "presented=" << m_presentedFingerprintHex
+                           << "— tearing down WAN session.";
+    m_awaitingCertDecision = false;
+    m_presentedFingerprintHex.clear();
+    emit errorOccurred(QStringLiteral("Certificate rejected by user"));
+    disconnectFromRadio();
 }
 
 void WanConnection::onTlsDisconnected()

--- a/src/core/WanConnection.cpp
+++ b/src/core/WanConnection.cpp
@@ -112,7 +112,7 @@ void forgetPinnedCert(const QString& host)
 
 void forgetAllPinnedCerts()
 {
-    AppSettings::instance().setValue(kCertCacheKey, QByteArray());
+    AppSettings::instance().remove(kCertCacheKey);
 }
 } // namespace WanCertCache
 
@@ -362,6 +362,21 @@ void WanConnection::onHeartbeat()
 
 void WanConnection::processLine(const QString& line)
 {
+    // GHSA-wfx7-w6p8-4jr2 phase 2: while the operator is being prompted
+    // about a cert mismatch, the TLS channel stays open but we must not
+    // act on anything that arrives. A MITM on the path (the exact threat
+    // we're defending against) could otherwise fabricate V<version>\n
+    // and H<handle>\n bytes before the operator answers, causing this
+    // client to fire connected() / start heartbeats on attacker-controlled
+    // data. The radio never sees wan validate, but downstream code reacts
+    // to connected() — so we extend the suppression symmetrically:
+    // nothing gets parsed until the operator's decision lands.
+    if (m_awaitingCertDecision) {
+        qCDebug(lcSmartLink)
+            << "WAN RX (suppressed during cert-pin decision):" << line;
+        return;
+    }
+
     // Suppress noisy messages
     const bool isGps = line.contains("|gps ");
     bool isPingReply = false;

--- a/src/core/WanConnection.h
+++ b/src/core/WanConnection.h
@@ -9,10 +9,27 @@
 #include <QString>
 #include <QHostAddress>
 #include <QTimer>
+#include <QVector>
 #include <functional>
 #include <atomic>
 
 namespace AetherSDR {
+
+// Pinned-cert cache management for the Pinned Certificates settings UI
+// (#2951 / GHSA-wfx7-w6p8-4jr2). Backs the same store WanConnection
+// uses for TOFU pin enforcement; defined in WanConnection.cpp so the
+// JSON shape stays in one place.
+struct PinnedCertInfo {
+    QString host;
+    QString fingerprintHex;
+    QString pinnedAtIso;   // empty for legacy Phase 1 entries
+};
+
+namespace WanCertCache {
+    QVector<PinnedCertInfo> listPinnedCerts();
+    void forgetPinnedCert(const QString& host);
+    void forgetAllPinnedCerts();
+}
 
 // Manages a TLS connection to a FlexRadio over the internet (SmartLink).
 // Speaks the same V/H/R/S/M protocol as RadioConnection but over TLS,
@@ -42,6 +59,18 @@ public:
     quint32 sendCommand(const QString& command,
                         ResponseCallback callback = nullptr);
 
+    // Phase 2 of GHSA-wfx7-w6p8-4jr2 (#2951): operator decides whether
+    // to accept a new cert presented during a mismatch.  Connection is
+    // paused — wan validate has NOT been sent — until one of these
+    // methods is called by the UI in response to certFingerprintMismatch.
+    //
+    //   accept → overwrite the stored pin with the presented fingerprint
+    //            and resume the WAN handshake.
+    //   reject → tear the TLS session down and surface an error to the
+    //            caller; the radio never sees an authenticated session.
+    void acceptPresentedCert();
+    void rejectPresentedCert();
+
 signals:
     void connected();
     void disconnected();
@@ -50,6 +79,15 @@ signals:
     void statusReceived(const QString& object, const QMap<QString, QString>& kvs);
     void versionReceived(const QString& version);
     void pingRttMeasured(int ms);
+
+    // Phase 2 of GHSA-wfx7-w6p8-4jr2 (#2951). Fired when onTlsConnected
+    // detects a fingerprint mismatch against the stored pin. The UI is
+    // expected to prompt the operator and respond with accept/reject.
+    // While waiting for the response no wan validate is sent — an
+    // attacker on a hostile path never sees an authenticated session.
+    void certFingerprintMismatch(const QString& host,
+                                 const QString& expectedHex,
+                                 const QString& presentedHex);
 
 private slots:
     void onTlsConnected();
@@ -74,10 +112,18 @@ private:
     quint32 m_lastPingSeq{0};
     QElapsedTimer m_pingStopwatch;
 
-    // TOFU cert pin (GHSA-wfx7-w6p8-4jr2 phase 1).  Captured on first
-    // connect to a given host; subsequent connects warn on mismatch.
+    // TOFU cert pin (GHSA-wfx7-w6p8-4jr2). Captured on first connect
+    // to a given host; subsequent connects enforce on mismatch via the
+    // certFingerprintMismatch signal + accept/reject methods (phase 2).
     QString m_host;
     QString m_expectedFingerprintHex;
+    QString m_presentedFingerprintHex;  // pending on mismatch, awaiting UI decision
+    bool    m_awaitingCertDecision{false};
+    // Send wan validate once the pin decision lands (and at the end of
+    // the normal first-use / match path too). Factored out so the
+    // mismatch-accept path lands at exactly the same handshake step
+    // the no-prompt paths use.
+    void sendWanValidate();
 
     QMap<quint32, ResponseCallback> m_pendingCallbacks;
 };

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9530,6 +9530,11 @@ void MainWindow::onWanCertFingerprintMismatch(const QString& host,
         statusBar()->showMessage(
             tr("SmartLink certificate updated for %1").arg(host), 4000);
         m_radioModel.acceptPresentedWanCert();
+        // If the Radio Setup dialog is open with the SmartLink tab
+        // showing, the just-updated pin needs to surface in the table
+        // without requiring the operator to close+re-open the tab.
+        if (m_radioSetupDialog)
+            m_radioSetupDialog->refreshPinnedCertsTable();
     } else {
         statusBar()->showMessage(
             tr("SmartLink certificate rejected for %1").arg(host), 5000);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2215,6 +2215,8 @@ MainWindow::MainWindow(QWidget* parent)
             this, &MainWindow::onConnectionStateChanged);
     connect(&m_radioModel, &RadioModel::connectionError,
             this, &MainWindow::onConnectionError);
+    connect(&m_radioModel, &RadioModel::certFingerprintMismatch,
+            this, &MainWindow::onWanCertFingerprintMismatch);
     connect(&m_radioModel, &RadioModel::forcedDisconnectRequested,
             this, [this] {
         const bool wasWan = m_radioModel.isWan();
@@ -9478,6 +9480,61 @@ void MainWindow::onConnectionError(const QString& msg)
     statusBar()->showMessage("Connection error: " + msg, 5000);
     if (!m_reconnectDlg)
         setPanadapterConnectionAnimation(false);
+}
+
+void MainWindow::onWanCertFingerprintMismatch(const QString& host,
+                                              const QString& expectedHex,
+                                              const QString& presentedHex)
+{
+    // Phase 2 of GHSA-wfx7-w6p8-4jr2 (#2951). The WAN handshake is
+    // paused — no wan validate has been sent. Block here on a modal
+    // for the operator's decision, then route accept/reject back
+    // through RadioModel to the underlying WanConnection.
+    //
+    // Display formatting: insert a colon every two hex chars so the
+    // 64-char SHA-256 is scannable. The radio nickname isn't reliably
+    // available at this point in the handshake, so we use the host
+    // string (IP or hostname) as the user-facing identifier.
+    auto pretty = [](QString hex) {
+        hex = hex.toLower();
+        QString out;
+        out.reserve(hex.size() + hex.size() / 2);
+        for (int i = 0; i < hex.size(); ++i) {
+            if (i > 0 && (i % 2 == 0)) out.append(':');
+            out.append(hex.at(i));
+        }
+        return out;
+    };
+
+    QMessageBox box(this);
+    box.setIcon(QMessageBox::Warning);
+    box.setWindowTitle(tr("SmartLink certificate changed"));
+    box.setText(tr("<b>Certificate changed for %1</b>").arg(host.toHtmlEscaped()));
+    box.setInformativeText(tr(
+        "<p><b>Expected (pinned):</b><br/><tt>%1</tt></p>"
+        "<p><b>Presented:</b><br/><tt>%2</tt></p>"
+        "<p>This may be normal (radio firmware update, replaced radio) "
+        "or it may indicate a man-in-the-middle attack on the SmartLink "
+        "session.</p>"
+        "<p>Accept only if you recently updated firmware, replaced the "
+        "radio, or otherwise expect the certificate to change.</p>")
+        .arg(pretty(expectedHex), pretty(presentedHex)));
+    auto* acceptBtn = box.addButton(tr("Accept new certificate"),
+                                    QMessageBox::AcceptRole);
+    auto* rejectBtn = box.addButton(tr("Reject and disconnect"),
+                                    QMessageBox::RejectRole);
+    box.setDefaultButton(rejectBtn);
+    box.exec();
+
+    if (box.clickedButton() == acceptBtn) {
+        statusBar()->showMessage(
+            tr("SmartLink certificate updated for %1").arg(host), 4000);
+        m_radioModel.acceptPresentedWanCert();
+    } else {
+        statusBar()->showMessage(
+            tr("SmartLink certificate rejected for %1").arg(host), 5000);
+        m_radioModel.rejectPresentedWanCert();
+    }
 }
 
 void MainWindow::onRadioMessage(const QString& text, MessageSeverity severity)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -145,6 +145,11 @@ private slots:
     // Radio/connection events
     void onConnectionStateChanged(bool connected);
     void onConnectionError(const QString& msg);
+    // GHSA-wfx7-w6p8-4jr2 phase 2 (#2951): show mismatch modal and
+    // forward the operator's decision back to the WanConnection.
+    void onWanCertFingerprintMismatch(const QString& host,
+                                      const QString& expectedHex,
+                                      const QString& presentedHex);
     void onRadioMessage(const QString& text, MessageSeverity severity);
     void onSliceAdded(SliceModel* slice);
     void onSliceRemoved(int id);

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -18,6 +18,7 @@
 #include "core/FirmwareStager.h"
 #include "core/TgxlConnection.h"
 #include "core/PgxlConnection.h"
+#include "core/WanConnection.h"   // PinnedCertInfo + WanCertCache (#2951)
 #include "models/AntennaGeniusModel.h"
 
 #include <QCloseEvent>
@@ -26,6 +27,9 @@
 #include <QHBoxLayout>
 #include <QGridLayout>
 #include <QGroupBox>
+#include <QHeaderView>
+#include <QTableWidget>
+#include <QTableWidgetItem>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
@@ -463,6 +467,7 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
     addDeferred("USB Cables",      [this] { return buildUsbCablesTab(); });
     addDeferred("Peripherals",     [this] { return buildPeripheralsTab(); });
     addDeferred("Themes",          [this] { return buildUiEnhancementsTab(); });
+    addDeferred("SmartLink",       [this] { return buildSmartLinkTab(); });
 #ifdef HAVE_SERIALPORT
     addDeferred("Serial",          [this] { return buildSerialTab(); });
 #endif
@@ -4785,6 +4790,125 @@ QWidget* RadioSetupDialog::buildUiEnhancementsTab()
     }
 
     return page;
+}
+
+QWidget* RadioSetupDialog::buildSmartLinkTab()
+{
+    // Phase 2 of GHSA-wfx7-w6p8-4jr2 (#2951): Pinned Certificates panel.
+    // Lists every SmartLink host this client has TOFU-pinned a cert
+    // fingerprint for, when it was pinned, and lets the operator
+    // forget individual pins or clear the whole cache. Used when the
+    // operator deliberately rotates a radio's cert (firmware update,
+    // hardware replacement) and wants the next connect to re-pin
+    // silently instead of triggering the mismatch dialog.
+
+    auto* page = new QWidget;
+    auto* root = new QVBoxLayout(page);
+    root->setContentsMargins(16, 16, 16, 16);
+    root->setSpacing(12);
+
+    auto* grp = new QGroupBox("Pinned SmartLink Certificates");
+    grp->setStyleSheet(kGroupStyle);
+    auto* grpLay = new QVBoxLayout(grp);
+    grpLay->setSpacing(8);
+
+    auto* desc = new QLabel(
+        "AetherSDR pins each SmartLink radio's TLS certificate the first "
+        "time you connect (trust-on-first-use). Subsequent connects "
+        "compare against the pin; a mismatch shows a warning dialog and "
+        "pauses the connection until you accept or reject it.\n\n"
+        "Forget a pin when you deliberately change a radio's certificate "
+        "(firmware update, hardware replacement) so the next connect can "
+        "re-pin silently. See GHSA-wfx7-w6p8-4jr2 for the threat model.");
+    desc->setStyleSheet("QLabel { color: #7090a0; font-size: 11px; }");
+    desc->setWordWrap(true);
+    grpLay->addWidget(desc);
+
+    auto* table = new QTableWidget(0, 3, grp);
+    m_pinnedCertsTable = table;
+    table->setHorizontalHeaderLabels({"Host", "SHA-256 fingerprint", "Pinned"});
+    table->horizontalHeader()->setStretchLastSection(false);
+    table->horizontalHeader()->setSectionResizeMode(
+        0, QHeaderView::ResizeToContents);
+    table->horizontalHeader()->setSectionResizeMode(
+        1, QHeaderView::Stretch);
+    table->horizontalHeader()->setSectionResizeMode(
+        2, QHeaderView::ResizeToContents);
+    table->verticalHeader()->setVisible(false);
+    table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    table->setStyleSheet(
+        "QTableWidget { background: #0a1420; color: #c8d8e8;"
+        " gridline-color: #1a2a3a; }"
+        "QHeaderView::section { background: #1a2a3a; color: #b0c4d6;"
+        " padding: 4px; border: none; }");
+    grpLay->addWidget(table);
+
+    auto* btnRow = new QHBoxLayout;
+    btnRow->setSpacing(8);
+    auto* forgetSel = new QPushButton("Forget selected");
+    auto* forgetAll = new QPushButton("Forget all");
+    static const QString kPinnedBtnStyle =
+        "QPushButton { background: #1a2230; border: 1px solid #2a3744;"
+        " border-radius: 3px; color: #c8d8e8; font-size: 11px;"
+        " padding: 4px 12px; }"
+        "QPushButton:hover { background: #243044; color: #e8e8e8; }"
+        "QPushButton:pressed { background: #2a3a52; }";
+    forgetSel->setStyleSheet(kPinnedBtnStyle);
+    forgetAll->setStyleSheet(kPinnedBtnStyle);
+    btnRow->addWidget(forgetSel);
+    btnRow->addStretch();
+    btnRow->addWidget(forgetAll);
+    grpLay->addLayout(btnRow);
+
+    connect(forgetSel, &QPushButton::clicked, this, [this, table]() {
+        const int row = table->currentRow();
+        if (row < 0) return;
+        auto* item = table->item(row, 0);
+        if (!item) return;
+        const QString host = item->text();
+        WanCertCache::forgetPinnedCert(host);
+        refreshPinnedCertsTable();
+    });
+
+    connect(forgetAll, &QPushButton::clicked, this, [this]() {
+        if (QMessageBox::question(this, tr("Forget all SmartLink certificates"),
+                tr("Clear every pinned SmartLink cert fingerprint?\n\n"
+                   "Next connect to each radio will silently re-pin "
+                   "whatever certificate it presents (no mismatch warning)."))
+            != QMessageBox::Yes) {
+            return;
+        }
+        WanCertCache::forgetAllPinnedCerts();
+        refreshPinnedCertsTable();
+    });
+
+    root->addWidget(grp);
+    root->addStretch();
+
+    refreshPinnedCertsTable();
+    return page;
+}
+
+void RadioSetupDialog::refreshPinnedCertsTable()
+{
+    if (!m_pinnedCertsTable) return;
+    const QVector<PinnedCertInfo> pins = WanCertCache::listPinnedCerts();
+    m_pinnedCertsTable->setRowCount(pins.size());
+    for (int i = 0; i < pins.size(); ++i) {
+        const PinnedCertInfo& pin = pins.at(i);
+        m_pinnedCertsTable->setItem(i, 0, new QTableWidgetItem(pin.host));
+        // Use a monospace cell for the fingerprint so the hex aligns.
+        auto* fpItem = new QTableWidgetItem(pin.fingerprintHex);
+        QFont mono("monospace");
+        fpItem->setFont(mono);
+        fpItem->setToolTip(pin.fingerprintHex);
+        m_pinnedCertsTable->setItem(i, 1, fpItem);
+        const QString when = pin.pinnedAtIso.isEmpty()
+            ? QStringLiteral("(pre-phase 2)")
+            : pin.pinnedAtIso.left(10);   // YYYY-MM-DD
+        m_pinnedCertsTable->setItem(i, 2, new QTableWidgetItem(when));
+    }
 }
 
 } // namespace AetherSDR

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -15,6 +15,7 @@ class QPushButton;
 class QComboBox;
 class QCheckBox;
 class QVBoxLayout;
+class QTableWidget;
 
 namespace AetherSDR {
 
@@ -70,9 +71,18 @@ private:
     QWidget* buildUsbCablesTab();
     QWidget* buildPeripheralsTab();
     QWidget* buildUiEnhancementsTab();
+    // Phase 2 of GHSA-wfx7-w6p8-4jr2 (#2951) — Pinned Certificates list
+    // (host, sha256 fingerprint, pinned date) with per-row Forget and a
+    // Forget All button. Backed by WanCertCache in WanConnection.cpp.
+    QWidget* buildSmartLinkTab();
+    void     refreshPinnedCertsTable();
 #ifdef HAVE_SERIALPORT
     QWidget* buildSerialTab();
 #endif
+
+    // SmartLink Pinned Certs UI handle (#2951). Forward-declared at
+    // file scope above; full type comes from <QTableWidget> in the cpp.
+    QTableWidget* m_pinnedCertsTable{nullptr};
 
     RadioModel*  m_model;
     AudioEngine* m_audio{nullptr};

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -75,7 +75,15 @@ private:
     // (host, sha256 fingerprint, pinned date) with per-row Forget and a
     // Forget All button. Backed by WanCertCache in WanConnection.cpp.
     QWidget* buildSmartLinkTab();
+
+public:
+    // Public so MainWindow can refresh the table from outside this
+    // dialog when an accept-after-mismatch flow rewrites the pin
+    // cache. No-op if the SmartLink tab hasn't been built yet
+    // (m_pinnedCertsTable == nullptr).
     void     refreshPinnedCertsTable();
+
+private:
 #ifdef HAVE_SERIALPORT
     QWidget* buildSerialTab();
 #endif

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -876,6 +876,8 @@ void RadioModel::connectViaWan(WanConnection* wan, const QString& publicIp, quin
     connect(wan, &WanConnection::connected, this, &RadioModel::onConnected);
     connect(wan, &WanConnection::disconnected, this, &RadioModel::onDisconnected);
     connect(wan, &WanConnection::errorOccurred, this, &RadioModel::onConnectionError);
+    connect(wan, &WanConnection::certFingerprintMismatch,
+            this, &RadioModel::certFingerprintMismatch);
     connect(wan, &WanConnection::versionReceived, this, &RadioModel::onVersionReceived);
     connect(wan, &WanConnection::messageReceived, this, &RadioModel::onMessageReceived);
     connect(wan, &WanConnection::statusReceived, this, &RadioModel::onStatusReceived);
@@ -1084,6 +1086,18 @@ void RadioModel::disconnectFromRadio()
         QMetaObject::invokeMethod(m_connection, &RadioConnection::disconnectFromRadio,
                                   Qt::BlockingQueuedConnection);
     }
+}
+
+void RadioModel::acceptPresentedWanCert()
+{
+    if (m_wanConn)
+        m_wanConn->acceptPresentedCert();
+}
+
+void RadioModel::rejectPresentedWanCert()
+{
+    if (m_wanConn)
+        m_wanConn->rejectPresentedCert();
 }
 
 void RadioModel::forceDisconnect()

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -307,6 +307,12 @@ public:
     void disconnectFromRadio();
     void forceDisconnect();  // Close TCP but allow auto-reconnect
     bool isWan() const { return m_wanConn != nullptr; }
+
+    // Phase 2 of GHSA-wfx7-w6p8-4jr2 (#2951): forward the user's
+    // cert-mismatch decision down to the active WAN connection. No-op
+    // if not connected via WAN or no decision is pending.
+    void acceptPresentedWanCert();
+    void rejectPresentedWanCert();
     void setTransmit(bool tx, TransmitModel::PttSource source = TransmitModel::PttSource::Mox);
     void setDigitalVoiceTxSlice(int sliceId);
     QString audioCompressionParam() const;        // "none" or "opus" based on settings
@@ -361,6 +367,12 @@ signals:
     void sliceRemoved(int sliceId);
     void metersChanged();
     void connectionError(const QString& msg);
+    // Phase 2 of GHSA-wfx7-w6p8-4jr2 (#2951): forwarded from
+    // WanConnection. UI is expected to prompt the operator and call
+    // accept/rejectPresentedWanCert() in response.
+    void certFingerprintMismatch(const QString& host,
+                                 const QString& expectedHex,
+                                 const QString& presentedHex);
     // Emitted when another GUI client forces this client to disconnect.
     void forcedDisconnectRequested();
     // Emitted when a panadapter's center frequency or bandwidth changes.


### PR DESCRIPTION
## Summary

Closes #2951. Phase 2 of [GHSA-wfx7-w6p8-4jr2](https://github.com/aethersdr/AetherSDR/security/advisories/GHSA-wfx7-w6p8-4jr2) — turns the warn-only TLS fingerprint TOFU shipped in PR #2947 into actual enforcement + the operator UX needed to manage pins.

## Threat model

SmartLink WAN uses TLS with `VerifyNone` because radios self-sign. An active MITM on the network path could present any cert and Phase 1 would log a warning but proceed to send `wan validate handle=…`, giving the attacker a live authenticated session.

Phase 2 stops the handshake at the mismatch point. The radio (or attacker) sees an open TLS channel but never sees `wan validate` until the operator explicitly accepts via modal. Reject tears down TLS without ever authenticating.

## What changed

**Core ([src/core/WanConnection.{h,cpp}](src/core/WanConnection.h))**:
- New signal `certFingerprintMismatch(host, expectedHex, presentedHex)`
- `acceptPresentedCert()` / `rejectPresentedCert()` methods; handshake pauses until one is called
- Cache schema bump with back-compat reader:
  - Phase 1: `{"host": "<hex>"}`
  - Phase 2: `{"host": {"fp": "<hex>", "pinnedAt": "<ISO8601>"}}`
- New `WanCertCache` namespace API: `listPinnedCerts`, `forgetPinnedCert`, `forgetAllPinnedCerts`

**Relay ([src/models/RadioModel.{h,cpp}](src/models/RadioModel.h))**:
- Forwards `certFingerprintMismatch` from active WAN
- `accept` / `rejectPresentedWanCert()` convenience methods

**Operator dialog ([src/gui/MainWindow.cpp](src/gui/MainWindow.cpp))**:
- `onWanCertFingerprintMismatch()` slot shows `QMessageBox` modal with both fingerprints pretty-printed as colon-separated hex
- Default focus is on **Reject and disconnect** — accidental Enter doesn't accept a hostile cert

**Pinned Certificates UI ([src/gui/RadioSetupDialog.cpp](src/gui/RadioSetupDialog.cpp))**:
- New "SmartLink" tab in Radio Setup
- QTableWidget: Host / SHA-256 fingerprint (monospace) / Pinned date (YYYY-MM-DD)
- "Forget selected" + "Forget all" (with confirmation)
- Legacy Phase 1 entries show `(pre-phase 2)` in the date column

## Persistence

All state stays in the existing `SmartLinkCertFingerprintCache` AppSettings key. No new flat keys — Principle V compliant (single nested JSON under one key). Upgrade is seamless: existing Phase 1 string-only entries are honored as legitimate pins and upgrade to the new shape organically.

## Security properties

- **Attacker on hostile path** sees TLS handshake complete but never sees `wan validate` during the operator's decision window
- **Reject** tears down TLS immediately; no opportunity to inject during cleanup
- **Accept** is explicit, intentional; overwrites pin only on operator confirmation
- **Phase 1 → Phase 2 upgrade** has no first-use re-pin silent acceptance trap

## Stats

- 8 files, +417 / −32
- No new flat-key AppSettings (Principle V)
- All meter UI uses MeterSmoother (N/A, no meter changes)

## Test plan

Requires SmartLink WAN connection — cannot exercise from LAN-attached radio:

- [x] Build clean
- [ ] **First-use**: connect cleanly to a new SmartLink radio → pin captured silently with timestamp, visible in Radio Setup → SmartLink
- [ ] **Match**: subsequent connect to same radio → silent debug log, no UI
- [ ] **Mismatch**: rotate the radio's cert (firmware update, or manually edit cache) → modal appears with both fingerprints; **Accept** persists new pin and connection resumes; **Reject** disconnects cleanly with "Certificate rejected by user" status
- [ ] **Forget selected**: per-row Forget removes from list; next connect to that host re-pins silently
- [ ] **Forget all**: prompts confirmation, clears cache
- [ ] **Phase 1 upgrade**: existing string-only cache entries don't crash; show `(pre-phase 2)` in date column until next mismatch-and-accept rewrites them in Phase 2 shape

## Checklist

- [x] Commits are signed (squash-merge handles)
- [x] No new flat-key `AppSettings` calls — same key, nested JSON
- [x] All meter UI uses `MeterSmoother` (N/A)
- [x] Documentation updated if user-visible behavior changed (release notes will reference GHSA)
- [x] Security-sensitive changes reference a GHSA (GHSA-wfx7-w6p8-4jr2)

Closes #2951.

🤖 Generated with [Claude Code](https://claude.com/claude-code)