### PR TITLE
ci: trigger check-windows on MainWindow.cpp/.h changes (#2671)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,18 @@ jobs:
               - 'CMakeLists.txt'
               - 'third_party/**'
               - '.github/workflows/**'
+              # MainWindow.cpp / .h carry dozens of `#ifdef Q_OS_WIN`,
+              # `Q_OS_MAC`, and `HAVE_PIPEWIRE` branches; a change that
+              # looks Linux-only can break Windows in non-obvious ways.
+              # Post-mortems: #2633 → #2662 (unconditional m_daxBridge
+              # reference inside macOS-only guard) and #2670 (Windows
+              # behaviour change wasn't exercised by CI). Most recently
+              # the v26.5.3 ClientPhaseRotator.cpp M_PI MSVC break also
+              # slipped past check-windows because the file's path
+              # wasn't on the filter — same class of issue. Force the
+              # Windows CI build whenever this file changes. (#2671)
+              - 'src/gui/MainWindow.cpp'
+              - 'src/gui/MainWindow.h'
 
   # Cross-platform build check — runs only when CMakeLists.txt, third_party/,
   # or workflows are modified, to catch MSVC issues before release. (#796 lesson)


### PR DESCRIPTION
## Summary

- Adds `src/gui/MainWindow.cpp` and `src/gui/MainWindow.h` to the `dorny/paths-filter` `build` group so the Windows CI job runs whenever the hot file changes.
- The file is densely platform-guarded (`#ifdef Q_OS_WIN`, `Q_OS_MAC`, `HAVE_PIPEWIRE`), so Linux-passing edits can still break MSVC.

## Motivation

Same class of failure has bitten us repeatedly:
- **#2633 → #2662** — unconditional `m_daxBridge` reference inside a macOS-only guard, caught post-release.
- **#2670** — Windows behaviour change not exercised by CI.
- **v26.5.3 (#3024)** — `ClientPhaseRotator.cpp` bare `M_PI` broke MSVC (needs `_USE_MATH_DEFINES`). Different file, same shape: path not on the filter → `check-windows` didn't run → broken Windows build landed and required a follow-up patch.

This PR closes the gap for the highest-leverage file. Other hot platform-guarded files can be added later if their breakage rate justifies the runner time.

## Cost

Most PRs continue to skip `check-windows` (the filter still excludes most source paths). Cost increase is bounded to the subset of PRs that touch MainWindow.cpp/.h, which is exactly the subset that needs the coverage.

## Test plan

- [ ] CI: `check-paths` job runs and reports `build-changed=true` on this PR (because `.github/workflows/**` is itself a watched path).
- [ ] CI: `check-windows` job runs and passes (no source changed, so it should be a clean cache hit).
- [ ] After merge: next PR that touches `src/gui/MainWindow.cpp` triggers `check-windows` automatically.

Closes #2671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)