### PR TITLE
fix(panadapter): prime spectrum widget dBm range on wire to prevent flat secondary pans on reconnect

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2834,6 +2834,10 @@ MainWindow::MainWindow(QWidget* parent)
                 sw->overlayMenu()->syncWnbState(pan->wnbActive(),
                                                 pan->wnbLevel(),
                                                 pan->wnbUpdating());
+                // Prime the spectrum widget with the pan's current dBm range on
+                // reconnect so the noise-floor auto-adjust starts from the correct
+                // position. (#3029)
+                sw->setDbmRange(pan->minDbm(), pan->maxDbm());
             }
             return;
         }
@@ -11357,6 +11361,15 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             }
             sw->setDbmRange(minDbm, maxDbm);
         });
+
+        // Prime the spectrum widget with the pan's current dBm range immediately
+        // so the noise-floor auto-adjust starts from the correct position.
+        // Without this, the widget defaults to refLevel=-50 / dynamicRange=100
+        // while the radio model already knows the saved range (e.g. -130 to -40).
+        // On reconnect the auto-adjust would animate from the wrong baseline and
+        // fire dbmRangeChangeRequested with bogus values — which then locks out the
+        // correct radio-reported range via the pendingDbm guard. (#3029)
+        sw->setDbmRange(pan->minDbm(), pan->maxDbm());
 
         auto oldFpsConnection = m_panFpsReconcileConnections.take(applet->panId());
         if (oldFpsConnection)


### PR DESCRIPTION
## Summary

- **Bug**: Secondary panadapters (Slices B–H, up to 8 total) occasionally go completely flat after reconnecting to the radio — showing no signal while Slice A works normally. Switching bands restores them, and the issue is intermittent.
- **Root cause**: Two compounding issues:
  1. `SpectrumWidget` initialises with `refLevel = -50 dBm, dynamicRange = 100 dB` but `PanadapterModel` already carries the correct saved range (default −130 → −40 dBm). Neither `wirePanadapter()` nor the `panadapterAdded` reconnect path primed the widget from the model, so every non-primary pan started with a stale widget state.
  2. If `DisplayNoiseFloorEnable` is on for any secondary pan, the noise-floor auto-adjust begins animating `refLevel` toward its target from the wrong starting point (−50 instead of −40 dBm) before the radio echoes back its saved `min_dbm`/`max_dbm`. This produces bogus `dbmRangeChangeRequested` values (e.g. −84.59 → +5.41 dBm). The `pendingDbm` guard in `wirePanadapter` then poisons `PanadapterStream::m_dbmRanges` with those values and sends them to the radio, causing the VITA-49 decoder to normalise FFT bins to a window far above the actual HF noise floor. All real signals fall off the bottom of the display. The guard re-asserts the bogus range on every subsequent `levelChanged` echo, creating a self-reinforcing lock-out.
- **Slice A immunity**: Slice A is wired first; by the time its noise-floor auto-adjust fires, a dBm command from a separate code path has already arrived and set the correct range.

## Fix

Prime `sw->setDbmRange(pan->minDbm(), pan->maxDbm())` immediately after wiring `levelChanged` in both affected code paths (`MainWindow.cpp`):

- `wirePanadapter()` — every new applet at initial connection
- `panadapterAdded()` "existing applet" branch — every pan on reconnect

Both sites apply to all panadapters (1–8) unconditionally.

## Test plan

- [ ] Connect to radio with two or more panadapters and noise-floor auto-adjust enabled on all pans — confirm all pans display spectrum data after connect
- [ ] Disconnect and reconnect 5–10 times — confirm no secondary pan goes flat
- [ ] Switch bands while connected — confirm dBm range adjusts correctly on all pans
- [ ] Connect with a single panadapter — confirm no regression
- [ ] Verify noise-floor auto-adjust still tracks and adjusts the display correctly on all pans after connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)