### PR TITLE
fix(applet-panel): TXDSP drag silently failed due to ID mismatch (#1836)

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -138,6 +138,21 @@ protected:
         for (int i = 0; i < m_panel->m_appletOrder.size(); ++i) {
             if (m_panel->m_appletOrder[i].id == draggedId) { srcIdx = i; break; }
         }
+        // Composite tiles (e.g. TXDSP) have an internal ContainerWidget
+        // whose m_id ("tx_dsp") differs from the AppletEntry.id ("TXDSP")
+        // that owns it. The drag MIME data is set from the container's id
+        // in ContainerWidget; without this fallback, dragging TXDSP's title
+        // bar silently fails the AppletEntry lookup above. The container id
+        // "tx_dsp" is persisted (ContainerGeometry_tx_dsp, ContainerTree
+        // parent refs) so we can't rename it without a migration — aliasing
+        // here is the cheaper, regression-safe fix. (#1836)
+        if (srcIdx < 0) {
+            for (int i = 0; i < m_panel->m_appletOrder.size(); ++i) {
+                auto* c = qobject_cast<ContainerWidget*>(
+                    m_panel->m_appletOrder[i].widget);
+                if (c && c->id() == draggedId) { srcIdx = i; break; }
+            }
+        }
         if (srcIdx < 0) return;
 
         // Adjust drop index if moving down (after removing source)


### PR DESCRIPTION
## Summary

Fixes #1836. Dragging the TXDSP (VUDU) tile's title bar to reorder it in the applet panel silently did nothing because the composite tile's underlying container id (`tx_dsp`) and its AppletEntry id (`TXDSP`) didn't match.

## Root cause

\`AppletEntry.id = "TXDSP"\` is the persistence key (\`Applet_TXDSP\`), but the underlying \`ContainerWidget\` was created with id \`"tx_dsp"\` (used as the parent-id reference for its sub-containers). The drag MIME data is set from the container's id in [\`ContainerWidget.cpp:150\`](src/gui/containers/ContainerWidget.cpp#L150), so MIME \`"tx_dsp"\` never matched the \`AppletEntry.id == "TXDSP"\` lookup in \`dropEvent\`. \`srcIdx\` stayed -1, function early-returned. Silent failure.

## Fix

Aliasing fallback in [\`AppletPanel.cpp:128-155\`](src/gui/AppletPanel.cpp#L128-L155) \`dropEvent\`: if the dragged id doesn't match any \`AppletEntry.id\` directly, walk the entries again and check whether any of their underlying \`ContainerWidget\` instances has that id. Catches the composite-tile case without renaming anything.

## Why aliasing instead of renaming

While investigating, found that the container id \`"tx_dsp"\` is persisted in real user settings:

- \`<ContainerGeometry_tx_dsp>0,0,244,988</ContainerGeometry_tx_dsp>\`
- 13+ children in \`ContainerTree\` JSON with \`"parent": "tx_dsp"\`
- The \`"tx_dsp"\` entry itself in \`ContainerTree\` with its children list

A literal rename to \`"TXDSP"\` would orphan every existing user's TXDSP geometry + child layout on first launch. The alias-in-dropEvent fix is regression-safe: zero migration, container m_id stays as-is, only the lookup gains a fallback.

## Stats

- 1 file, +15 / -0
- No new flat-key AppSettings (Principle V N/A)
- MeterSmoother N/A (no meter code)

## Test plan

- [x] Local build clean
- [x] Visual confirmation by Jeremy: TXDSP drag now reorders cleanly
- [x] Non-composite applets (RX, EQ, etc.) still drag — fallback only triggers when direct lookup fails, so fast path unchanged
- [x] Pop-out + dock cycle still works — parent/child container relationship preserved (no renames)
- [ ] CI: build + check-paths green; check-windows skipped (no MainWindow.cpp / build deps touched)

## Checklist

- [x] No new flat-key \`AppSettings\`
- [x] All meter UI uses \`MeterSmoother\` (N/A)
- [x] Documentation updated if user-visible behavior changed (release notes will mention TXDSP reorder fix)

Closes #1836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)