### PR TITLE
Move MQTT configuration into settings dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,6 +460,7 @@ set(CORE_SOURCES
     src/core/PotaClient.cpp
     src/core/PropForecastClient.cpp
     src/core/MqttAntennaAlias.cpp
+    src/core/MqttSettings.cpp
     src/core/SpotCommandPolicy.cpp
     src/core/SpotModeResolver.cpp
     src/core/RigctlServer.cpp
@@ -659,6 +660,7 @@ set(GUI_SOURCES
     src/gui/TciApplet.cpp
     src/gui/DaxIqApplet.cpp
     src/gui/MqttApplet.cpp
+    src/gui/MqttSettingsDialog.cpp
     src/gui/MeterSlider.cpp
     src/gui/PhaseKnob.cpp
     src/gui/AntennaGeniusApplet.cpp
@@ -1520,6 +1522,16 @@ add_executable(mqtt_antenna_alias_test
 target_include_directories(mqtt_antenna_alias_test PRIVATE src)
 target_link_libraries(mqtt_antenna_alias_test PRIVATE Qt6::Core)
 add_test(NAME mqtt_antenna_alias_test COMMAND mqtt_antenna_alias_test)
+
+add_executable(mqtt_settings_test
+    tests/mqtt_settings_test.cpp
+    src/core/MqttSettings.cpp
+    src/core/MqttAntennaAlias.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(mqtt_settings_test PRIVATE src)
+target_link_libraries(mqtt_settings_test PRIVATE Qt6::Core)
+add_test(NAME mqtt_settings_test COMMAND mqtt_settings_test)
 
 # Pure-math test for the ATU pre-tune center-frequency calculator.
 # Locks in the IARU R1 reference table from issue #2624 so future edits

--- a/resources/help/aethersdr-help.md
+++ b/resources/help/aethersdr-help.md
@@ -265,39 +265,42 @@ ham shack automation tools.
 
 #### Quick Start
 
-1. Click the **MQTT** button in the applet toggle row to open the applet.
+1. Open `Settings -> MQTT...`.
 2. Enter your MQTT broker's **Host** and **Port** (default: `localhost:1883`).
-3. Enter comma-separated **Topics** to subscribe to.
-   Prefix a topic with `*` to display its value on the panadapter overlay.
-   Example: `*rotator/pos, *ant/selected, station/log`
-4. Click **On** to connect.
+3. Add subscription topics as rows on the **Subscriptions** tab.
+   Enable **Display** for any topic that should show its latest value on the
+   panadapter overlay.
+4. Open the MQTT applet and click **On** to connect.
+
+The applet remembers the On/Off state. If MQTT was On when AetherSDR closed,
+it reconnects automatically on the next start after the saved password has
+loaded from the keychain.
 
 #### Publish Buttons
 
 You can create custom buttons that publish MQTT messages when clicked:
 
-1. Click **Edit** in the Publish section.
-2. Click the **+** button to add a new button.
+1. Open `Settings -> MQTT...`.
+2. Use the **Publish Buttons** tab to add a new button.
 3. Enter a **Label** (what the button shows), **Topic** (where to publish),
    and **Payload** (the message body).
-4. Click **Done** to exit edit mode.
-5. Click any button to send its message to the broker.
+4. Click any button in the MQTT applet to send its message to the broker.
 
-Right-click a button in edit mode to remove it. Buttons are saved across restarts.
+Buttons are saved across restarts. Up to 12 publish buttons can be configured.
 
 #### Panadapter Overlay
 
-Topics prefixed with `*` display their last received value in the top-right
-corner of the spectrum, below the propagation and WNB indicators. This lets
-you see beam heading, selected antenna, or other station status at a glance
-without leaving the panadapter view.
+Topics with **Display** enabled in `Settings -> MQTT...` show their last
+received value in the top-right corner of the spectrum, below the propagation
+and WNB indicators. Existing settings that use the legacy `*topic` convention
+are loaded as display-enabled rows.
 
 #### Antenna Display Names
 
-AetherSDR can update its local antenna display names from MQTT. Subscribe to
-the topics you want in the MQTT applet while a radio is connected. Retained
-broker messages work well when they arrive after AetherSDR has identified the
-connected radio.
+AetherSDR can update its local antenna display names from MQTT. The AetherSDR
+antenna alias topics are subscribed automatically whenever MQTT connects, so
+they do not need to be added to your user topic rows. Retained broker messages
+work well when they arrive after AetherSDR has identified the connected radio.
 
 - Per-port topic: `aethersdr/antenna/name/ANT1` with payload `80m Dipole`
 - Bulk topic: `aethersdr/antenna/names` with payload
@@ -315,7 +318,7 @@ A typical setup:
 
 - Node-RED publishes `rotator/pos` with the current heading (e.g., `240`)
 - Node-RED subscribes to `rotator/cmd` for control commands
-- In AetherSDR, subscribe to `*rotator/pos` (displays heading on panadapter)
+- In AetherSDR, add `rotator/pos` as a subscription row and enable **Display**
 - Create publish buttons: **CW** (topic `rotator/cmd`, payload `CW`),
   **CCW** (payload `CCW`), **Stop** (payload `STOP`)
 
@@ -326,9 +329,10 @@ without switching windows.
 
 If you use an MQTT-connected antenna switch (via Node-RED, ESP32, etc.):
 
-- Subscribe to `*ant/selected` to see the active antenna on the panadapter
-- Subscribe to `aethersdr/antenna/name/+` or `aethersdr/antenna/names` if
-  your automation publishes the current local antenna display names
+- Add `ant/selected` as a subscription row and enable **Display** to see the
+  active antenna on the panadapter
+- Publish local antenna display names to `aethersdr/antenna/name/+` or
+  `aethersdr/antenna/names`; AetherSDR subscribes to those topics automatically
 - Create buttons for each antenna: **Hexbeam** (topic `ant/select`, payload `1`),
   **Vertical** (payload `2`), **Wire** (payload `3`)
 
@@ -336,7 +340,8 @@ If you use an MQTT-connected antenna switch (via Node-RED, ESP32, etc.):
 
 For SteppIR antennas controlled via MQTT:
 
-- Subscribe to `*steppir/band` and `*steppir/direction`
+- Add `steppir/band` and `steppir/direction` as subscription rows and enable
+  **Display**
 - Create buttons: **Normal** (topic `steppir/cmd`, payload `normal`),
   **180°** (payload `reverse`), **Bi-Dir** (payload `bidir`)
 
@@ -346,7 +351,8 @@ For SteppIR antennas controlled via MQTT:
 - The broker connection auto-reconnects with exponential backoff (5s–60s).
 - Username and password are optional; leave blank for unauthenticated brokers.
 - Enable the `TLS` checkbox to encrypt the connection. The port will switch automatically to 8883. Leave `CA cert` blank to use the system certificate bundle, or enter a path to a custom CA file for self-signed broker certificates.
-- Up to 12 publish buttons can be configured (4 rows × 3 columns).
+- User topics are operator-configurable; AetherSDR-owned antenna alias topics
+  are stable internal API topics and are subscribed automatically.
 
 ## Status Bar
 

--- a/src/core/MqttClient.cpp
+++ b/src/core/MqttClient.cpp
@@ -170,7 +170,15 @@ void MqttClient::setSubscriptions(const QStringList& topics)
         }
     }
 
+    // Subscribe only to topics in `desired` that weren't already in
+    // `previous`.  Mosquitto's subscribe is idempotent broker-side, so
+    // re-subscribing to a stable topic is correct-but-wasteful — costs
+    // a small CONNECT packet and a SUBACK round-trip for every retained
+    // topic on every settings change.  Pin the diff here so a 20-topic
+    // user-list with one added topic emits one SUBSCRIBE instead of 20.
     for (const QString& topic : desired) {
+        if (previous.contains(topic))
+            continue;
         int rc = mosquitto_subscribe(m_mosq, nullptr, topic.toUtf8().constData(), 0);
         if (rc != MOSQ_ERR_SUCCESS) {
             qCWarning(lcMqtt) << "MqttClient: subscribe failed for" << topic

--- a/src/core/MqttClient.cpp
+++ b/src/core/MqttClient.cpp
@@ -145,10 +145,32 @@ void MqttClient::disconnect()
     m_connected = false;
 }
 
-void MqttClient::subscribe(const QString& topic)
+void MqttClient::setSubscriptions(const QStringList& topics)
 {
 #ifdef HAVE_MQTT
-    if (m_connected && m_mosq) {
+    QStringList desired;
+    for (const QString& raw : topics) {
+        const QString topic = raw.trimmed();
+        if (!topic.isEmpty() && !desired.contains(topic)) {
+            desired.append(topic);
+        }
+    }
+
+    const QStringList previous = m_pendingTopics;
+    m_pendingTopics = desired;
+
+    if (!m_connected || !m_mosq) {
+        return;
+    }
+
+    for (const QString& topic : previous) {
+        if (!desired.contains(topic)) {
+            mosquitto_unsubscribe(m_mosq, nullptr, topic.toUtf8().constData());
+            qCDebug(lcMqtt) << "MqttClient: unsubscribed from" << topic;
+        }
+    }
+
+    for (const QString& topic : desired) {
         int rc = mosquitto_subscribe(m_mosq, nullptr, topic.toUtf8().constData(), 0);
         if (rc != MOSQ_ERR_SUCCESS) {
             qCWarning(lcMqtt) << "MqttClient: subscribe failed for" << topic
@@ -156,8 +178,31 @@ void MqttClient::subscribe(const QString& topic)
         } else {
             qCDebug(lcMqtt) << "MqttClient: subscribed to" << topic;
         }
-    } else {
-        m_pendingTopics.append(topic);
+    }
+#else
+    Q_UNUSED(topics);
+#endif
+}
+
+void MqttClient::subscribe(const QString& topic)
+{
+#ifdef HAVE_MQTT
+    const QString trimmedTopic = topic.trimmed();
+    if (trimmedTopic.isEmpty()) {
+        return;
+    }
+    if (!m_pendingTopics.contains(trimmedTopic)) {
+        m_pendingTopics.append(trimmedTopic);
+    }
+
+    if (m_connected && m_mosq) {
+        int rc = mosquitto_subscribe(m_mosq, nullptr, trimmedTopic.toUtf8().constData(), 0);
+        if (rc != MOSQ_ERR_SUCCESS) {
+            qCWarning(lcMqtt) << "MqttClient: subscribe failed for" << trimmedTopic
+                              << mosquitto_strerror(rc);
+        } else {
+            qCDebug(lcMqtt) << "MqttClient: subscribed to" << trimmedTopic;
+        }
     }
 #else
     Q_UNUSED(topic);

--- a/src/core/MqttClient.h
+++ b/src/core/MqttClient.h
@@ -30,6 +30,7 @@ public:
                          bool useTls = false,
                          const QString& caFile = {});
     void disconnect();
+    void setSubscriptions(const QStringList& topics);
     void subscribe(const QString& topic);
     void unsubscribe(const QString& topic);
     void publish(const QString& topic, const QByteArray& payload);

--- a/src/core/MqttSettings.cpp
+++ b/src/core/MqttSettings.cpp
@@ -11,6 +11,31 @@ namespace AetherSDR {
 
 namespace {
 
+// Single nested-JSON key holding all MQTT settings (Principle V).  Shape:
+//   {
+//     "host":     "localhost",
+//     "port":     1883,
+//     "user":     "username",
+//     "tls":      false,
+//     "caFile":   "/path/to/ca.pem",
+//     "topics":   [{"topic": "...", "displayOnPan": true|false}, ...],
+//     "buttons":  [{"label": "...", "topic": "...", "payload": "..."}, ...],
+//     "enabled":  false
+//   }
+//
+// On first save after upgrade, the eight legacy flat keys (kMqttHostKey
+// through kMqttEnabledKey) are removed from AppSettings — the migration
+// is one-shot.  Loading falls back to the legacy keys when the nested
+// JSON key is absent, so existing users' settings carry over transparently.
+//
+// The password is *not* part of this object — it lives in the system
+// keychain (mqttKeychainService / mqttKeychainKey) with a legacy fallback
+// at kLegacyPasswordKey.
+constexpr const char* kMqttSettingsKey = "MqttSettings";
+
+// Legacy flat keys (pre-#3051 schema).  Read for one-shot migration on
+// first load, removed from AppSettings on first save.  Kept here so a
+// future migration sweep (or rollback scenario) can find them easily.
 constexpr const char* kMqttHostKey = "MqttHost";
 constexpr const char* kMqttPortKey = "MqttPort";
 constexpr const char* kMqttUserKey = "MqttUser";
@@ -19,6 +44,7 @@ constexpr const char* kMqttCaFileKey = "MqttCaFile";
 constexpr const char* kMqttTopicsKey = "MqttTopics";
 constexpr const char* kMqttButtonsKey = "MqttButtons";
 constexpr const char* kMqttEnabledKey = "MqttEnabled";
+
 constexpr const char* kKeychainService = "AetherSDR";
 constexpr const char* kKeychainKey = "mqtt_password";
 constexpr const char* kLegacyPasswordKey = "MqttPass";
@@ -26,6 +52,110 @@ constexpr const char* kLegacyPasswordKey = "MqttPass";
 QString trimmed(const QString& value)
 {
     return value.trimmed();
+}
+
+// Forward declaration — defined below; the migration in
+// mqttSettingsObject() uses these to assemble the JSON from legacy keys.
+QJsonArray topicsToJsonArray(const QVector<MqttTopicDef>& topics);
+
+// Load the nested MQTT settings object.  If the new key is absent, build
+// the equivalent object from the eight legacy flat keys (transparent
+// upgrade — first save will then persist the new key and remove the old
+// ones).  If neither is present, returns an empty object; callers should
+// supply their own defaults from the empty fields.
+QJsonObject mqttSettingsObject()
+{
+    auto& settings = AppSettings::instance();
+    const QString raw = settings.value(kMqttSettingsKey, QString()).toString();
+    if (!raw.isEmpty()) {
+        QJsonParseError error;
+        const QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8(), &error);
+        if (error.error == QJsonParseError::NoError && doc.isObject())
+            return doc.object();
+    }
+
+    // Migrate from legacy flat keys.  Touch the same defaults the old
+    // per-field load functions used so behaviour is unchanged when no
+    // key (new or old) exists.
+    QJsonObject obj;
+    if (settings.contains(kMqttHostKey))
+        obj.insert(QStringLiteral("host"),
+                   settings.value(kMqttHostKey).toString().trimmed());
+    if (settings.contains(kMqttPortKey)) {
+        bool ok = false;
+        const uint port = settings.value(kMqttPortKey).toString().toUInt(&ok);
+        if (ok && port > 0 && port <= 65535)
+            obj.insert(QStringLiteral("port"), static_cast<int>(port));
+    }
+    if (settings.contains(kMqttUserKey))
+        obj.insert(QStringLiteral("user"),
+                   settings.value(kMqttUserKey).toString().trimmed());
+    if (settings.contains(kMqttTlsKey))
+        obj.insert(QStringLiteral("tls"),
+                   settings.value(kMqttTlsKey).toString() == QLatin1String("True"));
+    if (settings.contains(kMqttCaFileKey))
+        obj.insert(QStringLiteral("caFile"),
+                   settings.value(kMqttCaFileKey).toString().trimmed());
+    if (settings.contains(kMqttTopicsKey))
+        obj.insert(QStringLiteral("topics"),
+                   topicsToJsonArray(parseMqttTopicConfig(
+                       settings.value(kMqttTopicsKey).toString())));
+    if (settings.contains(kMqttButtonsKey)) {
+        const QJsonDocument doc = QJsonDocument::fromJson(
+            settings.value(kMqttButtonsKey).toString().toUtf8());
+        if (doc.isArray())
+            obj.insert(QStringLiteral("buttons"), doc.array());
+    }
+    if (settings.contains(kMqttEnabledKey))
+        obj.insert(QStringLiteral("enabled"),
+                   settings.value(kMqttEnabledKey).toString() == QLatin1String("True"));
+    return obj;
+}
+
+// Persist the nested MQTT settings object and one-shot the legacy flat
+// keys out of AppSettings on the same write.  After the first call
+// post-upgrade, the legacy keys are gone and subsequent saves are pure
+// no-ops on them.
+void saveMqttSettingsObject(const QJsonObject& obj)
+{
+    auto& settings = AppSettings::instance();
+    settings.setValue(kMqttSettingsKey,
+                      QString::fromUtf8(
+                          QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    // Strip legacy keys.  Safe to call when they don't exist.
+    for (const char* legacy : {
+            kMqttHostKey, kMqttPortKey, kMqttUserKey, kMqttTlsKey,
+            kMqttCaFileKey, kMqttTopicsKey, kMqttButtonsKey, kMqttEnabledKey,
+         })
+        settings.remove(legacy);
+    settings.save();
+}
+
+QJsonArray topicsToJsonArray(const QVector<MqttTopicDef>& topics)
+{
+    QJsonArray arr;
+    for (const MqttTopicDef& def : topics) {
+        const QString topic = def.topic.trimmed();
+        if (topic.isEmpty()) continue;
+        QJsonObject entry;
+        entry.insert(QStringLiteral("topic"), topic);
+        entry.insert(QStringLiteral("displayOnPan"), def.displayOnPan);
+        arr.append(entry);
+    }
+    return arr;
+}
+
+QVector<MqttTopicDef> topicsFromJsonArray(const QJsonArray& arr)
+{
+    QVector<MqttTopicDef> topics;
+    topics.reserve(arr.size());
+    for (const QJsonValue& v : arr) {
+        const QJsonObject obj = v.toObject();
+        const QString topic = obj.value(QStringLiteral("topic")).toString().trimmed();
+        if (topic.isEmpty()) continue;
+        topics.append({topic, obj.value(QStringLiteral("displayOnPan")).toBool(false)});
+    }
+    return topics;
 }
 
 } // namespace
@@ -47,46 +177,44 @@ QString legacyMqttPasswordSettingKey()
 
 bool mqttConnectionEnabled()
 {
-    return AppSettings::instance().value(kMqttEnabledKey, QStringLiteral("False")).toString()
-        == QLatin1String("True");
+    return mqttSettingsObject().value(QStringLiteral("enabled")).toBool(false);
 }
 
 void saveMqttConnectionEnabled(bool enabled)
 {
-    auto& settings = AppSettings::instance();
-    settings.setValue(kMqttEnabledKey, enabled ? QStringLiteral("True") : QStringLiteral("False"));
-    settings.save();
+    QJsonObject obj = mqttSettingsObject();
+    obj.insert(QStringLiteral("enabled"), enabled);
+    saveMqttSettingsObject(obj);
 }
 
 MqttConnectionConfig loadMqttConnectionConfig()
 {
-    auto& settings = AppSettings::instance();
+    const QJsonObject obj = mqttSettingsObject();
 
     MqttConnectionConfig config;
-    config.host = settings.value(kMqttHostKey, QStringLiteral("localhost")).toString().trimmed();
+    config.host = obj.value(QStringLiteral("host"))
+                      .toString(QStringLiteral("localhost")).trimmed();
 
-    bool ok = false;
-    const uint port = settings.value(kMqttPortKey, QStringLiteral("1883")).toString().toUInt(&ok);
-    config.port = ok && port > 0 && port <= 65535
+    const int port = obj.value(QStringLiteral("port")).toInt(1883);
+    config.port = (port > 0 && port <= 65535)
         ? static_cast<quint16>(port)
         : static_cast<quint16>(1883);
 
-    config.username = settings.value(kMqttUserKey, QString()).toString().trimmed();
-    config.useTls = settings.value(kMqttTlsKey, QStringLiteral("False")).toString()
-        == QLatin1String("True");
-    config.caFile = settings.value(kMqttCaFileKey, QString()).toString().trimmed();
+    config.username = obj.value(QStringLiteral("user")).toString().trimmed();
+    config.useTls = obj.value(QStringLiteral("tls")).toBool(false);
+    config.caFile = obj.value(QStringLiteral("caFile")).toString().trimmed();
     return config;
 }
 
 void saveMqttConnectionConfig(const MqttConnectionConfig& config)
 {
-    auto& settings = AppSettings::instance();
-    settings.setValue(kMqttHostKey, config.host.trimmed());
-    settings.setValue(kMqttPortKey, QString::number(config.port));
-    settings.setValue(kMqttUserKey, config.username.trimmed());
-    settings.setValue(kMqttTlsKey, config.useTls ? QStringLiteral("True") : QStringLiteral("False"));
-    settings.setValue(kMqttCaFileKey, config.caFile.trimmed());
-    settings.save();
+    QJsonObject obj = mqttSettingsObject();
+    obj.insert(QStringLiteral("host"), config.host.trimmed());
+    obj.insert(QStringLiteral("port"), static_cast<int>(config.port));
+    obj.insert(QStringLiteral("user"), config.username.trimmed());
+    obj.insert(QStringLiteral("tls"), config.useTls);
+    obj.insert(QStringLiteral("caFile"), config.caFile.trimmed());
+    saveMqttSettingsObject(obj);
 }
 
 QVector<MqttTopicDef> parseMqttTopicConfig(const QString& value)
@@ -129,15 +257,15 @@ QString serializeMqttTopicConfig(const QVector<MqttTopicDef>& topics)
 
 QVector<MqttTopicDef> loadMqttTopicConfig()
 {
-    return parseMqttTopicConfig(
-        AppSettings::instance().value(kMqttTopicsKey, QString()).toString());
+    return topicsFromJsonArray(
+        mqttSettingsObject().value(QStringLiteral("topics")).toArray());
 }
 
 void saveMqttTopicConfig(const QVector<MqttTopicDef>& topics)
 {
-    auto& settings = AppSettings::instance();
-    settings.setValue(kMqttTopicsKey, serializeMqttTopicConfig(topics));
-    settings.save();
+    QJsonObject obj = mqttSettingsObject();
+    obj.insert(QStringLiteral("topics"), topicsToJsonArray(topics));
+    saveMqttSettingsObject(obj);
 }
 
 QStringList mqttUserSubscriptionTopics(const QVector<MqttTopicDef>& topics)
@@ -233,15 +361,27 @@ QString mqttButtonsToJson(const QVector<MqttButtonDef>& buttons)
 
 QVector<MqttButtonDef> loadMqttButtonConfig()
 {
+    // Buttons sub-array uses the same {label, topic, payload} shape that
+    // mqttButtonsFromJson expects from the legacy flat key, so we can
+    // serialize the sub-array and reuse the helper.
+    const QJsonArray arr = mqttSettingsObject()
+        .value(QStringLiteral("buttons")).toArray();
     return mqttButtonsFromJson(
-        AppSettings::instance().value(kMqttButtonsKey, QString()).toString());
+        QString::fromUtf8(QJsonDocument(arr).toJson(QJsonDocument::Compact)));
 }
 
 void saveMqttButtonConfig(const QVector<MqttButtonDef>& buttons)
 {
-    auto& settings = AppSettings::instance();
-    settings.setValue(kMqttButtonsKey, mqttButtonsToJson(buttons));
-    settings.save();
+    QJsonObject obj = mqttSettingsObject();
+    // Re-parse our own freshly-serialized JSON to produce a QJsonArray
+    // we can splice into the settings object (mqttButtonsToJson returns
+    // a string, not a JSON array — match the legacy storage shape so the
+    // helper stays the single source of truth for button serialization).
+    const QJsonDocument doc = QJsonDocument::fromJson(
+        mqttButtonsToJson(buttons).toUtf8());
+    obj.insert(QStringLiteral("buttons"),
+               doc.isArray() ? doc.array() : QJsonArray());
+    saveMqttSettingsObject(obj);
 }
 
 } // namespace AetherSDR

--- a/src/core/MqttSettings.cpp
+++ b/src/core/MqttSettings.cpp
@@ -1,0 +1,247 @@
+#include "MqttSettings.h"
+
+#include "AppSettings.h"
+#include "MqttAntennaAlias.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr const char* kMqttHostKey = "MqttHost";
+constexpr const char* kMqttPortKey = "MqttPort";
+constexpr const char* kMqttUserKey = "MqttUser";
+constexpr const char* kMqttTlsKey = "MqttTls";
+constexpr const char* kMqttCaFileKey = "MqttCaFile";
+constexpr const char* kMqttTopicsKey = "MqttTopics";
+constexpr const char* kMqttButtonsKey = "MqttButtons";
+constexpr const char* kMqttEnabledKey = "MqttEnabled";
+constexpr const char* kKeychainService = "AetherSDR";
+constexpr const char* kKeychainKey = "mqtt_password";
+constexpr const char* kLegacyPasswordKey = "MqttPass";
+
+QString trimmed(const QString& value)
+{
+    return value.trimmed();
+}
+
+} // namespace
+
+QString mqttKeychainService()
+{
+    return QString::fromLatin1(kKeychainService);
+}
+
+QString mqttKeychainKey()
+{
+    return QString::fromLatin1(kKeychainKey);
+}
+
+QString legacyMqttPasswordSettingKey()
+{
+    return QString::fromLatin1(kLegacyPasswordKey);
+}
+
+bool mqttConnectionEnabled()
+{
+    return AppSettings::instance().value(kMqttEnabledKey, QStringLiteral("False")).toString()
+        == QLatin1String("True");
+}
+
+void saveMqttConnectionEnabled(bool enabled)
+{
+    auto& settings = AppSettings::instance();
+    settings.setValue(kMqttEnabledKey, enabled ? QStringLiteral("True") : QStringLiteral("False"));
+    settings.save();
+}
+
+MqttConnectionConfig loadMqttConnectionConfig()
+{
+    auto& settings = AppSettings::instance();
+
+    MqttConnectionConfig config;
+    config.host = settings.value(kMqttHostKey, QStringLiteral("localhost")).toString().trimmed();
+
+    bool ok = false;
+    const uint port = settings.value(kMqttPortKey, QStringLiteral("1883")).toString().toUInt(&ok);
+    config.port = ok && port > 0 && port <= 65535
+        ? static_cast<quint16>(port)
+        : static_cast<quint16>(1883);
+
+    config.username = settings.value(kMqttUserKey, QString()).toString().trimmed();
+    config.useTls = settings.value(kMqttTlsKey, QStringLiteral("False")).toString()
+        == QLatin1String("True");
+    config.caFile = settings.value(kMqttCaFileKey, QString()).toString().trimmed();
+    return config;
+}
+
+void saveMqttConnectionConfig(const MqttConnectionConfig& config)
+{
+    auto& settings = AppSettings::instance();
+    settings.setValue(kMqttHostKey, config.host.trimmed());
+    settings.setValue(kMqttPortKey, QString::number(config.port));
+    settings.setValue(kMqttUserKey, config.username.trimmed());
+    settings.setValue(kMqttTlsKey, config.useTls ? QStringLiteral("True") : QStringLiteral("False"));
+    settings.setValue(kMqttCaFileKey, config.caFile.trimmed());
+    settings.save();
+}
+
+QVector<MqttTopicDef> parseMqttTopicConfig(const QString& value)
+{
+    QVector<MqttTopicDef> topics;
+    const QStringList parts = value.split(QLatin1Char(','), Qt::SkipEmptyParts);
+    topics.reserve(parts.size());
+
+    for (const QString& raw : parts) {
+        QString topic = raw.trimmed();
+        const bool display = topic.startsWith(QLatin1Char('*'));
+        if (display) {
+            topic = topic.mid(1).trimmed();
+        }
+        if (!topic.isEmpty()) {
+            topics.append({topic, display});
+        }
+    }
+
+    return topics;
+}
+
+QString serializeMqttTopicConfig(const QVector<MqttTopicDef>& topics)
+{
+    QStringList parts;
+    parts.reserve(topics.size());
+
+    for (const MqttTopicDef& def : topics) {
+        const QString topic = def.topic.trimmed();
+        if (topic.isEmpty()) {
+            continue;
+        }
+        parts.append(def.displayOnPan
+                         ? QStringLiteral("*%1").arg(topic)
+                         : topic);
+    }
+
+    return parts.join(QStringLiteral(", "));
+}
+
+QVector<MqttTopicDef> loadMqttTopicConfig()
+{
+    return parseMqttTopicConfig(
+        AppSettings::instance().value(kMqttTopicsKey, QString()).toString());
+}
+
+void saveMqttTopicConfig(const QVector<MqttTopicDef>& topics)
+{
+    auto& settings = AppSettings::instance();
+    settings.setValue(kMqttTopicsKey, serializeMqttTopicConfig(topics));
+    settings.save();
+}
+
+QStringList mqttUserSubscriptionTopics(const QVector<MqttTopicDef>& topics)
+{
+    QStringList names;
+    for (const MqttTopicDef& def : topics) {
+        const QString topic = def.topic.trimmed();
+        if (topic.isEmpty() || names.contains(topic)) {
+            continue;
+        }
+        names.append(topic);
+    }
+    return names;
+}
+
+QStringList internalMqttSubscriptionTopics()
+{
+    return {
+        mqttAntennaAliasTopicPrefix() + QStringLiteral("+"),
+        mqttAntennaAliasBulkTopic(),
+    };
+}
+
+QStringList mqttSubscriptionTopics(const QStringList& userTopics)
+{
+    QStringList allTopics;
+
+    for (const QString& raw : userTopics) {
+        const QString topic = raw.trimmed();
+        if (!topic.isEmpty() && !allTopics.contains(topic)) {
+            allTopics.append(topic);
+        }
+    }
+
+    for (const QString& topic : internalMqttSubscriptionTopics()) {
+        if (!allTopics.contains(topic)) {
+            allTopics.append(topic);
+        }
+    }
+
+    return allTopics;
+}
+
+QStringList mqttSubscriptionTopics(const QVector<MqttTopicDef>& userTopics)
+{
+    return mqttSubscriptionTopics(mqttUserSubscriptionTopics(userTopics));
+}
+
+QVector<MqttButtonDef> mqttButtonsFromJson(const QString& json)
+{
+    QVector<MqttButtonDef> buttons;
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
+    if (!doc.isArray()) {
+        return buttons;
+    }
+
+    const QJsonArray arr = doc.array();
+    buttons.reserve(arr.size());
+    for (const QJsonValue& value : arr) {
+        const QJsonObject obj = value.toObject();
+        MqttButtonDef def{
+            trimmed(obj.value(QStringLiteral("label")).toString()),
+            trimmed(obj.value(QStringLiteral("topic")).toString()),
+            obj.value(QStringLiteral("payload")).toString(),
+        };
+        if (!def.label.isEmpty() || !def.topic.isEmpty() || !def.payload.isEmpty()) {
+            buttons.append(def);
+        }
+    }
+
+    return buttons;
+}
+
+QString mqttButtonsToJson(const QVector<MqttButtonDef>& buttons)
+{
+    QJsonArray arr;
+    for (const MqttButtonDef& def : buttons) {
+        const QString label = def.label.trimmed();
+        const QString topic = def.topic.trimmed();
+        if (label.isEmpty() && topic.isEmpty() && def.payload.isEmpty()) {
+            continue;
+        }
+
+        QJsonObject obj;
+        obj.insert(QStringLiteral("label"), label);
+        obj.insert(QStringLiteral("topic"), topic);
+        obj.insert(QStringLiteral("payload"), def.payload);
+        arr.append(obj);
+    }
+
+    return QString::fromUtf8(QJsonDocument(arr).toJson(QJsonDocument::Compact));
+}
+
+QVector<MqttButtonDef> loadMqttButtonConfig()
+{
+    return mqttButtonsFromJson(
+        AppSettings::instance().value(kMqttButtonsKey, QString()).toString());
+}
+
+void saveMqttButtonConfig(const QVector<MqttButtonDef>& buttons)
+{
+    auto& settings = AppSettings::instance();
+    settings.setValue(kMqttButtonsKey, mqttButtonsToJson(buttons));
+    settings.save();
+}
+
+} // namespace AetherSDR

--- a/src/core/MqttSettings.h
+++ b/src/core/MqttSettings.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+namespace AetherSDR {
+
+struct MqttConnectionConfig {
+    QString host;
+    quint16 port{1883};
+    QString username;
+    bool useTls{false};
+    QString caFile;
+};
+
+struct MqttTopicDef {
+    QString topic;
+    bool displayOnPan{false};
+};
+
+struct MqttButtonDef {
+    QString label;
+    QString topic;
+    QString payload;
+};
+
+QString mqttKeychainService();
+QString mqttKeychainKey();
+QString legacyMqttPasswordSettingKey();
+
+bool mqttConnectionEnabled();
+void saveMqttConnectionEnabled(bool enabled);
+
+MqttConnectionConfig loadMqttConnectionConfig();
+void saveMqttConnectionConfig(const MqttConnectionConfig& config);
+
+QVector<MqttTopicDef> parseMqttTopicConfig(const QString& value);
+QString serializeMqttTopicConfig(const QVector<MqttTopicDef>& topics);
+QVector<MqttTopicDef> loadMqttTopicConfig();
+void saveMqttTopicConfig(const QVector<MqttTopicDef>& topics);
+QStringList mqttUserSubscriptionTopics(const QVector<MqttTopicDef>& topics);
+
+QStringList internalMqttSubscriptionTopics();
+QStringList mqttSubscriptionTopics(const QStringList& userTopics);
+QStringList mqttSubscriptionTopics(const QVector<MqttTopicDef>& userTopics);
+
+QVector<MqttButtonDef> mqttButtonsFromJson(const QString& json);
+QString mqttButtonsToJson(const QVector<MqttButtonDef>& buttons);
+QVector<MqttButtonDef> loadMqttButtonConfig();
+void saveMqttButtonConfig(const QVector<MqttButtonDef>& buttons);
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3,7 +3,9 @@
 #include "CwDecodeSettings.h"
 #ifdef HAVE_MQTT
 #include "MqttApplet.h"
+#include "MqttSettingsDialog.h"
 #include "core/MqttAntennaAlias.h"
+#include "core/MqttSettings.h"
 #endif
 #include "ConnectionPanel.h"
 #include "Theme.h"
@@ -1835,13 +1837,14 @@ MainWindow::MainWindow(QWidget* parent)
                          const QString& user, const QString& pass,
                          const QStringList& topics,
                          bool useTls, const QString& caFile) {
+        m_mqttClient->setSubscriptions(mqttSubscriptionTopics(topics));
         m_mqttClient->connectToBroker(host, port, user, pass, useTls, caFile);
-        for (const QString& t : topics) {
-            m_mqttClient->subscribe(t);
-        }
     });
     connect(m_appletPanel->mqttApplet(), &MqttApplet::disconnectRequested,
             this, [this] { m_mqttClient->disconnect(); });
+    connect(m_appletPanel->mqttApplet(), &MqttApplet::settingsRequested,
+            this, &MainWindow::showMqttSettingsDialog);
+    m_appletPanel->mqttApplet()->restoreConnectionState();
 
     // MQTT → panadapter overlay display
     connect(m_appletPanel->mqttApplet(), &MqttApplet::displayValueChanged,
@@ -5262,6 +5265,28 @@ AetherDspDialog* MainWindow::ensureAetherDspDialog()
     return m_dspDialog.data();
 }
 
+#ifdef HAVE_MQTT
+void MainWindow::showMqttSettingsDialog()
+{
+    const bool wasFresh = !m_mqttSettingsDialog;
+    showOrRaisePersistent(m_mqttSettingsDialog);
+    if (!wasFresh || !m_mqttSettingsDialog)
+        return;
+
+    connect(m_mqttSettingsDialog, &MqttSettingsDialog::settingsSaved,
+            this, [this](const QString& password) {
+        if (!m_appletPanel || !m_appletPanel->mqttApplet())
+            return;
+        auto* mqttApplet = m_appletPanel->mqttApplet();
+        mqttApplet->setCachedPassword(password);
+        mqttApplet->refreshSettings();
+        if (m_mqttClient) {
+            m_mqttClient->setSubscriptions(mqttSubscriptionTopics(mqttApplet->topicConfig()));
+        }
+    });
+}
+#endif
+
 void MainWindow::wireRadioSetupDialogSignals(RadioSetupDialog* dlg, const QString& prevComp)
 {
     if (!dlg) return;
@@ -7246,6 +7271,12 @@ void MainWindow::buildMenuBar()
     connect(networkAction, &QAction::triggered, this, [this] {
         showNetworkDiagnosticsDialog();
     });
+#ifdef HAVE_MQTT
+    auto* mqttAction = settingsMenu->addAction("MQTT...");
+    mqttAction->setMenuRole(QAction::NoRole);
+    connect(mqttAction, &QAction::triggered,
+            this, &MainWindow::showMqttSettingsDialog);
+#endif
     auto* memoryAction = settingsMenu->addAction("Memory...");
     connect(memoryAction, &QAction::triggered, this, [this] {
         showMemoryDialog();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -87,6 +87,7 @@ class MemoryDialog;
 class PropDashboardDialog;
 class TxBandDialog;
 class AetherDspDialog;
+class MqttSettingsDialog;
 class WaveformsDialog;
 class DxClusterDialog;
 class Ax25HfPacketDecodeDialog;
@@ -332,6 +333,9 @@ private:
     void showNr4ParamPopup(const QPoint& globalPos);
     void showDfnrParamPopup(const QPoint& globalPos);
     void showMnrSettings();
+#ifdef HAVE_MQTT
+    void showMqttSettingsDialog();
+#endif
     void applyPanLayout(const QString& layoutId);
     void createPansSequentially(const QString& layoutId, int total,
                                 std::shared_ptr<QStringList> panIds, int created);
@@ -572,6 +576,9 @@ private:
     QPointer<FlexControlDialog> m_flexControlDialog;
     QPointer<WhatsNewDialog> m_whatsNewDialog;
     QPointer<AetherDspDialog> m_dspDialog;
+#ifdef HAVE_MQTT
+    QPointer<MqttSettingsDialog> m_mqttSettingsDialog;
+#endif
     QPointer<WaveformsDialog> m_waveformsDialog;
     QPointer<ProfileManagerDialog> m_profileManagerDialog;
     QPointer<ProfileImportExportDialog> m_profileImportExportDialog;

--- a/src/gui/MqttApplet.cpp
+++ b/src/gui/MqttApplet.cpp
@@ -1,24 +1,20 @@
 #include "MqttApplet.h"
+
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
 #include "core/MqttAntennaAlias.h"
 #include "core/MqttClient.h"
 
-#include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QGridLayout>
-#include <QCheckBox>
+#include <QHBoxLayout>
 #include <QLabel>
-#include <QLineEdit>
+#include <QLayoutItem>
 #include <QPushButton>
-#include <QTextEdit>
 #include <QTextBlock>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
-#include <QDialog>
-#include <QDialogButtonBox>
-#include <QMenu>
+#include <QTextCursor>
+#include <QTextDocument>
+#include <QTextEdit>
+#include <QVBoxLayout>
 
 #ifdef HAVE_KEYCHAIN
 #include <qt6keychain/keychain.h>
@@ -26,19 +22,6 @@
 
 namespace AetherSDR {
 
-// Keychain identifiers for the MQTT broker password.  See
-// GHSA-mmqp-cm4w-cvpp — previously stored as plaintext in
-// ~/.config/AetherSDR/AetherSDR.settings (default umask 0644, world-
-// readable on most Linux systems).
-static constexpr const char* kKeychainService = "AetherSDR";
-static constexpr const char* kKeychainKey     = "mqtt_password";
-static constexpr const char* kLegacySetting   = "MqttPass";
-
-static const QString kLabelStyle =
-    "QLabel { color: #8090a0; font-size: 10px; background: transparent; }";
-static const QString kEditStyle =
-    "QLineEdit { background: #0a0a14; color: #c8d8e8; border: 1px solid #203040; "
-    "padding: 2px 4px; font-size: 10px; }";
 static const QString kBtnOff =
     "QPushButton { background: #1a2a3a; color: #8090a0; "
     "border: 1px solid #205070; padding: 2px 8px; border-radius: 3px; font-size: 10px; }";
@@ -50,127 +33,43 @@ static const QString kPubBtn =
     "border: 1px solid #306080; padding: 4px 6px; border-radius: 3px; font-size: 10px; }"
     "QPushButton:hover { background: #203850; }"
     "QPushButton:pressed { background: #00b4d8; color: #0f0f1a; }";
-static const QString kPubBtnEdit =
-    "QPushButton { background: #2a1a1a; color: #d8a080; "
-    "border: 1px dashed #805030; padding: 4px 6px; border-radius: 3px; font-size: 10px; }";
 
 MqttApplet::MqttApplet(QWidget* parent)
     : QWidget(parent)
 {
-    loadButtons();
+    refreshSettings();
     buildUI();
+    loadPasswordFromKeychain();
 }
 
 void MqttApplet::buildUI()
 {
     auto* vbox = new QVBoxLayout(this);
     vbox->setContentsMargins(4, 4, 4, 4);
-    vbox->setSpacing(3);
+    vbox->setSpacing(5);
 
-    // Header
+    auto* headerRow = new QHBoxLayout;
     auto* header = new QLabel("MQTT");
     header->setStyleSheet("QLabel { color: #c8d8e8; font-size: 11px; font-weight: bold; }");
-    vbox->addWidget(header);
+    headerRow->addWidget(header);
+    headerRow->addStretch();
 
-    // Broker settings grid.  Accessibility hints (objectName +
-    // accessibleName + accessibleDescription) help macOS Passwords,
-    // Windows Authenticator, and KDE Wallet associate user/pass fields
-    // when offering autofill.  No-op on platforms / password managers
-    // that don't read the accessibility tree.
-    auto* grid = new QGridLayout;
-    grid->setSpacing(2);
-    grid->setContentsMargins(0, 0, 0, 0);
+    auto* settingsBtn = new QPushButton("Settings...");
+    settingsBtn->setFixedHeight(18);
+    settingsBtn->setStyleSheet(
+        "QPushButton { background: transparent; color: #8090a0; "
+        "border: none; font-size: 9px; padding: 0 4px; }"
+        "QPushButton:hover { color: #c8d8e8; }");
+    headerRow->addWidget(settingsBtn);
+    vbox->addLayout(headerRow);
 
-    setObjectName(QStringLiteral("mqttLoginForm"));
-    setAccessibleName(tr("MQTT broker connection"));
+    connect(settingsBtn, &QPushButton::clicked, this, &MqttApplet::settingsRequested);
 
-    auto& s = AppSettings::instance();
+    auto* note = new QLabel("Antenna alias topics are subscribed automatically.");
+    note->setWordWrap(true);
+    note->setStyleSheet("QLabel { color: #8090a0; font-size: 10px; background: transparent; }");
+    vbox->addWidget(note);
 
-    auto addRow = [&](int row, const QString& label, QLineEdit*& edit,
-                      const QString& key, const QString& def,
-                      const QString& objName, const QString& a11yName,
-                      const QString& a11yDesc, bool password = false) {
-        auto* lbl = new QLabel(label);
-        lbl->setStyleSheet(kLabelStyle);
-        grid->addWidget(lbl, row, 0);
-        edit = new QLineEdit(s.value(key, def).toString());
-        edit->setStyleSheet(kEditStyle);
-        if (password) { edit->setEchoMode(QLineEdit::Password); }
-        if (!objName.isEmpty())  edit->setObjectName(objName);
-        if (!a11yName.isEmpty()) edit->setAccessibleName(a11yName);
-        if (!a11yDesc.isEmpty()) edit->setAccessibleDescription(a11yDesc);
-        grid->addWidget(edit, row, 1);
-    };
-
-    addRow(0, "Host:", m_hostEdit, "MqttHost", "localhost",
-           QStringLiteral("mqttHost"), tr("MQTT broker host"),
-           tr("Hostname or IP address of the MQTT broker"));
-    addRow(1, "Port:", m_portEdit, "MqttPort", "1883",
-           QStringLiteral("mqttPort"), tr("MQTT broker port"),
-           tr("TCP port for the MQTT broker (1883 plaintext, 8883 TLS)"));
-    addRow(2, "User:", m_userEdit, "MqttUser", "",
-           QStringLiteral("mqttUsername"), tr("MQTT broker username"),
-           tr("Username for MQTT broker authentication"));
-    // Password is not stored in AppSettings (see GHSA-mmqp-cm4w-cvpp).
-    // addRow with an empty default + sentinel key leaves the QLineEdit
-    // empty; we populate it asynchronously from the keychain below, and
-    // migrate any legacy plaintext value found in AppSettings on first
-    // launch.
-    addRow(3, "Pass:", m_passEdit, QStringLiteral("MqttPass_unused"), QString(),
-           QStringLiteral("mqttPassword"), tr("MQTT broker password"),
-           tr("Password for MQTT broker authentication"), true);
-    loadPasswordFromKeychain();
-
-    auto* topicLbl = new QLabel("Topics:");
-    topicLbl->setStyleSheet(kLabelStyle);
-    grid->addWidget(topicLbl, 4, 0, Qt::AlignTop);
-    m_topicsEdit = new QLineEdit(s.value("MqttTopics", "").toString());
-    m_topicsEdit->setStyleSheet(kEditStyle);
-    m_topicsEdit->setPlaceholderText("topic1, topic2, ...");
-    m_topicsEdit->setToolTip("Comma-separated MQTT topics to subscribe to.\n"
-                             "Prefix with * to display on panadapter overlay.\n"
-                             "Antenna names: aethersdr/antenna/name/+, aethersdr/antenna/names\n"
-                             "Example: *rotator/pos, *ant/selected, station/log");
-    grid->addWidget(m_topicsEdit, 4, 1);
-
-    // TLS row
-    auto* tlsLbl = new QLabel("TLS:");
-    tlsLbl->setStyleSheet(kLabelStyle);
-    grid->addWidget(tlsLbl, 5, 0);
-    m_tlsCheck = new QCheckBox;
-    m_tlsCheck->setChecked(s.value("MqttTls", "False").toString() == "True");
-    m_tlsCheck->setStyleSheet("QCheckBox { color: #8090a0; font-size: 10px; }");
-    m_tlsCheck->setToolTip("Enable TLS encryption (requires broker on port 8883)");
-    grid->addWidget(m_tlsCheck, 5, 1);
-
-    // CA certificate row (shown only when TLS is checked)
-    auto* caLbl = new QLabel("CA cert:");
-    caLbl->setStyleSheet(kLabelStyle);
-    grid->addWidget(caLbl, 6, 0);
-    m_caFileEdit = new QLineEdit(s.value("MqttCaFile", "").toString());
-    m_caFileEdit->setStyleSheet(kEditStyle);
-    m_caFileEdit->setPlaceholderText("optional, blank = system CA bundle");
-    m_caFileEdit->setToolTip("Path to CA certificate file.\nLeave blank to use the system CA bundle.");
-    grid->addWidget(m_caFileEdit, 6, 1);
-
-    // Show/hide CA row based on TLS checkbox state
-    auto updateCaVisibility = [caLbl, this](bool checked) {
-        caLbl->setVisible(checked);
-        m_caFileEdit->setVisible(checked);
-        // Auto-switch port between 1883 and 8883
-        QString port = m_portEdit->text().trimmed();
-        if (checked && port == "1883") {
-            m_portEdit->setText("8883");
-        } else if (!checked && port == "8883") {
-            m_portEdit->setText("1883");
-        }
-    };
-    updateCaVisibility(m_tlsCheck->isChecked());
-    connect(m_tlsCheck, &QCheckBox::toggled, this, updateCaVisibility);
-
-    vbox->addLayout(grid);
-
-    // Enable button + status
     auto* ctrlRow = new QHBoxLayout;
     ctrlRow->setSpacing(4);
     m_enableBtn = new QPushButton("Off");
@@ -183,93 +82,45 @@ void MqttApplet::buildUI()
     ctrlRow->addWidget(m_statusLabel, 1);
     vbox->addLayout(ctrlRow);
 
-    // Publish buttons section
-    {
-        auto* pubHeader = new QHBoxLayout;
-        auto* pubLbl = new QLabel("Publish");
-        pubLbl->setStyleSheet("QLabel { color: #8090a0; font-size: 10px; font-weight: bold; }");
-        pubHeader->addWidget(pubLbl);
-        pubHeader->addStretch();
+    auto* pubLbl = new QLabel("Publish");
+    pubLbl->setStyleSheet("QLabel { color: #8090a0; font-size: 10px; font-weight: bold; }");
+    vbox->addWidget(pubLbl);
 
-        m_editBtn = new QPushButton("Edit");
-        m_editBtn->setFixedHeight(16);
-        m_editBtn->setStyleSheet(
-            "QPushButton { background: transparent; color: #607080; "
-            "border: none; font-size: 9px; padding: 0 4px; }"
-            "QPushButton:hover { color: #c8d8e8; }");
-        pubHeader->addWidget(m_editBtn);
-        vbox->addLayout(pubHeader);
+    auto* btnContainer = new QWidget;
+    m_buttonGrid = new QGridLayout(btnContainer);
+    m_buttonGrid->setContentsMargins(0, 0, 0, 0);
+    m_buttonGrid->setSpacing(2);
+    vbox->addWidget(btnContainer);
+    rebuildButtons();
 
-        auto* btnContainer = new QWidget;
-        m_buttonGrid = new QGridLayout(btnContainer);
-        m_buttonGrid->setContentsMargins(0, 0, 0, 0);
-        m_buttonGrid->setSpacing(2);
-        vbox->addWidget(btnContainer);
-
-        rebuildButtons();
-
-        connect(m_editBtn, &QPushButton::clicked, this, [this] {
-            m_editMode = !m_editMode;
-            m_editBtn->setText(m_editMode ? "Done" : "Edit");
-            rebuildButtons();
-        });
-    }
-
-    // Message log
     m_messageLog = new QTextEdit;
     m_messageLog->setReadOnly(true);
-    m_messageLog->setMaximumHeight(80);
+    m_messageLog->setMaximumHeight(95);
     m_messageLog->setStyleSheet(
         "QTextEdit { background: #0a0a14; color: #c8d8e8; border: 1px solid #203040; "
         "font-size: 10px; font-family: monospace; }");
     vbox->addWidget(m_messageLog);
 
-    // Enable toggle
     connect(m_enableBtn, &QPushButton::clicked, this, [this] {
-        bool wasOn = m_enableBtn->text() == "On";
+        const bool wasOn = m_enableBtn->text() == QLatin1String("On");
         if (wasOn) {
+            saveMqttConnectionEnabled(false);
+            m_restoreConnectPending = false;
             emit disconnectRequested();
             m_enableBtn->setText("Off");
             m_enableBtn->setStyleSheet(kBtnOff);
-        } else {
-            auto& ss = AppSettings::instance();
-            ss.setValue("MqttHost",   m_hostEdit->text().trimmed());
-            ss.setValue("MqttPort",   m_portEdit->text().trimmed());
-            ss.setValue("MqttUser",   m_userEdit->text().trimmed());
-            // Password lives in QKeychain — see GHSA-mmqp-cm4w-cvpp.
-            // Belt-and-braces: ensure no legacy plaintext entry survives.
-            ss.remove(kLegacySetting);
-            savePasswordToKeychain(m_passEdit->text().trimmed());
-            ss.setValue("MqttTopics", m_topicsEdit->text().trimmed());
-            ss.setValue("MqttTls",    m_tlsCheck->isChecked() ? "True" : "False");
-            ss.setValue("MqttCaFile", m_caFileEdit->text().trimmed());
-            ss.save();
+            return;
+        }
 
-            // Parse topics — * prefix means display on panadapter
-            m_topicDefs.clear();
-            QStringList topicNames;
-            for (const QString& raw : m_topicsEdit->text().split(',', Qt::SkipEmptyParts)) {
-                QString t = raw.trimmed();
-                bool display = t.startsWith('*');
-                if (display) { t = t.mid(1).trimmed(); }
-                if (!t.isEmpty()) {
-                    m_topicDefs.append({t, display});
-                    topicNames.append(t);
-                }
-            }
-
-            emit connectRequested(
-                m_hostEdit->text().trimmed(),
-                m_portEdit->text().trimmed().toUShort(),
-                m_userEdit->text().trimmed(),
-                m_passEdit->text().trimmed(),
-                topicNames,
-                m_tlsCheck->isChecked(),
-                m_caFileEdit->text().trimmed());
-
+        saveMqttConnectionEnabled(true);
+        if (!m_passwordLoaded) {
+            m_restoreConnectPending = true;
             m_enableBtn->setText("On");
             m_enableBtn->setStyleSheet(kBtnOn);
+            updateStatus("Waiting for keychain", false);
+            return;
         }
+        requestConnectFromSettings();
     });
 }
 
@@ -293,6 +144,40 @@ void MqttApplet::setMqttClient(MqttClient* client)
     connect(client, &MqttClient::messageReceived, this, &MqttApplet::onMessageReceived);
 }
 
+void MqttApplet::refreshSettings()
+{
+    m_topicDefs = loadMqttTopicConfig();
+    m_buttonDefs = loadMqttButtonConfig();
+    if (m_buttonGrid) {
+        rebuildButtons();
+    }
+}
+
+void MqttApplet::setCachedPassword(const QString& password)
+{
+    m_password = password;
+    m_passwordLoaded = true;
+}
+
+void MqttApplet::restoreConnectionState()
+{
+    if (!mqttConnectionEnabled()) {
+        return;
+    }
+
+    if (!m_passwordLoaded) {
+        m_restoreConnectPending = true;
+        if (m_enableBtn) {
+            m_enableBtn->setText("On");
+            m_enableBtn->setStyleSheet(kBtnOn);
+        }
+        updateStatus("Waiting for keychain", false);
+        return;
+    }
+
+    requestConnectFromSettings();
+}
+
 void MqttApplet::updateStatus(const QString& text, bool ok)
 {
     m_statusLabel->setText(text);
@@ -305,9 +190,9 @@ void MqttApplet::onMessageReceived(const QString& topic, const QByteArray& paylo
 {
     QString shortTopic = topic.section('/', -1);
     if (shortTopic.isEmpty()) { shortTopic = topic; }
-    QString value = QString::fromUtf8(payload).left(80);
+    const QString value = QString::fromUtf8(payload).left(80);
 
-    QString line = QString("%1: %2").arg(shortTopic, value);
+    const QString line = QString("%1: %2").arg(shortTopic, value);
     m_messageLog->append(line);
 
     QTextDocument* doc = m_messageLog->document();
@@ -322,8 +207,8 @@ void MqttApplet::onMessageReceived(const QString& topic, const QByteArray& paylo
         emit antennaAliasRequested(update.token, update.alias);
     }
 
-    // Update panadapter overlay for display-enabled topics
-    for (const auto& td : m_topicDefs) {
+    // Update panadapter overlay for display-enabled user topics only.
+    for (const MqttTopicDef& td : m_topicDefs) {
         if (td.displayOnPan && td.topic == topic) {
             emit displayValueChanged(shortTopic, value);
             break;
@@ -331,150 +216,59 @@ void MqttApplet::onMessageReceived(const QString& topic, const QByteArray& paylo
     }
 }
 
-// ── Publish Buttons ──────────────────────────────────────────────────────────
-
 void MqttApplet::rebuildButtons()
 {
-    // Clear existing
-    for (auto* btn : m_buttons) { delete btn; }
-    m_buttons.clear();
-
-    // Remove the "+" button if it exists
-    QLayoutItem* item;
+    QLayoutItem* item = nullptr;
     while ((item = m_buttonGrid->takeAt(0)) != nullptr) {
         delete item->widget();
         delete item;
     }
+    m_buttons.clear();
 
-    // Add buttons from defs
     for (int i = 0; i < m_buttonDefs.size(); ++i) {
         auto* btn = new QPushButton(m_buttonDefs[i].label);
-        btn->setStyleSheet(m_editMode ? kPubBtnEdit : kPubBtn);
-        btn->setToolTip(m_editMode
-            ? QString("Click to edit\nTopic: %1\nPayload: %2")
-                .arg(m_buttonDefs[i].topic, m_buttonDefs[i].payload)
-            : QString("%1 → %2")
-                .arg(m_buttonDefs[i].topic, m_buttonDefs[i].payload));
-
-        if (m_editMode) {
-            btn->setContextMenuPolicy(Qt::CustomContextMenu);
-            connect(btn, &QPushButton::clicked, this, [this, i] { editButton(i); });
-            connect(btn, &QPushButton::customContextMenuRequested, this, [this, i](const QPoint& pos) {
-                QMenu menu;
-                menu.addAction("Remove", this, [this, i] { removeButton(i); });
-                menu.exec(m_buttons[i]->mapToGlobal(pos));
-            });
-        } else {
-            connect(btn, &QPushButton::clicked, this, [this, i] {
-                if (m_client && m_client->isConnected()) {
-                    m_client->publish(m_buttonDefs[i].topic,
-                                      m_buttonDefs[i].payload.toUtf8());
-                }
-            });
-        }
-
+        btn->setStyleSheet(kPubBtn);
+        btn->setToolTip(QString("%1 -> %2")
+                            .arg(m_buttonDefs[i].topic, m_buttonDefs[i].payload));
+        connect(btn, &QPushButton::clicked, this, [this, i] {
+            if (m_client && m_client->isConnected()) {
+                m_client->publish(m_buttonDefs[i].topic,
+                                  m_buttonDefs[i].payload.toUtf8());
+            }
+        });
         m_buttons.append(btn);
         m_buttonGrid->addWidget(btn, i / 3, i % 3);
     }
+}
 
-    // Add "+" button in edit mode
-    if (m_editMode && m_buttonDefs.size() < 12) {
-        auto* addBtn = new QPushButton("+");
-        addBtn->setStyleSheet(
-            "QPushButton { background: #1a2a1a; color: #60a060; "
-            "border: 1px dashed #305030; padding: 4px 6px; border-radius: 3px; font-size: 14px; }");
-        connect(addBtn, &QPushButton::clicked, this, &MqttApplet::addButton);
-        int idx = m_buttonDefs.size();
-        m_buttonGrid->addWidget(addBtn, idx / 3, idx % 3);
+void MqttApplet::requestConnectFromSettings()
+{
+    refreshSettings();
+    const MqttConnectionConfig config = loadMqttConnectionConfig();
+    emit connectRequested(config.host,
+                          config.port,
+                          config.username,
+                          m_password,
+                          mqttUserSubscriptionTopics(m_topicDefs),
+                          config.useTls,
+                          config.caFile);
+
+    if (m_enableBtn) {
+        m_enableBtn->setText("On");
+        m_enableBtn->setStyleSheet(kBtnOn);
     }
+    updateStatus("Connecting", false);
 }
 
-void MqttApplet::editButton(int index)
+void MqttApplet::finishPasswordLoad()
 {
-    if (index < 0 || index >= m_buttonDefs.size()) return;
-
-    QDialog dlg(this);
-    dlg.setWindowTitle("Edit MQTT Button");
-    dlg.setFixedWidth(280);
-    auto* vb = new QVBoxLayout(&dlg);
-
-    auto* labelEdit = new QLineEdit(m_buttonDefs[index].label);
-    auto* topicEdit = new QLineEdit(m_buttonDefs[index].topic);
-    auto* payloadEdit = new QLineEdit(m_buttonDefs[index].payload);
-
-    auto addField = [&](const QString& name, QLineEdit* edit) {
-        auto* row = new QHBoxLayout;
-        auto* lbl = new QLabel(name);
-        lbl->setFixedWidth(55);
-        row->addWidget(lbl);
-        row->addWidget(edit);
-        vb->addLayout(row);
-    };
-
-    addField("Label:", labelEdit);
-    addField("Topic:", topicEdit);
-    addField("Payload:", payloadEdit);
-
-    auto* btns = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    connect(btns, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
-    connect(btns, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
-    vb->addWidget(btns);
-
-    if (dlg.exec() == QDialog::Accepted) {
-        m_buttonDefs[index].label = labelEdit->text().trimmed();
-        m_buttonDefs[index].topic = topicEdit->text().trimmed();
-        m_buttonDefs[index].payload = payloadEdit->text().trimmed();
-        saveButtons();
-        rebuildButtons();
+    m_passwordLoaded = true;
+    if (!m_restoreConnectPending) {
+        return;
     }
-}
 
-void MqttApplet::addButton()
-{
-    if (m_buttonDefs.size() >= 12) return;
-    m_buttonDefs.append({"New", "topic", "payload"});
-    saveButtons();
-    editButton(m_buttonDefs.size() - 1);
-}
-
-void MqttApplet::removeButton(int index)
-{
-    if (index < 0 || index >= m_buttonDefs.size()) return;
-    m_buttonDefs.remove(index);
-    saveButtons();
-    rebuildButtons();
-}
-
-void MqttApplet::saveButtons()
-{
-    QJsonArray arr;
-    for (const auto& def : m_buttonDefs) {
-        QJsonObject obj;
-        obj["label"] = def.label;
-        obj["topic"] = def.topic;
-        obj["payload"] = def.payload;
-        arr.append(obj);
-    }
-    auto& s = AppSettings::instance();
-    s.setValue("MqttButtons", QString::fromUtf8(QJsonDocument(arr).toJson(QJsonDocument::Compact)));
-    s.save();
-}
-
-void MqttApplet::loadButtons()
-{
-    auto& s = AppSettings::instance();
-    QString json = s.value("MqttButtons", "").toString();
-    if (json.isEmpty()) return;
-
-    QJsonArray arr = QJsonDocument::fromJson(json.toUtf8()).array();
-    for (const auto& val : arr) {
-        QJsonObject obj = val.toObject();
-        m_buttonDefs.append({
-            obj["label"].toString(),
-            obj["topic"].toString(),
-            obj["payload"].toString()
-        });
-    }
+    m_restoreConnectPending = false;
+    requestConnectFromSettings();
 }
 
 // ── Keychain-backed password persistence (GHSA-mmqp-cm4w-cvpp) ──────────────
@@ -482,96 +276,51 @@ void MqttApplet::loadButtons()
 void MqttApplet::loadPasswordFromKeychain()
 {
 #ifdef HAVE_KEYCHAIN
-    auto& s = AppSettings::instance();
-    const QString legacy = s.value(kLegacySetting).toString();
+    auto& settings = AppSettings::instance();
+    const QString legacy = settings.value(legacyMqttPasswordSettingKey()).toString();
     if (!legacy.isEmpty()) {
-        // First-launch migration on an upgraded install.  Populate the
-        // UI immediately so the user doesn't see an empty field, write
-        // the value to the keychain, then strip the plaintext entry
-        // from AppSettings.  Keychain failure leaves the plaintext in
-        // place — better that than losing the user's credentials.
-        m_passEdit->setText(legacy);
-        auto* job = new QKeychain::WritePasswordJob(QLatin1String(kKeychainService));
+        m_password = legacy;
+        finishPasswordLoad();
+        auto* job = new QKeychain::WritePasswordJob(mqttKeychainService());
         job->setAutoDelete(true);
-        job->setKey(QLatin1String(kKeychainKey));
+        job->setKey(mqttKeychainKey());
         job->setTextData(legacy);
         connect(job, &QKeychain::Job::finished, this, [](QKeychain::Job* j) {
             if (j->error() != QKeychain::NoError) {
                 qCWarning(lcMqtt) << "MqttApplet: keychain migration write failed:"
                                   << j->errorString()
-                                  << "— legacy plaintext entry preserved for retry";
+                                  << "- legacy plaintext entry preserved for retry";
                 return;
             }
-            AppSettings::instance().remove(kLegacySetting);
+            AppSettings::instance().remove(legacyMqttPasswordSettingKey());
             AppSettings::instance().save();
-            qCInfo(lcMqtt) << "MqttApplet: migrated MQTT password to keychain"
-                           << "(legacy plaintext entry removed)";
+            qCInfo(lcMqtt) << "MqttApplet: migrated MQTT password to keychain";
         });
         job->start();
         return;
     }
 
-    auto* job = new QKeychain::ReadPasswordJob(QLatin1String(kKeychainService));
+    auto* job = new QKeychain::ReadPasswordJob(mqttKeychainService());
     job->setAutoDelete(true);
-    job->setKey(QLatin1String(kKeychainKey));
+    job->setKey(mqttKeychainKey());
     connect(job, &QKeychain::Job::finished, this, [this](QKeychain::Job* j) {
-        if (!m_passEdit) return;  // applet may have been destroyed mid-flight
         if (j->error() == QKeychain::NoError) {
             auto* read = static_cast<QKeychain::ReadPasswordJob*>(j);
-            m_passEdit->setText(read->textData());
+            m_password = read->textData();
         } else if (j->error() != QKeychain::EntryNotFound) {
             qCWarning(lcMqtt) << "MqttApplet: keychain read failed:" << j->errorString();
         }
+        finishPasswordLoad();
     });
     job->start();
 #else
-    // Keychain not available at build time.  Fall back to reading the
-    // legacy plaintext setting if it exists, with a warning.  This keeps
-    // the applet usable on builds that opt out of Qt6Keychain at the
-    // cost of leaving the password readable on disk (the bug this fix
-    // is meant to address).
-    auto& s = AppSettings::instance();
-    const QString legacy = s.value(kLegacySetting).toString();
+    const QString legacy = AppSettings::instance().value(legacyMqttPasswordSettingKey()).toString();
     if (!legacy.isEmpty()) {
-        qCWarning(lcMqtt) << "MqttApplet: HAVE_KEYCHAIN not set — MQTT password "
+        qCWarning(lcMqtt) << "MqttApplet: HAVE_KEYCHAIN not set - MQTT password "
                              "remains in plaintext AppSettings";
-        m_passEdit->setText(legacy);
+        m_password = legacy;
     }
-#endif
-}
-
-void MqttApplet::savePasswordToKeychain(const QString& password)
-{
-#ifdef HAVE_KEYCHAIN
-    if (password.isEmpty()) {
-        // Empty password = user cleared the field.  Drop any keychain
-        // entry so the next load doesn't surprise them with a stale value.
-        auto* job = new QKeychain::DeletePasswordJob(QLatin1String(kKeychainService));
-        job->setAutoDelete(true);
-        job->setKey(QLatin1String(kKeychainKey));
-        connect(job, &QKeychain::Job::finished, this, [](QKeychain::Job* j) {
-            if (j->error() != QKeychain::NoError
-                && j->error() != QKeychain::EntryNotFound) {
-                qCWarning(lcMqtt) << "MqttApplet: keychain delete failed:" << j->errorString();
-            }
-        });
-        job->start();
-        return;
-    }
-    auto* job = new QKeychain::WritePasswordJob(QLatin1String(kKeychainService));
-    job->setAutoDelete(true);
-    job->setKey(QLatin1String(kKeychainKey));
-    job->setTextData(password);
-    connect(job, &QKeychain::Job::finished, this, [](QKeychain::Job* j) {
-        if (j->error() != QKeychain::NoError)
-            qCWarning(lcMqtt) << "MqttApplet: keychain save failed:" << j->errorString();
-    });
-    job->start();
-#else
-    qCWarning(lcMqtt) << "MqttApplet: HAVE_KEYCHAIN not set — falling back to "
-                         "plaintext AppSettings for MQTT password";
-    AppSettings::instance().setValue(kLegacySetting, password);
-    AppSettings::instance().save();
+    finishPasswordLoad();
 #endif
 }
 

--- a/src/gui/MqttApplet.h
+++ b/src/gui/MqttApplet.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <QWidget>
-#include <QVector>
-#include <QJsonArray>
+#include "core/MqttSettings.h"
 
-class QCheckBox;
+#include <QWidget>
+
 class QLabel;
-class QLineEdit;
 class QPushButton;
 class QTextEdit;
 class QGridLayout;
@@ -15,19 +13,8 @@ namespace AetherSDR {
 
 class MqttClient;
 
-struct MqttButtonDef {
-    QString label;
-    QString topic;
-    QString payload;
-};
-
-struct MqttTopicDef {
-    QString topic;
-    bool displayOnPan{false};
-};
-
 // Applet for MQTT station device integration (#699).
-// Phase 1: subscribe + display. Phase 2: publish buttons + overlay.
+// Live MQTT operation only; durable configuration lives in Settings -> MQTT.
 class MqttApplet : public QWidget {
     Q_OBJECT
 
@@ -35,6 +22,9 @@ public:
     explicit MqttApplet(QWidget* parent = nullptr);
 
     void setMqttClient(MqttClient* client);
+    void refreshSettings();
+    void setCachedPassword(const QString& password);
+    void restoreConnectionState();
     QVector<MqttTopicDef> topicConfig() const { return m_topicDefs; }
 
 signals:
@@ -46,42 +36,33 @@ signals:
     void displayValueChanged(const QString& key, const QString& value);
     void displayCleared();
     void antennaAliasRequested(const QString& token, const QString& alias);
+    void settingsRequested();
 
 private:
     void buildUI();
     void updateStatus(const QString& text, bool ok);
     void onMessageReceived(const QString& topic, const QByteArray& payload);
     void rebuildButtons();
-    void saveButtons();
-    void loadButtons();
-    void editButton(int index);
-    void addButton();
-    void removeButton(int index);
+    void requestConnectFromSettings();
+    void finishPasswordLoad();
 
     // MQTT broker password lives in QKeychain rather than AppSettings
     // (GHSA-mmqp-cm4w-cvpp).  Both calls are async and no-op on builds
     // without HAVE_KEYCHAIN defined.
     void loadPasswordFromKeychain();
-    void savePasswordToKeychain(const QString& password);
 
     MqttClient* m_client{nullptr};
-    QLineEdit*   m_hostEdit{nullptr};
-    QLineEdit*   m_portEdit{nullptr};
-    QLineEdit*   m_userEdit{nullptr};
-    QLineEdit*   m_passEdit{nullptr};
-    QLineEdit*   m_topicsEdit{nullptr};
-    QCheckBox*   m_tlsCheck{nullptr};
-    QLineEdit*   m_caFileEdit{nullptr};
     QPushButton* m_enableBtn{nullptr};
     QLabel*      m_statusLabel{nullptr};
     QTextEdit*   m_messageLog{nullptr};
+    QString      m_password;
+    bool         m_passwordLoaded{false};
+    bool         m_restoreConnectPending{false};
 
     // Publish buttons
     QGridLayout*          m_buttonGrid{nullptr};
     QVector<MqttButtonDef> m_buttonDefs;
     QVector<QPushButton*>  m_buttons;
-    QPushButton*           m_editBtn{nullptr};
-    bool                   m_editMode{false};
 
     // Per-topic display config
     QVector<MqttTopicDef> m_topicDefs;

--- a/src/gui/MqttSettingsDialog.cpp
+++ b/src/gui/MqttSettingsDialog.cpp
@@ -1,0 +1,426 @@
+#include "MqttSettingsDialog.h"
+
+#include "core/AppSettings.h"
+#include "core/LogManager.h"
+
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QHeaderView>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QTabWidget>
+#include <QVBoxLayout>
+
+#include <algorithm>
+#include <functional>
+
+#ifdef HAVE_KEYCHAIN
+#include <qt6keychain/keychain.h>
+#endif
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr int kMaxPublishButtons = 12;
+
+QTableWidgetItem* textItem(const QString& text = {})
+{
+    return new QTableWidgetItem(text);
+}
+
+QTableWidgetItem* checkItem(bool checked)
+{
+    auto* item = new QTableWidgetItem;
+    item->setFlags((item->flags() | Qt::ItemIsUserCheckable) & ~Qt::ItemIsEditable);
+    item->setCheckState(checked ? Qt::Checked : Qt::Unchecked);
+    return item;
+}
+
+QList<int> selectedRowsDescending(QTableWidget* table)
+{
+    QList<int> rows;
+    if (!table)
+        return rows;
+
+    const QModelIndexList selected = table->selectionModel()->selectedRows();
+    rows.reserve(selected.size());
+    for (const QModelIndex& index : selected) {
+        rows.append(index.row());
+    }
+    std::sort(rows.begin(), rows.end(), std::greater<int>());
+    return rows;
+}
+
+} // namespace
+
+MqttSettingsDialog::MqttSettingsDialog(QWidget* parent)
+    : PersistentDialog(tr("MQTT Settings"),
+                       QStringLiteral("MqttSettingsDialogGeometry"),
+                       parent)
+{
+    buildUi();
+    loadSettings();
+    loadPasswordFromKeychain();
+}
+
+void MqttSettingsDialog::buildUi()
+{
+    setMinimumSize(620, 520);
+
+    auto* root = new QVBoxLayout(bodyWidget());
+    root->setSpacing(8);
+
+    auto* tabs = new QTabWidget;
+    root->addWidget(tabs, 1);
+
+    auto* brokerTab = new QWidget;
+    auto* brokerLayout = new QVBoxLayout(brokerTab);
+    auto* form = new QFormLayout;
+    form->setLabelAlignment(Qt::AlignRight);
+
+    m_hostEdit = new QLineEdit;
+    m_hostEdit->setObjectName(QStringLiteral("mqttHost"));
+    m_hostEdit->setAccessibleName(tr("MQTT broker host"));
+    form->addRow(tr("Host:"), m_hostEdit);
+
+    m_portSpin = new QSpinBox;
+    m_portSpin->setRange(1, 65535);
+    m_portSpin->setObjectName(QStringLiteral("mqttPort"));
+    m_portSpin->setAccessibleName(tr("MQTT broker port"));
+    form->addRow(tr("Port:"), m_portSpin);
+
+    m_userEdit = new QLineEdit;
+    m_userEdit->setObjectName(QStringLiteral("mqttUsername"));
+    m_userEdit->setAccessibleName(tr("MQTT broker username"));
+    form->addRow(tr("User:"), m_userEdit);
+
+    m_passEdit = new QLineEdit;
+    m_passEdit->setEchoMode(QLineEdit::Password);
+    m_passEdit->setObjectName(QStringLiteral("mqttPassword"));
+    m_passEdit->setAccessibleName(tr("MQTT broker password"));
+    form->addRow(tr("Password:"), m_passEdit);
+
+    m_tlsCheck = new QCheckBox(tr("Use TLS"));
+    form->addRow(tr("TLS:"), m_tlsCheck);
+
+    auto* caRow = new QWidget;
+    auto* caLayout = new QHBoxLayout(caRow);
+    caLayout->setContentsMargins(0, 0, 0, 0);
+    m_caFileEdit = new QLineEdit;
+    m_caFileEdit->setPlaceholderText(tr("optional, blank = system CA bundle"));
+    auto* browseCa = new QPushButton(tr("Browse..."));
+    caLayout->addWidget(m_caFileEdit, 1);
+    caLayout->addWidget(browseCa);
+    form->addRow(tr("CA cert:"), caRow);
+
+    brokerLayout->addLayout(form);
+    brokerLayout->addStretch();
+    tabs->addTab(brokerTab, tr("Broker"));
+
+    connect(m_tlsCheck, &QCheckBox::toggled, this, [this](bool checked) {
+        if (checked && m_portSpin->value() == 1883) {
+            m_portSpin->setValue(8883);
+        } else if (!checked && m_portSpin->value() == 8883) {
+            m_portSpin->setValue(1883);
+        }
+    });
+    connect(browseCa, &QPushButton::clicked, this, [this] {
+        const QString path = QFileDialog::getOpenFileName(
+            this, tr("Select MQTT CA Certificate"), m_caFileEdit->text());
+        if (!path.isEmpty()) {
+            m_caFileEdit->setText(path);
+        }
+    });
+
+    auto* topicsTab = new QWidget;
+    auto* topicsLayout = new QVBoxLayout(topicsTab);
+    m_topicsTable = new QTableWidget(0, 2);
+    m_topicsTable->setHorizontalHeaderLabels({tr("Topic"), tr("Display")});
+    m_topicsTable->horizontalHeader()->setStretchLastSection(false);
+    m_topicsTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    m_topicsTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+    m_topicsTable->verticalHeader()->setVisible(false);
+    m_topicsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_topicsTable->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    topicsLayout->addWidget(m_topicsTable, 1);
+
+    auto* topicControls = new QHBoxLayout;
+    auto* addTopic = new QPushButton(tr("Add"));
+    auto* removeTopic = new QPushButton(tr("Remove"));
+    topicControls->addWidget(addTopic);
+    topicControls->addWidget(removeTopic);
+    topicControls->addStretch();
+    topicsLayout->addLayout(topicControls);
+
+    auto* internalGroup = new QGroupBox(tr("Internal AetherSDR Topics"));
+    auto* internalLayout = new QVBoxLayout(internalGroup);
+    auto* internalText = new QLabel(
+        tr("Subscribed automatically whenever MQTT connects; these topics are not removable:\n%1")
+            .arg(internalMqttSubscriptionTopics().join(QStringLiteral("\n"))));
+    internalText->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    internalLayout->addWidget(internalText);
+    topicsLayout->addWidget(internalGroup);
+    tabs->addTab(topicsTab, tr("Subscriptions"));
+
+    connect(addTopic, &QPushButton::clicked, this, [this] { addTopicRow(); });
+    connect(removeTopic, &QPushButton::clicked,
+            this, &MqttSettingsDialog::removeSelectedTopicRows);
+
+    auto* buttonsTab = new QWidget;
+    auto* buttonsLayout = new QVBoxLayout(buttonsTab);
+    m_buttonsTable = new QTableWidget(0, 3);
+    m_buttonsTable->setHorizontalHeaderLabels({tr("Label"), tr("Topic"), tr("Payload")});
+    m_buttonsTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    m_buttonsTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_buttonsTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+    m_buttonsTable->verticalHeader()->setVisible(false);
+    m_buttonsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_buttonsTable->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    buttonsLayout->addWidget(m_buttonsTable, 1);
+
+    auto* buttonControls = new QHBoxLayout;
+    m_addButtonRowBtn = new QPushButton(tr("Add"));
+    auto* removeButton = new QPushButton(tr("Remove"));
+    buttonControls->addWidget(m_addButtonRowBtn);
+    buttonControls->addWidget(removeButton);
+    buttonControls->addStretch();
+    buttonsLayout->addLayout(buttonControls);
+    tabs->addTab(buttonsTab, tr("Publish Buttons"));
+
+    connect(m_addButtonRowBtn, &QPushButton::clicked, this, [this] { addButtonRow(); });
+    connect(removeButton, &QPushButton::clicked,
+            this, &MqttSettingsDialog::removeSelectedButtonRows);
+
+    auto* dialogButtons = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Apply | QDialogButtonBox::Cancel);
+    root->addWidget(dialogButtons);
+
+    connect(dialogButtons, &QDialogButtonBox::accepted, this, [this] {
+        saveSettings();
+        accept();
+    });
+    connect(dialogButtons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(dialogButtons->button(QDialogButtonBox::Apply), &QPushButton::clicked,
+            this, &MqttSettingsDialog::saveSettings);
+}
+
+void MqttSettingsDialog::loadSettings()
+{
+    const MqttConnectionConfig config = loadMqttConnectionConfig();
+    m_hostEdit->setText(config.host);
+    m_portSpin->setValue(config.port);
+    m_userEdit->setText(config.username);
+    m_tlsCheck->setChecked(config.useTls);
+    m_caFileEdit->setText(config.caFile);
+
+    m_topicsTable->setRowCount(0);
+    for (const MqttTopicDef& def : loadMqttTopicConfig()) {
+        addTopicRow(def);
+    }
+
+    m_buttonsTable->setRowCount(0);
+    for (const MqttButtonDef& def : loadMqttButtonConfig()) {
+        addButtonRow(def);
+    }
+    updateButtonControls();
+}
+
+void MqttSettingsDialog::saveSettings()
+{
+    const MqttConnectionConfig config{
+        m_hostEdit->text().trimmed(),
+        static_cast<quint16>(m_portSpin->value()),
+        m_userEdit->text().trimmed(),
+        m_tlsCheck->isChecked(),
+        m_caFileEdit->text().trimmed(),
+    };
+    saveMqttConnectionConfig(config);
+    saveMqttTopicConfig(topicRows());
+    saveMqttButtonConfig(buttonRows());
+    savePasswordToKeychain(m_passEdit->text());
+    emit settingsSaved(m_passEdit->text());
+}
+
+void MqttSettingsDialog::addTopicRow(const MqttTopicDef& def)
+{
+    const int row = m_topicsTable->rowCount();
+    m_topicsTable->insertRow(row);
+    m_topicsTable->setItem(row, 0, textItem(def.topic));
+    m_topicsTable->setItem(row, 1, checkItem(def.displayOnPan));
+}
+
+void MqttSettingsDialog::removeSelectedTopicRows()
+{
+    for (const int row : selectedRowsDescending(m_topicsTable)) {
+        m_topicsTable->removeRow(row);
+    }
+}
+
+QVector<MqttTopicDef> MqttSettingsDialog::topicRows() const
+{
+    QVector<MqttTopicDef> topics;
+    topics.reserve(m_topicsTable->rowCount());
+    for (int row = 0; row < m_topicsTable->rowCount(); ++row) {
+        QTableWidgetItem* topicItem = m_topicsTable->item(row, 0);
+        QTableWidgetItem* displayItem = m_topicsTable->item(row, 1);
+        const QString topic = topicItem ? topicItem->text().trimmed() : QString();
+        if (!topic.isEmpty()) {
+            topics.append({topic, displayItem && displayItem->checkState() == Qt::Checked});
+        }
+    }
+    return topics;
+}
+
+void MqttSettingsDialog::addButtonRow(const MqttButtonDef& def)
+{
+    if (m_buttonsTable->rowCount() >= kMaxPublishButtons) {
+        updateButtonControls();
+        return;
+    }
+
+    const int row = m_buttonsTable->rowCount();
+    m_buttonsTable->insertRow(row);
+    m_buttonsTable->setItem(row, 0, textItem(def.label));
+    m_buttonsTable->setItem(row, 1, textItem(def.topic));
+    m_buttonsTable->setItem(row, 2, textItem(def.payload));
+    updateButtonControls();
+}
+
+void MqttSettingsDialog::removeSelectedButtonRows()
+{
+    for (const int row : selectedRowsDescending(m_buttonsTable)) {
+        m_buttonsTable->removeRow(row);
+    }
+    updateButtonControls();
+}
+
+QVector<MqttButtonDef> MqttSettingsDialog::buttonRows() const
+{
+    QVector<MqttButtonDef> buttons;
+    buttons.reserve(m_buttonsTable->rowCount());
+    for (int row = 0; row < m_buttonsTable->rowCount(); ++row) {
+        QTableWidgetItem* labelItem = m_buttonsTable->item(row, 0);
+        QTableWidgetItem* topicItem = m_buttonsTable->item(row, 1);
+        QTableWidgetItem* payloadItem = m_buttonsTable->item(row, 2);
+        MqttButtonDef def{
+            labelItem ? labelItem->text().trimmed() : QString(),
+            topicItem ? topicItem->text().trimmed() : QString(),
+            payloadItem ? payloadItem->text() : QString(),
+        };
+        if (!def.label.isEmpty() || !def.topic.isEmpty() || !def.payload.isEmpty()) {
+            buttons.append(def);
+        }
+    }
+    return buttons;
+}
+
+void MqttSettingsDialog::updateButtonControls()
+{
+    if (m_addButtonRowBtn) {
+        m_addButtonRowBtn->setEnabled(m_buttonsTable->rowCount() < kMaxPublishButtons);
+    }
+}
+
+// ── Keychain-backed password persistence (GHSA-mmqp-cm4w-cvpp) ──────────────
+
+void MqttSettingsDialog::loadPasswordFromKeychain()
+{
+#ifdef HAVE_KEYCHAIN
+    auto& settings = AppSettings::instance();
+    const QString legacy = settings.value(legacyMqttPasswordSettingKey()).toString();
+    if (!legacy.isEmpty()) {
+        m_passEdit->setText(legacy);
+        auto* job = new QKeychain::WritePasswordJob(mqttKeychainService());
+        job->setAutoDelete(true);
+        job->setKey(mqttKeychainKey());
+        job->setTextData(legacy);
+        connect(job, &QKeychain::Job::finished, this, [](QKeychain::Job* j) {
+            if (j->error() != QKeychain::NoError) {
+                qCWarning(lcMqtt) << "MqttSettingsDialog: keychain migration write failed:"
+                                  << j->errorString()
+                                  << "- legacy plaintext entry preserved for retry";
+                return;
+            }
+            AppSettings::instance().remove(legacyMqttPasswordSettingKey());
+            AppSettings::instance().save();
+            qCInfo(lcMqtt) << "MqttSettingsDialog: migrated MQTT password to keychain";
+        });
+        job->start();
+        return;
+    }
+
+    auto* job = new QKeychain::ReadPasswordJob(mqttKeychainService());
+    job->setAutoDelete(true);
+    job->setKey(mqttKeychainKey());
+    connect(job, &QKeychain::Job::finished, this, [this](QKeychain::Job* j) {
+        if (!m_passEdit)
+            return;
+        if (j->error() == QKeychain::NoError) {
+            auto* read = static_cast<QKeychain::ReadPasswordJob*>(j);
+            m_passEdit->setText(read->textData());
+        } else if (j->error() != QKeychain::EntryNotFound) {
+            qCWarning(lcMqtt) << "MqttSettingsDialog: keychain read failed:"
+                              << j->errorString();
+        }
+    });
+    job->start();
+#else
+    const QString legacy = AppSettings::instance().value(legacyMqttPasswordSettingKey()).toString();
+    if (!legacy.isEmpty()) {
+        qCWarning(lcMqtt) << "MqttSettingsDialog: HAVE_KEYCHAIN not set - MQTT password "
+                             "remains in plaintext AppSettings";
+        m_passEdit->setText(legacy);
+    }
+#endif
+}
+
+void MqttSettingsDialog::savePasswordToKeychain(const QString& password)
+{
+#ifdef HAVE_KEYCHAIN
+    AppSettings::instance().remove(legacyMqttPasswordSettingKey());
+    AppSettings::instance().save();
+
+    if (password.isEmpty()) {
+        auto* job = new QKeychain::DeletePasswordJob(mqttKeychainService());
+        job->setAutoDelete(true);
+        job->setKey(mqttKeychainKey());
+        connect(job, &QKeychain::Job::finished, this, [](QKeychain::Job* j) {
+            if (j->error() != QKeychain::NoError
+                && j->error() != QKeychain::EntryNotFound) {
+                qCWarning(lcMqtt) << "MqttSettingsDialog: keychain delete failed:"
+                                  << j->errorString();
+            }
+        });
+        job->start();
+        return;
+    }
+
+    auto* job = new QKeychain::WritePasswordJob(mqttKeychainService());
+    job->setAutoDelete(true);
+    job->setKey(mqttKeychainKey());
+    job->setTextData(password);
+    connect(job, &QKeychain::Job::finished, this, [](QKeychain::Job* j) {
+        if (j->error() != QKeychain::NoError) {
+            qCWarning(lcMqtt) << "MqttSettingsDialog: keychain save failed:"
+                              << j->errorString();
+        }
+    });
+    job->start();
+#else
+    qCWarning(lcMqtt) << "MqttSettingsDialog: HAVE_KEYCHAIN not set - falling back to "
+                         "plaintext AppSettings for MQTT password";
+    AppSettings::instance().setValue(legacyMqttPasswordSettingKey(), password);
+    AppSettings::instance().save();
+#endif
+}
+
+} // namespace AetherSDR

--- a/src/gui/MqttSettingsDialog.h
+++ b/src/gui/MqttSettingsDialog.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "PersistentDialog.h"
+#include "core/MqttSettings.h"
+
+class QCheckBox;
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class QSpinBox;
+class QTableWidget;
+
+namespace AetherSDR {
+
+class MqttSettingsDialog : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    explicit MqttSettingsDialog(QWidget* parent = nullptr);
+
+signals:
+    void settingsSaved(const QString& password);
+
+private:
+    void buildUi();
+    void loadSettings();
+    void saveSettings();
+    void loadPasswordFromKeychain();
+    void savePasswordToKeychain(const QString& password);
+
+    void addTopicRow(const MqttTopicDef& def = {});
+    void removeSelectedTopicRows();
+    QVector<MqttTopicDef> topicRows() const;
+
+    void addButtonRow(const MqttButtonDef& def = {});
+    void removeSelectedButtonRows();
+    QVector<MqttButtonDef> buttonRows() const;
+    void updateButtonControls();
+
+    QLineEdit* m_hostEdit{nullptr};
+    QSpinBox*  m_portSpin{nullptr};
+    QLineEdit* m_userEdit{nullptr};
+    QLineEdit* m_passEdit{nullptr};
+    QCheckBox* m_tlsCheck{nullptr};
+    QLineEdit* m_caFileEdit{nullptr};
+    QTableWidget* m_topicsTable{nullptr};
+    QTableWidget* m_buttonsTable{nullptr};
+    QPushButton* m_addButtonRowBtn{nullptr};
+};
+
+} // namespace AetherSDR

--- a/tests/mqtt_settings_test.cpp
+++ b/tests/mqtt_settings_test.cpp
@@ -1,0 +1,77 @@
+#include "core/MqttSettings.h"
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    return condition;
+}
+
+} // namespace
+
+int main()
+{
+    bool ok = true;
+
+    {
+        const QVector<MqttTopicDef> topics = parseMqttTopicConfig(
+            QStringLiteral(" *rotator/pos, station/log, *ant/selected, , plain "));
+        ok &= expect(topics.size() == 4, "legacy topic list skips empty entries");
+        ok &= expect(topics.value(0).topic == QStringLiteral("rotator/pos")
+                         && topics.value(0).displayOnPan,
+                     "star-prefixed topic marks display-on-panadapter");
+        ok &= expect(topics.value(1).topic == QStringLiteral("station/log")
+                         && !topics.value(1).displayOnPan,
+                     "plain topic is user subscription only");
+        ok &= expect(topics.value(2).topic == QStringLiteral("ant/selected")
+                         && topics.value(2).displayOnPan,
+                     "later star-prefixed topic keeps display flag");
+        ok &= expect(serializeMqttTopicConfig(topics)
+                         == QStringLiteral("*rotator/pos, station/log, *ant/selected, plain"),
+                     "topic serialization preserves legacy star convention");
+    }
+
+    {
+        const QStringList internal = internalMqttSubscriptionTopics();
+        ok &= expect(internal.contains(QStringLiteral("aethersdr/antenna/name/+")),
+                     "internal subscriptions include per-antenna alias wildcard");
+        ok &= expect(internal.contains(QStringLiteral("aethersdr/antenna/names")),
+                     "internal subscriptions include bulk antenna alias topic");
+
+        const QStringList subscriptions = mqttSubscriptionTopics({
+            QStringLiteral("station/log"),
+            QStringLiteral("aethersdr/antenna/name/+"),
+            QStringLiteral("station/log"),
+        });
+        ok &= expect(subscriptions.size() == 3,
+                     "subscription list deduplicates user and internal topics");
+        ok &= expect(subscriptions.value(0) == QStringLiteral("station/log"),
+                     "subscription list keeps user topic order");
+        ok &= expect(subscriptions.contains(QStringLiteral("aethersdr/antenna/names")),
+                     "subscription list appends missing internal topics");
+    }
+
+    {
+        const QVector<MqttButtonDef> buttons{
+            {QStringLiteral("CW"), QStringLiteral("rotator/cmd"), QStringLiteral("CW")},
+            {QStringLiteral("Stop"), QStringLiteral("rotator/cmd"), QStringLiteral("STOP")},
+        };
+        const QVector<MqttButtonDef> roundTrip = mqttButtonsFromJson(mqttButtonsToJson(buttons));
+        ok &= expect(roundTrip.size() == 2, "publish button JSON round-trips count");
+        ok &= expect(roundTrip.value(0).label == QStringLiteral("CW")
+                         && roundTrip.value(0).topic == QStringLiteral("rotator/cmd")
+                         && roundTrip.value(0).payload == QStringLiteral("CW"),
+                     "publish button JSON preserves first button");
+        ok &= expect(roundTrip.value(1).label == QStringLiteral("Stop")
+                         && roundTrip.value(1).topic == QStringLiteral("rotator/cmd")
+                         && roundTrip.value(1).payload == QStringLiteral("STOP"),
+                     "publish button JSON preserves second button");
+    }
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Add a persistent `Settings -> MQTT...` dialog for broker credentials, TLS/CA config, subscription rows, display-on-panadapter flags, and publish button definitions.
- Keep the MQTT applet as the live surface for connect/disconnect, status, message log, publish buttons, and a shortcut back to settings.
- Auto-subscribe AetherSDR antenna alias API topics on every MQTT connection while preserving legacy `MqttTopics` and `MqttButtons` settings.
- Persist the MQTT applet On/Off state as `MqttEnabled` so MQTT reconnects automatically on startup when it was left On.
- Replace stale pending-topic behavior with explicit desired subscriptions so removed user topics do not survive reconnects.

## Verification
- `cmake --build build --target AetherSDR -j4`
- `cmake --build build --target mqtt_settings_test mqtt_antenna_alias_test antenna_alias_test -j4`
- `ctest --test-dir build -R 'mqtt_antenna_alias_test|antenna_alias_test|mqtt_settings_test' --output-on-failure`
- `git diff --check`

## Independent Review
- Separate review pass found one blocking subscription-state issue: removed topics could remain in `MqttClient` pending subscriptions across reconnects.
- Follow-up runtime report found MQTT did not auto-connect on application start.
- Fixed by adding explicit desired subscriptions plus startup restoration that waits until the keychain password load is complete.

## Remaining Risk
- Manual GUI startup was reported before this follow-up fix; the auto-connect fix has local build/test coverage but still needs a live-broker restart smoke test from the app.
