### PR TITLE
chore(codeowners): re-tier per framework — governance/security/bot in T1, infra in T2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,18 +48,6 @@ docs/                        @ten9876 @jensenpat @NF0T @rfoust
 .github/docker/              @ten9876 @jensenpat @NF0T @rfoust
 .github/ISSUE_TEMPLATE/      @ten9876 @jensenpat @NF0T @rfoust
 
-# Visual / UX direction (per CLAUDE.md "AI Agent Boundaries")
-src/gui/MainWindow.h         @ten9876 @jensenpat @NF0T @rfoust
-src/gui/MainWindow.cpp       @ten9876 @jensenpat @NF0T @rfoust
-
-# Architecture — central state, threading, protocol bedrock
-src/models/RadioModel.h      @ten9876 @jensenpat @NF0T @rfoust
-src/models/RadioModel.cpp    @ten9876 @jensenpat @NF0T @rfoust
-src/core/AudioEngine.h       @ten9876 @jensenpat @NF0T @rfoust
-src/core/AudioEngine.cpp     @ten9876 @jensenpat @NF0T @rfoust
-src/core/PanadapterStream.h  @ten9876 @jensenpat @NF0T @rfoust
-src/core/PanadapterStream.cpp @ten9876 @jensenpat @NF0T @rfoust
-
 # Build configuration
 CMakeLists.txt               @ten9876 @jensenpat @NF0T @rfoust
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,36 @@
 # AetherSDR CODEOWNERS
 #
-# Three tiers, last-matching-pattern wins. Numbered by exclusivity, not
-# by file position — Tier 1 is the smallest, most-exclusive owner set;
-# Tier 3 is the broadest fall-through default. The file is laid out
-# broad → specific so the more restrictive tiers override the broader
-# defaults via CODEOWNERS' last-match-wins semantics:
+# Three tiers, last-matching-pattern wins. Numbered by exclusivity, not by
+# file position — Tier 1 is the smallest, most-exclusive owner set; Tier 3
+# is the broadest fall-through default. The file is laid out broad →
+# specific so the more restrictive tiers override the broader defaults via
+# CODEOWNERS' last-match-wins semantics:
 #
-#   Tier 3 (broad default)             — top of file (the `*` line)
-#   Tier 2 (project collaborators)     — middle (specific paths)
-#   Tier 1 (project policy)            — bottom (most specific paths)
+#   Tier 3 (source code, broad default)       — top of file (the `*` line)
+#   Tier 2 (project infrastructure)           — middle (specific paths)
+#   Tier 1 (governance, security, bot policy) — bottom (most specific paths)
 #
-# Tier 1 — @ten9876 only (project policy & repo-canon).
-# Tier 2 — @ten9876 + @jensenpat + @NF0T + @rfoust (project collaborators).
+# Tier 1 — @ten9876 only.
+#         Project governance and direction (CONSTITUTION, GOVERNANCE,
+#         CONTRIBUTING, CODE_OF_CONDUCT, LICENSE, ROADMAP), security
+#         controls (SECURITY*, signing keys, CODEOWNERS itself, CodeQL
+#         configs, CI workflow definitions), legal/compliance
+#         (THIRD_PARTY_LICENSES), and bot/agent instruction
+#         (AGENTS.md, CLAUDE.md, GEMINI.md, .claude/commands/).
+# Tier 2 — @ten9876 + @jensenpat + @NF0T + @rfoust.
+#         Project infrastructure: CI/CD configuration not in T1
+#         (dependabot, docker, issue templates), documentation
+#         (docs/, *.md catchall, including README/CHANGELOG/SUPPORT
+#         which fall through here from the *.md glob), tests, and
+#         build configuration (CMakeLists.txt).
 # Tier 3 — same human roster as Tier 2 (broad default fall-through).
+#         AetherSDR source code and anything else not enumerated
+#         above (src/, third_party/, plugins/, hal-plugin/,
+#         resources/, packaging/, scripts/).
 #
-# All approvals are human-only. @AetherClaude (the project's machine user)
-# is intentionally NOT in any owner set — bot-generated PRs still need a
-# human reviewer regardless of which paths they touch. The Tier 2 / Tier 3
-# split is preserved for documentary purposes: Tier 2 enumerates the
-# specific architecture / collaborator surfaces; Tier 3 is the broad
-# default that catches everything else with the same human roster.
+# All approvals are human-only. @AetherClaude (the project's machine
+# user) is intentionally NOT in any owner set — bot-generated PRs
+# still need a human reviewer regardless of which paths they touch.
 #
 # CODEOWNERS has no permission hierarchy — each path matches exactly one
 # line (last wins) and that line's owners completely replace any earlier
@@ -30,20 +41,21 @@
 # membership, so a contributor cannot approve their own PR even on
 # paths they own.
 
-# ── Tier 3: broad default — fall-through for any path not enumerated ───────
+# ── Tier 3: source code, broad default — catches anything not enumerated ───
 *                            @ten9876 @jensenpat @NF0T @rfoust
 
-# ── Tier 2: project collaborators — explicit human-attention surfaces ──────
-# Specific paths called out as collaborator territory. Functionally
-# identical to Tier 3 today (same owner set), but enumerated explicitly
-# so a future tier change (e.g. expanding the collaborator roster, or
-# reintroducing bot approval on the broad default) doesn't accidentally
-# alter coverage of these high-touch surfaces.
+# ── Tier 2: project infrastructure — explicit collaborator surfaces ────────
+# CI/CD configuration not in Tier 1, documentation, tests, build config.
+# Functionally identical to Tier 3's owner set today, but enumerated
+# explicitly so a future tier change doesn't accidentally alter coverage
+# of these surfaces.
 
-# Mechanical / safe surfaces
+# Documentation & tests
 tests/                       @ten9876 @jensenpat @NF0T @rfoust
 docs/                        @ten9876 @jensenpat @NF0T @rfoust
 *.md                         @ten9876 @jensenpat @NF0T @rfoust
+
+# GitHub-specific tooling
 .github/dependabot.yml       @ten9876 @jensenpat @NF0T @rfoust
 .github/docker/              @ten9876 @jensenpat @NF0T @rfoust
 .github/ISSUE_TEMPLATE/      @ten9876 @jensenpat @NF0T @rfoust
@@ -51,19 +63,9 @@ docs/                        @ten9876 @jensenpat @NF0T @rfoust
 # Build configuration
 CMakeLists.txt               @ten9876 @jensenpat @NF0T @rfoust
 
-# Security tooling & agent configuration
-.github/codeql/              @ten9876 @jensenpat @NF0T @rfoust
-.claude/commands/            @ten9876 @jensenpat @NF0T @rfoust
-
-# ── Tier 1: project policy — maintainer-only ──────────────────────────────
-# Every file in the repo's root directory is project-policy / repo-canon
-# (with the explicit exception of CMakeLists.txt — kept at Tier 2 because
-# build-config edits are appropriate for the broader collaborator set).
-# Listed individually rather than via `/*` so the intent is auditable and
-# new root-dir files trigger a deliberate review of which tier they
-# belong in (added or omitted by the PR that introduces them).
+# ── Tier 1: governance, security, bot policy — maintainer-only ────────────
+# Project governance & direction
 AGENTS.md                    @ten9876
-CHANGELOG.md                 @ten9876
 CLAUDE.md                    @ten9876
 CODE_OF_CONDUCT.md           @ten9876
 CONSTITUTION.md              @ten9876
@@ -71,16 +73,21 @@ CONTRIBUTING.md              @ten9876
 GEMINI.md                    @ten9876
 GOVERNANCE.md                @ten9876
 LICENSE                      @ten9876
-README.md                    @ten9876
 ROADMAP.md                   @ten9876
-SECURITY-AUDIT.md            @ten9876
+
+# Security & compliance
 SECURITY.md                  @ten9876
-SUPPORT.md                   @ten9876
+SECURITY-AUDIT.md            @ten9876
 THIRD_PARTY_LICENSES         @ten9876
 .github/CODEOWNERS           @ten9876
+.github/codeql/              @ten9876
+docs/RELEASE-SIGNING-KEY.pub.asc  @ten9876
 
 # CI runtime — release artifacts, registry pushes, GITHUB_TOKEN scopes.
+# Kept at Tier 1 despite the framework's CI/CD-in-T2 default because a
+# malicious workflow change can exfiltrate secrets or publish unsigned
+# releases. Workflow-config sensitivity outweighs the categorical match.
 .github/workflows/           @ten9876
 
-# Release signing key — overrides the Tier 2 docs/ pattern.
-docs/RELEASE-SIGNING-KEY.pub.asc  @ten9876
+# Bot / agent instruction (source of truth for AI tool behaviour)
+.claude/commands/            @ten9876

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,23 +22,23 @@ docs/                        @ten9876 @jensenpat @AetherClaude
 
 # ── Tier 3: architecture & infrastructure — bot cannot approve ─────────────
 # Visual/UX direction (per CLAUDE.md "AI Agent Boundaries")
-src/gui/MainWindow.h         @ten9876 @jensenpat
-src/gui/MainWindow.cpp       @ten9876 @jensenpat
+src/gui/MainWindow.h         @ten9876 @jensenpat @NF0T @rfoust
+src/gui/MainWindow.cpp       @ten9876 @jensenpat @NF0T @rfoust
 
 # Architecture — central state, threading, protocol bedrock
-src/models/RadioModel.h      @ten9876 @jensenpat
-src/models/RadioModel.cpp    @ten9876 @jensenpat
-src/core/AudioEngine.h       @ten9876 @jensenpat
-src/core/AudioEngine.cpp     @ten9876 @jensenpat
-src/core/PanadapterStream.h  @ten9876 @jensenpat
-src/core/PanadapterStream.cpp @ten9876 @jensenpat
+src/models/RadioModel.h      @ten9876 @jensenpat @NF0T @rfoust
+src/models/RadioModel.cpp    @ten9876 @jensenpat @NF0T @rfoust
+src/core/AudioEngine.h       @ten9876 @jensenpat @NF0T @rfoust
+src/core/AudioEngine.cpp     @ten9876 @jensenpat @NF0T @rfoust
+src/core/PanadapterStream.h  @ten9876 @jensenpat @NF0T @rfoust
+src/core/PanadapterStream.cpp @ten9876 @jensenpat @NF0T @rfoust
 
 # Build configuration
-CMakeLists.txt               @ten9876 @jensenpat
+CMakeLists.txt               @ten9876 @jensenpat @NF0T @rfoust
 
 # Security tooling & agent configuration
-.github/codeql/              @ten9876 @jensenpat
-.claude/commands/            @ten9876 @jensenpat
+.github/codeql/              @ten9876 @jensenpat @NF0T @rfoust
+.claude/commands/            @ten9876 @jensenpat @NF0T @rfoust
 
 # ── Tier 4: project policy — maintainer-only ──────────────────────────────
 # Every file in the repo's root directory is project-policy / repo-canon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,33 +1,45 @@
 # AetherSDR CODEOWNERS
 #
-# Four tiers, last-matching-pattern wins:
-#   1. Broad default — co-maintainers (ten9876, jensenpat, NF0T, rfoust)
-#   2. Mechanical/safe paths — co-maintainers + @AetherClaude (machine user)
-#   3. Architecture & infrastructure — co-maintainers (no bot approval)
-#   4. Project policy — reserved to @ten9876
+# Three tiers, last-matching-pattern wins. Numbered by exclusivity, not
+# by file position — Tier 1 is the smallest, most-exclusive owner set;
+# Tier 3 is the broadest fall-through default. The file is laid out
+# broad → specific so the more restrictive tiers override the broader
+# defaults via CODEOWNERS' last-match-wins semantics:
 #
-# CODEOWNERS has no permission hierarchy — each path matches exactly one line
-# (last wins) and that line's owners completely replace any earlier match.
-# Co-maintainers are listed on Tier 1, 2, and 3 explicitly so they can
-# approve any non-Tier-4 PR. The tiers differ only by whether the bot
-# (@AetherClaude) or the maintainer (@ten9876 only) is also in the owner set.
+#   Tier 3 (broad default)             — top of file (the `*` line)
+#   Tier 2 (project collaborators)     — middle (specific paths)
+#   Tier 1 (project policy)            — bottom (most specific paths)
 #
-# Self-approval is hard-blocked by GitHub regardless of CODEOWNERS membership,
-# so a contributor cannot approve their own PR even on paths they own.
+# Tier 1 — @ten9876 only (project policy & repo-canon).
+# Tier 2 — @ten9876 + @jensenpat + @NF0T + @rfoust (humans only, no bot).
+# Tier 3 — Tier 2 + @AetherClaude (bot may approve broad-default PRs).
+#
+# CODEOWNERS has no permission hierarchy — each path matches exactly one
+# line (last wins) and that line's owners completely replace any earlier
+# match. The numbering above is documentary; the operative semantics
+# come from the file's pattern order plus last-match-wins.
+#
+# Self-approval is hard-blocked by GitHub regardless of CODEOWNERS
+# membership, so a contributor cannot approve their own PR even on
+# paths they own.
 
-# ── Tier 1: broad default ──────────────────────────────────────────────────
-*                            @ten9876 @jensenpat @NF0T @rfoust
+# ── Tier 3: broad default — bot can approve fall-through paths ─────────────
+*                            @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
 
-# ── Tier 2: mechanical/safe paths — bot can also approve ───────────────────
-tests/                       @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
-docs/                        @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
-*.md                         @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
-.github/dependabot.yml       @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
-.github/docker/              @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
-.github/ISSUE_TEMPLATE/      @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
+# ── Tier 2: project collaborators — humans only, no bot approval ───────────
+# Specific paths that need human judgment: mechanical/safe surfaces (docs,
+# tests, GitHub config) plus the architecture & infrastructure hot files.
+# Removing the bot from these forces a human reviewer for any change.
 
-# ── Tier 3: architecture & infrastructure — bot cannot approve ─────────────
-# Visual/UX direction (per CLAUDE.md "AI Agent Boundaries")
+# Mechanical / safe surfaces
+tests/                       @ten9876 @jensenpat @NF0T @rfoust
+docs/                        @ten9876 @jensenpat @NF0T @rfoust
+*.md                         @ten9876 @jensenpat @NF0T @rfoust
+.github/dependabot.yml       @ten9876 @jensenpat @NF0T @rfoust
+.github/docker/              @ten9876 @jensenpat @NF0T @rfoust
+.github/ISSUE_TEMPLATE/      @ten9876 @jensenpat @NF0T @rfoust
+
+# Visual / UX direction (per CLAUDE.md "AI Agent Boundaries")
 src/gui/MainWindow.h         @ten9876 @jensenpat @NF0T @rfoust
 src/gui/MainWindow.cpp       @ten9876 @jensenpat @NF0T @rfoust
 
@@ -46,13 +58,13 @@ CMakeLists.txt               @ten9876 @jensenpat @NF0T @rfoust
 .github/codeql/              @ten9876 @jensenpat @NF0T @rfoust
 .claude/commands/            @ten9876 @jensenpat @NF0T @rfoust
 
-# ── Tier 4: project policy — maintainer-only ──────────────────────────────
+# ── Tier 1: project policy — maintainer-only ──────────────────────────────
 # Every file in the repo's root directory is project-policy / repo-canon
-# (with the explicit exception of CMakeLists.txt — kept at Tier 3 because
-# build-config edits are appropriate for the architecture-owner subset).
+# (with the explicit exception of CMakeLists.txt — kept at Tier 2 because
+# build-config edits are appropriate for the broader collaborator set).
 # Listed individually rather than via `/*` so the intent is auditable and
-# new root-dir files trigger a deliberate review of which tier they belong
-# in (added or omitted by the PR that introduces them).
+# new root-dir files trigger a deliberate review of which tier they
+# belong in (added or omitted by the PR that introduces them).
 AGENTS.md                    @ten9876
 CHANGELOG.md                 @ten9876
 CLAUDE.md                    @ten9876
@@ -73,5 +85,5 @@ THIRD_PARTY_LICENSES         @ten9876
 # CI runtime — release artifacts, registry pushes, GITHUB_TOKEN scopes.
 .github/workflows/           @ten9876
 
-# Release signing key — overrides the tier-2 docs/ pattern.
+# Release signing key — overrides the Tier 2 docs/ pattern.
 docs/RELEASE-SIGNING-KEY.pub.asc  @ten9876

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,12 +41,27 @@ CMakeLists.txt               @ten9876 @jensenpat
 .claude/commands/            @ten9876 @jensenpat
 
 # ── Tier 4: project policy — maintainer-only ──────────────────────────────
+# Every file in the repo's root directory is project-policy / repo-canon
+# (with the explicit exception of CMakeLists.txt — kept at Tier 3 because
+# build-config edits are appropriate for the architecture-owner subset).
+# Listed individually rather than via `/*` so the intent is auditable and
+# new root-dir files trigger a deliberate review of which tier they belong
+# in (added or omitted by the PR that introduces them).
+AGENTS.md                    @ten9876
+CHANGELOG.md                 @ten9876
 CLAUDE.md                    @ten9876
-CONTRIBUTING.md              @ten9876
-GOVERNANCE.md                @ten9876
 CODE_OF_CONDUCT.md           @ten9876
-SECURITY.md                  @ten9876
+CONSTITUTION.md              @ten9876
+CONTRIBUTING.md              @ten9876
+GEMINI.md                    @ten9876
+GOVERNANCE.md                @ten9876
 LICENSE                      @ten9876
+README.md                    @ten9876
+ROADMAP.md                   @ten9876
+SECURITY-AUDIT.md            @ten9876
+SECURITY.md                  @ten9876
+SUPPORT.md                   @ten9876
+THIRD_PARTY_LICENSES         @ten9876
 .github/CODEOWNERS           @ten9876
 
 # CI runtime — release artifacts, registry pushes, GITHUB_TOKEN scopes.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,24 +1,30 @@
 # AetherSDR CODEOWNERS
 #
 # Four tiers, last-matching-pattern wins:
-#   1. Broad default — jensenpat + maintainer
-#   2. Mechanical/safe paths — also approvable by @AetherClaude (machine user)
-#   3. Architecture & infrastructure — jensenpat + maintainer (no bot approval)
+#   1. Broad default — co-maintainers (ten9876, jensenpat, NF0T, rfoust)
+#   2. Mechanical/safe paths — co-maintainers + @AetherClaude (machine user)
+#   3. Architecture & infrastructure — co-maintainers (no bot approval)
 #   4. Project policy — reserved to @ten9876
+#
+# CODEOWNERS has no permission hierarchy — each path matches exactly one line
+# (last wins) and that line's owners completely replace any earlier match.
+# Co-maintainers are listed on Tier 1, 2, and 3 explicitly so they can
+# approve any non-Tier-4 PR. The tiers differ only by whether the bot
+# (@AetherClaude) or the maintainer (@ten9876 only) is also in the owner set.
 #
 # Self-approval is hard-blocked by GitHub regardless of CODEOWNERS membership,
 # so a contributor cannot approve their own PR even on paths they own.
 
 # ── Tier 1: broad default ──────────────────────────────────────────────────
-*                            @ten9876 @jensenpat
+*                            @ten9876 @jensenpat @NF0T @rfoust
 
 # ── Tier 2: mechanical/safe paths — bot can also approve ───────────────────
-tests/                       @ten9876 @jensenpat @AetherClaude
-docs/                        @ten9876 @jensenpat @AetherClaude
-*.md                         @ten9876 @jensenpat @AetherClaude
-.github/dependabot.yml       @ten9876 @jensenpat @AetherClaude
-.github/docker/              @ten9876 @jensenpat @AetherClaude
-.github/ISSUE_TEMPLATE/      @ten9876 @jensenpat @AetherClaude
+tests/                       @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
+docs/                        @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
+*.md                         @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
+.github/dependabot.yml       @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
+.github/docker/              @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
+.github/ISSUE_TEMPLATE/      @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
 
 # ── Tier 3: architecture & infrastructure — bot cannot approve ─────────────
 # Visual/UX direction (per CLAUDE.md "AI Agent Boundaries")

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,31 +2,35 @@
 #
 # Three tiers, last-matching-pattern wins. Numbered by exclusivity, not by
 # file position — Tier 1 is the smallest, most-exclusive owner set; Tier 3
-# is the broadest fall-through default. The file is laid out broad →
-# specific so the more restrictive tiers override the broader defaults via
-# CODEOWNERS' last-match-wins semantics:
+# is the broadest. The file is laid out broad → specific so the more
+# restrictive tiers override the broader defaults via CODEOWNERS'
+# last-match-wins semantics:
 #
 #   Tier 3 (source code, broad default)       — top of file (the `*` line)
 #   Tier 2 (project infrastructure)           — middle (specific paths)
 #   Tier 1 (governance, security, bot policy) — bottom (most specific paths)
 #
-# Tier 1 — @ten9876 only.
+# Tier 1 — @ten9876.
 #         Project governance and direction (CONSTITUTION, GOVERNANCE,
 #         CONTRIBUTING, CODE_OF_CONDUCT, LICENSE, ROADMAP), security
 #         controls (SECURITY*, signing keys, CODEOWNERS itself, CodeQL
 #         configs, CI workflow definitions), legal/compliance
 #         (THIRD_PARTY_LICENSES), and bot/agent instruction
 #         (AGENTS.md, CLAUDE.md, GEMINI.md, .claude/commands/).
-# Tier 2 — @ten9876 + @jensenpat + @NF0T + @rfoust.
+# Tier 2 — @ten9876 + @jensenpat.
 #         Project infrastructure: CI/CD configuration not in T1
 #         (dependabot, docker, issue templates), documentation
 #         (docs/, *.md catchall, including README/CHANGELOG/SUPPORT
 #         which fall through here from the *.md glob), tests, and
-#         build configuration (CMakeLists.txt).
-# Tier 3 — same human roster as Tier 2 (broad default fall-through).
+#         build configuration (CMakeLists.txt). Narrower owner set
+#         than Tier 3 because infrastructure changes need deeper
+#         repo context than routine source review.
+# Tier 3 — @ten9876 + @jensenpat + @NF0T + @rfoust.
 #         AetherSDR source code and anything else not enumerated
 #         above (src/, third_party/, plugins/, hal-plugin/,
-#         resources/, packaging/, scripts/).
+#         resources/, packaging/, scripts/). Broadest collaborator
+#         roster because routine source review benefits from more
+#         eyes.
 #
 # All approvals are human-only. @AetherClaude (the project's machine
 # user) is intentionally NOT in any owner set — bot-generated PRs
@@ -44,24 +48,23 @@
 # ── Tier 3: source code, broad default — catches anything not enumerated ───
 *                            @ten9876 @jensenpat @NF0T @rfoust
 
-# ── Tier 2: project infrastructure — explicit collaborator surfaces ────────
+# ── Tier 2: project infrastructure — narrower owner set than Tier 3 ────────
 # CI/CD configuration not in Tier 1, documentation, tests, build config.
-# Functionally identical to Tier 3's owner set today, but enumerated
-# explicitly so a future tier change doesn't accidentally alter coverage
-# of these surfaces.
+# Approvers are @ten9876 + @jensenpat only — infrastructure changes need
+# deeper repo context than the broader source-review roster.
 
 # Documentation & tests
-tests/                       @ten9876 @jensenpat @NF0T @rfoust
-docs/                        @ten9876 @jensenpat @NF0T @rfoust
-*.md                         @ten9876 @jensenpat @NF0T @rfoust
+tests/                       @ten9876 @jensenpat
+docs/                        @ten9876 @jensenpat
+*.md                         @ten9876 @jensenpat
 
 # GitHub-specific tooling
-.github/dependabot.yml       @ten9876 @jensenpat @NF0T @rfoust
-.github/docker/              @ten9876 @jensenpat @NF0T @rfoust
-.github/ISSUE_TEMPLATE/      @ten9876 @jensenpat @NF0T @rfoust
+.github/dependabot.yml       @ten9876 @jensenpat
+.github/docker/              @ten9876 @jensenpat
+.github/ISSUE_TEMPLATE/      @ten9876 @jensenpat
 
 # Build configuration
-CMakeLists.txt               @ten9876 @jensenpat @NF0T @rfoust
+CMakeLists.txt               @ten9876 @jensenpat
 
 # ── Tier 1: governance, security, bot policy — maintainer-only ────────────
 # Project governance & direction

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,15 @@
 #   Tier 1 (project policy)            — bottom (most specific paths)
 #
 # Tier 1 — @ten9876 only (project policy & repo-canon).
-# Tier 2 — @ten9876 + @jensenpat + @NF0T + @rfoust (humans only, no bot).
-# Tier 3 — Tier 2 + @AetherClaude (bot may approve broad-default PRs).
+# Tier 2 — @ten9876 + @jensenpat + @NF0T + @rfoust (project collaborators).
+# Tier 3 — same human roster as Tier 2 (broad default fall-through).
+#
+# All approvals are human-only. @AetherClaude (the project's machine user)
+# is intentionally NOT in any owner set — bot-generated PRs still need a
+# human reviewer regardless of which paths they touch. The Tier 2 / Tier 3
+# split is preserved for documentary purposes: Tier 2 enumerates the
+# specific architecture / collaborator surfaces; Tier 3 is the broad
+# default that catches everything else with the same human roster.
 #
 # CODEOWNERS has no permission hierarchy — each path matches exactly one
 # line (last wins) and that line's owners completely replace any earlier
@@ -23,13 +30,15 @@
 # membership, so a contributor cannot approve their own PR even on
 # paths they own.
 
-# ── Tier 3: broad default — bot can approve fall-through paths ─────────────
-*                            @ten9876 @jensenpat @NF0T @rfoust @AetherClaude
+# ── Tier 3: broad default — fall-through for any path not enumerated ───────
+*                            @ten9876 @jensenpat @NF0T @rfoust
 
-# ── Tier 2: project collaborators — humans only, no bot approval ───────────
-# Specific paths that need human judgment: mechanical/safe surfaces (docs,
-# tests, GitHub config) plus the architecture & infrastructure hot files.
-# Removing the bot from these forces a human reviewer for any change.
+# ── Tier 2: project collaborators — explicit human-attention surfaces ──────
+# Specific paths called out as collaborator territory. Functionally
+# identical to Tier 3 today (same owner set), but enumerated explicitly
+# so a future tier change (e.g. expanding the collaborator roster, or
+# reintroducing bot approval on the broad default) doesn't accidentally
+# alter coverage of these high-touch surfaces.
 
 # Mechanical / safe surfaces
 tests/                       @ten9876 @jensenpat @NF0T @rfoust


### PR DESCRIPTION
## Summary

Final CODEOWNERS structure aligned to the maintainer-direction three-tier framework, with progressively narrower owner sets at higher tiers. All approvals human-only; @AetherClaude absent from every owner set.

Final state in commit \`1aa9a446\` (8 commits total on the branch documenting the iterative refinement).

## Final tier structure

| Tier | Owners | Coverage |
|---|---|---|
| **Tier 1** | @ten9876 | Governance/direction, security, bot policy, CI workflows |
| **Tier 2** | @ten9876 + @jensenpat | Project infrastructure (docs, tests, GH tooling, build config) |
| **Tier 3** | @ten9876 + @jensenpat + @NF0T + @rfoust | Source code (broad default) |

Each tier has a progressively wider roster:
- **T1 is single-approver** for governance/security/bot policy where direction needs to be authoritative.
- **T2 narrows the source-review pool to 2** because infrastructure (docs, tests, CI, build config) needs deeper repo context than routine source review.
- **T3 has the full 4-human roster** because routine source review benefits from more eyes.

## Detailed path coverage

**Tier 1 — @ten9876:**
- Governance/direction: \`AGENTS.md\`, \`CLAUDE.md\`, \`GEMINI.md\`, \`CONSTITUTION.md\`, \`GOVERNANCE.md\`, \`CONTRIBUTING.md\`, \`CODE_OF_CONDUCT.md\`, \`LICENSE\`, \`ROADMAP.md\`
- Security/compliance: \`SECURITY.md\`, \`SECURITY-AUDIT.md\`, \`THIRD_PARTY_LICENSES\`, \`.github/CODEOWNERS\`, \`.github/codeql/\`, \`docs/RELEASE-SIGNING-KEY.pub.asc\`
- CI runtime (kept here despite the framework's CI-in-T2 default — workflow changes can exfiltrate secrets or publish unsigned releases): \`.github/workflows/\`
- Bot/agent instruction: \`.claude/commands/\`

**Tier 2 — @ten9876 + @jensenpat:**
- Documentation & tests: \`tests/\`, \`docs/\`, \`*.md\` (catches README.md, CHANGELOG.md, SUPPORT.md by fall-through)
- GitHub-specific tooling: \`.github/dependabot.yml\`, \`.github/docker/\`, \`.github/ISSUE_TEMPLATE/\`
- Build configuration: \`CMakeLists.txt\`

**Tier 3 — @ten9876 + @jensenpat + @NF0T + @rfoust:**
- \`*\` catches source and anything not enumerated: \`src/\`, \`third_party/\`, \`plugins/\`, \`hal-plugin/\`, \`resources/\`, \`packaging/\`, \`scripts/\`

## How last-match-wins resolves (post-merge)

| File | Pattern that matches | Tier | Owner set |
|---|---|---|---|
| \`CLAUDE.md\` | T1: \`CLAUDE.md\` (overrides \`*.md\`) | T1 | @ten9876 |
| \`README.md\` | T2: \`*.md\` (no T1 override) | T2 | @ten9876 + @jensenpat |
| \`CHANGELOG.md\` | T2: \`*.md\` | T2 | @ten9876 + @jensenpat |
| \`docs/install.md\` | T2: \`docs/\` (last match) | T2 | @ten9876 + @jensenpat |
| \`.github/workflows/ci.yml\` | T1: \`.github/workflows/\` | T1 | @ten9876 |
| \`.github/codeql/codeql-config.yml\` | T1: \`.github/codeql/\` | T1 | @ten9876 |
| \`.claude/commands/loop.md\` | T1: \`.claude/commands/\` (overrides \`*.md\`) | T1 | @ten9876 |
| \`src/gui/MainWindow.cpp\` | T3: \`*\` | T3 | 4 humans |
| \`tests/foo.cpp\` | T2: \`tests/\` | T2 | @ten9876 + @jensenpat |
| \`CMakeLists.txt\` | T2: \`CMakeLists.txt\` | T2 | @ten9876 + @jensenpat |

## Co-maintainer roster

- **@NF0T (Ryan)** — Windows-installer RADE integration; Windows-build + FreeDV protocol background. Source-code Tier 3 only.
- **@rfoust (Robbie Foust)** — FlexControl wheel tuning overhaul ([#3029](https://github.com/aethersdr/AetherSDR/pull/3029)); input/UX layer expertise. Source-code Tier 3 only.

## Stats

- 1 file change to \`.github/CODEOWNERS\`
- 8 commits total on the branch documenting the iterative refinement

## Test plan

- [x] Diff review confirms only \`.github/CODEOWNERS\` is touched
- [x] \`grep -c AetherClaude .github/CODEOWNERS\` returns 1 (only the documentary inline mention)
- [x] \`grep "@NF0T" .github/CODEOWNERS\` returns 2 matches (header doc + Tier 3 \`*\` line only)
- [ ] GitHub validates CODEOWNERS syntax on push (red banner on PR if invalid)
- [ ] After merge: PR touching \`CLAUDE.md\` requires \`@ten9876\` (T1)
- [ ] After merge: PR touching \`README.md\` is approvable by @ten9876 or @jensenpat (T2 — narrower than before)
- [ ] After merge: PR touching \`docs/foo.md\` requires @ten9876 or @jensenpat (T2)
- [ ] After merge: PR touching \`.github/workflows/ci.yml\` requires \`@ten9876\` (T1)
- [ ] After merge: PR touching \`src/gui/MainWindow.cpp\` approvable by any of 4 humans (T3)
- [ ] After merge: bot-authored PRs cannot self-approve via CODEOWNERS regardless of path

🤖 Generated with [Claude Code](https://claude.com/claude-code)