### PR TITLE
chore(codeowners): convert to @aethersdr team mentions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,14 +10,14 @@
 #   Tier 2 (project infrastructure)           — middle (specific paths)
 #   Tier 1 (governance, security, bot policy) — bottom (most specific paths)
 #
-# Tier 1 — @ten9876.
+# Tier 1 — @aethersdr/maintainers (currently: @ten9876).
 #         Project governance and direction (CONSTITUTION, GOVERNANCE,
 #         CONTRIBUTING, CODE_OF_CONDUCT, LICENSE, ROADMAP), security
 #         controls (SECURITY*, signing keys, CODEOWNERS itself, CodeQL
 #         configs, CI workflow definitions), legal/compliance
 #         (THIRD_PARTY_LICENSES), and bot/agent instruction
 #         (AGENTS.md, CLAUDE.md, GEMINI.md, .claude/commands/).
-# Tier 2 — @ten9876 + @jensenpat.
+# Tier 2 — @aethersdr/infrastructure (currently: @ten9876, @jensenpat).
 #         Project infrastructure: CI/CD configuration not in T1
 #         (dependabot, docker, issue templates), documentation
 #         (docs/, *.md catchall, including README/CHANGELOG/SUPPORT
@@ -25,15 +25,21 @@
 #         build configuration (CMakeLists.txt). Narrower owner set
 #         than Tier 3 because infrastructure changes need deeper
 #         repo context than routine source review.
-# Tier 3 — @ten9876 + @jensenpat + @NF0T + @rfoust.
+# Tier 3 — @aethersdr/reviewers (currently: @ten9876, @jensenpat, @NF0T, @rfoust).
 #         AetherSDR source code and anything else not enumerated
 #         above (src/, third_party/, plugins/, hal-plugin/,
 #         resources/, packaging/, scripts/). Broadest collaborator
 #         roster because routine source review benefits from more
 #         eyes.
 #
+# Team rosters are managed in the GitHub org settings:
+#   https://github.com/orgs/aethersdr/teams
+# Adding or removing a code owner is a single team-membership change
+# rather than an edit to this file. The roster lists above are
+# documentation only — the live source of truth is the org team.
+#
 # All approvals are human-only. @AetherClaude (the project's machine
-# user) is intentionally NOT in any owner set — bot-generated PRs
+# user) is intentionally NOT a member of any team — bot-generated PRs
 # still need a human reviewer regardless of which paths they touch.
 #
 # CODEOWNERS has no permission hierarchy — each path matches exactly one
@@ -46,51 +52,49 @@
 # paths they own.
 
 # ── Tier 3: source code, broad default — catches anything not enumerated ───
-*                            @ten9876 @jensenpat @NF0T @rfoust
+*                            @aethersdr/reviewers
 
 # ── Tier 2: project infrastructure — narrower owner set than Tier 3 ────────
 # CI/CD configuration not in Tier 1, documentation, tests, build config.
-# Approvers are @ten9876 + @jensenpat only — infrastructure changes need
-# deeper repo context than the broader source-review roster.
 
 # Documentation & tests
-tests/                       @ten9876 @jensenpat
-docs/                        @ten9876 @jensenpat
-*.md                         @ten9876 @jensenpat
+tests/                       @aethersdr/infrastructure
+docs/                        @aethersdr/infrastructure
+*.md                         @aethersdr/infrastructure
 
 # GitHub-specific tooling
-.github/dependabot.yml       @ten9876 @jensenpat
-.github/docker/              @ten9876 @jensenpat
-.github/ISSUE_TEMPLATE/      @ten9876 @jensenpat
+.github/dependabot.yml       @aethersdr/infrastructure
+.github/docker/              @aethersdr/infrastructure
+.github/ISSUE_TEMPLATE/      @aethersdr/infrastructure
 
 # Build configuration
-CMakeLists.txt               @ten9876 @jensenpat
+CMakeLists.txt               @aethersdr/infrastructure
 
 # ── Tier 1: governance, security, bot policy — maintainer-only ────────────
 # Project governance & direction
-AGENTS.md                    @ten9876
-CLAUDE.md                    @ten9876
-CODE_OF_CONDUCT.md           @ten9876
-CONSTITUTION.md              @ten9876
-CONTRIBUTING.md              @ten9876
-GEMINI.md                    @ten9876
-GOVERNANCE.md                @ten9876
-LICENSE                      @ten9876
-ROADMAP.md                   @ten9876
+AGENTS.md                    @aethersdr/maintainers
+CLAUDE.md                    @aethersdr/maintainers
+CODE_OF_CONDUCT.md           @aethersdr/maintainers
+CONSTITUTION.md              @aethersdr/maintainers
+CONTRIBUTING.md              @aethersdr/maintainers
+GEMINI.md                    @aethersdr/maintainers
+GOVERNANCE.md                @aethersdr/maintainers
+LICENSE                      @aethersdr/maintainers
+ROADMAP.md                   @aethersdr/maintainers
 
 # Security & compliance
-SECURITY.md                  @ten9876
-SECURITY-AUDIT.md            @ten9876
-THIRD_PARTY_LICENSES         @ten9876
-.github/CODEOWNERS           @ten9876
-.github/codeql/              @ten9876
-docs/RELEASE-SIGNING-KEY.pub.asc  @ten9876
+SECURITY.md                  @aethersdr/maintainers
+SECURITY-AUDIT.md            @aethersdr/maintainers
+THIRD_PARTY_LICENSES         @aethersdr/maintainers
+.github/CODEOWNERS           @aethersdr/maintainers
+.github/codeql/              @aethersdr/maintainers
+docs/RELEASE-SIGNING-KEY.pub.asc  @aethersdr/maintainers
 
 # CI runtime — release artifacts, registry pushes, GITHUB_TOKEN scopes.
 # Kept at Tier 1 despite the framework's CI/CD-in-T2 default because a
 # malicious workflow change can exfiltrate secrets or publish unsigned
 # releases. Workflow-config sensitivity outweighs the categorical match.
-.github/workflows/           @ten9876
+.github/workflows/           @aethersdr/maintainers
 
 # Bot / agent instruction (source of truth for AI tool behaviour)
-.claude/commands/            @ten9876
+.claude/commands/            @aethersdr/maintainers


### PR DESCRIPTION
## Summary

Replaces individual \`@user\` mentions in CODEOWNERS with GitHub team mentions. Identical approval semantics — only the *shape* of each owner-set line changes. Roster management moves from "edit CODEOWNERS" to "edit team membership in the org Teams UI."

Builds on the framework merged in #3053.

## What changes

| Tier | Was | Now | Members today |
|---|---|---|---|
| Tier 1 | \`@ten9876\` | \`@aethersdr/maintainers\` | @ten9876 |
| Tier 2 | \`@ten9876 @jensenpat\` | \`@aethersdr/infrastructure\` | @ten9876, @jensenpat |
| Tier 3 | \`@ten9876 @jensenpat @NF0T @rfoust\` | \`@aethersdr/reviewers\` | @ten9876, @jensenpat, @NF0T, @rfoust |

The path-to-tier mapping is unchanged from #3053. No file moves tier; only the mention shape on each line changes.

## Prerequisite — repo access for the teams

GitHub only honors \`@org/team\` mentions in CODEOWNERS when the team has **Write or higher** access to the repository. Before this PR merges, verify in the org Teams UI:

| Team | Required access | Recommended |
|---|---|---|
| \`@aethersdr/maintainers\` | Write (minimum) | **Admin** (manages branch protection / settings) |
| \`@aethersdr/infrastructure\` | Write (minimum) | **Maintain** (can edit some repo settings / manage releases) |
| \`@aethersdr/reviewers\` | Write (minimum) | **Write** |

Per team: org Teams page → click the team → **Repositories** tab → **Add repository** → \`aethersdr/AetherSDR\` → set access level.

GitHub will surface a warning at the top of this PR's "Files changed" tab if any of the team mentions fail to resolve (team doesn't exist, doesn't have access, or has the wrong access level). If the file is valid, no warning.

## Header comment changes

The doc block at the top of CODEOWNERS now:

- References team slugs as the source of truth, with \`(currently: <users>)\` annotations naming the current human members for documentation
- Points readers to \`https://github.com/orgs/aethersdr/teams\` as the live roster source
- Notes that \`@AetherClaude\` is intentionally not a member of any team (preserves the human-only-approval rule from #3053)

## How last-match-wins resolves (post-merge, semantically identical to today)

| File | Pattern that matches | Team |
|---|---|---|
| \`CLAUDE.md\` | T1: \`CLAUDE.md\` | @aethersdr/maintainers |
| \`README.md\` | T2: \`*.md\` | @aethersdr/infrastructure |
| \`docs/install.md\` | T2: \`docs/\` (last match) | @aethersdr/infrastructure |
| \`.github/workflows/ci.yml\` | T1: \`.github/workflows/\` | @aethersdr/maintainers |
| \`.github/codeql/codeql-config.yml\` | T1: \`.github/codeql/\` | @aethersdr/maintainers |
| \`.claude/commands/loop.md\` | T1: \`.claude/commands/\` | @aethersdr/maintainers |
| \`src/gui/MainWindow.cpp\` | T3: \`*\` | @aethersdr/reviewers |
| \`tests/foo.cpp\` | T2: \`tests/\` | @aethersdr/infrastructure |
| \`CMakeLists.txt\` | T2: \`CMakeLists.txt\` | @aethersdr/infrastructure |

## Why this is a follow-up rather than a fix-up of #3053

- #3053 settled the tier model + path categorization
- This PR is a pure mention-shape refactor on top of the settled model
- Keeping them separate makes each step easier to review and bisect
- This change requires the teams to exist (they do, as of today) and have repo access (must be granted before merge)

## Stats

- 1 file change to \`.github/CODEOWNERS\`
- +35 / -31

## Test plan

- [x] Diff review confirms only \`.github/CODEOWNERS\` is touched
- [x] All owner-set lines now reference \`@aethersdr/<team>\` (no individual @user mentions on owner-set lines)
- [ ] Org Teams UI: verify all three teams exist with the expected member rosters
- [ ] Org Teams UI: verify each team has \`aethersdr/AetherSDR\` listed under Repositories with Write+ access
- [ ] GitHub validates the CODEOWNERS syntax on this PR — no warning banner on the Files changed tab
- [ ] After merge: test PR touching \`README.md\` shows "Requesting review from @aethersdr/infrastructure"
- [ ] After merge: test PR touching \`CLAUDE.md\` shows "Requesting review from @aethersdr/maintainers"
- [ ] After merge: test PR touching \`src/gui/MainWindow.cpp\` shows "Requesting review from @aethersdr/reviewers"
- [ ] After merge: adding a new contributor to \`@aethersdr/reviewers\` immediately makes them an eligible reviewer on any \`*\` path, with no further CODEOWNERS edits required

🤖 Generated with [Claude Code](https://claude.com/claude-code)