### PR TITLE
feat(tci): per-mode overflow handling with right-click slider menu

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -283,6 +283,17 @@ void TciServer::setTxGain(float gain)
     s.save();
 }
 
+void TciServer::setOverflowMode(int mode)
+{
+    if (mode < 0 || mode > 2) return;
+    auto next = static_cast<OverflowMode>(mode);
+    if (m_overflowMode == next) return;
+    m_overflowMode = next;
+    auto& s = AppSettings::instance();
+    s.setValue("TciTxOverflowMode", QString::number(mode));
+    s.save();
+}
+
 void TciServer::setRxChannelGain(int channel, float gain)
 {
     if (channel < 1 || channel > 4) return;
@@ -853,18 +864,49 @@ void TciServer::onBinaryMessage(const QByteArray& data)
     double sumSq = 0.0;
     float peak = 0.0f;
     qint64 clipSamples = 0;
-    for (int i = 0; i < outputSamples; ++i) {
-        float v = dst[i] * m_txGain;
-        if (v > 1.0f) {
-            v = 1.0f;
-            ++clipSamples;
-        } else if (v < -1.0f) {
-            v = -1.0f;
-            ++clipSamples;
+    // Three overflow regimes selectable via right-click on the TCI TX slider:
+    //   Clip     — saturating clamp at ±1.0; cheap defensive limiter,
+    //              introduces harmonics on overshoots but protects the
+    //              radio float→int16 stage from out-of-range input.
+    //   NaNGuard — pass everything except NaN/Inf (which the radio can't
+    //              digest); preserves bit-exact tones for well-formed
+    //              digital clients, accepts that a malformed >1.0 client
+    //              will reach the radio.
+    //   Measure  — pure bypass: count overshoots for telemetry but never
+    //              touch sample data.  100% client-side passthrough.
+    switch (m_overflowMode) {
+    case OverflowMode::Clip:
+        for (int i = 0; i < outputSamples; ++i) {
+            float v = dst[i] * m_txGain;
+            if (v > 1.0f) { v = 1.0f; ++clipSamples; }
+            else if (v < -1.0f) { v = -1.0f; ++clipSamples; }
+            dst[i] = v;
+            peak = std::max(peak, std::abs(v));
+            sumSq += static_cast<double>(v) * static_cast<double>(v);
         }
-        dst[i] = v;
-        peak = std::max(peak, std::abs(v));
-        sumSq += static_cast<double>(v) * static_cast<double>(v);
+        break;
+    case OverflowMode::NaNGuard:
+        for (int i = 0; i < outputSamples; ++i) {
+            float v = dst[i] * m_txGain;
+            if (!std::isfinite(v)) { v = 0.0f; ++clipSamples; }
+            else if (std::abs(v) > 1.0f) ++clipSamples;
+            dst[i] = v;
+            peak = std::max(peak, std::abs(v));
+            sumSq += static_cast<double>(v) * static_cast<double>(v);
+        }
+        break;
+    case OverflowMode::Measure:
+        for (int i = 0; i < outputSamples; ++i) {
+            const float v = dst[i] * m_txGain;
+            dst[i] = v;
+            if (!std::isfinite(v) || std::abs(v) > 1.0f) ++clipSamples;
+            const float absV = std::isfinite(v) ? std::abs(v) : 0.0f;
+            peak = std::max(peak, absV);
+            sumSq += std::isfinite(v)
+                       ? static_cast<double>(v) * static_cast<double>(v)
+                       : 0.0;
+        }
+        break;
     }
 
     ++m_txAudioBlocks;
@@ -1397,6 +1439,12 @@ void TciServer::startTxChrono(QWebSocket* client, int trx)
     m_txGain = std::clamp(
         txGainSettings.value("TciTxGain", "0.5").toString().toFloat(),
         0.0f, 1.0f);
+    {
+        bool ok = false;
+        int rawMode = txGainSettings.value("TciTxOverflowMode", "0").toString().toInt(&ok);
+        if (!ok || rawMode < 0 || rawMode > 2) rawMode = 0;
+        m_overflowMode = static_cast<OverflowMode>(rawMode);
+    }
     m_txChronoAccumNs = 0;
     m_txChronoRequestedFrames = 0;
     m_txAudioBlocks = 0;

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -74,6 +74,18 @@ public:
     void setTxGain(float gain);
     float txGain() const { return m_txGain; }
 
+    // TCI TX overflow handling.  After gain, samples whose magnitude
+    // exceeds full-scale (±1.0) are handled per this mode:
+    //   Clip     — saturating clamp to ±1.0 (legacy default, defensive)
+    //   NaNGuard — pass-through; only zero NaN/Inf (preserves bit-exactness
+    //              for legitimate digital-mode tones at the cost of letting
+    //              malformed >1.0 clients through)
+    //   Measure  — pure bypass; count clip events but never mutate samples
+    // Persists to TciTxOverflowMode (0/1/2).
+    enum class OverflowMode : int { Clip = 0, NaNGuard = 1, Measure = 2 };
+    void setOverflowMode(int mode);
+    int overflowMode() const { return static_cast<int>(m_overflowMode); }
+
     // Per-channel TCI RX gain (0.0–1.0), applied to outbound DAX audio before
     // resampling and sending to TCI clients.  Decoupled from DaxRxGain<n> so
     // DAX bridge and TCI maintain independent per-channel gains.
@@ -193,6 +205,7 @@ private:
     qint64            m_txChronoRequestedFrames{0};
     bool              m_txUseRadioRoute{true};
     float             m_txGain{1.0f};
+    OverflowMode      m_overflowMode{OverflowMode::Clip};
     float             m_rxChannelGain[4]{1.0f, 1.0f, 1.0f, 1.0f};
     qint64            m_txAudioBlocks{0};
     qint64            m_txInputFrames{0};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4403,6 +4403,8 @@ MainWindow::MainWindow(QWidget* parent)
             m_tciServer, &TciServer::setRxChannelGain);
     connect(m_appletPanel->tciApplet(), &TciApplet::tciTxGainChanged,
             m_tciServer, &TciServer::setTxGain);
+    connect(m_appletPanel->tciApplet(), &TciApplet::tciTxOverflowModeChanged,
+            m_tciServer, &TciServer::setOverflowMode);
 
     // TciServer level signals → TCI applet meters
     connect(m_tciServer, &TciServer::rxLevel,

--- a/src/gui/TciApplet.cpp
+++ b/src/gui/TciApplet.cpp
@@ -13,6 +13,8 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QLineEdit>
+#include <QMenu>
+#include <QActionGroup>
 #include <algorithm>
 #endif
 
@@ -131,6 +133,57 @@ void TciApplet::buildUI()
             // TciServer::setTxGain() persists TciTxGain internally.
             emit tciTxGainChanged(g);
         });
+
+        // Right-click on the TX slider → overflow-mode picker.  Lets users
+        // choose how out-of-range (>1.0) samples from TCI clients are
+        // handled before the radio sees them.  Default Clip preserves the
+        // legacy defensive limiter; NaNGuard / Measure are progressively
+        // less destructive for digital-mode tone fidelity.
+        m_txMeter->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(m_txMeter, &QWidget::customContextMenuRequested,
+                this, [this](const QPoint& pos) {
+            int saved = AppSettings::instance()
+                          .value("TciTxOverflowMode", "0").toString().toInt();
+            saved = std::clamp(saved, 0, 2);
+
+            QMenu menu(this);
+            menu.setTitle("TX overflow handling");
+            auto* group = new QActionGroup(&menu);
+            group->setExclusive(true);
+
+            struct Item { int mode; const char* label; const char* tip; };
+            const Item items[] = {
+                { 0, "Clip (saturating ±1.0)",
+                  "Hard-clamp overshoots to ±1.0.  Defensive default; "
+                  "introduces harmonics on overshoot but protects downstream "
+                  "int16 conversion." },
+                { 1, "NaN guard (zero NaN/Inf only)",
+                  "Pass samples through bit-exact; only zero pathological "
+                  "NaN/Inf values.  Preserves digital-mode tone fidelity; "
+                  "out-of-range floats reach the radio." },
+                { 2, "Measure only (true bypass)",
+                  "Never mutate samples.  Count overshoots for telemetry; "
+                  "the downstream int16 conversion still clamps in the "
+                  "radio-native DAX route." },
+            };
+
+            for (const auto& it : items) {
+                auto* act = menu.addAction(QString::fromUtf8(it.label));
+                act->setToolTip(QString::fromUtf8(it.tip));
+                act->setCheckable(true);
+                act->setChecked(it.mode == saved);
+                act->setData(it.mode);
+                group->addAction(act);
+            }
+
+            connect(&menu, &QMenu::triggered, this, [this](QAction* act) {
+                if (!act) return;
+                emit tciTxOverflowModeChanged(act->data().toInt());
+            });
+
+            menu.exec(m_txMeter->mapToGlobal(pos));
+        });
+
         row->addWidget(m_txMeter, 1);
 
         outer->addLayout(row);

--- a/src/gui/TciApplet.h
+++ b/src/gui/TciApplet.h
@@ -38,6 +38,8 @@ signals:
     void tciToggled(bool on);
     void tciRxGainChanged(int channel, float gain);  // 1-4, 0.0–1.0
     void tciTxGainChanged(float gain);
+    // 0=Clip, 1=NaNGuard, 2=Measure — selected via right-click on TX slider.
+    void tciTxOverflowModeChanged(int mode);
 
 private:
 #ifdef HAVE_WEBSOCKETS


### PR DESCRIPTION
The TCI TX path applied a hard ±1.0 saturating clamp unconditionally
after the gain stage, introducing harmonic distortion on any overshoot.
For well-formed digital-mode tones at -3 dBFS the clamp is a no-op, but
the asymmetry with the DAX path (which has no float-domain clamp at all)
made "100% client-side bypass" claims inaccurate.

Users now pick the regime via right-click on the TCI TX slider:

  Clip     — saturating clamp at ±1.0 (legacy default, defensive)
  NaNGuard — zero NaN/Inf only; pass everything else bit-exact
  Measure  — pure passthrough; count overshoots for telemetry,
             never mutate samples (downstream int16 conversion in
             the radio-native DAX route still clamps)

Selection persists to TciTxOverflowMode (0/1/2).  Default stays Clip so
existing users see no behavior change; WSJT-X / FT8 operators chasing
bit-exact tone fidelity can switch to NaNGuard or Measure.

Telemetry (peak / sumSq / clipSamples) preserved across all three
modes; Measure mode guards the math against NaN so a pathological
client can't poison the running stats.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
