### PR TITLE
docs(changelog): fix contributor attributions in v26.5.3 — @nigelfenton + @G6PWY-Chris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,15 @@ handle, TCI architecture), **@NF0T** (Ryan B, 12 commits — Windows
 installer + RADE + various), **@rfoust** (Robbie Foust, 9 commits —
 FlexControl wheel UX overhaul), **@Ozy311** (5 commits — BYPASS state
 persistence, applet float/dock title-bar sync, ProfileManager auto-save
-signal, DX Spots slider cap, BYPASS tooltip), **@M7HNF-Ian** (Nigel
-Fenton, 5 commits), **@chibondking** (CJ Johnson, 5 commits — panadapter
-dBm prime fix), **@M8WLO** (Andy, 4 commits), **@s53zo** (2 commits —
+signal, DX Spots slider cap, BYPASS tooltip), **@nigelfenton** (Nigel
+Fenton, G0JKN, 5 commits — TCI Network dialog tab, tx_gain + ALC, use-
+after-free fix, vfo emit on band-change, mic-capture suppress during
+TCI feed), **@chibondking** (CJ Johnson, 5 commits — panadapter dBm
+prime fix), **@M8WLO** (Andy, 4 commits), **@s53zo** (2 commits —
 substantial MQTT settings dialog refactor with self-found subscription-
 state fix), **@pepefrog1234** (2 commits — the macOS silent-SSB-TX fix
-+ set_split_vfo ping-pong fix), **@K5PTB** (2 commits), **@chrisb1964**
-(1 commit), and **@aethersdr-agent** (the AetherClaude orchestrator,
++ set_split_vfo ping-pong fix), **@K5PTB** (2 commits), **@G6PWY-Chris**
+(Chris G6PWY, 1 commit), and **@aethersdr-agent** (the AetherClaude orchestrator,
 22 commits — automated fixes on `aetherclaude-eligible` issues).
 Dependabot contributed 6 security and version bumps.
 


### PR DESCRIPTION
Two attribution errors in the v26.5.3 release CHANGELOG:

1. @M7HNF-Ian (Ian, separate GitHub account) → @nigelfenton (Nigel
   Fenton, G0JKN) — Nigel authored all 5 of the commits I bucketed
   under that line: TCI Network dialog tab (#2879), tx_gain + ALC
   (#2950), use-after-free fix (#2946), vfo emit on band-change
   (#2828), mic-capture suppress during TCI feed (#2982).

2. @chrisb1964 → @G6PWY-Chris (Chris G6PWY) — single commit author
   in the cycle was the latter; chrisb1964 is unrelated.

Reported by Nigel directly.  All other handles verified against
gh api repos/.../commits/<sha>.

GitHub release notes already updated; this lands the same fix in
the in-repo CHANGELOG.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
