### PR TITLE
[windows] Restore Windows Snap for custom title bar

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -130,6 +130,7 @@
 #include <QDateTime>
 #include <QPropertyAnimation>
 #include <QIcon>
+#include <QCursor>
 #include <QKeyEvent>
 #include <QMouseEvent>
 #include <QHelpEvent>
@@ -190,6 +191,7 @@
 #ifdef Q_OS_WIN
 #define NOMINMAX
 #include <windows.h>
+#include <windowsx.h>
 #include <psapi.h>
 #else
 #include <sys/resource.h>
@@ -331,6 +333,21 @@ bool memoryRevealTargetMatches(double actualMhz, double targetMhz)
     return targetMhz <= 0.0
         || std::abs(actualMhz - targetMhz) <= kMemoryRevealTargetToleranceMhz;
 }
+
+#ifdef Q_OS_WIN
+bool mainWindowCustomFrameEnabled()
+{
+    return AppSettings::instance()
+        .value("FramelessWindow", "True").toString() == "True";
+}
+
+int windowsResizeBorderThickness(HWND hwnd)
+{
+    const UINT dpi = GetDpiForWindow(hwnd);
+    return GetSystemMetricsForDpi(SM_CXSIZEFRAME, dpi)
+        + GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi);
+}
+#endif
 
 bool flexWheelModeForAction(const QString& actionName, FlexWheelMode& mode)
 {
@@ -1378,8 +1395,11 @@ MainWindow::MainWindow(QWidget* parent)
             s.setValue("FramelessMigratedV0823", "True");
             s.save();
         }
-        if (s.value("FramelessWindow", "True").toString() == "True")
+        if (s.value("FramelessWindow", "True").toString() == "True") {
+#ifndef Q_OS_WIN
             setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
+#endif
+        }
 
         // 8-axis edge resize for frameless mode — same install pattern
         // as the floating dialogs (SpotHub, RadioSetup, MemoryDialog).
@@ -1521,6 +1541,9 @@ MainWindow::MainWindow(QWidget* parent)
 
     buildMenuBar();
     buildUI();
+#ifdef Q_OS_WIN
+    applyWindowsCustomFrame();
+#endif
     registerShortcutActions();
 
     m_swrSweepTimer.setTimerType(Qt::PreciseTimer);
@@ -5454,6 +5477,122 @@ void MainWindow::resizeEvent(QResizeEvent* event)
         m_sizeGrip->raise();
     }
 }
+
+#if defined(Q_OS_WIN)
+void MainWindow::applyWindowsCustomFrame()
+{
+    HWND hwnd = reinterpret_cast<HWND>(winId());
+    if (!hwnd) {
+        return;
+    }
+
+    LONG_PTR style = GetWindowLongPtr(hwnd, GWL_STYLE);
+    const LONG_PTR desiredStyle = style
+        | WS_CAPTION
+        | WS_THICKFRAME
+        | WS_SYSMENU
+        | WS_MINIMIZEBOX
+        | WS_MAXIMIZEBOX;
+    if (style != desiredStyle) {
+        SetWindowLongPtr(hwnd, GWL_STYLE, desiredStyle);
+    }
+
+    SetWindowPos(hwnd, nullptr, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER
+                 | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+}
+
+bool MainWindow::nativeEvent(const QByteArray& eventType, void* message, qintptr* result)
+{
+    MSG* msg = static_cast<MSG*>(message);
+    if (!msg || !result || !mainWindowCustomFrameEnabled()) {
+        return QMainWindow::nativeEvent(eventType, message, result);
+    }
+
+    if (msg->message == WM_NCCALCSIZE && msg->wParam) {
+        if (IsZoomed(msg->hwnd) && windowHandle()
+            && windowHandle()->visibility() != QWindow::FullScreen) {
+            auto* params = reinterpret_cast<NCCALCSIZE_PARAMS*>(msg->lParam);
+            RECT* clientArea = &params->rgrc[0];
+            const int border = windowsResizeBorderThickness(msg->hwnd);
+            clientArea->top += border;
+            clientArea->bottom -= border;
+            clientArea->left += border;
+            clientArea->right -= border;
+        }
+        *result = 0;
+        return true;
+    }
+
+    if (msg->message == WM_NCHITTEST) {
+        RECT windowRect;
+        if (!GetWindowRect(msg->hwnd, &windowRect)) {
+            return QMainWindow::nativeEvent(eventType, message, result);
+        }
+
+        const POINT nativePos{GET_X_LPARAM(msg->lParam), GET_Y_LPARAM(msg->lParam)};
+        if (nativePos.x < windowRect.left || nativePos.x > windowRect.right
+            || nativePos.y < windowRect.top || nativePos.y > windowRect.bottom) {
+            return QMainWindow::nativeEvent(eventType, message, result);
+        }
+
+        const bool canResize = !IsZoomed(msg->hwnd)
+            && !(windowState() & Qt::WindowFullScreen);
+        if (canResize) {
+            const int border = windowsResizeBorderThickness(msg->hwnd);
+            const bool onLeft = nativePos.x >= windowRect.left
+                && nativePos.x < windowRect.left + border;
+            const bool onRight = nativePos.x > windowRect.right - border
+                && nativePos.x <= windowRect.right;
+            const bool onTop = nativePos.y >= windowRect.top
+                && nativePos.y < windowRect.top + border;
+            const bool onBottom = nativePos.y > windowRect.bottom - border
+                && nativePos.y <= windowRect.bottom;
+
+            if (onTop && onLeft) {
+                *result = HTTOPLEFT;
+                return true;
+            }
+            if (onTop && onRight) {
+                *result = HTTOPRIGHT;
+                return true;
+            }
+            if (onBottom && onLeft) {
+                *result = HTBOTTOMLEFT;
+                return true;
+            }
+            if (onBottom && onRight) {
+                *result = HTBOTTOMRIGHT;
+                return true;
+            }
+            if (onLeft) {
+                *result = HTLEFT;
+                return true;
+            }
+            if (onRight) {
+                *result = HTRIGHT;
+                return true;
+            }
+            if (onTop) {
+                *result = HTTOP;
+                return true;
+            }
+            if (onBottom) {
+                *result = HTBOTTOM;
+                return true;
+            }
+        }
+
+        if (m_titleBar && m_titleBar->isVisible()
+            && m_titleBar->isSystemMoveAreaAt(QCursor::pos())) {
+            *result = HTCAPTION;
+            return true;
+        }
+    }
+
+    return QMainWindow::nativeEvent(eventType, message, result);
+}
+#endif
 
 void MainWindow::changeEvent(QEvent* event)
 {
@@ -12903,6 +13042,17 @@ void MainWindow::setFramelessWindow(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
     Qt::WindowFlags flags = windowFlags();
+#ifdef Q_OS_WIN
+    if (flags & Qt::FramelessWindowHint) {
+        flags &= ~Qt::FramelessWindowHint;
+        setWindowFlags(flags);
+        setGeometry(geom);
+        if (wasVisible) {
+            show();
+        }
+    }
+    applyWindowsCustomFrame();
+#else
     if (on)
         flags |= Qt::FramelessWindowHint;
     else
@@ -12911,6 +13061,7 @@ void MainWindow::setFramelessWindow(bool on)
     setGeometry(geom);
     if (wasVisible)
         show();
+#endif
 
     // Keep the bottom-right size grip in sync — only useful when frameless.
     if (m_sizeGrip) m_sizeGrip->setVisible(on);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -141,6 +141,10 @@ protected:
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
+#if defined(Q_OS_WIN)
+    bool nativeEvent(const QByteArray& eventType, void* message, qintptr* result) override;
+    void applyWindowsCustomFrame();
+#endif
 
 private slots:
     // Radio/connection events
@@ -280,9 +284,8 @@ private:
     // both chain widgets so they stay in lock-step.
     void onTxChainStageEnabledChanged(AudioEngine::TxChainStage stage,
                                       bool enabled);
-    // Toggle OS window-chrome on/off (Qt::FramelessWindowHint).  Persists
-    // to AppSettings("FramelessWindow"). When on, users move/close the
-    // window via keyboard shortcuts or taskbar.
+    // Toggle OS window-chrome on/off. Persists to AppSettings("FramelessWindow").
+    // When on, TitleBar provides the drag surface and window-control buttons.
     void setFramelessWindow(bool on);
 
     // Lazy-construct + show + raise + activate for a PersistentDialog

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -28,6 +28,13 @@
 #include <QJsonObject>
 #include "core/VersionNumber.h"
 
+#ifdef Q_OS_WIN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
 namespace AetherSDR {
 
 namespace {
@@ -454,6 +461,33 @@ bool TitleBar::isDragHandle(QObject* obj) const
     return obj && obj->property(kTitleDragHandleProperty).toBool();
 }
 
+bool TitleBar::isSystemMoveAreaAt(const QPoint& globalPos) const
+{
+    const QPoint localPos = mapFromGlobal(globalPos);
+    if (!rect().contains(localPos)) {
+        return false;
+    }
+
+    QWidget* child = childAt(localPos);
+    if (!child) {
+        return true;
+    }
+
+    if (m_menuBar && (child == m_menuBar || m_menuBar->isAncestorOf(child))) {
+        const QPoint menuPos = m_menuBar->mapFromGlobal(globalPos);
+        return !m_menuBar->actionAt(menuPos);
+    }
+
+    for (QWidget* widget = child; widget && widget != this;
+         widget = widget->parentWidget()) {
+        if (isDragHandle(widget)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool TitleBar::startWindowMove(QMouseEvent* ev, bool useSystemMove)
 {
     if (!ev || ev->button() != Qt::LeftButton)
@@ -463,15 +497,25 @@ bool TitleBar::startWindowMove(QMouseEvent* ev, bool useSystemMove)
     if (!w)
         return false;
 
-    m_windowMoveActive = true;
-    m_windowMoveUsesSystem = false;
-    m_windowMovePressGlobal = ev->globalPosition().toPoint();
-    m_windowMoveStartPos = w->pos();
-
     if (useSystemMove) {
-#ifndef Q_OS_MAC
+#ifdef Q_OS_WIN
+        HWND hwnd = reinterpret_cast<HWND>(w->winId());
+        if (hwnd) {
+            const QPoint globalPos = ev->globalPosition().toPoint();
+            ReleaseCapture();
+            SendMessageW(hwnd, WM_NCLBUTTONDOWN, HTCAPTION,
+                         MAKELPARAM(globalPos.x(), globalPos.y()));
+            ev->accept();
+            return true;
+        }
+#elif !defined(Q_OS_MAC)
         if (auto* h = w->windowHandle())
-            m_windowMoveUsesSystem = h->startSystemMove();
+            if (h->startSystemMove()) {
+                m_windowMoveActive = true;
+                m_windowMoveUsesSystem = true;
+                ev->accept();
+                return true;
+            }
 #endif
     }
 
@@ -480,8 +524,11 @@ bool TitleBar::startWindowMove(QMouseEvent* ev, bool useSystemMove)
     // so subsequent mouse-move events stop reaching us as soon as the
     // cursor leaves the widget that was clicked.  Explicitly grab on
     // TitleBar so all moves/releases route to our handlers.
-    if (!m_windowMoveUsesSystem)
-        grabMouse();
+    m_windowMoveActive = true;
+    m_windowMoveUsesSystem = false;
+    m_windowMovePressGlobal = ev->globalPosition().toPoint();
+    m_windowMoveStartPos = w->pos();
+    grabMouse();
 
     ev->accept();
     return true;
@@ -563,7 +610,7 @@ bool TitleBar::eventFilter(QObject* obj, QEvent* ev)
         } else if (ev->type() == QEvent::MouseButtonPress) {
             auto* me = static_cast<QMouseEvent*>(ev);
             if (me->button() == Qt::LeftButton && !m_menuBar->actionAt(me->pos()))
-                return startWindowMove(me, false);
+                return startWindowMove(me);
         }
     }
 

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -44,6 +44,10 @@ public:
     // own Qt::Window.
     void setAppletFloating(bool floating);
 
+    // Windows native hit-testing uses this to expose custom title-bar gaps
+    // as caption drag zones while keeping controls interactive.
+    bool isSystemMoveAreaAt(const QPoint& globalPos) const;
+
 signals:
     void pcAudioToggled(bool on);
     void masterVolumeChanged(int pct);


### PR DESCRIPTION
## Summary

- Preserve native Windows overlapped-window styles for the main window so Snap Assist can recognize it as a normal resizable window.
- On Windows, avoid Qt 6.8.3's `Qt::FramelessWindowHint`/`WS_POPUP` path for the main window while frameless mode is enabled; instead hide the native frame with `WM_NCCALCSIZE`.
- Return Windows non-client hit-test values (`HTCAPTION`, resize edges/corners) for the custom title bar and window edges so the center title-bar handle invokes the OS move/snap UI.
- Keep existing frameless propagation for dialogs/floating child windows unchanged.

## Why

Qt 6.8.3 creates `Qt::FramelessWindowHint` top-level windows as `WS_POPUP` and its Windows platform hit-test path skips frameless windows. That prevents Windows from taking over the drag operation for Snap Assist even when the app returns `HTCAPTION`. Keeping native frame style bits and hiding the frame through `WM_NCCALCSIZE` matches the Windows custom-frame contract and restores the native snap preview.

## Testing

- Built on Windows/MSVC with 8-way parallel build:
  `powershell -NoProfile -ExecutionPolicy Bypass -Command ". 'C:\Users\patj\Documents\AetherSDR\scripts\enter-msvc.ps1' -Arch x64; cmake --build build-msvc --config RelWithDebInfo --parallel 8"`
- Ran `windeployqt` after build:
  `C:\Users\patj\Documents\AetherSDR\Qt\6.8.3\msvc2022_64\bin\windeployqt.exe --release --compiler-runtime C:\Users\patj\Documents\AetherSDR\upstream\AetherSDR-windows-window-snap\build-msvc\AetherSDR.exe`
- Manual Windows verification: dragging the center handle in the frameless title bar now shows the Windows Snap UI and snaps to top/left/right.

`windeployqt` emitted the existing local warnings about missing `dxcompiler.dll`/`dxil.dll` and unset `VCINSTALLDIR`; deployment otherwise completed.