### PR TITLE
feat(theme): Phase 2 gradient token support (linear + radial)

### DIFF
--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "name": "Default Dark",
   "author": "AetherSDR Team",
-  "version": "1.1",
-  "description": "AetherSDR's original dark theme — expanded to the Phase 2 canonical taxonomy (51 tokens). Visually compatible with v26.5.3; sub-perceptual diffs at sites where close-variant colours collapsed onto canonical tokens (see docs/theming/canonical-tokens.md).",
+  "version": "1.2",
+  "description": "AetherSDR's original dark theme — Phase 2 canonical taxonomy (51 tokens) plus the waterfall colormap gradient validating gradient-token support. Visually compatible with v26.5.3; sub-perceptual diffs at sites where close-variant colours collapsed onto canonical tokens (see docs/theming/canonical-tokens.md).",
   "tokens": {
     "color": {
       "background": {
@@ -45,6 +45,20 @@
         "peakHold": "#ffb84d",
         "average": "#8ea8c0",
         "grid": "#1a2330"
+      },
+      "waterfall.colormap": {
+        "type": "linear-gradient",
+        "angle": 180,
+        "stops": [
+          { "at": 0.00, "color": "#000000" },
+          { "at": 0.15, "color": "#000040" },
+          { "at": 0.30, "color": "#0040c0" },
+          { "at": 0.45, "color": "#00c0c0" },
+          { "at": 0.60, "color": "#00c040" },
+          { "at": 0.75, "color": "#c0c000" },
+          { "at": 0.90, "color": "#c04000" },
+          { "at": 1.00, "color": "#ffffff" }
+        ]
       },
       "slice": {
         "a": "#ff4040",

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -6,14 +6,55 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QLinearGradient>
+#include <QRadialGradient>
 #include <QRegularExpression>
+#include <QtMath>
+#include <cmath>
 
 namespace AetherSDR {
 
 namespace {
+
+// Parse a JSON gradient object into the structured ThemeGradient form.
+// Recognised schema (linear):
+//   { "type": "linear-gradient", "angle": 180,
+//     "stops": [ { "at": 0.0, "color": "#aabbcc" }, ... ] }
+// Recognised schema (radial):
+//   { "type": "radial-gradient", "center": [0.5, 0.5], "radius": 0.7,
+//     "stops": [ ... ] }
+// Unknown "type" values default to Linear with an empty stop list — the
+// downstream brush()/cssFragment() handles empty-stop gradients as
+// transparent black.
+ThemeGradient parseGradient(const QJsonObject& obj)
+{
+    ThemeGradient g;
+    const QString type = obj.value("type").toString();
+    g.type = (type == QLatin1String("radial-gradient")) ? ThemeGradient::Radial
+                                                        : ThemeGradient::Linear;
+    g.angle = obj.value("angle").toDouble(180.0);
+    if (g.type == ThemeGradient::Radial) {
+        const QJsonArray c = obj.value("center").toArray();
+        if (c.size() >= 2) {
+            g.center = QPointF(c.at(0).toDouble(0.5), c.at(1).toDouble(0.5));
+        }
+        g.radius = obj.value("radius").toDouble(0.5);
+    }
+    const QJsonArray stops = obj.value("stops").toArray();
+    g.stops.reserve(stops.size());
+    for (const QJsonValue& v : stops) {
+        const QJsonObject so = v.toObject();
+        ThemeGradientStop s;
+        s.at = so.value("at").toDouble(0.0);
+        s.color = QColor(so.value("color").toString());
+        g.stops.append(s);
+    }
+    return g;
+}
 
 // Recursively walk a JSON object, emitting `category.subkey...leaf = value`
 // pairs into `out`.  Schema lets users group tokens under "color", "font",
@@ -26,16 +67,11 @@ void flattenTokens(const QJsonObject& obj, const QString& prefix,
                                              : prefix + QLatin1Char('.') + it.key();
         const QJsonValue v = it.value();
         if (v.isObject()) {
-            // Plain nested object — keep recursing.  Gradient objects
-            // (which also start with "type": "linear-gradient" etc.) land
-            // in Phase 2; for now we ignore them on load so an early
-            // theme file with a gradient still loads its scalars cleanly.
             const QJsonObject inner = v.toObject();
+            // Gradient objects carry a "type" string discriminator that
+            // distinguishes them from plain nested token groups.
             if (inner.contains("type") && inner.value("type").isString()) {
-                // Phase 2 will store gradients as a structured QVariant.
-                // For Phase 1, log and skip so the rest of the theme loads.
-                qCDebug(lcGui) << "ThemeManager: gradient token" << key
-                                << "skipped (Phase 2 work)";
+                out.insert(key, QVariant::fromValue(parseGradient(inner)));
                 continue;
             }
             flattenTokens(inner, key, out);
@@ -47,6 +83,56 @@ void flattenTokens(const QJsonObject& obj, const QString& prefix,
             out.insert(key, v.toBool());
         }
     }
+}
+
+// Convert a CSS-convention angle (0deg = bottom→top, 90deg = left→right,
+// 180deg = top→bottom, 270deg = right→left) to a 0–1 normalised
+// (x1, y1, x2, y2) endpoint pair that covers a unit square.
+//
+// Used by both brush() (mapping onto a real QRect) and cssFragment()
+// (emitting normalised stylesheet coords).  Extracted so the two paths
+// stay in lock-step — a future bug in one would otherwise produce subtle
+// mismatches between the painted gradient and the stylesheet-emitted
+// preview.
+void linearAngleToEndpoints(qreal angleDeg,
+                            qreal& x1, qreal& y1, qreal& x2, qreal& y2)
+{
+    const qreal rad = qDegreesToRadians(angleDeg);
+    // Half-diagonal of the unit square — guarantees the gradient line
+    // reaches the corners regardless of angle.  sqrt(2)/2 ≈ 0.7071.
+    constexpr qreal kHalfDiagonal = 0.7071067811865476;
+    const qreal dx = std::sin(rad);
+    const qreal dy = -std::cos(rad);  // CSS Y axis is inverted vs screen
+    x1 = 0.5 - dx * kHalfDiagonal;
+    y1 = 0.5 - dy * kHalfDiagonal;
+    x2 = 0.5 + dx * kHalfDiagonal;
+    y2 = 0.5 + dy * kHalfDiagonal;
+}
+
+// Emit a Qt stylesheet gradient fragment for the given gradient.
+QString gradientCssFragment(const ThemeGradient& g)
+{
+    QString out;
+    if (g.type == ThemeGradient::Linear) {
+        qreal x1, y1, x2, y2;
+        linearAngleToEndpoints(g.angle, x1, y1, x2, y2);
+        out = QStringLiteral("qlineargradient(x1:%1, y1:%2, x2:%3, y2:%4")
+                  .arg(x1, 0, 'f', 4).arg(y1, 0, 'f', 4)
+                  .arg(x2, 0, 'f', 4).arg(y2, 0, 'f', 4);
+    } else {
+        out = QStringLiteral("qradialgradient(cx:%1, cy:%2, radius:%3, "
+                             "fx:%1, fy:%2")
+                  .arg(g.center.x(), 0, 'f', 4)
+                  .arg(g.center.y(), 0, 'f', 4)
+                  .arg(g.radius,     0, 'f', 4);
+    }
+    for (const auto& s : g.stops) {
+        out += QStringLiteral(", stop:%1 %2")
+                   .arg(s.at, 0, 'f', 4)
+                   .arg(s.color.name(QColor::HexRgb));
+    }
+    out += QLatin1Char(')');
+    return out;
 }
 
 } // namespace
@@ -264,7 +350,81 @@ QColor ThemeManager::color(const QString& token) const
         qCWarning(lcGui) << "ThemeManager: missing color token" << token;
         return QColor(Qt::transparent);
     }
+    // Gradient tokens: graceful fallback to the first stop's colour so
+    // existing callers asking for a flat colour on what's now a gradient
+    // token don't crash.  Callers that actually want the gradient should
+    // use brush() or cssFragment().
+    if (it.value().canConvert<ThemeGradient>()) {
+        const auto g = it.value().value<ThemeGradient>();
+        if (!g.stops.isEmpty()) return g.stops.first().color;
+        return QColor(Qt::transparent);
+    }
     return QColor(it.value().toString());
+}
+
+QBrush ThemeManager::brush(const QString& token, const QRect& bounds) const
+{
+    const auto it = m_tokens.constFind(token);
+    if (it == m_tokens.constEnd()) {
+        qCWarning(lcGui) << "ThemeManager: missing brush token" << token;
+        return QBrush(Qt::transparent);
+    }
+    if (!it.value().canConvert<ThemeGradient>()) {
+        // Scalar — wrap the colour into a solid brush.
+        return QBrush(QColor(it.value().toString()));
+    }
+    const auto g = it.value().value<ThemeGradient>();
+    if (g.type == ThemeGradient::Linear) {
+        qreal nx1, ny1, nx2, ny2;
+        linearAngleToEndpoints(g.angle, nx1, ny1, nx2, ny2);
+        QPointF start, end;
+        if (bounds.isValid()) {
+            // Map normalised endpoints onto the requested rect.
+            start = QPointF(bounds.x() + bounds.width()  * nx1,
+                            bounds.y() + bounds.height() * ny1);
+            end   = QPointF(bounds.x() + bounds.width()  * nx2,
+                            bounds.y() + bounds.height() * ny2);
+        } else {
+            // Default to ObjectBoundingMode (0-1 normalised) — useful when
+            // the caller intends to assign the brush via QPalette and let
+            // Qt scale it to the widget at paint time.
+            start = QPointF(nx1, ny1);
+            end   = QPointF(nx2, ny2);
+        }
+        QLinearGradient lg(start, end);
+        if (!bounds.isValid()) {
+            lg.setCoordinateMode(QGradient::ObjectBoundingMode);
+        }
+        for (const auto& s : g.stops) lg.setColorAt(s.at, s.color);
+        return QBrush(lg);
+    }
+    // Radial.
+    QPointF center;
+    qreal radius;
+    if (bounds.isValid()) {
+        center = QPointF(bounds.x() + bounds.width()  * g.center.x(),
+                         bounds.y() + bounds.height() * g.center.y());
+        radius = std::min(bounds.width(), bounds.height()) * g.radius;
+    } else {
+        center = g.center;
+        radius = g.radius;
+    }
+    QRadialGradient rg(center, radius);
+    if (!bounds.isValid()) {
+        rg.setCoordinateMode(QGradient::ObjectBoundingMode);
+    }
+    for (const auto& s : g.stops) rg.setColorAt(s.at, s.color);
+    return QBrush(rg);
+}
+
+QString ThemeManager::cssFragment(const QString& token) const
+{
+    const auto it = m_tokens.constFind(token);
+    if (it == m_tokens.constEnd()) return QString();
+    if (it.value().canConvert<ThemeGradient>()) {
+        return gradientCssFragment(it.value().value<ThemeGradient>());
+    }
+    return it.value().toString();
 }
 
 QFont ThemeManager::font(const QString& token) const
@@ -300,16 +460,20 @@ QString ThemeManager::value(const QString& token) const
 {
     const auto it = m_tokens.constFind(token);
     if (it == m_tokens.constEnd()) return QString();
+    // Gradient tokens have no meaningful raw scalar — return empty so
+    // callers that expected a string don't accidentally inline the
+    // QVariant::toString() of a structured value.  Use cssFragment()
+    // for the stylesheet form or brush() for paint code.
+    if (it.value().canConvert<ThemeGradient>()) return QString();
     return it.value().toString();
 }
 
 QString ThemeManager::resolve(const QString& stylesheetTemplate) const
 {
     // Replace every {{token.name}} with the token's stylesheet fragment.
-    // Today: scalar colour tokens emit "#rrggbb"; numeric tokens emit
-    // their value as a plain string ("12" -> "12px" is the caller's
-    // responsibility).  Phase 2 routes gradient tokens through
-    // cssFragment() and emits qlineargradient(...) directly.
+    // Routes through cssFragment(): scalar colour tokens emit "#rrggbb",
+    // numeric tokens emit their plain value ("12" — caller adds "px"),
+    // gradient tokens emit qlineargradient(...) / qradialgradient(...).
     static const QRegularExpression kRe(QStringLiteral(R"(\{\{([^}]+)\}\})"));
     QString out = stylesheetTemplate;
     QRegularExpressionMatchIterator it = kRe.globalMatch(stylesheetTemplate);
@@ -317,7 +481,7 @@ QString ThemeManager::resolve(const QString& stylesheetTemplate) const
     while (it.hasNext()) {
         const QRegularExpressionMatch m = it.next();
         const QString token = m.captured(1).trimmed();
-        const QString val = value(token);
+        const QString val = cssFragment(token);
         // Adjust for the running offset as substitutions change length.
         out.replace(m.capturedStart(0) + offset,
                     m.capturedLength(0),

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -6,46 +6,96 @@
 #include <QHash>
 #include <QColor>
 #include <QFont>
+#include <QBrush>
+#include <QPointF>
+#include <QRect>
 #include <QVariant>
+#include <QVector>
 
 namespace AetherSDR {
 
-// Token-based theming subsystem (RFC #3076 Phase 1).
+// Token-based theming subsystem (RFC #3076 Phase 1+2).
 //
 // Every visual decision in the GUI — colours, fonts, key spacings —
 // resolves through a named token (e.g. "color.accent", "font.size.normal").
 // Themes are JSON files at ~/.config/AetherSDR/themes/<name>.json plus the
 // built-in default-dark / default-light shipped under :/themes/.
 //
-// Phase 1 ships:
-//   - the manager singleton + token API
-//   - JSON loader (scalar values only — gradient support lands in Phase 2)
-//   - stylesheet template resolver ({{token.name}} substitution)
-//   - active-theme persistence via AppSettings (ActiveTheme key)
-//   - default-dark.json baked into Qt resources, bit-identical to today's
-//     hardcoded palette so v0 ships with zero visual diff
+// Phase 1 shipped: manager singleton, scalar token API, JSON loader,
+// stylesheet template resolver, ActiveTheme persistence, default-dark.json
+// baked into resources.
 //
-// Phase 2 will: add the migration audit tool, convert shared stylesheets
-// to the template form, and start recording the widget→token reverse-map
-// for the eventual inspector-mode editor.
+// Phase 2 adds (this commit): first-class gradient tokens.  A color token
+// can be a scalar (#rrggbb) or a gradient object describing a linear or
+// radial gradient with N stops.  brush() returns a QBrush wrapping the
+// resolved Qt gradient; cssFragment() emits the matching qlineargradient
+// / qradialgradient stylesheet syntax; resolve() routes through
+// cssFragment() so existing {{token}} templating "just works" for
+// gradient-typed tokens.
+
+// Gradient definition stored inside m_tokens.  Lives in the public header
+// so the audit/editor tooling can inspect / mutate themes by value.
+struct ThemeGradientStop {
+    qreal  at    = 0.0;   // 0.0–1.0 position
+    QColor color;
+};
+
+struct ThemeGradient {
+    enum Type { Linear, Radial };
+
+    Type    type   = Linear;
+    // Linear: CSS-convention angle.  0deg = bottom→top, 90deg = left→right,
+    // 180deg = top→bottom, 270deg = right→left.  Mirrors the CSS3
+    // linear-gradient() syntax so designers can pull values straight from
+    // CSS or DevTools.
+    qreal   angle  = 180.0;
+    // Radial: normalised centre + radius in 0–1 units of the painted area.
+    QPointF center{0.5, 0.5};
+    qreal   radius = 0.5;
+    QVector<ThemeGradientStop> stops;
+};
+
 class ThemeManager : public QObject {
     Q_OBJECT
 public:
     static ThemeManager& instance();
 
-    // Token accessors.  Missing tokens log a warning and return the
-    // compiled-in default for the type (transparent black / default
-    // QFont / 0).  Phase 5's editor will surface missing-token warnings
-    // to the user; for now they're warning logs only.
+    // Scalar accessors.  Missing tokens log a warning and return the
+    // compiled-in default for the type.  For gradient-typed tokens,
+    // color() returns the gradient's first stop as a graceful fallback;
+    // callers that want the full gradient should use brush() or
+    // cssFragment().
     QColor   color(const QString& token) const;
     QFont    font(const QString& token) const;
     int      sizing(const QString& token) const;
-    QString  value(const QString& token) const;   // raw token resolution
+    QString  value(const QString& token) const;   // raw scalar value, "" for gradients
+
+    // Brush accessor — returns the right Qt brush type for the token.
+    //   - scalar token  → QBrush(QColor)
+    //   - linear        → QBrush(QLinearGradient) mapped onto `bounds`
+    //   - radial        → QBrush(QRadialGradient) mapped onto `bounds`
+    // `bounds` only matters for gradient tokens; pass the widget rect or
+    // the paint area when drawing into a specific QPainter.  An empty
+    // QRect produces a 0–1 normalised gradient suitable for stylesheets
+    // that reference the brush via QPalette or Qt's stylesheet system.
+    QBrush   brush(const QString& token, const QRect& bounds = QRect()) const;
+
+    // Stylesheet fragment.  Emits the right syntax for use inside a Qt
+    // stylesheet:
+    //   - scalar token  → "#rrggbb"
+    //   - linear        → "qlineargradient(x1:.., y1:.., x2:.., y2:..,
+    //                       stop:0 #aabbcc, stop:1 #ddeeff)"
+    //   - radial        → "qradialgradient(cx:.., cy:.., radius:.., fx:.., fy:..,
+    //                       stop:0 #aabbcc, stop:1 #ddeeff)"
+    // Numeric tokens emit their value as a plain string ("12" — adding
+    // "px" / unit suffix is the caller's responsibility).
+    QString  cssFragment(const QString& token) const;
 
     // Stylesheet template resolver.  Replaces every "{{token.name}}"
-    // placeholder with the corresponding token's stylesheet fragment
-    // (today: #rrggbb for colours, raw value for sizing).  Phase 2 will
-    // add gradient tokens emitting qlineargradient(...) syntax.
+    // placeholder by calling cssFragment(), so a stylesheet like
+    //   "QPushButton { background: {{color.button.idle}}; }"
+    // gets a literal "#aabbcc" or a "qlineargradient(...)" inlined
+    // depending on whether the token is scalar or gradient.
     QString  resolve(const QString& stylesheetTemplate) const;
 
     // Theme management.
@@ -53,7 +103,7 @@ public:
     QString     activeTheme() const;
     bool        setActiveTheme(const QString& name);
 
-    // Phase 1 doesn't implement save / import / export — those land with
+    // Phase 1 didn't implement save / import / export — those land with
     // the editor in Phase 5.  Reserved on the API surface so consumers
     // can be written against the final shape from day 1.
 
@@ -82,8 +132,12 @@ private:
 
     // Resource path or filesystem path indexed by theme display name.
     QHash<QString, QString> m_themePaths;
+    // QVariant holds either a QString (scalar) or a ThemeGradient
+    // (typed via Q_DECLARE_METATYPE below).
     QHash<QString, QVariant> m_tokens;
     QString m_activeTheme;
 };
 
 } // namespace AetherSDR
+
+Q_DECLARE_METATYPE(AetherSDR::ThemeGradient)

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -101,6 +101,48 @@ int main(int argc, char** argv)
     const QString badOut = tm.resolve(badTpl);
     EXPECT_TRUE(!badOut.contains("{{"));
 
+    // ── Phase 2 gradient token support ──
+    // The waterfall.colormap token is the canonical 8-stop linear gradient
+    // covering the RF visualisation range from silent (black) to clipped
+    // (white).  Verifies the full gradient parsing + brush construction +
+    // cssFragment emission + resolve() routing path end-to-end.
+    {
+        // color() on a gradient token returns the first stop as a
+        // graceful fallback for callers that don't know about gradients.
+        EXPECT_EQ(tm.color("color.waterfall.colormap").name().toLower(),
+                  QString("#000000"));
+
+        // value() on a gradient token returns empty — the structured
+        // form has no meaningful raw scalar.
+        EXPECT_TRUE(tm.value("color.waterfall.colormap").isEmpty());
+
+        // brush() on a gradient token returns a non-Solid brush.
+        QBrush b = tm.brush("color.waterfall.colormap", QRect(0, 0, 100, 50));
+        EXPECT_TRUE(b.style() == Qt::LinearGradientPattern);
+        const QGradient* grad = b.gradient();
+        EXPECT_TRUE(grad != nullptr);
+        EXPECT_EQ(grad->stops().size(), 8);
+
+        // cssFragment() emits Qt's qlineargradient(...) syntax with the
+        // angle properly mapped to (x1,y1,x2,y2) endpoints + every stop
+        // present.
+        const QString css = tm.cssFragment("color.waterfall.colormap");
+        EXPECT_TRUE(css.startsWith("qlineargradient("));
+        EXPECT_TRUE(css.contains("stop:0.0000 #000000"));
+        EXPECT_TRUE(css.contains("stop:1.0000 #ffffff"));
+        EXPECT_TRUE(css.contains("stop:0.4500 #00c0c0"));  // mid colormap
+
+        // resolve() routes gradient tokens through cssFragment(), so an
+        // existing {{token}} stylesheet template substitutes the
+        // qlineargradient(...) string seamlessly.
+        const QString gradTpl =
+            "QWidget { background: {{color.waterfall.colormap}}; }";
+        const QString gradOut = tm.resolve(gradTpl);
+        EXPECT_TRUE(gradOut.contains("background: qlineargradient("));
+        EXPECT_TRUE(gradOut.contains("stop:1.0000 #ffffff"));
+        EXPECT_TRUE(!gradOut.contains("{{"));
+    }
+
     // ── themeChanged signal fires on setActiveTheme ──
     QSignalSpy spy(&tm, &ThemeManager::themeChanged);
     // Setting the same theme is a no-op (already active) — no signal expected


### PR DESCRIPTION
## Summary

Adds first-class gradient tokens to the theming subsystem per RFC #3076 Phase 2. A color token can now be either a scalar (#rrggbb) or a structured gradient object describing a linear or radial gradient with N stops.

## Schema

\`\`\`jsonc
// Scalar (unchanged from Phase 1)
\"color.accent\": \"#00b4d8\"

// Linear gradient
\"color.button.idle\": {
  \"type\": \"linear-gradient\",
  \"angle\": 180,
  \"stops\": [
    { \"at\": 0.0, \"color\": \"#1a2330\" },
    { \"at\": 1.0, \"color\": \"#0a0e14\" }
  ]
}

// Radial gradient
\"color.led.armed\": {
  \"type\": \"radial-gradient\",
  \"center\": [0.5, 0.5],
  \"radius\": 0.7,
  \"stops\": [ ... ]
}
\`\`\`

Conical gradients deferred — Qt supports them but the use case in radio UI is thin.

## API additions to ThemeManager

- \`QBrush brush(token, bounds = {})\` — Qt brush wrapping the resolved gradient mapped onto a paint rect; empty rect = ObjectBoundingMode
- \`QString cssFragment(token)\` — emits \`qlineargradient(...)\` / \`qradialgradient(...)\` for gradients, \`#rrggbb\` for scalars
- \`resolve(template)\` now routes through \`cssFragment()\` — existing \`{{token}}\` templating handles gradients transparently
- \`color(token)\` returns first stop's colour as graceful fallback on gradient tokens

## Angle convention

CSS3-compatible: 0deg=bottom→top, 90deg=left→right, 180deg=top→bottom, 270deg=right→left. \`linearAngleToEndpoints()\` helper keeps brush() and cssFragment() in lock-step.

## default-dark.json v1.2

Adds \`color.waterfall.colormap\` as the first gradient token — 8-stop linear gradient covering the RF visualisation range. Validates the path end-to-end. **No consumer wired yet** — waterfall widget still uses its hardcoded gradient. That conversion lands with the Phase 3 panadapter/waterfall migration.

## Tests

theme_manager_test exercises gradient parsing, brush construction, cssFragment emission, color() fallback, value() empty-on-gradient, resolve() routing.

## Behavior at runtime today

Zero visible change. Foundation only.

## Test plan

- [x] Linux: theme_manager_test passes locally (worktree build, PASS)
- [x] Linux: full AetherSDR target builds clean
- [ ] CI: build / check-paths / check-windows / CodeQL green

73, Jeremy KK7GWY & Claude (AI dev partner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)