### PR TITLE
feat(theme): Phase 2 pilot — migrate ComboStyle to applyStyleSheet + tokens

### DIFF
--- a/src/gui/ComboStyle.h
+++ b/src/gui/ComboStyle.h
@@ -1,30 +1,50 @@
 #pragma once
 
 // Shared combo box styling for consistent down-arrow appearance across all
-// QComboBox instances in AetherSDR. Use applyComboStyle(combo) on any
-// QComboBox to get the standard dark-themed look with painted down-arrow.
+// QComboBox instances in AetherSDR.  Use applyComboStyle(combo) on any
+// QComboBox to get the standard themed look with painted down-arrow.
+//
+// Theme-aware (RFC #3076 Phase 2): colours come from canonical tokens
+// (color.background.1, color.text.primary, color.background.2,
+// color.accent, color.text.secondary).  The combo's stylesheet re-applies
+// automatically when the user switches themes via ThemeManager::applyStyleSheet
+// (free live-reload through the widget-tracked reverse-map).  The custom
+// down-arrow PNG is also regenerated whenever the theme changes so its
+// colour stays in sync with the rest of the combo.
+
+#include "core/ThemeManager.h"
 
 #include <QComboBox>
 #include <QDir>
 #include <QFile>
-#include <QPixmap>
 #include <QPainter>
+#include <QPixmap>
+#include <QPointer>
 
 namespace AetherSDR {
 
-// Generate a small down-arrow PNG (cached in temp dir, created once).
+namespace detail {
+
+// Generate (or reuse) the down-arrow PNG coloured by the current theme's
+// color.text.secondary token.  Cached under /tmp with the colour hex in
+// the filename so each theme's arrow gets its own cache entry — switching
+// themes back and forth doesn't re-encode the PNG every time.
 inline QString comboArrowPath()
 {
-    static QString path;
-    if (!path.isEmpty()) return path;
-    path = QDir::temp().filePath("aethersdr_combo_arrow.png");
+    const QString colourHex = ThemeManager::instance()
+                                  .color("color.text.secondary")
+                                  .name(QColor::HexRgb)
+                                  .remove(QLatin1Char('#'));
+    const QString path = QDir::temp().filePath(
+        QStringLiteral("aethersdr_combo_arrow_%1.png").arg(colourHex));
     if (QFile::exists(path)) return path;
+
     QPixmap pm(8, 6);
     pm.fill(Qt::transparent);
     QPainter p(&pm);
     p.setRenderHint(QPainter::Antialiasing);
     p.setPen(Qt::NoPen);
-    p.setBrush(QColor(0x8a, 0xa8, 0xc0));
+    p.setBrush(ThemeManager::instance().color("color.text.secondary"));
     const QPointF tri[] = {{0, 0}, {8, 0}, {4, 6}};
     p.drawPolygon(tri, 3);
     p.end();
@@ -32,23 +52,54 @@ inline QString comboArrowPath()
     return path;
 }
 
-// Standard combo box stylesheet matching the dark theme with painted arrow.
-inline QString comboStyleSheet()
+} // namespace detail
+
+// Stylesheet template — references token placeholders rather than baked-in
+// hex.  ThemeManager::resolve() expands the {{...}} placeholders at apply
+// time.  The arrow URL is arg()ed in by the caller because it depends on
+// the active theme's text.secondary colour (cached PNG path varies per
+// theme).
+inline QString comboStyleTemplate()
 {
-    return QString(
-        "QComboBox { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050;"
+    return QStringLiteral(
+        "QComboBox { background: {{color.background.1}};"
+        " color: {{color.text.primary}};"
+        " border: 1px solid {{color.background.2}};"
         " padding: 2px 2px 2px 4px; border-radius: 2px; }"
         "QComboBox::drop-down { border: none; width: 14px; }"
         "QComboBox::down-arrow { image: url(%1); width: 8px; height: 6px; }"
-        "QComboBox QAbstractItemView { background: #1a2a3a; color: #c8d8e8;"
-        " selection-background-color: #00b4d8; }")
-        .arg(comboArrowPath());
+        "QComboBox QAbstractItemView { background: {{color.background.1}};"
+        " color: {{color.text.primary}};"
+        " selection-background-color: {{color.accent}}; }")
+        .arg(detail::comboArrowPath());
 }
 
-// Apply the standard style to a combo box.
+// Apply the themed style to a combo box.  Routes through
+// ThemeManager::applyStyleSheet so the combo gets free live re-theme on
+// theme changes via the widget-tracked reverse-map.
+//
+// Additionally connects themeChanged → refresh because the arrow URL
+// embedded in the template depends on the active theme.  Without the
+// extra connection, theme changes would re-resolve the {{tokens}} but
+// keep the stale arrow URL.  The double-apply is wasteful but small; a
+// Phase 5 follow-up could introduce a "computed token" mechanism to
+// avoid the duplicate apply if combos become a hot path.
 inline void applyComboStyle(QComboBox* combo)
 {
-    combo->setStyleSheet(comboStyleSheet());
+    if (!combo) return;
+
+    ThemeManager::instance().applyStyleSheet(combo, comboStyleTemplate());
+
+    // QPointer guards against the combo being destroyed before the theme
+    // change fires.  The combo is also the receiver-context for the
+    // connection so Qt cleans up the lambda when the combo dies.
+    QPointer<QComboBox> guard(combo);
+    QObject::connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
+                     combo, [guard]() {
+        if (guard) {
+            ThemeManager::instance().applyStyleSheet(guard, comboStyleTemplate());
+        }
+    });
 }
 
 } // namespace AetherSDR

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1212,7 +1212,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         grid->addWidget(lbl, row, 0);
         m_freqGridSpacingCmb = new QComboBox;
         m_freqGridSpacingCmb->setFixedHeight(18);
-        m_freqGridSpacingCmb->setStyleSheet(comboStyleSheet());
+        applyComboStyle(m_freqGridSpacingCmb);
         m_freqGridSpacingCmb->addItem("Auto", 0);
         for (int khz : {1, 2, 5, 10, 25, 50, 100})
             m_freqGridSpacingCmb->addItem(QString("%1 kHz").arg(khz), khz);
@@ -1231,7 +1231,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         grid->addWidget(lbl, row, 0);
         m_colorSchemeCmb = new QComboBox;
         m_colorSchemeCmb->setFixedHeight(18);
-        m_colorSchemeCmb->setStyleSheet(comboStyleSheet());
+        applyComboStyle(m_colorSchemeCmb);
         for (int i = 0; i < static_cast<int>(WfColorScheme::Count); ++i)
             m_colorSchemeCmb->addItem(wfSchemeName(static_cast<WfColorScheme>(i)));
         grid->addWidget(m_colorSchemeCmb, row, 1, 1, 3);


### PR DESCRIPTION
## Summary

First real consumer of the RFC #3076 Phase 2 theming infrastructure. Migrates [src/gui/ComboStyle.h](src/gui/ComboStyle.h) — the central styling helper for every QComboBox in AetherSDR — from hardcoded hex to canonical token references via \`ThemeManager::applyStyleSheet\`.

## Why ComboStyle as the pilot

- **High leverage:** \`applyComboStyle()\` is called from 20+ sites (AppletPanel, RadioSetupDialog, PhoneCwApplet, RxApplet, StripEqPanel, WaveApplet, SpectrumOverlayMenu, …) — one function migrated themes them all.
- **Small surface:** single 54-line header, easy to review and rollback.
- **Covers both code paths:** stylesheet template + paint-code QColor literal (the arrow PNG), exercising both \`resolve()\` and direct \`ThemeManager::color()\` lookup.

## Migration details

**Hex → tokens:**
| Was | Now |
|---|---|
| \`#1a2a3a\` | \`{{color.background.1}}\` |
| \`#c8d8e8\` | \`{{color.text.primary}}\` |
| \`#304050\` | \`{{color.background.2}}\` |
| \`#00b4d8\` | \`{{color.accent}}\` |
| \`QColor(0x8a, 0xa8, 0xc0)\` | \`ThemeManager::color(\"color.text.secondary\")\` |

**Routing:** \`applyComboStyle\` now calls \`ThemeManager::applyStyleSheet\` instead of \`combo->setStyleSheet\`. Combos get free live re-theme on theme change via the widget-tracked reverse-map (PR #3085).

**Arrow PNG cache:** filename now includes the resolved \`text.secondary\` hex so each theme variation gets its own cached arrow (\`/tmp/aethersdr_combo_arrow_<hex>.png\`).

**SpectrumOverlayMenu.cpp:** two direct calls to \`comboStyleSheet()\` (the underlying-now-removed helper) converted to \`applyComboStyle()\`.

## Tradeoff documented inline

\`applyComboStyle\` installs **two** connections on \`themeChanged\`:
1. The reverse-map's automatic re-apply (from #3085)
2. An explicit refresh lambda that regenerates the arrow URL

The double-apply is wasteful but small. The arrow URL has to be computed at apply time (it's a filesystem path that depends on the resolved colour), not a \`{{token}}\` placeholder. Phase 5 could introduce a "computed token" mechanism if combos become a hot path.

QPointer guards the lambda against widget destruction between the connection and the next theme change.

## Verified locally

- [x] Linux build clean (all 20+ call sites still resolve)
- [x] AetherSDR binary launches without crash (offscreen QPA, 3s smoke test)
- [x] No visible diff expected today — resolved colours match the previous hardcoded values exactly

## Stacking note

This PR is based on \`auto/theme-phase2-widget-map\` (PR #3085) because it consumes \`ThemeManager::applyStyleSheet\` which only exists there. When #3085 merges, this rebases cleanly to a single-commit diff against main.

## Test plan

- [ ] CI green on the dependent #3085 first
- [ ] CI green here after rebase
- [ ] Visual smoke: launch app, open Radio Setup dialog, confirm every combo box (profile picker, RCA/ACC, mic source dropdowns) renders identically to v26.5.3
- [ ] After Phase 4 Light theme lands: confirm theme switch repaints every combo simultaneously without a restart

73, Jeremy KK7GWY & Claude (AI dev partner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)