### PR TITLE
[windows] Show Qt menu separators on Windows

### DIFF
--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -491,7 +491,8 @@ bool AetherSDR::CwxPanel::eventFilter(QObject* obj, QEvent* event)
             QMenu menu(this);
             menu.setStyleSheet(
                 "QMenu { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050; }"
-                "QMenu::item:selected { background: #00b4d8; color: #000; }");
+                "QMenu::item:selected { background: #00b4d8; color: #000; }"
+                "QMenu::separator { height: 1px; background: #304050; margin: 4px 8px; }");
             QAction* resendAction = menu.addAction("Resend");
             menu.addSeparator();
             QAction* clearAction  = menu.addAction("Clear History");

--- a/src/gui/Theme.h
+++ b/src/gui/Theme.h
@@ -88,6 +88,7 @@ inline QString appStylesheetTemplate()
         QMenuBar::item:selected { background-color: {{color.background.1}}; }
         QMenu { background-color: {{color.background.0}}; border: 1px solid {{color.border.strong}}; }
         QMenu::item:selected { background-color: {{color.accent}}; color: #000; }
+        QMenu::separator { height: 1px; background: {{color.border.strong}}; margin: 4px 8px; }
         QStatusBar { background-color: {{color.background.0}}; border-top: 1px solid {{color.border.strong}}; }
         QProgressBar {
             background-color: {{color.background.0}};

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -736,7 +736,8 @@ void TitleBar::setMenuBar(QMenuBar* mb)
         "QMenuBar::item { padding: 4px 8px; }"
         "QMenuBar::item:selected { background: #203040; color: #ffffff; }"
         "QMenu { background: #0f0f1a; color: #c8d8e8; border: 1px solid #304050; }"
-        "QMenu::item:selected { background: #0070c0; }");
+        "QMenu::item:selected { background: #0070c0; }"
+        "QMenu::separator { height: 1px; background: #304050; margin: 4px 8px; }");
     mb->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
     m_menuBar = mb;
     m_menuBar->installEventFilter(this);


### PR DESCRIPTION
## Summary

- Add explicit `QMenu::separator` styling to the app-wide Qt stylesheet.
- Add the same separator rule to the frameless titlebar menu stylesheet, which overrides the app-wide menu rules for the main menu bar.
- Patch the CWX history context menu's local stylesheet so its separator action also renders consistently.

## Root Cause

Qt treats menu separators as their own `QMenu::separator` subcontrol. AetherSDR styled `QMenu` and selected menu items, but left the separator subcontrol to the platform/base-style fallback. On Windows, that fallback can effectively paint no visible separator once the menu is stylesheet-owned, while macOS and Linux still showed one.

## Validation

- `git diff --check`
- No app build was run for this stylesheet-only change.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
