### PR TITLE
[codex] Add panadapter context slice creation

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -12242,6 +12242,17 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         if (m_radioModel.slices().size() <= 1) return;
         m_radioModel.sendCommand(QString("slice remove %1").arg(sliceId));
     });
+    connect(sw, &SpectrumWidget::sliceCreateRequested,
+            this, [this, applet](double freqMhz) {
+        const int limit = m_radioModel.maxSlices();
+        if (m_radioModel.slices().size() < limit) {
+            m_radioModel.addSliceOnPan(applet->panId(), freqMhz);
+        } else {
+            statusBar()->showMessage(
+                QString("%1 supports a maximum of %2 slices")
+                    .arg(m_radioModel.model()).arg(limit), 4000);
+        }
+    });
     connect(sw, &SpectrumWidget::sliceTuneRequested,
             this, [this](int sliceId, double freqMhz) {
         if (auto* s = m_radioModel.slice(sliceId))

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -3373,6 +3373,8 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
                 [this, snappedMhz]{ showAddSpotDialog(snappedMhz); });
             menu.addAction(QString("Add TNF at %1 MHz").arg(freqStr), this,
                 [this, freqMhz]{ emit tnfCreateRequested(freqMhz); });
+            menu.addAction(QString("Add Slice at %1 MHz").arg(freqStr), this,
+                [this, snappedMhz]{ emit sliceCreateRequested(snappedMhz); });
         }
 
         if (hitTnf < 0) {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -479,6 +479,7 @@ signals:
     void tnfWidthRequested(int id, int widthHz);
     void tnfDepthRequested(int id, int depthDb);
     void tnfPermanentRequested(int id, bool permanent);
+    void sliceCreateRequested(double freqMhz);
     void sliceCloseRequested(int sliceId);
     void propForecastClicked();  // click on K/A/SFI overlay text
     void sliceTuneRequested(int sliceId, double freqMhz);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1435,7 +1435,21 @@ void RadioModel::addSliceOnPan(const QString& panId)
             break;
         }
     }
-    const QString freq = QString::number(newFreq, 'f', 6);
+    addSliceOnPan(panId, newFreq);
+}
+
+void RadioModel::addSliceOnPan(const QString& panId, double freqMhz)
+{
+    if (panId.isEmpty()) {
+        qCWarning(lcProtocol) << "RadioModel::addSliceOnPan: no panadapter, cannot create slice";
+        return;
+    }
+    if (!std::isfinite(freqMhz)) {
+        qCWarning(lcProtocol) << "RadioModel::addSliceOnPan: invalid frequency" << freqMhz;
+        return;
+    }
+
+    const QString freq = QString::number(freqMhz, 'f', 6);
     const QString cmd = QString("slice create pan=%1 freq=%2").arg(panId, freq);
 
     qCDebug(lcProtocol) << "RadioModel::addSliceOnPan:" << cmd;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -331,6 +331,7 @@ public:
     void cwAutoTuneOnce(int sliceId);                // one-shot (no int= param)
     void addSlice();           // Create a new slice on the active panadapter
     void addSliceOnPan(const QString& panId); // Create a new slice on a specific pan
+    void addSliceOnPan(const QString& panId, double freqMhz); // Create slice on specific pan/frequency
     void createPanadapter();   // Create a new independent panadapter
     void removePanadapter(const QString& panId);
     void setPanBandwidth(double bandwidthMhz);


### PR DESCRIPTION
## Summary
- Add an `Add Slice at <frequency> MHz` action to the panadapter right-click menu under the existing TNF action.
- Route the request through the active panadapter so the radio receives `slice create pan=<panId> freq=<MHz>`.
- Reuse the existing slice-create failure handling so radio-side slice limits still show the current graceful status message.

## Validation
- `git diff --check`
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build --parallel`