### PR TITLE
[ux] Show active pan renderer in About dialog

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8237,6 +8237,12 @@ void MainWindow::buildMenuBar()
         // useful when bug-reporting against a dev/test build that doesn't
         // correspond to a tagged release.  See CMakeLists.txt for the capture
         // and the file-top #define for the non-CMake-build fallback.
+        const QString rendererDescription = [this]() {
+            if (SpectrumWidget* sw = spectrum()) {
+                return sw->rendererDescription();
+            }
+            return QStringLiteral("No active pan");
+        }();
         auto* header = new QLabel(QString(
             "<div style='text-align:center;'>"
             "<h2 style='margin-bottom:2px; color:#c8d8e8;'>AetherSDR</h2>"
@@ -8246,20 +8252,24 @@ void MainWindow::buildMenuBar()
             "for FlexRadio transceivers.</p>"
             "<p style='font-size:11px; color:#6a8090;'>"
             "Built with Qt %2 &middot; C++20<br>"
-            "Compiled: %3</p>"
+            "Compiled: %3<br>"
+            "Renderer: %5</p>"
             "</div>")
             .arg(QCoreApplication::applicationVersion(), qVersion(),
                  QStringLiteral(__DATE__),
-                 QStringLiteral(AETHER_GIT_SHA)));
+                 QStringLiteral(AETHER_GIT_SHA),
+                 rendererDescription.toHtmlEscaped()));
         header->setAlignment(Qt::AlignCenter);
         header->setWordWrap(true);
         // Tooltip explains the staleness possibility — the SHA is baked at
         // CMake configure time, so a dev who runs `cmake --build` after a
         // new commit without re-configuring sees the previous SHA here.
         // Re-running `cmake --fresh` (or deleting CMakeCache.txt) captures
-        // the current HEAD.
+        // the current HEAD. The renderer line comes from the active pan at
+        // dialog-open time, after Qt has picked a real QRhi backend when the
+        // GPU path is active.
         header->setToolTip(
-            QStringLiteral("Build identity. SHA is captured at CMake "
+            QStringLiteral("Build identity and active pan renderer. SHA is captured at CMake "
                            "configure time — re-run `cmake -B build` after "
                            "a new commit if you need the current value."));
         vbox->addWidget(header);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -259,6 +259,60 @@ static QRgb interpolateGradient(float t, const WfGradientStop* stops, int n)
     return qRgb(qBound(0, r, 255), qBound(0, g, 255), qBound(0, b, 255));
 }
 
+#ifdef AETHER_GPU_SPECTRUM
+static bool qtSoftwareOpenGlRequested()
+{
+    return qEnvironmentVariableIsSet("AETHER_NO_GPU")
+        || qEnvironmentVariable("QT_OPENGL").compare(
+            QStringLiteral("software"), Qt::CaseInsensitive) == 0;
+}
+
+static bool qrhiDeviceNameLooksSoftware(const QString& deviceName)
+{
+    const QString lower = deviceName.toLower();
+    return lower.contains(QStringLiteral("llvmpipe"))
+        || lower.contains(QStringLiteral("softpipe"))
+        || lower.contains(QStringLiteral("swiftshader"))
+        || lower.contains(QStringLiteral("software"))
+        || lower.contains(QStringLiteral("warp"))
+        || lower.contains(QStringLiteral("microsoft basic render"));
+}
+#endif
+
+QString SpectrumWidget::rendererDescription() const
+{
+#ifdef AETHER_GPU_SPECTRUM
+    QRhi* currentRhi = rhi();
+    if (!currentRhi) {
+        return QStringLiteral("QRhi initializing");
+    }
+
+    const QString backendName = QString::fromLatin1(currentRhi->backendName());
+    const QRhiDriverInfo driverInfo = currentRhi->driverInfo();
+    const QString deviceName = QString::fromUtf8(driverInfo.deviceName).trimmed();
+    const bool softwareOpenGl = currentRhi->backend() == QRhi::OpenGLES2
+        && qtSoftwareOpenGlRequested();
+    const bool cpuDevice = driverInfo.deviceType == QRhiDriverInfo::CpuDevice
+        || softwareOpenGl
+        || qrhiDeviceNameLooksSoftware(deviceName);
+
+    QStringList details;
+    details << backendName;
+    if (!deviceName.isEmpty()) {
+        details << deviceName;
+    }
+    if (softwareOpenGl) {
+        details << QStringLiteral("software OpenGL");
+    }
+
+    return QStringLiteral("%1 QRhi (%2)")
+        .arg(cpuDevice ? QStringLiteral("CPU") : QStringLiteral("GPU"),
+             details.join(QStringLiteral("; ")));
+#else
+    return QStringLiteral("CPU QPainter");
+#endif
+}
+
 SpectrumWidget::SpectrumWidget(QWidget* parent)
     : SPECTRUM_BASE_CLASS(parent)
 {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -92,6 +92,7 @@ public:
     void resetGpuResources();  // tear down GPU pipelines for reparenting (#1240)
     void prepareForTopLevelChange(); // unregister QRhiWidget from the current backing-store QRhi
     void prepareForShutdown(); // tear down QRhi/native resources before QWidget backing store destruction
+    QString rendererDescription() const;
     void setConnectionAnimationVisible(bool on, const QString& label = {});
     void showInterlockNotification(const QString& message, int durationMs = 5000);
 


### PR DESCRIPTION
## Summary

- Add `SpectrumWidget::rendererDescription()` so each pan can report the renderer it is actually using at runtime.
- Show a new `Renderer:` line under `Compiled:` in the About dialog for support diagnostics.
- Report live QRhi backend/device details when available, classify known software/CPU QRhi paths, and keep CPU `QPainter` fallback builds explicit.

## Validation

- `git diff --check`
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `env -u CPLUS_INCLUDE_PATH cmake --build build --parallel 22`
- Deployed `/Users/patj/Documents/AetherSDR/.worktrees/about-renderer-label/build/AetherSDR.app` to `patj@mac.jensencloud.net:/Users/patj/Desktop/AetherSDR.app` and cleared quarantine.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
