### PR TITLE
[codex] Avoid macOS bitmap cursor crash path

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2997,6 +2997,22 @@ void SpectrumWidget::setSpectrumCursor(Qt::CursorShape shape)
     // standard Qt cursor changes can pass through QImage::toCGImage() in the
     // Cocoa platform plugin; issue #2458 crashed in that path while dispatching
     // enter/leave events.
+#ifdef Q_OS_MAC
+    // Qt 6.11's Cocoa plugin can synthesize some standard cursors from bitmap
+    // resources before handing them to CoreGraphics. Avoid the bitmap-backed
+    // shapes used in the panadapter hot paths; issue #2910 reports the same
+    // QImage::toCGImage() crash after the redundant-install guard shipped.
+    switch (shape) {
+    case Qt::SplitVCursor:
+        shape = Qt::SizeVerCursor;
+        break;
+    case Qt::SizeAllCursor:
+        shape = Qt::OpenHandCursor;
+        break;
+    default:
+        break;
+    }
+#endif
     if (cursor().shape() == shape) {
         return;
     }


### PR DESCRIPTION
Fixes #2910

## What changed
- Keep the existing spectrum cursor funnel and redundant-install guard.
- On macOS only, substitute two panadapter cursor shapes before installing them:
  - Qt::SplitVCursor -> Qt::SizeVerCursor
  - Qt::SizeAllCursor -> Qt::OpenHandCursor

## Why
Issue #2910 reports the same macOS QImage::toCGImage() / CoreGraphics cursor crash signature after the earlier redundant setCursor() guard shipped in #2461 and in v26.5.2.1.

AetherSDR does not construct custom image cursors in this path, so the remaining low-risk client-side mitigation is to avoid Qt/Cocoa's bitmap-backed standard cursor synthesis for the spectrum hot paths while leaving Linux and Windows behavior unchanged.

## Validation
- git diff --check
- cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
- cmake --build build --parallel 8