### PR TITLE
[audio] Fix NR2 FFTW wisdom cancellation and status logging

### DIFF
--- a/docs/architecture/audio-pipeline.md
+++ b/docs/architecture/audio-pipeline.md
@@ -641,6 +641,15 @@ Radio-provided taps:
 | DAX low-latency TX | `AudioEngine::feedDaxTxAudio()` | float32 stereo | VITA PCC `0x03E3` float32 stereo | 24 kHz | 2 | 128 stereo frames per packet |
 | DAX radio-native TX | `AudioEngine::feedDaxTxAudio()` | float32 stereo | VITA PCC `0x0123` Int16 mono | 24 kHz | 2 -> 1 | Safe stronger-channel/average mono collapse; radio `dax=1` route |
 
+NR2 enable is gated by `MainWindow::enableNr2WithWisdom()`. If FFTW wisdom
+needs first-run generation, cancellation leaves the current audio path untouched:
+NR2 is not initialized, other client DSP state is not reset, and wisdom is only
+installed after a complete temp-file export.
+Startup and NR2-enable preflight emit an `aether.audio.summary` "Audio NR2
+wisdom summary" that records whether cached wisdom is valid, missing, or
+invalid/stale and where the wisdom file lives. Invalid/stale wisdom also emits a
+warning before it is discarded and regenerated.
+
 ## Downmix, duplication, resampling, and format-change table
 
 | Location | Operation | Input | Output | Notes |

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -45,9 +45,11 @@
 #include <limits>
 #include <QIODevice>
 #include <QFile>
+#include <QFileInfo>
 #include <QMediaDevices>
 #include <QAudioDevice>
 #include <QDir>
+#include <QDateTime>
 #include <QtEndian>
 #include <QThread>
 #include <QJsonDocument>
@@ -58,6 +60,10 @@
 #include <optional>
 
 namespace AetherSDR {
+
+static QString wisdomDir();
+static void logNr2WisdomSummary(const QString& context);
+static void logNr2WisdomGenerationSummary(SpectralNR::WisdomResult result);
 
 namespace {
 constexpr qint64 kTxAutoRestartMinRuntimeMs = 60000;
@@ -644,6 +650,7 @@ AudioEngine::AudioEngine(QObject* parent)
 
     AudioSummaryLogger::logStartupEnvironment(
         DeviceDiagnostics::buildAudioStartupSnapshot(this, QJsonObject{}));
+    logNr2WisdomSummary(QStringLiteral("startup"));
 
     // Opus TX pacing timer — sends one queued packet every 10ms for even
     // delivery timing. Without this, QAudioSource delivers bursts of samples
@@ -3339,18 +3346,110 @@ QString AudioEngine::wisdomFilePath()
     return wisdomDir() + "aethersdr_fftw_wisdom";
 }
 
+static QString wisdomFileDetailText(const QFileInfo& info)
+{
+    if (!info.exists()) {
+        return QStringLiteral("path=\"%1\"")
+            .arg(QDir::toNativeSeparators(info.absoluteFilePath()));
+    }
+
+    return QStringLiteral("path=\"%1\" size=%2B modified=\"%3\"")
+        .arg(QDir::toNativeSeparators(info.absoluteFilePath()))
+        .arg(info.size())
+        .arg(info.lastModified().toString(Qt::ISODateWithMs));
+}
+
+static QString wisdomResultText(SpectralNR::WisdomResult result)
+{
+    switch (result) {
+    case SpectralNR::WisdomResult::Ready:     return QStringLiteral("ready");
+    case SpectralNR::WisdomResult::Generated: return QStringLiteral("generated");
+    case SpectralNR::WisdomResult::Cancelled: return QStringLiteral("cancelled");
+    case SpectralNR::WisdomResult::Failed:    return QStringLiteral("failed");
+    }
+    return QStringLiteral("unknown");
+}
+
+static void logNr2WisdomSummary(const QString& context)
+{
+#ifndef HAVE_FFTW3
+    QStringList lines;
+    lines << QStringLiteral("Audio NR2 wisdom summary:")
+          << QStringLiteral("  context=%1 status=unavailable action=runtime-plans reason=\"built without FFTW3\"")
+                 .arg(context);
+    qCInfo(lcAudioSummary).noquote() << lines.join(QLatin1Char('\n'));
+#else
+    const QString directory = wisdomDir();
+    const QString path = directory + "aethersdr_fftw_wisdom";
+    const QFileInfo info(path);
+
+    QString status;
+    QString action;
+    bool warn = false;
+
+    if (!info.exists()) {
+        status = QStringLiteral("missing");
+        action = QStringLiteral("train-on-first-enable");
+    } else if (!info.isFile()) {
+        status = QStringLiteral("invalid");
+        action = QStringLiteral("discard-and-regenerate-on-first-enable");
+        warn = true;
+    } else if (SpectralNR::loadWisdom(directory.toStdString())) {
+        status = QStringLiteral("valid");
+        action = QStringLiteral("use-cached-wisdom");
+    } else {
+        status = QStringLiteral("invalid-or-stale");
+        action = QStringLiteral("discard-and-regenerate-on-first-enable");
+        warn = true;
+    }
+
+    QStringList lines;
+    lines << QStringLiteral("Audio NR2 wisdom summary:")
+          << QStringLiteral("  context=%1 status=%2 action=%3")
+                 .arg(context, status, action)
+          << QStringLiteral("  %1").arg(wisdomFileDetailText(info));
+
+    const QString summary = lines.join(QLatin1Char('\n'));
+    if (warn) {
+        qCWarning(lcAudioSummary).noquote() << summary;
+        qCWarning(lcAudio).noquote()
+            << QStringLiteral("AudioEngine: NR2 FFTW wisdom %1; %2 %3")
+                   .arg(status, action, wisdomFileDetailText(info));
+    } else {
+        qCInfo(lcAudioSummary).noquote() << summary;
+    }
+#endif
+}
+
+static void logNr2WisdomGenerationSummary(SpectralNR::WisdomResult result)
+{
+    const QFileInfo info(AudioEngine::wisdomFilePath());
+    QStringList lines;
+    lines << QStringLiteral("Audio NR2 wisdom generation summary:")
+          << QStringLiteral("  result=%1").arg(wisdomResultText(result))
+          << QStringLiteral("  %1").arg(wisdomFileDetailText(info));
+
+    const QString summary = lines.join(QLatin1Char('\n'));
+    if (result == SpectralNR::WisdomResult::Failed) {
+        qCWarning(lcAudioSummary).noquote() << summary;
+    } else {
+        qCInfo(lcAudioSummary).noquote() << summary;
+    }
+}
+
 bool AudioEngine::needsWisdomGeneration()
 {
 #ifndef HAVE_FFTW3
     return false;
 #else
     const QString path = wisdomFilePath();
-    if (!QFile::exists(path))
+    if (!QFile::exists(path)) {
+        logNr2WisdomSummary(QStringLiteral("NR2 enable preflight"));
         return true;
+    }
 
     if (!SpectralNR::loadWisdom(wisdomDir().toStdString())) {
-        qCWarning(lcAudio) << "AudioEngine: NR2 FFTW wisdom exists but could not be imported;"
-                           << "will regenerate" << path;
+        logNr2WisdomSummary(QStringLiteral("NR2 enable preflight"));
         return true;
     }
 
@@ -3358,9 +3457,15 @@ bool AudioEngine::needsWisdomGeneration()
 #endif
 }
 
-void AudioEngine::generateWisdom(std::function<void(int,int,const std::string&)> progress)
+SpectralNR::WisdomResult AudioEngine::generateWisdom(
+    SpectralNR::WisdomProgressCb progress,
+    SpectralNR::WisdomCancelCb shouldCancel)
 {
-    SpectralNR::generateWisdom(wisdomDir().toStdString(), std::move(progress));
+    const auto result = SpectralNR::generateWisdom(wisdomDir().toStdString(),
+                                                   std::move(progress),
+                                                   std::move(shouldCancel));
+    logNr2WisdomGenerationSummary(result);
+    return result;
 }
 
 void AudioEngine::setNr2Enabled(bool on)

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -17,6 +17,7 @@
 #include <QPointer>
 
 #include "TxMicChannelNormalizer.h"
+#include "SpectralNR.h"
 
 class QMediaDevices;
 
@@ -27,7 +28,6 @@ class QMediaDevices;
 
 namespace AetherSDR {
 
-class SpectralNR;
 class SpecbleachFilter;
 class RNNoiseFilter;
 class NvidiaBnrFilter;
@@ -427,7 +427,9 @@ public:
     static bool needsWisdomGeneration();
     static QString wisdomFilePath();
     // Must be called from a worker thread — blocks for several minutes.
-    static void generateWisdom(std::function<void(int,int,const std::string&)> progress = nullptr);
+    static SpectralNR::WisdomResult generateWisdom(
+        SpectralNR::WisdomProgressCb progress = nullptr,
+        SpectralNR::WisdomCancelCb shouldCancel = nullptr);
 
     // Device selection (restarts the stream if currently running)
     void setOutputDevice(const QAudioDevice& dev);

--- a/src/core/SpectralNR.cpp
+++ b/src/core/SpectralNR.cpp
@@ -30,6 +30,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "SpectralNR.h"
 #include "LogManager.h"
 #include <algorithm>
+#include <cstdio>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -50,6 +51,37 @@ std::string wisdomPathForDirectory(const std::string& directory)
     wisdomFile += "aethersdr_fftw_wisdom";
     return wisdomFile;
 }
+
+std::string wisdomTempPathForDirectory(const std::string& directory)
+{
+    return wisdomPathForDirectory(directory) + ".tmp";
+}
+
+#ifdef HAVE_FFTW3
+bool exportWisdomAtomically(const std::string& directory)
+{
+    const std::string wisdomFile = wisdomPathForDirectory(directory);
+    const std::string tempFile = wisdomTempPathForDirectory(directory);
+
+    std::remove(tempFile.c_str());
+    if (!fftw_export_wisdom_to_filename(tempFile.c_str())) {
+        std::remove(tempFile.c_str());
+        qCWarning(lcDsp) << "SpectralNR: failed to export FFTW wisdom to"
+                         << QString::fromStdString(tempFile);
+        return false;
+    }
+
+    std::remove(wisdomFile.c_str());
+    if (std::rename(tempFile.c_str(), wisdomFile.c_str()) != 0) {
+        qCWarning(lcDsp) << "SpectralNR: failed to install FFTW wisdom at"
+                         << QString::fromStdString(wisdomFile);
+        std::remove(tempFile.c_str());
+        return false;
+    }
+
+    return true;
+}
+#endif
 
 } // namespace
 
@@ -223,15 +255,26 @@ bool SpectralNR::loadWisdom(const std::string& directory)
 #endif
 }
 
-bool SpectralNR::generateWisdom(const std::string& directory,
-                                WisdomProgressCb progress)
+SpectralNR::WisdomResult SpectralNR::generateWisdom(const std::string& directory,
+                                                    WisdomProgressCb progress,
+                                                    WisdomCancelCb shouldCancel)
 {
 #ifdef HAVE_FFTW3
-    const std::string wisdomFile = wisdomPathForDirectory(directory);
+    const auto cancelled = [&shouldCancel]() {
+        return shouldCancel && shouldCancel();
+    };
+
+    std::remove(wisdomTempPathForDirectory(directory).c_str());
+
+    if (cancelled())
+        return WisdomResult::Cancelled;
 
     if (loadWisdom(directory)) {
-        return false;  // wisdom loaded from file — no generation needed
+        return WisdomResult::Ready;  // wisdom loaded from file — no generation needed
     }
+    // If a wisdom file exists but cannot be imported, treat it as stale/partial
+    // and remove it before attempting a replacement.
+    std::remove(wisdomPathForDirectory(directory).c_str());
 
     // Try to import Thetis/WDSP wisdom (compatible FFTW3 format)
     // This gives us a head start if Thetis is installed
@@ -243,9 +286,17 @@ bool SpectralNR::generateWisdom(const std::string& directory,
                 + "\\OpenHPSDR\\Thetis-x64\\wdspWisdom00";
             std::lock_guard<std::mutex> lock(s_fftwMutex);
             if (fftw_import_wisdom_from_filename(thetisWisdom.c_str())) {
-                // Save as our own so we don't depend on Thetis in future
-                fftw_export_wisdom_to_filename(wisdomFile.c_str());
-                return false;
+                if (cancelled())
+                    return WisdomResult::Cancelled;
+                // Save as our own so we don't depend on Thetis in future.
+                if (!exportWisdomAtomically(directory))
+                    return WisdomResult::Failed;
+                if (cancelled()) {
+                    std::remove(wisdomPathForDirectory(directory).c_str());
+                    std::remove(wisdomTempPathForDirectory(directory).c_str());
+                    return WisdomResult::Cancelled;
+                }
+                return WisdomResult::Ready;
             }
         }
     }
@@ -257,6 +308,13 @@ bool SpectralNR::generateWisdom(const std::string& directory,
     constexpr int maxSize = 262144;
     auto* cbuf = fftw_alloc_complex(maxSize);
     auto* rbuf = static_cast<double*>(fftw_malloc(maxSize * sizeof(double)));
+    if (!cbuf || !rbuf) {
+        fftw_free(rbuf);
+        fftw_free(cbuf);
+        std::remove(wisdomTempPathForDirectory(directory).c_str());
+        qCWarning(lcDsp) << "SpectralNR: failed to allocate buffers for FFTW wisdom";
+        return WisdomResult::Failed;
+    }
 
     // Count total steps for progress reporting
     // Sizes: 64, 128, 256, ... 262144 = 13 sizes × 4 plan types = 52 steps
@@ -269,6 +327,12 @@ bool SpectralNR::generateWisdom(const std::string& directory,
         // preventing concurrent plan creation (#467)
 
         // 1. Complex forward
+        if (cancelled()) {
+            fftw_free(rbuf);
+            fftw_free(cbuf);
+            std::remove(wisdomTempPathForDirectory(directory).c_str());
+            return WisdomResult::Cancelled;
+        }
         if (progress) progress(step, totalSteps,
             "Computing COMPLEX FORWARD FFT size " + std::to_string(psize) + "...");
         {   std::lock_guard<std::mutex> lock(s_fftwMutex);
@@ -279,6 +343,12 @@ bool SpectralNR::generateWisdom(const std::string& directory,
         if (progress) progress(++step, totalSteps, "");
 
         // 2. Complex backward (same size)
+        if (cancelled()) {
+            fftw_free(rbuf);
+            fftw_free(cbuf);
+            std::remove(wisdomTempPathForDirectory(directory).c_str());
+            return WisdomResult::Cancelled;
+        }
         if (progress) progress(step, totalSteps,
             "Computing COMPLEX BACKWARD FFT size " + std::to_string(psize) + "...");
         {   std::lock_guard<std::mutex> lock(s_fftwMutex);
@@ -289,6 +359,12 @@ bool SpectralNR::generateWisdom(const std::string& directory,
         if (progress) progress(++step, totalSteps, "");
 
         // 3. Real-to-complex forward
+        if (cancelled()) {
+            fftw_free(rbuf);
+            fftw_free(cbuf);
+            std::remove(wisdomTempPathForDirectory(directory).c_str());
+            return WisdomResult::Cancelled;
+        }
         if (progress) progress(step, totalSteps,
             "Computing REAL-TO-COMPLEX FFT size " + std::to_string(psize) + "...");
         {   std::lock_guard<std::mutex> lock(s_fftwMutex);
@@ -298,6 +374,12 @@ bool SpectralNR::generateWisdom(const std::string& directory,
         if (progress) progress(++step, totalSteps, "");
 
         // 4. Complex-to-real inverse
+        if (cancelled()) {
+            fftw_free(rbuf);
+            fftw_free(cbuf);
+            std::remove(wisdomTempPathForDirectory(directory).c_str());
+            return WisdomResult::Cancelled;
+        }
         if (progress) progress(step, totalSteps,
             "Computing COMPLEX-TO-REAL FFT size " + std::to_string(psize) + "...");
         {   std::lock_guard<std::mutex> lock(s_fftwMutex);
@@ -307,19 +389,31 @@ bool SpectralNR::generateWisdom(const std::string& directory,
         if (progress) progress(++step, totalSteps, "");
     }
 
+    if (cancelled()) {
+        fftw_free(rbuf);
+        fftw_free(cbuf);
+        std::remove(wisdomTempPathForDirectory(directory).c_str());
+        return WisdomResult::Cancelled;
+    }
+
+    bool exported = false;
     {
         std::lock_guard<std::mutex> lock(s_fftwMutex);
-        if (!fftw_export_wisdom_to_filename(wisdomFile.c_str()))
-            qCWarning(lcDsp) << "SpectralNR: failed to export FFTW wisdom to"
-                             << QString::fromStdString(wisdomFile);
+        exported = exportWisdomAtomically(directory);
     }
     fftw_free(rbuf);
     fftw_free(cbuf);
-    return true;  // wisdom was generated
+    if (cancelled()) {
+        std::remove(wisdomPathForDirectory(directory).c_str());
+        std::remove(wisdomTempPathForDirectory(directory).c_str());
+        return WisdomResult::Cancelled;
+    }
+    return exported ? WisdomResult::Generated : WisdomResult::Failed;
 #else
     (void)directory;
     (void)progress;
-    return false;
+    (void)shouldCancel;
+    return WisdomResult::Ready;
 #endif
 }
 

--- a/src/core/SpectralNR.h
+++ b/src/core/SpectralNR.h
@@ -96,12 +96,19 @@ public:
 
     // Generate FFTW wisdom file for optimal FFT performance.
     // Call once on first use; subsequent runs load existing wisdom.
-    // Returns true if wisdom was generated (slow — several minutes), false if loaded.
     // The progress callback receives (currentStep, totalSteps, description).
     using WisdomProgressCb = std::function<void(int, int, const std::string&)>;
+    using WisdomCancelCb = std::function<bool()>;
+    enum class WisdomResult {
+        Ready,      // existing or imported wisdom is ready
+        Generated,  // new wisdom was generated and saved
+        Cancelled,  // caller cancelled before wisdom was ready
+        Failed,     // generation or export failed
+    };
     static bool loadWisdom(const std::string& directory);
-    static bool generateWisdom(const std::string& directory,
-                               WisdomProgressCb progress = nullptr);
+    static WisdomResult generateWisdom(const std::string& directory,
+                                       WisdomProgressCb progress = nullptr,
+                                       WisdomCancelCb shouldCancel = nullptr);
 
 private:
     // FFTW plan creation/destruction is NOT thread-safe. This mutex guards

--- a/src/gui/AetherDspWidget.cpp
+++ b/src/gui/AetherDspWidget.cpp
@@ -1036,6 +1036,8 @@ QWidget* AetherDspWidget::buildDfnrPage()
 
 void AetherDspWidget::syncFromEngine()
 {
+    syncDspSelectorFromEngine();
+
     auto& s = AppSettings::instance();
 
     int gainMethod = s.value("NR2GainMethod", "2").toInt();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -119,6 +119,7 @@
 #include "FramelessWindowTitleBar.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <memory>
 #include <functional>
@@ -12791,6 +12792,10 @@ void MainWindow::updateNr2Availability()
 void MainWindow::enableNr2WithWisdom()
 {
     if (AudioEngine::needsWisdomGeneration()) {
+        const auto cancelled = std::make_shared<std::atomic_bool>(false);
+        const auto result = std::make_shared<std::atomic<int>>(
+            static_cast<int>(SpectralNR::WisdomResult::Failed));
+
         const bool frameless =
             AppSettings::instance().value("FramelessWindow", "True").toString() == "True";
 
@@ -12832,6 +12837,14 @@ void MainWindow::enableNr2WithWisdom()
         progress->setRange(0, 100);
         progress->setValue(0);
         body->addWidget(progress);
+
+        auto* buttonRow = new QHBoxLayout();
+        buttonRow->addStretch();
+        auto* cancelButton = new QPushButton("Cancel", content);
+        cancelButton->setAutoDefault(false);
+        cancelButton->setDefault(false);
+        buttonRow->addWidget(cancelButton);
+        body->addLayout(buttonRow);
         root->addWidget(content);
 
         dlg->show();
@@ -12843,29 +12856,75 @@ void MainWindow::enableNr2WithWisdom()
         breathe->setEndValue(1.0);
         breathe->setLoopCount(-1);
 
-        auto* thread = QThread::create([dlg, breathe, label, progress]() {
-            AudioEngine::generateWisdom([dlg, breathe, label, progress](int step, int total, const std::string& desc) {
-                int pct = total > 0 ? (step * 100 / total) : 0;
-                QString d = QString::fromStdString(desc);
-                QMetaObject::invokeMethod(dlg, [breathe, label, progress, pct, d]() {
-                    if (!d.isEmpty()) {
-                        label->setText(d + "\n\n"
-                            "This window will automatically close when wisdom generation is complete.");
-                        if (progress->value() >= 90 && breathe->state() != QAbstractAnimation::Running)
-                            breathe->start();
-                    } else {
-                        progress->setValue(pct);
-                    }
-                });
-            });
+        const auto requestCancel = [cancelled, label, progress, cancelButton]() {
+            if (cancelled->exchange(true))
+                return;
+            cancelButton->setEnabled(false);
+            progress->setRange(0, 0);
+            label->setText("Canceling FFTW wisdom generation...\n\n"
+                           "Audio will continue unchanged. This may take a moment while the current FFT plan finishes.");
+        };
+        connect(cancelButton, &QPushButton::clicked, dlg, requestCancel);
+        connect(dlg, &QDialog::rejected, dlg, requestCancel);
+
+        const QPointer<QDialog> dlgGuard(dlg);
+        auto* thread = QThread::create([cancelled, result, dlgGuard, breathe, label, progress]() {
+            const auto wisdomResult = AudioEngine::generateWisdom(
+                [cancelled, dlgGuard, breathe, label, progress](int step, int total, const std::string& desc) {
+                    if (!dlgGuard)
+                        return;
+                    if (cancelled->load())
+                        return;
+                    int pct = total > 0 ? (step * 100 / total) : 0;
+                    QString d = QString::fromStdString(desc);
+                    QMetaObject::invokeMethod(dlgGuard.data(), [dlgGuard, breathe, label, progress, pct, d]() {
+                        if (!dlgGuard)
+                            return;
+                        if (!d.isEmpty()) {
+                            label->setText(d + "\n\n"
+                                "This window will automatically close when wisdom generation is complete.");
+                            if (progress->value() >= 90 && breathe->state() != QAbstractAnimation::Running)
+                                breathe->start();
+                        } else {
+                            progress->setValue(pct);
+                        }
+                    });
+                },
+                [cancelled]() { return cancelled->load(); });
+            result->store(static_cast<int>(wisdomResult));
         });
-        connect(thread, &QThread::finished, this, [this, dlg, breathe, progress, label, thread]() {
+        connect(thread, &QThread::finished, this, [this, dlg, breathe, progress, label, thread, result]() {
+            const auto wisdomResult =
+                static_cast<SpectralNR::WisdomResult>(result->load());
+            const bool ready = wisdomResult == SpectralNR::WisdomResult::Ready
+                            || wisdomResult == SpectralNR::WisdomResult::Generated;
             breathe->stop();
             dlg->setWindowOpacity(1.0);
-            progress->setValue(100);
+            progress->setRange(0, 100);
+            progress->setValue(ready ? 100 : 0);
+
+            if (!ready) {
+                label->setText(wisdomResult == SpectralNR::WisdomResult::Cancelled
+                    ? "Wisdom generation canceled. Audio was left unchanged."
+                    : "Wisdom generation failed. Audio was left unchanged.");
+                if (auto* a = m_appletPanel ? m_appletPanel->clientRxDspApplet() : nullptr) {
+                    if (auto* w = a->widget())
+                        w->syncFromEngine();
+                }
+                if (m_dspDialog)
+                    m_dspDialog->syncFromEngine();
+                statusBar()->showMessage("NR2 was not enabled; audio is unchanged", 4000);
+                QTimer::singleShot(800, this, [dlg, thread]() {
+                    dlg->accept();
+                    dlg->deleteLater();
+                    thread->deleteLater();
+                });
+                return;
+            }
+
             label->setText("Wisdom generation complete!");
             QTimer::singleShot(800, this, [this, dlg, thread]() {
-                dlg->close();
+                dlg->accept();
                 dlg->deleteLater();
                 thread->deleteLater();
                 QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNr2Enabled(true); });
@@ -13812,9 +13871,13 @@ void MainWindow::registerShortcutActions()
         });
     m_shortcutManager.registerAction("nr2_toggle", "NR2 Toggle", "DSP",
         QKeySequence(), [this]() {
-            QMetaObject::invokeMethod(m_audio, [this]() {
-                m_audio->setNr2Enabled(!m_audio->nr2Enabled());
-            });
+            if (m_audio->nr2Enabled()) {
+                QMetaObject::invokeMethod(m_audio, [this]() {
+                    m_audio->setNr2Enabled(false);
+                });
+            } else {
+                enableNr2WithWisdom();
+            }
         });
     m_shortcutManager.registerAction("rn2_toggle", "RN2 (RNNoise) Toggle", "DSP",
         QKeySequence(), [this]() {
@@ -15742,7 +15805,13 @@ void MainWindow::registerMidiParams()
         [this]() -> float { auto* s = activeSlice(); return s && s->xitOn() ? 1 : 0; });
 
     reg("rx.nr2Enable", "NR2 (Spectral)", "RX", P::Toggle, 0, 1,
-        [this](float v) { QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2Enabled(v > 0.5f); }); },
+        [this](float v) {
+            if (v > 0.5f) {
+                enableNr2WithWisdom();
+            } else {
+                QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNr2Enabled(false); });
+            }
+        },
         [this]() -> float { return m_audio->nr2Enabled() ? 1 : 0; });
 
     reg("rx.rn2Enable", "RN2 (RNNoise)", "RX", P::Toggle, 0, 1,


### PR DESCRIPTION
## Summary

Fixes NR2 FFTW wisdom cancellation so dismissing or canceling the first-run training dialog no longer leaves the audio path in a half-enabled state, and adds support-log-visible status summaries for the wisdom cache.

## Root Cause

`MainWindow::enableNr2WithWisdom()` displayed a modal FFTW wisdom progress dialog, but the dialog did not communicate cancellation to the training worker. If the user closed or canceled the dialog, the worker could continue in the background and the `QThread::finished` handler would still call `m_audio->setNr2Enabled(true)`.

On Windows this meant NR2 could be initialized after the user had canceled, potentially using stale or partial wisdom state and perturbing the active audio path.

FFTW wisdom was also exported directly to the final cache file, so failed or interrupted generation could leave artifacts behind for the next run to attempt to import.

## Changes

- Add `SpectralNR::WisdomResult` with explicit `Ready`, `Generated`, `Cancelled`, and `Failed` outcomes.
- Add a cancellation callback to NR2 wisdom generation and check it before and after expensive FFTW plan steps.
- Export FFTW wisdom through `aethersdr_fftw_wisdom.tmp` and atomically rename it only after a successful export.
- Remove temporary or stale wisdom artifacts on cancellation or failure.
- Treat non-importable existing wisdom as invalid/stale and discard it before regeneration.
- Update `MainWindow::enableNr2WithWisdom()` so dialog cancel/close requests cancellation and does not enable NR2 unless wisdom is actually ready.
- Re-sync the AetherDSP UI from the engine after cancellation/failure so the visual NR2 button reflects the real audio state.
- Route keyboard shortcut and control-surface NR2 enable paths through the wisdom-gated enable flow.
- Add `aether.audio.summary` startup and preflight logging for NR2 wisdom status: valid, missing, invalid/stale, generated, canceled, or failed.
- Document the NR2 wisdom cancellation and logging behavior in the audio pipeline notes.

## User Impact

If a user cancels NR2 FFTW training, AetherSDR leaves the current audio path unchanged. NR2 is not initialized, other client DSP state is not reset, and partial wisdom files are not left behind.

Support logs now include a concise NR2 wisdom summary with the cache path, validity state, size, and modification time when applicable.

## Validation

- `git diff --check`
- `env -u CPLUS_INCLUDE_PATH cmake --build build --target AetherSDR --parallel 22`
- Built app: `/Users/patj/Documents/AetherSDR/.worktrees/nr2-fftw-cancel/build/AetherSDR.app`
- Deployed the rebuilt app to `patj@mac.jensencloud.net:/Users/patj/Desktop/AetherSDR.app` and cleared quarantine
- `ctest --test-dir build -N` listed test targets only; the app target build did not build the test executables

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
