### PR TITLE
fix(theme): align background.0 + text.primary tokens to dominant codebase hex

### DIFF
--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -2,12 +2,12 @@
   "schemaVersion": 1,
   "name": "Default Dark",
   "author": "AetherSDR Team",
-  "version": "1.2",
-  "description": "AetherSDR's original dark theme — Phase 2 canonical taxonomy (51 tokens) plus the waterfall colormap gradient validating gradient-token support. Visually compatible with v26.5.3; sub-perceptual diffs at sites where close-variant colours collapsed onto canonical tokens (see docs/theming/canonical-tokens.md).",
+  "version": "1.3",
+  "description": "AetherSDR's original dark theme — Phase 2 canonical taxonomy (51 tokens) plus the waterfall colormap gradient. v1.3: tokens realigned to the dominant codebase hex values (background.0 was #0a0e14 → #0f0f1a to match the 84-ref QWidget base; text.primary was #e6f0fa → #c8d8e8 to match the 367-ref body text). Visually bit-identical to v26.5.3 at the majority of sites.",
   "tokens": {
     "color": {
       "background": {
-        "0": "#0a0e14",
+        "0": "#0f0f1a",
         "1": "#1a2a3a",
         "2": "#304050",
         "3": "#506070",
@@ -21,7 +21,7 @@
       "accent.danger": "#ff4d4d",
       "accent.success": "#4dd87a",
       "text": {
-        "primary": "#e6f0fa",
+        "primary": "#c8d8e8",
         "secondary": "#8ea8c0",
         "label": "#506070",
         "disabled": "#3a4a5a"

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -174,8 +174,11 @@ void ThemeManager::seedBuiltinDefaults()
     // with the JSON resource manually; Phase 5's editor will eventually
     // generate this table from the resource at compile time.
 
-    // Backgrounds (6 tiers)
-    m_tokens.insert("color.background.0",        QString("#0a0e14"));
+    // Backgrounds (6 tiers).  background.0 is the dominant codebase
+    // QWidget base (#0f0f1a, 84 refs); aligning the canonical token to
+    // that value makes the migration bit-identical at every QWidget
+    // that doesn't paint its own background.
+    m_tokens.insert("color.background.0",        QString("#0f0f1a"));
     m_tokens.insert("color.background.1",        QString("#1a2a3a"));
     m_tokens.insert("color.background.2",        QString("#304050"));
     m_tokens.insert("color.background.3",        QString("#506070"));
@@ -190,8 +193,10 @@ void ThemeManager::seedBuiltinDefaults()
     m_tokens.insert("color.accent.danger",   QString("#ff4d4d"));
     m_tokens.insert("color.accent.success",  QString("#4dd87a"));
 
-    // Text (4 tiers — label and disabled distinct for Phase 4 contrast tuning)
-    m_tokens.insert("color.text.primary",   QString("#e6f0fa"));
+    // Text (4 tiers — label and disabled distinct for Phase 4 contrast
+    // tuning).  text.primary aligned to the dominant codebase body-text
+    // value (#c8d8e8, 367 refs across applets / dialogs / labels).
+    m_tokens.insert("color.text.primary",   QString("#c8d8e8"));
     m_tokens.insert("color.text.secondary", QString("#8ea8c0"));
     m_tokens.insert("color.text.label",     QString("#506070"));
     m_tokens.insert("color.text.disabled",  QString("#3a4a5a"));


### PR DESCRIPTION
Post-#3102 user testing surfaced visible darkening of applet
backgrounds, title bar, and status bar.  Root cause: my canonical
taxonomy picked design-aesthetic values for two of the highest-impact
tokens instead of the actual dominant codebase hex:

  color.background.0  was #0a0e14  →  now #0f0f1a
                      (84 refs to literal #0f0f1a — the QWidget base
                      colour in Theme.h's app-wide stylesheet; the
                      old token value was ΔRGB 12 darker, perceptible
                      against dark UI)

  color.text.primary  was #e6f0fa  →  now #c8d8e8
                      (367 refs — the most-used colour in the whole
                      codebase by far; the old token value was visibly
                      lighter)

Both files updated in lockstep:
  - resources/themes/default-dark.json (v1.2 → v1.3, baked into the
    Qt resource bundle)
  - src/core/ThemeManager.cpp::seedBuiltinDefaults() (the compiled-in
    fallback when no theme file loads)

No call-site changes needed — every site that resolves through
ThemeManager::color() or the {{color.text.primary}} / {{color.background.0}}
template placeholders automatically picks up the new values.

Lesson for the taxonomy doc: canonical token values must come from
the **dominant codebase hex** at sites that use the token, not from
the designer's first instinct.  Phase 4 Light theme can revisit the
aesthetic tuning; Phase 2's job is bit-identical-where-possible
preservation of the v26.5.3 look.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
