### PR TITLE
feat(flexcontrol): accept aether-pad CDC controllers via VID/PID alias

### DIFF
--- a/src/core/FlexControlManager.cpp
+++ b/src/core/FlexControlManager.cpp
@@ -25,10 +25,21 @@ FlexControlManager::~FlexControlManager()
 
 QString FlexControlManager::detectPort()
 {
+    // Compatible devices: FlexRadio's native FlexControl plus open-hardware
+    // controllers that speak the documented FlexControl token stream
+    // (D;/U;/X.S;/etc + I...; LED commands). The aether-pad project uses
+    // an Arduino Giga R1 in its AetherControl persona; this mirrors the
+    // existing HID-path alias for the RC-28 persona.
+    static constexpr struct { quint16 vid; quint16 pid; } kCompatibleDevices[] = {
+        { VendorId, ProductId },   // FlexRadio FlexControl (native)
+        { 0x2341,   0x0266   },    // Arduino Giga R1 CDC (aether-pad)
+    };
     for (const auto& info : QSerialPortInfo::availablePorts()) {
-        if (info.vendorIdentifier() == VendorId &&
-            info.productIdentifier() == ProductId)
-            return info.portName();
+        for (const auto& dev : kCompatibleDevices) {
+            if (info.vendorIdentifier() == dev.vid &&
+                info.productIdentifier() == dev.pid)
+                return info.portName();
+        }
     }
     return {};
 }


### PR DESCRIPTION
## Summary

Extends `FlexControlManager::detectPort` to scan a small compile-time list of compatible USB IDs instead of matching only FlexRadio's native FlexControl pair (`0x2192 / 0x0010`). Adds the Arduino Giga R1 CDC pair (`0x2341 / 0x0266`) so the [aether-pad](https://github.com/nigelfenton/aether-pad) project's AetherControl persona is detected automatically — no driver changes, no VID/PID spoofing.

## Motivation

The FlexControl protocol documented in `FlexControlManager.h` is small, well-specified, and OS-portable, which makes it an attractive integration target for community-built controllers. The only blocker today is the strict VID/PID gate in `detectPort()`.

aether-pad is an Arduino Giga R1-based standalone control surface. Its AetherControl persona emits the documented FlexControl token stream verbatim:

| Direction         | Tokens                                                          |
| ----------------- | --------------------------------------------------------------- |
| aether-pad → host | `D;`, `D02;`–`D06;`, `U;`, `U02;`–`U06;` (rotation, accelerated) |
| aether-pad → host | `X1S;`/`X1C;`/`X1L;` (Aux1 tap/double/hold; same for X2, X3)    |
| aether-pad → host | bare `S;`/`C;`/`L;` (encoder PUSH button — per `#2263` capture) |
| aether-pad → host | `F0304;` (init/reset announce)                                  |
| host → aether-pad | `I000;` / `I100;` / `I010;` / `I001;` (Aux LED state)           |

From AetherControl's perspective it's a real FlexControl; the only thing that differs is the USB IDs the device advertises during enumeration.

## Change

`detectPort()` now iterates a `static constexpr` table of `{vid, pid}` pairs. The native FlexControl pair stays first, so behaviour for operators using genuine FlexRadio hardware is unchanged. Adding additional compatible controllers (other open-hardware boards, vendor variants) in the future is one line in the table.

```cpp
static constexpr struct { quint16 vid; quint16 pid; } kCompatibleDevices[] = {
    { VendorId, ProductId },   // FlexRadio FlexControl (native)
    { 0x2341,   0x0266   },    // Arduino Giga R1 CDC (aether-pad)
};
```

## Precedent

Mirrors the same pattern already established for the controller-emulator HID path used by aether-pad's RC-28 persona (`HidDeviceParser::kSupportedDevices` entry that routes the Arduino HID VID/PID to `IcomRC28Parser`). Single approach for both controller-class personas.

## Testing

- Genuine FlexControl detection: unchanged — native VID/PID matches first iteration.
- aether-pad in AetherControl persona: enumerates as Arduino CDC, gets matched on second table entry, returns its port name to the dialog's Detect/Connect flow.
- LED round-trip (`I…;`) and tuning events confirmed by the aether-pad operator UI on the touchscreen indicator state.

## Cross-platform

Patch lives in shared model code; no platform-specific guards needed. The aether-pad bench has been validated on Windows; macOS and Linux build paths are unchanged from current `main`.

## Out of scope

- No protocol changes.
- No new configuration surface (the table is compile-time; user-extensible allowlists could come later if there's demand).
- No spoofing of FlexRadio VID/PID anywhere in the firmware ecosystem — that path was rejected on ethical grounds.

## Status

Filing as **draft** — the aether-pad firmware side (multi-persona menu, AetherControl USB CDC emitter wiring, per-persona screens) is still in progress on [nigelfenton/aether-pad@feat/rc28-test-mode](https://github.com/nigelfenton/aether-pad/tree/feat/rc28-test-mode). This PR can be ready-for-review once the firmware bench is fully exercising the alias end-to-end.

---

73, Nigel G0JKN/W3
