### PR TITLE
[cat] Fix WSJT-X startup CAT lock-mode timeout

### DIFF
--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -369,7 +369,11 @@ QString RigctlProtocol::processCommand(const QString& cmd)
             // suppress their own mode-set commands.
             if (m_extended)
                 return QStringLiteral("get_lock_mode:\nLock Mode: 0\n") + rprt(0);
-            return QStringLiteral("0\n");
+            // Hamlib's NET rigctl backend probes this long-form command during
+            // WSJT-X startup and waits for a status terminator after the value.
+            // Without it, the client blocks until its command timeout, delaying
+            // the queued QSY after a USB->DIGU mode change.
+            return QStringLiteral("0\n") + rprt(0);
         }
         if (name == "set_lock_mode") {
             // "0" = unlock: already unlocked, accept as no-op.

--- a/tests/rigctld_test.cpp
+++ b/tests/rigctld_test.cpp
@@ -1248,7 +1248,7 @@ void section13(const QString& host, quint16 port, int timeout,
 
     RigctlClient c(timeout);
     if (!c.connectToServer(host, port)) {
-        for (int i = 1; i <= 9; ++i)
+        for (int i = 1; i <= 10; ++i)
             r.skip(QStringLiteral("13.%1").arg(i), QStringLiteral("could not connect"));
         return;
     }
@@ -1312,6 +1312,14 @@ void section13(const QString& host, quint16 port, int timeout,
     raw = c.sendRaw(QStringLiteral("\\nonexistent_bare_xyz"), 1);
     r.check(QStringLiteral("13.9  unknown command (bare) returns RPRT -4"),
             raw == QStringList{QStringLiteral("RPRT -4")},
+            raw.join(QStringLiteral(" | ")));
+
+    // 13.10  WSJT-X/Hamlib startup probe: value plus status terminator.
+    // Hamlib's NET rigctl backend waits for RPRT after this long-form getter;
+    // if the terminator is missing, startup CAT work queues behind a timeout.
+    raw = c.sendRaw(QStringLiteral("\\get_lock_mode"), 2);
+    r.check(QStringLiteral("13.10 get_lock_mode (bare) returns value and RPRT 0"),
+            raw == QStringList{QStringLiteral("0"), QStringLiteral("RPRT 0")},
             raw.join(QStringLiteral(" | ")));
 
     // Best-effort restore


### PR DESCRIPTION
## Summary

Fixes a WSJT-X startup CAT stall where Hamlib would stop issuing queued frequency/mode work for roughly 20 seconds after probing `\get_lock_mode` through AetherSDR's rigctld server.

The actual QSY command was not being received by AetherSDR until after Hamlib's timeout expired. This made the bug look like AetherSDR was buffering or delaying a frequency change after WSJT-X connected, especially when the active VFO started in `USB` and WSJT-X needed to move it into `PKTUSB`/Flex `DIGU`.

This PR makes the bare long-form `\get_lock_mode` response include the Hamlib status terminator that the NET rigctl backend expects:

```text
0
RPRT 0
```

instead of only:

```text
0
```

## Root Cause

WSJT-X/Hamlib sends a long-form bare `\get_lock_mode` command during startup. AetherSDR returned the lock value (`0`) but did not terminate that response with `RPRT 0` unless the command was in extended mode.

The latest pre-fix log made the timing visible:

- WSJT-X startup CAT sequence began normally.
- AetherSDR responded to `\get_lock_mode` with only `"0"`.
- Hamlib stopped sending new CAT commands for about 20 seconds.
- WSJT-X then sent `M PKTUSB -1`; AetherSDR switched the Flex slice from `USB` to `DIGU` and enabled DAX TX.
- AetherSDR again responded to `\get_lock_mode` with only `"0"`.
- Hamlib stopped sending new CAT commands for about another 20 seconds.
- The queued frequency change finally arrived after the second timeout.

The key pre-fix timing from `aethersdr-20260524-221826.log` was:

| Time | Event |
|---|---|
| `22:18:36.914` | `F 14043100.000000 -> RPRT 0` |
| `22:18:36.914` | `\get_lock_mode -> "0"` |
| `22:18:56.933` | next CAT command after ~20s silence |
| `22:18:56.934` | `M PKTUSB -1 -> RPRT 0` and Flex slice mode set to `DIGU` |
| `22:18:56.971` | `\get_lock_mode -> "0"` |
| `22:19:17.149` | queued `F 7074000.000000 -> RPRT 0` finally arrives |

That made the issue protocol-level rather than DAX/audio-level: AetherSDR could not act on the QSY because Hamlib had not delivered it yet.

## Changes

### `RigctlProtocol`

Bare `\get_lock_mode` now returns the value plus status terminator:

```text
0
RPRT 0
```

Extended-mode behavior is unchanged and continues to return the labeled response plus `RPRT 0`.

This is intentionally scoped to `get_lock_mode`, because that command is a long-form Hamlib startup probe and the observed stall is specifically tied to the missing terminator there.

### `rigctld_test`

Adds a regression check in the bare-response section:

- sends raw `\get_lock_mode`
- reads two lines
- verifies the exact response is `0`, `RPRT 0`

The skip accounting for section 13 was updated from 9 to 10 checks.

## Source References

### AetherSDR rigctld server and protocol path

The server path is straightforward and was useful for proving that the delay was upstream of AetherSDR command execution:

- `src/core/RigctlServer.cpp:158` calls `cs.protocol->handleLine(line)` for each newline-delimited rigctld command.
- `src/core/RigctlServer.cpp:159-162` logs the command and response, then writes the response bytes to the socket.
- The CAT log line therefore represents a command AetherSDR has actually received, processed, and responded to. The absence of CAT log lines after pre-fix `\get_lock_mode` showed that Hamlib was not sending more commands during the stall.

The fixed protocol branch is:

- `src/core/RigctlProtocol.cpp:366` enters the `get_lock_mode` handler.
- `src/core/RigctlProtocol.cpp:370-371` preserves extended-mode behavior: labeled value plus `RPRT 0`.
- `src/core/RigctlProtocol.cpp:372-376` now handles the bare long-form Hamlib startup probe by returning the value and the status terminator.

The regression coverage is in the bare/non-extended rigctld test path:

- `tests/rigctld_test.cpp:1238-1241` documents that section 13 uses a fresh connection that never sends `+`, matching the bare protocol path used by WSJT-X/fldigi-style clients.
- `tests/rigctld_test.cpp:1250-1253` updates skip accounting for the added check.
- `tests/rigctld_test.cpp:1317-1323` sends raw `\get_lock_mode`, reads two lines, and verifies the exact response is `0` followed by `RPRT 0`.

### WSJT-X / Hamlib source path inspected

Local WSJT-X source inspected from:

```text
/Users/patj/Documents/wsjtx-improved/Transceiver/HamlibTransceiver.cpp
```

Relevant source references:

- `HamlibTransceiver.cpp:377-378` maps Hamlib `RIG_MODE_PKTUSB` back to WSJT-X `DIG_U`.
- `HamlibTransceiver.cpp:403-404` maps WSJT-X `DIG_U` to Hamlib `RIG_MODE_PKTUSB`; this is why AetherSDR sees `M PKTUSB -1` during the USB-to-digital startup transition.
- `HamlibTransceiver.cpp:644` opens the Hamlib rig connection with `rig_open(...)`.
- `HamlibTransceiver.cpp:659-660` notes that the NET rigctl backend advertises broad capability support, so WSJT-X/Hamlib does active startup probing.
- `HamlibTransceiver.cpp:829-862` performs the startup frequency-resolution probe by setting and reading back small test frequency offsets, matching the observed `F ...955`, readback, then restore pattern in the AetherSDR logs.
- `HamlibTransceiver.cpp:915-929` shows the RX frequency path: WSJT-X/Hamlib sets frequency, reads current mode, and conditionally sets the mapped mode.
- `HamlibTransceiver.cpp:996-1009` shows the transmit/split-side path also sets frequency, reads mode, and conditionally sets the mapped mode.

The specific `\get_lock_mode` command appears to be emitted by Hamlib's NET rigctl backend during its capability/startup probing rather than being a direct WSJT-X source-level call. The local WSJT-X source still explains the surrounding command sequence observed in the AetherSDR logs: connection open, frequency resolution probe, current mode read as USB, mode mapping to PKTUSB/DIG_U, then queued QSY.

## Post-Fix Validation From Logs

After deploying the build, the latest three test-session logs show the timeout gone. Each session now returns `0\nRPRT 0`, and the following mode/QSY commands continue within milliseconds rather than after a 20-second timeout.

Pulled with the `logpull` skill to:

```text
/private/tmp/aethersdr-logpull/20260524-223649
```

Remote logs inspected:

- `/Users/patj/Library/Preferences/AetherSDR/aethersdr-20260524-223315.log`
- `/Users/patj/Library/Preferences/AetherSDR/aethersdr-20260524-223353.log`
- `/Users/patj/Library/Preferences/AetherSDR/aethersdr-20260524-223429.log`

Post-fix startup timing:

| Log | `\get_lock_mode` response | Next `M PKTUSB` | Startup QSY |
|---|---:|---:|---:|
| `223315` | `22:33:33.802` -> `0\nRPRT 0` | `+27ms` | `14.074` at `+127ms` |
| `223353` | `22:34:03.145` -> `0\nRPRT 0` | `+51ms` | `14.074` at `+134ms` |
| `223429` | `22:34:36.967` -> `0\nRPRT 0` | same timestamp | `14.074` at `+128ms` |

Representative fixed sequence from `aethersdr-20260524-223429.log`:

```text
22:34:36.944  F 14082900.000000 -> RPRT 0
22:34:36.967  \get_lock_mode -> 0\nRPRT 0
22:34:36.967  m -> USB\n2700
22:34:36.967  M PKTUSB -1 -> RPRT 0
22:34:36.967  slice set 0 mode=DIGU
22:34:36.969  transmit set dax=1
22:34:37.095  F 14074000.000000 -> RPRT 0
```

No 20-second CAT silence after `\get_lock_mode` was present in the last three sessions.

## Audio / DAX Checks

The pulled post-fix logs also showed normal audio summary logging:

| Log | startup | RX | TX | CW | aux | failure | category |
|---|---|---|---|---|---|---|---|
| `aethersdr-20260524-223315.log` | yes | yes | no | yes | yes | no | yes |
| `aethersdr-20260524-223353.log` | yes | yes | no | yes | yes | no | yes |
| `aethersdr-20260524-223429.log` | yes | yes | no | yes | yes | no | yes |

Notes:

- Missing TX source summary is expected for these sessions because TX mic capture was not started.
- CW sidetone summaries were present.
- Auxiliary sink summaries were present.
- No audio open failure summaries were present.
- RX sink used `MacBook Air Speakers`, `48000Hz`, `Float`, `resampling=yes`, `fallback=no`.
- CW PortAudio matched `MacBook Air Speakers`, `fallback=no`.
- Auxiliary sink had `resampling=no`, `fallback=no`.

## Build / Test

### Commands run

```bash
git diff --check
env -u CPLUS_INCLUDE_PATH cmake --build build --target rigctld_test -j22
env -u CPLUS_INCLUDE_PATH cmake --build build -j22
```

Results:

- `git diff --check` passed.
- `rigctld_test` target built successfully.
- Full `AetherSDR.app` build completed successfully.
- Fresh app deployed to `patj@mac.jensencloud.net:/Users/patj/Desktop/AetherSDR.app` and quarantine was cleared.

Build environment note:

- The local shell had `CPLUS_INCLUDE_PATH` pointing at CommandLineTools libc++ headers, which mixed CLT C++ headers with the Xcode SDK C headers and broke unrelated C++ compilation.
- Unsetting `CPLUS_INCLUDE_PATH` for the build gave a consistent Xcode SDK/toolchain view and allowed the full build to complete.

### Detailed validation matrix

| Area | What was checked | Result |
|---|---|---|
| Diff hygiene | `git diff --check` | passed |
| Focused build | `env -u CPLUS_INCLUDE_PATH cmake --build build --target rigctld_test -j22` | passed; no work after final rebuild |
| Full app build | `env -u CPLUS_INCLUDE_PATH cmake --build build -j22` | passed; `AetherSDR.app` linked successfully |
| Deployment | `deploy-aethersdr-test-build` skill with built `build/AetherSDR.app` | uploaded to test Mac Desktop and cleared quarantine |
| Pre-fix logs | pulled latest logs before the fix with `logpull --count 5` | reproduced two CAT silences after bare `\get_lock_mode -> "0"` |
| Post-fix logs | pulled latest logs after deploy with `logpull --count 3` | no CAT silence after `\get_lock_mode`; follow-on commands arrived in 0-51ms |
| Audio/DAX sanity | scanned summary/failure/fallback/sample-rate indicators in pulled logs | no audio open failures; DAX/audio summaries normal for exercised paths |

### Pre-fix log pull

Pulled to:

```text
/private/tmp/aethersdr-logpull/20260524-222034
```

Remote logs captured:

- `/Users/patj/Library/Preferences/AetherSDR/aethersdr-20260524-221826.log`
- `/Users/patj/Library/Preferences/AetherSDR/aethersdr-20260524-221703.log`
- `/Users/patj/Library/Preferences/AetherSDR/aethersdr-20260524-221547.log`
- `/Users/patj/Library/Preferences/AetherSDR/aethersdr-20260524-220001.log`
- `/Users/patj/Library/Preferences/AetherSDR/aethersdr-20260524-194032.log`

The key failing session was `aethersdr-20260524-221826.log`. It showed:

```text
22:18:36.914  F 14043100.000000 -> RPRT 0
22:18:36.914  \get_lock_mode -> "0"
22:18:56.933  next CAT command after roughly 20 seconds
22:18:56.934  M PKTUSB -1 -> RPRT 0
22:18:56.934  slice set 0 mode=DIGU
22:18:56.965  F 14043100.000000 -> RPRT 0
22:18:56.971  \get_lock_mode -> "0"
22:19:17.021  next CAT command after roughly 20 seconds
22:19:17.149  F 7074000.000000 -> RPRT 0
```

That sequence proved that AetherSDR was not delaying a command it had already received. The actual QSY did not appear in the rigctld logs until after Hamlib recovered from the missing terminator.

### Post-fix log pull

Pulled to:

```text
/private/tmp/aethersdr-logpull/20260524-223649
```

Remote logs captured:

- `/Users/patj/Library/Preferences/AetherSDR/aethersdr-20260524-223315.log`
- `/Users/patj/Library/Preferences/AetherSDR/aethersdr-20260524-223353.log`
- `/Users/patj/Library/Preferences/AetherSDR/aethersdr-20260524-223429.log`

The last three sessions all showed the intended response and immediate continuation:

| Log | Lock probe | Follow-on behavior |
|---|---|---|
| `223315` | `22:33:33.802 \get_lock_mode -> 0\nRPRT 0` | `M PKTUSB` at `22:33:33.829`, `F 14074000` at `22:33:33.929` |
| `223353` | `22:34:03.145 \get_lock_mode -> 0\nRPRT 0` | `M PKTUSB` at `22:34:03.196`, `F 14074000` at `22:34:03.279` |
| `223429` | `22:34:36.967 \get_lock_mode -> 0\nRPRT 0` | `M PKTUSB` at `22:34:36.967`, `F 14074000` at `22:34:37.095` |

The newest session also later accepted additional QSY traffic while normal polling continued:

```text
22:34:49.786  F 7074000.000000 -> RPRT 0
22:34:50.495  F 14074000.000000 -> RPRT 0
```

### Audio summary validation

The logpull validation table for the post-fix logs was:

| Log | startup | RX | TX | CW | aux | failure | category |
|---|---|---|---|---|---|---|---|
| `aethersdr-20260524-223315.log` | yes | yes | no | yes | yes | no | yes |
| `aethersdr-20260524-223353.log` | yes | yes | no | yes | yes | no | yes |
| `aethersdr-20260524-223429.log` | yes | yes | no | yes | yes | no | yes |

Audio/DAX observations:

- TX source summary was absent in these logs because TX mic capture was not started during the sessions.
- CW sidetone summary was present in all three post-fix sessions.
- Auxiliary sink summary was present in all three post-fix sessions.
- No `Audio open failure summary` appeared.
- RX sink summary showed `MacBook Air Speakers`, `48000Hz`, `Float`, `resampling=yes`, `fallback=no`.
- CW sidetone PortAudio matched `MacBook Air Speakers`, `fallback=no`.
- Auxiliary sink summary showed `Quindar local sink`, `48000Hz`, `Float`, `resampling=no`, `fallback=no`.

## Documentation

No docs were updated because this is a narrow rigctld protocol compatibility fix. It does not change AetherSDR's core audio pipeline, DAX transport behavior, or user-facing configuration.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
