### PR TITLE
feat(theme): Phase 3 PR 4/5 — file-scope const QColor migration in comp/gate/curve widgets

### DIFF
--- a/src/gui/ClientCompCurveWidget.cpp
+++ b/src/gui/ClientCompCurveWidget.cpp
@@ -10,6 +10,7 @@
 #include <QTimer>
 #include <algorithm>
 #include <cmath>
+#include "core/ThemeManager.h"
 
 namespace AetherSDR {
 
@@ -17,16 +18,14 @@ namespace {
 
 constexpr float kBallSmoothAlpha = 0.30f;  // per-tick; ~8 ticks to settle
 
-const QColor kBgColor       ("#0a1420");
-const QColor kGridColor     ("#1e3040");
-const QColor kGridMajorColor("#2a4458");
-const QColor kAxisLabelColor("#607888");
-const QColor kIdentityColor ("#2a3a4a");
-const QColor kCurveColor    ("#4db8d4");
-const QColor kBallGlowColor ("#ffd070");
-const QColor kBallCoreColor ("#ffffff");
-
-// dBFS ticks for the grid (both axes).
+inline QColor kBgColor() { return AetherSDR::ThemeManager::instance().color("color.background.0"); }
+inline QColor kGridColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kGridMajorColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kAxisLabelColor() { return AetherSDR::ThemeManager::instance().color("color.text.label"); }
+inline QColor kIdentityColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kCurveColor() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
+inline QColor kBallGlowColor() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }
+inline QColor kBallCoreColor() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }  // dBFS ticks for the grid (both axes).
 const float kMajorTicks[] = { 0.0f, -12.0f, -24.0f, -36.0f, -48.0f, -60.0f };
 const float kMinorTicks[] = { -6.0f, -18.0f, -30.0f, -42.0f, -54.0f };
 
@@ -118,7 +117,7 @@ void ClientCompCurveWidget::paintEvent(QPaintEvent*)
     p.setRenderHint(QPainter::Antialiasing, true);
 
     const QRectF r = rect();
-    p.fillRect(r, kBgColor);
+    p.fillRect(r, kBgColor());
     drawGrid(p, r);
     drawCurve(p, r);
     if (m_comp) drawBall(p, r);
@@ -128,8 +127,8 @@ void ClientCompCurveWidget::drawGrid(QPainter& p, const QRectF& r) const
 {
     p.save();
 
-    const QPen minorPen(kGridColor, 1.0);
-    const QPen majorPen(kGridMajorColor, 1.0);
+    const QPen minorPen(kGridColor(), 1.0);
+    const QPen majorPen(kGridMajorColor(), 1.0);
 
     // Minor ticks
     p.setPen(minorPen);
@@ -176,7 +175,7 @@ void ClientCompCurveWidget::drawGrid(QPainter& p, const QRectF& r) const
             // prepare() with the painter's actual transform avoids a
             // first-paint rebuild on HiDPI displays.
             m_axisLabels[i].prepare(p.transform(), f);
-            p.setPen(kAxisLabelColor);
+            p.setPen(kAxisLabelColor());
             p.drawStaticText(QPointF(x + 2.0f, r.bottom() - 2.0f - ascent),
                              m_axisLabels[i]);
             p.drawStaticText(QPointF(r.left() + 2.0f, y - 2.0f - ascent),
@@ -187,7 +186,7 @@ void ClientCompCurveWidget::drawGrid(QPainter& p, const QRectF& r) const
 
     // Unity diagonal (below-threshold passthrough) drawn as a dim
     // reference so the user can see how far the curve bends away.
-    p.setPen(QPen(kIdentityColor, 1.0, Qt::DashLine));
+    p.setPen(QPen(kIdentityColor(), 1.0, Qt::DashLine));
     p.drawLine(QPointF(dbToX(kMinDb), dbToY(kMinDb)),
                QPointF(dbToX(kMaxDb), dbToY(kMaxDb)));
 
@@ -213,7 +212,7 @@ void ClientCompCurveWidget::drawCurve(QPainter& p, const QRectF& r) const
         else        path.lineTo(pt);
     }
 
-    QPen curvePen(kCurveColor, m_compact ? 1.5 : 2.0);
+    QPen curvePen(kCurveColor(), m_compact ? 1.5 : 2.0);
     curvePen.setJoinStyle(Qt::RoundJoin);
     curvePen.setCapStyle(Qt::RoundCap);
     p.setPen(curvePen);
@@ -224,7 +223,7 @@ void ClientCompCurveWidget::drawCurve(QPainter& p, const QRectF& r) const
     if (!m_compact) {
         const float T = m_comp->thresholdDb();
         const QPointF t(dbToX(T), dbToY(curveOutputDb(T)));
-        p.setBrush(kCurveColor);
+        p.setBrush(kCurveColor());
         p.setPen(Qt::NoPen);
         p.drawEllipse(t, 3.0, 3.0);
     }
@@ -245,7 +244,7 @@ void ClientCompCurveWidget::drawBall(QPainter& p, const QRectF& r) const
     // passages look livelier than quiet ones.
     const float glow = m_compact ? 8.0f : 11.0f;
     QRadialGradient g(pt, glow);
-    QColor glowColor = kBallGlowColor;
+    QColor glowColor = kBallGlowColor();
     glowColor.setAlpha(200);
     g.setColorAt(0.0, glowColor);
     glowColor.setAlpha(0);
@@ -255,7 +254,7 @@ void ClientCompCurveWidget::drawBall(QPainter& p, const QRectF& r) const
     p.drawEllipse(pt, glow, glow);
 
     // White core
-    p.setBrush(kBallCoreColor);
+    p.setBrush(kBallCoreColor());
     p.drawEllipse(pt, m_compact ? 2.5 : 3.5, m_compact ? 2.5 : 3.5);
     p.restore();
 }

--- a/src/gui/ClientCompKnob.cpp
+++ b/src/gui/ClientCompKnob.cpp
@@ -17,6 +17,7 @@
 #include <QWheelEvent>
 #include <algorithm>
 #include <cmath>
+#include "core/ThemeManager.h"
 
 namespace AetherSDR {
 
@@ -28,12 +29,11 @@ constexpr float kFineMultiplier     = 0.25f;   // Shift-drag scales ×0.25
 constexpr float kArcStartDeg        = 225.0f;  // 7:30 clockwise to
 constexpr float kArcSpanDeg         = -270.0f; // 4:30  = 270° sweep
 
-const QColor kRingBg     ("#1a2a3a");
-const QColor kRingArc    ("#4db8d4");
-const QColor kPointer    ("#e8e8e8");
-const QColor kLabelColor ("#b0c4d6");
-const QColor kValueColor ("#e8e8e8");
-
+inline QColor kRingBg() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kRingArc() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
+inline QColor kPointer() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }
+inline QColor kLabelColor() { return AetherSDR::ThemeManager::instance().color("color.text.secondary"); }
+inline QColor kValueColor() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }
 } // namespace
 
 ClientCompKnob::ClientCompKnob(QWidget* parent) : QWidget(parent)
@@ -266,13 +266,13 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
             fm = QFontMetrics(labelFont);
         }
         p.setFont(labelFont);
-        p.setPen(kLabelColor);
+        p.setPen(kLabelColor());
         p.drawText(QRectF(0, 0, w, 12), Qt::AlignCenter, m_label);
     }
 
     // Background ring.
     const qreal thick = std::max(2.0, diameter * 0.10);
-    QPen bgPen(kRingBg, thick);
+    QPen bgPen(kRingBg(), thick);
     bgPen.setCapStyle(Qt::FlatCap);
     p.setPen(bgPen);
     p.drawArc(ring.adjusted(thick * 0.5, thick * 0.5,
@@ -281,7 +281,7 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
               static_cast<int>(kArcSpanDeg * 16.0f));
 
     // Value arc.
-    QPen arcPen(kRingArc, thick);
+    QPen arcPen(kRingArc(), thick);
     arcPen.setCapStyle(Qt::FlatCap);
     p.setPen(arcPen);
     p.drawArc(ring.adjusted(thick * 0.5, thick * 0.5,
@@ -299,7 +299,7 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
                        c.y() - rOut * std::sin(angle));
     const QPointF pIn (c.x() + rIn  * std::cos(angle),
                        c.y() - rIn  * std::sin(angle));
-    QPen pointerPen(kPointer, thick * 0.6);
+    QPen pointerPen(kPointer(), thick * 0.6);
     pointerPen.setCapStyle(Qt::RoundCap);
     p.setPen(pointerPen);
     p.drawLine(pIn, pOut);
@@ -330,7 +330,7 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
         }
 
         p.setFont(centerFont);
-        p.setPen(kLabelColor);
+        p.setPen(kLabelColor());
         p.drawText(ring, Qt::AlignCenter, m_label);
     }
 
@@ -342,7 +342,7 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
         valueFont.setBold(true);
         valueFont.setPixelSize(11);
         p.setFont(valueFont);
-        p.setPen(kValueColor);
+        p.setPen(kValueColor());
         p.drawText(valueRect(), Qt::AlignCenter, formatValue());
     }
 }

--- a/src/gui/ClientCompLimiterButton.cpp
+++ b/src/gui/ClientCompLimiterButton.cpp
@@ -3,6 +3,7 @@
 #include <QPainter>
 #include <QPaintEvent>
 #include <QRadialGradient>
+#include "core/ThemeManager.h"
 
 namespace AetherSDR {
 
@@ -12,16 +13,15 @@ namespace {
 //   - Disarmed (limiter disabled) — dim, grey, clearly "off"
 //   - Armed (limiter enabled, not firing) — dark green body, bright green text
 //   - Active (firing, held 500 ms) — red body + halo, white text
-const QColor kBgArmed    ("#006040");
-const QColor kBgDisarmed ("#0e1b28");
-const QColor kBgActive   ("#d03030");
-const QColor kBorderArm  ("#00a060");
-const QColor kBorderOff  ("#2a3a4a");
-const QColor kBorderHit  ("#ff8080");
-const QColor kTextArmed  ("#00ff88");
-const QColor kTextOff    ("#607888");
-const QColor kTextActive ("#ffffff");
-
+inline QColor kBgArmed() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
+inline QColor kBgDisarmed() { return AetherSDR::ThemeManager::instance().color("color.background.0"); }
+inline QColor kBgActive() { return AetherSDR::ThemeManager::instance().color("color.accent.danger"); }
+inline QColor kBorderArm() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
+inline QColor kBorderOff() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kBorderHit() { return AetherSDR::ThemeManager::instance().color("color.accent.danger"); }
+inline QColor kTextArmed() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
+inline QColor kTextOff() { return AetherSDR::ThemeManager::instance().color("color.text.label"); }
+inline QColor kTextActive() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }
 } // namespace
 
 ClientCompLimiterButton::ClientCompLimiterButton(QWidget* parent)
@@ -61,17 +61,17 @@ void ClientCompLimiterButton::paintEvent(QPaintEvent*)
     QColor border;
     QColor textColor;
     if (m_active) {
-        bg = kBgActive;
-        border = kBorderHit;
-        textColor = kTextActive;
+        bg = kBgActive();
+        border = kBorderHit();
+        textColor = kTextActive();
     } else if (isChecked()) {
-        bg = kBgArmed;
-        border = kBorderArm;
-        textColor = kTextArmed;
+        bg = kBgArmed();
+        border = kBorderArm();
+        textColor = kTextArmed();
     } else {
-        bg = kBgDisarmed;
-        border = kBorderOff;
-        textColor = kTextOff;
+        bg = kBgDisarmed();
+        border = kBorderOff();
+        textColor = kTextOff();
     }
 
     if (underMouse() && !m_active) {
@@ -87,7 +87,7 @@ void ClientCompLimiterButton::paintEvent(QPaintEvent*)
     // indicator on hardware gear.
     if (m_active) {
         QRadialGradient g(r.center(), r.width() * 0.6);
-        QColor glow = kBgActive;
+        QColor glow = kBgActive();
         glow.setAlpha(90);
         g.setColorAt(0.0, glow);
         glow.setAlpha(0);

--- a/src/gui/ClientCompMeter.cpp
+++ b/src/gui/ClientCompMeter.cpp
@@ -5,6 +5,7 @@
 #include <QLinearGradient>
 #include <algorithm>
 #include <cmath>
+#include "core/ThemeManager.h"
 
 namespace AetherSDR {
 
@@ -16,16 +17,16 @@ constexpr float kGrMaxMag   =  20.0f;    // GR range 0..-20 dB
 constexpr int   kPeakHoldMs =  700;
 constexpr float kPeakDecayDbPer100Ms = 1.0f;
 
-const QColor kBarBg    ("#0a1420");
-const QColor kLevelLo  ("#56c48b");
-const QColor kLevelMid ("#e8d65a");
-const QColor kLevelHi  ("#e85a5a");
-const QColor kGrColor  ("#e8a540");
-const QColor kLabelColor("#b0c4d6");
-const QColor kPeakLine ("#ffffff");
-const QColor kCeilingLine("#f2c14e");     // bright amber — matches LIMIT button
+inline QColor kBarBg() { return AetherSDR::ThemeManager::instance().color("color.background.0"); }
+inline QColor kLevelLo() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
+inline QColor kLevelMid() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }
+inline QColor kLevelHi() { return AetherSDR::ThemeManager::instance().color("color.accent.danger"); }
+inline QColor kGrColor() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }
+inline QColor kLabelColor() { return AetherSDR::ThemeManager::instance().color("color.text.secondary"); }
+inline QColor kPeakLine() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }
+inline QColor kCeilingLine() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }  // bright amber — matches LIMIT button
 const QColor kCeilingZone("#3a1810");     // dim red tint for the "no-go" zone
-const QColor kLimGrTick ("#4db8d4");      // cyan, distinct from the white peak line
+inline QColor kLimGrTick() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }  // cyan, distinct from the white peak line
 
 } // namespace
 
@@ -172,14 +173,14 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
         p.setFont(f);
         // Amber matches the THRESH fader's label colour so the paired
         // meters read as one consistent strip header.
-        p.setPen(QColor("#e8a540"));
+        p.setPen(AetherSDR::ThemeManager::instance().color("color.accent.warning"));
         p.drawText(QRectF(0, 0, w, labelH), Qt::AlignCenter, m_label);
     }
 
-    p.fillRect(bar, kBarBg);
+    p.fillRect(bar, kBarBg());
     // Border matches the THRESH fader so the paired meters read as
     // one visual idiom across the comp editor.
-    p.setPen(QPen(QColor("#243a4e"), 1));
+    p.setPen(QPen(AetherSDR::ThemeManager::instance().color("color.background.1"), 1));
     p.setBrush(Qt::NoBrush);
     p.drawRect(QRectF(bar.left(), bar.top(),
                       bar.width() - 1, bar.height() - 1));
@@ -189,9 +190,9 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
         QRectF fill(bar.left(), bar.bottom() - fillH, bar.width(), fillH);
 
         QLinearGradient g(0, bar.bottom(), 0, bar.top());
-        g.setColorAt(0.0, kLevelLo);
-        g.setColorAt(0.7, kLevelMid);
-        g.setColorAt(1.0, kLevelHi);
+        g.setColorAt(0.0, kLevelLo());
+        g.setColorAt(0.7, kLevelMid());
+        g.setColorAt(1.0, kLevelHi());
         p.fillRect(fill, g);
 
         // Limiter overlay — draw ceiling zone + line if a ceiling has
@@ -215,7 +216,7 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
             // Ceiling line — bright amber, slightly thicker than the
             // peak line so it reads as a structural limit, not a meter
             // value.
-            p.setPen(QPen(kCeilingLine, 1.5));
+            p.setPen(QPen(kCeilingLine(), 1.5));
             p.drawLine(QPointF(bar.left() - 2.0, cy),
                        QPointF(bar.right() + 2.0, cy));
 
@@ -227,7 +228,7 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
                 const float grSpanDb = std::min(-m_limGrDb, 12.0f);
                 const float tickH =
                     (grSpanDb / (kLevelMaxDb - kLevelMinDb)) * bar.height();
-                p.setPen(QPen(kLimGrTick, 2.0));
+                p.setPen(QPen(kLimGrTick(), 2.0));
                 p.drawLine(QPointF(bar.center().x(), cy),
                            QPointF(bar.center().x(), cy + tickH));
             }
@@ -238,18 +239,18 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
                 (m_peakDb - kLevelMinDb) / (kLevelMaxDb - kLevelMinDb),
                 0.0f, 1.0f);
             const float y = bar.bottom() - tp * bar.height();
-            p.setPen(QPen(kPeakLine, 1.0));
+            p.setPen(QPen(kPeakLine(), 1.0));
             p.drawLine(QPointF(bar.left(), y), QPointF(bar.right(), y));
         }
     } else {
         const float fillH = m_smooth.value() * bar.height();
         QRectF fill(bar.left(), bar.top(), bar.width(), fillH);
-        p.fillRect(fill, kGrColor);
+        p.fillRect(fill, kGrColor());
 
         const float peakMag = std::clamp(-m_peakDb, 0.0f, kGrMaxMag);
         if (peakMag > 0.0f) {
             const float y = bar.top() + (peakMag / kGrMaxMag) * bar.height();
-            p.setPen(QPen(kPeakLine, 1.0));
+            p.setPen(QPen(kPeakLine(), 1.0));
             p.drawLine(QPointF(bar.left(), y), QPointF(bar.right(), y));
         }
     }
@@ -292,7 +293,7 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
             const float norm = (ticks[i].db - minDb) / (maxDb - minDb);
             const int y = static_cast<int>(bar.bottom() - norm * bar.height());
 
-            p.setPen(QColor("#7f93a5"));
+            p.setPen(AetherSDR::ThemeManager::instance().color("color.text.secondary"));
             const QString s = QString::fromLatin1(ticks[i].label);
             const int tw = fm.horizontalAdvance(s);
             const int ty = std::clamp(y + fm.ascent() / 2 - 1,
@@ -300,14 +301,14 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
                                       static_cast<int>(bar.bottom()) - 1);
             if (tickLeft) {
                 p.drawText(textRight - tw, ty, s);
-                p.setPen(QColor("#405060"));
+                p.setPen(AetherSDR::ThemeManager::instance().color("color.meter.bar.fill"));
                 p.drawLine(textRight, y,
                            static_cast<int>(bar.left()) - 1, y);
             } else {
                 // Right side — labels grow from the bar outward.
                 const int textLeft = static_cast<int>(bar.right()) + kTickGap + 1;
                 p.drawText(textLeft, ty, s);
-                p.setPen(QColor("#405060"));
+                p.setPen(AetherSDR::ThemeManager::instance().color("color.meter.bar.fill"));
                 p.drawLine(static_cast<int>(bar.right()), y,
                            textLeft - 1, y);
             }
@@ -334,7 +335,7 @@ void ClientCompMeter::paintEvent(QPaintEvent*)
         f.setPixelSize(10);
         f.setBold(true);
         p.setFont(f);
-        p.setPen(QColor("#e8e8e8"));
+        p.setPen(AetherSDR::ThemeManager::instance().color("color.text.primary"));
         constexpr int kFooterRightPad = 3;
         const QRectF footer(0, h - valueH,
                             w - kFooterRightPad, valueH);

--- a/src/gui/ClientCompThresholdFader.cpp
+++ b/src/gui/ClientCompThresholdFader.cpp
@@ -25,10 +25,9 @@ namespace {
 constexpr float kPeakAttack  = 0.6f;
 constexpr float kPeakRelease = 0.08f;
 
-const QColor kHandleFill   ("#e8a540");   // amber — same as threshold chevron
-const QColor kHandleStroke ("#0a1a28");
-const QColor kHandleCenter ("#3a2a10");
-
+inline QColor kHandleFill() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }  // amber — same as threshold chevron
+inline QColor kHandleStroke() { return AetherSDR::ThemeManager::instance().color("color.background.0"); }
+inline QColor kHandleCenter() { return AetherSDR::ThemeManager::instance().color("color.background.tx"); }
 } // namespace
 
 ClientCompThresholdFader::ClientCompThresholdFader(QWidget* parent)
@@ -194,7 +193,7 @@ void ClientCompThresholdFader::paintEvent(QPaintEvent*)
     const int barLeft = kLabelColW + kGap + kHandleOverhang;
     const QRect barR(barLeft, stripTop, kBarW, m_stripH);
 
-    p.fillRect(barR, QColor("#06111c"));
+    p.fillRect(barR, AetherSDR::ThemeManager::instance().color("color.background.0"));
 
     // Level fill — same green→amber→red gradient as the output fader so
     // the metering vocabulary is consistent across the app.
@@ -214,7 +213,7 @@ void ClientCompThresholdFader::paintEvent(QPaintEvent*)
         p.fillRect(fill, grad);
     }
 
-    p.setPen(QPen(QColor("#243a4e"), 1));
+    p.setPen(QPen(AetherSDR::ThemeManager::instance().color("color.background.1"), 1));
     p.setBrush(Qt::NoBrush);
     p.drawRect(barR.adjusted(0, 0, -1, -1));
 
@@ -237,7 +236,7 @@ void ClientCompThresholdFader::paintEvent(QPaintEvent*)
         const float norm = (t.db - kMeterMinDb) / (kMeterMaxDb - kMeterMinDb);
         const int y = stripTop + static_cast<int>((1.0f - norm) * m_stripH);
 
-        p.setPen(QColor("#7f93a5"));
+        p.setPen(AetherSDR::ThemeManager::instance().color("color.text.secondary"));
         const QString s = QString::fromLatin1(t.label);
         const int tw = fm.horizontalAdvance(s);
         const int ty = std::clamp(y + fm.ascent() / 2 - 1,
@@ -245,7 +244,7 @@ void ClientCompThresholdFader::paintEvent(QPaintEvent*)
                                   stripTop + m_stripH - 1);
         p.drawText(textRight - tw, ty, s);
 
-        p.setPen(QColor("#405060"));
+        p.setPen(AetherSDR::ThemeManager::instance().color("color.meter.bar.fill"));
         p.drawLine(textRight, y, barLeft - 1, y);
     }
 
@@ -259,10 +258,10 @@ void ClientCompThresholdFader::paintEvent(QPaintEvent*)
                         handleY - kHandleH / 2,
                         kBarW + kHandleOverhang * 2,
                         kHandleH);
-    p.setPen(QPen(kHandleStroke, 1));
-    p.setBrush(kHandleFill);
+    p.setPen(QPen(kHandleStroke(), 1));
+    p.setBrush(kHandleFill());
     p.drawRect(handleR);
-    p.setPen(kHandleCenter);
+    p.setPen(kHandleCenter());
     p.drawLine(handleR.left() + 1, handleY,
                handleR.right() - 1, handleY);
 
@@ -274,7 +273,7 @@ void ClientCompThresholdFader::paintEvent(QPaintEvent*)
     caret.lineTo(barLeft - kHandleOverhang,     cy - 3);
     caret.lineTo(barLeft - kHandleOverhang,     cy + 3);
     caret.closeSubpath();
-    p.setBrush(kHandleFill);
+    p.setBrush(kHandleFill());
     p.setPen(Qt::NoPen);
     p.drawPath(caret);
 }

--- a/src/gui/ClientDeEssCurveWidget.cpp
+++ b/src/gui/ClientDeEssCurveWidget.cpp
@@ -9,6 +9,7 @@
 #include <QTimer>
 #include <algorithm>
 #include <cmath>
+#include "core/ThemeManager.h"
 
 namespace AetherSDR {
 
@@ -17,16 +18,14 @@ namespace {
 constexpr float kBallSmoothAlpha = 0.30f;
 constexpr float kTwoPi = 6.283185307179586476f;
 
-const QColor kBgColor       ("#0a1420");
-const QColor kGridColor     ("#1e3040");
-const QColor kGridMajorColor("#2a4458");
-const QColor kAxisLabelColor("#607888");
-const QColor kCurveColor    ("#d47272");   // soft red — "sibilant band"
-const QColor kThreshColor   ("#4db8d4");
-const QColor kBallGlowColor ("#ffd070");
-const QColor kBallCoreColor ("#ffffff");
-
-// Log-freq major ticks.
+inline QColor kBgColor() { return AetherSDR::ThemeManager::instance().color("color.background.0"); }
+inline QColor kGridColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kGridMajorColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kAxisLabelColor() { return AetherSDR::ThemeManager::instance().color("color.text.label"); }
+inline QColor kCurveColor() { return AetherSDR::ThemeManager::instance().color("color.accent.danger"); }  // soft red — "sibilant band"
+inline QColor kThreshColor() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
+inline QColor kBallGlowColor() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }
+inline QColor kBallCoreColor() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }  // Log-freq major ticks.
 const float kFreqMajor[] = { 100.0f, 500.0f, 1000.0f, 2000.0f,
                              5000.0f, 10000.0f };
 
@@ -122,16 +121,16 @@ void ClientDeEssCurveWidget::paintEvent(QPaintEvent*)
     p.setRenderHint(QPainter::Antialiasing, true);
 
     const QRectF r = rect();
-    p.fillRect(r, kBgColor);
+    p.fillRect(r, kBgColor());
 
     // Grid — vertical at major freqs, horizontal at 0 / -12 / -24.
     p.save();
-    p.setPen(QPen(kGridColor, 1.0));
+    p.setPen(QPen(kGridColor(), 1.0));
     for (float db : { 0.0f, -12.0f, -24.0f }) {
         const float y = dbToY(db);
         p.drawLine(QPointF(r.left(), y), QPointF(r.right(), y));
     }
-    p.setPen(QPen(kGridMajorColor, 1.0));
+    p.setPen(QPen(kGridMajorColor(), 1.0));
     QFont font = p.font();
     font.setPixelSize(8);
     p.setFont(font);
@@ -163,10 +162,10 @@ void ClientDeEssCurveWidget::paintEvent(QPaintEvent*)
         p.drawLine(QPointF(x, r.top()), QPointF(x, r.bottom()));
         if (!m_compact) {
             m_axisLabels[i].prepare(p.transform(), font);
-            p.setPen(kAxisLabelColor);
+            p.setPen(kAxisLabelColor());
             p.drawStaticText(QPointF(x + 2.0f, r.bottom() - 2.0f - ascent),
                              m_axisLabels[i]);
-            p.setPen(QPen(kGridMajorColor, 1.0));
+            p.setPen(QPen(kGridMajorColor(), 1.0));
         }
     }
     p.restore();
@@ -186,7 +185,7 @@ void ClientDeEssCurveWidget::paintEvent(QPaintEvent*)
             if (i == 0) path.moveTo(pt);
             else        path.lineTo(pt);
         }
-        QPen curvePen(kCurveColor, m_compact ? 1.5 : 2.0);
+        QPen curvePen(kCurveColor(), m_compact ? 1.5 : 2.0);
         curvePen.setJoinStyle(Qt::RoundJoin);
         curvePen.setCapStyle(Qt::RoundCap);
         p.setPen(curvePen);
@@ -201,19 +200,19 @@ void ClientDeEssCurveWidget::paintEvent(QPaintEvent*)
         const float y = dbToY(scDb);
         const float glow = m_compact ? 6.0f : 9.0f;
         QRadialGradient g(QPointF(x, y), glow);
-        QColor gc = kBallGlowColor; gc.setAlpha(200);
+        QColor gc = kBallGlowColor(); gc.setAlpha(200);
         g.setColorAt(0.0, gc);
         gc.setAlpha(0);
         g.setColorAt(1.0, gc);
         p.setBrush(g);
         p.setPen(Qt::NoPen);
         p.drawEllipse(QPointF(x, y), glow, glow);
-        p.setBrush(kBallCoreColor);
+        p.setBrush(kBallCoreColor());
         p.drawEllipse(QPointF(x, y), m_compact ? 2.0 : 3.0,
                                       m_compact ? 2.0 : 3.0);
 
         // Threshold horizontal line — dim cyan.
-        QColor tc = kThreshColor; tc.setAlpha(150);
+        QColor tc = kThreshColor(); tc.setAlpha(150);
         p.setPen(QPen(tc, 1.2, Qt::DashLine));
         const float yT = dbToY(std::clamp(m_deEss->thresholdDb(),
                                           kMinDb, kMaxDb));

--- a/src/gui/ClientGateCurveWidget.cpp
+++ b/src/gui/ClientGateCurveWidget.cpp
@@ -9,6 +9,7 @@
 #include <QTimer>
 #include <algorithm>
 #include <cmath>
+#include "core/ThemeManager.h"
 
 namespace AetherSDR {
 
@@ -16,16 +17,14 @@ namespace {
 
 constexpr float kBallSmoothAlpha = 0.30f;
 
-const QColor kBgColor       ("#0a1420");
-const QColor kGridColor     ("#1e3040");
-const QColor kGridMajorColor("#2a4458");
-const QColor kAxisLabelColor("#607888");
-const QColor kIdentityColor ("#2a3a4a");
-const QColor kCurveColor    ("#c8a040");   // amber — reads as gate/expander
-const QColor kBallGlowColor ("#ffd070");
-const QColor kBallCoreColor ("#ffffff");
-
-// -80..0 dB range with matching majors; gate can attenuate much
+inline QColor kBgColor() { return AetherSDR::ThemeManager::instance().color("color.background.0"); }
+inline QColor kGridColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kGridMajorColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kAxisLabelColor() { return AetherSDR::ThemeManager::instance().color("color.text.label"); }
+inline QColor kIdentityColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kCurveColor() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }  // amber — reads as gate/expander
+inline QColor kBallGlowColor() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }
+inline QColor kBallCoreColor() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }  // -80..0 dB range with matching majors; gate can attenuate much
 // deeper than comp, so the grid needs to show the full -80 floor.
 const float kMajorTicks[] = { 0.0f, -20.0f, -40.0f, -60.0f, -80.0f };
 const float kMinorTicks[] = { -10.0f, -30.0f, -50.0f, -70.0f };
@@ -97,7 +96,7 @@ void ClientGateCurveWidget::paintEvent(QPaintEvent*)
     p.setRenderHint(QPainter::Antialiasing, true);
 
     const QRectF r = rect();
-    p.fillRect(r, kBgColor);
+    p.fillRect(r, kBgColor());
     drawGrid(p, r);
     drawHysteresisBand(p, r);
     drawCurve(p, r);
@@ -131,8 +130,8 @@ void ClientGateCurveWidget::drawGrid(QPainter& p, const QRectF& r) const
 {
     p.save();
 
-    const QPen minorPen(kGridColor, 1.0);
-    const QPen majorPen(kGridMajorColor, 1.0);
+    const QPen minorPen(kGridColor(), 1.0);
+    const QPen majorPen(kGridMajorColor(), 1.0);
 
     p.setPen(minorPen);
     for (float db : kMinorTicks) {
@@ -169,7 +168,7 @@ void ClientGateCurveWidget::drawGrid(QPainter& p, const QRectF& r) const
 
         if (!m_compact && db != 0.0f && db != kMinDb) {
             m_axisLabels[i].prepare(p.transform(), f);
-            p.setPen(kAxisLabelColor);
+            p.setPen(kAxisLabelColor());
             p.drawStaticText(QPointF(x + 2.0f, r.bottom() - 2.0f - ascent),
                              m_axisLabels[i]);
             p.drawStaticText(QPointF(r.left() + 2.0f, y - 2.0f - ascent),
@@ -180,7 +179,7 @@ void ClientGateCurveWidget::drawGrid(QPainter& p, const QRectF& r) const
 
     // Identity diagonal — dim reference showing where the curve sits
     // when the gate is fully open (above threshold).
-    p.setPen(QPen(kIdentityColor, 1.0, Qt::DashLine));
+    p.setPen(QPen(kIdentityColor(), 1.0, Qt::DashLine));
     p.drawLine(QPointF(dbToX(kMinDb), dbToY(kMinDb)),
                QPointF(dbToX(kMaxDb), dbToY(kMaxDb)));
 
@@ -204,7 +203,7 @@ void ClientGateCurveWidget::drawCurve(QPainter& p, const QRectF& r) const
         else        path.lineTo(pt);
     }
 
-    QPen curvePen(kCurveColor, m_compact ? 1.5 : 2.0);
+    QPen curvePen(kCurveColor(), m_compact ? 1.5 : 2.0);
     curvePen.setJoinStyle(Qt::RoundJoin);
     curvePen.setCapStyle(Qt::RoundCap);
     p.setPen(curvePen);
@@ -214,7 +213,7 @@ void ClientGateCurveWidget::drawCurve(QPainter& p, const QRectF& r) const
     if (!m_compact) {
         const float T = m_gate->thresholdDb();
         const QPointF t(dbToX(T), dbToY(curveOutputDb(T)));
-        p.setBrush(kCurveColor);
+        p.setBrush(kCurveColor());
         p.setPen(Qt::NoPen);
         p.drawEllipse(t, 3.0, 3.0);
     }
@@ -232,7 +231,7 @@ void ClientGateCurveWidget::drawBall(QPainter& p, const QRectF& r) const
     p.save();
     const float glow = m_compact ? 8.0f : 11.0f;
     QRadialGradient g(pt, glow);
-    QColor glowColor = kBallGlowColor;
+    QColor glowColor = kBallGlowColor();
     glowColor.setAlpha(200);
     g.setColorAt(0.0, glowColor);
     glowColor.setAlpha(0);
@@ -241,7 +240,7 @@ void ClientGateCurveWidget::drawBall(QPainter& p, const QRectF& r) const
     p.setPen(Qt::NoPen);
     p.drawEllipse(pt, glow, glow);
 
-    p.setBrush(kBallCoreColor);
+    p.setBrush(kBallCoreColor());
     p.drawEllipse(pt, m_compact ? 2.5 : 3.5, m_compact ? 2.5 : 3.5);
     p.restore();
 }

--- a/src/gui/ClientGateLevelView.cpp
+++ b/src/gui/ClientGateLevelView.cpp
@@ -7,6 +7,7 @@
 #include <QPen>
 #include <QTimer>
 #include <algorithm>
+#include "core/ThemeManager.h"
 
 namespace AetherSDR {
 
@@ -15,15 +16,15 @@ namespace {
 constexpr int kHistoryCount = 120;      // ~4 s at 30 Hz
 constexpr int kPollMs       = 33;
 
-const QColor kBgColor     ("#0a1420");
-const QColor kFrameColor  ("#2a3a4a");
-const QColor kGridColor   ("#1e3040");
-const QColor kAxisLabel   ("#607888");
-const QColor kInputColor  ("#f0f4f8");   // white input outline
-const QColor kAudibleColor("#f2c14e");   // amber — audio that passes through
-const QColor kReduceColor ("#1f2a38");   // dark gray reduction overlay
-const QColor kThreshColor ("#4db8d4");   // cyan threshold lines
-const QColor kPeakColor   ("#e8a540");   // amber peak bar
+inline QColor kBgColor() { return AetherSDR::ThemeManager::instance().color("color.background.0"); }
+inline QColor kFrameColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kGridColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kAxisLabel() { return AetherSDR::ThemeManager::instance().color("color.text.label"); }
+inline QColor kInputColor() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }  // white input outline
+inline QColor kAudibleColor() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }  // amber — audio that passes through
+inline QColor kReduceColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }  // dark gray reduction overlay
+inline QColor kThreshColor() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }  // cyan threshold lines
+inline QColor kPeakColor() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }  // amber peak bar
 
 // dB ticks shown on the left gutter.
 const float kTicks[] = { 6.0f, 0.0f, -6.0f, -12.0f, -18.0f,
@@ -79,7 +80,7 @@ void ClientGateLevelView::paintEvent(QPaintEvent*)
     p.setRenderHint(QPainter::Antialiasing, true);
 
     const QRectF full = rect();
-    p.fillRect(full, kBgColor);
+    p.fillRect(full, kBgColor());
 
     // Plot region: inset the left gutter for dB labels and the right
     // strip for the peak bar.
@@ -88,7 +89,7 @@ void ClientGateLevelView::paintEvent(QPaintEvent*)
                       full.height() - 8);
 
     // Frame the plot.
-    p.setPen(QPen(kFrameColor, 1.0));
+    p.setPen(QPen(kFrameColor(), 1.0));
     p.drawRect(plot);
 
     // Horizontal grid + labels.
@@ -97,9 +98,9 @@ void ClientGateLevelView::paintEvent(QPaintEvent*)
     p.setFont(f);
     for (float db : kTicks) {
         const float y = dbToY(db);
-        p.setPen(QPen(kGridColor, 1.0));
+        p.setPen(QPen(kGridColor(), 1.0));
         p.drawLine(QPointF(plot.left(), y), QPointF(plot.right(), y));
-        p.setPen(kAxisLabel);
+        p.setPen(kAxisLabel());
         QString s = (db > 0.0f ? "+" : "") + QString::number(static_cast<int>(db));
         p.drawText(QPointF(full.left() + 2.0f, y + 3.0f), s);
     }
@@ -138,7 +139,7 @@ void ClientGateLevelView::paintEvent(QPaintEvent*)
     audiblePath.lineTo(plot.left(),  plot.bottom());
     audiblePath.closeSubpath();
 
-    QColor audibleFill = kAudibleColor; audibleFill.setAlpha(90);
+    QColor audibleFill = kAudibleColor(); audibleFill.setAlpha(90);
     p.setBrush(audibleFill);
     p.setPen(Qt::NoPen);
     p.drawPath(audiblePath);
@@ -162,7 +163,7 @@ void ClientGateLevelView::paintEvent(QPaintEvent*)
     }
     gatedPath.closeSubpath();
 
-    p.setBrush(kReduceColor);
+    p.setBrush(kReduceColor());
     p.setPen(Qt::NoPen);
     p.drawPath(gatedPath);
 
@@ -176,7 +177,7 @@ void ClientGateLevelView::paintEvent(QPaintEvent*)
         if (i == 0) inputOutline.moveTo(x, yIn);
         else        inputOutline.lineTo(x, yIn);
     }
-    p.setPen(QPen(kInputColor, 1.2));
+    p.setPen(QPen(kInputColor(), 1.2));
     p.setBrush(Qt::NoBrush);
     p.drawPath(inputOutline);
 
@@ -186,11 +187,11 @@ void ClientGateLevelView::paintEvent(QPaintEvent*)
     if (m_gate) {
         const float T  = m_gate->thresholdDb();
         const float Tc = T - m_gate->returnDb();
-        QPen pen(kThreshColor, 1.5);
+        QPen pen(kThreshColor(), 1.5);
         p.setPen(pen);
         const float yT  = dbToY(std::clamp(T,  kBottomDb, kTopDb));
         p.drawLine(QPointF(plot.left(), yT), QPointF(plot.right(), yT));
-        QColor returnCol = kThreshColor; returnCol.setAlpha(180);
+        QColor returnCol = kThreshColor(); returnCol.setAlpha(180);
         p.setPen(QPen(returnCol, 1.2));
         const float yTc = dbToY(std::clamp(Tc, kBottomDb, kTopDb));
         p.drawLine(QPointF(plot.left(), yTc), QPointF(plot.right(), yTc));
@@ -200,8 +201,8 @@ void ClientGateLevelView::paintEvent(QPaintEvent*)
     {
         const QRectF bar(full.right() - kPeakBarPx - 2, plot.top(),
                          kPeakBarPx, plot.height());
-        p.fillRect(bar, kBgColor);
-        p.setPen(QPen(kFrameColor, 1.0));
+        p.fillRect(bar, kBgColor());
+        p.setPen(QPen(kFrameColor(), 1.0));
         p.drawRect(bar);
 
         if (m_gate) {
@@ -210,7 +211,7 @@ void ClientGateLevelView::paintEvent(QPaintEvent*)
             const float yIn = dbToY(inDb);
             const QRectF fill(bar.left() + 1, yIn,
                               bar.width() - 2, bar.bottom() - yIn - 1);
-            p.fillRect(fill, kPeakColor);
+            p.fillRect(fill, kPeakColor());
         }
     }
 }

--- a/src/gui/ClientTubeCurveWidget.cpp
+++ b/src/gui/ClientTubeCurveWidget.cpp
@@ -9,6 +9,7 @@
 #include <QTimer>
 #include <algorithm>
 #include <cmath>
+#include "core/ThemeManager.h"
 
 namespace AetherSDR {
 
@@ -16,14 +17,13 @@ namespace {
 
 constexpr float kBallSmoothAlpha = 0.30f;
 
-const QColor kBgColor       ("#0a1420");
-const QColor kFrameColor    ("#2a3a4a");
-const QColor kGridColor     ("#1e3040");
-const QColor kAxisColor     ("#2a4458");
-const QColor kCurveColor    ("#4db8d4");   // cyan
-const QColor kBallGlowColor ("#ffd070");
-const QColor kBallCoreColor ("#ffffff");
-
+inline QColor kBgColor() { return AetherSDR::ThemeManager::instance().color("color.background.0"); }
+inline QColor kFrameColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kGridColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kAxisColor() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+inline QColor kCurveColor() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }  // cyan
+inline QColor kBallGlowColor() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }
+inline QColor kBallCoreColor() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }
 float dbToLin(float db) noexcept
 {
     return std::pow(10.0f, db * 0.05f);
@@ -104,17 +104,17 @@ void ClientTubeCurveWidget::paintEvent(QPaintEvent*)
     p.setRenderHint(QPainter::Antialiasing, true);
 
     const QRectF r = rect();
-    p.fillRect(r, kBgColor);
+    p.fillRect(r, kBgColor());
 
     // Grid — a few reference lines at ±0.5, ±1.0.
-    p.setPen(QPen(kGridColor, 1.0));
+    p.setPen(QPen(kGridColor(), 1.0));
     for (float v : { -1.0f, -0.5f, 0.5f, 1.0f }) {
         p.drawLine(QPointF(xToPx(v), r.top()), QPointF(xToPx(v), r.bottom()));
         p.drawLine(QPointF(r.left(), yToPx(v)), QPointF(r.right(), yToPx(v)));
     }
 
     // Centre axes — slightly brighter.
-    p.setPen(QPen(kAxisColor, 1.0));
+    p.setPen(QPen(kAxisColor(), 1.0));
     p.drawLine(QPointF(xToPx(0.0f), r.top()),  QPointF(xToPx(0.0f), r.bottom()));
     p.drawLine(QPointF(r.left(), yToPx(0.0f)), QPointF(r.right(), yToPx(0.0f)));
 
@@ -130,7 +130,7 @@ void ClientTubeCurveWidget::paintEvent(QPaintEvent*)
             if (i == 0) path.moveTo(pt);
             else        path.lineTo(pt);
         }
-        QPen curvePen(kCurveColor, m_compact ? 1.5 : 2.0);
+        QPen curvePen(kCurveColor(), m_compact ? 1.5 : 2.0);
         curvePen.setJoinStyle(Qt::RoundJoin);
         curvePen.setCapStyle(Qt::RoundCap);
         p.setPen(curvePen);
@@ -142,20 +142,20 @@ void ClientTubeCurveWidget::paintEvent(QPaintEvent*)
         const QPointF pt(xToPx(x), yToPx(y));
         const float glow = m_compact ? 7.0f : 10.0f;
         QRadialGradient g(pt, glow);
-        QColor gc = kBallGlowColor; gc.setAlpha(200);
+        QColor gc = kBallGlowColor(); gc.setAlpha(200);
         g.setColorAt(0.0, gc);
         gc.setAlpha(0);
         g.setColorAt(1.0, gc);
         p.setBrush(g);
         p.setPen(Qt::NoPen);
         p.drawEllipse(pt, glow, glow);
-        p.setBrush(kBallCoreColor);
+        p.setBrush(kBallCoreColor());
         p.drawEllipse(pt, m_compact ? 2.2 : 3.0,
                           m_compact ? 2.2 : 3.0);
     }
 
     // Frame.
-    p.setPen(QPen(kFrameColor, 1.0));
+    p.setPen(QPen(kFrameColor(), 1.0));
     p.setBrush(Qt::NoBrush);
     p.drawRect(r.adjusted(0.5, 0.5, -0.5, -0.5));
 }

--- a/tools/migrate_colours.py
+++ b/tools/migrate_colours.py
@@ -179,6 +179,25 @@ CANONICAL_TOKENS: dict[str, str] = {
     "#9cb0c0": "color.text.secondary",  # 1 refs, ΔRGB=4
     "#9fb3c8": "color.text.secondary",  # 1 refs, ΔRGB=2
     "#8190a3": "color.text.secondary",  # 1 refs, ΔRGB=4
+
+    # ── Meter/curve widget close-mappings (PR 4/5 paint migration) ──
+    # File-scope const QColor declarations in ClientCompKnob/Meter/
+    # CurveWidget/ThresholdFader/LimiterButton/GateLevelView. Each is
+    # close to an existing canonical value; absorbing them lets the
+    # entire compressor + gate + tube panel respond to theme switching.
+    "#0a1a28": "color.background.0",         # dark panel base, ΔRGB≈10 from #0a0e14
+    "#1f2a38": "color.background.1",         # raised panel, ΔRGB≈9 from #1a2a3a
+    "#56c48b": "color.accent.success",       # meter level-lo green, ΔRGB≈46 from #4dd87a
+    "#607888": "color.text.label",           # axis labels, ΔRGB≈8 from #607080
+    "#b0c4d6": "color.text.secondary",       # knob/meter labels, ΔRGB≈16 from #a0b4c8
+    "#c8a040": "color.accent.warning",       # gate curve amber, ΔRGB≈55 from #e8a540
+    "#d03030": "color.accent.danger",        # limiter active red, ΔRGB≈16 from #c03030
+    "#d47272": "color.accent.danger",        # de-ess soft red sibilant band
+    "#e85a5a": "color.accent.danger",        # meter level-hi red, ΔRGB≈23 from #ff4d4d
+    "#e8a540": "color.accent.warning",       # threshold/peak amber, canonical family member
+    "#e8d65a": "color.accent.warning",       # meter level-mid yellow
+    "#e8e8e8": "color.text.primary",         # knob pointer/value off-white, ΔRGB≈32 from #c8d8e8
+    "#f0f4f8": "color.text.primary",         # gate input outline near-white, ΔRGB≈10 from #e6f0fa
 }
 
 # Build a regex that matches any of our known hex codes, longest first

--- a/tools/migrate_paint_colours.py
+++ b/tools/migrate_paint_colours.py
@@ -88,6 +88,85 @@ QCOLOR_4ARG_RE = re.compile(
 # Matches: QColor("#aabbcc")
 QCOLOR_HEX_STR_RE = re.compile(r'QColor\s*\(\s*"(#[0-9a-fA-F]{3,6})"\s*\)')
 
+# Matches:  const QColor kName ("#aabbcc");
+#           static const QColor kName("#aabbcc");
+# Captures: 1=identifier  2=hex literal
+FILE_SCOPE_HEX_RE = re.compile(
+    r'^(?:static\s+)?const\s+QColor\s+([A-Za-z_][A-Za-z0-9_]*)\s*'
+    r'\(\s*"(#[0-9a-fA-F]{3,6})"\s*\)\s*;\s*'
+    r'(//[^\n]*)?$',
+    re.MULTILINE,
+)
+
+# Matches:  const QColor kName(0xAA, 0xBB, 0xCC);
+#           static const QColor kName(0xAA, 0xBB, 0xCC, 0xDD);
+# Captures: 1=ident  2=R  3=G  4=B  5=optional alpha
+FILE_SCOPE_RGB_RE = re.compile(
+    r'^(?:static\s+)?const\s+QColor\s+([A-Za-z_][A-Za-z0-9_]*)\s*'
+    r'\(\s*(0x[0-9a-fA-F]{1,2}|\d{1,3})\s*,\s*'
+    r'(0x[0-9a-fA-F]{1,2}|\d{1,3})\s*,\s*'
+    r'(0x[0-9a-fA-F]{1,2}|\d{1,3})'
+    r'(?:\s*,\s*(0x[0-9a-fA-F]{1,3}|\d{1,3}))?\s*\)\s*;\s*'
+    r'(//[^\n]*)?$',
+    re.MULTILINE,
+)
+
+
+def rewrite_file_scope_consts(content: str) -> tuple[str, int, int]:
+    """Convert file-scope `const QColor kName("#hex");` declarations to
+    `inline QColor kName() { return ThemeManager::instance().color("token"); }`
+    plus rewrite every bare `kName` reference in the file to `kName()`.
+
+    Returns (new_content, replacements, skipped)."""
+    rep = 0
+    skipped = 0
+    renamed_idents: list[str] = []
+
+    def replace_decl_hex(m: re.Match) -> str:
+        nonlocal rep, skipped
+        ident, hex_str = m.group(1), m.group(2).lower()
+        comment = m.group(3) or ''
+        tok = hex_to_token(hex_str)
+        if tok is None:
+            skipped += 1
+            return m.group(0)
+        rep += 1
+        renamed_idents.append(ident)
+        tail = f'  {comment}' if comment else ''
+        return (f'inline QColor {ident}() {{ return '
+                f'AetherSDR::ThemeManager::instance().color("{tok}"); }}{tail}')
+
+    def replace_decl_rgb(m: re.Match) -> str:
+        nonlocal rep, skipped
+        ident = m.group(1)
+        hex_str = rgb_components_to_hex([m.group(2), m.group(3), m.group(4)])
+        alpha = m.group(5)
+        comment = m.group(6) or ''
+        tok = hex_to_token(hex_str)
+        if tok is None:
+            skipped += 1
+            return m.group(0)
+        rep += 1
+        renamed_idents.append(ident)
+        tail = f'  {comment}' if comment else ''
+        if alpha is not None:
+            body = f'AetherSDR::theme::withAlpha("{tok}", {alpha.strip()})'
+        else:
+            body = f'AetherSDR::ThemeManager::instance().color("{tok}")'
+        return f'inline QColor {ident}() {{ return {body}; }}{tail}'
+
+    content = FILE_SCOPE_HEX_RE.sub(replace_decl_hex, content)
+    content = FILE_SCOPE_RGB_RE.sub(replace_decl_rgb, content)
+
+    # Now rewrite call sites: any bare `ident` not followed by `(` becomes
+    # `ident()`. The negative lookahead avoids double-rewriting our own
+    # injected `ident() { ... }` declaration line.
+    for ident in renamed_idents:
+        call_site_re = re.compile(rf'\b{re.escape(ident)}\b(?!\s*\()')
+        content = call_site_re.sub(f'{ident}()', content)
+
+    return content, rep, skipped
+
 
 def rewrite_paint_qcolor(content: str) -> tuple[str, int, int]:
     """Returns (new_content, replacements, skipped_unmatched_hex)."""
@@ -135,13 +214,20 @@ def process_file(path: Path, apply: bool) -> tuple[int, int]:
         text = path.read_text(encoding='utf-8', errors='replace')
     except OSError:
         return 0, 0
+    # File-scope `const QColor kName(...);` first — those declarations also
+    # match the QColor(...) regexes below, so we lift them out into inline
+    # functions first and the remaining QColor(...) literals inside paint
+    # functions get handled by the regular pass.
+    text, fs_rep, fs_skipped = rewrite_file_scope_consts(text)
     new_text, rep, skipped = rewrite_paint_qcolor(text)
-    if rep == 0:
-        return 0, skipped
+    total_rep = fs_rep + rep
+    total_skipped = fs_skipped + skipped
+    if total_rep == 0:
+        return 0, total_skipped
     new_text = ensure_themeManager_include(new_text)
     if apply:
         path.write_text(new_text, encoding='utf-8')
-    return rep, skipped
+    return total_rep, total_skipped
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

**PR 4 of 5** in the Phase 2/3 wrap-up. Migrates 76 file-scope const \`QColor\` declarations across 9 compressor / gate / curve widget files so the entire compressor + gate + tube panel responds to theme switching.

## The pattern

File-scope \`const QColor\` declarations construct their value at static-init time, which is too early for the ThemeManager singleton. The migration converts them to inline functions that defer the lookup to first paint:

\`\`\`cpp
// Before
const QColor kRingBg("#1a2a3a");
// ...
QPen pen(kRingBg, 2);

// After
inline QColor kRingBg() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
// ...
QPen pen(kRingBg(), 2);
\`\`\`

Call sites are rewritten too — \`kName\` → \`kName()\` — via a negative lookahead in the tool so we don't double-rewrite the declaration line itself.

## Tool changes — \`tools/migrate_paint_colours.py\`

- New \`FILE_SCOPE_HEX_RE\` and \`FILE_SCOPE_RGB_RE\` patterns matching both \`QColor("#aabbcc")\` and \`QColor(0xAA, 0xBB, 0xCC[, alpha])\` declaration forms
- New \`rewrite_file_scope_consts()\` pass that runs first, before the in-paint-code pass, so the same hex literal isn't matched twice
- Preserves the trailing comment if any (\`const QColor kCurveColor ("#c8a040"); // amber\`)

## Canonical table — \`tools/migrate_colours.py\`

13 close-mappings absorbed from the comp/gate/curve sweep. Each is annotated with its sibling canonical value and the ΔRGB deviation so the rationale is auditable later:

\`\`\`python
"#b0c4d6": "color.text.secondary",   # knob/meter labels, ΔRGB≈16 from #a0b4c8
"#e85a5a": "color.accent.danger",    # meter level-hi red, ΔRGB≈23 from #ff4d4d
"#c8a040": "color.accent.warning",   # gate curve amber
# ... 10 more
\`\`\`

## Files touched (9)

- ClientCompKnob (5 colors)
- ClientCompMeter (15)
- ClientCompCurveWidget (8)
- ClientGateCurveWidget (8)
- ClientDeEssCurveWidget (8)
- ClientTubeCurveWidget (7)
- ClientCompLimiterButton (9)
- ClientCompThresholdFader (7)
- ClientGateLevelView (9)

## Skip-count (7 left for PR 5/5)

- \`#3a1810\` — meter no-go zone dark red, unique tint
- 6 gradient-stop literals inside \`ThresholdFader\` / \`GateCurveWidget\` paint code that warrant a dedicated meter-gradient token set in PR 5/5

## Verified locally

- [x] Linux build clean across **all 308 targets** (main app + every test)
- [x] No regressions flagged by the compiler

## Why this is incremental

Compressor, gate, de-esser, tube, and limiter widgets now participate in theme switching. The remaining file-scope-const pattern in RxChain / KeyboardMap / StripChain / StripWaveform / WaveformWidget falls under PR 5/5 along with the waterfall colormap + slice indicators + spectrum-domain canonical-table extension.

## Test plan

- [ ] CI: build / check-paths / check-windows / CodeQL
- [ ] Visual smoke: open the app, open the COMP applet, confirm comp/gate/de-ess curves + threshold fader + limiter button + meters render identically (the 76 migrated literals resolve to the same — or to-within-ΔRGB-of-50 hex values as before via the canonical table)

73, Jeremy KK7GWY & Claude (AI dev partner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)