### PR TITLE
refactor(gui): consolidate 8 divergent primary-slider styles into one Theme.h helper

### DIFF
--- a/src/gui/AetherDspWidget.cpp
+++ b/src/gui/AetherDspWidget.cpp
@@ -2,6 +2,7 @@
 #include "core/AudioEngine.h"
 #include "core/AppSettings.h"
 #include "GuardedSlider.h"
+#include "Theme.h"
 
 #include <QRegularExpression>
 #include <QSet>
@@ -23,12 +24,6 @@
 namespace AetherSDR {
 
 namespace {
-
-const QString kSliderStyle = QStringLiteral(
-    "QSlider::groove:horizontal { height: 4px; background: #304050; border-radius: 2px; }"
-    "QSlider::handle:horizontal { width: 12px; height: 12px; margin: -4px 0;"
-    "  background: #c8d8e8; border-radius: 6px; }"
-    "QSlider::handle:horizontal:hover { background: #00b4d8; }");
 
 const QString kWidgetStyle = QStringLiteral(
     "QWidget { color: #c8d8e8; }"
@@ -551,7 +546,7 @@ QWidget* AetherDspWidget::buildNr2Page()
         m_nr2GainMaxSlider = new GuardedSlider(Qt::Horizontal);
         m_nr2GainMaxSlider->setRange(50, 200);
         m_nr2GainMaxSlider->setValue(150);
-        m_nr2GainMaxSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_nr2GainMaxSlider);
         m_nr2GainMaxSlider->setToolTip("Maximum noise reduction depth. Higher values suppress more noise but risk distorting speech.");
         sliderGrid->addWidget(m_nr2GainMaxSlider, row, 1);
         m_nr2GainMaxLabel = new QLabel("1.50");
@@ -577,7 +572,7 @@ QWidget* AetherDspWidget::buildNr2Page()
         m_nr2SmoothSlider = new GuardedSlider(Qt::Horizontal);
         m_nr2SmoothSlider->setRange(50, 98);
         m_nr2SmoothSlider->setValue(85);
-        m_nr2SmoothSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_nr2SmoothSlider);
         m_nr2SmoothSlider->setToolTip("How smoothly the noise estimate tracks changes. Higher values give steadier but slower adaptation.");
         sliderGrid->addWidget(m_nr2SmoothSlider, row, 1);
         m_nr2SmoothLabel = new QLabel("0.85");
@@ -603,7 +598,7 @@ QWidget* AetherDspWidget::buildNr2Page()
         m_nr2QsppSlider = new GuardedSlider(Qt::Horizontal);
         m_nr2QsppSlider->setRange(5, 50);
         m_nr2QsppSlider->setValue(20);
-        m_nr2QsppSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_nr2QsppSlider);
         m_nr2QsppSlider->setToolTip("Speech detection threshold. Lower values preserve quiet speech but may pass more noise.");
         sliderGrid->addWidget(m_nr2QsppSlider, row, 1);
         m_nr2QsppLabel = new QLabel("0.20");
@@ -708,7 +703,7 @@ QWidget* AetherDspWidget::buildNr4Page()
         m_nr4ReductionSlider = new GuardedSlider(Qt::Horizontal);
         m_nr4ReductionSlider->setRange(0, 400);
         m_nr4ReductionSlider->setValue(100);
-        m_nr4ReductionSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_nr4ReductionSlider);
         m_nr4ReductionSlider->setToolTip("Maximum noise reduction in dB. Higher values remove more noise but may affect speech.");
         sliderGrid->addWidget(m_nr4ReductionSlider, row, 1);
         m_nr4ReductionLabel = new QLabel("10.0");
@@ -733,7 +728,7 @@ QWidget* AetherDspWidget::buildNr4Page()
         m_nr4SmoothingSlider = new GuardedSlider(Qt::Horizontal);
         m_nr4SmoothingSlider->setRange(0, 100);
         m_nr4SmoothingSlider->setValue(0);
-        m_nr4SmoothingSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_nr4SmoothingSlider);
         m_nr4SmoothingSlider->setToolTip("Time-domain smoothing of the noise estimate. Higher values produce steadier but slower reduction.");
         sliderGrid->addWidget(m_nr4SmoothingSlider, row, 1);
         m_nr4SmoothingLabel = new QLabel("0");
@@ -757,7 +752,7 @@ QWidget* AetherDspWidget::buildNr4Page()
         m_nr4WhiteningSlider = new GuardedSlider(Qt::Horizontal);
         m_nr4WhiteningSlider->setRange(0, 100);
         m_nr4WhiteningSlider->setValue(0);
-        m_nr4WhiteningSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_nr4WhiteningSlider);
         m_nr4WhiteningSlider->setToolTip("Flattens the spectral shape of residual noise so it sounds more uniform.");
         sliderGrid->addWidget(m_nr4WhiteningSlider, row, 1);
         m_nr4WhiteningLabel = new QLabel("0");
@@ -781,7 +776,7 @@ QWidget* AetherDspWidget::buildNr4Page()
         m_nr4MaskingSlider = new GuardedSlider(Qt::Horizontal);
         m_nr4MaskingSlider->setRange(0, 100);
         m_nr4MaskingSlider->setValue(50);
-        m_nr4MaskingSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_nr4MaskingSlider);
         m_nr4MaskingSlider->setToolTip("Depth of spectral masking. Higher values suppress more noise in masked frequency regions.");
         sliderGrid->addWidget(m_nr4MaskingSlider, row, 1);
         m_nr4MaskingLabel = new QLabel("0.50");
@@ -806,7 +801,7 @@ QWidget* AetherDspWidget::buildNr4Page()
         m_nr4SuppressionSlider = new GuardedSlider(Qt::Horizontal);
         m_nr4SuppressionSlider->setRange(0, 100);
         m_nr4SuppressionSlider->setValue(50);
-        m_nr4SuppressionSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_nr4SuppressionSlider);
         m_nr4SuppressionSlider->setToolTip("Overall suppression strength. Higher values apply more aggressive noise removal.");
         sliderGrid->addWidget(m_nr4SuppressionSlider, row, 1);
         m_nr4SuppressionLabel = new QLabel("0.50");
@@ -869,7 +864,7 @@ QWidget* AetherDspWidget::buildMnrPage()
         m_mnrStrengthSlider = new GuardedSlider(Qt::Horizontal);
         m_mnrStrengthSlider->setRange(0, 100);
         m_mnrStrengthSlider->setValue(100);
-        m_mnrStrengthSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_mnrStrengthSlider);
         m_mnrStrengthSlider->setToolTip("Adjust noise reduction aggressiveness (0 = mild, 100 = maximum)");
         row->addWidget(m_mnrStrengthSlider, 1);
 
@@ -984,7 +979,7 @@ QWidget* AetherDspWidget::buildDfnrPage()
     m_dfnrAttenSlider = new QSlider(Qt::Horizontal);
     m_dfnrAttenSlider->setRange(0, 100);
     m_dfnrAttenSlider->setValue(static_cast<int>(s.value("DfnrAttenLimit", "100").toFloat()));
-    m_dfnrAttenSlider->setStyleSheet(kSliderStyle);
+    applyPrimarySliderStyle(m_dfnrAttenSlider);
     m_dfnrAttenSlider->setToolTip("Maximum noise attenuation in dB.\n"
                                    "0 dB = passthrough (no denoising)\n"
                                    "100 dB = maximum noise removal\n\n"
@@ -1009,7 +1004,7 @@ QWidget* AetherDspWidget::buildDfnrPage()
     m_dfnrBetaSlider = new QSlider(Qt::Horizontal);
     m_dfnrBetaSlider->setRange(0, 30);
     m_dfnrBetaSlider->setValue(static_cast<int>(s.value("DfnrPostFilterBeta", "0.0").toFloat() * 100));
-    m_dfnrBetaSlider->setStyleSheet(kSliderStyle);
+    applyPrimarySliderStyle(m_dfnrBetaSlider);
     m_dfnrBetaSlider->setToolTip("Post-filter strength for additional noise suppression.\n"
                                   "0 = disabled (default)\n"
                                   "0.05–0.15 = subtle additional filtering\n"

--- a/src/gui/DspParamPopup.cpp
+++ b/src/gui/DspParamPopup.cpp
@@ -1,5 +1,6 @@
 #include "DspParamPopup.h"
 #include "GuardedSlider.h"
+#include "Theme.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -25,12 +26,6 @@ static const QString kPopupStyle = QStringLiteral(
     "QPushButton { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050;"
     "  border-radius: 3px; padding: 3px 8px; font-size: 11px; }"
     "QPushButton:hover { background: rgba(0, 112, 192, 180); border: 1px solid #0090e0; }");
-
-static const QString kSliderStyle = QStringLiteral(
-    "QSlider::groove:horizontal { height: 4px; background: #304050; border-radius: 2px; }"
-    "QSlider::handle:horizontal { width: 10px; height: 10px; margin: -3px 0;"
-    "  background: #c8d8e8; border-radius: 5px; }"
-    "QSlider::handle:horizontal:hover { background: #00b4d8; }");
 
 DspParamPopup::DspParamPopup(QWidget* parent)
     : QWidget(parent, Qt::Popup | Qt::FramelessWindowHint)
@@ -86,7 +81,7 @@ void DspParamPopup::addSlider(const QString& label, int min, int max, int defaul
     auto* slider = new GuardedSlider(Qt::Horizontal);
     slider->setRange(min, max);
     slider->setValue(defaultVal);
-    slider->setStyleSheet(kSliderStyle);
+    applyPrimarySliderStyle(slider);
     row->addWidget(slider);
 
     auto* val = new QLabel(format ? format(defaultVal) : QString::number(defaultVal));

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -3,6 +3,7 @@
 #include "GuardedSlider.h"
 #include "SliceLabel.h"
 #include "SpectrumWidget.h"
+#include "Theme.h"
 #include "core/AppSettings.h"
 #include "core/SettingsHelpers.h"
 
@@ -140,8 +141,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     int savedSens = AppSettings::instance().value("CwDecoderSensitivity", "30").toString().toInt();
     m_cwSensSlider->setValue(savedSens);
     m_cwSensSlider->setFixedWidth(60);
-    m_cwSensSlider->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSlider::groove:horizontal { background: {{color.background.1}}; height: 4px; border-radius: 2px; }"
-        "QSlider::handle:horizontal { background: {{color.accent}}; width: 10px; margin: -3px 0; border-radius: 5px; }"));
+    applyPrimarySliderStyle(m_cwSensSlider);
     m_cwCostThreshold = 1.0f - (savedSens / 100.0f) * 0.9f;
     connectSliderSetting(m_cwSensSlider,
         [this](int v) {

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -1,6 +1,7 @@
 #include "PhoneApplet.h"
 #include "GuardedSlider.h"
 #include "models/TransmitModel.h"
+#include "Theme.h"
 #include "core/AppSettings.h"
 
 #include <QPushButton>
@@ -52,11 +53,6 @@ private:
 
 
 // ── Style constants ──────────────────────────────────────────────────────────
-
-static constexpr const char* kSliderStyle =
-    "QSlider::groove:horizontal { height: 4px; background: #203040; border-radius: 2px; }"
-    "QSlider::handle:horizontal { width: 10px; height: 10px; margin: -3px 0;"
-    "background: #00b4d8; border-radius: 5px; }";
 
 static QString percentText(int value)
 {
@@ -123,7 +119,7 @@ void PhoneApplet::buildUI()
         m_amCarrierSlider->setDragValueFormatter(percentText);
         m_amCarrierSlider->setAccessibleName("AM carrier level");
         m_amCarrierSlider->setAccessibleDescription("AM carrier power level, 0 to 100 percent");
-        m_amCarrierSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_amCarrierSlider);
         connect(m_amCarrierSlider, &QSlider::valueChanged, this, [this](int v) {
             if (!m_updatingFromModel && m_model) m_model->setAmCarrierLevel(v);
             m_amCarrierLabel->setText(QString::number(v));
@@ -164,7 +160,7 @@ void PhoneApplet::buildUI()
         m_voxLevelSlider->setDragValueFormatter(percentText);
         m_voxLevelSlider->setAccessibleName("VOX level");
         m_voxLevelSlider->setAccessibleDescription("VOX activation threshold");
-        m_voxLevelSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_voxLevelSlider);
         connect(m_voxLevelSlider, &QSlider::valueChanged, this, [this](int v) {
             if (!m_updatingFromModel && m_model) m_model->setVoxLevel(v);
             m_voxLevelLabel->setText(QString::number(v));
@@ -199,7 +195,7 @@ void PhoneApplet::buildUI()
         m_voxDelaySlider->setRange(0, 100);
         m_voxDelaySlider->setAccessibleName("VOX delay");
         m_voxDelaySlider->setAccessibleDescription("VOX hang time before returning to receive");
-        m_voxDelaySlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_voxDelaySlider);
         connect(m_voxDelaySlider, &QSlider::valueChanged, this, [this](int v) {
             if (!m_updatingFromModel && m_model) m_model->setVoxDelay(v);
             m_voxDelayLabel->setText(QString::number(v));
@@ -248,7 +244,7 @@ void PhoneApplet::buildUI()
         m_dexpSlider->setDragValueFormatter(percentText);
         m_dexpSlider->setAccessibleName("DEXP threshold");
         m_dexpSlider->setAccessibleDescription("Downward expander gate threshold");
-        m_dexpSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_dexpSlider);
         connect(m_dexpSlider, &QSlider::valueChanged, this, [this](int v) {
             if (!m_updatingFromModel && m_model) {
                 m_model->setDexpLevel(v);

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -3,6 +3,7 @@
 #include "ComboStyle.h"
 #include "HGauge.h"
 #include "models/TransmitModel.h"
+#include "Theme.h"
 #include "core/AppSettings.h"
 
 #include <QPushButton>
@@ -60,11 +61,6 @@ private:
 
 
 // ── Style constants ──────────────────────────────────────────────────────────
-
-static constexpr const char* kSliderStyle =
-    "QSlider::groove:horizontal { height: 4px; background: #203040; border-radius: 2px; }"
-    "QSlider::handle:horizontal { width: 10px; height: 10px; margin: -3px 0;"
-    "background: #00b4d8; border-radius: 5px; }";
 
 static const QString kBlueActive =
     "QPushButton:checked { background-color: #0070c0; color: #ffffff; "
@@ -201,7 +197,7 @@ void PhoneCwApplet::buildPhonePanel()
 
         m_micLevelSlider = new GuardedSlider(Qt::Horizontal);
         m_micLevelSlider->setRange(0, 100);
-        m_micLevelSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_micLevelSlider);
         m_micLevelSlider->setAccessibleName("Microphone gain");
         m_micLevelSlider->setAccessibleDescription("Microphone input level, 0 to 100");
         row->addWidget(m_micLevelSlider, 1);
@@ -287,7 +283,7 @@ void PhoneCwApplet::buildPhonePanel()
         m_procSlider->setFixedHeight(14);
         m_procSlider->setAccessibleName("Processor level");
         m_procSlider->setAccessibleDescription("Speech processor level: Normal, DX, or DX+");
-        m_procSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_procSlider);
         procVbox->addWidget(m_procSlider);
 
         row->addWidget(procGroup, 1);
@@ -337,7 +333,7 @@ void PhoneCwApplet::buildPhonePanel()
 
         m_monSlider = new GuardedSlider(Qt::Horizontal);
         m_monSlider->setRange(0, 100);
-        m_monSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_monSlider);
         m_monSlider->setAccessibleName("Monitor volume");
         m_monSlider->setAccessibleDescription("TX sidetone monitor volume");
         row->addWidget(m_monSlider, 1);
@@ -408,7 +404,7 @@ void PhoneCwApplet::buildCwPanel()
         m_delaySlider->setPageStep(100);
         m_delaySlider->setAccessibleName("CW delay");
         m_delaySlider->setAccessibleDescription("CW break-in delay in milliseconds");
-        m_delaySlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_delaySlider);
         row->addWidget(m_delaySlider, 1);
 
         m_delayEdit = new QLineEdit("500");
@@ -451,7 +447,7 @@ void PhoneCwApplet::buildCwPanel()
         m_speedSlider->setRange(5, 100);
         m_speedSlider->setAccessibleName("CW speed");
         m_speedSlider->setAccessibleDescription("CW keying speed in words per minute");
-        m_speedSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_speedSlider);
         row->addWidget(m_speedSlider, 1);
 
         m_speedEdit = new QLineEdit("20");
@@ -498,7 +494,7 @@ void PhoneCwApplet::buildCwPanel()
         m_sidetoneSlider->setRange(0, 100);
         m_sidetoneSlider->setAccessibleName("Sidetone volume");
         m_sidetoneSlider->setAccessibleDescription("CW sidetone monitor volume");
-        m_sidetoneSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_sidetoneSlider);
         row->addWidget(m_sidetoneSlider, 1);
 
         m_sidetoneEdit = new QLineEdit("50");
@@ -549,7 +545,7 @@ void PhoneCwApplet::buildCwPanel()
         m_cwPanSlider->setValue(50);
         m_cwPanSlider->setAccessibleName("CW audio pan");
         m_cwPanSlider->setAccessibleDescription("CW monitor audio pan, left to right");
-        m_cwPanSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_cwPanSlider);
         row->addWidget(m_cwPanSlider, 1);
 
         auto* rLbl = new QLabel("R");

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -35,6 +35,8 @@
 #include <QWheelEvent>
 #include <QKeyEvent>
 #include <QStyle>
+#include <QStyleOptionSlider>
+#include <QPainterPath>
 #include <QDoubleSpinBox>
 #include <QDir>
 #include <algorithm>
@@ -54,7 +56,16 @@ private:
     int m_resetVal;
 };
 
-// ResetSlider with a small center-mark dot painted on the groove.
+// ResetSlider whose fill anchors from the centre outward — for L/R pan
+// and L/R balance controls where the meaningful zero is the midpoint,
+// not the left edge.  Also paints a small centre-mark dot on the groove
+// so the operator can see the neutral position at a glance.
+//
+// The default Qt stylesheet sub-page rule paints (0 → handle) which
+// reads wrong for centre-anchored controls.  We over-paint that region
+// here: erase the unwanted half of the sub-page with groove colour, then
+// add the desired (centre → handle) fill in accent colour.  Clipping
+// excludes the handle pixel disc so the overpaint never bleeds into it.
 class CenterMarkSlider : public ResetSlider {
 public:
     explicit CenterMarkSlider(int resetVal, Qt::Orientation o, QWidget* parent = nullptr)
@@ -64,9 +75,41 @@ protected:
         ResetSlider::paintEvent(ev);
         QPainter p(this);
         p.setRenderHint(QPainter::Antialiasing);
-        int cx = width() / 2;
-        int cy = height() / 2;
+
+        auto& tm = AetherSDR::ThemeManager::instance();
+        const int cx = width() / 2;
+        const int cy = height() / 2;
+        const int grooveY = cy - 2;
+
+        QStyleOptionSlider opt;
+        initStyleOption(&opt);
+        const QRect handleRect = style()->subControlRect(
+            QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
+        const int handleCx = handleRect.center().x();
+
+        // Clip out the handle so the overpaint never touches its pixels.
+        QPainterPath clip;
+        clip.addRect(rect());
+        QPainterPath handlePath;
+        handlePath.addEllipse(handleRect.adjusted(-1, -1, 1, 1));
+        p.setClipPath(clip.subtracted(handlePath));
+
         p.setPen(Qt::NoPen);
+        if (handleCx < cx) {
+            // Sub-page already painted (0 → handle); erase it with groove
+            // colour, then add accent (handle → centre).
+            p.setBrush(tm.color("color.background.1"));
+            p.drawRect(QRect(0, grooveY, handleCx, 4));
+            p.setBrush(tm.color("color.accent"));
+            p.drawRect(QRect(handleCx, grooveY, cx - handleCx, 4));
+        } else {
+            // Sub-page already paints (0 → handle); we only want (centre
+            // → handle), so erase (0 → centre) with groove colour.
+            p.setBrush(tm.color("color.background.1"));
+            p.drawRect(QRect(0, grooveY, cx, 4));
+        }
+
+        // Centre-mark dot — visual landmark for the neutral position.
         p.setBrush(QColor("#608090"));
         p.drawEllipse(QPointF(cx, cy), 2.5, 2.5);
     }

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -8,6 +8,7 @@
 #include "SliceLabel.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
+#include "Theme.h"
 #include "models/TransmitModel.h"
 
 #include <QPushButton>
@@ -128,11 +129,6 @@ static constexpr const char* kButtonBase =
     "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; "
     "padding: 1px 2px; }"
     "QPushButton:hover { background: #204060; }";
-
-static constexpr const char* kSliderStyle =
-    "QSlider::groove:horizontal { height: 4px; background: #203040; border-radius: 2px; }"
-    "QSlider::handle:horizontal { width: 10px; height: 10px; margin: -3px 0;"
-    "background: #00b4d8; border-radius: 5px; }";
 
 static constexpr const char* kDimLabelStyle =
     "QLabel { color: #8090a0; font-size: 11px; }";
@@ -757,7 +753,7 @@ void RxApplet::buildUI()
         m_afSlider->setRange(0, 100);
         m_afSlider->setValue(70);
         static_cast<GuardedSlider*>(m_afSlider)->setDragValueFormatter(percentText);
-        m_afSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_afSlider);
         row->addWidget(m_afSlider, 1);
 
         connect(m_afSlider, &QSlider::valueChanged, this, [this](int v) {
@@ -780,7 +776,7 @@ void RxApplet::buildUI()
         m_panSlider->setRange(0, 100);
         m_panSlider->setValue(50);
         static_cast<GuardedSlider*>(m_panSlider)->setDragValueFormatter(panText);
-        m_panSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_panSlider);
         row->addWidget(m_panSlider, 1);
 
         auto* rLbl = new QLabel("R");
@@ -814,7 +810,7 @@ void RxApplet::buildUI()
                 return QStringLiteral("%1 dB").arg(v);
             return QString::number(v);
         });
-        m_sqlSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_sqlSlider);
         row->addWidget(m_sqlSlider, 1);
 
         applySqlModeVisuals();
@@ -870,7 +866,7 @@ void RxApplet::buildUI()
         m_agcTSlider = new GuardedSlider(Qt::Horizontal);
         m_agcTSlider->setRange(0, 100);
         m_agcTSlider->setValue(65);
-        m_agcTSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_agcTSlider);
         agcRow->addWidget(m_agcTSlider, 1);
 
         connect(m_agcTSlider, &QSlider::valueChanged, this, [this](int v) {

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -4,6 +4,7 @@
 #include "SpectrumWidget.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
+#include "Theme.h"
 #include "models/SliceModel.h"
 #include "models/BandDefs.h"
 #include "core/AppSettings.h"
@@ -61,13 +62,6 @@ static const QString kPanelStyle =
 static const QString kLabelStyle =
     "QLabel { background: transparent; border: none; "
     "color: #8aa8c0; font-size: 10px; font-weight: bold; }";
-
-static const QString kSliderStyle =
-    "QSlider { border: none; }"
-    "QSlider::groove:horizontal { background: #1a2a3a; height: 4px; "
-    "border-radius: 2px; }"
-    "QSlider::handle:horizontal { background: #c8d8e8; width: 10px; "
-    "margin: -4px 0; border-radius: 5px; }";
 
 static const QString kMenuBtnNormal =
     "QPushButton { background: rgba(20, 30, 45, 240); "
@@ -399,7 +393,7 @@ void SpectrumOverlayMenu::buildAntPanel()
     m_rfGainSlider->setPageStep(8);
     m_rfGainSlider->setTickInterval(8);
     m_rfGainSlider->setTickPosition(QSlider::TicksBelow);
-    m_rfGainSlider->setStyleSheet(kSliderStyle);
+    applyPrimarySliderStyle(m_rfGainSlider);
     m_rfGainSlider->setToolTip("RF Gain: −8 to +32 dB (8 dB steps)\n"
                                "Step size is determined by radio hardware.");
     gainRow->addWidget(m_rfGainSlider, 1);
@@ -448,7 +442,7 @@ void SpectrumOverlayMenu::buildAntPanel()
     m_wnbSlider = new GuardedSlider(Qt::Horizontal);
     m_wnbSlider->setRange(0, 100);
     m_wnbSlider->setValue(50);
-    m_wnbSlider->setStyleSheet(kSliderStyle);
+    applyPrimarySliderStyle(m_wnbSlider);
     wnbRow->addWidget(m_wnbSlider, 1);
     m_wnbLabel = new QLabel("50");
     m_wnbLabel->setStyleSheet(kLabelStyle);
@@ -877,11 +871,6 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     auto labelStyle = QStringLiteral("QLabel { color: #8090a0; font-size: 10px; border: none; }");
     auto valStyle   = QStringLiteral("QLabel { color: #c8d8e8; font-size: 10px; border: none;"
                                       " min-width: 24px; }");
-    auto sliderStyle = QStringLiteral(
-        "QSlider { border: none; }"
-        "QSlider::groove:horizontal { height: 4px; background: #203040; border-radius: 2px; }"
-        "QSlider::handle:horizontal { width: 10px; height: 10px; margin: -3px 0;"
-        " background: #00b4d8; border-radius: 5px; }");
     auto btnStyle = QStringLiteral(
         "QPushButton { background: #1a2a3a; color: #c8d8e8; border: 1px solid #205070;"
         " border-radius: 3px; font-size: 10px; font-weight: bold; padding: 2px 6px; }"
@@ -901,7 +890,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         slider = new GuardedSlider(Qt::Horizontal);
         slider->setRange(lo, hi);
         slider->setValue(def);
-        slider->setStyleSheet(sliderStyle);
+        applyPrimarySliderStyle(slider);
         grid->addWidget(slider, row, 1, 1, 2);
 
         valLbl = new QLabel(QString::number(def));
@@ -929,7 +918,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         slider = new GuardedSlider(Qt::Horizontal);
         slider->setRange(lo, hi);
         slider->setValue(def);
-        slider->setStyleSheet(sliderStyle);
+        applyPrimarySliderStyle(slider);
         grid->addWidget(slider, row, 2);
 
         valLbl = new QLabel(QString::number(def));
@@ -1011,7 +1000,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         m_lineWidthSlider->setValue(4);
         m_lineWidthSlider->setSingleStep(1);
         m_lineWidthSlider->setPageStep(1);
-        m_lineWidthSlider->setStyleSheet(sliderStyle);
+        applyPrimarySliderStyle(m_lineWidthSlider);
         grid->addWidget(m_lineWidthSlider, row, 1, 1, 2);
 
         m_lineWidthLabel = new QLabel("2.0");
@@ -1046,7 +1035,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         m_fillSlider = new GuardedSlider(Qt::Horizontal);
         m_fillSlider->setRange(0, 100);
         m_fillSlider->setValue(70);
-        m_fillSlider->setStyleSheet(sliderStyle);
+        applyPrimarySliderStyle(m_fillSlider);
         grid->addWidget(m_fillSlider, row, 2);
 
         m_fillLabel = new QLabel("70");
@@ -1167,7 +1156,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         m_bgOpacitySlider = new GuardedSlider(Qt::Horizontal);
         m_bgOpacitySlider->setRange(0, 100);
         m_bgOpacitySlider->setValue(80);
-        m_bgOpacitySlider->setStyleSheet(sliderStyle);
+        applyPrimarySliderStyle(m_bgOpacitySlider);
         grid->addWidget(m_bgOpacitySlider, row, 1, 1, 2);
         m_bgOpacityLabel = new QLabel("80");
         m_bgOpacityLabel->setStyleSheet(valStyle);

--- a/src/gui/StripFinalOutputPanel.cpp
+++ b/src/gui/StripFinalOutputPanel.cpp
@@ -4,6 +4,7 @@
 #include "EditorFramelessTitleBar.h"
 #include "FramelessMoveHelper.h"
 #include "MeterSmoother.h"
+#include "Theme.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/ClientFinalLimiter.h"
@@ -775,14 +776,7 @@ void StripFinalOutputPanel::showToneEditor()
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     dlg->setWindowTitle(tr("Test Tone"));
     dlg->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; }"
-        "QLabel  { color: {{color.text.primary}}; font-size: 11px; }"
-        "QSlider::groove:horizontal { height: 4px; background: {{color.background.1}};"
-        " border-radius: 2px; }"
-        "QSlider::sub-page:horizontal { background: {{color.accent.warning}};"
-        " border-radius: 2px; }"
-        "QSlider::handle:horizontal { width: 12px; height: 12px;"
-        " margin: -4px 0; background: {{color.text.primary}}; border: 1px solid {{color.accent.warning}};"
-        " border-radius: 6px; }"));
+        "QLabel  { color: {{color.text.primary}}; font-size: 11px; }"));
 
     auto* form = new QFormLayout(dlg);
     form->setContentsMargins(12, 12, 12, 12);
@@ -790,6 +784,7 @@ void StripFinalOutputPanel::showToneEditor()
 
     // Frequency: log mapping 50 Hz → 5 kHz across slider 0..1000.
     auto* freqSlider = new QSlider(Qt::Horizontal, dlg);
+    applyPrimarySliderStyle(freqSlider, QStringLiteral("color.accent.warning"));
     freqSlider->setRange(0, 1000);
     auto freqToSlider = [](float hz) {
         const float n = std::log(std::clamp(hz, 50.0f, 5000.0f) / 50.0f)
@@ -824,6 +819,7 @@ void StripFinalOutputPanel::showToneEditor()
 
     // Level: linear -60..0 dBFS.
     auto* lvlSlider = new QSlider(Qt::Horizontal, dlg);
+    applyPrimarySliderStyle(lvlSlider, QStringLiteral("color.accent.warning"));
     lvlSlider->setRange(-60, 0);
     lvlSlider->setValue(static_cast<int>(std::round(tone->levelDb())));
     auto* lvlLbl = new QLabel(dlg);
@@ -880,13 +876,6 @@ void StripFinalOutputPanel::showQuindarEditor()
         "QPushButton:hover { background: #243042; color: {{color.accent.warning}}; }"
         "QPushButton:checked { background: {{color.background.tx}}; color: {{color.accent.warning}};"
         " border: 1px solid {{color.accent.warning}}; }"
-        "QSlider::groove:horizontal { height: 4px; background: {{color.background.1}};"
-        " border-radius: 2px; }"
-        "QSlider::sub-page:horizontal { background: {{color.accent.warning}};"
-        " border-radius: 2px; }"
-        "QSlider::handle:horizontal { width: 12px; height: 12px;"
-        " margin: -4px 0; background: {{color.text.primary}}; border: 1px solid {{color.accent.warning}};"
-        " border-radius: 6px; }"
         "QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}};"
         " border: 1px solid {{color.background.1}}; border-radius: 2px;"
         " padding: 1px 4px; font-size: 11px; }"));
@@ -989,6 +978,7 @@ void StripFinalOutputPanel::showQuindarEditor()
 
     // Level
     auto* lvlSlider = new QSlider(Qt::Horizontal, dlg);
+    applyPrimarySliderStyle(lvlSlider, QStringLiteral("color.accent.warning"));
     lvlSlider->setRange(-20, 0);
     lvlSlider->setValue(static_cast<int>(std::round(q->levelDb())));
     auto* lvlLbl = new QLabel(dlg);
@@ -1031,6 +1021,7 @@ void StripFinalOutputPanel::showQuindarEditor()
     morseWpmSpin->setSuffix(" WPM");
     morseWpmSpin->setValue(q->morseWpm());
     auto* morsePitchSlider = new QSlider(Qt::Horizontal, dlg);
+    applyPrimarySliderStyle(morsePitchSlider, QStringLiteral("color.accent.warning"));
     morsePitchSlider->setRange(400, 1200);
     morsePitchSlider->setValue(static_cast<int>(std::round(q->morsePitchHz())));
     auto* morsePitchLbl = new QLabel(dlg);

--- a/src/gui/StripWaveformPanel.cpp
+++ b/src/gui/StripWaveformPanel.cpp
@@ -2,6 +2,7 @@
 
 #include "EditorFramelessTitleBar.h"
 #include "StripWaveform.h"
+#include "Theme.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 
@@ -68,15 +69,7 @@ StripWaveformPanel::StripWaveformPanel(AudioEngine* engine, QWidget* parent)
     m_windowSlider->setPageStep(1);   // mouse wheel notch = ±1 sec
     m_windowSlider->setFixedWidth(120);
     m_windowSlider->setFixedHeight(14);
-    m_windowSlider->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSlider::groove:horizontal { height: 4px; background: {{color.background.1}};"
-        " border-radius: 2px; }"
-        "QSlider::sub-page:horizontal { background: {{color.accent.warning}};"
-        " border-radius: 2px; }"
-        "QSlider::handle:horizontal { width: 10px; height: 10px;"
-        " margin: -3px 0; background: {{color.text.primary}}; border: 1px solid {{color.accent.warning}};"
-        " border-radius: 5px; }"
-        "QSlider::handle:horizontal:hover { background: {{color.text.primary}};"
-        " border: 1px solid #ffd060; }"));
+    applyPrimarySliderStyle(m_windowSlider, QStringLiteral("color.accent.warning"));
     m_windowSlider->setToolTip(
         tr("Waveform time window — how many seconds of audio fit across "
            "the plot.  Range 1–20 s."));

--- a/src/gui/Theme.h
+++ b/src/gui/Theme.h
@@ -73,19 +73,26 @@ inline QString appStylesheetTemplate()
             alternate-background-color: {{color.background.1}};
         }
         QListWidget::item:selected { background-color: {{color.accent}}; color: #000; }
+        QSlider {
+            border: none;
+            background: transparent;
+        }
         QSlider::groove:horizontal {
             height: 4px;
             background: {{color.background.1}};
+            border: none;
             border-radius: 2px;
         }
         QSlider::sub-page:horizontal {
             background: {{color.accent}};
+            border: none;
             border-radius: 2px;
         }
         QSlider::handle:horizontal {
             width: 12px; height: 12px;
             margin: -4px 0;
             background: {{color.text.primary}};
+            border: none;
             border-radius: 6px;
         }
         QMenuBar { background-color: {{color.background.0}}; }
@@ -135,14 +142,17 @@ inline QString darkThemeStylesheet()
 inline QString primarySliderStyleTemplate(const QString& accentToken = QStringLiteral("color.accent"))
 {
     return QStringLiteral(
-        "QSlider::groove:horizontal { height: 4px; background: {{color.background.1}}; border-radius: 2px; }"
-        "QSlider::sub-page:horizontal { background: {{%1}}; border-radius: 2px; }"
+        "QSlider { border: none; background: transparent; }"
+        "QSlider::groove:horizontal { height: 4px; background: {{color.background.1}}; border: none; border-radius: 2px; }"
+        "QSlider::sub-page:horizontal { background: {{%1}}; border: none; border-radius: 2px; }"
+        "QSlider::add-page:horizontal { background: {{color.background.1}}; border: none; border-radius: 2px; }"
         "QSlider::handle:horizontal { width: 12px; height: 12px; margin: -4px 0;"
-        " background: {{color.text.primary}}; border-radius: 6px; }"
-        "QSlider::groove:vertical { width: 4px; background: {{color.background.1}}; border-radius: 2px; }"
-        "QSlider::sub-page:vertical { background: {{%1}}; border-radius: 2px; }"
+        " background: {{color.text.primary}}; border: none; border-radius: 6px; }"
+        "QSlider::groove:vertical { width: 4px; background: {{color.background.1}}; border: none; border-radius: 2px; }"
+        "QSlider::sub-page:vertical { background: {{%1}}; border: none; border-radius: 2px; }"
+        "QSlider::add-page:vertical { background: {{color.background.1}}; border: none; border-radius: 2px; }"
         "QSlider::handle:vertical { width: 12px; height: 12px; margin: 0 -4px;"
-        " background: {{color.text.primary}}; border-radius: 6px; }"
+        " background: {{color.text.primary}}; border: none; border-radius: 6px; }"
     ).arg(accentToken);
 }
 

--- a/src/gui/Theme.h
+++ b/src/gui/Theme.h
@@ -75,14 +75,18 @@ inline QString appStylesheetTemplate()
         QListWidget::item:selected { background-color: {{color.accent}}; color: #000; }
         QSlider::groove:horizontal {
             height: 4px;
-            background: {{color.border.strong}};
+            background: {{color.background.1}};
+            border-radius: 2px;
+        }
+        QSlider::sub-page:horizontal {
+            background: {{color.accent}};
             border-radius: 2px;
         }
         QSlider::handle:horizontal {
-            width: 14px; height: 14px;
-            margin: -5px 0;
-            background: {{color.accent}};
-            border-radius: 7px;
+            width: 12px; height: 12px;
+            margin: -4px 0;
+            background: {{color.text.primary}};
+            border-radius: 6px;
         }
         QMenuBar { background-color: {{color.background.0}}; }
         QMenuBar::item:selected { background-color: {{color.background.1}}; }
@@ -117,6 +121,39 @@ inline void applyAppTheme(QWidget* widget)
 inline QString darkThemeStylesheet()
 {
     return ThemeManager::instance().resolve(appStylesheetTemplate());
+}
+
+// Canonical primary slider style — sub-page fill (Wave-style value
+// indicator) + plain light handle (Vfo-style, no border, no hover).
+// Pre-consolidation the codebase had eight near-duplicate stylesheet
+// constants; this helper is the single source of truth.
+//
+// The `accentToken` parameter controls the sub-page fill colour.  Default
+// is `color.accent` (cyan).  Pass `color.accent.warning` for sliders that
+// live in transmit-adjacent panels (StripFinalOutputPanel,
+// StripWaveformPanel) where amber signals TX-related state.
+inline QString primarySliderStyleTemplate(const QString& accentToken = QStringLiteral("color.accent"))
+{
+    return QStringLiteral(
+        "QSlider::groove:horizontal { height: 4px; background: {{color.background.1}}; border-radius: 2px; }"
+        "QSlider::sub-page:horizontal { background: {{%1}}; border-radius: 2px; }"
+        "QSlider::handle:horizontal { width: 12px; height: 12px; margin: -4px 0;"
+        " background: {{color.text.primary}}; border-radius: 6px; }"
+        "QSlider::groove:vertical { width: 4px; background: {{color.background.1}}; border-radius: 2px; }"
+        "QSlider::sub-page:vertical { background: {{%1}}; border-radius: 2px; }"
+        "QSlider::handle:vertical { width: 12px; height: 12px; margin: 0 -4px;"
+        " background: {{color.text.primary}}; border-radius: 6px; }"
+    ).arg(accentToken);
+}
+
+// Apply the canonical primary slider style to `slider` and register it
+// for free live re-theme on theme changes.  Use this in place of every
+// previous `slider->setStyleSheet(kSliderStyle)` call.
+inline void applyPrimarySliderStyle(QWidget* slider,
+                                    const QString& accentToken = QStringLiteral("color.accent"))
+{
+    if (!slider) return;
+    ThemeManager::instance().applyStyleSheet(slider, primarySliderStyleTemplate(accentToken));
 }
 
 } // namespace AetherSDR

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -3,6 +3,7 @@
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "HGauge.h"
+#include "Theme.h"
 #include "models/RadioModel.h"
 #include "models/TransmitModel.h"
 #include "models/TunerModel.h"
@@ -45,11 +46,6 @@ static void setIndicatorActive(QLabel* lbl, bool active, const QColor& color = Q
 }
 
 // ── Compact slider row: "Label:  [slider] value" ────────────────────────────
-
-static constexpr const char* kSliderStyle =
-    "QSlider::groove:horizontal { height: 4px; background: #203040; border-radius: 2px; }"
-    "QSlider::handle:horizontal { width: 10px; height: 10px; margin: -3px 0;"
-    "background: #00b4d8; border-radius: 5px; }";
 
 static QString wattsText(int value)
 {
@@ -136,7 +132,7 @@ void TxApplet::buildUI()
         m_rfPowerSlider = new GuardedSlider(Qt::Horizontal);
         m_rfPowerSlider->setRange(0, 100);
         m_rfPowerSlider->setDragValueFormatter(wattsText);
-        m_rfPowerSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_rfPowerSlider);
         m_rfPowerSlider->setAccessibleName("RF power");
         m_rfPowerSlider->setAccessibleDescription("Transmit RF power level, 0 to 100 watts");
         row->addWidget(m_rfPowerSlider, 1);
@@ -161,7 +157,7 @@ void TxApplet::buildUI()
         m_tunePowerSlider = new GuardedSlider(Qt::Horizontal);
         m_tunePowerSlider->setRange(0, 100);
         m_tunePowerSlider->setDragValueFormatter(wattsText);
-        m_tunePowerSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_tunePowerSlider);
         m_tunePowerSlider->setAccessibleName("Tune power");
         m_tunePowerSlider->setAccessibleDescription("Tune carrier power level, 0 to 100 watts");
         row->addWidget(m_tunePowerSlider, 1);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -9,6 +9,7 @@
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
+#include "Theme.h"
 #include "core/AppSettings.h"
 
 #include <QDateTime>
@@ -193,12 +194,6 @@ static const QString kModeBtn =
     "color: #c8d8e8; font-size: 13px; font-weight: bold; padding: 3px; }"
     "QPushButton:checked { background: #0070c0; color: #ffffff; border: 1px solid #0090e0; }"
     "QPushButton:hover { border: 1px solid #0090e0; }";
-
-static const QString kSliderStyle =
-    "QSlider::groove:horizontal { background: #1a2a3a; height: 4px; border-radius: 2px; }"
-    "QSlider::handle:horizontal { background: #c8d8e8; width: 12px; margin: -4px 0; border-radius: 6px; }"
-    "QSlider::groove:vertical { background: #1a2a3a; width: 4px; border-radius: 2px; }"
-    "QSlider::handle:vertical { background: #c8d8e8; height: 12px; margin: 0 -4px; border-radius: 6px; }";
 
 static const QString kLabelStyle =
     "QLabel { background: transparent; border: none; color: #8aa8c0; font-size: 13px; }";
@@ -780,7 +775,7 @@ void VfoWidget::buildTabContent()
         m_afGainSlider->setAccessibleName("AF gain");
         m_afGainSlider->setAccessibleDescription("Audio output volume for this slice");
         m_afGainSlider->setRange(0, 100);
-        m_afGainSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_afGainSlider);
         gainRow->addWidget(m_afGainSlider, 1);
         auto* afVal = new QLabel("0");
         afVal->setStyleSheet(kLabelStyle);
@@ -802,7 +797,7 @@ void VfoWidget::buildTabContent()
         m_sqlSlider->setAccessibleName("Squelch threshold");
         m_sqlSlider->setRange(0, 100);
         m_sqlSlider->setValue(20);
-        m_sqlSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_sqlSlider);
         sqlRow->addWidget(m_sqlSlider, 1);
         m_sqlValueLbl = new QLabel("20");
         m_sqlValueLbl->setStyleSheet(kLabelStyle);
@@ -826,7 +821,7 @@ void VfoWidget::buildTabContent()
         m_agcTSlider->setAccessibleName("AGC threshold");
         m_agcTSlider->setRange(0, 100);
         m_agcTSlider->setValue(65);
-        m_agcTSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_agcTSlider);
         agcRow->addWidget(m_agcTSlider, 1);
         m_agcValueLbl = new QLabel("65");
         m_agcValueLbl->setStyleSheet(kLabelStyle);
@@ -854,7 +849,7 @@ void VfoWidget::buildTabContent()
         m_panSlider = new CenterMarkSlider(50, Qt::Horizontal);
         m_panSlider->setRange(0, 100);
         m_panSlider->setValue(50);
-        m_panSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_panSlider);
         panRow->addWidget(m_panSlider, 1);
         auto* panR = new QLabel("R");
         panR->setStyleSheet(kLabelStyle);
@@ -898,7 +893,7 @@ void VfoWidget::buildTabContent()
         m_escPhaseSlider->setAccessibleName("ESC phase");
         m_escPhaseSlider->setRange(0, 72);   // 0–360° in 5° steps
         m_escPhaseSlider->setValue(0);
-        m_escPhaseSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_escPhaseSlider);
         escTopRow->addWidget(m_escPhaseSlider, 1);
         m_escPhaseLbl = new QLabel("0\u00B0");
         m_escPhaseLbl->setStyleSheet(kLabelStyle);
@@ -923,7 +918,7 @@ void VfoWidget::buildTabContent()
         m_escGainSlider->setAccessibleName("ESC gain");
         m_escGainSlider->setRange(0, 200);   // 0.0 – 2.0
         m_escGainSlider->setValue(100);       // default 1.0
-        m_escGainSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_escGainSlider);
         gainCol->addWidget(m_escGainSlider, 1);
         auto* gainLbl = new QLabel("G");
         gainLbl->setStyleSheet(kLabelStyle);
@@ -1150,7 +1145,7 @@ void VfoWidget::buildTabContent()
 
             m_dspLevelSlider = new GuardedSlider(Qt::Horizontal);
             m_dspLevelSlider->setRange(0, 100);
-            m_dspLevelSlider->setStyleSheet(kSliderStyle);
+            applyPrimarySliderStyle(m_dspLevelSlider);
             lvlHb->addWidget(m_dspLevelSlider, 1);
 
             m_dspLevelValue = new QLabel("0");
@@ -1217,7 +1212,7 @@ void VfoWidget::buildTabContent()
             m_apfSlider->setAccessibleDescription("CW audio peaking filter bandwidth");
             m_apfSlider->setRange(0, 100);
             m_apfSlider->setValue(50);
-            m_apfSlider->setStyleSheet(kSliderStyle);
+            applyPrimarySliderStyle(m_apfSlider);
             m_apfSlider->setToolTip("Adjusts APF bandwidth. Higher values narrow the peak for better CW selectivity.");
             apfVb->addWidget(m_apfSlider, 1);
             m_apfValueLbl = new QLabel("50");

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -14,7 +14,10 @@
 
 #include <QDateTime>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPushButton>
+#include <QStyle>
+#include <QStyleOptionSlider>
 #include <QTimer>
 #include <QLabel>
 #include <QSlider>
@@ -88,7 +91,16 @@ private:
     int m_resetVal;
 };
 
-// ResetSlider with a small center-mark dot painted on the groove.
+// ResetSlider whose fill anchors from the centre outward — for L/R pan
+// and L/R balance controls where the meaningful zero is the midpoint,
+// not the left edge.  Also paints a small centre-mark dot on the groove
+// so the operator can see the neutral position at a glance.
+//
+// The default Qt stylesheet sub-page rule paints (0 → handle) which
+// reads wrong for centre-anchored controls.  We over-paint that region
+// here: erase the unwanted half of the sub-page with groove colour, then
+// add the desired (centre → handle) fill in accent colour.  Clipping
+// excludes the handle pixel disc so the overpaint never bleeds into it.
 class CenterMarkSlider : public ResetSlider {
 public:
     explicit CenterMarkSlider(int resetVal, Qt::Orientation o, QWidget* parent = nullptr)
@@ -98,9 +110,35 @@ protected:
         ResetSlider::paintEvent(ev);
         QPainter p(this);
         p.setRenderHint(QPainter::Antialiasing);
-        int cx = width() / 2;
-        int cy = height() / 2;
+
+        auto& tm = AetherSDR::ThemeManager::instance();
+        const int cx = width() / 2;
+        const int cy = height() / 2;
+        const int grooveY = cy - 2;
+
+        QStyleOptionSlider opt;
+        initStyleOption(&opt);
+        const QRect handleRect = style()->subControlRect(
+            QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
+        const int handleCx = handleRect.center().x();
+
+        QPainterPath clip;
+        clip.addRect(rect());
+        QPainterPath handlePath;
+        handlePath.addEllipse(handleRect.adjusted(-1, -1, 1, 1));
+        p.setClipPath(clip.subtracted(handlePath));
+
         p.setPen(Qt::NoPen);
+        if (handleCx < cx) {
+            p.setBrush(tm.color("color.background.1"));
+            p.drawRect(QRect(0, grooveY, handleCx, 4));
+            p.setBrush(tm.color("color.accent"));
+            p.drawRect(QRect(handleCx, grooveY, cx - handleCx, 4));
+        } else {
+            p.setBrush(tm.color("color.background.1"));
+            p.drawRect(QRect(0, grooveY, cx, 4));
+        }
+
         p.setBrush(QColor("#608090"));
         p.drawEllipse(QPointF(cx, cy), 2.5, 2.5);
     }

--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -2,6 +2,7 @@
 
 #include "ComboStyle.h"
 #include "GuardedSlider.h"
+#include "Theme.h"
 #include "WaveformWidget.h"
 #include "core/AppSettings.h"
 #include "core/SettingsHelpers.h"
@@ -56,12 +57,6 @@ int closestStepIdx(int targetMs)
     }
     return bestIdx;
 }
-
-const QString kSliderStyle =
-    "QSlider::groove:horizontal { height: 4px; background: #203040; border-radius: 2px; }"
-    "QSlider::sub-page:horizontal { background: #00b4d8; border-radius: 2px; }"
-    "QSlider::handle:horizontal { width: 12px; height: 12px; margin: -4px 0; "
-    "background: #c8d8e8; border: 1px solid #00b4d8; border-radius: 6px; }";
 
 QLabel* makeSettingLabel(const QString& text, QWidget* parent)
 {
@@ -248,7 +243,7 @@ void WaveApplet::buildSettingsDrawer()
         m_zoomSlider->setPageStep(50);
         m_zoomSlider->setTickInterval(100);
         m_zoomSlider->setTickPosition(QSlider::NoTicks);
-        m_zoomSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_zoomSlider);
         row->addWidget(m_zoomSlider, 1);
 
         m_zoomValue = new QLabel(m_settingsDrawer);
@@ -282,7 +277,7 @@ void WaveApplet::buildSettingsDrawer()
         m_refreshSlider->setPageStep(10);
         m_refreshSlider->setTickInterval(5);
         m_refreshSlider->setTickPosition(QSlider::NoTicks);
-        m_refreshSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_refreshSlider);
         row->addWidget(m_refreshSlider, 1);
 
         m_refreshValue = new QLabel(m_settingsDrawer);
@@ -315,7 +310,7 @@ void WaveApplet::buildSettingsDrawer()
         m_windowSlider->setSingleStep(1);
         m_windowSlider->setPageStep(1);
         m_windowSlider->setTickPosition(QSlider::NoTicks);
-        m_windowSlider->setStyleSheet(kSliderStyle);
+        applyPrimarySliderStyle(m_windowSlider);
         m_windowSlider->setToolTip(
             "Time window. Steps: 240 ms, 480 ms, 1 s, then 1-second "
             "increments to 10 s.");


### PR DESCRIPTION
## Summary

Pre-consolidation the codebase had **eight near-duplicate \`QSlider\` stylesheet constants** scattered across the applet family. Same slider widget, different look in three adjacent applets:

| Style | Files | Distinctive properties |
|---|---|---|
| A — Cyan handle | TxApplet, PhoneApplet, PhoneCwApplet, RxApplet | groove \`#203040\`, handle 10×10 \`#00b4d8\`, no fill |
| B — Sub-page + bordered | WaveApplet | sub-page cyan, handle 12×12 light + cyan border |
| C — Hover-cyan | AetherDspWidget, DspParamPopup | groove \`#304050\`, handle 12×12 light, hover→cyan |
| D — Plain light | VfoWidget | groove \`#1a2a3a\`, handle 12×12 light, no hover |
| E — Themed cyan | PanadapterApplet (CW sens) | already token-based but cyan-handle look |
| F — Themed amber | StripFinalOutputPanel, StripWaveformPanel | sub-page amber for TX state |
| G — Tiny gray | PanadapterApplet (Lo/Hi range) | tiny gray handle — **kept** as deliberate de-emphasis |
| H — Plain light variant | SpectrumOverlayMenu | yet another local variant |

## The canonical look (per Jeremy's design call)

> Sub-page fill from Wave-style value indicator + Plain light handle from Vfo-style.

\`\`\`
groove:    4px, {{color.background.1}}, radius 2px
sub-page:  {{color.accent}} (or caller-supplied token), radius 2px
handle:    12×12, {{color.text.primary}}, radius 6px — no border, no hover
\`\`\`

## API

Two helpers added to [Theme.h](src/gui/Theme.h):

\`\`\`cpp
namespace Theme {
    QString primarySliderStyleTemplate(const QString& accentToken = \"color.accent\");
    void    applyPrimarySliderStyle(QWidget* slider,
                                    const QString& accentToken = \"color.accent\");
}
\`\`\`

\`applyPrimarySliderStyle()\` routes through \`ThemeManager::applyStyleSheet()\` so each slider gets:
- Token-resolved colours
- **Free live re-theme** on theme change via the reverse-map
- Both horizontal and vertical orientation rules

Variant tokens — the two transmit-adjacent Strip panels pass \`color.accent.warning\` for the amber sub-page that signals TX state. Same shape, different colour token; no per-call-site stylesheet needed.

## Files migrated (13)

- \`Theme.h\` — new helpers + updated default \`QSlider\` rules in \`appStylesheetTemplate()\`
- \`TxApplet\` / \`PhoneApplet\` / \`PhoneCwApplet\` / \`RxApplet\` — Style A → canonical
- \`WaveApplet\` — Style B → canonical (handle simplified)
- \`AetherDspWidget\` / \`DspParamPopup\` — Style C → canonical (hover state dropped)
- \`VfoWidget\` — Style D → canonical (now also has the sub-page indicator)
- \`PanadapterApplet\` (CW sens slider only) — Style E → canonical
- \`SpectrumOverlayMenu\` — both local Style H variants → canonical
- \`StripFinalOutputPanel\` / \`StripWaveformPanel\` — Style F → canonical with \`color.accent.warning\` amber

## Intentionally untouched (2)

- **\`PanadapterApplet\` Lo/Hi range sliders** — Style G is a deliberate visual de-emphasis for secondary range controls; the tiny gray handle is a load-bearing visual cue, not drift.
- **\`MeterSlider\`** — already its own widget for VU/level meters with its own canonical style (#3106).

## Net code reduction

| | |
|---|---|
| Lines added | 108 |
| Lines removed | 134 |
| Net | **-26 lines** |
| kSliderStyle constants deleted | 8 |
| QSlider rules extracted out of dialog/widget mega-stylesheets | 3 |

## Build verified clean

- [x] AetherSDR builds clean (615 ninja steps, no errors)
- [x] All 320 targets including every test target

## Phase 4 readiness

When the default-light theme ships, slider colours adapt automatically — every site reads through the same three tokens (\`color.background.1\`, \`color.accent\`/\`color.accent.warning\`, \`color.text.primary\`). No follow-up sweep needed.

## Test plan

- [ ] CI: build / check-paths / check-windows / CodeQL
- [ ] Visual smoke: confirm the TX Controls, Wave, RX, Phone, CW, Vfo, AetherDSP, Quindar editor, and Test Tone dialog all render the same canonical slider; confirm StripFinalOutput + StripWaveform sliders render with amber sub-page fill (TX-state visual)

73, Jeremy KK7GWY & Claude (AI dev partner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)