### PR TITLE
feat(theme): waterfall colormap runtime theming for all 5 presets

### DIFF
--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -47,18 +47,60 @@
         "grid": "#1a2330"
       },
       "waterfall.colormap": {
-        "type": "linear-gradient",
-        "angle": 180,
-        "stops": [
-          { "at": 0.00, "color": "#000000" },
-          { "at": 0.15, "color": "#000040" },
-          { "at": 0.30, "color": "#0040c0" },
-          { "at": 0.45, "color": "#00c0c0" },
-          { "at": 0.60, "color": "#00c040" },
-          { "at": 0.75, "color": "#c0c000" },
-          { "at": 0.90, "color": "#c04000" },
-          { "at": 1.00, "color": "#ffffff" }
-        ]
+        "default": {
+          "type": "linear-gradient",
+          "angle": 180,
+          "stops": [
+            { "at": 0.00, "color": "#000000" },
+            { "at": 0.15, "color": "#000080" },
+            { "at": 0.30, "color": "#0040ff" },
+            { "at": 0.45, "color": "#00c8ff" },
+            { "at": 0.60, "color": "#00dc00" },
+            { "at": 0.80, "color": "#ffff00" },
+            { "at": 1.00, "color": "#ff0000" }
+          ]
+        },
+        "grayscale": {
+          "type": "linear-gradient",
+          "angle": 180,
+          "stops": [
+            { "at": 0.00, "color": "#000000" },
+            { "at": 1.00, "color": "#ffffff" }
+          ]
+        },
+        "blueGreen": {
+          "type": "linear-gradient",
+          "angle": 180,
+          "stops": [
+            { "at": 0.00, "color": "#000000" },
+            { "at": 0.25, "color": "#001e78" },
+            { "at": 0.50, "color": "#0064b4" },
+            { "at": 0.75, "color": "#00c882" },
+            { "at": 1.00, "color": "#dcffdc" }
+          ]
+        },
+        "fire": {
+          "type": "linear-gradient",
+          "angle": 180,
+          "stops": [
+            { "at": 0.00, "color": "#000000" },
+            { "at": 0.25, "color": "#800000" },
+            { "at": 0.50, "color": "#dc5000" },
+            { "at": 0.75, "color": "#ffc800" },
+            { "at": 1.00, "color": "#ffffdc" }
+          ]
+        },
+        "plasma": {
+          "type": "linear-gradient",
+          "angle": 180,
+          "stops": [
+            { "at": 0.00, "color": "#000000" },
+            { "at": 0.25, "color": "#50008c" },
+            { "at": 0.50, "color": "#c80078" },
+            { "at": 0.75, "color": "#f07800" },
+            { "at": 1.00, "color": "#ffff50" }
+          ]
+        }
       },
       "slice": {
         "a": "#ff4040",

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -189,52 +189,81 @@ static QString formatFlagFrequency(double freqMhz)
         .arg(hzPart, 3, 10, QChar('0'));
 }
 
-// ─── Waterfall color scheme gradient presets ─────────────────────────────────
+// ─── Waterfall color scheme gradient cache ────────────────────────────────────
+//
+// The five preset schemes (Default, Grayscale, Blue-Green, Fire, Plasma) used
+// to live as compile-time const tables.  They now resolve through ThemeManager
+// against `color.waterfall.colormap.{default,grayscale,blueGreen,fire,plasma}`
+// gradient tokens so a theme switch (or user theme override) reshapes any of
+// them.  Cached once per theme load — `intensityToRgb` and `fftDbmToRgb` hit
+// this hundreds of times per second per row, so we can't afford a token
+// lookup on every pixel.
+//
+// Invalidated by ThemeManager::themeChanged via a SpectrumWidget connection
+// in the constructor; first call lazily populates if the cache hasn't been
+// initialized yet.
 
-static constexpr WfGradientStop kDefaultStops[] = {
-    {0.00f,   0,   0,   0},   // black
-    {0.15f,   0,   0, 128},   // dark blue
-    {0.30f,   0,  64, 255},   // blue
-    {0.45f,   0, 200, 255},   // cyan
-    {0.60f,   0, 220,   0},   // green
-    {0.80f, 255, 255,   0},   // yellow
-    {1.00f, 255,   0,   0},   // red
+namespace {
+
+struct WfStopsCache {
+    std::array<std::vector<WfGradientStop>, static_cast<int>(WfColorScheme::Count)> stops;
+    bool initialized = false;
 };
-static constexpr WfGradientStop kGrayscaleStops[] = {
-    {0.00f,   0,   0,   0},
-    {1.00f, 255, 255, 255},
-};
-static constexpr WfGradientStop kBlueGreenStops[] = {
-    {0.00f,   0,   0,   0},
-    {0.25f,   0,  30, 120},
-    {0.50f,   0, 100, 180},
-    {0.75f,   0, 200, 130},
-    {1.00f, 220, 255, 220},
-};
-static constexpr WfGradientStop kFireStops[] = {
-    {0.00f,   0,   0,   0},
-    {0.25f, 128,   0,   0},
-    {0.50f, 220,  80,   0},
-    {0.75f, 255, 200,   0},
-    {1.00f, 255, 255, 220},
-};
-static constexpr WfGradientStop kPlasmaStops[] = {
-    {0.00f,   0,   0,   0},
-    {0.25f,  80,   0, 140},
-    {0.50f, 200,   0, 120},
-    {0.75f, 240, 120,   0},
-    {1.00f, 255, 255,  80},
-};
+
+WfStopsCache& wfStopsCache()
+{
+    static WfStopsCache c;
+    return c;
+}
+
+const char* wfSchemeToken(WfColorScheme s)
+{
+    switch (s) {
+    case WfColorScheme::Grayscale: return "color.waterfall.colormap.grayscale";
+    case WfColorScheme::BlueGreen: return "color.waterfall.colormap.blueGreen";
+    case WfColorScheme::Fire:      return "color.waterfall.colormap.fire";
+    case WfColorScheme::Plasma:    return "color.waterfall.colormap.plasma";
+    default:                       return "color.waterfall.colormap.default";
+    }
+}
+
+void rebuildWfStopsCacheFromTheme()
+{
+    auto& c = wfStopsCache();
+    auto& tm = ThemeManager::instance();
+    for (int i = 0; i < static_cast<int>(WfColorScheme::Count); ++i) {
+        const QBrush br = tm.brush(QString::fromLatin1(
+            wfSchemeToken(static_cast<WfColorScheme>(i))));
+        std::vector<WfGradientStop> v;
+        if (br.gradient()) {
+            for (const auto& gs : br.gradient()->stops()) {
+                WfGradientStop s;
+                s.pos = static_cast<float>(gs.first);
+                s.r   = gs.second.red();
+                s.g   = gs.second.green();
+                s.b   = gs.second.blue();
+                v.push_back(s);
+            }
+        }
+        // Fallback so a missing/malformed token still produces a usable
+        // black→white ramp instead of a divide-by-zero on the first paint.
+        if (v.size() < 2)
+            v = { {0.0f, 0, 0, 0}, {1.0f, 255, 255, 255} };
+        c.stops[i] = std::move(v);
+    }
+    c.initialized = true;
+}
+
+} // namespace
 
 const WfGradientStop* wfSchemeStops(WfColorScheme scheme, int& count)
 {
-    switch (scheme) {
-    case WfColorScheme::Grayscale: count = 2; return kGrayscaleStops;
-    case WfColorScheme::BlueGreen: count = 5; return kBlueGreenStops;
-    case WfColorScheme::Fire:      count = 5; return kFireStops;
-    case WfColorScheme::Plasma:    count = 5; return kPlasmaStops;
-    default:                       count = 7; return kDefaultStops;
-    }
+    auto& c = wfStopsCache();
+    if (!c.initialized)
+        rebuildWfStopsCacheFromTheme();
+    const auto& v = c.stops[static_cast<int>(scheme)];
+    count = static_cast<int>(v.size());
+    return v.data();
 }
 
 const char* wfSchemeName(WfColorScheme scheme)
@@ -477,6 +506,18 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
 
     connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged,
             this, [this]() { markOverlayDirty(); });
+
+    // Refresh the waterfall colormap cache when the theme changes.  Existing
+    // already-rendered rows keep their pre-switch colours (same behaviour as
+    // changing the Scheme: dropdown — recolouring history would force a full
+    // O(rows × cols) repaint we don't currently amortise).  New rows pick up
+    // the new palette on the next push.
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
+            this, [this]() {
+        rebuildWfStopsCacheFromTheme();
+        markOverlayDirty();
+        update();
+    });
 }
 
 SpectrumWidget::~SpectrumWidget()


### PR DESCRIPTION
## Summary

Closes the third (and last mechanical) deferred item from the Phase 3 closeout. All five waterfall colormap presets exposed via the Spectrum Overlay → Display → \`Scheme:\` dropdown (**Default / Grayscale / Blue-Green / Fire / Plasma**) now resolve through \`ThemeManager\` against named gradient tokens.

## Why all five (not one)

The user-facing dropdown stays — operators still pick from the same five presets and the choice still drives which colormap paints. **What changed is the *content* of each preset**: a future light theme can ship a brighter \"Default\" for daylight viewing, redesign \"Fire\" with a softer stop set, etc., entirely from JSON without touching code.

## JSON shape

The previous flat \`color.waterfall.colormap\` gradient (never wired up — its stops had drifted from the actual compile-time defaults) is replaced by a nested object with five named gradient sub-tokens:

\`\`\`
color.waterfall.colormap.default     (7 stops, black→…→red)
color.waterfall.colormap.grayscale   (2 stops, black→white)
color.waterfall.colormap.blueGreen   (5 stops, black→blue→teal→green→white)
color.waterfall.colormap.fire        (5 stops, black→red→orange→yellow→white)
color.waterfall.colormap.plasma      (5 stops, black→purple→magenta→orange→yellow)
\`\`\`

\`ThemeManager::flattenTokens()\` already routes inner objects through \`parseGradient()\` whenever they carry the \`type\` discriminator, so each sub-token resolves through \`brush()\` / \`cssFragment()\` like any other gradient.

## C++ wiring — \`src/gui/SpectrumWidget.cpp\`

A file-static \`WfStopsCache\` holds five \`std::vector<WfGradientStop>\` — the converted form of each named gradient's stop list. Lazy-populated on first \`wfSchemeStops()\` call so the function works during early static-init sequences where the SpectrumWidget hasn't been constructed yet.

SpectrumWidget's constructor connects to \`ThemeManager::themeChanged\`:

1. Rebuild the cache from the new theme's gradient tokens.
2. Mark the static overlay dirty.
3. \`update()\`.

**Already-rendered waterfall rows keep their pre-switch colours** — same behaviour as changing the \`Scheme:\` dropdown today, since recolouring the history image would force an O(rows × cols) repaint we don't currently amortise. New rows pick up the new palette on the next push.

The five compile-time \`kDefaultStops\` / \`kGrayscaleStops\` / etc. tables are deleted; JSON is now the source of truth.

## Visual continuity

Default-dark's stop hex values mirror the deleted compile-time tables exactly, so the dark theme renders the same waterfall across all five presets. Only the source of truth has moved.

## Build verified clean

- [x] AetherSDR builds clean
- [x] All 320 targets including every test target

## Phase 3/4 status

| Item | Status |
|---|---|
| Slice indicators runtime themed | ✅ #3121 |
| Waterfall colormap runtime themed | ✅ this PR |
| default-light theme | ⏳ last Phase 4 milestone |

After this lands, every load-bearing colour decision in the GUI flows through the token system. Default-light becomes a pure JSON authoring exercise (plus a contrast pass).

## Test plan

- [ ] CI: build / check-paths / check-windows / CodeQL
- [ ] Visual smoke: open the Spectrum Overlay → Display tab and cycle through all 5 colormap presets, confirm each renders identically to current main on default-dark
- [ ] Bonus: drop a custom theme JSON into \`~/.config/AetherSDR/themes/\` with a re-coloured \`color.waterfall.colormap.fire\` to confirm theme switching repaints new rows with the override

73, Jeremy KK7GWY & Claude (AI dev partner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)