### PR TITLE
cleanup(theme): rescue 10 misattributed comments + tighten migration tool regex

### DIFF
--- a/src/gui/ClientChainWidget.cpp
+++ b/src/gui/ClientChainWidget.cpp
@@ -62,11 +62,13 @@ inline QColor kBgEndpoint() { return AetherSDR::ThemeManager::instance().color("
 inline QColor kBgActive() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
 inline QColor kBorderIdle() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
 inline QColor kBorderActive() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
-inline QColor kBorderGrey() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }  // MIC endpoint "ready" state — matches RxApplet's SQL-button green
+inline QColor kBorderGrey() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+// MIC endpoint "ready" state — matches RxApplet's SQL-button green
 // so users recognise the visual language across the sidebar.
 inline QColor kBgMicReady() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
 inline QColor kBorderMicReady() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
-inline QColor kTextMicReady() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }  // TX endpoint "active" state — red, pulsing via setTxActive().
+inline QColor kTextMicReady() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
+// TX endpoint "active" state — red, pulsing via setTxActive().
 // Two shades lerped by the pulse factor give a breathing effect.
 inline QColor kBgTxActiveDim() { return AetherSDR::ThemeManager::instance().color("color.background.tx"); }
 inline QColor kBgTxActiveHot() { return AetherSDR::ThemeManager::instance().color("color.accent.danger"); }
@@ -77,7 +79,9 @@ inline QColor kTextLabel() { return AetherSDR::ThemeManager::instance().color("c
 inline QColor kTextDim() { return AetherSDR::ThemeManager::instance().color("color.background.3"); }
 inline QColor kLedActive() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
 inline QColor kLedBypass() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
-inline QColor kDropIndicator() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }  // User-facing short label for each stage.  Kept 4 chars or fewer so
+inline QColor kDropIndicator() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
+
+// User-facing short label for each stage.  Kept 4 chars or fewer so
 // it fits inside the narrow boxes when the chain is crowded.
 QString stageLabel(AudioEngine::TxChainStage s)
 {

--- a/src/gui/ClientRxChainWidget.cpp
+++ b/src/gui/ClientRxChainWidget.cpp
@@ -52,7 +52,8 @@ inline QColor kBgEndpoint() { return AetherSDR::ThemeManager::instance().color("
 inline QColor kBgActive() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
 inline QColor kBorderIdle() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
 inline QColor kBorderActive() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
-inline QColor kBorderGrey() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }  // Status-tile "active" treatment — matches the MIC-ready green from
+inline QColor kBorderGrey() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+// Status-tile "active" treatment — matches the MIC-ready green from
 // the TX widget so the visual language carries across.
 inline QColor kBgStatusActive() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
 inline QColor kBorderStatusActive() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
@@ -60,7 +61,9 @@ inline QColor kTextStatusActive() { return AetherSDR::ThemeManager::instance().c
 inline QColor kConnector() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
 inline QColor kTextLabel() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }
 inline QColor kTextDim() { return AetherSDR::ThemeManager::instance().color("color.background.3"); }
-inline QColor kDropIndicator() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }  // Distinct from the TX chain's mime so a stray drag from one widget
+inline QColor kDropIndicator() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
+
+// Distinct from the TX chain's mime so a stray drag from one widget
 // can't be dropped on the other.
 constexpr const char* kMimeFormat = "application/x-aethersdr-rx-chain-stage";
 

--- a/src/gui/StripChainWidget.cpp
+++ b/src/gui/StripChainWidget.cpp
@@ -62,11 +62,13 @@ inline QColor kBgEndpoint() { return AetherSDR::ThemeManager::instance().color("
 inline QColor kBgActive() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
 inline QColor kBorderIdle() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
 inline QColor kBorderActive() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
-inline QColor kBorderGrey() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }  // MIC endpoint "ready" state — matches RxApplet's SQL-button green
+inline QColor kBorderGrey() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+// MIC endpoint "ready" state — matches RxApplet's SQL-button green
 // so users recognise the visual language across the sidebar.
 inline QColor kBgMicReady() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
 inline QColor kBorderMicReady() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
-inline QColor kTextMicReady() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }  // TX endpoint "active" state — red, pulsing via setTxActive().
+inline QColor kTextMicReady() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
+// TX endpoint "active" state — red, pulsing via setTxActive().
 // Two shades lerped by the pulse factor give a breathing effect.
 inline QColor kBgTxActiveDim() { return AetherSDR::ThemeManager::instance().color("color.background.tx"); }
 inline QColor kBgTxActiveHot() { return AetherSDR::ThemeManager::instance().color("color.accent.danger"); }
@@ -77,7 +79,9 @@ inline QColor kTextLabel() { return AetherSDR::ThemeManager::instance().color("c
 inline QColor kTextDim() { return AetherSDR::ThemeManager::instance().color("color.background.3"); }
 inline QColor kLedActive() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
 inline QColor kLedBypass() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
-inline QColor kDropIndicator() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }  // User-facing short label for each stage.  Kept 4 chars or fewer so
+inline QColor kDropIndicator() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
+
+// User-facing short label for each stage.  Kept 4 chars or fewer so
 // it fits inside the narrow boxes when the chain is crowded.
 QString stageLabel(AudioEngine::TxChainStage s)
 {

--- a/src/gui/StripRxChainWidget.cpp
+++ b/src/gui/StripRxChainWidget.cpp
@@ -52,7 +52,8 @@ inline QColor kBgEndpoint() { return AetherSDR::ThemeManager::instance().color("
 inline QColor kBgActive() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
 inline QColor kBorderIdle() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
 inline QColor kBorderActive() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
-inline QColor kBorderGrey() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }  // Status-tile "active" colour — green, matches the TX-side mic-ready
+inline QColor kBorderGrey() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
+// Status-tile "active" colour — green, matches the TX-side mic-ready
 // tone so the language reads consistently across both strips.
 inline QColor kBgStatusOn() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
 inline QColor kBorderStatusOn() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
@@ -62,7 +63,9 @@ inline QColor kTextLabel() { return AetherSDR::ThemeManager::instance().color("c
 inline QColor kTextDim() { return AetherSDR::ThemeManager::instance().color("color.background.3"); }
 inline QColor kLedActive() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
 inline QColor kLedBypass() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
-inline QColor kDropIndicator() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }  // User-facing short label for each RX stage.  Mirrors the docked
+inline QColor kDropIndicator() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
+
+// User-facing short label for each RX stage.  Mirrors the docked
 // `ClientRxChainWidget::stageLabel` so both surfaces read the same.
 QString stageLabel(AudioEngine::RxChainStage s)
 {

--- a/tools/migrate_paint_colours.py
+++ b/tools/migrate_paint_colours.py
@@ -91,9 +91,14 @@ QCOLOR_HEX_STR_RE = re.compile(r'QColor\s*\(\s*"(#[0-9a-fA-F]{3,6})"\s*\)')
 # Matches:  const QColor kName ("#aabbcc");
 #           static const QColor kName("#aabbcc");
 # Captures: 1=identifier  2=hex literal
+#
+# The trailing `[ \t]*` (not `\s*`) keeps the optional inline comment scoped to
+# the same line as the semicolon — `\s*` would let the engine swallow the
+# newline before a section-header comment on the next line and re-emit it as
+# an inline comment on the converted declaration. See #3119.
 FILE_SCOPE_HEX_RE = re.compile(
     r'^(?:static\s+)?const\s+QColor\s+([A-Za-z_][A-Za-z0-9_]*)\s*'
-    r'\(\s*"(#[0-9a-fA-F]{3,6})"\s*\)\s*;\s*'
+    r'\(\s*"(#[0-9a-fA-F]{3,6})"\s*\)\s*;[ \t]*'
     r'(//[^\n]*)?$',
     re.MULTILINE,
 )
@@ -101,12 +106,15 @@ FILE_SCOPE_HEX_RE = re.compile(
 # Matches:  const QColor kName(0xAA, 0xBB, 0xCC);
 #           static const QColor kName(0xAA, 0xBB, 0xCC, 0xDD);
 # Captures: 1=ident  2=R  3=G  4=B  5=optional alpha
+#
+# Same `[ \t]*` rationale as FILE_SCOPE_HEX_RE — keep the inline comment
+# capture from swallowing the newline before a section-header comment.
 FILE_SCOPE_RGB_RE = re.compile(
     r'^(?:static\s+)?const\s+QColor\s+([A-Za-z_][A-Za-z0-9_]*)\s*'
     r'\(\s*(0x[0-9a-fA-F]{1,2}|\d{1,3})\s*,\s*'
     r'(0x[0-9a-fA-F]{1,2}|\d{1,3})\s*,\s*'
     r'(0x[0-9a-fA-F]{1,2}|\d{1,3})'
-    r'(?:\s*,\s*(0x[0-9a-fA-F]{1,3}|\d{1,3}))?\s*\)\s*;\s*'
+    r'(?:\s*,\s*(0x[0-9a-fA-F]{1,3}|\d{1,3}))?\s*\)\s*;[ \t]*'
     r'(//[^\n]*)?$',
     re.MULTILINE,
 )


### PR DESCRIPTION
Closes #3119.

Two parts, both in one PR per the issue's recommendation.

## 1. Tool fix — `tools/migrate_paint_colours.py`

`FILE_SCOPE_HEX_RE` and `FILE_SCOPE_RGB_RE` ended with `\s*;\s*(//[^\n]*)?$`. The second `\s*` was permissive enough to consume the newline before a section-header comment on the next line, so the regex re-emitted that comment as an inline comment on the converted declaration. Replaced the second `\s*` with `[ \t]*` so the optional inline comment only attaches when it lives on the same line as the semicolon. Annotated both patterns so the next reader sees why this matters.

```diff
-    r'\(\s*"(#[0-9a-fA-F]{3,6})"\s*\)\s*;\s*'
+    r'\(\s*"(#[0-9a-fA-F]{3,6})"\s*\)\s*;[ \t]*'
```

```diff
-    r'(?:\s*,\s*(0x[0-9a-fA-F]{1,3}|\d{1,3}))?\s*\)\s*;\s*'
+    r'(?:\s*,\s*(0x[0-9a-fA-F]{1,3}|\d{1,3}))?\s*\)\s*;[ \t]*'
```

## 2. Cleanup — 10 sites across 4 files

Re-flowed the misattributed section-header comments so they sit on their own line above the function they were written to describe:

| File | Lines |
|---|---|
| `src/gui/ClientChainWidget.cpp` | 65, 69, 80 |
| `src/gui/ClientRxChainWidget.cpp` | 55, 63 |
| `src/gui/StripChainWidget.cpp` | 65, 69, 80 |
| `src/gui/StripRxChainWidget.cpp` | 55, 65 |

After this PR, the search query from the issue returns nothing:

```bash
$ grep -n '^inline QColor.*}  //' src/gui/*ChainWidget.cpp
$
```

## Verification

- No runtime impact — all changes are comment placement (cpp) and a regex tighten in a one-shot migration tool (py).
- The regex change passes a smoke test: a declaration followed by a section-header comment on the next line no longer captures the comment; a same-line inline comment still attaches as before.

AI was used for assistance.