### PR TITLE
feat(serial): add DCD as a third configurable input pin (HaliKey Serial)

### DIFF
--- a/src/core/SerialPortController.cpp
+++ b/src/core/SerialPortController.cpp
@@ -117,10 +117,12 @@ bool SerialPortController::open(const QString& portName, int baudRate,
     // Sample initial pin state
     DWORD modemStat = 0;
     ::GetCommModemStatus(hPort, &modemStat);
-    bool cts = (modemStat & MS_CTS_ON) != 0;
-    bool dsr = (modemStat & MS_DSR_ON) != 0;
+    bool cts = (modemStat & MS_CTS_ON)  != 0;
+    bool dsr = (modemStat & MS_DSR_ON)  != 0;
+    bool dcd = (modemStat & MS_RLSD_ON) != 0;   // RLSD = Receive Line Signal Detect = DCD
     m_lastCtsActive = m_ctsActiveHigh ? cts : !cts;
     m_lastDsrActive = m_dsrActiveHigh ? dsr : !dsr;
+    m_lastDcdActive = m_dcdActiveHigh ? dcd : !dcd;
     m_debounceTimer.start();
 
     m_hWin        = static_cast<void*>(hPort);
@@ -128,9 +130,10 @@ bool SerialPortController::open(const QString& portName, int baudRate,
     m_winBaudRate = baudRate;
 
     qCDebug(lcDevices) << "SerialPortController: opened" << portName << "at" << baudRate
-                       << "(Win32) DSR=" << dsr << "CTS=" << cts
+                       << "(Win32) DSR=" << dsr << "CTS=" << cts << "DCD=" << dcd
                        << "dsrFn=" << static_cast<int>(m_dsrFn)
-                       << "ctsFn=" << static_cast<int>(m_ctsFn);
+                       << "ctsFn=" << static_cast<int>(m_ctsFn)
+                       << "dcdFn=" << static_cast<int>(m_dcdFn);
 
     // Start the WaitCommEvent watcher thread
     m_stopWinWatch.store(false);
@@ -149,12 +152,14 @@ void SerialPortController::close()
 
     // Emit PTT release before closing to avoid stuck TX
     bool pttWasActive = (m_ctsFn == InputFunction::PttInput && m_lastCtsActive)
-                     || (m_dsrFn == InputFunction::PttInput && m_lastDsrActive);
+                     || (m_dsrFn == InputFunction::PttInput && m_lastDsrActive)
+                     || (m_dcdFn == InputFunction::PttInput && m_lastDcdActive);
     if (pttWasActive)
         emit externalPttChanged(false);
 
     m_lastCtsActive = false;
     m_lastDsrActive = false;
+    m_lastDcdActive = false;
 
     // Deassert configured output pins
     if (m_dtrFn != PinFunction::None)
@@ -231,26 +236,29 @@ void SerialPortController::runWinWatcher()
         // GetCommModemStatus in the context of a WaitCommEvent completion.
         DWORD modemStat = 0;
         ::GetCommModemStatus(hPort, &modemStat);
-        bool dsr = (modemStat & MS_DSR_ON) != 0;
-        bool cts = (modemStat & MS_CTS_ON) != 0;
+        bool dsr = (modemStat & MS_DSR_ON)  != 0;
+        bool cts = (modemStat & MS_CTS_ON)  != 0;
+        bool dcd = (modemStat & MS_RLSD_ON) != 0;
 
         qCDebug(lcDevices) << "SerialPortController: WaitCommEvent"
-                           << Qt::hex << evtMask << "DSR=" << dsr << "CTS=" << cts;
+                           << Qt::hex << evtMask
+                           << "DSR=" << dsr << "CTS=" << cts << "DCD=" << dcd;
 
         // Marshal the pin state back to this object's thread
-        QMetaObject::invokeMethod(this, [this, dsr, cts]() {
-            processWinPinChange(dsr, cts);
+        QMetaObject::invokeMethod(this, [this, dsr, cts, dcd]() {
+            processWinPinChange(dsr, cts, dcd);
         }, Qt::QueuedConnection);
     }
 
     qCDebug(lcDevices) << "SerialPortController: watcher thread exiting";
 }
 
-void SerialPortController::processWinPinChange(bool dsrRaw, bool ctsRaw)
+void SerialPortController::processWinPinChange(bool dsrRaw, bool ctsRaw, bool dcdRaw)
 {
     if (!isOpen()) return;
     bool ctsActive = m_ctsActiveHigh ? ctsRaw : !ctsRaw;
     bool dsrActive = m_dsrActiveHigh ? dsrRaw : !dsrRaw;
+    bool dcdActive = m_dcdActiveHigh ? dcdRaw : !dcdRaw;
 
     bool debounceOk = m_debounceTimer.elapsed() >= DEBOUNCE_MS;
 
@@ -267,12 +275,19 @@ void SerialPortController::processWinPinChange(bool dsrRaw, bool ctsRaw)
         m_debounceTimer.restart();
         emit externalPttChanged(dsrActive);
     }
+    if (m_dcdFn == InputFunction::PttInput && dcdActive != m_lastDcdActive && debounceOk) {
+        qCDebug(lcDevices) << "SerialPortController: DCD PTT edge →" << dcdActive;
+        m_lastDcdActive = dcdActive;
+        m_debounceTimer.restart();
+        emit externalPttChanged(dcdActive);
+    }
 
     // ── CW straight key ──────────────────────────────────────────────────
     bool keyDown = false;
     bool hasKey = false;
     if (m_ctsFn == InputFunction::CwKeyInput) { keyDown = ctsActive; hasKey = true; }
     if (m_dsrFn == InputFunction::CwKeyInput) { keyDown = dsrActive; hasKey = true; }
+    if (m_dcdFn == InputFunction::CwKeyInput) { keyDown = dcdActive; hasKey = true; }
     if (hasKey && keyDown != m_lastKeyDown) {
         m_lastKeyDown = keyDown;
         emit cwKeyChanged(keyDown);
@@ -283,8 +298,15 @@ void SerialPortController::processWinPinChange(bool dsrRaw, bool ctsRaw)
     bool hasPaddle = false;
     if (m_ctsFn == InputFunction::CwDitInput) { ditActive = ctsActive; hasPaddle = true; }
     if (m_dsrFn == InputFunction::CwDitInput) { ditActive = dsrActive; hasPaddle = true; }
+    if (m_dcdFn == InputFunction::CwDitInput) { ditActive = dcdActive; hasPaddle = true; }
     if (m_ctsFn == InputFunction::CwDahInput) { dahActive = ctsActive; hasPaddle = true; }
     if (m_dsrFn == InputFunction::CwDahInput) { dahActive = dsrActive; hasPaddle = true; }
+    if (m_dcdFn == InputFunction::CwDahInput) { dahActive = dcdActive; hasPaddle = true; }
+
+    // Track DCD edge even when it isn't driving paddle/key, so the
+    // close-time stuck-PTT check above and the polarity-flip rebaseline
+    // in loadSettings() both see the latest state.
+    m_lastDcdActive = dcdActive;
 
     if (m_paddleSwap) std::swap(ditActive, dahActive);
 
@@ -332,15 +354,19 @@ bool SerialPortController::open(const QString& portName, int baudRate,
         auto pinState = m_port.pinoutSignals();
         bool cts = pinState.testFlag(QSerialPort::ClearToSendSignal);
         bool dsr = pinState.testFlag(QSerialPort::DataSetReadySignal);
+        bool dcd = pinState.testFlag(QSerialPort::DataCarrierDetectSignal);
         m_lastCtsActive = m_ctsActiveHigh ? cts : !cts;
         m_lastDsrActive = m_dsrActiveHigh ? dsr : !dsr;
+        m_lastDcdActive = m_dcdActiveHigh ? dcd : !dcd;
         qCDebug(lcDevices) << "SerialPortController: open() initial pin sample —"
                            << "raw=" << Qt::hex << static_cast<int>(pinState)
-                           << "DSR=" << dsr << "CTS=" << cts
+                           << "DSR=" << dsr << "CTS=" << cts << "DCD=" << dcd
                            << "dsrActiveHigh=" << m_dsrActiveHigh
                            << "ctsActiveHigh=" << m_ctsActiveHigh
+                           << "dcdActiveHigh=" << m_dcdActiveHigh
                            << "→ lastDsrActive=" << m_lastDsrActive
-                           << "lastCtsActive=" << m_lastCtsActive;
+                           << "lastCtsActive=" << m_lastCtsActive
+                           << "lastDcdActive=" << m_lastDcdActive;
     }
     m_pollLogged = false;
     m_debounceTimer.start();
@@ -365,12 +391,14 @@ void SerialPortController::close()
     m_pollTimer.stop();
     if (m_port.isOpen()) {
         bool pttWasActive = (m_ctsFn == InputFunction::PttInput && m_lastCtsActive)
-                         || (m_dsrFn == InputFunction::PttInput && m_lastDsrActive);
+                         || (m_dsrFn == InputFunction::PttInput && m_lastDsrActive)
+                         || (m_dcdFn == InputFunction::PttInput && m_lastDcdActive);
         if (pttWasActive)
             emit externalPttChanged(false);
 
         m_lastCtsActive = false;
         m_lastDsrActive = false;
+        m_lastDcdActive = false;
 
         if (m_dtrFn != PinFunction::None)
             m_port.setDataTerminalReady(!m_dtrActiveHigh);
@@ -421,7 +449,9 @@ void SerialPortController::applyPin(PinFunction targetFn, bool active)
 void SerialPortController::updatePolling()
 {
 #ifdef HAVE_SERIALPORT
-    bool needsPoll = (m_ctsFn != InputFunction::None || m_dsrFn != InputFunction::None);
+    bool needsPoll = (m_ctsFn != InputFunction::None
+                    || m_dsrFn != InputFunction::None
+                    || m_dcdFn != InputFunction::None);
     if (needsPoll && m_port.isOpen() && !m_pollTimer.isActive())
         m_pollTimer.start(POLL_INTERVAL_MS);
     else if (!needsPoll && m_pollTimer.isActive())
@@ -444,13 +474,17 @@ void SerialPortController::pollInputPins()
 
     bool cts = pinState.testFlag(QSerialPort::ClearToSendSignal);
     bool dsr = pinState.testFlag(QSerialPort::DataSetReadySignal);
+    bool dcd = pinState.testFlag(QSerialPort::DataCarrierDetectSignal);
 
     bool ctsActive = m_ctsActiveHigh ? cts : !cts;
     bool dsrActive = m_dsrActiveHigh ? dsr : !dsr;
+    bool dcdActive = m_dcdActiveHigh ? dcd : !dcd;
 
     bool debounceOk = m_debounceTimer.elapsed() >= DEBOUNCE_MS;
 
-    bool hasPttInput = (m_ctsFn == InputFunction::PttInput || m_dsrFn == InputFunction::PttInput);
+    bool hasPttInput = (m_ctsFn == InputFunction::PttInput
+                     || m_dsrFn == InputFunction::PttInput
+                     || m_dcdFn == InputFunction::PttInput);
     if (hasPttInput) {
         if (pinState != m_lastRawPins || debounceOk != m_lastDebounceLogged || !m_pollLogged) {
             m_lastRawPins = pinState;
@@ -458,15 +492,17 @@ void SerialPortController::pollInputPins()
             qCDebug(lcDevices)
                 << "SerialPortController poll:"
                 << "raw=" << Qt::hex << static_cast<int>(pinState)
-                << "CTS=" << cts << "DSR=" << dsr
-                << "ctsActive=" << ctsActive << "dsrActive=" << dsrActive
-                << "lastCts=" << m_lastCtsActive << "lastDsr=" << m_lastDsrActive
+                << "CTS=" << cts << "DSR=" << dsr << "DCD=" << dcd
+                << "ctsActive=" << ctsActive << "dsrActive=" << dsrActive << "dcdActive=" << dcdActive
+                << "lastCts=" << m_lastCtsActive << "lastDsr=" << m_lastDsrActive << "lastDcd=" << m_lastDcdActive
                 << "debounceOk=" << debounceOk
                 << "debounceElapsed=" << m_debounceTimer.elapsed() << "ms"
                 << "ctsFn=" << static_cast<int>(m_ctsFn)
                 << "dsrFn=" << static_cast<int>(m_dsrFn)
+                << "dcdFn=" << static_cast<int>(m_dcdFn)
                 << "ctsPolActiveHigh=" << m_ctsActiveHigh
-                << "dsrPolActiveHigh=" << m_dsrActiveHigh;
+                << "dsrPolActiveHigh=" << m_dsrActiveHigh
+                << "dcdPolActiveHigh=" << m_dcdActiveHigh;
         }
     }
 
@@ -474,7 +510,7 @@ void SerialPortController::pollInputPins()
         m_pollLogged = true;
         qCDebug(lcDevices) << "SerialPortController: first poll — raw pinoutSignals ="
                            << Qt::hex << static_cast<int>(pinState)
-                           << "DSR=" << dsr << "CTS=" << cts;
+                           << "DSR=" << dsr << "CTS=" << cts << "DCD=" << dcd;
     }
 
     // ── PTT input ────────────────────────────────────────────────────────
@@ -490,12 +526,19 @@ void SerialPortController::pollInputPins()
         m_debounceTimer.restart();
         emit externalPttChanged(dsrActive);
     }
+    if (m_dcdFn == InputFunction::PttInput && dcdActive != m_lastDcdActive && debounceOk) {
+        qCDebug(lcDevices) << "SerialPortController: DCD PTT edge →" << dcdActive;
+        m_lastDcdActive = dcdActive;
+        m_debounceTimer.restart();
+        emit externalPttChanged(dcdActive);
+    }
 
     // ── CW straight key ──────────────────────────────────────────────────
     bool keyDown = false;
     bool hasKey = false;
     if (m_ctsFn == InputFunction::CwKeyInput) { keyDown = ctsActive; hasKey = true; }
     if (m_dsrFn == InputFunction::CwKeyInput) { keyDown = dsrActive; hasKey = true; }
+    if (m_dcdFn == InputFunction::CwKeyInput) { keyDown = dcdActive; hasKey = true; }
     if (hasKey && keyDown != m_lastKeyDown) {
         m_lastKeyDown = keyDown;
         emit cwKeyChanged(keyDown);
@@ -506,8 +549,14 @@ void SerialPortController::pollInputPins()
     bool hasPaddle = false;
     if (m_ctsFn == InputFunction::CwDitInput) { ditActive = ctsActive; hasPaddle = true; }
     if (m_dsrFn == InputFunction::CwDitInput) { ditActive = dsrActive; hasPaddle = true; }
+    if (m_dcdFn == InputFunction::CwDitInput) { ditActive = dcdActive; hasPaddle = true; }
     if (m_ctsFn == InputFunction::CwDahInput) { dahActive = ctsActive; hasPaddle = true; }
     if (m_dsrFn == InputFunction::CwDahInput) { dahActive = dsrActive; hasPaddle = true; }
+    if (m_dcdFn == InputFunction::CwDahInput) { dahActive = dcdActive; hasPaddle = true; }
+
+    // Track DCD edge regardless of role so close-time stuck-PTT detection
+    // and polarity-flip rebaselines see fresh state.
+    m_lastDcdActive = dcdActive;
 
     if (m_paddleSwap) std::swap(ditActive, dahActive);
 
@@ -563,8 +612,10 @@ void SerialPortController::loadSettings()
 
     m_ctsFn = strToInputFn(s.value("SerialCtsFunction", "None").toString());
     m_dsrFn = strToInputFn(s.value("SerialDsrFunction", "None").toString());
+    m_dcdFn = strToInputFn(s.value("SerialDcdFunction", "None").toString());
     m_ctsActiveHigh = s.value("SerialCtsPolarity", "ActiveHigh").toString() == "ActiveHigh";
     m_dsrActiveHigh = s.value("SerialDsrPolarity", "ActiveHigh").toString() == "ActiveHigh";
+    m_dcdActiveHigh = s.value("SerialDcdPolarity", "ActiveHigh").toString() == "ActiveHigh";
     m_paddleSwap = s.value("SerialPaddleSwap", "False").toString() == "True";
 
     bool shouldOpen = s.value("SerialAutoOpen", "False").toString() == "True"
@@ -576,8 +627,10 @@ void SerialPortController::loadSettings()
                        << "isOpen=" << isOpen()
                        << "dsrFn=" << static_cast<int>(m_dsrFn)
                        << "ctsFn=" << static_cast<int>(m_ctsFn)
+                       << "dcdFn=" << static_cast<int>(m_dcdFn)
                        << "dsrActiveHigh=" << m_dsrActiveHigh
-                       << "ctsActiveHigh=" << m_ctsActiveHigh;
+                       << "ctsActiveHigh=" << m_ctsActiveHigh
+                       << "dcdActiveHigh=" << m_dcdActiveHigh;
 
     if (!port.isEmpty() && shouldOpen) {
         int baud = s.value("SerialBaudRate", "9600").toInt();
@@ -603,10 +656,12 @@ void SerialPortController::loadSettings()
             {
                 DWORD modemStat = 0;
                 ::GetCommModemStatus(static_cast<HANDLE>(m_hWin), &modemStat);
-                bool cts = (modemStat & MS_CTS_ON) != 0;
-                bool dsr = (modemStat & MS_DSR_ON) != 0;
+                bool cts = (modemStat & MS_CTS_ON)  != 0;
+                bool dsr = (modemStat & MS_DSR_ON)  != 0;
+                bool dcd = (modemStat & MS_RLSD_ON) != 0;
                 m_lastCtsActive = m_ctsActiveHigh ? cts : !cts;
                 m_lastDsrActive = m_dsrActiveHigh ? dsr : !dsr;
+                m_lastDcdActive = m_dcdActiveHigh ? dcd : !dcd;
             }
 #else
 #  ifdef HAVE_SERIALPORT
@@ -614,8 +669,10 @@ void SerialPortController::loadSettings()
                 auto pinState = m_port.pinoutSignals();
                 bool cts = pinState.testFlag(QSerialPort::ClearToSendSignal);
                 bool dsr = pinState.testFlag(QSerialPort::DataSetReadySignal);
+                bool dcd = pinState.testFlag(QSerialPort::DataCarrierDetectSignal);
                 m_lastCtsActive = m_ctsActiveHigh ? cts : !cts;
                 m_lastDsrActive = m_dsrActiveHigh ? dsr : !dsr;
+                m_lastDcdActive = m_dcdActiveHigh ? dcd : !dcd;
             }
             updatePolling();
 #  endif
@@ -660,8 +717,10 @@ void SerialPortController::saveSettings()
     s.setValue("SerialRtsPolarity", m_rtsActiveHigh ? "ActiveHigh" : "ActiveLow");
     s.setValue("SerialCtsFunction", inputFnToStr(m_ctsFn));
     s.setValue("SerialDsrFunction", inputFnToStr(m_dsrFn));
+    s.setValue("SerialDcdFunction", inputFnToStr(m_dcdFn));
     s.setValue("SerialCtsPolarity", m_ctsActiveHigh ? "ActiveHigh" : "ActiveLow");
     s.setValue("SerialDsrPolarity", m_dsrActiveHigh ? "ActiveHigh" : "ActiveLow");
+    s.setValue("SerialDcdPolarity", m_dcdActiveHigh ? "ActiveHigh" : "ActiveLow");
     s.setValue("SerialPaddleSwap", m_paddleSwap ? "True" : "False");
     s.setValue("SerialAutoOpen", isOpen() ? "True" : "False");
     s.setValue("SerialPortOpen", isOpen() ? "True" : "False");

--- a/src/core/SerialPortController.h
+++ b/src/core/SerialPortController.h
@@ -21,10 +21,14 @@
 namespace AetherSDR {
 
 // Controls DTR/RTS lines on a USB-serial adapter for hardware PTT
-// and CW keying, and monitors CTS/DSR for external PTT and CW key/paddle input.
+// and CW keying, and monitors CTS/DSR/DCD for external PTT and CW key/paddle input.
 //
 // Output: Assert DTR/RTS when transmitting (amplifier keying, sequencer)
-// Input:  Monitor CTS/DSR for foot switch PTT, straight key, or iambic paddle
+// Input:  Monitor CTS/DSR/DCD for foot switch PTT, straight key, or iambic paddle.
+//         DCD was added so accessories that wire to the FTDI chip's DCD# pin
+//         (such as Halibut Electronics' HaliKey Serial, where TRS Ring is
+//         wired to both DSR and DCD) work without requiring users to also
+//         have the DSR# pin physically connected.
 //
 // On Windows, uses Win32 WaitCommEvent directly — QSerialPort::pinoutSignals()
 // (backed by GetCommModemStatus) returns stale data on FTDI and similar drivers
@@ -41,7 +45,7 @@ class SerialPortController : public QObject {
 public:
     // Output functions (DTR/RTS)
     enum class PinFunction { None, PTT, CwKey, CwPTT };
-    // Input functions (CTS/DSR)
+    // Input functions (CTS/DSR/DCD)
     enum class InputFunction { None, PttInput, CwKeyInput, CwDitInput, CwDahInput };
 
     explicit SerialPortController(QObject* parent = nullptr);
@@ -64,16 +68,20 @@ public:
     bool dtrPolarity() const { return m_dtrActiveHigh; }
     bool rtsPolarity() const { return m_rtsActiveHigh; }
 
-    // Input pin config (CTS/DSR)
+    // Input pin config (CTS/DSR/DCD)
     void setCtsFunction(InputFunction fn) { m_ctsFn = fn; updatePolling(); }
     void setDsrFunction(InputFunction fn) { m_dsrFn = fn; updatePolling(); }
+    void setDcdFunction(InputFunction fn) { m_dcdFn = fn; updatePolling(); }
     void setCtsPolarity(bool activeHigh) { m_ctsActiveHigh = activeHigh; }
     void setDsrPolarity(bool activeHigh) { m_dsrActiveHigh = activeHigh; }
+    void setDcdPolarity(bool activeHigh) { m_dcdActiveHigh = activeHigh; }
 
     InputFunction ctsFunction() const { return m_ctsFn; }
     InputFunction dsrFunction() const { return m_dsrFn; }
+    InputFunction dcdFunction() const { return m_dcdFn; }
     bool ctsPolarity() const { return m_ctsActiveHigh; }
     bool dsrPolarity() const { return m_dsrActiveHigh; }
+    bool dcdPolarity() const { return m_dcdActiveHigh; }
 
     // Paddle swap (swap dit/dah without rewiring)
     void setPaddleSwap(bool swap) { m_paddleSwap = swap; }
@@ -106,14 +114,17 @@ private:
     // Input state
     InputFunction m_ctsFn{InputFunction::None};
     InputFunction m_dsrFn{InputFunction::None};
+    InputFunction m_dcdFn{InputFunction::None};
     bool m_ctsActiveHigh{false};
     bool m_dsrActiveHigh{false};
+    bool m_dcdActiveHigh{false};
     bool m_paddleSwap{false};
 
 #if defined(HAVE_SERIALPORT) || defined(Q_OS_WIN)
     // Shared input tracking state (always accessed on this object's thread)
     bool          m_lastCtsActive{false};
     bool          m_lastDsrActive{false};
+    bool          m_lastDcdActive{false};
     bool          m_lastKeyDown{false};
     bool          m_lastDitActive{false};
     bool          m_lastDahActive{false};
@@ -135,7 +146,7 @@ private:
     void runWinWatcher();
 
 private slots:
-    void processWinPinChange(bool dsrRaw, bool ctsRaw);
+    void processWinPinChange(bool dsrRaw, bool ctsRaw, bool dcdRaw);
 
 #elif defined(HAVE_SERIALPORT)
     // Non-Windows path: poll via QSerialPort timer

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -3882,6 +3882,15 @@ QWidget* RadioSetupDialog::buildSerialTab()
         grid->addWidget(makeInputFnCombo("SerialDsrFunction"), 4, 1);
         grid->addWidget(makePolCombo("SerialDsrPolarity"), 4, 2);
 
+        // DCD row (input) — added for accessories that wire to the FTDI
+        // chip's DCD# pin (e.g. HaliKey Serial from Halibut Electronics,
+        // whose TRS Ring is wired to both DSR and DCD).
+        auto* dcdLabel = new QLabel("DCD");
+        dcdLabel->setStyleSheet("QLabel { color: #60a0c0; }");
+        grid->addWidget(dcdLabel, 5, 0);
+        grid->addWidget(makeInputFnCombo("SerialDcdFunction"), 5, 1);
+        grid->addWidget(makePolCombo("SerialDcdPolarity"), 5, 2);
+
         // Paddle swap
         auto* swapCb = new QCheckBox("Paddle Swap (swap dit/dah)");
         swapCb->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; }"));
@@ -3891,7 +3900,7 @@ QWidget* RadioSetupDialog::buildSerialTab()
             s.setValue("SerialPaddleSwap", on ? "True" : "False");
             s.save();
         });
-        grid->addWidget(swapCb, 5, 0, 1, 3);
+        grid->addWidget(swapCb, 6, 0, 1, 3);
 
         vbox->addWidget(group);
     }


### PR DESCRIPTION
## Summary

Adds DCD as a parallel third input alongside CTS and DSR in the Serial tab. Halibut Electronics' [HaliKey Serial](https://electronics.halibut.com/product/halikey/) wires the TRS Ring conductor to **both** the FTDI chip's DSR# pin and its DCD# pin — but in practice many FTDI variants only electrically assert DCD#, so an operator configuring AetherSDR to listen on DSR sees nothing and the device never works.

That's the failure mode @LB2EG reported on the AetherSDR Discord ("Halikey serial does not work on AetherSDR. I have tried all the combinations in serial setup window… It looks like the Halikey serial require DCD signal that AetherSDR lacks").

After this PR, HaliKey Serial users (and anyone else with a DCD-wired accessory) can route CW Dit / CW Dah / PTT / straight-key roles at DCD the same way they already could at CTS or DSR.

## Changes

### \`src/core/SerialPortController.{h,cpp}\`

- \`InputFunction\` parallels: \`setDcdFunction()\`, \`setDcdPolarity()\`, \`dcdFunction()\`, \`dcdPolarity()\`, \`m_dcdFn\`, \`m_dcdActiveHigh\`, \`m_lastDcdActive\`
- **Windows path**: \`EV_RLSD\` was already in the \`SetCommMask\` call; the \`GetCommModemStatus\` reads now also pull \`MS_RLSD_ON\` (RLSD = Receive Line Signal Detect, MSDN's name for DCD). Edge detection mirrors the existing DSR/CTS PTT/CwKey/CwDit/CwDah blocks. \`processWinPinChange()\` takes a third \`dcdRaw\` argument.
- **Linux/macOS path**: \`pollInputPins()\` reads \`QSerialPort::DataCarrierDetectSignal\` and runs identical polarity + debounce + role-routing logic.
- \`updatePolling()\` now considers DCD when deciding whether to start the poll timer.
- New \`SerialDcdFunction\` / \`SerialDcdPolarity\` AppSettings keys, defaulted to None / ActiveHigh so existing installs keep working.
- DCD edge tracked on every callback even when its role is None — keeps the close-time stuck-PTT guard and the polarity-flip rebaseline in \`loadSettings()\` honest.

### \`src/gui/RadioSetupDialog.cpp\`

- New "DCD" row in the Serial tab, identical layout to the CTS and DSR rows it sits below (input-function combo + polarity combo).
- Paddle-swap checkbox moves down one grid row.

## Settings backwards compatibility

Old configs missing \`SerialDcdFunction\` / \`SerialDcdPolarity\` load as None / ActiveHigh — semantically equivalent to not having the feature at all.

## HaliKey Serial recommended config (audited against the [User Guide](https://halibut-electronics.github.io/HaliKey/User%20Guide.pdf))

HaliKey's TRS wiring per §2.2.1 of the User Guide:

> Tip to left paddle, Dit
> Ring to right paddle, Dah
> Sleeve to common, Ground.

Inside the FTDI chip the TRS conductors land on:

- **Tip** → CTS#
- **Ring** → DSR# *and* DCD# (both)
- **Sleeve** → GND

In AetherSDR's **Settings → Serial tab**, configure as follows:

| Pin | Function     | Polarity      |
|-----|--------------|---------------|
| CTS | CW Dit Input | **Active Low** |
| DCD | CW Dah Input | **Active Low** |
| DSR | None         | (don't care)   |

**Polarity must be Active Low** for both CTS and DCD — HaliKey uses contact-closure-to-ground (signal goes LOW when the paddle is pressed). This matches §3.2.1 step 8 of the User Guide ("Polarity: Active Low"). The default in AetherSDR's UI is Active High, so this is the most common config mistake to look out for.

**Leave DSR as None** even though Ring is electrically wired to both DSR# and DCD#. Assigning the same role to two pins uses last-wins semantics inside \`SerialPortController\`, so DCD's reading overrides DSR's. That's fine when both pins drive consistently, but it can produce inverted behavior on FTDI variants where DSR# stays HIGH while DCD# does the actual work — which is exactly the variant Richard hit. Picking DCD only sidesteps the ambiguity.

Swap Dit/Dah with the existing **Paddle Swap** checkbox if your paddles are wired right-handed.

This matches how the macOS Ham Radio Apps (§3.2.3 of the User Guide) and SmartSDR-for-MacOS route the same TRS Ring signal.

## Build verified clean

- [x] AetherSDR builds clean
- [x] All 320 targets including every test target

## Test plan

- [ ] CI: build / check-paths / check-windows / CodeQL
- [ ] @LB2EG validation on real HaliKey Serial hardware once a build drops (Linux + macOS test paths)
- [ ] Sanity smoke: verify CTS-only and DSR-only configs still work unchanged after this lands

73, Jeremy KK7GWY & Claude (AI dev partner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)