### PR TITLE
feat(smartcat): SmartCAT TCP server — TS-2000 and FlexCAT dialects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,9 @@ set(CORE_SOURCES
     src/core/PerfTelemetry.cpp
     src/core/RigctlProtocol.cpp
     src/core/RigctlPty.cpp
+    src/core/SmartCatProtocol.cpp
+    src/core/SmartCatSession.cpp
+    src/core/CatPort.cpp
     src/core/SmartLinkClient.cpp
     src/core/WanConnection.cpp
     src/core/DxClusterClient.cpp
@@ -467,7 +470,6 @@ set(CORE_SOURCES
     src/core/MqttSettings.cpp
     src/core/SpotCommandPolicy.cpp
     src/core/SpotModeResolver.cpp
-    src/core/RigctlServer.cpp
     src/core/TciServer.cpp
     src/core/TciProtocol.cpp
     src/core/MqttClient.cpp
@@ -1867,6 +1869,22 @@ add_executable(rigctld_test
 )
 target_include_directories(rigctld_test PRIVATE src)
 target_link_libraries(rigctld_test PRIVATE Qt6::Core Qt6::Network)
+
+# Integration tests — require a running AetherSDR instance with CAT ports enabled.
+# Not added to ctest; run manually:
+#   ./build/CAT_TS-2000_test  [--host HOST] [--port PORT] [--ptt] [--cw] [--pty PATH]
+#   ./build/CAT_Flex_test     [--host HOST] [--port PORT] [--ptt] [--cw] [--pty PATH]
+add_executable(CAT_TS-2000_test
+    tests/CAT_TS-2000_test.cpp
+)
+target_include_directories(CAT_TS-2000_test PRIVATE src)
+target_link_libraries(CAT_TS-2000_test PRIVATE Qt6::Core Qt6::Network)
+
+add_executable(CAT_Flex_test
+    tests/CAT_Flex_test.cpp
+)
+target_include_directories(CAT_Flex_test PRIVATE src)
+target_link_libraries(CAT_Flex_test PRIVATE Qt6::Core Qt6::Network)
 
 
 # ── Install rules ────────────────────────────────────────────────────────────

--- a/src/core/CatPort.cpp
+++ b/src/core/CatPort.cpp
@@ -1,0 +1,373 @@
+#include "CatPort.h"
+#include "LogManager.h"
+#include "RigctlProtocol.h"
+#include "SmartCatProtocol.h"
+#include "SmartCatSession.h"
+#include "models/RadioModel.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QStandardPaths>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QSocketNotifier>
+
+#ifndef Q_OS_WIN
+#include <unistd.h>
+#include <fcntl.h>
+#include <termios.h>
+#include <sys/stat.h>
+#ifdef Q_OS_MAC
+#include <util.h>
+#else
+#include <pty.h>
+#endif
+#endif
+
+namespace AetherSDR {
+
+// Per-user symlink path — mirrors RigctlPty::defaultSymlinkPath() exactly
+// (GHSA-qxhr-cwrc-pvrm: no /tmp cross-user collisions, no TOCTOU window).
+QString CatPort::defaultSymlinkPath(int portIndex)
+{
+    QString leaf;
+    if (portIndex >= 0 && portIndex < 8) {
+        const char letter = static_cast<char>('A' + portIndex);
+        leaf = QStringLiteral("cat-%1").arg(QChar(letter));
+    } else {
+        leaf = QStringLiteral("cat-%1").arg(portIndex);
+    }
+
+    QString base = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+    if (base.isEmpty())
+        base = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    if (base.isEmpty())
+        base = QDir::homePath() + QStringLiteral("/.cache/aethersdr");
+
+    if (!base.contains(QStringLiteral("aethersdr"), Qt::CaseInsensitive))
+        base += QStringLiteral("/aethersdr");
+
+    return base + QChar('/') + leaf;
+}
+
+CatPort::CatPort(RadioModel* model, QObject* parent)
+    : QObject(parent)
+    , m_model(model)
+{}
+
+CatPort::~CatPort()
+{
+    stop();
+}
+
+bool CatPort::start(quint16 port)
+{
+    if (isRunning()) return true;
+
+    m_tcpServer = new QTcpServer(this);
+    if (!m_tcpServer->listen(QHostAddress::Any, port)) {
+        qCWarning(lcCat) << "CatPort: failed to bind port" << port
+                         << m_tcpServer->errorString();
+        delete m_tcpServer;
+        m_tcpServer = nullptr;
+        return false;
+    }
+
+    connect(m_tcpServer, &QTcpServer::newConnection,
+            this, &CatPort::onNewConnection);
+
+    startPty();
+
+    qCInfo(lcCat) << "CatPort: listening on port" << port
+                  << "dialect" << static_cast<int>(m_dialect);
+    return true;
+}
+
+void CatPort::stop()
+{
+    stopPty();
+
+    if (m_tcpServer) {
+        m_tcpServer->close();
+        delete m_tcpServer;
+        m_tcpServer = nullptr;
+    }
+
+    // Close all rigctld clients
+    for (auto& c : m_rigctlClients) {
+        c.socket->abort();
+        delete c.protocol;
+    }
+    m_rigctlClients.clear();
+
+    // Close all SmartCAT sessions (sessions own their sockets)
+    for (auto* s : m_catSessions)
+        s->deleteLater();
+    m_catSessions.clear();
+
+    emit clientCountChanged(0);
+}
+
+bool CatPort::isRunning() const
+{
+    return m_tcpServer && m_tcpServer->isListening();
+}
+
+quint16 CatPort::port() const
+{
+    return m_tcpServer ? m_tcpServer->serverPort() : 0;
+}
+
+int CatPort::clientCount() const
+{
+    return m_rigctlClients.size() + m_catSessions.size();
+}
+
+QString CatPort::ptyPath() const
+{
+#ifndef Q_OS_WIN
+    if (!isRunning()) return {};
+    if (!m_symlinkPath.isEmpty())
+        return m_symlinkPath;
+    return m_ptySlavePath;
+#else
+    return {};
+#endif
+}
+
+// ── New TCP connection ───────────────────────────────────────────────────────
+
+void CatPort::onNewConnection()
+{
+    QTcpSocket* socket = m_tcpServer->nextPendingConnection();
+    if (!socket) return;
+
+    if (m_dialect == CatDialect::Rigctld) {
+        RigctlClient c;
+        c.socket   = socket;
+        c.protocol = new RigctlProtocol(m_model);
+        c.protocol->setSliceIndex(m_vfoA);
+        m_rigctlClients.append(c);
+
+        connect(socket, &QTcpSocket::readyRead,
+                this, &CatPort::onRigctlData);
+        connect(socket, &QTcpSocket::disconnected,
+                this, &CatPort::onRigctlDisconnected);
+
+        qCInfo(lcCat) << "CatPort: rigctld client connected on port" << port();
+    } else {
+        bool flex = (m_dialect == CatDialect::FlexCAT);
+        auto* session = new SmartCatSession(socket, m_model,
+                                            m_vfoA, m_vfoB, flex, this);
+        m_catSessions.append(session);
+
+        connect(session, &SmartCatSession::sessionEnded,
+                this, &CatPort::onCatSessionEnded);
+
+        qCInfo(lcCat) << "CatPort: SmartCAT client connected on port" << port()
+                      << "(flex=" << flex << ")";
+    }
+
+    emit clientCountChanged(clientCount());
+}
+
+// ── Rigctld TCP I/O ──────────────────────────────────────────────────────────
+
+void CatPort::onRigctlData()
+{
+    auto* socket = qobject_cast<QTcpSocket*>(sender());
+    if (!socket) return;
+
+    for (auto& c : m_rigctlClients) {
+        if (c.socket != socket) continue;
+        c.buffer.append(socket->readAll());
+
+        while (true) {
+            int nlPos = c.buffer.indexOf('\n');
+            if (nlPos < 0) nlPos = c.buffer.indexOf('\r');
+            if (nlPos < 0) break;
+
+            QString line = QString::fromUtf8(c.buffer.left(nlPos)).trimmed();
+            c.buffer.remove(0, nlPos + 1);
+            if (line.isEmpty()) continue;
+
+            QString resp = c.protocol->handleLine(line);
+            if (!resp.isEmpty())
+                socket->write(resp.toUtf8());
+        }
+        break;
+    }
+}
+
+void CatPort::onRigctlDisconnected()
+{
+    auto* socket = qobject_cast<QTcpSocket*>(sender());
+    if (!socket) return;
+
+    for (int i = 0; i < m_rigctlClients.size(); ++i) {
+        if (m_rigctlClients[i].socket == socket) {
+            delete m_rigctlClients[i].protocol;
+            m_rigctlClients.removeAt(i);
+            socket->deleteLater();
+            qCInfo(lcCat) << "CatPort: rigctld client disconnected";
+            break;
+        }
+    }
+    emit clientCountChanged(clientCount());
+}
+
+// ── SmartCAT session ended ───────────────────────────────────────────────────
+
+void CatPort::onCatSessionEnded(SmartCatSession* session)
+{
+    m_catSessions.removeOne(session);
+    session->deleteLater();
+    qCInfo(lcCat) << "CatPort: SmartCAT session ended";
+    emit clientCountChanged(clientCount());
+}
+
+// ── PTY ─────────────────────────────────────────────────────────────────────
+
+void CatPort::startPty()
+{
+#ifndef Q_OS_WIN
+    char slaveName[256] = {};
+    if (openpty(&m_ptyMasterFd, &m_ptySlaveFd, slaveName, nullptr, nullptr) != 0) {
+        qCWarning(lcCat) << "CatPort: openpty() failed";
+        return;
+    }
+
+    m_ptySlavePath = QString::fromLocal8Bit(slaveName);
+
+    int flags = fcntl(m_ptyMasterFd, F_GETFL);
+    fcntl(m_ptyMasterFd, F_SETFL, flags | O_NONBLOCK);
+
+    struct termios tio;
+    if (tcgetattr(m_ptySlaveFd, &tio) == 0) {
+        cfmakeraw(&tio);
+        tio.c_cc[VMIN]  = 1;
+        tio.c_cc[VTIME] = 0;
+        tcsetattr(m_ptySlaveFd, TCSANOW, &tio);
+    }
+
+    if (!m_symlinkPath.isEmpty()) {
+        // Atomic replace: symlink to a tmp name in the same dir, then rename().
+        // rename() is atomic; avoids the TOCTOU window of unlink+symlink.
+        const QFileInfo info(m_symlinkPath);
+        const QString parentDir = info.absolutePath();
+        if (!QDir().mkpath(parentDir))
+            qCWarning(lcCat) << "CatPort: failed to mkpath" << parentDir;
+        if (::chmod(parentDir.toLocal8Bit().constData(), 0700) != 0)
+            qCWarning(lcCat) << "CatPort: chmod 0700 failed on" << parentDir;
+
+        const QString tmpPath = m_symlinkPath + QStringLiteral(".tmp");
+        ::unlink(tmpPath.toLocal8Bit().constData());
+        if (::symlink(slaveName, tmpPath.toLocal8Bit().constData()) == 0) {
+            if (::rename(tmpPath.toLocal8Bit().constData(),
+                         m_symlinkPath.toLocal8Bit().constData()) != 0) {
+                ::unlink(tmpPath.toLocal8Bit().constData());
+                qCWarning(lcCat) << "CatPort: symlink rename failed:" << m_symlinkPath;
+            }
+        } else {
+            qCWarning(lcCat) << "CatPort: symlink (tmp) failed:" << tmpPath;
+        }
+    }
+
+    // Create the right protocol handler for this dialect
+    if (m_dialect == CatDialect::Rigctld) {
+        m_ptyRigctlProtocol = new RigctlProtocol(m_model);
+        m_ptyRigctlProtocol->setSliceIndex(m_vfoA);
+    } else {
+        bool flex = (m_dialect == CatDialect::FlexCAT);
+        m_ptyCatProtocol = new SmartCatProtocol(m_model, m_vfoA, m_vfoB, flex);
+    }
+
+    m_ptyNotifier = new QSocketNotifier(m_ptyMasterFd, QSocketNotifier::Read, this);
+    connect(m_ptyNotifier, &QSocketNotifier::activated,
+            this, &CatPort::onPtyData);
+
+    qCInfo(lcCat) << "CatPort: PTY started on" << m_ptySlavePath
+                  << "symlink:" << m_symlinkPath;
+    emit ptyPathChanged(ptyPath());
+#endif
+}
+
+void CatPort::stopPty()
+{
+#ifndef Q_OS_WIN
+    if (m_ptyMasterFd < 0) return;
+
+    delete m_ptyNotifier;
+    m_ptyNotifier = nullptr;
+
+    delete m_ptyRigctlProtocol;
+    m_ptyRigctlProtocol = nullptr;
+    delete m_ptyCatProtocol;
+    m_ptyCatProtocol = nullptr;
+
+    ::close(m_ptyMasterFd);
+    ::close(m_ptySlaveFd);
+    m_ptyMasterFd = -1;
+    m_ptySlaveFd  = -1;
+    m_ptyBuffer.clear();
+
+    if (!m_symlinkPath.isEmpty())
+        ::unlink(m_symlinkPath.toLocal8Bit().constData());
+
+    m_ptySlavePath.clear();
+    emit ptyPathChanged({});
+    qCInfo(lcCat) << "CatPort: PTY stopped";
+#endif
+}
+
+void CatPort::onPtyData()
+{
+#ifndef Q_OS_WIN
+    char buf[4096];
+    ssize_t n = ::read(m_ptyMasterFd, buf, sizeof(buf));
+    if (n <= 0) return;
+
+    m_ptyBuffer.append(buf, static_cast<int>(n));
+
+    // Rigctld framing: newline-delimited
+    if (m_dialect == CatDialect::Rigctld) {
+        while (true) {
+            int nlPos = m_ptyBuffer.indexOf('\n');
+            if (nlPos < 0) nlPos = m_ptyBuffer.indexOf('\r');
+            if (nlPos < 0) break;
+
+            QString line = QString::fromUtf8(m_ptyBuffer.left(nlPos)).trimmed();
+            m_ptyBuffer.remove(0, nlPos + 1);
+            if (line.isEmpty()) continue;
+
+            if (m_ptyRigctlProtocol) {
+                QString resp = m_ptyRigctlProtocol->handleLine(line);
+                if (!resp.isEmpty()) {
+                    QByteArray data = resp.toUtf8();
+                    if (::write(m_ptyMasterFd, data.constData(), data.size()) < 0)
+                        qCWarning(lcCat) << "CatPort: PTY write failed";
+                }
+            }
+        }
+    } else {
+        // SmartCAT framing: semicolon-delimited
+        int pos;
+        while ((pos = m_ptyBuffer.indexOf(';')) >= 0) {
+            QString cmd = QString::fromUtf8(m_ptyBuffer.left(pos)).trimmed();
+            m_ptyBuffer.remove(0, pos + 1);
+            if (cmd.isEmpty()) continue;
+
+            if (m_ptyCatProtocol) {
+                QString resp = m_ptyCatProtocol->processCommand(cmd);
+                if (!resp.isEmpty()) {
+                    QByteArray data = resp.toUtf8();
+                    if (::write(m_ptyMasterFd, data.constData(), data.size()) < 0)
+                        qCWarning(lcCat) << "CatPort: PTY write failed";
+                }
+            }
+        }
+    }
+#endif
+}
+
+} // namespace AetherSDR

--- a/src/core/CatPort.h
+++ b/src/core/CatPort.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <QObject>
+#include <QList>
+#include <QString>
+
+class QTcpServer;
+class QTcpSocket;
+class QSocketNotifier;
+
+namespace AetherSDR {
+
+class RadioModel;
+class RigctlProtocol;
+class SmartCatProtocol;
+class SmartCatSession;
+
+enum class CatDialect {
+    Rigctld,   // Hamlib rigctld protocol (newline-framed)
+    TS2000,    // Kenwood TS-2000 CAT, no Flex ZZ extensions
+    FlexCAT    // Kenwood TS-2000 + FlexRadio ZZ extensions
+};
+
+// Unified CAT port: one TCP server + one PTY (non-Windows), any dialect.
+// Replaces the separate RigctlServer / SmartCatServer / RigctlPty hierarchy.
+//
+// Dialect and VFO assignments must be set before calling start().
+// They cannot be changed while the port is running (per SmartSDR for Mac UX).
+class CatPort : public QObject {
+    Q_OBJECT
+
+public:
+    static constexpr int kVfoNone = -1;  // VFO B = simplex
+
+    explicit CatPort(RadioModel* model, QObject* parent = nullptr);
+    ~CatPort() override;
+
+    bool start(quint16 port);
+    void stop();
+
+    bool    isRunning() const;
+    quint16 port() const;
+    int     clientCount() const;
+    QString ptyPath() const;  // empty on Windows or if PTY not running
+
+    // Config (effective only when stopped)
+    void       setDialect(CatDialect d) { m_dialect = d; }
+    CatDialect dialect() const          { return m_dialect; }
+    void       setVfoA(int idx)         { m_vfoA = idx; }
+    void       setVfoB(int idx)         { m_vfoB = idx; }
+    int        vfoA() const             { return m_vfoA; }
+    int        vfoB() const             { return m_vfoB; }
+
+    // Per-user symlink path for the PTY slave device (GHSA-qxhr-cwrc-pvrm).
+    // Mirrors RigctlPty::defaultSymlinkPath() — same platform/path logic.
+    static QString defaultSymlinkPath(int portIndex);
+    void    setSymlinkPath(const QString& path) { m_symlinkPath = path; }
+    QString symlinkPath() const                 { return m_symlinkPath; }
+
+signals:
+    void clientCountChanged(int count);
+    void ptyPathChanged(const QString& path);
+
+private slots:
+    void onNewConnection();
+    // Rigctld TCP I/O
+    void onRigctlData();
+    void onRigctlDisconnected();
+    // SmartCAT TCP
+    void onCatSessionEnded(SmartCatSession* session);
+    // PTY data
+    void onPtyData();
+
+private:
+    void startPty();
+    void stopPty();
+
+    // Rigctld client state (inline, mirrors former RigctlServer)
+    struct RigctlClient {
+        QTcpSocket*     socket{nullptr};
+        RigctlProtocol* protocol{nullptr};
+        QByteArray      buffer;
+    };
+
+    RadioModel*             m_model;
+    CatDialect              m_dialect{CatDialect::Rigctld};
+    int                     m_vfoA{0};
+    int                     m_vfoB{kVfoNone};
+    QString                 m_symlinkPath;
+
+    QTcpServer*             m_tcpServer{nullptr};
+    QList<RigctlClient>     m_rigctlClients;
+    QList<SmartCatSession*> m_catSessions;
+
+    // PTY (non-Windows only)
+#ifndef Q_OS_WIN
+    int              m_ptyMasterFd{-1};
+    int              m_ptySlaveFd{-1};
+    QString          m_ptySlavePath;
+    QSocketNotifier* m_ptyNotifier{nullptr};
+    QByteArray       m_ptyBuffer;
+    // Protocol handler for PTY (one of these is active, the other null)
+    RigctlProtocol*  m_ptyRigctlProtocol{nullptr};
+    SmartCatProtocol* m_ptyCatProtocol{nullptr};
+#endif
+};
+
+} // namespace AetherSDR

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -1,4 +1,5 @@
 #include "RigctlProtocol.h"
+#include "LogManager.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
@@ -243,6 +244,17 @@ QString RigctlProtocol::rprt(int code) const
 // ── Main entry point ────────────────────────────────────────────────────────
 
 QString RigctlProtocol::handleLine(const QString& line)
+{
+    const QString trimmedIn = line.trimmed();
+    if (!trimmedIn.isEmpty())
+        qCDebug(lcCat).noquote() << "rigctld ←" << trimmedIn;
+    const QString resp = handleLineImpl(line);
+    if (!resp.isEmpty())
+        qCDebug(lcCat).noquote() << "rigctld →" << resp.trimmed();
+    return resp;
+}
+
+QString RigctlProtocol::handleLineImpl(const QString& line)
 {
     if (m_pendingMorseLine) {
         m_pendingMorseLine = false;

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -29,6 +29,8 @@ public:
     bool extendedMode() const     { return m_extended; }
 
 private:
+    QString handleLineImpl(const QString& line);
+
     // Process a single command (short or long form).
     // Returns the response string.
     QString processCommand(const QString& cmd);

--- a/src/core/SmartCatProtocol.cpp
+++ b/src/core/SmartCatProtocol.cpp
@@ -1,0 +1,1462 @@
+#include "SmartCatProtocol.h"
+#include "LogManager.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+#include "models/TransmitModel.h"
+#include "models/CwxModel.h"
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+// ── Mode conversion tables ──────────────────────────────────────────────────
+//
+// SmartSDR mode strings verified against FLEX-8600 fw v1.4.0.0.
+// Kenwood 1-digit codes: 1=LSB 2=USB 3=CW 4=FM 5=AM 6=DIGL 9=DIGU
+// ZZ 2-digit codes from SmartSDR CAT User Guide Rev. v4.1.5:
+//   00=LSB 01=USB 03=CWL 04=CWU(CW) 05=FM 06=AM 07=DIGU 09=DIGL
+//   10=SAM 11=NFM 12=DFM 20=FDV 30=RTTY 40=DSTR
+
+QString SmartCatProtocol::modeToKenwood(const QString& ssdrMode)
+{
+    if (ssdrMode == "LSB")  return "1";
+    if (ssdrMode == "USB")  return "2";
+    if (ssdrMode == "CW")   return "3";
+    if (ssdrMode == "CWL")  return "3";
+    if (ssdrMode == "FM")   return "4";
+    if (ssdrMode == "NFM")  return "4";
+    if (ssdrMode == "AM")   return "5";
+    if (ssdrMode == "SAM")  return "5";
+    if (ssdrMode == "DIGL") return "6";
+    if (ssdrMode == "RTTY") return "6";
+    if (ssdrMode == "DIGU") return "9";
+    if (ssdrMode == "FDV")  return "9";
+    return "2";
+}
+
+QString SmartCatProtocol::modeToZZ(const QString& ssdrMode)
+{
+    if (ssdrMode == "LSB")  return "00";
+    if (ssdrMode == "USB")  return "01";
+    if (ssdrMode == "CWL")  return "03";
+    if (ssdrMode == "CW")   return "04";
+    if (ssdrMode == "FM")   return "05";
+    if (ssdrMode == "AM")   return "06";
+    if (ssdrMode == "DIGU") return "07";
+    if (ssdrMode == "DIGL") return "09";
+    if (ssdrMode == "SAM")  return "10";
+    if (ssdrMode == "NFM")  return "11";
+    if (ssdrMode == "DFM")  return "12";
+    if (ssdrMode == "FDV")  return "20";
+    if (ssdrMode == "RTTY") return "30";
+    if (ssdrMode == "DSTR") return "40";
+    return "01";
+}
+
+QString SmartCatProtocol::kenwoodToSSDR(QChar c)
+{
+    switch (c.toLatin1()) {
+        case '1': return "LSB";
+        case '2': return "USB";
+        case '3': return "CW";
+        case '4': return "FM";
+        case '5': return "AM";
+        case '6': return "DIGL";
+        case '9': return "DIGU";
+        default:  return "USB";
+    }
+}
+
+QString SmartCatProtocol::zzToSSDR(const QString& two)
+{
+    if (two == "00") return "LSB";
+    if (two == "01") return "USB";
+    if (two == "03") return "CWL";
+    if (two == "04") return "CW";
+    if (two == "05") return "FM";
+    if (two == "06") return "AM";
+    if (two == "07") return "DIGU";
+    if (two == "09") return "DIGL";
+    if (two == "10") return "SAM";
+    if (two == "11") return "NFM";
+    if (two == "12") return "DFM";
+    if (two == "20") return "FDV";
+    if (two == "30") return "RTTY";
+    if (two == "40") return "DSTR";
+    return "USB";
+}
+
+QString SmartCatProtocol::freqField(double mhz)
+{
+    quint64 hz = static_cast<quint64>(mhz * 1e6 + 0.5);
+    return QString::number(hz).rightJustified(11, '0');
+}
+
+// ── Constructor ─────────────────────────────────────────────────────────────
+
+SmartCatProtocol::SmartCatProtocol(RadioModel* model, int vfoA, int vfoB,
+                                   bool flexExtensions)
+    : m_model(model)
+    , m_vfoA(vfoA)
+    , m_vfoB(vfoB)
+    , m_flexExtensions(flexExtensions)
+{}
+
+// ── Slice accessors ─────────────────────────────────────────────────────────
+
+SliceModel* SmartCatProtocol::sliceA() const
+{
+    if (!m_model) return nullptr;
+    for (auto* s : m_model->slices()) {
+        if (s->sliceId() == m_vfoA) return s;
+    }
+    const auto& slices = m_model->slices();
+    return slices.isEmpty() ? nullptr : slices.first();
+}
+
+SliceModel* SmartCatProtocol::sliceB() const
+{
+    if (m_vfoB < 0 || !m_model) return nullptr;
+    for (auto* s : m_model->slices()) {
+        if (s->sliceId() == m_vfoB) return s;
+    }
+    return nullptr;
+}
+
+// ── Command dispatcher ──────────────────────────────────────────────────────
+
+QString SmartCatProtocol::processCommand(const QString& cmd)
+{
+    if (!cmd.isEmpty())
+        qCDebug(lcCat).noquote() << "CAT ←" << cmd;
+    const QString resp = processCommandImpl(cmd);
+    if (!resp.isEmpty())
+        qCDebug(lcCat).noquote() << "CAT →" << resp.trimmed();
+    return resp;
+}
+
+QString SmartCatProtocol::processCommandImpl(const QString& cmd)
+{
+    if (cmd.isEmpty()) return {};
+
+    const QString upper = cmd.toUpper();
+
+    if (m_flexExtensions && upper.startsWith("ZZ") && upper.size() >= 4) {
+        const QString name = upper.left(4);
+        const QString arg  = cmd.mid(4);
+        if (name == "ZZFA") {
+            // cmdFA returns "FA...;"; prepend "ZZ" so the response matches the command prefix.
+            // Set commands and errors (?;) pass through unchanged.
+            QString r = cmdFA(arg);
+            return r.startsWith(QLatin1String("FA")) ? QStringLiteral("ZZ") + r : r;
+        }
+        if (name == "ZZFB") {
+            QString r = cmdFB(arg);
+            return r.startsWith(QLatin1String("FB")) ? QStringLiteral("ZZ") + r : r;
+        }
+        if (name == "ZZMD") return cmdZZMD(arg);
+        if (name == "ZZME") return cmdZZME(arg);
+        if (name == "ZZIF") return cmdZZIF();
+        if (name == "ZZAI") {
+            // AI query — the session handles enable/disable; we just report state
+            if (arg.isEmpty() || arg == "?")
+                return QString("ZZAI%1;").arg(m_aiEnabled ? "01" : "00");
+            return {};  // set handled by session
+        }
+        if (name == "ZZSW") return cmdZZSW(arg);
+        if (name == "ZZTX") return cmdTX(arg);
+        if (name == "ZZRX") return cmdRX();
+        if (name == "ZZSM") return cmdZZSM(arg);
+        // ── Tier-2 ZZ commands ──────────────────────────────────────────────
+        if (name == "ZZAG") return cmdZZAG(arg);
+        if (name == "ZZAR") return cmdZZAR(arg);
+        if (name == "ZZAS") return cmdZZAS(arg);
+        if (name == "ZZBI") return cmdZZBI(arg);
+        if (name == "ZZDE") return cmdZZDE(arg);
+        if (name == "ZZFI") return cmdZZFI(arg);
+        if (name == "ZZFJ") return cmdZZFJ(arg);
+        if (name == "ZZFR") return cmdZZFR();
+        if (name == "ZZFT") { m_splitEnabled = !m_splitEnabled; return {}; }
+        if (name == "ZZGT") return cmdZZGT(arg);
+        if (name == "ZZLE") return cmdZZLE(arg);
+        if (name == "ZZLB") return cmdZZLB(arg);
+        if (name == "ZZLF") return cmdZZLF(arg);
+        if (name == "ZZMA") return cmdZZMA(arg);
+        if (name == "ZZMB") return cmdZZMB(arg);
+        if (name == "ZZMG") return cmdZZMG(arg);
+        if (name == "ZZNL") return cmdZZNL(arg);
+        if (name == "ZZNR") return cmdZZNR(arg);
+        if (name == "ZZPC") return cmdZZPC(arg);
+        if (name == "ZZRC") return cmdZZRC();
+        if (name == "ZZRD") return cmdZZRD(arg);
+        if (name == "ZZRG") return cmdZZRG(arg);
+        if (name == "ZZRT") return cmdZZRT(arg);
+        if (name == "ZZRU") return cmdZZRU(arg);
+        if (name == "ZZRW") return cmdZZRW(arg);
+        if (name == "ZZRY") return cmdZZRY(arg);
+        if (name == "ZZXC") return cmdZZXC();
+        if (name == "ZZXG") return cmdZZXG(arg);
+        if (name == "ZZXS") return cmdZZXS(arg);
+        return "?;";
+    }
+
+    if (upper.size() >= 2) {
+        const QString name = upper.left(2);
+        const QString arg  = cmd.mid(2);
+        if (name == "BY") return cmdBY(arg);
+        if (name == "DN") return cmdDN(arg);
+        if (name == "FA") return cmdFA(arg);
+        if (name == "FB") return cmdFB(arg);
+        if (name == "FW") return cmdFW(arg);
+        if (name == "MD") return cmdMD(arg);
+        if (name == "IF") return cmdIF();
+        if (name == "AI") {
+            // AI query — report state; session handles wiring
+            if (arg.isEmpty())
+                return QString("AI%1;").arg(m_aiEnabled ? 1 : 0);
+            return {};  // set handled by session
+        }
+        if (name == "FT") return cmdFT(arg);
+        if (name == "FR") return cmdFR(arg);
+        if (name == "LK") return cmdLK(arg);
+        if (name == "MG") return cmdMG(arg);
+        if (name == "NB") return cmdNB(arg);
+        if (name == "NL") return cmdNL(arg);
+        if (name == "NR") return cmdNR(arg);
+        if (name == "NT") return cmdNT(arg);
+        if (name == "OI") return cmdOI();
+        if (name == "PA") return cmdPA(arg);
+        if (name == "TX") return cmdTX(arg);
+        if (name == "RX") return cmdRX();
+        if (name == "ID") return cmdID();
+        if (name == "PS") return cmdPS();
+        if (name == "RA") return cmdRA(arg);
+        if (name == "RL") return cmdRL(arg);
+        if (name == "RM") return cmdRM(arg);
+        if (name == "SM") return cmdSM(arg);
+        if (name == "SQ") return cmdSQ(arg);
+        if (name == "TY") return cmdTY(arg);
+        if (name == "UP") return cmdUP(arg);
+        // ── Tier-2 base commands ─────────────────────────────────────────────
+        if (name == "AG") return cmdAG(arg);
+        if (name == "GT") return cmdGT(arg);
+        if (name == "KS") return cmdKS(arg);
+        if (name == "KY") return cmdKY(arg);
+        if (name == "PC") return cmdPC(arg);
+        if (name == "PT") return cmdPT(arg);
+        if (name == "RC") return cmdRC();
+        if (name == "RD") return cmdRD(arg);
+        if (name == "RG") return cmdRG(arg);
+        if (name == "RT") return cmdRT(arg);
+        if (name == "RU") return cmdRU(arg);
+        if (name == "SL") return cmdSL(arg);
+        if (name == "SH") return cmdSH(arg);
+        if (name == "VX") {
+            // VOX enable/disable — stub; report VOX off, accept set silently.
+            if (arg.isEmpty()) return QStringLiteral("VX0;");
+            return {};
+        }
+        if (name == "XT") return cmdXT(arg);
+        return "?;";
+    }
+
+    return "?;";
+}
+
+// ── FA / ZZFA — VFO A frequency ─────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdFA(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return "FA" + freqField(a->frequency()) + ";";
+    bool ok;
+    double hz = arg.toDouble(&ok);
+    if (!ok) return "?;";
+    a->setFrequency(hz / 1e6);
+    return {};
+}
+
+// ── FB / ZZFB — VFO B frequency ─────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdFB(const QString& arg)
+{
+    SliceModel* b = sliceB();
+    if (!b) {
+        SliceModel* a = sliceA();
+        if (!a) return "?;";
+        if (arg.isEmpty())
+            return "FB" + freqField(a->frequency()) + ";";
+        return {};
+    }
+    if (arg.isEmpty())
+        return "FB" + freqField(b->frequency()) + ";";
+    bool ok;
+    double hz = arg.toDouble(&ok);
+    if (!ok) return "?;";
+    b->setFrequency(hz / 1e6);
+    return {};
+}
+
+// ── MD — mode get/set (Kenwood 1-digit) ──────────────────────────────────────
+
+QString SmartCatProtocol::cmdMD(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return "MD" + modeToKenwood(a->mode()) + ";";
+    if (arg.size() != 1) return "?;";
+    a->setMode(kenwoodToSSDR(arg[0]));
+    return {};
+}
+
+// ── ZZMD — mode get/set (ZZ 2-digit) ─────────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZMD(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return "ZZMD" + modeToZZ(a->mode()) + ";";
+    if (arg.size() != 2) return "?;";
+    a->setMode(zzToSSDR(arg));
+    return {};
+}
+
+// ── ZZME — VFO B mode get/set ────────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZME(const QString& arg)
+{
+    SliceModel* b = sliceB();
+    if (!b) return "?;";
+    if (arg.isEmpty())
+        return "ZZME" + modeToZZ(b->mode()) + ";";
+    if (arg.size() != 2) return "?;";
+    b->setMode(zzToSSDR(arg));
+    return {};
+}
+
+// ── IF — composite Kenwood TS-2000 status (35-char body) ─────────────────────
+//
+// P1[0-10]  11-digit VFO-A Hz    P2[11-15] step 5 digits
+// P3[16-21] RIT+sign+5            P4[22] RIT  P5[23] XIT
+// P6[24-25] memory                P7[26] TX/RX  P8[27] mode
+// P9[28] function  P10[29] scan   P11[30] split
+// P12[31] tone  P13[32-33] CTCSS  P14[34] DCS
+
+QString SmartCatProtocol::cmdIF()
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+
+    QString body;
+    body += freqField(a->frequency());
+    body += QStringLiteral("00010");
+    body += QStringLiteral("+00000");
+    body += '0';
+    body += '0';
+    body += QStringLiteral("00");
+    body += m_model->isRadioTransmitting() ? '1' : '0';
+    body += modeToKenwood(a->mode());
+    body += '0';
+    body += '0';
+    body += m_splitEnabled ? '1' : '0';
+    body += '0';
+    body += QStringLiteral("00");
+    body += '0';
+
+    return "IF" + body + ";";
+}
+
+// ── ZZIF — SmartSDR extended IF ───────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZIF()
+{
+    QString resp = cmdIF();
+    if (resp == "?;") return "?;";
+    return "ZZ" + resp;
+}
+
+// ── FT / ZZSW — split enable ─────────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdFT(const QString& arg)
+{
+    if (arg.isEmpty())
+        return QString("FT%1;").arg(m_splitEnabled ? 1 : 0);
+    m_splitEnabled = (arg == "1");
+    return {};
+}
+
+QString SmartCatProtocol::cmdZZSW(const QString& arg)
+{
+    if (arg.isEmpty())
+        return QString("ZZSW%1;").arg(m_splitEnabled ? "1" : "0");
+    m_splitEnabled = (arg == "1");
+    return {};
+}
+
+// ── FR — RX VFO select (accepted, no-op) ─────────────────────────────────────
+
+QString SmartCatProtocol::cmdFR(const QString& /*arg*/)
+{
+    return {};
+}
+
+// ── TX / ZZTX — PTT on ───────────────────────────────────────────────────────
+// P1: 0 = PTT off (alias for RX;), 1/2 = PTT on selecting mic source.
+// Use PttSource::Dax to match rigctld: CAT callers must bypass local voice-mode
+// interlocks so the radio itself is authoritative.
+
+QString SmartCatProtocol::cmdTX(const QString& arg)
+{
+    if (arg == "0") return cmdRX();
+    m_pttAssertedByMe = true;
+    m_model->setTransmit(true, TransmitModel::PttSource::Dax);
+    return {};
+}
+
+// ── RX / ZZRX — PTT off ──────────────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdRX()
+{
+    m_pttAssertedByMe = false;
+    m_model->setTransmit(false, TransmitModel::PttSource::Dax);
+    return {};
+}
+
+// ── PTT safety release ───────────────────────────────────────────────────────
+
+void SmartCatProtocol::releasePtt()
+{
+    if (!m_pttAssertedByMe) return;
+    m_pttAssertedByMe = false;
+    m_model->setTransmit(false, TransmitModel::PttSource::Dax);
+}
+
+// ── ID — rig identification ───────────────────────────────────────────────────
+// Table from SmartSDR CAT User Guide Rev. v4.1.5:
+//   904=FLEX-6700  905=FLEX-6500  906=FLEX-6700R  907=FLEX-6300
+//   908=FLEX-6400/M  909=FLEX-6600/M  910=FLEX-8400/M  911=FLEX-8600/M
+//   930=AU-510/M  931=AU-520/M
+
+QString SmartCatProtocol::cmdID()
+{
+    // TS-2000 dialect: identify as Kenwood TS-2000 (ID019 per Kenwood CAT spec)
+    if (!m_flexExtensions)
+        return QStringLiteral("ID019;");
+
+    const QString m = m_model->model();
+    if (m.contains("6700R")) return QStringLiteral("ID906;");
+    if (m.contains("6700"))  return QStringLiteral("ID904;");
+    if (m.contains("6500"))  return QStringLiteral("ID905;");
+    if (m.contains("6300"))  return QStringLiteral("ID907;");
+    if (m.contains("6400"))  return QStringLiteral("ID908;");
+    if (m.contains("6600"))  return QStringLiteral("ID909;");
+    if (m.contains("8400"))  return QStringLiteral("ID910;");
+    if (m.contains("8600"))  return QStringLiteral("ID911;");
+    if (m.contains("AU-510")) return QStringLiteral("ID930;");
+    if (m.contains("AU-520")) return QStringLiteral("ID931;");
+    return QStringLiteral("ID919;");
+}
+
+// ── PS — power status ────────────────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdPS()
+{
+    return QStringLiteral("PS1;");
+}
+
+// ── SM / ZZSM — S-meter (Tier 1: always 0) ──────────────────────────────────
+
+QString SmartCatProtocol::cmdSM(const QString& /*arg*/)
+{
+    return QStringLiteral("SM00000;");
+}
+
+QString SmartCatProtocol::cmdZZSM(const QString& /*arg*/)
+{
+    return QStringLiteral("ZZSM0000;");
+}
+
+// ── Tier-2 helpers (file-scope) ──────────────────────────────────────────────
+
+static QString fmt3(int v)
+{
+    return QString::number(v).rightJustified(3, '0');
+}
+
+static QString ritField(int hz)
+{
+    return (hz >= 0 ? QStringLiteral("+") : QStringLiteral("-"))
+           + QString::number(qAbs(hz)).rightJustified(5, '0');
+}
+
+static int agcModeToZZ(const QString& mode)
+{
+    if (mode == "off")  return 0;
+    if (mode == "slow") return 2;
+    if (mode == "med")  return 3;
+    if (mode == "fast") return 4;
+    return 3;
+}
+
+static QString zzToAgcMode(const QString& code)
+{
+    if (code == "0") return "off";
+    if (code == "2") return "slow";
+    if (code == "3") return "med";
+    if (code == "4") return "fast";
+    return "med";
+}
+
+static constexpr int kRitMaxHz = 9999;
+
+// ── AG / ZZAG — VFO A audio gain (0-100, 3-digit) ───────────────────────────
+
+QString SmartCatProtocol::cmdAG(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return "AG" + fmt3(static_cast<int>(a->audioGain() + 0.5f)) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    a->setAudioGain(static_cast<float>(v));
+    return {};
+}
+
+QString SmartCatProtocol::cmdZZAG(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return "ZZAG" + fmt3(static_cast<int>(a->audioGain() + 0.5f)) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    a->setAudioGain(static_cast<float>(v));
+    return {};
+}
+
+// ── ZZLE — VFO B audio gain (0-100, 3-digit) ────────────────────────────────
+
+QString SmartCatProtocol::cmdZZLE(const QString& arg)
+{
+    SliceModel* b = sliceB();
+    if (!b) return "?;";
+    if (arg.isEmpty())
+        return "ZZLE" + fmt3(static_cast<int>(b->audioGain() + 0.5f)) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    b->setAudioGain(static_cast<float>(v));
+    return {};
+}
+
+// ── ZZLB — VFO A audio pan (0-100, 3-digit; 0=full left, 50=center) ─────────
+
+QString SmartCatProtocol::cmdZZLB(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return "ZZLB" + fmt3(a->audioPan()) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    a->setAudioPan(v);
+    return {};
+}
+
+// ── ZZLF — VFO B audio pan ───────────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZLF(const QString& arg)
+{
+    SliceModel* b = sliceB();
+    if (!b) return "?;";
+    if (arg.isEmpty())
+        return "ZZLF" + fmt3(b->audioPan()) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    b->setAudioPan(v);
+    return {};
+}
+
+// ── ZZMA — VFO A mute (0/1) ─────────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZMA(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("ZZMA%1;").arg(a->audioMute() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    a->setAudioMute(arg == "1");
+    return {};
+}
+
+// ── ZZMB — VFO B mute (0/1) ─────────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZMB(const QString& arg)
+{
+    SliceModel* b = sliceB();
+    if (!b) return "?;";
+    if (arg.isEmpty())
+        return QString("ZZMB%1;").arg(b->audioMute() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    b->setAudioMute(arg == "1");
+    return {};
+}
+
+// ── GT / ZZGT — AGC mode (0=Off, 2=Slow, 3=Med, 4=Fast) ────────────────────
+
+QString SmartCatProtocol::cmdGT(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("GT%1;").arg(agcModeToZZ(a->agcMode()));
+    a->setAgcMode(zzToAgcMode(arg));
+    return {};
+}
+
+QString SmartCatProtocol::cmdZZGT(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("ZZGT%1;").arg(agcModeToZZ(a->agcMode()));
+    a->setAgcMode(zzToAgcMode(arg));
+    return {};
+}
+
+// ── ZZAR — VFO A AGC threshold (0-100, 3-digit) ─────────────────────────────
+
+QString SmartCatProtocol::cmdZZAR(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return "ZZAR" + fmt3(a->agcThreshold()) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    a->setAgcThreshold(v);
+    return {};
+}
+
+// ── ZZAS — VFO B AGC threshold (0-100, 3-digit) ─────────────────────────────
+
+QString SmartCatProtocol::cmdZZAS(const QString& arg)
+{
+    SliceModel* b = sliceB();
+    if (!b) return "?;";
+    if (arg.isEmpty())
+        return "ZZAS" + fmt3(b->agcThreshold()) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    b->setAgcThreshold(v);
+    return {};
+}
+
+// ── PC / ZZPC — RF power drive level (0-100, 3-digit) ───────────────────────
+
+QString SmartCatProtocol::cmdPC(const QString& arg)
+{
+    TransmitModel& tx = m_model->transmitModel();
+    if (arg.isEmpty())
+        return "PC" + fmt3(tx.rfPower()) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    tx.setRfPower(v);
+    return {};
+}
+
+QString SmartCatProtocol::cmdZZPC(const QString& arg)
+{
+    TransmitModel& tx = m_model->transmitModel();
+    if (arg.isEmpty())
+        return "ZZPC" + fmt3(tx.rfPower()) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    tx.setRfPower(v);
+    return {};
+}
+
+// ── ZZMG — Transmitter mic gain (0-100, 3-digit) ────────────────────────────
+
+QString SmartCatProtocol::cmdZZMG(const QString& arg)
+{
+    TransmitModel& tx = m_model->transmitModel();
+    if (arg.isEmpty())
+        return "ZZMG" + fmt3(tx.micLevel()) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    tx.setMicLevel(v);
+    return {};
+}
+
+// ── RG / ZZRG — VFO A RIT frequency get/set (±NNNNN Hz) ─────────────────────
+
+QString SmartCatProtocol::cmdRG(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return "RG" + ritField(a->ritFreq()) + ";";
+    bool ok;
+    int hz = arg.toInt(&ok);
+    if (!ok) return "?;";
+    a->setRit(a->ritOn(), std::clamp(hz, -kRitMaxHz, kRitMaxHz));
+    return {};
+}
+
+QString SmartCatProtocol::cmdZZRG(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return "ZZRG" + ritField(a->ritFreq()) + ";";
+    bool ok;
+    int hz = arg.toInt(&ok);
+    if (!ok) return "?;";
+    a->setRit(a->ritOn(), std::clamp(hz, -kRitMaxHz, kRitMaxHz));
+    return {};
+}
+
+// ── RC / ZZRC — clear VFO A RIT frequency to 0 ──────────────────────────────
+
+QString SmartCatProtocol::cmdRC()
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    a->setRit(a->ritOn(), 0);
+    return {};
+}
+
+QString SmartCatProtocol::cmdZZRC()
+{
+    return cmdRC();
+}
+
+// ── RD / ZZRD — decrement VFO A RIT frequency ───────────────────────────────
+
+QString SmartCatProtocol::cmdRD(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    int step = arg.isEmpty() ? 10 : qAbs(arg.toInt());
+    a->setRit(a->ritOn(), std::clamp(a->ritFreq() - step, -kRitMaxHz, kRitMaxHz));
+    return {};
+}
+
+QString SmartCatProtocol::cmdZZRD(const QString& arg)
+{
+    return cmdRD(arg);
+}
+
+// ── RU / ZZRU — increment VFO A RIT frequency ───────────────────────────────
+
+QString SmartCatProtocol::cmdRU(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    int step = arg.isEmpty() ? 10 : qAbs(arg.toInt());
+    a->setRit(a->ritOn(), std::clamp(a->ritFreq() + step, -kRitMaxHz, kRitMaxHz));
+    return {};
+}
+
+QString SmartCatProtocol::cmdZZRU(const QString& arg)
+{
+    return cmdRU(arg);
+}
+
+// ── RT / ZZRT — VFO A RIT state (0/1) ───────────────────────────────────────
+
+QString SmartCatProtocol::cmdRT(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("RT%1;").arg(a->ritOn() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    a->setRit(arg == "1", a->ritFreq());
+    return {};
+}
+
+QString SmartCatProtocol::cmdZZRT(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("ZZRT%1;").arg(a->ritOn() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    a->setRit(arg == "1", a->ritFreq());
+    return {};
+}
+
+// ── ZZRW — VFO B RIT frequency get/set ──────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZRW(const QString& arg)
+{
+    SliceModel* b = sliceB();
+    if (!b) return "?;";
+    if (arg.isEmpty())
+        return "ZZRW" + ritField(b->ritFreq()) + ";";
+    bool ok;
+    int hz = arg.toInt(&ok);
+    if (!ok) return "?;";
+    b->setRit(b->ritOn(), std::clamp(hz, -kRitMaxHz, kRitMaxHz));
+    return {};
+}
+
+// ── ZZRY — VFO B RIT state (0/1) ────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZRY(const QString& arg)
+{
+    SliceModel* b = sliceB();
+    if (!b) return "?;";
+    if (arg.isEmpty())
+        return QString("ZZRY%1;").arg(b->ritOn() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    b->setRit(arg == "1", b->ritFreq());
+    return {};
+}
+
+// ── ZZXG — VFO A XIT frequency get/set ──────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZXG(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return "ZZXG" + ritField(a->xitFreq()) + ";";
+    bool ok;
+    int hz = arg.toInt(&ok);
+    if (!ok) return "?;";
+    a->setXit(a->xitOn(), std::clamp(hz, -kRitMaxHz, kRitMaxHz));
+    return {};
+}
+
+// ── ZZXC — clear VFO A XIT frequency to 0 ───────────────────────────────────
+
+QString SmartCatProtocol::cmdZZXC()
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    a->setXit(a->xitOn(), 0);
+    return {};
+}
+
+// ── XT / ZZXS — VFO A XIT state (0/1) ───────────────────────────────────────
+
+QString SmartCatProtocol::cmdXT(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("XT%1;").arg(a->xitOn() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    a->setXit(arg == "1", a->xitFreq());
+    return {};
+}
+
+QString SmartCatProtocol::cmdZZXS(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("ZZXS%1;").arg(a->xitOn() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    a->setXit(arg == "1", a->xitFreq());
+    return {};
+}
+
+// ── KS — CW keying speed (005-100 WPM, 3-digit) ─────────────────────────────
+
+QString SmartCatProtocol::cmdKS(const QString& arg)
+{
+    TransmitModel& tx = m_model->transmitModel();
+    if (arg.isEmpty())
+        return "KS" + fmt3(tx.cwSpeed()) + ";";
+    bool ok;
+    int wpm = arg.toInt(&ok);
+    if (!ok || wpm < 5 || wpm > 100) return "?;";
+    tx.setCwSpeed(wpm);
+    return {};
+}
+
+// ── PT — CW pitch frequency (100-999 Hz, 3-digit; values < 100 silently ignored)
+
+QString SmartCatProtocol::cmdPT(const QString& arg)
+{
+    TransmitModel& tx = m_model->transmitModel();
+    if (arg.isEmpty())
+        return "PT" + fmt3(tx.cwPitch()) + ";";
+    bool ok;
+    int hz = arg.toInt(&ok);
+    if (!ok) return "?;";
+    if (hz < 100) return {};   // silently ignored per guide
+    tx.setCwPitch(hz);
+    return {};
+}
+
+// ── KY — send text to CWX keyer ──────────────────────────────────────────────
+// Set:   "KY<sp><text>;" — P1 is 1 space byte, P2 is up to 24 chars of text
+// Query: "KY;"           → "KY0;" (buffer empty) or "KY1;" (transmitting)
+
+QString SmartCatProtocol::cmdKY(const QString& arg)
+{
+    if (arg.isEmpty())
+        return QString("KY%1;").arg(m_model->cwxActive() ? 1 : 0);
+    if (arg.size() < 2) return "?;";
+    // arg[0] is the fixed P1 space; text starts at arg[1], max 24 chars
+    const QString text = arg.mid(1).left(24);
+    if (!text.isEmpty())
+        m_model->cwxModel().send(text);
+    return {};
+}
+
+// ── NB — Wide Noise Blanker state (0/1) ──────────────────────────────────────
+
+QString SmartCatProtocol::cmdNB(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("NB%1;").arg(a->nbOn() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    a->setNb(arg == "1");
+    return {};
+}
+
+// ── ZZNL — Wide Noise Blanker level (0-100, 3-digit) ────────────────────────
+
+QString SmartCatProtocol::cmdZZNL(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return "ZZNL" + fmt3(a->nbLevel()) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    a->setNbLevel(v);
+    return {};
+}
+
+// ── ZZNR — Noise Reduction state (0/1) ───────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZNR(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("ZZNR%1;").arg(a->nrOn() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    a->setNr(arg == "1");
+    return {};
+}
+
+// ── ZZBI — Binaural receive (0/1) ────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZBI(const QString& arg)
+{
+    if (!m_model) return "?;";
+    if (arg.isEmpty())
+        return QString("ZZBI%1;").arg(m_model->binauralRx() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    m_model->setBinauralRx(arg == "1");
+    return {};
+}
+
+// ── ZZDE — Diversity Receive (FLEX-6700) ─────────────────────────────────────
+
+QString SmartCatProtocol::cmdZZDE(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("ZZDE%1;").arg(a->diversity() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    a->setDiversity(arg == "1");
+    return {};
+}
+
+// ── SL / SH — DSP filter low / high cutoff (Kenwood SSB/FM codes) ────────────
+//
+// Kenwood encodes filter edges as an index into a fixed Hz table rather than
+// raw Hz values.  We map from the slice's filterLow/filterHigh (signed Hz
+// relative to carrier) to the nearest table entry, then round-trip back on set.
+//
+// SL table (low-edge): 00=10, 01=50, 02=100, 03=200, 04=300, 05=400,
+//                      06=500, 07=600, 08=700, 09=800, 10=900, 11=1000 Hz
+// SH table (high-edge): 00=1400,01=1600,02=1800,03=2000,04=2200,05=2400,
+//                       06=2600,07=2800,08=3000,09=3400,10=4000,11=5000 Hz
+
+static const int kSLHz[] = { 10, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
+static const int kSHHz[] = { 1400, 1600, 1800, 2000, 2200, 2400, 2600, 2800, 3000, 3400, 4000, 5000 };
+static constexpr int kSLCount = 12;
+static constexpr int kSHCount = 12;
+
+static int nearestIndex(const int* table, int count, int hz)
+{
+    int best = 0;
+    int bestDist = qAbs(table[0] - hz);
+    for (int i = 1; i < count; ++i) {
+        int d = qAbs(table[i] - hz);
+        if (d < bestDist) { bestDist = d; best = i; }
+    }
+    return best;
+}
+
+QString SmartCatProtocol::cmdSL(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty()) {
+        int sl_hz = qMin(qAbs(a->filterLow()), qAbs(a->filterHigh()));
+        int code  = nearestIndex(kSLHz, kSLCount, sl_hz);
+        return QString("SL%1;").arg(code, 2, 10, QChar('0'));
+    }
+    bool ok;
+    int code = arg.toInt(&ok);
+    if (!ok || code < 0 || code >= kSLCount) return "?;";
+    int sl_hz = kSLHz[code];
+    // preserve the sign: low edge is negative for LSB, positive for USB
+    int sh_hz = qMax(qAbs(a->filterLow()), qAbs(a->filterHigh()));
+    if (a->filterLow() < 0)
+        a->setFilterWidth(-sh_hz, -sl_hz);
+    else
+        a->setFilterWidth(sl_hz, sh_hz);
+    return {};
+}
+
+QString SmartCatProtocol::cmdSH(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty()) {
+        int sh_hz = qMax(qAbs(a->filterLow()), qAbs(a->filterHigh()));
+        int code  = nearestIndex(kSHHz, kSHCount, sh_hz);
+        return QString("SH%1;").arg(code, 2, 10, QChar('0'));
+    }
+    bool ok;
+    int code = arg.toInt(&ok);
+    if (!ok || code < 0 || code >= kSHCount) return "?;";
+    int sh_hz = kSHHz[code];
+    int sl_hz = qMin(qAbs(a->filterLow()), qAbs(a->filterHigh()));
+    if (a->filterLow() < 0)
+        a->setFilterWidth(-sh_hz, -sl_hz);
+    else
+        a->setFilterWidth(sl_hz, sh_hz);
+    return {};
+}
+
+// ── ZZFR — toggle active VFO (swaps m_vfoA ↔ m_vfoB) ───────────────────────
+
+QString SmartCatProtocol::cmdZZFR()
+{
+    std::swap(m_vfoA, m_vfoB);
+    return {};
+}
+
+// ── SQ — squelch level (P1=main/sub selector, P2=000-255) ────────────────────
+//
+// MacLoggerDX polls SQ0; to detect squelch state.
+// P1: 0=main, 1=sub.  We only support main (slice A).
+// P2: 000-255 squelch level.
+
+QString SmartCatProtocol::cmdSQ(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    // Read: SQ; or SQ0; (P1 channel selector only)
+    if (arg.isEmpty() || arg.size() == 1)
+        return QString("SQ0%1;").arg(a->squelchLevel(), 3, 10, QChar('0'));
+    // Set: SQP1LLL; — P1 is 1 char (0=main, 1=sub), LLL is 3-digit level
+    if (arg.size() < 4) return "?;";
+    // arg[0] is the P1 channel selector (ignore, we only have main)
+    bool ok;
+    int level = arg.mid(1).toInt(&ok);
+    if (!ok || level < 0 || level > 255) return "?;";
+    a->setSquelch(a->squelchOn(), level);
+    return {};
+}
+
+// ── NR — Noise Reduction ON/OFF (0=off, 1=NR1, 2=NR2) ──────────────────────
+//
+// Kenwood TS-2000 NR command maps 0/1/2. SmartSDR only has a binary NR
+// on/off via nrOn()/setNr(). Treat 0=off, 1 or 2 = on.
+
+QString SmartCatProtocol::cmdNR(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("NR%1;").arg(a->nrOn() ? 1 : 0);
+    if (arg != "0" && arg != "1" && arg != "2") return "?;";
+    a->setNr(arg != "0");
+    return {};
+}
+
+// ── NL — Noise Blanker level (001-010 per TS-2000 spec) ──────────────────────
+//
+// SmartSDR stores NB level 0-100.  We scale: NB level 1-10 maps to 0-100
+// linearly (each TS-2000 step ≈ 10 SmartSDR units).
+
+QString SmartCatProtocol::cmdNL(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty()) {
+        // Map SmartSDR 0-100 → TS-2000 001-010
+        int ssdr = a->nbLevel();                        // 0-100
+        int ts   = qBound(1, (ssdr + 5) / 10, 10);    // round to 1-10
+        return QString("NL%1;").arg(ts, 3, 10, QChar('0'));
+    }
+    bool ok;
+    int ts = arg.toInt(&ok);
+    if (!ok || ts < 0 || ts > 10) return "?;";
+    // Map TS-2000 0-10 → SmartSDR 0-100
+    int ssdr = qBound(0, ts * 10, 100);
+    a->setNbLevel(ssdr);
+    return {};
+}
+
+// ── NT — Auto Notch (ANF) ON/OFF ─────────────────────────────────────────────
+
+QString SmartCatProtocol::cmdNT(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty())
+        return QString("NT%1;").arg(a->anfOn() ? 1 : 0);
+    if (arg != "0" && arg != "1") return "?;";
+    a->setAnf(arg == "1");
+    return {};
+}
+
+// ── RA — Attenuator (00=off, 01-99=on) ───────────────────────────────────────
+//
+// SmartSDR FlexRadios do not expose a discrete attenuator switch via the
+// model layer. RF gain is a separate continuous control (RG / rfGain).
+// Return a fixed "ATT off" (RA00) and silently accept sets to avoid ?; errors
+// from logging software that queries RA.
+
+QString SmartCatProtocol::cmdRA(const QString& arg)
+{
+    if (arg.isEmpty()) return QStringLiteral("RA0000;");
+    // Accept set silently (P1 is 2 digits, P2 is 2 digits for sub — total 4)
+    return {};
+}
+
+// ── PA — Pre-amplifier ON/OFF ─────────────────────────────────────────────────
+//
+// SmartSDR does not expose a dedicated pre-amplifier enable flag via the
+// CAT-accessible model. Return fixed "preamp off" and accept sets silently.
+// PA answer format: P1=main preamp, P2=sub preamp.
+
+QString SmartCatProtocol::cmdPA(const QString& arg)
+{
+    if (arg.isEmpty()) return QStringLiteral("PA00;");
+    return {};
+}
+
+// ── MG — Microphone gain (000-100, 3-digit) ─────────────────────────────────
+//
+// Same data as ZZMG but without the ZZ prefix (plain Kenwood command).
+
+QString SmartCatProtocol::cmdMG(const QString& arg)
+{
+    TransmitModel& tx = m_model->transmitModel();
+    if (arg.isEmpty())
+        return "MG" + fmt3(tx.micLevel()) + ";";
+    bool ok;
+    int v = arg.toInt(&ok);
+    if (!ok || v < 0 || v > 100) return "?;";
+    tx.setMicLevel(v);
+    return {};
+}
+
+// ── RL — Noise Reduction level (00-09 per TS-2000 spec) ──────────────────────
+//
+// SmartSDR stores NR level 0-100.  TS-2000 uses 00 (AUTO/0ms) through 09.
+// We map linearly: TS-2000 00-09 ↔ SmartSDR 0-100.
+
+QString SmartCatProtocol::cmdRL(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    if (arg.isEmpty()) {
+        int ssdr = a->nrLevel();                      // 0-100
+        int ts   = qBound(0, (ssdr + 5) / 10, 9);   // round to 0-9
+        return QString("RL%1;").arg(ts, 2, 10, QChar('0'));
+    }
+    bool ok;
+    int ts = arg.toInt(&ok);
+    if (!ok || ts < 0 || ts > 9) return "?;";
+    int ssdr = qBound(0, ts * 11, 100);   // 9*11=99 ≈ 100
+    a->setNrLevel(ssdr);
+    return {};
+}
+
+// ── RM — Meter reading (stub) ─────────────────────────────────────────────────
+//
+// P1 selects meter: 0=unselected, 1=SWR, 2=COMP, 3=ALC.
+// P2 is the dot-count reading 0000-0030.
+// The CAT protocol layer has no access to live meter telemetry; return a
+// fixed zero-dots value and silently accept set commands.
+
+QString SmartCatProtocol::cmdRM(const QString& arg)
+{
+    // Query: RM; or RM P1; — return zero reading; no live meter data.
+    if (arg.isEmpty() || arg.size() == 1)
+        return QString("RM%1%2;").arg(arg.isEmpty() ? QChar('0') : arg[0])
+                                  .arg(0, 4, 10, QChar('0'));
+    return {};
+}
+
+// ── LK — Key lock status (stub) ──────────────────────────────────────────────
+//
+// SDRs have no front-panel key lock. Return "unlocked" (LK00) and accept sets.
+
+QString SmartCatProtocol::cmdLK(const QString& arg)
+{
+    if (arg.isEmpty()) return QStringLiteral("LK00;");
+    return {};
+}
+
+// ── TY — Firmware type (stub) ────────────────────────────────────────────────
+//
+// P1 is reserved (space), P2: 0=overseas, 1=JP100W, 2=JP20W.
+// We always report overseas type.
+
+QString SmartCatProtocol::cmdTY(const QString& arg)
+{
+    if (arg.isEmpty()) return QStringLiteral("TY  0;");
+    return {};
+}
+
+// ── BY — Busy indicator (squelch open) ───────────────────────────────────────
+//
+// P1=main busy (0=not busy/squelch closed, 1=busy/squelch open).
+// P2=sub busy (0 — no sub-receiver in SDR mode).
+// We treat the squelch state as the "busy" indicator.
+
+QString SmartCatProtocol::cmdBY(const QString& /*arg*/)
+{
+    SliceModel* a = sliceA();
+    // If no slice or squelch is off (always open), report busy=1.
+    // If squelch is on and active (signal present), report busy=1, else 0.
+    // SmartSDR doesn't directly expose squelch-open state, only the
+    // threshold. Return 0 (not busy) as a safe default.
+    int busy = 0;
+    if (a && a->squelchOn() && a->squelchLevel() == 0)
+        busy = 1;  // squelch at 0 means always open = busy
+    return QStringLiteral("BY") + QChar('0' + busy) + "0;";
+}
+
+// ── OI — Opposite IF (VFO B composite status, same format as IF) ─────────────
+//
+// OI returns the same 37-character body as IF but for the "opposite" VFO (B).
+// Used by some logging apps to read split TX frequency without switching VFOs.
+
+QString SmartCatProtocol::cmdOI()
+{
+    SliceModel* b = sliceB();
+    SliceModel* a = sliceA();
+    // Fall back to slice A if there is no VFO B
+    SliceModel* s = b ? b : a;
+    if (!s) return "?;";
+
+    QString body;
+    body += freqField(s->frequency());
+    body += QStringLiteral("00010");
+    body += QStringLiteral("+00000");
+    body += '0';
+    body += '0';
+    body += QStringLiteral("00");
+    body += m_model->isRadioTransmitting() ? '1' : '0';
+    body += modeToKenwood(s->mode());
+    body += '0';
+    body += '0';
+    body += m_splitEnabled ? '1' : '0';
+    body += '0';
+    body += QStringLiteral("00");
+    body += '0';
+
+    return "OI" + body + ";";
+}
+
+// ── UP — VFO frequency step up ────────────────────────────────────────────────
+//
+// Emulates the microphone UP key — steps the VFO A frequency up by one step.
+// P1 is 2-digit step count (optional; default 1 step).
+// Uses the slice's stepHz() for the step size.
+
+QString SmartCatProtocol::cmdUP(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    int steps = 1;
+    if (!arg.isEmpty()) {
+        bool ok;
+        int n = arg.toInt(&ok);
+        if (ok && n > 0) steps = n;
+    }
+    double stepMhz = static_cast<double>(a->stepHz()) / 1e6;
+    a->setFrequency(a->frequency() + stepMhz * steps);
+    return {};
+}
+
+// ── DN — VFO frequency step down ─────────────────────────────────────────────
+//
+// Emulates the microphone DN key — steps the VFO A frequency down by one step.
+
+QString SmartCatProtocol::cmdDN(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+    int steps = 1;
+    if (!arg.isEmpty()) {
+        bool ok;
+        int n = arg.toInt(&ok);
+        if (ok && n > 0) steps = n;
+    }
+    double stepMhz = static_cast<double>(a->stepHz()) / 1e6;
+    a->setFrequency(a->frequency() - stepMhz * steps);
+    return {};
+}
+
+// ── FW — DSP filter width ─────────────────────────────────────────────────────
+//
+// TS-2000 FW command sets the DSP receive filter width in Hz.
+// Valid only in CW (50-2000 Hz) and FM/AM (0=narrow, 1=wide) modes.
+// In SSB mode the spec says to use SL/SH instead — we return ?; for SSB.
+// CW: we map the supplied Hz to filter edges ±(hz/2) around the carrier.
+// FM/AM: 0=narrow (±2500 Hz), 1=wide (±5000 Hz).
+
+static const int kFwCwValues[] = { 50, 80, 100, 150, 200, 300, 400, 500, 600, 1000, 2000 };
+static constexpr int kFwCwCount = 11;
+
+static int nearestCwFw(int hz)
+{
+    int best = kFwCwValues[0];
+    int bestDist = qAbs(best - hz);
+    for (int i = 1; i < kFwCwCount; ++i) {
+        int d = qAbs(kFwCwValues[i] - hz);
+        if (d < bestDist) { bestDist = d; best = kFwCwValues[i]; }
+    }
+    return best;
+}
+
+QString SmartCatProtocol::cmdFW(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+
+    const QString mode = a->mode();
+    const bool isCw   = (mode == "CW" || mode == "CWL");
+    const bool isFm   = (mode == "FM" || mode == "NFM" || mode == "DFM");
+    const bool isAm   = (mode == "AM" || mode == "SAM");
+
+    // SSB and digital modes: FW is not valid
+    if (!isCw && !isFm && !isAm) return "?;";
+
+    if (arg.isEmpty()) {
+        if (isCw) {
+            // Compute current filter width in Hz
+            int bw = qAbs(a->filterHigh()) + qAbs(a->filterLow());
+            int nearest = nearestCwFw(bw);
+            return QString("FW%1;").arg(nearest, 4, 10, QChar('0'));
+        } else {
+            // FM/AM: 0=narrow (filter width ≤ 5000), 1=wide
+            int bw = qAbs(a->filterHigh()) + qAbs(a->filterLow());
+            return QString("FW%1;").arg(bw <= 5000 ? "0000" : "0001");
+        }
+    }
+
+    bool ok;
+    int hz = arg.toInt(&ok);
+    if (!ok || hz < 0) return "?;";
+
+    if (isCw) {
+        int bw = nearestCwFw(hz);
+        // Symmetric filter around 0 Hz: low = -bw/2, high = +bw/2
+        a->setFilterWidth(-(bw / 2), bw / 2);
+    } else {
+        // FM/AM: 0=narrow, 1=wide
+        if (hz == 0)
+            a->setFilterWidth(-2500, 2500);
+        else
+            a->setFilterWidth(-5000, 5000);
+    }
+    return {};
+}
+
+// ── ZZFI / ZZFJ — VFO A/B DSP Filter Index ──────────────────────────────────
+// Index 00 = widest, 07 = narrowest. Boundaries from CAT guide v4.1.5 §3.3.9.
+
+static const int kZZFIThresh[] = { 3300, 2900, 2700, 2400, 2100, 1800, 1500 };
+static const int kZZFIRepBw[]  = { 3600, 3100, 2800, 2550, 2250, 1950, 1650, 1200 };
+static constexpr int kZZFICount = 8;
+
+static int bwToZZFIIndex(int bwHz)
+{
+    for (int i = 0; i < kZZFICount - 1; ++i)
+        if (bwHz > kZZFIThresh[i])
+            return i;
+    return kZZFICount - 1;
+}
+
+static QString zzfiQuery(SliceModel* s)
+{
+    if (!s) return "?;";
+    int bw = s->filterHigh() - s->filterLow();
+    return QString("ZZFI%1;").arg(bwToZZFIIndex(qAbs(bw)), 2, 10, QChar('0'));
+}
+
+static QString zzfijSet(SliceModel* s, const QString& arg, const QString& prefix)
+{
+    if (!s) return "?;";
+    bool ok;
+    int idx = arg.toInt(&ok);
+    if (!ok || idx < 0 || idx >= kZZFICount) return "?;";
+    int newBw  = kZZFIRepBw[idx];
+    int center = (s->filterLow() + s->filterHigh()) / 2;
+    s->setFilterWidth(center - newBw / 2, center + newBw / 2);
+    Q_UNUSED(prefix)
+    return {};
+}
+
+QString SmartCatProtocol::cmdZZFI(const QString& arg)
+{
+    SliceModel* a = sliceA();
+    if (arg.isEmpty()) {
+        QString r = zzfiQuery(a);
+        return r;
+    }
+    return zzfijSet(a, arg, "ZZFI");
+}
+
+QString SmartCatProtocol::cmdZZFJ(const QString& arg)
+{
+    SliceModel* b = sliceB();
+    if (arg.isEmpty()) {
+        if (!b) return zzfiQuery(sliceA()).replace("ZZFI", "ZZFJ");
+        QString r = zzfiQuery(b);
+        return r.replace("ZZFI", "ZZFJ");
+    }
+    return zzfijSet(b ? b : sliceA(), arg, "ZZFJ");
+}
+
+} // namespace AetherSDR

--- a/src/core/SmartCatProtocol.h
+++ b/src/core/SmartCatProtocol.h
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+class RadioModel;
+class SliceModel;
+
+// Pure request/response handler for the SmartSDR CAT (Kenwood) protocol.
+// No I/O — call processCommand() with one semicolon-delimited command (the
+// semicolon itself is NOT included). Returns the response to send, or an
+// empty string for set commands that produce no reply.
+//
+// Used by both SmartCatSession (TCP) and CatPort's PTY handler.
+// AI mode (async pushes) is NOT handled here; that is a session-level concern.
+class SmartCatProtocol {
+public:
+    explicit SmartCatProtocol(RadioModel* model,
+                              int vfoA = 0, int vfoB = -1,
+                              bool flexExtensions = true);
+
+    QString processCommand(const QString& cmd);
+
+    void setVfoA(int idx)            { m_vfoA = idx; }
+    void setVfoB(int idx)            { m_vfoB = idx; }
+    int  vfoA() const                { return m_vfoA; }
+    int  vfoB() const                { return m_vfoB; }
+
+    void setFlexExtensions(bool on)  { m_flexExtensions = on; }
+    bool flexExtensions() const      { return m_flexExtensions; }
+
+    // AI state: set by the session when AI enable/disable commands arrive.
+    // processCommand() reads this for AI query responses (AI; / ZZAI;).
+    bool aiEnabled() const           { return m_aiEnabled; }
+    void setAiEnabled(bool on)       { m_aiEnabled = on; }
+
+    // PTT safety: release transmit if this protocol instance asserted it.
+    // Call from the session's onDisconnected() / dtor so an abrupt client
+    // drop does not leave the radio keyed.  No-op if we never asserted PTT.
+    void releasePtt();
+
+    // Public helpers used by SmartCatSession's AI push
+    static QString freqField(double mhz);
+    static QString modeToKenwood(const QString& ssdrMode);
+    static QString modeToZZ(const QString& ssdrMode);
+
+private:
+    // ── Frequency / Mode ────────────────────────────────────────────────────
+    QString cmdFA(const QString& arg);
+    QString cmdFB(const QString& arg);
+    QString cmdMD(const QString& arg);
+    QString cmdZZMD(const QString& arg);
+    QString cmdZZME(const QString& arg);
+    QString cmdIF();
+    QString cmdZZIF();
+    QString cmdFT(const QString& arg);
+    QString cmdZZSW(const QString& arg);
+    QString cmdFR(const QString& arg);
+    QString cmdTX(const QString& arg);
+    QString cmdRX();
+    QString cmdID();
+    QString cmdPS();
+    QString cmdSM(const QString& arg);
+    QString cmdZZSM(const QString& arg);
+
+    // ── Audio gain / pan / mute ─────────────────────────────────────────────
+    QString cmdAG(const QString& arg);
+    QString cmdZZAG(const QString& arg);
+    QString cmdZZLE(const QString& arg);
+    QString cmdZZLB(const QString& arg);
+    QString cmdZZLF(const QString& arg);
+    QString cmdZZMA(const QString& arg);
+    QString cmdZZMB(const QString& arg);
+
+    // ── AGC ─────────────────────────────────────────────────────────────────
+    QString cmdGT(const QString& arg);
+    QString cmdZZGT(const QString& arg);
+    QString cmdZZAR(const QString& arg);
+    QString cmdZZAS(const QString& arg);
+
+    // ── RF Power / Mic Gain ─────────────────────────────────────────────────
+    QString cmdPC(const QString& arg);
+    QString cmdZZPC(const QString& arg);
+    QString cmdZZMG(const QString& arg);
+
+    // ── RIT ─────────────────────────────────────────────────────────────────
+    QString cmdRG(const QString& arg);
+    QString cmdZZRG(const QString& arg);
+    QString cmdRC();
+    QString cmdZZRC();
+    QString cmdRD(const QString& arg);
+    QString cmdZZRD(const QString& arg);
+    QString cmdRU(const QString& arg);
+    QString cmdZZRU(const QString& arg);
+    QString cmdRT(const QString& arg);
+    QString cmdZZRT(const QString& arg);
+    QString cmdZZRW(const QString& arg);
+    QString cmdZZRY(const QString& arg);
+
+    // ── XIT ─────────────────────────────────────────────────────────────────
+    QString cmdXT(const QString& arg);
+    QString cmdZZXG(const QString& arg);
+    QString cmdZZXC();
+    QString cmdZZXS(const QString& arg);
+
+    // ── CW ──────────────────────────────────────────────────────────────────
+    QString cmdKS(const QString& arg);
+    QString cmdPT(const QString& arg);
+    QString cmdKY(const QString& arg);
+
+    // ── Noise Blanker / Noise Reduction ─────────────────────────────────────
+    QString cmdNB(const QString& arg);
+    QString cmdNL(const QString& arg);
+    QString cmdNR(const QString& arg);
+    QString cmdNT(const QString& arg);
+    QString cmdRL(const QString& arg);
+    QString cmdZZNL(const QString& arg);
+    QString cmdZZNR(const QString& arg);
+
+    // ── DSP Filter (SL / SH / FW / ZZFI / ZZFJ) ────────────────────────────
+    QString cmdSL(const QString& arg);
+    QString cmdSH(const QString& arg);
+    QString cmdFW(const QString& arg);
+    QString cmdZZFI(const QString& arg);
+    QString cmdZZFJ(const QString& arg);
+
+    // ── Squelch ──────────────────────────────────────────────────────────────
+    QString cmdSQ(const QString& arg);
+
+    // ── RF / Mic / Attenuator / Preamp ───────────────────────────────────────
+    QString cmdMG(const QString& arg);
+    QString cmdRA(const QString& arg);
+    QString cmdPA(const QString& arg);
+
+    // ── Meter / Status stubs ─────────────────────────────────────────────────
+    QString cmdRM(const QString& arg);
+    QString cmdLK(const QString& arg);
+    QString cmdTY(const QString& arg);
+    QString cmdBY(const QString& arg);
+
+    // ── VFO step ─────────────────────────────────────────────────────────────
+    QString cmdUP(const QString& arg);
+    QString cmdDN(const QString& arg);
+
+    // ── Opposite IF (VFO B status) ───────────────────────────────────────────
+    QString cmdOI();
+
+    // ── Misc ─────────────────────────────────────────────────────────────────
+    QString cmdZZBI(const QString& arg);
+    QString cmdZZDE(const QString& arg);
+    QString cmdZZFR();
+
+    QString processCommandImpl(const QString& cmd);
+
+    SliceModel* sliceA() const;
+    SliceModel* sliceB() const;
+
+    static QString kenwoodToSSDR(QChar c);
+    static QString zzToSSDR(const QString& two);
+
+    RadioModel* m_model;
+    int         m_vfoA{0};
+    int         m_vfoB{-1};
+    bool        m_flexExtensions{true};
+    bool        m_aiEnabled{false};
+    bool        m_splitEnabled{false};
+    bool        m_pttAssertedByMe{false};
+};
+
+} // namespace AetherSDR

--- a/src/core/SmartCatSession.cpp
+++ b/src/core/SmartCatSession.cpp
@@ -1,0 +1,118 @@
+#include "SmartCatSession.h"
+#include "LogManager.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+namespace AetherSDR {
+
+SmartCatSession::SmartCatSession(QTcpSocket* socket, RadioModel* model,
+                                 int vfoA, int vfoB, bool flexExtensions,
+                                 QObject* parent)
+    : QObject(parent)
+    , m_protocol(model, vfoA, vfoB, flexExtensions)
+    , m_socket(socket)
+    , m_model(model)
+{
+    connect(socket, &QTcpSocket::readyRead,    this, &SmartCatSession::onReadyRead);
+    connect(socket, &QTcpSocket::disconnected, this, &SmartCatSession::onDisconnected);
+    socket->setParent(this);
+}
+
+SmartCatSession::~SmartCatSession()
+{
+    setAI(false);
+    m_protocol.releasePtt();
+}
+
+void SmartCatSession::send(const QString& data)
+{
+    if (m_socket && m_socket->isOpen())
+        m_socket->write(data.toUtf8());
+}
+
+void SmartCatSession::onReadyRead()
+{
+    m_buffer.append(m_socket->readAll());
+
+    int pos;
+    while ((pos = m_buffer.indexOf(';')) >= 0) {
+        QString cmd = QString::fromUtf8(m_buffer.left(pos)).trimmed();
+        m_buffer.remove(0, pos + 1);
+        if (cmd.isEmpty()) continue;
+
+        // AI enable/disable — handled at session level to wire/unwire signals
+        const QString upper = cmd.toUpper();
+        if (upper.left(2) == "AI" && upper.size() > 2) {
+            setAI(upper.mid(2) == "1");
+            m_protocol.setAiEnabled(m_aiEnabled);
+            continue;
+        }
+        if (upper.left(4) == "ZZAI" && upper.size() > 4) {
+            bool ok;
+            int val = upper.mid(4).toInt(&ok);
+            setAI(ok && val > 0);
+            m_protocol.setAiEnabled(m_aiEnabled);
+            continue;
+        }
+
+        QString resp = m_protocol.processCommand(cmd);
+        if (!resp.isEmpty()) {
+            qCDebug(lcCat) << "SmartCAT" << cmd << "->" << resp.left(40);
+            send(resp);
+        } else {
+            qCDebug(lcCat) << "SmartCAT" << cmd << "(set)";
+        }
+    }
+}
+
+void SmartCatSession::onDisconnected()
+{
+    m_protocol.releasePtt();
+    emit sessionEnded(this);
+}
+
+// ── AI mode — async frequency / mode push ───────────────────────────────────
+
+void SmartCatSession::setAI(bool on)
+{
+    if (m_aiEnabled == on) return;
+    m_aiEnabled = on;
+
+    SliceModel* a = vfoA();
+    if (!a) return;
+
+    if (on) {
+        connect(a, &SliceModel::frequencyChanged,
+                this, &SmartCatSession::onVfoAFrequencyChanged);
+        connect(a, &SliceModel::modeChanged,
+                this, &SmartCatSession::onVfoAModeChanged);
+    } else {
+        disconnect(a, &SliceModel::frequencyChanged,
+                   this, &SmartCatSession::onVfoAFrequencyChanged);
+        disconnect(a, &SliceModel::modeChanged,
+                   this, &SmartCatSession::onVfoAModeChanged);
+    }
+}
+
+void SmartCatSession::onVfoAFrequencyChanged(double mhz)
+{
+    send("FA" + SmartCatProtocol::freqField(mhz) + ";");
+}
+
+void SmartCatSession::onVfoAModeChanged(const QString& mode)
+{
+    send("MD" + SmartCatProtocol::modeToKenwood(mode) + ";");
+}
+
+SliceModel* SmartCatSession::vfoA() const
+{
+    if (!m_model) return nullptr;
+    const int idx = m_protocol.vfoA();
+    for (auto* s : m_model->slices()) {
+        if (s->sliceId() == idx) return s;
+    }
+    const auto& slices = m_model->slices();
+    return slices.isEmpty() ? nullptr : slices.first();
+}
+
+} // namespace AetherSDR

--- a/src/core/SmartCatSession.h
+++ b/src/core/SmartCatSession.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "SmartCatProtocol.h"
+
+#include <QObject>
+#include <QTcpSocket>
+#include <QByteArray>
+
+namespace AetherSDR {
+
+class RadioModel;
+class SliceModel;
+
+// Per-connection TCP session for the SmartSDR CAT protocol.
+//
+// Wraps SmartCatProtocol (pure request/response) with TCP socket I/O and
+// AI mode — the async push of FA/MD updates when slice state changes.
+//
+// The flexExtensions flag selects whether ZZ-prefixed commands are accepted;
+// false = plain Kenwood TS-2000 dialect, true = FlexRadio CAT (default).
+class SmartCatSession : public QObject {
+    Q_OBJECT
+
+public:
+    explicit SmartCatSession(QTcpSocket* socket, RadioModel* model,
+                             int vfoA = 0, int vfoB = -1,
+                             bool flexExtensions = true,
+                             QObject* parent = nullptr);
+    ~SmartCatSession() override;
+
+signals:
+    void sessionEnded(SmartCatSession* session);
+
+private slots:
+    void onReadyRead();
+    void onDisconnected();
+    void onVfoAFrequencyChanged(double mhz);
+    void onVfoAModeChanged(const QString& mode);
+
+private:
+    void setAI(bool on);
+    void send(const QString& data);
+
+    SliceModel* vfoA() const;
+
+    SmartCatProtocol m_protocol;
+    QTcpSocket*      m_socket;
+    RadioModel*      m_model;
+    QByteArray       m_buffer;
+    bool             m_aiEnabled{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -763,7 +763,17 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     }
 
     m_catControlApplet = new CatControlApplet;
-    m_appletOrder.append(makeEntry("CAT", "CAT Control", m_catControlApplet, false, btnRow2, btnLayout2));
+    {
+        auto catEntry = makeEntry("CAT", "CAT Control", m_catControlApplet, false, btnRow2, btnLayout2);
+        m_appletOrder.append(catEntry);
+        // Switch the applet between its simple (docked) and full-table (floating) views.
+        if (auto* c = qobject_cast<ContainerWidget*>(catEntry.widget)) {
+            connect(c, &ContainerWidget::dockModeChanged, m_catControlApplet,
+                    [this](ContainerWidget::DockMode mode) {
+                        m_catControlApplet->setFloating(mode == ContainerWidget::DockMode::Floating);
+                    });
+        }
+    }
 
     m_daxApplet = new DaxApplet;
     m_appletOrder.append(makeEntry("DAX", "DAX Audio", m_daxApplet, false, btnRow2, btnLayout2));

--- a/src/gui/CatControlApplet.cpp
+++ b/src/gui/CatControlApplet.cpp
@@ -1,282 +1,523 @@
 #include "CatControlApplet.h"
-#include "SliceColorManager.h"
-#include "core/RigctlServer.h"
-#include "core/RigctlPty.h"
 #include "core/AppSettings.h"
-#include "models/RadioModel.h"
-
-#include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QPushButton>
-#include <QLineEdit>
 #include "core/ThemeManager.h"
+
+#include <QCheckBox>
+#include <QClipboard>
+#include <QComboBox>
+#include <QFrame>
+#include <QGridLayout>
+#include <QGuiApplication>
+#include <QHBoxLayout>
+#include <QIntValidator>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMenu>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QVBoxLayout>
+#include <QWidget>
 
 namespace AetherSDR {
 
 namespace {
 
-constexpr const char* kSectionStyle =
-    "QWidget { background: transparent; }"
-    "QLabel { color: #8090a0; font-size: 11px; }"
-    "QPushButton { background: #1a2a3a; border: 1px solid #205070;"
-    "  border-radius: 3px; padding: 2px 8px; font-size: 11px; font-weight: bold; color: #c8d8e8; }"
-    "QPushButton:hover { background: #204060; }";
+// Stylesheet templates — tokens are resolved at runtime by ThemeManager.
+// Use ThemeManager::applyStyleSheet(widget, kXxx) so widgets re-style automatically
+// on theme changes.  The :checked colours on kGreenToggle have no matching token
+// (there is no dark-success-background token) so they stay hardcoded.
 
-const QString kGreenToggle =
-    "QPushButton { background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
-    " color: #c8d8e8; font-size: 11px; font-weight: bold; padding: 2px 8px; }"
-    "QPushButton:hover { background: #204060; }"
-    "QPushButton:checked { background: #006040; color: #00ff88; border: 1px solid #00a060; }";
+const char* kGreenToggle =
+    "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; border-radius: 3px;"
+    " color: {{color.text.primary}}; font-size: 11px; font-weight: bold; padding: 2px 8px; }"
+    "QPushButton:hover { background: {{color.background.2}}; }"
+    "QPushButton:checked { background: #006040; color: {{color.accent.success}}; border: 1px solid {{color.accent.success}}; }";
 
-constexpr const char* kDimLabel =
-    "QLabel { color: #8090a0; font-size: 11px; }";
+const char* kHintBtn =
+    "QPushButton { background: transparent; border: none; color: {{color.text.label}};"
+    " font-size: 10px; font-style: italic; text-align: right; padding: 0; }"
+    "QPushButton:hover { color: {{color.text.secondary}}; }";
 
-constexpr const char* kInsetStyle =
-    "QLineEdit { font-size: 10px; background: #0a0a18; border: 1px solid #1e2e3e;"
-    " border-radius: 3px; padding: 0px 2px; color: #c8d8e8; }";
+const char* kHeaderStyle =
+    "QLabel { color: {{color.text.label}}; font-size: 10px; font-weight: bold; }";
+
+const char* kDimLabel =
+    "QLabel { color: {{color.text.secondary}}; font-size: 11px; }";
+
+const char* kMonoLabel =
+    "QLabel { color: {{color.text.label}}; font-size: 10px; font-family: monospace; }";
+
+const char* kPortEdit =
+    "QLineEdit { font-size: 11px; background: {{color.background.0}}; border: 1px solid {{color.border.subtle}};"
+    " border-radius: 3px; padding: 0px 3px; color: {{color.text.primary}}; }"
+    "QLineEdit:read-only { color: {{color.text.label}}; background: {{color.background.0}}; border-color: {{color.border.subtle}}; }";
+
+const char* kComboStyle =
+    "QComboBox { font-size: 11px; background: {{color.background.1}}; border: 1px solid {{color.border.subtle}};"
+    " border-radius: 3px; padding: 0px 3px; color: {{color.text.primary}}; }"
+    "QComboBox:disabled { color: {{color.text.label}}; background: {{color.background.0}}; }"
+    "QComboBox::drop-down { border: none; }"
+    "QComboBox QAbstractItemView { background: {{color.background.1}}; color: {{color.text.primary}}; }"
+    // Editable combos (VFO A/B) — transparent line edit so it inherits the combo look
+    "QComboBox QLineEdit { background: transparent; border: none; color: {{color.text.primary}};"
+    " font-size: 11px; padding: 0px; }"
+    "QComboBox:disabled QLineEdit { color: {{color.text.label}}; }";
+
+const char* kSepStyle =
+    "QFrame { color: {{color.border.subtle}}; }";
+
+constexpr int kMinPort = 1024;
+constexpr int kMaxPort = 65535;
+
+QString sliceLetter(int idx)
+{
+    if (idx < 0 || idx > 25) return "—";
+    return QString(QChar('A' + idx));
+}
 
 } // namespace
 
+// ── Constructor ──────────────────────────────────────────────────────────────
+
 CatControlApplet::CatControlApplet(QWidget* parent) : QWidget(parent)
 {
-    buildUI();
-    hide();  // hidden by default, shown via CAT toggle button
+    setStyleSheet("QWidget { background: transparent; }");
+
+    m_rootLayout = new QVBoxLayout(this);
+    m_rootLayout->setContentsMargins(0, 0, 0, 0);
+    m_rootLayout->setSpacing(0);
+
+    // Docked page: always present, narrow
+    m_dockedPage = new QWidget(this);
+    buildDockedView(m_dockedPage);
+    m_rootLayout->addWidget(m_dockedPage);
+
+    // Floating page is built lazily on first setFloating(true) — not added here,
+    // so it cannot influence the docked sizeHint.
+
+    hide();
 }
 
-void CatControlApplet::buildUI()
+// ── Docked page ──────────────────────────────────────────────────────────────
+
+void CatControlApplet::buildDockedView(QWidget* page)
 {
-    setStyleSheet(kSectionStyle);
+    page->setStyleSheet("QWidget { background: transparent; }");
+    auto* root = new QVBoxLayout(page);
+    root->setContentsMargins(4, 4, 4, 4);
+    root->setSpacing(6);
 
-    auto* outer = new QVBoxLayout(this);
-    outer->setContentsMargins(0, 0, 0, 0);
-    outer->setSpacing(0);
+    auto* row = new QHBoxLayout;
+    row->setSpacing(6);
 
-    auto* content = new QWidget;
-    auto* root = new QVBoxLayout(content);
-    root->setContentsMargins(4, 2, 4, 2);
-    root->setSpacing(4);
-    outer->addWidget(content);
+    m_enableBtn = new QPushButton("Enable CAT");
+    m_enableBtn->setCheckable(true);
+    ThemeManager::instance().applyStyleSheet(m_enableBtn, kGreenToggle);
+    m_enableBtn->setFixedSize(100, 22);
+    {
+        QSignalBlocker b(m_enableBtn);
+        m_enableBtn->setChecked(
+            AppSettings::instance().value("CatEnabled", "False").toString() == "True");
+    }
+    row->addWidget(m_enableBtn);
+    row->addStretch();
+    root->addLayout(row);
+
+    root->addStretch();
+
+    auto* hint = new QPushButton("Pop out for configuration.");
+    ThemeManager::instance().applyStyleSheet(hint, kHintBtn);
+    hint->setFlat(true);
+    hint->setCursor(Qt::PointingHandCursor);
+    // Clicking the hint pops out the applet — but the actual pop-out is driven
+    // by the ContainerWidget's float button. The hint is informational only.
+    root->addWidget(hint);
+
+    connect(m_enableBtn, &QPushButton::toggled, this, [this](bool on) {
+        auto& s = AppSettings::instance();
+        s.setValue("CatEnabled", on ? "True" : "False");
+        s.save();
+        emit enableChanged(on);
+    });
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+void CatControlApplet::setCatEnabled(bool on)
+{
+    if (m_enableBtn) {
+        QSignalBlocker b(m_enableBtn);
+        m_enableBtn->setChecked(on);
+    }
+    if (m_floatingEnableBtn) {
+        QSignalBlocker b(m_floatingEnableBtn);
+        m_floatingEnableBtn->setChecked(on);
+    }
+    for (int i = 0; i < m_rows.size(); ++i)
+        updateRowLocked(i);
+}
+
+void CatControlApplet::setFloating(bool on)
+{
+    if (on) {
+        // Build the floating page on first use
+        if (!m_floatingPage) {
+            m_floatingPage = new QWidget(this);
+            m_floatingPage->setStyleSheet("QWidget { background: transparent; }");
+            auto* floatingRoot = new QVBoxLayout(m_floatingPage);
+            floatingRoot->setContentsMargins(4, 4, 4, 4);
+            floatingRoot->setSpacing(4);
+
+            // Enable button + note (must enable before ports can be configured)
+            auto* enableRow = new QHBoxLayout;
+            enableRow->setSpacing(8);
+            m_floatingEnableBtn = new QPushButton("Enable CAT");
+            m_floatingEnableBtn->setCheckable(true);
+            ThemeManager::instance().applyStyleSheet(m_floatingEnableBtn, kGreenToggle);
+            m_floatingEnableBtn->setFixedSize(100, 22);
+            {
+                QSignalBlocker b(m_floatingEnableBtn);
+                m_floatingEnableBtn->setChecked(
+                    AppSettings::instance().value("CatEnabled", "False").toString() == "True");
+            }
+            auto* noteLabel = new QLabel("Enable before configuring ports.");
+            ThemeManager::instance().applyStyleSheet(noteLabel,
+                "QLabel { color: {{color.text.label}}; font-size: 10px; font-style: italic; }");
+            enableRow->addWidget(m_floatingEnableBtn);
+            enableRow->addWidget(noteLabel);
+            enableRow->addStretch();
+            floatingRoot->addLayout(enableRow);
+
+            connect(m_floatingEnableBtn, &QPushButton::toggled, this, [this](bool on) {
+                auto& s = AppSettings::instance();
+                s.setValue("CatEnabled", on ? "True" : "False");
+                s.save();
+                if (m_enableBtn) {
+                    QSignalBlocker b(m_enableBtn);
+                    m_enableBtn->setChecked(on);
+                }
+                emit enableChanged(on);
+            });
+
+            auto* sep = new QFrame;
+            sep->setFrameShape(QFrame::HLine);
+            ThemeManager::instance().applyStyleSheet(sep, kSepStyle);
+            floatingRoot->addWidget(sep);
+
+            auto* scroll = new QScrollArea;
+            scroll->setWidgetResizable(true);
+            scroll->setFrameShape(QFrame::NoFrame);
+            scroll->setStyleSheet("QScrollArea { background: transparent; }");
+
+            auto* rowContainer = new QWidget;
+            rowContainer->setStyleSheet("QWidget { background: transparent; }");
+            m_grid = new QGridLayout(rowContainer);
+            m_grid->setContentsMargins(0, 0, 0, 0);
+            m_grid->setSpacing(3);
+            scroll->setWidget(rowContainer);
+            floatingRoot->addWidget(scroll);
+
+            m_rootLayout->addWidget(m_floatingPage);
+        }
+
+        if (!m_rowsBuilt && m_portCount > 0)
+            buildTableRows();
+
+        m_dockedPage->hide();
+        m_floatingPage->show();
+    } else {
+        if (m_floatingPage) m_floatingPage->hide();
+        m_dockedPage->show();
+    }
+}
+
+void CatControlApplet::setPorts(CatPort** ports, int count)
+{
+    m_portCount = qMin(count, kMaxPorts);
+    for (int i = 0; i < m_portCount; ++i)
+        m_ports[i] = ports[i];
+    for (int i = m_portCount; i < kMaxPorts; ++i)
+        m_ports[i] = nullptr;
+    m_rowsBuilt = false;
+    // If already floating, rebuild immediately
+    if (m_floatingPage && m_floatingPage->isVisible())
+        buildTableRows();
+}
+
+void CatControlApplet::setMaxSlices(int n)
+{
+    m_maxSlices = qMax(1, n);
+    for (int row = 0; row < m_rows.size(); ++row) {
+        PortRow& r = m_rows[row];
+        int savedA = r.vfoACombo->currentIndex();
+        int savedB = r.vfoBCombo->currentIndex();
+        r.vfoACombo->blockSignals(true);
+        r.vfoBCombo->blockSignals(true);
+        r.vfoACombo->clear();
+        r.vfoBCombo->clear();
+        populateVfoCombo(r.vfoACombo, false);
+        populateVfoCombo(r.vfoBCombo, true);
+        r.vfoACombo->setCurrentIndex(qMin(savedA, r.vfoACombo->count() - 1));
+        r.vfoBCombo->setCurrentIndex(qMin(savedB, r.vfoBCombo->count() - 1));
+        r.vfoACombo->blockSignals(false);
+        r.vfoBCombo->blockSignals(false);
+    }
+}
+
+// ── Build floating table rows ────────────────────────────────────────────────
+
+void CatControlApplet::populateVfoCombo(QComboBox* combo, bool includeNone)
+{
+    if (includeNone) combo->addItem("—", -1);
+    for (int i = 0; i < m_maxSlices; ++i)
+        combo->addItem(sliceLetter(i), i);
+}
+
+void CatControlApplet::buildTableRows()
+{
+    // Clear any existing rows
+    while (QLayoutItem* item = m_grid->takeAt(0)) {
+        if (item->widget()) item->widget()->setParent(nullptr);
+        delete item;
+    }
+    m_rows.clear();
+
+    // Header labels as grid row 0 — same layout as data rows, so columns always align.
+    // w=0 means no fixed width (used for the stretching PTY column).
+    auto addHdr = [&](const QString& text, int w, int col,
+                      Qt::Alignment align = Qt::AlignLeft | Qt::AlignVCenter) {
+        auto* lbl = new QLabel(text);
+        ThemeManager::instance().applyStyleSheet(lbl, kHeaderStyle);
+        if (w > 0) lbl->setFixedWidth(w);
+        lbl->setAlignment(align);
+        m_grid->addWidget(lbl, 0, col);
+    };
+    int hcol = 0;
+    addHdr("En",       22, hcol++);
+    addHdr("Port",     50, hcol++, Qt::AlignHCenter | Qt::AlignVCenter);
+    addHdr("Dialect",  68, hcol++);
+    addHdr("VFO A",    42, hcol++, Qt::AlignHCenter | Qt::AlignVCenter);
+    addHdr("VFO B",    42, hcol++, Qt::AlignHCenter | Qt::AlignVCenter);
+#ifndef Q_OS_WIN
+    addHdr("PTY",       0, hcol++);  // no fixed width — column stretches
+#endif
+    addHdr("Clients",  48, hcol++);
 
     auto& settings = AppSettings::instance();
 
-    // Enable row (created here, added to layout after channel rows)
-    auto* enableRow = new QHBoxLayout;
-    enableRow->setSpacing(4);
+    for (int i = 0; i < m_portCount; ++i) {
+        PortRow row;
+        const QString prefix = QString("CatPort_%1_").arg(i);
 
-    m_tcpEnable = new QPushButton("Enable TCP");
-    m_tcpEnable->setCheckable(true);
-    m_tcpEnable->setStyleSheet(kGreenToggle);
-    m_tcpEnable->setFixedSize(76, 22);
-    {
-        QSignalBlocker b(m_tcpEnable);
-        m_tcpEnable->setChecked(
-            settings.value("AutoStartRigctld", "False").toString() == "True");
-    }
-    enableRow->addWidget(m_tcpEnable);
-
-    m_ptyEnable = new QPushButton("Enable TTY");
-    m_ptyEnable->setCheckable(true);
-    m_ptyEnable->setStyleSheet(kGreenToggle);
-    m_ptyEnable->setFixedSize(76, 22);
-    {
-        QSignalBlocker b(m_ptyEnable);
-        m_ptyEnable->setChecked(
-            settings.value("AutoStartCAT", "False").toString() == "True");
-    }
-    enableRow->addWidget(m_ptyEnable);
-
-    enableRow->addStretch();
-
-    auto* portLabel = new QLabel("Base:");
-    portLabel->setStyleSheet(kDimLabel);
-    enableRow->addWidget(portLabel);
-
-    m_basePort = new QLineEdit(settings.value("CatTcpPort", "4532").toString());
-    m_basePort->setStyleSheet(kInsetStyle);
-    m_basePort->setFixedWidth(40);
-    m_basePort->setAlignment(Qt::AlignCenter);
-    enableRow->addWidget(m_basePort);
-
-    connect(m_basePort, &QLineEdit::editingFinished, this, [this]() {
-        int port = m_basePort->text().toInt();
-        if (port < 1024 || port > 65535) {
-            port = 4532;
-            m_basePort->setText("4532");
+        // Enable checkbox
+        row.enableCheck = new QCheckBox;
+        row.enableCheck->setFixedWidth(22);
+        {
+            bool en = settings.value(prefix + "Enabled", "False").toString() == "True";
+            QSignalBlocker b(row.enableCheck);
+            row.enableCheck->setChecked(en);
         }
-        auto& ss = AppSettings::instance();
-        ss.setValue("CatTcpPort", QString::number(port));
-        ss.save();
-        // If running, restart all servers with new base port
-        if (m_tcpEnable->isChecked()) {
-            for (int i = 0; i < kChannels; ++i) {
-                if (m_servers[i]) {
-                    m_servers[i]->stop();
-                    m_servers[i]->start(static_cast<quint16>(port + i));
-                }
-            }
-            updateAllChannelStatus();
+
+        // Port edit
+        row.portEdit = new QLineEdit;
+        ThemeManager::instance().applyStyleSheet(row.portEdit, kPortEdit);
+        row.portEdit->setFixedWidth(50);
+        row.portEdit->setAlignment(Qt::AlignCenter);
+        row.portEdit->setValidator(new QIntValidator(kMinPort, kMaxPort, row.portEdit));
+        row.portEdit->setPlaceholderText("port");
+        {
+            QString portStr = settings.value(prefix + "Port", "").toString();
+            QSignalBlocker b(row.portEdit);
+            row.portEdit->setText(portStr);
         }
-    });
 
-    // TCP toggle: start/stop all 4 servers
-    connect(m_tcpEnable, &QPushButton::toggled, this, [this](bool on) {
-        int basePort = m_basePort->text().toInt();
-        if (basePort < 1024 || basePort > 65535) {
-            basePort = 4532;
+        // Dialect combo
+        row.dialectCombo = new QComboBox;
+        ThemeManager::instance().applyStyleSheet(row.dialectCombo, kComboStyle);
+        row.dialectCombo->setFixedWidth(68);
+        row.dialectCombo->addItem("Rigctld",  static_cast<int>(CatDialect::Rigctld));
+        row.dialectCombo->addItem("TS-2000",  static_cast<int>(CatDialect::TS2000));
+        row.dialectCombo->addItem("Flex",     static_cast<int>(CatDialect::FlexCAT));
+        {
+            QString d = settings.value(prefix + "Dialect", "Rigctld").toString();
+            int idx = (d == "TS2000") ? 1 : (d == "FlexCAT") ? 2 : 0;
+            QSignalBlocker b(row.dialectCombo);
+            row.dialectCombo->setCurrentIndex(idx);
         }
-        auto& ss = AppSettings::instance();
-        ss.setValue("CatTcpPort", QString::number(basePort));
-        ss.setValue("AutoStartRigctld", on ? "True" : "False");
-        ss.save();
-        for (int i = 0; i < kChannels; ++i) {
-            if (!m_servers[i]) {
-                continue;
-            }
-            if (on) {
-                m_servers[i]->start(static_cast<quint16>(basePort + i));
-            } else {
-                m_servers[i]->stop();
-            }
+
+        // VFO A combo — editable+read-only so we can center the selected-item text
+        row.vfoACombo = new QComboBox;
+        ThemeManager::instance().applyStyleSheet(row.vfoACombo, kComboStyle);
+        row.vfoACombo->setFixedWidth(42);
+        populateVfoCombo(row.vfoACombo, false);
+        {
+            int vfoA = settings.value(prefix + "VfoA", "0").toInt();
+            int idx = row.vfoACombo->findData(vfoA);
+            QSignalBlocker b(row.vfoACombo);
+            row.vfoACombo->setCurrentIndex(qMax(0, idx));
         }
-        updateAllChannelStatus();
-    });
+        row.vfoACombo->setEditable(true);
+        row.vfoACombo->lineEdit()->setAlignment(Qt::AlignCenter);
+        row.vfoACombo->lineEdit()->setReadOnly(true);
+        row.vfoACombo->lineEdit()->setFocusPolicy(Qt::NoFocus);
 
-    // PTY toggle: start/stop all 4 PTYs
-    connect(m_ptyEnable, &QPushButton::toggled, this, [this](bool on) {
-        auto& ss = AppSettings::instance();
-        ss.setValue("AutoStartCAT", on ? "True" : "False");
-        ss.save();
-        for (int i = 0; i < kChannels; ++i) {
-            if (!m_ptys[i]) {
-                continue;
-            }
-            if (on) {
-                m_ptys[i]->start();
-            } else {
-                m_ptys[i]->stop();
-            }
+        // VFO B combo
+        row.vfoBCombo = new QComboBox;
+        ThemeManager::instance().applyStyleSheet(row.vfoBCombo, kComboStyle);
+        row.vfoBCombo->setFixedWidth(42);
+        populateVfoCombo(row.vfoBCombo, true);
+        {
+            int vfoB = settings.value(prefix + "VfoB", "-1").toInt();
+            int idx = row.vfoBCombo->findData(vfoB);
+            QSignalBlocker b(row.vfoBCombo);
+            row.vfoBCombo->setCurrentIndex(qMax(0, idx));
         }
-        updateAllChannelStatus();
-    });
+        row.vfoBCombo->setEditable(true);
+        row.vfoBCombo->lineEdit()->setAlignment(Qt::AlignCenter);
+        row.vfoBCombo->lineEdit()->setReadOnly(true);
+        row.vfoBCombo->lineEdit()->setFocusPolicy(Qt::NoFocus);
 
-    // Per-channel status rows
-    static const char kLetters[] = "ABCD";
-
-    for (int i = 0; i < kChannels; ++i) {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(4);
-
-        // Coloured badge
-        m_rows[i].badge = new QLabel(QString(kLetters[i]));
-        m_rows[i].badge->setFixedWidth(16);
-        m_rows[i].badge->setAlignment(Qt::AlignCenter);
-        m_rows[i].badge->setStyleSheet(
-            QStringLiteral("QLabel { color: %1; font-size: 11px; font-weight: bold; }")
-                .arg(SliceColorManager::instance().hexActive(i)));
-        row->addWidget(m_rows[i].badge);
-
-        // TCP status
-        m_rows[i].tcpStatus = new QLabel("(stopped)");
-        m_rows[i].tcpStatus->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.background.3}}; font-size: 10px; }"));
-        m_rows[i].tcpStatus->setFixedWidth(100);
-        row->addWidget(m_rows[i].tcpStatus);
-
-        // PTY path — canonical per-user location, computed by
-        // RigctlPty so the displayed path stays in sync with where
-        // the actual symlink is created (#2940 / GHSA-qxhr-cwrc-pvrm).
-        m_rows[i].ptyPath = new QLabel(RigctlPty::defaultSymlinkPath(i));
-        m_rows[i].ptyPath->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.background.3}}; font-size: 10px; }"));
-        row->addWidget(m_rows[i].ptyPath, 1);
-
-        root->addLayout(row);
-    }
-
-    root->addLayout(enableRow);
-}
-
-void CatControlApplet::setRadioModel(RadioModel* model)
-{
-    m_model = model;
-    if (model) {
-        connect(model, &RadioModel::connectionStateChanged,
-                this, [this](bool /*connected*/) {
-            updateAllChannelStatus();
-        });
-    }
-}
-
-void CatControlApplet::setRigctlServers(RigctlServer** servers, int count)
-{
-    for (int i = 0; i < kChannels && i < count; ++i) {
-        m_servers[i] = servers[i];
-        if (servers[i]) {
-            connect(servers[i], &RigctlServer::clientCountChanged,
-                    this, [this, i]() { updateChannelStatus(i); });
-        }
-    }
-}
-
-void CatControlApplet::setRigctlPtys(RigctlPty** ptys, int count)
-{
-    for (int i = 0; i < kChannels && i < count; ++i) {
-        m_ptys[i] = ptys[i];
-        if (ptys[i]) {
-            connect(ptys[i], &RigctlPty::started, this,
+        // PTY label — sizes to the actual path so the column is always wide enough
+        row.ptyLabel = new QLabel("—");
+#ifndef Q_OS_WIN
+        ThemeManager::instance().applyStyleSheet(row.ptyLabel, kMonoLabel);
+        // No fixed or minimum width — sizeHint is driven by the path text,
+        // so the grid column sizes itself dynamically to the actual path length.
+        if (m_ports[i]) {
+            QString path = m_ports[i]->ptyPath();
+            row.ptyLabel->setText(path.isEmpty() ? "—" : path);
+            connect(m_ports[i], &CatPort::ptyPathChanged, this,
                     [this, i](const QString& path) {
-                        m_rows[i].ptyPath->setText(path);
-                    });
-            connect(ptys[i], &RigctlPty::stopped, this,
-                    [this, i]() {
-                        m_rows[i].ptyPath->setText(RigctlPty::defaultSymlinkPath(i));
+                        if (i < m_rows.size())
+                            m_rows[i].ptyLabel->setText(path.isEmpty() ? "—" : path);
                     });
         }
+        row.ptyLabel->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(row.ptyLabel, &QLabel::customContextMenuRequested, this,
+                [this, i](const QPoint& pos) {
+                    if (i >= m_rows.size()) return;
+                    const QString path = m_rows[i].ptyLabel->text();
+                    if (path.isEmpty() || path == "—") return;
+                    QMenu menu;
+                    QAction* act = menu.addAction("Copy PTY Name");
+                    if (menu.exec(m_rows[i].ptyLabel->mapToGlobal(pos)) == act)
+                        QGuiApplication::clipboard()->setText(path);
+                });
+#else
+        row.ptyLabel->hide();
+#endif
+
+        // Clients label
+        row.clientLabel = new QLabel("—");
+        ThemeManager::instance().applyStyleSheet(row.clientLabel, kDimLabel);
+        row.clientLabel->setFixedWidth(48);
+        row.clientLabel->setAlignment(Qt::AlignCenter);
+        if (m_ports[i]) {
+            auto updateClients = [this, i]() {
+                if (i >= m_rows.size()) return;
+                int n = m_ports[i]->clientCount();
+                m_rows[i].clientLabel->setText(
+                    m_ports[i]->isRunning() ? QString::number(n) : "—");
+            };
+            updateClients();  // initialize — signal alone won't fire until first connect/disconnect
+            connect(m_ports[i], &CatPort::clientCountChanged, this, updateClients);
+        }
+
+        // Grid layout — data rows start at 1 (row 0 is the header)
+        int col = 0;
+        m_grid->addWidget(row.enableCheck,  i+1, col++);
+        m_grid->addWidget(row.portEdit,     i+1, col++);
+        m_grid->addWidget(row.dialectCombo, i+1, col++);
+        m_grid->addWidget(row.vfoACombo,    i+1, col++);
+        m_grid->addWidget(row.vfoBCombo,    i+1, col++);
+#ifndef Q_OS_WIN
+        m_grid->addWidget(row.ptyLabel,     i+1, col++);
+#endif
+        m_grid->addWidget(row.clientLabel,  i+1, col++);
+
+        // Connections
+        const int capturedI = i;
+
+        connect(row.enableCheck, &QCheckBox::toggled, this,
+                [this, capturedI](bool) {
+                    applyRowToSettings(capturedI);
+                    updateRowLocked(capturedI);
+                    emit configChanged();
+                });
+
+        connect(row.portEdit, &QLineEdit::editingFinished, this,
+                [this, capturedI]() {
+                    applyRowToSettings(capturedI);
+                    updateRowLocked(capturedI);
+                    emit configChanged();
+                });
+
+        connect(row.dialectCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this, capturedI](int) {
+                    applyRowToSettings(capturedI);
+                    emit configChanged();
+                });
+
+        connect(row.vfoACombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this, capturedI](int) {
+                    applyRowToSettings(capturedI);
+                    emit configChanged();
+                });
+
+        connect(row.vfoBCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this, capturedI](int) {
+                    applyRowToSettings(capturedI);
+                    emit configChanged();
+                });
+
+        m_rows.append(row);
+        updateRowLocked(i);
     }
+
+#ifndef Q_OS_WIN
+    m_grid->setColumnStretch(5, 1);  // PTY column (index 5) expands to fill available width
+#endif
+    m_grid->setRowStretch(m_portCount + 1, 1);
+    m_rowsBuilt = true;
 }
 
-void CatControlApplet::updateChannelStatus(int ch)
-{
-    if (ch < 0 || ch >= kChannels) {
-        return;
-    }
+// ── Lock controls while port is running ──────────────────────────────────────
 
-    auto* srv = m_servers[ch];
-    if (!srv || !srv->isRunning()) {
-        m_rows[ch].tcpStatus->setText("(stopped)");
-        m_rows[ch].tcpStatus->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.background.3}}; font-size: 10px; }"));
-    } else {
-        int n = srv->clientCount();
-        m_rows[ch].tcpStatus->setText(
-            QStringLiteral(":%1 (%2 client%3)")
-                .arg(srv->port())
-                .arg(n)
-                .arg(n == 1 ? "" : "s"));
-        m_rows[ch].tcpStatus->setStyleSheet(
-            n > 0 ? QStringLiteral("QLabel { color: %1; font-size: 10px; }")
-                         .arg(SliceColorManager::instance().hexActive(ch))
-                   : "QLabel { color: #8090a0; font-size: 10px; }");
-    }
+void CatControlApplet::updateRowLocked(int row)
+{
+    if (row >= m_rows.size()) return;
+    PortRow& r = m_rows[row];
+
+    bool hasPort  = !r.portEdit->text().isEmpty();
+    bool masterOn = AppSettings::instance().value("CatEnabled", "False").toString() == "True";
+    // Lock on UI state only — isRunning() lags behind the checkbox by one applyCatPortCount cycle.
+    bool locked   = masterOn && r.enableCheck->isChecked() && hasPort;
+
+    r.enableCheck->setEnabled(hasPort || !r.enableCheck->isChecked());
+    r.portEdit->setReadOnly(locked);
+    r.dialectCombo->setEnabled(!locked);
+    r.vfoACombo->setEnabled(!locked);
+    r.vfoBCombo->setEnabled(!locked);
 }
 
-void CatControlApplet::updateAllChannelStatus()
-{
-    for (int i = 0; i < kChannels; ++i) {
-        updateChannelStatus(i);
-    }
-}
+// ── Persist row settings ─────────────────────────────────────────────────────
 
-void CatControlApplet::setTcpEnabled(bool on)
+void CatControlApplet::applyRowToSettings(int row)
 {
-    QSignalBlocker b(m_tcpEnable);
-    m_tcpEnable->setChecked(on);
-    updateAllChannelStatus();
-}
+    if (row >= m_rows.size()) return;
+    const PortRow& r = m_rows[row];
+    auto& s = AppSettings::instance();
+    const QString prefix = QString("CatPort_%1_").arg(row);
 
-void CatControlApplet::setPtyEnabled(bool on)
-{
-    QSignalBlocker b(m_ptyEnable);
-    m_ptyEnable->setChecked(on);
-    updateAllChannelStatus();
+    s.setValue(prefix + "Enabled", r.enableCheck->isChecked() ? "True" : "False");
+    s.setValue(prefix + "Port",    r.portEdit->text());
+
+    int dIdx = r.dialectCombo->currentIndex();
+    QString dialect = (dIdx == 1) ? "TS2000" : (dIdx == 2) ? "FlexCAT" : "Rigctld";
+    s.setValue(prefix + "Dialect", dialect);
+    s.setValue(prefix + "VfoA", QString::number(r.vfoACombo->currentData().toInt()));
+    s.setValue(prefix + "VfoB", QString::number(r.vfoBCombo->currentData().toInt()));
+    s.save();
 }
 
 } // namespace AetherSDR

--- a/src/gui/CatControlApplet.h
+++ b/src/gui/CatControlApplet.h
@@ -1,57 +1,85 @@
 #pragma once
 
+#include "core/CatPort.h"
+
 #include <QWidget>
+#include <QList>
 
 class QPushButton;
-class QLabel;
+class QCheckBox;
+class QComboBox;
 class QLineEdit;
+class QLabel;
+class QVBoxLayout;
+class QGridLayout;
+class QIntValidator;
 
 namespace AetherSDR {
 
-class RadioModel;
-class RigctlServer;
-class RigctlPty;
-
-// CAT Control Applet — 4-channel rigctld TCP + PTY control panel.
-// Each channel (A-D) is bound to a slice index (0-3) and provides an
-// independent rigctld TCP port + PTY symlink.
+// CAT Control Applet — docked and floating views in one widget.
+//
+// Docked:   [Enable CAT]  "Pop out for configuration."
+// Floating: per-port table (En / Port / Dialect / VFO A / VFO B / PTY / Clients)
+//
+// AppletPanel calls setFloating(true/false) when the ContainerWidget's dock
+// mode changes. MainWindow calls setPorts() / setMaxSlices() after construction.
+// configChanged() fires whenever any per-port setting is saved; MainWindow
+// connects this to applyCatPortCount().
 class CatControlApplet : public QWidget {
     Q_OBJECT
 
 public:
-    static constexpr int kChannels = 4;
-
     explicit CatControlApplet(QWidget* parent = nullptr);
 
-    void setRadioModel(RadioModel* model);
-    void setRigctlServers(RigctlServer** servers, int count);
-    void setRigctlPtys(RigctlPty** ptys, int count);
+    // Wire the backing CatPort objects. Call before the applet is shown.
+    void setPorts(CatPort** ports, int count);
 
-    // Sync Enable button state (called by MainWindow on autostart)
-    void setTcpEnabled(bool on);
-    void setPtyEnabled(bool on);
+    // Update how many slices are available (scales VFO A/B combos).
+    void setMaxSlices(int n);
+
+    // Switch between docked (simple) and floating (full table) views.
+    void setFloating(bool on);
+
+    // Sync the master enable button without firing enableChanged.
+    void setCatEnabled(bool on);
+
+signals:
+    void enableChanged(bool on);  // master toggle
+    void configChanged();         // any per-port setting changed
 
 private:
-    void buildUI();
-    void updateChannelStatus(int ch);
-    void updateAllChannelStatus();
+    void buildDockedView(QWidget* page);
+    void buildTableRows();
+    void populateVfoCombo(QComboBox* combo, bool includeNone);
+    void applyRowToSettings(int row);
+    void updateRowLocked(int row);
 
-    RadioModel*   m_model{nullptr};
-    RigctlServer* m_servers[kChannels]{};
-    RigctlPty*    m_ptys[kChannels]{};
+    static constexpr int kMaxPorts = 8;
 
-    // Global controls
-    QPushButton* m_tcpEnable{nullptr};
-    QPushButton* m_ptyEnable{nullptr};
-    QLineEdit*   m_basePort{nullptr};
-
-    // Per-channel status rows
-    struct ChannelRow {
-        QLabel* badge{nullptr};      // coloured "A"/"B"/"C"/"D"
-        QLabel* tcpStatus{nullptr};  // ":4532 (1 client)" or "(stopped)"
-        QLabel* ptyPath{nullptr};    // RigctlPty::defaultSymlinkPath(i)
+    struct PortRow {
+        QCheckBox* enableCheck{nullptr};
+        QLineEdit* portEdit{nullptr};
+        QComboBox* dialectCombo{nullptr};
+        QComboBox* vfoACombo{nullptr};
+        QComboBox* vfoBCombo{nullptr};
+        QLabel*    ptyLabel{nullptr};
+        QLabel*    clientLabel{nullptr};
     };
-    ChannelRow m_rows[kChannels];
+
+    CatPort*  m_ports[kMaxPorts]{};
+    int       m_portCount{0};
+    int       m_maxSlices{kMaxPorts};  // show all letters pre-connection; capped to hw max on connect
+
+    QVBoxLayout*    m_rootLayout{nullptr};
+    QWidget*        m_dockedPage{nullptr};
+    QWidget*        m_floatingPage{nullptr};   // nullptr until first setFloating(true)
+    QPushButton*    m_enableBtn{nullptr};
+    QPushButton*    m_floatingEnableBtn{nullptr};
+
+    // Floating view internals
+    QGridLayout*    m_grid{nullptr};
+    QList<PortRow>  m_rows;
+    bool            m_rowsBuilt{false};
 };
 
 } // namespace AetherSDR

--- a/src/gui/CatPopoutWindow.cpp
+++ b/src/gui/CatPopoutWindow.cpp
@@ -1,0 +1,377 @@
+#include "CatPopoutWindow.h"
+#include "core/AppSettings.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QScrollArea>
+#include <QVBoxLayout>
+#include <QWidget>
+#include <QIntValidator>
+#include <QFrame>
+
+namespace AetherSDR {
+
+namespace {
+
+const char* kHeaderStyle =
+    "QLabel { color: #506070; font-size: 10px; font-weight: bold; }";
+const char* kDimLabel =
+    "QLabel { color: #8090a0; font-size: 11px; }";
+const char* kMonoLabel =
+    "QLabel { color: #607080; font-size: 10px; font-family: monospace; }";
+const char* kPortEdit =
+    "QLineEdit { font-size: 11px; background: #0a0a18; border: 1px solid #1e2e3e;"
+    " border-radius: 3px; padding: 0px 3px; color: #c8d8e8; }";
+const char* kComboStyle =
+    "QComboBox { font-size: 11px; background: #1a2a3a; border: 1px solid #1e2e3e;"
+    " border-radius: 3px; padding: 0px 3px; color: #c8d8e8; }"
+    "QComboBox::drop-down { border: none; }"
+    "QComboBox QAbstractItemView { background: #1a2a3a; color: #c8d8e8; }";
+
+const char* kSep =
+    "QFrame { color: #1e2e3e; }";
+
+// Minimum valid port number for CAT (exclude system ports)
+constexpr int kMinPort = 1024;
+constexpr int kMaxPort = 65535;
+
+QString sliceLetter(int idx)
+{
+    if (idx < 0 || idx > 25) return "—";
+    return QString(QChar('A' + idx));
+}
+
+} // namespace
+
+// ── Constructor ──────────────────────────────────────────────────────────────
+
+CatPopoutWindow::CatPopoutWindow(QWidget* parent)
+    : PersistentDialog("CAT Configuration", "CatPopoutGeometry", parent)
+{
+    setMinimumWidth(560);
+    buildTable();
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+void CatPopoutWindow::setPorts(CatPort** ports, int count)
+{
+    m_portCount = qMin(count, kMaxPorts);
+    for (int i = 0; i < m_portCount; ++i)
+        m_ports[i] = ports[i];
+    for (int i = m_portCount; i < kMaxPorts; ++i)
+        m_ports[i] = nullptr;
+    rebuildRows();
+}
+
+void CatPopoutWindow::setMaxSlices(int n)
+{
+    m_maxSlices = qMax(1, n);
+    // Rebuild VFO combos with updated slice count
+    for (int row = 0; row < m_rows.size(); ++row) {
+        PortRow& r = m_rows[row];
+        int savedA = r.vfoACombo->currentIndex();
+        int savedB = r.vfoBCombo->currentIndex();
+
+        r.vfoACombo->blockSignals(true);
+        r.vfoBCombo->blockSignals(true);
+
+        r.vfoACombo->clear();
+        r.vfoBCombo->clear();
+        populateVfoCombo(r.vfoACombo, false);
+        populateVfoCombo(r.vfoBCombo, true);
+
+        r.vfoACombo->setCurrentIndex(qMin(savedA, r.vfoACombo->count() - 1));
+        r.vfoBCombo->setCurrentIndex(qMin(savedB, r.vfoBCombo->count() - 1));
+
+        r.vfoACombo->blockSignals(false);
+        r.vfoBCombo->blockSignals(false);
+    }
+}
+
+void CatPopoutWindow::setMasterEnabled(bool on)
+{
+    m_masterEnabled = on;
+    for (int i = 0; i < m_rows.size(); ++i) {
+        bool portRunning = m_ports[i] && m_ports[i]->isRunning();
+        updateRowEnabled(i, portRunning);
+    }
+}
+
+// ── Build the fixed table structure ─────────────────────────────────────────
+
+void CatPopoutWindow::buildTable()
+{
+    auto* root = new QVBoxLayout(bodyWidget());
+    root->setContentsMargins(8, 8, 8, 8);
+    root->setSpacing(4);
+
+    // Column headers
+    auto* headerRow = new QHBoxLayout;
+    headerRow->setSpacing(0);
+
+    auto addHeader = [&](const QString& text, int fixedW) {
+        auto* lbl = new QLabel(text);
+        lbl->setStyleSheet(kHeaderStyle);
+        lbl->setFixedWidth(fixedW);
+        lbl->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+        headerRow->addWidget(lbl);
+    };
+
+    addHeader("En",      24);
+    addHeader("Port",    52);
+    addHeader("Dialect", 88);
+    addHeader("VFO A",   56);
+    addHeader("VFO B",   56);
+#ifndef Q_OS_WIN
+    addHeader("PTY",    140);
+#endif
+    addHeader("Clients", 50);
+    headerRow->addStretch();
+    root->addLayout(headerRow);
+
+    // Separator
+    auto* sep = new QFrame;
+    sep->setFrameShape(QFrame::HLine);
+    sep->setStyleSheet(kSep);
+    root->addWidget(sep);
+
+    // Scroll area for the rows
+    auto* scroll = new QScrollArea;
+    scroll->setWidgetResizable(true);
+    scroll->setFrameShape(QFrame::NoFrame);
+    scroll->setStyleSheet("QScrollArea { background: transparent; }");
+
+    auto* rowContainer = new QWidget;
+    rowContainer->setStyleSheet("QWidget { background: transparent; }");
+    m_grid = new QGridLayout(rowContainer);
+    m_grid->setContentsMargins(0, 0, 0, 0);
+    m_grid->setSpacing(3);
+
+    scroll->setWidget(rowContainer);
+    root->addWidget(scroll);
+}
+
+// ── Rebuild rows when ports change ──────────────────────────────────────────
+
+void CatPopoutWindow::populateVfoCombo(QComboBox* combo, bool includeNone)
+{
+    if (includeNone)
+        combo->addItem("—", -1);
+    for (int i = 0; i < m_maxSlices; ++i)
+        combo->addItem(sliceLetter(i), i);
+}
+
+void CatPopoutWindow::rebuildRows()
+{
+    // Remove existing rows from grid
+    while (QLayoutItem* item = m_grid->takeAt(0)) {
+        if (item->widget()) item->widget()->setParent(nullptr);
+        delete item;
+    }
+    m_rows.clear();
+
+    auto& settings = AppSettings::instance();
+
+    for (int i = 0; i < m_portCount; ++i) {
+        PortRow row;
+        const QString prefix = QString("CatPort_%1_").arg(i);
+
+        // Enable checkbox
+        row.enableCheck = new QCheckBox;
+        row.enableCheck->setFixedWidth(22);
+        {
+            bool en = settings.value(prefix + "Enabled", "False").toString() == "True";
+            QSignalBlocker b(row.enableCheck);
+            row.enableCheck->setChecked(en);
+        }
+
+        // Port line edit
+        row.portEdit = new QLineEdit;
+        row.portEdit->setStyleSheet(kPortEdit);
+        row.portEdit->setFixedWidth(50);
+        row.portEdit->setAlignment(Qt::AlignCenter);
+        row.portEdit->setValidator(new QIntValidator(kMinPort, kMaxPort, row.portEdit));
+        row.portEdit->setPlaceholderText("port");
+        {
+            QString portStr = settings.value(prefix + "Port", "").toString();
+            QSignalBlocker b(row.portEdit);
+            row.portEdit->setText(portStr);
+        }
+
+        // Dialect combo
+        row.dialectCombo = new QComboBox;
+        row.dialectCombo->setStyleSheet(kComboStyle);
+        row.dialectCombo->setFixedWidth(86);
+        row.dialectCombo->addItem("Rigctld",  static_cast<int>(CatDialect::Rigctld));
+        row.dialectCombo->addItem("TS-2000",  static_cast<int>(CatDialect::TS2000));
+        row.dialectCombo->addItem("FlexCAT",  static_cast<int>(CatDialect::FlexCAT));
+        {
+            QString d = settings.value(prefix + "Dialect", "Rigctld").toString();
+            int idx = 0;
+            if (d == "TS2000") idx = 1;
+            else if (d == "FlexCAT") idx = 2;
+            QSignalBlocker b(row.dialectCombo);
+            row.dialectCombo->setCurrentIndex(idx);
+        }
+
+        // VFO A combo
+        row.vfoACombo = new QComboBox;
+        row.vfoACombo->setStyleSheet(kComboStyle);
+        row.vfoACombo->setFixedWidth(54);
+        populateVfoCombo(row.vfoACombo, false);
+        {
+            int vfoA = settings.value(prefix + "VfoA", "0").toInt();
+            int idx = row.vfoACombo->findData(vfoA);
+            QSignalBlocker b(row.vfoACombo);
+            row.vfoACombo->setCurrentIndex(qMax(0, idx));
+        }
+
+        // VFO B combo
+        row.vfoBCombo = new QComboBox;
+        row.vfoBCombo->setStyleSheet(kComboStyle);
+        row.vfoBCombo->setFixedWidth(54);
+        populateVfoCombo(row.vfoBCombo, true);
+        {
+            int vfoB = settings.value(prefix + "VfoB", "-1").toInt();
+            int idx = row.vfoBCombo->findData(vfoB);
+            QSignalBlocker b(row.vfoBCombo);
+            row.vfoBCombo->setCurrentIndex(qMax(0, idx));
+        }
+
+#ifndef Q_OS_WIN
+        // PTY path (read-only label)
+        row.ptyLabel = new QLabel("—");
+        row.ptyLabel->setStyleSheet(kMonoLabel);
+        row.ptyLabel->setFixedWidth(138);
+        if (m_ports[i]) {
+            QString path = m_ports[i]->ptyPath();
+            row.ptyLabel->setText(path.isEmpty() ? "—" : path);
+            connect(m_ports[i], &CatPort::ptyPathChanged, this,
+                    [this, i](const QString& path) {
+                        if (i < m_rows.size())
+                            m_rows[i].ptyLabel->setText(path.isEmpty() ? "—" : path);
+                    });
+        }
+#else
+        row.ptyLabel = new QLabel;  // hidden placeholder on Windows
+#endif
+
+        // Client count
+        row.clientLabel = new QLabel("—");
+        row.clientLabel->setStyleSheet(kDimLabel);
+        row.clientLabel->setFixedWidth(48);
+        row.clientLabel->setAlignment(Qt::AlignCenter);
+        if (m_ports[i]) {
+            auto updateClients = [this, i]() {
+                if (i >= m_rows.size()) return;
+                int n = m_ports[i]->clientCount();
+                m_rows[i].clientLabel->setText(
+                    m_ports[i]->isRunning() ? QString::number(n) : "—");
+            };
+            connect(m_ports[i], &CatPort::clientCountChanged,
+                    this, updateClients);
+        }
+
+        // Add to grid
+        int col = 0;
+        m_grid->addWidget(row.enableCheck,  i, col++);
+        m_grid->addWidget(row.portEdit,     i, col++);
+        m_grid->addWidget(row.dialectCombo, i, col++);
+        m_grid->addWidget(row.vfoACombo,    i, col++);
+        m_grid->addWidget(row.vfoBCombo,    i, col++);
+#ifndef Q_OS_WIN
+        m_grid->addWidget(row.ptyLabel,     i, col++);
+#endif
+        m_grid->addWidget(row.clientLabel,  i, col++);
+
+        // ── Connections ──────────────────────────────────────────────────────
+
+        const int capturedI = i;
+
+        connect(row.enableCheck, &QCheckBox::toggled, this,
+                [this, capturedI](bool /*on*/) {
+                    applyRowToSettings(capturedI);
+                    updateRowEnabled(capturedI, false);
+                    emit configChanged();
+                });
+
+        connect(row.portEdit, &QLineEdit::editingFinished, this,
+                [this, capturedI]() {
+                    applyRowToSettings(capturedI);
+                    emit configChanged();
+                });
+
+        connect(row.dialectCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this, capturedI](int) {
+                    applyRowToSettings(capturedI);
+                    emit configChanged();
+                });
+
+        connect(row.vfoACombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this, capturedI](int) {
+                    applyRowToSettings(capturedI);
+                    emit configChanged();
+                });
+
+        connect(row.vfoBCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this, capturedI](int) {
+                    applyRowToSettings(capturedI);
+                    emit configChanged();
+                });
+
+        m_rows.append(row);
+        updateRowEnabled(i, m_ports[i] && m_ports[i]->isRunning());
+    }
+
+    // Push rows to top
+    m_grid->setRowStretch(m_portCount, 1);
+}
+
+// ── Gray out controls while the port is running ──────────────────────────────
+
+void CatPopoutWindow::updateRowEnabled(int row, bool portRunning)
+{
+    if (row >= m_rows.size()) return;
+    PortRow& r = m_rows[row];
+
+    bool hasPort = !r.portEdit->text().isEmpty();
+    // Enable checkbox can only be checked if there's a port number
+    r.enableCheck->setEnabled(hasPort || !r.enableCheck->isChecked());
+
+    // All config fields are locked while the port is running
+    bool locked = portRunning || (m_masterEnabled && r.enableCheck->isChecked() && hasPort);
+    r.portEdit->setEnabled(!locked);
+    r.dialectCombo->setEnabled(!locked);
+    r.vfoACombo->setEnabled(!locked);
+    r.vfoBCombo->setEnabled(!locked);
+}
+
+// ── Persist a row's settings ────────────────────────────────────────────────
+
+void CatPopoutWindow::applyRowToSettings(int row)
+{
+    if (row >= m_rows.size()) return;
+    const PortRow& r = m_rows[row];
+
+    auto& s = AppSettings::instance();
+    const QString prefix = QString("CatPort_%1_").arg(row);
+
+    s.setValue(prefix + "Enabled", r.enableCheck->isChecked() ? "True" : "False");
+    s.setValue(prefix + "Port",    r.portEdit->text());
+
+    int dIdx = r.dialectCombo->currentIndex();
+    QString dialect = (dIdx == 1) ? "TS2000" : (dIdx == 2) ? "FlexCAT" : "Rigctld";
+    s.setValue(prefix + "Dialect", dialect);
+
+    s.setValue(prefix + "VfoA", QString::number(r.vfoACombo->currentData().toInt()));
+    s.setValue(prefix + "VfoB", QString::number(r.vfoBCombo->currentData().toInt()));
+
+    s.save();
+}
+
+} // namespace AetherSDR

--- a/src/gui/CatPopoutWindow.h
+++ b/src/gui/CatPopoutWindow.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "PersistentDialog.h"
+#include "core/CatPort.h"
+
+#include <QList>
+
+class QCheckBox;
+class QLineEdit;
+class QComboBox;
+class QLabel;
+class QGridLayout;
+class QScrollArea;
+
+namespace AetherSDR {
+
+// Popped-out CAT configuration window.
+//
+// Shows one row per CatPort with:
+//   [En] [Port] [Dialect] [VFO A] [VFO B] [PTY path] [Clients]
+//
+// The enable checkbox freezes all other controls while the port is running
+// (matching SmartSDR for Mac UX). Emits configChanged() whenever any setting
+// is modified; MainWindow connects this to applyCatPortCount().
+class CatPopoutWindow : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    explicit CatPopoutWindow(QWidget* parent = nullptr);
+
+    // Called by MainWindow to wire the ports and set the slice count.
+    void setPorts(CatPort** ports, int count);
+    void setMaxSlices(int n);
+
+    // Sync the enable toggle state from the master enable in the applet.
+    void setMasterEnabled(bool on);
+
+signals:
+    void configChanged();
+
+private:
+    void buildTable();
+    void rebuildRows();
+    void updateRowEnabled(int row, bool portRunning);
+    void applyRowToSettings(int row);
+    void populateVfoCombo(QComboBox* combo, bool includeNone);
+
+    static constexpr int kMaxPorts = 8;
+
+    struct PortRow {
+        QCheckBox* enableCheck{nullptr};
+        QLineEdit* portEdit{nullptr};
+        QComboBox* dialectCombo{nullptr};
+        QComboBox* vfoACombo{nullptr};
+        QComboBox* vfoBCombo{nullptr};
+        QLabel*    ptyLabel{nullptr};
+        QLabel*    clientLabel{nullptr};
+    };
+
+    CatPort*  m_ports[kMaxPorts]{};
+    int       m_portCount{0};
+    int       m_maxSlices{2};
+    bool      m_masterEnabled{false};
+
+    QGridLayout* m_grid{nullptr};
+    QList<PortRow> m_rows;
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4407,21 +4407,40 @@ MainWindow::MainWindow(QWidget* parent)
         }
     });
 
-    // ── 8-channel CAT: rigctld + PTY (A-H, each bound to a slice) ────────────
-    {
-        for (int i = 0; i < kCatChannels; ++i) {
-            m_rigctlServers[i] = new RigctlServer(&m_radioModel, this);
-            m_rigctlServers[i]->setSliceIndex(i);
-            m_rigctlPtys[i] = new RigctlPty(&m_radioModel, this);
-            m_rigctlPtys[i]->setSliceIndex(i);
-            // Symlink path is computed per-user via
-            // RigctlPty::defaultSymlinkPath() (#2940 / GHSA-qxhr-cwrc-pvrm).
-            m_rigctlPtys[i]->setSymlinkPath(RigctlPty::defaultSymlinkPath(i));
-        }
+    // ── Unified CAT ports (kCatPorts slots, configured from settings) ───────────
+    // Migrate old dual-server settings to the new per-port schema on first run.
+    migrateCatSettings();
+    for (int i = 0; i < kCatPorts; ++i) {
+        m_catPorts[i] = new CatPort(&m_radioModel, this);
+        // Per-user symlink path (GHSA-qxhr-cwrc-pvrm — matches RigctlPty fix).
+        m_catPorts[i]->setSymlinkPath(CatPort::defaultSymlinkPath(i));
+        // Load persisted dialect and VFO config; port and enabled are read
+        // in applyCatPortCount() just before starting.
+        const QString prefix = QString("CatPort_%1_").arg(i);
+        auto& s = AppSettings::instance();
+        QString d = s.value(prefix + "Dialect", "Rigctld").toString();
+        CatDialect dial = (d == "FlexCAT") ? CatDialect::FlexCAT
+                        : (d == "TS2000")  ? CatDialect::TS2000
+                        : CatDialect::Rigctld;
+        m_catPorts[i]->setDialect(dial);
+        m_catPorts[i]->setVfoA(s.value(prefix + "VfoA", "0").toInt());
+        m_catPorts[i]->setVfoB(s.value(prefix + "VfoB", "-1").toInt());
     }
-    m_appletPanel->catControlApplet()->setRadioModel(&m_radioModel);
-    m_appletPanel->catControlApplet()->setRigctlServers(m_rigctlServers, kCatChannels);
-    m_appletPanel->catControlApplet()->setRigctlPtys(m_rigctlPtys, kCatChannels);
+
+    // Wire the applet to the port objects
+    m_appletPanel->catControlApplet()->setPorts(m_catPorts, kCatPorts);
+    m_appletPanel->catControlApplet()->setMaxSlices(catPortTargetCount());
+
+    // Wire master enable toggle from the docked applet
+    connect(m_appletPanel->catControlApplet(), &CatControlApplet::enableChanged,
+            this, [this](bool) { applyCatPortCount(); });
+
+    // Per-port config changes in the floating table → re-apply port states
+    connect(m_appletPanel->catControlApplet(), &CatControlApplet::configChanged,
+            this, [this]() { applyCatPortCount(); });
+
+    // Auto-start based on saved master enable
+    applyCatPortCount();
     m_appletPanel->daxApplet()->setRadioModel(&m_radioModel);
     m_appletPanel->daxIqApplet()->setRadioModel(&m_radioModel);
 #ifdef HAVE_WEBSOCKETS
@@ -7738,59 +7757,17 @@ void MainWindow::buildMenuBar()
 
     settingsMenu->addSeparator();
 
-    auto* autoRigctlAction = settingsMenu->addAction("Autostart rigctld with AetherSDR");
-    autoRigctlAction->setCheckable(true);
-    autoRigctlAction->setChecked(
-        AppSettings::instance().value("AutoStartRigctld", "False").toString() == "True");
-    connect(autoRigctlAction, &QAction::toggled, this, [this](bool on) {
-        auto& s = AppSettings::instance();
-        s.setValue("AutoStartRigctld", on ? "True" : "False");
-        s.save();
-        if (m_radioModel.isConnected()) {
-            const int basePort = s.value("CatTcpPort", "4532").toInt();
-            for (int i = 0; i < kCatChannels; ++i) {
-                if (on && m_rigctlServers[i] && !m_rigctlServers[i]->isRunning())
-                    m_rigctlServers[i]->start(static_cast<quint16>(basePort + i));
-                else if (!on && m_rigctlServers[i] && m_rigctlServers[i]->isRunning())
-                    m_rigctlServers[i]->stop();
-            }
-            if (m_appletPanel && m_appletPanel->catControlApplet())
-                m_appletPanel->catControlApplet()->setTcpEnabled(on);
-        }
-    });
-
-#ifdef _WIN32
-    // CAT virtual serial ports require macOS or Linux. Force the setting
-    // off so a saved True (e.g. from a Linux settings import) can't
-    // activate anything, and omit the menu entry entirely (#1556).
-    {
-        auto& s = AppSettings::instance();
-        if (s.value("AutoStartCAT", "False").toString() != "False") {
-            s.setValue("AutoStartCAT", "False");
-            s.save();
-        }
-    }
-#else
+    // CAT: unified port manager (rigctld / TS-2000 / FlexCAT per port)
     auto* autoCatAction = settingsMenu->addAction("Autostart CAT with AetherSDR");
     autoCatAction->setCheckable(true);
     autoCatAction->setChecked(
-        AppSettings::instance().value("AutoStartCAT", "False").toString() == "True");
+        AppSettings::instance().value("CatEnabled", "False").toString() == "True");
     connect(autoCatAction, &QAction::toggled, this, [this](bool on) {
         auto& s = AppSettings::instance();
-        s.setValue("AutoStartCAT", on ? "True" : "False");
+        s.setValue("CatEnabled", on ? "True" : "False");
         s.save();
-        if (m_radioModel.isConnected()) {
-            for (int i = 0; i < kCatChannels; ++i) {
-                if (on && m_rigctlPtys[i] && !m_rigctlPtys[i]->isRunning())
-                    m_rigctlPtys[i]->start();
-                else if (!on && m_rigctlPtys[i] && m_rigctlPtys[i]->isRunning())
-                    m_rigctlPtys[i]->stop();
-            }
-            if (m_appletPanel && m_appletPanel->catControlApplet())
-                m_appletPanel->catControlApplet()->setPtyEnabled(on);
-        }
+        applyCatPortCount();
     });
-#endif
 
     auto* autoTciAction = settingsMenu->addAction("Autostart TCI with AetherSDR");
     autoTciAction->setCheckable(true);
@@ -7863,10 +7840,7 @@ void MainWindow::buildMenuBar()
             && action != midiAction
 #endif
             && action != multiFlexAction
-            && action != autoRigctlAction
-#ifndef _WIN32
             && action != autoCatAction
-#endif
             && action != autoTciAction
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
             && action != autoDaxAction
@@ -9211,6 +9185,99 @@ void MainWindow::buildUI()
     }
 }
 
+// ─── CAT port helpers ─────────────────────────────────────────────────────────
+
+int MainWindow::catPortTargetCount() const
+{
+    if (!m_radioModel.isConnected()) return 1;
+    return RadioModel::maxSlicesForModel(m_radioModel.model());
+}
+
+void MainWindow::applyCatPortCount()
+{
+    auto& s = AppSettings::instance();
+    const bool masterOn = s.value("CatEnabled", "False").toString() == "True";
+    const int  target   = catPortTargetCount();
+
+    for (int i = 0; i < kCatPorts; ++i) {
+        if (!m_catPorts[i]) continue;
+
+        const QString prefix = QString("CatPort_%1_").arg(i);
+        const bool portEnabled = s.value(prefix + "Enabled", "False").toString() == "True";
+        const int  portNum     = s.value(prefix + "Port", "").toInt();
+        const bool shouldRun   = masterOn && portEnabled && (portNum >= 1024) && (i < target);
+
+        if (shouldRun && !m_catPorts[i]->isRunning()) {
+            // Re-apply config in case dialect/VFO was changed while stopped
+            QString d = s.value(prefix + "Dialect", "Rigctld").toString();
+            CatDialect dial = (d == "FlexCAT") ? CatDialect::FlexCAT
+                            : (d == "TS2000")  ? CatDialect::TS2000
+                            : CatDialect::Rigctld;
+            m_catPorts[i]->setDialect(dial);
+            m_catPorts[i]->setVfoA(s.value(prefix + "VfoA", "0").toInt());
+            m_catPorts[i]->setVfoB(s.value(prefix + "VfoB", "-1").toInt());
+            m_catPorts[i]->start(static_cast<quint16>(portNum));
+        } else if (!shouldRun && m_catPorts[i]->isRunning()) {
+            m_catPorts[i]->stop();
+        }
+    }
+
+    auto* applet = m_appletPanel ? m_appletPanel->catControlApplet() : nullptr;
+    if (applet) {
+        applet->setCatEnabled(masterOn);
+        // Show hardware max when connected; fall back to kMaxPorts (all letters) when not.
+        const int hwSlices = (target > 1) ? target : kCatPorts;
+        applet->setMaxSlices(hwSlices);
+    }
+}
+
+void MainWindow::migrateCatSettings()
+{
+    auto& s = AppSettings::instance();
+
+    // Only migrate if new schema not yet written
+    if (s.contains("CatPort_0_Port")) return;
+
+    // Port 0: old rigctld settings
+    QString rigPort = s.value("CatTcpPort", "4532").toString();
+    bool rigEnabled = s.value("AutoStartRigctld", "False").toString() == "True";
+    s.setValue("CatPort_0_Port",    rigPort);
+    s.setValue("CatPort_0_Dialect", "Rigctld");
+    s.setValue("CatPort_0_VfoA",    "0");
+    s.setValue("CatPort_0_VfoB",    "1");
+    s.setValue("CatPort_0_Enabled", rigEnabled ? "True" : "False");
+
+    // Port 1: old SmartCAT settings
+    QString catPort = s.value("SmartCatPort", "5001").toString();
+    bool catEnabled = s.value("AutoStartCAT", "False").toString() == "True";
+    s.setValue("CatPort_1_Port",    catPort);
+    s.setValue("CatPort_1_Dialect", "FlexCAT");
+    s.setValue("CatPort_1_VfoA",    "0");
+    s.setValue("CatPort_1_VfoB",    "1");
+    s.setValue("CatPort_1_Enabled", catEnabled ? "True" : "False");
+
+    // Remaining ports: disabled with no port
+    for (int i = 2; i < kCatPorts; ++i) {
+        const QString pfx = QString("CatPort_%1_").arg(i);
+        s.setValue(pfx + "Port",    "");
+        s.setValue(pfx + "Dialect", "FlexCAT");
+        s.setValue(pfx + "VfoA",    "0");
+        s.setValue(pfx + "VfoB",    "-1");
+        s.setValue(pfx + "Enabled", "False");
+    }
+
+    // Master enable: on if either old server was enabled
+    s.setValue("CatEnabled", (rigEnabled || catEnabled) ? "True" : "False");
+
+    s.save();
+}
+
+void MainWindow::adjustCatPortCounts(bool connected)
+{
+    Q_UNUSED(connected)
+    applyCatPortCount();
+}
+
 // ─── Theme ────────────────────────────────────────────────────────────────────
 
 void MainWindow::applyDarkTheme()
@@ -9318,38 +9385,14 @@ void MainWindow::onConnectionStateChanged(bool connected)
         if (m_bsExpiryTimer && !m_bsExpiryTimer->isActive())
             m_bsExpiryTimer->start();
 
-        // Auto-start 4-channel rigctld TCP servers if enabled
-        auto& as = AppSettings::instance();
-        if (as.value("AutoStartRigctld", "False").toString() == "True") {
-            const int basePort = as.value("CatTcpPort", "4532").toInt();
-            for (int i = 0; i < kCatChannels; ++i) {
-                if (m_rigctlServers[i] && !m_rigctlServers[i]->isRunning()) {
-                    m_rigctlServers[i]->start(
-                        static_cast<quint16>(basePort + i));
-                    qDebug() << "AutoStart: rigctld ch" << i
-                             << "on port" << (basePort + i);
-                }
-            }
-            if (m_appletPanel && m_appletPanel->catControlApplet())
-                m_appletPanel->catControlApplet()->setTcpEnabled(true);
-        }
-        // Auto-start 8-channel CAT virtual serial ports if enabled
-        if (as.value("AutoStartCAT", "False").toString() == "True") {
-            for (int i = 0; i < kCatChannels; ++i) {
-                if (m_rigctlPtys[i] && !m_rigctlPtys[i]->isRunning()) {
-                    m_rigctlPtys[i]->start();
-                    qDebug() << "AutoStart: PTY ch" << i
-                             << m_rigctlPtys[i]->symlinkPath();
-                }
-            }
-            if (m_appletPanel && m_appletPanel->catControlApplet())
-                m_appletPanel->catControlApplet()->setPtyEnabled(true);
-        }
+        // Apply CAT port counts for the newly connected radio.
+        // applyCatPortCount() starts/stops ports up to maxSlicesForModel().
+        applyCatPortCount();
 #ifdef HAVE_WEBSOCKETS
         // Auto-start TCI WebSocket server if enabled
-        if (as.value("AutoStartTCI", "False").toString() == "True") {
+        if (AppSettings::instance().value("AutoStartTCI", "False").toString() == "True") {
             if (m_tciServer && !m_tciServer->isRunning()) {
-                int tciPort = as.value("TciPort", "50001").toInt();
+                int tciPort = AppSettings::instance().value("TciPort", "50001").toInt();
                 m_tciServer->start(static_cast<quint16>(tciPort));
                 qDebug() << "AutoStart: TCI on port" << tciPort
                          << " running=" << m_tciServer->isRunning();
@@ -9494,6 +9537,10 @@ void MainWindow::onConnectionStateChanged(bool connected)
             }
         }
     } else {
+        // Radio disconnected: trim CAT ports back to 1 so apps on channel A
+        // stay connected through brief reconnects, higher channels stop cleanly.
+        applyCatPortCount();  // catPortTargetCount() returns 1 when !connected
+
         if (m_layoutRestoreTimer) {
             m_layoutRestoreTimer->stop();
         }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -7,11 +7,10 @@
 #include "core/CommandParser.h"   // MessageSeverity for onRadioMessage slot
 #include "core/RadioDiscovery.h"
 #include "core/AudioEngine.h"
-#include "core/RigctlServer.h"
+#include "core/CatPort.h"
 #ifdef HAVE_WEBSOCKETS
 #include "core/TciServer.h"
 #endif
-#include "core/RigctlPty.h"
 #include "core/SmartLinkClient.h"
 #include "core/WanConnection.h"
 #include "core/CwDecoder.h"
@@ -149,6 +148,7 @@ protected:
 private slots:
     // Radio/connection events
     void onConnectionStateChanged(bool connected);
+    void adjustCatPortCounts(bool connected);  // called from onConnectionStateChanged
     void onConnectionError(const QString& msg);
     // GHSA-wfx7-w6p8-4jr2 phase 2 (#2951): show mismatch modal and
     // forward the operator's decision back to the WanConnection.
@@ -422,10 +422,17 @@ private:
     QsoRecorder*      m_qsoRecorder{nullptr};
     ClientPuduMonitor* m_finalMonitor{nullptr};
     BandSettings      m_bandSettings;
-    // 8-channel CAT: each channel (A-H) binds to a slice index (0-7)
-    static constexpr int kCatChannels = 8;
-    RigctlServer*     m_rigctlServers[kCatChannels]{};
-    RigctlPty*        m_rigctlPtys[kCatChannels]{};
+    // CAT ports: up to 8 unified ports (rigctld / TS-2000 / FlexCAT), one per slice.
+    static constexpr int kCatPorts = 8;
+    CatPort* m_catPorts[kCatPorts]{};
+
+    // Returns how many CAT ports should be visible in the UI given radio state.
+    // 1 when no radio; maxSlicesForModel() when connected.
+    int catPortTargetCount() const;
+    // Start/stop ports to match CatEnabled master + per-port Enabled flags.
+    void applyCatPortCount();
+    // One-time settings migration from the old dual-server key schema.
+    void migrateCatSettings();
 #ifdef HAVE_WEBSOCKETS
     TciServer*        m_tciServer{nullptr};
 #endif

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1567,6 +1567,13 @@ void RadioModel::setPanDbmRange(float minDbm, float maxDbm)
             .arg(static_cast<double>(maxDbm), 0, 'f', 2));
 }
 
+void RadioModel::setBinauralRx(bool on)
+{
+    if (m_binauralRx == on) return;
+    m_binauralRx = on;
+    sendCmd(QString("radio set binaural_rx=%1").arg(on ? 1 : 0));
+}
+
 void RadioModel::setPanWnb(bool on)
 {
     if (m_activePanId.isEmpty()) return;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -201,6 +201,8 @@ public:
     }
     bool    tcxoPresent()  const { return m_tcxoPresent; }
     bool    binauralRx()   const { return m_binauralRx; }
+    bool    cwxActive()    const { return m_cwxActive; }
+    void    setBinauralRx(bool on);  // optimistic update + radio command
     bool    muteLocalWhenRemote() const { return m_muteLocalWhenRemote; }
     bool    autoSave() const { return m_autoSave; }
     int     freqErrorPpb() const { return m_freqErrorPpb; }

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -366,6 +366,10 @@ void TransmitModel::setActiveProfile(const QString& profile)
 void TransmitModel::setRfPower(int power)
 {
     power = qBound(0, power, 100);
+    if (m_rfPower != power) {
+        m_rfPower = power;
+        emit stateChanged();
+    }
     emit commandReady(QString("transmit set rfpower=%1").arg(power));
 }
 

--- a/tests/CAT_Flex_test.cpp
+++ b/tests/CAT_Flex_test.cpp
@@ -1,0 +1,1479 @@
+// AetherSDR FlexCAT (ZZ-extension) dialect CAT integration test.
+// Requires a running AetherSDR instance with a FlexCAT port enabled.
+//
+// Build:  cmake --build build --target CAT_Flex_test
+// Run:    ./build/CAT_Flex_test [--host HOST] [--port PORT] [--ptt] [--cw] [--pty PATH]
+//
+// Mirrors tests/test_flexcat.py.  PTT tests (section 10) are disabled by default;
+// enable only when a dummy load or antenna is connected.
+
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QSet>
+#include <QStandardPaths>
+#include <QTcpSocket>
+#include <QThread>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#if defined(Q_OS_UNIX)
+#include <cerrno>
+#include <fcntl.h>
+#include <termios.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+// ── Per-user PTY symlink path (matches CatPort::defaultSymlinkPath) ───────────
+
+static QString defaultPtyPath(int portIndex)
+{
+    const char letter = static_cast<char>('A' + portIndex);
+    const QString leaf = QStringLiteral("cat-") + QChar(letter);
+    QString base = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+    if (base.isEmpty())
+        base = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    if (base.isEmpty())
+        base = QDir::homePath() + QStringLiteral("/.cache/aethersdr");
+    if (!base.contains(QStringLiteral("aethersdr"), Qt::CaseInsensitive))
+        base += QStringLiteral("/aethersdr");
+    return base + QLatin1Char('/') + leaf;
+}
+
+// ── ANSI colour ───────────────────────────────────────────────────────────────
+
+static bool g_tty = false;
+
+static QString ansi(const char* code, const QString& s)
+{
+    if (!g_tty) return s;
+    return QLatin1String("\033[") + QLatin1String(code) + 'm' + s + QLatin1String("\033[0m");
+}
+
+static QString green(const QString& s)  { return ansi("92", s); }
+static QString red(const QString& s)    { return ansi("91", s); }
+static QString yellow(const QString& s) { return ansi("93", s); }
+static QString cyan(const QString& s)   { return ansi("96", s); }
+static QString bold(const QString& s)   { return ansi("1",  s); }
+
+// ── CatClient ─────────────────────────────────────────────────────────────────
+
+class CatClient
+{
+public:
+    explicit CatClient(int timeoutMs = 3000)
+        : m_timeout(timeoutMs) {}
+
+    bool connectToServer(const QString& host, quint16 port)
+    {
+        m_sock.connectToHost(host, port);
+        if (!m_sock.waitForConnected(m_timeout)) {
+            std::cerr << "Connection failed: "
+                      << m_sock.errorString().toStdString() << '\n';
+            return false;
+        }
+        m_sock.setSocketOption(QAbstractSocket::LowDelayOption, 1);
+        return true;
+    }
+
+    // Send "cmd;" and read response up to next ';'; returns string without ';'.
+    QString query(const QString& cmd)
+    {
+        m_sock.write((cmd + ';').toUtf8());
+        m_sock.flush();
+        return readUntilSemi();
+    }
+
+    // Send "cmd;" with no response expected (set commands).
+    void send(const QString& cmd)
+    {
+        m_sock.write((cmd + ';').toUtf8());
+        m_sock.flush();
+    }
+
+    // Read until ';' with a custom timeout; returns null QString on timeout.
+    QString tryRead(int msTimeout)
+    {
+        const int saved = m_timeout;
+        m_timeout = msTimeout;
+        QString result = readUntilSemi();
+        m_timeout = saved;
+        return result;
+    }
+
+    void close() { m_sock.disconnectFromHost(); }
+
+    // Public for manual poll loops.
+    QString readUntilSemi()
+    {
+        while (!m_buf.contains(';')) {
+            if (!m_sock.waitForReadyRead(m_timeout))
+                return {};
+            m_buf += m_sock.readAll();
+        }
+        const int idx = m_buf.indexOf(';');
+        QString resp = QString::fromUtf8(m_buf.left(idx));
+        m_buf.remove(0, idx + 1);
+        return resp;
+    }
+
+private:
+    QTcpSocket m_sock;
+    QByteArray m_buf;
+    int        m_timeout;
+};
+
+// ── Runner ────────────────────────────────────────────────────────────────────
+
+class Runner
+{
+public:
+    void section(const QString& title)
+    {
+        std::cout << '\n' << bold(cyan(title)).toStdString() << '\n'
+                  << std::string(64, '-') << '\n';
+    }
+
+    bool check(const QString& name, bool cond, const QString& detail = {})
+    {
+        if (cond) {
+            ++m_passed;
+            std::cout << "  " << green(QStringLiteral("PASS")).toStdString()
+                      << "  " << name.toStdString() << '\n';
+        } else {
+            ++m_failed;
+            std::cout << "  " << red(QStringLiteral("FAIL")).toStdString()
+                      << "  " << name.toStdString();
+            if (!detail.isEmpty())
+                std::cout << "  " << yellow(QStringLiteral("→")).toStdString()
+                          << ' ' << detail.toStdString();
+            std::cout << '\n';
+        }
+        return cond;
+    }
+
+    void skip(const QString& name, const QString& reason = {})
+    {
+        ++m_skipped;
+        std::cout << "  " << yellow(QStringLiteral("SKIP")).toStdString()
+                  << "  " << name.toStdString();
+        if (!reason.isEmpty())
+            std::cout << "  (" << reason.toStdString() << ')';
+        std::cout << '\n';
+    }
+
+    bool summary() const
+    {
+        const int total = m_passed + m_failed;
+        std::cout << '\n' << std::string(64, '=') << '\n'
+                  << bold(QStringLiteral("Results: %1/%2 passed")
+                          .arg(m_passed).arg(total)).toStdString() << '\n';
+        if (m_skipped)
+            std::cout << "  Skipped: " << m_skipped << '\n';
+        if (m_failed)
+            std::cout << red(QStringLiteral("  Failed:  %1").arg(m_failed))
+                             .toStdString() << '\n';
+        std::cout << std::string(64, '=') << '\n';
+        return m_failed == 0;
+    }
+
+    int failed() const { return m_failed; }
+
+private:
+    int m_passed{0};
+    int m_failed{0};
+    int m_skipped{0};
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+static QString repr(const QString& s)
+{
+    if (s.isNull()) return QStringLiteral("(timeout)");
+    return '"' + s + '"';
+}
+
+static QString hz11(qint64 hz)
+{
+    return QStringLiteral("%1").arg(hz, 11, 10, QChar('0'));
+}
+
+static bool isDigits(const QString& s, int n)
+{
+    if (s.size() != n) return false;
+    for (const QChar c : s) {
+        if (!c.isDigit()) return false;
+    }
+    return true;
+}
+
+static bool isValidAgcCode(const QString& s)
+{
+    return s == QLatin1String("0") || s == QLatin1String("2") ||
+           s == QLatin1String("3") || s == QLatin1String("4");
+}
+
+struct IfFields {
+    QString freq_hz;
+    QString step;
+    QString rit_hz;
+    QChar   rit_on{'?'};
+    QChar   xit{'?'};
+    QString mem;
+    QChar   tx{'?'};
+    QChar   mode{'?'};
+    QChar   func{'?'};
+    QChar   scan{'?'};
+    QChar   split{'?'};
+    QChar   tone{'?'};
+    QString ctcss;
+    QChar   dcs{'?'};
+    bool    valid{false};
+};
+
+static IfFields parseIfBody(const QString& body)
+{
+    IfFields f;
+    if (body.size() != 35) return f;
+    f.freq_hz = body.mid(0, 11);
+    f.step    = body.mid(11, 5);
+    f.rit_hz  = body.mid(16, 6);
+    f.rit_on  = body[22];
+    f.xit     = body[23];
+    f.mem     = body.mid(24, 2);
+    f.tx      = body[26];
+    f.mode    = body[27];
+    f.func    = body[28];
+    f.scan    = body[29];
+    f.split   = body[30];
+    f.tone    = body[31];
+    f.ctcss   = body.mid(32, 2);
+    f.dcs     = body[34];
+    f.valid   = true;
+    return f;
+}
+
+static const QSet<QString> kValidIDs = {
+    QStringLiteral("ID904"), QStringLiteral("ID905"), QStringLiteral("ID906"),
+    QStringLiteral("ID907"), QStringLiteral("ID908"), QStringLiteral("ID909"),
+    QStringLiteral("ID910"), QStringLiteral("ID911"), QStringLiteral("ID919"),
+    QStringLiteral("ID930"), QStringLiteral("ID931"),
+};
+
+// ZZ 2-digit code → (Kenwood 1-digit, mode name)
+struct ZzModeEntry { const char* zzCode; char kwDigit; const char* name; };
+static const ZzModeEntry kZzModes[] = {
+    { "00", '1', "LSB"  },
+    { "01", '2', "USB"  },
+    { "04", '3', "CW"   },
+    { "05", '4', "FM"   },
+    { "06", '5', "AM"   },
+    { "07", '9', "DIGU" },
+    { "09", '6', "DIGL" },
+};
+
+// Poll until ZZMD and MD both reflect an expected mode change (3-second deadline).
+static void pollUntilModeAgrees(CatClient& c, const QString& zzExpect, const QString& mdExpect,
+                                QString& outZz, QString& outMd)
+{
+    QElapsedTimer timer;
+    timer.start();
+    do {
+        outZz = c.query(QStringLiteral("ZZMD"));
+        outMd = c.query(QStringLiteral("MD"));
+        if (outZz == zzExpect && outMd == mdExpect) return;
+        if (timer.elapsed() < 3000) QThread::msleep(150);
+    } while (timer.elapsed() < 3000);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 1 — Connection & Base Command Compatibility
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section1(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 1 — Connection & Base Command Compatibility"));
+
+    QString resp = c.query(QStringLiteral("ID"));
+    r.check(QStringLiteral("1.1  ID; → valid model ID from CAT guide table (base cmd works in FlexCAT)"),
+            kValidIDs.contains(resp), repr(resp));
+
+    resp = c.query(QStringLiteral("PS"));
+    r.check(QStringLiteral("1.2  PS; → PS1"),
+            resp == QLatin1String("PS1"), repr(resp));
+
+    resp = c.query(QStringLiteral("FA"));
+    r.check(QStringLiteral("1.3  FA; (base command) returns \"FA\" + 11-digit Hz"),
+            resp.startsWith(QLatin1String("FA")) && isDigits(resp.mid(2), 11), repr(resp));
+
+    resp = c.query(QStringLiteral("MD"));
+    r.check(QStringLiteral("1.4  MD; (base command) returns \"MD\" + single digit"),
+            resp.startsWith(QLatin1String("MD")) && resp.size() == 3 && resp[2].isDigit(), repr(resp));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 2 — ZZFA — VFO-A Frequency
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section2(CatClient& c, Runner& r, qint64 origHz)
+{
+    r.section(QStringLiteral("Section 2 — ZZFA — VFO-A Frequency"));
+
+    QString resp = c.query(QStringLiteral("ZZFA"));
+    r.check(QStringLiteral("2.1  ZZFA; returns \"ZZFA\" + 11-digit Hz"),
+            resp.startsWith(QLatin1String("ZZFA")) && isDigits(resp.mid(4), 11), repr(resp));
+
+    QString faResp = c.query(QStringLiteral("FA"));
+    r.check(QStringLiteral("2.2  ZZFA; and FA; return the same frequency"),
+            resp.mid(4) == faResp.mid(2),
+            QStringLiteral("ZZFA=%1 FA=%2").arg(repr(resp.mid(4)), repr(faResp.mid(2))));
+
+    const qint64 testHz = 14'074'000;
+    c.send(QStringLiteral("ZZFA") + hz11(testHz));
+    QThread::msleep(150);
+
+    QString respZz = c.query(QStringLiteral("ZZFA"));
+    QString respFa = c.query(QStringLiteral("FA"));
+    r.check(QStringLiteral("2.3  set ZZFA 14.074 MHz → ZZFA; confirms"),
+            respZz == QStringLiteral("ZZFA") + hz11(testHz),
+            QStringLiteral("got %1").arg(repr(respZz)));
+    r.check(QStringLiteral("2.4  FA; also reflects ZZFA set (cross-dialect consistency)"),
+            respFa == QStringLiteral("FA") + hz11(testHz),
+            QStringLiteral("got %1").arg(repr(respFa)));
+
+    const qint64 test2Hz = 21'074'000;
+    c.send(QStringLiteral("FA") + hz11(test2Hz));
+    QThread::msleep(150);
+    respZz = c.query(QStringLiteral("ZZFA"));
+    r.check(QStringLiteral("2.5  set via base FA; ZZFA; reflects the change"),
+            respZz == QStringLiteral("ZZFA") + hz11(test2Hz),
+            QStringLiteral("got %1").arg(repr(respZz)));
+
+    c.send(QStringLiteral("FA") + hz11(origHz));
+    QThread::msleep(100);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 3 — ZZFB — VFO-B Frequency
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section3(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 3 — ZZFB — VFO-B Frequency"));
+
+    QString resp = c.query(QStringLiteral("ZZFB"));
+    r.check(QStringLiteral("3.1  ZZFB; returns \"ZZFB\" + 11-digit Hz"),
+            resp.startsWith(QLatin1String("ZZFB")) && isDigits(resp.mid(4), 11), repr(resp));
+
+    QString fbResp = c.query(QStringLiteral("FB"));
+    r.check(QStringLiteral("3.2  ZZFB; and FB; agree"),
+            resp.mid(4) == fbResp.mid(2),
+            QStringLiteral("ZZFB=%1 FB=%2").arg(repr(resp.mid(4)), repr(fbResp.mid(2))));
+
+    QString faResp = c.query(QStringLiteral("FA"));
+    const bool vfoBMapped = (resp.mid(4) != faResp.mid(2) &&
+                              !resp.mid(4).isEmpty() && !faResp.mid(2).isEmpty());
+
+    if (!vfoBMapped) {
+        r.skip(QStringLiteral("3.3  set ZZFB 14.225 MHz → ZZFB; confirms"),
+               QStringLiteral("VFO B not mapped to a second slice — configure port VFO B first"));
+    } else {
+        const qint64 testHz = 14'225'000;
+        c.send(QStringLiteral("ZZFB") + hz11(testHz));
+        QElapsedTimer timer;
+        timer.start();
+        QString pollResp;
+        do {
+            pollResp = c.query(QStringLiteral("ZZFB"));
+            if (pollResp == QStringLiteral("ZZFB") + hz11(testHz)) break;
+            if (timer.elapsed() < 2000) QThread::msleep(100);
+        } while (timer.elapsed() < 2000);
+        r.check(QStringLiteral("3.3  set ZZFB 14.225 MHz → ZZFB; confirms"),
+                pollResp == QStringLiteral("ZZFB") + hz11(testHz),
+                QStringLiteral("got %1").arg(repr(pollResp)));
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 4 — ZZMD — Mode (2-digit ZZ codes)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section4(CatClient& c, Runner& r, const QString& origModeDigit)
+{
+    r.section(QStringLiteral("Section 4 — ZZMD — Mode (2-digit ZZ codes)"));
+
+    QString resp = c.query(QStringLiteral("ZZMD"));
+    r.check(QStringLiteral("4.1  ZZMD; returns \"ZZMD\" + 2-digit code"),
+            resp.startsWith(QLatin1String("ZZMD")) && isDigits(resp.mid(4), 2), repr(resp));
+
+    int checkIdx = 2;
+    for (const ZzModeEntry& mode : kZzModes) {
+        const QString zzCode  = QString::fromLatin1(mode.zzCode);
+        const QString kwDigit = QString(QLatin1Char(mode.kwDigit));
+        c.send(QStringLiteral("ZZMD") + zzCode);
+        QString respZz, respMd;
+        pollUntilModeAgrees(c, QStringLiteral("ZZMD") + zzCode, QStringLiteral("MD") + kwDigit,
+                            respZz, respMd);
+        r.check(QStringLiteral("4.%1  set ZZMD%2 (%3) → ZZMD; round-trips")
+                    .arg(checkIdx).arg(zzCode, QString::fromLatin1(mode.name)),
+                respZz == QStringLiteral("ZZMD") + zzCode, repr(respZz));
+        r.check(QStringLiteral("     MD; agrees with ZZMD%1 (%2) → MD%3")
+                    .arg(zzCode, QString::fromLatin1(mode.name), kwDigit),
+                respMd == QStringLiteral("MD") + kwDigit,
+                QStringLiteral("expected MD%1, got %2").arg(kwDigit, repr(respMd)));
+        ++checkIdx;
+    }
+
+    c.send(QStringLiteral("MD") + origModeDigit);
+    QThread::msleep(200);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 5 — ZZME — VFO B DSP Mode (get/set)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section5(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 5 — ZZME — VFO B DSP Mode (get/set)"));
+
+    QString resp = c.query(QStringLiteral("ZZME"));
+    const bool vfoBPresent = resp.startsWith(QLatin1String("ZZME")) && isDigits(resp.mid(4), 2);
+
+    if (!vfoBPresent) {
+        r.check(QStringLiteral("5.1  ZZME; → ?; when no VFO B slice mapped"),
+                resp == QLatin1String("?"), repr(resp));
+        r.skip(QStringLiteral("5.2  ZZME set/get round-trip"),
+               QStringLiteral("no VFO B slice"));
+        r.skip(QStringLiteral("5.3  ZZME set does not affect VFO A (ZZMD)"),
+               QStringLiteral("no VFO B slice"));
+        return;
+    }
+
+    r.check(QStringLiteral("5.1  ZZME; → \"ZZME\" + 2-digit code (VFO B mode)"),
+            vfoBPresent, repr(resp));
+
+    const QString origZzme = resp;
+    // Avoid FM (05) — band-restricted on HF. Toggle between DIGU (07) and LSB (00).
+    const QString testZzme = (origZzme == QLatin1String("ZZME07"))
+                             ? QStringLiteral("ZZME00") : QStringLiteral("ZZME07");
+    c.send(testZzme);
+    QElapsedTimer timer;
+    timer.start();
+    QString respB;
+    do {
+        respB = c.query(QStringLiteral("ZZME"));
+        if (respB == testZzme) break;
+        if (timer.elapsed() < 2000) QThread::msleep(100);
+    } while (timer.elapsed() < 2000);
+    QString respA = c.query(QStringLiteral("ZZMD"));
+    r.check(QStringLiteral("5.2  set %1 (VFO B mode) → ZZME; confirms %1").arg(testZzme),
+            respB == testZzme, QStringLiteral("got %1").arg(repr(respB)));
+    r.check(QStringLiteral("5.3  setting ZZME does not change VFO A (ZZMD unchanged)"),
+            respA.startsWith(QLatin1String("ZZMD")),
+            QStringLiteral("ZZMD=%1").arg(repr(respA)));
+
+    c.send(origZzme);
+    QThread::msleep(100);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 6 — ZZIF — Extended IF Status
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section6(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 6 — ZZIF — Extended IF Status"));
+
+    c.send(QStringLiteral("FA") + hz11(14'225'000));
+    c.send(QStringLiteral("MD2"));
+    c.send(QStringLiteral("FT0"));
+    QThread::msleep(200);
+
+    QString resp = c.query(QStringLiteral("ZZIF"));
+    const QString body = resp.startsWith(QLatin1String("ZZIF")) ? resp.mid(4) : QString();
+    const IfFields fields = parseIfBody(body);
+
+    r.check(QStringLiteral("6.1  ZZIF; returns \"ZZIF\" + exactly 35-char body"),
+            resp.startsWith(QLatin1String("ZZIF")) && body.size() == 35,
+            QStringLiteral("body len=%1 resp=%2").arg(body.size()).arg(repr(resp.left(16))));
+
+    r.check(QStringLiteral("6.2  ZZIF body freq field is all digits"),
+            isDigits(fields.freq_hz, 11), repr(fields.freq_hz));
+
+    QString zzfaResp = c.query(QStringLiteral("ZZFA"));
+    const QString zzfaHz = zzfaResp.startsWith(QLatin1String("ZZFA")) ? zzfaResp.mid(4) : QString();
+    r.check(QStringLiteral("6.3  ZZIF body freq field matches ZZFA; response"),
+            fields.freq_hz == zzfaHz,
+            QStringLiteral("ZZIF=%1 ZZFA=%2").arg(repr(fields.freq_hz), repr(zzfaHz)));
+
+    QString mdResp = c.query(QStringLiteral("MD"));
+    const QString mdDigit = mdResp.startsWith(QLatin1String("MD")) ? mdResp.mid(2) : QString();
+    r.check(QStringLiteral("6.4  ZZIF body mode (pos 27, Kenwood digit) matches MD;"),
+            QString(fields.mode) == mdDigit,
+            QStringLiteral("IF mode=%1 MD=%2").arg(repr(QString(fields.mode)), repr(mdDigit)));
+
+    QString ifResp = c.query(QStringLiteral("IF"));
+    const QString ifBody = ifResp.startsWith(QLatin1String("IF")) ? ifResp.mid(2) : QString();
+    r.check(QStringLiteral("6.5  ZZIF body is identical to IF body"),
+            body == ifBody,
+            QStringLiteral("ZZIF body=%1 IF body=%2").arg(repr(body.left(16)), repr(ifBody.left(16))));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 7 — ZZAI — AI Mode (async unsolicited updates)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section7(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 7 — ZZAI — AI Mode (async unsolicited updates)"));
+
+    QString resp = c.query(QStringLiteral("ZZAI"));
+    r.check(QStringLiteral("7.1  ZZAI; → ZZAI00 (disabled by default)"),
+            resp == QLatin1String("ZZAI00"), repr(resp));
+
+    QString aiResp = c.query(QStringLiteral("AI"));
+    r.check(QStringLiteral("7.2  AI; and ZZAI; share the same state (both report disabled)"),
+            aiResp == QLatin1String("AI0"), repr(aiResp));
+
+    c.send(QStringLiteral("ZZAI01"));
+    resp = c.query(QStringLiteral("ZZAI"));
+    r.check(QStringLiteral("7.3  ZZAI01; enables AI; ZZAI; → ZZAI01"),
+            resp == QLatin1String("ZZAI01"), repr(resp));
+    aiResp = c.query(QStringLiteral("AI"));
+    r.check(QStringLiteral("7.4  AI; reflects ZZAI enable (shared state)"),
+            aiResp == QLatin1String("AI1"), repr(aiResp));
+
+    const qint64 newHz = 14'100'000;
+    c.send(QStringLiteral("ZZFA") + hz11(newHz));
+    QString push = c.tryRead(2000);
+    r.check(QStringLiteral("7.5  AI push after ZZFA set → push is \"FA<freq>\" (NOT ZZFA prefix)"),
+            push == QStringLiteral("FA") + hz11(newHz), repr(push));
+
+    c.send(QStringLiteral("ZZMD05"));  // FM
+    push = c.tryRead(2000);
+    r.check(QStringLiteral("7.6  AI push after ZZMD set → push is \"MD4\" (FM, NOT ZZMD prefix)"),
+            push == QLatin1String("MD4"), repr(push));
+
+    c.send(QStringLiteral("ZZAI00"));
+    resp = c.query(QStringLiteral("ZZAI"));
+    r.check(QStringLiteral("7.7  ZZAI00; disables AI; ZZAI; → ZZAI00"),
+            resp == QLatin1String("ZZAI00"), repr(resp));
+
+    c.send(QStringLiteral("ZZFA") + hz11(14'225'000));
+    QString silence = c.tryRead(500);
+    r.check(QStringLiteral("7.8  no AI push after ZZAI00 (silence expected)"),
+            silence.isNull(),
+            QStringLiteral("got unexpected push: %1").arg(repr(silence)));
+
+    c.send(QStringLiteral("AI1"));
+    resp = c.query(QStringLiteral("ZZAI"));
+    r.check(QStringLiteral("7.9  enable via base AI1; → ZZAI; → ZZAI01"),
+            resp == QLatin1String("ZZAI01"), repr(resp));
+
+    c.send(QStringLiteral("AI0"));
+    resp = c.query(QStringLiteral("ZZAI"));
+    r.check(QStringLiteral("7.10 disable via base AI0; → ZZAI; → ZZAI00"),
+            resp == QLatin1String("ZZAI00"), repr(resp));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 8 — ZZSW — Split
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section8(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 8 — ZZSW — Split"));
+
+    QString resp = c.query(QStringLiteral("ZZSW"));
+    r.check(QStringLiteral("8.1  ZZSW; → ZZSW0 (split off initially)"),
+            resp == QLatin1String("ZZSW0"), repr(resp));
+
+    c.send(QStringLiteral("ZZSW1"));
+    QString respZz = c.query(QStringLiteral("ZZSW"));
+    QString respFt = c.query(QStringLiteral("FT"));
+    r.check(QStringLiteral("8.2  ZZSW1; enables split; ZZSW; → ZZSW1"),
+            respZz == QLatin1String("ZZSW1"), repr(respZz));
+    r.check(QStringLiteral("8.3  FT; also reflects split on (FT1)"),
+            respFt == QLatin1String("FT1"), repr(respFt));
+
+    c.send(QStringLiteral("ZZSW0"));
+    c.send(QStringLiteral("FT1"));
+    respZz = c.query(QStringLiteral("ZZSW"));
+    r.check(QStringLiteral("8.4  set split via base FT1; → ZZSW; → ZZSW1"),
+            respZz == QLatin1String("ZZSW1"), repr(respZz));
+
+    c.send(QStringLiteral("ZZSW0"));
+    respZz = c.query(QStringLiteral("ZZSW"));
+    respFt = c.query(QStringLiteral("FT"));
+    r.check(QStringLiteral("8.5  ZZSW0; clears split; ZZSW; → ZZSW0"),
+            respZz == QLatin1String("ZZSW0"), repr(respZz));
+    r.check(QStringLiteral("8.6  FT; also reflects split off (FT0)"),
+            respFt == QLatin1String("FT0"), repr(respFt));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 9 — ZZSM — S-Meter
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section9(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 9 — ZZSM — S-Meter"));
+
+    QString resp = c.query(QStringLiteral("ZZSM0"));
+    r.check(QStringLiteral("9.1  ZZSM0; → ZZSM0000 (4-digit zero)"),
+            resp == QLatin1String("ZZSM0000"), repr(resp));
+
+    resp = c.query(QStringLiteral("SM0"));
+    r.check(QStringLiteral("9.2  SM0; (base) → SM00000 (5-digit zero)"),
+            resp == QLatin1String("SM00000"), repr(resp));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 10 — PTT  (optional — requires dummy load or antenna)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section10ptt(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 10 — PTT  ⚠  TX ACTIVE"));
+
+    QString resp = c.query(QStringLiteral("ZZIF"));
+    IfFields fields = parseIfBody(resp.startsWith(QLatin1String("ZZIF")) ? resp.mid(4) : QString());
+    r.check(QStringLiteral("10.0 ZZIF confirms TX=0 before keying"),
+            fields.tx == QChar('0'), repr(QString(fields.tx)));
+
+    c.send(QStringLiteral("ZZTX"));
+    QThread::msleep(1000);
+
+    resp = c.query(QStringLiteral("ZZIF"));
+    fields = parseIfBody(resp.startsWith(QLatin1String("ZZIF")) ? resp.mid(4) : QString());
+    const bool txOn = (fields.tx == QChar('1'));
+
+    if (!txOn) {
+        r.skip(QStringLiteral("10.1 ZZTX; keys radio; ZZIF TX='1'"),
+               QStringLiteral("TX blocked — check interlock/inhibit line"));
+        r.skip(QStringLiteral("10.2 ZZRX; unkeys radio; ZZIF TX='0'"),
+               QStringLiteral("TX blocked"));
+        r.skip(QStringLiteral("10.3 base TX;/RX; also work; IF TX='0'"),
+               QStringLiteral("TX blocked"));
+        c.send(QStringLiteral("ZZRX"));
+        c.send(QStringLiteral("RX"));
+        return;
+    }
+
+    r.check(QStringLiteral("10.1 ZZTX; keys radio; ZZIF body TX field = '1'"),
+            txOn, repr(QString(fields.tx)));
+
+    c.send(QStringLiteral("ZZRX"));
+    QThread::msleep(250);
+
+    resp = c.query(QStringLiteral("ZZIF"));
+    fields = parseIfBody(resp.startsWith(QLatin1String("ZZIF")) ? resp.mid(4) : QString());
+    r.check(QStringLiteral("10.2 ZZRX; unkeys radio; ZZIF body TX field = '0'"),
+            fields.tx == QChar('0'), repr(QString(fields.tx)));
+
+    c.send(QStringLiteral("TX"));
+    QThread::msleep(500);
+    c.send(QStringLiteral("RX"));
+    QThread::msleep(250);
+    resp = c.query(QStringLiteral("IF"));
+    fields = parseIfBody(resp.startsWith(QLatin1String("IF")) ? resp.mid(2) : QString());
+    r.check(QStringLiteral("10.3 base TX; / RX; also work in FlexCAT mode; IF confirms TX=0"),
+            fields.tx == QChar('0'), repr(QString(fields.tx)));
+
+    // Safety: watch 2 s — firmware may briefly re-assert TX after unkey
+    {
+        QElapsedTimer safeTimer; safeTimer.start();
+        bool sawTxOn = false;
+        c.send(QStringLiteral("ZZRX")); c.send(QStringLiteral("RX"));
+        do {
+            QThread::msleep(250);
+            resp = c.query(QStringLiteral("ZZIF"));
+            fields = parseIfBody(resp.startsWith(QLatin1String("ZZIF")) ? resp.mid(4) : QString());
+            if (fields.tx != QChar('0')) {
+                sawTxOn = true;
+                c.send(QStringLiteral("ZZRX")); c.send(QStringLiteral("RX"));
+            }
+        } while (safeTimer.elapsed() < 2000);
+        if (sawTxOn)
+            qWarning("10.S: TX re-asserted during 2-s safety watch — forced RX; possible firmware bug");
+        r.check(QStringLiteral("10.S safety: TX confirmed off after 2-s watch"),
+                fields.tx == QChar('0'), repr(QString(fields.tx)));
+    }
+}
+
+void section10skip(Runner& r)
+{
+    r.section(QStringLiteral("Section 10 — PTT  (skipped — pass --ptt to enable)"));
+    for (const char* name : { "10.0 baseline", "10.1 ZZTX; keys",
+                               "10.2 ZZRX; unkeys", "10.3 base TX/RX" }) {
+        r.skip(QString::fromLatin1(name), QStringLiteral("--ptt not set"));
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 11 — Unknown / Invalid ZZ Commands
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section11(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 11 — Unknown / Invalid ZZ Commands"));
+
+    struct Entry { const char* cmd; const char* label; };
+    static const Entry entries[] = {
+        { "ZZXQ", "11.1" }, { "ZZAB", "11.2" }, { "ZZZZ", "11.3" },
+    };
+    for (const Entry& e : entries) {
+        QString resp = c.query(QString::fromLatin1(e.cmd));
+        r.check(QStringLiteral("%1  %2; → ?;")
+                    .arg(QString::fromLatin1(e.label), QString::fromLatin1(e.cmd)),
+                resp == QLatin1String("?"), repr(resp));
+    }
+
+    QString resp = c.query(QStringLiteral("XQ"));
+    r.check(QStringLiteral("11.4  base unknown XQ; → ?;"),
+            resp == QLatin1String("?"), repr(resp));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 12 — Cross-Dialect Consistency (base ↔ ZZ commands)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section12(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 12 — Cross-Dialect Consistency (base ↔ ZZ commands)"));
+
+    const qint64 testHz = 14'074'000;
+    c.send(QStringLiteral("FA") + hz11(testHz));
+    QThread::msleep(150);
+    QString resp = c.query(QStringLiteral("ZZFA"));
+    r.check(QStringLiteral("12.1 set freq via FA; → ZZFA; reflects it"),
+            resp == QStringLiteral("ZZFA") + hz11(testHz),
+            QStringLiteral("got %1").arg(repr(resp)));
+
+    const qint64 test2Hz = 7'074'000;
+    c.send(QStringLiteral("ZZFA") + hz11(test2Hz));
+    QThread::msleep(150);
+    resp = c.query(QStringLiteral("FA"));
+    r.check(QStringLiteral("12.2 set freq via ZZFA; → FA; reflects it"),
+            resp == QStringLiteral("FA") + hz11(test2Hz),
+            QStringLiteral("got %1").arg(repr(resp)));
+
+    auto setAndPollMode = [&](const QString& label, const QString& sendCmd,
+                              const QString& zzExpect, const QString& mdExpect) {
+        c.send(sendCmd);
+        QString rz, rm;
+        pollUntilModeAgrees(c, zzExpect, mdExpect, rz, rm);
+        r.check(QStringLiteral("%1 → ZZMD; → %2").arg(label, zzExpect),
+                rz == zzExpect, repr(rz));
+        r.check(QStringLiteral("%1 → MD; → %2").arg(label, mdExpect),
+                rm == mdExpect, repr(rm));
+    };
+
+    setAndPollMode(QStringLiteral("12.3 set mode via MD1 (LSB)"),
+                   QStringLiteral("MD1"), QStringLiteral("ZZMD00"), QStringLiteral("MD1"));
+    setAndPollMode(QStringLiteral("12.4 set mode via MD2 (USB)"),
+                   QStringLiteral("MD2"), QStringLiteral("ZZMD01"), QStringLiteral("MD2"));
+    setAndPollMode(QStringLiteral("12.5 set mode via ZZMD04 (CW)"),
+                   QStringLiteral("ZZMD04"), QStringLiteral("ZZMD04"), QStringLiteral("MD3"));
+    setAndPollMode(QStringLiteral("12.6 set mode via ZZMD09 (DIGL)"),
+                   QStringLiteral("ZZMD09"), QStringLiteral("ZZMD09"), QStringLiteral("MD6"));
+
+    c.send(QStringLiteral("FT1"));
+    resp = c.query(QStringLiteral("ZZSW"));
+    r.check(QStringLiteral("12.7 set split via FT1; → ZZSW; → ZZSW1"),
+            resp == QLatin1String("ZZSW1"), repr(resp));
+
+    c.send(QStringLiteral("ZZSW0"));
+    resp = c.query(QStringLiteral("FT"));
+    r.check(QStringLiteral("12.8 clear split via ZZSW0; → FT; → FT0"),
+            resp == QLatin1String("FT0"), repr(resp));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 13 — Tier-2 ZZ Commands
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section13(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 13 — Tier-2 ZZ Commands (audio, AGC, power, RIT, XIT, NB/NR, binaural)"));
+
+    // ── ZZAG / AG cross-check ──────────────────────────────────────────────
+    QString respZz = c.query(QStringLiteral("ZZAG"));
+    QString respAg = c.query(QStringLiteral("AG"));
+    r.check(QStringLiteral("13.1  ZZAG; → \"ZZAG\" + 3-digit gain"),
+            respZz.startsWith(QLatin1String("ZZAG")) && isDigits(respZz.mid(4), 3), repr(respZz));
+    r.check(QStringLiteral("13.2  ZZAG; and AG; agree on gain value"),
+            respAg.startsWith(QLatin1String("AG")) && respZz.mid(4) == respAg.mid(2),
+            QStringLiteral("ZZAG=%1 AG=%2").arg(repr(respZz.mid(4)), repr(respAg.mid(2))));
+
+    const QString origAg = respZz;
+    c.send(QStringLiteral("ZZAG060"));
+    QThread::msleep(100);
+    QString gotAg = c.query(QStringLiteral("AG"));
+    r.check(QStringLiteral("13.3  set ZZAG060 → AG; also reflects it (cross-dialect)"),
+            gotAg == QLatin1String("AG060"), repr(gotAg));
+
+    if (origAg.startsWith(QLatin1String("ZZAG"))) { c.send(origAg); QThread::msleep(50); }
+
+    // ── ZZGT / GT cross-check ──────────────────────────────────────────────
+    respZz = c.query(QStringLiteral("ZZGT"));
+    QString respGt = c.query(QStringLiteral("GT"));
+    r.check(QStringLiteral("13.4  ZZGT; → \"ZZGT\" + valid AGC code (0/2/3/4)"),
+            respZz.startsWith(QLatin1String("ZZGT")) && isValidAgcCode(respZz.mid(4)), repr(respZz));
+    r.check(QStringLiteral("13.5  ZZGT; and GT; return the same AGC code"),
+            respGt.startsWith(QLatin1String("GT")) && respZz.mid(4) == respGt.mid(2),
+            QStringLiteral("ZZGT=%1 GT=%2").arg(repr(respZz.mid(4)), repr(respGt.mid(2))));
+
+    const QString origGt = respZz;
+    c.send(QStringLiteral("ZZGT3"));
+    QThread::msleep(150);
+    QString gotGt = c.query(QStringLiteral("GT"));
+    r.check(QStringLiteral("13.6  set ZZGT3 → GT; also reflects GT3"),
+            gotGt == QLatin1String("GT3"), repr(gotGt));
+
+    if (origGt.startsWith(QLatin1String("ZZGT"))) { c.send(origGt); QThread::msleep(100); }
+
+    // ── ZZPC / PC cross-check ──────────────────────────────────────────────
+    respZz = c.query(QStringLiteral("ZZPC"));
+    QString respPc = c.query(QStringLiteral("PC"));
+    r.check(QStringLiteral("13.7  ZZPC; → \"ZZPC\" + 3-digit power"),
+            respZz.startsWith(QLatin1String("ZZPC")) && isDigits(respZz.mid(4), 3), repr(respZz));
+    r.check(QStringLiteral("13.8  ZZPC; and PC; agree on power value"),
+            respPc.startsWith(QLatin1String("PC")) && respZz.mid(4) == respPc.mid(2),
+            QStringLiteral("ZZPC=%1 PC=%2").arg(repr(respZz.mid(4)), repr(respPc.mid(2))));
+
+    const QString origPc = respZz;
+    c.send(QStringLiteral("ZZPC070"));
+    QThread::msleep(100);
+    QString gotPc = c.query(QStringLiteral("PC"));
+    r.check(QStringLiteral("13.9  set ZZPC070 → PC; reflects PC070"),
+            gotPc == QLatin1String("PC070"), repr(gotPc));
+
+    if (origPc.startsWith(QLatin1String("ZZPC"))) { c.send(origPc); QThread::msleep(50); }
+
+    // ── ZZMG: Mic gain ────────────────────────────────────────────────────
+    QString origMg = c.query(QStringLiteral("ZZMG"));
+    r.check(QStringLiteral("13.10 ZZMG; → \"ZZMG\" + 3-digit gain"),
+            origMg.startsWith(QLatin1String("ZZMG")) && isDigits(origMg.mid(4), 3), repr(origMg));
+
+    c.send(QStringLiteral("ZZMG050"));
+    QThread::msleep(100);
+    QString gotMg = c.query(QStringLiteral("ZZMG"));
+    r.check(QStringLiteral("13.11 set ZZMG050 → ZZMG; confirms ZZMG050"),
+            gotMg == QLatin1String("ZZMG050"), repr(gotMg));
+
+    if (origMg.startsWith(QLatin1String("ZZMG"))) { c.send(origMg); QThread::msleep(50); }
+
+    // ── ZZMA: VFO A mute ──────────────────────────────────────────────────
+    QString origMa = c.query(QStringLiteral("ZZMA"));
+    r.check(QStringLiteral("13.12 ZZMA; → ZZMA0 or ZZMA1"),
+            origMa == QLatin1String("ZZMA0") || origMa == QLatin1String("ZZMA1"), repr(origMa));
+
+    QString newMa = (origMa == QLatin1String("ZZMA0"))
+                    ? QStringLiteral("ZZMA1") : QStringLiteral("ZZMA0");
+    c.send(newMa);
+    QThread::msleep(100);
+    QString gotMa = c.query(QStringLiteral("ZZMA"));
+    r.check(QStringLiteral("13.13 toggle ZZMA → confirms %1").arg(newMa),
+            gotMa == newMa, repr(gotMa));
+
+    c.send(origMa);
+    QThread::msleep(100);
+
+    // ── ZZLB: VFO A audio pan ─────────────────────────────────────────────
+    QString origLb = c.query(QStringLiteral("ZZLB"));
+    r.check(QStringLiteral("13.14 ZZLB; → \"ZZLB\" + 3-digit pan (0-100)"),
+            origLb.startsWith(QLatin1String("ZZLB")) && isDigits(origLb.mid(4), 3), repr(origLb));
+
+    c.send(QStringLiteral("ZZLB050"));
+    QThread::msleep(100);
+    QString gotLb = c.query(QStringLiteral("ZZLB"));
+    r.check(QStringLiteral("13.15 set ZZLB050 (center) → ZZLB; confirms ZZLB050"),
+            gotLb == QLatin1String("ZZLB050"), repr(gotLb));
+
+    if (origLb.startsWith(QLatin1String("ZZLB"))) { c.send(origLb); QThread::msleep(50); }
+
+    // ── ZZRT / RT: RIT state ──────────────────────────────────────────────
+    c.send(QStringLiteral("RT0"));
+    QThread::msleep(50);
+
+    QString respZzRt = c.query(QStringLiteral("ZZRT"));
+    QString respRt   = c.query(QStringLiteral("RT"));
+    r.check(QStringLiteral("13.16 ZZRT; → ZZRT0 or ZZRT1"),
+            respZzRt == QLatin1String("ZZRT0") || respZzRt == QLatin1String("ZZRT1"), repr(respZzRt));
+    r.check(QStringLiteral("13.17 ZZRT; and RT; agree"),
+            respRt.startsWith(QLatin1String("RT")) && respZzRt.mid(4) == respRt.mid(2),
+            QStringLiteral("ZZRT=%1 RT=%2").arg(repr(respZzRt), repr(respRt)));
+
+    c.send(QStringLiteral("ZZRT1"));
+    QThread::msleep(100);
+    QString gotRt = c.query(QStringLiteral("RT"));
+    r.check(QStringLiteral("13.18 ZZRT1; enables RIT → RT; reflects RT1"),
+            gotRt == QLatin1String("RT1"), repr(gotRt));
+
+    // ── ZZRG: RIT frequency ───────────────────────────────────────────────
+    c.send(QStringLiteral("ZZRG+00750"));
+    QThread::msleep(100);
+    QString gotZzrg = c.query(QStringLiteral("ZZRG"));
+    r.check(QStringLiteral("13.19 set ZZRG+00750 → ZZRG; confirms ZZRG+00750"),
+            gotZzrg == QLatin1String("ZZRG+00750"), repr(gotZzrg));
+
+    QString gotRg = c.query(QStringLiteral("RG"));
+    r.check(QStringLiteral("13.20 RG; (base) also reflects ZZRG set"),
+            gotRg == QLatin1String("RG+00750"), repr(gotRg));
+
+    // ── ZZRC: clear RIT ───────────────────────────────────────────────────
+    c.send(QStringLiteral("ZZRC"));
+    QThread::msleep(50);
+    gotZzrg = c.query(QStringLiteral("ZZRG"));
+    r.check(QStringLiteral("13.21 ZZRC; clears RIT → ZZRG; returns ZZRG+00000"),
+            gotZzrg == QLatin1String("ZZRG+00000"), repr(gotZzrg));
+
+    // ── ZZRD / ZZRU: increment / decrement ────────────────────────────────
+    c.send(QStringLiteral("ZZRU00200"));
+    QThread::msleep(50);
+    gotZzrg = c.query(QStringLiteral("ZZRG"));
+    r.check(QStringLiteral("13.22 ZZRU00200; increments RIT → ZZRG+00200"),
+            gotZzrg == QLatin1String("ZZRG+00200"), repr(gotZzrg));
+
+    c.send(QStringLiteral("ZZRD00050"));
+    QThread::msleep(50);
+    gotZzrg = c.query(QStringLiteral("ZZRG"));
+    r.check(QStringLiteral("13.23 ZZRD00050; decrements → ZZRG+00150"),
+            gotZzrg == QLatin1String("ZZRG+00150"), repr(gotZzrg));
+
+    c.send(QStringLiteral("ZZRC"));
+    c.send(QStringLiteral("ZZRT0"));
+    c.send(QStringLiteral("RT0"));
+    QThread::msleep(50);
+
+    // ── ZZXS / XT: XIT state ──────────────────────────────────────────────
+    respZz = c.query(QStringLiteral("ZZXS"));
+    r.check(QStringLiteral("13.24 ZZXS; → ZZXS0 or ZZXS1"),
+            respZz == QLatin1String("ZZXS0") || respZz == QLatin1String("ZZXS1"), repr(respZz));
+
+    c.send(QStringLiteral("ZZXS1"));
+    QThread::msleep(100);
+    QString gotXt = c.query(QStringLiteral("XT"));
+    r.check(QStringLiteral("13.25 ZZXS1; enables XIT → XT; reflects XT1"),
+            gotXt == QLatin1String("XT1"), repr(gotXt));
+
+    // ── ZZXG: XIT frequency ───────────────────────────────────────────────
+    c.send(QStringLiteral("ZZXG-00300"));
+    QThread::msleep(100);
+    QString gotZzxg = c.query(QStringLiteral("ZZXG"));
+    r.check(QStringLiteral("13.26 set ZZXG-00300 → ZZXG; confirms ZZXG-00300"),
+            gotZzxg == QLatin1String("ZZXG-00300"), repr(gotZzxg));
+
+    // ── ZZXC: clear XIT ───────────────────────────────────────────────────
+    c.send(QStringLiteral("ZZXC"));
+    QThread::msleep(50);
+    gotZzxg = c.query(QStringLiteral("ZZXG"));
+    r.check(QStringLiteral("13.27 ZZXC; clears XIT → ZZXG; returns ZZXG+00000"),
+            gotZzxg == QLatin1String("ZZXG+00000"), repr(gotZzxg));
+
+    c.send(QStringLiteral("ZZXS0"));
+    c.send(QStringLiteral("XT0"));
+    QThread::msleep(50);
+
+    // ── ZZNR: Noise Reduction state ───────────────────────────────────────
+    QString origNr = c.query(QStringLiteral("ZZNR"));
+    r.check(QStringLiteral("13.28 ZZNR; → ZZNR0 or ZZNR1"),
+            origNr == QLatin1String("ZZNR0") || origNr == QLatin1String("ZZNR1"), repr(origNr));
+
+    QString newNr = (origNr == QLatin1String("ZZNR0"))
+                    ? QStringLiteral("ZZNR1") : QStringLiteral("ZZNR0");
+    c.send(newNr);
+    QThread::msleep(100);
+    QString gotNr = c.query(QStringLiteral("ZZNR"));
+    r.check(QStringLiteral("13.29 toggle ZZNR → confirms %1").arg(newNr),
+            gotNr == newNr, repr(gotNr));
+
+    c.send(origNr);
+    QThread::msleep(50);
+
+    // ── ZZNL: Noise Blanker level ─────────────────────────────────────────
+    QString origNl = c.query(QStringLiteral("ZZNL"));
+    r.check(QStringLiteral("13.30 ZZNL; → \"ZZNL\" + 3-digit level"),
+            origNl.startsWith(QLatin1String("ZZNL")) && isDigits(origNl.mid(4), 3), repr(origNl));
+
+    c.send(QStringLiteral("ZZNL040"));
+    QThread::msleep(100);
+    QString gotNl = c.query(QStringLiteral("ZZNL"));
+    r.check(QStringLiteral("13.31 set ZZNL040 → ZZNL; confirms ZZNL040"),
+            gotNl == QLatin1String("ZZNL040"), repr(gotNl));
+
+    if (origNl.startsWith(QLatin1String("ZZNL"))) { c.send(origNl); QThread::msleep(50); }
+
+    // ── ZZBI: Binaural receive ────────────────────────────────────────────
+    QString origBi = c.query(QStringLiteral("ZZBI"));
+    r.check(QStringLiteral("13.32 ZZBI; → ZZBI0 or ZZBI1"),
+            origBi == QLatin1String("ZZBI0") || origBi == QLatin1String("ZZBI1"), repr(origBi));
+
+    QString newBi = (origBi == QLatin1String("ZZBI0"))
+                    ? QStringLiteral("ZZBI1") : QStringLiteral("ZZBI0");
+    c.send(newBi);
+    QThread::msleep(100);
+    QString gotBi = c.query(QStringLiteral("ZZBI"));
+    r.check(QStringLiteral("13.33 toggle ZZBI → confirms %1").arg(newBi),
+            gotBi == newBi, repr(gotBi));
+
+    c.send(origBi);
+    QThread::msleep(200);
+
+    // ── ZZFR: toggle active VFO ───────────────────────────────────────────
+    QString faBefore = c.query(QStringLiteral("ZZFA"));
+    QString fbBefore = c.query(QStringLiteral("ZZFB"));
+    c.send(QStringLiteral("ZZFR"));
+    QThread::msleep(50);
+    QString faAfter = c.query(QStringLiteral("ZZFA"));
+    // If VFO A and B differ, after ZZFR the new ZZFA should match old ZZFB.
+    // If they're equal (single-slice session), the swap is a no-op — treat as pass.
+    const bool zzfrOk = (faBefore.mid(4) == fbBefore.mid(4))
+                        ? true
+                        : (faAfter.mid(4) == fbBefore.mid(4));
+    r.check(QStringLiteral("13.34 ZZFR; swaps VFOs — new ZZFA matches old ZZFB freq"),
+            zzfrOk,
+            QStringLiteral("before: ZZFA=%1 ZZFB=%2 after ZZFA=%3")
+                .arg(repr(faBefore.mid(4)), repr(fbBefore.mid(4)), repr(faAfter.mid(4))));
+    c.send(QStringLiteral("ZZFR"));  // swap back
+    QThread::msleep(50);
+
+    // ── ZZAR: VFO A AGC threshold (0-100, 3-digit) ───────────────────────────
+    QString origAr = c.query(QStringLiteral("ZZAR"));
+    r.check(QStringLiteral("13.35 ZZAR; → \"ZZAR\" + 3-digit threshold"),
+            origAr.startsWith(QLatin1String("ZZAR")) && isDigits(origAr.mid(4), 3), repr(origAr));
+
+    c.send(QStringLiteral("ZZAR060"));
+    QThread::msleep(100);
+    QString gotAr = c.query(QStringLiteral("ZZAR"));
+    r.check(QStringLiteral("13.36 set ZZAR060 → ZZAR; confirms ZZAR060"),
+            gotAr == QLatin1String("ZZAR060"), repr(gotAr));
+
+    if (origAr.startsWith(QLatin1String("ZZAR"))) { c.send(origAr); QThread::msleep(50); }
+
+    // ── VFO B presence check (probe via ZZLE) ─────────────────────────────────
+    QString zzleProbe = c.query(QStringLiteral("ZZLE"));
+    const bool vfoBAvail = zzleProbe.startsWith(QLatin1String("ZZLE")) && isDigits(zzleProbe.mid(4), 3);
+
+    // ── ZZLE: VFO B audio gain ────────────────────────────────────────────────
+    if (!vfoBAvail) {
+        r.check(QStringLiteral("13.37 ZZLE; → ? when no VFO B slice"),
+                zzleProbe == QLatin1String("?"), repr(zzleProbe));
+        r.skip(QStringLiteral("13.38 set ZZLE round-trip"), QStringLiteral("no VFO B slice"));
+    } else {
+        r.check(QStringLiteral("13.37 ZZLE; → \"ZZLE\" + 3-digit gain (VFO B audio)"),
+                vfoBAvail, repr(zzleProbe));
+        c.send(QStringLiteral("ZZLE065"));
+        QThread::msleep(100);
+        QString gotLe = c.query(QStringLiteral("ZZLE"));
+        r.check(QStringLiteral("13.38 set ZZLE065 → ZZLE; confirms ZZLE065"),
+                gotLe == QLatin1String("ZZLE065"), repr(gotLe));
+        c.send(zzleProbe);  // restore original gain
+        QThread::msleep(50);
+    }
+
+    // ── ZZLF: VFO B audio pan ─────────────────────────────────────────────────
+    if (!vfoBAvail) {
+        r.skip(QStringLiteral("13.39 ZZLF; → ? when no VFO B"), QStringLiteral("no VFO B slice"));
+        r.skip(QStringLiteral("13.40 set ZZLF round-trip"), QStringLiteral("no VFO B slice"));
+    } else {
+        QString origLf = c.query(QStringLiteral("ZZLF"));
+        r.check(QStringLiteral("13.39 ZZLF; → \"ZZLF\" + 3-digit pan (VFO B)"),
+                origLf.startsWith(QLatin1String("ZZLF")) && isDigits(origLf.mid(4), 3), repr(origLf));
+        c.send(QStringLiteral("ZZLF050"));
+        QThread::msleep(100);
+        QString gotLf = c.query(QStringLiteral("ZZLF"));
+        r.check(QStringLiteral("13.40 set ZZLF050 (center) → ZZLF; confirms ZZLF050"),
+                gotLf == QLatin1String("ZZLF050"), repr(gotLf));
+        if (origLf.startsWith(QLatin1String("ZZLF"))) { c.send(origLf); QThread::msleep(50); }
+    }
+
+    // ── ZZMB: VFO B mute (0/1) ────────────────────────────────────────────────
+    if (!vfoBAvail) {
+        r.skip(QStringLiteral("13.41 ZZMB; → ? when no VFO B"), QStringLiteral("no VFO B slice"));
+        r.skip(QStringLiteral("13.42 toggle ZZMB round-trip"), QStringLiteral("no VFO B slice"));
+    } else {
+        QString origMb = c.query(QStringLiteral("ZZMB"));
+        r.check(QStringLiteral("13.41 ZZMB; → ZZMB0 or ZZMB1"),
+                origMb == QLatin1String("ZZMB0") || origMb == QLatin1String("ZZMB1"), repr(origMb));
+        QString newMb = (origMb == QLatin1String("ZZMB0"))
+                        ? QStringLiteral("ZZMB1") : QStringLiteral("ZZMB0");
+        c.send(newMb);
+        QThread::msleep(100);
+        QString gotMb = c.query(QStringLiteral("ZZMB"));
+        r.check(QStringLiteral("13.42 toggle ZZMB → confirms %1").arg(newMb),
+                gotMb == newMb, repr(gotMb));
+        c.send(origMb);
+        QThread::msleep(100);
+    }
+
+    // ── ZZAS: VFO B AGC threshold (0-100, 3-digit) ────────────────────────────
+    if (!vfoBAvail) {
+        r.skip(QStringLiteral("13.43 ZZAS; → ? when no VFO B"), QStringLiteral("no VFO B slice"));
+        r.skip(QStringLiteral("13.44 set ZZAS round-trip"), QStringLiteral("no VFO B slice"));
+    } else {
+        QString origAs = c.query(QStringLiteral("ZZAS"));
+        r.check(QStringLiteral("13.43 ZZAS; → \"ZZAS\" + 3-digit threshold (VFO B AGC)"),
+                origAs.startsWith(QLatin1String("ZZAS")) && isDigits(origAs.mid(4), 3), repr(origAs));
+        c.send(QStringLiteral("ZZAS055"));
+        QThread::msleep(100);
+        QString gotAs = c.query(QStringLiteral("ZZAS"));
+        r.check(QStringLiteral("13.44 set ZZAS055 → ZZAS; confirms ZZAS055"),
+                gotAs == QLatin1String("ZZAS055"), repr(gotAs));
+        if (origAs.startsWith(QLatin1String("ZZAS"))) { c.send(origAs); QThread::msleep(50); }
+    }
+
+    // ── ZZRW: VFO B RIT frequency ─────────────────────────────────────────────
+    if (!vfoBAvail) {
+        r.skip(QStringLiteral("13.45 set ZZRW+00300 round-trip"), QStringLiteral("no VFO B slice"));
+        r.skip(QStringLiteral("13.46 clear ZZRW → ZZRW+00000"), QStringLiteral("no VFO B slice"));
+    } else {
+        c.send(QStringLiteral("ZZRY0"));    // ensure VFO B RIT is off before touching freq
+        c.send(QStringLiteral("ZZRW+00000"));
+        QThread::msleep(50);
+        c.send(QStringLiteral("ZZRW+00300"));
+        QThread::msleep(100);
+        QString gotRw = c.query(QStringLiteral("ZZRW"));
+        r.check(QStringLiteral("13.45 set ZZRW+00300 → ZZRW; confirms ZZRW+00300"),
+                gotRw == QLatin1String("ZZRW+00300"), repr(gotRw));
+        c.send(QStringLiteral("ZZRW+00000"));
+        QThread::msleep(50);
+        gotRw = c.query(QStringLiteral("ZZRW"));
+        r.check(QStringLiteral("13.46 clear ZZRW → ZZRW; confirms ZZRW+00000"),
+                gotRw == QLatin1String("ZZRW+00000"), repr(gotRw));
+    }
+
+    // ── ZZRY: VFO B RIT state (0/1) ───────────────────────────────────────────
+    if (!vfoBAvail) {
+        r.skip(QStringLiteral("13.47 ZZRY0 confirms VFO B RIT off"), QStringLiteral("no VFO B slice"));
+        r.skip(QStringLiteral("13.48 ZZRY1 enables VFO B RIT"), QStringLiteral("no VFO B slice"));
+    } else {
+        c.send(QStringLiteral("ZZRY0"));
+        QThread::msleep(50);
+        QString gotRy = c.query(QStringLiteral("ZZRY"));
+        r.check(QStringLiteral("13.47 ZZRY0; clears VFO B RIT → ZZRY; confirms ZZRY0"),
+                gotRy == QLatin1String("ZZRY0"), repr(gotRy));
+        c.send(QStringLiteral("ZZRY1"));
+        QThread::msleep(100);
+        gotRy = c.query(QStringLiteral("ZZRY"));
+        r.check(QStringLiteral("13.48 ZZRY1; enables VFO B RIT → ZZRY; confirms ZZRY1"),
+                gotRy == QLatin1String("ZZRY1"), repr(gotRy));
+        c.send(QStringLiteral("ZZRY0"));  // leave RIT off
+        QThread::msleep(50);
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 14 — CW Keyer (KY send)  (optional — requires antenna/dummy load)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section14cw(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 14 — CW Keyer (KY)  ⚠  TX ACTIVE"));
+
+    QString origMd = c.query(QStringLiteral("MD"));
+    c.send(QStringLiteral("ZZMD04"));  // CW mode required for keying
+    QThread::msleep(200);
+
+    QString resp = c.query(QStringLiteral("KY"));
+    r.check(QStringLiteral("14.1 KY; → KY0 (buffer idle before send)"),
+            resp == QLatin1String("KY0"), repr(resp));
+
+    // 18 chars: ~2 s at 100 WPM, ~8 s at 25 WPM — recognisable on-air if accidentally transmitted
+    c.send(QStringLiteral("KY CQ CQ CQ TEST TEST"));  // P1 = mandatory space, text follows
+
+    QElapsedTimer timer;
+    timer.start();
+    QString pollResp;
+    do {
+        pollResp = c.query(QStringLiteral("KY"));
+        if (pollResp == QLatin1String("KY1")) break;
+        if (timer.elapsed() < 5000) QThread::msleep(20);
+    } while (timer.elapsed() < 5000);
+    if (pollResp != QLatin1String("KY1")) {
+        r.skip(QStringLiteral("14.2 KY CQ CQ CQ TEST TEST; → KY1 (busy)"),
+               QStringLiteral("keyer did not start — check interlock/inhibit line"));
+        r.skip(QStringLiteral("14.3 KY; → KY0 (complete)"),
+               QStringLiteral("keyer did not start"));
+        if (origMd.startsWith(QLatin1String("MD"))) { c.send(origMd); QThread::msleep(100); }
+        c.send(QStringLiteral("RX"));
+        return;
+    }
+    r.check(QStringLiteral("14.2 KY CQ CQ CQ TEST TEST; → KY; → KY1 (keyer busy / transmitting)"),
+            true, {});
+
+    timer.restart();
+    do {
+        pollResp = c.query(QStringLiteral("KY"));
+        if (pollResp == QLatin1String("KY0")) break;
+        if (timer.elapsed() < 15000) QThread::msleep(200);
+    } while (timer.elapsed() < 15000);
+    r.check(QStringLiteral("14.3 KY; → KY0 (keyer idle after transmission complete)"),
+            pollResp == QLatin1String("KY0"), repr(pollResp));
+
+    if (origMd.startsWith(QLatin1String("MD"))) { c.send(origMd); QThread::msleep(100); }
+
+    // Safety: watch 2 s — CW TX-tail may keep PA on after keyer reports KY0
+    {
+        QElapsedTimer safeTimer; safeTimer.start();
+        bool sawTxOn = false;
+        QString safeResp; IfFields sf;
+        c.send(QStringLiteral("ZZRX")); c.send(QStringLiteral("RX"));
+        do {
+            QThread::msleep(250);
+            safeResp = c.query(QStringLiteral("ZZIF"));
+            sf = parseIfBody(safeResp.startsWith(QLatin1String("ZZIF")) ? safeResp.mid(4) : QString());
+            if (sf.tx != QChar('0')) {
+                sawTxOn = true;
+                c.send(QStringLiteral("ZZRX")); c.send(QStringLiteral("RX"));
+            }
+        } while (safeTimer.elapsed() < 2000);
+        if (sawTxOn)
+            qWarning("14.S: TX re-asserted during 2-s safety watch — forced RX; possible firmware bug");
+        r.check(QStringLiteral("14.S safety: TX confirmed off after 2-s watch"),
+                sf.tx == QChar('0'), repr(QString(sf.tx)));
+    }
+}
+
+void section14skip(Runner& r)
+{
+    r.section(QStringLiteral("Section 14 — CW Keyer (skipped — pass --cw to enable)"));
+    for (const char* name : { "14.1 KY; → KY0 baseline",
+                               "14.2 KY CQ CQ CQ TEST TEST; → KY1 (busy)",
+                               "14.3 KY; → KY0 (complete)" }) {
+        r.skip(QString::fromLatin1(name), QStringLiteral("--cw not set"));
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 16 — ZZDE — Diversity Receive (FLEX-6700)
+// Accepts ZZDE0/ZZDE1 (6700 with diversity) or ?; (non-6700 or no diversity
+// slice).  On a valid response the set/get round-trip is also verified.
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section16(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 16 — ZZDE — Diversity Receive (FLEX-6700)"));
+
+    QString orig = c.query(QStringLiteral("ZZDE"));
+    const bool validResp = (orig == QLatin1String("ZZDE0") ||
+                            orig == QLatin1String("ZZDE1"));
+    const bool noSupport = (orig == QLatin1String("?"));
+
+    r.check(QStringLiteral("16.1 ZZDE; → ZZDE0, ZZDE1 (6700), or ?; (non-6700)"),
+            validResp || noSupport, repr(orig));
+
+    if (validResp) {
+        QString toggle = (orig == QLatin1String("ZZDE0"))
+                         ? QStringLiteral("ZZDE1") : QStringLiteral("ZZDE0");
+        c.send(toggle);
+        QThread::msleep(50);
+        QString got = c.query(QStringLiteral("ZZDE"));
+        r.check(QStringLiteral("16.2 ZZDE set/get round-trip"),
+                got == toggle, repr(got));
+        c.send(orig);   // restore
+        QThread::msleep(50);
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 15 — PTY round-trip  (Unix only; skips if device cannot be opened)
+// ═════════════════════════════════════════════════════════════════════════════
+
+#if defined(Q_OS_UNIX)
+class PtyClient
+{
+public:
+    explicit PtyClient(int timeoutMs = 3000) : m_timeout(timeoutMs) {}
+    ~PtyClient() { closeDevice(); }
+
+    bool openDevice(const QString& path)
+    {
+        m_fd = ::open(path.toLocal8Bit().constData(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+        if (m_fd < 0) return false;
+        struct termios tio;
+        if (::tcgetattr(m_fd, &tio) == 0) {
+            ::cfmakeraw(&tio);
+            tio.c_cc[VMIN]  = 0;
+            tio.c_cc[VTIME] = 0;
+            ::tcsetattr(m_fd, TCSANOW, &tio);
+        }
+        return true;
+    }
+
+    void closeDevice() { if (m_fd >= 0) { ::close(m_fd); m_fd = -1; } m_buf.clear(); }
+
+    void send(const QString& cmd)
+    {
+        QByteArray d = (cmd + ';').toUtf8();
+        ::write(m_fd, d.constData(), d.size());
+    }
+
+    QString query(const QString& cmd) { send(cmd); return readUntilSemi(); }
+
+    QString readUntilSemi()
+    {
+        QElapsedTimer t; t.start();
+        while (!m_buf.contains(';')) {
+            char tmp[256];
+            ssize_t n = ::read(m_fd, tmp, sizeof(tmp));
+            if (n > 0) m_buf.append(tmp, static_cast<int>(n));
+            else { if (t.elapsed() >= m_timeout) return {}; QThread::msleep(10); }
+        }
+        const int idx = m_buf.indexOf(';');
+        QString resp = QString::fromUtf8(m_buf.left(idx));
+        m_buf.remove(0, idx + 1);
+        return resp;
+    }
+
+private:
+    int        m_fd{-1};
+    QByteArray m_buf;
+    int        m_timeout;
+};
+
+void section15pty(Runner& r, const QString& ptyPath)
+{
+    r.section(QStringLiteral("Section 15 — PTY round-trip (%1)").arg(ptyPath));
+
+    PtyClient p;
+    if (!p.openDevice(ptyPath)) {
+        for (const char* name : { "15.1 PTY ID;", "15.2 PTY ZZFA;", "15.3 PTY PS;" })
+            r.skip(QString::fromLatin1(name),
+                   QStringLiteral("cannot open %1").arg(ptyPath));
+        return;
+    }
+
+    QString resp = p.query(QStringLiteral("ID"));
+    r.check(QStringLiteral("15.1 ID; via PTY → valid model ID"),
+            kValidIDs.contains(resp), repr(resp));
+
+    resp = p.query(QStringLiteral("ZZFA"));
+    r.check(QStringLiteral("15.2 ZZFA; via PTY → \"ZZFA\" + 11-digit Hz"),
+            resp.startsWith(QLatin1String("ZZFA")) && isDigits(resp.mid(4), 11), repr(resp));
+
+    resp = p.query(QStringLiteral("PS"));
+    r.check(QStringLiteral("15.3 PS; via PTY → PS1"),
+            resp == QLatin1String("PS1"), repr(resp));
+}
+#else
+void section15pty(Runner& r, const QString& ptyPath)
+{
+    r.section(QStringLiteral("Section 15 — PTY round-trip (Unix only)"));
+    for (const char* name : { "15.1 PTY ID;", "15.2 PTY ZZFA;", "15.3 PTY PS;" })
+        r.skip(QString::fromLatin1(name), QStringLiteral("Unix only"));
+    (void)ptyPath;
+}
+#endif
+
+} // namespace
+
+// ═════════════════════════════════════════════════════════════════════════════
+// main
+// ═════════════════════════════════════════════════════════════════════════════
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+    QCoreApplication::setApplicationName(QStringLiteral("smartcat_flexcat_test"));
+
+#if defined(Q_OS_UNIX)
+    g_tty = isatty(STDOUT_FILENO);
+#endif
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(
+        QStringLiteral("AetherSDR FlexCAT (ZZ-extension) dialect CAT integration test"));
+    parser.addHelpOption();
+    parser.addOption({ QStringLiteral("host"),    QStringLiteral("CAT host"), QStringLiteral("HOST"), QStringLiteral("localhost") });
+    parser.addOption({ QStringLiteral("port"),    QStringLiteral("FlexCAT port"), QStringLiteral("PORT"), QStringLiteral("5001") });
+    parser.addOption({ QStringLiteral("timeout"), QStringLiteral("Read timeout (ms)"), QStringLiteral("MS"), QStringLiteral("3000") });
+    parser.addOption({ QStringLiteral("ptt"),     QStringLiteral("Enable PTT tests (needs dummy load)") });
+    parser.addOption({ QStringLiteral("cw"),      QStringLiteral("Enable CW keyer tests (needs antenna/dummy load)") });
+    const QString defaultPty1 = defaultPtyPath(1);
+    parser.addOption({ QStringLiteral("pty"),     QStringLiteral("PTY device path for PTY round-trip test (default: %1)").arg(defaultPty1),
+                       QStringLiteral("PATH"),    defaultPty1 });
+    parser.process(app);
+
+    const QString host    = parser.value(QStringLiteral("host"));
+    const quint16 port    = static_cast<quint16>(parser.value(QStringLiteral("port")).toUInt());
+    const int     timeout = parser.value(QStringLiteral("timeout")).toInt();
+    const bool    doPtt   = parser.isSet(QStringLiteral("ptt"));
+    const bool    doCw    = parser.isSet(QStringLiteral("cw"));
+
+    std::cout << '\n' << bold(QStringLiteral("AetherSDR FlexCAT (ZZ-extension) Test Suite")).toStdString() << '\n'
+              << "Connecting to " << host.toStdString() << ':' << port << " ...\n";
+
+    CatClient c(timeout);
+    if (!c.connectToServer(host, port)) {
+        std::cerr << red(QStringLiteral("Connection failed.")).toStdString() << '\n'
+                  << yellow(QStringLiteral("Ensure AetherSDR is running with a FlexCAT port at the given port.")).toStdString() << '\n';
+        return EXIT_FAILURE;
+    }
+    std::cout << green(QStringLiteral("Connected.")).toStdString() << '\n';
+    if (doPtt)
+        std::cout << yellow(QStringLiteral("⚠  PTT tests enabled — ensure a dummy load or antenna is connected")).toStdString() << '\n';
+    if (doCw)
+        std::cout << yellow(QStringLiteral("⚠  CW tests enabled — radio will transmit")).toStdString() << '\n';
+
+    Runner r;
+
+    qint64 origHz    = 14'225'000;
+    QString origMode = QStringLiteral("2");
+    {
+        QString faResp = c.query(QStringLiteral("FA"));
+        if (faResp.startsWith(QLatin1String("FA")) && isDigits(faResp.mid(2), 11))
+            origHz = faResp.mid(2).toLongLong();
+        QString mdResp = c.query(QStringLiteral("MD"));
+        if (mdResp.startsWith(QLatin1String("MD")))
+            origMode = mdResp.mid(2);
+    }
+
+    section1(c, r);
+    section2(c, r, origHz);
+    section3(c, r);
+    section4(c, r, origMode);
+    section5(c, r);
+    section6(c, r);
+    section7(c, r);
+    section8(c, r);
+    section9(c, r);
+    if (doPtt) { section10ptt(c, r); } else { section10skip(r); }
+    section11(c, r);
+    section12(c, r);
+    section13(c, r);
+    if (doCw) { section14cw(c, r); } else { section14skip(r); }
+    section16(c, r);
+    section15pty(r, parser.value(QStringLiteral("pty")));
+
+    // Restore radio state
+    c.send(QStringLiteral("ZZAI00"));
+    c.send(QStringLiteral("AI0"));
+    c.send(QStringLiteral("ZZSW0"));
+    c.send(QStringLiteral("FT0"));
+    c.send(QStringLiteral("ZZRT0"));
+    c.send(QStringLiteral("ZZRC"));
+    c.send(QStringLiteral("RT0"));
+    c.send(QStringLiteral("RC"));
+    c.send(QStringLiteral("ZZXS0"));
+    c.send(QStringLiteral("ZZXC"));
+    c.send(QStringLiteral("XT0"));
+    c.send(QStringLiteral("ZZMA0"));  // un-mute VFO A
+    c.send(QStringLiteral("ZZMB0"));  // un-mute VFO B
+    c.send(QStringLiteral("ZZRY0"));  // clear VFO B RIT
+    c.send(QStringLiteral("ZZRW+00000"));
+    c.send(QStringLiteral("ZZRX"));
+    c.send(QStringLiteral("RX"));
+    c.send(QStringLiteral("FA") + hz11(origHz));
+    c.send(QStringLiteral("MD") + origMode);
+
+    c.close();
+    return r.summary() ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/CAT_TS-2000_test.cpp
+++ b/tests/CAT_TS-2000_test.cpp
@@ -1,0 +1,1274 @@
+// AetherSDR TS-2000 dialect CAT integration test.
+// Requires a running AetherSDR instance with a TS-2000 CAT port enabled.
+//
+// Build:  cmake --build build --target CAT_TS-2000_test
+// Run:    ./build/CAT_TS-2000_test [--host HOST] [--port PORT] [--ptt] [--cw] [--pty PATH]
+//
+// Mirrors tests/test_ts2000.py.  PTT tests (section 9) are disabled by default;
+// enable only when a dummy load or antenna is connected.
+
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QSet>
+#include <QStandardPaths>
+#include <QTcpSocket>
+#include <QThread>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#if defined(Q_OS_UNIX)
+#include <cerrno>
+#include <fcntl.h>
+#include <termios.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+// ── Per-user PTY symlink path (matches CatPort::defaultSymlinkPath) ───────────
+
+static QString defaultPtyPath(int portIndex)
+{
+    const char letter = static_cast<char>('A' + portIndex);
+    const QString leaf = QStringLiteral("cat-") + QChar(letter);
+    QString base = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+    if (base.isEmpty())
+        base = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    if (base.isEmpty())
+        base = QDir::homePath() + QStringLiteral("/.cache/aethersdr");
+    if (!base.contains(QStringLiteral("aethersdr"), Qt::CaseInsensitive))
+        base += QStringLiteral("/aethersdr");
+    return base + QLatin1Char('/') + leaf;
+}
+
+// ── ANSI colour ───────────────────────────────────────────────────────────────
+
+static bool g_tty = false;
+
+static QString ansi(const char* code, const QString& s)
+{
+    if (!g_tty) return s;
+    return QLatin1String("\033[") + QLatin1String(code) + 'm' + s + QLatin1String("\033[0m");
+}
+
+static QString green(const QString& s)  { return ansi("92", s); }
+static QString red(const QString& s)    { return ansi("91", s); }
+static QString yellow(const QString& s) { return ansi("93", s); }
+static QString cyan(const QString& s)   { return ansi("96", s); }
+static QString bold(const QString& s)   { return ansi("1",  s); }
+
+// ── CatClient ─────────────────────────────────────────────────────────────────
+
+class CatClient
+{
+public:
+    explicit CatClient(int timeoutMs = 3000)
+        : m_timeout(timeoutMs) {}
+
+    bool connectToServer(const QString& host, quint16 port)
+    {
+        m_sock.connectToHost(host, port);
+        if (!m_sock.waitForConnected(m_timeout)) {
+            std::cerr << "Connection failed: "
+                      << m_sock.errorString().toStdString() << '\n';
+            return false;
+        }
+        m_sock.setSocketOption(QAbstractSocket::LowDelayOption, 1);
+        return true;
+    }
+
+    // Send "cmd;" and read response up to next ';'; returns string without ';'.
+    QString query(const QString& cmd)
+    {
+        m_sock.write((cmd + ';').toUtf8());
+        m_sock.flush();
+        return readUntilSemi();
+    }
+
+    // Send "cmd;" with no response expected (set commands).
+    void send(const QString& cmd)
+    {
+        m_sock.write((cmd + ';').toUtf8());
+        m_sock.flush();
+    }
+
+    // Read until ';' with a custom timeout; returns null QString on timeout.
+    QString tryRead(int msTimeout)
+    {
+        const int saved = m_timeout;
+        m_timeout = msTimeout;
+        QString result = readUntilSemi();
+        m_timeout = saved;
+        return result;
+    }
+
+    void close() { m_sock.disconnectFromHost(); }
+
+    // Public for manual poll loops.
+    QString readUntilSemi()
+    {
+        while (!m_buf.contains(';')) {
+            if (!m_sock.waitForReadyRead(m_timeout))
+                return {};
+            m_buf += m_sock.readAll();
+        }
+        const int idx = m_buf.indexOf(';');
+        QString resp = QString::fromUtf8(m_buf.left(idx));
+        m_buf.remove(0, idx + 1);
+        return resp;
+    }
+
+private:
+    QTcpSocket m_sock;
+    QByteArray m_buf;
+    int        m_timeout;
+};
+
+// ── Runner ────────────────────────────────────────────────────────────────────
+
+class Runner
+{
+public:
+    void section(const QString& title)
+    {
+        std::cout << '\n' << bold(cyan(title)).toStdString() << '\n'
+                  << std::string(64, '-') << '\n';
+    }
+
+    bool check(const QString& name, bool cond, const QString& detail = {})
+    {
+        if (cond) {
+            ++m_passed;
+            std::cout << "  " << green(QStringLiteral("PASS")).toStdString()
+                      << "  " << name.toStdString() << '\n';
+        } else {
+            ++m_failed;
+            std::cout << "  " << red(QStringLiteral("FAIL")).toStdString()
+                      << "  " << name.toStdString();
+            if (!detail.isEmpty())
+                std::cout << "  " << yellow(QStringLiteral("→")).toStdString()
+                          << ' ' << detail.toStdString();
+            std::cout << '\n';
+        }
+        return cond;
+    }
+
+    void skip(const QString& name, const QString& reason = {})
+    {
+        ++m_skipped;
+        std::cout << "  " << yellow(QStringLiteral("SKIP")).toStdString()
+                  << "  " << name.toStdString();
+        if (!reason.isEmpty())
+            std::cout << "  (" << reason.toStdString() << ')';
+        std::cout << '\n';
+    }
+
+    bool summary() const
+    {
+        const int total = m_passed + m_failed;
+        std::cout << '\n' << std::string(64, '=') << '\n'
+                  << bold(QStringLiteral("Results: %1/%2 passed")
+                          .arg(m_passed).arg(total)).toStdString() << '\n';
+        if (m_skipped)
+            std::cout << "  Skipped: " << m_skipped << '\n';
+        if (m_failed)
+            std::cout << red(QStringLiteral("  Failed:  %1").arg(m_failed))
+                             .toStdString() << '\n';
+        std::cout << std::string(64, '=') << '\n';
+        return m_failed == 0;
+    }
+
+    int failed() const { return m_failed; }
+
+private:
+    int m_passed{0};
+    int m_failed{0};
+    int m_skipped{0};
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+static QString repr(const QString& s)
+{
+    if (s.isNull()) return QStringLiteral("(timeout)");
+    return '"' + s + '"';
+}
+
+static QString hz11(qint64 hz)
+{
+    return QStringLiteral("%1").arg(hz, 11, 10, QChar('0'));
+}
+
+static bool isDigits(const QString& s, int n)
+{
+    if (s.size() != n) return false;
+    for (const QChar c : s) {
+        if (!c.isDigit()) return false;
+    }
+    return true;
+}
+
+static bool isValidAgcCode(const QString& s)
+{
+    return s == QLatin1String("0") || s == QLatin1String("2") ||
+           s == QLatin1String("3") || s == QLatin1String("4");
+}
+
+struct IfFields {
+    QString freq_hz;
+    QString step;
+    QString rit_hz;
+    QChar   rit_on{'?'};
+    QChar   xit{'?'};
+    QString mem;
+    QChar   tx{'?'};
+    QChar   mode{'?'};
+    QChar   func{'?'};
+    QChar   scan{'?'};
+    QChar   split{'?'};
+    QChar   tone{'?'};
+    QString ctcss;
+    QChar   dcs{'?'};
+    bool    valid{false};
+};
+
+static IfFields parseIfBody(const QString& body)
+{
+    IfFields f;
+    if (body.size() != 35) return f;
+    f.freq_hz = body.mid(0, 11);
+    f.step    = body.mid(11, 5);
+    f.rit_hz  = body.mid(16, 6);
+    f.rit_on  = body[22];
+    f.xit     = body[23];
+    f.mem     = body.mid(24, 2);
+    f.tx      = body[26];
+    f.mode    = body[27];
+    f.func    = body[28];
+    f.scan    = body[29];
+    f.split   = body[30];
+    f.tone    = body[31];
+    f.ctcss   = body.mid(32, 2);
+    f.dcs     = body[34];
+    f.valid   = true;
+    return f;
+}
+
+static const QSet<QString> kValidIDs = {
+    QStringLiteral("ID019"),  // Kenwood TS-2000 (TS-2000 dialect)
+    QStringLiteral("ID904"), QStringLiteral("ID905"), QStringLiteral("ID906"),
+    QStringLiteral("ID907"), QStringLiteral("ID908"), QStringLiteral("ID909"),
+    QStringLiteral("ID910"), QStringLiteral("ID911"), QStringLiteral("ID919"),
+    QStringLiteral("ID930"), QStringLiteral("ID931"),
+};
+
+struct ModeEntry { char code; const char* name; };
+static const ModeEntry kKenwoodModes[] = {
+    { '1', "LSB" }, { '2', "USB" }, { '3', "CW" },
+    { '4', "FM"  }, { '5', "AM"  }, { '6', "DIGL" }, { '9', "DIGU" },
+};
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 1 — Connection & Identification
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section1(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 1 — Connection & Identification"));
+
+    QString resp = c.query(QStringLiteral("ID"));
+    r.check(QStringLiteral("1.1  ID; → valid model ID from CAT guide table"),
+            kValidIDs.contains(resp), repr(resp));
+
+    resp = c.query(QStringLiteral("PS"));
+    r.check(QStringLiteral("1.2  PS; → PS1 (power on)"),
+            resp == QLatin1String("PS1"), repr(resp));
+
+    resp = c.query(QStringLiteral("SM0"));
+    r.check(QStringLiteral("1.3  SM0; → SM00000 (S-meter zero)"),
+            resp == QLatin1String("SM00000"), repr(resp));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 2 — VFO-A Frequency (FA)
+// ═════════════════════════════════════════════════════════════════════════════
+
+qint64 section2(CatClient& c, Runner& r, qint64 origHz)
+{
+    r.section(QStringLiteral("Section 2 — VFO-A Frequency (FA)"));
+
+    QString resp = c.query(QStringLiteral("FA"));
+    r.check(QStringLiteral("2.1  FA; returns \"FA\" + 11-digit Hz"),
+            resp.startsWith(QLatin1String("FA")) && isDigits(resp.mid(2), 11),
+            repr(resp));
+    qint64 currentHz = (resp.startsWith(QLatin1String("FA")) && isDigits(resp.mid(2), 11))
+                       ? resp.mid(2).toLongLong()
+                       : origHz;
+
+    const qint64 testHz = 14'074'000;
+    c.send(QStringLiteral("FA") + hz11(testHz));
+    QThread::msleep(150);
+    resp = c.query(QStringLiteral("FA"));
+    r.check(QStringLiteral("2.2  set FA 14.074 MHz → FA; confirms new frequency"),
+            resp == QStringLiteral("FA") + hz11(testHz),
+            QStringLiteral("got %1").arg(repr(resp)));
+
+    const qint64 test2Hz = 7'074'000;
+    c.send(QStringLiteral("FA") + hz11(test2Hz));
+    QThread::msleep(150);
+    resp = c.query(QStringLiteral("FA"));
+    r.check(QStringLiteral("2.3  second set FA (different band) confirms correctly"),
+            resp == QStringLiteral("FA") + hz11(test2Hz),
+            QStringLiteral("got %1").arg(repr(resp)));
+
+    c.send(QStringLiteral("FA") + hz11(origHz));
+    QThread::msleep(100);
+    return currentHz;
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 3 — VFO-B Frequency (FB)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section3(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 3 — VFO-B Frequency (FB)"));
+
+    QString resp = c.query(QStringLiteral("FB"));
+    r.check(QStringLiteral("3.1  FB; returns \"FB\" + 11-digit Hz"),
+            resp.startsWith(QLatin1String("FB")) && isDigits(resp.mid(2), 11),
+            repr(resp));
+
+    QString faResp = c.query(QStringLiteral("FA"));
+    const QString faHz = faResp.startsWith(QLatin1String("FA")) ? faResp.mid(2) : QString();
+    const QString fbHz = resp.startsWith(QLatin1String("FB")) ? resp.mid(2) : QString();
+    const bool vfoBMapped = (!fbHz.isEmpty() && !faHz.isEmpty() && fbHz != faHz);
+
+    if (!vfoBMapped) {
+        r.skip(QStringLiteral("3.2  set FB 14.225 MHz → FB; confirms"),
+               QStringLiteral("VFO B not mapped to a second slice — configure port VFO B first"));
+    } else {
+        const qint64 testHz = 14'225'000;
+        c.send(QStringLiteral("FB") + hz11(testHz));
+        QElapsedTimer timer;
+        timer.start();
+        QString pollResp;
+        do {
+            pollResp = c.query(QStringLiteral("FB"));
+            if (pollResp == QStringLiteral("FB") + hz11(testHz)) break;
+            if (timer.elapsed() < 2000) QThread::msleep(100);
+        } while (timer.elapsed() < 2000);
+        r.check(QStringLiteral("3.2  set FB 14.225 MHz → FB; confirms"),
+                pollResp == QStringLiteral("FB") + hz11(testHz),
+                QStringLiteral("got %1").arg(repr(pollResp)));
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 4 — Mode (MD) — Kenwood 1-digit codes
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section4(CatClient& c, Runner& r, const QString& origModeDigit)
+{
+    r.section(QStringLiteral("Section 4 — Mode (MD) — Kenwood 1-digit codes"));
+
+    QString resp = c.query(QStringLiteral("MD"));
+    const QString digit = resp.startsWith(QLatin1String("MD")) ? resp.mid(2) : QString();
+    bool validDigit = false;
+    for (const ModeEntry& m : kKenwoodModes) {
+        if (digit == QString(QLatin1Char(m.code))) { validDigit = true; break; }
+    }
+    r.check(QStringLiteral("4.1  MD; returns \"MD\" + valid Kenwood mode digit"),
+            resp.startsWith(QLatin1String("MD")) && validDigit, repr(resp));
+
+    int checkNum = 2;
+    for (const ModeEntry& mode : kKenwoodModes) {
+        const QString codeStr = QString(QLatin1Char(mode.code));
+        c.send(QStringLiteral("MD") + codeStr);
+        QElapsedTimer timer;
+        timer.start();
+        QString pollResp;
+        do {
+            pollResp = c.query(QStringLiteral("MD"));
+            if (pollResp == QStringLiteral("MD") + codeStr) break;
+            if (timer.elapsed() < 2000) QThread::msleep(100);
+        } while (timer.elapsed() < 2000);
+        r.check(QStringLiteral("4.%1  set MD%2 (%3) → MD; round-trips correctly")
+                    .arg(checkNum).arg(codeStr, QString::fromLatin1(mode.name)),
+                pollResp == QStringLiteral("MD") + codeStr,
+                QStringLiteral("got %1").arg(repr(pollResp)));
+        ++checkNum;
+    }
+
+    c.send(QStringLiteral("MD") + origModeDigit);
+    QThread::msleep(200);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 5 — IF Composite Status
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section5(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 5 — IF Composite Status"));
+
+    c.send(QStringLiteral("FA") + hz11(14'225'000));
+    c.send(QStringLiteral("MD2"));
+    c.send(QStringLiteral("FT0"));
+    QThread::msleep(200);
+
+    QString resp = c.query(QStringLiteral("IF"));
+    const QString body = resp.startsWith(QLatin1String("IF")) ? resp.mid(2) : QString();
+    const IfFields fields = parseIfBody(body);
+
+    r.check(QStringLiteral("5.1  IF; returns \"IF\" + exactly 35-char body"),
+            resp.startsWith(QLatin1String("IF")) && body.size() == 35,
+            QStringLiteral("body len=%1 body=%2").arg(body.size()).arg(repr(body)));
+
+    r.check(QStringLiteral("5.2  IF body freq field (0-10) is all digits"),
+            isDigits(fields.freq_hz, 11), repr(fields.freq_hz));
+
+    QString faResp = c.query(QStringLiteral("FA"));
+    const QString faHz = faResp.startsWith(QLatin1String("FA")) ? faResp.mid(2) : QString();
+    r.check(QStringLiteral("5.3  IF body freq field matches FA; response"),
+            fields.freq_hz == faHz,
+            QStringLiteral("IF=%1 FA=%2").arg(repr(fields.freq_hz), repr(faHz)));
+
+    r.check(QStringLiteral("5.4  IF body TX field (pos 26) is '0' while receiving"),
+            fields.tx == QChar('0'), repr(QString(fields.tx)));
+
+    QString mdResp = c.query(QStringLiteral("MD"));
+    const QString mdDigit = mdResp.startsWith(QLatin1String("MD")) ? mdResp.mid(2) : QString();
+    r.check(QStringLiteral("5.5  IF body mode field (pos 27) matches MD; digit"),
+            QString(fields.mode) == mdDigit,
+            QStringLiteral("IF mode=%1 MD=%2").arg(repr(QString(fields.mode)), repr(mdDigit)));
+
+    r.check(QStringLiteral("5.6  IF body split field (pos 30) is '0' (FT0 set above)"),
+            fields.split == QChar('0'), repr(QString(fields.split)));
+
+    r.check(QStringLiteral("5.7  IF body step (pos 11-15) is 5 digits"),
+            isDigits(fields.step, 5), repr(fields.step));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 6 — AI Mode (async unsolicited updates)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section6(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 6 — AI Mode (async unsolicited updates)"));
+
+    QString resp = c.query(QStringLiteral("AI"));
+    r.check(QStringLiteral("6.1  AI; → AI0 (disabled by default)"),
+            resp == QLatin1String("AI0"), repr(resp));
+
+    c.send(QStringLiteral("AI1"));
+    resp = c.query(QStringLiteral("AI"));
+    r.check(QStringLiteral("6.2  AI1; enables AI; AI; → AI1"),
+            resp == QLatin1String("AI1"), repr(resp));
+
+    const qint64 newHz = 14'100'000;
+    c.send(QStringLiteral("FA") + hz11(newHz));
+    QString push = c.tryRead(2000);
+    r.check(QStringLiteral("6.3  AI push after FA set — received FA%1").arg(hz11(newHz)),
+            push == QStringLiteral("FA") + hz11(newHz), repr(push));
+
+    // Drain any async state pushes that may arrive alongside or after the FA
+    // change (mode-by-band, filter notifications, etc.).  Use a 500 ms window
+    // and keep looping until the stream is quiet.
+    { QString p; do { p = c.tryRead(500); } while (!p.isNull()); }
+
+    c.send(QStringLiteral("MD1"));
+    // Scan incoming pushes for MD1; skip any stale state pushes that may
+    // have been queued before our command was processed.
+    push = {};
+    {
+        QElapsedTimer t; t.start();
+        while (t.elapsed() < 3000) {
+            QString p = c.tryRead(500);
+            if (p.isNull()) break;
+            if (p == QLatin1String("MD1")) { push = p; break; }
+        }
+    }
+    r.check(QStringLiteral("6.4  AI push after MD set — received MD1 (LSB)"),
+            push == QLatin1String("MD1"), repr(push));
+
+    c.send(QStringLiteral("AI0"));
+    resp = c.query(QStringLiteral("AI"));
+    r.check(QStringLiteral("6.5  AI0; disables AI; AI; → AI0"),
+            resp == QLatin1String("AI0"), repr(resp));
+
+    c.send(QStringLiteral("FA") + hz11(14'225'000));
+    QString silence = c.tryRead(500);
+    r.check(QStringLiteral("6.6  no AI push after AI0 (set FA, expect silence)"),
+            silence.isNull(),
+            QStringLiteral("got unexpected push: %1").arg(repr(silence)));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 7 — Split (FT)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section7(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 7 — Split (FT)"));
+
+    QString resp = c.query(QStringLiteral("FT"));
+    r.check(QStringLiteral("7.1  FT; → FT0 (split off initially)"),
+            resp == QLatin1String("FT0"), repr(resp));
+
+    c.send(QStringLiteral("FT1"));
+    resp = c.query(QStringLiteral("FT"));
+    r.check(QStringLiteral("7.2  FT1; enables split; FT; → FT1"),
+            resp == QLatin1String("FT1"), repr(resp));
+
+    QString respIf = c.query(QStringLiteral("IF"));
+    IfFields fields = parseIfBody(respIf.startsWith(QLatin1String("IF")) ? respIf.mid(2) : QString());
+    r.check(QStringLiteral("7.3  IF body split field (pos 30) is '1' while split on"),
+            fields.split == QChar('1'),
+            QStringLiteral("split=%1").arg(repr(QString(fields.split))));
+
+    c.send(QStringLiteral("FT0"));
+    resp = c.query(QStringLiteral("FT"));
+    r.check(QStringLiteral("7.4  FT0; clears split; FT; → FT0"),
+            resp == QLatin1String("FT0"), repr(resp));
+
+    respIf = c.query(QStringLiteral("IF"));
+    fields = parseIfBody(respIf.startsWith(QLatin1String("IF")) ? respIf.mid(2) : QString());
+    r.check(QStringLiteral("7.5  IF body split field returns to '0' after FT0"),
+            fields.split == QChar('0'), repr(QString(fields.split)));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 8 — FR (RX VFO select — accepted, no-op)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section8(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 8 — FR (RX VFO select — accepted, no-op)"));
+
+    c.send(QStringLiteral("FR0"));
+    c.send(QStringLiteral("FR1"));
+    QThread::msleep(50);
+    QString resp = c.query(QStringLiteral("FA"));
+    r.check(QStringLiteral("8.1  FR0; FR1; produce no response; FA; works normally after"),
+            resp.startsWith(QLatin1String("FA")) && isDigits(resp.mid(2), 11),
+            repr(resp));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 9 — PTT  (optional — requires dummy load or antenna)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section9ptt(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 9 — PTT  ⚠  TX ACTIVE"));
+
+    QString resp = c.query(QStringLiteral("IF"));
+    IfFields fields = parseIfBody(resp.startsWith(QLatin1String("IF")) ? resp.mid(2) : QString());
+    r.check(QStringLiteral("9.0  IF confirms TX=0 before keying"),
+            fields.tx == QChar('0'), repr(QString(fields.tx)));
+
+    c.send(QStringLiteral("TX"));
+    QThread::msleep(1000);
+
+    resp = c.query(QStringLiteral("IF"));
+    fields = parseIfBody(resp.startsWith(QLatin1String("IF")) ? resp.mid(2) : QString());
+    const bool txOn = (fields.tx == QChar('1'));
+
+    if (!txOn) {
+        r.skip(QStringLiteral("9.1  TX; keys radio; IF TX='1'"),
+               QStringLiteral("TX blocked — check interlock/inhibit line"));
+        r.skip(QStringLiteral("9.2  RX; unkeys radio; IF TX='0'"),
+               QStringLiteral("TX blocked"));
+        r.skip(QStringLiteral("9.3  TX0; alt unkey; IF TX='0'"),
+               QStringLiteral("TX blocked"));
+        c.send(QStringLiteral("RX"));
+        return;
+    }
+
+    r.check(QStringLiteral("9.1  TX; keys radio; IF body TX field = '1'"),
+            txOn, repr(QString(fields.tx)));
+
+    c.send(QStringLiteral("RX"));
+    QThread::msleep(250);
+
+    resp = c.query(QStringLiteral("IF"));
+    fields = parseIfBody(resp.startsWith(QLatin1String("IF")) ? resp.mid(2) : QString());
+    r.check(QStringLiteral("9.2  RX; unkeys radio; IF body TX field = '0'"),
+            fields.tx == QChar('0'), repr(QString(fields.tx)));
+
+    c.send(QStringLiteral("TX0"));
+    QThread::msleep(150);
+    resp = c.query(QStringLiteral("IF"));
+    fields = parseIfBody(resp.startsWith(QLatin1String("IF")) ? resp.mid(2) : QString());
+    r.check(QStringLiteral("9.3  TX0; (alternate unkey) accepted; IF TX field = '0'"),
+            fields.tx == QChar('0'), repr(QString(fields.tx)));
+
+    // Safety: watch 2 s — firmware may briefly re-assert TX after unkey
+    {
+        QElapsedTimer safeTimer; safeTimer.start();
+        bool sawTxOn = false;
+        c.send(QStringLiteral("RX"));
+        do {
+            QThread::msleep(250);
+            resp = c.query(QStringLiteral("IF"));
+            fields = parseIfBody(resp.startsWith(QLatin1String("IF")) ? resp.mid(2) : QString());
+            if (fields.tx != QChar('0')) { sawTxOn = true; c.send(QStringLiteral("RX")); }
+        } while (safeTimer.elapsed() < 2000);
+        if (sawTxOn)
+            qWarning("9.S: TX re-asserted during 2-s safety watch — forced RX; possible firmware bug");
+        r.check(QStringLiteral("9.S  safety: TX confirmed off after 2-s watch"),
+                fields.tx == QChar('0'), repr(QString(fields.tx)));
+    }
+}
+
+void section9skip(Runner& r)
+{
+    r.section(QStringLiteral("Section 9 — PTT  (skipped — pass --ptt to enable)"));
+    for (const char* name : { "9.0 IF TX=0 baseline", "9.1 TX; keys",
+                               "9.2 RX; unkeys", "9.3 TX0; alt form" }) {
+        r.skip(QString::fromLatin1(name), QStringLiteral("--ptt not set"));
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 10 — ZZ Extensions Blocked (TS-2000 dialect)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section10(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 10 — ZZ Extensions Blocked (TS-2000 dialect)"));
+
+    struct Entry { const char* cmd; const char* label; };
+    static const Entry entries[] = {
+        { "ZZFA",  "10.1" }, { "ZZFB",  "10.2" }, { "ZZMD",  "10.3" },
+        { "ZZME",  "10.4" }, { "ZZIF",  "10.5" }, { "ZZAI",  "10.6" },
+        { "ZZSW",  "10.7" }, { "ZZSM0", "10.8" },
+    };
+    for (const Entry& e : entries) {
+        QString resp = c.query(QString::fromLatin1(e.cmd));
+        r.check(QStringLiteral("%1  %2; → ?; (ZZ blocked in TS-2000)")
+                    .arg(QString::fromLatin1(e.label), QString::fromLatin1(e.cmd)),
+                resp == QLatin1String("?"), repr(resp));
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 11 — Unknown / Invalid Commands
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section11(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 11 — Unknown / Invalid Commands"));
+
+    struct Entry { const char* cmd; const char* label; };
+    static const Entry entries[] = {
+        { "XQ",   "11.1" }, { "ZZ",   "11.2" }, { "ABCD", "11.3" },
+    };
+    for (const Entry& e : entries) {
+        QString resp = c.query(QString::fromLatin1(e.cmd));
+        r.check(QStringLiteral("%1  %2; → ?;")
+                    .arg(QString::fromLatin1(e.label), QString::fromLatin1(e.cmd)),
+                resp == QLatin1String("?"), repr(resp));
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, KY, RT, RG, RC, RD, RU, XT)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section12(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, KY, RT, RG, XT)"));
+
+    // ── AG: VFO A audio gain (0-100, 3-digit) ──────────────────────────────
+    QString origAg = c.query(QStringLiteral("AG"));
+    r.check(QStringLiteral("12.1  AG; → \"AG\" + 3-digit gain"),
+            origAg.startsWith(QLatin1String("AG")) && isDigits(origAg.mid(2), 3), repr(origAg));
+
+    c.send(QStringLiteral("AG075"));
+    QThread::msleep(100);
+    QString resp = c.query(QStringLiteral("AG"));
+    r.check(QStringLiteral("12.2  set AG075 → AG; confirms AG075"),
+            resp == QLatin1String("AG075"), repr(resp));
+
+    if (origAg.startsWith(QLatin1String("AG"))) { c.send(origAg); QThread::msleep(50); }
+
+    // ── GT: AGC mode (0=Off, 2=Slow, 3=Med, 4=Fast) ────────────────────────
+    QString origGt = c.query(QStringLiteral("GT"));
+    r.check(QStringLiteral("12.3  GT; → \"GT\" + valid AGC code"),
+            origGt.startsWith(QLatin1String("GT")) && isValidAgcCode(origGt.mid(2)), repr(origGt));
+
+    c.send(QStringLiteral("GT3"));
+    QThread::msleep(150);
+    resp = c.query(QStringLiteral("GT"));
+    r.check(QStringLiteral("12.4  set GT3 (Med) → GT; confirms GT3"),
+            resp == QLatin1String("GT3"), repr(resp));
+
+    if (origGt.startsWith(QLatin1String("GT"))) { c.send(origGt); QThread::msleep(100); }
+
+    // ── PC: RF power (0-100, 3-digit) ──────────────────────────────────────
+    QString origPc = c.query(QStringLiteral("PC"));
+    r.check(QStringLiteral("12.5  PC; → \"PC\" + 3-digit power"),
+            origPc.startsWith(QLatin1String("PC")) && isDigits(origPc.mid(2), 3), repr(origPc));
+
+    c.send(QStringLiteral("PC080"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("PC"));
+    r.check(QStringLiteral("12.6  set PC080 → PC; confirms PC080"),
+            resp == QLatin1String("PC080"), repr(resp));
+
+    if (origPc.startsWith(QLatin1String("PC"))) { c.send(origPc); QThread::msleep(50); }
+
+    // ── NB: Wide Noise Blanker state (0/1) ─────────────────────────────────
+    QString origNb = c.query(QStringLiteral("NB"));
+    r.check(QStringLiteral("12.7  NB; → NB0 or NB1"),
+            origNb == QLatin1String("NB0") || origNb == QLatin1String("NB1"), repr(origNb));
+
+    QString newNb = (origNb == QLatin1String("NB0")) ? QStringLiteral("NB1") : QStringLiteral("NB0");
+    c.send(newNb);
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("NB"));
+    r.check(QStringLiteral("12.8  toggle NB → confirms %1").arg(newNb),
+            resp == newNb, repr(resp));
+
+    c.send(origNb);
+    QThread::msleep(50);
+
+    // ── KS: CW keying speed (005-100, 3-digit) ──────────────────────────────
+    QString origKs = c.query(QStringLiteral("KS"));
+    r.check(QStringLiteral("12.9  KS; → \"KS\" + 3-digit WPM"),
+            origKs.startsWith(QLatin1String("KS")) && isDigits(origKs.mid(2), 3), repr(origKs));
+
+    c.send(QStringLiteral("KS025"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("KS"));
+    r.check(QStringLiteral("12.10 set KS025 (25 WPM) → KS; confirms KS025"),
+            resp == QLatin1String("KS025"), repr(resp));
+
+    if (origKs.startsWith(QLatin1String("KS"))) { c.send(origKs); QThread::msleep(50); }
+
+    // ── PT: CW pitch (100-999, 3-digit) ─────────────────────────────────────
+    QString origPt = c.query(QStringLiteral("PT"));
+    r.check(QStringLiteral("12.11 PT; → \"PT\" + 3-digit Hz"),
+            origPt.startsWith(QLatin1String("PT")) && isDigits(origPt.mid(2), 3), repr(origPt));
+
+    c.send(QStringLiteral("PT600"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("PT"));
+    r.check(QStringLiteral("12.12 set PT600 (600 Hz) → PT; confirms PT600"),
+            resp == QLatin1String("PT600"), repr(resp));
+
+    if (origPt.startsWith(QLatin1String("PT"))) { c.send(origPt); QThread::msleep(50); }
+
+    // ── KY: CW send / busy query ─────────────────────────────────────────────
+    resp = c.query(QStringLiteral("KY"));
+    r.check(QStringLiteral("12.13 KY; (query) → KY0 (not busy) or KY1 (busy)"),
+            resp == QLatin1String("KY0") || resp == QLatin1String("KY1"), repr(resp));
+
+    // ── RT: RIT state (0/1) ──────────────────────────────────────────────────
+    resp = c.query(QStringLiteral("RT"));
+    r.check(QStringLiteral("12.14 RT; → RT0 or RT1"),
+            resp == QLatin1String("RT0") || resp == QLatin1String("RT1"), repr(resp));
+
+    c.send(QStringLiteral("RT1"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("RT"));
+    r.check(QStringLiteral("12.14b RT1; enables RIT → RT; confirms RT1"),
+            resp == QLatin1String("RT1"), repr(resp));
+
+    c.send(QStringLiteral("RT0"));
+    QThread::msleep(50);
+    resp = c.query(QStringLiteral("RT"));
+    r.check(QStringLiteral("12.14c RT0; clears RIT → RT; confirms RT0"),
+            resp == QLatin1String("RT0"), repr(resp));
+
+    // ── RG: RIT frequency (±NNNNN Hz) ────────────────────────────────────────
+    c.send(QStringLiteral("RG+00500"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("RG"));
+    r.check(QStringLiteral("12.15 set RG+00500 → RG; returns \"RG+00500\""),
+            resp == QLatin1String("RG+00500"), repr(resp));
+
+    // ── RC: clear RIT to 0 ───────────────────────────────────────────────────
+    c.send(QStringLiteral("RC"));
+    QThread::msleep(50);
+    resp = c.query(QStringLiteral("RG"));
+    r.check(QStringLiteral("12.16 RC; clears RIT → RG; returns \"RG+00000\""),
+            resp == QLatin1String("RG+00000"), repr(resp));
+
+    // ── RU / RD: increment / decrement ───────────────────────────────────────
+    c.send(QStringLiteral("RU00100"));
+    QThread::msleep(50);
+    resp = c.query(QStringLiteral("RG"));
+    r.check(QStringLiteral("12.17 RU00100; increments RIT by 100 Hz → RG+00100"),
+            resp == QLatin1String("RG+00100"), repr(resp));
+
+    c.send(QStringLiteral("RD00050"));
+    QThread::msleep(50);
+    resp = c.query(QStringLiteral("RG"));
+    r.check(QStringLiteral("12.18 RD00050; decrements RIT by 50 Hz → RG+00050"),
+            resp == QLatin1String("RG+00050"), repr(resp));
+
+    c.send(QStringLiteral("RC"));
+    c.send(QStringLiteral("RT0"));
+    QThread::msleep(50);
+
+    // ── XT: XIT state (0/1) ──────────────────────────────────────────────────
+    resp = c.query(QStringLiteral("XT"));
+    r.check(QStringLiteral("12.19 XT; → XT0 or XT1"),
+            resp == QLatin1String("XT0") || resp == QLatin1String("XT1"), repr(resp));
+
+    c.send(QStringLiteral("XT1"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("XT"));
+    r.check(QStringLiteral("12.20 XT1; enables XIT → XT; confirms XT1"),
+            resp == QLatin1String("XT1"), repr(resp));
+
+    c.send(QStringLiteral("XT0"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("XT"));
+    r.check(QStringLiteral("12.21 XT0; clears XIT → XT; confirms XT0"),
+            resp == QLatin1String("XT0"), repr(resp));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 13 — CW Keyer (KY send)  (optional — requires antenna/dummy load)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section13cw(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 13 — CW Keyer (KY)  ⚠  TX ACTIVE"));
+
+    QString origMd = c.query(QStringLiteral("MD"));
+    c.send(QStringLiteral("MD3"));  // CW mode required for keying
+    QThread::msleep(200);
+
+    QString resp = c.query(QStringLiteral("KY"));
+    r.check(QStringLiteral("13.1 KY; → KY0 (buffer idle before send)"),
+            resp == QLatin1String("KY0"), repr(resp));
+
+    // 18 chars: ~2 s at 100 WPM, ~8 s at 25 WPM — recognisable on-air if accidentally transmitted
+    c.send(QStringLiteral("KY CQ CQ CQ TEST TEST"));  // P1 = mandatory space, text follows
+
+    QElapsedTimer timer;
+    timer.start();
+    QString pollResp;
+    do {
+        pollResp = c.query(QStringLiteral("KY"));
+        if (pollResp == QLatin1String("KY1")) break;
+        if (timer.elapsed() < 5000) QThread::msleep(20);
+    } while (timer.elapsed() < 5000);
+    if (pollResp != QLatin1String("KY1")) {
+        r.skip(QStringLiteral("13.2 KY CQ CQ CQ TEST TEST; → KY1 (busy)"),
+               QStringLiteral("keyer did not start — check interlock/inhibit line"));
+        r.skip(QStringLiteral("13.3 KY; → KY0 (complete)"),
+               QStringLiteral("keyer did not start"));
+        if (origMd.startsWith(QLatin1String("MD"))) { c.send(origMd); QThread::msleep(100); }
+        c.send(QStringLiteral("RX"));
+        return;
+    }
+    r.check(QStringLiteral("13.2 KY CQ CQ CQ TEST TEST; → KY; → KY1 (keyer busy / transmitting)"),
+            true, {});
+
+    timer.restart();
+    do {
+        pollResp = c.query(QStringLiteral("KY"));
+        if (pollResp == QLatin1String("KY0")) break;
+        if (timer.elapsed() < 15000) QThread::msleep(200);
+    } while (timer.elapsed() < 15000);
+    r.check(QStringLiteral("13.3 KY; → KY0 (keyer idle after transmission complete)"),
+            pollResp == QLatin1String("KY0"), repr(pollResp));
+
+    if (origMd.startsWith(QLatin1String("MD"))) { c.send(origMd); QThread::msleep(100); }
+
+    // Safety: watch 2 s — CW TX-tail may keep PA on after keyer reports KY0
+    {
+        QElapsedTimer safeTimer; safeTimer.start();
+        bool sawTxOn = false;
+        QString safeResp; IfFields sf;
+        c.send(QStringLiteral("RX"));
+        do {
+            QThread::msleep(250);
+            safeResp = c.query(QStringLiteral("IF"));
+            sf = parseIfBody(safeResp.startsWith(QLatin1String("IF")) ? safeResp.mid(2) : QString());
+            if (sf.tx != QChar('0')) { sawTxOn = true; c.send(QStringLiteral("RX")); }
+        } while (safeTimer.elapsed() < 2000);
+        if (sawTxOn)
+            qWarning("13.S: TX re-asserted during 2-s safety watch — forced RX; possible firmware bug");
+        r.check(QStringLiteral("13.S safety: TX confirmed off after 2-s watch"),
+                sf.tx == QChar('0'), repr(QString(sf.tx)));
+    }
+}
+
+void section13skip(Runner& r)
+{
+    r.section(QStringLiteral("Section 13 — CW Keyer (skipped — pass --cw to enable)"));
+    for (const char* name : { "13.1 KY; → KY0 baseline",
+                               "13.2 KY CQ CQ CQ TEST TEST; → KY1 (busy)",
+                               "13.3 KY; → KY0 (complete)" }) {
+        r.skip(QString::fromLatin1(name), QStringLiteral("--cw not set"));
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 14 — PTY round-trip  (Unix only; skips if device cannot be opened)
+// ═════════════════════════════════════════════════════════════════════════════
+
+#if defined(Q_OS_UNIX)
+class PtyClient
+{
+public:
+    explicit PtyClient(int timeoutMs = 3000) : m_timeout(timeoutMs) {}
+    ~PtyClient() { closeDevice(); }
+
+    bool openDevice(const QString& path)
+    {
+        m_fd = ::open(path.toLocal8Bit().constData(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+        if (m_fd < 0) return false;
+        struct termios tio;
+        if (::tcgetattr(m_fd, &tio) == 0) {
+            ::cfmakeraw(&tio);
+            tio.c_cc[VMIN]  = 0;
+            tio.c_cc[VTIME] = 0;
+            ::tcsetattr(m_fd, TCSANOW, &tio);
+        }
+        return true;
+    }
+
+    void closeDevice() { if (m_fd >= 0) { ::close(m_fd); m_fd = -1; } m_buf.clear(); }
+
+    void send(const QString& cmd)
+    {
+        QByteArray d = (cmd + ';').toUtf8();
+        ::write(m_fd, d.constData(), d.size());
+    }
+
+    QString query(const QString& cmd) { send(cmd); return readUntilSemi(); }
+
+    QString readUntilSemi()
+    {
+        QElapsedTimer t; t.start();
+        while (!m_buf.contains(';')) {
+            char tmp[256];
+            ssize_t n = ::read(m_fd, tmp, sizeof(tmp));
+            if (n > 0) m_buf.append(tmp, static_cast<int>(n));
+            else { if (t.elapsed() >= m_timeout) return {}; QThread::msleep(10); }
+        }
+        const int idx = m_buf.indexOf(';');
+        QString resp = QString::fromUtf8(m_buf.left(idx));
+        m_buf.remove(0, idx + 1);
+        return resp;
+    }
+
+private:
+    int        m_fd{-1};
+    QByteArray m_buf;
+    int        m_timeout;
+};
+
+void section14pty(Runner& r, const QString& ptyPath)
+{
+    r.section(QStringLiteral("Section 14 — PTY round-trip (%1)").arg(ptyPath));
+
+    PtyClient p;
+    if (!p.openDevice(ptyPath)) {
+        for (const char* name : { "14.1 PTY ID;", "14.2 PTY FA;", "14.3 PTY PS;" })
+            r.skip(QString::fromLatin1(name),
+                   QStringLiteral("cannot open %1").arg(ptyPath));
+        return;
+    }
+
+    QString resp = p.query(QStringLiteral("ID"));
+    r.check(QStringLiteral("14.1 ID; via PTY → valid model ID"),
+            kValidIDs.contains(resp), repr(resp));
+
+    resp = p.query(QStringLiteral("FA"));
+    r.check(QStringLiteral("14.2 FA; via PTY → \"FA\" + 11-digit Hz"),
+            resp.startsWith(QLatin1String("FA")) && isDigits(resp.mid(2), 11), repr(resp));
+
+    resp = p.query(QStringLiteral("PS"));
+    r.check(QStringLiteral("14.3 PS; via PTY → PS1"),
+            resp == QLatin1String("PS1"), repr(resp));
+}
+#else
+void section14pty(Runner& r, const QString& ptyPath)
+{
+    r.section(QStringLiteral("Section 14 — PTY round-trip (Unix only)"));
+    for (const char* name : { "14.1 PTY ID;", "14.2 PTY FA;", "14.3 PTY PS;" })
+        r.skip(QString::fromLatin1(name), QStringLiteral("Unix only"));
+    (void)ptyPath;
+}
+#endif
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 15 — Squelch, NR/NL/NT/RL, MG, FW, OI, UP/DN, stubs
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section15(CatClient& c, Runner& r)
+{
+    r.section(QStringLiteral("Section 15 — SQ / NR / NL / NT / RL / MG / FW / OI / UP / DN / stubs"));
+
+    // ── SQ: Squelch ──────────────────────────────────────────────────────────
+    // MacLoggerDX uses "SQ0;" (P1 channel selector = 0) to poll squelch.
+    QString resp = c.query(QStringLiteral("SQ"));
+    r.check(QStringLiteral("15.1  SQ; → SQ0 + 3-digit level"),
+            resp.startsWith(QLatin1String("SQ0")) && isDigits(resp.mid(3), 3), repr(resp));
+
+    resp = c.query(QStringLiteral("SQ0"));
+    r.check(QStringLiteral("15.2  SQ0; (P1 form) → SQ0 + 3-digit level"),
+            resp.startsWith(QLatin1String("SQ0")) && isDigits(resp.mid(3), 3), repr(resp));
+
+    QString origSq = resp;
+    c.send(QStringLiteral("SQ0050"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("SQ0"));
+    r.check(QStringLiteral("15.3  set SQ0050 → SQ0; confirms SQ0050"),
+            resp == QLatin1String("SQ0050"), repr(resp));
+
+    if (origSq.startsWith(QLatin1String("SQ"))) { c.send(origSq); QThread::msleep(50); }
+
+    // ── NR: Noise Reduction (0=off, 1=NR1, 2=NR2) ────────────────────────────
+    QString origNr = c.query(QStringLiteral("NR"));
+    r.check(QStringLiteral("15.4  NR; → NR0, NR1, or NR2"),
+            origNr == QLatin1String("NR0") || origNr == QLatin1String("NR1") ||
+            origNr == QLatin1String("NR2"), repr(origNr));
+
+    c.send(QStringLiteral("NR1"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("NR"));
+    r.check(QStringLiteral("15.5  set NR1 → NR; confirms NR1"),
+            resp == QLatin1String("NR1"), repr(resp));
+
+    c.send(QStringLiteral("NR0"));
+    QThread::msleep(50);
+
+    // ── NL: Noise Blanker level (001-010) ─────────────────────────────────────
+    QString origNl = c.query(QStringLiteral("NL"));
+    r.check(QStringLiteral("15.6  NL; → NL + 3-digit level (001-010)"),
+            origNl.startsWith(QLatin1String("NL")) && isDigits(origNl.mid(2), 3) &&
+            origNl.mid(2).toInt() >= 1 && origNl.mid(2).toInt() <= 10, repr(origNl));
+
+    c.send(QStringLiteral("NL005"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("NL"));
+    r.check(QStringLiteral("15.7  set NL005 → NL; confirms NL005"),
+            resp == QLatin1String("NL005"), repr(resp));
+
+    if (origNl.startsWith(QLatin1String("NL"))) { c.send(origNl); QThread::msleep(50); }
+
+    // ── NT: Auto Notch / ANF (0=off, 1=on) ───────────────────────────────────
+    QString origNt = c.query(QStringLiteral("NT"));
+    r.check(QStringLiteral("15.8  NT; → NT0 or NT1"),
+            origNt == QLatin1String("NT0") || origNt == QLatin1String("NT1"), repr(origNt));
+
+    QString newNt = (origNt == QLatin1String("NT0")) ? QStringLiteral("NT1") : QStringLiteral("NT0");
+    c.send(newNt);
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("NT"));
+    r.check(QStringLiteral("15.9  toggle NT → confirms %1").arg(newNt),
+            resp == newNt, repr(resp));
+
+    c.send(origNt);
+    QThread::msleep(50);
+
+    // ── RL: Noise Reduction level (00-09) ────────────────────────────────────
+    QString origRl = c.query(QStringLiteral("RL"));
+    r.check(QStringLiteral("15.10 RL; → RL + 2-digit level (00-09)"),
+            origRl.startsWith(QLatin1String("RL")) && isDigits(origRl.mid(2), 2) &&
+            origRl.mid(2).toInt() <= 9, repr(origRl));
+
+    c.send(QStringLiteral("RL04"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("RL"));
+    r.check(QStringLiteral("15.11 set RL04 → RL; confirms RL04"),
+            resp == QLatin1String("RL04"), repr(resp));
+
+    if (origRl.startsWith(QLatin1String("RL"))) { c.send(origRl); QThread::msleep(50); }
+
+    // ── MG: Microphone gain (000-100) ─────────────────────────────────────────
+    QString origMg = c.query(QStringLiteral("MG"));
+    r.check(QStringLiteral("15.12 MG; → MG + 3-digit gain"),
+            origMg.startsWith(QLatin1String("MG")) && isDigits(origMg.mid(2), 3), repr(origMg));
+
+    c.send(QStringLiteral("MG050"));
+    QThread::msleep(100);
+    resp = c.query(QStringLiteral("MG"));
+    r.check(QStringLiteral("15.13 set MG050 → MG; confirms MG050"),
+            resp == QLatin1String("MG050"), repr(resp));
+
+    if (origMg.startsWith(QLatin1String("MG"))) { c.send(origMg); QThread::msleep(50); }
+
+    // ── FW: Filter width (valid for CW/FM/AM; returns ?; for SSB) ────────────
+    // Radio is typically in USB at this point in tests; expect ?;.
+    resp = c.query(QStringLiteral("FW"));
+    r.check(QStringLiteral("15.14 FW; in SSB mode → ?, or FW + 4-digit Hz in CW/FM/AM"),
+            resp == QLatin1String("?") ||
+            (resp.startsWith(QLatin1String("FW")) && isDigits(resp.mid(2), 4)), repr(resp));
+
+    // ── OI: Opposite IF (VFO B composite status, same layout as IF) ───────────
+    resp = c.query(QStringLiteral("OI"));
+    r.check(QStringLiteral("15.15 OI; → OI + 35-char body"),
+            resp.startsWith(QLatin1String("OI")) && resp.size() == 37, repr(resp));
+
+    if (resp.size() == 37) {
+        IfFields f = parseIfBody(resp.mid(2));
+        r.check(QStringLiteral("15.16 OI body valid (freq + status fields)"),
+                f.valid && isDigits(f.freq_hz, 11), repr(resp.mid(2)));
+    } else {
+        r.skip(QStringLiteral("15.16 OI body valid"), QStringLiteral("OI body wrong length"));
+    }
+
+    // ── BY: Busy indicator ────────────────────────────────────────────────────
+    resp = c.query(QStringLiteral("BY"));
+    r.check(QStringLiteral("15.17 BY; → BY + 2 chars (P1P2, each 0 or 1)"),
+            resp.startsWith(QLatin1String("BY")) && resp.size() == 4 &&
+            (resp[2] == '0' || resp[2] == '1') &&
+            (resp[3] == '0' || resp[3] == '1'), repr(resp));
+
+    // ── Stubs: RA, PA, RM, LK, TY ─────────────────────────────────────────────
+    resp = c.query(QStringLiteral("RA"));
+    r.check(QStringLiteral("15.18 RA; → RA0000 (attenuator off, no sub-RX)"),
+            resp == QLatin1String("RA0000"), repr(resp));
+
+    resp = c.query(QStringLiteral("PA"));
+    r.check(QStringLiteral("15.19 PA; → PA00 (preamp off)"),
+            resp == QLatin1String("PA00"), repr(resp));
+
+    resp = c.query(QStringLiteral("RM0"));
+    r.check(QStringLiteral("15.20 RM0; → RM + 5 digits (meter stub)"),
+            resp.startsWith(QLatin1String("RM")) && isDigits(resp.mid(2), 5), repr(resp));
+
+    resp = c.query(QStringLiteral("LK"));
+    r.check(QStringLiteral("15.21 LK; → LK00 (key lock off)"),
+            resp == QLatin1String("LK00"), repr(resp));
+
+    resp = c.query(QStringLiteral("TY"));
+    r.check(QStringLiteral("15.22 TY; → TY format (3-char body: 2 spaces + digit)"),
+            resp.startsWith(QLatin1String("TY")) && resp.size() == 5 &&
+            resp[2] == ' ' && resp[3] == ' ' &&
+            (resp[4] == '0' || resp[4] == '1' || resp[4] == '2'), repr(resp));
+
+    // ── UP / DN: VFO step ─────────────────────────────────────────────────────
+    QString faBase = c.query(QStringLiteral("FA"));
+    qint64 baseHz = 0;
+    if (faBase.startsWith(QLatin1String("FA")) && isDigits(faBase.mid(2), 11))
+        baseHz = faBase.mid(2).toLongLong();
+
+    c.send(QStringLiteral("UP"));
+    QThread::msleep(100);
+    QString faUp = c.query(QStringLiteral("FA"));
+    qint64 upHz = 0;
+    if (faUp.startsWith(QLatin1String("FA")) && isDigits(faUp.mid(2), 11))
+        upHz = faUp.mid(2).toLongLong();
+    r.check(QStringLiteral("15.23 UP; → FA increases by one step"),
+            baseHz > 0 && upHz > baseHz, repr(faUp));
+
+    c.send(QStringLiteral("DN"));
+    QThread::msleep(100);
+    QString faDn = c.query(QStringLiteral("FA"));
+    qint64 dnHz = 0;
+    if (faDn.startsWith(QLatin1String("FA")) && isDigits(faDn.mid(2), 11))
+        dnHz = faDn.mid(2).toLongLong();
+    r.check(QStringLiteral("15.24 DN; → FA returns to base frequency"),
+            dnHz == baseHz, repr(faDn));
+}
+
+} // namespace
+
+// ═════════════════════════════════════════════════════════════════════════════
+// main
+// ═════════════════════════════════════════════════════════════════════════════
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+    QCoreApplication::setApplicationName(QStringLiteral("smartcat_ts2000_test"));
+
+#if defined(Q_OS_UNIX)
+    g_tty = isatty(STDOUT_FILENO);
+#endif
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(
+        QStringLiteral("AetherSDR TS-2000 dialect CAT integration test"));
+    parser.addHelpOption();
+    parser.addOption({ QStringLiteral("host"),    QStringLiteral("CAT host"), QStringLiteral("HOST"), QStringLiteral("localhost") });
+    parser.addOption({ QStringLiteral("port"),    QStringLiteral("TS-2000 CAT port"), QStringLiteral("PORT"), QStringLiteral("5002") });
+    parser.addOption({ QStringLiteral("timeout"), QStringLiteral("Read timeout (ms)"), QStringLiteral("MS"), QStringLiteral("3000") });
+    parser.addOption({ QStringLiteral("ptt"),     QStringLiteral("Enable PTT tests (needs dummy load)") });
+    parser.addOption({ QStringLiteral("cw"),      QStringLiteral("Enable CW keyer tests (needs antenna/dummy load)") });
+    const QString defaultPty2 = defaultPtyPath(2);
+    parser.addOption({ QStringLiteral("pty"),     QStringLiteral("PTY device path for PTY round-trip test (default: %1)").arg(defaultPty2),
+                       QStringLiteral("PATH"),    defaultPty2 });
+    parser.process(app);
+
+    const QString host    = parser.value(QStringLiteral("host"));
+    const quint16 port    = static_cast<quint16>(parser.value(QStringLiteral("port")).toUInt());
+    const int     timeout = parser.value(QStringLiteral("timeout")).toInt();
+    const bool    doPtt   = parser.isSet(QStringLiteral("ptt"));
+    const bool    doCw    = parser.isSet(QStringLiteral("cw"));
+
+    std::cout << '\n' << bold(QStringLiteral("AetherSDR TS-2000 CAT Test Suite")).toStdString() << '\n'
+              << "Connecting to " << host.toStdString() << ':' << port << " ...\n";
+
+    CatClient c(timeout);
+    if (!c.connectToServer(host, port)) {
+        std::cerr << red(QStringLiteral("Connection failed.")).toStdString() << '\n'
+                  << yellow(QStringLiteral("Ensure AetherSDR is running with a TS-2000 port at the given port.")).toStdString() << '\n';
+        return EXIT_FAILURE;
+    }
+    std::cout << green(QStringLiteral("Connected.")).toStdString() << '\n';
+    if (doPtt)
+        std::cout << yellow(QStringLiteral("⚠  PTT tests enabled — ensure a dummy load or antenna is connected")).toStdString() << '\n';
+    if (doCw)
+        std::cout << yellow(QStringLiteral("⚠  CW tests enabled — radio will transmit")).toStdString() << '\n';
+
+    Runner r;
+
+    qint64 origHz   = 14'225'000;
+    QString origMode = QStringLiteral("2");
+    {
+        QString faResp = c.query(QStringLiteral("FA"));
+        if (faResp.startsWith(QLatin1String("FA")) && isDigits(faResp.mid(2), 11))
+            origHz = faResp.mid(2).toLongLong();
+        QString mdResp = c.query(QStringLiteral("MD"));
+        if (mdResp.startsWith(QLatin1String("MD")))
+            origMode = mdResp.mid(2);
+    }
+
+    section1(c, r);
+    section2(c, r, origHz);
+    section3(c, r);
+    section4(c, r, origMode);
+    section5(c, r);
+    section6(c, r);
+    section7(c, r);
+    section8(c, r);
+    if (doPtt) { section9ptt(c, r); } else { section9skip(r); }
+    section10(c, r);
+    section11(c, r);
+    section12(c, r);
+    if (doCw) { section13cw(c, r); } else { section13skip(r); }
+    section14pty(r, parser.value(QStringLiteral("pty")));
+    section15(c, r);
+
+    // Restore radio state
+    c.send(QStringLiteral("AI0"));
+    c.send(QStringLiteral("FT0"));
+    c.send(QStringLiteral("RT0"));
+    c.send(QStringLiteral("RC"));
+    c.send(QStringLiteral("XT0"));
+    c.send(QStringLiteral("RX"));
+    c.send(QStringLiteral("FA") + hz11(origHz));
+    c.send(QStringLiteral("MD") + origMode);
+
+    c.close();
+    return r.summary() ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/rigctld_test.cpp
+++ b/tests/rigctld_test.cpp
@@ -2,17 +2,20 @@
 // Requires a running AetherSDR instance with rigctld enabled (default: localhost:4532).
 //
 // Build:  cmake --build build --target rigctld_test
-// Run:    ./build/rigctld_test [--host HOST] [--port PORT] [--ptt] [--cw]
+// Run:    ./build/rigctld_test [--host HOST] [--port PORT] [--ptt] [--cw] [--pty PATH]
 //
 // PTT tests (section 6) and CW/Morse tests (section 11) are disabled by default.
 // Enable only when a dummy load or antenna is connected.
+// PTY test (section 16) runs automatically; skips if the per-user cat-A symlink cannot be opened.
 
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QCoreApplication>
+#include <QDir>
 #include <QElapsedTimer>
 #include <QRegularExpression>
 #include <QSet>
+#include <QStandardPaths>
 #include <QTcpSocket>
 #include <QThread>
 
@@ -22,10 +25,29 @@
 #include <string>
 
 #if defined(Q_OS_UNIX)
+#include <cerrno>
+#include <fcntl.h>
+#include <termios.h>
 #include <unistd.h>
 #endif
 
 namespace {
+
+// ── Per-user PTY symlink path (matches CatPort::defaultSymlinkPath) ───────────
+
+static QString defaultPtyPath(int portIndex)
+{
+    const char letter = static_cast<char>('A' + portIndex);
+    const QString leaf = QStringLiteral("cat-") + QChar(letter);
+    QString base = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+    if (base.isEmpty())
+        base = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    if (base.isEmpty())
+        base = QDir::homePath() + QStringLiteral("/.cache/aethersdr");
+    if (!base.contains(QStringLiteral("aethersdr"), Qt::CaseInsensitive))
+        base += QStringLiteral("/aethersdr");
+    return base + QLatin1Char('/') + leaf;
+}
 
 // ── ANSI colour ───────────────────────────────────────────────────────────────
 
@@ -519,7 +541,7 @@ void section4(RigctlClient& c, Runner& r)
         do {
             freqDown = c.field(c.send(QStringLiteral("\\get_freq")),
                                QStringLiteral("Frequency")).toLongLong();
-            if (qAbs(freqDown - freqBefore) <= 1 || t.elapsed() >= 1000) break;
+            if (qAbs(freqDown - freqBefore) <= 1 || t.elapsed() >= 2000) break;
             QThread::msleep(100);
         } while (true);
     }
@@ -809,6 +831,24 @@ void section6Ptt(RigctlClient& c, Runner& r)
                     && qAbs(pwrRestored.toDouble() - origRfpower.toDouble()) < 0.02,
                 pwrRestored);
     }
+
+    // Safety: watch 2 s — firmware may briefly re-assert PTT after set_ptt 0
+    {
+        QElapsedTimer safeTimer; safeTimer.start();
+        bool sawTxOn = false;
+        c.send(QStringLiteral("\\set_ptt 0"));
+        do {
+            QThread::msleep(250);
+            lines = c.send(QStringLiteral("\\get_ptt"));
+            const QString pttSafe = c.field(lines, QStringLiteral("PTT"));
+            if (pttSafe == QLatin1String("1")) { sawTxOn = true; c.send(QStringLiteral("\\set_ptt 0")); }
+        } while (safeTimer.elapsed() < 2000);
+        if (sawTxOn)
+            qWarning("6.S: PTT re-asserted during 2-s safety watch — forced set_ptt 0; possible firmware bug");
+        r.check(QStringLiteral("6.S  safety: PTT confirmed 0 after 2-s watch"),
+                c.ok(lines) && c.field(lines, QStringLiteral("PTT")) == QLatin1String("0"),
+                c.field(lines, QStringLiteral("PTT")));
+    }
 }
 
 void section6Skip(Runner& r)
@@ -819,6 +859,7 @@ void section6Skip(Runner& r)
              "6.1  get_ptt baseline", "6.2  set_ptt 1", "6.3  get_ptt TX",
              "6.4  set_ptt 0",        "6.4b get_ptt RX", "6.5  get_dcd",
              "6.6  restore RFPOWER", "6.6b confirm RFPOWER restored",
+             "6.S  safety: PTT 0 after 2-s watch",
          })
         r.skip(QLatin1String(name), QStringLiteral("--ptt not set"));
 }
@@ -1155,9 +1196,27 @@ void section11Cw(RigctlClient& c, Runner& r)
     QThread::msleep(500);
     c.send(QStringLiteral("\\stop_morse"));
 
-    // 11.4  PTT releases cleanly after CW completes (manual verification)
-    std::cout << "  " << yellow(QStringLiteral("NOTE")).toStdString()
-              << "  11.4 TX release after CW — verify radio returns to RX manually\n";
+    // 11.4  Safety: watch 2 s — CW TX-tail may keep PTT on after stop_morse
+    {
+        QElapsedTimer safeTimer; safeTimer.start();
+        bool sawTxOn = false;
+        c.send(QStringLiteral("\\set_ptt 0"));
+        do {
+            QThread::msleep(250);
+            lines = c.send(QStringLiteral("\\get_ptt"));
+            const QString pttSafe = c.field(lines, QStringLiteral("PTT"));
+            if (pttSafe == QLatin1String("1")) {
+                sawTxOn = true;
+                c.send(QStringLiteral("\\set_ptt 0"));
+                c.send(QStringLiteral("\\stop_morse"));
+            }
+        } while (safeTimer.elapsed() < 2000);
+        if (sawTxOn)
+            qWarning("11.4: PTT re-asserted during 2-s safety watch — forced set_ptt 0; possible firmware bug");
+        r.check(QStringLiteral("11.4 safety: PTT confirmed 0 after 2-s watch"),
+                c.ok(lines) && c.field(lines, QStringLiteral("PTT")) == QLatin1String("0"),
+                c.field(lines, QStringLiteral("PTT")));
+    }
 
     // Restore break-in state and mode
     if (origFbkin == QLatin1String("0") || origFbkin == QLatin1String("1"))
@@ -1198,7 +1257,7 @@ void section11Skip(Runner& r)
              "11.0d set_mode CW 500", "11.0d2 mode confirmed CW",
              "11.0e get_func FBKIN", "11.0f set_func FBKIN 1",
              "11.1 send_morse inline", "11.2 stop_morse",
-             "11.3 two-line form",     "11.4 TX release",
+             "11.3 two-line form",     "11.4 safety: PTT 0 after 2-s watch",
              "11.5 restore RFPOWER",   "11.5b confirm RFPOWER restored",
          })
         r.skip(QLatin1String(name), QStringLiteral("--cw not set"));
@@ -1545,6 +1604,126 @@ void sectionEdge(RigctlClient& c, Runner& r)
     c.send(QStringLiteral("\\stop_morse"));
 }
 
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 16 — PTY round-trip  (Unix only; skips if device cannot be opened)
+// ═════════════════════════════════════════════════════════════════════════════
+
+#if defined(Q_OS_UNIX)
+class PtyClient
+{
+public:
+    explicit PtyClient(int timeoutMs = 3000) : m_timeout(timeoutMs) {}
+    ~PtyClient() { if (m_fd >= 0) ::close(m_fd); }
+
+    bool openDevice(const QString& path)
+    {
+        errno = 0;
+        m_fd = ::open(path.toLocal8Bit().constData(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+        if (m_fd < 0) return false;
+        struct termios tio;
+        if (::tcgetattr(m_fd, &tio) == 0) {
+            ::cfmakeraw(&tio);
+            tio.c_cc[VMIN]  = 0;
+            tio.c_cc[VTIME] = 0;
+            ::tcsetattr(m_fd, TCSANOW, &tio);
+        }
+        return true;
+    }
+
+    void send(const QString& cmd)
+    {
+        QByteArray ba = ('+' + cmd + QLatin1Char('\n')).toUtf8();
+        ::write(m_fd, ba.constData(), ba.size());
+    }
+
+    QStringList readUntilRprt()
+    {
+        QStringList result;
+        QByteArray lineBuf;
+        QElapsedTimer timer; timer.start();
+        while (timer.elapsed() < m_timeout) {
+            char ch;
+            if (::read(m_fd, &ch, 1) == 1) {
+                if (ch == '\n') {
+                    QString line = QString::fromUtf8(lineBuf).trimmed();
+                    lineBuf.clear();
+                    if (!line.isEmpty()) {
+                        result.append(line);
+                        if (line.startsWith(QLatin1String("RPRT"))) return result;
+                    }
+                } else if (ch != '\r') {
+                    lineBuf.append(ch);
+                }
+            } else {
+                QThread::msleep(10);
+            }
+        }
+        return result;
+    }
+
+    QStringList query(const QString& cmd) { send(cmd); return readUntilRprt(); }
+
+    static QString field(const QStringList& lines, const QString& label)
+    {
+        const QString prefix = label + QLatin1String(": ");
+        for (const QString& l : lines) {
+            if (l.startsWith(prefix)) return l.mid(prefix.size());
+        }
+        return {};
+    }
+
+    static bool ok(const QStringList& lines)
+    {
+        return lines.contains(QStringLiteral("RPRT 0"));
+    }
+
+private:
+    int m_fd{-1};
+    int m_timeout;
+};
+
+void sectionPty(Runner& r, const QString& ptyPath)
+{
+    r.section(QStringLiteral("Section 16 — PTY round-trip  (skips if device cannot be opened)"));
+
+    PtyClient p;
+    if (!p.openDevice(ptyPath)) {
+        const QString why = QStringLiteral("cannot open %1 (%2)")
+                                .arg(ptyPath, QString::fromLocal8Bit(::strerror(errno)));
+        for (const char* name : { "16.1 get_freq via PTY", "16.2 get_mode via PTY",
+                                   "16.3 get_info via PTY" })
+            r.skip(QString::fromLatin1(name), why);
+        return;
+    }
+
+    QStringList lines = p.query(QStringLiteral("\\get_freq"));
+    const QString freq = PtyClient::field(lines, QStringLiteral("Frequency"));
+    r.check(QStringLiteral("16.1 get_freq via PTY → Frequency: <integer>"),
+            PtyClient::ok(lines) && isInt(freq),
+            freq.isEmpty() ? QStringLiteral("(no response)") : freq);
+
+    lines = p.query(QStringLiteral("\\get_mode"));
+    const QString mode = PtyClient::field(lines, QStringLiteral("Mode"));
+    r.check(QStringLiteral("16.2 get_mode via PTY → Mode: <string>"),
+            PtyClient::ok(lines) && !mode.isEmpty(),
+            mode.isEmpty() ? QStringLiteral("(no response)") : mode);
+
+    lines = p.query(QStringLiteral("\\get_rig_info"));
+    const QString info = PtyClient::field(lines, QStringLiteral("Info"));
+    r.check(QStringLiteral("16.3 get_rig_info via PTY → Info: <string>"),
+            PtyClient::ok(lines) && !info.isEmpty(),
+            info.isEmpty() ? QStringLiteral("(no response)") : info);
+}
+#else
+void sectionPty(Runner& r, const QString&)
+{
+    r.section(QStringLiteral("Section 16 — PTY round-trip  (skipped — Unix only)"));
+    for (const char* name : { "16.1 get_freq via PTY", "16.2 get_mode via PTY",
+                               "16.3 get_info via PTY" })
+        r.skip(QString::fromLatin1(name), QStringLiteral("not Unix"));
+}
+#endif
+
 } // namespace
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -1582,12 +1761,17 @@ int main(int argc, char** argv)
         QStringLiteral("enable PTT tests (section 6) — requires dummy load or antenna"));
     QCommandLineOption cwOpt({QStringLiteral("cw")},
         QStringLiteral("enable CW/Morse tests (section 11) — requires --ptt and CW mode"));
+    const QString defaultPty0 = defaultPtyPath(0);
+    QCommandLineOption ptyOpt({QStringLiteral("pty")},
+        QStringLiteral("PTY device path for section 16 (default: %1)").arg(defaultPty0),
+        QStringLiteral("PATH"), defaultPty0);
 
     parser.addOption(hostOpt);
     parser.addOption(portOpt);
     parser.addOption(timeoutOpt);
     parser.addOption(pttOpt);
     parser.addOption(cwOpt);
+    parser.addOption(ptyOpt);
     parser.process(app);
 
     const QString  host    = parser.value(hostOpt);
@@ -1595,6 +1779,7 @@ int main(int argc, char** argv)
     const int      timeout = parser.value(timeoutOpt).toInt();
     const bool     doPtt   = parser.isSet(pttOpt);
     const bool     doCw    = parser.isSet(cwOpt);
+    const QString  ptyPath = parser.value(ptyOpt);
 
     std::cout << '\n' << bold(QStringLiteral("AetherSDR rigctld Test Suite")).toStdString() << '\n'
               << "Connecting to " << host.toStdString() << ':' << port << " ...\n";
@@ -1654,6 +1839,7 @@ int main(int argc, char** argv)
     section14(c, r);
     section15(c, r);
     sectionEdge(c, r);
+    sectionPty(r, ptyPath);
 
     // Best-effort state restore.
     c.send(QStringLiteral("\\set_ptt 0"));


### PR DESCRIPTION
## CAT Protocol Coverage

- Full Kenwood TS-2000 command set, referencing the manual appendix, except commands not applicable to a FlexRadio
- Full FlexCAT command set per SmartCAT User Guide v4.1.5, with the exception of ZZPA/ZZPE (panadapter data streaming — out of scope for a CAT server)
- Two TCP ports by default: 4532 (rigctld) and 5001 (FlexCAT). Up to 6 more ports can be configured/enabled; each port has a companion PTY that accepts the same commands and responds identically. PTY paths are shown in the pop-out applet and can be copied to the clipboard with a right-click — handy when configuring external apps.

## Why CAT in addition to rigctld

Some external apps do not support rigctld, but expect to send TS-2000 CAT commands, with extensions by FlexRadio. AetherSDR now speaks both protocols, giving operators the flexibility to use whichever their software requires — setups that currently use SmartCAT can work directly with AetherSDR without change. TCI is preferred, but this supports both legacy apps and legacy hams.

## CAT applet redesign

Inspired by SmartSDR for macOS. The space-consuming configuration only appears when popped out, avoiding clutter of the right panel.

## Test suites

- **`CAT_TS-2000_test`**: 15 sections, 103 checks (92 always-on + 11 PTT/CW gated)
- **`CAT_Flex_test`**: 16 sections, 129 checks (105 always-on + 24 PTT/CW gated)

PTT and CW keyer tests are **skipped by default** to avoid unintended transmissions. Enable with `--ptt` and `--cw` when a radio is connected and the operator is ready to transmit.

A firmware TX race was noted during CW testing: the radio briefly reports TX=0 via CAT while the PA is still hot after CW completes. Safety watches are added to the test suite; documented as known hardware behaviour.

## Integration testing

Tested against real hardware (FlexRadio 6500, firmware 4.2.18). Primary platform: macOS. Also tested on Raspberry Pi 5 / Raspberry Pi OS Trixie.

| App | Connection | Result |
|---|---|---|
| fldigi | TCP + PTY | ✓ |
| WSJT-X | TCP + PTY | ✓ |
| MacLoggerDX | PTY (TS-2000 only) | ✓ |
| N1MM+ | TCP | ✓ (CAT sync; CW keying not possible — see below) |

### N1MM CW keying — known limitation

N1MM keys CW by toggling RTS/DTR on a real serial COM port. Virtual serial ports (PTYs) are not exposed as COM ports in Windows, so RTS/DTR keying cannot reach AetherSDR. No workaround exists without a WinKeyer-compatible keyer emulator. Documented here so operators don't waste time chasing it.

## Security

Applied the PTY symlink fix (same pattern as GHSA-qxhr-cwrc-pvrm, #3027) to `CatPort`: per-user symlink directories, atomic rename instead of unlink+symlink.

## Code quality

**UAF audit:** `SmartCatProtocol` and the new `RigctlProtocol` additions are both clean — no `[this]` captures in queued lambdas; all dispatch is synchronous on the main thread.

**ThemeManager:** `CatControlApplet` was included in the Phase 2 mass migration (#3102). Because this branch replaces the entire applet, that migration did not carry forward. We applied `ThemeManager::applyStyleSheet()` throughout — both the docked panel and the pop-out — so all widgets auto-restyle on `themeChanged`, consistent with the rest of the codebase. One intentional hardcode remains: the `:checked` background `#006040` (CAT active state). There is no `color.background.success` token analogous to `color.background.tx`; adding one would complete the conversion and is worth proposing as a follow-up.

Closes #2962

🤖 Generated with [Claude Code](https://claude.com/claude-code)