### PR TITLE
[slice] Enhance slice troubleshooter diagnostics

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -52,6 +52,7 @@
 #include <QDateTime>
 #include <QtEndian>
 #include <QThread>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QStringList>
@@ -112,6 +113,17 @@ QString audioErrorName(QAudio::Error error)
 #endif
     case QAudio::FatalError: return QStringLiteral("FatalError");
     default: return QStringLiteral("UnknownError");
+    }
+}
+
+QString audioStateName(QAudio::State state)
+{
+    switch (state) {
+    case QAudio::ActiveState: return QStringLiteral("Active");
+    case QAudio::SuspendedState: return QStringLiteral("Suspended");
+    case QAudio::StoppedState: return QStringLiteral("Stopped");
+    case QAudio::IdleState: return QStringLiteral("Idle");
+    default: return QStringLiteral("Unknown");
     }
 }
 
@@ -817,6 +829,117 @@ QAudioFormat AudioEngine::makeFormat() const
     fmt.setChannelCount(2);                        // stereo
     fmt.setSampleFormat(QAudioFormat::Float);
     return fmt;
+}
+
+QJsonArray AudioEngine::audioEndpointDiagnostics() const
+{
+    const auto outputDescription = [this]() {
+        const QAudioDevice dev = m_outputDevice.isNull()
+            ? QMediaDevices::defaultAudioOutput()
+            : m_outputDevice;
+        return dev.isNull() ? QStringLiteral("Unavailable") : dev.description();
+    };
+    const auto inputDescription = [this]() {
+        const QAudioDevice dev = m_inputDevice.isNull()
+            ? QMediaDevices::defaultAudioInput()
+            : m_inputDevice;
+        return dev.isNull() ? QStringLiteral("Unavailable") : dev.description();
+    };
+
+    QJsonArray endpoints;
+
+    const bool rxRunning = m_audioSink != nullptr;
+    const bool rxDeviceOpen = !m_audioDevice.isNull() && m_audioDevice->isOpen();
+    QJsonObject rx;
+    rx["name"] = QStringLiteral("RX output");
+    rx["direction"] = QStringLiteral("rx");
+    rx["kind"] = QStringLiteral("sink");
+    rx["backend"] = QStringLiteral("QAudioSink");
+    rx["device"] = outputDescription();
+    rx["running"] = rxRunning;
+    rx["operational"] = rxRunning && rxDeviceOpen;
+    rx["device_open"] = rxDeviceOpen;
+    rx["state"] = rxRunning ? audioStateName(m_audioSink->state()) : QStringLiteral("Stopped");
+    rx["error"] = rxRunning ? audioErrorName(m_audioSink->error()) : QStringLiteral("NoError");
+    rx["sample_rate_hz"] = rxRunning ? QJsonValue(m_rxBufferSampleRate.load()) : QJsonValue();
+    rx["channel_count"] = rxRunning ? QJsonValue(2) : QJsonValue();
+    rx["sample_format"] = rxRunning ? QStringLiteral("Float") : QString();
+    rx["resampling_active"] = rxRunning ? QJsonValue(m_resampleTo48k) : QJsonValue();
+    rx["buffer_bytes"] = static_cast<double>(m_rxBufferBytes.load());
+    rx["buffer_peak_bytes"] = static_cast<double>(m_rxBufferPeakBytes.load());
+    rx["underrun_count"] = static_cast<double>(m_rxBufferUnderrunCount.load());
+    endpoints.append(rx);
+
+    const bool txRunning = m_audioSource != nullptr;
+#ifdef Q_OS_MAC
+    const bool txDeviceOpen = m_micBuffer && m_micBuffer->isOpen();
+#else
+    const bool txDeviceOpen = !m_micDevice.isNull() && m_micDevice->isOpen();
+#endif
+    QJsonObject tx;
+    tx["name"] = QStringLiteral("TX input");
+    tx["direction"] = QStringLiteral("tx");
+    tx["kind"] = QStringLiteral("source");
+    tx["backend"] = QStringLiteral("QAudioSource");
+    tx["device"] = inputDescription();
+    tx["running"] = txRunning;
+    tx["operational"] = txRunning && txDeviceOpen;
+    tx["device_open"] = txDeviceOpen;
+    tx["state"] = txRunning ? audioStateName(m_audioSource->state()) : QStringLiteral("Stopped");
+    tx["error"] = txRunning ? audioErrorName(m_audioSource->error()) : QStringLiteral("NoError");
+    tx["sample_rate_hz"] = txRunning ? QJsonValue(m_txInputRate) : QJsonValue();
+    tx["channel_count"] = txRunning ? QJsonValue(m_txInputChannels) : QJsonValue();
+    tx["sample_format"] = txRunning ? QStringLiteral("Int16") : QString();
+    tx["resampling_active"] = txRunning ? QJsonValue(m_txNeedsResample) : QJsonValue();
+    tx["note"] = m_txInputMono ? QStringLiteral("mono input promoted to stereo for radio TX") : QString();
+    endpoints.append(tx);
+
+    const bool sidetoneRunning = m_sidetoneSink && m_sidetoneSink->isRunning();
+    QJsonObject sidetone;
+    sidetone["name"] = QStringLiteral("CW sidetone");
+    sidetone["direction"] = QStringLiteral("tx");
+    sidetone["kind"] = QStringLiteral("sink");
+    sidetone["backend"] = m_sidetoneSink
+        ? QString::fromLatin1(m_sidetoneSink->name())
+        : QStringLiteral("not initialized");
+    sidetone["device"] = m_sidetoneSink && !m_sidetoneSink->deviceDescription().trimmed().isEmpty()
+        ? m_sidetoneSink->deviceDescription()
+        : outputDescription();
+    sidetone["running"] = sidetoneRunning;
+    sidetone["operational"] = sidetoneRunning;
+    sidetone["device_open"] = sidetoneRunning;
+    sidetone["state"] = sidetoneRunning ? QStringLiteral("Active") : QStringLiteral("Stopped");
+    sidetone["error"] = QStringLiteral("NoError");
+    sidetone["sample_rate_hz"] = sidetoneRunning ? QJsonValue(m_sidetoneSink->actualRateHz()) : QJsonValue();
+    sidetone["channel_count"] = sidetoneRunning ? QJsonValue(2) : QJsonValue();
+    sidetone["sample_format"] = QString();
+    sidetone["resampling_active"] = QJsonValue();
+    sidetone["note"] = m_sidetoneSink && m_sidetoneSink->fallbackOccurred()
+        ? m_sidetoneSink->fallbackReason()
+        : QString();
+    endpoints.append(sidetone);
+
+    const bool quindarRunning = m_quindarLocalSink && m_quindarLocalSink->isRunning();
+    QJsonObject quindar;
+    quindar["name"] = QStringLiteral("Quindar local monitor");
+    quindar["direction"] = QStringLiteral("tx");
+    quindar["kind"] = QStringLiteral("sink");
+    quindar["backend"] = QStringLiteral("QAudioSink");
+    quindar["device"] = outputDescription();
+    quindar["running"] = quindarRunning;
+    quindar["operational"] = quindarRunning;
+    quindar["device_open"] = quindarRunning;
+    quindar["state"] = quindarRunning ? QStringLiteral("Active") : QStringLiteral("Stopped");
+    quindar["error"] = QStringLiteral("NoError");
+    quindar["sample_rate_hz"] = quindarRunning ? QJsonValue(m_quindarLocalSink->actualRateHz()) : QJsonValue();
+    quindar["channel_count"] = quindarRunning ? QJsonValue(2) : QJsonValue();
+    quindar["sample_format"] = quindarRunning ? QStringLiteral("Float") : QString();
+    quindar["resampling_active"] = quindarRunning
+        ? QJsonValue(m_quindarLocalSink->actualRateHz() != 48000)
+        : QJsonValue();
+    endpoints.append(quindar);
+
+    return endpoints;
 }
 
 // ─── RX stream ───────────────────────────────────────────────────────────────

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -6,6 +6,7 @@
 #include <QAudioDevice>
 #include <QAudioFormat>
 #include <QIODevice>
+#include <QJsonArray>
 #include <QUdpSocket>
 #include <QTimer>
 #include <atomic>
@@ -124,6 +125,11 @@ public:
     void setMuted(bool m);
     bool isRxStreaming() const { return m_audioSink != nullptr; }
     bool isTxStreaming() const { return m_audioSource != nullptr; }
+    int  txInputSampleRate() const { return m_txInputRate; }
+    int  txInputChannelCount() const { return m_txInputChannels; }
+    bool txInputResamplingTo24k() const { return m_txNeedsResample; }
+    bool rxOutputResamplingActive() const { return m_resampleTo48k; }
+    QJsonArray audioEndpointDiagnostics() const;
 
     // Client-side PC mic gain (0-100 → 0.0-1.0, applied before Opus encoding)
     void setPcMicGain(int level) { m_pcMicGain.store(qBound(0, level, 100) / 100.0f); }

--- a/src/core/DeviceDiagnostics.cpp
+++ b/src/core/DeviceDiagnostics.cpp
@@ -237,6 +237,18 @@ QJsonObject buildAudioDevicesSnapshot(const AudioEngine* audio, const QJsonObjec
     rxRoute["output"] = pcAudioEnabled ? "PC audio" : "Radio audio";
     rxRoute["source"] = "PcAudioEnabled app setting";
     rxRoute["selected_output_device"] = selectedOutput.description();
+    rxRoute["actual_sample_rate_hz"] = (audio && audio->isRxStreaming())
+        ? QJsonValue(audio->rxBufferSampleRate())
+        : QJsonValue();
+    rxRoute["actual_channel_count"] = (audio && audio->isRxStreaming())
+        ? QJsonValue(2)
+        : QJsonValue();
+    rxRoute["actual_sample_format"] = (audio && audio->isRxStreaming())
+        ? QJsonValue(QStringLiteral("Float"))
+        : QJsonValue();
+    rxRoute["resampling_active"] = (audio && audio->isRxStreaming())
+        ? QJsonValue(audio->rxOutputResamplingActive())
+        : QJsonValue();
     rxRoute["radio_lineout_available"] = true;
     rxRoute["remote_audio_rx_stream_id"] = remoteAudioRx["stream_id"];
     rxRoute["remote_audio_rx_stream_id_known"] = remoteAudioRx["stream_id_known"];
@@ -255,6 +267,18 @@ QJsonObject buildAudioDevicesSnapshot(const AudioEngine* audio, const QJsonObjec
     if (mic.contains(QStringLiteral("dax_on")))
         txRoute["dax_on"] = mic["dax_on"].toBool();
     txRoute["selected_input_device"] = selectedInput.description();
+    txRoute["actual_sample_rate_hz"] = (audio && audio->isTxStreaming())
+        ? QJsonValue(audio->txInputSampleRate())
+        : QJsonValue();
+    txRoute["actual_channel_count"] = (audio && audio->isTxStreaming())
+        ? QJsonValue(audio->txInputChannelCount())
+        : QJsonValue();
+    txRoute["actual_sample_format"] = (audio && audio->isTxStreaming())
+        ? QJsonValue(QStringLiteral("Int16"))
+        : QJsonValue();
+    txRoute["resampling_to_24k"] = (audio && audio->isTxStreaming())
+        ? QJsonValue(audio->txInputResamplingTo24k())
+        : QJsonValue();
     // Surface the active TX slice's id, mode, and per-slice DAX channel here
     // so the bundle's TX route summary has the same context a triager would
     // otherwise have to cross-reference from the per-slice section. WSJT-X /
@@ -301,6 +325,7 @@ QJsonObject buildAudioDevicesSnapshot(const AudioEngine* audio, const QJsonObjec
         obj["tx_streaming"] = audio->isTxStreaming();
         obj["dax_tx_mode"] = audio->isDaxTxMode();
         obj["dax_tx_use_radio_route"] = audio->daxTxUseRadioRoute();
+        obj["audio_endpoints"] = audio->audioEndpointDiagnostics();
     } else {
         volumes["engine_rx_volume_pct"] = QJsonValue();
         volumes["engine_rx_muted"] = QJsonValue();
@@ -309,6 +334,7 @@ QJsonObject buildAudioDevicesSnapshot(const AudioEngine* audio, const QJsonObjec
         obj["tx_streaming"] = QJsonValue();
         obj["dax_tx_mode"] = QJsonValue();
         obj["dax_tx_use_radio_route"] = QJsonValue();
+        obj["audio_endpoints"] = QJsonArray{};
     }
 
     obj["volumes"] = volumes;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8218,7 +8218,15 @@ void MainWindow::buildMenuBar()
     });
     helpMenu->addAction("Slice Troubleshooting...", this, [this]() {
         SliceTroubleshootingDialog dlg(&m_radioModel, m_audio, this,
-                                       [this]() { return buildControlDevicesSnapshot(); });
+                                       [this]() { return buildControlDevicesSnapshot(); },
+                                       [this]() {
+                                           QJsonObject renderer;
+                                           renderer["available"] = true;
+                                           renderer["description"] = spectrum()
+                                               ? spectrum()->rendererDescription()
+                                               : QStringLiteral("No active pan");
+                                           return renderer;
+                                       });
         dlg.exec();
     });
     helpMenu->addSeparator();

--- a/src/gui/SliceTroubleshootingDialog.cpp
+++ b/src/gui/SliceTroubleshootingDialog.cpp
@@ -7,6 +7,7 @@
 
 #include <QApplication>
 #include <QClipboard>
+#include <QColor>
 #include <QDateTime>
 #include <QDir>
 #include <QFileDialog>
@@ -15,10 +16,14 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QLabel>
+#include <QLineEdit>
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QSaveFile>
 #include <QTabWidget>
+#include <QTextCursor>
+#include <QTextDocument>
+#include <QTextEdit>
 #include <QVBoxLayout>
 #include <QStringList>
 #include <utility>
@@ -90,9 +95,19 @@ QString formatMeterBullet(const QJsonObject& meter, const QString& prefix = "- "
     return line;
 }
 
+QString formatJsonIntArray(const QJsonArray& values)
+{
+    QStringList parts;
+    for (const QJsonValue& value : values) {
+        if (value.isDouble())
+            parts << QString::number(value.toInt());
+    }
+    return parts.isEmpty() ? QStringLiteral("none") : parts.join(QStringLiteral("`, `"));
+}
+
 QString formatPanBullet(const QJsonObject& pan)
 {
-    return QString(
+    QString line = QString(
         "- `%1` active `%2`, center `%3 MHz`, bandwidth `%4 MHz`, RF gain `%5`, "
         "preamp `%6`, WNB `%7` (`%8`), waterfall `%9`")
         .arg(orPlaceholder(pan["pan_id"].toString()))
@@ -104,6 +119,19 @@ QString formatPanBullet(const QJsonObject& pan)
         .arg(yesNo(pan["wnb_active"].toBool()))
         .arg(formatNumber(pan["wnb_level"], 0))
         .arg(orPlaceholder(pan["waterfall_id"].toString()));
+
+    const QJsonObject status = pan["slice_connection_status"].toObject();
+    if (!status.isEmpty()) {
+        line += QString(" — `%1`: %2 connected `%3`, active `%4`")
+            .arg(orPlaceholder(status["state"].toString(), "unknown"),
+                 orPlaceholder(status["summary"].toString(), "Slice link state unavailable."),
+                 formatJsonIntArray(status["connected_slice_ids"].toArray()),
+                 formatJsonIntArray(status["active_slice_ids"].toArray()));
+        if (status["attention_required"].toBool())
+            line += QStringLiteral(" (attention)");
+    }
+
+    return line;
 }
 
 QString formatXvtrBullet(const QJsonObject& xvtr)
@@ -142,6 +170,11 @@ QString formatBoolValue(const QJsonValue& value)
 QString formatPercentValue(const QJsonValue& value)
 {
     return value.isDouble() ? QString("%1%").arg(qRound(value.toDouble())) : QStringLiteral("n/a");
+}
+
+QString formatHzValue(const QJsonValue& value)
+{
+    return value.isDouble() ? QString("%1 Hz").arg(value.toInt()) : QStringLiteral("n/a");
 }
 
 QString formatAudioDeviceShort(const QJsonObject& device)
@@ -203,6 +236,47 @@ QString formatControlDeviceBullet(const QJsonObject& device)
                  ? QString::number(device["target_slice_id"].toInt())
                  : QStringLiteral("n/a"))
         .arg(orPlaceholder(device["detail"].toString(), "n/a"));
+}
+
+QString formatAudioEndpointBullet(const QJsonObject& endpoint)
+{
+    const QString direction = orPlaceholder(endpoint["direction"].toString(), "n/a").toUpper();
+    const QString kind = orPlaceholder(endpoint["kind"].toString(), "endpoint");
+    const QString backend = orPlaceholder(endpoint["backend"].toString());
+    const QString state = orPlaceholder(endpoint["state"].toString(), "n/a");
+    const QString error = orPlaceholder(endpoint["error"].toString(), "n/a");
+    const QString details = QString("rate `%1`, channels `%2`, format `%3`, resampling `%4`")
+        .arg(formatHzValue(endpoint["sample_rate_hz"]))
+        .arg(endpoint["channel_count"].isDouble()
+                 ? QString::number(endpoint["channel_count"].toInt())
+                 : QStringLiteral("n/a"))
+        .arg(orPlaceholder(endpoint["sample_format"].toString()))
+        .arg(formatBoolValue(endpoint["resampling_active"]));
+
+    QString line = QString("- `%1` [%2 %3]: operational `%4`, running `%5`, state `%6`, error `%7`, backend `%8`, device `%9`, %10")
+        .arg(orPlaceholder(endpoint["name"].toString()))
+        .arg(direction)
+        .arg(kind)
+        .arg(yesNo(endpoint["operational"].toBool()))
+        .arg(yesNo(endpoint["running"].toBool()))
+        .arg(state)
+        .arg(error)
+        .arg(backend)
+        .arg(orPlaceholder(endpoint["device"].toString(), "Unavailable"))
+        .arg(details);
+
+    if (endpoint.contains("buffer_bytes")) {
+        line += QString(", buffer `%1 B`, peak `%2 B`, underruns `%3`")
+            .arg(endpoint["buffer_bytes"].toInt())
+            .arg(endpoint["buffer_peak_bytes"].toInt())
+            .arg(QString::number(endpoint["underrun_count"].toDouble(), 'f', 0));
+    }
+
+    const QString note = endpoint["note"].toString().trimmed();
+    if (!note.isEmpty())
+        line += QString(" — %1").arg(note);
+
+    return line;
 }
 
 QString formatMidiBindingBullet(const QJsonObject& binding, const QString& prefix = "  - ")
@@ -307,11 +381,13 @@ QJsonObject buildClientDspSnapshot(const AudioEngine* audio)
 SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model,
                                                        AudioEngine* audio,
                                                        QWidget* parent,
-                                                       SnapshotProvider controlDevicesProvider)
+                                                       SnapshotProvider controlDevicesProvider,
+                                                       SnapshotProvider rendererProvider)
     : QDialog(parent)
     , m_model(model)
     , m_audio(audio)
     , m_controlDevicesProvider(std::move(controlDevicesProvider))
+    , m_rendererProvider(std::move(rendererProvider))
 {
     setWindowTitle("Slice Troubleshooting");
     setMinimumSize(920, 720);
@@ -329,7 +405,26 @@ SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model,
     intro->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; }"));
     root->addWidget(intro);
 
-    auto* tabs = new QTabWidget;
+    auto* searchRow = new QHBoxLayout;
+    searchRow->setSpacing(8);
+    auto* searchLabel = new QLabel("Find:");
+    searchLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+    m_searchEdit = new QLineEdit;
+    m_searchEdit->setClearButtonEnabled(true);
+    m_searchEdit->setPlaceholderText("Search snapshot...");
+    m_searchEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit {"
+        "  background: {{color.background.0}};"
+        "  color: {{color.text.primary}};"
+        "  border: 1px solid {{color.background.2}};"
+        "  padding: 4px 6px;"
+        "}"));
+    auto* findNextBtn = new QPushButton("Find Next");
+    searchRow->addWidget(searchLabel);
+    searchRow->addWidget(m_searchEdit, 1);
+    searchRow->addWidget(findNextBtn);
+    root->addLayout(searchRow);
+
+    m_tabs = new QTabWidget;
     m_summaryView = new QPlainTextEdit;
     m_summaryView->setReadOnly(true);
     m_summaryView->setLineWrapMode(QPlainTextEdit::NoWrap);
@@ -340,7 +435,7 @@ SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model,
         "  font-size: 11px;"
         "  border: 1px solid {{color.background.1}};"
         "}"));
-    tabs->addTab(m_summaryView, "Issue Summary");
+    m_tabs->addTab(m_summaryView, "Issue Summary");
 
     m_jsonView = new QPlainTextEdit;
     m_jsonView->setReadOnly(true);
@@ -352,8 +447,8 @@ SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model,
         "  font-size: 11px;"
         "  border: 1px solid {{color.background.1}};"
         "}"));
-    tabs->addTab(m_jsonView, "JSON");
-    root->addWidget(tabs, 1);
+    m_tabs->addTab(m_jsonView, "JSON");
+    root->addWidget(m_tabs, 1);
 
     auto* footer = new QHBoxLayout;
     m_statusLabel = new QLabel;
@@ -378,6 +473,10 @@ SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model,
     connect(copyJsonBtn, &QPushButton::clicked, this, [this] { copyJson(); });
     connect(exportJsonBtn, &QPushButton::clicked, this, [this] { exportJson(); });
     connect(closeBtn, &QPushButton::clicked, this, &QDialog::accept);
+    connect(m_searchEdit, &QLineEdit::textChanged, this, [this] { updateSearchHighlights(); });
+    connect(m_searchEdit, &QLineEdit::returnPressed, this, [this] { findNextMatch(); });
+    connect(findNextBtn, &QPushButton::clicked, this, [this] { findNextMatch(); });
+    connect(m_tabs, &QTabWidget::currentChanged, this, [this] { updateSearchHighlights(); });
 
     refreshSnapshot();
 }
@@ -392,6 +491,12 @@ void SliceTroubleshootingDialog::refreshSnapshot()
     QJsonObject ui;
     ui["controls_locked"] = ::ControlsLock::isLocked();
     m_snapshot["ui"] = ui;
+    m_snapshot["renderer"] = m_rendererProvider
+        ? m_rendererProvider()
+        : QJsonObject{
+            {"available", false},
+            {"description", "Renderer provider unavailable."}
+        };
     m_snapshot["client_dsp"] = buildClientDspSnapshot(m_audio);
 
     const QJsonObject audioDevices = DeviceDiagnostics::buildAudioDevicesSnapshot(m_audio, m_snapshot);
@@ -405,13 +510,14 @@ void SliceTroubleshootingDialog::refreshSnapshot()
             {"note", "No control device provider registered."},
             {"devices", QJsonArray{}}
         };
-    m_snapshot["schema_version"] = 3;
+    m_snapshot["schema_version"] = 5;
 
     m_summaryText = buildSummary(m_snapshot);
     m_jsonText = QString::fromUtf8(QJsonDocument(m_snapshot).toJson(QJsonDocument::Indented));
 
     m_summaryView->setPlainText(m_summaryText);
     m_jsonView->setPlainText(m_jsonText);
+    updateSearchHighlights();
 
     const QJsonObject counts = m_snapshot["counts"].toObject();
     setStatusMessage(QString("Snapshot refreshed: %1 slice(s), %2 global meter(s), %3 total meter(s).")
@@ -465,12 +571,80 @@ void SliceTroubleshootingDialog::setStatusMessage(const QString& message)
     m_statusLabel->setText(message);
 }
 
+QPlainTextEdit* SliceTroubleshootingDialog::activeTextView() const
+{
+    if (m_tabs && m_tabs->currentWidget() == m_jsonView)
+        return m_jsonView;
+    return m_summaryView;
+}
+
+void SliceTroubleshootingDialog::updateSearchHighlights()
+{
+    const QString needle = m_searchEdit ? m_searchEdit->text() : QString();
+    const QColor highlightColor(255, 214, 102, 90);
+
+    int activeMatchCount = 0;
+    for (QPlainTextEdit* view : {m_summaryView, m_jsonView}) {
+        if (!view)
+            continue;
+
+        QList<QTextEdit::ExtraSelection> selections;
+        if (!needle.isEmpty()) {
+            QTextCursor cursor(view->document());
+            while (true) {
+                cursor = view->document()->find(needle, cursor);
+                if (cursor.isNull())
+                    break;
+
+                QTextEdit::ExtraSelection selection;
+                selection.cursor = cursor;
+                selection.format.setBackground(highlightColor);
+                selections.append(selection);
+                if (view == activeTextView())
+                    ++activeMatchCount;
+            }
+        }
+        view->setExtraSelections(selections);
+    }
+
+    if (!needle.isEmpty())
+        setStatusMessage(QString("Search: %1 match(es) in current tab.").arg(activeMatchCount));
+}
+
+void SliceTroubleshootingDialog::findNextMatch()
+{
+    QPlainTextEdit* view = activeTextView();
+    const QString needle = m_searchEdit ? m_searchEdit->text() : QString();
+    if (!view || needle.isEmpty())
+        return;
+
+    QTextCursor cursor = view->textCursor();
+    if (cursor.hasSelection())
+        cursor.setPosition(cursor.selectionEnd());
+
+    QTextCursor match = view->document()->find(needle, cursor);
+    if (match.isNull()) {
+        cursor = QTextCursor(view->document());
+        match = view->document()->find(needle, cursor);
+    }
+
+    if (match.isNull()) {
+        setStatusMessage(QString("Search: `%1` was not found in the current tab.").arg(needle));
+        return;
+    }
+
+    view->setTextCursor(match);
+    view->centerCursor();
+    updateSearchHighlights();
+}
+
 QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
 {
     QStringList lines;
 
     const QJsonObject app = snapshot["app"].toObject();
     const QJsonObject ui = snapshot["ui"].toObject();
+    const QJsonObject renderer = snapshot["renderer"].toObject();
     const QJsonObject radio = snapshot["radio"].toObject();
     const QJsonObject network = radio["network"].toObject();
     const QJsonObject ownership = radio["ownership"].toObject();
@@ -499,6 +673,7 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
     const QJsonObject audioVolumes = audioDevices["volumes"].toObject();
     const QJsonObject rxRoute = audioDevices["rx_route"].toObject();
     const QJsonObject txRoute = audioDevices["tx_route"].toObject();
+    const QJsonArray audioEndpoints = audioDevices["audio_endpoints"].toArray();
     const QJsonObject controlDevices = snapshot["control_devices"].toObject();
 
     lines << "# Slice Troubleshooting Snapshot";
@@ -545,6 +720,15 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
     lines << "## App UI State";
     lines << QString("- Global LCK: `%1`")
                  .arg(yesNo(ui["controls_locked"].toBool()));
+    lines << "";
+
+    lines << "## Renderer";
+    if (!renderer["available"].toBool()) {
+        lines << QString("- %1").arg(orPlaceholder(renderer["description"].toString(), "Renderer state is unavailable."));
+    } else {
+        lines << QString("- Active pan renderer: `%1`")
+                     .arg(orPlaceholder(renderer["description"].toString(), "No active pan"));
+    }
     lines << "";
 
     lines << "## Global Radio State";
@@ -645,9 +829,10 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
     if (!audioDevices["available"].toBool()) {
         lines << "- Live audio engine state is unavailable; Qt Multimedia device enumeration is still included below.";
     }
-    lines << QString("- RX route: `%1` (source `%2`), PC audio enabled `%3`, PC mute `%4`, master `%5`, engine volume `%6`, engine mute `%7`, RX stream `%8`")
+    lines << QString("- RX route: `%1` (source `%2`), negotiated rate `%3`, PC audio enabled `%4`, PC mute `%5`, master `%6`, engine volume `%7`, engine mute `%8`, RX stream `%9`")
                  .arg(orPlaceholder(rxRoute["output"].toString(), "Unknown"))
                  .arg(orPlaceholder(rxRoute["source"].toString()))
+                 .arg(formatHzValue(rxRoute["actual_sample_rate_hz"]))
                  .arg(yesNo(audioVolumes["pc_audio_enabled"].toBool()))
                  .arg(yesNo(audioVolumes["pc_audio_muted"].toBool()))
                  .arg(formatPercentValue(audioVolumes["pc_master_volume_pct"]))
@@ -661,10 +846,14 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
                  .arg(formatBoolValue(rxRoute["remote_audio_rx_remove_requested"]))
                  .arg(formatBoolValue(rxRoute["remote_audio_rx_status_seen"]))
                  .arg(formatBoolValue(rxRoute["remote_audio_rx_owned_by_us"]));
-    lines << QString("- TX input route: `%1` (mic `%2`, DAX `%3`), PC mic gain `%4`, TX stream `%5`, DAX TX mode `%6`, DAX radio route `%7`")
+    lines << QString("- TX input route: `%1` (mic `%2`, DAX `%3`), negotiated rate `%4`, channels `%5`, PC mic gain `%6`, TX stream `%7`, DAX TX mode `%8`, DAX radio route `%9`")
                  .arg(orPlaceholder(txRoute["input"].toString(), "Unknown"))
                  .arg(orPlaceholder(txRoute["mic_selection"].toString()))
                  .arg(yesNo(txRoute["dax_on"].toBool()))
+                 .arg(formatHzValue(txRoute["actual_sample_rate_hz"]))
+                 .arg(txRoute["actual_channel_count"].isDouble()
+                          ? QString::number(txRoute["actual_channel_count"].toInt())
+                          : QStringLiteral("n/a"))
                  .arg(formatPercentValue(audioVolumes["pc_mic_gain_pct"]))
                  .arg(formatBoolValue(audioDevices["tx_streaming"]))
                  .arg(formatBoolValue(audioDevices["dax_tx_mode"]))
@@ -744,21 +933,21 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
     }
     lines << "";
 
+    lines << "## Audio Sinks / Sources";
+    if (audioEndpoints.isEmpty()) {
+        lines << "- No audio endpoint diagnostics are available.";
+    } else {
+        for (const QJsonValue& value : audioEndpoints)
+            lines << formatAudioEndpointBullet(value.toObject());
+    }
+    lines << "";
+
     lines << "## Clients";
     if (ownership["clients"].toArray().isEmpty()) {
         lines << "- No client metadata is currently tracked.";
     } else {
         for (const QJsonValue& value : ownership["clients"].toArray())
             lines << formatClientBullet(value.toObject());
-    }
-    lines << "";
-
-    lines << "## Panadapters";
-    if (snapshot["panadapters"].toArray().isEmpty()) {
-        lines << "- None";
-    } else {
-        for (const QJsonValue& value : snapshot["panadapters"].toArray())
-            lines << formatPanBullet(value.toObject());
     }
     lines << "";
 
@@ -859,6 +1048,15 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
     }
     lines << "";
 
+    lines << "## Panadapters";
+    if (snapshot["panadapters"].toArray().isEmpty()) {
+        lines << "- None";
+    } else {
+        for (const QJsonValue& value : snapshot["panadapters"].toArray())
+            lines << formatPanBullet(value.toObject());
+    }
+    lines << "";
+
     lines << "## Slices";
     const QJsonArray slices = snapshot["slices"].toArray();
     if (slices.isEmpty()) {
@@ -884,6 +1082,7 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
             const QJsonObject digital = slice["digital"].toObject();
             const QJsonObject fm = slice["fm"].toObject();
             const QJsonObject pan = slice["panadapter_state"].toObject();
+            const QJsonObject panConnection = slice["panadapter_connection_status"].toObject();
             const QString sliceRxRoute = orPlaceholder(audio["rx_route"].toString(), "Unknown");
             const QString sliceRxTarget = sliceRxRoute == QStringLiteral("PC audio")
                 ? orPlaceholder(audio["selected_output_device"].toString(), "Unavailable")
@@ -896,6 +1095,16 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
                          .arg(yesNo(slice["tx_slice"].toBool()))
                          .arg(formatNumber(slice["frequency_mhz"], 6))
                          .arg(orPlaceholder(slice["mode"].toString()));
+            if (!panConnection.isEmpty()) {
+                QString linkLine = QString("- Pan link: `%1`, pan present `%2`, active pan `%3` — %4")
+                    .arg(orPlaceholder(panConnection["state"].toString(), "unknown"))
+                    .arg(yesNo(panConnection["panadapter_present"].toBool()))
+                    .arg(yesNo(panConnection["active_panadapter"].toBool()))
+                    .arg(orPlaceholder(panConnection["summary"].toString(), "Panadapter link state unavailable."));
+                if (panConnection["attention_required"].toBool())
+                    linkLine += QStringLiteral(" (attention)");
+                lines << linkLine;
+            }
             lines << QString("- Filter: `%1..%2 Hz`, step `%3 Hz`, modes `%4`")
                          .arg(filter["low_hz"].toInt())
                          .arg(filter["high_hz"].toInt())

--- a/src/gui/SliceTroubleshootingDialog.h
+++ b/src/gui/SliceTroubleshootingDialog.h
@@ -5,7 +5,9 @@
 #include <functional>
 
 class QLabel;
+class QLineEdit;
 class QPlainTextEdit;
+class QTabWidget;
 
 namespace AetherSDR {
 
@@ -21,7 +23,8 @@ public:
     explicit SliceTroubleshootingDialog(RadioModel* model,
                                         AudioEngine* audio = nullptr,
                                         QWidget* parent = nullptr,
-                                        SnapshotProvider controlDevicesProvider = {});
+                                        SnapshotProvider controlDevicesProvider = {},
+                                        SnapshotProvider rendererProvider = {});
 
 private:
     void refreshSnapshot();
@@ -29,18 +32,24 @@ private:
     void copyJson();
     void exportJson();
     void setStatusMessage(const QString& message);
+    void updateSearchHighlights();
+    void findNextMatch();
+    QPlainTextEdit* activeTextView() const;
 
     static QString buildSummary(const QJsonObject& snapshot);
 
     RadioModel* m_model{nullptr};
     AudioEngine* m_audio{nullptr};
     SnapshotProvider m_controlDevicesProvider;
+    SnapshotProvider m_rendererProvider;
     QJsonObject m_snapshot;
     QString m_summaryText;
     QString m_jsonText;
 
+    QTabWidget* m_tabs{nullptr};
     QPlainTextEdit* m_summaryView{nullptr};
     QPlainTextEdit* m_jsonView{nullptr};
+    QLineEdit* m_searchEdit{nullptr};
     QLabel* m_statusLabel{nullptr};
 };
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -223,6 +223,98 @@ QJsonObject panToJson(const PanadapterModel* pan, const QString& activePanId)
     return obj;
 }
 
+QJsonObject panSliceConnectionStatus(const QJsonObject& pan, const QJsonArray& slices)
+{
+    const QString panId = pan["pan_id"].toString();
+    QVector<int> connectedSliceIds;
+    QVector<int> activeSliceIds;
+    QVector<int> txSliceIds;
+
+    for (const QJsonValue& value : slices) {
+        const QJsonObject slice = value.toObject();
+        if (slice["pan_id"].toString() != panId || !slice["slice_id"].isDouble())
+            continue;
+
+        const int sliceId = slice["slice_id"].toInt();
+        connectedSliceIds.append(sliceId);
+        if (slice["active"].toBool())
+            activeSliceIds.append(sliceId);
+        if (slice["tx_slice"].toBool())
+            txSliceIds.append(sliceId);
+    }
+
+    QJsonObject status;
+    status["pan_id"] = panId;
+    status["connected_slice_ids"] = toJsonArray(connectedSliceIds);
+    status["active_slice_ids"] = toJsonArray(activeSliceIds);
+    status["tx_slice_ids"] = toJsonArray(txSliceIds);
+    status["connected_slice_count"] = connectedSliceIds.size();
+    status["active_slice_count"] = activeSliceIds.size();
+    status["has_connected_slice"] = !connectedSliceIds.isEmpty();
+    status["has_active_slice"] = !activeSliceIds.isEmpty();
+    status["has_tx_slice"] = !txSliceIds.isEmpty();
+
+    if (connectedSliceIds.isEmpty()) {
+        status["state"] = QStringLiteral("no_slice_connected");
+        status["attention_required"] = true;
+        status["summary"] = QStringLiteral("No slice connected.");
+        status["possible_issue"] =
+            QStringLiteral("Panadapter exists but no SliceModel references it; the slice may have been closed, failed to attach, or fallen out of the app cache.");
+    } else if (activeSliceIds.size() > 1) {
+        status["state"] = QStringLiteral("multiple_active_slices_connected");
+        status["attention_required"] = true;
+        status["summary"] = QStringLiteral("Multiple active slices are connected to this panadapter.");
+        status["possible_issue"] =
+            QStringLiteral("More than one connected slice is marked active for the same panadapter.");
+    } else if (activeSliceIds.isEmpty()) {
+        status["state"] = QStringLiteral("slice_connected_no_active");
+        status["attention_required"] = false;
+        status["summary"] = QStringLiteral("Slice connected, but none of the connected slices is currently active.");
+    } else {
+        status["state"] = QStringLiteral("active_slice_connected");
+        status["attention_required"] = false;
+        status["summary"] = QStringLiteral("Active slice connected.");
+    }
+
+    return status;
+}
+
+QJsonObject slicePanadapterConnectionStatus(int sliceId,
+                                            const QString& panId,
+                                            bool panadapterPresent,
+                                            bool activePanadapter)
+{
+    QJsonObject status;
+    status["slice_id"] = sliceId;
+    status["pan_id"] = panId;
+    status["panadapter_present"] = panadapterPresent;
+    status["active_panadapter"] = activePanadapter;
+
+    if (panId.trimmed().isEmpty()) {
+        status["state"] = QStringLiteral("no_panadapter_id");
+        status["attention_required"] = true;
+        status["summary"] = QStringLiteral("Slice has no panadapter id.");
+        status["possible_issue"] =
+            QStringLiteral("The slice exists in the app cache without a panadapter association.");
+    } else if (!panadapterPresent) {
+        status["state"] = QStringLiteral("panadapter_missing");
+        status["attention_required"] = true;
+        status["summary"] = QStringLiteral("Slice references a panadapter that is not currently tracked.");
+        status["possible_issue"] =
+            QStringLiteral("The linked panadapter may have closed, crashed, or failed to create before the slice cache was updated.");
+    } else if (!activePanadapter) {
+        status["state"] = QStringLiteral("panadapter_connected_inactive");
+        status["attention_required"] = false;
+        status["summary"] = QStringLiteral("Slice is connected to a tracked, inactive panadapter.");
+    } else {
+        status["state"] = QStringLiteral("active_panadapter_connected");
+        status["attention_required"] = false;
+        status["summary"] = QStringLiteral("Slice is connected to the active panadapter.");
+    }
+
+    return status;
+}
+
 QJsonObject xvtrToJson(const RadioModel::XvtrInfo& xvtr)
 {
     QJsonObject obj;
@@ -5489,13 +5581,28 @@ QJsonObject RadioModel::troubleshootingSnapshot() const
         fm["deviation_hz"] = sliceModel->fmDeviation();
         slice["fm"] = fm;
 
-        if (PanadapterModel* pan = panadapter(sliceModel->panId()))
+        PanadapterModel* pan = panadapter(sliceModel->panId());
+        slice["panadapter_connection_status"] =
+            slicePanadapterConnectionStatus(sliceModel->sliceId(),
+                                            sliceModel->panId(),
+                                            pan != nullptr,
+                                            pan && pan->panId() == m_activePanId);
+        if (pan)
             slice["panadapter_state"] = panToJson(pan, m_activePanId);
 
         slice["meters"] = m_meterModel.metersForSource("SLC", sliceModel->sliceId());
         slices.append(slice);
     }
     snapshot["slices"] = slices;
+
+    QJsonArray annotatedPanadapters;
+    for (const QJsonValue& value : panadapters) {
+        QJsonObject pan = value.toObject();
+        pan["slice_connection_status"] = panSliceConnectionStatus(pan, slices);
+        annotatedPanadapters.append(pan);
+    }
+    panadapters = annotatedPanadapters;
+    snapshot["panadapters"] = panadapters;
 
     QJsonObject counts;
     counts["panadapters"] = panadapters.size();


### PR DESCRIPTION
## Summary

- Add searchable Slice Troubleshooting output with highlight-all matches and Find Next support across the summary and JSON tabs.
- Surface renderer details, negotiated RX/TX audio rates, and per-endpoint audio sink/source health in the troubleshooter snapshot.
- Add explicit panadapter/slice linkage diagnostics in JSON via `slice_connection_status` and slice-side `panadapter_connection_status`, then reuse that status in the human-readable summary.
- Move the panadapter summary after Global Meter Cache so pan and slice state are easier to compare.

## Impact

This makes support bundles easier for users and AI agents to inspect quickly: stale pans, missing slices, inactive links, negotiated audio format/rate mismatches, and endpoint failures are now visible without manual cross-referencing.

## Validation

- `cmake --build build --parallel 22`
- `ctest --test-dir build --output-on-failure -j 22 -E theme_manager_test` passed 21/21
- Full `ctest --test-dir build --output-on-failure -j 22` still hits the existing local `theme_manager_test` preferences/theme failure seen before this PR
- Deployed rebuilt app to the remote test Mac; default Desktop `AetherSDR.app` replacement is blocked by remote permissions, so the runnable quarantined-cleared build was placed at `/Users/patj/Desktop/AetherSDR-slice-link-status-20260525.app`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
