### PR TITLE
Add option to not include build timestamp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
+option(BUILD_TIMESTAMPS "Place build timestamps in the final binary" ON)
+
 # macOS: ensure Homebrew lib/include paths are in the search path
 # (universal builds with CMAKE_OSX_ARCHITECTURES may not search /opt/homebrew by default)
 if(APPLE)
@@ -836,6 +838,10 @@ endif()  # NOT MSVC
 qt_add_resources(RESOURCES resources/resources.qrc)
 
 add_executable(AetherSDR ${ALL_SOURCES} ${RNNOISE_SOURCES} ${GGMORSE_SOURCES} ${RADE_SOURCES} ${BNR_SOURCES} ${SPECBLEACH_SOURCES} ${RESOURCES})
+
+if (BUILD_TIMESTAMPS)
+    target_compile_definitions(AetherSDR PUBLIC BUILD_TIMESTAMPS)
+endif()
 
 # Capture the git short SHA at configure time and surface it in the About
 # dialog so dev/test builds are identifiable.  Falls back to "unknown" for

--- a/src/core/SupportBundle.cpp
+++ b/src/core/SupportBundle.cpp
@@ -27,7 +27,11 @@ SupportBundle::SystemInfo SupportBundle::collectSystemInfo()
         QSysInfo::prettyProductName(),
         QSysInfo::kernelVersion(),
         QSysInfo::currentCpuArchitecture(),
+        #ifdef BUILD_TIMESTAMPS
         QString::fromLatin1(__DATE__)
+        #else
+        QString::fromLatin1("---")
+        #endif
     };
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8292,10 +8292,18 @@ void MainWindow::buildMenuBar()
             "Compiled: %3<br>"
             "Renderer: %5</p>"
             "</div>")
+            #ifdef BUILD_TIMESTAMPS
             .arg(QCoreApplication::applicationVersion(), qVersion(),
                  QStringLiteral(__DATE__),
                  QStringLiteral(AETHER_GIT_SHA),
                  rendererDescription.toHtmlEscaped()));
+
+            #else
+            .arg(QCoreApplication::applicationVersion(), qVersion(), 
+                 QStringLiteral("---"),
+                 QStringLiteral("---"),
+                 rendererDescription.toHtmlEscaped()));
+            #endif
         header->setAlignment(Qt::AlignCenter);
         header->setWordWrap(true);
         // Tooltip explains the staleness possibility — the SHA is baked at


### PR DESCRIPTION
Hello,

As timestamping can make the reproducible builds fail, I think it is a good idea to add an option for it,
especially as Debian is preferring reproducible builds now.

Thanks,
Dawid SP9SKA