### PR TITLE
feat(theme): Phase 5 PR 2 — Theme Editor inspector mode + 505-site reverse-map sweep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,6 +680,7 @@ set(GUI_SOURCES
     src/gui/HelpDialog.cpp
     src/gui/WhatsNewDialog.cpp
     src/gui/ThemeEditorDialog.cpp
+    src/gui/ThemeInspector.cpp
 )
 
 set(ALL_SOURCES

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -717,6 +717,26 @@ void ThemeManager::clearWidgetTracking(QWidget* widget)
     }
 }
 
+void ThemeManager::declareWidgetTokens(QWidget* widget, const QStringList& tokens)
+{
+    if (!widget) return;
+
+    // Hook the destroyed() signal exactly once per widget — same convention
+    // as applyStyleSheet so the inspector reverse-map never holds a
+    // dangling pointer.
+    if (!m_trackedWidgets.contains(widget)) {
+        connect(widget, &QObject::destroyed,
+                this, &ThemeManager::onTrackedWidgetDestroyed);
+    }
+    TrackedWidget ctx;
+    // Empty template marks this entry as paint-code-declared so
+    // reapplyAllTrackedStyleSheets() skips it (no setStyleSheet on a
+    // paint-only widget).
+    ctx.stylesheetTemplate.clear();
+    ctx.tokens = tokens;
+    m_trackedWidgets.insert(widget, ctx);
+}
+
 QStringList ThemeManager::tokensForWidget(const QWidget* widget) const
 {
     // const_cast is safe — the QHash lookup doesn't mutate the widget,
@@ -747,7 +767,13 @@ void ThemeManager::reapplyAllTrackedStyleSheets()
     for (QWidget* w : widgets) {
         const auto it = m_trackedWidgets.constFind(w);
         if (it == m_trackedWidgets.constEnd()) continue;  // dropped mid-sweep
-        w->setStyleSheet(resolve(it.value().stylesheetTemplate));
+        // Paint-code widgets registered via declareWidgetTokens() have an
+        // empty template — skip them so we don't wipe any stylesheet they
+        // may have inherited from a parent / Theme.h helper.  They handle
+        // theme changes by connecting to themeChanged themselves.
+        const QString& tmpl = it.value().stylesheetTemplate;
+        if (tmpl.isEmpty()) continue;
+        w->setStyleSheet(resolve(tmpl));
     }
 }
 

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -123,9 +123,20 @@ public:
     void clearWidgetTracking(QWidget* widget);
 
     // Inspector lookup: tokens referenced by the widget's last-applied
-    // stylesheet template.  Empty list if the widget was never themed
-    // through applyStyleSheet().
+    // stylesheet template OR declared explicitly via declareWidgetTokens().
+    // Empty list if the widget was never tracked.
     QStringList tokensForWidget(const QWidget* widget) const;
+
+    // Custom-paint widgets (panadapter, waterfall, meters, slice indicators)
+    // read tokens directly inside paintEvent rather than going through a
+    // stylesheet template, so applyStyleSheet's reverse-map never sees them.
+    // declareWidgetTokens() lets such widgets advertise the tokens they
+    // paint with, so the Phase 5 inspector can answer "what paints this?"
+    // for paint-code regions too.  Re-call to update; entries are cleared
+    // automatically when the widget is destroyed.  Paint-code widgets are
+    // not auto-repainted on themeChanged — they're expected to connect
+    // themselves to themeChanged and call update().
+    void declareWidgetTokens(QWidget* widget, const QStringList& tokens);
 
     // Stateless helper exposing the same token-extraction regex used
     // by applyStyleSheet().  Tooling (audit scripts, the Phase 5

--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -9,7 +9,7 @@ namespace AetherSDR {
 AetherDspDialog::AetherDspDialog(AudioEngine* audio, QWidget* parent)
     : PersistentDialog("AetherDSP Settings", "AetherDspDialogGeometry", parent)
 {
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }");
 
     auto* body = new QVBoxLayout(bodyWidget());
     body->setSpacing(0);

--- a/src/gui/AetherDspWidget.cpp
+++ b/src/gui/AetherDspWidget.cpp
@@ -886,7 +886,7 @@ QWidget* AetherDspWidget::buildMnrPage()
     auto* info = new QLabel("Asymmetric temporal smoothing: fast release (~15ms) for quick noise suppression,\n"
                             "gentle attack (~64ms) to preserve speech transients without artifacts.");
     info->setWordWrap(true);
-    info->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(info, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
     vbox->addSpacing(8);
     vbox->addWidget(info);
 
@@ -907,7 +907,7 @@ QWidget* AetherDspWidget::buildRn2Page()
         "parameters.");
     lbl->setWordWrap(true);
     lbl->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-    lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     vbox->addWidget(lbl);
     vbox->addStretch();
     return page;
@@ -926,7 +926,7 @@ QWidget* AetherDspWidget::buildBnrPage()
         "controlled from the slice overlay menu.");
     lbl->setWordWrap(true);
     lbl->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-    lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     vbox->addWidget(lbl);
     vbox->addStretch();
     return page;
@@ -953,7 +953,7 @@ QWidget* AetherDspWidget::buildDfnrPage()
     auto* info = new QLabel("AI-powered speech enhancement — higher fidelity than RNNoise "
                             "in high-noise HF environments. CPU-only, 10 ms latency, 48 kHz.");
     info->setWordWrap(true);
-    info->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(info, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     {
         auto* infoRow = new QHBoxLayout;
         infoRow->setContentsMargins(0, 0, 10, 0);

--- a/src/gui/AetherialAudioStrip.cpp
+++ b/src/gui/AetherialAudioStrip.cpp
@@ -73,9 +73,9 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
     });
     const QString title = QString::fromUtf8("Aetherial Audio \xe2\x80\x94 Channel Strip");
     setWindowTitle(title);
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: {{color.background.0}}; color: {{color.text.primary}}; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QWidget { background: {{color.background.0}}; color: {{color.text.primary}}; }"
         "QFrame#stripGroupBox { border: 1px solid {{color.background.1}};"
-        " border-radius: 4px; background: transparent; }"));
+        " border-radius: 4px; background: transparent; }");
     // Width is hard — the chain row + 50 px tiles need the full
     // 1140 px to read.  Height drops to 900 so the strip fits on a
     // 1080p display (1080 minus taskbar/title chrome ≈ 1000); the
@@ -116,9 +116,9 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
         m_titleBar = new QWidget(this);
         m_titleBar->setFixedHeight(18);
         m_titleBar->setAttribute(Qt::WA_StyledBackground, true);
-        m_titleBar->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_titleBar, "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
             "stop:0 #5a7494, stop:0.5 #384e68, stop:1 {{color.background.1}}); "
-            "border-bottom: 1px solid #0a1a28; }"));
+            "border-bottom: 1px solid #0a1a28; }");
         m_titleBar->installEventFilter(this);
 
         auto* row = new QHBoxLayout(m_titleBar);
@@ -130,8 +130,8 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
         // event filter installed below.
         auto* grip = new QLabel(QString::fromUtf8("\xe2\x8b\xae\xe2\x8b\xae"),
                                 m_titleBar);
-        grip->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: transparent; color: {{color.text.secondary}};"
-            " font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(grip, "QLabel { background: transparent; color: {{color.text.secondary}};"
+            " font-size: 10px; }");
         row->addWidget(grip);
 
         m_titleLbl = new QLabel(title + QString::fromUtf8(" \xe2\x80\x94 TX"),
@@ -289,7 +289,7 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
         m_bypassBtn = new QPushButton("BYPASS", content);
         m_bypassBtn->setCheckable(true);
         m_bypassBtn->setFixedHeight(30);
-        m_bypassBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton {"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_bypassBtn, "QPushButton {"
             "  background: {{color.background.1}}; border: 1px solid #4a3020; border-radius: 3px;"
             "  color: #c8a070; font-size: 12px; font-weight: bold;"
             "  padding: 2px 10px;"
@@ -299,7 +299,7 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
             "QPushButton:checked {"
             "  background: #4a3818; color: {{color.accent.warning}}; border: 1px solid {{color.accent.warning}};"
             "}"
-            "QPushButton:checked:hover { background: #5a4a28; }"));
+            "QPushButton:checked:hover { background: #5a4a28; }");
         m_bypassBtn->setToolTip(
             tr("Bypass every stage in the active chain (including RN2) "
                "except the Final Output Stage (Trim, LIM, DC).  Click "
@@ -378,14 +378,14 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
         m_presetCombo->setToolTip(
             "Channel-strip presets — pick a stored preset to load it, or use "
             "Import\xe2\x80\xa6 / Export\xe2\x80\xa6 to share presets via files.");
-        m_presetCombo->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QComboBox { background: {{color.background.1}}; color: {{color.text.primary}};"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_presetCombo, "QComboBox { background: {{color.background.1}}; color: {{color.text.primary}};"
             " border: 1px solid {{color.background.1}}; border-radius: 4px;"
             " padding: 1px 6px; font-size: 12px; }"
             "QComboBox:hover { border-color: #4a8fcf; }"
             "QComboBox::drop-down { width: 14px; border: none; }"
             "QComboBox QAbstractItemView { background: {{color.background.1}};"
             " color: {{color.text.primary}}; selection-background-color: #2a4a6a;"
-            " border: 1px solid {{color.background.1}}; }"));
+            " border: 1px solid {{color.background.1}}; }");
         connect(m_presetCombo,
                 QOverload<int>::of(&QComboBox::activated),
                 this, &AetherialAudioStrip::onPresetComboActivated);
@@ -513,7 +513,7 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
     gridScroll->setFrameShape(QFrame::NoFrame);
     gridScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     gridScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    gridScroll->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QScrollArea { background: transparent; border: none; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(gridScroll, "QScrollArea { background: transparent; border: none; }"
         "QScrollArea > QWidget > QWidget { background: transparent; }"
         "QScrollBar:vertical { background: #0a1018; width: 10px; "
         "border: none; margin: 0; }"
@@ -523,7 +523,7 @@ AetherialAudioStrip::AetherialAudioStrip(AudioEngine* engine, QWidget* parent)
         "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical "
         "{ height: 0; border: none; background: none; }"
         "QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical "
-        "{ background: none; }"));
+        "{ background: none; }");
 
     // RX panel grid (#2425) — same `wrap`-into-frame helper as TX, but
     // 4 rows of [ADSP|AGC-T] / [EQ wide] / [AGC-C|DESS] / [TUBE|EVO].

--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -62,9 +62,9 @@ AmpApplet::AmpApplet(QWidget* parent)
 
     m_operateBtn = new QPushButton("OPERATE");
     m_operateBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Expanding);
-    m_operateBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_operateBtn, "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
-        "QPushButton:hover { background: {{color.background.1}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; }");
     m_operateBtn->hide();
     connect(m_operateBtn, &QPushButton::clicked, this, [this]() {
         // Toggle: if currently operating → standby, else → operate
@@ -120,14 +120,14 @@ void AmpApplet::setState(const QString& state)
                       || state.startsWith("TRANSMIT"));
     if (operating) {
         m_operateBtn->setText("OPERATE");
-        m_operateBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #006030; border: 1px solid #008040; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_operateBtn, "QPushButton { background: #006030; border: 1px solid #008040; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
-            "QPushButton:hover { background: #007040; }"));
+            "QPushButton:hover { background: #007040; }");
     } else {
         m_operateBtn->setText("STANDBY");
-        m_operateBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_operateBtn, "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
-            "QPushButton:hover { background: {{color.background.1}}; }"));
+            "QPushButton:hover { background: {{color.background.1}}; }");
     }
     m_operateBtn->show();
 }

--- a/src/gui/AntennaGeniusApplet.cpp
+++ b/src/gui/AntennaGeniusApplet.cpp
@@ -74,11 +74,11 @@ void AntennaGeniusApplet::buildUI()
         row->setSpacing(4);
 
         m_deviceCombo = new GuardedComboBox;
-        m_deviceCombo->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QComboBox { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_deviceCombo, "QComboBox { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
             "border-radius: 3px; padding: 2px 4px; color: {{color.text.primary}}; font-size: 10px; }"
             "QComboBox::drop-down { border: none; }"
             "QComboBox QAbstractItemView { background: {{color.background.1}}; color: {{color.text.primary}}; "
-            "selection-background-color: {{color.background.2}}; }"));
+            "selection-background-color: {{color.background.2}}; }");
         m_deviceCombo->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_deviceCombo->setMinimumWidth(0);
         row->addWidget(m_deviceCombo, 1);
@@ -109,8 +109,8 @@ void AntennaGeniusApplet::buildUI()
         row->addWidget(label);
 
         m_manualIpEdit = new QLineEdit;
-        m_manualIpEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
-            "border-radius: 3px; padding: 2px 4px; color: {{color.text.primary}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_manualIpEdit, "QLineEdit { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
+            "border-radius: 3px; padding: 2px 4px; color: {{color.text.primary}}; font-size: 10px; }");
         m_manualIpEdit->setPlaceholderText("IP address");
         m_manualIpEdit->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_manualIpEdit->setMinimumWidth(0);
@@ -147,7 +147,7 @@ void AntennaGeniusApplet::buildUI()
         hdr->addStretch();
 
         m_portAAntLabel = new QLabel("—");
-        m_portAAntLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.accent.success}}; font-size: 11px; font-weight: bold;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_portAAntLabel, "color: {{color.accent.success}}; font-size: 11px; font-weight: bold;");
         m_portAAntLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         m_portAAntLabel->setMinimumWidth(0);
         hdr->addWidget(m_portAAntLabel, 1);
@@ -173,7 +173,7 @@ void AntennaGeniusApplet::buildUI()
     // Separator
     auto* sep = new QWidget;
     sep->setFixedHeight(1);
-    sep->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("background: {{color.background.1}};"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(sep, "background: {{color.background.1}};");
     vbox->addWidget(sep);
 
     // ── Port B section ──────────────────────────────────────────────────────
@@ -196,7 +196,7 @@ void AntennaGeniusApplet::buildUI()
         hdr->addStretch();
 
         m_portBAntLabel = new QLabel("—");
-        m_portBAntLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.accent.success}}; font-size: 11px; font-weight: bold;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_portBAntLabel, "color: {{color.accent.success}}; font-size: 11px; font-weight: bold;");
         m_portBAntLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         m_portBAntLabel->setMinimumWidth(0);
         hdr->addWidget(m_portBAntLabel, 1);
@@ -264,7 +264,7 @@ void AntennaGeniusApplet::tryManualConnect()
     QHostAddress addr(ip);
     if (addr.isNull()) {
         m_statusLabel->setText("Invalid IP address");
-        m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.danger}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.accent.danger}}; font-size: 10px; }");
         return;
     }
     AppSettings::instance().setValue("AG_ManualIp", ip);
@@ -301,7 +301,7 @@ void AntennaGeniusApplet::setModel(AntennaGeniusModel* model)
         m_statusLabel->setText(QString("Connected — %1 v%2")
             .arg(m_model->connectedDevice().name,
                  m_model->connectedDevice().version));
-        m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.accent}}; font-size: 10px;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "color: {{color.accent}}; font-size: 10px;");
 
         // Hide Port B if device has only 1 radio port.
         m_portBSection->setVisible(m_model->connectedDevice().radioPorts >= 2);
@@ -319,7 +319,7 @@ void AntennaGeniusApplet::setModel(AntennaGeniusModel* model)
     connect(m_model, &AntennaGeniusModel::connectionError, this,
             [this](const QString& msg) {
         m_statusLabel->setText("Error: " + msg);
-        m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.accent.danger}}; font-size: 10px;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "color: {{color.accent.danger}}; font-size: 10px;");
     });
 
     // Antenna list loaded → rebuild button grids.
@@ -422,9 +422,9 @@ void AntennaGeniusApplet::updatePortDisplay(int portId)
 
     // TX indicator — highlight antenna label red when transmitting.
     if (ps.transmitting) {
-        antLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.accent.danger}}; font-size: 11px; font-weight: bold;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(antLabel, "color: {{color.accent.danger}}; font-size: 11px; font-weight: bold;");
     } else {
-        antLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.accent.success}}; font-size: 11px; font-weight: bold;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(antLabel, "color: {{color.accent.success}}; font-size: 11px; font-weight: bold;");
     }
 
     // Get the other port's selected antenna so we can block duplicates.
@@ -444,10 +444,10 @@ void AntennaGeniusApplet::updatePortDisplay(int portId)
         btns[i]->setChecked(inUseByOther ? false : isActive);
 
         if (inUseByOther) {
-            btns[i]->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #101820; border: 1px solid #182028; "
+            AetherSDR::ThemeManager::instance().applyStyleSheet(btns[i], "QPushButton { background: #101820; border: 1px solid #182028; "
                 "border-radius: 3px; padding: 2px 2px; font-size: 10px; color: {{color.background.2}}; }"
                 "QPushButton:checked { background: #202830; color: #606878; "
-                "border: 1px solid #303848; }"));
+                "border: 1px solid #303848; }");
             QString otherLabel = (portId == 1) ? "Port B" : "Port A";
             btns[i]->setToolTip(QString("%1 — in use by %2")
                 .arg(antennas[i].name, otherLabel));
@@ -467,10 +467,10 @@ void AntennaGeniusApplet::updatePortDisplay(int portId)
             btns[i]->setToolTip(antennas[i].name);
         } else if (!canRx && !canTx) {
             // No permission on this band — dim the button
-            btns[i]->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #101820; border: 1px solid #182028; "
+            AetherSDR::ThemeManager::instance().applyStyleSheet(btns[i], "QPushButton { background: #101820; border: 1px solid #182028; "
                 "border-radius: 3px; padding: 2px 2px; font-size: 10px; color: {{color.background.2}}; }"
                 "QPushButton:checked { background: #202830; color: #606878; "
-                "border: 1px solid #303848; }"));
+                "border: 1px solid #303848; }");
             btns[i]->setToolTip(QString("%1 — no RX/TX on %2")
                 .arg(antennas[i].name, m_model->bandName(band)));
         } else if (canRx && !canTx) {
@@ -492,7 +492,7 @@ void AntennaGeniusApplet::updatePortDisplay(int portId)
         // RX antenna can't TX — show TX antenna separately
         QString txName = m_model->antennaName(ps.txAntenna);
         antLabel->setText(antName + "  TX:" + txName);
-        antLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.accent.warning}}; font-size: 10px; font-weight: bold;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(antLabel, "color: {{color.accent.warning}}; font-size: 10px; font-weight: bold;");
     }
 
     // AUTO button state.
@@ -504,7 +504,7 @@ void AntennaGeniusApplet::updatePortDisplay(int portId)
     // Inhibit indicator
     if (ps.inhibited) {
         antLabel->setText(antName + " [INHIBIT]");
-        antLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.accent.warning}}; font-size: 11px; font-weight: bold;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(antLabel, "color: {{color.accent.warning}}; font-size: 11px; font-weight: bold;");
     }
 
     m_updatingFromModel = false;

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -295,9 +295,9 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     peakBtn->setAccessibleName("Peak hold");
     peakBtn->setAccessibleDescription("Toggle peak hold line on S-meter");
     peakBtn->setFixedHeight(20);
-    peakBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.0}}; color: {{color.text.secondary}}; border: 1px solid #334; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(peakBtn, "QPushButton { background: {{color.background.0}}; color: {{color.text.secondary}}; border: 1px solid #334; "
         "border-radius: 3px; font-size: 10px; padding: 0 6px; } "
-        "QPushButton:checked { background: #0a3060; color: {{color.accent}}; border-color: {{color.accent}}; }"));
+        "QPushButton:checked { background: #0a3060; color: {{color.accent}}; border-color: {{color.accent}}; }");
 
     auto* decayLabel = new QLabel("Decay", peakRow);
     decayLabel->setStyleSheet(labelStyle);
@@ -313,9 +313,9 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     resetBtn->setFixedSize(32, 20);
     resetBtn->setToolTip("Reset peak hold");
     resetBtn->setAccessibleName("Reset peak hold");
-    resetBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.0}}; color: {{color.text.secondary}}; border: 1px solid #334; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(resetBtn, "QPushButton { background: {{color.background.0}}; color: {{color.text.secondary}}; border: 1px solid #334; "
         "border-radius: 3px; font-size: 10px; padding: 0 4px; } "
-        "QPushButton:pressed { background: #2a2a4e; color: {{color.text.primary}}; }"));
+        "QPushButton:pressed { background: #2a2a4e; color: {{color.text.primary}}; }");
 
     peakLayout->addWidget(peakBtn);
     peakLayout->addWidget(decayLabel);
@@ -376,10 +376,10 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_scrollArea->setWidgetResizable(true);
     // Handle dims to #2a3a4a at rest, brightens to #4a6880 on hover/drag.
     // 500 ms delay before dimming back so quick drags don't flicker.
-    m_scrollArea->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QScrollBar:vertical { background: {{color.background.0}}; width: 12px; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_scrollArea, "QScrollBar:vertical { background: {{color.background.0}}; width: 12px; }"
         "QScrollBar::handle:vertical { background: {{color.background.1}}; border-radius: 4px; min-height: 20px; }"
         "QScrollBar::handle:vertical[active=\"true\"] { background: #4a6880; }"
-        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }"));
+        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }");
 
     if (auto* sb = m_scrollArea->verticalScrollBar()) {
         sb->setProperty("active", false);
@@ -416,7 +416,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // Drop indicator line (cyan, hidden by default)
     m_dropIndicator = new QWidget(container);
     m_dropIndicator->setFixedHeight(2);
-    m_dropIndicator->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("background: {{color.accent}};"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_dropIndicator, "background: {{color.accent}};");
     m_dropIndicator->hide();
 
     auto& settings = AppSettings::instance();

--- a/src/gui/AtuPreTuneDialog.cpp
+++ b/src/gui/AtuPreTuneDialog.cpp
@@ -246,7 +246,7 @@ void AtuPreTuneDialog::buildConfigPage()
 
     m_planNameLabel = new QLabel(m_configPage);
     m_planNameLabel->setWordWrap(true);
-    m_planNameLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.text.primary}}; font-size: 11px;"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_planNameLabel, "color: {{color.text.primary}}; font-size: 11px;");
     layout->addWidget(m_planNameLabel);
 
     auto* disclaimer = new QLabel(kDisclaimerText, m_configPage);
@@ -260,7 +260,7 @@ void AtuPreTuneDialog::buildConfigPage()
     {
         auto* row = new QHBoxLayout;
         auto* lbl = new QLabel("Mode:", m_configPage);
-        lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.text.secondary}}; font-size: 11px;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "color: {{color.text.secondary}}; font-size: 11px;");
         row->addWidget(lbl);
         m_modeCombo = new QComboBox(m_configPage);
         m_modeCombo->addItem("Step (confirm each point)", static_cast<int>(Mode::Step));
@@ -276,7 +276,7 @@ void AtuPreTuneDialog::buildConfigPage()
         auto* row = new QHBoxLayout(m_licenseClassRow);
         row->setContentsMargins(0, 0, 0, 0);
         auto* lbl = new QLabel("License class:", m_licenseClassRow);
-        lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.text.secondary}}; font-size: 11px;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "color: {{color.text.secondary}}; font-size: 11px;");
         row->addWidget(lbl);
         m_licenseClassCombo = new QComboBox(m_licenseClassRow);
         row->addWidget(m_licenseClassCombo, 1);
@@ -298,10 +298,10 @@ void AtuPreTuneDialog::buildConfigPage()
     btnRow->addStretch(1);
     m_cancelBtn = new QPushButton("Cancel", m_configPage);
     m_startBtn  = new QPushButton("START", m_configPage);
-    m_startBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #006030; border: 1px solid #008040; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_startBtn, "QPushButton { background: #006030; border: 1px solid #008040; "
         "color: {{color.text.primary}}; padding: 4px 12px; font-weight: bold; }"
         "QPushButton:hover { background: #007038; }"
-        "QPushButton:disabled { background: #1a2a1a; color: #556070; }"));
+        "QPushButton:disabled { background: #1a2a1a; color: #556070; }");
     btnRow->addWidget(m_cancelBtn);
     btnRow->addWidget(m_startBtn);
     layout->addLayout(btnRow);
@@ -321,24 +321,24 @@ void AtuPreTuneDialog::buildSweepPage()
 
     m_sweepStatus = new QLabel("", m_sweepPage);
     m_sweepStatus->setWordWrap(true);
-    m_sweepStatus->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 13px; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_sweepStatus, "QLabel { color: {{color.text.primary}}; font-size: 13px; font-weight: bold; }");
     layout->addWidget(m_sweepStatus);
 
     m_sweepProgress = new QLabel("", m_sweepPage);
-    m_sweepProgress->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_sweepProgress, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
     layout->addWidget(m_sweepProgress);
 
     m_sweepResult = new QLabel("", m_sweepPage);
     m_sweepResult->setWordWrap(true);
-    m_sweepResult->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_sweepResult, "QLabel { color: {{color.text.primary}}; font-size: 11px; }");
     layout->addWidget(m_sweepResult, 1);
 
     auto* row = new QHBoxLayout;
     m_tuneBtn  = new QPushButton("Tune this frequency", m_sweepPage);
-    m_tuneBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #006030; border: 1px solid #008040; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_tuneBtn, "QPushButton { background: #006030; border: 1px solid #008040; "
         "color: {{color.text.primary}}; padding: 4px 12px; font-weight: bold; }"
         "QPushButton:hover { background: #007038; }"
-        "QPushButton:disabled { background: #1a2a1a; color: #556070; }"));
+        "QPushButton:disabled { background: #1a2a1a; color: #556070; }");
     m_skipBtn  = new QPushButton("Skip", m_sweepPage);
     m_continueAfterFailBtn = new QPushButton("Continue", m_sweepPage);
     m_continueAfterFailBtn->setVisible(false);
@@ -457,7 +457,7 @@ void AtuPreTuneDialog::populateBands()
         lineLayout->setSpacing(8);
         row.check = new QCheckBox(row.name, lineWidget);
         row.check->setChecked(true);
-        row.check->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.text.primary}}; font-size: 11px; font-weight: bold;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(row.check, "color: {{color.text.primary}}; font-size: 11px; font-weight: bold;");
         row.check->setMinimumWidth(54);
         lineLayout->addWidget(row.check);
 
@@ -472,7 +472,7 @@ void AtuPreTuneDialog::populateBands()
             .arg(estSecs % 60, 2, 10, QChar('0'));
         row.info = new QLabel(infoText, lineWidget);
         row.info->setTextFormat(Qt::RichText);
-        row.info->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.text.secondary}}; font-size: 10px;"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(row.info, "color: {{color.text.secondary}}; font-size: 10px;");
         lineLayout->addWidget(row.info, 1);
         m_bandsLayout->addWidget(lineWidget);
 
@@ -842,9 +842,9 @@ void AtuPreTuneDialog::setAbortButtonAbortMode()
 {
     if (!m_abortBtn) return;
     m_abortBtn->setText("ABORT");
-    m_abortBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #802020; border: 1px solid {{color.accent.danger}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_abortBtn, "QPushButton { background: #802020; border: 1px solid {{color.accent.danger}}; "
         "color: {{color.text.primary}}; padding: 4px 12px; font-weight: bold; }"
-        "QPushButton:hover { background: #903030; }"));
+        "QPushButton:hover { background: #903030; }");
 }
 
 void AtuPreTuneDialog::setAbortButtonCloseMode()

--- a/src/gui/BandStackPanel.cpp
+++ b/src/gui/BandStackPanel.cpp
@@ -22,7 +22,7 @@ BandStackPanel::BandStackPanel(QWidget* parent)
     : QWidget(parent)
 {
     setFixedWidth(80);
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("background: {{color.background.0}};"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "background: {{color.background.0}};");
 
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(4, 4, 4, 4);
@@ -32,10 +32,10 @@ BandStackPanel::BandStackPanel(QWidget* parent)
     m_scrollArea = new QScrollArea(this);
     m_scrollArea->setWidgetResizable(true);
     m_scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    m_scrollArea->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QScrollArea { background: transparent; border: none; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_scrollArea, "QScrollArea { background: transparent; border: none; }"
         "QScrollBar:vertical { background: {{color.background.0}}; width: 6px; }"
         "QScrollBar::handle:vertical { background: {{color.background.2}}; border-radius: 3px; }"
-        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }"));
+        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }");
 
     auto* scrollContent = new QWidget;
     m_buttonLayout = new QVBoxLayout(scrollContent);
@@ -67,10 +67,10 @@ BandStackPanel::BandStackPanel(QWidget* parent)
 
     m_addButton = new QPushButton("+", this);
     m_addButton->setFixedSize(26, 26);
-    m_addButton->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_addButton, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.secondary}}; font-size: 16px; font-weight: bold; "
         "padding: 0px; margin: 0px; }"
-        "QPushButton:hover { background: {{color.background.1}}; color: {{color.text.primary}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; color: {{color.text.primary}}; }");
     m_addButton->setToolTip("Save current frequency as a bookmark");
     connect(m_addButton, &QPushButton::clicked, this, &BandStackPanel::addRequested);
     bottomRow->addWidget(m_addButton);
@@ -189,8 +189,8 @@ QLabel* BandStackPanel::createBandHeader(const QString& bandName,
     auto* label = new QLabel(bandName, m_scrollArea->widget());
     label->setFixedHeight(18);
     label->setAlignment(Qt::AlignCenter);
-    label->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 10px; font-weight: bold; "
-        "border-bottom: 1px solid {{color.background.1}}; padding-bottom: 1px; margin-top: 4px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(label, "QLabel { color: {{color.text.label}}; font-size: 10px; font-weight: bold; "
+        "border-bottom: 1px solid {{color.background.1}}; padding-bottom: 1px; margin-top: 4px; }");
 
     if (lowMhz > 0 || highMhz > 0) {
         label->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/src/gui/ClientCompThresholdFader.cpp
+++ b/src/gui/ClientCompThresholdFader.cpp
@@ -49,8 +49,8 @@ ClientCompThresholdFader::ClientCompThresholdFader(QWidget* parent)
 
     auto* top = new QLabel("THRESH");
     top->setAlignment(Qt::AlignCenter);
-    top->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.warning}}; font-size: 9px; font-weight: bold;"
-        " background: transparent; border: none; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(top, "QLabel { color: {{color.accent.warning}}; font-size: 9px; font-weight: bold;"
+        " background: transparent; border: none; }");
     root->addWidget(top);
 
     root->addStretch(1);
@@ -62,11 +62,11 @@ ClientCompThresholdFader::ClientCompThresholdFader(QWidget* parent)
     m_valueEdit = new QLineEdit;
     m_valueEdit->setAlignment(Qt::AlignCenter);
     m_valueEdit->setFrame(false);
-    m_valueEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { color: #e8e8e8; font-size: 10px; font-weight: bold;"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_valueEdit, "QLineEdit { color: #e8e8e8; font-size: 10px; font-weight: bold;"
         " background: transparent; border: 1px solid transparent;"
         " border-radius: 2px; padding: 0;"
         " selection-background-color: {{color.background.2}}; }"
-        "QLineEdit:focus { background: {{color.background.0}}; border: 1px solid {{color.accent}}; }"));
+        "QLineEdit:focus { background: {{color.background.0}}; border: 1px solid {{color.accent}}; }");
     m_valueEdit->installEventFilter(this);
     root->addWidget(m_valueEdit);
 

--- a/src/gui/ClientEqEditor.cpp
+++ b/src/gui/ClientEqEditor.cpp
@@ -89,7 +89,7 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
             "Drag peak/shelf = freq + gain · "
             "drag HP/LP = freq + Q · Shift + drag for Q · "
             "click icon to cycle type");
-        hint->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.background.3}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(hint, "QLabel { color: {{color.background.3}}; font-size: 10px; }");
         row->addWidget(hint, 1);
 
         // Smoothing — fractional-octave display smoothing for the FFT
@@ -97,7 +97,7 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
         // Persisted globally (single user preference, shared between RX
         // and TX editors).
         auto* smoothingLbl = new QLabel("Smoothing:");
-        smoothingLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(smoothingLbl, "QLabel { color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }");
         row->addWidget(smoothingLbl);
 
         auto* smoothingCombo = new QComboBox;
@@ -142,7 +142,7 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
         peakHoldBtn->setToolTip(
             "Freeze the analyzer peak-hold trace at its highest level.\n"
             "Toggle off to resume normal decay.");
-        peakHoldBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton {"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(peakHoldBtn, "QPushButton {"
             "  background: {{color.background.0}}; color: {{color.text.primary}};"
             "  border: 1px solid {{color.background.1}}; border-radius: 3px;"
             "  padding: 2px 12px; font-size: 11px; font-weight: bold;"
@@ -152,7 +152,7 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
             "  background: #c8a040; color: {{color.background.0}};"
             "  border-color: #d4b050;"
             "}"
-            "QPushButton:checked:hover { background: #d4b050; }"));
+            "QPushButton:checked:hover { background: #d4b050; }");
         connect(peakHoldBtn, &QPushButton::toggled, this, [this](bool on) {
             if (m_canvas) m_canvas->setPeakHoldFrozen(on);
         });
@@ -195,13 +195,13 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
         auto* resetBtn = new QPushButton("Reset");
         resetBtn->setFixedHeight(24);
         resetBtn->setToolTip("Reset all bands to default values");
-        resetBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton {"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(resetBtn, "QPushButton {"
             "  background: {{color.background.0}}; color: {{color.text.primary}};"
             "  border: 1px solid {{color.background.1}}; border-radius: 3px;"
             "  padding: 2px 12px; font-size: 11px; font-weight: bold;"
             "}"
             "QPushButton:hover { background: {{color.background.1}}; }"
-            "QPushButton:pressed { background: {{color.background.1}}; }"));
+            "QPushButton:pressed { background: {{color.background.1}}; }");
         connect(resetBtn, &QPushButton::clicked, this, [this]() {
             ClientEq* eq = (m_path == ClientEqApplet::Path::Rx)
                 ? m_audio->clientEqRx() : m_audio->clientEqTx();

--- a/src/gui/ClientEqOutputFader.cpp
+++ b/src/gui/ClientEqOutputFader.cpp
@@ -57,8 +57,8 @@ ClientEqOutputFader::ClientEqOutputFader(QWidget* parent) : QWidget(parent)
 
     auto* top = new QLabel("OUT");
     top->setAlignment(Qt::AlignCenter);
-    top->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; font-weight: bold;"
-        " background: transparent; border: none; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(top, "QLabel { color: {{color.text.secondary}}; font-size: 10px; font-weight: bold;"
+        " background: transparent; border: none; }");
     root->addWidget(top);
 
     root->addStretch(1);
@@ -70,11 +70,11 @@ ClientEqOutputFader::ClientEqOutputFader(QWidget* parent) : QWidget(parent)
     m_valueEdit = new QLineEdit;
     m_valueEdit->setAlignment(Qt::AlignCenter);
     m_valueEdit->setFrame(false);
-    m_valueEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { color: {{color.text.primary}}; font-size: 10px; font-weight: bold;"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_valueEdit, "QLineEdit { color: {{color.text.primary}}; font-size: 10px; font-weight: bold;"
         " background: transparent; border: 1px solid transparent;"
         " border-radius: 2px; padding: 0;"
         " selection-background-color: {{color.background.2}}; }"
-        "QLineEdit:focus { background: {{color.background.0}}; border: 1px solid {{color.accent}}; }"));
+        "QLineEdit:focus { background: {{color.background.0}}; border: 1px solid {{color.accent}}; }");
     m_valueEdit->installEventFilter(this);
     root->addWidget(m_valueEdit);
 

--- a/src/gui/ClientPuduApplet.cpp
+++ b/src/gui/ClientPuduApplet.cpp
@@ -62,8 +62,8 @@ QWidget* makeBracketLabel(const QString& text)
     leftLine->setStyleSheet("QFrame { color: #4a5a6a; }");
 
     auto* lbl = new QLabel(text);
-    lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-weight: bold; "
-                       "font-size: 10px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.primary}}; font-weight: bold; "
+                       "font-size: 10px; }");
     lbl->setAlignment(Qt::AlignCenter);
 
     auto* rightLine = new QFrame;

--- a/src/gui/ClientPuduEditor.cpp
+++ b/src/gui/ClientPuduEditor.cpp
@@ -70,8 +70,8 @@ QWidget* makeBracketLabel(const QString& text)
     leftLine->setStyleSheet("QFrame { color: #5a6a7a; }");
 
     auto* lbl = new QLabel(text);
-    lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-weight: bold; "
-                       "font-size: 13px; letter-spacing: 2px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.primary}}; font-weight: bold; "
+                       "font-size: 13px; letter-spacing: 2px; }");
     lbl->setAlignment(Qt::AlignCenter);
 
     auto* rightLine = new QFrame;

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -183,13 +183,13 @@ QString normalizedStatus(QString status)
 ConnectionPanel::ConnectionPanel(QWidget* parent)
     : QWidget(parent)
 {
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("ConnectionPanel { background: {{color.background.0}}; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "ConnectionPanel { background: {{color.background.0}}; }"
         "QGroupBox { border: 1px solid {{color.background.2}}; border-radius: 7px; margin-top: 10px; "
         "color: {{color.text.primary}}; font-weight: bold; }"
         "QGroupBox::title { subcontrol-origin: margin; left: 10px; padding: 0 4px; }"
         "QListWidget { background: #09111b; border: 1px solid {{color.background.2}}; border-radius: 4px; "
         "color: {{color.text.primary}}; padding: 2px; }"
-        "QPushButton { padding: 5px 12px; }"));
+        "QPushButton { padding: 5px 12px; }");
 
     const QString editStyle =
         "QLineEdit { border: 1px solid #304050; border-radius: 4px; padding: 4px 6px; "
@@ -240,8 +240,8 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     outer->addWidget(content, 1);
 
     auto* titleLabel = new QLabel("Connect to a Radio", this);
-    titleLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 18px; font-weight: bold; "
-        "background: transparent; border: none; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(titleLabel, "QLabel { color: {{color.text.primary}}; font-size: 18px; font-weight: bold; "
+        "background: transparent; border: none; }");
     root->addWidget(titleLabel);
 
     auto* introLabel = makeWrappedLabel(
@@ -341,8 +341,8 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     emptyCalloutLayout->setContentsMargins(14, 14, 14, 14);
     emptyCalloutLayout->setSpacing(8);
     auto* emptyTitle = new QLabel("No local radios found yet", emptyCallout);
-    emptyTitle->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 15px; font-weight: bold; "
-        "background: transparent; border: none; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(emptyTitle, "QLabel { color: {{color.text.primary}}; font-size: 15px; font-weight: bold; "
+        "background: transparent; border: none; }");
     emptyCalloutLayout->addWidget(emptyTitle);
     emptyCalloutLayout->addWidget(makeWrappedLabel(
         "AetherSDR is still listening for discovery packets. If your station is on a VPN "
@@ -544,7 +544,7 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     optionsLayout->setContentsMargins(12, 10, 12, 10);
     optionsLayout->setSpacing(6);
     auto* optionsTitle = new QLabel("Connection options for slower links", m_linkOptionsWidget);
-    optionsTitle->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-weight: bold; background: transparent; border: none; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(optionsTitle, "QLabel { color: {{color.text.primary}}; font-weight: bold; background: transparent; border: none; }");
     optionsLayout->addWidget(optionsTitle);
     m_lowBwHintLabel = makeWrappedLabel(QString(), kHintLabelStyle);
     optionsLayout->addWidget(m_lowBwHintLabel);

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -100,7 +100,7 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
     : QWidget(parent), m_model(model)
 {
     setFixedWidth(250);
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: {{color.background.0}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QWidget { background: {{color.background.0}}; }");
 
     auto* vbox = new QVBoxLayout(this);
     vbox->setContentsMargins(0, 0, 0, 0);
@@ -108,8 +108,8 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
 
     // Title
     auto* title = new QLabel("CWX");
-    title->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 14px; font-weight: bold; "
-                         "padding: 6px 8px; background: {{color.background.0}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(title, "QLabel { color: {{color.accent}}; font-size: 14px; font-weight: bold; "
+                         "padding: 6px 8px; background: {{color.background.0}}; }");
     vbox->addWidget(title);
 
     // Stacked widget for Send/Live vs Setup
@@ -125,7 +125,7 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
 
     // ── Bottom bar ─────────────────────────────────────────────
     auto* bar = new QWidget;
-    bar->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: {{color.background.0}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(bar, "QWidget { background: {{color.background.0}}; }");
     auto* barLayout = new QHBoxLayout(bar);
     barLayout->setContentsMargins(4, 4, 4, 4);
     barLayout->setSpacing(4);
@@ -146,15 +146,15 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
     barLayout->addWidget(m_setupBtn);
 
     auto* speedLabel = new QLabel("Speed:");
-    speedLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(speedLabel, "QLabel { color: {{color.text.primary}}; font-size: 11px; }");
     barLayout->addWidget(speedLabel);
 
     m_speedSpin = new QSpinBox;
     m_speedSpin->setRange(5, 100);
     m_speedSpin->setValue(20);
     m_speedSpin->setFixedWidth(50);
-    m_speedSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
-        "border-radius: 2px; font-size: 11px; padding: 2px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_speedSpin, "QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
+        "border-radius: 2px; font-size: 11px; padding: 2px; }");
     barLayout->addWidget(m_speedSpin);
 
     vbox->addWidget(bar);
@@ -292,10 +292,10 @@ void CwxPanel::buildSendView()
     // History — scroll area with painted bubbles, scrolls from bottom up
     m_historyScroll = new QScrollArea;
     m_historyScroll->setWidgetResizable(true);
-    m_historyScroll->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QScrollArea { background: {{color.background.0}}; border: none; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_historyScroll, "QScrollArea { background: {{color.background.0}}; border: none; }");
     m_historyScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_historyContainer = new QWidget;
-    m_historyContainer->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: {{color.background.0}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_historyContainer, "QWidget { background: {{color.background.0}}; }");
     m_historyLayout = new QVBoxLayout(m_historyContainer);
     m_historyLayout->setContentsMargins(0, 0, 0, 4);
     m_historyLayout->setSpacing(4);
@@ -328,8 +328,8 @@ void CwxPanel::buildSetupView()
     m_delaySpin->setRange(0, 2000);
     m_delaySpin->setValue(5);
     m_delaySpin->setFixedWidth(60);
-    m_delaySpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
-        "border-radius: 2px; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_delaySpin, "QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
+        "border-radius: 2px; font-size: 11px; }");
     topRow->addWidget(m_delaySpin);
 
     m_qskBtn = new QPushButton("QSK");
@@ -346,7 +346,7 @@ void CwxPanel::buildSetupView()
 
     // Style labels
     for (auto* lbl : m_setupPage->findChildren<QLabel*>())
-        lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.primary}}; font-size: 11px; }");
 
     // F1-F12 macro slots — each stretches to fill available height
     auto* macroWidget = new QWidget;
@@ -358,15 +358,15 @@ void CwxPanel::buildSetupView()
         auto* label = new QPushButton(QString("F%1").arg(i + 1));
         label->setFixedWidth(28);
         label->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
-        label->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(label, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 2px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; "
             "padding: 2px; }"
-            "QPushButton:hover { background: {{color.background.1}}; }"));
+            "QPushButton:hover { background: {{color.background.1}}; }");
         macroGrid->addWidget(label, i, 0);
 
         m_macroEdits[i] = new QTextEdit;
-        m_macroEdits[i]->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTextEdit { background: {{color.text.primary}}; color: {{color.background.spectrum}}; border: 1px solid {{color.background.2}}; "
-            "border-radius: 2px; padding: 2px; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_macroEdits[i], "QTextEdit { background: {{color.text.primary}}; color: {{color.background.spectrum}}; border: 1px solid {{color.background.2}}; "
+            "border-radius: 2px; padding: 2px; font-size: 11px; }");
         m_macroEdits[i]->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         m_macroEdits[i]->setPlaceholderText(QString("F%1 macro...").arg(i + 1));
         m_macroEdits[i]->setAcceptRichText(false);
@@ -391,7 +391,7 @@ void CwxPanel::buildSetupView()
 
     // Prosign legend
     auto* legend = new QLabel("Prosigns: = (BT)  + (AR)  ( (KN)  & (BK)  $ (SK)");
-    legend->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 9px; padding: 4px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(legend, "QLabel { color: {{color.text.label}}; font-size: 9px; padding: 4px; }");
     legend->setWordWrap(true);
     vbox->addWidget(legend);
 }
@@ -486,9 +486,9 @@ bool AetherSDR::CwxPanel::eventFilter(QObject* obj, QEvent* event)
         if (event->type() == QEvent::ContextMenu) {
             auto* ce = static_cast<QContextMenuEvent*>(event);
             QMenu menu(this);
-            menu.setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QMenu { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; }"
+            AetherSDR::ThemeManager::instance().applyStyleSheet(&menu, "QMenu { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; }"
                 "QMenu::item:selected { background: {{color.accent}}; color: {{color.background.spectrum}}; }"
-                "QMenu::separator { height: 1px; background: {{color.background.2}}; margin: 4px 8px; }"));
+                "QMenu::separator { height: 1px; background: {{color.background.2}}; margin: 4px 8px; }");
             QAction* resendAction = menu.addAction("Resend");
             menu.addSeparator();
             QAction* clearAction  = menu.addAction("Clear History");

--- a/src/gui/DaxIqApplet.cpp
+++ b/src/gui/DaxIqApplet.cpp
@@ -98,8 +98,8 @@ void DaxIqApplet::buildUI()
         m_iqMeter[i]->setValue(0);
         m_iqMeter[i]->setTextVisible(false);
         m_iqMeter[i]->setFixedHeight(14);
-        m_iqMeter[i]->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QProgressBar { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; border-radius: 2px; }"
-            "QProgressBar::chunk { background: {{color.accent}}; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_iqMeter[i], "QProgressBar { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; border-radius: 2px; }"
+            "QProgressBar::chunk { background: {{color.accent}}; }");
         row->addWidget(m_iqMeter[i], 1);
 
         m_iqEnable[i] = new QPushButton("Off");

--- a/src/gui/DspParamPopup.cpp
+++ b/src/gui/DspParamPopup.cpp
@@ -44,7 +44,7 @@ void DspParamPopup::addRadioGroup(const QString& label, const QStringList& optio
                                    int defaultIdx, std::function<void(int)> onChange)
 {
     auto* lbl = new QLabel(label);
-    lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 10px; font-weight: bold; }");
     m_layout->addWidget(lbl);
 
     auto* row = new QHBoxLayout;
@@ -85,7 +85,7 @@ void DspParamPopup::addSlider(const QString& label, int min, int max, int defaul
     row->addWidget(slider);
 
     auto* val = new QLabel(format ? format(defaultVal) : QString::number(defaultVal));
-    val->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; min-width: 36px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(val, "QLabel { color: {{color.text.primary}}; min-width: 36px; }");
     val->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     row->addWidget(val);
 

--- a/src/gui/DvkPanel.cpp
+++ b/src/gui/DvkPanel.cpp
@@ -43,7 +43,7 @@ DvkPanel::DvkPanel(DvkModel* model, QWidget* parent)
 
     // Title
     auto* title = new QLabel("Digital Voice Keyer");
-    title->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-weight: bold; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(title, "QLabel { color: {{color.accent}}; font-weight: bold; font-size: 12px; }");
     outerVbox->addWidget(title);
 
     // Grid of slots — each row gets equal stretch
@@ -57,7 +57,7 @@ DvkPanel::DvkPanel(DvkModel* model, QWidget* parent)
 
         // Inset container per row: VBox with content row + progress bar
         auto* rowFrame = new QFrame;
-        rowFrame->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QFrame { background: #0f1520; border: 1px solid {{color.background.1}}; border-radius: 3px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(rowFrame, "QFrame { background: #0f1520; border: 1px solid {{color.background.1}}; border-radius: 3px; }");
         rowFrame->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         auto* rowVbox = new QVBoxLayout(rowFrame);
         rowVbox->setContentsMargins(3, 2, 3, 1);
@@ -160,7 +160,7 @@ DvkPanel::DvkPanel(DvkModel* model, QWidget* parent)
 
     // Status label
     m_statusLabel = new QLabel("Status: Idle");
-    m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 10px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.text.label}}; font-size: 10px; }");
     outerVbox->addWidget(m_statusLabel);
 
     // Wire buttons
@@ -511,10 +511,10 @@ void DvkPanel::showContextMenu(int id, const QPoint& globalPos)
         m_wavTransfer->download(id, path);
     });
 
-    menu.setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QMenu { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(&menu, "QMenu { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; }"
         "QMenu::item:selected { background: {{color.accent}}; color: {{color.background.spectrum}}; }"
         "QMenu::item:disabled { color: #505060; }"
-        "QMenu::separator { height: 1px; background: {{color.background.1}}; margin: 2px 6px; }"));
+        "QMenu::separator { height: 1px; background: {{color.background.1}}; margin: 2px 6px; }");
 
     menu.exec(globalPos);
 }
@@ -533,8 +533,8 @@ void DvkPanel::startRename(int id)
 
     m_renameSlot = id;
     m_renameEdit = new QLineEdit;
-    m_renameEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.accent}}; "
-        "border-radius: 2px; font-size: 10px; padding: 0px 2px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_renameEdit, "QLineEdit { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.accent}}; "
+        "border-radius: 2px; font-size: 10px; padding: 0px 2px; }");
     m_renameEdit->setText(label->text());
     m_renameEdit->selectAll();
     m_renameEdit->setMaxLength(40);

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -281,10 +281,10 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
     root->setContentsMargins(4, 4, 4, 4);
 
     auto* tabs = new QTabWidget;
-    tabs->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTabWidget::pane { border: 1px solid {{color.background.1}}; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(tabs, "QTabWidget::pane { border: 1px solid {{color.background.1}}; }"
         "QTabBar::tab { background: {{color.background.0}}; color: #808890; border: 1px solid {{color.background.1}}; "
         "  padding: 6px 16px; margin-right: 2px; }"
-        "QTabBar::tab:selected { background: {{color.background.0}}; color: {{color.accent}}; border-bottom: none; }"));
+        "QTabBar::tab:selected { background: {{color.background.0}}; color: {{color.accent}}; border-bottom: none; }");
 
     buildClusterTab(tabs);
     buildRbnTab(tabs);
@@ -327,7 +327,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
 
     connect(clusterClient, &DxClusterClient::connected, this, [this] {
         m_statusLabel->setText(QString("Connected to %1:%2").arg(m_client->host()).arg(m_client->port()));
-        m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.accent}}; font-size: 11px; }");
         m_connectBtn->setText("Disconnect");
         m_cmdEdit->setEnabled(true);
         m_sendBtn->setEnabled(true);
@@ -335,7 +335,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
     });
     connect(clusterClient, &DxClusterClient::disconnected, this, [this] {
         m_statusLabel->setText("Disconnected");
-        m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         m_connectBtn->setText("Connect");
         m_cmdEdit->setEnabled(false);
         m_sendBtn->setEnabled(false);
@@ -343,7 +343,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
     });
     connect(clusterClient, &DxClusterClient::connectionError, this, [this](const QString& err) {
         m_statusLabel->setText("Error: " + err);
-        m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.danger}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.accent.danger}}; font-size: 11px; }");
         m_console->appendPlainText("--- Error: " + err + " ---");
     });
 
@@ -379,7 +379,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
 
     connect(rbnClient, &DxClusterClient::connected, this, [this] {
         m_rbnStatusLabel->setText(QString("Connected to %1:%2").arg(m_rbnClient->host()).arg(m_rbnClient->port()));
-        m_rbnStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnStatusLabel, "QLabel { color: {{color.accent}}; font-size: 11px; }");
         m_rbnConnectBtn->setText("Disconnect");
         m_rbnCmdEdit->setEnabled(true);
         m_rbnSendBtn->setEnabled(true);
@@ -387,7 +387,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
     });
     connect(rbnClient, &DxClusterClient::disconnected, this, [this] {
         m_rbnStatusLabel->setText("Disconnected");
-        m_rbnStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         m_rbnConnectBtn->setText("Connect");
         m_rbnCmdEdit->setEnabled(false);
         m_rbnSendBtn->setEnabled(false);
@@ -395,7 +395,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
     });
     connect(rbnClient, &DxClusterClient::connectionError, this, [this](const QString& err) {
         m_rbnStatusLabel->setText("Error: " + err);
-        m_rbnStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.danger}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnStatusLabel, "QLabel { color: {{color.accent.danger}}; font-size: 11px; }");
         m_rbnConsole->appendPlainText("--- Error: " + err + " ---");
     });
 
@@ -461,13 +461,13 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
 
     connect(wsjtxClient, &WsjtxClient::listening, this, [this] {
         m_wsjtxStatusLabel->setText(QString("Listening on port %1").arg(m_wsjtxPortSpin->value()));
-        m_wsjtxStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_wsjtxStatusLabel, "QLabel { color: {{color.accent}}; font-size: 11px; }");
         m_wsjtxStartBtn->setText("Stop");
         m_wsjtxConsole->appendPlainText("--- Listening ---");
     });
     connect(wsjtxClient, &WsjtxClient::stopped, this, [this] {
         m_wsjtxStatusLabel->setText("Stopped");
-        m_wsjtxStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_wsjtxStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         m_wsjtxStartBtn->setText("Start");
         m_wsjtxConsole->appendPlainText("--- Stopped ---");
     });
@@ -491,13 +491,13 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
 
     connect(spotCollectorClient, &SpotCollectorClient::listening, this, [this] {
         m_scStatusLabel->setText(QString("Listening on port %1").arg(m_scPortSpin->value()));
-        m_scStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_scStatusLabel, "QLabel { color: {{color.accent}}; font-size: 11px; }");
         m_scStartBtn->setText("Stop");
         m_scConsole->appendPlainText("--- Listening ---");
     });
     connect(spotCollectorClient, &SpotCollectorClient::stopped, this, [this] {
         m_scStatusLabel->setText("Stopped");
-        m_scStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_scStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         m_scStartBtn->setText("Start");
         m_scConsole->appendPlainText("--- Stopped ---");
     });
@@ -519,13 +519,13 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
 
     connect(potaClient, &PotaClient::started, this, [this] {
         m_potaStatusLabel->setText("Polling...");
-        m_potaStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_potaStatusLabel, "QLabel { color: {{color.accent}}; font-size: 11px; }");
         m_potaStartBtn->setText("Stop");
         m_potaConsole->appendPlainText("--- Polling started ---");
     });
     connect(potaClient, &PotaClient::stopped, this, [this] {
         m_potaStatusLabel->setText("Stopped");
-        m_potaStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_potaStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         m_potaStartBtn->setText("Start");
         m_potaConsole->appendPlainText("--- Stopped ---");
     });
@@ -554,13 +554,13 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
     });
     connect(freedvClient, &FreeDvClient::started, this, [this] {
         m_freedvStatusLabel->setText("Connecting...");
-        m_freedvStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_freedvStatusLabel, "QLabel { color: {{color.accent}}; font-size: 11px; }");
         m_freedvStartBtn->setText("Stop");
         m_freedvConsole->appendPlainText("--- Connecting ---");
     });
     connect(freedvClient, &FreeDvClient::stopped, this, [this] {
         m_freedvStatusLabel->setText("Stopped");
-        m_freedvStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_freedvStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         m_freedvStartBtn->setText("Start");
         m_freedvConsole->appendPlainText("--- Stopped ---");
     });
@@ -572,7 +572,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
     connect(freedvClient, &FreeDvClient::rawLineReceived, this, [this](const QString& line) {
         if (line.startsWith("Connected to")) {
             m_freedvStatusLabel->setText("Connected");
-            m_freedvStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.success}}; font-size: 11px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_freedvStatusLabel, "QLabel { color: {{color.accent.success}}; font-size: 11px; }");
         }
     });
 
@@ -681,7 +681,7 @@ void DxClusterDialog::buildClusterTab(QTabWidget* tabs)
     grid->addWidget(new QLabel("Server:"), row, 0);
     m_hostEdit = new QLineEdit(s.value("DxClusterHost", "dxc.nc7j.com").toString());
     m_hostEdit->setPlaceholderText("dxc.nc7j.com");
-    m_hostEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_hostEdit, "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     grid->addWidget(m_hostEdit, row, 1);
     row++;
 
@@ -689,14 +689,14 @@ void DxClusterDialog::buildClusterTab(QTabWidget* tabs)
     m_portSpin = new QSpinBox;
     m_portSpin->setRange(1, 65535);
     m_portSpin->setValue(s.value("DxClusterPort", 7300).toInt());
-    m_portSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_portSpin, "QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     grid->addWidget(m_portSpin, row, 1);
     row++;
 
     grid->addWidget(new QLabel("Callsign:"), row, 0);
     m_callEdit = new QLineEdit(s.value("DxClusterCallsign").toString());
     m_callEdit->setPlaceholderText("your callsign");
-    m_callEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_callEdit, "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     grid->addWidget(m_callEdit, row, 1);
     row++;
 
@@ -735,16 +735,16 @@ void DxClusterDialog::buildClusterTab(QTabWidget* tabs)
     btnRow->addStretch();
 
     m_statusLabel = new QLabel("Disconnected");
-    m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
     btnRow->addWidget(m_statusLabel);
     btnRow->addStretch();
 
     m_connectBtn = new QPushButton(m_client->isConnected() ? "Disconnect" : "Connect");
     m_connectBtn->setFixedWidth(100);
-    m_connectBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_connectBtn, "QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
         "border: 1px solid {{color.accent.dim}}; padding: 4px; border-radius: 3px; }"
         "QPushButton:hover { background: {{color.accent.bright}}; }"
-        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }"));
+        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }");
     connect(m_connectBtn, &QPushButton::clicked, this, [this] {
         if (m_client->isConnected()) {
             emit disconnectRequested();
@@ -755,7 +755,7 @@ void DxClusterDialog::buildClusterTab(QTabWidget* tabs)
         quint16 port = static_cast<quint16>(m_portSpin->value());
         if (host.isEmpty() || call.isEmpty()) {
             m_statusLabel->setText("Server and callsign are required");
-            m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.danger}}; font-size: 11px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.accent.danger}}; font-size: 11px; }");
             return;
         }
         auto& s = AppSettings::instance();
@@ -773,12 +773,12 @@ void DxClusterDialog::buildClusterTab(QTabWidget* tabs)
     // ── Console output ──────────────────────────────────────────────────
     auto* consoleRow = new QHBoxLayout;
     auto* consoleLabel = new QLabel("Cluster Console");
-    consoleLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(consoleLabel, "QLabel { color: {{color.accent}}; font-weight: bold; }");
     consoleRow->addWidget(consoleLabel);
     consoleRow->addStretch();
 
     auto* dxcColorLabel = new QLabel("Spot Color:");
-    dxcColorLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(dxcColorLabel, "QLabel { color: {{color.text.label}}; font-size: 12px; }");
     consoleRow->addWidget(dxcColorLabel);
 
     QColor dxcColor(s.value("DxClusterSpotColor", "#D2B48C").toString());
@@ -805,21 +805,21 @@ void DxClusterDialog::buildClusterTab(QTabWidget* tabs)
     m_console = new QPlainTextEdit;
     m_console->setReadOnly(true);
     m_console->setMaximumBlockCount(2000);
-    m_console->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPlainTextEdit {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_console, "QPlainTextEdit {"
         "  background: {{color.background.0}};"
         "  color: {{color.text.secondary}};"
         "  font-family: monospace;"
         "  font-size: 11px;"
         "  border: 1px solid {{color.background.1}};"
         "  padding: 4px;"
-        "}"));
+        "}");
     layout->addWidget(m_console, 1);
 
     // Command input row
     auto* cmdRow = new QHBoxLayout;
     m_cmdEdit = new QLineEdit;
     m_cmdEdit->setPlaceholderText("Type a cluster command (e.g. sh/dx 20, set/filter, bye)");
-    m_cmdEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; font-family: monospace; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_cmdEdit, "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; font-family: monospace; }");
     m_cmdEdit->setEnabled(m_client->isConnected());
     connect(m_cmdEdit, &QLineEdit::returnPressed, this, [this] {
         QString cmd = m_cmdEdit->text().trimmed();
@@ -864,7 +864,7 @@ void DxClusterDialog::buildRbnTab(QTabWidget* tabs)
     grid->addWidget(new QLabel("Server:"), row, 0);
     m_rbnHostEdit = new QLineEdit(s.value("RbnHost", "telnet.reversebeacon.net").toString());
     m_rbnHostEdit->setPlaceholderText("telnet.reversebeacon.net");
-    m_rbnHostEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnHostEdit, "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     grid->addWidget(m_rbnHostEdit, row, 1);
     row++;
 
@@ -872,14 +872,14 @@ void DxClusterDialog::buildRbnTab(QTabWidget* tabs)
     m_rbnPortSpin = new QSpinBox;
     m_rbnPortSpin->setRange(1, 65535);
     m_rbnPortSpin->setValue(s.value("RbnPort", 7000).toInt());
-    m_rbnPortSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnPortSpin, "QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     grid->addWidget(m_rbnPortSpin, row, 1);
     row++;
 
     grid->addWidget(new QLabel("Callsign:"), row, 0);
     m_rbnCallEdit = new QLineEdit(defaultCall);
     m_rbnCallEdit->setPlaceholderText("your callsign");
-    m_rbnCallEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnCallEdit, "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     grid->addWidget(m_rbnCallEdit, row, 1);
     row++;
 
@@ -890,7 +890,7 @@ void DxClusterDialog::buildRbnTab(QTabWidget* tabs)
     rateSpin->setRange(1, 100);
     rateSpin->setValue(s.value("RbnRateLimit", 10).toInt());
     rateSpin->setSuffix(" spots/sec");
-    rateSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(rateSpin, "QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     connect(rateSpin, &QSpinBox::valueChanged, this, [](int v) {
         auto& s = AppSettings::instance();
         s.setValue("RbnRateLimit", v);
@@ -936,16 +936,16 @@ void DxClusterDialog::buildRbnTab(QTabWidget* tabs)
     btnRow->addStretch();
 
     m_rbnStatusLabel = new QLabel("Disconnected");
-    m_rbnStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
     btnRow->addWidget(m_rbnStatusLabel);
     btnRow->addStretch();
 
     m_rbnConnectBtn = new QPushButton(m_rbnClient->isConnected() ? "Disconnect" : "Connect");
     m_rbnConnectBtn->setFixedWidth(100);
-    m_rbnConnectBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnConnectBtn, "QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
         "border: 1px solid {{color.accent.dim}}; padding: 4px; border-radius: 3px; }"
         "QPushButton:hover { background: {{color.accent.bright}}; }"
-        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }"));
+        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }");
     connect(m_rbnConnectBtn, &QPushButton::clicked, this, [this] {
         if (m_rbnClient->isConnected()) {
             emit rbnDisconnectRequested();
@@ -956,7 +956,7 @@ void DxClusterDialog::buildRbnTab(QTabWidget* tabs)
         quint16 port = static_cast<quint16>(m_rbnPortSpin->value());
         if (host.isEmpty() || call.isEmpty()) {
             m_rbnStatusLabel->setText("Server and callsign are required");
-            m_rbnStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.danger}}; font-size: 11px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnStatusLabel, "QLabel { color: {{color.accent.danger}}; font-size: 11px; }");
             return;
         }
         auto& s = AppSettings::instance();
@@ -974,12 +974,12 @@ void DxClusterDialog::buildRbnTab(QTabWidget* tabs)
     // ── Console output ──────────────────────────────────────────────────
     auto* rbnConsoleRow = new QHBoxLayout;
     auto* rbnConsoleLabel = new QLabel("RBN Console");
-    rbnConsoleLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(rbnConsoleLabel, "QLabel { color: {{color.accent}}; font-weight: bold; }");
     rbnConsoleRow->addWidget(rbnConsoleLabel);
     rbnConsoleRow->addStretch();
 
     auto* rbnColorLabel = new QLabel("Spot Color:");
-    rbnColorLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(rbnColorLabel, "QLabel { color: {{color.text.label}}; font-size: 12px; }");
     rbnConsoleRow->addWidget(rbnColorLabel);
 
     QColor rbnColor(s.value("RbnSpotColor", "#4488FF").toString());
@@ -1006,21 +1006,21 @@ void DxClusterDialog::buildRbnTab(QTabWidget* tabs)
     m_rbnConsole = new QPlainTextEdit;
     m_rbnConsole->setReadOnly(true);
     m_rbnConsole->setMaximumBlockCount(2000);
-    m_rbnConsole->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPlainTextEdit {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnConsole, "QPlainTextEdit {"
         "  background: {{color.background.0}};"
         "  color: {{color.text.secondary}};"
         "  font-family: monospace;"
         "  font-size: 11px;"
         "  border: 1px solid {{color.background.1}};"
         "  padding: 4px;"
-        "}"));
+        "}");
     layout->addWidget(m_rbnConsole, 1);
 
     // Command input row
     auto* cmdRow = new QHBoxLayout;
     m_rbnCmdEdit = new QLineEdit;
     m_rbnCmdEdit->setPlaceholderText("Type an RBN command (e.g. set/skimmer, set/ft8, bye)");
-    m_rbnCmdEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; font-family: monospace; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnCmdEdit, "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; font-family: monospace; }");
     m_rbnCmdEdit->setEnabled(m_rbnClient->isConnected());
     connect(m_rbnCmdEdit, &QLineEdit::returnPressed, this, [this] {
         QString cmd = m_rbnCmdEdit->text().trimmed();
@@ -1062,7 +1062,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     grid->addWidget(new QLabel("Address:"), row, 0);
     m_wsjtxAddrEdit = new QLineEdit(s.value("WsjtxAddress", "224.0.0.1").toString());
     m_wsjtxAddrEdit->setPlaceholderText("224.0.0.1 (multicast) or 0.0.0.0 (any)");
-    m_wsjtxAddrEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_wsjtxAddrEdit, "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     grid->addWidget(m_wsjtxAddrEdit, row, 1);
     row++;
 
@@ -1070,7 +1070,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     m_wsjtxPortSpin = new QSpinBox;
     m_wsjtxPortSpin->setRange(1, 65535);
     m_wsjtxPortSpin->setValue(s.value("WsjtxPort", 2237).toInt());
-    m_wsjtxPortSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_wsjtxPortSpin, "QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     grid->addWidget(m_wsjtxPortSpin, row, 1);
     row++;
 
@@ -1094,16 +1094,16 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     btnRow->addStretch();
 
     m_wsjtxStatusLabel = new QLabel("Stopped");
-    m_wsjtxStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_wsjtxStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
     btnRow->addWidget(m_wsjtxStatusLabel);
     btnRow->addStretch();
 
     m_wsjtxStartBtn = new QPushButton(m_wsjtxClient->isListening() ? "Stop" : "Start");
     m_wsjtxStartBtn->setFixedWidth(100);
-    m_wsjtxStartBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_wsjtxStartBtn, "QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
         "border: 1px solid {{color.accent.dim}}; padding: 4px; border-radius: 3px; }"
         "QPushButton:hover { background: {{color.accent.bright}}; }"
-        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }"));
+        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }");
     connect(m_wsjtxStartBtn, &QPushButton::clicked, this, [this] {
         if (m_wsjtxClient->isListening()) {
             emit wsjtxStopRequested();
@@ -1128,7 +1128,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     auto* filterRow = new QHBoxLayout;
     filterRow->setSpacing(6);
     auto* filterLabel = new QLabel("Spot Filter:");
-    filterLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 14px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(filterLabel, "QLabel { color: {{color.text.label}}; font-size: 14px; }");
     filterRow->addWidget(filterLabel);
 
     QString cbStyle = "QCheckBox { color: #a0b0c0; font-size: 14px; spacing: 3px; }"
@@ -1230,7 +1230,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     });
     filterRow->addWidget(m_wsjtxColorDefault);
     auto* defaultLabel = new QLabel("Default");
-    defaultLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 14px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(defaultLabel, "QLabel { color: {{color.text.secondary}}; font-size: 14px; }");
     filterRow->addWidget(defaultLabel);
 
     layout->addLayout(filterRow);
@@ -1239,12 +1239,12 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     // Decodes label + spot lifetime slider
     auto* decodeRow = new QHBoxLayout;
     auto* consoleLabel = new QLabel("WSJT-X Decodes");
-    consoleLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(consoleLabel, "QLabel { color: {{color.accent}}; font-weight: bold; }");
     decodeRow->addWidget(consoleLabel);
     decodeRow->addStretch();
 
     auto* lifeLabel = new QLabel("Spot Life:");
-    lifeLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(lifeLabel, "QLabel { color: {{color.text.label}}; font-size: 12px; }");
     decodeRow->addWidget(lifeLabel);
 
     int wsjtxLife = s.value("WsjtxSpotLifetime", 120).toInt();
@@ -1257,7 +1257,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     auto* wsjtxLifeValue = new QLabel(QString("%1s").arg(wsjtxLife));
     wsjtxLifeValue->setFixedWidth(35);
     wsjtxLifeValue->setAlignment(Qt::AlignRight);
-    wsjtxLifeValue->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(wsjtxLifeValue, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     decodeRow->addWidget(wsjtxLifeValue);
 
     connect(wsjtxLifeSlider, &QSlider::valueChanged, this, [wsjtxLifeValue](int v) {
@@ -1271,14 +1271,14 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     m_wsjtxConsole = new QPlainTextEdit;
     m_wsjtxConsole->setReadOnly(true);
     m_wsjtxConsole->setMaximumBlockCount(2000);
-    m_wsjtxConsole->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPlainTextEdit {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_wsjtxConsole, "QPlainTextEdit {"
         "  background: {{color.background.0}};"
         "  color: {{color.text.secondary}};"
         "  font-family: monospace;"
         "  font-size: 11px;"
         "  border: 1px solid {{color.background.1}};"
         "  padding: 4px;"
-        "}"));
+        "}");
     layout->addWidget(m_wsjtxConsole, 1);
 
     tabs->addTab(page, "WSJT-X");
@@ -1304,7 +1304,7 @@ void DxClusterDialog::buildSpotCollectorTab(QTabWidget* tabs)
     m_scPortSpin = new QSpinBox;
     m_scPortSpin->setRange(1, 65535);
     m_scPortSpin->setValue(s.value("SpotCollectorPort", 9999).toInt());
-    m_scPortSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_scPortSpin, "QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     grid->addWidget(m_scPortSpin, 0, 1);
 
     connLayout->addLayout(grid);
@@ -1314,7 +1314,7 @@ void DxClusterDialog::buildSpotCollectorTab(QTabWidget* tabs)
         "In SpotCollector, enable UDP broadcast to this port (default 9999).\n"
         "Alternatively, use the DX Cluster tab to connect to SpotCollector's telnet interface.");
     helpLabel->setWordWrap(true);
-    helpLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(helpLabel, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
     connLayout->addWidget(helpLabel);
 
     // Button row
@@ -1335,16 +1335,16 @@ void DxClusterDialog::buildSpotCollectorTab(QTabWidget* tabs)
     btnRow->addStretch();
 
     m_scStatusLabel = new QLabel("Stopped");
-    m_scStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_scStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
     btnRow->addWidget(m_scStatusLabel);
     btnRow->addStretch();
 
     m_scStartBtn = new QPushButton(m_spotCollectorClient->isListening() ? "Stop" : "Start");
     m_scStartBtn->setFixedWidth(100);
-    m_scStartBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_scStartBtn, "QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
         "border: 1px solid {{color.accent.dim}}; padding: 4px; border-radius: 3px; }"
         "QPushButton:hover { background: {{color.accent.bright}}; }"
-        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }"));
+        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }");
     connect(m_scStartBtn, &QPushButton::clicked, this, [this] {
         if (m_spotCollectorClient->isListening()) {
             emit spotCollectorStopRequested();
@@ -1363,26 +1363,26 @@ void DxClusterDialog::buildSpotCollectorTab(QTabWidget* tabs)
 
     // ── Console output ──────────────────────────────────────────────────
     auto* consoleLabel = new QLabel("SpotCollector Spots");
-    consoleLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(consoleLabel, "QLabel { color: {{color.accent}}; font-weight: bold; }");
     layout->addWidget(consoleLabel);
 
     m_scConsole = new QPlainTextEdit;
     m_scConsole->setReadOnly(true);
     m_scConsole->setMaximumBlockCount(2000);
-    m_scConsole->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPlainTextEdit {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_scConsole, "QPlainTextEdit {"
         "  background: {{color.background.0}};"
         "  color: {{color.text.secondary}};"
         "  font-family: monospace;"
         "  font-size: 11px;"
         "  border: 1px solid {{color.background.1}};"
         "  padding: 4px;"
-        "}"));
+        "}");
     layout->addWidget(m_scConsole, 1);
 
     // Update status if already listening
     if (m_spotCollectorClient->isListening()) {
         m_scStatusLabel->setText(QString("Listening on port %1").arg(m_scPortSpin->value()));
-        m_scStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_scStatusLabel, "QLabel { color: {{color.accent}}; font-size: 11px; }");
         m_scStartBtn->setText("Stop");
     }
 
@@ -1417,7 +1417,7 @@ void DxClusterDialog::buildPotaTab(QTabWidget* tabs)
     m_potaIntervalSpin->setRange(15, 300);
     m_potaIntervalSpin->setValue(s.value("PotaPollInterval", 30).toInt());
     m_potaIntervalSpin->setSuffix(" sec");
-    m_potaIntervalSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_potaIntervalSpin, "QSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     connect(m_potaIntervalSpin, &QSpinBox::valueChanged, this, [](int v) {
         auto& s = AppSettings::instance();
         s.setValue("PotaPollInterval", v);
@@ -1446,16 +1446,16 @@ void DxClusterDialog::buildPotaTab(QTabWidget* tabs)
     btnRow->addStretch();
 
     m_potaStatusLabel = new QLabel("Stopped");
-    m_potaStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_potaStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
     btnRow->addWidget(m_potaStatusLabel);
     btnRow->addStretch();
 
     m_potaStartBtn = new QPushButton(m_potaClient->isPolling() ? "Stop" : "Start");
     m_potaStartBtn->setFixedWidth(100);
-    m_potaStartBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_potaStartBtn, "QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
         "border: 1px solid {{color.accent.dim}}; padding: 4px; border-radius: 3px; }"
         "QPushButton:hover { background: {{color.accent.bright}}; }"
-        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }"));
+        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }");
     connect(m_potaStartBtn, &QPushButton::clicked, this, [this] {
         if (m_potaClient->isPolling()) {
             emit potaStopRequested();
@@ -1475,12 +1475,12 @@ void DxClusterDialog::buildPotaTab(QTabWidget* tabs)
     // ── Console output ──────────────────────────────────────────────────
     auto* consoleRow = new QHBoxLayout;
     auto* consoleLabel = new QLabel("POTA Activations");
-    consoleLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(consoleLabel, "QLabel { color: {{color.accent}}; font-weight: bold; }");
     consoleRow->addWidget(consoleLabel);
     consoleRow->addStretch();
 
     auto* spotColorLabel = new QLabel("Spot Color:");
-    spotColorLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(spotColorLabel, "QLabel { color: {{color.text.label}}; font-size: 12px; }");
     consoleRow->addWidget(spotColorLabel);
 
     QColor potaColor(s.value("PotaSpotColor", "#FFFF00").toString());
@@ -1507,14 +1507,14 @@ void DxClusterDialog::buildPotaTab(QTabWidget* tabs)
     m_potaConsole = new QPlainTextEdit;
     m_potaConsole->setReadOnly(true);
     m_potaConsole->setMaximumBlockCount(2000);
-    m_potaConsole->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPlainTextEdit {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_potaConsole, "QPlainTextEdit {"
         "  background: {{color.background.0}};"
         "  color: {{color.text.secondary}};"
         "  font-family: monospace;"
         "  font-size: 11px;"
         "  border: 1px solid {{color.background.1}};"
         "  padding: 4px;"
-        "}"));
+        "}");
     layout->addWidget(m_potaConsole, 1);
 
     tabs->addTab(page, "POTA");
@@ -1564,16 +1564,16 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     btnRow->addStretch();
 
     m_freedvStatusLabel = new QLabel("Stopped");
-    m_freedvStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_freedvStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
     btnRow->addWidget(m_freedvStatusLabel);
     btnRow->addStretch();
 
     m_freedvStartBtn = new QPushButton(m_freedvClient->isConnected() ? "Stop" : "Start");
     m_freedvStartBtn->setFixedWidth(100);
-    m_freedvStartBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_freedvStartBtn, "QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
         "border: 1px solid {{color.accent.dim}}; padding: 4px; border-radius: 3px; }"
         "QPushButton:hover { background: {{color.accent.bright}}; }"
-        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }"));
+        "QPushButton:disabled { background: #404060; color: {{color.text.label}}; }");
     connect(m_freedvStartBtn, &QPushButton::clicked, this, [this] {
         if (m_freedvClient->isConnected()) {
             emit freedvStopRequested();
@@ -1661,8 +1661,8 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
                                              : s.value("FreeDvMyCallsign", "").toString());
         m_fdvCallsignEdit->setReadOnly(useRadio);
     }
-    m_fdvCallsignEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"
-        "QLineEdit[readOnly=\"true\"] { color: {{color.text.label}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_fdvCallsignEdit, "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"
+        "QLineEdit[readOnly=\"true\"] { color: {{color.text.label}}; }");
     connect(m_fdvCallsignEdit, &QLineEdit::editingFinished, this, [this] {
         auto& as = AppSettings::instance();
         as.setValue("FreeDvMyCallsign", m_fdvCallsignEdit->text().trimmed().toUpper());
@@ -1696,8 +1696,8 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     m_fdvGridEdit->setPlaceholderText("AA00");
     m_fdvGridEdit->setMaxLength(6);
     m_fdvGridEdit->setText(s.value("FreeDvMyGrid", "").toString());
-    m_fdvGridEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"
-        "QLineEdit[readOnly=\"true\"] { color: {{color.text.label}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_fdvGridEdit, "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"
+        "QLineEdit[readOnly=\"true\"] { color: {{color.text.label}}; }");
     connect(m_fdvGridEdit, &QLineEdit::editingFinished, this, [this] {
         auto& as = AppSettings::instance();
         as.setValue("FreeDvMyGrid", m_fdvGridEdit->text().trimmed().toUpper());
@@ -1738,7 +1738,7 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     m_fdvMessageEdit = new QLineEdit;
     m_fdvMessageEdit->setPlaceholderText("Optional message shown on reporter map");
     m_fdvMessageEdit->setText(s.value("FreeDvMyMessage", "").toString());
-    m_fdvMessageEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_fdvMessageEdit, "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     connect(m_fdvMessageEdit, &QLineEdit::editingFinished, this, [this] {
         auto& as = AppSettings::instance();
         QString msg = m_fdvMessageEdit->text().trimmed();
@@ -1754,12 +1754,12 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     // ── Console output ──────────────────────────────────────────────────
     auto* consoleRow = new QHBoxLayout;
     auto* consoleLabel = new QLabel("FreeDV Spots");
-    consoleLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(consoleLabel, "QLabel { color: {{color.accent}}; font-weight: bold; }");
     consoleRow->addWidget(consoleLabel);
     consoleRow->addStretch();
 
     auto* spotColorLabel = new QLabel("Spot Color:");
-    spotColorLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(spotColorLabel, "QLabel { color: {{color.text.label}}; font-size: 12px; }");
     consoleRow->addWidget(spotColorLabel);
 
     QColor freedvColor(s.value("FreeDvSpotColor", "#FF8C00").toString());
@@ -1786,14 +1786,14 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     m_freedvConsole = new QPlainTextEdit;
     m_freedvConsole->setReadOnly(true);
     m_freedvConsole->setMaximumBlockCount(2000);
-    m_freedvConsole->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPlainTextEdit {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_freedvConsole, "QPlainTextEdit {"
         "  background: {{color.background.0}};"
         "  color: {{color.text.secondary}};"
         "  font-family: monospace;"
         "  font-size: 11px;"
         "  border: 1px solid {{color.background.1}};"
         "  padding: 4px;"
-        "}"));
+        "}");
     layout->addWidget(m_freedvConsole, 1);
 
     tabs->addTab(page, "FreeDV");
@@ -1810,7 +1810,7 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
     auto* filterRow = new QHBoxLayout;
     filterRow->setSpacing(2);
     auto* filterLabel = new QLabel("Bands:");
-    filterLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 13px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(filterLabel, "QLabel { color: {{color.text.label}}; font-size: 13px; }");
     filterRow->addWidget(filterLabel);
 
     // Table model + band filter proxy
@@ -1853,7 +1853,7 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
     m_spotTable->verticalHeader()->setVisible(false);
     m_spotTable->verticalHeader()->setDefaultSectionSize(20);
     m_spotTable->horizontalHeader()->setStretchLastSection(true);
-    m_spotTable->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTableView {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_spotTable, "QTableView {"
         "  background: {{color.background.0}};"
         "  alternate-background-color: #0f0f1e;"
         "  color: {{color.text.primary}};"
@@ -1872,7 +1872,7 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
         "  padding: 3px 6px;"
         "  font-weight: bold;"
         "  font-size: 11px;"
-        "}"));
+        "}");
 
     // Column widths
     m_spotTable->setColumnWidth(SpotTableModel::ColTime, 50);
@@ -1903,7 +1903,7 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
     // Bottom bar: spot count + clear
     auto* bottomRow = new QHBoxLayout;
     auto* countLabel = new QLabel("0 spots");
-    countLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(countLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
     connect(m_spotModel, &QAbstractTableModel::rowsInserted, this, [this, countLabel] {
         countLabel->setText(QString("%1 spots").arg(m_spotModel->rowCount()));
     });
@@ -2252,7 +2252,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     // ── Total Spots ─────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Total Spots:"), row, 0);
     m_totalSpotsLabel = new QLabel("0");
-    m_totalSpotsLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_totalSpotsLabel, "QLabel { color: {{color.text.primary}}; font-weight: bold; }");
     grid->addWidget(m_totalSpotsLabel, row++, 1);
 
     layout->addLayout(grid);
@@ -2272,8 +2272,8 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     {
         auto* dxccTitle = new QLabel("DXCC Coloring");
         dxccTitle->setAlignment(Qt::AlignCenter);
-        dxccTitle->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { font-size: 13px; font-weight: bold; color: #80b0d0; "
-            "border-top: 1px solid {{color.background.2}}; padding-top: 8px; margin-top: 6px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(dxccTitle, "QLabel { font-size: 13px; font-weight: bold; color: #80b0d0; "
+            "border-top: 1px solid {{color.background.2}}; padding-top: 8px; margin-top: 6px; }");
         leftCol->addWidget(dxccTitle);
 
         auto* dxccGrid = new QGridLayout;
@@ -2393,8 +2393,8 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     {
         auto* shTitle = new QLabel("Signal History");
         shTitle->setAlignment(Qt::AlignCenter);
-        shTitle->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { font-size: 13px; font-weight: bold; color: #80b0d0; "
-            "border-top: 1px solid {{color.background.2}}; padding-top: 8px; margin-top: 6px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(shTitle, "QLabel { font-size: 13px; font-weight: bold; color: #80b0d0; "
+            "border-top: 1px solid {{color.background.2}}; padding-top: 8px; margin-top: 6px; }");
         rightCol->addWidget(shTitle);
 
         auto* shGrid = new QGridLayout;
@@ -2631,13 +2631,13 @@ void DxClusterDialog::updateStatus()
     // Cluster status
     if (m_client->isConnected()) {
         m_statusLabel->setText(QString("Connected to %1:%2").arg(m_client->host()).arg(m_client->port()));
-        m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.accent}}; font-size: 11px; }");
         m_connectBtn->setText("Disconnect");
         m_cmdEdit->setEnabled(true);
         m_sendBtn->setEnabled(true);
     } else {
         m_statusLabel->setText("Disconnected");
-        m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         m_connectBtn->setText("Connect");
         m_cmdEdit->setEnabled(false);
         m_sendBtn->setEnabled(false);
@@ -2645,13 +2645,13 @@ void DxClusterDialog::updateStatus()
     // RBN status
     if (m_rbnClient->isConnected()) {
         m_rbnStatusLabel->setText(QString("Connected to %1:%2").arg(m_rbnClient->host()).arg(m_rbnClient->port()));
-        m_rbnStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnStatusLabel, "QLabel { color: {{color.accent}}; font-size: 11px; }");
         m_rbnConnectBtn->setText("Disconnect");
         m_rbnCmdEdit->setEnabled(true);
         m_rbnSendBtn->setEnabled(true);
     } else {
         m_rbnStatusLabel->setText("Disconnected");
-        m_rbnStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_rbnStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         m_rbnConnectBtn->setText("Connect");
         m_rbnCmdEdit->setEnabled(false);
         m_rbnSendBtn->setEnabled(false);
@@ -2659,21 +2659,21 @@ void DxClusterDialog::updateStatus()
     // WSJT-X status
     if (m_wsjtxClient->isListening()) {
         m_wsjtxStatusLabel->setText(QString("Listening on port %1").arg(m_wsjtxPortSpin->value()));
-        m_wsjtxStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_wsjtxStatusLabel, "QLabel { color: {{color.accent}}; font-size: 11px; }");
         m_wsjtxStartBtn->setText("Stop");
     } else {
         m_wsjtxStatusLabel->setText("Stopped");
-        m_wsjtxStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_wsjtxStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         m_wsjtxStartBtn->setText("Start");
     }
     // POTA status
     if (m_potaClient->isPolling()) {
         m_potaStatusLabel->setText("Polling...");
-        m_potaStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_potaStatusLabel, "QLabel { color: {{color.accent}}; font-size: 11px; }");
         m_potaStartBtn->setText("Stop");
     } else {
         m_potaStatusLabel->setText("Stopped");
-        m_potaStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_potaStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         m_potaStartBtn->setText("Start");
     }
 }

--- a/src/gui/DxClusterStartupCommandsDialog.cpp
+++ b/src/gui/DxClusterStartupCommandsDialog.cpp
@@ -29,7 +29,7 @@ DxClusterStartupCommandsDialog::DxClusterStartupCommandsDialog(
 {
     setModal(true);
     setMinimumSize(560, 380);
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }");
 
     auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(10);
@@ -37,20 +37,20 @@ DxClusterStartupCommandsDialog::DxClusterStartupCommandsDialog(
     auto* header = new QLabel(kHeaderText);
     header->setWordWrap(true);
     header->setTextFormat(Qt::RichText);
-    header->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; line-height: 1.4; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(header, "QLabel { color: {{color.text.secondary}}; font-size: 11px; line-height: 1.4; }");
     root->addWidget(header);
 
     m_edit = new QPlainTextEdit;
     m_edit->setPlaceholderText(
         "One cluster command per line — e.g. SET/NAME John");
-    m_edit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPlainTextEdit {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_edit, "QPlainTextEdit {"
         "  background: {{color.background.0}};"
         "  color: {{color.text.primary}};"
         "  font-family: monospace;"
         "  font-size: 12px;"
         "  border: 1px solid {{color.background.1}};"
         "  padding: 4px;"
-        "}"));
+        "}");
     m_edit->setPlainText(AppSettings::instance().value(m_key).toString());
     root->addWidget(m_edit, 1);
 
@@ -59,20 +59,20 @@ DxClusterStartupCommandsDialog::DxClusterStartupCommandsDialog(
     btnRow->addStretch();
 
     auto* cancelBtn = new QPushButton("Cancel");
-    cancelBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; color: {{color.text.primary}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(cancelBtn, "QPushButton { background: {{color.background.1}}; color: {{color.text.primary}}; "
         "border: 1px solid {{color.background.2}}; border-radius: 3px;"
         " padding: 6px 16px; font-size: 11px; }"
-        "QPushButton:hover { background: {{color.background.1}}; border-color: {{color.accent.dim}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; border-color: {{color.accent.dim}}; }");
     connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
     btnRow->addWidget(cancelBtn);
 
     auto* okBtn = new QPushButton("OK");
     okBtn->setDefault(true);
-    okBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold;"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(okBtn, "QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold;"
         " border: 1px solid {{color.accent.dim}}; border-radius: 3px;"
         " padding: 6px 16px; font-size: 11px; }"
         "QPushButton:hover { background: {{color.accent.bright}}; }"
-        "QPushButton:default { border: 2px solid #00f0ff; }"));
+        "QPushButton:default { border: 2px solid #00f0ff; }");
     connect(okBtn, &QPushButton::clicked, this, &QDialog::accept);
     btnRow->addWidget(okBtn);
 

--- a/src/gui/EditorFramelessTitleBar.cpp
+++ b/src/gui/EditorFramelessTitleBar.cpp
@@ -13,15 +13,15 @@ EditorFramelessTitleBar::EditorFramelessTitleBar(QWidget* parent)
 {
     setObjectName(QStringLiteral("editorFramelessTitleBar"));
     setFixedHeight(20);
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("background: {{color.background.0}};"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "background: {{color.background.0}};");
 
     auto* row = new QHBoxLayout(this);
     row->setContentsMargins(8, 0, 4, 0);
     row->setSpacing(2);
 
     m_titleLbl = new QLabel(this);
-    m_titleLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; "
-        "font-weight: bold; background: transparent; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_titleLbl, "QLabel { color: {{color.text.primary}}; font-size: 11px; "
+        "font-weight: bold; background: transparent; }");
     m_titleLbl->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
     row->addWidget(m_titleLbl);
     row->addStretch();

--- a/src/gui/EqApplet.cpp
+++ b/src/gui/EqApplet.cpp
@@ -26,10 +26,10 @@ public:
         setFixedSize(22, 22);
         setCursor(Qt::PointingHandCursor);
         setToolTip("Reset all bands to 0 dB");
-        setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background-color: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QPushButton { background-color: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; }"
             "QPushButton:hover { background-color: {{color.background.1}}; }"
-            "QPushButton:pressed { background-color: {{color.accent}}; }"));
+            "QPushButton:pressed { background-color: {{color.accent}}; }");
     }
 
 protected:
@@ -209,7 +209,7 @@ void EqApplet::buildUI()
         for (int i = 0; i < EqualizerModel::BandCount; ++i) {
             auto* lbl = new QLabel(EqualizerModel::bandLabel(static_cast<EqualizerModel::Band>(i)));
             lbl->setAlignment(Qt::AlignCenter);
-            lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 10px; }");
             row->addWidget(lbl, 1);
         }
 
@@ -231,19 +231,19 @@ void EqApplet::buildUI()
             auto* scaleCol = new QVBoxLayout;
             scaleCol->setSpacing(0);
             auto* topLbl = new QLabel("+10");
-            topLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 9px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(topLbl, "QLabel { color: {{color.text.secondary}}; font-size: 9px; }");
             topLbl->setAlignment(Qt::AlignRight | Qt::AlignTop);
             topLbl->setFixedWidth(20);
             scaleCol->addWidget(topLbl);
             scaleCol->addStretch();
             auto* midLbl = new QLabel("0");
-            midLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 9px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(midLbl, "QLabel { color: {{color.text.secondary}}; font-size: 9px; }");
             midLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
             midLbl->setFixedWidth(20);
             scaleCol->addWidget(midLbl);
             scaleCol->addStretch();
             auto* botLbl = new QLabel("-10");
-            botLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 9px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(botLbl, "QLabel { color: {{color.text.secondary}}; font-size: 9px; }");
             botLbl->setAlignment(Qt::AlignRight | Qt::AlignBottom);
             botLbl->setFixedWidth(20);
             scaleCol->addWidget(botLbl);
@@ -274,7 +274,7 @@ void EqApplet::buildUI()
 
             auto* valLbl = new QLabel("0");
             valLbl->setAlignment(Qt::AlignCenter);
-            valLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 9px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(valLbl, "QLabel { color: {{color.text.primary}}; font-size: 9px; }");
             m_valueLabels[i] = valLbl;
             col->addWidget(valLbl);
 
@@ -298,19 +298,19 @@ void EqApplet::buildUI()
             auto* scaleCol = new QVBoxLayout;
             scaleCol->setSpacing(0);
             auto* topLbl = new QLabel("+10");
-            topLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 9px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(topLbl, "QLabel { color: {{color.text.secondary}}; font-size: 9px; }");
             topLbl->setAlignment(Qt::AlignLeft | Qt::AlignTop);
             topLbl->setFixedWidth(20);
             scaleCol->addWidget(topLbl);
             scaleCol->addStretch();
             auto* midLbl = new QLabel("0");
-            midLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 9px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(midLbl, "QLabel { color: {{color.text.secondary}}; font-size: 9px; }");
             midLbl->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
             midLbl->setFixedWidth(20);
             scaleCol->addWidget(midLbl);
             scaleCol->addStretch();
             auto* botLbl = new QLabel("-10");
-            botLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 9px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(botLbl, "QLabel { color: {{color.text.secondary}}; font-size: 9px; }");
             botLbl->setAlignment(Qt::AlignLeft | Qt::AlignBottom);
             botLbl->setFixedWidth(20);
             scaleCol->addWidget(botLbl);

--- a/src/gui/FramelessWindowTitleBar.cpp
+++ b/src/gui/FramelessWindowTitleBar.cpp
@@ -46,7 +46,7 @@ FramelessWindowTitleBar::FramelessWindowTitleBar(const QString& title, QWidget* 
     row->setSpacing(4);
 
     auto* grip = new QLabel(QString::fromUtf8("\xe2\x8b\xae\xe2\x8b\xae"), this);
-    grip->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: transparent; color: {{color.text.secondary}}; font-size: 10px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(grip, "QLabel { background: transparent; color: {{color.text.secondary}}; font-size: 10px; }");
     row->addWidget(grip);
 
     m_titleLabel = new QLabel(title, this);

--- a/src/gui/HelpDialog.cpp
+++ b/src/gui/HelpDialog.cpp
@@ -61,25 +61,25 @@ void HelpDialog::buildUI(const QString& resourcePath)
     layout->setSpacing(0);
 
     auto* header = new QWidget(this);
-    header->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("background: {{color.background.0}};"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(header, "background: {{color.background.0}};");
     auto* headerLayout = new QVBoxLayout(header);
     headerLayout->setContentsMargins(20, 18, 20, 14);
     headerLayout->setSpacing(6);
 
     auto* eyebrow = new QLabel("AETHERSDR OFFLINE HELP", header);
-    eyebrow->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.accent}}; font-size: 11px; letter-spacing: 2px;"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(eyebrow, "color: {{color.accent}}; font-size: 11px; letter-spacing: 2px;");
     headerLayout->addWidget(eyebrow);
 
     auto* title = new QLabel(windowTitle(), header);
     title->setWordWrap(true);
-    title->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.text.primary}}; font-size: 22px; font-weight: 700;"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(title, "color: {{color.text.primary}}; font-size: 22px; font-weight: 700;");
     headerLayout->addWidget(title);
 
     auto* subtitle = new QLabel(
         "Bundled help is available even when your station computer is offline.",
         header);
     subtitle->setWordWrap(true);
-    subtitle->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.text.secondary}}; font-size: 12px;"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(subtitle, "color: {{color.text.secondary}}; font-size: 12px;");
     headerLayout->addWidget(subtitle);
 
     auto* findRow = new QWidget(header);
@@ -89,7 +89,7 @@ void HelpDialog::buildUI(const QString& resourcePath)
     findLayout->setSpacing(8);
 
     auto* findLabel = new QLabel("Find:", findRow);
-    findLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.text.secondary}}; font-size: 12px; font-weight: 700;"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(findLabel, "color: {{color.text.secondary}}; font-size: 12px; font-weight: 700;");
     findLayout->addWidget(findLabel);
 
     m_findEdit = new QLineEdit(findRow);
@@ -136,7 +136,7 @@ void HelpDialog::buildUI(const QString& resourcePath)
     m_findStatus = new QLabel(findRow);
     m_findStatus->setObjectName("helpFindStatus");
     m_findStatus->setMinimumWidth(96);
-    m_findStatus->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.text.secondary}}; font-size: 11px;"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_findStatus, "color: {{color.text.secondary}}; font-size: 11px;");
     findLayout->addWidget(m_findStatus);
 
     headerLayout->addWidget(findRow);
@@ -145,7 +145,7 @@ void HelpDialog::buildUI(const QString& resourcePath)
 
     auto* separator = new QWidget(this);
     separator->setFixedHeight(1);
-    separator->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("background: {{color.background.1}};"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(separator, "background: {{color.background.1}};");
     layout->addWidget(separator);
 
     m_browser = new QTextBrowser(this);
@@ -170,7 +170,7 @@ void HelpDialog::buildUI(const QString& resourcePath)
         "code { color: #d8e4ee; background-color: #152230; }"
         "a { color: #00b4d8; text-decoration: none; }");
     m_browser->setMarkdown(loadMarkdown(resourcePath));
-    m_browser->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTextBrowser {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_browser, "QTextBrowser {"
         "  background: {{color.background.0}};"
         "  color: #d8e4ee;"
         "  border: none;"
@@ -207,7 +207,7 @@ void HelpDialog::buildUI(const QString& resourcePath)
         "}"
         "QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {"
         "  width: 0px;"
-        "}"));
+        "}");
     layout->addWidget(m_browser, 1);
 
     connect(m_findEdit, &QLineEdit::textChanged, this, [this](const QString& text) {
@@ -228,7 +228,7 @@ void HelpDialog::buildUI(const QString& resourcePath)
     prevShortcut->setContext(Qt::WidgetShortcut);
 
     auto* footer = new QWidget(this);
-    footer->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("background: {{color.background.0}};"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(footer, "background: {{color.background.0}};");
     auto* footerLayout = new QHBoxLayout(footer);
     footerLayout->setContentsMargins(16, 12, 16, 16);
 
@@ -236,7 +236,7 @@ void HelpDialog::buildUI(const QString& resourcePath)
         "Tip: The Help menu keeps each guide separate so you can reopen just the topic you need.",
         footer);
     hint->setWordWrap(true);
-    hint->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.text.secondary}}; font-size: 11px;"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(hint, "color: {{color.text.secondary}}; font-size: 11px;");
     footerLayout->addWidget(hint, 1);
 
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, footer);
@@ -244,7 +244,7 @@ void HelpDialog::buildUI(const QString& resourcePath)
     closeButton->setCursor(Qt::PointingHandCursor);
     closeButton->setAutoDefault(false);
     closeButton->setDefault(false);
-    closeButton->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(closeButton, "QPushButton {"
         "  background: {{color.accent}};"
         "  color: {{color.background.0}};"
         "  font-weight: 700;"
@@ -254,13 +254,13 @@ void HelpDialog::buildUI(const QString& resourcePath)
         "  min-height: 32px;"
         "  padding: 0 18px;"
         "}"
-        "QPushButton:hover { background: #18c8ea; }"));
+        "QPushButton:hover { background: #18c8ea; }");
     connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::close);
     footerLayout->addWidget(buttons, 0, Qt::AlignRight);
 
     layout->addWidget(footer);
 
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("HelpDialog { background: {{color.background.0}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "HelpDialog { background: {{color.background.0}}; }");
 }
 
 void HelpDialog::focusFindField()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1238,7 +1238,7 @@ void MainWindow::showForcedDisconnectDialog(bool wasWan,
     dialog->setWindowModality(Qt::ApplicationModal);
     dialog->setWindowFlags(dialog->windowFlags() & ~Qt::WindowContextHelpButtonHint);
     dialog->setFixedWidth(460);
-    dialog->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(dialog, "QDialog { background: {{color.background.0}}; }"
         "QFrame#forcedDisconnectHeader {"
         "  background: qlineargradient(x1:0, y1:0, x2:1, y2:0,"
         "    stop:0 #103626, stop:1 #10283a);"
@@ -1262,7 +1262,7 @@ void MainWindow::showForcedDisconnectDialog(bool wasWan,
         "  color: {{color.background.0}};"
         "  font-weight: bold;"
         "}"
-        "QPushButton#primaryButton:hover { background: {{color.accent.bright}}; }"));
+        "QPushButton#primaryButton:hover { background: {{color.accent.bright}}; }");
 
     auto* outer = new QVBoxLayout(dialog);
     outer->setContentsMargins(0, 0, 0, 0);
@@ -2655,8 +2655,8 @@ MainWindow::MainWindow(QWidget* parent)
             m_appletPanel->phoneCwApplet()->updateAlc(-20.0f);
         }
         if (tx) {
-            m_txIndicator->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: white; background: {{color.accent.danger}}; font-weight: bold; "
-                "font-size: 21px; border-radius: 4px; padding: 0px 1px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_txIndicator, "QLabel { color: white; background: {{color.accent.danger}}; font-weight: bold; "
+                "font-size: 21px; border-radius: 4px; padding: 0px 1px; }");
         } else {
             m_txIndicator->setStyleSheet(
                 "QLabel { color: rgba(255,255,255,128); font-weight: bold; "
@@ -7054,7 +7054,7 @@ void MainWindow::showQuickAddMemoryDialog(const QString& preferredPanId)
     root->addWidget(nameEdit);
 
     auto* freqLabel = new QLabel(QString("Current Frequency: %1 MHz").arg(frequencyText), &dialog);
-    freqLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(freqLabel, "QLabel { color: {{color.text.primary}}; font-size: 12px; }");
     root->addWidget(freqLabel);
 
     auto* summaryLabel = new QLabel(summaryText, &dialog);
@@ -7662,10 +7662,10 @@ void MainWindow::buildMenuBar()
 
     for (const auto& def : inhibitDefs) {
         auto* cb = new QCheckBox(def.label);
-        cb->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; padding: 4px 12px; }"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(cb, "QCheckBox { color: {{color.text.primary}}; padding: 4px 12px; }"
             "QCheckBox::indicator { width: 14px; height: 14px; }"
             "QCheckBox::indicator:unchecked { border: 1px solid {{color.background.3}}; background: {{color.background.1}}; border-radius: 2px; }"
-            "QCheckBox::indicator:checked { border: 1px solid {{color.accent}}; background: {{color.accent}}; border-radius: 2px; }"));
+            "QCheckBox::indicator:checked { border: 1px solid {{color.accent}}; background: {{color.accent}}; border-radius: 2px; }");
         bool on = settings.value(def.key, "False").toString() == "True";
         cb->setChecked(on);
 
@@ -8258,7 +8258,7 @@ void MainWindow::buildMenuBar()
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         dlg->setWindowTitle("About AetherSDR");
         dlg->setFixedWidth(380);
-        dlg->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(dlg, "QDialog { background: {{color.background.0}}; }");
 
         auto* vbox = new QVBoxLayout(dlg);
         vbox->setSpacing(8);
@@ -8315,7 +8315,7 @@ void MainWindow::buildMenuBar()
         // Separator
         auto* sep1 = new QFrame;
         sep1->setFrameShape(QFrame::HLine);
-        sep1->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.background.2}};"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(sep1, "color: {{color.background.2}};");
         vbox->addWidget(sep1);
 
         // Contributors label
@@ -8326,7 +8326,7 @@ void MainWindow::buildMenuBar()
         // Scrollable contributors list
         auto* contribLabel = new QLabel("Jeremy (KK7GWY)<br>Claude &middot; Anthropic<br>rfoust<br>Ian (M7HNF)<br>VE3NEM<br>jensenpat<br>chibondking<br>Dependabot");
         contribLabel->setAlignment(Qt::AlignCenter);
-        contribLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(contribLabel, "QLabel { color: {{color.text.primary}}; font-size: 11px; }");
         contribLabel->setWordWrap(true);
 
         auto* scroll = new QScrollArea;
@@ -8334,16 +8334,16 @@ void MainWindow::buildMenuBar()
         scroll->setWidgetResizable(true);
         scroll->setFixedHeight(80);
         scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-        scroll->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QScrollArea { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; border-radius: 4px; }"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(scroll, "QScrollArea { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; border-radius: 4px; }"
             "QScrollBar:vertical { background: {{color.background.0}}; width: 6px; }"
             "QScrollBar::handle:vertical { background: {{color.background.2}}; border-radius: 3px; }"
-            "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }"));
+            "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }");
         vbox->addWidget(scroll);
 
         // Separator
         auto* sep2 = new QFrame;
         sep2->setFrameShape(QFrame::HLine);
-        sep2->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("color: {{color.background.2}};"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(sep2, "color: {{color.background.2}};");
         vbox->addWidget(sep2);
 
         // Footer
@@ -8369,9 +8369,9 @@ void MainWindow::buildMenuBar()
 
         // OK button
         auto* okBtn = new QPushButton("OK");
-        okBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(okBtn, "QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
             "border-radius: 4px; padding: 6px 24px; }"
-            "QPushButton:hover { background: {{color.accent.bright}}; }"));
+            "QPushButton:hover { background: {{color.accent.bright}}; }");
         connect(okBtn, &QPushButton::clicked, dlg, &QDialog::close);
         vbox->addWidget(okBtn, 0, Qt::AlignCenter);
 
@@ -8832,9 +8832,9 @@ void MainWindow::buildUI()
     m_sizeGrip->raise();
     m_sizeGrip->setVisible(
         AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
-    statusBar()->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QStatusBar { background: {{color.background.0}}; border-top: 1px solid {{color.background.1}}; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(statusBar(), "QStatusBar { background: {{color.background.0}}; border-top: 1px solid {{color.background.1}}; }"
         "QStatusBar::item { border: none; }"
-        "QLabel { font-size: 21px; background: transparent; }"));
+        "QLabel { font-size: 21px; background: transparent; }");
 
     const QString valStyle  = "QLabel { color: #8aa8c0; font-size: 21px; }";
     const QString sepStyle  = "QLabel { color: #304050; font-size: 21px; }";
@@ -8961,10 +8961,10 @@ void MainWindow::buildUI()
     radioVbox->setContentsMargins(0, 0, 0, 0);
     radioVbox->setSpacing(0);
     m_radioInfoLabel = new QLabel("");
-    m_radioInfoLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_radioInfoLabel, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     m_radioInfoLabel->setAlignment(Qt::AlignCenter);
     m_radioVersionLabel = new QLabel("");
-    m_radioVersionLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_radioVersionLabel, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     m_radioVersionLabel->setAlignment(Qt::AlignCenter);
     radioVbox->addWidget(m_radioInfoLabel);
     radioVbox->addWidget(m_radioVersionLabel);
@@ -8974,8 +8974,8 @@ void MainWindow::buildUI()
     hbox->addStretch(1);
 
     m_stationNickLabel = new QLabel("N0CALL");
-    m_stationNickLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 21px; background: {{color.background.0}}; "
-        "border: 1px solid rgba(255,255,255,128); padding: 2px 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_stationNickLabel, "QLabel { color: {{color.text.primary}}; font-size: 21px; background: {{color.background.0}}; "
+        "border: 1px solid rgba(255,255,255,128); padding: 2px 12px; }");
     m_stationNickLabel->setAlignment(Qt::AlignCenter);
     m_stationNickLabel->setCursor(Qt::PointingHandCursor);
     m_stationNickLabel->setToolTip("Double-click to connect/disconnect");
@@ -8997,10 +8997,10 @@ void MainWindow::buildUI()
     gpsVbox->setContentsMargins(0, 0, 0, 0);
     gpsVbox->setSpacing(0);
     m_gpsLabel = new QLabel("");
-    m_gpsLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_gpsLabel, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     m_gpsLabel->setAlignment(Qt::AlignCenter);
     m_gpsStatusLabel = new QLabel("");
-    m_gpsStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_gpsStatusLabel, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     m_gpsStatusLabel->setAlignment(Qt::AlignCenter);
     gpsVbox->addWidget(m_gpsLabel);
     gpsVbox->addWidget(m_gpsStatusLabel);
@@ -9016,11 +9016,11 @@ void MainWindow::buildUI()
         cpuVbox->setContentsMargins(0, 0, 0, 0);
         cpuVbox->setSpacing(0);
         m_cpuLabel = new QLabel("CPU: \u2014");
-        m_cpuLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_cpuLabel, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
         m_cpuLabel->setAlignment(Qt::AlignCenter);
         m_cpuLabel->setToolTip("AetherSDR process CPU usage");
         m_memLabel = new QLabel("Mem: \u2014");
-        m_memLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 12px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_memLabel, "QLabel { color: {{color.text.label}}; font-size: 12px; }");
         m_memLabel->setAlignment(Qt::AlignCenter);
         m_memLabel->setToolTip("AetherSDR process memory (RSS)");
         cpuVbox->addWidget(m_cpuLabel);
@@ -9111,13 +9111,13 @@ void MainWindow::buildUI()
     paVbox->setContentsMargins(0, 0, 0, 0);
     paVbox->setSpacing(0);
     m_paTempLabel = new QLabel("");
-    m_paTempLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_paTempLabel, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     m_paTempLabel->setAlignment(Qt::AlignCenter);
     m_paTempLabel->setCursor(Qt::PointingHandCursor);
     m_paTempLabel->installEventFilter(this);
     updatePaTempLabel();
     m_supplyVoltLabel = new QLabel("");
-    m_supplyVoltLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_supplyVoltLabel, "QLabel { color: {{color.text.label}}; font-size: 12px; }");
     m_supplyVoltLabel->setAlignment(Qt::AlignCenter);
     paVbox->addWidget(m_paTempLabel);
     paVbox->addWidget(m_supplyVoltLabel);
@@ -9133,11 +9133,11 @@ void MainWindow::buildUI()
     netVbox->setContentsMargins(0, 0, 0, 0);
     netVbox->setSpacing(0);
     auto* netTitle = new QLabel("Network:");
-    netTitle->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(netTitle, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     netTitle->setAlignment(Qt::AlignCenter);
     netVbox->addWidget(netTitle);
     m_networkLabel = new QLabel("");
-    m_networkLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_networkLabel, "QLabel { color: {{color.text.label}}; font-size: 12px; }");
     m_networkLabel->setTextFormat(Qt::RichText);
     m_networkLabel->setAlignment(Qt::AlignCenter);
     m_networkLabel->setToolTip(buildNetworkTooltip(m_radioModel));
@@ -9203,11 +9203,11 @@ void MainWindow::buildUI()
     timeVbox->setContentsMargins(0, 0, 0, 0);
     timeVbox->setSpacing(0);
     m_gpsDateLabel = new QLabel("");
-    m_gpsDateLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_gpsDateLabel, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     m_gpsDateLabel->setAlignment(Qt::AlignCenter);
     m_gpsDateLabel->setMinimumWidth(kTelemetryStackMinWidth);
     m_gpsTimeLabel = new QLabel("");
-    m_gpsTimeLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_gpsTimeLabel, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
     m_gpsTimeLabel->setAlignment(Qt::AlignCenter);
     m_gpsTimeLabel->setMinimumWidth(kTelemetryStackMinWidth);
     timeVbox->addWidget(m_gpsDateLabel);
@@ -9637,7 +9637,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
         m_radioInfoLabel->setText("");
         m_radioVersionLabel->setText("");
         m_stationLabel->setText("N0CALL");
-        m_tnfIndicator->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.background.2}}; font-weight: bold; font-size: 24px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_tnfIndicator, "QLabel { color: {{color.background.2}}; font-weight: bold; font-size: 24px; }");
         m_tnfIndicator->setToolTip(buildTnfTooltip(m_radioModel.tnfModel()));
         if (auto* bandStackPanel = m_panStack ? m_panStack->bandStackPanel() : nullptr) {
             bandStackPanel->clear();
@@ -9714,14 +9714,14 @@ void MainWindow::onConnectionStateChanged(bool connected)
             m_reconnectDlg->setWindowFlag(Qt::FramelessWindowHint, frameless);
             m_reconnectDlg->setModal(false);
             m_reconnectDlg->setFixedSize(400, 150);
-            m_reconnectDlg->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; }"
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_reconnectDlg, "QDialog { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; }"
                 "QLabel { color: {{color.text.primary}}; background: transparent; }"
                 "QLabel#reconnectTitle { color: {{color.text.primary}}; font-size: 16px; font-weight: bold; }"
                 "QLabel#reconnectBody { color: {{color.text.secondary}}; font-size: 12px; }"
                 "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
                 "border-radius: 3px; color: {{color.text.primary}}; font-size: 12px; "
                 "font-weight: bold; padding: 6px 20px; }"
-                "QPushButton:hover { background: {{color.background.1}}; }"));
+                "QPushButton:hover { background: {{color.background.1}}; }");
 
             auto* root = new QVBoxLayout(m_reconnectDlg);
             root->setContentsMargins(0, 0, 0, 0);
@@ -12975,12 +12975,12 @@ void MainWindow::enableNr2WithWisdom()
         dlg->setWindowFlag(Qt::Tool, true);
         dlg->setAttribute(Qt::WA_ShowWithoutActivating, true);
         dlg->setMinimumWidth(500);
-        dlg->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: #050710; }"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(dlg, "QDialog { background: #050710; }"
             "QLabel { color: {{color.text.secondary}}; background: transparent; }"
             "QProgressBar { text-align: center; font-size: 13px;"
             " font-weight: bold; color: {{color.text.primary}};"
             " background: {{color.background.0}}; border: 1px solid {{color.background.1}}; border-radius: 3px; }"
-            "QProgressBar::chunk { background: {{color.accent}}; }"));
+            "QProgressBar::chunk { background: {{color.accent}}; }");
 
         auto* root = new QVBoxLayout(dlg);
         root->setContentsMargins(0, 0, 0, 0);

--- a/src/gui/MemoryBrowsePanel.cpp
+++ b/src/gui/MemoryBrowsePanel.cpp
@@ -32,7 +32,7 @@ MemoryBrowsePanel::MemoryBrowsePanel(QWidget* parent)
     : QWidget(parent)
 {
     setFixedSize(252, 460);
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("background: rgba(15, 15, 26, 220); border: 1px solid {{color.background.2}}; border-radius: 3px;"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "background: rgba(15, 15, 26, 220); border: 1px solid {{color.background.2}}; border-radius: 3px;");
 
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(3, 3, 3, 3);
@@ -41,7 +41,7 @@ MemoryBrowsePanel::MemoryBrowsePanel(QWidget* parent)
     m_emptyLabel = new QLabel("No memories are available yet.", this);
     m_emptyLabel->setAlignment(Qt::AlignCenter);
     m_emptyLabel->setWordWrap(true);
-    m_emptyLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 12px; padding: 12px 8px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_emptyLabel, "QLabel { color: {{color.text.label}}; font-size: 12px; padding: 12px 8px; }");
     root->addWidget(m_emptyLabel, 1);
 
     m_table = new QTableWidget(0, 2, this);
@@ -61,13 +61,13 @@ MemoryBrowsePanel::MemoryBrowsePanel(QWidget* parent)
     m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
     m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
     m_table->setColumnWidth(0, 96);
-    m_table->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTableWidget { background: #0f1720; border: 1px solid {{color.background.1}}; border-radius: 2px; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_table, "QTableWidget { background: #0f1720; border: 1px solid {{color.background.1}}; border-radius: 2px; "
         "color: #d2dbe4; selection-background-color: #2060a0; selection-color: {{color.text.primary}}; }"
         "QHeaderView::section { background: #101b26; color: #70879b; border: none; "
         "border-bottom: 1px solid {{color.background.1}}; font-size: 11px; font-weight: bold; padding: 4px 3px; }"
         "QScrollBar:vertical { background: {{color.background.0}}; width: 6px; }"
         "QScrollBar::handle:vertical { background: {{color.background.2}}; border-radius: 3px; }"
-        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }"));
+        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }");
     root->addWidget(m_table, 1);
     m_table->hide();
 
@@ -76,11 +76,11 @@ MemoryBrowsePanel::MemoryBrowsePanel(QWidget* parent)
     // Style matches the spectrum overlay menu buttons it replaces.
     m_addBtn = new QPushButton(QStringLiteral("Add Memory"), this);
     m_addBtn->setFixedHeight(22);
-    m_addBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: rgba(20, 30, 45, 240); "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_addBtn, "QPushButton { background: rgba(20, 30, 45, 240); "
         "border: 1px solid rgba(255, 255, 255, 40); border-radius: 2px; "
         "color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }"
         "QPushButton:hover { background: rgba(0, 112, 192, 180); "
-        "border: 1px solid {{color.accent.dim}}; }"));
+        "border: 1px solid {{color.accent.dim}}; }");
     m_addBtn->setToolTip("Save the current slice on this panadapter as a memory.");
     root->addWidget(m_addBtn, 0);
     connect(m_addBtn, &QPushButton::clicked, this,

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -264,8 +264,8 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     m_table->setSortingEnabled(false);
     m_table->installEventFilter(this);
     m_table->viewport()->installEventFilter(this);
-    m_table->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTableWidget { alternate-background-color: {{color.background.0}}; }"
-        "QTableWidget::item:selected { background: #2060a0; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_table, "QTableWidget { alternate-background-color: {{color.background.0}}; }"
+        "QTableWidget::item:selected { background: #2060a0; }");
     auto* header = m_table->horizontalHeader();
     header->setSectionsClickable(true);
     header->setSortIndicatorShown(false);

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -40,7 +40,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
       m_manager(manager)
 {
     setMinimumSize(700, 550);
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; }");
 
     auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(8);
@@ -70,14 +70,14 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
                 m_manager->closePort();
                 m_connectBtn->setText("Connect");
                 m_statusLabel->setText("Disconnected");
-                m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+                AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
             } else {
                 int idx = m_portCombo->currentIndex();
                 if (idx < 0) return;
                 if (m_manager->openPort(idx)) {
                     m_connectBtn->setText("Disconnect");
                     m_statusLabel->setText("Connected: " + m_manager->currentPortName());
-                    m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.success}}; font-size: 11px; }"));
+                    AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.accent.success}}; font-size: 11px; }");
                     // Save device preference
                     auto& ms = MidiSettings::instance();
                     ms.setLastDevice(m_manager->currentPortName());
@@ -95,11 +95,11 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         grid->addWidget(m_statusLabel, 1, 0, 1, 2);
 
         m_activityLabel = new QLabel("");
-        m_activityLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 10px; font-family: monospace; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_activityLabel, "QLabel { color: {{color.accent}}; font-size: 10px; font-family: monospace; }");
         grid->addWidget(m_activityLabel, 1, 2, 1, 2);
 
         auto* autoConnect = new QCheckBox("Auto-connect on startup");
-        autoConnect->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(autoConnect, "QCheckBox { color: {{color.text.primary}}; }");
         autoConnect->setChecked(MidiSettings::instance().autoConnect());
         connect(autoConnect, &QCheckBox::toggled, this, [](bool on) {
             MidiSettings::instance().setAutoConnect(on);
@@ -129,11 +129,11 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         m_bindingTable->setSelectionBehavior(QAbstractItemView::SelectRows);
         m_bindingTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
         m_bindingTable->verticalHeader()->setVisible(false);
-        m_bindingTable->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTableWidget { background: {{color.background.0}}; color: {{color.text.primary}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_bindingTable, "QTableWidget { background: {{color.background.0}}; color: {{color.text.primary}}; "
             "border: 1px solid {{color.background.1}}; font-size: 11px; gridline-color: {{color.background.1}}; }"
             "QTableWidget::item:selected { background: {{color.accent}}; color: {{color.background.0}}; }"
             "QHeaderView::section { background: {{color.background.0}}; color: {{color.text.secondary}}; "
-            "border: 1px solid {{color.background.1}}; padding: 3px; font-size: 11px; }"));
+            "border: 1px solid {{color.background.1}}; padding: 3px; font-size: 11px; }");
         vbox->addWidget(m_bindingTable, 1);
 
         // Add binding row

--- a/src/gui/MqttApplet.cpp
+++ b/src/gui/MqttApplet.cpp
@@ -51,15 +51,15 @@ void MqttApplet::buildUI()
 
     auto* headerRow = new QHBoxLayout;
     auto* header = new QLabel("MQTT");
-    header->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(header, "QLabel { color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }");
     headerRow->addWidget(header);
     headerRow->addStretch();
 
     auto* settingsBtn = new QPushButton("Settings...");
     settingsBtn->setFixedHeight(18);
-    settingsBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: transparent; color: {{color.text.secondary}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(settingsBtn, "QPushButton { background: transparent; color: {{color.text.secondary}}; "
         "border: none; font-size: 9px; padding: 0 4px; }"
-        "QPushButton:hover { color: {{color.text.primary}}; }"));
+        "QPushButton:hover { color: {{color.text.primary}}; }");
     headerRow->addWidget(settingsBtn);
     vbox->addLayout(headerRow);
 
@@ -67,7 +67,7 @@ void MqttApplet::buildUI()
 
     auto* note = new QLabel("Antenna alias topics are subscribed automatically.");
     note->setWordWrap(true);
-    note->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; background: transparent; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(note, "QLabel { color: {{color.text.secondary}}; font-size: 10px; background: transparent; }");
     vbox->addWidget(note);
 
     auto* ctrlRow = new QHBoxLayout;
@@ -78,12 +78,12 @@ void MqttApplet::buildUI()
     ctrlRow->addWidget(m_enableBtn);
 
     m_statusLabel = new QLabel("Disconnected");
-    m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.text.secondary}}; font-size: 10px; }");
     ctrlRow->addWidget(m_statusLabel, 1);
     vbox->addLayout(ctrlRow);
 
     auto* pubLbl = new QLabel("Publish");
-    pubLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(pubLbl, "QLabel { color: {{color.text.secondary}}; font-size: 10px; font-weight: bold; }");
     vbox->addWidget(pubLbl);
 
     auto* btnContainer = new QWidget;
@@ -96,8 +96,8 @@ void MqttApplet::buildUI()
     m_messageLog = new QTextEdit;
     m_messageLog->setReadOnly(true);
     m_messageLog->setMaximumHeight(95);
-    m_messageLog->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTextEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; "
-        "font-size: 10px; font-family: monospace; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_messageLog, "QTextEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; "
+        "font-size: 10px; font-family: monospace; }");
     vbox->addWidget(m_messageLog);
 
     connect(m_enableBtn, &QPushButton::clicked, this, [this] {

--- a/src/gui/MultiFlexDialog.cpp
+++ b/src/gui/MultiFlexDialog.cpp
@@ -45,7 +45,7 @@ MultiFlexDialog::MultiFlexDialog(RadioModel* model, QWidget* parent)
     // Title
     auto* title = new QLabel("multiFLEX Stations");
     title->setAlignment(Qt::AlignCenter);
-    title->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { font-size: 16px; font-weight: bold; color: {{color.text.primary}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(title, "QLabel { font-size: 16px; font-weight: bold; color: {{color.text.primary}}; }");
     root->addWidget(title);
 
     // Enable/disable button
@@ -80,7 +80,7 @@ MultiFlexDialog::MultiFlexDialog(RadioModel* model, QWidget* parent)
     auto* pttRow = new QHBoxLayout;
     pttRow->addStretch();
     m_pttLabel = new QLabel;
-    m_pttLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_pttLabel, "QLabel { color: {{color.text.secondary}}; }");
     pttRow->addWidget(m_pttLabel);
     m_pttBtn = new QPushButton("Enable");
     connect(m_pttBtn, &QPushButton::clicked, this, [this]() {

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -863,7 +863,7 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     auto makeNote = [](const QString& text) {
         auto* l = new QLabel(text);
         l->setWordWrap(true);
-        l->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; line-height: 1.1; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(l, "QLabel { color: {{color.text.secondary}}; font-size: 10px; line-height: 1.1; }");
         return l;
     };
 
@@ -874,10 +874,10 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
         auto* value = new QLabel("--");
         value->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
         value->setMinimumHeight(value->fontMetrics().height() + 4);
-        value->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-weight: 700; font-size: 18px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(value, "QLabel { color: {{color.text.primary}}; font-weight: 700; font-size: 18px; }");
         auto* hint = new QLabel(subtitle);
         hint->setWordWrap(true);
-        hint->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(hint, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
         layout->addWidget(value);
         layout->addWidget(hint);
         layout->addStretch();
@@ -1087,7 +1087,7 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     m_audioStreamsDetailLabel->setWordWrap(true);
     m_audioStreamsDetailLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     m_audioStreamsDetailLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
-    m_audioStreamsDetailLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_audioStreamsDetailLabel, "QLabel { color: {{color.text.secondary}}; font-size: 10px; }");
     m_audioStreamsDetailLabel->setToolTip(
         "The radio normally sends one mixed PC speaker stream. Use the Audio tab for per-stream timing rows.");
     audioGrid->addWidget(m_audioStreamsDetailLabel, row++, 1);
@@ -1160,7 +1160,7 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
                 "each row below is shown separately; slice letters list the unmuted slices feeding the speaker mix.",
                 audioPage);
             audioNote->setWordWrap(true);
-            audioNote->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(audioNote, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
             audioLayout->insertWidget(0, audioNote);
 
             m_audioStreamsTable = new QTableWidget(0, 9, audioPage);
@@ -1288,16 +1288,16 @@ QWidget* NetworkDiagnosticsDialog::buildTciTab()
         "client has subscribed to. You can type your own label in the "
         "Name column — it is saved locally, keyed by IP address.");
     intro->setWordWrap(true);
-    intro->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(intro, "QLabel { color: {{color.text.secondary}}; }");
     layout->addWidget(intro);
 
     auto* clientsHdr = new QLabel(QStringLiteral("Connected clients"));
-    clientsHdr->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-weight: bold; "
-        "letter-spacing: 0.06em; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(clientsHdr, "QLabel { color: {{color.text.secondary}}; font-weight: bold; "
+        "letter-spacing: 0.06em; }");
     layout->addWidget(clientsHdr);
 
     m_tciClientSummary = new QLabel;
-    m_tciClientSummary->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_tciClientSummary, "QLabel { color: {{color.text.primary}}; font-weight: bold; }");
     layout->addWidget(m_tciClientSummary);
 
     m_tciClientTable = new QTableWidget(0, 7, this);
@@ -1320,11 +1320,11 @@ QWidget* NetworkDiagnosticsDialog::buildTciTab()
     hh->setSectionResizeMode(2, QHeaderView::Stretch);            // Likely role
     for (int c = 3; c < 7; ++c)
         hh->setSectionResizeMode(c, QHeaderView::ResizeToContents);
-    m_tciClientTable->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTableWidget { background: {{color.background.0}}; color: {{color.text.primary}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_tciClientTable, "QTableWidget { background: {{color.background.0}}; color: {{color.text.primary}}; "
         "gridline-color: {{color.background.1}}; border: 1px solid {{color.background.1}}; }"
         "QTableWidget::item:selected { background: #173049; }"
         "QHeaderView::section { background: {{color.background.0}}; color: {{color.text.secondary}}; "
-        "border: 1px solid {{color.background.1}}; padding: 3px 6px; font-weight: bold; }"));
+        "border: 1px solid {{color.background.1}}; padding: 3px 6px; font-weight: bold; }");
     // Keep the roster compact (~6 rows then scroll) so the monitor below
     // gets the bulk of the page.
     m_tciClientTable->setSizePolicy(QSizePolicy::Expanding,
@@ -1355,8 +1355,8 @@ QWidget* NetworkDiagnosticsDialog::buildTciTab()
 
     // ── Live traffic monitor ──────────────────────────────────────────────
     auto* monHdr = new QLabel(QStringLiteral("TCI traffic monitor"));
-    monHdr->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-weight: bold; "
-        "letter-spacing: 0.06em; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(monHdr, "QLabel { color: {{color.text.secondary}}; font-weight: bold; "
+        "letter-spacing: 0.06em; }");
     layout->addWidget(monHdr);
 
     auto* mHelp = new QLabel(QStringLiteral(
@@ -1364,7 +1364,7 @@ QWidget* NetworkDiagnosticsDialog::buildTciTab()
         "to suppress all messages of that command — same as the standalone "
         "TCI Monitor."));
     mHelp->setWordWrap(true);
-    mHelp->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(mHelp, "QLabel { color: {{color.text.secondary}}; }");
     layout->addWidget(mHelp);
 
     const QString btnStyle = QStringLiteral(
@@ -1439,12 +1439,12 @@ QWidget* NetworkDiagnosticsDialog::buildTciTab()
     m_tciLogTable->horizontalHeader()->setStretchLastSection(true);
     m_tciLogTable->setColumnWidth(0, 96);
     m_tciLogTable->setColumnWidth(1, 150);
-    m_tciLogTable->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTableWidget { background: #07070e; color: #dde6f0; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_tciLogTable, "QTableWidget { background: #07070e; color: #dde6f0; "
         "border: 1px solid {{color.background.1}}; font-family: Consolas, monospace; "
         "font-size: 11px; gridline-color: transparent; }"
         "QTableWidget::item:selected { background: #173049; }"
         "QHeaderView::section { background: {{color.background.0}}; color: {{color.text.secondary}}; "
-        "border: 1px solid {{color.background.1}}; padding: 2px 6px; }"));
+        "border: 1px solid {{color.background.1}}; padding: 2px 6px; }");
     m_tciLogTable->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_tciLogTable, &QTableWidget::customContextMenuRequested,
             this, &NetworkDiagnosticsDialog::onTciLogContextMenu);
@@ -1775,7 +1775,7 @@ QWidget* NetworkDiagnosticsDialog::buildLogsTab()
     auto* infoRow = new QHBoxLayout;
     m_logPathLabel = new QLabel(page);
     m_logPathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    m_logPathLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_logPathLabel, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
     infoRow->addWidget(m_logPathLabel, 1);
 
     m_logLiveToggle = new QPushButton("Live", page);
@@ -2656,7 +2656,7 @@ void NetworkDiagnosticsDialog::refresh()
         m_audioFeedDeficitLabel->setText("Unavailable");
         m_audioLateGapLabel->setText("Unavailable");
         m_audioStreamHealthLabel->setText("Unavailable");
-        m_audioStreamHealthLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-weight: 700; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_audioStreamHealthLabel, "QLabel { color: {{color.text.secondary}}; font-weight: 700; }");
         m_audioStreamsDetailLabel->setText("Unavailable");
         updateAudioStreamTable(m_audioStreamsTable, m_model, {});
         m_overviewAudioValue->setText("Unavailable");
@@ -2671,14 +2671,14 @@ void NetworkDiagnosticsDialog::refresh()
         m_statusLabel->setStyleSheet("QLabel { color: #80ed91; font-weight: 700; }");
         m_overviewStatusValue->setStyleSheet("QLabel { color: #80ed91; font-weight: 700; font-size: 18px; }");
     } else if (q == "Fair") {
-        m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.warning}}; font-weight: 700; }"));
-        m_overviewStatusValue->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.warning}}; font-weight: 700; font-size: 18px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.accent.warning}}; font-weight: 700; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_overviewStatusValue, "QLabel { color: {{color.accent.warning}}; font-weight: 700; font-size: 18px; }");
     } else if (q == "Poor") {
-        m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.danger}}; font-weight: 700; }"));
-        m_overviewStatusValue->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.danger}}; font-weight: 700; font-size: 18px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.accent.danger}}; font-weight: 700; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_overviewStatusValue, "QLabel { color: {{color.accent.danger}}; font-weight: 700; font-size: 18px; }");
     } else {
-        m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-weight: 700; }"));
-        m_overviewStatusValue->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-weight: 700; font-size: 18px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.text.primary}}; font-weight: 700; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_overviewStatusValue, "QLabel { color: {{color.text.primary}}; font-weight: 700; font-size: 18px; }");
     }
 
     updateCharts();

--- a/src/gui/PanLayoutDialog.cpp
+++ b/src/gui/PanLayoutDialog.cpp
@@ -110,8 +110,8 @@ PanLayoutDialog::PanLayoutDialog(int maxPans, const QString& currentLayout,
                                  QWidget* parent)
     : PersistentDialog("Panadapter Layout", /*geomKey*/ QString(), parent)
 {
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; }"
-                  "QLabel { color: {{color.text.primary}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; }"
+                  "QLabel { color: {{color.text.primary}}; }");
     // Fixed-size grid of thumbnails — body content is the same regardless of
     // chrome state; the dialog wraps it.  Modal dialog; no geometry persist.
     bodyWidget()->setFixedSize(560, 502);
@@ -124,7 +124,7 @@ void PanLayoutDialog::buildUI(int maxPans, const QString& currentLayout)
     vbox->setSpacing(8);
 
     auto* title = new QLabel("Choose panadapter layout:");
-    title->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 13px; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(title, "QLabel { color: {{color.text.secondary}}; font-size: 13px; font-weight: bold; }");
     title->setAlignment(Qt::AlignCenter);
     vbox->addWidget(title);
 
@@ -142,9 +142,9 @@ void PanLayoutDialog::buildUI(int maxPans, const QString& currentLayout)
 
         auto* btn = new QPushButton;
         btn->setFixedSize(130, 115);
-        btn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: transparent; border: none; }"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(btn, "QPushButton { background: transparent; border: none; }"
             "QPushButton:hover { background: rgba(0, 180, 216, 30); "
-            "border: 1px solid {{color.accent}}; border-radius: 4px; }"));
+            "border: 1px solid {{color.accent}}; border-radius: 4px; }");
 
         auto* btnLayout = new QVBoxLayout(btn);
         btnLayout->setContentsMargins(4, 4, 4, 2);
@@ -176,9 +176,9 @@ void PanLayoutDialog::buildUI(int maxPans, const QString& currentLayout)
 
     auto* cancelBtn = new QPushButton("Cancel");
     cancelBtn->setFixedWidth(80);
-    cancelBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(cancelBtn, "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; padding: 4px; }"
-        "QPushButton:hover { background: {{color.background.1}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; }");
     connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
     vbox->addWidget(cancelBtn, 0, Qt::AlignCenter);
 }

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -34,9 +34,9 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     // ── Title bar (16px gradient, matching applet style) ─────────────────
     m_titleBar = new QWidget;
     m_titleBar->setFixedHeight(16);
-    m_titleBar->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_titleBar, "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
         "stop:0 {{color.text.disabled}}, stop:0.5 {{color.background.1}}, stop:1 #1a2a38); "
-        "border-bottom: 1px solid #0a1a28; }"));
+        "border-bottom: 1px solid #0a1a28; }");
     m_titleBar->installEventFilter(this);  // drag-to-move when floating
     auto* titleBar = m_titleBar;
 
@@ -46,12 +46,12 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
 
     // Drag grip dots (matching applet title bar style)
     auto* grip = new QLabel(QString::fromUtf8("\xe2\x8b\xae\xe2\x8b\xae"));
-    grip->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: transparent; color: {{color.text.label}}; font-size: 10px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(grip, "QLabel { background: transparent; color: {{color.text.label}}; font-size: 10px; }");
     barLayout->addWidget(grip);
 
     m_titleLabel = new QLabel("Slice A");
-    m_titleLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: transparent; color: {{color.text.secondary}}; "
-                                "font-size: 10px; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_titleLabel, "QLabel { background: transparent; color: {{color.text.secondary}}; "
+                                "font-size: 10px; font-weight: bold; }");
     m_titleLabel->setTextFormat(Qt::RichText);  // slice letter may be HTML (#2606)
     barLayout->addWidget(m_titleLabel);
     barLayout->addStretch();
@@ -110,7 +110,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_cwPanel->setCursor(Qt::ArrowCursor);  // prevent invisible cursor from native-window parent (#1096)
     m_cwPanel->setFixedHeight(80);
     m_cwPanel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    m_cwPanel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: {{color.background.0}}; border-top: 1px solid {{color.background.1}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_cwPanel, "QWidget { background: {{color.background.0}}; border-top: 1px solid {{color.background.1}}; }");
 
     auto* cwLayout = new QVBoxLayout(m_cwPanel);
     cwLayout->setContentsMargins(4, 2, 4, 2);
@@ -120,21 +120,21 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     auto* cwBar = new QHBoxLayout;
     cwBar->setSpacing(6);
     auto* cwTitle = new QLabel("CW");
-    cwTitle->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 10px; font-weight: bold; background: transparent; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(cwTitle, "QLabel { color: {{color.accent}}; font-size: 10px; font-weight: bold; background: transparent; }");
     cwBar->addWidget(cwTitle);
     auto* cwHint = new QLabel("(requires PC Audio)");
-    cwHint->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.meter.bar.fill}}; font-size: 9px; background: transparent; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(cwHint, "QLabel { color: {{color.meter.bar.fill}}; font-size: 9px; background: transparent; }");
     cwBar->addWidget(cwHint);
 
     m_cwStatsLabel = new QLabel;
-    m_cwStatsLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 10px; background: transparent; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_cwStatsLabel, "QLabel { color: {{color.text.label}}; font-size: 10px; background: transparent; }");
     m_cwStatsLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     m_cwStatsLabel->setFixedWidth(m_cwStatsLabel->fontMetrics().horizontalAdvance("1200 Hz  120 WPM"));
     cwBar->addWidget(m_cwStatsLabel);
 
     // Sensitivity slider — filters low-confidence decodes
     auto* sensLabel = new QLabel("Sens:");
-    sensLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 9px; background: transparent; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(sensLabel, "QLabel { color: {{color.text.label}}; font-size: 9px; background: transparent; }");
     cwBar->addWidget(sensLabel);
     m_cwSensSlider = new GuardedSlider(Qt::Horizontal);
     m_cwSensSlider->setRange(0, 100);  // 0=show everything, 100=only high confidence
@@ -160,10 +160,10 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_lockPitchBtn->setCheckable(true);
     m_lockPitchBtn->setFixedSize(28, 16);
     m_lockPitchBtn->setToolTip("Lock decoder pitch to current frequency");
-    m_lockPitchBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; color: {{color.text.label}}; border: 1px solid {{color.background.1}};"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_lockPitchBtn, "QPushButton { background: {{color.background.1}}; color: {{color.text.label}}; border: 1px solid {{color.background.1}};"
         " border-radius: 2px; font-size: 8px; padding: 0; }"
         "QPushButton:checked { color: {{color.accent}}; border-color: {{color.accent}}; }"
-        "QPushButton:hover { color: {{color.text.primary}}; }"));
+        "QPushButton:hover { color: {{color.text.primary}}; }");
     cwBar->addWidget(m_lockPitchBtn);
 
     // Lock Speed button
@@ -180,7 +180,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
         "QSlider::handle:horizontal { background: #6a8090; width: 8px; margin: -3px 0; border-radius: 4px; }";
 
     auto* minLabel = new QLabel("Lo:");
-    minLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(minLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
     cwBar->addWidget(minLabel);
 
     m_pitchMinSlider = new GuardedSlider(Qt::Horizontal);
@@ -191,12 +191,12 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_pitchMinSlider->setToolTip("Decoder pitch search minimum (Hz)");
     cwBar->addWidget(m_pitchMinSlider);
     m_pitchMinValLabel = new QLabel(QString::number(m_pitchMinSlider->value()));
-    m_pitchMinValLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_pitchMinValLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
     m_pitchMinValLabel->setFixedWidth(24);
     cwBar->addWidget(m_pitchMinValLabel);
 
     auto* maxLabel = new QLabel("Hi:");
-    maxLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(maxLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
     cwBar->addWidget(maxLabel);
 
     m_pitchMaxSlider = new GuardedSlider(Qt::Horizontal);
@@ -207,7 +207,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_pitchMaxSlider->setToolTip("Decoder pitch search maximum (Hz)");
     cwBar->addWidget(m_pitchMaxSlider);
     m_pitchMaxValLabel = new QLabel(QString::number(m_pitchMaxSlider->value()));
-    m_pitchMaxValLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_pitchMaxValLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
     m_pitchMaxValLabel->setFixedWidth(24);
     cwBar->addWidget(m_pitchMaxValLabel);
 
@@ -270,10 +270,10 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
 
     auto* closeBtn = new QPushButton("\u2715");
     closeBtn->setToolTip("Close CW decoder");
-    closeBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; color: {{color.text.secondary}}; border: 1px solid {{color.background.1}};"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(closeBtn, "QPushButton { background: {{color.background.1}}; color: {{color.text.secondary}}; border: 1px solid {{color.background.1}};"
         " border-radius: 2px; font-size: 9px; font-weight: bold;"
         " padding: 1px 6px; }"
-        "QPushButton:hover { color: #ff6060; background: {{color.background.1}}; }"));
+        "QPushButton:hover { color: #ff6060; background: {{color.background.1}}; }");
     connect(closeBtn, &QPushButton::clicked, this, [this]() {
         m_cwPanel->hide();
         emit cwPanelCloseRequested();
@@ -286,11 +286,11 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_cwText = new QTextEdit;
     m_cwText->setReadOnly(true);
     m_cwText->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    m_cwText->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTextEdit { background: {{color.background.0}}; color: {{color.accent.success}}; border: none;"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_cwText, "QTextEdit { background: {{color.background.0}}; color: {{color.accent.success}}; border: none;"
         " font-family: monospace; font-size: 13px; font-weight: bold; }"
         "QScrollBar:vertical { width: 6px; background: {{color.background.0}}; }"
         "QScrollBar::handle:vertical { background: {{color.background.2}}; border-radius: 3px; }"
-        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }"));
+        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }");
     m_cwText->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_cwText->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_cwText->setWordWrapMode(QTextOption::WrapAnywhere);

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -26,10 +26,10 @@ public:
     {
         setFlat(false);
         setFixedSize(22, 22);
-        setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
             "border-radius: 3px; padding: 0; margin: 0; min-width: 0; min-height: 0; }"
             "QPushButton:hover { background: {{color.background.1}}; }"
-            "QPushButton:pressed { background: {{color.accent}}; }"));
+            "QPushButton:pressed { background: {{color.accent}}; }");
     }
 protected:
     void paintEvent(QPaintEvent* ev) override {
@@ -109,7 +109,7 @@ void PhoneApplet::buildUI()
 
         auto* lbl = new QLabel("AM\nCarrier:");
         lbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
         lbl->setFixedWidth(52);
         row->addWidget(lbl);
         row->addSpacing(10);
@@ -129,7 +129,7 @@ void PhoneApplet::buildUI()
         m_amCarrierLabel = new QLabel("48");
         m_amCarrierLabel->setFixedWidth(26);
         m_amCarrierLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        m_amCarrierLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_amCarrierLabel, "QLabel { color: {{color.text.primary}}; font-size: 11px; }");
         row->addWidget(m_amCarrierLabel);
 
         vbox->addWidget(rowW);
@@ -170,7 +170,7 @@ void PhoneApplet::buildUI()
         m_voxLevelLabel = new QLabel("50");
         m_voxLevelLabel->setFixedWidth(26);
         m_voxLevelLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        m_voxLevelLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_voxLevelLabel, "QLabel { color: {{color.text.primary}}; font-size: 11px; }");
         row->addWidget(m_voxLevelLabel);
 
         vbox->addWidget(rowW);
@@ -186,7 +186,7 @@ void PhoneApplet::buildUI()
 
         auto* lbl = new QLabel("Delay:");
         lbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
         lbl->setFixedWidth(52);
         row->addWidget(lbl);
         row->addSpacing(10);
@@ -205,7 +205,7 @@ void PhoneApplet::buildUI()
         m_voxDelayLabel = new QLabel("50");
         m_voxDelayLabel->setFixedWidth(26);
         m_voxDelayLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        m_voxDelayLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_voxDelayLabel, "QLabel { color: {{color.text.primary}}; font-size: 11px; }");
         row->addWidget(m_voxDelayLabel);
 
         vbox->addWidget(rowW);
@@ -259,7 +259,7 @@ void PhoneApplet::buildUI()
         m_dexpLabel = new QLabel("0");
         m_dexpLabel->setFixedWidth(26);
         m_dexpLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        m_dexpLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_dexpLabel, "QLabel { color: {{color.text.primary}}; font-size: 11px; }");
         row->addWidget(m_dexpLabel);
 
         vbox->addWidget(rowW);
@@ -278,14 +278,14 @@ void PhoneApplet::buildUI()
 
         auto* lowLbl = new QLabel("Low Cut");
         lowLbl->setAlignment(Qt::AlignCenter);
-        lowLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lowLbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
         lowCol->addWidget(lowLbl);
 
         auto* lowRow = new QHBoxLayout;
         lowRow->setSpacing(2);
 
         auto* txLbl = new QLabel("TX");
-        txLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(txLbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; font-weight: bold; }");
         txLbl->setFixedWidth(18);
         lowRow->addWidget(txLbl);
 
@@ -314,8 +314,8 @@ void PhoneApplet::buildUI()
         m_lowCutLabel->setAccessibleName("TX low cut frequency");
         m_lowCutLabel->setFixedWidth(46);
         m_lowCutLabel->setAlignment(Qt::AlignCenter);
-        m_lowCutLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { font-size: 11px; color: {{color.text.primary}}; background: {{color.background.0}}; "
-            "border: 1px solid {{color.background.1}}; border-radius: 3px; padding: 1px 3px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_lowCutLabel, "QLabel { font-size: 11px; color: {{color.text.primary}}; background: {{color.background.0}}; "
+            "border: 1px solid {{color.background.1}}; border-radius: 3px; padding: 1px 3px; }");
         connect(m_lowCutLabel, &ScrollableLabel::scrolled, this,
                 [lowCutUp, lowCutDown](int dir) {
             if (dir > 0) lowCutUp(); else lowCutDown();
@@ -338,7 +338,7 @@ void PhoneApplet::buildUI()
 
         auto* highLbl = new QLabel("High Cut");
         highLbl->setAlignment(Qt::AlignCenter);
-        highLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(highLbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
         highCol->addWidget(highLbl);
 
         auto* highRow = new QHBoxLayout;
@@ -365,8 +365,8 @@ void PhoneApplet::buildUI()
         m_highCutLabel->setAccessibleName("TX high cut frequency");
         m_highCutLabel->setFixedWidth(46);
         m_highCutLabel->setAlignment(Qt::AlignCenter);
-        m_highCutLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { font-size: 11px; color: {{color.text.primary}}; background: {{color.background.0}}; "
-            "border: 1px solid {{color.background.1}}; border-radius: 3px; padding: 1px 3px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_highCutLabel, "QLabel { font-size: 11px; color: {{color.text.primary}}; background: {{color.background.0}}; "
+            "border: 1px solid {{color.background.1}}; border-radius: 3px; padding: 1px 3px; }");
         connect(m_highCutLabel, &ScrollableLabel::scrolled, this,
                 [highCutUp, highCutDown](int dir) {
             if (dir > 0) highCutUp(); else highCutDown();

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -34,10 +34,10 @@ public:
     {
         setFlat(false);
         setFixedSize(22, 22);
-        setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
             "border-radius: 3px; padding: 0; margin: 0; min-width: 0; min-height: 0; }"
             "QPushButton:hover { background: {{color.background.1}}; }"
-            "QPushButton:pressed { background: {{color.accent}}; }"));
+            "QPushButton:pressed { background: {{color.accent}}; }");
     }
 protected:
     void paintEvent(QPaintEvent* ev) override {
@@ -392,7 +392,7 @@ void PhoneCwApplet::buildCwPanel()
         row->setSpacing(4);
 
         auto* lbl = new QLabel("Delay:");
-        lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
         lbl->setFixedWidth(kLeftColW);
         row->addWidget(lbl);
 
@@ -437,7 +437,7 @@ void PhoneCwApplet::buildCwPanel()
         row->setSpacing(4);
 
         auto* lbl = new QLabel("Speed:");
-        lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
         lbl->setFixedWidth(kLeftColW);
         row->addWidget(lbl);
 
@@ -587,7 +587,7 @@ void PhoneCwApplet::buildCwPanel()
 
         // Pitch: label + < value > stepper (inset display matching RIT/XIT style)
         auto* pitchLbl = new QLabel("Pitch:");
-        pitchLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(pitchLbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
         row->addWidget(pitchLbl);
 
         m_pitchDown = new CwTriBtn(CwTriBtn::Left);
@@ -600,9 +600,9 @@ void PhoneCwApplet::buildCwPanel()
         m_pitchEdit->setAccessibleName("CW pitch frequency");
         m_pitchEdit->setAccessibleDescription("CW sidetone pitch in Hz, 100 to 6000");
         m_pitchEdit->setValidator(new QIntValidator(100, 6000, m_pitchEdit));
-        m_pitchEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { font-size: 11px; background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_pitchEdit, "QLineEdit { font-size: 11px; background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
             "border-radius: 3px; padding: 1px 3px; color: {{color.text.primary}}; }"
-            "QLineEdit:focus { border: 1px solid {{color.accent}}; }"));
+            "QLineEdit:focus { border: 1px solid {{color.accent}}; }");
         row->addWidget(m_pitchEdit);
 
         m_pitchUp = new CwTriBtn(CwTriBtn::Right);

--- a/src/gui/PropDashboardDialog.cpp
+++ b/src/gui/PropDashboardDialog.cpp
@@ -519,7 +519,7 @@ PropDashboardDialog::PropDashboardDialog(PropForecastClient* client, QWidget* pa
         ++row;
         auto* sep = new QLabel;
         sep->setFixedHeight(1);
-        sep->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.1}}; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(sep, "QLabel { background: {{color.background.1}}; }");
         g->addWidget(sep, row, 0, 1, 4);
 
         ++row;
@@ -553,14 +553,14 @@ PropDashboardDialog::PropDashboardDialog(PropForecastClient* client, QWidget* pa
         m_rationale = new QLabel;
         m_rationale->setWordWrap(true);
         m_rationale->setText("Forecast rationale will appear when NOAA publishes the current discussion.");
-        m_rationale->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel {"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_rationale, "QLabel {"
             " color: #9cb0c0;"
             " font-size: 10px;"
             " background: #0f1d2b;"
             " border: 1px solid {{color.background.1}};"
             " border-radius: 10px;"
             " padding: 8px;"
-            "}"));
+            "}");
         g->addWidget(m_rationale, row, 0, 1, 4);
 
         row1->addWidget(group, 3);
@@ -613,11 +613,11 @@ PropDashboardDialog::PropDashboardDialog(PropForecastClient* client, QWidget* pa
 
         auto* learnPanel = new QFrame;
         learnPanel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-        learnPanel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QFrame {"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(learnPanel, "QFrame {"
             " background: {{color.background.0}};"
             " border: 1px solid #22384d;"
             " border-radius: 10px;"
-            "}"));
+            "}");
         auto* learnLayout = new QVBoxLayout(learnPanel);
         learnLayout->setContentsMargins(10, 10, 10, 10);
         learnLayout->setSpacing(8);
@@ -746,11 +746,11 @@ PropDashboardDialog::PropDashboardDialog(PropForecastClient* client, QWidget* pa
         note->setStyleSheet(kMutedStyle);
 
         auto* learnPanel = new QFrame;
-        learnPanel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QFrame {"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(learnPanel, "QFrame {"
             " background: {{color.background.0}};"
             " border: 1px solid #22384d;"
             " border-radius: 10px;"
-            "}"));
+            "}");
         auto* learnLayout = new QVBoxLayout(learnPanel);
         learnLayout->setContentsMargins(10, 10, 10, 10);
         learnLayout->setSpacing(8);

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -252,9 +252,9 @@ static void showCopiedPopup(QWidget* anchor)
                              Qt::ToolTip | Qt::FramelessWindowHint);
     popup->setAttribute(Qt::WA_DeleteOnClose);
     popup->setAttribute(Qt::WA_ShowWithoutActivating);
-    popup->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.0}}; border: 1px solid {{color.background.2}};"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(popup, "QLabel { background: {{color.background.0}}; border: 1px solid {{color.background.2}};"
         " border-radius: 4px; color: {{color.text.primary}}; font-size: 11px;"
-        " font-weight: bold; padding: 4px 8px; }"));
+        " font-weight: bold; padding: 4px 8px; }");
     popup->adjustSize();
 
     const QPoint globalCenter = anchor->mapToGlobal(anchor->rect().center());
@@ -423,17 +423,17 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
       m_tgxl(tgxl), m_pgxl(pgxl), m_ag(ag)
 {
     setMinimumSize(820, 620);
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; }");
 
     auto* layout = new QVBoxLayout(bodyWidget());
 
     auto* tabs = new QTabWidget;
     m_tabs = tabs;
-    tabs->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTabWidget::pane { border: 1px solid {{color.background.2}}; background: {{color.background.0}}; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(tabs, "QTabWidget::pane { border: 1px solid {{color.background.2}}; background: {{color.background.0}}; }"
         "QTabBar::tab { background: {{color.background.1}}; color: {{color.text.secondary}}; "
         "border: 1px solid {{color.background.2}}; padding: 4px 12px; margin-right: 2px; }"
         "QTabBar::tab:selected { background: {{color.background.0}}; color: {{color.text.primary}}; "
-        "border-bottom-color: {{color.background.0}}; }"));
+        "border-bottom-color: {{color.background.0}}; }");
 
     // Build only the default (Radio) tab eagerly; defer the rest until first
     // selected.  This avoids hardware-probing calls (QSerialPortInfo,
@@ -476,9 +476,9 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
     layout->addWidget(tabs);
 
     auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close);
-    buttons->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(buttons, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; padding: 4px 16px; }"
-        "QPushButton:hover { background: {{color.background.1}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; }");
     connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::close);
     layout->addWidget(buttons);
 }
@@ -536,9 +536,9 @@ QWidget* RadioSetupDialog::buildRadioTab()
                         0, 0);
 
         m_regionLabel = new QLabel(m_model->region().isEmpty() ? "USA" : m_model->region());
-        m_regionLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_regionLabel, "QLabel { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.accent.bright}}; font-size: 11px; font-weight: bold; "
-            "padding: 3px 10px; }"));
+            "padding: 3px 10px; }");
         m_regionLabel->setAlignment(Qt::AlignCenter);
         grid->addWidget(makeInfoField(QStringLiteral("Region:"), m_regionLabel,
                                       kInfoRightLabelWidth),
@@ -754,9 +754,9 @@ QWidget* RadioSetupDialog::buildRadioTab()
         m_fwProgress->setValue(0);
         m_fwProgress->setTextVisible(true);
         m_fwProgress->setFixedHeight(20);
-        m_fwProgress->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QProgressBar { text-align: center; font-size: 11px; color: {{color.text.primary}};"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_fwProgress, "QProgressBar { text-align: center; font-size: 11px; color: {{color.text.primary}};"
             " background: {{color.background.1}}; border: 1px solid #2e4e6e; border-radius: 3px; }"
-            "QProgressBar::chunk { background: {{color.accent}}; }"));
+            "QProgressBar::chunk { background: {{color.accent}}; }");
         m_fwProgress->hide();
         vlay->addWidget(m_fwProgress);
 
@@ -769,9 +769,9 @@ QWidget* RadioSetupDialog::buildRadioTab()
         // Button row
         auto* btnRow = new QHBoxLayout;
         auto* checkBtn = new QPushButton("Check for Update");
-        checkBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid #2e4e6e;"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(checkBtn, "QPushButton { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid #2e4e6e;"
             " border-radius: 3px; padding: 4px 8px; }"
-            "QPushButton:hover { background: {{color.background.1}}; }"));
+            "QPushButton:hover { background: {{color.background.1}}; }");
         btnRow->addWidget(checkBtn);
 
         auto* browseBtn = new QPushButton("Select Installer...");
@@ -780,10 +780,10 @@ QWidget* RadioSetupDialog::buildRadioTab()
 
         m_fwUploadBtn = new QPushButton("Upload Firmware");
         m_fwUploadBtn->setEnabled(false);
-        m_fwUploadBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #1a3a1a; color: #80e080; border: 1px solid #2e6e2e;"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_fwUploadBtn, "QPushButton { background: #1a3a1a; color: #80e080; border: 1px solid #2e6e2e;"
             " border-radius: 3px; padding: 4px 8px; }"
             "QPushButton:hover { background: #2a4a2a; }"
-            "QPushButton:disabled { background: #1a1a2a; color: {{color.meter.bar.fill}}; border-color: {{color.background.1}}; }"));
+            "QPushButton:disabled { background: #1a1a2a; color: {{color.meter.bar.fill}}; border-color: {{color.background.1}}; }");
         btnRow->addWidget(m_fwUploadBtn);
         vlay->addLayout(btnRow);
 
@@ -942,7 +942,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
         auto* hdr = new QHBoxLayout;
         hdr->addStretch(1);
         auto* modelLbl = new QLabel(m_model->model());
-        modelLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(modelLbl, "QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }");
         hdr->addWidget(modelLbl);
         vbox->addLayout(hdr);
     }
@@ -994,11 +994,11 @@ QWidget* RadioSetupDialog::buildNetworkTab()
         auto* enforceBtn = new QPushButton(m_model->enforcePrivateIp() ? "Enabled" : "Disabled");
         enforceBtn->setCheckable(true);
         enforceBtn->setChecked(m_model->enforcePrivateIp());
-        enforceBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(enforceBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; font-weight: bold; "
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
-            "border: 1px solid #20a040; }"));
+            "border: 1px solid #20a040; }");
         connect(enforceBtn, &QPushButton::toggled, this, [this, enforceBtn](bool on) {
             enforceBtn->setText(on ? "Enabled" : "Disabled");
             m_model->sendCommand(
@@ -1050,11 +1050,11 @@ QGroupBox* RadioSetupDialog::buildIpConfigGroup()
     auto* dhcpBtn = new QPushButton("DHCP");
     dhcpBtn->setCheckable(true);
     dhcpBtn->setChecked(!isStatic);
-    dhcpBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(dhcpBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; font-weight: bold; "
         "padding: 4px 16px; }"
         "QPushButton:checked { background: {{color.background.2}}; color: {{color.text.primary}}; "
-        "border: 1px solid {{color.accent.dim}}; }"));
+        "border: 1px solid {{color.accent.dim}}; }");
     btnRow->addWidget(dhcpBtn);
 
     auto* staticBtn = new QPushButton("Static");
@@ -1094,10 +1094,10 @@ QGroupBox* RadioSetupDialog::buildIpConfigGroup()
 
     auto* applyBtn = new QPushButton("Apply");
     applyBtn->setEnabled(false);
-    applyBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(applyBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; font-weight: bold; "
         "padding: 4px 16px; }"
-        "QPushButton:hover { background: {{color.background.1}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; }");
     gvbox->addWidget(applyBtn, 0, Qt::AlignLeft);
 
     connect(dhcpBtn, &QPushButton::clicked, this,
@@ -1145,7 +1145,7 @@ QWidget* RadioSetupDialog::buildGpsTab()
         auto* hdr = new QHBoxLayout;
         hdr->addStretch(1);
         auto* modelLbl = new QLabel(m_model->model());
-        modelLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(modelLbl, "QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }");
         hdr->addWidget(modelLbl);
         vbox->addLayout(hdr);
     }
@@ -1206,7 +1206,7 @@ QWidget* RadioSetupDialog::buildTxTab()
         auto* hdr = new QHBoxLayout;
         hdr->addStretch(1);
         auto* modelLbl = new QLabel(m_model->model());
-        modelLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(modelLbl, "QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }");
         hdr->addWidget(modelLbl);
         vbox->addLayout(hdr);
     }
@@ -1270,10 +1270,10 @@ QWidget* RadioSetupDialog::buildTxTab()
 
         // TX Band Settings button
         auto* bandSetBtn = new QPushButton("TX Band Settings");
-        bandSetBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(bandSetBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; font-weight: bold; "
             "padding: 4px 12px; }"
-            "QPushButton:hover { background: {{color.background.1}}; }"));
+            "QPushButton:hover { background: {{color.background.1}}; }");
         connect(bandSetBtn, &QPushButton::clicked, this, [this] {
             emit txBandSettingsRequested();
         });
@@ -1354,11 +1354,11 @@ QWidget* RadioSetupDialog::buildTxTab()
         auto* swBtn = new QPushButton(tx.showTxInWaterfall() ? "Enabled" : "Disabled");
         swBtn->setCheckable(true);
         swBtn->setChecked(tx.showTxInWaterfall());
-        swBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(swBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; font-weight: bold; "
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
-            "border: 1px solid #20a040; }"));
+            "border: 1px solid #20a040; }");
         connect(swBtn, &QPushButton::toggled, this, [this, swBtn](bool on) {
             swBtn->setText(on ? "Enabled" : "Disabled");
             m_model->sendCommand(
@@ -1437,7 +1437,7 @@ QWidget* RadioSetupDialog::buildPhoneCwTab()
         auto* hdr = new QHBoxLayout;
         hdr->addStretch(1);
         auto* modelLbl = new QLabel(m_model->model());
-        modelLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(modelLbl, "QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }");
         hdr->addWidget(modelLbl);
         vbox->addLayout(hdr);
     }
@@ -1626,7 +1626,7 @@ QWidget* RadioSetupDialog::buildRxTab()
         auto* hdr = new QHBoxLayout;
         hdr->addStretch(1);
         auto* modelLbl = new QLabel(m_model->model());
-        modelLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(modelLbl, "QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }");
         hdr->addWidget(modelLbl);
         vbox->addLayout(hdr);
     }
@@ -1674,7 +1674,7 @@ QWidget* RadioSetupDialog::buildRxTab()
         startBtn->setStyleSheet(kTogStyle);
         startBtn->setFixedWidth(60);
         auto* calStatus = new QLabel;
-        calStatus->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(calStatus, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
         calStatus->setMinimumWidth(130);
 
         auto calibrationActive = std::make_shared<bool>(false);
@@ -1733,7 +1733,7 @@ QWidget* RadioSetupDialog::buildRxTab()
                     }
                     if (code == 0) {
                         statusGuard->setText("Calibrating...");
-                        statusGuard->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 11px; }"));
+                        AetherSDR::ThemeManager::instance().applyStyleSheet(statusGuard, "QLabel { color: {{color.accent.bright}}; font-size: 11px; }");
                         qCDebug(lcProtocol)
                             << "RadioSetupDialog: radio pll_start accepted";
                         return;
@@ -1819,7 +1819,7 @@ QWidget* RadioSetupDialog::buildRxTab()
             if (pllDone == QStringLiteral("0")) {
                 *pllRunningSeen = true;
                 calStatus->setText("Calibrating...");
-                calStatus->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 11px; }"));
+                AetherSDR::ThemeManager::instance().applyStyleSheet(calStatus, "QLabel { color: {{color.accent.bright}}; font-size: 11px; }");
                 return;
             }
 
@@ -1838,7 +1838,7 @@ QWidget* RadioSetupDialog::buildRxTab()
                 calStatus->setText(freqError.isEmpty()
                     ? QStringLiteral("Complete")
                     : QStringLiteral("Complete (%1 ppb)").arg(freqError));
-                calStatus->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.success}}; font-size: 11px; }"));
+                AetherSDR::ThemeManager::instance().applyStyleSheet(calStatus, "QLabel { color: {{color.accent.success}}; font-size: 11px; }");
                 qCDebug(lcProtocol)
                     << "RadioSetupDialog: frequency calibration completed"
                     << "freq_error_ppb=" << freqError
@@ -1951,9 +1951,9 @@ QWidget* RadioSetupDialog::buildAudioTab()
     lineoutMute->setCheckable(true);
     lineoutMute->setChecked(m_model->lineoutMute());
     lineoutMute->setFixedWidth(50);
-    lineoutMute->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(lineoutMute, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; padding: 2px; }"
-        "QPushButton:checked { background: #8b0000; color: {{color.text.primary}}; }"));
+        "QPushButton:checked { background: #8b0000; color: {{color.text.primary}}; }");
     lineoutRow->addWidget(lineoutLabel);
     lineoutRow->addWidget(lineoutSlider, 1);
     lineoutRow->addWidget(lineoutValue);
@@ -1981,9 +1981,9 @@ QWidget* RadioSetupDialog::buildAudioTab()
     hpMute->setCheckable(true);
     hpMute->setChecked(m_model->headphoneMute());
     hpMute->setFixedWidth(50);
-    hpMute->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(hpMute, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; padding: 2px; }"
-        "QPushButton:checked { background: #8b0000; color: {{color.text.primary}}; }"));
+        "QPushButton:checked { background: #8b0000; color: {{color.text.primary}}; }");
     hpRow->addWidget(hpLabel);
     hpRow->addWidget(hpSlider, 1);
     hpRow->addWidget(hpValue);
@@ -2008,9 +2008,9 @@ QWidget* RadioSetupDialog::buildAudioTab()
         spkMute->setCheckable(true);
         spkMute->setChecked(m_model->frontSpeakerMute());
         spkMute->setFixedWidth(50);
-        spkMute->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(spkMute, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; padding: 2px; }"
-            "QPushButton:checked { background: #8b0000; color: {{color.text.primary}}; }"));
+            "QPushButton:checked { background: #8b0000; color: {{color.text.primary}}; }");
         spkRow->addWidget(spkLabel);
         spkRow->addStretch(1);
         spkRow->addWidget(spkMute);
@@ -2078,7 +2078,7 @@ QWidget* RadioSetupDialog::buildAudioTab()
         compLayout->addStretch();
 
         auto* hint = new QLabel("Auto = Opus on SmartLink, uncompressed on LAN");
-        hint->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(hint, "QLabel { color: {{color.text.label}}; font-size: 10px; }");
         compLayout->addWidget(hint);
 
         vbox->addWidget(compGroup);
@@ -2091,7 +2091,7 @@ QWidget* RadioSetupDialog::buildAudioTab()
     {
         auto* plcCheck = new QCheckBox(
             "Smooth packet loss (conceal dropped audio packets)");
-        plcCheck->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(plcCheck, "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }");
         plcCheck->setToolTip(
             "When the radio's audio stream loses a UDP packet, fade the gap\n"
             "to silence (uncompressed) or synthesize a perceptually smooth\n"
@@ -2124,7 +2124,7 @@ QWidget* RadioSetupDialog::buildAudioTab()
     // ── Prevent Sleep ───────────────────────────────────────────────────
     {
         auto* sleepCheck = new QCheckBox("Prevent system sleep while connected");
-        sleepCheck->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(sleepCheck, "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }");
         sleepCheck->setToolTip("Hold a system power assertion to prevent idle sleep\n"
                                "while connected to a radio. Keeps TCP/UDP/audio\n"
                                "streams alive during long sessions.");
@@ -2181,7 +2181,7 @@ QWidget* RadioSetupDialog::buildAudioTab()
     pcLayout->addLayout(outRow);
 
     auto* promptCheck = new QCheckBox("Prompt on Audio Device Changes");
-    promptCheck->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(promptCheck, "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }");
     promptCheck->setToolTip("Show the Audio Device Detected dialog when a new PC audio device appears.");
     const bool suppressAudioDeviceNotifications =
         AppSettings::instance()
@@ -2232,11 +2232,11 @@ QWidget* RadioSetupDialog::buildAudioTab()
         boostBtn->setChecked(boostOn);
         boostBtn->setToolTip("Apply 50% software gain boost to PC audio output.\n"
                              "Compensates for lower levels with AGC-controlled audio.");
-        boostBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(boostBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; font-weight: bold; "
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
-            "border: 1px solid #20a040; }"));
+            "border: 1px solid #20a040; }");
         connect(boostBtn, &QPushButton::toggled, this, [this, boostBtn](bool on) {
             boostBtn->setText(on ? "Enabled" : "Disabled");
             auto& s = AppSettings::instance();
@@ -2267,7 +2267,7 @@ QWidget* RadioSetupDialog::buildAudioTab()
         auto* bufUnit = new QLabel("ms");
         bufUnit->setStyleSheet(kLabelStyle);
         auto* bufHint = new QLabel("(50–1000, increase for VPN/SmartLink jitter)");
-        bufHint->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.background.3}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(bufHint, "QLabel { color: {{color.background.3}}; font-size: 10px; }");
         connect(bufEdit, &QLineEdit::editingFinished, this, [this, bufEdit] {
             int val = qBound(50, bufEdit->text().toInt(), 1000);
             bufEdit->setText(QString::number(val));
@@ -2352,8 +2352,8 @@ QWidget* RadioSetupDialog::buildAudioTab()
         dirEdit->setText(settings.value("QsoRecordingDir",
             QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)
             + "/AetherSDR/Recordings").toString());
-        dirEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
-            "border-radius: 3px; padding: 2px 4px; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(dirEdit, "QLineEdit { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
+            "border-radius: 3px; padding: 2px 4px; font-size: 11px; }");
         auto* browseBtn = new QPushButton("...");
         browseBtn->setFixedWidth(30);
         browseBtn->setStyleSheet(modeBtnStyle);
@@ -2380,7 +2380,7 @@ QWidget* RadioSetupDialog::buildAudioTab()
         // Auto-record on TX
         auto* autoRow = new QHBoxLayout;
         auto* autoCheck = new QCheckBox("Auto-record on TX");
-        autoCheck->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(autoCheck, "QCheckBox { color: {{color.text.primary}}; }");
         autoCheck->setChecked(settings.value("QsoRecordingAutoRecord", "False").toString() == "True");
         connect(autoCheck, &QCheckBox::toggled, this, [](bool on) {
             auto& s = AppSettings::instance();
@@ -2391,13 +2391,13 @@ QWidget* RadioSetupDialog::buildAudioTab()
 
         // Idle timeout
         auto* timeoutLabel = new QLabel("Idle timeout:");
-        timeoutLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(timeoutLabel, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
         auto* timeoutSpin = new QSpinBox;
         timeoutSpin->setRange(10, 3600);
         timeoutSpin->setSuffix(" sec");
         timeoutSpin->setValue(settings.value("QsoRecordingIdleTimeout", "120").toInt());
-        timeoutSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
-            "border-radius: 3px; padding: 2px; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(timeoutSpin, "QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
+            "border-radius: 3px; padding: 2px; font-size: 11px; }");
         connect(timeoutSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, [](int v) {
             auto& s = AppSettings::instance();
             s.setValue("QsoRecordingIdleTimeout", QString::number(v));
@@ -2424,9 +2424,9 @@ QWidget* RadioSetupDialog::buildAudioTab()
         autoStart->setCheckable(true);
         autoStart->setChecked(
             AppSettings::instance().value("BnrAutostart", "False").toString() == "True");
-        autoStart->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(autoStart, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; padding: 2px 10px; }"
-            "QPushButton:checked { background: #00607a; color: {{color.text.primary}}; border-color: {{color.accent}}; }"));
+            "QPushButton:checked { background: #00607a; color: {{color.text.primary}}; border-color: {{color.accent}}; }");
         autoRow->addWidget(autoStart);
 
         // Container name
@@ -2435,8 +2435,8 @@ QWidget* RadioSetupDialog::buildAudioTab()
         auto* nameEdit = new QLineEdit(
             AppSettings::instance().value("BnrContainerName", "maxine-bnr").toString());
         nameEdit->setFixedWidth(120);
-        nameEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
-            "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; padding: 2px 4px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(nameEdit, "QLineEdit { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+            "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; padding: 2px 4px; }");
         autoRow->addWidget(nameLbl);
         autoRow->addWidget(nameEdit);
         autoRow->addStretch(1);
@@ -2453,9 +2453,9 @@ QWidget* RadioSetupDialog::buildAudioTab()
 
         auto* checkBtn = new QPushButton("Check Status");
         checkBtn->setFixedWidth(90);
-        checkBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(checkBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; padding: 2px; }"
-            "QPushButton:hover { background: {{color.background.1}}; }"));
+            "QPushButton:hover { background: {{color.background.1}}; }");
         statusRow->addWidget(checkBtn);
 
         auto* startBtn = new QPushButton("Start");
@@ -2543,7 +2543,7 @@ QWidget* RadioSetupDialog::buildFiltersTab()
         auto* hdr = new QHBoxLayout;
         hdr->addStretch(1);
         auto* modelLbl = new QLabel(m_model->model());
-        modelLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(modelLbl, "QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }");
         hdr->addWidget(modelLbl);
         vbox->addLayout(hdr);
     }
@@ -2633,10 +2633,10 @@ QWidget* RadioSetupDialog::buildFiltersTab()
 
         auto* chk = new QCheckBox("Use Low Latency Filters for Digital Modes");
         chk->setChecked(m_model->lowLatencyDigital());
-        chk->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; font-size: 12px; spacing: 8px; }"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(chk, "QCheckBox { color: {{color.text.primary}}; font-size: 12px; spacing: 8px; }"
             "QCheckBox::indicator { width: 16px; height: 16px; "
             "border: 2px solid {{color.background.3}}; border-radius: 3px; background: {{color.background.0}}; }"
-            "QCheckBox::indicator:checked { background: {{color.background.2}}; border: 2px solid #00a0e0; }"));
+            "QCheckBox::indicator:checked { background: {{color.background.2}}; border: 2px solid #00a0e0; }");
         connect(chk, &QCheckBox::toggled, this, [this](bool on) {
             m_model->sendCommand(
                 QString("radio set low_latency_digital_modes=%1").arg(on ? 1 : 0));
@@ -2660,18 +2660,18 @@ QWidget* RadioSetupDialog::buildXvtrTab()
         auto* hdr = new QHBoxLayout;
         hdr->addStretch(1);
         auto* modelLbl = new QLabel(m_model->model());
-        modelLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(modelLbl, "QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }");
         hdr->addWidget(modelLbl);
         vbox->addLayout(hdr);
     }
 
     // Sub-tabs: one per XVTR + a "+" tab to add new
     auto* xvtrTabs = new QTabWidget;
-    xvtrTabs->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTabWidget::pane { border: 1px solid {{color.background.2}}; background: {{color.background.0}}; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(xvtrTabs, "QTabWidget::pane { border: 1px solid {{color.background.2}}; background: {{color.background.0}}; }"
         "QTabBar::tab { background: {{color.background.1}}; color: {{color.text.secondary}}; "
         "border: 1px solid {{color.background.2}}; padding: 3px 10px; margin-right: 2px; }"
         "QTabBar::tab:selected { background: {{color.background.0}}; color: {{color.text.primary}}; "
-        "border-bottom-color: {{color.background.0}}; }"));
+        "border-bottom-color: {{color.background.0}}; }");
 
     auto buildXvtrPage = [this, xvtrTabs](int idx, const RadioModel::XvtrInfo& x) {
         auto* pg = new QWidget;
@@ -2711,11 +2711,11 @@ QWidget* RadioSetupDialog::buildXvtrTab()
         auto* rxOnlyBtn = new QPushButton(x.rxOnly ? "Enabled" : "Disabled");
         rxOnlyBtn->setCheckable(true);
         rxOnlyBtn->setChecked(x.rxOnly);
-        rxOnlyBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(rxOnlyBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; font-weight: bold; "
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
-            "border: 1px solid #20a040; }"));
+            "border: 1px solid #20a040; }");
         connect(rxOnlyBtn, &QPushButton::toggled, this, [this, rxOnlyBtn, idx](bool on) {
             rxOnlyBtn->setText(on ? "Enabled" : "Disabled");
             m_model->sendCommand(
@@ -2786,10 +2786,10 @@ QWidget* RadioSetupDialog::buildXvtrTab()
     auto* addPage = new QWidget;
     auto* addVb = new QVBoxLayout(addPage);
     auto* addBtn = new QPushButton("Create New Transverter");
-    addBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(addBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 12px; font-weight: bold; "
         "padding: 8px 20px; }"
-        "QPushButton:hover { background: {{color.background.1}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; }");
     connect(addBtn, &QPushButton::clicked, this, [this, xvtrTabs, buildXvtrPage] {
         m_model->sendCmdPublic("xvtr create",
             [this, xvtrTabs, buildXvtrPage](int code, const QString& body) {
@@ -2837,7 +2837,7 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
         auto* hdr = new QHBoxLayout;
         hdr->addStretch(1);
         auto* modelLbl = new QLabel(m_model->model());
-        modelLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(modelLbl, "QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }");
         hdr->addWidget(modelLbl);
         vbox->addLayout(hdr);
     }
@@ -2898,7 +2898,7 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
 
         auto addHeader = [grid](const QString& text, int col) {
             auto* lbl = new QLabel(text);
-            lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; font-weight: bold; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; font-weight: bold; }");
             grid->addWidget(lbl, 0, col);
         };
         addHeader("Port", 0);
@@ -2908,7 +2908,7 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
         const QStringList tokens = m_model->knownAntennaTokens();
         if (tokens.isEmpty()) {
             auto* empty = new QLabel("Waiting for antenna ports from the radio.");
-            empty->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 12px; padding: 8px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(empty, "QLabel { color: {{color.text.label}}; font-size: 12px; padding: 8px; }");
             grid->addWidget(empty, 1, 0, 1, 4);
             return;
         }
@@ -2932,10 +2932,10 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
             grid->addWidget(preview, row, 2);
 
             auto* clearBtn = new QPushButton("Clear");
-            clearBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+            AetherSDR::ThemeManager::instance().applyStyleSheet(clearBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
                 "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; "
                 "font-weight: bold; padding: 3px 10px; }"
-                "QPushButton:hover { background: {{color.background.1}}; }"));
+                "QPushButton:hover { background: {{color.background.1}}; }");
             grid->addWidget(clearBtn, row, 3);
 
             connect(edit, &QLineEdit::textChanged, this,
@@ -2992,7 +2992,7 @@ QWidget* RadioSetupDialog::buildApdTab()
         auto* hdr = new QHBoxLayout;
         hdr->addStretch(1);
         auto* modelLbl = new QLabel(m_model->model());
-        modelLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(modelLbl, "QLabel { color: {{color.accent.bright}}; font-size: 20px; font-weight: bold; }");
         hdr->addWidget(modelLbl);
         vbox->addLayout(hdr);
     }
@@ -3040,10 +3040,10 @@ QWidget* RadioSetupDialog::buildApdTab()
         grid->addWidget(resetLbl, 2, 0);
 
         auto* resetBtn = new QPushButton("Reset");
-        resetBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(resetBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; "
             "font-weight: bold; padding: 3px 16px; }"
-            "QPushButton:hover { background: {{color.background.1}}; }"));
+            "QPushButton:hover { background: {{color.background.1}}; }");
         connect(resetBtn, &QPushButton::clicked, this, [this] {
             m_model->transmitModel().resetApdEqualizer();
         });
@@ -3107,10 +3107,10 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
     auto* listLayout = new QVBoxLayout(listGroup);
 
     auto* cableList = new QListWidget;
-    cableList->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QListWidget { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(cableList, "QListWidget { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; "
         "font-size: 11px; }"
         "QListWidget::item { padding: 4px; }"
-        "QListWidget::item:selected { background: {{color.accent}}; color: {{color.background.0}}; }"));
+        "QListWidget::item:selected { background: {{color.accent}}; color: {{color.background.0}}; }");
     listLayout->addWidget(cableList);
     hbox->addWidget(listGroup);
 
@@ -3229,7 +3229,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         catEnabledCheck->setStyleSheet(kCheck);
         hg->addWidget(catEnabledCheck, 1, 0, 1, 2);
         catStatusLabel = new QLabel("Unplugged");
-        catStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(catStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         hg->addWidget(new QLabel("Status:"), 2, 0);
         hg->addWidget(catStatusLabel, 2, 1);
         vbox->addWidget(headerGroup);
@@ -3280,7 +3280,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         bcdEnabledCheck->setStyleSheet(kCheck);
         hg->addWidget(bcdEnabledCheck, 1, 0, 1, 2);
         bcdStatusLabel = new QLabel("Unplugged");
-        bcdStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(bcdStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         hg->addWidget(new QLabel("Status:"), 2, 0);
         hg->addWidget(bcdStatusLabel, 2, 1);
         vbox->addWidget(headerGroup);
@@ -3330,7 +3330,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         bitEnabledCheck->setStyleSheet(kCheck);
         hg->addWidget(bitEnabledCheck, 1, 0, 1, 2);
         bitStatusLabel = new QLabel("Unplugged");
-        bitStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(bitStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         hg->addWidget(new QLabel("Status:"), 2, 0);
         hg->addWidget(bitStatusLabel, 2, 1);
         vbox->addWidget(headerGroup);
@@ -3345,7 +3345,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         int col = 0;
         for (const auto& h : {"Bit", "En", "Source", "Output", "Polarity", "Band"}) {
             auto* lbl = new QLabel(h);
-            lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; font-weight: bold; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 10px; font-weight: bold; }");
             lbl->setAlignment(Qt::AlignCenter);
             bitGrid->addWidget(lbl, 0, col++);
         }
@@ -3354,7 +3354,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
             int row = b + 1;
             auto* bitLabel = new QLabel(QString::number(b));
             bitLabel->setAlignment(Qt::AlignCenter);
-            bitLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 10px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(bitLabel, "QLabel { color: {{color.text.primary}}; font-size: 10px; }");
             bitGrid->addWidget(bitLabel, row, 0);
 
             auto* enCheck = new QCheckBox;
@@ -3441,7 +3441,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         ptEnabledCheck->setStyleSheet(kCheck);
         hg->addWidget(ptEnabledCheck, 1, 0, 1, 2);
         ptStatusLabel = new QLabel("Unplugged");
-        ptStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(ptStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         hg->addWidget(new QLabel("Status:"), 2, 0);
         hg->addWidget(ptStatusLabel, 2, 1);
         vbox->addWidget(headerGroup);
@@ -3893,7 +3893,7 @@ QWidget* RadioSetupDialog::buildSerialTab()
 
         // Paddle swap
         auto* swapCb = new QCheckBox("Paddle Swap (swap dit/dah)");
-        swapCb->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(swapCb, "QCheckBox { color: {{color.text.primary}}; }");
         swapCb->setChecked(AppSettings::instance().value("SerialPaddleSwap", "False").toString() == "True");
         connect(swapCb, &QCheckBox::toggled, this, [](bool on) {
             auto& s = AppSettings::instance();
@@ -3939,10 +3939,10 @@ QWidget* RadioSetupDialog::buildSerialTab()
             closeBtn->setEnabled(open);
             if (open) {
                 statusLabel->setText("Open");
-                statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.success}}; font-size: 11px; }"));
+                AetherSDR::ThemeManager::instance().applyStyleSheet(statusLabel, "QLabel { color: {{color.accent.success}}; font-size: 11px; }");
             } else {
                 statusLabel->setText("Closed");
-                statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+                AetherSDR::ThemeManager::instance().applyStyleSheet(statusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
             }
         };
 
@@ -3966,7 +3966,7 @@ QWidget* RadioSetupDialog::buildSerialTab()
         vbox->addLayout(row);
 
         auto* autoOpen = new QCheckBox("Auto-open serial port on startup");
-        autoOpen->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(autoOpen, "QCheckBox { color: {{color.text.primary}}; }");
         autoOpen->setChecked(settings.value("SerialAutoOpen", "False").toString() == "True");
         connect(autoOpen, &QCheckBox::toggled, this, [](bool on) {
             auto& s = AppSettings::instance();
@@ -3985,7 +3985,7 @@ QWidget* RadioSetupDialog::buildSerialTab()
 
         // Status
         auto* fcStatusLabel = new QLabel("Not detected");
-        fcStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(fcStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         m_flexControlStatusLabel = fcStatusLabel;
         grid->addWidget(new QLabel("Status:"), 0, 0);
         grid->addWidget(fcStatusLabel, 0, 1);
@@ -3994,9 +3994,9 @@ QWidget* RadioSetupDialog::buildSerialTab()
         auto* fcDetectBtn = new QPushButton("Detect");
         // Same macOS-native-metrics consideration as the Open/Close pair above.
         fcDetectBtn->setMinimumWidth(80);
-        fcDetectBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(fcDetectBtn, "QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
             "border: 1px solid {{color.accent.dim}}; padding: 3px; border-radius: 3px; }"
-            "QPushButton:hover { background: {{color.accent.bright}}; }"));
+            "QPushButton:hover { background: {{color.accent.bright}}; }");
         auto* fcCloseBtn = new QPushButton("Close");
         fcCloseBtn->setMinimumWidth(80);
         fcCloseBtn->setStyleSheet(fcDetectBtn->styleSheet());
@@ -4093,7 +4093,7 @@ QWidget* RadioSetupDialog::buildSerialTab()
 
         // Auto-detect checkbox
         auto* autoDetect = new QCheckBox("Auto-detect on startup");
-        autoDetect->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(autoDetect, "QCheckBox { color: {{color.text.primary}}; }");
         autoDetect->setChecked(settings.value("FlexControlAutoDetect", "True").toString() == "True");
         connect(autoDetect, &QCheckBox::toggled, this, [this](bool on) {
             auto& s = AppSettings::instance();
@@ -4104,7 +4104,7 @@ QWidget* RadioSetupDialog::buildSerialTab()
         grid->addWidget(autoDetect, 5, 0, 1, 3);
 
         auto* invertDir = new QCheckBox("Invert tuning direction");
-        invertDir->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(invertDir, "QCheckBox { color: {{color.text.primary}}; }");
         invertDir->setChecked(settings.value("FlexControlInvertDir", "False").toString() == "True");
         m_flexControlInvertCheck = invertDir;
         connect(invertDir, &QCheckBox::toggled, this, [this](bool on) {
@@ -4141,7 +4141,7 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
     // Column headers
     auto addHeader = [&](int col, const QString& text) {
         auto* lbl = new QLabel(text);
-        lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; font-weight: bold; }");
         grid->addWidget(lbl, 0, col);
     };
     addHeader(0, "Device");
@@ -4192,8 +4192,8 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
         } else {
             portSpin->setValue(defaultPort);
         }
-        portSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSpinBox { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
-            "border-radius: 3px; color: {{color.text.primary}}; font-size: 12px; padding: 2px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(portSpin, "QSpinBox { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+            "border-radius: 3px; color: {{color.text.primary}}; font-size: 12px; padding: 2px; }");
         grid->addWidget(portSpin, row, 2);
 
         // Status label
@@ -4401,7 +4401,7 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
         "This is needed for remote, VPN, and SmartLink connections. "
         "Configured devices auto-connect when the radio connects.");
     note->setWordWrap(true);
-    note->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; padding: 8px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(note, "QLabel { color: {{color.text.label}}; font-size: 11px; padding: 8px; }");
     vbox->addWidget(note);
 
     vbox->addStretch();
@@ -4465,10 +4465,10 @@ void RadioSetupDialog::setFlexControlConnectionStatus(bool connected, const QStr
                 ? AppSettings::instance().value("FlexControlPort").toString()
                 : port;
             m_flexControlStatusLabel->setText(QString("Connected (%1)").arg(displayPort));
-            m_flexControlStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.success}}; font-size: 11px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_flexControlStatusLabel, "QLabel { color: {{color.accent.success}}; font-size: 11px; }");
         } else {
             m_flexControlStatusLabel->setText("Not detected");
-            m_flexControlStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.label}}; font-size: 11px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_flexControlStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
         }
     }
     if (m_flexControlCloseButton)
@@ -4513,8 +4513,8 @@ QWidget* RadioSetupDialog::buildUiEnhancementsTab()
         auto* globalRadio = new QRadioButton("Global slot index (A=0, B=1, …)");
         auto* radioIdxRadio =
             new QRadioButton("Radio-assigned letter with global subscript (A₂)");
-        globalRadio->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QRadioButton { color: {{color.text.primary}}; font-size: 12px; }"));
-        radioIdxRadio->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QRadioButton { color: {{color.text.primary}}; font-size: 12px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(globalRadio, "QRadioButton { color: {{color.text.primary}}; font-size: 12px; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(radioIdxRadio, "QRadioButton { color: {{color.text.primary}}; font-size: 12px; }");
         radioRow->addWidget(globalRadio);
         radioRow->addWidget(radioIdxRadio);
         radioRow->addStretch();
@@ -4563,8 +4563,8 @@ QWidget* RadioSetupDialog::buildUiEnhancementsTab()
     auto* modeLayout = new QHBoxLayout;
     auto* defaultsRadio = new QRadioButton("Use Aether defaults");
     auto* customRadio   = new QRadioButton("Custom colors");
-    defaultsRadio->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QRadioButton { color: {{color.text.primary}}; font-size: 12px; }"));
-    customRadio->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QRadioButton { color: {{color.text.primary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(defaultsRadio, "QRadioButton { color: {{color.text.primary}}; font-size: 12px; }");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(customRadio, "QRadioButton { color: {{color.text.primary}}; font-size: 12px; }");
     modeLayout->addWidget(defaultsRadio);
     modeLayout->addWidget(customRadio);
     modeLayout->addStretch();
@@ -4589,7 +4589,7 @@ QWidget* RadioSetupDialog::buildUiEnhancementsTab()
 
         auto* lbl = new QLabel(QString(kLetters[i]));
         lbl->setAlignment(Qt::AlignCenter);
-        lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
 
         auto* btn = new QPushButton(QString(kLetters[i]));
         btn->setStyleSheet(kBtnBase);
@@ -4605,9 +4605,9 @@ QWidget* RadioSetupDialog::buildUiEnhancementsTab()
     // Reset-all button
     auto* resetRow = new QHBoxLayout;
     auto* resetBtn = new QPushButton("Reset All to Defaults");
-    resetBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(resetBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; padding: 3px 12px; }"
-        "QPushButton:hover { background: {{color.background.1}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; }");
     resetRow->addWidget(resetBtn);
     resetRow->addStretch();
     grpLayout->addLayout(resetRow);
@@ -4711,7 +4711,7 @@ QWidget* RadioSetupDialog::buildUiEnhancementsTab()
         row->setSpacing(8);
 
         auto* clickLabel = new QLabel("Delay (ms):");
-        clickLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 12px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(clickLabel, "QLabel { color: {{color.text.primary}}; font-size: 12px; }");
         row->addWidget(clickLabel);
 
         auto& s = AppSettings::instance();
@@ -4725,14 +4725,14 @@ QWidget* RadioSetupDialog::buildUiEnhancementsTab()
         clickSpin->setSuffix(" ms");
         clickSpin->setValue(qBound(0, current, 1000));
         clickSpin->setFixedWidth(110);
-        clickSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; "
-            "border: 1px solid {{color.background.2}}; border-radius: 3px; padding: 2px 4px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(clickSpin, "QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; "
+            "border: 1px solid {{color.background.2}}; border-radius: 3px; padding: 2px 4px; }");
         row->addWidget(clickSpin);
 
         auto* resetBtn = new QPushButton("Reset");
-        resetBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; color: {{color.text.primary}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(resetBtn, "QPushButton { background: {{color.background.1}}; color: {{color.text.primary}}; "
             "border: 1px solid {{color.background.2}}; border-radius: 3px; padding: 4px 12px; }"
-            "QPushButton:hover { border-color: #60a0c0; }"));
+            "QPushButton:hover { border-color: #60a0c0; }");
         resetBtn->setToolTip(QString("Reset to platform default (%1 ms)")
                              .arg(platformDefault));
         row->addWidget(resetBtn);
@@ -4814,10 +4814,10 @@ QWidget* RadioSetupDialog::buildSmartLinkTab()
     table->verticalHeader()->setVisible(false);
     table->setEditTriggers(QAbstractItemView::NoEditTriggers);
     table->setSelectionBehavior(QAbstractItemView::SelectRows);
-    table->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTableWidget { background: {{color.background.0}}; color: {{color.text.primary}};"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(table, "QTableWidget { background: {{color.background.0}}; color: {{color.text.primary}};"
         " gridline-color: {{color.background.1}}; }"
         "QHeaderView::section { background: {{color.background.1}}; color: #b0c4d6;"
-        " padding: 4px; border: none; }"));
+        " padding: 4px; border: none; }");
     grpLay->addWidget(table);
 
     auto* btnRow = new QHBoxLayout;

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -124,10 +124,10 @@ public:
     {
         setFlat(false);
         setFixedSize(22, 22);
-        setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
             "border-radius: 3px; padding: 0; margin: 0; min-width: 0; min-height: 0; }"
             "QPushButton:hover { background: {{color.background.1}}; }"
-            "QPushButton:pressed { background: {{color.accent}}; }"));
+            "QPushButton:pressed { background: {{color.accent}}; }");
     }
 protected:
     void paintEvent(QPaintEvent* ev) override {
@@ -348,8 +348,8 @@ void RxApplet::buildUI()
         m_sliceBadge->setFixedSize(20, 20);
         m_sliceBadge->setAlignment(Qt::AlignCenter);
         m_sliceBadge->setTextFormat(Qt::RichText);  // slice letter may be HTML (#2606)
-        m_sliceBadge->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.2}}; color: {{color.text.primary}}; "
-            "border-radius: 3px; font-weight: bold; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_sliceBadge, "QLabel { background: {{color.background.2}}; color: {{color.text.primary}}; "
+            "border-radius: 3px; font-weight: bold; font-size: 11px; }");
         row->addWidget(m_sliceBadge);
 
         // Tune-lock toggle (🔓 unlocked / 🔒 locked)
@@ -397,9 +397,9 @@ void RxApplet::buildUI()
         // TX antenna dropdown (red text, no border)
         m_txAntBtn = new QPushButton("ANT1");
         m_txAntBtn->setFlat(true);
-        m_txAntBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { color: {{color.accent.danger}}; background: transparent; border: none; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_txAntBtn, "QPushButton { color: {{color.accent.danger}}; background: transparent; border: none; "
             "font-size: 10px; font-weight: bold; padding: 0 2px; }"
-            "QPushButton:hover { color: #ff6666; }"));
+            "QPushButton:hover { color: #ff6666; }");
         connect(m_txAntBtn, &QPushButton::clicked, this, [this] {
             QMenu menu(this);
             const QString cur = m_slice ? m_slice->txAntenna() : "";
@@ -424,7 +424,7 @@ void RxApplet::buildUI()
         // Filter width label (e.g. "2.7K") — centered between ANT and QSK
         m_filterWidthLbl = new QLabel("2.7K");
         m_filterWidthLbl->setAlignment(Qt::AlignCenter);
-        m_filterWidthLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent.bright}}; font-size: 11px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_filterWidthLbl, "QLabel { color: {{color.accent.bright}}; font-size: 11px; font-weight: bold; }");
         row->addWidget(m_filterWidthLbl);
 
         row->addStretch(1);
@@ -434,9 +434,9 @@ void RxApplet::buildUI()
         m_qskBtn->setCheckable(true);
         m_qskBtn->setFlat(true);
         m_qskBtn->setEnabled(false);
-        m_qskBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { color: {{color.text.secondary}}; background: transparent; border: none; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_qskBtn, "QPushButton { color: {{color.text.secondary}}; background: transparent; border: none; "
             "font-size: 10px; font-weight: bold; padding: 0 2px; }"
-            "QPushButton:checked { color: #ffb800; }"));
+            "QPushButton:checked { color: #ffb800; }");
         row->addWidget(m_qskBtn);
 
         root->addLayout(row);
@@ -451,10 +451,10 @@ void RxApplet::buildUI()
         // TX slice indicator badge — click to set this slice as TX
         m_txBadge = new QPushButton("TX");
         m_txBadge->setFixedSize(20, 20);
-        m_txBadge->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.meter.bar.fill}}; color: {{color.text.primary}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_txBadge, "QPushButton { background: {{color.meter.bar.fill}}; color: {{color.text.primary}}; "
             "border-radius: 3px; border: none; font-weight: bold; font-size: 10px;"
             " padding: 0px; margin: 0px; }"
-            "QPushButton:hover { background: {{color.background.3}}; }"));
+            "QPushButton:hover { background: {{color.background.3}}; }");
         connect(m_txBadge, &QPushButton::clicked, this, [this] {
             if (m_slice) m_slice->setTxSlice(!m_slice->isTxSlice());
         });
@@ -496,15 +496,15 @@ void RxApplet::buildUI()
 
         m_freqLabel = new QLabel("0.000.000");
         m_freqLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        m_freqLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 28px; font-weight: bold;"
-            " background: transparent; padding: 0; margin: 0; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_freqLabel, "QLabel { color: {{color.text.primary}}; font-size: 28px; font-weight: bold;"
+            " background: transparent; padding: 0; margin: 0; }");
         m_freqLabel->installEventFilter(this);
         m_freqStack->addWidget(m_freqLabel);
 
         m_freqEdit = new QLineEdit;
-        m_freqEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; border: 1px solid {{color.accent}};"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_freqEdit, "QLineEdit { background: {{color.background.0}}; border: 1px solid {{color.accent}};"
             " border-radius: 3px; color: #00e5ff; font-size: 20px;"
-            " font-weight: bold; padding: 0 4px; }"));
+            " font-weight: bold; padding: 0 4px; }");
         m_freqEdit->setAlignment(Qt::AlignRight);
         m_freqEdit->setPlaceholderText("MHz");
         m_freqEdit->installEventFilter(this);
@@ -572,8 +572,8 @@ void RxApplet::buildUI()
         m_stepDown  = mkLeft();
         m_stepLabel = new ScrollableLabel(formatStepLabel(m_stepSizes[m_stepIdx]));
         m_stepLabel->setAlignment(Qt::AlignCenter);
-        m_stepLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { font-size: 11px; background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
-            "border-radius: 3px; padding: 1px 2px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_stepLabel, "QLabel { font-size: 11px; background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
+            "border-radius: 3px; padding: 1px 2px; }");
         m_stepUp = mkRight();
 
         auto stepDown = [this] {
@@ -688,9 +688,9 @@ void RxApplet::buildUI()
             m_offsetSpin->setSingleStep(0.1);
             m_offsetSpin->setValue(0.0);
             m_offsetSpin->setSuffix(" Mhz");
-            m_offsetSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDoubleSpinBox { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_offsetSpin, "QDoubleSpinBox { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
                 "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; padding: 1px 2px; }"
-                "QDoubleSpinBox::up-button, QDoubleSpinBox::down-button { width: 0; }"));
+                "QDoubleSpinBox::up-button, QDoubleSpinBox::down-button { width: 0; }");
             row->addWidget(m_offsetSpin, 1);
             fmLayout->addLayout(row);
 
@@ -768,8 +768,8 @@ void RxApplet::buildUI()
 
         m_muteBtn = new QPushButton(QString::fromUtf8("\xF0\x9F\x94\x8A")); // 🔊
         m_muteBtn->setFixedSize(18, 18);
-        m_muteBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: transparent; border: none; font-size: 12px; padding: 0px; }"
-            "QPushButton:hover { background: {{color.background.1}}; border-radius: 3px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_muteBtn, "QPushButton { background: transparent; border: none; font-size: 12px; padding: 0px; }"
+            "QPushButton:hover { background: {{color.background.1}}; border-radius: 3px; }");
         // Single click toggles this slice; double click toggles all owned
         // slices.  Defer the single-click action by the platform double-
         // click interval so the second click can override it; the visual
@@ -954,8 +954,8 @@ void RxApplet::buildUI()
 
         m_ritLabel = new ScrollableLabel("+0 Hz");
         m_ritLabel->setAlignment(Qt::AlignCenter);
-        m_ritLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { font-size: 10px; background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
-            "border-radius: 3px; padding: 0px 2px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_ritLabel, "QLabel { font-size: 10px; background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
+            "border-radius: 3px; padding: 0px 2px; }");
         row->addWidget(m_ritLabel, 1);
         connect(m_ritLabel, &ScrollableLabel::scrolled, this, [this](int dir) {
             if (m_slice) m_slice->setRit(m_ritOnBtn->isChecked(),
@@ -1006,8 +1006,8 @@ void RxApplet::buildUI()
 
         m_xitLabel = new ScrollableLabel("+0 Hz");
         m_xitLabel->setAlignment(Qt::AlignCenter);
-        m_xitLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { font-size: 10px; background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
-            "border-radius: 3px; padding: 0px 2px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_xitLabel, "QLabel { font-size: 10px; background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
+            "border-radius: 3px; padding: 0px 2px; }");
         row->addWidget(m_xitLabel, 1);
         connect(m_xitLabel, &ScrollableLabel::scrolled, this, [this](int dir) {
             if (m_slice) m_slice->setXit(m_xitOnBtn->isChecked(),

--- a/src/gui/ShackSwitchApplet.cpp
+++ b/src/gui/ShackSwitchApplet.cpp
@@ -369,8 +369,8 @@ void ShackSwitchApplet::rebuildAntennaRows()
         hl->setSpacing(2);
 
         auto* nameLbl = new QLabel(ant.name);
-        nameLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.0}}; border: 1px solid #1c2a40; border-radius: 3px; "
-            "padding: 4px 6px; font-size: 11px; color: #dde6f0; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(nameLbl, "QLabel { background: {{color.background.0}}; border: 1px solid #1c2a40; border-radius: 3px; "
+            "padding: 4px 6px; font-size: 11px; color: #dde6f0; }");
         nameLbl->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         hl->addWidget(nameLbl, 1);
 

--- a/src/gui/ShortcutDialog.cpp
+++ b/src/gui/ShortcutDialog.cpp
@@ -68,7 +68,7 @@ void ShortcutDialog::buildUI()
             .arg(c.name(), c.lighter(140).name()));
         legendRow->addWidget(swatch);
         auto* lbl = new QLabel(cat);
-        lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
         legendRow->addWidget(lbl);
     }
     legendRow->addStretch();
@@ -80,7 +80,7 @@ void ShortcutDialog::buildUI()
 
     selGroup->addWidget(new QLabel("Key:"));
     m_selectedKeyLabel = new QLabel("(none)");
-    m_selectedKeyLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-weight: bold; font-size: 14px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_selectedKeyLabel, "QLabel { color: {{color.accent}}; font-weight: bold; font-size: 14px; }");
     m_selectedKeyLabel->setFixedWidth(80);
     selGroup->addWidget(m_selectedKeyLabel);
 
@@ -97,7 +97,7 @@ void ShortcutDialog::buildUI()
     selGroup->addWidget(m_actionCombo);
 
     m_categoryLabel = new QLabel;
-    m_categoryLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_categoryLabel, "QLabel { color: {{color.text.secondary}}; }");
     selGroup->addWidget(m_categoryLabel);
 
     auto* clearBtn = new QPushButton("Clear");

--- a/src/gui/SliceTroubleshootingDialog.cpp
+++ b/src/gui/SliceTroubleshootingDialog.cpp
@@ -402,22 +402,22 @@ SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model,
         "Use <b>Issue Summary</b> for GitHub reports and <b>JSON</b> for AI-assisted troubleshooting. "
         "This dialog does not re-query the radio.");
     intro->setWordWrap(true);
-    intro->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(intro, "QLabel { color: {{color.text.primary}}; }");
     root->addWidget(intro);
 
     auto* searchRow = new QHBoxLayout;
     searchRow->setSpacing(8);
     auto* searchLabel = new QLabel("Find:");
-    searchLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(searchLabel, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
     m_searchEdit = new QLineEdit;
     m_searchEdit->setClearButtonEnabled(true);
     m_searchEdit->setPlaceholderText("Search snapshot...");
-    m_searchEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_searchEdit, "QLineEdit {"
         "  background: {{color.background.0}};"
         "  color: {{color.text.primary}};"
         "  border: 1px solid {{color.background.2}};"
         "  padding: 4px 6px;"
-        "}"));
+        "}");
     auto* findNextBtn = new QPushButton("Find Next");
     searchRow->addWidget(searchLabel);
     searchRow->addWidget(m_searchEdit, 1);
@@ -428,31 +428,31 @@ SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model,
     m_summaryView = new QPlainTextEdit;
     m_summaryView->setReadOnly(true);
     m_summaryView->setLineWrapMode(QPlainTextEdit::NoWrap);
-    m_summaryView->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPlainTextEdit {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_summaryView, "QPlainTextEdit {"
         "  background: {{color.background.0}};"
         "  color: #d6e4f2;"
         "  font-family: monospace;"
         "  font-size: 11px;"
         "  border: 1px solid {{color.background.1}};"
-        "}"));
+        "}");
     m_tabs->addTab(m_summaryView, "Issue Summary");
 
     m_jsonView = new QPlainTextEdit;
     m_jsonView->setReadOnly(true);
     m_jsonView->setLineWrapMode(QPlainTextEdit::NoWrap);
-    m_jsonView->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPlainTextEdit {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_jsonView, "QPlainTextEdit {"
         "  background: {{color.background.0}};"
         "  color: #9ed4ff;"
         "  font-family: monospace;"
         "  font-size: 11px;"
         "  border: 1px solid {{color.background.1}};"
-        "}"));
+        "}");
     m_tabs->addTab(m_jsonView, "JSON");
     root->addWidget(m_tabs, 1);
 
     auto* footer = new QHBoxLayout;
     m_statusLabel = new QLabel;
-    m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
     footer->addWidget(m_statusLabel, 1);
 
     auto* refreshBtn = new QPushButton("Refresh Snapshot");

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -133,11 +133,11 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
     // Toggle button (arrow)
     m_toggleBtn = new QPushButton(this);
     m_toggleBtn->setFixedSize(BTN_W, BTN_H);
-    m_toggleBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: rgba(20, 30, 45, 240); "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_toggleBtn, "QPushButton { background: rgba(20, 30, 45, 240); "
         "border: 1px solid rgba(255, 255, 255, 40); border-radius: 2px; "
         "color: {{color.text.primary}}; font-size: 13px; font-weight: bold; }"
         "QPushButton:hover { background: rgba(0, 112, 192, 180); "
-        "border: 1px solid {{color.accent.dim}}; }"));
+        "border: 1px solid {{color.accent.dim}}; }");
     connect(m_toggleBtn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggle);
 
     // Menu buttons — Band, ANT, DSP handled specially (sub-panels)
@@ -219,8 +219,8 @@ void SpectrumOverlayMenu::setMemories(const QMap<int, MemoryEntry>& memories)
 void SpectrumOverlayMenu::buildBandPanel()
 {
     m_bandPanel = new QWidget(parentWidget());
-    m_bandPanel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: rgba(15, 15, 26, 220); "
-                                "border: 1px solid {{color.background.2}}; border-radius: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget { background: rgba(15, 15, 26, 220); "
+                                "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
     m_bandPanel->hide();
 
     auto* grid = new QGridLayout(m_bandPanel);
@@ -435,11 +435,11 @@ void SpectrumOverlayMenu::buildAntPanel()
     m_wnbBtn = new QPushButton("WNB");
     m_wnbBtn->setCheckable(true);
     m_wnbBtn->setFixedSize(48, 22);
-    m_wnbBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_wnbBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 2px; color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }"
         "QPushButton:checked { background: {{color.background.2}}; color: {{color.text.primary}}; "
         "border: 1px solid {{color.accent.dim}}; }"
-        "QPushButton:hover { border: 1px solid {{color.accent.dim}}; }"));
+        "QPushButton:hover { border: 1px solid {{color.accent.dim}}; }");
     wnbRow->addWidget(m_wnbBtn);
     m_wnbSlider = new GuardedSlider(Qt::Horizontal);
     m_wnbSlider->setRange(0, 100);
@@ -861,8 +861,8 @@ void SpectrumOverlayMenu::updateLayout()
 void SpectrumOverlayMenu::buildDisplayPanel()
 {
     m_displayPanel = new QWidget(parentWidget());
-    m_displayPanel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: rgba(15, 15, 26, 220); "
-                                   "border: 1px solid {{color.background.2}}; border-radius: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_displayPanel, "QWidget { background: rgba(15, 15, 26, 220); "
+                                   "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
     m_displayPanel->hide();
 
     auto* grid = new QGridLayout(m_displayPanel);
@@ -1556,8 +1556,8 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     }
 
     m_bandPanel = new QWidget(parentWidget());
-    m_bandPanel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: rgba(15, 15, 26, 220); "
-                                "border: 1px solid {{color.background.2}}; border-radius: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget { background: rgba(15, 15, 26, 220); "
+                                "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
     m_bandPanel->hide();
     m_bandPanel->installEventFilter(this);
 
@@ -1690,8 +1690,8 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     }
 
     m_xvtrPanel = new QWidget(parentWidget());
-    m_xvtrPanel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: rgba(15, 15, 26, 220); "
-                                "border: 1px solid {{color.background.2}}; border-radius: 3px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_xvtrPanel, "QWidget { background: rgba(15, 15, 26, 220); "
+                                "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
     m_xvtrPanel->hide();
     m_xvtrPanel->installEventFilter(this);
     m_xvtrPanelVisible = false;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -390,9 +390,9 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     m_interlockNotificationLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
     m_interlockNotificationLabel->setAlignment(Qt::AlignCenter);
     m_interlockNotificationLabel->setWordWrap(true);
-    m_interlockNotificationLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: rgba(10,10,20,225); color: #d7fbff; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_interlockNotificationLabel, "QLabel { background: rgba(10,10,20,225); color: #d7fbff; "
         "border: 2px solid {{color.accent}}; padding: 10px 14px; "
-        "font-size: 13px; font-weight: bold; }"));
+        "font-size: 13px; font-weight: bold; }");
     m_interlockNotificationLabel->hide();
     m_interlockNotificationLabel->raise();
 
@@ -4158,11 +4158,11 @@ void SpectrumWidget::showAddSpotDialog(double freqMhz)
     auto& as = AppSettings::instance();
     QDialog dlg(this);
     dlg.setWindowTitle("Add Spot");
-    dlg.setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(&dlg, "QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }"
                       "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid #304060; padding: 4px; }"
                       "QComboBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid #304060; padding: 4px; }"
                       "QLabel { color: {{color.text.primary}}; }"
-                      "QCheckBox { color: {{color.text.primary}}; }"));
+                      "QCheckBox { color: {{color.text.primary}}; }");
 
     auto* layout = new QFormLayout(&dlg);
 
@@ -7265,7 +7265,7 @@ void SpectrumWidget::drawSwrSweep(QPainter& p, const QRect& specRect)
 void SpectrumWidget::showSpotClusterPopup(const SpotCluster& cluster, const QPoint& globalPos)
 {
     auto* menu = new QMenu(this);
-    menu->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QMenu {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(menu, "QMenu {"
         "  background: {{color.background.0}};"
         "  border: 1px solid #305070;"
         "  padding: 4px;"
@@ -7278,7 +7278,7 @@ void SpectrumWidget::showSpotClusterPopup(const SpotCluster& cluster, const QPoi
         "QMenu::item:selected {"
         "  background: {{color.background.2}};"
         "  color: {{color.accent}};"
-        "}"));
+        "}");
 
     for (const auto& spot : cluster.spots) {
         QString text = QString("%1  %2 kHz")

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -41,7 +41,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
 
     auto* title = new QLabel("Spot Settings");
     title->setAlignment(Qt::AlignCenter);
-    title->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { font-size: 16px; font-weight: bold; color: {{color.text.primary}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(title, "QLabel { font-size: 16px; font-weight: bold; color: {{color.text.primary}}; }");
     root->addWidget(title);
     root->addSpacing(8);
 
@@ -291,7 +291,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     // ── Total Spots ─────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Total Spots:"), row, 0);
     m_totalSpotsLabel = new QLabel("0");
-    m_totalSpotsLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_totalSpotsLabel, "QLabel { color: {{color.text.primary}}; font-weight: bold; }");
     grid->addWidget(m_totalSpotsLabel, row++, 1);
 
     root->addLayout(grid);

--- a/src/gui/StripDeEssPanel.cpp
+++ b/src/gui/StripDeEssPanel.cpp
@@ -204,11 +204,11 @@ StripDeEssPanel::StripDeEssPanel(AudioEngine* engine, QWidget* parent)
     m_slopeBtn->setMinimumWidth(76);
     m_slopeBtn->setMaximumWidth(76);
     m_slopeBtn->setCursor(Qt::PointingHandCursor);
-    m_slopeBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}};"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_slopeBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}};"
         " border-radius: 3px; color: #b0c4d6; font-size: 11px;"
         " font-weight: bold; padding: 1px; }"
         "QPushButton:hover { background: #243044; color: #e8e8e8; }"
-        "QPushButton:pressed { background: #2a3a52; }"));
+        "QPushButton:pressed { background: #2a3a52; }");
     m_slopeBtn->setToolTip(tr(
         "Sidechain / notch filter slope.\n\n"
         "Each click steps through 12 → 24 → 36 → 48 dB/oct (1 to 4 "

--- a/src/gui/StripEqPanel.cpp
+++ b/src/gui/StripEqPanel.cpp
@@ -90,7 +90,7 @@ StripEqPanel::StripEqPanel(AudioEngine* engine, QWidget* parent)
             "Drag peak/shelf = freq + gain · "
             "drag HP/LP = freq + Q · Shift + drag for Q · "
             "click icon to cycle type");
-        hint->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.background.3}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(hint, "QLabel { color: {{color.background.3}}; font-size: 10px; }");
         row->addWidget(hint, 1);
 
         // Smoothing — fractional-octave display smoothing for the FFT
@@ -98,7 +98,7 @@ StripEqPanel::StripEqPanel(AudioEngine* engine, QWidget* parent)
         // Persisted globally (single user preference, shared between RX
         // and TX editors).
         auto* smoothingLbl = new QLabel("Smoothing:");
-        smoothingLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(smoothingLbl, "QLabel { color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }");
         row->addWidget(smoothingLbl);
 
         auto* smoothingCombo = new QComboBox;
@@ -143,7 +143,7 @@ StripEqPanel::StripEqPanel(AudioEngine* engine, QWidget* parent)
         peakHoldBtn->setToolTip(
             "Freeze the analyzer peak-hold trace at its highest level.\n"
             "Toggle off to resume normal decay.");
-        peakHoldBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton {"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(peakHoldBtn, "QPushButton {"
             "  background: {{color.background.0}}; color: {{color.text.primary}};"
             "  border: 1px solid {{color.background.1}}; border-radius: 3px;"
             "  padding: 2px 12px; font-size: 11px; font-weight: bold;"
@@ -153,7 +153,7 @@ StripEqPanel::StripEqPanel(AudioEngine* engine, QWidget* parent)
             "  background: #c8a040; color: {{color.background.0}};"
             "  border-color: #d4b050;"
             "}"
-            "QPushButton:checked:hover { background: #d4b050; }"));
+            "QPushButton:checked:hover { background: #d4b050; }");
         connect(peakHoldBtn, &QPushButton::toggled, this, [this](bool on) {
             if (m_canvas) m_canvas->setPeakHoldFrozen(on);
         });
@@ -196,13 +196,13 @@ StripEqPanel::StripEqPanel(AudioEngine* engine, QWidget* parent)
         auto* resetBtn = new QPushButton("Reset");
         resetBtn->setFixedHeight(24);
         resetBtn->setToolTip("Reset all bands to default values");
-        resetBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton {"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(resetBtn, "QPushButton {"
             "  background: {{color.background.0}}; color: {{color.text.primary}};"
             "  border: 1px solid {{color.background.1}}; border-radius: 3px;"
             "  padding: 2px 12px; font-size: 11px; font-weight: bold;"
             "}"
             "QPushButton:hover { background: {{color.background.1}}; }"
-            "QPushButton:pressed { background: {{color.background.1}}; }"));
+            "QPushButton:pressed { background: {{color.background.1}}; }");
         connect(resetBtn, &QPushButton::clicked, this, [this]() {
             ClientEq* eq = (m_path == ClientEqApplet::Path::Rx)
                 ? m_audio->clientEqRx() : m_audio->clientEqTx();

--- a/src/gui/StripFinalOutputPanel.cpp
+++ b/src/gui/StripFinalOutputPanel.cpp
@@ -569,10 +569,10 @@ StripFinalOutputPanel::StripFinalOutputPanel(AudioEngine* engine, QWidget* paren
         ovrBtn->setFixedSize(56, 18);
         ovrBtn->setCursor(Qt::PointingHandCursor);
         ovrBtn->setFlat(true);
-        ovrBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}};"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(ovrBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}};"
             " border-radius: 3px; color: {{color.background.3}}; font-size: 10px;"
             " font-weight: bold; padding: 1px; }"
-            "QPushButton:hover { color: {{color.text.primary}}; }"));
+            "QPushButton:hover { color: {{color.text.primary}}; }");
         ovrBtn->setToolTip(tr("Latches red on any sample that hits "
                               "0 dBFS BEFORE the limiter — i.e. the "
                               "limiter is the only thing that saved "
@@ -592,16 +592,16 @@ StripFinalOutputPanel::StripFinalOutputPanel(AudioEngine* engine, QWidget* paren
         m_limitLed = new QLabel("LIMIT", this);
         m_limitLed->setAlignment(Qt::AlignCenter);
         m_limitLed->setFixedSize(56, 18);
-        m_limitLed->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.1}}; border: 1px solid {{color.background.1}};"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_limitLed, "QLabel { background: {{color.background.1}}; border: 1px solid {{color.background.1}};"
             " border-radius: 3px; color: {{color.background.3}}; font-size: 10px;"
-            " font-weight: bold; padding: 1px; }"));
+            " font-weight: bold; padding: 1px; }");
         col->addWidget(m_limitLed);
 
         m_activityLbl = new QLabel("Lim: 0%", this);
         m_activityLbl->setAlignment(Qt::AlignCenter);
         m_activityLbl->setFixedSize(56, 18);
-        m_activityLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: transparent; color: {{color.background.3}};"
-            " font-size: 10px; font-weight: bold; padding: 1px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_activityLbl, "QLabel { background: transparent; color: {{color.background.3}};"
+            " font-size: 10px; font-weight: bold; padding: 1px; }");
         m_activityLbl->setToolTip(tr(
             "Limiter activity — what percentage of the trailing 3 s of "
             "audio the brickwall limiter was actively clamping peaks.\n\n"
@@ -620,13 +620,13 @@ StripFinalOutputPanel::StripFinalOutputPanel(AudioEngine* engine, QWidget* paren
         m_holdBtn->setFixedSize(56, 18);
         m_holdBtn->setCursor(Qt::PointingHandCursor);
         m_holdBtn->setFlat(true);
-        m_holdBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}};"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_holdBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}};"
             " border-radius: 3px; color: {{color.background.3}}; font-size: 10px;"
             " font-weight: bold; padding: 1px; }"
             "QPushButton:hover { color: {{color.text.primary}}; }"
             "QPushButton:checked { background: #183020; border: 1px solid #2eb872;"
             " color: #2eb872; }"
-            "QPushButton:checked:hover { color: #6ffaa9; }"));
+            "QPushButton:checked:hover { color: #6ffaa9; }");
         m_holdBtn->setToolTip(tr(
             "Peak-hold. When engaged (green), the PK / RMS / GR / CRST "
             "readouts latch their worst-case value since this button was "
@@ -775,8 +775,8 @@ void StripFinalOutputPanel::showToneEditor()
     auto* dlg = new QDialog(this);
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     dlg->setWindowTitle(tr("Test Tone"));
-    dlg->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; }"
-        "QLabel  { color: {{color.text.primary}}; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(dlg, "QDialog { background: {{color.background.0}}; }"
+        "QLabel  { color: {{color.text.primary}}; font-size: 11px; }");
 
     auto* form = new QFormLayout(dlg);
     form->setContentsMargins(12, 12, 12, 12);
@@ -868,7 +868,7 @@ void StripFinalOutputPanel::showQuindarEditor()
         dlg->setWindowFlags(dlg->windowFlags() | Qt::FramelessWindowHint);
     }
     dlg->setWindowTitle(tr("Quindar Tones"));
-    dlg->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(dlg, "QDialog { background: {{color.background.0}}; }"
         "QLabel  { color: {{color.text.primary}}; font-size: 11px; }"
         "QPushButton { background: {{color.background.1}}; color: {{color.text.primary}};"
         " border: 1px solid {{color.background.1}}; border-radius: 3px;"
@@ -878,7 +878,7 @@ void StripFinalOutputPanel::showQuindarEditor()
         " border: 1px solid {{color.accent.warning}}; }"
         "QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}};"
         " border: 1px solid {{color.background.1}}; border-radius: 2px;"
-        " padding: 1px 4px; font-size: 11px; }"));
+        " padding: 1px 4px; font-size: 11px; }");
 
     auto* dlgRoot = new QVBoxLayout(dlg);
     dlgRoot->setContentsMargins(0, 0, 0, 0);
@@ -895,9 +895,9 @@ void StripFinalOutputPanel::showQuindarEditor()
     titleBar->setFixedHeight(18);
     titleBar->setVisible(frameless);
     titleBar->setAttribute(Qt::WA_StyledBackground, true);
-    titleBar->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(titleBar, "QWidget { background: qlineargradient(x1:0,y1:0,x2:0,y2:1,"
         "stop:0 #5a7494, stop:0.5 #384e68, stop:1 {{color.background.1}}); "
-        "border-bottom: 1px solid #0a1a28; }"));
+        "border-bottom: 1px solid #0a1a28; }");
     titleBar->setCursor(Qt::OpenHandCursor);
     auto* tbLayout = new QHBoxLayout(titleBar);
     tbLayout->setContentsMargins(6, 0, 2, 0);
@@ -910,10 +910,10 @@ void StripFinalOutputPanel::showQuindarEditor()
     tbLayout->addStretch();
     auto* tbCloseBtn = new QPushButton(QString::fromUtf8("\xc3\x97"), titleBar);
     tbCloseBtn->setFixedSize(16, 16);
-    tbCloseBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: transparent; border: none;"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(tbCloseBtn, "QPushButton { background: transparent; border: none;"
         " color: {{color.text.primary}}; font-size: 11px; font-weight: bold;"
         " padding: 0px 4px; }"
-        "QPushButton:hover { color: {{color.text.primary}}; }"));
+        "QPushButton:hover { color: {{color.text.primary}}; }");
     tbCloseBtn->setCursor(Qt::ArrowCursor);
     tbCloseBtn->setToolTip(tr("Close"));
     connect(tbCloseBtn, &QPushButton::clicked, dlg, &QDialog::accept);

--- a/src/gui/StripPuduPanel.cpp
+++ b/src/gui/StripPuduPanel.cpp
@@ -70,8 +70,8 @@ QWidget* makeBracketLabel(const QString& text)
     leftLine->setStyleSheet("QFrame { color: #5a6a7a; }");
 
     auto* lbl = new QLabel(text);
-    lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-weight: bold; "
-                       "font-size: 13px; letter-spacing: 2px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.primary}}; font-weight: bold; "
+                       "font-size: 13px; letter-spacing: 2px; }");
     lbl->setAlignment(Qt::AlignCenter);
 
     auto* rightLine = new QFrame;

--- a/src/gui/StripWaveformPanel.cpp
+++ b/src/gui/StripWaveformPanel.cpp
@@ -50,13 +50,13 @@ StripWaveformPanel::StripWaveformPanel(AudioEngine* engine, QWidget* parent)
     // envelope behaviour.
     m_modeBtn = new QPushButton(this);
     m_modeBtn->setFixedSize(78, 18);
-    m_modeBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_modeBtn, "QPushButton {"
         "  background: {{color.background.1}}; border: 1px solid {{color.background.1}};"
         "  border-radius: 3px; color: #c8a070;"
         "  font-size: 10px; font-weight: bold; padding: 1px 6px;"
         "}"
         "QPushButton:hover { background: #3a2818; color: {{color.accent.warning}};"
-        "                    border: 1px solid {{color.accent.warning}}; }"));
+        "                    border: 1px solid {{color.accent.warning}}; }");
     m_modeBtn->setToolTip("Cycle waveform view: Scope → Envelope → History");
     connect(m_modeBtn, &QPushButton::clicked,
             this, &StripWaveformPanel::cycleViewMode);
@@ -79,8 +79,8 @@ StripWaveformPanel::StripWaveformPanel(AudioEngine* engine, QWidget* parent)
     m_windowLbl = new QLabel(this);
     m_windowLbl->setFixedWidth(28);
     m_windowLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    m_windowLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: transparent; color: {{color.text.secondary}};"
-        " font-size: 10px; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_windowLbl, "QLabel { background: transparent; color: {{color.text.secondary}};"
+        " font-size: 10px; font-weight: bold; }");
 
     auto* titleRow = new QHBoxLayout;
     titleRow->setContentsMargins(0, 0, 0, 0);

--- a/src/gui/SupportDialog.cpp
+++ b/src/gui/SupportDialog.cpp
@@ -60,7 +60,7 @@ void SupportDialog::buildUI()
         auto* cb = new QCheckBox(cat.label);
         cb->setToolTip(cat.description);
         cb->setChecked(cat.enabled);
-        cb->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.primary}}; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(cb, "QCheckBox { color: {{color.text.primary}}; }");
         gridLayout->addWidget(cb, row, col);
 
         connect(cb, &QCheckBox::toggled, this, [id = cat.id](bool on) {
@@ -105,13 +105,13 @@ void SupportDialog::buildUI()
     m_logViewer = new QPlainTextEdit;
     m_logViewer->setReadOnly(true);
     m_logViewer->setMaximumBlockCount(2000);
-    m_logViewer->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPlainTextEdit {"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_logViewer, "QPlainTextEdit {"
         "  background: {{color.background.0}};"
         "  color: {{color.text.secondary}};"
         "  font-family: monospace;"
         "  font-size: 11px;"
         "  border: 1px solid {{color.background.1}};"
-        "}"));
+        "}");
     layout->addWidget(m_logViewer, 1);  // stretch
 
     // ── Log action buttons ────────────────────────────────────────────────
@@ -131,7 +131,7 @@ void SupportDialog::buildUI()
     connect(resetBtn, &QPushButton::clicked, this, &SupportDialog::resetSettings);
     auto* sendBtn = new QPushButton("File an Issue");
     sendBtn->setFixedHeight(26);
-    sendBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #00607a; color: {{color.text.primary}}; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(sendBtn, "QPushButton { background: #00607a; color: {{color.text.primary}}; font-weight: bold; }");
     connect(sendBtn, &QPushButton::clicked, this, [this]() {
         // Create support bundle
         SupportBundle::RadioInfo radio;

--- a/src/gui/SwrSweepLicenseDialog.cpp
+++ b/src/gui/SwrSweepLicenseDialog.cpp
@@ -33,7 +33,7 @@ SwrSweepLicenseDialog::SwrSweepLicenseDialog(QWidget* parent)
 {
     setModal(true);
     setMinimumSize(520, 240);
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }");
 
     auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(14);
@@ -41,14 +41,14 @@ SwrSweepLicenseDialog::SwrSweepLicenseDialog(QWidget* parent)
     auto* disclaimer = new QLabel(kDisclaimerText);
     disclaimer->setWordWrap(true);
     disclaimer->setTextFormat(Qt::RichText);
-    disclaimer->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 12px; line-height: 1.4; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(disclaimer, "QLabel { color: {{color.text.primary}}; font-size: 12px; line-height: 1.4; }");
     root->addWidget(disclaimer);
 
     m_rememberCheck = new QCheckBox("Remember my answer");
-    m_rememberCheck->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QCheckBox { color: {{color.text.secondary}}; font-size: 11px; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_rememberCheck, "QCheckBox { color: {{color.text.secondary}}; font-size: 11px; }"
         "QCheckBox::indicator { width: 14px; height: 14px;"
         " border: 1px solid #406080; border-radius: 2px; background: {{color.background.0}}; }"
-        "QCheckBox::indicator:checked { background: {{color.accent}}; }"));
+        "QCheckBox::indicator:checked { background: {{color.accent}}; }");
     root->addWidget(m_rememberCheck);
 
     auto* btnRow = new QHBoxLayout;
@@ -56,20 +56,20 @@ SwrSweepLicenseDialog::SwrSweepLicenseDialog(QWidget* parent)
     btnRow->addStretch();
 
     auto* cancelBtn = new QPushButton("Cancel");
-    cancelBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; color: {{color.text.primary}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(cancelBtn, "QPushButton { background: {{color.background.1}}; color: {{color.text.primary}}; "
         "border: 1px solid {{color.background.2}}; border-radius: 3px;"
         " padding: 6px 16px; font-size: 11px; }"
-        "QPushButton:hover { background: {{color.background.1}}; border-color: {{color.accent.dim}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; border-color: {{color.accent.dim}}; }");
     connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
     btnRow->addWidget(cancelBtn);
 
     auto* acceptBtn = new QPushButton("I am licensed to use this feature");
     acceptBtn->setDefault(true);
-    acceptBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold;"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(acceptBtn, "QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold;"
         " border: 1px solid {{color.accent.dim}}; border-radius: 3px;"
         " padding: 6px 16px; font-size: 11px; }"
         "QPushButton:hover { background: {{color.accent.bright}}; }"
-        "QPushButton:default { border: 2px solid #00f0ff; }"));
+        "QPushButton:default { border: 2px solid #00f0ff; }");
     connect(acceptBtn, &QPushButton::clicked, this, &QDialog::accept);
     btnRow->addWidget(acceptBtn);
 

--- a/src/gui/TciApplet.cpp
+++ b/src/gui/TciApplet.cpp
@@ -206,7 +206,7 @@ void TciApplet::buildUI()
     enableRow->addWidget(m_tciPort);
 
     m_tciStatus = new QLabel("(stopped)");
-    m_tciStatus->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.background.3}}; font-size: 10px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_tciStatus, "QLabel { color: {{color.background.3}}; font-size: 10px; }");
     enableRow->addWidget(m_tciStatus, 1);
 
     m_tciEnable = new QPushButton("Enable");
@@ -280,7 +280,7 @@ void TciApplet::updateTciStatus()
     }
     if (!m_tciServer || !m_tciServer->isRunning()) {
         m_tciStatus->setText("(stopped)");
-        m_tciStatus->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.background.3}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_tciStatus, "QLabel { color: {{color.background.3}}; font-size: 10px; }");
     } else {
         int n = m_tciServer->clientCount();
         m_tciStatus->setText(

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -1,8 +1,10 @@
 #include "ThemeEditorDialog.h"
 #include "Theme.h"
+#include "ThemeInspector.h"
 #include "core/ThemeManager.h"
 
 #include <QColorDialog>
+#include <QFontMetrics>
 #include <QHBoxLayout>
 #include <QInputDialog>
 #include <QLabel>
@@ -13,7 +15,10 @@
 #include <QPainter>
 #include <QPixmap>
 #include <QPushButton>
+#include <QSet>
+#include <QSignalBlocker>
 #include <QVBoxLayout>
+#include <QWidget>
 
 namespace AetherSDR {
 
@@ -64,6 +69,23 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     m_tokenList->setSelectionMode(QAbstractItemView::SingleSelection);
     root->addWidget(m_tokenList, 1);
 
+    // Inspector toggle row — sits above the filter so it reads as a mode
+    // switch ("am I clicking on the main UI to pick a token?") rather than
+    // a button buried with Save As / Close.
+    auto* inspectRow = new QHBoxLayout;
+    m_inspectBtn = new QPushButton(QStringLiteral("🎯  Inspect"), this);
+    m_inspectBtn->setCheckable(true);
+    m_inspectBtn->setToolTip(QStringLiteral(
+        "Click, then point at any region of the main UI to find the\n"
+        "token(s) painting it.  ESC cancels."));
+    inspectRow->addWidget(m_inspectBtn);
+    m_inspectStatus = new QLabel(this);
+    m_inspectStatus->setWordWrap(true);
+    m_inspectStatus->setStyleSheet(QStringLiteral(
+        "QLabel { font-style: italic; }"));
+    inspectRow->addWidget(m_inspectStatus, 1);
+    root->addLayout(inspectRow);
+
     auto* btnRow = new QHBoxLayout;
     btnRow->addStretch(1);
     m_saveAsBtn = new QPushButton(QStringLiteral("Save As…"), this);
@@ -78,13 +100,11 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
 
     connect(m_tokenList, &QListWidget::itemClicked,
             this, &ThemeEditorDialog::onTokenRowClicked);
-    connect(m_filterEdit, &QLineEdit::textChanged, this, [this](const QString& q) {
-        const QString needle = q.trimmed().toLower();
-        for (int i = 0; i < m_tokenList->count(); ++i) {
-            auto* item = m_tokenList->item(i);
-            item->setHidden(!needle.isEmpty()
-                            && !item->data(Qt::UserRole).toString().contains(needle));
-        }
+    connect(m_filterEdit, &QLineEdit::textChanged, this, [this](const QString&) {
+        // Re-evaluate visibility against both the text filter and the
+        // last inspector-picked subset (if any) — filterTokensTo() reads
+        // the QLineEdit's current text directly.
+        filterTokensTo(m_activeSubset);
     });
     connect(m_saveAsBtn, &QPushButton::clicked,
             this, &ThemeEditorDialog::onSaveAsClicked);
@@ -95,6 +115,20 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     // doesn't lie about what it's editing.
     connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
             this, &ThemeEditorDialog::onActiveThemeChanged);
+
+    // Inspector wiring.  The inspector is owned by the dialog (parent),
+    // so it dies when the dialog does and removes its event filter
+    // cleanly.
+    m_inspector = new ThemeInspector(this, this);
+    connect(m_inspectBtn, &QPushButton::toggled,
+            this, &ThemeEditorDialog::onInspectToggled);
+    connect(m_inspector, &ThemeInspector::widgetPicked,
+            this, &ThemeEditorDialog::onInspectorPicked);
+    connect(m_inspector, &ThemeInspector::activeChanged,
+            this, &ThemeEditorDialog::onInspectorActiveChanged);
+    connect(m_inspector, &ThemeInspector::canceled, this, [this]() {
+        updateInspectorStatus(QStringLiteral("Inspector canceled."));
+    });
 }
 
 void ThemeEditorDialog::refreshTokenList()
@@ -187,6 +221,112 @@ void ThemeEditorDialog::onSaveAsClicked()
     }
     // saveCurrentThemeAs() makes the new theme active; onActiveThemeChanged
     // will fire from themeChanged and refresh the title.
+}
+
+void ThemeEditorDialog::onInspectToggled(bool on)
+{
+    if (!m_inspector) return;
+    if (on) {
+        m_activeSubset.clear();
+        filterTokensTo({});                       // clear any prior subset
+        m_filterEdit->clear();
+        updateInspectorStatus(QStringLiteral(
+            "Move the cursor over the main UI and click a region.  "
+            "ESC cancels."));
+        m_inspector->start();
+    } else {
+        m_inspector->stop();
+    }
+}
+
+void ThemeEditorDialog::onInspectorActiveChanged(bool active)
+{
+    // Keep the toggle button's checked state in lock-step with the
+    // inspector — covers self-deactivation paths (post-pick, ESC).
+    if (m_inspectBtn && m_inspectBtn->isChecked() != active) {
+        QSignalBlocker sb(m_inspectBtn);
+        m_inspectBtn->setChecked(active);
+    }
+}
+
+void ThemeEditorDialog::onInspectorPicked(QWidget* target, QPoint /*localPos*/)
+{
+    if (!target) return;
+    auto& tm = ThemeManager::instance();
+
+    // Walk up the parent chain until we find a widget with a declared
+    // token list — that's how a click on a deep child (e.g. the QLabel
+    // inside a QPushButton inside a themed panel) still surfaces the
+    // panel-level tokens.
+    QStringList tokens;
+    QWidget* w = target;
+    QString hitName = target->metaObject()->className();
+    while (w && tokens.isEmpty()) {
+        tokens = tm.tokensForWidget(w);
+        if (!tokens.isEmpty()) break;
+        w = w->parentWidget();
+    }
+
+    if (tokens.isEmpty()) {
+        updateInspectorStatus(QStringLiteral(
+            "%1: no theme tokens registered for this region yet.  Use the "
+            "filter or browse the full token list below.").arg(hitName));
+        m_activeSubset.clear();
+        filterTokensTo({});
+        return;
+    }
+
+    m_activeSubset = tokens;
+    filterTokensTo(tokens);
+
+    const QString matchedClass = w ? w->metaObject()->className() : hitName;
+    if (w && w != target) {
+        updateInspectorStatus(QStringLiteral(
+            "%1 (via %2): %3 token%4.").arg(matchedClass).arg(hitName)
+            .arg(tokens.size()).arg(tokens.size() == 1 ? "" : "s"));
+    } else {
+        updateInspectorStatus(QStringLiteral(
+            "%1: %2 token%3.").arg(matchedClass)
+            .arg(tokens.size()).arg(tokens.size() == 1 ? "" : "s"));
+    }
+
+    // Convenience: if exactly one color token matched, open the picker
+    // straight away — that's the "click ugly thing → fix it" flow.
+    if (tokens.size() == 1) {
+        for (int i = 0; i < m_tokenList->count(); ++i) {
+            auto* item = m_tokenList->item(i);
+            if (item->isHidden()) continue;
+            if (item->data(Qt::UserRole).toString() == tokens.first()) {
+                m_tokenList->setCurrentItem(item);
+                onTokenRowClicked(item);
+                break;
+            }
+        }
+    }
+}
+
+void ThemeEditorDialog::updateInspectorStatus(const QString& text)
+{
+    if (m_inspectStatus) m_inspectStatus->setText(text);
+}
+
+void ThemeEditorDialog::filterTokensTo(const QStringList& subset)
+{
+    // Empty subset → unhide everything that the text filter doesn't
+    // already exclude (i.e. fall back to the QLineEdit's current
+    // textChanged behaviour).
+    const QString needle = m_filterEdit
+                               ? m_filterEdit->text().trimmed().toLower()
+                               : QString();
+    const QSet<QString> wanted(subset.begin(), subset.end());
+    for (int i = 0; i < m_tokenList->count(); ++i) {
+        auto* item = m_tokenList->item(i);
+        const QString key = item->data(Qt::UserRole).toString();
+        bool hidden = false;
+        if (!subset.isEmpty() && !wanted.contains(key)) hidden = true;
+        if (!hidden && !needle.isEmpty() && !key.contains(needle)) hidden = true;
+        item->setHidden(hidden);
+    }
 }
 
 void ThemeEditorDialog::onActiveThemeChanged()

--- a/src/gui/ThemeEditorDialog.h
+++ b/src/gui/ThemeEditorDialog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QPointer>
 
 class QListWidget;
 class QListWidgetItem;
@@ -9,6 +10,8 @@ class QLineEdit;
 class QPushButton;
 
 namespace AetherSDR {
+
+class ThemeInspector;
 
 // Modeless dialog for live-editing the active theme's color tokens.
 //
@@ -38,14 +41,27 @@ private slots:
     void onSaveAsClicked();
     void onActiveThemeChanged();     // re-load when user picks a different theme
 
+    // Inspector-mode handlers.
+    void onInspectToggled(bool on);
+    void onInspectorPicked(QWidget* target, QPoint localPos);
+    void onInspectorActiveChanged(bool active);
+
 private:
     void updateTitle();
     void updateRow(QListWidgetItem* item);   // re-paint swatch + hex label
+    void updateInspectorStatus(const QString& text);
+    // Filter the token list down to a specific subset, e.g. tokens
+    // returned by tokensForWidget().  An empty list clears the filter.
+    void filterTokensTo(const QStringList& subset);
 
     QLabel*      m_themeLabel{nullptr};   // "Editing: <name>"
     QLineEdit*   m_filterEdit{nullptr};   // type-to-filter token names
     QListWidget* m_tokenList{nullptr};
     QPushButton* m_saveAsBtn{nullptr};
+    QPushButton* m_inspectBtn{nullptr};   // checkable
+    QLabel*      m_inspectStatus{nullptr};
+    ThemeInspector* m_inspector{nullptr};
+    QStringList     m_activeSubset;       // last inspector-picked token list
 
     // Tracks the active-theme NAME we last rendered against, so the
     // themeChanged handler can distinguish "user switched theme" (full

--- a/src/gui/ThemeInspector.cpp
+++ b/src/gui/ThemeInspector.cpp
@@ -1,0 +1,165 @@
+#include "ThemeInspector.h"
+#include "core/ThemeManager.h"
+
+#include <QApplication>
+#include <QCursor>
+#include <QDialog>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QWidget>
+
+namespace AetherSDR {
+
+// Frameless top-level overlay that draws a cyan outline around the widget
+// under the cursor.  Click-through via WindowTransparentForInput so the
+// global event filter remains the single source of mouse/keyboard events.
+class ThemeInspectorOverlay : public QWidget {
+public:
+    ThemeInspectorOverlay()
+        : QWidget(nullptr,
+                  Qt::Tool
+                  | Qt::FramelessWindowHint
+                  | Qt::WindowStaysOnTopHint
+                  | Qt::WindowTransparentForInput
+                  | Qt::BypassWindowManagerHint)
+    {
+        setAttribute(Qt::WA_TranslucentBackground);
+        setAttribute(Qt::WA_TransparentForMouseEvents);
+        setAttribute(Qt::WA_ShowWithoutActivating);
+        setFocusPolicy(Qt::NoFocus);
+    }
+
+protected:
+    void paintEvent(QPaintEvent*) override
+    {
+        QPainter p(this);
+        p.setRenderHint(QPainter::Antialiasing);
+        const QColor accent = ThemeManager::instance().color("color.accent");
+        QColor fill = accent;
+        fill.setAlpha(40);
+        p.setBrush(fill);
+        p.setPen(QPen(accent, 2));
+        p.drawRoundedRect(rect().adjusted(1, 1, -1, -1), 3, 3);
+    }
+};
+
+ThemeInspector::ThemeInspector(QDialog* editorDialog, QObject* parent)
+    : QObject(parent), m_editor(editorDialog)
+{}
+
+ThemeInspector::~ThemeInspector()
+{
+    if (m_active) stop();
+    delete m_overlay;
+}
+
+void ThemeInspector::start()
+{
+    if (m_active) return;
+    m_active = true;
+
+    if (!m_overlay) m_overlay = new ThemeInspectorOverlay;
+
+    QApplication::setOverrideCursor(QCursor(Qt::CrossCursor));
+    qApp->installEventFilter(this);
+    emit activeChanged(true);
+}
+
+void ThemeInspector::stop()
+{
+    if (!m_active) return;
+    m_active = false;
+    qApp->removeEventFilter(this);
+    QApplication::restoreOverrideCursor();
+    if (m_overlay) m_overlay->hide();
+    m_lastTarget.clear();
+    emit activeChanged(false);
+}
+
+bool ThemeInspector::eventFilter(QObject* /*obj*/, QEvent* ev)
+{
+    if (!m_active) return false;
+
+    switch (ev->type()) {
+    case QEvent::MouseMove: {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        updateOverlay(resolveTarget(me->globalPosition().toPoint()));
+        return false;
+    }
+    case QEvent::MouseButtonPress: {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (me->button() != Qt::LeftButton) return false;
+        const QPoint gp = me->globalPosition().toPoint();
+        QWidget* target = resolveTarget(gp);
+        if (!target) {
+            // Click on the editor dialog or its children — let the dialog
+            // handle it normally (so the operator can re-toggle Inspect
+            // off without it counting as a pick).
+            return false;
+        }
+        const QPoint local = target->mapFromGlobal(gp);
+        stop();
+        emit widgetPicked(target, local);
+        return true;  // eat the click so it doesn't reach the underlying widget
+    }
+    case QEvent::MouseButtonRelease: {
+        // Eat the matching release so half a click doesn't slip through.
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (me->button() != Qt::LeftButton) return false;
+        QWidget* target = QApplication::widgetAt(me->globalPosition().toPoint());
+        if (target && belongsToEditor(target)) return false;
+        return true;
+    }
+    case QEvent::KeyPress: {
+        auto* ke = static_cast<QKeyEvent*>(ev);
+        if (ke->key() == Qt::Key_Escape) {
+            stop();
+            emit canceled();
+            return true;
+        }
+        return false;
+    }
+    default:
+        return false;
+    }
+}
+
+QWidget* ThemeInspector::resolveTarget(const QPoint& globalPos) const
+{
+    QWidget* w = QApplication::widgetAt(globalPos);
+    if (!w) return nullptr;
+    if (belongsToEditor(w)) return nullptr;
+    if (m_overlay && (w == m_overlay || m_overlay->isAncestorOf(w))) return nullptr;
+    return w;
+}
+
+bool ThemeInspector::belongsToEditor(QWidget* w) const
+{
+    if (!m_editor || !w) return false;
+    if (w == m_editor) return true;
+    if (m_editor->isAncestorOf(w)) return true;
+    // Catches child popups owned by the editor (QColorDialog, etc.)
+    QWidget* top = w->window();
+    return top == m_editor;
+}
+
+void ThemeInspector::updateOverlay(QWidget* target)
+{
+    if (!m_overlay) return;
+    if (!target) {
+        m_overlay->hide();
+        m_lastTarget.clear();
+        return;
+    }
+    if (m_lastTarget == target && m_overlay->isVisible()) return;
+    m_lastTarget = target;
+    const QRect global(target->mapToGlobal(QPoint(0, 0)), target->size());
+    m_overlay->setGeometry(global);
+    if (!m_overlay->isVisible()) m_overlay->show();
+    m_overlay->raise();
+    m_overlay->update();
+}
+
+} // namespace AetherSDR

--- a/src/gui/ThemeInspector.h
+++ b/src/gui/ThemeInspector.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <QObject>
+#include <QPointer>
+
+class QDialog;
+class QEvent;
+class QWidget;
+
+namespace AetherSDR {
+
+class ThemeInspectorOverlay;
+
+// Browser-devtools-style "click to find the token painting this region".
+//
+// Lifecycle is driven by ThemeEditorDialog.  When the operator clicks the
+// "Inspect" toggle:
+//   1. start() installs a QApplication-level event filter and shows a
+//      transparent always-on-top overlay sized to the widget under the
+//      cursor.
+//   2. As the cursor moves, the overlay tracks the deepest widget at the
+//      global position (skipping the editor dialog itself + the overlay).
+//   3. Left-click captures (widget, local position), eats the event so it
+//      never reaches the underlying widget, deactivates, and emits
+//      widgetPicked() so the dialog can run tokensForWidget() and surface
+//      the matches.
+//   4. ESC cancels without picking.
+//
+// The overlay uses Qt::WindowTransparentForInput + WA_TransparentForMouseEvents
+// so it never intercepts events itself — the global event filter is the
+// authoritative event source.
+class ThemeInspector : public QObject {
+    Q_OBJECT
+public:
+    explicit ThemeInspector(QDialog* editorDialog, QObject* parent = nullptr);
+    ~ThemeInspector() override;
+
+    bool isActive() const { return m_active; }
+
+public slots:
+    void start();
+    void stop();
+
+signals:
+    // Emitted on left-click during inspect mode.  `target` is the deepest
+    // QWidget at the click point that wasn't part of the editor dialog;
+    // `localPos` is the click position in `target`'s local coordinates.
+    void widgetPicked(QWidget* target, QPoint localPos);
+
+    // Emitted when the operator cancels inspect mode without picking
+    // (ESC, or explicit stop() from the dialog).
+    void canceled();
+
+    // State-mirror signal so the dialog's toggle button stays in sync if
+    // inspect mode self-exits (after a pick, after ESC, on hidden-dialog).
+    void activeChanged(bool active);
+
+protected:
+    bool eventFilter(QObject* obj, QEvent* ev) override;
+
+private:
+    QWidget* resolveTarget(const QPoint& globalPos) const;
+    bool     belongsToEditor(QWidget* w) const;
+    void     updateOverlay(QWidget* target);
+
+    QDialog* m_editor;
+    bool     m_active{false};
+    QPointer<QWidget>      m_lastTarget;
+    ThemeInspectorOverlay* m_overlay{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -101,7 +101,7 @@ TitleBar::TitleBar(QWidget* parent)
     : QWidget(parent)
 {
     setFixedHeight(32);
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("TitleBar { background: {{color.background.0}}; border-bottom: 1px solid {{color.background.1}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "TitleBar { background: {{color.background.0}}; border-bottom: 1px solid {{color.background.1}}; }");
 
     m_hbox = new QHBoxLayout(this);
     m_hbox->setContentsMargins(4, 2, 8, 2);
@@ -121,7 +121,7 @@ TitleBar::TitleBar(QWidget* parent)
     // ── Heartbeat indicator ─────────────────────────────────────────────────
     m_heartbeat = new QLabel;
     m_heartbeat->setFixedSize(10, 10);
-    m_heartbeat->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.2}}; border-radius: 5px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_heartbeat, "QLabel { background: {{color.background.2}}; border-radius: 5px; }");
     m_heartbeat->setToolTip("Radio discovery heartbeat");
     m_heartbeat->setAccessibleName("Radio heartbeat");
     m_heartbeat->setAccessibleDescription("Flashes green when radio discovery packets are received");
@@ -132,7 +132,7 @@ TitleBar::TitleBar(QWidget* parent)
     m_heartbeatOffTimer->setSingleShot(true);
     m_heartbeatOffTimer->setInterval(100);
     connect(m_heartbeatOffTimer, &QTimer::timeout, this, [this]() {
-        m_heartbeat->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.2}}; border-radius: 5px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_heartbeat, "QLabel { background: {{color.background.2}}; border-radius: 5px; }");
     });
 
     // 500ms alarm blink timer (red/grey alternating)
@@ -180,7 +180,7 @@ TitleBar::TitleBar(QWidget* parent)
 
     m_appNameLabel = new QLabel(
         QString("AetherSDR v%1").arg(QCoreApplication::applicationVersion()));
-    m_appNameLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 14px; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_appNameLabel, "QLabel { color: {{color.accent}}; font-size: 14px; font-weight: bold; }");
     m_appNameLabel->setAlignment(Qt::AlignCenter);
     markDragHandle(m_appNameLabel);
     m_hbox->addWidget(m_appNameLabel);
@@ -276,14 +276,14 @@ TitleBar::TitleBar(QWidget* parent)
     m_masterSlider->setFixedHeight(16);
     m_masterSlider->setAccessibleName("Master volume");
     m_masterSlider->setAccessibleDescription("Line out volume level, 0 to 100 percent");
-    m_masterSlider->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSlider::groove:horizontal { background: {{color.background.1}}; height: 4px; border-radius: 2px; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_masterSlider, "QSlider::groove:horizontal { background: {{color.background.1}}; height: 4px; border-radius: 2px; }"
         "QSlider::handle:horizontal { background: {{color.accent}}; width: 10px; margin: -3px 0; border-radius: 5px; }"
-        "QSlider::sub-page:horizontal { background: {{color.accent}}; border-radius: 2px; }"));
+        "QSlider::sub-page:horizontal { background: {{color.accent}}; border-radius: 2px; }");
     m_hbox->addWidget(m_masterSlider);
 
     m_masterLabel = new QLabel(QString::number(savedVol));
     m_masterLabel->setFixedWidth(22);
-    m_masterLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_masterLabel, "QLabel { color: {{color.text.secondary}}; font-size: 10px; }");
     m_masterLabel->setAlignment(Qt::AlignCenter);
     markDragHandle(m_masterLabel);
     m_hbox->addWidget(m_masterLabel);
@@ -318,14 +318,14 @@ TitleBar::TitleBar(QWidget* parent)
     m_hpSlider->setFixedHeight(16);
     m_hpSlider->setAccessibleName("Headphone volume");
     m_hpSlider->setAccessibleDescription("Headphone volume level, 0 to 100 percent");
-    m_hpSlider->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QSlider::groove:horizontal { background: {{color.background.1}}; height: 4px; border-radius: 2px; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_hpSlider, "QSlider::groove:horizontal { background: {{color.background.1}}; height: 4px; border-radius: 2px; }"
         "QSlider::handle:horizontal { background: {{color.accent}}; width: 10px; margin: -3px 0; border-radius: 5px; }"
-        "QSlider::sub-page:horizontal { background: {{color.accent}}; border-radius: 2px; }"));
+        "QSlider::sub-page:horizontal { background: {{color.accent}}; border-radius: 2px; }");
     m_hbox->addWidget(m_hpSlider);
 
     m_hpLabel = new QLabel("50");
     m_hpLabel->setFixedWidth(22);
-    m_hpLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_hpLabel, "QLabel { color: {{color.text.secondary}}; font-size: 10px; }");
     m_hpLabel->setAlignment(Qt::AlignCenter);
     markDragHandle(m_hpLabel);
     m_hbox->addWidget(m_hpLabel);
@@ -343,7 +343,7 @@ TitleBar::TitleBar(QWidget* parent)
 
     auto* sep = new QFrame;
     sep->setFixedSize(1, 20);
-    sep->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QFrame { background: {{color.background.2}}; border: none; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(sep, "QFrame { background: {{color.background.2}}; border: none; }");
     markDragHandle(sep);
     m_hbox->addWidget(sep);
 
@@ -397,7 +397,7 @@ TitleBar::TitleBar(QWidget* parent)
 
     m_dockSep = new QFrame;
     m_dockSep->setFixedSize(1, 20);
-    m_dockSep->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QFrame { background: {{color.background.2}}; border: none; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_dockSep, "QFrame { background: {{color.background.2}}; border: none; }");
     markDragHandle(m_dockSep);
     m_hbox->addWidget(m_dockSep);
 
@@ -728,12 +728,12 @@ void TitleBar::mouseDoubleClickEvent(QMouseEvent* ev)
 void TitleBar::setMenuBar(QMenuBar* mb)
 {
     if (!mb) return;
-    mb->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QMenuBar { background: transparent; color: {{color.text.secondary}}; font-size: 12px; }"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(mb, "QMenuBar { background: transparent; color: {{color.text.secondary}}; font-size: 12px; }"
         "QMenuBar::item { padding: 4px 8px; }"
         "QMenuBar::item:selected { background: {{color.background.1}}; color: {{color.text.primary}}; }"
         "QMenu { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; }"
         "QMenu::item:selected { background: {{color.background.2}}; }"
-        "QMenu::separator { height: 1px; background: {{color.background.2}}; margin: 4px 8px; }"));
+        "QMenu::separator { height: 1px; background: {{color.background.2}}; margin: 4px 8px; }");
     mb->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
     m_menuBar = mb;
     m_menuBar->installEventFilter(this);
@@ -913,7 +913,7 @@ void TitleBar::showFeatureRequestDialogImpl()
     sDlg = dlg;
     dlg->setWindowTitle("AI-Assisted Issue Reporter");
     dlg->setAttribute(Qt::WA_DeleteOnClose);
-    dlg->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDialog { background: {{color.background.0}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(dlg, "QDialog { background: {{color.background.0}}; }");
     dlg->setMinimumWidth(620);
 
     auto* vbox = new QVBoxLayout(dlg);
@@ -976,9 +976,9 @@ void TitleBar::showFeatureRequestDialogImpl()
     auto* btnRow2 = new QHBoxLayout;
 
     auto* submitBtn = new QPushButton("Submit Your Idea", dlg);
-    submitBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(submitBtn, "QPushButton { background: {{color.accent}}; color: {{color.background.0}}; font-weight: bold; "
         "border-radius: 4px; padding: 8px 20px; font-size: 13px; }"
-        "QPushButton:hover { background: {{color.accent.bright}}; }"));
+        "QPushButton:hover { background: {{color.accent.bright}}; }");
     connect(submitBtn, &QPushButton::clicked, dlg, [dlg] {
         QDesktopServices::openUrl(QUrl(
             "https://github.com/aethersdr/AetherSDR/issues/new?template=feature_request.yml"));
@@ -987,9 +987,9 @@ void TitleBar::showFeatureRequestDialogImpl()
     btnRow2->addWidget(submitBtn);
 
     auto* bugBtn = new QPushButton("Report a Bug", dlg);
-    bugBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #cc4040; color: {{color.text.primary}}; font-weight: bold; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(bugBtn, "QPushButton { background: #cc4040; color: {{color.text.primary}}; font-weight: bold; "
         "border-radius: 4px; padding: 8px 20px; font-size: 13px; }"
-        "QPushButton:hover { background: #dd5050; }"));
+        "QPushButton:hover { background: #dd5050; }");
     connect(bugBtn, &QPushButton::clicked, dlg, [dlg] {
         QDesktopServices::openUrl(QUrl(
             "https://github.com/aethersdr/AetherSDR/issues/new?template=bug_report.yml"));
@@ -1022,7 +1022,7 @@ void TitleBar::setDiscovering(bool active)
     } else {
         m_heartbeat->setToolTip("Radio discovery heartbeat");
         // Return to idle gray — onHeartbeat() will take over once pings arrive
-        m_heartbeat->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.2}}; border-radius: 5px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_heartbeat, "QLabel { background: {{color.background.2}}; border-radius: 5px; }");
     }
 }
 

--- a/src/gui/TunerApplet.cpp
+++ b/src/gui/TunerApplet.cpp
@@ -110,16 +110,16 @@ void TunerApplet::buildUI()
 
     m_tuneBtn = new QPushButton("TUNE");
     m_tuneBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Expanding);
-    m_tuneBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_tuneBtn, "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
-        "QPushButton:hover { background: {{color.background.1}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; }");
     btnCol->addWidget(m_tuneBtn);
 
     m_operateBtn = new QPushButton("OPERATE");
     m_operateBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Expanding);
-    m_operateBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_operateBtn, "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
-        "QPushButton:hover { background: {{color.background.1}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; }");
     btnCol->addWidget(m_operateBtn);
 
     bottomRow->addLayout(btnCol, 3);  // stretch 3 (30%)
@@ -138,9 +138,9 @@ void TunerApplet::buildUI()
             auto* btn = new QPushButton(text);
             btn->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
             btn->setFixedHeight(22);
-            btn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+            AetherSDR::ThemeManager::instance().applyStyleSheet(btn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
                 "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
-                "QPushButton:hover { background: {{color.background.1}}; }"));
+                "QPushButton:hover { background: {{color.background.1}}; }");
             return btn;
         };
 
@@ -228,14 +228,14 @@ void TunerApplet::setTunerModel(TunerModel* model)
             m_postTuneCapture = false;
             m_postTuneTimer->stop();
             m_tuneSwr = 999.0f;  // reset high so capture tracking works
-            m_tuneBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #cc2222; border: 1px solid {{color.accent.danger}}; "
-                "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_tuneBtn, "QPushButton { background: #cc2222; border: 1px solid {{color.accent.danger}}; "
+                "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }");
             m_tuneBtn->setText("TUNING...");
         } else {
             // Restore normal style
-            m_tuneBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_tuneBtn, "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
                 "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
-                "QPushButton:hover { background: {{color.background.1}}; }"));
+                "QPushButton:hover { background: {{color.background.1}}; }");
 
             // Don't display result immediately — the final settled SWR from
             // the TGXL often arrives after tuning=0 via TCP.  Start a short
@@ -273,19 +273,19 @@ void TunerApplet::syncFromModel()
     // operate=0            → STANDBY (default)
     if (m_model->isOperate() && !m_model->isBypass()) {
         m_operateBtn->setText("OPERATE");
-        m_operateBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #006030; border: 1px solid #008040; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_operateBtn, "QPushButton { background: #006030; border: 1px solid #008040; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
-            "QPushButton:hover { background: #007040; }"));
+            "QPushButton:hover { background: #007040; }");
     } else if (m_model->isOperate() && m_model->isBypass()) {
         m_operateBtn->setText("BYPASS");
-        m_operateBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #8a6000; border: 1px solid #a07000; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_operateBtn, "QPushButton { background: #8a6000; border: 1px solid #a07000; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
-            "QPushButton:hover { background: #9a7000; }"));
+            "QPushButton:hover { background: #9a7000; }");
     } else {
         m_operateBtn->setText("STANDBY");
-        m_operateBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_operateBtn, "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
-            "QPushButton:hover { background: {{color.background.1}}; }"));
+            "QPushButton:hover { background: {{color.background.1}}; }");
     }
 }
 

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -30,7 +30,7 @@ namespace AetherSDR {
 static QLabel* makeIndicator(const QString& text)
 {
     auto* lbl = new QLabel(text);
-    lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.meter.bar.fill}}; font-size: 9px; font-weight: bold; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.meter.bar.fill}}; font-size: 9px; font-weight: bold; }");
     lbl->setAlignment(Qt::AlignCenter);
     return lbl;
 }
@@ -41,7 +41,7 @@ static void setIndicatorActive(QLabel* lbl, bool active, const QColor& color = Q
         lbl->setStyleSheet(
             QString("QLabel { color: %1; font-size: 9px; font-weight: bold; }").arg(color.name()));
     } else {
-        lbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.meter.bar.fill}}; font-size: 9px; font-weight: bold; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.meter.bar.fill}}; font-size: 9px; font-weight: bold; }");
     }
 }
 
@@ -125,7 +125,7 @@ void TxApplet::buildUI()
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
         auto* label = new QLabel("RF Power:");
-        label->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(label, "QLabel { color: {{color.text.secondary}}; font-size: 10px; }");
         label->setFixedWidth(62);
         row->addWidget(label);
 
@@ -138,7 +138,7 @@ void TxApplet::buildUI()
         row->addWidget(m_rfPowerSlider, 1);
 
         m_rfPowerLabel = new QLabel("100");
-        m_rfPowerLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_rfPowerLabel, "QLabel { color: {{color.text.primary}}; font-size: 10px; }");
         m_rfPowerLabel->setFixedWidth(30);
         m_rfPowerLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         row->addWidget(m_rfPowerLabel);
@@ -150,7 +150,7 @@ void TxApplet::buildUI()
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
         auto* label = new QLabel("Tune Pwr:");
-        label->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(label, "QLabel { color: {{color.text.secondary}}; font-size: 10px; }");
         label->setFixedWidth(62);
         row->addWidget(label);
 
@@ -163,7 +163,7 @@ void TxApplet::buildUI()
         row->addWidget(m_tunePowerSlider, 1);
 
         m_tunePowerLabel = new QLabel("10");
-        m_tunePowerLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_tunePowerLabel, "QLabel { color: {{color.text.primary}}; font-size: 10px; }");
         m_tunePowerLabel->setFixedWidth(30);
         m_tunePowerLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         row->addWidget(m_tunePowerLabel);
@@ -266,10 +266,10 @@ void TxApplet::buildUI()
         m_apdBtn->setAccessibleName("APD pre-distortion");
         m_apdBtn->setAccessibleDescription("Toggle adaptive pre-distortion");
         m_apdBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
-        m_apdBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_apdBtn, "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
             "QPushButton:checked { background: #006030; border: 1px solid #008040; color: {{color.text.primary}}; }"
-            "QPushButton:hover { background: {{color.background.1}}; }"));
+            "QPushButton:hover { background: {{color.background.1}}; }");
         row->addWidget(m_apdBtn, 2);  // 40%
 
         // Inset container for ATU status words (styled like RIT/XIT readout)
@@ -277,8 +277,8 @@ void TxApplet::buildUI()
         inset->setFixedHeight(22);
         inset->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         inset->setObjectName("atuInset");
-        inset->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("#atuInset { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; border-radius: 3px; }"
-            "#atuInset QLabel { border: none; background: transparent; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(inset, "#atuInset { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; border-radius: 3px; }"
+            "#atuInset QLabel { border: none; background: transparent; }");
         auto* insetLayout = new QHBoxLayout(inset);
         insetLayout->setContentsMargins(4, 0, 4, 0);
         insetLayout->setSpacing(2);
@@ -388,15 +388,15 @@ void TxApplet::setTransmitModel(TransmitModel* model)
     // Tune state → red button
     connect(m_model, &TransmitModel::tuneChanged, this, [this](bool tuning) {
         if (tuning) {
-            m_tuneBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #cc2222; border: 1px solid {{color.accent.danger}}; "
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_tuneBtn, "QPushButton { background: #cc2222; border: 1px solid {{color.accent.danger}}; "
                 "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; "
-                "padding: 2px; }"));
+                "padding: 2px; }");
             m_tuneBtn->setText("TUNING...");
         } else {
-            m_tuneBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_tuneBtn, "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
                 "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; "
                 "padding: 2px; }"
-                "QPushButton:hover { background: {{color.background.1}}; }"));
+                "QPushButton:hover { background: {{color.background.1}}; }");
             m_tuneBtn->setText("TUNE");
         }
     });

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -153,10 +153,10 @@ public:
     {
         setFlat(false);
         setFixedSize(22, 22);
-        setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.1}}; "
             "border-radius: 3px; padding: 0; margin: 0; min-width: 0; min-height: 0; }"
             "QPushButton:hover { background: {{color.background.1}}; }"
-            "QPushButton:pressed { background: {{color.accent}}; }"));
+            "QPushButton:pressed { background: {{color.accent}}; }");
     }
 protected:
     void paintEvent(QPaintEvent* ev) override {
@@ -440,9 +440,9 @@ void VfoWidget::buildUI()
     hdr->addWidget(m_txAntBtn);
 
     m_filterWidthLbl = new QLabel("2.7K");
-    m_filterWidthLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: transparent; border: none; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_filterWidthLbl, "QLabel { background: transparent; border: none; "
                                      "color: {{color.accent.bright}}; font-size: 13px; font-weight: bold; "
-                                     "margin: 0; padding: 0; }"));
+                                     "margin: 0; padding: 0; }");
     hdr->addWidget(m_filterWidthLbl);
 
     hdr->addStretch(1);
@@ -478,8 +478,8 @@ void VfoWidget::buildUI()
     m_sliceBadge->setAlignment(Qt::AlignCenter);
     m_sliceBadge->setCursor(Qt::PointingHandCursor);
     m_sliceBadge->setTextFormat(Qt::RichText);  // slice letter may be HTML (#2606)
-    m_sliceBadge->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.2}}; color: {{color.text.primary}}; "
-        "border-radius: 3px; font-weight: bold; font-size: 11px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_sliceBadge, "QLabel { background: {{color.background.2}}; color: {{color.text.primary}}; "
+        "border-radius: 3px; font-weight: bold; font-size: 11px; }");
     hdr->addWidget(m_sliceBadge);
 
     root->addLayout(hdr);
@@ -564,9 +564,9 @@ void VfoWidget::buildUI()
 
     // ── Collapsed-mode frequency label (child of parent like close/lock) ───
     m_collapsedFreqLabel = new QLabel(btnParent);
-    m_collapsedFreqLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: rgba(10,10,20,220); border: 1px solid rgba(255,255,255,60);"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_collapsedFreqLabel, "QLabel { background: rgba(10,10,20,220); border: 1px solid rgba(255,255,255,60);"
         " border-radius: 3px; color: {{color.text.primary}}; font-size: 14px; font-weight: bold;"
-        " padding: 1px 4px; }"));
+        " padding: 1px 4px; }");
     m_collapsedFreqLabel->setAlignment(Qt::AlignCenter);
     m_collapsedFreqLabel->hide();
 
@@ -575,19 +575,19 @@ void VfoWidget::buildUI()
     m_freqStack->setFixedHeight(30);
 
     m_freqLabel = new QLabel("14.225.000");
-    m_freqLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: transparent;"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_freqLabel, "QLabel { background: transparent;"
                                 " border: 1px solid rgba(255,255,255,80);"
                                 " border-radius: 3px;"
                                 " color: {{color.text.primary}}; font-size: 26px; font-weight: bold;"
-                                " padding: 0 0 0 2px; }"));
+                                " padding: 0 0 0 2px; }");
     m_freqLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     m_freqLabel->installEventFilter(this);
     m_freqStack->addWidget(m_freqLabel);
 
     m_freqEdit = new QLineEdit;
-    m_freqEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { background: {{color.background.0}}; border: 1px solid {{color.accent}};"
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_freqEdit, "QLineEdit { background: {{color.background.0}}; border: 1px solid {{color.accent}};"
         " border-radius: 3px; color: #00e5ff; font-size: 22px;"
-        " font-weight: bold; padding: 0 2px 0 0; }"));
+        " font-weight: bold; padding: 0 2px 0 0; }");
     m_freqEdit->setAlignment(Qt::AlignRight);
     // Size to fit "0000.000.000" at the label font size (4-digit MHz for XVTR/SHF)
     QFont labelFont;
@@ -661,8 +661,8 @@ void VfoWidget::buildUI()
         m_radeStatusLabel = new QLabel;
         m_radeStatusLabel->setFixedHeight(16);
         m_radeStatusLabel->setTextFormat(Qt::RichText);
-        m_radeStatusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 10px; font-weight: bold;"
-            " background: transparent; border: none; padding: 0; margin: 0; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_radeStatusLabel, "QLabel { color: {{color.accent}}; font-size: 10px; font-weight: bold;"
+            " background: transparent; border: none; padding: 0; margin: 0; }");
         m_radeStatusLabel->hide();
         freqRow->addWidget(m_radeStatusLabel);
 #endif
@@ -689,8 +689,8 @@ void VfoWidget::buildUI()
             " background: transparent; border: none; padding: 0; margin: 0; }";
 
         m_radeCallsignLabel = new QLabel;
-        m_radeCallsignLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 10px; font-weight: bold;"
-            " background: transparent; border: none; padding: 0; margin: 0; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_radeCallsignLabel, "QLabel { color: {{color.accent}}; font-size: 10px; font-weight: bold;"
+            " background: transparent; border: none; padding: 0; margin: 0; }");
         m_radeCallsignLabel->hide();
         infoLayout->addWidget(m_radeCallsignLabel);
 
@@ -803,11 +803,11 @@ void VfoWidget::buildTabContent()
         m_muteBtn->setCheckable(true);
         m_muteBtn->setFixedHeight(20);
         m_muteBtn->setFixedWidth(60);
-        m_muteBtn->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}};"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_muteBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}};"
             " border-radius: 2px; color: {{color.text.primary}}; font-size: 13px;"
             " font-weight: bold; padding: 1px 4px; }"
             "QPushButton:checked { background: #6a2020; color: {{color.accent.danger}};"
-            " border: 1px solid #a04040; }"));
+            " border: 1px solid #a04040; }");
         gainRow->addWidget(m_muteBtn);
         m_afGainSlider = new GuardedSlider(Qt::Horizontal);
         m_afGainSlider->setAccessibleName("AF gain");
@@ -976,14 +976,14 @@ void VfoWidget::buildTabContent()
         escMeterRow->setContentsMargins(0, 0, 10, 0);
         escMeterRow->addStretch();
         m_escMeterLbl = new QLabel("ESC:");
-        m_escMeterLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; font-family: monospace; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_escMeterLbl, "QLabel { color: {{color.accent}}; font-size: 11px; font-family: monospace; }");
         escMeterRow->addWidget(m_escMeterLbl);
         m_escMeterBar = new LevelBar(m_escLevelDbm);
         m_escMeterBar->setFixedHeight(8);
         m_escMeterBar->setFixedWidth(60);
         escMeterRow->addWidget(m_escMeterBar);
         m_escDbmLbl = new QLabel("--- dBm");
-        m_escDbmLbl->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.accent}}; font-size: 11px; font-family: monospace; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_escDbmLbl, "QLabel { color: {{color.accent}}; font-size: 11px; font-family: monospace; }");
         m_escDbmLbl->setAlignment(Qt::AlignRight);
         escMeterRow->addWidget(m_escDbmLbl);
         escVbox->addLayout(escMeterRow);
@@ -1201,8 +1201,8 @@ void VfoWidget::buildTabContent()
             lvlHb->setSpacing(4);
 
             m_dspLevelLabel = new QLabel("NR");
-            m_dspLevelLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 13px; font-weight: bold;"
-                "  min-width: 40px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_dspLevelLabel, "QLabel { color: {{color.text.primary}}; font-size: 13px; font-weight: bold;"
+                "  min-width: 40px; }");
             m_dspLevelLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
             lvlHb->addWidget(m_dspLevelLabel);
 
@@ -1212,8 +1212,8 @@ void VfoWidget::buildTabContent()
             lvlHb->addWidget(m_dspLevelSlider, 1);
 
             m_dspLevelValue = new QLabel("0");
-            m_dspLevelValue->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 10px; min-width: 24px;"
-                "  padding-right: 4px; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_dspLevelValue, "QLabel { color: {{color.text.primary}}; font-size: 10px; min-width: 24px;"
+                "  padding-right: 4px; }");
             m_dspLevelValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
             lvlHb->addWidget(m_dspLevelValue);
 
@@ -1425,8 +1425,8 @@ void VfoWidget::buildTabContent()
 
             m_digOffsetEdit = new QLineEdit;
             m_digOffsetEdit->setAlignment(Qt::AlignCenter);
-            m_digOffsetEdit->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLineEdit { font-size: 10px; background: {{color.background.0}}; border: 1px solid {{color.accent}}; "
-                "border-radius: 3px; padding: 0px 2px; color: #00e5ff; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_digOffsetEdit, "QLineEdit { font-size: 10px; background: {{color.background.0}}; border: 1px solid {{color.accent}}; "
+                "border-radius: 3px; padding: 0px 2px; color: #00e5ff; }");
             m_digOffsetStack->addWidget(m_digOffsetEdit);   // index 1
 
             row->addWidget(m_digOffsetStack, 1);
@@ -1563,9 +1563,9 @@ void VfoWidget::buildTabContent()
             m_fmOffsetSpin->setDecimals(3);
             m_fmOffsetSpin->setSingleStep(0.1);
             m_fmOffsetSpin->setSuffix(" MHz");
-            m_fmOffsetSpin->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QDoubleSpinBox { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_fmOffsetSpin, "QDoubleSpinBox { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; "
                 "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; padding: 1px 2px; }"
-                "QDoubleSpinBox::up-button, QDoubleSpinBox::down-button { width: 0; }"));
+                "QDoubleSpinBox::up-button, QDoubleSpinBox::down-button { width: 0; }");
             offRow->addWidget(m_fmOffsetSpin, 1);
             fvb->addLayout(offRow);
 
@@ -2953,13 +2953,13 @@ void VfoWidget::setSlice(SliceModel* slice)
 void VfoWidget::updateTxBadgeStyle(bool isTx)
 {
     if (isTx) {
-        m_txBadge->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #cc0000; color: {{color.text.primary}}; border: none; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_txBadge, "QPushButton { background: #cc0000; color: {{color.text.primary}}; border: none; "
             "border-radius: 2px; font-size: 12px; font-weight: bold; padding: 0; }"
-            "QPushButton:hover { background: #ff2222; }"));
+            "QPushButton:hover { background: #ff2222; }");
     } else {
-        m_txBadge->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #404040; color: {{color.text.label}}; border: none; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_txBadge, "QPushButton { background: #404040; color: {{color.text.label}}; border: none; "
             "border-radius: 2px; font-size: 12px; font-weight: bold; padding: 0; }"
-            "QPushButton:hover { background: #606060; color: #c0c0c0; }"));
+            "QPushButton:hover { background: #606060; color: #c0c0c0; }");
     }
 }
 
@@ -2969,17 +2969,17 @@ void VfoWidget::updateSplitBadge(bool isTxSlice, bool isRxSplit)
         // TX slice in split pair — show SWAP button
         m_splitBadge->show();
         m_splitBadge->setText("SWAP");
-        m_splitBadge->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: {{color.background.1}}; color: #80c0ff; border: none; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_splitBadge, "QPushButton { background: {{color.background.1}}; color: #80c0ff; border: none; "
             "border-radius: 2px; font-size: 11px; font-weight: bold; "
             "padding: 0px 3px; }"
-            "QPushButton:hover { background: #306080; color: {{color.text.primary}}; }"));
+            "QPushButton:hover { background: #306080; color: {{color.text.primary}}; }");
     } else if (isRxSplit) {
         // RX slice that initiated split — red badge, full opacity
         m_splitBadge->show();
-        m_splitBadge->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QPushButton { background: #cc0000; color: {{color.text.primary}}; border: none; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_splitBadge, "QPushButton { background: #cc0000; color: {{color.text.primary}}; border: none; "
             "border-radius: 2px; font-size: 11px; font-weight: bold; "
             "padding: 0px 3px; }"
-            "QPushButton:hover { background: #ee2222; }"));
+            "QPushButton:hover { background: #ee2222; }");
     } else {
         // Split not active — ghosted on all slices
         m_splitBadge->show();
@@ -4051,8 +4051,8 @@ bool VfoWidget::eventFilter(QObject* obj, QEvent* event)
         auto* me = static_cast<QMouseEvent*>(event);
         if (me->button() == Qt::RightButton && m_slice) {
             QMenu menu(this);
-            menu.setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QMenu { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid #304060; }"
-                "QMenu::item:selected { background: {{color.accent}}; color: {{color.background.0}}; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(&menu, "QMenu { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid #304060; }"
+                "QMenu::item:selected { background: {{color.accent}}; color: {{color.background.0}}; }");
             menu.addAction("Add Spot", this, [this] {
                 emit addSpotRequested(m_slice->frequency());
             });
@@ -4099,8 +4099,8 @@ void VfoWidget::setRadeActive(bool on, const QString& label)
         m_radeInfoRow->setVisible(on);
         if (!on) {
             m_radeSnrLabel->setText("---");
-            m_radeSnrLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px;"
-                " background: transparent; border: none; padding: 0; margin: 0; }"));
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_radeSnrLabel, "QLabel { color: {{color.text.secondary}}; font-size: 10px;"
+                " background: transparent; border: none; padding: 0; margin: 0; }");
             m_radeOffsetLabel->hide();
             m_radeCallsignLabel->hide();
         }
@@ -4115,8 +4115,8 @@ void VfoWidget::setRadeSynced(bool synced)
                                : "<font color='#505050'>\u25CB</font>";
     m_radeStatusLabel->setText(m_radeLabel + " " + led);
     if (!synced) {
-        m_radeSnrLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px;"
-            " background: transparent; border: none; padding: 0; margin: 0; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_radeSnrLabel, "QLabel { color: {{color.text.secondary}}; font-size: 10px;"
+            " background: transparent; border: none; padding: 0; margin: 0; }");
         m_radeSnrLabel->setText("---");
         m_radeOffsetLabel->hide();
     } else {

--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -63,7 +63,7 @@ QLabel* makeSettingLabel(const QString& text, QWidget* parent)
     auto* label = new QLabel(text, parent);
     label->setFixedWidth(62);
     label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-    label->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.secondary}}; font-size: 10px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(label, "QLabel { color: {{color.text.secondary}}; font-size: 10px; }");
     return label;
 }
 
@@ -249,7 +249,7 @@ void WaveApplet::buildSettingsDrawer()
         m_zoomValue = new QLabel(m_settingsDrawer);
         m_zoomValue->setFixedWidth(38);
         m_zoomValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        m_zoomValue->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_zoomValue, "QLabel { color: {{color.text.primary}}; font-size: 10px; }");
         row->addWidget(m_zoomValue);
 
         connectSliderSetting(m_zoomSlider,
@@ -283,7 +283,7 @@ void WaveApplet::buildSettingsDrawer()
         m_refreshValue = new QLabel(m_settingsDrawer);
         m_refreshValue->setFixedWidth(38);
         m_refreshValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        m_refreshValue->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_refreshValue, "QLabel { color: {{color.text.primary}}; font-size: 10px; }");
         row->addWidget(m_refreshValue);
 
         connectSliderSetting(m_refreshSlider,
@@ -319,7 +319,7 @@ void WaveApplet::buildSettingsDrawer()
         m_windowValue = new QLabel(m_settingsDrawer);
         m_windowValue->setFixedWidth(48);
         m_windowValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        m_windowValue->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { color: {{color.text.primary}}; font-size: 10px; }"));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_windowValue, "QLabel { color: {{color.text.primary}}; font-size: 10px; }");
         row->addWidget(m_windowValue);
 
         connectSliderSetting(m_windowSlider,

--- a/src/gui/WhatsNewDialog.cpp
+++ b/src/gui/WhatsNewDialog.cpp
@@ -248,37 +248,37 @@ void WhatsNewDialog::buildUI(const QString& lastSeenVersion,
         "AETHERSDR V%1</span><br>"
         "<span style='color: #dce8f3; font-size: 24px; font-weight: bold;'>"
         "%2</span></div>").arg(currentVersion, heading));
-    header->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.0}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(header, "QLabel { background: {{color.background.0}}; }");
     layout->addWidget(header);
 
     m_statusLabel = new QLabel;
     m_statusLabel->setAlignment(Qt::AlignCenter);
     m_statusLabel->setWordWrap(true);
     m_statusLabel->setContentsMargins(18, 0, 18, 8);
-    m_statusLabel->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: {{color.background.0}}; color: {{color.text.secondary}}; font-size: 12px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_statusLabel, "QLabel { background: {{color.background.0}}; color: {{color.text.secondary}}; font-size: 12px; }");
     layout->addWidget(m_statusLabel);
 
     auto* sep = new QWidget;
     sep->setFixedHeight(1);
-    sep->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("background: {{color.background.1}};"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(sep, "background: {{color.background.1}};");
     layout->addWidget(sep);
 
     m_browser = new QTextBrowser;
     m_browser->setOpenExternalLinks(false);
     m_browser->setOpenLinks(false);
     m_browser->setReadOnly(true);
-    m_browser->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QTextBrowser { background: {{color.background.0}}; color: #d6e2ee; border: none; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_browser, "QTextBrowser { background: {{color.background.0}}; color: #d6e2ee; border: none; "
         "padding: 18px; font-size: 13px; }"
         "QScrollBar:vertical { background: {{color.background.0}}; width: 10px; }"
         "QScrollBar::handle:vertical { background: {{color.background.2}}; border-radius: 5px; }"
-        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }"));
+        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }");
     connect(m_browser, &QTextBrowser::anchorClicked, this, [](const QUrl& url) {
         QDesktopServices::openUrl(githubUrlForMaybeRelativeLink(url));
     });
     layout->addWidget(m_browser, 1);
 
     auto* footer = new QWidget;
-    footer->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("background: {{color.background.0}};"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(footer, "background: {{color.background.0}};");
     auto* footerLayout = new QHBoxLayout(footer);
     footerLayout->setContentsMargins(16, 12, 16, 16);
     footerLayout->setSpacing(12);
@@ -326,7 +326,7 @@ void WhatsNewDialog::buildUI(const QString& lastSeenVersion,
     footerLayout->addStretch(1);
     layout->addWidget(footer);
 
-    setStyleSheet(AetherSDR::ThemeManager::instance().resolve("WhatsNewDialog { background: {{color.background.0}}; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this, "WhatsNewDialog { background: {{color.background.0}}; }");
 
     showLoadingState();
     fetchLiveReleaseNotes();

--- a/src/gui/containers/ContainerTitleBar.cpp
+++ b/src/gui/containers/ContainerTitleBar.cpp
@@ -67,7 +67,7 @@ ContainerTitleBar::ContainerTitleBar(const QString& title, QWidget* parent)
     // Drag grip glyph (⋮⋮) — purely decorative; actual drag events
     // come from mouseMoveEvent on the bar as a whole.
     auto* grip = new QLabel(QString::fromUtf8("\xe2\x8b\xae\xe2\x8b\xae"));
-    grip->setStyleSheet(AetherSDR::ThemeManager::instance().resolve("QLabel { background: transparent; color: {{color.text.secondary}}; font-size: 10px; }"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(grip, "QLabel { background: transparent; color: {{color.text.secondary}}; font-size: 10px; }");
     layout->addWidget(grip);
 
     m_titleLabel = new QLabel(title);

--- a/tools/migrate_setStyleSheet_to_applyStyleSheet.py
+++ b/tools/migrate_setStyleSheet_to_applyStyleSheet.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+Phase 5 PR 2 sweep — convert every
+
+    WIDGET->setStyleSheet(THEMEREF.resolve("template"));
+    setStyleSheet(THEMEREF.resolve("template"));        // called on `this`
+    obj.setStyleSheet(THEMEREF.resolve("template"));    // stack-allocated
+
+into
+
+    THEMEREF.applyStyleSheet(WIDGET, "template");
+    THEMEREF.applyStyleSheet(this,   "template");
+    THEMEREF.applyStyleSheet(&obj,   "template");
+
+The replacement is bit-identical at runtime (applyStyleSheet's first step is
+`widget->setStyleSheet(resolve(template))`) but adds the (widget → tokens)
+reverse-map entry that the Phase 5 inspector queries.
+
+The receiver-finding walk handles arbitrary chained-access expressions:
+  m_btn->setStyleSheet(...)
+  this->m_btn->setStyleSheet(...)
+  btns[i]->setStyleSheet(...)
+  statusBar()->setStyleSheet(...)
+  parent()->widget->setStyleSheet(...)
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+STYLE_RE = re.compile(r'\bsetStyleSheet\s*\(')
+
+
+def find_matching_paren(src: str, open_idx: int) -> int:
+    """Given index of '(' return index of matching ')'. -1 on imbalance."""
+    depth = 0
+    i = open_idx
+    in_str = False
+    str_ch = ''
+    while i < len(src):
+        c = src[i]
+        if in_str:
+            if c == '\\':
+                i += 2
+                continue
+            if c == str_ch:
+                in_str = False
+        else:
+            if c in ('"', "'"):
+                in_str = True
+                str_ch = c
+            elif c == '(':
+                depth += 1
+            elif c == ')':
+                depth -= 1
+                if depth == 0:
+                    return i
+        i += 1
+    return -1
+
+
+def find_matching_paren_back(src: str, close_idx: int) -> int:
+    """Walk backwards from a ')' or ']' to its matching open. -1 if none."""
+    open_ch, close_ch = {'(': '(', ')': '(', '[': '[', ']': '['}.get(src[close_idx]), src[close_idx]
+    if src[close_idx] == ')':
+        opener = '('
+    elif src[close_idx] == ']':
+        opener = '['
+    else:
+        return -1
+    depth = 1
+    i = close_idx - 1
+    while i >= 0:
+        c = src[i]
+        if c == src[close_idx]:
+            depth += 1
+        elif c == opener:
+            depth -= 1
+            if depth == 0:
+                return i
+        i -= 1
+    return -1
+
+
+# Characters that can be part of a chained receiver expression once we
+# strip out balanced (...) / [...] groups.  Anything outside this set
+# (e.g. ';', '{', ',', '=', '+', whitespace at the start of a line)
+# terminates the receiver.
+RECEIVER_TOKEN_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.")
+
+
+def find_receiver_start(src: str, end: int) -> int:
+    """Scan backwards from `end` (exclusive) to find the start of the
+    receiver expression for setStyleSheet.  Returns the start index, or
+    `end` itself if the call has no receiver (implicit `this`).
+    """
+    i = end - 1
+    # Skip optional `->` immediately before the call.  If we see one,
+    # there IS a receiver.  If we see whitespace-only back to a statement
+    # boundary, there's no receiver.
+    while i >= 0 and src[i] in ' \t':
+        i -= 1
+    if i < 1:
+        return end
+    # Need either `->` or `.` (or `::` though that's a static-call thing
+    # and doesn't apply to setStyleSheet which is non-static).
+    if src[i] == '>' and src[i-1] == '-':
+        i -= 2  # skip past '->'
+    elif src[i] == '.':
+        i -= 1  # skip past '.'
+    else:
+        return end  # no receiver — implicit `this`
+
+    # Walk backwards consuming the receiver expression.  Track paren/
+    # bracket depth so we don't stop in the middle of `arr[i]` or
+    # `func(args)`.
+    start = i + 1
+    while i >= 0:
+        c = src[i]
+        if c == ')':
+            jump = find_matching_paren_back(src, i)
+            if jump < 0:
+                break
+            i = jump - 1
+            start = i + 1
+            continue
+        if c == ']':
+            jump = find_matching_paren_back(src, i)
+            if jump < 0:
+                break
+            i = jump - 1
+            start = i + 1
+            continue
+        # Member access chain — keep going.
+        if c == '>' and i > 0 and src[i-1] == '-':
+            i -= 2
+            start = i + 1
+            continue
+        if c == '.':
+            i -= 1
+            start = i + 1
+            continue
+        if c == ':' and i > 0 and src[i-1] == ':':
+            i -= 2
+            start = i + 1
+            continue
+        if c in RECEIVER_TOKEN_CHARS:
+            i -= 1
+            start = i + 1
+            continue
+        break
+    return start
+
+
+def extract_resolve_call(arg_text: str):
+    """Return (themeref, args_text) if arg_text is exactly `THEMEREF.resolve(...)`
+    at the top level (with no trailing garbage other than whitespace).
+    """
+    s = arg_text.strip()
+    depth = 0
+    in_str = False
+    str_ch = ''
+    candidates = []
+    i = 0
+    while i < len(s):
+        c = s[i]
+        if in_str:
+            if c == '\\':
+                i += 2
+                continue
+            if c == str_ch:
+                in_str = False
+        else:
+            if c in ('"', "'"):
+                in_str = True
+                str_ch = c
+            elif c == '(':
+                depth += 1
+            elif c == ')':
+                depth -= 1
+            elif depth == 0 and c == '.':
+                if s[i:i+9] == '.resolve(':
+                    candidates.append(i)
+        i += 1
+    if not candidates:
+        return None
+    dot = candidates[0]
+    themeref = s[:dot].strip()
+    open_paren = dot + len('.resolve')
+    close_paren = find_matching_paren(s, open_paren)
+    if close_paren < 0:
+        return None
+    inner = s[open_paren + 1:close_paren]
+    trailing = s[close_paren + 1:].strip()
+    if trailing != '':
+        return None
+    if not themeref:
+        return None
+    return themeref, inner
+
+
+def transform_file(path: Path, dry_run: bool = False, verbose: bool = False):
+    text = path.read_text()
+    out = []
+    cursor = 0
+    changes = 0
+    skipped = 0
+
+    while True:
+        m = STYLE_RE.search(text, cursor)
+        if not m:
+            out.append(text[cursor:])
+            break
+        # Walk back to find receiver start.
+        rec_start = find_receiver_start(text, m.start())
+        out.append(text[cursor:rec_start])
+
+        open_paren = m.end() - 1
+        close_paren = find_matching_paren(text, open_paren)
+        if close_paren < 0:
+            out.append(text[rec_start:])
+            break
+
+        inner = text[open_paren + 1:close_paren]
+        parsed = extract_resolve_call(inner)
+        if not parsed:
+            # Not a resolve-wrapping setStyleSheet — preserve verbatim.
+            out.append(text[rec_start:close_paren + 1])
+            cursor = close_paren + 1
+            skipped += 1
+            continue
+
+        themeref, template_args = parsed
+        receiver_text = text[rec_start:m.start()].rstrip()
+        # Receiver_text ends with '->' or '.' (or is empty for `this`).
+        if receiver_text.endswith('->'):
+            widget_expr = receiver_text[:-2].rstrip()
+        elif receiver_text.endswith('.'):
+            widget_expr = '&' + receiver_text[:-1].rstrip()
+        else:
+            widget_expr = 'this'
+        if not widget_expr or widget_expr == '&':
+            # Bail — receiver looked weird, leave the source alone.
+            out.append(text[rec_start:close_paren + 1])
+            cursor = close_paren + 1
+            skipped += 1
+            continue
+
+        replacement = f"{themeref}.applyStyleSheet({widget_expr}, {template_args})"
+        out.append(replacement)
+        cursor = close_paren + 1
+        changes += 1
+        if verbose:
+            print(f"  {path}:{text.count(chr(10), 0, rec_start)+1}: {widget_expr}")
+
+    new_text = ''.join(out)
+    if new_text != text:
+        if dry_run:
+            print(f"{path}: {changes} migrated, {skipped} skipped (dry run)")
+        else:
+            path.write_text(new_text)
+            print(f"{path}: {changes} migrated, {skipped} skipped")
+    return changes
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('paths', nargs='+', help='files or directories to scan')
+    ap.add_argument('--dry-run', action='store_true')
+    ap.add_argument('-v', '--verbose', action='store_true')
+    args = ap.parse_args()
+
+    targets = []
+    for p in args.paths:
+        pp = Path(p)
+        if pp.is_dir():
+            targets.extend(sorted(pp.rglob('*.cpp')))
+            targets.extend(sorted(pp.rglob('*.h')))
+        else:
+            targets.append(pp)
+
+    total = 0
+    for t in targets:
+        total += transform_file(t, dry_run=args.dry_run, verbose=args.verbose)
+    print(f"Total: {total} sites" + (" (dry run)" if args.dry_run else ""))
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Browser-devtools-style "click on the wrong-coloured part of the UI to fix it" inspector lands on top of the Phase 5 PR 1 token-tree editor.  Per [RFC #3076](https://github.com/aethersdr/AetherSDR/issues/3076) the inspector is the **primary** interaction for the Theme Editor — the token tree is the secondary navigation.

## New surface

**View → Theme Editor → 🎯 Inspect:**

- Click the toggle, cursor becomes a cross.
- Move over the main UI — a cyan rounded outline tracks the widget under the cursor (top-level overlay, click-through, always-on-top).
- Click a region — token list filters to just the tokens painting it, status reads `ClassName: N tokens`. If exactly one matches, the colour picker opens immediately for the "click ugly thing → fix it" flow.
- ESC cancels without picking.
- The dialog itself is invisible to the inspector (no self-targeting).

## Reverse-map coverage: 22 → 527 widgets

The Phase 2 stylesheet resolver already had a `(widget → tokens)` reverse-map populated by `ThemeManager::applyStyleSheet()`, but only 22 sites in the codebase called that API.  The remaining 505 sites used the equivalent-but-untracked `widget->setStyleSheet(theme.resolve(template))` pattern, leaving hundreds of widgets invisible to the inspector.

This PR sweeps all 505 sites to `applyStyleSheet()` via a balanced-paren-aware Python migration tool (kept under `tools/` for the next sweep we need to do).

**Bit-identical at runtime** — `applyStyleSheet` internally does the same `widget->setStyleSheet(resolve(template))` call — but the widget now shows up in the reverse-map.

## `ThemeManager` additions

- `declareWidgetTokens(widget, tokens)` — explicit hook for custom-paint widgets (panadapter, waterfall, meters, slice indicators) that read tokens directly in `paintEvent` rather than through a stylesheet template.  Same destroy-signal cleanup as `applyStyleSheet`.
- `reapplyAllTrackedStyleSheets()` now skips entries with empty templates so paint-code-only declarations don't wipe any stylesheet the widget inherited from a parent / `Theme.h` helper.

## `ThemeInspector` class

`src/gui/ThemeInspector.{h,cpp}` — `QObject` lifecycle:

- `start()` installs a `QApplication`-level event filter + shows a frameless translucent overlay (`Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::WindowTransparentForInput`) with `WA_TransparentForMouseEvents` so it never intercepts events itself.  The global event filter is the authoritative event source.
- Mouse moves → `QApplication::widgetAt(globalPos)` → reposition overlay (skipping editor + overlay self-hits).
- Left-click → eats the event, emits `widgetPicked(target, localPos)`, auto-deactivates.
- ESC → eats the event, emits `canceled()`, deactivates.

The dialog walks up the parent chain from the picked widget until it finds a tracked ancestor, so a click on a deep child (a `QLabel` inside a `QPushButton` inside a themed panel) still surfaces the panel-level tokens.

## Migration tool

`tools/migrate_setStyleSheet_to_applyStyleSheet.py` — balanced-paren walker that handles arbitrary chained receivers (`m_btn->`, `this->m_btn->`, `btns[i]->`, `statusBar()->`, `parent()->widget->`), multi-line adjacent-string-literal templates, and the dot-form case (`menu.setStyleSheet(...)`) where the receiver is a stack-allocated value and `applyStyleSheet` needs `&obj`.

## Known limits (follow-up PRs)

- Custom-paint widgets (`SpectrumWidget`, `MeterWidget`, slice indicators on the panadapter, applet headers painted in code) aren't declared yet.  Clicks on the spectrum trace or meter bars fall through to the parent widget's tokens or hit "no tokens registered for this region yet."  **Phase 5 PR 3** will add the `themeRegions()` mixin from the RFC for fine-grained sub-region lookup.
- Test `theme_manager_test` has pre-existing stale assertions from before the Phase 2 token realignment.  Not introduced by this PR; needs its own cleanup.

## Test plan

- [x] Builds clean (`--target all`, including all test executables — no bot-CMake-omission regressions)
- [x] Visual smoke: every panel/dialog/applet renders identically (sweep is runtime-bit-identical)
- [x] Inspector flow on KDE Plasma X11 — outline tracking, click-to-pick, ESC cancel all working
- [x] Slice strip widgets (VfoWidget) inspectable: slice badge, filter-width label, freq label, band/mode buttons, mute/lock/tx
- [x] Title bar + status bar inspectable
- [ ] Wayland session smoke (untested locally — relying on CI)
- [ ] Custom-paint widgets (panadapter, waterfall) — known not-yet-instrumented; falls through to parent chain