### PR TITLE
[tci] Add clicked_on_spot event support for Log4OM interoperability

### DIFF
--- a/docs/architecture/tci-receivers.md
+++ b/docs/architecture/tci-receivers.md
@@ -29,6 +29,19 @@ than passing through raw Flex slice IDs.
    back to the first owned slice.  This keeps older clients that cached
    raw Flex IDs functional in the common single-slice case.
 
+## Spot Click Notifications
+
+When a visible spot is clicked, AetherSDR broadcasts the click to every
+connected TCI client using both protocol spellings:
+
+- `clicked_on_spot:<callsign>,<frequency_hz>;`
+- `rx_clicked_on_spot:<receiver>,0,<callsign>,<frequency_hz>;`
+
+The receiver is the same contiguous `trx` index used by `vfo:` and
+`modulation:` events.  The channel field is `0`, matching AetherSDR's
+single-VFO path for a slice.  This mirrors Thetis behavior and keeps older
+clients such as Log4OM working while giving TCI v2 clients receiver context.
+
 ## Why this changed
 
 Flex slice IDs are radio-global and not necessarily contiguous within a

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1349,18 +1349,72 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
 
 // ── Wire spot click notifications ───────────────────────────────────────
 
+SliceModel* TciServer::sliceForPanId(const QString& panId) const
+{
+    if (!m_model || panId.isEmpty())
+        return nullptr;
+
+    for (auto* slice : m_model->slices()) {
+        if (slice && slice->panId() == panId)
+            return slice;
+    }
+
+    return nullptr;
+}
+
+void TciServer::broadcastSpotClicked(const QString& callsign, long long frequencyHz,
+                                     int trx, int channel)
+{
+    if (m_clients.isEmpty())
+        return;
+
+    const QString call = callsign.trimmed();
+    if (call.isEmpty() || frequencyHz <= 0)
+        return;
+
+    const int safeTrx = std::max(0, trx);
+    const int safeChannel = std::max(0, channel);
+
+    // TCI v2 clients may listen for the receiver-qualified form; older
+    // Log4OM-style clients commonly use the original two-field message.
+    broadcast(QStringLiteral("clicked_on_spot:%1,%2;")
+                  .arg(call)
+                  .arg(frequencyHz));
+    broadcast(QStringLiteral("rx_clicked_on_spot:%1,%2,%3,%4;")
+                  .arg(safeTrx)
+                  .arg(safeChannel)
+                  .arg(call)
+                  .arg(frequencyHz));
+}
+
+void TciServer::notifySpotClicked(int spotIndex, SliceModel* slice)
+{
+    if (!m_model)
+        return;
+
+    const auto& spots = m_model->spotModel().spots();
+    auto it = spots.find(spotIndex);
+    if (it == spots.end())
+        return;
+
+    SliceModel* resolvedSlice = slice;
+    if (!resolvedSlice) {
+        const auto slices = m_model->slices();
+        if (!slices.isEmpty())
+            resolvedSlice = slices.first();
+    }
+
+    const int trx = TciProtocol::tciTrxForSlice(m_model, resolvedSlice);
+    const long long hz = static_cast<long long>(std::round(it->rxFreqMhz * 1e6));
+    broadcastSpotClicked(it->callsign, hz, trx, 0);
+}
+
 void TciServer::wireSpotModel()
 {
     if (!m_model) return;
     connect(&m_model->spotModel(), &SpotModel::spotTriggered,
-            this, [this](int index, const QString&) {
-        if (m_clients.isEmpty()) return;
-        auto& spots = m_model->spotModel().spots();
-        if (!spots.contains(index)) return;
-        const auto& spot = spots[index];
-        long long hz = static_cast<long long>(spot.rxFreqMhz * 1e6);
-        broadcast(QStringLiteral("clicked_on_spot:%1,%2;")
-                      .arg(spot.callsign).arg(hz));
+            this, [this](int index, const QString& panId) {
+        notifySpotClicked(index, sliceForPanId(panId));
     });
 }
 

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -96,6 +96,7 @@ public:
     // Wire slice signals for state change broadcasts
     void wireSlice(int trx, SliceModel* slice);
     void wireSpotModel();
+    void notifySpotClicked(int spotIndex, SliceModel* slice = nullptr);
 
 public slots:
     // RX audio from main audio pipeline (float32 stereo, 24 kHz)
@@ -139,6 +140,9 @@ private slots:
 
 private:
     void sendInitBurst(QWebSocket* client);
+    void broadcastSpotClicked(const QString& callsign, long long frequencyHz,
+                              int trx, int channel);
+    SliceModel* sliceForPanId(const QString& panId) const;
     void broadcast(const QString& msg);
     void broadcastBinary(const QByteArray& data);
     void startTxChrono(QWebSocket* client, int trx);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -12240,7 +12240,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // conjure a slice; click is the explicit "create here" affordance.
     });
 
-    // ── Spot trigger — notify the radio when a spot label is clicked (#341)
+    // ── Spot trigger — notify the radio/TCI clients when a spot label is clicked (#341)
     connect(sw, &SpectrumWidget::spotTriggered, this, [this, applet](int spotIndex) {
         const auto& spots = m_radioModel.spotModel().spots();
         auto it = spots.find(spotIndex);
@@ -12253,16 +12253,21 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             return;
         }
 
-        if (!isPassiveLocalSpotId(spotIndex))
+        auto* s = preferredMemorySlice(applet->panId());
+        const bool tciSpot = it->source.compare(QStringLiteral("TCI"), Qt::CaseInsensitive) == 0;
+        if (tciSpot) {
+            if (m_tciServer && s && !s->isLocked() && !m_swrSweep.running)
+                m_tciServer->notifySpotClicked(spotIndex, s);
+        } else if (!isPassiveLocalSpotId(spotIndex)) {
             m_radioModel.sendCommand(
                 QString("spot trigger %1 pan=%2").arg(spotIndex).arg(applet->panId()));
+        }
 
         // Auto-switch mode from spot metadata (#424). Default flipped to True
         // in #1846 since spots now ship with trigger_action=none — the radio
         // no longer changes mode on click, so auto-mode is the only path.
         if (AppSettings::instance().value("SpotAutoSwitchMode", "True").toString() != "True")
             return;
-        auto* s = preferredMemorySlice(applet->panId());
         if (!s) return;
 
         // FreeDV spots imply RADE — activate the RADE engine on this slice


### PR DESCRIPTION
## Summary

This fixes the Log4OM TCI spot-click flow where Log4OM can inject a spot into AetherSDR, AetherSDR tunes when the user clicks that spot on the panadapter, but Log4OM never receives a spot-click notification back to populate its logging fields.

AetherSDR already accepted TCI `spot:` messages and rendered them locally, but those spots use synthetic local IDs. When the user clicked one, the UI attempted to send `spot trigger <id>` to the Flex radio. The radio does not know those local TCI spot IDs, so there was no radio-origin `spot ... triggered` status echo, and therefore the TCI server never emitted `clicked_on_spot` back to connected clients.

This also adds spot event compatibility with RUMlogNG, Swisslog for Windows, LogHX and LogHX3, similar to Thetis implementation.

## What Changed

- Added `TciServer::notifySpotClicked(...)` so UI paths can explicitly notify TCI clients when a locally rendered spot is clicked.
- Centralized TCI spot-click formatting in the TCI server and now emits both forms used by Thetis / TCI clients:
  - `clicked_on_spot:<callsign>,<frequency_hz>;`
  - `rx_clicked_on_spot:<receiver>,0,<callsign>,<frequency_hz>;`
- Updated the existing `SpotModel::spotTriggered` wiring so radio-origin spot trigger echoes also send the receiver-qualified `rx_clicked_on_spot` form.
- Updated the panadapter spot-click path so TCI-origin spots skip the invalid Flex `spot trigger 10000...` command and notify TCI clients directly instead.
- Documented the receiver/channel behavior in the TCI receiver architecture note.

## Protocol Behavior

The implementation mirrors the Thetis behavior and the TCI standard shape:

- TCI clients send spots with `spot:<callsign>,<mode>,<frequency_hz>,<color>,<text>;`.
- AetherSDR stores those as local `source=TCI` spots.
- When the user clicks the rendered spot, AetherSDR tunes the slice through the existing spectrum-click path.
- AetherSDR then broadcasts the clicked spot notification to all connected TCI clients.

The receiver value in `rx_clicked_on_spot` uses the same contiguous TCI `trx` index policy as `vfo:` and `modulation:`. The channel is currently `0`, matching AetherSDR's single-VFO path for the slice.

## Validation

- `git diff --check`
- Configured a fresh macOS build with the pinned Command Line Tools SDK:
  - `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk`
- Built the app successfully:
  - `cmake --build build --target AetherSDR -j22`

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
