### PR TITLE
ci(sanitizers): pin Run tests step to bash so pipefail + PIPESTATUS work

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -78,6 +78,15 @@ jobs:
         # `outputs.exit` sees an empty string.  Net result: every run
         # appears green and no tests actually execute under the
         # sanitizers.  Pin to bash so the bashisms work as intended.
+        #
+        # `|| ec=$?` is also required: GitHub Actions' default bash flags
+        # include `-e`, so a non-zero pipeline exit (e.g. ctest reporting
+        # a test failure or sanitizer crash) would terminate the script
+        # before the `echo "exit=..."` line wrote outputs.exit.  Without
+        # outputs.exit set, the downstream `if: outputs.exit != '0'`
+        # gates all skip — the very failure path we wrote them for.
+        # Capturing into `ec` survives -e and lets us always emit the
+        # real ctest exit code.
         shell: bash
         run: |
           set -o pipefail
@@ -87,8 +96,9 @@ jobs:
           done <<'EOF'
           ${{ matrix.sanitizer.runtime_env }}
           EOF
-          ctest --test-dir build --output-on-failure 2>&1 | tee sanitizer.log
-          echo "exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          ec=0
+          ctest --test-dir build --output-on-failure 2>&1 | tee sanitizer.log || ec=$?
+          echo "exit=$ec" >> "$GITHUB_OUTPUT"
 
       - name: Extract failure report
         id: extract

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -71,6 +71,14 @@ jobs:
         continue-on-error: true
         env:
           QT_QPA_PLATFORM: offscreen
+        # The container image's /bin/sh is Dash, which doesn't understand
+        # `set -o pipefail` or ${PIPESTATUS[0]} — without `shell: bash`
+        # the step exits at code 2 before reaching ctest, the
+        # continue-on-error swallows it, and downstream gating on
+        # `outputs.exit` sees an empty string.  Net result: every run
+        # appears green and no tests actually execute under the
+        # sanitizers.  Pin to bash so the bashisms work as intended.
+        shell: bash
         run: |
           set -o pipefail
           # Export each KEY=value line from runtime_env into the test env.


### PR DESCRIPTION
## Summary

The Sanitizers workflow ([first run #26397650182](https://github.com/aethersdr/AetherSDR/actions/runs/26397650182), 2026-05-25 07:00 UTC) reported green — but it didn't actually run anything under the sanitizers. The "Run tests under sanitizer" step exited at code 2 on its very first line, before `ctest` ran. \`continue-on-error: true\` silenced the failure at the job level, and every downstream gate on \`steps.ctest.outputs.exit != '0'\` then matched against an unset output, so the workflow walked through to completion. Every scheduled run since the workflow landed (PR #2866, 2026-05-21) has produced a false-clean result with zero sanitizer coverage.

## Root cause

The container image \`ghcr.io/ten9876/aethersdr-ci:latest\` defaults \`/bin/sh\` to **Dash**, which doesn't understand \`set -o pipefail\` or \`\${PIPESTATUS[0]}\`. Two bashisms, both at line 75/83 of [`.github/workflows/sanitizers.yml`](.github/workflows/sanitizers.yml).

Run log signature:
```
/__w/_temp/...sh: 1: set: Illegal option -o pipefail
##[error]Process completed with exit code 2.
```

## Fix

One-line: add \`shell: bash\` to the "Run tests under sanitizer" step. Bash is present in the container; only this step uses non-POSIX features, so leaving the other steps on the default shell keeps the patch minimal.

## Verification

Triggered \`workflow_dispatch\` on this branch: [run #26415106480](https://github.com/aethersdr/AetherSDR/actions/runs/26415106480). With the fix in place, the step should now reach \`ctest\` and either pass cleanly or surface real sanitizer findings (and file/update the sticky tracking issue). Result will appear there before this PR merges.

## Test plan

- [ ] Workflow dispatch run on this branch executes \`ctest\` (verifiable in the step log)
- [ ] If tests pass under sanitizers: no behavior change vs. \"green\" appearance, but now meaningful
- [ ] If tests fail: sticky issue gets opened or appended, artifacts uploaded
- [ ] CI green on the PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)