### PR TITLE
feat(theme): Phase 5 PR 4 — font + sizing pickers + per-token reset + theme rename/delete

### DIFF
--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -487,6 +487,18 @@ void ThemeManager::setGradient(const QString& token, const ThemeGradient& g)
     emit themeChanged();
 }
 
+void ThemeManager::setString(const QString& token, const QString& value)
+{
+    const auto it = m_tokens.constFind(token);
+    if (it != m_tokens.constEnd() &&
+        it.value().userType() == QMetaType::QString &&
+        it.value().toString() == value) {
+        return;
+    }
+    m_tokens.insert(token, QVariant(value));
+    emit themeChanged();
+}
+
 void ThemeManager::ensureFactoryLoaded() const
 {
     if (m_factoryLoaded) return;
@@ -515,6 +527,153 @@ ThemeGradient ThemeManager::factoryGradient(const QString& token) const
     if (it == m_factoryTokens.constEnd()) return {};
     if (!it.value().canConvert<ThemeGradient>()) return {};
     return it.value().value<ThemeGradient>();
+}
+
+QColor ThemeManager::factoryColor(const QString& token) const
+{
+    ensureFactoryLoaded();
+    const auto it = m_factoryTokens.constFind(token);
+    if (it == m_factoryTokens.constEnd()) return QColor();
+    if (it.value().canConvert<ThemeGradient>()) {
+        // Token is a gradient in the factory baseline — graceful fallback
+        // to the first stop's colour, matching ThemeManager::color()'s
+        // behaviour for gradient tokens.
+        const auto g = it.value().value<ThemeGradient>();
+        if (g.stops.isEmpty()) return QColor();
+        return g.stops.first().color;
+    }
+    if (it.value().userType() != QMetaType::QString) return QColor();
+    return QColor(it.value().toString());
+}
+
+int ThemeManager::factorySizing(const QString& token) const
+{
+    ensureFactoryLoaded();
+    const auto it = m_factoryTokens.constFind(token);
+    if (it == m_factoryTokens.constEnd()) return -1;
+    bool ok = false;
+    const int v = it.value().toInt(&ok);
+    if (!ok) return -1;
+    return v;
+}
+
+QString ThemeManager::factoryString(const QString& token) const
+{
+    ensureFactoryLoaded();
+    const auto it = m_factoryTokens.constFind(token);
+    if (it == m_factoryTokens.constEnd()) return QString();
+    if (it.value().userType() != QMetaType::QString) return QString();
+    return it.value().toString();
+}
+
+bool ThemeManager::hasFactoryValue(const QString& token) const
+{
+    ensureFactoryLoaded();
+    return m_factoryTokens.contains(token);
+}
+
+bool ThemeManager::isBuiltInTheme(const QString& name) const
+{
+    // Built-ins live inside the Qt resource bundle.  Path map records
+    // ":/themes/<file>.json" for them; user themes use absolute paths.
+    const auto it = m_themePaths.constFind(name);
+    if (it == m_themePaths.constEnd()) return false;
+    return it.value().startsWith(QStringLiteral(":/themes/"));
+}
+
+bool ThemeManager::deleteTheme(const QString& name)
+{
+    if (name.isEmpty()) return false;
+    if (isBuiltInTheme(name)) {
+        qCWarning(lcGui) << "ThemeManager::deleteTheme: refusing to delete "
+                            "built-in theme" << name;
+        return false;
+    }
+    const auto it = m_themePaths.constFind(name);
+    if (it == m_themePaths.constEnd()) return false;
+    const QString path = it.value();
+
+    // If the operator is deleting the currently active theme, fall back
+    // to Default Dark before unlinking — otherwise every consumer of the
+    // active theme would briefly render against an inconsistent token
+    // map while the file is still being closed.
+    if (m_activeTheme == name) {
+        setActiveTheme(QStringLiteral("Default Dark"));
+    }
+
+    QFile f(path);
+    if (!f.remove()) {
+        qCWarning(lcGui) << "ThemeManager::deleteTheme: unlink failed for"
+                         << path << f.errorString();
+        return false;
+    }
+    m_themePaths.remove(name);
+    return true;
+}
+
+bool ThemeManager::renameTheme(const QString& oldName, const QString& newName)
+{
+    const QString trimmed = newName.trimmed();
+    if (oldName.isEmpty() || trimmed.isEmpty()) return false;
+    if (oldName == trimmed) return true;  // no-op rename
+    if (isBuiltInTheme(oldName)) {
+        qCWarning(lcGui) << "ThemeManager::renameTheme: refusing to rename "
+                            "built-in theme" << oldName;
+        return false;
+    }
+    if (m_themePaths.contains(trimmed)) {
+        qCWarning(lcGui) << "ThemeManager::renameTheme: target already exists"
+                         << trimmed;
+        return false;
+    }
+    const auto it = m_themePaths.constFind(oldName);
+    if (it == m_themePaths.constEnd()) return false;
+    const QString oldPath = it.value();
+    const QFileInfo fi(oldPath);
+    const QString newPath = fi.absolutePath()
+                            + QLatin1Char('/') + trimmed + QStringLiteral(".json");
+
+    // The theme name is stored inside the JSON too — round-trip the file
+    // through QJsonDocument so the on-disk "name" field matches the new
+    // filename (otherwise the editor's "Editing: …" header would lie).
+    QFile f(oldPath);
+    if (!f.open(QIODevice::ReadOnly)) {
+        qCWarning(lcGui) << "ThemeManager::renameTheme: cannot read"
+                         << oldPath << f.errorString();
+        return false;
+    }
+    QJsonParseError perr;
+    auto doc = QJsonDocument::fromJson(f.readAll(), &perr);
+    f.close();
+    if (perr.error != QJsonParseError::NoError || !doc.isObject()) {
+        qCWarning(lcGui) << "ThemeManager::renameTheme: parse error"
+                         << perr.errorString();
+        return false;
+    }
+    QJsonObject root = doc.object();
+    root.insert("name", trimmed);
+    doc.setObject(root);
+
+    QFile out(newPath);
+    if (!out.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        qCWarning(lcGui) << "ThemeManager::renameTheme: cannot write"
+                         << newPath << out.errorString();
+        return false;
+    }
+    out.write(doc.toJson(QJsonDocument::Indented));
+    out.close();
+
+    QFile::remove(oldPath);
+    m_themePaths.remove(oldName);
+    m_themePaths.insert(trimmed, newPath);
+
+    if (m_activeTheme == oldName) {
+        m_activeTheme = trimmed;
+        AppSettings::instance().setValue("ActiveTheme", trimmed);
+        AppSettings::instance().save();
+        emit themeChanged();
+    }
+    return true;
 }
 
 bool ThemeManager::saveCurrentThemeAs(const QString& newThemeName)

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -199,13 +199,31 @@ public:
     ThemeGradient gradient(const QString& token) const;
     void          setGradient(const QString& token, const ThemeGradient& g);
 
-    // Factory-default lookup — reads from the bundled
-    // `:/themes/default-dark.json` so the gradient editor's
-    // "Reset to default" button can restore the canonical colormap
-    // shape after the operator wanders into territory they don't like.
-    // Returns an empty gradient if the token isn't a gradient in the
-    // bundled defaults (caller should check stops.size()).
+    // Family / font-family setter for the Phase 5 PR 4 font picker.
+    // Mirrors setColor()/setSizing() — overwrites whatever was at the
+    // token and emits themeChanged so consumers re-resolve their fonts.
+    void setString(const QString& token, const QString& value);
+
+    // Factory-default lookups — read from a one-shot snapshot of the
+    // bundled `:/themes/default-dark.json` so every Reset-to-default
+    // affordance in the editor restores the canonical value.  Each
+    // returns a sentinel (empty / invalid / 0 / -1) when the token has
+    // no factory baseline — callers should check before using.
     ThemeGradient factoryGradient(const QString& token) const;
+    QColor        factoryColor(const QString& token) const;
+    int           factorySizing(const QString& token) const;     // -1 = none
+    QString       factoryString(const QString& token) const;
+    bool          hasFactoryValue(const QString& token) const;
+
+    // Theme-file management — Delete / Rename for the user's saved
+    // themes living under ~/.config/AetherSDR/themes/.  Both refuse
+    // on built-in themes (those live inside the Qt resource bundle
+    // and aren't deletable).  Delete switches the active theme back
+    // to "Default Dark" before unlinking so the UI doesn't render
+    // half-blank during the file removal.
+    bool        deleteTheme(const QString& name);
+    bool        renameTheme(const QString& oldName, const QString& newName);
+    bool        isBuiltInTheme(const QString& name) const;
 
     bool        saveCurrentThemeAs(const QString& newThemeName);
 

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -7,6 +7,7 @@
 #include <QAction>
 #include <QColorDialog>
 #include <QCursor>
+#include <QFontDialog>
 #include <QFontMetrics>
 #include <QHBoxLayout>
 #include <QLinearGradient>
@@ -160,12 +161,29 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     root->addLayout(inspectRow);
 
     auto* btnRow = new QHBoxLayout;
+    // Theme-management dropdown — left side, since it's a destructive
+    // group that shouldn't be confused with the Save / Close primary
+    // actions on the right.  Built-in themes can't be renamed or
+    // deleted; actions are disabled at click time when the active
+    // theme is built-in.
+    auto* themeActionsBtn = new QPushButton(QStringLiteral("Theme actions ▾"), bodyWidget());
+    auto* themeActionsMenu = new QMenu(themeActionsBtn);
+    auto* renameAct = themeActionsMenu->addAction(QStringLiteral("Rename theme…"));
+    auto* deleteAct = themeActionsMenu->addAction(QStringLiteral("Delete theme…"));
+    themeActionsBtn->setMenu(themeActionsMenu);
+    btnRow->addWidget(themeActionsBtn);
+
     btnRow->addStretch(1);
     m_saveAsBtn = new QPushButton(QStringLiteral("Save As…"), bodyWidget());
     auto* closeBtn = new QPushButton(QStringLiteral("Close"), bodyWidget());
     btnRow->addWidget(m_saveAsBtn);
     btnRow->addWidget(closeBtn);
     root->addLayout(btnRow);
+
+    connect(renameAct, &QAction::triggered,
+            this, &ThemeEditorDialog::onRenameThemeClicked);
+    connect(deleteAct, &QAction::triggered,
+            this, &ThemeEditorDialog::onDeleteThemeClicked);
 
     refreshTokenList();
     updateTitle();
@@ -209,43 +227,56 @@ void ThemeEditorDialog::refreshTokenList()
     m_tokenList->clear();
     auto& tm = ThemeManager::instance();
     for (const QString& key : tm.allTokenKeys()) {
-        // Color + gradient tokens are both editable through this list;
-        // sizing + font get their own editing surfaces in a follow-on PR.
-        if (!key.startsWith(QStringLiteral("color.")))
-            continue;
-        const QBrush br = tm.brush(key);
-        if (br.gradient()) {
-            // Gradient row — opens GradientEditorDialog on click.
-            const ThemeGradient g = tm.gradient(key);
-            auto* item = new QListWidgetItem(gradientSwatchIcon(g),
-                gradientRowText(key, g));
-            item->setData(Qt::UserRole, key);
-            m_tokenList->addItem(item);
+        // Editable token namespaces — gradient + scalar colours under
+        // "color.", string + integer leaves under "font." and "sizing.".
+        if (!key.startsWith(QStringLiteral("color."))
+            && !key.startsWith(QStringLiteral("font."))
+            && !key.startsWith(QStringLiteral("sizing."))) {
             continue;
         }
-
-        const QColor c = tm.color(key);
-        auto* item = new QListWidgetItem(swatchIcon(c),
-            QStringLiteral("%1   %2").arg(key, -36).arg(colorToTokenHex(c)));
+        auto* item = new QListWidgetItem;
         item->setData(Qt::UserRole, key);
         m_tokenList->addItem(item);
+        populateRow(item);
+    }
+}
+
+void ThemeEditorDialog::populateRow(QListWidgetItem* item)
+{
+    if (!item) return;
+    const QString key = item->data(Qt::UserRole).toString();
+    auto& tm = ThemeManager::instance();
+
+    if (key.startsWith(QStringLiteral("color."))) {
+        if (tm.brush(key).gradient()) {
+            const ThemeGradient g = tm.gradient(key);
+            item->setIcon(gradientSwatchIcon(g));
+            item->setText(gradientRowText(key, g));
+            return;
+        }
+        const QColor c = tm.color(key);
+        item->setIcon(swatchIcon(c));
+        item->setText(QStringLiteral("%1   %2").arg(key, -36).arg(colorToTokenHex(c)));
+        return;
+    }
+    if (key.startsWith(QStringLiteral("font.family."))) {
+        const QString family = tm.value(key);
+        item->setIcon(QIcon());
+        item->setText(QStringLiteral("%1   %2").arg(key, -36).arg(family));
+        return;
+    }
+    if (key.startsWith(QStringLiteral("font.size."))
+        || key.startsWith(QStringLiteral("sizing."))) {
+        const int v = tm.sizing(key);
+        item->setIcon(QIcon());
+        item->setText(QStringLiteral("%1   %2 px").arg(key, -36).arg(v));
+        return;
     }
 }
 
 void ThemeEditorDialog::updateRow(QListWidgetItem* item)
 {
-    if (!item) return;
-    const QString key = item->data(Qt::UserRole).toString();
-    auto& tm = ThemeManager::instance();
-    if (tm.brush(key).gradient()) {
-        const ThemeGradient g = tm.gradient(key);
-        item->setIcon(gradientSwatchIcon(g));
-        item->setText(gradientRowText(key, g));
-        return;
-    }
-    const QColor c = tm.color(key);
-    item->setIcon(swatchIcon(c));
-    item->setText(QStringLiteral("%1   %2").arg(key, -36).arg(colorToTokenHex(c)));
+    populateRow(item);
 }
 
 void ThemeEditorDialog::updateTitle()
@@ -262,29 +293,49 @@ void ThemeEditorDialog::onTokenRowClicked(QListWidgetItem* item)
     const QString key = item->data(Qt::UserRole).toString();
     auto& tm = ThemeManager::instance();
 
-    // Every color token can be either a flat colour or a gradient.  Show
-    // a small chooser menu at the cursor so the operator can decide each
-    // time — the "current" type stays as the first action, and the
-    // other appears as a "Convert to…" follow-up so an unintentional
-    // type-switch needs an explicit click.
-    const bool isGradient = tm.brush(key).gradient() != nullptr;
-
+    // Click-menu adapts to the token's namespace + current type:
+    //   * color.*   — flat ↔ gradient chooser
+    //   * font.family.* — font family picker
+    //   * font.size.* / sizing.* — numeric picker
+    // A "Reset to default" entry shows up at the bottom whenever the
+    // token has a factory baseline (every bundled token does).
     QMenu menu(this);
-    QAction* flatAct = nullptr;
-    QAction* gradAct = nullptr;
-    if (isGradient) {
-        gradAct = menu.addAction(QStringLiteral("Edit gradient…"));
-        menu.addSeparator();
-        flatAct = menu.addAction(QStringLiteral("Convert to flat colour…"));
-    } else {
-        flatAct = menu.addAction(QStringLiteral("Edit flat colour…"));
-        menu.addSeparator();
-        gradAct = menu.addAction(QStringLiteral("Convert to gradient…"));
+    QAction* flatAct   = nullptr;
+    QAction* gradAct   = nullptr;
+    QAction* familyAct = nullptr;
+    QAction* numAct    = nullptr;
+
+    if (key.startsWith(QStringLiteral("color."))) {
+        const bool isGradient = tm.brush(key).gradient() != nullptr;
+        if (isGradient) {
+            gradAct = menu.addAction(QStringLiteral("Edit gradient…"));
+            menu.addSeparator();
+            flatAct = menu.addAction(QStringLiteral("Convert to flat colour…"));
+        } else {
+            flatAct = menu.addAction(QStringLiteral("Edit flat colour…"));
+            menu.addSeparator();
+            gradAct = menu.addAction(QStringLiteral("Convert to gradient…"));
+        }
+    } else if (key.startsWith(QStringLiteral("font.family."))) {
+        familyAct = menu.addAction(QStringLiteral("Edit font family…"));
+    } else if (key.startsWith(QStringLiteral("font.size."))
+               || key.startsWith(QStringLiteral("sizing."))) {
+        numAct = menu.addAction(QStringLiteral("Edit size…"));
     }
+
+    QAction* resetAct = nullptr;
+    if (tm.hasFactoryValue(key)) {
+        if (!menu.isEmpty()) menu.addSeparator();
+        resetAct = menu.addAction(QStringLiteral("Reset to default"));
+    }
+
     QAction* chosen = menu.exec(QCursor::pos());
-    if (chosen == flatAct)      editTokenAsFlat(key, item);
-    else if (chosen == gradAct) editTokenAsGradient(key, item);
-    // else: dismissed without picking — no-op.
+    if (!chosen) return;
+    if      (chosen == flatAct)   editTokenAsFlat(key, item);
+    else if (chosen == gradAct)   editTokenAsGradient(key, item);
+    else if (chosen == familyAct) editTokenFontFamily(key, item);
+    else if (chosen == numAct)    editTokenSizing(key, item);
+    else if (chosen == resetAct)  resetTokenToFactory(key, item);
 }
 
 void ThemeEditorDialog::editTokenAsFlat(const QString& key, QListWidgetItem* item)
@@ -323,6 +374,123 @@ void ThemeEditorDialog::editTokenAsGradient(const QString& key, QListWidgetItem*
         tm.setGradient(key, dlg.currentGradient());  // overwrites any prior scalar
         updateRow(item);
     }
+}
+
+void ThemeEditorDialog::editTokenFontFamily(const QString& key,
+                                            QListWidgetItem* item)
+{
+    auto& tm = ThemeManager::instance();
+    const QString currentFamily = tm.value(key);
+    QFont seed;
+    if (!currentFamily.isEmpty()) seed.setFamily(currentFamily);
+
+    bool ok = false;
+    const QFont chosen = QFontDialog::getFont(&ok, seed, this,
+        QStringLiteral("Edit %1").arg(key));
+    if (!ok) return;
+    tm.setString(key, chosen.family());
+    updateRow(item);
+}
+
+void ThemeEditorDialog::editTokenSizing(const QString& key,
+                                        QListWidgetItem* item)
+{
+    auto& tm = ThemeManager::instance();
+    const int current = tm.sizing(key);
+    // Integer tokens span both font.size.* and sizing.*; allow a generous
+    // range and let the QSpinBox handle clamping.  Range chosen to cover
+    // realistic font sizes (4–96 px) and panel paddings (0–48 px) in one
+    // input — at the cost of letting a user dial a 96-px panel padding
+    // if they really want one.
+    bool ok = false;
+    const int chosen = QInputDialog::getInt(this,
+        QStringLiteral("Edit %1").arg(key),
+        QStringLiteral("Value (px):"),
+        current, 0, 96, 1, &ok);
+    if (!ok) return;
+    tm.setSizing(key, chosen);
+    updateRow(item);
+}
+
+void ThemeEditorDialog::onRenameThemeClicked()
+{
+    auto& tm = ThemeManager::instance();
+    const QString current = tm.activeTheme();
+    if (tm.isBuiltInTheme(current)) {
+        QMessageBox::information(this, QStringLiteral("Cannot rename"),
+            QStringLiteral("\"%1\" is a built-in theme and can't be renamed. "
+                           "Use Save As… to create an editable copy under a "
+                           "different name first.").arg(current));
+        return;
+    }
+    bool ok = false;
+    const QString newName = QInputDialog::getText(this,
+        QStringLiteral("Rename theme"),
+        QStringLiteral("New name for \"%1\":").arg(current),
+        QLineEdit::Normal, current, &ok).trimmed();
+    if (!ok || newName.isEmpty() || newName == current) return;
+
+    if (!tm.renameTheme(current, newName)) {
+        QMessageBox::warning(this, QStringLiteral("Rename failed"),
+            QStringLiteral("Could not rename \"%1\" to \"%2\".  A theme with "
+                           "that name may already exist, or the theme file "
+                           "may be unwriteable.").arg(current, newName));
+    }
+}
+
+void ThemeEditorDialog::onDeleteThemeClicked()
+{
+    auto& tm = ThemeManager::instance();
+    const QString current = tm.activeTheme();
+    if (tm.isBuiltInTheme(current)) {
+        QMessageBox::information(this, QStringLiteral("Cannot delete"),
+            QStringLiteral("\"%1\" is a built-in theme and can't be deleted.").arg(current));
+        return;
+    }
+    const auto reply = QMessageBox::question(this,
+        QStringLiteral("Delete theme"),
+        QStringLiteral("Permanently delete \"%1\"?\n\n"
+                       "The theme file at "
+                       "~/.config/AetherSDR/themes/%1.json will be removed. "
+                       "The active theme will switch to Default Dark.")
+            .arg(current),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    if (reply != QMessageBox::Yes) return;
+
+    if (!tm.deleteTheme(current)) {
+        QMessageBox::warning(this, QStringLiteral("Delete failed"),
+            QStringLiteral("Could not delete \"%1\". The theme file may be "
+                           "locked by another process.").arg(current));
+    }
+}
+
+void ThemeEditorDialog::resetTokenToFactory(const QString& key,
+                                            QListWidgetItem* item)
+{
+    auto& tm = ThemeManager::instance();
+    if (!tm.hasFactoryValue(key)) return;
+
+    if (key.startsWith(QStringLiteral("color."))) {
+        // Gradients restore through setGradient; scalars through setColor.
+        // The factory snapshot lookup goes through factoryGradient first,
+        // falls back to factoryColor.  An empty gradient with a valid
+        // factoryColor means the factory baseline is a scalar.
+        const ThemeGradient g = tm.factoryGradient(key);
+        if (!g.stops.isEmpty()) {
+            tm.setGradient(key, g);
+        } else {
+            const QColor c = tm.factoryColor(key);
+            if (c.isValid()) tm.setColor(key, c);
+        }
+    } else if (key.startsWith(QStringLiteral("font.family."))) {
+        const QString f = tm.factoryString(key);
+        if (!f.isEmpty()) tm.setString(key, f);
+    } else if (key.startsWith(QStringLiteral("font.size."))
+               || key.startsWith(QStringLiteral("sizing."))) {
+        const int v = tm.factorySizing(key);
+        if (v >= 0) tm.setSizing(key, v);
+    }
+    updateRow(item);
 }
 
 void ThemeEditorDialog::onSaveAsClicked()

--- a/src/gui/ThemeEditorDialog.h
+++ b/src/gui/ThemeEditorDialog.h
@@ -54,10 +54,19 @@ private slots:
     // so the initial visual output matches the previous flat colour.
     void editTokenAsFlat(const QString& key, QListWidgetItem* item);
     void editTokenAsGradient(const QString& key, QListWidgetItem* item);
+    void editTokenFontFamily(const QString& key, QListWidgetItem* item);
+    void editTokenSizing(const QString& key, QListWidgetItem* item);
+    void resetTokenToFactory(const QString& key, QListWidgetItem* item);
+
+    // Theme-file management — Rename / Delete on the "Theme actions ▾"
+    // menu next to Save As.
+    void onRenameThemeClicked();
+    void onDeleteThemeClicked();
 
 private:
     void updateTitle();
     void updateRow(QListWidgetItem* item);   // re-paint swatch + hex label
+    void populateRow(QListWidgetItem* item); // shared by refresh + update
     void updateInspectorStatus(const QString& text);
     // Filter the token list down to a specific subset, e.g. tokens
     // returned by tokensForWidget().  An empty list clears the filter.

--- a/src/gui/ThemeInspector.cpp
+++ b/src/gui/ThemeInspector.cpp
@@ -83,11 +83,14 @@ bool ThemeInspector::eventFilter(QObject* /*obj*/, QEvent* ev)
     if (!m_active) return false;
 
     // While the editor has spawned a modal child dialog (QColorDialog,
-    // GradientEditorDialog, "Theme exists" confirm, …), pause overlay
-    // tracking and let every event flow through unmolested.  The modal
-    // owns the user's attention; once it closes the inspector resumes
-    // on the next mouse move.
-    if (QApplication::activeModalWidget()) {
+    // GradientEditorDialog, "Theme exists" confirm, …) OR a popup widget
+    // (the row's type-chooser QMenu, the Theme actions dropdown, …),
+    // pause overlay tracking and let every event flow through unmolested.
+    // QMenu doesn't register as a modal dialog in Qt's bookkeeping —
+    // it's an "active popup" — so both checks are required to cover
+    // the full child-interaction surface.  The inspector resumes on
+    // the next mouse move after the popup / modal closes.
+    if (QApplication::activeModalWidget() || QApplication::activePopupWidget()) {
         if (m_overlay && m_overlay->isVisible()) m_overlay->hide();
         m_lastTarget.clear();
         return false;


### PR DESCRIPTION
## Summary

Closes [RFC #3076](https://github.com/aethersdr/AetherSDR/issues/3076)'s Phase 5 — every editable token namespace now has a working picker in the Theme Editor, and saved user themes can be renamed or deleted from the dialog without touching the filesystem.

## ThemeManager additions

- `setString(token, value)` — font-family setter; mirrors `setColor` / `setSizing`
- `factoryColor()` / `factorySizing()` / `factoryString()` / `hasFactoryValue()` — extend the factory-snapshot lookup beyond gradients
- `deleteTheme(name)` — switches active theme to Default Dark before unlinking; refuses on built-ins
- `renameTheme(oldName, newName)` — rewrites the JSON file's `"name"` field + filesystem rename in lockstep; refuses on built-ins and name collisions
- `isBuiltInTheme(name)` — detected by whether the recorded path is inside the Qt resource bundle (`:/themes/`)

## Editor changes

The token list now surfaces **every** editable namespace.  Font-family tokens show the family name, integer tokens show "N px", gradient + scalar colour rows keep the existing swatch + descriptor.

Click-menu adapts to the token's namespace:

| Namespace | Menu options |
|---|---|
| `color.*` | Existing flat ↔ gradient chooser |
| `font.family.*` | "Edit font family…" (`QFontDialog`) |
| `font.size.*` / `sizing.*` | "Edit size…" (`QInputDialog::getInt`, 0–96) |

A **"Reset to default"** entry surfaces at the bottom of the menu whenever the token has a factory baseline.  The route picks the right setter based on the token's namespace + the factory value's shape (gradient vs scalar colour vs integer vs string).

New **"Theme actions ▾"** dropdown at the left of the button row:

- **Rename theme…** — refuses on built-ins with a friendly message pointing to Save As…
- **Delete theme…** — confirms before unlinking; switches to Default Dark first so consumers don't render against a half-loaded token map

## Inspector overlay fix

The cyan tracking outline was leaking on top of the row's type-chooser QMenu and the Theme actions dropdown.  `ThemeInspector::eventFilter` now early-returns and hides its overlay whenever **either** `QApplication::activeModalWidget()` OR `QApplication::activePopupWidget()` is non-null — QMenus register as popups, not modals, so both checks are required to cover the full child-interaction surface.  Same auto-resume on close.

## Test plan

- [x] Builds clean (`--target all`)
- [x] `font.family.ui` → "Edit font family…" → QFontDialog → pick → UI re-fonts
- [x] `font.size.normal` → "Edit size…" → spinbox → labels grow
- [x] `sizing.panel.padding` → spinbox → applet panels get roomier
- [x] Right-edit anything → "Reset to default" → restores from `:/themes/default-dark.json`
- [x] Theme actions ▾ → Delete theme… (on a user-saved theme) → switches to Default Dark + removes JSON file
- [x] Save As "My Test" → Theme actions ▾ → Rename theme… → "My Renamed" → file renames + active state follows
- [x] Inspect on + click font row → menu shows; cyan overlay stays hidden through the QMenu and the subsequent QFontDialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)