### PR TITLE
feat(theme): Phase 6 — .aethertheme import/export + drag-and-drop

### DIFF
--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -778,6 +778,172 @@ bool ThemeManager::saveCurrentThemeAs(const QString& newThemeName)
     return true;
 }
 
+bool ThemeManager::exportThemeToFile(const QString& themeName,
+                                     const QString& filePath,
+                                     QString* errorMessage) const
+{
+    auto fail = [errorMessage](const QString& msg) {
+        if (errorMessage) *errorMessage = msg;
+        return false;
+    };
+    if (themeName.isEmpty()) return fail(QStringLiteral("Empty theme name."));
+    if (filePath.isEmpty())  return fail(QStringLiteral("Empty file path."));
+
+    // For the *active* theme, the live m_tokens already holds the operator's
+    // session edits — saveCurrentThemeAs uses that snapshot.  For any other
+    // theme, re-read its on-disk JSON so we don't accidentally export the
+    // active theme's tokens under a different name.
+    QJsonObject doc;
+    if (themeName == m_activeTheme) {
+        QJsonObject tokensObj;
+        const int gradMetaId = qMetaTypeId<ThemeGradient>();
+        for (auto it = m_tokens.constBegin(); it != m_tokens.constEnd(); ++it) {
+            const QVariant& v = it.value();
+            const int ut = v.userType();
+            QJsonValue leaf;
+            if (ut == QMetaType::QString)      leaf = v.toString();
+            else if (ut == QMetaType::Int)     leaf = v.toInt();
+            else if (ut == QMetaType::Double)  leaf = v.toDouble();
+            else if (ut == QMetaType::Bool)    leaf = v.toBool();
+            else if (ut == gradMetaId) {
+                const ThemeGradient g = v.value<ThemeGradient>();
+                QJsonObject gj;
+                gj.insert("type", g.type == ThemeGradient::Radial
+                                    ? QStringLiteral("radial-gradient")
+                                    : QStringLiteral("linear-gradient"));
+                gj.insert("angle", g.angle);
+                if (g.type == ThemeGradient::Radial) {
+                    gj.insert("centerX", g.center.x());
+                    gj.insert("centerY", g.center.y());
+                    gj.insert("radius",  g.radius);
+                }
+                QJsonArray stops;
+                for (const auto& s : g.stops) {
+                    QJsonObject sj;
+                    sj.insert("at",    s.at);
+                    sj.insert("color", colorToTokenString(s.color));
+                    stops.append(sj);
+                }
+                gj.insert("stops", stops);
+                leaf = gj;
+            }
+            else continue;
+            tokensObj.insert(it.key(), leaf);
+        }
+        doc.insert("schemaVersion", 1);
+        doc.insert("name",          themeName);
+        doc.insert("author",        QStringLiteral("AetherSDR user"));
+        doc.insert("version",       QStringLiteral("1.0"));
+        doc.insert("description",   QStringLiteral("Exported via the Theme Editor."));
+        doc.insert("tokens",        tokensObj);
+    } else {
+        const auto pit = m_themePaths.constFind(themeName);
+        if (pit == m_themePaths.constEnd())
+            return fail(QStringLiteral("Theme \"%1\" is not registered.").arg(themeName));
+        QFile src(pit.value());
+        if (!src.open(QIODevice::ReadOnly))
+            return fail(QStringLiteral("Cannot read source theme: %1").arg(src.errorString()));
+        QJsonParseError perr;
+        const auto parsed = QJsonDocument::fromJson(src.readAll(), &perr);
+        if (perr.error != QJsonParseError::NoError || !parsed.isObject())
+            return fail(QStringLiteral("Source theme is not valid JSON: %1").arg(perr.errorString()));
+        doc = parsed.object();
+    }
+
+    QFile f(filePath);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return fail(QStringLiteral("Cannot write file: %1").arg(f.errorString()));
+    f.write(QJsonDocument(doc).toJson(QJsonDocument::Indented));
+    f.close();
+    return true;
+}
+
+QString ThemeManager::importThemeFromFile(const QString& filePath,
+                                          QString* errorMessage)
+{
+    auto fail = [errorMessage](const QString& msg) -> QString {
+        if (errorMessage) *errorMessage = msg;
+        return QString();
+    };
+    if (filePath.isEmpty()) return fail(QStringLiteral("Empty file path."));
+
+    QFile in(filePath);
+    if (!in.open(QIODevice::ReadOnly))
+        return fail(QStringLiteral("Cannot open file: %1").arg(in.errorString()));
+    QJsonParseError perr;
+    const auto doc = QJsonDocument::fromJson(in.readAll(), &perr);
+    in.close();
+    if (perr.error != QJsonParseError::NoError || !doc.isObject())
+        return fail(QStringLiteral("File is not a valid theme JSON: %1").arg(perr.errorString()));
+
+    const QJsonObject root = doc.object();
+    const int schemaVersion = root.value(QStringLiteral("schemaVersion")).toInt(0);
+    if (schemaVersion <= 0)
+        return fail(QStringLiteral("Missing or invalid schemaVersion — file may not be a theme."));
+    if (schemaVersion > 1) {
+        // Forward-compatible-ish: load anyway, but warn the operator.
+        // Unknown tokens round-trip; missing tokens fall back to factory.
+        qCWarning(lcGui) << "ThemeManager::importThemeFromFile: schemaVersion"
+                         << schemaVersion << "is newer than this build supports;"
+                         << "loading anyway with unknown tokens preserved.";
+    }
+
+    // Pick a destination name: prefer the JSON's "name" field, fall back
+    // to the file's basename.  Sanitise so we can't path-traverse via
+    // a malicious name field — slashes get replaced with underscores.
+    QString name = root.value(QStringLiteral("name")).toString().trimmed();
+    if (name.isEmpty()) name = QFileInfo(filePath).completeBaseName();
+    name.replace(QLatin1Char('/'),  QLatin1Char('_'));
+    name.replace(QLatin1Char('\\'), QLatin1Char('_'));
+    if (name.isEmpty()) return fail(QStringLiteral("Cannot derive a theme name from the file."));
+
+    // Refuse to clobber a built-in theme by name — the user can't edit
+    // those anyway and the resource-bundle copy shadows whatever lands
+    // on disk, which would be confusing.
+    if (isBuiltInTheme(name))
+        return fail(QStringLiteral("\"%1\" matches a built-in theme name. "
+                                   "Rename the file's \"name\" field or "
+                                   "rename the file itself.").arg(name));
+
+    const QString userDir = QStandardPaths::writableLocation(
+                                QStandardPaths::GenericConfigLocation)
+                            + QStringLiteral("/AetherSDR/themes");
+    QDir().mkpath(userDir);
+    const QString destPath = userDir + QLatin1Char('/')
+                           + name + QStringLiteral(".json");
+
+    // If a same-named user theme already exists, append a numeric suffix
+    // instead of overwriting — operators sharing themes shouldn't have
+    // to be paranoid about collisions destroying their existing work.
+    QString finalName = name;
+    QString finalPath = destPath;
+    int suffix = 2;
+    while (QFile::exists(finalPath)) {
+        finalName = QStringLiteral("%1 (%2)").arg(name).arg(suffix++);
+        finalPath = userDir + QLatin1Char('/')
+                  + finalName + QStringLiteral(".json");
+        if (suffix > 99) return fail(QStringLiteral("Too many collisions on name \"%1\".").arg(name));
+    }
+
+    // Rewrite "name" so the destination JSON matches its on-disk filename
+    // (otherwise the editor's "Editing: …" header would show the file's
+    // original name even after we suffixed it).
+    QJsonObject patched = root;
+    patched.insert("name", finalName);
+    QFile out(finalPath);
+    if (!out.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return fail(QStringLiteral("Cannot write destination: %1").arg(out.errorString()));
+    out.write(QJsonDocument(patched).toJson(QJsonDocument::Indented));
+    out.close();
+
+    m_themePaths.insert(finalName, finalPath);
+    if (!setActiveTheme(finalName)) {
+        return fail(QStringLiteral("Imported file at %1 but failed to apply it.")
+                        .arg(finalPath));
+    }
+    return finalName;
+}
+
 QColor ThemeManager::color(const QString& token) const
 {
     const auto it = m_tokens.constFind(token);

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -227,6 +227,33 @@ public:
 
     bool        saveCurrentThemeAs(const QString& newThemeName);
 
+    // Phase 6 — share-friendly file format.  `.aethertheme` is plain JSON
+    // (same shape `saveCurrentThemeAs` writes to the user-dir) with a
+    // `schemaVersion` discriminator.  Missing tokens on import fall back
+    // to the built-in defaults; unknown tokens round-trip unchanged so
+    // a future v2 theme still loads on this v1 build (just with the
+    // unknown tokens unused).
+    //
+    // exportThemeToFile():
+    //   * `themeName` — name registered with ThemeManager.  Pass
+    //     `activeTheme()` to dump the live state.
+    //   * `filePath`  — absolute target path.  Caller picks the dialog;
+    //     this method just writes JSON.
+    //
+    // importThemeFromFile():
+    //   * Validates magic + schema, picks a theme name from the JSON's
+    //     "name" field (fallback: file stem), copies the file into
+    //     `~/.config/AetherSDR/themes/`, registers it in m_themePaths,
+    //     and makes it the active theme.
+    //   * Returns the imported theme's display name on success, empty
+    //     on failure.  Caller surfaces the failure reason via the
+    //     `errorMessage` out-param.
+    bool    exportThemeToFile(const QString& themeName,
+                              const QString& filePath,
+                              QString* errorMessage = nullptr) const;
+    QString importThemeFromFile(const QString& filePath,
+                                QString* errorMessage = nullptr);
+
 signals:
     // Fired whenever the active theme changes.  Every widget that reads
     // tokens connects here and calls update() / re-applies its stylesheet.

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -7,8 +7,14 @@
 #include <QAction>
 #include <QColorDialog>
 #include <QCursor>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QFileDialog>
+#include <QFileInfo>
 #include <QFontDialog>
 #include <QFontMetrics>
+#include <QMimeData>
+#include <QUrl>
 #include <QHBoxLayout>
 #include <QLinearGradient>
 #include <QMenu>
@@ -166,10 +172,15 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     // actions on the right.  Built-in themes can't be renamed or
     // deleted; actions are disabled at click time when the active
     // theme is built-in.
-    auto* themeActionsBtn = new QPushButton(QStringLiteral("Theme actions ▾"), bodyWidget());
+    // No trailing ▾ in the label — QPushButton auto-renders a dropdown
+    // arrow once setMenu() is called below, and the two collide visually.
+    auto* themeActionsBtn = new QPushButton(QStringLiteral("Theme actions"), bodyWidget());
     auto* themeActionsMenu = new QMenu(themeActionsBtn);
     auto* renameAct = themeActionsMenu->addAction(QStringLiteral("Rename theme…"));
     auto* deleteAct = themeActionsMenu->addAction(QStringLiteral("Delete theme…"));
+    themeActionsMenu->addSeparator();
+    auto* exportAct = themeActionsMenu->addAction(QStringLiteral("Export to file…"));
+    auto* importAct = themeActionsMenu->addAction(QStringLiteral("Import from file…"));
     themeActionsBtn->setMenu(themeActionsMenu);
     btnRow->addWidget(themeActionsBtn);
 
@@ -184,6 +195,15 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
             this, &ThemeEditorDialog::onRenameThemeClicked);
     connect(deleteAct, &QAction::triggered,
             this, &ThemeEditorDialog::onDeleteThemeClicked);
+    connect(exportAct, &QAction::triggered,
+            this, &ThemeEditorDialog::onExportThemeClicked);
+    connect(importAct, &QAction::triggered,
+            this, &ThemeEditorDialog::onImportThemeClicked);
+
+    // Accept .aethertheme / .json drag-and-drop on the dialog body — the
+    // PersistentDialog base widget gets the drop events as long as the
+    // outermost dialog has setAcceptDrops(true).
+    setAcceptDrops(true);
 
     refreshTokenList();
     updateTitle();
@@ -436,6 +456,91 @@ void ThemeEditorDialog::onRenameThemeClicked()
                            "that name may already exist, or the theme file "
                            "may be unwriteable.").arg(current, newName));
     }
+}
+
+void ThemeEditorDialog::onExportThemeClicked()
+{
+    auto& tm = ThemeManager::instance();
+    const QString current = tm.activeTheme();
+    if (current.isEmpty()) return;
+
+    // Suggest a filename matching the theme name + the `.aethertheme`
+    // extension so shared files are recognisable on sight.  The OS file
+    // picker remembers the last directory across invocations.
+    const QString suggested = QDir::homePath()
+                              + QLatin1Char('/')
+                              + current + QStringLiteral(".aethertheme");
+    const QString path = QFileDialog::getSaveFileName(this,
+        QStringLiteral("Export theme"), suggested,
+        QStringLiteral("AetherSDR themes (*.aethertheme *.json)"));
+    if (path.isEmpty()) return;
+
+    QString err;
+    if (!tm.exportThemeToFile(current, path, &err)) {
+        QMessageBox::warning(this, QStringLiteral("Export failed"),
+            QStringLiteral("Could not write \"%1\":\n\n%2").arg(path, err));
+        return;
+    }
+}
+
+void ThemeEditorDialog::onImportThemeClicked()
+{
+    const QString path = QFileDialog::getOpenFileName(this,
+        QStringLiteral("Import theme"), QDir::homePath(),
+        QStringLiteral("AetherSDR themes (*.aethertheme *.json)"));
+    if (path.isEmpty()) return;
+    importThemeFromPath(path);
+}
+
+void ThemeEditorDialog::importThemeFromPath(const QString& filePath)
+{
+    auto& tm = ThemeManager::instance();
+    QString err;
+    const QString name = tm.importThemeFromFile(filePath, &err);
+    if (name.isEmpty()) {
+        QMessageBox::warning(this, QStringLiteral("Import failed"),
+            QStringLiteral("Could not import \"%1\":\n\n%2").arg(filePath, err));
+        return;
+    }
+    QMessageBox::information(this, QStringLiteral("Theme imported"),
+        QStringLiteral("Installed \"%1\" and made it the active theme.").arg(name));
+}
+
+void ThemeEditorDialog::dragEnterEvent(QDragEnterEvent* event)
+{
+    if (!event->mimeData()->hasUrls()) {
+        PersistentDialog::dragEnterEvent(event);
+        return;
+    }
+    // Only accept drops where every URL is a theme-shaped file — refusing
+    // the drop is the cleanest signal that an arbitrary file isn't valid.
+    const auto urls = event->mimeData()->urls();
+    for (const QUrl& u : urls) {
+        if (!u.isLocalFile()) {
+            PersistentDialog::dragEnterEvent(event);
+            return;
+        }
+        const QString suffix = QFileInfo(u.toLocalFile()).suffix().toLower();
+        if (suffix != QStringLiteral("aethertheme")
+            && suffix != QStringLiteral("json")) {
+            PersistentDialog::dragEnterEvent(event);
+            return;
+        }
+    }
+    event->acceptProposedAction();
+}
+
+void ThemeEditorDialog::dropEvent(QDropEvent* event)
+{
+    if (!event->mimeData()->hasUrls()) {
+        PersistentDialog::dropEvent(event);
+        return;
+    }
+    const auto urls = event->mimeData()->urls();
+    for (const QUrl& u : urls) {
+        if (u.isLocalFile()) importThemeFromPath(u.toLocalFile());
+    }
+    event->acceptProposedAction();
 }
 
 void ThemeEditorDialog::onDeleteThemeClicked()

--- a/src/gui/ThemeEditorDialog.h
+++ b/src/gui/ThemeEditorDialog.h
@@ -4,6 +4,8 @@
 
 #include <QPointer>
 
+class QDragEnterEvent;
+class QDropEvent;
 class QListWidget;
 class QListWidgetItem;
 class QLabel;
@@ -58,10 +60,20 @@ private slots:
     void editTokenSizing(const QString& key, QListWidgetItem* item);
     void resetTokenToFactory(const QString& key, QListWidgetItem* item);
 
-    // Theme-file management — Rename / Delete on the "Theme actions ▾"
-    // menu next to Save As.
+    // Theme-file management — Rename / Delete / Export / Import on the
+    // "Theme actions ▾" menu next to Save As.
     void onRenameThemeClicked();
     void onDeleteThemeClicked();
+    void onExportThemeClicked();
+    void onImportThemeClicked();
+    // Shared body for both the menu Import and the drag-and-drop path.
+    void importThemeFromPath(const QString& filePath);
+
+protected:
+    // Drag-and-drop: drop a `.aethertheme` (or `.json` theme) on the
+    // dialog to install + activate it.
+    void dragEnterEvent(QDragEnterEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
 
 private:
     void updateTitle();


### PR DESCRIPTION
## Summary

Closes [RFC #3076](https://github.com/aethersdr/AetherSDR/issues/3076) by adding a share-friendly file format for AetherSDR themes plus the import / export / drag-and-drop UI that operators need to actually swap themes around.

**Depends on #3160** — currently targets `auto/theme-pr4` so the diff shows only Phase 6's delta.  Will retarget to main once #3160 lands.

## ThemeManager additions

- `exportThemeToFile(themeName, filePath, *err)` — dumps the active theme's live state (or another registered theme's on-disk JSON) to an arbitrary file
- `importThemeFromFile(filePath, *err)` — validates schema, picks a destination name from the JSON's `"name"` field (file stem fallback), sanitises against path traversal, refuses to clobber built-ins, suffixes `(2)` / `(3)`… on name collisions, copies into `~/.config/AetherSDR/themes/`, makes it active.  Returns the final name on success.

## Theme Editor changes

- **"Theme actions" menu** gains an Export… / Import… pair below the existing Rename / Delete actions
- **Drag-and-drop**: drop one or more `.aethertheme` (or `.json` theme) files anywhere on the dialog window → each imports + activates in order
- Drop validation refuses non-local URLs and any file whose extension isn't `aethertheme` / `json` — arbitrary files get the no-go cursor at drag-enter
- Cosmetic: removed the manual `▾` glyph from "Theme actions" button label (QPushButton with `setMenu()` auto-renders one; the two collided)

## File format (`.aethertheme`)

Plain JSON, identical shape to the user-dir `themes/*.json` files (same `schemaVersion`, `name`, `author`, `version`, `description`, `tokens`).  Sharing happens via file exchange — Discord, Discussions, gist, email attachment.  No hosted marketplace.

## Format compatibility

- `schemaVersion = 1` is current; `> 1` loads with a log warning instead of refusing — unknown tokens round-trip unchanged so a future v2 theme survives a v1 build
- Missing tokens on import fall back to built-in defaults via the existing `seedBuiltinDefaults()` path

## Test plan

- [x] Builds clean (`--target all`)
- [x] Save As "My Glassy Plasma" → Theme actions → Export to file… → save as `.aethertheme`
- [x] Switch to Default Dark → Theme actions → Import from file… → re-imports + activates
- [x] Drag the same file onto the dialog → re-imports as "My Glassy Plasma (2)"
- [x] Drop a non-theme file → silently refused at drag-enter
- [x] Single Qt-rendered dropdown arrow on the Theme actions button (was two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)