### PR TITLE
build(cmake): honour SOURCE_DATE_EPOCH for reproducible distro builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -892,6 +892,23 @@ else()
     message(STATUS "Build SHA: ${AETHER_GIT_SHA} (git unavailable or not a git checkout)")
 endif()
 
+# Reproducible-builds.org SOURCE_DATE_EPOCH support.  When a distro
+# packager (Debian, Arch, NixOS, openSUSE, Fedora, etc.) sets
+#   export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+# before invoking cmake, GCC 7.2+ and Clang automatically substitute
+# __DATE__ and __TIME__ with that fixed timestamp.  Many archive tools
+# (ar, tar, zip, objcopy) honour the same variable, so the built binary
+# becomes byte-reproducible across hosts.
+#
+# No source-tree changes needed — this block just surfaces a configure-
+# time status line so packagers can confirm at a glance that their
+# env-var actually reached the build.  Originally proposed as
+# https://github.com/aethersdr/AetherSDR/pull/3139 (closed in favour
+# of this ecosystem-standard approach).
+if(DEFINED ENV{SOURCE_DATE_EPOCH})
+    message(STATUS "Reproducible build: honoring SOURCE_DATE_EPOCH=$ENV{SOURCE_DATE_EPOCH}")
+endif()
+
 # Windows: GUI app (no console window) + icon resource
 if(WIN32)
     set_target_properties(AetherSDR PROPERTIES WIN32_EXECUTABLE TRUE)


### PR DESCRIPTION
## Summary

Distros that participate in [reproducible-builds.org](https://reproducible-builds.org/) (Debian, Arch, NixOS, openSUSE, Fedora, etc.) set `SOURCE_DATE_EPOCH` before invoking cmake to make `__DATE__` / `__TIME__` deterministic.  GCC 7.2+ and Clang [already honour the env var](https://gcc.gnu.org/onlinedocs/cpp/Environment-Variables.html) at the compiler level — no source-tree changes are needed for AetherSDR to produce reproducible builds under these packagers' standard pipelines.

This change is just a configure-time status line so packagers can confirm at a glance that their env-var actually reached the build:

\`\`\`
$ SOURCE_DATE_EPOCH=\$(git log -1 --format=%ct) cmake -B build -S .
…
-- Build SHA: 8b0c2d59
-- Reproducible build: honoring SOURCE_DATE_EPOCH=1717238400
…
\`\`\`

Unset → no diff vs. main.

## Context

Closes the ecosystem-standard alternative to #3139, where @dawkagaming proposed a project-specific `BUILD_TIMESTAMPS` opt-out flag to suppress \`__DATE__\` for reproducibility.  The counter-proposal in #3139's review thread laid out why `SOURCE_DATE_EPOCH` is preferable:

1. **Universal**: every packager already knows it from non-AetherSDR work
2. **No source-file \`#ifdef\` branches** — the toolchain handles substitution
3. **Preserves real compile-date info** for end users; no \`"---"\` placeholders in About
4. **Covers more than \`__DATE__\`** — \`__TIME__\`, \`ar\`/\`ld\` link timestamps, deterministic-archive tooling all honour it
5. **Doesn't conflate the git SHA** — the SHA is already deterministic from the source tree

@dawkagaming closed #3139 in favour of this approach.  Credit to him for surfacing the reproducibility problem in the first place — the implementation took a different shape but the diagnosis was correct.

## Test plan

- [x] Configure without \`SOURCE_DATE_EPOCH\`: no diff vs. main (no status line, no behavior change)
- [x] Configure with \`SOURCE_DATE_EPOCH=1717238400\`: prints "Reproducible build: honoring …"
- [x] Full build (\`--target AetherSDR\`) clean
- [x] No source-tree changes (no \`#ifdef\`s, no preprocessor branching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)