### PR TITLE
feat(hid): recognize aether-pad RC-28 emulator (Arduino VID/PID alias)

### DIFF
--- a/src/core/HidDeviceParser.cpp
+++ b/src/core/HidDeviceParser.cpp
@@ -8,6 +8,15 @@ static const HidDeviceId kSupportedDevices[] = {
     {0x077D, 0x0410, "Griffin PowerMate"},
     {0x0B33, 0x0020, "Contour ShuttleXpress"},
     {0x0B33, 0x0030, "Contour ShuttlePro v2"},
+    // AetherPad (Arduino Giga R1) running its RC-28 emulator firmware
+    // (github.com/nigelfenton/aether-pad). The Giga's mbed PluggableUSB
+    // stack hardcodes the device-level VID/PID to Arduino's composite
+    // 0x2341:0x0266, so the emulator can't claim Icom's identity — we
+    // route the Arduino-default VID/PID to IcomRC28Parser instead.
+    // Gives a hardware-in-the-loop test bench for the RC-28 wire
+    // protocol; validated against PR #2870's report-layout fix
+    // (end-to-end test 2026-05-20).
+    {0x2341, 0x0266, "AetherPad RC-28 emulator (Arduino Giga R1)"},
 };
 
 const HidDeviceId* HidDeviceParser::supportedDevices() { return kSupportedDevices; }
@@ -19,6 +28,9 @@ std::unique_ptr<HidDeviceParser> HidDeviceParser::create(uint16_t vid, uint16_t 
     if (vid == 0x077D && pid == 0x0410) return std::make_unique<GriffinPowerMateParser>();
     if (vid == 0x0B33 && pid == 0x0020) return std::make_unique<ShuttleXpressParser>();
     if (vid == 0x0B33 && pid == 0x0030) return std::make_unique<ShuttleProV2Parser>();
+    // AetherPad emulator alias — same parser as the real RC-28 (see
+    // comment in kSupportedDevices above).
+    if (vid == 0x2341 && pid == 0x0266) return std::make_unique<IcomRC28Parser>();
     return nullptr;
 }
 


### PR DESCRIPTION
## Summary

Adds the Arduino composite VID/PID `0x2341:0x0266` to `HidDeviceParser`'s supported-devices table, routing it to `IcomRC28Parser`. Twelve lines, no behaviour change for any existing device.

## Motivation

The aether-pad reference implementation ([github.com/nigelfenton/aether-pad](https://github.com/nigelfenton/aether-pad)) is a small Arduino Giga R1-based RC-28 emulator I've been using as a hardware-in-the-loop test bench for the RC-28 wire protocol. End-to-end validation against PR #2870's report-layout fix was done with this bench on 2026-05-20 (parse-side DIAG trace + frequency display tracking each detent).

The bench has been carrying this alias as a local-only patch since then. Filing it upstream so the bench works against unmodified `main` going forward, and so other folks who want to build community RC-28-compatible hardware on Arduino have a path in.

## Why an alias rather than spoofing Icom's VID/PID

The Giga R1's mbed PluggableUSB stack hardcodes the device-level VID/PID at the core level — the emulator firmware can't claim `0x0C26:0x001E` even if it wanted to. And spoofing FlexRadio-class hardware identifiers in community firmware is something I'd rather not do for the obvious driver-INF / ethical reasons. Routing the Arduino-default composite VID/PID to the same parser is the clean way in.

The wire protocol is identical to the real RC-28 — same 32-byte report layout, same seq/dir/button encoding documented above `IcomRC28Parser`. The alias just gives community hardware a supported route into the existing parser.

## Test plan
- [x] Compiles clean (incremental Windows build, 698/698 targets)
- [x] Binary launches + stays alive, closes cleanly
- [x] Live wire validation already on file from the 2026-05-20 bench (with this exact patch on a feature branch); aether-pad firmware on [nigelfenton/aether-pad@feat/rc28-test-mode](https://github.com/nigelfenton/aether-pad/tree/feat/rc28-test-mode) drives the protocol bytes

## Out of scope

The aether-pad also has an AetherControl-style FlexControl-protocol persona in flight — that needs separate plumbing on the AE side (`FlexControlManager::detectPort()`'s VID/PID filter is the blocker there). I'll file that as its own PR once the firmware-side persona work lands. This PR is just the HID alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)