### PR TITLE
feat(net): adaptive throttle toggle in Connect panel (all modes)

### DIFF
--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -559,6 +559,23 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     optionsLayout->addWidget(m_lowBwCheck);
     root->addWidget(m_linkOptionsWidget);
 
+    m_adaptiveThrottleCheck = new QCheckBox("Enable adaptive frame-rate throttle", this);
+    const bool adaptiveEnabled = AppSettings::instance()
+        .value("AdaptiveThrottleEnabled", "False").toString() == "True";
+    m_adaptiveThrottleCheck->setChecked(adaptiveEnabled);
+    m_adaptiveThrottleCheck->setToolTip(
+        "Automatically reduces FFT/waterfall frame rate when network quality degrades, "
+        "reducing the chance of a disconnect on congested links. "
+        "Toggling while connected takes effect at the next quality update; "
+        "reconnect to lift an already-applied cap immediately.");
+    m_adaptiveThrottleCheck->setStyleSheet(lowBandwidthCheckStyle);
+    connect(m_adaptiveThrottleCheck, &QCheckBox::toggled, this, [](bool on) {
+        auto& s = AppSettings::instance();
+        s.setValue("AdaptiveThrottleEnabled", on ? "True" : "False");
+        s.save();
+    });
+    root->addWidget(m_adaptiveThrottleCheck);
+
     m_autoConnectCheck = new QCheckBox("Connect to last radio on start up", this);
     m_autoConnectCheck->setChecked(
         AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() == "True");
@@ -855,10 +872,10 @@ void ConnectionPanel::updateActionState()
 void ConnectionPanel::updateLowBandwidthVisibility()
 {
     const auto mode = static_cast<ConnectionMode>(m_modeStack->currentIndex());
-    const bool visible = mode == SmartLinkMode || mode == ManualMode;
-    m_linkOptionsWidget->setVisible(visible);
+    const bool slowLinksVisible = mode == SmartLinkMode || mode == ManualMode;
+    m_linkOptionsWidget->setVisible(slowLinksVisible);
 
-    if (!visible)
+    if (!slowLinksVisible)
         return;
 
     if (mode == SmartLinkMode) {

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -141,6 +141,7 @@ private:
     QWidget*     m_linkOptionsWidget{nullptr};
     QLabel*      m_lowBwHintLabel{nullptr};
     QCheckBox*   m_lowBwCheck{nullptr};
+    QCheckBox*   m_adaptiveThrottleCheck{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2802,6 +2802,8 @@ void RadioModel::sendAdaptiveCapToPan(const QString& panId, int fpsCap)
 
 void RadioModel::applyAdaptiveFrameRate(NetState newState, NetState oldState)
 {
+    if (AppSettings::instance().value("AdaptiveThrottleEnabled", "False").toString() != "True")
+        return;
     const int newCap = fpsCapForState(newState);
     const int oldCap = fpsCapForState(oldState);
     if (newCap == oldCap)


### PR DESCRIPTION
## Summary

- Adds an **\"Enable adaptive frame-rate throttle\"** checkbox to all three connection modes, wired to a new `AdaptiveThrottleEnabled` AppSettings key (default `False` — opt-in)
- **Live-reads** `AppSettings` inside `applyAdaptiveFrameRate()` on every quality state transition instead of caching at connect time — toggle is responsive mid-session, not just at next connect
- Tooltip is explicit: toggling mid-session takes effect at the next quality update; reconnect lifts an already-applied cap immediately
- Fixes #3173 (user seeing automatic fps reduction they didn't expect — caused by #2829 shipping always-on)

## Design decisions addressed from review

| Concern | Resolution |
|---|---|
| Cached flag ignored mid-session toggles | Dropped `m_adaptiveThrottleEnabled` member; `applyAdaptiveFrameRate()` reads AppSettings live |
| Tooltip implied a live switch | Updated to explain next-quality-update semantics and reconnect-to-lift |
| Default `True` vs `False` | Keeping `False` (opt-in) — issue #3173 confirms the always-on behaviour surprises users |

## All three connect paths covered

All paths funnel through `onConnected()` → `startNetworkMonitor()` → `evaluateNetworkQuality()` → `applyAdaptiveFrameRate()`, so the live check is reached regardless of connection type.

## Test plan

- [ ] Checkbox appears in all three connection modes, unchecked by default
- [ ] Check the box, connect; confirm adaptive fps commands appear in `lcProtocol` as quality degrades
- [ ] Leave unchecked, connect; confirm no fps throttle commands are sent
- [ ] Toggle mid-session; confirm change takes effect at next quality state transition
- [ ] Setting persists across app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)