### PR TITLE
feat(theme): inline Theme Editor + auto-persist + built-in protection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -719,6 +719,8 @@ set(GUI_SOURCES
     src/gui/ThemeEditorDialog.cpp
     src/gui/ThemeInspector.cpp
     src/gui/GradientEditorDialog.cpp
+    src/gui/TokenEditorWidget.cpp
+    src/gui/CompactColorPicker.cpp
 )
 
 set(ALL_SOURCES

--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -159,13 +159,13 @@
         },
         "font": {
           "family": {
-            "ui":         "Inter",
-            "mono":       "monospace",
-            "segment7":   "DSEG7 Modern",
-            "segment14":  "DSEG14 Modern",
-            "weather":    "DSEGWeather",
-            "freq":       "DSEG7 Modern",
-            "temp":       "DSEG7 Modern"
+            "ui":         { "family": "Inter",         "size": 12, "color": "#c8d8e8" },
+            "mono":       { "family": "monospace",     "size": 12, "color": "#c8d8e8" },
+            "segment7":   { "family": "DSEG7 Modern",  "size": 14, "color": "#00b4d8" },
+            "segment14":  { "family": "DSEG14 Modern", "size": 14, "color": "#00b4d8" },
+            "weather":    { "family": "DSEGWeather",   "size": 14, "color": "#c8d8e8" },
+            "freq":       { "family": "DSEG7 Modern",  "size": 14, "color": "#00b4d8" },
+            "temp":       { "family": "DSEG7 Modern",  "size": 12, "color": "#8ea8c0" }
           },
           "size": {
             "tiny":   9,

--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -164,7 +164,7 @@
             "segment7":   { "family": "DSEG7 Modern",  "size": 14, "color": "#00b4d8" },
             "segment14":  { "family": "DSEG14 Modern", "size": 14, "color": "#00b4d8" },
             "weather":    { "family": "DSEGWeather",   "size": 14, "color": "#c8d8e8" },
-            "freq":       { "family": "DSEG7 Modern",  "size": 26, "color": "#00b4d8" },
+            "freq":       { "family": "DSEG7 Modern",  "size": 20, "color": "#00b4d8" },
             "temp":       { "family": "DSEG7 Modern",  "size": 12, "color": "#8ea8c0" }
           },
           "size": {

--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -164,7 +164,7 @@
             "segment7":   { "family": "DSEG7 Modern",  "size": 14, "color": "#00b4d8" },
             "segment14":  { "family": "DSEG14 Modern", "size": 14, "color": "#00b4d8" },
             "weather":    { "family": "DSEGWeather",   "size": 14, "color": "#c8d8e8" },
-            "freq":       { "family": "DSEG7 Modern",  "size": 14, "color": "#00b4d8" },
+            "freq":       { "family": "DSEG7 Modern",  "size": 26, "color": "#00b4d8" },
             "temp":       { "family": "DSEG7 Modern",  "size": 12, "color": "#8ea8c0" }
           },
           "size": {

--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -1,168 +1,190 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "name": "Default Dark",
   "author": "AetherSDR Team",
-  "version": "1.3",
-  "description": "AetherSDR's original dark theme — Phase 2 canonical taxonomy (51 tokens) plus the waterfall colormap gradient. v1.3: tokens realigned to the dominant codebase hex values (background.0 was #0a0e14 → #0f0f1a to match the 84-ref QWidget base; text.primary was #e6f0fa → #c8d8e8 to match the 367-ref body text). Visually bit-identical to v26.5.3 at the majority of sites.",
-  "tokens": {
-    "color": {
-      "background": {
-        "0": "#0f0f1a",
-        "1": "#1a2a3a",
-        "2": "#304050",
-        "3": "#506070",
-        "tx": "#3a2a0e",
-        "success": "#006040",
-        "spectrum": "#000000",
-        "app": "#0f0f1a"
-      },
-      "accent": "#00b4d8",
-      "accent.bright": "#00c8f0",
-      "accent.dim": "#0070c0",
-      "accent.warning": "#ffb84d",
-      "accent.danger": "#ff4d4d",
-      "accent.success": "#4dd87a",
-      "text": {
-        "primary": "#c8d8e8",
-        "secondary": "#8ea8c0",
-        "label": "#506070",
-        "disabled": "#3a4a5a"
-      },
-      "border": {
-        "subtle": "#1a2330",
-        "strong": "#2a3a4d",
-        "accent": "#00b4d8",
-        "tx": "#5a4a28"
-      },
-      "meter": {
-        "crst": "#ff4d4d",
-        "rms": "#00b4d8",
-        "thresh": "#ffb84d",
-        "peak": "#e6f0fa",
-        "gainReduction": "#f2c14e",
-        "bar.fill": "#405060",
-        "bar.fillGradient": {
-          "type": "linear-gradient",
-          "angle": 0,
-          "stops": [
-            { "at": 0.00, "color": "#2f9e6a" },
-            { "at": 0.55, "color": "#6cc56a" },
-            { "at": 0.80, "color": "#e8b94c" },
-            { "at": 0.95, "color": "#e8553c" },
-            { "at": 1.00, "color": "#f2362a" }
-          ]
+  "version": "1.4",
+  "description": "AetherSDR's original dark theme — v2 schema (primitives + nested scopes).  Semantic tokens resolve through a tailwind-style palette of shared colour primitives via {alias} references; the rendered output is bit-identical to v1.3.",
+  "primitives": {
+    "color.blue.500":  "#00b4d8",
+    "color.blue.300":  "#00c8f0",
+    "color.blue.700":  "#0070c0",
+    "color.red.500":   "#ff4d4d",
+    "color.amber.500": "#ffb84d",
+    "color.green.500": "#4dd87a",
+    "color.gray.50":   "#e6f0fa",
+    "color.gray.200":  "#c8d8e8",
+    "color.gray.400":  "#8ea8c0",
+    "color.gray.500":  "#506070",
+    "color.gray.600":  "#3a4a5a",
+    "color.gray.700":  "#304050",
+    "color.gray.800":  "#1a2a3a",
+    "color.gray.850":  "#1a2330",
+    "color.gray.900":  "#0f0f1a",
+    "color.gray.950":  "#000000"
+  },
+  "scopes": {
+    "root": {
+      "tokens": {
+        "color": {
+          "background": {
+            "0":        "{color.gray.900}",
+            "1":        "{color.gray.800}",
+            "2":        "{color.gray.700}",
+            "3":        "{color.gray.500}",
+            "tx":       "#3a2a0e",
+            "success":  "#006040",
+            "spectrum": "{color.gray.950}",
+            "app":      "{color.gray.900}"
+          },
+          "accent":         "{color.blue.500}",
+          "accent.bright":  "{color.blue.300}",
+          "accent.dim":     "{color.blue.700}",
+          "accent.warning": "{color.amber.500}",
+          "accent.danger":  "{color.red.500}",
+          "accent.success": "{color.green.500}",
+          "text": {
+            "primary":   "{color.gray.200}",
+            "secondary": "{color.gray.400}",
+            "label":     "{color.gray.500}",
+            "disabled":  "{color.gray.600}"
+          },
+          "border": {
+            "subtle": "{color.gray.850}",
+            "strong": "#2a3a4d",
+            "accent": "{color.blue.500}",
+            "tx":     "#5a4a28"
+          },
+          "meter": {
+            "crst":   "{color.red.500}",
+            "rms":    "{color.blue.500}",
+            "thresh": "{color.amber.500}",
+            "peak":   "{color.gray.50}",
+            "gainReduction": "#f2c14e",
+            "bar.fill": "#405060",
+            "bar.fillGradient": {
+              "type": "linear-gradient",
+              "angle": 0,
+              "stops": [
+                { "at": 0.00, "color": "#2f9e6a" },
+                { "at": 0.55, "color": "#6cc56a" },
+                { "at": 0.80, "color": "#e8b94c" },
+                { "at": 0.95, "color": "#e8553c" },
+                { "at": 1.00, "color": "#f2362a" }
+              ]
+            }
+          },
+          "spectrum": {
+            "trace":    "{color.blue.500}",
+            "peakHold": "{color.amber.500}",
+            "average":  "{color.gray.400}",
+            "grid":     "{color.gray.850}"
+          },
+          "waterfall.colormap": {
+            "default": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.15, "color": "#000080" },
+                { "at": 0.30, "color": "#0040ff" },
+                { "at": 0.45, "color": "#00c8ff" },
+                { "at": 0.60, "color": "#00dc00" },
+                { "at": 0.80, "color": "#ffff00" },
+                { "at": 1.00, "color": "#ff0000" }
+              ]
+            },
+            "grayscale": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 1.00, "color": "#ffffff" }
+              ]
+            },
+            "blueGreen": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#001e78" },
+                { "at": 0.50, "color": "#0064b4" },
+                { "at": 0.75, "color": "#00c882" },
+                { "at": 1.00, "color": "#dcffdc" }
+              ]
+            },
+            "fire": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#800000" },
+                { "at": 0.50, "color": "#dc5000" },
+                { "at": 0.75, "color": "#ffc800" },
+                { "at": 1.00, "color": "#ffffdc" }
+              ]
+            },
+            "plasma": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#50008c" },
+                { "at": 0.50, "color": "#c80078" },
+                { "at": 0.75, "color": "#f07800" },
+                { "at": 1.00, "color": "#ffff50" }
+              ]
+            }
+          },
+          "slice": {
+            "a":  "#00d4ff",
+            "b":  "#ff40ff",
+            "c":  "#40ff40",
+            "d":  "#ffff00",
+            "e":  "#ffa000",
+            "f":  "#00e0c0",
+            "g":  "#ff6080",
+            "h":  "#b080ff",
+            "tx": "{color.red.500}",
+            "dim": {
+              "a": "#006080",
+              "b": "#802080",
+              "c": "#208020",
+              "d": "#808000",
+              "e": "#805000",
+              "f": "#007060",
+              "g": "#803040",
+              "h": "#584080"
+            }
+          }
+        },
+        "font": {
+          "family": {
+            "ui":         "Inter",
+            "mono":       "monospace",
+            "segment7":   "DSEG7 Modern",
+            "segment14":  "DSEG14 Modern",
+            "weather":    "DSEGWeather",
+            "freq":       "DSEG7 Modern",
+            "temp":       "DSEG7 Modern"
+          },
+          "size": {
+            "tiny":   9,
+            "small":  10,
+            "normal": 12,
+            "large":  14
+          }
+        },
+        "sizing": {
+          "panel": {
+            "padding":      4,
+            "spacing":      4,
+            "cornerRadius": 4
+          },
+          "border": {
+            "subtle": 1,
+            "strong": 2
+          }
         }
-      },
-      "spectrum": {
-        "trace": "#00b4d8",
-        "peakHold": "#ffb84d",
-        "average": "#8ea8c0",
-        "grid": "#1a2330"
-      },
-      "waterfall.colormap": {
-        "default": {
-          "type": "linear-gradient",
-          "angle": 180,
-          "stops": [
-            { "at": 0.00, "color": "#000000" },
-            { "at": 0.15, "color": "#000080" },
-            { "at": 0.30, "color": "#0040ff" },
-            { "at": 0.45, "color": "#00c8ff" },
-            { "at": 0.60, "color": "#00dc00" },
-            { "at": 0.80, "color": "#ffff00" },
-            { "at": 1.00, "color": "#ff0000" }
-          ]
-        },
-        "grayscale": {
-          "type": "linear-gradient",
-          "angle": 180,
-          "stops": [
-            { "at": 0.00, "color": "#000000" },
-            { "at": 1.00, "color": "#ffffff" }
-          ]
-        },
-        "blueGreen": {
-          "type": "linear-gradient",
-          "angle": 180,
-          "stops": [
-            { "at": 0.00, "color": "#000000" },
-            { "at": 0.25, "color": "#001e78" },
-            { "at": 0.50, "color": "#0064b4" },
-            { "at": 0.75, "color": "#00c882" },
-            { "at": 1.00, "color": "#dcffdc" }
-          ]
-        },
-        "fire": {
-          "type": "linear-gradient",
-          "angle": 180,
-          "stops": [
-            { "at": 0.00, "color": "#000000" },
-            { "at": 0.25, "color": "#800000" },
-            { "at": 0.50, "color": "#dc5000" },
-            { "at": 0.75, "color": "#ffc800" },
-            { "at": 1.00, "color": "#ffffdc" }
-          ]
-        },
-        "plasma": {
-          "type": "linear-gradient",
-          "angle": 180,
-          "stops": [
-            { "at": 0.00, "color": "#000000" },
-            { "at": 0.25, "color": "#50008c" },
-            { "at": 0.50, "color": "#c80078" },
-            { "at": 0.75, "color": "#f07800" },
-            { "at": 1.00, "color": "#ffff50" }
-          ]
-        }
-      },
-      "slice": {
-        "a": "#00d4ff",
-        "b": "#ff40ff",
-        "c": "#40ff40",
-        "d": "#ffff00",
-        "e": "#ffa000",
-        "f": "#00e0c0",
-        "g": "#ff6080",
-        "h": "#b080ff",
-        "tx": "#ff4d4d",
-        "dim": {
-          "a": "#006080",
-          "b": "#802080",
-          "c": "#208020",
-          "d": "#808000",
-          "e": "#805000",
-          "f": "#007060",
-          "g": "#803040",
-          "h": "#584080"
-        }
-      }
-    },
-    "font": {
-      "family": {
-        "ui": "Inter",
-        "mono": "monospace",
-        "segment7": "DSEG7 Modern",
-        "segment14": "DSEG14 Modern",
-        "weather": "DSEGWeather",
-        "freq": "DSEG7 Modern",
-        "temp": "DSEG7 Modern"
-      },
-      "size": {
-        "tiny": 9,
-        "small": 10,
-        "normal": 12,
-        "large": 14
-      }
-    },
-    "sizing": {
-      "panel": {
-        "padding": 4,
-        "spacing": 4,
-        "cornerRadius": 4
-      },
-      "border": {
-        "subtle": 1,
-        "strong": 2
       }
     }
   }

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -160,13 +160,13 @@
         },
         "font": {
           "family": {
-            "ui":         "Inter",
-            "mono":       "monospace",
-            "segment7":   "DSEG7 Modern",
-            "segment14":  "DSEG14 Modern",
-            "weather":    "DSEGWeather",
-            "freq":       "DSEG7 Modern",
-            "temp":       "DSEG7 Modern"
+            "ui":         { "family": "Inter",         "size": 12, "color": "#1a2a3a" },
+            "mono":       { "family": "monospace",     "size": 12, "color": "#1a2a3a" },
+            "segment7":   { "family": "DSEG7 Modern",  "size": 14, "color": "#0088b0" },
+            "segment14":  { "family": "DSEG14 Modern", "size": 14, "color": "#0088b0" },
+            "weather":    { "family": "DSEGWeather",   "size": 14, "color": "#1a2a3a" },
+            "freq":       { "family": "DSEG7 Modern",  "size": 14, "color": "#0088b0" },
+            "temp":       { "family": "DSEG7 Modern",  "size": 12, "color": "#506070" }
           },
           "size": {
             "tiny":   9,

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -165,7 +165,7 @@
             "segment7":   { "family": "DSEG7 Modern",  "size": 14, "color": "#0088b0" },
             "segment14":  { "family": "DSEG14 Modern", "size": 14, "color": "#0088b0" },
             "weather":    { "family": "DSEGWeather",   "size": 14, "color": "#1a2a3a" },
-            "freq":       { "family": "DSEG7 Modern",  "size": 14, "color": "#0088b0" },
+            "freq":       { "family": "DSEG7 Modern",  "size": 26, "color": "#0088b0" },
             "temp":       { "family": "DSEG7 Modern",  "size": 12, "color": "#506070" }
           },
           "size": {

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -1,168 +1,191 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "name": "Default Light",
   "author": "AetherSDR Team",
-  "version": "1.0",
-  "description": "AetherSDR's first light theme — daylight-readable variant of the canonical token taxonomy. Backgrounds invert (panel ramp goes light→dark for elevation), text colours invert (primary text now dark on light), accents darken to maintain contrast against the light canvas. Slice and meter colours keep semantic meaning. Waterfall colormaps are unchanged (intensity gradients render the same in both themes — they're opaque, not transparent).",
-  "tokens": {
-    "color": {
-      "background": {
-        "0": "#f5f5f8",
-        "1": "#dde5ed",
-        "2": "#c8d2dc",
-        "3": "#b0bcc8",
-        "tx": "#ffeacc",
-        "success": "#c8e8d0",
-        "spectrum": "#ffffff",
-        "app": "#f5f5f8"
-      },
-      "accent": "#0088b0",
-      "accent.bright": "#0098c0",
-      "accent.dim": "#005080",
-      "accent.warning": "#d08010",
-      "accent.danger": "#c02020",
-      "accent.success": "#1a8040",
-      "text": {
-        "primary": "#1a2a3a",
-        "secondary": "#506070",
-        "label": "#7090a8",
-        "disabled": "#a0b0c0"
-      },
-      "border": {
-        "subtle": "#c0c8d0",
-        "strong": "#90a0b0",
-        "accent": "#0088b0",
-        "tx": "#b08840"
-      },
-      "meter": {
-        "crst": "#c02020",
-        "rms": "#0088b0",
-        "thresh": "#d08010",
-        "peak": "#1a2a3a",
-        "gainReduction": "#a06010",
-        "bar.fill": "#c0c8d0",
-        "bar.fillGradient": {
-          "type": "linear-gradient",
-          "angle": 0,
-          "stops": [
-            { "at": 0.00, "color": "#2f9e6a" },
-            { "at": 0.55, "color": "#6cc56a" },
-            { "at": 0.80, "color": "#e8b94c" },
-            { "at": 0.95, "color": "#e8553c" },
-            { "at": 1.00, "color": "#f2362a" }
-          ]
+  "version": "1.1",
+  "description": "AetherSDR's first light theme — v2 schema (primitives + nested scopes).  Semantic tokens resolve through a tailwind-style palette via {alias} references; rendered output is bit-identical to v1.0.",
+  "primitives": {
+    "color.blue.500":  "#0088b0",
+    "color.blue.300":  "#0098c0",
+    "color.blue.700":  "#005080",
+    "color.red.500":   "#c02020",
+    "color.amber.500": "#d08010",
+    "color.green.500": "#1a8040",
+    "color.gray.50":   "#1a2a3a",
+    "color.gray.100":  "#506070",
+    "color.gray.300":  "#7090a8",
+    "color.gray.400":  "#90a0b0",
+    "color.gray.500":  "#a0b0c0",
+    "color.gray.600":  "#b0bcc8",
+    "color.gray.700":  "#c0c8d0",
+    "color.gray.750":  "#c8d2dc",
+    "color.gray.800":  "#dde5ed",
+    "color.gray.900":  "#f5f5f8",
+    "color.gray.950":  "#ffffff"
+  },
+  "scopes": {
+    "root": {
+      "tokens": {
+        "color": {
+          "background": {
+            "0":        "{color.gray.900}",
+            "1":        "{color.gray.800}",
+            "2":        "{color.gray.750}",
+            "3":        "{color.gray.600}",
+            "tx":       "#ffeacc",
+            "success":  "#c8e8d0",
+            "spectrum": "{color.gray.950}",
+            "app":      "{color.gray.900}"
+          },
+          "accent":         "{color.blue.500}",
+          "accent.bright":  "{color.blue.300}",
+          "accent.dim":     "{color.blue.700}",
+          "accent.warning": "{color.amber.500}",
+          "accent.danger":  "{color.red.500}",
+          "accent.success": "{color.green.500}",
+          "text": {
+            "primary":   "{color.gray.50}",
+            "secondary": "{color.gray.100}",
+            "label":     "{color.gray.300}",
+            "disabled":  "{color.gray.500}"
+          },
+          "border": {
+            "subtle": "{color.gray.700}",
+            "strong": "{color.gray.400}",
+            "accent": "{color.blue.500}",
+            "tx":     "#b08840"
+          },
+          "meter": {
+            "crst":   "{color.red.500}",
+            "rms":    "{color.blue.500}",
+            "thresh": "{color.amber.500}",
+            "peak":   "{color.gray.50}",
+            "gainReduction": "#a06010",
+            "bar.fill": "{color.gray.700}",
+            "bar.fillGradient": {
+              "type": "linear-gradient",
+              "angle": 0,
+              "stops": [
+                { "at": 0.00, "color": "#2f9e6a" },
+                { "at": 0.55, "color": "#6cc56a" },
+                { "at": 0.80, "color": "#e8b94c" },
+                { "at": 0.95, "color": "#e8553c" },
+                { "at": 1.00, "color": "#f2362a" }
+              ]
+            }
+          },
+          "spectrum": {
+            "trace":    "{color.blue.500}",
+            "peakHold": "#c08020",
+            "average":  "{color.gray.100}",
+            "grid":     "#d0d8e0"
+          },
+          "waterfall.colormap": {
+            "default": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.15, "color": "#000080" },
+                { "at": 0.30, "color": "#0040ff" },
+                { "at": 0.45, "color": "#00c8ff" },
+                { "at": 0.60, "color": "#00dc00" },
+                { "at": 0.80, "color": "#ffff00" },
+                { "at": 1.00, "color": "#ff0000" }
+              ]
+            },
+            "grayscale": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 1.00, "color": "#ffffff" }
+              ]
+            },
+            "blueGreen": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#001e78" },
+                { "at": 0.50, "color": "#0064b4" },
+                { "at": 0.75, "color": "#00c882" },
+                { "at": 1.00, "color": "#dcffdc" }
+              ]
+            },
+            "fire": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#800000" },
+                { "at": 0.50, "color": "#dc5000" },
+                { "at": 0.75, "color": "#ffc800" },
+                { "at": 1.00, "color": "#ffffdc" }
+              ]
+            },
+            "plasma": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#50008c" },
+                { "at": 0.50, "color": "#c80078" },
+                { "at": 0.75, "color": "#f07800" },
+                { "at": 1.00, "color": "#ffff50" }
+              ]
+            }
+          },
+          "slice": {
+            "a":  "{color.blue.500}",
+            "b":  "#a020a0",
+            "c":  "#208020",
+            "d":  "#a08000",
+            "e":  "#c06000",
+            "f":  "#008070",
+            "g":  "#a04060",
+            "h":  "#604090",
+            "tx": "{color.red.500}",
+            "dim": {
+              "a": "#a0c8e0",
+              "b": "#e0c0e0",
+              "c": "#c0e0c0",
+              "d": "#e0e0c0",
+              "e": "#e0c8a0",
+              "f": "#c0e0d8",
+              "g": "#e0c0c8",
+              "h": "#d0c0e0"
+            }
+          }
+        },
+        "font": {
+          "family": {
+            "ui":         "Inter",
+            "mono":       "monospace",
+            "segment7":   "DSEG7 Modern",
+            "segment14":  "DSEG14 Modern",
+            "weather":    "DSEGWeather",
+            "freq":       "DSEG7 Modern",
+            "temp":       "DSEG7 Modern"
+          },
+          "size": {
+            "tiny":   9,
+            "small":  10,
+            "normal": 12,
+            "large":  14
+          }
+        },
+        "sizing": {
+          "panel": {
+            "padding":      4,
+            "spacing":      4,
+            "cornerRadius": 4
+          },
+          "border": {
+            "subtle": 1,
+            "strong": 2
+          }
         }
-      },
-      "spectrum": {
-        "trace": "#0088b0",
-        "peakHold": "#c08020",
-        "average": "#506070",
-        "grid": "#d0d8e0"
-      },
-      "waterfall.colormap": {
-        "default": {
-          "type": "linear-gradient",
-          "angle": 180,
-          "stops": [
-            { "at": 0.00, "color": "#000000" },
-            { "at": 0.15, "color": "#000080" },
-            { "at": 0.30, "color": "#0040ff" },
-            { "at": 0.45, "color": "#00c8ff" },
-            { "at": 0.60, "color": "#00dc00" },
-            { "at": 0.80, "color": "#ffff00" },
-            { "at": 1.00, "color": "#ff0000" }
-          ]
-        },
-        "grayscale": {
-          "type": "linear-gradient",
-          "angle": 180,
-          "stops": [
-            { "at": 0.00, "color": "#000000" },
-            { "at": 1.00, "color": "#ffffff" }
-          ]
-        },
-        "blueGreen": {
-          "type": "linear-gradient",
-          "angle": 180,
-          "stops": [
-            { "at": 0.00, "color": "#000000" },
-            { "at": 0.25, "color": "#001e78" },
-            { "at": 0.50, "color": "#0064b4" },
-            { "at": 0.75, "color": "#00c882" },
-            { "at": 1.00, "color": "#dcffdc" }
-          ]
-        },
-        "fire": {
-          "type": "linear-gradient",
-          "angle": 180,
-          "stops": [
-            { "at": 0.00, "color": "#000000" },
-            { "at": 0.25, "color": "#800000" },
-            { "at": 0.50, "color": "#dc5000" },
-            { "at": 0.75, "color": "#ffc800" },
-            { "at": 1.00, "color": "#ffffdc" }
-          ]
-        },
-        "plasma": {
-          "type": "linear-gradient",
-          "angle": 180,
-          "stops": [
-            { "at": 0.00, "color": "#000000" },
-            { "at": 0.25, "color": "#50008c" },
-            { "at": 0.50, "color": "#c80078" },
-            { "at": 0.75, "color": "#f07800" },
-            { "at": 1.00, "color": "#ffff50" }
-          ]
-        }
-      },
-      "slice": {
-        "a": "#0088b0",
-        "b": "#a020a0",
-        "c": "#208020",
-        "d": "#a08000",
-        "e": "#c06000",
-        "f": "#008070",
-        "g": "#a04060",
-        "h": "#604090",
-        "tx": "#c02020",
-        "dim": {
-          "a": "#a0c8e0",
-          "b": "#e0c0e0",
-          "c": "#c0e0c0",
-          "d": "#e0e0c0",
-          "e": "#e0c8a0",
-          "f": "#c0e0d8",
-          "g": "#e0c0c8",
-          "h": "#d0c0e0"
-        }
-      }
-    },
-    "font": {
-      "family": {
-        "ui": "Inter",
-        "mono": "monospace",
-        "segment7": "DSEG7 Modern",
-        "segment14": "DSEG14 Modern",
-        "weather": "DSEGWeather",
-        "freq": "DSEG7 Modern",
-        "temp": "DSEG7 Modern"
-      },
-      "size": {
-        "tiny": 9,
-        "small": 10,
-        "normal": 12,
-        "large": 14
-      }
-    },
-    "sizing": {
-      "panel": {
-        "padding": 4,
-        "spacing": 4,
-        "cornerRadius": 4
-      },
-      "border": {
-        "subtle": 1,
-        "strong": 2
       }
     }
   }

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -1338,19 +1338,30 @@ QString ThemeManager::cssFragment(const QString& token) const
     // alias-resolve through the primitives palette emit the right
     // literal value.
     const QVariant v = lookupRaw(QString(), token);
-    if (!v.isValid()) return QString();
-    if (v.userType() == qMetaTypeId<ThemeGradient>()) {
-        return gradientCssFragment(v.value<ThemeGradient>());
+    if (v.isValid()) {
+        if (v.userType() == qMetaTypeId<ThemeGradient>()) {
+            return gradientCssFragment(v.value<ThemeGradient>());
+        }
+        if (v.userType() == qMetaTypeId<ThemeFont>()) {
+            return v.value<ThemeFont>().family;
+        }
+        return colorHexToCssFragment(v.toString());
     }
-    // Compound font tokens: QSS templates referencing {{font.family.X}}
-    // expect the family string (e.g. for `font-family: "{{font.family.ui}}"`).
-    // Emit just .family — the size + color from the compound are
-    // surfaced through font(token) / fontToken(token) for callers that
-    // need them.
-    if (v.userType() == qMetaTypeId<ThemeFont>()) {
-        return v.value<ThemeFont>().family;
+    // Virtual lookup: `font.size.<role>` falls through to the embedded
+    // size field on `font.family.<role>` when no direct token exists.
+    // Lets QSS templates write `font-size: {{font.size.freq}}px` and have
+    // edits to the freq compound's size take effect without needing a
+    // separate scalar token namespace.
+    if (token.startsWith(QStringLiteral("font.size."))) {
+        const QString role = token.mid(QStringLiteral("font.size.").size());
+        const QVariant compound = lookupRaw(QString(),
+                                            QStringLiteral("font.family.") + role);
+        if (compound.userType() == qMetaTypeId<ThemeFont>()) {
+            const int sz = compound.value<ThemeFont>().size;
+            if (sz > 0) return QString::number(sz);
+        }
     }
-    return colorHexToCssFragment(v.toString());
+    return QString();
 }
 
 QFont ThemeManager::font(const QString& token) const
@@ -1377,14 +1388,27 @@ QFont ThemeManager::font(const QString& token) const
 int ThemeManager::sizing(const QString& token) const
 {
     const QVariant val = lookupRaw(QString(), token);
-    if (!val.isValid()) {
-        qCWarning(lcGui) << "ThemeManager: missing sizing token" << token;
-        return 0;
+    if (val.isValid()) {
+        bool ok = false;
+        const int v = val.toInt(&ok);
+        if (ok) return v;
+        return static_cast<int>(val.toDouble());
     }
-    bool ok = false;
-    const int v = val.toInt(&ok);
-    if (ok) return v;
-    return static_cast<int>(val.toDouble());
+    // Virtual font.size.<role> fallback into font.family.<role>'s
+    // embedded size, mirroring the cssFragment path.  Paint code that
+    // composes a QFont sized off a per-role compound thus reads the
+    // same number QSS templates do.
+    if (token.startsWith(QStringLiteral("font.size."))) {
+        const QString role = token.mid(QStringLiteral("font.size.").size());
+        const QVariant compound = lookupRaw(QString(),
+                                            QStringLiteral("font.family.") + role);
+        if (compound.userType() == qMetaTypeId<ThemeFont>()) {
+            const int sz = compound.value<ThemeFont>().size;
+            if (sz > 0) return sz;
+        }
+    }
+    qCWarning(lcGui) << "ThemeManager: missing sizing token" << token;
+    return 0;
 }
 
 QString ThemeManager::value(const QString& token) const
@@ -1798,14 +1822,28 @@ QString ThemeManager::cssFragment(const QWidget* widget, const QString& token) c
     // when no scope sets the token — keeps every QSS template valid
     // even when the active theme has no per-container overrides yet.
     const QVariant v = lookupRaw(containerPathFor(widget), token);
-    if (!v.isValid()) return cssFragment(token);
-    if (v.userType() == qMetaTypeId<ThemeGradient>()) {
-        return gradientCssFragment(v.value<ThemeGradient>());
+    if (v.isValid()) {
+        if (v.userType() == qMetaTypeId<ThemeGradient>()) {
+            return gradientCssFragment(v.value<ThemeGradient>());
+        }
+        if (v.userType() == qMetaTypeId<ThemeFont>()) {
+            return v.value<ThemeFont>().family;
+        }
+        return colorHexToCssFragment(v.toString());
     }
-    if (v.userType() == qMetaTypeId<ThemeFont>()) {
-        return v.value<ThemeFont>().family;
+    // Virtual font.size.<role> → font.family.<role>'s embedded size,
+    // walking the widget's scope chain so the freq label can vary per
+    // applet too.
+    if (token.startsWith(QStringLiteral("font.size."))) {
+        const QString role = token.mid(QStringLiteral("font.size.").size());
+        const QVariant compound = lookupRaw(containerPathFor(widget),
+                                            QStringLiteral("font.family.") + role);
+        if (compound.userType() == qMetaTypeId<ThemeFont>()) {
+            const int sz = compound.value<ThemeFont>().size;
+            if (sz > 0) return QString::number(sz);
+        }
     }
-    return colorHexToCssFragment(v.toString());
+    return cssFragment(token);
 }
 
 ThemeGradient ThemeManager::gradient(const QWidget* widget, const QString& token) const

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -559,6 +559,11 @@ bool ThemeManager::loadThemeFromPath(const QString& path)
                       QString(), m_rootScope->tokens);
     }
     rebuildScopePathIndex();
+    // Replay declared containers — the JSON load just wiped the scope
+    // tree's children, but widgets registered their container paths
+    // at construction time and we need those scopes to keep existing
+    // so the editor's tree picker can still navigate to them.
+    for (const QString& path : m_declaredContainers) scopeOrCreate(path);
     return true;
 }
 
@@ -1341,10 +1346,16 @@ QString ThemeManager::value(const QString& token) const
 
 QString ThemeManager::resolve(const QString& stylesheetTemplate) const
 {
+    return resolveFor(nullptr, stylesheetTemplate);
+}
+
+QString ThemeManager::resolveFor(const QWidget* widget,
+                                 const QString& stylesheetTemplate) const
+{
     // Replace every {{token.name}} with the token's stylesheet fragment.
-    // Routes through cssFragment(): scalar colour tokens emit "#rrggbb",
-    // numeric tokens emit their plain value ("12" — caller adds "px"),
-    // gradient tokens emit qlineargradient(...) / qradialgradient(...).
+    // When `widget` is non-null the token is resolved through its
+    // container chain (containerPathFor → scope tree walk).  When null
+    // (legacy resolve() callers) lookups go straight to root scope.
     static const QRegularExpression kRe(QStringLiteral(R"(\{\{([^}]+)\}\})"));
     QString out = stylesheetTemplate;
     QRegularExpressionMatchIterator it = kRe.globalMatch(stylesheetTemplate);
@@ -1352,8 +1363,8 @@ QString ThemeManager::resolve(const QString& stylesheetTemplate) const
     while (it.hasNext()) {
         const QRegularExpressionMatch m = it.next();
         const QString token = m.captured(1).trimmed();
-        const QString val = cssFragment(token);
-        // Adjust for the running offset as substitutions change length.
+        const QString val = widget ? cssFragment(widget, token)
+                                    : cssFragment(token);
         out.replace(m.capturedStart(0) + offset,
                     m.capturedLength(0),
                     val);
@@ -1383,7 +1394,10 @@ void ThemeManager::applyStyleSheet(QWidget* widget, const QString& stylesheetTem
     // Resolve and apply right away so the caller gets the same visual
     // result they'd have gotten from setStyleSheet(resolve(...)) — the
     // tracking is an additive side-effect, not a behaviour change.
-    widget->setStyleSheet(resolve(stylesheetTemplate));
+    // Scope-aware resolve — the widget's container chain decides which
+    // overrides apply.  Widgets with no declared ancestor fall through
+    // to root scope, matching the historical flat behaviour.
+    widget->setStyleSheet(resolveFor(widget, stylesheetTemplate));
 
     // First-time registration: connect to destroyed() so the entry
     // disappears when the widget does.  Subsequent calls on the same
@@ -1516,7 +1530,10 @@ void ThemeManager::reapplyAllTrackedStyleSheets()
         const auto& ctx = it.value();
         if (ctx.stylesheetTemplate.isEmpty()) continue;
         if (targeted && !ctx.tokens.contains(m_currentEditToken)) continue;
-        w->setStyleSheet(resolve(ctx.stylesheetTemplate));
+        // Scope-aware re-apply — same path as applyStyleSheet() so an
+        // edit at a non-root scope visibly takes effect for every
+        // tracked widget under that container.
+        w->setStyleSheet(resolveFor(w, ctx.stylesheetTemplate));
     }
 }
 
@@ -1538,6 +1555,16 @@ QString ThemeManager::containerPathFor(const QWidget* widget) const
         w = w->parentWidget();
     }
     return QString();
+}
+
+void ThemeManager::registerDeclaredContainer(const QString& containerPath)
+{
+    if (containerPath.isEmpty()) return;
+    m_declaredContainers.insert(containerPath);
+    // Ensure the scope exists in the tree even when no override is
+    // present yet — keeps the path visible to the editor's tree
+    // picker between theme loads.
+    scopeOrCreate(containerPath);
 }
 
 QStringList ThemeManager::containerPaths() const
@@ -1617,8 +1644,15 @@ QBrush ThemeManager::brush(const QWidget* widget, const QString& token,
 
 QString ThemeManager::cssFragment(const QWidget* widget, const QString& token) const
 {
-    Q_UNUSED(widget);
-    return cssFragment(token);
+    // Scope-walk via the widget's container chain.  Falls back to root
+    // when no scope sets the token — keeps every QSS template valid
+    // even when the active theme has no per-container overrides yet.
+    const QVariant v = lookupRaw(containerPathFor(widget), token);
+    if (!v.isValid()) return cssFragment(token);
+    if (v.userType() == qMetaTypeId<ThemeGradient>()) {
+        return gradientCssFragment(v.value<ThemeGradient>());
+    }
+    return colorHexToCssFragment(v.toString());
 }
 
 ThemeGradient ThemeManager::gradient(const QWidget* widget, const QString& token) const
@@ -1692,6 +1726,12 @@ void setContainer(QWidget* widget, const QString& containerPath)
 {
     if (!widget) return;
     widget->setProperty("themeContainer", containerPath);
+    // Register the declared path with ThemeManager so it stays visible
+    // in the editor's container tree even when no override has been
+    // written to that scope yet.
+    if (!containerPath.isEmpty()) {
+        ThemeManager::instance().registerDeclaredContainer(containerPath);
+    }
 }
 
 QString containerOf(const QWidget* widget)

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -1605,6 +1605,17 @@ bool ThemeManager::isOverriddenAt(const QString& containerPath, const QString& t
     return s->tokens.constFind(token) != s->tokens.constEnd();
 }
 
+void ThemeManager::removeOverride(const QString& containerPath, const QString& token)
+{
+    ThemeScope* s = scopeForPath(containerPath);
+    if (!s) return;
+    if (s->tokens.remove(token) == 0) return;  // nothing to drop
+    m_currentEditToken = token;
+    emit themeChanged();
+    m_currentEditToken.clear();
+    saveActiveTheme();
+}
+
 QStringList ThemeManager::containerPaths() const
 {
     QStringList out;

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -1734,6 +1734,16 @@ void ThemeManager::removeOverride(const QString& containerPath, const QString& t
 {
     ThemeScope* s = scopeForPath(containerPath);
     if (!s) return;
+    // Root scope is the BASE — there's nothing for the token to
+    // inherit FROM if we drop its root entry, so a "clear" there would
+    // delete the value tree-wide rather than restore inheritance.
+    // Reject root-scope clears defensively; the editor surface
+    // already hides the menu for the root column.
+    if (s == m_rootScope.get()) {
+        qCWarning(lcGui) << "ThemeManager::removeOverride: refusing to drop"
+                         << token << "from root scope (would delete it tree-wide)";
+        return;
+    }
     if (s->tokens.remove(token) == 0) return;  // nothing to drop
     m_currentEditToken = token;
     emit themeChanged();

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -682,10 +682,9 @@ void ThemeManager::setSizing(const QString& token, int value)
 
 ThemeGradient ThemeManager::gradient(const QString& token) const
 {
-    const auto it = m_tokens.constFind(token);
-    if (it == m_tokens.constEnd()) return {};
-    if (!it.value().canConvert<ThemeGradient>()) return {};
-    return it.value().value<ThemeGradient>();
+    const QVariant v = lookupRaw(QString(), token);
+    if (v.userType() != qMetaTypeId<ThemeGradient>()) return {};
+    return v.value<ThemeGradient>();
 }
 
 void ThemeManager::setGradient(const QString& token, const ThemeGradient& g)
@@ -1218,35 +1217,35 @@ QString ThemeManager::importThemeFromFile(const QString& filePath,
 
 QColor ThemeManager::color(const QString& token) const
 {
-    const auto it = m_tokens.constFind(token);
-    if (it == m_tokens.constEnd()) {
+    // Route through lookupRaw so `{primitive.key}` aliases stored in
+    // semantic tokens resolve through the primitives map.  Passing ""
+    // for the path reads root scope, matching legacy bare-token
+    // behaviour exactly when no aliases are in play.
+    const QVariant v = lookupRaw(QString(), token);
+    if (!v.isValid()) {
         qCWarning(lcGui) << "ThemeManager: missing color token" << token;
         return QColor(Qt::transparent);
     }
-    // Gradient tokens: graceful fallback to the first stop's colour so
-    // existing callers asking for a flat colour on what's now a gradient
-    // token don't crash.  Callers that actually want the gradient should
-    // use brush() or cssFragment().
-    if (it.value().canConvert<ThemeGradient>()) {
-        const auto g = it.value().value<ThemeGradient>();
+    if (v.userType() == qMetaTypeId<ThemeGradient>()) {
+        const auto g = v.value<ThemeGradient>();
         if (!g.stops.isEmpty()) return g.stops.first().color;
         return QColor(Qt::transparent);
     }
-    return QColor(it.value().toString());
+    return QColor(v.toString());
 }
 
 QBrush ThemeManager::brush(const QString& token, const QRect& bounds) const
 {
-    const auto it = m_tokens.constFind(token);
-    if (it == m_tokens.constEnd()) {
+    const QVariant val = lookupRaw(QString(), token);
+    if (!val.isValid()) {
         qCWarning(lcGui) << "ThemeManager: missing brush token" << token;
         return QBrush(Qt::transparent);
     }
-    if (!it.value().canConvert<ThemeGradient>()) {
+    if (val.userType() != qMetaTypeId<ThemeGradient>()) {
         // Scalar — wrap the colour into a solid brush.
-        return QBrush(QColor(it.value().toString()));
+        return QBrush(QColor(val.toString()));
     }
-    const auto g = it.value().value<ThemeGradient>();
+    const auto g = val.value<ThemeGradient>();
     if (g.type == ThemeGradient::Linear) {
         qreal nx1, ny1, nx2, ny2;
         linearAngleToEndpoints(g.angle, nx1, ny1, nx2, ny2);
@@ -1292,15 +1291,16 @@ QBrush ThemeManager::brush(const QString& token, const QRect& bounds) const
 
 QString ThemeManager::cssFragment(const QString& token) const
 {
-    const auto it = m_tokens.constFind(token);
-    if (it == m_tokens.constEnd()) return QString();
-    if (it.value().canConvert<ThemeGradient>()) {
-        return gradientCssFragment(it.value().value<ThemeGradient>());
+    // Alias-aware: lookupRaw expands `{primitive.key}` references before
+    // returning, so QSS templates referencing semantic tokens that
+    // alias-resolve through the primitives palette emit the right
+    // literal value.
+    const QVariant v = lookupRaw(QString(), token);
+    if (!v.isValid()) return QString();
+    if (v.userType() == qMetaTypeId<ThemeGradient>()) {
+        return gradientCssFragment(v.value<ThemeGradient>());
     }
-    // Scalar tokens: route translucent values through rgba(...) so Qt's
-    // stylesheet parser actually honours alpha.  Opaque values pass
-    // through verbatim ("#rrggbb").
-    return colorHexToCssFragment(it.value().toString());
+    return colorHexToCssFragment(v.toString());
 }
 
 QFont ThemeManager::font(const QString& token) const
@@ -1321,27 +1321,23 @@ QFont ThemeManager::font(const QString& token) const
 
 int ThemeManager::sizing(const QString& token) const
 {
-    const auto it = m_tokens.constFind(token);
-    if (it == m_tokens.constEnd()) {
+    const QVariant val = lookupRaw(QString(), token);
+    if (!val.isValid()) {
         qCWarning(lcGui) << "ThemeManager: missing sizing token" << token;
         return 0;
     }
     bool ok = false;
-    const int v = it.value().toInt(&ok);
+    const int v = val.toInt(&ok);
     if (ok) return v;
-    return static_cast<int>(it.value().toDouble());
+    return static_cast<int>(val.toDouble());
 }
 
 QString ThemeManager::value(const QString& token) const
 {
-    const auto it = m_tokens.constFind(token);
-    if (it == m_tokens.constEnd()) return QString();
-    // Gradient tokens have no meaningful raw scalar — return empty so
-    // callers that expected a string don't accidentally inline the
-    // QVariant::toString() of a structured value.  Use cssFragment()
-    // for the stylesheet form or brush() for paint code.
-    if (it.value().canConvert<ThemeGradient>()) return QString();
-    return it.value().toString();
+    const QVariant v = lookupRaw(QString(), token);
+    if (!v.isValid()) return QString();
+    if (v.userType() == qMetaTypeId<ThemeGradient>()) return QString();
+    return v.toString();
 }
 
 QString ThemeManager::resolve(const QString& stylesheetTemplate) const

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -57,6 +57,22 @@ ThemeGradient parseGradient(const QJsonObject& obj)
     return g;
 }
 
+// Parse a JSON compound-font object into the structured ThemeFont form.
+// Schema: { "family": "Inter", "size": 12, "color": "#c8d8e8" }
+// Family is required; size defaults to 0 (caller uses role-default);
+// color defaults to invalid (caller falls back to color.text.primary).
+ThemeFont parseFont(const QJsonObject& obj)
+{
+    ThemeFont f;
+    f.family = obj.value("family").toString();
+    if (obj.contains("size")) f.size = obj.value("size").toInt(0);
+    if (obj.contains("color")) {
+        const QColor c(obj.value("color").toString());
+        if (c.isValid()) f.color = c;
+    }
+    return f;
+}
+
 // Round-trip-safe hex encoding for token storage.  Qt's QColor::name()
 // defaults to "#rrggbb" and silently drops alpha — so any caller storing
 // `color.name()` loses translucency.  Always use the explicit format that
@@ -97,6 +113,13 @@ void flattenTokens(const QJsonObject& obj, const QString& prefix,
             // distinguishes them from plain nested token groups.
             if (inner.contains("type") && inner.value("type").isString()) {
                 out.insert(key, QVariant::fromValue(parseGradient(inner)));
+                continue;
+            }
+            // Compound font object — required `family` field with no
+            // `type` discriminator.  Tells this layer apart from the
+            // legacy bare-string family tokens.
+            if (inner.contains("family") && inner.value("family").isString()) {
+                out.insert(key, QVariant::fromValue(parseFont(inner)));
                 continue;
             }
             flattenTokens(inner, key, out);
@@ -283,6 +306,7 @@ ThemeManager::ThemeManager()
     // the header sets up the template machinery, but explicit registration
     // here makes saveCurrentThemeAs()'s type check timing-independent.
     qRegisterMetaType<ThemeGradient>("AetherSDR::ThemeGradient");
+    qRegisterMetaType<ThemeFont>("AetherSDR::ThemeFont");
 
     seedBuiltinDefaults();
     scanAvailableThemes();
@@ -913,6 +937,7 @@ QJsonObject ThemeManager::scopeToJson(const ThemeScope* scope) const
     // bugs (color.accent vs. color.accent.bright) and because the
     // editor never reads the file in nested form.
     const int gradMetaId = qMetaTypeId<ThemeGradient>();
+    const int fontMetaId = qMetaTypeId<ThemeFont>();
     QJsonObject result;
     if (!scope->tokens.isEmpty()) {
         QJsonObject toks;
@@ -945,6 +970,14 @@ QJsonObject ThemeManager::scopeToJson(const ThemeScope* scope) const
                 }
                 gj.insert("stops", stops);
                 leaf = gj;
+            }
+            else if (ut == fontMetaId) {
+                const ThemeFont f = v.value<ThemeFont>();
+                QJsonObject fj;
+                fj.insert("family", f.family);
+                if (f.size > 0)       fj.insert("size",  f.size);
+                if (f.color.isValid()) fj.insert("color", colorToTokenString(f.color));
+                leaf = fj;
             }
             else {
                 qCWarning(lcGui) << "ThemeManager::scopeToJson: skipping token"
@@ -1068,6 +1101,7 @@ bool ThemeManager::exportThemeToFile(const QString& themeName,
     if (themeName == m_activeTheme) {
         QJsonObject tokensObj;
         const int gradMetaId = qMetaTypeId<ThemeGradient>();
+        const int fontMetaId = qMetaTypeId<ThemeFont>();
         for (auto it = m_tokens.constBegin(); it != m_tokens.constEnd(); ++it) {
             const QVariant& v = it.value();
             const int ut = v.userType();
@@ -1097,6 +1131,14 @@ bool ThemeManager::exportThemeToFile(const QString& themeName,
                 }
                 gj.insert("stops", stops);
                 leaf = gj;
+            }
+            else if (ut == fontMetaId) {
+                const ThemeFont f = v.value<ThemeFont>();
+                QJsonObject fj;
+                fj.insert("family", f.family);
+                if (f.size > 0)        fj.insert("size",  f.size);
+                if (f.color.isValid()) fj.insert("color", colorToTokenString(f.color));
+                leaf = fj;
             }
             else continue;
             tokensObj.insert(it.key(), leaf);
@@ -1305,13 +1347,18 @@ QString ThemeManager::cssFragment(const QString& token) const
 
 QFont ThemeManager::font(const QString& token) const
 {
-    // Convention: font.* tokens are read as a (family, size) compound
-    // when the caller asks for a font object.  Sub-tokens (family / size
-    // / weight) come from sibling tokens — caller passes the *base*
-    // token (e.g. "font" for the UI default) and we assemble from
-    // "font.family.ui" + "font.size.normal".  Phase 1 ships only the
-    // direct read for the simplest path; richer font composition lands
-    // when Phase 5's font picker arrives.
+    // Compound-token fast path — if the operator passed a font.family.*
+    // (or any token that resolved to a ThemeFont), assemble directly
+    // from its family + embedded size.  Falls back to the legacy
+    // composition (font.family.ui family + sizing(token)) for callers
+    // that pass a font.size.* token name.
+    const QVariant v = lookupRaw(QString(), token);
+    if (v.userType() == qMetaTypeId<ThemeFont>()) {
+        const ThemeFont tf = v.value<ThemeFont>();
+        QFont qf(tf.family);
+        if (tf.size > 0) qf.setPointSize(tf.size);
+        return qf;
+    }
     QFont f;
     const QString family = value("font.family.ui");
     if (!family.isEmpty()) f.setFamily(family);
@@ -1337,7 +1384,48 @@ QString ThemeManager::value(const QString& token) const
     const QVariant v = lookupRaw(QString(), token);
     if (!v.isValid()) return QString();
     if (v.userType() == qMetaTypeId<ThemeGradient>()) return QString();
+    // Compound font tokens transparently downgrade to their family
+    // string so the ~35 sites that read `tm.value("font.family.ui")`
+    // keep working after the v1-string → v2-compound migration.
+    if (v.userType() == qMetaTypeId<ThemeFont>()) {
+        return v.value<ThemeFont>().family;
+    }
     return v.toString();
+}
+
+ThemeFont ThemeManager::fontToken(const QString& token) const
+{
+    return fontTokenAt(QString(), token);
+}
+
+ThemeFont ThemeManager::fontTokenAt(const QString& containerPath,
+                                    const QString& token) const
+{
+    const QVariant v = lookupRaw(containerPath, token);
+    if (v.userType() == qMetaTypeId<ThemeFont>()) return v.value<ThemeFont>();
+    // Legacy v1 path: bare family string with no embedded size / color.
+    ThemeFont f;
+    f.family = v.toString();
+    return f;
+}
+
+void ThemeManager::setFontToken(const QString& token, const ThemeFont& f)
+{
+    setFontToken(QString(), token, f);
+}
+
+void ThemeManager::setFontToken(const QString& containerPath,
+                                const QString& token, const ThemeFont& f)
+{
+    ThemeScope* scope = containerPath.isEmpty()
+                            ? m_rootScope.get()
+                            : scopeOrCreate(containerPath);
+    if (!scope) return;
+    scope->tokens.insert(token, QVariant::fromValue(f));
+    m_currentEditToken = token;
+    emit themeChanged();
+    m_currentEditToken.clear();
+    saveActiveTheme();
 }
 
 QString ThemeManager::resolve(const QString& stylesheetTemplate) const
@@ -1588,6 +1676,11 @@ QString ThemeManager::valueAt(const QString& containerPath, const QString& token
     const QVariant v = lookupRaw(containerPath, token);
     if (!v.isValid()) return value(token);
     if (v.userType() == qMetaTypeId<ThemeGradient>()) return {};
+    // Compound font tokens transparently downgrade to .family — same
+    // contract as the bare `value(token)` overload.
+    if (v.userType() == qMetaTypeId<ThemeFont>()) {
+        return v.value<ThemeFont>().family;
+    }
     return v.toString();
 }
 

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -1342,6 +1342,14 @@ QString ThemeManager::cssFragment(const QString& token) const
     if (v.userType() == qMetaTypeId<ThemeGradient>()) {
         return gradientCssFragment(v.value<ThemeGradient>());
     }
+    // Compound font tokens: QSS templates referencing {{font.family.X}}
+    // expect the family string (e.g. for `font-family: "{{font.family.ui}}"`).
+    // Emit just .family — the size + color from the compound are
+    // surfaced through font(token) / fontToken(token) for callers that
+    // need them.
+    if (v.userType() == qMetaTypeId<ThemeFont>()) {
+        return v.value<ThemeFont>().family;
+    }
     return colorHexToCssFragment(v.toString());
 }
 
@@ -1793,6 +1801,9 @@ QString ThemeManager::cssFragment(const QWidget* widget, const QString& token) c
     if (!v.isValid()) return cssFragment(token);
     if (v.userType() == qMetaTypeId<ThemeGradient>()) {
         return gradientCssFragment(v.value<ThemeGradient>());
+    }
+    if (v.userType() == qMetaTypeId<ThemeFont>()) {
+        return v.value<ThemeFont>().family;
     }
     return colorHexToCssFragment(v.toString());
 }

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -473,7 +473,15 @@ void ThemeManager::setColor(const QString& token, const QColor& color)
     const auto it = m_tokens.constFind(token);
     if (it != m_tokens.constEnd() && it.value().toString() == hex) return;
     m_tokens.insert(token, QVariant(hex));
+    // Smart-invalidation hint scope — reapplyAllTrackedStyleSheets reads
+    // this during the synchronous themeChanged dispatch and skips every
+    // tracked widget whose template doesn't reference `token`.  Cleared
+    // before returning so subsequent full-theme reloads (setActiveTheme)
+    // walk every widget.
+    m_currentEditToken = token;
     emit themeChanged();
+    m_currentEditToken.clear();
+    saveActiveTheme();
 }
 
 void ThemeManager::setSizing(const QString& token, int value)
@@ -481,7 +489,10 @@ void ThemeManager::setSizing(const QString& token, int value)
     const auto it = m_tokens.constFind(token);
     if (it != m_tokens.constEnd() && it.value().toInt() == value) return;
     m_tokens.insert(token, QVariant(value));
+    m_currentEditToken = token;
     emit themeChanged();
+    m_currentEditToken.clear();
+    saveActiveTheme();
 }
 
 ThemeGradient ThemeManager::gradient(const QString& token) const
@@ -495,7 +506,10 @@ ThemeGradient ThemeManager::gradient(const QString& token) const
 void ThemeManager::setGradient(const QString& token, const ThemeGradient& g)
 {
     m_tokens.insert(token, QVariant::fromValue(g));
+    m_currentEditToken = token;
     emit themeChanged();
+    m_currentEditToken.clear();
+    saveActiveTheme();
 }
 
 void ThemeManager::setString(const QString& token, const QString& value)
@@ -507,7 +521,25 @@ void ThemeManager::setString(const QString& token, const QString& value)
         return;
     }
     m_tokens.insert(token, QVariant(value));
+    m_currentEditToken = token;
     emit themeChanged();
+    m_currentEditToken.clear();
+    saveActiveTheme();
+}
+
+bool ThemeManager::saveActiveTheme()
+{
+    if (m_activeTheme.isEmpty()) return false;
+    if (isBuiltInTheme(m_activeTheme)) {
+        // Built-ins live in :/themes/ and can't be overwritten.  The
+        // TokenEditorWidget gates OK clicks on built-in themes through a
+        // Save As prompt, so the only way we'd land here is a setter
+        // being called outside that flow — be defensive and skip.
+        return false;
+    }
+    const auto it = m_themePaths.constFind(m_activeTheme);
+    if (it == m_themePaths.constEnd()) return false;
+    return writeThemeFile(m_activeTheme, it.value());
 }
 
 void ThemeManager::ensureFactoryLoaded() const
@@ -687,10 +719,8 @@ bool ThemeManager::renameTheme(const QString& oldName, const QString& newName)
     return true;
 }
 
-bool ThemeManager::saveCurrentThemeAs(const QString& newThemeName)
+bool ThemeManager::writeThemeFile(const QString& themeName, const QString& path)
 {
-    if (newThemeName.trimmed().isEmpty()) return false;
-
     // Round-trip-safe flat dotted-key serialization.  The bundled themes
     // organize tokens into nested objects for human readability, but the
     // earlier deep-walk version of this code had two bugs that lost data
@@ -705,11 +735,7 @@ bool ThemeManager::saveCurrentThemeAs(const QString& newThemeName)
     //
     // The flat output below is a strict subset of what flattenTokens()
     // accepts (`{"tokens": {"color.background.0": "#0f0f1a", ...}}`):
-    // each dotted key becomes a literal JSON key inside `tokens`.  Less
-    // pretty than the bundled themes, but every token round-trips
-    // perfectly with zero conflict surface.  Future-Phase-5 polish can
-    // group these into the bundled nested layout once the editor is
-    // doing more than dump-and-reload.
+    // each dotted key becomes a literal JSON key inside `tokens`.
     QJsonObject tokensObj;
     const int gradMetaId = qMetaTypeId<ThemeGradient>();
     for (auto it = m_tokens.constBegin(); it != m_tokens.constEnd(); ++it) {
@@ -743,21 +769,35 @@ bool ThemeManager::saveCurrentThemeAs(const QString& newThemeName)
             leaf = gj;
         }
         else {
-            qCWarning(lcGui) << "ThemeManager::saveCurrentThemeAs: skipping token"
+            qCWarning(lcGui) << "ThemeManager::writeThemeFile: skipping token"
                              << it.key() << "with unsupported metatype" << ut;
             continue;
         }
         tokensObj.insert(it.key(), leaf);
     }
-    QJsonObject root = tokensObj;
 
     QJsonObject doc;
     doc.insert("schemaVersion", 1);
-    doc.insert("name",          newThemeName);
+    doc.insert("name",          themeName);
     doc.insert("author",        QStringLiteral("AetherSDR user"));
     doc.insert("version",       QStringLiteral("1.0"));
-    doc.insert("description",   QStringLiteral("Created via the Theme Editor."));
-    doc.insert("tokens",        root);
+    doc.insert("description",   QStringLiteral("Edited via the Theme Editor."));
+    doc.insert("tokens",        tokensObj);
+
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        qCWarning(lcGui) << "ThemeManager::writeThemeFile failed to open"
+                         << path << f.errorString();
+        return false;
+    }
+    f.write(QJsonDocument(doc).toJson(QJsonDocument::Indented));
+    f.close();
+    return true;
+}
+
+bool ThemeManager::saveCurrentThemeAs(const QString& newThemeName)
+{
+    if (newThemeName.trimmed().isEmpty()) return false;
 
     // Mirror scanAvailableThemes — GenericConfigLocation + "/AetherSDR"
     // keeps the saved theme alongside the existing user-dir layout
@@ -768,14 +808,7 @@ bool ThemeManager::saveCurrentThemeAs(const QString& newThemeName)
     QDir().mkpath(userDir);
     const QString path = userDir + QLatin1Char('/')
                        + newThemeName + QStringLiteral(".json");
-    QFile f(path);
-    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-        qCWarning(lcGui) << "ThemeManager: saveCurrentThemeAs failed to open"
-                         << path << f.errorString();
-        return false;
-    }
-    f.write(QJsonDocument(doc).toJson(QJsonDocument::Indented));
-    f.close();
+    if (!writeThemeFile(newThemeName, path)) return false;
 
     // Register the new theme in the path map so availableThemes() picks it
     // up immediately, then make it the active theme (loads cleanly from
@@ -1240,6 +1273,16 @@ void ThemeManager::reapplyAllTrackedStyleSheets()
     // that might in turn touch m_trackedWidgets.  Iterating a copy
     // avoids the QHash-mutation-during-iteration undefined behaviour.
     const auto widgets = m_trackedWidgets.keys();
+    // Smart invalidation: when this re-apply is the consequence of a
+    // single-token edit (setColor / setGradient / setSizing / setString),
+    // m_currentEditToken is set and we skip every widget whose recorded
+    // template doesn't reference that token.  For 500+ tracked widgets
+    // and a typical token consumed by ~5–10 sites, this is a 50–100x
+    // speedup over the full walk and is the difference between a
+    // smooth picker drag and "every mouse move stalls the UI".
+    // setActiveTheme leaves m_currentEditToken empty so the full theme
+    // switch still touches every tracked stylesheet.
+    const bool targeted = !m_currentEditToken.isEmpty();
     for (QWidget* w : widgets) {
         const auto it = m_trackedWidgets.constFind(w);
         if (it == m_trackedWidgets.constEnd()) continue;  // dropped mid-sweep
@@ -1247,9 +1290,10 @@ void ThemeManager::reapplyAllTrackedStyleSheets()
         // empty template — skip them so we don't wipe any stylesheet they
         // may have inherited from a parent / Theme.h helper.  They handle
         // theme changes by connecting to themeChanged themselves.
-        const QString& tmpl = it.value().stylesheetTemplate;
-        if (tmpl.isEmpty()) continue;
-        w->setStyleSheet(resolve(tmpl));
+        const auto& ctx = it.value();
+        if (ctx.stylesheetTemplate.isEmpty()) continue;
+        if (targeted && !ctx.tokens.contains(m_currentEditToken)) continue;
+        w->setStyleSheet(resolve(ctx.stylesheetTemplate));
     }
 }
 

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -1567,6 +1567,48 @@ void ThemeManager::registerDeclaredContainer(const QString& containerPath)
     scopeOrCreate(containerPath);
 }
 
+QColor ThemeManager::colorAt(const QString& containerPath, const QString& token) const
+{
+    const QVariant v = lookupRaw(containerPath, token);
+    if (!v.isValid()) return color(token);
+    if (v.userType() == qMetaTypeId<ThemeGradient>()) {
+        const ThemeGradient g = v.value<ThemeGradient>();
+        return g.stops.isEmpty() ? QColor() : g.stops.first().color;
+    }
+    return QColor(v.toString());
+}
+
+int ThemeManager::sizingAt(const QString& containerPath, const QString& token) const
+{
+    const QVariant v = lookupRaw(containerPath, token);
+    if (!v.isValid()) return sizing(token);
+    bool ok = false;
+    const int n = v.toInt(&ok);
+    return ok ? n : sizing(token);
+}
+
+QString ThemeManager::valueAt(const QString& containerPath, const QString& token) const
+{
+    const QVariant v = lookupRaw(containerPath, token);
+    if (!v.isValid()) return value(token);
+    if (v.userType() == qMetaTypeId<ThemeGradient>()) return {};
+    return v.toString();
+}
+
+ThemeGradient ThemeManager::gradientAt(const QString& containerPath, const QString& token) const
+{
+    const QVariant v = lookupRaw(containerPath, token);
+    if (v.userType() == qMetaTypeId<ThemeGradient>()) return v.value<ThemeGradient>();
+    return gradient(token);
+}
+
+bool ThemeManager::isOverriddenAt(const QString& containerPath, const QString& token) const
+{
+    const ThemeScope* s = scopeForPath(containerPath);
+    if (!s) return false;
+    return s->tokens.constFind(token) != s->tokens.constEnd();
+}
+
 QStringList ThemeManager::containerPaths() const
 {
     QStringList out;

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -162,6 +162,103 @@ QString gradientCssFragment(const ThemeGradient& g)
 
 } // namespace
 
+// ─────────────────────────────────────────────── scope tree ──────────────
+
+// A single node in the container scope tree.  Lives in the .cpp so the
+// header doesn't need to expose its layout — public scope-aware API
+// references scopes only by string path.
+struct ThemeScope {
+    QString name;                    // segment name (e.g. "spectrum")
+    QString path;                    // full path "" / "spectrum" / "spectrum/panadapter"
+    ThemeScope* parent {nullptr};
+    QHash<QString, QVariant> tokens; // semantic tokens overridden at this scope
+    // Children kept in a std::map (move-only-friendly + deterministic
+    // iteration order) — QHash refuses unique_ptr values because its
+    // implicit-copy paths can't compile against move-only types.
+    std::map<QString, std::unique_ptr<ThemeScope>> children;
+};
+
+ThemeManager::~ThemeManager() = default;
+
+ThemeScope* ThemeManager::scopeForPath(const QString& path) const
+{
+    if (path.isEmpty() || path == QLatin1String("root")) {
+        return m_rootScope.get();
+    }
+    const auto it = m_scopeByPath.constFind(path);
+    return (it == m_scopeByPath.constEnd()) ? nullptr : it.value();
+}
+
+ThemeScope* ThemeManager::scopeOrCreate(const QString& path)
+{
+    if (path.isEmpty() || path == QLatin1String("root")) return m_rootScope.get();
+    if (auto* existing = scopeForPath(path)) return existing;
+
+    // Walk segments from root, creating any missing intermediate scopes.
+    ThemeScope* cur = m_rootScope.get();
+    const QStringList segs = path.split(QLatin1Char('/'), Qt::SkipEmptyParts);
+    QString runningPath;
+    for (const QString& seg : segs) {
+        runningPath = runningPath.isEmpty()
+                          ? seg : runningPath + QLatin1Char('/') + seg;
+        auto it = cur->children.find(seg);
+        if (it == cur->children.end()) {
+            auto child = std::make_unique<ThemeScope>();
+            child->name   = seg;
+            child->path   = runningPath;
+            child->parent = cur;
+            ThemeScope* raw = child.get();
+            cur->children.emplace(seg, std::move(child));
+            m_scopeByPath.insert(runningPath, raw);
+            cur = raw;
+        } else {
+            cur = it->second.get();
+        }
+    }
+    return cur;
+}
+
+QVariant ThemeManager::resolveAlias(const QVariant& v) const
+{
+    if (v.userType() != QMetaType::QString) return v;
+    const QString s = v.toString();
+    if (s.size() < 3 || !s.startsWith(QLatin1Char('{')) || !s.endsWith(QLatin1Char('}'))) {
+        return v;
+    }
+    const QString key = s.mid(1, s.size() - 2);
+    const auto it = m_primitives.constFind(key);
+    if (it == m_primitives.constEnd()) return v;  // unresolved alias — return literal
+    return it.value();
+}
+
+QVariant ThemeManager::lookupRaw(const QString& containerPath, const QString& key) const
+{
+    const ThemeScope* scope = scopeForPath(containerPath);
+    if (!scope) scope = m_rootScope.get();
+    while (scope) {
+        const auto it = scope->tokens.constFind(key);
+        if (it != scope->tokens.constEnd()) return resolveAlias(it.value());
+        scope = scope->parent;
+    }
+    return {};
+}
+
+void ThemeManager::rebuildScopePathIndex()
+{
+    m_scopeByPath.clear();
+    if (!m_rootScope) return;
+    m_scopeByPath.insert(QString(), m_rootScope.get());      // empty key = root
+    m_scopeByPath.insert(QStringLiteral("root"), m_rootScope.get());
+    std::function<void(ThemeScope*)> walk = [&](ThemeScope* s) {
+        for (auto& kv : s->children) {
+            ThemeScope* child = kv.second.get();
+            m_scopeByPath.insert(child->path, child);
+            walk(child);
+        }
+    };
+    walk(m_rootScope.get());
+}
+
 ThemeManager& ThemeManager::instance()
 {
     static ThemeManager s_instance;
@@ -169,7 +266,17 @@ ThemeManager& ThemeManager::instance()
 }
 
 ThemeManager::ThemeManager()
+    : m_rootScope(std::make_unique<ThemeScope>())
+    , m_tokens(m_rootScope->tokens)
 {
+    // Root scope identity — empty name, empty path, no parent.  Indexed
+    // under both "" (canonical) and "root" so callers using either form
+    // resolve to the same node.
+    m_rootScope->name = QString();
+    m_rootScope->path = QString();
+    m_scopeByPath.insert(QString(),                m_rootScope.get());
+    m_scopeByPath.insert(QStringLiteral("root"),   m_rootScope.get());
+
     // Explicit metatype registration so qMetaTypeId<ThemeGradient>() and
     // direct userType comparisons resolve correctly even before the first
     // QVariant::fromValue<ThemeGradient>() call.  Q_DECLARE_METATYPE in
@@ -414,15 +521,88 @@ bool ThemeManager::loadThemeFromPath(const QString& path)
         return false;
     }
 
-    // Compiled-in defaults stay as the fallback layer; tokens defined in
-    // the file overwrite them.  This is how older theme files with fewer
-    // tokens still produce a fully-rendered UI on a newer build.
-    QHash<QString, QVariant> newTokens;
-    seedBuiltinDefaults();  // reset to defaults
-    newTokens = m_tokens;
-    flattenTokens(root.value("tokens").toObject(), QString(), newTokens);
-    m_tokens.swap(newTokens);
+    // Reset the scope tree before loading the new theme.  Compiled-in
+    // defaults stay as the fallback layer so older theme files with
+    // fewer tokens still produce a fully-rendered UI on a newer build.
+    m_rootScope->children.clear();
+    m_primitives.clear();
+    rebuildScopePathIndex();
+    seedBuiltinDefaults();  // resets m_tokens (= root scope tokens) to defaults
+
+    if (schemaVersion >= 2) {
+        // v2 — primitives + nested scopes.  Canonical shape is
+        // `scopes: { root: { tokens, scopes } }`; we unwrap the literal
+        // "root" here so readScopeFromJson only sees the recursive
+        // {tokens, scopes} shape.
+        readPrimitivesFromJson(root.value("primitives").toObject());
+        if (root.contains("scopes")) {
+            const QJsonObject scopesObj = root.value("scopes").toObject();
+            if (scopesObj.contains("root")) {
+                readScopeFromJson(scopesObj.value("root").toObject(),
+                                  m_rootScope.get());
+            } else {
+                // Tolerate files that drop the root wrapper — every
+                // entry under "scopes" becomes a direct child of root.
+                readScopeFromJson(QJsonObject{{"scopes", scopesObj}},
+                                  m_rootScope.get());
+            }
+        } else if (root.contains("tokens")) {
+            // Tolerated mixed shape: v2 file with no scope wrapper —
+            // tokens at the top level land in root scope.
+            flattenTokens(root.value("tokens").toObject(),
+                          QString(), m_rootScope->tokens);
+        }
+    } else {
+        // v1 — flat tokens, all in root scope.  Auto-migrated to v2 on
+        // the next saveActiveTheme().
+        flattenTokens(root.value("tokens").toObject(),
+                      QString(), m_rootScope->tokens);
+    }
+    rebuildScopePathIndex();
     return true;
+}
+
+void ThemeManager::readPrimitivesFromJson(const QJsonObject& obj)
+{
+    for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
+        const QJsonValue v = it.value();
+        if (v.isString())      m_primitives.insert(it.key(), v.toString());
+        else if (v.isDouble()) m_primitives.insert(it.key(), v.toDouble());
+        else if (v.isBool())   m_primitives.insert(it.key(), v.toBool());
+        else if (v.isObject()) {
+            const QJsonObject o = v.toObject();
+            if (o.contains("type") && o.value("type").isString()) {
+                m_primitives.insert(it.key(),
+                                    QVariant::fromValue(parseGradient(o)));
+            }
+        }
+    }
+}
+
+void ThemeManager::readScopeFromJson(const QJsonObject& obj, ThemeScope* into)
+{
+    // Per-scope shape: `{tokens: {...}, scopes: {<name>: <subscope>}}`.
+    // The loader is responsible for unwrapping the outermost "root"
+    // before calling here; this function handles the recursive shape.
+    if (obj.contains("tokens")) {
+        flattenTokens(obj.value("tokens").toObject(),
+                      QString(), into->tokens);
+    }
+    if (obj.contains("scopes")) {
+        const QJsonObject children = obj.value("scopes").toObject();
+        for (auto it = children.constBegin(); it != children.constEnd(); ++it) {
+            const QString name = it.key();
+            auto child = std::make_unique<ThemeScope>();
+            child->name = name;
+            child->path = into->path.isEmpty()
+                              ? name
+                              : into->path + QLatin1Char('/') + name;
+            child->parent = into;
+            ThemeScope* raw = child.get();
+            into->children.emplace(name, std::move(child));
+            readScopeFromJson(it.value().toObject(), raw);
+        }
+    }
 }
 
 QStringList ThemeManager::availableThemes() const
@@ -719,45 +899,90 @@ bool ThemeManager::renameTheme(const QString& oldName, const QString& newName)
     return true;
 }
 
+QJsonObject ThemeManager::scopeToJson(const ThemeScope* scope) const
+{
+    // Per-scope shape: { "tokens": {...}, "scopes": {<child>: ...} }.
+    // Either / both may be omitted when empty.  Tokens are written flat
+    // (dotted keys) — the migration through scope tree doesn't try to
+    // re-nest token keys back into the legacy bundled layout, both
+    // because earlier deep-walk attempts at that hit prefix-conflict
+    // bugs (color.accent vs. color.accent.bright) and because the
+    // editor never reads the file in nested form.
+    const int gradMetaId = qMetaTypeId<ThemeGradient>();
+    QJsonObject result;
+    if (!scope->tokens.isEmpty()) {
+        QJsonObject toks;
+        for (auto it = scope->tokens.constBegin(); it != scope->tokens.constEnd(); ++it) {
+            const QVariant& v = it.value();
+            const int ut = v.userType();
+            QJsonValue leaf;
+            if (ut == QMetaType::QString)      leaf = v.toString();
+            else if (ut == QMetaType::Int)     leaf = v.toInt();
+            else if (ut == QMetaType::Double)  leaf = v.toDouble();
+            else if (ut == QMetaType::Bool)    leaf = v.toBool();
+            else if (ut == gradMetaId) {
+                const ThemeGradient g = v.value<ThemeGradient>();
+                QJsonObject gj;
+                gj.insert("type", g.type == ThemeGradient::Radial
+                                    ? QStringLiteral("radial-gradient")
+                                    : QStringLiteral("linear-gradient"));
+                gj.insert("angle", g.angle);
+                if (g.type == ThemeGradient::Radial) {
+                    gj.insert("centerX", g.center.x());
+                    gj.insert("centerY", g.center.y());
+                    gj.insert("radius",  g.radius);
+                }
+                QJsonArray stops;
+                for (const auto& s : g.stops) {
+                    QJsonObject sj;
+                    sj.insert("at",    s.at);
+                    sj.insert("color", colorToTokenString(s.color));
+                    stops.append(sj);
+                }
+                gj.insert("stops", stops);
+                leaf = gj;
+            }
+            else {
+                qCWarning(lcGui) << "ThemeManager::scopeToJson: skipping token"
+                                 << it.key() << "with unsupported metatype" << ut;
+                continue;
+            }
+            toks.insert(it.key(), leaf);
+        }
+        result.insert("tokens", toks);
+    }
+    if (!scope->children.empty()) {
+        QJsonObject scopesObj;
+        for (auto& kv : scope->children) {
+            scopesObj.insert(kv.first, scopeToJson(kv.second.get()));
+        }
+        result.insert("scopes", scopesObj);
+    }
+    return result;
+}
+
 bool ThemeManager::writeThemeFile(const QString& themeName, const QString& path)
 {
-    // Round-trip-safe flat dotted-key serialization.  The bundled themes
-    // organize tokens into nested objects for human readability, but the
-    // earlier deep-walk version of this code had two bugs that lost data
-    // when it tried to reproduce that layout:
-    //
-    //   * Prefix-conflict — a scalar like `color.accent` collided with
-    //     nested children like `color.accent.bright`; whichever was
-    //     processed second clobbered the first.
-    //   * Gradient tokens were silently skipped via a fragile
-    //     canConvert<ThemeGradient>() check (false negatives observed
-    //     under some metatype-registration timings).
-    //
-    // The flat output below is a strict subset of what flattenTokens()
-    // accepts (`{"tokens": {"color.background.0": "#0f0f1a", ...}}`):
-    // each dotted key becomes a literal JSON key inside `tokens`.
-    QJsonObject tokensObj;
+    // v2 schema — primitives map + nested scope tree.  v1 themes loaded
+    // from disk auto-upgrade on first save through this writer.
+    QJsonObject primitives;
     const int gradMetaId = qMetaTypeId<ThemeGradient>();
-    for (auto it = m_tokens.constBegin(); it != m_tokens.constEnd(); ++it) {
+    for (auto it = m_primitives.constBegin(); it != m_primitives.constEnd(); ++it) {
         const QVariant& v = it.value();
         const int ut = v.userType();
-        QJsonValue leaf;
-        if (ut == QMetaType::QString)      leaf = v.toString();
-        else if (ut == QMetaType::Int)     leaf = v.toInt();
-        else if (ut == QMetaType::Double)  leaf = v.toDouble();
-        else if (ut == QMetaType::Bool)    leaf = v.toBool();
+        if (ut == QMetaType::QString)      primitives.insert(it.key(), v.toString());
+        else if (ut == QMetaType::Int)     primitives.insert(it.key(), v.toInt());
+        else if (ut == QMetaType::Double)  primitives.insert(it.key(), v.toDouble());
+        else if (ut == QMetaType::Bool)    primitives.insert(it.key(), v.toBool());
         else if (ut == gradMetaId) {
+            // Same gradient JSON shape as scope-level tokens; the loader
+            // recognises both ambient locations.
             const ThemeGradient g = v.value<ThemeGradient>();
             QJsonObject gj;
             gj.insert("type", g.type == ThemeGradient::Radial
                                 ? QStringLiteral("radial-gradient")
                                 : QStringLiteral("linear-gradient"));
             gj.insert("angle", g.angle);
-            if (g.type == ThemeGradient::Radial) {
-                gj.insert("centerX", g.center.x());
-                gj.insert("centerY", g.center.y());
-                gj.insert("radius",  g.radius);
-            }
             QJsonArray stops;
             for (const auto& s : g.stops) {
                 QJsonObject sj;
@@ -766,23 +991,21 @@ bool ThemeManager::writeThemeFile(const QString& themeName, const QString& path)
                 stops.append(sj);
             }
             gj.insert("stops", stops);
-            leaf = gj;
+            primitives.insert(it.key(), gj);
         }
-        else {
-            qCWarning(lcGui) << "ThemeManager::writeThemeFile: skipping token"
-                             << it.key() << "with unsupported metatype" << ut;
-            continue;
-        }
-        tokensObj.insert(it.key(), leaf);
     }
 
+    QJsonObject scopes;
+    scopes.insert(QStringLiteral("root"), scopeToJson(m_rootScope.get()));
+
     QJsonObject doc;
-    doc.insert("schemaVersion", 1);
+    doc.insert("schemaVersion", 2);
     doc.insert("name",          themeName);
     doc.insert("author",        QStringLiteral("AetherSDR user"));
     doc.insert("version",       QStringLiteral("1.0"));
     doc.insert("description",   QStringLiteral("Edited via the Theme Editor."));
-    doc.insert("tokens",        tokensObj);
+    if (!primitives.isEmpty()) doc.insert("primitives", primitives);
+    doc.insert("scopes",        scopes);
 
     QFile f(path);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
@@ -1296,5 +1519,186 @@ void ThemeManager::reapplyAllTrackedStyleSheets()
         w->setStyleSheet(resolve(ctx.stylesheetTemplate));
     }
 }
+
+// ─────────────────────────────────────── scope-aware public API ─────────
+
+QString ThemeManager::containerPathFor(const QWidget* widget) const
+{
+    // Walk the Qt parent chain looking for the nearest declared
+    // themeContainer property.  An empty / missing property is treated
+    // as "no declaration here" — the walk continues past it.  Returns
+    // an empty string (== root scope) if no ancestor declares one.
+    const QWidget* w = widget;
+    while (w) {
+        const QVariant prop = w->property("themeContainer");
+        if (prop.isValid()) {
+            const QString s = prop.toString();
+            if (!s.isEmpty()) return s;
+        }
+        w = w->parentWidget();
+    }
+    return QString();
+}
+
+QStringList ThemeManager::containerPaths() const
+{
+    QStringList out;
+    out.reserve(m_scopeByPath.size());
+    std::function<void(const ThemeScope*)> walk = [&](const ThemeScope* s) {
+        if (s == m_rootScope.get()) {
+            out.append(QString());
+        } else {
+            out.append(s->path);
+        }
+        // Deterministic alphabetical order at each level.
+        // std::map iterates in key order already — pass children
+        // through directly.
+        for (auto& kv : s->children) walk(kv.second.get());
+    };
+    walk(m_rootScope.get());
+    return out;
+}
+
+QColor ThemeManager::color(const QWidget* widget, const QString& token) const
+{
+    const QVariant v = lookupRaw(containerPathFor(widget), token);
+    if (!v.isValid()) {
+        // Same fallback rules as the bare-token color() overload.
+        return color(token);
+    }
+    if (v.userType() == qMetaTypeId<ThemeGradient>()) {
+        const ThemeGradient g = v.value<ThemeGradient>();
+        return g.stops.isEmpty() ? QColor() : g.stops.first().color;
+    }
+    return QColor(v.toString());
+}
+
+int ThemeManager::sizing(const QWidget* widget, const QString& token) const
+{
+    const QVariant v = lookupRaw(containerPathFor(widget), token);
+    if (!v.isValid()) return sizing(token);
+    bool ok = false;
+    const int n = v.toInt(&ok);
+    return ok ? n : sizing(token);
+}
+
+QFont ThemeManager::font(const QWidget* widget, const QString& token) const
+{
+    Q_UNUSED(widget);
+    // Font tokens currently resolve as plain string family + a fixed
+    // size in the bare-token overload.  Scope-aware font resolution
+    // (where a container can override "font.family.ui" or
+    // "font.size.normal") falls through to the legacy code path
+    // unchanged until PR 4 starts populating container scopes.  The
+    // widget-aware lookup wired through containerPathFor will still
+    // pick up any overrides for tokens defined under nested scopes
+    // when callers route through here.
+    return font(token);
+}
+
+QString ThemeManager::value(const QWidget* widget, const QString& token) const
+{
+    const QVariant v = lookupRaw(containerPathFor(widget), token);
+    if (!v.isValid()) return value(token);
+    if (v.userType() == qMetaTypeId<ThemeGradient>()) return {};
+    return v.toString();
+}
+
+QBrush ThemeManager::brush(const QWidget* widget, const QString& token,
+                           const QRect& bounds) const
+{
+    Q_UNUSED(widget);
+    // brush() / cssFragment() build off the same token resolution that
+    // bare-token color()/gradient() use — for now route through the
+    // legacy overload.  PR 4 wires this up to scope-aware lookup once
+    // gradient tokens start living under non-root scopes.
+    return brush(token, bounds);
+}
+
+QString ThemeManager::cssFragment(const QWidget* widget, const QString& token) const
+{
+    Q_UNUSED(widget);
+    return cssFragment(token);
+}
+
+ThemeGradient ThemeManager::gradient(const QWidget* widget, const QString& token) const
+{
+    const QVariant v = lookupRaw(containerPathFor(widget), token);
+    if (v.userType() == qMetaTypeId<ThemeGradient>()) return v.value<ThemeGradient>();
+    return gradient(token);
+}
+
+void ThemeManager::setColor(const QString& containerPath, const QString& token, const QColor& color)
+{
+    if (!color.isValid()) return;
+    if (containerPath.isEmpty()) {
+        setColor(token, color);  // route through the root-scope overload
+        return;
+    }
+    const QString hex = colorToTokenString(color);
+    ThemeScope* scope = scopeOrCreate(containerPath);
+    const auto it = scope->tokens.constFind(token);
+    if (it != scope->tokens.constEnd() && it.value().toString() == hex) return;
+    scope->tokens.insert(token, QVariant(hex));
+    m_currentEditToken = token;
+    emit themeChanged();
+    m_currentEditToken.clear();
+    saveActiveTheme();
+}
+
+void ThemeManager::setSizing(const QString& containerPath, const QString& token, int v)
+{
+    if (containerPath.isEmpty()) { setSizing(token, v); return; }
+    ThemeScope* scope = scopeOrCreate(containerPath);
+    const auto it = scope->tokens.constFind(token);
+    if (it != scope->tokens.constEnd() && it.value().toInt() == v) return;
+    scope->tokens.insert(token, QVariant(v));
+    m_currentEditToken = token;
+    emit themeChanged();
+    m_currentEditToken.clear();
+    saveActiveTheme();
+}
+
+void ThemeManager::setGradient(const QString& containerPath, const QString& token, const ThemeGradient& g)
+{
+    if (containerPath.isEmpty()) { setGradient(token, g); return; }
+    ThemeScope* scope = scopeOrCreate(containerPath);
+    scope->tokens.insert(token, QVariant::fromValue(g));
+    m_currentEditToken = token;
+    emit themeChanged();
+    m_currentEditToken.clear();
+    saveActiveTheme();
+}
+
+void ThemeManager::setString(const QString& containerPath, const QString& token, const QString& v)
+{
+    if (containerPath.isEmpty()) { setString(token, v); return; }
+    ThemeScope* scope = scopeOrCreate(containerPath);
+    const auto it = scope->tokens.constFind(token);
+    if (it != scope->tokens.constEnd()
+        && it.value().userType() == QMetaType::QString
+        && it.value().toString() == v) {
+        return;
+    }
+    scope->tokens.insert(token, QVariant(v));
+    m_currentEditToken = token;
+    emit themeChanged();
+    m_currentEditToken.clear();
+    saveActiveTheme();
+}
+
+namespace theme {
+void setContainer(QWidget* widget, const QString& containerPath)
+{
+    if (!widget) return;
+    widget->setProperty("themeContainer", containerPath);
+}
+
+QString containerOf(const QWidget* widget)
+{
+    if (!widget) return {};
+    return widget->property("themeContainer").toString();
+}
+} // namespace theme
 
 } // namespace AetherSDR

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -260,6 +260,17 @@ public:
     QStringList containerPaths() const;
     QString     containerPathFor(const QWidget* widget) const;
 
+    // Path-string scope-aware getters.  Mirror the widget-aware
+    // overloads but accept a literal container path string — used by
+    // the v2 editor whose container picker holds a path, not a widget.
+    QColor        colorAt(const QString& containerPath, const QString& token) const;
+    int           sizingAt(const QString& containerPath, const QString& token) const;
+    QString       valueAt(const QString& containerPath, const QString& token) const;
+    ThemeGradient gradientAt(const QString& containerPath, const QString& token) const;
+    // Indicates whether `containerPath` itself overrides `token` (true)
+    // or just inherits it from an ancestor (false).
+    bool          isOverriddenAt(const QString& containerPath, const QString& token) const;
+
     // Container declarations — widgets call this through
     // theme::setContainer() to register their scope; ThemeManager keeps
     // the path alive in m_declaredContainers so it stays visible in

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -14,11 +14,20 @@
 #include <QVariant>
 #include <QVector>
 
+#include <QJsonObject>
+
 #include <functional>
+#include <map>
+#include <memory>
 
 class QWidget;
 
 namespace AetherSDR {
+
+// Forward declaration — full definition lives in the .cpp.  The scope
+// tree is an implementation detail of ThemeManager but the public
+// scope-aware API needs to reference it indirectly via QString paths.
+struct ThemeScope;
 
 // Token-based theming subsystem (RFC #3076 Phase 1+2).
 //
@@ -71,10 +80,25 @@ public:
     // color() returns the gradient's first stop as a graceful fallback;
     // callers that want the full gradient should use brush() or
     // cssFragment().
+    //
+    // Two flavours:
+    //   * `color(token)` — root-scope lookup (the historical flat
+    //     namespace).  Every existing call site routes through this
+    //     overload unchanged.
+    //   * `color(widget, token)` — walks the widget's Qt parent chain
+    //     looking for a `themeContainer` property; the first such
+    //     ancestor's container path is used as the lookup origin.  Walks
+    //     the scope tree from there up to root, returning the first
+    //     match.  Falls back to root-scope lookup for widgets with no
+    //     declared container in their ancestry.
     QColor   color(const QString& token) const;
+    QColor   color(const QWidget* widget, const QString& token) const;
     QFont    font(const QString& token) const;
+    QFont    font(const QWidget* widget, const QString& token) const;
     int      sizing(const QString& token) const;
+    int      sizing(const QWidget* widget, const QString& token) const;
     QString  value(const QString& token) const;   // raw scalar value, "" for gradients
+    QString  value(const QWidget* widget, const QString& token) const;
 
     // Brush accessor — returns the right Qt brush type for the token.
     //   - scalar token  → QBrush(QColor)
@@ -85,6 +109,8 @@ public:
     // QRect produces a 0–1 normalised gradient suitable for stylesheets
     // that reference the brush via QPalette or Qt's stylesheet system.
     QBrush   brush(const QString& token, const QRect& bounds = QRect()) const;
+    QBrush   brush(const QWidget* widget, const QString& token,
+                   const QRect& bounds = QRect()) const;
 
     // Stylesheet fragment.  Emits the right syntax for use inside a Qt
     // stylesheet:
@@ -96,6 +122,7 @@ public:
     // Numeric tokens emit their value as a plain string ("12" — adding
     // "px" / unit suffix is the caller's responsibility).
     QString  cssFragment(const QString& token) const;
+    QString  cssFragment(const QWidget* widget, const QString& token) const;
 
     // Stylesheet template resolver.  Replaces every "{{token.name}}"
     // placeholder by calling cssFragment(), so a stylesheet like
@@ -187,8 +214,20 @@ public:
     // until saved through saveCurrentThemeAs() (writes m_tokens to
     // `~/.config/AetherSDR/themes/<name>.json`).
     QStringList allTokenKeys() const;
+
+    // Scope-aware setters.  Bare-token overloads (existing call sites)
+    // write to the root scope.  Container-path overloads write to a
+    // named scope, creating it (and any missing parents) on demand.
+    //   - `setColor("color.accent", c)`                  → root["color.accent"] = c
+    //   - `setColor("spectrum", "color.accent", c)`      → root.spectrum["color.accent"] = c
+    //   - `setColor("spectrum/panadapter", "...", c)`    → nested two levels deep
+    // Path segments are separated by '/'.  Empty path == root.
     void        setColor(const QString& token, const QColor& color);
+    void        setColor(const QString& containerPath,
+                         const QString& token, const QColor& color);
     void        setSizing(const QString& token, int value);
+    void        setSizing(const QString& containerPath,
+                          const QString& token, int value);
 
     // Structured-gradient accessor + mutator for the Phase 5 gradient
     // editor.  gradient() returns an empty ThemeGradient (zero stops)
@@ -197,12 +236,28 @@ public:
     // themeChanged() so widgets re-paint with the new colormap on the
     // next event-loop turn.
     ThemeGradient gradient(const QString& token) const;
+    ThemeGradient gradient(const QWidget* widget, const QString& token) const;
     void          setGradient(const QString& token, const ThemeGradient& g);
+    void          setGradient(const QString& containerPath,
+                              const QString& token, const ThemeGradient& g);
 
     // Family / font-family setter for the Phase 5 PR 4 font picker.
     // Mirrors setColor()/setSizing() — overwrites whatever was at the
     // token and emits themeChanged so consumers re-resolve their fonts.
     void setString(const QString& token, const QString& value);
+    void setString(const QString& containerPath,
+                   const QString& token, const QString& value);
+
+    // Container-tree introspection (used by the v2 Theme Editor's
+    // container picker — left rail tree + columnar overrides table).
+    //   * `containerPaths()` — every scope present in the active theme,
+    //     "" for root.  Sorted in tree order so the editor can render
+    //     them as a hierarchical tree.
+    //   * `containerPathFor(widget)` — walks `widget`'s Qt parent chain
+    //     looking for the nearest `themeContainer` property; returns ""
+    //     if none of `widget`'s ancestors declared one.
+    QStringList containerPaths() const;
+    QString     containerPathFor(const QWidget* widget) const;
 
     // Factory-default lookups — read from a one-shot snapshot of the
     // bundled `:/themes/default-dark.json` so every Reset-to-default
@@ -276,7 +331,8 @@ private slots:
 
 private:
     ThemeManager();
-    ~ThemeManager() override = default;
+    ~ThemeManager() override;   // out-of-line so std::unique_ptr<ThemeScope>
+                                // member doesn't need the full type in this header
     Q_DISABLE_COPY_MOVE(ThemeManager)
 
     // Re-apply every tracked widget's stylesheet template with freshly
@@ -292,21 +348,56 @@ private:
     // are not committed (the previously-active theme stays loaded).
     bool loadThemeFromPath(const QString& path);
 
-    // Serialize the current m_tokens into AetherSDR's flat-dotted-key
-    // theme JSON and write it to `path`.  Shared by saveCurrentThemeAs
-    // (new user copy) and saveActiveTheme (rewrite the active file in
-    // place).  Returns false if the file can't be opened.
+    // Serialize the current scope tree into AetherSDR's v2 theme JSON
+    // (primitives + nested scopes) and write it to `path`.  Shared by
+    // saveCurrentThemeAs (new user copy) and saveActiveTheme (rewrite
+    // the active file in place).  Returns false if the file can't be
+    // opened.
     bool writeThemeFile(const QString& themeName, const QString& path);
 
     // Built-in compiled-in defaults so a totally missing theme file
     // still produces a usable UI.  Populated in the constructor.
     void seedBuiltinDefaults();
 
+    // Scope-tree helpers.
+    //   * `scopeForPath(path)`   — returns the scope at `path` (nullptr
+    //     if missing).  "" / "root" both map to the root scope.
+    //   * `scopeOrCreate(path)`  — same, but creates the scope (and any
+    //     missing parents) on demand.  Used by the scope-aware setters.
+    //   * `resolveAlias(v)`      — if `v` is a `{primitive.key}` string,
+    //     look it up in m_primitives and return that.  Otherwise pass
+    //     `v` through unchanged.
+    //   * `lookupRaw(path, key)` — walks the scope chain from `path` up
+    //     to root, returning the first matching token (alias-resolved).
+    //     Returns an invalid QVariant when nothing matches.
+    ThemeScope* scopeForPath(const QString& path) const;
+    ThemeScope* scopeOrCreate(const QString& path);
+    QVariant    resolveAlias(const QVariant& v) const;
+    QVariant    lookupRaw(const QString& containerPath, const QString& key) const;
+    void        rebuildScopePathIndex();
+
+    // JSON schema helpers.  v2 themes are `{schemaVersion:2, primitives:{},
+    // scopes:{ root: { tokens:{}, scopes:{} } }}`.  v1 themes (no schema
+    // version OR schemaVersion 1) carry a flat `tokens:{}` block that
+    // migrates into the root scope on load.
+    void        readPrimitivesFromJson(const QJsonObject& obj);
+    void        readScopeFromJson(const QJsonObject& obj, ThemeScope* into);
+    QJsonObject scopeToJson(const ThemeScope* scope) const;
+
     // Resource path or filesystem path indexed by theme display name.
     QHash<QString, QString> m_themePaths;
-    // QVariant holds either a QString (scalar) or a ThemeGradient
-    // (typed via Q_DECLARE_METATYPE below).
-    QHash<QString, QVariant> m_tokens;
+
+    // Token storage — a tree of scopes rooted at m_rootScope, with a
+    // flat path → scope index for O(1) lookup.  Primitives live in a
+    // separate flat map referenced via `{primitive.key}` aliases inside
+    // scope tokens.  `m_tokens` is a reference into the root scope's
+    // token hash so every legacy `m_tokens.foo` call site (96 of them
+    // pre-refactor) compiles unchanged — the root scope IS the flat
+    // namespace that existed before the scope tree was introduced.
+    std::unique_ptr<ThemeScope>      m_rootScope;
+    QHash<QString, ThemeScope*>      m_scopeByPath;
+    QHash<QString, QVariant>         m_primitives;
+    QHash<QString, QVariant>&        m_tokens;
     QString m_activeTheme;
 
     // Factory-default snapshot, loaded once from `:/themes/default-dark.json`
@@ -353,6 +444,21 @@ inline QColor withAlpha(const QString& token, int alpha)
     c.setAlpha(alpha);
     return c;
 }
+
+// Declare a widget's container scope.  Stored as a Qt dynamic
+// property ("themeContainer"); ThemeManager::containerPathFor() walks
+// the Qt parent chain looking for the first declared ancestor so any
+// child widget inherits its enclosing container automatically.
+//
+//   theme::setContainer(spectrumWidget, "spectrum");
+//   theme::setContainer(panadapter,     "spectrum/panadapter");
+//   // A QLabel inside panadapter with no declaration of its own
+//   // resolves to "spectrum/panadapter" via the parent walk.
+//
+// Passing an empty path detaches the widget from any container,
+// reverting it to root-scope lookups (also useful for tests).
+void setContainer(QWidget* widget, const QString& containerPath);
+QString containerOf(const QWidget* widget);
 } // namespace theme
 
 } // namespace AetherSDR

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -71,6 +71,23 @@ struct ThemeGradient {
     QVector<ThemeGradientStop> stops;
 };
 
+// Compound font token — bundles the typeface family, point size, and a
+// recommended foreground color for a typographic role.  Used by the
+// `font.family.*` token namespace (which historically stored a bare
+// family string).  JSON shape: { "family": "Inter", "size": 12,
+// "color": "#c8d8e8" }; the `family` field is required, `size` defaults
+// to 0 (caller uses its role-default), `color` defaults to invalid
+// (caller falls back to color.text.primary).
+//
+// Backward compat: `ThemeManager::value(token)` returns the .family
+// field when called on a ThemeFont so the ~35 sites that just want
+// the family name keep working unchanged.
+struct ThemeFont {
+    QString family;
+    int     size  {0};   // 0 = unset
+    QColor  color;       // invalid = unset
+};
+
 class ThemeManager : public QObject {
     Q_OBJECT
 public:
@@ -248,6 +265,19 @@ public:
     void setString(const QString& token, const QString& value);
     void setString(const QString& containerPath,
                    const QString& token, const QString& value);
+
+    // Compound font-token accessors.  font.family.* tokens may store
+    // either a bare family string (legacy v1 themes) or a structured
+    // ThemeFont (family + size + color).  These accessors abstract over
+    // both shapes — `fontToken*()` returns the ThemeFont with sensible
+    // defaults filled in from the legacy string + role-default size/color
+    // when the token isn't compound.
+    ThemeFont     fontToken(const QString& token) const;
+    ThemeFont     fontTokenAt(const QString& containerPath,
+                              const QString& token) const;
+    void          setFontToken(const QString& token, const ThemeFont& f);
+    void          setFontToken(const QString& containerPath,
+                               const QString& token, const ThemeFont& f);
 
     // Container-tree introspection (used by the v2 Theme Editor's
     // container picker — left rail tree + columnar overrides table).
@@ -503,3 +533,4 @@ QString containerOf(const QWidget* widget);
 } // namespace AetherSDR
 
 Q_DECLARE_METATYPE(AetherSDR::ThemeGradient)
+Q_DECLARE_METATYPE(AetherSDR::ThemeFont)

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -5,6 +5,7 @@
 #include <QString>
 #include <QStringList>
 #include <QHash>
+#include <QSet>
 #include <QColor>
 #include <QFont>
 #include <QBrush>
@@ -259,6 +260,20 @@ public:
     QStringList containerPaths() const;
     QString     containerPathFor(const QWidget* widget) const;
 
+    // Container declarations — widgets call this through
+    // theme::setContainer() to register their scope; ThemeManager keeps
+    // the path alive in m_declaredContainers so it stays visible in
+    // containerPaths() even after a theme load wipes empty scopes from
+    // the tree.  Idempotent.
+    void        registerDeclaredContainer(const QString& containerPath);
+
+    // Widget-aware QSS resolver — replaces each {{token}} placeholder
+    // with the widget's-scope css fragment instead of the root-only
+    // value.  applyStyleSheet() routes through this so widgets nested
+    // under a declared container automatically pick up its overrides
+    // on the next reapplyAllTrackedStyleSheets() pass.
+    QString     resolveFor(const QWidget* widget, const QString& stylesheetTemplate) const;
+
     // Factory-default lookups — read from a one-shot snapshot of the
     // bundled `:/themes/default-dark.json` so every Reset-to-default
     // affordance in the editor restores the canonical value.  Each
@@ -398,6 +413,12 @@ private:
     QHash<QString, ThemeScope*>      m_scopeByPath;
     QHash<QString, QVariant>         m_primitives;
     QHash<QString, QVariant>&        m_tokens;
+    // Widget-declared container paths.  Persisted across theme loads so
+    // a fresh JSON file (which only writes scopes that own overrides)
+    // doesn't make a declared-but-unoverridden container vanish from
+    // the editor's tree picker.  Re-installed into m_scopeByPath after
+    // every loadThemeFromPath().
+    QSet<QString>                    m_declaredContainers;
     QString m_activeTheme;
 
     // Factory-default snapshot, loaded once from `:/themes/default-dark.json`

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -227,6 +227,14 @@ public:
 
     bool        saveCurrentThemeAs(const QString& newThemeName);
 
+    // Persist the current in-memory token state back to the active
+    // theme's on-disk file.  No-op for built-in themes (their path
+    // points at the read-only resource bundle) and for unknown
+    // themes.  Called automatically by setColor / setSizing /
+    // setGradient / setString so edits survive a restart without
+    // requiring an explicit "Save" gesture.
+    bool        saveActiveTheme();
+
     // Phase 6 — share-friendly file format.  `.aethertheme` is plain JSON
     // (same shape `saveCurrentThemeAs` writes to the user-dir) with a
     // `schemaVersion` discriminator.  Missing tokens on import fall back
@@ -284,6 +292,12 @@ private:
     // are not committed (the previously-active theme stays loaded).
     bool loadThemeFromPath(const QString& path);
 
+    // Serialize the current m_tokens into AetherSDR's flat-dotted-key
+    // theme JSON and write it to `path`.  Shared by saveCurrentThemeAs
+    // (new user copy) and saveActiveTheme (rewrite the active file in
+    // place).  Returns false if the file can't be opened.
+    bool writeThemeFile(const QString& themeName, const QString& path);
+
     // Built-in compiled-in defaults so a totally missing theme file
     // still produces a usable UI.  Populated in the constructor.
     void seedBuiltinDefaults();
@@ -302,6 +316,15 @@ private:
     mutable QHash<QString, QVariant> m_factoryTokens;
     mutable bool m_factoryLoaded{false};
     void ensureFactoryLoaded() const;
+
+    // Smart-invalidation hint — set transiently by setColor / setGradient
+    // / setSizing / setString to the token that just changed, then
+    // cleared after the synchronous themeChanged emission.  Lets
+    // reapplyAllTrackedStyleSheets skip every widget whose template
+    // doesn't reference that token, which is the 50–100x speedup that
+    // makes a CompactColorPicker drag feel like 60fps live editing
+    // instead of a stuck slideshow.
+    QString m_currentEditToken;
 
     // Reverse-map: widget instance → (template, tokens-it-references).
     // Populated by applyStyleSheet / declareWidgetTokens / declareWidgetRegions,

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -271,6 +271,13 @@ public:
     // or just inherits it from an ancestor (false).
     bool          isOverriddenAt(const QString& containerPath, const QString& token) const;
 
+    // Drop the local override for `token` at `containerPath`, falling
+    // back to inheritance from the scope's parent.  No-op when there
+    // is no override to drop.  Emits themeChanged + persists to disk
+    // through saveActiveTheme() so the inheritance restoration
+    // survives a restart.
+    void          removeOverride(const QString& containerPath, const QString& token);
+
     // Container declarations — widgets call this through
     // theme::setContainer() to register their scope; ThemeManager keeps
     // the path alive in m_declaredContainers so it stays visible in

--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -9,6 +9,7 @@ namespace AetherSDR {
 AetherDspDialog::AetherDspDialog(AudioEngine* audio, QWidget* parent)
     : PersistentDialog("AetherDSP Settings", "AetherDspDialogGeometry", parent)
 {
+    theme::setContainer(this, QStringLiteral("dialog/aetherDsp"));
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }");
 
     auto* body = new QVBoxLayout(bodyWidget());

--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -12,6 +12,7 @@ namespace AetherSDR {
 AmpApplet::AmpApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/amp"));
     auto* vbox = new QVBoxLayout(this);
     vbox->setContentsMargins(4, 2, 4, 2);
     vbox->setSpacing(2);

--- a/src/gui/AntennaGeniusApplet.cpp
+++ b/src/gui/AntennaGeniusApplet.cpp
@@ -49,6 +49,7 @@ static constexpr const char* kValueStyle =
 AntennaGeniusApplet::AntennaGeniusApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/antgen"));
     hide();
     setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
     setMaximumWidth(260);

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -173,6 +173,12 @@ private:
 
 AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 {
+    // Parent container for every applet hosted in this rail.  Each
+    // individual applet declares its own child scope ("applet.tx",
+    // "applet.rx", …) inside its own constructor so widgets inside
+    // an applet inherit applet.<name> → applet → root.
+    theme::setContainer(this, QStringLiteral("applet"));
+
     setFixedWidth(260);
 
     auto* root = new QVBoxLayout(this);

--- a/src/gui/AtuPreTuneDialog.cpp
+++ b/src/gui/AtuPreTuneDialog.cpp
@@ -145,6 +145,7 @@ AtuPreTuneDialog::AtuPreTuneDialog(RadioModel* radio,
       m_radio(radio),
       m_bandPlan(bandPlan)
 {
+    theme::setContainer(this, QStringLiteral("dialog/atuPreTune"));
     setWindowTitle("ATU Band Pre-Tune Sweep");
     setModal(false);
     resize(560, 640);

--- a/src/gui/AudioDeviceChangeDialog.cpp
+++ b/src/gui/AudioDeviceChangeDialog.cpp
@@ -2,6 +2,7 @@
 #include "FramelessResizer.h"
 #include "FramelessWindowTitleBar.h"
 #include "core/AppSettings.h"
+#include "core/ThemeManager.h"
 
 #include <QAudioDevice>
 #include <QColor>
@@ -239,6 +240,7 @@ AudioDeviceChangeDialog::AudioDeviceChangeDialog(
     , m_inputDevices(inputDevices)
     , m_outputDevices(outputDevices)
 {
+    theme::setContainer(this, QStringLiteral("dialog/audioDeviceChange"));
     setWindowTitle(QStringLiteral("Audio Device Detected"));
     setModal(true);
     setWindowModality(Qt::ApplicationModal);

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -4,6 +4,7 @@
 #include "core/AppSettings.h"
 #include "core/DaxTxPolicy.h"
 #include "core/LogManager.h"
+#include "core/ThemeManager.h"
 #include "core/tnc/Ax25FrameFormatter.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
@@ -501,6 +502,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     , m_audio(audio)
     , m_radio(radio)
 {
+    theme::setContainer(this, QStringLiteral("dialog/ax25Decode"));
     setMinimumSize(1080, 680);
 
     m_shim = new AetherAx25LibmodemShim(this);

--- a/src/gui/BandStackPanel.cpp
+++ b/src/gui/BandStackPanel.cpp
@@ -21,6 +21,7 @@ static const char* kMenuStyle =
 BandStackPanel::BandStackPanel(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("panel/bandStack"));
     setFixedWidth(80);
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "background: {{color.background.0}};");
 

--- a/src/gui/CatControlApplet.cpp
+++ b/src/gui/CatControlApplet.cpp
@@ -81,6 +81,7 @@ QString sliceLetter(int idx)
 
 CatControlApplet::CatControlApplet(QWidget* parent) : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/cat"));
     setStyleSheet("QWidget { background: transparent; }");
 
     m_rootLayout = new QVBoxLayout(this);

--- a/src/gui/ClientChainApplet.cpp
+++ b/src/gui/ClientChainApplet.cpp
@@ -9,6 +9,7 @@
 #include "core/ClientPudu.h"
 #include "core/ClientReverb.h"
 #include "core/ClientTube.h"
+#include "core/ThemeManager.h"
 
 #include <QButtonGroup>
 #include <QHBoxLayout>
@@ -82,6 +83,7 @@ const QString kBypassBtnStyle = QStringLiteral(
 
 ClientChainApplet::ClientChainApplet(QWidget* parent) : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/chain"));
     setStyleSheet("QWidget { background: transparent; }");
 
     auto* outer = new QVBoxLayout(this);

--- a/src/gui/ClientCompApplet.cpp
+++ b/src/gui/ClientCompApplet.cpp
@@ -4,6 +4,7 @@
 #include "MeterSmoother.h"
 #include "core/AudioEngine.h"
 #include "core/ClientComp.h"
+#include "core/ThemeManager.h"
 
 #include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
@@ -106,6 +107,7 @@ ClientCompApplet::ClientCompApplet(Side side, QWidget* parent)
     : QWidget(parent)
     , m_side(side)
 {
+    theme::setContainer(this, QStringLiteral("applet/comp"));
     buildUI();
     hide();  // hidden until toggled on from the button tray
 }

--- a/src/gui/ClientDeEssApplet.cpp
+++ b/src/gui/ClientDeEssApplet.cpp
@@ -4,6 +4,7 @@
 #include "MeterSmoother.h"
 #include "core/AudioEngine.h"
 #include "core/ClientDeEss.h"
+#include "core/ThemeManager.h"
 
 #include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
@@ -101,6 +102,7 @@ constexpr const char* kEditStyle =
 
 ClientDeEssApplet::ClientDeEssApplet(QWidget* parent) : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/deess"));
     buildUI();
     hide();
 }

--- a/src/gui/ClientDisconnectDialog.cpp
+++ b/src/gui/ClientDisconnectDialog.cpp
@@ -1,5 +1,7 @@
 #include "ClientDisconnectDialog.h"
 
+#include "core/ThemeManager.h"
+
 #include <QAbstractButton>
 #include <QApplication>
 #include <QCursor>
@@ -71,6 +73,7 @@ ClientDisconnectDialog::ClientDisconnectDialog(const QList<Client>& clients,
     : QDialog(parent)
     , m_clients(clients)
 {
+    theme::setContainer(this, QStringLiteral("dialog/clientDisconnect"));
     const bool remoteMode = mode == Mode::RemoteClientDisconnect;
 
     setWindowTitle(remoteMode ? tr("Disconnect remote clients") : tr("Radio in use"));

--- a/src/gui/ClientEqApplet.cpp
+++ b/src/gui/ClientEqApplet.cpp
@@ -2,6 +2,7 @@
 #include "ClientEqCurveWidget.h"
 #include "core/AudioEngine.h"
 #include "core/ClientEq.h"
+#include "core/ThemeManager.h"
 
 #include <QVBoxLayout>
 
@@ -11,6 +12,7 @@ ClientEqApplet::ClientEqApplet(Path path, QWidget* parent)
     : QWidget(parent)
     , m_currentPath(path)
 {
+    theme::setContainer(this, QStringLiteral("applet/clientEq"));
     buildUI();
     hide();  // hidden until toggled on from the button tray
 }

--- a/src/gui/ClientGateApplet.cpp
+++ b/src/gui/ClientGateApplet.cpp
@@ -4,6 +4,7 @@
 #include "MeterSmoother.h"
 #include "core/AudioEngine.h"
 #include "core/ClientGate.h"
+#include "core/ThemeManager.h"
 
 #include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
@@ -106,6 +107,7 @@ ClientGateApplet::ClientGateApplet(Side side, QWidget* parent)
     : QWidget(parent)
     , m_side(side)
 {
+    theme::setContainer(this, QStringLiteral("applet/gate"));
     buildUI();
     hide();
 }

--- a/src/gui/ClientPuduApplet.cpp
+++ b/src/gui/ClientPuduApplet.cpp
@@ -83,6 +83,7 @@ ClientPuduApplet::ClientPuduApplet(Side side, QWidget* parent)
     : QWidget(parent)
     , m_side(side)
 {
+    theme::setContainer(this, QStringLiteral("applet/pudu"));
     buildUI();
     hide();
 }

--- a/src/gui/ClientReverbApplet.cpp
+++ b/src/gui/ClientReverbApplet.cpp
@@ -2,6 +2,7 @@
 #include "ClientCompKnob.h"
 #include "core/AudioEngine.h"
 #include "core/ClientReverb.h"
+#include "core/ThemeManager.h"
 
 #include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
@@ -147,6 +148,7 @@ private:
 
 ClientReverbApplet::ClientReverbApplet(QWidget* parent) : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/reverb"));
     buildUI();
     hide();
 }

--- a/src/gui/ClientRxDspApplet.cpp
+++ b/src/gui/ClientRxDspApplet.cpp
@@ -1,6 +1,7 @@
 #include "ClientRxDspApplet.h"
 #include "AetherDspWidget.h"
 #include "core/AudioEngine.h"
+#include "core/ThemeManager.h"
 
 #include <QVBoxLayout>
 
@@ -8,6 +9,7 @@ namespace AetherSDR {
 
 ClientRxDspApplet::ClientRxDspApplet(QWidget* parent) : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/rxdsp"));
     setStyleSheet("QWidget { background: transparent; }");
     // Cap horizontal width so the embedded AetherDspWidget can't push the
     // PooDoo container wider than its 280 px slot — sliders + tab bar

--- a/src/gui/ClientTubeApplet.cpp
+++ b/src/gui/ClientTubeApplet.cpp
@@ -3,6 +3,7 @@
 #include "ClientTubeCurveWidget.h"
 #include "core/AudioEngine.h"
 #include "core/ClientTube.h"
+#include "core/ThemeManager.h"
 
 #include <QGraphicsOpacityEffect>
 #include <QHBoxLayout>
@@ -38,6 +39,7 @@ ClientTubeApplet::ClientTubeApplet(Side side, QWidget* parent)
     : QWidget(parent)
     , m_side(side)
 {
+    theme::setContainer(this, QStringLiteral("applet/tube"));
     buildUI();
     hide();
 }

--- a/src/gui/CompactColorPicker.cpp
+++ b/src/gui/CompactColorPicker.cpp
@@ -1,8 +1,11 @@
 #include "CompactColorPicker.h"
 
+#include <QApplication>
 #include <QGridLayout>
+#include <QGuiApplication>
 #include <QHBoxLayout>
 #include <QImage>
+#include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
 #include <QLinearGradient>
@@ -10,6 +13,8 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QPixmap>
+#include <QPushButton>
+#include <QScreen>
 #include <QSignalBlocker>
 #include <QSpinBox>
 #include <QVBoxLayout>
@@ -25,6 +30,42 @@ QString colorToTokenHex(const QColor& c)
     return c.alpha() == 255 ? c.name(QColor::HexRgb)
                             : c.name(QColor::HexArgb);
 }
+
+// Render a small eyedropper glyph for the picker button.  Drawn at
+// device-pixel resolution so HiDPI displays don't blur it.
+QIcon makeEyedropperIcon(const QColor& strokeColor)
+{
+    const qreal dpr = qApp ? qApp->devicePixelRatio() : 1.0;
+    const int side = 16;
+    QPixmap pm(QSize(side, side) * dpr);
+    pm.setDevicePixelRatio(dpr);
+    pm.fill(Qt::transparent);
+
+    QPainter p(&pm);
+    p.setRenderHint(QPainter::Antialiasing, true);
+    QPen pen(strokeColor);
+    pen.setWidthF(1.6);
+    pen.setCapStyle(Qt::RoundCap);
+    p.setPen(pen);
+    p.setBrush(strokeColor);
+
+    // Bulb at the top-right (the squeezable end of the pipette).
+    p.drawEllipse(QPointF(11.5, 4.5), 2.4, 2.4);
+    // Stem — diagonal pipe from bulb to tip.
+    p.setBrush(Qt::NoBrush);
+    p.drawLine(QPointF(10.2, 5.6), QPointF(3.4, 12.4));
+    // Drip at the tip.
+    p.setBrush(strokeColor);
+    p.drawEllipse(QPointF(3.0, 13.0), 1.1, 1.1);
+    return QIcon(pm);
+}
+
+// Screen colour picking is implemented via grabMouse(Qt::CrossCursor) +
+// grabKeyboard() on the picker widget — exactly the same approach
+// QColorDialog uses internally for its "Pick Screen Color" button.
+// The platform integration handles Wayland portal / X11 XGrabPointer /
+// Win32 SetCapture under the hood, so this works on every platform
+// where QColorDialog's eyedropper works.
 
 // Common 2x2 checkerboard tile painter, used by the alpha slider and
 // the live swatch so translucent values don't disappear into the
@@ -383,6 +424,17 @@ CompactColorPicker::CompactColorPicker(QWidget* parent) : QWidget(parent)
     m_hex->setMaxLength(9);
     m_hex->setFixedWidth(96);
     hexRow->addWidget(m_hex);
+
+    m_eyedropper = new QPushButton(this);
+    m_eyedropper->setIcon(makeEyedropperIcon(palette().color(QPalette::WindowText)));
+    m_eyedropper->setIconSize(QSize(14, 14));
+    m_eyedropper->setFixedSize(24, 24);
+    m_eyedropper->setToolTip(QStringLiteral(
+        "Pick a colour from anywhere on the screen.\n"
+        "Click to sample.  Esc or right-click cancels."));
+    m_eyedropper->setAccessibleName(QStringLiteral("Pick colour from screen"));
+    hexRow->addWidget(m_eyedropper);
+
     hexRow->addStretch(1);
     root->addLayout(hexRow);
 
@@ -393,6 +445,8 @@ CompactColorPicker::CompactColorPicker(QWidget* parent) : QWidget(parent)
     connect(m_alpha, &AlphaSlider::alphaPicked, this, &CompactColorPicker::onAlphaPicked);
     connect(m_hex,   &QLineEdit::editingFinished,
             this, &CompactColorPicker::onHexEdited);
+    connect(m_eyedropper, &QPushButton::clicked,
+            this, &CompactColorPicker::onEyedropperClicked);
     for (QSpinBox* sb : {m_r, m_g, m_b}) {
         connect(sb, qOverload<int>(&QSpinBox::valueChanged),
                 this, &CompactColorPicker::onRgbEdited);
@@ -497,6 +551,78 @@ void CompactColorPicker::onRgbEdited()
     if (m_updating) return;
     m_color = QColor(m_r->value(), m_g->value(), m_b->value(), m_alpha->alpha());
     emitChange();
+}
+
+void CompactColorPicker::onEyedropperClicked()
+{
+    if (m_pickingScreen) return;
+    m_pickingScreen = true;
+    // Same pair QColorDialog::pickScreenColor() uses internally — grabMouse
+    // routes every mouse event to us regardless of which app the cursor is
+    // over; grabKeyboard catches Esc-to-cancel before any other widget
+    // sees it.  Qt's platform integration handles the Wayland-portal /
+    // X11-XGrabPointer / Win32-SetCapture mechanics under the hood.
+    grabMouse(QCursor(Qt::CrossCursor));
+    grabKeyboard();
+}
+
+bool CompactColorPicker::event(QEvent* ev)
+{
+    if (!m_pickingScreen) return QWidget::event(ev);
+
+    switch (ev->type()) {
+    case QEvent::MouseButtonRelease: {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        // Release the grabs FIRST so QScreen::grabWindow sees a clean
+        // composited image (no leftover crosshair cursor in the capture).
+        releaseMouse();
+        releaseKeyboard();
+        m_pickingScreen = false;
+
+        if (me->button() == Qt::LeftButton) {
+            const QPoint gp = me->globalPosition().toPoint();
+            if (auto* screen = QGuiApplication::screenAt(gp)) {
+                const QPoint local = gp - screen->geometry().topLeft();
+                const QPixmap pm = screen->grabWindow(
+                    0, local.x(), local.y(), 1, 1);
+                if (!pm.isNull()) {
+                    const QColor sampled = pm.toImage().pixelColor(0, 0);
+                    if (sampled.isValid()) {
+                        // Preserve the current alpha — the eyedropper
+                        // reads only RGB from the screen; the alpha
+                        // slider remains the source of truth.
+                        QColor next = sampled;
+                        next.setAlpha(m_color.alpha());
+                        setColor(next);
+                        emitChange();
+                    }
+                }
+            }
+        }
+        ev->accept();
+        return true;
+    }
+    case QEvent::MouseButtonPress: {
+        // Eat the press so it doesn't reach the underlying widget;
+        // the release handler does the actual sampling.
+        ev->accept();
+        return true;
+    }
+    case QEvent::KeyPress: {
+        auto* ke = static_cast<QKeyEvent*>(ev);
+        if (ke->key() == Qt::Key_Escape) {
+            releaseMouse();
+            releaseKeyboard();
+            m_pickingScreen = false;
+            ev->accept();
+            return true;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+    return QWidget::event(ev);
 }
 
 } // namespace AetherSDR

--- a/src/gui/CompactColorPicker.cpp
+++ b/src/gui/CompactColorPicker.cpp
@@ -1,0 +1,502 @@
+#include "CompactColorPicker.h"
+
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QImage>
+#include <QLabel>
+#include <QLineEdit>
+#include <QLinearGradient>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPixmap>
+#include <QSignalBlocker>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+namespace {
+
+QString colorToTokenHex(const QColor& c)
+{
+    return c.alpha() == 255 ? c.name(QColor::HexRgb)
+                            : c.name(QColor::HexArgb);
+}
+
+// Common 2x2 checkerboard tile painter, used by the alpha slider and
+// the live swatch so translucent values don't disappear into the
+// surrounding dark theme.
+void paintCheckerboard(QPainter& p, const QRect& r)
+{
+    constexpr int tile = 6;
+    for (int y = r.top(); y < r.bottom(); y += tile) {
+        for (int x = r.left(); x < r.right(); x += tile) {
+            const bool dark = ((x / tile + y / tile) & 1) == 0;
+            p.fillRect(QRect(x, y, tile, tile),
+                       dark ? QColor(0x80, 0x80, 0x80) : QColor(0xc8, 0xc8, 0xc8));
+        }
+    }
+}
+
+} // namespace
+
+// ───────────────────────────────────────────────────────────── SVSquare ──
+
+SVSquare::SVSquare(QWidget* parent) : QWidget(parent)
+{
+    setFixedSize(200, 200);
+    setMouseTracking(false);
+    setCursor(Qt::CrossCursor);
+}
+
+void SVSquare::setHue(int h)
+{
+    h = std::clamp(h, 0, 359);
+    if (h == m_h) return;
+    m_h = h;
+    rebuildCache();
+    update();
+}
+
+void SVSquare::setSV(int s, int v)
+{
+    s = std::clamp(s, 0, 255);
+    v = std::clamp(v, 0, 255);
+    if (s == m_s && v == m_v) return;
+    m_s = s;
+    m_v = v;
+    update();
+}
+
+void SVSquare::resizeEvent(QResizeEvent*)
+{
+    rebuildCache();
+}
+
+void SVSquare::rebuildCache()
+{
+    // Render the SV plane at the current hue into a QImage cache.
+    // Two-gradient composite: horizontal white→hue and vertical
+    // transparent→black, painted with Multiply / SourceOver semantics
+    // via the gradient's alpha component.  Faster than per-pixel setPixel.
+    const QSize sz = size().isValid() ? size() : QSize(180, 180);
+    if (sz.width() < 2 || sz.height() < 2) return;
+    m_cache = QImage(sz, QImage::Format_ARGB32_Premultiplied);
+    QPainter p(&m_cache);
+
+    const QColor hueColor = QColor::fromHsv(m_h, 255, 255);
+    QLinearGradient horizontal(0, 0, sz.width(), 0);
+    horizontal.setColorAt(0.0, QColor(255, 255, 255));
+    horizontal.setColorAt(1.0, hueColor);
+    p.fillRect(m_cache.rect(), horizontal);
+
+    QLinearGradient vertical(0, 0, 0, sz.height());
+    vertical.setColorAt(0.0, QColor(0, 0, 0, 0));
+    vertical.setColorAt(1.0, QColor(0, 0, 0, 255));
+    p.fillRect(m_cache.rect(), vertical);
+}
+
+void SVSquare::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    if (m_cache.isNull()) rebuildCache();
+    p.drawImage(0, 0, m_cache);
+
+    // Border so the plane stops cleanly against the dialog background.
+    p.setBrush(Qt::NoBrush);
+    p.setPen(QPen(QColor(0, 0, 0, 120), 1));
+    p.drawRect(rect().adjusted(0, 0, -1, -1));
+
+    // Crosshair marker at the current (s, v).  White ring on a black
+    // dot so it stays visible against any underlying colour.
+    const int x = static_cast<int>(std::round(m_s / 255.0 * (width() - 1)));
+    const int y = static_cast<int>(std::round((1.0 - m_v / 255.0) * (height() - 1)));
+    p.setBrush(Qt::NoBrush);
+    p.setPen(QPen(QColor(0, 0, 0, 200), 2));
+    p.drawEllipse(QPoint(x, y), 6, 6);
+    p.setPen(QPen(QColor(255, 255, 255, 220), 1));
+    p.drawEllipse(QPoint(x, y), 6, 6);
+}
+
+void SVSquare::mousePressEvent(QMouseEvent* e)
+{
+    if (e->button() == Qt::LeftButton) {
+        pickFromMouse(e->pos());
+        e->accept();
+        return;
+    }
+    QWidget::mousePressEvent(e);
+}
+
+void SVSquare::mouseMoveEvent(QMouseEvent* e)
+{
+    if (e->buttons() & Qt::LeftButton) {
+        pickFromMouse(e->pos());
+        e->accept();
+        return;
+    }
+    QWidget::mouseMoveEvent(e);
+}
+
+void SVSquare::pickFromMouse(const QPoint& p)
+{
+    const int w = std::max(1, width()  - 1);
+    const int h = std::max(1, height() - 1);
+    const int x = std::clamp(p.x(), 0, w);
+    const int y = std::clamp(p.y(), 0, h);
+    const int s = static_cast<int>(std::round(static_cast<double>(x) / w * 255.0));
+    const int v = static_cast<int>(std::round((1.0 - static_cast<double>(y) / h) * 255.0));
+    setSV(s, v);
+    emit svPicked(s, v);
+}
+
+// ───────────────────────────────────────────────────────────── HueStrip ──
+
+HueStrip::HueStrip(QWidget* parent) : QWidget(parent)
+{
+    setFixedSize(12, 200);
+    setCursor(Qt::SizeVerCursor);
+}
+
+void HueStrip::setHue(int h)
+{
+    h = std::clamp(h, 0, 359);
+    if (h == m_h) return;
+    m_h = h;
+    update();
+}
+
+void HueStrip::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    // Vertical hue ramp — 7 stops from R round the wheel back to R.
+    QLinearGradient g(0, 0, 0, height());
+    g.setColorAt(0.0000, QColor::fromHsv(  0, 255, 255));
+    g.setColorAt(0.1667, QColor::fromHsv( 60, 255, 255));
+    g.setColorAt(0.3333, QColor::fromHsv(120, 255, 255));
+    g.setColorAt(0.5000, QColor::fromHsv(180, 255, 255));
+    g.setColorAt(0.6667, QColor::fromHsv(240, 255, 255));
+    g.setColorAt(0.8333, QColor::fromHsv(300, 255, 255));
+    g.setColorAt(1.0000, QColor::fromHsv(359, 255, 255));
+    p.fillRect(rect(), g);
+
+    p.setBrush(Qt::NoBrush);
+    p.setPen(QPen(QColor(0, 0, 0, 120), 1));
+    p.drawRect(rect().adjusted(0, 0, -1, -1));
+
+    // Marker: prominent square thumb at the current hue.  Full strip
+    // width × ~9px tall, dark outer ring + white inner fill so it's
+    // visible against any hue, plus a 1px central tick showing the
+    // exact selected hue line.
+    const int y = static_cast<int>(std::round(m_h / 359.0 * (height() - 1)));
+    const int half = 4;
+    const QRect thumbOuter(0, y - half, width(), half * 2 + 1);
+    p.setBrush(QColor(0, 0, 0, 220));
+    p.setPen(Qt::NoPen);
+    p.drawRect(thumbOuter);
+    const QRect thumbInner = thumbOuter.adjusted(1, 1, -1, -1);
+    p.setBrush(Qt::white);
+    p.drawRect(thumbInner);
+    p.setPen(QPen(QColor(0, 0, 0, 220), 1));
+    p.drawLine(1, y, width() - 2, y);
+}
+
+void HueStrip::mousePressEvent(QMouseEvent* e)
+{
+    if (e->button() == Qt::LeftButton) { pickFromMouse(e->pos()); e->accept(); return; }
+    QWidget::mousePressEvent(e);
+}
+
+void HueStrip::mouseMoveEvent(QMouseEvent* e)
+{
+    if (e->buttons() & Qt::LeftButton) { pickFromMouse(e->pos()); e->accept(); return; }
+    QWidget::mouseMoveEvent(e);
+}
+
+void HueStrip::pickFromMouse(const QPoint& p)
+{
+    const int h = std::max(1, height() - 1);
+    const int y = std::clamp(p.y(), 0, h);
+    const int hue = static_cast<int>(std::round(static_cast<double>(y) / h * 359.0));
+    setHue(hue);
+    emit huePicked(hue);
+}
+
+// ────────────────────────────────────────────────────────── AlphaSlider ──
+
+AlphaSlider::AlphaSlider(QWidget* parent) : QWidget(parent)
+{
+    setFixedSize(200, 12);
+    setCursor(Qt::SizeHorCursor);
+}
+
+void AlphaSlider::setAlpha(int a)
+{
+    a = std::clamp(a, 0, 255);
+    if (a == m_a) return;
+    m_a = a;
+    update();
+}
+
+void AlphaSlider::setBaseColor(const QColor& c)
+{
+    QColor opaque = c;
+    opaque.setAlpha(255);
+    if (opaque == m_base) return;
+    m_base = opaque;
+    update();
+}
+
+void AlphaSlider::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    paintCheckerboard(p, rect());
+
+    QLinearGradient g(0, 0, width(), 0);
+    QColor a0 = m_base; a0.setAlpha(0);
+    QColor a1 = m_base; a1.setAlpha(255);
+    g.setColorAt(0.0, a0);
+    g.setColorAt(1.0, a1);
+    p.fillRect(rect(), g);
+
+    // Square border + corners — matches the HueStrip's flat look.
+    p.setBrush(Qt::NoBrush);
+    p.setPen(QPen(QColor(0, 0, 0, 120), 1));
+    p.drawRect(rect().adjusted(0, 0, -1, -1));
+
+    // Marker: prominent square thumb at the current alpha position.
+    // ~9px wide × full strip height, dark outer ring + white inner
+    // fill so it stays visible over both the checkerboard and the
+    // color overlay.
+    const int x = static_cast<int>(std::round(m_a / 255.0 * (width() - 1)));
+    const int half = 4;
+    const QRect thumbOuter(x - half, 0, half * 2 + 1, height());
+    p.setBrush(QColor(0, 0, 0, 220));
+    p.setPen(Qt::NoPen);
+    p.drawRect(thumbOuter);
+    const QRect thumbInner = thumbOuter.adjusted(1, 1, -1, -1);
+    p.setBrush(Qt::white);
+    p.drawRect(thumbInner);
+    p.setPen(QPen(QColor(0, 0, 0, 220), 1));
+    p.drawLine(x, 1, x, height() - 2);
+}
+
+void AlphaSlider::mousePressEvent(QMouseEvent* e)
+{
+    if (e->button() == Qt::LeftButton) { pickFromMouse(e->pos()); e->accept(); return; }
+    QWidget::mousePressEvent(e);
+}
+
+void AlphaSlider::mouseMoveEvent(QMouseEvent* e)
+{
+    if (e->buttons() & Qt::LeftButton) { pickFromMouse(e->pos()); e->accept(); return; }
+    QWidget::mouseMoveEvent(e);
+}
+
+void AlphaSlider::pickFromMouse(const QPoint& p)
+{
+    const int w = std::max(1, width() - 1);
+    const int x = std::clamp(p.x(), 0, w);
+    const int a = static_cast<int>(std::round(static_cast<double>(x) / w * 255.0));
+    setAlpha(a);
+    emit alphaPicked(a);
+}
+
+// ────────────────────────────────────────────────────── CompactColorPicker ─
+
+CompactColorPicker::CompactColorPicker(QWidget* parent) : QWidget(parent)
+{
+    // Size policy + layout sizing both pinned — the picker is a
+    // compact fixed-content block, and we don't want the parent
+    // QStackedWidget page to stretch it vertically by spreading the
+    // child rows apart.  SetFixedSize makes the layout report a
+    // single canonical sizeHint; Fixed vertical policy stops the
+    // parent from overriding it.
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(0, 0, 0, 0);
+    root->setSpacing(6);
+    root->setSizeConstraint(QLayout::SetMinimumSize);
+
+    // SV / Hue / Alpha live in their own sub-VBox with explicit 4 px
+    // spacing so the surrounding root spacing (6 px) doesn't bleed in
+    // around them — Jeremy wants the visual gap between SV ↔ Hue and
+    // SV ↔ Alpha to be exactly 4 px while preserving the wider gaps
+    // between the alpha bar and the RGB / Hex rows below.
+    auto* svBlock = new QVBoxLayout;
+    svBlock->setSpacing(4);
+    svBlock->setContentsMargins(0, 0, 0, 0);
+
+    auto* topRow = new QHBoxLayout;
+    topRow->setSpacing(4);
+    m_sv  = new SVSquare(this);
+    m_hue = new HueStrip(this);
+    topRow->addWidget(m_sv);
+    topRow->addWidget(m_hue);
+    topRow->addStretch(1);
+    svBlock->addLayout(topRow);
+
+    auto* alphaRow = new QHBoxLayout;
+    alphaRow->setSpacing(0);
+    m_alpha = new AlphaSlider(this);
+    alphaRow->addWidget(m_alpha);
+    alphaRow->addStretch(1);
+    svBlock->addLayout(alphaRow);
+
+    root->addLayout(svBlock);
+
+    // Row 3: R / G / B spin boxes — alpha is handled by the bar above,
+    // so this row stays compact.  Padding inside each spin box is
+    // trimmed via stylesheet and the fixed width tightened so all
+    // three pairs fit inside the 218 px width of the SV+hue block
+    // above (200 + 6 + 12 = 218).
+    auto* rgbRow = new QHBoxLayout;
+    rgbRow->setSpacing(2);
+    auto makeRgb = [&](const QString& label, QSpinBox*& slot) {
+        rgbRow->addWidget(new QLabel(label, this));
+        slot = new QSpinBox(this);
+        slot->setRange(0, 255);
+        slot->setFixedWidth(58);
+        slot->setStyleSheet(QStringLiteral(
+            "QSpinBox { padding: 1px 2px 1px 3px; }"));
+        rgbRow->addWidget(slot);
+    };
+    makeRgb(QStringLiteral("R"), m_r);
+    makeRgb(QStringLiteral("G"), m_g);
+    makeRgb(QStringLiteral("B"), m_b);
+    rgbRow->addStretch(1);
+    root->addLayout(rgbRow);
+
+    // Row 4: live swatch + hex line edit.
+    auto* hexRow = new QHBoxLayout;
+    hexRow->setSpacing(6);
+    m_swatch = new QLabel(this);
+    m_swatch->setFixedSize(28, 24);
+    hexRow->addWidget(m_swatch);
+    hexRow->addWidget(new QLabel(QStringLiteral("Hex"), this));
+    m_hex = new QLineEdit(this);
+    m_hex->setPlaceholderText(QStringLiteral("#rrggbb"));
+    m_hex->setMaxLength(9);
+    m_hex->setFixedWidth(96);
+    hexRow->addWidget(m_hex);
+    hexRow->addStretch(1);
+    root->addLayout(hexRow);
+
+    rebuildFromColor();
+
+    connect(m_sv,    &SVSquare::svPicked,     this, &CompactColorPicker::onSVPicked);
+    connect(m_hue,   &HueStrip::huePicked,    this, &CompactColorPicker::onHuePicked);
+    connect(m_alpha, &AlphaSlider::alphaPicked, this, &CompactColorPicker::onAlphaPicked);
+    connect(m_hex,   &QLineEdit::editingFinished,
+            this, &CompactColorPicker::onHexEdited);
+    for (QSpinBox* sb : {m_r, m_g, m_b}) {
+        connect(sb, qOverload<int>(&QSpinBox::valueChanged),
+                this, &CompactColorPicker::onRgbEdited);
+    }
+}
+
+void CompactColorPicker::setColor(const QColor& c)
+{
+    if (!c.isValid()) return;
+    if (c == m_color) return;
+    m_color = c;
+    m_updating = true;
+    rebuildFromColor();
+    m_updating = false;
+}
+
+void CompactColorPicker::rebuildFromColor()
+{
+    int h, s, v, a;
+    m_color.getHsv(&h, &s, &v, &a);
+    if (h < 0) h = m_hue->hue();  // achromatic colours report hue=-1
+    {
+        QSignalBlocker bH(m_hue), bS(m_sv), bA(m_alpha);
+        QSignalBlocker bR(m_r), bG(m_g), bB(m_b), bHex(m_hex);
+        m_hue->setHue(h);
+        m_sv->setHue(h);
+        m_sv->setSV(s, v);
+        m_alpha->setAlpha(a);
+        m_alpha->setBaseColor(m_color);
+        m_r->setValue(m_color.red());
+        m_g->setValue(m_color.green());
+        m_b->setValue(m_color.blue());
+        m_hex->setText(colorToTokenHex(m_color));
+    }
+    // Live swatch — small rounded rect over the standard checkerboard.
+    QPixmap pm(m_swatch->size());
+    pm.fill(Qt::transparent);
+    QPainter p(&pm);
+    p.setRenderHint(QPainter::Antialiasing);
+    QPainterPath clip;
+    clip.addRoundedRect(QRectF(0.5, 0.5, pm.width() - 1.0, pm.height() - 1.0), 3, 3);
+    p.save();
+    p.setClipPath(clip);
+    paintCheckerboard(p, pm.rect());
+    p.fillRect(pm.rect(), m_color);
+    p.restore();
+    p.setBrush(Qt::NoBrush);
+    p.setPen(QPen(QColor(0, 0, 0, 120), 1));
+    p.drawRoundedRect(QRectF(0.5, 0.5, pm.width() - 1.0, pm.height() - 1.0), 3, 3);
+    m_swatch->setPixmap(pm);
+}
+
+void CompactColorPicker::emitChange()
+{
+    rebuildFromColor();
+    emit colorChanged(m_color);
+}
+
+void CompactColorPicker::onSVPicked(int s, int v)
+{
+    if (m_updating) return;
+    const int h = m_hue->hue();
+    QColor c = QColor::fromHsv(h, s, v);
+    c.setAlpha(m_alpha->alpha());
+    m_color = c;
+    emitChange();
+}
+
+void CompactColorPicker::onHuePicked(int h)
+{
+    if (m_updating) return;
+    m_sv->setHue(h);
+    QColor c = QColor::fromHsv(h, m_sv->saturation(), m_sv->value());
+    c.setAlpha(m_alpha->alpha());
+    m_color = c;
+    emitChange();
+}
+
+void CompactColorPicker::onAlphaPicked(int a)
+{
+    if (m_updating) return;
+    m_color.setAlpha(a);
+    emitChange();
+}
+
+void CompactColorPicker::onHexEdited()
+{
+    if (m_updating) return;
+    QColor c(m_hex->text().trimmed());
+    if (!c.isValid()) {
+        // Snap back to current — bad input ignored.
+        QSignalBlocker bHex(m_hex);
+        m_hex->setText(colorToTokenHex(m_color));
+        return;
+    }
+    m_color = c;
+    emitChange();
+}
+
+void CompactColorPicker::onRgbEdited()
+{
+    if (m_updating) return;
+    m_color = QColor(m_r->value(), m_g->value(), m_b->value(), m_alpha->alpha());
+    emitChange();
+}
+
+} // namespace AetherSDR

--- a/src/gui/CompactColorPicker.h
+++ b/src/gui/CompactColorPicker.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <QColor>
+#include <QWidget>
+
+class QLabel;
+class QLineEdit;
+class QSpinBox;
+
+namespace AetherSDR {
+
+// Internal sub-widgets — paint-and-drag for hue / saturation+value /
+// alpha.  All three emit "value changed" signals so the composite picker
+// can stay in sync without polling.
+class SVSquare : public QWidget {
+    Q_OBJECT
+public:
+    explicit SVSquare(QWidget* parent = nullptr);
+    void setHue(int h);            // 0–359
+    void setSV(int s, int v);      // 0–255 each
+    int saturation() const { return m_s; }
+    int value()      const { return m_v; }
+
+signals:
+    void svPicked(int s, int v);
+
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+    void resizeEvent(QResizeEvent*) override;
+
+private:
+    void pickFromMouse(const QPoint& p);
+    void rebuildCache();
+
+    int m_h{180};
+    int m_s{255};
+    int m_v{255};
+    QImage m_cache;  // pre-rendered SV plane at current hue
+};
+
+class HueStrip : public QWidget {
+    Q_OBJECT
+public:
+    explicit HueStrip(QWidget* parent = nullptr);
+    void setHue(int h);    // 0–359
+    int  hue() const { return m_h; }
+
+signals:
+    void huePicked(int h);
+
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+
+private:
+    void pickFromMouse(const QPoint& p);
+    int m_h{180};
+};
+
+class AlphaSlider : public QWidget {
+    Q_OBJECT
+public:
+    explicit AlphaSlider(QWidget* parent = nullptr);
+    void setAlpha(int a);                 // 0–255
+    void setBaseColor(const QColor& c);   // R/G/B at alpha 255
+    int  alpha() const { return m_a; }
+
+signals:
+    void alphaPicked(int a);
+
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+
+private:
+    void pickFromMouse(const QPoint& p);
+    int    m_a{255};
+    QColor m_base{0, 180, 216};
+};
+
+
+// Composite colour picker — SV square + hue strip + alpha slider + hex
+// + RGB inputs + a live swatch.  All controls stay in sync; the widget
+// emits colourChanged() whenever the operator touches anything.
+//
+// Used inline by TokenEditorWidget to edit both scalar colour tokens
+// and individual gradient stop colours without spawning a separate
+// QColorDialog window.  Roughly 280×260 px; resize-friendly.
+class CompactColorPicker : public QWidget {
+    Q_OBJECT
+public:
+    explicit CompactColorPicker(QWidget* parent = nullptr);
+
+    QColor color() const { return m_color; }
+    void   setColor(const QColor& c);
+
+signals:
+    void colorChanged(const QColor& c);
+
+private slots:
+    void onSVPicked(int s, int v);
+    void onHuePicked(int h);
+    void onAlphaPicked(int a);
+    void onHexEdited();
+    void onRgbEdited();
+
+private:
+    void rebuildFromColor();   // sync sub-widgets from m_color
+    void emitChange();         // emit colorChanged + refresh swatch
+
+    QColor      m_color{0, 180, 216, 255};
+    SVSquare*   m_sv{nullptr};
+    HueStrip*   m_hue{nullptr};
+    AlphaSlider* m_alpha{nullptr};
+    QLineEdit*  m_hex{nullptr};
+    QSpinBox*   m_r{nullptr};
+    QSpinBox*   m_g{nullptr};
+    QSpinBox*   m_b{nullptr};
+    QLabel*     m_swatch{nullptr};
+    bool        m_updating{false};   // re-entrancy guard during sync
+};
+
+} // namespace AetherSDR

--- a/src/gui/CompactColorPicker.h
+++ b/src/gui/CompactColorPicker.h
@@ -5,6 +5,7 @@
 
 class QLabel;
 class QLineEdit;
+class QPushButton;
 class QSpinBox;
 
 namespace AetherSDR {
@@ -107,6 +108,7 @@ private slots:
     void onAlphaPicked(int a);
     void onHexEdited();
     void onRgbEdited();
+    void onEyedropperClicked();
 
 private:
     void rebuildFromColor();   // sync sub-widgets from m_color
@@ -116,12 +118,17 @@ private:
     SVSquare*   m_sv{nullptr};
     HueStrip*   m_hue{nullptr};
     AlphaSlider* m_alpha{nullptr};
-    QLineEdit*  m_hex{nullptr};
-    QSpinBox*   m_r{nullptr};
-    QSpinBox*   m_g{nullptr};
-    QSpinBox*   m_b{nullptr};
-    QLabel*     m_swatch{nullptr};
-    bool        m_updating{false};   // re-entrancy guard during sync
+    QLineEdit*   m_hex{nullptr};
+    QPushButton* m_eyedropper{nullptr};
+    QSpinBox*    m_r{nullptr};
+    QSpinBox*    m_g{nullptr};
+    QSpinBox*    m_b{nullptr};
+    QLabel*      m_swatch{nullptr};
+    bool         m_updating{false};   // re-entrancy guard during sync
+    bool         m_pickingScreen{false};  // grabMouse/grabKeyboard active
+
+protected:
+    bool event(QEvent* ev) override;  // intercepts events during screen pick
 };
 
 } // namespace AetherSDR

--- a/src/gui/ConnectedStationsDialog.cpp
+++ b/src/gui/ConnectedStationsDialog.cpp
@@ -1,5 +1,7 @@
 #include "ConnectedStationsDialog.h"
 
+#include "core/ThemeManager.h"
+
 #include <QApplication>
 #include <QButtonGroup>
 #include <QCursor>
@@ -95,6 +97,7 @@ ConnectedStationsDialog::ConnectedStationsDialog(const RadioMeta& radio,
                                                  QWidget* parent)
     : QDialog(parent)
 {
+    theme::setContainer(this, QStringLiteral("dialog/connectedStations"));
     setWindowTitle(tr("Connected Stations"));
     setModal(true);
     setWindowModality(Qt::ApplicationModal);

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -183,6 +183,7 @@ QString normalizedStatus(QString status)
 ConnectionPanel::ConnectionPanel(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("panel/connection"));
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "ConnectionPanel { background: {{color.background.0}}; }"
         "QGroupBox { border: 1px solid {{color.background.2}}; border-radius: 7px; margin-top: 10px; "
         "color: {{color.text.primary}}; font-weight: bold; }"

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -137,6 +137,7 @@ static const char* kTextStyle =
 CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
     : QWidget(parent), m_model(model)
 {
+    theme::setContainer(this, QStringLiteral("panel/cwx"));
     setFixedWidth(250);
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QWidget { background: {{color.background.0}}; }");
 

--- a/src/gui/DaxApplet.cpp
+++ b/src/gui/DaxApplet.cpp
@@ -2,6 +2,7 @@
 #include "MeterSlider.h"
 #include "SliceLabel.h"
 #include "core/AppSettings.h"
+#include "core/ThemeManager.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 
@@ -37,6 +38,7 @@ const QString kStatusLabel = "QLabel { color: #506070; font-size: 11px; }";
 
 DaxApplet::DaxApplet(QWidget* parent) : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/dax"));
     buildUI();
     hide();  // hidden by default
 }

--- a/src/gui/DaxIqApplet.cpp
+++ b/src/gui/DaxIqApplet.cpp
@@ -43,6 +43,7 @@ const QString kIqBtnOff =
 
 DaxIqApplet::DaxIqApplet(QWidget* parent) : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/daxiq"));
     buildUI();
     hide();  // hidden by default
 }

--- a/src/gui/DvkPanel.cpp
+++ b/src/gui/DvkPanel.cpp
@@ -37,6 +37,7 @@ static const char* kBtnStyle =
 DvkPanel::DvkPanel(DvkModel* model, QWidget* parent)
     : QWidget(parent), m_model(model)
 {
+    theme::setContainer(this, QStringLiteral("panel/dvk"));
     auto* outerVbox = new QVBoxLayout(this);
     outerVbox->setContentsMargins(4, 4, 4, 4);
     outerVbox->setSpacing(4);

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -273,6 +273,7 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
 #endif
       m_radioModel(radioModel), m_dxccProvider(dxccProvider)
 {
+    theme::setContainer(this, QStringLiteral("dialog/dxCluster"));
     setMinimumSize(680, 560);
     resize(760, 640);
 

--- a/src/gui/DxClusterStartupCommandsDialog.cpp
+++ b/src/gui/DxClusterStartupCommandsDialog.cpp
@@ -27,6 +27,7 @@ DxClusterStartupCommandsDialog::DxClusterStartupCommandsDialog(
     : PersistentDialog(title, /*geomKey*/ QString(), parent)
     , m_key(appSettingsKey)
 {
+    theme::setContainer(this, QStringLiteral("dialog/dxClusterStartup"));
     setModal(true);
     setMinimumSize(560, 380);
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }");

--- a/src/gui/EditorFramelessTitleBar.cpp
+++ b/src/gui/EditorFramelessTitleBar.cpp
@@ -11,6 +11,7 @@ namespace AetherSDR {
 EditorFramelessTitleBar::EditorFramelessTitleBar(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("titlebar"));
     setObjectName(QStringLiteral("editorFramelessTitleBar"));
     setFixedHeight(20);
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "background: {{color.background.0}};");

--- a/src/gui/EqApplet.cpp
+++ b/src/gui/EqApplet.cpp
@@ -97,6 +97,7 @@ static QString dbWithSignText(int v)
 EqApplet::EqApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/eq"));
     buildUI();
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     setVisible(false);

--- a/src/gui/FavoritesPickerDialog.cpp
+++ b/src/gui/FavoritesPickerDialog.cpp
@@ -131,6 +131,7 @@ FavoritesPickerDialog::FavoritesPickerDialog(const QList<Entry>& allEntries,
     , m_favoriteSplit(favoriteSplit)
     , m_entries(allEntries)
 {
+    theme::setContainer(this, QStringLiteral("dialog/favoritesPicker"));
     // Default height sized so the Active list shows the full default set
     // (~19 items at ~24 px + chrome ≈ 620 px) without a scrollbar on first
     // open.  Minimum stays smaller so the user can shrink it if they want.

--- a/src/gui/FlexControlDialog.cpp
+++ b/src/gui/FlexControlDialog.cpp
@@ -3,6 +3,7 @@
 #include "GuardedSlider.h"
 #include "SliceLabel.h"
 #include "core/AppSettings.h"
+#include "core/ThemeManager.h"
 #include "models/SliceModel.h"
 
 #include <QApplication>
@@ -974,6 +975,7 @@ FlexControlDialog::FlexControlDialog(QWidget* parent)
                        QStringLiteral("FlexControlDialogGeometry"),
                        parent)
 {
+    theme::setContainer(this, QStringLiteral("dialog/flexControl"));
     setModal(false);
     setWindowModality(Qt::NonModal);
     setMinimumSize(430, 610);

--- a/src/gui/FramelessWindowTitleBar.cpp
+++ b/src/gui/FramelessWindowTitleBar.cpp
@@ -37,6 +37,7 @@ constexpr const char* kCloseButtonStyle =
 FramelessWindowTitleBar::FramelessWindowTitleBar(const QString& title, QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("titlebar"));
     setFixedHeight(18);
     setAttribute(Qt::WA_StyledBackground, true);
     setStyleSheet(kBarStyle);

--- a/src/gui/GradientEditorDialog.cpp
+++ b/src/gui/GradientEditorDialog.cpp
@@ -1,6 +1,7 @@
 #include "GradientEditorDialog.h"
 #include "Theme.h"
 #include "core/AppSettings.h"
+#include "core/ThemeManager.h"
 
 #include <QApplication>
 #include <QColorDialog>
@@ -288,6 +289,7 @@ GradientEditorDialog::GradientEditorDialog(const QString& tokenName,
                        parent),
       m_tokenName(tokenName), m_gradient(initial)
 {
+    theme::setContainer(this, QStringLiteral("dialog/gradientEditor"));
     setModal(true);
     setMinimumSize(520, 420);
     applyAppTheme(this);

--- a/src/gui/GradientEditorDialog.cpp
+++ b/src/gui/GradientEditorDialog.cpp
@@ -66,7 +66,10 @@ QIcon stopSwatchIcon(const QColor& c)
 GradientStrip::GradientStrip(QWidget* parent)
     : QWidget(parent)
 {
-    setMinimumHeight(kStripHeight + kMarkerStripH + kStripMargin);
+    // Markers are now overlaid on the gradient itself, so the widget
+    // no longer needs a separate marker band below the strip.  Min
+    // height covers the gradient bar plus a small breathing margin.
+    setMinimumHeight(kStripHeight + kStripMargin);
     setMouseTracking(true);
     setFocusPolicy(Qt::StrongFocus);
 }
@@ -86,17 +89,30 @@ void GradientStrip::setSelectedStop(int index)
 
 QRect GradientStrip::stripRect() const
 {
-    return QRect(kStripMargin,
-                 kStripMargin / 2,
-                 width() - kStripMargin * 2,
-                 kStripHeight);
+    // Fill the available widget height (minus a small symmetric margin)
+    // so a small fixed-height widget — e.g. the 35px-tall strip embedded
+    // in TokenEditorWidget — still leaves room for both the gradient
+    // and the markers overlaid on it.
+    const int hMargin = kStripMargin;
+    const int vMargin = kStripMargin / 2;
+    return QRect(hMargin,
+                 vMargin,
+                 width() - hMargin * 2,
+                 std::max(8, height() - vMargin * 2));
 }
 
 QRect GradientStrip::markerRect(qreal at) const
 {
+    // Marker is overlaid on the gradient bar (anchored to the bottom
+    // edge of the strip and pointing up).  Sized to fit inside the
+    // strip even when the strip is shrunken to ~35px total.
+    const QRect r = stripRect();
     const int x = positionToX(at);
-    const int yTop = stripRect().bottom() + 2;
-    return QRect(x - kMarkerHalfW, yTop, kMarkerHalfW * 2, kMarkerStripH - 4);
+    const int h = std::clamp(r.height() - 4, 10, kMarkerStripH);
+    return QRect(x - kMarkerHalfW,
+                 r.bottom() - h + 1,
+                 kMarkerHalfW * 2,
+                 h);
 }
 
 int GradientStrip::positionToX(qreal at) const
@@ -166,28 +182,30 @@ void GradientStrip::paintEvent(QPaintEvent*)
     p.setPen(QPen(QColor(0, 0, 0, 80), 1));
     p.drawRoundedRect(r, 4, 4);
 
-    // Stop markers — small downward-pointing triangles below the strip,
-    // colour-matched to each stop.  Selected stop gets a cyan halo.
+    // Stop markers — square chip thumbs matching the HueStrip /
+    // AlphaSlider style: dark outer rect, white inner fill, with a
+    // narrow vertical band of the stop's color through the center
+    // (so each stop's color is still identifiable at a glance).
+    // Selected stop swaps the dark outer for the accent cyan.
     for (int i = 0; i < m_g.stops.size(); ++i) {
         const QRect mr = markerRect(m_g.stops[i].at);
+        const bool selected = (i == m_selectedIndex);
+
+        p.setPen(Qt::NoPen);
+        p.setBrush(selected ? QColor(0, 0x9b, 0xc4) : QColor(0, 0, 0, 220));
+        p.drawRect(mr);
+
+        const QRect inner = mr.adjusted(1, 1, -1, -1);
+        p.setBrush(Qt::white);
+        p.drawRect(inner);
+
+        // Stop's color shown as a vertical band through the center —
+        // ~3px wide on a 12px-wide marker so the white edges still
+        // read as the visible outline against any gradient under it.
         const int cx = mr.center().x();
-        const int top = mr.top() + 2;
-        const int bot = mr.bottom() - 2;
-        QPolygon tri;
-        tri << QPoint(cx, top)
-            << QPoint(cx - kMarkerHalfW, bot)
-            << QPoint(cx + kMarkerHalfW, bot);
-
-        if (i == m_selectedIndex) {
-            p.setBrush(Qt::NoBrush);
-            p.setPen(QPen(QColor(0, 0x9b, 0xc4), 2));
-            QRect halo = mr.adjusted(-2, -2, 2, 2);
-            p.drawRoundedRect(halo, 4, 4);
-        }
-
+        const QRect colorBand(cx - 1, inner.top(), 3, inner.height());
         p.setBrush(m_g.stops[i].color);
-        p.setPen(QPen(QColor(0, 0, 0, 160), 1));
-        p.drawPolygon(tri);
+        p.drawRect(colorBand);
     }
 }
 
@@ -284,7 +302,7 @@ GradientEditorDialog::GradientEditorDialog(const QString& tokenName,
     root->setSpacing(8);
 
     auto* hdr = new QLabel(QStringLiteral(
-        "<b>%1</b><br>Click a stop to recolour it, drag along the strip "
+        "<b>%1</b><br>Click a stop to recolor it, drag along the strip "
         "to reposition, right-click to delete, or double-click an empty "
         "spot to add a new stop.").arg(tokenName.toHtmlEscaped()), bodyWidget());
     hdr->setWordWrap(true);
@@ -304,7 +322,7 @@ GradientEditorDialog::GradientEditorDialog(const QString& tokenName,
     auto* stopBtnCol = new QVBoxLayout;
     auto* addBtn  = new QPushButton(QStringLiteral("+ Add stop"), bodyWidget());
     auto* delBtn  = new QPushButton(QStringLiteral("− Delete stop"), bodyWidget());
-    auto* editBtn = new QPushButton(QStringLiteral("Edit colour…"), bodyWidget());
+    auto* editBtn = new QPushButton(QStringLiteral("Edit color…"), bodyWidget());
     stopBtnCol->addWidget(addBtn);
     stopBtnCol->addWidget(delBtn);
     stopBtnCol->addWidget(editBtn);
@@ -600,7 +618,7 @@ void GradientEditorDialog::onEditColorBtnClicked()
     if (idx < 0 || idx >= m_gradient.stops.size()) return;
     const QColor current = m_gradient.stops[idx].color;
     const QColor chosen = QColorDialog::getColor(current, this,
-        QStringLiteral("Edit stop %1 colour").arg(idx),
+        QStringLiteral("Edit stop %1 color").arg(idx),
         QColorDialog::ShowAlphaChannel);
     if (!chosen.isValid()) return;
     m_gradient.stops[idx].color = chosen;

--- a/src/gui/HealthApplet.cpp
+++ b/src/gui/HealthApplet.cpp
@@ -332,6 +332,7 @@ private:
 HealthApplet::HealthApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet.hlth"));
     hide();
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 

--- a/src/gui/HealthApplet.cpp
+++ b/src/gui/HealthApplet.cpp
@@ -332,7 +332,7 @@ private:
 HealthApplet::HealthApplet(QWidget* parent)
     : QWidget(parent)
 {
-    theme::setContainer(this, QStringLiteral("applet.hlth"));
+    theme::setContainer(this, QStringLiteral("applet/hlth"));
     hide();
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 

--- a/src/gui/HelpDialog.cpp
+++ b/src/gui/HelpDialog.cpp
@@ -46,6 +46,7 @@ HelpDialog::HelpDialog(const QString& windowTitle,
                        QWidget* parent)
     : QDialog(parent)
 {
+    theme::setContainer(this, QStringLiteral("dialog/help"));
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     setWindowTitle(windowTitle);
     buildUI(resourcePath);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1376,6 +1376,12 @@ void MainWindow::showForcedDisconnectDialog(bool wasWan,
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
 {
+    // Status bar is the only top-level shell besides the spectrum / applet
+    // rail / titlebar that the operator can directly retheme.  Declare its
+    // container here — statusBar() lazy-creates the QStatusBar on first
+    // call, so this is also the construction point.
+    theme::setContainer(statusBar(), QStringLiteral("statusbar"));
+
     setWindowTitle(QString("AetherSDR v%1").arg(QCoreApplication::applicationVersion()));
     setWindowIcon(QIcon(":/icon.png"));
     setMinimumSize(1024, 400);

--- a/src/gui/MemoryBrowsePanel.cpp
+++ b/src/gui/MemoryBrowsePanel.cpp
@@ -31,6 +31,7 @@ QString displayMemoryName(const MemoryEntry& memory)
 MemoryBrowsePanel::MemoryBrowsePanel(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("panel/memoryBrowse"));
     setFixedSize(252, 460);
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "background: rgba(15, 15, 26, 220); border: 1px solid {{color.background.2}}; border-radius: 3px;");
 

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -225,6 +225,7 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     : PersistentDialog("Memory Channels", "MemoryDialogGeometry", parent),
       m_model(model)
 {
+    theme::setContainer(this, QStringLiteral("dialog/memory"));
     resize(1000, 500);
 
     auto* root = new QVBoxLayout(bodyWidget());

--- a/src/gui/MeterApplet.cpp
+++ b/src/gui/MeterApplet.cpp
@@ -1,5 +1,6 @@
 #include "MeterApplet.h"
 #include "HGauge.h"
+#include "core/ThemeManager.h"
 #include "models/MeterModel.h"
 
 #include <QVBoxLayout>
@@ -14,6 +15,7 @@ static const char* kSectionStyle =
 MeterApplet::MeterApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/meter"));
     auto* vbox = new QVBoxLayout(this);
     vbox->setContentsMargins(4, 2, 4, 2);
     vbox->setSpacing(2);

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -39,6 +39,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
     : PersistentDialog("MIDI Controller Mapping", "MidiMappingDialogGeometry", parent),
       m_manager(manager)
 {
+    theme::setContainer(this, QStringLiteral("dialog/midiMapping"));
     setMinimumSize(700, 550);
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; }");
 

--- a/src/gui/MqttApplet.cpp
+++ b/src/gui/MqttApplet.cpp
@@ -38,6 +38,7 @@ static const QString kPubBtn =
 MqttApplet::MqttApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/mqtt"));
     refreshSettings();
     buildUI();
     loadPasswordFromKeychain();

--- a/src/gui/MqttSettingsDialog.cpp
+++ b/src/gui/MqttSettingsDialog.cpp
@@ -2,6 +2,7 @@
 
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
+#include "core/ThemeManager.h"
 
 #include <QCheckBox>
 #include <QDialogButtonBox>
@@ -67,6 +68,7 @@ MqttSettingsDialog::MqttSettingsDialog(QWidget* parent)
                        QStringLiteral("MqttSettingsDialogGeometry"),
                        parent)
 {
+    theme::setContainer(this, QStringLiteral("dialog/mqttSettings"));
     buildUi();
     loadSettings();
     loadPasswordFromKeychain();

--- a/src/gui/MultiFlexDialog.cpp
+++ b/src/gui/MultiFlexDialog.cpp
@@ -35,6 +35,7 @@ MultiFlexDialog::MultiFlexDialog(RadioModel* model, QWidget* parent)
     : PersistentDialog("multiFLEX Dashboard", "MultiFlexDialogGeometry", parent),
       m_model(model)
 {
+    theme::setContainer(this, QStringLiteral("dialog/multiFlex"));
     setMinimumSize(680, 280);
     resize(760, 320);
     setStyleSheet(kDialogStyle);

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -784,6 +784,7 @@ NetworkDiagnosticsDialog::NetworkDiagnosticsDialog(RadioModel* model,
     : PersistentDialog("Network Diagnostics", "NetworkDiagnosticsDialogGeometry", parent),
       m_model(model), m_audio(audio), m_history(history), m_tci(tci)
 {
+    theme::setContainer(this, QStringLiteral("dialog/networkDiag"));
     setMinimumSize(920, 680);
     resize(980, 760);
     bodyWidget()->setStyleSheet(QString::fromLatin1(kNetworkDiagnosticsStyle));

--- a/src/gui/PanLayoutDialog.cpp
+++ b/src/gui/PanLayoutDialog.cpp
@@ -110,6 +110,7 @@ PanLayoutDialog::PanLayoutDialog(int maxPans, const QString& currentLayout,
                                  QWidget* parent)
     : PersistentDialog("Panadapter Layout", /*geomKey*/ QString(), parent)
 {
+    theme::setContainer(this, QStringLiteral("dialog/panLayout"));
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; }"
                   "QLabel { color: {{color.text.primary}}; }");
     // Fixed-size grid of thumbnails — body content is the same regardless of

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -27,6 +27,7 @@ namespace AetherSDR {
 PanadapterApplet::PanadapterApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/panadapter"));
     auto* layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -83,6 +83,7 @@ static const QString kStepBtnStyle =
 PhoneApplet::PhoneApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/phone"));
     buildUI();
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     setVisible(false);

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -103,7 +103,7 @@ static constexpr float kAlcGaugeFloorDbfs = -20.0f;
 PhoneCwApplet::PhoneCwApplet(QWidget* parent)
     : QWidget(parent)
 {
-    theme::setContainer(this, QStringLiteral("applet.digi"));
+    theme::setContainer(this, QStringLiteral("applet/digi"));
     hide();
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -103,6 +103,7 @@ static constexpr float kAlcGaugeFloorDbfs = -20.0f;
 PhoneCwApplet::PhoneCwApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet.digi"));
     hide();
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 

--- a/src/gui/ProfileImportExportDialog.cpp
+++ b/src/gui/ProfileImportExportDialog.cpp
@@ -1,6 +1,7 @@
 #include "ProfileImportExportDialog.h"
 
 #include "core/AppSettings.h"
+#include "core/ThemeManager.h"
 #include "models/RadioModel.h"
 #include "models/TransmitModel.h"
 
@@ -86,6 +87,7 @@ ProfileImportExportDialog::ProfileImportExportDialog(RadioModel* model, QWidget*
                        QStringLiteral("ProfileImportExportDialogGeometry"), parent),
       m_model(model)
 {
+    theme::setContainer(this, QStringLiteral("dialog/profileIO"));
     setMinimumSize(560, 430);
     setStyleSheet(kDialogStyle);
 

--- a/src/gui/ProfileManagerDialog.cpp
+++ b/src/gui/ProfileManagerDialog.cpp
@@ -1,4 +1,5 @@
 #include "ProfileManagerDialog.h"
+#include "core/ThemeManager.h"
 #include "models/RadioModel.h"
 #include "models/TransmitModel.h"
 
@@ -39,6 +40,7 @@ ProfileManagerDialog::ProfileManagerDialog(RadioModel* model, QWidget* parent)
     : PersistentDialog("Profile Manager", "ProfileManagerDialogGeometry", parent),
       m_model(model)
 {
+    theme::setContainer(this, QStringLiteral("dialog/profileManager"));
     setMinimumSize(460, 400);
     setStyleSheet(kDialogStyle);
 

--- a/src/gui/PropDashboardDialog.cpp
+++ b/src/gui/PropDashboardDialog.cpp
@@ -370,6 +370,7 @@ PropDashboardDialog::PropDashboardDialog(PropForecastClient* client, QWidget* pa
                        QStringLiteral("PropDashboardDialogGeometry"), parent),
       m_client(client)
 {
+    theme::setContainer(this, QStringLiteral("dialog/propDashboard"));
     setStyleSheet(kDialogStyle);
 
     const QScreen* screen = parentWidget() && parentWidget()->screen()

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -422,6 +422,7 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
       m_model(model), m_audio(audio),
       m_tgxl(tgxl), m_pgxl(pgxl), m_ag(ag)
 {
+    theme::setContainer(this, QStringLiteral("dialog/radioSetup"));
     setMinimumSize(820, 620);
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; }");
 

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -517,7 +517,7 @@ void RxApplet::buildUI()
         // VfoWidget's frequency label reads the same token so both surfaces
         // re-theme in lockstep when the operator picks a new family in the
         // Theme Editor.
-        AetherSDR::ThemeManager::instance().applyStyleSheet(m_freqLabel, "QLabel { color: {{color.text.primary}}; font-size: 28px; font-weight: bold;"
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_freqLabel, "QLabel { color: {{color.text.primary}}; font-size: {{font.size.freq}}px; font-weight: bold;"
             " font-family: \"{{font.family.freq}}\";"
             " background: transparent; padding: 0; margin: 0; }");
         m_freqLabel->installEventFilter(this);

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -314,7 +314,7 @@ static QPushButton* mkRight(QWidget* parent = nullptr) { return new TriBtn(TriBt
 
 RxApplet::RxApplet(QWidget* parent) : QWidget(parent)
 {
-    theme::setContainer(this, QStringLiteral("applet.rx"));
+    theme::setContainer(this, QStringLiteral("applet/rx"));
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     // Recall the last user-chosen Manual squelch threshold from prior
     // sessions.  Auto mode clobbers the slice's squelchLevel with

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -314,6 +314,7 @@ static QPushButton* mkRight(QWidget* parent = nullptr) { return new TriBtn(TriBt
 
 RxApplet::RxApplet(QWidget* parent) : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet.rx"));
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     // Recall the last user-chosen Manual squelch threshold from prior
     // sessions.  Auto mode clobbers the slice's squelchLevel with

--- a/src/gui/ShackSwitchApplet.cpp
+++ b/src/gui/ShackSwitchApplet.cpp
@@ -76,6 +76,7 @@ static constexpr const char* kDummyLoadBtnActiveStyle =
 ShackSwitchApplet::ShackSwitchApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/shackSwitch"));
     hide();
     setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
     setMaximumWidth(260);

--- a/src/gui/ShortcutDialog.cpp
+++ b/src/gui/ShortcutDialog.cpp
@@ -38,6 +38,7 @@ static const char* kDialogStyle =
 ShortcutDialog::ShortcutDialog(ShortcutManager* mgr, QWidget* parent)
     : QDialog(parent), m_mgr(mgr)
 {
+    theme::setContainer(this, QStringLiteral("dialog/shortcut"));
     setWindowTitle("Keyboard Shortcuts");
     setMinimumSize(950, 700);
     resize(1100, 800);

--- a/src/gui/SliceTroubleshootingDialog.cpp
+++ b/src/gui/SliceTroubleshootingDialog.cpp
@@ -389,6 +389,7 @@ SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model,
     , m_controlDevicesProvider(std::move(controlDevicesProvider))
     , m_rendererProvider(std::move(rendererProvider))
 {
+    theme::setContainer(this, QStringLiteral("dialog/sliceTroubleshoot"));
     setWindowTitle("Slice Troubleshooting");
     setMinimumSize(920, 720);
     resize(980, 760);

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -195,6 +195,19 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
         if (panel) panel->installEventFilter(this);
 
     updateLayout();
+
+    // Inspector coverage — every button + sub-panel inside the overlay
+    // menu paints via applyStyleSheet, so child widgets are tracked
+    // individually.  Declare the same token set on the overlay menu
+    // itself so an Inspect-mode click on the menu's empty area (or its
+    // toggle arrow / row dividers) still surfaces a useful hit-list
+    // rather than falling through to the SpectrumWidget catch-all.
+    AetherSDR::ThemeManager::instance().declareWidgetTokens(this, QStringList{
+        "color.background.0", "color.background.1",
+        "color.text.primary", "color.text.label",
+        "color.accent", "color.accent.bright", "color.accent.dim",
+        "color.border.subtle", "color.border.strong",
+    });
 }
 
 void SpectrumOverlayMenu::raiseAll()

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -346,6 +346,12 @@ QString SpectrumWidget::rendererDescription() const
 SpectrumWidget::SpectrumWidget(QWidget* parent)
     : SPECTRUM_BASE_CLASS(parent)
 {
+    // Container declaration — every token lookup made by this widget or
+    // any of its children (without their own declaration) resolves
+    // through the "spectrum" scope chain.  Token migration into this
+    // scope happens in step 4 of the refactor.
+    theme::setContainer(this, QStringLiteral("spectrum"));
+
     setMinimumHeight(100);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setAutoFillBackground(false);

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -14,6 +14,7 @@ namespace AetherSDR {
 SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     : QDialog(parent), m_model(model)
 {
+    theme::setContainer(this, QStringLiteral("dialog/spotSettings"));
     setWindowTitle("Spot Settings");
     setMinimumSize(380, 520);
     resize(380, 520);

--- a/src/gui/SupportDialog.cpp
+++ b/src/gui/SupportDialog.cpp
@@ -33,6 +33,7 @@ namespace AetherSDR {
 SupportDialog::SupportDialog(QWidget* parent)
     : QDialog(parent)
 {
+    theme::setContainer(this, QStringLiteral("dialog/support"));
     setWindowTitle("Support & Diagnostics");
     setMinimumSize(600, 520);
     resize(680, 600);

--- a/src/gui/SwrSweepLicenseDialog.cpp
+++ b/src/gui/SwrSweepLicenseDialog.cpp
@@ -31,6 +31,7 @@ SwrSweepLicenseDialog::SwrSweepLicenseDialog(QWidget* parent)
     : PersistentDialog("Antenna SWR Sweep — License Confirmation",
                        /*geomKey*/ QString(), parent)
 {
+    theme::setContainer(this, QStringLiteral("dialog/swrSweepLicense"));
     setModal(true);
     setMinimumSize(520, 240);
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }");

--- a/src/gui/TciApplet.cpp
+++ b/src/gui/TciApplet.cpp
@@ -53,6 +53,7 @@ const QString kStatusLabel = "QLabel { color: #506070; font-size: 11px; }";
 
 TciApplet::TciApplet(QWidget* parent) : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/tci"));
 #ifdef HAVE_WEBSOCKETS
     buildUI();
     hide();  // hidden by default

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -160,9 +160,22 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     divider->setFrameShadow(QFrame::Sunken);
     root->addWidget(divider);
 
-    // Inspector toggle row — global event filter; clicking the main UI
-    // surfaces the tokens painting that region into the list below.
+    // Inspector + scope picker row.  Layout left-to-right:
+    //   [Scope: combo] [Inspect btn] [Editing label] [status] [Reset btn]
+    // Scope picker sits leftmost so it visually anchors the row as
+    // "where this edit will land".  Combo width is clamped to the
+    // longest container-path label + 4 px pad on each side; no
+    // stretch so it doesn't grow with the dialog.
     auto* inspectRow = new QHBoxLayout;
+    inspectRow->addWidget(new QLabel(QStringLiteral("Scope:"), bodyWidget()));
+    m_containerCombo = new QComboBox(bodyWidget());
+    m_containerCombo->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+    m_containerCombo->setToolTip(QStringLiteral(
+        "Container scope to edit.  \"(root)\" is the global namespace.\n"
+        "Selecting a nested scope (e.g. applet.tx) routes new overrides\n"
+        "into that scope, and only widgets inside that container see them."));
+    inspectRow->addWidget(m_containerCombo);
+
     m_inspectBtn = new QPushButton(QStringLiteral("🎯  Inspect"), bodyWidget());
     m_inspectBtn->setCheckable(true);
     m_inspectBtn->setToolTip(QStringLiteral(
@@ -188,21 +201,6 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
         inspectRow->addWidget(reset, 0, Qt::AlignRight);
     }
     root->addLayout(inspectRow);
-
-    // Container scope picker.  Selecting a non-root container scopes
-    // subsequent OK commits to that container — TokenEditorWidget routes
-    // setColor / setSizing / setGradient / setString through the
-    // scope-aware overloads when m_activeContainerPath is non-empty.
-    auto* containerRow = new QHBoxLayout;
-    containerRow->setSpacing(6);
-    containerRow->addWidget(new QLabel(QStringLiteral("Scope:"), bodyWidget()));
-    m_containerCombo = new QComboBox(bodyWidget());
-    m_containerCombo->setToolTip(QStringLiteral(
-        "Container scope to edit.  \"(root)\" is the global namespace.\n"
-        "Selecting a nested scope (e.g. applet.tx) routes new overrides\n"
-        "into that scope, and only widgets inside that container see them."));
-    containerRow->addWidget(m_containerCombo, 1);
-    root->addLayout(containerRow);
 
     m_filterEdit = new QLineEdit(bodyWidget());
     m_filterEdit->setPlaceholderText(QStringLiteral("Filter tokens (e.g. accent, slice, meter)…"));
@@ -762,6 +760,20 @@ void ThemeEditorDialog::refreshContainerCombo()
         if (path.isEmpty()) continue;  // already added as "(root)"
         m_containerCombo->addItem(path, path);
     }
+    // Clamp the combo to the longest label + 4 px pad on each side
+    // (plus arrow + frame allowance).  Sized once per refresh; combo
+    // stays exactly that wide regardless of which item is selected.
+    QFontMetrics fm(m_containerCombo->font());
+    int maxLabelW = 0;
+    for (int i = 0; i < m_containerCombo->count(); ++i) {
+        maxLabelW = std::max(maxLabelW,
+                             fm.horizontalAdvance(m_containerCombo->itemText(i)));
+    }
+    // 4 px L + 4 px R text padding (overrides Theme.h's 6/6 default),
+    // ~20 px dropdown arrow, ~2 px frame borders.
+    m_containerCombo->setStyleSheet(QStringLiteral(
+        "QComboBox { padding: 2px 4px; }"));
+    m_containerCombo->setFixedWidth(maxLabelW + 4 + 4 + 20 + 2);
     // Restore previous selection by path string, falling back to root.
     int idx = m_containerCombo->findData(m_activeContainerPath);
     if (idx < 0) idx = 0;

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -21,8 +21,9 @@
 #include <QMimeData>
 #include <QUrl>
 #include <QLineEdit>
-#include <QListWidget>
-#include <QListWidgetItem>
+#include <QHeaderView>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
 #include <QMessageBox>
 #include <QPainter>
 #include <QPainterPath>
@@ -215,10 +216,18 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     }
     root->addLayout(filterRow);
 
-    m_tokenList = new QListWidget(bodyWidget());
+    m_tokenList = new QTreeWidget(bodyWidget());
     m_tokenList->setIconSize(QSize(18, 18));
     m_tokenList->setAlternatingRowColors(true);
     m_tokenList->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_tokenList->setRootIsDecorated(false);   // flat-table look
+    m_tokenList->setIndentation(0);
+    m_tokenList->setUniformRowHeights(true);
+    m_tokenList->setSortingEnabled(false);
+    // Columns rebuild dynamically as the scope picker changes — see
+    // rebuildColumns().  Initial setup with just the Object + Value
+    // pair so the widget has something to render before refreshTokenList.
+    rebuildColumns();
     root->addWidget(m_tokenList, 1);
 
     auto* btnRow = new QHBoxLayout;
@@ -268,7 +277,7 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     // Selection-driven editing — `currentItemChanged` fires for both
     // mouse clicks and keyboard navigation so arrow-key walks through
     // the list also update the inline editor.
-    connect(m_tokenList, &QListWidget::currentItemChanged,
+    connect(m_tokenList, &QTreeWidget::currentItemChanged,
             this, &ThemeEditorDialog::onTokenRowSelectionChanged);
     connect(m_tokenEditor, &TokenEditorWidget::tokenChanged,
             this, &ThemeEditorDialog::onTokenEditedByEditor);
@@ -311,9 +320,56 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     });
 }
 
+void ThemeEditorDialog::rebuildColumns()
+{
+    if (!m_tokenList) return;
+    // Column layout: Object | <root, seg0, seg0/seg1, …, leaf> | Value
+    QStringList scopeLevels;       // canonical paths for each header column
+    QStringList headerLabels = { QStringLiteral("Object") };
+    if (m_activeContainerPath.isEmpty()) {
+        // No scope selected → just Object + Value.  Skip the "root"
+        // column since it would duplicate the Value column.
+    } else {
+        scopeLevels.append(QString());          // root
+        headerLabels.append(QStringLiteral("root"));
+        const QStringList segs = m_activeContainerPath.split(QLatin1Char('/'),
+                                                             Qt::SkipEmptyParts);
+        QString running;
+        for (const QString& s : segs) {
+            running = running.isEmpty() ? s : running + QLatin1Char('/') + s;
+            scopeLevels.append(running);
+            headerLabels.append(s);
+        }
+    }
+    headerLabels.append(QStringLiteral("Value"));
+
+    m_tokenList->setColumnCount(headerLabels.size());
+    m_tokenList->setHeaderLabels(headerLabels);
+    // The Object + Value columns size to content; intermediate scope
+    // columns get reasonable fixed widths so the table doesn't lurch
+    // every time the user picks a different leaf.
+    auto* hdr = m_tokenList->header();
+    if (hdr) {
+        hdr->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+        for (int i = 1; i < headerLabels.size() - 1; ++i) {
+            hdr->setSectionResizeMode(i, QHeaderView::Stretch);
+        }
+        hdr->setSectionResizeMode(headerLabels.size() - 1,
+                                  QHeaderView::ResizeToContents);
+        hdr->setStretchLastSection(false);
+    }
+    // Stash scope paths on the header column index so populateRow()
+    // can use them to look up the override value at each level.
+    for (int i = 0; i < scopeLevels.size(); ++i) {
+        // header data slot per column: Qt::UserRole carries the path
+        m_tokenList->headerItem()->setData(i + 1, Qt::UserRole, scopeLevels.at(i));
+    }
+}
+
 void ThemeEditorDialog::refreshTokenList()
 {
     m_tokenList->clear();
+    rebuildColumns();
     auto& tm = ThemeManager::instance();
     for (const QString& key : tm.allTokenKeys()) {
         // Editable token namespaces — gradient + scalar colours under
@@ -323,47 +379,97 @@ void ThemeEditorDialog::refreshTokenList()
             && !key.startsWith(QStringLiteral("sizing."))) {
             continue;
         }
-        auto* item = new QListWidgetItem;
-        item->setData(Qt::UserRole, key);
-        m_tokenList->addItem(item);
+        auto* item = new QTreeWidgetItem;
+        item->setData(0, Qt::UserRole, key);
+        m_tokenList->addTopLevelItem(item);
         populateRow(item);
     }
 }
 
-void ThemeEditorDialog::populateRow(QListWidgetItem* item)
+void ThemeEditorDialog::populateRow(QTreeWidgetItem* item)
 {
     if (!item) return;
-    const QString key = item->data(Qt::UserRole).toString();
+    const QString key = item->data(0, Qt::UserRole).toString();
     auto& tm = ThemeManager::instance();
 
+    // Column 0 — Object: token name + swatch.
+    QIcon swatch;
     if (key.startsWith(QStringLiteral("color."))) {
         if (tm.brush(key).gradient()) {
-            const ThemeGradient g = tm.gradient(key);
-            item->setIcon(gradientSwatchIcon(g));
-            item->setText(gradientRowText(key, g));
-            return;
+            swatch = gradientSwatchIcon(tm.gradient(key));
+        } else {
+            swatch = swatchIcon(tm.color(key));
         }
-        const QColor c = tm.color(key);
-        item->setIcon(swatchIcon(c));
-        item->setText(QStringLiteral("%1   %2").arg(key, -36).arg(colorToTokenHex(c)));
-        return;
     }
-    if (key.startsWith(QStringLiteral("font.family."))) {
-        const QString family = tm.value(key);
-        item->setIcon(QIcon());
-        item->setText(QStringLiteral("%1   %2").arg(key, -36).arg(family));
-        return;
+    item->setIcon(0, swatch);
+    item->setText(0, key);
+
+    // Intermediate scope-chain columns (if any).  Each shows either
+    // the literal override stored at that scope, or "inherited" in
+    // italics when the scope inherits from an ancestor.
+    const int nCols = m_tokenList->columnCount();
+    const int lastCol = nCols - 1;
+    const QFont normalFont = m_tokenList->font();
+    QFont inheritedFont = normalFont; inheritedFont.setItalic(true);
+    for (int col = 1; col < lastCol; ++col) {
+        const QString scopePath = m_tokenList->headerItem()->data(col, Qt::UserRole).toString();
+        if (tm.isOverriddenAt(scopePath, key)) {
+            // Format the override succinctly: hex for colours, plain
+            // number / string for sizings and font families.
+            QString text;
+            if (key.startsWith(QStringLiteral("color."))) {
+                if (tm.brush(key).gradient()) {
+                    {
+                    const ThemeGradient g = tm.gradientAt(scopePath, key);
+                    text = g.type == ThemeGradient::Radial
+                        ? QStringLiteral("radial, %1 stops").arg(g.stops.size())
+                        : QStringLiteral("linear, %1°, %2 stops")
+                              .arg(static_cast<int>(std::round(g.angle)))
+                              .arg(g.stops.size());
+                }
+                } else {
+                    text = colorToTokenHex(tm.colorAt(scopePath, key));
+                }
+            } else if (key.startsWith(QStringLiteral("font.family."))) {
+                text = tm.valueAt(scopePath, key);
+            } else {
+                text = QStringLiteral("%1 px").arg(tm.sizingAt(scopePath, key));
+            }
+            item->setText(col, text);
+            item->setFont(col, normalFont);
+            item->setForeground(col, QBrush());
+        } else {
+            item->setText(col, QStringLiteral("inherited"));
+            item->setFont(col, inheritedFont);
+            item->setForeground(col, QBrush(QColor(0x60, 0x70, 0x80)));
+        }
     }
-    if (key.startsWith(QStringLiteral("font.size."))
-        || key.startsWith(QStringLiteral("sizing."))) {
-        const int v = tm.sizing(key);
-        item->setIcon(QIcon());
-        item->setText(QStringLiteral("%1   %2 px").arg(key, -36).arg(v));
-        return;
+
+    // Last column — Value: the resolved value walking the chain from
+    // the leaf container (or root, when no scope is selected).
+    const QString leafPath = m_activeContainerPath;
+    if (key.startsWith(QStringLiteral("color."))) {
+        if (tm.brush(key).gradient()) {
+            {
+                const ThemeGradient g = tm.gradientAt(leafPath, key);
+                const QString text = g.type == ThemeGradient::Radial
+                    ? QStringLiteral("radial, %1 stops").arg(g.stops.size())
+                    : QStringLiteral("linear, %1°, %2 stops")
+                          .arg(static_cast<int>(std::round(g.angle)))
+                          .arg(g.stops.size());
+                item->setText(lastCol, text);
+            }
+        } else {
+            item->setText(lastCol, colorToTokenHex(tm.colorAt(leafPath, key)));
+        }
+    } else if (key.startsWith(QStringLiteral("font.family."))) {
+        item->setText(lastCol, tm.valueAt(leafPath, key));
+    } else {
+        item->setText(lastCol, QStringLiteral("%1 px").arg(tm.sizingAt(leafPath, key)));
     }
 }
 
-void ThemeEditorDialog::updateRow(QListWidgetItem* item)
+void ThemeEditorDialog::updateRow(QTreeWidgetItem* item)
 {
     populateRow(item);
 }
@@ -386,7 +492,7 @@ void ThemeEditorDialog::onTokenRowSelectionChanged()
         m_tokenEditor->setToken(QString());
         return;
     }
-    m_tokenEditor->setToken(item->data(Qt::UserRole).toString());
+    m_tokenEditor->setToken(item->data(0, Qt::UserRole).toString());
 }
 
 void ThemeEditorDialog::onTokenEditedByEditor(const QString& key)
@@ -396,9 +502,9 @@ void ThemeEditorDialog::onTokenEditedByEditor(const QString& key)
     // the edit.  ThemeManager's themeChanged signal already drove a
     // repaint everywhere else; this just keeps the editor's own list
     // consistent.
-    for (int i = 0; i < m_tokenList->count(); ++i) {
-        auto* item = m_tokenList->item(i);
-        if (item->data(Qt::UserRole).toString() == key) {
+    for (int i = 0; i < m_tokenList->topLevelItemCount(); ++i) {
+        auto* item = m_tokenList->topLevelItem(i);
+        if (item->data(0, Qt::UserRole).toString() == key) {
             updateRow(item);
             break;
         }
@@ -633,9 +739,10 @@ void ThemeEditorDialog::onSaveAsBeforeCommit()
     // list highlight matches what the editor is showing.
     const QString committed = m_tokenEditor->currentToken();
     if (!committed.isEmpty()) {
-        for (int i = 0; i < m_tokenList->count(); ++i) {
-            if (m_tokenList->item(i)->data(Qt::UserRole).toString() == committed) {
-                m_tokenList->setCurrentRow(i);
+        for (int i = 0; i < m_tokenList->topLevelItemCount(); ++i) {
+            auto* it = m_tokenList->topLevelItem(i);
+            if (it->data(0, Qt::UserRole).toString() == committed) {
+                m_tokenList->setCurrentItem(it);
                 break;
             }
         }
@@ -722,10 +829,10 @@ void ThemeEditorDialog::onInspectorPicked(QWidget* target, QPoint localPos)
     // inline editor surfaces it immediately — the "click ugly thing →
     // fix it" flow now happens in the editor above instead of a modal.
     if (tokens.size() == 1) {
-        for (int i = 0; i < m_tokenList->count(); ++i) {
-            auto* item = m_tokenList->item(i);
+        for (int i = 0; i < m_tokenList->topLevelItemCount(); ++i) {
+            auto* item = m_tokenList->topLevelItem(i);
             if (item->isHidden()) continue;
-            if (item->data(Qt::UserRole).toString() == tokens.first()) {
+            if (item->data(0, Qt::UserRole).toString() == tokens.first()) {
                 m_tokenList->setCurrentItem(item);
                 break;
             }
@@ -747,9 +854,9 @@ void ThemeEditorDialog::filterTokensTo(const QStringList& subset)
                                ? m_filterEdit->text().trimmed().toLower()
                                : QString();
     const QSet<QString> wanted(subset.begin(), subset.end());
-    for (int i = 0; i < m_tokenList->count(); ++i) {
-        auto* item = m_tokenList->item(i);
-        const QString key = item->data(Qt::UserRole).toString();
+    for (int i = 0; i < m_tokenList->topLevelItemCount(); ++i) {
+        auto* item = m_tokenList->topLevelItem(i);
+        const QString key = item->data(0, Qt::UserRole).toString();
         bool hidden = false;
         if (!subset.isEmpty() && !wanted.contains(key)) hidden = true;
         if (!hidden && !needle.isEmpty() && !key.contains(needle)) hidden = true;
@@ -794,6 +901,10 @@ void ThemeEditorDialog::onContainerChanged(int)
     if (!m_containerCombo) return;
     m_activeContainerPath = m_containerCombo->currentData().toString();
     if (m_tokenEditor) m_tokenEditor->setActiveContainerPath(m_activeContainerPath);
+    // Rebuild columns + repopulate cells — the per-scope override
+    // cells and the resolved-value column both depend on the active
+    // scope's path.
+    refreshTokenList();
 }
 
 void ThemeEditorDialog::onActiveThemeChanged()

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -1,25 +1,24 @@
 #include "ThemeEditorDialog.h"
-#include "GradientEditorDialog.h"
 #include "Theme.h"
 #include "ThemeInspector.h"
+#include "TokenEditorWidget.h"
 #include "core/ThemeManager.h"
 
 #include <QAction>
-#include <QColorDialog>
 #include <QCursor>
 #include <QDragEnterEvent>
 #include <QDropEvent>
 #include <QFileDialog>
 #include <QFileInfo>
-#include <QFontDialog>
 #include <QFontMetrics>
-#include <QMimeData>
-#include <QUrl>
+#include <QFrame>
 #include <QHBoxLayout>
-#include <QLinearGradient>
-#include <QMenu>
 #include <QInputDialog>
 #include <QLabel>
+#include <QLinearGradient>
+#include <QMenu>
+#include <QMimeData>
+#include <QUrl>
 #include <QLineEdit>
 #include <QListWidget>
 #include <QListWidgetItem>
@@ -127,7 +126,10 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     // bodyWidget() with the actual editor controls.  Subclasses are
     // expected to be non-modal — MainWindow's showOrRaisePersistent
     // wires that up + the frameless chrome from AppSettings.
-    setMinimumSize(420, 560);
+    // Size budget — fits CompactColorPicker (~218×220) on the color
+    // page; the gradient page is taller (strip + stop list + picker
+    // + angle row).
+    setMinimumSize(440, 720);
     applyAppTheme(this);
 
     auto* root = new QVBoxLayout(bodyWidget());
@@ -139,6 +141,48 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
         "QLabel { font-weight: bold; }"));
     root->addWidget(m_themeLabel);
 
+    // Inline editor — swaps controls based on the currently selected
+    // token's namespace + value shape.  Sits above the filter + token
+    // list so the operator can see what they're editing without their
+    // gaze jumping to a separate window.  Every control writes live to
+    // ThemeManager, so the rest of the app re-themes as they edit.
+    m_tokenEditor = new TokenEditorWidget(bodyWidget());
+    root->addWidget(m_tokenEditor);
+
+    auto* divider = new QFrame(bodyWidget());
+    divider->setFrameShape(QFrame::HLine);
+    divider->setFrameShadow(QFrame::Sunken);
+    root->addWidget(divider);
+
+    // Inspector toggle row — global event filter; clicking the main UI
+    // surfaces the tokens painting that region into the list below.
+    auto* inspectRow = new QHBoxLayout;
+    m_inspectBtn = new QPushButton(QStringLiteral("🎯  Inspect"), bodyWidget());
+    m_inspectBtn->setCheckable(true);
+    m_inspectBtn->setToolTip(QStringLiteral(
+        "Click, then point at any region of the main UI to find the\n"
+        "token(s) painting it.  ESC cancels."));
+    inspectRow->addWidget(m_inspectBtn);
+    // "Editing: <token>" sits left-aligned right after the Inspect
+    // button.  Inspector status text takes the leftover stretch so
+    // transient messages ("Inspector canceled.") show between the
+    // header and the Reset button without nudging either side.
+    if (auto* hdr = m_tokenEditor->headerLabel()) {
+        inspectRow->addWidget(hdr, 0, Qt::AlignLeft | Qt::AlignVCenter);
+    }
+    m_inspectStatus = new QLabel(bodyWidget());
+    m_inspectStatus->setWordWrap(true);
+    m_inspectStatus->setStyleSheet(QStringLiteral(
+        "QLabel { font-style: italic; }"));
+    inspectRow->addWidget(m_inspectStatus, 1);
+    // Reset button reparents out of the editor's bottom row and sits
+    // right-aligned on the inspect row — keeps the editor's Cancel/OK
+    // pair clean, and Reset stays visible without scrolling.
+    if (auto* reset = m_tokenEditor->resetButton()) {
+        inspectRow->addWidget(reset, 0, Qt::AlignRight);
+    }
+    root->addLayout(inspectRow);
+
     m_filterEdit = new QLineEdit(bodyWidget());
     m_filterEdit->setPlaceholderText(QStringLiteral("Filter tokens (e.g. accent, slice, meter)…"));
     root->addWidget(m_filterEdit);
@@ -148,23 +192,6 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     m_tokenList->setAlternatingRowColors(true);
     m_tokenList->setSelectionMode(QAbstractItemView::SingleSelection);
     root->addWidget(m_tokenList, 1);
-
-    // Inspector toggle row — sits above the filter so it reads as a mode
-    // switch ("am I clicking on the main UI to pick a token?") rather than
-    // a button buried with Save As / Close.
-    auto* inspectRow = new QHBoxLayout;
-    m_inspectBtn = new QPushButton(QStringLiteral("🎯  Inspect"), bodyWidget());
-    m_inspectBtn->setCheckable(true);
-    m_inspectBtn->setToolTip(QStringLiteral(
-        "Click, then point at any region of the main UI to find the\n"
-        "token(s) painting it.  ESC cancels."));
-    inspectRow->addWidget(m_inspectBtn);
-    m_inspectStatus = new QLabel(bodyWidget());
-    m_inspectStatus->setWordWrap(true);
-    m_inspectStatus->setStyleSheet(QStringLiteral(
-        "QLabel { font-style: italic; }"));
-    inspectRow->addWidget(m_inspectStatus, 1);
-    root->addLayout(inspectRow);
 
     auto* btnRow = new QHBoxLayout;
     // Theme-management dropdown — left side, since it's a destructive
@@ -209,8 +236,18 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     updateTitle();
     m_lastRenderedTheme = ThemeManager::instance().activeTheme();
 
-    connect(m_tokenList, &QListWidget::itemClicked,
-            this, &ThemeEditorDialog::onTokenRowClicked);
+    // Selection-driven editing — `currentItemChanged` fires for both
+    // mouse clicks and keyboard navigation so arrow-key walks through
+    // the list also update the inline editor.
+    connect(m_tokenList, &QListWidget::currentItemChanged,
+            this, &ThemeEditorDialog::onTokenRowSelectionChanged);
+    connect(m_tokenEditor, &TokenEditorWidget::tokenChanged,
+            this, &ThemeEditorDialog::onTokenEditedByEditor);
+    // Built-in themes can't be edited in place; the editor stashes
+    // its buffered edit and asks us to run Save As, then we restore
+    // the snapshot into the new user copy.
+    connect(m_tokenEditor, &TokenEditorWidget::requestSaveAsBeforeCommit,
+            this, &ThemeEditorDialog::onSaveAsBeforeCommit);
     connect(m_filterEdit, &QLineEdit::textChanged, this, [this](const QString&) {
         // Re-evaluate visibility against both the text filter and the
         // last inspector-picked subset (if any) — filterTokensTo() reads
@@ -302,134 +339,38 @@ void ThemeEditorDialog::updateRow(QListWidgetItem* item)
 void ThemeEditorDialog::updateTitle()
 {
     const QString name = ThemeManager::instance().activeTheme();
-    m_themeLabel->setText(QStringLiteral("Editing: %1").arg(
+    m_themeLabel->setText(QStringLiteral("Profile: %1").arg(
         name.isEmpty() ? QStringLiteral("(no active theme)") : name));
     setWindowTitle(QStringLiteral("Theme Editor — %1").arg(name));
 }
 
-void ThemeEditorDialog::onTokenRowClicked(QListWidgetItem* item)
+void ThemeEditorDialog::onTokenRowSelectionChanged()
 {
-    if (!item) return;
-    const QString key = item->data(Qt::UserRole).toString();
-    auto& tm = ThemeManager::instance();
+    // Triggered by either mouse click or keyboard navigation on the
+    // token list — load the selected token into the inline editor so
+    // its controls reflect the value and the operator can edit in place.
+    auto* item = m_tokenList->currentItem();
+    if (!item) {
+        m_tokenEditor->setToken(QString());
+        return;
+    }
+    m_tokenEditor->setToken(item->data(Qt::UserRole).toString());
+}
 
-    // Click-menu adapts to the token's namespace + current type:
-    //   * color.*   — flat ↔ gradient chooser
-    //   * font.family.* — font family picker
-    //   * font.size.* / sizing.* — numeric picker
-    // A "Reset to default" entry shows up at the bottom whenever the
-    // token has a factory baseline (every bundled token does).
-    QMenu menu(this);
-    QAction* flatAct   = nullptr;
-    QAction* gradAct   = nullptr;
-    QAction* familyAct = nullptr;
-    QAction* numAct    = nullptr;
-
-    if (key.startsWith(QStringLiteral("color."))) {
-        const bool isGradient = tm.brush(key).gradient() != nullptr;
-        if (isGradient) {
-            gradAct = menu.addAction(QStringLiteral("Edit gradient…"));
-            menu.addSeparator();
-            flatAct = menu.addAction(QStringLiteral("Convert to flat colour…"));
-        } else {
-            flatAct = menu.addAction(QStringLiteral("Edit flat colour…"));
-            menu.addSeparator();
-            gradAct = menu.addAction(QStringLiteral("Convert to gradient…"));
+void ThemeEditorDialog::onTokenEditedByEditor(const QString& key)
+{
+    // The inline editor just wrote a new value for `key` to ThemeManager —
+    // refresh the matching list row so its swatch + descriptor reflect
+    // the edit.  ThemeManager's themeChanged signal already drove a
+    // repaint everywhere else; this just keeps the editor's own list
+    // consistent.
+    for (int i = 0; i < m_tokenList->count(); ++i) {
+        auto* item = m_tokenList->item(i);
+        if (item->data(Qt::UserRole).toString() == key) {
+            updateRow(item);
+            break;
         }
-    } else if (key.startsWith(QStringLiteral("font.family."))) {
-        familyAct = menu.addAction(QStringLiteral("Edit font family…"));
-    } else if (key.startsWith(QStringLiteral("font.size."))
-               || key.startsWith(QStringLiteral("sizing."))) {
-        numAct = menu.addAction(QStringLiteral("Edit size…"));
     }
-
-    QAction* resetAct = nullptr;
-    if (tm.hasFactoryValue(key)) {
-        if (!menu.isEmpty()) menu.addSeparator();
-        resetAct = menu.addAction(QStringLiteral("Reset to default"));
-    }
-
-    QAction* chosen = menu.exec(QCursor::pos());
-    if (!chosen) return;
-    if      (chosen == flatAct)   editTokenAsFlat(key, item);
-    else if (chosen == gradAct)   editTokenAsGradient(key, item);
-    else if (chosen == familyAct) editTokenFontFamily(key, item);
-    else if (chosen == numAct)    editTokenSizing(key, item);
-    else if (chosen == resetAct)  resetTokenToFactory(key, item);
-}
-
-void ThemeEditorDialog::editTokenAsFlat(const QString& key, QListWidgetItem* item)
-{
-    auto& tm = ThemeManager::instance();
-    // ThemeManager::color() returns the first-stop colour when the token
-    // is currently a gradient — exactly the right seed for "I want this
-    // flat now, starting from the dominant gradient colour."
-    const QColor current = tm.color(key);
-    const QColor chosen = QColorDialog::getColor(current, this,
-        QStringLiteral("Edit %1").arg(key),
-        QColorDialog::ShowAlphaChannel);
-    if (!chosen.isValid()) return;
-    tm.setColor(key, chosen);   // overwrites any previous gradient entry
-    updateRow(item);
-}
-
-void ThemeEditorDialog::editTokenAsGradient(const QString& key, QListWidgetItem* item)
-{
-    auto& tm = ThemeManager::instance();
-    ThemeGradient before = tm.gradient(key);
-    if (before.stops.isEmpty()) {
-        // Token is currently flat — seed a 2-stop linear gradient with
-        // the scalar colour at both ends.  The initial render matches
-        // the previous flat output exactly, so opening the editor
-        // doesn't perturb anything until the operator makes a deliberate
-        // edit.  Angle 0 (bottom→top) matches the canonical convention
-        // used by the meter and waterfall gradients.
-        const QColor c = tm.color(key);
-        before.type   = ThemeGradient::Linear;
-        before.angle  = 0.0;
-        before.stops  = { {0.0, c}, {1.0, c} };
-    }
-    GradientEditorDialog dlg(key, before, this);
-    if (dlg.exec() == QDialog::Accepted) {
-        tm.setGradient(key, dlg.currentGradient());  // overwrites any prior scalar
-        updateRow(item);
-    }
-}
-
-void ThemeEditorDialog::editTokenFontFamily(const QString& key,
-                                            QListWidgetItem* item)
-{
-    auto& tm = ThemeManager::instance();
-    const QString currentFamily = tm.value(key);
-    QFont seed;
-    if (!currentFamily.isEmpty()) seed.setFamily(currentFamily);
-
-    bool ok = false;
-    const QFont chosen = QFontDialog::getFont(&ok, seed, this,
-        QStringLiteral("Edit %1").arg(key));
-    if (!ok) return;
-    tm.setString(key, chosen.family());
-    updateRow(item);
-}
-
-void ThemeEditorDialog::editTokenSizing(const QString& key,
-                                        QListWidgetItem* item)
-{
-    auto& tm = ThemeManager::instance();
-    const int current = tm.sizing(key);
-    // Integer tokens span both font.size.* and sizing.*; allow a generous
-    // range and let the QSpinBox handle clamping.  Range chosen to cover
-    // realistic font sizes (4–96 px) and panel paddings (0–48 px) in one
-    // input — at the cost of letting a user dial a 96-px panel padding
-    // if they really want one.
-    bool ok = false;
-    const int chosen = QInputDialog::getInt(this,
-        QStringLiteral("Edit %1").arg(key),
-        QStringLiteral("Value (px):"),
-        current, 0, 96, 1, &ok);
-    if (!ok) return;
-    tm.setSizing(key, chosen);
-    updateRow(item);
 }
 
 void ThemeEditorDialog::onRenameThemeClicked()
@@ -569,34 +510,6 @@ void ThemeEditorDialog::onDeleteThemeClicked()
     }
 }
 
-void ThemeEditorDialog::resetTokenToFactory(const QString& key,
-                                            QListWidgetItem* item)
-{
-    auto& tm = ThemeManager::instance();
-    if (!tm.hasFactoryValue(key)) return;
-
-    if (key.startsWith(QStringLiteral("color."))) {
-        // Gradients restore through setGradient; scalars through setColor.
-        // The factory snapshot lookup goes through factoryGradient first,
-        // falls back to factoryColor.  An empty gradient with a valid
-        // factoryColor means the factory baseline is a scalar.
-        const ThemeGradient g = tm.factoryGradient(key);
-        if (!g.stops.isEmpty()) {
-            tm.setGradient(key, g);
-        } else {
-            const QColor c = tm.factoryColor(key);
-            if (c.isValid()) tm.setColor(key, c);
-        }
-    } else if (key.startsWith(QStringLiteral("font.family."))) {
-        const QString f = tm.factoryString(key);
-        if (!f.isEmpty()) tm.setString(key, f);
-    } else if (key.startsWith(QStringLiteral("font.size."))
-               || key.startsWith(QStringLiteral("sizing."))) {
-        const int v = tm.factorySizing(key);
-        if (v >= 0) tm.setSizing(key, v);
-    }
-    updateRow(item);
-}
 
 void ThemeEditorDialog::onSaveAsClicked()
 {
@@ -632,6 +545,69 @@ void ThemeEditorDialog::onSaveAsClicked()
     }
     // saveCurrentThemeAs() makes the new theme active; onActiveThemeChanged
     // will fire from themeChanged and refresh the title.
+}
+
+void ThemeEditorDialog::onSaveAsBeforeCommit()
+{
+    auto& tm = ThemeManager::instance();
+    const QString current = tm.activeTheme();
+    if (!tm.isBuiltInTheme(current)) {
+        // Race / stale signal — nothing to fork, just complete the
+        // commit directly.
+        m_tokenEditor->completeDeferredCommit();
+        return;
+    }
+
+    bool ok = false;
+    QString suggestion = QStringLiteral("My %1").arg(current);
+    const QString name = QInputDialog::getText(this,
+        QStringLiteral("Save Theme As"),
+        QStringLiteral("\"%1\" is a built-in theme and can't be modified "
+                       "directly.\nSave your changes as a new theme:")
+            .arg(current),
+        QLineEdit::Normal, suggestion, &ok).trimmed();
+    if (!ok || name.isEmpty()) return;  // user cancelled — buffer stays uncommitted
+
+    // Disallow accidentally writing to another built-in or overwriting
+    // an existing user theme without confirmation.
+    if (tm.isBuiltInTheme(name)) {
+        QMessageBox::warning(this, QStringLiteral("Reserved name"),
+            QStringLiteral("\"%1\" is a built-in theme name and can't be used.")
+                .arg(name));
+        return;
+    }
+    const QStringList existing = tm.availableThemes();
+    if (existing.contains(name)) {
+        const auto reply = QMessageBox::question(this,
+            QStringLiteral("Theme exists"),
+            QStringLiteral("A theme named \"%1\" already exists. Overwrite it?").arg(name),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        if (reply != QMessageBox::Yes) return;
+    }
+
+    if (!tm.saveCurrentThemeAs(name)) {
+        QMessageBox::warning(this, QStringLiteral("Save failed"),
+            QStringLiteral("Could not write the theme file. Check that "
+                           "~/.config/AetherSDR/themes/ is writable."));
+        return;
+    }
+    // saveCurrentThemeAs() has switched the active theme and refreshed
+    // the list (clearing the editor's selection in the process).  The
+    // editor stashed its buffer in DeferredEdit before emitting; tell
+    // it to write that into the new user copy now.
+    m_tokenEditor->completeDeferredCommit();
+
+    // Re-select the row that matches the just-committed token so the
+    // list highlight matches what the editor is showing.
+    const QString committed = m_tokenEditor->currentToken();
+    if (!committed.isEmpty()) {
+        for (int i = 0; i < m_tokenList->count(); ++i) {
+            if (m_tokenList->item(i)->data(Qt::UserRole).toString() == committed) {
+                m_tokenList->setCurrentRow(i);
+                break;
+            }
+        }
+    }
 }
 
 void ThemeEditorDialog::onInspectToggled(bool on)
@@ -710,15 +686,15 @@ void ThemeEditorDialog::onInspectorPicked(QWidget* target, QPoint localPos)
             .arg(tokens.size()).arg(tokens.size() == 1 ? "" : "s"));
     }
 
-    // Convenience: if exactly one color token matched, open the picker
-    // straight away — that's the "click ugly thing → fix it" flow.
+    // Convenience: if exactly one token matched, select it so the
+    // inline editor surfaces it immediately — the "click ugly thing →
+    // fix it" flow now happens in the editor above instead of a modal.
     if (tokens.size() == 1) {
         for (int i = 0; i < m_tokenList->count(); ++i) {
             auto* item = m_tokenList->item(i);
             if (item->isHidden()) continue;
             if (item->data(Qt::UserRole).toString() == tokens.first()) {
                 m_tokenList->setCurrentItem(item);
-                onTokenRowClicked(item);
                 break;
             }
         }

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -105,17 +105,6 @@ QIcon gradientSwatchIcon(const ThemeGradient& g)
 
 // Build the short text shown on a gradient row: "N stops, Xdeg" so the
 // list stays scannable without having to open every gradient.
-QString gradientRowText(const QString& key, const ThemeGradient& g)
-{
-    const QString kind = g.type == ThemeGradient::Radial
-                             ? QStringLiteral("radial")
-                             : QStringLiteral("linear, %1°").arg(
-                                   static_cast<int>(std::round(g.angle)));
-    return QStringLiteral("%1   %2, %3 stops")
-        .arg(key, -36)
-        .arg(kind)
-        .arg(g.stops.size());
-}
 } // namespace
 
 ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
@@ -137,7 +126,7 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     // Container declaration — places this dialog under the "dialog"
     // umbrella so step 3's editor UI can navigate from root → dialog →
     // dialog.themeEditor when rendering its own scope tree.
-    theme::setContainer(this, QStringLiteral("dialog.themeEditor"));
+    theme::setContainer(this, QStringLiteral("dialog/themeEditor"));
 
     auto* root = new QVBoxLayout(bodyWidget());
     root->setContentsMargins(8, 8, 8, 8);

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -952,6 +952,10 @@ void ThemeEditorDialog::onTokenContextMenu(const QPoint& pos)
     if (column <= 0 || column >= m_tokenList->columnCount() - 1) return;
     const QString scopePath =
         m_tokenList->headerItem()->data(column, Qt::UserRole).toString();
+    // Root column has no parent to fall back to — "clear" there would
+    // delete the token tree-wide.  Reset-to-factory belongs to the
+    // dedicated Reset button on the inspect row.
+    if (scopePath.isEmpty()) return;
     const QString token = item->data(0, Qt::UserRole).toString();
     auto& tm = ThemeManager::instance();
     if (!tm.isOverriddenAt(scopePath, token)) return;  // nothing to clear

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -189,11 +189,9 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     if (auto* hdr = m_tokenEditor->headerLabel()) {
         inspectRow->addWidget(hdr, 0, Qt::AlignLeft | Qt::AlignVCenter);
     }
-    m_inspectStatus = new QLabel(bodyWidget());
-    m_inspectStatus->setWordWrap(true);
-    m_inspectStatus->setStyleSheet(QStringLiteral(
-        "QLabel { font-style: italic; }"));
-    inspectRow->addWidget(m_inspectStatus, 1);
+    // Stretch spacer absorbs slack between the header and the Reset
+    // button now that the inspector status has moved to the filter row.
+    inspectRow->addStretch(1);
     // Reset button reparents out of the editor's bottom row and sits
     // right-aligned on the inspect row — keeps the editor's Cancel/OK
     // pair clean, and Reset stays visible without scrolling.
@@ -202,9 +200,21 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     }
     root->addLayout(inspectRow);
 
+    // Filter input + inspector status share one row: filter is clamped
+    // to ~50% of the body width, status takes the rest so transient
+    // inspector messages have room to render without spilling.
+    auto* filterRow = new QHBoxLayout;
+    filterRow->setSpacing(8);
     m_filterEdit = new QLineEdit(bodyWidget());
     m_filterEdit->setPlaceholderText(QStringLiteral("Filter tokens (e.g. accent, slice, meter)…"));
-    root->addWidget(m_filterEdit);
+    m_filterEdit->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    filterRow->addWidget(m_filterEdit, 1);
+    m_inspectStatus = new QLabel(bodyWidget());
+    m_inspectStatus->setWordWrap(true);
+    m_inspectStatus->setStyleSheet(QStringLiteral(
+        "QLabel { font-style: italic; }"));
+    filterRow->addWidget(m_inspectStatus, 1);
+    root->addLayout(filterRow);
 
     m_tokenList = new QListWidget(bodyWidget());
     m_tokenList->setIconSize(QSize(18, 18));

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -132,6 +132,11 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     setMinimumSize(440, 720);
     applyAppTheme(this);
 
+    // Container declaration — places this dialog under the "dialog"
+    // umbrella so step 3's editor UI can navigate from root → dialog →
+    // dialog.themeEditor when rendering its own scope tree.
+    theme::setContainer(this, QStringLiteral("dialog.themeEditor"));
+
     auto* root = new QVBoxLayout(bodyWidget());
     root->setContentsMargins(8, 8, 8, 8);
     root->setSpacing(6);

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -268,6 +268,14 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     // the list also update the inline editor.
     connect(m_tokenList, &QTreeWidget::currentItemChanged,
             this, &ThemeEditorDialog::onTokenRowSelectionChanged);
+    // Click on a scope-column cell focuses that scope in the picker AND
+    // selects the row's token — the columnar view becomes the primary
+    // navigation surface instead of being read-only.
+    connect(m_tokenList, &QTreeWidget::itemClicked,
+            this, &ThemeEditorDialog::onTokenCellClicked);
+    m_tokenList->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(m_tokenList, &QTreeWidget::customContextMenuRequested,
+            this, &ThemeEditorDialog::onTokenContextMenu);
     connect(m_tokenEditor, &TokenEditorWidget::tokenChanged,
             this, &ThemeEditorDialog::onTokenEditedByEditor);
     // Built-in themes can't be edited in place; the editor stashes
@@ -894,6 +902,57 @@ void ThemeEditorDialog::onContainerChanged(int)
     // cells and the resolved-value column both depend on the active
     // scope's path.
     refreshTokenList();
+}
+
+void ThemeEditorDialog::onTokenCellClicked(QTreeWidgetItem* item, int column)
+{
+    if (!item || !m_tokenList) return;
+    if (column == 0) return;                                  // Object column: already wired via currentItemChanged
+    if (column == m_tokenList->columnCount() - 1) return;     // Value column: just informational
+    // Scope-chain column — switch the active scope to that column's
+    // path so the editor's commit lands there.  The user's perspective
+    // becomes "I want to override this token at this exact scope".
+    const QString scopePath =
+        m_tokenList->headerItem()->data(column, Qt::UserRole).toString();
+    // Sync the picker, which fires onContainerChanged → updates the
+    // editor + columns + repopulates the rows.
+    const int idx = m_containerCombo
+                        ? m_containerCombo->findData(scopePath)
+                        : -1;
+    if (idx >= 0) m_containerCombo->setCurrentIndex(idx);
+    // After the picker change re-selects the previous current row,
+    // explicitly re-select this row so the editor reflects the clicked
+    // token (the refresh may have lost the highlight).
+    m_tokenList->setCurrentItem(item);
+}
+
+void ThemeEditorDialog::onTokenContextMenu(const QPoint& pos)
+{
+    if (!m_tokenList) return;
+    QTreeWidgetItem* item = m_tokenList->itemAt(pos);
+    if (!item) return;
+    const int column = m_tokenList->columnAt(pos.x());
+    // Right-click is only meaningful on a scope-chain column (not
+    // Object, not Value) where an actual override could exist.
+    if (column <= 0 || column >= m_tokenList->columnCount() - 1) return;
+    const QString scopePath =
+        m_tokenList->headerItem()->data(column, Qt::UserRole).toString();
+    const QString token = item->data(0, Qt::UserRole).toString();
+    auto& tm = ThemeManager::instance();
+    if (!tm.isOverriddenAt(scopePath, token)) return;  // nothing to clear
+
+    const QString scopeLabel = scopePath.isEmpty()
+                                   ? QStringLiteral("(root)")
+                                   : scopePath;
+    QMenu menu(this);
+    QAction* clearAct = menu.addAction(
+        QStringLiteral("Clear override at %1").arg(scopeLabel));
+    QAction* picked = menu.exec(m_tokenList->viewport()->mapToGlobal(pos));
+    if (picked == clearAct) {
+        tm.removeOverride(scopePath, token);
+        // Refresh the row so the column flips back to italic "inherited".
+        populateRow(item);
+    }
 }
 
 void ThemeEditorDialog::onActiveThemeChanged()

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -186,12 +186,13 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     // button.  Inspector status text takes the leftover stretch so
     // transient messages ("Inspector canceled.") show between the
     // header and the Reset button without nudging either side.
-    if (auto* hdr = m_tokenEditor->headerLabel()) {
-        inspectRow->addWidget(hdr, 0, Qt::AlignLeft | Qt::AlignVCenter);
-    }
-    // Stretch spacer absorbs slack between the header and the Reset
-    // button now that the inspector status has moved to the filter row.
-    inspectRow->addStretch(1);
+    // Inspector status sits on the inspect row in transient-message
+    // territory; Editing label moves down to the filter row.
+    m_inspectStatus = new QLabel(bodyWidget());
+    m_inspectStatus->setWordWrap(true);
+    m_inspectStatus->setStyleSheet(QStringLiteral(
+        "QLabel { font-style: italic; }"));
+    inspectRow->addWidget(m_inspectStatus, 1);
     // Reset button reparents out of the editor's bottom row and sits
     // right-aligned on the inspect row — keeps the editor's Cancel/OK
     // pair clean, and Reset stays visible without scrolling.
@@ -200,20 +201,18 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     }
     root->addLayout(inspectRow);
 
-    // Filter input + inspector status share one row: filter is clamped
-    // to ~50% of the body width, status takes the rest so transient
-    // inspector messages have room to render without spilling.
+    // Filter input + "Editing: <token>" header share one row: filter
+    // is clamped to ~50% of the body width, header takes the rest so
+    // its single-line layout always has the room it needs to render.
     auto* filterRow = new QHBoxLayout;
     filterRow->setSpacing(8);
     m_filterEdit = new QLineEdit(bodyWidget());
     m_filterEdit->setPlaceholderText(QStringLiteral("Filter tokens (e.g. accent, slice, meter)…"));
     m_filterEdit->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     filterRow->addWidget(m_filterEdit, 1);
-    m_inspectStatus = new QLabel(bodyWidget());
-    m_inspectStatus->setWordWrap(true);
-    m_inspectStatus->setStyleSheet(QStringLiteral(
-        "QLabel { font-style: italic; }"));
-    filterRow->addWidget(m_inspectStatus, 1);
+    if (auto* hdr = m_tokenEditor->headerLabel()) {
+        filterRow->addWidget(hdr, 1, Qt::AlignLeft | Qt::AlignVCenter);
+    }
     root->addLayout(filterRow);
 
     m_tokenList = new QListWidget(bodyWidget());

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -5,6 +5,7 @@
 #include "core/ThemeManager.h"
 
 #include <QAction>
+#include <QComboBox>
 #include <QCursor>
 #include <QDragEnterEvent>
 #include <QDropEvent>
@@ -188,6 +189,21 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     }
     root->addLayout(inspectRow);
 
+    // Container scope picker.  Selecting a non-root container scopes
+    // subsequent OK commits to that container — TokenEditorWidget routes
+    // setColor / setSizing / setGradient / setString through the
+    // scope-aware overloads when m_activeContainerPath is non-empty.
+    auto* containerRow = new QHBoxLayout;
+    containerRow->setSpacing(6);
+    containerRow->addWidget(new QLabel(QStringLiteral("Scope:"), bodyWidget()));
+    m_containerCombo = new QComboBox(bodyWidget());
+    m_containerCombo->setToolTip(QStringLiteral(
+        "Container scope to edit.  \"(root)\" is the global namespace.\n"
+        "Selecting a nested scope (e.g. applet.tx) routes new overrides\n"
+        "into that scope, and only widgets inside that container see them."));
+    containerRow->addWidget(m_containerCombo, 1);
+    root->addLayout(containerRow);
+
     m_filterEdit = new QLineEdit(bodyWidget());
     m_filterEdit->setPlaceholderText(QStringLiteral("Filter tokens (e.g. accent, slice, meter)…"));
     root->addWidget(m_filterEdit);
@@ -237,6 +253,7 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     // outermost dialog has setAcceptDrops(true).
     setAcceptDrops(true);
 
+    refreshContainerCombo();
     refreshTokenList();
     updateTitle();
     m_lastRenderedTheme = ThemeManager::instance().activeTheme();
@@ -253,6 +270,9 @@ ThemeEditorDialog::ThemeEditorDialog(QWidget* parent)
     // the snapshot into the new user copy.
     connect(m_tokenEditor, &TokenEditorWidget::requestSaveAsBeforeCommit,
             this, &ThemeEditorDialog::onSaveAsBeforeCommit);
+    connect(m_containerCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &ThemeEditorDialog::onContainerChanged);
+
     connect(m_filterEdit, &QLineEdit::textChanged, this, [this](const QString&) {
         // Re-evaluate visibility against both the text filter and the
         // last inspector-picked subset (if any) — filterTokensTo() reads
@@ -730,6 +750,31 @@ void ThemeEditorDialog::filterTokensTo(const QStringList& subset)
     }
 }
 
+void ThemeEditorDialog::refreshContainerCombo()
+{
+    if (!m_containerCombo) return;
+    QSignalBlocker block(m_containerCombo);
+    m_containerCombo->clear();
+    // Friendlier label for the empty (root) path so the dropdown is
+    // self-explanatory; userData carries the real path string.
+    m_containerCombo->addItem(QStringLiteral("(root)"), QString());
+    for (const QString& path : ThemeManager::instance().containerPaths()) {
+        if (path.isEmpty()) continue;  // already added as "(root)"
+        m_containerCombo->addItem(path, path);
+    }
+    // Restore previous selection by path string, falling back to root.
+    int idx = m_containerCombo->findData(m_activeContainerPath);
+    if (idx < 0) idx = 0;
+    m_containerCombo->setCurrentIndex(idx);
+}
+
+void ThemeEditorDialog::onContainerChanged(int)
+{
+    if (!m_containerCombo) return;
+    m_activeContainerPath = m_containerCombo->currentData().toString();
+    if (m_tokenEditor) m_tokenEditor->setActiveContainerPath(m_activeContainerPath);
+}
+
 void ThemeEditorDialog::onActiveThemeChanged()
 {
     // themeChanged fires for BOTH "user switched active theme" (View →
@@ -745,6 +790,7 @@ void ThemeEditorDialog::onActiveThemeChanged()
     updateTitle();
     if (current != m_lastRenderedTheme) {
         m_lastRenderedTheme = current;
+        refreshContainerCombo();
         refreshTokenList();
     }
 }

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -777,6 +777,16 @@ void ThemeEditorDialog::onInspectorPicked(QWidget* target, QPoint localPos)
     if (!target) return;
     auto& tm = ThemeManager::instance();
 
+    // Auto-select the picked widget's container scope so any subsequent
+    // edit lands at the right level of the inheritance chain.  Walks
+    // `target`'s Qt parent chain to the nearest declared `themeContainer`
+    // (the same lookup widget-aware getters use for token resolution).
+    const QString pickedScope = tm.containerPathFor(target);
+    if (m_containerCombo) {
+        const int idx = m_containerCombo->findData(pickedScope);
+        if (idx >= 0) m_containerCombo->setCurrentIndex(idx);
+    }
+
     // Walk up the parent chain until we find a widget with a declared
     // token list — that's how a click on a deep child (e.g. the QLabel
     // inside a QPushButton inside a themed panel) still surfaces the
@@ -812,14 +822,19 @@ void ThemeEditorDialog::onInspectorPicked(QWidget* target, QPoint localPos)
     filterTokensTo(tokens);
 
     const QString matchedClass = w ? w->metaObject()->className() : hitName;
+    const QString scopeSuffix = pickedScope.isEmpty()
+        ? QString()
+        : QStringLiteral("  ·  scope: %1").arg(pickedScope);
     if (w && w != target) {
         updateInspectorStatus(QStringLiteral(
-            "%1 (via %2): %3 token%4.").arg(matchedClass).arg(hitName)
-            .arg(tokens.size()).arg(tokens.size() == 1 ? "" : "s"));
+            "%1 (via %2): %3 token%4.%5").arg(matchedClass).arg(hitName)
+            .arg(tokens.size()).arg(tokens.size() == 1 ? "" : "s")
+            .arg(scopeSuffix));
     } else {
         updateInspectorStatus(QStringLiteral(
-            "%1: %2 token%3.").arg(matchedClass)
-            .arg(tokens.size()).arg(tokens.size() == 1 ? "" : "s"));
+            "%1: %2 token%3.%4").arg(matchedClass)
+            .arg(tokens.size()).arg(tokens.size() == 1 ? "" : "s")
+            .arg(scopeSuffix));
     }
 
     // Convenience: if exactly one token matched, select it so the

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -7,6 +7,7 @@
 #include <QAction>
 #include <QComboBox>
 #include <QCursor>
+#include <QTimer>
 #include <QDragEnterEvent>
 #include <QDropEvent>
 #include <QFileDialog>
@@ -913,10 +914,16 @@ void ThemeEditorDialog::onContainerChanged(int)
     if (!m_containerCombo) return;
     m_activeContainerPath = m_containerCombo->currentData().toString();
     if (m_tokenEditor) m_tokenEditor->setActiveContainerPath(m_activeContainerPath);
-    // Rebuild columns + repopulate cells — the per-scope override
-    // cells and the resolved-value column both depend on the active
-    // scope's path.
-    refreshTokenList();
+    // Defer the heavy rebuild to the next event-loop tick.  When the
+    // inspector triggers a scope change via setCurrentIndex, the slot
+    // runs inside the synchronous signal cascade from
+    // ThemeInspector::eventFilter → widgetPicked → onInspectorPicked
+    // → setCurrentIndex; tearing down QTreeWidgetItems (and their
+    // QPixmap-backed icon QVariants) inside that stack has hit a
+    // destructor SEGV in the wild.  Deferring breaks the chain — the
+    // inspector callback completes, and the rebuild runs from a
+    // clean stack on the next iteration.
+    QTimer::singleShot(0, this, &ThemeEditorDialog::refreshTokenList);
 }
 
 void ThemeEditorDialog::onTokenCellClicked(QTreeWidgetItem* item, int column)

--- a/src/gui/ThemeEditorDialog.h
+++ b/src/gui/ThemeEditorDialog.h
@@ -6,8 +6,8 @@
 
 class QDragEnterEvent;
 class QDropEvent;
-class QListWidget;
-class QListWidgetItem;
+class QTreeWidget;
+class QTreeWidgetItem;
 class QLabel;
 class QComboBox;
 class QLineEdit;
@@ -71,8 +71,9 @@ protected:
 
 private:
     void updateTitle();
-    void updateRow(QListWidgetItem* item);   // re-paint swatch + hex label
-    void populateRow(QListWidgetItem* item); // shared by refresh + update
+    void updateRow(QTreeWidgetItem* item);   // re-paint swatch + hex label
+    void populateRow(QTreeWidgetItem* item); // shared by refresh + update
+    void rebuildColumns();                   // adjust column count + headers to active scope
     void updateInspectorStatus(const QString& text);
     // Filter the token list down to a specific subset, e.g. tokens
     // returned by tokensForWidget().  An empty list clears the filter.
@@ -82,7 +83,7 @@ private:
     TokenEditorWidget* m_tokenEditor{nullptr};   // inline editor stack
     QComboBox*   m_containerCombo{nullptr};   // scope picker — root + declared paths
     QLineEdit*   m_filterEdit{nullptr};   // type-to-filter token names
-    QListWidget* m_tokenList{nullptr};
+    QTreeWidget* m_tokenList{nullptr};   // multi-column: Object | <scope chain…> | Value
     void         refreshContainerCombo();
     QString      m_activeContainerPath;  // empty == root scope
     QPushButton* m_saveAsBtn{nullptr};

--- a/src/gui/ThemeEditorDialog.h
+++ b/src/gui/ThemeEditorDialog.h
@@ -48,6 +48,13 @@ private slots:
     void onSaveAsBeforeCommit();     // fork built-in theme before committing an edit
     void onActiveThemeChanged();     // re-load when user picks a different theme
     void onContainerChanged(int);    // user picked a different scope from the container combo
+    // Click a scope-column cell in the columnar token table → focus
+    // that scope in the picker AND select the row's token for editing.
+    void onTokenCellClicked(QTreeWidgetItem* item, int column);
+    // Right-click a scope-column cell → context menu with
+    // "Clear override at <scope>" (enabled only when an override
+    // actually exists at that level for the row's token).
+    void onTokenContextMenu(const QPoint& pos);
 
     // Inspector-mode handlers.
     void onInspectToggled(bool on);

--- a/src/gui/ThemeEditorDialog.h
+++ b/src/gui/ThemeEditorDialog.h
@@ -9,6 +9,7 @@ class QDropEvent;
 class QListWidget;
 class QListWidgetItem;
 class QLabel;
+class QComboBox;
 class QLineEdit;
 class QPushButton;
 
@@ -46,6 +47,7 @@ private slots:
     void onSaveAsClicked();
     void onSaveAsBeforeCommit();     // fork built-in theme before committing an edit
     void onActiveThemeChanged();     // re-load when user picks a different theme
+    void onContainerChanged(int);    // user picked a different scope from the container combo
 
     // Inspector-mode handlers.
     void onInspectToggled(bool on);
@@ -78,8 +80,11 @@ private:
 
     QLabel*      m_themeLabel{nullptr};   // "Editing: <name>"
     TokenEditorWidget* m_tokenEditor{nullptr};   // inline editor stack
+    QComboBox*   m_containerCombo{nullptr};   // scope picker — root + declared paths
     QLineEdit*   m_filterEdit{nullptr};   // type-to-filter token names
     QListWidget* m_tokenList{nullptr};
+    void         refreshContainerCombo();
+    QString      m_activeContainerPath;  // empty == root scope
     QPushButton* m_saveAsBtn{nullptr};
     QPushButton* m_inspectBtn{nullptr};   // checkable
     QLabel*      m_inspectStatus{nullptr};

--- a/src/gui/ThemeEditorDialog.h
+++ b/src/gui/ThemeEditorDialog.h
@@ -15,6 +15,7 @@ class QPushButton;
 namespace AetherSDR {
 
 class ThemeInspector;
+class TokenEditorWidget;
 
 // Modeless dialog for live-editing the active theme's color tokens.
 //
@@ -40,8 +41,10 @@ public:
 
 private slots:
     void refreshTokenList();         // rebuild rows from ThemeManager
-    void onTokenRowClicked(QListWidgetItem* item);
+    void onTokenRowSelectionChanged();
+    void onTokenEditedByEditor(const QString& key);
     void onSaveAsClicked();
+    void onSaveAsBeforeCommit();     // fork built-in theme before committing an edit
     void onActiveThemeChanged();     // re-load when user picks a different theme
 
     // Inspector-mode handlers.
@@ -49,19 +52,8 @@ private slots:
     void onInspectorPicked(QWidget* target, QPoint localPos);
     void onInspectorActiveChanged(bool active);
 
-    // Routes wired from the type-chooser menu in onTokenRowClicked.
-    // editTokenAsFlat falls back to the first-stop colour when the token
-    // is currently a gradient.  editTokenAsGradient seeds a 2-stop
-    // gradient from the scalar value when the token is currently flat,
-    // so the initial visual output matches the previous flat colour.
-    void editTokenAsFlat(const QString& key, QListWidgetItem* item);
-    void editTokenAsGradient(const QString& key, QListWidgetItem* item);
-    void editTokenFontFamily(const QString& key, QListWidgetItem* item);
-    void editTokenSizing(const QString& key, QListWidgetItem* item);
-    void resetTokenToFactory(const QString& key, QListWidgetItem* item);
-
     // Theme-file management — Rename / Delete / Export / Import on the
-    // "Theme actions ▾" menu next to Save As.
+    // "Theme actions" menu next to Save As.
     void onRenameThemeClicked();
     void onDeleteThemeClicked();
     void onExportThemeClicked();
@@ -85,6 +77,7 @@ private:
     void filterTokensTo(const QStringList& subset);
 
     QLabel*      m_themeLabel{nullptr};   // "Editing: <name>"
+    TokenEditorWidget* m_tokenEditor{nullptr};   // inline editor stack
     QLineEdit*   m_filterEdit{nullptr};   // type-to-filter token names
     QListWidget* m_tokenList{nullptr};
     QPushButton* m_saveAsBtn{nullptr};

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -100,6 +100,7 @@ QPixmap buildPopOutIcon(bool active)
 TitleBar::TitleBar(QWidget* parent)
     : QWidget(parent)
 {
+    AetherSDR::theme::setContainer(this, QStringLiteral("titlebar"));
     setFixedHeight(32);
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "TitleBar { background: {{color.background.0}}; border-bottom: 1px solid {{color.background.1}}; }");
 

--- a/src/gui/TokenEditorWidget.cpp
+++ b/src/gui/TokenEditorWidget.cpp
@@ -223,10 +223,14 @@ void TokenEditorWidget::buildFontGroup(QVBoxLayout* root)
     row->addWidget(m_fontCombo);
 
     m_fontSizeCombo = new QComboBox(this);
-    // Hard-capped at 20 px — anything bigger overflows the freq display
-    // glyph cell, meter labels, and several status-row widgets that
-    // assume small/normal/large stays within their reserved height.
-    for (int sz : {7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20}) {
+    // Preset sizes — the 7-20 range covers `font.size.tiny/small/normal/large`
+    // (those scalar tokens are still hard-capped at 20 to keep label
+    // rows from overflowing).  Larger sizes are for the compound
+    // `font.family.<role>.size` field; the freq label defaults to 26
+    // and segment displays often go to 36+.  Bump clamps differ per
+    // target — see onFontSizeBumpUp/Down().
+    for (int sz : {7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20,
+                   24, 28, 32, 36, 48, 60, 72}) {
         m_fontSizeCombo->addItem(QStringLiteral("%1 pt").arg(sz),
                                  QVariant(sz));
     }
@@ -1080,28 +1084,37 @@ void TokenEditorWidget::onFontSizeChanged(int v)
         // font.size.* / sizing.* token — the size combo IS the editor.
         m_bufferNumeric = v;
         markDirty();
+    } else if (m_target == TargetFontFamily) {
+        // font.family.* is now a compound (family + size + color), so
+        // the size combo IS part of what we commit.  Mark dirty so the
+        // OK button activates and commitBufferToThemeManager writes
+        // the new ThemeFont with the picked size.
+        markDirty();
     }
-    // For font.family.* tokens the combo is purely informational so
-    // there's nothing to mark dirty — operator must pick the
-    // corresponding font.size.* token to actually commit a size change.
 }
 
 void TokenEditorWidget::onFontSizeBumpUp()
 {
-    m_bufferFontSize = std::clamp(m_bufferFontSize + 1, 7, 20);
+    // font.size.*/sizing.* scalar tokens stay capped at 20 — overflowing
+    // those breaks status-row labels.  font.family.* compounds can go
+    // larger (the freq compound is 26 by default, segment displays
+    // commonly run to 36-48).
+    const int hi = (m_target == TargetFontFamily) ? 96 : 20;
+    m_bufferFontSize = std::clamp(m_bufferFontSize + 1, 7, hi);
     syncFontSizeComboToBuffer(m_bufferFontSize);
-    if (m_target == TargetNumeric) {
-        m_bufferNumeric = m_bufferFontSize;
+    if (m_target == TargetNumeric || m_target == TargetFontFamily) {
+        if (m_target == TargetNumeric) m_bufferNumeric = m_bufferFontSize;
         markDirty();
     }
 }
 
 void TokenEditorWidget::onFontSizeBumpDown()
 {
-    m_bufferFontSize = std::clamp(m_bufferFontSize - 1, 7, 20);
+    const int hi = (m_target == TargetFontFamily) ? 96 : 20;
+    m_bufferFontSize = std::clamp(m_bufferFontSize - 1, 7, hi);
     syncFontSizeComboToBuffer(m_bufferFontSize);
-    if (m_target == TargetNumeric) {
-        m_bufferNumeric = m_bufferFontSize;
+    if (m_target == TargetNumeric || m_target == TargetFontFamily) {
+        if (m_target == TargetNumeric) m_bufferNumeric = m_bufferFontSize;
         markDirty();
     }
 }

--- a/src/gui/TokenEditorWidget.cpp
+++ b/src/gui/TokenEditorWidget.cpp
@@ -1,0 +1,1218 @@
+#include "TokenEditorWidget.h"
+#include "CompactColorPicker.h"
+#include "GradientEditorDialog.h"  // re-uses GradientStrip class
+#include "core/AppSettings.h"
+
+#include <QButtonGroup>
+#include <QComboBox>
+#include <QFontComboBox>
+#include <QFrame>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QMessageBox>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QSignalBlocker>
+#include <QSpinBox>
+#include <QStringList>
+#include <QToolButton>
+#include <QVBoxLayout>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+QString colorToTokenHex(const QColor& c)
+{
+    return c.alpha() == 255 ? c.name(QColor::HexRgb)
+                            : c.name(QColor::HexArgb);
+}
+
+// Paint a 28x24 rounded swatch with the standard 8 px checkerboard
+// under a translucent colour fill — mirrors CompactColorPicker's hex
+// swatch (so the recent-colors row visually matches that swatch).
+QPixmap makeRecentSwatchPixmap(const QColor& c, const QSize& sz)
+{
+    QPixmap pm(sz);
+    pm.fill(Qt::transparent);
+    QPainter p(&pm);
+    p.setRenderHint(QPainter::Antialiasing);
+    QPainterPath clip;
+    clip.addRoundedRect(
+        QRectF(0.5, 0.5, sz.width() - 1.0, sz.height() - 1.0), 3, 3);
+    p.save();
+    p.setClipPath(clip);
+    constexpr int tile = 6;
+    for (int y = 0; y < sz.height(); y += tile) {
+        for (int x = 0; x < sz.width(); x += tile) {
+            const bool dark = ((x / tile + y / tile) & 1) == 0;
+            p.fillRect(QRect(x, y, tile, tile),
+                       dark ? QColor(0x80, 0x80, 0x80)
+                            : QColor(0xc8, 0xc8, 0xc8));
+        }
+    }
+    p.fillRect(pm.rect(), c);
+    p.restore();
+    p.setBrush(Qt::NoBrush);
+    p.setPen(QPen(QColor(0, 0, 0, 120), 1));
+    p.drawRoundedRect(
+        QRectF(0.5, 0.5, sz.width() - 1.0, sz.height() - 1.0), 3, 3);
+    return pm;
+}
+
+QIcon stopSwatchIcon(const QColor& c)
+{
+    QPixmap pm(16, 16);
+    pm.fill(Qt::transparent);
+    QPainter p(&pm);
+    p.setRenderHint(QPainter::Antialiasing);
+    QPainterPath clip;
+    clip.addRoundedRect(QRectF(0.5, 0.5, 15.0, 15.0), 3, 3);
+    p.save();
+    p.setClipPath(clip);
+    p.fillRect(QRect(0, 0, 16, 16), QColor(0xc8, 0xc8, 0xc8));
+    p.fillRect(QRect(0, 0, 8, 8),   QColor(0x80, 0x80, 0x80));
+    p.fillRect(QRect(8, 8, 8, 8),   QColor(0x80, 0x80, 0x80));
+    p.restore();
+    p.setBrush(c);
+    p.setPen(QPen(QColor(0, 0, 0, 80), 1));
+    p.drawRoundedRect(QRectF(0.5, 0.5, 15.0, 15.0), 3, 3);
+    return QIcon(pm);
+}
+
+} // namespace
+
+TokenEditorWidget::TokenEditorWidget(QWidget* parent)
+    : QWidget(parent)
+{
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(6, 6, 6, 6);
+    root->setSpacing(6);
+
+    buildHeaderRow(root);
+    buildTypeRow(root);
+
+    // Colour + Gradient stops share a single horizontal row so the
+    // gradient editor sits to the right of the colour picker — saves
+    // vertical real estate and visually couples the two groups since
+    // the picker doubles as the selected-stop editor in gradient mode.
+    auto* colorRow = new QHBoxLayout;
+    colorRow->setSpacing(12);
+    // AlignTop on both column widgets ensures their first rows line up
+    // against the top of the HBox regardless of how Qt's vertical
+    // stretch heuristics distribute the extra height between them.
+    colorRow->addWidget(buildColorGroup(), 0, Qt::AlignTop);
+    colorRow->addWidget(buildGradientGroup(), 1, Qt::AlignTop);
+    root->addLayout(colorRow);
+
+    // Construct the action buttons (Reset / Cancel / OK) before the
+    // font row so the font row can embed Cancel + OK at its right end.
+    // Reset is reparented out by ThemeEditorDialog (inspect row).
+    buildButtonRow(root);
+    buildFontGroup(root);
+
+    // Recent-colors swatches are per-theme; when the user switches the
+    // active theme (View menu, Save As, etc.) reload them so each
+    // theme's history stays distinct.  themeChanged also fires for
+    // in-place setColor edits — reloadRecentColorsIfThemeChanged()
+    // skips those by comparing the active theme name against the one
+    // we last loaded from.
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
+            this, &TokenEditorWidget::reloadRecentColorsIfThemeChanged);
+
+    // Initialise to the "nothing selected" state — every group visible
+    // but greyed out so the operator can see the full surface before
+    // they pick a token.
+    setToken(QString());
+}
+
+// ─────────────────────────────────────────────────────────── header row ─
+
+void TokenEditorWidget::buildHeaderRow(QVBoxLayout* root)
+{
+    Q_UNUSED(root);
+    // Label is owned by the editor but placed by the parent
+    // ThemeEditorDialog into its inspect row (see headerLabel()) —
+    // the editor stays a clean stack of editing controls.
+    m_header = new QLabel(this);
+    // Word-wrap off so the label width = max line width; the token
+    // string is allowed to be long without being broken mid-word.
+    // Multi-line layout is produced explicitly via <br/> in setToken().
+    m_header->setWordWrap(false);
+    m_header->setTextFormat(Qt::RichText);
+    m_header->setStyleSheet(QStringLiteral(
+        "QLabel { font-weight: bold; }"));
+}
+
+// ────────────────────────────────────────────────────── type chooser ────
+
+void TokenEditorWidget::buildTypeRow(QVBoxLayout* root)
+{
+    auto* row = new QHBoxLayout;
+    m_typeLabel = new QLabel(QStringLiteral("Type:"), this);
+    row->addWidget(m_typeLabel);
+    m_typeFlat     = new QRadioButton(QStringLiteral("Flat color"), this);
+    m_typeGradient = new QRadioButton(QStringLiteral("Gradient"),    this);
+    m_typeGroup    = new QButtonGroup(this);
+    m_typeGroup->addButton(m_typeFlat,     0);
+    m_typeGroup->addButton(m_typeGradient, 1);
+    row->addWidget(m_typeFlat);
+    row->addWidget(m_typeGradient);
+    row->addStretch(1);
+    root->addLayout(row);
+
+    connect(m_typeGroup, qOverload<int>(&QButtonGroup::idClicked),
+            this, &TokenEditorWidget::onColorTypeToggled);
+}
+
+// ───────────────────────────────────────────────────────── color group ──
+
+QWidget* TokenEditorWidget::buildColorGroup()
+{
+    auto* group = new QWidget(this);
+    auto* lay = new QVBoxLayout(group);
+    lay->setContentsMargins(0, 0, 0, 0);
+    lay->setSpacing(4);
+    // Force the label to the same height as the gradient column's
+    // label-row (which contains 22 px tool buttons), so the two
+    // headers line up exactly across columns.
+    m_colorGroupLabel = new QLabel(QStringLiteral("<b>Color</b>"), group);
+    m_colorGroupLabel->setFixedHeight(22);
+    lay->addWidget(m_colorGroupLabel);
+    m_colorPicker = new CompactColorPicker(group);
+    lay->addWidget(m_colorPicker);
+    lay->addStretch(1);
+
+    connect(m_colorPicker, &CompactColorPicker::colorChanged,
+            this, &TokenEditorWidget::onColorPickerChanged);
+    return group;
+}
+
+// ────────────────────────────────────────────────────────── font group ──
+
+void TokenEditorWidget::buildFontGroup(QVBoxLayout* root)
+{
+    m_fontGroupLabel = new QLabel(QStringLiteral("<b>Font</b>"), this);
+    root->addWidget(m_fontGroupLabel);
+
+    auto* row = new QHBoxLayout;
+    row->setSpacing(4);
+
+    m_fontCombo = new QFontComboBox(this);
+    m_fontCombo->setEditable(false);
+    m_fontCombo->setMaximumWidth(180);
+    // Each family in the dropdown is rendered IN that family at the
+    // view's font size.  Default is the app's default size, which
+    // makes the list visually overwhelming.  Drop by 4px so the
+    // list fits more entries and feels less shouty.
+    if (auto* view = m_fontCombo->view()) {
+        QFont viewFont = view->font();
+        const QFontInfo fi(viewFont);
+        viewFont.setPixelSize(std::max(8, fi.pixelSize() - 4));
+        view->setFont(viewFont);
+    }
+    row->addWidget(m_fontCombo);
+
+    m_fontSizeCombo = new QComboBox(this);
+    // Hard-capped at 20 px — anything bigger overflows the freq display
+    // glyph cell, meter labels, and several status-row widgets that
+    // assume small/normal/large stays within their reserved height.
+    for (int sz : {7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20}) {
+        m_fontSizeCombo->addItem(QStringLiteral("%1 pt").arg(sz),
+                                 QVariant(sz));
+    }
+    m_fontSizeCombo->setFixedWidth(70);
+    row->addWidget(m_fontSizeCombo);
+
+    auto makeStyleBtn = [&](const QString& text, const QString& tip,
+                            bool checkable) {
+        auto* b = new QToolButton(this);
+        b->setText(text);
+        b->setToolTip(tip);
+        b->setCheckable(checkable);
+        b->setFixedSize(28, 28);
+        QFont f = b->font();
+        if (text == QStringLiteral("B")) f.setBold(true);
+        if (text == QStringLiteral("I")) f.setItalic(true);
+        if (text == QStringLiteral("U")) f.setUnderline(true);
+        if (text == QStringLiteral("S")) f.setStrikeOut(true);
+        b->setFont(f);
+        row->addWidget(b);
+        return b;
+    };
+    m_fontBoldBtn      = makeStyleBtn(QStringLiteral("B"),
+        QStringLiteral("Bold (placeholder — future font.weight tokens)"),
+        true);
+    m_fontItalicBtn    = makeStyleBtn(QStringLiteral("I"),
+        QStringLiteral("Italic (placeholder — future font.style tokens)"),
+        true);
+    m_fontUnderlineBtn = makeStyleBtn(QStringLiteral("U"),
+        QStringLiteral("Underline (placeholder — future tokens)"),
+        true);
+    m_fontStrikeBtn    = makeStyleBtn(QStringLiteral("S"),
+        QStringLiteral("Strikethrough (placeholder — future tokens)"),
+        true);
+
+    m_fontSizeUpBtn   = makeStyleBtn(QStringLiteral("A↑"),
+        QStringLiteral("Increase size by 1 pt"), false);
+    m_fontSizeDownBtn = makeStyleBtn(QStringLiteral("A↓"),
+        QStringLiteral("Decrease size by 1 pt"), false);
+    m_fontClearBtn    = makeStyleBtn(QStringLiteral("⌧"),
+        QStringLiteral("Clear formatting (placeholder — future tokens)"),
+        false);
+
+    row->addStretch(1);
+    // Cancel / OK live at the right end of the font row so they're
+    // always at a predictable position regardless of token kind.
+    // Constructed earlier in buildButtonRow().
+    row->addWidget(m_cancelBtn);
+    row->addWidget(m_okBtn);
+    root->addLayout(row);
+
+    connect(m_fontCombo, &QFontComboBox::currentFontChanged,
+            this, [this](const QFont& f) { onFontFamilyChanged(f.family()); });
+    connect(m_fontSizeCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, [this](int) {
+        if (m_settingControlsFromToken) return;
+        bool ok = false;
+        const int v = m_fontSizeCombo->currentData().toInt(&ok);
+        if (ok) onFontSizeChanged(v);
+    });
+    connect(m_fontSizeUpBtn,   &QToolButton::clicked,
+            this, &TokenEditorWidget::onFontSizeBumpUp);
+    connect(m_fontSizeDownBtn, &QToolButton::clicked,
+            this, &TokenEditorWidget::onFontSizeBumpDown);
+}
+
+// ────────────────────────────────────────────────────── gradient group ──
+
+QWidget* TokenEditorWidget::buildGradientGroup()
+{
+    auto* group = new QWidget(this);
+    auto* lay = new QVBoxLayout(group);
+    lay->setContentsMargins(0, 0, 0, 0);
+    lay->setSpacing(4);
+
+    // Header row carries: [Gradient stops] [stretch] [Angle: spin] [+] [−].
+    // Putting the angle widget here (rather than in a row of its own
+    // below the stop list) reclaims one vertical row in this column and
+    // groups every action that affects the gradient as a whole.
+    // The row is forced to 22 px tall (matching the Color column's
+    // header) so the two column headers stay flush.
+    auto* labelRow = new QHBoxLayout;
+    labelRow->setSpacing(4);
+    labelRow->setContentsMargins(0, 0, 0, 0);
+    m_gradGroupLabel = new QLabel(QStringLiteral("<b>Gradient stops</b>"), group);
+    m_gradGroupLabel->setFixedHeight(22);
+    labelRow->addWidget(m_gradGroupLabel);
+    labelRow->addStretch(1);
+    auto* angleLabel = new QLabel(QStringLiteral("Angle:"), group);
+    labelRow->addWidget(angleLabel);
+    m_gradAngleSpin = new QSpinBox(group);
+    m_gradAngleSpin->setRange(0, 360);
+    m_gradAngleSpin->setSuffix(QStringLiteral("°"));
+    m_gradAngleSpin->setSingleStep(15);
+    m_gradAngleSpin->setFixedWidth(72);
+    labelRow->addWidget(m_gradAngleSpin);
+    m_gradAddBtn = new QToolButton(group);
+    m_gradAddBtn->setText(QStringLiteral("+"));
+    m_gradAddBtn->setFixedSize(22, 22);
+    m_gradAddBtn->setToolTip(QStringLiteral(
+        "Add a stop between the selected one and the next, or at the "
+        "midpoint of the gradient if nothing is selected."));
+    m_gradDelBtn = new QToolButton(group);
+    m_gradDelBtn->setText(QStringLiteral("−"));
+    m_gradDelBtn->setFixedSize(22, 22);
+    m_gradDelBtn->setToolTip(QStringLiteral(
+        "Remove the selected stop.  Refuses below two stops."));
+    labelRow->addWidget(m_gradAddBtn);
+    labelRow->addWidget(m_gradDelBtn);
+    lay->addLayout(labelRow);
+
+    m_gradStrip = new GradientStrip(group);
+    m_gradStrip->setFixedHeight(35);
+    lay->addWidget(m_gradStrip);
+
+    m_gradStopList = new QListWidget(group);
+    m_gradStopList->setIconSize(QSize(16, 16));
+    m_gradStopList->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_gradStopList->setFrameShape(QFrame::NoFrame);
+    m_gradStopList->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    m_gradStopList->setFixedHeight(164);
+
+    // Wrap the stop list with 8 px horizontal insets so its left/right
+    // edges line up with the GradientStrip's painted gradient bar
+    // (the strip widget reserves an 8 px kStripMargin on each side
+    // before rendering the bar — that's why the unwrapped list looked
+    // wider).  Top margin of 4 supplements the column's 4 px default
+    // spacing, yielding the requested 8 px gap between strip and list.
+    auto* listInset = new QHBoxLayout;
+    listInset->setContentsMargins(8, 4, 8, 0);
+    listInset->addWidget(m_gradStopList);
+    lay->addLayout(listInset);
+
+    // Recent-colors 2×10 grid lives in the gradient column below the
+    // stop list — fills the otherwise-empty space and provides quick
+    // re-pick of any of the last 20 confirmed colours.  Stays enabled
+    // even when the gradient group is disabled (scalar-color tokens).
+    buildRecentColorsGrid(lay, group);
+
+    // Soak any leftover vertical space so the gradient column packs
+    // tight to the top, matching the Color column's bottom stretch.
+    lay->addStretch(1);
+
+    connect(m_gradStrip, &GradientStrip::stopMoved,
+            this, &TokenEditorWidget::onGradientStopMoved);
+    connect(m_gradStrip, &GradientStrip::stopActivated,
+            this, &TokenEditorWidget::onGradientStopActivated);
+    connect(m_gradStrip, &GradientStrip::requestNewStop,
+            this, &TokenEditorWidget::onGradientRequestNewStop);
+    connect(m_gradStrip, &GradientStrip::requestDeleteStop,
+            this, &TokenEditorWidget::onGradientRequestDeleteStop);
+    connect(m_gradStopList, &QListWidget::itemSelectionChanged,
+            this, &TokenEditorWidget::onGradientStopListSelectionChanged);
+    connect(m_gradAngleSpin, qOverload<int>(&QSpinBox::valueChanged),
+            this, &TokenEditorWidget::onGradientAngleChanged);
+    connect(m_gradAddBtn, &QToolButton::clicked,
+            this, &TokenEditorWidget::onGradientAddStop);
+    connect(m_gradDelBtn, &QToolButton::clicked,
+            this, &TokenEditorWidget::onGradientDeleteStop);
+    return group;
+}
+
+// ─────────────────────────────────────────────── recent colors grid ─────
+
+void TokenEditorWidget::buildRecentColorsGrid(QVBoxLayout* lay, QWidget* group)
+{
+    auto* label = new QLabel(QStringLiteral("<i>Recent colors</i>"), group);
+    label->setStyleSheet(QStringLiteral("QLabel { color: #8ea8c0; }"));
+    lay->addWidget(label);
+
+    auto* grid = new QGridLayout;
+    grid->setSpacing(2);
+    grid->setContentsMargins(0, 0, 0, 0);
+    m_recentButtons.reserve(20);
+    for (int i = 0; i < 20; ++i) {
+        auto* b = new QToolButton(group);
+        b->setFixedSize(28, 24);
+        b->setIconSize(QSize(28, 24));
+        b->setAutoRaise(false);
+        b->setToolTip(QStringLiteral("Empty slot"));
+        b->setContextMenuPolicy(Qt::CustomContextMenu);
+        // Transparent button frame so the icon (a rounded swatch
+        // matching the hex swatch) is the only thing the user sees.
+        b->setStyleSheet(QStringLiteral(
+            "QToolButton { background: transparent; border: none; padding: 0px; }"
+            "QToolButton:hover { background: rgba(0, 188, 212, 40); border-radius: 3px; }"));
+        const int row = i / 10;
+        const int col = i % 10;
+        grid->addWidget(b, row, col);
+        m_recentButtons.append(b);
+        connect(b, &QToolButton::clicked, this, [this, i]() {
+            applyRecentColor(i);
+        });
+        // Right-click on a populated slot removes that color from the
+        // recents list (no confirmation — recents are recoverable by
+        // simply re-picking the colour and confirming with OK).
+        connect(b, &QToolButton::customContextMenuRequested,
+                this, [this, i](const QPoint&) {
+            if (i < 0 || i >= m_recentColors.size()) return;
+            m_recentColors.removeAt(i);
+            saveRecentColors();
+            refreshRecentButtons();
+        });
+    }
+    lay->addLayout(grid);
+
+    loadRecentColors();
+    refreshRecentButtons();
+}
+
+QString TokenEditorWidget::recentColorsKeyFor(const QString& themeName)
+{
+    // Per-theme bucket — themes that share a name on disk share their
+    // recents.  Fall back to a global key when no theme is active so
+    // we never write a stray "ThemeEditor.RecentColors/" entry.
+    if (themeName.isEmpty()) return QStringLiteral("ThemeEditor.RecentColors");
+    return QStringLiteral("ThemeEditor.RecentColors/") + themeName;
+}
+
+void TokenEditorWidget::loadRecentColors()
+{
+    m_recentColors.clear();
+    m_recentColorsTheme = ThemeManager::instance().activeTheme();
+    const QString blob = AppSettings::instance()
+        .value(recentColorsKeyFor(m_recentColorsTheme)).toString();
+    if (blob.isEmpty()) return;
+    const QStringList parts = blob.split(QLatin1Char(';'), Qt::SkipEmptyParts);
+    for (const QString& s : parts) {
+        QColor c(s);
+        if (c.isValid()) m_recentColors.append(c);
+        if (m_recentColors.size() >= 20) break;
+    }
+}
+
+void TokenEditorWidget::saveRecentColors() const
+{
+    QStringList parts;
+    parts.reserve(m_recentColors.size());
+    for (const QColor& c : m_recentColors) {
+        parts << (c.alpha() == 255 ? c.name(QColor::HexRgb)
+                                   : c.name(QColor::HexArgb));
+    }
+    // Always write to the same bucket we last loaded from — guarantees
+    // a push() that follows a Save As lands in the new theme's bucket
+    // (Save As triggers reloadRecentColorsIfThemeChanged() first, which
+    // updates m_recentColorsTheme to the new copy).
+    AppSettings::instance().setValue(
+        recentColorsKeyFor(m_recentColorsTheme),
+        parts.join(QLatin1Char(';')));
+}
+
+void TokenEditorWidget::reloadRecentColorsIfThemeChanged()
+{
+    const QString active = ThemeManager::instance().activeTheme();
+    if (active == m_recentColorsTheme) return;
+    loadRecentColors();
+    refreshRecentButtons();
+}
+
+void TokenEditorWidget::pushRecentColor(const QColor& c)
+{
+    if (!c.isValid()) return;
+    // Move-to-front: drop any existing entry with the same ARGB.
+    for (int i = m_recentColors.size() - 1; i >= 0; --i) {
+        if (m_recentColors[i].rgba() == c.rgba()) m_recentColors.removeAt(i);
+    }
+    m_recentColors.prepend(c);
+    while (m_recentColors.size() > 20) m_recentColors.removeLast();
+    saveRecentColors();
+    refreshRecentButtons();
+}
+
+void TokenEditorWidget::refreshRecentButtons()
+{
+    static const QSize kSwatchSz(28, 24);
+    for (int i = 0; i < m_recentButtons.size(); ++i) {
+        QToolButton* b = m_recentButtons[i];
+        if (i < m_recentColors.size()) {
+            const QColor& c = m_recentColors[i];
+            b->setIcon(QIcon(makeRecentSwatchPixmap(c, kSwatchSz)));
+            b->setToolTip(colorToTokenHex(c));
+            b->setEnabled(true);
+        } else {
+            // Empty slot — same rounded outline as the populated
+            // swatches but filled with a dim background tone.
+            const QColor empty(0x1a, 0x22, 0x30);
+            b->setIcon(QIcon(makeRecentSwatchPixmap(empty, kSwatchSz)));
+            b->setToolTip(QStringLiteral("Empty slot"));
+            b->setEnabled(false);
+        }
+    }
+}
+
+void TokenEditorWidget::applyRecentColor(int idx)
+{
+    if (idx < 0 || idx >= m_recentColors.size()) return;
+    const QColor c = m_recentColors[idx];
+    if (m_target == TargetScalarColor) {
+        m_bufferColor = c;
+        QSignalBlocker block(m_colorPicker);
+        m_colorPicker->setColor(c);
+        markDirty();
+    } else if (m_target == TargetGradient) {
+        const int si = selectedGradientStopIndex();
+        if (si < 0 || si >= m_gradientBuf.stops.size()) return;
+        m_gradientBuf.stops[si].color = c;
+        QSignalBlocker block(m_colorPicker);
+        m_colorPicker->setColor(c);
+        syncGradientStripAndList();
+        selectGradientStop(si);
+        markDirty();
+    }
+}
+
+// ─────────────────────────────────────────────────────── button row ─────
+
+void TokenEditorWidget::buildButtonRow(QVBoxLayout* root)
+{
+    Q_UNUSED(root);
+    // Action buttons are owned by this widget but placed elsewhere:
+    //   Reset  → inspect row (ThemeEditorDialog::resetButton())
+    //   Cancel → font row    (buildFontGroup())
+    //   OK     → font row    (buildFontGroup())
+    // No layout is added here; this function exists only to keep the
+    // construction + signal wiring of all three buttons in one place.
+    m_resetBtn = new QPushButton(QStringLiteral("Reset to default"), this);
+    m_resetBtn->setEnabled(false);
+    m_resetBtn->setToolTip(QStringLiteral(
+        "Restore this token's controls to its canonical value from the "
+        "bundled Default Dark theme.  Buffered locally — click OK to "
+        "commit, Cancel to back out."));
+    m_cancelBtn = new QPushButton(QStringLiteral("Cancel"), this);
+    m_okBtn     = new QPushButton(QStringLiteral("OK"),     this);
+    m_okBtn->setDefault(true);
+    m_cancelBtn->setEnabled(false);
+    m_okBtn->setEnabled(false);
+    m_cancelBtn->setToolTip(QStringLiteral(
+        "Discard local edits and reload from the active theme's saved values."));
+    m_okBtn->setToolTip(QStringLiteral(
+        "Commit the current values to the theme.  The rest of the app "
+        "re-themes once when you click this, not on every drag."));
+
+    connect(m_resetBtn,  &QPushButton::clicked, this, &TokenEditorWidget::onResetClicked);
+    connect(m_okBtn,     &QPushButton::clicked, this, &TokenEditorWidget::onOkClicked);
+    connect(m_cancelBtn, &QPushButton::clicked, this, &TokenEditorWidget::onCancelClicked);
+}
+
+// ────────────────────────────────────────────── enable / disable groups ─
+
+void TokenEditorWidget::applyEnableState()
+{
+    // Type radios — only meaningful for color tokens.
+    const bool colorTok = (m_target == TargetScalarColor
+                           || m_target == TargetGradient);
+    m_typeLabel->setEnabled(colorTok);
+    m_typeFlat->setEnabled(colorTok);
+    m_typeGradient->setEnabled(colorTok);
+
+    // Color group — picker is enabled for both scalar (binds to buffer)
+    // and gradient (binds to selected stop, requires a stop to be
+    // selected).  Disabled for font / numeric / nothing-selected.
+    const bool colorEnabled =
+        m_target == TargetScalarColor ||
+        (m_target == TargetGradient && selectedGradientStopIndex() >= 0);
+    m_colorGroupLabel->setEnabled(m_target == TargetScalarColor
+                                  || m_target == TargetGradient);
+    m_colorPicker->setEnabled(colorEnabled);
+
+    // Font group — the row serves two distinct edits depending on
+    // token type:
+    //   * font.family.*           → family combo edits family
+    //   * font.size.* / sizing.*  → size combo + A↑/A↓ edit the
+    //                                 integer; family combo is dim
+    const bool fontFamily  = (m_target == TargetFontFamily);
+    const bool sizeTok     = (m_target == TargetNumeric);
+    const bool fontGroup   = fontFamily || sizeTok;
+    m_fontGroupLabel->setEnabled(fontGroup);
+    m_fontCombo->setEnabled(fontFamily);
+    m_fontSizeCombo->setEnabled(sizeTok || fontFamily);
+    m_fontSizeUpBtn->setEnabled(sizeTok || fontFamily);
+    m_fontSizeDownBtn->setEnabled(sizeTok || fontFamily);
+    // Bold / italic / underline / strike / clear are placeholders — no
+    // font.weight / font.style tokens exist yet, so they always stay
+    // disabled (the tooltip explains).
+    for (QToolButton* b : {m_fontBoldBtn, m_fontItalicBtn,
+                           m_fontUnderlineBtn, m_fontStrikeBtn,
+                           m_fontClearBtn}) {
+        b->setEnabled(false);
+    }
+
+    // Gradient group.
+    const bool gradEnabled = (m_target == TargetGradient);
+    m_gradGroupLabel->setEnabled(gradEnabled);
+    m_gradStrip->setEnabled(gradEnabled);
+    m_gradStopList->setEnabled(gradEnabled);
+    m_gradAddBtn->setEnabled(gradEnabled);
+    m_gradDelBtn->setEnabled(gradEnabled);
+    m_gradAngleSpin->setEnabled(gradEnabled);
+
+    refreshResetButton();
+}
+
+void TokenEditorWidget::refreshResetButton()
+{
+    if (m_currentToken.isEmpty()) {
+        m_resetBtn->setEnabled(false);
+        return;
+    }
+    m_resetBtn->setEnabled(
+        ThemeManager::instance().hasFactoryValue(m_currentToken));
+}
+
+// ───────────────────────────────────────────────────────── markDirty ─────
+
+void TokenEditorWidget::markDirty()
+{
+    if (m_settingControlsFromToken) return;
+    if (m_currentToken.isEmpty()) return;
+    if (m_dirty) return;
+    m_dirty = true;
+    m_okBtn->setEnabled(true);
+    m_cancelBtn->setEnabled(true);
+    const QString base = m_header->text();
+    if (!base.contains(QStringLiteral("unsaved"))) {
+        m_header->setText(base + QStringLiteral(
+            "  <span style=\"color:#ffb84d;font-style:italic;font-weight:normal;\">"
+            "• unsaved</span>"));
+    }
+}
+
+// ──────────────────────────────────────────────────── load current token ─
+
+void TokenEditorWidget::loadCurrentTokenIntoBuffers()
+{
+    auto& tm = ThemeManager::instance();
+    m_settingControlsFromToken = true;
+
+    if (m_currentToken.startsWith(QStringLiteral("color."))) {
+        const bool isGradient = tm.brush(m_currentToken).gradient() != nullptr;
+        if (isGradient) {
+            m_target = TargetGradient;
+            m_gradientBuf = tm.gradient(m_currentToken);
+            m_bufferColor = m_gradientBuf.stops.isEmpty()
+                                ? QColor(255, 255, 255)
+                                : m_gradientBuf.stops.first().color;
+            QSignalBlocker bAngle(m_gradAngleSpin);
+            m_gradAngleSpin->setValue(static_cast<int>(
+                std::round(m_gradientBuf.angle)) % 361);
+            syncGradientStripAndList();
+            QSignalBlocker bRadio(m_typeGroup);
+            m_typeGradient->setChecked(true);
+        } else {
+            m_target = TargetScalarColor;
+            m_bufferColor = tm.color(m_currentToken);
+            QSignalBlocker bRadio(m_typeGroup);
+            m_typeFlat->setChecked(true);
+            // Clear the gradient list visually so it doesn't show stale
+            // entries from a previously-loaded gradient token.
+            m_gradientBuf = {};
+            syncGradientStripAndList();
+        }
+        QSignalBlocker bPick(m_colorPicker);
+        m_colorPicker->setColor(m_bufferColor);
+    } else if (m_currentToken.startsWith(QStringLiteral("font.family."))) {
+        m_target = TargetFontFamily;
+        m_bufferFontFamily = tm.value(m_currentToken);
+        QSignalBlocker bCombo(m_fontCombo);
+        m_fontCombo->setCurrentFont(QFont(m_bufferFontFamily));
+        // Size combo doesn't map to a specific token in family-mode —
+        // seed from the canonical font.size.normal so the UI shows
+        // *something* sensible.  Operator can A↑/A↓ but the commit
+        // only writes the family.
+        m_bufferFontSize = std::max(1, tm.sizing("font.size.normal"));
+        syncFontSizeComboToBuffer(m_bufferFontSize);
+    } else if (m_currentToken.startsWith(QStringLiteral("font.size."))
+               || m_currentToken.startsWith(QStringLiteral("sizing."))) {
+        m_target = TargetNumeric;
+        m_bufferNumeric = tm.sizing(m_currentToken);
+        m_bufferFontSize = std::max(1, m_bufferNumeric);
+        syncFontSizeComboToBuffer(m_bufferNumeric);
+    } else {
+        m_target = TargetNone;
+    }
+
+    m_settingControlsFromToken = false;
+}
+
+// ─────────────────────────────────────────────────────────── setToken ───
+
+void TokenEditorWidget::setToken(const QString& key)
+{
+    m_currentToken = key;
+    m_dirty = false;
+    m_okBtn->setEnabled(false);
+    m_cancelBtn->setEnabled(false);
+
+    if (key.isEmpty()) {
+        m_header->setText(QStringLiteral(
+            "<i>Click a token in the list below to edit it here.</i>"));
+        m_target = TargetNone;
+        // Clear the gradient list so the "Gradient stops" group doesn't
+        // show stale rows when nothing is selected.
+        m_settingControlsFromToken = true;
+        m_gradientBuf = {};
+        syncGradientStripAndList();
+        m_settingControlsFromToken = false;
+        applyEnableState();
+        return;
+    }
+
+    loadCurrentTokenIntoBuffers();
+
+    QString typeLabel;
+    switch (m_target) {
+        case TargetScalarColor: typeLabel = QStringLiteral("flat color"); break;
+        case TargetGradient:    typeLabel = QStringLiteral("gradient");    break;
+        case TargetFontFamily:  typeLabel = QStringLiteral("font family"); break;
+        case TargetNumeric:     typeLabel = QStringLiteral("size (px)");   break;
+        default:                typeLabel = QStringLiteral("(unknown)");   break;
+    }
+    // Single-line layout: "Editing:" and the token sit on the same
+    // row.  Word-wrap is off so the label keeps its natural width
+    // without breaking mid-string.
+    m_header->setText(QStringLiteral(
+        "Editing: %1 <span style=\"font-weight:normal;font-style:italic;\">(%2)</span>")
+        .arg(key.toHtmlEscaped(), typeLabel));
+    applyEnableState();
+}
+
+// ─────────────────────────────────────────────────────── color picker ───
+
+void TokenEditorWidget::onColorPickerChanged(const QColor& c)
+{
+    if (m_settingControlsFromToken || m_currentToken.isEmpty()) return;
+    if (!c.isValid()) return;
+    if (m_target == TargetScalarColor) {
+        m_bufferColor = c;
+        markDirty();
+    } else if (m_target == TargetGradient) {
+        const int sel = selectedGradientStopIndex();
+        if (sel < 0 || sel >= m_gradientBuf.stops.size()) return;
+        m_gradientBuf.stops[sel].color = c;
+        // Refresh the strip + the matching list row swatch + label.
+        m_gradStrip->setGradient(m_gradientBuf);
+        if (auto* item = m_gradStopList->item(sel)) {
+            item->setIcon(stopSwatchIcon(c));
+            const auto& s = m_gradientBuf.stops[sel];
+            item->setText(QStringLiteral("%1  at %2  %3")
+                              .arg(sel, 2, 10, QChar('0'))
+                              .arg(QString::number(s.at, 'f', 4), -8)
+                              .arg(colorToTokenHex(c)));
+        }
+        markDirty();
+    }
+}
+
+void TokenEditorWidget::onColorTypeToggled()
+{
+    if (m_settingControlsFromToken || m_currentToken.isEmpty()) return;
+    if (!m_currentToken.startsWith(QStringLiteral("color."))) return;
+
+    if (m_typeGradient->isChecked() && m_target != TargetGradient) {
+        // Flat → gradient: seed a 2-stop ramp with the current scalar
+        // at both ends so the initial appearance is identical.
+        ThemeGradient g;
+        g.type  = ThemeGradient::Linear;
+        g.angle = 0.0;
+        g.stops = { {0.0, m_bufferColor}, {1.0, m_bufferColor} };
+        m_settingControlsFromToken = true;
+        m_gradientBuf = g;
+        m_target = TargetGradient;
+        QSignalBlocker bAngle(m_gradAngleSpin);
+        m_gradAngleSpin->setValue(0);
+        syncGradientStripAndList();
+        m_settingControlsFromToken = false;
+        applyEnableState();
+        markDirty();
+    } else if (m_typeFlat->isChecked() && m_target != TargetScalarColor) {
+        // Gradient → flat: take the first stop's colour as the seed.
+        const QColor seed = m_gradientBuf.stops.isEmpty()
+                                ? m_bufferColor
+                                : m_gradientBuf.stops.first().color;
+        m_settingControlsFromToken = true;
+        m_bufferColor = seed;
+        m_target = TargetScalarColor;
+        m_gradientBuf = {};
+        QSignalBlocker bPick(m_colorPicker);
+        m_colorPicker->setColor(seed);
+        syncGradientStripAndList();
+        m_settingControlsFromToken = false;
+        applyEnableState();
+        markDirty();
+    }
+}
+
+// ────────────────────────────────────────────────────────── gradient ────
+
+void TokenEditorWidget::syncGradientStripAndList()
+{
+    m_gradStrip->setGradient(m_gradientBuf);
+    rebuildGradientStopList();
+}
+
+void TokenEditorWidget::rebuildGradientStopList()
+{
+    QSignalBlocker block(m_gradStopList);
+    m_gradStopList->clear();
+    for (int i = 0; i < m_gradientBuf.stops.size(); ++i) {
+        const auto& s = m_gradientBuf.stops[i];
+        auto* item = new QListWidgetItem(stopSwatchIcon(s.color),
+            QStringLiteral("%1  at %2  %3")
+                .arg(i, 2, 10, QChar('0'))
+                .arg(QString::number(s.at, 'f', 4), -8)
+                .arg(colorToTokenHex(s.color)));
+        item->setData(Qt::UserRole, i);
+        m_gradStopList->addItem(item);
+    }
+}
+
+void TokenEditorWidget::selectGradientStop(int index)
+{
+    if (index < 0 || index >= m_gradientBuf.stops.size()) {
+        m_gradStopList->clearSelection();
+        m_gradStrip->setSelectedStop(-1);
+        return;
+    }
+    QSignalBlocker block(m_gradStopList);
+    m_gradStopList->setCurrentRow(index);
+    m_gradStrip->setSelectedStop(index);
+}
+
+int TokenEditorWidget::selectedGradientStopIndex() const
+{
+    const auto sel = m_gradStopList->selectedItems();
+    if (sel.isEmpty()) return -1;
+    return sel.first()->data(Qt::UserRole).toInt();
+}
+
+void TokenEditorWidget::sortGradientStopsByAt()
+{
+    const int prevSel = selectedGradientStopIndex();
+    QColor prevColor;
+    qreal  prevAt = -1.0;
+    if (prevSel >= 0 && prevSel < m_gradientBuf.stops.size()) {
+        prevColor = m_gradientBuf.stops[prevSel].color;
+        prevAt    = m_gradientBuf.stops[prevSel].at;
+    }
+    std::sort(m_gradientBuf.stops.begin(), m_gradientBuf.stops.end(),
+              [](const ThemeGradientStop& a, const ThemeGradientStop& b) {
+                  return a.at < b.at;
+              });
+    syncGradientStripAndList();
+    if (prevAt >= 0.0) {
+        for (int i = 0; i < m_gradientBuf.stops.size(); ++i) {
+            if (qFuzzyCompare(m_gradientBuf.stops[i].at, prevAt) &&
+                m_gradientBuf.stops[i].color == prevColor) {
+                selectGradientStop(i);
+                return;
+            }
+        }
+    }
+}
+
+void TokenEditorWidget::onGradientStopMoved(int index, qreal newAt)
+{
+    if (m_settingControlsFromToken) return;
+    if (index < 0 || index >= m_gradientBuf.stops.size()) return;
+    m_gradientBuf.stops[index].at = newAt;
+    m_gradStrip->setGradient(m_gradientBuf);
+    if (auto* item = m_gradStopList->item(index)) {
+        const auto& s = m_gradientBuf.stops[index];
+        item->setText(QStringLiteral("%1  at %2  %3")
+                          .arg(index, 2, 10, QChar('0'))
+                          .arg(QString::number(s.at, 'f', 4), -8)
+                          .arg(colorToTokenHex(s.color)));
+    }
+    markDirty();
+}
+
+void TokenEditorWidget::onGradientStopActivated(int index)
+{
+    selectGradientStop(index);
+    applyEnableState();
+}
+
+void TokenEditorWidget::onGradientRequestNewStop(qreal at)
+{
+    if (m_settingControlsFromToken) return;
+    ThemeGradientStop s;
+    s.at = at;
+    if (m_gradientBuf.stops.isEmpty()) {
+        s.color = QColor(0xff, 0xff, 0xff);
+    } else if (m_gradientBuf.stops.size() == 1) {
+        s.color = m_gradientBuf.stops.first().color;
+    } else {
+        ThemeGradient sorted = m_gradientBuf;
+        std::sort(sorted.stops.begin(), sorted.stops.end(),
+                  [](const auto& a, const auto& b) { return a.at < b.at; });
+        const auto& first = sorted.stops.first();
+        const auto& last  = sorted.stops.last();
+        if (at <= first.at)      s.color = first.color;
+        else if (at >= last.at)  s.color = last.color;
+        else {
+            for (int i = 1; i < sorted.stops.size(); ++i) {
+                const auto& a = sorted.stops[i - 1];
+                const auto& b = sorted.stops[i];
+                if (at >= a.at && at <= b.at) {
+                    const qreal span = std::max(1e-9, b.at - a.at);
+                    const qreal t = (at - a.at) / span;
+                    auto blend = [t](int x, int y) {
+                        return static_cast<int>(std::round((1.0 - t) * x + t * y));
+                    };
+                    s.color = QColor(blend(a.color.red(),   b.color.red()),
+                                     blend(a.color.green(), b.color.green()),
+                                     blend(a.color.blue(),  b.color.blue()),
+                                     blend(a.color.alpha(), b.color.alpha()));
+                    break;
+                }
+            }
+        }
+    }
+    m_gradientBuf.stops.append(s);
+    sortGradientStopsByAt();
+    for (int i = 0; i < m_gradientBuf.stops.size(); ++i) {
+        if (qFuzzyCompare(m_gradientBuf.stops[i].at, s.at) &&
+            m_gradientBuf.stops[i].color == s.color) {
+            selectGradientStop(i);
+            break;
+        }
+    }
+    applyEnableState();
+    markDirty();
+}
+
+void TokenEditorWidget::onGradientRequestDeleteStop(int index)
+{
+    if (m_settingControlsFromToken) return;
+    if (index < 0 || index >= m_gradientBuf.stops.size()) return;
+    if (m_gradientBuf.stops.size() <= 2) {
+        QMessageBox::information(this, QStringLiteral("Cannot delete stop"),
+            QStringLiteral("A gradient needs at least two stops."));
+        return;
+    }
+    m_gradientBuf.stops.removeAt(index);
+    syncGradientStripAndList();
+    selectGradientStop(std::min(index,
+                                static_cast<int>(m_gradientBuf.stops.size()) - 1));
+    applyEnableState();
+    markDirty();
+}
+
+void TokenEditorWidget::onGradientStopListSelectionChanged()
+{
+    const int sel = selectedGradientStopIndex();
+    m_gradStrip->setSelectedStop(sel);
+    // When a stop is now selected, push its colour into the picker so
+    // the operator can edit it.  The picker's enable state is gated on
+    // having a selection.
+    if (m_target == TargetGradient) {
+        m_settingControlsFromToken = true;
+        if (sel >= 0 && sel < m_gradientBuf.stops.size()) {
+            QSignalBlocker block(m_colorPicker);
+            m_colorPicker->setColor(m_gradientBuf.stops[sel].color);
+        }
+        m_settingControlsFromToken = false;
+        applyEnableState();
+    }
+}
+
+void TokenEditorWidget::onGradientAngleChanged(int deg)
+{
+    if (m_settingControlsFromToken) return;
+    m_gradientBuf.angle = static_cast<qreal>(deg);
+    markDirty();
+}
+
+void TokenEditorWidget::onGradientAddStop()
+{
+    qreal at = 0.5;
+    const int sel = selectedGradientStopIndex();
+    if (sel >= 0 && sel < m_gradientBuf.stops.size() - 1) {
+        at = (m_gradientBuf.stops[sel].at + m_gradientBuf.stops[sel + 1].at) / 2.0;
+    } else if (sel == m_gradientBuf.stops.size() - 1 && sel > 0) {
+        at = (m_gradientBuf.stops[sel - 1].at + m_gradientBuf.stops[sel].at) / 2.0;
+    }
+    onGradientRequestNewStop(at);
+}
+
+void TokenEditorWidget::onGradientDeleteStop()
+{
+    onGradientRequestDeleteStop(selectedGradientStopIndex());
+}
+
+// ────────────────────────────────────────────────────────── font ────────
+
+void TokenEditorWidget::onFontFamilyChanged(const QString& family)
+{
+    if (m_settingControlsFromToken || m_currentToken.isEmpty()) return;
+    if (m_target != TargetFontFamily) return;
+    if (family.isEmpty()) return;
+    m_bufferFontFamily = family;
+    markDirty();
+}
+
+void TokenEditorWidget::onFontSizeChanged(int v)
+{
+    if (m_settingControlsFromToken || m_currentToken.isEmpty()) return;
+    if (v <= 0) return;
+    m_bufferFontSize = v;
+    if (m_target == TargetNumeric) {
+        // font.size.* / sizing.* token — the size combo IS the editor.
+        m_bufferNumeric = v;
+        markDirty();
+    }
+    // For font.family.* tokens the combo is purely informational so
+    // there's nothing to mark dirty — operator must pick the
+    // corresponding font.size.* token to actually commit a size change.
+}
+
+void TokenEditorWidget::onFontSizeBumpUp()
+{
+    m_bufferFontSize = std::clamp(m_bufferFontSize + 1, 7, 20);
+    syncFontSizeComboToBuffer(m_bufferFontSize);
+    if (m_target == TargetNumeric) {
+        m_bufferNumeric = m_bufferFontSize;
+        markDirty();
+    }
+}
+
+void TokenEditorWidget::onFontSizeBumpDown()
+{
+    m_bufferFontSize = std::clamp(m_bufferFontSize - 1, 7, 20);
+    syncFontSizeComboToBuffer(m_bufferFontSize);
+    if (m_target == TargetNumeric) {
+        m_bufferNumeric = m_bufferFontSize;
+        markDirty();
+    }
+}
+
+void TokenEditorWidget::syncFontSizeComboToBuffer(int sz)
+{
+    QSignalBlocker block(m_fontSizeCombo);
+    int idx = -1;
+    for (int i = 0; i < m_fontSizeCombo->count(); ++i) {
+        if (m_fontSizeCombo->itemData(i).toInt() == sz) { idx = i; break; }
+    }
+    if (idx < 0) {
+        // Insert in sorted order so the dropdown stays low→high.
+        int insertAt = m_fontSizeCombo->count();
+        for (int i = 0; i < m_fontSizeCombo->count(); ++i) {
+            if (m_fontSizeCombo->itemData(i).toInt() > sz) { insertAt = i; break; }
+        }
+        m_fontSizeCombo->insertItem(insertAt,
+                                    QStringLiteral("%1 pt").arg(sz),
+                                    QVariant(sz));
+        idx = insertAt;
+    }
+    m_fontSizeCombo->setCurrentIndex(idx);
+}
+
+// ────────────────────────────────────────────────────────── numeric ─────
+
+void TokenEditorWidget::onNumericValueChanged(int /*v*/)
+{
+    // Stub — kept so any leftover signal connections compile.  The
+    // size combo + A↑/A↓ handle numeric editing through the font row.
+}
+
+// ──────────────────────────────────────────────────────── reset / OK ────
+
+void TokenEditorWidget::onResetClicked()
+{
+    if (m_currentToken.isEmpty()) return;
+    auto& tm = ThemeManager::instance();
+    if (!tm.hasFactoryValue(m_currentToken)) return;
+
+    m_settingControlsFromToken = true;
+    if (m_target == TargetScalarColor) {
+        const QColor c = tm.factoryColor(m_currentToken);
+        if (c.isValid()) {
+            m_bufferColor = c;
+            QSignalBlocker block(m_colorPicker);
+            m_colorPicker->setColor(c);
+        }
+    } else if (m_target == TargetGradient) {
+        const ThemeGradient g = tm.factoryGradient(m_currentToken);
+        if (!g.stops.isEmpty()) {
+            m_gradientBuf = g;
+            QSignalBlocker bAngle(m_gradAngleSpin);
+            m_gradAngleSpin->setValue(static_cast<int>(
+                std::round(g.angle)) % 361);
+            syncGradientStripAndList();
+            if (!m_gradientBuf.stops.isEmpty()) selectGradientStop(0);
+        }
+    } else if (m_target == TargetFontFamily) {
+        const QString f = tm.factoryString(m_currentToken);
+        if (!f.isEmpty()) {
+            m_bufferFontFamily = f;
+            QSignalBlocker block(m_fontCombo);
+            m_fontCombo->setCurrentFont(QFont(f));
+        }
+    } else if (m_target == TargetNumeric) {
+        const int v = tm.factorySizing(m_currentToken);
+        if (v >= 0) {
+            m_bufferNumeric  = v;
+            m_bufferFontSize = std::max(1, v);
+            syncFontSizeComboToBuffer(v);
+        }
+    }
+    m_settingControlsFromToken = false;
+    applyEnableState();
+    markDirty();
+}
+
+void TokenEditorWidget::commitBufferToThemeManager()
+{
+    if (m_currentToken.isEmpty()) return;
+    auto& tm = ThemeManager::instance();
+    switch (m_target) {
+        case TargetScalarColor:
+            tm.setColor(m_currentToken, m_bufferColor);
+            pushRecentColor(m_bufferColor);
+            break;
+        case TargetGradient:
+            tm.setGradient(m_currentToken, m_gradientBuf);
+            // The selected stop is the one the operator was actively
+            // editing — record its colour as the "most recent".
+            if (const int si = selectedGradientStopIndex();
+                si >= 0 && si < m_gradientBuf.stops.size()) {
+                pushRecentColor(m_gradientBuf.stops[si].color);
+            }
+            break;
+        case TargetFontFamily:  tm.setString(m_currentToken, m_bufferFontFamily); break;
+        case TargetNumeric:     tm.setSizing(m_currentToken, m_bufferNumeric); break;
+        default: break;
+    }
+}
+
+void TokenEditorWidget::onOkClicked()
+{
+    if (m_currentToken.isEmpty() || !m_dirty) return;
+
+    // Built-in bundled themes ("Default Dark" / "Default Light") are
+    // read-only — overwriting them would silently shadow the bundled
+    // copy from the user dir.  Defer the commit, hand the dialog a
+    // chance to run Save As, and let it call back into
+    // completeDeferredCommit() once the active theme is a user copy.
+    auto& tm = ThemeManager::instance();
+    if (tm.isBuiltInTheme(tm.activeTheme())) {
+        m_deferredEdit = DeferredEdit{
+            m_currentToken, m_target, m_bufferColor, m_gradientBuf,
+            m_bufferFontFamily, m_bufferNumeric, m_bufferFontSize, true};
+        emit requestSaveAsBeforeCommit();
+        return;
+    }
+
+    commitBufferToThemeManager();
+    emit tokenChanged(m_currentToken);
+    setToken(m_currentToken);
+}
+
+void TokenEditorWidget::completeDeferredCommit()
+{
+    if (!m_deferredEdit.pending) return;
+    // Restore the buffer snapshot — Save As's themeChanged signal ran
+    // refreshTokenList() which called setToken("") and wiped the live
+    // buffer.  After this, the active theme is a fresh user copy with
+    // the original token values, so commitBufferToThemeManager() will
+    // write our edits to that copy.
+    m_currentToken    = m_deferredEdit.token;
+    m_target          = m_deferredEdit.target;
+    m_bufferColor     = m_deferredEdit.color;
+    m_gradientBuf     = m_deferredEdit.gradient;
+    m_bufferFontFamily = m_deferredEdit.fontFamily;
+    m_bufferNumeric   = m_deferredEdit.numeric;
+    m_bufferFontSize  = m_deferredEdit.fontSize;
+    m_deferredEdit    = {};
+    commitBufferToThemeManager();
+    emit tokenChanged(m_currentToken);
+    setToken(m_currentToken);
+}
+
+void TokenEditorWidget::onCancelClicked()
+{
+    if (m_currentToken.isEmpty()) return;
+    setToken(m_currentToken);
+}
+
+} // namespace AetherSDR

--- a/src/gui/TokenEditorWidget.cpp
+++ b/src/gui/TokenEditorWidget.cpp
@@ -585,14 +585,18 @@ void TokenEditorWidget::applyEnableState()
     m_typeFlat->setEnabled(colorTok);
     m_typeGradient->setEnabled(colorTok);
 
-    // Color group — picker is enabled for both scalar (binds to buffer)
-    // and gradient (binds to selected stop, requires a stop to be
-    // selected).  Disabled for font / numeric / nothing-selected.
+    // Color group — picker is enabled for scalar tokens (binds to buffer),
+    // gradient tokens (binds to selected stop), AND font.family.*
+    // compound tokens (binds to the compound's `color` field so family +
+    // size + color are all edited in one view).  Disabled for plain
+    // numeric / nothing-selected.
     const bool colorEnabled =
         m_target == TargetScalarColor ||
-        (m_target == TargetGradient && selectedGradientStopIndex() >= 0);
+        (m_target == TargetGradient && selectedGradientStopIndex() >= 0) ||
+        m_target == TargetFontFamily;
     m_colorGroupLabel->setEnabled(m_target == TargetScalarColor
-                                  || m_target == TargetGradient);
+                                  || m_target == TargetGradient
+                                  || m_target == TargetFontFamily);
     m_colorPicker->setEnabled(colorEnabled);
 
     // Font group — the row serves two distinct edits depending on
@@ -694,11 +698,25 @@ void TokenEditorWidget::loadCurrentTokenIntoBuffers()
         m_colorPicker->setColor(m_bufferColor);
     } else if (m_currentToken.startsWith(QStringLiteral("font.family."))) {
         m_target = TargetFontFamily;
-        m_bufferFontFamily = tm.valueAt(path, m_currentToken);
+        // Compound: load family + size + color from ThemeFont.  Falls
+        // through to legacy bare-string + font.size.normal when the
+        // token is still a v1 string (e.g. older imported themes).
+        const ThemeFont tf = tm.fontTokenAt(path, m_currentToken);
+        m_bufferFontFamily = tf.family;
         QSignalBlocker bCombo(m_fontCombo);
         m_fontCombo->setCurrentFont(QFont(m_bufferFontFamily));
-        m_bufferFontSize = std::max(1, tm.sizingAt(path, QStringLiteral("font.size.normal")));
+        m_bufferFontSize = tf.size > 0
+                              ? tf.size
+                              : std::max(1, tm.sizingAt(path, QStringLiteral("font.size.normal")));
         syncFontSizeComboToBuffer(m_bufferFontSize);
+        // Surface the embedded colour through the existing CompactColorPicker
+        // so the operator can edit it alongside family + size.  Invalid
+        // colour (legacy or fresh token) falls back to color.text.primary.
+        m_bufferColor = tf.color.isValid()
+                            ? tf.color
+                            : tm.colorAt(path, QStringLiteral("color.text.primary"));
+        QSignalBlocker bPick(m_colorPicker);
+        m_colorPicker->setColor(m_bufferColor);
     } else if (m_currentToken.startsWith(QStringLiteral("font.size."))
                || m_currentToken.startsWith(QStringLiteral("sizing."))) {
         m_target = TargetNumeric;
@@ -779,6 +797,12 @@ void TokenEditorWidget::onColorPickerChanged(const QColor& c)
     if (m_settingControlsFromToken || m_currentToken.isEmpty()) return;
     if (!c.isValid()) return;
     if (m_target == TargetScalarColor) {
+        m_bufferColor = c;
+        markDirty();
+    } else if (m_target == TargetFontFamily) {
+        // Font-compound editing — the colour field of the ThemeFont is
+        // edited through the same picker as scalar colour tokens; the
+        // commit pulls it from m_bufferColor.
         m_bufferColor = c;
         markDirty();
     } else if (m_target == TargetGradient) {
@@ -1177,7 +1201,18 @@ void TokenEditorWidget::commitBufferToThemeManager()
                 pushRecentColor(m_gradientBuf.stops[si].color);
             }
             break;
-        case TargetFontFamily:  tm.setString(path, m_currentToken, m_bufferFontFamily); break;
+        case TargetFontFamily: {
+            // Compound write — family + size + color all land in the
+            // same ThemeFont so the on-disk shape matches the editor's
+            // grouped UI.
+            ThemeFont tf;
+            tf.family = m_bufferFontFamily;
+            tf.size   = m_bufferFontSize;
+            tf.color  = m_bufferColor;
+            tm.setFontToken(path, m_currentToken, tf);
+            if (m_bufferColor.isValid()) pushRecentColor(m_bufferColor);
+            break;
+        }
         case TargetNumeric:     tm.setSizing(path, m_currentToken, m_bufferNumeric); break;
         default: break;
     }

--- a/src/gui/TokenEditorWidget.cpp
+++ b/src/gui/TokenEditorWidget.cpp
@@ -662,13 +662,17 @@ void TokenEditorWidget::markDirty()
 void TokenEditorWidget::loadCurrentTokenIntoBuffers()
 {
     auto& tm = ThemeManager::instance();
+    const QString& path = m_activeContainerPath;
     m_settingControlsFromToken = true;
 
     if (m_currentToken.startsWith(QStringLiteral("color."))) {
+        // Gradient detection still uses root brush() — gradient tokens
+        // are namespace-shaped (color.waterfall.colormap.*) and not yet
+        // overridden in nested scopes.  PR step 4 may revisit this.
         const bool isGradient = tm.brush(m_currentToken).gradient() != nullptr;
         if (isGradient) {
             m_target = TargetGradient;
-            m_gradientBuf = tm.gradient(m_currentToken);
+            m_gradientBuf = tm.gradientAt(path, m_currentToken);
             m_bufferColor = m_gradientBuf.stops.isEmpty()
                                 ? QColor(255, 255, 255)
                                 : m_gradientBuf.stops.first().color;
@@ -680,11 +684,9 @@ void TokenEditorWidget::loadCurrentTokenIntoBuffers()
             m_typeGradient->setChecked(true);
         } else {
             m_target = TargetScalarColor;
-            m_bufferColor = tm.color(m_currentToken);
+            m_bufferColor = tm.colorAt(path, m_currentToken);
             QSignalBlocker bRadio(m_typeGroup);
             m_typeFlat->setChecked(true);
-            // Clear the gradient list visually so it doesn't show stale
-            // entries from a previously-loaded gradient token.
             m_gradientBuf = {};
             syncGradientStripAndList();
         }
@@ -692,19 +694,15 @@ void TokenEditorWidget::loadCurrentTokenIntoBuffers()
         m_colorPicker->setColor(m_bufferColor);
     } else if (m_currentToken.startsWith(QStringLiteral("font.family."))) {
         m_target = TargetFontFamily;
-        m_bufferFontFamily = tm.value(m_currentToken);
+        m_bufferFontFamily = tm.valueAt(path, m_currentToken);
         QSignalBlocker bCombo(m_fontCombo);
         m_fontCombo->setCurrentFont(QFont(m_bufferFontFamily));
-        // Size combo doesn't map to a specific token in family-mode —
-        // seed from the canonical font.size.normal so the UI shows
-        // *something* sensible.  Operator can A↑/A↓ but the commit
-        // only writes the family.
-        m_bufferFontSize = std::max(1, tm.sizing("font.size.normal"));
+        m_bufferFontSize = std::max(1, tm.sizingAt(path, QStringLiteral("font.size.normal")));
         syncFontSizeComboToBuffer(m_bufferFontSize);
     } else if (m_currentToken.startsWith(QStringLiteral("font.size."))
                || m_currentToken.startsWith(QStringLiteral("sizing."))) {
         m_target = TargetNumeric;
-        m_bufferNumeric = tm.sizing(m_currentToken);
+        m_bufferNumeric = tm.sizingAt(path, m_currentToken);
         m_bufferFontSize = std::max(1, m_bufferNumeric);
         syncFontSizeComboToBuffer(m_bufferNumeric);
     } else {
@@ -750,10 +748,28 @@ void TokenEditorWidget::setToken(const QString& key)
     // Single-line layout: "Editing:" and the token sit on the same
     // row.  Word-wrap is off so the label keeps its natural width
     // without breaking mid-string.
+    // Append the current scope to the header when editing a non-root
+    // container, so the operator can see where their commit will land
+    // alongside the token name + kind.
+    const QString scopeSuffix = m_activeContainerPath.isEmpty()
+        ? QString()
+        : QStringLiteral(" <span style=\"font-weight:normal;color:#00bcd4;\">"
+                         "@ %1</span>").arg(m_activeContainerPath.toHtmlEscaped());
     m_header->setText(QStringLiteral(
-        "Editing: %1 <span style=\"font-weight:normal;font-style:italic;\">(%2)</span>")
-        .arg(key.toHtmlEscaped(), typeLabel));
+        "Editing: %1 <span style=\"font-weight:normal;font-style:italic;\">(%2)</span>%3")
+        .arg(key.toHtmlEscaped(), typeLabel, scopeSuffix));
     applyEnableState();
+}
+
+void TokenEditorWidget::setActiveContainerPath(const QString& path)
+{
+    if (path == m_activeContainerPath) return;
+    m_activeContainerPath = path;
+    // Reload the currently-selected token so the buffer reflects the
+    // new scope's resolved value (the user just navigated containers,
+    // not tokens — their selection should keep pointing at the same
+    // semantic but the controls should now show the new scope's value).
+    if (!m_currentToken.isEmpty()) setToken(m_currentToken);
 }
 
 // ─────────────────────────────────────────────────────── color picker ───
@@ -1145,22 +1161,24 @@ void TokenEditorWidget::commitBufferToThemeManager()
 {
     if (m_currentToken.isEmpty()) return;
     auto& tm = ThemeManager::instance();
+    const QString& path = m_activeContainerPath;
+    // The scope-aware setters short-circuit to the bare-token (root)
+    // overload when `path` is empty, so the historical flat-namespace
+    // behaviour is preserved for the default selection.
     switch (m_target) {
         case TargetScalarColor:
-            tm.setColor(m_currentToken, m_bufferColor);
+            tm.setColor(path, m_currentToken, m_bufferColor);
             pushRecentColor(m_bufferColor);
             break;
         case TargetGradient:
-            tm.setGradient(m_currentToken, m_gradientBuf);
-            // The selected stop is the one the operator was actively
-            // editing — record its colour as the "most recent".
+            tm.setGradient(path, m_currentToken, m_gradientBuf);
             if (const int si = selectedGradientStopIndex();
                 si >= 0 && si < m_gradientBuf.stops.size()) {
                 pushRecentColor(m_gradientBuf.stops[si].color);
             }
             break;
-        case TargetFontFamily:  tm.setString(m_currentToken, m_bufferFontFamily); break;
-        case TargetNumeric:     tm.setSizing(m_currentToken, m_bufferNumeric); break;
+        case TargetFontFamily:  tm.setString(path, m_currentToken, m_bufferFontFamily); break;
+        case TargetNumeric:     tm.setSizing(path, m_currentToken, m_bufferNumeric); break;
         default: break;
     }
 }

--- a/src/gui/TokenEditorWidget.h
+++ b/src/gui/TokenEditorWidget.h
@@ -1,0 +1,220 @@
+#pragma once
+
+#include "core/ThemeManager.h"
+
+#include <QColor>
+#include <QList>
+#include <QPointer>
+#include <QVector>
+#include <QWidget>
+
+class QButtonGroup;
+class QComboBox;
+class QFontComboBox;
+class QLabel;
+class QLineEdit;
+class QListWidget;
+class QListWidgetItem;
+class QPushButton;
+class QRadioButton;
+class QSpinBox;
+class QToolButton;
+class QVBoxLayout;
+
+namespace AetherSDR {
+
+class CompactColorPicker;
+class GradientStrip;
+
+// Inline token editor used by ThemeEditorDialog.  Shows every control
+// group at all times (single vertical layout, no stacked-widget swap)
+// and enables/disables each group based on the current token's
+// namespace + value shape:
+//
+//   * color.* (scalar)   — CompactColorPicker bound to the scalar buffer
+//   * color.* (gradient) — GradientStrip + stop list + angle; the
+//     CompactColorPicker is bound to the currently-selected stop
+//   * font.family.*      — Font toolbar (family + size + style buttons)
+//   * font.size.* / sizing.* — pixel-value spin box
+//
+// All edits write to local buffers only.  ThemeManager isn't touched
+// until the operator clicks OK; Cancel discards back to the last
+// committed value.  This keeps drag interactions (SV crosshair,
+// gradient stop drag) cheap — only the picker's own widgets repaint
+// at mouse-event rate, never the rest of the app.
+class TokenEditorWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit TokenEditorWidget(QWidget* parent = nullptr);
+
+    void setToken(const QString& key);
+    const QString& currentToken() const { return m_currentToken; }
+
+    // Owned by this widget but placed by the parent dialog (typically
+    // into the Inspect row).  Stays in sync with the current token +
+    // dirty state via setToken() / markDirty().
+    QLabel*      headerLabel() const { return m_header; }
+    QPushButton* resetButton() const { return m_resetBtn; }
+
+signals:
+    void tokenChanged(const QString& key);
+
+    // Emitted when the operator hits OK while the active theme is one
+    // of the built-in bundled themes ("Default Dark" / "Default Light")
+    // — the parent dialog runs the Save As flow on the user's behalf,
+    // then invokes completeDeferredCommit() to apply the buffered
+    // edits to the new user copy.
+    void requestSaveAsBeforeCommit();
+
+public:
+    // Apply the pending buffered edit captured before the parent
+    // dialog ran Save As.  Called after the active theme has been
+    // switched to a non-built-in copy.  No-op if no edit is pending.
+    void completeDeferredCommit();
+
+private slots:
+    void onColorPickerChanged(const QColor& c);
+    void onColorTypeToggled();
+    void onGradientStopMoved(int index, qreal newAt);
+    void onGradientStopActivated(int index);
+    void onGradientRequestNewStop(qreal at);
+    void onGradientRequestDeleteStop(int index);
+    void onGradientStopListSelectionChanged();
+    void onGradientAngleChanged(int deg);
+    void onGradientAddStop();
+    void onGradientDeleteStop();
+    void onFontFamilyChanged(const QString& family);
+    void onFontSizeChanged(int v);
+    void onFontSizeBumpUp();
+    void onFontSizeBumpDown();
+    void onNumericValueChanged(int v);
+    void onResetClicked();
+    void onOkClicked();
+    void onCancelClicked();
+
+private:
+    enum EditTarget {
+        TargetNone,         // no token selected — everything disabled
+        TargetScalarColor,  // picker → m_bufferColor
+        TargetGradient,     // picker → m_gradientBuf.stops[selected].color
+        TargetFontFamily,   // font toolbar → m_bufferFontFamily
+        TargetNumeric,      // numeric spin → m_bufferNumeric
+    };
+
+    void buildHeaderRow(QVBoxLayout* root);
+    void buildTypeRow(QVBoxLayout* root);
+    QWidget* buildColorGroup();
+    QWidget* buildGradientGroup();
+    void buildFontGroup(QVBoxLayout* root);
+    void buildNumericGroup(QVBoxLayout* root);
+    void buildButtonRow(QVBoxLayout* root);
+
+    void applyEnableState();
+    void loadCurrentTokenIntoBuffers();
+
+    void selectGradientStop(int index);
+    int  selectedGradientStopIndex() const;
+    void rebuildGradientStopList();
+    void syncGradientStripAndList();
+    void sortGradientStopsByAt();
+
+    void refreshResetButton();
+    void markDirty();
+    void commitBufferToThemeManager();
+
+    // Select `sz` in the non-editable font-size combo, inserting a new
+    // entry in sorted order if the preset list doesn't already contain
+    // it (so A↑/A↓ bumps to off-preset values stay in sync).
+    void syncFontSizeComboToBuffer(int sz);
+
+    QLabel*       m_header{nullptr};
+    QPushButton*  m_okBtn{nullptr};
+    QPushButton*  m_cancelBtn{nullptr};
+    QPushButton*  m_resetBtn{nullptr};
+
+    // Type chooser — only meaningful for color.* tokens.
+    QRadioButton* m_typeFlat{nullptr};
+    QRadioButton* m_typeGradient{nullptr};
+    QButtonGroup* m_typeGroup{nullptr};
+    QLabel*       m_typeLabel{nullptr};
+
+    // Color group — single CompactColorPicker that rebinds between the
+    // scalar buffer (flat-color tokens) and the selected gradient stop
+    // (gradient-color tokens).
+    QLabel*             m_colorGroupLabel{nullptr};
+    CompactColorPicker* m_colorPicker{nullptr};
+
+    // Font group — family combo + size combo + style buttons (B/I/U/S),
+    // size bump (A↑/A↓), clear-formatting placeholder.  Style buttons
+    // are visual placeholders — AetherSDR has no font.weight / font.style
+    // tokens yet, so they're disabled with a "future tokens" tooltip.
+    QLabel*        m_fontGroupLabel{nullptr};
+    QFontComboBox* m_fontCombo{nullptr};
+    QComboBox*     m_fontSizeCombo{nullptr};
+    QToolButton*   m_fontBoldBtn{nullptr};
+    QToolButton*   m_fontItalicBtn{nullptr};
+    QToolButton*   m_fontUnderlineBtn{nullptr};
+    QToolButton*   m_fontStrikeBtn{nullptr};
+    QToolButton*   m_fontSizeUpBtn{nullptr};
+    QToolButton*   m_fontSizeDownBtn{nullptr};
+    QToolButton*   m_fontClearBtn{nullptr};
+
+    // Gradient group — strip + stop list + inline +/- buttons next to
+    // the label + angle spinbox.  The "selected stop colour" is
+    // edited via the shared color picker above (no second embedded
+    // picker — saves vertical space).
+    QLabel*        m_gradGroupLabel{nullptr};
+    GradientStrip* m_gradStrip{nullptr};
+    QListWidget*   m_gradStopList{nullptr};
+    QToolButton*   m_gradAddBtn{nullptr};
+    QToolButton*   m_gradDelBtn{nullptr};
+    QSpinBox*      m_gradAngleSpin{nullptr};
+
+    // Recent-colors grid — 2 rows × 10 swatches sitting in the
+    // gradient column below the stop list.  Per-theme: each theme
+    // keeps its own list in AppSettings under the key
+    // "ThemeEditor.RecentColors/<theme name>".  Loaded on
+    // construction and re-loaded whenever the active theme changes
+    // (theme switch via View menu, Save As, etc.).
+    QVector<QToolButton*> m_recentButtons;
+    QList<QColor>         m_recentColors;
+    QString               m_recentColorsTheme;  // theme last loaded into m_recentColors
+    void buildRecentColorsGrid(QVBoxLayout* lay, QWidget* group);
+    void loadRecentColors();
+    void saveRecentColors() const;
+    void pushRecentColor(const QColor& c);
+    void refreshRecentButtons();
+    void applyRecentColor(int idx);
+    void reloadRecentColorsIfThemeChanged();
+    static QString recentColorsKeyFor(const QString& themeName);
+
+    QString    m_currentToken;
+    EditTarget m_target{TargetNone};
+
+    // Working copies — never written to ThemeManager until OK.
+    QColor        m_bufferColor;
+    ThemeGradient m_gradientBuf;
+    QString       m_bufferFontFamily;
+    int           m_bufferFontSize{12};
+    int           m_bufferNumeric{0};
+
+    // Snapshot of the buffer used to survive the list-rebuild that
+    // happens when Save As switches the active theme out from under
+    // an in-progress edit on a built-in theme.
+    struct DeferredEdit {
+        QString       token;
+        EditTarget    target {TargetNone};
+        QColor        color;
+        ThemeGradient gradient;
+        QString       fontFamily;
+        int           numeric {0};
+        int           fontSize {12};
+        bool          pending {false};
+    };
+    DeferredEdit m_deferredEdit;
+    bool          m_dirty{false};
+    bool          m_settingControlsFromToken{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/TokenEditorWidget.h
+++ b/src/gui/TokenEditorWidget.h
@@ -51,6 +51,14 @@ public:
     void setToken(const QString& key);
     const QString& currentToken() const { return m_currentToken; }
 
+    // Container scope this editor is editing under.  Empty = root.
+    // Setting a non-empty path routes commits through the scope-aware
+    // ThemeManager setters and reads through `valueAt(path, token)`
+    // so the buffer reflects the scope's resolved value (including
+    // inherited values from ancestors).
+    void setActiveContainerPath(const QString& path);
+    QString activeContainerPath() const { return m_activeContainerPath; }
+
     // Owned by this widget but placed by the parent dialog (typically
     // into the Inspect row).  Stays in sync with the current token +
     // dirty state via setToken() / markDirty().
@@ -190,6 +198,7 @@ private:
     static QString recentColorsKeyFor(const QString& themeName);
 
     QString    m_currentToken;
+    QString    m_activeContainerPath;  // empty == root scope
     EditTarget m_target{TargetNone};
 
     // Working copies — never written to ThemeManager until OK.

--- a/src/gui/TunerApplet.cpp
+++ b/src/gui/TunerApplet.cpp
@@ -20,6 +20,7 @@ namespace AetherSDR {
 TunerApplet::TunerApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/tuner"));
     hide();   // hidden by default until toggled on
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -57,7 +57,7 @@ static QString wattsText(int value)
 TxApplet::TxApplet(QWidget* parent)
     : QWidget(parent)
 {
-    theme::setContainer(this, QStringLiteral("applet.tx"));
+    theme::setContainer(this, QStringLiteral("applet/tx"));
     hide();
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     buildUI();

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -57,6 +57,7 @@ static QString wattsText(int value)
 TxApplet::TxApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet.tx"));
     hide();
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     buildUI();

--- a/src/gui/TxBandDialog.cpp
+++ b/src/gui/TxBandDialog.cpp
@@ -1,5 +1,6 @@
 #include "TxBandDialog.h"
 
+#include "core/ThemeManager.h"
 #include "models/RadioModel.h"
 #include "models/TransmitModel.h"
 
@@ -22,6 +23,7 @@ TxBandDialog::TxBandDialog(RadioModel* model, QWidget* parent)
         parent),
       m_model(model)
 {
+    theme::setContainer(this, QStringLiteral("dialog/txBand"));
     setMinimumSize(700, 450);
     setStyleSheet(QStringLiteral("QDialog { background: #0f0f1a; }"));
 

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -251,6 +251,11 @@ static bool likelyTxAntennaFallbackToken(const QString& token)
 VfoWidget::VfoWidget(QWidget* parent)
     : QWidget(parent)
 {
+    // Container scope — VFO flags are their own theming surface; inspector
+    // clicks should land here, not bubble up to `spectrum`.  Lives under
+    // the spectrum scope so unset tokens inherit the spectrum overrides.
+    AetherSDR::theme::setContainer(this, QStringLiteral("spectrum/vfo"));
+
     setObjectName("VfoWidgetRoot");
     setMinimumWidth(WIDGET_W);
     setMaximumWidth(WIDGET_W);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -272,6 +272,21 @@ VfoWidget::VfoWidget(QWidget* parent)
         syncFromSlice();  // refreshes badge stylesheet
         update();         // refreshes collapsed-mode painter
     });
+
+    // Inspector coverage — VfoWidget paints its background + signal meter
+    // through raw QPainter calls keyed off ThemeManager::color(), so
+    // applyStyleSheet's reverse-map never sees it.  Declare every token
+    // the widget reads so an Inspect-mode click on the flag, callsign
+    // badge, or signal meter strip surfaces a meaningful hit-list.
+    AetherSDR::ThemeManager::instance().declareWidgetTokens(this, QStringList{
+        "color.background.0", "color.background.1", "color.background.2",
+        "color.text.primary", "color.text.label",
+        "color.accent", "color.accent.bright", "color.accent.dim",
+        "color.accent.danger",
+        "color.slice.a", "color.slice.b", "color.slice.c", "color.slice.d",
+        "color.slice.e", "color.slice.f", "color.slice.g", "color.slice.h",
+        "color.slice.tx",
+    });
 }
 
 void VfoWidget::wheelEvent(QWheelEvent* ev)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -597,7 +597,7 @@ void VfoWidget::buildUI()
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_freqLabel, "QLabel { background: transparent;"
                                 " border: 1px solid rgba(255,255,255,80);"
                                 " border-radius: 3px;"
-                                " color: {{color.text.primary}}; font-size: 26px; font-weight: bold;"
+                                " color: {{color.text.primary}}; font-size: {{font.size.freq}}px; font-weight: bold;"
                                 " font-family: \"{{font.family.freq}}\";"
                                 " padding: 0 0 0 2px; }");
     m_freqLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);

--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -98,6 +98,7 @@ QString settingForViewMode(WaveformWidget::ViewMode mode)
 WaveApplet::WaveApplet(QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("applet/wave"));
     auto* layout = new QVBoxLayout(this);
     layout->setContentsMargins(2, 2, 2, 2);
     layout->setSpacing(3);

--- a/src/gui/WaveformsDialog.cpp
+++ b/src/gui/WaveformsDialog.cpp
@@ -1,4 +1,5 @@
 #include "WaveformsDialog.h"
+#include "core/ThemeManager.h"
 #include "models/FlexWaveformModel.h"
 
 #include <QFrame>
@@ -15,6 +16,7 @@ WaveformsDialog::WaveformsDialog(FlexWaveformModel* model, QWidget* parent)
     : PersistentDialog(tr("Waveforms"), QStringLiteral("WaveformsDialogGeometry"), parent)
     , m_model(model)
 {
+    theme::setContainer(this, QStringLiteral("dialog/waveforms"));
     setMinimumSize(440, 200);
 
     auto* root = new QVBoxLayout(bodyWidget());

--- a/src/gui/WhatsNewDialog.cpp
+++ b/src/gui/WhatsNewDialog.cpp
@@ -213,6 +213,7 @@ WhatsNewDialog::WhatsNewDialog(const QString& lastSeenVersion,
     : PersistentDialog("What's New - AetherSDR", "WhatsNewDialogGeometry", parent)
     , m_currentVersion(currentVersion)
 {
+    theme::setContainer(this, QStringLiteral("dialog/whatsNew"));
     setAttribute(Qt::WA_DeleteOnClose);
     buildUI(lastSeenVersion, currentVersion, showUpgrade, currentVersionOnly);
 }

--- a/src/gui/containers/ContainerTitleBar.cpp
+++ b/src/gui/containers/ContainerTitleBar.cpp
@@ -55,6 +55,7 @@ constexpr int kDragThresholdPx = 6;
 ContainerTitleBar::ContainerTitleBar(const QString& title, QWidget* parent)
     : QWidget(parent)
 {
+    theme::setContainer(this, QStringLiteral("titlebar"));
     setFixedHeight(kHeight);
     setCursor(Qt::OpenHandCursor);
     setAttribute(Qt::WA_StyledBackground, true);


### PR DESCRIPTION
## Summary
Folds every editing interaction into the Theme Editor dialog (no spawned sub-dialogs), tightens the layout, and closes a long-standing persistence hole. Built-in themes (Default Dark / Default Light) are now read-only — the first edit forks them through Save As so the bundled defaults can't be silently shadowed.

**Draft** — more work is coming on top of this; opening early for visibility.

## What's in this PR

### Editor surface
- New **`TokenEditorWidget`** — single vertical stack of always-visible groups (color picker, gradient stops, font row). Disabled groups dim instead of disappearing.
- New **`CompactColorPicker`** — 200×200 SV square + 12×200 hue strip + 200×12 alpha slider with checkerboard. Replaces `QColorDialog` spawn. Square strip borders + chip-style thumbs (dark outer ring, white inner fill, 1-px tick) consistent across hue / alpha / gradient stop markers.
- Inspect row carries `[Inspect] [Profile: name] [status] [Reset to default]`. Editing label is single-line rich-text `Editing: token (kind)`.
- Font row carries `Cancel` / `OK` at the right end; the dedicated bottom button row is gone.
- **Recent colors** — 2×10 grid of 28×24 rounded swatches matching the hex swatch. Left-click applies; right-click removes the slot. Persists **per-theme** under `ThemeEditor.RecentColors/<theme>` and reloads on theme switch.
- Font size combo non-editable, capped to **7–20 pt** (larger sizes break the freq glyph cell + status-row widgets). `QFontComboBox` also non-editable; dropdown font reduced 4 px.
- Gradient angle moved up into the stops header row alongside `+/−`.
- Gradient strip markers overlay the bar (chip-thumb style) instead of a triangle band below — survives the 35 px fixed-height embed.
- RGB row shrunk to fit inside the SV+hue block width via tighter spinbox padding + width 64→58.

### Behaviour
- **OK/Cancel commit model** — edits stay buffer-local until confirmed. Cancel reloads from `ThemeManager`.
- **Built-in theme guard** — `onOkClicked` snapshots the buffer into a `DeferredEdit`, emits `requestSaveAsBeforeCommit`; the dialog runs Save As and calls `completeDeferredCommit()` which restores the snapshot and writes to the new user copy. Buffer survives the `refreshTokenList()` that fires from `themeChanged`.
- **Auto-persist** — added `ThemeManager::saveActiveTheme()` called from `setColor` / `setSizing` / `setGradient` / `setString`. Wraps a shared `writeThemeFile()` helper extracted from `saveCurrentThemeAs`. No-op on built-ins. Closes the silent "edits gone after restart" bug.

### Naming
- `Editing: <theme>` → `Profile: <theme>`.
- `Colour` → `Color` throughout the editor + gradient-edit prompts.

## Test plan
- [ ] Edit a token on a user theme — confirm with OK, restart, change persists
- [ ] Edit a token on Default Dark — Save As prompt appears with `My Default Dark` pre-filled; confirm, edit lands in new theme; cancel leaves Default Dark untouched
- [ ] Verify recent-colors persist across restart and stay separate per theme
- [ ] Right-click a recent swatch removes that slot
- [ ] Gradient editing: drag stops, add/remove, change angle, change stop colors
- [ ] Font row: pick family, pick size 7–20 pt, A↑/A↓ bumps clamp at 7 and 20
- [ ] Confirm no Theme Editor regressions on light + dark + custom themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)