### PR TITLE
docs(CODEOWNERS): add @chibondking to Tier 3 reviewer roster

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,7 +25,7 @@
 #         build configuration (CMakeLists.txt). Narrower owner set
 #         than Tier 3 because infrastructure changes need deeper
 #         repo context than routine source review.
-# Tier 3 — @aethersdr/reviewers (currently: @ten9876, @jensenpat, @NF0T, @rfoust).
+# Tier 3 — @aethersdr/reviewers (currently: @ten9876, @jensenpat, @NF0T, @rfoust, @chibondking).
 #         AetherSDR source code and anything else not enumerated
 #         above (src/, third_party/, plugins/, hal-plugin/,
 #         resources/, packaging/, scripts/). Broadest collaborator


### PR DESCRIPTION
## Summary

Updates the Tier 3 roster comment in `.github/CODEOWNERS` to reflect @chibondking joining the `@aethersdr/reviewers` team.

The team membership grant is the operative change — the file's own header note explicitly says the inline roster is documentation only and the live source of truth is the GitHub org team.  This PR just keeps the comment in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)