### PR TITLE
[windows] Add Windows Store MSIX packaging groundwork

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -130,12 +130,22 @@ jobs:
       - name: Create portable ZIP
         run: |
           # Keep portable ZIP app-local runtime behavior aligned with the installer.
+          # Sanitize github.ref_name — release-tag pushes give a slash-free
+          # "v26.5.3" but workflow_dispatch on a branch ref like
+          # "codex/windows-store-msix" injects slashes that break the
+          # Compress-Archive destination path.  Strip every filesystem-unsafe
+          # character so ad-hoc dispatch runs (e.g. validating new packaging
+          # work on a branch) reach the later Inno + MSIX steps instead of
+          # exiting 1 at the very first artifact-creation step.
           Copy-Item -Path installer-runtime\*.dll -Destination deploy\ -Force
-          Compress-Archive -Path deploy\* -DestinationPath "AetherSDR-${{ github.ref_name }}-Windows-x64-portable.zip"
+          $safeRefName = "${{ github.ref_name }}" -replace '[\\/:*?"<>|]', '_'
+          Compress-Archive -Path deploy\* -DestinationPath "AetherSDR-$safeRefName-Windows-x64-portable.zip"
 
       - name: Create installer (Inno Setup)
         run: |
-          $version = "${{ github.ref_name }}" -replace '^v', ''
+          # Same sanitization as the portable ZIP step — Inno also pukes on
+          # filesystem-unsafe characters in /DAPP_VERSION.
+          $version = "${{ github.ref_name }}" -replace '^v', '' -replace '[\\/:*?"<>|]', '_'
           $runtimeDir = (Resolve-Path "installer-runtime").Path
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAPP_VERSION=$version "/DVC_RUNTIME_DIR=$runtimeDir" packaging\windows\installer.iss
 

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -133,7 +133,20 @@ jobs:
           Copy-Item -Path installer-runtime\*.dll -Destination deploy\ -Force
           Compress-Archive -Path deploy\* -DestinationPath "AetherSDR-${{ github.ref_name }}-Windows-x64-portable.zip"
 
+      - name: Create installer (Inno Setup)
+        run: |
+          $version = "${{ github.ref_name }}" -replace '^v', ''
+          $runtimeDir = (Resolve-Path "installer-runtime").Path
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAPP_VERSION=$version "/DVC_RUNTIME_DIR=$runtimeDir" packaging\windows\installer.iss
+
+      # MSIX runs AFTER the portable ZIP + Inno installer steps and is
+      # gated with continue-on-error so a future MSIX hiccup (missing SDK
+      # tool on a runner image bump, signtool flake, etc.) can't gate the
+      # established portable-zip + Inno installer delivery path that real
+      # users depend on.  When MSIX matures we can promote it back into
+      # the hard-required artifact set.
       - name: Create MSIX package
+        continue-on-error: true
         env:
           AETHERSDR_MSIX_IDENTITY_NAME: ${{ vars.AETHERSDR_MSIX_IDENTITY_NAME }}
           AETHERSDR_MSIX_PUBLISHER: ${{ vars.AETHERSDR_MSIX_PUBLISHER }}
@@ -145,12 +158,6 @@ jobs:
           AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR: ${{ vars.AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR }}
         run: |
           powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\create-msix.ps1 -DeployDir deploy -OutputDir . -CreateUpload -SkipSign
-
-      - name: Create installer (Inno Setup)
-        run: |
-          $version = "${{ github.ref_name }}" -replace '^v', ''
-          $runtimeDir = (Resolve-Path "installer-runtime").Path
-          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAPP_VERSION=$version "/DVC_RUNTIME_DIR=$runtimeDir" packaging\windows\installer.iss
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -133,6 +133,19 @@ jobs:
           Copy-Item -Path installer-runtime\*.dll -Destination deploy\ -Force
           Compress-Archive -Path deploy\* -DestinationPath "AetherSDR-${{ github.ref_name }}-Windows-x64-portable.zip"
 
+      - name: Create MSIX package
+        env:
+          AETHERSDR_MSIX_IDENTITY_NAME: ${{ vars.AETHERSDR_MSIX_IDENTITY_NAME }}
+          AETHERSDR_MSIX_PUBLISHER: ${{ vars.AETHERSDR_MSIX_PUBLISHER }}
+          AETHERSDR_MSIX_DISPLAY_NAME: ${{ vars.AETHERSDR_MSIX_DISPLAY_NAME }}
+          AETHERSDR_MSIX_PUBLISHER_DISPLAY_NAME: ${{ vars.AETHERSDR_MSIX_PUBLISHER_DISPLAY_NAME }}
+          AETHERSDR_MSIX_DESCRIPTION: ${{ vars.AETHERSDR_MSIX_DESCRIPTION }}
+          AETHERSDR_MSIX_BACKGROUND_COLOR: ${{ vars.AETHERSDR_MSIX_BACKGROUND_COLOR }}
+          AETHERSDR_MSIX_INSTALLER_ACCENT_COLOR: ${{ vars.AETHERSDR_MSIX_INSTALLER_ACCENT_COLOR }}
+          AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR: ${{ vars.AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR }}
+        run: |
+          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\create-msix.ps1 -DeployDir deploy -OutputDir . -CreateUpload -SkipSign
+
       - name: Create installer (Inno Setup)
         run: |
           $version = "${{ github.ref_name }}" -replace '^v', ''
@@ -146,6 +159,8 @@ jobs:
           path: |
             AetherSDR-*.zip
             AetherSDR-*-setup.exe
+            AetherSDR-*.msix
+            AetherSDR-*.msixupload
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 build/
 build-*/
+deploy/
+deploy-*/
+installer-runtime/
+installer-runtime-*/
 .cache/
 *.user
 .qtc_clangd/
@@ -10,3 +14,13 @@ CMakeFiles/
 docs/logo-original.jpg
 docs/logo_upscayl.png
 SECURITY-AUDIT.md
+msix-root/
+*.appx
+*.appxbundle
+*.appxsym
+*.appxupload
+*.msix
+*.msixbundle
+*.msixupload
+*.pfx
+packaging/windows/certs/

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -1,0 +1,174 @@
+# Windows Store MSIX Packaging
+
+This document tracks the command-line MSIX path for AetherSDR. The goal is to
+reuse the existing Windows `deploy` directory, then add the package identity,
+manifest, visual assets, signing, and Store upload wrapper around it.
+
+## Current Build Path
+
+1. Build `AetherSDR.exe` with MSVC.
+2. Run `windeployqt` into `deploy`.
+3. Copy third-party DLLs and the MSVC runtime DLLs into `deploy`.
+4. Run `packaging/windows/create-msix.ps1`.
+
+The script creates `msix-root/`, writes `AppxManifest.xml`, generates package
+icons from `docs/assets/logo-circle.png`, adds App Installer UX metadata, runs
+`makeappx.exe`, optionally signs the MSIX with `signtool.exe`, and optionally
+creates a `.msixupload` archive for Partner Center.
+
+Development package:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -Command ". 'C:\Users\patj\Documents\AetherSDR\scripts\enter-msvc.ps1' -Arch x64; & '.\packaging\windows\create-msix.ps1' -DeployDir deploy -OutputDir . -CreateUpload -SkipSign"
+```
+
+Store identity package:
+
+```powershell
+$env:AETHERSDR_MSIX_IDENTITY_NAME = "PartnerCenter.Assigned.Name"
+$env:AETHERSDR_MSIX_PUBLISHER = "CN=Partner-Center-Assigned-Publisher"
+$env:AETHERSDR_MSIX_PUBLISHER_DISPLAY_NAME = "AetherSDR"
+powershell -NoProfile -ExecutionPolicy Bypass -Command ". 'C:\Users\patj\Documents\AetherSDR\scripts\enter-msvc.ps1' -Arch x64; & '.\packaging\windows\create-msix.ps1' -DeployDir deploy -OutputDir . -CreateUpload"
+```
+
+## Manifest Values
+
+Values we can automate:
+
+- `Identity.Version`: read from `project(AetherSDR VERSION ...)` and normalized
+  to four MSIX components, such as `26.5.3.0`.
+- `Identity.ProcessorArchitecture`: `x64` for the current Windows build.
+- `Application.Executable`: `AetherSDR.exe`.
+- `TargetDeviceFamily`: `Windows.Desktop`, currently Windows 10 build 19041+
+  because the manifest uses `uap10:RuntimeBehavior`.
+- Visual assets: generated from the existing AetherSDR logo.
+
+Values that must come from Partner Center for the Store package:
+
+- `Identity.Name`: assigned after reserving the product name.
+- `Identity.Publisher`: assigned by Partner Center and tied to the developer
+  account/certificate identity.
+
+Values that need maintainer choice:
+
+- Public Store/product name: likely `AetherSDR`, but confirm before reserving.
+- `PublisherDisplayName`: `AetherSDR`.
+- Short manifest description:
+  `Multi-platform SDR client for FlexRadio transceivers (6000/8600/Aurora).`
+- Capability disclosure comfort:
+  - `runFullTrust`: required for a packaged classic desktop app.
+  - `internetClient`: needed for SmartLink, release metadata, propagation data,
+    and other internet-backed features.
+  - `privateNetworkClientServer`: needed for LAN radio/peripheral TCP and UDP.
+  - `microphone`: recommended because AetherSDR captures PC mic audio for TX.
+
+## Automation Plan
+
+Already automatable:
+
+- Local MSIX creation from the existing Windows deploy folder.
+- CI artifact creation after the current `windeployqt` deployment step.
+- Store identity injection from GitHub repository variables.
+- Signing from GitHub secrets when a development/test PFX exists.
+- `.msixupload` creation for Partner Center.
+
+Not fully automatable until account setup:
+
+- Reserving the Store product name.
+- Copying the Partner Center package identity values into GitHub variables.
+- Final Store submission unless Partner Center API credentials are created and
+  stored as secrets.
+
+## Known WACK Follow-Ups
+
+The Windows App Certification Kit currently gives useful Store-readiness
+signals, but some findings need follow-up before final submission:
+
+- `Blocked executables`: AetherSDR shells out to PowerShell for Windows support
+  bundle ZIP creation. Replace that path with in-process ZIP creation.
+- `Archive files usage`: DFNR currently ships `DeepFilterNet3_onnx.tar.gz`.
+  The archive contains `enc.onnx`, `erb_dec.onnx`, `df_dec.onnx`, and
+  `config.ini`, but the current DeepFilter C API expects the tar.gz path. Check
+  whether `df_create(nullptr, ...)` can use the embedded default model before
+  deciding whether to exclude the archive from the Store package.
+- `DPIAwarenessValidation`: add PerMonitorV2 DPI awareness to the desktop app
+  manifest or initialize DPI awareness explicitly before final Store testing.
+- Qt and vendor DLLs may still report process-launch imports or short blocked
+  string matches. Treat those separately from app-owned launch behavior.
+
+## GitHub Variables
+
+The Windows installer workflow reads these optional repository variables before
+building the MSIX artifact:
+
+- `AETHERSDR_MSIX_IDENTITY_NAME`
+- `AETHERSDR_MSIX_PUBLISHER`
+- `AETHERSDR_MSIX_DISPLAY_NAME`
+- `AETHERSDR_MSIX_PUBLISHER_DISPLAY_NAME`
+- `AETHERSDR_MSIX_DESCRIPTION`
+- `AETHERSDR_MSIX_BACKGROUND_COLOR`
+- `AETHERSDR_MSIX_INSTALLER_ACCENT_COLOR`
+- `AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR`
+
+If the identity variables are unset, CI still builds a development package using
+`AetherSDR.AetherSDR` and `CN=AetherSDR Development`. That package is useful for
+manifest/package validation, but it is not the final Store identity.
+
+## Local Sideload Signing
+
+Windows requires MSIX packages to be signed with a certificate that is trusted
+on the machine installing the package. Unsigned packages, or packages signed by
+an untrusted self-signed certificate, fail with errors such as `0x800B010A`.
+
+For local development, create a certificate whose subject exactly matches the
+development manifest publisher:
+
+```powershell
+$cert = New-SelfSignedCertificate `
+  -Type Custom `
+  -Subject "CN=AetherSDR Development" `
+  -FriendlyName "AetherSDR MSIX Development" `
+  -KeyUsage DigitalSignature `
+  -CertStoreLocation "Cert:\CurrentUser\My" `
+  -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
+
+$password = Read-Host -AsSecureString "PFX password"
+New-Item -ItemType Directory -Force -Path packaging\windows\certs | Out-Null
+Export-PfxCertificate -Cert $cert -FilePath packaging\windows\certs\aethersdr-msix-dev.pfx -Password $password
+Export-Certificate -Cert $cert -FilePath packaging\windows\certs\aethersdr-msix-dev.cer
+```
+
+Trust the certificate on the test machine, then rebuild the package without
+`-SkipSign`:
+
+```powershell
+Import-Certificate -FilePath packaging\windows\certs\aethersdr-msix-dev.cer -CertStoreLocation Cert:\LocalMachine\TrustedPeople
+$env:AETHERSDR_MSIX_CERTIFICATE_FILE = "packaging\windows\certs\aethersdr-msix-dev.pfx"
+$env:AETHERSDR_MSIX_CERTIFICATE_PASSWORD = "<the PFX password>"
+powershell -NoProfile -ExecutionPolicy Bypass -Command ". 'C:\Users\patj\Documents\AetherSDR\scripts\enter-msvc.ps1' -Arch x64; & '.\packaging\windows\create-msix.ps1' -DeployDir deploy -OutputDir . -CreateUpload"
+```
+
+Production Store packages should use Partner Center identity values. Packages
+distributed through the Microsoft Store are signed by the Store during
+submission, so this local self-signed certificate is only for sideload testing.
+
+## Notes From Microsoft Docs
+
+- [Manual MSIX packaging](https://learn.microsoft.com/en-us/windows/msix/desktop/desktop-to-uwp-manual-conversion)
+  is manifest plus package components plus `MakeAppx.exe`.
+- [MakeAppx.exe](https://learn.microsoft.com/en-us/windows/msix/package/create-app-package-with-makeappx-tool)
+  creates `.msix` packages, but does not create `.msixupload` files for
+  Partner Center; those are normally produced by Visual Studio or assembled
+  manually.
+- [Custom App Installer UX](https://learn.microsoft.com/en-us/windows/msix/app-installer/how-to-create-custom-app-installer-ux)
+  uses `Msix.AppInstaller.Data/MSIXAppInstallerData.xml` under the package root.
+- [Package identity](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/package-identity-overview)
+  consists of name, version, architecture, resource ID, and publisher.
+- [MSIX signing](https://learn.microsoft.com/en-us/windows/msix/package/sign-msix-package-guide)
+  requires the package certificate subject to match the manifest publisher; the
+  Store signs submitted packages for Store distribution.
+- [Desktop full-trust packages](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-distribute)
+  require Store approval for the `runFullTrust` restricted capability.
+- The Store signs published packages with a trusted certificate, but local
+  sideload testing still needs a package signed by a certificate trusted on the
+  test machine.

--- a/packaging/windows/create-msix.ps1
+++ b/packaging/windows/create-msix.ps1
@@ -1,0 +1,458 @@
+<#
+.SYNOPSIS
+    Build an MSIX package from the staged Windows deploy directory.
+
+.DESCRIPTION
+    This script expects the same deploy directory used by the portable ZIP and
+    Inno installer workflow: AetherSDR.exe, Qt DLLs/plugins from windeployqt,
+    third-party runtime DLLs, and data/model files.
+
+    Store identity values are deliberately parameters/env vars so the repo can
+    build development packages before Partner Center assigns the final package
+    Name and Publisher.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$DeployDir = "deploy",
+    [string]$PackageRoot = "msix-root",
+    [string]$OutputDir = ".",
+
+    [string]$PackageName = $env:AETHERSDR_MSIX_IDENTITY_NAME,
+    [string]$Publisher = $env:AETHERSDR_MSIX_PUBLISHER,
+    [string]$DisplayName = $(if ($env:AETHERSDR_MSIX_DISPLAY_NAME) { $env:AETHERSDR_MSIX_DISPLAY_NAME } else { "AetherSDR" }),
+    [string]$PublisherDisplayName = $(if ($env:AETHERSDR_MSIX_PUBLISHER_DISPLAY_NAME) { $env:AETHERSDR_MSIX_PUBLISHER_DISPLAY_NAME } else { "AetherSDR" }),
+    [string]$Description = $(if ($env:AETHERSDR_MSIX_DESCRIPTION) { $env:AETHERSDR_MSIX_DESCRIPTION } else { "Multi-platform SDR client for FlexRadio transceivers (6000/8600/Aurora)." }),
+    [string]$Version = $env:AETHERSDR_MSIX_VERSION,
+    [ValidateSet("x64", "x86", "arm", "arm64", "neutral")]
+    [string]$Architecture = $(if ($env:AETHERSDR_MSIX_ARCHITECTURE) { $env:AETHERSDR_MSIX_ARCHITECTURE } else { "x64" }),
+    [string]$MinVersion = $(if ($env:AETHERSDR_MSIX_MIN_VERSION) { $env:AETHERSDR_MSIX_MIN_VERSION } else { "10.0.19041.0" }),
+    [string]$MaxVersionTested = $(if ($env:AETHERSDR_MSIX_MAX_VERSION_TESTED) { $env:AETHERSDR_MSIX_MAX_VERSION_TESTED } else { "10.0.26100.0" }),
+    [string]$BackgroundColor = $(if ($env:AETHERSDR_MSIX_BACKGROUND_COLOR) { $env:AETHERSDR_MSIX_BACKGROUND_COLOR } else { "#202020" }),
+    [string]$InstallerAccentColor = $(if ($env:AETHERSDR_MSIX_INSTALLER_ACCENT_COLOR) { $env:AETHERSDR_MSIX_INSTALLER_ACCENT_COLOR } else { "#202020" }),
+    [string]$InstallerBackgroundColor = $(if ($env:AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR) { $env:AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR } else { "#202020" }),
+
+    [string]$IconSource = "docs/assets/logo-circle.png",
+    [string]$PdbPath = "build/AetherSDR.pdb",
+    [switch]$CreateUpload,
+
+    [string]$CertificateFile = $env:AETHERSDR_MSIX_CERTIFICATE_FILE,
+    [string]$CertificatePassword = $env:AETHERSDR_MSIX_CERTIFICATE_PASSWORD,
+    [string]$TimestampUrl = $env:AETHERSDR_MSIX_TIMESTAMP_URL,
+    [switch]$SkipSign
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-InputPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+}
+
+function Convert-ToMsixVersion {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$InputVersion
+    )
+
+    $parts = @($InputVersion.Split("."))
+    if ($parts.Count -lt 2 -or $parts.Count -gt 4) {
+        throw "MSIX version must have 2 to 4 numeric parts before normalization: $InputVersion"
+    }
+
+    while ($parts.Count -lt 4) {
+        $parts += "0"
+    }
+
+    foreach ($part in $parts) {
+        $number = 0
+        if (-not [int]::TryParse($part, [ref]$number) -or $number -lt 0 -or $number -gt 65535) {
+            throw "MSIX version component '$part' must be an integer from 0 through 65535."
+        }
+    }
+
+    return ($parts -join ".")
+}
+
+function Get-ProjectVersion {
+    $cmakePath = Resolve-InputPath "CMakeLists.txt"
+    $match = Select-String -Path $cmakePath -Pattern "^\s*project\(AetherSDR\s+VERSION\s+([0-9]+(?:\.[0-9]+){1,3})" | Select-Object -First 1
+    if (-not $match) {
+        throw "Could not find project(AetherSDR VERSION ...) in CMakeLists.txt."
+    }
+
+    return $match.Matches[0].Groups[1].Value
+}
+
+function Find-WindowsSdkTool {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ToolName
+    )
+
+    $command = Get-Command $ToolName -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    $kitsRoot = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin"
+    if (Test-Path -LiteralPath $kitsRoot) {
+        $candidates = Get-ChildItem -LiteralPath $kitsRoot -Directory -ErrorAction SilentlyContinue |
+            Sort-Object Name -Descending |
+            ForEach-Object { Join-Path $_.FullName "x64\$ToolName" } |
+            Where-Object { Test-Path -LiteralPath $_ }
+
+        if ($candidates) {
+            return @($candidates)[0]
+        }
+    }
+
+    $ackPath = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\App Certification Kit\$ToolName"
+    if (Test-Path -LiteralPath $ackPath) {
+        return $ackPath
+    }
+
+    throw "Could not find $ToolName. Install the Windows SDK or add the tool to PATH."
+}
+
+function Escape-Xml {
+    param(
+        [AllowNull()]
+        [string]$Value
+    )
+
+    if ($null -eq $Value) {
+        return ""
+    }
+
+    return [System.Security.SecurityElement]::Escape($Value)
+}
+
+function New-LogoPng {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Drawing.Image]$Source,
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath,
+        [Parameter(Mandatory = $true)]
+        [int]$Width,
+        [Parameter(Mandatory = $true)]
+        [int]$Height,
+        [double]$PaddingFraction = 0.02
+    )
+
+    $bitmap = New-Object System.Drawing.Bitmap $Width, $Height, ([System.Drawing.Imaging.PixelFormat]::Format32bppArgb)
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    try {
+        $graphics.Clear([System.Drawing.Color]::Transparent)
+        $graphics.CompositingQuality = [System.Drawing.Drawing2D.CompositingQuality]::HighQuality
+        $graphics.InterpolationMode = [System.Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+        $graphics.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::HighQuality
+        $graphics.PixelOffsetMode = [System.Drawing.Drawing2D.PixelOffsetMode]::HighQuality
+
+        $availableWidth = [double]$Width * (1.0 - (2.0 * $PaddingFraction))
+        $availableHeight = [double]$Height * (1.0 - (2.0 * $PaddingFraction))
+        $scale = [Math]::Min($availableWidth / [double]$Source.Width, $availableHeight / [double]$Source.Height)
+        $targetWidth = [Math]::Max(1, [int][Math]::Round([double]$Source.Width * $scale))
+        $targetHeight = [Math]::Max(1, [int][Math]::Round([double]$Source.Height * $scale))
+        $targetX = [int][Math]::Round(([double]$Width - $targetWidth) / 2.0)
+        $targetY = [int][Math]::Round(([double]$Height - $targetHeight) / 2.0)
+
+        $graphics.DrawImage($Source, $targetX, $targetY, $targetWidth, $targetHeight)
+        $bitmap.Save($OutputPath, [System.Drawing.Imaging.ImageFormat]::Png)
+    }
+    finally {
+        $graphics.Dispose()
+        $bitmap.Dispose()
+    }
+}
+
+function New-AppInstallerUx {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath,
+        [Parameter(Mandatory = $true)]
+        [string]$AccentColor,
+        [Parameter(Mandatory = $true)]
+        [string]$BackgroundColor
+    )
+
+    $xml = @"
+<?xml version="1.0" encoding="utf-8"?>
+<AppInstallerUX
+  xmlns="http://schemas.microsoft.com/msix/appinstallerux"
+  xmlns:ux="http://schemas.microsoft.com/msix/appinstallerux"
+  xmlns:ux2="http://schemas.microsoft.com/msix/appinstallerux/2"
+  IgnorableNamespaces="ux ux2"
+  Version="1.0.0">
+  <UX
+    AccentColor="$(Escape-Xml $AccentColor)"
+    FontFamily="Segoe UI"
+    AllowUserInteraction="true"
+    BackgroundColor="$(Escape-Xml $BackgroundColor)"
+    AppNameInTitle="true"
+    HyperLinkFontSize="12">
+    <Icon HorizontalAlignment="right" Logo="Assets\AppInstallerLogo.png" TopMargin="64" />
+    <Buttons HorizontalAlignment="right" IsSecondaryButtonAccent="true" />
+    <LaunchWhenReady HorizontalAlignment="left" />
+    <AppInformation Mode="normal" />
+  </UX>
+</AppInstallerUX>
+"@
+
+    Set-Content -LiteralPath $OutputPath -Value $xml -Encoding UTF8
+}
+
+function New-AppxSym {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$InputPdbPath,
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath
+    )
+
+    if (-not (Test-Path -LiteralPath $InputPdbPath)) {
+        Write-Host "No PDB found at $InputPdbPath; skipping .appxsym creation."
+        return $null
+    }
+
+    $stageDir = Join-Path ([System.IO.Path]::GetDirectoryName($OutputPath)) "appxsym-stage"
+    if (Test-Path -LiteralPath $stageDir) {
+        Remove-Item -LiteralPath $stageDir -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $stageDir -Force | Out-Null
+
+    Copy-Item -LiteralPath $InputPdbPath -Destination (Join-Path $stageDir ([System.IO.Path]::GetFileName($InputPdbPath))) -Force
+
+    $zipPath = "$OutputPath.zip"
+    if (Test-Path -LiteralPath $zipPath) {
+        Remove-Item -LiteralPath $zipPath -Force
+    }
+    if (Test-Path -LiteralPath $OutputPath) {
+        Remove-Item -LiteralPath $OutputPath -Force
+    }
+
+    Compress-Archive -Path (Join-Path $stageDir "*") -DestinationPath $zipPath -Force
+    Move-Item -LiteralPath $zipPath -Destination $OutputPath -Force
+    Remove-Item -LiteralPath $stageDir -Recurse -Force
+
+    return $OutputPath
+}
+
+function New-MsixUpload {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$MsixPath,
+        [string]$AppxSymPath,
+        [Parameter(Mandatory = $true)]
+        [string]$OutputPath
+    )
+
+    $stageDir = Join-Path ([System.IO.Path]::GetDirectoryName($OutputPath)) "msixupload-stage"
+    if (Test-Path -LiteralPath $stageDir) {
+        Remove-Item -LiteralPath $stageDir -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $stageDir -Force | Out-Null
+
+    Copy-Item -LiteralPath $MsixPath -Destination $stageDir -Force
+    if ($AppxSymPath -and (Test-Path -LiteralPath $AppxSymPath)) {
+        Copy-Item -LiteralPath $AppxSymPath -Destination $stageDir -Force
+    }
+
+    $zipPath = "$OutputPath.zip"
+    if (Test-Path -LiteralPath $zipPath) {
+        Remove-Item -LiteralPath $zipPath -Force
+    }
+    if (Test-Path -LiteralPath $OutputPath) {
+        Remove-Item -LiteralPath $OutputPath -Force
+    }
+
+    Compress-Archive -Path (Join-Path $stageDir "*") -DestinationPath $zipPath -Force
+    Move-Item -LiteralPath $zipPath -Destination $OutputPath -Force
+    Remove-Item -LiteralPath $stageDir -Recurse -Force
+}
+
+if ([string]::IsNullOrWhiteSpace($PackageName)) {
+    $PackageName = "AetherSDR.AetherSDR"
+    Write-Warning "AETHERSDR_MSIX_IDENTITY_NAME is not set; using development identity '$PackageName'."
+}
+
+if ([string]::IsNullOrWhiteSpace($Publisher)) {
+    $Publisher = "CN=AetherSDR Development"
+    Write-Warning "AETHERSDR_MSIX_PUBLISHER is not set; using development publisher '$Publisher'. Store builds must use the Partner Center Publisher value."
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = Get-ProjectVersion
+}
+$msixVersion = Convert-ToMsixVersion $Version
+
+$resolvedDeployDir = Resolve-InputPath $DeployDir
+$resolvedPackageRoot = Resolve-InputPath $PackageRoot
+$resolvedOutputDir = Resolve-InputPath $OutputDir
+$resolvedIconSource = Resolve-InputPath $IconSource
+$resolvedPdbPath = Resolve-InputPath $PdbPath
+
+if (-not (Test-Path -LiteralPath $resolvedDeployDir)) {
+    throw "Deploy directory not found: $resolvedDeployDir"
+}
+
+$exePath = Join-Path $resolvedDeployDir "AetherSDR.exe"
+if (-not (Test-Path -LiteralPath $exePath)) {
+    throw "AetherSDR.exe not found in deploy directory: $resolvedDeployDir"
+}
+
+if (-not (Test-Path -LiteralPath $resolvedIconSource)) {
+    throw "Icon source not found: $resolvedIconSource"
+}
+
+New-Item -ItemType Directory -Path $resolvedOutputDir -Force | Out-Null
+
+if (Test-Path -LiteralPath $resolvedPackageRoot) {
+    Remove-Item -LiteralPath $resolvedPackageRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Path $resolvedPackageRoot -Force | Out-Null
+
+Copy-Item -Path (Join-Path $resolvedDeployDir "*") -Destination $resolvedPackageRoot -Recurse -Force
+
+# windeployqt may copy vc_redist.x64.exe for traditional installers. MSIX
+# packages carry the app-local CRT DLLs instead, so keep the redistributable
+# installer executable out of the package payload.
+Get-ChildItem -LiteralPath $resolvedPackageRoot -File -Filter "vc_redist*.exe" -ErrorAction SilentlyContinue |
+    Remove-Item -Force
+
+$assetsDir = Join-Path $resolvedPackageRoot "Assets"
+New-Item -ItemType Directory -Path $assetsDir -Force | Out-Null
+
+Add-Type -AssemblyName System.Drawing
+$sourceImage = [System.Drawing.Image]::FromFile($resolvedIconSource)
+try {
+    New-LogoPng -Source $sourceImage -OutputPath (Join-Path $assetsDir "StoreLogo.png") -Width 50 -Height 50 -PaddingFraction 0.02
+    New-LogoPng -Source $sourceImage -OutputPath (Join-Path $assetsDir "AppInstallerLogo.png") -Width 256 -Height 256 -PaddingFraction 0.0
+    New-LogoPng -Source $sourceImage -OutputPath (Join-Path $assetsDir "Square44x44Logo.png") -Width 44 -Height 44
+    New-LogoPng -Source $sourceImage -OutputPath (Join-Path $assetsDir "Square71x71Logo.png") -Width 71 -Height 71
+    New-LogoPng -Source $sourceImage -OutputPath (Join-Path $assetsDir "Square150x150Logo.png") -Width 150 -Height 150
+    New-LogoPng -Source $sourceImage -OutputPath (Join-Path $assetsDir "Square310x310Logo.png") -Width 310 -Height 310
+    New-LogoPng -Source $sourceImage -OutputPath (Join-Path $assetsDir "Wide310x150Logo.png") -Width 310 -Height 150
+    foreach ($targetSize in @(16, 24, 32, 48, 64, 256)) {
+        New-LogoPng -Source $sourceImage -OutputPath (Join-Path $assetsDir "Square44x44Logo.targetsize-$targetSize.png") -Width $targetSize -Height $targetSize -PaddingFraction 0.0
+        New-LogoPng -Source $sourceImage -OutputPath (Join-Path $assetsDir "Square44x44Logo.targetsize-$targetSize`_altform-unplated.png") -Width $targetSize -Height $targetSize -PaddingFraction 0.0
+    }
+}
+finally {
+    $sourceImage.Dispose()
+}
+
+$appInstallerUxDir = Join-Path $resolvedPackageRoot "Msix.AppInstaller.Data"
+New-Item -ItemType Directory -Path $appInstallerUxDir -Force | Out-Null
+New-AppInstallerUx `
+    -OutputPath (Join-Path $appInstallerUxDir "MSIXAppInstallerData.xml") `
+    -AccentColor $InstallerAccentColor `
+    -BackgroundColor $InstallerBackgroundColor
+
+$manifestPath = Join-Path $resolvedPackageRoot "AppxManifest.xml"
+$manifest = @"
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap uap10 rescap">
+  <Identity
+    Name="$(Escape-Xml $PackageName)"
+    Publisher="$(Escape-Xml $Publisher)"
+    Version="$(Escape-Xml $msixVersion)"
+    ProcessorArchitecture="$(Escape-Xml $Architecture)" />
+  <Properties>
+    <DisplayName>$(Escape-Xml $DisplayName)</DisplayName>
+    <PublisherDisplayName>$(Escape-Xml $PublisherDisplayName)</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="$(Escape-Xml $MinVersion)" MaxVersionTested="$(Escape-Xml $MaxVersionTested)" />
+  </Dependencies>
+  <Applications>
+    <Application
+      Id="AetherSDR"
+      Executable="AetherSDR.exe"
+      uap10:RuntimeBehavior="packagedClassicApp"
+      uap10:TrustLevel="mediumIL">
+      <uap:VisualElements
+        DisplayName="$(Escape-Xml $DisplayName)"
+        Description="$(Escape-Xml $Description)"
+        BackgroundColor="$(Escape-Xml $BackgroundColor)"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile
+          Square71x71Logo="Assets\Square71x71Logo.png"
+          Wide310x150Logo="Assets\Wide310x150Logo.png"
+          Square310x310Logo="Assets\Square310x310Logo.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <Capability Name="internetClient" />
+    <Capability Name="privateNetworkClientServer" />
+    <rescap:Capability Name="runFullTrust" />
+    <DeviceCapability Name="microphone" />
+  </Capabilities>
+</Package>
+"@
+
+Set-Content -LiteralPath $manifestPath -Value $manifest -Encoding UTF8
+
+$makeAppx = Find-WindowsSdkTool "makeappx.exe"
+$packageBaseName = "AetherSDR-$msixVersion-Windows-$Architecture"
+$msixPath = Join-Path $resolvedOutputDir "$packageBaseName.msix"
+if (Test-Path -LiteralPath $msixPath) {
+    Remove-Item -LiteralPath $msixPath -Force
+}
+
+Write-Host "Packing MSIX: $msixPath"
+& $makeAppx pack /v /h SHA256 /d $resolvedPackageRoot /p $msixPath /o
+if ($LASTEXITCODE -ne 0) {
+    throw "makeappx failed with exit code $LASTEXITCODE."
+}
+
+if (-not $SkipSign -and -not [string]::IsNullOrWhiteSpace($CertificateFile)) {
+    $signtool = Find-WindowsSdkTool "signtool.exe"
+    $resolvedCertificateFile = Resolve-InputPath $CertificateFile
+    $signArgs = @("sign", "/fd", "SHA256", "/f", $resolvedCertificateFile)
+    if (-not [string]::IsNullOrWhiteSpace($CertificatePassword)) {
+        $signArgs += @("/p", $CertificatePassword)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($TimestampUrl)) {
+        $signArgs += @("/tr", $TimestampUrl, "/td", "SHA256")
+    }
+    $signArgs += $msixPath
+
+    Write-Host "Signing MSIX with $resolvedCertificateFile"
+    & $signtool @signArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "signtool failed with exit code $LASTEXITCODE."
+    }
+}
+elseif ($SkipSign) {
+    Write-Host "Skipping MSIX signing because -SkipSign was specified."
+}
+else {
+    Write-Warning "No signing certificate was provided; created unsigned MSIX."
+}
+
+$appxSymPath = $null
+if ($CreateUpload) {
+    $appxSymPath = New-AppxSym -InputPdbPath $resolvedPdbPath -OutputPath (Join-Path $resolvedOutputDir "$packageBaseName.appxsym")
+    $uploadPath = Join-Path $resolvedOutputDir "$packageBaseName.msixupload"
+    New-MsixUpload -MsixPath $msixPath -AppxSymPath $appxSymPath -OutputPath $uploadPath
+    Write-Host "Created Store upload package: $uploadPath"
+}
+
+Write-Host "Created MSIX package: $msixPath"


### PR DESCRIPTION
## Summary

This PR adds the first pass of Windows Store/MSIX packaging support for AetherSDR.

- Adds `packaging/windows/create-msix.ps1` to generate an MSIX package from the existing Windows `deploy` directory.
- Generates MSIX visual assets from the existing logo, writes `AppxManifest.xml`, adds App Installer UX metadata, runs `makeappx.exe`, optionally signs with `signtool.exe`, and can create a `.msixupload` for Partner Center.
- Wires the Windows installer workflow to build unsigned MSIX/MSIXUPLOAD artifacts alongside the portable zip and Inno installer.
- Adds repository variable hooks for Partner Center identity/display values and package color options.
- Adds docs for local packaging, sideload signing, manifest values, GitHub variables, and current WACK follow-ups.
- Ignores generated MSIX/package roots, deploy folders, local certs, and related package artifacts.

## Current Manifest Defaults

- Display name: `AetherSDR`
- Publisher display name: `AetherSDR`
- Description: `Multi-platform SDR client for FlexRadio transceivers (6000/8600/Aurora).`
- Minimum OS: Windows 10 2004 / build 19041
- Capabilities: `runFullTrust`, `internetClient`, `privateNetworkClientServer`, `microphone`

Partner Center will still need to provide the final `Identity.Name` and `Identity.Publisher` values.

## Validation

- PowerShell parser check passed for `packaging/windows/create-msix.ps1`.
- `git diff --check` passed.
- Local MSVC/Qt build and unsigned MSIX generation were exercised manually while developing this branch.
- Windows App Certification Kit was run locally; the docs now capture the remaining follow-ups.

## Known Follow-Ups

- Replace the Windows support-bundle PowerShell `Compress-Archive` call with in-process ZIP creation.
- Decide how to handle DFNR for Store packaging. The current `DeepFilterNet3_onnx.tar.gz` archive triggers WACK archive checks; `df_create(nullptr, ...)` may allow using the embedded default model instead.
- Add PerMonitorV2 DPI awareness before final WACK/Store submission.
- Review Qt/vendor DLL blocked-executable warnings separately from app-owned process-launch behavior.