### PR TITLE
feat(theme): carve sliders + knobs into dedicated namespaces with per-applet overrides

### DIFF
--- a/docs/theming/slider-knob-tokens.md
+++ b/docs/theming/slider-knob-tokens.md
@@ -1,0 +1,231 @@
+# Slider + knob token namespaces
+
+First worked example of carving a control type out of the generic
+theme categories (`color.accent` / `color.background.1` /
+`color.text.primary`) into dedicated namespaces with per-applet
+overrides through the v2 scope tree.  This document captures the
+pattern so future passes (toggle buttons, spinboxes, progress bars,
+…) follow the same shape.
+
+## Namespaces
+
+```
+color.slider.background           ← groove + add-page (unfilled portion)
+color.slider.foreground           ← sub-page (filled portion, the value indicator)
+color.slider.handle               ← thumb
+color.slider.background.disabled
+color.slider.foreground.disabled
+color.slider.handle.disabled
+
+color.knob.background             ← outer ring / track
+color.knob.foreground             ← indicator arc (value position)
+color.knob.handle                 ← center pointer / tick
+color.knob.background.disabled
+color.knob.foreground.disabled
+color.knob.handle.disabled
+```
+
+State suffix (`.disabled`) matches the existing
+`color.text.disabled` / `color.accent.bright` pattern.  Future state
+variants (`.hover`, `.pressed`) follow the same suffix slot when
+they're needed.
+
+## Cascade — root → applet → applet/&lt;name&gt;
+
+The bundled themes seed sensible root-scope defaults aliased to the
+primitives palette (`{color.blue.500}` etc.) for visual continuity
+with the pre-namespace look:
+
+```json
+"color": {
+  "slider": {
+    "background":          "{color.gray.800}",
+    "foreground":          "{color.blue.500}",
+    "handle":              "{color.gray.200}",
+    "background.disabled": "{color.gray.850}",
+    "foreground.disabled": "{color.gray.600}",
+    "handle.disabled":     "{color.gray.500}"
+  }
+}
+```
+
+Per-applet overrides live under `scopes.applet.scopes.<name>.tokens`:
+
+```json
+"scopes": {
+  "applet": {
+    "tokens": {},
+    "scopes": {
+      "tx":   { "tokens": { "color.slider.foreground": "{color.red.500}",
+                            "color.knob.foreground":   "{color.red.500}" } },
+      "rx":   { "tokens": { "color.slider.foreground": "{color.green.500}",
+                            "color.knob.foreground":   "{color.green.500}" } },
+      "comp": { "tokens": { "color.slider.foreground": "{color.amber.500}",
+                            "color.knob.foreground":   "{color.amber.500}" } }
+    }
+  }
+}
+```
+
+Result at runtime: a `QSlider` inside `TxApplet` walks
+`applet/tx → applet → root`, finds the `{color.red.500}` override at
+`applet/tx`, resolves to `#ff4d4d`.  A `QSlider` outside any applet
+walks straight to root and resolves to `#00b4d8`.
+
+## seedBuiltinDefaults — compile-time safety net
+
+`ThemeManager::seedBuiltinDefaults()` also seeds:
+
+1. Root-scope hex values for all 12 new tokens (raw hex, not aliases,
+   so the seeds don't depend on the primitives palette being loaded).
+2. Per-applet scope overrides (`applet/tx`, `applet/rx`,
+   `applet/comp`) created via `scopeOrCreate()` with the
+   red/green/amber foreground values.
+
+This means **older user themes** (forked before this PR) that have
+no slider/knob entries in their on-disk JSON still get the canonical
+look + per-applet differentiation.  The bundled themes' JSON
+re-asserts the same values via primitive aliases (idempotent).
+
+## The QSS migration
+
+Two surfaces in `gui/Theme.h`:
+
+### Global QSS (`appStylesheetTemplate`)
+
+Every slider rule (groove / sub-page / add-page / handle, horizontal
++ vertical, normal + disabled) reads from `color.slider.*`.  Applied
+to the main window via `applyAppTheme()` — descendant sliders
+inherit unless they have their own per-widget stylesheet.
+
+### Per-slider helper (`applyPrimarySliderStyle`)
+
+The canonical helper that ~20 call sites use.  Default `accentToken`
+arg is `"color.slider.foreground"` — call sites that pass nothing
+pick up the namespace automatically.  Sites that pass an explicit
+token (e.g. `"color.accent.warning"` for TX-adjacent amber, or
+`"color.slice.a"` for per-slice colour) still work — the explicit
+override wins.
+
+## The knob paint code (`ClientCompKnob`)
+
+Knobs paint via custom `QPainter` calls, not QSS.  The colour helper
+functions take a `const QWidget*` parameter so they can call the
+widget-aware lookup:
+
+```cpp
+inline QColor kRingArc(const QWidget* w) {
+    return ThemeManager::instance().color(w, "color.knob.foreground");
+}
+```
+
+Passing `this` from `paintEvent` lets the widget-aware overload walk
+the knob's container chain, so the `applet/comp` scope override
+naturally reaches the rendered arc colour — no per-knob
+`applyStyleSheet` plumbing needed.
+
+## The ParentChange event filter (the subtle one)
+
+**Symptom we hit:** sliders inside `TxApplet` still rendered blue
+even though the editor confirmed the `applet/tx` scope override was
+stored correctly.
+
+**Root cause:** helpers like `applyPrimarySliderStyle` are commonly
+called **before** the widget is added to its parent layout.
+Example from `TxApplet::buildUI()`:
+
+```cpp
+m_rfPowerSlider = new GuardedSlider(Qt::Horizontal);   // no parent
+m_rfPowerSlider->setRange(0, 100);
+applyPrimarySliderStyle(m_rfPowerSlider);              // <-- resolved here
+row->addWidget(m_rfPowerSlider, 1);                    // parent assigned here
+```
+
+`applyStyleSheet` resolves the template at apply time.  With no
+parent yet, `containerPathFor` walks nothing and returns `""` (root
+scope).  The QSS gets locked to root's blue, then the slider is
+reparented to TxApplet — too late, the QSS was already resolved.
+
+**Fix:** `ThemeManager` installs itself as an event filter on every
+widget tracked through `applyStyleSheet`.  When the widget receives
+`QEvent::ParentChange`, the template is re-resolved against the
+now-correct scope chain and re-applied.  Cost: trivial — only fires
+during initial construction (and rare deliberate reparents).
+
+```cpp
+bool ThemeManager::eventFilter(QObject* watched, QEvent* event) {
+    if (event->type() == QEvent::ParentChange) {
+        QWidget* w = qobject_cast<QWidget*>(watched);
+        if (w) {
+            const auto it = m_trackedWidgets.constFind(w);
+            if (it != m_trackedWidgets.constEnd()
+                && !it.value().stylesheetTemplate.isEmpty()) {
+                w->setStyleSheet(resolveFor(w, it.value().stylesheetTemplate));
+            }
+        }
+    }
+    return QObject::eventFilter(watched, event);
+}
+```
+
+This is a general fix — every helper that configures a widget
+pre-parent (`applyAppTheme`, `applyPrimarySliderStyle`, the dozens
+of inline `applyStyleSheet` sites in ctor bodies) now works
+correctly without any per-call-site change.
+
+**Implication for future control-type carve-outs:** you don't need
+to audit call sites for "is this slider attached to its parent yet?"
+The filter handles it.
+
+## Pattern for adding new control namespaces
+
+When carving the next control type out (toggles, spinboxes, …):
+
+1. **Define the namespace.**  Match the slider/knob shape:
+   `color.<type>.background`, `.foreground`, `.handle`, each with a
+   `.disabled` variant.
+2. **Seed both layers.**
+   - Add JSON entries to both bundled themes' root scope, aliased to
+     primitives.
+   - Add raw-hex root entries to `seedBuiltinDefaults()` for forked
+     user themes that pre-date the new namespace.
+3. **Migrate the QSS or paint code.**
+   - QSS-styled controls (`QToolButton`, `QSpinBox`, …): swap the
+     borrowed tokens in `Theme.h`'s `appStylesheetTemplate` and any
+     per-call-site helpers.  The ParentChange filter handles the
+     pre-reparent gotcha automatically.
+   - Paint-code controls: change the colour helpers to take a
+     `const QWidget*` and route through the widget-aware
+     `tm.color(widget, token)` overload.
+4. **Optional: per-applet overrides.**  Add nested-scope JSON
+   entries under `scopes.applet.scopes.<name>` for the applets that
+   should differ, and seed them in `seedBuiltinDefaults()` for
+   pre-existing user themes.
+5. **Document.**  Add a section to this directory referencing the
+   pattern.
+
+## Files touched in this PR
+
+| File | Role |
+|---|---|
+| `resources/themes/default-dark.json` | Token defs + nested scope overrides |
+| `resources/themes/default-light.json` | Same |
+| `src/core/ThemeManager.h` / `.cpp` | seedBuiltinDefaults + ParentChange filter |
+| `src/gui/Theme.h` | Global QSS + `applyPrimarySliderStyle` migration |
+| `src/gui/TitleBar.cpp` | Master volume + headphone slider QSS |
+| `src/gui/TxApplet.cpp` / `RxApplet.cpp` / `ClientCompApplet.cpp` | Applet-level QSS for un-helper'd sliders |
+| `src/gui/ClientCompKnob.cpp` | Widget-aware paint-code migration |
+
+## Out of scope (follow-ups)
+
+- **`PhaseKnob` paint code** still uses 6 hardcoded `QColor` literals
+  (no `tm.color()` lookups at all).  Migrating it needs more design
+  judgment than a rename — separate sweep.
+- **Hardcoded-hex slider sites** in `PanadapterApplet`,
+  `EqApplet`, `RadioSetupDialog`, `FlexControlDialog` bypass the
+  theme system entirely.  Each needs its local stylesheet dropped
+  in favour of the global QSS + per-applet override path.
+- **`color.knob.*` overrides at non-applet scopes** — e.g. if a
+  knob inside a dialog should differ from the same knob inside an
+  applet.  Available today (the namespace + scope tree both
+  support it); nothing's been declared yet.

--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -155,6 +155,22 @@
               "g": "#803040",
               "h": "#584080"
             }
+          },
+          "slider": {
+            "background":          "{color.gray.800}",
+            "foreground":          "{color.blue.500}",
+            "handle":              "{color.gray.200}",
+            "background.disabled": "{color.gray.850}",
+            "foreground.disabled": "{color.gray.600}",
+            "handle.disabled":     "{color.gray.500}"
+          },
+          "knob": {
+            "background":          "{color.gray.700}",
+            "foreground":          "{color.blue.500}",
+            "handle":              "{color.gray.200}",
+            "background.disabled": "{color.gray.800}",
+            "foreground.disabled": "{color.gray.600}",
+            "handle.disabled":     "{color.gray.500}"
           }
         },
         "font": {

--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -165,10 +165,10 @@
             "handle.disabled":     "{color.gray.500}"
           },
           "knob": {
-            "background":          "{color.gray.700}",
-            "foreground":          "{color.blue.500}",
+            "background":          "{color.gray.800}",
+            "foreground":          "{color.blue.700}",
             "handle":              "{color.gray.200}",
-            "background.disabled": "{color.gray.800}",
+            "background.disabled": "{color.gray.850}",
             "foreground.disabled": "{color.gray.600}",
             "handle.disabled":     "{color.gray.500}"
           }

--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -201,6 +201,31 @@
             "strong": 2
           }
         }
+      },
+      "scopes": {
+        "applet": {
+          "tokens": {},
+          "scopes": {
+            "tx": {
+              "tokens": {
+                "color.slider.foreground": "{color.red.500}",
+                "color.knob.foreground":   "{color.red.500}"
+              }
+            },
+            "rx": {
+              "tokens": {
+                "color.slider.foreground": "{color.green.500}",
+                "color.knob.foreground":   "{color.green.500}"
+              }
+            },
+            "comp": {
+              "tokens": {
+                "color.slider.foreground": "{color.amber.500}",
+                "color.knob.foreground":   "{color.amber.500}"
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -202,6 +202,31 @@
             "strong": 2
           }
         }
+      },
+      "scopes": {
+        "applet": {
+          "tokens": {},
+          "scopes": {
+            "tx": {
+              "tokens": {
+                "color.slider.foreground": "{color.red.500}",
+                "color.knob.foreground":   "{color.red.500}"
+              }
+            },
+            "rx": {
+              "tokens": {
+                "color.slider.foreground": "{color.green.500}",
+                "color.knob.foreground":   "{color.green.500}"
+              }
+            },
+            "comp": {
+              "tokens": {
+                "color.slider.foreground": "{color.amber.500}",
+                "color.knob.foreground":   "{color.amber.500}"
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -156,6 +156,22 @@
               "g": "#e0c0c8",
               "h": "#d0c0e0"
             }
+          },
+          "slider": {
+            "background":          "{color.gray.700}",
+            "foreground":          "{color.blue.500}",
+            "handle":              "{color.gray.50}",
+            "background.disabled": "{color.gray.800}",
+            "foreground.disabled": "{color.gray.500}",
+            "handle.disabled":     "{color.gray.400}"
+          },
+          "knob": {
+            "background":          "{color.gray.700}",
+            "foreground":          "{color.blue.500}",
+            "handle":              "{color.gray.50}",
+            "background.disabled": "{color.gray.800}",
+            "foreground.disabled": "{color.gray.500}",
+            "handle.disabled":     "{color.gray.400}"
           }
         },
         "font": {

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -166,10 +166,10 @@
             "handle.disabled":     "{color.gray.400}"
           },
           "knob": {
-            "background":          "{color.gray.700}",
-            "foreground":          "{color.blue.500}",
+            "background":          "{color.gray.800}",
+            "foreground":          "{color.blue.700}",
             "handle":              "{color.gray.50}",
-            "background.disabled": "{color.gray.800}",
+            "background.disabled": "{color.gray.700}",
             "foreground.disabled": "{color.gray.500}",
             "handle.disabled":     "{color.gray.400}"
           }

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -2,6 +2,7 @@
 #include "AppSettings.h"
 #include "LogManager.h"
 
+#include <QEvent>
 #include <QStandardPaths>
 #include <QDir>
 #include <QFile>
@@ -1558,16 +1559,40 @@ void ThemeManager::applyStyleSheet(QWidget* widget, const QString& stylesheetTem
     widget->setStyleSheet(resolveFor(widget, stylesheetTemplate));
 
     // First-time registration: connect to destroyed() so the entry
-    // disappears when the widget does.  Subsequent calls on the same
-    // widget just overwrite the recorded template / token list.
+    // disappears when the widget does, AND install ourselves as an
+    // event filter so a later QEvent::ParentChange re-resolves the
+    // template against the widget's now-correct scope chain.
+    // (Widgets configured pre-reparent — common for helpers like
+    // applyPrimarySliderStyle — would otherwise be stuck with their
+    // resolved-at-no-parent root-scope QSS.)  Subsequent calls on
+    // the same widget just overwrite the recorded template / token
+    // list without re-installing.
     if (!m_trackedWidgets.contains(widget)) {
         connect(widget, &QObject::destroyed,
                 this, &ThemeManager::onTrackedWidgetDestroyed);
+        widget->installEventFilter(this);
     }
     TrackedWidget ctx;
     ctx.stylesheetTemplate = stylesheetTemplate;
     ctx.tokens = extractReferencedTokens(stylesheetTemplate);
     m_trackedWidgets.insert(widget, ctx);
+}
+
+bool ThemeManager::eventFilter(QObject* watched, QEvent* event)
+{
+    if (event->type() == QEvent::ParentChange) {
+        QWidget* w = qobject_cast<QWidget*>(watched);
+        if (w) {
+            const auto it = m_trackedWidgets.constFind(w);
+            if (it != m_trackedWidgets.constEnd()
+                && !it.value().stylesheetTemplate.isEmpty()) {
+                // Re-resolve against the new scope chain.  Cheap: only
+                // fires on rare reparent events, not in any hot path.
+                w->setStyleSheet(resolveFor(w, it.value().stylesheetTemplate));
+            }
+        }
+    }
+    return QObject::eventFilter(watched, event);
 }
 
 void ThemeManager::clearWidgetTracking(QWidget* widget)

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -481,6 +481,13 @@ void ThemeManager::seedBuiltinDefaults()
     // editable in the Theme Editor.  Raw hex used here so the seeds
     // don't depend on the primitives palette being loaded yet
     // (older user themes have no primitives section).
+    //
+    // KEEP IN SYNC: the hex values below mirror the primitives palette
+    // in resources/themes/default-dark.json (color.red.500 / .green.500
+    // / .amber.500).  If those primitives shift, update both sites or
+    // the seeded look will drift from the JSON-defined look on bundled
+    // themes (silently — both layers resolve, the JSON wins, but the
+    // visible vs. seeded values diverge for pre-PR user themes).
     {
         ThemeScope* s = scopeOrCreate(QStringLiteral("applet/tx"));
         s->tokens.insert("color.slider.foreground", QString("#ff4d4d"));
@@ -591,10 +598,17 @@ bool ThemeManager::loadThemeFromPath(const QString& path)
     // Reset the scope tree before loading the new theme.  Compiled-in
     // defaults stay as the fallback layer so older theme files with
     // fewer tokens still produce a fully-rendered UI on a newer build.
+    //
+    // Ordering matters: clear() empties any child scopes from the
+    // previous theme load (including the per-applet scope seeds), then
+    // seedBuiltinDefaults() re-seeds them via scopeOrCreate().  If the
+    // active theme's JSON contains its own nested scopes, readScopeFromJson
+    // below overwrites the seeded values where they overlap — the seeds
+    // are the floor, the JSON wins where defined.
     m_rootScope->children.clear();
     m_primitives.clear();
     rebuildScopePathIndex();
-    seedBuiltinDefaults();  // resets m_tokens (= root scope tokens) to defaults
+    seedBuiltinDefaults();  // resets m_tokens (= root scope tokens) + re-seeds applet/* scope tree
 
     if (schemaVersion >= 2) {
         // v2 — primitives + nested scopes.  Canonical shape is
@@ -1570,6 +1584,15 @@ void ThemeManager::applyStyleSheet(QWidget* widget, const QString& stylesheetTem
     if (!m_trackedWidgets.contains(widget)) {
         connect(widget, &QObject::destroyed,
                 this, &ThemeManager::onTrackedWidgetDestroyed);
+        // Event filter cost: installEventFilter routes every event
+        // delivered to `widget` through ThemeManager::eventFilter().
+        // The handler early-outs on a single int compare for everything
+        // that isn't QEvent::ParentChange, so per-event overhead is
+        // negligible — but with N tracked widgets the cumulative
+        // wakeups during high-frequency interaction (drag, paint
+        // storms) is N×events.  If profiling ever flags this, gate the
+        // install to "widgets that have no parent at apply time" since
+        // those are the only ones that NEED the post-reparent fix.
         widget->installEventFilter(this);
     }
     TrackedWidget ctx;

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -430,6 +430,24 @@ void ThemeManager::seedBuiltinDefaults()
     m_tokens.insert("color.slice.h",  QString("#ff60a0"));
     m_tokens.insert("color.slice.tx", QString("#ff4d4d"));
 
+    // Slider + knob component tokens — seeded so themes that pre-date
+    // the namespace (e.g. user copies forked before this PR) still
+    // resolve the canonical Wave-blue look instead of falling through
+    // to empty QSS.  Default Dark / Default Light's JSON aliases
+    // override these when those themes load.
+    m_tokens.insert("color.slider.background",          QString("#1a2a3a"));
+    m_tokens.insert("color.slider.foreground",          QString("#00b4d8"));
+    m_tokens.insert("color.slider.handle",              QString("#c8d8e8"));
+    m_tokens.insert("color.slider.background.disabled", QString("#1a2330"));
+    m_tokens.insert("color.slider.foreground.disabled", QString("#3a4a5a"));
+    m_tokens.insert("color.slider.handle.disabled",     QString("#506070"));
+    m_tokens.insert("color.knob.background",            QString("#1a2a3a"));
+    m_tokens.insert("color.knob.foreground",            QString("#0070c0"));
+    m_tokens.insert("color.knob.handle",                QString("#c8d8e8"));
+    m_tokens.insert("color.knob.background.disabled",   QString("#1a2330"));
+    m_tokens.insert("color.knob.foreground.disabled",   QString("#3a4a5a"));
+    m_tokens.insert("color.knob.handle.disabled",       QString("#506070"));
+
     // Font + sizing
     m_tokens.insert("font.family.ui",        QString("Inter"));
     m_tokens.insert("font.family.mono",      QString("monospace"));
@@ -453,6 +471,30 @@ void ThemeManager::seedBuiltinDefaults()
     m_tokens.insert("sizing.panel.cornerRadius", 4);
     m_tokens.insert("sizing.border.subtle",      1);
     m_tokens.insert("sizing.border.strong",      2);
+
+    // Per-applet slider + knob foreground overrides seeded into the
+    // scope tree so user themes that pre-date the v2 scope architecture
+    // (e.g. "My Default Dark" forked before this PR) still get the
+    // visible per-applet differentiation.  Bundled themes' JSON
+    // re-asserts these via {color.red.500} aliases — idempotent and
+    // editable in the Theme Editor.  Raw hex used here so the seeds
+    // don't depend on the primitives palette being loaded yet
+    // (older user themes have no primitives section).
+    {
+        ThemeScope* s = scopeOrCreate(QStringLiteral("applet/tx"));
+        s->tokens.insert("color.slider.foreground", QString("#ff4d4d"));
+        s->tokens.insert("color.knob.foreground",   QString("#ff4d4d"));
+    }
+    {
+        ThemeScope* s = scopeOrCreate(QStringLiteral("applet/rx"));
+        s->tokens.insert("color.slider.foreground", QString("#4dd87a"));
+        s->tokens.insert("color.knob.foreground",   QString("#4dd87a"));
+    }
+    {
+        ThemeScope* s = scopeOrCreate(QStringLiteral("applet/comp"));
+        s->tokens.insert("color.slider.foreground", QString("#ffb84d"));
+        s->tokens.insert("color.knob.foreground",   QString("#ffb84d"));
+    }
 }
 
 void ThemeManager::scanAvailableThemes()

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -387,6 +387,19 @@ signals:
     // re-themed automatically; paint-code consumers connect themselves.
     void themeChanged();
 
+protected:
+    // Re-resolve a tracked widget's stylesheet template whenever it gets
+    // reparented.  Widgets that have applyStyleSheet() called before
+    // they're added to a layout (common — many widgets are configured
+    // pre-parenting in helper functions) would otherwise resolve their
+    // tokens against the WRONG scope chain (typically root, because
+    // containerPathFor walks Qt's parent chain).  This filter catches
+    // the subsequent QEvent::ParentChange and re-resolves so the
+    // widget's containing applet / dialog scope finally reaches its
+    // QSS — visible result: e.g. RF Power slider inside TxApplet
+    // takes the applet/tx scope's red foreground instead of root blue.
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
 private slots:
     // Cleanup hook — fired when a widget tracked through applyStyleSheet
     // is destroyed.  Removes its entry from the reverse-map.

--- a/src/gui/ClientCompApplet.cpp
+++ b/src/gui/ClientCompApplet.cpp
@@ -108,6 +108,11 @@ ClientCompApplet::ClientCompApplet(Side side, QWidget* parent)
     , m_side(side)
 {
     theme::setContainer(this, QStringLiteral("applet/comp"));
+    // Slider fill at applet/comp scope (amber — compression amount
+    // carries a warning-ish cast for "you are colouring the signal").
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this,
+        "QSlider::sub-page:horizontal { background: {{color.slider.foreground}}; }"
+        "QSlider::sub-page:vertical   { background: {{color.slider.foreground}}; }");
     buildUI();
     hide();  // hidden until toggled on from the button tray
 }

--- a/src/gui/ClientCompKnob.cpp
+++ b/src/gui/ClientCompKnob.cpp
@@ -31,14 +31,17 @@ constexpr float kArcSpanDeg         = -270.0f; // 4:30  = 270° sweep
 
 // Knob components read from the dedicated color.knob.* namespace
 // (carved out of color.background.1 / color.accent.dim /
-// color.text.primary).  Designers can retint knobs per-applet without
-// rippling into other accent-consumers.  Label + value text below
-// the knob stay on color.text.* — those are text, not knob proper.
-inline QColor kRingBg() { return AetherSDR::ThemeManager::instance().color("color.knob.background"); }
-inline QColor kRingArc() { return AetherSDR::ThemeManager::instance().color("color.knob.foreground"); }
-inline QColor kPointer() { return AetherSDR::ThemeManager::instance().color("color.knob.handle"); }
-inline QColor kLabelColor() { return AetherSDR::ThemeManager::instance().color("color.text.secondary"); }
-inline QColor kValueColor() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }
+// color.text.primary).  Each helper takes the owning widget so the
+// widget-aware overload walks the container chain — that's how
+// per-applet container overrides (e.g. applet/comp's amber knob
+// foreground) actually reach the rendered output.  Label + value
+// text below the knob stay on color.text.* — those are text, not
+// knob componentry.
+inline QColor kRingBg(const QWidget* w) { return AetherSDR::ThemeManager::instance().color(w, "color.knob.background"); }
+inline QColor kRingArc(const QWidget* w) { return AetherSDR::ThemeManager::instance().color(w, "color.knob.foreground"); }
+inline QColor kPointer(const QWidget* w) { return AetherSDR::ThemeManager::instance().color(w, "color.knob.handle"); }
+inline QColor kLabelColor(const QWidget* w) { return AetherSDR::ThemeManager::instance().color(w, "color.text.secondary"); }
+inline QColor kValueColor(const QWidget* w) { return AetherSDR::ThemeManager::instance().color(w, "color.text.primary"); }
 } // namespace
 
 ClientCompKnob::ClientCompKnob(QWidget* parent) : QWidget(parent)
@@ -271,13 +274,13 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
             fm = QFontMetrics(labelFont);
         }
         p.setFont(labelFont);
-        p.setPen(kLabelColor());
+        p.setPen(kLabelColor(this));
         p.drawText(QRectF(0, 0, w, 12), Qt::AlignCenter, m_label);
     }
 
     // Background ring.
     const qreal thick = std::max(2.0, diameter * 0.10);
-    QPen bgPen(kRingBg(), thick);
+    QPen bgPen(kRingBg(this), thick);
     bgPen.setCapStyle(Qt::FlatCap);
     p.setPen(bgPen);
     p.drawArc(ring.adjusted(thick * 0.5, thick * 0.5,
@@ -286,7 +289,7 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
               static_cast<int>(kArcSpanDeg * 16.0f));
 
     // Value arc.
-    QPen arcPen(kRingArc(), thick);
+    QPen arcPen(kRingArc(this), thick);
     arcPen.setCapStyle(Qt::FlatCap);
     p.setPen(arcPen);
     p.drawArc(ring.adjusted(thick * 0.5, thick * 0.5,
@@ -304,7 +307,7 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
                        c.y() - rOut * std::sin(angle));
     const QPointF pIn (c.x() + rIn  * std::cos(angle),
                        c.y() - rIn  * std::sin(angle));
-    QPen pointerPen(kPointer(), thick * 0.6);
+    QPen pointerPen(kPointer(this), thick * 0.6);
     pointerPen.setCapStyle(Qt::RoundCap);
     p.setPen(pointerPen);
     p.drawLine(pIn, pOut);
@@ -335,7 +338,7 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
         }
 
         p.setFont(centerFont);
-        p.setPen(kLabelColor());
+        p.setPen(kLabelColor(this));
         p.drawText(ring, Qt::AlignCenter, m_label);
     }
 
@@ -347,7 +350,7 @@ void ClientCompKnob::paintEvent(QPaintEvent*)
         valueFont.setBold(true);
         valueFont.setPixelSize(11);
         p.setFont(valueFont);
-        p.setPen(kValueColor());
+        p.setPen(kValueColor(this));
         p.drawText(valueRect(), Qt::AlignCenter, formatValue());
     }
 }

--- a/src/gui/ClientCompKnob.cpp
+++ b/src/gui/ClientCompKnob.cpp
@@ -29,9 +29,14 @@ constexpr float kFineMultiplier     = 0.25f;   // Shift-drag scales ×0.25
 constexpr float kArcStartDeg        = 225.0f;  // 7:30 clockwise to
 constexpr float kArcSpanDeg         = -270.0f; // 4:30  = 270° sweep
 
-inline QColor kRingBg() { return AetherSDR::ThemeManager::instance().color("color.background.1"); }
-inline QColor kRingArc() { return AetherSDR::ThemeManager::instance().color("color.accent.dim"); }
-inline QColor kPointer() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }
+// Knob components read from the dedicated color.knob.* namespace
+// (carved out of color.background.1 / color.accent.dim /
+// color.text.primary).  Designers can retint knobs per-applet without
+// rippling into other accent-consumers.  Label + value text below
+// the knob stay on color.text.* — those are text, not knob proper.
+inline QColor kRingBg() { return AetherSDR::ThemeManager::instance().color("color.knob.background"); }
+inline QColor kRingArc() { return AetherSDR::ThemeManager::instance().color("color.knob.foreground"); }
+inline QColor kPointer() { return AetherSDR::ThemeManager::instance().color("color.knob.handle"); }
 inline QColor kLabelColor() { return AetherSDR::ThemeManager::instance().color("color.text.secondary"); }
 inline QColor kValueColor() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }
 } // namespace

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -315,6 +315,10 @@ static QPushButton* mkRight(QWidget* parent = nullptr) { return new TriBtn(TriBt
 RxApplet::RxApplet(QWidget* parent) : QWidget(parent)
 {
     theme::setContainer(this, QStringLiteral("applet/rx"));
+    // Slider fill at applet/rx scope (green semantic — receive is passive).
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this,
+        "QSlider::sub-page:horizontal { background: {{color.slider.foreground}}; }"
+        "QSlider::sub-page:vertical   { background: {{color.slider.foreground}}; }");
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     // Recall the last user-chosen Manual squelch threshold from prior
     // sessions.  Auto mode clobbers the slice's squelchLevel with

--- a/src/gui/Theme.h
+++ b/src/gui/Theme.h
@@ -77,23 +77,74 @@ inline QString appStylesheetTemplate()
             border: none;
             background: transparent;
         }
+        /* Slider components now read from the dedicated color.slider.*
+           namespace (carved out of color.background.1 / color.accent /
+           color.text.primary so designers can retint sliders without
+           rippling into buttons / borders / body text).  Vertical
+           rules added alongside horizontal so the canonical look
+           matches regardless of orientation. */
         QSlider::groove:horizontal {
             height: 4px;
-            background: {{color.background.1}};
+            background: {{color.slider.background}};
             border: none;
             border-radius: 2px;
         }
         QSlider::sub-page:horizontal {
-            background: {{color.accent}};
+            background: {{color.slider.foreground}};
+            border: none;
+            border-radius: 2px;
+        }
+        QSlider::add-page:horizontal {
+            background: {{color.slider.background}};
             border: none;
             border-radius: 2px;
         }
         QSlider::handle:horizontal {
             width: 12px; height: 12px;
             margin: -4px 0;
-            background: {{color.text.primary}};
+            background: {{color.slider.handle}};
             border: none;
             border-radius: 6px;
+        }
+        QSlider::groove:vertical {
+            width: 4px;
+            background: {{color.slider.background}};
+            border: none;
+            border-radius: 2px;
+        }
+        QSlider::sub-page:vertical {
+            background: {{color.slider.foreground}};
+            border: none;
+            border-radius: 2px;
+        }
+        QSlider::add-page:vertical {
+            background: {{color.slider.background}};
+            border: none;
+            border-radius: 2px;
+        }
+        QSlider::handle:vertical {
+            width: 12px; height: 12px;
+            margin: 0 -4px;
+            background: {{color.slider.handle}};
+            border: none;
+            border-radius: 6px;
+        }
+        /* Disabled state — quieter background, washed-out fill,
+           dim handle.  Hover / pressed states still fall through
+           to Qt defaults (deferred per design review). */
+        QSlider::groove:horizontal:disabled,
+        QSlider::groove:vertical:disabled,
+        QSlider::add-page:horizontal:disabled,
+        QSlider::add-page:vertical:disabled {
+            background: {{color.slider.background.disabled}};
+        }
+        QSlider::sub-page:horizontal:disabled,
+        QSlider::sub-page:vertical:disabled {
+            background: {{color.slider.foreground.disabled}};
+        }
+        QSlider::handle:horizontal:disabled,
+        QSlider::handle:vertical:disabled {
+            background: {{color.slider.handle.disabled}};
         }
         QMenuBar { background-color: {{color.background.0}}; }
         QMenuBar::item:selected { background-color: {{color.background.1}}; }
@@ -135,24 +186,34 @@ inline QString darkThemeStylesheet()
 // Pre-consolidation the codebase had eight near-duplicate stylesheet
 // constants; this helper is the single source of truth.
 //
-// The `accentToken` parameter controls the sub-page fill colour.  Default
-// is `color.accent` (cyan).  Pass `color.accent.warning` for sliders that
-// live in transmit-adjacent panels (StripFinalOutputPanel,
-// StripWaveformPanel) where amber signals TX-related state.
-inline QString primarySliderStyleTemplate(const QString& accentToken = QStringLiteral("color.accent"))
+// The `accentToken` parameter controls the sub-page fill colour.
+// Default is `color.slider.foreground` (the canonical slider fill —
+// carved out of `color.accent` so retinting sliders no longer ripples
+// into buttons / borders / focus rings).  Call sites that need a per-
+// slice colour (slicePrimarySliderStyle) or a TX-warning amber pass
+// their own token here — those overrides still work since the helper
+// just substitutes whatever token name is provided.
+inline QString primarySliderStyleTemplate(const QString& accentToken = QStringLiteral("color.slider.foreground"))
 {
     return QStringLiteral(
         "QSlider { border: none; background: transparent; }"
-        "QSlider::groove:horizontal { height: 4px; background: {{color.background.1}}; border: none; border-radius: 2px; }"
+        "QSlider::groove:horizontal { height: 4px; background: {{color.slider.background}}; border: none; border-radius: 2px; }"
         "QSlider::sub-page:horizontal { background: {{%1}}; border: none; border-radius: 2px; }"
-        "QSlider::add-page:horizontal { background: {{color.background.1}}; border: none; border-radius: 2px; }"
+        "QSlider::add-page:horizontal { background: {{color.slider.background}}; border: none; border-radius: 2px; }"
         "QSlider::handle:horizontal { width: 12px; height: 12px; margin: -4px 0;"
-        " background: {{color.text.primary}}; border: none; border-radius: 6px; }"
-        "QSlider::groove:vertical { width: 4px; background: {{color.background.1}}; border: none; border-radius: 2px; }"
+        " background: {{color.slider.handle}}; border: none; border-radius: 6px; }"
+        "QSlider::groove:vertical { width: 4px; background: {{color.slider.background}}; border: none; border-radius: 2px; }"
         "QSlider::sub-page:vertical { background: {{%1}}; border: none; border-radius: 2px; }"
-        "QSlider::add-page:vertical { background: {{color.background.1}}; border: none; border-radius: 2px; }"
+        "QSlider::add-page:vertical { background: {{color.slider.background}}; border: none; border-radius: 2px; }"
         "QSlider::handle:vertical { width: 12px; height: 12px; margin: 0 -4px;"
-        " background: {{color.text.primary}}; border: none; border-radius: 6px; }"
+        " background: {{color.slider.handle}}; border: none; border-radius: 6px; }"
+        "QSlider::groove:horizontal:disabled, QSlider::groove:vertical:disabled,"
+        " QSlider::add-page:horizontal:disabled, QSlider::add-page:vertical:disabled"
+        " { background: {{color.slider.background.disabled}}; }"
+        "QSlider::sub-page:horizontal:disabled, QSlider::sub-page:vertical:disabled"
+        " { background: {{color.slider.foreground.disabled}}; }"
+        "QSlider::handle:horizontal:disabled, QSlider::handle:vertical:disabled"
+        " { background: {{color.slider.handle.disabled}}; }"
     ).arg(accentToken);
 }
 

--- a/src/gui/Theme.h
+++ b/src/gui/Theme.h
@@ -220,8 +220,17 @@ inline QString primarySliderStyleTemplate(const QString& accentToken = QStringLi
 // Apply the canonical primary slider style to `slider` and register it
 // for free live re-theme on theme changes.  Use this in place of every
 // previous `slider->setStyleSheet(kSliderStyle)` call.
+//
+// Default `accentToken` is `color.slider.foreground` — the canonical
+// slider fill token, carved out of `color.accent`.  Callers that
+// hard-code a specific token (e.g. `color.accent.warning` for
+// TX-adjacent panels, or `color.slice.a` for per-slice colour) still
+// work — that token name is what gets substituted.  Resolution is
+// widget-aware (walks the slider's container chain), so the applet's
+// scope override naturally reaches the rendered output without any
+// per-call-site change.
 inline void applyPrimarySliderStyle(QWidget* slider,
-                                    const QString& accentToken = QStringLiteral("color.accent"))
+                                    const QString& accentToken = QStringLiteral("color.slider.foreground"))
 {
     if (!slider) return;
     ThemeManager::instance().applyStyleSheet(slider, primarySliderStyleTemplate(accentToken));

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -277,9 +277,9 @@ TitleBar::TitleBar(QWidget* parent)
     m_masterSlider->setFixedHeight(16);
     m_masterSlider->setAccessibleName("Master volume");
     m_masterSlider->setAccessibleDescription("Line out volume level, 0 to 100 percent");
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_masterSlider, "QSlider::groove:horizontal { background: {{color.background.1}}; height: 4px; border-radius: 2px; }"
-        "QSlider::handle:horizontal { background: {{color.accent}}; width: 10px; margin: -3px 0; border-radius: 5px; }"
-        "QSlider::sub-page:horizontal { background: {{color.accent}}; border-radius: 2px; }");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_masterSlider, "QSlider::groove:horizontal { background: {{color.slider.background}}; height: 4px; border-radius: 2px; }"
+        "QSlider::handle:horizontal { background: {{color.slider.handle}}; width: 10px; margin: -3px 0; border-radius: 5px; }"
+        "QSlider::sub-page:horizontal { background: {{color.slider.foreground}}; border-radius: 2px; }");
     m_hbox->addWidget(m_masterSlider);
 
     m_masterLabel = new QLabel(QString::number(savedVol));
@@ -319,9 +319,9 @@ TitleBar::TitleBar(QWidget* parent)
     m_hpSlider->setFixedHeight(16);
     m_hpSlider->setAccessibleName("Headphone volume");
     m_hpSlider->setAccessibleDescription("Headphone volume level, 0 to 100 percent");
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_hpSlider, "QSlider::groove:horizontal { background: {{color.background.1}}; height: 4px; border-radius: 2px; }"
-        "QSlider::handle:horizontal { background: {{color.accent}}; width: 10px; margin: -3px 0; border-radius: 5px; }"
-        "QSlider::sub-page:horizontal { background: {{color.accent}}; border-radius: 2px; }");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_hpSlider, "QSlider::groove:horizontal { background: {{color.slider.background}}; height: 4px; border-radius: 2px; }"
+        "QSlider::handle:horizontal { background: {{color.slider.handle}}; width: 10px; margin: -3px 0; border-radius: 5px; }"
+        "QSlider::sub-page:horizontal { background: {{color.slider.foreground}}; border-radius: 2px; }");
     m_hbox->addWidget(m_hpSlider);
 
     m_hpLabel = new QLabel("50");

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -58,6 +58,13 @@ TxApplet::TxApplet(QWidget* parent)
     : QWidget(parent)
 {
     theme::setContainer(this, QStringLiteral("applet/tx"));
+    // Slider fill at applet/tx scope — the scope override gets applied
+    // via this applet-level stylesheet (Qt QSS cascades to descendants;
+    // resolveFor() picks up applet/tx → applet → root and finds the
+    // {color.red.500} alias).
+    AetherSDR::ThemeManager::instance().applyStyleSheet(this,
+        "QSlider::sub-page:horizontal { background: {{color.slider.foreground}}; }"
+        "QSlider::sub-page:vertical   { background: {{color.slider.foreground}}; }");
     hide();
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     buildUI();

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -242,6 +242,74 @@ int main(int argc, char** argv)
         QApplication::processEvents();
     }
 
+    // ── Slider + knob token namespaces seeded from compiled defaults ──
+    // Older user themes (forked before the namespace existed) have no
+    // slider/knob entries in their on-disk JSON.  seedBuiltinDefaults()
+    // is responsible for ensuring those tokens still resolve to the
+    // canonical Wave-blue look instead of empty / Qt-default rendering.
+    {
+        auto& tm = ThemeManager::instance();
+        tm.setActiveTheme("Default Dark");
+        EXPECT_TRUE(tm.color("color.slider.foreground").isValid());
+        EXPECT_TRUE(tm.color("color.slider.background").isValid());
+        EXPECT_TRUE(tm.color("color.slider.handle").isValid());
+        EXPECT_TRUE(tm.color("color.knob.foreground").isValid());
+        EXPECT_EQ(tm.color("color.slider.foreground").name().toLower(),
+                  QString("#00b4d8"));
+    }
+
+    // ── Per-applet scope cascade ──
+    // The bundled themes ship nested-scope overrides under
+    // scopes.applet.scopes.{tx,rx,comp}.  A widget walking via
+    // applet/tx should resolve the foreground to red, not the root
+    // scope's blue.
+    {
+        auto& tm = ThemeManager::instance();
+        tm.setActiveTheme("Default Dark");
+        EXPECT_EQ(tm.colorAt("applet/tx",   "color.slider.foreground").name().toLower(),
+                  QString("#ff4d4d"));
+        EXPECT_EQ(tm.colorAt("applet/rx",   "color.slider.foreground").name().toLower(),
+                  QString("#4dd87a"));
+        EXPECT_EQ(tm.colorAt("applet/comp", "color.slider.foreground").name().toLower(),
+                  QString("#ffb84d"));
+        EXPECT_EQ(tm.colorAt("applet/tx",   "color.knob.foreground").name().toLower(),
+                  QString("#ff4d4d"));
+        // Unrelated applet inherits root scope.
+        EXPECT_EQ(tm.colorAt("applet/dax",  "color.slider.foreground").name().toLower(),
+                  QString("#00b4d8"));
+        // isOverriddenAt distinguishes "set here" from "inherited".
+        EXPECT_TRUE(tm.isOverriddenAt("applet/tx", "color.slider.foreground"));
+        EXPECT_TRUE(!tm.isOverriddenAt("applet/tx", "color.text.primary"));
+    }
+
+    // ── ParentChange re-resolution ──
+    // applyStyleSheet on a widget with no parent locks the resolved
+    // stylesheet to root scope.  After the widget is reparented to a
+    // container marked themeContainer = "applet/tx", the
+    // QEvent::ParentChange filter should kick in and re-resolve
+    // against the new chain.
+    {
+        auto& tm = ThemeManager::instance();
+        tm.setActiveTheme("Default Dark");
+
+        QWidget txHost;
+        theme::setContainer(&txHost, "applet/tx");
+
+        QLabel* probe = new QLabel;  // no parent yet
+        tm.applyStyleSheet(probe,
+            "QLabel { color: {{color.slider.foreground}}; }");
+        // At apply time probe has no parent → resolves to root blue.
+        EXPECT_TRUE(probe->styleSheet().contains("#00b4d8"));
+
+        probe->setParent(&txHost);
+        QApplication::processEvents();
+        // After reparent the filter re-resolves through applet/tx → red.
+        EXPECT_TRUE(probe->styleSheet().contains("#ff4d4d"));
+
+        delete probe;
+        QApplication::processEvents();
+    }
+
     // ── extractReferencedTokens static helper ──
     // Order-preserving deduplication; empty placeholders ignored.
     {


### PR DESCRIPTION
First worked example of carving a control type out of the generic theme categories (`color.accent` / `color.background.1` / `color.text.primary`) into dedicated namespaces with per-applet overrides through the v2 scope tree.  Sets the pattern for follow-up sweeps (toggle buttons, spinboxes, progress bars, …).

**Draft** — opening early for visibility; more polish may layer on top.

## What's in this PR

### New token namespaces (12 entries)

```
color.slider.background           ← groove + add-page
color.slider.foreground           ← sub-page (filled portion)
color.slider.handle               ← thumb
color.slider.background.disabled
color.slider.foreground.disabled
color.slider.handle.disabled

color.knob.background             ← ring / track
color.knob.foreground             ← indicator arc
color.knob.handle                 ← center pointer / tick
color.knob.background.disabled
color.knob.foreground.disabled
color.knob.handle.disabled
```

State suffix (`.disabled`) matches existing `color.text.disabled` / `color.accent.bright` pattern.  Hover / pressed deferred — explicit design call.

### Per-applet cascade (visible result)

Bundled themes ship nested-scope overrides:

| Scope | `color.slider.foreground` & `color.knob.foreground` |
|---|---|
| `applet/tx` | `{color.red.500}` |
| `applet/rx` | `{color.green.500}` |
| `applet/comp` | `{color.amber.500}` |
| (everywhere else) | inherits root → `{color.blue.500}` |

Open the TX applet → sliders + the comp knob (if a comp lives inside) render red. Open RX → green. Open the compressor applet → amber. All other surfaces stay the canonical blue.

### The ParentChange event filter (general fix)

While building this, surfaced a latent bug: helpers like `applyPrimarySliderStyle` are commonly called **before** the widget is added to its parent layout (configure → applyStyle → addWidget).  At apply time the widget has no parent, so `containerPathFor` walks nothing and resolves the QSS against root scope.  The applet-scope override never reaches the widget.

Fix: `ThemeManager` now installs itself as an event filter on every widget tracked through `applyStyleSheet`.  `QEvent::ParentChange` re-resolves the template against the now-correct scope chain.  Cheap — only fires during initial construction / rare deliberate reparents.

This makes **every** helper that configures a widget pre-parent work correctly (applyAppTheme, applyPrimarySliderStyle, the dozens of inline applyStyleSheet sites in ctor bodies) without per-call-site changes.

### seedBuiltinDefaults safety net

Older user themes (forked before this PR exists) get:
1. Root-scope hex values for all 12 tokens (raw hex, no primitives dependency).
2. `applet/tx`, `applet/rx`, `applet/comp` scope-tree seeds via `scopeOrCreate()` with the red/green/amber overrides.

Bundled themes' JSON re-asserts these via `{color.red.500}` aliases — idempotent, but the seed is what makes per-applet differentiation work on a "My Default Dark" forked last week.

## Files touched

| File | Role |
|---|---|
| `resources/themes/default-dark.json`, `default-light.json` | Token defs + nested scope overrides |
| `src/core/ThemeManager.{h,cpp}` | seedBuiltinDefaults extension + ParentChange filter |
| `src/gui/Theme.h` | Global QSS migration + `applyPrimarySliderStyle` default arg |
| `src/gui/TitleBar.cpp` | Master + headphone sliders read from `color.slider.*` |
| `src/gui/TxApplet.cpp` / `RxApplet.cpp` / `ClientCompApplet.cpp` | Applet-level slider QSS override (catches sliders not using the helper) |
| `src/gui/ClientCompKnob.cpp` | Widget-aware paint-code migration to `color.knob.*` |
| `docs/theming/slider-knob-tokens.md` | Full writeup of the namespace + cascade + ParentChange pattern |

## Out of scope (follow-ups)

- **`PhaseKnob`** paint code still uses 6 hardcoded `QColor` literals — needs more design judgment than a rename.
- **Hardcoded-hex slider sites** in `PanadapterApplet`, `EqApplet`, `RadioSetupDialog`, `FlexControlDialog` bypass the theme system entirely.  Each needs its local stylesheet dropped in favour of the global QSS + per-applet override path.
- **Dialog-scope knob overrides** — available today (namespace + scope tree both support it); nothing declared yet.

## Test plan

- [ ] Open TX applet — every slider's filled portion is **red**.
- [ ] Open RX applet — every slider's filled portion is **green**.
- [ ] Open the compressor applet — every knob arc + slider fill is **amber**.
- [ ] Every other applet (DAX, EQ, Phone, …) renders the canonical **blue** fill from root scope.
- [ ] Disable an AGC slider (or any slider in a disabled section) — groove/fill/handle shift to the muted disabled variants.
- [ ] Open Theme Editor, pick scope `applet/tx` — the columnar view shows `color.slider.foreground` overridden at the `tx` column.
- [ ] Inspector click on a slider surfaces the 6 `color.slider.*` entries; click on a comp knob surfaces the 6 `color.knob.*` entries.
- [ ] Smoke-test on both Default Dark and Default Light.
- [ ] Verify a user theme forked before this PR (e.g. "My Default Dark") still gets the per-applet colours via the seeded defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)