### PR TITLE
feat(spots): keyboard frequency entry in Add Spot dialog (#3183)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4364,7 +4364,7 @@ void SpectrumWidget::showAddSpotDialog(double freqMhz)
     auto* layout = new QFormLayout(&dlg);
 
     auto* freqSpin = new QDoubleSpinBox;
-    freqSpin->setRange(0.030, 54.000);
+    freqSpin->setRange(0.030, 50000.000);  // 50 GHz cap matches VfoWidget convention
     freqSpin->setDecimals(6);
     freqSpin->setSingleStep(m_stepHz > 0 ? m_stepHz / 1e6 : 0.001);
     freqSpin->setSuffix(" MHz");

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -26,6 +26,7 @@
 #include <QCheckBox>
 #include <QDialogButtonBox>
 #include <QFrame>
+#include <QDoubleSpinBox>
 #include <QLabel>
 #include <QVBoxLayout>
 #include <QWidgetAction>
@@ -4353,14 +4354,23 @@ void SpectrumWidget::showAddSpotDialog(double freqMhz)
     dlg.setWindowTitle("Add Spot");
     AetherSDR::ThemeManager::instance().applyStyleSheet(&dlg, "QDialog { background: {{color.background.0}}; color: {{color.text.primary}}; }"
                       "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid #304060; padding: 4px; }"
+                      "QDoubleSpinBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid #304060; padding: 4px; }"
+                      "QDoubleSpinBox::up-button { background: #304060; width: 16px; }"
+                      "QDoubleSpinBox::down-button { background: #304060; width: 16px; }"
                       "QComboBox { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid #304060; padding: 4px; }"
                       "QLabel { color: {{color.text.primary}}; }"
                       "QCheckBox { color: {{color.text.primary}}; }");
 
     auto* layout = new QFormLayout(&dlg);
 
-    auto* freqLabel = new QLabel(QString("%1 MHz").arg(freqMhz, 0, 'f', 6));
-    layout->addRow("Frequency:", freqLabel);
+    auto* freqSpin = new QDoubleSpinBox;
+    freqSpin->setRange(0.030, 54.000);
+    freqSpin->setDecimals(6);
+    freqSpin->setSingleStep(m_stepHz > 0 ? m_stepHz / 1e6 : 0.001);
+    freqSpin->setSuffix(" MHz");
+    freqSpin->setValue(freqMhz);
+    freqSpin->setAlignment(Qt::AlignRight);
+    layout->addRow("Frequency (MHz):", freqSpin);
 
     auto* callEdit = new QLineEdit;
     callEdit->setPlaceholderText("Callsign (required)");
@@ -4394,8 +4404,12 @@ void SpectrumWidget::showAddSpotDialog(double freqMhz)
     connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
     connect(buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
 
+    freqSpin->setFocus();
+    freqSpin->selectAll();
+
     if (dlg.exec() != QDialog::Accepted) return;
 
+    const double finalFreqMhz = freqSpin->value();
     const QString callsign = callEdit->text().trimmed().toUpper();
     if (callsign.isEmpty()) return;
 
@@ -4407,7 +4421,7 @@ void SpectrumWidget::showAddSpotDialog(double freqMhz)
     as.setValue("ManualSpotLifetime", QString::number(lifetimeSec));
     as.setValue("SpotForwardToCluster", forward ? "True" : "False");
 
-    emit spotAddRequested(freqMhz, callsign, comment, lifetimeSec, forward);
+    emit spotAddRequested(finalFreqMhz, callsign, comment, lifetimeSec, forward);
 }
 
 void SpectrumWidget::mouseDoubleClickEvent(QMouseEvent* ev)


### PR DESCRIPTION
## Summary

- Replaces the static frequency label in the "Add Spot" dialog with a `QDoubleSpinBox`, allowing the user to type a frequency directly instead of relying solely on the right-click location
- Spinbox is focused and selected by default — open the dialog and start typing immediately
- Range enforced to 0.030–54.000 MHz; step size follows the panadapter's current `m_stepHz`; 6 decimal places (Hz resolution)
- Styled via ThemeManager to match the existing dialog theme
- Emits the spinbox value rather than the snapped right-click frequency, so a manually typed value is honoured

Fixes #3183

## Test plan

- [ ] Right-click spectrum → "Add Spot at X MHz..." — dialog opens with editable frequency field focused
- [ ] Type a new frequency (e.g. `14.225`) — spinbox accepts it, Tab moves to callsign field
- [ ] Submit the dialog — spot appears at the typed frequency, not the original right-click frequency
- [ ] Spin arrows increment/decrement by the radio's step size
- [ ] Values below 0.030 or above 54.000 are clamped by the spinbox
- [ ] "Add Spot" from the VFO widget toolbar also opens the updated dialog
- [ ] Theme styling matches the rest of the dialog