### PR TITLE
fix(spots): exempt memory bookmarks from smart filter; fix stale S-history cache (#2894)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -16829,9 +16829,7 @@ void MainWindow::expireSHistoryMarkers()
         // Rebuild unconditionally: hit-window timestamps age out every second
         // even when no new detections arrive, which hides markers whose peaks
         // have fallen below the 25% threshold.
-        if (!entries.isEmpty()) {
-            rebuildSHistoryForPan(it.key());
-        }
+        rebuildSHistoryForPan(it.key());
     }
 }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -6909,9 +6909,10 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
 
         // Determine draw opacity.
         // QRM markers: always 30%.  Smart-filter unmatched/expired spots: user-configurable (default 20%).  Normal: 100%.
-        const bool isQrm = (spot.source == QStringLiteral("QRM"));
+        const bool isQrm    = (spot.source == QStringLiteral("QRM"));
+        const bool isMemory = (spot.source == QStringLiteral("Memory"));
         bool dimForFilter = false;
-        if (!isQrm && smartFilterReady && !sHistVoiceFreqs.isEmpty()) {
+        if (!isQrm && !isMemory && smartFilterReady && !sHistVoiceFreqs.isEmpty()) {
             // Only apply to voice/SSB spots; leave CW/digital at full opacity.
             const QString mu = spot.mode.toUpper();
             const bool isDigital = mu.contains("CW")   || mu.contains("FT")  ||


### PR DESCRIPTION
## Summary

Fixes two related defects in the Smart Spot Filtering path reported in #2894.

**Defect A — Memory bookmarks dimmed by smart filter (`SpectrumWidget.cpp`)**
Memory bookmarks shared `m_spotMarkers` with DX spots and passed through the smart-filter gate, which only exempted `QRM`-source markers. Added an `isMemory` check so `Memory`-source spots always render at full opacity. The filter's documented scope is DX voice spots; user-curated memory bookmarks have no S-History to match against.

**Defect B — Stale S-history cache causes periodic global dim (`MainWindow.cpp`)**
`expireSHistoryMarkers()` only called `rebuildSHistoryForPan()` when `entries` was non-empty after the erase pass. When all entries aged out simultaneously (quiet band, or a cluster batch arriving at once), `SpectrumWidget::m_sHistoryMarkers` was left holding stale frequencies — every voice spot and memory bookmark dimmed for ~60 s until new voice activity arrived. Removed the guard so the rebuild always fires, matching the comment immediately above it ("Rebuild unconditionally…").

## Changes

- `src/gui/SpectrumWidget.cpp` — add `isMemory` boolean; extend filter gate to `!isQrm && !isMemory`
- `src/gui/MainWindow.cpp` — remove `if (!entries.isEmpty())` guard around `rebuildSHistoryForPan()`

## Test plan

- [ ] Enable Smart Spot Filtering (View → Smart Spot Filtering)
- [ ] Add memory bookmarks on the panadapter — confirm they render at full opacity regardless of S-History state
- [ ] On a quiet band, wait 60+ seconds — confirm voice DX spots do not globally dim and recover cyclically
- [ ] DX voice spots without matching S-History activity still dim as expected
- [ ] CW/digital spots unaffected (existing behaviour preserved)
- [ ] Toggling Smart Spot Filtering off/on still restores all spots to full opacity