### PR TITLE
fix(smeter): Level TX mode reads MIC meter instead of MICPEAK (#3187)

### DIFF
--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -93,9 +93,9 @@ void SMeterWidget::setTxMeters(float fwdPower, float swr)
 
 void SMeterWidget::setMicMeters(float micLevel, float compLevel, float micPeak, float compPeak)
 {
-    Q_UNUSED(micLevel);
     Q_UNUSED(compLevel);
-    m_micLevel = micPeak;
+    m_micLevel = micLevel;   // MIC meter — live level, matches Phone/CW Level gauge
+    m_micPeak  = micPeak;    // MICPEAK meter — stored for future peak-tick rendering
     // MeterModel normalizes COMPPEAK to a 0..25 dB compression amount.
     m_compLevel = qBound(0.0f, compPeak, 25.0f);
 

--- a/src/gui/SMeterWidget.h
+++ b/src/gui/SMeterWidget.h
@@ -85,7 +85,8 @@ private:
     // TX meter values (updated continuously, used when transmitting)
     float   m_txPower{0.0f};
     float   m_txSwr{1.0f};
-    float   m_micLevel{-50.0f};
+    float   m_micLevel{-50.0f};  // MIC meter — drives Level mode needle
+    float   m_micPeak{-50.0f};   // MICPEAK meter — reserved for future peak tick
     float   m_compLevel{0.0f};
 
     // Mode state


### PR DESCRIPTION
## Summary

`SMeterWidget::setMicMeters()` was assigning `m_micLevel = micPeak` (the `MICPEAK` meter value) and ignoring the `micLevel` parameter (the `MIC` meter). `TxMode::Level` calls `currentTxValue()` which returns `m_micLevel`, so the S-Meter needle in Level mode was driven by `MICPEAK` — a value that may be stale or not streamed on some radio/firmware configurations, leaving the needle pinned at zero.

The Phone/CW Level gauge already uses the `MIC` meter (instantaneous level). This fix makes the S-Meter Level needle use the same meter, so both displays agree.

`MICPEAK` is now stored in a separate `m_micPeak` member, preserving the value for future peak-tick rendering without affecting the Level needle.

## Changes

- `src/gui/SMeterWidget.h` — add `float m_micPeak{-50.0f}` member
- `src/gui/SMeterWidget.cpp` — `m_micLevel = micLevel` (was `micPeak`); store peak in `m_micPeak`; remove erroneous `Q_UNUSED(micLevel)`

## Test plan

- [ ] Transmit with Level mode selected — S-Meter needle moves with audio in sync with the Phone/CW Level gauge
- [ ] Power and SWR modes unaffected
- [ ] Compression mode unaffected
- [ ] Needle returns to RX S-Meter reading immediately on un-key

Fixes #3187