### PR TITLE
fix(overlay): stop SpectrumWidget killing child-widget tooltips; expand CI path filter (#2355, #3052)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,14 @@ jobs:
               # Windows CI build whenever this file changes. (#2671)
               - 'src/gui/MainWindow.cpp'
               - 'src/gui/MainWindow.h'
+              # AudioEngine.cpp / .h are equally dense with platform-guarded
+              # code (WASAPI, CoreAudio, ALSA/PipeWire paths). A Linux-passing
+              # change inside a Q_OS_WIN block will skip check-windows without
+              # this entry. Post-mortem: #2929 (WASAPI mono-mic recovery)
+              # landed on main unverified because AudioEngine wasn't in the
+              # filter. (#3052)
+              - 'src/core/AudioEngine.cpp'
+              - 'src/core/AudioEngine.h'
 
   # Cross-platform build check — runs only when CMakeLists.txt, third_party/,
   # or workflows are modified, to catch MSVC issues before release. (#796 lesson)

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -3839,6 +3839,15 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
     const auto dragStatePublisher = makeScopeExit([this] { publishPerfDragState(); });
     (void)dragStatePublisher;
 
+    // Let child widgets (overlay menu buttons) own the pointer while hovered so
+    // their tooltips are not killed by SpectrumWidget's QToolTip::hideText() calls.
+    // Guard is skipped during active drags — those always start in the spectrum
+    // area, not over child widgets. (#2355)
+    if (!anyDragActive() && childAt(ev->position().toPoint())) {
+        ev->ignore();
+        return;
+    }
+
     const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
     const int contentH = height() - chromeH;
     const int specH = static_cast<int>(contentH * m_spectrumFrac);


### PR DESCRIPTION
## Summary

Two unrelated small fixes bundled together.

### Fix #2355 — overlay menu tooltips dismissed immediately

`mouseMoveEvent()` in `SpectrumWidget` contains multiple `QToolTip::hideText()` call sites that fire whenever the cursor moves over any child widget, including `SpectrumOverlayMenu` buttons (MEM+, MEM▶, DAX). This immediately dismisses their tooltips as soon as the mouse enters the button rect.

Added an early-return guard at the top of `mouseMoveEvent()`: if the cursor is over a child widget and no drag is active, the event is ignored and returned so the child owns the pointer. Active drags are exempt — they always originate in the spectrum area, so `childAt()` returns null during a drag regardless.

### Fix #3052 — expand `check-windows` path filter to `AudioEngine`

`AudioEngine.cpp/.h` carries the same density of `Q_OS_WIN` / `Q_OS_MAC` platform guards as `MainWindow`, but was absent from the dorny/paths-filter `build` group. A Linux-passing change inside a `#ifdef Q_OS_WIN` block could land on `main` without triggering a Windows CI check. Adds both files to the filter, with a post-mortem comment referencing #2929.

## Changes

- `src/gui/SpectrumWidget.cpp` — 8-line `childAt()` + `anyDragActive()` guard in `mouseMoveEvent()`
- `.github/workflows/ci.yml` — add `src/core/AudioEngine.cpp` and `src/core/AudioEngine.h` to `build` filter

## Test plan

- [ ] Hover over MEM+, MEM▶, DAX buttons in the spectrum overlay — tooltips persist for their full duration
- [ ] Hover over a DX spot marker in the spectrum — tooltip still shows normally
- [ ] Hover over a TNF notch — TNF popup still shows
- [ ] Drag a VFO or TNF across the overlay area — drag continues uninterrupted
- [ ] CI: modify `AudioEngine.cpp` in a PR — `check-windows` job should now trigger

Fixes #2355, #3052