### PR TITLE
cleanup(theme): swap kGreenToggle #006040 for color.background.success (#3141)

### DIFF
--- a/src/gui/CatControlApplet.cpp
+++ b/src/gui/CatControlApplet.cpp
@@ -24,14 +24,13 @@ namespace {
 
 // Stylesheet templates — tokens are resolved at runtime by ThemeManager.
 // Use ThemeManager::applyStyleSheet(widget, kXxx) so widgets re-style automatically
-// on theme changes.  The :checked colours on kGreenToggle have no matching token
-// (there is no dark-success-background token) so they stay hardcoded.
+// on theme changes.
 
 const char* kGreenToggle =
     "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; border-radius: 3px;"
     " color: {{color.text.primary}}; font-size: 11px; font-weight: bold; padding: 2px 8px; }"
     "QPushButton:hover { background: {{color.background.2}}; }"
-    "QPushButton:checked { background: #006040; color: {{color.accent.success}}; border: 1px solid {{color.accent.success}}; }";
+    "QPushButton:checked { background: {{color.background.success}}; color: {{color.accent.success}}; border: 1px solid {{color.accent.success}}; }";
 
 const char* kHintBtn =
     "QPushButton { background: transparent; border: none; color: {{color.text.label}};"


### PR DESCRIPTION
Closes #3141.

## Summary

Mechanical token swap in `CatControlApplet.cpp::kGreenToggle`:

- `background: #006040` → `background: {{color.background.success}}`
- Stale comment block about "no dark-success-background token" removed (the token landed in PR #3130 alongside the Theme Editor work).

## Why

The literal `#006040` was bit-identical to the new dark token `color.background.success`, so the swap is visually-identical on Default Dark. The original concern was light theme: the hardcoded saturated dark-green on a light surround was unreadable. With the token, light theme now resolves to the soft mint `#c8e8d0` defined in `default-light.json`.

## Diff

```cpp
// Before
"QPushButton:checked { background: #006040; color: {{color.accent.success}}; "
"border: 1px solid {{color.accent.success}}; }";

// After
"QPushButton:checked { background: {{color.background.success}}; "
"color: {{color.accent.success}}; "
"border: 1px solid {{color.accent.success}}; }";
```

## Verification

Built on Windows 11 (MSVC + Ninja + Qt 6) on top of `aethersdr/AetherSDR` main at `9f3f1c4c`. Smoke-tested both docked and floating CAT Control variants in both bundled themes:

| Theme | Variant | `:checked` background | Result |
| --- | --- | --- | --- |
| Default Dark | docked | `#006040` (token resolves to bit-identical value) | unchanged ✓ |
| Default Dark | floating pop-out | `#006040` | unchanged ✓ |
| Default Light | docked | `#c8e8d0` soft mint | legible ✓ |
| Default Light | floating pop-out | `#c8e8d0` | legible ✓ |

Screenshots of dark `:checked` (proof of pixel-identical regression) and light `:checked` (the legibility fix) available — happy to attach to the description in a follow-up commit comment.

## Acceptance checklist (from #3141)

- [x] `#006040` literal removed from `kGreenToggle` in `CatControlApplet.cpp`
- [x] Stale "no dark-success-background token" comment removed
- [x] Dark theme renders identically (token is bit-identical)
- [x] Light theme `:checked` button is now legible

cc @ten9876 @jensenpat

73 Nigel G0JKN

🤖 Generated with [Claude Code](https://claude.com/claude-code)