### PR TITLE
fix(theme): editor UX polish — filter persistence + reset semantics + factory-loader v2

### DIFF
--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -824,8 +824,46 @@ void ThemeManager::ensureFactoryLoaded() const
                          << err.errorString();
         return;
     }
-    flattenTokens(doc.object().value("tokens").toObject(), QString(),
-                  m_factoryTokens);
+    const QJsonObject root = doc.object();
+    const int schemaVer = root.value("schemaVersion").toInt(0);
+    if (schemaVer >= 2) {
+        // v2: tokens live under scopes.root.tokens, and most values are
+        // {primitive} aliases that need resolving before factoryColor()
+        // can return a valid QColor.  The legacy single-line flattenTokens
+        // call below worked for v1 (flat tokens at the document root) but
+        // landed an empty m_factoryTokens against every v2 theme — which
+        // silently disabled the Reset button at root scope across the
+        // whole editor.
+        QHash<QString, QString> factoryPrims;
+        const QJsonObject primitives = root.value("primitives").toObject();
+        for (auto it = primitives.constBegin(); it != primitives.constEnd(); ++it) {
+            if (it.value().isString())
+                factoryPrims.insert(it.key(), it.value().toString());
+        }
+        const QJsonObject scopesObj = root.value("scopes").toObject();
+        const QJsonObject rootScope = scopesObj.value("root").toObject();
+        flattenTokens(rootScope.value("tokens").toObject(), QString(),
+                      m_factoryTokens);
+        // Resolve `{primitive}` aliases inline so factoryColor() /
+        // factoryString() see concrete hex / family values without
+        // needing a second lookup pass.  Single-hop resolution matches
+        // the live runtime resolver (resolveAlias in this file).
+        for (auto it = m_factoryTokens.begin(); it != m_factoryTokens.end(); ++it) {
+            if (it.value().userType() != QMetaType::QString) continue;
+            const QString s = it.value().toString();
+            if (s.size() < 3 ||
+                !s.startsWith(QLatin1Char('{')) ||
+                !s.endsWith(QLatin1Char('}'))) continue;
+            const auto pit = factoryPrims.constFind(s.mid(1, s.size() - 2));
+            if (pit != factoryPrims.constEnd()) it.value() = pit.value();
+        }
+    } else {
+        // v1: flat tokens at document root.  Auto-migrated to v2 on
+        // saveActiveTheme, but pre-migration files still load through
+        // this branch.
+        flattenTokens(root.value("tokens").toObject(), QString(),
+                      m_factoryTokens);
+    }
 }
 
 ThemeGradient ThemeManager::factoryGradient(const QString& token) const

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -2,6 +2,7 @@
 #include "Theme.h"
 #include "ThemeInspector.h"
 #include "TokenEditorWidget.h"
+#include "core/AppSettings.h"
 #include "core/ThemeManager.h"
 
 #include <QAction>
@@ -382,6 +383,11 @@ void ThemeEditorDialog::refreshTokenList()
         m_tokenList->addTopLevelItem(item);
         populateRow(item);
     }
+    // Re-apply the current filter (text + inspector subset) so the
+    // user's view doesn't suddenly fall back to "show everything"
+    // after a scope change / theme reload.  filterTokensTo reads the
+    // QLineEdit's current text directly.
+    filterTokensTo(m_activeSubset);
 }
 
 void ThemeEditorDialog::populateRow(QTreeWidgetItem* item)
@@ -643,6 +649,17 @@ void ThemeEditorDialog::onDeleteThemeClicked()
         QMessageBox::warning(this, QStringLiteral("Delete failed"),
             QStringLiteral("Could not delete \"%1\". The theme file may be "
                            "locked by another process.").arg(current));
+        return;
+    }
+
+    // The per-theme recent-colors bucket in AppSettings outlives the
+    // theme file by default; clean it up so deleted themes don't
+    // accumulate orphan entries under ThemeEditor.RecentColors/<name>.
+    auto& s = AppSettings::instance();
+    const QString recentsKey = TokenEditorWidget::recentColorsKeyFor(current);
+    if (s.contains(recentsKey)) {
+        s.remove(recentsKey);
+        s.save();
     }
 }
 

--- a/src/gui/TokenEditorWidget.cpp
+++ b/src/gui/TokenEditorWidget.cpp
@@ -643,8 +643,20 @@ void TokenEditorWidget::refreshResetButton()
         m_resetBtn->setEnabled(false);
         return;
     }
-    m_resetBtn->setEnabled(
-        ThemeManager::instance().hasFactoryValue(m_currentToken));
+    auto& tm = ThemeManager::instance();
+    if (m_activeContainerPath.isEmpty()) {
+        // Root scope: Reset loads the bundled factory value into the
+        // edit buffer for the user to confirm via OK.  Only useful
+        // when there's a factory value to fall back to.
+        m_resetBtn->setEnabled(tm.hasFactoryValue(m_currentToken));
+    } else {
+        // Nested scope: Reset means "clear my override here" — useful
+        // only when there IS an override at this scope to clear.
+        // Mirrors right-click → Clear Override on the scope-chain
+        // column, so the button's enable state matches that semantic.
+        m_resetBtn->setEnabled(
+            tm.isOverriddenAt(m_activeContainerPath, m_currentToken));
+    }
 }
 
 // ───────────────────────────────────────────────────────── markDirty ─────
@@ -1154,6 +1166,32 @@ void TokenEditorWidget::onResetClicked()
 {
     if (m_currentToken.isEmpty()) return;
     auto& tm = ThemeManager::instance();
+
+    // Nested scope: Reset means "clear my override here" so the
+    // scope falls back to inheriting from its parent.  Mirrors the
+    // right-click → Clear Override action on the scope-chain column
+    // (ThemeEditorDialog::showTokenContextMenu).  The previous
+    // behaviour — loading the bundled factory value into the buffer
+    // and writing a new override on OK — has been confusing here
+    // since the v2 scope tree landed (per #3184).
+    if (!m_activeContainerPath.isEmpty()) {
+        if (!tm.isOverriddenAt(m_activeContainerPath, m_currentToken)) return;
+        tm.removeOverride(m_activeContainerPath, m_currentToken);
+        // Reload the editor's buffer + controls from the now-inherited
+        // value so there's no stale pending edit.  setToken clears
+        // m_dirty / disables OK + Cancel internally.
+        setToken(m_currentToken);
+        // Trigger the parent dialog to repopulate the matching token-list
+        // row so the scope-chain column flips to italic "inherited" and
+        // the Value column shows the now-resolved value instead of the
+        // stale override.  onTokenEditedByEditor finds the row by token
+        // key and calls populateRow on it.
+        emit tokenChanged(m_currentToken);
+        return;
+    }
+
+    // Root scope: existing behaviour — load the bundled factory value
+    // into the edit buffer for the user to confirm via OK.
     if (!tm.hasFactoryValue(m_currentToken)) return;
 
     m_settingControlsFromToken = true;

--- a/src/gui/TokenEditorWidget.h
+++ b/src/gui/TokenEditorWidget.h
@@ -81,6 +81,12 @@ public:
     // switched to a non-built-in copy.  No-op if no edit is pending.
     void completeDeferredCommit();
 
+    // AppSettings key for the per-theme recent-colors bucket.  Public
+    // so the editor dialog can clear the bucket when a theme is
+    // deleted (otherwise orphan entries accumulate forever in
+    // AppSettings.RecentColors/<deleted theme>).
+    static QString recentColorsKeyFor(const QString& themeName);
+
 private slots:
     void onColorPickerChanged(const QColor& c);
     void onColorTypeToggled();
@@ -195,7 +201,6 @@ private:
     void refreshRecentButtons();
     void applyRecentColor(int idx);
     void reloadRecentColorsIfThemeChanged();
-    static QString recentColorsKeyFor(const QString& themeName);
 
     QString    m_currentToken;
     QString    m_activeContainerPath;  // empty == root scope

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -300,6 +300,15 @@ int main(int argc, char** argv)
         EXPECT_EQ(tm.factoryColor("color.accent").name().toLower(),
                   QString("#00b4d8"));  // alias {color.blue.500} resolved
         EXPECT_TRUE(tm.hasFactoryValue("color.background.0"));
+        // Gradient tokens land in m_factoryTokens as QVariant<ThemeGradient>
+        // rather than QString.  The alias-resolution loop must skip those
+        // (userType() != QMetaType::QString) — and factoryColor() must take
+        // the first-stop-fallback branch at ThemeManager.cpp:849-851 to
+        // return a valid colour.  Lock both in: color.meter.bar.fillGradient
+        // is bundled as a v2 gradient with first stop #2f9e6a.
+        EXPECT_TRUE(tm.hasFactoryValue("color.meter.bar.fillGradient"));
+        EXPECT_EQ(tm.factoryColor("color.meter.bar.fillGradient").name().toLower(),
+                  QString("#2f9e6a"));
         // Tokens that don't exist in the bundled theme should still
         // report no factory value (sanity check the lookup isn't
         // unconditionally returning true).

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -285,6 +285,27 @@ int main(int argc, char** argv)
         EXPECT_TRUE(!tm.isOverriddenAt("applet/tx", "color.text.primary"));
     }
 
+    // ── Factory-snapshot v2 schema awareness ──
+    // ensureFactoryLoaded() reads :/themes/default-dark.json to build
+    // m_factoryTokens, which Reset-to-default reads at root scope.  The
+    // pre-PR loader only knew the v1 shape (top-level "tokens") and
+    // therefore landed an empty map for any v2-schema theme — silently
+    // disabling Reset at root scope across the editor since #3176.  This
+    // test locks in the v2-aware factory path so a future schema bump
+    // doesn't regress it.
+    {
+        auto& tm = ThemeManager::instance();
+        tm.setActiveTheme("Default Dark");
+        EXPECT_TRUE(tm.hasFactoryValue("color.accent"));
+        EXPECT_EQ(tm.factoryColor("color.accent").name().toLower(),
+                  QString("#00b4d8"));  // alias {color.blue.500} resolved
+        EXPECT_TRUE(tm.hasFactoryValue("color.background.0"));
+        // Tokens that don't exist in the bundled theme should still
+        // report no factory value (sanity check the lookup isn't
+        // unconditionally returning true).
+        EXPECT_TRUE(!tm.hasFactoryValue("color.totally.fictional.token"));
+    }
+
     // ── ParentChange re-resolution ──
     // applyStyleSheet on a widget with no parent locks the resolved
     // stylesheet to root scope.  After the widget is reparented to a


### PR DESCRIPTION
Four targeted fixes to the Theme Editor surface picking up the Tier 3 "editor UX polish" bullets from [#3184](https://github.com/aethersdr/AetherSDR/issues/3184). Hand-tested across both bundled themes and a forked user theme; `theme_manager_test` gains coverage for the per-applet cascade and the new v2-aware factory snapshot.

## 1. Filter persistence across scope changes

`refreshTokenList()` rebuilds the token tree from scratch but never re-applied the current text/inspector subset filter — so switching the scope dropdown (or any path that triggers a refresh) caused the filter to silently fall back to "show everything" while the `QLineEdit` kept the text it was apparently filtering by.

One-line fix: call `filterTokensTo(m_activeSubset)` at the end of `refreshTokenList` so the rebuilt rows immediately honour the filter.

## 2. Theme-delete-time cleanup of recent-color buckets

Per-theme recent-color grids persist under the `AppSettings` key `ThemeEditor.RecentColors/<theme name>`. Deleting the theme file used to leave those entries behind forever — a small but real leak called out in #3184.

`onDeleteThemeClicked` now removes the matching key after the theme file deletion succeeds. `TokenEditorWidget::recentColorsKeyFor` is promoted from private to public-static so the dialog can call the canonical key formatter directly (no string-duplication risk).

## 3. Reset-to-default semantics at nested scopes

**At root scope** Reset still loads the bundled factory value into the edit buffer for the user to confirm via OK — that behaviour is preserved.

**At nested scopes** (`applet/tx`, `applet/rx`, `applet/comp`, …) the previous behaviour was incorrect: Reset loaded the factory value into the buffer, and OK then wrote that value as a *new* override at the nested scope. Per #3184 the intended semantic at a non-root scope is "clear my override here so the scope falls back to inheriting from its parent" — i.e. exactly what right-click → Clear Override on the scope-chain column already does.

`onResetClicked` now branches:
- **root scope**: existing factory-load-into-buffer behaviour
- **nested scope**: calls `removeOverride()` directly, reloads the editor's buffer + picker from the now-inherited value, emits `tokenChanged` so the parent dialog repopulates the matching row (so the scope column flips to italic *"inherited"* AND the Value column reflects the now-resolved value — without that signal the Value column would stay stale, as observed during testing).

`refreshResetButton` also branches: at root scope it enables based on `hasFactoryValue` (existing), at nested scope it enables only when there's actually an override at this scope to clear — mirrors the right-click → Clear Override gating, so the button visually reflects whether clicking it has any effect.

## 4. Factory-snapshot v2 schema awareness (uncovered during testing)

While verifying Fix #3 at root scope, discovered that Reset there was *also* broken — but for an unrelated reason that predates this PR.

`ThemeManager::ensureFactoryLoaded()` reads `:/themes/default-dark.json` to build the `m_factoryTokens` map that `factoryColor` / `factoryString` / `factorySizing` / `hasFactoryValue` all read from. Its single `flattenTokens` call read from `doc.object().value("tokens")` — which is the **v1 schema** shape. In v2 (the canonical shape since [#3176](https://github.com/aethersdr/AetherSDR/pull/3176)) the tokens live under `scopes.root.tokens`; the v1 path produces an empty `m_factoryTokens` against any v2 theme.

Downstream effect: `hasFactoryValue` returns false for every token in a v2 theme → `refreshResetButton` disables the Reset button at root scope (or with the existing styling, leaves it visually indistinguishable from enabled — silent failure either way) → `factoryColor` returns invalid QColor. **Silently broken across every v2 theme since #3176 landed in March.**

`ensureFactoryLoaded` now branches on `schemaVersion`:
- **v2**: reads `primitives` + `scopes.root.tokens`, then resolves `{primitive}` aliases inline before storing in `m_factoryTokens`, so `factoryColor` sees concrete hex values without needing a second lookup pass (matches the live runtime resolver — single-hop).
- **v1**: existing path preserved for older themes still on disk pending auto-migration.

`theme_manager_test` gains assertions on `hasFactoryValue` + `factoryColor` for `color.accent` (alias-resolved) and `color.background.0` to lock this in against future schema bumps.

## Verification

Windows 11, MSVC + Ninja + Qt 6.10.3, branched from `aethersdr/AetherSDR` main at `4ee99f78`.

| Check | Result |
|---|---|
| Filter persistence — type "accent", switch scope to `applet/tx` | Filter stays applied (list does NOT re-expand) ✓ |
| Nested-scope Reset — forked theme, `applet/tx`, `color.slider.foreground` (`#ff4d4d` override) → click Reset | Picker reloaded `#ff4d4d` → `#00b4d8`, tx column flipped from override to italic *"inherited"*, Value column updated to `#00b4d8`, Reset button disabled ✓ |
| Root-scope Reset — same theme, `(root)`, changed `color.accent` to magenta `#a12c66`, OK'd, then Reset | Picker flipped magenta → factory blue `#00b4d8`, `• unsaved` indicator appeared, OK + Cancel re-enabled, token list row still showed `#a12c66` (uncommitted buffer) ✓ |
| `theme_manager_test` — new factory-snapshot + per-applet cascade assertions | Pass ✓ |
| `theme_manager_test` — 4 pre-existing failures (`importThemeFromFile`-related, Windows-vs-CI env issue) | Also present on clean `main` at the same source line numbers (398/400/451/590 there → 419/421/472/611 here, +21 from inserted test block). Not introduced by this PR. Happy to investigate separately. |

## Out of scope (follow-ups)

- The `importThemeFromFile` test failures are not investigated here — they predate this PR and the root-cause looks Windows-environment-specific (`QTemporaryDir` / `XDG_CONFIG_HOME` interaction).
- Tooltips / hint text explaining what Reset does at root vs nested could further close the UX gap, but the enable-state gating already gives correct feedback.

cc @ten9876 @jensenpat @chibondking

73 Nigel G0JKN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
