### PR TITLE
fix(net): guard ensureOwnedPanadapter cap path with AdaptiveThrottleEnabled check

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2778,6 +2778,8 @@ int RadioModel::fpsCapForState(NetState s)
 
 int RadioModel::currentAdaptiveFpsCap() const
 {
+    if (AppSettings::instance().value("AdaptiveThrottleEnabled", "False").toString() != "True")
+        return 0;
     return fpsCapForState(m_netState);
 }
 
@@ -3418,7 +3420,12 @@ PanadapterModel* RadioModel::ensureOwnedPanadapter(const QString& panId)
 
     // Apply active throttle cap immediately — applyAdaptiveFrameRate only fires
     // on tier transitions, so a pan opened mid-throttle would run at the radio
-    // default (~25 fps) until the next state change.
+    // default (~25 fps) until the next state change. currentAdaptiveFpsCap()
+    // returns 0 when AdaptiveThrottleEnabled is off, so activeCap > 0 already
+    // gates both the push and the deferred lambda.
+    // Note: if the pan is created in a healthy state and the network degrades
+    // before waterfallId arrives, this connect is never made and the cap is
+    // applied by the next applyAdaptiveFrameRate() tier transition instead.
     const int activeCap = currentAdaptiveFpsCap();
     if (activeCap > 0) {
         qCDebug(lcProtocol) << "RadioModel: applying active throttle cap" << activeCap
@@ -3430,7 +3437,7 @@ PanadapterModel* RadioModel::ensureOwnedPanadapter(const QString& panId)
                 this, [this, normalizedPanId]() {
             const int cap = currentAdaptiveFpsCap();
             if (cap > 0) sendAdaptiveCapToPan(normalizedPanId, cap);
-        });
+        }, Qt::UniqueConnection);
     }
 
     connect(pan, &PanadapterModel::waterfallIdChanged,


### PR DESCRIPTION
## Summary

Closes a gap in the adaptive frame-rate throttle toggle introduced in #3175.

When a panadapter was **opened mid-session** while the network was already in a degraded state, `ensureOwnedPanadapter()` applied the active fps cap directly via `sendAdaptiveCapToPan()` without consulting `AdaptiveThrottleEnabled`. The toggle was bypassed for newly-registered pans, including the deferred `waterfallIdChanged` re-apply lambda.

## Approach: gate at the source

Rather than adding inline checks at each call site (which multiplies the guard and creates a latent risk for future callers), the fix moves the enable check into `currentAdaptiveFpsCap()`:

```cpp
int RadioModel::currentAdaptiveFpsCap() const
{
    if (AppSettings::instance().value("AdaptiveThrottleEnabled", "False").toString() != "True")
        return 0;
    return fpsCapForState(m_netState);
}
```

`ensureOwnedPanadapter()` already gates on `activeCap > 0` — it gets correct behaviour for free with no other changes. `applyAdaptiveFrameRate()` keeps its own early-return as a short-circuit (it calls `fpsCapForState` directly, not `currentAdaptiveFpsCap`).

## All `sendAdaptiveCapToPan` call sites now covered

| Location | How gated |
|---|---|
| `applyAdaptiveFrameRate()` | explicit early-return (short-circuit; calls `fpsCapForState` directly) |
| `ensureOwnedPanadapter()` immediate cap | `activeCap > 0` — `currentAdaptiveFpsCap()` returns 0 when off |
| `ensureOwnedPanadapter()` `waterfallIdChanged` lambda | same — `cap > 0` check calls `currentAdaptiveFpsCap()` |

## Additional nits addressed

- `Qt::UniqueConnection` added to the `waterfallIdChanged` lambda to prevent duplicate cap commands if `waterfallId` changes more than once on a pan
- Comment added documenting the narrow ordering edge case: pan created healthy → network degrades → `waterfallId` arrives before next tier transition. `applyAdaptiveFrameRate()` catches it on the next transition; noted, not fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)