### PR TITLE
[cw] drift-correct local CWX sidetone keyer

### DIFF
--- a/src/core/CwxLocalKeyer.cpp
+++ b/src/core/CwxLocalKeyer.cpp
@@ -55,6 +55,8 @@ void CwxLocalKeyer::stop()
     m_queue.clear();
     m_elements.clear();
     m_running = false;
+    m_elapsed.invalidate();
+    m_nextEdgeMs = 0;
     if (m_currentlyDown) {
         m_currentlyDown = false;
         emit keyStateChanged(false);
@@ -102,6 +104,8 @@ void CwxLocalKeyer::scheduleNext()
     if (m_elements.isEmpty()) {
         if (m_queue.isEmpty()) {
             m_running = false;
+            m_elapsed.invalidate();
+            m_nextEdgeMs = 0;
             if (m_currentlyDown) {
                 m_currentlyDown = false;
                 emit keyStateChanged(false);
@@ -140,7 +144,19 @@ void CwxLocalKeyer::scheduleNext()
         m_currentlyDown = keyDownNext;
         emit keyStateChanged(keyDownNext);
     }
-    m_timer.start(durationMs);
+    // Drift-correct against an absolute clock: the next edge should land
+    // at m_nextEdgeMs from the start of the run, not durationMs from now.
+    // Without this, GUI-thread event-loop coalescing on macOS (panadapter
+    // paint, VITA-49 burst handling) pushes each successive edge later
+    // and the slip accumulates — audible as stuttering and structurally
+    // wrong letter/word spacing on long contest macros (#2980).
+    if (!m_elapsed.isValid()) {
+        m_elapsed.start();
+        m_nextEdgeMs = 0;
+    }
+    m_nextEdgeMs += durationMs;
+    const qint64 wait = qMax<qint64>(1, m_nextEdgeMs - m_elapsed.elapsed());
+    m_timer.start(static_cast<int>(wait));
 }
 
 void CwxLocalKeyer::onTick()

--- a/src/core/CwxLocalKeyer.h
+++ b/src/core/CwxLocalKeyer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QElapsedTimer>
 #include <QObject>
 #include <QQueue>
 #include <QString>
@@ -53,6 +54,13 @@ private:
     int           m_unitMs{60};   // 60 ms = 20 WPM
     bool          m_running{false};
     bool          m_currentlyDown{false};
+    // Drift-corrected scheduling: absolute target edge time vs an elapsed
+    // reference, so a late tick is followed by a correspondingly shorter
+    // wait. Without this, every event-loop coalescing event on the GUI
+    // thread (panadapter paint, VITA-49 burst) pushes the next edge later
+    // and accumulates audible stutter / wrong word spacing on macOS (#2980).
+    QElapsedTimer m_elapsed;
+    qint64        m_nextEdgeMs{0};
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Summary

This is a clean replacement PR for the CWX local sidetone timing fix from #3109, rebased onto current `upstream/main`.

- Replaces relative `QTimer::start(durationMs)` scheduling in `CwxLocalKeyer` with absolute, drift-corrected edge scheduling.
- Tracks a `QElapsedTimer` epoch plus accumulated `m_nextEdgeMs` target so late GUI-thread timer dispatch is recovered on the following wait instead of accumulating.
- Resets the timing epoch when CWX drains or is explicitly stopped, so each new run starts from a fresh clock.
- Keeps the public API and `keyStateChanged(bool)` signal shape unchanged.

## Root Cause

CWX local sidetone is driven from `CwxLocalKeyer`, which runs on the GUI thread and schedules each Morse element with `m_timer.start(durationMs)` relative to the time the previous timeout handler finally ran.

On macOS, panadapter/waterfall paint, VITA-49 burst handling, status processing, and general Cocoa run-loop coalescing can delay `QTimer` delivery even with `Qt::PreciseTimer`. With relative scheduling, every delayed timeout pushes every later edge farther behind. Over a long CWX macro that slip becomes audible as local sidetone stutter and can stretch letter/word spacing.

The radio's own CWX keyer remains authoritative for the on-air signal. This change only corrects AetherSDR's local sidetone cadence so it stays aligned with the intended CW timing under GUI load.

## Implementation Notes

The scheduler now works like this:

1. Start an elapsed-time epoch on the first element of a run.
2. Accumulate the absolute target time for the next Morse edge in `m_nextEdgeMs`.
3. Start the timer for `target - elapsed`, clamped to at least 1 ms.
4. If a timeout arrives late, the next wait is shortened so the following edge returns to the intended timeline.
5. Invalidate the elapsed timer and zero the target when the run drains or `stop()` cancels it.

## Validation

Built and tested from current `upstream/main` plus this patch on macOS.

Automated checks run:

- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk`
- `cmake --build build --parallel 22`
- `build/cw_sidetone_test` passed
- `build/iambic_keyer_test` passed
- `QT_QPA_PLATFORM=offscreen build/cwx_panel_test` passed
- `ctest --test-dir build --output-on-failure -j 22` reached 21/22 passing; `theme_manager_test` is failing on current latest-main local preference/theme-import state and is unrelated to the two-file `CwxLocalKeyer` change.

Manual radio test performed by @jensenpat:

- Created a CWX macro containing 30 `S` characters.
- Watched each character's timing on the WAVE scope.
- Aggressively dragged the panadapter during playback to create GUI-thread pressure.
- Observed that character timing stayed lined up and the sidetone cadence sounded consistent throughout.

The corrected build was also deployed to the remote macOS test machine at `patj@mac.jensencloud.net:/Users/patj/Desktop/AetherSDR.app` and quarantine was cleared.

## Reviewer Test Plan

1. Build AetherSDR on macOS with the pinned CommandLineTools SDK.
2. Connect to a radio in `CW` or `CWL`.
3. Enable CW sidetone / PC audio and set CW speed around 20-30 WPM.
4. Create a CWX macro with a repetitive pattern such as 30 `S` characters, or a long contest macro.
5. Send the macro and watch timing on WAVE scope or another audio/timing view.
6. While it sends, aggressively drag or resize the panadapter/waterfall to create GUI load.
7. Expected result: local sidetone remains even and character timing does not progressively slip.
8. Press `Esc` while CWX is active; expected result: CWX sends `cwx clear` and local sidetone stops.

## Follow-Up Note

The title-bar `TX` cancel path forces MOX/CW/PTT down but does not currently clear the CWX local sidetone queue. `Esc` is the correct CWX abort path today. That is a separate UX/cancel-path follow-up from this timing drift fix.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
