### PR TITLE
cleanup(theme): tokenize hardcoded slider sites (Panadapter / Eq / RadioSetup / FlexControl)

### DIFF
--- a/src/gui/EqApplet.cpp
+++ b/src/gui/EqApplet.cpp
@@ -76,11 +76,17 @@ static const QString kBlueActive =
     "QPushButton:checked { background-color: #0070c0; color: #ffffff; "
     "border: 1px solid #0090e0; }";
 
-// Vertical slider style — thin groove, small handle
+// Vertical EQ band slider style — thin groove, accent-coloured handle.
+// Sizes kept site-local (intentional compact dimensions for the band
+// column rhythm); colours routed through color.slider.* so per-applet
+// override + live theme switching both light up.  Handle uses the
+// foreground (fill) token rather than the canonical handle token
+// because the EQ slider's visual idiom puts the accent colour on the
+// handle itself (there's no sub-page fill rule here).
 static constexpr const char* kVSliderStyle =
-    "QSlider::groove:vertical { width: 4px; background: #203040; border-radius: 2px; }"
+    "QSlider::groove:vertical { width: 4px; background: {{color.slider.background}}; border-radius: 2px; }"
     "QSlider::handle:vertical { height: 10px; width: 16px; margin: 0 -6px;"
-    "background: #00b4d8; border-radius: 5px; }";
+    "background: {{color.slider.foreground}}; border-radius: 5px; }";
 
 // Drag-popup formatter for EQ band sliders.  Matches the file-scope
 // free-function shape used by the other applets (wattsText, percentText,
@@ -262,7 +268,7 @@ void EqApplet::buildUI()
             slider->setValue(0);
             slider->setDragValueFormatter(dbWithSignText);
             slider->setTickPosition(QSlider::NoTicks);
-            slider->setStyleSheet(kVSliderStyle);
+            AetherSDR::ThemeManager::instance().applyStyleSheet(slider, kVSliderStyle);
             slider->setFixedHeight(100);
             slider->setAccessibleName(
                 QString("EQ %1").arg(EqualizerModel::bandLabel(static_cast<EqualizerModel::Band>(i))));

--- a/src/gui/FlexControlDialog.cpp
+++ b/src/gui/FlexControlDialog.cpp
@@ -197,21 +197,28 @@ QPushButton#OptionButton:checked {
     background: #173528;
     border-color: #65d379;
 }
+/* Slider rules tokenized as part of Pat's (b) hardcoded-slider sweep.
+   The wider handle (16 px) + bordered ring are deliberate FlexControl
+   visual identity, kept site-local.  Colours route through
+   color.slider.background / .handle for the structural tokens and
+   color.accent.success for the green fill + handle border, which
+   preserves the FlexControl green look while still letting a future
+   dialog/flexControl scope override retint it without touching code. */
 QSlider::groove:horizontal {
     height: 5px;
     border-radius: 2px;
-    background: #162437;
+    background: {{color.slider.background}};
 }
 QSlider::sub-page:horizontal {
-    background: #65d379;
+    background: {{color.accent.success}};
     border-radius: 2px;
 }
 QSlider::handle:horizontal {
     width: 16px;
     margin: -6px 0;
     border-radius: 8px;
-    background: #d8e2ef;
-    border: 1px solid #65d379;
+    background: {{color.slider.handle}};
+    border: 1px solid {{color.accent.success}};
 }
 QComboBox {
     color: #d8e2ef;
@@ -980,7 +987,15 @@ FlexControlDialog::FlexControlDialog(QWidget* parent)
     setWindowModality(Qt::NonModal);
     setMinimumSize(430, 610);
 
-    bodyWidget()->setStyleSheet(QString::fromLatin1(kFlexControlStyle));
+    // applyStyleSheet (not raw setStyleSheet) so the {{color.slider.*}} +
+    // {{color.accent.success}} tokens in the slider rules resolve at apply
+    // time, AND the body widget is registered for free live re-theme when
+    // the user switches Default Dark ↔ Default Light without restarting.
+    // Other (non-slider) hardcoded colours in the template remain as-is —
+    // out of scope for the slider-sweep PR; a follow-up could tokenize
+    // the rest of the FlexControl dialog stylesheet.
+    AetherSDR::ThemeManager::instance().applyStyleSheet(
+        bodyWidget(), QString::fromLatin1(kFlexControlStyle));
     auto* root = new QVBoxLayout(bodyWidget());
     root->setSizeConstraint(QLayout::SetMinimumSize);
     root->setContentsMargins(14, 14, 14, 14);

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -175,10 +175,14 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_lockSpeedBtn->setStyleSheet(m_lockPitchBtn->styleSheet());
     cwBar->addWidget(m_lockSpeedBtn);
 
-    // Pitch range sliders — constrain decoder frequency search
-    const QString rangeSliderStyle =
-        "QSlider::groove:horizontal { background: #1a2a3a; height: 4px; border-radius: 2px; }"
-        "QSlider::handle:horizontal { background: #6a8090; width: 8px; margin: -3px 0; border-radius: 4px; }";
+    // Pitch range sliders — constrain decoder frequency search.  Compact
+    // 50px-wide sliders for the CW bar; sizes kept site-local (deliberate
+    // narrow handle), colours routed through the color.slider.* namespace
+    // so the per-applet override path can retint them and live theme
+    // switching works without a per-site reapplication.
+    const QString rangeSliderStyle = QStringLiteral(
+        "QSlider::groove:horizontal { background: {{color.slider.background}}; height: 4px; border-radius: 2px; }"
+        "QSlider::handle:horizontal { background: {{color.slider.handle}}; width: 8px; margin: -3px 0; border-radius: 4px; }");
 
     auto* minLabel = new QLabel("Lo:");
     AetherSDR::ThemeManager::instance().applyStyleSheet(minLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
@@ -188,7 +192,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_pitchMinSlider->setRange(300, 1200);
     m_pitchMinSlider->setValue(500);
     m_pitchMinSlider->setFixedWidth(50);
-    m_pitchMinSlider->setStyleSheet(rangeSliderStyle);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_pitchMinSlider, rangeSliderStyle);
     m_pitchMinSlider->setToolTip("Decoder pitch search minimum (Hz)");
     cwBar->addWidget(m_pitchMinSlider);
     m_pitchMinValLabel = new QLabel(QString::number(m_pitchMinSlider->value()));
@@ -204,7 +208,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_pitchMaxSlider->setRange(300, 1200);
     m_pitchMaxSlider->setValue(700);
     m_pitchMaxSlider->setFixedWidth(50);
-    m_pitchMaxSlider->setStyleSheet(rangeSliderStyle);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_pitchMaxSlider, rangeSliderStyle);
     m_pitchMaxSlider->setToolTip("Decoder pitch search maximum (Hz)");
     cwBar->addWidget(m_pitchMaxSlider);
     m_pitchMaxValLabel = new QLabel(QString::number(m_pitchMaxSlider->value()));

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -2556,10 +2556,15 @@ QWidget* RadioSetupDialog::buildFiltersTab()
         "QPushButton:checked { background: #0070c0; color: #ffffff; "
         "border: 1px solid #0090e0; }";
 
-    static const QString kFilterSlider =
-        "QSlider::groove:horizontal { background: #1a2a3a; height: 6px; border-radius: 3px; }"
-        "QSlider::handle:horizontal { background: #c8d8e8; width: 14px; "
-        "margin: -5px 0; border-radius: 7px; }";
+    // Filter sharpness sliders — taller groove + wider handle than the
+    // canonical slider for the radio-setup dialog's heavier visual style.
+    // Sizes kept site-local (deliberate emphasis); colours routed through
+    // color.slider.* so live theme switching works and per-applet
+    // overrides could retint these in future without per-call-site work.
+    static const QString kFilterSlider = QStringLiteral(
+        "QSlider::groove:horizontal { background: {{color.slider.background}}; height: 6px; border-radius: 3px; }"
+        "QSlider::handle:horizontal { background: {{color.slider.handle}}; width: 14px; "
+        "margin: -5px 0; border-radius: 7px; }");
 
     // Filter Options group
     {
@@ -2601,7 +2606,7 @@ QWidget* RadioSetupDialog::buildFiltersTab()
             auto* slider = new GuardedSlider(Qt::Horizontal);
             slider->setRange(0, 3);
             slider->setValue(r.level);
-            slider->setStyleSheet(kFilterSlider);
+            AetherSDR::ThemeManager::instance().applyStyleSheet(slider, kFilterSlider);
             slider->setEnabled(!r.autoOn);
             grid->addWidget(slider, row, 1, 1, 2);
 


### PR DESCRIPTION
Closes the second half of Pat's "both" answer to **(a)** the toggle namespace work (landed as [#3198](https://github.com/aethersdr/AetherSDR/pull/3198)) and **(b)** the hardcoded-hex slider sites called out in [#3188](https://github.com/aethersdr/AetherSDR/pull/3188)'s *Out of scope* section.

## Background

[#3188](https://github.com/aethersdr/AetherSDR/pull/3188) tagged four sites as bypassing the `color.slider.*` namespace entirely:

> **Hardcoded-hex slider sites** in `PanadapterApplet`, `EqApplet`, `RadioSetupDialog`, `FlexControlDialog` bypass the theme system entirely. Each needs its local stylesheet dropped in favour of the global QSS + per-applet override path.

Each site used inline `setStyleSheet(...)` calls full of hardcoded hex values — so the v2 per-applet override path couldn't reach them, and theme switches required an app restart.  This PR tokenizes the colours and routes through `ThemeManager::applyStyleSheet` so:

- the per-applet override cascade lights up automatically once a relevant scope exists (none of the four currently sits under `applet/tx|rx|comp`, so the immediate effect at root scope is the canonical Wave-blue / accent-success treatment);
- live theme switching (Dark ↔ Light without restart) re-resolves the tokens and repaints, matching the rest of the namespace-aware UI.

## Approach — Option A (tokenize colours, preserve sizes)

Site-local slider **dimensions** are preserved intentionally — the four sites each chose bespoke handle widths / groove heights for the UX context they live in (Panadapter's tiny 8px handle for the CW bar, EqApplet's 10×16 vertical handle for band-column rhythm, RadioSetup's emphasis-sized 14px handle, FlexControl's 16px bordered ring).

Homogenizing them via `applyPrimarySliderStyle` would have been a more literal interpretation of "drop the local stylesheet" but would have introduced visible regressions across all four sites.  **Option A** (tokenize colours, preserve sizes) achieves Pat's stated goal — sliders honour the theme system — without the visual cost.

## Per-site notes

| File | Sliders | Token migration |
|---|---|---|
| `PanadapterApplet.cpp` | 2 pitch sliders (CW decoder bar) | `#1a2a3a` groove → `{{color.slider.background}}`<br>`#6a8090` handle → `{{color.slider.handle}}` |
| `EqApplet.cpp` | 8 vertical EQ band sliders | `#203040` groove → `{{color.slider.background}}`<br>`#00b4d8` handle → `{{color.slider.foreground}}` (the EQ idiom puts the accent colour on the handle itself — no sub-page rule) |
| `RadioSetupDialog.cpp` | 3 filter-sharpness sliders (voice / cw / digital) | `#1a2a3a` groove → `{{color.slider.background}}`<br>`#c8d8e8` handle → `{{color.slider.handle}}`<br>(`lineoutSlider` + `hpSlider` already inherit from the global QSS — no migration needed) |
| `FlexControlDialog.cpp` | 2 sliders (spin / sensitivity) inside the dialog-wide `kFlexControlStyle` template | `#162437` groove → `{{color.slider.background}}`<br>`#65d379` sub-page → `{{color.accent.success}}` (preserves FlexControl green identity)<br>`#d8e2ef` handle → `{{color.slider.handle}}`<br>`#65d379` handle border → `{{color.accent.success}}`<br>Body widget switched to `applyStyleSheet` so the tokens resolve + live re-theme registers |

## Verification

Windows 11 (MSVC + Ninja + Qt 6.10.3) on top of `aethersdr/AetherSDR` main at `4ee99f78`.

| Site | Default Dark | Default Light |
|---|---|---|
| PanadapterApplet pitch sliders | ✓ dark groove + light handle | ✓ light groove + dark handle — **live re-theme adapts cleanly** |
| EqApplet band sliders | ✓ dark groove + accent-cyan handle | ✓ handle resolves to light-theme accent (`#0088b0`) |
| RadioSetupDialog filter sliders | ✓ dark groove + light handle | ✓ light groove + dark handle — **live re-theme adapts cleanly** |
| FlexControlDialog spin + sensitivity | ✓ dark groove + green sub-page + bordered handle | ✓ sub-page green preserved (the green is `color.accent.success` which is green in both bundled themes; gray shades adapt around it) |

`theme_manager_test`: zero new failures.  The 4 pre-existing `importThemeFromFile`-related failures on clean main remain (Windows-vs-CI env issue, not introduced here).

## Observed during testing — out of scope for this PR

While verifying in Default Light, two **broader migration debt** items came to light that go beyond this slider sweep:

- **`RadioSetupDialog` light-theme contrast** — `kLabelStyle` (`color: #c8d8e8`), `kValueStyle` (`color: #00c8ff`), `kGroupStyle` (border `#304050`, title `#8aa8c0`), and `kEditStyle` (background `#1a2a3a`) all hardcode dark-theme colours.  Labels render as low-contrast pale text against the light-theme `#f5f5f8` background, and edit fields look misplaced.  Migrating those constants needs the same `{{token}}` + `applyStyleSheet` pattern and touches dozens of call sites across the dialog — a separate follow-up PR.
- **`FlexControlDialog` whole-dialog migration debt** — the dialog template hardcodes `#0b1625` button backgrounds, `#31455f` borders, `#65d379` FlexControl-green accents throughout.  The slider rules now adapt to theme; the rest of the dialog stays dark in light theme.  A separate "FlexControl light-theme migration" PR would close this; touching it here would have ballooned the slider-cleanup scope.

Both observations were flagged as candidates for the next cleanup sweep that follows this one.

## Together with #3198

This PR completes Pat's "both" answer.  With #3198 (toggle namespace carve-out) and this PR (slider site cleanup) merged, the four originally-cited problem sites from #3188's Out-of-scope section all become theme-system-aware and the toggle button class joins the slider + knob namespace pattern as a third carved-out widget type.

cc @ten9876 @jensenpat @chibondking

73 Nigel G0JKN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
