### PR TITLE
[windows] Exclude DFNR model archive from Store MSIX package

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -167,7 +167,7 @@ jobs:
           AETHERSDR_MSIX_INSTALLER_ACCENT_COLOR: ${{ vars.AETHERSDR_MSIX_INSTALLER_ACCENT_COLOR }}
           AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR: ${{ vars.AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR }}
         run: |
-          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\create-msix.ps1 -DeployDir deploy -OutputDir . -CreateUpload -SkipSign
+          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\create-msix.ps1 -DeployDir deploy -OutputDir . -CreateUpload -SkipSign -ExcludeDfnrModel
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docs/logo-original.jpg
 docs/logo_upscayl.png
 SECURITY-AUDIT.md
 msix-root/
+msix-root-*/
 *.appx
 *.appxbundle
 *.appxsym

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -13,8 +13,9 @@ manifest, visual assets, signing, and Store upload wrapper around it.
 
 The script creates `msix-root/`, writes `AppxManifest.xml`, generates package
 icons from `docs/assets/logo-circle.png`, adds App Installer UX metadata, runs
-`makeappx.exe`, optionally signs the MSIX with `signtool.exe`, and optionally
-creates a `.msixupload` archive for Partner Center.
+`makeappx.exe`, optionally omits the DFNR model archive for Store readiness,
+optionally signs the MSIX with `signtool.exe`, and optionally creates a
+`.msixupload` archive for Partner Center.
 
 Development package:
 
@@ -28,7 +29,7 @@ Store identity package:
 $env:AETHERSDR_MSIX_IDENTITY_NAME = "PartnerCenter.Assigned.Name"
 $env:AETHERSDR_MSIX_PUBLISHER = "CN=Partner-Center-Assigned-Publisher"
 $env:AETHERSDR_MSIX_PUBLISHER_DISPLAY_NAME = "AetherSDR"
-powershell -NoProfile -ExecutionPolicy Bypass -Command ". 'C:\Users\patj\Documents\AetherSDR\scripts\enter-msvc.ps1' -Arch x64; & '.\packaging\windows\create-msix.ps1' -DeployDir deploy -OutputDir . -CreateUpload"
+powershell -NoProfile -ExecutionPolicy Bypass -Command ". 'C:\Users\patj\Documents\AetherSDR\scripts\enter-msvc.ps1' -Arch x64; & '.\packaging\windows\create-msix.ps1' -DeployDir deploy -OutputDir . -CreateUpload -ExcludeDfnrModel"
 ```
 
 ## Manifest Values
@@ -86,11 +87,12 @@ signals, but some findings need follow-up before final submission:
 
 - `Blocked executables`: AetherSDR shells out to PowerShell for Windows support
   bundle ZIP creation. Replace that path with in-process ZIP creation.
-- `Archive files usage`: DFNR currently ships `DeepFilterNet3_onnx.tar.gz`.
-  The archive contains `enc.onnx`, `erb_dec.onnx`, `df_dec.onnx`, and
-  `config.ini`, but the current DeepFilter C API expects the tar.gz path. Check
-  whether `df_create(nullptr, ...)` can use the embedded default model before
-  deciding whether to exclude the archive from the Store package.
+- `Archive files usage`: Store MSIX builds pass `-ExcludeDfnrModel` so the
+  package does not include `DeepFilterNet3_onnx.tar.gz`. The archive contains
+  `enc.onnx`, `erb_dec.onnx`, `df_dec.onnx`, and `config.ini`, but the current
+  DeepFilter C API expects the tar.gz path. Check whether `df_create(nullptr,
+  ...)` can use the embedded default model before restoring DFNR in Store
+  packages.
 - `DPIAwarenessValidation`: add PerMonitorV2 DPI awareness to the desktop app
   manifest or initialize DPI awareness explicitly before final Store testing.
 - Qt and vendor DLLs may still report process-launch imports or short blocked

--- a/packaging/windows/create-msix.ps1
+++ b/packaging/windows/create-msix.ps1
@@ -35,6 +35,7 @@ param(
     [string]$IconSource = "docs/assets/logo-circle.png",
     [string]$PdbPath = "build/AetherSDR.pdb",
     [switch]$CreateUpload,
+    [switch]$ExcludeDfnrModel,
 
     [string]$CertificateFile = $env:AETHERSDR_MSIX_CERTIFICATE_FILE,
     [string]$CertificatePassword = $env:AETHERSDR_MSIX_CERTIFICATE_PASSWORD,
@@ -324,6 +325,14 @@ Copy-Item -Path (Join-Path $resolvedDeployDir "*") -Destination $resolvedPackage
 # installer executable out of the package payload.
 Get-ChildItem -LiteralPath $resolvedPackageRoot -File -Filter "vc_redist*.exe" -ErrorAction SilentlyContinue |
     Remove-Item -Force
+
+if ($ExcludeDfnrModel) {
+    $dfnrModels = Get-ChildItem -LiteralPath $resolvedPackageRoot -Recurse -File -Filter "DeepFilterNet3_onnx.tar.gz" -ErrorAction SilentlyContinue
+    foreach ($model in $dfnrModels) {
+        Write-Host "Excluding DFNR model from MSIX package: $($model.FullName)"
+        Remove-Item -LiteralPath $model.FullName -Force
+    }
+}
 
 $assetsDir = Join-Path $resolvedPackageRoot "Assets"
 New-Item -ItemType Directory -Path $assetsDir -Force | Out-Null


### PR DESCRIPTION
## Summary

This PR keeps the Windows Store MSIX payload free of the DFNR model archive.

- Adds `-ExcludeDfnrModel` to `packaging/windows/create-msix.ps1`.
- Uses that switch in the Windows installer workflow's MSIX step, so the Store-style MSIX artifact omits `DeepFilterNet3_onnx.tar.gz` while leaving the normal deploy folder alone.
- Updates the Windows Store/MSIX notes to document the Store packaging behavior and the remaining DFNR follow-up.
- Ignores custom `msix-root-*` test/package roots created while validating MSIX output.

## Validation

- Merged/tested against latest `origin/main` (`4ee99f78`).
- PowerShell parser check passed for `packaging/windows/create-msix.ps1`.
- `git diff --check` passed.
- MSVC configure/build completed with `-j 8`; `windeployqt` was run afterward into a fresh deploy directory.
- Generated an unsigned MSIX with `-ExcludeDfnrModel` and verified `DeepFilterNet3_onnx.tar.gz` is not present in the package entries.
- Ran Windows App Certification Kit against the generated MSIX. `Archive files usage` now passes; the remaining warnings are the existing blocked-executable and DPI-awareness findings.

## Notes

This intentionally does not change the DFNR runtime code. The Store package skips the external tarball for now; restoring DFNR in Store builds should wait until we confirm `df_create(nullptr, ...)` can use the embedded default model or add another Store-compliant model loading path.