### PR TITLE
fix(gui): report macOS phys_footprint in status-bar memory (#3197)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -198,6 +198,11 @@
 #include <psapi.h>
 #else
 #include <sys/resource.h>
+#ifdef Q_OS_MAC
+#include <mach/mach.h>
+#include <mach/task.h>
+#include <mach/task_info.h>
+#endif
 #endif
 #include <QLocale>
 #include <QFile>
@@ -9094,7 +9099,13 @@ void MainWindow::buildUI()
         m_memLabel = new QLabel("Mem: \u2014");
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_memLabel, "QLabel { color: {{color.text.label}}; font-size: 12px; }");
         m_memLabel->setAlignment(Qt::AlignCenter);
-        m_memLabel->setToolTip("AetherSDR process memory (RSS)");
+#if defined(Q_OS_WIN)
+        m_memLabel->setToolTip("AetherSDR process working set (matches Task Manager)");
+#elif defined(Q_OS_MAC)
+        m_memLabel->setToolTip("AetherSDR process physical footprint (matches Activity Monitor)");
+#else
+        m_memLabel->setToolTip("AetherSDR process resident set (VmRSS from /proc/self/status)");
+#endif
         cpuVbox->addWidget(m_cpuLabel);
         cpuVbox->addWidget(m_memLabel);
         hbox->addWidget(cpuStack);
@@ -9151,25 +9162,39 @@ void MainWindow::buildUI()
                 m_cpuLabel->setStyleSheet(QString("QLabel { color: %1; font-size: 12px; }").arg(color));
             }
 
-            // Memory (RSS)
+            // Memory: report the "what the OS sees right now" footprint, not the
+            // per-process high-water mark. ru_maxrss is monotonic and excludes
+            // compressed/IOKit/purgeable memory on macOS, so it disagrees badly
+            // with Activity Monitor — see issue #3197.
+            quint64 memBytes = 0;
 #ifdef Q_OS_WIN
             PROCESS_MEMORY_COUNTERS pmc;
             if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc))) {
-                double mb = pmc.WorkingSetSize / (1024.0 * 1024.0);
-                m_memLabel->setText(QString("Mem: %1 MB").arg(static_cast<int>(mb)));
+                memBytes = pmc.WorkingSetSize;
+            }
+#elif defined(Q_OS_MAC)
+            task_vm_info_data_t info{};
+            mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+            if (task_info(mach_task_self(), TASK_VM_INFO,
+                          reinterpret_cast<task_info_t>(&info), &count) == KERN_SUCCESS) {
+                memBytes = info.phys_footprint;
             }
 #else
-            // getrusage ru_maxrss is in KB on Linux, bytes on macOS
-            struct rusage ruMem;
-            if (getrusage(RUSAGE_SELF, &ruMem) == 0) {
-#ifdef Q_OS_MAC
-                double mb = ruMem.ru_maxrss / (1024.0 * 1024.0);
-#else
-                double mb = ruMem.ru_maxrss / 1024.0;
-#endif
-                m_memLabel->setText(QString("Mem: %1 MB").arg(static_cast<int>(mb)));
+            QFile statusFile("/proc/self/status");
+            if (statusFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                while (!statusFile.atEnd()) {
+                    const QByteArray line = statusFile.readLine();
+                    if (line.startsWith("VmRSS:")) {
+                        memBytes = line.mid(6).trimmed().split(' ').first().toULongLong() * 1024ULL;
+                        break;
+                    }
+                }
             }
 #endif
+            if (memBytes > 0) {
+                double mb = memBytes / (1024.0 * 1024.0);
+                m_memLabel->setText(QString("Mem: %1 MB").arg(static_cast<int>(mb)));
+            }
         });
         m_cpuTimer->start();
     }


### PR DESCRIPTION
## Summary

Fixes #3197 — on macOS the status-bar `Mem` readout showed ~859 MB while Activity Monitor reported the same process at ~3.19 GB (a ~3.8× understatement).

Two distinct problems with the previous `ru_maxrss`-based metric on macOS:

1. **High-water mark, not current.** `ru_maxrss` monotonically increases over the process lifetime and never reflects pages that were faulted out or compressed.
2. **Excludes compressed / IOKit / purgeable pages.** Activity Monitor's *Memory* column uses `phys_footprint` from `task_info(TASK_VM_INFO)`, which sums anonymous + compressed + IOKit + purgeable. For a Qt/QRhi app with Metal driver state and a long-lived spectrum/waterfall pipeline, the delta is large.

### Changes (single file: `src/gui/MainWindow.cpp`)

- **macOS**: replace `ru_maxrss` with `task_info(mach_task_self(), TASK_VM_INFO, …).phys_footprint` — the exact field Activity Monitor renders, so the two readouts agree by construction.
- **Linux** (while we're here): switch from `ru_maxrss` to reading `VmRSS:` from `/proc/self/status` so Linux also reports current resident, not the per-process peak.
- **Windows**: unchanged — `WorkingSetSize` is already current, not peak.
- Tooltip updated from *"AetherSDR process memory (RSS)"* to *"AetherSDR process physical footprint (matches Activity Monitor)"*.
- Added mach headers (`<mach/mach.h>`, `<mach/task.h>`, `<mach/task_info.h>`) under `Q_OS_MAC`.

All three platforms now report a "what the OS sees right now" footprint, matching the unification the reporter asked for under *"unifying behind a `phys_footprint`-style metric on all three platforms."*

### Out of scope

Whether ~3 GB on an idle single-slice session is itself excessive (waterfall tile retention, FFT history, Metal/QRhi overhead, leaked textures, etc.). That's a separate investigation, well-suited to the per-thread memory trending in the forthcoming System Info diagnostics dialog (#2554). This PR just unblocks the display so any future investigation has a number that matches Activity Monitor.

## Test plan

- [x] Local build on Apple Silicon (`cmake --build build --target AetherSDR`) — compiles clean; only pre-existing `-Wdeprecated-this-capture` warnings unrelated to this change.
- [x] App launched from the build directory (PID 7857); status-bar `Mem` value should now track Activity Monitor's *Memory* column within rounding instead of underreporting by ~3.8×.
- [ ] Linux smoke test (`/proc/self/status` VmRSS path) — not exercised locally; logic is straightforward but a Linux reviewer / CI run is welcome.
- [ ] Windows — no code path changed; existing behavior preserved.

## Notes for reviewer

- Touches `src/gui/MainWindow.{h,cpp}` — **maintainer-only** tier per `.github/CODEOWNERS`, routing this to @ten9876.
- Triage in #3197 by @aethersdr-agent confirmed root cause and proposed exactly this fix.