### PR TITLE
fix(overlay): stop SpectrumWidget from killing child-widget tooltips (#2355)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -3839,6 +3839,15 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
     const auto dragStatePublisher = makeScopeExit([this] { publishPerfDragState(); });
     (void)dragStatePublisher;
 
+    // Let child widgets (overlay menu buttons) own the pointer while hovered so
+    // their tooltips are not killed by SpectrumWidget's QToolTip::hideText() calls.
+    // Guard is skipped during active drags — those always start in the spectrum
+    // area, not over child widgets. (#2355)
+    if (!anyDragActive() && childAt(ev->position().toPoint())) {
+        ev->ignore();
+        return;
+    }
+
     const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
     const int contentH = height() - chromeH;
     const int specH = static_cast<int>(contentH * m_spectrumFrac);


### PR DESCRIPTION
## Problem

`SpectrumWidget::mouseMoveEvent()` contains multiple `QToolTip::hideText()` call sites that fire whenever the cursor moves anywhere inside the widget. This includes movement over `SpectrumOverlayMenu` child buttons (MEM+, MEM▶, DAX) — their tooltips are dismissed the instant the mouse enters the button rect, making them effectively invisible.

## Fix

Add an early-return guard immediately after the `dragStatePublisher` setup in `mouseMoveEvent()`: if `childAt()` returns a non-null widget and no drag is active, the event is ignored and returned early so the child widget owns the pointer (and therefore its own tooltip).

Active drags are exempt from the guard — drags always originate in the spectrum area, so `childAt()` returns null during a drag regardless, and the guard is a no-op.

## Testing

Tested locally: hovering over the MEM+, MEM▶, and DAX overlay buttons now shows their tooltips and holds them until the cursor leaves. Spectrum dragging (pan, zoom, TNF drag, slice drag) is unaffected.

Fixes #2355