### PR TITLE
ci: add AudioEngine to check-windows path filter (#3052)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,14 @@ jobs:
               # Windows CI build whenever this file changes. (#2671)
               - 'src/gui/MainWindow.cpp'
               - 'src/gui/MainWindow.h'
+              # AudioEngine.cpp / .h are equally dense with platform-guarded
+              # code (WASAPI, CoreAudio, ALSA/PipeWire paths). A Linux-passing
+              # change inside a Q_OS_WIN block will skip check-windows without
+              # this entry. Post-mortem: #2929 (WASAPI mono-mic recovery)
+              # landed on main unverified because AudioEngine wasn't in the
+              # filter. (#3052)
+              - 'src/core/AudioEngine.cpp'
+              - 'src/core/AudioEngine.h'
 
   # Cross-platform build check — runs only when CMakeLists.txt, third_party/,
   # or workflows are modified, to catch MSVC issues before release. (#796 lesson)


### PR DESCRIPTION
## Problem

`AudioEngine.cpp` and `AudioEngine.h` are as dense with `#ifdef Q_OS_WIN` / `Q_OS_MAC` / `HAVE_PIPEWIRE` branches as `MainWindow`, but were absent from the dorny/paths-filter `build` group that gates the `check-windows` CI job.

A Linux-passing change inside a `#ifdef Q_OS_WIN` block can therefore land on `main` without triggering a Windows build check. This is the same class of issue that motivated adding `MainWindow` to the filter in #2671.

**Post-mortem:** PR #2929 (WASAPI mono-mic recovery) slipped past `check-windows` for exactly this reason — `AudioEngine.cpp` carried the platform-guarded change but wasn't on the filter.

## Fix

Add `src/core/AudioEngine.cpp` and `src/core/AudioEngine.h` to the `build` paths group, with a comment referencing the post-mortem. Pattern mirrors the existing `MainWindow` entry.

Fixes #3052