### PR TITLE
feat(mqtt): publish CW decoded text to aethersdr/cw/decode

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1876,6 +1876,16 @@ MainWindow::MainWindow(QWidget* parent)
             this, &MainWindow::showMqttSettingsDialog);
     m_appletPanel->mqttApplet()->restoreConnectionState();
 
+    // CW decode → MQTT topic "aethersdr/cw/decode".
+    // Publishes {"text":"K","freq":14.025,"rx":true} per decoded character.
+    // RX decoder uses rx:true; TX sidetone decoder uses rx:false.
+    // Any MQTT subscriber (e.g. a contest logger) receives the stream
+    // without additional AetherSDR interfaces.
+    connect(&m_cwDecoder,   &CwDecoder::textDecoded, this,
+            [this](const QString& t, float) { publishCwDecodeMqtt(t, true);  });
+    connect(&m_cwDecoderTx, &CwDecoder::textDecoded, this,
+            [this](const QString& t, float) { publishCwDecodeMqtt(t, false); });
+
     // MQTT → panadapter overlay display
     connect(m_appletPanel->mqttApplet(), &MqttApplet::displayValueChanged,
             this, [this](const QString& key, const QString& value) {
@@ -5338,6 +5348,18 @@ void MainWindow::showMqttSettingsDialog()
             m_mqttClient->setSubscriptions(mqttSubscriptionTopics(mqttApplet->topicConfig()));
         }
     });
+}
+
+void MainWindow::publishCwDecodeMqtt(const QString& text, bool rx)
+{
+    if (!m_mqttClient || !m_mqttClient->isConnected()) return;
+    QJsonObject obj;
+    obj[QStringLiteral("text")] = text;
+    obj[QStringLiteral("rx")]   = rx;
+    if (auto* s = activeSlice(); s && s->frequency() > 0.0)
+        obj[QStringLiteral("freq")] = s->frequency();
+    m_mqttClient->publish(QStringLiteral("aethersdr/cw/decode"),
+                          QJsonDocument(obj).toJson(QJsonDocument::Compact));
 }
 #endif
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1882,9 +1882,9 @@ MainWindow::MainWindow(QWidget* parent)
     // Any MQTT subscriber (e.g. a contest logger) receives the stream
     // without additional AetherSDR interfaces.
     connect(&m_cwDecoder,   &CwDecoder::textDecoded, this,
-            [this](const QString& t, float) { publishCwDecodeMqtt(t, true);  });
+            [this](const QString& t, float cost) { publishCwDecodeMqtt(t, cost, true);  });
     connect(&m_cwDecoderTx, &CwDecoder::textDecoded, this,
-            [this](const QString& t, float) { publishCwDecodeMqtt(t, false); });
+            [this](const QString& t, float cost) { publishCwDecodeMqtt(t, cost, false); });
 
     // MQTT → panadapter overlay display
     connect(m_appletPanel->mqttApplet(), &MqttApplet::displayValueChanged,
@@ -5350,9 +5350,12 @@ void MainWindow::showMqttSettingsDialog()
     });
 }
 
-void MainWindow::publishCwDecodeMqtt(const QString& text, bool rx)
+void MainWindow::publishCwDecodeMqtt(const QString& text, float cost, bool rx)
 {
     if (!m_mqttClient || !m_mqttClient->isConnected()) return;
+    // Apply the same sensitivity threshold as the active CW panel so the
+    // MQTT stream matches exactly what the decoder window displays.
+    if (m_cwDecoderApplet && cost >= m_cwDecoderApplet->cwCostThreshold()) return;
     QJsonObject obj;
     obj[QStringLiteral("text")] = text;
     obj[QStringLiteral("rx")]   = rx;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5352,12 +5352,15 @@ void MainWindow::showMqttSettingsDialog()
 
 void MainWindow::publishCwDecodeMqtt(const QString& text, float cost, bool rx)
 {
-    if (!m_mqttClient || !m_mqttClient->isConnected()) return;
-    // Apply the same sensitivity threshold as the active CW panel so the
-    // MQTT stream matches exactly what the decoder window displays.
-    if (m_cwDecoderApplet && cost >= m_cwDecoderApplet->cwCostThreshold()) return;
+    if (!m_mqttClient) return;
+    // No CW panel active → nothing is displayed → don't publish.
+    if (!m_cwDecoderApplet || cost >= m_cwDecoderApplet->cwCostThreshold()) return;
+    // Mirror panel normalization: \n → space; drop whitespace-only TX chunks.
+    QString clean = text;
+    clean.replace(QLatin1Char('\n'), QLatin1Char(' '));
+    if (!rx && clean.trimmed().isEmpty()) return;
     QJsonObject obj;
-    obj[QStringLiteral("text")] = text;
+    obj[QStringLiteral("text")] = clean;
     obj[QStringLiteral("rx")]   = rx;
     if (auto* s = activeSlice(); s && s->frequency() > 0.0)
         obj[QStringLiteral("freq")] = s->frequency();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -338,6 +338,7 @@ private:
     void showMnrSettings();
 #ifdef HAVE_MQTT
     void showMqttSettingsDialog();
+    void publishCwDecodeMqtt(const QString& text, bool rx);
 #endif
     void applyPanLayout(const QString& layoutId);
     void createPansSequentially(const QString& layoutId, int total,

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -338,7 +338,7 @@ private:
     void showMnrSettings();
 #ifdef HAVE_MQTT
     void showMqttSettingsDialog();
-    void publishCwDecodeMqtt(const QString& text, bool rx);
+    void publishCwDecodeMqtt(const QString& text, float cost, bool rx);
 #endif
     void applyPanLayout(const QString& layoutId);
     void createPansSequentially(const QString& layoutId, int total,

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -47,8 +47,9 @@ public:
     void appendCwTextTx(const QString& text, float cost = 0.0f);
     void setCwStats(float pitchHz, float speedWpm);
     void clearCwText();
-    QPushButton* lockPitchButton() const { return m_lockPitchBtn; }
-    QPushButton* lockSpeedButton() const { return m_lockSpeedBtn; }
+    QPushButton* lockPitchButton()  const { return m_lockPitchBtn; }
+    QPushButton* lockSpeedButton()  const { return m_lockSpeedBtn; }
+    float        cwCostThreshold()  const { return m_cwCostThreshold; }
 
     QSize sizeHint() const override { return {800, 316}; }
 


### PR DESCRIPTION
## Summary

- Connects both the RX and TX CW decoders to a new
  `publishCwDecodeMqtt()` helper in `MainWindow` that fires on every
  `textDecoded` emission
- Applies the active panel's `m_cwCostThreshold` so the MQTT feed
  matches exactly what the CW decoder window displays
- Mirrors `PanadapterApplet` text normalization: `\n` → space, drop
  whitespace-only TX chunks
- Bails silently when no CW panel is active or MQTT is disconnected

## Payload format

```json
{"text":"K","freq":14.025,"rx":true}
```

- `text` — normalized decoded character(s)
- `freq` — active slice frequency in MHz (omitted if no slice active)
- `rx` — `false` for TX sidetone decoder output

## Commit breakdown

1. `feat`: core wiring — `publishCwDecodeMqtt()` + two `connect` calls
   in the `HAVE_MQTT` block
2. `fix`: add `cwCostThreshold()` public getter on `PanadapterApplet`;
   apply threshold in the publisher
3. `fix`: triage feedback — invert null-applet guard, drop redundant
   `isConnected()` check, add text normalization

## Test plan

- [ ] Enable MQTT in AetherSDR (Settings → MQTT → localhost:1883)
- [ ] Tune to a CW signal with the decoder running
- [ ] Confirm `mosquitto_sub -t aethersdr/cw/decode -v` shows the same
      characters as the decoder panel
- [ ] Adjust sensitivity slider — confirm MQTT feed changes in lockstep
- [ ] Disable MQTT — confirm no errors logged
- [ ] No CW panel open — confirm nothing published

## Related

Closes #3215