### PR TITLE
fix(liquid-dsp): guard -lc/-lm link flags against WIN32 platforms

### DIFF
--- a/third_party/liquid-dsp/CMakeLists.txt
+++ b/third_party/liquid-dsp/CMakeLists.txt
@@ -465,7 +465,12 @@ foreach(target ${LIQUID_TARGETS})
     set_target_properties(${target}
         PROPERTIES
             PUBLIC_HEADER include/liquid.h)
-    target_link_libraries(${target} c m)
+    # -lc and -lm are POSIX/Linux conventions; on Windows (MinGW and MSVC)
+    # the CRT is linked automatically — explicitly passing them causes
+    # MinGW ld to error "cannot find -lc" since there is no libc.a.
+    if(NOT WIN32)
+        target_link_libraries(${target} c m)
+    endif()
     if (fftw3f_FOUND)
         target_link_libraries(${target} fftw3f)
     endif()


### PR DESCRIPTION
## Problem

`target_link_libraries(${target} c m)` at line 468 of
`third_party/liquid-dsp/CMakeLists.txt` is a POSIX/Linux convention.
On Windows the C runtime is linked automatically by both MinGW-w64 and
MSVC — passing `-lc`/`-lm` explicitly causes MinGW `ld` to fail at
link time:

    cannot find -lc: No such file or directory

This regression was introduced when liquid-dsp was vendored in #3046.

## Fix

Wrap the `target_link_libraries` call in `if(NOT WIN32) … endif()`.
`WIN32` is true for both MinGW-w64 and MSVC on Windows (it is a
platform variable, not a compiler variable), so this correctly suppresses
the flag for all Windows toolchains while leaving Linux and macOS
behaviour unchanged.

This is a stopgap that restores a clean Windows build. The full
Windows/MSVC solution (ExternalProject with mingw-w64) is tracked
in #3049.

## Testing

- Built cleanly on Windows 11 with MinGW GCC 13.1.0 / Qt 6.11.0 /
  Ninja — no linker errors.
- Linux and macOS paths are unchanged; the guard only fires on WIN32.

Related: #3049

🤖 Generated with [Claude Code](https://claude.ai/claude-code)