### PR TITLE
[windows] Embed DFNR model and set Store identity

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -169,6 +169,7 @@ jobs:
           AETHERSDR_MSIX_INSTALLER_ACCENT_COLOR: ${{ vars.AETHERSDR_MSIX_INSTALLER_ACCENT_COLOR }}
           AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR: ${{ vars.AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR }}
         run: |
+          . .\packaging\windows\store-identity.ps1
           powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\create-msix.ps1 -DeployDir deploy -OutputDir . -CreateUpload -SkipSign -ExcludeDfnrModel
 
       - name: Upload artifacts

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -114,9 +114,8 @@ jobs:
           if (Test-Path "third_party\deepfilter\lib\windows-x86_64\deepfilter.dll") {
             copy third_party\deepfilter\lib\windows-x86_64\deepfilter.dll deploy\
           }
-          if (Test-Path "third_party\deepfilter\models\DeepFilterNet3_onnx.tar.gz") {
-            copy third_party\deepfilter\models\DeepFilterNet3_onnx.tar.gz deploy\
-          }
+          # Windows builds embed the DFNR model in AetherSDR.exe resources, so
+          # no loose DeepFilterNet3_onnx.tar.gz payload is deployed.
           # NOTE: MQTT TLS is disabled (-DMQTT_TLS=OFF) so no OpenSSL DLLs
           # are needed. This avoids the "libssl-3-x64.dll not found" crash
           # on systems without OpenSSL installed (#1341, #1362).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,14 @@ option(ENABLE_DFNR "Enable DFNR DeepFilterNet3 noise reduction" ON)
 option(ENABLE_MQTT "Enable MQTT client support" ON)
 option(MQTT_TLS "Enable MQTT TLS via OpenSSL (disable for AppImage)" ON)
 option(LOWER_CASE_BINARY_NAME "Make the output binary lower case. Only affects Linux" OFF)
+if(WIN32)
+    set(AETHER_EMBED_DFNR_MODEL_DEFAULT ON)
+else()
+    set(AETHER_EMBED_DFNR_MODEL_DEFAULT OFF)
+endif()
+option(AETHER_EMBED_DFNR_MODEL
+       "Embed the DFNR model payload into application resources instead of deploying a loose archive"
+       ${AETHER_EMBED_DFNR_MODEL_DEFAULT})
 
 # macOS: ensure Homebrew lib/include paths are in the search path
 # (universal builds with CMAKE_OSX_ARCHITECTURES may not search /opt/homebrew by default)
@@ -376,9 +384,11 @@ else()
 endif()
 
 # DeepFilterNet3 DFNR — bundled neural noise reduction (MIT/Apache-2.0)
-# Pre-built static library from Rust crate (libdf), model weights embedded.
+# Pre-built libdf library from the Rust crate; model payload is handled below.
 if(ENABLE_DFNR)
     set(DEEPFILTER_DIR ${CMAKE_SOURCE_DIR}/third_party/deepfilter)
+    set(DFNR_MODEL "${DEEPFILTER_DIR}/models/DeepFilterNet3_onnx.tar.gz")
+    set(DFNR_EMBEDDED_MODEL_NAME "DeepFilterNet3_onnx.dfmodel")
     if(WIN32)
         set(DFNR_LIB_DIR "${DEEPFILTER_DIR}/lib/windows-x86_64")
         if(MINGW)
@@ -878,9 +888,28 @@ if(NOT MSVC)
     endif()
 endif()  # NOT MSVC
 
+set(DFNR_RESOURCES "")
+if(ENABLE_DFNR AND AETHER_EMBED_DFNR_MODEL)
+    if(EXISTS "${DFNR_MODEL}")
+        file(TO_CMAKE_PATH "${DFNR_MODEL}" DFNR_MODEL_QRC_PATH)
+        set(DFNR_MODEL_QRC "${CMAKE_CURRENT_BINARY_DIR}/dfnr_model.qrc")
+        file(WRITE "${DFNR_MODEL_QRC}"
+"<RCC>
+    <qresource prefix=\"/models\">
+        <file alias=\"${DFNR_EMBEDDED_MODEL_NAME}\">${DFNR_MODEL_QRC_PATH}</file>
+    </qresource>
+</RCC>
+")
+        qt_add_resources(DFNR_RESOURCES "${DFNR_MODEL_QRC}")
+        message(STATUS "DFNR model will be embedded in Qt resources")
+    else()
+        message(WARNING "AETHER_EMBED_DFNR_MODEL is ON, but DFNR model not found at ${DFNR_MODEL}")
+    endif()
+endif()
+
 qt_add_resources(RESOURCES resources/resources.qrc)
 
-add_executable(AetherSDR ${ALL_SOURCES} ${RNNOISE_SOURCES} ${GGMORSE_SOURCES} ${RADE_SOURCES} ${BNR_SOURCES} ${SPECBLEACH_SOURCES} ${RESOURCES})
+add_executable(AetherSDR ${ALL_SOURCES} ${RNNOISE_SOURCES} ${GGMORSE_SOURCES} ${RADE_SOURCES} ${BNR_SOURCES} ${SPECBLEACH_SOURCES} ${RESOURCES} ${DFNR_RESOURCES})
 
 if (USE_SYSTEM_ZLIB)
     target_link_libraries(AetherSDR PRIVATE PkgConfig::zlib)
@@ -1350,8 +1379,7 @@ if(ENABLE_DFNR)
                 "${DFNR_DLL}" "$<TARGET_FILE_DIR:AetherSDR>"
             COMMENT "Copying deepfilter.dll to build directory")
     endif()
-    set(DFNR_MODEL "${DEEPFILTER_DIR}/models/DeepFilterNet3_onnx.tar.gz")
-    if(EXISTS ${DFNR_MODEL})
+    if(EXISTS "${DFNR_MODEL}" AND NOT AETHER_EMBED_DFNR_MODEL)
         if(APPLE)
             # macOS: place in Resources/ so notarization doesn't reject a
             # non-Mach-O file inside Contents/MacOS/
@@ -1369,7 +1397,7 @@ if(ENABLE_DFNR)
         endif()
     endif()
     # Install the model alongside the binary for cmake --install
-    if(NOT APPLE)
+    if(NOT APPLE AND NOT AETHER_EMBED_DFNR_MODEL)
         install(FILES "${DFNR_MODEL}"
             DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/AetherSDR"
             OPTIONAL)

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -32,10 +32,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command ". 'C:\Users\patj\Documen
 Store identity package:
 
 ```powershell
-$env:AETHERSDR_MSIX_IDENTITY_NAME = "PartnerCenter.Assigned.Name"
-$env:AETHERSDR_MSIX_PUBLISHER = "CN=Partner-Center-Assigned-Publisher"
-$env:AETHERSDR_MSIX_PUBLISHER_DISPLAY_NAME = "AetherSDR"
-powershell -NoProfile -ExecutionPolicy Bypass -Command ". 'C:\Users\patj\Documents\AetherSDR\scripts\enter-msvc.ps1' -Arch x64; & '.\packaging\windows\create-msix.ps1' -DeployDir deploy -OutputDir . -CreateUpload -ExcludeDfnrModel"
+powershell -NoProfile -ExecutionPolicy Bypass -Command ". 'C:\Users\patj\Documents\AetherSDR\scripts\enter-msvc.ps1' -Arch x64; . '.\packaging\windows\store-identity.ps1'; & '.\packaging\windows\create-msix.ps1' -DeployDir deploy -OutputDir . -CreateUpload -SkipSign -ExcludeDfnrModel"
 ```
 
 ## Manifest Values
@@ -50,16 +47,18 @@ Values we can automate:
   because the manifest uses `uap10:RuntimeBehavior`.
 - Visual assets: generated from the existing AetherSDR logo.
 
-Values that must come from Partner Center for the Store package:
+Partner Center Store package values:
 
-- `Identity.Name`: assigned after reserving the product name.
-- `Identity.Publisher`: assigned by Partner Center and tied to the developer
-  account/certificate identity.
+- `Identity.Name`: `AetherSDR.AetherSDR`
+- `Identity.Publisher`: `CN=E03F94A2-AEAB-46D2-8BF1-6419C305CC44`
+- `PublisherDisplayName`: `AetherSDR`
+
+These values are in `packaging/windows/store-identity.ps1`. The file only sets
+variables that are currently unset, so CI repository variables or local shell
+environment variables can still override them for testing.
 
 Values that need maintainer choice:
 
-- Public Store/product name: likely `AetherSDR`, but confirm before reserving.
-- `PublisherDisplayName`: `AetherSDR`.
 - Short manifest description:
   `Multi-platform SDR client for FlexRadio transceivers (6000/8600/Aurora).`
 - Capability disclosure comfort:
@@ -75,14 +74,13 @@ Already automatable:
 
 - Local MSIX creation from the existing Windows deploy folder.
 - CI artifact creation after the current `windeployqt` deployment step.
-- Store identity injection from GitHub repository variables.
+- Store identity injection from `packaging/windows/store-identity.ps1`, with
+  optional GitHub repository variable overrides.
 - Signing from GitHub secrets when a development/test PFX exists.
 - `.msixupload` creation for Partner Center.
 
 Not fully automatable until account setup:
 
-- Reserving the Store product name.
-- Copying the Partner Center package identity values into GitHub variables.
 - Final Store submission unless Partner Center API credentials are created and
   stored as secrets.
 
@@ -106,8 +104,9 @@ signals, but some findings need follow-up before final submission:
 
 ## GitHub Variables
 
-The Windows installer workflow reads these optional repository variables before
-building the MSIX artifact:
+The Windows installer workflow sources `packaging/windows/store-identity.ps1`
+before building the MSIX artifact. These optional repository variables override
+the checked-in defaults when set:
 
 - `AETHERSDR_MSIX_IDENTITY_NAME`
 - `AETHERSDR_MSIX_PUBLISHER`
@@ -118,9 +117,8 @@ building the MSIX artifact:
 - `AETHERSDR_MSIX_INSTALLER_ACCENT_COLOR`
 - `AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR`
 
-If the identity variables are unset, CI still builds a development package using
-`AetherSDR.AetherSDR` and `CN=AetherSDR Development`. That package is useful for
-manifest/package validation, but it is not the final Store identity.
+If the identity variables are unset, CI now uses the checked-in Partner Center
+identity defaults from `store-identity.ps1`.
 
 ## Local Sideload Signing
 

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -13,9 +13,15 @@ manifest, visual assets, signing, and Store upload wrapper around it.
 
 The script creates `msix-root/`, writes `AppxManifest.xml`, generates package
 icons from `docs/assets/logo-circle.png`, adds App Installer UX metadata, runs
-`makeappx.exe`, optionally omits the DFNR model archive for Store readiness,
+`makeappx.exe`, optionally omits loose DFNR model payloads for Store readiness,
 optionally signs the MSIX with `signtool.exe`, and optionally creates a
 `.msixupload` archive for Partner Center.
+
+Windows DFNR builds embed the DeepFilterNet model payload in Qt resources by
+default (`AETHER_EMBED_DFNR_MODEL=ON`). At runtime, AetherSDR extracts that
+payload to writable app-local data as `DeepFilterNet3_onnx.dfmodel` because the
+DeepFilter C API requires a filesystem path. This keeps DFNR available in Store
+MSIX builds without packaging a loose `DeepFilterNet3_onnx.tar.gz` file.
 
 Development package:
 
@@ -87,12 +93,10 @@ signals, but some findings need follow-up before final submission:
 
 - `Blocked executables`: AetherSDR shells out to PowerShell for Windows support
   bundle ZIP creation. Replace that path with in-process ZIP creation.
-- `Archive files usage`: Store MSIX builds pass `-ExcludeDfnrModel` so the
-  package does not include `DeepFilterNet3_onnx.tar.gz`. The archive contains
-  `enc.onnx`, `erb_dec.onnx`, `df_dec.onnx`, and `config.ini`, but the current
-  DeepFilter C API expects the tar.gz path. Check whether `df_create(nullptr,
-  ...)` can use the embedded default model before restoring DFNR in Store
-  packages.
+- `Archive files usage`: Windows DFNR builds embed the model payload in Qt
+  resources and do not deploy a loose `DeepFilterNet3_onnx.tar.gz` file. The
+  `-ExcludeDfnrModel` switch remains as a packaging safety net for older deploy
+  directories or custom builds with loose DFNR payloads.
 - `DPIAwarenessValidation`: AetherSDR.exe now embeds a PerMonitorV2 desktop
   app manifest, and the Windows installer workflow verifies the deployed
   executable before MSIX packaging. WACK 10.0.26100.7705 reports

--- a/packaging/windows/create-msix.ps1
+++ b/packaging/windows/create-msix.ps1
@@ -327,10 +327,12 @@ Get-ChildItem -LiteralPath $resolvedPackageRoot -File -Filter "vc_redist*.exe" -
     Remove-Item -Force
 
 if ($ExcludeDfnrModel) {
-    $dfnrModels = Get-ChildItem -LiteralPath $resolvedPackageRoot -Recurse -File -Filter "DeepFilterNet3_onnx.tar.gz" -ErrorAction SilentlyContinue
-    foreach ($model in $dfnrModels) {
-        Write-Host "Excluding DFNR model from MSIX package: $($model.FullName)"
-        Remove-Item -LiteralPath $model.FullName -Force
+    foreach ($filter in @("DeepFilterNet3_onnx.tar.gz", "DeepFilterNet3_onnx.dfmodel")) {
+        $dfnrModels = Get-ChildItem -LiteralPath $resolvedPackageRoot -Recurse -File -Filter $filter -ErrorAction SilentlyContinue
+        foreach ($model in $dfnrModels) {
+            Write-Host "Excluding loose DFNR model payload from MSIX package: $($model.FullName)"
+            Remove-Item -LiteralPath $model.FullName -Force
+        }
     }
 }
 

--- a/packaging/windows/store-identity.ps1
+++ b/packaging/windows/store-identity.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+    Set the Partner Center package identity for AetherSDR Store MSIX builds.
+
+.DESCRIPTION
+    These values are assigned on the Partner Center Product identity page after
+    reserving the Microsoft Store product name. They are public package
+    identity values, not signing secrets. Existing environment variables win so
+    CI/release callers can still override them without editing this file.
+#>
+
+if ([string]::IsNullOrWhiteSpace($env:AETHERSDR_MSIX_IDENTITY_NAME)) {
+    $env:AETHERSDR_MSIX_IDENTITY_NAME = "AetherSDR.AetherSDR"
+}
+
+if ([string]::IsNullOrWhiteSpace($env:AETHERSDR_MSIX_PUBLISHER)) {
+    $env:AETHERSDR_MSIX_PUBLISHER = "CN=E03F94A2-AEAB-46D2-8BF1-6419C305CC44"
+}
+
+if ([string]::IsNullOrWhiteSpace($env:AETHERSDR_MSIX_DISPLAY_NAME)) {
+    $env:AETHERSDR_MSIX_DISPLAY_NAME = "AetherSDR"
+}
+
+if ([string]::IsNullOrWhiteSpace($env:AETHERSDR_MSIX_PUBLISHER_DISPLAY_NAME)) {
+    $env:AETHERSDR_MSIX_PUBLISHER_DISPLAY_NAME = "AetherSDR"
+}

--- a/src/core/DeepFilterFilter.cpp
+++ b/src/core/DeepFilterFilter.cpp
@@ -7,13 +7,128 @@
 #include <cstring>
 #include <vector>
 #include <QCoreApplication>
+#include <QCryptographicHash>
 #include <QDir>
 #include <QDebug>
+#include <QFile>
+#include <QFileInfo>
+#include <QSaveFile>
 #include <QStandardPaths>
 
 namespace AetherSDR {
 
-static constexpr const char* kModelFileName = "DeepFilterNet3_onnx.tar.gz";
+static constexpr const char* kEmbeddedModelFileName = "DeepFilterNet3_onnx.dfmodel";
+static constexpr const char* kLegacyModelFileName = "DeepFilterNet3_onnx.tar.gz";
+static constexpr const char* kEmbeddedModelResource = ":/models/DeepFilterNet3_onnx.dfmodel";
+
+static QByteArray existingModelPath(const QString& path, QStringList& searched)
+{
+    searched << path;
+    if (!QFile::exists(path)) {
+        return {};
+    }
+
+    const QString canonical = QFileInfo(path).canonicalFilePath();
+    return (canonical.isEmpty() ? path : canonical).toUtf8();
+}
+
+static QByteArray findModelInDirectory(const QString& directory, QStringList& searched)
+{
+    const QDir dir(directory);
+    for (const char* fileName : {kEmbeddedModelFileName, kLegacyModelFileName}) {
+        const QByteArray path = existingModelPath(dir.filePath(QString::fromLatin1(fileName)), searched);
+        if (!path.isEmpty()) {
+            return path;
+        }
+    }
+    return {};
+}
+
+static QByteArray extractEmbeddedModel(QStringList& searched)
+{
+    const QString resourcePath = QString::fromLatin1(kEmbeddedModelResource);
+    searched << resourcePath;
+
+    QFile resource(resourcePath);
+    if (!resource.exists()) {
+        return {};
+    }
+    if (!resource.open(QIODevice::ReadOnly)) {
+        qWarning() << "DeepFilterFilter: embedded model resource exists but could not be opened:"
+                   << resource.errorString();
+        return {};
+    }
+
+    const QByteArray modelBytes = resource.readAll();
+    if (modelBytes.isEmpty() && resource.size() > 0) {
+        qWarning() << "DeepFilterFilter: embedded model resource could not be read:"
+                   << resource.errorString();
+        return {};
+    }
+
+    QString dataDir = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+    if (dataDir.isEmpty()) {
+        dataDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+    }
+    if (dataDir.isEmpty()) {
+        qWarning() << "DeepFilterFilter: no writable app data directory for embedded model cache";
+        return {};
+    }
+
+    const QString modelDir = QDir(dataDir).filePath(QStringLiteral("models"));
+    if (!QDir().mkpath(modelDir)) {
+        qWarning() << "DeepFilterFilter: could not create embedded model cache directory" << modelDir;
+        return {};
+    }
+
+    const QString targetPath = QDir(modelDir).filePath(QString::fromLatin1(kEmbeddedModelFileName));
+    const QString hashPath = targetPath + QStringLiteral(".sha256");
+    searched << targetPath;
+
+    const QByteArray resourceHash =
+        QCryptographicHash::hash(modelBytes, QCryptographicHash::Sha256).toHex();
+
+    bool cachedHashMatches = false;
+    if (QFileInfo::exists(targetPath)) {
+        QFile hashFile(hashPath);
+        if (hashFile.open(QIODevice::ReadOnly)) {
+            cachedHashMatches = hashFile.readAll().trimmed() == resourceHash;
+        }
+    }
+    if (cachedHashMatches) {
+        const QString canonical = QFileInfo(targetPath).canonicalFilePath();
+        return (canonical.isEmpty() ? targetPath : canonical).toUtf8();
+    }
+
+    QSaveFile targetFile(targetPath);
+    if (!targetFile.open(QIODevice::WriteOnly)) {
+        qWarning() << "DeepFilterFilter: could not open embedded model cache for writing:"
+                   << targetPath << targetFile.errorString();
+        return {};
+    }
+    if (targetFile.write(modelBytes) != modelBytes.size()) {
+        qWarning() << "DeepFilterFilter: could not write embedded model cache:"
+                   << targetPath << targetFile.errorString();
+        return {};
+    }
+    if (!targetFile.commit()) {
+        qWarning() << "DeepFilterFilter: could not commit embedded model cache:"
+                   << targetPath << targetFile.errorString();
+        return {};
+    }
+
+    QSaveFile newHashFile(hashPath);
+    if (newHashFile.open(QIODevice::WriteOnly)) {
+        newHashFile.write(resourceHash);
+        if (!newHashFile.commit()) {
+            qWarning() << "DeepFilterFilter: could not commit embedded model cache hash:"
+                       << hashPath << newHashFile.errorString();
+        }
+    }
+
+    const QString canonical = QFileInfo(targetPath).canonicalFilePath();
+    return (canonical.isEmpty() ? targetPath : canonical).toUtf8();
+}
 
 static QByteArray findModelPath()
 {
@@ -21,39 +136,40 @@ static QByteArray findModelPath()
     QStringList searched;
 
     // 1. Adjacent to the executable (Linux/Windows build dir, or installed)
-    QString path = exeDir + "/" + kModelFileName;
-    searched << path;
-    if (QFile::exists(path)) {
-        return path.toUtf8();
+    QByteArray path = findModelInDirectory(exeDir, searched);
+    if (!path.isEmpty()) {
+        return path;
     }
     // 2. macOS app bundle: Contents/Resources/
-    path = exeDir + "/../Resources/" + kModelFileName;
-    searched << path;
-    if (QFile::exists(path)) {
-        return QDir(path).canonicalPath().toUtf8();
+    path = findModelInDirectory(QDir(exeDir).filePath(QStringLiteral("../Resources")), searched);
+    if (!path.isEmpty()) {
+        return path;
     }
     // 3. Dev builds: third_party dir relative to exe
-    path = exeDir + "/../third_party/deepfilter/models/" + kModelFileName;
-    searched << path;
-    if (QFile::exists(path)) {
-        return QDir(path).canonicalPath().toUtf8();
+    path = findModelInDirectory(QDir(exeDir).filePath(QStringLiteral("../third_party/deepfilter/models")), searched);
+    if (!path.isEmpty()) {
+        return path;
     }
     // 4. XDG data directory (Linux installed via package or cmake --install)
     QString dataDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
     if (!dataDir.isEmpty()) {
-        path = dataDir + "/AetherSDR/" + kModelFileName;
-        searched << path;
-        if (QFile::exists(path)) {
-            return path.toUtf8();
+        path = findModelInDirectory(QDir(dataDir).filePath(QStringLiteral("AetherSDR")), searched);
+        if (!path.isEmpty()) {
+            return path;
         }
     }
     // 5. System-wide install paths (Linux)
     for (const QString& prefix : {QStringLiteral("/usr/share"), QStringLiteral("/usr/local/share")}) {
-        path = prefix + "/AetherSDR/" + kModelFileName;
-        searched << path;
-        if (QFile::exists(path)) {
-            return path.toUtf8();
+        path = findModelInDirectory(QDir(prefix).filePath(QStringLiteral("AetherSDR")), searched);
+        if (!path.isEmpty()) {
+            return path;
         }
+    }
+    // 6. Store-ready Windows builds embed the model payload in Qt resources and
+    // materialize it into writable app-local data because libdf requires a path.
+    path = extractEmbeddedModel(searched);
+    if (!path.isEmpty()) {
+        return path;
     }
 
     qWarning() << "DeepFilterFilter: model not found. Searched:" << searched;


### PR DESCRIPTION
## Summary

This prepares the Windows Store MSIX package for submission while keeping DFNR enabled without shipping the DeepFilterNet model as a `.tar.gz` archive.

- Embed the DeepFilterNet model resources at build time so Store packages can load DFNR data directly from Qt resources.
- Update the Windows MSIX packaging script and CI workflow to exclude the loose DFNR model payload for Store builds.
- Add checked-in Partner Center package identity defaults for the Store submission:
  - `Identity.Name`: `AetherSDR.AetherSDR`
  - `Identity.Publisher`: `CN=E03F94A2-AEAB-46D2-8BF1-6419C305CC44`
  - `PublisherDisplayName`: `AetherSDR`
- Document the Store build flow, identity defaults, validation steps, and upload package behavior.

## Implementation Notes

The DFNR loader now first tries the existing app-data model location, then falls back to a packaged resource path when the model is embedded. This lets normal development/test builds continue to use external model files while Store builds avoid archive payloads that WACK flags.

The workflow sources `packaging/windows/store-identity.ps1` before creating the MSIX. The helper only fills missing environment variables, so CI repository variables or local shell variables can still override the identity when needed.

## Validation

Built locally from a fresh Windows Store submission worktree using the MSVC environment and 8 build jobs.

- `cmake --build build\msvc-store-submit --target AetherSDR -j 8`
- `windeployqt deploy\AetherSDR.exe --release --no-translations --no-system-d3d-compiler`
- `packaging\windows\create-msix.ps1 -DeployDir deploy -PackageRoot AetherSDR-store-submission\msix-root -OutputDir AetherSDR-store-submission -CreateUpload -SkipSign -ExcludeDfnrModel`
- `packaging\windows\check-dpi-awareness.ps1 -ExePath deploy\AetherSDR.exe`
- Windows App Certification Kit on the final MSIX

Final local validation results:

- Manifest identity verified as `AetherSDR.AetherSDR` / `CN=E03F94A2-AEAB-46D2-8BF1-6419C305CC44` / `AetherSDR`.
- Final package contains `deepfilter.dll` and `AetherSDR.exe`, but no `DeepFilterNet`, `.dfmodel`, or `.tar.gz` payload.
- WACK overall result: `PASS`.
- WACK `Archive files usage`: `PASS`.
- WACK `DPIAwarenessValidation`: `PASS`.
- WACK optional `Blocked executables`: still reports findings from Qt/OpenGL/process API/static string matches, but overall WACK remains `PASS`.

The final local artifact for Partner Center submission is the generated `.msixupload`; it is intentionally unsigned with `-SkipSign` because Microsoft signs Store-distributed packages.