### PR TITLE
fix(windows): resolve LNK1220 manifest conflict and Qt::UniqueConnection assert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1031,8 +1031,14 @@ elseif(WIN32)
         target_sources(AetherSDR PRIVATE "${WIN_RC}")
     endif()
     if(MSVC)
-        target_link_options(AetherSDR PRIVATE
-            "/MANIFESTINPUT:${CMAKE_SOURCE_DIR}/packaging/windows/AetherSDR.exe.manifest")
+        # Suppress the linker's own manifest pipeline so vs_link_exe does not generate
+        # a competing manifest.res.  The manifest is embedded via AetherSDR.rc (type 24
+        # id 1) which is compiled into the binary as a regular Win32 resource.
+        # Background: MSVC 14.50+ (VS 2022 17.10) requires /MANIFEST:EMBED alongside
+        # /MANIFESTINPUT, but CMake's vs_link_exe (up through 4.2.3) still emits the
+        # old /MANIFEST /MANIFESTFILE: pair, producing LNK1220.  Switching to the .rc
+        # approach avoids the two-pass manifest pipeline entirely.
+        target_link_options(AetherSDR PRIVATE "/MANIFEST:NO")
     endif()
 endif()
 

--- a/packaging/windows/AetherSDR.rc
+++ b/packaging/windows/AetherSDR.rc
@@ -1,1 +1,7 @@
 IDI_ICON1 ICON "AetherSDR.ico"
+
+// Embed the application manifest (DPI awareness, UAC level, common-controls v6).
+// Resource type 24 (RT_MANIFEST), ID 1 = exe manifest.
+// Replaces the former /MANIFESTINPUT linker flag which broke on MSVC 14.50+
+// (LNK1220: requires /MANIFEST:EMBED — CMake vs_link_exe does not emit that flag).
+1 24 "AetherSDR.exe.manifest"

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -2413,7 +2413,7 @@ NetworkDiagnosticsHistory::NetworkDiagnosticsHistory(RadioModel* model, AudioEng
         ev.fpsCap      = fpsCap;
         m_throttleEvents.push_back(ev);
         if (active) ++m_throttleSessionCount;
-    }, Qt::UniqueConnection);
+    });
 
     // Seed adaptive-throttle state from the model in case the dialog opens
     // while throttle is already engaged; without this seed the badge,


### PR DESCRIPTION
## Summary

Two unrelated Windows-only build/runtime failures that both surfaced when building against MSVC 14.50.35728 (VS 2022 17.10).

- **LNK1220 linker error**: MSVC 14.50 now requires `/MANIFEST:EMBED` alongside `/MANIFESTINPUT`, but CMake 4.2.3's `vs_link_exe` helper still emits the old `/MANIFEST /MANIFESTFILE:` pair — triggering `LINK : fatal error LNK1220`. Fixed by suppressing the linker's manifest pipeline entirely (`/MANIFEST:NO`) and embedding the manifest as an `RT_MANIFEST` Win32 resource (`1 24 "AetherSDR.exe.manifest"`) directly in `AetherSDR.rc`. Verified post-build with `mt.exe` extraction: DPI awareness (PerMonitorV2), asInvoker UAC, and Common Controls v6 all confirmed present.
- **Qt::UniqueConnection runtime assert**: `NetworkDiagnosticsHistory` constructor was passing `Qt::UniqueConnection` to a lambda slot. Qt cannot deduplicate lambda closures (no stable address) and asserts at runtime. Removed the flag — the connection is made once in the constructor so it is already de facto unique.

## Files changed

| File | Change |
|---|---|
| `CMakeLists.txt` | Replace `/MANIFESTINPUT` with `/MANIFEST:NO` under `if(MSVC)` guard |
| `packaging/windows/AetherSDR.rc` | Add `1 24 "AetherSDR.exe.manifest"` RT_MANIFEST resource |
| `src/gui/NetworkDiagnosticsDialog.cpp` | Remove `Qt::UniqueConnection` from lambda connection in `NetworkDiagnosticsHistory` ctor |

## Test plan

- [ ] Windows build completes without LNK1220 on MSVC 14.50+ (VS 2022 17.10)
- [ ] `mt.exe -inputresource:AetherSDR.exe;#1` extracts manifest with PerMonitorV2 DPI, asInvoker, Common Controls v6
- [ ] Application starts without Qt assert dialog (`QObject::connect: Unique connection requires the slot to be a pointer to a member function...`)
- [ ] CI check-windows gate passes
- [ ] Linux CI unaffected (MSVC guard is `if(MSVC)` only; `.rc` change is Windows-only build input)

## Constitution

**Principle XI — Fixes Are Demonstrated**: both fixes verified locally before staging. Manifest confirmed by `mt.exe` extraction. Qt assert confirmed absent at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)