### PR TITLE
fix(audio): add preferredFormat() fallback for WASAPI Float32 output devices

### DIFF
--- a/src/core/ClientPuduMonitor.cpp
+++ b/src/core/ClientPuduMonitor.cpp
@@ -225,21 +225,54 @@ void ClientPuduMonitor::startPlayback()
         fallbackReasons << QStringLiteral("24000Hz Int16 stereo unsupported -> 48000Hz");
         attemptedFormats << QStringLiteral("48000Hz 2ch Int16");
         if (!dev.isFormatSupported(fmt)) {
-            // Neither 24 kHz nor 48 kHz int16 — extremely rare.  Give up
-            // quietly; playback was best-effort anyway.
-            AudioSummaryLogger::OpenFailureSummary failure;
-            failure.path = QStringLiteral("Aetherial monitor playback");
-            failure.backend = QStringLiteral("QAudioSink");
-            failure.deviceDescription = dev.description();
-            failure.attemptedFormats = attemptedFormats.join(QStringLiteral("; "));
-            failure.failureReason = QStringLiteral("output device supports neither 24000Hz nor 48000Hz Int16 stereo");
-            failure.fallbackReason = fallbackReasons.join(QStringLiteral("; "));
-            AudioSummaryLogger::logOpenFailure(failure);
-            bail(); return;
+            // Int16 @ 24 kHz and 48 kHz both rejected.  On Windows this is
+            // typically WASAPI shared mode running a Float32 mix pipeline -
+            // the hardware is capable of Int16 but the OS-level mixer refuses
+            // the format.  Try the device's preferred format before giving up,
+            // following the QuindarLocalSink / AudioEngine precedent.
+            QAudioFormat preferred = dev.preferredFormat();
+            preferred.setChannelCount(kChannels);
+            if (preferred.isValid() && dev.isFormatSupported(preferred)) {
+                fmt = preferred;
+                sinkRate = fmt.sampleRate();
+                fallbackReasons << QStringLiteral("48000Hz Int16 unsupported -> preferredFormat (%1Hz %2)")
+                                       .arg(sinkRate)
+                                       .arg(AudioSummaryLogger::sampleFormatName(fmt.sampleFormat()));
+                attemptedFormats << QStringLiteral("%1Hz %2ch %3")
+                                        .arg(sinkRate)
+                                        .arg(fmt.channelCount())
+                                        .arg(AudioSummaryLogger::sampleFormatName(fmt.sampleFormat()));
+            } else {
+                AudioSummaryLogger::OpenFailureSummary failure;
+                failure.path = QStringLiteral("Aetherial monitor playback");
+                failure.backend = QStringLiteral("QAudioSink");
+                failure.deviceDescription = dev.description();
+                failure.attemptedFormats = attemptedFormats.join(QStringLiteral("; "));
+                failure.failureReason = QStringLiteral("output device supports neither Int16 stereo nor its own preferredFormat");
+                failure.fallbackReason = fallbackReasons.join(QStringLiteral("; "));
+                AudioSummaryLogger::logOpenFailure(failure);
+                bail(); return;
+            }
         }
     }
 
     if (!preparePlaybackPcm(sinkRate)) { bail(); return; }
+
+    // If the sink negotiated a non-Int16 format (e.g. Float32 via WASAPI
+    // shared mode), convert the Int16 payload from preparePlaybackPcm()
+    // to the required sample format.  Only Float32 is handled here since
+    // that is the only format preferredFormat() returns in practice on
+    // WASAPI and CoreAudio devices that reject Int16.
+    if (fmt.sampleFormat() == QAudioFormat::Float) {
+        const int frames = m_playPcm.size() / kBytesPerFrame;
+        QByteArray floatPcm(frames * kChannels * static_cast<int>(sizeof(float)), '\0');
+        const auto* src = reinterpret_cast<const int16_t*>(m_playPcm.constData());
+        auto*       dst = reinterpret_cast<float*>(floatPcm.data());
+        for (int i = 0; i < frames * kChannels; ++i) {
+            dst[i] = src[i] / 32768.0f;
+        }
+        m_playPcm = std::move(floatPcm);
+    }
 
     // ── QBuffer → QAudioSink (pull mode) ───────────────────────────
     // Sink pulls from QBuffer at its own cadence.  No timer, no


### PR DESCRIPTION
## Summary

`ClientPuduMonitor::startPlayback()` accepted only Int16 stereo at 24 kHz or 48 kHz. On Windows 11 with WASAPI shared mode, the audio engine mixer runs internally in Float32. When the shared pipeline is in Float32 mode, `IAudioClient::IsFormatSupported()` (surfaced via `QAudioDevice::isFormatSupported()`) rejects Int16 regardless of hardware capability — causing `startPlayback()` to bail at format negotiation on any Windows machine whose WASAPI mix format is not Int16.

Root cause confirmed: the same C-Media USB device opens successfully in `AudioEngine` as Float32 stereo 48 kHz — the hardware is not the constraint, the WASAPI shared pipeline is. This is the same class of format-negotiation problem already solved in `QuindarLocalSink.cpp:61` and `AudioEngine.cpp:306` via `dev.preferredFormat()`.

## Fix

When both Int16 @ 24 kHz and Int16 @ 48 kHz are rejected, query `dev.preferredFormat()`, enforce stereo channel count, and accept it if `isFormatSupported()` confirms it. After `preparePlaybackPcm()` produces the resampled Int16 buffer, convert Int16 → Float32 in-place when the negotiated sink format is Float32 (trivial per-sample multiply; the r8brain resampler already handles any rate conversion).

The accepted format and fallback reason are recorded in the `AudioSummaryLogger` open-success summary, making the path inspectable from future support bundles.

## Files changed

| File | Change |
|---|---|
| `src/core/ClientPuduMonitor.cpp` | Add `preferredFormat()` as third format candidate; add Int16→Float32 conversion post-resample when sink format is Float32 |

## Test plan

- [ ] Windows 11 with C-Media USB (or any WASAPI Float32 device): record audio → confirm actual audio playback through device, not just a recovered-but-silent RX stream
- [ ] Confirm `Audio Auxiliary sink summary` log line now appears for "Aetherial monitor playback" with fallback reason showing `preferredFormat` path
- [ ] Linux build: record and play back → confirm Int16 24 kHz fast path taken; preferredFormat branch unreached
- [ ] macOS: confirm Int16 48 kHz path taken on standard CoreAudio devices
- [ ] CI check-windows, check-macos, check-paths pass

## Constitution

**Principle VIII — Evidence Over Assertion**: the WASAPI Float32 behavior is confirmed by the log in #3222 showing `format=Float` for `AudioEngine`'s successful open of the same device that `ClientPuduMonitor` fails on. The fix follows `QuindarLocalSink`'s established `preferredFormat()` pattern rather than asserting a novel approach.

Fixes #3229
Refs #3222

🤖 Generated with [Claude Code](https://claude.com/claude-code)