### PR TITLE
fix(SpectrumWidget): suppress spot tooltip strobe on overlay rebuild

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4498,6 +4498,7 @@ void SpectrumWidget::leaveEvent(QEvent* event)
 {
     QWidget::leaveEvent(event);
     m_hoveredSpotKey.clear();
+    m_lastTooltipRect = {};
     updateTrackedCursorState(QPoint(-1, -1), false);
 }
 
@@ -7091,10 +7092,14 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
                     + QString::number(qRound(hr.freqMhz * 1000.0));
                 if (key != m_hoveredSpotKey) continue;
                 if (!hr.rect.contains(mapFromGlobal(cursorPos))) continue;
-                if (hr.markerIndex >= 0 && hr.markerIndex < m_spotMarkers.size())
-                    QToolTip::showText(cursorPos + QPoint(0, 20),
-                                       spotMarkerTooltip(m_spotMarkers[hr.markerIndex]),
-                                       this, hr.rect);
+                if (hr.markerIndex >= 0 && hr.markerIndex < m_spotMarkers.size()) {
+                    if (hr.rect != m_lastTooltipRect) {
+                        m_lastTooltipRect = hr.rect;
+                        QToolTip::showText(cursorPos + QPoint(0, 20),
+                                           spotMarkerTooltip(m_spotMarkers[hr.markerIndex]),
+                                           this, hr.rect);
+                    }
+                }
                 break;
             }
         }, Qt::QueuedConnection);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -951,6 +951,7 @@ private:
     QVector<SpotHitRect> m_spotClickRects;
     QString m_hoveredSpotKey;          // callsign@freqKHz, empty when no spot hovered
     bool    m_tooltipRefreshPending{false}; // guards against duplicate queued refreshes
+    QRect   m_lastTooltipRect;              // suppresses showText() when hr.rect unchanged
 
     QVector<SpotCluster> m_spotClusters;
     bool m_showSpots{true};


### PR DESCRIPTION
## Problem

When a spot cluster update or band change arrives while the mouse is
hovering over a spot marker, the tooltip strobes (rapidly hides and
reappears). This happens on every network refresh that contains new or
moved spots.

## Root cause

`drawSpotMarkers()` queues a `QToolTip::showText()` call via
`QueuedConnection` each time the static overlay is rebuilt with a hovered
spot key active. When successive `setSpotMarkers()` batches cause multiple
sequential overlay rebuilds, each rebuild queues a fresh `showText()` call
with whatever `hr.rect` the current spot layout produced. If that rect
shifted even slightly (collision-nudge cascade, new arrivals, sort-order
change), Qt treats it as a different tooltip anchor — hide, then show —
producing the visible strobe.

The existing `m_tooltipRefreshPending` guard correctly blocks duplicate
fires within a single event-loop drain cycle, but it resets between dirty
cycles, so it does not prevent strobe caused by rapid sequential cycles.

Root cause verified by reading the queued lambda in `drawSpotMarkers()` and
the `spotMarkersVisuallyEqual()` guard in `setSpotMarkers()` directly in
source before implementing the fix (Principle VIII: Evidence Over
Assertion).

## Fix

Cache the last `hr.rect` passed to `showText()` in `m_lastTooltipRect`. In
the queued refresh path, skip `showText()` entirely when the hovered spot's
hit-rect matches the cached value — no rect change means no anchor movement,
so Qt would not produce a new tooltip position anyway. Clear the cache in
`leaveEvent()` so re-entering a spot always produces a fresh show.

## Changes

- `src/gui/SpectrumWidget.h` — add `QRect m_lastTooltipRect`
- `src/gui/SpectrumWidget.cpp` — rect-cache check in queued refresh lambda;
  cache clear in `leaveEvent()`

## Testing

Reproduce with a live cluster feed (or rapid `setSpotMarkers()` calls) while
hovering a spot. With the fix the tooltip remains stable during updates; it
still refreshes correctly when the spot physically moves enough to change
the hit-rect. `leaveEvent` + re-hover also produces a clean show.

Fixes #3200