### PR TITLE
feat(tci): add mic_level handler (bridge existing setMicLevel to TCI)

### DIFF
--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -205,6 +205,7 @@ QString TciProtocol::generateInitBurst()
         // Without it, WSJT-X/JTDX crash parsing args.at(1) on a 1-element list.
         burst += QStringLiteral("drive:%1,%2;").arg(txTrx).arg(tx.rfPower());
         burst += QStringLiteral("tune_drive:%1,%2;").arg(txTrx).arg(tx.tunePower());
+        burst += QStringLiteral("mic_level:%1;").arg(tx.micLevel());
         burst += QStringLiteral("trx:%1,%2;").arg(txTrx).arg(isTx ? "true" : "false");
     }
 
@@ -305,6 +306,7 @@ QString TciProtocol::handleCommand(const QString& cmd)
     if (name == "tune")             return cmdTune(args, isSet);
     if (name == "drive")            return cmdDrive(args, isSet);
     if (name == "tune_drive")       return cmdTuneDrive(args, isSet);
+    if (name == "mic_level")        return cmdMicLevel(args, isSet);
     if (name == "rit_enable")       return cmdRitEnable(args, isSet);
     if (name == "xit_enable")       return cmdXitEnable(args, isSet);
     if (name == "rit_offset")       return cmdRitOffset(args, isSet);
@@ -531,6 +533,35 @@ QString TciProtocol::cmdTuneDrive(const QStringList& args, bool /*isSet*/)
     }, Qt::QueuedConnection);
 
     m_pendingNotification = QStringLiteral("tune_drive:%1;").arg(pwr);
+    return {};
+}
+
+// ── MIC_LEVEL: get/set mic input gain ─────────────────────────────────────
+
+// mic_level bridges TransmitModel::setMicLevel() (the existing radio-side
+// setter wired into FlexLib via commandReady) to TCI clients.  Single arg
+// 0-100 (percent), global — mic is whole-radio, not per-trx — matching the
+// drive/tune_drive convention.  Accepts the legacy TRX-prefixed form
+// `mic_level:0,N;` for forward compatibility with strict-spec clients (the
+// trx index is ignored since mic is global).
+//
+// Added 2026-05-27 to unblock the aethersdr-ulanzi-plugin Mic Gain ▲▼ keys,
+// which already send the verb but currently land on a missing dispatcher
+// entry → silently ignored.
+QString TciProtocol::cmdMicLevel(const QStringList& args, bool /*isSet*/)
+{
+    if (args.isEmpty()) {
+        int lvl = m_model ? m_model->transmitModel().micLevel() : 0;
+        return QStringLiteral("mic_level:%1;").arg(lvl);
+    }
+    bool ok;
+    int lvl = args[args.size() == 1 ? 0 : 1].toInt(&ok);
+    if (!ok) return {};
+    QMetaObject::invokeMethod(m_model, [model = m_model, lvl]() {
+        model->transmitModel().setMicLevel(lvl);
+    }, Qt::QueuedConnection);
+
+    m_pendingNotification = QStringLiteral("mic_level:%1;").arg(lvl);
     return {};
 }
 

--- a/src/core/TciProtocol.h
+++ b/src/core/TciProtocol.h
@@ -48,6 +48,7 @@ private:
     QString cmdTune(const QStringList& args, bool isSet);
     QString cmdDrive(const QStringList& args, bool isSet);
     QString cmdTuneDrive(const QStringList& args, bool isSet);
+    QString cmdMicLevel(const QStringList& args, bool isSet);
     QString cmdTxGain(const QStringList& args, bool isSet);
     QString cmdRitEnable(const QStringList& args, bool isSet);
     QString cmdXitEnable(const QStringList& args, bool isSet);

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -517,7 +517,10 @@ void TransmitModel::setMicSelection(const QString& input)
 void TransmitModel::setMicLevel(int level)
 {
     level = qBound(0, level, 100);
-    m_micLevel = level;
+    if (m_micLevel != level) {
+        m_micLevel = level;
+        emit micStateChanged();  // PhoneCwApplet's mic slider binds to this
+    }
     emit commandReady(QString("transmit set miclevel=%1").arg(level));
 }
 


### PR DESCRIPTION
## Summary

Adds a `mic_level` command to `TciProtocol`, bridging the existing `TransmitModel::setMicLevel(int)` setter to TCI clients. Until now `mic_level:` commands sent over TCI silently no-op'd — `handleCommand`'s dispatcher had no entry for them.

**3 files changed (+36 / -1):**

| File | Change |
|---|---|
| `src/core/TciProtocol.h` | Declare `cmdMicLevel(const QStringList&, bool)` |
| `src/core/TciProtocol.cpp` | Dispatcher entry, `cmdMicLevel` body (cloned from `cmdDrive`), init-burst line |
| `src/models/TransmitModel.cpp` | **`setMicLevel` now emits `micStateChanged`** + equality guard (see below) |

## The `TransmitModel::setMicLevel` change (behaviour change — calling it out explicitly)

`setMicLevel` previously updated `m_micLevel` and emitted `commandReady` toward FlexLib, but **never emitted `micStateChanged`** — the signal the mic-level slider binds to (`PhoneCwApplet.cpp:667` → `:728`, also `MainWindow.cpp:2420`). This was invisible until now because nothing called `setMicLevel` from a non-UI path; the slider's own `onValueChanged` was the only entry. Once `cmdMicLevel` started calling it programmatically over TCI, the gap surfaced: the radio + internal state updated, but the UI slider froze.

Fix mirrors `setSpeechProcessorLevel` / `setRfPower`: equality guard + emit the state-changed signal before `commandReady`. Without it the TCI handler is functionally half-broken (no UI feedback), so it belongs in this PR.

## `cmdMicLevel`

Near-exact clone of `cmdDrive` — global verb (no per-trx; mic is whole-radio), accepts spec form `mic_level:N;` and legacy TRX-prefixed `mic_level:0,N;` (trx ignored). Init burst gains a `mic_level:<value>;` line so clients learn the current value on connect.

## Split out

The unrelated `/MANIFEST:EMBED` CMakeLists build fix that was previously bundled here is now **#3237** (separate PR, reviewed against the Windows toolchain matrix independently). This PR is purely the `mic_level` TCI feature + its required UI-signal fix.

## Verified — three platforms

- **Linux** (Ubuntu 24.04, Qt 6.4.2): live test — sent `mic_level:0,30/60/90` over TCI, AE mic slider tracked each value. Confirmed end-to-end: parse → dispatcher → `setMicLevel` → `micStateChanged` → UI repaint.
- **Windows** (MSVC 14.50, Qt 6.10.3): builds + launches (with #3237's CMake fix locally).
- **macOS** (Apple Silicon, Qt 6.11): builds clean.

## Test plan

- [x] Live mic_level slider-tracking verified on Linux
- [x] Builds on all three platforms
- [ ] CI matrix (auto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)