### PR TITLE
fix(RadioModel,NetworkDiag): remove Qt::UniqueConnection from adaptive-throttle lambda slots

### DIFF
--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -2413,7 +2413,7 @@ NetworkDiagnosticsHistory::NetworkDiagnosticsHistory(RadioModel* model, AudioEng
         ev.fpsCap      = fpsCap;
         m_throttleEvents.push_back(ev);
         if (active) ++m_throttleSessionCount;
-    }, Qt::UniqueConnection);
+    });
 
     // Seed adaptive-throttle state from the model in case the dialog opens
     // while throttle is already engaged; without this seed the badge,

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3437,7 +3437,7 @@ PanadapterModel* RadioModel::ensureOwnedPanadapter(const QString& panId)
                 this, [this, normalizedPanId]() {
             const int cap = currentAdaptiveFpsCap();
             if (cap > 0) sendAdaptiveCapToPan(normalizedPanId, cap);
-        }, Qt::UniqueConnection);
+        });
     }
 
     connect(pan, &PanadapterModel::waterfallIdChanged,


### PR DESCRIPTION
## Summary

Two `Qt::UniqueConnection` + lambda assert sites introduced by the adaptive throttle feature. Both assert at runtime with:

```
ASSERT failure in "QObject::connect: Unique connection requires the slot to be a pointer to a member function of a QObject subclass."
Qt6Core.dll  qobject.h:269
```

`Qt::UniqueConnection` is only valid with `&ClassName::memberFunction` pointer syntax — Qt has no way to compare lambda closures for deduplication.

> **Note**: the LNK1220 build failure is handled separately by #3237 (already merged). This PR covers the two runtime asserts only.

## Fixes

### 1 — `RadioModel::ensureOwnedPanadapter` (`RadioModel.cpp:3440`)

Asserts whenever a **second slice is added while autothrottle is actively capping fps**. The function already has an early-return guard at line 3412 (`if (auto* existing = …) return existing`) that ensures the connection is made at most once per pan — `Qt::UniqueConnection` was both invalid with a lambda and redundant.

### 2 — `NetworkDiagnosticsHistory` constructor (`NetworkDiagnosticsDialog.cpp:2416`)

Same issue. The connection is made exactly once in the constructor so the flag was always a no-op in addition to being invalid.

## Files changed

| File | Change |
|---|---|
| `src/models/RadioModel.cpp` | Remove `Qt::UniqueConnection` from deferred-cap lambda in `ensureOwnedPanadapter` |
| `src/gui/NetworkDiagnosticsDialog.cpp` | Remove `Qt::UniqueConnection` from `adaptiveThrottleChanged` lambda in `NetworkDiagnosticsHistory` ctor |

## Test plan

- [x] Autothrottle off, single slice — no assert
- [x] Autothrottle on, single slice — no assert
- [x] Autothrottle on, second slice added mid-session — no assert, both slices render at capped fps
- [x] Autothrottle toggled on/off mid-session — correct behavior throughout
- [ ] CI green

## Constitution

**Principle XI — Fixes Are Demonstrated**: both assert sites verified absent on Windows under autothrottle on and off before this commit was staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)