### PR TITLE
feat(hid): Elgato StreamDeck+ support — encoders, LCD buttons, touchscreen labels (#1510)

### DIFF
--- a/src/core/HidDeviceParser.cpp
+++ b/src/core/HidDeviceParser.cpp
@@ -194,54 +194,48 @@ HidEvent ShuttleProV2Parser::parse(const uint8_t* buf, size_t len)
 }
 
 // ── Elgato StreamDeck+ ─────────────────────────────────────────────────────
-// 64-byte reports. hidapi prepends the 1-byte report ID on Windows/Linux so
-// hid_read(buf, 65) returns 65; on macOS it strips the ID and returns 64.
-// Use len to discriminate — same pattern as IcomRC28Parser.
-// Data layout (0-indexed, after stripping report ID where present):
-//   [0] event type: 0x00=key state, 0x02=encoder rotation, 0x03=encoder press
-//   [1] unused (typically 0x01)
-// Key state report  [2..9]: 8 key states (0=up, 1=down)
-// Encoder rotation  [2..5]: 4 signed int8 deltas (positive=CW)
-// Encoder press     [2..5]: 4 encoder button states (0=up, 1=down)
-//
-// Button numbering convention: LCD keys 1-8, encoder press buttons 9-12.
-// This keeps encoder press events distinct from LCD key events in the
-// existing HidEncoderManager button dispatch.
+// 14-byte reports. hidapi always includes the report ID as buf[0] = 0x01.
+// Protocol verified against python-elgato-streamdeck v0.9.8 source:
+//   buf[0]  = 0x01 (report ID — strip it)
+//   buf[1]  = event type: 0x00=key, 0x02=touchscreen, 0x03=dial
+//   buf[2..3] = reserved
+//   Dial event (buf[1]==0x03):
+//     buf[4] = sub-type: 0x01=turn, 0x00=push
+//     buf[5..8] = 4 encoder values (signed int8 delta for turn, bool for push)
+//   Key event (buf[1]==0x00):
+//     buf[4..11] = 8 LCD key states (0=up, 1=down)
+// Button numbering: LCD keys 1-8, encoder press buttons 9-12.
 
 HidEvent StreamDeckPlusParser::parse(const uint8_t* buf, size_t len)
 {
-    if (len < 7) return {};
+    if (len < 9) return {};
 
-    // Windows/Linux: hidapi includes the report ID → hid_read returns 65 bytes.
-    // macOS: hidapi strips the report ID → hid_read returns 64 bytes.
-    const uint8_t* data = (len >= 65) ? buf + 1 : buf;
-
-    const uint8_t type = data[0];
-
-    if (type == 0x02) {
-        // Encoder rotation — return first non-zero delta
-        for (int i = 0; i < 4; ++i) {
-            int delta = static_cast<int>(static_cast<int8_t>(data[2 + i]));
-            if (delta != 0)
-                return {.type = HidEvent::Rotate, .steps = delta, .encoderIndex = i};
-        }
-        return {};
-    }
+    // buf[0] = report ID (0x01) — always present in hidraw reads on all platforms
+    const uint8_t type    = buf[1];
+    const uint8_t subtype = buf[4];
 
     if (type == 0x03) {
-        // Encoder button press/release — return first changed encoder
-        uint8_t newState = 0;
-        for (int i = 0; i < 4; ++i) {
-            if (data[2 + i])
-                newState |= (1u << i);
-        }
-        uint8_t changed = newState ^ m_prevEncBtns;
-        if (changed) {
-            m_prevEncBtns = newState;
+        if (subtype == 0x01) {
+            // Encoder turn — return first non-zero delta
             for (int i = 0; i < 4; ++i) {
-                if (changed & (1u << i)) {
-                    const int act = (newState & (1u << i)) ? 0 : 1;  // 0=press, 1=release
-                    return {.type = HidEvent::Button, .button = 9 + i, .action = act};
+                int delta = static_cast<int>(static_cast<int8_t>(buf[5 + i]));
+                if (delta != 0)
+                    return {.type = HidEvent::Rotate, .steps = delta, .encoderIndex = i};
+            }
+        } else if (subtype == 0x00) {
+            // Encoder push — return first changed encoder button
+            uint8_t newState = 0;
+            for (int i = 0; i < 4; ++i) {
+                if (buf[5 + i]) newState |= (1u << i);
+            }
+            uint8_t changed = newState ^ m_prevEncBtns;
+            if (changed) {
+                m_prevEncBtns = newState;
+                for (int i = 0; i < 4; ++i) {
+                    if (changed & (1u << i)) {
+                        const int act = (newState & (1u << i)) ? 0 : 1;
+                        return {.type = HidEvent::Button, .button = 9 + i, .action = act};
+                    }
                 }
             }
         }
@@ -249,12 +243,11 @@ HidEvent StreamDeckPlusParser::parse(const uint8_t* buf, size_t len)
     }
 
     if (type == 0x00) {
-        // LCD key press/release — return first changed key
-        if (len < 11) return {};
+        // LCD key — return first changed key
+        if (len < 12) return {};
         uint8_t newState = 0;
         for (int i = 0; i < 8; ++i) {
-            if (data[2 + i])
-                newState |= (1u << i);
+            if (buf[4 + i]) newState |= (1u << i);
         }
         uint8_t changed = newState ^ m_prevKeys;
         if (changed) {

--- a/src/core/HidDeviceParser.cpp
+++ b/src/core/HidDeviceParser.cpp
@@ -17,6 +17,8 @@ static const HidDeviceId kSupportedDevices[] = {
     // protocol; validated against PR #2870's report-layout fix
     // (end-to-end test 2026-05-20).
     {0x2341, 0x0266, "AetherPad RC-28 emulator (Arduino Giga R1)"},
+    // Elgato StreamDeck+ — 8 LCD buttons + 4 encoder dials (#1510)
+    {0x0FD9, 0x0084, "Elgato StreamDeck+"},
 };
 
 const HidDeviceId* HidDeviceParser::supportedDevices() { return kSupportedDevices; }
@@ -31,6 +33,7 @@ std::unique_ptr<HidDeviceParser> HidDeviceParser::create(uint16_t vid, uint16_t 
     // AetherPad emulator alias — same parser as the real RC-28 (see
     // comment in kSupportedDevices above).
     if (vid == 0x2341 && pid == 0x0266) return std::make_unique<IcomRC28Parser>();
+    if (vid == 0x0FD9 && pid == 0x0084) return std::make_unique<StreamDeckPlusParser>();
     return nullptr;
 }
 
@@ -185,6 +188,85 @@ HidEvent ShuttleProV2Parser::parse(const uint8_t* buf, size_t len)
         if (delta < -128) delta += 256;
         m_prevJog = jog;
         return {HidEvent::Rotate, delta, 0, 0};
+    }
+
+    return {};
+}
+
+// ── Elgato StreamDeck+ ─────────────────────────────────────────────────────
+// 64-byte reports. hidapi prepends the 1-byte report ID on Windows/Linux so
+// hid_read(buf, 65) returns 65; on macOS it strips the ID and returns 64.
+// Use len to discriminate — same pattern as IcomRC28Parser.
+// Data layout (0-indexed, after stripping report ID where present):
+//   [0] event type: 0x00=key state, 0x02=encoder rotation, 0x03=encoder press
+//   [1] unused (typically 0x01)
+// Key state report  [2..9]: 8 key states (0=up, 1=down)
+// Encoder rotation  [2..5]: 4 signed int8 deltas (positive=CW)
+// Encoder press     [2..5]: 4 encoder button states (0=up, 1=down)
+//
+// Button numbering convention: LCD keys 1-8, encoder press buttons 9-12.
+// This keeps encoder press events distinct from LCD key events in the
+// existing HidEncoderManager button dispatch.
+
+HidEvent StreamDeckPlusParser::parse(const uint8_t* buf, size_t len)
+{
+    if (len < 7) return {};
+
+    // Windows/Linux: hidapi includes the report ID → hid_read returns 65 bytes.
+    // macOS: hidapi strips the report ID → hid_read returns 64 bytes.
+    const uint8_t* data = (len >= 65) ? buf + 1 : buf;
+
+    const uint8_t type = data[0];
+
+    if (type == 0x02) {
+        // Encoder rotation — return first non-zero delta
+        for (int i = 0; i < 4; ++i) {
+            int delta = static_cast<int>(static_cast<int8_t>(data[2 + i]));
+            if (delta != 0)
+                return {.type = HidEvent::Rotate, .steps = delta, .encoderIndex = i};
+        }
+        return {};
+    }
+
+    if (type == 0x03) {
+        // Encoder button press/release — return first changed encoder
+        uint8_t newState = 0;
+        for (int i = 0; i < 4; ++i) {
+            if (data[2 + i])
+                newState |= (1u << i);
+        }
+        uint8_t changed = newState ^ m_prevEncBtns;
+        if (changed) {
+            m_prevEncBtns = newState;
+            for (int i = 0; i < 4; ++i) {
+                if (changed & (1u << i)) {
+                    const int act = (newState & (1u << i)) ? 0 : 1;  // 0=press, 1=release
+                    return {.type = HidEvent::Button, .button = 9 + i, .action = act};
+                }
+            }
+        }
+        return {};
+    }
+
+    if (type == 0x00) {
+        // LCD key press/release — return first changed key
+        if (len < 11) return {};
+        uint8_t newState = 0;
+        for (int i = 0; i < 8; ++i) {
+            if (data[2 + i])
+                newState |= (1u << i);
+        }
+        uint8_t changed = newState ^ m_prevKeys;
+        if (changed) {
+            m_prevKeys = newState;
+            for (int i = 0; i < 8; ++i) {
+                if (changed & (1u << i)) {
+                    const int act = (newState & (1u << i)) ? 0 : 1;
+                    return {.type = HidEvent::Button, .button = i + 1, .action = act};
+                }
+            }
+        }
+        return {};
     }
 
     return {};

--- a/src/core/HidDeviceParser.h
+++ b/src/core/HidDeviceParser.h
@@ -10,9 +10,10 @@ namespace AetherSDR {
 struct HidEvent {
     enum Type { None, Rotate, Button };
     Type type{None};
-    int  steps{0};       // for Rotate: +CW, -CCW
-    int  button{0};      // 1-based button number
-    int  action{0};      // 0=press, 1=release
+    int  steps{0};           // for Rotate: +CW, -CCW
+    int  button{0};          // 1-based button number
+    int  action{0};          // 0=press, 1=release
+    int  encoderIndex{0};    // for multi-encoder devices: 0-based dial index (last so existing {type,steps,button,action} inits stay valid)
 };
 
 struct HidDeviceId {
@@ -26,6 +27,7 @@ public:
     virtual ~HidDeviceParser() = default;
     virtual HidEvent parse(const uint8_t* buf, size_t len) = 0;
     virtual size_t reportSize() const = 0;
+    virtual int encoderCount() const { return 1; }
 
     static std::unique_ptr<HidDeviceParser> create(uint16_t vid, uint16_t pid);
     static const HidDeviceId* supportedDevices();
@@ -73,6 +75,26 @@ private:
     uint8_t m_prevJog{0};
     uint16_t m_prevButtons{0};
     bool m_firstReport{true};
+};
+
+// Elgato StreamDeck+ (VID 0x0FD9, PID 0x0084)
+// 64-byte reports; hidapi prepends the 1-byte report ID on Windows/Linux
+// (hid_read returns 65), strips it on macOS (hid_read returns 64).
+// Layout (after stripping report ID where present):
+//   [0] event type: 0x00=key state, 0x02=encoder rotation, 0x03=encoder press
+//   [1] unused (typically 0x01)
+//   Key state   [2..9]:  8 button states (0=up, 1=down)
+//   Enc rotate  [2..5]:  4 signed int8 deltas per encoder (positive=CW)
+//   Enc press   [2..5]:  4 encoder button states (0=up, 1=down)
+// Button numbering: LCD keys 1-8, encoder press buttons 9-12.
+class StreamDeckPlusParser : public HidDeviceParser {
+public:
+    HidEvent parse(const uint8_t* buf, size_t len) override;
+    size_t reportSize() const override { return 65; }
+    int encoderCount() const override { return 4; }
+private:
+    uint8_t m_prevKeys{0};         // bitmask of previous LCD key states (bits 0-7)
+    uint8_t m_prevEncBtns{0};      // bitmask of previous encoder button states (bits 0-3)
 };
 
 } // namespace AetherSDR

--- a/src/core/HidDeviceParser.h
+++ b/src/core/HidDeviceParser.h
@@ -78,19 +78,23 @@ private:
 };
 
 // Elgato StreamDeck+ (VID 0x0FD9, PID 0x0084)
-// 64-byte reports; hidapi prepends the 1-byte report ID on Windows/Linux
-// (hid_read returns 65), strips it on macOS (hid_read returns 64).
-// Layout (after stripping report ID where present):
-//   [0] event type: 0x00=key state, 0x02=encoder rotation, 0x03=encoder press
-//   [1] unused (typically 0x01)
-//   Key state   [2..9]:  8 button states (0=up, 1=down)
-//   Enc rotate  [2..5]:  4 signed int8 deltas per encoder (positive=CW)
-//   Enc press   [2..5]:  4 encoder button states (0=up, 1=down)
+// 14-byte reports (device HID descriptor advertises 512 but only first 14
+// bytes carry event data; matching python-elgato-streamdeck library behaviour).
+// hidapi always includes the 1-byte report ID (0x01) as buf[0] on all platforms.
+// Layout (all indices into raw buf[]):
+//   [0] report ID = 0x01 (always present — strip it)
+//   [1] event type: 0x00=key state, 0x02=touchscreen, 0x03=dial (encoder)
+//   [2..3] reserved/padding
+//   Dial event ([1]==0x03):
+//     [4] sub-type: 0x01=turn, 0x00=push
+//     [5..8] 4 encoder values (signed int8 delta for turn, bool for push)
+//   Key event ([1]==0x00):
+//     [4..11] 8 LCD key states (0=up, 1=down)
 // Button numbering: LCD keys 1-8, encoder press buttons 9-12.
 class StreamDeckPlusParser : public HidDeviceParser {
 public:
     HidEvent parse(const uint8_t* buf, size_t len) override;
-    size_t reportSize() const override { return 65; }
+    size_t reportSize() const override { return 14; }
     int encoderCount() const override { return 4; }
 private:
     uint8_t m_prevKeys{0};         // bitmask of previous LCD key states (bits 0-7)

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -147,6 +147,12 @@ void HidEncoderManager::hotplugCheck()
     }
 }
 
+void HidEncoderManager::setKeyImages(const QVector<QByteArray>& jpegImages)
+{
+    for (int i = 0; i < jpegImages.size(); ++i)
+        setKeyImage(i, jpegImages[i]);
+}
+
 void HidEncoderManager::setKeyImage(int key, const QByteArray& jpegData)
 {
     if (!m_device || !isStreamDeckPlus()) return;
@@ -176,7 +182,7 @@ void HidEncoderManager::setKeyImage(int key, const QByteArray& jpegData)
         pkt[7] = static_cast<uint8_t>((pageNumber >> 8) & 0xFF);
         std::memcpy(pkt + HEADER_SIZE, jpegData.constData() + offset, chunkLen);
 
-        hid_send_feature_report(m_device, pkt, PACKET_SIZE);
+        hid_write(m_device, pkt, PACKET_SIZE);
 
         offset     += chunkLen;
         pageNumber++;

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -4,6 +4,7 @@
 #include "core/LogManager.h"
 
 #include <QDebug>
+#include <cstring>
 
 namespace AetherSDR {
 
@@ -143,6 +144,42 @@ void HidEncoderManager::hotplugCheck()
     if (m_openVid && m_openPid) {
         if (open(m_openVid, m_openPid))
             m_hotplugTimer->stop();
+    }
+}
+
+void HidEncoderManager::setKeyImage(int key, const QByteArray& jpegData)
+{
+    if (!m_device || !isStreamDeckPlus()) return;
+
+    // StreamDeck+ LCD image write: 1024-byte feature reports (report ID 0x02),
+    // command 0x07 (set key image). Protocol verified against python-elgato-streamdeck.
+    constexpr int PACKET_SIZE  = 1024;
+    constexpr int HEADER_SIZE  = 8;
+    constexpr int PAYLOAD_SIZE = PACKET_SIZE - HEADER_SIZE;
+
+    const int totalBytes = jpegData.size();
+    int offset     = 0;
+    int pageNumber = 0;
+
+    while (offset < totalBytes) {
+        uint8_t pkt[PACKET_SIZE] = {};
+        const int chunkLen = std::min(PAYLOAD_SIZE, totalBytes - offset);
+        const bool isLast  = (offset + chunkLen >= totalBytes);
+
+        pkt[0] = 0x02;   // report ID
+        pkt[1] = 0x07;   // command: set key image
+        pkt[2] = static_cast<uint8_t>(key);
+        pkt[3] = isLast ? 1 : 0;
+        pkt[4] = static_cast<uint8_t>(chunkLen & 0xFF);
+        pkt[5] = static_cast<uint8_t>((chunkLen >> 8) & 0xFF);
+        pkt[6] = static_cast<uint8_t>(pageNumber & 0xFF);
+        pkt[7] = static_cast<uint8_t>((pageNumber >> 8) & 0xFF);
+        std::memcpy(pkt + HEADER_SIZE, jpegData.constData() + offset, chunkLen);
+
+        hid_send_feature_report(m_device, pkt, PACKET_SIZE);
+
+        offset     += chunkLen;
+        pageNumber++;
     }
 }
 

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -189,6 +189,52 @@ void HidEncoderManager::setKeyImage(int key, const QByteArray& jpegData)
     }
 }
 
+void HidEncoderManager::setTouchscreenImage(const QByteArray& jpegData,
+                                             int x_pos, int y_pos,
+                                             int width, int height)
+{
+    if (!m_device || !isStreamDeckPlus()) return;
+
+    // Touchscreen write: 1024-byte packets, 16-byte header, command 0x0c.
+    // Protocol verified against python-elgato-streamdeck StreamDeckPlus.set_touchscreen_image().
+    constexpr int PACKET_SIZE  = 1024;
+    constexpr int HEADER_SIZE  = 16;
+    constexpr int PAYLOAD_SIZE = PACKET_SIZE - HEADER_SIZE;
+
+    const int totalBytes = jpegData.size();
+    int offset     = 0;
+    int pageNumber = 0;
+
+    while (offset < totalBytes) {
+        uint8_t pkt[PACKET_SIZE] = {};
+        const int chunkLen = std::min(PAYLOAD_SIZE, totalBytes - offset);
+        const bool isLast  = (offset + chunkLen >= totalBytes);
+
+        pkt[0]  = 0x02;
+        pkt[1]  = 0x0c;
+        pkt[2]  = static_cast<uint8_t>(x_pos & 0xff);
+        pkt[3]  = static_cast<uint8_t>((x_pos >> 8) & 0xff);
+        pkt[4]  = static_cast<uint8_t>(y_pos & 0xff);
+        pkt[5]  = static_cast<uint8_t>((y_pos >> 8) & 0xff);
+        pkt[6]  = static_cast<uint8_t>(width & 0xff);
+        pkt[7]  = static_cast<uint8_t>((width >> 8) & 0xff);
+        pkt[8]  = static_cast<uint8_t>(height & 0xff);
+        pkt[9]  = static_cast<uint8_t>((height >> 8) & 0xff);
+        pkt[10] = isLast ? 1 : 0;
+        pkt[11] = static_cast<uint8_t>(pageNumber & 0xff);
+        pkt[12] = static_cast<uint8_t>((pageNumber >> 8) & 0xff);
+        pkt[13] = static_cast<uint8_t>(chunkLen & 0xff);
+        pkt[14] = static_cast<uint8_t>((chunkLen >> 8) & 0xff);
+        pkt[15] = 0x00;
+        std::memcpy(pkt + HEADER_SIZE, jpegData.constData() + offset, chunkLen);
+
+        hid_write(m_device, pkt, PACKET_SIZE);
+
+        offset     += chunkLen;
+        pageNumber++;
+    }
+}
+
 void HidEncoderManager::loadSettings()
 {
     auto& s = AppSettings::instance();

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -123,7 +123,7 @@ void HidEncoderManager::poll()
         auto event = m_parser->parse(m_buf, static_cast<size_t>(res));
         switch (event.type) {
         case HidEvent::Rotate:
-            emit tuneSteps(m_invertDirection ? -event.steps : event.steps);
+            emit tuneSteps(event.encoderIndex, m_invertDirection ? -event.steps : event.steps);
             break;
         case HidEvent::Button:
             emit buttonPressed(event.button, event.action);

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -4,6 +4,7 @@
 #include "core/LogManager.h"
 
 #include <QDebug>
+#include <algorithm>
 #include <cstring>
 
 namespace AetherSDR {

--- a/src/core/HidEncoderManager.h
+++ b/src/core/HidEncoderManager.h
@@ -42,6 +42,11 @@ public slots:
     // No-op if device is not a StreamDeck+.
     void setKeyImages(const QVector<QByteArray>& jpegImages);
     void setKeyImage(int key, const QByteArray& jpegData);
+    // Write an 800x100 JPEG to the touchscreen strip above the dials.
+    // x_pos/y_pos/width/height let you update a sub-region; defaults write the full strip.
+    void setTouchscreenImage(const QByteArray& jpegData,
+                             int x_pos = 0, int y_pos = 0,
+                             int width = 800, int height = 100);
 
 signals:
     void tuneSteps(int encoderIndex, int steps);

--- a/src/core/HidEncoderManager.h
+++ b/src/core/HidEncoderManager.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QTimer>
+#include <QByteArray>
 #include <memory>
 #include <hidapi/hidapi.h>
 #include "HidDeviceParser.h"
@@ -30,11 +31,15 @@ public:
     uint16_t vendorId() const { return m_openVid; }
     uint16_t productId() const { return m_openPid; }
     int encoderCount() const { return m_parser ? m_parser->encoderCount() : 1; }
+    bool isStreamDeckPlus() const { return m_openVid == 0x0FD9 && m_openPid == 0x0084; }
 
     void setInvertDirection(bool invert) { m_invertDirection = invert; }
 
 public slots:
     void loadSettings();
+    // Write a 120x120 JPEG image to StreamDeck+ LCD key (0-based key index 0-7).
+    // No-op if device is not a StreamDeck+. Called via QueuedConnection from main thread.
+    void setKeyImage(int key, const QByteArray& jpegData);
 
 signals:
     void tuneSteps(int encoderIndex, int steps);

--- a/src/core/HidEncoderManager.h
+++ b/src/core/HidEncoderManager.h
@@ -37,8 +37,10 @@ public:
 
 public slots:
     void loadSettings();
-    // Write a 120x120 JPEG image to StreamDeck+ LCD key (0-based key index 0-7).
-    // No-op if device is not a StreamDeck+. Called via QueuedConnection from main thread.
+    // Write 120x120 JPEG images to StreamDeck+ LCD keys. Pass all 8 images at once
+    // so one queued call updates the whole display without flooding the event queue.
+    // No-op if device is not a StreamDeck+.
+    void setKeyImages(const QVector<QByteArray>& jpegImages);
     void setKeyImage(int key, const QByteArray& jpegData);
 
 signals:

--- a/src/core/HidEncoderManager.h
+++ b/src/core/HidEncoderManager.h
@@ -29,6 +29,7 @@ public:
     QString deviceName() const { return m_deviceName; }
     uint16_t vendorId() const { return m_openVid; }
     uint16_t productId() const { return m_openPid; }
+    int encoderCount() const { return m_parser ? m_parser->encoderCount() : 1; }
 
     void setInvertDirection(bool invert) { m_invertDirection = invert; }
 
@@ -36,7 +37,7 @@ public slots:
     void loadSettings();
 
 signals:
-    void tuneSteps(int steps);
+    void tuneSteps(int encoderIndex, int steps);
     void buttonPressed(int button, int action);
     void connectionChanged(bool connected, const QString& deviceName);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3914,29 +3914,15 @@ MainWindow::MainWindow(QWidget* parent)
     m_hidEncoder = new HidEncoderManager;
     m_hidEncoder->moveToThread(m_extCtrlThread);
 
-    // HID encoder coalesce timer — same 20ms pattern as FlexControl
-    m_hidCoalesceTimer.setSingleShot(true);
-    m_hidCoalesceTimer.setInterval(20);
-    connect(&m_hidCoalesceTimer, &QTimer::timeout, this, [this]() {
-        if (m_hidPendingSteps == 0) return;
-        auto* s = activeSlice();
-        if (!s) { m_hidPendingSteps = 0; return; }
-        if (s->isLocked()) {
-            s->notifyTuneBlockedByLock();
-            m_hidPendingSteps = 0;
-            return;
-        }
-        int stepHz = spectrum() ? spectrum()->stepSize() : 100;
-        double newMhz = s->frequency() + m_hidPendingSteps * stepHz / 1e6;
-        m_hidPendingSteps = 0;
-        applyTuneRequest(s, newMhz, TuneIntent::IncrementalTune, "hid-encoder");
-    });
-
+    // Per-encoder action dispatch — routes each dial to its configured action.
+    // applyFlexControlWheelAction handles coalescing internally for frequency.
     connect(m_hidEncoder, &HidEncoderManager::tuneSteps,
-            this, [this](int steps) {
-        m_hidPendingSteps += steps;
-        if (!m_hidCoalesceTimer.isActive())
-            m_hidCoalesceTimer.start();
+            this, [this](int encoderIndex, int steps) {
+        const QString actionId = AppSettings::instance()
+            .value(QString("HidEncoderAction%1").arg(encoderIndex),
+                   MainWindow::hidEncoderDefaultAction(encoderIndex))
+            .toString();
+        applyFlexControlWheelAction(actionId, steps);
     });
 
     connect(m_hidEncoder, &HidEncoderManager::buttonPressed,
@@ -6452,6 +6438,18 @@ void MainWindow::handleFlexControlButton(int button, int action)
 void MainWindow::handleVirtualFlexControlWheel(const QString& actionId, int steps)
 {
     applyFlexControlWheelAction(actionId, steps);
+}
+
+// static
+QString MainWindow::hidEncoderDefaultAction(int encoderIndex)
+{
+    switch (encoderIndex) {
+    case 0:  return QStringLiteral("WheelFrequency");
+    case 1:  return QStringLiteral("WheelRit");
+    case 2:  return QStringLiteral("WheelXit");
+    case 3:  return QStringLiteral("WheelVolume");
+    default: return QStringLiteral("WheelFrequency");
+    }
 }
 
 void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
@@ -10458,9 +10456,8 @@ void MainWindow::onSliceAdded(SliceModel* s)
 #ifdef HAVE_SERIALPORT
         activeTuning = activeTuning || m_flexCoalesceTimer.isActive();
 #endif
-#ifdef HAVE_HIDAPI
-        activeTuning = activeTuning || m_hidCoalesceTimer.isActive();
-#endif
+        // HID encoder frequency tuning routes through applyFlexControlWheelAction,
+        // so m_flexCoalesceTimer above already covers it.
         const bool memoryRevealPending = (m_pendingMemoryRevealSliceId == s->sliceId());
         if (activeTuning && s->sliceId() == m_activeSliceId && !memoryRevealPending)
             return;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6556,18 +6556,19 @@ void MainWindow::refreshStreamDeckLabels()
     const bool ritOn = slice && slice->ritOn();
     const bool xitOn = slice && slice->xitOn();
 
+    // Build all 8 images on the main thread, then dispatch a single queued call
+    // to write them all on the ext-ctrl thread — avoids flooding the event queue.
+    QVector<QByteArray> images(8);
+
     for (int i = 0; i < 4; ++i) {
-        // Turn label — keys 0-3 (top row)
+        // Turn label — key i (top row, 0-3)
         const QString turnId  = settings.value(QString("HidEncoderAction%1").arg(i),
                                                QString::fromLatin1(kTurnDflt[i])).toString();
         const QString turnLbl = kShortLabels.value(turnId, turnId.left(6).toUpper());
-        QByteArray turnImg = renderKeyImageJpeg(turnLbl, QString("ENC %1").arg(i + 1),
-                                                QColor(20, 30, 55), Qt::white);
-        QMetaObject::invokeMethod(m_hidEncoder, [enc=m_hidEncoder, k=i, d=turnImg](){
-            enc->setKeyImage(k, d);
-        }, Qt::QueuedConnection);
+        images[i] = renderKeyImageJpeg(turnLbl, QString("ENC %1").arg(i + 1),
+                                       QColor(20, 30, 55), Qt::white);
 
-        // Push label — keys 4-7 (bottom row)
+        // Push label — key 4+i (bottom row, 4-7)
         const QString pushId  = settings.value(QString("HidEncoderPushAction%1").arg(i),
                                                QString::fromLatin1(kPushDflt[i])).toString();
         const QString pushLbl = kShortLabels.value(pushId, pushId.left(6).toUpper());
@@ -6587,16 +6588,17 @@ void MainWindow::refreshStreamDeckLabels()
         }
 
         QColor bg;
-        if (active)                                  bg = QColor(10, 80, 10);
+        if (active)                                    bg = QColor(10, 80, 10);
         else if (pushId == QLatin1String("StepCycle")) bg = QColor(20, 30, 55);
         else if (pushId == QLatin1String("None"))      bg = QColor(15, 15, 15);
         else                                           bg = QColor(55, 20, 20);
 
-        QByteArray pushImg = renderKeyImageJpeg(pushLbl, stateTxt, bg, Qt::white);
-        QMetaObject::invokeMethod(m_hidEncoder, [enc=m_hidEncoder, k=4+i, d=pushImg](){
-            enc->setKeyImage(k, d);
-        }, Qt::QueuedConnection);
+        images[4 + i] = renderKeyImageJpeg(pushLbl, stateTxt, bg, Qt::white);
     }
+
+    QMetaObject::invokeMethod(m_hidEncoder, [enc=m_hidEncoder, imgs=images](){
+        enc->setKeyImages(imgs);
+    }, Qt::QueuedConnection);
 }
 #endif
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3930,24 +3930,40 @@ MainWindow::MainWindow(QWidget* parent)
 
     connect(m_hidEncoder, &HidEncoderManager::buttonPressed,
             this, [this](int button, int action) {
-        // Encoder press buttons 9-12 map to encoder indices 0-3; others keep button
-        // number as-is. Only fire on press (action==0); release is ignored here.
+        // Only fire on press; release is suppressed.
         if (action != 0) return;
-        const int encoderIndex = (button >= 9 && button <= 12) ? button - 9 : -1;
-        const QString key = (encoderIndex >= 0)
-            ? QString("HidEncoderPushAction%1").arg(encoderIndex)
-            : QString("HidEncoderBtn%1Action").arg(button);
-        const QString dflt = (encoderIndex >= 0)
-            ? MainWindow::hidEncoderDefaultPushAction(encoderIndex)
-            : QStringLiteral("None");
-        const QString actionName = AppSettings::instance().value(key, dflt).toString();
 
-        if (actionName == "StepCycle") {
+        QString actionName;
+        if (button >= 1 && button <= 8) {
+            // LCD keys — settings key HidKeyAction{0-7}
+            actionName = AppSettings::instance()
+                .value(QString("HidKeyAction%1").arg(button - 1), QStringLiteral("None"))
+                .toString();
+        } else if (button >= 9 && button <= 12) {
+            // Encoder press buttons — settings key HidEncoderPushAction{0-3}
+            const int enc = button - 9;
+            actionName = AppSettings::instance()
+                .value(QString("HidEncoderPushAction%1").arg(enc),
+                       MainWindow::hidEncoderDefaultPushAction(enc))
+                .toString();
+        } else {
+            return;
+        }
+
+        if (actionName == "None" || actionName.isEmpty()) return;
+
+        if (actionName == "StepCycle" || actionName == "StepUp") {
             if (auto* rx = m_appletPanel->rxApplet()) rx->cycleStepUp();
+        } else if (actionName == "StepDown") {
+            if (auto* rx = m_appletPanel->rxApplet()) rx->cycleStepDown();
         } else if (actionName == "ToggleRit") {
             if (auto* s = activeSlice()) s->setRit(!s->ritOn(), s->ritFreq());
         } else if (actionName == "ToggleXit") {
             if (auto* s = activeSlice()) s->setXit(!s->xitOn(), s->xitFreq());
+        } else if (actionName == "ClearRit") {
+            if (auto* s = activeSlice()) s->setRit(s->ritOn(), 0);
+        } else if (actionName == "ClearXit") {
+            if (auto* s = activeSlice()) s->setXit(s->xitOn(), 0);
         } else if (actionName == "ToggleMox") {
             m_radioModel.setTransmit(!m_radioModel.transmitModel().isTransmitting());
         } else if (actionName == "ToggleTune") {
@@ -3959,6 +3975,81 @@ MainWindow::MainWindow(QWidget* parent)
             m_audio->setMuted(!m_audio->isMuted());
         } else if (actionName == "ToggleLock") {
             if (auto* s = activeSlice()) s->setLocked(!s->isLocked());
+        } else if (actionName == "ToggleApf") {
+            if (auto* s = activeSlice()) s->setApf(!s->apfOn());
+        } else if (actionName == "ToggleAgc") {
+            if (auto* s = activeSlice()) {
+                static const char* modes[] = {"off","slow","med","fast"};
+                const QString cur = s->agcMode().toLower();
+                int idx = 0;
+                for (int i = 0; i < 4; ++i) if (cur == modes[i]) { idx = i; break; }
+                s->setAgcMode(modes[(idx + 1) % 4]);
+            }
+        } else if (actionName == "BandZoom") {
+            auto* s = activeSlice();
+            if (s) {
+                const QString panId = !s->panId().isEmpty() ? s->panId()
+                    : (m_panStack ? m_panStack->activePanId() : m_radioModel.panId());
+                if (!panId.isEmpty()) {
+                    m_flexVirtualBandZoomOn = !m_flexVirtualBandZoomOn;
+                    m_radioModel.sendCommand(QString("display pan set %1 band_zoom=%2")
+                        .arg(panId).arg(m_flexVirtualBandZoomOn ? 1 : 0));
+                }
+            }
+        } else if (actionName == "SegmentZoom") {
+            auto* s = activeSlice();
+            if (s) {
+                const QString panId = !s->panId().isEmpty() ? s->panId()
+                    : (m_panStack ? m_panStack->activePanId() : m_radioModel.panId());
+                if (!panId.isEmpty()) {
+                    m_flexVirtualSegmentZoomOn = !m_flexVirtualSegmentZoomOn;
+                    m_radioModel.sendCommand(QString("display pan set %1 segment_zoom=%2")
+                        .arg(panId).arg(m_flexVirtualSegmentZoomOn ? 1 : 0));
+                }
+            }
+        } else if (actionName == "NextSlice") {
+            const auto& slices = m_radioModel.slices();
+            if (slices.size() > 1) {
+                int idx = 0;
+                for (int i = 0; i < slices.size(); ++i)
+                    if (slices[i]->sliceId() == m_activeSliceId) { idx = i; break; }
+                setActiveSlice(slices[(idx + 1) % slices.size()]->sliceId());
+            }
+        } else if (actionName == "PrevSlice") {
+            const auto& slices = m_radioModel.slices();
+            if (slices.size() > 1) {
+                int idx = 0;
+                for (int i = 0; i < slices.size(); ++i)
+                    if (slices[i]->sliceId() == m_activeSliceId) { idx = i; break; }
+                setActiveSlice(slices[(idx - 1 + slices.size()) % slices.size()]->sliceId());
+            }
+        } else if (actionName == "VolumeUp") {
+            const int next = std::clamp(
+                AppSettings::instance().value("MasterVolume","100").toInt() + 5, 0, 100);
+            if (m_titleBar) m_titleBar->setMasterVolume(next);
+            applyMasterVolume(next);
+        } else if (actionName == "VolumeDown") {
+            const int next = std::clamp(
+                AppSettings::instance().value("MasterVolume","100").toInt() - 5, 0, 100);
+            if (m_titleBar) m_titleBar->setMasterVolume(next);
+            applyMasterVolume(next);
+        } else if (actionName == "SplitActiveSlice") {
+            if (!m_splitActive) {
+                auto* s = activeSlice();
+                if (s && m_radioModel.slices().size() < m_radioModel.maxSlices()) {
+                    QString panId = s->panId().isEmpty()
+                        ? (m_panStack ? m_panStack->activePanId() : m_radioModel.panId())
+                        : s->panId();
+                    const bool isCw = s->mode() == "CW" || s->mode() == "CWL";
+                    m_splitActive   = true;
+                    m_splitRxSliceId = s->sliceId();
+                    m_radioModel.sendCommand(
+                        QString("slice create pan=%1 freq=%2")
+                        .arg(panId).arg(s->frequency() + (isCw ? 0.001 : 0.005), 0, 'f', 6));
+                }
+            } else {
+                disableSplit();
+            }
         }
     });
 
@@ -6552,6 +6643,30 @@ static QByteArray renderTouchscreenJpeg(
     return bytes;
 }
 
+// Render a 120x120 JPEG label for a single StreamDeck+ LCD key.
+static QByteArray renderKeyImageJpeg(const QString& label, const QColor& bg)
+{
+    QImage img(120, 120, QImage::Format_RGB32);
+    img.fill(bg);
+
+    if (!label.isEmpty()) {
+        QPainter p(&img);
+        p.setRenderHint(QPainter::TextAntialiasing);
+        QFont f;
+        f.setPixelSize(label.length() > 6 ? 22 : 28);
+        f.setBold(true);
+        p.setFont(f);
+        p.setPen(Qt::white);
+        p.drawText(QRect(4, 4, 112, 112), Qt::AlignCenter | Qt::TextWordWrap, label);
+    }
+
+    QByteArray bytes;
+    QBuffer buf(&bytes);
+    buf.open(QIODevice::WriteOnly);
+    img.save(&buf, "JPEG", 90);
+    return bytes;
+}
+
 void MainWindow::refreshStreamDeckLabels()
 {
     if (!m_hidEncoder || !m_hidEncoder->isOpen() || !m_hidEncoder->isStreamDeckPlus())
@@ -6608,15 +6723,53 @@ void MainWindow::refreshStreamDeckLabels()
 
     QByteArray tsImg = renderTouchscreenJpeg(turnLabels, pushLabels, stateTexts, activeFlags);
 
-    // Blank the 8 LCD keys — one black 120x120 JPEG reused for all
-    QImage blank(120, 120, QImage::Format_RGB32);
-    blank.fill(Qt::black);
-    QByteArray blankJpeg;
-    { QBuffer b(&blankJpeg); b.open(QIODevice::WriteOnly); blank.save(&b, "JPEG", 80); }
-    QVector<QByteArray> blankKeys(8, blankJpeg);
+    // Build labeled 120x120 images for the 8 LCD keys
+    static const QHash<QString, QColor> kKeyBgColors{
+        {QStringLiteral("ToggleMox"),        QColor(70, 20, 20)},
+        {QStringLiteral("ToggleTune"),       QColor(70, 20, 20)},
+        {QStringLiteral("ToggleRit"),        QColor(20, 55, 20)},
+        {QStringLiteral("ToggleXit"),        QColor(20, 55, 20)},
+        {QStringLiteral("ClearRit"),         QColor(20, 40, 20)},
+        {QStringLiteral("ClearXit"),         QColor(20, 40, 20)},
+        {QStringLiteral("VolumeUp"),         QColor(40, 20, 60)},
+        {QStringLiteral("VolumeDown"),       QColor(40, 20, 60)},
+        {QStringLiteral("SplitActiveSlice"), QColor(60, 40, 10)},
+    };
+    static const QHash<QString, QString> kKeyShortLabels{
+        {QStringLiteral("None"),             {}},
+        {QStringLiteral("ToggleMox"),        QStringLiteral("MOX")},
+        {QStringLiteral("ToggleTune"),       QStringLiteral("TUNE")},
+        {QStringLiteral("ToggleRit"),        QStringLiteral("RIT")},
+        {QStringLiteral("ToggleXit"),        QStringLiteral("XIT")},
+        {QStringLiteral("ClearRit"),         QStringLiteral("CLR\nRIT")},
+        {QStringLiteral("ClearXit"),         QStringLiteral("CLR\nXIT")},
+        {QStringLiteral("StepUp"),           QStringLiteral("STEP\nUP")},
+        {QStringLiteral("StepDown"),         QStringLiteral("STEP\nDN")},
+        {QStringLiteral("ToggleMute"),       QStringLiteral("MUTE")},
+        {QStringLiteral("ToggleLock"),       QStringLiteral("LOCK")},
+        {QStringLiteral("ToggleApf"),        QStringLiteral("APF")},
+        {QStringLiteral("ToggleAgc"),        QStringLiteral("AGC")},
+        {QStringLiteral("BandZoom"),         QStringLiteral("BAND\nZOOM")},
+        {QStringLiteral("SegmentZoom"),      QStringLiteral("SEG\nZOOM")},
+        {QStringLiteral("NextSlice"),        QStringLiteral("NEXT\nSLICE")},
+        {QStringLiteral("PrevSlice"),        QStringLiteral("PREV\nSLICE")},
+        {QStringLiteral("VolumeUp"),         QStringLiteral("VOL +")},
+        {QStringLiteral("VolumeDown"),       QStringLiteral("VOL -")},
+        {QStringLiteral("SplitActiveSlice"), QStringLiteral("SPLIT")},
+    };
+    const QColor kDefaultKeyBg(20, 28, 45);
+
+    QVector<QByteArray> keyImages(8);
+    for (int i = 0; i < 8; ++i) {
+        const QString actionId = settings.value(QString("HidKeyAction%1").arg(i),
+                                                QStringLiteral("None")).toString();
+        const QString lbl = kKeyShortLabels.value(actionId, actionId.left(8).toUpper());
+        const QColor  bg  = kKeyBgColors.value(actionId, kDefaultKeyBg);
+        keyImages[i] = renderKeyImageJpeg(lbl, bg);
+    }
 
     QMetaObject::invokeMethod(m_hidEncoder,
-        [enc=m_hidEncoder, ts=tsImg, keys=blankKeys]() {
+        [enc=m_hidEncoder, ts=tsImg, keys=keyImages]() {
             enc->setTouchscreenImage(ts);
             enc->setKeyImages(keys);
         }, Qt::QueuedConnection);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6484,32 +6484,63 @@ QString MainWindow::hidEncoderDefaultPushAction(int encoderIndex)
 }
 
 #ifdef HAVE_HIDAPI
-// Render a 120x120 JPEG image with two centered text lines for a StreamDeck+ key.
-// bg/fg: background and foreground colors. Image is flipped 180° per StreamDeck+ spec.
-static QByteArray renderKeyImageJpeg(const QString& label, const QString& sub,
-                                      const QColor& bg, const QColor& fg)
+// Render the full 800x100 touchscreen strip for the StreamDeck+.
+// Four equal 200x100 sections, one per encoder. Each section shows the turn
+// action on the top half and the push action + state on the bottom half.
+static QByteArray renderTouchscreenJpeg(
+    const std::array<QString,4>& turnLabels,
+    const std::array<QString,4>& pushLabels,
+    const std::array<QString,4>& stateTexts,
+    const std::array<bool,4>&    active)
 {
-    QImage img(120, 120, QImage::Format_RGB32);
-    img.fill(bg);
+    constexpr int W = 800, H = 100, COLS = 4, COL_W = W / COLS;
+
+    QImage img(W, H, QImage::Format_RGB32);
+    img.fill(QColor(15, 15, 20));
 
     QPainter p(&img);
     p.setRenderHint(QPainter::TextAntialiasing);
 
-    if (!label.isEmpty()) {
-        QFont f;
-        f.setPixelSize(32);
-        f.setBold(true);
-        p.setFont(f);
-        p.setPen(fg);
-        p.drawText(QRect(4, 10, 112, 60), Qt::AlignCenter | Qt::AlignVCenter, label);
-    }
+    for (int i = 0; i < COLS; ++i) {
+        const int x = i * COL_W;
 
-    if (!sub.isEmpty()) {
-        QFont f;
-        f.setPixelSize(18);
-        p.setFont(f);
-        p.setPen(QColor(190, 190, 190));
-        p.drawText(QRect(4, 72, 112, 38), Qt::AlignCenter | Qt::AlignVCenter, sub);
+        // Top half: turn action — dark blue tint
+        p.fillRect(x, 0, COL_W - 1, 49, QColor(18, 28, 52));
+
+        // Bottom half: push action — color indicates state
+        QColor pushBg;
+        if (active[i])                                       pushBg = QColor(10, 70, 10);
+        else if (pushLabels[i].isEmpty())                    pushBg = QColor(12, 12, 16);
+        else                                                 pushBg = QColor(45, 18, 18);
+        p.fillRect(x, 51, COL_W - 1, H - 51, pushBg);
+
+        // Divider line (1px, slightly lighter)
+        p.fillRect(x + COL_W - 1, 0, 1, H, QColor(40, 40, 50));
+        // Horizontal divider between top/bottom halves
+        p.fillRect(x, 49, COL_W - 1, 2, QColor(35, 35, 45));
+
+        // Turn label
+        if (!turnLabels[i].isEmpty()) {
+            QFont f;
+            f.setPixelSize(20);
+            f.setBold(true);
+            p.setFont(f);
+            p.setPen(Qt::white);
+            p.drawText(QRect(x + 2, 0, COL_W - 4, 49), Qt::AlignCenter, turnLabels[i]);
+        }
+
+        // Push label + state
+        if (!pushLabels[i].isEmpty()) {
+            QFont f;
+            f.setPixelSize(16);
+            f.setBold(active[i]);
+            p.setFont(f);
+            const QString line = stateTexts[i].isEmpty()
+                ? pushLabels[i]
+                : pushLabels[i] + QLatin1String("  ") + stateTexts[i];
+            p.setPen(active[i] ? QColor(120, 255, 120) : QColor(200, 200, 200));
+            p.drawText(QRect(x + 2, 51, COL_W - 4, H - 51), Qt::AlignCenter, line);
+        }
     }
 
     p.end();
@@ -6517,7 +6548,7 @@ static QByteArray renderKeyImageJpeg(const QString& label, const QString& sub,
     QByteArray bytes;
     QBuffer buf(&bytes);
     buf.open(QIODevice::WriteOnly);
-    img.save(&buf, "JPEG", 90);
+    img.save(&buf, "JPEG", 92);
     return bytes;
 }
 
@@ -6553,49 +6584,42 @@ void MainWindow::refreshStreamDeckLabels()
     const bool ritOn = slice && slice->ritOn();
     const bool xitOn = slice && slice->xitOn();
 
-    // Build all 8 images on the main thread, then dispatch a single queued call
-    // to write them all on the ext-ctrl thread — avoids flooding the event queue.
-    QVector<QByteArray> images(8);
+    std::array<QString,4> turnLabels, pushLabels, stateTexts;
+    std::array<bool,4> activeFlags{};
 
     for (int i = 0; i < 4; ++i) {
-        // Turn label — key i (top row, 0-3)
-        const QString turnId  = settings.value(QString("HidEncoderAction%1").arg(i),
-                                               QString::fromLatin1(kTurnDflt[i])).toString();
-        const QString turnLbl = kShortLabels.value(turnId, turnId.left(6).toUpper());
-        images[i] = renderKeyImageJpeg(turnLbl, QString("ENC %1").arg(i + 1),
-                                       QColor(20, 30, 55), Qt::white);
+        const QString turnId = settings.value(QString("HidEncoderAction%1").arg(i),
+                                              QString::fromLatin1(kTurnDflt[i])).toString();
+        turnLabels[i] = kShortLabels.value(turnId, turnId.left(6).toUpper());
 
-        // Push label — key 4+i (bottom row, 4-7)
-        const QString pushId  = settings.value(QString("HidEncoderPushAction%1").arg(i),
-                                               QString::fromLatin1(kPushDflt[i])).toString();
-        const QString pushLbl = kShortLabels.value(pushId, pushId.left(6).toUpper());
+        const QString pushId = settings.value(QString("HidEncoderPushAction%1").arg(i),
+                                              QString::fromLatin1(kPushDflt[i])).toString();
+        pushLabels[i] = kShortLabels.value(pushId, pushId.left(6).toUpper());
 
-        bool active = false;
-        QString stateTxt;
         if (pushId == QLatin1String("ToggleRit")) {
-            active   = ritOn;
-            stateTxt = ritOn ? QStringLiteral("ON") : QStringLiteral("OFF");
+            activeFlags[i] = ritOn;
+            stateTexts[i]  = ritOn ? QStringLiteral("ON") : QStringLiteral("OFF");
         } else if (pushId == QLatin1String("ToggleXit")) {
-            active   = xitOn;
-            stateTxt = xitOn ? QStringLiteral("ON") : QStringLiteral("OFF");
-        } else if (pushId == QLatin1String("StepCycle")) {
-            stateTxt = QStringLiteral("PUSH");
-        } else if (!pushId.isEmpty() && pushId != QLatin1String("None")) {
-            stateTxt = QStringLiteral("PUSH");
+            activeFlags[i] = xitOn;
+            stateTexts[i]  = xitOn ? QStringLiteral("ON") : QStringLiteral("OFF");
         }
-
-        QColor bg;
-        if (active)                                    bg = QColor(10, 80, 10);
-        else if (pushId == QLatin1String("StepCycle")) bg = QColor(20, 30, 55);
-        else if (pushId == QLatin1String("None"))      bg = QColor(15, 15, 15);
-        else                                           bg = QColor(55, 20, 20);
-
-        images[4 + i] = renderKeyImageJpeg(pushLbl, stateTxt, bg, Qt::white);
+        // StepCycle and others: no state text, not "active"
     }
 
-    QMetaObject::invokeMethod(m_hidEncoder, [enc=m_hidEncoder, imgs=images](){
-        enc->setKeyImages(imgs);
-    }, Qt::QueuedConnection);
+    QByteArray tsImg = renderTouchscreenJpeg(turnLabels, pushLabels, stateTexts, activeFlags);
+
+    // Blank the 8 LCD keys — one black 120x120 JPEG reused for all
+    QImage blank(120, 120, QImage::Format_RGB32);
+    blank.fill(Qt::black);
+    QByteArray blankJpeg;
+    { QBuffer b(&blankJpeg); b.open(QIODevice::WriteOnly); blank.save(&b, "JPEG", 80); }
+    QVector<QByteArray> blankKeys(8, blankJpeg);
+
+    QMetaObject::invokeMethod(m_hidEncoder,
+        [enc=m_hidEncoder, ts=tsImg, keys=blankKeys]() {
+            enc->setTouchscreenImage(ts);
+            enc->setKeyImages(keys);
+        }, Qt::QueuedConnection);
 }
 #endif
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6514,9 +6514,6 @@ static QByteArray renderKeyImageJpeg(const QString& label, const QString& sub,
 
     p.end();
 
-    // StreamDeck+ expects images flipped both axes (KEY_FLIP = (True, True))
-    img = img.mirrored(true, true);
-
     QByteArray bytes;
     QBuffer buf(&bytes);
     buf.open(QIODevice::WriteOnly);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5578,6 +5578,9 @@ void MainWindow::wireRadioSetupDialogSignals(RadioSetupDialog* dlg, const QStrin
         if (m_flexControlDialog)
             m_flexControlDialog->refreshButtonActions();
         syncFlexControlIndicatorForSettings();
+#ifdef HAVE_HIDAPI
+        refreshStreamDeckLabels();
+#endif
     });
     dlg->setFlexControlConnectionStatus(
         m_flexControlConnected,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -139,6 +139,9 @@
 #include <QHelpEvent>
 #include <QWindow>
 #include <QPixmap>
+#include <QImage>
+#include <QBuffer>
+#include <QFont>
 #include <QWidgetAction>
 #include <QPainter>
 #include <QVBoxLayout>
@@ -3960,8 +3963,9 @@ MainWindow::MainWindow(QWidget* parent)
     });
 
     connect(m_hidEncoder, &HidEncoderManager::connectionChanged,
-            this, [](bool connected, const QString& name) {
+            this, [this](bool connected, const QString& name) {
         qDebug() << "HID encoder:" << (connected ? "connected" : "disconnected") << name;
+        if (connected) refreshStreamDeckLabels();
     });
 
     // StreamDeck native integration removed — use TCI StreamController plugin instead.
@@ -6478,6 +6482,123 @@ QString MainWindow::hidEncoderDefaultPushAction(int encoderIndex)
     default: return QStringLiteral("None");
     }
 }
+
+#ifdef HAVE_HIDAPI
+// Render a 120x120 JPEG image with two centered text lines for a StreamDeck+ key.
+// bg/fg: background and foreground colors. Image is flipped 180° per StreamDeck+ spec.
+static QByteArray renderKeyImageJpeg(const QString& label, const QString& sub,
+                                      const QColor& bg, const QColor& fg)
+{
+    QImage img(120, 120, QImage::Format_RGB32);
+    img.fill(bg);
+
+    QPainter p(&img);
+    p.setRenderHint(QPainter::TextAntialiasing);
+
+    if (!label.isEmpty()) {
+        QFont f;
+        f.setPixelSize(32);
+        f.setBold(true);
+        p.setFont(f);
+        p.setPen(fg);
+        p.drawText(QRect(4, 10, 112, 60), Qt::AlignCenter | Qt::AlignVCenter, label);
+    }
+
+    if (!sub.isEmpty()) {
+        QFont f;
+        f.setPixelSize(18);
+        p.setFont(f);
+        p.setPen(QColor(190, 190, 190));
+        p.drawText(QRect(4, 72, 112, 38), Qt::AlignCenter | Qt::AlignVCenter, sub);
+    }
+
+    p.end();
+
+    // StreamDeck+ expects images flipped both axes (KEY_FLIP = (True, True))
+    img = img.mirrored(true, true);
+
+    QByteArray bytes;
+    QBuffer buf(&bytes);
+    buf.open(QIODevice::WriteOnly);
+    img.save(&buf, "JPEG", 90);
+    return bytes;
+}
+
+void MainWindow::refreshStreamDeckLabels()
+{
+    if (!m_hidEncoder || !m_hidEncoder->isOpen() || !m_hidEncoder->isStreamDeckPlus())
+        return;
+
+    static const QHash<QString, QString> kShortLabels{
+        {QStringLiteral("WheelFrequency"),      QStringLiteral("TUNE")},
+        {QStringLiteral("WheelRit"),            QStringLiteral("RIT")},
+        {QStringLiteral("WheelXit"),            QStringLiteral("XIT")},
+        {QStringLiteral("WheelVolume"),         QStringLiteral("VOL")},
+        {QStringLiteral("WheelHeadphoneVolume"),QStringLiteral("H.VOL")},
+        {QStringLiteral("WheelAgcT"),           QStringLiteral("AGC-T")},
+        {QStringLiteral("WheelApf"),            QStringLiteral("APF")},
+        {QStringLiteral("WheelCwSpeed"),        QStringLiteral("CW SPD")},
+        {QStringLiteral("WheelPower"),          QStringLiteral("RF PWR")},
+        {QStringLiteral("StepCycle"),           QStringLiteral("STEP")},
+        {QStringLiteral("ToggleRit"),           QStringLiteral("RIT")},
+        {QStringLiteral("ToggleXit"),           QStringLiteral("XIT")},
+        {QStringLiteral("ToggleMox"),           QStringLiteral("MOX")},
+        {QStringLiteral("ToggleMute"),          QStringLiteral("MUTE")},
+        {QStringLiteral("ToggleLock"),          QStringLiteral("LOCK")},
+        {QStringLiteral("None"),                {}},
+    };
+
+    static const char* kTurnDflt[4] = {"WheelFrequency","WheelRit","WheelXit","WheelVolume"};
+    static const char* kPushDflt[4] = {"StepCycle","ToggleRit","ToggleXit","None"};
+
+    auto& settings = AppSettings::instance();
+    auto* slice    = activeSlice();
+    const bool ritOn = slice && slice->ritOn();
+    const bool xitOn = slice && slice->xitOn();
+
+    for (int i = 0; i < 4; ++i) {
+        // Turn label — keys 0-3 (top row)
+        const QString turnId  = settings.value(QString("HidEncoderAction%1").arg(i),
+                                               QString::fromLatin1(kTurnDflt[i])).toString();
+        const QString turnLbl = kShortLabels.value(turnId, turnId.left(6).toUpper());
+        QByteArray turnImg = renderKeyImageJpeg(turnLbl, QString("ENC %1").arg(i + 1),
+                                                QColor(20, 30, 55), Qt::white);
+        QMetaObject::invokeMethod(m_hidEncoder, [enc=m_hidEncoder, k=i, d=turnImg](){
+            enc->setKeyImage(k, d);
+        }, Qt::QueuedConnection);
+
+        // Push label — keys 4-7 (bottom row)
+        const QString pushId  = settings.value(QString("HidEncoderPushAction%1").arg(i),
+                                               QString::fromLatin1(kPushDflt[i])).toString();
+        const QString pushLbl = kShortLabels.value(pushId, pushId.left(6).toUpper());
+
+        bool active = false;
+        QString stateTxt;
+        if (pushId == QLatin1String("ToggleRit")) {
+            active   = ritOn;
+            stateTxt = ritOn ? QStringLiteral("ON") : QStringLiteral("OFF");
+        } else if (pushId == QLatin1String("ToggleXit")) {
+            active   = xitOn;
+            stateTxt = xitOn ? QStringLiteral("ON") : QStringLiteral("OFF");
+        } else if (pushId == QLatin1String("StepCycle")) {
+            stateTxt = QStringLiteral("PUSH");
+        } else if (!pushId.isEmpty() && pushId != QLatin1String("None")) {
+            stateTxt = QStringLiteral("PUSH");
+        }
+
+        QColor bg;
+        if (active)                                  bg = QColor(10, 80, 10);
+        else if (pushId == QLatin1String("StepCycle")) bg = QColor(20, 30, 55);
+        else if (pushId == QLatin1String("None"))      bg = QColor(15, 15, 15);
+        else                                           bg = QColor(55, 20, 20);
+
+        QByteArray pushImg = renderKeyImageJpeg(pushLbl, stateTxt, bg, Qt::white);
+        QMetaObject::invokeMethod(m_hidEncoder, [enc=m_hidEncoder, k=4+i, d=pushImg](){
+            enc->setKeyImage(k, d);
+        }, Qt::QueuedConnection);
+    }
+}
+#endif
 
 void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
 {
@@ -11262,6 +11383,15 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
 
     // Update MEM button target-slice badge on every overlay (#1781)
     refreshMemoryBrowsePanel();
+
+#ifdef HAVE_HIDAPI
+    // Rewire StreamDeck+ RIT/XIT state triggers when the active slice changes
+    disconnect(m_sdRitConn);
+    disconnect(m_sdXitConn);
+    m_sdRitConn = connect(s, &SliceModel::ritChanged, this, [this](bool, int){ refreshStreamDeckLabels(); });
+    m_sdXitConn = connect(s, &SliceModel::xitChanged, this, [this](bool, int){ refreshStreamDeckLabels(); });
+    if (sliceId != prevId) refreshStreamDeckLabels();
+#endif
 
     qDebug() << "MainWindow: active slice set to" << sliceId;
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3927,19 +3927,34 @@ MainWindow::MainWindow(QWidget* parent)
 
     connect(m_hidEncoder, &HidEncoderManager::buttonPressed,
             this, [this](int button, int action) {
-        // Reuse same action dispatch as FlexControl
-        QString key = QString("HidEncoderBtn%1Action%2").arg(button).arg(action);
-        QString actionName = AppSettings::instance().value(key, "None").toString();
-        if (actionName == "ToggleMox")
+        // Encoder press buttons 9-12 map to encoder indices 0-3; others keep button
+        // number as-is. Only fire on press (action==0); release is ignored here.
+        if (action != 0) return;
+        const int encoderIndex = (button >= 9 && button <= 12) ? button - 9 : -1;
+        const QString key = (encoderIndex >= 0)
+            ? QString("HidEncoderPushAction%1").arg(encoderIndex)
+            : QString("HidEncoderBtn%1Action").arg(button);
+        const QString dflt = (encoderIndex >= 0)
+            ? MainWindow::hidEncoderDefaultPushAction(encoderIndex)
+            : QStringLiteral("None");
+        const QString actionName = AppSettings::instance().value(key, dflt).toString();
+
+        if (actionName == "StepCycle") {
+            if (auto* rx = m_appletPanel->rxApplet()) rx->cycleStepUp();
+        } else if (actionName == "ToggleRit") {
+            if (auto* s = activeSlice()) s->setRit(!s->ritOn(), s->ritFreq());
+        } else if (actionName == "ToggleXit") {
+            if (auto* s = activeSlice()) s->setXit(!s->xitOn(), s->xitFreq());
+        } else if (actionName == "ToggleMox") {
             m_radioModel.setTransmit(!m_radioModel.transmitModel().isTransmitting());
-        else if (actionName == "ToggleTune") {
+        } else if (actionName == "ToggleTune") {
             if (m_radioModel.transmitModel().isTuning())
                 m_radioModel.transmitModel().stopTune();
             else
                 m_radioModel.transmitModel().startTune();
-        } else if (actionName == "ToggleMute")
+        } else if (actionName == "ToggleMute") {
             m_audio->setMuted(!m_audio->isMuted());
-        else if (actionName == "ToggleLock") {
+        } else if (actionName == "ToggleLock") {
             if (auto* s = activeSlice()) s->setLocked(!s->isLocked());
         }
     });
@@ -6449,6 +6464,18 @@ QString MainWindow::hidEncoderDefaultAction(int encoderIndex)
     case 2:  return QStringLiteral("WheelXit");
     case 3:  return QStringLiteral("WheelVolume");
     default: return QStringLiteral("WheelFrequency");
+    }
+}
+
+// static
+QString MainWindow::hidEncoderDefaultPushAction(int encoderIndex)
+{
+    switch (encoderIndex) {
+    case 0:  return QStringLiteral("StepCycle");  // tuning encoder push → cycle step size
+    case 1:  return QStringLiteral("ToggleRit");
+    case 2:  return QStringLiteral("ToggleXit");
+    case 3:  return QStringLiteral("None");
+    default: return QStringLiteral("None");
     }
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -543,6 +543,7 @@ private:
 #ifdef HAVE_HIDAPI
     HidEncoderManager*   m_hidEncoder{nullptr};
     static QString hidEncoderDefaultAction(int encoderIndex);
+    static QString hidEncoderDefaultPushAction(int encoderIndex);
 #endif
 #ifdef HAVE_MIDI
     MidiControlManager*  m_midiControl{nullptr};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -544,6 +544,9 @@ private:
     HidEncoderManager*   m_hidEncoder{nullptr};
     static QString hidEncoderDefaultAction(int encoderIndex);
     static QString hidEncoderDefaultPushAction(int encoderIndex);
+    void refreshStreamDeckLabels();
+    QMetaObject::Connection m_sdRitConn;
+    QMetaObject::Connection m_sdXitConn;
 #endif
 #ifdef HAVE_MIDI
     MidiControlManager*  m_midiControl{nullptr};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -542,8 +542,7 @@ private:
     bool                 m_flexVirtualSegmentZoomOn{false};
 #ifdef HAVE_HIDAPI
     HidEncoderManager*   m_hidEncoder{nullptr};
-    QTimer               m_hidCoalesceTimer;
-    int                  m_hidPendingSteps{0};
+    static QString hidEncoderDefaultAction(int encoderIndex);
 #endif
 #ifdef HAVE_MIDI
     MidiControlManager*  m_midiControl{nullptr};

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4124,8 +4124,78 @@ QWidget* RadioSetupDialog::buildSerialTab()
         vbox->addWidget(group);
     }
 
-    // ── HID Encoder — per-encoder action mapping (#1510) ──────────────────────
+    // ── HID / StreamDeck+ LCD button action mapping (#1510) ──────────────────
 #ifdef HAVE_HIDAPI
+    {
+        auto* group = new QGroupBox("StreamDeck+ LCD Button Actions");
+        group->setStyleSheet(kGroupStyle);
+        auto* grid = new QGridLayout(group);
+        grid->setSpacing(6);
+
+        auto* note = new QLabel(
+            "Assign an action to each of the 8 LCD buttons. "
+            "The button label updates on the device to match.");
+        note->setWordWrap(true);
+        note->setStyleSheet(kLabelStyle);
+        grid->addWidget(note, 0, 0, 1, 4);
+
+        static const struct { const char* id; const char* label; } kKeyActions[] = {
+            {"None",             "None"},
+            {"ToggleMox",        "Toggle TX (MOX)"},
+            {"ToggleTune",       "Toggle Tune"},
+            {"ToggleRit",        "Toggle RIT on/off"},
+            {"ToggleXit",        "Toggle XIT on/off"},
+            {"ClearRit",         "Clear RIT offset"},
+            {"ClearXit",         "Clear XIT offset"},
+            {"StepUp",           "Step Size Up"},
+            {"StepDown",         "Step Size Down"},
+            {"ToggleMute",       "Toggle Mute"},
+            {"ToggleLock",       "Toggle Slice Lock"},
+            {"ToggleApf",        "Toggle APF"},
+            {"ToggleAgc",        "Cycle AGC Mode"},
+            {"BandZoom",         "Toggle Band Zoom"},
+            {"SegmentZoom",      "Toggle Segment Zoom"},
+            {"NextSlice",        "Next Slice"},
+            {"PrevSlice",        "Previous Slice"},
+            {"VolumeUp",         "Volume Up (+5)"},
+            {"VolumeDown",       "Volume Down (-5)"},
+            {"SplitActiveSlice", "Toggle Split"},
+        };
+
+        // 8 keys laid out as 2 columns of 4
+        for (int i = 0; i < 8; ++i) {
+            const int row = (i % 4) + 1;
+            const int col = (i / 4) * 2;
+
+            grid->addWidget(new QLabel(QString("Key %1:").arg(i + 1)), row, col);
+
+            auto* combo = new QComboBox;
+            combo->setStyleSheet(QString(kEditStyle).replace("QLineEdit", "QComboBox"));
+            for (const auto& act : kKeyActions)
+                combo->addItem(QString::fromLatin1(act.label), QString::fromLatin1(act.id));
+
+            const QString key    = QString("HidKeyAction%1").arg(i);
+            const QString saved  = settings.value(key, QStringLiteral("None")).toString();
+            const int     selIdx = combo->findData(saved);
+            combo->setCurrentIndex(selIdx >= 0 ? selIdx : 0);
+
+            connect(combo, &QComboBox::currentIndexChanged, this, [combo, key, this](int) {
+                auto& s = AppSettings::instance();
+                s.setValue(key, combo->currentData().toString());
+                s.save();
+                emit serialSettingsChanged();
+            });
+
+            m_hidKeyActionCombos[i] = combo;
+            grid->addWidget(combo, row, col + 1);
+        }
+        grid->setColumnStretch(1, 1);
+        grid->setColumnStretch(3, 1);
+
+        vbox->addWidget(group);
+    }
+
+    // ── HID Encoder — per-encoder action mapping (#1510) ─────────────────────
     {
         auto* group = new QGroupBox("HID Encoder / StreamDeck+ Encoders");
         group->setStyleSheet(kGroupStyle);
@@ -4236,76 +4306,6 @@ QWidget* RadioSetupDialog::buildSerialTab()
             grid->addWidget(combo, i + 1, 1, 1, 2);
             grid->setColumnStretch(1, 1);
         }
-
-        vbox->addWidget(group);
-    }
-
-    // ── HID / StreamDeck+ LCD button action mapping (#1510) ──────────────────
-    {
-        auto* group = new QGroupBox("StreamDeck+ LCD Button Actions");
-        group->setStyleSheet(kGroupStyle);
-        auto* grid = new QGridLayout(group);
-        grid->setSpacing(6);
-
-        auto* note = new QLabel(
-            "Assign an action to each of the 8 LCD buttons. "
-            "The button label updates on the device to match.");
-        note->setWordWrap(true);
-        note->setStyleSheet(kLabelStyle);
-        grid->addWidget(note, 0, 0, 1, 4);
-
-        static const struct { const char* id; const char* label; } kKeyActions[] = {
-            {"None",             "None"},
-            {"ToggleMox",        "Toggle TX (MOX)"},
-            {"ToggleTune",       "Toggle Tune"},
-            {"ToggleRit",        "Toggle RIT on/off"},
-            {"ToggleXit",        "Toggle XIT on/off"},
-            {"ClearRit",         "Clear RIT offset"},
-            {"ClearXit",         "Clear XIT offset"},
-            {"StepUp",           "Step Size Up"},
-            {"StepDown",         "Step Size Down"},
-            {"ToggleMute",       "Toggle Mute"},
-            {"ToggleLock",       "Toggle Slice Lock"},
-            {"ToggleApf",        "Toggle APF"},
-            {"ToggleAgc",        "Cycle AGC Mode"},
-            {"BandZoom",         "Toggle Band Zoom"},
-            {"SegmentZoom",      "Toggle Segment Zoom"},
-            {"NextSlice",        "Next Slice"},
-            {"PrevSlice",        "Previous Slice"},
-            {"VolumeUp",         "Volume Up (+5)"},
-            {"VolumeDown",       "Volume Down (-5)"},
-            {"SplitActiveSlice", "Toggle Split"},
-        };
-
-        // 8 keys laid out as 2 columns of 4
-        for (int i = 0; i < 8; ++i) {
-            const int row = (i % 4) + 1;
-            const int col = (i / 4) * 2;
-
-            grid->addWidget(new QLabel(QString("Key %1:").arg(i + 1)), row, col);
-
-            auto* combo = new QComboBox;
-            combo->setStyleSheet(QString(kEditStyle).replace("QLineEdit", "QComboBox"));
-            for (const auto& act : kKeyActions)
-                combo->addItem(QString::fromLatin1(act.label), QString::fromLatin1(act.id));
-
-            const QString key    = QString("HidKeyAction%1").arg(i);
-            const QString saved  = settings.value(key, QStringLiteral("None")).toString();
-            const int     selIdx = combo->findData(saved);
-            combo->setCurrentIndex(selIdx >= 0 ? selIdx : 0);
-
-            connect(combo, &QComboBox::currentIndexChanged, this, [combo, key, this](int) {
-                auto& s = AppSettings::instance();
-                s.setValue(key, combo->currentData().toString());
-                s.save();
-                emit serialSettingsChanged();
-            });
-
-            m_hidKeyActionCombos[i] = combo;
-            grid->addWidget(combo, row, col + 1);
-        }
-        grid->setColumnStretch(1, 1);
-        grid->setColumnStretch(3, 1);
 
         vbox->addWidget(group);
     }

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4124,6 +4124,67 @@ QWidget* RadioSetupDialog::buildSerialTab()
         vbox->addWidget(group);
     }
 
+    // ── HID Encoder — per-encoder action mapping (#1510) ──────────────────────
+#ifdef HAVE_HIDAPI
+    {
+        auto* group = new QGroupBox("HID Encoder / StreamDeck+ Encoders");
+        group->setStyleSheet(kGroupStyle);
+        auto* grid = new QGridLayout(group);
+        grid->setSpacing(6);
+
+        auto* note = new QLabel(
+            "Assign an action to each encoder dial. "
+            "Single-encoder devices (RC-28, PowerMate, ShuttleXpress) use Encoder 1 only.");
+        note->setWordWrap(true);
+        note->setStyleSheet(kLabelStyle);
+        grid->addWidget(note, 0, 0, 1, 3);
+
+        static const struct { const char* id; const char* label; } kEncoderActions[] = {
+            {"WheelFrequency",      "Tune Slice"},
+            {"WheelRit",            "RIT (Receive Incremental Tuning)"},
+            {"WheelXit",            "XIT (Transmit Incremental Tuning)"},
+            {"WheelVolume",         "Master Volume"},
+            {"WheelHeadphoneVolume","Headphone Volume"},
+            {"WheelAgcT",           "AGC Threshold"},
+            {"WheelApf",            "APF Level"},
+            {"WheelCwSpeed",        "CW Speed"},
+            {"WheelPower",          "RF Power"},
+            {"None",                "None"},
+        };
+
+        static const char* kEncoderDefaults[4] = {
+            "WheelFrequency", "WheelRit", "WheelXit", "WheelVolume"
+        };
+
+        for (int i = 0; i < 4; ++i) {
+            grid->addWidget(new QLabel(QString("Encoder %1:").arg(i + 1)), i + 1, 0);
+
+            auto* combo = new QComboBox;
+            combo->setStyleSheet(QString(kEditStyle).replace("QLineEdit", "QComboBox"));
+            for (const auto& act : kEncoderActions)
+                combo->addItem(QString::fromLatin1(act.label), QString::fromLatin1(act.id));
+
+            const QString key = QString("HidEncoderAction%1").arg(i);
+            const QString saved = settings.value(key, QString::fromLatin1(kEncoderDefaults[i])).toString();
+            const int idx = combo->findData(saved);
+            combo->setCurrentIndex(idx >= 0 ? idx : 0);
+
+            connect(combo, &QComboBox::currentIndexChanged, this, [combo, key, this](int) {
+                auto& s = AppSettings::instance();
+                s.setValue(key, combo->currentData().toString());
+                s.save();
+                emit serialSettingsChanged();
+            });
+
+            m_hidEncoderActionCombos[i] = combo;
+            grid->addWidget(combo, i + 1, 1, 1, 2);
+            grid->setColumnStretch(1, 1);
+        }
+
+        vbox->addWidget(group);
+    }
+#endif
+
     vbox->addStretch();
     return page;
 }

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4239,6 +4239,76 @@ QWidget* RadioSetupDialog::buildSerialTab()
 
         vbox->addWidget(group);
     }
+
+    // ── HID / StreamDeck+ LCD button action mapping (#1510) ──────────────────
+    {
+        auto* group = new QGroupBox("StreamDeck+ LCD Button Actions");
+        group->setStyleSheet(kGroupStyle);
+        auto* grid = new QGridLayout(group);
+        grid->setSpacing(6);
+
+        auto* note = new QLabel(
+            "Assign an action to each of the 8 LCD buttons. "
+            "The button label updates on the device to match.");
+        note->setWordWrap(true);
+        note->setStyleSheet(kLabelStyle);
+        grid->addWidget(note, 0, 0, 1, 4);
+
+        static const struct { const char* id; const char* label; } kKeyActions[] = {
+            {"None",             "None"},
+            {"ToggleMox",        "Toggle TX (MOX)"},
+            {"ToggleTune",       "Toggle Tune"},
+            {"ToggleRit",        "Toggle RIT on/off"},
+            {"ToggleXit",        "Toggle XIT on/off"},
+            {"ClearRit",         "Clear RIT offset"},
+            {"ClearXit",         "Clear XIT offset"},
+            {"StepUp",           "Step Size Up"},
+            {"StepDown",         "Step Size Down"},
+            {"ToggleMute",       "Toggle Mute"},
+            {"ToggleLock",       "Toggle Slice Lock"},
+            {"ToggleApf",        "Toggle APF"},
+            {"ToggleAgc",        "Cycle AGC Mode"},
+            {"BandZoom",         "Toggle Band Zoom"},
+            {"SegmentZoom",      "Toggle Segment Zoom"},
+            {"NextSlice",        "Next Slice"},
+            {"PrevSlice",        "Previous Slice"},
+            {"VolumeUp",         "Volume Up (+5)"},
+            {"VolumeDown",       "Volume Down (-5)"},
+            {"SplitActiveSlice", "Toggle Split"},
+        };
+
+        // 8 keys laid out as 2 columns of 4
+        for (int i = 0; i < 8; ++i) {
+            const int row = (i % 4) + 1;
+            const int col = (i / 4) * 2;
+
+            grid->addWidget(new QLabel(QString("Key %1:").arg(i + 1)), row, col);
+
+            auto* combo = new QComboBox;
+            combo->setStyleSheet(QString(kEditStyle).replace("QLineEdit", "QComboBox"));
+            for (const auto& act : kKeyActions)
+                combo->addItem(QString::fromLatin1(act.label), QString::fromLatin1(act.id));
+
+            const QString key    = QString("HidKeyAction%1").arg(i);
+            const QString saved  = settings.value(key, QStringLiteral("None")).toString();
+            const int     selIdx = combo->findData(saved);
+            combo->setCurrentIndex(selIdx >= 0 ? selIdx : 0);
+
+            connect(combo, &QComboBox::currentIndexChanged, this, [combo, key, this](int) {
+                auto& s = AppSettings::instance();
+                s.setValue(key, combo->currentData().toString());
+                s.save();
+                emit serialSettingsChanged();
+            });
+
+            m_hidKeyActionCombos[i] = combo;
+            grid->addWidget(combo, row, col + 1);
+        }
+        grid->setColumnStretch(1, 1);
+        grid->setColumnStretch(3, 1);
+
+        vbox->addWidget(group);
+    }
 #endif
 
     vbox->addStretch();

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4183,6 +4183,62 @@ QWidget* RadioSetupDialog::buildSerialTab()
 
         vbox->addWidget(group);
     }
+
+    // ── HID Encoder — per-encoder push-button action mapping (#1510) ─────────
+    {
+        auto* group = new QGroupBox("StreamDeck+ Encoder Push Actions");
+        group->setStyleSheet(kGroupStyle);
+        auto* grid = new QGridLayout(group);
+        grid->setSpacing(6);
+
+        auto* note = new QLabel(
+            "Action when each encoder dial is pressed. "
+            "Defaults: Enc 1 = Cycle Tuning Step, Enc 2 = Toggle RIT, Enc 3 = Toggle XIT.");
+        note->setWordWrap(true);
+        note->setStyleSheet(kLabelStyle);
+        grid->addWidget(note, 0, 0, 1, 3);
+
+        static const struct { const char* id; const char* label; } kPushActions[] = {
+            {"StepCycle",  "Cycle Tuning Step"},
+            {"ToggleRit",  "Toggle RIT on/off"},
+            {"ToggleXit",  "Toggle XIT on/off"},
+            {"ToggleMox",  "Toggle TX (MOX)"},
+            {"ToggleMute", "Toggle Mute"},
+            {"ToggleLock", "Lock Slice"},
+            {"None",       "None"},
+        };
+
+        static const char* kPushDefaults[4] = {
+            "StepCycle", "ToggleRit", "ToggleXit", "None"
+        };
+
+        for (int i = 0; i < 4; ++i) {
+            grid->addWidget(new QLabel(QString("Encoder %1 push:").arg(i + 1)), i + 1, 0);
+
+            auto* combo = new QComboBox;
+            combo->setStyleSheet(QString(kEditStyle).replace("QLineEdit", "QComboBox"));
+            for (const auto& act : kPushActions)
+                combo->addItem(QString::fromLatin1(act.label), QString::fromLatin1(act.id));
+
+            const QString key = QString("HidEncoderPushAction%1").arg(i);
+            const QString saved = settings.value(key, QString::fromLatin1(kPushDefaults[i])).toString();
+            const int idx = combo->findData(saved);
+            combo->setCurrentIndex(idx >= 0 ? idx : 0);
+
+            connect(combo, &QComboBox::currentIndexChanged, this, [combo, key, this](int) {
+                auto& s = AppSettings::instance();
+                s.setValue(key, combo->currentData().toString());
+                s.save();
+                emit serialSettingsChanged();
+            });
+
+            m_hidEncoderPushActionCombos[i] = combo;
+            grid->addWidget(combo, i + 1, 1, 1, 2);
+            grid->setColumnStretch(1, 1);
+        }
+
+        vbox->addWidget(group);
+    }
 #endif
 
     vbox->addStretch();

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -108,6 +108,7 @@ private:
 #ifdef HAVE_HIDAPI
     std::array<QComboBox*, 4> m_hidEncoderActionCombos{};
     std::array<QComboBox*, 4> m_hidEncoderPushActionCombos{};
+    std::array<QComboBox*, 8> m_hidKeyActionCombos{};
 #endif
 
     // Radio tab fields

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -107,6 +107,7 @@ private:
     QCheckBox* m_flexControlInvertCheck{nullptr};
 #ifdef HAVE_HIDAPI
     std::array<QComboBox*, 4> m_hidEncoderActionCombos{};
+    std::array<QComboBox*, 4> m_hidEncoderPushActionCombos{};
 #endif
 
     // Radio tab fields

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -4,6 +4,7 @@
 
 #include <QHash>
 #include <QVector>
+#include <array>
 #include <functional>
 
 class QTabWidget;
@@ -104,6 +105,9 @@ private:
     QPushButton* m_flexControlDetectButton{nullptr};
     QPushButton* m_flexControlCloseButton{nullptr};
     QCheckBox* m_flexControlInvertCheck{nullptr};
+#ifdef HAVE_HIDAPI
+    std::array<QComboBox*, 4> m_hidEncoderActionCombos{};
+#endif
 
     // Radio tab fields
     QLabel* m_serialLabel{nullptr};


### PR DESCRIPTION
## Summary

Implements full Elgato StreamDeck+ (VID 0x0FD9, PID 0x0084) support, closing #1510.

- **4 encoder dials** — each independently configurable to any wheel action (Tune, RIT, XIT, Volume, AGC-T, APF, CW Speed, RF Power, Headphone Volume)
- **Encoder push buttons** — each independently configurable; defaults: Enc 1 = Cycle Tuning Step, Enc 2 = Toggle RIT, Enc 3 = Toggle XIT
- **8 LCD buttons** — each configurable to 19 actions (MOX, Tune, RIT/XIT toggle+clear, Step Up/Down, Mute, Lock, APF, AGC, Band/Segment Zoom, Next/Prev Slice, Volume ±5, Split); button images update in real-time to show the assigned label
- **Touchscreen strip** — 800×100 JPEG above the dials showing turn action (top) and push action + live ON/OFF state (bottom); RIT/XIT sections go green when active
- **Settings UI** — three group boxes in Settings → Radio → Serial tab ordered to match the physical device layout (LCD buttons → dial turn → dial push); all changes push to device immediately

### udev rule required for non-root access
```
SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0084", MODE="0666"
```

### Protocol notes
- Input: 14-byte reports, report ID `0x01` at `buf[0]`, event type at `buf[1]`; dial turns type `0x03`/sub `0x01`, pushes `0x03`/`0x00`, LCD keys `0x00`
- Key image output: 1024-byte `hid_write`, command `0x07`, 8-byte header, 120×120 JPEG
- Touchscreen output: 1024-byte `hid_write`, command `0x0c`, 16-byte header with x/y/w/h, 800×100 JPEG
- Protocol verified against python-elgato-streamdeck v0.9.8

### Compatibility
Existing single-encoder devices (Icom RC-28, AetherPad emulator, Griffin PowerMate, Contour ShuttleXpress/Pro v2) are unaffected — `encoderIndex` was added as the last field of `HidEvent` to preserve all existing 4-field aggregate initializers.

## Test plan
- [ ] StreamDeck+ dials tune frequency, RIT, XIT, volume by default
- [ ] Encoder 1 push cycles tuning step; Enc 2/3 push toggles RIT/XIT
- [ ] Touchscreen strip shows correct labels; RIT/XIT sections change color with state
- [ ] LCD buttons execute configured actions and display matching labels
- [ ] Settings combos in Serial tab update device labels immediately on change
- [ ] RC-28 / PowerMate / ShuttleXpress still work normally (no regression)
- [ ] Build succeeds with and without `HAVE_HIDAPI`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)