### PR TITLE
fix(cmake): pair /MANIFESTINPUT with required /MANIFEST:EMBED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1060,7 +1060,11 @@ elseif(WIN32)
         target_sources(AetherSDR PRIVATE "${WIN_RC}")
     endif()
     if(MSVC)
+        # /MANIFESTINPUT requires /MANIFEST:EMBED per MSVC docs.  Newer MSVC
+        # toolsets (VS 18.x / 14.50+) enforce this strictly with LNK1220;
+        # older ones were lenient.  Be explicit.
         target_link_options(AetherSDR PRIVATE
+            "/MANIFEST:EMBED"
             "/MANIFESTINPUT:${CMAKE_SOURCE_DIR}/packaging/windows/AetherSDR.exe.manifest")
     endif()
 endif()


### PR DESCRIPTION
## Summary

`CMakeLists.txt:1062` passes `/MANIFESTINPUT:<path>` to the MSVC linker but not the required `/MANIFEST:EMBED`. Per MSVC docs the former is only valid alongside the latter. Older toolsets accepted the lone flag with a warning; newer ones (VS 18.x / MSVC 14.50+) fail hard:

```
LINK : fatal error LNK1220: 'MANIFESTINPUT' requires '/MANIFEST:EMBED' specification
```

One-line fix (4 lines incl. comment): add `/MANIFEST:EMBED` to the `target_link_options` call so the manifest is embedded inline (the intended behaviour anyway).

## Why a separate PR

Split out of #3234 (the `mic_level` TCI handler) on reviewer request — this is an unrelated build-system change and deserves independent review against the Windows toolchain matrix.

## Context

- Hit on a fresh Windows build with **Visual Studio 18 Build Tools, toolset 14.50.35717**, Windows SDK 10.0.26100.0.
- This branch is cut from `44eaef7c` (the #3225 "Embed DFNR model and set Store identity" merge), so it sits on top of the latest Windows/manifest changes — no conflict with #3225's Store-identity handling (different part of the file).
- CI presumably uses an older MSVC, which is why this has been latent.

## Test plan

- [x] Windows local build (MSVC 14.50) links clean with the fix; fails with LNK1220 without it
- [x] No effect on Linux/macOS — the change is inside the existing `if(MSVC)` block
- [ ] CI Windows matrix (auto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)