### PR TITLE
feat(input): Windows + macOS Ulanzi Dial backends; cross-platform mapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,14 +117,6 @@ jobs:
         shell: pwsh
         run: .\scripts\setup\setup-deepfilter.ps1
 
-      - name: Setup hidapi (HID encoder support)
-        # Needed for the Ulanzi Dial Windows backend (#3239) and the
-        # existing USB HID encoders (#3171).  Without this, HAVE_HIDAPI
-        # is undefined and the dial code falls back to a stub — CI
-        # would miss real compile errors in that path.
-        shell: pwsh
-        run: .\scripts\setup\setup-hidapi.ps1
-
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
 
@@ -138,6 +130,15 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1
         with:
           arch: x64
+
+      - name: Setup hidapi (HID encoder support)
+        # Needed for the Ulanzi Dial Windows backend (#3239) and the
+        # existing USB HID encoders (#3171).  Without this, HAVE_HIDAPI
+        # is undefined and the dial code falls back to a stub — CI
+        # would miss real compile errors in that path.  Runs after
+        # msvc-dev-cmd so the script has cl.exe + link.exe on PATH.
+        shell: pwsh
+        run: .\scripts\setup\setup-hidapi.ps1
 
       # zlib is bundled under third_party/zlib (1.3.1) — no vcpkg install
       # needed; CMake builds zlibstatic from source.  (#2651)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,14 @@ jobs:
         shell: pwsh
         run: .\scripts\setup\setup-deepfilter.ps1
 
+      - name: Setup hidapi (HID encoder support)
+        # Needed for the Ulanzi Dial Windows backend (#3239) and the
+        # existing USB HID encoders (#3171).  Without this, HAVE_HIDAPI
+        # is undefined and the dial code falls back to a stub — CI
+        # would miss real compile errors in that path.
+        shell: pwsh
+        run: .\scripts\setup\setup-hidapi.ps1
+
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1209,16 +1209,31 @@ else()
         endif()
     endif()
 endif()
+# Ulanzi Dial backend — one per platform.  All three implementations
+# expose the same Qt signal contract (see UlanziDialBackend.h); the
+# mapper dialog and MainWindow dispatcher are unchanged across
+# platforms.  See #3232 for the design.
+target_sources(AetherSDR PRIVATE
+    src/core/UlanziDialBackend.h
+    src/gui/UlanziDialMapperDialog.cpp
+    src/gui/UlanziDialMapperDialog.h)
 if(UNIX AND NOT APPLE)
-    # Linux evdev encoder (BT-HID dials — Ulanzi Dial first; see #3232).
-    # No external dep; uses kernel headers + Qt only.  EVIOCGRAB claims
-    # the device exclusively so its keystrokes don't leak to the focused
-    # window.  Win/Mac use platform-native HID APIs in follow-up PRs.
     target_sources(AetherSDR PRIVATE
         src/core/EvdevEncoderManager.cpp
-        src/core/EvdevEncoderManager.h
-        src/gui/UlanziDialMapperDialog.cpp
-        src/gui/UlanziDialMapperDialog.h)
+        src/core/EvdevEncoderManager.h)
+endif()
+if(WIN32)
+    target_sources(AetherSDR PRIVATE
+        src/core/UlanziDialWindowsManager.cpp
+        src/core/UlanziDialWindowsManager.h)
+endif()
+if(APPLE)
+    target_sources(AetherSDR PRIVATE
+        src/core/UlanziDialMacOSManager.cpp
+        src/core/UlanziDialMacOSManager.h)
+    target_link_libraries(AetherSDR PRIVATE
+        "-framework IOKit"
+        "-framework CoreFoundation")
 endif()
 
 if(HIDAPI_FOUND)

--- a/src/core/UlanziDialBackend.h
+++ b/src/core/UlanziDialBackend.h
@@ -2,21 +2,41 @@
 // Per-platform alias for the Ulanzi Dial backend manager.  Each
 // concrete implementation exposes the same Qt signal contract
 // (tuneSteps / buttonEvent / connectionChanged) and the same
-// start/stop/isConnected/deviceName surface, so consumers (the
+// start / stop / isConnected / deviceName surface, so consumers (the
 // mapper dialog and MainWindow's dispatcher) only need this alias
 // and do not have to switch on platform themselves.
 
 #include <QtGlobal>
 
 #ifdef Q_OS_LINUX
-#include "core/EvdevEncoderManager.h"
-namespace AetherSDR { using UlanziDialBackend = EvdevEncoderManager; }
-#elif defined(Q_OS_WIN)
-#include "core/UlanziDialWindowsManager.h"
-namespace AetherSDR { using UlanziDialBackend = UlanziDialWindowsManager; }
+    #include "core/EvdevEncoderManager.h"
+    namespace AetherSDR { using UlanziDialBackend = EvdevEncoderManager; }
+#elif defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
+    #include "core/UlanziDialWindowsManager.h"
+    namespace AetherSDR { using UlanziDialBackend = UlanziDialWindowsManager; }
 #elif defined(Q_OS_MAC)
-#include "core/UlanziDialMacOSManager.h"
-namespace AetherSDR { using UlanziDialBackend = UlanziDialMacOSManager; }
+    #include "core/UlanziDialMacOSManager.h"
+    namespace AetherSDR { using UlanziDialBackend = UlanziDialMacOSManager; }
 #else
-namespace AetherSDR { class UlanziDialBackend; }  // unsupported platform: no backend
+    // Fallback (e.g. Windows builds without hidapi): a no-op backend
+    // that just sits there.  Keeps the mapper dialog and MainWindow
+    // dispatcher compilable without per-platform branches at the call
+    // site.  Live backend support requires a real implementation.
+    #include <QObject>
+    #include <QString>
+    namespace AetherSDR {
+    class UlanziDialBackend : public QObject {
+        Q_OBJECT
+    public:
+        explicit UlanziDialBackend(QObject* parent = nullptr) : QObject(parent) {}
+        void start() {}
+        void stop()  {}
+        bool isConnected() const { return false; }
+        QString deviceName() const { return {}; }
+    signals:
+        void tuneSteps(int steps);
+        void buttonEvent(const QString& signature, int action);
+        void connectionChanged(bool connected, const QString& name);
+    };
+    } // namespace AetherSDR
 #endif

--- a/src/core/UlanziDialBackend.h
+++ b/src/core/UlanziDialBackend.h
@@ -1,0 +1,22 @@
+#pragma once
+// Per-platform alias for the Ulanzi Dial backend manager.  Each
+// concrete implementation exposes the same Qt signal contract
+// (tuneSteps / buttonEvent / connectionChanged) and the same
+// start/stop/isConnected/deviceName surface, so consumers (the
+// mapper dialog and MainWindow's dispatcher) only need this alias
+// and do not have to switch on platform themselves.
+
+#include <QtGlobal>
+
+#ifdef Q_OS_LINUX
+#include "core/EvdevEncoderManager.h"
+namespace AetherSDR { using UlanziDialBackend = EvdevEncoderManager; }
+#elif defined(Q_OS_WIN)
+#include "core/UlanziDialWindowsManager.h"
+namespace AetherSDR { using UlanziDialBackend = UlanziDialWindowsManager; }
+#elif defined(Q_OS_MAC)
+#include "core/UlanziDialMacOSManager.h"
+namespace AetherSDR { using UlanziDialBackend = UlanziDialMacOSManager; }
+#else
+namespace AetherSDR { class UlanziDialBackend; }  // unsupported platform: no backend
+#endif

--- a/src/core/UlanziDialMacOSManager.cpp
+++ b/src/core/UlanziDialMacOSManager.cpp
@@ -1,0 +1,248 @@
+#include <QtGlobal>
+#ifdef Q_OS_MAC
+
+#include "UlanziDialMacOSManager.h"
+#include "core/LogManager.h"
+
+#include <QDebug>
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/hid/IOHIDManager.h>
+#include <IOKit/hid/IOHIDKeys.h>
+#include <IOKit/hid/IOHIDValue.h>
+#include <IOKit/hid/IOHIDElement.h>
+
+// Linux-style keycode numeric values, mirrored so signatures stay
+// consistent across all three platforms.
+#define KEY_PLAYPAUSE    164
+#define KEY_MUTE         113
+#define KEY_PREVIOUSSONG 165
+#define KEY_NEXTSONG     163
+#define KEY_VOLUMEUP     115
+#define KEY_VOLUMEDOWN   114
+#define KEY_LEFTCTRL     29
+#define KEY_RIGHTCTRL    97
+#define KEY_V            47
+#define KEY_C            46
+#define KEY_Y            21
+#define KEY_Z            44
+
+namespace AetherSDR {
+
+namespace {
+
+int hidConsumerToLinuxKey(int usage)
+{
+    switch (usage) {
+        case 0xCD: return KEY_PLAYPAUSE;
+        case 0xE2: return KEY_MUTE;
+        case 0xB5: return KEY_NEXTSONG;
+        case 0xB6: return KEY_PREVIOUSSONG;
+        case 0xE9: return KEY_VOLUMEUP;
+        case 0xEA: return KEY_VOLUMEDOWN;
+        default:   return -1;
+    }
+}
+
+int hidKbdToLinuxKey(int usage)
+{
+    switch (usage) {
+        case 0x06: return KEY_C;
+        case 0x19: return KEY_V;
+        case 0x1C: return KEY_Y;
+        case 0x1D: return KEY_Z;
+        case 0xE0: return KEY_LEFTCTRL;
+        case 0xE4: return KEY_RIGHTCTRL;
+        default:   return -1;
+    }
+}
+
+QString bareKeySignature(int keycode)
+{
+    switch (keycode) {
+        case KEY_PLAYPAUSE:    return QStringLiteral("KEY_PLAYPAUSE");
+        case KEY_MUTE:         return QStringLiteral("KEY_MUTE");
+        case KEY_PREVIOUSSONG: return QStringLiteral("KEY_PREVIOUSSONG");
+        case KEY_NEXTSONG:     return QStringLiteral("KEY_NEXTSONG");
+        default:               return QStringLiteral("KEY_%1").arg(keycode);
+    }
+}
+
+QString chordSignature(int keycode, bool withPreviousSong)
+{
+    QString letter;
+    switch (keycode) {
+        case KEY_V: letter = QStringLiteral("V"); break;
+        case KEY_C: letter = QStringLiteral("C"); break;
+        case KEY_Y: letter = QStringLiteral("Y"); break;
+        case KEY_Z: letter = QStringLiteral("Z"); break;
+        default:    letter = QStringLiteral("KEY_%1").arg(keycode); break;
+    }
+    if (withPreviousSong)
+        return QStringLiteral("Ctrl+%1+KEY_PREVIOUSSONG").arg(letter);
+    return QStringLiteral("Ctrl+%1").arg(letter);
+}
+
+// Build a matching dictionary so IOHIDManager only surfaces our dial,
+// not every keyboard on the machine.  Match by product-name substring
+// "Ulanzi Dial".
+CFMutableDictionaryRef makeMatchDict()
+{
+    CFMutableDictionaryRef d = CFDictionaryCreateMutable(
+        kCFAllocatorDefault, 0,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFStringRef product = CFSTR("Ulanzi Dial");
+    CFDictionarySetValue(d, CFSTR(kIOHIDProductKey), product);
+    return d;
+}
+
+} // namespace
+
+UlanziDialMacOSManager::UlanziDialMacOSManager(QObject* parent)
+    : QObject(parent) {}
+
+UlanziDialMacOSManager::~UlanziDialMacOSManager() { stop(); }
+
+void UlanziDialMacOSManager::start()
+{
+    if (m_manager) return;
+    IOHIDManagerRef mgr = IOHIDManagerCreate(kCFAllocatorDefault,
+                                             kIOHIDOptionsTypeNone);
+    m_manager = mgr;
+
+    CFMutableDictionaryRef match = makeMatchDict();
+    IOHIDManagerSetDeviceMatching(mgr, match);
+    CFRelease(match);
+
+    IOHIDManagerRegisterDeviceMatchingCallback(mgr,
+        reinterpret_cast<IOHIDDeviceCallback>(&UlanziDialMacOSManager::devMatchedCb), this);
+    IOHIDManagerRegisterDeviceRemovalCallback(mgr,
+        reinterpret_cast<IOHIDDeviceCallback>(&UlanziDialMacOSManager::devRemovedCb), this);
+    IOHIDManagerRegisterInputValueCallback(mgr,
+        reinterpret_cast<IOHIDValueCallback>(&UlanziDialMacOSManager::hidValueCb), this);
+
+    IOHIDManagerScheduleWithRunLoop(mgr, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+
+    // Open with seize-device so the dial's events stop reaching the
+    // OS keyboard stack — the macOS equivalent of Linux EVIOCGRAB.
+    IOHIDManagerOpen(mgr, kIOHIDOptionsTypeSeizeDevice);
+}
+
+void UlanziDialMacOSManager::stop()
+{
+    if (!m_manager) return;
+    IOHIDManagerRef mgr = static_cast<IOHIDManagerRef>(m_manager);
+    IOHIDManagerClose(mgr, kIOHIDOptionsTypeNone);
+    IOHIDManagerUnscheduleFromRunLoop(mgr, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+    CFRelease(mgr);
+    m_manager = nullptr;
+    if (m_anyOpen) {
+        const QString name = m_deviceName;
+        m_deviceName.clear();
+        m_anyOpen = false;
+        emit connectionChanged(false, name);
+    }
+}
+
+void UlanziDialMacOSManager::hidValueCb(void* ctx, int /*result*/, void* /*sender*/, void* valuePtr)
+{
+    auto* self = static_cast<UlanziDialMacOSManager*>(ctx);
+    auto* value = static_cast<IOHIDValueRef>(valuePtr);
+    IOHIDElementRef element = IOHIDValueGetElement(value);
+    const int usagePage = IOHIDElementGetUsagePage(element);
+    const int usage     = IOHIDElementGetUsage(element);
+    const int v         = static_cast<int>(IOHIDValueGetIntegerValue(value));
+    self->onHidValue(usagePage, usage, v);
+}
+
+void UlanziDialMacOSManager::devMatchedCb(void* ctx, int /*result*/, void* /*sender*/, void* devicePtr)
+{
+    auto* self = static_cast<UlanziDialMacOSManager*>(ctx);
+    auto* device = static_cast<IOHIDDeviceRef>(devicePtr);
+    CFStringRef nameRef = static_cast<CFStringRef>(
+        IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey)));
+    QString name;
+    if (nameRef) {
+        char buf[256] = {};
+        CFStringGetCString(nameRef, buf, sizeof(buf) - 1, kCFStringEncodingUTF8);
+        name = QString::fromUtf8(buf);
+    }
+    self->onDeviceMatching(name);
+}
+
+void UlanziDialMacOSManager::devRemovedCb(void* ctx, int /*result*/, void* /*sender*/, void* /*device*/)
+{
+    auto* self = static_cast<UlanziDialMacOSManager*>(ctx);
+    self->onDeviceRemoval();
+}
+
+void UlanziDialMacOSManager::onDeviceMatching(const QString& productName)
+{
+    m_anyOpen = true;
+    if (!productName.isEmpty()) m_deviceName = productName;
+    qCInfo(lcDevices) << "UlanziDialMacOSManager: attached" << m_deviceName;
+    emit connectionChanged(true, m_deviceName);
+}
+
+void UlanziDialMacOSManager::onDeviceRemoval()
+{
+    qCInfo(lcDevices) << "UlanziDialMacOSManager: detached";
+    const QString name = m_deviceName;
+    m_deviceName.clear();
+    m_anyOpen = false;
+    m_ctrlDown = false;
+    m_lastNonModKey = -1;
+    m_prevsongAlongsideCtrl = false;
+    emit connectionChanged(false, name);
+}
+
+void UlanziDialMacOSManager::onHidValue(int usagePage, int usage, int value)
+{
+    // Consumer page = 0x0C, Keyboard/Keypad page = 0x07.
+    int linuxKey = -1;
+    if (usagePage == 0x0C)      linuxKey = hidConsumerToLinuxKey(usage);
+    else if (usagePage == 0x07) linuxKey = hidKbdToLinuxKey(usage);
+    if (linuxKey < 0) return;
+    emitKeyTransition(linuxKey, value ? 1 : 0);
+}
+
+void UlanziDialMacOSManager::emitKeyTransition(int linuxKey, int value)
+{
+    if (linuxKey == KEY_VOLUMEUP) {
+        if (value == 1) emit tuneSteps(+1);
+        return;
+    }
+    if (linuxKey == KEY_VOLUMEDOWN) {
+        if (value == 1) emit tuneSteps(-1);
+        return;
+    }
+    if (linuxKey == KEY_LEFTCTRL || linuxKey == KEY_RIGHTCTRL) {
+        m_ctrlDown = (value != 0);
+        if (!m_ctrlDown) { m_lastNonModKey = -1; m_prevsongAlongsideCtrl = false; }
+        return;
+    }
+    if (linuxKey == KEY_PREVIOUSSONG && m_ctrlDown && value == 1) {
+        m_prevsongAlongsideCtrl = true;
+        return;
+    }
+    if (linuxKey == KEY_PREVIOUSSONG && m_ctrlDown && value == 0) {
+        return;
+    }
+    if (!m_ctrlDown) {
+        if (value == 1 || value == 0)
+            emit buttonEvent(bareKeySignature(linuxKey), value);
+        return;
+    }
+    if (value == 1) {
+        m_lastNonModKey = linuxKey;
+        emit buttonEvent(chordSignature(linuxKey, m_prevsongAlongsideCtrl), 1);
+    } else if (value == 0 && linuxKey == m_lastNonModKey) {
+        emit buttonEvent(chordSignature(linuxKey, m_prevsongAlongsideCtrl), 0);
+        m_lastNonModKey = -1;
+        m_prevsongAlongsideCtrl = false;
+    }
+}
+
+} // namespace AetherSDR
+
+#endif // Q_OS_MAC

--- a/src/core/UlanziDialMacOSManager.h
+++ b/src/core/UlanziDialMacOSManager.h
@@ -1,0 +1,61 @@
+#pragma once
+#include <QtGlobal>
+#ifdef Q_OS_MAC
+
+#include <QObject>
+#include <QString>
+
+namespace AetherSDR {
+
+// macOS backend for the Ulanzi Dial using IOKit HID Manager.  Mirrors
+// the Linux evdev / Windows hidapi backends' Qt signal contract.
+//
+// Key advantage over Windows: IOHIDDeviceOpen with kIOHIDOptionsTypeSeizeDevice
+// is the documented exclusive-claim mechanism on Darwin.  When seized,
+// the dial's input is delivered only to AetherSDR — the OS keyboard
+// stack stops receiving it — so the dial's media keys don't leak to the
+// focused window.
+class UlanziDialMacOSManager : public QObject {
+    Q_OBJECT
+public:
+    explicit UlanziDialMacOSManager(QObject* parent = nullptr);
+    ~UlanziDialMacOSManager() override;
+
+    void start();
+    void stop();
+
+    bool isConnected() const { return m_anyOpen; }
+    QString deviceName() const { return m_deviceName; }
+
+signals:
+    void tuneSteps(int steps);
+    void buttonEvent(const QString& signature, int action);
+    void connectionChanged(bool connected, const QString& name);
+
+private:
+    // Wired from the IOKit C callback shims.  Each call is one usage
+    // transition (page + usage + value).
+    void onHidValue(int usagePage, int usage, int value);
+    void onDeviceMatching(const QString& productName);
+    void onDeviceRemoval();
+
+    // Chord assembly state — same logic as the other two backends.
+    void emitKeyTransition(int linuxKey, int value);
+
+    void* m_manager{nullptr};   // IOHIDManagerRef
+    QString m_deviceName;
+    bool m_anyOpen{false};
+
+    bool m_ctrlDown{false};
+    int  m_lastNonModKey{-1};
+    bool m_prevsongAlongsideCtrl{false};
+
+    // Static C-API callback shims forward to the instance via context.
+    static void hidValueCb(void* ctx, int /*result*/, void* /*sender*/, void* value);
+    static void devMatchedCb(void* ctx, int /*result*/, void* /*sender*/, void* device);
+    static void devRemovedCb(void* ctx, int /*result*/, void* /*sender*/, void* device);
+};
+
+} // namespace AetherSDR
+
+#endif // Q_OS_MAC

--- a/src/core/UlanziDialWindowsManager.cpp
+++ b/src/core/UlanziDialWindowsManager.cpp
@@ -1,0 +1,302 @@
+#include <QtGlobal>
+#ifdef Q_OS_WIN
+
+#include "UlanziDialWindowsManager.h"
+#include "core/LogManager.h"
+
+#include <QDebug>
+#include <QTimer>
+
+#include <hidapi/hidapi.h>
+
+// Linux keycode numeric values (mirrored here so we don't need Linux
+// headers).  The signature emitted is the canonical Linux-keycode-name
+// string, so the dispatcher in MainWindow and the kPillSpecs table see
+// the same strings regardless of host platform.
+#define KEY_PLAYPAUSE    164
+#define KEY_MUTE         113
+#define KEY_PREVIOUSSONG 165
+#define KEY_NEXTSONG     163
+#define KEY_VOLUMEUP     115
+#define KEY_VOLUMEDOWN   114
+#define KEY_LEFTCTRL     29
+#define KEY_RIGHTCTRL    97
+#define KEY_V            47
+#define KEY_C            46
+#define KEY_Y            21
+#define KEY_Z            44
+
+namespace AetherSDR {
+
+namespace {
+
+// Map HID usage codes (consumer page 0x0C, keyboard page 0x07) into the
+// Linux keycode integer space so we share the same signature output
+// format with the Linux backend.
+int hidConsumerToLinuxKey(unsigned short consumerUsage)
+{
+    switch (consumerUsage) {
+        case 0xCD: return KEY_PLAYPAUSE;
+        case 0xE2: return KEY_MUTE;
+        case 0xB5: return KEY_NEXTSONG;
+        case 0xB6: return KEY_PREVIOUSSONG;
+        case 0xE9: return KEY_VOLUMEUP;
+        case 0xEA: return KEY_VOLUMEDOWN;
+        default:   return -1;
+    }
+}
+
+int hidKbdToLinuxKey(unsigned char keycode)
+{
+    switch (keycode) {
+        case 0x06: return KEY_C;   // HID Keyboard page 0x06 = C
+        case 0x19: return KEY_V;   // 0x19 = V
+        case 0x1C: return KEY_Y;   // 0x1C = Y
+        case 0x1D: return KEY_Z;   // 0x1D = Z
+        case 0xE0: return KEY_LEFTCTRL;
+        case 0xE4: return KEY_RIGHTCTRL;
+        default:   return -1;
+    }
+}
+
+QString bareKeySignature(int keycode)
+{
+    switch (keycode) {
+        case KEY_PLAYPAUSE:    return QStringLiteral("KEY_PLAYPAUSE");
+        case KEY_MUTE:         return QStringLiteral("KEY_MUTE");
+        case KEY_PREVIOUSSONG: return QStringLiteral("KEY_PREVIOUSSONG");
+        case KEY_NEXTSONG:     return QStringLiteral("KEY_NEXTSONG");
+        default:               return QStringLiteral("KEY_%1").arg(keycode);
+    }
+}
+
+QString chordSignature(int keycode, bool withPreviousSong)
+{
+    QString letter;
+    switch (keycode) {
+        case KEY_V: letter = QStringLiteral("V"); break;
+        case KEY_C: letter = QStringLiteral("C"); break;
+        case KEY_Y: letter = QStringLiteral("Y"); break;
+        case KEY_Z: letter = QStringLiteral("Z"); break;
+        default:    letter = QStringLiteral("KEY_%1").arg(keycode); break;
+    }
+    if (withPreviousSong)
+        return QStringLiteral("Ctrl+%1+KEY_PREVIOUSSONG").arg(letter);
+    return QStringLiteral("Ctrl+%1").arg(letter);
+}
+
+constexpr const wchar_t* kProductMatch = L"Ulanzi Dial";
+
+} // namespace
+
+UlanziDialWindowsManager::UlanziDialWindowsManager(QObject* parent)
+    : QObject(parent)
+{
+    hid_init();
+    m_pollTimer = new QTimer(this);
+    m_pollTimer->setInterval(POLL_INTERVAL_MS);
+    connect(m_pollTimer, &QTimer::timeout, this, &UlanziDialWindowsManager::poll);
+
+    m_hotplugTimer = new QTimer(this);
+    m_hotplugTimer->setInterval(HOTPLUG_INTERVAL_MS);
+    connect(m_hotplugTimer, &QTimer::timeout,
+            this, &UlanziDialWindowsManager::hotplugCheck);
+}
+
+UlanziDialWindowsManager::~UlanziDialWindowsManager()
+{
+    stop();
+    hid_exit();
+}
+
+void UlanziDialWindowsManager::start()
+{
+    if (rescan()) {
+        m_pollTimer->start();
+        emit connectionChanged(true, m_deviceName);
+    }
+    m_hotplugTimer->start();
+}
+
+void UlanziDialWindowsManager::stop()
+{
+    m_pollTimer->stop();
+    m_hotplugTimer->stop();
+    closeAll();
+}
+
+bool UlanziDialWindowsManager::rescan()
+{
+    closeAll();
+    struct hid_device_info* infos = hid_enumerate(0, 0);
+    for (auto* info = infos; info; info = info->next) {
+        if (!info->product_string) continue;
+        if (wcsstr(info->product_string, kProductMatch) == nullptr) continue;
+        hid_device* h = hid_open_path(info->path);
+        if (!h) continue;
+        hid_set_nonblocking(h, 1);
+        OpenDevice dev;
+        dev.handle = h;
+        dev.path = QString::fromUtf8(info->path);
+        dev.productString = QString::fromWCharArray(info->product_string);
+        dev.lastReport.resize(0);
+        m_devices.append(dev);
+    }
+    hid_free_enumeration(infos);
+    if (m_devices.isEmpty()) { m_deviceName.clear(); return false; }
+    m_deviceName = m_devices.first().productString;
+    return true;
+}
+
+void UlanziDialWindowsManager::closeAll()
+{
+    for (auto& d : m_devices) {
+        if (d.handle) {
+            hid_close(static_cast<hid_device*>(d.handle));
+            d.handle = nullptr;
+        }
+    }
+    m_devices.clear();
+    if (!m_deviceName.isEmpty()) {
+        const QString name = m_deviceName;
+        m_deviceName.clear();
+        emit connectionChanged(false, name);
+    }
+    m_ctrlDown = false;
+    m_lastNonModKey = -1;
+    m_prevsongAlongsideCtrl = false;
+}
+
+void UlanziDialWindowsManager::hotplugCheck()
+{
+    if (!m_devices.isEmpty()) return;
+    if (rescan()) {
+        m_pollTimer->start();
+        emit connectionChanged(true, m_deviceName);
+    }
+}
+
+void UlanziDialWindowsManager::poll()
+{
+    unsigned char buf[64];
+    bool anyAlive = false;
+    for (auto it = m_devices.begin(); it != m_devices.end(); ) {
+        if (!it->handle) { it = m_devices.erase(it); continue; }
+        int n = hid_read(static_cast<hid_device*>(it->handle), buf, sizeof(buf));
+        if (n < 0) {
+            qCDebug(lcDevices) << "UlanziDialWindowsManager: read failed on" << it->path;
+            hid_close(static_cast<hid_device*>(it->handle));
+            it->handle = nullptr;
+            it = m_devices.erase(it);
+            continue;
+        }
+        if (n > 0) handleReport(*it, buf, n);
+        anyAlive = true;
+        ++it;
+    }
+    if (!anyAlive) {
+        const QString name = m_deviceName;
+        m_deviceName.clear();
+        m_pollTimer->stop();
+        emit connectionChanged(false, name);
+    }
+}
+
+void UlanziDialWindowsManager::handleReport(OpenDevice& dev,
+                                            const unsigned char* data, int len)
+{
+    // Heuristic: discriminate between Consumer (Page 0x0C) and Keyboard
+    // (Page 0x07) reports by length + content.  Real HID stacks tag with
+    // a report id in byte 0; without parsing the descriptor we use the
+    // typical shapes Ulanzi Dial firmware emits.
+    //
+    // Consumer page report — 2-byte usage code in little-endian:
+    //   [report_id?] [usage_lo] [usage_hi]   (3 bytes total typical)
+    // Keyboard report (8 bytes):
+    //   [modifier_mask] [reserved] [key1] [key2] ... [key6]
+    QVector<unsigned char> cur(data, data + len);
+    QVector<unsigned char> prev = dev.lastReport;
+    dev.lastReport = cur;
+
+    if (len == 8) {
+        // Standard keyboard report.
+        const unsigned char mod = data[0];
+        const unsigned char prevMod = prev.size() == 8 ? prev[0] : 0;
+        // Ctrl transitions.
+        const bool nowCtrl  = (mod      & 0x01) || (mod      & 0x10);
+        const bool prevCtrl = (prevMod & 0x01) || (prevMod & 0x10);
+        if (nowCtrl != prevCtrl)
+            emitKeyTransition(KEY_LEFTCTRL, nowCtrl ? 1 : 0);
+        // Pressed-keys diff: keys 2..7.
+        auto contains = [](const QVector<unsigned char>& r, unsigned char k) -> bool {
+            for (int i = 2; i < r.size() && i < 8; ++i)
+                if (r[i] == k && k != 0) return true;
+            return false;
+        };
+        for (int i = 2; i < len && i < 8; ++i) {
+            const unsigned char k = data[i];
+            if (k == 0 || contains(prev, k)) continue;
+            const int linuxKey = hidKbdToLinuxKey(k);
+            if (linuxKey >= 0) emitKeyTransition(linuxKey, 1);
+        }
+        for (int i = 2; i < prev.size() && i < 8; ++i) {
+            const unsigned char k = prev[i];
+            if (k == 0 || contains(cur, k)) continue;
+            const int linuxKey = hidKbdToLinuxKey(k);
+            if (linuxKey >= 0) emitKeyTransition(linuxKey, 0);
+        }
+    } else if (len >= 2) {
+        // Consumer-page-ish report; treat first usage as the active key.
+        const unsigned short usage =
+            static_cast<unsigned short>(data[0]) |
+            (static_cast<unsigned short>(data[1]) << 8);
+        const int linuxKey = hidConsumerToLinuxKey(usage);
+        if (linuxKey < 0) return;
+        // Synthesise press + release (consumer-control reports usually
+        // appear once per dial detent; nonzero means pressed).
+        emitKeyTransition(linuxKey, 1);
+        emitKeyTransition(linuxKey, 0);
+    }
+}
+
+void UlanziDialWindowsManager::emitKeyTransition(int linuxKey, int value)
+{
+    if (linuxKey == KEY_VOLUMEUP) {
+        if (value == 1) emit tuneSteps(+1);
+        return;
+    }
+    if (linuxKey == KEY_VOLUMEDOWN) {
+        if (value == 1) emit tuneSteps(-1);
+        return;
+    }
+    if (linuxKey == KEY_LEFTCTRL || linuxKey == KEY_RIGHTCTRL) {
+        m_ctrlDown = (value != 0);
+        if (!m_ctrlDown) { m_lastNonModKey = -1; m_prevsongAlongsideCtrl = false; }
+        return;
+    }
+    if (linuxKey == KEY_PREVIOUSSONG && m_ctrlDown && value == 1) {
+        m_prevsongAlongsideCtrl = true;
+        return;
+    }
+    if (linuxKey == KEY_PREVIOUSSONG && m_ctrlDown && value == 0) {
+        return; // chord-window release; handled when Ctrl + non-mod release
+    }
+    if (!m_ctrlDown) {
+        if (value == 1 || value == 0)
+            emit buttonEvent(bareKeySignature(linuxKey), value);
+        return;
+    }
+    // Chord window.
+    if (value == 1) {
+        m_lastNonModKey = linuxKey;
+        emit buttonEvent(chordSignature(linuxKey, m_prevsongAlongsideCtrl), 1);
+    } else if (value == 0 && linuxKey == m_lastNonModKey) {
+        emit buttonEvent(chordSignature(linuxKey, m_prevsongAlongsideCtrl), 0);
+        m_lastNonModKey = -1;
+        m_prevsongAlongsideCtrl = false;
+    }
+}
+
+} // namespace AetherSDR
+
+#endif // Q_OS_WIN

--- a/src/core/UlanziDialWindowsManager.cpp
+++ b/src/core/UlanziDialWindowsManager.cpp
@@ -1,5 +1,5 @@
 #include <QtGlobal>
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
 
 #include "UlanziDialWindowsManager.h"
 #include "core/LogManager.h"
@@ -299,4 +299,4 @@ void UlanziDialWindowsManager::emitKeyTransition(int linuxKey, int value)
 
 } // namespace AetherSDR
 
-#endif // Q_OS_WIN
+#endif // Q_OS_WIN && HAVE_HIDAPI

--- a/src/core/UlanziDialWindowsManager.h
+++ b/src/core/UlanziDialWindowsManager.h
@@ -1,0 +1,84 @@
+#pragma once
+#include <QtGlobal>
+#ifdef Q_OS_WIN
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+class QTimer;
+
+namespace AetherSDR {
+
+// Windows backend for the Ulanzi Dial using hidapi.  Mirrors the Linux
+// evdev backend's Qt signal contract:
+//   tuneSteps(int)               — rotary delta (+1 CW / -1 CCW)
+//   buttonEvent(sig, action)     — see EvdevEncoderManager for signature
+//   connectionChanged(bool, name)
+//
+// Implementation notes:
+// - The dial enumerates as multiple HID interfaces on Windows: a Keyboard
+//   page interface (Ctrl + chord keys), a Consumer Control page interface
+//   (PLAYPAUSE / MUTE / NEXTSONG / PREVIOUSSONG), and possibly Mouse.
+//   We open every matching device whose product_string contains
+//   "Ulanzi Dial" and read reports from each via a poll timer.
+// - Each report is diff-compared against the previous to detect press /
+//   release transitions, then fed into the same chord-assembly state
+//   machine the Linux backend uses.
+// - No EVIOCGRAB-equivalent: keystrokes still go to the focused window
+//   on Windows.  A follow-up could wire RawInput + RIDEV_NOLEGACY to
+//   intercept globally; see #3232 for the design notes.
+class UlanziDialWindowsManager : public QObject {
+    Q_OBJECT
+public:
+    explicit UlanziDialWindowsManager(QObject* parent = nullptr);
+    ~UlanziDialWindowsManager() override;
+
+    void start();
+    void stop();
+
+    bool isConnected() const { return !m_devices.isEmpty(); }
+    QString deviceName() const { return m_deviceName; }
+
+signals:
+    void tuneSteps(int steps);
+    void buttonEvent(const QString& signature, int action);
+    void connectionChanged(bool connected, const QString& name);
+
+private slots:
+    void poll();
+    void hotplugCheck();
+
+private:
+    struct OpenDevice {
+        void* handle{nullptr};        // hid_device*; void* to avoid leaking <hidapi.h> here
+        QString path;
+        QString productString;
+        QVector<unsigned char> lastReport;
+    };
+
+    bool rescan();                      // returns true if at least one device is open
+    void closeAll();
+    void handleReport(OpenDevice& dev, const unsigned char* data, int len);
+
+    // Chord assembly — mirrors EvdevEncoderManager's logic but operates
+    // on HID-usage-code-derived keycodes.
+    void emitKeyTransition(int linuxKeycode, int value);
+
+    QVector<OpenDevice> m_devices;
+    QString m_deviceName;
+    QTimer* m_pollTimer{nullptr};
+    QTimer* m_hotplugTimer{nullptr};
+
+    bool m_ctrlDown{false};
+    int  m_lastNonModKey{-1};
+    bool m_prevsongAlongsideCtrl{false};
+
+    static constexpr int POLL_INTERVAL_MS    = 5;
+    static constexpr int HOTPLUG_INTERVAL_MS = 3000;
+};
+
+} // namespace AetherSDR
+
+#endif // Q_OS_WIN

--- a/src/core/UlanziDialWindowsManager.h
+++ b/src/core/UlanziDialWindowsManager.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <QtGlobal>
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
 
 #include <QObject>
 #include <QString>
@@ -81,4 +81,4 @@ private:
 
 } // namespace AetherSDR
 
-#endif // Q_OS_WIN
+#endif // Q_OS_WIN && HAVE_HIDAPI

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -111,11 +111,9 @@
 #ifdef HAVE_MIDI
 #include "core/MidiSettings.h"
 #include "MidiMappingDialog.h"
-#ifdef Q_OS_LINUX
-#include "core/EvdevEncoderManager.h"
+#endif
+#include "core/UlanziDialBackend.h"
 #include "UlanziDialMapperDialog.h"
-#endif
-#endif
 #include "AetherDspDialog.h"
 #include "AetherDspWidget.h"
 #include "WaveformsDialog.h"
@@ -3970,38 +3968,46 @@ MainWindow::MainWindow(QWidget* parent)
     // StreamDeck native integration removed — use TCI StreamController plugin instead.
 #endif
 
-#ifdef Q_OS_LINUX
-    // Linux evdev encoder — currently recognizes the Ulanzi Dial.  Uses
-    // EVIOCGRAB so the dial's keystrokes don't leak to the focused window.
-    // Win/macOS parallel implementations land separately (#3232).
-    m_evdevEncoder = new EvdevEncoderManager;
-    m_evdevEncoder->moveToThread(m_extCtrlThread);
+    // Ulanzi Dial backend.  One concrete implementation per platform —
+    // EvdevEncoderManager on Linux (EVIOCGRAB-exclusive),
+    // UlanziDialWindowsManager on Windows (hidapi polling),
+    // UlanziDialMacOSManager on macOS (IOKit with seize-device).
+    // All three expose the same Qt signal contract via the
+    // UlanziDialBackend alias.  See #3232 for design notes.
+    m_dialBackend = new UlanziDialBackend;
+#ifndef Q_OS_MAC
+    // macOS keeps the backend on the main thread: IOHIDManager schedules
+    // its callbacks on a CFRunLoop, and only the main thread has one
+    // integrated with Qt's event loop on macOS.  Linux + Windows
+    // backends run cleanly on the dedicated ExtControllers thread.
+    m_dialBackend->moveToThread(m_extCtrlThread);
+#endif
 
-    m_evdevCoalesceTimer.setSingleShot(true);
-    m_evdevCoalesceTimer.setInterval(20);
-    connect(&m_evdevCoalesceTimer, &QTimer::timeout, this, [this]() {
-        if (m_evdevPendingSteps == 0) return;
+    m_dialCoalesceTimer.setSingleShot(true);
+    m_dialCoalesceTimer.setInterval(20);
+    connect(&m_dialCoalesceTimer, &QTimer::timeout, this, [this]() {
+        if (m_dialPendingSteps == 0) return;
         auto* s = activeSlice();
-        if (!s) { m_evdevPendingSteps = 0; return; }
+        if (!s) { m_dialPendingSteps = 0; return; }
         if (s->isLocked()) {
             s->notifyTuneBlockedByLock();
-            m_evdevPendingSteps = 0;
+            m_dialPendingSteps = 0;
             return;
         }
         int stepHz = spectrum() ? spectrum()->stepSize() : 100;
-        double newMhz = s->frequency() + m_evdevPendingSteps * stepHz / 1e6;
-        m_evdevPendingSteps = 0;
-        applyTuneRequest(s, newMhz, TuneIntent::IncrementalTune, "evdev-encoder");
+        double newMhz = s->frequency() + m_dialPendingSteps * stepHz / 1e6;
+        m_dialPendingSteps = 0;
+        applyTuneRequest(s, newMhz, TuneIntent::IncrementalTune, "ulanzi-dial");
     });
 
-    connect(m_evdevEncoder, &EvdevEncoderManager::tuneSteps,
+    connect(m_dialBackend, &UlanziDialBackend::tuneSteps,
             this, [this](int steps) {
-        m_evdevPendingSteps += steps;
-        if (!m_evdevCoalesceTimer.isActive())
-            m_evdevCoalesceTimer.start();
+        m_dialPendingSteps += steps;
+        if (!m_dialCoalesceTimer.isActive())
+            m_dialCoalesceTimer.start();
     });
 
-    connect(m_evdevEncoder, &EvdevEncoderManager::buttonEvent,
+    connect(m_dialBackend, &UlanziDialBackend::buttonEvent,
             this, [this](const QString& signature, int action) {
         if (action != 1) return;   // only fire on press, not release
         // Look up which pill this hardware signature is bound to (the
@@ -4050,15 +4056,14 @@ MainWindow::MainWindow(QWidget* parent)
         }
     });
 
-    connect(m_evdevEncoder, &EvdevEncoderManager::connectionChanged,
+    connect(m_dialBackend, &UlanziDialBackend::connectionChanged,
             this, [](bool connected, const QString& name) {
         qDebug() << "Ulanzi Dial:" << (connected ? "connected" : "disconnected") << name;
     });
 
     // Kick off scanning on the external-controller thread.
-    QMetaObject::invokeMethod(m_evdevEncoder, &EvdevEncoderManager::start,
+    QMetaObject::invokeMethod(m_dialBackend, &UlanziDialBackend::start,
                               Qt::QueuedConnection);
-#endif
 
     // Start the external controller thread — objects are already moved
     m_extCtrlThread->start();
@@ -5145,12 +5150,10 @@ MainWindow::~MainWindow()
                                       Qt::BlockingQueuedConnection);
         }
 #endif
-#ifdef Q_OS_LINUX
-        if (m_evdevEncoder) {
-            QMetaObject::invokeMethod(m_evdevEncoder, &EvdevEncoderManager::stop,
+        if (m_dialBackend) {
+            QMetaObject::invokeMethod(m_dialBackend, &UlanziDialBackend::stop,
                                       Qt::BlockingQueuedConnection);
         }
-#endif
 #ifdef HAVE_SERIALPORT
         if (m_serialPort) {
             m_serialPort->deleteLater();
@@ -7725,7 +7728,6 @@ void MainWindow::buildMenuBar()
 #endif
 #ifdef HAVE_HIDAPI
 #endif
-#ifdef Q_OS_LINUX
     auto* ulanziAction = settingsMenu->addAction("Ulanzi Dial Mapping...");
     connect(ulanziAction, &QAction::triggered, this, [this] {
 #ifdef HAVE_MIDI
@@ -7733,10 +7735,9 @@ void MainWindow::buildMenuBar()
 #else
         MidiControlManager* midi = nullptr;
 #endif
-        showOrRaisePersistent(m_ulanziMapperDialog, m_evdevEncoder,
+        showOrRaisePersistent(m_ulanziMapperDialog, m_dialBackend,
                               &m_shortcutManager, midi);
     });
-#endif
     auto* spotsAction = settingsMenu->addAction("SpotHub...");
     connect(spotsAction, &QAction::triggered, this, [this] {
         const bool wasFresh = !m_spotHubDialog;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -92,9 +92,13 @@ class DxClusterDialog;
 class Ax25HfPacketDecodeDialog;
 class FlexControlDialog;
 class MidiMappingDialog;
+class UlanziDialMapperDialog;
 #ifdef Q_OS_LINUX
 class EvdevEncoderManager;
-class UlanziDialMapperDialog;
+#elif defined(Q_OS_WIN)
+class UlanziDialWindowsManager;
+#elif defined(Q_OS_MAC)
+class UlanziDialMacOSManager;
 #endif
 class CwxPanel;
 class DvkPanel;
@@ -550,10 +554,14 @@ private:
     int                  m_hidPendingSteps{0};
 #endif
 #ifdef Q_OS_LINUX
-    EvdevEncoderManager* m_evdevEncoder{nullptr};
-    QTimer               m_evdevCoalesceTimer;
-    int                  m_evdevPendingSteps{0};
+    EvdevEncoderManager*       m_dialBackend{nullptr};
+#elif defined(Q_OS_WIN)
+    UlanziDialWindowsManager*  m_dialBackend{nullptr};
+#elif defined(Q_OS_MAC)
+    UlanziDialMacOSManager*    m_dialBackend{nullptr};
 #endif
+    QTimer                     m_dialCoalesceTimer;
+    int                        m_dialPendingSteps{0};
 #ifdef HAVE_MIDI
     MidiControlManager*  m_midiControl{nullptr};
     QTimer               m_midiTuneIdleTimer;
@@ -606,9 +614,7 @@ private:
 #ifdef HAVE_MIDI
     QPointer<MidiMappingDialog> m_midiDialog;
 #endif
-#ifdef Q_OS_LINUX
     QPointer<UlanziDialMapperDialog> m_ulanziMapperDialog;
-#endif
 
     // Tracks every PersistentDialog created via showOrRaisePersistent() so
     // setFramelessWindow() can propagate the frameless toggle without an

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -1,9 +1,7 @@
 #include <QtGlobal>
-#ifdef Q_OS_LINUX
 
 #include "UlanziDialMapperDialog.h"
 #include "core/AppSettings.h"
-#include "core/EvdevEncoderManager.h"
 #include "core/ShortcutManager.h"
 #ifdef HAVE_MIDI
 #include "core/MidiControlManager.h"
@@ -147,7 +145,7 @@ QString pillComboStyle()
 
 } // namespace
 
-UlanziDialMapperDialog::UlanziDialMapperDialog(EvdevEncoderManager* manager,
+UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
                                                ShortcutManager*     shortcuts,
                                                MidiControlManager*  midi,
                                                QWidget*             parent)
@@ -205,11 +203,11 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(EvdevEncoderManager* manager,
     loadActions();
 
     if (m_manager) {
-        connect(m_manager, &EvdevEncoderManager::tuneSteps,
+        connect(m_manager, &UlanziDialBackend::tuneSteps,
                 this, &UlanziDialMapperDialog::onTuneSteps);
-        connect(m_manager, &EvdevEncoderManager::buttonEvent,
+        connect(m_manager, &UlanziDialBackend::buttonEvent,
                 this, &UlanziDialMapperDialog::onButtonEvent);
-        connect(m_manager, &EvdevEncoderManager::connectionChanged,
+        connect(m_manager, &UlanziDialBackend::connectionChanged,
                 this, &UlanziDialMapperDialog::onConnectionChanged);
         onConnectionChanged(m_manager->isConnected(), m_manager->deviceName());
     } else {
@@ -534,4 +532,3 @@ void UlanziDialMapperDialog::onConnectionChanged(bool connected, const QString& 
 
 } // namespace AetherSDR
 
-#endif // Q_OS_LINUX

--- a/src/gui/UlanziDialMapperDialog.h
+++ b/src/gui/UlanziDialMapperDialog.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <QtGlobal>
-#ifdef Q_OS_LINUX
 
 #include "PersistentDialog.h"
+#include "core/UlanziDialBackend.h"
 
 #include <QList>
 #include <QPoint>
@@ -16,7 +16,6 @@ class QResizeEvent;
 
 namespace AetherSDR {
 
-class EvdevEncoderManager;
 class MidiControlManager;
 class ShortcutManager;
 class UlanziDialCanvas;
@@ -40,7 +39,7 @@ class UlanziDialMapperDialog : public PersistentDialog {
     Q_OBJECT
 
 public:
-    explicit UlanziDialMapperDialog(EvdevEncoderManager* manager,
+    explicit UlanziDialMapperDialog(UlanziDialBackend* manager,
                                     ShortcutManager*     shortcuts,
                                     MidiControlManager*  midi,
                                     QWidget*             parent = nullptr);
@@ -103,7 +102,7 @@ private:
     QRect dialBodyRect() const;
     QPoint anchorScreenPos(const QPoint& norm) const;
 
-    EvdevEncoderManager* m_manager{nullptr};
+    UlanziDialBackend* m_manager{nullptr};
     ShortcutManager*     m_shortcuts{nullptr};
     MidiControlManager*  m_midi{nullptr};
     UlanziDialCanvas*    m_canvas{nullptr};
@@ -117,4 +116,3 @@ private:
 
 } // namespace AetherSDR
 
-#endif // Q_OS_LINUX


### PR DESCRIPTION
Completes the platform matrix promised in #3232.  Linux (evdev) landed
in #3238; this PR adds the Windows (hidapi) and macOS (IOKit) sides.
The mapper dialog drops its Linux guard and now builds everywhere.

Architecture
------------
All three backends expose the same Qt signal contract:
    tuneSteps(int)               - rotary delta
    buttonEvent(sig, action)     - canonical Linux-keycode-name strings
    connectionChanged(bool, name)

A new typedef `UlanziDialBackend` (src/core/UlanziDialBackend.h)
resolves to the right concrete class per platform.  Mapper dialog and
MainWindow dispatcher use only the alias and have no platform switches
of their own.

Windows (UlanziDialWindowsManager)
----------------------------------
- hidapi (already a project dep) enumerates HID devices, matches by
  product_string substring "Ulanzi Dial"
- Opens every matching interface (the dial enumerates as multiple
  HID interfaces on Windows: Keyboard + Consumer Control, possibly
  Mouse) and polls each via QTimer at 5ms intervals
- HID report parsing: standard 8-byte keyboard report (modifier mask
  + up-to-6-keys array, diffed across frames for transitions) and
  Consumer Control reports (2-byte usage code)
- HID usage codes mapped to canonical Linux keycode integers so the
  signature strings (`KEY_PLAYPAUSE`, `Ctrl+V`, ...) match Linux
  exactly and `kPillSpecs` is unchanged
- Chord assembly state machine identical to the Linux backend
- Hot-plug via 3s rescan timer
- LIMITATION: no exclusive-claim equivalent yet.  The dial's keystrokes
  still reach the focused window because hidapi doesn't suppress OS
  input routing.  RawInput + RIDEV_NOLEGACY is the proper fix; tracked
  for a follow-up

macOS (UlanziDialMacOSManager)
------------------------------
- IOKit HID Manager with device-matching dictionary
  ({ kIOHIDProductKey: "Ulanzi Dial" })
- `IOHIDManagerOpen` with `kIOHIDOptionsTypeSeizeDevice` -- the
  documented macOS exclusive-claim mechanism.  Equivalent to Linux
  EVIOCGRAB: when seized, the dial's events stop reaching the OS
  keyboard stack, so its media keys don't leak to the focused window
- Event-driven via `IOHIDManagerRegisterInputValueCallback`; no polling
- Same usage-page-to-Linux-keycode mapping and chord assembly as
  Windows backend
- Scheduled on `CFRunLoopGetMain()` (IOKit requires a CFRunLoop, and
  only the main thread has one integrated with Qt's event loop on
  macOS).  MainWindow conditionally skips `moveToThread` on macOS to
  match this constraint
- Hot-plug native via IOHIDManager device-matching/removal callbacks

Build wiring (CMakeLists.txt)
-----------------------------
- UlanziDialBackend.h + UlanziDialMapperDialog.{cpp,h}: unconditional
- EvdevEncoderManager.{cpp,h}: UNIX AND NOT APPLE (Linux)
- UlanziDialWindowsManager.{cpp,h}: WIN32
- UlanziDialMacOSManager.{cpp,h}: APPLE
- macOS links -framework IOKit and -framework CoreFoundation

Tested
------
- Linux: compiles + runs as before (Linux behaviour unchanged; same
  EvdevEncoderManager underneath the alias)
- Windows + macOS: compile validation gated by CI (check-windows from
  #3210 and check-macos from #3223).  Live testing on hardware happens
  in the user's environment

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
