### PR TITLE
fix(transmit): emit micStateChanged() from setMonGainSb (#2180)

### DIFF
--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -563,6 +563,7 @@ void TransmitModel::setMonGainSb(int gain)
 {
     gain = qBound(0, gain, 100);
     m_monGainSb = gain;
+    emit micStateChanged();
     emit commandReady(QString("transmit set mon_gain_sb=%1").arg(gain));
 }
 


### PR DESCRIPTION
## Problem

`TransmitModel::setMonGainSb()` updates `m_monGainSb` and emits `commandReady` but never emits `micStateChanged()`. A UI slider bound to monitor gain via the model signal won't repaint when the value is changed by MIDI controller, keyboard shortcut, or radio echo — until an unrelated event happens to trigger a redraw.

Same class of gap as #2084 (VOX setters) and the `setMicLevel` part of #2180.

**Note:** `setMicLevel` was fixed concurrently in PR #3234 (with a change guard). This PR addresses the remaining gap — `setMonGainSb`.

## Fix

Add `emit micStateChanged()` after updating `m_monGainSb`, consistent with how all other mic-state setters behave.

## Setter audit (per #2180)

| Setter | Signal emitted? |
|---|---|
| `setMicSelection` | ✅ `micStateChanged()` |
| `setMicLevel` | ✅ `micStateChanged()` — fixed in #3234 |
| `setSpeechProcessorEnable` | ✅ `micStateChanged()` |
| `setSpeechProcessorLevel` | ✅ `micStateChanged()` |
| `setMonGainSb` | ❌ **missing** — fixed here |
| `setMonGainCw` | ✅ `phoneStateChanged()` |
| `setMonPanCw` | ✅ `phoneStateChanged()` |

Fixes #2180