### PR TITLE
fix(cw): prefer WASAPI host API for CW sidetone on Windows (#3193)

### DIFF
--- a/src/core/CwSidetonePortAudioSink.cpp
+++ b/src/core/CwSidetonePortAudioSink.cpp
@@ -30,45 +30,68 @@ PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
         return paNoDevice;
     }
 
-    PaDeviceIndex partialMatch = paNoDevice;
-    QString partialMatchName;
-    bool partialMatchAmbiguous = false;
+    // Collect all partial-match candidates. On Windows a single physical
+    // device appears under multiple host APIs (MME, DirectSound, WASAPI);
+    // the candidate list lets us prefer WASAPI instead of giving up when
+    // more than one partial match is found. (#3193)
+    struct Candidate { PaDeviceIndex idx; QString rawName; PaHostApiTypeId apiType; };
+    QList<Candidate> partials;
+
     for (PaDeviceIndex i = 0; i < count; ++i) {
         const PaDeviceInfo* info = Pa_GetDeviceInfo(i);
         if (!info || info->maxOutputChannels <= 0 || !info->name)
             continue;
 
         const QString rawName = QString::fromUtf8(info->name);
-        const QString candidate =
-            normalizedDeviceName(rawName);
+        const QString candidate = normalizedDeviceName(rawName);
         if (candidate == target)
             return i;
 
         if (candidate.contains(target) || target.contains(candidate)) {
-            if (partialMatch == paNoDevice) {
-                partialMatch = i;
-                partialMatchName = rawName;
-            } else {
-                partialMatchAmbiguous = true;
-            }
+            // paInDevelopment (0) is used as a safe "unknown" sentinel when
+            // Pa_GetHostApiInfo returns null — it will never equal paWASAPI.
+            PaHostApiTypeId apiType = paInDevelopment;
+            if (const PaHostApiInfo* api = Pa_GetHostApiInfo(info->hostApi))
+                apiType = api->type;
+            partials.append({i, rawName, apiType});
         }
     }
 
-    if (partialMatchAmbiguous) {
-        qCWarning(lcAudio) << "CwSidetonePortAudioSink: selected Qt output device"
-                           << device.description()
-                           << "matched multiple PortAudio outputs";
+    if (partials.isEmpty())
         return paNoDevice;
-    }
 
-    if (partialMatch != paNoDevice) {
+    if (partials.size() == 1) {
         qCWarning(lcAudio) << "CwSidetonePortAudioSink: selected Qt output device"
                            << device.description()
                            << "partially matched PortAudio output"
-                           << partialMatchName
+                           << partials[0].rawName
                            << "by name substring";
+        return partials[0].idx;
     }
-    return partialMatch;
+
+#ifdef Q_OS_WIN
+    // Multiple matches — the same physical device enumerated under different
+    // host APIs. Prefer WASAPI (~10 ms shared-mode latency) over MME or
+    // DirectSound (50–150 ms) to reduce CW timing jitter. (#3193)
+    QList<Candidate> wasapiCandidates;
+    for (const Candidate& c : partials) {
+        if (c.apiType == paWASAPI)
+            wasapiCandidates.append(c);
+    }
+    if (wasapiCandidates.size() == 1) {
+        qCInfo(lcAudio) << "CwSidetonePortAudioSink: selected Qt output device"
+                        << device.description()
+                        << "resolved to WASAPI output"
+                        << wasapiCandidates[0].rawName
+                        << "(preferred over" << partials.size() - 1 << "other host API(s))";
+        return wasapiCandidates[0].idx;
+    }
+#endif
+
+    qCWarning(lcAudio) << "CwSidetonePortAudioSink: selected Qt output device"
+                       << device.description()
+                       << "matched multiple PortAudio outputs";
+    return paNoDevice;
 }
 
 PaDeviceIndex defaultPortAudioOutputDevice()
@@ -84,6 +107,26 @@ PaDeviceIndex defaultPortAudioOutputDevice()
                 && api->defaultOutputDevice != paNoDevice) {
                 devIdx = api->defaultOutputDevice;
                 qCInfo(lcAudio) << "CwSidetonePortAudioSink: using JACK host API"
+                                << "(device" << devIdx << ")";
+                break;
+            }
+        }
+    }
+#endif
+#ifdef Q_OS_WIN
+    // Pa_GetDefaultOutputDevice() on Windows typically returns an MME device
+    // (the first enumerated host API), which has 50–150 ms OS-level buffering.
+    // Prefer WASAPI shared mode (~10 ms) to reduce CW timing jitter on fast
+    // keying. Mirrors the Linux JACK preference above. (#3193)
+    if (devIdx == paNoDevice) {
+        const PaHostApiIndex apiCount = Pa_GetHostApiCount();
+        for (PaHostApiIndex i = 0; i < apiCount; ++i) {
+            const PaHostApiInfo* api = Pa_GetHostApiInfo(i);
+            if (!api || !api->name) continue;
+            if (qstrncmp(api->name, "Windows WASAPI", 14) == 0
+                && api->defaultOutputDevice != paNoDevice) {
+                devIdx = api->defaultOutputDevice;
+                qCInfo(lcAudio) << "CwSidetonePortAudioSink: using WASAPI host API"
                                 << "(device" << devIdx << ")";
                 break;
             }


### PR DESCRIPTION
Standalone split of Fix #2 from #3194, as requested by @jensenpat.

## Problem

`CwSidetonePortAudioSink` picks audio output devices via PortAudio, but on Windows:

1. **`defaultPortAudioOutputDevice()`** falls straight through to `Pa_GetDefaultOutputDevice()`, which returns an MME device (the first host API PortAudio enumerates). MME carries 50–150 ms OS-level buffering, producing audible CW timing jitter on fast keying.

2. **`findPortAudioOutputDevice()`** matches devices by name substring. On Windows, the same physical device is enumerated three times under MME, DirectSound, and WASAPI. The old code treated this as an ambiguous match and returned `paNoDevice` — causing the sidetone to fall back to `CwSidetoneQAudioSink` and lose low-latency timing. When it did resolve, it picked whichever host API appeared first (MME).

## Fix

**`defaultPortAudioOutputDevice()`** — add a WASAPI preference pass before the `Pa_GetDefaultOutputDevice()` fallback, mirroring the existing Linux JACK preference exactly. WASAPI shared mode runs at ~10 ms, vs 50–150 ms for MME.

**`findPortAudioOutputDevice()`** — collect all partial-match candidates, then resolve to the WASAPI entry when exactly one exists. Logs a clear `qCInfo` message showing which host API won. Falls back to the existing "matched multiple" warning only if multiple WASAPI entries are somehow present (pathological case).

## Scope

`CwSidetonePortAudioSink.cpp` only. No changes to `AudioEngine.cpp`, no RX path changes, no buffer size changes.

## Related

- Partially addresses #3193 (CW sidetone latency component)
- May also help #2528 (TX→RX delay when stopping CW) and the latency component of #2694
- Sibling of the held #3194 Fix #1 (RX WASAPI ring cap — separate review track)