### PR TITLE
fix(tci): seed master AF volume in connect init burst

### DIFF
--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -207,6 +207,14 @@ QString TciProtocol::generateInitBurst()
         burst += QStringLiteral("tune_drive:%1,%2;").arg(txTrx).arg(tx.tunePower());
         burst += QStringLiteral("mic_level:%1;").arg(tx.micLevel());
         burst += QStringLiteral("trx:%1,%2;").arg(txTrx).arg(isTx ? "true" : "false");
+
+        // Master AF volume — whole-radio (no trx prefix), same saved value
+        // cmdVolume's GET returns. Without it the init burst seeds drive/
+        // mic_level but not AF, so a client's local mirror starts at a default
+        // guess and the first AF-gain step jumps to that guess instead of the
+        // radio's real level (Ulanzi/Elgato/StreamController gain steppers).
+        burst += QStringLiteral("volume:%1;")
+                     .arg(AppSettings::instance().value("MasterVolume", "100").toInt());
     }
 
     // ── Phase 3: Audio / IQ stream configuration ──────────────────────


### PR DESCRIPTION
## Summary

The TCI connect init burst already seeds `drive:` (RF power) and `mic_level:`, but never emitted `volume:` (master AF gain). A TCI control client that steps AF gain (the Ulanzi / Elgato / StreamController gain steppers) therefore had no way to learn the radio's current AF level on connect — its local mirror started at a hardcoded default, so the **first** AF Gain ±step was computed against that default and snapped the slider to ~50/55 regardless of the real level. Only after the first echo did subsequent steps track correctly.

## Change

One line in `generateInitBurst()`: emit `volume:<MasterVolume>;` (whole-radio, no trx prefix) alongside the existing `drive`/`mic_level` seeds, reading the same saved value `cmdVolume`'s GET returns (`AppSettings` `MasterVolume`). `+8 / -0` incl. comment.

This fixes the first-press jump for **every** TCI gain client, not just the one that surfaced it.

## Verification

- **Server-side:** before the fix the init burst had no `volume:` line; after, it emits `volume:87` (the radio's real level), confirmed via a WebSocket init-burst capture.
- **Live on hardware:** confirmed on the **Ulanzi D100H** deck — the first AF Gain press now steps from the radio's actual value instead of jumping to the default. RF and MIC unaffected.

## Test plan

- [x] Init burst now contains `volume:<current>;` (server-side capture)
- [x] First AF-gain step relative to real value — live on Ulanzi D100H
- [x] RF / MIC seeds unchanged
- [ ] CI matrix (auto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)