### PR TITLE
feat(mqtt): show internal publish topics in Publish Buttons settings tab

### DIFF
--- a/src/core/MqttSettings.cpp
+++ b/src/core/MqttSettings.cpp
@@ -291,7 +291,7 @@ QStringList internalMqttSubscriptionTopics()
 
 QStringList internalMqttPublishTopics()
 {
-    return { QStringLiteral("aethersdr/cw/decode") };
+    return { QString(kCwDecodeTopic) };
 }
 
 QStringList mqttSubscriptionTopics(const QStringList& userTopics)

--- a/src/core/MqttSettings.cpp
+++ b/src/core/MqttSettings.cpp
@@ -289,6 +289,11 @@ QStringList internalMqttSubscriptionTopics()
     };
 }
 
+QStringList internalMqttPublishTopics()
+{
+    return { QStringLiteral("aethersdr/cw/decode") };
+}
+
 QStringList mqttSubscriptionTopics(const QStringList& userTopics)
 {
     QStringList allTopics;

--- a/src/core/MqttSettings.h
+++ b/src/core/MqttSettings.h
@@ -43,6 +43,8 @@ QStringList mqttUserSubscriptionTopics(const QVector<MqttTopicDef>& topics);
 
 QStringList internalMqttSubscriptionTopics();
 QStringList mqttSubscriptionTopics(const QStringList& userTopics);
+
+QStringList internalMqttPublishTopics();
 QStringList mqttSubscriptionTopics(const QVector<MqttTopicDef>& userTopics);
 
 QVector<MqttButtonDef> mqttButtonsFromJson(const QString& json);

--- a/src/core/MqttSettings.h
+++ b/src/core/MqttSettings.h
@@ -44,6 +44,8 @@ QStringList mqttUserSubscriptionTopics(const QVector<MqttTopicDef>& topics);
 QStringList internalMqttSubscriptionTopics();
 QStringList mqttSubscriptionTopics(const QStringList& userTopics);
 
+inline constexpr QLatin1String kCwDecodeTopic{"aethersdr/cw/decode"};
+
 QStringList internalMqttPublishTopics();
 QStringList mqttSubscriptionTopics(const QVector<MqttTopicDef>& userTopics);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5646,7 +5646,7 @@ void MainWindow::publishCwDecodeMqtt(const QString& text, float cost, bool rx)
     obj[QStringLiteral("rx")]   = rx;
     if (auto* s = activeSlice(); s && s->frequency() > 0.0)
         obj[QStringLiteral("freq")] = s->frequency();
-    m_mqttClient->publish(QStringLiteral("aethersdr/cw/decode"),
+    m_mqttClient->publish(QString(kCwDecodeTopic),
                           QJsonDocument(obj).toJson(QJsonDocument::Compact));
 }
 #endif

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5646,7 +5646,7 @@ void MainWindow::publishCwDecodeMqtt(const QString& text, float cost, bool rx)
     obj[QStringLiteral("rx")]   = rx;
     if (auto* s = activeSlice(); s && s->frequency() > 0.0)
         obj[QStringLiteral("freq")] = s->frequency();
-    m_mqttClient->publish(QString(kCwDecodeTopic),
+    m_mqttClient->publish(QString::fromLatin1(kCwDecodeTopic),
                           QJsonDocument(obj).toJson(QJsonDocument::Compact));
 }
 #endif

--- a/src/gui/MqttSettingsDialog.cpp
+++ b/src/gui/MqttSettingsDialog.cpp
@@ -196,6 +196,18 @@ void MqttSettingsDialog::buildUi()
     buttonControls->addWidget(removeButton);
     buttonControls->addStretch();
     buttonsLayout->addLayout(buttonControls);
+
+    auto* pubInternalGroup = new QGroupBox(tr("Internal AetherSDR Topics"));
+    auto* pubInternalLayout = new QVBoxLayout(pubInternalGroup);
+    auto* pubInternalText = new QLabel(
+        tr("Published automatically whenever MQTT is connected; these topics are not user-configurable:\n"
+           "aethersdr/cw/decode\n"
+           "  Payload: {\"text\":\"K\",\"freq\":14.025,\"rx\":true}\n"
+           "  rx: true = received CW,  false = transmitted (sidetone)"));
+    pubInternalText->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    pubInternalLayout->addWidget(pubInternalText);
+    buttonsLayout->addWidget(pubInternalGroup);
+
     tabs->addTab(buttonsTab, tr("Publish Buttons"));
 
     connect(m_addButtonRowBtn, &QPushButton::clicked, this, [this] { addButtonRow(); });

--- a/src/gui/MqttSettingsDialog.cpp
+++ b/src/gui/MqttSettingsDialog.cpp
@@ -2,6 +2,7 @@
 
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
+#include "core/MqttSettings.h"
 #include "core/ThemeManager.h"
 
 #include <QCheckBox>
@@ -201,9 +202,10 @@ void MqttSettingsDialog::buildUi()
     auto* pubInternalLayout = new QVBoxLayout(pubInternalGroup);
     auto* pubInternalText = new QLabel(
         tr("Published automatically whenever MQTT is connected; these topics are not user-configurable:\n"
-           "aethersdr/cw/decode\n"
+           "%1\n"
            "  Payload: {\"text\":\"K\",\"freq\":14.025,\"rx\":true}\n"
-           "  rx: true = received CW,  false = transmitted (sidetone)"));
+           "  rx: true = received CW,  false = transmitted (sidetone)")
+            .arg(QLatin1String(kCwDecodeTopic)));
     pubInternalText->setTextInteractionFlags(Qt::TextSelectableByMouse);
     pubInternalLayout->addWidget(pubInternalText);
     buttonsLayout->addWidget(pubInternalGroup);

--- a/src/gui/MqttSettingsDialog.cpp
+++ b/src/gui/MqttSettingsDialog.cpp
@@ -202,7 +202,7 @@ void MqttSettingsDialog::buildUi()
     auto* pubInternalLayout = new QVBoxLayout(pubInternalGroup);
     auto* pubInternalText = new QLabel(
         tr("Published automatically whenever MQTT is connected; these topics are not user-configurable:\n"
-           "%1").arg(QLatin1String(kCwDecodeTopic)));
+           "%1").arg(internalMqttPublishTopics().join(QStringLiteral("\n"))));
     pubInternalText->setTextInteractionFlags(Qt::TextSelectableByMouse);
     pubInternalLayout->addWidget(pubInternalText);
     buttonsLayout->addWidget(pubInternalGroup);

--- a/src/gui/MqttSettingsDialog.cpp
+++ b/src/gui/MqttSettingsDialog.cpp
@@ -202,10 +202,7 @@ void MqttSettingsDialog::buildUi()
     auto* pubInternalLayout = new QVBoxLayout(pubInternalGroup);
     auto* pubInternalText = new QLabel(
         tr("Published automatically whenever MQTT is connected; these topics are not user-configurable:\n"
-           "%1\n"
-           "  Payload: {\"text\":\"K\",\"freq\":14.025,\"rx\":true}\n"
-           "  rx: true = received CW,  false = transmitted (sidetone)")
-            .arg(QLatin1String(kCwDecodeTopic)));
+           "%1").arg(QLatin1String(kCwDecodeTopic)));
     pubInternalText->setTextInteractionFlags(Qt::TextSelectableByMouse);
     pubInternalLayout->addWidget(pubInternalText);
     buttonsLayout->addWidget(pubInternalGroup);


### PR DESCRIPTION
Closes #3249.

## Summary

The Subscriptions tab already has an **Internal AetherSDR Topics** group box listing topics AetherSDR subscribes to automatically. The Publish Buttons tab had no equivalent, leaving `aethersdr/cw/decode` — published for every decoded CW character since #3216 — undiscoverable without reading source.

- Adds a matching read-only group box to the bottom of the Publish Buttons tab; label text is mouse-selectable for copy-paste into subscriber configs
- Adds `internalMqttPublishTopics()` to `MqttSettings.h/.cpp` alongside the existing `internalMqttSubscriptionTopics()` for a machine-readable topic list
- Extracts the hardcoded `"aethersdr/cw/decode"` string into `inline constexpr QLatin1String kCwDecodeTopic` in `MqttSettings.h`; the publish call in `MainWindow` and the new settings panel now share the same definition — addressing the minor observation from the #3216 review

## Files changed

| File | Change |
|---|---|
| `src/core/MqttSettings.h` | `kCwDecodeTopic` constant + `internalMqttPublishTopics()` declaration |
| `src/core/MqttSettings.cpp` | `internalMqttPublishTopics()` implementation |
| `src/gui/MqttSettingsDialog.cpp` | Group box added to Publish Buttons tab |
| `src/gui/MainWindow.cpp` | Publish call uses `kCwDecodeTopic` |

## Test plan

- [x] Build clean (macOS, no warnings from changed files)
- [x] MQTT settings dialog → Publish Buttons tab shows **Internal AetherSDR Topics** group box with `aethersdr/cw/decode`
- [x] Label text is mouse-selectable
- [x] Subscriptions tab unchanged
- [x] No behavior change — UI only

🤖 Generated with [Claude Code](https://claude.com/claude-code)