### PR TITLE
[modem] implement 1200 baud VHF (Bell 202) AX.25 receive profile

### DIFF
--- a/docs/MODEM.md
+++ b/docs/MODEM.md
@@ -1,6 +1,8 @@
 # AetherModem AX.25 Notes
 
-This file captures the current 300 baud HF AX.25 modem bring-up notes for the AetherSDR AetherModem window.
+This file captures the AX.25 modem bring-up notes for the AetherSDR AetherModem
+window. It covers the original 300 baud HF profile and the 1200 baud VHF (Bell
+202 / 2m APRS) profile added afterward.
 
 The working test packet has been:
 
@@ -74,6 +76,55 @@ The current build logs:
 - per-frame decode phase offset
 
 The packet activity graph uses AX.25-like candidate deltas rather than raw HDLC candidate deltas, because raw HDLC counts are lane-summed and noisy.
+
+## VHF 1200 baud (Bell 202 / 2m APRS)
+
+The `Vhf1200` profile decodes standard 2m FM APRS (e.g. 144.390 MHz in North
+America), including via a transverter where the radio sits on an HF IF in FM.
+Select it with the **1200 baud VHF** profile button in the AetherModem window.
+
+```text
+sample rate:       24000 Hz
+baud:              1200
+mark:              1200 Hz
+space:             2200 Hz
+samples/symbol:    20
+polarity:          Normal for upright FM-demodulated AFSK
+lanes:             18 (10 free-running phase + 4 tracked phases x 2 PLL alphas)
+```
+
+Unlike HF, 1200 baud uses a **hybrid decode bank** (tuned by `kVhf1200*` in
+`src/core/tnc/AetherAx25LibmodemShim.cpp`) that favors aggressive capture:
+
+- **Free-running phase lanes** (PLL alpha 0, spread across the 20-sample symbol)
+  decode clean / short / strong bursts the instant they arrive — at least one
+  lane samples the eye center, the same proven mechanism as the HF bank. This is
+  what makes the synthetic and chunked 1200 loopback tests decode; a single
+  Gardner-only lane (the original stub) never locked reliably.
+- **Gardner-tracked lanes** (PLL alpha 0.010 and 0.025) chase the symbol clock
+  for TX/RX drift and fading on longer or weaker bursts.
+
+Duplicate suppression collapses the same frame seen by several lanes into one
+emission, so the 18-lane bank still reports each packet once.
+
+Polarity is **Normal** for upright FM-demodulated AFSK; use Reverse only as a
+tone-sense check if a mode/sideband change kills all decodes. TX remains 300
+baud HF only for now — the 1200 profile is receive-only.
+
+### Iterating on 1200 baud
+
+- Enable the **AetherModem** (`aether.ax25`) log category. On every profile
+  switch the modem logs a one-line config summary
+  (`modem configured: 1200 baud VHF ... lanes=18`), and each decode logs
+  `decoded AX.25 frame baud=1200 conf=... SRC=... payload=...`.
+- Click the packet-activity graph to toggle the per-second diagnostics summary
+  (tones, gate, symbols, confidence, HDLC/AX.25 candidates, FCS reject classes)
+  — identical instrumentation to the HF path, now tagged with `baud=`.
+- Replay a saved capture against every profile/polarity in one pass:
+  `ax25_libmodem_shim_test --replay-capture <mono-float32.wav>`. Use the
+  window's **Capture 3m** button to record a real 2m session first.
+- If marginal bursts are missed, raise `kVhf1200FreeRunPhaseCount` for denser
+  fixed-phase coverage, or adjust `kVhf1200PllAlphas` for the tracked lanes.
 
 ## Radio and Level Learnings
 

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -48,6 +48,26 @@ constexpr std::array<int, 21> kHf300DecodePhaseOffsets = {
     43, 47, 51, 55, 59, 63, 67, 71, 75, 79
 };
 
+// 1200 baud VHF (Bell 202 / APRS): an aggressive bank of independent correlator
+// demodulators, combining two complementary strategies so the widest range of
+// bursts is captured. Duplicate suppression collapses the same frame seen by
+// several lanes into one emission, like a multi-decoder TNC (e.g. Dire Wolf).
+//
+//   * Free-running lanes (PLL alpha 0) spread evenly across the symbol period.
+//     With no timing loop they sample at a fixed phase, so on a clean burst at
+//     least one lane lands on the eye center and decodes immediately — the same
+//     proven mechanism as the HF bank. Best for short / strong / clean packets.
+//   * Gardner-tracked lanes (PLL alpha > 0) actively chase the symbol clock, so
+//     they tolerate TX/RX clock drift and fading over longer or weaker bursts
+//     where a fixed-phase lane would slip off the eye. A tight and a loose loop
+//     bandwidth bracket clean-vs-fast-acquisition trade-offs.
+//
+// Total lanes = kVhf1200FreeRunPhaseCount
+//             + kVhf1200TrackedPhaseCount * kVhf1200PllAlphas.size().
+constexpr int kVhf1200FreeRunPhaseCount = 10;
+constexpr int kVhf1200TrackedPhaseCount = 4;
+constexpr std::array<double, 2> kVhf1200PllAlphas = { 0.010, 0.025 };
+
 QString fcsToString(const std::array<uint8_t, 2>& fcs)
 {
     return QStringLiteral("%1%2")
@@ -339,9 +359,7 @@ struct AetherAx25LibmodemShim::Impl {
             ? config.markHz
             : config.spaceHz;
 
-        const double pllAlpha = config.profile == Ax25ModemProfile::Hf300 ? 0.0 : 0.015;
-
-        auto addLane = [&](int phaseOffsetSamples) {
+        auto addLane = [&](int phaseOffsetSamples, double pllAlpha) {
             auto& lane = lanes.emplace_back();
             lane.phaseOffsetSamples = phaseOffsetSamples;
             lane.samplesUntilStart = phaseOffsetSamples;
@@ -362,12 +380,46 @@ struct AetherAx25LibmodemShim::Impl {
         };
 
         if (config.profile == Ax25ModemProfile::Hf300) {
+            // HF: free-running lanes (pll_alpha 0), recovery by phase diversity.
             for (int phaseOffset : kHf300DecodePhaseOffsets)
-                addLane(phaseOffset);
+                addLane(phaseOffset, 0.0);
         } else {
-            addLane(0);
+            // VHF 1200: hybrid bank. Phase offsets are derived from the symbol
+            // period so the spread stays correct if the sample rate ever changes.
+            const int samplesPerSymbol = config.baud > 0
+                ? config.sampleRate / config.baud
+                : 0;
+            if (samplesPerSymbol <= 0) {
+                addLane(0, 0.0);
+            } else {
+                // Free-running phase-diversity lanes — decode clean/short bursts.
+                for (int phase = 0; phase < kVhf1200FreeRunPhaseCount; ++phase) {
+                    const int phaseOffset = (samplesPerSymbol * phase) / kVhf1200FreeRunPhaseCount;
+                    addLane(phaseOffset, 0.0);
+                }
+                // Gardner-tracked lanes — follow clock drift on long/weak bursts.
+                for (int phase = 0; phase < kVhf1200TrackedPhaseCount; ++phase) {
+                    const int phaseOffset = (samplesPerSymbol * phase) / kVhf1200TrackedPhaseCount;
+                    for (double laneAlpha : kVhf1200PllAlphas)
+                        addLane(phaseOffset, laneAlpha);
+                }
+            }
         }
         resetDecoderState(true, true);
+
+        qCInfo(lcAx25).noquote()
+            << QStringLiteral("modem configured: %1 sampleRate=%2Hz baud=%3 samplesPerSymbol=%4 "
+                              "mark=%5Hz space=%6Hz polarity=%7 lanes=%8")
+                   .arg(ax25ModemProfileName(config.profile))
+                   .arg(config.sampleRate)
+                   .arg(config.baud)
+                   .arg(config.baud > 0 ? config.sampleRate / config.baud : 0)
+                   .arg(mark, 0, 'f', 0)
+                   .arg(space, 0, 'f', 0)
+                   .arg(config.polarity == Ax25TonePolarity::Inverted
+                        ? QStringLiteral("Reverse")
+                        : QStringLiteral("Normal"))
+                   .arg(lanes.size());
     }
 
     void resetDecoderState(bool clearCounters, bool clearDiagnostics)
@@ -1026,8 +1078,10 @@ void AetherAx25LibmodemShim::feedAudio(const QByteArray& monoFloat32Pcm, int sam
     const auto* samples = reinterpret_cast<const float*>(monoFloat32Pcm.constData());
     const QVector<Ax25DecodedFrame> frames = processMonoFloat(samples, sampleCount, sampleRate);
     for (const auto& frame : frames) {
-        qCDebug(lcAx25).noquote()
-            << QStringLiteral("decoded AX.25 frame SRC=%1 DST=%2 VIA=%3 UI=%4 pid=%5 phase=%6 payload=%7")
+        qCInfo(lcAx25).noquote()
+            << QStringLiteral("decoded AX.25 frame baud=%1 conf=%2 SRC=%3 DST=%4 VIA=%5 UI=%6 pid=%7 phase=%8 payload=%9")
+                .arg(m_impl->config.baud)
+                .arg(frame.confidenceOrQuality, 0, 'f', 2)
                 .arg(frame.source,
                      frame.destination,
                      frame.path.join(QStringLiteral(",")),
@@ -1040,7 +1094,8 @@ void AetherAx25LibmodemShim::feedAudio(const QByteArray& monoFloat32Pcm, int sam
     if (auto diagnostics = m_impl->takeDiagnosticsIfReady(sampleRate)) {
         if (m_impl->diagnosticsLoggingEnabled) {
             qCDebug(lcAx25).nospace()
-                << "sr=" << diagnostics->sampleRate
+                << "baud=" << m_impl->config.baud
+                << " sr=" << diagnostics->sampleRate
                 << " rms=" << QString::number(diagnostics->rmsDbfs, 'f', 1) << "dBFS"
                 << " peak=" << QString::number(diagnostics->peakDbfs, 'f', 1) << "dBFS"
                 << " clip=" << QString::number(diagnostics->clippedPercent, 'f', 2) << "%"

--- a/tests/ax25_libmodem_shim_test.cpp
+++ b/tests/ax25_libmodem_shim_test.cpp
@@ -58,6 +58,13 @@ lm::packet fixedAprsTestPacket()
                       "!3644.00N\\11947.00W-KI6BCJ HF APRS test via Direwolf 300 baud");
 }
 
+lm::packet fixedVhf1200AprsTestPacket()
+{
+    return lm::packet("KK7GWY-9", "APDW18",
+                      {"WIDE1-1", "WIDE2-1"},
+                      "!4742.00N/12217.00W>2m APRS via AetherModem 1200 baud");
+}
+
 QByteArray sinePcm(int sampleRate, double frequencyHz, double amplitude)
 {
     QByteArray pcm;
@@ -238,7 +245,7 @@ void printReplayDiagnostics(const char* label,
 {
     std::printf(
         "%s: frames=%lld rms=%.1f dBFS peak=%.1f dBFS clip=%.2f%% "
-        "tone1600=%.1f dBFS tone1800=%.1f dBFS dTone=%.1f dB "
+        "tone%.0f=%.1f dBFS tone%.0f=%.1f dBFS dTone=%.1f dB "
         "gate=%s gateRms=%.1f dBFS gateFloor=%.1f dBFS gateResets=%llu "
         "lanes=%d symbols=%d conf=%.2f ones=%.1f%% starts=%llu hdlc=%llu ax25=%llu ok=%llu reject=%llu "
         "short=%llu badFcs=%llu malformed=%llu last=%s bytes=%d bits=%d fcs=%s/%s\n",
@@ -247,7 +254,9 @@ void printReplayDiagnostics(const char* label,
         diagnostics.rmsDbfs,
         diagnostics.peakDbfs,
         diagnostics.clippedPercent,
+        diagnostics.markToneHz,
         diagnostics.markToneDbfs,
+        diagnostics.spaceToneHz,
         diagnostics.spaceToneDbfs,
         diagnostics.markMinusSpaceDb,
         diagnostics.receiveGateOpen ? "open" : "idle",
@@ -287,40 +296,49 @@ int replayCapture(const QString& path)
                 audio.samples.size(),
                 audio.sampleRate);
 
-    for (Ax25TonePolarity polarity : {Ax25TonePolarity::Normal, Ax25TonePolarity::Inverted}) {
-        AetherAx25LibmodemShim shim;
-        shim.configure(ax25DemodConfigForProfile(Ax25ModemProfile::Hf300, polarity));
-        QVector<Ax25DecodedFrame> frames;
-        QVector<double> frameTimesSeconds;
-        constexpr int chunkSamples = 1024;
-        for (size_t offset = 0; offset < audio.samples.size(); offset += chunkSamples) {
-            const int count = static_cast<int>(
-                std::min<size_t>(chunkSamples, audio.samples.size() - offset));
-            const auto chunkFrames = shim.processMonoFloat(audio.samples.data() + offset,
-                                                           count,
-                                                           audio.sampleRate);
-            frames += chunkFrames;
-            for (qsizetype i = 0; i < chunkFrames.size(); ++i) {
-                frameTimesSeconds.append(
-                    static_cast<double>(offset + static_cast<size_t>(count))
-                    / static_cast<double>(audio.sampleRate));
+    // Sweep every profile and polarity so a single capture (e.g. a real 2m
+    // APRS recording) is scored against HF 300 and VHF 1200 in one pass.
+    for (Ax25ModemProfile profile : {Ax25ModemProfile::Hf300, Ax25ModemProfile::Vhf1200}) {
+        for (Ax25TonePolarity polarity : {Ax25TonePolarity::Normal, Ax25TonePolarity::Inverted}) {
+            AetherAx25LibmodemShim shim;
+            shim.configure(ax25DemodConfigForProfile(profile, polarity));
+            QVector<Ax25DecodedFrame> frames;
+            QVector<double> frameTimesSeconds;
+            constexpr int chunkSamples = 1024;
+            for (size_t offset = 0; offset < audio.samples.size(); offset += chunkSamples) {
+                const int count = static_cast<int>(
+                    std::min<size_t>(chunkSamples, audio.samples.size() - offset));
+                const auto chunkFrames = shim.processMonoFloat(audio.samples.data() + offset,
+                                                               count,
+                                                               audio.sampleRate);
+                frames += chunkFrames;
+                for (qsizetype i = 0; i < chunkFrames.size(); ++i) {
+                    frameTimesSeconds.append(
+                        static_cast<double>(offset + static_cast<size_t>(count))
+                        / static_cast<double>(audio.sampleRate));
+                }
             }
-        }
-        const auto diagnostics = shim.diagnosticsSnapshot();
-        printReplayDiagnostics(polarity == Ax25TonePolarity::Normal ? "Normal" : "Reverse",
-                               diagnostics,
-                               frames.size());
-        for (qsizetype i = 0; i < frames.size(); ++i) {
-            const auto& frame = frames.at(i);
-            std::printf("  %.1fs phase=%d %s > %s%s  %s\n",
-                        frameTimesSeconds.value(i, 0.0),
-                        frame.decodePhaseOffsetSamples,
-                        qPrintable(frame.source),
-                        qPrintable(frame.destination),
-                        qPrintable(frame.path.isEmpty()
-                            ? QString()
-                            : QStringLiteral(",") + frame.path.join(QStringLiteral(","))),
-                        qPrintable(frame.payloadText.isEmpty() ? frame.payloadHex : frame.payloadText));
+            const auto diagnostics = shim.diagnosticsSnapshot();
+            const QString label = QStringLiteral("%1 %2")
+                .arg(ax25ModemProfileName(profile),
+                     polarity == Ax25TonePolarity::Normal
+                         ? QStringLiteral("Normal")
+                         : QStringLiteral("Reverse"));
+            printReplayDiagnostics(qPrintable(label),
+                                   diagnostics,
+                                   frames.size());
+            for (qsizetype i = 0; i < frames.size(); ++i) {
+                const auto& frame = frames.at(i);
+                std::printf("  %.1fs phase=%d %s > %s%s  %s\n",
+                            frameTimesSeconds.value(i, 0.0),
+                            frame.decodePhaseOffsetSamples,
+                            qPrintable(frame.source),
+                            qPrintable(frame.destination),
+                            qPrintable(frame.path.isEmpty()
+                                ? QString()
+                                : QStringLiteral(",") + frame.path.join(QStringLiteral(","))),
+                            qPrintable(frame.payloadText.isEmpty() ? frame.payloadHex : frame.payloadText));
+            }
         }
     }
 
@@ -347,7 +365,10 @@ void testVhf1200ProfileConfig()
     report("VHF sample rate", cfg.sampleRate == 24000);
     report("VHF baud", cfg.baud == 1200);
     report("VHF tones", cfg.markHz == 1200.0 && cfg.spaceHz == 2200.0);
-    report("VHF profile keeps one decode lane", shim.diagnosticsSnapshot().decodeLanes == 1);
+    // Aggressive multi-lane decode bank: 10 free-running phase lanes + 4 tracked
+    // phases x 2 PLL bandwidths = 18 (see kVhf1200* in the shim).
+    report("VHF profile runs the 18-lane decode bank",
+           shim.diagnosticsSnapshot().decodeLanes == 18);
     report("VHF description names profile", shim.demodDescription().contains(QStringLiteral("1200 baud VHF")));
 }
 
@@ -402,6 +423,73 @@ void testSyntheticHf300AfskLoopbackDecodes()
     report("synthetic loopback UI frame", frame.isUiFrame && frame.control == 0x03 && frame.pid == 0xf0);
     report("synthetic loopback payload",
            frame.payloadText == QStringLiteral("!3644.00N\\11947.00W-KI6BCJ HF APRS test via Direwolf 300 baud"));
+}
+
+void testSyntheticVhf1200AfskLoopbackDecodes()
+{
+    const auto cfg = ax25DemodConfigForProfile(Ax25ModemProfile::Vhf1200);
+
+    AetherAx25LibmodemShim shim;
+    shim.configure(cfg);
+
+    const auto frameBytes = lm::ax25::encode_frame(fixedVhf1200AprsTestPacket());
+    const auto bits = lm::ax25::encode_bitstream(frameBytes, 0, 80, 8);
+    const auto audio = afskPcmFromBits(bits, cfg);
+    const auto frames = shim.processMonoFloat(audio.data(),
+                                              static_cast<int>(audio.size()),
+                                              cfg.sampleRate);
+    const auto diagnostics = shim.diagnosticsSnapshot();
+
+    report("synthetic 1200 baud AFSK loopback emits one frame", frames.size() == 1);
+    report("synthetic 1200 baud AFSK loopback runs the decode bank", diagnostics.decodeLanes > 1);
+    report("synthetic 1200 baud AFSK loopback produced symbols", diagnostics.demodSymbols > 0);
+    report("synthetic 1200 baud AFSK loopback has no clipping", diagnostics.clippedPercent == 0.0);
+    if (frames.isEmpty())
+        return;
+
+    const auto& frame = frames.first();
+    report("synthetic 1200 loopback source", frame.source == QStringLiteral("KK7GWY-9"));
+    report("synthetic 1200 loopback destination", frame.destination == QStringLiteral("APDW18"));
+    report("synthetic 1200 loopback path",
+           frame.path == QStringList({QStringLiteral("WIDE1-1"), QStringLiteral("WIDE2-1")}));
+    report("synthetic 1200 loopback UI frame", frame.isUiFrame && frame.control == 0x03 && frame.pid == 0xf0);
+    report("synthetic 1200 loopback payload",
+           frame.payloadText == QStringLiteral("!4742.00N/12217.00W>2m APRS via AetherModem 1200 baud"));
+}
+
+void testChunkedVhf1200ReplayDecodes()
+{
+    const auto cfg = ax25DemodConfigForProfile(Ax25ModemProfile::Vhf1200);
+    const auto frameBytes = lm::ax25::encode_frame(fixedVhf1200AprsTestPacket());
+    const auto bits = lm::ax25::encode_bitstream(frameBytes, 0, 80, 8);
+    const auto packetAudio = afskPcmFromBits(bits, cfg);
+
+    // Near-silent lead-in so the receive gate has a floor to open against, then
+    // the burst, fed in 1024-sample chunks exactly like the live RX audio tap.
+    std::vector<float> audio(static_cast<size_t>(cfg.sampleRate), 0.002f);
+    audio.insert(audio.end(), packetAudio.begin(), packetAudio.end());
+
+    AetherAx25LibmodemShim shim;
+    shim.configure(cfg);
+
+    QVector<Ax25DecodedFrame> frames;
+    constexpr int chunkSamples = 1024;
+    for (size_t offset = 0; offset < audio.size(); offset += chunkSamples) {
+        const int count = static_cast<int>(
+            std::min<size_t>(chunkSamples, audio.size() - offset));
+        frames += shim.processMonoFloat(audio.data() + offset, count, cfg.sampleRate);
+    }
+
+    const auto diagnostics = shim.diagnosticsSnapshot();
+    report("chunked 1200 replay receive gate opened", diagnostics.receiveGateResets > 0);
+    report("chunked 1200 replay emits one frame", frames.size() == 1);
+    if (frames.isEmpty())
+        return;
+    report("chunked 1200 replay source", frames.first().source == QStringLiteral("KK7GWY-9"));
+    report("chunked 1200 replay path",
+           frames.first().path == QStringList({QStringLiteral("WIDE1-1"), QStringLiteral("WIDE2-1")}));
+    report("chunked 1200 replay payload",
+           frames.first().payloadText == QStringLiteral("!4742.00N/12217.00W>2m APRS via AetherModem 1200 baud"));
 }
 
 void testTransmitRawPayloadBuildsLoopbackAudio()
@@ -654,6 +742,8 @@ int main(int argc, char** argv)
     testVhf1200ProfileConfig();
     testKnownGoodBitstreamDecodes();
     testSyntheticHf300AfskLoopbackDecodes();
+    testSyntheticVhf1200AfskLoopbackDecodes();
+    testChunkedVhf1200ReplayDecodes();
     testTransmitRawPayloadBuildsLoopbackAudio();
     testTransmitMonitorSyntaxBuildsLoopbackAudio();
     testMalformedTransmitMonitorSyntaxIsRejected();


### PR DESCRIPTION

<img width="1126" height="726" alt="Screenshot 2026-05-28 at 4 22 16 PM" src="https://github.com/user-attachments/assets/0174c233-68b9-4270-9290-33b19708922c" />

## Summary

The `Vhf1200` modem profile existed as an unfinished stub — a single
Gardner-tracked lane that never reliably decoded a frame, with no decode tests.
This PR builds out the complete 1200 baud / 2m APRS receive path behind the
existing **1200 baud VHF** profile button in the AetherModem window.

**300 baud HF path is completely untouched.** The only structural change to the
`Hf300` branch is that `addLane` now takes an explicit PLL alpha (0.0 for HF,
same as before) — the 21 free-running lanes are byte-for-byte identical to
main.

---

## The problem with the stub

The original `Vhf1200` stub called `addLane(0)` — a single lane with a
hard-coded `pllAlpha = 0.015`. A Gardner timing loop needs bit transitions to
converge, and an APRS burst with a short preamble gives it very little runway.
In practice the loop never locked reliably; the test `testVhf1200ProfileConfig`
only checked the config fields and never exercised decoding.

---

## Hybrid 18-lane decode bank

Replaced the stub with a two-tier bank that mirrors how a multi-decoder TNC
(e.g. Dire Wolf) trades CPU for capture rate. All parameters are in named
`constexpr` constants for easy tuning once real 2m captures establish a
baseline.

### Free-running phase lanes (10 lanes, PLL alpha = 0)

Spread evenly across the 20-sample symbol period. With no timing loop they
sample at a fixed phase; at least one lane always lands on the eye center and
decodes clean / short / strong APRS bursts **immediately** — the same proven
mechanism as the HF 300 band's 21-lane phase-diversity bank. This is what makes
1200 baud actually decode in the loopback tests.

### Gardner-tracked lanes (8 lanes = 4 phases × 2 PLL alphas)

Phase offsets spread across the symbol; PLL alpha {0.010, 0.025} brackets
clean-vs-fast-acquisition. These lanes actively chase the symbol clock for
TX/RX drift and fading on longer or weaker bursts where a fixed-phase lane
would slip off the eye.

Duplicate suppression already collapses all lanes — each packet is emitted once
regardless of how many lanes decode it.

---

## Logging (aether.ax25 / AetherModem category)

| Event | Level | Fields added |
|---|---|---|
| Every `configure()` call | `qCInfo` | profile, sampleRate, baud, samplesPerSymbol, mark/space Hz, polarity, lanes |
| Every decoded frame | `qCInfo` (was `qCDebug`) | `baud=`, `conf=` |
| Per-second diagnostics | `qCDebug` | `baud=` prefix |

The config summary fires whenever the user switches profiles in the UI — a
clean breadcrumb for log-driven iteration. Promoting frame decodes to `qCInfo`
means they're visible without enabling the full verbose diagnostics stream.

---

## Tests

Two new end-to-end tests in `ax25_libmodem_shim_test`:

| Test | What it covers |
|---|---|
| `testSyntheticVhf1200AfskLoopbackDecodes` | Synthesizes Bell 202 AFSK from an APRS test packet, feeds it to the shim in one block, verifies clean single-frame decode with correct addresses, path, and payload |
| `testChunkedVhf1200ReplayDecodes` | Same packet prefixed with a near-silent lead-in, fed in 1024-sample chunks (matching the live RX audio tap), verifying receive gate fires and frame decodes through the streaming path |

Lane-count assertion in `testVhf1200ProfileConfig` updated to pin the 18-lane
bank as a regression guard.

**All tests pass** (80+ assertions, zero failures).

---

## Replay tool

`--replay-capture` now sweeps all four combinations (Hf300/Vhf1200 ×
Normal/Inverted) in a single pass — drop a real 2m WAV capture in and
immediately see how both profiles score it. Diagnostics header uses actual tone
Hz from the config rather than hardcoded 1600/1800 labels.

---

## Docs

New **VHF 1200 baud** section added to `docs/MODEM.md` covering:
- Profile config (sample rate, baud, tones, lane count)
- Why the hybrid bank design (free-running vs Gardner-tracked trade-offs)
- Expected polarity (Normal for upright FM-demodulated AFSK)
- Iteration recipe: enabling the log category, using `--replay-capture`, and
  tuning `kVhf1200FreeRunPhaseCount` / `kVhf1200PllAlphas` for marginal bursts

---

## Maintainer notes

- `Ax25HfPacketDecodeDialog` class is still named `*Hf*` even though it now
  drives both profiles — the rename was left out of scope to keep this diff
  minimal. Worth tracking separately (#2605 or similar).
- TX remains 300 baud HF only. 1200 baud TX can follow once the RX path proves
  itself against real-world captures.
- Initial lane tuning (`kVhf1200FreeRunPhaseCount = 10`, `kVhf1200TrackedPhaseCount = 4`)
  was calibrated against the synthetic loopback tests. First real 2m captures
  from the transverter setup should drive any follow-up tuning via
  `--replay-capture`.

## Test plan

- [ ] Select **1200 baud VHF** in the AetherModem window; confirm the log category emits `modem configured: 1200 baud VHF ... lanes=18`
- [ ] Switch back to **300 baud HF**; confirm `lanes=21` and no change in HF behavior
- [ ] With a 2m APRS source (TNC, Dire Wolf, or transverter to 144.390): enable the modem and observe decoded frames with `baud=1200 conf=... SRC=...` in the AetherModem log
- [ ] Record a 3-minute capture via **Capture 3m**, then replay: `ax25_libmodem_shim_test --replay-capture <file.wav>` — should score the VHF 1200 Normal column
- [ ] Run `ax25_libmodem_shim_test` — all tests pass, zero failures
- [ ] Verify HF captures from `docs/MODEM.md` still replay at their documented frame counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)