### PR TITLE
fix(hid): fix macOS shutdown deadlock — UlanziDialMacOS stop() + HID cleanup

### DIFF
--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -94,6 +94,7 @@ bool HidEncoderManager::open(uint16_t vid, uint16_t pid)
 void HidEncoderManager::close()
 {
     m_pollTimer->stop();
+    m_hotplugTimer->stop();
     if (m_device) {
         hid_close(m_device);
         m_device = nullptr;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5246,10 +5246,6 @@ MainWindow::~MainWindow()
                                       Qt::BlockingQueuedConnection);
         }
 #endif
-        if (m_dialBackend) {
-            QMetaObject::invokeMethod(m_dialBackend, &UlanziDialBackend::stop,
-                                      Qt::BlockingQueuedConnection);
-        }
 #ifdef HAVE_SERIALPORT
         if (m_serialPort) {
             m_serialPort->deleteLater();
@@ -5263,13 +5259,23 @@ MainWindow::~MainWindow()
             m_midiControl->deleteLater();
         }
 #endif
-#ifdef HAVE_HIDAPI
-        if (m_hidEncoder) {
-            m_hidEncoder->deleteLater();
-        }
-#endif
         m_extCtrlThread->quit();
         m_extCtrlThread->wait(3000);
+        // Delete ExtControllers objects synchronously after the thread stops.
+        // deleteLater() races with quit() and can leave destructors unrun.
+        // On macOS, UlanziDialMacOSManager::stop() calls
+        // IOHIDManagerUnscheduleFromRunLoop(...GetMain()) which must run on the
+        // main thread — calling it via BlockingQueuedConnection deadlocks because
+        // the main thread is blocked waiting for the cross-thread call to return.
+        // Safe to call directly here: the ExtControllers thread has stopped so
+        // there is no race on m_dialBackend's state.
+        if (m_dialBackend) m_dialBackend->stop();
+        delete m_dialBackend;
+        m_dialBackend = nullptr;
+#ifdef HAVE_HIDAPI
+        delete m_hidEncoder;
+        m_hidEncoder = nullptr;
+#endif
     } else {
 #ifdef HAVE_SERIALPORT
         delete m_serialPort;


### PR DESCRIPTION
Closes #3254.

## Summary

- Removes the `BlockingQueuedConnection` for `m_dialBackend->stop()` in `~MainWindow()`. On macOS, `UlanziDialMacOSManager::stop()` calls `IOHIDManagerUnscheduleFromRunLoop(mgr, CFRunLoopGetMain(), …)`, which needs the main CFRunLoop to process the source removal — calling it via `BlockingQueuedConnection` deadlocks because the main thread is blocked waiting for the cross-thread call to return. After `m_extCtrlThread->wait(3000)` the worker is fully stopped, so `stop()` is called directly on the main thread instead — no cross-thread handoff, no deadlock.
- Replaces `deleteLater()` for `m_dialBackend` and `m_hidEncoder` with synchronous `delete` after `wait()`. `deleteLater()` posts a `DeferredDelete` event to the object's thread; if `quit()` drains the loop first, the destructor never fires and `hid_exit()` doesn't run, keeping the HIDAPI IOKit thread alive. `m_serialPort` / `m_flexControl` / `m_midiControl` `deleteLater` calls are intentionally left unchanged (Windows handle-leak mitigation, as documented in the existing comment at that site).
- Adds `m_hotplugTimer->stop()` to `HidEncoderManager::close()` alongside the existing `m_pollTimer->stop()`.

## Test plan

- [x] File → Quit — process exits cleanly, dock icon gone
- [x] Window close button — process exits cleanly, dock icon gone
- [x] Build clean, no new warnings
- Tested on macOS Apple Silicon; no Ulanzi Dial or StreamDeck+ device present — the deadlock fires regardless because `IOHIDManagerScheduleWithRunLoop(...GetMain())` is called unconditionally in `start()`

## Files changed

| File | Change |
|---|---|
| `src/gui/MainWindow.cpp` | Remove `BlockingQueuedConnection` for `m_dialBackend->stop()`; call directly after `wait()`; synchronous `delete` for `m_dialBackend` and `m_hidEncoder` |
| `src/core/HidEncoderManager.cpp` | Add `m_hotplugTimer->stop()` to `close()` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)