### PR TITLE
feat(eq): reference target curve overlay on the Aetherial Parametric EQ

### DIFF
--- a/src/gui/ClientEqCurveWidget.cpp
+++ b/src/gui/ClientEqCurveWidget.cpp
@@ -142,6 +142,107 @@ void ClientEqCurveWidget::setFilterCutoffs(int lowHz, int highHz)
     update();
 }
 
+namespace {
+// Reference target curves — point-to-point in log-freq × linear-dB space
+// (the standard rendering for target curves).  Each entry is a magnitude
+// trace digitised from its source; the user picks one as a visual target
+// to shape their parametric EQ toward.
+struct RefPoint { float hz; float db; };
+
+// AT&T 1959 "optimum transmission frequency response for speech" — the
+// canonical Bell Labs presence-peak target.  Peak +5 dB at 2.5 kHz,
+// rolls off below 300 Hz and above 3.4 kHz.
+constexpr RefPoint kAttRef1959[] = {
+    {   50.0f, -20.0f }, {  100.0f, -12.0f }, {  200.0f,  -6.0f },
+    {  300.0f,  -2.0f }, {  500.0f,   0.0f }, { 1000.0f,   0.0f },
+    { 1500.0f,   1.0f }, { 2000.0f,   3.0f }, { 2500.0f,   5.0f },
+    { 3000.0f,   4.0f }, { 3400.0f,   0.0f }, { 4000.0f,  -6.0f },
+    { 5000.0f, -12.0f },
+};
+
+// Heil "DX / contest" target — Bob Heil's published recommendation for
+// maximum talk power in pile-ups.  Sharper +6 dB peak at 2.7 kHz, more
+// aggressive low-cut than AT&T 1959.
+constexpr RefPoint kHeilDx[] = {
+    {   50.0f, -25.0f }, {  100.0f, -18.0f }, {  200.0f, -10.0f },
+    {  300.0f,  -4.0f }, {  500.0f,  -1.0f }, { 1000.0f,   0.0f },
+    { 1500.0f,   2.0f }, { 2000.0f,   4.0f }, { 2500.0f,   6.0f },
+    { 2700.0f,   6.0f }, { 3000.0f,   5.0f }, { 3400.0f,  -2.0f },
+    { 4000.0f, -10.0f }, { 5000.0f, -18.0f },
+};
+
+// Astatic D-104 "lollipop" crystal mic — classic AM/SSB rig microphone,
+// extremely peaky presence response around 3 kHz, deep low-end rolloff.
+// Digitised from the manufacturer / Heil "legendary mic" comparison chart.
+constexpr RefPoint kAstaticD104[] = {
+    {   50.0f, -32.0f }, {  100.0f, -22.0f }, {  200.0f, -14.0f },
+    {  300.0f,  -8.0f }, {  500.0f,  -4.0f }, { 1000.0f,   0.0f },
+    { 1500.0f,   2.0f }, { 2000.0f,   5.0f }, { 2500.0f,   8.0f },
+    { 3000.0f,  10.0f }, { 3500.0f,   7.0f }, { 4000.0f,   2.0f },
+    { 5000.0f, -10.0f }, { 7000.0f, -22.0f },
+};
+
+// Shure 444 — classic broadcast-style desk mic, broader response with
+// gentler presence boost.  Smoothest of the legendary mics.
+constexpr RefPoint kShure444[] = {
+    {   50.0f, -15.0f }, {  100.0f, -10.0f }, {  200.0f,  -4.0f },
+    {  300.0f,  -1.0f }, {  500.0f,   0.0f }, { 1000.0f,   1.0f },
+    { 1500.0f,   2.0f }, { 2000.0f,   3.0f }, { 2500.0f,   4.0f },
+    { 3000.0f,   4.0f }, { 3500.0f,   3.0f }, { 4000.0f,   1.0f },
+    { 5000.0f,  -3.0f }, { 7000.0f, -10.0f },
+};
+
+// Heil HC-5 — modern dynamic SSB mic, target shape Heil designs his
+// element around.  Mid-presence boost peaks ~3 kHz at +5 dB.
+constexpr RefPoint kHeilHC5[] = {
+    {   50.0f, -28.0f }, {  100.0f, -18.0f }, {  200.0f,  -8.0f },
+    {  300.0f,  -3.0f }, {  500.0f,   0.0f }, { 1000.0f,   0.0f },
+    { 1500.0f,   2.0f }, { 2000.0f,   4.0f }, { 2500.0f,   6.0f },
+    { 3000.0f,   5.0f }, { 3500.0f,   1.0f }, { 4000.0f,  -5.0f },
+    { 5000.0f, -15.0f },
+};
+
+struct RefPreset {
+    const char* id;       // stable ID for AppSettings
+    const RefPoint* pts;  // point array
+    int count;            // number of points
+};
+constexpr RefPreset kPresets[] = {
+    { "AT&T 1959",    kAttRef1959,  sizeof(kAttRef1959)  / sizeof(RefPoint) },
+    { "Heil DX",      kHeilDx,      sizeof(kHeilDx)      / sizeof(RefPoint) },
+    { "Astatic D-104",kAstaticD104, sizeof(kAstaticD104) / sizeof(RefPoint) },
+    { "Shure 444",    kShure444,    sizeof(kShure444)    / sizeof(RefPoint) },
+    { "Heil HC-5",    kHeilHC5,     sizeof(kHeilHC5)     / sizeof(RefPoint) },
+};
+
+const RefPreset* findPreset(const QString& id)
+{
+    for (const auto& p : kPresets)
+        if (id == QLatin1String(p.id)) return &p;
+    return nullptr;
+}
+} // namespace
+
+const QStringList& ClientEqCurveWidget::referenceCurveIds()
+{
+    static const QStringList ids = []{
+        QStringList out;
+        out << QStringLiteral("Off");
+        for (const auto& p : kPresets)
+            out << QString::fromLatin1(p.id);
+        return out;
+    }();
+    return ids;
+}
+
+void ClientEqCurveWidget::setReferenceCurvePreset(const QString& id)
+{
+    const QString normalised = (id == QLatin1String("Off")) ? QString() : id;
+    if (m_referencePreset == normalised) return;
+    m_referencePreset = normalised;
+    update();
+}
+
 std::vector<float> ClientEqCurveWidget::applyFractionalOctaveSmoothing(
     const std::vector<float>& binsDb, double sampleRate, int octaveFraction)
 {
@@ -390,6 +491,27 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
             p.setBrush(Qt::NoBrush);
             p.drawPath(peakPath);
         }
+    }
+
+    // Reference curve overlay — selected preset.  Drawn after the
+    // analyzer but before the EQ band curves so the user's adjustments
+    // sit on top of the target they're shaping toward.  Amber,
+    // semi-transparent.
+    if (const RefPreset* preset = findPreset(m_referencePreset)) {
+        QPainterPath refPath;
+        for (int i = 0; i < preset->count; ++i) {
+            const float x = freqToX(preset->pts[i].hz);
+            const float y = dbToY(preset->pts[i].db);
+            if (i == 0) refPath.moveTo(x, y);
+            else        refPath.lineTo(x, y);
+        }
+        QPen refPen(QColor(220, 180, 60, 220));
+        refPen.setWidth(2);
+        refPen.setJoinStyle(Qt::RoundJoin);
+        refPen.setCapStyle(Qt::RoundCap);
+        p.setPen(refPen);
+        p.setBrush(Qt::NoBrush);
+        p.drawPath(refPath);
     }
 
     if (!m_eq || m_eq->activeBandCount() == 0) {

--- a/src/gui/ClientEqCurveWidget.h
+++ b/src/gui/ClientEqCurveWidget.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QString>
+#include <QStringList>
 #include <QWidget>
 #include <vector>
 
@@ -86,6 +88,19 @@ public:
     // hidden.
     void setFilterCutoffs(int lowHz, int highHz);
 
+    // Overlay one of several reference curves on the EQ canvas as a
+    // thin amber line.  Use kReferenceCurveIds[] below for the canonical
+    // names; empty string or "Off" hides the overlay.  Curves include
+    // the AT&T 1959 intelligibility target plus digitized responses of
+    // famous SSB microphones (Astatic D-104, Shure 444, Heil HC-5)
+    // and a Bob-Heil-style aggressive DX preset.
+    void setReferenceCurvePreset(const QString& id);
+    QString referenceCurvePreset() const { return m_referencePreset; }
+
+    // Stable IDs for AppSettings persistence and combo-box wiring.  The
+    // first entry is always "Off".
+    static const QStringList& referenceCurveIds();
+
 signals:
     void selectedBandChanged(int idx);
     // Fired whenever band params mutate on the audio side from user
@@ -123,6 +138,7 @@ protected:
     int                m_smoothingFraction{96};  // 96 = effectively off
     int                m_filterLowCutHz{0};      // 0 = don't draw
     int                m_filterHighCutHz{0};     // 0 = don't draw
+    QString            m_referencePreset;  // empty = off
 
 private:
     void applySmoothing();

--- a/src/gui/ClientEqEditor.cpp
+++ b/src/gui/ClientEqEditor.cpp
@@ -92,6 +92,44 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
         AetherSDR::ThemeManager::instance().applyStyleSheet(hint, "QLabel { color: {{color.background.3}}; font-size: 10px; }");
         row->addWidget(hint, 1);
 
+        // Reference curve overlay — paints one of several target curves
+        // on the EQ canvas as a thin amber line.  Includes the AT&T 1959
+        // Bell Labs presence-peak target plus digitised responses of
+        // famous SSB microphones.  Persisted globally.
+        auto* refLbl = new QLabel("Ref:");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(refLbl,
+            "QLabel { color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }");
+        row->addWidget(refLbl);
+
+        auto* refCombo = new QComboBox;
+        for (const QString& id : ClientEqCurveWidget::referenceCurveIds())
+            refCombo->addItem(id, id);
+        refCombo->setFixedHeight(24);
+        refCombo->setToolTip(
+            "Overlay a reference target curve on the EQ canvas (amber).\n"
+            "• AT&T 1959 — Bell Labs intelligibility target, +5 dB @ 2.5 kHz\n"
+            "• Heil DX — aggressive presence boost for SSB contests\n"
+            "• Astatic D-104 — classic lollipop mic, sharp peak @ 3 kHz\n"
+            "• Shure 444 — broadcast-style desk mic, gentler boost\n"
+            "• Heil HC-5 — modern dynamic SSB element\n"
+            "Used as a visual target while you adjust EQ bands.");
+        AetherSDR::applyComboStyle(refCombo);
+
+        const QString savedRef = AppSettings::instance()
+            .value("ClientEqReferenceCurve", "Off").toString();
+        const int savedRefIdx = refCombo->findData(savedRef);
+        refCombo->setCurrentIndex(savedRefIdx >= 0 ? savedRefIdx : 0);
+        // Cached for later apply — m_canvas is nullptr at this point.
+        m_savedReferenceCurvePreset = (savedRef == "Off") ? QString() : savedRef;
+        connect(refCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this, refCombo](int idx) {
+            const QString id = refCombo->itemData(idx).toString();
+            if (m_canvas) m_canvas->setReferenceCurvePreset(id);
+            AppSettings::instance().setValue("ClientEqReferenceCurve", id);
+            AppSettings::instance().save();
+        });
+        row->addWidget(refCombo);
+
         // Smoothing — fractional-octave display smoothing for the FFT
         // analyzer trace.  Doesn't affect EQ math, just the visual.
         // Persisted globally (single user preference, shared between RX
@@ -251,6 +289,7 @@ ClientEqEditor::ClientEqEditor(AudioEngine* engine, QWidget* parent)
     // The combo box already shows the right value from the toolbar build,
     // but the canvas needed to be constructed before this push could land.
     m_canvas->setSmoothingOctaveFraction(m_savedSmoothingFraction);
+    m_canvas->setReferenceCurvePreset(m_savedReferenceCurvePreset);
     eqColumn->addWidget(m_canvas, 1);
     // Forward cutoff-line drag events as a path-tagged signal so MainWindow
     // can dispatch to TransmitModel (TX) or the active SliceModel (RX).

--- a/src/gui/ClientEqEditor.h
+++ b/src/gui/ClientEqEditor.h
@@ -89,6 +89,7 @@ private:
     int                        m_rxFilterLowCutHz{0};
     int                        m_rxFilterHighCutHz{0};
     int                        m_savedSmoothingFraction{96};
+    QString                    m_savedReferenceCurvePreset;
     // The frameless title bar carries the active path label (e.g.
     // "Aetherial Parametric EQ — TX").  Held as a void* + cast at use
     // site to keep the inline EditorFramelessTitleBar class out of the

--- a/src/gui/StripEqPanel.cpp
+++ b/src/gui/StripEqPanel.cpp
@@ -93,6 +93,43 @@ StripEqPanel::StripEqPanel(AudioEngine* engine, QWidget* parent)
         AetherSDR::ThemeManager::instance().applyStyleSheet(hint, "QLabel { color: {{color.background.3}}; font-size: 10px; }");
         row->addWidget(hint, 1);
 
+        // Reference curve overlay — paints one of several target curves
+        // on the EQ canvas as a thin amber line.  Includes the AT&T 1959
+        // Bell Labs presence-peak target plus digitised responses of
+        // famous SSB microphones.  Persisted globally.
+        auto* refLbl = new QLabel("Ref:");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(refLbl,
+            "QLabel { color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }");
+        row->addWidget(refLbl);
+
+        auto* refCombo = new QComboBox;
+        for (const QString& id : ClientEqCurveWidget::referenceCurveIds())
+            refCombo->addItem(id, id);
+        refCombo->setFixedHeight(24);
+        refCombo->setToolTip(
+            "Overlay a reference target curve on the EQ canvas (amber).\n"
+            "• AT&T 1959 — Bell Labs intelligibility target, +5 dB @ 2.5 kHz\n"
+            "• Heil DX — aggressive presence boost for SSB contests\n"
+            "• Astatic D-104 — classic lollipop mic, sharp peak @ 3 kHz\n"
+            "• Shure 444 — broadcast-style desk mic, gentler boost\n"
+            "• Heil HC-5 — modern dynamic SSB element\n"
+            "Used as a visual target while you adjust EQ bands.");
+        AetherSDR::applyComboStyle(refCombo);
+
+        const QString savedRef = AppSettings::instance()
+            .value("ClientEqReferenceCurve", "Off").toString();
+        const int savedRefIdx = refCombo->findData(savedRef);
+        refCombo->setCurrentIndex(savedRefIdx >= 0 ? savedRefIdx : 0);
+        m_savedReferenceCurvePreset = (savedRef == "Off") ? QString() : savedRef;
+        connect(refCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this, refCombo](int idx) {
+            const QString id = refCombo->itemData(idx).toString();
+            if (m_canvas) m_canvas->setReferenceCurvePreset(id);
+            AppSettings::instance().setValue("ClientEqReferenceCurve", id);
+            AppSettings::instance().save();
+        });
+        row->addWidget(refCombo);
+
         // Smoothing — fractional-octave display smoothing for the FFT
         // analyzer trace.  Doesn't affect EQ math, just the visual.
         // Persisted globally (single user preference, shared between RX
@@ -254,6 +291,7 @@ StripEqPanel::StripEqPanel(AudioEngine* engine, QWidget* parent)
     // The combo box already shows the right value from the toolbar build,
     // but the canvas needed to be constructed before this push could land.
     m_canvas->setSmoothingOctaveFraction(m_savedSmoothingFraction);
+    m_canvas->setReferenceCurvePreset(m_savedReferenceCurvePreset);
     eqColumn->addWidget(m_canvas, 1);
     // Forward cutoff-line drag events as a path-tagged signal so MainWindow
     // can dispatch to TransmitModel (TX) or the active SliceModel (RX).

--- a/src/gui/StripEqPanel.h
+++ b/src/gui/StripEqPanel.h
@@ -96,6 +96,7 @@ private:
     int                        m_rxFilterLowCutHz{0};
     int                        m_rxFilterHighCutHz{0};
     int                        m_savedSmoothingFraction{96};
+    QString                    m_savedReferenceCurvePreset;
     // The frameless title bar carries the active path label (e.g.
     // "Aetherial Parametric EQ — TX").  Held as a void* + cast at use
     // site to keep the inline EditorFramelessTitleBar class out of the


### PR DESCRIPTION
Adds a "Ref:" dropdown to the left of the existing "Smoothing:" combo
in both the Channel Strip's EQ panel and the floating ClientEqEditor.
Five selectable presets render as a thin amber line over the EQ canvas
so the user can shape the parametric EQ toward a known target shape:

- AT&T 1959  - Bell Labs "optimum transmission frequency response for
               speech" from the 1959 AT&T handbook.  Peak +5 dB at 2.5
               kHz, rolls off below 300 Hz and above 3.4 kHz.  The
               canonical presence-peak intelligibility target cited
               throughout broadcast and SSB audio engineering.
- Heil DX    - Bob Heil's aggressive DX/contest curve.  Sharper +6 dB
               peak at 2.7 kHz, harder low-cut than AT&T 1959.
- Astatic D-104 - Classic crystal "lollipop" mic, very peaky around
               3 kHz with deep low-end rolloff.  Digitized from the
               "legendary mics" comparison chart.
- Shure 444  - Broadcast-style desk mic, gentler and broader response.
- Heil HC-5  - Modern dynamic SSB element.

Implementation:

- ClientEqCurveWidget gets setReferenceCurvePreset(QString) and a
  static referenceCurveIds() list (canonical IDs for combo + settings).
  Curves are stored as { hz, dB } point arrays joined point-to-point
  in log-freq x linear-dB space (standard target-curve rendering),
  drawn after the FFT analyzer but before the EQ band curves so the
  user's adjustments sit on top of the target.
- Selection persisted to AppSettings as "ClientEqReferenceCurve"
  (string ID; "Off" hides the overlay).  Shared between RX/TX
  editors and between the strip view and the floating editor.
- Toolbar: same QComboBox styling as the existing Smoothing combo,
  placed immediately to the left.

Phase 1 of the request - on/off toggle with a single curve - was
expanded to the 5-preset version after user feedback referencing the
familiar "legendary mics" chart that ham operators compare against.

Files:
- src/gui/ClientEqCurveWidget.{h,cpp}  - API + preset tables + paint
- src/gui/ClientEqEditor.{h,cpp}       - toolbar combo + persistence
- src/gui/StripEqPanel.{h,cpp}         - same toolbar combo for strip view

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
