### PR TITLE
[modem] KISS-over-TCP TNC server + AetherModem UX overhaul

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,6 +575,8 @@ set(CORE_SOURCES
     src/core/MemoryRecallPolicy.cpp
     src/core/tnc/AetherAx25LibmodemShim.cpp
     src/core/tnc/Ax25FrameFormatter.cpp
+    src/core/tnc/KissFraming.cpp
+    src/core/tnc/KissTncServer.cpp
 )
 
 if(APPLE)
@@ -1893,6 +1895,7 @@ add_executable(ax25_libmodem_shim_test
     tests/ax25_libmodem_shim_test.cpp
     src/core/tnc/AetherAx25LibmodemShim.cpp
     src/core/tnc/Ax25FrameFormatter.cpp
+    src/core/tnc/KissFraming.cpp
     # LogManager.cpp provides lcAx25 (the shim's qCDebug category, #2763);
     # LogManager.cpp depends on AsyncLogWriter via the m_writer member, so
     # AppSettings + AsyncLogWriter come along to satisfy the constructor /

--- a/docs/MODEM.md
+++ b/docs/MODEM.md
@@ -173,6 +173,35 @@ path, payload bytes, AX.25 frame bytes, bit count, waveform duration, RMS/peak,
 baud, mark/space, polarity, preamble/postamble flag counts, DAX TX stream id,
 PTT lead/tail timing, and paced chunk progress when debug is enabled.
 
+## KISS TNC (TCP)
+
+The **KISS TNC** tab next to AX.25 turns AetherModem into a KISS-over-TCP TNC so
+any host packet/APRS application drives the modem:
+
+- **Enable TNC** starts/stops a `QTcpServer` (cross-platform) on the configured
+  **TCP port** (default **8001**, all interfaces). **Start TNC on Startup**
+  persists the choice; when set, the app constructs the AetherModem window
+  hidden at launch so the server runs headless and survives the window closing.
+- Multiple clients are supported. Each gets an independent, resync-safe KISS
+  decoder. Dead/stuck clients are reaped via TCP keepalive, a slow-consumer
+  write-backlog cap, and an idle sweep; a client cap bounds resource use.
+- **RX → clients:** every decoded frame is forwarded to all clients as a KISS
+  data frame. The exact on-air bytes (address..info, no FCS) are captured at
+  decode (`Ax25DecodedFrame::ax25FrameNoFcs`) so hosts get a byte-faithful copy.
+- **clients → TX:** a client's KISS data frame is queued and keyed onto the air
+  with the baud profile selected on the AX.25 tab. The modem computes/->appends
+  the FCS (`buildTransmitAudioFromFrame`). Queued frames serialize through the
+  one-at-a-time TX path; the queue drains as each transmit completes.
+- Enabling the TNC also enables the modem (RX tap) for you; a slice must be
+  attached and the radio ready for traffic to flow.
+
+KISS framing lives in `src/core/tnc/KissFraming.{h,cpp}` (pure, unit-tested);
+the server is `src/core/tnc/KissTncServer.{h,cpp}`. All lifecycle and per-frame
+activity logs on the `aether.ax25` (AetherModem) category prefixed `KISS`, so a
+problem can be triaged as client-side (connect/parse/backlog) vs RF-side
+(decode/level/gate). The TNC STATUS panel shows listening port, client count,
+and RX/TX frame counters.
+
 ## Open Work
 
 The remaining missed packets are mostly AX.25-looking candidates that fail FCS. That means the decoder is often finding packet structure but still has symbol/bit errors before CRC.
@@ -187,4 +216,5 @@ Next work should focus on:
 - validating over-the-air AetherModem TX level, timing, and FCS decode with a
   second receiver
 
-Out of scope remains KISS, APRS-IS, maps, digipeating, and connected-mode AX.25.
+Out of scope remains APRS-IS, maps, digipeating, and connected-mode AX.25.
+(KISS-over-TCP is now implemented — see the KISS TNC section above.)

--- a/docs/MODEM.md
+++ b/docs/MODEM.md
@@ -108,8 +108,10 @@ Duplicate suppression collapses the same frame seen by several lanes into one
 emission, so the 18-lane bank still reports each packet once.
 
 Polarity is **Normal** for upright FM-demodulated AFSK; use Reverse only as a
-tone-sense check if a mode/sideband change kills all decodes. TX remains 300
-baud HF only for now — the 1200 profile is receive-only.
+tone-sense check if a mode/sideband change kills all decodes. Both receive and
+transmit are available on the 1200 profile (see the Experimental TX Path
+section) — the AetherModem text field keys an AX.25 UI frame at whichever baud
+profile is selected.
 
 ### Iterating on 1200 baud
 
@@ -145,9 +147,13 @@ For current testing, keep receive audio in this rough range:
 
 ## Experimental TX Path
 
-The first TX pass is intentionally narrow:
+AX.25 UI-frame transmit works on **both** the 300 baud HF and 1200 baud VHF
+profiles. The transmit field keys whichever profile is currently selected, so
+the same text field that sends an HF packet on 14 MHz sends a 2m APRS packet
+(via a transverter) when 1200 baud VHF is active.
 
-- 300 baud HF AX.25 UI frames only.
+- AX.25 UI frames at the selected baud profile (HF 300 → 1600/1800 Hz;
+  VHF 1200 → 1200/2200 Hz Bell 202).
 - The transmit field accepts raw payload text or full `SRC>DST,path:payload`
   monitor syntax.
 - Raw text defaults to `<radio callsign> > APRS` with no digipeater path.
@@ -156,11 +162,16 @@ The first TX pass is intentionally narrow:
 - The window sets DAX TX routing, keys PTT with a short settle/lead time,
   feeds the generated audio in 20 ms chunks, then unkeys and restores the
   previous DAX state.
+- **TXDELAY (preamble) is profile-aware.** HF 300 keeps its long preamble
+  (`kTxPreambleFlags`, ~2.1 s); VHF 1200 uses a shorter one
+  (`kVhf1200TxPreambleFlags` = 64 flags, ~0.43 s) since each flag is 4x quicker
+  at 1200 baud. Raise the VHF value if a transverter's T/R switching clips the
+  start of the burst.
 
 TX diagnostics in the `aether.ax25` category include packet source/destination,
 path, payload bytes, AX.25 frame bytes, bit count, waveform duration, RMS/peak,
-DAX TX stream id, PTT lead/tail timing, and paced chunk progress when debug is
-enabled.
+baud, mark/space, polarity, preamble/postamble flag counts, DAX TX stream id,
+PTT lead/tail timing, and paced chunk progress when debug is enabled.
 
 ## Open Work
 

--- a/docs/MODEM.md
+++ b/docs/MODEM.md
@@ -1,6 +1,8 @@
 # AetherModem AX.25 Notes
 
-This file captures the current 300 baud HF AX.25 modem bring-up notes for the AetherSDR AetherModem window.
+This file captures the AX.25 modem bring-up notes for the AetherSDR AetherModem
+window. It covers the original 300 baud HF profile and the 1200 baud VHF (Bell
+202 / 2m APRS) profile added afterward.
 
 The working test packet has been:
 
@@ -74,6 +76,55 @@ The current build logs:
 - per-frame decode phase offset
 
 The packet activity graph uses AX.25-like candidate deltas rather than raw HDLC candidate deltas, because raw HDLC counts are lane-summed and noisy.
+
+## VHF 1200 baud (Bell 202 / 2m APRS)
+
+The `Vhf1200` profile decodes standard 2m FM APRS (e.g. 144.390 MHz in North
+America), including via a transverter where the radio sits on an HF IF in FM.
+Select it with the **1200 baud VHF** profile button in the AetherModem window.
+
+```text
+sample rate:       24000 Hz
+baud:              1200
+mark:              1200 Hz
+space:             2200 Hz
+samples/symbol:    20
+polarity:          Normal for upright FM-demodulated AFSK
+lanes:             18 (10 free-running phase + 4 tracked phases x 2 PLL alphas)
+```
+
+Unlike HF, 1200 baud uses a **hybrid decode bank** (tuned by `kVhf1200*` in
+`src/core/tnc/AetherAx25LibmodemShim.cpp`) that favors aggressive capture:
+
+- **Free-running phase lanes** (PLL alpha 0, spread across the 20-sample symbol)
+  decode clean / short / strong bursts the instant they arrive — at least one
+  lane samples the eye center, the same proven mechanism as the HF bank. This is
+  what makes the synthetic and chunked 1200 loopback tests decode; a single
+  Gardner-only lane (the original stub) never locked reliably.
+- **Gardner-tracked lanes** (PLL alpha 0.010 and 0.025) chase the symbol clock
+  for TX/RX drift and fading on longer or weaker bursts.
+
+Duplicate suppression collapses the same frame seen by several lanes into one
+emission, so the 18-lane bank still reports each packet once.
+
+Polarity is **Normal** for upright FM-demodulated AFSK; use Reverse only as a
+tone-sense check if a mode/sideband change kills all decodes. TX remains 300
+baud HF only for now — the 1200 profile is receive-only.
+
+### Iterating on 1200 baud
+
+- Enable the **AetherModem** (`aether.ax25`) log category. On every profile
+  switch the modem logs a one-line config summary
+  (`modem configured: 1200 baud VHF ... lanes=18`), and each decode logs
+  `decoded AX.25 frame baud=1200 conf=... SRC=... payload=...`.
+- Click the packet-activity graph to toggle the per-second diagnostics summary
+  (tones, gate, symbols, confidence, HDLC/AX.25 candidates, FCS reject classes)
+  — identical instrumentation to the HF path, now tagged with `baud=`.
+- Replay a saved capture against every profile/polarity in one pass:
+  `ax25_libmodem_shim_test --replay-capture <mono-float32.wav>`. Use the
+  window's **Capture 3m** button to record a real 2m session first.
+- If marginal bursts are missed, raise `kVhf1200FreeRunPhaseCount` for denser
+  fixed-phase coverage, or adjust `kVhf1200PllAlphas` for the tracked lanes.
 
 ## Radio and Level Learnings
 

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -35,7 +35,14 @@ constexpr double kReceiveGateMinimumDbfs = -32.0;
 constexpr double kReceiveGateFloorAlpha = 0.04;
 constexpr double kReceiveGateCloseSeconds = 3.0;
 constexpr int kDuplicateSuppressSeconds = 2;
-constexpr int kTxPreambleFlags = 80;
+// TX preamble (TXDELAY) is the run of leading HDLC flags that lets the far
+// receiver's PLL/AGC settle before frame data. It is profile-specific: HF 300
+// keeps its long preamble, while VHF 1200 uses a shorter one because at 1200
+// baud each flag is 4x quicker (80 flags = 533 ms vs a far more typical ~0.43 s
+// here), trimming dead air and slot time without starving the receiver. Tune
+// kVhf1200TxPreambleFlags if a transverter's T/R switching needs more lead-in.
+constexpr int kTxPreambleFlags = 80;        // HF 300: ~2.13 s of flags
+constexpr int kVhf1200TxPreambleFlags = 64; // VHF 1200: ~0.43 s of flags
 constexpr int kTxPostambleFlags = 8;
 constexpr int kTxVitaPacketFrames = 128;
 constexpr double kTxAfskAmplitude = 0.35;
@@ -956,7 +963,10 @@ Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
     result.polarity = cfg.polarity;
     result.markHz = cfg.markHz;
     result.spaceHz = cfg.spaceHz;
-    result.preambleFlags = kTxPreambleFlags;
+    const int preambleFlags = cfg.profile == Ax25ModemProfile::Vhf1200
+        ? kVhf1200TxPreambleFlags
+        : kTxPreambleFlags;
+    result.preambleFlags = preambleFlags;
     result.postambleFlags = kTxPostambleFlags;
     result.vitaPacketFrames = kTxVitaPacketFrames;
 
@@ -987,7 +997,7 @@ Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
     const std::vector<uint8_t> bits = lm::ax25::encode_bitstream(
         frameBytes,
         0,
-        kTxPreambleFlags,
+        preambleFlags,
         kTxPostambleFlags);
     result.frameBytes = static_cast<int>(frameBytes.size());
     result.bitCount = static_cast<int>(bits.size());
@@ -1031,7 +1041,7 @@ Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
     result.ok = true;
 
     qCInfo(lcAx25).noquote()
-        << QStringLiteral("AX.25 TX packetized SRC=%1 DST=%2 VIA=%3 payloadBytes=%4 frameBytes=%5 bits=%6 samples=%7 duration=%8s levelRms=%9dBFS levelPeak=%10dBFS baud=%11 mark=%12 space=%13 polarity=%14")
+        << QStringLiteral("AX.25 TX packetized SRC=%1 DST=%2 VIA=%3 payloadBytes=%4 frameBytes=%5 bits=%6 samples=%7 duration=%8s levelRms=%9dBFS levelPeak=%10dBFS baud=%11 mark=%12 space=%13 polarity=%14 preamble=%15 postamble=%16")
             .arg(result.frame.source,
                  result.frame.destination,
                  result.frame.path.join(QStringLiteral(",")))
@@ -1047,7 +1057,9 @@ Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
             .arg(result.spaceHz, 0, 'f', 0)
             .arg(result.polarity == Ax25TonePolarity::Normal
                  ? QStringLiteral("Normal")
-                 : QStringLiteral("Reverse"));
+                 : QStringLiteral("Reverse"))
+            .arg(result.preambleFlags)
+            .arg(result.postambleFlags);
     return result;
 }
 

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -212,6 +212,137 @@ void measureStereoFloatPcm(const QByteArray& pcm, double& rmsDbfs, double& peakD
     peakDbfs = toDbfs(peak);
 }
 
+int txPreambleFlagsForProfile(Ax25ModemProfile profile)
+{
+    return profile == Ax25ModemProfile::Vhf1200 ? kVhf1200TxPreambleFlags : kTxPreambleFlags;
+}
+
+// Fill the rate / tone / preamble fields of a TX result from the active config
+// and validate the sample-rate/baud combination. Returns false (with error set)
+// if the combination cannot be rendered.
+bool initTxResult(const Ax25DemodConfig& cfg, Ax25TransmitResult& result)
+{
+    result.sampleRate = cfg.sampleRate;
+    result.baud = cfg.baud;
+    result.polarity = cfg.polarity;
+    result.markHz = cfg.markHz;
+    result.spaceHz = cfg.spaceHz;
+    result.preambleFlags = txPreambleFlagsForProfile(cfg.profile);
+    result.postambleFlags = kTxPostambleFlags;
+    result.vitaPacketFrames = kTxVitaPacketFrames;
+
+    if (cfg.sampleRate <= 0 || cfg.baud <= 0 || cfg.sampleRate % cfg.baud != 0) {
+        result.error = QStringLiteral("unsupported TX sample-rate/baud combination: %1 Hz / %2 baud")
+            .arg(cfg.sampleRate)
+            .arg(cfg.baud);
+        return false;
+    }
+    return true;
+}
+
+// Modulate an encoded AX.25 bitstream into padded stereo float32 AFSK and fill
+// the audio fields of the result. Shared by the text and KISS transmit paths.
+void renderBitsToResult(const std::vector<uint8_t>& bits,
+                        const Ax25DemodConfig& cfg,
+                        Ax25TransmitResult& result)
+{
+    result.bitCount = static_cast<int>(bits.size());
+    const int samplesPerSymbol = cfg.sampleRate / cfg.baud;
+    const int payloadFrames = static_cast<int>(bits.size()) * samplesPerSymbol;
+    const int paddedFrames = ((payloadFrames + kTxVitaPacketFrames - 1) / kTxVitaPacketFrames)
+        * kTxVitaPacketFrames;
+    result.audioFrames = paddedFrames;
+    result.durationSeconds = static_cast<double>(paddedFrames) / static_cast<double>(cfg.sampleRate);
+    result.stereoFloat32Pcm.resize(paddedFrames * 2 * static_cast<int>(sizeof(float)));
+
+    const double mark = cfg.polarity == Ax25TonePolarity::Inverted ? cfg.spaceHz : cfg.markHz;
+    const double space = cfg.polarity == Ax25TonePolarity::Inverted ? cfg.markHz : cfg.spaceHz;
+    double phase = 0.0;
+    int frameIndex = 0;
+    auto* dst = reinterpret_cast<float*>(result.stereoFloat32Pcm.data());
+    for (uint8_t bit : bits) {
+        const double frequency = bit ? mark : space;
+        const double phaseStep = 2.0 * kPi * frequency / static_cast<double>(cfg.sampleRate);
+        for (int i = 0; i < samplesPerSymbol; ++i) {
+            const float sample = static_cast<float>(kTxAfskAmplitude * std::sin(phase));
+            dst[frameIndex * 2] = sample;
+            dst[frameIndex * 2 + 1] = sample;
+            ++frameIndex;
+            phase += phaseStep;
+            if (phase >= 2.0 * kPi)
+                phase -= 2.0 * kPi;
+        }
+    }
+    while (frameIndex < paddedFrames) {
+        dst[frameIndex * 2] = 0.0f;
+        dst[frameIndex * 2 + 1] = 0.0f;
+        ++frameIndex;
+    }
+    measureStereoFloatPcm(result.stereoFloat32Pcm, result.rmsDbfs, result.peakDbfs);
+}
+
+void logTxSummary(const Ax25TransmitResult& result, const QString& via)
+{
+    qCInfo(lcAx25).noquote()
+        << QStringLiteral("AX.25 TX packetized via=%1 SRC=%2 DST=%3 PATH=%4 payloadBytes=%5 "
+                          "frameBytes=%6 bits=%7 samples=%8 duration=%9s levelRms=%10dBFS "
+                          "levelPeak=%11dBFS baud=%12 mark=%13 space=%14 polarity=%15 "
+                          "preamble=%16 postamble=%17")
+            .arg(via,
+                 result.frame.source,
+                 result.frame.destination,
+                 result.frame.path.join(QStringLiteral(",")))
+            .arg(result.frame.payload.size())
+            .arg(result.frameBytes)
+            .arg(result.bitCount)
+            .arg(result.audioFrames)
+            .arg(result.durationSeconds, 0, 'f', 2)
+            .arg(result.rmsDbfs, 0, 'f', 1)
+            .arg(result.peakDbfs, 0, 'f', 1)
+            .arg(result.baud)
+            .arg(result.markHz, 0, 'f', 0)
+            .arg(result.spaceHz, 0, 'f', 0)
+            .arg(result.polarity == Ax25TonePolarity::Normal
+                 ? QStringLiteral("Normal")
+                 : QStringLiteral("Reverse"))
+            .arg(result.preambleFlags)
+            .arg(result.postambleFlags);
+}
+
+// Best-effort decode of raw AX.25 frame bytes (no FCS) into display fields for
+// the TX terminal/log. Returns a frame with payloadHex set if it cannot parse.
+Ax25TransmitFrame transmitFrameFromBytes(const QByteArray& ax25NoFcs)
+{
+    Ax25TransmitFrame out;
+    lm::address from;
+    lm::address to;
+    std::array<lm::address, 8> path = {};
+    std::array<uint8_t, 256> data = {};
+    uint8_t control = 0;
+    uint8_t pid = 0;
+    const auto* begin = reinterpret_cast<const uint8_t*>(ax25NoFcs.constData());
+    const auto* end = begin + ax25NoFcs.size();
+
+    auto [pathOut, dataOut, parsed] = lm::ax25::try_decode_frame_no_fcs(
+        begin, end, from, to, path.begin(), data.begin(), data.size(), control, pid);
+    if (!parsed) {
+        out.payloadHex = QString::fromLatin1(ax25NoFcs.toHex(' ')).toUpper();
+        return out;
+    }
+
+    out.source = addressToString(from);
+    out.destination = addressToString(to);
+    for (auto it = path.begin(); it != pathOut; ++it)
+        out.path.append(addressToString(*it));
+    out.control = control;
+    out.pid = pid;
+    const auto dataLength = static_cast<qsizetype>(std::distance(data.begin(), dataOut));
+    out.payload = QByteArray(reinterpret_cast<const char*>(data.data()), dataLength);
+    out.payloadText = Ax25FrameFormatter::payloadText(out.payload);
+    out.payloadHex = Ax25FrameFormatter::payloadHex(out.payload);
+    return out;
+}
+
 } // namespace
 
 Ax25DemodConfig ax25DemodConfigForProfile(Ax25ModemProfile profile, Ax25TonePolarity polarity)
@@ -713,7 +844,16 @@ struct AetherAx25LibmodemShim::Impl {
         frame.control[0] = control;
         frame.pid = pid;
         frame.crc = actualFcs;
-        return toDecodedFrame(frame, lane.lastQuality, lane.phaseOffsetSamples);
+        Ax25DecodedFrame decodedFrame =
+            toDecodedFrame(frame, lane.lastQuality, lane.phaseOffsetSamples);
+        // Capture the exact on-air frame bytes minus the trailing 2-byte FCS so
+        // the KISS TNC can forward the decode to host apps verbatim.
+        if (candidateFrameBytesSize >= 2) {
+            decodedFrame.ax25FrameNoFcs = QByteArray(
+                reinterpret_cast<const char*>(lane.candidateFrameBytes.data()),
+                static_cast<qsizetype>(candidateFrameBytesSize - 2));
+        }
+        return decodedFrame;
     }
 
     bool shouldEmitFrame(const Ax25DecodedFrame& frame)
@@ -958,24 +1098,8 @@ Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
 {
     Ax25TransmitResult result;
     const auto cfg = m_impl->config;
-    result.sampleRate = cfg.sampleRate;
-    result.baud = cfg.baud;
-    result.polarity = cfg.polarity;
-    result.markHz = cfg.markHz;
-    result.spaceHz = cfg.spaceHz;
-    const int preambleFlags = cfg.profile == Ax25ModemProfile::Vhf1200
-        ? kVhf1200TxPreambleFlags
-        : kTxPreambleFlags;
-    result.preambleFlags = preambleFlags;
-    result.postambleFlags = kTxPostambleFlags;
-    result.vitaPacketFrames = kTxVitaPacketFrames;
-
-    if (cfg.sampleRate <= 0 || cfg.baud <= 0 || cfg.sampleRate % cfg.baud != 0) {
-        result.error = QStringLiteral("unsupported TX sample-rate/baud combination: %1 Hz / %2 baud")
-            .arg(cfg.sampleRate)
-            .arg(cfg.baud);
+    if (!initTxResult(cfg, result))
         return result;
-    }
 
     QString error;
     const std::optional<lm::packet> maybePacket =
@@ -995,71 +1119,44 @@ Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
 
     const std::vector<uint8_t> frameBytes = lm::ax25::encode_frame(packet);
     const std::vector<uint8_t> bits = lm::ax25::encode_bitstream(
-        frameBytes,
-        0,
-        preambleFlags,
-        kTxPostambleFlags);
+        frameBytes, 0, result.preambleFlags, kTxPostambleFlags);
     result.frameBytes = static_cast<int>(frameBytes.size());
-    result.bitCount = static_cast<int>(bits.size());
-
-    const int samplesPerSymbol = cfg.sampleRate / cfg.baud;
-    const int payloadFrames = static_cast<int>(bits.size()) * samplesPerSymbol;
-    const int paddedFrames = ((payloadFrames + kTxVitaPacketFrames - 1) / kTxVitaPacketFrames)
-        * kTxVitaPacketFrames;
-    result.audioFrames = paddedFrames;
-    result.durationSeconds = static_cast<double>(paddedFrames) / static_cast<double>(cfg.sampleRate);
-    result.stereoFloat32Pcm.resize(paddedFrames * 2 * static_cast<int>(sizeof(float)));
-
-    const double mark = cfg.polarity == Ax25TonePolarity::Inverted
-        ? cfg.spaceHz
-        : cfg.markHz;
-    const double space = cfg.polarity == Ax25TonePolarity::Inverted
-        ? cfg.markHz
-        : cfg.spaceHz;
-    double phase = 0.0;
-    int frameIndex = 0;
-    auto* dst = reinterpret_cast<float*>(result.stereoFloat32Pcm.data());
-    for (uint8_t bit : bits) {
-        const double frequency = bit ? mark : space;
-        const double phaseStep = 2.0 * kPi * frequency / static_cast<double>(cfg.sampleRate);
-        for (int i = 0; i < samplesPerSymbol; ++i) {
-            const float sample = static_cast<float>(kTxAfskAmplitude * std::sin(phase));
-            dst[frameIndex * 2] = sample;
-            dst[frameIndex * 2 + 1] = sample;
-            ++frameIndex;
-            phase += phaseStep;
-            if (phase >= 2.0 * kPi)
-                phase -= 2.0 * kPi;
-        }
-    }
-    while (frameIndex < paddedFrames) {
-        dst[frameIndex * 2] = 0.0f;
-        dst[frameIndex * 2 + 1] = 0.0f;
-        ++frameIndex;
-    }
-    measureStereoFloatPcm(result.stereoFloat32Pcm, result.rmsDbfs, result.peakDbfs);
+    renderBitsToResult(bits, cfg, result);
     result.ok = true;
+    logTxSummary(result, QStringLiteral("text"));
+    return result;
+}
 
-    qCInfo(lcAx25).noquote()
-        << QStringLiteral("AX.25 TX packetized SRC=%1 DST=%2 VIA=%3 payloadBytes=%4 frameBytes=%5 bits=%6 samples=%7 duration=%8s levelRms=%9dBFS levelPeak=%10dBFS baud=%11 mark=%12 space=%13 polarity=%14 preamble=%15 postamble=%16")
-            .arg(result.frame.source,
-                 result.frame.destination,
-                 result.frame.path.join(QStringLiteral(",")))
-            .arg(result.frame.payload.size())
-            .arg(result.frameBytes)
-            .arg(result.bitCount)
-            .arg(result.audioFrames)
-            .arg(result.durationSeconds, 0, 'f', 2)
-            .arg(result.rmsDbfs, 0, 'f', 1)
-            .arg(result.peakDbfs, 0, 'f', 1)
-            .arg(result.baud)
-            .arg(result.markHz, 0, 'f', 0)
-            .arg(result.spaceHz, 0, 'f', 0)
-            .arg(result.polarity == Ax25TonePolarity::Normal
-                 ? QStringLiteral("Normal")
-                 : QStringLiteral("Reverse"))
-            .arg(result.preambleFlags)
-            .arg(result.postambleFlags);
+Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudioFromFrame(
+    const QByteArray& ax25NoFcs) const
+{
+    Ax25TransmitResult result;
+    const auto cfg = m_impl->config;
+    if (!initTxResult(cfg, result))
+        return result;
+
+    // Minimum AX.25 UI frame: dest(7) + src(7) + control(1) = 15 bytes.
+    if (ax25NoFcs.size() < 15) {
+        result.error = QStringLiteral("KISS frame too short: %1 bytes (need >= 15)")
+            .arg(ax25NoFcs.size());
+        return result;
+    }
+
+    // The host sends the frame without an FCS; the TNC computes and appends it.
+    std::vector<uint8_t> frameBytes(
+        reinterpret_cast<const uint8_t*>(ax25NoFcs.constData()),
+        reinterpret_cast<const uint8_t*>(ax25NoFcs.constData()) + ax25NoFcs.size());
+    const std::array<uint8_t, 2> crc = lm::ax25::compute_crc(frameBytes.begin(), frameBytes.end());
+    frameBytes.push_back(crc[0]);
+    frameBytes.push_back(crc[1]);
+
+    const std::vector<uint8_t> bits = lm::ax25::encode_bitstream(
+        frameBytes, 0, result.preambleFlags, kTxPostambleFlags);
+    result.frameBytes = static_cast<int>(frameBytes.size());
+    result.frame = transmitFrameFromBytes(ax25NoFcs);
+    renderBitsToResult(bits, cfg, result);
+    result.ok = true;
+    logTxSummary(result, QStringLiteral("kiss"));
     return result;
 }
 

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -48,6 +48,26 @@ constexpr std::array<int, 21> kHf300DecodePhaseOffsets = {
     43, 47, 51, 55, 59, 63, 67, 71, 75, 79
 };
 
+// 1200 baud VHF (Bell 202 / APRS): an aggressive bank of independent correlator
+// demodulators, combining two complementary strategies so the widest range of
+// bursts is captured. Duplicate suppression collapses the same frame seen by
+// several lanes into one emission, like a multi-decoder TNC (e.g. Dire Wolf).
+//
+//   * Free-running lanes (PLL alpha 0) spread evenly across the symbol period.
+//     With no timing loop they sample at a fixed phase, so on a clean burst at
+//     least one lane lands on the eye center and decodes immediately — the same
+//     proven mechanism as the HF bank. Best for short / strong / clean packets.
+//   * Gardner-tracked lanes (PLL alpha > 0) actively chase the symbol clock, so
+//     they tolerate TX/RX clock drift and fading over longer or weaker bursts
+//     where a fixed-phase lane would slip off the eye. A tight and a loose loop
+//     bandwidth bracket clean-vs-fast-acquisition trade-offs.
+//
+// Total lanes = kVhf1200FreeRunPhaseCount
+//             + kVhf1200TrackedPhaseCount * kVhf1200PllAlphas.size().
+constexpr int kVhf1200FreeRunPhaseCount = 10;
+constexpr int kVhf1200TrackedPhaseCount = 4;
+constexpr std::array<double, 2> kVhf1200PllAlphas = { 0.010, 0.025 };
+
 QString fcsToString(const std::array<uint8_t, 2>& fcs)
 {
     return QStringLiteral("%1%2")
@@ -339,9 +359,7 @@ struct AetherAx25LibmodemShim::Impl {
             ? config.markHz
             : config.spaceHz;
 
-        const double pllAlpha = config.profile == Ax25ModemProfile::Hf300 ? 0.0 : 0.015;
-
-        auto addLane = [&](int phaseOffsetSamples) {
+        auto addLane = [&](int phaseOffsetSamples, double pllAlpha) {
             auto& lane = lanes.emplace_back();
             lane.phaseOffsetSamples = phaseOffsetSamples;
             lane.samplesUntilStart = phaseOffsetSamples;
@@ -362,12 +380,46 @@ struct AetherAx25LibmodemShim::Impl {
         };
 
         if (config.profile == Ax25ModemProfile::Hf300) {
+            // HF: free-running lanes (pll_alpha 0), recovery by phase diversity.
             for (int phaseOffset : kHf300DecodePhaseOffsets)
-                addLane(phaseOffset);
+                addLane(phaseOffset, 0.0);
         } else {
-            addLane(0);
+            // VHF 1200: hybrid bank. Phase offsets are derived from the symbol
+            // period so the spread stays correct if the sample rate ever changes.
+            const int samplesPerSymbol = config.baud > 0
+                ? config.sampleRate / config.baud
+                : 0;
+            if (samplesPerSymbol <= 0) {
+                addLane(0, 0.0);
+            } else {
+                // Free-running phase-diversity lanes — decode clean/short bursts.
+                for (int phase = 0; phase < kVhf1200FreeRunPhaseCount; ++phase) {
+                    const int phaseOffset = (samplesPerSymbol * phase) / kVhf1200FreeRunPhaseCount;
+                    addLane(phaseOffset, 0.0);
+                }
+                // Gardner-tracked lanes — follow clock drift on long/weak bursts.
+                for (int phase = 0; phase < kVhf1200TrackedPhaseCount; ++phase) {
+                    const int phaseOffset = (samplesPerSymbol * phase) / kVhf1200TrackedPhaseCount;
+                    for (double laneAlpha : kVhf1200PllAlphas)
+                        addLane(phaseOffset, laneAlpha);
+                }
+            }
         }
         resetDecoderState(true, true);
+
+        qCInfo(lcAx25).noquote()
+            << QStringLiteral("modem configured: %1 sampleRate=%2Hz baud=%3 samplesPerSymbol=%4 "
+                              "mark=%5Hz space=%6Hz polarity=%7 lanes=%8")
+                   .arg(ax25ModemProfileName(config.profile))
+                   .arg(config.sampleRate)
+                   .arg(config.baud)
+                   .arg(config.baud > 0 ? config.sampleRate / config.baud : 0)
+                   .arg(mark, 0, 'f', 0)
+                   .arg(space, 0, 'f', 0)
+                   .arg(config.polarity == Ax25TonePolarity::Inverted
+                        ? QStringLiteral("Reverse")
+                        : QStringLiteral("Normal"))
+                   .arg(lanes.size());
     }
 
     void resetDecoderState(bool clearCounters, bool clearDiagnostics)
@@ -1026,8 +1078,10 @@ void AetherAx25LibmodemShim::feedAudio(const QByteArray& monoFloat32Pcm, int sam
     const auto* samples = reinterpret_cast<const float*>(monoFloat32Pcm.constData());
     const QVector<Ax25DecodedFrame> frames = processMonoFloat(samples, sampleCount, sampleRate);
     for (const auto& frame : frames) {
-        qCDebug(lcAx25).noquote()
-            << QStringLiteral("decoded AX.25 frame SRC=%1 DST=%2 VIA=%3 UI=%4 pid=%5 phase=%6 payload=%7")
+        qCInfo(lcAx25).noquote()
+            << QStringLiteral("decoded AX.25 frame baud=%1 conf=%2 SRC=%3 DST=%4 VIA=%5 UI=%6 pid=%7 phase=%8 payload=%9")
+                .arg(m_impl->config.baud)
+                .arg(frame.confidenceOrQuality, 0, 'f', 2)
                 .arg(frame.source,
                      frame.destination,
                      frame.path.join(QStringLiteral(",")),
@@ -1040,7 +1094,8 @@ void AetherAx25LibmodemShim::feedAudio(const QByteArray& monoFloat32Pcm, int sam
     if (auto diagnostics = m_impl->takeDiagnosticsIfReady(sampleRate)) {
         if (m_impl->diagnosticsLoggingEnabled) {
             qCDebug(lcAx25).nospace()
-                << "sr=" << diagnostics->sampleRate
+                << "baud=" << m_impl->config.baud
+                << " sr=" << diagnostics->sampleRate
                 << " rms=" << QString::number(diagnostics->rmsDbfs, 'f', 1) << "dBFS"
                 << " peak=" << QString::number(diagnostics->peakDbfs, 'f', 1) << "dBFS"
                 << " clip=" << QString::number(diagnostics->clippedPercent, 'f', 2) << "%"

--- a/src/core/tnc/AetherAx25LibmodemShim.h
+++ b/src/core/tnc/AetherAx25LibmodemShim.h
@@ -126,6 +126,10 @@ public:
     Ax25TransmitResult buildTransmitAudio(const QString& text,
                                           const QString& defaultSource,
                                           const QString& defaultDestination = QStringLiteral("APRS")) const;
+    // Build TX audio from a raw AX.25 frame (address..info, no FCS), e.g. the
+    // payload of a KISS data frame from a host application. The FCS is computed
+    // and appended here before HDLC framing and AFSK modulation.
+    Ax25TransmitResult buildTransmitAudioFromFrame(const QByteArray& ax25NoFcs) const;
 
     Ax25DecoderDiagnostics diagnosticsSnapshot() const;
     QString demodDescription() const;

--- a/src/core/tnc/Ax25DecodedFrame.h
+++ b/src/core/tnc/Ax25DecodedFrame.h
@@ -27,6 +27,10 @@ struct Ax25DecodedFrame {
     bool fcsOk{false};
     double confidenceOrQuality{0.0};
     int decodePhaseOffsetSamples{-1};
+    // Raw on-air AX.25 frame bytes (address through info), WITHOUT HDLC flags or
+    // the 2-byte FCS — i.e. exactly the payload of a KISS data frame, so the TNC
+    // can forward a decode to host applications byte-for-byte.
+    QByteArray ax25FrameNoFcs;
 };
 
 } // namespace AetherSDR

--- a/src/core/tnc/KissFraming.cpp
+++ b/src/core/tnc/KissFraming.cpp
@@ -1,0 +1,109 @@
+#include "core/tnc/KissFraming.h"
+
+namespace AetherSDR::kiss {
+
+QByteArray escape(const QByteArray& in)
+{
+    QByteArray out;
+    out.reserve(in.size() + 8);
+    for (const char ch : in) {
+        const quint8 b = static_cast<quint8>(ch);
+        if (b == kFend) {
+            out.append(static_cast<char>(kFesc));
+            out.append(static_cast<char>(kTfend));
+        } else if (b == kFesc) {
+            out.append(static_cast<char>(kFesc));
+            out.append(static_cast<char>(kTfesc));
+        } else {
+            out.append(ch);
+        }
+    }
+    return out;
+}
+
+QByteArray unescape(const QByteArray& in)
+{
+    QByteArray out;
+    out.reserve(in.size());
+    bool escape = false;
+    for (const char ch : in) {
+        const quint8 b = static_cast<quint8>(ch);
+        if (escape) {
+            if (b == kTfend) {
+                out.append(static_cast<char>(kFend));
+            } else if (b == kTfesc) {
+                out.append(static_cast<char>(kFesc));
+            } else {
+                out.append(ch); // invalid escape — keep the byte literally
+            }
+            escape = false;
+        } else if (b == kFesc) {
+            escape = true;
+        } else {
+            out.append(ch);
+        }
+    }
+    return out;
+}
+
+QByteArray encodeDataFrame(const QByteArray& ax25NoFcs, quint8 port)
+{
+    QByteArray out;
+    out.reserve(ax25NoFcs.size() + 4);
+    out.append(static_cast<char>(kFend));
+    out.append(static_cast<char>((port << 4) | kCmdData));
+    out.append(escape(ax25NoFcs));
+    out.append(static_cast<char>(kFend));
+    return out;
+}
+
+QVector<QByteArray> Decoder::feed(const QByteArray& bytes)
+{
+    QVector<QByteArray> frames;
+    for (const char ch : bytes) {
+        const quint8 b = static_cast<quint8>(ch);
+
+        if (b == kFend) {
+            if (m_synced && !m_overflow && !m_frame.isEmpty())
+                frames.append(unescape(m_frame));
+            m_frame.clear();
+            m_synced = true;
+            m_overflow = false;
+            continue;
+        }
+
+        if (!m_synced)
+            continue; // ignore bytes before the first frame boundary
+
+        if (m_overflow)
+            continue; // drop the rest of an oversized frame until next FEND
+
+        m_frame.append(ch);
+        if (m_frame.size() > kMaxFrameBytes) {
+            m_frame.clear();
+            m_overflow = true;
+        }
+    }
+    return frames;
+}
+
+void Decoder::reset()
+{
+    m_frame.clear();
+    m_synced = false;
+    m_overflow = false;
+}
+
+bool splitTypeByte(const QByteArray& frameWithType, quint8& port, quint8& command,
+                   QByteArray& payload)
+{
+    if (frameWithType.isEmpty())
+        return false;
+    const quint8 type = static_cast<quint8>(frameWithType.at(0));
+    port = (type >> 4) & 0x0F;
+    command = type & 0x0F;
+    payload = frameWithType.mid(1);
+    return true;
+}
+
+} // namespace AetherSDR::kiss

--- a/src/core/tnc/KissFraming.h
+++ b/src/core/tnc/KissFraming.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <QByteArray>
+#include <QVector>
+#include <QtGlobal>
+
+// Pure KISS (Keep It Simple Stupid) TNC framing — no Qt::Network dependency so
+// it can be unit-tested standalone. KISS wraps raw AX.25 frames (address through
+// info, WITHOUT the HDLC flags or FCS) for exchange with a host APRS/packet
+// application over a serial or TCP link.
+//
+// Reference: the KISS protocol (Chepponis & Karn, 1987).
+
+namespace AetherSDR::kiss {
+
+constexpr quint8 kFend = 0xC0;  // Frame End delimiter
+constexpr quint8 kFesc = 0xDB;  // Frame Escape
+constexpr quint8 kTfend = 0xDC; // Transposed Frame End
+constexpr quint8 kTfesc = 0xDD; // Transposed Frame Escape
+
+// Low-nibble command codes of the KISS type byte (high nibble = port).
+constexpr quint8 kCmdData = 0x00;
+constexpr quint8 kCmdTxDelay = 0x01;
+constexpr quint8 kCmdPersistence = 0x02;
+constexpr quint8 kCmdSlotTime = 0x03;
+constexpr quint8 kCmdTxTail = 0x04;
+constexpr quint8 kCmdFullDuplex = 0x05;
+constexpr quint8 kCmdSetHardware = 0x06;
+constexpr quint8 kCmdReturn = 0xFF;
+
+// Largest in-progress KISS frame we will buffer before treating the stream as
+// garbage and resyncing. A full AX.25 frame is well under 512 bytes; this is a
+// generous guard against a runaway/desynced client.
+constexpr int kMaxFrameBytes = 4096;
+
+// Escape FEND/FESC occurrences in a payload per the KISS transposition rules.
+QByteArray escape(const QByteArray& in);
+
+// Reverse of escape(). Lone/!invalid escapes are passed through literally.
+QByteArray unescape(const QByteArray& in);
+
+// Wrap a raw AX.25 frame (no FCS) as a complete KISS data frame:
+//   FEND, (port<<4 | CmdData), <escaped bytes>, FEND
+QByteArray encodeDataFrame(const QByteArray& ax25NoFcs, quint8 port = 0);
+
+// Incremental, resync-safe KISS deframer. Feed arbitrary byte chunks from a
+// socket; returns any complete frames. Each returned frame includes its leading
+// type byte (so callers can read the port/command) and is already unescaped.
+class Decoder {
+public:
+    QVector<QByteArray> feed(const QByteArray& bytes);
+    void reset();
+
+    // True once we have seen our first FEND and are tracking a frame boundary.
+    bool synced() const { return m_synced; }
+
+private:
+    QByteArray m_frame;
+    bool m_synced = false;
+    bool m_overflow = false;
+};
+
+// Convenience: split a complete (unescaped) KISS frame into its command nibble,
+// port, and payload (everything after the type byte). Returns false if empty.
+bool splitTypeByte(const QByteArray& frameWithType, quint8& port, quint8& command,
+                   QByteArray& payload);
+
+} // namespace AetherSDR::kiss

--- a/src/core/tnc/KissTncServer.cpp
+++ b/src/core/tnc/KissTncServer.cpp
@@ -1,0 +1,251 @@
+#include "core/tnc/KissTncServer.h"
+
+#include "core/LogManager.h"
+
+#include <QHostAddress>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QTimer>
+
+namespace AetherSDR {
+
+KissTncServer::KissTncServer(QObject* parent)
+    : QObject(parent)
+{
+}
+
+KissTncServer::~KissTncServer()
+{
+    stop();
+}
+
+bool KissTncServer::start(quint16 port)
+{
+    stop();
+
+    m_server = new QTcpServer(this);
+    connect(m_server, &QTcpServer::newConnection, this, &KissTncServer::onNewConnection);
+
+    if (!m_server->listen(QHostAddress::Any, port)) {
+        m_lastError = m_server->errorString();
+        qCWarning(lcAx25).noquote()
+            << QStringLiteral("KISS TNC failed to listen on port %1: %2").arg(port).arg(m_lastError);
+        emit activity(QStringLiteral("KISS TNC could not bind port %1: %2").arg(port).arg(m_lastError));
+        m_server->deleteLater();
+        m_server = nullptr;
+        return false;
+    }
+
+    m_port = port;
+    m_lastError.clear();
+    m_framesToClients = 0;
+    m_framesFromClients = 0;
+
+    m_sweepTimer = new QTimer(this);
+    m_sweepTimer->setInterval(kSweepIntervalMs);
+    connect(m_sweepTimer, &QTimer::timeout, this, &KissTncServer::onSweepTimer);
+    m_sweepTimer->start();
+
+    qCInfo(lcAx25).noquote()
+        << QStringLiteral("KISS TNC listening on TCP port %1 (all interfaces), maxClients=%2")
+               .arg(port).arg(m_maxClients);
+    emit activity(QStringLiteral("KISS TNC listening on TCP port %1.").arg(port));
+    emit listeningChanged(true);
+    return true;
+}
+
+void KissTncServer::stop()
+{
+    if (m_sweepTimer) {
+        m_sweepTimer->stop();
+        m_sweepTimer->deleteLater();
+        m_sweepTimer = nullptr;
+    }
+
+    const bool wasListening = m_server != nullptr;
+    const int hadClients = m_clients.size();
+
+    for (auto it = m_clients.begin(); it != m_clients.end(); ++it) {
+        QTcpSocket* socket = it.key();
+        socket->disconnect(this); // stop our slots firing during teardown
+        socket->abort();
+        socket->deleteLater();
+    }
+    m_clients.clear();
+
+    if (m_server) {
+        m_server->close();
+        m_server->deleteLater();
+        m_server = nullptr;
+    }
+
+    if (wasListening) {
+        qCInfo(lcAx25).noquote()
+            << QStringLiteral("KISS TNC stopped (closed %1 client(s)).").arg(hadClients);
+        emit activity(QStringLiteral("KISS TNC stopped."));
+        emit listeningChanged(false);
+        emitClientCount();
+    }
+}
+
+bool KissTncServer::isListening() const
+{
+    return m_server != nullptr && m_server->isListening();
+}
+
+void KissTncServer::onNewConnection()
+{
+    if (!m_server)
+        return;
+
+    while (QTcpSocket* socket = m_server->nextPendingConnection()) {
+        if (m_clients.size() >= m_maxClients) {
+            const QString peer = QStringLiteral("%1:%2")
+                .arg(socket->peerAddress().toString()).arg(socket->peerPort());
+            qCWarning(lcAx25).noquote()
+                << QStringLiteral("KISS TNC refused %1: client limit (%2) reached")
+                       .arg(peer).arg(m_maxClients);
+            emit activity(QStringLiteral("KISS TNC refused %1 (client limit reached).").arg(peer));
+            socket->abort();
+            socket->deleteLater();
+            continue;
+        }
+
+        // TCP keepalive lets the OS reap a peer that vanished without a FIN.
+        socket->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
+        socket->setSocketOption(QAbstractSocket::LowDelayOption, 1); // Nagle off: small KISS frames
+
+        Client client;
+        client.peer = QStringLiteral("%1:%2")
+            .arg(socket->peerAddress().toString()).arg(socket->peerPort());
+        client.lastActivity.start();
+        m_clients.insert(socket, client);
+
+        connect(socket, &QTcpSocket::readyRead, this, &KissTncServer::onReadyRead);
+        connect(socket, &QTcpSocket::disconnected, this, &KissTncServer::onDisconnected);
+
+        qCInfo(lcAx25).noquote()
+            << QStringLiteral("KISS TNC client connected: %1 (now %2 client(s))")
+                   .arg(client.peer).arg(m_clients.size());
+        emit activity(QStringLiteral("KISS client connected: %1.").arg(client.peer));
+        emitClientCount();
+    }
+}
+
+void KissTncServer::onReadyRead()
+{
+    auto* socket = qobject_cast<QTcpSocket*>(sender());
+    if (!socket)
+        return;
+    auto it = m_clients.find(socket);
+    if (it == m_clients.end())
+        return;
+
+    it->lastActivity.restart();
+    const QByteArray chunk = socket->readAll();
+    const QVector<QByteArray> frames = it->decoder.feed(chunk);
+
+    for (const QByteArray& frame : frames) {
+        quint8 portNibble = 0;
+        quint8 command = 0;
+        QByteArray payload;
+        if (!kiss::splitTypeByte(frame, portNibble, command, payload))
+            continue;
+
+        if (command == kiss::kCmdData) {
+            if (payload.isEmpty())
+                continue;
+            ++m_framesFromClients;
+            qCDebug(lcAx25).noquote()
+                << QStringLiteral("KISS TX from %1: %2 AX.25 bytes (frame #%3)")
+                       .arg(it->peer).arg(payload.size()).arg(m_framesFromClients);
+            emit ax25FrameFromClient(payload);
+        } else if (command == kiss::kCmdReturn) {
+            qCDebug(lcAx25).noquote()
+                << QStringLiteral("KISS exit (return) from %1 — ignored on a TCP link").arg(it->peer);
+        } else {
+            qCDebug(lcAx25).noquote()
+                << QStringLiteral("KISS param from %1: cmd=0x%2 bytes=%3")
+                       .arg(it->peer).arg(command, 2, 16, QLatin1Char('0')).arg(payload.size());
+            emit kissParameterReceived(command, payload);
+        }
+    }
+}
+
+void KissTncServer::broadcastAx25Frame(const QByteArray& ax25NoFcs)
+{
+    if (ax25NoFcs.isEmpty() || m_clients.isEmpty())
+        return;
+
+    const QByteArray kissFrame = kiss::encodeDataFrame(ax25NoFcs);
+    int delivered = 0;
+    QVector<QTcpSocket*> slowConsumers;
+    for (auto it = m_clients.begin(); it != m_clients.end(); ++it) {
+        QTcpSocket* socket = it.key();
+        if (socket->state() != QAbstractSocket::ConnectedState)
+            continue;
+        if (socket->bytesToWrite() > kMaxWriteBacklogBytes) {
+            slowConsumers.append(socket);
+            continue;
+        }
+        socket->write(kissFrame);
+        ++delivered;
+    }
+
+    if (delivered > 0)
+        ++m_framesToClients;
+
+    qCDebug(lcAx25).noquote()
+        << QStringLiteral("KISS RX broadcast: %1 AX.25 bytes to %2 client(s) (frame #%3)")
+               .arg(ax25NoFcs.size()).arg(delivered).arg(m_framesToClients);
+
+    for (QTcpSocket* socket : slowConsumers)
+        closeClient(socket, QStringLiteral("write backlog exceeded (slow consumer)"));
+}
+
+void KissTncServer::onDisconnected()
+{
+    auto* socket = qobject_cast<QTcpSocket*>(sender());
+    if (!socket)
+        return;
+    closeClient(socket, QStringLiteral("disconnected"));
+}
+
+void KissTncServer::onSweepTimer()
+{
+    QVector<QTcpSocket*> stale;
+    for (auto it = m_clients.begin(); it != m_clients.end(); ++it) {
+        if (it->lastActivity.isValid() && it->lastActivity.elapsed() > kIdleTimeoutMs)
+            stale.append(it.key());
+    }
+    for (QTcpSocket* socket : stale)
+        closeClient(socket, QStringLiteral("idle timeout"));
+}
+
+void KissTncServer::closeClient(QTcpSocket* socket, const QString& reason)
+{
+    auto it = m_clients.find(socket);
+    if (it == m_clients.end()) {
+        socket->deleteLater();
+        return;
+    }
+    const QString peer = it->peer;
+    m_clients.erase(it);
+
+    socket->disconnect(this);
+    socket->abort();
+    socket->deleteLater();
+
+    qCInfo(lcAx25).noquote()
+        << QStringLiteral("KISS TNC client %1 closed: %2 (now %3 client(s))")
+               .arg(peer, reason).arg(m_clients.size());
+    emit activity(QStringLiteral("KISS client %1 closed: %2.").arg(peer, reason));
+    emitClientCount();
+}
+
+void KissTncServer::emitClientCount()
+{
+    emit clientCountChanged(m_clients.size());
+}
+
+} // namespace AetherSDR

--- a/src/core/tnc/KissTncServer.h
+++ b/src/core/tnc/KissTncServer.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "core/tnc/KissFraming.h"
+
+#include <QByteArray>
+#include <QElapsedTimer>
+#include <QHash>
+#include <QObject>
+#include <QString>
+
+class QTcpServer;
+class QTcpSocket;
+class QTimer;
+
+namespace AetherSDR {
+
+// A KISS-over-TCP TNC server. Host applications (APRS clients, terminal/packet
+// programs, Dire Wolf-style tools) connect over TCP and exchange raw AX.25
+// frames in KISS framing; AetherModem provides the AFSK modem underneath.
+//
+// - Cross-platform (Qt QTcpServer/QTcpSocket).
+// - Multiple simultaneous clients; each gets its own resync-safe KISS decoder.
+// - TCP keepalive plus slow-consumer and optional idle timeouts so dead or
+//   stuck clients are reaped rather than leaking sockets/memory.
+// - All lifecycle and per-frame activity is logged on the aether.ax25 category
+//   (prefixed "KISS") so issues can be triaged as client-side vs RF-side.
+class KissTncServer : public QObject {
+    Q_OBJECT
+
+public:
+    explicit KissTncServer(QObject* parent = nullptr);
+    ~KissTncServer() override;
+
+    // Start listening on the given TCP port (all interfaces). Returns true on
+    // success; on failure lastError() explains why and listeningChanged stays
+    // false. Restarting on a new port is a stop() + start().
+    bool start(quint16 port);
+    void stop();
+
+    bool isListening() const;
+    quint16 port() const { return m_port; }
+    int clientCount() const { return m_clients.size(); }
+    QString lastError() const { return m_lastError; }
+
+    quint64 framesToClients() const { return m_framesToClients; }
+    quint64 framesFromClients() const { return m_framesFromClients; }
+
+    // Max simultaneous clients; further connections are refused. Default 8.
+    void setMaxClients(int n) { m_maxClients = n; }
+
+public slots:
+    // RX path: an AX.25 frame (address..info, no FCS) was decoded off the air;
+    // fan it out to every connected client as a KISS data frame.
+    void broadcastAx25Frame(const QByteArray& ax25NoFcs);
+
+signals:
+    // TX path: a client sent a KISS data frame; payload is the raw AX.25 frame
+    // (no FCS) to key onto the air.
+    void ax25FrameFromClient(const QByteArray& ax25NoFcs);
+
+    // A non-data KISS command (TXDELAY, persistence, etc.) arrived.
+    void kissParameterReceived(quint8 command, const QByteArray& value);
+
+    void listeningChanged(bool listening);
+    void clientCountChanged(int count);
+
+    // Human-readable lifecycle line for the AetherModem window terminal.
+    void activity(const QString& message);
+
+private slots:
+    void onNewConnection();
+    void onReadyRead();
+    void onDisconnected();
+    void onSweepTimer();
+
+private:
+    struct Client {
+        kiss::Decoder decoder;
+        QElapsedTimer lastActivity;
+        QString peer;
+    };
+
+    void closeClient(QTcpSocket* socket, const QString& reason);
+    void emitClientCount();
+
+    QTcpServer* m_server = nullptr;
+    QHash<QTcpSocket*, Client> m_clients;
+    QTimer* m_sweepTimer = nullptr;
+    quint16 m_port = 8001;
+    int m_maxClients = 8;
+    QString m_lastError;
+    quint64 m_framesToClients = 0;
+    quint64 m_framesFromClients = 0;
+
+    // Drop a client whose unsent backlog exceeds this (slow/stuck consumer).
+    static constexpr qint64 kMaxWriteBacklogBytes = 256 * 1024;
+    // Drop a client idle (no bytes received) longer than this. Generous because
+    // a legitimate KISS client may sit quiet for long stretches; TCP keepalive
+    // is the primary dead-peer detector.
+    static constexpr qint64 kIdleTimeoutMs = 30 * 60 * 1000;
+    static constexpr int kSweepIntervalMs = 30 * 1000;
+};
+
+} // namespace AetherSDR

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -6,10 +6,12 @@
 #include "core/LogManager.h"
 #include "core/ThemeManager.h"
 #include "core/tnc/Ax25FrameFormatter.h"
+#include "core/tnc/KissTncServer.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
 
+#include <QButtonGroup>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDateTime>
@@ -25,7 +27,10 @@
 #include <QPushButton>
 #include <QRadioButton>
 #include <QScrollBar>
+#include <QSignalBlocker>
 #include <QSizePolicy>
+#include <QSpinBox>
+#include <QStackedWidget>
 #include <QTextDocument>
 #include <QTextEdit>
 #include <QTimer>
@@ -41,8 +46,11 @@ namespace AetherSDR {
 namespace {
 
 constexpr auto kPacketDecoderProfileSetting = "Ax25PacketDecoderProfile";
-constexpr auto kPacketDecoderPolaritySetting = "Ax25PacketDecoderPolarity";
 constexpr auto kPacketDecoderDebugSetting = "Ax25PacketDecoderDiagnosticsDebug";
+constexpr auto kTncEnabledSetting = "AetherModemKissTncEnabled";
+constexpr auto kTncStartOnStartupSetting = "AetherModemKissTncStartOnStartup";
+constexpr auto kTncPortSetting = "AetherModemKissTncPort";
+constexpr int kTncDefaultPort = 8001;
 constexpr int kAudioCaptureSeconds = 180;
 constexpr int kTxDaxSettleMs = 150;
 constexpr int kTxLeadMs = 200;
@@ -239,22 +247,6 @@ Ax25ModemProfile profileFromSettingsValue(const QString& value)
     return Ax25ModemProfile::Hf300;
 }
 
-QString polaritySettingsValue(Ax25TonePolarity polarity)
-{
-    return polarity == Ax25TonePolarity::Inverted
-        ? QStringLiteral("Reverse")
-        : QStringLiteral("Normal");
-}
-
-Ax25TonePolarity polarityFromSettingsValue(const QString& value)
-{
-    if (value.compare(QStringLiteral("Reverse"), Qt::CaseInsensitive) == 0
-        || value.compare(QStringLiteral("Inverted"), Qt::CaseInsensitive) == 0) {
-        return Ax25TonePolarity::Inverted;
-    }
-    return Ax25TonePolarity::Normal;
-}
-
 QLabel* sectionLabel(const QString& text, QWidget* parent)
 {
     auto* label = new QLabel(text, parent);
@@ -389,12 +381,12 @@ public:
         : QWidget(parent)
         , m_levels(68)
     {
-        setMinimumHeight(38);
+        setMinimumHeight(56);
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         setCursor(Qt::PointingHandCursor);
         updateToolTip();
         for (int i = 0; i < m_levels.size(); ++i)
-            m_levels[i] = 4 + ((i * 7) % 6);
+            m_levels[i] = 6 + ((i * 7) % 8);
     }
 
     void setDebugEnabled(bool enabled)
@@ -411,12 +403,15 @@ public:
         m_clickHandler = std::move(handler);
     }
 
+    // Bar levels are pixel heights against the (taller) usable height; values
+    // are scaled so even one or two packets/sec produce a clearly visible spike
+    // rather than sitting on the floor.
     void recordFrame()
     {
         m_cursor = (m_cursor + 9) % m_levels.size();
-        m_levels[m_cursor] = 30;
+        m_levels[m_cursor] = 46;
         if (m_cursor + 3 < m_levels.size())
-            m_levels[m_cursor + 3] = 18;
+            m_levels[m_cursor + 3] = 28;
         update();
     }
 
@@ -426,11 +421,11 @@ public:
             return;
 
         m_cursor = (m_cursor + 1) % m_levels.size();
-        int level = receiveGateOpen ? 9 : 3;
+        int level = receiveGateOpen ? 16 : 6;
         if (hdlcCandidates > 0)
-            level = std::max(level, 9 + std::min(14, hdlcCandidates * 3));
+            level = std::max(level, 16 + std::min(28, hdlcCandidates * 5));
         if (acceptedFrames > 0)
-            level = 30;
+            level = 46;
         m_levels[m_cursor] = level;
         update();
     }
@@ -438,7 +433,7 @@ public:
     void reset()
     {
         for (int i = 0; i < m_levels.size(); ++i)
-            m_levels[i] = 3 + ((i * 5) % 5);
+            m_levels[i] = 6 + ((i * 5) % 7);
         m_cursor = 0;
         update();
     }
@@ -504,7 +499,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
                                                    RadioModel* radio,
                                                    SliceModel* initialSlice,
                                                    QWidget* parent)
-    : PersistentDialog(QStringLiteral("AetherModem - Packet Decoder (Experimental)"),
+    : PersistentDialog(QStringLiteral("AetherModem"),
                        QStringLiteral("Ax25HfPacketDecodeDialogGeometry"),
                        parent)
     , m_audio(audio)
@@ -514,6 +509,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     setMinimumSize(1080, 680);
 
     m_shim = new AetherAx25LibmodemShim(this);
+    m_kissServer = new KissTncServer(this);
     m_heartbeatTimer = new QTimer(this);
     m_heartbeatTimer->setInterval(1000);
     m_txPaceTimer = new QTimer(this);
@@ -523,35 +519,35 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(10);
 
-    // Em-dash is — (U+2014).  Don't use the byte-escape \xE2\x80\x94 form
-    // here — inside QStringLiteral the literal expands to a UTF-16 (u"...")
-    // string where each \xXX is a single char16_t code unit, not a byte of a
-    // multi-byte UTF-8 sequence.  Three separate code units (0x00E2, 0x0080,
-    // 0x0094) render as "â" + two control glyphs, which is what shipped.
-    auto* experimentalBanner = new QLabel(
-        QStringLiteral("<b>Experimental — AX.25 modem bring-up.</b> "
-                       "300 baud HF and 1200 baud VHF (Bell 202 / 2m APRS) "
-                       "AX.25 receive and transmit are active."),
-        bodyWidget());
-    experimentalBanner->setObjectName(QStringLiteral("ExperimentalBanner"));
-    experimentalBanner->setWordWrap(true);
-    experimentalBanner->setTextFormat(Qt::RichText);
-    root->addWidget(experimentalBanner);
-
     auto* tabsFrame = panel(QStringLiteral("TabsFrame"), bodyWidget());
     auto* tabs = new QHBoxLayout(tabsFrame);
     tabs->setContentsMargins(0, 0, 0, 0);
     tabs->setSpacing(0);
-    tabs->addWidget(tabButton(QStringLiteral("AX.25"), true, tabsFrame), 1);
-    auto* terminalTab = tabButton(QStringLiteral("Terminal"), false, tabsFrame);
-    terminalTab->setVisible(false);
-    tabs->addWidget(terminalTab, 1);
-    auto* mailboxTab = tabButton(QStringLiteral("Mailbox"), false, tabsFrame);
-    mailboxTab->setVisible(false);
-    tabs->addWidget(mailboxTab, 1);
+    m_ax25Tab = tabButton(QStringLiteral("AX.25"), true, tabsFrame);
+    m_kissTab = tabButton(QStringLiteral("KISS TNC"), false, tabsFrame);
+    m_ax25Tab->setEnabled(true);
+    m_kissTab->setEnabled(true);
+    auto* tabGroup = new QButtonGroup(this);
+    tabGroup->setExclusive(true);
+    tabGroup->addButton(m_ax25Tab, 0);
+    tabGroup->addButton(m_kissTab, 1);
+    tabs->addWidget(m_ax25Tab, 1);
+    tabs->addWidget(m_kissTab, 1);
     root->addWidget(tabsFrame);
 
-    auto* controlsFrame = panel(QStringLiteral("ControlsFrame"), bodyWidget());
+    m_tabStack = new QStackedWidget(bodyWidget());
+    root->addWidget(m_tabStack);
+    connect(tabGroup, &QButtonGroup::idClicked, m_tabStack, &QStackedWidget::setCurrentIndex);
+
+    // AX.25 page: modem config + transmit. The log and status row below the
+    // stack are shared by both tabs.
+    auto* ax25Page = new QWidget(m_tabStack);
+    auto* ax25PageLayout = new QVBoxLayout(ax25Page);
+    ax25PageLayout->setContentsMargins(0, 0, 0, 0);
+    ax25PageLayout->setSpacing(10);
+    m_tabStack->addWidget(ax25Page);
+
+    auto* controlsFrame = panel(QStringLiteral("ControlsFrame"), ax25Page);
     auto* controls = new QHBoxLayout(controlsFrame);
     controls->setContentsMargins(16, 14, 16, 14);
     controls->setSpacing(20);
@@ -579,22 +575,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_enableDecode = new QCheckBox(QStringLiteral("Enable Modem"), modemCell);
     modemLayout->addWidget(m_enableDecode);
     controls->addWidget(modemCell, 1);
-
-    auto* polarityCell = panel(QStringLiteral("ControlCell"), controlsFrame);
-    auto* polarityLayout = new QVBoxLayout(polarityCell);
-    polarityLayout->setContentsMargins(0, 0, 20, 0);
-    polarityLayout->setSpacing(12);
-    polarityLayout->addWidget(sectionLabel(QStringLiteral("TONE POLARITY"), polarityCell));
-    auto* polarityButtons = new QHBoxLayout;
-    polarityButtons->setSpacing(34);
-    m_polarityNormal = new QRadioButton(QStringLiteral("Normal"), polarityCell);
-    m_polarityReverse = new QRadioButton(QStringLiteral("Reverse"), polarityCell);
-    m_polarityNormal->setChecked(true);
-    polarityButtons->addWidget(m_polarityNormal);
-    polarityButtons->addWidget(m_polarityReverse);
-    polarityButtons->addStretch(1);
-    polarityLayout->addLayout(polarityButtons);
-    controls->addWidget(polarityCell, 2);
+    controls->addStretch(2);
 
     m_captureButton = new QPushButton(QStringLiteral("Capture 3m"), controlsFrame);
     m_captureButton->setMinimumHeight(42);
@@ -603,9 +584,9 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_clearButton = new QPushButton(QStringLiteral("Clear Log"), controlsFrame);
     m_clearButton->setMinimumHeight(42);
     controls->addWidget(m_clearButton);
-    root->addWidget(controlsFrame);
+    ax25PageLayout->addWidget(controlsFrame);
 
-    auto* txFrame = panel(QStringLiteral("ControlsFrame"), bodyWidget());
+    auto* txFrame = panel(QStringLiteral("ControlsFrame"), ax25Page);
     auto* txLayout = new QHBoxLayout(txFrame);
     txLayout->setContentsMargins(16, 12, 16, 12);
     txLayout->setSpacing(12);
@@ -617,7 +598,11 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_txButton = new QPushButton(QStringLiteral("Transmit"), txFrame);
     m_txButton->setMinimumHeight(42);
     txLayout->addWidget(m_txButton);
-    root->addWidget(txFrame);
+    ax25PageLayout->addWidget(txFrame);
+    ax25PageLayout->addStretch(1);
+
+    // KISS TNC page (built lazily into the same stack).
+    m_tabStack->addWidget(buildKissTncPage());
 
     auto* logFrame = panel(QStringLiteral("LogFrame"), bodyWidget());
     auto* logLayout = new QVBoxLayout(logFrame);
@@ -669,10 +654,12 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
                                      &m_gainStageValue,
                                      bodyWidget()), 1);
 
+    // PACKET ACTIVITY: label stacked above the graphic so it lines up with the
+    // MODEM STATUS and GAIN STAGE panel labels to its left.
     auto* activityFrame = panel(QStringLiteral("StatusFrame"), bodyWidget());
-    auto* activityLayout = new QHBoxLayout(activityFrame);
+    auto* activityLayout = new QVBoxLayout(activityFrame);
     activityLayout->setContentsMargins(16, 12, 16, 12);
-    activityLayout->setSpacing(18);
+    activityLayout->setSpacing(10);
     m_packetActivityTitle = sectionLabel(QStringLiteral("PACKET ACTIVITY"), activityFrame);
     activityLayout->addWidget(m_packetActivityTitle);
     m_packetActivity = new PacketActivityWidget(activityFrame);
@@ -685,13 +672,9 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
 
     const Ax25ModemProfile savedProfile = profileFromSettingsValue(
         AppSettings::instance().value(kPacketDecoderProfileSetting, QStringLiteral("Hf300")).toString());
-    const Ax25TonePolarity savedPolarity = polarityFromSettingsValue(
-        AppSettings::instance().value(kPacketDecoderPolaritySetting, QStringLiteral("Normal")).toString());
     const bool savedDebug = AppSettings::instance().value(kPacketDecoderDebugSetting, false).toBool();
     m_hf300Profile->setChecked(savedProfile == Ax25ModemProfile::Hf300);
     m_vhf1200Profile->setChecked(savedProfile == Ax25ModemProfile::Vhf1200);
-    m_polarityNormal->setChecked(savedPolarity == Ax25TonePolarity::Normal);
-    m_polarityReverse->setChecked(savedPolarity == Ax25TonePolarity::Inverted);
     setDiagnosticsDebugEnabled(savedDebug, false);
     setModemProfile(savedProfile, false);
 
@@ -729,18 +712,17 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
             this, &Ax25HfPacketDecodeDialog::startTransmitFromUi);
     connect(m_txPaceTimer, &QTimer::timeout,
             this, &Ax25HfPacketDecodeDialog::paceTransmitAudio);
-    connect(m_polarityNormal, &QRadioButton::toggled, this, [this](bool checked) {
-        if (!checked)
-            return;
-        setTonePolarity(Ax25TonePolarity::Normal, true);
-    });
-    connect(m_polarityReverse, &QRadioButton::toggled, this, [this](bool checked) {
-        if (!checked)
-            return;
-        setTonePolarity(Ax25TonePolarity::Inverted, true);
-    });
     connect(m_shim, &AetherAx25LibmodemShim::frameDecoded,
             this, &Ax25HfPacketDecodeDialog::appendFrame);
+    // RX -> KISS clients: forward every decoded frame to connected hosts.
+    connect(m_shim, &AetherAx25LibmodemShim::frameDecoded, this,
+            [this](const Ax25DecodedFrame& frame) {
+        if (m_kissServer && m_kissServer->isListening() && !frame.ax25FrameNoFcs.isEmpty()) {
+            m_kissServer->broadcastAx25Frame(frame.ax25FrameNoFcs);
+            ++m_kissRxCount;
+            refreshTncStatus();
+        }
+    });
     connect(m_shim, &AetherAx25LibmodemShim::diagnosticsUpdated,
             this, &Ax25HfPacketDecodeDialog::updateDiagnostics);
     connect(m_shim, &AetherAx25LibmodemShim::statusChanged,
@@ -769,12 +751,42 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
                 Qt::QueuedConnection);
     }
 
+    // KISS TNC server wiring.
+    connect(m_kissServer, &KissTncServer::ax25FrameFromClient,
+            this, &Ax25HfPacketDecodeDialog::handleKissFrameFromClient);
+    connect(m_kissServer, &KissTncServer::activity,
+            this, &Ax25HfPacketDecodeDialog::appendSystemLine);
+    connect(m_kissServer, &KissTncServer::listeningChanged,
+            this, [this](bool) { refreshTncStatus(); });
+    connect(m_kissServer, &KissTncServer::clientCountChanged,
+            this, [this](int) { refreshTncStatus(); });
+    connect(m_tncEnable, &QCheckBox::toggled, this, [this](bool on) {
+        setTncEnabled(on, true);
+    });
+    connect(m_tncStartOnStartup, &QCheckBox::toggled, this, [](bool on) {
+        AppSettings::instance().setValue(kTncStartOnStartupSetting,
+                                         on ? QStringLiteral("True") : QStringLiteral("False"));
+        AppSettings::instance().save();
+    });
+    connect(m_tncPort, qOverload<int>(&QSpinBox::valueChanged), this, [this](int value) {
+        AppSettings::instance().setValue(kTncPortSetting, QString::number(value));
+        AppSettings::instance().save();
+        if (m_tncEnable && m_tncEnable->isChecked()) {
+            appendSystemLine(QStringLiteral("KISS TNC port changed to %1; restarting listener.")
+                .arg(value));
+            setTncEnabled(false, false);
+            setTncEnabled(true, false);
+        }
+    });
+
     appendSystemLine(QStringLiteral("AetherModem initialized."));
     appendSystemLine(QStringLiteral("Enable Modem to start the RX audio tap."));
     appendSystemLine(QStringLiteral("TX accepts raw payload text or full SRC>DST,path:payload syntax."));
     setAttachedSlice(initialSlice);
     refreshStatus();
     refreshTransmitControls();
+    applyTncStartOnStartup();
+    refreshTncStatus();
 }
 
 Ax25HfPacketDecodeDialog::~Ax25HfPacketDecodeDialog()
@@ -783,6 +795,8 @@ Ax25HfPacketDecodeDialog::~Ax25HfPacketDecodeDialog()
         finishTransmit(true, QStringLiteral("AetherModem window closing"));
     if (m_captureActive)
         finishAudioCapture(false);
+    if (m_kissServer)
+        m_kissServer->stop();
     if (m_audio)
         m_audio->setTncRxTapEnabled(false);
 }
@@ -826,17 +840,10 @@ void Ax25HfPacketDecodeDialog::setAttachedSlice(SliceModel* slice)
     refreshStatus();
 }
 
-Ax25TonePolarity Ax25HfPacketDecodeDialog::selectedTonePolarity() const
-{
-    return m_polarityReverse && m_polarityReverse->isChecked()
-        ? Ax25TonePolarity::Inverted
-        : Ax25TonePolarity::Normal;
-}
-
 void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool persist)
 {
-    const auto polarity = selectedTonePolarity();
-    m_shim->configure(ax25DemodConfigForProfile(profile, polarity));
+    // Tone polarity is always Normal for the supported HF DIGU / VHF FM paths.
+    m_shim->configure(ax25DemodConfigForProfile(profile, Ax25TonePolarity::Normal));
     m_lastDiagnostics = {};
     m_lastDiagnosticsUtc = {};
 
@@ -847,27 +854,6 @@ void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool pe
 
     if (m_log)
         appendSystemLine(QStringLiteral("Configured %1.").arg(m_shim->demodDescription()));
-    refreshStatus();
-}
-
-void Ax25HfPacketDecodeDialog::setTonePolarity(Ax25TonePolarity polarity, bool persist)
-{
-    auto cfg = m_shim->config();
-    if (cfg.polarity == polarity && persist)
-        return;
-
-    cfg.polarity = polarity;
-    m_shim->configure(cfg);
-    m_lastDiagnostics = {};
-    m_lastDiagnosticsUtc = {};
-
-    if (persist) {
-        AppSettings::instance().setValue(kPacketDecoderPolaritySetting, polaritySettingsValue(polarity));
-        AppSettings::instance().save();
-    }
-
-    appendSystemLine(QStringLiteral("Tone polarity changed to %1. Configured %2.")
-        .arg(polaritySettingsValue(polarity), m_shim->demodDescription()));
     refreshStatus();
 }
 
@@ -1009,7 +995,12 @@ void Ax25HfPacketDecodeDialog::startTransmitFromUi()
         qCWarning(lcAx25).noquote() << "AX.25 TX packetization failed:" << tx.error;
         return;
     }
+    beginTransmission(tx, false);
+}
 
+void Ax25HfPacketDecodeDialog::beginTransmission(const Ax25TransmitResult& tx, bool fromKiss)
+{
+    m_txFromKiss = fromKiss;
     m_pendingTx = tx;
     m_txPcm = tx.stereoFloat32Pcm;
     m_txOffsetBytes = 0;
@@ -1023,9 +1014,10 @@ void Ax25HfPacketDecodeDialog::startTransmitFromUi()
         : 0;
 
     appendSystemLine(QStringLiteral(
-        "TX packetized: %1 > %2%3, %4 payload bytes, %5 frame bytes, %6 bits, %7 s, RMS %8 dBFS, peak %9 dBFS.")
-        .arg(tx.frame.source,
-             tx.frame.destination,
+        "TX packetized (%1): %2 > %3%4, %5 payload bytes, %6 frame bytes, %7 bits, %8 s, RMS %9 dBFS, peak %10 dBFS.")
+        .arg(fromKiss ? QStringLiteral("KISS") : QStringLiteral("text"),
+             tx.frame.source.isEmpty() ? QStringLiteral("?") : tx.frame.source,
+             tx.frame.destination.isEmpty() ? QStringLiteral("?") : tx.frame.destination,
              tx.frame.path.isEmpty()
                  ? QString()
                  : QStringLiteral(" via %1").arg(tx.frame.path.join(QStringLiteral(","))))
@@ -1268,7 +1260,21 @@ void Ax25HfPacketDecodeDialog::finishTransmit(bool aborted, const QString& reaso
     m_txChunkCount = 0;
     m_txRestoreAudioDaxMode = false;
     m_txRestoreTransmitDax = false;
+    m_txFromKiss = false;
     refreshTransmitControls();
+
+    // Drain any queued KISS transmits. On a clean finish, kick the next one on a
+    // deferred (queued) call so we never re-enter the TX path within finish; on
+    // an abort, drop the backlog so a broken radio can't spin the queue.
+    if (aborted) {
+        if (!m_kissTxQueue.isEmpty()) {
+            appendSystemLine(QStringLiteral("Dropping %1 queued KISS TX frame(s) after abort.")
+                .arg(m_kissTxQueue.size()));
+            m_kissTxQueue.clear();
+        }
+    } else if (!m_kissTxQueue.isEmpty()) {
+        QTimer::singleShot(0, this, [this] { maybeStartNextKissTx(); });
+    }
 }
 
 void Ax25HfPacketDecodeDialog::appendFrame(const Ax25DecodedFrame& frame)
@@ -1633,6 +1639,168 @@ QString Ax25HfPacketDecodeDialog::formatTerminalLine(const Ax25DecodedFrame& fra
         .arg(time.toHtmlEscaped(),
              route.toHtmlEscaped(),
              payload.toHtmlEscaped());
+}
+
+QWidget* Ax25HfPacketDecodeDialog::buildKissTncPage()
+{
+    auto* page = new QWidget(m_tabStack);
+    auto* layout = new QVBoxLayout(page);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(10);
+
+    auto* controlsFrame = panel(QStringLiteral("ControlsFrame"), page);
+    auto* controls = new QHBoxLayout(controlsFrame);
+    controls->setContentsMargins(16, 14, 16, 14);
+    controls->setSpacing(20);
+
+    auto* serverCell = panel(QStringLiteral("ControlCell"), controlsFrame);
+    auto* serverLayout = new QVBoxLayout(serverCell);
+    serverLayout->setContentsMargins(0, 0, 20, 0);
+    serverLayout->setSpacing(12);
+    serverLayout->addWidget(sectionLabel(QStringLiteral("KISS TNC SERVER"), serverCell));
+    m_tncEnable = new QCheckBox(QStringLiteral("Enable TNC"), serverCell);
+    serverLayout->addWidget(m_tncEnable);
+    m_tncStartOnStartup = new QCheckBox(QStringLiteral("Start TNC on Startup"), serverCell);
+    serverLayout->addWidget(m_tncStartOnStartup);
+    controls->addWidget(serverCell, 2);
+
+    auto* portCell = panel(QStringLiteral("ControlCell"), controlsFrame);
+    auto* portLayout = new QVBoxLayout(portCell);
+    portLayout->setContentsMargins(0, 0, 20, 0);
+    portLayout->setSpacing(12);
+    portLayout->addWidget(sectionLabel(QStringLiteral("TCP PORT"), portCell));
+    m_tncPort = new QSpinBox(portCell);
+    m_tncPort->setRange(1, 65535);
+    m_tncPort->setValue(kTncDefaultPort);
+    m_tncPort->setMaximumWidth(140);
+    portLayout->addWidget(m_tncPort);
+    controls->addWidget(portCell, 1);
+    controls->addStretch(2);
+    layout->addWidget(controlsFrame);
+
+    auto* statusFrame = statusPanel(QStringLiteral("TNC STATUS"),
+                                    &m_tncStatusDot, &m_tncStatusValue, page);
+    layout->addWidget(statusFrame);
+
+    auto* help = new QLabel(
+        QStringLiteral("Point a KISS-over-TCP client (Xastir, YAAC, APRSdroid, UISS, Dire Wolf "
+                       "clients, terminal/packet programs, …) at this host and TCP port. Decoded "
+                       "frames are pushed to every connected client; frames a client sends are "
+                       "keyed onto the air using the baud profile selected on the AX.25 tab. "
+                       "The modem must be enabled with a slice attached for the TNC to carry "
+                       "traffic — enabling the TNC turns the modem on for you."),
+        page);
+    help->setObjectName(QStringLiteral("StatusValue"));
+    help->setWordWrap(true);
+    layout->addWidget(help);
+    layout->addStretch(1);
+
+    // Seed control values from settings (before signals are wired in the ctor).
+    m_tncPort->setValue(AppSettings::instance()
+        .value(kTncPortSetting, QString::number(kTncDefaultPort)).toInt());
+    m_tncStartOnStartup->setChecked(AppSettings::instance()
+        .value(kTncStartOnStartupSetting, QStringLiteral("False")).toString()
+            == QStringLiteral("True"));
+
+    return page;
+}
+
+void Ax25HfPacketDecodeDialog::setTncEnabled(bool enabled, bool persist)
+{
+    if (persist) {
+        AppSettings::instance().setValue(kTncEnabledSetting,
+            enabled ? QStringLiteral("True") : QStringLiteral("False"));
+        AppSettings::instance().save();
+    }
+
+    if (enabled) {
+        // The TNC needs the modem RX tap running to forward decodes to clients.
+        if (m_enableDecode && !m_enableDecode->isChecked()) {
+            appendSystemLine(QStringLiteral("Enabling the modem for the KISS TNC."));
+            m_enableDecode->setChecked(true);
+        }
+        const quint16 port = static_cast<quint16>(m_tncPort ? m_tncPort->value() : kTncDefaultPort);
+        if (!m_kissServer->start(port) && m_tncEnable) {
+            QSignalBlocker blocker(m_tncEnable);
+            m_tncEnable->setChecked(false);
+        }
+    } else {
+        m_kissServer->stop();
+    }
+    refreshTncStatus();
+}
+
+void Ax25HfPacketDecodeDialog::applyTncStartOnStartup()
+{
+    const bool startOnStartup = AppSettings::instance()
+        .value(kTncStartOnStartupSetting, QStringLiteral("False")).toString()
+            == QStringLiteral("True");
+    if (startOnStartup && m_tncEnable) {
+        appendSystemLine(QStringLiteral("KISS TNC: start-on-startup enabled; starting listener."));
+        m_tncEnable->setChecked(true); // fires setTncEnabled() via the toggled connection
+    }
+}
+
+void Ax25HfPacketDecodeDialog::handleKissFrameFromClient(const QByteArray& ax25NoFcs)
+{
+    if (ax25NoFcs.isEmpty())
+        return;
+    if (!m_audio || !m_radio) {
+        appendSystemLine(QStringLiteral("KISS TX dropped: audio engine or radio not ready."));
+        return;
+    }
+    m_kissTxQueue.enqueue(ax25NoFcs);
+    ++m_kissTxCount;
+    refreshTncStatus();
+    maybeStartNextKissTx();
+}
+
+void Ax25HfPacketDecodeDialog::maybeStartNextKissTx()
+{
+    if (m_kissTxQueue.isEmpty())
+        return;
+    if (m_txActive || m_txPendingStream)
+        return; // finishTransmit() re-drains when the current TX completes
+    if (!m_audio || !m_radio) {
+        m_kissTxQueue.clear();
+        return;
+    }
+    if (m_radio->isRadioTransmitting() || m_radio->transmitModel().isTransmitting()) {
+        QTimer::singleShot(250, this, [this] { maybeStartNextKissTx(); }); // radio busy; retry
+        return;
+    }
+
+    const QByteArray frame = m_kissTxQueue.dequeue();
+    Ax25TransmitResult tx = m_shim->buildTransmitAudioFromFrame(frame);
+    if (!tx.ok) {
+        appendSystemLine(QStringLiteral("KISS TX packetization failed: %1.").arg(tx.error));
+        qCWarning(lcAx25).noquote() << "KISS TX packetization failed:" << tx.error;
+        QTimer::singleShot(0, this, [this] { maybeStartNextKissTx(); }); // skip to next frame
+        return;
+    }
+    beginTransmission(tx, true);
+}
+
+void Ax25HfPacketDecodeDialog::refreshTncStatus()
+{
+    if (!m_tncStatusValue)
+        return;
+    const bool listening = m_kissServer && m_kissServer->isListening();
+    if (listening) {
+        m_tncStatusValue->setText(QStringLiteral("Listening on %1  |  %2 client(s)  |  RX %3  TX %4")
+            .arg(m_kissServer->port())
+            .arg(m_kissServer->clientCount())
+            .arg(m_kissRxCount)
+            .arg(m_kissTxCount));
+    } else {
+        m_tncStatusValue->setText(QStringLiteral("Stopped"));
+    }
+    if (m_tncStatusDot) {
+        m_tncStatusDot->setFixedSize(12, 12);
+        m_tncStatusDot->setStyleSheet(listening
+            ? QStringLiteral("background:#5fce66;border-radius:6px;")
+            : QStringLiteral("background:#8190a3;border-radius:6px;"));
+    }
 }
 
 } // namespace AetherSDR

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -48,6 +48,14 @@ constexpr int kTxDaxSettleMs = 150;
 constexpr int kTxLeadMs = 200;
 constexpr int kTxTailMs = 250;
 constexpr int kTxChunkMs = 20;
+// TX jitter buffer: how far ahead of real time we keep the radio's TX FIFO.
+// The pacer runs on the GUI thread, which jitters under RX-decode / diagnostics
+// / render load (measured stalls of 40-55 ms). Front-loading this much audio
+// and then catch-up pacing keeps the FIFO from underrunning during those
+// stalls. Must comfortably exceed the worst pacer gap, and stay within the
+// radio's DAX TX buffer depth. Raise if clipping persists; lower if the FIFO
+// overflows.
+constexpr int kTxLeadBufferMs = 120;
 
 constexpr const char* kAetherModemStyle = R"(
 QWidget {
@@ -1135,11 +1143,9 @@ void Ax25HfPacketDecodeDialog::paceTransmitAudio()
     }
     m_txPaceLastChunkMs = nowMs;
 
-    const qsizetype bytesPerChunk = static_cast<qsizetype>(m_pendingTx.sampleRate)
-        * kTxChunkMs / 1000
-        * 2
-        * static_cast<qsizetype>(sizeof(float));
-    if (bytesPerChunk <= 0) {
+    const qsizetype frameBytes = 2 * static_cast<qsizetype>(sizeof(float)); // stereo float32
+    const qsizetype bytesPerMs = static_cast<qsizetype>(m_pendingTx.sampleRate) * frameBytes / 1000;
+    if (bytesPerMs <= 0) {
         finishTransmit(true, QStringLiteral("invalid TX pacing chunk size"));
         return;
     }
@@ -1148,9 +1154,11 @@ void Ax25HfPacketDecodeDialog::paceTransmitAudio()
         if (m_txPaceTimer)
             m_txPaceTimer->stop();
 
-        // Pacing health summary. stretch ~1.0 with maxGap ~kTxChunkMs and
-        // lateChunks=0 means the pacer kept real time; stretch >> 1.0 or a large
-        // maxGap / lateChunks confirms GUI-thread starvation feeding the radio.
+        // Pacing health summary. With catch-up pacing, stretch <= ~1.0 means we
+        // kept up with real time and the radio FIFO stayed fed; stretch >> 1.0
+        // means even catch-up could not keep up (FIFO would underrun). maxGap /
+        // lateChunks still report raw GUI-thread jitter, but gaps smaller than
+        // kTxLeadBufferMs are absorbed by the lead cushion and are harmless.
         const double audioMs = m_pendingTx.durationSeconds * 1000.0;
         const qint64 wallMs = m_txPaceClock.isValid() ? m_txPaceClock.elapsed() : 0;
         const double stretch = audioMs > 0.0 ? static_cast<double>(wallMs) / audioMs : 0.0;
@@ -1181,7 +1189,19 @@ void Ax25HfPacketDecodeDialog::paceTransmitAudio()
         return;
     }
 
-    const qsizetype sendBytes = std::min<qsizetype>(bytesPerChunk, m_txPcm.size() - m_txOffsetBytes);
+    // Catch-up pacing: keep the radio's TX FIFO filled to (real time elapsed +
+    // kTxLeadBufferMs). When a tick lands late this ships a larger chunk to
+    // refill the cushion; when we are already ahead it ships nothing and waits
+    // for real time to advance. This holds the average rate at real time (no
+    // chronic lag) while absorbing GUI-thread stalls up to the lead buffer.
+    const qsizetype targetBytes = bytesPerMs * (nowMs + kTxLeadBufferMs);
+    if (targetBytes <= m_txOffsetBytes)
+        return; // FIFO is far enough ahead; wait for the next tick.
+    qsizetype sendBytes = std::min<qsizetype>(targetBytes - m_txOffsetBytes,
+                                              m_txPcm.size() - m_txOffsetBytes);
+    sendBytes -= sendBytes % frameBytes; // keep stereo-frame aligned
+    if (sendBytes <= 0)
+        return;
     const QByteArray chunk = m_txPcm.mid(m_txOffsetBytes, sendBytes);
     m_txOffsetBytes += sendBytes;
     ++m_txChunkIndex;

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -522,8 +522,8 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     // 0x0094) render as "â" + two control glyphs, which is what shipped.
     auto* experimentalBanner = new QLabel(
         QStringLiteral("<b>Experimental — AX.25 modem bring-up.</b> "
-                       "300 baud HF RX/TX is active; 1200 baud VHF remains "
-                       "receive-focused while timing work continues."),
+                       "300 baud HF and 1200 baud VHF (Bell 202 / 2m APRS) "
+                       "AX.25 receive and transmit are active."),
         bodyWidget());
     experimentalBanner->setObjectName(QStringLiteral("ExperimentalBanner"));
     experimentalBanner->setWordWrap(true);
@@ -985,10 +985,6 @@ void Ax25HfPacketDecodeDialog::startTransmitFromUi()
     }
     if (!m_txText)
         return;
-    if (!m_hf300Profile || !m_hf300Profile->isChecked()) {
-        appendSystemLine(QStringLiteral("TX is enabled for the 300 baud HF profile in this pass."));
-        return;
-    }
     if (!m_audio || !m_radio) {
         appendSystemLine(QStringLiteral("TX unavailable: audio engine or radio model is not ready."));
         return;
@@ -1362,9 +1358,8 @@ void Ax25HfPacketDecodeDialog::refreshTransmitControls()
     if (!m_txButton)
         return;
 
-    const bool hfTx = m_hf300Profile && m_hf300Profile->isChecked();
     const bool hasText = m_txText && !m_txText->text().trimmed().isEmpty();
-    const bool ready = hfTx && hasText && !m_txActive && !m_txPendingStream;
+    const bool ready = hasText && !m_txActive && !m_txPendingStream;
     m_txButton->setEnabled(ready);
     if (m_txActive) {
         m_txButton->setText(QStringLiteral("Transmitting..."));
@@ -1376,10 +1371,9 @@ void Ax25HfPacketDecodeDialog::refreshTransmitControls()
 
     if (m_txText) {
         m_txText->setEnabled(!m_txActive && !m_txPendingStream);
-        m_txText->setToolTip(hfTx
-            ? QStringLiteral("Transmit a 300 baud HF AX.25 UI frame. Raw text uses %1>APRS; full SRC>DST,path:payload syntax is also accepted.")
-                .arg(defaultTransmitSource())
-            : QStringLiteral("TX is enabled for 300 baud HF in this pass."));
+        m_txText->setToolTip(
+            QStringLiteral("Transmit a %1 AX.25 UI frame. Raw text uses %2>APRS; full SRC>DST,path:payload syntax is also accepted.")
+                .arg(ax25ModemProfileName(m_shim->config().profile), defaultTransmitSource()));
     }
 }
 

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -1106,6 +1106,10 @@ void Ax25HfPacketDecodeDialog::beginTransmitWhenReady()
             appendSystemLine(QStringLiteral("Sending AX.25 AFSK audio: %1 chunks at %2 ms.")
                 .arg(m_txChunkCount)
                 .arg(kTxChunkMs));
+            m_txPaceClock.restart();
+            m_txPaceLastChunkMs = -1;
+            m_txPaceMaxGapMs = 0;
+            m_txPaceLateChunks = 0;
             paceTransmitAudio();
             if (m_txActive && m_txPaceTimer)
                 m_txPaceTimer->start();
@@ -1117,6 +1121,19 @@ void Ax25HfPacketDecodeDialog::paceTransmitAudio()
 {
     if (!m_txActive || !m_audio)
         return;
+
+    // Measure scheduling gap between pacer ticks. The pacer wants to fire every
+    // kTxChunkMs; a much larger gap means the GUI thread stalled (heartbeat,
+    // 1 Hz diagnostics, RX decode, render) and the radio TX FIFO likely
+    // underran — the suspected cause of periodic AFSK corruption.
+    const qint64 nowMs = m_txPaceClock.isValid() ? m_txPaceClock.elapsed() : 0;
+    if (m_txPaceLastChunkMs >= 0) {
+        const qint64 gapMs = nowMs - m_txPaceLastChunkMs;
+        m_txPaceMaxGapMs = std::max(m_txPaceMaxGapMs, gapMs);
+        if (gapMs > 2 * kTxChunkMs)
+            ++m_txPaceLateChunks;
+    }
+    m_txPaceLastChunkMs = nowMs;
 
     const qsizetype bytesPerChunk = static_cast<qsizetype>(m_pendingTx.sampleRate)
         * kTxChunkMs / 1000
@@ -1130,6 +1147,32 @@ void Ax25HfPacketDecodeDialog::paceTransmitAudio()
     if (m_txOffsetBytes >= m_txPcm.size()) {
         if (m_txPaceTimer)
             m_txPaceTimer->stop();
+
+        // Pacing health summary. stretch ~1.0 with maxGap ~kTxChunkMs and
+        // lateChunks=0 means the pacer kept real time; stretch >> 1.0 or a large
+        // maxGap / lateChunks confirms GUI-thread starvation feeding the radio.
+        const double audioMs = m_pendingTx.durationSeconds * 1000.0;
+        const qint64 wallMs = m_txPaceClock.isValid() ? m_txPaceClock.elapsed() : 0;
+        const double stretch = audioMs > 0.0 ? static_cast<double>(wallMs) / audioMs : 0.0;
+        qCInfo(lcAx25).noquote()
+            << QStringLiteral("AX.25 TX pacing summary: baud=%1 chunks=%2 audioMs=%3 wallMs=%4 "
+                              "stretch=%5x maxChunkGapMs=%6 lateChunks=%7 nominalChunkMs=%8")
+                .arg(m_shim->config().baud)
+                .arg(m_txChunkIndex)
+                .arg(audioMs, 0, 'f', 0)
+                .arg(wallMs)
+                .arg(stretch, 0, 'f', 2)
+                .arg(m_txPaceMaxGapMs)
+                .arg(m_txPaceLateChunks)
+                .arg(kTxChunkMs);
+        appendSystemLine(QStringLiteral(
+            "TX pacing: %1 chunks, audio %2 ms vs wall %3 ms (%4x), max gap %5 ms, late %6.")
+            .arg(m_txChunkIndex)
+            .arg(audioMs, 0, 'f', 0)
+            .arg(wallMs)
+            .arg(stretch, 0, 'f', 2)
+            .arg(m_txPaceMaxGapMs)
+            .arg(m_txPaceLateChunks));
         appendSystemLine(QStringLiteral("AX.25 TX audio queued; waiting %1 ms before unkey.")
             .arg(kTxTailMs));
         QTimer::singleShot(kTxTailMs, this, [this] {

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -3,21 +3,27 @@
 #include "PersistentDialog.h"
 #include "core/tnc/AetherAx25LibmodemShim.h"
 
+#include <QByteArray>
 #include <QElapsedTimer>
 #include <QMetaObject>
 #include <QPointer>
+#include <QQueue>
 
+class QAbstractButton;
 class QCheckBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
 class QRadioButton;
+class QSpinBox;
+class QStackedWidget;
 class QTextEdit;
 class QTimer;
 
 namespace AetherSDR {
 
 class AudioEngine;
+class KissTncServer;
 class PacketActivityWidget;
 class RadioModel;
 class SliceModel;
@@ -35,17 +41,24 @@ public:
     void setAttachedSlice(SliceModel* slice);
 
 private:
-    Ax25TonePolarity selectedTonePolarity() const;
     void setModemProfile(Ax25ModemProfile profile, bool persist);
-    void setTonePolarity(Ax25TonePolarity polarity, bool persist);
     void setDecodeEnabled(bool enabled);
     void handleRxAudio(const QByteArray& monoFloat32Pcm, int sampleRate);
     void startAudioCapture();
     void finishAudioCapture(bool save);
     void startTransmitFromUi();
+    void beginTransmission(const Ax25TransmitResult& tx, bool fromKiss);
     void beginTransmitWhenReady();
     void paceTransmitAudio();
     void finishTransmit(bool aborted, const QString& reason);
+
+    // KISS TNC tab + TCP server wiring.
+    QWidget* buildKissTncPage();
+    void setTncEnabled(bool enabled, bool persist);
+    void applyTncStartOnStartup();
+    void handleKissFrameFromClient(const QByteArray& ax25NoFcs);
+    void maybeStartNextKissTx();
+    void refreshTncStatus();
     void appendFrame(const Ax25DecodedFrame& frame);
     void updateDiagnostics(const Ax25DecoderDiagnostics& diagnostics);
     void updateHeartbeat();
@@ -63,11 +76,12 @@ private:
     AudioEngine* m_audio{nullptr};
     RadioModel* m_radio{nullptr};
     AetherAx25LibmodemShim* m_shim{nullptr};
+    QStackedWidget* m_tabStack{nullptr};
+    QAbstractButton* m_ax25Tab{nullptr};
+    QAbstractButton* m_kissTab{nullptr};
     QRadioButton* m_hf300Profile{nullptr};
     QRadioButton* m_vhf1200Profile{nullptr};
     QCheckBox* m_enableDecode{nullptr};
-    QRadioButton* m_polarityNormal{nullptr};
-    QRadioButton* m_polarityReverse{nullptr};
     QLineEdit* m_txText{nullptr};
     QPushButton* m_txButton{nullptr};
     QTextEdit* m_log{nullptr};
@@ -114,6 +128,18 @@ private:
     bool m_txRestoreTransmitDax{false};
     bool m_txPreviousAudioDaxMode{false};
     bool m_txPreviousTransmitDax{false};
+    bool m_txFromKiss{false};
+
+    // KISS TNC server (TCP) and its controls.
+    KissTncServer* m_kissServer{nullptr};
+    QCheckBox* m_tncEnable{nullptr};
+    QCheckBox* m_tncStartOnStartup{nullptr};
+    QSpinBox* m_tncPort{nullptr};
+    QLabel* m_tncStatusDot{nullptr};
+    QLabel* m_tncStatusValue{nullptr};
+    QQueue<QByteArray> m_kissTxQueue;
+    quint64 m_kissTxCount{0};
+    quint64 m_kissRxCount{0};
 };
 
 } // namespace AetherSDR

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -3,6 +3,7 @@
 #include "PersistentDialog.h"
 #include "core/tnc/AetherAx25LibmodemShim.h"
 
+#include <QElapsedTimer>
 #include <QMetaObject>
 #include <QPointer>
 
@@ -102,6 +103,11 @@ private:
     qsizetype m_txOffsetBytes{0};
     int m_txChunkIndex{0};
     int m_txChunkCount{0};
+    // TX pacing health: detects GUI-thread stalls starving the 20 ms pacer.
+    QElapsedTimer m_txPaceClock;
+    qint64 m_txPaceLastChunkMs{-1};
+    qint64 m_txPaceMaxGapMs{0};
+    int m_txPaceLateChunks{0};
     bool m_txActive{false};
     bool m_txPendingStream{false};
     bool m_txRestoreAudioDaxMode{false};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1728,6 +1728,12 @@ MainWindow::MainWindow(QWidget* parent)
         s.save();
     });
 
+    // Start the AetherModem KISS TNC headlessly at launch if the user enabled
+    // "Start TNC on Startup" — constructs the (hidden, persistent) AetherModem
+    // window so the TCP server runs without the window being opened. Deferred so
+    // the audio engine and main window are fully up first.
+    QTimer::singleShot(0, this, [this] { startKissTncOnStartupIfConfigured(); });
+
     // Auto-connect: when a radio is discovered, check if it matches the last one
     connect(&m_discovery, &RadioDiscovery::radioDiscovered,
             this, [this](const RadioInfo& info) {
@@ -6352,6 +6358,25 @@ void MainWindow::showAx25HfPacketDecodeDialog()
     showOrRaisePersistent(m_ax25HfPacketDecodeDialog, m_audio, &m_radioModel, slice);
     if (m_ax25HfPacketDecodeDialog)
         m_ax25HfPacketDecodeDialog->setAttachedSlice(slice);
+}
+
+void MainWindow::startKissTncOnStartupIfConfigured()
+{
+    if (m_ax25HfPacketDecodeDialog)
+        return; // already constructed (e.g. user opened the window)
+    if (AppSettings::instance()
+            .value("AetherModemKissTncStartOnStartup", "False").toString()
+                != QStringLiteral("True"))
+        return;
+
+    // Construct the AetherModem window hidden and persistent (no WA_DeleteOnClose)
+    // so the KISS TCP server runs from launch and survives the window being
+    // closed. The dialog's constructor auto-starts the TNC per the same setting.
+    auto* dlg = new Ax25HfPacketDecodeDialog(m_audio, &m_radioModel, activeSlice(), this);
+    dlg->setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+    m_ax25HfPacketDecodeDialog = dlg;
+    m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
 }
 
 void MainWindow::showFlexControlDialog()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -356,6 +356,7 @@ private:
     void updatePaTempLabel();
     void showNetworkDiagnosticsDialog();
     void showAx25HfPacketDecodeDialog();
+    void startKissTncOnStartupIfConfigured();
     void showFlexControlDialog();
     void handleFlexControlTuneSteps(int steps);
     void handleFlexControlButton(int button, int action);

--- a/tests/ax25_libmodem_shim_test.cpp
+++ b/tests/ax25_libmodem_shim_test.cpp
@@ -552,6 +552,48 @@ void testTransmitMonitorSyntaxBuildsLoopbackAudio()
     report("TX monitor loopback payload", frames.first().payloadText == QStringLiteral("!3644.00N\\11947.00W-Test TX"));
 }
 
+void testTransmitVhf1200LoopbackDecodes()
+{
+    AetherAx25LibmodemShim txShim;
+    txShim.configure(ax25DemodConfigForProfile(Ax25ModemProfile::Vhf1200));
+
+    const Ax25TransmitResult tx = txShim.buildTransmitAudio(
+        QStringLiteral("KK7GWY-9>APDW18,WIDE1-1:!4742.00N/12217.00W>2m APRS TX"),
+        QStringLiteral("KK7GWY"));
+    report("VHF 1200 TX packetizes", tx.ok);
+    if (!tx.ok)
+        return;
+    report("VHF 1200 TX reports 1200 baud", tx.baud == 1200);
+    report("VHF 1200 TX uses Bell 202 tones", tx.markHz == 1200.0 && tx.spaceHz == 2200.0);
+    report("VHF 1200 TX stereo PCM generated", !tx.stereoFloat32Pcm.isEmpty() && tx.audioFrames > 0);
+    report("VHF 1200 TX padded to VITA packet frames", (tx.audioFrames % tx.vitaPacketFrames) == 0);
+    report("VHF 1200 TX waveform has sane level", tx.peakDbfs < -6.0 && tx.peakDbfs > -12.0);
+
+    // TXDELAY optimization: VHF 1200 emits a shorter preamble than HF 300.
+    AetherAx25LibmodemShim hfShim;
+    hfShim.configure(ax25DemodConfigForProfile(Ax25ModemProfile::Hf300));
+    const Ax25TransmitResult hfTx = hfShim.buildTransmitAudio(
+        QStringLiteral("hello"), QStringLiteral("KK7GWY"));
+    report("VHF 1200 TX uses a shorter preamble than HF 300",
+           hfTx.ok && tx.preambleFlags > 0 && tx.preambleFlags < hfTx.preambleFlags);
+
+    const std::vector<float> mono = monoFromStereoFloat32(tx.stereoFloat32Pcm);
+    AetherAx25LibmodemShim rxShim;
+    rxShim.configure(ax25DemodConfigForProfile(Ax25ModemProfile::Vhf1200));
+    const auto frames = rxShim.processMonoFloat(mono.data(),
+                                                static_cast<int>(mono.size()),
+                                                tx.sampleRate);
+    report("VHF 1200 TX loopback decodes", frames.size() == 1);
+    if (frames.isEmpty())
+        return;
+    report("VHF 1200 TX loopback source", frames.first().source == QStringLiteral("KK7GWY-9"));
+    report("VHF 1200 TX loopback destination", frames.first().destination == QStringLiteral("APDW18"));
+    report("VHF 1200 TX loopback path",
+           frames.first().path == QStringList({QStringLiteral("WIDE1-1")}));
+    report("VHF 1200 TX loopback payload",
+           frames.first().payloadText == QStringLiteral("!4742.00N/12217.00W>2m APRS TX"));
+}
+
 void testMalformedTransmitMonitorSyntaxIsRejected()
 {
     AetherAx25LibmodemShim txShim;
@@ -746,6 +788,7 @@ int main(int argc, char** argv)
     testChunkedVhf1200ReplayDecodes();
     testTransmitRawPayloadBuildsLoopbackAudio();
     testTransmitMonitorSyntaxBuildsLoopbackAudio();
+    testTransmitVhf1200LoopbackDecodes();
     testMalformedTransmitMonitorSyntaxIsRejected();
     testChunkedSyntheticReplayUsesReceiveGate();
     testReplayWavLoaderFeedsShim();

--- a/tests/ax25_libmodem_shim_test.cpp
+++ b/tests/ax25_libmodem_shim_test.cpp
@@ -1,4 +1,5 @@
 #include "core/tnc/AetherAx25LibmodemShim.h"
+#include "core/tnc/KissFraming.h"
 
 #include "bitstream.h"
 
@@ -594,6 +595,88 @@ void testTransmitVhf1200LoopbackDecodes()
            frames.first().payloadText == QStringLiteral("!4742.00N/12217.00W>2m APRS TX"));
 }
 
+void testKissFramingRoundTrip()
+{
+    namespace k = AetherSDR::kiss;
+
+    // Payload deliberately contains FEND (0xC0) and FESC (0xDB) so escaping runs.
+    QByteArray ax25;
+    ax25.append(static_cast<char>(0xC0));
+    ax25.append(static_cast<char>(0x01));
+    ax25.append(static_cast<char>(0xDB));
+    ax25.append("HELLO");
+
+    const QByteArray framed = k::encodeDataFrame(ax25);
+    report("KISS frame is delimited by FEND",
+           !framed.isEmpty()
+           && static_cast<quint8>(framed.front()) == k::kFend
+           && static_cast<quint8>(framed.back()) == k::kFend);
+    report("KISS framing escaped the special bytes", framed.size() > ax25.size() + 3);
+
+    k::Decoder decoder;
+    const QVector<QByteArray> frames = decoder.feed(framed);
+    report("KISS decoder yields exactly one frame", frames.size() == 1);
+    if (!frames.isEmpty()) {
+        quint8 port = 9;
+        quint8 command = 9;
+        QByteArray payload;
+        k::splitTypeByte(frames.first(), port, command, payload);
+        report("KISS decoded a data command on port 0", port == 0 && command == k::kCmdData);
+        report("KISS payload round-trips through escape/unescape", payload == ax25);
+    }
+
+    // Feeding one byte at a time must reassemble identically (TCP can split).
+    k::Decoder dripDecoder;
+    QVector<QByteArray> dripFrames;
+    for (int i = 0; i < framed.size(); ++i)
+        dripFrames += dripDecoder.feed(framed.mid(i, 1));
+    bool dripOk = dripFrames.size() == 1;
+    if (dripOk) {
+        quint8 p = 0;
+        quint8 c = 0;
+        QByteArray pl;
+        k::splitTypeByte(dripFrames.first(), p, c, pl);
+        dripOk = (pl == ax25);
+    }
+    report("KISS decoder reassembles across byte-split feeds", dripOk);
+}
+
+void testKissTxFromFrameLoopbackDecodes()
+{
+    AetherAx25LibmodemShim txShim;
+    txShim.configure(ax25DemodConfigForProfile(Ax25ModemProfile::Vhf1200));
+
+    // A KISS data frame carries a raw AX.25 frame with no FCS: encode a packet
+    // and drop the trailing 2-byte FCS to simulate what a host app would send.
+    const std::vector<uint8_t> frameWithFcs = lm::ax25::encode_frame(fixedVhf1200AprsTestPacket());
+    const QByteArray ax25NoFcs(reinterpret_cast<const char*>(frameWithFcs.data()),
+                               static_cast<qsizetype>(frameWithFcs.size() - 2));
+
+    const Ax25TransmitResult tx = txShim.buildTransmitAudioFromFrame(ax25NoFcs);
+    report("KISS TX-from-frame packetizes", tx.ok);
+    if (!tx.ok)
+        return;
+    report("KISS TX-from-frame is 1200 baud", tx.baud == 1200);
+    report("KISS TX-from-frame appended FCS", tx.frameBytes == ax25NoFcs.size() + 2);
+
+    const std::vector<float> mono = monoFromStereoFloat32(tx.stereoFloat32Pcm);
+    AetherAx25LibmodemShim rxShim;
+    rxShim.configure(ax25DemodConfigForProfile(Ax25ModemProfile::Vhf1200));
+    const auto frames = rxShim.processMonoFloat(mono.data(),
+                                                static_cast<int>(mono.size()),
+                                                tx.sampleRate);
+    report("KISS TX-from-frame loopback decodes one frame", frames.size() == 1);
+    if (frames.isEmpty())
+        return;
+    report("KISS TX loopback source", frames.first().source == QStringLiteral("KK7GWY-9"));
+    report("KISS TX loopback payload",
+           frames.first().payloadText
+               == QStringLiteral("!4742.00N/12217.00W>2m APRS via AetherModem 1200 baud"));
+    // RX raw-frame capture must round-trip back to exactly what we keyed.
+    report("KISS RX raw frame bytes match the keyed frame",
+           frames.first().ax25FrameNoFcs == ax25NoFcs);
+}
+
 void testMalformedTransmitMonitorSyntaxIsRejected()
 {
     AetherAx25LibmodemShim txShim;
@@ -789,6 +872,8 @@ int main(int argc, char** argv)
     testTransmitRawPayloadBuildsLoopbackAudio();
     testTransmitMonitorSyntaxBuildsLoopbackAudio();
     testTransmitVhf1200LoopbackDecodes();
+    testKissFramingRoundTrip();
+    testKissTxFromFrameLoopbackDecodes();
     testMalformedTransmitMonitorSyntaxIsRejected();
     testChunkedSyntheticReplayUsesReceiveGate();
     testReplayWavLoaderFeedsShim();

--- a/tests/ax25_libmodem_shim_test.cpp
+++ b/tests/ax25_libmodem_shim_test.cpp
@@ -58,6 +58,13 @@ lm::packet fixedAprsTestPacket()
                       "!3644.00N\\11947.00W-KI6BCJ HF APRS test via Direwolf 300 baud");
 }
 
+lm::packet fixedVhf1200AprsTestPacket()
+{
+    return lm::packet("KK7GWY-9", "APDW18",
+                      {"WIDE1-1", "WIDE2-1"},
+                      "!4742.00N/12217.00W>2m APRS via AetherModem 1200 baud");
+}
+
 QByteArray sinePcm(int sampleRate, double frequencyHz, double amplitude)
 {
     QByteArray pcm;
@@ -238,7 +245,7 @@ void printReplayDiagnostics(const char* label,
 {
     std::printf(
         "%s: frames=%lld rms=%.1f dBFS peak=%.1f dBFS clip=%.2f%% "
-        "tone1600=%.1f dBFS tone1800=%.1f dBFS dTone=%.1f dB "
+        "tone%.0f=%.1f dBFS tone%.0f=%.1f dBFS dTone=%.1f dB "
         "gate=%s gateRms=%.1f dBFS gateFloor=%.1f dBFS gateResets=%llu "
         "lanes=%d symbols=%d conf=%.2f ones=%.1f%% starts=%llu hdlc=%llu ax25=%llu ok=%llu reject=%llu "
         "short=%llu badFcs=%llu malformed=%llu last=%s bytes=%d bits=%d fcs=%s/%s\n",
@@ -247,7 +254,9 @@ void printReplayDiagnostics(const char* label,
         diagnostics.rmsDbfs,
         diagnostics.peakDbfs,
         diagnostics.clippedPercent,
+        diagnostics.markToneHz,
         diagnostics.markToneDbfs,
+        diagnostics.spaceToneHz,
         diagnostics.spaceToneDbfs,
         diagnostics.markMinusSpaceDb,
         diagnostics.receiveGateOpen ? "open" : "idle",
@@ -287,40 +296,49 @@ int replayCapture(const QString& path)
                 audio.samples.size(),
                 audio.sampleRate);
 
-    for (Ax25TonePolarity polarity : {Ax25TonePolarity::Normal, Ax25TonePolarity::Inverted}) {
-        AetherAx25LibmodemShim shim;
-        shim.configure(ax25DemodConfigForProfile(Ax25ModemProfile::Hf300, polarity));
-        QVector<Ax25DecodedFrame> frames;
-        QVector<double> frameTimesSeconds;
-        constexpr int chunkSamples = 1024;
-        for (size_t offset = 0; offset < audio.samples.size(); offset += chunkSamples) {
-            const int count = static_cast<int>(
-                std::min<size_t>(chunkSamples, audio.samples.size() - offset));
-            const auto chunkFrames = shim.processMonoFloat(audio.samples.data() + offset,
-                                                           count,
-                                                           audio.sampleRate);
-            frames += chunkFrames;
-            for (qsizetype i = 0; i < chunkFrames.size(); ++i) {
-                frameTimesSeconds.append(
-                    static_cast<double>(offset + static_cast<size_t>(count))
-                    / static_cast<double>(audio.sampleRate));
+    // Sweep every profile and polarity so a single capture (e.g. a real 2m
+    // APRS recording) is scored against HF 300 and VHF 1200 in one pass.
+    for (Ax25ModemProfile profile : {Ax25ModemProfile::Hf300, Ax25ModemProfile::Vhf1200}) {
+        for (Ax25TonePolarity polarity : {Ax25TonePolarity::Normal, Ax25TonePolarity::Inverted}) {
+            AetherAx25LibmodemShim shim;
+            shim.configure(ax25DemodConfigForProfile(profile, polarity));
+            QVector<Ax25DecodedFrame> frames;
+            QVector<double> frameTimesSeconds;
+            constexpr int chunkSamples = 1024;
+            for (size_t offset = 0; offset < audio.samples.size(); offset += chunkSamples) {
+                const int count = static_cast<int>(
+                    std::min<size_t>(chunkSamples, audio.samples.size() - offset));
+                const auto chunkFrames = shim.processMonoFloat(audio.samples.data() + offset,
+                                                               count,
+                                                               audio.sampleRate);
+                frames += chunkFrames;
+                for (qsizetype i = 0; i < chunkFrames.size(); ++i) {
+                    frameTimesSeconds.append(
+                        static_cast<double>(offset + static_cast<size_t>(count))
+                        / static_cast<double>(audio.sampleRate));
+                }
             }
-        }
-        const auto diagnostics = shim.diagnosticsSnapshot();
-        printReplayDiagnostics(polarity == Ax25TonePolarity::Normal ? "Normal" : "Reverse",
-                               diagnostics,
-                               frames.size());
-        for (qsizetype i = 0; i < frames.size(); ++i) {
-            const auto& frame = frames.at(i);
-            std::printf("  %.1fs phase=%d %s > %s%s  %s\n",
-                        frameTimesSeconds.value(i, 0.0),
-                        frame.decodePhaseOffsetSamples,
-                        qPrintable(frame.source),
-                        qPrintable(frame.destination),
-                        qPrintable(frame.path.isEmpty()
-                            ? QString()
-                            : QStringLiteral(",") + frame.path.join(QStringLiteral(","))),
-                        qPrintable(frame.payloadText.isEmpty() ? frame.payloadHex : frame.payloadText));
+            const auto diagnostics = shim.diagnosticsSnapshot();
+            const QString label = QStringLiteral("%1 %2")
+                .arg(ax25ModemProfileName(profile),
+                     polarity == Ax25TonePolarity::Normal
+                         ? QStringLiteral("Normal")
+                         : QStringLiteral("Reverse"));
+            printReplayDiagnostics(qPrintable(label),
+                                   diagnostics,
+                                   frames.size());
+            for (qsizetype i = 0; i < frames.size(); ++i) {
+                const auto& frame = frames.at(i);
+                std::printf("  %.1fs phase=%d %s > %s%s  %s\n",
+                            frameTimesSeconds.value(i, 0.0),
+                            frame.decodePhaseOffsetSamples,
+                            qPrintable(frame.source),
+                            qPrintable(frame.destination),
+                            qPrintable(frame.path.isEmpty()
+                                ? QString()
+                                : QStringLiteral(",") + frame.path.join(QStringLiteral(","))),
+                            qPrintable(frame.payloadText.isEmpty() ? frame.payloadHex : frame.payloadText));
+            }
         }
     }
 
@@ -347,7 +365,10 @@ void testVhf1200ProfileConfig()
     report("VHF sample rate", cfg.sampleRate == 24000);
     report("VHF baud", cfg.baud == 1200);
     report("VHF tones", cfg.markHz == 1200.0 && cfg.spaceHz == 2200.0);
-    report("VHF profile keeps one decode lane", shim.diagnosticsSnapshot().decodeLanes == 1);
+    // Aggressive multi-lane decode bank: 10 free-running phase lanes + 4 tracked
+    // phases x 2 PLL bandwidths = 18 (see kVhf1200* in the shim).
+    report("VHF profile runs the 18-lane decode bank",
+           shim.diagnosticsSnapshot().decodeLanes == 18);
     report("VHF description names profile", shim.demodDescription().contains(QStringLiteral("1200 baud VHF")));
 }
 
@@ -402,6 +423,73 @@ void testSyntheticHf300AfskLoopbackDecodes()
     report("synthetic loopback UI frame", frame.isUiFrame && frame.control == 0x03 && frame.pid == 0xf0);
     report("synthetic loopback payload",
            frame.payloadText == QStringLiteral("!3644.00N\\11947.00W-KI6BCJ HF APRS test via Direwolf 300 baud"));
+}
+
+void testSyntheticVhf1200AfskLoopbackDecodes()
+{
+    const auto cfg = ax25DemodConfigForProfile(Ax25ModemProfile::Vhf1200);
+
+    AetherAx25LibmodemShim shim;
+    shim.configure(cfg);
+
+    const auto frameBytes = lm::ax25::encode_frame(fixedVhf1200AprsTestPacket());
+    const auto bits = lm::ax25::encode_bitstream(frameBytes, 0, 80, 8);
+    const auto audio = afskPcmFromBits(bits, cfg);
+    const auto frames = shim.processMonoFloat(audio.data(),
+                                              static_cast<int>(audio.size()),
+                                              cfg.sampleRate);
+    const auto diagnostics = shim.diagnosticsSnapshot();
+
+    report("synthetic 1200 baud AFSK loopback emits one frame", frames.size() == 1);
+    report("synthetic 1200 baud AFSK loopback runs the decode bank", diagnostics.decodeLanes > 1);
+    report("synthetic 1200 baud AFSK loopback produced symbols", diagnostics.demodSymbols > 0);
+    report("synthetic 1200 baud AFSK loopback has no clipping", diagnostics.clippedPercent == 0.0);
+    if (frames.isEmpty())
+        return;
+
+    const auto& frame = frames.first();
+    report("synthetic 1200 loopback source", frame.source == QStringLiteral("KK7GWY-9"));
+    report("synthetic 1200 loopback destination", frame.destination == QStringLiteral("APDW18"));
+    report("synthetic 1200 loopback path",
+           frame.path == QStringList({QStringLiteral("WIDE1-1"), QStringLiteral("WIDE2-1")}));
+    report("synthetic 1200 loopback UI frame", frame.isUiFrame && frame.control == 0x03 && frame.pid == 0xf0);
+    report("synthetic 1200 loopback payload",
+           frame.payloadText == QStringLiteral("!4742.00N/12217.00W>2m APRS via AetherModem 1200 baud"));
+}
+
+void testChunkedVhf1200ReplayDecodes()
+{
+    const auto cfg = ax25DemodConfigForProfile(Ax25ModemProfile::Vhf1200);
+    const auto frameBytes = lm::ax25::encode_frame(fixedVhf1200AprsTestPacket());
+    const auto bits = lm::ax25::encode_bitstream(frameBytes, 0, 80, 8);
+    const auto packetAudio = afskPcmFromBits(bits, cfg);
+
+    // Near-silent lead-in so the receive gate has a floor to open against, then
+    // the burst, fed in 1024-sample chunks exactly like the live RX audio tap.
+    std::vector<float> audio(static_cast<size_t>(cfg.sampleRate), 0.002f);
+    audio.insert(audio.end(), packetAudio.begin(), packetAudio.end());
+
+    AetherAx25LibmodemShim shim;
+    shim.configure(cfg);
+
+    QVector<Ax25DecodedFrame> frames;
+    constexpr int chunkSamples = 1024;
+    for (size_t offset = 0; offset < audio.size(); offset += chunkSamples) {
+        const int count = static_cast<int>(
+            std::min<size_t>(chunkSamples, audio.size() - offset));
+        frames += shim.processMonoFloat(audio.data() + offset, count, cfg.sampleRate);
+    }
+
+    const auto diagnostics = shim.diagnosticsSnapshot();
+    report("chunked 1200 replay receive gate opened", diagnostics.receiveGateResets > 0);
+    report("chunked 1200 replay emits one frame", frames.size() == 1);
+    if (frames.isEmpty())
+        return;
+    report("chunked 1200 replay source", frames.first().source == QStringLiteral("KK7GWY-9"));
+    report("chunked 1200 replay path",
+           frames.first().path == QStringList({QStringLiteral("WIDE1-1"), QStringLiteral("WIDE2-1")}));
+    report("chunked 1200 replay payload",
+           frames.first().payloadText == QStringLiteral("!4742.00N/12217.00W>2m APRS via AetherModem 1200 baud"));
 }
 
 void testTransmitRawPayloadBuildsLoopbackAudio()
@@ -654,6 +742,8 @@ int main(int argc, char** argv)
     testVhf1200ProfileConfig();
     testKnownGoodBitstreamDecodes();
     testSyntheticHf300AfskLoopbackDecodes();
+    testSyntheticVhf1200AfskLoopbackDecodes();
+    testChunkedVhf1200ReplayDecodes();
     testTransmitRawPayloadBuildsLoopbackAudio();
     testTransmitMonitorSyntaxBuildsLoopbackAudio();
     testMalformedTransmitMonitorSyntaxIsRejected();


### PR DESCRIPTION
> **Draft.** Stacked on #3256 (1200-baud TX); review the KISS commit. Will
> retarget to `main` as the stack merges.
>
> **Known follow-up (tomorrow AM):** background/persistence behavior — the KISS
> server currently lives in the AetherModem dialog. With **Start on Startup** it
> runs headless and persists; but if a user *manually* enables the TNC and then
> closes the window (WA_DeleteOnClose), the dialog tears down and stops the
> server. Planned fix: move `KissTncServer` ownership to `MainWindow` so the TNC
> always persists regardless of the window. Keeping this in draft until then.

## Summary

Adds a **KISS-over-TCP TNC** to AetherModem so any host packet/APRS app (Xastir,
YAAC, APRSdroid, UISS, Dire Wolf clients, terminal programs) can send and receive
AX.25 through AetherModem's AFSK modem — plus the requested AetherModem UX
cleanup.

## KISS TNC server

- **`src/core/tnc/KissFraming.{h,cpp}`** — pure KISS framing (FEND/FESC escaping,
  resync-safe incremental decoder, data-frame encode). No Qt::Network dependency,
  so it is unit-tested standalone.
- **`src/core/tnc/KissTncServer.{h,cpp}`** — cross-platform `QTcpServer`:
  - multiple simultaneous clients, each with its own KISS decoder;
  - **proper timeouts**: TCP keepalive + slow-consumer write-backlog cap + idle
    sweep + max-client cap, so dead/stuck clients are reaped, not leaked;
  - RX → all clients (KISS data frames); client → `ax25FrameFromClient` signal.
- **Shim support:**
  - RX captures the exact on-air AX.25 bytes (no FCS) into
    `Ax25DecodedFrame::ax25FrameNoFcs`, so decodes forward to hosts byte-faithfully;
  - `buildTransmitAudioFromFrame()` keys a raw KISS frame (computes/appends FCS),
    refactored to share AFSK rendering with the text TX path.
- **Dialog:** functional **AX.25 / KISS TNC** tabs (`QStackedWidget`); **Enable
  TNC**, **Start TNC on Startup**, **TCP port** (default **8001**) controls, all
  persisted; a serialized KISS TX queue feeding the existing PTT/DAX/pacing path;
  a **TNC STATUS** panel (port, client count, RX/TX counters). Enabling the TNC
  also enables the modem. `MainWindow::startKissTncOnStartupIfConfigured()`
  constructs the window hidden + persistent at launch when Start-on-Startup is
  set (see follow-up note above re: the manual-enable case).

## AetherModem UX overhaul (per request)

- Window renamed `AetherModem - Packet Decoder (Experimental)` → **`AetherModem`**.
- Removed the **Experimental** banner entirely.
- Removed the **Tone Polarity** radios; polarity is always Normal (the correct
  sense for the supported HF DIGU / VHF FM paths).
- **Packet Activity:** taller bars + boosted levels so 1–2 packets/sec are
  clearly visible instead of sitting on the floor; **PACKET ACTIVITY** label
  moved above the graphic to line up with the MODEM STATUS / GAIN STAGE panels.

## Logging

All KISS lifecycle/per-frame activity logs on the `aether.ax25` (AetherModem)
category prefixed `KISS` (listen/stop, client connect/disconnect/refuse/reap, RX
broadcast, TX from client, parse/param) so issues triage as client-side vs
RF-side.

## Tests

`ax25_libmodem_shim_test` gains:
- KISS framing round-trip (incl. FEND/FESC escaping and byte-split reassembly);
- KISS TX-from-frame → AFSK → RX loopback, also asserting the captured RX raw
  frame matches the keyed frame.

All tests pass; full app builds clean on macOS.

## Test plan

- [ ] KISS TNC tab → Enable TNC (8001) → connect Xastir / YAAC / APRSdroid / a
      Dire Wolf KISS client at `host:8001`; confirm connect logged on `aether.ax25`
- [ ] Decode a 2m APRS frame → appears in the host app (RX → client)
- [ ] Send from the host app → keyed on the air at the selected baud (client → TX)
- [ ] Multiple clients simultaneously; kill one rudely → reaped, others fine
- [ ] Toggle Start on Startup, relaunch → TNC listening without opening the window
- [ ] AX.25 tab still transmits/receives unchanged; window title, removed banner,
      removed polarity, taller activity bars, label alignment all as expected
- [ ] `ax25_libmodem_shim_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)