### PR TITLE
[xvtr] Fix XVTR LO Error units display

### DIFF
--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -2707,7 +2707,7 @@ QWidget* RadioSetupDialog::buildXvtrTab()
         auto* rfEdit     = addField(1, 0, "RF Freq (MHz):", QString::number(x.rfFreq, 'f', 3));
         auto* ifEdit     = addField(1, 1, "IF Freq (MHz):", QString::number(x.ifFreq, 'f', 3));
         auto* loEdit     = addField(2, 0, "LO Freq (MHz):", QString::number(x.rfFreq - x.ifFreq, 'f', 3), false);
-        auto* errEdit    = addField(2, 1, "LO Error (Hz):", QString::number(x.loError, 'f', 0));
+        auto* errEdit    = addField(2, 1, "LO Error (MHz):", QString::number(x.loError, 'f', 6));
         auto* rxGainEdit = addField(3, 0, "RX Gain (dB):", QString::number(x.rxGain, 'f', 1));
 
         // RX Only toggle


### PR DESCRIPTION
## Summary

- Relabel the XVTR setup LO Error field from `LO Error (Hz)` to `LO Error (MHz)`.
- Display the existing `x.loError` protocol value with 6 decimal places so small MHz offsets remain visible, e.g. 2 kHz as `0.002000`.
- Leave the command path unchanged so `xvtr set ... lo_error=<value>` continues to send the protocol-exact MHz value entered by the user.

## Scope

This PR only addresses the LO Error unit-label/display mismatch from #3246. It does not include the Max Power clamp or CW AutoTune changes.

Refs #3246

## Verification

- Configured with `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk`.
- Built successfully with `cmake --build build -j22`.
- Built app: `/Users/patj/.codex/worktrees/b9ac/AetherSDR/build/AetherSDR.app`.

## Deployment Note

The deploy script uploaded the built app bundle to `patj@mac.jensencloud.net:/Users/patj/Desktop/AetherSDR.app.uploading.97285`, but replacing the existing remote `/Users/patj/Desktop/AetherSDR.app` and clearing quarantine failed because the remote `rm -rf` step returned `Operation not permitted` for the existing bundle contents, including `/Users/patj/Desktop/AetherSDR.app/Contents/MacOS/AetherSDR`.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
