### PR TITLE
[xvtr] Clamp XVTR Max Power before sending

### DIFF
--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4,6 +4,7 @@
 #include "ComboStyle.h"
 #include "SliceColorManager.h"
 #include "models/RadioModel.h"
+#include "models/XvtrPolicy.h"
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
 #include <QApplication>
@@ -38,6 +39,7 @@
 #include <QSpinBox>
 #include <QDialogButtonBox>
 #include <QCheckBox>
+#include <QDoubleValidator>
 #include <QTimer>
 #include <QDesktopServices>
 #include <QUrl>
@@ -2745,6 +2747,38 @@ QWidget* RadioSetupDialog::buildXvtrTab()
         });
         grid->addWidget(removeBtn, 4, 3);
 
+        auto maxPowerRange = [this, ifEdit] {
+            return XvtrPolicy::maxPowerRangeFor(ifEdit->text().toDouble(), m_model->model());
+        };
+        auto* maxPwrValidator = new QDoubleValidator(maxPwrEdit);
+        maxPwrValidator->setDecimals(2);
+        maxPwrValidator->setNotation(QDoubleValidator::StandardNotation);
+        auto updateMaxPowerValidator = [maxPwrValidator, maxPowerRange] {
+            const XvtrPolicy::MaxPowerRange range = maxPowerRange();
+            maxPwrValidator->setRange(range.minimumDbm, range.maximumDbm, 2);
+        };
+        updateMaxPowerValidator();
+        maxPwrEdit->setValidator(maxPwrValidator);
+        auto submitMaxPower = [this, maxPwrEdit, ifEdit, idx](bool sendWhenUnchanged) {
+            bool ok = false;
+            const double requested = maxPwrEdit->text().toDouble(&ok);
+            if (!ok) {
+                return;
+            }
+
+            const double clamped = XvtrPolicy::clampMaxPowerDbm(
+                requested, ifEdit->text().toDouble(), m_model->model());
+            maxPwrEdit->setText(QString::number(clamped, 'f', 2));
+            if (!sendWhenUnchanged && qFuzzyCompare(requested + 1.0, clamped + 1.0)) {
+                return;
+            }
+
+            m_model->sendCommand(
+                QString("xvtr set %1 max_power=%2")
+                    .arg(idx)
+                    .arg(QString::number(clamped, 'f', 2)));
+        };
+
         // Wire editable fields
         connect(nameEdit, &QLineEdit::editingFinished, this, [this, nameEdit, idx] {
             m_model->sendCommand(
@@ -2760,10 +2794,13 @@ QWidget* RadioSetupDialog::buildXvtrTab()
                 QString("xvtr set %1 rf_freq=%2").arg(idx).arg(rfEdit->text()));
             updateLo();
         });
-        connect(ifEdit, &QLineEdit::editingFinished, this, [this, ifEdit, idx, updateLo] {
+        connect(ifEdit, &QLineEdit::editingFinished, this,
+                [this, ifEdit, idx, updateLo, updateMaxPowerValidator, submitMaxPower] {
             m_model->sendCommand(
                 QString("xvtr set %1 if_freq=%2").arg(idx).arg(ifEdit->text()));
             updateLo();
+            updateMaxPowerValidator();
+            submitMaxPower(false);
         });
         connect(errEdit, &QLineEdit::editingFinished, this, [this, errEdit, idx] {
             m_model->sendCommand(
@@ -2773,9 +2810,8 @@ QWidget* RadioSetupDialog::buildXvtrTab()
             m_model->sendCommand(
                 QString("xvtr set %1 rx_gain=%2").arg(idx).arg(rxGainEdit->text()));
         });
-        connect(maxPwrEdit, &QLineEdit::editingFinished, this, [this, maxPwrEdit, idx] {
-            m_model->sendCommand(
-                QString("xvtr set %1 max_power=%2").arg(idx).arg(maxPwrEdit->text()));
+        connect(maxPwrEdit, &QLineEdit::editingFinished, this, [submitMaxPower] {
+            submitMaxPower(true);
         });
 
         return pg;

--- a/src/models/XvtrPolicy.cpp
+++ b/src/models/XvtrPolicy.cpp
@@ -9,6 +9,12 @@ namespace AetherSDR::XvtrPolicy {
 
 namespace {
 
+constexpr double kMaxPowerFloorDbm = -10.0;
+constexpr double kHighIfThresholdMhz = 80.0;
+constexpr double kHighIfMaxPowerDbm = 8.0;
+constexpr double kLowIfLegacyMaxPowerDbm = 10.0;
+constexpr double kLowIfDefaultMaxPowerDbm = 15.0;
+
 bool isNativeBandKey(const QString& key, ModelCapabilities caps)
 {
     static const QSet<QString> kAlwaysNativeBandKeys = {
@@ -46,6 +52,15 @@ double tileBandwidth(double lowMhz, double highMhz)
 double tileCenter(double lowMhz, double highMhz)
 {
     return (lowMhz + highMhz) / 2.0;
+}
+
+bool usesLegacyLowIfMaxPower(const QString& radioModel)
+{
+    const QString model = radioModel.trimmed().toUpper();
+    return model == QLatin1String("FLEX-6400") ||
+           model == QLatin1String("FLEX-6400M") ||
+           model == QLatin1String("FLEX-6600") ||
+           model == QLatin1String("FLEX-6600M");
 }
 
 } // namespace
@@ -140,6 +155,25 @@ WaterfallTileRange mapWaterfallTileRange(double lowMhz, double highMhz,
 
     const double offset = panCenterMhz - tileCenter(lowMhz, highMhz);
     return {lowMhz + offset, highMhz + offset, true};
+}
+
+MaxPowerRange maxPowerRangeFor(double ifFreqMhz, const QString& radioModel)
+{
+    if (ifFreqMhz >= kHighIfThresholdMhz) {
+        return {kMaxPowerFloorDbm, kHighIfMaxPowerDbm};
+    }
+
+    if (usesLegacyLowIfMaxPower(radioModel)) {
+        return {kMaxPowerFloorDbm, kLowIfLegacyMaxPowerDbm};
+    }
+
+    return {kMaxPowerFloorDbm, kLowIfDefaultMaxPowerDbm};
+}
+
+double clampMaxPowerDbm(double maxPowerDbm, double ifFreqMhz, const QString& radioModel)
+{
+    const MaxPowerRange range = maxPowerRangeFor(ifFreqMhz, radioModel);
+    return std::clamp(maxPowerDbm, range.minimumDbm, range.maximumDbm);
 }
 
 } // namespace AetherSDR::XvtrPolicy

--- a/src/models/XvtrPolicy.h
+++ b/src/models/XvtrPolicy.h
@@ -39,6 +39,11 @@ struct WaterfallTileMatch {
     double  toleranceMhz{0.0};
 };
 
+struct MaxPowerRange {
+    double minimumDbm{-10.0};
+    double maximumDbm{15.0};
+};
+
 BandStackKeyResult resolveBandStackKey(const QString& bandName,
                                        const QVector<Transverter>& xvtrs,
                                        ModelCapabilities caps = {});
@@ -57,5 +62,8 @@ WaterfallTileRange mapWaterfallTileRange(double lowMhz, double highMhz,
                                          double panCenterMhz,
                                          const QVector<Transverter>& xvtrs,
                                          bool hasXvtrSliceAntenna);
+
+MaxPowerRange maxPowerRangeFor(double ifFreqMhz, const QString& radioModel);
+double clampMaxPowerDbm(double maxPowerDbm, double ifFreqMhz, const QString& radioModel);
 
 } // namespace AetherSDR::XvtrPolicy

--- a/tests/xvtr_policy_test.cpp
+++ b/tests/xvtr_policy_test.cpp
@@ -76,6 +76,29 @@ void expectRange(const char* label, const XvtrPolicy::WaterfallTileRange& range,
            detailFor(range));
 }
 
+void expectMaxPowerRange(const char* label, double ifMhz, const QString& radioModel,
+                         double expectedMin, double expectedMax)
+{
+    const XvtrPolicy::MaxPowerRange range =
+        XvtrPolicy::maxPowerRangeFor(ifMhz, radioModel);
+    report(label,
+           near(range.minimumDbm, expectedMin) && near(range.maximumDbm, expectedMax),
+           QStringLiteral("min=%1 max=%2")
+               .arg(range.minimumDbm)
+               .arg(range.maximumDbm)
+               .toStdString());
+}
+
+void expectClampedMaxPower(const char* label, double requestedDbm, double ifMhz,
+                           const QString& radioModel, double expectedDbm)
+{
+    const double clamped =
+        XvtrPolicy::clampMaxPowerDbm(requestedDbm, ifMhz, radioModel);
+    report(label,
+           near(clamped, expectedDbm),
+           QStringLiteral("clamped=%1").arg(clamped).toStdString());
+}
+
 void testBandStackKeysUseFlexIndex()
 {
     const QVector<XvtrPolicy::Transverter> xvtrs = {
@@ -233,6 +256,27 @@ void testXvtrWaterfallGuardrails()
                 inRange, 144.125, 144.625, false);
 }
 
+void testMaxPowerClampMirrorsFlexLib()
+{
+    expectMaxPowerRange("6400 low IF caps max power at +10 dBm",
+                        28.0, QStringLiteral("FLEX-6400"), -10.0, 10.0);
+    expectMaxPowerRange("6600M low IF caps max power at +10 dBm",
+                        28.0, QStringLiteral("FLEX-6600M"), -10.0, 10.0);
+    expectMaxPowerRange("8600 low IF caps max power at +15 dBm",
+                        28.0, QStringLiteral("FLEX-8600"), -10.0, 15.0);
+    expectMaxPowerRange("high IF caps max power at +8 dBm",
+                        80.0, QStringLiteral("FLEX-8600"), -10.0, 8.0);
+
+    expectClampedMaxPower("max power clamps legacy low IF ceiling",
+                          100.0, 28.0, QStringLiteral("FLEX-6400"), 10.0);
+    expectClampedMaxPower("max power clamps default low IF ceiling",
+                          100.0, 28.0, QStringLiteral("FLEX-8600"), 15.0);
+    expectClampedMaxPower("max power clamps high IF ceiling",
+                          100.0, 80.0, QStringLiteral("FLEX-8600"), 8.0);
+    expectClampedMaxPower("max power clamps shared floor",
+                          -99.0, 28.0, QStringLiteral("FLEX-8600"), -10.0);
+}
+
 } // namespace
 
 int main()
@@ -243,6 +287,7 @@ int main()
     testHfWaterfallDoesNotShiftWhenTileLagsByOneSpan();
     testXvtrWaterfallMapsIfToRfBands();
     testXvtrWaterfallGuardrails();
+    testMaxPowerClampMirrorsFlexLib();
 
     return g_failed == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

- Mirror FlexLib XVTR MaxPower bounds in `XvtrPolicy` so AetherSDR clamps before sending `xvtr set ... max_power=`.
- Add a `QDoubleValidator` to the Radio Setup XVTR Max Power field using the active radio model and IF-frequency-dependent dBm range.
- Clamp again on submit, including after IF frequency edits that tighten the allowed Max Power ceiling.
- Add focused `xvtr_policy_test` coverage for the FlexLib ranges: -10 dBm floor, +8 dBm high IF ceiling, +10 dBm 6400/6600 low IF ceiling, and +15 dBm default low IF ceiling.

Refs #3246 (fix #3 only: XVTR Max Power clamp).

## Test Plan

- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk`
- `cmake --build build -j22`
- `./build/xvtr_policy_test`
- Built app: `/Users/patj/.codex/worktrees/145c/AetherSDR/build/AetherSDR.app`
- Deploy attempted with `$deploy-aethersdr-test-build`; upload reached the remote, but replacing `/Users/patj/Desktop/AetherSDR.app` failed repeatedly because remote `rm` returned `Operation not permitted` for the existing app bundle contents.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat