### PR TITLE
feat(tgxl): SSDR-parity PWR/SWR display in TunerApplet

### DIFF
--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -108,6 +108,10 @@ public:
     // in the natural direction.
     void setFillFromRight(bool on) { m_fillFromRight = on; update(); }
 
+    void setBallistics(const MeterSmoother::Ballistics& b) {
+        m_smooth.setBallistics(b);
+    }
+
     void setRange(float min, float max, float redStart,
                   const QVector<Tick>& ticks, float yellowStart = std::numeric_limits<float>::quiet_NaN()) {
         m_min = min; m_max = max; m_redStart = redStart;

--- a/src/gui/TunerApplet.cpp
+++ b/src/gui/TunerApplet.cpp
@@ -10,6 +10,7 @@
 #include <QSignalBlocker>
 #include <QTimer>
 #include "core/ThemeManager.h"
+#include "MeterSmoother.h"
 
 namespace AetherSDR {
 
@@ -77,18 +78,46 @@ void TunerApplet::buildUI()
     vbox->setContentsMargins(4, 2, 4, 2);
     vbox->setSpacing(2);
 
+    static const char* kRowLabelStyle =
+        "QLabel { color: #c8d8e8; font-size: 10px; font-weight: bold; }";
+
     // Forward Power gauge — default barefoot (0–200 W); switches to
     // 0–2000 W if a PGXL amplifier is detected via setAmplifierMode().
-    m_fwdGauge = new HGauge(0.0f, 200.0f, 125.0f, "Fwd Pwr", "W",
+    // External row label carries the live value; internal gauge label is empty.
+    m_pwrLabel = new QLabel("PWR", this);
+    m_pwrLabel->setFixedWidth(72);
+    m_pwrLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    m_pwrLabel->setStyleSheet(kRowLabelStyle);
+    m_fwdGauge = new HGauge(0.0f, 200.0f, 125.0f, "", "",
         {{0, "0"}, {50, "50"}, {100, "100"}, {150, "150"}, {200, "200"}},
         this, 80.0f);
-    vbox->addWidget(m_fwdGauge);
+    // Slow release: bar rises quickly on RF bursts but decays over ~800 ms
+    static_cast<HGauge*>(m_fwdGauge)->setBallistics({0.030f, 0.800f});
+    auto* pwrRow = new QHBoxLayout;
+    pwrRow->setSpacing(4);
+    pwrRow->addWidget(m_pwrLabel);
+    pwrRow->addWidget(m_fwdGauge, 1);
+    vbox->addLayout(pwrRow);
 
     // SWR gauge
-    m_swrGauge = new HGauge(1.0f, 3.0f, 2.5f, "SWR", "",
+    m_swrLabel = new QLabel("SWR", this);
+    m_swrLabel->setFixedWidth(72);
+    m_swrLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    m_swrLabel->setStyleSheet(kRowLabelStyle);
+    m_swrGauge = new HGauge(1.0f, 3.0f, 2.5f, "", "",
         {{1.0f, "1"}, {1.5f, "1.5"}, {2.5f, "2.5"}, {3.0f, "3"}},
         this, 2.0f);
-    vbox->addWidget(m_swrGauge);
+    auto* swrRow = new QHBoxLayout;
+    swrRow->setSpacing(4);
+    swrRow->addWidget(m_swrLabel);
+    swrRow->addWidget(m_swrGauge, 1);
+    vbox->addLayout(swrRow);
+
+    // 10 Hz label update timer — decouples digit flicker from gauge frame rate
+    m_labelTimer = new QTimer(this);
+    m_labelTimer->setInterval(kMeterReadoutUpdateMs);
+    connect(m_labelTimer, &QTimer::timeout, this, &TunerApplet::updateValueLabels);
+    m_labelTimer->start();
 
     // Bottom section: relay bars (75% left) + buttons (25% right)
     auto* bottomRow = new QHBoxLayout;
@@ -322,6 +351,20 @@ void TunerApplet::updateMeters(float fwdPower, float swr)
     if (m_postTuneCapture && swr > 1.01f) {
         m_tuneSwr = swr;
         m_tuneBtn->setText(QString("SWR %1").arg(swr, 0, 'f', 2));
+    }
+}
+
+void TunerApplet::updateValueLabels()
+{
+    // Only show the numeric value when meaningful power is present.
+    // PWR and SWR are indeterminate at idle (< 5 W) so suppress to avoid
+    // cluttering the label with noise-floor readings.
+    if (m_fwdPower >= 5.0f) {
+        m_pwrLabel->setText(QStringLiteral("PWR  %1").arg(static_cast<int>(m_fwdPower)));
+        m_swrLabel->setText(QStringLiteral("SWR  %1:1").arg(m_swr, 0, 'f', 1));
+    } else {
+        m_pwrLabel->setText("PWR");
+        m_swrLabel->setText("SWR");
     }
 }
 

--- a/src/gui/TunerApplet.cpp
+++ b/src/gui/TunerApplet.cpp
@@ -10,8 +10,6 @@
 #include <QSignalBlocker>
 #include <QTimer>
 #include "core/ThemeManager.h"
-#include "MeterSmoother.h"
-
 namespace AetherSDR {
 
 
@@ -24,6 +22,17 @@ TunerApplet::TunerApplet(QWidget* parent)
     theme::setContainer(this, QStringLiteral("applet/tuner"));
     hide();   // hidden by default until toggled on
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
+    // Label clear timer: once power drops below threshold, wait 800 ms before
+    // blanking the PWR/SWR text so inter-packet noise doesn't cause blinking.
+    m_labelClearTimer = new QTimer(this);
+    m_labelClearTimer->setSingleShot(true);
+    m_labelClearTimer->setInterval(800);
+    connect(m_labelClearTimer, &QTimer::timeout, this, [this]() {
+        m_labelShowing = false;
+        m_pwrLabel->setText("PWR");
+        m_swrLabel->setText("SWR");
+    });
 
     // Post-tune capture timer: after tuning=0 arrives, keep capturing SWR
     // for 400ms so the final settled value from the TGXL has time to arrive.
@@ -112,12 +121,6 @@ void TunerApplet::buildUI()
     swrRow->addWidget(m_swrLabel);
     swrRow->addWidget(m_swrGauge, 1);
     vbox->addLayout(swrRow);
-
-    // 10 Hz label update timer — decouples digit flicker from gauge frame rate
-    m_labelTimer = new QTimer(this);
-    m_labelTimer->setInterval(kMeterReadoutUpdateMs);
-    connect(m_labelTimer, &QTimer::timeout, this, &TunerApplet::updateValueLabels);
-    m_labelTimer->start();
 
     // Bottom section: relay bars (75% left) + buttons (25% right)
     auto* bottomRow = new QHBoxLayout;
@@ -344,6 +347,7 @@ void TunerApplet::updateMeters(float fwdPower, float swr)
     m_swr = swr;
     static_cast<HGauge*>(m_fwdGauge)->setValue(fwdPower);
     static_cast<HGauge*>(m_swrGauge)->setValue(swr);
+    updateValueLabels();
 
     // During the post-tune capture window, record the last non-idle SWR.
     // The TGXL reports the settled SWR shortly after tuning=0 arrives;
@@ -356,15 +360,14 @@ void TunerApplet::updateMeters(float fwdPower, float swr)
 
 void TunerApplet::updateValueLabels()
 {
-    // Only show the numeric value when meaningful power is present.
-    // PWR and SWR are indeterminate at idle (< 5 W) so suppress to avoid
-    // cluttering the label with noise-floor readings.
     if (m_fwdPower >= 5.0f) {
+        m_labelClearTimer->stop();
+        m_labelShowing = true;
         m_pwrLabel->setText(QStringLiteral("PWR  %1").arg(static_cast<int>(m_fwdPower)));
         m_swrLabel->setText(QStringLiteral("SWR  %1:1").arg(m_swr, 0, 'f', 1));
-    } else {
-        m_pwrLabel->setText("PWR");
-        m_swrLabel->setText("SWR");
+    } else if (m_labelShowing && !m_labelClearTimer->isActive()) {
+        // Power dropped — start hold window before blanking
+        m_labelClearTimer->start();
     }
 }
 

--- a/src/gui/TunerApplet.h
+++ b/src/gui/TunerApplet.h
@@ -44,6 +44,7 @@ private:
     void syncFromModel();
     void cycleOperateState();
     void updateAntennaButtons(int antA);
+    void updateValueLabels();
 
     TunerModel* m_model{nullptr};
     MeterModel* m_meter{nullptr};
@@ -51,6 +52,11 @@ private:
     // Gauges (custom-painted inner widgets)
     QWidget* m_fwdGauge{nullptr};
     QWidget* m_swrGauge{nullptr};
+
+    // Row labels that show live numeric values ("PWR 987", "SWR 1.2:1")
+    QLabel*  m_pwrLabel{nullptr};
+    QLabel*  m_swrLabel{nullptr};
+    QTimer*  m_labelTimer{nullptr};
 
     // Relay bars
     QWidget* m_c1Bar{nullptr};

--- a/src/gui/TunerApplet.h
+++ b/src/gui/TunerApplet.h
@@ -56,7 +56,8 @@ private:
     // Row labels that show live numeric values ("PWR 987", "SWR 1.2:1")
     QLabel*  m_pwrLabel{nullptr};
     QLabel*  m_swrLabel{nullptr};
-    QTimer*  m_labelTimer{nullptr};
+    QTimer*  m_labelClearTimer{nullptr};  // holds label visible after power drops
+    bool     m_labelShowing{false};
 
     // Relay bars
     QWidget* m_c1Bar{nullptr};


### PR DESCRIPTION
## Summary

Brings the TGXL (Tuner Genius XL) applet's PWR/SWR display to parity with SmartSDR.

### What changed

- **External row labels** — PWR and SWR labels now live to the left of their bargauges (72 px fixed width) and carry live numeric values: `PWR  987`, `SWR  1.2:1`. Internal gauge label is empty, matching the PGXL applet layout.
- **Slow-release fwd-power ballistics** — fwd gauge uses `{30 ms attack / 800 ms release}` so the bar rises quickly on RF bursts and decays slowly, matching SmartSDR behaviour.
- **Threshold gating** — values are only shown when forward power ≥ 5 W; at idle the labels read `PWR` / `SWR` with no noisy floor reading.
- **800 ms hold on label clear** — instead of a polling timer (which caused blinking against the TGXL's slower/irregular update cadence), labels update synchronously on each meter event and are held visible for 800 ms after power drops below threshold, eliminating flicker.
- **`HGauge::setBallistics()`** — added as a public API so individual gauges can opt into custom attack/release curves without subclassing.

### What's remaining / deferred

- Secondary temperature display for TGXL (no temp field in TGXL protocol; N/A for this device)
- PGXL secondary temp (`tempb` / compound `temp` field) — requires pcap analysis to confirm exact key name

## Test plan

- [ ] Transmit with barefoot radio — PWR and SWR appear and hold during TX, blank ~800 ms after TX ends
- [ ] Confirm no blink/flicker at threshold
- [ ] Verify fwd gauge decays slowly after TX (800 ms tail visible)
- [ ] Relay bars (C1 / L / C2) still update normally
- [ ] TUNE / OPERATE / BYPASS / STANDBY buttons unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)