### PR TITLE
feat(modem): KISS-over-TCP TNC + AetherModem UX overhaul

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,6 +575,8 @@ set(CORE_SOURCES
     src/core/MemoryRecallPolicy.cpp
     src/core/tnc/AetherAx25LibmodemShim.cpp
     src/core/tnc/Ax25FrameFormatter.cpp
+    src/core/tnc/KissFraming.cpp
+    src/core/tnc/KissTncServer.cpp
 )
 
 if(APPLE)
@@ -1902,6 +1904,7 @@ add_executable(ax25_libmodem_shim_test
     tests/ax25_libmodem_shim_test.cpp
     src/core/tnc/AetherAx25LibmodemShim.cpp
     src/core/tnc/Ax25FrameFormatter.cpp
+    src/core/tnc/KissFraming.cpp
     # LogManager.cpp provides lcAx25 (the shim's qCDebug category, #2763);
     # LogManager.cpp depends on AsyncLogWriter via the m_writer member, so
     # AppSettings + AsyncLogWriter come along to satisfy the constructor /

--- a/docs/MODEM.md
+++ b/docs/MODEM.md
@@ -173,6 +173,35 @@ path, payload bytes, AX.25 frame bytes, bit count, waveform duration, RMS/peak,
 baud, mark/space, polarity, preamble/postamble flag counts, DAX TX stream id,
 PTT lead/tail timing, and paced chunk progress when debug is enabled.
 
+## KISS TNC (TCP)
+
+The **KISS TNC** tab next to AX.25 turns AetherModem into a KISS-over-TCP TNC so
+any host packet/APRS application drives the modem:
+
+- **Enable TNC** starts/stops a `QTcpServer` (cross-platform) on the configured
+  **TCP port** (default **8001**, all interfaces). **Start TNC on Startup**
+  persists the choice; when set, the app constructs the AetherModem window
+  hidden at launch so the server runs headless and survives the window closing.
+- Multiple clients are supported. Each gets an independent, resync-safe KISS
+  decoder. Dead/stuck clients are reaped via TCP keepalive, a slow-consumer
+  write-backlog cap, and an idle sweep; a client cap bounds resource use.
+- **RX → clients:** every decoded frame is forwarded to all clients as a KISS
+  data frame. The exact on-air bytes (address..info, no FCS) are captured at
+  decode (`Ax25DecodedFrame::ax25FrameNoFcs`) so hosts get a byte-faithful copy.
+- **clients → TX:** a client's KISS data frame is queued and keyed onto the air
+  with the baud profile selected on the AX.25 tab. The modem computes/->appends
+  the FCS (`buildTransmitAudioFromFrame`). Queued frames serialize through the
+  one-at-a-time TX path; the queue drains as each transmit completes.
+- Enabling the TNC also enables the modem (RX tap) for you; a slice must be
+  attached and the radio ready for traffic to flow.
+
+KISS framing lives in `src/core/tnc/KissFraming.{h,cpp}` (pure, unit-tested);
+the server is `src/core/tnc/KissTncServer.{h,cpp}`. All lifecycle and per-frame
+activity logs on the `aether.ax25` (AetherModem) category prefixed `KISS`, so a
+problem can be triaged as client-side (connect/parse/backlog) vs RF-side
+(decode/level/gate). The TNC STATUS panel shows listening port, client count,
+and RX/TX frame counters.
+
 ## Open Work
 
 The remaining missed packets are mostly AX.25-looking candidates that fail FCS. That means the decoder is often finding packet structure but still has symbol/bit errors before CRC.
@@ -187,4 +216,5 @@ Next work should focus on:
 - validating over-the-air AetherModem TX level, timing, and FCS decode with a
   second receiver
 
-Out of scope remains KISS, APRS-IS, maps, digipeating, and connected-mode AX.25.
+Out of scope remains APRS-IS, maps, digipeating, and connected-mode AX.25.
+(KISS-over-TCP is now implemented — see the KISS TNC section above.)

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -212,6 +212,137 @@ void measureStereoFloatPcm(const QByteArray& pcm, double& rmsDbfs, double& peakD
     peakDbfs = toDbfs(peak);
 }
 
+int txPreambleFlagsForProfile(Ax25ModemProfile profile)
+{
+    return profile == Ax25ModemProfile::Vhf1200 ? kVhf1200TxPreambleFlags : kTxPreambleFlags;
+}
+
+// Fill the rate / tone / preamble fields of a TX result from the active config
+// and validate the sample-rate/baud combination. Returns false (with error set)
+// if the combination cannot be rendered.
+bool initTxResult(const Ax25DemodConfig& cfg, Ax25TransmitResult& result)
+{
+    result.sampleRate = cfg.sampleRate;
+    result.baud = cfg.baud;
+    result.polarity = cfg.polarity;
+    result.markHz = cfg.markHz;
+    result.spaceHz = cfg.spaceHz;
+    result.preambleFlags = txPreambleFlagsForProfile(cfg.profile);
+    result.postambleFlags = kTxPostambleFlags;
+    result.vitaPacketFrames = kTxVitaPacketFrames;
+
+    if (cfg.sampleRate <= 0 || cfg.baud <= 0 || cfg.sampleRate % cfg.baud != 0) {
+        result.error = QStringLiteral("unsupported TX sample-rate/baud combination: %1 Hz / %2 baud")
+            .arg(cfg.sampleRate)
+            .arg(cfg.baud);
+        return false;
+    }
+    return true;
+}
+
+// Modulate an encoded AX.25 bitstream into padded stereo float32 AFSK and fill
+// the audio fields of the result. Shared by the text and KISS transmit paths.
+void renderBitsToResult(const std::vector<uint8_t>& bits,
+                        const Ax25DemodConfig& cfg,
+                        Ax25TransmitResult& result)
+{
+    result.bitCount = static_cast<int>(bits.size());
+    const int samplesPerSymbol = cfg.sampleRate / cfg.baud;
+    const int payloadFrames = static_cast<int>(bits.size()) * samplesPerSymbol;
+    const int paddedFrames = ((payloadFrames + kTxVitaPacketFrames - 1) / kTxVitaPacketFrames)
+        * kTxVitaPacketFrames;
+    result.audioFrames = paddedFrames;
+    result.durationSeconds = static_cast<double>(paddedFrames) / static_cast<double>(cfg.sampleRate);
+    result.stereoFloat32Pcm.resize(paddedFrames * 2 * static_cast<int>(sizeof(float)));
+
+    const double mark = cfg.polarity == Ax25TonePolarity::Inverted ? cfg.spaceHz : cfg.markHz;
+    const double space = cfg.polarity == Ax25TonePolarity::Inverted ? cfg.markHz : cfg.spaceHz;
+    double phase = 0.0;
+    int frameIndex = 0;
+    auto* dst = reinterpret_cast<float*>(result.stereoFloat32Pcm.data());
+    for (uint8_t bit : bits) {
+        const double frequency = bit ? mark : space;
+        const double phaseStep = 2.0 * kPi * frequency / static_cast<double>(cfg.sampleRate);
+        for (int i = 0; i < samplesPerSymbol; ++i) {
+            const float sample = static_cast<float>(kTxAfskAmplitude * std::sin(phase));
+            dst[frameIndex * 2] = sample;
+            dst[frameIndex * 2 + 1] = sample;
+            ++frameIndex;
+            phase += phaseStep;
+            if (phase >= 2.0 * kPi)
+                phase -= 2.0 * kPi;
+        }
+    }
+    while (frameIndex < paddedFrames) {
+        dst[frameIndex * 2] = 0.0f;
+        dst[frameIndex * 2 + 1] = 0.0f;
+        ++frameIndex;
+    }
+    measureStereoFloatPcm(result.stereoFloat32Pcm, result.rmsDbfs, result.peakDbfs);
+}
+
+void logTxSummary(const Ax25TransmitResult& result, const QString& via)
+{
+    qCInfo(lcAx25).noquote()
+        << QStringLiteral("AX.25 TX packetized via=%1 SRC=%2 DST=%3 PATH=%4 payloadBytes=%5 "
+                          "frameBytes=%6 bits=%7 samples=%8 duration=%9s levelRms=%10dBFS "
+                          "levelPeak=%11dBFS baud=%12 mark=%13 space=%14 polarity=%15 "
+                          "preamble=%16 postamble=%17")
+            .arg(via,
+                 result.frame.source,
+                 result.frame.destination,
+                 result.frame.path.join(QStringLiteral(",")))
+            .arg(result.frame.payload.size())
+            .arg(result.frameBytes)
+            .arg(result.bitCount)
+            .arg(result.audioFrames)
+            .arg(result.durationSeconds, 0, 'f', 2)
+            .arg(result.rmsDbfs, 0, 'f', 1)
+            .arg(result.peakDbfs, 0, 'f', 1)
+            .arg(result.baud)
+            .arg(result.markHz, 0, 'f', 0)
+            .arg(result.spaceHz, 0, 'f', 0)
+            .arg(result.polarity == Ax25TonePolarity::Normal
+                 ? QStringLiteral("Normal")
+                 : QStringLiteral("Reverse"))
+            .arg(result.preambleFlags)
+            .arg(result.postambleFlags);
+}
+
+// Best-effort decode of raw AX.25 frame bytes (no FCS) into display fields for
+// the TX terminal/log. Returns a frame with payloadHex set if it cannot parse.
+Ax25TransmitFrame transmitFrameFromBytes(const QByteArray& ax25NoFcs)
+{
+    Ax25TransmitFrame out;
+    lm::address from;
+    lm::address to;
+    std::array<lm::address, 8> path = {};
+    std::array<uint8_t, 256> data = {};
+    uint8_t control = 0;
+    uint8_t pid = 0;
+    const auto* begin = reinterpret_cast<const uint8_t*>(ax25NoFcs.constData());
+    const auto* end = begin + ax25NoFcs.size();
+
+    auto [pathOut, dataOut, parsed] = lm::ax25::try_decode_frame_no_fcs(
+        begin, end, from, to, path.begin(), data.begin(), data.size(), control, pid);
+    if (!parsed) {
+        out.payloadHex = QString::fromLatin1(ax25NoFcs.toHex(' ')).toUpper();
+        return out;
+    }
+
+    out.source = addressToString(from);
+    out.destination = addressToString(to);
+    for (auto it = path.begin(); it != pathOut; ++it)
+        out.path.append(addressToString(*it));
+    out.control = control;
+    out.pid = pid;
+    const auto dataLength = static_cast<qsizetype>(std::distance(data.begin(), dataOut));
+    out.payload = QByteArray(reinterpret_cast<const char*>(data.data()), dataLength);
+    out.payloadText = Ax25FrameFormatter::payloadText(out.payload);
+    out.payloadHex = Ax25FrameFormatter::payloadHex(out.payload);
+    return out;
+}
+
 } // namespace
 
 Ax25DemodConfig ax25DemodConfigForProfile(Ax25ModemProfile profile, Ax25TonePolarity polarity)
@@ -713,7 +844,16 @@ struct AetherAx25LibmodemShim::Impl {
         frame.control[0] = control;
         frame.pid = pid;
         frame.crc = actualFcs;
-        return toDecodedFrame(frame, lane.lastQuality, lane.phaseOffsetSamples);
+        Ax25DecodedFrame decodedFrame =
+            toDecodedFrame(frame, lane.lastQuality, lane.phaseOffsetSamples);
+        // Capture the exact on-air frame bytes minus the trailing 2-byte FCS so
+        // the KISS TNC can forward the decode to host apps verbatim.
+        if (candidateFrameBytesSize >= 2) {
+            decodedFrame.ax25FrameNoFcs = QByteArray(
+                reinterpret_cast<const char*>(lane.candidateFrameBytes.data()),
+                static_cast<qsizetype>(candidateFrameBytesSize - 2));
+        }
+        return decodedFrame;
     }
 
     bool shouldEmitFrame(const Ax25DecodedFrame& frame)
@@ -958,24 +1098,8 @@ Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
 {
     Ax25TransmitResult result;
     const auto cfg = m_impl->config;
-    result.sampleRate = cfg.sampleRate;
-    result.baud = cfg.baud;
-    result.polarity = cfg.polarity;
-    result.markHz = cfg.markHz;
-    result.spaceHz = cfg.spaceHz;
-    const int preambleFlags = cfg.profile == Ax25ModemProfile::Vhf1200
-        ? kVhf1200TxPreambleFlags
-        : kTxPreambleFlags;
-    result.preambleFlags = preambleFlags;
-    result.postambleFlags = kTxPostambleFlags;
-    result.vitaPacketFrames = kTxVitaPacketFrames;
-
-    if (cfg.sampleRate <= 0 || cfg.baud <= 0 || cfg.sampleRate % cfg.baud != 0) {
-        result.error = QStringLiteral("unsupported TX sample-rate/baud combination: %1 Hz / %2 baud")
-            .arg(cfg.sampleRate)
-            .arg(cfg.baud);
+    if (!initTxResult(cfg, result))
         return result;
-    }
 
     QString error;
     const std::optional<lm::packet> maybePacket =
@@ -995,71 +1119,44 @@ Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
 
     const std::vector<uint8_t> frameBytes = lm::ax25::encode_frame(packet);
     const std::vector<uint8_t> bits = lm::ax25::encode_bitstream(
-        frameBytes,
-        0,
-        preambleFlags,
-        kTxPostambleFlags);
+        frameBytes, 0, result.preambleFlags, kTxPostambleFlags);
     result.frameBytes = static_cast<int>(frameBytes.size());
-    result.bitCount = static_cast<int>(bits.size());
-
-    const int samplesPerSymbol = cfg.sampleRate / cfg.baud;
-    const int payloadFrames = static_cast<int>(bits.size()) * samplesPerSymbol;
-    const int paddedFrames = ((payloadFrames + kTxVitaPacketFrames - 1) / kTxVitaPacketFrames)
-        * kTxVitaPacketFrames;
-    result.audioFrames = paddedFrames;
-    result.durationSeconds = static_cast<double>(paddedFrames) / static_cast<double>(cfg.sampleRate);
-    result.stereoFloat32Pcm.resize(paddedFrames * 2 * static_cast<int>(sizeof(float)));
-
-    const double mark = cfg.polarity == Ax25TonePolarity::Inverted
-        ? cfg.spaceHz
-        : cfg.markHz;
-    const double space = cfg.polarity == Ax25TonePolarity::Inverted
-        ? cfg.markHz
-        : cfg.spaceHz;
-    double phase = 0.0;
-    int frameIndex = 0;
-    auto* dst = reinterpret_cast<float*>(result.stereoFloat32Pcm.data());
-    for (uint8_t bit : bits) {
-        const double frequency = bit ? mark : space;
-        const double phaseStep = 2.0 * kPi * frequency / static_cast<double>(cfg.sampleRate);
-        for (int i = 0; i < samplesPerSymbol; ++i) {
-            const float sample = static_cast<float>(kTxAfskAmplitude * std::sin(phase));
-            dst[frameIndex * 2] = sample;
-            dst[frameIndex * 2 + 1] = sample;
-            ++frameIndex;
-            phase += phaseStep;
-            if (phase >= 2.0 * kPi)
-                phase -= 2.0 * kPi;
-        }
-    }
-    while (frameIndex < paddedFrames) {
-        dst[frameIndex * 2] = 0.0f;
-        dst[frameIndex * 2 + 1] = 0.0f;
-        ++frameIndex;
-    }
-    measureStereoFloatPcm(result.stereoFloat32Pcm, result.rmsDbfs, result.peakDbfs);
+    renderBitsToResult(bits, cfg, result);
     result.ok = true;
+    logTxSummary(result, QStringLiteral("text"));
+    return result;
+}
 
-    qCInfo(lcAx25).noquote()
-        << QStringLiteral("AX.25 TX packetized SRC=%1 DST=%2 VIA=%3 payloadBytes=%4 frameBytes=%5 bits=%6 samples=%7 duration=%8s levelRms=%9dBFS levelPeak=%10dBFS baud=%11 mark=%12 space=%13 polarity=%14 preamble=%15 postamble=%16")
-            .arg(result.frame.source,
-                 result.frame.destination,
-                 result.frame.path.join(QStringLiteral(",")))
-            .arg(result.frame.payload.size())
-            .arg(result.frameBytes)
-            .arg(result.bitCount)
-            .arg(result.audioFrames)
-            .arg(result.durationSeconds, 0, 'f', 2)
-            .arg(result.rmsDbfs, 0, 'f', 1)
-            .arg(result.peakDbfs, 0, 'f', 1)
-            .arg(result.baud)
-            .arg(result.markHz, 0, 'f', 0)
-            .arg(result.spaceHz, 0, 'f', 0)
-            .arg(result.polarity == Ax25TonePolarity::Normal
-                 ? QStringLiteral("Normal")
-                 : QStringLiteral("Reverse"))
-            .arg(result.preambleFlags)
-            .arg(result.postambleFlags);
+Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudioFromFrame(
+    const QByteArray& ax25NoFcs) const
+{
+    Ax25TransmitResult result;
+    const auto cfg = m_impl->config;
+    if (!initTxResult(cfg, result))
+        return result;
+
+    // Minimum AX.25 UI frame: dest(7) + src(7) + control(1) = 15 bytes.
+    if (ax25NoFcs.size() < 15) {
+        result.error = QStringLiteral("KISS frame too short: %1 bytes (need >= 15)")
+            .arg(ax25NoFcs.size());
+        return result;
+    }
+
+    // The host sends the frame without an FCS; the TNC computes and appends it.
+    std::vector<uint8_t> frameBytes(
+        reinterpret_cast<const uint8_t*>(ax25NoFcs.constData()),
+        reinterpret_cast<const uint8_t*>(ax25NoFcs.constData()) + ax25NoFcs.size());
+    const std::array<uint8_t, 2> crc = lm::ax25::compute_crc(frameBytes.begin(), frameBytes.end());
+    frameBytes.push_back(crc[0]);
+    frameBytes.push_back(crc[1]);
+
+    const std::vector<uint8_t> bits = lm::ax25::encode_bitstream(
+        frameBytes, 0, result.preambleFlags, kTxPostambleFlags);
+    result.frameBytes = static_cast<int>(frameBytes.size());
+    result.frame = transmitFrameFromBytes(ax25NoFcs);
+    renderBitsToResult(bits, cfg, result);
+    result.ok = true;
+    logTxSummary(result, QStringLiteral("kiss"));
     return result;
 }
 

--- a/src/core/tnc/AetherAx25LibmodemShim.h
+++ b/src/core/tnc/AetherAx25LibmodemShim.h
@@ -126,6 +126,10 @@ public:
     Ax25TransmitResult buildTransmitAudio(const QString& text,
                                           const QString& defaultSource,
                                           const QString& defaultDestination = QStringLiteral("APRS")) const;
+    // Build TX audio from a raw AX.25 frame (address..info, no FCS), e.g. the
+    // payload of a KISS data frame from a host application. The FCS is computed
+    // and appended here before HDLC framing and AFSK modulation.
+    Ax25TransmitResult buildTransmitAudioFromFrame(const QByteArray& ax25NoFcs) const;
 
     Ax25DecoderDiagnostics diagnosticsSnapshot() const;
     QString demodDescription() const;

--- a/src/core/tnc/Ax25DecodedFrame.h
+++ b/src/core/tnc/Ax25DecodedFrame.h
@@ -27,6 +27,10 @@ struct Ax25DecodedFrame {
     bool fcsOk{false};
     double confidenceOrQuality{0.0};
     int decodePhaseOffsetSamples{-1};
+    // Raw on-air AX.25 frame bytes (address through info), WITHOUT HDLC flags or
+    // the 2-byte FCS — i.e. exactly the payload of a KISS data frame, so the TNC
+    // can forward a decode to host applications byte-for-byte.
+    QByteArray ax25FrameNoFcs;
 };
 
 } // namespace AetherSDR

--- a/src/core/tnc/KissFraming.cpp
+++ b/src/core/tnc/KissFraming.cpp
@@ -1,0 +1,109 @@
+#include "core/tnc/KissFraming.h"
+
+namespace AetherSDR::kiss {
+
+QByteArray escape(const QByteArray& in)
+{
+    QByteArray out;
+    out.reserve(in.size() + 8);
+    for (const char ch : in) {
+        const quint8 b = static_cast<quint8>(ch);
+        if (b == kFend) {
+            out.append(static_cast<char>(kFesc));
+            out.append(static_cast<char>(kTfend));
+        } else if (b == kFesc) {
+            out.append(static_cast<char>(kFesc));
+            out.append(static_cast<char>(kTfesc));
+        } else {
+            out.append(ch);
+        }
+    }
+    return out;
+}
+
+QByteArray unescape(const QByteArray& in)
+{
+    QByteArray out;
+    out.reserve(in.size());
+    bool escape = false;
+    for (const char ch : in) {
+        const quint8 b = static_cast<quint8>(ch);
+        if (escape) {
+            if (b == kTfend) {
+                out.append(static_cast<char>(kFend));
+            } else if (b == kTfesc) {
+                out.append(static_cast<char>(kFesc));
+            } else {
+                out.append(ch); // invalid escape — keep the byte literally
+            }
+            escape = false;
+        } else if (b == kFesc) {
+            escape = true;
+        } else {
+            out.append(ch);
+        }
+    }
+    return out;
+}
+
+QByteArray encodeDataFrame(const QByteArray& ax25NoFcs, quint8 port)
+{
+    QByteArray out;
+    out.reserve(ax25NoFcs.size() + 4);
+    out.append(static_cast<char>(kFend));
+    out.append(static_cast<char>((port << 4) | kCmdData));
+    out.append(escape(ax25NoFcs));
+    out.append(static_cast<char>(kFend));
+    return out;
+}
+
+QVector<QByteArray> Decoder::feed(const QByteArray& bytes)
+{
+    QVector<QByteArray> frames;
+    for (const char ch : bytes) {
+        const quint8 b = static_cast<quint8>(ch);
+
+        if (b == kFend) {
+            if (m_synced && !m_overflow && !m_frame.isEmpty())
+                frames.append(unescape(m_frame));
+            m_frame.clear();
+            m_synced = true;
+            m_overflow = false;
+            continue;
+        }
+
+        if (!m_synced)
+            continue; // ignore bytes before the first frame boundary
+
+        if (m_overflow)
+            continue; // drop the rest of an oversized frame until next FEND
+
+        m_frame.append(ch);
+        if (m_frame.size() > kMaxFrameBytes) {
+            m_frame.clear();
+            m_overflow = true;
+        }
+    }
+    return frames;
+}
+
+void Decoder::reset()
+{
+    m_frame.clear();
+    m_synced = false;
+    m_overflow = false;
+}
+
+bool splitTypeByte(const QByteArray& frameWithType, quint8& port, quint8& command,
+                   QByteArray& payload)
+{
+    if (frameWithType.isEmpty())
+        return false;
+    const quint8 type = static_cast<quint8>(frameWithType.at(0));
+    port = (type >> 4) & 0x0F;
+    command = type & 0x0F;
+    payload = frameWithType.mid(1);
+    return true;
+}
+
+} // namespace AetherSDR::kiss

--- a/src/core/tnc/KissFraming.h
+++ b/src/core/tnc/KissFraming.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <QByteArray>
+#include <QVector>
+#include <QtGlobal>
+
+// Pure KISS (Keep It Simple Stupid) TNC framing — no Qt::Network dependency so
+// it can be unit-tested standalone. KISS wraps raw AX.25 frames (address through
+// info, WITHOUT the HDLC flags or FCS) for exchange with a host APRS/packet
+// application over a serial or TCP link.
+//
+// Reference: the KISS protocol (Chepponis & Karn, 1987).
+
+namespace AetherSDR::kiss {
+
+constexpr quint8 kFend = 0xC0;  // Frame End delimiter
+constexpr quint8 kFesc = 0xDB;  // Frame Escape
+constexpr quint8 kTfend = 0xDC; // Transposed Frame End
+constexpr quint8 kTfesc = 0xDD; // Transposed Frame Escape
+
+// Low-nibble command codes of the KISS type byte (high nibble = port).
+constexpr quint8 kCmdData = 0x00;
+constexpr quint8 kCmdTxDelay = 0x01;
+constexpr quint8 kCmdPersistence = 0x02;
+constexpr quint8 kCmdSlotTime = 0x03;
+constexpr quint8 kCmdTxTail = 0x04;
+constexpr quint8 kCmdFullDuplex = 0x05;
+constexpr quint8 kCmdSetHardware = 0x06;
+constexpr quint8 kCmdReturn = 0xFF;
+
+// Largest in-progress KISS frame we will buffer before treating the stream as
+// garbage and resyncing. A full AX.25 frame is well under 512 bytes; this is a
+// generous guard against a runaway/desynced client.
+constexpr int kMaxFrameBytes = 4096;
+
+// Escape FEND/FESC occurrences in a payload per the KISS transposition rules.
+QByteArray escape(const QByteArray& in);
+
+// Reverse of escape(). Lone/!invalid escapes are passed through literally.
+QByteArray unescape(const QByteArray& in);
+
+// Wrap a raw AX.25 frame (no FCS) as a complete KISS data frame:
+//   FEND, (port<<4 | CmdData), <escaped bytes>, FEND
+QByteArray encodeDataFrame(const QByteArray& ax25NoFcs, quint8 port = 0);
+
+// Incremental, resync-safe KISS deframer. Feed arbitrary byte chunks from a
+// socket; returns any complete frames. Each returned frame includes its leading
+// type byte (so callers can read the port/command) and is already unescaped.
+class Decoder {
+public:
+    QVector<QByteArray> feed(const QByteArray& bytes);
+    void reset();
+
+    // True once we have seen our first FEND and are tracking a frame boundary.
+    bool synced() const { return m_synced; }
+
+private:
+    QByteArray m_frame;
+    bool m_synced = false;
+    bool m_overflow = false;
+};
+
+// Convenience: split a complete (unescaped) KISS frame into its command nibble,
+// port, and payload (everything after the type byte). Returns false if empty.
+bool splitTypeByte(const QByteArray& frameWithType, quint8& port, quint8& command,
+                   QByteArray& payload);
+
+} // namespace AetherSDR::kiss

--- a/src/core/tnc/KissTncServer.cpp
+++ b/src/core/tnc/KissTncServer.cpp
@@ -1,0 +1,251 @@
+#include "core/tnc/KissTncServer.h"
+
+#include "core/LogManager.h"
+
+#include <QHostAddress>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QTimer>
+
+namespace AetherSDR {
+
+KissTncServer::KissTncServer(QObject* parent)
+    : QObject(parent)
+{
+}
+
+KissTncServer::~KissTncServer()
+{
+    stop();
+}
+
+bool KissTncServer::start(quint16 port)
+{
+    stop();
+
+    m_server = new QTcpServer(this);
+    connect(m_server, &QTcpServer::newConnection, this, &KissTncServer::onNewConnection);
+
+    if (!m_server->listen(QHostAddress::Any, port)) {
+        m_lastError = m_server->errorString();
+        qCWarning(lcAx25).noquote()
+            << QStringLiteral("KISS TNC failed to listen on port %1: %2").arg(port).arg(m_lastError);
+        emit activity(QStringLiteral("KISS TNC could not bind port %1: %2").arg(port).arg(m_lastError));
+        m_server->deleteLater();
+        m_server = nullptr;
+        return false;
+    }
+
+    m_port = port;
+    m_lastError.clear();
+    m_framesToClients = 0;
+    m_framesFromClients = 0;
+
+    m_sweepTimer = new QTimer(this);
+    m_sweepTimer->setInterval(kSweepIntervalMs);
+    connect(m_sweepTimer, &QTimer::timeout, this, &KissTncServer::onSweepTimer);
+    m_sweepTimer->start();
+
+    qCInfo(lcAx25).noquote()
+        << QStringLiteral("KISS TNC listening on TCP port %1 (all interfaces), maxClients=%2")
+               .arg(port).arg(m_maxClients);
+    emit activity(QStringLiteral("KISS TNC listening on TCP port %1.").arg(port));
+    emit listeningChanged(true);
+    return true;
+}
+
+void KissTncServer::stop()
+{
+    if (m_sweepTimer) {
+        m_sweepTimer->stop();
+        m_sweepTimer->deleteLater();
+        m_sweepTimer = nullptr;
+    }
+
+    const bool wasListening = m_server != nullptr;
+    const int hadClients = m_clients.size();
+
+    for (auto it = m_clients.begin(); it != m_clients.end(); ++it) {
+        QTcpSocket* socket = it.key();
+        socket->disconnect(this); // stop our slots firing during teardown
+        socket->abort();
+        socket->deleteLater();
+    }
+    m_clients.clear();
+
+    if (m_server) {
+        m_server->close();
+        m_server->deleteLater();
+        m_server = nullptr;
+    }
+
+    if (wasListening) {
+        qCInfo(lcAx25).noquote()
+            << QStringLiteral("KISS TNC stopped (closed %1 client(s)).").arg(hadClients);
+        emit activity(QStringLiteral("KISS TNC stopped."));
+        emit listeningChanged(false);
+        emitClientCount();
+    }
+}
+
+bool KissTncServer::isListening() const
+{
+    return m_server != nullptr && m_server->isListening();
+}
+
+void KissTncServer::onNewConnection()
+{
+    if (!m_server)
+        return;
+
+    while (QTcpSocket* socket = m_server->nextPendingConnection()) {
+        if (m_clients.size() >= m_maxClients) {
+            const QString peer = QStringLiteral("%1:%2")
+                .arg(socket->peerAddress().toString()).arg(socket->peerPort());
+            qCWarning(lcAx25).noquote()
+                << QStringLiteral("KISS TNC refused %1: client limit (%2) reached")
+                       .arg(peer).arg(m_maxClients);
+            emit activity(QStringLiteral("KISS TNC refused %1 (client limit reached).").arg(peer));
+            socket->abort();
+            socket->deleteLater();
+            continue;
+        }
+
+        // TCP keepalive lets the OS reap a peer that vanished without a FIN.
+        socket->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
+        socket->setSocketOption(QAbstractSocket::LowDelayOption, 1); // Nagle off: small KISS frames
+
+        Client client;
+        client.peer = QStringLiteral("%1:%2")
+            .arg(socket->peerAddress().toString()).arg(socket->peerPort());
+        client.lastActivity.start();
+        m_clients.insert(socket, client);
+
+        connect(socket, &QTcpSocket::readyRead, this, &KissTncServer::onReadyRead);
+        connect(socket, &QTcpSocket::disconnected, this, &KissTncServer::onDisconnected);
+
+        qCInfo(lcAx25).noquote()
+            << QStringLiteral("KISS TNC client connected: %1 (now %2 client(s))")
+                   .arg(client.peer).arg(m_clients.size());
+        emit activity(QStringLiteral("KISS client connected: %1.").arg(client.peer));
+        emitClientCount();
+    }
+}
+
+void KissTncServer::onReadyRead()
+{
+    auto* socket = qobject_cast<QTcpSocket*>(sender());
+    if (!socket)
+        return;
+    auto it = m_clients.find(socket);
+    if (it == m_clients.end())
+        return;
+
+    it->lastActivity.restart();
+    const QByteArray chunk = socket->readAll();
+    const QVector<QByteArray> frames = it->decoder.feed(chunk);
+
+    for (const QByteArray& frame : frames) {
+        quint8 portNibble = 0;
+        quint8 command = 0;
+        QByteArray payload;
+        if (!kiss::splitTypeByte(frame, portNibble, command, payload))
+            continue;
+
+        if (command == kiss::kCmdData) {
+            if (payload.isEmpty())
+                continue;
+            ++m_framesFromClients;
+            qCDebug(lcAx25).noquote()
+                << QStringLiteral("KISS TX from %1: %2 AX.25 bytes (frame #%3)")
+                       .arg(it->peer).arg(payload.size()).arg(m_framesFromClients);
+            emit ax25FrameFromClient(payload);
+        } else if (command == kiss::kCmdReturn) {
+            qCDebug(lcAx25).noquote()
+                << QStringLiteral("KISS exit (return) from %1 — ignored on a TCP link").arg(it->peer);
+        } else {
+            qCDebug(lcAx25).noquote()
+                << QStringLiteral("KISS param from %1: cmd=0x%2 bytes=%3")
+                       .arg(it->peer).arg(command, 2, 16, QLatin1Char('0')).arg(payload.size());
+            emit kissParameterReceived(command, payload);
+        }
+    }
+}
+
+void KissTncServer::broadcastAx25Frame(const QByteArray& ax25NoFcs)
+{
+    if (ax25NoFcs.isEmpty() || m_clients.isEmpty())
+        return;
+
+    const QByteArray kissFrame = kiss::encodeDataFrame(ax25NoFcs);
+    int delivered = 0;
+    QVector<QTcpSocket*> slowConsumers;
+    for (auto it = m_clients.begin(); it != m_clients.end(); ++it) {
+        QTcpSocket* socket = it.key();
+        if (socket->state() != QAbstractSocket::ConnectedState)
+            continue;
+        if (socket->bytesToWrite() > kMaxWriteBacklogBytes) {
+            slowConsumers.append(socket);
+            continue;
+        }
+        socket->write(kissFrame);
+        ++delivered;
+    }
+
+    if (delivered > 0)
+        ++m_framesToClients;
+
+    qCDebug(lcAx25).noquote()
+        << QStringLiteral("KISS RX broadcast: %1 AX.25 bytes to %2 client(s) (frame #%3)")
+               .arg(ax25NoFcs.size()).arg(delivered).arg(m_framesToClients);
+
+    for (QTcpSocket* socket : slowConsumers)
+        closeClient(socket, QStringLiteral("write backlog exceeded (slow consumer)"));
+}
+
+void KissTncServer::onDisconnected()
+{
+    auto* socket = qobject_cast<QTcpSocket*>(sender());
+    if (!socket)
+        return;
+    closeClient(socket, QStringLiteral("disconnected"));
+}
+
+void KissTncServer::onSweepTimer()
+{
+    QVector<QTcpSocket*> stale;
+    for (auto it = m_clients.begin(); it != m_clients.end(); ++it) {
+        if (it->lastActivity.isValid() && it->lastActivity.elapsed() > kIdleTimeoutMs)
+            stale.append(it.key());
+    }
+    for (QTcpSocket* socket : stale)
+        closeClient(socket, QStringLiteral("idle timeout"));
+}
+
+void KissTncServer::closeClient(QTcpSocket* socket, const QString& reason)
+{
+    auto it = m_clients.find(socket);
+    if (it == m_clients.end()) {
+        socket->deleteLater();
+        return;
+    }
+    const QString peer = it->peer;
+    m_clients.erase(it);
+
+    socket->disconnect(this);
+    socket->abort();
+    socket->deleteLater();
+
+    qCInfo(lcAx25).noquote()
+        << QStringLiteral("KISS TNC client %1 closed: %2 (now %3 client(s))")
+               .arg(peer, reason).arg(m_clients.size());
+    emit activity(QStringLiteral("KISS client %1 closed: %2.").arg(peer, reason));
+    emitClientCount();
+}
+
+void KissTncServer::emitClientCount()
+{
+    emit clientCountChanged(m_clients.size());
+}
+
+} // namespace AetherSDR

--- a/src/core/tnc/KissTncServer.h
+++ b/src/core/tnc/KissTncServer.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "core/tnc/KissFraming.h"
+
+#include <QByteArray>
+#include <QElapsedTimer>
+#include <QHash>
+#include <QObject>
+#include <QString>
+
+class QTcpServer;
+class QTcpSocket;
+class QTimer;
+
+namespace AetherSDR {
+
+// A KISS-over-TCP TNC server. Host applications (APRS clients, terminal/packet
+// programs, Dire Wolf-style tools) connect over TCP and exchange raw AX.25
+// frames in KISS framing; AetherModem provides the AFSK modem underneath.
+//
+// - Cross-platform (Qt QTcpServer/QTcpSocket).
+// - Multiple simultaneous clients; each gets its own resync-safe KISS decoder.
+// - TCP keepalive plus slow-consumer and optional idle timeouts so dead or
+//   stuck clients are reaped rather than leaking sockets/memory.
+// - All lifecycle and per-frame activity is logged on the aether.ax25 category
+//   (prefixed "KISS") so issues can be triaged as client-side vs RF-side.
+class KissTncServer : public QObject {
+    Q_OBJECT
+
+public:
+    explicit KissTncServer(QObject* parent = nullptr);
+    ~KissTncServer() override;
+
+    // Start listening on the given TCP port (all interfaces). Returns true on
+    // success; on failure lastError() explains why and listeningChanged stays
+    // false. Restarting on a new port is a stop() + start().
+    bool start(quint16 port);
+    void stop();
+
+    bool isListening() const;
+    quint16 port() const { return m_port; }
+    int clientCount() const { return m_clients.size(); }
+    QString lastError() const { return m_lastError; }
+
+    quint64 framesToClients() const { return m_framesToClients; }
+    quint64 framesFromClients() const { return m_framesFromClients; }
+
+    // Max simultaneous clients; further connections are refused. Default 8.
+    void setMaxClients(int n) { m_maxClients = n; }
+
+public slots:
+    // RX path: an AX.25 frame (address..info, no FCS) was decoded off the air;
+    // fan it out to every connected client as a KISS data frame.
+    void broadcastAx25Frame(const QByteArray& ax25NoFcs);
+
+signals:
+    // TX path: a client sent a KISS data frame; payload is the raw AX.25 frame
+    // (no FCS) to key onto the air.
+    void ax25FrameFromClient(const QByteArray& ax25NoFcs);
+
+    // A non-data KISS command (TXDELAY, persistence, etc.) arrived.
+    void kissParameterReceived(quint8 command, const QByteArray& value);
+
+    void listeningChanged(bool listening);
+    void clientCountChanged(int count);
+
+    // Human-readable lifecycle line for the AetherModem window terminal.
+    void activity(const QString& message);
+
+private slots:
+    void onNewConnection();
+    void onReadyRead();
+    void onDisconnected();
+    void onSweepTimer();
+
+private:
+    struct Client {
+        kiss::Decoder decoder;
+        QElapsedTimer lastActivity;
+        QString peer;
+    };
+
+    void closeClient(QTcpSocket* socket, const QString& reason);
+    void emitClientCount();
+
+    QTcpServer* m_server = nullptr;
+    QHash<QTcpSocket*, Client> m_clients;
+    QTimer* m_sweepTimer = nullptr;
+    quint16 m_port = 8001;
+    int m_maxClients = 8;
+    QString m_lastError;
+    quint64 m_framesToClients = 0;
+    quint64 m_framesFromClients = 0;
+
+    // Drop a client whose unsent backlog exceeds this (slow/stuck consumer).
+    static constexpr qint64 kMaxWriteBacklogBytes = 256 * 1024;
+    // Drop a client idle (no bytes received) longer than this. Generous because
+    // a legitimate KISS client may sit quiet for long stretches; TCP keepalive
+    // is the primary dead-peer detector.
+    static constexpr qint64 kIdleTimeoutMs = 30 * 60 * 1000;
+    static constexpr int kSweepIntervalMs = 30 * 1000;
+};
+
+} // namespace AetherSDR

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -6,10 +6,12 @@
 #include "core/LogManager.h"
 #include "core/ThemeManager.h"
 #include "core/tnc/Ax25FrameFormatter.h"
+#include "core/tnc/KissTncServer.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
 
+#include <QButtonGroup>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDateTime>
@@ -25,7 +27,10 @@
 #include <QPushButton>
 #include <QRadioButton>
 #include <QScrollBar>
+#include <QSignalBlocker>
 #include <QSizePolicy>
+#include <QSpinBox>
+#include <QStackedWidget>
 #include <QTextDocument>
 #include <QTextEdit>
 #include <QTimer>
@@ -41,8 +46,11 @@ namespace AetherSDR {
 namespace {
 
 constexpr auto kPacketDecoderProfileSetting = "Ax25PacketDecoderProfile";
-constexpr auto kPacketDecoderPolaritySetting = "Ax25PacketDecoderPolarity";
 constexpr auto kPacketDecoderDebugSetting = "Ax25PacketDecoderDiagnosticsDebug";
+constexpr auto kTncEnabledSetting = "AetherModemKissTncEnabled";
+constexpr auto kTncStartOnStartupSetting = "AetherModemKissTncStartOnStartup";
+constexpr auto kTncPortSetting = "AetherModemKissTncPort";
+constexpr int kTncDefaultPort = 8001;
 constexpr int kAudioCaptureSeconds = 180;
 constexpr int kTxDaxSettleMs = 150;
 constexpr int kTxLeadMs = 200;
@@ -239,22 +247,6 @@ Ax25ModemProfile profileFromSettingsValue(const QString& value)
     return Ax25ModemProfile::Hf300;
 }
 
-QString polaritySettingsValue(Ax25TonePolarity polarity)
-{
-    return polarity == Ax25TonePolarity::Inverted
-        ? QStringLiteral("Reverse")
-        : QStringLiteral("Normal");
-}
-
-Ax25TonePolarity polarityFromSettingsValue(const QString& value)
-{
-    if (value.compare(QStringLiteral("Reverse"), Qt::CaseInsensitive) == 0
-        || value.compare(QStringLiteral("Inverted"), Qt::CaseInsensitive) == 0) {
-        return Ax25TonePolarity::Inverted;
-    }
-    return Ax25TonePolarity::Normal;
-}
-
 QLabel* sectionLabel(const QString& text, QWidget* parent)
 {
     auto* label = new QLabel(text, parent);
@@ -389,12 +381,12 @@ public:
         : QWidget(parent)
         , m_levels(68)
     {
-        setMinimumHeight(38);
+        setMinimumHeight(56);
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         setCursor(Qt::PointingHandCursor);
         updateToolTip();
         for (int i = 0; i < m_levels.size(); ++i)
-            m_levels[i] = 4 + ((i * 7) % 6);
+            m_levels[i] = 6 + ((i * 7) % 8);
     }
 
     void setDebugEnabled(bool enabled)
@@ -411,12 +403,15 @@ public:
         m_clickHandler = std::move(handler);
     }
 
+    // Bar levels are pixel heights against the (taller) usable height; values
+    // are scaled so even one or two packets/sec produce a clearly visible spike
+    // rather than sitting on the floor.
     void recordFrame()
     {
         m_cursor = (m_cursor + 9) % m_levels.size();
-        m_levels[m_cursor] = 30;
+        m_levels[m_cursor] = 46;
         if (m_cursor + 3 < m_levels.size())
-            m_levels[m_cursor + 3] = 18;
+            m_levels[m_cursor + 3] = 28;
         update();
     }
 
@@ -426,11 +421,11 @@ public:
             return;
 
         m_cursor = (m_cursor + 1) % m_levels.size();
-        int level = receiveGateOpen ? 9 : 3;
+        int level = receiveGateOpen ? 16 : 6;
         if (hdlcCandidates > 0)
-            level = std::max(level, 9 + std::min(14, hdlcCandidates * 3));
+            level = std::max(level, 16 + std::min(28, hdlcCandidates * 5));
         if (acceptedFrames > 0)
-            level = 30;
+            level = 46;
         m_levels[m_cursor] = level;
         update();
     }
@@ -438,7 +433,7 @@ public:
     void reset()
     {
         for (int i = 0; i < m_levels.size(); ++i)
-            m_levels[i] = 3 + ((i * 5) % 5);
+            m_levels[i] = 6 + ((i * 5) % 7);
         m_cursor = 0;
         update();
     }
@@ -504,7 +499,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
                                                    RadioModel* radio,
                                                    SliceModel* initialSlice,
                                                    QWidget* parent)
-    : PersistentDialog(QStringLiteral("AetherModem - Packet Decoder (Experimental)"),
+    : PersistentDialog(QStringLiteral("AetherModem"),
                        QStringLiteral("Ax25HfPacketDecodeDialogGeometry"),
                        parent)
     , m_audio(audio)
@@ -514,6 +509,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     setMinimumSize(1080, 680);
 
     m_shim = new AetherAx25LibmodemShim(this);
+    m_kissServer = new KissTncServer(this);
     m_heartbeatTimer = new QTimer(this);
     m_heartbeatTimer->setInterval(1000);
     m_txPaceTimer = new QTimer(this);
@@ -523,35 +519,35 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(10);
 
-    // Em-dash is — (U+2014).  Don't use the byte-escape \xE2\x80\x94 form
-    // here — inside QStringLiteral the literal expands to a UTF-16 (u"...")
-    // string where each \xXX is a single char16_t code unit, not a byte of a
-    // multi-byte UTF-8 sequence.  Three separate code units (0x00E2, 0x0080,
-    // 0x0094) render as "â" + two control glyphs, which is what shipped.
-    auto* experimentalBanner = new QLabel(
-        QStringLiteral("<b>Experimental — AX.25 modem bring-up.</b> "
-                       "300 baud HF and 1200 baud VHF (Bell 202 / 2m APRS) "
-                       "AX.25 receive and transmit are active."),
-        bodyWidget());
-    experimentalBanner->setObjectName(QStringLiteral("ExperimentalBanner"));
-    experimentalBanner->setWordWrap(true);
-    experimentalBanner->setTextFormat(Qt::RichText);
-    root->addWidget(experimentalBanner);
-
     auto* tabsFrame = panel(QStringLiteral("TabsFrame"), bodyWidget());
     auto* tabs = new QHBoxLayout(tabsFrame);
     tabs->setContentsMargins(0, 0, 0, 0);
     tabs->setSpacing(0);
-    tabs->addWidget(tabButton(QStringLiteral("AX.25"), true, tabsFrame), 1);
-    auto* terminalTab = tabButton(QStringLiteral("Terminal"), false, tabsFrame);
-    terminalTab->setVisible(false);
-    tabs->addWidget(terminalTab, 1);
-    auto* mailboxTab = tabButton(QStringLiteral("Mailbox"), false, tabsFrame);
-    mailboxTab->setVisible(false);
-    tabs->addWidget(mailboxTab, 1);
+    m_ax25Tab = tabButton(QStringLiteral("AX.25"), true, tabsFrame);
+    m_kissTab = tabButton(QStringLiteral("KISS TNC"), false, tabsFrame);
+    m_ax25Tab->setEnabled(true);
+    m_kissTab->setEnabled(true);
+    auto* tabGroup = new QButtonGroup(this);
+    tabGroup->setExclusive(true);
+    tabGroup->addButton(m_ax25Tab, 0);
+    tabGroup->addButton(m_kissTab, 1);
+    tabs->addWidget(m_ax25Tab, 1);
+    tabs->addWidget(m_kissTab, 1);
     root->addWidget(tabsFrame);
 
-    auto* controlsFrame = panel(QStringLiteral("ControlsFrame"), bodyWidget());
+    m_tabStack = new QStackedWidget(bodyWidget());
+    root->addWidget(m_tabStack);
+    connect(tabGroup, &QButtonGroup::idClicked, m_tabStack, &QStackedWidget::setCurrentIndex);
+
+    // AX.25 page: modem config + transmit. The log and status row below the
+    // stack are shared by both tabs.
+    auto* ax25Page = new QWidget(m_tabStack);
+    auto* ax25PageLayout = new QVBoxLayout(ax25Page);
+    ax25PageLayout->setContentsMargins(0, 0, 0, 0);
+    ax25PageLayout->setSpacing(10);
+    m_tabStack->addWidget(ax25Page);
+
+    auto* controlsFrame = panel(QStringLiteral("ControlsFrame"), ax25Page);
     auto* controls = new QHBoxLayout(controlsFrame);
     controls->setContentsMargins(16, 14, 16, 14);
     controls->setSpacing(20);
@@ -579,22 +575,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_enableDecode = new QCheckBox(QStringLiteral("Enable Modem"), modemCell);
     modemLayout->addWidget(m_enableDecode);
     controls->addWidget(modemCell, 1);
-
-    auto* polarityCell = panel(QStringLiteral("ControlCell"), controlsFrame);
-    auto* polarityLayout = new QVBoxLayout(polarityCell);
-    polarityLayout->setContentsMargins(0, 0, 20, 0);
-    polarityLayout->setSpacing(12);
-    polarityLayout->addWidget(sectionLabel(QStringLiteral("TONE POLARITY"), polarityCell));
-    auto* polarityButtons = new QHBoxLayout;
-    polarityButtons->setSpacing(34);
-    m_polarityNormal = new QRadioButton(QStringLiteral("Normal"), polarityCell);
-    m_polarityReverse = new QRadioButton(QStringLiteral("Reverse"), polarityCell);
-    m_polarityNormal->setChecked(true);
-    polarityButtons->addWidget(m_polarityNormal);
-    polarityButtons->addWidget(m_polarityReverse);
-    polarityButtons->addStretch(1);
-    polarityLayout->addLayout(polarityButtons);
-    controls->addWidget(polarityCell, 2);
+    controls->addStretch(2);
 
     m_captureButton = new QPushButton(QStringLiteral("Capture 3m"), controlsFrame);
     m_captureButton->setMinimumHeight(42);
@@ -603,9 +584,9 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_clearButton = new QPushButton(QStringLiteral("Clear Log"), controlsFrame);
     m_clearButton->setMinimumHeight(42);
     controls->addWidget(m_clearButton);
-    root->addWidget(controlsFrame);
+    ax25PageLayout->addWidget(controlsFrame);
 
-    auto* txFrame = panel(QStringLiteral("ControlsFrame"), bodyWidget());
+    auto* txFrame = panel(QStringLiteral("ControlsFrame"), ax25Page);
     auto* txLayout = new QHBoxLayout(txFrame);
     txLayout->setContentsMargins(16, 12, 16, 12);
     txLayout->setSpacing(12);
@@ -617,7 +598,11 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_txButton = new QPushButton(QStringLiteral("Transmit"), txFrame);
     m_txButton->setMinimumHeight(42);
     txLayout->addWidget(m_txButton);
-    root->addWidget(txFrame);
+    ax25PageLayout->addWidget(txFrame);
+    ax25PageLayout->addStretch(1);
+
+    // KISS TNC page (built lazily into the same stack).
+    m_tabStack->addWidget(buildKissTncPage());
 
     auto* logFrame = panel(QStringLiteral("LogFrame"), bodyWidget());
     auto* logLayout = new QVBoxLayout(logFrame);
@@ -669,10 +654,12 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
                                      &m_gainStageValue,
                                      bodyWidget()), 1);
 
+    // PACKET ACTIVITY: label stacked above the graphic so it lines up with the
+    // MODEM STATUS and GAIN STAGE panel labels to its left.
     auto* activityFrame = panel(QStringLiteral("StatusFrame"), bodyWidget());
-    auto* activityLayout = new QHBoxLayout(activityFrame);
+    auto* activityLayout = new QVBoxLayout(activityFrame);
     activityLayout->setContentsMargins(16, 12, 16, 12);
-    activityLayout->setSpacing(18);
+    activityLayout->setSpacing(10);
     m_packetActivityTitle = sectionLabel(QStringLiteral("PACKET ACTIVITY"), activityFrame);
     activityLayout->addWidget(m_packetActivityTitle);
     m_packetActivity = new PacketActivityWidget(activityFrame);
@@ -685,13 +672,9 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
 
     const Ax25ModemProfile savedProfile = profileFromSettingsValue(
         AppSettings::instance().value(kPacketDecoderProfileSetting, QStringLiteral("Hf300")).toString());
-    const Ax25TonePolarity savedPolarity = polarityFromSettingsValue(
-        AppSettings::instance().value(kPacketDecoderPolaritySetting, QStringLiteral("Normal")).toString());
     const bool savedDebug = AppSettings::instance().value(kPacketDecoderDebugSetting, false).toBool();
     m_hf300Profile->setChecked(savedProfile == Ax25ModemProfile::Hf300);
     m_vhf1200Profile->setChecked(savedProfile == Ax25ModemProfile::Vhf1200);
-    m_polarityNormal->setChecked(savedPolarity == Ax25TonePolarity::Normal);
-    m_polarityReverse->setChecked(savedPolarity == Ax25TonePolarity::Inverted);
     setDiagnosticsDebugEnabled(savedDebug, false);
     setModemProfile(savedProfile, false);
 
@@ -729,18 +712,17 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
             this, &Ax25HfPacketDecodeDialog::startTransmitFromUi);
     connect(m_txPaceTimer, &QTimer::timeout,
             this, &Ax25HfPacketDecodeDialog::paceTransmitAudio);
-    connect(m_polarityNormal, &QRadioButton::toggled, this, [this](bool checked) {
-        if (!checked)
-            return;
-        setTonePolarity(Ax25TonePolarity::Normal, true);
-    });
-    connect(m_polarityReverse, &QRadioButton::toggled, this, [this](bool checked) {
-        if (!checked)
-            return;
-        setTonePolarity(Ax25TonePolarity::Inverted, true);
-    });
     connect(m_shim, &AetherAx25LibmodemShim::frameDecoded,
             this, &Ax25HfPacketDecodeDialog::appendFrame);
+    // RX -> KISS clients: forward every decoded frame to connected hosts.
+    connect(m_shim, &AetherAx25LibmodemShim::frameDecoded, this,
+            [this](const Ax25DecodedFrame& frame) {
+        if (m_kissServer && m_kissServer->isListening() && !frame.ax25FrameNoFcs.isEmpty()) {
+            m_kissServer->broadcastAx25Frame(frame.ax25FrameNoFcs);
+            ++m_kissRxCount;
+            refreshTncStatus();
+        }
+    });
     connect(m_shim, &AetherAx25LibmodemShim::diagnosticsUpdated,
             this, &Ax25HfPacketDecodeDialog::updateDiagnostics);
     connect(m_shim, &AetherAx25LibmodemShim::statusChanged,
@@ -769,12 +751,42 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
                 Qt::QueuedConnection);
     }
 
+    // KISS TNC server wiring.
+    connect(m_kissServer, &KissTncServer::ax25FrameFromClient,
+            this, &Ax25HfPacketDecodeDialog::handleKissFrameFromClient);
+    connect(m_kissServer, &KissTncServer::activity,
+            this, &Ax25HfPacketDecodeDialog::appendSystemLine);
+    connect(m_kissServer, &KissTncServer::listeningChanged,
+            this, [this](bool) { refreshTncStatus(); });
+    connect(m_kissServer, &KissTncServer::clientCountChanged,
+            this, [this](int) { refreshTncStatus(); });
+    connect(m_tncEnable, &QCheckBox::toggled, this, [this](bool on) {
+        setTncEnabled(on, true);
+    });
+    connect(m_tncStartOnStartup, &QCheckBox::toggled, this, [](bool on) {
+        AppSettings::instance().setValue(kTncStartOnStartupSetting,
+                                         on ? QStringLiteral("True") : QStringLiteral("False"));
+        AppSettings::instance().save();
+    });
+    connect(m_tncPort, qOverload<int>(&QSpinBox::valueChanged), this, [this](int value) {
+        AppSettings::instance().setValue(kTncPortSetting, QString::number(value));
+        AppSettings::instance().save();
+        if (m_tncEnable && m_tncEnable->isChecked()) {
+            appendSystemLine(QStringLiteral("KISS TNC port changed to %1; restarting listener.")
+                .arg(value));
+            setTncEnabled(false, false);
+            setTncEnabled(true, false);
+        }
+    });
+
     appendSystemLine(QStringLiteral("AetherModem initialized."));
     appendSystemLine(QStringLiteral("Enable Modem to start the RX audio tap."));
     appendSystemLine(QStringLiteral("TX accepts raw payload text or full SRC>DST,path:payload syntax."));
     setAttachedSlice(initialSlice);
     refreshStatus();
     refreshTransmitControls();
+    applyTncStartOnStartup();
+    refreshTncStatus();
 }
 
 Ax25HfPacketDecodeDialog::~Ax25HfPacketDecodeDialog()
@@ -783,6 +795,8 @@ Ax25HfPacketDecodeDialog::~Ax25HfPacketDecodeDialog()
         finishTransmit(true, QStringLiteral("AetherModem window closing"));
     if (m_captureActive)
         finishAudioCapture(false);
+    if (m_kissServer)
+        m_kissServer->stop();
     if (m_audio)
         m_audio->setTncRxTapEnabled(false);
 }
@@ -826,17 +840,10 @@ void Ax25HfPacketDecodeDialog::setAttachedSlice(SliceModel* slice)
     refreshStatus();
 }
 
-Ax25TonePolarity Ax25HfPacketDecodeDialog::selectedTonePolarity() const
-{
-    return m_polarityReverse && m_polarityReverse->isChecked()
-        ? Ax25TonePolarity::Inverted
-        : Ax25TonePolarity::Normal;
-}
-
 void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool persist)
 {
-    const auto polarity = selectedTonePolarity();
-    m_shim->configure(ax25DemodConfigForProfile(profile, polarity));
+    // Tone polarity is always Normal for the supported HF DIGU / VHF FM paths.
+    m_shim->configure(ax25DemodConfigForProfile(profile, Ax25TonePolarity::Normal));
     m_lastDiagnostics = {};
     m_lastDiagnosticsUtc = {};
 
@@ -847,27 +854,6 @@ void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool pe
 
     if (m_log)
         appendSystemLine(QStringLiteral("Configured %1.").arg(m_shim->demodDescription()));
-    refreshStatus();
-}
-
-void Ax25HfPacketDecodeDialog::setTonePolarity(Ax25TonePolarity polarity, bool persist)
-{
-    auto cfg = m_shim->config();
-    if (cfg.polarity == polarity && persist)
-        return;
-
-    cfg.polarity = polarity;
-    m_shim->configure(cfg);
-    m_lastDiagnostics = {};
-    m_lastDiagnosticsUtc = {};
-
-    if (persist) {
-        AppSettings::instance().setValue(kPacketDecoderPolaritySetting, polaritySettingsValue(polarity));
-        AppSettings::instance().save();
-    }
-
-    appendSystemLine(QStringLiteral("Tone polarity changed to %1. Configured %2.")
-        .arg(polaritySettingsValue(polarity), m_shim->demodDescription()));
     refreshStatus();
 }
 
@@ -1009,7 +995,12 @@ void Ax25HfPacketDecodeDialog::startTransmitFromUi()
         qCWarning(lcAx25).noquote() << "AX.25 TX packetization failed:" << tx.error;
         return;
     }
+    beginTransmission(tx, false);
+}
 
+void Ax25HfPacketDecodeDialog::beginTransmission(const Ax25TransmitResult& tx, bool fromKiss)
+{
+    m_txFromKiss = fromKiss;
     m_pendingTx = tx;
     m_txPcm = tx.stereoFloat32Pcm;
     m_txOffsetBytes = 0;
@@ -1023,9 +1014,10 @@ void Ax25HfPacketDecodeDialog::startTransmitFromUi()
         : 0;
 
     appendSystemLine(QStringLiteral(
-        "TX packetized: %1 > %2%3, %4 payload bytes, %5 frame bytes, %6 bits, %7 s, RMS %8 dBFS, peak %9 dBFS.")
-        .arg(tx.frame.source,
-             tx.frame.destination,
+        "TX packetized (%1): %2 > %3%4, %5 payload bytes, %6 frame bytes, %7 bits, %8 s, RMS %9 dBFS, peak %10 dBFS.")
+        .arg(fromKiss ? QStringLiteral("KISS") : QStringLiteral("text"),
+             tx.frame.source.isEmpty() ? QStringLiteral("?") : tx.frame.source,
+             tx.frame.destination.isEmpty() ? QStringLiteral("?") : tx.frame.destination,
              tx.frame.path.isEmpty()
                  ? QString()
                  : QStringLiteral(" via %1").arg(tx.frame.path.join(QStringLiteral(","))))
@@ -1268,7 +1260,21 @@ void Ax25HfPacketDecodeDialog::finishTransmit(bool aborted, const QString& reaso
     m_txChunkCount = 0;
     m_txRestoreAudioDaxMode = false;
     m_txRestoreTransmitDax = false;
+    m_txFromKiss = false;
     refreshTransmitControls();
+
+    // Drain any queued KISS transmits. On a clean finish, kick the next one on a
+    // deferred (queued) call so we never re-enter the TX path within finish; on
+    // an abort, drop the backlog so a broken radio can't spin the queue.
+    if (aborted) {
+        if (!m_kissTxQueue.isEmpty()) {
+            appendSystemLine(QStringLiteral("Dropping %1 queued KISS TX frame(s) after abort.")
+                .arg(m_kissTxQueue.size()));
+            m_kissTxQueue.clear();
+        }
+    } else if (!m_kissTxQueue.isEmpty()) {
+        QTimer::singleShot(0, this, [this] { maybeStartNextKissTx(); });
+    }
 }
 
 void Ax25HfPacketDecodeDialog::appendFrame(const Ax25DecodedFrame& frame)
@@ -1633,6 +1639,168 @@ QString Ax25HfPacketDecodeDialog::formatTerminalLine(const Ax25DecodedFrame& fra
         .arg(time.toHtmlEscaped(),
              route.toHtmlEscaped(),
              payload.toHtmlEscaped());
+}
+
+QWidget* Ax25HfPacketDecodeDialog::buildKissTncPage()
+{
+    auto* page = new QWidget(m_tabStack);
+    auto* layout = new QVBoxLayout(page);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(10);
+
+    auto* controlsFrame = panel(QStringLiteral("ControlsFrame"), page);
+    auto* controls = new QHBoxLayout(controlsFrame);
+    controls->setContentsMargins(16, 14, 16, 14);
+    controls->setSpacing(20);
+
+    auto* serverCell = panel(QStringLiteral("ControlCell"), controlsFrame);
+    auto* serverLayout = new QVBoxLayout(serverCell);
+    serverLayout->setContentsMargins(0, 0, 20, 0);
+    serverLayout->setSpacing(12);
+    serverLayout->addWidget(sectionLabel(QStringLiteral("KISS TNC SERVER"), serverCell));
+    m_tncEnable = new QCheckBox(QStringLiteral("Enable TNC"), serverCell);
+    serverLayout->addWidget(m_tncEnable);
+    m_tncStartOnStartup = new QCheckBox(QStringLiteral("Start TNC on Startup"), serverCell);
+    serverLayout->addWidget(m_tncStartOnStartup);
+    controls->addWidget(serverCell, 2);
+
+    auto* portCell = panel(QStringLiteral("ControlCell"), controlsFrame);
+    auto* portLayout = new QVBoxLayout(portCell);
+    portLayout->setContentsMargins(0, 0, 20, 0);
+    portLayout->setSpacing(12);
+    portLayout->addWidget(sectionLabel(QStringLiteral("TCP PORT"), portCell));
+    m_tncPort = new QSpinBox(portCell);
+    m_tncPort->setRange(1, 65535);
+    m_tncPort->setValue(kTncDefaultPort);
+    m_tncPort->setMaximumWidth(140);
+    portLayout->addWidget(m_tncPort);
+    controls->addWidget(portCell, 1);
+    controls->addStretch(2);
+    layout->addWidget(controlsFrame);
+
+    auto* statusFrame = statusPanel(QStringLiteral("TNC STATUS"),
+                                    &m_tncStatusDot, &m_tncStatusValue, page);
+    layout->addWidget(statusFrame);
+
+    auto* help = new QLabel(
+        QStringLiteral("Point a KISS-over-TCP client (Xastir, YAAC, APRSdroid, UISS, Dire Wolf "
+                       "clients, terminal/packet programs, …) at this host and TCP port. Decoded "
+                       "frames are pushed to every connected client; frames a client sends are "
+                       "keyed onto the air using the baud profile selected on the AX.25 tab. "
+                       "The modem must be enabled with a slice attached for the TNC to carry "
+                       "traffic — enabling the TNC turns the modem on for you."),
+        page);
+    help->setObjectName(QStringLiteral("StatusValue"));
+    help->setWordWrap(true);
+    layout->addWidget(help);
+    layout->addStretch(1);
+
+    // Seed control values from settings (before signals are wired in the ctor).
+    m_tncPort->setValue(AppSettings::instance()
+        .value(kTncPortSetting, QString::number(kTncDefaultPort)).toInt());
+    m_tncStartOnStartup->setChecked(AppSettings::instance()
+        .value(kTncStartOnStartupSetting, QStringLiteral("False")).toString()
+            == QStringLiteral("True"));
+
+    return page;
+}
+
+void Ax25HfPacketDecodeDialog::setTncEnabled(bool enabled, bool persist)
+{
+    if (persist) {
+        AppSettings::instance().setValue(kTncEnabledSetting,
+            enabled ? QStringLiteral("True") : QStringLiteral("False"));
+        AppSettings::instance().save();
+    }
+
+    if (enabled) {
+        // The TNC needs the modem RX tap running to forward decodes to clients.
+        if (m_enableDecode && !m_enableDecode->isChecked()) {
+            appendSystemLine(QStringLiteral("Enabling the modem for the KISS TNC."));
+            m_enableDecode->setChecked(true);
+        }
+        const quint16 port = static_cast<quint16>(m_tncPort ? m_tncPort->value() : kTncDefaultPort);
+        if (!m_kissServer->start(port) && m_tncEnable) {
+            QSignalBlocker blocker(m_tncEnable);
+            m_tncEnable->setChecked(false);
+        }
+    } else {
+        m_kissServer->stop();
+    }
+    refreshTncStatus();
+}
+
+void Ax25HfPacketDecodeDialog::applyTncStartOnStartup()
+{
+    const bool startOnStartup = AppSettings::instance()
+        .value(kTncStartOnStartupSetting, QStringLiteral("False")).toString()
+            == QStringLiteral("True");
+    if (startOnStartup && m_tncEnable) {
+        appendSystemLine(QStringLiteral("KISS TNC: start-on-startup enabled; starting listener."));
+        m_tncEnable->setChecked(true); // fires setTncEnabled() via the toggled connection
+    }
+}
+
+void Ax25HfPacketDecodeDialog::handleKissFrameFromClient(const QByteArray& ax25NoFcs)
+{
+    if (ax25NoFcs.isEmpty())
+        return;
+    if (!m_audio || !m_radio) {
+        appendSystemLine(QStringLiteral("KISS TX dropped: audio engine or radio not ready."));
+        return;
+    }
+    m_kissTxQueue.enqueue(ax25NoFcs);
+    ++m_kissTxCount;
+    refreshTncStatus();
+    maybeStartNextKissTx();
+}
+
+void Ax25HfPacketDecodeDialog::maybeStartNextKissTx()
+{
+    if (m_kissTxQueue.isEmpty())
+        return;
+    if (m_txActive || m_txPendingStream)
+        return; // finishTransmit() re-drains when the current TX completes
+    if (!m_audio || !m_radio) {
+        m_kissTxQueue.clear();
+        return;
+    }
+    if (m_radio->isRadioTransmitting() || m_radio->transmitModel().isTransmitting()) {
+        QTimer::singleShot(250, this, [this] { maybeStartNextKissTx(); }); // radio busy; retry
+        return;
+    }
+
+    const QByteArray frame = m_kissTxQueue.dequeue();
+    Ax25TransmitResult tx = m_shim->buildTransmitAudioFromFrame(frame);
+    if (!tx.ok) {
+        appendSystemLine(QStringLiteral("KISS TX packetization failed: %1.").arg(tx.error));
+        qCWarning(lcAx25).noquote() << "KISS TX packetization failed:" << tx.error;
+        QTimer::singleShot(0, this, [this] { maybeStartNextKissTx(); }); // skip to next frame
+        return;
+    }
+    beginTransmission(tx, true);
+}
+
+void Ax25HfPacketDecodeDialog::refreshTncStatus()
+{
+    if (!m_tncStatusValue)
+        return;
+    const bool listening = m_kissServer && m_kissServer->isListening();
+    if (listening) {
+        m_tncStatusValue->setText(QStringLiteral("Listening on %1  |  %2 client(s)  |  RX %3  TX %4")
+            .arg(m_kissServer->port())
+            .arg(m_kissServer->clientCount())
+            .arg(m_kissRxCount)
+            .arg(m_kissTxCount));
+    } else {
+        m_tncStatusValue->setText(QStringLiteral("Stopped"));
+    }
+    if (m_tncStatusDot) {
+        m_tncStatusDot->setFixedSize(12, 12);
+        m_tncStatusDot->setStyleSheet(listening
+            ? QStringLiteral("background:#5fce66;border-radius:6px;")
+            : QStringLiteral("background:#8190a3;border-radius:6px;"));
+    }
 }
 
 } // namespace AetherSDR

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -31,6 +31,8 @@
 #include <QSizePolicy>
 #include <QSpinBox>
 #include <QStackedWidget>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QTextDocument>
 #include <QTextEdit>
 #include <QTimer>
@@ -47,13 +49,21 @@ namespace {
 
 constexpr auto kPacketDecoderProfileSetting = "Ax25PacketDecoderProfile";
 constexpr auto kPacketDecoderDebugSetting = "Ax25PacketDecoderDiagnosticsDebug";
-// TNC setting keys + defaults now live in the header (TncSettings namespace)
-// so MainWindow can read the same constants the dialog writes. Aliased here
-// for unchanged call-site readability.
-constexpr auto kTncEnabledSetting        = TncSettings::kEnabled;
-constexpr auto kTncStartOnStartupSetting = TncSettings::kStartOnStartup;
-constexpr auto kTncPortSetting           = TncSettings::kPort;
-constexpr int  kTncDefaultPort           = TncSettings::kDefaultPort;
+// TNC settings live as nested JSON under "AetherModemKissTnc" — see
+// TncSettings class in the header. Legacy flat-key migration in
+// TncSettings::migrateLegacy() is run from MainWindow at startup.
+constexpr auto kTncSettingsKey   = "AetherModemKissTnc";
+
+// Symmetry with KissTncServer's kMaxWriteBacklogBytes on the RX path: cap
+// the TX queue so a misbehaving KISS client pushing frames faster than RF
+// can drain them can't grow it without bound. Drop-oldest on overflow
+// (oldest is the most-stale; better to lose old data than block new).
+constexpr int kMaxKissTxQueueDepth   = 64;
+// Maximum 250 ms radio-busy retries per head-of-queue frame before we
+// abandon it and try the next one. 60 × 250 ms = 15 s — long enough to
+// ride out an ATU tune or a long voice transmission, short enough that a
+// stuck-PTT radio doesn't permanently jam the queue.
+constexpr int kMaxKissTxBusyRetries  = 60;
 constexpr int kAudioCaptureSeconds = 180;
 constexpr int kTxDaxSettleMs = 150;
 constexpr int kTxLeadMs = 200;
@@ -377,6 +387,72 @@ bool writeMonoFloatWav(const QString& path, const QByteArray& pcm, int sampleRat
 }
 
 } // namespace
+
+// ─────────────────────────────────────────────────────────────────────────
+// TncSettings — nested-JSON persistence (Constitution Principle V).
+// ─────────────────────────────────────────────────────────────────────────
+
+QJsonObject TncSettings::readObj()
+{
+    const QString json =
+        AppSettings::instance().value(kTncSettingsKey, QString{}).toString();
+    if (json.isEmpty()) return {};
+    return QJsonDocument::fromJson(json.toUtf8()).object();
+}
+
+void TncSettings::write(const QJsonObject& o)
+{
+    auto& s = AppSettings::instance();
+    s.setValue(kTncSettingsKey,
+               QString::fromUtf8(
+                   QJsonDocument(o).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+void TncSettings::setEnabled(bool on)
+{
+    QJsonObject o = readObj();
+    o["enabled"] = on ? QStringLiteral("True") : QStringLiteral("False");
+    write(o);
+}
+
+void TncSettings::setStartOnStartup(bool on)
+{
+    QJsonObject o = readObj();
+    o["startOnStartup"] = on ? QStringLiteral("True") : QStringLiteral("False");
+    write(o);
+}
+
+void TncSettings::setPort(int p)
+{
+    if (p < kMinPort || p > kMaxPort) p = kDefaultPort;
+    QJsonObject o = readObj();
+    o["port"] = QString::number(p);
+    write(o);
+}
+
+void TncSettings::migrateLegacy()
+{
+    auto& s = AppSettings::instance();
+    if (s.contains(kTncSettingsKey)) return;  // already migrated
+
+    // Read the three legacy flat keys with the same defaults the old code used.
+    const QString enabledStr        = s.value("AetherModemKissTncEnabled",        "False").toString();
+    const QString startOnStartupStr = s.value("AetherModemKissTncStartOnStartup", "False").toString();
+    const int     portInt           = s.value("AetherModemKissTncPort",
+                                              QString::number(kDefaultPort)).toString().toInt();
+
+    QJsonObject o;
+    o["enabled"]        = enabledStr;
+    o["startOnStartup"] = startOnStartupStr;
+    o["port"]           = QString::number(
+        (portInt >= kMinPort && portInt <= kMaxPort) ? portInt : kDefaultPort);
+    write(o);
+
+    // The legacy flat keys are left in place — AppSettings is XML and
+    // a future cleanup PR can drop them once we know no other reader
+    // still touches them. The nested blob is now authoritative.
+}
 
 class PacketActivityWidget final : public QWidget {
 public:
@@ -767,13 +843,10 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
         setTncEnabled(on, true);
     });
     connect(m_tncStartOnStartup, &QCheckBox::toggled, this, [](bool on) {
-        AppSettings::instance().setValue(kTncStartOnStartupSetting,
-                                         on ? QStringLiteral("True") : QStringLiteral("False"));
-        AppSettings::instance().save();
+        TncSettings::setStartOnStartup(on);
     });
     connect(m_tncPort, qOverload<int>(&QSpinBox::valueChanged), this, [this](int value) {
-        AppSettings::instance().setValue(kTncPortSetting, QString::number(value));
-        AppSettings::instance().save();
+        TncSettings::setPort(value);
         if (m_tncEnable && m_tncEnable->isChecked()) {
             appendSystemLine(QStringLiteral("KISS TNC port changed to %1; restarting listener.")
                 .arg(value));
@@ -1674,7 +1747,7 @@ QWidget* Ax25HfPacketDecodeDialog::buildKissTncPage()
     portLayout->addWidget(sectionLabel(QStringLiteral("TCP PORT"), portCell));
     m_tncPort = new QSpinBox(portCell);
     m_tncPort->setRange(TncSettings::kMinPort, TncSettings::kMaxPort);
-    m_tncPort->setValue(kTncDefaultPort);
+    m_tncPort->setValue(TncSettings::kDefaultPort);
     m_tncPort->setMaximumWidth(140);
     portLayout->addWidget(m_tncPort);
     controls->addWidget(portCell, 1);
@@ -1699,11 +1772,8 @@ QWidget* Ax25HfPacketDecodeDialog::buildKissTncPage()
     layout->addStretch(1);
 
     // Seed control values from settings (before signals are wired in the ctor).
-    m_tncPort->setValue(AppSettings::instance()
-        .value(kTncPortSetting, QString::number(kTncDefaultPort)).toInt());
-    m_tncStartOnStartup->setChecked(AppSettings::instance()
-        .value(kTncStartOnStartupSetting, QStringLiteral("False")).toString()
-            == QStringLiteral("True"));
+    m_tncPort->setValue(TncSettings::port());
+    m_tncStartOnStartup->setChecked(TncSettings::startOnStartup());
 
     return page;
 }
@@ -1711,9 +1781,7 @@ QWidget* Ax25HfPacketDecodeDialog::buildKissTncPage()
 void Ax25HfPacketDecodeDialog::setTncEnabled(bool enabled, bool persist)
 {
     if (persist) {
-        AppSettings::instance().setValue(kTncEnabledSetting,
-            enabled ? QStringLiteral("True") : QStringLiteral("False"));
-        AppSettings::instance().save();
+        TncSettings::setEnabled(enabled);
     }
 
     if (enabled) {
@@ -1722,7 +1790,8 @@ void Ax25HfPacketDecodeDialog::setTncEnabled(bool enabled, bool persist)
             appendSystemLine(QStringLiteral("Enabling the modem for the KISS TNC."));
             m_enableDecode->setChecked(true);
         }
-        const quint16 port = static_cast<quint16>(m_tncPort ? m_tncPort->value() : kTncDefaultPort);
+        const quint16 port = static_cast<quint16>(
+            m_tncPort ? m_tncPort->value() : TncSettings::kDefaultPort);
         if (!m_kissServer->start(port) && m_tncEnable) {
             QSignalBlocker blocker(m_tncEnable);
             m_tncEnable->setChecked(false);
@@ -1735,10 +1804,7 @@ void Ax25HfPacketDecodeDialog::setTncEnabled(bool enabled, bool persist)
 
 void Ax25HfPacketDecodeDialog::applyTncStartOnStartup()
 {
-    const bool startOnStartup = AppSettings::instance()
-        .value(kTncStartOnStartupSetting, QStringLiteral("False")).toString()
-            == QStringLiteral("True");
-    if (startOnStartup && m_tncEnable) {
+    if (TncSettings::startOnStartup() && m_tncEnable) {
         appendSystemLine(QStringLiteral("KISS TNC: start-on-startup enabled; starting listener."));
         m_tncEnable->setChecked(true); // fires setTncEnabled() via the toggled connection
     }
@@ -1750,7 +1816,24 @@ void Ax25HfPacketDecodeDialog::handleKissFrameFromClient(const QByteArray& ax25N
         return;
     if (!m_audio || !m_radio) {
         appendSystemLine(QStringLiteral("KISS TX dropped: audio engine or radio not ready."));
+        qCWarning(lcAx25).noquote()
+            << "KISS TX dropped: audio engine or radio not ready (queue size:"
+            << m_kissTxQueue.size() << ").";
         return;
+    }
+    // Cap the queue to prevent a misbehaving KISS client (or a stalled
+    // PTT-deny on the radio) from growing it without bound. Drop the
+    // oldest pending frame — newer data is more useful than stale
+    // backlog. Symmetric with KissTncServer::kMaxWriteBacklogBytes on
+    // the RX path.
+    while (m_kissTxQueue.size() >= kMaxKissTxQueueDepth) {
+        m_kissTxQueue.dequeue();
+        appendSystemLine(QStringLiteral(
+            "KISS TX queue full (%1 frames); dropping oldest pending frame.")
+            .arg(kMaxKissTxQueueDepth));
+        qCWarning(lcAx25).noquote()
+            << "KISS TX queue full; dropping oldest pending frame. cap="
+            << kMaxKissTxQueueDepth;
     }
     m_kissTxQueue.enqueue(ax25NoFcs);
     ++m_kissTxCount;
@@ -1765,15 +1848,44 @@ void Ax25HfPacketDecodeDialog::maybeStartNextKissTx()
     if (m_txActive || m_txPendingStream)
         return; // finishTransmit() re-drains when the current TX completes
     if (!m_audio || !m_radio) {
+        const int dropped = m_kissTxQueue.size();
         m_kissTxQueue.clear();
+        m_kissTxBusyRetries = 0;
+        if (dropped > 0) {
+            appendSystemLine(QStringLiteral(
+                "KISS TX backlog (%1 frames) dropped: audio engine or radio went away.")
+                .arg(dropped));
+            qCWarning(lcAx25).noquote()
+                << "KISS TX backlog dropped — audio/radio not ready. frames="
+                << dropped;
+        }
         return;
     }
     if (m_radio->isRadioTransmitting() || m_radio->transmitModel().isTransmitting()) {
+        ++m_kissTxBusyRetries;
+        if (m_kissTxBusyRetries > kMaxKissTxBusyRetries) {
+            // Give up on the head-of-queue frame and move on. A stuck PTT
+            // shouldn't permanently jam every subsequent frame behind it.
+            m_kissTxQueue.dequeue();
+            const int retries = m_kissTxBusyRetries;
+            m_kissTxBusyRetries = 0;
+            appendSystemLine(QStringLiteral(
+                "KISS TX abandoned head frame: radio stayed transmitting for "
+                "%1 retries (~%2 s); trying next.")
+                .arg(retries).arg(retries / 4));
+            qCWarning(lcAx25).noquote()
+                << "KISS TX abandoned head-of-queue frame after radio-busy "
+                   "retries. retries=" << retries
+                << "cap=" << kMaxKissTxBusyRetries;
+            QTimer::singleShot(0, this, [this] { maybeStartNextKissTx(); });
+            return;
+        }
         QTimer::singleShot(250, this, [this] { maybeStartNextKissTx(); }); // radio busy; retry
         return;
     }
 
     const QByteArray frame = m_kissTxQueue.dequeue();
+    m_kissTxBusyRetries = 0;
     Ax25TransmitResult tx = m_shim->buildTransmitAudioFromFrame(frame);
     if (!tx.ok) {
         appendSystemLine(QStringLiteral("KISS TX packetization failed: %1.").arg(tx.error));

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -47,10 +47,13 @@ namespace {
 
 constexpr auto kPacketDecoderProfileSetting = "Ax25PacketDecoderProfile";
 constexpr auto kPacketDecoderDebugSetting = "Ax25PacketDecoderDiagnosticsDebug";
-constexpr auto kTncEnabledSetting = "AetherModemKissTncEnabled";
-constexpr auto kTncStartOnStartupSetting = "AetherModemKissTncStartOnStartup";
-constexpr auto kTncPortSetting = "AetherModemKissTncPort";
-constexpr int kTncDefaultPort = 8001;
+// TNC setting keys + defaults now live in the header (TncSettings namespace)
+// so MainWindow can read the same constants the dialog writes. Aliased here
+// for unchanged call-site readability.
+constexpr auto kTncEnabledSetting        = TncSettings::kEnabled;
+constexpr auto kTncStartOnStartupSetting = TncSettings::kStartOnStartup;
+constexpr auto kTncPortSetting           = TncSettings::kPort;
+constexpr int  kTncDefaultPort           = TncSettings::kDefaultPort;
 constexpr int kAudioCaptureSeconds = 180;
 constexpr int kTxDaxSettleMs = 150;
 constexpr int kTxLeadMs = 200;
@@ -1670,7 +1673,7 @@ QWidget* Ax25HfPacketDecodeDialog::buildKissTncPage()
     portLayout->setSpacing(12);
     portLayout->addWidget(sectionLabel(QStringLiteral("TCP PORT"), portCell));
     m_tncPort = new QSpinBox(portCell);
-    m_tncPort->setRange(1, 65535);
+    m_tncPort->setRange(TncSettings::kMinPort, TncSettings::kMaxPort);
     m_tncPort->setValue(kTncDefaultPort);
     m_tncPort->setMaximumWidth(140);
     portLayout->addWidget(m_tncPort);

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -3,21 +3,27 @@
 #include "PersistentDialog.h"
 #include "core/tnc/AetherAx25LibmodemShim.h"
 
+#include <QByteArray>
 #include <QElapsedTimer>
 #include <QMetaObject>
 #include <QPointer>
+#include <QQueue>
 
+class QAbstractButton;
 class QCheckBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
 class QRadioButton;
+class QSpinBox;
+class QStackedWidget;
 class QTextEdit;
 class QTimer;
 
 namespace AetherSDR {
 
 class AudioEngine;
+class KissTncServer;
 class PacketActivityWidget;
 class RadioModel;
 class SliceModel;
@@ -35,17 +41,24 @@ public:
     void setAttachedSlice(SliceModel* slice);
 
 private:
-    Ax25TonePolarity selectedTonePolarity() const;
     void setModemProfile(Ax25ModemProfile profile, bool persist);
-    void setTonePolarity(Ax25TonePolarity polarity, bool persist);
     void setDecodeEnabled(bool enabled);
     void handleRxAudio(const QByteArray& monoFloat32Pcm, int sampleRate);
     void startAudioCapture();
     void finishAudioCapture(bool save);
     void startTransmitFromUi();
+    void beginTransmission(const Ax25TransmitResult& tx, bool fromKiss);
     void beginTransmitWhenReady();
     void paceTransmitAudio();
     void finishTransmit(bool aborted, const QString& reason);
+
+    // KISS TNC tab + TCP server wiring.
+    QWidget* buildKissTncPage();
+    void setTncEnabled(bool enabled, bool persist);
+    void applyTncStartOnStartup();
+    void handleKissFrameFromClient(const QByteArray& ax25NoFcs);
+    void maybeStartNextKissTx();
+    void refreshTncStatus();
     void appendFrame(const Ax25DecodedFrame& frame);
     void updateDiagnostics(const Ax25DecoderDiagnostics& diagnostics);
     void updateHeartbeat();
@@ -63,11 +76,12 @@ private:
     AudioEngine* m_audio{nullptr};
     RadioModel* m_radio{nullptr};
     AetherAx25LibmodemShim* m_shim{nullptr};
+    QStackedWidget* m_tabStack{nullptr};
+    QAbstractButton* m_ax25Tab{nullptr};
+    QAbstractButton* m_kissTab{nullptr};
     QRadioButton* m_hf300Profile{nullptr};
     QRadioButton* m_vhf1200Profile{nullptr};
     QCheckBox* m_enableDecode{nullptr};
-    QRadioButton* m_polarityNormal{nullptr};
-    QRadioButton* m_polarityReverse{nullptr};
     QLineEdit* m_txText{nullptr};
     QPushButton* m_txButton{nullptr};
     QTextEdit* m_log{nullptr};
@@ -114,6 +128,18 @@ private:
     bool m_txRestoreTransmitDax{false};
     bool m_txPreviousAudioDaxMode{false};
     bool m_txPreviousTransmitDax{false};
+    bool m_txFromKiss{false};
+
+    // KISS TNC server (TCP) and its controls.
+    KissTncServer* m_kissServer{nullptr};
+    QCheckBox* m_tncEnable{nullptr};
+    QCheckBox* m_tncStartOnStartup{nullptr};
+    QSpinBox* m_tncPort{nullptr};
+    QLabel* m_tncStatusDot{nullptr};
+    QLabel* m_tncStatusValue{nullptr};
+    QQueue<QByteArray> m_kissTxQueue;
+    quint64 m_kissTxCount{0};
+    quint64 m_kissRxCount{0};
 };
 
 } // namespace AetherSDR

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -28,6 +28,22 @@ class PacketActivityWidget;
 class RadioModel;
 class SliceModel;
 
+// AppSettings keys used by the AetherModem KISS TNC. Promoted to the header
+// so MainWindow::startKissTncOnStartupIfConfigured (which constructs the
+// dialog hidden + persistent at launch) reads from the same source of truth
+// the dialog writes to — a rename here can't silently desync the two sides.
+namespace TncSettings {
+constexpr auto kEnabled        = "AetherModemKissTncEnabled";
+constexpr auto kStartOnStartup = "AetherModemKissTncStartOnStartup";
+constexpr auto kPort           = "AetherModemKissTncPort";
+constexpr int  kDefaultPort    = 8001;
+// Lowest TCP port the spinbox lets the operator pick. Ports below 1024 need
+// root on macOS / Linux; the bind would fail silently into m_lastError and
+// the listener would stay off. No reason to expose that foot-gun.
+constexpr int  kMinPort        = 1024;
+constexpr int  kMaxPort        = 65535;
+}
+
 class Ax25HfPacketDecodeDialog : public PersistentDialog {
     Q_OBJECT
 

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -5,6 +5,7 @@
 
 #include <QByteArray>
 #include <QElapsedTimer>
+#include <QJsonObject>
 #include <QMetaObject>
 #include <QPointer>
 #include <QQueue>
@@ -28,21 +29,47 @@ class PacketActivityWidget;
 class RadioModel;
 class SliceModel;
 
-// AppSettings keys used by the AetherModem KISS TNC. Promoted to the header
-// so MainWindow::startKissTncOnStartupIfConfigured (which constructs the
-// dialog hidden + persistent at launch) reads from the same source of truth
-// the dialog writes to — a rename here can't silently desync the two sides.
-namespace TncSettings {
-constexpr auto kEnabled        = "AetherModemKissTncEnabled";
-constexpr auto kStartOnStartup = "AetherModemKissTncStartOnStartup";
-constexpr auto kPort           = "AetherModemKissTncPort";
-constexpr int  kDefaultPort    = 8001;
-// Lowest TCP port the spinbox lets the operator pick. Ports below 1024 need
-// root on macOS / Linux; the bind would fail silently into m_lastError and
-// the listener would stay off. No reason to expose that foot-gun.
-constexpr int  kMinPort        = 1024;
-constexpr int  kMaxPort        = 65535;
-}
+// Persistence for the AetherModem KISS TNC. Per Constitution Principle V,
+// new feature configuration lives as a nested JSON blob under one root key
+// rather than a stack of flat AppSettings entries. Mirrors the
+// CwDecodeSettings pattern.
+//
+// One-shot migration from the legacy flat keys is in migrateLegacy(); call
+// once at startup before any reader runs.
+class TncSettings {
+public:
+    // Defaults — kept as constants for the spinbox/UI to bound against.
+    static constexpr int kDefaultPort = 8001;  // Dire Wolf convention
+    // Lowest TCP port the spinbox lets the operator pick. Ports below 1024
+    // need root on macOS / Linux; the bind would fail silently into
+    // m_lastError and the listener would stay off. No reason to expose that
+    // foot-gun.
+    static constexpr int kMinPort = 1024;
+    static constexpr int kMaxPort = 65535;
+
+    static bool enabled()         { return readObj().value("enabled").toString("False") == "True"; }
+    static bool startOnStartup()  { return readObj().value("startOnStartup").toString("False") == "True"; }
+    static int  port()
+    {
+        const int p = readObj().value("port").toString(QString::number(kDefaultPort)).toInt();
+        if (p < kMinPort || p > kMaxPort) return kDefaultPort;
+        return p;
+    }
+
+    static void setEnabled(bool on);
+    static void setStartOnStartup(bool on);
+    static void setPort(int p);
+
+    // One-shot migration from the three legacy flat keys
+    // (AetherModemKissTncEnabled / AetherModemKissTncStartOnStartup /
+    // AetherModemKissTncPort) into the nested blob. Safe to call repeatedly;
+    // returns immediately if the nested blob already exists.
+    static void migrateLegacy();
+
+private:
+    static QJsonObject readObj();
+    static void write(const QJsonObject& o);
+};
 
 class Ax25HfPacketDecodeDialog : public PersistentDialog {
     Q_OBJECT
@@ -154,6 +181,11 @@ private:
     QLabel* m_tncStatusDot{nullptr};
     QLabel* m_tncStatusValue{nullptr};
     QQueue<QByteArray> m_kissTxQueue;
+    // Number of 250 ms radio-busy retries currently elapsed on the head-of-
+    // queue frame. Capped (kMaxKissTxBusyRetries) so a stuck-transmitting
+    // radio can't spin maybeStartNextKissTx() forever and starve later
+    // frames behind it. Reset on each new dequeue.
+    int m_kissTxBusyRetries{0};
     quint64 m_kissTxCount{0};
     quint64 m_kissRxCount{0};
 };

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1728,6 +1728,12 @@ MainWindow::MainWindow(QWidget* parent)
         s.save();
     });
 
+    // Start the AetherModem KISS TNC headlessly at launch if the user enabled
+    // "Start TNC on Startup" — constructs the (hidden, persistent) AetherModem
+    // window so the TCP server runs without the window being opened. Deferred so
+    // the audio engine and main window are fully up first.
+    QTimer::singleShot(0, this, [this] { startKissTncOnStartupIfConfigured(); });
+
     // Auto-connect: when a radio is discovered, check if it matches the last one
     connect(&m_discovery, &RadioDiscovery::radioDiscovered,
             this, [this](const RadioInfo& info) {
@@ -6422,6 +6428,25 @@ void MainWindow::showAx25HfPacketDecodeDialog()
     showOrRaisePersistent(m_ax25HfPacketDecodeDialog, m_audio, &m_radioModel, slice);
     if (m_ax25HfPacketDecodeDialog)
         m_ax25HfPacketDecodeDialog->setAttachedSlice(slice);
+}
+
+void MainWindow::startKissTncOnStartupIfConfigured()
+{
+    if (m_ax25HfPacketDecodeDialog)
+        return; // already constructed (e.g. user opened the window)
+    if (AppSettings::instance()
+            .value("AetherModemKissTncStartOnStartup", "False").toString()
+                != QStringLiteral("True"))
+        return;
+
+    // Construct the AetherModem window hidden and persistent (no WA_DeleteOnClose)
+    // so the KISS TCP server runs from launch and survives the window being
+    // closed. The dialog's constructor auto-starts the TNC per the same setting.
+    auto* dlg = new Ax25HfPacketDecodeDialog(m_audio, &m_radioModel, activeSlice(), this);
+    dlg->setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+    m_ax25HfPacketDecodeDialog = dlg;
+    m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
 }
 
 void MainWindow::showFlexControlDialog()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6434,8 +6434,10 @@ void MainWindow::startKissTncOnStartupIfConfigured()
 {
     if (m_ax25HfPacketDecodeDialog)
         return; // already constructed (e.g. user opened the window)
+    // Same key the dialog reads in its own constructor — promoted to the
+    // dialog header so both sides can't drift if the key is ever renamed.
     if (AppSettings::instance()
-            .value("AetherModemKissTncStartOnStartup", "False").toString()
+            .value(TncSettings::kStartOnStartup, "False").toString()
                 != QStringLiteral("True"))
         return;
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6425,20 +6425,37 @@ void MainWindow::showNetworkDiagnosticsDialog()
 void MainWindow::showAx25HfPacketDecodeDialog()
 {
     SliceModel* slice = activeSlice();
-    showOrRaisePersistent(m_ax25HfPacketDecodeDialog, m_audio, &m_radioModel, slice);
-    if (m_ax25HfPacketDecodeDialog)
-        m_ax25HfPacketDecodeDialog->setAttachedSlice(slice);
+
+    // Construct on first open if it didn't already come up via
+    // startKissTncOnStartupIfConfigured(). Intentionally NOT using
+    // showOrRaisePersistent() here because that template sets
+    // WA_DeleteOnClose: closing the window would destroy the dialog and
+    // along with it the KISS TCP server, dropping every connected client
+    // without warning. The TNC server lifecycle is decoupled from the
+    // window's open/close cycle — the dialog stays alive as long as
+    // MainWindow does and is just hidden on close.
+    if (!m_ax25HfPacketDecodeDialog) {
+        auto* dlg = new Ax25HfPacketDecodeDialog(m_audio, &m_radioModel, slice, this);
+        dlg->setFramelessMode(
+            AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+        m_ax25HfPacketDecodeDialog = dlg;
+        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+    }
+    m_ax25HfPacketDecodeDialog->setAttachedSlice(slice);
+    m_ax25HfPacketDecodeDialog->show();
+    m_ax25HfPacketDecodeDialog->raise();
+    m_ax25HfPacketDecodeDialog->activateWindow();
 }
 
 void MainWindow::startKissTncOnStartupIfConfigured()
 {
     if (m_ax25HfPacketDecodeDialog)
         return; // already constructed (e.g. user opened the window)
-    // Same key the dialog reads in its own constructor — promoted to the
-    // dialog header so both sides can't drift if the key is ever renamed.
-    if (AppSettings::instance()
-            .value(TncSettings::kStartOnStartup, "False").toString()
-                != QStringLiteral("True"))
+    // One-shot migration from legacy flat keys (AetherModemKissTnc*) into
+    // the nested-JSON blob (Constitution Principle V). Safe to call on
+    // every startup — no-op once the blob exists.
+    TncSettings::migrateLegacy();
+    if (!TncSettings::startOnStartup())
         return;
 
     // Construct the AetherModem window hidden and persistent (no WA_DeleteOnClose)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -356,6 +356,7 @@ private:
     void updatePaTempLabel();
     void showNetworkDiagnosticsDialog();
     void showAx25HfPacketDecodeDialog();
+    void startKissTncOnStartupIfConfigured();
     void showFlexControlDialog();
     void handleFlexControlTuneSteps(int steps);
     void handleFlexControlButton(int button, int action);

--- a/tests/ax25_libmodem_shim_test.cpp
+++ b/tests/ax25_libmodem_shim_test.cpp
@@ -1,4 +1,5 @@
 #include "core/tnc/AetherAx25LibmodemShim.h"
+#include "core/tnc/KissFraming.h"
 
 #include "bitstream.h"
 
@@ -594,6 +595,88 @@ void testTransmitVhf1200LoopbackDecodes()
            frames.first().payloadText == QStringLiteral("!4742.00N/12217.00W>2m APRS TX"));
 }
 
+void testKissFramingRoundTrip()
+{
+    namespace k = AetherSDR::kiss;
+
+    // Payload deliberately contains FEND (0xC0) and FESC (0xDB) so escaping runs.
+    QByteArray ax25;
+    ax25.append(static_cast<char>(0xC0));
+    ax25.append(static_cast<char>(0x01));
+    ax25.append(static_cast<char>(0xDB));
+    ax25.append("HELLO");
+
+    const QByteArray framed = k::encodeDataFrame(ax25);
+    report("KISS frame is delimited by FEND",
+           !framed.isEmpty()
+           && static_cast<quint8>(framed.front()) == k::kFend
+           && static_cast<quint8>(framed.back()) == k::kFend);
+    report("KISS framing escaped the special bytes", framed.size() > ax25.size() + 3);
+
+    k::Decoder decoder;
+    const QVector<QByteArray> frames = decoder.feed(framed);
+    report("KISS decoder yields exactly one frame", frames.size() == 1);
+    if (!frames.isEmpty()) {
+        quint8 port = 9;
+        quint8 command = 9;
+        QByteArray payload;
+        k::splitTypeByte(frames.first(), port, command, payload);
+        report("KISS decoded a data command on port 0", port == 0 && command == k::kCmdData);
+        report("KISS payload round-trips through escape/unescape", payload == ax25);
+    }
+
+    // Feeding one byte at a time must reassemble identically (TCP can split).
+    k::Decoder dripDecoder;
+    QVector<QByteArray> dripFrames;
+    for (int i = 0; i < framed.size(); ++i)
+        dripFrames += dripDecoder.feed(framed.mid(i, 1));
+    bool dripOk = dripFrames.size() == 1;
+    if (dripOk) {
+        quint8 p = 0;
+        quint8 c = 0;
+        QByteArray pl;
+        k::splitTypeByte(dripFrames.first(), p, c, pl);
+        dripOk = (pl == ax25);
+    }
+    report("KISS decoder reassembles across byte-split feeds", dripOk);
+}
+
+void testKissTxFromFrameLoopbackDecodes()
+{
+    AetherAx25LibmodemShim txShim;
+    txShim.configure(ax25DemodConfigForProfile(Ax25ModemProfile::Vhf1200));
+
+    // A KISS data frame carries a raw AX.25 frame with no FCS: encode a packet
+    // and drop the trailing 2-byte FCS to simulate what a host app would send.
+    const std::vector<uint8_t> frameWithFcs = lm::ax25::encode_frame(fixedVhf1200AprsTestPacket());
+    const QByteArray ax25NoFcs(reinterpret_cast<const char*>(frameWithFcs.data()),
+                               static_cast<qsizetype>(frameWithFcs.size() - 2));
+
+    const Ax25TransmitResult tx = txShim.buildTransmitAudioFromFrame(ax25NoFcs);
+    report("KISS TX-from-frame packetizes", tx.ok);
+    if (!tx.ok)
+        return;
+    report("KISS TX-from-frame is 1200 baud", tx.baud == 1200);
+    report("KISS TX-from-frame appended FCS", tx.frameBytes == ax25NoFcs.size() + 2);
+
+    const std::vector<float> mono = monoFromStereoFloat32(tx.stereoFloat32Pcm);
+    AetherAx25LibmodemShim rxShim;
+    rxShim.configure(ax25DemodConfigForProfile(Ax25ModemProfile::Vhf1200));
+    const auto frames = rxShim.processMonoFloat(mono.data(),
+                                                static_cast<int>(mono.size()),
+                                                tx.sampleRate);
+    report("KISS TX-from-frame loopback decodes one frame", frames.size() == 1);
+    if (frames.isEmpty())
+        return;
+    report("KISS TX loopback source", frames.first().source == QStringLiteral("KK7GWY-9"));
+    report("KISS TX loopback payload",
+           frames.first().payloadText
+               == QStringLiteral("!4742.00N/12217.00W>2m APRS via AetherModem 1200 baud"));
+    // RX raw-frame capture must round-trip back to exactly what we keyed.
+    report("KISS RX raw frame bytes match the keyed frame",
+           frames.first().ax25FrameNoFcs == ax25NoFcs);
+}
+
 void testMalformedTransmitMonitorSyntaxIsRejected()
 {
     AetherAx25LibmodemShim txShim;
@@ -789,6 +872,8 @@ int main(int argc, char** argv)
     testTransmitRawPayloadBuildsLoopbackAudio();
     testTransmitMonitorSyntaxBuildsLoopbackAudio();
     testTransmitVhf1200LoopbackDecodes();
+    testKissFramingRoundTrip();
+    testKissTxFromFrameLoopbackDecodes();
     testMalformedTransmitMonitorSyntaxIsRejected();
     testChunkedSyntheticReplayUsesReceiveGate();
     testReplayWavLoaderFeedsShim();


### PR DESCRIPTION
## Summary

Adds a **KISS-over-TCP TNC** to AetherModem so any host packet/APRS app (Xastir,
YAAC, APRSdroid, UISS, Dire Wolf clients, terminal programs) can send and receive
AX.25 through AetherModem's AFSK modem — plus the requested AetherModem UX cleanup.

## KISS TNC server

- **`src/core/tnc/KissFraming.{h,cpp}`** — pure KISS framing (FEND/FESC escaping,
  resync-safe incremental decoder, data-frame encode). No Qt::Network dependency,
  so it is unit-tested standalone.
- **`src/core/tnc/KissTncServer.{h,cpp}`** — cross-platform `QTcpServer`:
  - multiple simultaneous clients, each with its own KISS decoder;
  - **proper timeouts**: TCP keepalive + slow-consumer write-backlog cap + idle
    sweep + max-client cap, so dead/stuck clients are reaped, not leaked;
  - RX → all clients (KISS data frames); client → `ax25FrameFromClient` signal.
- **Shim support:**
  - RX captures the exact on-air AX.25 bytes (no FCS) into
    `Ax25DecodedFrame::ax25FrameNoFcs`, so decodes forward byte-faithfully;
  - `buildTransmitAudioFromFrame()` keys a raw KISS frame (computes/appends FCS),
    refactored to share AFSK rendering with the text TX path.
- **Dialog:** functional **AX.25 / KISS TNC** tabs (`QStackedWidget`); **Enable
  TNC**, **Start TNC on Startup**, **TCP port** (default **8001**) controls, all
  persisted; a serialized KISS TX queue feeding the existing PTT/DAX/pacing path;
  a **TNC STATUS** panel (port, client count, RX/TX counters). Enabling the TNC
  also enables the modem. `MainWindow::startKissTncOnStartupIfConfigured()`
  constructs the window hidden + persistent at launch when Start-on-Startup is set
  (see the follow-up note above re: the manual-enable case).

## AetherModem UX overhaul (per request)

- Window renamed `AetherModem - Packet Decoder (Experimental)` → **`AetherModem`**.
- Removed the **Experimental** banner entirely.
- Removed the **Tone Polarity** radios; polarity is always Normal (the correct
  sense for the supported HF DIGU / VHF FM paths).
- **Packet Activity:** taller bars + boosted levels so 1–2 packets/sec are clearly
  visible instead of sitting on the floor; **PACKET ACTIVITY** label moved above
  the graphic to line up with the MODEM STATUS / GAIN STAGE panels.

## Logging

All KISS lifecycle/per-frame activity logs on the `aether.ax25` (AetherModem)
category prefixed `KISS` (listen/stop, client connect/disconnect/refuse/reap, RX
broadcast, TX from client, parse/param) so issues triage as client-side vs RF-side.

## Tests

`ax25_libmodem_shim_test` gains:
- KISS framing round-trip (incl. FEND/FESC escaping and byte-split reassembly);
- KISS TX-from-frame → AFSK → RX loopback, also asserting the captured RX raw
  frame matches the keyed frame.

All tests pass; full app builds clean on macOS against current `main`.

## Test plan

- [ ] KISS TNC tab → Enable TNC (8001) → connect Xastir / YAAC / APRSdroid / a
      Dire Wolf KISS client at `host:8001`; confirm connect logged on `aether.ax25`
- [ ] Decode a 2m APRS frame → appears in the host app (RX → client)
- [ ] Send from the host app → keyed on the air at the selected baud (client → TX)
- [ ] Multiple clients simultaneously; kill one rudely → reaped, others fine
- [ ] Toggle Start on Startup, relaunch → TNC listening without opening the window
- [ ] AX.25 RX/TX unchanged; window title, removed banner/polarity, taller activity
      bars, label alignment all as expected
- [ ] `ax25_libmodem_shim_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)