### PR TITLE
fix(eq): stop EQ band sliders painting inverted blue fill

### DIFF
--- a/src/gui/EqApplet.cpp
+++ b/src/gui/EqApplet.cpp
@@ -83,8 +83,18 @@ static const QString kBlueActive =
 // foreground (fill) token rather than the canonical handle token
 // because the EQ slider's visual idiom puts the accent colour on the
 // handle itself (there's no sub-page fill rule here).
+//
+// sub-page / add-page are pinned to the groove background to neutralise
+// the global app-wide QSlider::sub-page:vertical fill (Theme.h), which
+// otherwise cascades in and paints the accent colour.  On a vertical
+// slider Qt paints sub-page from the handle *upward*, so with the EQ
+// handle centred at 0 dB that leaked fill reads upside-down (blue from
+// centre up).  Both halves stay groove-coloured so only the handle
+// carries the accent, matching this applet's intended idiom.
 static constexpr const char* kVSliderStyle =
     "QSlider::groove:vertical { width: 4px; background: {{color.slider.background}}; border-radius: 2px; }"
+    "QSlider::sub-page:vertical { background: {{color.slider.background}}; border: none; border-radius: 2px; }"
+    "QSlider::add-page:vertical { background: {{color.slider.background}}; border: none; border-radius: 2px; }"
     "QSlider::handle:vertical { height: 10px; width: 16px; margin: 0 -6px;"
     "background: {{color.slider.foreground}}; border-radius: 5px; }";
 


### PR DESCRIPTION
## Problem

The Equalizer applet's vertical band sliders rendered a blue fill from the **centre up** instead of centre down, making the EQ look upside-down.

## Root cause

The EQ band sliders were designed to carry the accent colour on the **handle only**, with no groove fill (see the `kVSliderStyle` comment in `EqApplet.cpp`). However, `kVSliderStyle` only overrode `groove` and `handle` — it never set `sub-page`/`add-page`. As a result the global app-wide rule `QSlider::sub-page:vertical { background: {{color.slider.foreground}} }` in `Theme.h` cascaded down onto the EQ sliders and painted the accent (blue) fill.

On a vertical `QSlider`, Qt paints `sub-page` from the handle **upward** — the same quirk already documented in `VfoWidget.cpp` and `RxApplet.cpp`. With the EQ handle centred at 0 dB, the leaked fill ran from centre up, reading upside-down.

## Fix

Pin `sub-page:vertical` and `add-page:vertical` to the groove background colour inside `kVSliderStyle`, so both halves stay neutral and only the handle carries the accent — exactly the idiom the applet's own comment describes. No behavioural change beyond removing the unintended fill; theme tokens (`color.slider.*`) and live theme-switch are preserved.

## Testing

- Full build (`cmake --build build -j8`) succeeds.
- Visual: EQ band sliders now show a neutral groove with the accent on the handle, no inverted fill.

## Notes for review

Pure styling fix, no logic/protocol change. Slice 0 RX flow unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)