### PR TITLE
feat(gui): Lean render mode — opaque pan/VFO, capped repaint, WAVE off, meter throttle (#3283)

### DIFF
--- a/src/gui/ClientCompApplet.cpp
+++ b/src/gui/ClientCompApplet.cpp
@@ -34,9 +34,11 @@ public:
         m_animTimer.setTimerType(Qt::PreciseTimer);
         m_animTimer.setInterval(kMeterSmootherIntervalMs);
         connect(&m_animTimer, &QTimer::timeout, this, [this]() {
-            if (!m_smooth.tick(m_animElapsed.restart()))
+            const bool settled = !m_smooth.tick(m_animElapsed.restart());
+            if (settled)
                 m_animTimer.stop();
-            update();
+            if (settled || MeterSmoother::shouldRepaint())
+                update();
         });
     }
 

--- a/src/gui/ClientCompApplet.cpp
+++ b/src/gui/ClientCompApplet.cpp
@@ -37,7 +37,7 @@ public:
             const bool settled = !m_smooth.tick(m_animElapsed.restart());
             if (settled)
                 m_animTimer.stop();
-            if (settled || MeterSmoother::shouldRepaint())
+            if (settled || m_smooth.shouldRepaint())
                 update();
         });
     }

--- a/src/gui/ClientCompMeter.cpp
+++ b/src/gui/ClientCompMeter.cpp
@@ -40,9 +40,11 @@ ClientCompMeter::ClientCompMeter(QWidget* parent) : QWidget(parent)
     m_animTimer.setTimerType(Qt::PreciseTimer);
     m_animTimer.setInterval(kMeterSmootherIntervalMs);
     connect(&m_animTimer, &QTimer::timeout, this, [this]() {
-        if (!m_smooth.tick(m_animElapsed.restart()))
+        const bool settled = !m_smooth.tick(m_animElapsed.restart());
+        if (settled)
             m_animTimer.stop();
-        update();
+        if (settled || MeterSmoother::shouldRepaint())
+            update();
     });
 
     // Phase 5 PR 3b — repaint when the theme changes so live edits to

--- a/src/gui/ClientCompMeter.cpp
+++ b/src/gui/ClientCompMeter.cpp
@@ -43,7 +43,7 @@ ClientCompMeter::ClientCompMeter(QWidget* parent) : QWidget(parent)
         const bool settled = !m_smooth.tick(m_animElapsed.restart());
         if (settled)
             m_animTimer.stop();
-        if (settled || MeterSmoother::shouldRepaint())
+        if (settled || m_smooth.shouldRepaint())
             update();
     });
 

--- a/src/gui/ClientDeEssApplet.cpp
+++ b/src/gui/ClientDeEssApplet.cpp
@@ -32,9 +32,11 @@ public:
         m_animTimer.setTimerType(Qt::PreciseTimer);
         m_animTimer.setInterval(kMeterSmootherIntervalMs);
         connect(&m_animTimer, &QTimer::timeout, this, [this]() {
-            if (!m_smooth.tick(m_animElapsed.restart()))
+            const bool settled = !m_smooth.tick(m_animElapsed.restart());
+            if (settled)
                 m_animTimer.stop();
-            update();
+            if (settled || MeterSmoother::shouldRepaint())
+                update();
         });
     }
 

--- a/src/gui/ClientDeEssApplet.cpp
+++ b/src/gui/ClientDeEssApplet.cpp
@@ -35,7 +35,7 @@ public:
             const bool settled = !m_smooth.tick(m_animElapsed.restart());
             if (settled)
                 m_animTimer.stop();
-            if (settled || MeterSmoother::shouldRepaint())
+            if (settled || m_smooth.shouldRepaint())
                 update();
         });
     }

--- a/src/gui/ClientGateApplet.cpp
+++ b/src/gui/ClientGateApplet.cpp
@@ -33,9 +33,11 @@ public:
         m_animTimer.setTimerType(Qt::PreciseTimer);
         m_animTimer.setInterval(kMeterSmootherIntervalMs);
         connect(&m_animTimer, &QTimer::timeout, this, [this]() {
-            if (!m_smooth.tick(m_animElapsed.restart()))
+            const bool settled = !m_smooth.tick(m_animElapsed.restart());
+            if (settled)
                 m_animTimer.stop();
-            update();
+            if (settled || MeterSmoother::shouldRepaint())
+                update();
         });
     }
 

--- a/src/gui/ClientGateApplet.cpp
+++ b/src/gui/ClientGateApplet.cpp
@@ -36,7 +36,7 @@ public:
             const bool settled = !m_smooth.tick(m_animElapsed.restart());
             if (settled)
                 m_animTimer.stop();
-            if (settled || MeterSmoother::shouldRepaint())
+            if (settled || m_smooth.shouldRepaint())
                 update();
         });
     }

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "core/AppSettings.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+
+namespace AetherSDR {
+
+// Persistence helper for display-related UI toggles (#3283 Lean Mode is the
+// first; future display-feature toggles like frameless / theme variants land
+// here as additional fields).
+//
+// Stored as a nested JSON blob under AppSettings["Display"], per the
+// nested-JSON-per-feature convention (constitution Principle V).  The legacy
+// flat key "LeanMode" is migrated into this blob on first read so existing
+// users keep their behavior.
+class DisplaySettings {
+public:
+    static bool leanMode() { return readObj().value("leanMode").toString("False") == "True"; }
+
+    static void setLeanMode(bool on)
+    {
+        QJsonObject o = readObj();
+        o["leanMode"] = on ? QStringLiteral("True") : QStringLiteral("False");
+        write(o);
+    }
+
+    // One-shot migration from the legacy "LeanMode" flat key.  Run at app
+    // startup before any caller reads the new blob.  Safe to call repeatedly:
+    // returns immediately if the new blob already exists.
+    static void migrateLegacy()
+    {
+        auto& s = AppSettings::instance();
+        if (s.contains("Display")) return;
+        const bool legacyLean =
+            s.value("LeanMode", "False").toString() == "True";
+        QJsonObject o;
+        o["leanMode"] = legacyLean ? QStringLiteral("True") : QStringLiteral("False");
+        write(o);
+        // Leave the legacy flat key in place — harmless after migration, and a
+        // future cleanup PR can drop it once we're confident no other reader
+        // still touches it.
+    }
+
+private:
+    static QJsonObject readObj()
+    {
+        const QString json =
+            AppSettings::instance().value("Display", QString{}).toString();
+        if (json.isEmpty()) return {};
+        return QJsonDocument::fromJson(json.toUtf8()).object();
+    }
+    static void write(const QJsonObject& o)
+    {
+        auto& s = AppSettings::instance();
+        s.setValue("Display",
+                   QString::fromUtf8(
+                       QJsonDocument(o).toJson(QJsonDocument::Compact)));
+        s.save();
+    }
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -29,6 +29,7 @@
 #endif
 #include "SpectrumOverlayMenu.h"
 #include "VfoWidget.h"
+#include "MeterSmoother.h"  // global lean-mode meter repaint throttle (#3283)
 #include "AppletPanel.h"
 #include "containers/ContainerManager.h"
 #include "RxApplet.h"
@@ -1473,6 +1474,14 @@ MainWindow::MainWindow(QWidget* parent)
     // Audio worker thread (#502) — AudioEngine runs on its own thread so
     // audio processing never competes with paintEvent for main thread CPU.
     m_audioThread = new QThread(this);
+    // Lean render mode (#3283): read persisted state early so panadapters
+    // created during startup seed their Lean button/widget correctly, then
+    // apply once after construction to cover VFOs + the WAVE applet.
+    m_leanMode = AppSettings::instance().value("LeanMode", "False").toString() == "True";
+    if (m_leanMode) {
+        QTimer::singleShot(0, this, [this]() { applyLeanMode(true); });
+    }
+
     m_audioThread->setObjectName("AudioEngine");
     m_audio = new AudioEngine;  // no parent — will be moved to thread
     m_audio->setRxBoost(
@@ -10020,6 +10029,40 @@ void MainWindow::applyDarkTheme()
 
 // ─── Radio/model event handlers ───────────────────────────────────────────────
 
+void MainWindow::applyLeanMode(bool on)
+{
+    m_leanMode = on;
+
+    // Panadapters: opaque single layer (no wallpaper / fill) + 60 Hz cap.
+    // Also keep every pan's Lean button in sync (the toggle is global).
+    for (auto* sw : findChildren<SpectrumWidget*>()) {
+        sw->setLeanMode(on);
+        if (auto* menu = sw->overlayMenu())
+            menu->setLeanChecked(on);
+    }
+
+    // VFO panels: opaque, cacheable layer (kills the translucent re-composite).
+    for (auto* vfo : findChildren<VfoWidget*>())
+        vfo->setOpaqueMode(on);
+
+    // WAVE scope: hidden + feed dropped.
+    if (m_appletPanel) {
+        if (auto* wave = m_appletPanel->waveApplet())
+            wave->setActive(!on);
+    }
+
+    // Meters: throttle their animation repaint so they stop dirtying the shared
+    // backing store every frame (which forces a full-window texture re-upload to
+    // recomposite with the GPU panadapter — the dominant pooled cost on large/5K
+    // windows; see #3283). Native-layering the panel was tried and did not
+    // isolate them under Qt 6.11/macOS, so we cap the repaint rate instead.
+    MeterSmoother::setLeanThrottle(on);
+
+    auto& s = AppSettings::instance();
+    s.setValue("LeanMode", on ? "True" : "False");
+    s.save();
+}
+
 void MainWindow::onConnectionStateChanged(bool connected)
 {
     if (m_shuttingDown) {
@@ -12607,6 +12650,12 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     }
 
     // ── Per-pan display controls (client-side) ───────────────────────────
+    // Global lean render mode — every pan's Lean button drives the same
+    // app-wide toggle; seed this new pan's button + widget with current state.
+    connect(menu, &SpectrumOverlayMenu::leanModeToggled,
+            this, &MainWindow::applyLeanMode);
+    menu->setLeanChecked(m_leanMode);
+    sw->setLeanMode(m_leanMode);
     connect(menu, &SpectrumOverlayMenu::fftFillAlphaChanged,
             sw, &SpectrumWidget::setFftFillAlpha);
     connect(menu, &SpectrumOverlayMenu::fftFillColorChanged,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1,6 +1,7 @@
 #include "MainWindow.h"
 
 #include "CwDecodeSettings.h"
+#include "DisplaySettings.h"
 #ifdef HAVE_MQTT
 #include "MqttApplet.h"
 #include "MqttSettingsDialog.h"
@@ -1477,7 +1478,10 @@ MainWindow::MainWindow(QWidget* parent)
     // Lean render mode (#3283): read persisted state early so panadapters
     // created during startup seed their Lean button/widget correctly, then
     // apply once after construction to cover VFOs + the WAVE applet.
-    m_leanMode = AppSettings::instance().value("LeanMode", "False").toString() == "True";
+    // Persistence is the nested "Display" blob (Principle V); the legacy
+    // flat "LeanMode" key is migrated into it on first read.
+    DisplaySettings::migrateLegacy();
+    m_leanMode = DisplaySettings::leanMode();
     if (m_leanMode) {
         QTimer::singleShot(0, this, [this]() { applyLeanMode(true); });
     }
@@ -10033,7 +10037,7 @@ void MainWindow::applyLeanMode(bool on)
 {
     m_leanMode = on;
 
-    // Panadapters: opaque single layer (no wallpaper / fill) + 60 Hz cap.
+    // Panadapters: opaque single layer (no wallpaper / fill) + ~30 Hz cap.
     // Also keep every pan's Lean button in sync (the toggle is global).
     for (auto* sw : findChildren<SpectrumWidget*>()) {
         sw->setLeanMode(on);
@@ -10045,10 +10049,18 @@ void MainWindow::applyLeanMode(bool on)
     for (auto* vfo : findChildren<VfoWidget*>())
         vfo->setOpaqueMode(on);
 
-    // WAVE scope: hidden + feed dropped.
+    // WAVE scope: hidden + feed dropped. Round-trip respects the user's
+    // pre-Lean choice (if they had the scope hidden before enabling Lean,
+    // disabling Lean must not silently re-show it).
     if (m_appletPanel) {
-        if (auto* wave = m_appletPanel->waveApplet())
-            wave->setActive(!on);
+        if (auto* wave = m_appletPanel->waveApplet()) {
+            if (on) {
+                m_preLeanWaveActive = wave->isActive();
+                wave->setActive(false);
+            } else {
+                wave->setActive(m_preLeanWaveActive);
+            }
+        }
     }
 
     // Meters: throttle their animation repaint so they stop dirtying the shared
@@ -10058,9 +10070,7 @@ void MainWindow::applyLeanMode(bool on)
     // isolate them under Qt 6.11/macOS, so we cap the repaint rate instead.
     MeterSmoother::setLeanThrottle(on);
 
-    auto& s = AppSettings::instance();
-    s.setValue("LeanMode", on ? "True" : "False");
-    s.save();
+    DisplaySettings::setLeanMode(on);
 }
 
 void MainWindow::onConnectionStateChanged(bool connected)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -155,6 +155,10 @@ protected:
 #endif
 
 private slots:
+    // Global lean render mode (#3283): opaque pan + VFO, 60 Hz repaint cap,
+    // WAVE scope off. Applied across all panes/VFOs, persisted, reversible.
+    void applyLeanMode(bool on);
+
     // Radio/connection events
     void onConnectionStateChanged(bool connected);
     void adjustCatPortCounts(bool connected);  // called from onConnectionStateChanged
@@ -673,6 +677,7 @@ private:
     // Active slice tracking for multi-slice support
     int m_activeSliceId{-1};
     bool m_splitActive{false};
+    bool m_leanMode{false};  // global lean render mode state (#3283)
     int  m_splitRxSliceId{-1};
     int  m_splitTxSliceId{-1};
     int  m_pendingMemoryRevealSliceId{-1};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -155,8 +155,9 @@ protected:
 #endif
 
 private slots:
-    // Global lean render mode (#3283): opaque pan + VFO, 60 Hz repaint cap,
-    // WAVE scope off. Applied across all panes/VFOs, persisted, reversible.
+    // Global lean render mode (#3283): opaque pan + VFO, ~30 Hz repaint cap
+    // (kLeanFrameMs = 33), WAVE scope off, meters throttled to ~12 Hz per
+    // instance. Applied across all panes/VFOs, persisted, reversible.
     void applyLeanMode(bool on);
 
     // Radio/connection events
@@ -678,6 +679,10 @@ private:
     int m_activeSliceId{-1};
     bool m_splitActive{false};
     bool m_leanMode{false};  // global lean render mode state (#3283)
+    // Pre-lean WaveApplet active state, captured on Lean activation so the
+    // round-trip restores whatever the user had before instead of silently
+    // re-showing the scope. Only meaningful while m_leanMode is true.
+    bool m_preLeanWaveActive{true};
     int  m_splitRxSliceId{-1};
     int  m_splitTxSliceId{-1};
     int  m_pendingMemoryRevealSliceId{-1};

--- a/src/gui/MeterSmoother.h
+++ b/src/gui/MeterSmoother.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QtGlobal>
+#include <QElapsedTimer>
 #include <cmath>
 
 namespace AetherSDR {
@@ -99,7 +100,45 @@ public:
     void setBallistics(const Ballistics& b) { m_b = b; }
     const Ballistics& ballistics() const { return m_b; }
 
+    // ── Lean-mode shared repaint gate (#3283) ──────────────────────────────
+    // Every meter animates its MeterSmoother at ~120 Hz; each tick repaints,
+    // and on a window that also hosts the GPU panadapter every repaint forces a
+    // full-window backing-store→texture re-upload (the dominant pooled cost on
+    // large/5K displays). Lean mode keeps the smoother integrating at the full
+    // rate (so ballistics stay smooth) but gates the *repaint* to ~kLeanRepaintHz
+    // via a single shared clock, so all meters batch into one frame instead of
+    // dirtying the backing store independently 120×/sec.
+    //
+    // Usage at the meter's timer callback:
+    //     const bool settled = !m_smooth.tick(elapsed);
+    //     if (settled) m_timer.stop();
+    //     if (settled || MeterSmoother::shouldRepaint()) update();
+    // (Always paint the settled frame so the final value is never dropped.)
+    static void setLeanThrottle(bool on) { s_leanThrottle = on; }
+    static bool leanThrottle() { return s_leanThrottle; }
+    static bool shouldRepaint()
+    {
+        if (!s_leanThrottle) {
+            return true;
+        }
+        constexpr qint64 kGateMs = 1000 / kLeanRepaintHz;
+        static QElapsedTimer gate;
+        static qint64 lastMs = -1;
+        if (!gate.isValid()) {
+            gate.start();
+        }
+        const qint64 now = gate.elapsed();
+        if (lastMs < 0 || now - lastMs >= kGateMs) {
+            lastMs = now;
+            return true;
+        }
+        return false;
+    }
+
 private:
+    static constexpr int kLeanRepaintHz = 12;  // gated meter repaint rate in lean
+    static inline bool s_leanThrottle = false;
+
     Ballistics m_b;
     float      m_display{0.0f};
     float      m_target{0.0f};

--- a/src/gui/MeterSmoother.h
+++ b/src/gui/MeterSmoother.h
@@ -100,36 +100,42 @@ public:
     void setBallistics(const Ballistics& b) { m_b = b; }
     const Ballistics& ballistics() const { return m_b; }
 
-    // ── Lean-mode shared repaint gate (#3283) ──────────────────────────────
+    // ── Lean-mode per-widget repaint gate (#3283) ──────────────────────────
     // Every meter animates its MeterSmoother at ~120 Hz; each tick repaints,
     // and on a window that also hosts the GPU panadapter every repaint forces a
     // full-window backing-store→texture re-upload (the dominant pooled cost on
     // large/5K displays). Lean mode keeps the smoother integrating at the full
     // rate (so ballistics stay smooth) but gates the *repaint* to ~kLeanRepaintHz
-    // via a single shared clock, so all meters batch into one frame instead of
-    // dirtying the backing store independently 120×/sec.
+    // per widget.
+    //
+    // The gate is per-instance (each MeterSmoother carries its own clock),
+    // because every active meter owns its own MeterSmoother. A previous
+    // shared-static version of this gate underdelivered on its own claim: with
+    // N meters racing into the gate, the first to tick each ~83 ms window got
+    // through and the other N−1 were starved that window, so each individual
+    // meter only saw the green light at roughly (kLeanRepaintHz / N) Hz —
+    // visibly stuttery on GR bars and S-meter needles. Per-instance gates let
+    // every meter independently hit the target rate.
     //
     // Usage at the meter's timer callback:
     //     const bool settled = !m_smooth.tick(elapsed);
     //     if (settled) m_timer.stop();
-    //     if (settled || MeterSmoother::shouldRepaint()) update();
+    //     if (settled || m_smooth.shouldRepaint()) update();
     // (Always paint the settled frame so the final value is never dropped.)
     static void setLeanThrottle(bool on) { s_leanThrottle = on; }
     static bool leanThrottle() { return s_leanThrottle; }
-    static bool shouldRepaint()
+    bool shouldRepaint()
     {
         if (!s_leanThrottle) {
             return true;
         }
         constexpr qint64 kGateMs = 1000 / kLeanRepaintHz;
-        static QElapsedTimer gate;
-        static qint64 lastMs = -1;
-        if (!gate.isValid()) {
-            gate.start();
+        if (!m_gate.isValid()) {
+            m_gate.start();
         }
-        const qint64 now = gate.elapsed();
-        if (lastMs < 0 || now - lastMs >= kGateMs) {
-            lastMs = now;
+        const qint64 now = m_gate.elapsed();
+        if (m_lastMs < 0 || now - m_lastMs >= kGateMs) {
+            m_lastMs = now;
             return true;
         }
         return false;
@@ -139,9 +145,11 @@ private:
     static constexpr int kLeanRepaintHz = 12;  // gated meter repaint rate in lean
     static inline bool s_leanThrottle = false;
 
-    Ballistics m_b;
-    float      m_display{0.0f};
-    float      m_target{0.0f};
+    Ballistics     m_b;
+    float          m_display{0.0f};
+    float          m_target{0.0f};
+    QElapsedTimer  m_gate;
+    qint64         m_lastMs{-1};
 };
 
 // Recommended driving-timer interval for a MeterSmoother.  8 ms ≈

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -1,4 +1,5 @@
 #include "SMeterWidget.h"
+#include "MeterSmoother.h"  // shared lean-mode repaint gate (#3283)
 
 #include <QPainter>
 #include <QPainterPath>
@@ -203,11 +204,16 @@ void SMeterWidget::animateNeedle()
         && m_peakHoldTimer.elapsed() > m_peakHoldTimeMs
         && m_peakHoldDbm > m_levelDbm + 0.01f;
 
-    if (needleAtTarget && !peakHoldAnimating) {
+    const bool settled = needleAtTarget && !peakHoldAnimating;
+    if (settled) {
         m_needleAnimation.stop();
     }
 
-    update();
+    // Gate the needle repaint in lean mode so it stops dirtying the shared
+    // backing store ~120×/sec (#3283); always paint the settled frame.
+    if (settled || MeterSmoother::shouldRepaint()) {
+        update();
+    }
 }
 
 void SMeterWidget::updatePeakHoldValue()

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -211,7 +211,7 @@ void SMeterWidget::animateNeedle()
 
     // Gate the needle repaint in lean mode so it stops dirtying the shared
     // backing store ~120×/sec (#3283); always paint the settled frame.
-    if (settled || MeterSmoother::shouldRepaint()) {
+    if (settled || m_smooth.shouldRepaint()) {
         update();
     }
 }

--- a/src/gui/SMeterWidget.h
+++ b/src/gui/SMeterWidget.h
@@ -4,6 +4,8 @@
 #include <QTimer>
 #include <QElapsedTimer>
 
+#include "MeterSmoother.h"
+
 namespace AetherSDR {
 
 // Analog S-Meter gauge widget matching the SmartSDR look.
@@ -129,6 +131,14 @@ private:
     // Arc geometry: shallow arc spanning ~70° (like SmartSDR)
     static constexpr float ARC_START_DEG = 55.0f;   // right end (degrees from +X axis)
     static constexpr float ARC_END_DEG   = 125.0f;  // left end
+
+    // SMeterWidget runs its own needle animation (see m_needleAnimation /
+    // m_needleFraction above), but lean-mode repaint throttling is shared
+    // with every other meter through MeterSmoother::shouldRepaint().
+    // Holding an instance here only for its per-widget gate keeps every
+    // meter independently hitting kLeanRepaintHz instead of starving on a
+    // shared static (#3283).
+    MeterSmoother m_smooth;
 };
 
 } // namespace AetherSDR

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -234,7 +234,6 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
         {"Memory",    5, nullptr},   // 6 — toggleMemoryPanel
         // MEM+ moved into MemoryBrowsePanel (bottom button — doesn't scroll).
         {"DAX",       3, nullptr},   // 6 — toggleDaxPanel
-        {"Lean",      6, nullptr},   // 7 — global lean render mode (checkable)
     };
 
     for (const auto& def : defs) {
@@ -249,13 +248,6 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleDisplayPanel);
         else if (def.specialIdx == 5)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleMemoryPanel);
-        else if (def.specialIdx == 6) {
-            // Lean: checkable toggle, drives the global low-overhead render mode.
-            btn->setCheckable(true);
-            m_leanBtn = btn;
-            connect(btn, &QPushButton::toggled, this,
-                    [this](bool on) { emit leanModeToggled(on); });
-        }
         else if (def.text == "+RX")
             connect(btn, &QPushButton::clicked, this, [this]() { emit addRxClicked(m_panId); });
         else if (def.sig)
@@ -272,11 +264,6 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
         m_menuBtns[kBtnDisplay]->setToolTip("Open panadapter and waterfall display settings.");
         m_menuBtns[kBtnMemoryBrowse]->setToolTip("Browse saved memories for quick recall.");
         m_menuBtns[kBtnDax]->setToolTip("Open DAX audio routing channel selector.");
-    }
-    if (m_leanBtn) {
-        m_leanBtn->setToolTip("Lean mode: opaque panadapter + VFO, capped repaint, "
-                              "WAVE scope off. Reduces CPU/GPU load. Persists across "
-                              "restarts.");
     }
 
     buildBandPanel();
@@ -1357,6 +1344,23 @@ void SpectrumOverlayMenu::buildDisplayPanel()
             emit backgroundImageCleared();
         });
         grid->addWidget(clearBtn, row, 3);
+        ++row;
+    }
+
+    // ── Lean render mode toggle (#3283) ─────────────────────────────────
+    // Global low-overhead render mode: opaque panadapter + VFO, capped
+    // repaint, WAVE scope off, throttled meters. Lives under Display, just
+    // below the background chooser. Drives the app-wide toggle.
+    {
+        m_leanBtn = new QPushButton("Lean Mode");
+        m_leanBtn->setCheckable(true);
+        m_leanBtn->setStyleSheet(btnStyle);
+        m_leanBtn->setToolTip("Lean mode: opaque panadapter + VFO, capped "
+                              "repaint, WAVE scope off, throttled meters. "
+                              "Reduces CPU/GPU load. Persists across restarts.");
+        connect(m_leanBtn, &QPushButton::toggled, this,
+                [this](bool on) { emit leanModeToggled(on); });
+        grid->addWidget(m_leanBtn, row, 0, 1, 4);
         ++row;
     }
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -234,6 +234,7 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
         {"Memory",    5, nullptr},   // 6 — toggleMemoryPanel
         // MEM+ moved into MemoryBrowsePanel (bottom button — doesn't scroll).
         {"DAX",       3, nullptr},   // 6 — toggleDaxPanel
+        {"Lean",      6, nullptr},   // 7 — global lean render mode (checkable)
     };
 
     for (const auto& def : defs) {
@@ -248,6 +249,13 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleDisplayPanel);
         else if (def.specialIdx == 5)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleMemoryPanel);
+        else if (def.specialIdx == 6) {
+            // Lean: checkable toggle, drives the global low-overhead render mode.
+            btn->setCheckable(true);
+            m_leanBtn = btn;
+            connect(btn, &QPushButton::toggled, this,
+                    [this](bool on) { emit leanModeToggled(on); });
+        }
         else if (def.text == "+RX")
             connect(btn, &QPushButton::clicked, this, [this]() { emit addRxClicked(m_panId); });
         else if (def.sig)
@@ -264,6 +272,11 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
         m_menuBtns[kBtnDisplay]->setToolTip("Open panadapter and waterfall display settings.");
         m_menuBtns[kBtnMemoryBrowse]->setToolTip("Browse saved memories for quick recall.");
         m_menuBtns[kBtnDax]->setToolTip("Open DAX audio routing channel selector.");
+    }
+    if (m_leanBtn) {
+        m_leanBtn->setToolTip("Lean mode: opaque panadapter + VFO, capped repaint, "
+                              "WAVE scope off. Reduces CPU/GPU load. Persists across "
+                              "restarts.");
     }
 
     buildBandPanel();
@@ -612,6 +625,14 @@ void SpectrumOverlayMenu::setPanId(const QString& id)
     m_panId = id;
     wirePanadapterRxAntenna();
     refreshAntennaCombo();
+}
+
+void SpectrumOverlayMenu::setLeanChecked(bool on)
+{
+    if (!m_leanBtn || m_leanBtn->isChecked() == on)
+        return;
+    QSignalBlocker block(m_leanBtn);  // reflect state without re-emitting
+    m_leanBtn->setChecked(on);
 }
 
 void SpectrumOverlayMenu::setRadioModel(RadioModel* model)

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -60,6 +60,10 @@ public:
     void setPanId(const QString& id);
     QString panId() const { return m_panId; }
 
+    // Reflect the global Lean-mode state on this pan's Lean button without
+    // re-emitting (MainWindow keeps every pan's button in sync).
+    void setLeanChecked(bool on);
+
     // Connect/disconnect the ANT panel to a slice model.
     void setSlice(SliceModel* slice);
     void setWnbState(bool on, int level);
@@ -145,6 +149,8 @@ signals:
     void backgroundOpacityChanged(int pct);
     void backgroundFillColorChanged(const QColor& color);
     void displaySettingsReset();
+    // Global low-overhead render mode (opaque pan/VFO, capped repaint, WAVE off).
+    void leanModeToggled(bool on);
 
 private:
     QString m_panId;
@@ -180,8 +186,10 @@ private:
     static constexpr int kBtnDisplay = 4;
     static constexpr int kBtnMemoryBrowse = 5;
     static constexpr int kBtnDax = 6;
+    static constexpr int kBtnLean = 7;
 
     QPushButton* m_toggleBtn{nullptr};
+    QPushButton* m_leanBtn{nullptr};
     QVector<QPushButton*> m_menuBtns;
     bool m_expanded{true};
 

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -186,10 +186,9 @@ private:
     static constexpr int kBtnDisplay = 4;
     static constexpr int kBtnMemoryBrowse = 5;
     static constexpr int kBtnDax = 6;
-    static constexpr int kBtnLean = 7;
 
     QPushButton* m_toggleBtn{nullptr};
-    QPushButton* m_leanBtn{nullptr};
+    QPushButton* m_leanBtn{nullptr};  // Lean toggle (lives in the Display panel)
     QVector<QPushButton*> m_menuBtns;
     bool m_expanded{true};
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -3136,7 +3136,7 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
         }
     }
 
-    update();
+    leanCappedUpdate();
 }
 
 void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
@@ -3316,7 +3316,7 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     if (PerfTelemetry::instance().enabled())
         PerfTelemetry::instance().recordWaterfallNativeRows(rowsToPush);
 
-    update();
+    leanCappedUpdate();
 }
 
 // ─── Layout helpers ────────────────────────────────────────────────────────────
@@ -4604,6 +4604,27 @@ void SpectrumWidget::leaveEvent(QEvent* event)
     updateTrackedCursorState(QPoint(-1, -1), false);
 }
 
+void SpectrumWidget::setLeanMode(bool on)
+{
+    if (m_leanMode == on)
+        return;
+    m_leanMode = on;
+    m_leanRepaintClock.invalidate();
+    markOverlayDirty();  // re-render with/without wallpaper + fill
+}
+
+void SpectrumWidget::leanCappedUpdate()
+{
+    if (m_leanMode) {
+        if (m_leanRepaintClock.isValid()
+            && m_leanRepaintClock.elapsed() < kLeanFrameMs) {
+            return;  // drop frames above ~60 Hz
+        }
+        m_leanRepaintClock.restart();
+    }
+    update();
+}
+
 void SpectrumWidget::setBackgroundImage(const QString& path)
 {
     m_bgImagePath = path;
@@ -5446,7 +5467,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             QPainter bp(&m_overlayBg);
             bp.setRenderHint(QPainter::Antialiasing, false);
             bp.fillRect(specRect, m_bgFillColor);
-            if (!m_bgImage.isNull()) {
+            if (!m_leanMode && !m_bgImage.isNull()) {
                 if (m_bgScaledSize != specRect.size()) {
                     QImage expanded = m_bgImage.scaled(specRect.size(),
                         Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
@@ -5684,7 +5705,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             const float fr = m_fftFillColor.redF();
             const float fg = m_fftFillColor.greenF();
             const float fb = m_fftFillColor.blueF();
-            const float fa = m_fftFillAlpha;
+            const float fa = m_leanMode ? 0.0f : m_fftFillAlpha;
 
             // Solid fill: slider sweeps from translucent gradient to solid.
             // At low slider: soft glow under curve (bright top, dark faint base)
@@ -6080,7 +6101,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         //           bleeds through as the slider moves toward 100
         //   above:  grid → FFT trace → band plan → markers
         p.fillRect(specRect, m_bgFillColor);
-        if (!m_bgImage.isNull()) {
+        if (!m_leanMode && !m_bgImage.isNull()) {
             if (m_bgScaledSize != specRect.size()) {
                 QImage expanded = m_bgImage.scaled(specRect.size(),
                     Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
@@ -6497,8 +6518,9 @@ void SpectrumWidget::drawSpectrum(QPainter& p, const QRect& r)
 
             float avgT = (pts[i].t + pts[i+1].t) * 0.5f;
             QColor top = heatColor(avgT);
-            top.setAlphaF(m_fftFillAlpha * 0.3f);
-            QColor bot(0, 0, 77, static_cast<int>(255 * m_fftFillAlpha));
+            const float swFillAlpha = m_leanMode ? 0.0f : m_fftFillAlpha;
+            top.setAlphaF(swFillAlpha * 0.3f);
+            QColor bot(0, 0, 77, static_cast<int>(255 * swFillAlpha));
             QLinearGradient grad(0, qMin(pts[i].y, pts[i+1].y), 0, bottom);
             grad.setColorAt(0.0, top);
             grad.setColorAt(1.0, bot);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4618,7 +4618,7 @@ void SpectrumWidget::leanCappedUpdate()
     if (m_leanMode) {
         if (m_leanRepaintClock.isValid()
             && m_leanRepaintClock.elapsed() < kLeanFrameMs) {
-            return;  // drop frames above ~60 Hz
+            return;  // drop frames above ~30 Hz (kLeanFrameMs = 33)
         }
         m_leanRepaintClock.restart();
     }

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -172,6 +172,12 @@ public:
     // Set the current demod mode (for zoom centering behavior).
     void setMode(const QString& mode) { m_mode = mode; }
 
+    // Lean render mode (#3283): skip the wallpaper layer (render an opaque
+    // single layer), drop the translucent FFT fill, and cap spectrum/waterfall
+    // repaints to ~60 Hz. Reversible — no persisted state is destroyed.
+    void setLeanMode(bool on);
+    bool leanMode() const { return m_leanMode; }
+
 
     // Access the floating overlay menu (for wiring signals).
     SpectrumOverlayMenu* overlayMenu() const { return m_overlayMenu; }
@@ -801,6 +807,15 @@ private:
     FilterEdge m_draggingFilter{FilterEdge::None};
     int m_filterDragStartX{0};      // pixel X at grab time (#764)
     int m_filterDragStartHz{0};     // filter edge Hz at grab time (#764)
+    // Lean render mode state (#3283).
+    bool m_leanMode{false};
+    QElapsedTimer m_leanRepaintClock;       // repaint cap in lean mode
+    // Each panadapter present forces a full-window backing-store→GPU texture
+    // re-upload (the dominant pooled cost on large/5K windows — #3283), so the
+    // present rate ~= the flush rate. 33 ms (~30 Hz) roughly halves that upload
+    // load vs 60 Hz while staying visually smooth for a low-overhead mode.
+    static constexpr int kLeanFrameMs = 33;
+    void leanCappedUpdate();                // update(), throttled when lean
     // VFO passband drag state (#404)
     bool m_draggingVfo{false};
     int  m_vfoDragOffsetHz{0};  // Hz offset from VFO at grab point (#1120)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -173,8 +173,12 @@ public:
     void setMode(const QString& mode) { m_mode = mode; }
 
     // Lean render mode (#3283): skip the wallpaper layer (render an opaque
-    // single layer), drop the translucent FFT fill, and cap spectrum/waterfall
-    // repaints to ~60 Hz. Reversible — no persisted state is destroyed.
+    // single layer), drop the translucent FFT fill, and cap the spectrum and
+    // waterfall data-driven repaints to ~30 Hz (kLeanFrameMs = 33). The cap is
+    // applied via leanCappedUpdate() only on the two high-frequency entry
+    // points (updateSpectrum, updateWaterfallRow); interactive paths (cursor
+    // moves, marker drags, etc.) keep their immediate update() calls so input
+    // feels snappy. Reversible — no persisted state is destroyed.
     void setLeanMode(bool on);
     bool leanMode() const { return m_leanMode; }
 

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1992,6 +1992,32 @@ void VfoWidget::showTab(int index)
 
 // ── Collapsed flag toggle ─────────────────────────────────────────────────────
 
+void VfoWidget::setOpaqueMode(bool on)
+{
+    if (m_opaqueMode == on)
+        return;
+    m_opaqueMode = on;
+
+    // The panel's paintEvent already fills an opaque dark rounded rect; the
+    // translucent attribute + "background: transparent" stylesheet only existed
+    // to let the rounded corners show through. In lean mode we trade rounded
+    // corners for an opaque, independently-cacheable layer.
+    //
+    // The #VfoWidgetRoot stylesheet is what actually governs Qt's opacity
+    // decision here — with "background: transparent" the compositor re-blends
+    // the whole panel (and its buttons) over the window on every sync. Swapping
+    // to an opaque background lets it cache + Source-blit instead, which is the
+    // dominant idle/drag pool cost (#3283). Clearing WA_TranslucentBackground
+    // alone is not enough while the stylesheet stays transparent.
+    setAttribute(Qt::WA_TranslucentBackground, !on);
+    setStyleSheet(on
+        ? QStringLiteral("QWidget#VfoWidgetRoot { background: #0a0a14; border: none; }")
+        : kBgStyle);
+    update();
+    if (QWidget* p = parentWidget())
+        p->update();
+}
+
 void VfoWidget::setCollapsed(bool collapsed)
 {
     if (m_collapsed == collapsed) return;

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -83,6 +83,11 @@ public:
     bool isCollapsed() const { return m_collapsed; }
     void setCollapsed(bool collapsed);
 
+    // Lean render mode: drop WA_TranslucentBackground so the panel composites
+    // as an opaque, cacheable layer instead of being alpha-blended over the
+    // whole window every frame (the dominant idle CPU cost — see #3283).
+    void setOpaqueMode(bool on);
+
     // Which side of the slice marker the flag panel is currently rendered on.
     // Tracked by updatePosition() via m_lastOnLeft.  Used by panFollowVfo()
     // to extend the pan-follow trigger to the flag's outer edge — single-side
@@ -171,6 +176,7 @@ private:
     float          m_signalMeterFraction{0.0f};
     float          m_targetSignalMeterFraction{0.0f};
     bool           m_collapsed{false};
+    bool           m_opaqueMode{false};  // lean mode: opaque (non-translucent) panel
     bool           m_collapseToggled{false};  // guard: absorb release after toggle
     int            m_scrollAccum{0};    // trackpad pixel scroll accumulator
     int            m_angleAccum{0};     // mouse wheel angle accumulator

--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -386,8 +386,18 @@ void WaveApplet::appendScopeSamples(const QByteArray& monoFloat32Pcm,
                                     int sampleRate,
                                     bool tx)
 {
+    if (!m_active)
+        return;  // lean mode: drop the feed so the scope never repaints
     if (m_waveform)
         m_waveform->appendScopeSamples(monoFloat32Pcm, sampleRate, tx);
+}
+
+void WaveApplet::setActive(bool on)
+{
+    if (m_active == on)
+        return;
+    m_active = on;
+    setVisible(on);
 }
 
 void WaveApplet::setTransmitting(bool tx)

--- a/src/gui/WaveApplet.h
+++ b/src/gui/WaveApplet.h
@@ -25,6 +25,10 @@ public slots:
     void appendScopeSamples(const QByteArray& monoFloat32Pcm, int sampleRate, bool tx);
     void setTransmitting(bool tx);
 
+    // Lean mode: fully disable the scope — hide the applet and drop incoming
+    // sample batches so the 24 Hz software repaint stops entirely (#3283).
+    void setActive(bool on);
+
 private:
     void buildSettingsDrawer();
     void setSettingsExpanded(bool expanded);
@@ -32,6 +36,7 @@ private:
     void updateRefreshLabel();
     void updateWindowLabel();
 
+    bool m_active{true};  // false in lean mode — applet hidden + feed dropped
     WaveformWidget* m_waveform{nullptr};
     QFrame* m_settingsDrawer{nullptr};
     GuardedComboBox* m_viewCombo{nullptr};

--- a/src/gui/WaveApplet.h
+++ b/src/gui/WaveApplet.h
@@ -25,9 +25,15 @@ public slots:
     void appendScopeSamples(const QByteArray& monoFloat32Pcm, int sampleRate, bool tx);
     void setTransmitting(bool tx);
 
-    // Lean mode: fully disable the scope — hide the applet and drop incoming
-    // sample batches so the 24 Hz software repaint stops entirely (#3283).
+    // Lean mode: fully disable the scope — hide the applet and short-circuit
+    // the appendScopeSamples handler so the m_waveform sample buffer +
+    // 24 Hz software repaint stop entirely. The upstream
+    // AudioEngine::{tx,rx}PostChainScopeReady signal still fires per audio
+    // callback (Qt queues the event onto the GUI thread either way), so the
+    // "drop sample feed" framing means the appended-and-repainted work is
+    // skipped, not the signal emission itself. (#3283)
     void setActive(bool on);
+    bool isActive() const { return m_active; }
 
 private:
     void buildSettingsDrawer();


### PR DESCRIPTION
## Summary

Adds a reversible, persisted **"Lean"** render mode — a checkable button in each panadapter's overlay-menu column — that bundles the render-cost reductions found during the #3283 profiling investigation into one app-wide toggle. Driven by `MainWindow::applyLeanMode`, persisted as `LeanMode` in `AppSettings`, restored on startup.

> **Draft / experimental.** Lean changes visual presentation (opaque VFO with square corners, no wallpaper/FFT fill, throttled meters), so it needs maintainer **visual-design sign-off** per the autonomy boundaries in `CLAUDE.md`. Opening as draft for that review and for discussion of scope.

## What Lean does

| Effect | Implementation |
|---|---|
| Opaque single-layer panadapter | `SpectrumWidget::setLeanMode` — skip wallpaper texture (GPU + software paths), drop translucent FFT fill, cap spectrum/waterfall repaint to ~30 Hz |
| Opaque VFO panel | `VfoWidget::setOpaqueMode` — swap `#VfoWidgetRoot` stylesheet to an opaque background so it composites as a cacheable opaque layer |
| WAVE scope off | `WaveApplet::setActive` — hide the scope **and** drop its sample feed |
| Meter repaint throttle | `MeterSmoother::shouldRepaint` — shared ~12 Hz gate; meters keep integrating ballistics at full rate but batch their repaints (wired into the comp/gate/de-ess GR meters + S-meter needle) |

## Profiling result (honest)

Matched same-session A/B (identical band, meters open, idle):

| | Total CPU | Main thread | Pooled |
|---|---:|---:|---:|
| Lean OFF | 1.62 cores | 606 ms/s | 890 ms/s |
| **Lean ON** | 1.65 cores | **477 ms/s (−21%)** | 1043 ms/s |

- **Reliable win: main-thread CPU −21%** → better input/drag responsiveness (the felt improvement; input runs on the main thread).
- **Total CPU is flat.** The dominant *pooled* cost is the **QRhiWidget compositing tax** — Qt uploading the full-window software backing store to a GPU texture every composite to blend with the GPU panadapter. It's pixel-area-bound (much worse on 5K) and **dominated by incoming data rate**, so the widget-level Lean changes don't reach it.

⚠️ Idle pooled CPU swings hugely with band activity (same UI state measured 0 → ~1040 ms/s across quiet vs busy bands), so only same-session pairs are trustworthy. Full trace tables, what didn't work (native-layering the applet panel — no effect under Qt 6.11/macOS), and the remaining structural fix directions (dirty-region-only backing-store upload, or moving meters/VFO onto the GPU) are in #3283.

## Scope / review notes

- Purely additive + reversible; no behavior change when Lean is off (default).
- Visual/UX decisions (square VFO corners in lean, hidden wallpaper/fill, the new button, throttled meters) are flagged for maintainer review.
- Open question for maintainers: is Lean worth shipping for the responsiveness win alone, or should it be trimmed to just the main-thread items (scope-off + opaque VFO) and the pool tackled structurally instead?

Relates to #3283.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
