### PR TITLE
Add Qt accessibility enforcement tooling for src/gui/ (AGENTS.md + CI check)

### DIFF
--- a/.github/workflows/a11y-check.yml
+++ b/.github/workflows/a11y-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  pull-requests: write   # needed to label and comment; read-only on fork PRs (steps gracefully skip)
+
 jobs:
   a11y-check:
     name: Qt Accessibility Static Analysis
@@ -20,7 +23,6 @@ jobs:
           python-version: "3.12"
 
       - name: Get changed src/gui/ files
-        id: changed
         run: |
           git diff --name-only origin/${{ github.base_ref }}...HEAD \
             | grep -E '^src/gui/.*\.(cpp|h)$' \
@@ -29,10 +31,56 @@ jobs:
           cat /tmp/changed_gui_files.txt || echo "(none)"
 
       - name: Run accessibility check
+        id: a11y
         run: |
           FILES=$(cat /tmp/changed_gui_files.txt | tr '\n' ' ')
           if [ -z "$FILES" ]; then
             echo "No src/gui/ files changed -- skipping."
+            echo "findings=0" >> $GITHUB_OUTPUT
             exit 0
           fi
-          python tools/check_a11y.py $FILES
+          python tools/check_a11y.py $FILES | tee /tmp/a11y_output.txt
+          COUNT=$(grep -c "^::warning" /tmp/a11y_output.txt || echo "0")
+          echo "findings=$COUNT" >> $GITHUB_OUTPUT
+
+      # Label the PR so AetherClaude picks it up for automated remediation.
+      # continue-on-error: true because fork PRs have a read-only GITHUB_TOKEN
+      # and the label step would otherwise fail -- findings are still annotated
+      # inline on the diff regardless.
+      - name: Label PR for AetherClaude auto-remediation
+        if: steps.a11y.outputs.findings != '0'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --add-label "aetherclaude-eligible" \
+            --repo ${{ github.repository }}
+
+      - name: Comment with accessibility summary
+        if: steps.a11y.outputs.findings != '0'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SUMMARY=$(grep -E "(Files scanned|Files with findings|Total findings)" \
+            /tmp/a11y_output.txt | sed 's/^/> /' || echo "")
+          cat > /tmp/a11y_comment.md << COMMENTEOF
+          ## Accessibility check findings
+
+          This PR touches \`src/gui/\` files with **${{ steps.a11y.outputs.findings }}** accessibility issue(s).
+          Full details appear as inline annotations on the diff above.
+
+          ${SUMMARY}
+
+          This PR has been labeled \`aetherclaude-eligible\` — AetherClaude will generate
+          remediation patches (mechanical fixes: missing \`setAccessibleName\` calls,
+          \`QAccessibleValueChangeEvent\` in value-change methods, focus policy on
+          interactive widgets). Structural fixes (keyboard navigation, \`QAccessibleInterface\`
+          subclasses) are flagged for human review in #3288.
+
+          *Findings are warnings only — the build is not blocked.*
+          COMMENTEOF
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body-file /tmp/a11y_comment.md

--- a/.github/workflows/a11y-check.yml
+++ b/.github/workflows/a11y-check.yml
@@ -1,0 +1,38 @@
+name: Accessibility Check
+
+on:
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  a11y-check:
+    name: Qt Accessibility Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Get changed src/gui/ files
+        id: changed
+        run: |
+          git diff --name-only origin/${{ github.base_ref }}...HEAD \
+            | grep -E '^src/gui/.*\.(cpp|h)$' \
+            > /tmp/changed_gui_files.txt || true
+          echo "Changed src/gui files:"
+          cat /tmp/changed_gui_files.txt || echo "(none)"
+
+      - name: Run accessibility check
+        run: |
+          FILES=$(cat /tmp/changed_gui_files.txt | tr '\n' ' ')
+          if [ -z "$FILES" ]; then
+            echo "No src/gui/ files changed -- skipping."
+            exit 0
+          fi
+          python tools/check_a11y.py $FILES

--- a/.github/workflows/a11y-check.yml
+++ b/.github/workflows/a11y-check.yml
@@ -73,7 +73,7 @@ jobs:
 
           ${SUMMARY}
 
-          See [\`docs/a11y.md\`](../blob/main/docs/a11y.md) for the canonical
+          See [\`docs/a11y.md\`](docs/a11y.md) for the canonical
           Qt patterns (\`setAccessibleName\`, \`QAccessibleValueChangeEvent\`,
           \`QAccessibleInterface\` subclasses, etc.). Structural remediation
           (keyboard navigation, custom \`QAccessibleInterface\` subclasses)

--- a/.github/workflows/a11y-check.yml
+++ b/.github/workflows/a11y-check.yml
@@ -5,7 +5,7 @@ on:
     branches: ["**"]
 
 permissions:
-  pull-requests: write   # needed to label and comment; read-only on fork PRs (steps gracefully skip)
+  pull-requests: write   # needed to post the summary comment; read-only on fork PRs (step gracefully skips)
 
 jobs:
   a11y-check:
@@ -43,20 +43,20 @@ jobs:
           COUNT=$(grep -c "^::warning" /tmp/a11y_output.txt || echo "0")
           echo "findings=$COUNT" >> $GITHUB_OUTPUT
 
-      # Label the PR so AetherClaude picks it up for automated remediation.
+      # Post a summary comment so the finding count is visible at the PR top
+      # level (the per-line annotations appear on the diff itself).
       # continue-on-error: true because fork PRs have a read-only GITHUB_TOKEN
-      # and the label step would otherwise fail -- findings are still annotated
-      # inline on the diff regardless.
-      - name: Label PR for AetherClaude auto-remediation
-        if: steps.a11y.outputs.findings != '0'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
-            --add-label "aetherclaude-eligible" \
-            --repo ${{ github.repository }}
-
+      # and the comment step would otherwise fail -- the inline annotations
+      # appear on the diff regardless.
+      #
+      # NOTE: this workflow intentionally does NOT auto-apply the
+      # aetherclaude-eligible label. Per AGENTS.md and CONSTITUTION.md
+      # (Principle X), that label is the issue-level claim mechanism that
+      # gates AetherClaude implementation work — applying it to PRs would
+      # repurpose the label off-spec and trigger AetherClaude to write
+      # remediation patches on community contributors' open PRs without
+      # their consent. Accessibility remediation should be picked up via a
+      # follow-up issue (e.g. #3288), not by side-effect of opening a PR.
       - name: Comment with accessibility summary
         if: steps.a11y.outputs.findings != '0'
         continue-on-error: true
@@ -73,11 +73,11 @@ jobs:
 
           ${SUMMARY}
 
-          This PR has been labeled \`aetherclaude-eligible\` — AetherClaude will generate
-          remediation patches (mechanical fixes: missing \`setAccessibleName\` calls,
-          \`QAccessibleValueChangeEvent\` in value-change methods, focus policy on
-          interactive widgets). Structural fixes (keyboard navigation, \`QAccessibleInterface\`
-          subclasses) are flagged for human review in #3288.
+          See [\`docs/a11y.md\`](../blob/main/docs/a11y.md) for the canonical
+          Qt patterns (\`setAccessibleName\`, \`QAccessibleValueChangeEvent\`,
+          \`QAccessibleInterface\` subclasses, etc.). Structural remediation
+          (keyboard navigation, custom \`QAccessibleInterface\` subclasses)
+          is tracked in #3288.
 
           *Findings are warnings only — the build is not blocked.*
           COMMENTEOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,3 +389,81 @@ Filter all status and VITA-49 packets by `client_handle` — three layers:
 
 Early status messages arrive WITHOUT `client_handle`. Create SliceModels for
 all initially, remove other clients' when handle arrives.
+
+---
+
+## Accessibility Enforcement — `src/gui/` Rules
+
+Whenever you touch any file under `src/gui/`, apply the following checks to
+every widget you create or modify. These fixes are **invisible to sighted
+users** — no visual changes, no layout changes, no new UI elements.
+
+### Required on every QWidget subclass constructor
+
+1. **Accessible name** — every interactive or informational widget must have:
+   ```cpp
+   widget->setAccessibleName(tr("Human readable name"));
+   ```
+   Use a concise noun phrase (e.g. `"Frequency display"`, `"RF Gain"`).
+
+2. **Accessible description** — add context for screen reader users:
+   ```cpp
+   widget->setAccessibleDescription(tr("What this control does or displays"));
+   ```
+
+3. **Tab focus** — every interactive widget (buttons, sliders, spin boxes,
+   custom controls that respond to mouse/keyboard) must have:
+   ```cpp
+   widget->setFocusPolicy(Qt::TabFocus);
+   ```
+   If the widget already uses `Qt::StrongFocus` or `Qt::WheelFocus`, leave it.
+   Decorative-only widgets: leave `Qt::NoFocus`.
+
+### Live value updates
+
+Any method that changes a displayed value — `setLevel(`, `setValue(`,
+`updateFreqLabel(`, `setText(` on a label that shows live data — must fire a
+`QAccessibleValueChangeEvent` **after** the state change:
+```cpp
+QAccessibleValueChangeEvent ev(this, newValue);
+QAccessible::updateAccessibility(&ev);
+```
+For text-only updates where there is no numeric value, use:
+```cpp
+QAccessibleEvent ev(this, QAccessible::NameChanged);
+QAccessible::updateAccessibility(&ev);
+```
+
+### Custom-painted widgets (`paintEvent` override)
+
+If a class overrides `paintEvent` and draws its own content (spectrum,
+waterfall, meter, scope), Qt cannot introspect the rendered output. You must
+either:
+- Provide a `QAccessibleInterface` subclass (named `FooAccessible`) that
+  returns meaningful `text(QAccessible::Name)` and `text(QAccessible::Value)`
+  strings, and register it via `QAccessible::installFactory`; **or**
+- Annotate the PR with `// TODO(a11y): QAccessibleInterface needed` and open
+  a follow-up issue tagged `GUI`.
+
+Do **not** use `setAttribute(Qt::WA_AcceptTouchEvents, false)` to hide a
+widget from the accessibility tree — that affects touch input, not AT
+exposure. The correct way to exclude a purely decorative widget from the
+a11y tree is to return `QAccessible::NoRole` from the
+`QAccessibleInterface::role()` override, or leave `Qt::NoFocus` set and
+omit `setAccessibleName` so AT tools skip it naturally.
+
+### Interactive `QLabel` anti-pattern
+
+Any `QLabel` that has a `mousePressEvent` override or appears inside an
+`eventFilter` handling click events is acting as a button without accessible
+semantics. Replace it with `QPushButton` (styled flat if needed), or at
+minimum add a keyboard activation path (`setFocusPolicy(Qt::TabFocus)` plus
+a `keyPressEvent` handler for `Qt::Key_Return`/`Qt::Key_Space`) and return
+`QAccessible::Button` from a `QAccessibleInterface::role()` override.
+
+### CI enforcement
+
+`tools/check_a11y.py` runs on every PR via `.github/workflows/a11y-check.yml`
+and emits inline GitHub annotations for the patterns above. It exits 0
+(warning-only) and never blocks a build — findings are informational so
+sighted contributors are not gated on accessibility compliance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,78 +392,16 @@ all initially, remove other clients' when handle arrives.
 
 ---
 
-## Accessibility Enforcement — `src/gui/` Rules
+## Accessibility — `src/gui/` Rules
 
-Whenever you touch any file under `src/gui/`, apply the following checks to
-every widget you create or modify. These fixes are **invisible to sighted
-users** — no visual changes, no layout changes, no new UI elements.
+Touching any file under `src/gui/`? Read [`docs/a11y.md`](docs/a11y.md)
+**before** adding or modifying a widget. Canonical Qt patterns:
+`setAccessibleName` / `setAccessibleDescription`, `QAccessibleValueChangeEvent`
+on every value-change method, `QAccessibleInterface` subclass for any
+`paintEvent` override, and the interactive-`QLabel` anti-pattern (replace
+with `QPushButton` or add keyboard activation).
 
-### Required on every QWidget subclass constructor
-
-1. **Accessible name** — every interactive or informational widget must have:
-   ```cpp
-   widget->setAccessibleName(tr("Human readable name"));
-   ```
-   Use a concise noun phrase (e.g. `"Frequency display"`, `"RF Gain"`).
-
-2. **Accessible description** — add context for screen reader users:
-   ```cpp
-   widget->setAccessibleDescription(tr("What this control does or displays"));
-   ```
-
-3. **Tab focus** — every interactive widget (buttons, sliders, spin boxes,
-   custom controls that respond to mouse/keyboard) must have:
-   ```cpp
-   widget->setFocusPolicy(Qt::TabFocus);
-   ```
-   If the widget already uses `Qt::StrongFocus` or `Qt::WheelFocus`, leave it.
-   Decorative-only widgets: leave `Qt::NoFocus`.
-
-### Live value updates
-
-Any method that changes a displayed value — `setLevel(`, `setValue(`,
-`updateFreqLabel(`, `setText(` on a label that shows live data — must fire a
-`QAccessibleValueChangeEvent` **after** the state change:
-```cpp
-QAccessibleValueChangeEvent ev(this, newValue);
-QAccessible::updateAccessibility(&ev);
-```
-For text-only updates where there is no numeric value, use:
-```cpp
-QAccessibleEvent ev(this, QAccessible::NameChanged);
-QAccessible::updateAccessibility(&ev);
-```
-
-### Custom-painted widgets (`paintEvent` override)
-
-If a class overrides `paintEvent` and draws its own content (spectrum,
-waterfall, meter, scope), Qt cannot introspect the rendered output. You must
-either:
-- Provide a `QAccessibleInterface` subclass (named `FooAccessible`) that
-  returns meaningful `text(QAccessible::Name)` and `text(QAccessible::Value)`
-  strings, and register it via `QAccessible::installFactory`; **or**
-- Annotate the PR with `// TODO(a11y): QAccessibleInterface needed` and open
-  a follow-up issue tagged `GUI`.
-
-Do **not** use `setAttribute(Qt::WA_AcceptTouchEvents, false)` to hide a
-widget from the accessibility tree — that affects touch input, not AT
-exposure. The correct way to exclude a purely decorative widget from the
-a11y tree is to return `QAccessible::NoRole` from the
-`QAccessibleInterface::role()` override, or leave `Qt::NoFocus` set and
-omit `setAccessibleName` so AT tools skip it naturally.
-
-### Interactive `QLabel` anti-pattern
-
-Any `QLabel` that has a `mousePressEvent` override or appears inside an
-`eventFilter` handling click events is acting as a button without accessible
-semantics. Replace it with `QPushButton` (styled flat if needed), or at
-minimum add a keyboard activation path (`setFocusPolicy(Qt::TabFocus)` plus
-a `keyPressEvent` handler for `Qt::Key_Return`/`Qt::Key_Space`) and return
-`QAccessible::Button` from a `QAccessibleInterface::role()` override.
-
-### CI enforcement
-
-`tools/check_a11y.py` runs on every PR via `.github/workflows/a11y-check.yml`
-and emits inline GitHub annotations for the patterns above. It exits 0
-(warning-only) and never blocks a build — findings are informational so
-sighted contributors are not gated on accessibility compliance.
+CI enforcement: [`tools/check_a11y.py`](tools/check_a11y.py) runs on every
+PR via [`.github/workflows/a11y-check.yml`](.github/workflows/a11y-check.yml)
+and emits inline diff annotations for the patterns above. Warning-only
+(`exit 0`); never blocks a build.

--- a/docs/a11y.md
+++ b/docs/a11y.md
@@ -1,12 +1,15 @@
-# Accessibility Enforcement — `src/gui/` Rules
+# Accessibility — `src/gui/` Patterns
 
 > **For AI agents and human contributors touching any file under `src/gui/`.**
 > Linked from [`AGENTS.md`](../AGENTS.md) so every AI tool that reads this
-> repo's canonical agent guide picks these rules up automatically.
+> repo's canonical agent guide picks these patterns up automatically.
 
-Whenever you touch any file under `src/gui/`, apply the following checks to
-every widget you create or modify. These fixes are **invisible to sighted
-users** — no visual changes, no layout changes, no new UI elements.
+These are *patterns*, not gates. CI lints to `::warning` annotations only —
+it never blocks a build. Adopt what fits the widget you're touching;
+silence the lint when it doesn't fit (see [Suppressing the lint](#suppressing-the-lint)
+below). The goal is to make AetherSDR usable for screen-reader users without
+making it bureaucratic for sighted contributors. Patterns here are invisible
+to sighted users — no visual changes, no layout changes, no new UI elements.
 
 ## Background
 
@@ -29,32 +32,39 @@ navigate to the S-meter and hear "S-Meter," but they would never hear
 
 Phase 2 fixes that, and the rules below are how we keep it fixed.
 
-## Required on every `QWidget` subclass constructor
+## Naming interactive and informational widgets
 
-1. **Accessible name** — every interactive or informational widget must have:
+1. **Accessible name** — interactive controls (buttons, sliders, spin boxes,
+   custom focusable widgets) and informational displays (meters, readouts,
+   status badges) read better with:
    ```cpp
    widget->setAccessibleName(tr("Human readable name"));
    ```
    Use a concise noun phrase (e.g. `"Frequency display"`, `"RF Gain"`).
+   Layout-only containers (`QFrame` wrappers, decorative spacers, static
+   "Hz" suffix labels next to a spin box) don't need one — the name on
+   the parent control covers the group.
 
-2. **Accessible description** — add context for screen reader users:
+2. **Accessible description** — *optional*. Add only when the name alone
+   doesn't convey purpose. A redundant description ("RF Gain. The RF gain
+   control.") becomes noise on a screen reader.
    ```cpp
-   widget->setAccessibleDescription(tr("What this control does or displays"));
+   widget->setAccessibleDescription(tr("0 to 100 dB attenuation before AGC"));
    ```
 
-3. **Tab focus** — every interactive widget (buttons, sliders, spin boxes,
-   custom controls that respond to mouse/keyboard) must have:
+3. **Tab focus** — every keyboard-operable widget needs to be reachable:
    ```cpp
    widget->setFocusPolicy(Qt::TabFocus);
    ```
-   If the widget already uses `Qt::StrongFocus` or `Qt::WheelFocus`, leave it.
+   Leave `Qt::StrongFocus` or `Qt::WheelFocus` alone if already set.
    Decorative-only widgets: leave `Qt::NoFocus`.
 
 ## Live value updates
 
-Any method that changes a displayed value — `setLevel(`, `setValue(`,
-`updateFreqLabel(`, `setText(` on a label that shows live data — must fire a
-`QAccessibleValueChangeEvent` **after** the state change:
+Methods that change a displayed value — `setLevel`, `updateFreqLabel`,
+`updateReadout`, custom `updateValue` — should fire a
+`QAccessibleValueChangeEvent` **after** the state change so VoiceOver /
+NVDA / Orca announce the new value:
 ```cpp
 QAccessibleValueChangeEvent ev(this, newValue);
 QAccessible::updateAccessibility(&ev);
@@ -65,16 +75,41 @@ QAccessibleEvent ev(this, QAccessible::NameChanged);
 QAccessible::updateAccessibility(&ev);
 ```
 
+**Throttle high-rate updaters.** A continuous tuning sweep can drive a
+frequency-label `setText` at 30+ Hz; firing an announcement on every
+interim frame turns a screen reader into a stutter machine and bothers
+sighted users on the same machine because the SR overlay paints over the
+UI. Announce *settled* values — match the cadence to what a sighted user
+would read as "the value stopped changing." Patterns that work:
+
+- Use the same `MeterSmoother` settled-frame gate already in use for
+  lean-mode paint throttling (see [`MeterSmoother.h`](../src/gui/MeterSmoother.h)).
+- For knob/dial-driven changes, fire the announcement on
+  `QAbstractSlider::sliderReleased` rather than `valueChanged`.
+- For free-form updates, debounce to ~10 Hz with a `QTimer::singleShot`.
+
+A noisy `updateAccessibility` is worse than no `updateAccessibility` —
+prefer slightly stale to spammy. The linter's per-method suppression
+comment (below) is the right answer if a value-change method genuinely
+needs to fire silently (e.g., it updates internal cache only).
+
 ## Custom-painted widgets (`paintEvent` override)
 
-If a class overrides `paintEvent` and draws its own content (spectrum,
-waterfall, meter, scope), Qt cannot introspect the rendered output. You must
-either:
+If a class overrides `paintEvent` and draws **data-bearing** content
+(spectrum, waterfall, meter, scope, gauge), Qt cannot introspect the
+rendered output. Options:
+
 - Provide a `QAccessibleInterface` subclass (named `FooAccessible`) that
   returns meaningful `text(QAccessible::Name)` and `text(QAccessible::Value)`
   strings, and register it via `QAccessible::installFactory`; **or**
-- Annotate the PR with `// TODO(a11y): QAccessibleInterface needed` and open
-  a follow-up issue tagged `GUI`.
+- Annotate the file with `// TODO(a11y): QAccessibleInterface needed` and
+  open a follow-up issue (link it from the comment).
+
+The linter only flags `paintEvent` overrides on widgets that **also expose
+value-change setters**. A purely decorative `paintEvent` (custom badge
+backdrop, gradient frame, hover overlay) has no data to announce — those
+widgets don't trip the lint, and if one slips through, mark it with
+`// a11y-check: skip-file`.
 
 Do **not** use `setAttribute(Qt::WA_AcceptTouchEvents, false)` to hide a
 widget from the accessibility tree — that affects touch input, not AT
@@ -91,6 +126,35 @@ semantics. Replace it with `QPushButton` (styled flat if needed), or at
 minimum add a keyboard activation path (`setFocusPolicy(Qt::TabFocus)` plus
 a `keyPressEvent` handler for `Qt::Key_Return`/`Qt::Key_Space`) and return
 `QAccessible::Button` from a `QAccessibleInterface::role()` override.
+
+## Suppressing the lint
+
+The CI lint is a nudge, not a gate. If a finding doesn't fit your widget,
+silence it.
+
+**Whole-file opt-out** — for genuinely decorative widgets (custom button
+chrome, gradient backdrops, badge widgets that don't carry data), add
+anywhere in the file:
+```cpp
+// a11y-check: skip-file
+```
+The linter short-circuits the file and emits zero findings against it.
+
+**Per-method opt-out** — for a single value-change method that legitimately
+shouldn't announce (internal-only cache update, computed value that the
+public-facing setter already announces), add on the method line or anywhere
+in its body:
+```cpp
+// a11y-check: skip
+void FooWidget::setInternalCache(float v) {
+    m_cache = v;  // no AT update -- the announcing setter is setLevel()
+}
+```
+
+Suppression comments are first-class: there is no review pressure to remove
+them, and AetherClaude / Claude Code / Copilot will leave them alone unless
+explicitly asked to revisit them. The point of the lint is to surface
+genuine misses, not to coerce ceremony onto widgets that don't need it.
 
 ## CI enforcement
 

--- a/docs/a11y.md
+++ b/docs/a11y.md
@@ -30,7 +30,7 @@ navigate to the S-meter and hear "S-Meter," but they would never hear
 "S9" or "S9+20." They could find the VFO frequency display and hear
 "VFO A," but tuning the dial was completely silent.
 
-Phase 2 fixes that, and the rules below are how we keep it fixed.
+Phase 2 fixes that, and the patterns below are how we keep it fixed.
 
 ## Naming interactive and informational widgets
 

--- a/docs/a11y.md
+++ b/docs/a11y.md
@@ -1,0 +1,101 @@
+# Accessibility Enforcement — `src/gui/` Rules
+
+> **For AI agents and human contributors touching any file under `src/gui/`.**
+> Linked from [`AGENTS.md`](../AGENTS.md) so every AI tool that reads this
+> repo's canonical agent guide picks these rules up automatically.
+
+Whenever you touch any file under `src/gui/`, apply the following checks to
+every widget you create or modify. These fixes are **invisible to sighted
+users** — no visual changes, no layout changes, no new UI elements.
+
+## Background
+
+Phase 1 ([#899](https://github.com/aethersdr/AetherSDR/pull/899), merged
+2026-04-07) brought every interactive control up to the point where
+VoiceOver can find it and read a name — `setAccessibleName` /
+`setAccessibleDescription` on instantiated widgets.
+
+Phase 2 (tracked in
+[#3288](https://github.com/aethersdr/AetherSDR/issues/3288),
+scaffolding in
+[#3289](https://github.com/aethersdr/AetherSDR/pull/3289)) closes the
+single highest-impact remaining gap: `QAccessible::updateAccessibility`
+was called **zero times** in the entire codebase. That means even widgets
+with accessible names were static labels to VoiceOver — no values,
+states, or live changes were ever announced. A screen-reader user could
+navigate to the S-meter and hear "S-Meter," but they would never hear
+"S9" or "S9+20." They could find the VFO frequency display and hear
+"VFO A," but tuning the dial was completely silent.
+
+Phase 2 fixes that, and the rules below are how we keep it fixed.
+
+## Required on every `QWidget` subclass constructor
+
+1. **Accessible name** — every interactive or informational widget must have:
+   ```cpp
+   widget->setAccessibleName(tr("Human readable name"));
+   ```
+   Use a concise noun phrase (e.g. `"Frequency display"`, `"RF Gain"`).
+
+2. **Accessible description** — add context for screen reader users:
+   ```cpp
+   widget->setAccessibleDescription(tr("What this control does or displays"));
+   ```
+
+3. **Tab focus** — every interactive widget (buttons, sliders, spin boxes,
+   custom controls that respond to mouse/keyboard) must have:
+   ```cpp
+   widget->setFocusPolicy(Qt::TabFocus);
+   ```
+   If the widget already uses `Qt::StrongFocus` or `Qt::WheelFocus`, leave it.
+   Decorative-only widgets: leave `Qt::NoFocus`.
+
+## Live value updates
+
+Any method that changes a displayed value — `setLevel(`, `setValue(`,
+`updateFreqLabel(`, `setText(` on a label that shows live data — must fire a
+`QAccessibleValueChangeEvent` **after** the state change:
+```cpp
+QAccessibleValueChangeEvent ev(this, newValue);
+QAccessible::updateAccessibility(&ev);
+```
+For text-only updates where there is no numeric value, use:
+```cpp
+QAccessibleEvent ev(this, QAccessible::NameChanged);
+QAccessible::updateAccessibility(&ev);
+```
+
+## Custom-painted widgets (`paintEvent` override)
+
+If a class overrides `paintEvent` and draws its own content (spectrum,
+waterfall, meter, scope), Qt cannot introspect the rendered output. You must
+either:
+- Provide a `QAccessibleInterface` subclass (named `FooAccessible`) that
+  returns meaningful `text(QAccessible::Name)` and `text(QAccessible::Value)`
+  strings, and register it via `QAccessible::installFactory`; **or**
+- Annotate the PR with `// TODO(a11y): QAccessibleInterface needed` and open
+  a follow-up issue tagged `GUI`.
+
+Do **not** use `setAttribute(Qt::WA_AcceptTouchEvents, false)` to hide a
+widget from the accessibility tree — that affects touch input, not AT
+exposure. The correct way to exclude a purely decorative widget from the
+a11y tree is to return `QAccessible::NoRole` from the
+`QAccessibleInterface::role()` override, or leave `Qt::NoFocus` set and
+omit `setAccessibleName` so AT tools skip it naturally.
+
+## Interactive `QLabel` anti-pattern
+
+Any `QLabel` that has a `mousePressEvent` override or appears inside an
+`eventFilter` handling click events is acting as a button without accessible
+semantics. Replace it with `QPushButton` (styled flat if needed), or at
+minimum add a keyboard activation path (`setFocusPolicy(Qt::TabFocus)` plus
+a `keyPressEvent` handler for `Qt::Key_Return`/`Qt::Key_Space`) and return
+`QAccessible::Button` from a `QAccessibleInterface::role()` override.
+
+## CI enforcement
+
+[`tools/check_a11y.py`](../tools/check_a11y.py) runs on every PR via
+[`.github/workflows/a11y-check.yml`](../.github/workflows/a11y-check.yml)
+and emits inline GitHub annotations for the patterns above. It exits 0
+(warning-only) and never blocks a build — findings are informational so
+sighted contributors are not gated on accessibility compliance.

--- a/tools/check_a11y.py
+++ b/tools/check_a11y.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+AetherSDR accessibility static checker.
+
+Scans changed (or all) src/gui/ C++/header files for common accessibility
+omissions and emits GitHub Actions annotation-format warnings so findings
+appear inline on PRs.
+
+Exit 0 always -- accessibility issues are informational, not build-blocking.
+Sighted developers should see the findings without being blocked by them.
+
+Usage:
+    python tools/check_a11y.py [file1.cpp file2.h ...]
+    git diff --name-only origin/main...HEAD | python tools/check_a11y.py
+    python tools/check_a11y.py          # scans all of src/gui/
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Annotation helpers
+# ---------------------------------------------------------------------------
+
+def warn(filepath: str, line: int, title: str, message: str) -> None:
+    """Emit a GitHub Actions warning annotation."""
+    clean = filepath.lstrip("./")
+    print(f"::warning file={clean},line={line},title={title}::{message}")
+
+
+# ---------------------------------------------------------------------------
+# File collection
+# ---------------------------------------------------------------------------
+
+def collect_files(args: list) -> list:
+    candidates = []
+
+    if args:
+        candidates = args
+    elif not sys.stdin.isatty():
+        candidates = [line.strip() for line in sys.stdin if line.strip()]
+
+    if candidates:
+        return [
+            Path(p) for p in candidates
+            if re.search(r"src[/\\]gui[/\\]", p)
+            and p.endswith((".cpp", ".h"))
+            and Path(p).is_file()
+        ]
+
+    # Full scan fallback
+    gui_root = Path("src/gui")
+    if not gui_root.is_dir():
+        gui_root = Path(__file__).parent.parent / "src" / "gui"
+    if not gui_root.is_dir():
+        print("::warning title=a11y-check::Could not locate src/gui/ -- skipping scan")
+        return []
+
+    return list(gui_root.rglob("*.cpp")) + list(gui_root.rglob("*.h"))
+
+
+# ---------------------------------------------------------------------------
+# Per-file checks
+# ---------------------------------------------------------------------------
+
+def check_file(path: Path) -> list:
+    """Run all accessibility checks on a single file.
+    Returns list of (line_number, title, message) tuples.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return [(1, "a11y-check-error", f"Could not read file: {exc}")]
+
+    lines = text.splitlines()
+    findings = []
+    findings += check_interactive_labels(lines)
+    findings += check_value_change_methods(lines)
+    findings += check_widget_constructor_names(lines)
+    findings += check_custom_painted_widgets(lines, path)
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check 1 -- Interactive QLabel
+# ---------------------------------------------------------------------------
+
+def check_interactive_labels(lines: list) -> list:
+    findings = []
+    label_vars = set()
+    qlabel_decl = re.compile(r"\bQLabel\s*\*?\s*(\w+)\s*(?:=|;|\()")
+    for ln, line in enumerate(lines, 1):
+        m = qlabel_decl.search(line)
+        if m:
+            label_vars.add(m.group(1))
+
+    subclass_qlabel = re.compile(r"class\s+\w+\s*:\s*public\s+QLabel")
+    mouse_press = re.compile(r"\bmousePressEvent\b")
+    event_filter = re.compile(r"\beventFilter\b")
+    full_text = "\n".join(lines)
+    is_qlabel_subclass = bool(subclass_qlabel.search(full_text))
+
+    for ln, line in enumerate(lines, 1):
+        if is_qlabel_subclass and mouse_press.search(line):
+            findings.append((
+                ln,
+                "interactive-label-no-role",
+                "QLabel subclass overrides mousePressEvent -- replace with QPushButton "
+                "or add keyboard activation + QAccessibleInterface returning Button role.",
+            ))
+
+        if event_filter.search(line):
+            for var in label_vars:
+                start = max(0, ln - 6)
+                end = min(len(lines), ln + 5)
+                context = "\n".join(lines[start:end])
+                if re.search(rf"\b{re.escape(var)}\b", context):
+                    findings.append((
+                        ln,
+                        "interactive-label-no-role",
+                        f"QLabel '{var}' appears in eventFilter -- replace with "
+                        "QPushButton or add keyboard activation path.",
+                    ))
+                    break
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check 2 -- Value-change methods missing live-region update
+# ---------------------------------------------------------------------------
+
+def check_value_change_methods(lines: list) -> list:
+    findings = []
+    value_method_re = re.compile(
+        r"\b(setLevel|setValue|updateFreqLabel|setText)\s*\("
+    )
+    update_a11y_re = re.compile(r"QAccessible::updateAccessibility")
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = value_method_re.search(line)
+        if m:
+            method_start = i + 1
+            method_name = m.group(1)
+
+            brace_depth = 0
+            body_lines = []
+            j = i
+            found_open = False
+            while j < len(lines):
+                for ch in lines[j]:
+                    if ch == "{":
+                        brace_depth += 1
+                        found_open = True
+                    elif ch == "}":
+                        brace_depth -= 1
+                if found_open:
+                    body_lines.append(lines[j])
+                    if brace_depth == 0:
+                        break
+                j += 1
+
+            if found_open and body_lines:
+                body_text = "\n".join(body_lines)
+                if not update_a11y_re.search(body_text):
+                    findings.append((
+                        method_start,
+                        "value-method-missing-a11y-update",
+                        f"{method_name}() changes a displayed value but never calls "
+                        "QAccessible::updateAccessibility -- screen readers won't "
+                        "announce the change. Add: "
+                        "QAccessibleValueChangeEvent ev(this, newValue); "
+                        "QAccessible::updateAccessibility(&ev);",
+                    ))
+            i = j + 1
+            continue
+        i += 1
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check 3 -- Widget constructor with no setAccessibleName calls
+# ---------------------------------------------------------------------------
+
+def check_widget_constructor_names(lines: list) -> list:
+    findings = []
+    ctor_re = re.compile(r"^(\w+)::\1\s*\(")
+    qwidget_subclass_re = re.compile(
+        r"class\s+(\w+)\s*:[^{]*\bQ(?:Widget|Frame|Dialog|MainWindow|GroupBox|"
+        r"ScrollArea|StackedWidget|TabWidget|Splitter|DockWidget)\b"
+    )
+    new_qwidget_re = re.compile(r"\bnew\s+Q[A-Z]\w+\s*\(")
+    accessible_name_re = re.compile(r"\bsetAccessibleName\s*\(")
+    full_text = "\n".join(lines)
+
+    widget_classes = set()
+    for m in qwidget_subclass_re.finditer(full_text):
+        widget_classes.add(m.group(1))
+
+    if not widget_classes:
+        return findings
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = ctor_re.search(line)
+        if m:
+            class_name = m.group(1)
+            if class_name not in widget_classes:
+                i += 1
+                continue
+
+            ctor_start = i + 1
+            brace_depth = 0
+            body_lines = []
+            j = i
+            found_open = False
+            while j < len(lines):
+                for ch in lines[j]:
+                    if ch == "{":
+                        brace_depth += 1
+                        found_open = True
+                    elif ch == "}":
+                        brace_depth -= 1
+                if found_open:
+                    body_lines.append(lines[j])
+                    if brace_depth == 0:
+                        break
+                j += 1
+
+            if found_open and body_lines:
+                body_text = "\n".join(body_lines)
+                creates_widgets = bool(new_qwidget_re.search(body_text))
+                has_names = bool(accessible_name_re.search(body_text))
+
+                if creates_widgets and not has_names:
+                    findings.append((
+                        ctor_start,
+                        "constructor-missing-accessible-names",
+                        f"{class_name}::{class_name}() creates child widgets but "
+                        "calls setAccessibleName() zero times -- AT users cannot "
+                        "identify controls. Add setAccessibleName(tr(\"...\")) for "
+                        "each interactive or informational child widget.",
+                    ))
+            i = j + 1
+            continue
+        i += 1
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check 4 -- Custom-painted widget without QAccessibleInterface companion
+# ---------------------------------------------------------------------------
+
+def check_custom_painted_widgets(lines: list, path: Path) -> list:
+    findings = []
+    paint_event_re = re.compile(r"\bpaintEvent\s*\(")
+    accessible_iface_re = re.compile(r"QAccessibleInterface")
+    qwidget_subclass_re = re.compile(
+        r"class\s+(\w+)\s*:[^{]*\bQ(?:Widget|Frame|OpenGLWidget|GLWidget)\b"
+    )
+    full_text = "\n".join(lines)
+
+    if not paint_event_re.search(full_text):
+        return findings
+
+    widget_classes = [m.group(1) for m in qwidget_subclass_re.finditer(full_text)]
+    if not widget_classes:
+        return findings
+
+    has_iface_here = bool(accessible_iface_re.search(full_text))
+    stem = path.stem
+    companion_patterns = [
+        path.parent / f"{stem}Accessible.h",
+        path.parent / f"{stem}Accessible.cpp",
+        path.parent / f"{stem}_accessible.h",
+        path.parent / f"{stem}_accessible.cpp",
+    ]
+    has_companion = any(p.is_file() for p in companion_patterns)
+
+    if has_iface_here or has_companion:
+        return findings
+
+    for ln, line in enumerate(lines, 1):
+        if paint_event_re.search(line):
+            for cls in widget_classes:
+                findings.append((
+                    ln,
+                    "custom-painted-widget-needs-accessible-interface",
+                    f"{cls} overrides paintEvent but has no QAccessibleInterface "
+                    "subclass in this file or a companion *Accessible.h -- "
+                    "screen readers cannot read custom-drawn content. "
+                    "Implement QAccessibleInterface returning meaningful "
+                    "text(Name)/text(Value) strings, or add "
+                    "// TODO(a11y): QAccessibleInterface needed and open a "
+                    "follow-up issue tagged 'GUI'.",
+                ))
+            break
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    files = collect_files(sys.argv[1:])
+
+    if not files:
+        print("a11y-check: no src/gui/ files to check.")
+        sys.exit(0)
+
+    total_findings = 0
+    file_count = 0
+
+    for path in sorted(files):
+        findings = check_file(path)
+        if findings:
+            file_count += 1
+            for (line, title, message) in findings:
+                warn(str(path), line, title, message)
+                total_findings += 1
+
+    print()
+    print("=== AetherSDR accessibility check summary ===")
+    print(f"Files scanned      : {len(files)}")
+    print(f"Files with findings: {file_count}")
+    print(f"Total findings     : {total_findings}")
+    if total_findings == 0:
+        print("No accessibility issues found.")
+    else:
+        print(
+            "These are warnings only -- the build is not blocked. "
+            "Findings appear inline on the PR diff."
+        )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_a11y.py
+++ b/tools/check_a11y.py
@@ -74,6 +74,14 @@ def check_file(path: Path) -> list:
     except OSError as exc:
         return [(1, "a11y-check-error", f"Could not read file: {exc}")]
 
+    # File-level suppression. A widget that is genuinely decorative (custom
+    # badges, gradient backgrounds, layout-only frames) can opt out of the
+    # whole scan by adding `// a11y-check: skip-file` anywhere in the file.
+    # Keeps the lint accommodating — contributors aren't forced to either
+    # add ceremony or argue with the linter on legitimate decoration.
+    if re.search(r"//\s*a11y-check\s*:\s*skip-file", text):
+        return []
+
     lines = text.splitlines()
     findings = []
     findings += check_interactive_labels(lines)
@@ -133,11 +141,34 @@ def check_interactive_labels(lines: list) -> list:
 # ---------------------------------------------------------------------------
 
 def check_value_change_methods(lines: list) -> list:
+    """Flag out-of-line method DEFINITIONS that change a displayed value but
+    never fire QAccessible::updateAccessibility.
+
+    The earlier version of this check matched any call site of the listed
+    methods, so a one-time `m_button->setText("Cancel")` inside a widget
+    constructor body fired the warning. With ~5 button-label setText() calls
+    per dialog, the empirical noise floor was ~840 findings across src/gui/
+    — enough that the signal (S-meter, VFO, level readouts) drowned in
+    button labels.
+
+    Scoping to `ClassName::method(` removes call sites entirely:
+        FooDialog::FooDialog() { m_btn->setText("Cancel"); }   <- skipped
+        void SMeterWidget::setLevel(float dbm) { ... }          <- checked
+
+    setText is intentionally NOT on the watched list — it is used on every
+    QLabel/QPushButton constructor and the call/definition split alone is
+    not enough to keep it quiet. Custom widgets that override setText for
+    live values can adopt one of the domain-specific names below
+    (updateReadout, updateLabel, etc.) which makes the intent explicit at
+    the call site too.
+    """
     findings = []
     value_method_re = re.compile(
-        r"\b(setLevel|setValue|updateFreqLabel|setText)\s*\("
+        r"\b\w+::(setLevel|setDbm|setFrequency|updateFreqLabel|"
+        r"updateReadout|updateLabel|updateLevel|updateValue)\s*\("
     )
     update_a11y_re = re.compile(r"QAccessible::updateAccessibility")
+    suppress_re = re.compile(r"//\s*a11y-check\s*:\s*skip")
 
     i = 0
     while i < len(lines):
@@ -166,7 +197,12 @@ def check_value_change_methods(lines: list) -> list:
 
             if found_open and body_lines:
                 body_text = "\n".join(body_lines)
-                if not update_a11y_re.search(body_text):
+                # Per-method suppression: `// a11y-check: skip` on the
+                # method-definition line or anywhere in its body.
+                suppressed = bool(
+                    suppress_re.search(line) or suppress_re.search(body_text)
+                )
+                if not suppressed and not update_a11y_re.search(body_text):
                     findings.append((
                         method_start,
                         "value-method-missing-a11y-update",
@@ -174,7 +210,11 @@ def check_value_change_methods(lines: list) -> list:
                         "QAccessible::updateAccessibility -- screen readers won't "
                         "announce the change. Add: "
                         "QAccessibleValueChangeEvent ev(this, newValue); "
-                        "QAccessible::updateAccessibility(&ev);",
+                        "QAccessible::updateAccessibility(&ev); "
+                        "(For high-rate updaters, throttle to settled values "
+                        "to avoid screen-reader spam — see docs/a11y.md. "
+                        "To suppress this warning, add '// a11y-check: skip' "
+                        "on the method line.)",
                     ))
             i = j + 1
             continue
@@ -259,15 +299,43 @@ def check_widget_constructor_names(lines: list) -> list:
 # ---------------------------------------------------------------------------
 
 def check_custom_painted_widgets(lines: list, path: Path) -> list:
+    """Flag custom-painted widgets that ALSO display data (have a value-change
+    method).
+
+    Earlier this check fired on any paintEvent override — but src/gui/ has
+    many small widgets that paint their own gradient/badge/border purely for
+    visual decoration (no data to announce). Annotating each of those with a
+    QAccessibleInterface subclass would be ceremony with no a11y payoff.
+
+    Adding the "has at least one data-change setter" precondition narrows
+    the scan to widgets that genuinely have screen-reader-relevant content
+    (S-meter, spectrum, waterfall, scope, gauge). A decorative widget that
+    happens to add `setText` doesn't trip this because setText is not on
+    the watched list (see check_value_change_methods()).
+
+    File-level escape hatch: `// a11y-check: skip-file` short-circuits
+    this check (and the others) entirely.
+    """
     findings = []
     paint_event_re = re.compile(r"\bpaintEvent\s*\(")
     accessible_iface_re = re.compile(r"QAccessibleInterface")
     qwidget_subclass_re = re.compile(
         r"class\s+(\w+)\s*:[^{]*\bQ(?:Widget|Frame|OpenGLWidget|GLWidget)\b"
     )
+    # Same watched-name set as check_value_change_methods. A custom-painted
+    # widget is "data-carrying" if it defines one of these or has a public
+    # setter declaration matching one.
+    data_setter_re = re.compile(
+        r"\b(setLevel|setDbm|setFrequency|updateFreqLabel|"
+        r"updateReadout|updateLabel|updateLevel|updateValue)\s*\("
+    )
     full_text = "\n".join(lines)
 
     if not paint_event_re.search(full_text):
+        return findings
+
+    if not data_setter_re.search(full_text):
+        # Decorative widget — no data setters, no payoff in a QAccessibleInterface.
         return findings
 
     widget_classes = [m.group(1) for m in qwidget_subclass_re.finditer(full_text)]
@@ -293,13 +361,16 @@ def check_custom_painted_widgets(lines: list, path: Path) -> list:
                 findings.append((
                     ln,
                     "custom-painted-widget-needs-accessible-interface",
-                    f"{cls} overrides paintEvent but has no QAccessibleInterface "
-                    "subclass in this file or a companion *Accessible.h -- "
-                    "screen readers cannot read custom-drawn content. "
-                    "Implement QAccessibleInterface returning meaningful "
+                    f"{cls} overrides paintEvent AND exposes data setters, "
+                    "but has no QAccessibleInterface subclass in this file "
+                    "or a companion *Accessible.h -- screen readers cannot "
+                    "read its custom-drawn content. Implement "
+                    "QAccessibleInterface returning meaningful "
                     "text(Name)/text(Value) strings, or add "
                     "// TODO(a11y): QAccessibleInterface needed and open a "
-                    "follow-up issue tagged 'GUI'.",
+                    "follow-up issue tagged 'GUI'. "
+                    "(Purely decorative paintEvent? Add "
+                    "'// a11y-check: skip-file' anywhere in the file.)",
                 ))
             break
 


### PR DESCRIPTION
Companion to #3288 (Phase 2 accessibility audit).

This PR makes accessibility **automatic and invisible** — AI agents and human contributors working on `src/gui/` get guidance and inline CI annotations without any visual changes to the app.

## What's in this PR

### `AGENTS.md` — new Accessibility Enforcement section

All six AI tools that read this repo's canonical agent guide (`CLAUDE.md`, `copilot-instructions.md`, `GEMINI.md`, `CONVENTIONS.md`, etc. all point here) will now see the accessibility rules whenever they touch `src/gui/`. The section covers:

- `setAccessibleName` / `setAccessibleDescription` in every widget constructor
- `QAccessibleValueChangeEvent` in value-change methods (`setLevel`, `setValue`, `updateFreqLabel`, `setText`)
- `setFocusPolicy(Qt::TabFocus)` for interactive widgets
- `QAccessibleInterface` subclass requirement for `paintEvent` overrides
- The interactive `QLabel` anti-pattern (with correct fix path)
- Common misconception corrected: `Qt::WA_AcceptTouchEvents` does **not** hide a widget from AT tools

### `tools/check_a11y.py` — static accessibility linter

Pure Python, no Qt toolchain required. Four checks, each operating on file text:

1. `QLabel` used as an interactive element (has `mousePressEvent` or appears in `eventFilter`) — flag as missing accessible role
2. Value-change method defined without `QAccessible::updateAccessibility` in its body
3. `QWidget` subclass constructor that creates child widgets but calls `setAccessibleName` zero times
4. `paintEvent` override without a `QAccessibleInterface` subclass or `*Accessible.h` companion

Output format is GitHub Actions `::warning file=...,line=...,title=...::` so findings appear as **inline PR annotations** on the diff. Exit code is always 0 — accessibility is informational, never a build-blocker.

### `.github/workflows/a11y-check.yml`

Runs on every PR. Diffs against the base branch, filters to changed `src/gui/` files, passes them to `check_a11y.py`. Completes in seconds (Python only — no compile step).

## What this does NOT do

- No changes to any file in `src/` — the quick-win `setAccessibleName` additions and structural fixes are tracked in #3288 and will follow as separate PRs
- No new dependencies
- No visual changes to the application

## Verification

```sh
# Should emit warnings for SMeterWidget::setLevel() and SpectrumWidget paint override
python3 tools/check_a11y.py src/gui/SMeterWidget.cpp src/gui/SpectrumWidget.cpp
```

— AI5OS (@w9fyi)