### PR TITLE
feat(hid): initial Icom RC-28 encoder support

### DIFF
--- a/src/core/HidDeviceParser.cpp
+++ b/src/core/HidDeviceParser.cpp
@@ -38,33 +38,27 @@ std::unique_ptr<HidDeviceParser> HidDeviceParser::create(uint16_t vid, uint16_t 
 }
 
 // ── Icom RC-28 ──────────────────────────────────────────────────────────────
-// 32-byte reports. hidapi prepends the 1-byte report ID on Windows/Linux so
-// hid_read(buf, 33) returns 33; on macOS it strips the ID and returns 32.
-// We request 33 bytes (reportSize) and use len to tell the two apart — no
-// value-based heuristic that could collide with data bytes.
-// Data layout (0-indexed, after stripping report ID where present):
-//   [0] seq counter: 0x01 = first report of knob step, 0x02 = second
-//   [1] unused (0x00)
-//   [2] direction: 0x01 = CW (+1), 0x02 = CCW (-1), 0x00 = no rotation
-//   [3] unused (0x00)
-//   [4] button state enum: 0x07 = idle, 0x05 = F1, 0x03 = F2, 0x06 = TX bar
-// Each knob detent fires two reports (seq 0x01 then 0x02); we emit only on
-// seq 0x01 to produce exactly one tuning step per detent.
+// 32-byte reports, no report ID prefix on any platform (hidraw returns 32 bytes).
+// Verified layout (cross-referenced against FlexRC-28 open-source driver):
+//   [0] = 0x01 constant — guard byte, discard report if != 0x01
+//   [1] = detent counter (increments each click; device sends burst of identical
+//         reports per detent — deduplicate on this field)
+//   [2] = 0x00 (unused)
+//   [3] = direction: 0x01 = CW, 0x02 = CCW
+//   [4] = 0x00 (unused)
+//   [5] = button state bitmask (active-low): 0x07 = all idle,
+//         bit0=TX/PTT, bit1=F1, bit2=F2
 
 HidEvent IcomRC28Parser::parse(const uint8_t* buf, size_t len)
 {
-    if (len < 5) return {};
+    if (len < 6) return {};
+    if (buf[0] != 0x01) return {};
 
-    // Windows/Linux: hidapi includes the report ID → hid_read returns 33 bytes.
-    // macOS: hidapi strips the report ID → hid_read returns 32 bytes.
-    const uint8_t* data = (len >= 33) ? buf + 1 : buf;
+    const uint8_t counter = buf[1];
+    const uint8_t dir     = buf[3];
+    const uint8_t btns    = buf[5];
 
-    const uint8_t seq  = data[0];
-    const uint8_t dir  = data[2];
-    const uint8_t btns = data[4];
-
-    // Button events use absolute state, not bitmask.
-    // RC-28 has 3 buttons: F1 (1), F2 (2), TX bar (3).
+    // Button events (active-low bitmask → same enum values as before).
     if (btns != m_prevButtonState) {
         const uint8_t prev = m_prevButtonState;
         m_prevButtonState  = btns;
@@ -80,9 +74,9 @@ HidEvent IcomRC28Parser::parse(const uint8_t* buf, size_t len)
         }
     }
 
-    // Rotation: only emit on first report of each pair (seq == 0x01) to
-    // produce exactly one step per detent (the device sends two reports per click).
-    if (seq == 0x01 && dir != 0x00) {
+    // Rotation: deduplicate on counter to emit exactly one step per detent.
+    if ((dir == 0x01 || dir == 0x02) && counter != m_prevCounter) {
+        m_prevCounter = counter;
         return {HidEvent::Rotate, (dir == 0x01) ? 1 : -1, 0, 0};
     }
 

--- a/src/core/HidDeviceParser.h
+++ b/src/core/HidDeviceParser.h
@@ -35,15 +35,17 @@ public:
 };
 
 // Icom RC-28 (VID 0x0C26, PID 0x001E)
-// 32-byte reports. hidapi prepends the 1-byte report ID on Windows/Linux (hid_read
-// returns 33); strips it on macOS (hid_read returns 32). Use len to discriminate.
-// Layout (after report ID): [0]=seq, [2]=direction, [4]=button state enum.
+// 32-byte reports, no report ID prefix (hidraw returns exactly 32 bytes).
+// Actual layout (verified from hardware): [0]=0x01 constant, [1]=detent counter,
+// [2]=0x00, [3]=direction (0x01=CW, 0x02=CCW), [4]=0x00, [5]=button state enum.
+// The device sends multiple identical reports per detent; deduplicate on counter.
 class IcomRC28Parser : public HidDeviceParser {
 public:
     HidEvent parse(const uint8_t* buf, size_t len) override;
-    size_t reportSize() const override { return 33; }
+    size_t reportSize() const override { return 32; }
 private:
     uint8_t m_prevButtonState{0x07};  // 0x07 = all released (idle)
+    uint8_t m_prevCounter{0xff};
 };
 
 // Griffin PowerMate (VID 0x077D, PID 0x0410)

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -96,6 +96,9 @@ void HidEncoderManager::close()
     m_pollTimer->stop();
     m_hotplugTimer->stop();
     if (m_device) {
+        // Extinguish RC-28 LEDs on clean close. hid_write may return EIO if
+        // the device was surprise-disconnected; that is safe to ignore here.
+        setRC28Leds(RC28_LEDS_OFF);
         hid_close(m_device);
         m_device = nullptr;
     }
@@ -146,6 +149,17 @@ void HidEncoderManager::hotplugCheck()
     if (m_openVid && m_openPid) {
         if (open(m_openVid, m_openPid))
             m_hotplugTimer->stop();
+        return;
+    }
+    // No device was ever opened (initial startup without device connected):
+    // scan all supported devices so a late-connect RC-28/PowerMate/etc. is found.
+    const auto* devices = HidDeviceParser::supportedDevices();
+    int count = HidDeviceParser::supportedDeviceCount();
+    for (int i = 0; i < count; ++i) {
+        if (open(devices[i].vid, devices[i].pid)) {
+            m_hotplugTimer->stop();
+            return;
+        }
     }
 }
 
@@ -253,6 +267,17 @@ void HidEncoderManager::setTouchscreenImage(const QByteArray& jpegData,
         offset     += chunkLen;
         pageNumber++;
     }
+}
+
+void HidEncoderManager::setRC28Leds(uint8_t ledByte)
+{
+    if (!m_device || !isRC28Compatible()) return;
+    // Output report: report ID 0x00, command 0x01, LED byte, rest zeros.
+    uint8_t report[33] = {};
+    report[0] = 0x00;
+    report[1] = 0x01;
+    report[2] = ledByte;
+    hid_write(m_device, report, sizeof(report));
 }
 
 void HidEncoderManager::loadSettings()

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -149,17 +149,6 @@ void HidEncoderManager::hotplugCheck()
     if (m_openVid && m_openPid) {
         if (open(m_openVid, m_openPid))
             m_hotplugTimer->stop();
-        return;
-    }
-    // No device was ever opened (initial startup without device connected):
-    // scan all supported devices so a late-connect RC-28/PowerMate/etc. is found.
-    const auto* devices = HidDeviceParser::supportedDevices();
-    int count = HidDeviceParser::supportedDeviceCount();
-    for (int i = 0; i < count; ++i) {
-        if (open(devices[i].vid, devices[i].pid)) {
-            m_hotplugTimer->stop();
-            return;
-        }
     }
 }
 
@@ -272,7 +261,10 @@ void HidEncoderManager::setTouchscreenImage(const QByteArray& jpegData,
 void HidEncoderManager::setRC28Leds(uint8_t ledByte)
 {
     if (!m_device || !isRC28Compatible()) return;
-    // Output report: report ID 0x00, command 0x01, LED byte, rest zeros.
+    // Output report: [0x00=reportID, 0x01=cmd, ledByte, zeros...], 33 bytes total.
+    // Format verified against FlexRC-28 Node.js driver (_sendLED) and
+    // wfview src/usbcontroller.cpp (RC28 featureLEDControl path).
+    // Active-low: bit0=TX, bit1=F1, bit2=F2, bit3=LINK; 0x0F = all off.
     uint8_t report[33] = {};
     report[0] = 0x00;
     report[1] = 0x01;

--- a/src/core/HidEncoderManager.h
+++ b/src/core/HidEncoderManager.h
@@ -42,11 +42,28 @@ public:
         return m_openVid.load(std::memory_order_relaxed) == 0x0FD9
             && m_openPid.load(std::memory_order_relaxed) == 0x0084;
     }
+    // True for the real Icom RC-28 and the AetherPad emulator — both run the
+    // same wire protocol including the LED output report.
+    bool isRC28Compatible() const {
+        const uint16_t vid = m_openVid.load(std::memory_order_relaxed);
+        const uint16_t pid = m_openPid.load(std::memory_order_relaxed);
+        return (vid == 0x0C26 && pid == 0x001E)   // Icom RC-28
+            || (vid == 0x2341 && pid == 0x0266);   // AetherPad emulator
+    }
 
     void setInvertDirection(bool invert) { m_invertDirection = invert; }
 
+    // Active-low LED byte constants for setRC28Leds().
+    static constexpr uint8_t RC28_LEDS_OFF      = 0x0F;  // all LEDs off
+    static constexpr uint8_t RC28_LEDS_LINK     = 0x07;  // LINK on, rest off
+    static constexpr uint8_t RC28_LEDS_TX_LINK  = 0x06;  // TX + LINK on
+
 public slots:
     void loadSettings();
+    // Set the LED state on an RC-28-compatible device. ledByte is active-low:
+    //   bit0=TX/PTT, bit1=F1, bit2=F2, bit3=LINK. Clear bit = LED on.
+    // No-op if the connected device is not RC-28-compatible.
+    void setRC28Leds(uint8_t ledByte);
     // Write 120x120 JPEG images to StreamDeck+ LCD keys. Pass all 8 images at once
     // so one queued call updates the whole display without flooding the event queue.
     // No-op if device is not a StreamDeck+.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3322,6 +3322,16 @@ MainWindow::MainWindow(QWidget* parent)
         settings.save();
         if (m_flexControlDialog)
             m_flexControlDialog->setStepSize(step);
+        {
+            QString stepStr;
+            if (step >= 1000000)
+                stepStr = QString("%1 MHz").arg(step / 1000000.0, 0, 'f', step % 1000000 ? 1 : 0);
+            else if (step >= 1000)
+                stepStr = QString("%1 kHz").arg(step / 1000.0, 0, 'f', step % 1000 ? 1 : 0);
+            else
+                stepStr = QString("%1 Hz").arg(step);
+            statusBar()->showMessage(QString("Step: %1").arg(stepStr), 2000);
+        }
         // Invalidate persistent encoder accumulators so the next tick rebases
         // and re-snaps to the new step grid. Without this, an in-flight target
         // computed against the previous step size carries an off-grid residual
@@ -3942,14 +3952,18 @@ MainWindow::MainWindow(QWidget* parent)
 
     connect(m_hidEncoder, &HidEncoderManager::buttonPressed,
             this, [this](int button, int action) {
-        // Only fire on press; release is suppressed.
-        if (action != 0) return;
-
         QString actionName;
         if (button >= 1 && button <= 8) {
-            // LCD keys — settings key HidKeyAction{0-7}
+            // RC-28 buttons 1-3 (F1, F2, TX bar) get sensible defaults when
+            // the user hasn't explicitly configured them.
+            QString dflt = QStringLiteral("None");
+            if (m_hidEncoder->isRC28Compatible()) {
+                if      (button == 1) dflt = QStringLiteral("StepUp");
+                else if (button == 2) dflt = QStringLiteral("StepDown");
+                else if (button == 3) dflt = QStringLiteral("PTT");
+            }
             actionName = AppSettings::instance()
-                .value(QString("HidKeyAction%1").arg(button - 1), QStringLiteral("None"))
+                .value(QString("HidKeyAction%1").arg(button - 1), dflt)
                 .toString();
         } else if (button >= 9 && button <= 12) {
             // Encoder press buttons — settings key HidEncoderPushAction{0-3}
@@ -3963,6 +3977,17 @@ MainWindow::MainWindow(QWidget* parent)
         }
 
         if (actionName == "None" || actionName.isEmpty()) return;
+
+        // PTT: TX bar held down = transmit on, released = transmit off.
+        // This is the only action that needs both press (action==0) and release (action==1).
+        if (actionName == QStringLiteral("PTT")) {
+            if (m_radioModel.isConnected())
+                m_radioModel.setTransmit(action == 0);
+            return;
+        }
+
+        // All other actions fire only on press.
+        if (action != 0) return;
 
         if (actionName == "StepCycle" || actionName == "StepUp") {
             if (auto* rx = m_appletPanel->rxApplet()) rx->cycleStepUp();
@@ -4068,7 +4093,32 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_hidEncoder, &HidEncoderManager::connectionChanged,
             this, [this](bool connected, const QString& name) {
         qDebug() << "HID encoder:" << (connected ? "connected" : "disconnected") << name;
-        if (connected) refreshStreamDeckLabels();
+        if (connected) {
+            refreshStreamDeckLabels();
+            // Sync RC-28 LEDs to current radio state on connect (handles hot-plug).
+            // LINK stays on while connected; TX mirrors current MOX state.
+            if (m_hidEncoder->isRC28Compatible()) {
+                const uint8_t ledByte = m_radioModel.transmitModel().isMox()
+                    ? HidEncoderManager::RC28_LEDS_TX_LINK
+                    : HidEncoderManager::RC28_LEDS_LINK;
+                QMetaObject::invokeMethod(m_hidEncoder, [this, ledByte] {
+                    m_hidEncoder->setRC28Leds(ledByte);
+                });
+            }
+        }
+    });
+
+    // RC-28 TX LED: mirror MOX state to the device's red TRANSMIT LED.
+    connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
+            this, [this](bool mox) {
+        if (m_hidEncoder && m_hidEncoder->isRC28Compatible()) {
+            const uint8_t ledByte = mox
+                ? HidEncoderManager::RC28_LEDS_TX_LINK
+                : HidEncoderManager::RC28_LEDS_LINK;
+            QMetaObject::invokeMethod(m_hidEncoder, [this, ledByte] {
+                m_hidEncoder->setRC28Leds(ledByte);
+            });
+        }
     });
 
     // StreamDeck native integration removed — use TCI StreamController plugin instead.
@@ -4220,7 +4270,7 @@ MainWindow::MainWindow(QWidget* parent)
         auto& s = AppSettings::instance();
         if (!s.contains("HidEncoderEnabled")) {
             const bool hadAutodetect =
-                s.value("HidEncoderAutoDetect", "False").toString() == "True";
+                s.value("HidEncoderAutoDetect", "True").toString() == "True";
             s.setValue("HidEncoderEnabled", hadAutodetect ? "True" : "False");
         }
     }
@@ -6726,6 +6776,7 @@ void MainWindow::handleVirtualFlexControlWheel(const QString& actionId, int step
     applyFlexControlWheelAction(actionId, steps);
 }
 
+#ifdef HAVE_HIDAPI
 // static
 QString MainWindow::hidEncoderDefaultAction(int encoderIndex)
 {
@@ -6749,6 +6800,7 @@ QString MainWindow::hidEncoderDefaultPushAction(int encoderIndex)
     default: return QStringLiteral("None");
     }
 }
+#endif
 
 #ifdef HAVE_HIDAPI
 // Render the full 800x100 touchscreen strip for the StreamDeck+.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4270,7 +4270,7 @@ MainWindow::MainWindow(QWidget* parent)
         auto& s = AppSettings::instance();
         if (!s.contains("HidEncoderEnabled")) {
             const bool hadAutodetect =
-                s.value("HidEncoderAutoDetect", "True").toString() == "True";
+                s.value("HidEncoderAutoDetect", "False").toString() == "True";
             s.setValue("HidEncoderEnabled", hadAutodetect ? "True" : "False");
         }
     }
@@ -6776,7 +6776,6 @@ void MainWindow::handleVirtualFlexControlWheel(const QString& actionId, int step
     applyFlexControlWheelAction(actionId, steps);
 }
 
-#ifdef HAVE_HIDAPI
 // static
 QString MainWindow::hidEncoderDefaultAction(int encoderIndex)
 {
@@ -6800,7 +6799,6 @@ QString MainWindow::hidEncoderDefaultPushAction(int encoderIndex)
     default: return QStringLiteral("None");
     }
 }
-#endif
 
 #ifdef HAVE_HIDAPI
 // Render the full 800x100 touchscreen strip for the StreamDeck+.


### PR DESCRIPTION
Closes #616

## Summary

- **Fixes silent no-op**: `IcomRC28Parser` had wrong byte offsets — direction was being read from `buf[2]` (always `0x00`) instead of `buf[3]`, and buttons from `buf[4]` instead of `buf[5]`. All encoder events were silently discarded. Layout verified against hardware captures and cross-referenced with the open-source FlexRC-28 reference driver.
- **Counter-based deduplication**: the RC-28 sends bursts of identical reports per detent; dedup on `buf[1]` emits exactly one step per physical click.
- **LED control**: LINK LED lights when AetherSDR opens the device and extinguishes on close/disconnect. TX LED mirrors MOX state. Both sync correctly on hot-plug. Output report format (`[0x00, 0x01, ledByte, zeros…]`, 33 bytes, active-low bitmask) verified against the FlexRC-28 Node.js driver (`_sendLED`) and wfview `src/usbcontroller.cpp` (RC28 `featureLEDControl` path).
- **Button defaults for RC-28**: F1=StepUp, F2=StepDown, TX bar=PTT (hold-to-talk — fires `setTransmit` on both press and release).
- **Step-change toast**: status bar briefly shows the new step size when F1/F2 is pressed.
- **`isRC28Compatible()`**: covers both Icom VID/PID (`0x0C26:0x001E`) and the AetherPad emulator (`0x2341:0x0266`), which runs the same wire protocol.

> **Note:** The `hotplugCheck()` scan fix and `#ifdef HAVE_HIDAPI` guard fix have been extracted to PR #3298 per reviewer request — both were bugs in `main` independent of this work.

> **Migration default (open question):** The one-time migration fallback for `HidEncoderAutoDetect` has been left at `"False"` (opt-in) — matching the pre-PR baseline. This means clean installs will not have `HidEncoderEnabled` set automatically. Whether RC-28 support should be opt-in or opt-out for new users is a product decision left open for the merge review.

## Limitations / follow-up work

- **Button customization UI is not included in this PR.** F1, F2, and TX bar actions can be overridden via the `HidKeyAction{0-2}` settings keys, but there is no UI for this yet. A follow-up PR will add a configuration panel.
- **Direct USB connection only.** This implementation supports the RC-28 connected via USB directly to the computer running AetherSDR. Connecting the RC-28 directly to the FlexRadio hardware is not addressed by this change.

## Test plan

- [ ] RC-28 LINK LED lights on app launch; goes out when AetherSDR quits
- [ ] Rotating encoder CW/CCW moves VFO frequency
- [ ] F1 steps tuning rate up; status bar shows new step size
- [ ] F2 steps tuning rate down
- [ ] Holding TX bar activates MOX and lights TX LED; releasing drops both
- [ ] Hot-plug: unplug and re-plug RC-28 while app is running — LINK LED returns and encoder/buttons resume without restart

## Platform testing

| Platform | Result |
|---|---|
| macOS Tahoe (arm64) | ✅ Tested |
| Debian 13 (arm64) | ✅ Tested |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)