### PR TITLE
fix(hid): hotplugCheck full scan + HAVE_HIDAPI guard fixes

### DIFF
--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -146,6 +146,17 @@ void HidEncoderManager::hotplugCheck()
     if (m_openVid && m_openPid) {
         if (open(m_openVid, m_openPid))
             m_hotplugTimer->stop();
+        return;
+    }
+    // No VID/PID recorded: device was never opened (started without encoder
+    // attached). Scan all supported devices so a late-connect is picked up.
+    const auto* devices = HidDeviceParser::supportedDevices();
+    int count = HidDeviceParser::supportedDeviceCount();
+    for (int i = 0; i < count; ++i) {
+        if (open(devices[i].vid, devices[i].pid)) {
+            m_hotplugTimer->stop();
+            return;
+        }
     }
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6726,6 +6726,7 @@ void MainWindow::handleVirtualFlexControlWheel(const QString& actionId, int step
     applyFlexControlWheelAction(actionId, steps);
 }
 
+#ifdef HAVE_HIDAPI
 // static
 QString MainWindow::hidEncoderDefaultAction(int encoderIndex)
 {
@@ -6749,6 +6750,7 @@ QString MainWindow::hidEncoderDefaultPushAction(int encoderIndex)
     default: return QStringLiteral("None");
     }
 }
+#endif
 
 #ifdef HAVE_HIDAPI
 // Render the full 800x100 touchscreen strip for the StreamDeck+.


### PR DESCRIPTION
hotplugCheck() never found a device connected after startup when no device was present at loadSettings() time — m_openVid/m_openPid stay zero, so the early-return branch was never taken and the scan loop was missing entirely.  Add the missing `return` after the reconnect attempt and a full VID/PID scan for the cold-start case.

hidEncoderDefaultAction() / hidEncoderDefaultPushAction() were defined outside #ifdef HAVE_HIDAPI despite being declared inside it; clang flagged the mismatch on non-HIDAPI builds.

<!--
Thanks for contributing to AetherSDR!

Before opening the PR, please:
- Read AGENTS.md if this is your first contribution (or your AI tool's
  first contribution) — it has the conventions every contributor agent
  is expected to follow.
- Read CONTRIBUTING.md for the commit-signing and branch-protection
  rules.
- If you're an AI agent: claim the originating issue first by assigning
  yourself via `gh issue edit <N> --add-assignee <handle>`. Double-
  assigning alongside the @aethersdr-agent triage bot is fine.
-->

## Summary

<!-- One-paragraph description of what changes and why.  If this fixes
an issue, lead with "Fixes #N" or "Closes #N". -->

## Constitution principle honored

<!-- Cite the principle by Roman numeral when relevant.  E.g.
"Principle V — new feature uses nested-JSON persistence."
"Principle II — MeterSmoother used for the new meter widget."
See CONSTITUTION.md for the full list. -->

## Test plan

- [ ] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug

## Checklist

- [ ] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [ ] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [ ] All meter UI uses `MeterSmoother` (Principle II)
- [ ] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable