### PR TITLE
fix: prefer discrete GPU on Windows hybrid laptops Principle XI.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,7 @@ static int aetherTolerantX11ErrorHandler(AetherX11Display*, AetherX11ErrorEvent*
 #endif  // __linux__
 
 #ifdef Q_OS_WIN
+#include <windows.h>
 // Request discrete GPU on hybrid laptops (NVIDIA Optimus / AMD PowerXpress).
 // Intel iGPU D3D11 driver corrupts its stack during QRhiWidget reparenting (#1921).
 extern "C" __declspec(dllexport) DWORD NvOptimusEnablement             = 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,13 @@ static int aetherTolerantX11ErrorHandler(AetherX11Display*, AetherX11ErrorEvent*
 }
 #endif  // __linux__
 
+#ifdef Q_OS_WIN
+// Request discrete GPU on hybrid laptops (NVIDIA Optimus / AMD PowerXpress).
+// Intel iGPU D3D11 driver corrupts its stack during QRhiWidget reparenting (#1921).
+extern "C" __declspec(dllexport) DWORD NvOptimusEnablement             = 1;
+extern "C" __declspec(dllexport) int   AmdPowerXpressRequestHighPerformance = 1;
+#endif // Q_OS_WIN
+
 static void messageHandler(QtMsgType type, const QMessageLogContext& ctx, const QString& msg)
 {
     AetherSDR::LogManager::instance().enqueueMessage(type, ctx, msg);


### PR DESCRIPTION
## Summary

Fixes #1921 — `STATUS_STACK_BUFFER_OVERRUN` crash on every pop-out attempt on Windows hybrid-GPU laptops (Intel iGPU + discrete NVIDIA/AMD GPU).

### Root cause

Intel's D3D11 user-mode driver (`igd10um64xe.dll`) corrupts its own stack during `UpdateSubresource`, called from `QRhi::endOffscreenFrame` during the swap-chain teardown/recreate cycle that `SpectrumWidget::resizeEvent` triggers on widget reparenting (`floatPanadapter` / `dockPanadapter`). This is an Intel driver bug, but AetherSDR's pop-out flow reliably triggers it when the process is running on the Intel GPU.

### Fix

Add the standard NVIDIA Optimus / AMD PowerXpress DLL exports to `src/main.cpp`. The vendor driver loaders inspect the PE export table at process startup and bind the discrete GPU instead of the Intel iGPU when these symbols are present with value `1`.

```cpp
#ifdef Q_OS_WIN
// Request discrete GPU on hybrid laptops (NVIDIA Optimus / AMD PowerXpress).
// Intel iGPU D3D11 driver corrupts its stack during QRhiWidget reparenting (#1921).
extern "C" __declspec(dllexport) DWORD NvOptimusEnablement             = 1;
extern "C" __declspec(dllexport) int   AmdPowerXpressRequestHighPerformance = 1;
#endif // Q_OS_WIN
```

**Scope:** the exports are no-ops on Intel-only hardware (no dGPU present) and are compiled out on macOS and Linux. This is the same mechanism used by Qt Quick, Chromium, and every major game engine for this problem.

**Reporter-verified:** reporter confirmed AetherSDR launches on the RTX 4090 and the pop-out crash does not reproduce with this change applied (see issue #1921).

### What this does NOT fix

Intel-only laptops (no discrete GPU) are unaffected. The double `resetGpuResources()` call pattern in `PanadapterStack::floatPanadapter()` and `dockPanadapter()` (immediate + deferred via `refreshAfterReparent()`) is the structural trigger on the Windows D3D11 path — that is a separate follow-up issue requiring cross-backend testing.

## Files changed

- `src/main.cpp` — +7 lines (one `#ifdef Q_OS_WIN` block + surrounding blank lines)

## Test plan

- [ ] Linux build clean (no new warnings — `#ifdef Q_OS_WIN` compiles out)
- [ ] `check-windows` CI green (MSVC build, no `C4190` or related warnings)
- [ ] Windows: `dumpbin /EXPORTS AetherSDR.exe | findstr -i "Optimus\|HighPerf"` shows both exports
- [ ] Windows hybrid-GPU: AetherSDR starts on discrete GPU; pop-out does not crash

🤖 Implemented with [Claude Code](https://claude.com/claude-code)