### PR TITLE
fix(rade): align filter passband with FreeDV waveform convention

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -15978,9 +15978,9 @@ void MainWindow::activateRADE(int sliceId)
     const int     prevFilterHigh = s->filterHigh();
     s->setMode(mode);
     if (mode == "DIGL")
-        s->setFilterWidth(-3500, 0);
+        s->setFilterWidth(-2250, -750);
     else
-        s->setFilterWidth(0, 3500);
+        s->setFilterWidth(750, 2250);
 
     // Remember which slice and its previous mute state
     m_radeSliceId = sliceId;


### PR DESCRIPTION
## Summary

- RADE `activateRADE()` previously set the slice filter to the full 0–3500 Hz range, which does not match the RADE OFDM modem's actual audio passband
- Changed to **750–2250 Hz** (DIGU) / **−2250 to −750 Hz** (DIGL) — centre 1500 Hz, width 1500 Hz — matching the freedv-waveform Docker reference implementation
- Tighter passband improves interference immunity by excluding spectral regions the modem never uses (DC offset, carrier leakage, 2250–3500 Hz)

## Test plan

- [ ] Enable RADE on a USB band (20m) — confirm filter display shows 750–2250 Hz
- [ ] Enable RADE on an LSB band (40m) — confirm filter display shows −2250 to −750 Hz
- [ ] Disable RADE — confirm previous filter is restored correctly
- [ ] Verify RADE audio encodes/decodes end-to-end with the new passband

Fixes #3300. Principle I.

🤖 Generated with [Claude Code](https://claude.com/claude-code)