### PR TITLE
accessibility: phase 2 — widget names, live announcements, VFO tabs, keyboard nav

### DIFF
--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -41,6 +41,7 @@ AmpApplet::AmpApplet(QWidget* parent)
     // Slow release: bar rises quickly on RF bursts but decays over ~800 ms
     // so brief transmissions remain visible — matches S-meter peak-hold feel.
     m_fwdGauge->setBallistics({0.030f, 0.800f});
+    m_fwdGauge->setAccessibleName(tr("Forward power"));
     auto* pwrRow = new QHBoxLayout;
     pwrRow->setSpacing(4);
     pwrRow->addWidget(m_pwrLabel);
@@ -53,6 +54,7 @@ AmpApplet::AmpApplet(QWidget* parent)
     m_swrGauge = new HGauge(1.0f, 3.0f, 2.5f, "", "",
         {{1.0f, "1"}, {1.5f, "1.5"}, {2.0f, "2"}, {2.5f, "2.5"}, {3.0f, "3"}},
         this, 2.0f);
+    m_swrGauge->setAccessibleName(tr("SWR"));
     auto* swrRow = new QHBoxLayout;
     swrRow->setSpacing(4);
     swrRow->addWidget(m_swrLabel);
@@ -65,6 +67,7 @@ AmpApplet::AmpApplet(QWidget* parent)
     m_idGauge = new HGauge(0.0f, 70.0f, 60.0f, "", "",
         {{0, "0"}, {10, "10"}, {20, "20"}, {30, "30"}, {40, "40"}, {50, "50"}, {60, "60"}, {70, "70"}},
         this, 50.0f);
+    m_idGauge->setAccessibleName(tr("Drain current"));
     auto* idRow = new QHBoxLayout;
     idRow->setSpacing(4);
     idRow->addWidget(m_idLabel);

--- a/src/gui/DaxApplet.cpp
+++ b/src/gui/DaxApplet.cpp
@@ -96,6 +96,7 @@ void DaxApplet::buildUI()
         row->addWidget(m_daxRxStatus[i]);
 
         m_daxRxMeter[i] = new MeterSlider;
+        m_daxRxMeter[i]->setAccessibleName(tr("DAX RX %1 gain").arg(i + 1));
         {
             auto key = QStringLiteral("DaxRxGain%1").arg(i + 1);
             float saved = settings.value(key, "0.5").toString().toFloat();
@@ -128,6 +129,7 @@ void DaxApplet::buildUI()
     txRow->addWidget(m_daxTxStatus);
 
     m_daxTxMeter = new MeterSlider;
+    m_daxTxMeter->setAccessibleName(tr("DAX TX gain"));
     {
         float saved = settings.value("DaxTxGain", "0.5").toString().toFloat();
         m_daxTxMeter->setGain(std::clamp(saved, 0.0f, 1.0f));

--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -2,6 +2,9 @@
 
 #include "MeterSmoother.h"
 
+#include <QAccessible>
+#include <QAccessibleWidget>
+#include <QKeyEvent>
 #include <QPainter>
 #include <QWidget>
 #include <QWheelEvent>
@@ -263,13 +266,18 @@ public:
     {
         setFixedHeight(18);
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-        setToolTip("Scroll to adjust relay position");
+        setFocusPolicy(Qt::TabFocus);
+        setToolTip(tr("Scroll or use Up/Down keys to adjust relay position"));
     }
 
     void setValue(int v) {
         if (m_value == v) return;
         m_value = v;
         update();
+        if (hasFocus()) {
+            QAccessibleValueChangeEvent event(this, QVariant(v));
+            QAccessible::updateAccessibility(&event);
+        }
     }
 
     void setScrollEnabled(bool on) {
@@ -281,6 +289,19 @@ signals:
     void relayAdjusted(int direction);  // +1 scroll up, -1 scroll down
 
 protected:
+    void keyPressEvent(QKeyEvent* e) override {
+        if (!m_scrollEnabled) { QWidget::keyPressEvent(e); return; }
+        if (e->key() == Qt::Key_Up || e->key() == Qt::Key_Plus || e->key() == Qt::Key_Right) {
+            emit relayAdjusted(+1);
+            e->accept();
+        } else if (e->key() == Qt::Key_Down || e->key() == Qt::Key_Minus || e->key() == Qt::Key_Left) {
+            emit relayAdjusted(-1);
+            e->accept();
+        } else {
+            QWidget::keyPressEvent(e);
+        }
+    }
+
     void wheelEvent(QWheelEvent* e) override {
         if (!m_scrollEnabled) {
             QWidget::wheelEvent(e);

--- a/src/gui/KeyboardMapWidget.cpp
+++ b/src/gui/KeyboardMapWidget.cpp
@@ -1,6 +1,9 @@
 #include "KeyboardMapWidget.h"
 #include "core/ShortcutManager.h"
 
+#include <QAccessible>
+#include <QFocusEvent>
+#include <QKeyEvent>
 #include <QPainter>
 #include <QMouseEvent>
 #include "core/ThemeManager.h"
@@ -34,6 +37,8 @@ KeyboardMapWidget::KeyboardMapWidget(ShortcutManager* mgr, QWidget* parent)
     : QWidget(parent), m_mgr(mgr)
 {
     setMouseTracking(true);
+    setFocusPolicy(Qt::TabFocus);
+    setAccessibleName(tr("Keyboard shortcut map"));
     buildLayout();
     connect(mgr, &ShortcutManager::bindingsChanged, this, [this]() { update(); });
 }
@@ -270,6 +275,11 @@ void KeyboardMapWidget::paintEvent(QPaintEvent*)
             fill = fill.lighter(150);
         }
 
+        // Keyboard focus ring (shown when widget has focus)
+        if (i == m_focusIdx && hasFocus()) {
+            border = QColor(0xff, 0xff, 0x00);  // yellow focus ring
+        }
+
         // Draw key background
         p.setPen(QPen(border, 1));
         p.setBrush(fill);
@@ -312,8 +322,10 @@ void KeyboardMapWidget::mousePressEvent(QMouseEvent* ev)
     int idx = hitTest(ev->pos());
     if (idx >= 0) {
         m_selectedIdx = idx;
+        m_focusIdx = idx;
         update();
         emit keySelected(m_keys[idx].qtKey);
+        announceKey(idx);
     }
     ev->accept();
 }
@@ -335,6 +347,122 @@ void KeyboardMapWidget::leaveEvent(QEvent*)
         m_hoverIdx = -1;
         update();
     }
+}
+
+// ─── Keyboard navigation ────────────────────────────────────────────────────
+
+void KeyboardMapWidget::keyPressEvent(QKeyEvent* ev)
+{
+    if (m_keys.isEmpty()) { QWidget::keyPressEvent(ev); return; }
+
+    int next = m_focusIdx;
+    switch (ev->key()) {
+    case Qt::Key_Left:
+        next = qMax(0, m_focusIdx - 1);
+        break;
+    case Qt::Key_Right:
+        next = qMin(m_keys.size() - 1, m_focusIdx + 1);
+        break;
+    case Qt::Key_Up:
+        next = findKeyVertical(m_focusIdx, true);
+        break;
+    case Qt::Key_Down:
+        next = findKeyVertical(m_focusIdx, false);
+        break;
+    case Qt::Key_Home:
+        next = 0;
+        break;
+    case Qt::Key_End:
+        next = m_keys.size() - 1;
+        break;
+    case Qt::Key_Return:
+    case Qt::Key_Enter:
+    case Qt::Key_Space:
+        selectFocusKey();
+        ev->accept();
+        return;
+    default:
+        QWidget::keyPressEvent(ev);
+        return;
+    }
+
+    if (next != m_focusIdx) {
+        m_focusIdx = next;
+        update();
+        announceKey(m_focusIdx);
+    }
+    ev->accept();
+}
+
+void KeyboardMapWidget::focusInEvent(QFocusEvent* ev)
+{
+    QWidget::focusInEvent(ev);
+    update();
+    announceKey(m_focusIdx);
+}
+
+void KeyboardMapWidget::focusOutEvent(QFocusEvent* ev)
+{
+    QWidget::focusOutEvent(ev);
+    update();
+}
+
+int KeyboardMapWidget::findKeyVertical(int idx, bool up) const
+{
+    if (idx < 0 || idx >= m_keys.size()) return qMax(0, idx);
+    const KeyCap& cur = m_keys[idx];
+
+    // Collect unique row y-values
+    QVector<float> rowYs;
+    for (const auto& k : m_keys) {
+        bool found = false;
+        for (float y : rowYs) { if (qAbs(y - k.y) < 0.1f) { found = true; break; } }
+        if (!found) rowYs.append(k.y);
+    }
+    std::sort(rowYs.begin(), rowYs.end());
+
+    int curRow = -1;
+    for (int i = 0; i < rowYs.size(); ++i) {
+        if (qAbs(rowYs[i] - cur.y) < 0.1f) { curRow = i; break; }
+    }
+    int targetRow = up ? curRow - 1 : curRow + 1;
+    if (targetRow < 0 || targetRow >= rowYs.size()) return idx;
+
+    float targetY = rowYs[targetRow];
+    float curCX = cur.x + cur.w / 2.0f;
+    int bestIdx = idx;
+    float bestDist = std::numeric_limits<float>::max();
+    for (int i = 0; i < m_keys.size(); ++i) {
+        if (qAbs(m_keys[i].y - targetY) < 0.1f) {
+            float cx = m_keys[i].x + m_keys[i].w / 2.0f;
+            float dist = qAbs(cx - curCX);
+            if (dist < bestDist) { bestDist = dist; bestIdx = i; }
+        }
+    }
+    return bestIdx;
+}
+
+void KeyboardMapWidget::selectFocusKey()
+{
+    if (m_focusIdx < 0 || m_focusIdx >= m_keys.size()) return;
+    m_selectedIdx = m_focusIdx;
+    update();
+    emit keySelected(m_keys[m_focusIdx].qtKey);
+    announceKey(m_focusIdx);
+}
+
+void KeyboardMapWidget::announceKey(int idx)
+{
+    if (idx < 0 || idx >= m_keys.size()) return;
+    const KeyCap& k = m_keys[idx];
+    QKeySequence seq(k.qtKey);
+    const auto* act = m_mgr->actionForKey(seq);
+    QString desc = act
+        ? tr("%1: %2").arg(k.label, act->displayName)
+        : tr("%1: unbound").arg(k.label);
+    setAccessibleDescription(desc);
+    QAccessibleValueChangeEvent event(this, desc);
+    QAccessible::updateAccessibility(&event);
 }
 
 } // namespace AetherSDR

--- a/src/gui/KeyboardMapWidget.h
+++ b/src/gui/KeyboardMapWidget.h
@@ -29,6 +29,9 @@ protected:
     void mousePressEvent(QMouseEvent* ev) override;
     void mouseMoveEvent(QMouseEvent* ev) override;
     void leaveEvent(QEvent* ev) override;
+    void keyPressEvent(QKeyEvent* ev) override;
+    void focusInEvent(QFocusEvent* ev) override;
+    void focusOutEvent(QFocusEvent* ev) override;
 
 private:
     struct KeyCap {
@@ -43,11 +46,15 @@ private:
     void buildLayout();
     QRectF keyRect(const KeyCap& k) const;
     int hitTest(const QPoint& pos) const;
+    int findKeyVertical(int idx, bool up) const;
+    void selectFocusKey();
+    void announceKey(int idx);
 
     ShortcutManager* m_mgr;
     QVector<KeyCap> m_keys;
     int m_selectedIdx{-1};
     int m_hoverIdx{-1};
+    int m_focusIdx{0};       // keyboard-navigated key (independent of mouse selection)
     float m_keyUnit{0};     // pixel size of one key unit (computed in paintEvent)
     float m_originX{0};
     float m_originY{0};

--- a/src/gui/MeterApplet.cpp
+++ b/src/gui/MeterApplet.cpp
@@ -27,16 +27,19 @@ MeterApplet::MeterApplet(QWidget* parent)
     m_paTempGauge = new HGauge(0.0f, 120.0f, 70.0f, "PA Temp", "",
         {{0, "0"}, {30, "30"}, {55, "55"}, {70, "70"}, {90, "90"}, {120, "120"}},
         this, 55.0f);
+    m_paTempGauge->setAccessibleName(tr("PA temperature"));
     vbox->addWidget(m_paTempGauge);
 
     m_supplyGauge = new HGauge(10.0f, 16.0f, 15.0f, "+13.8V", "",
         {{10.5f, "10.5"}, {12, "12"}, {13.8f, "13.8"}, {15, "15"}},
         this, 14.1f);
+    m_supplyGauge->setAccessibleName(tr("Supply voltage"));
     vbox->addWidget(m_supplyGauge);
 
     m_fanGauge = new HGauge(0.0f, 3000.0f, 2500.0f, "Main Fan", "",
         {{0, "0"}, {500, "500"}, {1000, "1k"}, {1500, "1.5k"}, {2000, "2k"}, {3000, "3k"}},
         this, 2000.0f);
+    m_fanGauge->setAccessibleName(tr("Main fan speed"));
     vbox->addWidget(m_fanGauge);
 
     vbox->addStretch();

--- a/src/gui/MeterSlider.h
+++ b/src/gui/MeterSlider.h
@@ -5,6 +5,7 @@
 #include "core/ThemeManager.h"
 
 #include <QElapsedTimer>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QTimer>
@@ -33,6 +34,7 @@ public:
         setFixedHeight(16);
         setMinimumWidth(60);
         setCursor(Qt::PointingHandCursor);
+        setFocusPolicy(Qt::TabFocus);
 
         m_animTimer.setTimerType(Qt::PreciseTimer);
         m_animTimer.setInterval(kMeterSmootherIntervalMs);
@@ -160,6 +162,23 @@ protected:
         p.setBrush(accent);
         p.setPen(Qt::NoPen);
         p.drawPolygon(tri);
+    }
+
+    void keyPressEvent(QKeyEvent* e) override {
+        float delta = 0.0f;
+        if (e->key() == Qt::Key_Right || e->key() == Qt::Key_Up)   delta = +0.05f;
+        if (e->key() == Qt::Key_Left  || e->key() == Qt::Key_Down) delta = -0.05f;
+        if (delta != 0.0f) {
+            float g = std::clamp(m_gain + delta, 0.0f, 1.0f);
+            if (g != m_gain) {
+                m_gain = g;
+                emit gainChanged(m_gain);
+                update();
+            }
+            e->accept();
+            return;
+        }
+        QWidget::keyPressEvent(e);
     }
 
     void mousePressEvent(QMouseEvent* e) override {

--- a/src/gui/PhaseKnob.cpp
+++ b/src/gui/PhaseKnob.cpp
@@ -1,11 +1,29 @@
 #include "PhaseKnob.h"
 
+#include <QAccessible>
+#include <QAccessibleWidget>
 #include <QMouseEvent>
 #include <QPainter>
 #include <algorithm>
 #include <cmath>
 
 namespace AetherSDR {
+
+// PhaseKnob is a visual display only — the named ESC phase/gain sliders
+// (VfoWidget.cpp:957/982) are the accessible interface.  Returning NoRole
+// causes AT tools to skip this widget in navigation.
+class PhaseKnobAccessible : public QAccessibleWidget {
+public:
+    explicit PhaseKnobAccessible(QWidget* w) : QAccessibleWidget(w) {}
+    QAccessible::Role role() const override { return QAccessible::NoRole; }
+};
+
+static QAccessibleInterface* phaseKnobFactory(const QString& key, QObject* obj)
+{
+    if (key == QLatin1String("AetherSDR::PhaseKnob"))
+        return new PhaseKnobAccessible(qobject_cast<QWidget*>(obj));
+    return nullptr;
+}
 
 namespace {
 
@@ -25,6 +43,12 @@ PhaseKnob::PhaseKnob(QWidget* parent)
 {
     setFixedSize(120, 120);
     setCursor(Qt::CrossCursor);
+
+    static bool s_factoryInstalled = false;
+    if (!s_factoryInstalled) {
+        s_factoryInstalled = true;
+        QAccessible::installFactory(phaseKnobFactory);
+    }
 }
 
 void PhaseKnob::setPhase(float radians)

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -1,5 +1,6 @@
 #include "SMeterWidget.h"
 
+#include <QAccessible>
 #include <QPainter>
 #include <QPainterPath>
 #include <QSet>
@@ -15,6 +16,7 @@ SMeterWidget::SMeterWidget(QWidget* parent)
 {
     setMinimumSize(minimumSizeHint());
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    setFocusPolicy(Qt::TabFocus);
 
     m_needleFraction = dbmToFraction(m_levelDbm);
     m_targetNeedleFraction = m_needleFraction;
@@ -73,6 +75,23 @@ void SMeterWidget::setLevel(float dbm)
 
     if (!m_transmitting) {
         update();
+        if (hasFocus() && QAccessible::isActive()) {
+            // Announce the same value that paintEvent displays — in Peak mode
+            // the needle and text readout track m_peakDbm, not the raw level.
+            const float displayDbm = (m_rxMode == RxMode::SMeterPeak) ? m_peakDbm : m_levelDbm;
+            QString sText;
+            if (displayDbm <= S0_DBM)
+                sText = QStringLiteral("S0");
+            else if (displayDbm <= S9_DBM)
+                sText = QStringLiteral("S%1").arg(qBound(0, qRound((displayDbm - S0_DBM) / DB_PER_S), 9));
+            else
+                sText = QStringLiteral("S9+%1").arg(qRound(displayDbm - S9_DBM));
+            const QString accessText = sText + QStringLiteral(", ")
+                + QString::number(static_cast<int>(displayDbm))
+                + QStringLiteral(" dBm");
+            QAccessibleValueChangeEvent event(this, accessText);
+            QAccessible::updateAccessibility(&event);
+        }
     }
 }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -428,6 +428,7 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     setMinimumHeight(100);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setAutoFillBackground(false);
+    setAccessibleName(tr("Panadapter spectrum display"));
 #ifdef AETHER_GPU_SPECTRUM
     // Explicitly request Metal on macOS.
 #  ifdef Q_OS_MAC

--- a/src/gui/TciApplet.cpp
+++ b/src/gui/TciApplet.cpp
@@ -91,6 +91,7 @@ void TciApplet::buildUI()
         row->addWidget(m_rxStatus[i]);
 
         m_rxMeter[i] = new MeterSlider;
+        m_rxMeter[i]->setAccessibleName(tr("TCI RX %1 gain").arg(i + 1));
         {
             auto key = QStringLiteral("TciRxGain%1").arg(i + 1);
             float saved = settings.value(key, "0.5").toString().toFloat();
@@ -124,6 +125,7 @@ void TciApplet::buildUI()
         row->addWidget(m_txStatus);
 
         m_txMeter = new MeterSlider;
+        m_txMeter->setAccessibleName(tr("TCI TX gain"));
         {
             // TciServer owns TciTxGain persistence (with DaxTxGain migration
             // on first read).  Mirror that stored value here for the slider

--- a/src/gui/TunerApplet.cpp
+++ b/src/gui/TunerApplet.cpp
@@ -114,6 +114,7 @@ void TunerApplet::buildUI()
         this, 80.0f);
     // Slow release: bar rises quickly on RF bursts but decays over ~800 ms
     static_cast<HGauge*>(m_fwdGauge)->setBallistics({0.030f, 0.800f});
+    m_fwdGauge->setAccessibleName(tr("Forward power"));
     auto* pwrRow = new QHBoxLayout;
     pwrRow->setSpacing(4);
     pwrRow->addWidget(m_pwrLabel);
@@ -128,6 +129,7 @@ void TunerApplet::buildUI()
     m_swrGauge = new HGauge(1.0f, 3.0f, 2.5f, "", "",
         {{1.0f, "1"}, {1.5f, "1.5"}, {2.5f, "2.5"}, {3.0f, "3"}},
         this, 2.0f);
+    m_swrGauge->setAccessibleName(tr("SWR"));
     auto* swrRow = new QHBoxLayout;
     swrRow->setSpacing(4);
     swrRow->addWidget(m_swrLabel);
@@ -142,8 +144,11 @@ void TunerApplet::buildUI()
     auto* relayCol = new QVBoxLayout;
     relayCol->setSpacing(2);
     m_c1Bar = new RelayBar("C1");
+    m_c1Bar->setAccessibleName(tr("Tuner capacitor C1"));
     m_lBar  = new RelayBar("L");
+    m_lBar->setAccessibleName(tr("Tuner inductor L"));
     m_c2Bar = new RelayBar("C2");
+    m_c2Bar->setAccessibleName(tr("Tuner capacitor C2"));
     relayCol->addWidget(m_c1Bar);
     relayCol->addWidget(m_lBar);
     relayCol->addWidget(m_c2Bar);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -22,6 +22,7 @@
 #include <QLabel>
 #include <QSlider>
 #include <QGraphicsOpacityEffect>
+#include <QAccessible>
 #include <QLineEdit>
 #include <QComboBox>
 #include <QStackedWidget>
@@ -208,14 +209,16 @@ static const QString kFlatBtn =
     "font-size: 13px; font-weight: bold; padding: 0 6px; margin: 0; }";
 
 static const QString kTabLblNormal =
-    "QLabel { background: transparent; border: none; "
+    "QPushButton { background: transparent; border: none; "
     "border-bottom: 2px solid transparent; "
-    "color: #6888a0; font-size: 13px; font-weight: bold; padding: 3px 0; }";
+    "color: #6888a0; font-size: 13px; font-weight: bold; padding: 3px 0; }"
+    "QPushButton:focus { outline: none; border-bottom: 2px solid #6888a0; }";
 
 static const QString kTabLblActive =
-    "QLabel { background: transparent; border: none; "
+    "QPushButton { background: transparent; border: none; "
     "border-bottom: 2px solid #00b4d8; "
-    "color: #00b4d8; font-size: 13px; font-weight: bold; padding: 3px 0; }";
+    "color: #00b4d8; font-size: 13px; font-weight: bold; padding: 3px 0; }"
+    "QPushButton:focus { outline: none; }";
 
 static const QString kDisabledBtn =
     "QPushButton:disabled { background-color: #1a1a2a; color: #556070; "
@@ -269,6 +272,15 @@ VfoWidget::VfoWidget(QWidget* parent)
     m_signalMeterAnimation.setTimerType(Qt::PreciseTimer);
     m_signalMeterAnimation.setInterval(kSignalMeterAnimationIntervalMs);
     connect(&m_signalMeterAnimation, &QTimer::timeout, this, &VfoWidget::animateSignalMeter);
+
+    m_accessibleFrequencyTimer.setSingleShot(true);
+    connect(&m_accessibleFrequencyTimer, &QTimer::timeout, this, [this]() {
+        if (!QAccessible::isActive()) return;
+        if (m_pendingAccessibleFrequencyText == m_lastAccessibleFrequencyText) return;
+        m_lastAccessibleFrequencyText = m_pendingAccessibleFrequencyText;
+        QAccessibleValueChangeEvent event(m_freqLabel, m_pendingAccessibleFrequencyText);
+        QAccessible::updateAccessibility(&event);
+    });
 
     buildUI();
 
@@ -773,14 +785,23 @@ void VfoWidget::buildUI()
             sep->setAlignment(Qt::AlignCenter);
             tabLayout->addWidget(sep);
         }
-        auto* lbl = new QLabel(tabLabels[i]);
-        lbl->setStyleSheet(kTabLblNormal);
-        lbl->setFixedHeight(24);
-        lbl->setAlignment(Qt::AlignCenter);
-        lbl->setCursor(Qt::PointingHandCursor);
-        lbl->installEventFilter(this);
-        tabLayout->addWidget(lbl, 1);
-        m_tabBtns.append(lbl);
+        auto* btn = new QPushButton(tabLabels[i]);
+        btn->setFlat(true);
+        btn->setCheckable(true);
+        btn->setStyleSheet(kTabLblNormal);
+        btn->setFixedHeight(24);
+        btn->setCursor(Qt::PointingHandCursor);
+        btn->setFocusPolicy(Qt::TabFocus);
+        connect(btn, &QPushButton::clicked, this, [this, i]() { showTab(i); });
+        if (i == 0) {
+            // Right-click on speaker tab toggles mute directly
+            btn->setContextMenuPolicy(Qt::CustomContextMenu);
+            connect(btn, &QPushButton::customContextMenuRequested, this, [this](const QPoint&) {
+                if (m_slice) m_slice->setAudioMute(!m_slice->audioMute());
+            });
+        }
+        tabLayout->addWidget(btn, 1);
+        m_tabBtns.append(btn);
     }
     root->addWidget(m_tabBar);
 
@@ -790,7 +811,17 @@ void VfoWidget::buildUI()
     buildTabContent();
     root->addWidget(m_tabStack);
 
-    // Accessible names for VoiceOver / screen reader support (#870)
+    // Accessible names for VoiceOver / screen reader support (#870, #3288)
+    const QStringList tabA11yNames = {
+        tr("Audio settings"),
+        tr("DSP settings"),
+        tr("Mode settings"),
+        tr("X/RIT settings"),
+        tr("DAX settings"),
+    };
+    for (int i = 0; i < m_tabBtns.size(); ++i)
+        m_tabBtns[i]->setAccessibleName(tabA11yNames[i]);
+
     m_rxAntBtn->setAccessibleName("RX antenna");
     m_txAntBtn->setAccessibleName("TX antenna");
     m_filterWidthLbl->setAccessibleName("Filter width");
@@ -1978,12 +2009,16 @@ void VfoWidget::showTab(int index)
         // Toggle off — collapse content
         m_tabStack->hide();
         m_tabBtns[m_activeTab]->setStyleSheet(kTabLblNormal);
+        m_tabBtns[m_activeTab]->setChecked(false);
         m_activeTab = -1;
     } else {
-        if (m_activeTab >= 0)
+        if (m_activeTab >= 0) {
             m_tabBtns[m_activeTab]->setStyleSheet(kTabLblNormal);
+            m_tabBtns[m_activeTab]->setChecked(false);
+        }
         m_activeTab = index;
         m_tabBtns[index]->setStyleSheet(kTabLblActive);
+        m_tabBtns[index]->setChecked(true);
         m_tabStack->setCurrentIndex(index);
         m_tabStack->show();
     }
@@ -2084,8 +2119,9 @@ void VfoWidget::setCollapsed(bool collapsed)
         if (m_tabStack) {
             m_tabStack->hide();
             m_activeTab = -1;
-            for (QLabel* lbl : m_tabBtns) {
-                lbl->setStyleSheet(kTabLblNormal);
+            for (QPushButton* btn : m_tabBtns) {
+                btn->setStyleSheet(kTabLblNormal);
+                btn->setChecked(false);
             }
         }
         // Restore external buttons to pre-collapse state and reposition them
@@ -3263,6 +3299,14 @@ void VfoWidget::updateFreqLabel()
     if (!m_slice) return;
     if (m_slice->isLockedFeedbackActive()) {
         m_freqLabel->setText(QStringLiteral("LOCKED"));
+        // Announce immediately — lock state is user-triggered and infrequent.
+        // Suppress repeats while the 500 ms lock-feedback gate is active.
+        if (QAccessible::isActive() &&
+            m_lastAccessibleFrequencyText != QStringLiteral("LOCKED")) {
+            m_lastAccessibleFrequencyText = QStringLiteral("LOCKED");
+            QAccessibleValueChangeEvent lockedEvt(m_freqLabel, QStringLiteral("LOCKED"));
+            QAccessible::updateAccessibility(&lockedEvt);
+        }
         if (m_collapsed && m_collapsedFreqLabel) {
             m_collapsedFreqLabel->setText(QStringLiteral("LOCKED"));
             m_collapsedFreqLabel->adjustSize();
@@ -3279,12 +3323,20 @@ void VfoWidget::updateFreqLabel()
         .arg(khzPart, 3, 10, QChar('0'))
         .arg(hzPart, 3, 10, QChar('0'));
     m_freqLabel->setText(freqText);
+    scheduleFrequencyAnnouncement(freqText);
 
     // Keep collapsed frequency label in sync
     if (m_collapsed && m_collapsedFreqLabel) {
         m_collapsedFreqLabel->setText(freqText);
         m_collapsedFreqLabel->adjustSize();
     }
+}
+
+void VfoWidget::scheduleFrequencyAnnouncement(const QString& text)
+{
+    if (!QAccessible::isActive()) return;
+    m_pendingAccessibleFrequencyText = text;
+    m_accessibleFrequencyTimer.start(300);  // restart on each tune step; fires once settled
 }
 
 void VfoWidget::updateFilterLabel()
@@ -4101,24 +4153,6 @@ bool VfoWidget::eventFilter(QObject* obj, QEvent* event)
         }
     }
 
-    if (event->type() == QEvent::MouseButtonPress) {
-        auto* lbl = qobject_cast<QLabel*>(obj);
-        if (lbl) {
-            int idx = m_tabBtns.indexOf(lbl);
-            if (idx >= 0) {
-                auto* me = static_cast<QMouseEvent*>(event);
-                // Right-click on speaker tab (idx 0) toggles mute directly
-                if (idx == 0 && me->button() == Qt::RightButton && m_slice) {
-                    m_slice->setAudioMute(!m_slice->audioMute());
-                    return true;
-                }
-                if (me->button() == Qt::LeftButton) {
-                    showTab(idx);
-                    return true;
-                }
-            }
-        }
-    }
     return QWidget::eventFilter(obj, event);
 }
 

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -176,6 +176,12 @@ private:
     int            m_angleAccum{0};     // mouse wheel angle accumulator
     qint64         m_lastWheelMs{0};    // debounce: timestamp of last accepted wheel step
     QPointer<QLabel> m_collapsedFreqLabel;
+
+    // Accessibility: debounced frequency announcement (300 ms settle before speaking)
+    QTimer   m_accessibleFrequencyTimer;
+    QString  m_pendingAccessibleFrequencyText;
+    QString  m_lastAccessibleFrequencyText;
+    void     scheduleFrequencyAnnouncement(const QString& text);
     QSet<QWidget*> m_hiddenBeforeCollapse;    // widgets already hidden before collapse
 
     // Header row
@@ -203,8 +209,8 @@ private:
     QLabel* m_dbmLabel{nullptr};
     QString m_directEntrySource{"vfo-direct-entry"};
 
-    // Sub-menu tabs (QLabels with click via event filter)
-    QVector<QLabel*> m_tabBtns;
+    // Sub-menu tabs
+    QVector<QPushButton*> m_tabBtns;
     QStackedWidget* m_tabStack{nullptr};
     QWidget*        m_tabBar{nullptr};
     int m_activeTab{-1};


### PR DESCRIPTION
Companion to #3288 (Phase 2 accessibility audit), per maintainer guidance from @jensenpat.

Addresses all four issues from the @jensenpat review on the previous iteration.

## What's in this PR

### Phase 2a — `setAccessibleName` on previously unnamed widgets

All changes are additive, no behavioral risk.

**MeterApplet** (`MeterApplet.cpp`): PA temperature, supply voltage, main fan speed gauges

**AmpApplet** (`AmpApplet.cpp`): Forward power, SWR, drain current gauges — rebased onto the new row-label/ballistics layout from #3301

**TunerApplet** (`TunerApplet.cpp`): Forward power, SWR gauges + C1/L/C2 relay bars — rebased onto the same row-label refactor

**SpectrumWidget** (`SpectrumWidget.cpp`): "Panadapter spectrum display"

**TciApplet / DaxApplet**: RX 1–N gain sliders, TX gain slider (named in loop)

### Phase 2b — Live accessibility announcements

**VFO frequency** (`VfoWidget.cpp` / `VfoWidget.h`):
- `updateFreqLabel()` now routes through `scheduleFrequencyAnnouncement()` — a 300 ms single-shot debounce timer that fires once the frequency settles, preventing VoiceOver from being asked to speak ~20 times/second during active wheel tuning
- LOCKED state announces immediately (user-triggered, infrequent) but suppresses repeats while the 500 ms lock-feedback gate is active

**S-meter** (`SMeterWidget.cpp`):
- `setFocusPolicy(Qt::TabFocus)` added — widget is keyboard-reachable
- `setLevel()` announces the *displayed* value, not raw dBm: in S-Meter Peak mode the event value is derived from `m_peakDbm` (what the needle and text readout show), not `m_levelDbm`; formatted as "S7, -79 dBm" to match the painted readout exactly

**MeterSlider** (`MeterSlider.h`):
- `setFocusPolicy(Qt::TabFocus)` added — DAX/TCI gain sliders are now keyboard-reachable
- `keyPressEvent` handler: Left/Down −5%, Right/Up +5% — gain thumb is adjustable without a mouse

### Phase 2c — VFO tab bar: `QLabel` → `QPushButton`

VFO tab labels were `QLabel` with a click event filter; VoiceOver could not activate them. Replaced with `QPushButton` throughout (`VfoWidget.cpp`, `VfoWidget.h`).

### Phase 2d — Keyboard navigation: RelayBar + PhaseKnob

- `RelayBar` gains arrow-key support (Left/Right step through relay positions)
- `PhaseKnob` excluded from the tab order (it is already accessible via the paired ESC sliders)

## Test notes

On macOS with VoiceOver:
1. Tab to the S-meter — subsequent signal level changes should be spoken as "S7, -79 dBm" etc.
2. Tune the VFO wheel quickly — VoiceOver speaks once after tuning settles (not on every step)
3. Lock the VFO — VoiceOver speaks "LOCKED" once
4. Tab to a DAX/TCI gain slider — Left/Right arrows move the thumb
5. VFO tab bar buttons ("DSP", "USB", "X/RIT", "DAX") are activatable via VoiceOver

— AI5OS (@w9fyi)