### PR TITLE
accessibility: phase 2c — VFO tab QLabel → QPushButton

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -208,14 +208,16 @@ static const QString kFlatBtn =
     "font-size: 13px; font-weight: bold; padding: 0 6px; margin: 0; }";
 
 static const QString kTabLblNormal =
-    "QLabel { background: transparent; border: none; "
+    "QPushButton { background: transparent; border: none; "
     "border-bottom: 2px solid transparent; "
-    "color: #6888a0; font-size: 13px; font-weight: bold; padding: 3px 0; }";
+    "color: #6888a0; font-size: 13px; font-weight: bold; padding: 3px 0; }"
+    "QPushButton:focus { outline: none; border-bottom: 2px solid #6888a0; }";
 
 static const QString kTabLblActive =
-    "QLabel { background: transparent; border: none; "
+    "QPushButton { background: transparent; border: none; "
     "border-bottom: 2px solid #00b4d8; "
-    "color: #00b4d8; font-size: 13px; font-weight: bold; padding: 3px 0; }";
+    "color: #00b4d8; font-size: 13px; font-weight: bold; padding: 3px 0; }"
+    "QPushButton:focus { outline: none; }";
 
 static const QString kDisabledBtn =
     "QPushButton:disabled { background-color: #1a1a2a; color: #556070; "
@@ -773,14 +775,23 @@ void VfoWidget::buildUI()
             sep->setAlignment(Qt::AlignCenter);
             tabLayout->addWidget(sep);
         }
-        auto* lbl = new QLabel(tabLabels[i]);
-        lbl->setStyleSheet(kTabLblNormal);
-        lbl->setFixedHeight(24);
-        lbl->setAlignment(Qt::AlignCenter);
-        lbl->setCursor(Qt::PointingHandCursor);
-        lbl->installEventFilter(this);
-        tabLayout->addWidget(lbl, 1);
-        m_tabBtns.append(lbl);
+        auto* btn = new QPushButton(tabLabels[i]);
+        btn->setFlat(true);
+        btn->setCheckable(true);
+        btn->setStyleSheet(kTabLblNormal);
+        btn->setFixedHeight(24);
+        btn->setCursor(Qt::PointingHandCursor);
+        btn->setFocusPolicy(Qt::TabFocus);
+        connect(btn, &QPushButton::clicked, this, [this, i]() { showTab(i); });
+        if (i == 0) {
+            // Right-click on speaker tab toggles mute directly
+            btn->setContextMenuPolicy(Qt::CustomContextMenu);
+            connect(btn, &QPushButton::customContextMenuRequested, this, [this](const QPoint&) {
+                if (m_slice) m_slice->setAudioMute(!m_slice->audioMute());
+            });
+        }
+        tabLayout->addWidget(btn, 1);
+        m_tabBtns.append(btn);
     }
     root->addWidget(m_tabBar);
 
@@ -790,7 +801,17 @@ void VfoWidget::buildUI()
     buildTabContent();
     root->addWidget(m_tabStack);
 
-    // Accessible names for VoiceOver / screen reader support (#870)
+    // Accessible names for VoiceOver / screen reader support (#870, #3288)
+    const QStringList tabA11yNames = {
+        tr("Audio settings"),
+        tr("DSP settings"),
+        tr("Mode settings"),
+        tr("X/RIT settings"),
+        tr("DAX settings"),
+    };
+    for (int i = 0; i < m_tabBtns.size(); ++i)
+        m_tabBtns[i]->setAccessibleName(tabA11yNames[i]);
+
     m_rxAntBtn->setAccessibleName("RX antenna");
     m_txAntBtn->setAccessibleName("TX antenna");
     m_filterWidthLbl->setAccessibleName("Filter width");
@@ -1978,12 +1999,16 @@ void VfoWidget::showTab(int index)
         // Toggle off — collapse content
         m_tabStack->hide();
         m_tabBtns[m_activeTab]->setStyleSheet(kTabLblNormal);
+        m_tabBtns[m_activeTab]->setChecked(false);
         m_activeTab = -1;
     } else {
-        if (m_activeTab >= 0)
+        if (m_activeTab >= 0) {
             m_tabBtns[m_activeTab]->setStyleSheet(kTabLblNormal);
+            m_tabBtns[m_activeTab]->setChecked(false);
+        }
         m_activeTab = index;
         m_tabBtns[index]->setStyleSheet(kTabLblActive);
+        m_tabBtns[index]->setChecked(true);
         m_tabStack->setCurrentIndex(index);
         m_tabStack->show();
     }
@@ -2084,8 +2109,9 @@ void VfoWidget::setCollapsed(bool collapsed)
         if (m_tabStack) {
             m_tabStack->hide();
             m_activeTab = -1;
-            for (QLabel* lbl : m_tabBtns) {
-                lbl->setStyleSheet(kTabLblNormal);
+            for (QPushButton* btn : m_tabBtns) {
+                btn->setStyleSheet(kTabLblNormal);
+                btn->setChecked(false);
             }
         }
         // Restore external buttons to pre-collapse state and reposition them
@@ -4089,24 +4115,6 @@ bool VfoWidget::eventFilter(QObject* obj, QEvent* event)
         }
     }
 
-    if (event->type() == QEvent::MouseButtonPress) {
-        auto* lbl = qobject_cast<QLabel*>(obj);
-        if (lbl) {
-            int idx = m_tabBtns.indexOf(lbl);
-            if (idx >= 0) {
-                auto* me = static_cast<QMouseEvent*>(event);
-                // Right-click on speaker tab (idx 0) toggles mute directly
-                if (idx == 0 && me->button() == Qt::RightButton && m_slice) {
-                    m_slice->setAudioMute(!m_slice->audioMute());
-                    return true;
-                }
-                if (me->button() == Qt::LeftButton) {
-                    showTab(idx);
-                    return true;
-                }
-            }
-        }
-    }
     return QWidget::eventFilter(obj, event);
 }
 

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -203,8 +203,8 @@ private:
     QLabel* m_dbmLabel{nullptr};
     QString m_directEntrySource{"vfo-direct-entry"};
 
-    // Sub-menu tabs (QLabels with click via event filter)
-    QVector<QLabel*> m_tabBtns;
+    // Sub-menu tabs
+    QVector<QPushButton*> m_tabBtns;
     QStackedWidget* m_tabStack{nullptr};
     QWidget*        m_tabBar{nullptr};
     int m_activeTab{-1};


### PR DESCRIPTION
Companion to #3288 (Phase 2 accessibility), per maintainer guidance from @jensenpat. Separate from #3303 (Phase 2a+2b names and live events).

## The problem

The five VFO tab bar items (🔊 / DSP / USB / X·RIT / DAX) are `QLabel` widgets. A `QLabel` has role `AXStaticText` in the macOS accessibility tree — VoiceOver announces them as text and has no way to activate them. The click-to-show behavior was hidden inside `eventFilter()`, completely invisible to any AT.

## What this PR does

Replaces the five `QLabel` tabs with flat `QPushButton`s, giving each one the correct `AXButton` role that AT tools expect.

**`VfoWidget.h`** — `m_tabBtns` type: `QVector<QLabel*>` → `QVector<QPushButton*>`

**`VfoWidget.cpp`**:
- `kTabLblNormal` / `kTabLblActive`: selector changed `QLabel{}` → `QPushButton{}`; adds a `:focus` rule so keyboard Tab navigation shows a visible focus indicator (WCAG 2.4.7)
- Tab construction loop:
  - `new QLabel` → `new QPushButton` with `setFlat(true)` (removes platform chrome), `setCheckable(true)` (AT can announce selected state), `setFocusPolicy(Qt::TabFocus)` (keyboard reachable)
  - Left-click wired directly: `connect(btn, &QPushButton::clicked, ...)` → `showTab(i)` — no event filter needed
  - Right-click on speaker tab (idx 0): moved from the `eventFilter` `MouseButtonPress` block to `customContextMenuRequested` signal
  - `installEventFilter(this)` removed — no longer needed for these buttons
- `showTab()`: adds `setChecked(true/false)` calls so VoiceOver can announce the selected/deselected state transition
- `setCollapsed()`: range-for type updated `QLabel*` → `QPushButton*`; adds `setChecked(false)` on tab reset
- `eventFilter()`: removes the entire `qobject_cast<QLabel*>` tab-click handling block (18 lines deleted)
- `buildUI()` a11y block: adds `setAccessibleName` for all five tabs ("Audio settings" / "DSP settings" / "Mode settings" / "X/RIT settings" / "DAX settings")

## What does NOT change

- Visual appearance is identical — `setFlat(true)` + the existing stylesheet produces the same look
- The separator `|` labels between tabs are untouched
- All dynamic `setText()` calls (`m_tabBtns[0]->setText(muteEmoji)`, `m_tabBtns[2]->setText(mode)`, etc.) work identically on `QPushButton`

## Test notes

On macOS with VoiceOver:
- Tab through the VFO controls — the five tab bar items should be announced as buttons with their names ("Audio settings", "DSP settings", etc.)
- Press Space or Enter to activate a tab — the panel should expand/collapse and VoiceOver should announce the state change
- Right-click (two-finger tap) on the speaker tab should still toggle mute
- Visual appearance should be pixel-identical to before

— AI5OS (@w9fyi)