### PR TITLE
accessibility: phase 2d — keyboard nav, RelayBar keys, PhaseKnob exclusion

### DIFF
--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -2,6 +2,9 @@
 
 #include "MeterSmoother.h"
 
+#include <QAccessible>
+#include <QAccessibleWidget>
+#include <QKeyEvent>
 #include <QPainter>
 #include <QWidget>
 #include <QWheelEvent>
@@ -253,13 +256,18 @@ public:
     {
         setFixedHeight(18);
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-        setToolTip("Scroll to adjust relay position");
+        setFocusPolicy(Qt::TabFocus);
+        setToolTip(tr("Scroll or use Up/Down keys to adjust relay position"));
     }
 
     void setValue(int v) {
         if (m_value == v) return;
         m_value = v;
         update();
+        if (hasFocus()) {
+            QAccessibleValueChangeEvent event(this, QVariant(v));
+            QAccessible::updateAccessibility(&event);
+        }
     }
 
     void setScrollEnabled(bool on) {
@@ -271,6 +279,19 @@ signals:
     void relayAdjusted(int direction);  // +1 scroll up, -1 scroll down
 
 protected:
+    void keyPressEvent(QKeyEvent* e) override {
+        if (!m_scrollEnabled) { QWidget::keyPressEvent(e); return; }
+        if (e->key() == Qt::Key_Up || e->key() == Qt::Key_Plus || e->key() == Qt::Key_Right) {
+            emit relayAdjusted(+1);
+            e->accept();
+        } else if (e->key() == Qt::Key_Down || e->key() == Qt::Key_Minus || e->key() == Qt::Key_Left) {
+            emit relayAdjusted(-1);
+            e->accept();
+        } else {
+            QWidget::keyPressEvent(e);
+        }
+    }
+
     void wheelEvent(QWheelEvent* e) override {
         if (!m_scrollEnabled) {
             QWidget::wheelEvent(e);

--- a/src/gui/KeyboardMapWidget.cpp
+++ b/src/gui/KeyboardMapWidget.cpp
@@ -1,6 +1,9 @@
 #include "KeyboardMapWidget.h"
 #include "core/ShortcutManager.h"
 
+#include <QAccessible>
+#include <QFocusEvent>
+#include <QKeyEvent>
 #include <QPainter>
 #include <QMouseEvent>
 #include "core/ThemeManager.h"
@@ -34,6 +37,8 @@ KeyboardMapWidget::KeyboardMapWidget(ShortcutManager* mgr, QWidget* parent)
     : QWidget(parent), m_mgr(mgr)
 {
     setMouseTracking(true);
+    setFocusPolicy(Qt::TabFocus);
+    setAccessibleName(tr("Keyboard shortcut map"));
     buildLayout();
     connect(mgr, &ShortcutManager::bindingsChanged, this, [this]() { update(); });
 }
@@ -270,6 +275,11 @@ void KeyboardMapWidget::paintEvent(QPaintEvent*)
             fill = fill.lighter(150);
         }
 
+        // Keyboard focus ring (shown when widget has focus)
+        if (i == m_focusIdx && hasFocus()) {
+            border = QColor(0xff, 0xff, 0x00);  // yellow focus ring
+        }
+
         // Draw key background
         p.setPen(QPen(border, 1));
         p.setBrush(fill);
@@ -312,8 +322,10 @@ void KeyboardMapWidget::mousePressEvent(QMouseEvent* ev)
     int idx = hitTest(ev->pos());
     if (idx >= 0) {
         m_selectedIdx = idx;
+        m_focusIdx = idx;
         update();
         emit keySelected(m_keys[idx].qtKey);
+        announceKey(idx);
     }
     ev->accept();
 }
@@ -335,6 +347,122 @@ void KeyboardMapWidget::leaveEvent(QEvent*)
         m_hoverIdx = -1;
         update();
     }
+}
+
+// ─── Keyboard navigation ────────────────────────────────────────────────────
+
+void KeyboardMapWidget::keyPressEvent(QKeyEvent* ev)
+{
+    if (m_keys.isEmpty()) { QWidget::keyPressEvent(ev); return; }
+
+    int next = m_focusIdx;
+    switch (ev->key()) {
+    case Qt::Key_Left:
+        next = qMax(0, m_focusIdx - 1);
+        break;
+    case Qt::Key_Right:
+        next = qMin(m_keys.size() - 1, m_focusIdx + 1);
+        break;
+    case Qt::Key_Up:
+        next = findKeyVertical(m_focusIdx, true);
+        break;
+    case Qt::Key_Down:
+        next = findKeyVertical(m_focusIdx, false);
+        break;
+    case Qt::Key_Home:
+        next = 0;
+        break;
+    case Qt::Key_End:
+        next = m_keys.size() - 1;
+        break;
+    case Qt::Key_Return:
+    case Qt::Key_Enter:
+    case Qt::Key_Space:
+        selectFocusKey();
+        ev->accept();
+        return;
+    default:
+        QWidget::keyPressEvent(ev);
+        return;
+    }
+
+    if (next != m_focusIdx) {
+        m_focusIdx = next;
+        update();
+        announceKey(m_focusIdx);
+    }
+    ev->accept();
+}
+
+void KeyboardMapWidget::focusInEvent(QFocusEvent* ev)
+{
+    QWidget::focusInEvent(ev);
+    update();
+    announceKey(m_focusIdx);
+}
+
+void KeyboardMapWidget::focusOutEvent(QFocusEvent* ev)
+{
+    QWidget::focusOutEvent(ev);
+    update();
+}
+
+int KeyboardMapWidget::findKeyVertical(int idx, bool up) const
+{
+    if (idx < 0 || idx >= m_keys.size()) return qMax(0, idx);
+    const KeyCap& cur = m_keys[idx];
+
+    // Collect unique row y-values
+    QVector<float> rowYs;
+    for (const auto& k : m_keys) {
+        bool found = false;
+        for (float y : rowYs) { if (qAbs(y - k.y) < 0.1f) { found = true; break; } }
+        if (!found) rowYs.append(k.y);
+    }
+    std::sort(rowYs.begin(), rowYs.end());
+
+    int curRow = -1;
+    for (int i = 0; i < rowYs.size(); ++i) {
+        if (qAbs(rowYs[i] - cur.y) < 0.1f) { curRow = i; break; }
+    }
+    int targetRow = up ? curRow - 1 : curRow + 1;
+    if (targetRow < 0 || targetRow >= rowYs.size()) return idx;
+
+    float targetY = rowYs[targetRow];
+    float curCX = cur.x + cur.w / 2.0f;
+    int bestIdx = idx;
+    float bestDist = std::numeric_limits<float>::max();
+    for (int i = 0; i < m_keys.size(); ++i) {
+        if (qAbs(m_keys[i].y - targetY) < 0.1f) {
+            float cx = m_keys[i].x + m_keys[i].w / 2.0f;
+            float dist = qAbs(cx - curCX);
+            if (dist < bestDist) { bestDist = dist; bestIdx = i; }
+        }
+    }
+    return bestIdx;
+}
+
+void KeyboardMapWidget::selectFocusKey()
+{
+    if (m_focusIdx < 0 || m_focusIdx >= m_keys.size()) return;
+    m_selectedIdx = m_focusIdx;
+    update();
+    emit keySelected(m_keys[m_focusIdx].qtKey);
+    announceKey(m_focusIdx);
+}
+
+void KeyboardMapWidget::announceKey(int idx)
+{
+    if (idx < 0 || idx >= m_keys.size()) return;
+    const KeyCap& k = m_keys[idx];
+    QKeySequence seq(k.qtKey);
+    const auto* act = m_mgr->actionForKey(seq);
+    QString desc = act
+        ? tr("%1: %2").arg(k.label, act->displayName)
+        : tr("%1: unbound").arg(k.label);
+    setAccessibleDescription(desc);
+    QAccessibleValueChangeEvent event(this, desc);
+    QAccessible::updateAccessibility(&event);
 }
 
 } // namespace AetherSDR

--- a/src/gui/KeyboardMapWidget.h
+++ b/src/gui/KeyboardMapWidget.h
@@ -29,6 +29,9 @@ protected:
     void mousePressEvent(QMouseEvent* ev) override;
     void mouseMoveEvent(QMouseEvent* ev) override;
     void leaveEvent(QEvent* ev) override;
+    void keyPressEvent(QKeyEvent* ev) override;
+    void focusInEvent(QFocusEvent* ev) override;
+    void focusOutEvent(QFocusEvent* ev) override;
 
 private:
     struct KeyCap {
@@ -43,11 +46,15 @@ private:
     void buildLayout();
     QRectF keyRect(const KeyCap& k) const;
     int hitTest(const QPoint& pos) const;
+    int findKeyVertical(int idx, bool up) const;
+    void selectFocusKey();
+    void announceKey(int idx);
 
     ShortcutManager* m_mgr;
     QVector<KeyCap> m_keys;
     int m_selectedIdx{-1};
     int m_hoverIdx{-1};
+    int m_focusIdx{0};       // keyboard-navigated key (independent of mouse selection)
     float m_keyUnit{0};     // pixel size of one key unit (computed in paintEvent)
     float m_originX{0};
     float m_originY{0};

--- a/src/gui/PhaseKnob.cpp
+++ b/src/gui/PhaseKnob.cpp
@@ -1,11 +1,29 @@
 #include "PhaseKnob.h"
 
+#include <QAccessible>
+#include <QAccessibleWidget>
 #include <QMouseEvent>
 #include <QPainter>
 #include <algorithm>
 #include <cmath>
 
 namespace AetherSDR {
+
+// PhaseKnob is a visual display only — the named ESC phase/gain sliders
+// (VfoWidget.cpp:957/982) are the accessible interface.  Returning NoRole
+// causes AT tools to skip this widget in navigation.
+class PhaseKnobAccessible : public QAccessibleWidget {
+public:
+    explicit PhaseKnobAccessible(QWidget* w) : QAccessibleWidget(w) {}
+    QAccessible::Role role() const override { return QAccessible::NoRole; }
+};
+
+static QAccessibleInterface* phaseKnobFactory(const QString& key, QObject* obj)
+{
+    if (key == QLatin1String("AetherSDR::PhaseKnob"))
+        return new PhaseKnobAccessible(qobject_cast<QWidget*>(obj));
+    return nullptr;
+}
 
 namespace {
 
@@ -25,6 +43,12 @@ PhaseKnob::PhaseKnob(QWidget* parent)
 {
     setFixedSize(120, 120);
     setCursor(Qt::CrossCursor);
+
+    static bool s_factoryInstalled = false;
+    if (!s_factoryInstalled) {
+        s_factoryInstalled = true;
+        QAccessible::installFactory(phaseKnobFactory);
+    }
 }
 
 void PhaseKnob::setPhase(float radians)


### PR DESCRIPTION
Companion to #3288 (Phase 2 accessibility), per maintainer guidance from @jensenpat. Third and final structural PR; follows #3303 (names + live events) and #3304 (VFO tab buttons).

## KeyboardMapWidget — fully keyboard-operable shortcut assignment

The shortcut dialog was previously completely inaccessible: mouse-only `hitTest()`, no focus policy, invisible to AT tools.

**Changes:**
- `setFocusPolicy(Qt::TabFocus)` — the keyboard map is now Tab-reachable
- `setAccessibleName(tr("Keyboard shortcut map"))` — widget has a name
- `keyPressEvent`:
  - Left/Right: move one key at a time in reading order
  - Up/Down: navigate to the nearest key in the row above/below (row-aware — groups keys by `y` coordinate within ±0.1 units, then finds closest `x` center in the target row)
  - Home/End: jump to first/last key
  - Space/Enter/Return: select the focused key and emit `keySelected()`
- Yellow focus ring drawn in `paintEvent` on the keyboard-navigated key (separate from the cyan selected-key highlight)
- `focusInEvent`: triggers repaint + announces current key
- `focusOutEvent`: triggers repaint to remove focus ring
- `mousePressEvent`: syncs `m_focusIdx` with `m_selectedIdx` so keyboard nav continues from the last mouse-clicked key
- `announceKey()`: sets `accessibleDescription` to `"KEY: action"` or `"KEY: unbound"` and fires `QAccessibleValueChangeEvent` — VoiceOver speaks the key label and its bound action on every navigation step

## RelayBar — keyboard-adjustable relay position

Relay bars were wheel-only, unreachable by keyboard or AT tools.

**Changes (`HGauge.h`):**
- `setFocusPolicy(Qt::TabFocus)` in constructor
- `keyPressEvent`: Up/Right/`+` emit `relayAdjusted(+1)`; Down/Left/`-` emit `relayAdjusted(-1)` — mirrors existing `wheelEvent` behavior
- `setValue()`: fires `QAccessibleValueChangeEvent` guarded by `hasFocus()` so VoiceOver announces relay position changes when the bar has focus

## PhaseKnob — excluded from accessibility tree

The PhaseKnob is a visual polar display; the named ESC phase slider ("ESC phase", `VfoWidget.cpp:957`) and ESC gain slider ("ESC gain", `VfoWidget.cpp:982`) are the correct accessible interface. Exposing PhaseKnob to AT adds duplicate, interaction-free noise.

**Change (`PhaseKnob.cpp`):**
- Installs a `QAccessibleInterface` factory (one-time via `static bool` guard) that returns a `PhaseKnobAccessible` with `role() = QAccessible::NoRole`. AT tools skip `NoRole` widgets in Tab navigation and "read all" traversal.

## Test notes

**KeyboardMapWidget:**
1. Open the Keyboard Map dialog (Shift+Ctrl+K or Preferences → Shortcuts)
2. Tab to the keyboard map widget — VoiceOver should announce "Keyboard shortcut map"
3. Press Tab to land on the map, then arrow keys to navigate — VoiceOver should announce each key label and its bound action (e.g. "F: Frequency: set frequency to VFO A")
4. Press Space or Enter on a key — should select it and open the action picker, identical to a mouse click

**RelayBar:**
1. Tab to a relay bar (C1, L, or C2) in the tuner applet
2. Up/Down keys should move the relay position just like scrolling

**PhaseKnob:**
1. Open the ESC panel (click the ESC button in a VFO widget)
2. Tab through the controls — the phase knob circle should not appear in Tab order; the "ESC phase" and "ESC gain" sliders should

— AI5OS (@w9fyi)