### PR TITLE
fix(dax): create DAX RX stream on per-slice channel (re)assignment (#2895)

### DIFF
--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -55,6 +55,13 @@ public:
     quint16 port() const;
     int clientCount() const { return m_clients.size(); }
 
+    // True if TCI currently owns or borrows a DAX RX stream on this channel
+    // (created or reused for an active audio client). Other DAX consumers —
+    // notably the DAX virtual-audio bridge — must consult this before removing
+    // a stream on the shared PanadapterStream map, so they don't silence a
+    // channel WSJT-X is decoding on (the mirror image of #3270). (#2895)
+    bool ownsDaxChannel(int channel) const { return m_tciDaxStreamIds.contains(channel); }
+
     // Snapshot of all currently connected clients (endpoint + subscriptions).
     // Cheap to call; intended for the Radio Setup → TCI tab on demand and
     // whenever clientsChanged() fires.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -16593,13 +16593,39 @@ bool MainWindow::startDax()
     // FlexLib creates streams on demand, not all 4 unconditionally.
     // Creating unused streams causes the radio to round-robin audio
     // across all of them, starving the active channels.
+    m_daxSliceLastCh.clear();
     for (auto* s : m_radioModel.slices()) {
         int ch = s->daxChannel();
+        m_daxSliceLastCh[s->sliceId()] = ch;
         if (ch >= 1 && ch <= 4) {
             m_radioModel.sendCommand(
                 QString("stream create type=dax_rx dax_channel=%1").arg(ch));
         }
     }
+
+    // #2895: the one-shot loop above only covers slices that ALREADY have a
+    // DAX channel at bridge startup (typically just slice 0 / DAX 1). When the
+    // user later assigns DAX 2-4 to another slice via the UI, SliceModel only
+    // sends `slice set <id> dax=<ch>` — it never sends `stream create
+    // type=dax_rx`, so the radio never registers a DAX client (dax_clients
+    // stays 0) and sends silence. React to per-slice channel changes here and
+    // create/remove the DAX RX stream on demand, mirroring the TCI path
+    // (TciServer::ensureDaxForTci, #1331/#1439) and FlexLib
+    // RequestDAXRXAudioStream(channel).
+    for (auto* s : m_radioModel.slices()) {
+        wireDaxSlice(s);
+    }
+    m_daxSliceConns.append(connect(&m_radioModel, &RadioModel::sliceAdded,
+                                   this, [this](SliceModel* s) {
+        if (!m_daxBridge || !s) return;
+        m_daxSliceLastCh[s->sliceId()] = s->daxChannel();
+        wireDaxSlice(s);
+        // A slice can arrive already carrying a DAX channel (radio profile
+        // restore); make sure its stream exists too.
+        if (s->daxChannel() >= 1 && s->daxChannel() <= 4) {
+            onDaxChannelChanged(s, s->daxChannel());
+        }
+    }));
 
     // Wire DAX RX: PanadapterStream routes registered DAX streams here
     connect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
@@ -16707,6 +16733,14 @@ void MainWindow::stopDax()
     m_audio->setDaxTxMode(false);
     m_audio->clearTxAccumulators();
 
+    // #2895: drop the per-slice daxChannelChanged / sliceAdded reactions wired
+    // in startDax() so they don't fire against a torn-down bridge.
+    for (const auto& c : m_daxSliceConns) {
+        disconnect(c);
+    }
+    m_daxSliceConns.clear();
+    m_daxSliceLastCh.clear();
+
     disconnect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
                m_daxBridge, nullptr);
     disconnect(m_daxBridge, &DaxBridge::txAudioReady,
@@ -16727,6 +16761,88 @@ void MainWindow::stopDax()
     delete m_daxBridge;
     m_daxBridge = nullptr;
     qInfo() << "MainWindow: stopping DAX audio bridge";
+}
+
+// #2895: connect one slice's daxChannelChanged so a DAX channel (re)assigned
+// after the bridge is already up still gets a radio-side DAX RX stream.
+void MainWindow::wireDaxSlice(SliceModel* slice)
+{
+    if (!slice) return;
+    m_daxSliceConns.append(connect(slice, &SliceModel::daxChannelChanged,
+                                   this, [this, slice](int newCh) {
+        if (!m_daxBridge) return;  // bridge torn down — ignore late signals
+        onDaxChannelChanged(slice, newCh);
+    }));
+}
+
+// Handle a slice's DAX channel transitioning. daxChannelChanged only fires on
+// an actual value change (SliceModel guards equality), and arrives from both
+// the local UI setter and the radio status echo — both are safe here because
+// the stream create is made idempotent by the daxStreamIdForChannel() guard.
+void MainWindow::onDaxChannelChanged(SliceModel* slice, int newCh)
+{
+    if (!slice || !m_daxBridge) return;
+    auto* ps = m_radioModel.panStream();
+    if (!ps) return;
+
+    const int sliceId = slice->sliceId();
+    const int oldCh = m_daxSliceLastCh.value(sliceId, 0);
+    if (oldCh == newCh) return;
+    m_daxSliceLastCh[sliceId] = newCh;
+
+    // 0 -> 1..4 (or 1..4 -> different 1..4): ensure the new channel has a
+    // radio-registered DAX RX stream. The stream status echo will register the
+    // stream id in PanadapterStream via the dax_rx handler wired in startDax().
+    if (newCh >= 1 && newCh <= 4) {
+        if (ps->daxStreamIdForChannel(newCh) == 0) {
+            m_radioModel.sendCommand(
+                QString("stream create type=dax_rx dax_channel=%1").arg(newCh));
+            qCInfo(lcDax) << "MainWindow: creating DAX RX stream for channel"
+                          << newCh << "(slice" << sliceId << ", #2895)";
+        }
+        // Re-assert slice -> DAX mapping so the radio registers our stream as a
+        // client. Without this dax_clients stays 0 and the radio sends silence
+        // (the #1439 workaround, mirrored from TciServer::ensureDaxForTci).
+        m_radioModel.sendCommand(
+            QString("slice set %1 dax=%2").arg(sliceId).arg(newCh));
+    }
+
+    // <old>:1..4 -> now released or moved: remove the old channel's stream if
+    // no other slice still references it.
+    if (oldCh >= 1 && oldCh <= 4) {
+        bool stillUsed = false;
+        for (auto* s : m_radioModel.slices()) {
+            if (s && s != slice && s->daxChannel() == oldCh) {
+                stillUsed = true;
+                break;
+            }
+        }
+        if (!stillUsed) {
+            const quint32 id = ps->daxStreamIdForChannel(oldCh);
+            // Ownership guard: the PanadapterStream DAX map is shared across
+            // every DAX consumer — the bridge, TCI (which borrows
+            // bridge-created streams, #1331/#1439), and RADE. Removing a stream
+            // another consumer is still using would silence WSJT-X or RADE
+            // audio — the mirror image of #3270. Only tear down a stream that
+            // no other consumer needs. (#2895)
+            const bool tciUsing = m_tciServer && m_tciServer->ownsDaxChannel(oldCh);
+            const bool radeUsing = (id != 0 && id == m_radeDaxStreamId);
+            if (id != 0 && !tciUsing && !radeUsing) {
+                m_radioModel.sendCommand(
+                    QString("stream remove 0x%1").arg(id, 0, 16));
+                ps->unregisterDaxStream(id);
+                qCInfo(lcDax) << "MainWindow: removed DAX RX stream"
+                              << "0x" + QString::number(id, 16)
+                              << "for channel" << oldCh << "(#2895)";
+            } else if (id != 0) {
+                qCInfo(lcDax) << "MainWindow: keeping DAX RX stream"
+                              << "0x" + QString::number(id, 16)
+                              << "for channel" << oldCh
+                              << "— still used by" << (tciUsing ? "TCI" : "RADE")
+                              << "(#2895)";
+            }
+        }
+    }
 }
 #endif
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -16618,7 +16618,9 @@ bool MainWindow::startDax()
     m_daxSliceConns.append(connect(&m_radioModel, &RadioModel::sliceAdded,
                                    this, [this](SliceModel* s) {
         if (!m_daxBridge || !s) return;
-        m_daxSliceLastCh[s->sliceId()] = s->daxChannel();
+        // Let onDaxChannelChanged() see a 0 -> channel transition for slices
+        // restored with DAX already assigned.
+        m_daxSliceLastCh[s->sliceId()] = 0;
         wireDaxSlice(s);
         // A slice can arrive already carrying a DAX channel (radio profile
         // restore); make sure its stream exists too.
@@ -16826,7 +16828,11 @@ void MainWindow::onDaxChannelChanged(SliceModel* slice, int newCh)
             // audio — the mirror image of #3270. Only tear down a stream that
             // no other consumer needs. (#2895)
             const bool tciUsing = m_tciServer && m_tciServer->ownsDaxChannel(oldCh);
+#ifdef HAVE_RADE
             const bool radeUsing = (id != 0 && id == m_radeDaxStreamId);
+#else
+            const bool radeUsing = false;
+#endif
             if (id != 0 && !tciUsing && !radeUsing) {
                 m_radioModel.sendCommand(
                     QString("stream remove 0x%1").arg(id, 0, 16));

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -855,6 +855,12 @@ private:
     QString m_savedMicSelection;  // restore on stopDax
     bool startDax();
     void stopDax();
+    // #2895: react to per-slice DAX channel (re)assignment while the bridge is
+    // up so the radio registers a DAX client for slices 1-3, not just slice 0.
+    void wireDaxSlice(SliceModel* slice);
+    void onDaxChannelChanged(SliceModel* slice, int newCh);
+    QList<QMetaObject::Connection> m_daxSliceConns;
+    QHash<int, int> m_daxSliceLastCh;  // sliceId -> last-known DAX channel
 #endif
 };
 


### PR DESCRIPTION
Fixes #2895

## Problem
`MainWindow::startDax()` only sent `stream create type=dax_rx dax_channel=N` once at bridge startup, iterating slices that *already* had a DAX channel — in practice just slice 0 / DAX 1. When the user later assigned DAX 2–4 to another slice via the UI, `SliceModel::setDaxChannel()` only sends `slice set <id> dax=<ch>` and never `stream create`, so the radio never registers a DAX client (`dax_clients` stays 0) and sends silence. Slices 1–3 were mute on Linux PipeWire (the report) and macOS. The reporter confirmed slices 1–3 DAX assignments aren't persisted, so the "assign-all-then-toggle" workaround can't work — a code fix was the only path.

## Fix
React to per-slice `daxChannelChanged` (and `RadioModel::sliceAdded`) while the bridge is up, mirroring the proven TCI path (`TciServer::ensureDaxForTci`, #1331/#1439) and FlexLib `RequestDAXRXAudioStream(channel)`:
- **0 → 1..4**: create the stream if `daxStreamIdForChannel(newCh) == 0`, then re-assert `slice set <id> dax=<newCh>` (the #1439 client-registration workaround). The status echo registers the stream in `PanadapterStream`.
- **release / move**: remove the old channel's stream when no other slice references it.
- `stopDax()` drops the new connections so late signals can't hit a torn-down bridge.

### Cross-consumer ownership guard
The `PanadapterStream` DAX map is shared across the bridge, TCI (which *borrows* bridge-created streams) and RADE. The removal path now consults `TciServer::ownsDaxChannel()` and `m_radeDaxStreamId`, so de-assigning a slice's DAX channel never tears out a stream WSJT-X or RADE is still using — the mirror image of #3270. Full consolidation of this hand-rolled coordination is tracked in #3305.

## Files
- `src/gui/MainWindow.cpp` / `.h` — `startDax()`/`stopDax()`, new `wireDaxSlice()` / `onDaxChannelChanged()`, `m_daxSliceConns` / `m_daxSliceLastCh`
- `src/core/TciServer.h` — new `ownsDaxChannel(int)` accessor

## Testing
Builds clean (macOS). Manual:
1. 2 slices (A on DAX 1, B on none); enable DAX bridge → A audio flows, `dax_clients=1` on ch 1.
2. Assign DAX 2 to slice B via UI → expect `stream create dax_channel=2` + `slice set B dax=2`, `dax_clients=1` on ch 2, audio on the previously-idle sink.
3. Re-assign B back to none → `stream remove` sent, ch 2 quiet, others keep flowing.
4. **Ownership guard:** with WSJT-X decoding on a DAX channel over TCI *and* the bridge up, de-assign that channel from the slice → WSJT-X audio keeps flowing; log shows `keeping DAX RX stream … still used by TCI`.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat