### PR TITLE
fix(spots): coalesce spot-marker rebuilds to stop multi-pan TCI freezes (#2481)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -12573,11 +12573,29 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         }
         swGuard->setSpotMarkers(markers);
     };
-    connect(spots, &SpotModel::spotAdded,   this, rebuildSpots);
-    connect(spots, &SpotModel::spotUpdated, this, rebuildSpots);
-    connect(spots, &SpotModel::spotRemoved, this, rebuildSpots);
-    connect(spots, &SpotModel::spotsCleared,this, rebuildSpots);
-    connect(spots, &SpotModel::spotsRefreshed, this, rebuildSpots);
+    // Coalesce spot-model change bursts into a single rebuild per repaint
+    // cadence (#2481). Each rebuildSpots() iterates every spot, runs a DXCC
+    // colour lookup per spot, and diffs the whole marker vector. Firing it
+    // once per incoming spot — and once per panadapter — turns two
+    // simultaneous high-rate cluster feeds (e.g. two LogHX3 Spot Machines via
+    // SpotCollector) into an O(spots x spots/sec x pans) main-thread storm
+    // that stutters the waterfall. A short single-shot timer collapses a burst
+    // of N spot signals into one rebuild. Parented to sw so it dies with the
+    // pan; QPointer in rebuildSpots already guards against a dangling widget.
+    auto* spotRebuildTimer = new QTimer(sw);
+    spotRebuildTimer->setSingleShot(true);
+    spotRebuildTimer->setInterval(50);  // ~20 Hz, below the FFT repaint cadence
+    connect(spotRebuildTimer, &QTimer::timeout, sw, rebuildSpots);
+    QPointer<QTimer> rebuildTimerGuard(spotRebuildTimer);
+    auto scheduleRebuildSpots = [rebuildTimerGuard]() {
+        if (rebuildTimerGuard && !rebuildTimerGuard->isActive())
+            rebuildTimerGuard->start();
+    };
+    connect(spots, &SpotModel::spotAdded,   this, scheduleRebuildSpots);
+    connect(spots, &SpotModel::spotUpdated, this, scheduleRebuildSpots);
+    connect(spots, &SpotModel::spotRemoved, this, scheduleRebuildSpots);
+    connect(spots, &SpotModel::spotsCleared,this, scheduleRebuildSpots);
+    connect(spots, &SpotModel::spotsRefreshed, this, scheduleRebuildSpots);
     {
         auto& s = AppSettings::instance();
         sw->setShowSpots(s.value("IsSpotsEnabled", "True").toString() == "True");


### PR DESCRIPTION
Fixes #2481

## Problem
With 2 panadapters and 2 LogHX3 logs each running Spot Machine over TCI, the waterfall intermittently froze. The reporter's isolation was decisive — disabling Spot Machine in **both** logs resolved it, and turning off the verbose logs did not. So the trigger is the **spot-marker render path on the main thread**, not the TCI audio fan-out the first triage suspected.

`wirePanadapter()` wired `rebuildSpots` directly to five `SpotModel` signals, **once per panadapter**. Every incoming spot emitted `spotAdded`/`spotUpdated`, firing `rebuildSpots`, which re-iterates *every* spot, runs `DxccColorProvider::colorForSpot()` (CTY resolution + QString allocations) per spot, and diffs the whole marker vector. Two simultaneous cluster feeds drove roughly **O(spots × spots/sec × pans)** main-thread work in bursts — the 10–170 ms paintEvent stalls seen in the support-bundle logs.

## Fix
Coalesce the five signals through a single **50 ms** (~20 Hz, below the FFT repaint cadence) single-shot timer per pan, so a burst of N spot events collapses to **one** `rebuildSpots` per pan per window instead of N × pans. Visual output is identical, just debounced. The timer is parented to the spectrum widget (per-pan lifetime) and `QPointer`-guarded, matching the sibling `rebuildTnfMarkers` pattern. No threading or signal-routing changes.

## Files
- `src/gui/MainWindow.cpp` — `wirePanadapter()` spot-signal wiring

## Structural follow-up (flagged, not done here)
`colorForSpot()` / DXCC resolution still runs on the GUI thread inside `rebuildSpots`. Moving it onto the existing `SpotClients` worker thread (PR #2420 already moved the spot *sockets* there) is the larger, structural fix and a maintainer call — deliberately left out of this contained mitigation per the autonomous-agent boundaries.

## Testing
Builds clean (985/985, macOS). Manual:
1. 2 panadapters + 2 LogHX3 logs (Spot Machine on) + 2 JTDX over TCI; let the cluster feeds run hot for several minutes.
2. Watch the waterfall for stutter and the title bar for "loose connection to radio" — both should be gone.
3. Confirm spots still appear/expire and DXCC colors render on both pans (refreshed at ≤20 Hz, visually indistinguishable).

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat