### PR TITLE
fix(gui): consistent toggle-button labeling across spot/radio dialogs (#2551)

### DIFF
--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2153,14 +2153,13 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     // ── Override Colors + color picker ──────────────────────────────────
     grid->addWidget(new QLabel("Override Colors:"), row, 0);
     auto* colorRow = new QHBoxLayout;
-    auto* overrideToggle = new QPushButton(overrideColors ? "Enabled" : "Disabled");
+    auto* overrideToggle = new QPushButton("Enabled");
     overrideToggle->setCheckable(true);
     overrideToggle->setChecked(overrideColors);
     overrideToggle->setFixedWidth(80);
     overrideToggle->setStyleSheet(
         kSpotHubToggle);
-    connect(overrideToggle, &QPushButton::toggled, this, [overrideToggle, save](bool on) {
-        overrideToggle->setText(on ? "Enabled" : "Disabled");
+    connect(overrideToggle, &QPushButton::toggled, this, [save](bool on) {
         save("IsSpotsOverrideColorsEnabled", on ? "True" : "False");
     });
     colorRow->addWidget(overrideToggle);
@@ -2237,15 +2236,14 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
 
     // ── Spot Lines ──────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Spot Lines:"), row, 0);
-    auto* spotLinesBtn = new QPushButton(spotLines ? "Enabled" : "Disabled");
+    auto* spotLinesBtn = new QPushButton("Enabled");
     spotLinesBtn->setCheckable(true);
     spotLinesBtn->setChecked(spotLines);
     spotLinesBtn->setFixedWidth(80);
     spotLinesBtn->setToolTip("Show vertical lines from the spectrum up to each spot label.\nDisable during contests to reduce clutter.");
     spotLinesBtn->setStyleSheet(
         kSpotHubToggle);
-    connect(spotLinesBtn, &QPushButton::toggled, this, [spotLinesBtn, save](bool on) {
-        spotLinesBtn->setText(on ? "Enabled" : "Disabled");
+    connect(spotLinesBtn, &QPushButton::toggled, this, [save](bool on) {
         save("IsSpotsLinesEnabled", on ? "True" : "False");
     });
     grid->addWidget(spotLinesBtn, row++, 1, Qt::AlignLeft);
@@ -2282,14 +2280,13 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         int drow = 0;
 
         bool dxccEnabled = m_dxccProvider ? m_dxccProvider->isEnabled() : false;
-        auto* dxccToggle = new QPushButton(dxccEnabled ? "Enabled" : "Disabled");
+        auto* dxccToggle = new QPushButton("Enabled");
         dxccToggle->setCheckable(true);
         dxccToggle->setChecked(dxccEnabled);
         dxccToggle->setFixedWidth(80);
         dxccToggle->setStyleSheet(
             kSpotHubToggle);
-        connect(dxccToggle, &QPushButton::toggled, this, [this, dxccToggle, save](bool on) {
-            dxccToggle->setText(on ? "Enabled" : "Disabled");
+        connect(dxccToggle, &QPushButton::toggled, this, [this, save](bool on) {
             save("IsDxccColoringEnabled", on ? "True" : "False");
             if (m_dxccProvider) m_dxccProvider->setEnabled(on);
         });
@@ -2493,7 +2490,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         // the carrier).
         const bool snapEnabled = AppSettings::instance()
             .value("SHistorySnapToStep", "False").toString() == "True";
-        auto* snapToggle = new QPushButton(snapEnabled ? "Enabled" : "Disabled");
+        auto* snapToggle = new QPushButton("Enabled");
         snapToggle->setCheckable(true);
         snapToggle->setChecked(snapEnabled);
         snapToggle->setFixedWidth(80);
@@ -2502,8 +2499,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
             "Round SHistory click-to-tune to the nearest multiple of the\n"
             "active slice's step size.  Hides the small carrier offset that\n"
             "comes from detecting voice on the panadapter.");
-        connect(snapToggle, &QPushButton::toggled, this, [snapToggle, save](bool on) {
-            snapToggle->setText(on ? "Enabled" : "Disabled");
+        connect(snapToggle, &QPushButton::toggled, this, [save](bool on) {
             save("SHistorySnapToStep", on ? "True" : "False");
         });
         shGrid->addWidget(new QLabel("Snap to Step:"), shr, 0);

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -512,13 +512,10 @@ QWidget* RadioSetupDialog::buildRadioTab()
         "border: 1px solid #20a040; }";
 
     auto makeToggle = [](bool checked) {
-        auto* btn = new QPushButton(checked ? "Enabled" : "Disabled");
+        auto* btn = new QPushButton("Enabled");
         btn->setCheckable(true);
         btn->setChecked(checked);
         btn->setStyleSheet(kToggleStyle);
-        QObject::connect(btn, &QPushButton::toggled, btn, [btn](bool on) {
-            btn->setText(on ? "Enabled" : "Disabled");
-        });
         return btn;
     };
 
@@ -994,7 +991,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
         grid->setSpacing(6);
 
         grid->addWidget(new QLabel("Enforce Private IP Connections:"), 0, 0);
-        auto* enforceBtn = new QPushButton(m_model->enforcePrivateIp() ? "Enabled" : "Disabled");
+        auto* enforceBtn = new QPushButton("Enabled");
         enforceBtn->setCheckable(true);
         enforceBtn->setChecked(m_model->enforcePrivateIp());
         AetherSDR::ThemeManager::instance().applyStyleSheet(enforceBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
@@ -1002,8 +999,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
             "border: 1px solid #20a040; }");
-        connect(enforceBtn, &QPushButton::toggled, this, [this, enforceBtn](bool on) {
-            enforceBtn->setText(on ? "Enabled" : "Disabled");
+        connect(enforceBtn, &QPushButton::toggled, this, [this](bool on) {
             m_model->sendCommand(
                 QString("radio set enforce_private_ip_connections=%1").arg(on ? 1 : 0));
         });
@@ -1354,7 +1350,7 @@ QWidget* RadioSetupDialog::buildTxTab()
         auto* swLbl = new QLabel("Show TX in Waterfall:");
         swLbl->setStyleSheet(kLabelStyle);
         grid->addWidget(swLbl, 1, 0);
-        auto* swBtn = new QPushButton(tx.showTxInWaterfall() ? "Enabled" : "Disabled");
+        auto* swBtn = new QPushButton("Enabled");
         swBtn->setCheckable(true);
         swBtn->setChecked(tx.showTxInWaterfall());
         AetherSDR::ThemeManager::instance().applyStyleSheet(swBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
@@ -1362,8 +1358,7 @@ QWidget* RadioSetupDialog::buildTxTab()
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
             "border: 1px solid #20a040; }");
-        connect(swBtn, &QPushButton::toggled, this, [this, swBtn](bool on) {
-            swBtn->setText(on ? "Enabled" : "Disabled");
+        connect(swBtn, &QPushButton::toggled, this, [this](bool on) {
             m_model->sendCommand(
                 QString("transmit set show_tx_in_waterfall=%1").arg(on ? 1 : 0));
         });
@@ -1488,9 +1483,8 @@ QWidget* RadioSetupDialog::buildPhoneCwTab()
         connect(boostBtn, &QPushButton::toggled, this, [this](bool on) {
             m_model->transmitModel().setMicBoost(on);
         });
-        auto* metBtn = mkTogBtn(tx.metInRx() ? "Enabled" : "Disabled", tx.metInRx());
-        connect(metBtn, &QPushButton::toggled, this, [this, metBtn](bool on) {
-            metBtn->setText(on ? "Enabled" : "Disabled");
+        auto* metBtn = mkTogBtn("Enabled", tx.metInRx());
+        connect(metBtn, &QPushButton::toggled, this, [this](bool on) {
             m_model->sendCommand(QString("transmit set met_in_rx=%1").arg(on ? 1 : 0));
         });
 
@@ -1513,8 +1507,7 @@ QWidget* RadioSetupDialog::buildPhoneCwTab()
         iamLbl->setStyleSheet(kLabelStyle);
         grid->addWidget(iamLbl, 0, 0);
         auto* iamBtn = mkTogBtn("Enabled", tx.cwIambic());
-        connect(iamBtn, &QPushButton::toggled, this, [this, iamBtn](bool on) {
-            iamBtn->setText(on ? "Enabled" : "Disabled");
+        connect(iamBtn, &QPushButton::toggled, this, [this](bool on) {
             m_model->sendCommand(QString("cw iambic %1").arg(on ? 1 : 0));
         });
         grid->addWidget(iamBtn, 0, 1);
@@ -1904,12 +1897,11 @@ QWidget* RadioSetupDialog::buildRxTab()
             auto* lbl = new QLabel(label);
             lbl->setStyleSheet(kLabelStyle);
             grid->addWidget(lbl, row, 0);
-            auto* btn = new QPushButton(checked ? "Enabled" : "Disabled");
+            auto* btn = new QPushButton("Enabled");
             btn->setCheckable(true);
             btn->setChecked(checked);
             btn->setStyleSheet(kTogStyle);
-            connect(btn, &QPushButton::toggled, this, [this, btn, cmd](bool on) {
-                btn->setText(on ? "Enabled" : "Disabled");
+            connect(btn, &QPushButton::toggled, this, [this, cmd](bool on) {
                 m_model->sendCommand(
                     QString("%1=%2").arg(cmd).arg(on ? 1 : 0));
             });
@@ -2230,7 +2222,7 @@ QWidget* RadioSetupDialog::buildAudioTab()
         boostLabel->setStyleSheet(kLabelStyle);
         boostLabel->setFixedWidth(90);
         bool boostOn = AppSettings::instance().value("AudioBoost", "False").toString() == "True";
-        auto* boostBtn = new QPushButton(boostOn ? "Enabled" : "Disabled");
+        auto* boostBtn = new QPushButton("Enabled");
         boostBtn->setCheckable(true);
         boostBtn->setChecked(boostOn);
         boostBtn->setToolTip("Apply 50% software gain boost to PC audio output.\n"
@@ -2240,8 +2232,7 @@ QWidget* RadioSetupDialog::buildAudioTab()
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
             "border: 1px solid #20a040; }");
-        connect(boostBtn, &QPushButton::toggled, this, [this, boostBtn](bool on) {
-            boostBtn->setText(on ? "Enabled" : "Disabled");
+        connect(boostBtn, &QPushButton::toggled, this, [this](bool on) {
             auto& s = AppSettings::instance();
             s.setValue("AudioBoost", on ? "True" : "False");
             s.save();
@@ -2716,7 +2707,7 @@ QWidget* RadioSetupDialog::buildXvtrTab()
         auto* rxOnlyLbl = new QLabel("RX Only:");
         rxOnlyLbl->setStyleSheet(kLabelStyle);
         grid->addWidget(rxOnlyLbl, 3, 2);
-        auto* rxOnlyBtn = new QPushButton(x.rxOnly ? "Enabled" : "Disabled");
+        auto* rxOnlyBtn = new QPushButton("Enabled");
         rxOnlyBtn->setCheckable(true);
         rxOnlyBtn->setChecked(x.rxOnly);
         AetherSDR::ThemeManager::instance().applyStyleSheet(rxOnlyBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
@@ -2724,8 +2715,7 @@ QWidget* RadioSetupDialog::buildXvtrTab()
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
             "border: 1px solid #20a040; }");
-        connect(rxOnlyBtn, &QPushButton::toggled, this, [this, rxOnlyBtn, idx](bool on) {
-            rxOnlyBtn->setText(on ? "Enabled" : "Disabled");
+        connect(rxOnlyBtn, &QPushButton::toggled, this, [this, idx](bool on) {
             m_model->sendCommand(
                 QString("xvtr set %1 rx_only=%2").arg(idx).arg(on ? 1 : 0));
         });

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -59,7 +59,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
 
     // ── Spots: Enabled/Disabled ─────────────────────────────────────────
     grid->addWidget(new QLabel("Spots:"), row, 0);
-    m_spotsToggle = new QPushButton(m_spotsEnabled ? "Enabled" : "Disabled");
+    m_spotsToggle = new QPushButton("Enabled");
     m_spotsToggle->setCheckable(true);
     m_spotsToggle->setChecked(m_spotsEnabled);
     m_spotsToggle->setFixedWidth(80);
@@ -68,14 +68,13 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
         "QPushButton:!checked { background: #603020; }");
     connect(m_spotsToggle, &QPushButton::toggled, this, [this, save](bool on) {
         m_spotsEnabled = on;
-        m_spotsToggle->setText(on ? "Enabled" : "Disabled");
         save("IsSpotsEnabled", on ? "True" : "False");
     });
     grid->addWidget(m_spotsToggle, row++, 1, Qt::AlignLeft);
 
     // ── Memories: Enabled/Disabled ──────────────────────────────────────
     grid->addWidget(new QLabel("Memories:"), row, 0);
-    m_memoriesToggle = new QPushButton(m_memoriesEnabled ? "Enabled" : "Disabled");
+    m_memoriesToggle = new QPushButton("Enabled");
     m_memoriesToggle->setCheckable(true);
     m_memoriesToggle->setChecked(m_memoriesEnabled);
     m_memoriesToggle->setFixedWidth(80);
@@ -86,7 +85,6 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
         "QPushButton:!checked { background: #603020; }");
     connect(m_memoriesToggle, &QPushButton::toggled, this, [this, save](bool on) {
         m_memoriesEnabled = on;
-        m_memoriesToggle->setText(on ? "Enabled" : "Disabled");
         save("IsMemorySpotsEnabled", on ? "True" : "False");
     });
     grid->addWidget(m_memoriesToggle, row++, 1, Qt::AlignLeft);
@@ -183,7 +181,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     // ── Override Colors + color picker ──────────────────────────────────
     grid->addWidget(new QLabel("Override Colors:"), row, 0);
     auto* colorRow = new QHBoxLayout;
-    m_overrideColorsToggle = new QPushButton(m_overrideColors ? "Enabled" : "Disabled");
+    m_overrideColorsToggle = new QPushButton("Enabled");
     m_overrideColorsToggle->setCheckable(true);
     m_overrideColorsToggle->setChecked(m_overrideColors);
     m_overrideColorsToggle->setFixedWidth(80);
@@ -192,7 +190,6 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
         "QPushButton:!checked { background: #603020; }");
     connect(m_overrideColorsToggle, &QPushButton::toggled, this, [this, save](bool on) {
         m_overrideColors = on;
-        m_overrideColorsToggle->setText(on ? "Enabled" : "Disabled");
         save("IsSpotsOverrideColorsEnabled", on ? "True" : "False");
     });
     colorRow->addWidget(m_overrideColorsToggle);
@@ -274,7 +271,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
 
     // ── Spot Lines ──────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Spot Lines:"), row, 0);
-    m_spotLinesToggle = new QPushButton(m_spotShowLines ? "Enabled" : "Disabled");
+    m_spotLinesToggle = new QPushButton("Enabled");
     m_spotLinesToggle->setCheckable(true);
     m_spotLinesToggle->setChecked(m_spotShowLines);
     m_spotLinesToggle->setFixedWidth(80);
@@ -284,7 +281,6 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
         "QPushButton:!checked { background: #603020; }");
     connect(m_spotLinesToggle, &QPushButton::toggled, this, [this, save](bool on) {
         m_spotShowLines = on;
-        m_spotLinesToggle->setText(on ? "Enabled" : "Disabled");
         save("IsSpotsLinesEnabled", on ? "True" : "False");
     });
     grid->addWidget(m_spotLinesToggle, row++, 1, Qt::AlignLeft);


### PR DESCRIPTION
Fixes #2551

## Problem
Toggle buttons in the **SpotHub Display** panel are inconsistent. Some flip their label between **"Enabled"** and **"Disabled"** via `setText()` in the `toggled` handler (Convention A, the anti-pattern), while the correct ones construct the button once with **"Enabled"** and signal state purely through the shared `:checked` (green `#206030`) / `:!checked` (red `#603020`) background stylesheet (Convention B). The flipping text is redundant with the color affordance, and the row `QLabel` already names the feature — so the inconsistency is pure noise. The report asked for a wider audit, which surfaced the same anti-pattern in `SpotSettingsDialog` and `RadioSetupDialog`.

## Fix
Convert every Convention-A toggle to Convention B: construct with `"Enabled"` and remove **only** the `setText(on ? "Enabled" : "Disabled")` line from the toggled lambda. No stylesheet changes — the green/red `:checked` rules already supply the state indication. Every `save()` / `sendCommand()` / member-write in those lambdas is preserved; where removing the flip left the captured `btn` pointer unused it was dropped from the capture list.

### Buttons changed (16)
- **`DxClusterDialog.cpp`** — Override Colors, Spot Lines, DXCC Colors (kept `setEnabled(on)`), Snap to Step
- **`SpotSettingsDialog.cpp`** — Spots, Memories, Override Colors, Spot Lines (each kept its member write)
- **`RadioSetupDialog.cpp`** — Level Meter in RX, Iambic, Enforce Private IP, Show TX in Waterfall, Audio Boost, XVTR RX Only, and the `makeToggle`/`addToggle` factories (each kept its radio command / setting write)

### Deliberately NOT changed
`MultiFlexDialog::m_enableBtn` is **not** this pattern — it is non-checkable, its text *and* full stylesheet (green vs red) are swapped imperatively in `refresh()` from radio state, and there is no `:checked` rule providing an independent color affordance. Stripping its `setText` would blank the button and break its coloring, so it is out of scope for this mechanical change.

## Theme-engine note
Per the maintainer's comment on the issue (this may be picked up by the theme engine): the current `ThemeManager` is a `{{color.*}}` **token-substitution** layer, not a state-driven engine — checked/unchecked color still comes from per-widget `:checked` rules. This fix removes the wrong *text* behavior independent of color and touches no stylesheet/token, so it is fully theme-compatible and these buttons would need no rework if a state-driven theme engine lands later.

## Files
- `src/gui/DxClusterDialog.cpp`, `src/gui/SpotSettingsDialog.cpp`, `src/gui/RadioSetupDialog.cpp`

## Testing
Builds clean (985/985, macOS). Manual:
1. SpotHub → Display: toggle Override Colors / Spot Lines / DXCC Colors / Snap to Step — label stays "Enabled", background green when on / dark when off; DXCC toggle still enables/disables coloring.
2. Spot Settings: toggle Spots / Memories / Override Colors / Spot Lines — label stable, color conveys state, underlying feature still reacts.
3. Radio Setup: toggle Enforce Private IP / Show TX in Waterfall / Level Meter in RX / Iambic / Mute Local / Binaural / Audio Boost / an XVTR RX Only — each keeps "Enabled" + green `:checked`, and the command/setting still fires.
4. MultiFlex enable button still flips text/color (intentionally unchanged).

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat