### PR TITLE
fix(cw): Zero Beat tunes the slice that owns the button, never the active one (#2516)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -13512,9 +13512,19 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
         if (m_radioModel.slice(sliceId))
             m_radioModel.cwAutoTuneOnce(sliceId);
     });
-    connect(w, &VfoWidget::zeroBeatRequested, this, [this]() {
-        SliceModel* slice = activeSlice();
+    connect(w, &VfoWidget::zeroBeatRequested, this, [this, sliceId]() {
+        // #2516: act on the slice that owns the clicked VfoWidget, NOT the
+        // active slice — otherwise pressing Zero Beat on slice A while slice
+        // B is active would tune B.
+        SliceModel* slice = m_radioModel.slice(sliceId);
         if (!slice) return;
+        // The shared CW decoder is fed by the active slice's audio and its
+        // estimatedPitch() re-routes per active slice (see routeCwDecoderOutput()).
+        // The detected pitch is therefore only meaningful for the active slice,
+        // so refuse to apply it to a non-active slice rather than tuning on a
+        // pitch that belongs to a different slice's audio.
+        SliceModel* active = activeSlice();
+        if (!active || active->sliceId() != sliceId) return;
         float detected = m_cwDecoder.estimatedPitch();
         if (detected <= 0.0f) return;
         int configured = m_radioModel.transmitModel().cwPitch();


### PR DESCRIPTION
Fixes #2516

## Problem
Pressing **Zero Beat** on Slice A's VFO could tune **Slice B** instead. The `zeroBeatRequested` handler operated on `activeSlice()` rather than the slice that owns the `VfoWidget` that emitted the signal. The signal carries no `sliceId`, and clicking the Zero Beat child `QPushButton` is consumed by the button so it does **not** propagate to the panel's `mousePressEvent` activation hook — so pressing Zero Beat on Slice A does not activate Slice A first. If Slice B was the active slice (e.g. most-recently focused on another pan/band), Slice B got tuned — exactly the report ("Slice B VFO moves on two different bands").

The sibling autotune handlers right above it already do this correctly by capturing `sliceId` and resolving `m_radioModel.slice(sliceId)`.

## Fix
Capture `sliceId` (matching the autotune handlers) and resolve the owning slice via `m_radioModel.slice(sliceId)`. Additionally short-circuit when that slice is **not the active one**:

```cpp
connect(w, &VfoWidget::zeroBeatRequested, this, [this, sliceId]() {
    SliceModel* slice = m_radioModel.slice(sliceId);
    if (!slice) return;
    SliceModel* active = activeSlice();
    if (!active || active->sliceId() != sliceId) return;  // pitch valid only for active slice
    ...
});
```

### Why the active-slice guard is required
The shared `m_cwDecoder` is fed only by the **active** slice's audio, and its `estimatedPitch()` re-routes per active slice (`routeCwDecoderOutput()` / `setActiveSliceInternal`). So the detected pitch is only meaningful for the active slice — retargeting the tune to the button's slice while it is *not* active would apply a different slice's audio pitch to this slice's frequency, still wrong. The guard makes Zero Beat on a non-active slice a **safe no-op** rather than a wrong tune. The hard requirement is met two ways: it only ever resolves the tune against the button's own `sliceId`, and it bails unless that slice is also active.

Does not touch slice 0 RX flow.

## UX decision
This is the minimal correctness fix. Two UX alternatives — (a) activate the clicked slice first, defer one tick so the decoder re-routes, then tune; (b) disable the Zero Beat button in `VfoWidget` when its slice is inactive — were considered. The maintainer opted to keep the silent no-op for now, so they are intentionally **not** included here.

## Files
- `src/gui/MainWindow.cpp` — `zeroBeatRequested` handler in `wireVfoWidget`

## Testing
Builds clean (985/985, macOS). Manual:
1. Two pans; slices A and B on different bands, both CW. Make **B** active; ensure a detectable CW tone on A.
2. Press Zero Beat on **A**'s VFO → neither slice moves (safe no-op), and critically **B does not move** (previously it would have).
3. Make **A** active with a CW signal present; press Zero Beat on A → A tunes to zero-beat. Normal single-active-slice behavior is unchanged.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat