### PR TITLE
fix(transmit): route Quindar outro timer through dispatchMoxOff()

### DIFF
--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -839,6 +839,15 @@ void TransmitModel::cancelPendingQuindarOff()
     m_quindarOutroInFlight = false;
 }
 
+void TransmitModel::dispatchMoxOff()
+{
+    if (m_pttOffHook) {
+        m_pttOffHook();
+        return;
+    }
+    setMox(false);
+}
+
 void TransmitModel::requestPttOn(PttSource source)
 {
     if (!runPttPreflight(source))
@@ -890,11 +899,7 @@ void TransmitModel::requestPttOff(PttSource /*source*/)
         || tone->phase() == ClientQuindarTone::Phase::Idle
         || m_quindarOutroInFlight) {
         cancelPendingQuindarOff();
-        if (m_pttOffHook) {
-            m_pttOffHook();
-            return;
-        }
-        setMox(false);
+        dispatchMoxOff();
         return;
     }
 
@@ -917,7 +922,7 @@ void TransmitModel::requestPttOff(PttSource /*source*/)
         m_pendingMoxOffTimer = nullptr;
         m_quindarOutroInFlight = false;
         emit quindarActiveChanged(false);
-        setMox(false);
+        dispatchMoxOff();
     });
     m_pendingMoxOffTimer->start();
 }

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -269,6 +269,7 @@ private:
     bool isPhoneModeForQuindar() const;
     bool runPttPreflight(PttSource source, bool resyncMoxOnBlock = true);
     void cancelPendingQuindarOff();
+    void dispatchMoxOff();
 
     // PTT coordinator state (#2262)
     class ClientQuindarTone* m_quindarTone{nullptr};


### PR DESCRIPTION
## Summary

Closes #3224.

`TransmitModel::requestPttOff()` had two exit paths that reach `setMox(false)`:

1. **Synchronous bypass path** — when Quindar is disabled, not in a phone mode, or
   the outro is already in flight. This path correctly consulted `m_pttOffHook`
   before dropping MOX.

2. **Quindar outro timer callback** — when the outro tone must play to completion
   before the carrier drops. This path called `setMox(false)` directly, silently
   bypassing any installed `PttOffHook`.

### Fix

Extract a private `dispatchMoxOff()` helper that owns the hook-or-setMox decision
and route both call sites through it. As a bonus, the previously inline hook check
in the synchronous path is replaced by the single `dispatchMoxOff()` call.

### Impact today

Latent — RADE (the only current `PttOffHook` consumer) uses DIGU/DIGL, which
`isPhoneModeForQuindar()` excludes, so the timer path cannot fire while RADE's
hook is installed. No user-observable behaviour changes.

### Why it still matters

FreeDV modes (FDV/FDVU/FDVL) are already in the `isPhoneModeForQuindar()` allowlist.
Any future FreeDV EOO hook wired through `setPttOffHook()` would be silently bypassed
the moment a Quindar-enabled user releases PTT — no additional configuration change
required. The fix eliminates that foot-gun before the wiring is ever attempted.

## Test plan

- [ ] SSB TX with Quindar enabled: outro tone plays, carrier drops normally (no hook
      installed — exercises `dispatchMoxOff()` → `setMox(false)` path)
- [ ] RADE TX: EOO sequence completes and carrier drops (sync path, unchanged — hook
      fires as before via the sync branch)
- [ ] SSB TX with Quindar disabled: carrier drops immediately (no regression)

## Refs

- Issue #3224
- PR #3221 — original RADE unified TX pipeline that introduced `PttOffHook`
- `TransmitModel.cpp:842` — new `dispatchMoxOff()` helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)