### PR TITLE
fix(transmit): exclude FreeDV modes from Quindar tone allowlist

### DIFF
--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -798,12 +798,14 @@ bool TransmitModel::isPhoneModeForQuindar() const
 {
     if (!m_txModeGetter) return false;
     const QString m = m_txModeGetter();
-    // Phone modes accepted for Quindar: SSB families, AM, FM, FreeDV.
-    // Digital (DIGU/DIGL/RTTY/CW/FT8) intentionally excluded — the
-    // tone would corrupt the digital waveform.
+    // Phone modes accepted for Quindar: SSB families, AM, FM.
+    // Digital modes intentionally excluded — the tone would corrupt the
+    // digital waveform. FreeDV (FDV/FDVU/FDVL) is excluded for the same
+    // reason: it now uses RADAE (the same neural encoder as RADE mode),
+    // so a Quindar sine produces codec-artifact noise on air rather than
+    // a recognisable signalling tone.
     return m == "USB" || m == "LSB"
-        || m == "AM"  || m == "FM"  || m == "NFM"
-        || m == "FDV" || m == "FDVU" || m == "FDVL";
+        || m == "AM"  || m == "FM"  || m == "NFM";
 }
 
 bool TransmitModel::runPttPreflight(PttSource source, bool resyncMoxOnBlock)


### PR DESCRIPTION
## Summary

Closes #3318.

`isPhoneModeForQuindar()` previously allowed Quindar intro/outro tones to fire in
FreeDV modes (FDV, FDVU, FDVL). FreeDV now uses RADAE — the same neural speech
autoencoder as RADE mode. The Quindar tone is injected into the TX audio stream
before it reaches the radio, where the radio's internal RADAE encoder processes it.
A 2525/2475 Hz sine fed into a neural encoder trained on speech produces
codec-artifact noise on air, not a recognisable signalling tone.

RADE mode was already correctly excluded (it uses DIGU/DIGL, never in the allowlist).
FreeDV was explicitly included, likely when FreeDV still used Codec2. This removes
the three FreeDV mode strings and updates the comment to explain the RADAE connection.

### Impact

No user-visible Quindar behaviour was working correctly in FreeDV modes before this
change — the tone was being mangled by RADAE before transmission. This removes a
broken feature, not a working one.

SSB/AM/FM Quindar behaviour is unchanged.

## Test plan

- [ ] SSB TX with Quindar enabled: intro/outro tones fire normally (no regression)
- [ ] FreeDV TX with Quindar enabled: no Quindar tones fire (expected new behaviour)

## Refs

- Issue #3318
- PR #3317 — `dispatchMoxOff()` refactor where this was surfaced
- `TransmitModel.cpp::isPhoneModeForQuindar()` — the only function changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)