### PR TITLE
feat(peripherals): auto-reconnect PGXL/TGXL/AG on unexpected connection drop

### DIFF
--- a/src/core/PeripheralSettings.h
+++ b/src/core/PeripheralSettings.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "core/AppSettings.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QJsonValue>
+#include <QString>
+
+namespace AetherSDR {
+
+// Peripherals feature settings live in one nested AppSettings JSON blob per
+// constitution Principle V. The temporary flat key from PR #3321 is migrated
+// so testers of the PR branch keep their selected behavior.
+class PeripheralSettings {
+public:
+    static bool autoReconnect()
+    {
+        const QJsonObject obj = readObj();
+        const QJsonValue value = obj.value(QStringLiteral("AutoReconnect"));
+        if (value.isBool()) {
+            return value.toBool();
+        }
+        return value.toString(QStringLiteral("False"))
+            .compare(QStringLiteral("True"), Qt::CaseInsensitive) == 0;
+    }
+
+    static void setAutoReconnect(bool on)
+    {
+        QJsonObject obj = readObj();
+        obj[QStringLiteral("AutoReconnect")] =
+            on ? QStringLiteral("True") : QStringLiteral("False");
+        write(obj);
+    }
+
+    static void migrateLegacy()
+    {
+        auto& settings = AppSettings::instance();
+        constexpr const char* kLegacyKey = "Peripherals_AutoReconnect";
+        if (!settings.contains(kLegacyKey)) {
+            return;
+        }
+
+        if (!settings.contains(kRootKey)) {
+            const bool legacyOn = settings.value(kLegacyKey, QStringLiteral("False"))
+                .toString()
+                .compare(QStringLiteral("True"), Qt::CaseInsensitive) == 0;
+            QJsonObject obj;
+            obj[QStringLiteral("AutoReconnect")] =
+                legacyOn ? QStringLiteral("True") : QStringLiteral("False");
+            settings.setValue(kRootKey,
+                              QString::fromUtf8(
+                                  QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+        }
+        settings.remove(kLegacyKey);
+        settings.save();
+    }
+
+private:
+    static constexpr const char* kRootKey = "Peripherals";
+
+    static QJsonObject readObj()
+    {
+        migrateLegacy();
+
+        const QString json =
+            AppSettings::instance().value(kRootKey, QString{}).toString();
+        if (json.isEmpty()) {
+            return {};
+        }
+
+        QJsonParseError error{};
+        const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8(), &error);
+        if (error.error != QJsonParseError::NoError || !doc.isObject()) {
+            return {};
+        }
+        return doc.object();
+    }
+
+    static void write(const QJsonObject& obj)
+    {
+        auto& settings = AppSettings::instance();
+        settings.setValue(kRootKey,
+                          QString::fromUtf8(
+                              QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+        settings.remove(QStringLiteral("Peripherals_AutoReconnect"));
+        settings.save();
+    }
+};
+
+} // namespace AetherSDR

--- a/src/core/PgxlConnection.cpp
+++ b/src/core/PgxlConnection.cpp
@@ -13,11 +13,28 @@ PgxlConnection::PgxlConnection(QObject* parent)
 
     m_pollTimer.setInterval(200);  // 5 Hz for responsive metering
     connect(&m_pollTimer, &QTimer::timeout, this, &PgxlConnection::pollStatus);
+
+    m_reconnectTimer.setSingleShot(true);
+    m_reconnectTimer.setInterval(5000);
+    connect(&m_reconnectTimer, &QTimer::timeout, this, [this]() {
+        if (!m_connected && !m_lastHost.isEmpty())
+            connectToPgxl(m_lastHost, m_lastPort);
+    });
 }
 
 void PgxlConnection::connectToPgxl(const QString& host, quint16 port)
 {
-    if (m_connected) disconnect();
+    m_lastHost = host;
+    m_lastPort = port;
+    m_deliberateDisconnect = false;
+    m_reconnectTimer.stop();
+    if (m_connected) {
+        m_deliberateDisconnect = true;
+        m_pollTimer.stop();
+        m_connected = false;
+        m_socket.abort();  // synchronous — onDisconnected will not fire
+        m_deliberateDisconnect = false;
+    }
     m_seq = 0;
     m_gotVersion = false;
     m_version.clear();
@@ -28,6 +45,8 @@ void PgxlConnection::connectToPgxl(const QString& host, quint16 port)
 
 void PgxlConnection::disconnect()
 {
+    m_deliberateDisconnect = true;
+    m_reconnectTimer.stop();
     m_pollTimer.stop();
     m_connected = false;
     m_socket.disconnectFromHost();
@@ -44,6 +63,9 @@ void PgxlConnection::onDisconnected()
     m_pollTimer.stop();
     m_connected = false;
     emit disconnected();
+    if (!m_deliberateDisconnect && m_autoReconnect && !m_lastHost.isEmpty())
+        m_reconnectTimer.start();
+    m_deliberateDisconnect = false;
 }
 
 void PgxlConnection::onError(QAbstractSocket::SocketError error)

--- a/src/core/PgxlConnection.cpp
+++ b/src/core/PgxlConnection.cpp
@@ -19,8 +19,9 @@ PgxlConnection::PgxlConnection(QObject* parent)
     m_reconnectTimer.setSingleShot(true);
     m_reconnectTimer.setInterval(5000);
     connect(&m_reconnectTimer, &QTimer::timeout, this, [this]() {
-        if (!m_connected && !m_lastHost.isEmpty())
+        if (!m_connected && !m_lastHost.isEmpty()) {
             connectToPgxl(m_lastHost, m_lastPort);
+        }
     });
 }
 
@@ -65,8 +66,9 @@ void PgxlConnection::onDisconnected()
     m_pollTimer.stop();
     m_connected = false;
     emit disconnected();
-    if (!m_deliberateDisconnect && m_autoReconnect && !m_lastHost.isEmpty())
+    if (!m_deliberateDisconnect && m_autoReconnect && !m_lastHost.isEmpty()) {
         m_reconnectTimer.start();
+    }
     m_deliberateDisconnect = false;
 }
 
@@ -79,8 +81,9 @@ void PgxlConnection::onError(QAbstractSocket::SocketError error)
     // the device returns or the user disconnects. isActive() prevents double-arm
     // when a live drop emits both errorOccurred and disconnected.
     if (!m_deliberateDisconnect && m_autoReconnect && !m_connected
-            && !m_lastHost.isEmpty() && !m_reconnectTimer.isActive())
+            && !m_lastHost.isEmpty() && !m_reconnectTimer.isActive()) {
         m_reconnectTimer.start();
+    }
 }
 
 void PgxlConnection::onReadyRead()

--- a/src/core/PgxlConnection.cpp
+++ b/src/core/PgxlConnection.cpp
@@ -14,6 +14,8 @@ PgxlConnection::PgxlConnection(QObject* parent)
     m_pollTimer.setInterval(200);  // 5 Hz for responsive metering
     connect(&m_pollTimer, &QTimer::timeout, this, &PgxlConnection::pollStatus);
 
+    // Retries every 5s indefinitely until the device returns or the user disconnects.
+    // This is intentional for a LAN peripheral that may be power-cycling.
     m_reconnectTimer.setSingleShot(true);
     m_reconnectTimer.setInterval(5000);
     connect(&m_reconnectTimer, &QTimer::timeout, this, [this]() {
@@ -72,6 +74,13 @@ void PgxlConnection::onError(QAbstractSocket::SocketError error)
 {
     qCWarning(lcTuner) << "PgxlConnection: socket error" << error
                         << m_socket.errorString();
+    // A failed reconnect attempt arrives here (not via onDisconnected) because
+    // the socket never reached ConnectedState. Re-arm so we keep retrying until
+    // the device returns or the user disconnects. isActive() prevents double-arm
+    // when a live drop emits both errorOccurred and disconnected.
+    if (!m_deliberateDisconnect && m_autoReconnect && !m_connected
+            && !m_lastHost.isEmpty() && !m_reconnectTimer.isActive())
+        m_reconnectTimer.start();
 }
 
 void PgxlConnection::onReadyRead()

--- a/src/core/PgxlConnection.h
+++ b/src/core/PgxlConnection.h
@@ -26,6 +26,8 @@ public:
     void connectToPgxl(const QString& host, quint16 port = 9008);
     void disconnect();
 
+    void setAutoReconnect(bool on) { m_autoReconnect = on; }
+
     quint32 sendCommand(const QString& cmd);
 
 signals:
@@ -45,11 +47,16 @@ private:
 
     QTcpSocket m_socket;
     QTimer     m_pollTimer;
+    QTimer     m_reconnectTimer;
     QByteArray m_readBuf;
     quint32    m_seq{0};
     bool       m_connected{false};
     bool       m_gotVersion{false};
+    bool       m_autoReconnect{false};
+    bool       m_deliberateDisconnect{false};
     QString    m_version;
+    QString    m_lastHost;
+    quint16    m_lastPort{9008};
 };
 
 } // namespace AetherSDR

--- a/src/core/TgxlConnection.cpp
+++ b/src/core/TgxlConnection.cpp
@@ -13,10 +13,21 @@ TgxlConnection::TgxlConnection(QObject* parent)
 
     m_pollTimer.setInterval(1000);
     connect(&m_pollTimer, &QTimer::timeout, this, &TgxlConnection::pollStatus);
+
+    m_reconnectTimer.setSingleShot(true);
+    m_reconnectTimer.setInterval(5000);
+    connect(&m_reconnectTimer, &QTimer::timeout, this, [this]() {
+        if (!m_connected && !m_lastHost.isEmpty())
+            connectToTgxl(m_lastHost, m_lastPort);
+    });
 }
 
 void TgxlConnection::connectToTgxl(const QString& host, quint16 port)
 {
+    m_lastHost = host;
+    m_lastPort = port;
+    m_deliberateDisconnect = false;
+    m_reconnectTimer.stop();
     // Abort any pending or active connection before starting a new one (#1039)
     m_pollTimer.stop();
     m_connected = false;
@@ -31,6 +42,8 @@ void TgxlConnection::connectToTgxl(const QString& host, quint16 port)
 
 void TgxlConnection::disconnect()
 {
+    m_deliberateDisconnect = true;
+    m_reconnectTimer.stop();
     m_pollTimer.stop();
     m_connected = false;
     m_socket.disconnectFromHost();
@@ -48,6 +61,9 @@ void TgxlConnection::onDisconnected()
     m_pollTimer.stop();
     m_connected = false;
     emit disconnected();
+    if (!m_deliberateDisconnect && m_autoReconnect && !m_lastHost.isEmpty())
+        m_reconnectTimer.start();
+    m_deliberateDisconnect = false;
 }
 
 void TgxlConnection::onError(QAbstractSocket::SocketError error)

--- a/src/core/TgxlConnection.cpp
+++ b/src/core/TgxlConnection.cpp
@@ -14,6 +14,8 @@ TgxlConnection::TgxlConnection(QObject* parent)
     m_pollTimer.setInterval(1000);
     connect(&m_pollTimer, &QTimer::timeout, this, &TgxlConnection::pollStatus);
 
+    // Retries every 5s indefinitely until the device returns or the user disconnects.
+    // This is intentional for a LAN peripheral that may be power-cycling.
     m_reconnectTimer.setSingleShot(true);
     m_reconnectTimer.setInterval(5000);
     connect(&m_reconnectTimer, &QTimer::timeout, this, [this]() {
@@ -71,6 +73,13 @@ void TgxlConnection::onError(QAbstractSocket::SocketError error)
     qCWarning(lcTuner) << "TgxlConnection: socket error" << error
                         << m_socket.errorString();
     emit connectionFailed(m_socket.errorString());
+    // A failed reconnect attempt arrives here (not via onDisconnected) because
+    // the socket never reached ConnectedState. Re-arm so we keep retrying until
+    // the device returns or the user disconnects. isActive() prevents double-arm
+    // when a live drop emits both errorOccurred and disconnected.
+    if (!m_deliberateDisconnect && m_autoReconnect && !m_connected
+            && !m_lastHost.isEmpty() && !m_reconnectTimer.isActive())
+        m_reconnectTimer.start();
 }
 
 void TgxlConnection::onReadyRead()

--- a/src/core/TgxlConnection.cpp
+++ b/src/core/TgxlConnection.cpp
@@ -19,8 +19,9 @@ TgxlConnection::TgxlConnection(QObject* parent)
     m_reconnectTimer.setSingleShot(true);
     m_reconnectTimer.setInterval(5000);
     connect(&m_reconnectTimer, &QTimer::timeout, this, [this]() {
-        if (!m_connected && !m_lastHost.isEmpty())
+        if (!m_connected && !m_lastHost.isEmpty()) {
             connectToTgxl(m_lastHost, m_lastPort);
+        }
     });
 }
 
@@ -63,8 +64,9 @@ void TgxlConnection::onDisconnected()
     m_pollTimer.stop();
     m_connected = false;
     emit disconnected();
-    if (!m_deliberateDisconnect && m_autoReconnect && !m_lastHost.isEmpty())
+    if (!m_deliberateDisconnect && m_autoReconnect && !m_lastHost.isEmpty()) {
         m_reconnectTimer.start();
+    }
     m_deliberateDisconnect = false;
 }
 
@@ -78,8 +80,9 @@ void TgxlConnection::onError(QAbstractSocket::SocketError error)
     // the device returns or the user disconnects. isActive() prevents double-arm
     // when a live drop emits both errorOccurred and disconnected.
     if (!m_deliberateDisconnect && m_autoReconnect && !m_connected
-            && !m_lastHost.isEmpty() && !m_reconnectTimer.isActive())
+            && !m_lastHost.isEmpty() && !m_reconnectTimer.isActive()) {
         m_reconnectTimer.start();
+    }
 }
 
 void TgxlConnection::onReadyRead()

--- a/src/core/TgxlConnection.h
+++ b/src/core/TgxlConnection.h
@@ -33,6 +33,8 @@ public:
     void connectToTgxl(const QString& host, quint16 port = 9010);
     void disconnect();
 
+    void setAutoReconnect(bool on) { m_autoReconnect = on; }
+
     // Manual relay adjustment: relay 0=C1, 1=L, 2=C2; direction +1 or -1
     void adjustRelay(int relay, int direction);
 
@@ -64,11 +66,16 @@ private:
 
     QTcpSocket m_socket;
     QTimer     m_pollTimer;       // 1/sec status poll
+    QTimer     m_reconnectTimer;
     QByteArray m_readBuf;
     quint32    m_seq{0};
     bool       m_connected{false};
     bool       m_gotVersion{false};
+    bool       m_autoReconnect{false};
+    bool       m_deliberateDisconnect{false};
     QString    m_version;
+    QString    m_lastHost;
+    quint16    m_lastPort{9010};
 };
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3557,6 +3557,14 @@ MainWindow::MainWindow(QWidget* parent)
             m_tgxlConn.disconnect();
         }
     });
+    // Apply auto-reconnect setting at startup so it's active before any connection is made
+    {
+        bool ar = (AppSettings::instance().value("Peripherals_AutoReconnect", "false").toString() == "true");
+        m_tgxlConn.setAutoReconnect(ar);
+        m_pgxlConn.setAutoReconnect(ar);
+        m_antennaGenius.setAutoReconnect(ar);
+    }
+
     // Wire TgxlConnection to TunerModel
     m_radioModel.tunerModel().setDirectConnection(&m_tgxlConn);
     // Also attempt connection when TGXL IP arrives (may come after presence)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -18,6 +18,7 @@
 #include "core/CommandParser.h"
 #include "core/LogManager.h"
 #include "core/PerfTelemetry.h"
+#include "core/PeripheralSettings.h"
 #include "core/VoiceSignalDetector.h"
 #include "core/MemoryRecallPolicy.h"
 #include "core/StreamStatus.h"
@@ -3559,7 +3560,7 @@ MainWindow::MainWindow(QWidget* parent)
     });
     // Apply auto-reconnect setting at startup so it's active before any connection is made
     {
-        bool ar = (AppSettings::instance().value("Peripherals_AutoReconnect", "false").toString() == "true");
+        const bool ar = PeripheralSettings::autoReconnect();
         m_tgxlConn.setAutoReconnect(ar);
         m_pgxlConn.setAutoReconnect(ar);
         m_antennaGenius.setAutoReconnect(ar);
@@ -10315,7 +10316,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
             }
 #endif
             // Propagate auto-reconnect setting to all peripheral connections
-            bool autoReconnect = (cs.value("Peripherals_AutoReconnect", "false").toString() == "true");
+            const bool autoReconnect = PeripheralSettings::autoReconnect();
             m_tgxlConn.setAutoReconnect(autoReconnect);
             m_pgxlConn.setAutoReconnect(autoReconnect);
             m_antennaGenius.setAutoReconnect(autoReconnect);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10306,6 +10306,12 @@ void MainWindow::onConnectionStateChanged(bool connected)
                     QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->startConnection(); });
             }
 #endif
+            // Propagate auto-reconnect setting to all peripheral connections
+            bool autoReconnect = (cs.value("Peripherals_AutoReconnect", "false").toString() == "true");
+            m_tgxlConn.setAutoReconnect(autoReconnect);
+            m_pgxlConn.setAutoReconnect(autoReconnect);
+            m_antennaGenius.setAutoReconnect(autoReconnect);
+
             // Auto-connect peripherals with manual IPs (#914)
             QString tgxlIp = cs.value("TGXL_ManualIp", "").toString();
             if (!tgxlIp.isEmpty() && !m_tgxlConn.isConnected()) {

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4686,9 +4686,15 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
     connect(reconnectCheck, &QCheckBox::toggled, this, [this](bool on) {
         PeripheralSettings::setAutoReconnect(on);
         // Propagate immediately to live connection objects
-        if (m_tgxl) m_tgxl->setAutoReconnect(on);
-        if (m_pgxl) m_pgxl->setAutoReconnect(on);
-        if (m_ag)   m_ag->setAutoReconnect(on);
+        if (m_tgxl) {
+            m_tgxl->setAutoReconnect(on);
+        }
+        if (m_pgxl) {
+            m_pgxl->setAutoReconnect(on);
+        }
+        if (m_ag) {
+            m_ag->setAutoReconnect(on);
+        }
     });
     vbox->addWidget(reconnectCheck);
 

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4682,9 +4682,13 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
         "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }");
     bool autoReconnect = (AppSettings::instance().value("Peripherals_AutoReconnect", "false").toString() == "true");
     reconnectCheck->setChecked(autoReconnect);
-    connect(reconnectCheck, &QCheckBox::toggled, this, [](bool on) {
+    connect(reconnectCheck, &QCheckBox::toggled, this, [this](bool on) {
         AppSettings::instance().setValue("Peripherals_AutoReconnect", on ? "true" : "false");
         AppSettings::instance().save();
+        // Propagate immediately to live connection objects
+        if (m_tgxl) m_tgxl->setAutoReconnect(on);
+        if (m_pgxl) m_pgxl->setAutoReconnect(on);
+        if (m_ag)   m_ag->setAutoReconnect(on);
     });
     vbox->addWidget(reconnectCheck);
 

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4676,6 +4676,18 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
 
     vbox->addWidget(group);
 
+    // Auto-reconnect checkbox
+    auto* reconnectCheck = new QCheckBox("Auto-reconnect to peripherals on connection drop");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(reconnectCheck,
+        "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }");
+    bool autoReconnect = (AppSettings::instance().value("Peripherals_AutoReconnect", "false").toString() == "true");
+    reconnectCheck->setChecked(autoReconnect);
+    connect(reconnectCheck, &QCheckBox::toggled, this, [](bool on) {
+        AppSettings::instance().setValue("Peripherals_AutoReconnect", on ? "true" : "false");
+        AppSettings::instance().save();
+    });
+    vbox->addWidget(reconnectCheck);
+
     // Info note
     auto* note = new QLabel(
         "Configure manual IP addresses for peripherals that cannot be discovered via UDP broadcast.\n"

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -7,6 +7,7 @@
 #include "models/XvtrPolicy.h"
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
+#include "core/PeripheralSettings.h"
 #include <QApplication>
 #include <QSysInfo>
 #include "core/AudioEngine.h"
@@ -4680,11 +4681,10 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
     auto* reconnectCheck = new QCheckBox("Auto-reconnect to peripherals on connection drop");
     AetherSDR::ThemeManager::instance().applyStyleSheet(reconnectCheck,
         "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }");
-    bool autoReconnect = (AppSettings::instance().value("Peripherals_AutoReconnect", "false").toString() == "true");
+    const bool autoReconnect = PeripheralSettings::autoReconnect();
     reconnectCheck->setChecked(autoReconnect);
     connect(reconnectCheck, &QCheckBox::toggled, this, [this](bool on) {
-        AppSettings::instance().setValue("Peripherals_AutoReconnect", on ? "true" : "false");
-        AppSettings::instance().save();
+        PeripheralSettings::setAutoReconnect(on);
         // Propagate immediately to live connection objects
         if (m_tgxl) m_tgxl->setAutoReconnect(on);
         if (m_pgxl) m_pgxl->setAutoReconnect(on);

--- a/src/models/AntennaGeniusModel.cpp
+++ b/src/models/AntennaGeniusModel.cpp
@@ -32,8 +32,9 @@ AntennaGeniusModel::AntennaGeniusModel(QObject* parent)
     m_reconnectTimer->setSingleShot(true);
     m_reconnectTimer->setInterval(5000);
     connect(m_reconnectTimer, &QTimer::timeout, this, [this]() {
-        if (!m_connected && m_device.port > 0 && !m_device.ip.isNull())
+        if (!m_connected && m_device.port > 0 && !m_device.ip.isNull()) {
             connectToDevice(m_device);
+        }
     });
 }
 
@@ -225,7 +226,9 @@ quint16 AntennaGeniusModel::peerPort() const
 void AntennaGeniusModel::disconnectFromDevice()
 {
     m_deliberateDisconnect = true;
-    if (m_reconnectTimer) m_reconnectTimer->stop();
+    if (m_reconnectTimer) {
+        m_reconnectTimer->stop();
+    }
     if (m_keepAlive) {
         m_keepAlive->stop();
         delete m_keepAlive;
@@ -295,8 +298,9 @@ void AntennaGeniusModel::onTcpError()
     // when a live drop emits both errorOccurred and disconnected.
     if (!m_deliberateDisconnect && m_autoReconnect && !m_connected
             && m_device.port > 0 && !m_device.ip.isNull()
-            && m_reconnectTimer && !m_reconnectTimer->isActive())
+            && m_reconnectTimer && !m_reconnectTimer->isActive()) {
         m_reconnectTimer->start();
+    }
 }
 
 void AntennaGeniusModel::onTcpReadyRead()

--- a/src/models/AntennaGeniusModel.cpp
+++ b/src/models/AntennaGeniusModel.cpp
@@ -25,6 +25,14 @@ AntennaGeniusModel::AntennaGeniusModel(QObject* parent)
 {
     m_portA.portId = 1;
     m_portB.portId = 2;
+
+    m_reconnectTimer = new QTimer(this);
+    m_reconnectTimer->setSingleShot(true);
+    m_reconnectTimer->setInterval(5000);
+    connect(m_reconnectTimer, &QTimer::timeout, this, [this]() {
+        if (!m_connected && m_device.port > 0 && !m_device.ip.isNull())
+            connectToDevice(m_device);
+    });
 }
 
 AntennaGeniusModel::~AntennaGeniusModel()
@@ -214,6 +222,8 @@ quint16 AntennaGeniusModel::peerPort() const
 
 void AntennaGeniusModel::disconnectFromDevice()
 {
+    m_deliberateDisconnect = true;
+    if (m_reconnectTimer) m_reconnectTimer->stop();
     if (m_keepAlive) {
         m_keepAlive->stop();
         delete m_keepAlive;
@@ -228,6 +238,7 @@ void AntennaGeniusModel::disconnectFromDevice()
         m_connected = false;
         emit disconnected();
     }
+    m_deliberateDisconnect = false;
     m_antennas.clear();
     m_bands.clear();
     m_portA = AgPortStatus{1};
@@ -255,6 +266,7 @@ void AntennaGeniusModel::onTcpConnected()
 void AntennaGeniusModel::onTcpDisconnected()
 {
     qCDebug(lcTuner) << "AntennaGenius: TCP disconnected";
+    bool wasConnected = m_connected;
     if (m_connected) {
         m_connected = false;
         emit disconnected();
@@ -262,6 +274,11 @@ void AntennaGeniusModel::onTcpDisconnected()
     if (m_keepAlive) {
         m_keepAlive->stop();
     }
+    if (!m_deliberateDisconnect && m_autoReconnect && wasConnected
+        && m_device.port > 0 && !m_device.ip.isNull()) {
+        m_reconnectTimer->start();
+    }
+    m_deliberateDisconnect = false;
 }
 
 void AntennaGeniusModel::onTcpError()

--- a/src/models/AntennaGeniusModel.cpp
+++ b/src/models/AntennaGeniusModel.cpp
@@ -26,6 +26,8 @@ AntennaGeniusModel::AntennaGeniusModel(QObject* parent)
     m_portA.portId = 1;
     m_portB.portId = 2;
 
+    // Retries every 5s indefinitely until the device returns or the user disconnects.
+    // This is intentional for a LAN peripheral that may be power-cycling.
     m_reconnectTimer = new QTimer(this);
     m_reconnectTimer->setSingleShot(true);
     m_reconnectTimer->setInterval(5000);
@@ -287,6 +289,14 @@ void AntennaGeniusModel::onTcpError()
     QString err = m_tcpSocket->errorString();
     qCWarning(lcTuner) << "AntennaGenius: TCP error:" << err;
     emit connectionError(err);
+    // A failed reconnect attempt arrives here (not via onTcpDisconnected) because
+    // the socket never reached ConnectedState. Re-arm so we keep retrying until
+    // the device returns or the user disconnects. isActive() prevents double-arm
+    // when a live drop emits both errorOccurred and disconnected.
+    if (!m_deliberateDisconnect && m_autoReconnect && !m_connected
+            && m_device.port > 0 && !m_device.ip.isNull()
+            && m_reconnectTimer && !m_reconnectTimer->isActive())
+        m_reconnectTimer->start();
 }
 
 void AntennaGeniusModel::onTcpReadyRead()

--- a/src/models/AntennaGeniusModel.h
+++ b/src/models/AntennaGeniusModel.h
@@ -90,6 +90,8 @@ public:
     void connectToAddress(const QHostAddress& ip, quint16 port);
     void disconnectFromDevice();
 
+    void setAutoReconnect(bool on) { m_autoReconnect = on; }
+
     // Getters
     bool isConnected()   const { return m_connected; }
     bool isConnecting()  const { return m_tcpSocket != nullptr && !m_connected; }
@@ -215,6 +217,11 @@ private:
 
     // Keep-alive
     QTimer* m_keepAlive{nullptr};
+
+    // Auto-reconnect
+    bool    m_autoReconnect{false};
+    bool    m_deliberateDisconnect{false};
+    QTimer* m_reconnectTimer{nullptr};
 
     // Track init commands
     int m_seqAntennaList{0};


### PR DESCRIPTION
## Summary

- When a direct TCP connection to PGXL, TGXL, or Antenna Genius drops unexpectedly, the connection is automatically retried every 5 seconds until the device returns
- A deliberate-disconnect guard prevents reconnect loops when the user explicitly clicks Disconnect in the Peripherals tab
- New checkbox in **Radio Setup -> Peripherals**: *Auto-reconnect to peripherals on connection drop* (default off, persisted as nested JSON in `AppSettings["Peripherals"]`)
- Setting is applied at app startup and propagated immediately when the checkbox is toggled

## Implementation

Each connection class (`PgxlConnection`, `TgxlConnection`, `AntennaGeniusModel`) gained:
- `m_lastHost` / `m_lastPort` - stored on every `connectTo*()` call
- `m_deliberateDisconnect` - set `true` in `disconnect()`, cleared in `onDisconnected()`
- `m_reconnectTimer` - 5-second single-shot; started in both `onDisconnected()` and `onError()`
- `setAutoReconnect(bool)` - public API propagated from `MainWindow` at startup and from the new checkbox

`PeripheralSettings` stores the new client-side toggle as a nested JSON blob and migrates the temporary `Peripherals_AutoReconnect` flat key used by earlier PR builds.

The error handler re-arm (added after review feedback from KK7GWY) handles the case where a retry attempt fails before the device is reachable again: Qt emits `errorOccurred` rather than `disconnected` when the socket never reached `ConnectedState`, so without this the timer would fire once and silently give up. `isActive()` prevents double-arming when a live drop emits both signals. The indefinite 5s retry is intentional - LAN peripherals may be power-cycling.

## Test plan

- [ ] Connect PGXL/TGXL/AG with auto-reconnect enabled; pull the Ethernet cable - device reconnects within ~5 seconds of cable reinsertion
- [ ] Pull cable, wait >30s (multiple retry cycles) - device reconnects when cable goes back in
- [ ] Click Disconnect in Peripherals tab - no reconnect attempt fires
- [ ] Toggle checkbox while connected - change takes effect immediately without requiring radio reconnect
- [ ] With auto-reconnect off - dropped connection stays disconnected (existing behavior)

Generated with [Claude Code](https://claude.ai/claude-code)
