### PR TITLE
fix(gui): restore main window to its saved screen on multi-monitor startup (#3319)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6104,6 +6104,48 @@ bool MainWindow::nativeEvent(const QByteArray& eventType, void* message, qintptr
 }
 #endif
 
+void MainWindow::restoreWindowGeometry()
+{
+    // Minimal mode owns its own (already post-show) geometry restore via
+    // MinimalModeGeometry — don't clobber it with the full-window blob. (#2483)
+    if (isMinimalMode()) {
+        return;
+    }
+
+    auto& s = AppSettings::instance();
+    const QString geomB64 = s.value("MainWindowGeometry").toString();
+    if (geomB64.isEmpty()) {
+        return;
+    }
+
+    // Re-apply now that the window is mapped.  The constructor-time
+    // restoreGeometry() runs before show(), and Qt6 does not reliably
+    // re-bind a not-yet-mapped window to its saved screen — so the WM
+    // places the window on the active screen, which the floating pop-out
+    // panels (shown during buildUI) have just stolen.  Re-applying here
+    // overrides that placement and honors the saved monitor. (#3319)
+    restoreGeometry(QByteArray::fromBase64(geomB64.toLatin1()));
+
+    // Clamp to a still-connected screen — the saved geometry may reference
+    // a monitor that's no longer attached.  Mirrors the floating-container
+    // guard in FloatingContainerWindow::restoreAndEnsureVisible().
+    const QPoint tl = frameGeometry().topLeft();
+    bool onScreen = false;
+    for (QScreen* screen : QGuiApplication::screens()) {
+        if (screen->availableGeometry().contains(tl)) {
+            onScreen = true;
+            break;
+        }
+    }
+    if (!onScreen) {
+        if (QScreen* screen = QGuiApplication::primaryScreen()) {
+            const QRect g = screen->availableGeometry();
+            move(g.center().x() - width() / 2,
+                 g.center().y() - height() / 2);
+        }
+    }
+}
+
 void MainWindow::changeEvent(QEvent* event)
 {
     QMainWindow::changeEvent(event);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -370,6 +370,11 @@ int main(int argc, char* argv[])
     {
         AetherSDR::MainWindow window;
         window.show();
+        // Re-apply the saved geometry once the window is mapped so the saved
+        // screen is honored on multi-monitor setups.  Constructor-time
+        // restoreGeometry() runs pre-show and Qt6 drops the screen binding,
+        // letting the window follow the just-shown pop-out panels. (#3319)
+        QTimer::singleShot(0, &window, &AetherSDR::MainWindow::restoreWindowGeometry);
         exitCode = app.exec();
     }
 


### PR DESCRIPTION
## Problem

Fixes #3319. On a multi-monitor setup, the main window does not reopen on the
screen it was last closed on. Instead it opens on whichever screen is showing
the popped-out panels (RX Controls, S-Meter, etc.), forcing the user to drag it
back every launch. The pop-out panels themselves restore to the correct screen
— only the main window "follows" them.

## Root cause

Restore **ordering** plus Qt6's pre-show screen binding:

1. Floating containers are restored **and shown** during `MainWindow::buildUI()`
   (`ContainerManager::restoreState()` → `FloatingContainerWindow::restoreAndEnsureVisible()`
   + `show()`). They become the most-recently-mapped top-level windows on
   monitor B.
2. The main window's `restoreGeometry()` runs later in the constructor but
   **before** `window.show()` in `main()`. On Qt6, applying `restoreGeometry()`
   to a not-yet-mapped window does not reliably re-bind it to its saved screen —
   the frame rectangle is stored but the screen association is dropped until the
   window is mapped.
3. When `show()` finally maps it, the WM places it on the **active screen** —
   monitor B, where the pop-outs were just shown. Hence the main window follows
   the pop-outs every launch.

The existing comments at the minimal-mode restore (#2483) already document this
exact class of bug; the minimal-mode path was moved post-show to dodge it, but
the base full-window restore still ran pre-show.

## Fix

Add `MainWindow::restoreWindowGeometry()` and call it via
`QTimer::singleShot(0, &window, ...)` immediately after `window.show()` in
`main()`. The queued slot runs after the window is mapped, so re-applying the
saved geometry now honors the saved **screen**, overriding the WM's
active-screen placement.

- Reuses the same "clamp to a still-connected screen" guard the floating
  windows already have, so a removed monitor doesn't strand the window.
- Skips minimal mode, which owns its own (already post-show) geometry restore
  (#2483).

## Cross-platform

Entirely Qt API — `QWidget::restoreGeometry`, `QGuiApplication::screens`,
`QTimer::singleShot`. No `#ifdef Q_OS_*` and no per-OS telemetry code: the same
path serves Windows, macOS, and Linux. (Tends to be most visible on Windows
with the frameless chrome, but the restore path is shared.)

## Testing

- Builds clean (Ninja, RelWithDebInfo, macOS arm64).
- Manual multi-monitor verification by the maintainer is the real check; I don't
  have a 3-monitor rig in CI. Steps: pop out RX Controls / S-Meter onto monitor
  B, leave the main window on monitor A, quit, relaunch — the main window should
  reopen on monitor A.

## Notes for maintainer review

- Per the autonomous-agent boundaries this is a bug fix with a clear root cause
  (startup ordering), not a UX/visual change. No defaults changed.
- File a follow-up if you'd prefer the geometry re-apply to live in a first-show
  `showEvent` guard inside `MainWindow` instead of the `singleShot` in `main()`
  — both were considered; the `singleShot` is the lower-risk, more localized
  option.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
