### PR TITLE
Restore main window to saved screen on multi-monitor startup

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5229,8 +5229,19 @@ MainWindow::MainWindow(QWidget* parent)
     // cache the position the way it does with native chrome). (#2483)
     if (s.value("MinimalModeEnabled", "False").toString() == "True") {
         toggleMinimalMode(true);
-        m_startupGeometryForFirstShow = QByteArray::fromBase64(
-            s.value("MinimalModeGeometry", "").toByteArray());
+        // Only swap to the minimal-mode blob when it actually exists.
+        // MinimalModeGeometry is written by toggleMinimalMode(false) and by
+        // closeEvent — never on first enable — so users upgrading from a build
+        // that predated the #2483 save path can have MinimalModeEnabled=True
+        // with no MinimalModeGeometry.  Overwriting unconditionally would wipe
+        // the valid MainWindowGeometry blob with empty bytes and skip the
+        // post-show screen restore entirely for exactly the multi-monitor
+        // minimal-mode operators this fix targets. (#3319)
+        const QByteArray minimalBlob = QByteArray::fromBase64(
+            s.value("MinimalModeGeometry", "").toString().toLatin1());
+        if (!minimalBlob.isEmpty()) {
+            m_startupGeometryForFirstShow = minimalBlob;
+        }
     }
 
     // Restore the Aetherial Audio Channel Strip if it was open on last
@@ -5992,6 +6003,13 @@ void MainWindow::showEvent(QShowEvent* event)
     }
 
     m_startupGeometryReapplied = true;
+    // Defer to a singleShot(0) so the re-apply runs after the constructor has
+    // fully returned.  This matters for the minimal-mode path: even though
+    // toggleMinimalMode(true) can emit a showEvent mid-construction (via
+    // showNormal()), the timer fires only once control unwinds back to the
+    // event loop — by which point m_startupGeometryForFirstShow has been
+    // finalized (swapped to the MinimalModeGeometry blob when present), so the
+    // correct blob is the one that gets re-applied. (#3319)
     QTimer::singleShot(0, this, &MainWindow::reapplyStartupGeometryAfterShow);
 }
 
@@ -6006,10 +6024,15 @@ void MainWindow::reapplyStartupGeometryAfterShow()
     // honors the saved monitor instead of the last pop-out's screen. (#3319)
     restoreGeometry(m_startupGeometryForFirstShow);
 
+    // Test the frame's center against each screen's full geometry rather than
+    // the top-left against availableGeometry().  A top-left landing in a
+    // taskbar/panel exclusion strip (or in a gap between two displays whose
+    // union covers the center) would otherwise be misreported as off-screen;
+    // the center on full geometry matches "is this window on a real display".
     bool onScreen = false;
-    const QPoint topLeft = frameGeometry().topLeft();
+    const QPoint center = frameGeometry().center();
     for (QScreen* screen : QGuiApplication::screens()) {
-        if (screen && screen->availableGeometry().contains(topLeft)) {
+        if (screen && screen->geometry().contains(center)) {
             onScreen = true;
             break;
         }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -129,6 +129,7 @@
 #include <functional>
 #include <QApplication>
 #include <QAudioDevice>
+#include <QGuiApplication>
 #include <QProcess>
 #include <QScreen>
 #include <QTimer>
@@ -5208,11 +5209,16 @@ MainWindow::MainWindow(QWidget* parent)
     // Restore saved geometry from XML settings
     auto& s = AppSettings::instance();
     const QString geomB64 = s.value("MainWindowGeometry").toString();
-    if (!geomB64.isEmpty())
-        restoreGeometry(QByteArray::fromBase64(geomB64.toLatin1()));
+    if (!geomB64.isEmpty()) {
+        m_startupGeometryForFirstShow = QByteArray::fromBase64(geomB64.toLatin1());
+        if (!m_startupGeometryForFirstShow.isEmpty()) {
+            restoreGeometry(m_startupGeometryForFirstShow);
+        }
+    }
     const QString stateB64 = s.value("MainWindowState").toString();
-    if (!stateB64.isEmpty())
+    if (!stateB64.isEmpty()) {
         restoreState(QByteArray::fromBase64(stateB64.toLatin1()));
+    }
 
     // Restore minimal mode AFTER full-window geometry has been applied.
     // Doing this earlier in the constructor caused toggleMinimalMode(true)
@@ -5221,8 +5227,11 @@ MainWindow::MainWindow(QWidget* parent)
     // placed on the correct screen — visible on Windows with
     // FramelessWindowHint as a position drift each launch (DWM doesn't
     // cache the position the way it does with native chrome). (#2483)
-    if (s.value("MinimalModeEnabled", "False").toString() == "True")
+    if (s.value("MinimalModeEnabled", "False").toString() == "True") {
         toggleMinimalMode(true);
+        m_startupGeometryForFirstShow = QByteArray::fromBase64(
+            s.value("MinimalModeGeometry", "").toByteArray());
+    }
 
     // Restore the Aetherial Audio Channel Strip if it was open on last
     // exit (#2301).  toggleAetherialStrip() lazy-creates and shows.
@@ -5972,6 +5981,49 @@ void MainWindow::paintEvent(QPaintEvent* event)
     p.setCompositionMode(QPainter::CompositionMode_Source);
     p.fillRect(rect(), bg.isValid() ? bg : QColor("#0f0f1a"));
     QMainWindow::paintEvent(event);
+}
+
+void MainWindow::showEvent(QShowEvent* event)
+{
+    QMainWindow::showEvent(event);
+
+    if (m_startupGeometryReapplied || m_startupGeometryForFirstShow.isEmpty()) {
+        return;
+    }
+
+    m_startupGeometryReapplied = true;
+    QTimer::singleShot(0, this, &MainWindow::reapplyStartupGeometryAfterShow);
+}
+
+void MainWindow::reapplyStartupGeometryAfterShow()
+{
+    if (m_startupGeometryForFirstShow.isEmpty()) {
+        return;
+    }
+
+    // Pop-out applet containers are restored and shown during construction.
+    // Re-apply the main-window geometry after this window is mapped so Qt
+    // honors the saved monitor instead of the last pop-out's screen. (#3319)
+    restoreGeometry(m_startupGeometryForFirstShow);
+
+    bool onScreen = false;
+    const QPoint topLeft = frameGeometry().topLeft();
+    for (QScreen* screen : QGuiApplication::screens()) {
+        if (screen && screen->availableGeometry().contains(topLeft)) {
+            onScreen = true;
+            break;
+        }
+    }
+    if (onScreen) {
+        return;
+    }
+
+    // Clamp to a connected screen if the saved monitor was removed.
+    if (QScreen* screen = QGuiApplication::primaryScreen()) {
+        const QRect available = screen->availableGeometry();
+        move(available.center().x() - width() / 2,
+             available.center().y() - height() / 2);
+    }
 }
 
 void MainWindow::resizeEvent(QResizeEvent* event)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -61,6 +61,7 @@
 
 class QAbstractSlider;
 class QMediaDevices;
+class QShowEvent;
 
 #include "gui/ClientEqApplet.h"   // ClientEqApplet::Path enum used in
                                    // onEqCutoffsDragRequested signature.
@@ -142,6 +143,7 @@ public:
     ~MainWindow() override;
 
 protected:
+    void showEvent(QShowEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
     void changeEvent(QEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
@@ -276,6 +278,7 @@ private:
     void registerShortcutActions();
     void applyUiScale(int pct);
     void stepUiScale(int direction);  // +1 = zoom in, -1 = zoom out
+    void reapplyStartupGeometryAfterShow();
     void toggleMinimalMode(bool on);
     // Toggle the Aetherial Audio Channel Strip — unified TX DSP window.
     // Stubbed in step 1 of #2301; step 4 lazy-creates the strip window
@@ -817,6 +820,8 @@ private:
     bool m_minimalMode{false};             // true when spectrum is hidden (#208)
     bool m_exitingMinimalMode{false};      // re-entry guard for changeEvent → toggleMinimalMode(false)
     bool m_enteringMinimalMode{false};     // suppress changeEvent during enter (macOS deferred WindowStateChange, #2365)
+    bool m_startupGeometryReapplied{false};
+    QByteArray m_startupGeometryForFirstShow;
     QAction* m_minimalModeAction{nullptr};
     bool m_panadapterConnectionAnimationVisible{false};
     bool m_waitingForFirstPanadapterFrame{false};


### PR DESCRIPTION
Fixes #3319

## Summary

This fixes the main window reopening on the wrong monitor when applet panels are popped out on another display. The main window now re-applies its saved startup geometry once after the first show event, when Qt has a mapped native window and can honor the saved screen association.

The fix is intentionally scoped to the main-window startup restore path:

- captures the saved `MainWindowGeometry` blob when it is first loaded from `AppSettings`
- keeps the existing constructor-time restore so startup sizing/state behavior remains unchanged
- schedules a one-shot post-show re-apply from `showEvent`
- clamps the restored frame back onto the primary screen if the saved monitor is no longer connected
- preserves the existing minimal-mode restore path by swapping the first-show blob to `MinimalModeGeometry` when minimal mode is enabled

## Root Cause

Floating applet containers are restored and shown during `MainWindow` construction. On a multi-monitor setup, those pop-outs can become the most recently mapped top-level windows on the secondary display before the main window itself is shown.

The main window then restores `MainWindowGeometry` while it is still hidden. Qt can apply the rectangle, but on some multi-display/window-manager combinations it does not reliably bind the hidden window to the saved monitor. When `main.cpp` finally calls `show()`, the window manager may place the main window on the active display, which is the display that just received the popped-out applets.

Re-applying the same saved geometry after first show gives Qt a real mapped window to move, so the saved monitor is respected.

## User Impact

Operators who keep AetherSDR on a dedicated monitor and pop out RX Controls, S-Meter, or similar panels onto another monitor no longer have to move the main window back on every launch.

If the saved monitor is unplugged, AetherSDR now falls back to the primary screen instead of trying to restore off-screen.

## Validation

Automated:

- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build -j8`
- `theme_manager_test` passed when run alone with a clean temporary `HOME`
- Remaining suite passed: `ctest --test-dir build --output-on-failure -j8 -E theme_manager_test`

Manual validation by @jensenpat:

- tested on laptop display only
- tested in a dual-screen environment with the main window and popped-out panels on separate displays
- unplugged the external monitor and verified the main window moved back to the laptop screen

## Notes

An all-in-one `ctest` run can make `theme_manager_test` see settings written by earlier tests under the same home directory. That test passed in isolation with a clean temporary `HOME`; the other 24 tests passed together.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.5 Pro 4/23) and tested by @jensenpat
