### PR TITLE
fix(ag-applet): prevent blank display from spurious antennasChanged emission

### DIFF
--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -135,8 +135,14 @@ AmpApplet::AmpApplet(QWidget* parent)
 
 void AmpApplet::setFwdPower(float watts)
 {
+    const bool wasPowered = (m_fwdWatts >= 5.0f);
     m_fwdWatts = watts;
     m_fwdGauge->setValue(watts);
+    const bool isPowered = (watts >= 5.0f);
+    if (!isPowered && wasPowered)
+        m_swrGauge->setValue(1.0f);   // clear bar — SWR is unmeasurable at idle
+    else if (isPowered && !wasPowered)
+        m_swrGauge->setValue(m_swrVal); // power resumed — restore cached value
     if (watts > m_peakFwd) {
         m_peakFwd = watts;
         m_fwdGauge->setPeakValue(watts);
@@ -148,7 +154,10 @@ void AmpApplet::setFwdPower(float watts)
 void AmpApplet::setSwr(float swr)
 {
     m_swrVal = swr;
-    m_swrGauge->setValue(swr);
+    // Only drive the gauge when there is forward power — SWR is not meaningful
+    // at idle and the radio/PGXL may report stale or noise values.
+    if (m_fwdWatts >= 5.0f)
+        m_swrGauge->setValue(swr);
     // Label text is updated by the 100 ms timer (updateValueLabels).
 }
 
@@ -208,7 +217,12 @@ void AmpApplet::updateValueLabels()
 void AmpApplet::setDrainVoltage(float volts)
 {
     if (!m_directConnected) return;
-    m_vddLabel->setText(QStringLiteral("Vdd  %1 V").arg(volts, 0, 'f', 1));
+    // PGXL reports vdd=0.0 when the drain supply is off (standby). Show a dash
+    // rather than "0.0 V" so it's clear the supply is off, not that we're reading zero.
+    if (volts < 1.0f)
+        m_vddLabel->setText("Vdd  — V");
+    else
+        m_vddLabel->setText(QStringLiteral("Vdd  %1 V").arg(volts, 0, 'f', 1));
 }
 
 void AmpApplet::setMainsVoltage(int volts)

--- a/src/gui/AntennaGeniusApplet.cpp
+++ b/src/gui/AntennaGeniusApplet.cpp
@@ -312,9 +312,19 @@ void AntennaGeniusApplet::setModel(AntennaGeniusModel* model)
         m_connectBtn->setText("Connect");
         m_statusLabel->setText("Disconnected");
         m_statusLabel->setStyleSheet("color: #606878; font-size: 10px;");
-        // Clear antenna buttons.
-        m_portABtns.clear();
-        m_portBBtns.clear();
+        // Remove antenna button widgets from the grid and clear the lists so the
+        // display and the model are consistent while disconnected.
+        auto clearGrid = [](QWidget* gridWidget, QList<QPushButton*>& btns) {
+            auto* gl = static_cast<QGridLayout*>(gridWidget->layout());
+            while (gl->count() > 0) {
+                auto* item = gl->takeAt(0);
+                delete item->widget();
+                delete item;
+            }
+            btns.clear();
+        };
+        clearGrid(m_portABtnGrid, m_portABtns);
+        clearGrid(m_portBBtnGrid, m_portBBtns);
     });
 
     connect(m_model, &AntennaGeniusModel::connectionError, this,
@@ -349,6 +359,9 @@ void AntennaGeniusApplet::rebuildAntennaButtons()
     if (!m_model) return;
 
     auto antennas = m_model->antennas();
+    // Don't wipe the existing buttons if the model hasn't loaded the list yet —
+    // that would leave the grid blank until the response arrives.
+    if (antennas.isEmpty()) return;
 
     // Helper: build a grid of antenna buttons for a given port.
     auto buildGrid = [&](QWidget* gridWidget, QList<QPushButton*>& btns, int portId) {

--- a/src/gui/TunerApplet.cpp
+++ b/src/gui/TunerApplet.cpp
@@ -358,7 +358,17 @@ void TunerApplet::updateMeters(float fwdPower, float swr)
     m_fwdPower = fwdPower;
     m_swr = swr;
     static_cast<HGauge*>(m_fwdGauge)->setValue(fwdPower);
-    static_cast<HGauge*>(m_swrGauge)->setValue(swr);
+    // TGXL sends swr=0.0000 (return loss = 0 dB) at idle — no incident signal
+    // to measure against. The model converts that to rho=1.0 → ratio=99.9, which
+    // pegs the gauge. Snap to 1.0 (empty) whenever forward power is below the
+    // noise floor; m_swr retains the raw value for post-tune capture logic.
+    // Threshold matches the label threshold (5 W) — 1 W was too low and let
+    // idle noise readings light up the SWR bar.
+    if (fwdPower >= 5.0f) {
+        static_cast<HGauge*>(m_swrGauge)->setValue(swr);
+    } else {
+        static_cast<HGauge*>(m_swrGauge)->setValueImmediate(1.0f);
+    }
     if (fwdPower > m_peakFwd) {
         m_peakFwd = fwdPower;
         static_cast<HGauge*>(m_fwdGauge)->setPeakValue(fwdPower);

--- a/src/models/AntennaGeniusModel.cpp
+++ b/src/models/AntennaGeniusModel.cpp
@@ -144,12 +144,18 @@ void AntennaGeniusModel::onDiscoveryDatagram()
         if (m_connected &&
             (m_device.serial.endsWith("-manual") || m_device.serial.startsWith("manual-")) &&
             !m_device.ip.isNull() && m_device.ip == info.ip) {
+            // Only emit antennasChanged once — when the placeholder serial is
+            // first replaced by the real one. Emitting on every beacon caused
+            // rebuildAntennaButtons to run every ~1s, blanking the display during
+            // the brief window before the antenna list response arrived.
+            bool serialChanged = (m_device.serial != info.serial);
             m_device.serial       = info.serial;
             m_device.name         = info.name;
             m_device.webPort      = info.webPort;
             m_device.radioPorts   = info.radioPorts;
             m_device.antennaPorts = info.antennaPorts;
-            emit antennasChanged();
+            if (serialChanged)
+                emit antennasChanged();
         }
     }
 }


### PR DESCRIPTION
## Root cause

Three bugs combined, across two applets.

---

### Bug 1 — AG applet: UDP beacon enrichment emitting `antennasChanged` before `antenna list` TCP response

`onDiscoveryDatagram` contains late-enrichment code that fires once per connect (the outer `m_device.serial.endsWith("-manual")` guard already ensures subsequent beacons skip the block after the first one updates the serial). The timing issue: the enrichment beacon can arrive in the window between `m_connected = true` (prologue received) and the `antenna list` TCP response — particularly on the first connect or after an explicit disconnect where `m_antennas` was cleared by `disconnectFromDevice()`. That single `emit antennasChanged()` triggered `rebuildAntennaButtons` with an empty antenna list, wiping the grid.

The `serialChanged` guard added here is belt-and-suspenders (the outer guard already limits to once per connect) and documents the intent clearly, so it stays. The real fix for the blank is the defence-in-depth early-return in `rebuildAntennaButtons`.

### Bug 2 — AG applet: `disconnected` handler left widget/model state inconsistent

The `disconnected` handler cleared `m_portABtns`/`m_portBBtns` (the `QList<QPushButton*>` members) but did not remove the actual button widgets from the `QGridLayout`. This left the view (grid with buttons) and the model (empty lists) inconsistent. `updatePortDisplay` iterates the lists, so no button state was ever refreshed — stale buttons remained visible and could not be properly updated.

Fix: delete the grid widgets on disconnect, mirroring the `buildGrid` cleanup in `rebuildAntennaButtons`.

### Defence-in-depth (AG applet)

`rebuildAntennaButtons` now returns early if the antenna list is empty, so a stale grid is never blanked by a rebuild that has nothing to show. Edge case acknowledged: if AG ever legitimately reports zero antennas, the grid retains stale buttons rather than clearing. For AG hardware this is effectively never; the disconnect path handles the real clear case.

---

### Bug 3 — AmpApplet (PGXL): SWR gauge fill shown at idle

`setSwr()` unconditionally called `m_swrGauge->setValue(swr)` on every telemetry update. The radio proxies PGXL telemetry continuously and may report a stale or noise SWR value while forward power is zero. The label text was already suppressed below 5 W (in `updateValueLabels`) but the gauge fill was not.

Fix: `setSwr()` only drives the gauge when `m_fwdWatts >= 5.0f`. `setFwdPower()` handles the two transition edges:
- power drops below 5 W → snap SWR gauge to 1.0 (no bar) immediately
- power rises above 5 W → restore the cached SWR value so the bar appears even if no new SWR update arrives first

### Bug 4 — TunerApplet (TGXL): SWR gauge threshold too low

`updateMeters()` already had a power gate for the SWR gauge, but its threshold was 1 W — too low. The TGXL (and the radio's meter proxy) report noise-floor power readings above 1 W at idle, so the SWR bar lit up with variable values whenever the radio was keyed off. The label suppression threshold was already 5 W, creating an inconsistency where the SWR label was blank but the bar was lit.

Fix: raise the SWR gauge gate from `fwdPower >= 1.0f` to `fwdPower >= 5.0f`, matching the label threshold and the AmpApplet fix. The `setValueImmediate(1.0f)` snap path is retained so the bar clears instantly without waiting for ballistics decay.

---

## Test plan

- [ ] Connect to AG via manual IP — antenna buttons appear promptly, no blank flash while loading
- [ ] Disconnect → reconnect AG — buttons clear on disconnect, repopulate correctly on reconnect
- [ ] Connect AG, leave for >60s — no periodic blank/flicker
- [ ] Key up with PGXL in STANDBY — SWR gauge stays empty (no bar)
- [ ] Key up with PGXL in OPERATE — SWR gauge fills normally during TX, clears within one packet after unkey
- [ ] Key up with TGXL in STANDBY — SWR gauge stays empty at idle, fills only when forward power ≥ 5 W
- [ ] Post-tune SWR result flash still displays correctly after a TGXL autotune cycle

🤖 Generated with [Claude Code](https://claude.ai/claude-code)