### PR TITLE
feat(cw): reusable RangeSlider widget; replace Lo/Hi pitch sliders; add WPM range control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,6 +662,7 @@ set(GUI_SOURCES
     src/gui/ProfileImportExportDialog.cpp
     src/gui/TxBandDialog.cpp
     src/gui/PanadapterApplet.cpp
+    src/gui/RangeSlider.cpp
     src/gui/PanadapterStack.cpp
     src/gui/PanLayoutDialog.cpp
     src/gui/AppletPanel.cpp

--- a/src/core/CwDecoder.cpp
+++ b/src/core/CwDecoder.cpp
@@ -65,16 +65,24 @@ void CwDecoder::stop()
     qCDebug(lcDsp) << "CwDecoder: stopped";
 }
 
+// Build and apply current ggmorse decode parameters from all stored state.
+void CwDecoder::applyDecodeParameters()
+{
+    if (!m_ggmorse) return;
+    GGMorse::ParametersDecode dp = GGMorse::getDefaultParametersDecode();
+    dp.frequency_hz          = m_pitchLocked ? m_pitch.load() : -1.0f;
+    dp.speed_wpm             = m_speedLocked ? m_speed.load() : -1.0f;
+    dp.frequencyRangeMin_hz  = m_pitchRangeMin;
+    dp.frequencyRangeMax_hz  = m_pitchRangeMax;
+    dp.speedRangeMin_wpm     = m_speedRangeMin;
+    dp.speedRangeMax_wpm     = m_speedRangeMax;
+    m_ggmorse->setParametersDecode(dp);
+}
+
 void CwDecoder::lockPitch(bool lock)
 {
     m_pitchLocked = lock;
-    if (!m_ggmorse) return;
-    GGMorse::ParametersDecode dp = GGMorse::getDefaultParametersDecode();
-    dp.frequency_hz = lock ? m_pitch.load() : -1.0f;
-    dp.speed_wpm = m_speedLocked ? m_speed.load() : -1.0f;
-    dp.frequencyRangeMin_hz = m_pitchRangeMin;
-    dp.frequencyRangeMax_hz = m_pitchRangeMax;
-    m_ggmorse->setParametersDecode(dp);
+    applyDecodeParameters();
     qCDebug(lcDsp) << "CwDecoder: pitch" << (lock ? "locked at" : "unlocked from")
                    << m_pitch.load() << "Hz";
 }
@@ -82,13 +90,7 @@ void CwDecoder::lockPitch(bool lock)
 void CwDecoder::lockSpeed(bool lock)
 {
     m_speedLocked = lock;
-    if (!m_ggmorse) return;
-    GGMorse::ParametersDecode dp = GGMorse::getDefaultParametersDecode();
-    dp.frequency_hz = m_pitchLocked ? m_pitch.load() : -1.0f;
-    dp.speed_wpm = lock ? m_speed.load() : -1.0f;
-    dp.frequencyRangeMin_hz = m_pitchRangeMin;
-    dp.frequencyRangeMax_hz = m_pitchRangeMax;
-    m_ggmorse->setParametersDecode(dp);
+    applyDecodeParameters();
     qCDebug(lcDsp) << "CwDecoder: speed" << (lock ? "locked at" : "unlocked from")
                    << m_speed.load() << "WPM";
 }
@@ -119,13 +121,7 @@ void CwDecoder::setKnownParameters(float pitchHz, float speedWpm)
     m_pitchRangeMin = std::max(100.0f, pitchHz - kPitchRangePad);
     m_pitchRangeMax = pitchHz + kPitchRangePad;
 
-    if (!m_ggmorse) return;
-    GGMorse::ParametersDecode dp = GGMorse::getDefaultParametersDecode();
-    dp.frequency_hz = pitchHz;
-    dp.speed_wpm = speedWpm;
-    dp.frequencyRangeMin_hz = m_pitchRangeMin;
-    dp.frequencyRangeMax_hz = m_pitchRangeMax;
-    m_ggmorse->setParametersDecode(dp);
+    applyDecodeParameters();
     qCDebug(lcDsp) << "CwDecoder: known params pitch=" << pitchHz
                    << "Hz speed=" << speedWpm << "WPM";
 }
@@ -134,14 +130,16 @@ void CwDecoder::setPitchRange(int minHz, int maxHz)
 {
     m_pitchRangeMin = static_cast<float>(minHz);
     m_pitchRangeMax = static_cast<float>(maxHz);
-    if (!m_ggmorse) return;
-    GGMorse::ParametersDecode dp = GGMorse::getDefaultParametersDecode();
-    dp.frequency_hz = m_pitchLocked ? m_pitch.load() : -1.0f;
-    dp.speed_wpm = m_speedLocked ? m_speed.load() : -1.0f;
-    dp.frequencyRangeMin_hz = m_pitchRangeMin;
-    dp.frequencyRangeMax_hz = m_pitchRangeMax;
-    m_ggmorse->setParametersDecode(dp);
+    applyDecodeParameters();
     qCDebug(lcDsp) << "CwDecoder: pitch range" << minHz << "-" << maxHz << "Hz";
+}
+
+void CwDecoder::setSpeedRange(int minWpm, int maxWpm)
+{
+    m_speedRangeMin = static_cast<float>(minWpm);
+    m_speedRangeMax = static_cast<float>(maxWpm);
+    applyDecodeParameters();
+    qCDebug(lcDsp) << "CwDecoder: speed range" << minWpm << "-" << maxWpm << "WPM";
 }
 
 void CwDecoder::feedAudio(const QByteArray& pcm24kStereo)

--- a/src/core/CwDecoder.h
+++ b/src/core/CwDecoder.h
@@ -39,6 +39,7 @@ public:
     void lockPitch(bool lock);
     void lockSpeed(bool lock);
     void setPitchRange(int minHz, int maxHz);
+    void setSpeedRange(int minWpm, int maxWpm);
 
     // Force pitch + speed to specific values and lock both — used by the
     // TX-side decoder (#2417) where the operator's keying parameters are
@@ -59,6 +60,7 @@ signals:
 
 private:
     void decodeLoop();
+    void applyDecodeParameters();
 
     QThread*      m_workerThread{nullptr};
     std::unique_ptr<GGMorse> m_ggmorse;
@@ -75,6 +77,8 @@ private:
     std::atomic<bool> m_speedLocked{false};
     std::atomic<float> m_pitchRangeMin{500.0f};
     std::atomic<float> m_pitchRangeMax{700.0f};
+    std::atomic<float> m_speedRangeMin{-1.0f};   // -1 = full range
+    std::atomic<float> m_speedRangeMax{-1.0f};
 };
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -12078,6 +12078,8 @@ void MainWindow::routeCwDecoderOutput()
                 &m_cwDecoder, &CwDecoder::lockSpeed);
         connect(m_cwDecoderApplet, &PanadapterApplet::pitchRangeChanged,
                 &m_cwDecoder, &CwDecoder::setPitchRange);
+        m_cwDecoder.setPitchRange(m_cwDecoderApplet->pitchRangeLow(),
+                                  m_cwDecoderApplet->pitchRangeHigh());
         connect(m_cwDecoderApplet, &PanadapterApplet::speedRangeChanged,
                 &m_cwDecoder, &CwDecoder::setSpeedRange);
         m_cwDecoder.setSpeedRange(m_cwDecoderApplet->speedRangeLow(),

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -12080,6 +12080,8 @@ void MainWindow::routeCwDecoderOutput()
                 &m_cwDecoder, &CwDecoder::setPitchRange);
         connect(m_cwDecoderApplet, &PanadapterApplet::speedRangeChanged,
                 &m_cwDecoder, &CwDecoder::setSpeedRange);
+        m_cwDecoder.setSpeedRange(m_cwDecoderApplet->speedRangeLow(),
+                                  m_cwDecoderApplet->speedRangeHigh());
         connect(m_cwDecoderApplet, &PanadapterApplet::cwPanelCloseRequested,
                 &m_cwDecoder, &CwDecoder::stop);
         connect(m_cwDecoderApplet, &PanadapterApplet::cwPanelCloseRequested,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -12052,6 +12052,8 @@ void MainWindow::routeCwDecoderOutput()
                        &m_cwDecoder, &CwDecoder::lockSpeed);
         disconnect(m_cwDecoderApplet, &PanadapterApplet::pitchRangeChanged,
                    &m_cwDecoder, &CwDecoder::setPitchRange);
+        disconnect(m_cwDecoderApplet, &PanadapterApplet::speedRangeChanged,
+                   &m_cwDecoder, &CwDecoder::setSpeedRange);
         disconnect(m_cwDecoderApplet, &PanadapterApplet::cwPanelCloseRequested,
                    &m_cwDecoder, &CwDecoder::stop);
         disconnect(m_cwDecoderApplet, &PanadapterApplet::cwPanelCloseRequested,
@@ -12076,6 +12078,8 @@ void MainWindow::routeCwDecoderOutput()
                 &m_cwDecoder, &CwDecoder::lockSpeed);
         connect(m_cwDecoderApplet, &PanadapterApplet::pitchRangeChanged,
                 &m_cwDecoder, &CwDecoder::setPitchRange);
+        connect(m_cwDecoderApplet, &PanadapterApplet::speedRangeChanged,
+                &m_cwDecoder, &CwDecoder::setSpeedRange);
         connect(m_cwDecoderApplet, &PanadapterApplet::cwPanelCloseRequested,
                 &m_cwDecoder, &CwDecoder::stop);
         connect(m_cwDecoderApplet, &PanadapterApplet::cwPanelCloseRequested,

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -181,7 +181,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     AetherSDR::ThemeManager::instance().applyStyleSheet(pitchLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
     cwBar->addWidget(pitchLabel);
 
-    m_pitchRangeSlider = new RangeSlider(100, 2000, 300, 1200, {}, this);
+    m_pitchRangeSlider = new RangeSlider(300, 1200, 500, 700, {}, this);
     m_pitchRangeSlider->setFixedWidth(160);
     m_pitchRangeSlider->setToolTip("Decoder pitch search range (Hz)");
     cwBar->addWidget(m_pitchRangeSlider);

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -176,26 +176,18 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_lockSpeedBtn->setStyleSheet(m_lockPitchBtn->styleSheet());
     cwBar->addWidget(m_lockSpeedBtn);
 
-    // Pitch range — double-handle slider, 100–2000 Hz, default 300–1200 Hz
-    auto* pitchLabel = new QLabel("Pitch:");
-    AetherSDR::ThemeManager::instance().applyStyleSheet(pitchLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
-    cwBar->addWidget(pitchLabel);
-
-    m_pitchRangeSlider = new RangeSlider(300, 1200, 500, 700, {}, this);
-    m_pitchRangeSlider->setFixedWidth(160);
+    // Pitch range — double-handle slider, label embedded in widget
+    m_pitchRangeSlider = new RangeSlider(300, 1200, 500, 700, "Pitch", {}, this);
+    m_pitchRangeSlider->setFixedWidth(195);
     m_pitchRangeSlider->setToolTip("Decoder pitch search range (Hz)");
     cwBar->addWidget(m_pitchRangeSlider);
     connect(m_pitchRangeSlider, &RangeSlider::rangeChanged, this, [this](int lo, int hi) {
         emit pitchRangeChanged(lo, hi);
     });
 
-    // WPM range — double-handle slider, 5–120 WPM, default 5–60 WPM
-    auto* wpmLabel = new QLabel("WPM:");
-    AetherSDR::ThemeManager::instance().applyStyleSheet(wpmLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
-    cwBar->addWidget(wpmLabel);
-
-    m_speedRangeSlider = new RangeSlider(5, 120, 5, 60, {}, this);
-    m_speedRangeSlider->setFixedWidth(160);
+    // WPM range — double-handle slider, label embedded in widget
+    m_speedRangeSlider = new RangeSlider(5, 120, 5, 60, "WPM", {}, this);
+    m_speedRangeSlider->setFixedWidth(195);
     m_speedRangeSlider->setToolTip("Decoder speed search range (WPM)");
     cwBar->addWidget(m_speedRangeSlider);
     connect(m_speedRangeSlider, &RangeSlider::rangeChanged, this, [this](int lo, int hi) {

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -1,6 +1,7 @@
 #include "PanadapterApplet.h"
 #include "FramelessMoveHelper.h"
 #include "GuardedSlider.h"
+#include "RangeSlider.h"
 #include "SliceLabel.h"
 #include "SpectrumWidget.h"
 #include "Theme.h"
@@ -175,70 +176,31 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_lockSpeedBtn->setStyleSheet(m_lockPitchBtn->styleSheet());
     cwBar->addWidget(m_lockSpeedBtn);
 
-    // Pitch range sliders — constrain decoder frequency search.  Compact
-    // 50px-wide sliders for the CW bar; sizes kept site-local (deliberate
-    // narrow handle), colours routed through the color.slider.* namespace
-    // so the per-applet override path can retint them and live theme
-    // switching works without a per-site reapplication.
-    const QString rangeSliderStyle = QStringLiteral(
-        "QSlider::groove:horizontal { background: {{color.slider.background}}; height: 4px; border-radius: 2px; }"
-        "QSlider::handle:horizontal { background: {{color.slider.handle}}; width: 8px; margin: -3px 0; border-radius: 4px; }");
+    // Pitch range — double-handle slider, 100–2000 Hz, default 300–1200 Hz
+    auto* pitchLabel = new QLabel("Pitch:");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(pitchLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
+    cwBar->addWidget(pitchLabel);
 
-    auto* minLabel = new QLabel("Lo:");
-    AetherSDR::ThemeManager::instance().applyStyleSheet(minLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
-    cwBar->addWidget(minLabel);
-
-    m_pitchMinSlider = new GuardedSlider(Qt::Horizontal);
-    m_pitchMinSlider->setRange(300, 1200);
-    m_pitchMinSlider->setValue(500);
-    m_pitchMinSlider->setFixedWidth(50);
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_pitchMinSlider, rangeSliderStyle);
-    m_pitchMinSlider->setToolTip("Decoder pitch search minimum (Hz)");
-    cwBar->addWidget(m_pitchMinSlider);
-    m_pitchMinValLabel = new QLabel(QString::number(m_pitchMinSlider->value()));
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_pitchMinValLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
-    m_pitchMinValLabel->setFixedWidth(24);
-    cwBar->addWidget(m_pitchMinValLabel);
-
-    auto* maxLabel = new QLabel("Hi:");
-    AetherSDR::ThemeManager::instance().applyStyleSheet(maxLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
-    cwBar->addWidget(maxLabel);
-
-    m_pitchMaxSlider = new GuardedSlider(Qt::Horizontal);
-    m_pitchMaxSlider->setRange(300, 1200);
-    m_pitchMaxSlider->setValue(700);
-    m_pitchMaxSlider->setFixedWidth(50);
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_pitchMaxSlider, rangeSliderStyle);
-    m_pitchMaxSlider->setToolTip("Decoder pitch search maximum (Hz)");
-    cwBar->addWidget(m_pitchMaxSlider);
-    m_pitchMaxValLabel = new QLabel(QString::number(m_pitchMaxSlider->value()));
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_pitchMaxValLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
-    m_pitchMaxValLabel->setFixedWidth(24);
-    cwBar->addWidget(m_pitchMaxValLabel);
-
-    // Update tooltips and emit range change — clamp so min ≤ max
-    connect(m_pitchMinSlider, &QSlider::valueChanged, this, [this](int v) {
-        if (v > m_pitchMaxSlider->value()) {
-            QSignalBlocker b(m_pitchMinSlider);
-            m_pitchMinSlider->setValue(m_pitchMaxSlider->value());
-            v = m_pitchMaxSlider->value();
-        }
-        m_pitchMinSlider->setToolTip(QString("%1 Hz").arg(v));
-        m_pitchMinValLabel->setText(QString::number(v));
-        emit pitchRangeChanged(v, m_pitchMaxSlider->value());
+    m_pitchRangeSlider = new RangeSlider(100, 2000, 300, 1200, {}, this);
+    m_pitchRangeSlider->setFixedWidth(160);
+    m_pitchRangeSlider->setToolTip("Decoder pitch search range (Hz)");
+    cwBar->addWidget(m_pitchRangeSlider);
+    connect(m_pitchRangeSlider, &RangeSlider::rangeChanged, this, [this](int lo, int hi) {
+        emit pitchRangeChanged(lo, hi);
     });
-    connect(m_pitchMaxSlider, &QSlider::valueChanged, this, [this](int v) {
-        if (v < m_pitchMinSlider->value()) {
-            QSignalBlocker b(m_pitchMaxSlider);
-            m_pitchMaxSlider->setValue(m_pitchMinSlider->value());
-            v = m_pitchMinSlider->value();
-        }
-        m_pitchMaxSlider->setToolTip(QString("%1 Hz").arg(v));
-        m_pitchMaxValLabel->setText(QString::number(v));
-        emit pitchRangeChanged(m_pitchMinSlider->value(), v);
+
+    // WPM range — double-handle slider, 5–120 WPM, default 5–60 WPM
+    auto* wpmLabel = new QLabel("WPM:");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(wpmLabel, "QLabel { color: {{color.text.label}}; font-size: 8px; background: transparent; }");
+    cwBar->addWidget(wpmLabel);
+
+    m_speedRangeSlider = new RangeSlider(5, 120, 5, 60, {}, this);
+    m_speedRangeSlider->setFixedWidth(160);
+    m_speedRangeSlider->setToolTip("Decoder speed search range (WPM)");
+    cwBar->addWidget(m_speedRangeSlider);
+    connect(m_speedRangeSlider, &RangeSlider::rangeChanged, this, [this](int lo, int hi) {
+        emit speedRangeChanged(lo, hi);
     });
-    m_pitchMinSlider->setToolTip(QString("%1 Hz").arg(m_pitchMinSlider->value()));
-    m_pitchMaxSlider->setToolTip(QString("%1 Hz").arg(m_pitchMaxSlider->value()));
 
     cwBar->addStretch();
 

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -186,7 +186,7 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     });
 
     // WPM range — double-handle slider, label embedded in widget
-    m_speedRangeSlider = new RangeSlider(5, 120, 5, 60, "WPM", {}, this);
+    m_speedRangeSlider = new RangeSlider(5, 60, 15, 40, "WPM", {}, this);
     m_speedRangeSlider->setFixedWidth(195);
     m_speedRangeSlider->setToolTip("Decoder speed search range (WPM)");
     cwBar->addWidget(m_speedRangeSlider);

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -308,6 +308,16 @@ void PanadapterApplet::setCwPanelVisible(bool visible)
     m_cwPanel->setVisible(visible);
 }
 
+int PanadapterApplet::speedRangeLow()  const
+{
+    return m_speedRangeSlider ? m_speedRangeSlider->low() : 15;
+}
+
+int PanadapterApplet::speedRangeHigh() const
+{
+    return m_speedRangeSlider ? m_speedRangeSlider->high() : 40;
+}
+
 void PanadapterApplet::appendCwText(const QString& text, float cost)
 {
     // Filter by sensitivity threshold — drop low-confidence decodes

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -318,6 +318,16 @@ int PanadapterApplet::speedRangeHigh() const
     return m_speedRangeSlider ? m_speedRangeSlider->high() : 40;
 }
 
+int PanadapterApplet::pitchRangeLow()  const
+{
+    return m_pitchRangeSlider ? m_pitchRangeSlider->low() : 500;
+}
+
+int PanadapterApplet::pitchRangeHigh() const
+{
+    return m_pitchRangeSlider ? m_pitchRangeSlider->high() : 700;
+}
+
 void PanadapterApplet::appendCwText(const QString& text, float cost)
 {
     // Filter by sensitivity threshold — drop low-confidence decodes

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -6,6 +6,7 @@ class QLabel;
 class QPushButton;
 class QSlider;
 class QTextEdit;
+class RangeSlider;
 
 namespace AetherSDR {
 
@@ -60,6 +61,7 @@ signals:
     void dockClicked();
     void maximizeRequested(const QString& panId);
     void pitchRangeChanged(int minHz, int maxHz);
+    void speedRangeChanged(int minWpm, int maxWpm);
     void cwPanelCloseRequested();
 
 protected:
@@ -82,10 +84,8 @@ private:
     QSlider*      m_cwSensSlider{nullptr};
     QPushButton*  m_lockPitchBtn{nullptr};
     QPushButton*  m_lockSpeedBtn{nullptr};
-    QSlider*      m_pitchMinSlider{nullptr};
-    QSlider*      m_pitchMaxSlider{nullptr};
-    QLabel*       m_pitchMinValLabel{nullptr};
-    QLabel*       m_pitchMaxValLabel{nullptr};
+    RangeSlider*  m_pitchRangeSlider{nullptr};
+    RangeSlider*  m_speedRangeSlider{nullptr};
     float         m_cwCostThreshold{0.70f};
 
     // Last CW text source — used by appendCwText / appendCwTextTx so the

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -53,6 +53,8 @@ public:
     float        cwCostThreshold()  const { return m_cwCostThreshold; }
     int speedRangeLow()   const;
     int speedRangeHigh()  const;
+    int pitchRangeLow()   const;
+    int pitchRangeHigh()  const;
 
     QSize sizeHint() const override { return {800, 316}; }
 

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -51,6 +51,8 @@ public:
     QPushButton* lockPitchButton()  const { return m_lockPitchBtn; }
     QPushButton* lockSpeedButton()  const { return m_lockSpeedBtn; }
     float        cwCostThreshold()  const { return m_cwCostThreshold; }
+    int speedRangeLow()   const;
+    int speedRangeHigh()  const;
 
     QSize sizeHint() const override { return {800, 316}; }
 

--- a/src/gui/RangeSlider.cpp
+++ b/src/gui/RangeSlider.cpp
@@ -1,0 +1,162 @@
+#include "RangeSlider.h"
+
+#include <QMouseEvent>
+#include <QPainter>
+#include <algorithm>
+
+RangeSlider::RangeSlider(int min, int max, int low, int high,
+                         const QString& unit, QWidget* parent)
+    : QWidget(parent)
+    , m_min(min), m_max(max)
+    , m_low(std::clamp(low,  min, max))
+    , m_high(std::clamp(high, min, max))
+    , m_unit(unit)
+{
+    setMouseTracking(false);
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+}
+
+void RangeSlider::setLow(int v)
+{
+    v = std::clamp(v, m_min, m_high);
+    if (v == m_low) return;
+    m_low = v;
+    update();
+    emit rangeChanged(m_low, m_high);
+}
+
+void RangeSlider::setHigh(int v)
+{
+    v = std::clamp(v, m_low, m_max);
+    if (v == m_high) return;
+    m_high = v;
+    update();
+    emit rangeChanged(m_low, m_high);
+}
+
+void RangeSlider::setRange(int min, int max)
+{
+    m_min  = min;
+    m_max  = max;
+    m_low  = std::clamp(m_low,  min, max);
+    m_high = std::clamp(m_high, min, max);
+    update();
+}
+
+// ── geometry helpers ────────────────────────────────────────────────────────
+
+QRect RangeSlider::grooveRect() const
+{
+    int gy = (height() - kGrooveH) / 2;
+    return QRect(kLabelW, gy, width() - 2 * kLabelW, kGrooveH);
+}
+
+int RangeSlider::valueToX(int val) const
+{
+    const QRect g = grooveRect();
+    if (m_max == m_min) return g.left();
+    return g.left() + (val - m_min) * g.width() / (m_max - m_min);
+}
+
+int RangeSlider::xToValue(int x) const
+{
+    const QRect g = grooveRect();
+    if (g.width() <= 0) return m_min;
+    return m_min + std::clamp(x - g.left(), 0, g.width())
+                   * (m_max - m_min) / g.width();
+}
+
+QRect RangeSlider::handleRect(int val) const
+{
+    int cx = valueToX(val);
+    int hy = (height() - kHandleH) / 2;
+    return QRect(cx - kHandleW / 2, hy, kHandleW, kHandleH);
+}
+
+// ── painting ────────────────────────────────────────────────────────────────
+
+void RangeSlider::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+
+    const QRect g = grooveRect();
+    const int   xLo = valueToX(m_low);
+    const int   xHi = valueToX(m_high);
+
+    // Groove background
+    p.setPen(Qt::NoPen);
+    p.setBrush(QColor(0x33, 0x33, 0x33));
+    p.drawRoundedRect(g, 2, 2);
+
+    // Highlighted range
+    QRect fill(xLo, g.top(), xHi - xLo, g.height());
+    p.setBrush(QColor(0x19, 0x76, 0xd2));   // Material blue 700
+    p.drawRect(fill);
+
+    // Handles
+    auto drawHandle = [&](int val) {
+        QRect h = handleRect(val);
+        p.setBrush(QColor(0xcc, 0xcc, 0xcc));
+        p.setPen(QPen(QColor(0x19, 0x76, 0xd2), 1));
+        p.drawRoundedRect(h, 2, 2);
+    };
+    drawHandle(m_low);
+    drawHandle(m_high);
+
+    // Value labels
+    QFont f = font();
+    f.setPixelSize(9);
+    p.setFont(f);
+    p.setPen(QColor(0xaa, 0xaa, 0xaa));
+
+    const QString loStr = QString::number(m_low)  + m_unit;
+    const QString hiStr = QString::number(m_high) + m_unit;
+    p.drawText(QRect(0, 0, kLabelW - 2, height()),
+               Qt::AlignRight | Qt::AlignVCenter, loStr);
+    p.drawText(QRect(width() - kLabelW + 2, 0, kLabelW - 2, height()),
+               Qt::AlignLeft | Qt::AlignVCenter, hiStr);
+}
+
+// ── mouse ────────────────────────────────────────────────────────────────────
+
+void RangeSlider::mousePressEvent(QMouseEvent* e)
+{
+    if (e->button() != Qt::LeftButton) return;
+
+    const int px = e->pos().x();
+    const bool nearLow  = std::abs(px - valueToX(m_low))  <= kHandleW;
+    const bool nearHigh = std::abs(px - valueToX(m_high)) <= kHandleW;
+
+    if (nearLow && nearHigh) {
+        // Both at same spot: pick the one in the direction of drag
+        m_dragging = (px <= valueToX(m_low)) ? Handle::Low : Handle::High;
+    } else if (nearLow) {
+        m_dragging = Handle::Low;
+    } else if (nearHigh) {
+        m_dragging = Handle::High;
+    } else {
+        // Click on groove: move nearest handle
+        int v = xToValue(px);
+        m_dragging = (std::abs(v - m_low) <= std::abs(v - m_high))
+                     ? Handle::Low : Handle::High;
+    }
+    mouseMoveEvent(e);
+}
+
+void RangeSlider::mouseMoveEvent(QMouseEvent* e)
+{
+    if (m_dragging == Handle::None) return;
+    const int v = xToValue(e->pos().x());
+    if (m_dragging == Handle::Low)
+        m_low  = std::clamp(v, m_min, m_high);
+    else
+        m_high = std::clamp(v, m_low, m_max);
+    update();
+    emit rangeChanged(m_low, m_high);
+}
+
+void RangeSlider::mouseReleaseEvent(QMouseEvent*)
+{
+    m_dragging = Handle::None;
+}

--- a/src/gui/RangeSlider.cpp
+++ b/src/gui/RangeSlider.cpp
@@ -5,12 +5,15 @@
 #include <algorithm>
 
 RangeSlider::RangeSlider(int min, int max, int low, int high,
-                         const QString& unit, QWidget* parent)
+                         const QString& label, const QString& unit,
+                         QWidget* parent)
     : QWidget(parent)
     , m_min(min), m_max(max)
     , m_low(std::clamp(low,  min, max))
     , m_high(std::clamp(high, min, max))
+    , m_label(label)
     , m_unit(unit)
+    , m_leftLabelW(label.isEmpty() ? kRightLabelW : 55)
 {
     setMouseTracking(false);
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
@@ -48,7 +51,7 @@ void RangeSlider::setRange(int min, int max)
 QRect RangeSlider::grooveRect() const
 {
     int gy = (height() - kGrooveH) / 2;
-    return QRect(kLabelW, gy, width() - 2 * kLabelW, kGrooveH);
+    return QRect(m_leftLabelW, gy, width() - m_leftLabelW - kRightLabelW, kGrooveH);
 }
 
 int RangeSlider::valueToX(int val) const
@@ -104,17 +107,37 @@ void RangeSlider::paintEvent(QPaintEvent*)
     drawHandle(m_low);
     drawHandle(m_high);
 
-    // Value labels
+    // Labels
     QFont f = font();
     f.setPixelSize(9);
     p.setFont(f);
-    p.setPen(QColor(0xaa, 0xaa, 0xaa));
 
-    const QString loStr = QString::number(m_low)  + m_unit;
+    // Left: dim label prefix, bright value
+    const QString loVal = QString::number(m_low) + m_unit;
+    if (!m_label.isEmpty()) {
+        // Draw the prefix in a dimmer color, value in normal color
+        const QString prefix = m_label + " ";
+        QFontMetrics fm(f);
+        const int prefixW = fm.horizontalAdvance(prefix);
+        const int totalW  = prefixW + fm.horizontalAdvance(loVal);
+        const int startX  = m_leftLabelW - 2 - totalW;
+
+        p.setPen(QColor(0x66, 0x66, 0x66));
+        p.drawText(startX, 0, prefixW, height(),
+                   Qt::AlignLeft | Qt::AlignVCenter, prefix);
+        p.setPen(QColor(0xaa, 0xaa, 0xaa));
+        p.drawText(startX + prefixW, 0, fm.horizontalAdvance(loVal) + 2, height(),
+                   Qt::AlignLeft | Qt::AlignVCenter, loVal);
+    } else {
+        p.setPen(QColor(0xaa, 0xaa, 0xaa));
+        p.drawText(QRect(0, 0, m_leftLabelW - 2, height()),
+                   Qt::AlignRight | Qt::AlignVCenter, loVal);
+    }
+
+    // Right: value only
     const QString hiStr = QString::number(m_high) + m_unit;
-    p.drawText(QRect(0, 0, kLabelW - 2, height()),
-               Qt::AlignRight | Qt::AlignVCenter, loStr);
-    p.drawText(QRect(width() - kLabelW + 2, 0, kLabelW - 2, height()),
+    p.setPen(QColor(0xaa, 0xaa, 0xaa));
+    p.drawText(QRect(width() - kRightLabelW + 2, 0, kRightLabelW - 2, height()),
                Qt::AlignLeft | Qt::AlignVCenter, hiStr);
 }
 
@@ -129,14 +152,12 @@ void RangeSlider::mousePressEvent(QMouseEvent* e)
     const bool nearHigh = std::abs(px - valueToX(m_high)) <= kHandleW;
 
     if (nearLow && nearHigh) {
-        // Both at same spot: pick the one in the direction of drag
         m_dragging = (px <= valueToX(m_low)) ? Handle::Low : Handle::High;
     } else if (nearLow) {
         m_dragging = Handle::Low;
     } else if (nearHigh) {
         m_dragging = Handle::High;
     } else {
-        // Click on groove: move nearest handle
         int v = xToValue(px);
         m_dragging = (std::abs(v - m_low) <= std::abs(v - m_high))
                      ? Handle::Low : Handle::High;

--- a/src/gui/RangeSlider.cpp
+++ b/src/gui/RangeSlider.cpp
@@ -1,5 +1,6 @@
 #include "RangeSlider.h"
 
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <QPainter>
 #include <algorithm>
@@ -17,6 +18,8 @@ RangeSlider::RangeSlider(int min, int max, int low, int high,
 {
     setMouseTracking(false);
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    setFocusPolicy(Qt::StrongFocus);
+    setAccessibleName(label.isEmpty() ? tr("Range slider") : label);
 }
 
 void RangeSlider::setLow(int v)
@@ -97,15 +100,20 @@ void RangeSlider::paintEvent(QPaintEvent*)
     p.setBrush(QColor(0x19, 0x76, 0xd2));   // Material blue 700
     p.drawRect(fill);
 
-    // Handles
-    auto drawHandle = [&](int val) {
-        QRect h = handleRect(val);
+    // Handles — focused handle gets a white focus ring
+    auto drawHandle = [&](int val, Handle h) {
+        QRect hr = handleRect(val);
         p.setBrush(QColor(0xcc, 0xcc, 0xcc));
         p.setPen(QPen(QColor(0x19, 0x76, 0xd2), 1));
-        p.drawRoundedRect(h, 2, 2);
+        p.drawRoundedRect(hr, 2, 2);
+        if (hasFocus() && m_focused == h) {
+            p.setBrush(Qt::NoBrush);
+            p.setPen(QPen(QColor(0xff, 0xff, 0xff), 1, Qt::DotLine));
+            p.drawRoundedRect(hr.adjusted(-2, -2, 2, 2), 3, 3);
+        }
     };
-    drawHandle(m_low);
-    drawHandle(m_high);
+    drawHandle(m_low,  Handle::Low);
+    drawHandle(m_high, Handle::High);
 
     // Labels
     QFont f = font();
@@ -162,7 +170,61 @@ void RangeSlider::mousePressEvent(QMouseEvent* e)
         m_dragging = (std::abs(v - m_low) <= std::abs(v - m_high))
                      ? Handle::Low : Handle::High;
     }
+    m_focused = m_dragging;  // clicked handle becomes keyboard target
+    setFocus();
     mouseMoveEvent(e);
+}
+
+void RangeSlider::keyPressEvent(QKeyEvent* e)
+{
+    // On first key press with no focused handle, default to Low
+    if (m_focused == Handle::None)
+        m_focused = Handle::Low;
+
+    switch (e->key()) {
+    case Qt::Key_Tab:
+        m_focused = (m_focused == Handle::Low) ? Handle::High : Handle::Low;
+        update();
+        e->accept();
+        return;
+    case Qt::Key_Backtab:
+        m_focused = (m_focused == Handle::High) ? Handle::Low : Handle::High;
+        update();
+        e->accept();
+        return;
+    case Qt::Key_Left:
+    case Qt::Key_Down:
+        if (m_focused == Handle::Low)
+            setLow(m_low - 1);
+        else
+            setHigh(m_high - 1);
+        e->accept();
+        return;
+    case Qt::Key_Right:
+    case Qt::Key_Up:
+        if (m_focused == Handle::Low)
+            setLow(m_low + 1);
+        else
+            setHigh(m_high + 1);
+        e->accept();
+        return;
+    default:
+        QWidget::keyPressEvent(e);
+    }
+}
+
+void RangeSlider::focusInEvent(QFocusEvent* e)
+{
+    if (m_focused == Handle::None)
+        m_focused = Handle::Low;
+    update();
+    QWidget::focusInEvent(e);
+}
+
+void RangeSlider::focusOutEvent(QFocusEvent* e)
+{
+    update();
+    QWidget::focusOutEvent(e);
 }
 
 void RangeSlider::mouseMoveEvent(QMouseEvent* e)

--- a/src/gui/RangeSlider.h
+++ b/src/gui/RangeSlider.h
@@ -10,8 +10,11 @@
 class RangeSlider : public QWidget {
     Q_OBJECT
 public:
+    // label: short prefix drawn left of the low value (e.g. "Pitch", "WPM")
+    // unit:  suffix appended to each value (e.g. " Hz")
     explicit RangeSlider(int min, int max, int low, int high,
-                         const QString& unit = {},
+                         const QString& label = {},
+                         const QString& unit  = {},
                          QWidget* parent = nullptr);
 
     int  low()  const { return m_low; }
@@ -21,8 +24,8 @@ public:
     void setHigh(int v);
     void setRange(int min, int max);
 
-    QSize sizeHint() const override { return {160, 20}; }
-    QSize minimumSizeHint() const override { return {100, 18}; }
+    QSize sizeHint()        const override { return {m_leftLabelW + 100 + kRightLabelW, 20}; }
+    QSize minimumSizeHint() const override { return {m_leftLabelW +  60 + kRightLabelW, 18}; }
 
 signals:
     void rangeChanged(int low, int high);
@@ -35,12 +38,14 @@ protected:
 
 private:
     int m_min, m_max, m_low, m_high;
+    QString m_label;
     QString m_unit;
 
-    static constexpr int kLabelW   = 30;   // px reserved each side for value text
-    static constexpr int kGrooveH  =  4;   // groove height
-    static constexpr int kHandleW  =  8;   // handle width
-    static constexpr int kHandleH  = 14;   // handle height
+    static constexpr int kRightLabelW = 30;  // px for right value text
+    static constexpr int kGrooveH     =  4;
+    static constexpr int kHandleW     =  8;
+    static constexpr int kHandleH     = 14;
+    int m_leftLabelW{30};                    // wider when m_label is set
 
     enum class Handle { None, Low, High } m_dragging{Handle::None};
 

--- a/src/gui/RangeSlider.h
+++ b/src/gui/RangeSlider.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <QWidget>
+
+// Compact double-handle range slider.
+//
+// Renders a groove with a highlighted bar between two draggable handles.
+// The current low/high values are drawn as labels on either side.
+// Emits rangeChanged(int low, int high) on every change.
+class RangeSlider : public QWidget {
+    Q_OBJECT
+public:
+    explicit RangeSlider(int min, int max, int low, int high,
+                         const QString& unit = {},
+                         QWidget* parent = nullptr);
+
+    int  low()  const { return m_low; }
+    int  high() const { return m_high; }
+
+    void setLow(int v);
+    void setHigh(int v);
+    void setRange(int min, int max);
+
+    QSize sizeHint() const override { return {160, 20}; }
+    QSize minimumSizeHint() const override { return {100, 18}; }
+
+signals:
+    void rangeChanged(int low, int high);
+
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+    void mouseReleaseEvent(QMouseEvent*) override;
+
+private:
+    int m_min, m_max, m_low, m_high;
+    QString m_unit;
+
+    static constexpr int kLabelW   = 30;   // px reserved each side for value text
+    static constexpr int kGrooveH  =  4;   // groove height
+    static constexpr int kHandleW  =  8;   // handle width
+    static constexpr int kHandleH  = 14;   // handle height
+
+    enum class Handle { None, Low, High } m_dragging{Handle::None};
+
+    QRect grooveRect()        const;
+    QRect handleRect(int val) const;
+    int   valueToX(int val)   const;
+    int   xToValue(int x)     const;
+};

--- a/src/gui/RangeSlider.h
+++ b/src/gui/RangeSlider.h
@@ -35,6 +35,9 @@ protected:
     void mousePressEvent(QMouseEvent*) override;
     void mouseMoveEvent(QMouseEvent*) override;
     void mouseReleaseEvent(QMouseEvent*) override;
+    void keyPressEvent(QKeyEvent*) override;
+    void focusInEvent(QFocusEvent*) override;
+    void focusOutEvent(QFocusEvent*) override;
 
 private:
     int m_min, m_max, m_low, m_high;
@@ -47,7 +50,9 @@ private:
     static constexpr int kHandleH     = 14;
     int m_leftLabelW{30};                    // wider when m_label is set
 
-    enum class Handle { None, Low, High } m_dragging{Handle::None};
+    enum class Handle { None, Low, High };
+    Handle m_dragging{Handle::None};
+    Handle m_focused {Handle::None};  // handle that responds to keyboard
 
     QRect grooveRect()        const;
     QRect handleRect(int val) const;

--- a/third_party/ggmorse/include/ggmorse/ggmorse.h
+++ b/third_party/ggmorse/include/ggmorse/ggmorse.h
@@ -46,6 +46,8 @@ extern "C" {
         float speed_wpm;
         float frequencyRangeMin_hz;
         float frequencyRangeMax_hz;
+        float speedRangeMin_wpm;    // coarse search lower bound (-1 = use default 5 WPM)
+        float speedRangeMax_wpm;    // coarse search upper bound (-1 = use default 55 WPM)
 
         bool applyFilterHighPass;
         bool applyFilterLowPass;

--- a/third_party/ggmorse/src/ggmorse.cpp
+++ b/third_party/ggmorse/src/ggmorse.cpp
@@ -191,10 +191,12 @@ const GGMorse::Parameters & GGMorse::getDefaultParameters() {
 
 const GGMorse::ParametersDecode & GGMorse::getDefaultParametersDecode() {
     static ggmorse_ParametersDecode result {
-        -1.0f,
-        -1.0f,
-        200.0f,
-        1200.0f,
+        -1.0f,    // frequency_hz — auto
+        -1.0f,    // speed_wpm    — auto
+        200.0f,   // frequencyRangeMin_hz
+        1200.0f,  // frequencyRangeMax_hz
+        -1.0f,    // speedRangeMin_wpm — use full range
+        -1.0f,    // speedRangeMax_wpm — use full range
         true,
         true,
     };
@@ -750,12 +752,15 @@ void GGMorse::decode_float() {
     int bestLevelIdx = 0;
     int bestSpeedIdx = 0;
 
-    int s0 = 0;
-    int s1 = 50;
-    int ds = 10;
+    // Speed range from caller (s-index = wpm - 5). Default 5..115 WPM.
+    const float sRangeMin = m_impl->parametersDecode.speedRangeMin_wpm;
+    const float sRangeMax = m_impl->parametersDecode.speedRangeMax_wpm;
+    int s0 = (sRangeMin > 0.0f) ? std::max(0, (int)std::round(sRangeMin - 5.0f)) : 0;
+    int s1 = (sRangeMax > 0.0f) ? std::min(110, (int)std::round(sRangeMax - 5.0f)) : 110;
+    int ds = 2;   // step of 2 WPM — was 10; finer grid catches any contest speed
     int nModes = 2;
 
-    if (speed_wpm > 0.0f && speed_wpm < 100.0f) {
+    if (speed_wpm > 0.0f && speed_wpm < 200.0f) {
         s0 = s1 = std::round(speed_wpm - 5.0f);
         nModes = 1;
     }

--- a/third_party/ggmorse/src/ggmorse.cpp
+++ b/third_party/ggmorse/src/ggmorse.cpp
@@ -779,7 +779,7 @@ void GGMorse::decode_float() {
         int l1 = (mode == 0) ? 90 : lOld + 10;
         int dl = (mode == 0) ? 20 : 2;
 
-        for (int s = s0; s <= s1 && s < 55; s += ds) {
+        for (int s = s0; s <= s1; s += ds) {
             float lendot_samples = kBaseSampleRate*(1e-3*lendot_ms(5 + s))/nDownsample;
 
             for (int l = l0; l <= l1; l += dl) {

--- a/third_party/ggmorse/src/ggmorse.cpp
+++ b/third_party/ggmorse/src/ggmorse.cpp
@@ -227,7 +227,7 @@ GGMorse::GGMorse(const Parameters & parameters)
         parameters.samplesPerFrame,
     })) {
 
-    m_impl->intervalsAll.resize(100);
+    m_impl->intervalsAll.resize(120);  // must be > max s-index (s = wpm-5, max 115 WPM → s=110)
     for (auto & intervals : m_impl->intervalsAll) {
         intervals.resize(100);
         for (auto & x : intervals) {
@@ -756,7 +756,7 @@ void GGMorse::decode_float() {
     const float sRangeMin = m_impl->parametersDecode.speedRangeMin_wpm;
     const float sRangeMax = m_impl->parametersDecode.speedRangeMax_wpm;
     int s0 = (sRangeMin > 0.0f) ? std::max(0, (int)std::round(sRangeMin - 5.0f)) : 0;
-    int s1 = (sRangeMax > 0.0f) ? std::min(110, (int)std::round(sRangeMax - 5.0f)) : 110;
+    int s1 = (sRangeMax > 0.0f) ? std::min(110, (int)std::round(sRangeMax - 5.0f)) : 50;
     int ds = 2;   // step of 2 WPM — was 10; finer grid catches any contest speed
     int nModes = 2;
 

--- a/third_party/ggmorse/src/ggmorse.cpp
+++ b/third_party/ggmorse/src/ggmorse.cpp
@@ -761,7 +761,7 @@ void GGMorse::decode_float() {
     int nModes = 2;
 
     if (speed_wpm > 0.0f && speed_wpm < 200.0f) {
-        s0 = s1 = std::round(speed_wpm - 5.0f);
+        s0 = s1 = std::min(110, (int)std::round(speed_wpm - 5.0f));
         nModes = 1;
     }
 
@@ -769,8 +769,8 @@ void GGMorse::decode_float() {
 
     for (int mode = 0; mode < nModes; ++mode) {
         if (mode == 1) {
-            s0 = std::min(std::max(0.0f, std::round(m_impl->statistics.estimatedSpeed_wpm - 5.0f - 2.0f)), 50.0f);
-            s1 = std::min(std::max(0.0f, std::round(m_impl->statistics.estimatedSpeed_wpm - 5.0f + 2.0f)), 50.0f);
+            s0 = std::min(std::max(0.0f, std::round(m_impl->statistics.estimatedSpeed_wpm - 5.0f - 2.0f)), 110.0f);
+            s1 = std::min(std::max(0.0f, std::round(m_impl->statistics.estimatedSpeed_wpm - 5.0f + 2.0f)), 110.0f);
             ds = 1;
         }
 


### PR DESCRIPTION
## Summary

Introduces a new reusable \`RangeSlider\` widget and uses it to improve the CW toolbar in two ways: replacing the existing two-slider pitch control with a single double-ended slider, and adding a WPM speed range control that didn't previously exist. Also tightens ggmorse's speed search step to eliminate missed WPM values.

## Changes

### New widget — \`RangeSlider\` (\`src/gui/RangeSlider.h/.cpp\`)
A standalone Qt widget with two draggable handles on a shared groove. Handles cannot cross. Features an embedded dim label prefix (e.g. "Pitch", "WPM") rendered inside the left margin — no separate label widget needed. Blue fill between handles (Material blue 700 \`#1976d2\`).
- Signal: \`rangeChanged(int low, int high)\`
- Slots: \`setLow\`, \`setHigh\`, \`setRange\`
- No external dependencies beyond Qt

### Pitch control — two sliders → one \`RangeSlider\`
The existing "Lo:" / "Hi:" slider pair (two separate \`GuardedSlider\` widgets with clamp logic) is replaced by a single \`RangeSlider\` (300–1200 Hz, default 500–700 Hz). Saves toolbar space, removes the clamp workaround, and makes the range relationship visually obvious.

### WPM range control — new
Adds a \`RangeSlider\` (5–60 WPM, default 15–40 WPM) giving the user control over ggmorse's speed search bounds for the first time. Wired through a new \`CwDecoder::setSpeedRange(int, int)\` slot connected in \`MainWindow\`.

### ggmorse speed search — \`ds\` 10 → 2
The downsample step in ggmorse's speed search was 10, causing it to test only 5, 15, 25, 35, 45, 55 WPM — missing 10, 20, 30, 40, and 50 WPM entirely. Reduced to ds=2, testing every 2 WPM within the configured range.

## Test plan
- [ ] Pitch \`RangeSlider\` — both handles drag; handles cannot cross; ggmorse pitch search respects the set bounds
- [ ] WPM \`RangeSlider\` — both handles drag; ggmorse speed search respects the set bounds
- [ ] ggmorse correctly decodes 30 WPM and 40 WPM signals (previously missed at ds=10)
- [ ] Embedded labels ("Pitch", "WPM") render correctly inside the widget
- [ ] No regressions in existing CW decode path

🤖 Generated with [Claude Code](https://claude.com/claude-code)