### PR TITLE
fix(gui): only toast "Step: …" on deliberate step changes, not radio syncs

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3309,10 +3309,36 @@ MainWindow::MainWindow(QWidget* parent)
     });
 #endif
 
-    // ── Tuning step size → AppSettings + radio command ─────────────────────
-    // Per-pan SpectrumWidget::setStepSize connections are made in wirePanadapter()
-    // so all pans (including new ones added at runtime) stay in sync.
+    // ── Tuning step size ───────────────────────────────────────────────────
+    // Two connections, split by source.  stepSizeChanged fires for ANY step
+    // change, including radio-driven syncs (syncStepFromSlice) after a memory
+    // recall or band crossing — so only source-agnostic bookkeeping that must
+    // track the radio's current step belongs here.  Per-pan
+    // SpectrumWidget::setStepSize connections are made in wirePanadapter() so
+    // all pans (including new ones added at runtime) stay in sync.
     connect(m_appletPanel->rxApplet(), &RxApplet::stepSizeChanged,
+            this, [this](int step) {
+        if (m_flexControlDialog)
+            m_flexControlDialog->setStepSize(step);
+        // Invalidate persistent encoder accumulators so the next tick rebases
+        // and re-snaps to the new step grid. Without this, an in-flight target
+        // computed against the previous step size carries an off-grid residual
+        // (e.g. step 20 Hz → 500 Hz leaves a 60 Hz tail; #3260).  This must run
+        // for radio-driven step changes too, so it stays on stepSizeChanged.
+        m_flexTargetMhz = -1.0;
+        m_flexCoalesceTimer.stop();
+#ifdef HAVE_MIDI
+        m_midiTuneTargetMhz = -1.0;
+        m_midiTuneIdleTimer.stop();
+#endif
+    });
+    // Deliberate operator step changes only (STEP buttons/scroll, cycle
+    // shortcuts, encoder push).  These push to the radio, persist, and show a
+    // brief toast.  Routing them through stepSizeChangedByUser keeps them off
+    // radio-driven syncs — otherwise every memory-spot recall or band crossing
+    // echoes a redundant `slice set step=` and spams a "Step: …" toast
+    // (the radio is already authoritative for the slice's step).
+    connect(m_appletPanel->rxApplet(), &RxApplet::stepSizeChangedByUser,
             this, [this](int step) {
         // Send step to radio for the active slice
         if (auto* s = m_radioModel.slice(m_activeSliceId))
@@ -3321,28 +3347,14 @@ MainWindow::MainWindow(QWidget* parent)
         auto& settings = AppSettings::instance();
         settings.setValue("TuningStepSize", QString::number(step));
         settings.save();
-        if (m_flexControlDialog)
-            m_flexControlDialog->setStepSize(step);
-        {
-            QString stepStr;
-            if (step >= 1000000)
-                stepStr = QString("%1 MHz").arg(step / 1000000.0, 0, 'f', step % 1000000 ? 1 : 0);
-            else if (step >= 1000)
-                stepStr = QString("%1 kHz").arg(step / 1000.0, 0, 'f', step % 1000 ? 1 : 0);
-            else
-                stepStr = QString("%1 Hz").arg(step);
-            statusBar()->showMessage(QString("Step: %1").arg(stepStr), 2000);
-        }
-        // Invalidate persistent encoder accumulators so the next tick rebases
-        // and re-snaps to the new step grid. Without this, an in-flight target
-        // computed against the previous step size carries an off-grid residual
-        // (e.g. step 20 Hz → 500 Hz leaves a 60 Hz tail; #3260).
-        m_flexTargetMhz = -1.0;
-        m_flexCoalesceTimer.stop();
-#ifdef HAVE_MIDI
-        m_midiTuneTargetMhz = -1.0;
-        m_midiTuneIdleTimer.stop();
-#endif
+        QString stepStr;
+        if (step >= 1000000)
+            stepStr = QString("%1 MHz").arg(step / 1000000.0, 0, 'f', step % 1000000 ? 1 : 0);
+        else if (step >= 1000)
+            stepStr = QString("%1 kHz").arg(step / 1000.0, 0, 'f', step % 1000 ? 1 : 0);
+        else
+            stepStr = QString("%1 Hz").arg(step);
+        statusBar()->showMessage(QString("Step: %1").arg(stepStr), 2000);
     });
     int savedStep = AppSettings::instance().value("TuningStepSize", "100").toInt();
     for (auto* a : m_panStack->allApplets()) a->spectrumWidget()->setStepSize(savedStep);

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -608,6 +608,7 @@ void RxApplet::buildUI()
                 m_stepIdx--;
                 m_stepLabel->setText(formatStepLabel(m_stepSizes[m_stepIdx]));
                 emit stepSizeChanged(m_stepSizes[m_stepIdx]);
+                emit stepSizeChangedByUser(m_stepSizes[m_stepIdx]);
             }
         };
         auto stepUp = [this] {
@@ -615,6 +616,7 @@ void RxApplet::buildUI()
                 m_stepIdx++;
                 m_stepLabel->setText(formatStepLabel(m_stepSizes[m_stepIdx]));
                 emit stepSizeChanged(m_stepSizes[m_stepIdx]);
+                emit stepSizeChangedByUser(m_stepSizes[m_stepIdx]);
             }
         };
         connect(m_stepDown, &QPushButton::clicked, this, stepDown);
@@ -2544,6 +2546,7 @@ void RxApplet::cycleStepUp()
     m_stepIdx = (m_stepIdx + 1) % m_stepSizes.size();
     m_stepLabel->setText(formatStepLabel(m_stepSizes[m_stepIdx]));
     emit stepSizeChanged(m_stepSizes[m_stepIdx]);
+    emit stepSizeChangedByUser(m_stepSizes[m_stepIdx]);
 }
 
 void RxApplet::cycleStepDown()
@@ -2552,6 +2555,7 @@ void RxApplet::cycleStepDown()
         m_stepIdx--;
         m_stepLabel->setText(formatStepLabel(m_stepSizes[m_stepIdx]));
         emit stepSizeChanged(m_stepSizes[m_stepIdx]);
+        emit stepSizeChangedByUser(m_stepSizes[m_stepIdx]);
     }
 }
 

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -96,8 +96,16 @@ signals:
     void sliceActivationRequested(int sliceId);
     // Emitted when the user adjusts the AF gain slider (0–100).
     void afGainChanged(int value);
-    // Emitted when the user changes the tuning step size (Hz).
+    // Emitted whenever the tuning step size changes (Hz), from ANY source —
+    // including radio-driven syncs via syncStepFromSlice() (memory recall,
+    // band crossing). Connect source-agnostic UI sync here (e.g. SpectrumWidget
+    // scroll-to-tune step), but NOT command echoes or user-facing toasts.
     void stepSizeChanged(int hz);
+    // Emitted only when the operator deliberately changes the step (STEP
+    // buttons/scroll, cycle shortcuts, encoder push). Use this for actions
+    // that should not fire on radio-driven syncs: pushing to the radio,
+    // persisting, and the "Step: …" status-bar toast.
+    void stepSizeChangedByUser(int hz);
     // Emitted when Auto SQL tracking is toggled.
     void sqlAutoChanged(bool on);
     // Emitted on every SQL mode transition (Off / Manual / Auto), so any


### PR DESCRIPTION
## Summary

Clicking a memory spot popped a status-bar toast on every recall — **\`Step: 250 Hz\`** on an AM spot, **\`Step: 100 Hz\`** on an LSB spot, etc. The step values are correct and radio-authoritative; the bug is that they were being announced.

## Root cause

The \`Step: …\` status-bar toast (added with the HID-encoder work, [MainWindow.cpp](src/gui/MainWindow.cpp)) lived in the \`RxApplet::stepSizeChanged\` handler. That signal fires for **every** step change — including \`RxApplet::syncStepFromSlice()\`, the radio-driven sync that runs whenever the radio pushes a new per-band/per-mode step. A memory-spot click does \`memory apply\` → the radio echoes the slice's step → \`stepChanged\` → \`syncStepFromSlice\` → \`stepSizeChanged\` → toast. The same handler also echoed a redundant \`slice set step=\` back to the radio for the radio's *own* push, even though step is radio-authoritative.

## Fix — split the signal by source

- **\`stepSizeChanged\`** (any source, incl. radio sync) keeps only the source-agnostic bookkeeping that must track the radio's current step: the FlexControl dialog readout and the encoder-accumulator rebase (#3260).
- **\`stepSizeChangedByUser\`** (new) is emitted only from deliberate operator actions — STEP buttons/scroll, cycle shortcuts, encoder push — and carries the radio command, \`AppSettings\` persistence, and the toast.

Net effect: manual step changes still confirm with a toast and push to the radio; radio-driven syncs (memory recall, band crossing) update the UI silently — no toast, no command echo.

## Files

- \`src/gui/RxApplet.h\` / \`src/gui/RxApplet.cpp\` — add \`stepSizeChangedByUser\`, emit it from the four operator paths (STEP up/down buttons, cycle up/down).
- \`src/gui/MainWindow.cpp\` — split the one handler into two connections by source.

## Note for maintainer review

This is a UX-surfacing decision (when the \`Step: …\` toast should appear), so flagging per the AI-agent boundaries in \`CLAUDE.md\`. The toast is preserved for deliberate operator step changes — including the hardware-encoder push it was originally added for — and only suppressed for radio-driven syncs. The redundant \`slice set step=\` echo on radio pushes is also removed as a side benefit (consistent with the radio-authoritative-settings policy).

## Test

- Builds clean (\`cmake --build\`, RelWithDebInfo, Ninja, macOS).
- Manual: click AM/LSB memory spots → step still applies correctly, no toast. Cycle step with \`[\` / \`]\` and the STEP buttons → toast still shows.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat