### PR TITLE
fix(gui): guard UlanziDial member type with HAVE_HIDAPI on Windows (#3343)

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -98,10 +98,12 @@ class RC28MappingDialog;
 class UlanziDialMapperDialog;
 #ifdef Q_OS_LINUX
 class EvdevEncoderManager;
-#elif defined(Q_OS_WIN)
+#elif defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
 class UlanziDialWindowsManager;
 #elif defined(Q_OS_MAC)
 class UlanziDialMacOSManager;
+#else
+class UlanziDialBackend;
 #endif
 class CwxPanel;
 class DvkPanel;
@@ -576,10 +578,12 @@ private:
 #endif
 #ifdef Q_OS_LINUX
     EvdevEncoderManager*       m_dialBackend{nullptr};
-#elif defined(Q_OS_WIN)
+#elif defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
     UlanziDialWindowsManager*  m_dialBackend{nullptr};
 #elif defined(Q_OS_MAC)
     UlanziDialMacOSManager*    m_dialBackend{nullptr};
+#else
+    UlanziDialBackend*         m_dialBackend{nullptr};
 #endif
     QTimer                     m_dialCoalesceTimer;
     int                        m_dialPendingSteps{0};


### PR DESCRIPTION
## Problem

Introduced by #3239 (Ulanzi Dial Windows backend). MinGW builds on Windows
**without** hidapi fail on `MainWindow.cpp` with:

    error: cannot convert 'AetherSDR::UlanziDialBackend*' to
           'AetherSDR::UlanziDialWindowsManager*' in assignment
    error: invalid use of incomplete type
           'class AetherSDR::UlanziDialWindowsManager'

`MainWindow.h` declared `m_dialBackend` as `UlanziDialWindowsManager*` under
`#elif defined(Q_OS_WIN)` — no `HAVE_HIDAPI` check. But `UlanziDialBackend.h`
only aliases `UlanziDialWindowsManager` under `Q_OS_WIN && HAVE_HIDAPI`; without
hidapi it falls through to a no-op stub class. The member type is an incomplete
forward-declared class unrelated to the alias, making assignment, `moveToThread`,
and all `connect()` calls fail to compile.

CI uses MSVC + hidapi so this was never caught by the build gate.

## Fix

Add `&& defined(HAVE_HIDAPI)` to both the forward-declaration and member-
declaration guards for `UlanziDialWindowsManager` in `MainWindow.h`. Add an
`#else` fallback in both spots using `UlanziDialBackend*` (the no-op stub).

## Testing

Built on Windows 11 / MinGW GCC 13.1.0 / Qt 6.11.0 without hidapi — full
build succeeds, `AetherSDR.exe` launches. No logic change on any platform
that already compiles (Linux evdev, Windows+hidapi, macOS).

## Files changed

- `src/gui/MainWindow.h` — 6 lines (2 guard conditions + 2 `#else` entries)

## CODEOWNERS note

`src/gui/MainWindow.h` is in the **maintainer-only** tier — requires
`@ten9876` review.

Fixes #3343