### PR TITLE
feat(agc): AGC-T noise-floor calibration tool (engine + panel)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,6 +485,7 @@ endif()
 # Sources
 set(CORE_SOURCES
     src/core/AppSettings.cpp
+    src/core/AgcTCalibrator.cpp
     src/core/SettingsHelpers.cpp
     src/core/ThemeManager.cpp
     src/core/BandStackSettings.cpp
@@ -621,6 +622,7 @@ set(MODEL_SOURCES
 
 set(GUI_SOURCES
     src/gui/MainWindow.cpp
+    src/gui/AgcCalibrationDialog.cpp
     src/gui/AudioDeviceChangeDialog.cpp
     src/gui/ConnectionPanel.cpp
     src/gui/ClientDisconnectDialog.cpp

--- a/docs/agc-t-calibration-design.md
+++ b/docs/agc-t-calibration-design.md
@@ -1,0 +1,320 @@
+# AGC-T Noise-Floor Calibration — Design
+
+**Status:** Proposal (no code yet)
+**Author:** Claude (Opus 4.8) with architecture by @jensenpat
+**Date:** 2026-06-01
+**Scope:** Help users set the "perfect" AGC-T value per band by calibrating it
+against the receiver noise floor, with a live visual aid and per-band recall.
+
+---
+
+## 0. Locked decisions (decision pass, 2026-06-01)
+
+Bias for all decisions: **successful, consistent operation for every operator
+skill level.** Still subject to maintainer (Jeremy/KK7GWY) sign-off on visuals.
+
+| # | Decision | Choice |
+|---|----------|--------|
+| Surface | How it's shown | **Panel + optional ambient pan line** (Option C, §5) |
+| Default mode | First action on open | **Auto-sweep first**; live curve shown, manual fine-tune always available (§4) |
+| Entry point | How it launches | **Right-click the AGC-T slider** — clean, no new chrome (§7) |
+| Per-band recall | On band change | **Suggest, never auto-apply** — lightweight prompt, no silent changes (§6) |
+| AGC-off target | Comfortable-noise setpoint | **Sensible fixed default**, exposed behind an "advanced" reveal (§4) |
+
+**Two flagged tensions** (chosen options trade against the all-skill-levels
+bias; mitigations adopted so we don't regress beginners):
+
+- *Right-click-only hurts discoverability.* Mitigation: the slider tooltip
+  states "Right-click to calibrate AGC-T against the noise floor," plus a
+  one-time discovery hint. Keeps the clean look while making the feature
+  findable.
+- *"Suggest, never auto-apply" adds per-band friction.* Mitigation: the
+  suggestion is a **non-modal, dismissible chip/banner** (never a blocking
+  dialog), with a per-band "don't suggest again" so it can't nag.
+
+---
+
+## 1. Goal
+
+SmartSDR users must re-tweak AGC-T every time band conditions or noise floor
+change, and the 0–100 knob has no obvious relationship to anything visible on
+screen. We want to (a) make finding the AGC-T "sweet spot" fast and visual,
+(b) optionally automate it, and (c) remember a good value per band so band
+changes don't force a re-tweak.
+
+---
+
+## 2. Background: what AGC-T actually does (the load-bearing distinction)
+
+There are **two different radio knobs**, both 0–100, both surfaced through the
+single AGC-T slider in `RxApplet`, selected by AGC mode:
+
+| AGC mode | Radio command | FlexLib property | What the value means |
+|----------|---------------|------------------|----------------------|
+| slow / med / fast | `slice set <id> agc_threshold=<0-100>` | `AGCThreshold` | The **knee**: signal level above which AGC begins applying gain. Set it just above the noise floor so AGC never pumps up band noise. |
+| off | `slice set <id> agc_off_level=<0-100>` | `AGCOffLevel` | A **fixed gain** applied to everything regardless of level. No knee. |
+
+The classic FlexRadio procedure — "tune to a clear spot, lower AGC-T until the
+background noise *just begins to decrease*, then back off slightly" — is a
+description of finding the **knee**, and it only applies when **AGC is ON**.
+([FlexRadio: How AGC works](https://helpdesk.flexradio.com/hc/en-us/articles/360029494371),
+[AGC-T adjustment procedure](https://community.flexradio.com/discussion/8027708/smartsdr-agc-t-adjustment-procedure))
+
+When AGC is **OFF**, `agc_off_level` is just fixed gain: turning it up makes
+both noise and signals monotonically louder, with no SNR benefit, and the
+operator must ride RF Gain to avoid overload. So "calibrate against the noise
+floor" with AGC off means something different: **pick the fixed gain that
+places the band-noise audio at a comfortable target level without overload** —
+a setpoint solve, not a knee-find.
+
+**Design consequence:** the tool must be AGC-mode aware. It runs a *knee-find*
+when AGC is on (`agc_threshold`) and a *target-level solve* when AGC is off
+(`agc_off_level`). The user's stated interest in the off-mode case is fully
+supported, but we present it honestly as "set comfortable noise gain," not as a
+mythical off-mode knee.
+
+### The crucial observability fact
+
+The 0–100 value is **arbitrary** — neither the radio status nor FlexLib exposes
+its dBm equivalent; the firmware maps it internally. Two consequences:
+
+1. We **cannot** analytically compute the "perfect" value from the noise floor.
+   We must find it **empirically** by observing the receiver's response while
+   we move the knob.
+2. The **RF noise floor in dBm does not change when AGC-T moves** (it's measured
+   off the pre-AGC FFT). The *only* observable that bends at the knee is the
+   **post-AGC audio level**. This is what the FlexRadio procedure means by
+   "the background noise begins to decrease" — it's an *audio* observation.
+
+---
+
+## 3. Signals we can measure (and which one is useful)
+
+| Signal | Source | Units | Moves with AGC-T? | Use |
+|--------|--------|-------|-------------------|-----|
+| RF noise floor | `SpectrumWidget::noiseFloorDbm()` (getter only, EMA-smoothed two-pass trimmed mean) `src/gui/SpectrumWidget.cpp:911` | dBm | **No** | Quiet-spot guard; ambient pan reference line; band fingerprint |
+| S-meter / LEVEL | `MeterModel::sLevelChanged(slice, dbm)` `src/models/MeterModel.cpp:620`, ~100 Hz | dBm | **No** (RF domain) | Quiet-spot guard (passband signal+noise vs floor) |
+| **Post-AGC audio RMS** | **`AudioEngine::levelChanged(float rms)`** `src/core/AudioEngine.h:476`, per audio frame (~10–20 ms) | linear 0–1 | **Yes — bends at the knee** | **The calibration observable** |
+
+There is **no AGC-gain-reduction meter** exposed by the radio, so we infer the
+knee from audio RMS, not from a gain-reduction readout.
+
+Note: `levelChanged` is emitted at several taps (pre-NR raw at
+`AudioEngine.cpp:1320`, and post each NR stage). For a clean, repeatable curve
+the calibration should read the **raw pre-NR tap** and hold AF gain + all NR
+constant during a sweep, so the only variable is AGC-T. (Implementation detail:
+either select the raw tap, or temporarily freeze NR/AF for the sweep duration
+and restore.)
+
+---
+
+## 4. The calibration engine (shared by manual and auto)
+
+Manual and auto are the **same engine** at different speeds — this is why
+"manual vs auto" isn't really a fork. The engine is: *set AGC-T → wait for AGC
+to settle → record audio RMS → repeat*. Manual = the user is the stepper; Auto
+= a timer is the stepper.
+
+### Sweep (auto)
+1. **Pre-flight guards:**
+   - AGC mode known; remember current AGC-T value for restore-on-cancel.
+   - Verify the passband is **quiet**: S-meter (LEVEL) within a small margin of
+     the measured noise floor, and no signal peak inside the filter passband on
+     the FFT. If not quiet, surface "tune to a clear spot" and refuse/auto-find
+     a clear segment within the current pan.
+   - Freeze AF gain and NR (or read raw tap) for the sweep.
+2. **Coarse pass:** step AGC-T high→low (e.g. 100→0 in steps of ~5), with a
+   per-step **settle delay** (~250–300 ms — the radio AGC needs time to react;
+   FlexRadio explicitly warns to wait after each change). Record `(value, rms)`.
+3. **Knee detection (AGC on):** find the point of maximum downward curvature /
+   where the slope first exceeds a threshold as noise starts dropping. Apply the
+   documented "back off slightly" by nudging a couple of points toward higher
+   threshold (more conservative). This is the sweet spot.
+4. **Fine pass (optional):** re-sweep ±10 around the candidate in steps of 1–2
+   for a precise knee.
+5. **Target solve (AGC off):** instead of a knee, interpolate the monotonic
+   `value→rms` curve to hit a chosen audio-noise setpoint (default ≈ a
+   comfortable dBFS), clamped to avoid overload (watch for clipping / S-meter
+   spikes).
+6. **Result:** propose a value; user Applies (sends the `slice set` command) or
+   Cancels (restores original). Optionally "Save for this band."
+
+Full coarse sweep cost ≈ 20 points × ~275 ms ≈ **~6 s**; coarse+fine ≈ **~10 s**.
+Acceptable; show a progress indicator and keep Cancel responsive.
+
+### Manual
+Same pipeline, but the user drags the AGC-T slider and the panel plots the live
+`(value, rms)` curve as points accumulate, with the detected-knee marker
+updating live. The user sees exactly where the noise starts to fall and can
+click "set to knee" or fine-tune by ear. This is the more trustworthy default
+(matches the user's instinct that manual is more consistent) and doubles as the
+data source for auto.
+
+---
+
+## 5. Viewing surface — options and recommendation
+
+The calibration variable (AGC-T, 0–100, audio domain) and its response (audio
+RMS) live in a coordinate space that is **not** the pan's frequency×dBm space.
+That governs the choice.
+
+**Option A — Dedicated live-graph panel (RECOMMENDED).**
+A small non-modal, frameless calibration window with a 2D plot:
+**x = AGC-T (0–100), y = audio-noise level (dB, relative)**. Overlays: live
+sweep curve, current-value marker, detected-knee marker (the sweet spot),
+optional target-level line (AGC-off mode). Controls: Start/Stop auto sweep,
+"Apply", "Save for band", AGC-mode/quiet-spot status chips. *Pros:* the curve
+makes the knee unmistakable; honest representation of what AGC-T does; doesn't
+clutter the pan; reusable across modes. *Cons:* a new window.
+
+**Option B — Line on the pan surface.**
+Draw the *measured RF noise floor* as a horizontal dBm reference line on the
+pan (a thin label like "NF −124 dBm"). *Pros:* always-on context, cheap (the
+floor is already computed; `DisplayNoiseFloor*` settings already exist).
+*Cons:* it **cannot honestly show AGC-T** — AGC-T is 0–100 in the audio domain
+and the floor line doesn't move when you turn the knob. Presenting it as "the
+AGC-T line" would mislead. Good as *ambient context*, not as the calibration
+instrument.
+
+**Option C — Hybrid (RECOMMENDED overall): A + B.**
+Use the dedicated panel (A) to *do* the calibration, and offer an optional
+persistent noise-floor reference line on the pan (B) for at-a-glance context
+between calibrations. Plus per-band recall (Section 6) so the result actually
+sticks. This gives the best of both without conflating domains.
+
+**Rejected:** trying to render an "AGC-T line" directly on the pan in dBm. It
+would require inventing/learning a 0–100→dBm mapping the firmware refuses to
+expose, and it would still be a static line that doesn't respond to the knob —
+exactly the wrong mental model.
+
+---
+
+## 6. Per-band persistence
+
+Per-band recall is the feature that makes this stick: calibrate once per band,
+and switching bands re-applies the good value.
+
+**Existing hooks (reuse, don't reinvent):**
+- `BandSnapshot { QString agcMode; int agcThreshold; }` `src/models/BandSettings.h:19`
+- `BandStackEntry { QString agcMode; int agcThreshold; }` `src/core/BandStackSettings.h:16`
+  persisted to `~/.config/AetherSDR/BandStack.settings`.
+- `bandForFrequency()` maps MHz → band name; `SliceModel::frequencyChanged` is
+  the trigger point.
+
+**Behavior (decision: suggest, never auto-apply):** on a deliberate band change
+to a band that has a stored calibration, show a **non-modal, dismissible
+chip/banner**: "Calibrated AGC-T (N) available for 20m — apply?" Applying
+**sends** the value as a `slice set` command (radio stays authoritative).
+Dismissing leaves the radio's current value untouched. A per-band "don't suggest
+again" suppresses the chip for that band. No value is ever applied silently.
+
+**Radio-authoritative policy nuance (important):** CLAUDE.md lists AGC/DSP flags
+as radio-authoritative — we must not *override radio status* from client
+persistence. The correct pattern (and what BandStack already does):
+- Applying a suggestion **sends** a `slice set` command (we're acting like a
+  user turning the knob), then normal status echo flows back.
+- **Never** intercept `applyStatus()` to clamp the radio's reported value to our
+  saved one — that creates the reconnect fight the policy warns about.
+- Store a calibrated value alongside `agcMode` (a value calibrated for med-AGC
+  is meaningless under off-AGC); only suggest when the saved mode matches the
+  current mode.
+
+Optionally store the noise-floor dBm at calibration time as a "band fingerprint"
+so the UI can warn "noise floor has shifted ~8 dB since you calibrated — re-run?"
+
+---
+
+## 7. Available APIs (reference)
+
+**Radio commands (already implemented in `SliceModel`):**
+- `SliceModel::setAgcMode("off|slow|med|fast")` → `slice set <id> agc_mode=...` `src/models/SliceModel.cpp:250`
+- `SliceModel::setAgcThreshold(0..100)` → `slice set <id> agc_threshold=...` `:258`
+- `SliceModel::setAgcOffLevel(0..100)` → `slice set <id> agc_off_level=...` `:267`
+- Status echo parsed in `applyStatus()` `:757`; signals `agcModeChanged`,
+  `agcThresholdChanged`, `agcOffLevelChanged`.
+
+**GUI control today:** single slider in `RxApplet`, range 0–100, routes to
+`setAgcOffLevel` when mode==off else `setAgcThreshold` `src/gui/RxApplet.cpp:851`.
+The calibration panel should drive these same setters so the existing slider and
+the panel stay in sync via the model signals.
+
+**Entry point (decision):** **right-click the AGC-T slider** opens the panel
+(add a context menu / `contextMenuEvent` on the slider). To offset the
+discoverability cost, set the slider tooltip to mention it ("Right-click to
+calibrate AGC-T against the noise floor") and show a one-time discovery hint.
+
+**Frameless dialog conventions:** follow `docs/dialog-patterns.md` and the
+`NetworkDiagnosticsDialog` pattern — `FramelessWindowTitleBar`,
+`FramelessResizer::install`, `setFramelessMode`, init from
+`AppSettings "FramelessWindow"`. Persist geometry. Use `AppSettings`, not
+`QSettings`. Use `MeterSmoother` for any displayed level value.
+
+---
+
+## 8. Edge cases & risks
+
+- **Not a quiet spot:** signal in the passband poisons the curve. Guard with
+  S-meter-vs-floor check + in-passband peak detection; auto-suggest the nearest
+  clear segment or block the sweep with guidance.
+- **Audible disruption:** sweeping changes loudness. Keep sweeps short, show
+  progress, restore on cancel, and consider a brief "calibrating…" mute option.
+- **AGC settle time:** too-fast stepping reads a transient, not steady state.
+  Honor the ~250–300 ms settle; make it a tunable constant.
+- **Mode mismatch on recall:** only apply a saved per-band value if the saved
+  AGC mode matches the current mode.
+- **FM:** AGC container is hidden in FM (`RxApplet.cpp:2232`); disable the tool
+  in FM.
+- **Multi-slice / multi-client:** calibrate the active/owned slice only; gate on
+  slice ownership like the rest of the app.
+- **NR/AF interference:** freeze or bypass for the sweep so only AGC-T varies.
+
+---
+
+## 8.5 Implementation status (branch aether/agc-t-noise-calibration)
+
+Implemented in this branch:
+- **Engine** — `src/core/AgcTCalibrator.{h,cpp}`: headless QObject, auto-sweep +
+  manual recording, knee detection (max-distance-from-chord) for AGC-on and a
+  target-level solve for AGC-off, quiet-spot guard, restore-on-stop.
+- **Panel** — `src/gui/AgcCalibrationDialog.{h,cpp}`: `PersistentDialog` subclass
+  with a live curve widget (`AgcCurveWidget`), Auto Sweep / Stop / Apply, mode
+  awareness, AGC-off target control, quiet-spot status line.
+- **Entry point** — right-click on the AGC-T slider in `RxApplet`
+  (`calibrateAgcTRequested(sliceId)` → `MainWindow::showAgcCalibrationDialog`),
+  with a tooltip discovery hint.
+
+Deferred to follow-up PRs (to keep this change reviewable):
+- **Per-band suggest chip** (§6) — store calibrated value + suggest-on-band-change.
+- **Ambient noise-floor line on the pan** (§5 Option B).
+
+## 9. Phased implementation plan
+
+1. **Engine (headless):** a `AgcTCalibrator` that, given the active slice +
+   audio-level + S-meter + noise-floor sources, runs manual-step and auto-sweep,
+   does knee detection / target solve, and emits curve + result. Unit-testable
+   with synthetic curves.
+2. **Panel (Option A):** frameless non-modal window with the live 2D graph,
+   markers, controls; wired to the engine and the existing `SliceModel` setters.
+3. **Per-band recall (Section 6):** extend BandStack/BandSnapshot, apply-on-
+   band-change, optional fingerprint warning.
+4. **Ambient pan line (Option B):** optional persistent noise-floor reference
+   line, reusing existing `DisplayNoiseFloor*` settings.
+5. **Polish:** quiet-spot auto-find, mute-during-sweep option, accessibility.
+
+---
+
+## 10. Decisions resolved + remaining maintainer sign-off
+
+Decision pass (2026-06-01) resolved the five open questions — see §0 for the
+table and the two flagged-tension mitigations. Summary:
+
+1. **Surface:** Option C — panel + optional ambient pan line. ✅
+2. **Entry point:** right-click the AGC-T slider (+ tooltip/discovery hint). ✅
+3. **Default mode:** auto-sweep first, manual fine-tune always available. ✅
+4. **Per-band recall:** suggest via dismissible chip, never auto-apply. ✅
+5. **AGC-off target:** sensible fixed default, advanced reveal to override. ✅
+
+Per CLAUDE.md, **visual design and UX direction remain Jeremy/KK7GWY's
+authority.** These decisions set engineering direction; the panel's visual
+design, exact chip styling, and copy still need maintainer review before/at PR
+time. Nothing here changes defaults that affect existing users until merged.

--- a/src/core/AgcTCalibrator.cpp
+++ b/src/core/AgcTCalibrator.cpp
@@ -1,0 +1,329 @@
+#include "core/AgcTCalibrator.h"
+
+#include "models/SliceModel.h"
+
+#include <QLoggingCategory>
+
+#include <algorithm>
+#include <cmath>
+
+Q_LOGGING_CATEGORY(lcAgcCal, "aether.agccal", QtWarningMsg)
+
+namespace AetherSDR {
+
+AgcTCalibrator::AgcTCalibrator(QObject* parent)
+    : QObject(parent)
+{
+    m_stepTimer.setSingleShot(true);
+    connect(&m_stepTimer, &QTimer::timeout, this, &AgcTCalibrator::onSweepStep);
+
+    m_manualTimer.setSingleShot(true);
+    connect(&m_manualTimer, &QTimer::timeout, this, &AgcTCalibrator::onManualSettle);
+}
+
+void AgcTCalibrator::setSlice(SliceModel* slice)
+{
+    if (m_slice == slice) {
+        return;
+    }
+    // Changing slices invalidates any in-flight calibration.
+    if (m_running) {
+        stop();
+    }
+    m_slice = slice;
+    clear();
+}
+
+AgcTCalibrator::Strategy AgcTCalibrator::strategy() const
+{
+    return useOffLevel() ? Strategy::TargetLevel : Strategy::Knee;
+}
+
+bool AgcTCalibrator::useOffLevel() const
+{
+    return m_slice && m_slice->agcMode() == QStringLiteral("off");
+}
+
+int AgcTCalibrator::currentValue() const
+{
+    if (!m_slice) {
+        return 0;
+    }
+    return useOffLevel() ? m_slice->agcOffLevel() : m_slice->agcThreshold();
+}
+
+void AgcTCalibrator::applyValue(int value)
+{
+    if (!m_slice) {
+        return;
+    }
+    value = std::clamp(value, 0, 100);
+    if (useOffLevel()) {
+        m_slice->setAgcOffLevel(value);
+    } else {
+        m_slice->setAgcThreshold(value);
+    }
+}
+
+float AgcTCalibrator::currentRmsDb() const
+{
+    const float rms = std::max(m_rmsEma, kRmsFloor);
+    return 20.0f * std::log10(rms);
+}
+
+// ---- live inputs ----------------------------------------------------------
+
+void AgcTCalibrator::onAudioLevel(float rms)
+{
+    if (!std::isfinite(rms)) {
+        return;
+    }
+    rms = std::max(0.0f, rms);
+    if (!m_haveRms) {
+        m_rmsEma = rms;
+        m_haveRms = true;
+    } else {
+        m_rmsEma = (1.0f - kRmsAlpha) * m_rmsEma + kRmsAlpha * rms;
+    }
+}
+
+void AgcTCalibrator::onSLevel(int sliceIndex, float dbm)
+{
+    if (m_slice && sliceIndex != m_slice->sliceId()) {
+        return;
+    }
+    if (!std::isfinite(dbm)) {
+        return;
+    }
+    m_sLevelDbm = dbm;
+    m_haveSLevel = true;
+    evaluateQuietSpot();
+}
+
+void AgcTCalibrator::setNoiseFloorDb(float dbm)
+{
+    if (!std::isfinite(dbm)) {
+        return;
+    }
+    m_noiseFloorDbm = dbm;
+    m_haveFloor = true;
+    evaluateQuietSpot();
+}
+
+void AgcTCalibrator::evaluateQuietSpot()
+{
+    if (!m_haveSLevel || !m_haveFloor) {
+        return;
+    }
+    const float margin = m_sLevelDbm - m_noiseFloorDbm;
+    emit quietSpotStatus(margin <= kQuietMarginDb, margin);
+}
+
+// ---- manual recording -----------------------------------------------------
+
+void AgcTCalibrator::onValueChanged(int value)
+{
+    if (m_auto) {
+        return; // the sweep drives the value itself
+    }
+    // Debounce: record once the value has settled.
+    m_pendingManualValue = std::clamp(value, 0, 100);
+    m_manualTimer.start(std::max(120, m_settleMs));
+}
+
+void AgcTCalibrator::onManualSettle()
+{
+    if (m_auto || m_pendingManualValue < 0) {
+        return;
+    }
+    recordPoint(m_pendingManualValue);
+    m_pendingManualValue = -1;
+    recompute();
+}
+
+// ---- auto sweep -----------------------------------------------------------
+
+void AgcTCalibrator::startAutoSweep()
+{
+    if (!m_slice) {
+        qCWarning(lcAgcCal) << "startAutoSweep with no slice";
+        return;
+    }
+    if (m_running) {
+        return;
+    }
+    m_originalValue = currentValue();
+    m_recommended = -1;
+    m_curve.clear();
+    m_running = true;
+    m_auto = true;
+    m_sweepStart = 100;
+    m_sweepValue = m_sweepStart;
+
+    applyValue(m_sweepValue);
+    emit started(strategy(), m_originalValue);
+    emit progress(m_sweepValue, 0);
+    // Wait for the AGC to settle before sampling this first point.
+    m_stepTimer.start(m_settleMs);
+}
+
+void AgcTCalibrator::onSweepStep()
+{
+    if (!m_running || !m_auto) {
+        return;
+    }
+    // Sample the value currently applied (already settled).
+    recordPoint(m_sweepValue);
+
+    const int span = std::max(1, m_sweepStart);
+    const int done = m_sweepStart - m_sweepValue;
+    emit progress(m_sweepValue, static_cast<int>(100.0 * done / span));
+
+    if (m_sweepValue <= 0) {
+        finishSweep();
+        return;
+    }
+    m_sweepValue = std::max(0, m_sweepValue - kSweepStep);
+    applyValue(m_sweepValue);
+    m_stepTimer.start(m_settleMs);
+}
+
+void AgcTCalibrator::finishSweep()
+{
+    m_stepTimer.stop();
+    m_running = false;
+    m_auto = false;
+    recompute();
+    // Apply the recommendation so the operator immediately hears the result.
+    // They still confirm with Apply (keep) or Stop (restore original).
+    if (m_recommended >= 0) {
+        applyValue(m_recommended);
+    }
+    emit finished(false); // not yet *confirmed*; UI decides keep vs restore
+}
+
+// ---- recording + detection ------------------------------------------------
+
+void AgcTCalibrator::recordPoint(int value)
+{
+    const float db = currentRmsDb();
+    // Replace an existing sample at the same value (manual re-visits).
+    for (Point& p : m_curve) {
+        if (p.value == value) {
+            p.rmsDb = db;
+            emit pointAdded(value, db);
+            return;
+        }
+    }
+    m_curve.push_back({value, db});
+    std::sort(m_curve.begin(), m_curve.end(),
+              [](const Point& a, const Point& b) { return a.value < b.value; });
+    emit pointAdded(value, db);
+}
+
+void AgcTCalibrator::recompute()
+{
+    if (m_curve.size() < 3) {
+        return;
+    }
+
+    QVector<Point> pts = m_curve; // already sorted by value ascending
+
+    if (strategy() == Strategy::TargetLevel) {
+        // AGC off: monotonic rms vs value. Solve for the value whose audio-noise
+        // level crosses the comfortable target, via linear interpolation.
+        int best = pts.first().value;
+        float bestErr = std::abs(pts.first().rmsDb - m_targetDb);
+        for (int i = 1; i < pts.size(); ++i) {
+            const Point& a = pts[i - 1];
+            const Point& b = pts[i];
+            // crossing between a and b?
+            const bool brackets = (a.rmsDb - m_targetDb) * (b.rmsDb - m_targetDb) <= 0.0f;
+            if (brackets && std::abs(b.rmsDb - a.rmsDb) > 1e-3f) {
+                const float t = (m_targetDb - a.rmsDb) / (b.rmsDb - a.rmsDb);
+                best = std::clamp(static_cast<int>(std::lround(a.value + t * (b.value - a.value))), 0, 100);
+                m_recommended = best;
+                emit recommendation(best, /*isKnee=*/false);
+                return;
+            }
+            const float err = std::abs(b.rmsDb - m_targetDb);
+            if (err < bestErr) {
+                bestErr = err;
+                best = b.value;
+            }
+        }
+        m_recommended = best;
+        emit recommendation(best, /*isKnee=*/false);
+        return;
+    }
+
+    // AGC on: find the knee (elbow) via maximum perpendicular distance from the
+    // chord joining the first and last points. On a curve of audio-RMS vs
+    // threshold, the noise stays high/flat at high thresholds then bends down as
+    // the threshold drops below the noise level — the bend is the knee.
+    const Point& first = pts.first();
+    const Point& last = pts.last();
+    const float dx = static_cast<float>(last.value - first.value);
+    const float dy = last.rmsDb - first.rmsDb;
+    const float len = std::sqrt(dx * dx + dy * dy);
+    if (len < 1e-6f) {
+        return;
+    }
+
+    int kneeValue = first.value;
+    float maxDist = -1.0f;
+    for (const Point& p : pts) {
+        // Perpendicular distance from point p to the chord.
+        const float num = std::abs(dy * (p.value - first.value) - dx * (p.rmsDb - first.rmsDb));
+        const float dist = num / len;
+        if (dist > maxDist) {
+            maxDist = dist;
+            kneeValue = p.value;
+        }
+    }
+
+    m_recommended = std::clamp(kneeValue, 0, 100);
+    emit recommendation(m_recommended, /*isKnee=*/true);
+}
+
+// ---- control ---------------------------------------------------------------
+
+void AgcTCalibrator::stop()
+{
+    const bool wasRunning = m_running || m_auto;
+    m_stepTimer.stop();
+    m_manualTimer.stop();
+    m_running = false;
+    m_auto = false;
+    if (m_originalValue >= 0) {
+        applyValue(m_originalValue); // restore what we found
+    }
+    if (wasRunning) {
+        emit finished(false);
+    }
+}
+
+void AgcTCalibrator::applyRecommendation()
+{
+    m_stepTimer.stop();
+    m_manualTimer.stop();
+    m_running = false;
+    m_auto = false;
+    if (m_recommended >= 0) {
+        applyValue(m_recommended);
+    }
+    emit finished(true);
+}
+
+void AgcTCalibrator::clear()
+{
+    if (m_running) {
+        return;
+    }
+    m_curve.clear();
+    m_recommended = -1;
+    m_pendingManualValue = -1;
+    m_manualTimer.stop();
+}
+
+} // namespace AetherSDR

--- a/src/core/AgcTCalibrator.h
+++ b/src/core/AgcTCalibrator.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <QObject>
+#include <QTimer>
+#include <QVector>
+
+namespace AetherSDR {
+
+class SliceModel;
+
+// AgcTCalibrator — headless engine that calibrates a slice's AGC-T value
+// against the receiver noise floor.
+//
+// Background (see docs/agc-t-calibration-design.md):
+//   * When AGC mode is slow/med/fast, the AGC-T knob is `agc_threshold` (the
+//     AGC "knee"). The goal is to find the knee: lower the threshold until the
+//     audio noise *just begins to decrease*. We detect that elbow on a curve of
+//     post-AGC audio RMS vs threshold value.
+//   * When AGC mode is off, the knob is `agc_off_level` (a fixed gain). There is
+//     no knee; instead we solve for the value that places the audio-noise level
+//     at a comfortable target.
+//
+// The 0-100 knob value has no radio-exposed dBm mapping (firmware v4.2.18), so
+// calibration is empirical: we vary the knob and observe the post-AGC audio RMS
+// fed in via onAudioLevel(). The radio remains authoritative — we only ever set
+// the value through SliceModel's setters (acting like a user turning the knob).
+//
+// Auto and manual calibration share this one engine: in auto mode a timer steps
+// the value and samples; in manual mode the user moves the slider and we record
+// (value, rms) points after each value settles. Both build the same curve, and
+// the same knee/target detector runs over it.
+class AgcTCalibrator : public QObject {
+    Q_OBJECT
+
+public:
+    enum class Strategy {
+        Knee,        // AGC on  -> find the elbow in audio-RMS vs threshold
+        TargetLevel  // AGC off -> solve for a target audio-noise level
+    };
+
+    struct Point {
+        int   value;   // AGC-T value 0..100
+        float rmsDb;   // post-AGC audio RMS, in dB (20*log10(rms))
+    };
+
+    explicit AgcTCalibrator(QObject* parent = nullptr);
+
+    void setSlice(SliceModel* slice);
+    SliceModel* slice() const { return m_slice; }
+
+    // Comfortable audio-noise target for the AGC-off solve, in dB (negative).
+    void  setTargetLevelDb(float db) { m_targetDb = db; }
+    float targetLevelDb() const { return m_targetDb; }
+
+    // Per-step settle time for the auto sweep (radio AGC needs time to react).
+    void setSettleMs(int ms) { m_settleMs = ms; }
+
+    bool             isRunning() const { return m_running; }
+    bool             isAuto() const { return m_auto; }
+    Strategy         strategy() const;
+    QVector<Point>   curve() const { return m_curve; }
+    int              recommendedValue() const { return m_recommended; }
+    bool             hasRecommendation() const { return m_recommended >= 0; }
+    int              originalValue() const { return m_originalValue; }
+
+public slots:
+    // Live inputs.
+    void onAudioLevel(float rms);            // AudioEngine::levelChanged (0..1 linear)
+    void onSLevel(int sliceIndex, float dbm);// MeterModel::sLevelChanged (passband S+N)
+    void setNoiseFloorDb(float dbm);         // measured RF noise floor (pan)
+    void onValueChanged(int value);          // slice AGC-T value changed (manual record)
+
+    // Control.
+    void startAutoSweep();
+    void stop();                  // abort: restore original value, finished(false)
+    void applyRecommendation();   // keep recommended value, finished(true)
+    void clear();                 // drop curve + recommendation (not running)
+
+signals:
+    void started(AgcTCalibrator::Strategy strategy, int originalValue);
+    void progress(int currentValue, int percent);
+    void pointAdded(int value, float rmsDb);
+    void recommendation(int value, bool isKnee);
+    void quietSpotStatus(bool quiet, float marginDb); // S-meter vs noise floor
+    void finished(bool applied);
+
+private:
+    int   currentValue() const;          // read the active knob from the slice
+    void  applyValue(int value);         // set the active knob on the slice
+    bool  useOffLevel() const;           // true when AGC mode == "off"
+    void  onSweepStep();                 // auto-sweep timer tick
+    void  onManualSettle();              // manual record timer tick
+    void  recordPoint(int value);        // append (value, currentRms) to curve
+    void  finishSweep();                 // compute recommendation after a sweep
+    void  recompute();                   // recompute recommendation from curve
+    float currentRmsDb() const;
+    void  evaluateQuietSpot();
+
+    SliceModel* m_slice{nullptr};
+
+    bool   m_running{false};
+    bool   m_auto{false};
+    int    m_originalValue{-1};
+    int    m_recommended{-1};
+
+    QVector<Point> m_curve;
+
+    // Audio RMS smoothing (fed from the audio thread via a queued signal).
+    float  m_rmsEma{0.0f};
+    bool   m_haveRms{false};
+    static constexpr float kRmsAlpha = 0.30f;
+    static constexpr float kRmsFloor = 1.0e-6f; // avoid log10(0)
+
+    // Quiet-spot guard.
+    float  m_sLevelDbm{-200.0f};
+    float  m_noiseFloorDbm{-200.0f};
+    bool   m_haveSLevel{false};
+    bool   m_haveFloor{false};
+    static constexpr float kQuietMarginDb = 6.0f;
+
+    // Auto sweep.
+    QTimer m_stepTimer;
+    int    m_sweepValue{100};
+    int    m_sweepStart{100};
+    static constexpr int kSweepStep = 4; // coarse step (100 -> 0)
+    int    m_settleMs{280};
+
+    // Manual record (settle after the user moves the slider).
+    QTimer m_manualTimer;
+    int    m_pendingManualValue{-1};
+
+    // AGC-off comfortable-noise target (dB). Tunable; sensible default.
+    float  m_targetDb{-28.0f};
+};
+
+} // namespace AetherSDR

--- a/src/core/AgcTCalibrator.h
+++ b/src/core/AgcTCalibrator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QPointer>
 #include <QTimer>
 #include <QVector>
 
@@ -46,7 +47,7 @@ public:
     explicit AgcTCalibrator(QObject* parent = nullptr);
 
     void setSlice(SliceModel* slice);
-    SliceModel* slice() const { return m_slice; }
+    SliceModel* slice() const { return m_slice.data(); }
 
     // Comfortable audio-noise target for the AGC-off solve, in dB (negative).
     void  setTargetLevelDb(float db) { m_targetDb = db; }
@@ -96,7 +97,9 @@ private:
     float currentRmsDb() const;
     void  evaluateQuietSpot();
 
-    SliceModel* m_slice{nullptr};
+    // QPointer so slice removal / disconnect mid-calibration doesn't dangle.
+    // All call sites null-check before use.
+    QPointer<SliceModel> m_slice;
 
     bool   m_running{false};
     bool   m_auto{false};

--- a/src/gui/AgcCalibrationDialog.cpp
+++ b/src/gui/AgcCalibrationDialog.cpp
@@ -8,6 +8,7 @@
 #include <QDoubleSpinBox>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QMessageBox>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPushButton>
@@ -294,6 +295,19 @@ int AgcCalibrationDialog::liveValue() const
                : m_slice->agcThreshold();
 }
 
+bool AgcCalibrationDialog::nrSuppressesCalibration() const
+{
+    if (m_audio && (m_audio->nr2Enabled() || m_audio->rn2Enabled()
+                  || m_audio->nr4Enabled() || m_audio->dfnrEnabled()
+                  || m_audio->mnrEnabled() || m_audio->bnrEnabled())) {
+        return true;
+    }
+    if (m_slice && m_slice->nrOn()) {
+        return true;
+    }
+    return false;
+}
+
 void AgcCalibrationDialog::updateModeUi()
 {
     const bool off = m_slice && m_slice->agcMode() == QStringLiteral("off");
@@ -301,6 +315,20 @@ void AgcCalibrationDialog::updateModeUi()
         off ? AgcTCalibrator::Strategy::TargetLevel : AgcTCalibrator::Strategy::Knee;
     m_curve->setStrategy(s);
     m_targetRow->setVisible(off);
+
+    // If NR is active (client or radio), the levelChanged tap reads post-NR
+    // audio and the AGC knee is masked. Warn in the hint label; the auto-sweep
+    // start path also refuses to begin until NR is off.
+    if (nrSuppressesCalibration() && m_hintLabel) {
+        m_hintLabel->setText(QStringLiteral(
+            "⚠ Disable Noise Reduction (NR/NR2/RN2/NR4/DFNR/MNR/BNR) for accurate "
+            "calibration — NR crushes the noise floor the knee detector is "
+            "looking for."));
+    } else if (m_hintLabel) {
+        m_hintLabel->setText(QStringLiteral(
+            "Tune to a clear spot, then Auto Sweep — or move the AGC-T "
+            "slider and watch where the noise bends."));
+    }
 
     if (!m_slice) {
         m_modeLabel->setText(QStringLiteral("No active slice."));
@@ -339,6 +367,21 @@ void AgcCalibrationDialog::onStartStop()
 {
     if (m_engine.isRunning()) {
         m_engine.stop(); // restores original value
+        return;
+    }
+    // Refuse to start while any NR stage is suppressing the calibration tap.
+    // The user can disable NR and try again. Mirrors the quiet-spot guard
+    // pattern in the engine and matches the in-hint warning text.
+    if (nrSuppressesCalibration()) {
+        QMessageBox::warning(
+            this,
+            QStringLiteral("Disable NR for AGC-T calibration"),
+            QStringLiteral(
+                "Noise Reduction is active and is crushing the audio noise "
+                "floor that the AGC knee detector measures. Turn off any of "
+                "NR / NR2 / RN2 / NR4 / DFNR / MNR / BNR, then try Auto Sweep "
+                "again."),
+            QMessageBox::Ok);
         return;
     }
     m_curve->clear();

--- a/src/gui/AgcCalibrationDialog.cpp
+++ b/src/gui/AgcCalibrationDialog.cpp
@@ -1,0 +1,414 @@
+#include "gui/AgcCalibrationDialog.h"
+
+#include "core/AudioEngine.h"
+#include "models/MeterModel.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include <QDoubleSpinBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPushButton>
+#include <QTimer>
+#include <QVBoxLayout>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+// ===========================================================================
+// AgcCurveWidget
+// ===========================================================================
+
+AgcCurveWidget::AgcCurveWidget(QWidget* parent)
+    : QWidget(parent)
+{
+    setMinimumSize(360, 200);
+    setAttribute(Qt::WA_StyledBackground, true);
+}
+
+void AgcCurveWidget::setCurve(const QVector<AgcTCalibrator::Point>& pts)
+{
+    m_pts = pts;
+    update();
+}
+
+void AgcCurveWidget::setCurrentValue(int value)
+{
+    if (m_current != value) {
+        m_current = value;
+        update();
+    }
+}
+
+void AgcCurveWidget::setRecommended(int value, bool isKnee)
+{
+    m_recommended = value;
+    m_recIsKnee = isKnee;
+    update();
+}
+
+void AgcCurveWidget::setStrategy(AgcTCalibrator::Strategy s)
+{
+    if (m_strategy != s) {
+        m_strategy = s;
+        update();
+    }
+}
+
+void AgcCurveWidget::setTargetDb(float db)
+{
+    m_targetDb = db;
+    update();
+}
+
+void AgcCurveWidget::clear()
+{
+    m_pts.clear();
+    m_current = -1;
+    m_recommended = -1;
+    update();
+}
+
+void AgcCurveWidget::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    const QRectF full = rect();
+    const qreal padL = 8.0, padR = 8.0, padT = 8.0, padB = 18.0;
+    const QRectF plot(full.left() + padL, full.top() + padT,
+                      full.width() - padL - padR, full.height() - padT - padB);
+
+    p.fillRect(full, QColor(18, 20, 24));
+    p.setPen(QPen(QColor(70, 76, 86), 1.0));
+    p.drawRect(plot);
+
+    auto xForValue = [&](int v) {
+        return plot.left() + (v / 100.0) * plot.width();
+    };
+
+    // Y range from data (audio-noise dB), with padding; fall back to a default.
+    float yMin = -90.0f, yMax = 0.0f;
+    if (!m_pts.isEmpty()) {
+        yMin = yMax = m_pts.first().rmsDb;
+        for (const auto& pt : m_pts) {
+            yMin = std::min(yMin, pt.rmsDb);
+            yMax = std::max(yMax, pt.rmsDb);
+        }
+        const float span = std::max(6.0f, yMax - yMin);
+        yMin -= span * 0.12f;
+        yMax += span * 0.12f;
+    }
+    auto yForDb = [&](float db) {
+        const float t = (db - yMin) / std::max(1e-3f, (yMax - yMin));
+        return plot.bottom() - t * plot.height();
+    };
+
+    // AGC-off target line.
+    if (m_strategy == AgcTCalibrator::Strategy::TargetLevel
+        && m_targetDb >= yMin && m_targetDb <= yMax) {
+        p.setPen(QPen(QColor(90, 150, 220), 1.0, Qt::DashLine));
+        const qreal y = yForDb(m_targetDb);
+        p.drawLine(QPointF(plot.left(), y), QPointF(plot.right(), y));
+    }
+
+    // Curve.
+    if (m_pts.size() >= 2) {
+        QPainterPath path;
+        path.moveTo(xForValue(m_pts.first().value), yForDb(m_pts.first().rmsDb));
+        for (int i = 1; i < m_pts.size(); ++i) {
+            path.lineTo(xForValue(m_pts[i].value), yForDb(m_pts[i].rmsDb));
+        }
+        p.setPen(QPen(QColor(120, 210, 140), 2.0));
+        p.drawPath(path);
+    }
+    p.setPen(Qt::NoPen);
+    p.setBrush(QColor(150, 230, 170));
+    for (const auto& pt : m_pts) {
+        p.drawEllipse(QPointF(xForValue(pt.value), yForDb(pt.rmsDb)), 2.0, 2.0);
+    }
+
+    // Recommended / knee marker.
+    if (m_recommended >= 0) {
+        const qreal x = xForValue(m_recommended);
+        p.setPen(QPen(QColor(245, 200, 90), 2.0));
+        p.drawLine(QPointF(x, plot.top()), QPointF(x, plot.bottom()));
+        p.setPen(QColor(245, 200, 90));
+        p.drawText(QPointF(std::min(x + 4, plot.right() - 70), plot.top() + 12),
+                   m_recIsKnee ? QStringLiteral("knee %1").arg(m_recommended)
+                               : QStringLiteral("target %1").arg(m_recommended));
+    }
+
+    // Current value marker.
+    if (m_current >= 0) {
+        const qreal x = xForValue(m_current);
+        p.setPen(QPen(QColor(220, 220, 230), 1.0, Qt::DotLine));
+        p.drawLine(QPointF(x, plot.top()), QPointF(x, plot.bottom()));
+    }
+
+    // X axis labels.
+    p.setPen(QColor(150, 156, 166));
+    p.drawText(QPointF(plot.left(), plot.bottom() + 14), QStringLiteral("0"));
+    p.drawText(QPointF(plot.right() - 24, plot.bottom() + 14), QStringLiteral("100"));
+    p.drawText(QPointF(plot.center().x() - 30, plot.bottom() + 14),
+               QStringLiteral("AGC-T"));
+}
+
+// ===========================================================================
+// AgcCalibrationDialog
+// ===========================================================================
+
+AgcCalibrationDialog::AgcCalibrationDialog(RadioModel* radio,
+                                           AudioEngine* audio,
+                                           NoiseFloorFn noiseFloorFn,
+                                           QWidget* parent)
+    : PersistentDialog(QStringLiteral("AGC-T Calibration"),
+                       QStringLiteral("AgcCalibrationDialogGeometry"), parent),
+      m_radio(radio), m_audio(audio), m_noiseFloorFn(std::move(noiseFloorFn))
+{
+    setMinimumSize(420, 360);
+    resize(460, 420);
+
+    auto* body = new QVBoxLayout(bodyWidget());
+    body->setContentsMargins(10, 10, 10, 10);
+    body->setSpacing(8);
+
+    m_modeLabel = new QLabel(this);
+    m_quietLabel = new QLabel(this);
+    body->addWidget(m_modeLabel);
+    body->addWidget(m_quietLabel);
+
+    m_curve = new AgcCurveWidget(this);
+    body->addWidget(m_curve, 1);
+
+    m_recLabel = new QLabel(this);
+    body->addWidget(m_recLabel);
+
+    // AGC-off advanced: comfortable-noise target.
+    m_targetRow = new QWidget(this);
+    auto* targetLayout = new QHBoxLayout(m_targetRow);
+    targetLayout->setContentsMargins(0, 0, 0, 0);
+    targetLayout->addWidget(new QLabel(QStringLiteral("Target audio noise (dB):"), m_targetRow));
+    m_targetSpin = new QDoubleSpinBox(m_targetRow);
+    m_targetSpin->setRange(-80.0, 0.0);
+    m_targetSpin->setSingleStep(1.0);
+    m_targetSpin->setValue(m_engine.targetLevelDb());
+    targetLayout->addWidget(m_targetSpin);
+    targetLayout->addStretch(1);
+    body->addWidget(m_targetRow);
+    connect(m_targetSpin, &QDoubleSpinBox::valueChanged, this, [this](double v) {
+        m_engine.setTargetLevelDb(static_cast<float>(v));
+        m_curve->setTargetDb(static_cast<float>(v));
+    });
+
+    auto* buttons = new QHBoxLayout;
+    m_startStopBtn = new QPushButton(QStringLiteral("Auto Sweep"), this);
+    m_applyBtn = new QPushButton(QStringLiteral("Apply"), this);
+    m_applyBtn->setEnabled(false);
+    buttons->addWidget(m_startStopBtn);
+    buttons->addStretch(1);
+    buttons->addWidget(m_applyBtn);
+    body->addLayout(buttons);
+
+    m_hintLabel = new QLabel(
+        QStringLiteral("Tune to a clear spot, then Auto Sweep — or move the AGC-T "
+                       "slider and watch where the noise bends."), this);
+    m_hintLabel->setWordWrap(true);
+    body->addWidget(m_hintLabel);
+
+    connect(m_startStopBtn, &QPushButton::clicked, this, &AgcCalibrationDialog::onStartStop);
+    connect(m_applyBtn, &QPushButton::clicked, this, &AgcCalibrationDialog::onApply);
+
+    // Engine wiring.
+    connect(&m_engine, &AgcTCalibrator::started, this, &AgcCalibrationDialog::onStarted);
+    connect(&m_engine, &AgcTCalibrator::progress, this, &AgcCalibrationDialog::onProgress);
+    connect(&m_engine, &AgcTCalibrator::pointAdded, this, &AgcCalibrationDialog::onPointAdded);
+    connect(&m_engine, &AgcTCalibrator::recommendation, this, &AgcCalibrationDialog::onRecommendation);
+    connect(&m_engine, &AgcTCalibrator::quietSpotStatus, this, &AgcCalibrationDialog::onQuietSpot);
+    connect(&m_engine, &AgcTCalibrator::finished, this, &AgcCalibrationDialog::onFinished);
+
+    // Live audio level (cross-thread; auto-queued) and S-meter feed.
+    if (m_audio) {
+        connect(m_audio, &AudioEngine::levelChanged,
+                &m_engine, &AgcTCalibrator::onAudioLevel);
+    }
+    if (m_radio) {
+        connect(&m_radio->meterModel(), &MeterModel::sLevelChanged,
+                &m_engine, &AgcTCalibrator::onSLevel);
+    }
+
+    // Periodically feed the measured RF noise floor for the quiet-spot guard.
+    m_floorTimer = new QTimer(this);
+    m_floorTimer->setInterval(500);
+    connect(m_floorTimer, &QTimer::timeout, this, &AgcCalibrationDialog::pollNoiseFloor);
+    m_floorTimer->start();
+
+    updateModeUi();
+}
+
+void AgcCalibrationDialog::setSlice(SliceModel* slice)
+{
+    if (m_slice == slice) {
+        return;
+    }
+    if (m_slice) {
+        disconnectSlice(m_slice);
+    }
+    m_slice = slice;
+    m_engine.setSlice(slice);
+    if (m_slice) {
+        connectSlice(m_slice);
+    }
+    m_curve->clear();
+    m_applyBtn->setEnabled(false);
+    updateModeUi();
+    refreshFromSlice();
+}
+
+void AgcCalibrationDialog::connectSlice(SliceModel* slice)
+{
+    connect(slice, &SliceModel::agcModeChanged, this, &AgcCalibrationDialog::updateModeUi);
+    connect(slice, &SliceModel::agcThresholdChanged, &m_engine, &AgcTCalibrator::onValueChanged);
+    connect(slice, &SliceModel::agcOffLevelChanged, &m_engine, &AgcTCalibrator::onValueChanged);
+    connect(slice, &SliceModel::agcThresholdChanged, this, &AgcCalibrationDialog::refreshFromSlice);
+    connect(slice, &SliceModel::agcOffLevelChanged, this, &AgcCalibrationDialog::refreshFromSlice);
+}
+
+void AgcCalibrationDialog::disconnectSlice(SliceModel* slice)
+{
+    disconnect(slice, nullptr, &m_engine, nullptr);
+    disconnect(slice, nullptr, this, nullptr);
+}
+
+int AgcCalibrationDialog::liveValue() const
+{
+    if (!m_slice) {
+        return -1;
+    }
+    return m_slice->agcMode() == QStringLiteral("off")
+               ? m_slice->agcOffLevel()
+               : m_slice->agcThreshold();
+}
+
+void AgcCalibrationDialog::updateModeUi()
+{
+    const bool off = m_slice && m_slice->agcMode() == QStringLiteral("off");
+    const AgcTCalibrator::Strategy s =
+        off ? AgcTCalibrator::Strategy::TargetLevel : AgcTCalibrator::Strategy::Knee;
+    m_curve->setStrategy(s);
+    m_targetRow->setVisible(off);
+
+    if (!m_slice) {
+        m_modeLabel->setText(QStringLiteral("No active slice."));
+        m_startStopBtn->setEnabled(false);
+        return;
+    }
+    m_startStopBtn->setEnabled(true);
+    if (off) {
+        m_modeLabel->setText(QStringLiteral(
+            "AGC: OFF — calibrating fixed gain (agc_off_level) to a comfortable "
+            "noise level. No knee in this mode."));
+    } else {
+        m_modeLabel->setText(QStringLiteral(
+            "AGC: %1 — finding the knee (agc_threshold) just above the noise floor.")
+            .arg(m_slice->agcMode().toUpper()));
+    }
+}
+
+void AgcCalibrationDialog::refreshFromSlice()
+{
+    m_curve->setCurrentValue(liveValue());
+}
+
+void AgcCalibrationDialog::pollNoiseFloor()
+{
+    if (!m_slice || !m_noiseFloorFn) {
+        return;
+    }
+    const float floorDb = m_noiseFloorFn(m_slice);
+    if (std::isfinite(floorDb)) {
+        m_engine.setNoiseFloorDb(floorDb);
+    }
+}
+
+void AgcCalibrationDialog::onStartStop()
+{
+    if (m_engine.isRunning()) {
+        m_engine.stop(); // restores original value
+        return;
+    }
+    m_curve->clear();
+    m_applyBtn->setEnabled(false);
+    m_engine.startAutoSweep();
+}
+
+void AgcCalibrationDialog::onApply()
+{
+    m_engine.applyRecommendation();
+}
+
+void AgcCalibrationDialog::onStarted(AgcTCalibrator::Strategy strategy, int originalValue)
+{
+    Q_UNUSED(originalValue);
+    m_curve->setStrategy(strategy);
+    m_startStopBtn->setText(QStringLiteral("Stop"));
+    m_applyBtn->setEnabled(false);
+    m_recLabel->setText(QStringLiteral("Sweeping…"));
+}
+
+void AgcCalibrationDialog::onProgress(int currentValue, int percent)
+{
+    m_curve->setCurrentValue(currentValue);
+    m_recLabel->setText(QStringLiteral("Sweeping… %1%").arg(percent));
+}
+
+void AgcCalibrationDialog::onPointAdded(int value, float rmsDb)
+{
+    Q_UNUSED(value);
+    Q_UNUSED(rmsDb);
+    m_curve->setCurve(m_engine.curve());
+}
+
+void AgcCalibrationDialog::onRecommendation(int value, bool isKnee)
+{
+    m_curve->setRecommended(value, isKnee);
+    m_recLabel->setText(isKnee
+        ? QStringLiteral("Recommended AGC-T (knee): %1").arg(value)
+        : QStringLiteral("Recommended AGC-T (target): %1").arg(value));
+    if (!m_engine.isRunning()) {
+        m_applyBtn->setEnabled(true);
+    }
+}
+
+void AgcCalibrationDialog::onQuietSpot(bool quiet, float marginDb)
+{
+    if (quiet) {
+        m_quietLabel->setText(QStringLiteral("✓ Quiet spot (signal %1 dB over floor).")
+                                  .arg(marginDb, 0, 'f', 1));
+    } else {
+        m_quietLabel->setText(QStringLiteral("⚠ Signal in passband (%1 dB over floor) "
+                                             "— tune to a clear spot for best results.")
+                                  .arg(marginDb, 0, 'f', 1));
+    }
+}
+
+void AgcCalibrationDialog::onFinished(bool applied)
+{
+    m_startStopBtn->setText(QStringLiteral("Auto Sweep"));
+    if (applied) {
+        m_applyBtn->setEnabled(false);
+        m_recLabel->setText(m_engine.hasRecommendation()
+            ? QStringLiteral("Applied AGC-T = %1.").arg(m_engine.recommendedValue())
+            : QStringLiteral("Applied."));
+    } else if (m_engine.hasRecommendation()) {
+        // Sweep done; recommendation applied to the radio but not yet confirmed.
+        m_applyBtn->setEnabled(true);
+    }
+    refreshFromSlice();
+}
+
+} // namespace AetherSDR

--- a/src/gui/AgcCalibrationDialog.h
+++ b/src/gui/AgcCalibrationDialog.h
@@ -3,6 +3,7 @@
 #include "gui/PersistentDialog.h"
 #include "core/AgcTCalibrator.h"
 
+#include <QPointer>
 #include <QVector>
 #include <QWidget>
 
@@ -84,11 +85,19 @@ private:
     void disconnectSlice(SliceModel* slice);
     void updateModeUi();
     int  liveValue() const;
+    // Any noise reduction stage that mutates the audio before levelChanged is
+    // emitted: client-side NR2/RN2/NR4/DFNR/MNR/BNR via AudioEngine, plus the
+    // radio-side NR (slice nr flag). The calibration tap is AudioEngine's
+    // post-NR levelChanged, so any of these masks the knee we are trying to
+    // find. See aethersdr-agent review on PR #3350.
+    bool nrSuppressesCalibration() const;
 
     RadioModel*  m_radio{nullptr};
     AudioEngine* m_audio{nullptr};
     NoiseFloorFn m_noiseFloorFn;
-    SliceModel*  m_slice{nullptr};
+    // QPointer so slice removal mid-calibration doesn't dangle through the
+    // polling timer or noise-floor lookup callback.
+    QPointer<SliceModel> m_slice;
 
     AgcTCalibrator m_engine;
     QTimer*        m_floorTimer{nullptr};

--- a/src/gui/AgcCalibrationDialog.h
+++ b/src/gui/AgcCalibrationDialog.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "gui/PersistentDialog.h"
+#include "core/AgcTCalibrator.h"
+
+#include <QVector>
+#include <QWidget>
+
+#include <functional>
+
+class QLabel;
+class QPushButton;
+class QDoubleSpinBox;
+class QTimer;
+
+namespace AetherSDR {
+
+class RadioModel;
+class SliceModel;
+class AudioEngine;
+
+// AgcCurveWidget — lightweight 2D plot of post-AGC audio noise (y, dB) versus
+// the AGC-T value (x, 0..100). Markers: current value, detected knee /
+// recommended value, and (AGC-off) the comfortable-noise target line.
+//
+// Visual styling here is deliberately plain — final visual design is the
+// maintainer's call (CLAUDE.md). This draws the data correctly; colors/fonts
+// are placeholders.
+class AgcCurveWidget : public QWidget {
+    Q_OBJECT
+public:
+    explicit AgcCurveWidget(QWidget* parent = nullptr);
+
+    void setCurve(const QVector<AgcTCalibrator::Point>& pts);
+    void setCurrentValue(int value);
+    void setRecommended(int value, bool isKnee);
+    void setStrategy(AgcTCalibrator::Strategy s);
+    void setTargetDb(float db);
+    void clear();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+private:
+    QVector<AgcTCalibrator::Point> m_pts;
+    int   m_current{-1};
+    int   m_recommended{-1};
+    bool  m_recIsKnee{true};
+    float m_targetDb{-28.0f};
+    AgcTCalibrator::Strategy m_strategy{AgcTCalibrator::Strategy::Knee};
+};
+
+// AgcCalibrationDialog — the calibration surface. Auto-sweep first (one click),
+// with the live curve always visible so the operator can fine-tune by hand.
+// Operates on the active slice; the radio stays authoritative (we only set the
+// value through SliceModel).
+class AgcCalibrationDialog : public PersistentDialog {
+    Q_OBJECT
+public:
+    using NoiseFloorFn = std::function<float(SliceModel*)>;
+
+    AgcCalibrationDialog(RadioModel* radio,
+                         AudioEngine* audio,
+                         NoiseFloorFn noiseFloorFn,
+                         QWidget* parent = nullptr);
+
+    // Point the panel at a slice (called on show and on active-slice change).
+    void setSlice(SliceModel* slice);
+
+private slots:
+    void onStartStop();
+    void onApply();
+    void onStarted(AgcTCalibrator::Strategy strategy, int originalValue);
+    void onProgress(int currentValue, int percent);
+    void onPointAdded(int value, float rmsDb);
+    void onRecommendation(int value, bool isKnee);
+    void onQuietSpot(bool quiet, float marginDb);
+    void onFinished(bool applied);
+    void pollNoiseFloor();
+    void refreshFromSlice();
+
+private:
+    void connectSlice(SliceModel* slice);
+    void disconnectSlice(SliceModel* slice);
+    void updateModeUi();
+    int  liveValue() const;
+
+    RadioModel*  m_radio{nullptr};
+    AudioEngine* m_audio{nullptr};
+    NoiseFloorFn m_noiseFloorFn;
+    SliceModel*  m_slice{nullptr};
+
+    AgcTCalibrator m_engine;
+    QTimer*        m_floorTimer{nullptr};
+
+    AgcCurveWidget* m_curve{nullptr};
+    QLabel*         m_modeLabel{nullptr};
+    QLabel*         m_quietLabel{nullptr};
+    QLabel*         m_recLabel{nullptr};
+    QLabel*         m_hintLabel{nullptr};
+    QPushButton*    m_startStopBtn{nullptr};
+    QPushButton*    m_applyBtn{nullptr};
+    QDoubleSpinBox* m_targetSpin{nullptr};
+    QWidget*        m_targetRow{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -73,6 +73,7 @@
 #include "AntennaGeniusApplet.h"
 #include "ShackSwitchApplet.h"
 #include "RadioSetupDialog.h"
+#include "AgcCalibrationDialog.h"
 #include "AudioDeviceChangeDialog.h"
 #include "NetworkDiagnosticsDialog.h"
 #include "PropDashboardDialog.h"
@@ -126,6 +127,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <functional>
 #include <QApplication>
@@ -3254,6 +3256,8 @@ MainWindow::MainWindow(QWidget* parent)
     // ── Slice tab toggle: click A/B/C/D → switch active slice (#1278) ──
     connect(m_appletPanel->rxApplet(), &RxApplet::sliceActivationRequested,
             this, &MainWindow::setActiveSlice);
+    connect(m_appletPanel->rxApplet(), &RxApplet::calibrateAgcTRequested,
+            this, &MainWindow::showAgcCalibrationDialog);
     // Sync slice tab capacity after radio info/status reports actual capacity.
     connect(&m_radioModel, &RadioModel::infoChanged, this, [this]() {
         if (m_radioModel.model().isEmpty()) {
@@ -6504,6 +6508,23 @@ void MainWindow::showNetworkDiagnosticsDialog()
     showOrRaisePersistent(m_networkDiagnosticsDialog,
                           &m_radioModel, m_audio, m_networkDiagnosticsHistory);
 #endif
+}
+
+void MainWindow::showAgcCalibrationDialog(int sliceId)
+{
+    SliceModel* slice = m_radioModel.slice(sliceId);
+    if (!slice) {
+        return;
+    }
+    // Provide the measured RF noise floor for the slice's pan (quiet-spot guard).
+    AgcCalibrationDialog::NoiseFloorFn floorFn = [this](SliceModel* s) -> float {
+        SpectrumWidget* sw = s ? spectrumForSlice(s) : nullptr;
+        return sw ? sw->noiseFloorDbm() : std::numeric_limits<float>::quiet_NaN();
+    };
+    showOrRaisePersistent(m_agcCalibrationDialog, &m_radioModel, m_audio, floorFn);
+    if (m_agcCalibrationDialog) {
+        m_agcCalibrationDialog->setSlice(slice);
+    }
 }
 
 void MainWindow::showAx25HfPacketDecodeDialog()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -82,6 +82,7 @@ class ProfileManagerDialog;
 class ProfileImportExportDialog;
 class RadioSetupDialog;
 class NetworkDiagnosticsDialog;
+class AgcCalibrationDialog;
 class MemoryDialog;
 class PropDashboardDialog;
 class TxBandDialog;
@@ -355,6 +356,7 @@ private:
     void showPanadapterSliceCapacityMessage();
     void updatePaTempLabel();
     void showNetworkDiagnosticsDialog();
+    void showAgcCalibrationDialog(int sliceId);
     void showAx25HfPacketDecodeDialog();
     void showFlexControlDialog();
     void handleFlexControlTuneSteps(int steps);
@@ -601,6 +603,7 @@ private:
     QPointer<DxClusterDialog> m_spotHubDialog;
     QPointer<RadioSetupDialog> m_radioSetupDialog;
     QPointer<NetworkDiagnosticsDialog> m_networkDiagnosticsDialog;
+    QPointer<AgcCalibrationDialog> m_agcCalibrationDialog;
     QPointer<PropDashboardDialog> m_propDashboardDialog;
     QPointer<TxBandDialog> m_txBandDialog;
     QPointer<MemoryDialog> m_memoryDialog;

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -939,13 +939,34 @@ void RxApplet::buildUI()
         applyPrimarySliderStyle(m_agcTSlider);
         agcRow->addWidget(m_agcTSlider, 1);
 
+        // Right-click entry point for the AGC-T noise calibration panel.
+        // (Discoverability mitigation for the right-click-only decision: the
+        // tooltip advertises it; see docs/agc-t-calibration-design.md.)
+        m_agcTSlider->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(m_agcTSlider, &QWidget::customContextMenuRequested, this,
+                [this](const QPoint& pos) {
+            if (!m_slice) {
+                return;
+            }
+            QMenu menu(m_agcTSlider);
+            menu.addAction(QStringLiteral("Calibrate AGC-T against noise floor…"),
+                           this, [this] {
+                if (m_slice) {
+                    emit calibrateAgcTRequested(m_slice->sliceId());
+                }
+            });
+            menu.exec(m_agcTSlider->mapToGlobal(pos));
+        });
+
         connect(m_agcTSlider, &QSlider::valueChanged, this, [this](int v) {
             if (m_slice) {
                 if (m_slice->agcMode() == "off") {
-                    m_agcTSlider->setToolTip(QString("AGC Off Level: %1").arg(v));
+                    m_agcTSlider->setToolTip(
+                        QString("AGC Off Level: %1\nRight-click to calibrate against the noise floor").arg(v));
                     m_slice->setAgcOffLevel(v);
                 } else {
-                    m_agcTSlider->setToolTip(QString("AGC Threshold: %1").arg(v));
+                    m_agcTSlider->setToolTip(
+                        QString("AGC Threshold: %1\nRight-click to calibrate against the noise floor").arg(v));
                     m_slice->setAgcThreshold(v);
                 }
             }

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -94,6 +94,9 @@ public:
 signals:
     // Emitted when the user clicks a slice tab button.
     void sliceActivationRequested(int sliceId);
+    // Emitted when the user requests the AGC-T noise calibration panel
+    // (right-click on the AGC-T slider). Carries the active slice id.
+    void calibrateAgcTRequested(int sliceId);
     // Emitted when the user adjusts the AF gain slider (0–100).
     void afGainChanged(int value);
     // Emitted when the user changes the tuning step size (Hz).


### PR DESCRIPTION
## Summary

Adds a guided tool to calibrate a slice's **AGC-T** value against the receiver
**noise floor**, so operators can dial in the right value per band instead of
guessing with the bare 0–100 slider.

The classic SmartSDR procedure — *tune to a clear spot, lower AGC-T until the
band noise just begins to drop, then stop* — is now assisted with a live graph
and an optional one-click auto-sweep.

## Why this approach

- **The knob has no exposed dBm mapping.** On firmware v4.2.18 the radio never
  reports what dBm a given AGC-T value corresponds to, so the "perfect" value
  can only be found **empirically** — by varying the knob and watching the
  receiver respond.
- **The RF noise floor doesn't move when AGC-T moves.** It's measured off the
  pre-AGC FFT. The *only* observable that bends at the AGC knee is the
  **post-AGC audio level** (`AudioEngine::levelChanged`). That's what the tool
  plots and what knee detection runs on. (This is also why a "line on the pan"
  alone can't visualize AGC-T — see the design doc.)
- **AGC mode changes the meaning of the knob.** The tool is mode-aware:
  - AGC **on** (slow/med/fast) → `agc_threshold` is the **knee**; we find the
    elbow on the audio-RMS-vs-threshold curve.
  - AGC **off** → `agc_off_level` is a **fixed gain** with no knee; we instead
    solve for the value that places band-noise audio at a comfortable target.

## What's included

| Area | File(s) | Notes |
|------|---------|-------|
| Engine | `src/core/AgcTCalibrator.{h,cpp}` | Headless `QObject`. Auto-sweep + manual recording on one engine. Knee detection (max-distance-from-chord) for AGC-on; target-level solve for AGC-off. Quiet-spot guard (S-meter vs measured noise floor). Restores original value on Stop. |
| Panel | `src/gui/AgcCalibrationDialog.{h,cpp}` | `PersistentDialog` (frameless + geometry-persist per convention). Live `AgcCurveWidget` plot (audio noise vs AGC-T), **Auto-Sweep-first** + Apply/Stop, AGC-off target control, quiet-spot status line. |
| Entry point | `src/gui/RxApplet.{h,cpp}` | Right-click the AGC-T slider → `calibrateAgcTRequested(sliceId)`; tooltip advertises it (discoverability mitigation). |
| Wiring | `src/gui/MainWindow.{h,cpp}` | Owns the dialog, `showAgcCalibrationDialog(sliceId)`, supplies per-slice noise floor via `spectrumForSlice()`. |
| Build | `CMakeLists.txt` | Registers the two new sources. |
| Docs | `docs/agc-t-calibration-design.md` | Full design + the resolved decision pass. |

## Radio-authoritative & protocol notes

- The radio stays authoritative: values are only ever set through `SliceModel`
  setters (`setAgcThreshold` / `setAgcOffLevel`) — the engine acts like a user
  turning the knob, then the normal status echo flows back. No `applyStatus`
  override, no client-side persistence of the radio value in this PR.

## Decisions (from the design decision pass)

Auto-sweep-first (consistent across skill levels), right-click entry point,
panel + optional ambient pan line as the surface, suggest-never-auto-apply for
per-band recall. Two tradeoffs against the "all skill levels" bias were flagged
and mitigated (tooltip discovery hint; non-modal dismissible suggestion). See
the design doc for the full table and rationale.

## Deferred (follow-up PRs, to keep this reviewable)

- Per-band **suggest chip** (store calibrated value + suggest on band change).
- Ambient **noise-floor line on the panadapter**.

## Testing

- Builds clean: Qt6 / C++20, `RelWithDebInfo`, Ninja, all warnings-as-usual
  (no new warnings in the added files). App bundle links successfully.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
