### PR TITLE
ci(macos-dmg): isolate arch legs, make Intel non-blocking (unblock v26.6.1 macOS release)

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -11,13 +11,32 @@ permissions:
 jobs:
   build-dmg:
     strategy:
+      # Isolate the two arch legs: a failure on one must not cancel the other.
+      # Before this, the default fail-fast cancelled the healthy apple-silicon
+      # build the moment the (unproven) Intel leg failed — see the v26.6.1
+      # release run where Intel's cancellation took apple-silicon down with it.
+      fail-fast: false
       matrix:
         include:
           - runner: macos-15
             label: apple-silicon
+            # apple-silicon is the proven, release-blocking artifact.
+            experimental: false
           - runner: macos-15-intel
             label: intel
+            # Intel is not yet release-ready: the deps-qt-6.8.3-macos-intel
+            # asset is missing (404 → 27-min from-source Qt), and that
+            # from-source build omits qttools, so macdeployqt is absent and
+            # "Bundle Qt frameworks" cannot succeed. Until that is fixed
+            # (add qttools to the module subset + populate the deps asset via
+            # the "Build macOS Qt (Intel deps)" workflow), keep this leg
+            # non-blocking so it cannot hold the release hostage. It still
+            # runs and attaches its DMG automatically once the toolchain works.
+            experimental: true
     runs-on: ${{ matrix.runner }}
+    # Non-blocking Intel: a failure on the experimental leg does not fail the
+    # workflow, so the apple-silicon DMG still ships and the release goes green.
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6


### PR DESCRIPTION
## Summary

Follow-up hardening to **#3349**. That PR fixed the apple-silicon DMG blocker (missing `--background` image). This PR fixes a **second, independent problem** that #3349 does *not* address: the matrix coupling that lets the unproven **Intel** leg sink the healthy **apple-silicon** leg, and the fact that Intel cannot currently succeed at all.

This is the macOS DMG pipeline's **first-ever production release** — no macOS DMG has shipped on any prior tag — so the two arch legs must be decoupled before re-tagging v26.6.1.

## Defensive review findings

**apple-silicon — fixed by #3349, confirmed complete.** On the original v26.6.1 release run, the apple-silicon job passed Code sign application → Create DMG (falsely "success" via the old `|| true`) and died only at **Sign DMG** on a `.dmg` that was never produced. The `codesign … libbrotlicommon` lines in the log are non-fatal `macdeployqt` verbosity — that step exited 0. #3349's background-image removal + `test -f` guard is a complete fix. ✅

**Intel — a separate, latent blocker.** The Intel leg has only ever been **cancelled by fail-fast**, never actually run, so its failure was hidden. Two confirmed faults:
1. The `deps-qt-6.8.3-macos-intel` release asset is **404** (never built) → Intel always falls back to a ~27-min from-source Qt build.
2. That from-source build's `--module-subset` **omits `qttools`**, and `macdeployqt` lives in `qttools`. The "Bundle Qt frameworks" step calls `$PWD/qt-install/bin/macdeployqt`, which therefore won't exist → the step **cannot succeed**. (The `Build macOS Qt (Intel deps)` builder workflow has the same omission, so simply populating the asset wouldn't help without also adding `qttools`.)

apple-silicon avoids this because it uses Homebrew `qt@6`, which ships `macdeployqt`.

**Matrix coupling.** `strategy.matrix` had no `fail-fast: false`, so a failing Intel leg cancels the healthy apple-silicon leg mid-build — observed on the release run.

## Changes (one file, `.github/workflows/macos-dmg.yml`)

1. **`fail-fast: false`** — Intel and apple-silicon legs no longer cancel each other.
2. **Per-leg `experimental` flag → `continue-on-error: ${{ matrix.experimental }}`** — apple-silicon (`experimental: false`) stays the release-blocking artifact; Intel (`experimental: true`) is non-blocking, so it cannot hold the release hostage. Intel still runs and will attach its DMG automatically once its toolchain is fixed.

Both changes are commented inline with the v26.6.1 history and the Intel root cause.

No application code changes. apple-silicon behaviour is unchanged.

## Why non-blocking rather than fixing Intel here

Getting v26.6.1 macOS DMGs out should not wait on the unproven Intel toolchain. This PR guarantees the working apple-silicon DMG ships and the workflow goes green now. The Intel fix (add `qttools` — and likely `qtsvg`/`qtimageformats` — to both module subsets, then populate the deps asset) is a larger, separately-verifiable change and is tracked as a follow-up.

## Post-merge plan

After this lands on `main`, the maintainer re-tags **v26.6.1** to a commit including this fix (and #3349). The `tags: ['v*']` push trigger then runs the macOS DMG workflow with the correct `github.ref_name`, the tag-gated *Attach to release* step upserts the apple-silicon DMG onto the existing v26.6.1 release, and the Intel leg fails non-fatally (no DMG yet) without blocking.

## Risk

CODEOWNERS: `.github/workflows/` is tier-1, maintainer-only approval (@ten9876). One workflow file, additive. No effect on Linux AppImage / Windows installer / sign-release workflows, and apple-silicon steps are untouched.

## Test plan

- [ ] CI green on this PR (workflow is tag/dispatch-triggered; PR CI won't exercise it directly).
- [ ] After merge + re-tag: macOS DMG workflow attaches `AetherSDR-v26.6.1-macOS-apple-silicon.dmg` to the v26.6.1 release; Intel leg fails non-fatally and the workflow conclusion is success.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat