### PR TITLE
fix(split): reclaim TX onto former RX slice when TX slice is removed out-of-band

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -11393,12 +11393,20 @@ void MainWindow::onSliceRemoved(int id)
 
     // If the split TX slice was closed, disable split
     if (m_splitActive && id == m_splitTxSliceId) {
+        // TX slice removed out-of-band (2nd client / front panel / rigctld),
+        // not via the in-app SPLIT toggle. Reclaim TX onto the former RX slice
+        // explicitly (mirror disableSplit). activeSlice() is wrong here:
+        // onSliceAdded() auto-focuses the new TX slice, so the active slice is
+        // the one just removed (already gone from the model -> nullptr, TX is
+        // never reclaimed) or, if a third slice was focused, the WRONG slice,
+        // which would be keyed via the radio command "slice set N tx=1".
+        const int rxId = m_splitRxSliceId;   // capture before reset
         m_splitActive = false;
         m_splitRxSliceId = -1;
         m_splitTxSliceId = -1;
         if (auto* sw = spectrum()) sw->setSplitPair(-1, -1);
-        if (auto* s = activeSlice())
-            s->setTxSlice(true);
+        if (auto* rx = m_radioModel.slice(rxId))
+            rx->setTxSlice(true);
         updateSplitState();
     }
 


### PR DESCRIPTION
## Summary

When operating split and the TX slice is removed out-of-band — by a second SmartSDR client, `rigctld`, or any external API client, rather than via AetherSDR's SPLIT toggle — `onSliceRemoved()` failed to reclaim TX onto the former RX slice. It relied on `activeSlice()`, but `onSliceAdded()` auto-focuses the new TX slice, so the active slice is the one being removed (already gone from the model → `nullptr`, TX never reclaimed) or, if a third slice is focused, the **wrong** slice — which then gets keyed via the real radio command `slice set <id> tx=1`.

This mirrors the existing correct teardown in `disableSplit()`, which reclaims TX onto the stored RX slice id explicitly.

## Why

- **Correctness:** the former RX slice now reliably reclaims TX on external TX-slice removal, matching the in-app SPLIT-off behavior.
- **Safety:** removes a path that could assign TX to an unintended slice via a live radio command (out-of-band TX).
- **Consistency:** the external-removal path and `disableSplit()` now use the same explicit `m_radioModel.slice(m_splitRxSliceId)` reclaim.

## Scope

- 3 functional lines in `src/gui/MainWindow.cpp` (`onSliceRemoved()`), plus an explanatory comment.
- No protocol / persistence / UX change. Focus-return is intentionally left to the existing fallback later in `onSliceRemoved()` to keep the change minimal.

## Test plan

- [x] Local incremental `ninja -C build` clean (Nobara 43, Qt 6.10.3, gcc 15.2.1).
- [x] Live A/B on a **FLEX-6700** — external `slice remove` of the split TX slice, with a third slice focused:

```
                 A(RX)   B(TX)   C(focused)
baseline after:  tx=0    gone    tx=1   <- TX leaked to wrong slice
patched  after:  tx=1    gone    tx=0   <- TX reclaimed by former RX
```

Closes #3353

---

73, Ozy **K6OZY**

AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent, on the Linux dev stack (`nobara-dell`).
