### PR TITLE
fix(network): count missed packets, not gap events, in the quality metric (#2825)

### DIFF
--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -599,13 +599,18 @@ void PanadapterStream::processDatagram(const QByteArray& data)
             const int expected = (stats.lastSeq + 1) & 0x0F;
             if (vitaSeq != expected) {
                 sequenceError = true;
+                // 4-bit modular distance: the number of packets skipped before
+                // the one we just received (1..15). errorCount / m_catStats[].errors
+                // keep counting gap EVENTS (the cumulative "sequence gaps" tally and
+                // per-category diagnostics); missedCount accumulates the true number
+                // of lost PACKETS, which feeds the windowed network-quality metric so
+                // a single bursty gap is no longer undercounted up to 15x. (#2825, #2731)
+                const int missed = (vitaSeq - stats.lastSeq - 1) & 0x0F;
                 stats.errorCount++;
+                stats.missedCount += missed;
                 m_catStats[cat].errors++;
-                if (cat == CatAudio) {
-                    // 4-bit modular distance, minus the one packet we just got. (#2731)
-                    audioMissedThisPacket =
-                        ((vitaSeq - stats.lastSeq - 1) & 0x0F);
-                }
+                if (cat == CatAudio)
+                    audioMissedThisPacket = missed;
             }
         }
         stats.lastSeq = vitaSeq;
@@ -1198,6 +1203,15 @@ int PanadapterStream::packetErrorCount() const
     int total = 0;
     for (auto it = m_streamStats.constBegin(); it != m_streamStats.constEnd(); ++it)
         total += it->errorCount;
+    return total;
+}
+
+int PanadapterStream::packetMissedCount() const
+{
+    QMutexLocker lock(&m_statsMutex);
+    int total = 0;
+    for (auto it = m_streamStats.constBegin(); it != m_streamStats.constEnd(); ++it)
+        total += it->missedCount;
     return total;
 }
 

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -194,6 +194,7 @@ private:
     struct StreamStats {
         int  lastSeq{-1};
         int  errorCount{0};
+        int  missedCount{0};
         int  totalCount{0};
     };
 
@@ -267,6 +268,7 @@ private:
 public:
     // Packet error/total counts across all owned streams (for network quality monitor).
     int packetErrorCount() const;
+    int packetMissedCount() const;
     int packetTotalCount() const;
     qint64 totalRxBytes() const { return m_totalRxBytes.load(); }
     qint64 totalTxBytes() const { return m_totalTxBytes.load(); }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -642,7 +642,8 @@ static QString buildNetworkTooltip(const RadioModel& model)
         << QString("Packet loss (%1s): %2")
                .arg(model.packetLossWindowSeconds())
                .arg(formatNetworkSeqErrors(model.packetLossWindowDrops(),
-                                           model.packetLossWindowPackets()))
+                                           model.packetLossWindowPackets()
+                                               + model.packetLossWindowDrops()))
         << QString("Network jitter: %1").arg(formatNetworkMs(model.audioPacketJitterMs()))
         << QString("Audio gap: %1 (max %2)")
                .arg(formatNetworkMs(model.audioPacketGapMs()),

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -2760,7 +2760,7 @@ void NetworkDiagnosticsDialog::refresh()
             QString("Last %1s: %2 / %3 dropped (%4%)   Total: %5 / %6 dropped (%7%)")
                 .arg(m_model->packetLossWindowSeconds())
                 .arg(windowDrops)
-                .arg(windowPackets)
+                .arg(windowPackets + windowDrops)
                 .arg(windowPct, 0, 'f', 2)
                 .arg(dropped).arg(total).arg(pct, 0, 'f', 2));
     } else {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2610,7 +2610,7 @@ void RadioModel::stopNetworkMonitor()
 
 void RadioModel::evaluateNetworkQuality()
 {
-    const int currentErrors = m_panStream->packetErrorCount();
+    const int currentErrors = m_panStream->packetMissedCount();
     const int currentPackets = m_panStream->packetTotalCount();
     recordNetworkHealthSample(currentErrors, currentPackets);
     const int ping = m_lastPingRtt;
@@ -2646,7 +2646,7 @@ void RadioModel::evaluateNetworkQuality()
 
 void RadioModel::resetNetworkHealthSamples()
 {
-    m_lastErrorCount = m_panStream ? m_panStream->packetErrorCount() : 0;
+    m_lastErrorCount = m_panStream ? m_panStream->packetMissedCount() : 0;
     m_lastPacketCount = m_panStream ? m_panStream->packetTotalCount() : 0;
     for (int i = 0; i < NETWORK_LOSS_WINDOW_SAMPLES; ++i) {
         m_lossSamplePackets[i] = 0;
@@ -2857,7 +2857,11 @@ double RadioModel::packetLossPercent() const
 {
     if (m_packetLossWindowPackets <= 0)
         return 0.0;
-    return (m_packetLossWindowErrors * 100.0) / m_packetLossWindowPackets;
+    // Loss over EXPECTED packets (received + missed) so the figure stays in
+    // [0,100] even under heavy bursts where missed can exceed received in a
+    // window. m_packetLossWindowErrors now accumulates missed packets. (#2825)
+    return (m_packetLossWindowErrors * 100.0)
+           / (m_packetLossWindowPackets + m_packetLossWindowErrors);
 }
 
 int RadioModel::audioPacketGapMs() const


### PR DESCRIPTION
## Summary

The network-quality indicator undercounted bursty packet loss. On a VITA-49 sequence gap, `PanadapterStream` counted the gap **event** (`errorCount++`) and ignored its **size** — but a single gap can hide up to 15 lost packets (4-bit sequence number). The windowed quality metric, which gates `applyAdaptiveFrameRate`, therefore read far healthier than reality under bursty loss.

This adds a per-stream `missedCount` that accumulates the true number of lost packets (the 4-bit modular gap distance, already computed for PLC concealment) and feeds the windowed network-quality metric from `packetMissedCount()` instead of the event-based `packetErrorCount()`. `packetLossPercent()` now divides by **expected** packets (received + missed) so the figure stays in `[0,100]` even under heavy bursts where missed can exceed received within a window.

## Why

- **Correctness:** the indicator/score (and the adaptive frame-rate it gates) now reflect the true magnitude of bursty loss, not just the number of discontinuity events.
- **Scoped, no semantic churn:** `errorCount` / `m_catStats[].errors` stay event-based on purpose — they drive the cumulative *"Total sequence gaps"* tally and the per-category diagnostics, which count events, not lost packets. So existing displays keep their meaning and the `errors ≤ packets` invariant the loss-% formulas rely on is preserved.

## Scope

- `src/core/PanadapterStream.{h,cpp}` — `missedCount` field + `packetMissedCount()`; gap block accumulates missed packets.
- `src/models/RadioModel.cpp` — windowed quality metric fed from `packetMissedCount()`; `packetLossPercent()` over expected packets.
- `src/gui/MainWindow.cpp` + `src/gui/NetworkDiagnosticsDialog.cpp` — windowed "Packet loss" readouts use the same expected denominator so the displayed count and % agree.
- No protocol / persistence change. Cumulative "sequence gaps" tally and per-category loss stay event-based.

## Test plan

- [x] Incremental `ninja -C build` clean (Nobara 43, Qt 6.10.3, gcc 15.2.1).
- [x] **Simulated packet loss + live A/B against a real radio (FLEX-6500).** Bursty inbound loss was simulated with `tc` (IFB ingress redirect + `netem loss gemodel`, scoped to the radio's source IP), then the live **Network Diagnostics** readout was compared against the measured ground-truth loss to confirm they match:

  | | Ground truth (netem) | Network Diag reports | Indicator |
  |---|---|---|---|
  | **Baseline** (`main`) | ~8% bursty | **2.65%** | Fair |
  | **Patched** (this PR) | ~8% bursty | **~10%** | **Poor (red)** |

  Audio/waterfall stutter was identical in both runs — i.e. the actual network condition was the same; only the reported metric changed. The baseline undercounts (counts each multi-packet burst as one event); this PR's reading tracks the true loss the diagnostics measured.

## Notes

- **Score thresholds left as-is (intentional).** The `networkQualityTargetScore` loss ladder is unchanged; it now acts on a metric that reflects true bursty loss, so the indicator and `applyAdaptiveFrameRate` respond more accurately/aggressively under bursts. For ordinary single-packet loss the metric is essentially unchanged (missed ≈ events), so light-loss behavior is preserved.
- **Windowed "drops" semantics.** The windowed readouts (`packetLossWindowDrops()`, `packetLossPercent()`, and `packet_loss_window_*` in the JSON export) now reflect missed *packets* rather than gap *events*. No in-repo consumer relies on the old meaning; the cumulative "Total … dropped" / `packet_drop_count` figures remain event-based.

> Note: `PanadapterStream::processDatagram()` is private and the class is socket-bound, so there is no isolated unit-test seam for the gap counter without adding production test-only API; verification is the live simulated-loss A/B above.

Closes #2825

---

73, Ozy **K6OZY**

AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent, on the Linux dev stack (`nobara-dell`).
