### PR TITLE
fix(midi): global.txButton toggle stuck on; mic level MIDI has no UI feedback (#3369)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -16072,7 +16072,7 @@ void MainWindow::registerMidiParams()
 
     reg("global.txButton", "TX Button", "Global", P::Toggle, 0, 1,
         [this](float v) { m_radioModel.setTransmit(v > 0.5f); },
-        [this]() -> float { return m_radioModel.transmitModel().isMox() ? 1 : 0; });
+        [this]() -> float { return m_radioModel.transmitModel().isTransmitting() ? 1 : 0; });
 
     reg("global.tnfEnable", "TNF Global", "Global", P::Toggle, 0, 1,
         [this](float v) { m_radioModel.sendCommand(QString("radio set tnf_enabled=%1").arg(v > 0.5f ? 1 : 0)); });

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -514,6 +514,7 @@ void TransmitModel::setMicLevel(int level)
 {
     level = qBound(0, level, 100);
     m_micLevel = level;
+    emit micStateChanged();
     emit commandReady(QString("transmit set miclevel=%1").arg(level));
 }
 


### PR DESCRIPTION
## Summary

- **[Global] TX Button** — `global.txButton` getter used `isMox()` which reads `m_mox`, a field the radio never populates from transmit status (always `false`). The toggle sentinel (`-1.0f`) reads the getter to decide the next state, so a getter that always returns `false` means every MIDI press drives TX on and the button can never be toggled off via MIDI. Fixed: changed to `isTransmitting()` — the same optimistic flag `setTransmit()` updates, identical to the fix already applied to `tx.mox` in `407ae4cf`.

- **[Phone/CW] Mic Level** — `setMicLevel()` updated `m_micLevel` and sent the radio command but did not emit `micStateChanged()`. Every other mic-related setter does (`setMicSelection`, `setSpeechProcessor`, `setSpeechProcessorLevel`). Without the signal, `PhoneCwApplet::syncPhoneFromModel` was never triggered, so the UI slider never moved when MIDI changed the level — making the binding appear broken even though the radio was receiving the correct command. Fixed: emit `micStateChanged()` before `commandReady()`.

Fixes #3369.

## Files changed

- `src/gui/MainWindow.cpp` — `global.txButton` getter: `isMox()` → `isTransmitting()`
- `src/models/TransmitModel.cpp` — `setMicLevel()`: add `emit micStateChanged()`

## Test plan

- [ ] Bind a MIDI button to **[Global] TX Button** — press should toggle TX on, second press should toggle TX off (no mouse required)
- [ ] Bind a MIDI knob to **[Phone/CW] Mic Level** — rotating should move the Mic Level slider in the Phone/CW applet in real time
- [ ] Confirm **[TX] MOX** still toggles correctly (already fixed in `407ae4cf`, no change here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)