### PR TITLE
perf(connect): cut ~1.3 s off the connect handshake (skip peek when multiFLEX on; pipeline subs)

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2024,25 +2024,32 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
         sendCmd("keepalive enable");
         startNetworkMonitor();
 
-    // Subscriptions are independent topics and the radio processes TCP commands
-    // in send order, so fire them back-to-back without round-tripping on each R
-    // response — exactly as the second sub batch (sub tnf/dax/codec/…) below
-    // already does. The previous one-RTT-per-sub chain serialized ~11 round
-    // trips (~0.7 s on a LAN) into the connect handshake for no protocol reason.
-    sendCmd("sub slice all");
-    sendCmd("sub pan all");
-    sendCmd("sub tx all");
-    sendCmd("sub atu all");
-    sendCmd("sub amplifier all");
-    sendCmd("sub meter all");
-    sendCmd("sub audio all");
-    sendCmd("sub gps all");
-    sendCmd("sub apd all");
-    armClientConnectionNoticeSuppression();
-    sendCmd("sub client all");
-    sendCmd("sub xvtr all");
-            // Memory status arrives via normal status handler — no subscription needed.
-            // "sub memory all" returns 500000A3 (invalid subscription object).
+        // Subscriptions are independent topics and the radio processes TCP commands
+        // in send order, so fire them back-to-back without round-tripping on each R
+        // response — exactly as the second sub batch (sub tnf/dax/codec/…) below
+        // already does. The previous one-RTT-per-sub chain serialized ~11 round
+        // trips (~0.7 s on a LAN) into the connect handshake for no protocol reason.
+        sendCmd("sub slice all");
+        sendCmd("sub pan all");
+        sendCmd("sub tx all");
+        sendCmd("sub atu all");
+        sendCmd("sub amplifier all");
+        sendCmd("sub meter all");
+        sendCmd("sub audio all");
+        sendCmd("sub gps all");
+        sendCmd("sub apd all");
+        // Suppression must be armed BEFORE "sub client all" because that
+        // subscription is what triggers the radio to send the client-status
+        // burst we want to suppress notices for. The earlier subs in this
+        // batch don't generate client-connection notices, so positioning here
+        // is safe; the old nested-callback layout made this self-documenting
+        // (suppression was armed in the sub apd response callback), the flat
+        // layout doesn't — hence the comment.
+        armClientConnectionNoticeSuppression();
+        sendCmd("sub client all");
+        sendCmd("sub xvtr all");
+        // Memory status arrives via normal status handler — no subscription needed.
+        // "sub memory all" returns 500000A3 (invalid subscription object).
         // Request available mic inputs (comma-separated response: "MIC,BAL,LINE,ACC")
         sendCmd("mic list", [this](int code, const QString& body) {
             if (code == 0) {
@@ -2470,6 +2477,11 @@ void RadioModel::onDisconnected()
     m_ampHandle.clear();
     m_ampOperate = false;
     m_fullDuplex = false;
+    // Reset to false so the next connect's skip-peek fast path requires the
+    // radio's mf_enable status to actually arrive before treating multiFLEX
+    // as enabled. Default-true would silently bypass the conflict check if
+    // the status burst hadn't been processed yet (#3391 review).
+    m_multiFlexEnabled = false;
     m_maxSlices = 4;
     m_model.clear();
     m_version.clear();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1875,6 +1875,22 @@ void RadioModel::peekForMultiFlexConflictThen(std::function<void()> continuation
     // 400 ms is enough for the radio's status burst to arrive on a LAN path.
     sendCmd("sub radio all", [this](int, const QString&) {
         sendCmd("sub client all", [this](int, const QString&) {
+            // Fast path: when multiFLEX is enabled the radio explicitly allows
+            // multiple GUI clients, so the conflict check below
+            // (!m_multiFlexEnabled && hasOthers) can never fire — there is
+            // nothing to wait for. mf_enable arrives in the radio status burst
+            // triggered by "sub radio all" above, so m_multiFlexEnabled is set
+            // by the time this callback runs. Skipping the 400 ms window here
+            // shaves it off the connect handshake. When mf is disabled (or its
+            // status hasn't arrived yet) we fall through to the original wait.
+            if (m_multiFlexEnabled) {
+                if (m_multiFlexContinuation) {
+                    auto cont = std::move(m_multiFlexContinuation);
+                    m_multiFlexContinuation = nullptr;
+                    cont();
+                }
+                return;
+            }
             QTimer::singleShot(400, this, [this] {
                 const quint32 ours2 = clientHandle();
                 bool hasOthers = false;
@@ -2008,21 +2024,23 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
         sendCmd("keepalive enable");
         startNetworkMonitor();
 
-    // Full command sequence — each step waits for its R response before sending the next.
-    // sub slice all → sub pan all → sub tx all → sub atu all → sub amplifier all
-    //   → sub meter all → sub audio all → ...
-    sendCmd("sub slice all", [this](int, const QString&) {
-      sendCmd("sub pan all", [this](int, const QString&) {
-      sendCmd("sub tx all", [this](int, const QString&) {
-        sendCmd("sub atu all", [this](int, const QString&) {
-        sendCmd("sub amplifier all", [this](int, const QString&) {
-          sendCmd("sub meter all", [this](int, const QString&) {
-            sendCmd("sub audio all", [this](int, const QString&) {
-            sendCmd("sub gps all", [this](int, const QString&) {
-            sendCmd("sub apd all", [this](int, const QString&) {
-            armClientConnectionNoticeSuppression();
-            sendCmd("sub client all", [this](int, const QString&) {
-            sendCmd("sub xvtr all", [this](int, const QString&) {
+    // Subscriptions are independent topics and the radio processes TCP commands
+    // in send order, so fire them back-to-back without round-tripping on each R
+    // response — exactly as the second sub batch (sub tnf/dax/codec/…) below
+    // already does. The previous one-RTT-per-sub chain serialized ~11 round
+    // trips (~0.7 s on a LAN) into the connect handshake for no protocol reason.
+    sendCmd("sub slice all");
+    sendCmd("sub pan all");
+    sendCmd("sub tx all");
+    sendCmd("sub atu all");
+    sendCmd("sub amplifier all");
+    sendCmd("sub meter all");
+    sendCmd("sub audio all");
+    sendCmd("sub gps all");
+    sendCmd("sub apd all");
+    armClientConnectionNoticeSuppression();
+    sendCmd("sub client all");
+    sendCmd("sub xvtr all");
             // Memory status arrives via normal status handler — no subscription needed.
             // "sub memory all" returns 500000A3 (invalid subscription object).
         // Request available mic inputs (comma-separated response: "MIC,BAL,LINE,ACC")
@@ -2294,17 +2312,6 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
             sendCmd("sub spot all");
             sendCmd("sub waveform all");
             sendCmd("sub license all");
-            }); // sub xvtr all
-            }); // sub client all
-            }); // sub apd all
-            }); // sub gps all
-            }); // sub audio all
-          }); // sub meter all
-        }); // sub amplifier all
-        }); // sub atu all
-      }); // sub tx all
-      }); // sub pan all
-    }); // sub slice all
     }); // client gui
 }
 


### PR DESCRIPTION
## What

Two independent latency wins on the radio **connect handshake** — the dominant stage of time-to-first-panadapter-frame on a warm launch. No new dependencies, no protocol additions, ~33 lines net in `RadioModel.cpp`.

### 1. Skip the 400 ms multiFLEX conflict peek when `mf_enable=1`
`peekForMultiFlexConflictThen` subscribes to radio/client topics, then waits a fixed `QTimer::singleShot(400)` for the client-status burst before sending `client gui`. But the conflict check is `!m_multiFlexEnabled && hasOthers` — when multiFLEX is **enabled**, the radio explicitly allows multiple GUI clients, so no conflict is possible and that 400 ms is pure dead time. `mf_enable` arrives in the radio status burst triggered by the preceding `sub radio all`, so `m_multiFlexEnabled` is already set when the callback runs; we proceed immediately. The mf-**disabled** path keeps the original 400 ms wait, so conflict detection is unchanged where it actually matters.

`onConnected → first pan stream id`: **~851 ms → ~423 ms**

### 2. Pipeline the first subscription batch
`sub slice all → … → sub xvtr all` was one nested `sendCmd` per command, each awaiting its `R` response — ~11 serial round trips (~0.7 s on a LAN). The radio processes TCP commands in send order, and the **second** sub batch in this same function (`sub tnf/dax/codec/…`) already fires without waiting, so the per-command serialization was gratuitous. Flattened to back-to-back fire-and-forget, matching the existing pattern.

`first pan stream id → subscriptions ACKed`: **~985 ms → ~71 ms**

## Applies to LAN, remote IP, and SmartLink — and helps remote *more*

The subscription pipelining (#2) lives in `registerAsGuiClient`, which is shared by **every** connection type. `onConnected` reaches it from both branches — LAN via `peekForMultiFlexConflictThen(…)`, and remote IP / SmartLink (WAN) via `sendCmd("client ip", … registerAsGuiClient)` — and `sendCmd` routes to `m_wanConn->sendCommand()` over the SmartLink TLS tunnel when WAN is active, or the LAN socket otherwise. Same flattened subs on all paths.

The win is "11 serial round-trips → one burst," so it scales with per-RTT latency: on LAN that's ~60 ms/RTT (~0.7 s saved), but over a routed/SmartLink link at 50–200 ms+/RTT the serial chain can cost 1.5–3 s, making the absolute saving **larger on remote flows**. Order-preserving pipelining is already proven for the WAN tunnel — the existing second sub batch fires-and-forget through this exact path.

The peek skip (#1) is **LAN-only** by construction: the WAN/SmartLink branch never runs the peek (it does a `client ip` round-trip instead, and multiFLEX conflicts on WAN are caught pre-connection via `licensedClients`). So #1 is a no-op there — no benefit, no regression.

## Impact

Combined handshake (**TCP connected → subscriptions ACKed**): **~1810 ms → ~494 ms** on LAN.

Measured warm launch → first panadapter frame: **~3.2 s → ~2.3 s** on a FLEX-8400M over LAN. (A "warm" launch = consent already granted; a cold first launch is dominated by the macOS local-network/mic consent dialogs, which are one-time human interaction and not representative.)

**Remote IP / SmartLink numbers are not yet measured** (tested on a LAN FLEX-8400M only); pipelining #2 covers those paths and is expected to help at least as much, but the figures above are LAN-measured.

## How it was found

Profiled the launch→connect→first-frame path with a temporary timeline instrument (kept out of this PR per request). The connect handshake was ~55% of warm startup; this PR addresses it. The remaining stages — UI init (~0.76 s) and the discovery broadcast wait (~0.85 s, bounded by the radio's ~1 Hz beacon) — are untouched here and are candidate follow-ups.

## Verification (on hardware)

- Connects cleanly to a FLEX-8400M over LAN.
- Pipelined subs are sent in a single burst (`C32…C42` same millisecond).
- No `peek window closed with no client status received` warning.
- Spectrum streams (`streamAck=yes`), panadapter renders, clean disconnect.
- No subscription/protocol errors introduced.

## Risk

Low. Both changes preserve command **send order** (which the radio honors) and the existing conflict-detection semantics. The mf-disabled connect path is byte-for-byte unchanged.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat

🤖 Generated with [Claude Code](https://claude.com/claude-code)