### PR TITLE
fix(gui): collapse ESC panel space immediately when DIV toggles off (#3383). Principle VIII.

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1126,7 +1126,9 @@ void VfoWidget::buildTabContent()
                 m_slice->setDiversity(on);
             // ESC panel only on diversity parent, not child
             m_escPanel->setVisible(on && m_slice && !m_slice->isDiversityChild());
-            resize(sizeHint());
+            // setVisible() only posts a LayoutRequest; adjustSize() activates the
+            // layout first so the panel collapses immediately (#3383)
+            adjustSize();
         });
         connect(m_escBtn, &QPushButton::toggled, this, [this](bool on) {
             if (!m_updatingFromModel && m_slice)
@@ -2194,7 +2196,7 @@ void VfoWidget::setDiversityAllowed(bool allowed)
     // ESC panel only visible when DIV is active on a dual-SCU radio
     if (m_escPanel && !allowed) {
         m_escPanel->setVisible(false);
-        resize(sizeHint());
+        adjustSize();  // flush pending layout before sizing (#3383)
     }
 }
 
@@ -2810,7 +2812,7 @@ void VfoWidget::setSlice(SliceModel* slice)
         QSignalBlocker sb(m_divBtn);
         m_divBtn->setChecked(on);
         m_escPanel->setVisible(on && !m_slice->isDiversityChild());
-        resize(sizeHint());
+        adjustSize();  // flush pending layout before sizing (#3383)
     });
     // ESC sync — phase is in radians, display as degrees
     {


### PR DESCRIPTION
## Summary

Fixes #3383. Toggling DIV off now collapses the ESC panel space immediately. The three sites that toggle `m_escPanel` visibility called `resize(sizeHint())` right after `setVisible()`, but `setVisible()` only posts a `LayoutRequest` to the audio tab's layout - it does not activate it synchronously - so `sizeHint()` still returned the stale pre-hide height and the panel kept a blank gap until something else (like clicking the speaker sub-tab) forced a reflow. `adjustSize()` activates the pending layout before computing the new size, which is the missing step. All three diversity-path call sites in `src/gui/VfoWidget.cpp` are swapped: the DIV button `toggled` handler, `setDiversityAllowed(false)` (non-dual-SCU reconnect path), and the `SliceModel::diversityChanged` model-sync handler. The DIV-on path benefits equally: the panel grows in one step instead of relying on a previously-posted layout pass.

## Context

#3383 reports the gap between the Med (AGC speed) row and the bottom of the panel after DIV is toggled off, with the layout only correcting after a tab switch. The @aethersdr-agent triage on the issue traced it to exactly these three call sites, and this PR follows that triage. The fourth `resize(sizeHint())` in the RADE info-row toggle is intentionally left as-is to keep this scoped to the diversity paths.

## Constitution principle honored

Principle VIII - Evidence Over Assertion. Root cause and call sites come from the @aethersdr-agent triage on #3383 plus Qt's documented `LayoutRequest`/`activate()` ordering (`QWidget::adjustSize()` activates the layout before reading the size hint). The diff is confined to those three sites.

## Test plan

- [x] Reproduction steps documented if user-reported bug (repro and expected behavior from #3383: DIV off collapses the AF/SQL/Med rows immediately; DIV on restores the full ESC panel height; rapid toggling settles correctly since every toggle now activates the layout before sizing)
- [x] Existing tests pass (CI) - no test code touched; the CI build matrix exercises compilation of the two-method swap

Not run against a real radio: no FlexLib or protocol surface is touched, and this machine has no Qt6 toolchain for a local GUI build, so compilation is delegated to CI.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls - none added (Principle V)
- [x] All meter UI uses `MeterSmoother` - no meter changes (Principle II)
- [x] Documentation updated if user-visible behavior changed - the visible change is the bug fix itself; no docs reference the stale-gap behavior
- [x] Security-sensitive changes reference a GHSA if applicable - not security-sensitive
