### PR TITLE
feat(gui): badge on keyboard slider steps; Enter releases slider focus

### DIFF
--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -53,6 +53,19 @@ public:
             m_dragValuePopup->hideNow();
     }
 
+    // Flash the value badge in response to a keyboard step, then let it
+    // linger and fade with the same timeout as a mouse release.  Keyboard
+    // nudges for these sliders are routed through MainWindow's shortcut
+    // lease (so global operating shortcuts can resume), so the lease handler
+    // calls this to mirror the mouse-drag readout. (#3303 follow-up)
+    void flashDragValue() {
+        if (!m_dragValuePopupEnabled)
+            return;
+        showDragValuePopup(mapToGlobal(rect().center()));
+        if (m_dragValuePopup)
+            m_dragValuePopup->linger();
+    }
+
     void mousePressEvent(QMouseEvent* ev) override {
         if (ControlsLock::isLocked()) {
             ev->ignore();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -123,6 +123,7 @@
 #include "WaveformsDialog.h"
 #include "ClientRxDspApplet.h"
 #include "DspParamPopup.h"
+#include "GuardedSlider.h"
 #include "FramelessResizer.h"
 #include "FramelessWindowTitleBar.h"
 
@@ -7772,12 +7773,27 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
             auto* slider = qobject_cast<QAbstractSlider*>(QApplication::focusWidget());
             if (slider && m_sliderShortcutLease.data() == slider && s_sliderShortcutLeaseActive) {
                 int k = ke->key();
+                // Enter hands keyboard control straight back to the panadapter's
+                // global shortcuts, instead of waiting for the lease to time out.
+                if (k == Qt::Key_Return || k == Qt::Key_Enter) {
+                    releaseSliderShortcutLease(true);
+                    return true;
+                }
+                // After a keyboard nudge, flash the same value badge the mouse
+                // drag shows so keyboard and mouse give identical feedback.
+                // GuardedSlider has no Q_OBJECT macro, so reach it via
+                // dynamic_cast rather than qobject_cast.
+                auto flashBadge = [slider]() {
+                    if (auto* gs = dynamic_cast<GuardedSlider*>(slider))
+                        gs->flashDragValue();
+                };
                 if (k == Qt::Key_Left || k == Qt::Key_Right
                     || k == Qt::Key_Up || k == Qt::Key_Down) {
                     bool increase = (k == Qt::Key_Right || k == Qt::Key_Up);
                     int step = (ke->modifiers() & Qt::ControlModifier)
                                    ? slider->pageStep() : slider->singleStep();
                     slider->setValue(slider->value() + (increase ? step : -step));
+                    flashBadge();
                     renewSliderShortcutLease();
                     return true;
                 }
@@ -7785,6 +7801,7 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
                     const int step = slider->pageStep();
                     slider->setValue(slider->value()
                                      + (k == Qt::Key_PageUp ? step : -step));
+                    flashBadge();
                     renewSliderShortcutLease();
                     return true;
                 }
@@ -7792,6 +7809,7 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
                     slider->setValue(k == Qt::Key_Home
                                          ? slider->minimum()
                                          : slider->maximum());
+                    flashBadge();
                     renewSliderShortcutLease();
                     return true;
                 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -124,6 +124,7 @@
 #include "ClientRxDspApplet.h"
 #include "DspParamPopup.h"
 #include "GuardedSlider.h"
+#include "MeterSlider.h"
 #include "FramelessResizer.h"
 #include "FramelessWindowTitleBar.h"
 
@@ -859,6 +860,15 @@ static bool shortcutInputCaptured()
 
 static bool shortcutGuard() {
     return s_keyboardShortcutsEnabled && !shortcutInputCaptured();
+}
+
+// True while the lease holder is actively being dragged with the mouse, so the
+// lease must not time out mid-drag.  Covers both QAbstractSlider handles and the
+// MeterSlider (TCI/DAX) custom fader.
+static bool leaseHolderBusy(QWidget* w) {
+    if (auto* s = qobject_cast<QAbstractSlider*>(w)) return s->isSliderDown();
+    if (auto* m = qobject_cast<AetherSDR::MeterSlider*>(w)) return m->isDragging();
+    return false;
 }
 
 static QKeySequence shortcutSequenceFromKeyEvent(const QKeyEvent* ev)
@@ -7641,7 +7651,7 @@ void MainWindow::showPropDashboard()
     showOrRaisePersistent(m_propDashboardDialog, m_propForecast);
 }
 
-void MainWindow::beginSliderShortcutLease(QAbstractSlider* slider)
+void MainWindow::beginSliderShortcutLease(QWidget* slider)
 {
     if (!slider) return;
 
@@ -7661,7 +7671,7 @@ void MainWindow::renewSliderShortcutLease()
     s_sliderShortcutLeaseActive = true;
     m_shortcutManager.setShortcutsEnabled(false);
 
-    if (m_sliderShortcutLease->isSliderDown()) {
+    if (leaseHolderBusy(m_sliderShortcutLease.data())) {
         m_sliderShortcutLeaseTimer.stop();
         return;
     }
@@ -7673,7 +7683,7 @@ void MainWindow::releaseSliderShortcutLease(bool clearFocus)
 {
     auto* slider = m_sliderShortcutLease.data();
 
-    if (clearFocus && slider && slider->isSliderDown()) {
+    if (clearFocus && slider && leaseHolderBusy(slider)) {
         renewSliderShortcutLease();
         return;
     }
@@ -7705,6 +7715,16 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
             beginSliderShortcutLease(slider);
         } else if (event->type() == QEvent::MouseButtonRelease
                    && m_sliderShortcutLease.data() == slider) {
+            renewSliderShortcutLease();
+        }
+    } else if (auto* meter = qobject_cast<AetherSDR::MeterSlider*>(obj)) {
+        // MeterSlider (TCI/DAX gain) gets the same lease so a mouse drag hands
+        // off to keyboard nudges, then global shortcuts resume after a beat.
+        if (event->type() == QEvent::MouseButtonPress
+            || event->type() == QEvent::MouseButtonDblClick) {
+            beginSliderShortcutLease(meter);
+        } else if (event->type() == QEvent::MouseButtonRelease
+                   && m_sliderShortcutLease.data() == meter) {
             renewSliderShortcutLease();
         }
     }
@@ -7765,6 +7785,20 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
                 }
             }
             return true;  // always consume Space to prevent button activation
+        }
+
+        // MeterSlider (TCI/DAX gain) handles its own arrow stepping, badge,
+        // and Enter-to-release inside keyPressEvent; the lease only frees the
+        // arrows from the global tune/AF shortcuts.  Renew it on each step so
+        // it doesn't expire mid-adjustment, then let the key fall through.
+        if (event->type() == QEvent::KeyPress) {
+            auto* meter = qobject_cast<AetherSDR::MeterSlider*>(QApplication::focusWidget());
+            if (meter && m_sliderShortcutLease.data() == meter && s_sliderShortcutLeaseActive) {
+                int k = ke->key();
+                if (k == Qt::Key_Left || k == Qt::Key_Right
+                    || k == Qt::Key_Up || k == Qt::Key_Down)
+                    renewSliderShortcutLease();
+            }
         }
 
         // A clicked slider gets a short keyboard lease so arrow nudges adjust
@@ -15532,6 +15566,8 @@ void MainWindow::registerShortcutActions()
             [this](QWidget* /*old*/, QWidget* now) {
         if (auto* slider = qobject_cast<QAbstractSlider*>(now))
             beginSliderShortcutLease(slider);
+        else if (auto* meter = qobject_cast<AetherSDR::MeterSlider*>(now))
+            beginSliderShortcutLease(meter);
         else
             releaseSliderShortcutLease(false);
     });

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -391,7 +391,11 @@ private:
     void updateBandStackIndicator();
     SliceModel* preferredMemorySlice(const QString& preferredPanId) const;
     bool activateMemorySpot(int memoryIndex, const QString& preferredPanId = {});
-    void beginSliderShortcutLease(QAbstractSlider* slider);
+    // The lease holder is usually a QAbstractSlider, but MeterSlider (the
+    // TCI/DAX combined meter+gain fader) is a plain QWidget that handles its
+    // own keys, so the lease is typed as QWidget* and frees the arrow keys
+    // for whichever control is focused.
+    void beginSliderShortcutLease(QWidget* slider);
     void renewSliderShortcutLease();
     void releaseSliderShortcutLease(bool clearFocus);
 
@@ -784,7 +788,7 @@ private:
     bool m_cwStraightKeyActive{false};
     bool m_cwLeftPaddleActive{false};
     bool m_cwRightPaddleActive{false};
-    QPointer<QAbstractSlider> m_sliderShortcutLease;
+    QPointer<QWidget> m_sliderShortcutLease;
     QTimer m_sliderShortcutLeaseTimer;
     struct SwrSweepSample {
         double freqMhz{0.0};

--- a/src/gui/MeterSlider.h
+++ b/src/gui/MeterSlider.h
@@ -34,7 +34,10 @@ public:
         setFixedHeight(16);
         setMinimumWidth(60);
         setCursor(Qt::PointingHandCursor);
-        setFocusPolicy(Qt::TabFocus);
+        // StrongFocus (was TabFocus) so a mouse click leaves keyboard focus on
+        // the fader — matching GuardedSlider — which lets keyboard stepping and
+        // the value badge work after a mouse interaction. (#3303 follow-up)
+        setFocusPolicy(Qt::StrongFocus);
 
         m_animTimer.setTimerType(Qt::PreciseTimer);
         m_animTimer.setInterval(kMeterSmootherIntervalMs);
@@ -52,6 +55,7 @@ public:
 
     float gain() const { return m_gain; }
     float level() const { return m_smooth.value(); }
+    bool isDragging() const { return m_dragging; }
 
     void setDragValueFormatter(DragValueFormatter formatter) {
         m_dragValueFormatter = std::move(formatter);
@@ -197,6 +201,10 @@ protected:
 
     void mousePressEvent(QMouseEvent* e) override {
         if (e->button() == Qt::LeftButton) {
+            // Take keyboard focus explicitly: the left-button path doesn't call
+            // the base handler, so rely on this rather than the focus policy's
+            // implicit click-to-focus to start the mouse→keyboard handoff.
+            setFocus(Qt::MouseFocusReason);
             m_dragging = true;
             updateGainFromMouse(e->pos().x());
             showDragValuePopup(e->globalPosition().toPoint());

--- a/src/gui/MeterSlider.h
+++ b/src/gui/MeterSlider.h
@@ -175,6 +175,20 @@ protected:
                 emit gainChanged(m_gain);
                 update();
             }
+            // Mirror the mouse-drag readout: show the value badge and let it
+            // linger with the same timeout, even when stepping by keyboard.
+            showDragValuePopup(dragValueAnchor(mapToGlobal(rect().center())));
+            if (m_dragValuePopup)
+                m_dragValuePopup->linger();
+            e->accept();
+            return;
+        }
+        // Enter hands keyboard control back to the panadapter's global
+        // shortcuts immediately, rather than waiting for focus to drift away.
+        if (e->key() == Qt::Key_Return || e->key() == Qt::Key_Enter) {
+            if (m_dragValuePopup)
+                m_dragValuePopup->hideNow();
+            clearFocus();
             e->accept();
             return;
         }


### PR DESCRIPTION
## Summary

Two small follow-ups to the applet-slider keyboard support that landed in #3303, plus an audit so the same UX is consistent across every applet slider. Both features make the keyboard path behave like the mouse path on applet sliders (AGC level, TCI/DAX gain, etc.).

### 1. Value badge on keyboard steps

When you drag an applet slider with the mouse, a value badge pops up above the thumb and lingers briefly (~450 ms) after release. Adjusting the **same slider with the keyboard** previously showed **no badge**.

Now keyboard stepping flashes the identical badge with the identical linger/fade timeout, so keyboard and mouse give matching visual feedback.

- `GuardedSlider` (AGC threshold, most applet sliders): gains a public `flashDragValue()`. Keyboard nudges for these sliders are routed through `MainWindow`'s shortcut-lease key handler, so that handler calls `flashDragValue()` after each arrow / `Ctrl`+arrow / `PageUp`/`PageDown` / `Home`/`End` step. It's reached via `dynamic_cast` because `GuardedSlider` has no `Q_OBJECT` macro.
- `MeterSlider` (TCI/DAX combined meter + gain fader): shows and lingers the badge directly from its own `keyPressEvent`.

### 2. Enter returns focus to the panadapter

After a mouse interaction, a slider holds a short keyboard lease (2 s) / focus, during which arrow keys nudge the slider instead of driving the global panadapter shortcuts. If you want those global shortcuts back **immediately** — without waiting for the lease to expire — you can now press **Enter** while the slider has focus.

- `GuardedSlider`: `MainWindow` releases the shortcut lease and clears slider focus, re-enabling the global operating shortcuts.
- `MeterSlider`: hides the badge and clears focus.

### 3. TCI/DAX (MeterSlider) — making the keyboard path actually reachable

The first pass added the badge + Enter handling to `MeterSlider`, but that code was **dead**: `MeterSlider` is a plain `QWidget` with `Qt::TabFocus`, so a mouse drag never left keyboard focus on it, and it never engaged the shortcut lease. Because the arrow keys are **global shortcuts** (`Left`/`Right` tune frequency, `Up`/`Down` adjust AF gain), a matched `QShortcut` consumes the key before the focused widget's `keyPressEvent` runs — so `MeterSlider`'s own arrow stepping (and the new badge) never executed.

Fixes, mirroring `GuardedSlider` behavior exactly:
- `MeterSlider`: `Qt::TabFocus` → `Qt::StrongFocus`, plus an explicit `setFocus(MouseFocusReason)` on left-press, so a mouse interaction hands off to the keyboard. Adds `isDragging()`.
- `MainWindow`: the shortcut lease is generalized from `QAbstractSlider*` to `QWidget*` so `MeterSlider` can hold it (freeing the arrows from the global tune/AF shortcuts while focused). `focusChanged` and the mouse-press event filter begin the lease for `MeterSlider` too, and a keypress hook renews it on each step so it doesn't expire mid-adjustment. A `leaseHolderBusy()` helper unifies `isSliderDown()`/`isDragging()` so the lease never times out mid-drag for either type.

### Applet-slider audit (gaps found)

| Slider type | Count | Mouse badge | Keyboard badge | Status |
|---|---|---|---|---|
| `GuardedSlider` | 66 | ✅ | ✅ (this PR) | covered |
| `MeterSlider` (TCI/DAX) | 4 | ✅ | ✅ (this PR) | covered |
| plain `QSlider` | 8 | ❌ | ❌ | pre-existing gap, see below |

The 8 plain `QSlider`s have **never** shown a badge (mouse or keyboard): `AetherDspWidget` DFNR atten/beta, `StripFinalOutputPanel` freq/level×2/morse-pitch, `StripWaveformPanel` window, `SpectrumOverlayMenu` line-width. Most live in transient **dialogs/menus**, not the main applet panel, and the keyboard-badge path depends on the panadapter shortcut lease that only applies in the main window. Converting them to `GuardedSlider` would give them the mouse badge for free; left out of this PR to keep it focused — easy follow-up if wanted.

## Behavior summary

| Action | Before | After |
|---|---|---|
| Keyboard-step an applet slider (incl. TCI/DAX) | no badge | badge flashes + lingers (same as mouse) |
| Press Enter with slider focused | nothing; wait out the lease | global panadapter shortcuts resume immediately |

## Testing

- Builds clean (Ninja / RelWithDebInfo, Qt6).
- Deployed to the test Mac for hands-on verification of badge timing, TCI/DAX keyboard stepping, and Enter-to-release behavior.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat