### PR TITLE
feat(audio): consolidated sink/rate negotiation foundation (#3306)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1693,6 +1693,17 @@ target_include_directories(tx_mic_channel_normalizer_test PRIVATE
 target_link_libraries(tx_mic_channel_normalizer_test PRIVATE Qt6::Core)
 add_test(NAME tx_mic_channel_normalizer_test COMMAND tx_mic_channel_normalizer_test)
 
+# Pure, headless, hardware-free golden matrix for the consolidated audio
+# format/rate negotiation policy (#3306). TargetOs is data, so this one binary
+# exercises the Windows/macOS/Linux ladders regardless of the CI host.
+add_executable(audio_format_negotiation_test
+    tests/audio_format_negotiation_test.cpp
+    src/core/AudioFormatNegotiator.cpp
+)
+target_include_directories(audio_format_negotiation_test PRIVATE src)
+target_link_libraries(audio_format_negotiation_test PRIVATE Qt6::Core)
+add_test(NAME audio_format_negotiation_test COMMAND audio_format_negotiation_test)
+
 add_executable(profile_transfer_test
     tests/profile_transfer_test.cpp
 )

--- a/docs/audio-sink-factory.md
+++ b/docs/audio-sink-factory.md
@@ -1,0 +1,186 @@
+# Consolidated audio sink factory
+
+> Status: **in progress** — foundation landed (pure negotiator + golden tests).
+> Tracking issue: [#3306](https://github.com/aethersdr/AetherSDR/issues/3306).
+> Companion doc: [`audio-pipeline.md`](audio-pipeline.md).
+
+## Why
+
+Every audio sink and source in AetherSDR currently answers two questions on its
+own:
+
+1. **"What rate / sample format does this device want, and how do I get my
+   24 kHz canonical audio onto it?"** — reimplemented ~9 times with ~6 divergent
+   fallback ladders and per-OS `#ifdef` branches that have drifted apart. This
+   is the root of a recurring class of platform bugs (44.1k-only devices
+   silently failing on some sinks, WASAPI Float32-only devices rejecting Int16,
+   macOS Bluetooth-HFP mics delivering silence).
+2. **"Which output device do I play to?"** — every *new* sink has historically
+   forgotten to follow the user's selected output device and instead opened the
+   system default. Each time, a reactive PR retrofits device-following:
+   CW sidetone ([#2899]), the Aetherial/Pudu monitor + QSO playback ([#3378],
+   closing [#3361]). This is the "**uncoupling**" the operators hit: change the
+   output device and CW / RADE / the Aetherial-Audio Pudu recorder keep playing
+   on the old endpoint.
+
+The factory makes both answers a **single shared responsibility** so a new sink
+inherits correct behaviour by construction instead of re-introducing the class.
+
+## Architecture
+
+```
+                        ┌─────────────────────────────────────────────┐
+                        │  AudioFormatNegotiator   (PURE, Qt6::Core)   │
+                        │  negotiate(os, dir, DeviceCaps, policy)      │
+                        │  buildLadder(...) · resamplerKindFor(...)    │
+                        └───────────────▲─────────────────────────────┘
+                                        │ injected DeviceCaps (no device I/O)
+                        ┌───────────────┴─────────────────────────────┐
+                        │  AudioDeviceNegotiator   (Qt Multimedia)     │
+                        │  probe(QAudioDevice) -> DeviceCaps           │
+                        │  negotiate(...) -> {QAudioFormat, kind, …}   │
+                        │  formatLadder(...) for try-at-open backends  │
+                        └───────────────▲─────────────────────────────┘
+                                        │
+                        ┌───────────────┴─────────────────────────────┐
+                        │  AudioOutputRouter   (device ownership)      │
+                        │  selected output/input device + change feed  │
+                        │  registers sinks; restarts them on change    │
+                        └───────────────▲─────────────────────────────┘
+            RX speaker · CW sidetone · Pudu monitor · Quindar · QSO playback ·
+            PC mic (TX) · TCI TX · RADE   (all consume the three layers above)
+```
+
+### Layer 1 — `AudioFormatNegotiator` (pure policy) ✅ landed
+
+A dependency-free function (links only `Qt6::Core`) over an **injected**
+`DeviceCaps` snapshot, with the **target OS as a parameter, not an `#ifdef`**.
+That single design choice is what makes the whole policy testable headless: one
+binary built on any CI runner exercises the Windows, macOS and Linux ladders
+against every device shape (see `tests/audio_format_negotiation_test.cpp`). This
+is the reason the historical bugs escaped CI — they were compiled behind
+`Q_OS_*` and a Linux runner could only ever see the Linux path.
+
+Key types (`src/core/AudioFormatNegotiator.h`):
+
+- `TargetOs { Windows, MacOS, Linux }` — data, not `#ifdef`.
+- `Direction { Output, Input }`.
+- `SampleFmt { Int16, Float32 }` — a Qt-Multimedia-free mirror of
+  `QAudioFormat::SampleFormat` (the live wrapper maps between them).
+- `ResamplerKind { None, PreservePan, MonoCollapse }` and
+  `ResamplerPolicy { RegenerateAtRate, PreservePan, MonoCollapse }`.
+- `DeviceCaps` — `supportedRates`, `supportedFormats`, `channels`,
+  `isBluetoothHfp`, `isFormatSupportedReliable`, `preferredRate/Format`.
+- `buildLadder()` / `negotiate()` / `resamplerKindFor()`.
+
+The ladder, in one place, owns:
+
+| Concern | Rule | History |
+|---|---|---|
+| Windows RX preferred rate | force **48 kHz** + r8brain (24 k via WASAPI resampler artifacts under NR) | [#2120] / PR [#2123] |
+| macOS RX preferred rate | **48 kHz** so A2DP devices stay off HFP/telephony | [#1705] |
+| Linux RX preferred rate | native **24 kHz** (no WASAPI in path) — deliberate divergence | #3306 |
+| 44.1 kHz fallback | **every** sink, every OS (was missing on RX/Quindar/QSO) | [#3385] |
+| Int16 ↔ Float32 | both tried per rate; Float-first output, Int16-first input | [#2669] / [#1090] |
+| `preferredFormat()` catch-all | final rung for Float32-only virtual drivers / WASAPI | [#3231] |
+| macOS mic preferred-rate-first | avoids silent 48 k open on 16 k-native mics | PR [#2930] |
+| macOS Bluetooth-HFP mic | native 8/16/24 k first, never forced to 48 k | [#2615] |
+| Windows probe-at-open | skip unreliable `isFormatSupported`, try at open | [#2120] / [#2929] |
+
+### Layer 2 — `AudioDeviceNegotiator` (live wrapper, Qt Multimedia) — next
+
+Thin, the **only** platform-specific code. `probe(QAudioDevice, Direction)`
+builds a `DeviceCaps` (rate probing via `isFormatSupported`, `preferredFormat`,
+per-OS `isFormatSupportedReliable`, and — fed by the existing CoreAudio HAL
+detection — `isBluetoothHfp`). Returns either a resolved `QAudioFormat` +
+`ResamplerKind` for reliable backends, or the ordered `QAudioFormat` **ladder**
+for try-at-open backends (Windows), so the caller walks it against
+`QAudioSink::start()` exactly as today.
+
+### Layer 3 — `AudioOutputRouter` (device ownership) — next
+
+`AudioEngine` already owns the persisted device IDs (`AudioOutputDeviceId` /
+`AudioInputDeviceId`) and is the only thing that calls `setOutputDevice()` /
+`setInputDevice()`. Today it emits `outputDeviceChanged()` / `inputDeviceChanged()`
+but **only `MainWindow::updatePcAudioTooltip()` listens** — the aux sinks do not,
+which is the uncoupling. The router turns this into one ownership point:
+
+- **single source of truth** for the resolved selected output/input device
+  (and "follow the system default" when none is pinned);
+- sinks **register** themselves; on a user device change *or* an OS-default
+  change ([#2899] showed both must be handled) the router restarts the
+  registered following sinks — no sink calls `QMediaDevices::defaultAudioOutput()`
+  on its own ever again;
+- one place to enforce the safety invariants below.
+
+## Invariants the factory must preserve (regression guards)
+
+These are load-bearing; each maps to a closed bug. The golden matrix encodes the
+rate ones; the others are enforced in the router/wrapper.
+
+1. **Two stereo resampler strategies stay distinct.** `PreservePan` (dual
+   independent L/R r8brain) for RX speaker + QSO playback; `MonoCollapse`
+   (`processStereoToStereo`) for TCI DAX TX + RADE. Conflating them collapsed
+   VITA-49 pan ([#2403] / PR [#2459]).
+2. **Resampler instances are per-stream / per-channel**, never shared — r8brain
+   is stateful; a shared instance bled Slice A audio into Slice B ([#1815]).
+3. **Unmute RX on every bail path.** Any sink that mutes live RX while it owns
+   the device must `muteRxRequested(false)` on *every* early-return / failure,
+   or RX stays dead until restart ([#3230]).
+4. **DAX shared-ownership refcount.** The `dax_rx` stream is torn down only when
+   neither a TCI client nor the DAX bridge nor RADE still needs it
+   ([#2633] / [#2886]).
+5. **No global WASAPI buffer cap.** A hard 100 ms ring cap for all device types
+   was rejected; latency must derive from the existing `rxBufferCapMs` knob
+   ([#3194] / [#3266]).
+6. **Land incrementally, one sink per PR, with soak time** — the maintainer's
+   explicit rule for audio-stack changes ([#3194] thread), matching #3306's
+   "helper first, migrate sinks incrementally."
+
+## Migration plan (one mergeable PR per step)
+
+1. **Foundation** ✅ — `AudioFormatNegotiator` + golden matrix
+   (`audio_format_negotiation_test`). Pure addition, zero behaviour change.
+2. **Live wrapper** — `AudioDeviceNegotiator`, with a unit smoke test against the
+   default device. Still no sink uses it yet.
+3. **RX speaker** onto the wrapper — behaviour identical for normal devices; the
+   *only* visible change is that a 44.1k-only output now works instead of
+   failing (the #3306 regression the foundation guards). Soak on Win/Mac/Linux.
+4. **PC mic (TX)** onto the wrapper — preserves macOS preferred-first / BT-HFP /
+   Windows probe-at-open.
+5. **`AudioOutputRouter`** + migrate the three uncoupled sinks (CW sidetone,
+   Pudu monitor, QSO playback) and Quindar onto it — closes the uncoupling
+   class so a future sink can't re-open it.
+6. **TCI TX** — drive the resampler from the client-negotiated rate instead of
+   the hardcoded `Resampler(48000, 24000)` (`TciServer.cpp`).
+7. **PipeWire DAX** — replace the hand-rolled linear interpolator with the shared
+   `Resampler`, keeping the 48 kHz node pinning.
+
+### Out of scope (radio/client-authoritative — pass the target in, don't choose)
+
+DAX IQ `daxiq_rate`; the TCI client-requested RX rate. These are inputs to the
+factory, not decisions it makes.
+
+<!-- references -->
+[#1090]: https://github.com/aethersdr/AetherSDR/pull/1090
+[#1705]: https://github.com/aethersdr/AetherSDR/issues/1705
+[#1815]: https://github.com/aethersdr/AetherSDR/pull/1815
+[#2120]: https://github.com/aethersdr/AetherSDR/issues/2120
+[#2123]: https://github.com/aethersdr/AetherSDR/pull/2123
+[#2403]: https://github.com/aethersdr/AetherSDR/issues/2403
+[#2459]: https://github.com/aethersdr/AetherSDR/pull/2459
+[#2615]: https://github.com/aethersdr/AetherSDR/pull/2615
+[#2633]: https://github.com/aethersdr/AetherSDR/pull/2633
+[#2669]: https://github.com/aethersdr/AetherSDR/pull/2669
+[#2886]: https://github.com/aethersdr/AetherSDR/issues/2886
+[#2899]: https://github.com/aethersdr/AetherSDR/pull/2899
+[#2929]: https://github.com/aethersdr/AetherSDR/issues/2929
+[#2930]: https://github.com/aethersdr/AetherSDR/pull/2930
+[#3193]: https://github.com/aethersdr/AetherSDR/issues/3193
+[#3194]: https://github.com/aethersdr/AetherSDR/pull/3194
+[#3231]: https://github.com/aethersdr/AetherSDR/pull/3231
+[#3230]: https://github.com/aethersdr/AetherSDR/pull/3230
+[#3266]: https://github.com/aethersdr/AetherSDR/issues/3266
+[#3361]: https://github.com/aethersdr/AetherSDR/issues/3361
+[#3378]: https://github.com/aethersdr/AetherSDR/pull/3378
+[#3385]: https://github.com/aethersdr/AetherSDR/issues/3385

--- a/src/core/AudioFormatNegotiator.cpp
+++ b/src/core/AudioFormatNegotiator.cpp
@@ -1,0 +1,232 @@
+#include "core/AudioFormatNegotiator.h"
+
+// PURE policy implementation — no Qt Multimedia, no live device I/O. Everything
+// here is a function of (TargetOs, Direction, DeviceCaps, ResamplerPolicy) so it
+// is exhaustively unit-testable on any CI runner (see
+// tests/audio_format_negotiation_test.cpp). Keep it that way: any call that
+// touches a real QAudioDevice belongs in the live wrapper, not here.
+
+namespace AetherSDR {
+namespace AudioFormatNegotiator {
+
+namespace {
+
+// Per-OS preferred rate order. The first entry is what that OS wants by
+// default; later entries are progressively more conservative. The universal
+// 44.1k rung and the device-preferred rung are appended by buildLadder() so
+// every sink gets the SAME complete fallback set (no more "Quindar has no
+// fallback / RX never tries 44.1k" divergence — #3306, #3385).
+QList<int> primaryRateOrder(TargetOs os, Direction dir, int internalRate)
+{
+    if (dir == Direction::Output) {
+        switch (os) {
+        // Windows: force 48k — WASAPI's shared-mode resampler adds artifacts at
+        // 24k that become audible once radio-side NR removes the noise floor;
+        // r8brain does the clean 24k->48k conversion instead (#2120 / PR #2123).
+        case TargetOs::Windows: return {48000, internalRate};
+        // macOS: prefer 48k so A2DP-capable Bluetooth devices stay on the normal
+        // output profile rather than being routed onto HFP/telephony (#1705).
+        case TargetOs::MacOS:   return {48000, internalRate};
+        // Linux: native 24k is fine (no WASAPI resampler in the path) — avoid an
+        // unnecessary upsample. Deliberate, documented divergence from Win/Mac.
+        case TargetOs::Linux:   return {internalRate, 48000};
+        }
+    } else { // Input (mic / TX capture)
+        switch (os) {
+        // Windows: WASAPI shared mode converts transparently; try 48k first.
+        case TargetOs::Windows: return {48000, 44100, internalRate, 16000};
+        // macOS: preferred-rate-first is enforced in buildLadder (CoreAudio lies
+        // about isFormatSupported(48000) for 16k-native / BT-HFP mics — #2930 /
+        // #2615); the remaining order is the conservative ladder.
+        case TargetOs::MacOS:   return {48000, 44100, internalRate, 16000};
+        // Linux: native 24k first, then the common rates.
+        case TargetOs::Linux:   return {internalRate, 48000, 44100};
+        }
+    }
+    return {internalRate};
+}
+
+// Format attempt order per direction. Output is Float-first (RX/sidetone/Quindar
+// produce float internally; Int16 is the WASAPI Int16-only fallback — #2669).
+// Input is Int16-first (mic native is Int16; Float is the virtual-driver /
+// Float-only-capture fallback — #1090).
+QList<SampleFmt> formatOrder(Direction dir)
+{
+    return dir == Direction::Output
+        ? QList<SampleFmt>{SampleFmt::Float32, SampleFmt::Int16}
+        : QList<SampleFmt>{SampleFmt::Int16, SampleFmt::Float32};
+}
+
+bool ladderHas(const QList<FormatCandidate>& ladder, int rate, SampleFmt fmt)
+{
+    for (const auto& c : ladder) {
+        if (c.rate == rate && c.fmt == fmt) return true;
+    }
+    return false;
+}
+
+} // namespace
+
+ResamplerKind resamplerKindFor(int deviceRate, ResamplerPolicy policy, int internalRate)
+{
+    if (deviceRate == internalRate) return ResamplerKind::None;
+    switch (policy) {
+    case ResamplerPolicy::RegenerateAtRate: return ResamplerKind::None;
+    case ResamplerPolicy::PreservePan:      return ResamplerKind::PreservePan;
+    case ResamplerPolicy::MonoCollapse:     return ResamplerKind::MonoCollapse;
+    }
+    return ResamplerKind::None;
+}
+
+QList<FormatCandidate> buildLadder(TargetOs os,
+                                   Direction dir,
+                                   const DeviceCaps& caps,
+                                   ResamplerPolicy policy,
+                                   int internalRate)
+{
+    QList<FormatCandidate> ladder;
+    const QList<SampleFmt> fmts = formatOrder(dir);
+
+    const auto add = [&](int rate, SampleFmt fmt, const QString& reason) {
+        if (rate <= 0) return;
+        if (ladderHas(ladder, rate, fmt)) return;
+        FormatCandidate c;
+        c.rate = rate;
+        c.fmt = fmt;
+        c.channels = 2;
+        c.resampler = resamplerKindFor(rate, policy, internalRate);
+        c.reason = reason;
+        ladder.append(c);
+    };
+
+    // macOS / preferred-first inputs: the device's own preferred rate leads the
+    // ladder so we never force a 16k-native or BT-HFP mic up to 48k (#2930 /
+    // #2615). preferredFormat is honoured here too.
+    const bool preferredFirst =
+        (dir == Direction::Input && os == TargetOs::MacOS && caps.preferredRate > 0);
+    if (preferredFirst) {
+        add(caps.preferredRate, caps.preferredFormat,
+            caps.isBluetoothHfp ? QStringLiteral("macOS Bluetooth-HFP native rate (#2615)")
+                                : QStringLiteral("macOS mic preferred rate first (#2930)"));
+    }
+
+    // Main per-OS rate order × format order.
+    const QList<int> rates = primaryRateOrder(os, dir, internalRate);
+    for (int rate : rates) {
+        for (SampleFmt fmt : fmts) {
+            QString reason = (rate == rates.first())
+                ? QStringLiteral("%1 preferred %2 Hz").arg(toString(os)).arg(rate)
+                : QStringLiteral("fallback %1 Hz").arg(rate);
+            add(rate, fmt, reason);
+        }
+    }
+
+    // Universal 44.1k rung — historically present only on the mic/CW paths, so a
+    // 44.1k-only device silently failed on RX/Quindar/QSO. Now every sink has it
+    // (#3385 / #3306 regression guard).
+    for (SampleFmt fmt : fmts) {
+        add(44100, fmt, QStringLiteral("universal 44.1 kHz fallback (#3385)"));
+    }
+
+    // Final rung: the device's own preferred format. For awkward backends
+    // (CommonRadioAudio / BlackHole Float32-only, WASAPI Float32-only) this is
+    // the catch-all that always opens (#1090 / #3231).
+    if (caps.preferredRate > 0) {
+        add(caps.preferredRate, caps.preferredFormat,
+            QStringLiteral("device preferredFormat catch-all (#3231)"));
+    }
+
+    return ladder;
+}
+
+NegotiatedFormat negotiate(TargetOs os,
+                           Direction dir,
+                           const DeviceCaps& caps,
+                           ResamplerPolicy policy,
+                           int internalRate)
+{
+    const QList<FormatCandidate> ladder = buildLadder(os, dir, caps, policy, internalRate);
+
+    const bool reliable = caps.isFormatSupportedReliable;
+    const bool nothingProbeable = caps.supportedRates.isEmpty();
+
+    const auto rungSupported = [&](const FormatCandidate& c, int index) -> bool {
+        if (!reliable) {
+            // Probe-at-open backends (WASAPI): we cannot trust isFormatSupported.
+            // If we know nothing about the device, optimistically take the first
+            // (preferred) rung and let the device decide the format at open.
+            if (nothingProbeable) return index == 0;
+            return caps.supportedRates.contains(c.rate);
+        }
+        if (!caps.supportedRates.contains(c.rate)) return false;
+        if (!caps.supportedFormats.contains(c.fmt)) return false;
+        // A mono-only device still satisfies a stereo rung — we open at the
+        // device's channel count and downmix (documented mono behaviour).
+        return caps.channels >= 1;
+    };
+
+    for (int i = 0; i < ladder.size(); ++i) {
+        const FormatCandidate& c = ladder.at(i);
+        if (!rungSupported(c, i)) continue;
+        NegotiatedFormat out;
+        out.ok = true;
+        out.rate = c.rate;
+        out.fmt = c.fmt;
+        // Open at the device's channel count when it has fewer than requested
+        // (mono device -> downmix). Probe-at-open backends keep the requested
+        // count since we don't have a trustworthy channel report.
+        out.channels = (reliable && caps.channels < c.channels) ? caps.channels : c.channels;
+        out.resampler = c.resampler;
+        out.fellBack = (i != 0);
+        out.reason = c.reason;
+        return out;
+    }
+
+    NegotiatedFormat out;
+    out.ok = false;
+    out.reason = QStringLiteral("device supports no rung in the negotiation ladder");
+    return out;
+}
+
+TargetOs hostTargetOs()
+{
+#if defined(Q_OS_WIN)
+    return TargetOs::Windows;
+#elif defined(Q_OS_MAC)
+    return TargetOs::MacOS;
+#else
+    return TargetOs::Linux;
+#endif
+}
+
+const char* toString(SampleFmt f)
+{
+    switch (f) {
+    case SampleFmt::Int16:   return "Int16";
+    case SampleFmt::Float32: return "Float32";
+    }
+    return "?";
+}
+
+const char* toString(ResamplerKind k)
+{
+    switch (k) {
+    case ResamplerKind::None:         return "None";
+    case ResamplerKind::PreservePan:  return "PreservePan";
+    case ResamplerKind::MonoCollapse: return "MonoCollapse";
+    }
+    return "?";
+}
+
+const char* toString(TargetOs os)
+{
+    switch (os) {
+    case TargetOs::Windows: return "Windows";
+    case TargetOs::MacOS:   return "macOS";
+    case TargetOs::Linux:   return "Linux";
+    }
+    return "?";
+}
+
+} // namespace AudioFormatNegotiator
+} // namespace AetherSDR

--- a/src/core/AudioFormatNegotiator.h
+++ b/src/core/AudioFormatNegotiator.h
@@ -1,0 +1,154 @@
+#pragma once
+
+// ─── Audio format / sample-rate negotiation policy ───────────────────────────
+//
+// One ladder, one set of per-OS rules — the single home for "what rate and
+// sample format does this device want, and how do I get my 24 kHz canonical
+// audio onto it" (issue #3306).
+//
+// Historically each audio sink/source re-implemented this with its own
+// divergent fallback ladder and per-OS `#ifdef` branches, which is the root of
+// a cluster of platform-specific audio bugs (44.1k-only devices silently
+// failing on some sinks, WASAPI Float32-only devices rejecting Int16, macOS
+// Bluetooth-HFP mics delivering silence, etc.).
+//
+// DESIGN CONSTRAINT (testability): this layer is a PURE function over an
+// *injected* capability snapshot (`DeviceCaps`) with the target OS passed in as
+// a PARAMETER, never an `#ifdef`. That lets a single headless test binary,
+// built once on any CI runner, exercise every OS's ladder against every device
+// shape — the reason the historical bugs escaped CI. The thin live wrapper
+// (see AudioDeviceNegotiator, Qt-Multimedia) is the only platform-specific part.
+//
+// This header deliberately depends on nothing beyond Qt Core (QString/QList) so
+// the policy can be unit-tested by an executable that links only Qt6::Core.
+// QAudioFormat (Qt Multimedia) is intentionally NOT used here; the live wrapper
+// converts SampleFmt <-> QAudioFormat::SampleFormat.
+
+#include <QList>
+#include <QString>
+
+namespace AetherSDR {
+namespace AudioFormatNegotiator {
+
+// Canonical internal rate: the radio VITA-49 narrowband audio rate. Everything
+// resamples to/from this single value (AudioEngine::DEFAULT_SAMPLE_RATE).
+constexpr int kInternalRate = 24000;
+
+// Target OS is data, not an #ifdef, so every runner tests every ladder.
+enum class TargetOs { Windows, MacOS, Linux };
+
+// Output = playback sink (RX speaker, sidetone, monitor, QSO playback, Quindar).
+// Input  = capture source (PC mic / TX).
+enum class Direction { Output, Input };
+
+// Dependency-free mirror of QAudioFormat::SampleFormat (the live wrapper maps
+// these to/from the Qt enum). Only the formats AetherSDR opens are modelled.
+enum class SampleFmt { Int16, Float32 };
+
+// Which resampler strategy converts between the device rate and kInternalRate.
+//   None         — sink regenerates/consumes natively at the device rate
+//                  (CW sidetone, Quindar tone), or rate already == kInternalRate.
+//   PreservePan  — dual independent L/R r8brain instances; keeps VITA-49 per-
+//                  channel pan intact. REQUIRED for RX speaker and QSO playback
+//                  (collapsing to mono here regressed pan: #2403 / PR #2459).
+//   MonoCollapse — Resampler::processStereoToStereo (downmix→resample→duplicate).
+//                  Correct ONLY where the payload is inherently mono: TCI DAX TX,
+//                  RADE modem. MUST NOT be used for RX/QSO.
+// These two stereo strategies are deliberately distinct and must never be
+// unified (the conflation that caused #2403).
+enum class ResamplerKind { None, PreservePan, MonoCollapse };
+
+// How a particular sink/source treats sample rate — drives ResamplerKind.
+enum class ResamplerPolicy {
+    RegenerateAtRate, // generator retunes to the device rate -> always None
+    PreservePan,      // RX speaker / QSO playback -> PreservePan when rate != internal
+    MonoCollapse,     // TCI DAX TX / RADE -> MonoCollapse when rate != internal
+};
+
+// Injected capability snapshot — everything the policy would otherwise read
+// live from a QAudioDevice / PortAudio / the HAL. Pure inputs only.
+struct DeviceCaps {
+    // Rates the device genuinely supports (what isFormatSupported() *should*
+    // report). Empty == nothing probeable (treat like an unreliable backend).
+    QList<int>       supportedRates;
+    // Sample formats the device's shared-mix / hardware accepts. On WASAPI a
+    // Float32-only shared format rejects Int16 regardless of hardware (#3231).
+    QList<SampleFmt> supportedFormats{SampleFmt::Float32, SampleFmt::Int16};
+    int  channels = 2;
+
+    // macOS Bluetooth hands-free/SCO capture route: caps out at 8/16/24k and
+    // must be opened at its native low rate, NOT forced to 48k (#2615).
+    bool isBluetoothHfp = false;
+
+    // False => isFormatSupported() is not trustworthy for this backend, so the
+    // caller must skip the probe and try-at-open instead. True for WASAPI on
+    // Windows (#2120 / #2929 / Voicemeeter / FlexRadio DAX false-negatives).
+    bool isFormatSupportedReliable = true;
+
+    // Device's own preferred format (QAudioDevice::preferredFormat) — the final
+    // ladder rung for awkward devices (#1090 / #3231). 0 == unknown.
+    int       preferredRate = 0;
+    SampleFmt preferredFormat = SampleFmt::Float32;
+};
+
+// One rung of the fallback ladder: a concrete format to attempt, in order.
+struct FormatCandidate {
+    int           rate = kInternalRate;
+    SampleFmt     fmt = SampleFmt::Float32;
+    int           channels = 2;
+    ResamplerKind resampler = ResamplerKind::None;
+    QString       reason;   // human-readable rung label for diagnostics/logs
+};
+
+// The negotiated outcome (the rung that won), plus context.
+struct NegotiatedFormat {
+    bool          ok = false;
+    int           rate = kInternalRate;
+    SampleFmt     fmt = SampleFmt::Float32;
+    int           channels = 2;
+    ResamplerKind resampler = ResamplerKind::None;
+    bool          fellBack = false;       // true if not the first/preferred rung
+    QString       reason;                 // why this rung was chosen
+};
+
+// Build the ordered fallback ladder for a direction. The first rung is the
+// per-OS preferred format; later rungs are progressively more conservative,
+// always ending with the universal rungs (44.1k + device preferredFormat) so
+// no sink is left with "no fallback" the way Quindar historically was.
+//
+// `policy` selects PreservePan vs MonoCollapse vs RegenerateAtRate for the
+// resampler kind attached to each non-internal-rate rung.
+QList<FormatCandidate> buildLadder(TargetOs os,
+                                   Direction dir,
+                                   const DeviceCaps& caps,
+                                   ResamplerPolicy policy,
+                                   int internalRate = kInternalRate);
+
+// Resolve the ladder against the device's actual capabilities — the PURE
+// equivalent of walking the ladder and opening the device. When
+// caps.isFormatSupportedReliable is true a rung "succeeds" iff its (rate,fmt,
+// channels) is supported; when false (probe-at-open backends) a rung succeeds
+// iff its rate is in supportedRates (format is decided by the device at open).
+// Returns ok=false only if the device truly supports nothing in the ladder.
+NegotiatedFormat negotiate(TargetOs os,
+                           Direction dir,
+                           const DeviceCaps& caps,
+                           ResamplerPolicy policy,
+                           int internalRate = kInternalRate);
+
+// The resampler kind for a concrete (deviceRate, policy) pair, independent of
+// the ladder — used by sinks that already know their negotiated rate.
+ResamplerKind resamplerKindFor(int deviceRate,
+                               ResamplerPolicy policy,
+                               int internalRate = kInternalRate);
+
+// The host OS as a TargetOs (the ONE place the real #ifdef lives). The live
+// wrapper passes this; tests pass an explicit value.
+TargetOs hostTargetOs();
+
+const char* toString(SampleFmt f);
+const char* toString(ResamplerKind k);
+const char* toString(TargetOs os);
+
+} // namespace AudioFormatNegotiator
+} // namespace AetherSDR

--- a/tests/audio_format_negotiation_test.cpp
+++ b/tests/audio_format_negotiation_test.cpp
@@ -1,0 +1,209 @@
+// Golden matrix for the consolidated audio format/rate negotiation policy
+// (issue #3306). The whole point of consolidation is that the negotiation
+// POLICY becomes testable in one headless place, so the entire class of
+// "44.1k device silently fails on sink X / OS Y" bugs is caught on CI rather
+// than in the field.
+//
+// Because TargetOs is DATA (not an #ifdef), every cell below runs on every CI
+// runner: a Linux runner proves the Windows and macOS ladders too.
+//
+// Run: ./build/audio_format_negotiation_test
+
+#include "core/AudioFormatNegotiator.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace AetherSDR::AudioFormatNegotiator;
+
+namespace {
+
+int g_failed = 0;
+int g_total = 0;
+
+void report(const std::string& name, bool ok, const std::string& detail = {})
+{
+    ++g_total;
+    std::printf("%s %-70s %s\n", ok ? "[ OK ]" : "[FAIL]", name.c_str(), detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+std::string fmtOf(const NegotiatedFormat& n)
+{
+    char buf[160];
+    std::snprintf(buf, sizeof(buf), "ok=%d rate=%d fmt=%s ch=%d resampler=%s fellBack=%d",
+                  n.ok ? 1 : 0, n.rate, toString(n.fmt), n.channels,
+                  toString(n.resampler), n.fellBack ? 1 : 0);
+    return buf;
+}
+
+// One golden row: negotiate(os,dir,caps,policy) must equal the expected fields.
+struct Row {
+    std::string name;
+    TargetOs    os;
+    Direction   dir;
+    ResamplerPolicy policy;
+    DeviceCaps  caps;
+    // expected
+    bool          ok;
+    int           rate;
+    SampleFmt     fmt;
+    ResamplerKind resampler;
+    int           channels;
+    bool          fellBack;
+};
+
+void runRow(const Row& r)
+{
+    const NegotiatedFormat n = negotiate(r.os, r.dir, r.caps, r.policy);
+    const bool ok = n.ok == r.ok
+                 && (!r.ok || (n.rate == r.rate && n.fmt == r.fmt
+                               && n.resampler == r.resampler && n.channels == r.channels
+                               && n.fellBack == r.fellBack));
+    std::string detail = "got [" + fmtOf(n) + "]";
+    report(r.name, ok, ok ? std::string() : detail);
+}
+
+// Helpers to build common device shapes.
+DeviceCaps dev(QList<int> rates,
+               QList<SampleFmt> fmts = {SampleFmt::Float32, SampleFmt::Int16},
+               int channels = 2)
+{
+    DeviceCaps c;
+    c.supportedRates = std::move(rates);
+    c.supportedFormats = std::move(fmts);
+    c.channels = channels;
+    if (!c.supportedRates.isEmpty()) {
+        c.preferredRate = c.supportedRates.first();
+        c.preferredFormat = c.supportedFormats.contains(SampleFmt::Float32)
+                                ? SampleFmt::Float32 : SampleFmt::Int16;
+    }
+    return c;
+}
+
+} // namespace
+
+int main()
+{
+    const auto F = SampleFmt::Float32;
+    const auto I = SampleFmt::Int16;
+    const auto Pan = ResamplerPolicy::PreservePan;
+    const auto Mono = ResamplerPolicy::MonoCollapse;
+    const auto Regen = ResamplerPolicy::RegenerateAtRate;
+    const auto Out = Direction::Output;
+    const auto In = Direction::Input;
+    const auto Win = TargetOs::Windows;
+    const auto Mac = TargetOs::MacOS;
+    const auto Lin = TargetOs::Linux;
+
+    // ── Standard 48k-only DAC, RX speaker (PreservePan) ───────────────────────
+    runRow({"std 48k DAC / Win / RX",  Win, Out, Pan, dev({48000}),
+            true, 48000, F, ResamplerKind::PreservePan, 2, false});
+    runRow({"std 48k DAC / Mac / RX",  Mac, Out, Pan, dev({48000}),
+            true, 48000, F, ResamplerKind::PreservePan, 2, false});
+    // Linux prefers 24k first; 48k-only device -> falls back to 48k (fellBack).
+    runRow({"std 48k DAC / Linux / RX", Lin, Out, Pan, dev({48000}),
+            true, 48000, F, ResamplerKind::PreservePan, 2, true});
+
+    // ── 24k-capable device: documents the INTENDED per-OS divergence ──────────
+    runRow({"24k+48k dev / Win / RX -> forces 48k (#2120)", Win, Out, Pan, dev({24000, 48000}),
+            true, 48000, F, ResamplerKind::PreservePan, 2, false});
+    runRow({"24k+48k dev / Mac / RX -> 48k (A2DP #1705)",   Mac, Out, Pan, dev({24000, 48000}),
+            true, 48000, F, ResamplerKind::PreservePan, 2, false});
+    runRow({"24k+48k dev / Linux / RX -> native 24k (no resample)", Lin, Out, Pan, dev({24000, 48000}),
+            true, 24000, F, ResamplerKind::None, 2, false});
+
+    // ── 44.1k-ONLY device: the regression guard. Today RX/Quindar FAIL this;
+    //    the unified ladder must succeed on every OS (#3385 / #3306). ──────────
+    runRow({"44.1k-only / Win / RX",   Win, Out, Pan, dev({44100}),
+            true, 44100, F, ResamplerKind::PreservePan, 2, true});
+    runRow({"44.1k-only / Mac / RX",   Mac, Out, Pan, dev({44100}),
+            true, 44100, F, ResamplerKind::PreservePan, 2, true});
+    runRow({"44.1k-only / Linux / RX", Lin, Out, Pan, dev({44100}),
+            true, 44100, F, ResamplerKind::PreservePan, 2, true});
+
+    // ── WASAPI Int16-only device: must skip the Float rungs (#2669). The
+    //    skipped 48k Float rung counts as a fall-back (fellBack=true). ────────
+    runRow({"Int16-only WASAPI / Win / RX", Win, Out, Pan, dev({48000}, {I}),
+            true, 48000, I, ResamplerKind::PreservePan, 2, true});
+
+    // ── WASAPI false-negative isFormatSupported: nothing probeable, probe at
+    //    open -> take the preferred 48k rung (#2120 / #3231) ──────────────────
+    {
+        DeviceCaps c;                       // supportedRates empty
+        c.isFormatSupportedReliable = false;
+        runRow({"WASAPI false-negative / Win / RX -> force 48k probe-at-open",
+                Win, Out, Pan, c,
+                true, 48000, F, ResamplerKind::PreservePan, 2, false});
+    }
+
+    // ── CW sidetone (RegenerateAtRate): no resampler, generator retunes ───────
+    runRow({"sidetone 48k dev / Mac -> regenerate, no resampler", Mac, Out, Regen, dev({48000}),
+            true, 48000, F, ResamplerKind::None, 2, false});
+    runRow({"sidetone 24k-cap / Linux -> 24k, no resampler", Lin, Out, Regen, dev({24000, 48000}),
+            true, 24000, F, ResamplerKind::None, 2, false});
+
+    // ── macOS Bluetooth-HFP mic: native low rate first, NOT forced to 48k
+    //    (#2615). preferred-first puts 16k ahead of the 48k ladder. ───────────
+    {
+        DeviceCaps c = dev({8000, 16000, 24000}, {I});
+        c.isBluetoothHfp = true;
+        c.preferredRate = 16000;
+        c.preferredFormat = I;
+        // preferred-first means the native rate is the PRIMARY choice, not a
+        // fallback -> fellBack=false.
+        runRow({"BT-HFP mic / Mac / TX -> native 16k (#2615)", Mac, In, Pan, c,
+                true, 16000, I, ResamplerKind::PreservePan, 2, false});
+    }
+
+    // ── macOS 16k-native mic that lies about 48k support (#2930): preferred
+    //    rate first avoids the silent-48k-open trap. ──────────────────────────
+    {
+        DeviceCaps c = dev({16000, 48000}, {I});
+        c.preferredRate = 16000;
+        c.preferredFormat = I;
+        runRow({"16k-native mic / Mac / TX -> preferred 16k first (#2930)", Mac, In, Pan, c,
+                true, 16000, I, ResamplerKind::PreservePan, 2, false});
+    }
+
+    // ── Linux mic standard: native 24k, no resample ──────────────────────────
+    runRow({"std mic / Linux / TX -> 24k native", Lin, In, Pan, dev({24000, 48000}, {I}),
+            true, 24000, I, ResamplerKind::None, 2, false});
+
+    // ── Windows mic: probe-at-open, 48k first (#2929) ─────────────────────────
+    {
+        DeviceCaps c;
+        c.isFormatSupportedReliable = false;
+        runRow({"std mic / Win / TX -> force 48k probe-at-open", Win, In, Pan, c,
+                true, 48000, I, ResamplerKind::PreservePan, 2, false});
+    }
+
+    // ── Mono-only output device: open at device channel count, downmix ────────
+    runRow({"mono-only 48k / Win / RX -> ch=1 downmix", Win, Out, Pan, dev({48000}, {F, I}, 1),
+            true, 48000, F, ResamplerKind::PreservePan, 1, false});
+
+    // ── TCI DAX TX / RADE use MonoCollapse, never PreservePan ─────────────────
+    runRow({"TCI-TX 48k client / Linux -> MonoCollapse to 24k", Lin, Out, Mono, dev({48000}),
+            true, 48000, F, ResamplerKind::MonoCollapse, 2, true});
+    // TCI client negotiates 24k then transmits: rate already internal -> None
+    // (NOT a hardcoded 48000->24000 mis-resample; the TciServer.cpp:1296 bug).
+    runRow({"TCI-TX 24k client / Linux -> no resample", Lin, Out, Mono, dev({24000, 48000}),
+            true, 24000, F, ResamplerKind::None, 2, false});
+
+    // ── Total failure: device supports nothing usable ────────────────────────
+    runRow({"empty reliable device -> negotiation fails", Lin, Out, Pan, dev({}, {F, I}),
+            false, 0, F, ResamplerKind::None, 0, false});
+
+    // ── resamplerKindFor unit checks (the two stereo strategies stay distinct).
+    report("resamplerKindFor 24k Pan == None",
+           resamplerKindFor(24000, Pan) == ResamplerKind::None);
+    report("resamplerKindFor 48k Pan == PreservePan",
+           resamplerKindFor(48000, Pan) == ResamplerKind::PreservePan);
+    report("resamplerKindFor 48k Mono == MonoCollapse",
+           resamplerKindFor(48000, Mono) == ResamplerKind::MonoCollapse);
+    report("resamplerKindFor 8k Regen == None",
+           resamplerKindFor(8000, Regen) == ResamplerKind::None);
+
+    std::printf("\n%d/%d checks passed\n", g_total - g_failed, g_total);
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## What

First, **pure-addition** step of the consolidated audio sink factory (#3306): a single shared, OS-parameterized format/rate **negotiation policy** that every audio sink and source will migrate onto, replacing the ~9 divergent per-sink fallback ladders and per-OS `#ifdef` branches that are the root of a recurring class of platform audio bugs.

Zero behaviour change — this is the maintainer-endorsed *"land the helper first, migrate sinks incrementally"* approach (#3306, and the #3194 thread's "sensitive audio-stack changes must be separate PRs with soak time").

## Why this shape

The historical bugs escaped CI because the per-OS rate ladders were compiled behind `Q_OS_*`, so a Linux runner could only ever exercise the Linux path. The new policy is a **pure function over an injected `DeviceCaps` snapshot with `TargetOs` as a parameter, not an `#ifdef`** — so one headless, hardware-free test binary exercises the Windows, macOS *and* Linux ladders on any runner.

## Contents

- **`src/core/AudioFormatNegotiator.{h,cpp}`** — dependency-free policy (links only `Qt6::Core`). One ladder owns:
  - Windows force-48k + r8brain (#2120/#2123), macOS 48k/A2DP (#1705), Linux native-24k — divergences preserved as **data**, not `#ifdef`.
  - The **universal 44.1 kHz rung** that RX/Quindar/QSO are missing today (#3385).
  - `Int16`↔`Float32` + `preferredFormat()` catch-all (#2669 / #1090 / #3231).
  - macOS mic preferred-rate-first (#2930) and Bluetooth-HFP native rate (#2615); Windows probe-at-open (#2929).
  - The two stereo resampler strategies — **PreservePan** (RX/QSO) vs **MonoCollapse** (TCI-TX/RADE) — kept deliberately distinct (#2403/#2459).
- **`tests/audio_format_negotiation_test.cpp`** — table-driven golden matrix, registered under CTest. **25/25 pass**, including the 44.1k-only-device regression guard.
- **`docs/audio-sink-factory.md`** — the full three-layer design (pure policy → live Qt wrapper → device-ownership router), the device-following **"uncoupling"** fix (CW / RADE / Aetherial-Audio "Pudu" recorder following the selected output), the regression-guard invariants, and the one-sink-per-PR migration plan.

## Test

```
$ ./build/audio_format_negotiation_test
...
25/25 checks passed
```

## Follow-ups (per the migration plan in the doc)

Live Qt wrapper → migrate RX speaker → migrate PC mic → `AudioOutputRouter` (closes the uncoupling class) → TCI-TX client-rate → PipeWire DAX shared resampler. Each a separate, soakable PR.

Refs #3306

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat