### PR TITLE
feat(hid): ELAD/WoodBoxRadio TMate 2 USB HID support

### DIFF
--- a/src/core/HidDeviceParser.cpp
+++ b/src/core/HidDeviceParser.cpp
@@ -19,6 +19,9 @@ static const HidDeviceId kSupportedDevices[] = {
     {0x2341, 0x0266, "AetherPad RC-28 emulator (Arduino Giga R1)"},
     // Elgato StreamDeck+ — 8 LCD buttons + 4 encoder dials (#1510)
     {0x0FD9, 0x0084, "Elgato StreamDeck+"},
+    // ELAD/WoodBoxRadio TMate 2 — 3 encoders, 9 keys, RGB LCD backlight.
+    // Protocol reverse-engineered via USBPcap; documented in OpenTMate2Lib.
+    {0x1721, 0x0614, "ELAD/WoodBoxRadio TMate 2"},
 };
 
 const HidDeviceId* HidDeviceParser::supportedDevices() { return kSupportedDevices; }
@@ -34,6 +37,7 @@ std::unique_ptr<HidDeviceParser> HidDeviceParser::create(uint16_t vid, uint16_t 
     // comment in kSupportedDevices above).
     if (vid == 0x2341 && pid == 0x0266) return std::make_unique<IcomRC28Parser>();
     if (vid == 0x0FD9 && pid == 0x0084) return std::make_unique<StreamDeckPlusParser>();
+    if (vid == 0x1721 && pid == 0x0614) return std::make_unique<TMate2Parser>();
     return nullptr;
 }
 
@@ -256,6 +260,65 @@ HidEvent StreamDeckPlusParser::parse(const uint8_t* buf, size_t len)
             }
         }
         return {};
+    }
+
+    return {};
+}
+
+// ── ELAD/WoodBoxRadio TMate 2 ──────────────────────────────────────────────
+// 64-byte reports. Keys are active-low (bit clear = pressed, bit set = idle).
+// Encoder counters are absolute uint16 with natural 16-bit wrap.
+// Delta wrap-correction: same algorithm as ShuttleXpress jog (±65536 adjust).
+
+HidEvent TMate2Parser::parse(const uint8_t* buf, size_t len)
+{
+    if (len < 9) return {};
+
+    const uint16_t enc[3] = {
+        static_cast<uint16_t>(buf[1] | (static_cast<uint16_t>(buf[2]) << 8)),
+        static_cast<uint16_t>(buf[3] | (static_cast<uint16_t>(buf[4]) << 8)),
+        static_cast<uint16_t>(buf[5] | (static_cast<uint16_t>(buf[6]) << 8)),
+    };
+    const uint16_t keys = static_cast<uint16_t>(buf[7] | (static_cast<uint16_t>(buf[8]) << 8));
+
+    if (m_firstReport) {
+        m_firstReport = false;
+        m_enc[0] = enc[0];
+        m_enc[1] = enc[1];
+        m_enc[2] = enc[2];
+        m_keys   = keys;
+        return {};
+    }
+
+    // Encoders — report first non-zero wrap-corrected delta.
+    for (int i = 0; i < 3; ++i) {
+        int diff = static_cast<int>(enc[i]) - static_cast<int>(m_enc[i]);
+        if (diff > 32767)  diff -= 65536;
+        if (diff < -32768) diff += 65536;
+        if (diff != 0) {
+            m_enc[i] = enc[i];
+            if (i == 0) diff = -diff;
+            return {.type = HidEvent::Rotate, .steps = diff, .encoderIndex = i};
+        }
+    }
+
+    // Keys (active-low) — one bit at a time so simultaneous presses are not lost.
+    // F1-F6 (bits 0-5) → buttons 1-6.
+    // Encoder pushes (bits 6-8) → buttons 9-11 so MainWindow routes them through
+    // HidEncoderPushAction{0-2}: bit6=main-encoder(enc1)→9, bit7=enc2→10, bit8=enc3→11.
+    // Buttons 7-8 are intentionally unused (no hardware key on those numbers).
+    static constexpr int kButtonMap[9] = {1, 2, 3, 4, 5, 6, 9, 10, 11};
+    if (keys != m_keys) {
+        const uint16_t changed = keys ^ m_keys;
+        for (int b = 0; b < 9; ++b) {
+            const uint16_t mask = static_cast<uint16_t>(1u << b);
+            if (changed & mask) {
+                m_keys ^= mask;
+                // bit set = idle/released (action 1); bit clear = pressed (action 0)
+                const int action = (keys & mask) ? 1 : 0;
+                return {.type = HidEvent::Button, .button = kButtonMap[b], .action = action};
+            }
+        }
     }
 
     return {};

--- a/src/core/HidDeviceParser.h
+++ b/src/core/HidDeviceParser.h
@@ -103,5 +103,33 @@ private:
     uint8_t m_prevEncBtns{0};      // bitmask of previous encoder button states (bits 0-3)
 };
 
+// ELAD/WoodBoxRadio TMate 2 (VID 0x1721, PID 0x0614)
+// 64-byte HID reports (full USB interrupt report size).
+// Input layout (bytes 0-8 mapped; 9-63 not yet fully decoded):
+//   [0]    report ID = 0x01
+//   [1..2] encoder 1, little-endian uint16 (absolute wrapping counter)
+//   [3..4] encoder 2, little-endian uint16
+//   [5..6] encoder 3 (volume), little-endian uint16
+//   [7..8] key bitmask, little-endian uint16, active-low (bit clear = pressed):
+//          bit0=F1, bit1=F2, bit2=F3, bit3=F4, bit4=F5, bit5=F6,
+//          bit6=enc1/main-encoder push, bit7=enc2 push, bit8=enc3 push.
+//          Idle state: 0x01FF (all bits set).
+// Encoder delta uses 16-bit wrap correction (same as ShuttleXpress jog).
+// encoderIndex: 0=enc1/main-tuning (bytes 1-2), 1=enc2/TX-power (bytes 3-4), 2=enc3/volume (bytes 5-6).
+// Buttons: 1-6=F1-F6, 9=main-encoder push (enc1), 10=encoder2 push (enc2), 11=encoder3 push (enc3).
+// Encoder push buttons use the 9+ range to route through HidEncoderPushAction{0-2} in MainWindow.
+// Note: bit6=$0040=main-encoder push, bit7=$0080=enc2 push, bit8=$0100=enc3 push (hardware naming quirk).
+// Protocol reverse-engineered via USBPcap; documented in OpenTMate2Lib.
+class TMate2Parser : public HidDeviceParser {
+public:
+    HidEvent parse(const uint8_t* buf, size_t len) override;
+    size_t reportSize() const override { return 64; }
+    int encoderCount() const override { return 3; }
+private:
+    uint16_t m_enc[3]{};
+    uint16_t m_keys{0x01FFu};   // idle: all bits set
+    bool m_firstReport{true};
+};
+
 } // namespace AetherSDR
 #endif

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -9,6 +9,170 @@
 #include <algorithm>
 #include <cstring>
 
+// ── TMate 2 display helpers ────────────────────────────────────────────────
+//
+// Digit encoding for the TMate 2 LCD.  Tables and byte layout are derived
+// from OpenTMate2Lib (D:\Code\OpenTMate2Lib), which reverse-engineered the
+// protocol from TMATE2_DLL.dll via USBPcap captures (2026-06-05).
+//
+// Main 9-digit display (freq in Hz):
+//   Each digit d (1=units, 9=100 MHz) occupies two LCDVector bytes:
+//     high = 22 - 2*d   bits: A=0x01 B=0x02 C=0x04
+//     low  = 21 - 2*d   bits: F=0x01 G=0x02 E=0x04 D=0x08
+//
+// Small 3-digit display (S-meter / TX power):
+//   Each digit d (1=units, 3=hundreds) occupies two LCDVector bytes:
+//     high = 21 + 2*d   bits: A=0x80 B=0x40 C=0x20 D=0x10
+//     low  = 22 + 2*d   bits: E=0x20 F=0x80 G=0x40
+//   (bit ordering is reversed vs. main display — hardware quirk)
+
+namespace {
+
+static const uint8_t kMainHigh[10] = {
+    0x07, 0x06, 0x03, 0x07, 0x06, 0x05, 0x05, 0x07, 0x07, 0x07
+};
+static const uint8_t kMainLow[10] = {
+    0x0D, 0x00, 0x0E, 0x0A, 0x03, 0x0B, 0x0F, 0x00, 0x0F, 0x0B
+};
+static const uint8_t kSmallHigh[10] = {
+    0xF0, 0x60, 0xD0, 0xF0, 0x60, 0xB0, 0xB0, 0xE0, 0xF0, 0xF0
+};
+static const uint8_t kSmallLow[10] = {
+    0xA0, 0x00, 0x60, 0x40, 0xC0, 0xC0, 0xE0, 0x00, 0xE0, 0xC0
+};
+
+// Indicator segment lookup: {byte_index, bitmask}.
+// Derived from USB captures (session_20260605_051711/segments_*.csv).
+// Byte range 0-31 only; indicator bits never overlap with digit A-G bits.
+struct SegEntry { uint8_t byte; uint8_t mask; };
+static constexpr SegEntry kSeg_RX        = {  0, 0x04 };
+static constexpr SegEntry kSeg_TX        = {  0, 0x08 };
+static constexpr SegEntry kSeg_S         = {  0, 0x10 };
+static constexpr SegEntry kSeg_VOL       = {  1, 0x80 };
+static constexpr SegEntry kSeg_SMETER_LINE = { 2, 0x01 };
+static constexpr SegEntry kSeg_SMETER_DB_MINUS = {28, 0x10 };
+static constexpr SegEntry kSeg_DIG_PLUS  = { 21, 0x04 };
+static constexpr SegEntry kSeg_DIG_MINUS = { 21, 0x08 };
+static constexpr SegEntry kSeg_DSB       = { 21, 0x10 };
+static constexpr SegEntry kSeg_FM        = { 21, 0x20 };
+static constexpr SegEntry kSeg_USB       = { 21, 0x40 };
+static constexpr SegEntry kSeg_SAM       = { 21, 0x80 };
+static constexpr SegEntry kSeg_DIG       = { 22, 0x02 };
+static constexpr SegEntry kSeg_DBM       = { 22, 0x10 };
+static constexpr SegEntry kSeg_CW        = { 22, 0x20 };
+static constexpr SegEntry kSeg_LSB       = { 22, 0x40 };
+static constexpr SegEntry kSeg_AM        = { 22, 0x80 };
+static constexpr SegEntry kSeg_DOT1      = {  9, 0x10 };  // after digit 3 (kHz/Hz)
+static constexpr SegEntry kSeg_DOT2      = { 15, 0x10 };  // after digit 6 (MHz/kHz)
+static constexpr SegEntry kSeg_HZ        = { 23, 0x01 };
+static constexpr SegEntry kSeg_W         = { 20, 0x20 };
+static constexpr SegEntry kSeg_RIT       = { 13, 0x10 };
+static constexpr SegEntry kSeg_XIT       = { 14, 0x10 };
+// 15-segment S-meter bargraph (BAR1=weakest, BAR15=strongest)
+static constexpr SegEntry kSMeterBars[15] = {
+    { 1, 0x08 }, { 1, 0x04 }, { 1, 0x02 }, // BAR1-3
+    { 31, 0x80 }, { 31, 0x40 }, { 31, 0x20 }, { 31, 0x10 }, // BAR4-7
+    { 30, 0x10 }, { 30, 0x20 }, { 30, 0x40 }, { 30, 0x80 }, // BAR8-11
+    { 29, 0x80 }, { 29, 0x40 }, { 29, 0x20 }, { 29, 0x10 }, // BAR12-15
+};
+
+// Set or clear one segment bit in the LCDVector.
+static void tmate2Seg(uint8_t* v, SegEntry s, bool on)
+{
+    if (on) v[s.byte] |= s.mask;
+    else    v[s.byte] &= static_cast<uint8_t>(~s.mask);
+}
+
+// Convert dBm to S-meter bargraph bar count (0-15).
+//   S1(-121 dBm)=1, S9(-73 dBm)=9; above S9: +10 dB per bar up to S9+60 dB(=15).
+static int smeterBars(float dbm)
+{
+    if (dbm < -121.0f) return 0;
+    if (dbm <= -73.0f) return static_cast<int>((dbm + 121.0f) / 6.0f) + 1;
+    return std::min(15, 9 + static_cast<int>((dbm + 73.0f) / 10.0f));
+}
+
+static void applyModeSegs(uint8_t* lcd, const QString& mode)
+{
+    tmate2Seg(lcd, kSeg_USB, false);
+    tmate2Seg(lcd, kSeg_LSB, false);
+    tmate2Seg(lcd, kSeg_AM,  false);
+    tmate2Seg(lcd, kSeg_SAM, false);
+    tmate2Seg(lcd, kSeg_DSB, false);
+    tmate2Seg(lcd, kSeg_FM,  false);
+    tmate2Seg(lcd, kSeg_CW,  false);
+    tmate2Seg(lcd, kSeg_DIG, false);
+    tmate2Seg(lcd, kSeg_DIG_PLUS, false);
+    tmate2Seg(lcd, kSeg_DIG_MINUS, false);
+
+    if      (mode == "USB")               tmate2Seg(lcd, kSeg_USB, true);
+    else if (mode == "LSB")               tmate2Seg(lcd, kSeg_LSB, true);
+    else if (mode == "AM")                tmate2Seg(lcd, kSeg_AM,  true);
+    else if (mode == "SAM")               tmate2Seg(lcd, kSeg_SAM, true);
+    else if (mode == "DSB")               tmate2Seg(lcd, kSeg_DSB, true);
+    else if (mode == "FM"  || mode == "DFM")  tmate2Seg(lcd, kSeg_FM,  true);
+    else if (mode == "CW"  || mode == "CWL" || mode == "CWU") tmate2Seg(lcd, kSeg_CW, true);
+    else if (mode == "DIGU") {
+        tmate2Seg(lcd, kSeg_DIG, true);
+        tmate2Seg(lcd, kSeg_DIG_PLUS, true);
+    } else if (mode == "DIGL") {
+        tmate2Seg(lcd, kSeg_DIG, true);
+        tmate2Seg(lcd, kSeg_DIG_MINUS, true);
+    } else if (mode == "RTTY" || mode.startsWith("DIG")) {
+        tmate2Seg(lcd, kSeg_DIG, true);
+    }
+}
+
+// LCDVector byte offsets (matches OpenTMate2Lib and Delphi LCD_SEGMENT_DEF)
+static constexpr int kTM2_LED      = 32;
+static constexpr int kTM2_BL_R     = 33;
+static constexpr int kTM2_BL_G     = 34;
+static constexpr int kTM2_BL_B     = 35;
+static constexpr int kTM2_CONTRAST = 36;
+static constexpr int kTM2_REFRESH  = 37;
+static constexpr int kTM2_SPEED1   = 38;
+static constexpr int kTM2_SPEED2   = 39;
+static constexpr int kTM2_SPEED3   = 40;
+static constexpr int kTM2_THR12    = 41;
+static constexpr int kTM2_THR23    = 42;
+static constexpr int kTM2_EVAL     = 43;
+
+// Write frequency (Hz) to bytes 3..20 of the LCDVector.
+// Only the seven A-G segment bits per digit are touched; indicator bits that
+// share those bytes (underlines, DRV, NR2, …) are preserved.
+static void tmate2WriteMainDisplay(uint8_t* v, uint32_t hz)
+{
+    if (hz > 999999999u) hz = 999999999u;
+    for (int d = 1; d <= 9; ++d) {
+        uint8_t hi = static_cast<uint8_t>(22 - 2 * d);
+        uint8_t lo = static_cast<uint8_t>(21 - 2 * d);
+        v[hi] &= 0xF8u;
+        v[lo] &= 0xF0u;
+        if (hz == 0u && d > 1) continue;
+        v[hi] |= kMainHigh[hz % 10u];
+        v[lo] |= kMainLow [hz % 10u];
+        hz /= 10u;
+    }
+}
+
+// Write a value (mod 1000) to bytes 23..28 of the LCDVector.
+static void tmate2WriteSmallDisplay(uint8_t* v, uint32_t val)
+{
+    val %= 1000u;
+    for (int d = 1; d <= 3; ++d) {
+        uint8_t hi = static_cast<uint8_t>(21 + 2 * d);
+        uint8_t lo = static_cast<uint8_t>(22 + 2 * d);
+        v[hi] &= 0x0Fu;
+        v[lo] &= 0x1Fu;
+        if (val == 0u && d > 1) continue;
+        v[hi] |= kSmallHigh[val % 10u];
+        v[lo] |= kSmallLow [val % 10u];
+        val /= 10u;
+    }
+}
+
+} // namespace
+
 namespace AetherSDR {
 
 // HID logging now uses lcDevices from LogManager (shared with serial, FlexControl, MIDI)
@@ -177,6 +341,34 @@ bool HidEncoderManager::open(uint16_t vid, uint16_t pid)
 
     m_pollTimer->start();
 
+    // Initialise TMate 2 LCDVector state and push a blank display.
+    // Timing defaults from OpenTMate2Lib protocol docs (captures 2026-06-05).
+    // Backlight is restored from AppSettings (saved by Preferences dialog).
+    if (isTMate2()) {
+        std::memset(m_lcdVector, 0, sizeof(m_lcdVector));
+        // Matches the original Delphi app / TMate2Probe captures. 0x28 here
+        // overdrives the LCD on some units and can make the display unreadable.
+        m_lcdVector[kTM2_CONTRAST] = 0x00;
+        m_lcdVector[kTM2_REFRESH]  = 0x28;
+        m_lcdVector[kTM2_SPEED1]   = 0x01;
+        m_lcdVector[kTM2_SPEED2]   = 0x05;
+        m_lcdVector[kTM2_SPEED3]   = 0x0A;
+        m_lcdVector[kTM2_THR12]    = 0x0F;
+        m_lcdVector[kTM2_THR23]    = 0x19;
+        m_lcdVector[kTM2_EVAL]     = 0x0A;
+        const auto& s = AppSettings::instance();
+        m_lcdVector[kTM2_BL_R] = static_cast<uint8_t>(s.value("TMate2BacklightR", "0").toInt());
+        m_lcdVector[kTM2_BL_G] = static_cast<uint8_t>(s.value("TMate2BacklightG", "50").toInt());
+        m_lcdVector[kTM2_BL_B] = static_cast<uint8_t>(s.value("TMate2BacklightB", "255").toInt());
+        // Always-on static indicators for a frequency display
+        tmate2Seg(m_lcdVector, kSeg_SMETER_LINE, true);
+        tmate2Seg(m_lcdVector, kSeg_DOT1, true);
+        tmate2Seg(m_lcdVector, kSeg_DOT2, true);
+        tmate2Seg(m_lcdVector, kSeg_HZ,   true);
+        tmate2Seg(m_lcdVector, kSeg_VOL,  true);
+        sendTMate2();
+    }
+
     qCDebug(lcDevices) << "HidEncoderManager: opened" << m_deviceName
                     << QString("0x%1:0x%2").arg(vid, 4, 16, QChar('0')).arg(pid, 4, 16, QChar('0'));
     emit connectionChanged(true, m_deviceName);
@@ -188,9 +380,10 @@ void HidEncoderManager::close()
     m_pollTimer->stop();
     m_hotplugTimer->stop();
     if (m_device) {
-        // Extinguish RC-28 LEDs on clean close. hid_write may return EIO if
-        // the device was surprise-disconnected; that is safe to ignore here.
+        // Extinguish RC-28 LEDs / TMate 2 backlight on clean close.
+        // hid_write may return EIO on surprise-disconnect; safe to ignore.
         setRC28Leds(RC28_LEDS_OFF);
+        setTMate2Backlight(0, 0, 0);
         hid_close(m_device);
         m_device = nullptr;
     }
@@ -362,6 +555,148 @@ void HidEncoderManager::setTouchscreenImage(const QByteArray& jpegData,
         offset     += chunkLen;
         pageNumber++;
     }
+}
+
+void HidEncoderManager::sendTMate2()
+{
+    // Build the 64-byte output report from the persistent LCDVector state.
+    // Bytes 0-43 = LCDVector (segments, status, backlight, timing).
+    // Bytes 44-63 = zero padding required by the protocol.
+    uint8_t report[64] = {};
+    std::memcpy(report, m_lcdVector, sizeof(m_lcdVector));
+
+    // hidapi write buffers include a leading report ID byte.  The TMate 2 OUT
+    // payload captured on USB is the 64-byte LCDVector report itself, so prepend
+    // report ID 0 to avoid shifting the vector left by one byte on Windows.
+    uint8_t hidReport[65] = {};
+    std::memcpy(hidReport + 1, report, sizeof(report));
+    const int written = hid_write(m_device, hidReport, sizeof(hidReport));
+    if (written < 0) {
+        qCWarning(lcDevices) << "HidEncoderManager::sendTMate2: hid_write failed";
+    }
+}
+
+void HidEncoderManager::setTMate2Backlight(uint8_t r, uint8_t g, uint8_t b)
+{
+    if (!m_device || !isTMate2()) return;
+    m_lcdVector[kTM2_BL_R] = r;
+    m_lcdVector[kTM2_BL_G] = g;
+    m_lcdVector[kTM2_BL_B] = b;
+    sendTMate2();
+}
+
+void HidEncoderManager::setTMate2Status(uint8_t led_byte)
+{
+    if (!m_device || !isTMate2()) return;
+    m_lcdVector[kTM2_LED] = led_byte;
+    sendTMate2();
+}
+
+void HidEncoderManager::setTMate2Display(uint32_t freq_hz, uint32_t small_val)
+{
+    if (!m_device || !isTMate2()) return;
+    tmate2WriteMainDisplay(m_lcdVector, freq_hz);
+    tmate2WriteSmallDisplay(m_lcdVector, small_val);
+    sendTMate2();
+}
+
+void HidEncoderManager::setTMate2Indicators(bool tx, const QString& mode,
+                                             float smeter_dbm, bool rit, bool xit)
+{
+    if (!m_device || !isTMate2()) return;
+
+    // RX / TX
+    tmate2Seg(m_lcdVector, kSeg_RX, !tx);
+    tmate2Seg(m_lcdVector, kSeg_TX,  tx);
+    tmate2Seg(m_lcdVector, kSeg_W,   tx);
+    tmate2Seg(m_lcdVector, kSeg_DBM, !tx);
+    tmate2Seg(m_lcdVector, kSeg_S,   !tx);
+    tmate2Seg(m_lcdVector, kSeg_VOL, true);
+    tmate2Seg(m_lcdVector, kSeg_SMETER_LINE, true);
+    tmate2Seg(m_lcdVector, kSeg_SMETER_DB_MINUS, !tx && smeter_dbm < 0.0f);
+
+    // Static frequency-display decorations (decimal dots + Hz unit). These are
+    // always on in the normal view; re-assert them here — not only in open() —
+    // so they survive after an overlay or idle-blank cleared them.
+    tmate2Seg(m_lcdVector, kSeg_DOT1, true);
+    tmate2Seg(m_lcdVector, kSeg_DOT2, true);
+    tmate2Seg(m_lcdVector, kSeg_HZ,   true);
+
+    // Mode — clear all mode bits first, then set the matching one
+    applyModeSegs(m_lcdVector, mode);
+
+    // S-meter bargraph — set bars 1..N on, rest off
+    const int bars = smeterBars(smeter_dbm);
+    for (int i = 0; i < 15; ++i)
+        tmate2Seg(m_lcdVector, kSMeterBars[i], i < bars);
+
+    // RIT / XIT
+    tmate2Seg(m_lcdVector, kSeg_RIT, rit);
+    tmate2Seg(m_lcdVector, kSeg_XIT, xit);
+
+    sendTMate2();
+}
+
+void HidEncoderManager::setTMate2OverlayIndicators(const QString& overlayType,
+                                                    int overlayValue,
+                                                    const QString& mode)
+{
+    if (!m_device || !isTMate2()) return;
+
+    const bool isVolume = overlayType == QLatin1String("volume");
+    const bool isPower  = overlayType == QLatin1String("power");
+    const bool isSpeed  = overlayType == QLatin1String("speed");
+    const bool isWpm    = overlayType == QLatin1String("wpm");
+    const bool isRit    = overlayType == QLatin1String("rit");
+
+    tmate2Seg(m_lcdVector, kSeg_SMETER_LINE, false);
+    tmate2Seg(m_lcdVector, kSeg_DOT1, false);
+    tmate2Seg(m_lcdVector, kSeg_DOT2, false);
+    tmate2Seg(m_lcdVector, kSeg_VOL, isVolume);
+    tmate2Seg(m_lcdVector, kSeg_W, isPower);
+    tmate2Seg(m_lcdVector, kSeg_HZ, isSpeed || isRit);
+    tmate2Seg(m_lcdVector, kSeg_RIT, isRit);
+    tmate2Seg(m_lcdVector, kSeg_SMETER_DB_MINUS, isRit && overlayValue < 0);
+    tmate2Seg(m_lcdVector, kSeg_DBM, false);
+    tmate2Seg(m_lcdVector, kSeg_S, false);
+    tmate2Seg(m_lcdVector, kSeg_RX, false);
+    tmate2Seg(m_lcdVector, kSeg_TX, false);
+    tmate2Seg(m_lcdVector, kSeg_XIT, false);
+
+    // Keep the current mode visible; for WPM force CW as an additional cue.
+    applyModeSegs(m_lcdVector, isWpm ? QStringLiteral("CW") : mode);
+
+    const int bars = (isVolume || isPower)
+        ? std::clamp((std::clamp(overlayValue, 0, 100) * 15 + 99) / 100, 0, 15)
+        : 0;
+    for (int i = 0; i < 15; ++i)
+        tmate2Seg(m_lcdVector, kSMeterBars[i], i < bars);
+
+    sendTMate2();
+}
+
+void HidEncoderManager::clearTMate2Indicators()
+{
+    if (!m_device || !isTMate2()) return;
+
+    tmate2Seg(m_lcdVector, kSeg_RX, false);
+    tmate2Seg(m_lcdVector, kSeg_TX, false);
+    tmate2Seg(m_lcdVector, kSeg_S, false);
+    tmate2Seg(m_lcdVector, kSeg_VOL, false);
+    tmate2Seg(m_lcdVector, kSeg_SMETER_LINE, false);
+    tmate2Seg(m_lcdVector, kSeg_SMETER_DB_MINUS, false);
+    tmate2Seg(m_lcdVector, kSeg_DOT1, false);
+    tmate2Seg(m_lcdVector, kSeg_DOT2, false);
+    tmate2Seg(m_lcdVector, kSeg_HZ, false);
+    tmate2Seg(m_lcdVector, kSeg_W, false);
+    tmate2Seg(m_lcdVector, kSeg_RIT, false);
+    tmate2Seg(m_lcdVector, kSeg_XIT, false);
+    tmate2Seg(m_lcdVector, kSeg_DBM, false);
+    applyModeSegs(m_lcdVector, QString());
+    for (const auto& bar : kSMeterBars)
+        tmate2Seg(m_lcdVector, bar, false);
+
+    sendTMate2();
 }
 
 void HidEncoderManager::setRC28Leds(uint8_t ledByte)

--- a/src/core/HidEncoderManager.h
+++ b/src/core/HidEncoderManager.h
@@ -47,6 +47,10 @@ public:
         return m_openVid.load(std::memory_order_relaxed) == 0x0FD9
             && m_openPid.load(std::memory_order_relaxed) == 0x0084;
     }
+    bool isTMate2() const {
+        return m_openVid.load(std::memory_order_relaxed) == 0x1721
+            && m_openPid.load(std::memory_order_relaxed) == 0x0614;
+    }
     // Single source of truth for the RC-28-compatible VID/PID set, shared by the
     // instance check below and open()'s multi-device guard. The emulator runs
     // the same wire protocol as the real RC-28, including the LED output report.
@@ -84,6 +88,34 @@ public slots:
     // No-op if device is not a StreamDeck+.
     void setKeyImages(const QVector<QByteArray>& jpegImages);
     void setKeyImage(int key, const QByteArray& jpegData);
+    // Set the RGB backlight on a TMate 2. No-op if device is not a TMate 2.
+    void setTMate2Backlight(uint8_t r, uint8_t g, uint8_t b);
+    // Set the LED status byte on a TMate 2 (byte 32 of the LCDVector).
+    //   bit0 = USB/radio connected, bit1 = VFO locked.
+    // No-op if device is not a TMate 2.
+    void setTMate2Status(uint8_t led_byte);
+    // Write frequency and S-meter/power value to the TMate 2 LCD.
+    //   freq_hz   : displayed right-aligned across the 9-digit main display.
+    //   small_val : displayed on the 3-digit S-meter/power display (mod 1000).
+    // Sends a full LCDVector update (backlight, contrast, timing are preserved).
+    // No-op if device is not a TMate 2.
+    void setTMate2Display(uint32_t freq_hz, uint32_t small_val);
+    // Update the TMate 2 segment indicators (RX/TX, mode, S-meter bargraph,
+    // RIT/XIT, decimal dots).  Call whenever any of these state items changes.
+    //   tx        : true = transmitting, false = receiving
+    //   mode      : demodulation mode string ("USB","LSB","AM","FM","CW","DIGL","DIGU",…)
+    //   smeter_dbm: S-meter reading in dBm; drives the 15-segment bargraph
+    //   rit/xit   : RIT / XIT active flags
+    // No-op if device is not a TMate 2.
+    void setTMate2Indicators(bool tx, const QString& mode, float smeter_dbm,
+                              bool rit, bool xit);
+    // Temporarily switch indicator segments to a TMate 2 overlay view.
+    // overlayType: "volume", "power", "speed", "wpm", or "rit".
+    void setTMate2OverlayIndicators(const QString& overlayType,
+                                     int overlayValue,
+                                     const QString& mode);
+    // Clear all non-digit TMate 2 indicator segments. Used by the idle blanker.
+    void clearTMate2Indicators();
     // Write an 800x100 JPEG to the touchscreen strip above the dials.
     // x_pos/y_pos/width/height let you update a sub-region; defaults write the full strip.
     void setTouchscreenImage(const QByteArray& jpegData,
@@ -127,6 +159,17 @@ private:
     std::atomic<uint16_t> m_openVid{0};
     std::atomic<uint16_t> m_openPid{0};
     bool m_invertDirection{false};
+
+    // Persistent LCDVector state for TMate 2 (44 bytes).  All output functions
+    // modify this buffer then send the full 64-byte report so that backlight,
+    // contrast, and timing fields are never accidentally reset to zero.
+    // Initialised to zeros; timing defaults are applied in open() when a
+    // TMate 2 is detected.  Protocol documented in OpenTMate2Lib.
+    uint8_t m_lcdVector[44]{};
+
+    // Send the current m_lcdVector to the device.  Pads to 64 bytes with zeros.
+    // Must only be called while m_device is open and isTMate2() is true.
+    void sendTMate2();
 
     QTimer* m_pollTimer{nullptr};
     QTimer* m_hotplugTimer{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -263,6 +263,43 @@ constexpr int kSwrSweepMaxPoints = 260;
 constexpr double kMemoryRevealTargetToleranceMhz = 0.000001;
 constexpr const char* kSuppressAudioDeviceNotificationsKey =
     "SuppressAudioDeviceNotifications";
+constexpr int kTMate2DefaultOverlayDurationMs = 1500;
+constexpr int kTMate2DefaultUserInteractionTimeoutMs = 2000;
+
+#ifdef HAVE_HIDAPI
+QString tmate2EncoderDefaultAction(int encoderIndex)
+{
+    switch (encoderIndex) {
+    case 0:  return QStringLiteral("WheelFrequency");
+    case 1:  return QStringLiteral("WheelRit");
+    case 2:  return QStringLiteral("WheelXit");
+    default: return QStringLiteral("WheelFrequency");
+    }
+}
+
+QString tmate2KeyDefaultAction(int keyIndex)
+{
+    switch (keyIndex) {
+    case 0:  return QStringLiteral("ToggleMox");
+    case 1:  return QStringLiteral("ToggleAgc");
+    case 2:  return QStringLiteral("BandZoom");
+    case 3:  return QStringLiteral("ToggleApf");
+    case 4:  return QStringLiteral("ToggleMute");
+    case 5:  return QStringLiteral("ToggleRit");
+    default: return QStringLiteral("None");
+    }
+}
+
+QString tmate2PushDefaultAction(int encoderIndex)
+{
+    switch (encoderIndex) {
+    case 0:  return QStringLiteral("StepCycle");
+    case 1:  return QStringLiteral("ToggleRit");
+    case 2:  return QStringLiteral("ToggleXit");
+    default: return QStringLiteral("None");
+    }
+}
+#endif
 
 bool isTransientAudioDeviceId(const QByteArray& id)
 {
@@ -3548,8 +3585,14 @@ MainWindow::MainWindow(QWidget* parent)
     // ── S-Meter: MeterModel → SMeterWidget (active slice only) ─────────────
     connect(&m_radioModel.meterModel(), &MeterModel::sLevelChanged,
             this, [this](int sliceIndex, float dbm) {
-        if (sliceIndex == m_activeSliceId)
+        if (sliceIndex == m_activeSliceId) {
             m_appletPanel->sMeterWidget()->setLevel(dbm);
+#ifdef HAVE_HIDAPI
+            m_tmate2SmeterDbm = dbm;
+            updateTMate2Display();
+            updateTMate2Indicators();
+#endif
+        }
     });
     // Symmetric with the amp-side guard at line ~3654 and the PGXL TCP path
     // at line ~3525: in OPERATE the amp owns the analog S-Meter, so drop the
@@ -3560,6 +3603,11 @@ MainWindow::MainWindow(QWidget* parent)
         if (m_radioModel.hasAmplifier() && m_radioModel.ampOperate())
             return;
         m_appletPanel->sMeterWidget()->setTxMeters(fwd, swr);
+#ifdef HAVE_HIDAPI
+        m_tmate2TxWatts = fwd;
+        if (m_radioModel.transmitModel().isTransmitting())
+            updateTMate2Display();
+#endif
     });
     connect(&m_radioModel.meterModel(), &MeterModel::micMetersChanged,
             m_appletPanel->sMeterWidget(), &SMeterWidget::setMicMeters);
@@ -3902,6 +3950,8 @@ MainWindow::MainWindow(QWidget* parent)
             this, &MainWindow::handleFlexControlButton);
     connect(m_flexControl, &FlexControlManager::buttonPressed,
             this, [this](int button, int action) {
+        if (m_hidEncoder->isTMate2())
+            noteTMate2Interaction();
         if (m_flexControlDialog)
             m_flexControlDialog->reflectButtonPress(button, action);
     });
@@ -4013,6 +4063,18 @@ MainWindow::MainWindow(QWidget* parent)
 #ifdef HAVE_HIDAPI
     m_hidEncoder = new HidEncoderManager;
     m_hidEncoder->moveToThread(m_extCtrlThread);
+    m_tmate2OverlayTimer.setSingleShot(true);
+    connect(&m_tmate2OverlayTimer, &QTimer::timeout, this, [this] {
+        m_tmate2Overlay = TMate2Overlay::None;
+        m_tmate2OverlayUntilMs = 0;
+        updateTMate2Display();
+        updateTMate2Indicators();
+        restartTMate2IdleTimer();
+    });
+    m_tmate2IdleTimer.setSingleShot(true);
+    connect(&m_tmate2IdleTimer, &QTimer::timeout, this, [this] {
+        blankTMate2Display();
+    });
 
     // Hold-detection timers for RC-28 F1/F2 — single-shot 600 ms, one per key so
     // both can be held at once without clobbering each other's state. (#3323)
@@ -4039,6 +4101,8 @@ MainWindow::MainWindow(QWidget* parent)
     // applyFlexControlWheelAction handles coalescing internally for frequency.
     connect(m_hidEncoder, &HidEncoderManager::tuneSteps,
             this, [this](int encoderIndex, int steps) {
+        if (m_hidEncoder->isTMate2())
+            noteTMate2Interaction();
         // Fast/Fine direct-tune mode (frequency only) — respect the slice lock
         // here since this path bypasses applyFlexControlWheelAction's own guard.
         // Fast mode: 100 Hz per tick. Fine mode: 1 Hz per tick.
@@ -4052,9 +4116,12 @@ MainWindow::MainWindow(QWidget* parent)
             }
             return;
         }
+        const bool isTMate2 = m_hidEncoder->isTMate2();
         const QString actionId = AppSettings::instance()
-            .value(QString("HidEncoderAction%1").arg(encoderIndex),
-                   MainWindow::hidEncoderDefaultAction(encoderIndex))
+            .value(QString(isTMate2 ? "TMate2EncoderAction%1" : "HidEncoderAction%1")
+                       .arg(encoderIndex),
+                   isTMate2 ? tmate2EncoderDefaultAction(encoderIndex)
+                             : MainWindow::hidEncoderDefaultAction(encoderIndex))
             .toString();
         applyFlexControlWheelAction(actionId, steps);
     });
@@ -4102,6 +4169,17 @@ MainWindow::MainWindow(QWidget* parent)
             // RC-28 TX bar is hardwired to PTT (mode configured in the RC-28
             // dialog); it is not remappable via the generic HID-key settings.
             actionName = QStringLiteral("PTT");
+        } else if (m_hidEncoder->isTMate2() && button >= 1 && button <= 6) {
+            actionName = AppSettings::instance()
+                .value(QString("TMate2KeyAction%1").arg(button - 1),
+                       tmate2KeyDefaultAction(button - 1))
+                .toString();
+        } else if (m_hidEncoder->isTMate2() && button >= 9 && button <= 11) {
+            const int enc = button - 9;
+            actionName = AppSettings::instance()
+                .value(QString("TMate2PushAction%1").arg(enc),
+                       tmate2PushDefaultAction(enc))
+                .toString();
         } else if (button >= 1 && button <= 8) {
             // Generic HID keys (StreamDeck+ LCD buttons 1–8).
             actionName = AppSettings::instance()
@@ -4161,8 +4239,12 @@ MainWindow::MainWindow(QWidget* parent)
             this, [this](bool connected, const QString& name) {
         qCDebug(lcDevices) << "HID encoder:" << (connected ? "connected" : "disconnected") << name;
         if (connected) {
+            if (m_hidEncoder->isTMate2())
+                noteTMate2Interaction();
             refreshStreamDeckLabels();
             updateRC28Leds();
+            updateTMate2Display();
+            updateTMate2Indicators();
         } else if (m_hidEncoder->isRC28Compatible()) {
             // RC-28 gone: stop any in-flight hold timers so they can't fire an
             // action for an absent encoder, and clear RC-28 stateful flags so a
@@ -4180,12 +4262,20 @@ MainWindow::MainWindow(QWidget* parent)
                 m_rc28PttLatched = false;
                 m_radioModel.setTransmit(false);
             }
+        } else {
+            m_tmate2IdleTimer.stop();
+            m_tmate2DisplayBlanked = false;
         }
     });
 
     // RC-28 TX LED: mirror MOX state to the device's red TRANSMIT LED.
     connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
-            this, [this](bool) { updateRC28Leds(); });
+            this, [this](bool tx) {
+        updateRC28Leds();
+        updateTMate2Display();
+        updateTMate2Indicators();
+        if (!tx) m_tmate2TxWatts = 0.0f;  // reset cached watts when leaving TX
+    });
 
     // RC-28 F-key LED for a Mute hold action — mute is global (not slice-scoped),
     // so refresh whenever it changes from any source (RC-28, GUI, MIDI…).
@@ -7001,6 +7091,203 @@ void MainWindow::updateRC28Leds()
     });
 }
 
+bool MainWindow::tmate2OverlayActive() const
+{
+    return m_tmate2Overlay != TMate2Overlay::None
+        && QDateTime::currentMSecsSinceEpoch() <= m_tmate2OverlayUntilMs;
+}
+
+QString MainWindow::tmate2OverlayName() const
+{
+    switch (m_tmate2Overlay) {
+    case TMate2Overlay::Volume: return QStringLiteral("volume");
+    case TMate2Overlay::Power:  return QStringLiteral("power");
+    case TMate2Overlay::Speed:  return QStringLiteral("speed");
+    case TMate2Overlay::Wpm:    return QStringLiteral("wpm");
+    case TMate2Overlay::Rit:    return QStringLiteral("rit");
+    case TMate2Overlay::None:   break;
+    }
+    return QString();
+}
+
+int MainWindow::tmate2IdleTimeoutMs() const
+{
+    auto& settings = AppSettings::instance();
+    const QVariant raw = settings.value("TMate2UserInteractionTimeoutMs");
+    if (!raw.isValid())
+        return 0;
+    const int timeoutMs = raw.toInt();
+    if (timeoutMs <= 0)
+        return 0;
+    return std::clamp(timeoutMs, 100, 60000);
+}
+
+void MainWindow::restartTMate2IdleTimer()
+{
+    if (!m_hidEncoder || !m_hidEncoder->isOpen() || !m_hidEncoder->isTMate2()) return;
+    const int idleMs = tmate2IdleTimeoutMs();
+    if (idleMs <= 0) {
+        m_tmate2IdleTimer.stop();
+        return;
+    }
+    m_tmate2IdleTimer.start(idleMs);
+}
+
+void MainWindow::noteTMate2Interaction()
+{
+    if (!m_hidEncoder || !m_hidEncoder->isOpen() || !m_hidEncoder->isTMate2()) return;
+    m_tmate2LastUserInteractionMs = QDateTime::currentMSecsSinceEpoch();
+    if (m_tmate2DisplayBlanked) {
+        m_tmate2DisplayBlanked = false;
+        updateTMate2Display();
+        updateTMate2Indicators();
+    }
+    restartTMate2IdleTimer();
+}
+
+void MainWindow::blankTMate2Display()
+{
+    if (!m_hidEncoder || !m_hidEncoder->isOpen() || !m_hidEncoder->isTMate2()) return;
+    if (tmate2OverlayActive()) {
+        restartTMate2IdleTimer();
+        return;
+    }
+    const int idleMs = tmate2IdleTimeoutMs();
+    if (idleMs <= 0)
+        return;
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    if (m_tmate2LastUserInteractionMs > 0 &&
+        now - m_tmate2LastUserInteractionMs < idleMs) {
+        m_tmate2IdleTimer.start(static_cast<int>(idleMs - (now - m_tmate2LastUserInteractionMs)));
+        return;
+    }
+    m_tmate2DisplayBlanked = true;
+    QMetaObject::invokeMethod(m_hidEncoder, [this] {
+        m_hidEncoder->setTMate2Display(0, 0);
+        m_hidEncoder->clearTMate2Indicators();
+    });
+}
+
+void MainWindow::triggerTMate2Overlay(TMate2Overlay overlay, int value)
+{
+    if (!m_hidEncoder || !m_hidEncoder->isOpen() || !m_hidEncoder->isTMate2()) return;
+    auto& settings = AppSettings::instance();
+    const int durationMs = std::clamp(
+        settings.value("TMate2OverlayDurationMs",
+                       QString::number(kTMate2DefaultOverlayDurationMs)).toInt(),
+        100, 10000);
+    m_tmate2Overlay = overlay;
+    m_tmate2OverlayValue = value;
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    m_tmate2LastUserInteractionMs = now;
+    m_tmate2DisplayBlanked = false;
+    m_tmate2OverlayUntilMs = now + durationMs;
+    m_tmate2OverlayTimer.start(durationMs);
+    updateTMate2Display();
+    updateTMate2Indicators();
+    restartTMate2IdleTimer();
+}
+
+// Push the current frequency and S-meter/power reading to the TMate 2 LCD.
+// Called whenever the active-slice frequency, S-meter level, or device
+// connection state changes.  Frequency comes from activeSlice(); S-meter uses
+// the last value cached in m_tmate2SmeterDbm.
+//
+// small_val mapping:
+//   RX: linear dBm offset from S9, clamped 0-999.
+//       S9 (-73 dBm) → 90; each dB above S9 adds 1 (S9+10 dB → 100);
+//       each dB below S9 subtracts 1 (S8 → 84, S5 → 66, S1 → 42).
+//   TX: forward power in watts from the last txMetersChanged sample.
+void MainWindow::updateTMate2Display()
+{
+    if (!m_hidEncoder || !m_hidEncoder->isOpen() || !m_hidEncoder->isTMate2()) return;
+    if (m_tmate2DisplayBlanked) return;
+
+    if (tmate2OverlayActive()) {
+        const int32_t mainVal = m_tmate2OverlayValue;
+        QMetaObject::invokeMethod(m_hidEncoder, [this, mainVal] {
+            m_hidEncoder->setTMate2Display(static_cast<uint32_t>(std::abs(mainVal)), 0);
+        });
+        return;
+    }
+    if (m_tmate2Overlay != TMate2Overlay::None) {
+        m_tmate2Overlay = TMate2Overlay::None;
+        m_tmate2OverlayUntilMs = 0;
+    }
+
+    // Frequency: active slice in Hz, 0 if no slice.
+    uint32_t freqHz = 0;
+    if (auto* s = activeSlice())
+        freqHz = static_cast<uint32_t>(std::round(s->frequency() * 1e6));
+
+    // S-meter small display: show the actual signal strength in dBm so the
+    // number matches the AetherSDR UI reading.  The DBM and "-" indicator
+    // segments (lit in setTMate2Indicators during RX) label it, so e.g.
+    // -95 dBm reads as "-95".  The S-unit itself is conveyed by the 15-bar
+    // bargraph, so the numeric and the bargraph are complementary, not
+    // redundant.
+    const int dbm       = static_cast<int>(std::round(m_tmate2SmeterDbm));
+    const uint32_t sVal = static_cast<uint32_t>(std::clamp(std::abs(dbm), 0, 999));
+
+    const uint32_t smallVal = m_radioModel.transmitModel().isTransmitting()
+        ? static_cast<uint32_t>(m_tmate2TxWatts + 0.5f)
+        : sVal;
+
+    QMetaObject::invokeMethod(m_hidEncoder, [this, freqHz, smallVal] {
+        m_hidEncoder->setTMate2Display(freqHz, smallVal);
+    });
+}
+
+// Push the LED status byte to the TMate 2.
+//   bit0 = radio connected; bit1 = VFO locked (active slice).
+void MainWindow::updateTMate2Status()
+{
+    if (!m_hidEncoder || !m_hidEncoder->isOpen() || !m_hidEncoder->isTMate2()) return;
+    uint8_t led = 0;
+    if (m_radioModel.isConnected())                              led |= 0x01u;
+    if (auto* s = activeSlice(); s && s->isLocked())            led |= 0x02u;
+    QMetaObject::invokeMethod(m_hidEncoder, [this, led] {
+        m_hidEncoder->setTMate2Status(led);
+    });
+}
+
+// Push all indicator segments (RX/TX, mode, S-meter bargraph, RIT/XIT) to
+// the TMate 2.  Called whenever any of these state items changes.
+void MainWindow::updateTMate2Indicators()
+{
+    if (!m_hidEncoder || !m_hidEncoder->isOpen() || !m_hidEncoder->isTMate2()) return;
+    if (m_tmate2DisplayBlanked) return;
+    auto* s = activeSlice();
+    const bool tx     = m_radioModel.transmitModel().isTransmitting();
+    const QString mode = s ? s->mode() : QStringLiteral("USB");
+    const bool rit    = s && s->ritOn();
+    const bool xit    = s && s->xitOn();
+    const float dbm   = m_tmate2SmeterDbm;
+    auto& settings = AppSettings::instance();
+    const uint8_t r = static_cast<uint8_t>(settings.value(
+        tx ? "TMate2TxBacklightR" : "TMate2BacklightR",
+        tx ? "255" : "0").toInt());
+    const uint8_t g = static_cast<uint8_t>(settings.value(
+        tx ? "TMate2TxBacklightG" : "TMate2BacklightG",
+        tx ? "30" : "50").toInt());
+    const uint8_t b = static_cast<uint8_t>(settings.value(
+        tx ? "TMate2TxBacklightB" : "TMate2BacklightB",
+        tx ? "0" : "255").toInt());
+    if (tmate2OverlayActive()) {
+        const QString overlay = tmate2OverlayName();
+        const int overlayValue = m_tmate2OverlayValue;
+        QMetaObject::invokeMethod(m_hidEncoder, [this, r, g, b, overlay, overlayValue, mode] {
+            m_hidEncoder->setTMate2Backlight(r, g, b);
+            m_hidEncoder->setTMate2OverlayIndicators(overlay, overlayValue, mode);
+        });
+        return;
+    }
+    QMetaObject::invokeMethod(m_hidEncoder, [this, tx, mode, dbm, rit, xit, r, g, b] {
+        m_hidEncoder->setTMate2Backlight(r, g, b);
+        m_hidEncoder->setTMate2Indicators(tx, mode, dbm, rit, xit);
+    });
+}
+
 // Dispatch a resolved HID action name and optionally log it to the mapping
 // dialog if it is open. Called for both F1/F2 hold (from the timer) and
 // short-press (on release). (#3323)
@@ -7012,14 +7299,28 @@ void MainWindow::dispatchHidAction(const QString& actionName,
 
     if (actionName == "StepCycle" || actionName == "StepUp") {
         if (auto* rx = m_appletPanel->rxApplet()) rx->cycleStepUp();
+        if (auto* s = activeSlice()) {
+            if (auto* sw = spectrumForSlice(s))
+                triggerTMate2Overlay(TMate2Overlay::Speed, sw->stepSize());
+        }
     } else if (actionName == "StepDown") {
         if (auto* rx = m_appletPanel->rxApplet()) rx->cycleStepDown();
+        if (auto* s = activeSlice()) {
+            if (auto* sw = spectrumForSlice(s))
+                triggerTMate2Overlay(TMate2Overlay::Speed, sw->stepSize());
+        }
     } else if (actionName == "ToggleRit") {
-        if (auto* s = activeSlice()) s->setRit(!s->ritOn(), s->ritFreq());
+        if (auto* s = activeSlice()) {
+            s->setRit(!s->ritOn(), s->ritFreq());
+            triggerTMate2Overlay(TMate2Overlay::Rit, s->ritOn() ? s->ritFreq() : 0);
+        }
     } else if (actionName == "ToggleXit") {
         if (auto* s = activeSlice()) s->setXit(!s->xitOn(), s->xitFreq());
     } else if (actionName == "ClearRit") {
-        if (auto* s = activeSlice()) s->setRit(s->ritOn(), 0);
+        if (auto* s = activeSlice()) {
+            s->setRit(s->ritOn(), 0);
+            triggerTMate2Overlay(TMate2Overlay::Rit, 0);
+        }
     } else if (actionName == "ClearXit") {
         if (auto* s = activeSlice()) s->setXit(s->xitOn(), 0);
     } else if (actionName == "ToggleMox") {
@@ -7430,6 +7731,7 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
         if (auto* s = activeSlice()) {
             const int hz = std::clamp(s->ritFreq() + steps * 10, -9999, 9999);
             s->setRit(true, hz);
+            triggerTMate2Overlay(TMate2Overlay::Rit, hz);
         }
     } else if (actionId == "WheelXit") {
         if (auto* s = activeSlice()) {
@@ -7446,11 +7748,13 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
         if (m_titleBar)
             m_titleBar->setMasterVolume(next);
         applyMasterVolume(next);
+        triggerTMate2Overlay(TMate2Overlay::Volume, next);
     } else if (actionId == "WheelHeadphoneVolume") {
         const int next = std::clamp(m_radioModel.headphoneGain() + steps * 2, 0, 100);
         if (m_titleBar)
             m_titleBar->setHeadphoneVolume(next);
         m_radioModel.setHeadphoneGain(next);
+        triggerTMate2Overlay(TMate2Overlay::Volume, next);
     } else if (actionId == "WheelAgcT") {
         if (auto* s = activeSlice())
             s->setAgcThreshold(std::clamp(s->agcThreshold() + steps, 0, 100));
@@ -7471,10 +7775,14 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
         setActiveSlice(slices[next]->sliceId());
     } else if (actionId == "WheelPower") {
         auto& tx = m_radioModel.transmitModel();
-        tx.setRfPower(std::clamp(tx.rfPower() + steps, 0, 100));
+        const int next = std::clamp(tx.rfPower() + steps, 0, 100);
+        tx.setRfPower(next);
+        triggerTMate2Overlay(TMate2Overlay::Power, next);
     } else if (actionId == "WheelCwSpeed") {
         auto& tx = m_radioModel.transmitModel();
-        tx.setCwSpeed(std::clamp(tx.cwSpeed() + steps, 5, 100));
+        const int next = std::clamp(tx.cwSpeed() + steps, 5, 100);
+        tx.setCwSpeed(next);
+        triggerTMate2Overlay(TMate2Overlay::Wpm, next);
     }
 }
 
@@ -10743,6 +11051,9 @@ void MainWindow::onConnectionStateChanged(bool connected)
                 m_agManualConnectTimer->start(7000);
             }
         }
+#ifdef HAVE_HIDAPI
+        updateTMate2Status();
+#endif
     } else {
         // Radio disconnected: trim CAT ports back to 1 so apps on channel A
         // stay connected through brief reconnects, higher channels stop cleanly.
@@ -10813,6 +11124,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
         if (m_rc28PttLatched) {
             m_rc28PttLatched = false;
         }
+        updateTMate2Status();
 #endif
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
         stopDax();
@@ -11500,6 +11812,11 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // Feed frequency to Antenna Genius for band→antenna recall
         if (s->sliceId() == m_activeSliceId)
             m_antennaGenius.setRadioFrequency(mhz);
+
+#ifdef HAVE_HIDAPI
+        if (s->sliceId() == m_activeSliceId)
+            updateTMate2Display();
+#endif
     });
 
     // Feed current frequency immediately (AG may connect later and reprocess).
@@ -12287,6 +12604,26 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     m_rc28RitConn  = connect(s, &SliceModel::ritChanged,    this, [this](bool, int){ updateRC28Leds(); });
     m_rc28XitConn  = connect(s, &SliceModel::xitChanged,    this, [this](bool, int){ updateRC28Leds(); });
     m_rc28LockConn = connect(s, &SliceModel::lockedChanged, this, [this](bool){ updateRC28Leds(); });
+
+    // Rewire TMate 2 status LED to the active slice's Lock state, and push an
+    // immediate display update so the LCD shows the new slice's frequency.
+    disconnect(m_tmate2LockConn);
+    disconnect(m_tmate2ModeConn);
+    disconnect(m_tmate2RitConn);
+    disconnect(m_tmate2XitConn);
+    m_tmate2LockConn = connect(s, &SliceModel::lockedChanged, this,
+                                [this](bool){ updateTMate2Status(); });
+    m_tmate2ModeConn = connect(s, &SliceModel::modeChanged,   this,
+                                [this](const QString&){ updateTMate2Indicators(); });
+    m_tmate2RitConn  = connect(s, &SliceModel::ritChanged,    this,
+                                [this](bool, int){ updateTMate2Indicators(); });
+    m_tmate2XitConn  = connect(s, &SliceModel::xitChanged,    this,
+                                [this](bool, int){ updateTMate2Indicators(); });
+    if (sliceId != prevId) {
+        updateTMate2Display();
+        updateTMate2Status();
+        updateTMate2Indicators();
+    }
 #endif
 
     qDebug() << "MainWindow: active slice set to" << sliceId;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -575,6 +575,34 @@ private:
     bool    m_rc28PttLatched{false};
     bool    m_hidFastTune{false};
     bool    m_hidFineTune{false};
+    enum class TMate2Overlay { None, Volume, Power, Speed, Wpm, Rit };
+    TMate2Overlay m_tmate2Overlay{TMate2Overlay::None};
+    int     m_tmate2OverlayValue{0};
+    qint64  m_tmate2OverlayUntilMs{0};
+    qint64  m_tmate2LastUserInteractionMs{0};
+    bool    m_tmate2DisplayBlanked{false};
+    QTimer  m_tmate2OverlayTimer;
+    QTimer  m_tmate2IdleTimer;
+    // Last S-meter reading (dBm) and TX power (watts) from the active slice;
+    // cached so updateTMate2Display/Indicators() can re-send without signal args.
+    float   m_tmate2SmeterDbm{-140.0f};
+    float   m_tmate2TxWatts{0.0f};
+    bool tmate2OverlayActive() const;
+    QString tmate2OverlayName() const;
+    int tmate2IdleTimeoutMs() const;
+    void restartTMate2IdleTimer();
+    void noteTMate2Interaction();
+    void blankTMate2Display();
+    void triggerTMate2Overlay(TMate2Overlay overlay, int value);
+    void updateTMate2Display();
+    void updateTMate2Status();
+    void updateTMate2Indicators();
+    // Per-slice connections rewired in setActiveSlice() so TMate 2 indicators
+    // track mode, RIT, XIT, and lock changes on the active slice.
+    QMetaObject::Connection m_tmate2LockConn;
+    QMetaObject::Connection m_tmate2ModeConn;
+    QMetaObject::Connection m_tmate2RitConn;
+    QMetaObject::Connection m_tmate2XitConn;
 #endif
 #ifdef Q_OS_LINUX
     EvdevEncoderManager*       m_dialBackend{nullptr};

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4404,6 +4404,279 @@ QWidget* RadioSetupDialog::buildSerialTab()
 
         vbox->addWidget(group);
     }
+
+    // --- TMate 2 device actions, encoders, and backlight ---------------------
+    {
+        auto* group = new QGroupBox("TMate 2 Key Actions");
+        group->setStyleSheet(kGroupStyle);
+        auto* grid = new QGridLayout(group);
+        grid->setSpacing(6);
+
+        auto* note = new QLabel("Assign actions to the six TMate 2 function keys.");
+        note->setWordWrap(true);
+        note->setStyleSheet(kLabelStyle);
+        grid->addWidget(note, 0, 0, 1, 4);
+
+        static const struct { const char* id; const char* label; } kTMate2KeyActions[] = {
+            {"None",             "None"},
+            {"ToggleMox",        "Toggle TX (MOX)"},
+            {"ToggleTune",       "Toggle Tune"},
+            {"ToggleRit",        "Toggle RIT on/off"},
+            {"ToggleXit",        "Toggle XIT on/off"},
+            {"ClearRit",         "Clear RIT offset"},
+            {"ClearXit",         "Clear XIT offset"},
+            {"StepUp",           "Step Size Up"},
+            {"StepDown",         "Step Size Down"},
+            {"ToggleMute",       "Toggle Mute"},
+            {"ToggleLock",       "Toggle Slice Lock"},
+            {"ToggleApf",        "Toggle APF"},
+            {"ToggleAgc",        "Cycle AGC Mode"},
+            {"BandZoom",         "Toggle Band Zoom"},
+            {"SegmentZoom",      "Toggle Segment Zoom"},
+            {"NextSlice",        "Next Slice"},
+            {"PrevSlice",        "Previous Slice"},
+            {"VolumeUp",         "Volume Up (+5)"},
+            {"VolumeDown",       "Volume Down (-5)"},
+            {"SplitActiveSlice", "Toggle Split"},
+        };
+
+        static const char* kTMate2KeyDefaults[6] = {
+            "ToggleMox", "ToggleAgc", "BandZoom", "ToggleApf", "ToggleMute", "ToggleRit"
+        };
+
+        for (int i = 0; i < 6; ++i) {
+            const int row = (i % 3) + 1;
+            const int col = (i / 3) * 2;
+            grid->addWidget(new QLabel(QString("F%1:").arg(i + 1)), row, col);
+
+            auto* combo = new QComboBox;
+            combo->setStyleSheet(QString(kEditStyle).replace("QLineEdit", "QComboBox"));
+            for (const auto& act : kTMate2KeyActions)
+                combo->addItem(QString::fromLatin1(act.label), QString::fromLatin1(act.id));
+
+            const QString key = QString("TMate2KeyAction%1").arg(i);
+            const QString saved = settings.value(
+                key, QString::fromLatin1(kTMate2KeyDefaults[i])).toString();
+            const int idx = combo->findData(saved);
+            combo->setCurrentIndex(idx >= 0 ? idx : 0);
+
+            connect(combo, &QComboBox::currentIndexChanged, this, [combo, key, this](int) {
+                auto& s = AppSettings::instance();
+                s.setValue(key, combo->currentData().toString());
+                s.save();
+                emit serialSettingsChanged();
+            });
+
+            m_tmate2KeyActionCombos[i] = combo;
+            grid->addWidget(combo, row, col + 1);
+        }
+        grid->setColumnStretch(1, 1);
+        grid->setColumnStretch(3, 1);
+
+        vbox->addWidget(group);
+    }
+
+    {
+        auto* group = new QGroupBox("TMate 2 Encoder Actions");
+        group->setStyleSheet(kGroupStyle);
+        auto* grid = new QGridLayout(group);
+        grid->setSpacing(6);
+
+        auto* note = new QLabel("Assign actions to the three TMate 2 encoder dials.");
+        note->setWordWrap(true);
+        note->setStyleSheet(kLabelStyle);
+        grid->addWidget(note, 0, 0, 1, 3);
+
+        static const struct { const char* id; const char* label; } kTMate2EncoderActions[] = {
+            {"WheelFrequency",      "Tune Slice"},
+            {"WheelRit",            "RIT (Receive Incremental Tuning)"},
+            {"WheelXit",            "XIT (Transmit Incremental Tuning)"},
+            {"WheelVolume",         "Master Volume"},
+            {"WheelHeadphoneVolume","Headphone Volume"},
+            {"WheelAgcT",           "AGC Threshold"},
+            {"WheelApf",            "APF Level"},
+            {"WheelCwSpeed",        "CW Speed"},
+            {"WheelPower",          "RF Power"},
+            {"None",                "None"},
+        };
+
+        static const char* kTMate2EncoderDefaults[3] = {
+            "WheelFrequency", "WheelRit", "WheelXit"
+        };
+
+        for (int i = 0; i < 3; ++i) {
+            grid->addWidget(new QLabel(QString("Encoder %1:").arg(i + 1)), i + 1, 0);
+
+            auto* combo = new QComboBox;
+            combo->setStyleSheet(QString(kEditStyle).replace("QLineEdit", "QComboBox"));
+            for (const auto& act : kTMate2EncoderActions)
+                combo->addItem(QString::fromLatin1(act.label), QString::fromLatin1(act.id));
+
+            const QString key = QString("TMate2EncoderAction%1").arg(i);
+            const QString saved = settings.value(
+                key, QString::fromLatin1(kTMate2EncoderDefaults[i])).toString();
+            const int idx = combo->findData(saved);
+            combo->setCurrentIndex(idx >= 0 ? idx : 0);
+
+            connect(combo, &QComboBox::currentIndexChanged, this, [combo, key, this](int) {
+                auto& s = AppSettings::instance();
+                s.setValue(key, combo->currentData().toString());
+                s.save();
+                emit serialSettingsChanged();
+            });
+
+            m_tmate2EncoderActionCombos[i] = combo;
+            grid->addWidget(combo, i + 1, 1, 1, 2);
+            grid->setColumnStretch(1, 1);
+        }
+
+        vbox->addWidget(group);
+    }
+
+    {
+        auto* group = new QGroupBox("TMate 2 Encoder Push Actions");
+        group->setStyleSheet(kGroupStyle);
+        auto* grid = new QGridLayout(group);
+        grid->setSpacing(6);
+
+        auto* note = new QLabel("Action when each TMate 2 encoder is pressed.");
+        note->setWordWrap(true);
+        note->setStyleSheet(kLabelStyle);
+        grid->addWidget(note, 0, 0, 1, 3);
+
+        static const struct { const char* id; const char* label; } kTMate2PushActions[] = {
+            {"StepCycle",  "Cycle Tuning Step"},
+            {"ToggleRit",  "Toggle RIT on/off"},
+            {"ToggleXit",  "Toggle XIT on/off"},
+            {"ToggleMox",  "Toggle TX (MOX)"},
+            {"ToggleMute", "Toggle Mute"},
+            {"ToggleLock", "Lock Slice"},
+            {"None",       "None"},
+        };
+
+        static const char* kTMate2PushDefaults[3] = {
+            "StepCycle", "ToggleRit", "ToggleXit"
+        };
+
+        for (int i = 0; i < 3; ++i) {
+            grid->addWidget(new QLabel(QString("Encoder %1 push:").arg(i + 1)), i + 1, 0);
+
+            auto* combo = new QComboBox;
+            combo->setStyleSheet(QString(kEditStyle).replace("QLineEdit", "QComboBox"));
+            for (const auto& act : kTMate2PushActions)
+                combo->addItem(QString::fromLatin1(act.label), QString::fromLatin1(act.id));
+
+            const QString key = QString("TMate2PushAction%1").arg(i);
+            const QString saved = settings.value(
+                key, QString::fromLatin1(kTMate2PushDefaults[i])).toString();
+            const int idx = combo->findData(saved);
+            combo->setCurrentIndex(idx >= 0 ? idx : 0);
+
+            connect(combo, &QComboBox::currentIndexChanged, this, [combo, key, this](int) {
+                auto& s = AppSettings::instance();
+                s.setValue(key, combo->currentData().toString());
+                s.save();
+                emit serialSettingsChanged();
+            });
+
+            m_tmate2EncoderPushActionCombos[i] = combo;
+            grid->addWidget(combo, i + 1, 1, 1, 2);
+            grid->setColumnStretch(1, 1);
+        }
+
+        vbox->addWidget(group);
+    }
+
+    {
+        auto* group = new QGroupBox("TMate 2 Display");
+        group->setStyleSheet(kGroupStyle);
+        auto* grid = new QGridLayout(group);
+        grid->setSpacing(6);
+
+        auto* note = new QLabel(
+            "Backlight colours and temporary display feedback. "
+            "Overlay duration controls how long changed values are shown on the TMate 2 LCD.");
+        note->setWordWrap(true);
+        note->setStyleSheet(kLabelStyle);
+        grid->addWidget(note, 0, 0, 1, 7);
+
+        static const struct {
+            const char* rowLabel;
+            const char* rKey; const char* gKey; const char* bKey;
+            const char* rDflt; const char* gDflt; const char* bDflt;
+            int spinOffset;
+        } kRows[2] = {
+            {"RX backlight:", "TMate2BacklightR",   "TMate2BacklightG",   "TMate2BacklightB",
+                              "0",                  "50",                 "255", 0},
+            {"TX backlight:", "TMate2TxBacklightR", "TMate2TxBacklightG", "TMate2TxBacklightB",
+                              "255",                "30",                 "0",   3},
+        };
+
+        static const char* kLabels[3] = {"R:", "G:", "B:"};
+        for (int row = 0; row < 2; ++row) {
+            auto* rowLbl = new QLabel(QString::fromLatin1(kRows[row].rowLabel));
+            rowLbl->setStyleSheet(kLabelStyle);
+            grid->addWidget(rowLbl, row + 1, 0);
+            const char* keys[3] = {kRows[row].rKey, kRows[row].gKey, kRows[row].bKey};
+            const char* dflts[3] = {kRows[row].rDflt, kRows[row].gDflt, kRows[row].bDflt};
+            for (int ch = 0; ch < 3; ++ch) {
+                auto* lbl = new QLabel(QString::fromLatin1(kLabels[ch]));
+                lbl->setStyleSheet(kLabelStyle);
+                grid->addWidget(lbl, row + 1, 1 + ch * 2);
+
+                auto* spin = new QSpinBox;
+                spin->setRange(0, 255);
+                spin->setValue(settings.value(keys[ch], dflts[ch]).toInt());
+                spin->setStyleSheet(QString(kEditStyle).replace("QLineEdit", "QSpinBox"));
+                grid->addWidget(spin, row + 1, 2 + ch * 2);
+                m_tmate2BacklightSpins[kRows[row].spinOffset + ch] = spin;
+
+                const QString key = QString::fromLatin1(keys[ch]);
+                connect(spin, QOverload<int>::of(&QSpinBox::valueChanged),
+                        this, [this, key](int val) {
+                    auto& s = AppSettings::instance();
+                    s.setValue(key, QString::number(val));
+                    s.save();
+                    emit serialSettingsChanged();
+                });
+            }
+        }
+
+        auto addTimingSpin = [&](int row, const QString& label, const QString& key,
+                                 int dflt, int min, int max, int step) -> QSpinBox* {
+            auto* lbl = new QLabel(label);
+            lbl->setStyleSheet(kLabelStyle);
+            grid->addWidget(lbl, row, 0, 1, 2);
+
+            auto* spin = new QSpinBox;
+            spin->setRange(min, max);
+            spin->setSingleStep(step);
+            spin->setSuffix(" ms");
+            spin->setValue(settings.value(key, QString::number(dflt)).toInt());
+            spin->setStyleSheet(QString(kEditStyle).replace("QLineEdit", "QSpinBox"));
+            grid->addWidget(spin, row, 2, 1, 2);
+
+            connect(spin, QOverload<int>::of(&QSpinBox::valueChanged),
+                    this, [this, key](int val) {
+                auto& s = AppSettings::instance();
+                s.setValue(key, QString::number(val));
+                s.save();
+                emit serialSettingsChanged();
+            });
+            return spin;
+        };
+
+        m_tmate2OverlayDurationSpin = addTimingSpin(
+            3, "Overlay duration:", "TMate2OverlayDurationMs", 1500, 100, 10000, 100);
+        m_tmate2UserInteractionTimeoutSpin = addTimingSpin(
+            4, "User interaction timeout:", "TMate2UserInteractionTimeoutMs", 2000, 0, 60000, 100);
+
+        for (int col = 2; col <= 6; col += 2)
+            grid->setColumnStretch(col, 1);
+
+        vbox->addWidget(group);
+    }
+
 #endif
 
     vbox->addStretch();

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -15,6 +15,7 @@ class QProgressBar;
 class QPushButton;
 class QComboBox;
 class QCheckBox;
+class QSpinBox;
 class QVBoxLayout;
 class QTableWidget;
 
@@ -109,6 +110,13 @@ private:
     std::array<QComboBox*, 4> m_hidEncoderActionCombos{};
     std::array<QComboBox*, 4> m_hidEncoderPushActionCombos{};
     std::array<QComboBox*, 8> m_hidKeyActionCombos{};
+    std::array<QComboBox*, 3> m_tmate2EncoderActionCombos{};
+    std::array<QComboBox*, 3> m_tmate2EncoderPushActionCombos{};
+    std::array<QComboBox*, 6> m_tmate2KeyActionCombos{};
+    // TMate 2 backlight spinboxes (RX RGB, TX RGB) and timing controls.
+    std::array<QSpinBox*, 6>  m_tmate2BacklightSpins{};
+    QSpinBox* m_tmate2OverlayDurationSpin{nullptr};
+    QSpinBox* m_tmate2UserInteractionTimeoutSpin{nullptr};
 #endif
 
     // Radio tab fields


### PR DESCRIPTION
## Summary

Adds full support for the **ELAD / WoodBoxRadio TMate 2** USB HID controller
(VID `0x1721` / PID `0x0614`) — three encoders, six function keys, and the
LCDVector display, all wired into the SDR. The USB protocol was
reverse-engineered from capture analysis.

## What's included

**Display layer (`HidEncoderManager`)**
- 44-byte LCDVector state buffer; every setter mutates it and re-sends the full
  report so backlight / contrast / timing are never reset. The report is
  prefixed with report-ID `0` so Windows hidapi does not shift the payload by
  one byte.
- 9-digit main frequency display + 3-digit small display, 15-segment S-meter
  bargraph, RX/TX, per-mode indicators (USB/LSB/AM/SAM/DSB/FM/CW/DIGU/DIGL/
  RTTY), RIT/XIT and decimal dots.
- `applyModeSegs()` shared between the live and overlay indicator paths.

**MainWindow wiring**
- Frequency, S-meter (dBm → S-units) and TX power tracked from the active
  slice; RX/TX backlight colours switch on MOX.
- Transient overlays (volume, RF power, CW speed, step size, RIT) shown for a
  configurable duration when the matching control changes.
- Idle blanking: the LCD clears after a configurable no-interaction timeout and
  wakes on the next encoder / button event.
- Encoder 0 direction inverted to match the physical tuning wheel.

**Config UI (`RadioSetupDialog`)**
- Per-key / per-encoder / per-push action mapping, RX and TX backlight RGB, and
  overlay / idle timing. All client-side `AppSettings`; no radio-authoritative
  state is persisted.

## Testing

- Built clean on **Linux** (CI container) and **Windows** (MSVC / Qt 6.8.3).
- Tested against **real TMate 2 hardware** — display, encoders, keys, overlays,
  backlight and idle blanking verified on-device.

## Note for reviewers

The TMate 2 settings use flat `AppSettings` keys (`TMate2KeyAction0` …),
matching the adjacent StreamDeck+/HID encoder config rather than the nested-JSON
form of **Principle V**. Happy to migrate these to a single nested-JSON blob if
you'd prefer the feature lead the way on that convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
