### PR TITLE
New Fetures: WideFM & PanLock Button

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,6 +573,9 @@ set(CORE_SOURCES
     src/core/SleepInhibitor.cpp
     src/core/MemoryCsvCompat.cpp
     src/core/MemoryRecallPolicy.cpp
+    src/core/WfmDemodulator.cpp
+    src/core/WaveOutWriter.cpp
+    src/core/WaveInReader.cpp
     src/core/tnc/AetherAx25LibmodemShim.cpp
     src/core/tnc/Ax25FrameFormatter.cpp
 )
@@ -622,6 +625,7 @@ set(MODEL_SOURCES
 set(GUI_SOURCES
     src/gui/MainWindow.cpp
     src/gui/AudioDeviceChangeDialog.cpp
+    src/gui/WfmDeviceDialog.cpp
     src/gui/ConnectionPanel.cpp
     src/gui/ClientDisconnectDialog.cpp
     src/gui/ConnectedStationsDialog.cpp

--- a/Resumen para empezar de nuevo.txt
+++ b/Resumen para empezar de nuevo.txt
@@ -1,0 +1,133 @@
+# Resumen del proyecto: Modo WFM en AetherSDR
+
+---
+
+## Objetivo
+
+Añadir un modo **WFM (Wide FM) funcional** en el software **AetherSDR** (SDR para FlexRadio 6600) que:
+
+1. Se active con el botón WFM ya existente en la UI
+2. Desmodule FM por software desde el stream DAX IQ del radio (canal 1, 48kHz)
+3. Envíe el audio desmodulado al cable virtual **Hi-Fi Cable Input (VB-Audio)** con **hasta 20kHz de ancho de banda de audio**
+4. Permita que **hs-soundmodem (UZ7HO)** decodifique señales G3RUH 9600 baud de satélites, leyendo desde **Hi-Fi Cable Output**
+
+---
+
+## Estado actual al dejar el trabajo
+
+- El botón WFM activa el demodulador ✅
+- Los paquetes IQ llegan continuamente (confirmado: 2800+ paquetes) ✅
+- El audio llega a hs-soundmodem ✅
+- El ancho de banda es correcto (1000–18000 Hz en waterfall) ✅
+- **Problema pendiente**: el waterfall de hs-soundmodem muestra líneas horizontales con huecos negros periódicos (audio entrecortado), mientras que en modo FM el waterfall es continuo y denso
+
+---
+
+## Arquitectura del código
+
+**Archivos creados/modificados:**
+
+| Archivo | Descripción |
+|---|---|
+| `src/core/WfmDemodulator.h/.cpp` | Demodulador FM por software (discriminador atan2) |
+| `src/core/WaveOutWriter.h/.cpp` | Salida de audio vía Windows waveOut API |
+| `src/gui/MainWindow.h/.cpp` | Cooldown anti-feedback y llamadas a WFM |
+| `CMakeLists.txt` | Añadido `WaveOutWriter.cpp` a las fuentes |
+
+**Flujo de señal:**
+```
+FlexRadio → DAX IQ UDP (VITA-49) → DaxIqModel → iqSamplesReady signal
+→ WfmDemodulator::onIqSamples() → discriminador FM atan2
+→ WaveOutWriter::write() → waveOut API Windows
+→ Hi-Fi Cable Input (VB-Audio) → Hi-Fi Cable Output → hs-soundmodem
+```
+
+**Parámetros del demodulador:**
+- `DAX_CHANNEL = 1`, `IQ_RATE = 48000 Hz`, `AUDIO_RATE = 48000 Hz`
+- `FILTER_HZ = ±20000 Hz` (filtro del slice en el radio)
+- `GAIN = 3.0` (ganancia discriminador, ~60% full scale para G3RUH ±4.8kHz desviación)
+- Sin de-énfasis (señales digitales de satélite no están pre-enfatizadas)
+
+**Discriminador FM (atan2):**
+```cpp
+float cross = I * prevQ - Q * prevI;
+float dot   = I * prevI + Q * prevQ;
+float audio = std::atan2(cross, dot) * (GAIN / M_PI);
+```
+
+---
+
+## Problema raíz inicial
+
+El código original tenía toda la demodulación dentro de `#ifndef _MSC_VER` (dependía de liquid-dsp, incompatible con Windows/MSVC). En Windows el botón WFM activaba el sink de audio pero no desmodulaba nada.
+
+---
+
+## Todo lo que se intentó para los cortes de audio
+
+### Intento 1: QAudioSink push mode directo
+- Escritura directa de PCM al sink desde `onIqSamples()`
+- **Problema**: El sink entra en `IdleState` (sinkState=3) entre paquetes IQ. WASAPI en modo compartido tiene latencia ~10ms igual que el intervalo entre paquetes → cero margen → cortes
+
+### Intento 2: QAudioSink push mode con buffer grande (500ms)
+- Buffer de 500ms + pre-llenado de silencio
+- **Resultado**: sinkState=0 (Active) ✅, `free` estable ✅, pero los cortes persistían
+- **Conclusión**: El pipeline Qt funcionaba correctamente; el problema estaba en otro lugar
+
+### Intento 3: QAudioSink pull mode con ring buffer
+- `WfmAudioBuffer` (QIODevice custom) + `QAudioSink::start(device)` en modo pull
+- `isSequential()`, `bytesAvailable()` override
+- **Problema**: Qt6 en Windows no consume datos del dispositivo custom en pull mode — `bytesFree()` siempre retornaba el máximo, el sink no llamaba `readData()`
+
+### Intento 4: Ring buffer + QTimer cada 10ms (push)
+- Timer pusha datos del ring al sink cada 10ms
+- **Problema**: Precisión real del timer de Windows es ~15ms → huecos de 5ms entre escrituras → cortes
+
+### Intento 5: waveOut API de Windows directamente
+- `WaveOutWriter` con `waveOutWrite()` y doble buffer (8 WAVEHDRs)
+- Sin dependencia de Qt audio
+- **Problema**: Spin-loop `Sleep(1)` bloqueaba el hilo Qt (event loop) → los paquetes IQ se acumulaban en cola → ráfagas → patrón entrecortado
+
+### Intento 6: waveOut con pre-llenado de silencio (16 buffers × 10ms)
+- Pre-encolar 16 buffers con silencio al inicio → 160ms de colchón
+- Cada paquete IQ reemplaza el buffer más antiguo
+- **Problema descubierto (comparando waterfalls FM vs WFM)**: Los buffers de silencio del pre-llenado se intercalan con el audio real en el FIFO de waveOut. Como waveOut es FIFO estricto, el orden es: silencio→silencio→...→audio→audio. Los 16 buffers de silencio juegan primero, luego el audio real va al final de la cola → patrón periódico de líneas/negro en el waterfall
+
+### Intento 7 (último, sin probar resultado): waveOut con hilo de reposición
+- `CALLBACK_EVENT` + hilo dedicado (`refillThreadProc`) con prioridad `ABOVE_NORMAL`
+- El hilo espera `WaitForSingleObject(m_refillEvent)` — Windows señaliza el evento en microsegundos cuando un buffer termina (`WOM_DONE`)
+- El hilo re-encola inmediatamente cada buffer con audio real (del pending con mutex) o silencio si no hay datos
+- La cola **nunca está vacía** — siempre hay el siguiente buffer listo antes de que el actual termine
+- **Estado**: Compilado, no probado aún
+
+---
+
+## Fix adicional aplicado: cooldown anti-feedback
+
+`setFilterWidth()` en `activateWFM()` envía un comando al radio → el radio responde con una actualización de modo → la UI actualiza el combo de modos → dispara `wfmActivated(false)` → `deactivateWFM()` mata el demodulador recién creado.
+
+**Fix**: `m_wfmCooldown` de 1 segundo en `MainWindow` que bloquea `deactivateWFM()` durante 1s después de la activación.
+
+---
+
+## Log de debug
+
+Hay un archivo de log activo en `C:\Users\reigc\wfm_debug.txt` que registra:
+- Apertura/cierre del WaveOutWriter
+- Número de paquetes IQ recibidos (cada 50)
+- Estado del sink
+
+---
+
+## Configuración de hs-soundmodem
+
+- **Input device**: `Hi-Fi Cable Output (VB-Audio Hi-Fi Cable)` ← debe coincidir con lo que AetherSDR escribe
+- **RX SampleRate**: 48000 Hz
+- **Dual channel**: activado
+- **Modo A**: FSK G3RUH 9600bd
+- **Modo B**: FSK G3RUH 4800bd
+
+---
+
+## Próximos pasos sugeridos
+

--- a/Resumen para empezar de nuevo.txt
+++ b/Resumen para empezar de nuevo.txt
@@ -110,13 +110,6 @@ El código original tenía toda la demodulación dentro de `#ifndef _MSC_VER` (d
 
 ---
 
-## Log de debug
-
-Hay un archivo de log activo en `C:\Users\reigc\wfm_debug.txt` que registra:
-- Apertura/cierre del WaveOutWriter
-- Número de paquetes IQ recibidos (cada 50)
-- Estado del sink
-
 ---
 
 ## Configuración de hs-soundmodem

--- a/src/core/WaveInReader.cpp
+++ b/src/core/WaveInReader.cpp
@@ -1,0 +1,152 @@
+#include "WaveInReader.h"
+#include <QFile>
+#include <QTextStream>
+#include <cstring>
+
+static void wfmLog(const QString& msg)
+{
+    QFile f("C:/Users/reigc/wfm_debug.txt");
+    if (f.open(QIODevice::Append | QIODevice::Text))
+        QTextStream(&f) << msg << "\n";
+}
+
+namespace AetherSDR {
+
+WaveInReader::WaveInReader(QObject* parent)
+    : QObject(parent)
+{}
+
+WaveInReader::~WaveInReader()
+{
+    close();
+}
+
+bool WaveInReader::open(const QString& deviceNameFragment, int sampleRate,
+                         int channels, int bitsPerSample)
+{
+    close();
+
+    const UINT numDevs = waveInGetNumDevs();
+    UINT devId = WAVE_MAPPER;
+    {
+        QString allDevs;
+        for (UINT i = 0; i < numDevs; ++i) {
+            WAVEINCAPSW caps{};
+            if (waveInGetDevCapsW(i, &caps, sizeof(caps)) == MMSYSERR_NOERROR) {
+                const QString name = QString::fromWCharArray(caps.szPname);
+                allDevs += QString("  [%1] %2\n").arg(i).arg(name);
+                if (m_deviceName.isEmpty()
+                        && name.contains(deviceNameFragment, Qt::CaseInsensitive)) {
+                    devId = i;
+                    m_deviceName = name;
+                }
+            }
+        }
+        wfmLog(QString("WaveInReader::open looking for '%1' among %2 waveIn devices:\n%3")
+               .arg(deviceNameFragment).arg(numDevs).arg(allDevs.trimmed()));
+    }
+
+    if (!deviceNameFragment.isEmpty() && m_deviceName.isEmpty()) {
+        wfmLog(QString("WaveInReader::open: '%1' not found — aborting").arg(deviceNameFragment));
+        return false;
+    }
+    if (m_deviceName.isEmpty())
+        m_deviceName = "(default)";
+
+    WAVEFORMATEX wfx{};
+    wfx.wFormatTag      = WAVE_FORMAT_PCM;
+    wfx.nChannels       = static_cast<WORD>(channels);
+    wfx.nSamplesPerSec  = static_cast<DWORD>(sampleRate);
+    wfx.wBitsPerSample  = static_cast<WORD>(bitsPerSample);
+    wfx.nBlockAlign     = wfx.nChannels * (wfx.wBitsPerSample / 8);
+    wfx.nAvgBytesPerSec = wfx.nSamplesPerSec * wfx.nBlockAlign;
+
+    m_captureEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
+
+    const MMRESULT res = waveInOpen(&m_hWaveIn, devId, &wfx,
+                                    reinterpret_cast<DWORD_PTR>(m_captureEvent),
+                                    0, CALLBACK_EVENT);
+    if (res != MMSYSERR_NOERROR) {
+        wfmLog(QString("waveInOpen failed: %1").arg(res));
+        CloseHandle(m_captureEvent);
+        m_captureEvent = nullptr;
+        m_hWaveIn      = nullptr;
+        return false;
+    }
+
+    m_bytesPerBuf = BUF_SAMPLES * channels * (bitsPerSample / 8);
+    for (int i = 0; i < NUM_BUFS; ++i) {
+        m_buffers[i].resize(m_bytesPerBuf, 0);
+        auto& hdr = m_headers[i];
+        std::memset(&hdr, 0, sizeof(hdr));
+        hdr.lpData         = m_buffers[i].data();
+        hdr.dwBufferLength = static_cast<DWORD>(m_bytesPerBuf);
+        waveInPrepareHeader(m_hWaveIn, &hdr, sizeof(hdr));
+        waveInAddBuffer(m_hWaveIn, &hdr, sizeof(hdr));
+    }
+
+    m_running       = true;
+    m_captureThread = CreateThread(NULL, 0, captureThreadProc, this, 0, NULL);
+    SetThreadPriority(m_captureThread, THREAD_PRIORITY_ABOVE_NORMAL);
+
+    waveInStart(m_hWaveIn);
+
+    wfmLog(QString("WaveInReader opened: device='%1' rate=%2 ch=%3 bits=%4")
+           .arg(m_deviceName).arg(sampleRate).arg(channels).arg(bitsPerSample));
+    return true;
+}
+
+void WaveInReader::close()
+{
+    if (!m_hWaveIn) return;
+
+    m_running = false;
+    if (m_captureEvent) SetEvent(m_captureEvent);
+    if (m_captureThread) {
+        WaitForSingleObject(m_captureThread, 2000);
+        CloseHandle(m_captureThread);
+        m_captureThread = nullptr;
+    }
+
+    waveInStop(m_hWaveIn);
+    waveInReset(m_hWaveIn);
+    for (int i = 0; i < NUM_BUFS; ++i)
+        waveInUnprepareHeader(m_hWaveIn, &m_headers[i], sizeof(m_headers[i]));
+    waveInClose(m_hWaveIn);
+    m_hWaveIn = nullptr;
+
+    if (m_captureEvent) {
+        CloseHandle(m_captureEvent);
+        m_captureEvent = nullptr;
+    }
+    wfmLog("WaveInReader closed");
+}
+
+// static
+DWORD WINAPI WaveInReader::captureThreadProc(LPVOID param)
+{
+    WaveInReader* r = reinterpret_cast<WaveInReader*>(param);
+    r->captureLoop();
+    return 0;
+}
+
+void WaveInReader::captureLoop()
+{
+    while (m_running) {
+        WaitForSingleObject(m_captureEvent, 50);
+        if (!m_running) break;
+
+        for (int i = 0; i < NUM_BUFS; ++i) {
+            auto& hdr = m_headers[i];
+            if (!(hdr.dwFlags & WHDR_DONE)) continue;
+
+            QByteArray pcm(m_buffers[i].constData(), m_bytesPerBuf);
+            emit pcmReady(pcm);
+
+            hdr.dwFlags &= ~WHDR_DONE;
+            waveInAddBuffer(m_hWaveIn, &hdr, sizeof(hdr));
+        }
+    }
+}
+
+} // namespace AetherSDR

--- a/src/core/WaveInReader.cpp
+++ b/src/core/WaveInReader.cpp
@@ -3,12 +3,6 @@
 #include <QTextStream>
 #include <cstring>
 
-static void wfmLog(const QString& msg)
-{
-    QFile f("C:/Users/reigc/wfm_debug.txt");
-    if (f.open(QIODevice::Append | QIODevice::Text))
-        QTextStream(&f) << msg << "\n";
-}
 
 namespace AetherSDR {
 
@@ -42,14 +36,14 @@ bool WaveInReader::open(const QString& deviceNameFragment, int sampleRate,
                 }
             }
         }
-        wfmLog(QString("WaveInReader::open looking for '%1' among %2 waveIn devices:\n%3")
-               .arg(deviceNameFragment).arg(numDevs).arg(allDevs.trimmed()));
     }
 
-    if (!deviceNameFragment.isEmpty() && m_deviceName.isEmpty()) {
+/*     if (!deviceNameFragment.isEmpty() && m_deviceName.isEmpty())
+    {
         wfmLog(QString("WaveInReader::open: '%1' not found — aborting").arg(deviceNameFragment));
         return false;
-    }
+    } */
+
     if (m_deviceName.isEmpty())
         m_deviceName = "(default)";
 
@@ -67,7 +61,6 @@ bool WaveInReader::open(const QString& deviceNameFragment, int sampleRate,
                                     reinterpret_cast<DWORD_PTR>(m_captureEvent),
                                     0, CALLBACK_EVENT);
     if (res != MMSYSERR_NOERROR) {
-        wfmLog(QString("waveInOpen failed: %1").arg(res));
         CloseHandle(m_captureEvent);
         m_captureEvent = nullptr;
         m_hWaveIn      = nullptr;
@@ -91,9 +84,9 @@ bool WaveInReader::open(const QString& deviceNameFragment, int sampleRate,
 
     waveInStart(m_hWaveIn);
 
-    wfmLog(QString("WaveInReader opened: device='%1' rate=%2 ch=%3 bits=%4")
+/*     wfmLog(QString("WaveInReader opened: device='%1' rate=%2 ch=%3 bits=%4")
            .arg(m_deviceName).arg(sampleRate).arg(channels).arg(bitsPerSample));
-    return true;
+    return true; */
 }
 
 void WaveInReader::close()
@@ -119,7 +112,6 @@ void WaveInReader::close()
         CloseHandle(m_captureEvent);
         m_captureEvent = nullptr;
     }
-    wfmLog("WaveInReader closed");
 }
 
 // static

--- a/src/core/WaveInReader.h
+++ b/src/core/WaveInReader.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QObject>
+#include <QByteArray>
+#include <QString>
+#include <QMutex>
+#include <windows.h>
+#include <mmsystem.h>
+
+namespace AetherSDR {
+
+// Reads PCM audio from a Windows waveIn (recording) device using a
+// dedicated capture thread.  Intended use: SmartSDR DAX IQ devices
+// (e.g. "DAX IQ RX 1") which deliver stereo audio where L=I and R=Q.
+class WaveInReader : public QObject {
+    Q_OBJECT
+
+public:
+    explicit WaveInReader(QObject* parent = nullptr);
+    ~WaveInReader() override;
+
+    bool open(const QString& deviceNameFragment, int sampleRate = 48000,
+              int channels = 2, int bitsPerSample = 16);
+    void close();
+    bool isOpen() const { return m_hWaveIn != nullptr; }
+
+    QString deviceName() const { return m_deviceName; }
+
+    void captureLoop();  // called by capture thread — do not call directly
+
+signals:
+    // Stereo Int16 PCM: for IQ streams, L channel = I, R channel = Q.
+    void pcmReady(const QByteArray& pcm);
+
+private:
+    static constexpr int NUM_BUFS    = 8;
+    static constexpr int BUF_SAMPLES = 512;
+
+    static DWORD WINAPI captureThreadProc(LPVOID param);
+
+    HWAVEIN    m_hWaveIn{nullptr};
+    HANDLE     m_captureEvent{nullptr};
+    HANDLE     m_captureThread{nullptr};
+    volatile bool m_running{false};
+
+    WAVEHDR    m_headers[NUM_BUFS]{};
+    QByteArray m_buffers[NUM_BUFS];
+    int        m_bytesPerBuf{0};
+    QString    m_deviceName;
+};
+
+} // namespace AetherSDR

--- a/src/core/WaveOutWriter.cpp
+++ b/src/core/WaveOutWriter.cpp
@@ -1,0 +1,172 @@
+#include "WaveOutWriter.h"
+#include <QFile>
+#include <QTextStream>
+#include <algorithm>
+#include <cstring>
+
+static void wfmLog(const QString& msg)
+{
+    QFile f("C:/Users/reigc/wfm_debug.txt");
+    if (f.open(QIODevice::Append | QIODevice::Text))
+        QTextStream(&f) << msg << "\n";
+}
+
+namespace AetherSDR {
+
+WaveOutWriter::WaveOutWriter(QObject* parent)
+    : QObject(parent)
+{}
+
+WaveOutWriter::~WaveOutWriter()
+{
+    close();
+}
+
+bool WaveOutWriter::open(const QString& deviceNameFragment, int sampleRate,
+                          int channels, int bitsPerSample)
+{
+    close();
+
+    // Find matching waveOut device
+    const UINT numDevs = waveOutGetNumDevs();
+    UINT       devId   = WAVE_MAPPER;
+    {
+        QString allDevs;
+        for (UINT i = 0; i < numDevs; ++i) {
+            WAVEOUTCAPSW caps{};
+            if (waveOutGetDevCapsW(i, &caps, sizeof(caps)) == MMSYSERR_NOERROR) {
+                const QString name = QString::fromWCharArray(caps.szPname);
+                allDevs += QString("  [%1] %2\n").arg(i).arg(name);
+                if (m_deviceName.isEmpty()
+                        && name.contains(deviceNameFragment, Qt::CaseInsensitive)) {
+                    devId = i;
+                    m_deviceName = name;
+                }
+            }
+        }
+        wfmLog(QString("WaveOutWriter::open looking for '%1' among %2 devices:\n%3")
+               .arg(deviceNameFragment).arg(numDevs).arg(allDevs.trimmed()));
+    }
+    // Fail explicitly if the named device wasn't found — don't fall back to
+    // WAVE_MAPPER (which would silently route audio to the default speakers).
+    if (!deviceNameFragment.isEmpty() && m_deviceName.isEmpty()) {
+        wfmLog(QString("WaveOutWriter::open: '%1' not found — aborting").arg(deviceNameFragment));
+        return false;
+    }
+    if (m_deviceName.isEmpty())
+        m_deviceName = "(default)";
+
+    WAVEFORMATEX wfx{};
+    wfx.wFormatTag      = WAVE_FORMAT_PCM;
+    wfx.nChannels       = static_cast<WORD>(channels);
+    wfx.nSamplesPerSec  = static_cast<DWORD>(sampleRate);
+    wfx.wBitsPerSample  = static_cast<WORD>(bitsPerSample);
+    wfx.nBlockAlign     = wfx.nChannels * (wfx.wBitsPerSample / 8);
+    wfx.nAvgBytesPerSec = wfx.nSamplesPerSec * wfx.nBlockAlign;
+
+    // Create event — waveOut signals it every time a buffer completes (WOM_DONE)
+    m_refillEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
+
+    const MMRESULT res = waveOutOpen(&m_hWaveOut, devId, &wfx,
+                                     reinterpret_cast<DWORD_PTR>(m_refillEvent),
+                                     0, CALLBACK_EVENT);
+    if (res != MMSYSERR_NOERROR) {
+        wfmLog(QString("waveOutOpen failed: %1").arg(res));
+        CloseHandle(m_refillEvent);
+        m_refillEvent = nullptr;
+        m_hWaveOut    = nullptr;
+        return false;
+    }
+
+    // Prepare buffers
+    m_bytesPerBuf = BUF_SAMPLES * channels * (bitsPerSample / 8);
+    for (int i = 0; i < NUM_BUFS; ++i) {
+        m_buffers[i].resize(m_bytesPerBuf, 0);
+        auto& hdr = m_headers[i];
+        std::memset(&hdr, 0, sizeof(hdr));
+        hdr.lpData         = m_buffers[i].data();
+        hdr.dwBufferLength = static_cast<DWORD>(m_bytesPerBuf);
+        waveOutPrepareHeader(m_hWaveOut, &hdr, sizeof(hdr));
+        // Pre-queue silence so driver is always playing something
+        waveOutWrite(m_hWaveOut, &hdr, sizeof(hdr));
+    }
+
+    // Start refill thread
+    m_running      = true;
+    m_refillThread = CreateThread(NULL, 0, refillThreadProc, this, 0, NULL);
+    SetThreadPriority(m_refillThread, THREAD_PRIORITY_ABOVE_NORMAL);
+
+    wfmLog(QString("WaveOutWriter opened: device='%1' rate=%2 ch=%3 bits=%4 bufBytes=%5")
+           .arg(m_deviceName).arg(sampleRate).arg(channels).arg(bitsPerSample).arg(m_bytesPerBuf));
+    return true;
+}
+
+void WaveOutWriter::close()
+{
+    if (!m_hWaveOut) return;
+
+    m_running = false;
+    if (m_refillEvent) SetEvent(m_refillEvent);  // wake thread so it can exit
+    if (m_refillThread) {
+        WaitForSingleObject(m_refillThread, 2000);
+        CloseHandle(m_refillThread);
+        m_refillThread = nullptr;
+    }
+
+    waveOutReset(m_hWaveOut);
+    for (int i = 0; i < NUM_BUFS; ++i)
+        waveOutUnprepareHeader(m_hWaveOut, &m_headers[i], sizeof(m_headers[i]));
+    waveOutClose(m_hWaveOut);
+    m_hWaveOut = nullptr;
+
+    if (m_refillEvent) {
+        CloseHandle(m_refillEvent);
+        m_refillEvent = nullptr;
+    }
+
+    m_pending.clear();
+    wfmLog("WaveOutWriter closed");
+}
+
+void WaveOutWriter::write(const QByteArray& pcm)
+{
+    QMutexLocker lock(&m_mutex);
+    m_pending.append(pcm);
+}
+
+// static
+DWORD WINAPI WaveOutWriter::refillThreadProc(LPVOID param)
+{
+    WaveOutWriter* w = reinterpret_cast<WaveOutWriter*>(param);
+    while (w->m_running) {
+        // Wait for WOM_DONE event (or close signal)
+        WaitForSingleObject(w->m_refillEvent, 50);
+        if (w->m_running)
+            w->refillDoneBuffers();
+    }
+    return 0;
+}
+
+void WaveOutWriter::refillDoneBuffers()
+{
+    for (int i = 0; i < NUM_BUFS; ++i) {
+        auto& hdr = m_headers[i];
+        if (!(hdr.dwFlags & WHDR_DONE)) continue;
+
+        {
+            QMutexLocker lock(&m_mutex);
+            if (m_pending.size() >= m_bytesPerBuf) {
+                std::memcpy(m_buffers[i].data(), m_pending.constData(), m_bytesPerBuf);
+                m_pending.remove(0, m_bytesPerBuf);
+            } else {
+                // No real audio ready — queue silence to keep driver busy
+                std::memset(m_buffers[i].data(), 0, m_bytesPerBuf);
+            }
+        }
+
+        hdr.dwFlags &= ~WHDR_DONE;
+        waveOutWrite(m_hWaveOut, &hdr, sizeof(hdr));
+    }
+}
+
+} // namespace AetherSDR

--- a/src/core/WaveOutWriter.cpp
+++ b/src/core/WaveOutWriter.cpp
@@ -4,12 +4,6 @@
 #include <algorithm>
 #include <cstring>
 
-static void wfmLog(const QString& msg)
-{
-    QFile f("C:/Users/reigc/wfm_debug.txt");
-    if (f.open(QIODevice::Append | QIODevice::Text))
-        QTextStream(&f) << msg << "\n";
-}
 
 namespace AetherSDR {
 
@@ -44,15 +38,15 @@ bool WaveOutWriter::open(const QString& deviceNameFragment, int sampleRate,
                 }
             }
         }
-        wfmLog(QString("WaveOutWriter::open looking for '%1' among %2 devices:\n%3")
-               .arg(deviceNameFragment).arg(numDevs).arg(allDevs.trimmed()));
     }
+
     // Fail explicitly if the named device wasn't found — don't fall back to
     // WAVE_MAPPER (which would silently route audio to the default speakers).
-    if (!deviceNameFragment.isEmpty() && m_deviceName.isEmpty()) {
+/*     if (!deviceNameFragment.isEmpty() && m_deviceName.isEmpty()) {
         wfmLog(QString("WaveOutWriter::open: '%1' not found — aborting").arg(deviceNameFragment));
         return false;
-    }
+    } */
+
     if (m_deviceName.isEmpty())
         m_deviceName = "(default)";
 
@@ -71,7 +65,6 @@ bool WaveOutWriter::open(const QString& deviceNameFragment, int sampleRate,
                                      reinterpret_cast<DWORD_PTR>(m_refillEvent),
                                      0, CALLBACK_EVENT);
     if (res != MMSYSERR_NOERROR) {
-        wfmLog(QString("waveOutOpen failed: %1").arg(res));
         CloseHandle(m_refillEvent);
         m_refillEvent = nullptr;
         m_hWaveOut    = nullptr;
@@ -95,9 +88,6 @@ bool WaveOutWriter::open(const QString& deviceNameFragment, int sampleRate,
     m_running      = true;
     m_refillThread = CreateThread(NULL, 0, refillThreadProc, this, 0, NULL);
     SetThreadPriority(m_refillThread, THREAD_PRIORITY_ABOVE_NORMAL);
-
-    wfmLog(QString("WaveOutWriter opened: device='%1' rate=%2 ch=%3 bits=%4 bufBytes=%5")
-           .arg(m_deviceName).arg(sampleRate).arg(channels).arg(bitsPerSample).arg(m_bytesPerBuf));
     return true;
 }
 
@@ -125,7 +115,6 @@ void WaveOutWriter::close()
     }
 
     m_pending.clear();
-    wfmLog("WaveOutWriter closed");
 }
 
 void WaveOutWriter::write(const QByteArray& pcm)

--- a/src/core/WaveOutWriter.h
+++ b/src/core/WaveOutWriter.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <QObject>
+#include <QByteArray>
+#include <QString>
+#include <QMutex>
+#include <windows.h>
+#include <mmsystem.h>
+
+namespace AetherSDR {
+
+// Writes PCM audio to a Windows waveOut device using a dedicated refill thread.
+// When each buffer finishes playing, the thread immediately re-queues it with
+// real audio (from the ring) or silence — the queue is NEVER empty.
+//
+// sampleRate   : 48000
+// channels     : 2 (stereo)
+// bitsPerSample: 16 (Int16)
+class WaveOutWriter : public QObject {
+    Q_OBJECT
+
+public:
+    explicit WaveOutWriter(QObject* parent = nullptr);
+    ~WaveOutWriter() override;
+
+    bool open(const QString& deviceNameFragment, int sampleRate = 48000,
+              int channels = 2, int bitsPerSample = 16);
+    void close();
+    bool isOpen() const { return m_hWaveOut != nullptr; }
+
+    // Push PCM bytes from the IQ processing thread (thread-safe).
+    void write(const QByteArray& pcm);
+
+    QString deviceName() const { return m_deviceName; }
+
+    // Called by the refill thread — do not call directly.
+    void refillDoneBuffers();
+
+private:
+    static constexpr int NUM_BUFS    = 8;    // rotating buffers
+    static constexpr int BUF_SAMPLES = 512;  // 10 ms at 48 kHz
+
+    static DWORD WINAPI refillThreadProc(LPVOID param);
+
+    HWAVEOUT   m_hWaveOut{nullptr};
+    HANDLE     m_refillEvent{nullptr};
+    HANDLE     m_refillThread{nullptr};
+    volatile bool m_running{false};
+
+    WAVEHDR    m_headers[NUM_BUFS]{};
+    QByteArray m_buffers[NUM_BUFS];
+    int        m_bytesPerBuf{0};
+
+    QByteArray m_pending;
+    QMutex     m_mutex;
+    QString    m_deviceName;
+};
+
+} // namespace AetherSDR

--- a/src/core/WfmDemodulator.cpp
+++ b/src/core/WfmDemodulator.cpp
@@ -8,12 +8,6 @@
 #include <algorithm>
 #include <cmath>
 
-static void wfmLog(const QString& msg)
-{
-    QFile f("C:/Users/reigc/wfm_debug.txt");
-    if (f.open(QIODevice::Append | QIODevice::Text))
-        QTextStream(&f) << msg << "\n";
-}
 
 namespace AetherSDR {
 
@@ -45,12 +39,9 @@ void WfmDemodulator::start(DaxIqModel* daxIq, const QString& audioDevice,
     const float step = -2.0f * static_cast<float>(M_PI) * freqOffsetHz / IQ_RATE;
     m_corrCosStep = std::cos(step);
     m_corrSinStep = std::sin(step);
-    wfmLog(QString("WfmDemodulator::start device='%1' freqOffsetHz=%2")
-           .arg(audioDevice).arg(freqOffsetHz, 0, 'f', 1));
-
     m_waveOut = new WaveOutWriter(this);
+
     if (!m_waveOut->open(audioDevice, AUDIO_RATE, 2, 16)) {
-        wfmLog("WfmDemodulator: failed to open audio device: " + audioDevice);
         delete m_waveOut;
         m_waveOut = nullptr;
         return;
@@ -67,14 +58,12 @@ void WfmDemodulator::start(DaxIqModel* daxIq, const QString& audioDevice,
         m_usingWaveIn = true;
         connect(m_waveIn, &WaveInReader::pcmReady,
                 this, &WfmDemodulator::onDaxIqPcm);
-        wfmLog(QString("WfmDemodulator: using waveIn path '%1'").arg(m_waveIn->deviceName()));
     } else {
         // Fall back to VITA-49 DaxIqModel path
         delete m_waveIn;
         m_waveIn = nullptr;
         connect(m_daxIq, &DaxIqModel::iqSamplesReady, this, &WfmDemodulator::onIqSamples);
         connect(m_daxIq, &DaxIqModel::streamChanged,   this, &WfmDemodulator::onStreamChanged);
-        wfmLog(QString("WfmDemodulator::start panId='%1' (VITA-49 fallback)").arg(m_panId));
         m_daxIq->createStream(DAX_CHANNEL);
     }
 
@@ -107,15 +96,10 @@ void WfmDemodulator::stop()
 void WfmDemodulator::onStreamChanged(int channel)
 {
     const auto& s = m_daxIq->stream(DAX_CHANNEL);
-    wfmLog(QString("onStreamChanged: ch=%1 panSent=%2 panId='%3' exists=%4 active=%5 streamId=0x%6")
-           .arg(channel).arg(m_panSent).arg(m_panId)
-           .arg(s.exists).arg(s.active)
-           .arg(s.streamId, 0, 16));
     if (channel != DAX_CHANNEL || m_panSent || m_panId.isEmpty()) return;
     if (!s.exists || s.streamId == 0) return;
     const QString cmd = QString("stream set 0x%1 pan=%2")
                         .arg(s.streamId, 0, 16).arg(m_panId);
-    wfmLog(QString("onStreamChanged: sending '%1'").arg(cmd));
     emit commandReady(cmd);
     m_panSent = true;
 }
@@ -211,10 +195,6 @@ void WfmDemodulator::processSamples(const QVector<float>& iqInterleaved)
         }
         iqRms    = std::sqrt(iqRms / numSamples);
         audioRms = std::sqrt(audioRms / numSamples);
-        wfmLog(QString("blk#%1 IQ_rms=%2 audio_rms=%3 audio_max=%4 path=%5")
-               .arg(s_blk).arg(iqRms,0,'f',6)
-               .arg(audioRms,0,'f',4).arg(audioMax,0,'f',4)
-               .arg(m_usingWaveIn ? "waveIn" : "vita49"));
     }
 
     m_waveOut->write(pcm);

--- a/src/core/WfmDemodulator.cpp
+++ b/src/core/WfmDemodulator.cpp
@@ -1,0 +1,223 @@
+#include "WfmDemodulator.h"
+#include "WaveOutWriter.h"
+#include "WaveInReader.h"
+#include "models/DaxIqModel.h"
+
+#include <QFile>
+#include <QTextStream>
+#include <algorithm>
+#include <cmath>
+
+static void wfmLog(const QString& msg)
+{
+    QFile f("C:/Users/reigc/wfm_debug.txt");
+    if (f.open(QIODevice::Append | QIODevice::Text))
+        QTextStream(&f) << msg << "\n";
+}
+
+namespace AetherSDR {
+
+WfmDemodulator::WfmDemodulator(QObject* parent)
+    : QObject(parent)
+{}
+
+WfmDemodulator::~WfmDemodulator()
+{
+    stop();
+}
+
+void WfmDemodulator::start(DaxIqModel* daxIq, const QString& audioDevice,
+                           const QString& panId, float freqOffsetHz)
+{
+    if (m_active) stop();
+
+    m_daxIq       = daxIq;
+    m_prevI       = 0.0f;
+    m_prevQ       = 0.0f;
+    m_corrCos     = 1.0f;
+    m_corrSin     = 0.0f;
+    m_panId       = panId;
+    m_panSent     = false;
+    m_usingWaveIn = false;
+
+    // Pre-compute the per-sample rotation for frequency correction.
+    // The shift is NEGATIVE to move the signal down to DC.
+    const float step = -2.0f * static_cast<float>(M_PI) * freqOffsetHz / IQ_RATE;
+    m_corrCosStep = std::cos(step);
+    m_corrSinStep = std::sin(step);
+    wfmLog(QString("WfmDemodulator::start device='%1' freqOffsetHz=%2")
+           .arg(audioDevice).arg(freqOffsetHz, 0, 'f', 1));
+
+    m_waveOut = new WaveOutWriter(this);
+    if (!m_waveOut->open(audioDevice, AUDIO_RATE, 2, 16)) {
+        wfmLog("WfmDemodulator: failed to open audio device: " + audioDevice);
+        delete m_waveOut;
+        m_waveOut = nullptr;
+        return;
+    }
+
+    // Try SmartSDR DAX waveIn IQ device first (primary path on Windows with DAX).
+    // SmartSDR DAX delivers IQ as stereo audio: L=I, R=Q at the configured IQ rate.
+    m_waveIn = new WaveInReader(this);
+    bool daxOk = m_waveIn->open("DAX IQ RX 1", IQ_RATE, 2, 16);
+    if (!daxOk) daxOk = m_waveIn->open("DAX RESERVED IQ RX 1", IQ_RATE, 2, 16);
+    if (!daxOk) daxOk = m_waveIn->open("DAX IQ", IQ_RATE, 2, 16);
+
+    if (daxOk) {
+        m_usingWaveIn = true;
+        connect(m_waveIn, &WaveInReader::pcmReady,
+                this, &WfmDemodulator::onDaxIqPcm);
+        wfmLog(QString("WfmDemodulator: using waveIn path '%1'").arg(m_waveIn->deviceName()));
+    } else {
+        // Fall back to VITA-49 DaxIqModel path
+        delete m_waveIn;
+        m_waveIn = nullptr;
+        connect(m_daxIq, &DaxIqModel::iqSamplesReady, this, &WfmDemodulator::onIqSamples);
+        connect(m_daxIq, &DaxIqModel::streamChanged,   this, &WfmDemodulator::onStreamChanged);
+        wfmLog(QString("WfmDemodulator::start panId='%1' (VITA-49 fallback)").arg(m_panId));
+        m_daxIq->createStream(DAX_CHANNEL);
+    }
+
+    m_active = true;
+}
+
+void WfmDemodulator::stop()
+{
+    if (!m_active) return;
+    m_active = false;
+
+    if (m_waveIn) {
+        m_waveIn->close();
+        delete m_waveIn;
+        m_waveIn = nullptr;
+    }
+    if (m_daxIq) {
+        if (!m_usingWaveIn)
+            m_daxIq->removeStream(DAX_CHANNEL);
+        disconnect(m_daxIq, nullptr, this, nullptr);
+        m_daxIq = nullptr;
+    }
+    if (m_waveOut) {
+        m_waveOut->close();
+        delete m_waveOut;
+        m_waveOut = nullptr;
+    }
+}
+
+void WfmDemodulator::onStreamChanged(int channel)
+{
+    const auto& s = m_daxIq->stream(DAX_CHANNEL);
+    wfmLog(QString("onStreamChanged: ch=%1 panSent=%2 panId='%3' exists=%4 active=%5 streamId=0x%6")
+           .arg(channel).arg(m_panSent).arg(m_panId)
+           .arg(s.exists).arg(s.active)
+           .arg(s.streamId, 0, 16));
+    if (channel != DAX_CHANNEL || m_panSent || m_panId.isEmpty()) return;
+    if (!s.exists || s.streamId == 0) return;
+    const QString cmd = QString("stream set 0x%1 pan=%2")
+                        .arg(s.streamId, 0, 16).arg(m_panId);
+    wfmLog(QString("onStreamChanged: sending '%1'").arg(cmd));
+    emit commandReady(cmd);
+    m_panSent = true;
+}
+
+// Primary IQ path: SmartSDR DAX waveIn (stereo Int16, L=I, R=Q)
+void WfmDemodulator::onDaxIqPcm(const QByteArray& pcm)
+{
+    if (!m_active || !m_waveOut) return;
+    const int numSamples = pcm.size() / (2 * sizeof(qint16));
+    if (numSamples <= 0) return;
+
+    const auto* src = reinterpret_cast<const qint16*>(pcm.constData());
+    QVector<float> iq(numSamples * 2);
+    for (int i = 0; i < numSamples; ++i) {
+        iq[2*i]   = src[2*i]   / 32768.0f;   // I = left channel
+        iq[2*i+1] = src[2*i+1] / 32768.0f;   // Q = right channel
+    }
+    processSamples(iq);
+}
+
+// Fallback IQ path: VITA-49 DaxIqModel
+void WfmDemodulator::onIqSamples(int channel, QVector<float> iqInterleaved, int /*sampleRate*/)
+{
+    if (channel != DAX_CHANNEL || !m_active || !m_waveOut) return;
+    processSamples(iqInterleaved);
+}
+
+void WfmDemodulator::processSamples(const QVector<float>& iqInterleaved)
+{
+    const int numSamples = iqInterleaved.size() / 2;
+    if (numSamples <= 0) return;
+
+    QByteArray pcm(numSamples * 2 * sizeof(qint16), Qt::Uninitialized);
+    auto* out = reinterpret_cast<qint16*>(pcm.data());
+
+    float prevI = m_prevI;
+    float prevQ = m_prevQ;
+
+    for (int i = 0; i < numSamples; ++i) {
+        float I = iqInterleaved[2 * i];
+        float Q = iqInterleaved[2 * i + 1];
+
+        // Frequency correction: rotate IQ by the running phasor to center
+        // the signal at DC (removes the panadapter→slice frequency offset).
+        {
+            const float Ic = I * m_corrCos - Q * m_corrSin;
+            const float Qc = I * m_corrSin + Q * m_corrCos;
+            I = Ic;  Q = Qc;
+            // Advance phasor (numerically stable incremental rotation)
+            const float newCos = m_corrCos * m_corrCosStep - m_corrSin * m_corrSinStep;
+            const float newSin = m_corrCos * m_corrSinStep + m_corrSin * m_corrCosStep;
+            // Renormalize every 4096 samples to prevent drift
+            m_corrCos = newCos;
+            m_corrSin = newSin;
+        }
+
+        const float amp = std::sqrt(I * I + Q * Q);
+        if (amp > 1e-9f) { I /= amp; Q /= amp; }
+        else              { I = prevI; Q = prevQ; }
+
+        const float cross = I * prevQ - Q * prevI;
+        const float dot   = I * prevI + Q * prevQ;
+        float audio = std::atan2(cross, dot) * (GAIN / static_cast<float>(M_PI));
+        audio = std::max(-1.0f, std::min(1.0f, audio));
+
+        prevI = I;
+        prevQ = Q;
+
+        const qint16 s16 = static_cast<qint16>(audio * 32767.0f * m_volume);
+        out[i * 2]     = s16;
+        out[i * 2 + 1] = s16;
+    }
+
+    m_prevI = prevI;
+    m_prevQ = prevQ;
+
+    // Renormalize frequency-correction phasor every block to prevent drift
+    {
+        const float norm = std::sqrt(m_corrCos * m_corrCos + m_corrSin * m_corrSin);
+        if (norm > 1e-9f) { m_corrCos /= norm; m_corrSin /= norm; }
+    }
+
+    static int s_blk = 0;
+    ++s_blk;
+    if (s_blk % 100 == 0) {
+        float iqRms = 0, audioRms = 0, audioMax = 0;
+        for (int i = 0; i < numSamples; ++i) {
+            const float rI = iqInterleaved[2*i], rQ = iqInterleaved[2*i+1];
+            iqRms += rI*rI + rQ*rQ;
+            const float a = std::abs(reinterpret_cast<const qint16*>(pcm.constData())[i*2] / 32767.0f);
+            audioRms += a*a;
+            if (a > audioMax) audioMax = a;
+        }
+        iqRms    = std::sqrt(iqRms / numSamples);
+        audioRms = std::sqrt(audioRms / numSamples);
+        wfmLog(QString("blk#%1 IQ_rms=%2 audio_rms=%3 audio_max=%4 path=%5")
+               .arg(s_blk).arg(iqRms,0,'f',6)
+               .arg(audioRms,0,'f',4).arg(audioMax,0,'f',4)
+               .arg(m_usingWaveIn ? "waveIn" : "vita49"));
+    }
+
+    m_waveOut->write(pcm);
+}
+
+} // namespace AetherSDR

--- a/src/core/WfmDemodulator.h
+++ b/src/core/WfmDemodulator.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <QObject>
+#include <QVector>
+#include <QByteArray>
+#include <algorithm>
+
+namespace AetherSDR {
+
+class DaxIqModel;
+class WaveOutWriter;
+class WaveInReader;
+
+// Software FM demodulator for satellite work (G3RUH 9600 baud, hs-soundmodem).
+// Uses a phase-difference (atan2) discriminator.
+//
+// IQ source     : SmartSDR DAX waveIn device (e.g. "DAX IQ RX 1") at 48 kHz
+//                 stereo Int16 (L=I, R=Q).  Falls back to VITA-49 DaxIqModel
+//                 if the DAX waveIn device is not found.
+// IF bandwidth  : ±20 kHz slice filter
+// Audio output  : 48 kHz, stereo, Int16 → Hi-Fi Cable Input
+// Gain          : G3RUH ±4.8 kHz deviation → ~60 % full scale
+class WfmDemodulator : public QObject {
+    Q_OBJECT
+
+public:
+    static constexpr int   DAX_CHANNEL = 1;
+    static constexpr int   IQ_RATE     = 48000;
+    static constexpr int   AUDIO_RATE  = 48000;
+    static constexpr int   FILTER_HZ   = 20000;
+    static constexpr float GAIN        = 1.0f;
+
+    explicit WfmDemodulator(QObject* parent = nullptr);
+    ~WfmDemodulator() override;
+
+    // audioDevice : full waveOut device name (e.g. "Hi-Fi Cable Input (VB-Audio Hi-Fi Cable)").
+    //               Passed straight to WaveOutWriter::open() which does a case-insensitive
+    //               contains() match, so a partial name also works.
+    // panId       : panadapter ID string ("0x40000000")
+    // freqOffsetHz: slice_frequency_hz − panadapter_center_hz
+    //   Applied as a complex frequency shift so the IQ is centered at the
+    //   satellite frequency before FM discrimination.
+    void start(DaxIqModel* daxIq, const QString& audioDevice,
+               const QString& panId = QString(), float freqOffsetHz = 0.0f);
+    void stop();
+    bool isActive() const { return m_active; }
+
+    // Volume 0–100 (maps linearly to 0.0–1.0 amplitude scale).
+    void setVolume(int pct) { m_volume = std::clamp(pct / 100.0f, 0.0f, 1.0f); }
+
+signals:
+    void commandReady(const QString& cmd);
+
+public slots:
+    // Called from WaveInReader (primary path when SmartSDR DAX is running)
+    void onDaxIqPcm(const QByteArray& pcm);
+    // Called from DaxIqModel VITA-49 path (fallback when no DAX waveIn found)
+    void onIqSamples(int channel, QVector<float> iqInterleaved, int sampleRate);
+    void onStreamChanged(int channel);
+
+private:
+    void processSamples(const QVector<float>& iqInterleaved);
+
+    DaxIqModel*    m_daxIq{nullptr};
+    WaveInReader*  m_waveIn{nullptr};   // SmartSDR DAX IQ waveIn path
+    WaveOutWriter* m_waveOut{nullptr};
+    bool           m_active{false};
+    bool           m_usingWaveIn{false};
+    float          m_volume{1.0f};
+    // Frequency-correction oscillator (centers IQ at slice frequency)
+    float          m_corrCos{1.0f};  // running phasor, real part
+    float          m_corrSin{0.0f};  // running phasor, imag part
+    float          m_corrCosStep{1.0f};  // per-sample rotation
+    float          m_corrSinStep{0.0f};
+    float          m_prevI{0.0f};
+    float          m_prevQ{0.0f};
+    float          m_agcGain{1.0f};
+    QString        m_panId;
+    bool           m_panSent{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -190,6 +190,9 @@
 #ifdef HAVE_RADE
 #include "core/RADEEngine.h"
 #endif
+#include "core/WfmDemodulator.h"
+#include "core/PanadapterStream.h"
+#include "gui/WfmDeviceDialog.h"
 #if defined(Q_OS_MAC)
 #include "core/VirtualAudioBridge.h"
 #include <QFileInfo>
@@ -3308,6 +3311,11 @@ MainWindow::MainWindow(QWidget* parent)
         else if (sliceId == m_radeSliceId) deactivateRADE();
     });
 #endif
+    connect(m_appletPanel->rxApplet(), &RxApplet::wfmActivated,
+            this, [this](bool on, int sliceId) {
+        if (on) activateWFM(sliceId);
+        else    deactivateWFM();
+    });
 
     // ── Tuning step size ───────────────────────────────────────────────────
     // Two connections, split by source.  stepSizeChanged fires for ANY step
@@ -3365,6 +3373,10 @@ MainWindow::MainWindow(QWidget* parent)
             m_appletPanel, &AppletPanel::setAntennaList);
     // Overlay-menu antenna wiring is now per-pan in wirePanadapter() (#1260).
     // Antenna list and S-meter are now wired per-widget in onSliceAdded.
+
+    // ── Title bar: Pan Follow ────────────────────────────────────────────────
+    connect(m_titleBar, &TitleBar::panFollowToggled,
+            this, &MainWindow::setPanFollow);
 
     // ── Title bar: PC Audio, master volume, headphone volume ────────────────
     // The remote_audio_rx stream controls the radio's audio routing:
@@ -13712,6 +13724,10 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
         else if (sliceId == m_radeSliceId) deactivateRADE();
     });
 #endif
+    connect(w, &VfoWidget::wfmActivated, this, [this](bool on, int sliceId) {
+        if (on) activateWFM(sliceId);
+        else    deactivateWFM();
+    });
 
     // AetherDSP button on the per-slice DSP tab — same entry point as the
     // Settings menu action and the RX chain double-click; reuses the
@@ -17861,6 +17877,153 @@ void MainWindow::onSpectrumReadyForSHistory(quint32 streamId, const QVector<floa
             PerfTelemetry::instance().recordSHistorySkipped();
         }
     }
+}
+
+// ─── WFM software demodulator ────────────────────────────────────────────────
+
+void MainWindow::activateWFM(int sliceId)
+{
+    if (m_wfmSliceId == sliceId) return;
+    deactivateWFM();
+
+    m_wfmCooldown = true;
+    QTimer::singleShot(1000, this, [this]{ m_wfmCooldown = false; });
+
+    auto* s = m_radioModel.slice(sliceId);
+    if (!s) return;
+
+    // Resolve audio output device FIRST — before touching the radio or
+    // establishing any connections.  The dialog can take several seconds and
+    // any pan/filter commands sent while it is open would race with SatPC32's
+    // Doppler corrections on port 4992.
+    auto resolveAudioDevice = [this]() -> QString {
+        while (true) {
+            QString device = AppSettings::instance()
+                                 .value("WfmAudioDevice").toString().trimmed();
+            if (device.isEmpty()) {
+                WfmDeviceDialog dlg(this);
+                if (dlg.exec() != QDialog::Accepted || dlg.selectedDevice().isEmpty())
+                    return {};   // user cancelled
+                device = dlg.selectedDevice();
+                if (dlg.rememberChoice()) {
+                    AppSettings::instance().setValue("WfmAudioDevice", device);
+                    AppSettings::instance().save();
+                }
+            }
+            return device;
+        }
+    };
+
+    const QString audioDevice = resolveAudioDevice();
+    if (audioDevice.isEmpty()) {
+        // User cancelled the device picker — abort activation.
+        m_wfmSliceId = -1;
+        return;
+    }
+
+    // Device confirmed — now it is safe to interact with the radio.
+
+    // Save current filter so deactivateWFM can restore it.
+    m_wfmPrevFilterLo = s->filterLow();
+    m_wfmPrevFilterHi = s->filterHigh();
+
+    // Widen IF filter for G3RUH (±20 kHz).
+    s->setFilterWidth(-WfmDemodulator::FILTER_HZ, WfmDemodulator::FILTER_HZ);
+    m_wfmSliceId = sliceId;
+
+    // Center the panadapter on the slice frequency so the DAX IQ RX 1 is
+    // centered at the satellite signal.  Also follow slice frequency changes
+    // (Doppler tracking via CAT) so the pan stays locked to the signal.
+    // Guard: skip if the pan is already at the slice frequency — avoids sending
+    // redundant "display pan set" commands that could race against SmartSDR CAT's
+    // "slice tune" and briefly revert the Doppler correction via pan-locked tuning.
+    auto centerPanAtSlice = [this, s]() {
+        const QString panId = s->panId();
+        if (panId.isEmpty()) return;
+        const double freq = s->frequency();
+        auto* pan = m_radioModel.panadapter(panId);
+        if (pan && qFuzzyCompare(pan->centerMhz(), freq)) return;
+        const QString freqStr = QString::number(freq, 'f', 6);
+        if (pan) pan->applyPanStatus({{"center", freqStr}});
+        m_radioModel.sendCommand(
+            QString("display pan set %1 center=%2").arg(panId, freqStr));
+    };
+    centerPanAtSlice();
+    m_wfmFreqConn = connect(s, &SliceModel::frequencyChanged,
+                            this, [centerPanAtSlice](double) { centerPanAtSlice(); });
+
+    // Software FM demodulation: DAX IQ → discriminator → chosen VAC at 48 kHz.
+    // freqOffsetHz=0 because DAX IQ RX 1 is already centered at the slice
+    // frequency (not the panadapter center), so no correction is needed.
+    m_wfmDemod = new WfmDemodulator(this);
+    connect(m_wfmDemod, &WfmDemodulator::commandReady,
+            &m_radioModel, &RadioModel::sendCommand);
+    // Slice audio_level → WfmDemodulator volume. Connecting to the SliceModel
+    // covers all control paths (RxApplet slider, VfoWidget slider, CAT, etc.)
+    // rather than wiring individual UI sources.
+    m_wfmDemod->setVolume(static_cast<int>(s->audioGain()));
+    connect(s, &SliceModel::audioGainChanged,
+            m_wfmDemod, [demod = m_wfmDemod](float g) { demod->setVolume(static_cast<int>(g)); });
+    m_wfmDemod->start(&m_radioModel.daxIqModel(), audioDevice, s->panId(), 0.0f);
+    if (!m_wfmDemod->isActive()) {
+        // Saved device failed to open (driver missing, device unplugged, etc.).
+        // Clear the preference so the picker shows again on the next attempt.
+        AppSettings::instance().setValue("WfmAudioDevice", QString());
+        AppSettings::instance().save();
+        delete m_wfmDemod;
+        m_wfmDemod = nullptr;
+        m_wfmSliceId = -1;
+    }
+}
+
+void MainWindow::deactivateWFM()
+{
+    if (m_wfmSliceId < 0) return;
+    if (m_wfmCooldown) return;
+
+    disconnect(m_wfmFreqConn);
+
+    if (m_wfmDemod) {
+        delete m_wfmDemod;
+        m_wfmDemod = nullptr;
+    }
+
+    // Restore the filter that was active before WFM was enabled.
+    if (auto* s = m_radioModel.slice(m_wfmSliceId)) {
+        if (m_wfmPrevFilterLo != 0 || m_wfmPrevFilterHi != 0)
+            s->setFilterWidth(m_wfmPrevFilterLo, m_wfmPrevFilterHi);
+    }
+
+    m_wfmSliceId = -1;
+    m_wfmPrevFilterLo = 0;
+    m_wfmPrevFilterHi = 0;
+}
+
+// ─── Pan Follow ───────────────────────────────────────────────────────────────
+
+void MainWindow::setPanFollow(bool on)
+{
+    disconnect(m_panFollowConn);
+    if (!on) return;
+
+    auto* s = m_radioModel.slice(0);
+    if (!s) return;
+
+    auto centerPan = [this, s]() {
+        const QString panId = s->panId();
+        if (panId.isEmpty()) return;
+        const double freq = s->frequency();
+        auto* pan = m_radioModel.panadapter(panId);
+        if (pan && qFuzzyCompare(pan->centerMhz(), freq)) return;
+        const QString freqStr = QString::number(freq, 'f', 6);
+        if (pan) pan->applyPanStatus({{"center", freqStr}});
+        m_radioModel.sendCommand(
+            QString("display pan set %1 center=%2").arg(panId, freqStr));
+    };
+
+    centerPan();
+    m_panFollowConn = connect(s, &SliceModel::frequencyChanged,
+                              this, [centerPan](double) { centerPan(); });
 }
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -66,6 +66,7 @@ class QMediaDevices;
                                    // onEqCutoffsDragRequested signature.
 #include "gui/PersistentDialog.h" // showOrRaisePersistent template needs
                                    // PersistentDialog visible at point of use.
+#include "core/UlanziDialBackend.h"
 
 namespace AetherSDR {
 
@@ -93,18 +94,12 @@ class Ax25HfPacketDecodeDialog;
 class FlexControlDialog;
 class MidiMappingDialog;
 class UlanziDialMapperDialog;
-#ifdef Q_OS_LINUX
-class EvdevEncoderManager;
-#elif defined(Q_OS_WIN)
-class UlanziDialWindowsManager;
-#elif defined(Q_OS_MAC)
-class UlanziDialMacOSManager;
-#endif
 class CwxPanel;
 class DvkPanel;
 #ifdef HAVE_RADE
 class RADEEngine;
 #endif
+class WfmDemodulator;
 #if defined(Q_OS_MAC)
 class VirtualAudioBridge;
 using DaxBridge = VirtualAudioBridge;
@@ -556,13 +551,7 @@ private:
     QMetaObject::Connection m_sdRitConn;
     QMetaObject::Connection m_sdXitConn;
 #endif
-#ifdef Q_OS_LINUX
-    EvdevEncoderManager*       m_dialBackend{nullptr};
-#elif defined(Q_OS_WIN)
-    UlanziDialWindowsManager*  m_dialBackend{nullptr};
-#elif defined(Q_OS_MAC)
-    UlanziDialMacOSManager*    m_dialBackend{nullptr};
-#endif
+    UlanziDialBackend*         m_dialBackend{nullptr};
     QTimer                     m_dialCoalesceTimer;
     int                        m_dialPendingSteps{0};
 #ifdef HAVE_MIDI
@@ -849,6 +838,19 @@ private:
     void onFdvMeterUpdated(int index, float value);
     void onFdvMetersChanged();
 #endif
+
+    WfmDemodulator* m_wfmDemod{nullptr};
+    int             m_wfmSliceId{-1};
+    bool            m_wfmCooldown{false};
+    int             m_wfmPrevFilterLo{0};
+    int             m_wfmPrevFilterHi{0};
+    QMetaObject::Connection m_wfmFreqConn;
+    void activateWFM(int sliceId);
+    void deactivateWFM();
+
+    // Pan Follow — keeps the panadapter centered on Slice A frequency
+    QMetaObject::Connection m_panFollowConn;
+    void setPanFollow(bool on);
 
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
     DaxBridge* m_daxBridge{nullptr};

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -496,6 +496,11 @@ void RxApplet::buildUI()
                 this, [this](int) {
             if (m_modeCombo->signalsBlocked()) return;
             QString mode = m_modeCombo->currentText();
+            if (mode == "WFM") {
+                emit wfmActivated(true, m_slice ? m_slice->sliceId() : -1);
+                return;
+            }
+            emit wfmActivated(false, m_slice ? m_slice->sliceId() : -1);
 #ifdef HAVE_RADE
             if (mode == "RADE") {
                 emit radeActivated(true, m_slice ? m_slice->sliceId() : -1);
@@ -511,6 +516,24 @@ void RxApplet::buildUI()
             if (m_slice) m_slice->setMode(mode);
         });
         m_freqRow->addWidget(m_modeCombo);
+
+        m_wfmButton = new QPushButton("WFM");
+        m_wfmButton->setCheckable(true);
+        m_wfmButton->setFixedSize(36, 20);
+        m_wfmButton->setToolTip("Software FM demodulator via DAX IQ → Hi-Fi Cable");
+        m_wfmButton->setStyleSheet(
+            "QPushButton { background: #444; color: #ccc; border: 1px solid #666;"
+            " border-radius: 3px; font-size: 10px; font-weight: bold; padding: 0 2px; }"
+            "QPushButton:checked { background: #2a7; color: #fff; border-color: #2a7; }"
+            "QPushButton:hover { background: #555; }");
+        connect(m_wfmButton, &QPushButton::toggled, this, [this](bool on) {
+            if (on) {
+                emit wfmActivated(true, m_slice ? m_slice->sliceId() : -1);
+            } else {
+                emit wfmActivated(false, m_slice ? m_slice->sliceId() : -1);
+            }
+        });
+        m_freqRow->addWidget(m_wfmButton);
 
         m_freqStack = new QStackedWidget;
         m_freqStack->setFixedHeight(34);

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -130,6 +130,7 @@ signals:
     // Emitted when user selects/deselects RADE digital voice mode
     void radeActivated(bool on, int sliceId);
 #endif
+    void wfmActivated(bool on, int sliceId);
 
 public:
     void setInitialStepSize(int hz);
@@ -206,6 +207,7 @@ private:
     QHBoxLayout* m_freqRow{nullptr};       // frequency display row
     QPushButton* m_txBadge{nullptr};       // TX slice indicator (click to set as TX slice)
     QComboBox*   m_modeCombo{nullptr};     // mode selector (USB, LSB, CW, etc.)
+    QPushButton* m_wfmButton{nullptr};     // WFM software demodulator toggle
     QLabel*      m_freqLabel{nullptr};     // frequency readout e.g. "14.289.510"
     QLineEdit*   m_freqEdit{nullptr};
     QStackedWidget* m_freqStack{nullptr};

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -219,6 +219,34 @@ TitleBar::TitleBar(QWidget* parent)
     // ── PC Audio + Master Vol + HP Vol ──────────────────────────────────────
     auto& s = AppSettings::instance();
 
+    // Pan Follow toggle — keeps the panadapter centered on Slice A frequency
+    m_panFollowBtn = new QPushButton("Pan Lock");
+    m_panFollowBtn->setCheckable(true);
+    m_panFollowBtn->setChecked(false);
+    m_panFollowBtn->setFixedHeight(22);
+    m_panFollowBtn->setFixedWidth(70);
+    m_panFollowBtn->setAccessibleName("Pan follow slice");
+    m_panFollowBtn->setAccessibleDescription("Keep panadapter centered on Slice A frequency");
+    m_panFollowBtn->setToolTip("Pan Lock — keeps the panadapter centered on Slice A frequency (e.g. for Doppler tracking)");
+
+    auto updatePanFollowStyle = [this]() {
+        m_panFollowBtn->setStyleSheet(m_panFollowBtn->isChecked()
+            ? "QPushButton { background: #1e4a8a; color: #b0e8ff; border: 1px solid #4090d0; "
+              "border-radius: 3px; font-size: 10px; font-weight: bold; }"
+              "QPushButton:hover { background: #2558a0; }"
+            : "QPushButton { background: #1a2a3a; color: #607080; border: 1px solid #304050; "
+              "border-radius: 3px; font-size: 10px; font-weight: bold; }"
+              "QPushButton:hover { background: #243848; }");
+    };
+    updatePanFollowStyle();
+
+    connect(m_panFollowBtn, &QPushButton::toggled, this, [this, updatePanFollowStyle](bool on) {
+        updatePanFollowStyle();
+        emit panFollowToggled(on);
+    });
+    m_hbox->addWidget(m_panFollowBtn);
+    m_hbox->addSpacing(4);
+
     // PC Audio toggle
     m_pcBtn = new QPushButton("PC Audio");
     m_pcBtn->setCheckable(true);

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -52,6 +52,7 @@ public:
     bool isSystemMoveAreaAt(const QPoint& globalPos) const;
 
 signals:
+    void panFollowToggled(bool on);
     void pcAudioToggled(bool on);
     void masterVolumeChanged(int pct);
     void headphoneVolumeChanged(int pct);
@@ -87,6 +88,7 @@ private:
     QLabel*      m_appNameLabel{nullptr};
     QLabel*      m_otherTxLabel{nullptr};
     QPushButton* m_mfBtn{nullptr};
+    QPushButton* m_panFollowBtn{nullptr};
     QPushButton* m_pcBtn{nullptr};
     QPushButton* m_speakerBtn{nullptr};
     QPushButton* m_headphoneBtn{nullptr};

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1829,6 +1829,19 @@ void VfoWidget::buildTabContent()
 
             modeRow->addWidget(btn, 1);
         }
+
+        // WFM software demodulator toggle (DAX IQ → Hi-Fi Cable)
+        m_wfmBtn = new QPushButton("WFM");
+        m_wfmBtn->setCheckable(true);
+        m_wfmBtn->setFixedHeight(26);
+        m_wfmBtn->setVisible(false);
+        m_wfmBtn->setToolTip("Software FM demodulator: DAX IQ → Hi-Fi Cable Input");
+        m_wfmBtn->setStyleSheet(kModeBtn);
+        connect(m_wfmBtn, &QPushButton::toggled, this, [this](bool on) {
+            emit wfmActivated(on, m_slice ? m_slice->sliceId() : -1);
+        });
+        modeRow->addWidget(m_wfmBtn, 1);
+
         vb->addLayout(modeRow);
 
         // Filter preset grid (4 columns, rebuilt on mode change)
@@ -2700,6 +2713,12 @@ void VfoWidget::setSlice(SliceModel* slice)
         bool isFdv  = mode.startsWith("FDV");  // FDVU, FDVM, etc.
         // Swap DSP tab label to OPT for FM modes
         m_tabBtns[1]->setText(isFm ? "OPT" : "DSP");
+        if (!isFm && m_wfmBtn->isChecked()) {
+            QSignalBlocker sb(m_wfmBtn);
+            m_wfmBtn->setChecked(false);
+            emit wfmActivated(false, m_slice ? m_slice->sliceId() : -1);
+        }
+        m_wfmBtn->setVisible(isFm);
         m_rttyContainer->setVisible(isRtty);
         m_apfContainer->setVisible(isCw);
         m_digContainer->setVisible(isDig && !isFdv && mode != "NT");
@@ -3240,6 +3259,12 @@ void VfoWidget::syncFromSlice()
     bool isDig = (m_slice->mode() == "DIGL" || m_slice->mode() == "DIGU" || m_slice->mode() == "NT");
     bool isFm = (m_slice->mode() == "FM" || m_slice->mode() == "NFM");
     m_tabBtns[1]->setText(isFm ? "OPT" : "DSP");
+    if (!isFm && m_wfmBtn->isChecked()) {
+        QSignalBlocker sb(m_wfmBtn);
+        m_wfmBtn->setChecked(false);
+        emit wfmActivated(false, m_slice->sliceId());
+    }
+    m_wfmBtn->setVisible(isFm);
     m_apfBtn->setVisible(isCw);
     m_anfBtn->setVisible(!isRtty && !isCw && !isDig && !isFm);
     m_anflBtn->setVisible(!isRtty && !isCw && !isDig && !isFm);

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -108,6 +108,7 @@ Q_SIGNALS:
 #ifdef HAVE_RADE
     void radeActivated(bool on, int sliceId);
 #endif
+    void wfmActivated(bool on, int sliceId);
     void recordToggled(bool on);
     void playToggled(bool on);
     void aetherDspRequested();     // user clicked the ADSP button on the DSP tab
@@ -330,6 +331,7 @@ private:
     QComboBox* m_modeCombo{nullptr};
     QPushButton* m_quickModeBtns[3]{};
     QString      m_quickModeAssign[3];  // e.g. "USB", "CW", "SSB", "DIG"
+    QPushButton* m_wfmBtn{nullptr};
     void updateQuickModeButtons();
     QGridLayout* m_filterGrid{nullptr};
     QVector<QPushButton*> m_filterBtns;

--- a/src/gui/WfmDeviceDialog.cpp
+++ b/src/gui/WfmDeviceDialog.cpp
@@ -1,0 +1,129 @@
+#include "WfmDeviceDialog.h"
+
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QListWidget>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+#ifdef Q_OS_WIN
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <mmsystem.h>
+#endif
+
+namespace AetherSDR {
+
+// Keywords that identify virtual audio cable (VAC) devices.
+// A device is shown if its name contains ANY of these (case-insensitive).
+static const QStringList kVacKeywords = {
+    "cable",        // VB-Audio Virtual Cable, VB-Audio Hi-Fi Cable, Virtual Audio Cable
+    "virtual",      // Virtual Audio Cable (Muzychenko), various others
+    "vb-audio",     // VB-Audio branding
+    "voicemeeter",  // VB-Audio Voicemeeter family
+    "dante",        // Audinate Dante Virtual Soundcard
+    "loopback",     // Loopback (Rogue Amoeba), others
+    "jack",         // JACK Audio Connection Kit
+    "blackhole",    // BlackHole (macOS)
+    "soundflower",  // Soundflower (macOS)
+};
+
+static bool isVacDevice(const QString& name)
+{
+    const QString lower = name.toLower();
+    for (const QString& kw : kVacKeywords) {
+        if (lower.contains(kw))
+            return true;
+    }
+    return false;
+}
+
+WfmDeviceDialog::WfmDeviceDialog(QWidget* parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("WFM Audio Output Device"));
+    setMinimumWidth(400);
+
+    auto* vb = new QVBoxLayout(this);
+    vb->setSpacing(10);
+    vb->setContentsMargins(16, 16, 16, 12);
+
+    auto* lbl = new QLabel(
+        tr("Select the virtual audio cable (VAC) to receive the WFM demodulated audio.\n"
+           "Install VB-Audio Virtual Cable or similar if no device appears below."),
+        this);
+    lbl->setWordWrap(true);
+    vb->addWidget(lbl);
+
+    m_list = new QListWidget(this);
+    m_list->setAlternatingRowColors(true);
+
+    const QStringList devices = enumerateDevices();
+    for (const QString& name : devices)
+        m_list->addItem(name);
+
+    if (m_list->count() == 0) {
+        auto* noDevLbl = new QLabel(
+            tr("<i>No virtual audio cable found.<br>"
+               "Install <b>VB-Audio Virtual Cable</b> and restart AetherSDR.</i>"),
+            this);
+        noDevLbl->setWordWrap(true);
+        vb->addWidget(noDevLbl);
+    } else {
+        m_list->setCurrentRow(0);
+    }
+
+    vb->addWidget(m_list);
+
+    m_remember = new QCheckBox(tr("Remember this choice"), this);
+    m_remember->setChecked(true);
+    vb->addWidget(m_remember);
+
+    auto* btns = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    btns->button(QDialogButtonBox::Ok)->setEnabled(m_list->count() > 0);
+    connect(btns, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(btns, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(m_list, &QListWidget::itemSelectionChanged, this, [btns, this]() {
+        btns->button(QDialogButtonBox::Ok)->setEnabled(m_list->currentItem() != nullptr);
+    });
+    vb->addWidget(btns);
+
+    // Double-click confirms
+    connect(m_list, &QListWidget::itemDoubleClicked, this, &QDialog::accept);
+}
+
+QString WfmDeviceDialog::selectedDevice() const
+{
+    auto* item = m_list->currentItem();
+    return item ? item->text() : QString();
+}
+
+bool WfmDeviceDialog::rememberChoice() const
+{
+    return m_remember->isChecked();
+}
+
+// static
+QStringList WfmDeviceDialog::enumerateDevices()
+{
+    QStringList devices;
+
+#ifdef Q_OS_WIN
+    const UINT count = waveOutGetNumDevs();
+    for (UINT i = 0; i < count; ++i) {
+        WAVEOUTCAPSW caps{};
+        if (waveOutGetDevCapsW(i, &caps, sizeof(caps)) == MMSYSERR_NOERROR) {
+            const QString name = QString::fromWCharArray(caps.szPname);
+            if (isVacDevice(name))
+                devices << name;
+        }
+    }
+#endif
+
+    return devices;
+}
+
+} // namespace AetherSDR

--- a/src/gui/WfmDeviceDialog.h
+++ b/src/gui/WfmDeviceDialog.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QDialog>
+#include <QStringList>
+
+class QListWidget;
+class QCheckBox;
+class QLabel;
+
+namespace AetherSDR {
+
+// Dialog shown on the first WFM activation (or when no device is saved).
+// Enumerates available waveOut audio devices and lets the user pick one.
+// The selection can be persisted via the "Remember this choice" checkbox
+// so the dialog does not appear again on subsequent activations.
+class WfmDeviceDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit WfmDeviceDialog(QWidget* parent = nullptr);
+
+    // Full device name chosen by the user, or empty if cancelled.
+    QString selectedDevice() const;
+
+    // True when the user ticked "Remember this choice".
+    bool rememberChoice() const;
+
+private:
+    static QStringList enumerateDevices();
+
+    QListWidget* m_list{nullptr};
+    QCheckBox*   m_remember{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/models/DaxIqModel.cpp
+++ b/src/models/DaxIqModel.cpp
@@ -24,7 +24,8 @@ DaxIqModel::DaxIqModel(QObject* parent)
     m_worker = new DaxIqWorker;
     m_worker->moveToThread(&m_workerThread);
     connect(&m_workerThread, &QThread::finished, m_worker, &QObject::deleteLater);
-    connect(m_worker, &DaxIqWorker::levelReady, this, &DaxIqModel::iqLevelReady);
+    connect(m_worker, &DaxIqWorker::levelReady,   this, &DaxIqModel::iqLevelReady);
+    connect(m_worker, &DaxIqWorker::samplesReady, this, &DaxIqModel::iqSamplesReady);
     m_workerThread.start();
 }
 
@@ -132,6 +133,10 @@ void DaxIqModel::handleStreamRemoved(quint32 streamId)
 
 void DaxIqModel::feedRawIqPacket(int channel, const QByteArray& rawPayload, int sampleRate)
 {
+    static int s_feedCount = 0;
+    if (++s_feedCount <= 3)
+        qDebug() << "DaxIqModel::feedRawIqPacket ch=" << channel
+                 << "size=" << rawPayload.size() << "rate=" << sampleRate;
     QMetaObject::invokeMethod(m_worker,
         [this, channel, rawPayload, sampleRate] {
             m_worker->processIqPacket(channel, rawPayload, sampleRate);
@@ -249,6 +254,15 @@ void DaxIqWorker::processIqPacket(int channel, const QByteArray& rawPayload, int
         m_sampleCount[idx] = 0;
         m_sumSq[idx] = 0.0;
     }
+
+    // Emit byte-swapped samples for software demodulators (all platforms)
+    QVector<float> samples(numFloats);
+    std::memcpy(samples.data(), swapped.constData(), swapped.size());
+    static int s_emitCount = 0;
+    if (++s_emitCount <= 3)
+        qDebug() << "DaxIqWorker: emitting samplesReady ch=" << channel
+                 << "samples=" << numSamples;
+    emit samplesReady(channel, std::move(samples), sampleRate);
 
     // Write to pipe (non-blocking, Linux/macOS only)
 #ifndef Q_OS_WIN

--- a/src/models/DaxIqModel.h
+++ b/src/models/DaxIqModel.h
@@ -5,6 +5,7 @@
 #include <QMap>
 #include <QString>
 #include <QThread>
+#include <QVector>
 
 namespace AetherSDR {
 
@@ -59,6 +60,7 @@ signals:
     void streamChanged(int channel);
     void commandReady(const QString& cmd);
     void iqLevelReady(int channel, float rms);
+    void iqSamplesReady(int channel, QVector<float> iqInterleaved, int sampleRate);
 
 private:
     IqStream m_streams[NUM_CHANNELS];  // index 0-3 for channels 1-4
@@ -89,6 +91,7 @@ public slots:
 
 signals:
     void levelReady(int channel, float rms);
+    void samplesReady(int channel, QVector<float> iqInterleaved, int sampleRate);
 
 private:
     int m_pipeFds[DaxIqModel::NUM_CHANNELS]{-1, -1, -1, -1};


### PR DESCRIPTION
<!--
Thanks for contributing to AetherSDR!

Before opening the PR, please:
- Read AGENTS.md if this is your first contribution (or your AI tool's
  first contribution) — it has the conventions every contributor agent
  is expected to follow.
- Read CONTRIBUTING.md for the commit-signing and branch-protection
  rules.
- If you're an AI agent: claim the originating issue first by assigning
  yourself via `gh issue edit <N> --add-assignee <handle>`. Double-
  assigning alongside the @aethersdr-agent triage bot is fine.
-->

## Summary

<!-- One-paragraph description of what changes and why.  If this fixes
an issue, lead with "Fixes #N" or "Closes #N". -->

## Constitution principle honored

<!-- Cite the principle by Roman numeral when relevant.  E.g.
"Principle V — new feature uses nested-JSON persistence."
"Principle II — MeterSmoother used for the new meter widget."
See CONSTITUTION.md for the full list. -->

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug

## Checklist

- [ ] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [ ] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [ ] All meter UI uses `MeterSmoother` (Principle II)
- [ ] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable