### PR TITLE
Feature/panlock: add PanLock button to TitleBar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ msix-root-*/
 *.msixupload
 *.pfx
 packaging/windows/certs/
-Resumen para empezar de nuevo.txt

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ msix-root-*/
 *.msixupload
 *.pfx
 packaging/windows/certs/
+Resumen para empezar de nuevo.txt

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3464,6 +3464,10 @@ MainWindow::MainWindow(QWidget* parent)
     // Overlay-menu antenna wiring is now per-pan in wirePanadapter() (#1260).
     // Antenna list and S-meter are now wired per-widget in onSliceAdded.
 
+    // ── Title bar: Pan Follow ────────────────────────────────────────────────
+    connect(m_titleBar, &TitleBar::panFollowToggled,
+            this, &MainWindow::setPanFollow);
+
     // ── Title bar: PC Audio, master volume, headphone volume ────────────────
     // The remote_audio_rx stream controls the radio's audio routing:
     // stream exists → audio to PC; stream removed → audio to radio speakers.
@@ -19124,6 +19128,33 @@ void MainWindow::onSpectrumReadyForSHistory(quint32 streamId, const QVector<floa
             PerfTelemetry::instance().recordSHistorySkipped();
         }
     }
+}
+
+// ─── Pan Follow ───────────────────────────────────────────────────────────────
+
+void MainWindow::setPanFollow(bool on)
+{
+    disconnect(m_panFollowConn);
+    if (!on) return;
+
+    auto* s = m_radioModel.slice(0);
+    if (!s) return;
+
+    auto centerPan = [this, s]() {
+        const QString panId = s->panId();
+        if (panId.isEmpty()) return;
+        const double freq = s->frequency();
+        auto* pan = m_radioModel.panadapter(panId);
+        if (pan && qFuzzyCompare(pan->centerMhz(), freq)) return;
+        const QString freqStr = QString::number(freq, 'f', 6);
+        if (pan) pan->applyPanStatus({{"center", freqStr}});
+        m_radioModel.sendCommand(
+            QString("display pan set %1 center=%2").arg(panId, freqStr));
+    };
+
+    centerPan();
+    m_panFollowConn = connect(s, &SliceModel::frequencyChanged,
+                              this, [centerPan](double) { centerPan(); });
 }
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3467,6 +3467,7 @@ MainWindow::MainWindow(QWidget* parent)
     // ── Title bar: Pan Follow ────────────────────────────────────────────────
     connect(m_titleBar, &TitleBar::panFollowToggled,
             this, &MainWindow::setPanFollow);
+    if (m_titleBar->isPanFollowChecked()) setPanFollow(true);
 
     // ── Title bar: PC Audio, master volume, headphone volume ────────────────
     // The remote_audio_rx stream controls the radio's audio routing:
@@ -19135,26 +19136,47 @@ void MainWindow::onSpectrumReadyForSHistory(quint32 streamId, const QVector<floa
 void MainWindow::setPanFollow(bool on)
 {
     disconnect(m_panFollowConn);
+    disconnect(m_panFollowSliceConn);
+
     if (!on) return;
 
-    auto* s = m_radioModel.slice(0);
-    if (!s) return;
+    // Re-attach helper: wires frequency tracking to whichever slice 0
+    // is currently live. Called on activation and whenever slice 0 is
+    // recreated (radio reconnect, slice re-assignment, etc.).
+    auto attachToSlice0 = [this]() {
+        disconnect(m_panFollowConn);
 
-    auto centerPan = [this, s]() {
-        const QString panId = s->panId();
-        if (panId.isEmpty()) return;
-        const double freq = s->frequency();
-        auto* pan = m_radioModel.panadapter(panId);
-        if (pan && qFuzzyCompare(pan->centerMhz(), freq)) return;
-        const QString freqStr = QString::number(freq, 'f', 6);
-        if (pan) pan->applyPanStatus({{"center", freqStr}});
-        m_radioModel.sendCommand(
-            QString("display pan set %1 center=%2").arg(panId, freqStr));
+        auto* s = m_radioModel.slice(0);
+        if (!s) {
+            // No slice yet — uncheck the button so UI matches reality.
+            if (m_titleBar) m_titleBar->setPanFollowChecked(false);
+            return;
+        }
+
+        auto centerPan = [this, s]() {
+            const QString panId = s->panId();
+            if (panId.isEmpty()) return;
+            const double freq = s->frequency();
+            auto* pan = m_radioModel.panadapter(panId);
+            if (pan && qFuzzyCompare(pan->centerMhz(), freq)) return;
+            const QString freqStr = QString::number(freq, 'f', 6);
+            if (pan) pan->applyPanStatus({{"center", freqStr}});
+            m_radioModel.sendCommand(
+                QString("display pan set %1 center=%2").arg(panId, freqStr));
+        };
+
+        centerPan();
+        m_panFollowConn = connect(s, &SliceModel::frequencyChanged,
+                                  this, [centerPan](double) { centerPan(); });
     };
 
-    centerPan();
-    m_panFollowConn = connect(s, &SliceModel::frequencyChanged,
-                              this, [centerPan](double) { centerPan(); });
+    attachToSlice0();
+
+    // Re-attach whenever a new slice 0 appears (reconnect / re-assignment).
+    m_panFollowSliceConn = connect(&m_radioModel, &RadioModel::sliceAdded,
+        this, [this, attachToSlice0](SliceModel* s) {
+            if (s && s->sliceId() == 0) attachToSlice0();
+        });
 }
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -929,6 +929,10 @@ private:
     void onFdvMetersChanged();
 #endif
 
+    // Pan Follow — keeps the panadapter centered on Slice A frequency
+    QMetaObject::Connection m_panFollowConn;
+    void setPanFollow(bool on);
+
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
     DaxBridge* m_daxBridge{nullptr};
     QString m_savedMicSelection;  // restore on stopDax

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -931,6 +931,7 @@ private:
 
     // Pan Follow — keeps the panadapter centered on Slice A frequency
     QMetaObject::Connection m_panFollowConn;
+    QMetaObject::Connection m_panFollowSliceConn;
     void setPanFollow(bool on);
 
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -219,6 +219,34 @@ TitleBar::TitleBar(QWidget* parent)
     // ── PC Audio + Master Vol + HP Vol ──────────────────────────────────────
     auto& s = AppSettings::instance();
 
+    // Pan Follow toggle — keeps the panadapter centered on Slice A frequency
+    m_panFollowBtn = new QPushButton("Pan Lock");
+    m_panFollowBtn->setCheckable(true);
+    m_panFollowBtn->setChecked(false);
+    m_panFollowBtn->setFixedHeight(22);
+    m_panFollowBtn->setFixedWidth(70);
+    m_panFollowBtn->setAccessibleName("Pan follow slice");
+    m_panFollowBtn->setAccessibleDescription("Keep panadapter centered on Slice A frequency");
+    m_panFollowBtn->setToolTip("Pan Lock — keeps the panadapter centered on Slice A frequency (e.g. for Doppler tracking)");
+
+    auto updatePanFollowStyle = [this]() {
+        m_panFollowBtn->setStyleSheet(m_panFollowBtn->isChecked()
+            ? "QPushButton { background: #1e4a8a; color: #b0e8ff; border: 1px solid #4090d0; "
+              "border-radius: 3px; font-size: 10px; font-weight: bold; }"
+              "QPushButton:hover { background: #2558a0; }"
+            : "QPushButton { background: #1a2a3a; color: #607080; border: 1px solid #304050; "
+              "border-radius: 3px; font-size: 10px; font-weight: bold; }"
+              "QPushButton:hover { background: #243848; }");
+    };
+    updatePanFollowStyle();
+
+    connect(m_panFollowBtn, &QPushButton::toggled, this, [this, updatePanFollowStyle](bool on) {
+        updatePanFollowStyle();
+        emit panFollowToggled(on);
+    });
+    m_hbox->addWidget(m_panFollowBtn);
+    m_hbox->addSpacing(4);
+
     // PC Audio toggle
     m_pcBtn = new QPushButton("PC Audio");
     m_pcBtn->setCheckable(true);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -222,7 +222,8 @@ TitleBar::TitleBar(QWidget* parent)
     // Pan Follow toggle — keeps the panadapter centered on Slice A frequency
     m_panFollowBtn = new QPushButton("Pan Lock");
     m_panFollowBtn->setCheckable(true);
-    m_panFollowBtn->setChecked(false);
+    bool panLockOn = s.value("PanLockEnabled", "False").toString() == "True";
+    m_panFollowBtn->setChecked(panLockOn);
     m_panFollowBtn->setFixedHeight(22);
     m_panFollowBtn->setFixedWidth(70);
     m_panFollowBtn->setAccessibleName("Pan follow slice");
@@ -242,6 +243,9 @@ TitleBar::TitleBar(QWidget* parent)
 
     connect(m_panFollowBtn, &QPushButton::toggled, this, [this, updatePanFollowStyle](bool on) {
         updatePanFollowStyle();
+        auto& ss = AppSettings::instance();
+        ss.setValue("PanLockEnabled", on ? "True" : "False");
+        ss.save();
         emit panFollowToggled(on);
     });
     m_hbox->addWidget(m_panFollowBtn);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -1,5 +1,6 @@
 #include "TitleBar.h"
 #include "GuardedSlider.h"
+#include "TitleBarSettings.h"
 #include "core/AppSettings.h"
 
 #include <QFrame>
@@ -220,11 +221,13 @@ TitleBar::TitleBar(QWidget* parent)
     // ── PC Audio + Master Vol + HP Vol ──────────────────────────────────────
     auto& s = AppSettings::instance();
 
-    // Pan Follow toggle — keeps the panadapter centered on Slice A frequency
+    // Pan Follow toggle — keeps the panadapter centered on Slice A frequency.
+    // Persistence is the nested "TitleBar" blob (Principle V); the legacy
+    // flat "PanLockEnabled" key is migrated into it on first read.
+    TitleBarSettings::migrateLegacy();
     m_panFollowBtn = new QPushButton("Pan Lock");
     m_panFollowBtn->setCheckable(true);
-    bool panLockOn = s.value("PanLockEnabled", "False").toString() == "True";
-    m_panFollowBtn->setChecked(panLockOn);
+    m_panFollowBtn->setChecked(TitleBarSettings::panLockEnabled());
     m_panFollowBtn->setFixedHeight(22);
     m_panFollowBtn->setFixedWidth(70);
     m_panFollowBtn->setAccessibleName("Pan follow slice");
@@ -244,9 +247,7 @@ TitleBar::TitleBar(QWidget* parent)
 
     connect(m_panFollowBtn, &QPushButton::toggled, this, [this, updatePanFollowStyle](bool on) {
         updatePanFollowStyle();
-        auto& ss = AppSettings::instance();
-        ss.setValue("PanLockEnabled", on ? "True" : "False");
-        ss.save();
+        TitleBarSettings::setPanLockEnabled(on);
         emit panFollowToggled(on);
     });
     m_hbox->addWidget(m_panFollowBtn);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -11,6 +11,7 @@
 #include <QMouseEvent>
 #include <QPointer>
 #include <QPushButton>
+#include <QSignalBlocker>
 #include <QSizePolicy>
 #include <QSlider>
 #include <QLabel>
@@ -489,6 +490,18 @@ void TitleBar::markDragHandle(QWidget* widget)
 bool TitleBar::isDragHandle(QObject* obj) const
 {
     return obj && obj->property(kTitleDragHandleProperty).toBool();
+}
+
+bool TitleBar::isPanFollowChecked() const
+{
+    return m_panFollowBtn && m_panFollowBtn->isChecked();
+}
+
+void TitleBar::setPanFollowChecked(bool on)
+{
+    if (!m_panFollowBtn) return;
+    QSignalBlocker block(m_panFollowBtn);
+    m_panFollowBtn->setChecked(on);
 }
 
 bool TitleBar::isSystemMoveAreaAt(const QPoint& globalPos) const

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -52,6 +52,7 @@ public:
     bool isSystemMoveAreaAt(const QPoint& globalPos) const;
 
 signals:
+    void panFollowToggled(bool on);
     void pcAudioToggled(bool on);
     void masterVolumeChanged(int pct);
     void headphoneVolumeChanged(int pct);
@@ -87,6 +88,7 @@ private:
     QLabel*      m_appNameLabel{nullptr};
     QLabel*      m_otherTxLabel{nullptr};
     QPushButton* m_mfBtn{nullptr};
+    QPushButton* m_panFollowBtn{nullptr};
     QPushButton* m_pcBtn{nullptr};
     QPushButton* m_speakerBtn{nullptr};
     QPushButton* m_headphoneBtn{nullptr};

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -53,6 +53,8 @@ public:
 
 signals:
     void panFollowToggled(bool on);
+    bool isPanFollowChecked() const { return m_panFollowBtn && m_panFollowBtn->isChecked(); }
+    void setPanFollowChecked(bool on) { if (m_panFollowBtn) { QSignalBlocker b(m_panFollowBtn); m_panFollowBtn->setChecked(on); } }
     void pcAudioToggled(bool on);
     void masterVolumeChanged(int pct);
     void headphoneVolumeChanged(int pct);

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -51,10 +51,13 @@ public:
     // as caption drag zones while keeping controls interactive.
     bool isSystemMoveAreaAt(const QPoint& globalPos) const;
 
+    // Pan Lock accessors. Out-of-line so the header doesn't need to pull in
+    // <QPushButton>; defined alongside the button's setup in TitleBar.cpp.
+    bool isPanFollowChecked() const;
+    void setPanFollowChecked(bool on);
+
 signals:
     void panFollowToggled(bool on);
-    bool isPanFollowChecked() const { return m_panFollowBtn && m_panFollowBtn->isChecked(); }
-    void setPanFollowChecked(bool on) { if (m_panFollowBtn) { QSignalBlocker b(m_panFollowBtn); m_panFollowBtn->setChecked(on); } }
     void pcAudioToggled(bool on);
     void masterVolumeChanged(int pct);
     void headphoneVolumeChanged(int pct);

--- a/src/gui/TitleBarSettings.h
+++ b/src/gui/TitleBarSettings.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "core/AppSettings.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+
+namespace AetherSDR {
+
+// Persistence helper for title-bar UI toggles (#3408 PanLock is the first;
+// future title-bar toggles land here as additional fields).
+//
+// Stored as a nested JSON blob under AppSettings["TitleBar"], per the
+// nested-JSON-per-feature convention (constitution Principle V).  The legacy
+// flat key "PanLockEnabled" is migrated into this blob on first read so
+// existing users keep their behavior.
+class TitleBarSettings {
+public:
+    static bool panLockEnabled()
+    {
+        return readObj().value("panLockEnabled").toString("False") == "True";
+    }
+
+    static void setPanLockEnabled(bool on)
+    {
+        QJsonObject o = readObj();
+        o["panLockEnabled"] = on ? QStringLiteral("True") : QStringLiteral("False");
+        write(o);
+    }
+
+    // One-shot migration from the legacy "PanLockEnabled" flat key.  Run at app
+    // startup (or TitleBar construction) before any caller reads the new blob.
+    // Safe to call repeatedly: returns immediately if the new blob already
+    // exists.
+    static void migrateLegacy()
+    {
+        auto& s = AppSettings::instance();
+        if (s.contains("TitleBar")) return;
+        const bool legacyPanLock =
+            s.value("PanLockEnabled", "False").toString() == "True";
+        QJsonObject o;
+        o["panLockEnabled"] =
+            legacyPanLock ? QStringLiteral("True") : QStringLiteral("False");
+        write(o);
+        // Leave the legacy flat key in place — harmless after migration, and a
+        // future cleanup PR can drop it once we're confident no other reader
+        // still touches it.
+    }
+
+private:
+    static QJsonObject readObj()
+    {
+        const QString json =
+            AppSettings::instance().value("TitleBar", QString{}).toString();
+        if (json.isEmpty()) return {};
+        return QJsonDocument::fromJson(json.toUtf8()).object();
+    }
+    static void write(const QJsonObject& o)
+    {
+        auto& s = AppSettings::instance();
+        s.setValue("TitleBar",
+                   QString::fromUtf8(
+                       QJsonDocument(o).toJson(QJsonDocument::Compact)));
+        s.save();
+    }
+};
+
+} // namespace AetherSDR


### PR DESCRIPTION
Summary:

Adds a toggleable Pan Lock button to the title bar that keeps the
panadapter centered on Slice A's frequency at all times. 
When active, any frequency change on Slice A — whether tuned by hand, by CAT, or by
Doppler-correction software such as SatPC32 — immediately recenters the
panadapter so the signal stays visible in the middle of the waterfall all the time.
Deactivating the button stops the tracking and leaves the panadapter at
its current center, allowing the operator to scroll freely across the
full waterfall width while Slice A continues to track independently.
Constitution principle honored: Principle III — the feature adds
capability without altering any existing behavior; operators who never
press the button experience no change.

Changes:

TitleBar: new m_panFollowBtn checkable widget with accessible name
and tooltip; emits panFollowToggled(bool) signal.
MainWindow: setPanFollow(bool) slot wired to
TitleBar::panFollowToggled; uses a persistent QMetaObject::Connection
(m_panFollowConn) so tracking is torn down cleanly on deactivation.

Test plan:
Platform: Windows 11, Flex-6600.
PanLock behavior:

Connected to the radio and opened the main window.
Pressed Pan Lock in the title bar — button turns blue/active.
Tuned Slice A manually across several MHz: panadapter recentered on
every frequency change, keeping the slice marker in the middle of the
waterfall at all times.
Sent CAT frequency commands via SatPC32 (Doppler tracking): panadapter
followed each correction in real time with no visible lag.
Pressed Pan Lock again to deactivate: panadapter stopped following
and remained at its last center position while Slice A could be moved
freely to any point in the waterfall.
Re-enabled and disabled the button multiple times — behavior was
consistent across all cycles with no crashes or stale connections.