### PR TITLE
fix(settings): band plan Off selection reverts to Small on restart (#3358)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8945,9 +8945,16 @@ void MainWindow::buildMenuBar()
 
     // Band Plan submenu — Off / Small / Medium / Large / Huge
     auto* bandPlanMenu = viewMenu->addMenu("Band Plan");
-    int savedBpSize = AppSettings::instance().value("BandPlanFontSize", "").toInt();
-    if (savedBpSize == 0 && AppSettings::instance().value("ShowBandPlan", "True").toString() == "True")
-        savedBpSize = 6;  // migrate old boolean setting
+    // Use contains() to distinguish an explicit "Off" (0) from an absent key.
+    // Without it, .toInt() returns 0 for both cases and the legacy migration
+    // always promotes a saved "Off" back to Small (6) on next launch. (#3358)
+    int savedBpSize;
+    if (!AppSettings::instance().contains("BandPlanFontSize")) {
+        savedBpSize = AppSettings::instance().value("ShowBandPlan", "True").toString() == "True"
+                      ? 6 : 0;  // migrate old boolean → default Small
+    } else {
+        savedBpSize = AppSettings::instance().value("BandPlanFontSize").toInt();
+    }
     auto* bpGroup = new QActionGroup(bandPlanMenu);
     struct BpOption { const char* label; int pt; };
     for (auto [label, pt] : {BpOption{"Off", 0}, {"Small", 6}, {"Medium", 10}, {"Large", 12}, {"Huge", 16}}) {


### PR DESCRIPTION
## Problem

Selecting **View → Band Plan → Off** writes \`BandPlanFontSize=0\` to \`AppSettings\`. On the next launch:

\`\`\`cpp
int savedBpSize = AppSettings::instance().value("BandPlanFontSize", "").toInt();
if (savedBpSize == 0 && AppSettings::instance().value("ShowBandPlan", "True").toString() == "True")
    savedBpSize = 6;  // migrate old boolean setting
\`\`\`

\`.toInt()\` returns \`0\` for both an **absent key** and an **explicitly stored zero** — they are indistinguishable. The legacy \`ShowBandPlan→int\` migration then always promotes \`0\` to \`6\` (Small) because \`ShowBandPlan\` defaults to \`"True"\`. The user's Off choice is silently discarded every restart.

## Fix

Gate the migration on \`AppSettings::contains()\` so an explicit \`0\` is preserved. Mirrors the correct pattern already used in \`SpectrumWidget.cpp:724\`.

## Testing

Verified locally on macOS (Apple Silicon, dev build off \`main\`):
- **Before fix:** set Band Plan→Off, restart → View→Band Plan shows **✓ Small** (bug reproduced)
- **After fix:** set Band Plan→Off, restart → View→Band Plan shows **✓ Off** ✅

Fixes #3358