### PR TITLE
fix(spectrum): spot display setters use update() instead of markOverlayDirty() (#3338)

### DIFF
--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -428,16 +428,16 @@ public:
     void setSHistorySnapToStep(bool on) { m_sHistorySnapToStep = on; }
     bool sHistorySnapToStep() const     { return m_sHistorySnapToStep; }
     void setSHistoryMarkers(const QVector<SpotMarker>& markers);
-    void setSpotFontSize(int px) { m_spotFontSize = px; update(); }
-    void setSpotMaxLevels(int n) { m_spotMaxLevels = n; update(); }
-    void setSpotStartPct(int pct) { m_spotStartPct = pct; update(); }
-    void setSpotOverrideColors(bool on) { m_spotOverrideColors = on; update(); }
-    void setSpotOverrideBg(bool on) { m_spotOverrideBg = on; update(); }
-    void setSpotShowLines(bool on) { m_spotShowLines = on; update(); }
+    void setSpotFontSize(int px) { m_spotFontSize = px; markOverlayDirty(); }
+    void setSpotMaxLevels(int n) { m_spotMaxLevels = n; markOverlayDirty(); }
+    void setSpotStartPct(int pct) { m_spotStartPct = pct; markOverlayDirty(); }
+    void setSpotOverrideColors(bool on) { m_spotOverrideColors = on; markOverlayDirty(); }
+    void setSpotOverrideBg(bool on) { m_spotOverrideBg = on; markOverlayDirty(); }
+    void setSpotShowLines(bool on) { m_spotShowLines = on; markOverlayDirty(); }
     bool spotShowLines() const { return m_spotShowLines; }
-    void setSpotColor(const QColor& c) { m_spotColor = c; update(); }
-    void setSpotBgColor(const QColor& c) { m_spotBgColor = c; update(); }
-    void setSpotBgOpacity(int pct) { m_spotBgOpacity = pct; update(); }
+    void setSpotColor(const QColor& c) { m_spotColor = c; markOverlayDirty(); }
+    void setSpotBgColor(const QColor& c) { m_spotBgColor = c; markOverlayDirty(); }
+    void setSpotBgOpacity(int pct) { m_spotBgOpacity = pct; markOverlayDirty(); }
     void setTransmitting(bool tx);
     void setShowTxInWaterfall(bool on) { m_showTxInWaterfall = on; }
     void setHasTxSlice(bool has) { m_hasTxSlice = has; }


### PR DESCRIPTION
## Problem

The 9 spot-display setters in `SpectrumWidget.h` call `update()`, which on the GPU path reuses the cached `m_overlayStatic` chrome texture without re-baking it. `drawSpotMarkers()` never re-runs, so toggling **Spot Lines** (or changing spot font size, start %, colours, etc.) has no immediate visual effect — the change only takes hold when something else triggers `markOverlayDirty()` (e.g. a new incoming spot).

This regression was introduced by #3124 (GPU path caches the chrome overlay) and became consistently visible after #3299 (discrete GPU preference on Windows) caused more users to hit the GPU path.

## Fix

Replace `update()` with `markOverlayDirty()` in all 9 setters. `markOverlayDirty()` calls `update()` internally — identical behaviour on the CPU path, correct invalidation on the GPU path.

All other display setters in the file (background opacity, MQTT display, prop forecast, etc.) already use `markOverlayDirty()`. The spot setters were the only outliers.

## Testing

Verified build compiles cleanly on macOS. GPU-path visual verification (toggle Spot Lines with spots visible → lines appear/disappear immediately) requires Windows with discrete GPU — the reporter in #3338 should be able to confirm.

Fixes #3338