### PR TITLE
fix(vfo): SPLIT badge nearly invisible in inactive state (#3402)

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -486,9 +486,9 @@ void VfoWidget::buildUI()
     m_splitBadge->setFixedHeight(20);  // match TX badge height
     m_splitBadge->setStyleSheet(
         "QPushButton { background: transparent; border: none; "
-        "color: rgba(255,255,255,40); font-size: 11px; font-weight: bold; "
+        "color: rgba(255,255,255,120); font-size: 11px; font-weight: bold; "
         "padding: 0px 3px; }"
-        "QPushButton:hover { color: rgba(255,255,255,80); }");
+        "QPushButton:hover { color: rgba(255,255,255,180); }");
     m_splitBadge->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     connect(m_splitBadge, &QPushButton::clicked, this, [this]() {
         if (m_splitBadge->text() == "SWAP")
@@ -3068,9 +3068,9 @@ void VfoWidget::updateSplitBadge(bool isTxSlice, bool isRxSplit)
         m_splitBadge->show();
         m_splitBadge->setStyleSheet(
             "QPushButton { background: transparent; border: none; "
-            "color: rgba(255,255,255,40); font-size: 11px; font-weight: bold; "
+            "color: rgba(255,255,255,120); font-size: 11px; font-weight: bold; "
             "padding: 0px 3px; }"
-            "QPushButton:hover { color: rgba(255,255,255,80); }");
+            "QPushButton:hover { color: rgba(255,255,255,180); }");
     }
 }
 


### PR DESCRIPTION
## Problem

The inactive SPLIT badge uses `rgba(255,255,255,40)` — 16% white opacity — which is indistinguishable from a disabled/unavailable control against the slice flag background. The same low alpha is applied at both construction time (`VfoWidget.cpp:489`) and in `updateSplitBadge()`'s "split not active" branch (`VfoWidget.cpp:3071`).

## Fix

Raise inactive alpha from 40 → 120 (47%) and hover alpha from 80 → 180 (71%). The badge is still clearly dimmer than the active SPLIT/SWAP states, which use explicit colours and a non-transparent background — but it's now legible as an available interactive control.

## Testing

Verified visually on macOS dev build — the SPLIT badge is now readable in the slice flag header when split is not active.

Fixes #3402