### PR TITLE
fix(cat): abort rigctld clients before deleting QTcpServer

### DIFF
--- a/src/core/CatPort.cpp
+++ b/src/core/CatPort.cpp
@@ -5,6 +5,8 @@
 #include "SmartCatSession.h"
 #include "models/RadioModel.h"
 
+#include <utility>
+
 #include <QDir>
 #include <QFileInfo>
 #include <QStandardPaths>
@@ -87,18 +89,24 @@ void CatPort::stop()
 {
     stopPty();
 
+    // Swap out the client list before iterating: abort() emits disconnected
+    // synchronously, and onRigctlDisconnected calls removeAt() on m_rigctlClients,
+    // which would invalidate the range-for with 2+ clients. Disconnecting signals
+    // first prevents that re-entrant mutation and the double-free it causes.
+    // Also fixes the original UAF: Qt parents sockets to m_tcpServer, so
+    // delete m_tcpServer frees them — abort() after that is a use-after-free.
+    auto clients = std::exchange(m_rigctlClients, {});
+    for (auto& c : clients) {
+        QObject::disconnect(c.socket, nullptr, this, nullptr);
+        c.socket->abort();
+        delete c.protocol;
+    }
+
     if (m_tcpServer) {
         m_tcpServer->close();
         delete m_tcpServer;
         m_tcpServer = nullptr;
     }
-
-    // Close all rigctld clients
-    for (auto& c : m_rigctlClients) {
-        c.socket->abort();
-        delete c.protocol;
-    }
-    m_rigctlClients.clear();
 
     // Close all SmartCAT sessions (sessions own their sockets)
     for (auto* s : m_catSessions)


### PR DESCRIPTION
## Summary

- `CatPort::stop()` called `c.socket->abort()` after `delete m_tcpServer`, which freed the sockets first (Qt parents them to the server via `nextPendingConnection()`) — use-after-free on every shutdown with a connected rigctld client

## Root cause

`QTcpServer::nextPendingConnection()` creates each `QTcpSocket` with the Qt server as its parent. `delete m_tcpServer` therefore frees all client sockets before the rigctld loop ran `abort()` on them.

## Fix

Move the rigctld client cleanup (abort + delete protocol) to before `delete m_tcpServer`.

## Repro / evidence

Triggered reliably by closing AetherSDR via the window close button while an external client is connected via rigctld (e.g. Direwolf PTT). AddressSanitizer trace:

```
ERROR: AddressSanitizer: SEGV on unknown address 0x0000000bd97d
    #0  QAbstractSocket::abort()             libQt6Network.so.6
    #1  AetherSDR::CatPort::stop()           CatPort.cpp:98
    #2  AetherSDR::CatPort::~CatPort()       CatPort.cpp:60
    #3  QObjectPrivate::deleteChildren()     libQt6Core.so.6
    #4  QWidget::~QWidget()                  libQt6Widgets.so.6
    #5  AetherSDR::MainWindow::~MainWindow() MainWindow.cpp:5490
```

## Test

- Debug build (ASAN): no SEGV on close with rigctld client connected ✓
- RelWithDebInfo build: clean exit on close ✓
- Platform: RPi5, Debian, Qt 6, rigctld client = Direwolf PTT