### PR TITLE
fix(gui): fix memory leaks found via AddressSanitizer

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4422,8 +4422,8 @@ MainWindow::MainWindow(QWidget* parent)
     // Client-side PC mic metering — radio CODEC meters only see hardware mics.
     // Apply VU-style ballistics: fast attack, slow decay (~20 dB/sec).
     {
-        auto* heldLevel = new float(-150.0f);  // persists across calls
-        auto* heldPeak  = new float(-150.0f);
+        auto heldLevel = std::make_shared<float>(-150.0f);
+        auto heldPeak  = std::make_shared<float>(-150.0f);
         connect(m_audio, &AudioEngine::pcMicLevelChanged,
                 this, [this, heldLevel, heldPeak](float peakDb, float avgDb) {
             if (m_radioModel.transmitModel().micSelection() != "PC" && !m_audio->isRadeMode()) return;
@@ -10155,7 +10155,6 @@ void MainWindow::buildUI()
     addSep();
 
     // Radio model (top) + version (bottom) stacked
-    m_radioInfoLabel = new QLabel("");
     auto* radioStack = new QWidget;
     auto* radioVbox = new QVBoxLayout(radioStack);
     radioVbox->setContentsMargins(0, 0, 0, 0);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10059,7 +10059,7 @@ void MainWindow::buildUI()
     };
 
     // Hidden connection state label (used by connect/disconnect logic)
-    m_connStatusLabel = new QLabel("");
+    m_connStatusLabel = new QLabel("", this);
     m_connStatusLabel->hide();
 
     // ── Left section ─────────────────────────────────────────────────────

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -662,9 +662,7 @@ void SpectrumWidget::prepareForShutdown()
     hide();
 
 #ifdef AETHER_GPU_SPECTRUM
-#ifndef Q_OS_LINUX
     releaseResources();
-#endif
 #ifdef Q_OS_MAC
     // Drop the native child window while its parent backing store is still
     // alive, so any remaining platform resources are gone before QWidgetWindow


### PR DESCRIPTION
## Summary

Three leaks found and fixed during an ASAN session on Linux/RPi5. Total reduction: 137,879 bytes → 0 bytes leaked on exit. The leaks were not causing a crash, but were detected while investigating a use-after-free in `CatPort::stop()` (see PR #3414).

- **`SpectrumWidget`**: `prepareForShutdown()` was guarded by `#ifndef Q_OS_LINUX`, preventing `releaseResources()` from running on Linux shutdown. Removing the guard eliminates 137 KB of GPU pipeline objects reported as leaked on exit.

- **`MainWindow` (two fixes in one commit)**: A `pcMicLevelChanged` signal lambda captured two heap-allocated `float` values via raw pointer — replaced with `std::make_shared<float>` so they are freed when the connection is destroyed. Also removed an orphaned `m_radioInfoLabel = new QLabel("")` allocation that was immediately overwritten four lines later.

- **`MainWindow`**: `m_connStatusLabel` was created with no parent and never added to a layout, so Qt never took ownership. Parenting to `this` also cleans up the `QAccessibleCache` entry created by the first `setText()` call.

> **Note:** the branch also contains a cherry-pick of the `CatPort` fix from PR #3414, included here only to keep ASAN output clean during testing. That fix is already tracked in its own PR.

## Test plan

- [ ] Debug/ASAN build on Linux (RPi5 aarch64): `LEAK_SANITIZER: detected memory leaks` absent on clean exit
- [ ] ASAN baseline before fixes: 137,879 bytes in 245 allocations
- [ ] ASAN after all fixes: 0 bytes leaked from application code

🤖 Generated with [Claude Code](https://claude.ai/claude-code)