### PR TITLE
fix(discovery): pause re-bind loop while connected, fully quiesce on routed/WAN (#3420)

### DIFF
--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -20,10 +20,20 @@ RadioDiscovery::RadioDiscovery(QObject* parent)
 
     // Periodic re-bind: handles the case where bind() succeeds but the socket
     // is stale (e.g. no network interface at launch, macOS consent silently
-    // dropping packets).  Stops once the first discovery packet arrives.
+    // dropping packets).  Stops once the first discovery packet arrives,
+    // the connection lifecycle pauses it (see setConnected), or the retry
+    // budget runs out (#3420).
     m_rebindTimer.setInterval(REBIND_INTERVAL_MS);
     connect(&m_rebindTimer, &QTimer::timeout, this, [this]() {
-        qCDebug(lcDiscovery) << "RadioDiscovery: no packets yet, re-binding socket";
+        if (m_rebindAttempts >= MAX_REBIND_RETRIES) {
+            m_rebindTimer.stop();
+            qCWarning(lcDiscovery) << "RadioDiscovery: giving up re-bind after"
+                                   << MAX_REBIND_RETRIES << "attempts (no broadcasts received)";
+            return;
+        }
+        ++m_rebindAttempts;
+        qCDebug(lcDiscovery) << "RadioDiscovery: no packets yet, re-binding socket (attempt"
+                             << m_rebindAttempts << "/" << MAX_REBIND_RETRIES << ")";
         startListening();
     });
 }
@@ -64,7 +74,11 @@ void RadioDiscovery::startListening()
 
     // Keep re-binding periodically until we actually receive a discovery packet.
     // Covers: no network at launch, macOS consent blocking packets, interface changes.
-    if (!m_receivedAny) {
+    // Skipped while a radio is connected — routed/VPN sessions cannot receive
+    // broadcasts by design, and local sessions don't need the churn (#3420).
+    // Bounded by MAX_REBIND_RETRIES so it self-terminates even without a
+    // connection event.
+    if (!m_connected && !m_receivedAny && m_rebindAttempts < MAX_REBIND_RETRIES) {
         m_rebindTimer.start();
     }
 
@@ -76,9 +90,36 @@ void RadioDiscovery::stopListening()
     m_bindRetryTimer.stop();
     m_rebindTimer.stop();
     m_bindRetryCount = 0;
+    m_rebindAttempts = 0;
     m_receivedAny = false;
     m_staleTimer.stop();
     m_socket.close();
+}
+
+void RadioDiscovery::setConnected(bool connected)
+{
+    if (m_connected == connected)
+        return;
+    m_connected = connected;
+
+    if (connected) {
+        // Active radio session: stop the 5-second re-bind churn.  The socket
+        // stays bound so passive discovery (Multi-Flex / other-GUI-client
+        // updates) still works on local networks.  On routed/VPN the
+        // broadcasts wouldn't reach us anyway, so this just halts the
+        // unbounded close()+bind() loop the issue described (#3420).
+        m_rebindTimer.stop();
+        qCDebug(lcDiscovery) << "RadioDiscovery: radio connected — pausing re-bind loop";
+    } else {
+        // Disconnected: reset the retry budget and, if we never actually
+        // received a broadcast this session and the socket is still bound,
+        // resume the re-bind loop with a fresh count.
+        m_rebindAttempts = 0;
+        if (!m_receivedAny && m_socket.state() == QAbstractSocket::BoundState) {
+            m_rebindTimer.start();
+            qCDebug(lcDiscovery) << "RadioDiscovery: radio disconnected — resuming re-bind loop";
+        }
+    }
 }
 
 void RadioDiscovery::onBindRetry()

--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -96,29 +96,37 @@ void RadioDiscovery::stopListening()
     m_socket.close();
 }
 
-void RadioDiscovery::setConnected(bool connected)
+void RadioDiscovery::setConnected(bool connected, bool remote)
 {
     if (m_connected == connected)
         return;
     m_connected = connected;
 
     if (connected) {
-        // Active radio session: stop the 5-second re-bind churn.  The socket
-        // stays bound so passive discovery (Multi-Flex / other-GUI-client
-        // updates) still works on local networks.  On routed/VPN the
-        // broadcasts wouldn't reach us anyway, so this just halts the
-        // unbounded close()+bind() loop the issue described (#3420).
+        // Active radio session: always stop the 5-second re-bind churn.
         m_rebindTimer.stop();
-        qCDebug(lcDiscovery) << "RadioDiscovery: radio connected — pausing re-bind loop";
-    } else {
-        // Disconnected: reset the retry budget and, if we never actually
-        // received a broadcast this session and the socket is still bound,
-        // resume the re-bind loop with a fresh count.
-        m_rebindAttempts = 0;
-        if (!m_receivedAny && m_socket.state() == QAbstractSocket::BoundState) {
-            m_rebindTimer.start();
-            qCDebug(lcDiscovery) << "RadioDiscovery: radio disconnected — resuming re-bind loop";
+        if (remote) {
+            // Routed/VPN/SmartLink: local UDP broadcasts cannot reach us by
+            // design, so keeping the socket bound buys nothing.  Fully quiesce
+            // — stop the stale sweep and release the socket — so discovery is
+            // completely idle for the rest of the session (#3420).
+            m_staleTimer.stop();
+            m_socket.close();
+            qCDebug(lcDiscovery) << "RadioDiscovery: remote radio connected — discovery fully paused";
+        } else {
+            // Local session: keep the socket bound and the stale sweep running
+            // so Multi-Flex / other-GUI-client broadcasts still refresh the
+            // radio list passively; only the re-bind churn stops.
+            qCDebug(lcDiscovery) << "RadioDiscovery: local radio connected — pausing re-bind loop";
         }
+    } else {
+        // Disconnected: resume normal discovery so the next connect (possibly a
+        // different local radio) can be found.  startListening() re-binds the
+        // socket if we released it, restarts the stale sweep, and re-arms the
+        // re-bind loop with a fresh retry budget when no broadcast has arrived.
+        m_rebindAttempts = 0;
+        qCDebug(lcDiscovery) << "RadioDiscovery: radio disconnected — resuming discovery";
+        startListening();
     }
 }
 

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -102,12 +102,22 @@ public:
     static constexpr int BIND_RETRY_MS      = 2000;  // retry interval when bind fails
     static constexpr int MAX_BIND_RETRIES   = 15;    // give up after 30s (15 × 2s)
     static constexpr int REBIND_INTERVAL_MS = 5000;  // re-bind interval until first packet received
+    static constexpr int MAX_REBIND_RETRIES = 12;    // give up re-bind after 60s (12 × 5s)
 
     explicit RadioDiscovery(QObject* parent = nullptr);
     ~RadioDiscovery() override;
 
     void startListening();
     void stopListening();
+
+    // Couple discovery's re-bind loop to the connection lifecycle.  When a
+    // radio is connected (especially via the routed/VPN path where broadcasts
+    // cannot reach us by design) we pause the 5-second re-bind churn so the
+    // socket stops thrashing for the rest of the session.  The socket stays
+    // bound so Multi-Flex / other-GUI-client broadcasts still update the
+    // radio list passively when they do arrive on local networks.  On
+    // disconnect the timer resumes with a fresh retry budget. (#3420)
+    void setConnected(bool connected);
 
     QList<RadioInfo> discoveredRadios() const { return m_radios; }
 
@@ -130,7 +140,9 @@ private:
     QTimer            m_bindRetryTimer;  // retries bind if first attempt fails (e.g. macOS net consent)
     QTimer            m_rebindTimer;     // periodic re-bind until first packet (handles interface changes)
     int               m_bindRetryCount{0};
+    int               m_rebindAttempts{0}; // count of re-bind firings, capped at MAX_REBIND_RETRIES (#3420)
     bool              m_receivedAny{false};
+    bool              m_connected{false};  // active radio connection — pauses re-bind churn (#3420)
     QList<RadioInfo>  m_radios;
 
     // Track last-seen time per serial for staleness detection

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -111,13 +111,17 @@ public:
     void stopListening();
 
     // Couple discovery's re-bind loop to the connection lifecycle.  When a
-    // radio is connected (especially via the routed/VPN path where broadcasts
-    // cannot reach us by design) we pause the 5-second re-bind churn so the
-    // socket stops thrashing for the rest of the session.  The socket stays
-    // bound so Multi-Flex / other-GUI-client broadcasts still update the
-    // radio list passively when they do arrive on local networks.  On
-    // disconnect the timer resumes with a fresh retry budget. (#3420)
-    void setConnected(bool connected);
+    // radio is connected we stop the 5-second re-bind churn for the rest of
+    // the session (#3420).  `remote` selects how aggressively to quiesce:
+    //   • local (remote=false): keep the socket bound and the stale sweep
+    //     running so Multi-Flex / other-GUI-client broadcasts still refresh
+    //     the radio list passively; only the re-bind churn stops.
+    //   • routed/VPN/SmartLink (remote=true): local UDP broadcasts cannot
+    //     reach us by design, so passive listening buys nothing — fully
+    //     quiesce by stopping the stale sweep and releasing the socket.
+    // On disconnect, discovery resumes (re-bind with a fresh retry budget) so
+    // the next connection — possibly a different local radio — can be found.
+    void setConnected(bool connected, bool remote);
 
     QList<RadioInfo> discoveredRadios() const { return m_radios; }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10575,6 +10575,13 @@ void MainWindow::onConnectionStateChanged(bool connected)
     }
 
     m_connPanel->setConnected(connected);
+
+    // Pause/resume the discovery re-bind loop in step with the connection
+    // lifecycle.  Without this the 5-second close()+bind() churn ran for the
+    // whole session on routed/VPN ("Connect by IP") sessions, where UDP
+    // broadcasts never reach the client by design (#3420).
+    m_discovery.setConnected(connected);
+
     if (connected) {
         m_suppressStartupPanLayoutRearrange = false;
         m_layoutRestoreUntilMs = kPanLayoutRestoreWaitingForFirstPan;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10579,8 +10579,13 @@ void MainWindow::onConnectionStateChanged(bool connected)
     // Pause/resume the discovery re-bind loop in step with the connection
     // lifecycle.  Without this the 5-second close()+bind() churn ran for the
     // whole session on routed/VPN ("Connect by IP") sessions, where UDP
-    // broadcasts never reach the client by design (#3420).
-    m_discovery.setConnected(connected);
+    // broadcasts never reach the client by design (#3420).  Routed and
+    // SmartLink/WAN sessions cannot receive local broadcasts at all, so flag
+    // them as "remote" to fully quiesce discovery rather than just pausing the
+    // re-bind churn.
+    const bool remoteConnection =
+        m_radioModel.isWan() || m_radioModel.lastRadioInfo().isRouted;
+    m_discovery.setConnected(connected, remoteConnection);
 
     if (connected) {
         m_suppressStartupPanLayoutRearrange = false;


### PR DESCRIPTION
## Summary

Fixes the background **discovery re-bind loop that runs forever while a radio is connected via IP** (routed / VPN / "Connect by IP"). `RadioDiscovery` was started once at launch and never coupled to the connection lifecycle, so its 5-second `close()` + re-`bind()` recovery loop — whose only exit was "first UDP broadcast received" — churned for the entire session on any link where broadcasts can't arrive (routed/VPN, SmartLink/WAN, or macOS Local Network consent silently dropping packets).

Closes #3420. **Supersedes #3421** (the autonomous-agent fix) — this PR contains that work plus the routed/WAN full-quiesce refinement and on-hardware verification. Please close #3421 as a duplicate.

## Root cause

- Discovery is a **UDP broadcast listener** on port 4992. It was started at app launch and only stopped at app shutdown or a manual "Retry Discovery" — `onConnectionStateChanged(true)` never touched it.
- `startListening()` arms a 5s `m_rebindTimer` whenever `!m_receivedAny`; the timer's lambda calls `startListening()` again (close + rebind). The **only** thing that stops it is the first inbound broadcast.
- "Connect by IP" is the routed path (`info.isRouted = true`), used precisely *because discovery broadcasts cannot reach the radio* (the panel's own UI says so). So `m_receivedAny` never flips → the re-bind loop runs indefinitely, every 5 seconds, while a perfectly healthy TCP session is up.
- There was **no retry cap** on the re-bind loop (unlike the bind-*failure* path, capped at `MAX_BIND_RETRIES`).

## What changed

Three complementary fixes, addressing all three options proposed in #3420:

**1. Stop the re-bind churn on connect** — new `RadioDiscovery::setConnected(connected, remote)`, wired from `MainWindow::onConnectionStateChanged()`. On connect the 5s re-bind timer is stopped for the rest of the session.

**2. Cap the re-bind attempts** — new `MAX_REBIND_RETRIES = 12` (60s) + `m_rebindAttempts` counter. Even with *no* connection event (e.g. no radio present, or macOS consent denied forever), discovery self-terminates the loop instead of thrashing indefinitely, logging a single give-up warning. The budget resets on disconnect and on `stopListening()`.

**3. Fully quiesce on routed / VPN / SmartLink connections** (`remote = true`) — for links where local broadcasts can't reach us by design, keeping the socket bound buys nothing, so discovery stops the stale sweep **and releases the UDP socket** — completely idle for the session. Local connections keep the conservative behavior: only the re-bind churn stops; the socket stays bound and the stale sweep runs so Multi-Flex / other-GUI-client broadcasts still refresh the radio list passively.

On **disconnect**, discovery resumes (`startListening()` re-binds the socket if it was released, restarts the stale sweep, and re-arms the bounded re-bind loop) so the next connection — possibly a different local radio — can still be found.

### `remote` predicate (MainWindow)

```cpp
const bool remoteConnection =
    m_radioModel.isWan() || m_radioModel.lastRadioInfo().isRouted;
m_discovery.setConnected(connected, remoteConnection);
```

`m_lastInfo` is set in `RadioModel::connectToRadio()` before `connectionStateChanged(true)` is emitted, so `isRouted`/`isWan()` are valid in the handler.

### Behavior matrix

| State | Re-bind churn | Stale sweep | UDP socket | Rationale |
|-------|:---:|:---:|:---:|-----------|
| Connected — **local** | stopped | running | bound | passive Multi-Flex / other-client updates still flow |
| Connected — **routed / VPN / WAN** | stopped | stopped | **released** | broadcasts can't reach us; nothing to listen for |
| Disconnected | resumes (bounded ≤12) | running | bound | find the next radio for the picker |
| Never connects / no radio | self-terminates after 12 (~60s) | running | bound | no infinite thrash |

## Files changed

- `src/core/RadioDiscovery.h` — `setConnected(bool, bool)`, `MAX_REBIND_RETRIES`, `m_rebindAttempts`, `m_connected`.
- `src/core/RadioDiscovery.cpp` — bounded re-bind lambda, connect-aware `startListening()` guard, `setConnected()` implementation.
- `src/gui/MainWindow.cpp` — compute `remote` and call `setConnected()` from the connection-state handler.

## Test plan

Manual steps:

1. **Connect by IP (routed) to a FlexRadio.** Expect discovery to fully pause on connect and stay silent — no `re-binding` lines — for the whole session.
2. **Temp disconnect.** Expect `resuming discovery` + a fresh `listening`; the picker is live again.
3. **Reconnect by IP.** Expect it to re-pause.
4. **Stay disconnected with no broadcast-reachable radio.** Expect the bounded loop to give up after 12 attempts (~60s).
5. **Connect to a locally-discovered radio.** Expect `local radio connected — pausing re-bind loop` and the radio list to keep updating passively. *(By design / code review — steps 1–4 were verified on hardware below.)*

### On-hardware results — FLEX-8400M, Connect-by-IP (routed)

Verified across two app sessions (IP redacted by the logger). Steps 1–4 confirmed:

**Routed connect → full quiesce; ~56s connected window with zero re-bind spam (the bug, gone):**
```
20:33:38.259  RadioDiscovery: listening on UDP 4992
20:33:39.230  Auto-connecting to routed radio …203
20:33:39.318  RadioDiscovery: remote radio connected — discovery fully paused
   … 56 seconds connected — NO re-bind lines …
```

**Temp disconnect → resume; bounded re-bind while disconnected; reconnect → re-pause:**
```
20:34:35.056  RadioDiscovery: radio disconnected — resuming discovery
20:34:35.057  RadioDiscovery: listening on UDP 4992
20:34:40.189  RadioDiscovery: no packets yet, re-binding socket (attempt 1 / 12 )
20:34:45.188  RadioDiscovery: no packets yet, re-binding socket (attempt 2 / 12 )
20:34:48.699  RadioDiscovery: remote radio connected — discovery fully paused
```

Observed: full quiesce within ~100 ms of every routed connect; the previously noisy connected window is now completely silent; disconnect cleanly resumes discovery; the re-bind counter increments and is capped, and resets to `attempt 1` on each new disconnect cycle. Builds clean on macOS (arm64, Qt6 / Homebrew, Ninja).

## Scope / risk

- **Client-side networking only** — no radio-authoritative state is touched; nothing persisted.
- The local "keep passively listening vs. fully quiesce" choice is intentionally conservative (local keeps listening). Happy to flip locals to full quiesce too if preferred — it's a one-line change in `setConnected()`.

## Relationship to #3421

This branch is built on #3421's commit and adds the routed/WAN full-quiesce refinement (option 3 from the issue) plus on-hardware verification. Once this merges, #3421 can be closed as superseded.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
