### PR TITLE
fix(tuner): optimistic state update in setOperate/setBypass prevents label desync (#3355)

### DIFF
--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -89,9 +89,8 @@ void TunerModel::setOperate(bool on)
     const QString cmd = "tgxl set handle=" + m_handle + " mode=" + (on ? "1" : "0");
     qCDebug(lcTuner) << "TunerModel:" << cmd;
     emit commandReady(cmd);
-    // Optimistic update: reflect the commanded state immediately so the button
-    // label stays in sync even before the radio echoes back the new state.
-    // applyStatus() self-corrects if the radio rejects or overrides our value.
+    // Optimistic update: reflect the commanded state immediately so the
+    // button label stays in sync even before the radio echoes back.
     if (m_operate != on) { m_operate = on; emit stateChanged(); }
 }
 
@@ -104,7 +103,8 @@ void TunerModel::setBypass(bool on)
     const QString cmd = "tgxl set handle=" + m_handle + " bypass=" + (on ? "1" : "0");
     qCDebug(lcTuner) << "TunerModel:" << cmd;
     emit commandReady(cmd);
-    // Optimistic update: same rationale as setOperate above.
+    // Optimistic update: reflect the commanded state immediately so the
+    // button label stays in sync even before the radio echoes back.
     if (m_bypass != on) { m_bypass = on; emit stateChanged(); }
 }
 

--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -89,6 +89,10 @@ void TunerModel::setOperate(bool on)
     const QString cmd = "tgxl set handle=" + m_handle + " mode=" + (on ? "1" : "0");
     qCDebug(lcTuner) << "TunerModel:" << cmd;
     emit commandReady(cmd);
+    // Optimistic update: reflect the commanded state immediately so the button
+    // label stays in sync even before the radio echoes back the new state.
+    // applyStatus() self-corrects if the radio rejects or overrides our value.
+    if (m_operate != on) { m_operate = on; emit stateChanged(); }
 }
 
 void TunerModel::setBypass(bool on)
@@ -100,6 +104,8 @@ void TunerModel::setBypass(bool on)
     const QString cmd = "tgxl set handle=" + m_handle + " bypass=" + (on ? "1" : "0");
     qCDebug(lcTuner) << "TunerModel:" << cmd;
     emit commandReady(cmd);
+    // Optimistic update: same rationale as setOperate above.
+    if (m_bypass != on) { m_bypass = on; emit stateChanged(); }
 }
 
 void TunerModel::autoTune()


### PR DESCRIPTION
## Root cause

`TunerModel::setOperate()` and `setBypass()` sent a TCP command to the radio via
`commandReady()` but left `m_operate` / `m_bypass` unchanged until the radio's TCP
echo arrived via `applyStatus()`. During that round-trip window, a rapid second
click would call `cycleOperateState()` with stale model state, take the wrong
branch, and send a command that moved the tuner to the unintended state. The button
label (via `syncFromModel()`) then reflected that wrong commanded state — label vs
actual state desync.

## Fix

Add an optimistic update after `commandReady()` in both setters:

```cpp
if (m_operate != on) { m_operate = on; emit stateChanged(); }
```

The button label now updates immediately on click so `cycleOperateState()` always
reads the current commanded state. When the radio echo arrives, `applyStatus()` sees
the same value and `changed` stays false — no redundant `stateChanged()` fires.
If the radio overrides our value (e.g. rejected command), `applyStatus()` 
self-corrects on the next echo.

## Testing

- Verified clean compile on macOS
- Code-reviewed: `applyStatus()` already guards every field with `if (m_field != val)` so the optimistic update and the eventual echo are idempotent
- **No TGXL hardware available for end-to-end test** — requesting reviewer confirmation with a live TGXL cycle

Fixes #3355