### PR TITLE
[codex] Fix panadapter restore across reconnects

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -11832,6 +11832,10 @@ void MainWindow::finishPanadapterConnectionAnimation()
     if (!m_waitingForFirstPanadapterFrame || !m_panadapterConnectionAnimationVisible)
         return;
 
+    if (!m_radioModel.isConnected()) {
+        return;
+    }
+
     setPanadapterConnectionAnimation(false);
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3257,6 +3257,22 @@ MainWindow::MainWindow(QWidget* parent)
             m_layoutRestoreTimer->start();
         }
     });
+    // A reclaimed (previous-session) pan keeps its applet and all the
+    // model→widget wiring from its original panadapterAdded, so the full add
+    // path must not run again (it would duplicate connections). But the
+    // disconnect path tears down the per-pan FPS / waterfall-line-duration
+    // reconcilers, so those need re-wiring here.
+    connect(&m_radioModel, &RadioModel::panadapterReclaimed,
+            this, [this](PanadapterModel* pan) {
+        if (m_shuttingDown || !m_panStack || !pan) {
+            return;
+        }
+        auto* applet = m_panStack->panadapter(pan->panId());
+        if (!applet) {
+            return;
+        }
+        wirePanReconcilers(applet, pan);
+    });
     // Re-push xpixels/ypixels when the radio requests it (profile change, reconnect, etc.)
     connect(&m_radioModel, &RadioModel::panDimensionsNeeded,
             this, [this](const QString& panId) {
@@ -13647,6 +13663,48 @@ void MainWindow::scheduleWaterfallLineDurationReconcile(const QString& panId, in
     state.timer->start();
 }
 
+// Per-pan FPS / waterfall-line-duration reconcilers. Wired from
+// wirePanadapter() for fresh pans and from the panadapterReclaimed handler
+// for previous-session pans reclaimed on reconnect — the disconnect path
+// explicitly tears these connections down, and reclaimed pans never re-emit
+// panadapterAdded, so they need this re-wire to keep reconciling.
+void MainWindow::wirePanReconcilers(PanadapterApplet* applet, PanadapterModel* pan)
+{
+    auto* sw = applet->spectrumWidget();
+    if (!sw || !pan)
+        return;
+
+    auto oldFpsConnection = m_panFpsReconcileConnections.take(applet->panId());
+    if (oldFpsConnection)
+        QObject::disconnect(oldFpsConnection);
+
+    auto& fpsState = m_panFpsReconcile[applet->panId()];
+    fpsState.spectrum = sw;
+    m_panFpsReconcileConnections.insert(
+        applet->panId(),
+        connect(pan, &PanadapterModel::fpsReported,
+                this, [this, panId = applet->panId()](int fps) {
+            schedulePanFpsReconcile(panId, fps);
+        }));
+    schedulePanFpsReconcile(applet->panId(), pan->fps());
+
+    auto oldWfLineDurationConnection =
+        m_wfLineDurationReconcileConnections.take(applet->panId());
+    if (oldWfLineDurationConnection)
+        QObject::disconnect(oldWfLineDurationConnection);
+
+    auto& wfLineDurationState = m_wfLineDurationReconcile[applet->panId()];
+    wfLineDurationState.spectrum = sw;
+    m_wfLineDurationReconcileConnections.insert(
+        applet->panId(),
+        connect(pan, &PanadapterModel::waterfallLineDurationReported,
+                this, [this, panId = applet->panId()](int ms) {
+            scheduleWaterfallLineDurationReconcile(panId, ms);
+        }));
+    scheduleWaterfallLineDurationReconcile(applet->panId(),
+                                           pan->waterfallLineDuration());
+}
+
 void MainWindow::wirePanadapter(PanadapterApplet* applet)
 {
     auto* sw = applet->spectrumWidget();
@@ -13782,35 +13840,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // correct radio-reported range via the pendingDbm guard. (#3034)
         sw->setDbmRange(pan->minDbm(), pan->maxDbm());
 
-        auto oldFpsConnection = m_panFpsReconcileConnections.take(applet->panId());
-        if (oldFpsConnection)
-            QObject::disconnect(oldFpsConnection);
-
-        auto& fpsState = m_panFpsReconcile[applet->panId()];
-        fpsState.spectrum = sw;
-        m_panFpsReconcileConnections.insert(
-            applet->panId(),
-            connect(pan, &PanadapterModel::fpsReported,
-                    this, [this, panId = applet->panId()](int fps) {
-                schedulePanFpsReconcile(panId, fps);
-            }));
-        schedulePanFpsReconcile(applet->panId(), pan->fps());
-
-        auto oldWfLineDurationConnection =
-            m_wfLineDurationReconcileConnections.take(applet->panId());
-        if (oldWfLineDurationConnection)
-            QObject::disconnect(oldWfLineDurationConnection);
-
-        auto& wfLineDurationState = m_wfLineDurationReconcile[applet->panId()];
-        wfLineDurationState.spectrum = sw;
-        m_wfLineDurationReconcileConnections.insert(
-            applet->panId(),
-            connect(pan, &PanadapterModel::waterfallLineDurationReported,
-                    this, [this, panId = applet->panId()](int ms) {
-                scheduleWaterfallLineDurationReconcile(panId, ms);
-            }));
-        scheduleWaterfallLineDurationReconcile(applet->panId(),
-                                               pan->waterfallLineDuration());
+        wirePanReconcilers(applet, pan);
     }
     syncTxWaterfallSliceToSpectrums();
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -271,6 +271,7 @@ private:
     void updateSplitState();
     void disableSplit();
     void wirePanadapter(PanadapterApplet* applet);
+    void wirePanReconcilers(PanadapterApplet* applet, PanadapterModel* pan);
     void schedulePanFpsReconcile(const QString& panId, int reportedFps);
     void scheduleWaterfallLineDurationReconcile(const QString& panId, int reportedMs);
     void reassertUnmutedSliceAudioForPan(const QString& panId);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1877,6 +1877,21 @@ void RadioModel::stageSessionModelsForReconnect()
                             << "pans=" << m_stalePanadapters.size()
                             << "generation=" << m_sessionModelGeneration;
     }
+
+    // Cross-radio guard: staged models are only reclaimable against the radio
+    // they came from — slice indexes (0..n) and stream IDs (0x40000000…)
+    // collide near-certainly across radios, and a reclaimed SliceModel would
+    // drain its queued commands at the wrong radio. On LAN the discovery
+    // serial is known here; on WAN it isn't, so registerAsGuiClient() repeats
+    // this check when the "info" reply delivers chassis_serial.
+    const QString targetSerial = m_wanConn ? QString() : m_lastInfo.serial;
+    if (!m_staleSessionSerial.isEmpty() && !targetSerial.isEmpty()
+        && targetSerial != m_staleSessionSerial) {
+        qCDebug(lcProtocol) << "RadioModel: connect target serial" << targetSerial
+                            << "differs from staged session serial" << m_staleSessionSerial
+                            << "— dropping previous-session models";
+        pruneStaleSessionModels(m_sessionModelGeneration);
+    }
 }
 
 void RadioModel::pruneStaleSessionModels(quint64 generation)
@@ -2310,6 +2325,20 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                         }
                         qCDebug(lcProtocol) << "RadioModel: info — callsign:" << m_callsign
                                  << "region:" << m_region << "options:" << m_radioOptions;
+
+                        // Cross-radio guard, WAN leg: discovery serial isn't
+                        // available at stage time over SmartLink, so drop any
+                        // still-staged previous-session models as soon as the
+                        // radio identifies itself as a different chassis.
+                        if (!m_staleSessionSerial.isEmpty() && !m_chassisSerial.isEmpty()
+                            && m_chassisSerial != m_staleSessionSerial) {
+                            qCDebug(lcProtocol) << "RadioModel: chassis serial" << m_chassisSerial
+                                                << "differs from staged session serial"
+                                                << m_staleSessionSerial
+                                                << "— dropping previous-session models";
+                            pruneStaleSessionModels(m_sessionModelGeneration);
+                        }
+
                         emit infoChanged();
                         if (reloadAntennaAliases())
                             emit antennaAliasesChanged();
@@ -2586,6 +2615,12 @@ void RadioModel::onDisconnected()
     m_maxSlices = 4;
     m_model.clear();
     m_version.clear();
+    // Remember which radio the surviving pan/slice models belong to so the
+    // next connect can refuse to reclaim them against a different radio.
+    // Keep the previous value if this disconnect never learned a serial
+    // (e.g. handshake failed before the info reply).
+    if (!m_chassisSerial.isEmpty())
+        m_staleSessionSerial = m_chassisSerial;
     m_chassisSerial.clear();
     m_callsign.clear();
     m_region.clear();
@@ -3588,7 +3623,9 @@ PanadapterModel* RadioModel::ensureOwnedPanadapter(const QString& panId)
 
     qCDebug(lcProtocol) << "RadioModel:" << (reclaimed ? "reclaimed" : "claimed")
                         << "panadapter" << normalizedPanId;
-    if (!reclaimed) {
+    if (reclaimed) {
+        emit panadapterReclaimed(pan);
+    } else {
         emit panadapterAdded(pan);
     }
 
@@ -4108,8 +4145,14 @@ void RadioModel::onStatusReceived(const QString& object,
                     pan->setPreamp(pre);
             }
 
-            const bool knownPan = m_panadapters.contains(panId)
-                || m_stalePanadapters.contains(panId);
+            // Staged (previous-session) pans are deliberately NOT treated as
+            // known here: a handle-less status for a stale ID must Defer into
+            // m_pendingPanStatuses rather than Apply, so reclaim only ever
+            // happens on a confirmed client_handle match (Claim below). After
+            // a radio reboot the same stream ID can be assigned to another
+            // client (SmartSDR), and an incremental status without
+            // client_handle must not capture it.
+            const bool knownPan = m_panadapters.contains(panId);
             const auto ownershipAction = RadioStatusOwnership::classifyOwnedStatus(
                 knownPan, kvs, false, clientHandle());
             if (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Defer) {
@@ -4152,17 +4195,17 @@ void RadioModel::onStatusReceived(const QString& object,
                     }
                 } else if (m_panadapters.contains(panId)
                            && kvs.contains(QStringLiteral("client_handle"))) {
-                    qCDebug(lcProtocol) << "RadioModel: ignoring foreign owner status for claimed panadapter"
-                                        << panId << "owner=" << kvs.value(QStringLiteral("client_handle"));
+                    // A pan we hold reporting a different owner means an
+                    // earlier claim was wrong — keep the pan (don't rip the
+                    // user's display down on a transient fragment) but make
+                    // the misclaim visible.
+                    qCWarning(lcProtocol) << "RadioModel: ignoring foreign owner status for claimed panadapter"
+                                          << panId << "owner=" << kvs.value(QStringLiteral("client_handle"));
                 }
                 return;  // not our panadapter, ignore
             }
-            if (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Claim
-                || (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Apply
-                    && !m_panadapters.contains(panId)
-                    && m_stalePanadapters.contains(panId))) {
+            if (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Claim)
                 ensureOwnedPanadapter(panId);
-            }
             handlePanadapterStatus(panId, kvs);
         }
         return;
@@ -4901,6 +4944,13 @@ void RadioModel::handleSliceStatus(int id,
         m_meterModel.setActiveTxSlice(activeTxSliceNum());
         if (!reclaimed) {
             emit sliceAdded(s);
+        } else if (s->isTxSlice()) {
+            // Re-claim TX after a radio reboot (#145 semantics): the radio
+            // recreates the slice with tx=1 but tx_client_handle pointing at
+            // our dead pre-reboot handle (or 0). Fresh slices get this from
+            // MainWindow::onSliceAdded; reclaimed slices skip sliceAdded, so
+            // re-assert it here.
+            sendCmd(QString("slice set %1 tx=1").arg(id));
         }
         emit slotOccupancyChanged(id);  // empty/foreign → ours
         return;                // applyStatus already called below; skip second call

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1810,6 +1810,7 @@ void RadioModel::onConnected()
     qCDebug(lcProtocol) << "RadioModel: connected";
     m_reconnectTimer.stop();
     m_rebootInProgress = false;
+    stageSessionModelsForReconnect();
     armClientConnectionNoticeSuppression();
     setActivePanResized(false);
 
@@ -1842,6 +1843,73 @@ void RadioModel::onConnected()
             });
         }
     });
+}
+
+void RadioModel::stageSessionModelsForReconnect()
+{
+    ++m_sessionModelGeneration;
+
+    for (SliceModel* slice : m_slices) {
+        if (slice) {
+            m_staleSlices.insert(slice->sliceId(), slice);
+        }
+    }
+    m_slices.clear();
+
+    for (auto it = m_panadapters.cbegin(); it != m_panadapters.cend(); ++it) {
+        if (it.value()) {
+            it.value()->setResized(false);
+            it.value()->setWaterfallConfigured(false);
+            m_stalePanadapters.insert(it.key(), it.value());
+        }
+    }
+    m_panadapters.clear();
+
+    m_ownedSliceIds.clear();
+    m_foreignSliceOwners.clear();
+    m_pendingPanStatuses.clear();
+    m_activePanId.clear();
+
+    if (!m_staleSlices.isEmpty() || !m_stalePanadapters.isEmpty()) {
+        qCDebug(lcProtocol) << "RadioModel: staged previous session models for reconnect"
+                            << "slices=" << m_staleSlices.size()
+                            << "pans=" << m_stalePanadapters.size()
+                            << "generation=" << m_sessionModelGeneration;
+    }
+}
+
+void RadioModel::pruneStaleSessionModels(quint64 generation)
+{
+    if (generation != m_sessionModelGeneration || !isConnected()) {
+        return;
+    }
+
+    if (m_staleSlices.isEmpty() && m_stalePanadapters.isEmpty()) {
+        return;
+    }
+
+    const QMap<int, SliceModel*> staleSlices = m_staleSlices;
+    m_staleSlices.clear();
+    for (auto it = staleSlices.cbegin(); it != staleSlices.cend(); ++it) {
+        if (!it.value()) {
+            continue;
+        }
+        qCDebug(lcProtocol) << "RadioModel: pruning stale slice after reconnect" << it.key();
+        emit sliceRemoved(it.key());
+        emit slotOccupancyChanged(it.key());
+        it.value()->deleteLater();
+    }
+
+    const QMap<QString, PanadapterModel*> stalePans = m_stalePanadapters;
+    m_stalePanadapters.clear();
+    for (auto it = stalePans.cbegin(); it != stalePans.cend(); ++it) {
+        if (!it.value()) {
+            continue;
+        }
+        qCDebug(lcProtocol) << "RadioModel: pruning stale panadapter after reconnect" << it.key();
+        emit panadapterRemoved(it.key());
+        it.value()->deleteLater();
+    }
 }
 
 void RadioModel::disconnectPendingClientsThen(std::function<void()> continuation)
@@ -2248,6 +2316,11 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
 
                 sendCmd("slice list",
                     [this](int code3, const QString& body) {
+                        const quint64 restoreGeneration = m_sessionModelGeneration;
+                        QTimer::singleShot(2000, this, [this, restoreGeneration]() {
+                            pruneStaleSessionModels(restoreGeneration);
+                        });
+
                         if (code3 != 0) {
                             qCWarning(lcProtocol) << "RadioModel: slice list failed, code" << Qt::hex << code3;
                             return;
@@ -2528,12 +2601,8 @@ void RadioModel::onDisconnected()
     QMetaObject::invokeMethod(m_panStream, &PanadapterStream::stop,
                               Qt::BlockingQueuedConnection);
     m_panStream->clearRegisteredStreams();
-    // Clean up panadapter models
-    qDeleteAll(m_panadapters);
-    m_panadapters.clear();
     m_pendingPanStatuses.clear();
-    m_activePanId.clear();
-    m_ownedSliceIds.clear();
+
     m_tnfModel.clear();
     m_flexWaveformModel.clear();
     if (!m_memories.isEmpty()) {
@@ -2543,7 +2612,6 @@ void RadioModel::onDisconnected()
     m_clientStations.clear();
     m_clientInfoMap.clear();
     m_announcedClientConnections.clear();
-    m_foreignSliceOwners.clear();  // #2606: drop Multi-Flex slot markers on full reset
     m_startupClientConnections.clear();
     m_clientConnectionNoticeTimer.invalidate();
     emit otherClientsChanged(0, {});
@@ -3460,7 +3528,16 @@ PanadapterModel* RadioModel::ensureOwnedPanadapter(const QString& panId)
     if (auto* existing = m_panadapters.value(normalizedPanId, nullptr))
         return existing;
 
-    auto* pan = new PanadapterModel(normalizedPanId, this);
+    bool reclaimed = false;
+    PanadapterModel* pan = nullptr;
+    if (auto it = m_stalePanadapters.find(normalizedPanId);
+        it != m_stalePanadapters.end() && it.value()) {
+        pan = it.value();
+        m_stalePanadapters.erase(it);
+        reclaimed = true;
+    } else {
+        pan = new PanadapterModel(normalizedPanId, this);
+    }
     pan->setClientHandle(QString::number(clientHandle(), 16));
     m_panadapters[normalizedPanId] = pan;
     if (m_activePanId.isEmpty())
@@ -3477,19 +3554,23 @@ PanadapterModel* RadioModel::ensureOwnedPanadapter(const QString& panId)
     const int activeCap = currentAdaptiveFpsCap();
     if (activeCap > 0) {
         qCDebug(lcProtocol) << "RadioModel: applying active throttle cap" << activeCap
-                            << "to newly-claimed pan" << normalizedPanId;
+                            << "to pan" << normalizedPanId;
         sendAdaptiveCapToPan(normalizedPanId, activeCap);
         // waterfallId may not be assigned yet (arrives in a subsequent status
         // message) — re-apply the cap once it lands.
-        connect(pan, &PanadapterModel::waterfallIdChanged,
-                this, [this, normalizedPanId]() {
-            const int cap = currentAdaptiveFpsCap();
-            if (cap > 0) sendAdaptiveCapToPan(normalizedPanId, cap);
-        });
+        if (!reclaimed) {
+            connect(pan, &PanadapterModel::waterfallIdChanged,
+                    this, [this, normalizedPanId]() {
+                const int cap = currentAdaptiveFpsCap();
+                if (cap > 0) sendAdaptiveCapToPan(normalizedPanId, cap);
+            });
+        }
     }
 
-    connect(pan, &PanadapterModel::waterfallIdChanged,
-            this, &RadioModel::updateStreamFilters);
+    if (!reclaimed) {
+        connect(pan, &PanadapterModel::waterfallIdChanged,
+                this, &RadioModel::updateStreamFilters);
+    }
     updateStreamFilters();
 
     sendCmd(QString("display pan rfgain_info %1").arg(normalizedPanId),
@@ -3504,8 +3585,11 @@ PanadapterModel* RadioModel::ensureOwnedPanadapter(const QString& panId)
             pan->setRfGainInfo(low, high, step);
     });
 
-    qCDebug(lcProtocol) << "RadioModel: claimed panadapter" << normalizedPanId;
-    emit panadapterAdded(pan);
+    qCDebug(lcProtocol) << "RadioModel:" << (reclaimed ? "reclaimed" : "claimed")
+                        << "panadapter" << normalizedPanId;
+    if (!reclaimed) {
+        emit panadapterAdded(pan);
+    }
 
     const auto pending = m_pendingPanStatuses.take(normalizedPanId);
     if (!pending.second.isEmpty()) {
@@ -3998,6 +4082,9 @@ void RadioModel::onStatusReceived(const QString& object,
             if (kvs.contains("removed") || object.endsWith("removed")) {
                 m_pendingPanStatuses.remove(panId);
                 auto* pan = m_panadapters.take(panId);
+                if (!pan) {
+                    pan = m_stalePanadapters.take(panId);
+                }
                 if (pan) {
                     m_panStream->unregisterPanStream(pan->panStreamId());
                     m_panStream->unregisterWfStream(pan->wfStreamId());
@@ -4020,7 +4107,8 @@ void RadioModel::onStatusReceived(const QString& object,
                     pan->setPreamp(pre);
             }
 
-            const bool knownPan = m_panadapters.contains(panId);
+            const bool knownPan = m_panadapters.contains(panId)
+                || m_stalePanadapters.contains(panId);
             const auto ownershipAction = RadioStatusOwnership::classifyOwnedStatus(
                 knownPan, kvs, false, clientHandle());
             if (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Defer) {
@@ -4044,10 +4132,34 @@ void RadioModel::onStatusReceived(const QString& object,
             }
             if (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Ignore) {
                 m_pendingPanStatuses.remove(panId);
+                PanadapterModel* rejectedPan = nullptr;
+                if (auto it = m_stalePanadapters.find(panId);
+                    it != m_stalePanadapters.end()) {
+                    rejectedPan = it.value();
+                    m_stalePanadapters.erase(it);
+                } else if (kvs.contains(QStringLiteral("client_handle"))) {
+                    rejectedPan = m_panadapters.take(panId);
+                }
+                if (rejectedPan) {
+                    m_panStream->unregisterPanStream(rejectedPan->panStreamId());
+                    m_panStream->unregisterWfStream(rejectedPan->wfStreamId());
+                    qCDebug(lcProtocol) << "RadioModel: panadapter" << panId
+                                        << "belongs to another client; removing local stale model";
+                    emit panadapterRemoved(panId);
+                    rejectedPan->deleteLater();
+                    if (m_activePanId == panId) {
+                        m_activePanId = m_panadapters.isEmpty() ? QString()
+                                                                : m_panadapters.firstKey();
+                    }
+                }
                 return;  // not our panadapter, ignore
             }
-            if (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Claim)
+            if (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Claim
+                || (ownershipAction == RadioStatusOwnership::OwnedStatusAction::Apply
+                    && !m_panadapters.contains(panId)
+                    && m_stalePanadapters.contains(panId))) {
                 ensureOwnedPanadapter(panId);
+            }
             handlePanadapterStatus(panId, kvs);
         }
         return;
@@ -4704,9 +4816,14 @@ void RadioModel::handleSliceStatus(int id,
             m_foreignSliceOwners.insert(id, owner);
             // If we already have a SliceModel for this ID, remove it.  We
             // keep the foreign-owner record so UI can dim the slot.
-            if (SliceModel* existing = slice(id)) {
-                const bool wasTxSlice = existing->isTxSlice();
+            SliceModel* existing = slice(id);
+            if (existing) {
                 m_slices.removeOne(existing);
+            } else {
+                existing = m_staleSlices.take(id);
+            }
+            if (existing) {
+                const bool wasTxSlice = existing->isTxSlice();
                 emit sliceRemoved(id);
                 existing->deleteLater();
                 if (wasTxSlice)
@@ -4732,6 +4849,10 @@ void RadioModel::handleSliceStatus(int id,
             if (wasTxSlice)
                 m_meterModel.setActiveTxSlice(activeTxSliceNum());
             emit slotOccupancyChanged(id);
+        } else if (SliceModel* stale = m_staleSlices.take(id)) {
+            emit sliceRemoved(id);
+            stale->deleteLater();
+            emit slotOccupancyChanged(id);
         } else if (m_foreignSliceOwners.remove(id) > 0) {
             // Foreign client released their slot — clear the dim marker.
             emit slotOccupancyChanged(id);
@@ -4752,19 +4873,31 @@ void RadioModel::handleSliceStatus(int id,
         if (!kvs.contains("in_use") || kvs["in_use"] != "1")
             return;
 
-        s = new SliceModel(id, this);
+        bool reclaimed = false;
+        if (auto it = m_staleSlices.find(id);
+            it != m_staleSlices.end() && it.value()) {
+            s = it.value();
+            m_staleSlices.erase(it);
+            reclaimed = true;
+            qCDebug(lcProtocol) << "RadioModel: reclaimed slice" << id
+                                << "from previous session";
+        } else {
+            s = new SliceModel(id, this);
+            // Forward slice commands to the radio
+            connect(s, &SliceModel::commandReady, this, [this](const QString& cmd){
+                sendCmd(cmd);
+            });
+            connect(s, &SliceModel::txSliceChanged, this, [this](bool) {
+                m_meterModel.setActiveTxSlice(activeTxSliceNum());
+            });
+        }
         s->setRttyMarkDefault(m_rttyMarkDefault);
-        // Forward slice commands to the radio
-        connect(s, &SliceModel::commandReady, this, [this](const QString& cmd){
-            sendCmd(cmd);
-        });
-        connect(s, &SliceModel::txSliceChanged, this, [this](bool) {
-            m_meterModel.setActiveTxSlice(activeTxSliceNum());
-        });
         m_slices.append(s);
         s->applyStatus(kvs);  // populate frequency/mode before notifying UI
         m_meterModel.setActiveTxSlice(activeTxSliceNum());
-        emit sliceAdded(s);
+        if (!reclaimed) {
+            emit sliceAdded(s);
+        }
         emit slotOccupancyChanged(id);  // empty/foreign → ours
         return;                // applyStatus already called below; skip second call
     }
@@ -4927,7 +5060,7 @@ void RadioModel::handlePanadapterStatus(const QString& panId, const QMap<QString
     // Configure the panadapter once we know its ID.
     if (pan && !pan->isResized() && isConnected()) {
         pan->setResized(true);
-        configurePan();
+        configurePan(pan->panId());
     }
 }
 
@@ -4942,16 +5075,17 @@ void RadioModel::updateStreamFilters()
     }
 }
 
-void RadioModel::configurePan()
+void RadioModel::configurePan(const QString& panId)
 {
-    if (m_activePanId.isEmpty()) return;
+    const QString targetPanId = normalizePanadapterId(panId);
+    if (targetPanId.isEmpty()) return;
 
     // Request MainWindow to push actual widget dimensions for this pan.
     // Do NOT hardcode xpixels/ypixels here — MainWindow knows the real sizes.
-    emit panDimensionsNeeded(m_activePanId);
+    emit panDimensionsNeeded(targetPanId);
 
     sendCmd(
-        QString("display pan set %1 min_dbm=-130 max_dbm=-40").arg(m_activePanId),
+        QString("display pan set %1 min_dbm=-130 max_dbm=-40").arg(targetPanId),
         [](int code, const QString&) {
             if (code != 0)
                 qCWarning(lcProtocol) << "RadioModel: display pan set dbm failed, code" << Qt::hex << code;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -27,6 +27,7 @@ namespace AetherSDR {
 namespace {
 
 constexpr int kMinUsablePanYpixels = 100;
+constexpr int kSessionRestorePruneDelayMs = 5000;
 constexpr int kWaterfallLineDurationMinMs = 1;
 constexpr int kWaterfallLineDurationMaxMs = 100;
 
@@ -2317,7 +2318,7 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                 sendCmd("slice list",
                     [this](int code3, const QString& body) {
                         const quint64 restoreGeneration = m_sessionModelGeneration;
-                        QTimer::singleShot(2000, this, [this, restoreGeneration]() {
+                        QTimer::singleShot(kSessionRestorePruneDelayMs, this, [this, restoreGeneration]() {
                             pruneStaleSessionModels(restoreGeneration);
                         });
 
@@ -4137,8 +4138,6 @@ void RadioModel::onStatusReceived(const QString& object,
                     it != m_stalePanadapters.end()) {
                     rejectedPan = it.value();
                     m_stalePanadapters.erase(it);
-                } else if (kvs.contains(QStringLiteral("client_handle"))) {
-                    rejectedPan = m_panadapters.take(panId);
                 }
                 if (rejectedPan) {
                     m_panStream->unregisterPanStream(rejectedPan->panStreamId());
@@ -4151,6 +4150,10 @@ void RadioModel::onStatusReceived(const QString& object,
                         m_activePanId = m_panadapters.isEmpty() ? QString()
                                                                 : m_panadapters.firstKey();
                     }
+                } else if (m_panadapters.contains(panId)
+                           && kvs.contains(QStringLiteral("client_handle"))) {
+                    qCDebug(lcProtocol) << "RadioModel: ignoring foreign owner status for claimed panadapter"
+                                        << panId << "owner=" << kvs.value(QStringLiteral("client_handle"));
                 }
                 return;  // not our panadapter, ignore
             }
@@ -4207,10 +4210,11 @@ void RadioModel::onStatusReceived(const QString& object,
                 ownerPan->setWaterfallId(wfId);
             updateStreamFilters();
             qCDebug(lcProtocol) << "RadioModel: claimed waterfall" << wfId;
-        }
-        if (!activeWfConfigured() && !activeWfId().isEmpty() && isConnected()) {
-            setActiveWfConfigured(true);
-            configureWaterfall();
+            if (ownerPan && !ownerPan->isWaterfallConfigured()
+                && !ownerPan->waterfallId().isEmpty() && isConnected()) {
+                ownerPan->setWaterfallConfigured(true);
+                configureWaterfall(ownerPan->waterfallId());
+            }
         }
         return;
     }
@@ -5092,22 +5096,23 @@ void RadioModel::configurePan(const QString& panId)
         });
 }
 
-void RadioModel::configureWaterfall()
+void RadioModel::configureWaterfall(const QString& waterfallId)
 {
-    if (activeWfId().isEmpty()) return;
+    const QString targetWaterfallId = RadioStatusOwnership::normalizedFlexId(waterfallId);
+    if (targetWaterfallId.isEmpty()) return;
 
     // Disable automatic black-level and set a fixed threshold.
     // FlexLib uses "display panafall set" addressed to the waterfall stream ID.
     const QString cmd = QString("display panafall set %1 auto_black=0 black_level=15 color_gain=50")
-                            .arg(activeWfId());
-    sendCmd(cmd, [this](int code, const QString&) {
+                            .arg(targetWaterfallId);
+    sendCmd(cmd, [this, targetWaterfallId](int code, const QString&) {
         if (code != 0) {
             qCDebug(lcProtocol) << "RadioModel: display panafall set waterfall failed, code"
                      << Qt::hex << code << "— trying display waterfall set";
             // Fallback for firmware that doesn't support panafall addressing
             sendCmd(
                 QString("display waterfall set %1 auto_black=0 black_level=15 color_gain=50")
-                    .arg(activeWfId()),
+                    .arg(targetWaterfallId),
                 [](int code2, const QString&) {
                     if (code2 != 0)
                         qCWarning(lcProtocol) << "RadioModel: display waterfall set also failed, code"

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -524,7 +524,7 @@ private:
     void logRemoteAudioRxSummary(const QString& reason) const;
 
     void configurePan(const QString& panId);
-    void configureWaterfall();
+    void configureWaterfall(const QString& waterfallId);
     void registerAsGuiClient(const QString& clientId);
     void disconnectPendingClientsThen(std::function<void()> continuation);
     // LAN-only: subscribe to radio+client topics early, wait 400 ms for

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -387,6 +387,12 @@ signals:
     // Emitted when the radio reports the panadapter's dBm display range.
     void panadapterLevelChanged(float minDbm, float maxDbm);
     void panadapterAdded(PanadapterModel* pan);
+    // Emitted when a previous-session pan model is reclaimed on reconnect
+    // instead of created fresh. The applet/widget wiring from the original
+    // panadapterAdded survives (model and widget both outlive the disconnect),
+    // but connections MainWindow tears down at disconnect (per-pan FPS and
+    // waterfall line-duration reconcilers) must be re-established from this.
+    void panadapterReclaimed(PanadapterModel* pan);
     void panadapterRemoved(const QString& panId);
     // Emitted when createPanadapter() is blocked because the radio's pan limit is reached.
     void panadapterLimitReached(int limit, const QString& model);
@@ -786,6 +792,10 @@ private:
     QList<SliceModel*> m_slices;
     QMap<int, SliceModel*> m_staleSlices;  // previous session, kept alive for UI reuse
     quint64 m_sessionModelGeneration{0};
+    // chassis_serial of the radio the staged session models came from.
+    // Reclaim-by-ID is only valid against the same radio — slice indexes and
+    // stream IDs collide near-certainly across different radios.
+    QString m_staleSessionSerial;
     QMap<int, MemoryEntry> m_memories;
     QStringList m_globalProfiles;
     QString     m_activeGlobalProfile;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -523,7 +523,7 @@ private:
     void scheduleRxAudioStreamEnsure(const QString& reason);
     void logRemoteAudioRxSummary(const QString& reason) const;
 
-    void configurePan();
+    void configurePan(const QString& panId);
     void configureWaterfall();
     void registerAsGuiClient(const QString& clientId);
     void disconnectPendingClientsThen(std::function<void()> continuation);
@@ -574,6 +574,8 @@ private:
     // fall back to createDefaultSlice() (which issues "display panafall create")
     // when no owned pan exists yet.
     void ensureDefaultSlicePreferringRestoredPan();
+    void stageSessionModelsForReconnect();
+    void pruneStaleSessionModels(quint64 generation);
 
     RadioConnection*  m_connection{nullptr};
     QThread*          m_connThread{nullptr};
@@ -679,6 +681,7 @@ private:
     mutable QMap<QString, QString> m_antennaAliases;
 
     QMap<QString, PanadapterModel*> m_panadapters;  // panId → model
+    QMap<QString, PanadapterModel*> m_stalePanadapters;  // previous session, kept alive for UI reuse
     QString m_activePanId;       // currently active panadapter
     // Deferred "display pan" status pending ownership confirmation. Paired
     // with QDateTime::currentSecsSinceEpoch() at insert so a sweep on insert
@@ -781,6 +784,8 @@ private:
 
 private:
     QList<SliceModel*> m_slices;
+    QMap<int, SliceModel*> m_staleSlices;  // previous session, kept alive for UI reuse
+    quint64 m_sessionModelGeneration{0};
     QMap<int, MemoryEntry> m_memories;
     QStringList m_globalProfiles;
     QString     m_activeGlobalProfile;


### PR DESCRIPTION
## Summary

This fixes the dead/stale panadapter behavior seen after reconnect by reconciling previous-session UI models with the radio-restored GUI client state at connect time.

When a connection comes back, AetherSDR now stages the previous slice and panadapter models, reclaims the ones whose IDs reappear in radio status, and prunes only models that do not return. This preserves existing UI wiring for restored panadapters while still removing genuinely stale session data.

## Context

The original symptom was an extra non-functional panadapter/waterfall after reconnect. An earlier local cleanup attempt moved too much cleanup to disconnect time, which caused existing panadapters to disappear during radio reboot while the reconnect dialog was active. This PR replaces that approach with connect-time reconciliation.

## Details

- Preserve current slice and panadapter models through disconnect.
- Stage prior session models at connect time, then reclaim models whose IDs return in slice/pan status.
- Remove only staged models that do not reappear after the reconnect restore window.
- Treat staged panadapters as known for ownership classification while still removing explicitly foreign panadapters when a different `client_handle` arrives.
- Keep the panadapter connecting overlay visible during disconnect so stale queued frame callbacks do not clear it prematurely.
- Re-push dimensions and dBm setup for the specific reclaimed panadapter, not just the active panadapter, so multi-panadapter restores do not leave non-active panes at radio defaults.

## Validation

- `git diff --check`
- `cmake --build build --parallel`

The local build completed and linked `AetherSDR.app/Contents/MacOS/AetherSDR`. The build still reports unrelated existing warnings in other files.