### PR TITLE
fix(freedv): gate spothub spots on tx_report, not freq_change

### DIFF
--- a/src/core/FreeDvClient.cpp
+++ b/src/core/FreeDvClient.cpp
@@ -307,16 +307,39 @@ void FreeDvClient::onFreqChange(const QJsonObject& data)
     if (info.gridSquare.isEmpty())
         info.gridSquare = data["grid_square"].toString();
 
-    if (freqMhz <= 0.0 || info.callsign.isEmpty()) return;
+    // No spot emitted here — freq_change fires on connect and on every
+    // VFO retune, including from stations that are only scanning.  Spots
+    // are created in onTxReport() when a station explicitly signals that
+    // it has begun transmitting.
+    if (freqMhz <= 0.0) return;
 
-    // Emit a spot for every station with a known frequency — this is
-    // the primary spot source.  rx_report only fires when one station
-    // actually decodes another, which is rare.  freq_change fires on
-    // connect (bulk_update) and whenever a station retunes.
+    QString logLine = QString("%1  %2  %3 MHz  freq_change")
+        .arg(QDateTime::currentDateTimeUtc().time().toString("HH:mm"),
+             info.callsign, QString::number(freqMhz, 'f', 4));
+    if (m_logFile.isOpen()) {
+        m_logFile.write((logLine + "\n").toUtf8());
+        m_logFile.flush();
+    }
+    emit rawLineReceived(logLine);
+}
+
+void FreeDvClient::onTxReport(const QJsonObject& data)
+{
+    QString sid = data["sid"].toString();
+    if (!m_stations.contains(sid)) return;
+    auto& info = m_stations[sid];
+
+    QString mode = data["mode"].toString();
+    if (!mode.isEmpty())
+        info.mode = mode;
+
+    if (!data["transmitting"].toBool()) return;
+    if (info.freqMhz <= 0.0 || info.callsign.isEmpty()) return;
+
     DxSpot spot;
     spot.dxCall      = info.callsign;
     spot.spotterCall = info.callsign;  // self-reported
-    spot.freqMhz     = freqMhz;
+    spot.freqMhz     = info.freqMhz;
     spot.source      = "FreeDV";
     spot.comment     = info.mode.isEmpty() ? "FreeDV" : info.mode;
     if (!info.gridSquare.isEmpty())
@@ -329,25 +352,15 @@ void FreeDvClient::onFreqChange(const QJsonObject& data)
         freedvColor = "#FF" + freedvColor.mid(1);
     spot.color = freedvColor;
 
-    QString logLine = QString("%1  %2  %3 MHz  %4")
+    QString logLine = QString("%1  %2  %3 MHz  TX %4")
         .arg(spot.utcTime.toString("HH:mm"), info.callsign,
-             QString::number(freqMhz, 'f', 4), spot.comment);
+             QString::number(info.freqMhz, 'f', 4), info.mode);
     if (m_logFile.isOpen()) {
         m_logFile.write((logLine + "\n").toUtf8());
         m_logFile.flush();
     }
     emit rawLineReceived(logLine);
     emit spotReceived(spot);
-}
-
-void FreeDvClient::onTxReport(const QJsonObject& data)
-{
-    QString sid = data["sid"].toString();
-    if (!m_stations.contains(sid)) return;
-    auto& info = m_stations[sid];
-    QString mode = data["mode"].toString();
-    if (!mode.isEmpty())
-        info.mode = mode;
 }
 
 void FreeDvClient::onRemoveConnection(const QJsonObject& data)


### PR DESCRIPTION
## Summary

Moves spot creation from `onFreqChange()` to `onTxReport()` in
`FreeDvClient`, fixing a spot flood on the FreeDV Reporter network.

Previously, a spot was emitted for every `freq_change` event. The server
sends `freq_change` for every station in the initial `bulk_update` snapshot
and again whenever any station retunes — including stations that are only
scanning the band and have never transmitted. This flooded the spothub with
spots for every station visible on qso.freedv.org, not just active
transmitters.

`tx_report{transmitting=true}` is the correct trigger: it fires exactly once
when a station begins PTT and is the signal used for this purpose by the
freedv-gui reference implementation. `tx_report{transmitting=false}` (PTT
release) is now explicitly checked and skipped, preventing a spurious spot
on key-up.

`onFreqChange()` still updates station state and logs `freq_change` events,
but no longer emits spots.

## Constitution principle honored

Principle IX — Surface Only What Survives: spot emission is now gated on a
confirmed, live TX event rather than a passive frequency update.

Principle VIII — Evidence Over Assertion: the trigger signal was verified
against the freedv-gui reference implementation (`onTransmitUpdateFn_` at
line 3619), which sets transmit state unconditionally from the boolean field
and never gates on `freq_change`.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Connect to FreeDV Reporter: confirm no immediate spot flood on connect
- [x] Station pressing PTT generates exactly one spot in the spothub
- [x] Station releasing PTT does not generate a spurious second spot
- [x] Stations tuning without transmitting generate no spots
- [x] `freq_change` events still appear in the FreeDV log with `freq_change`
      tag; TX spots appear with `TX` prefix
- [x] Existing tests pass (CI)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — N/A
- [x] All meter UI uses `MeterSmoother` — N/A
- [x] Documentation updated if user-visible behavior changed — N/A
      (log format change is internal/debug only)
- [x] Security-sensitive changes reference a GHSA if applicable — N/A