### PR TITLE
fix(audio): replace unreachable fallback in primaryRateOrder with Q_UNREACHABLE (#3432)

### DIFF
--- a/src/core/AudioFormatNegotiator.cpp
+++ b/src/core/AudioFormatNegotiator.cpp
@@ -43,7 +43,7 @@ QList<int> primaryRateOrder(TargetOs os, Direction dir, int internalRate)
         case TargetOs::Linux:   return {internalRate, 48000, 44100};
         }
     }
-    return {internalRate};
+    Q_UNREACHABLE(); // every TargetOs value is covered in both branches above
 }
 
 // Format attempt order per direction. Output is Float-first (RX/sidetone/Quindar


### PR DESCRIPTION
The trailing `return {internalRate}` after both direction/OS switch statements
in `primaryRateOrder()` is dead code — every `TargetOs` value is covered in
both the Output and Input branches. It silently masks future omissions: adding
a new `TargetOs` enum value without updating a switch would compile cleanly
and return the wrong rate list with no diagnostic.

Replace with `Q_UNREACHABLE()` so the invariant ("every `TargetOs` value is
handled in both directions") is enforced by the compiler/runtime rather than
papered over with a silent default.

## Testing

All 25 `audio_format_negotiation_test` checks pass (built and run locally on
macOS against the modified `AudioFormatNegotiator.cpp`).

Closes #3432