### PR TITLE
fix(gui): guard TMate2Overlay calls in applyFlexControlWheelAction with HAVE_HIDAPI

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7821,7 +7821,9 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
         if (auto* s = activeSlice()) {
             const int hz = std::clamp(s->ritFreq() + steps * 10, -9999, 9999);
             s->setRit(true, hz);
+#ifdef HAVE_HIDAPI
             triggerTMate2Overlay(TMate2Overlay::Rit, hz);
+#endif
         }
     } else if (actionId == "WheelXit") {
         if (auto* s = activeSlice()) {
@@ -7838,13 +7840,17 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
         if (m_titleBar)
             m_titleBar->setMasterVolume(next);
         applyMasterVolume(next);
+#ifdef HAVE_HIDAPI
         triggerTMate2Overlay(TMate2Overlay::Volume, next);
+#endif
     } else if (actionId == "WheelHeadphoneVolume") {
         const int next = std::clamp(m_radioModel.headphoneGain() + steps * 2, 0, 100);
         if (m_titleBar)
             m_titleBar->setHeadphoneVolume(next);
         m_radioModel.setHeadphoneGain(next);
+#ifdef HAVE_HIDAPI
         triggerTMate2Overlay(TMate2Overlay::Volume, next);
+#endif
     } else if (actionId == "WheelAgcT") {
         if (auto* s = activeSlice())
             s->setAgcThreshold(std::clamp(s->agcThreshold() + steps, 0, 100));
@@ -7867,12 +7873,16 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
         auto& tx = m_radioModel.transmitModel();
         const int next = std::clamp(tx.rfPower() + steps, 0, 100);
         tx.setRfPower(next);
+#ifdef HAVE_HIDAPI
         triggerTMate2Overlay(TMate2Overlay::Power, next);
+#endif
     } else if (actionId == "WheelCwSpeed") {
         auto& tx = m_radioModel.transmitModel();
         const int next = std::clamp(tx.cwSpeed() + steps, 5, 100);
         tx.setCwSpeed(next);
+#ifdef HAVE_HIDAPI
         triggerTMate2Overlay(TMate2Overlay::Wpm, next);
+#endif
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #3435.

`applyFlexControlWheelAction` is declared outside any `#ifdef HAVE_HIDAPI` block
(it handles wheel inputs from FlexControl, MIDI, and other non-HID sources), but
PR #3401 added five call sites inside it that reference `triggerTMate2Overlay(TMate2Overlay::...)`.
Both the `TMate2Overlay` enum class and `triggerTMate2Overlay` are declared inside
the `#ifdef HAVE_HIDAPI` block in `MainWindow.h` (lines 573–623), so they are
invisible to the compiler on configurations without HIDAPI — specifically the
MinGW / no-`setup-hidapi.ps1` Windows developer build.

**Affected actions:** `WheelRit`, `WheelVolume`, `WheelHeadphoneVolume`,
`WheelPower`, `WheelCwSpeed` — all five call sites are wrapped with
`#ifdef HAVE_HIDAPI` / `#endif`. Runtime behavior on HIDAPI-enabled builds
is unchanged.

This is the same guard pattern applied in PR #3344 to `UlanziDial`.

## Constitution principle honored

Principle IX — Surface Only What Survives. Code on `main` must compile on
all target platforms. The no-HIDAPI MinGW path is a required target
(Windows developer builds before running `setup-hidapi.ps1`); surfaces that
break that build do not survive the platform gate.

## Test plan

- [x] Build without `HAVE_HIDAPI` passes — MinGW GCC 13.1.0 / Qt 6.11.0 / no hidapi, verified locally
- [x] Build with `HAVE_HIDAPI` unaffected — same toolchain, guards compile out cleanly
- [x] Existing tests pass (CI)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — N/A
- [x] All meter UI uses `MeterSmoother` — N/A
- [x] Documentation updated if user-visible behavior changed — no user-visible change
- [x] Security-sensitive changes reference a GHSA if applicable — N/A