### PR TITLE
fix(dax): quote pipe source/sink properties so node descriptions survive pipewire-pulse

### DIFF
--- a/src/core/PipeWireAudioBridge.cpp
+++ b/src/core/PipeWireAudioBridge.cpp
@@ -253,7 +253,12 @@ bool PipeWireAudioBridge::loadPipeSource(int index)
         "load-module", "module-pipe-source",
         QStringLiteral("file=%1").arg(pipePath),
         QStringLiteral("source_name=%1").arg(sourceName),
-        QStringLiteral("source_properties=device.description=\"%1\" node.latency=256/48000").arg(sourceDesc),
+        // Single-quoted: the pipewire-pulse pulse-module argument parser splits
+        // the property value on unescaped whitespace, so unquoted the space in
+        // "AetherSDR DAX N" truncates device.description to "AetherSDR" and
+        // orphans node.latency. node.description is derived from
+        // device.description, so this also labels the node in qpwgraph / JACK.
+        QStringLiteral("source_properties='device.description=\"%1\" node.latency=256/48000'").arg(sourceDesc),
         QStringLiteral("format=float32le"),
         QStringLiteral("rate=%1").arg(PIPE_RATE),
         QStringLiteral("channels=%1").arg(PIPE_CHANNELS),
@@ -305,7 +310,9 @@ bool PipeWireAudioBridge::loadPipeSink()
         "load-module", "module-pipe-sink",
         QStringLiteral("file=%1").arg(pipePath),
         QStringLiteral("sink_name=%1").arg(sinkName),
-        QStringLiteral("sink_properties=device.description=\"%1\"").arg(sinkDesc),
+        // Single-quoted — see loadPipeSource(): unquoted, the space in
+        // "AetherSDR TX" truncates device.description to "AetherSDR".
+        QStringLiteral("sink_properties='device.description=\"%1\"'").arg(sinkDesc),
         QStringLiteral("format=s16le"),
         QStringLiteral("rate=%1").arg(TX_RATE),
         QStringLiteral("channels=%1").arg(TX_CHANNELS),


### PR DESCRIPTION
fix(dax): quote pipe source/sink properties so node descriptions survive pipewire-pulse

## Summary
On builds without `libpipewire-0.3` (native PipeWire off), DAX audio nodes are created
through the legacy `pactl module-pipe-source` / `module-pipe-sink` path. That path passes the
per-channel name as `source_properties=device.description="AetherSDR DAX N"`, but
**pipewire-pulse's pulse-module argument parser splits the property value on unescaped
whitespace and does not honor the embedded quotes for grouping.** The value is taken only up
to the first space, so `device.description` collapses to `"AetherSDR"` for every DAX RX node
and the TX node. `node.description` is derived from `device.description`, so qpwgraph, JACK
patchbays, WSJT-X and FLDIGI all show an indistinguishable `"AetherSDR"` and operators must
hand-route by guesswork.

The same truncation also orphans the trailing `node.latency=256/48000` quantum hint (#1008),
which never reaches the node.

## Fix
Wrap the property value in single quotes so the spaced `device.description` (and the
`node.latency` hint) survive the split. `node.description` is then derived correctly. 2 lines:

```diff
- QStringLiteral("source_properties=device.description=\"%1\" node.latency=256/48000").arg(sourceDesc),
+ QStringLiteral("source_properties='device.description=\"%1\" node.latency=256/48000'").arg(sourceDesc),
- QStringLiteral("sink_properties=device.description=\"%1\"").arg(sinkDesc),
+ QStringLiteral("sink_properties='device.description=\"%1\"'").arg(sinkDesc),
```

The native `pw_stream` path (`PipeWireNativeRxSource`) already sets `PW_KEY_NODE_DESCRIPTION`
via the API and is unaffected — this aligns the legacy fallback (and TX, which always uses the
legacy sink) with it.

## Why (quoting A/B)
Exact argv the code emits, read back with `pw-cli` on pipewire-pulse:

| `source_properties` value emitted                                       | `node.description` | `node.latency` |
|-------------------------------------------------------------------------|--------------------|----------------|
| `device.description="AetherSDR DAX 1" node.latency=256/48000` (before)   | `AetherSDR`        | dropped        |
| `device.description=AetherSDR\ DAX\ 1` (backslash)                       | `AetherSDR`        | n/a            |
| `'device.description="AetherSDR DAX 1" node.latency=256/48000'` (fix)    | `AetherSDR DAX 1`  | `256/48000`    |

## Test plan
- [x] Incremental `ninja -C build` clean (Nobara/FC43, Qt 6.10.3, gcc 15.2.1; native PipeWire off)
- [x] Live against a FLEX-6700, DAX enabled — `pw-cli ls Node`:
      `aethersdr-dax-1..4` → `AetherSDR DAX 1..4`, `aethersdr-tx` → `AetherSDR TX`
- [x] qpwgraph shows the named pipe nodes (screenshot)
- [x] FLDIGI Soundcard/Devices (PortAudio): Capture lists `AetherSDR DAX 1..4`, Playback `AetherSDR TX` (screenshots)
- [x] WSJT-X device list (maintainer/secondary — PulseAudio names follow the same `device.description`)

## Screenshots (patched build, live on a FLEX-6700, Linux/pipewire-pulse)
FLDIGI → Soundcard/Devices — **Capture** lists each DAX channel by name:

![FLDIGI Capture list](https://raw.githubusercontent.com/Ozy311/AetherSDR/pr3438-assets/pr-capture-list.png)

FLDIGI **Playback** — `AetherSDR TX` selectable by name:

![FLDIGI Playback list](https://raw.githubusercontent.com/Ozy311/AetherSDR/pr3438-assets/pr-playback-list.png)

qpwgraph — named pipe nodes (`AetherSDR DAX 1/2/4`, `AetherSDR TX`; pre-fix all read `AetherSDR`):

![qpwgraph](https://raw.githubusercontent.com/Ozy311/AetherSDR/pr3438-assets/qpwgraph-crop.png)

## Related
- #1008 — DAX RX latency; the `node.latency=256/48000` quantum hint this fix un-orphans.
- #2312 — added the `node.latency=256/48000` token to this exact RX line (latency work) but left
  the value unquoted; this fix makes both that hint and the spaced `device.description` survive.
  It deliberately kept the legacy `module-pipe-source/sink` fallback that this patch repairs.

## Notes / out of scope
- `node.nick` is intentionally not set (the native path doesn't set it either; `node.description`
  is what qpwgraph/JACK display).
- Known related (separate follow-up): the app's own RX/TX audio streams (`media.class`
  `Stream/Output/Audio` / `Stream/Input/Audio`) still carry the generic `node.name="AetherSDR"`
  with no `node.description`, so they appear as `AetherSDR` / `AetherSDR-<id>` in device lists.
  Different code path (main audio engine, not the DAX bridge) — tracked in #3440.
- `DaxIqModel.cpp` builds its `pactl` command with the same backslash-escaped-space form (via
  `bash -c`), so DAX-IQ descriptions are likely truncated the same way — separate follow-up.

Closes #3437

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent, on the Linux dev stack (`nobara-dell`: Nobara/FC43, KDE Plasma 6.6.4, Qt 6.10.3, kernel 7.0.9, Wayland; Dell Precision 5570).