### PR TITLE
fix(radio): make disabled Reboot Radio button legible instead of near-invisible (#3334)

### DIFF
--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -601,7 +601,12 @@ QWidget* RadioSetupDialog::buildRadioTab()
             "QPushButton { background: #3a1a1a; color: #ffb080; border: 1px solid #6e3030;"
             " border-radius: 3px; font-size: 11px; font-weight: bold; padding: 3px 10px; }"
             "QPushButton:hover { background: #4a2020; }"
-            "QPushButton:disabled { background: {{color.background.1}}; color: {{color.meter.bar.fill}}; border-color: {{color.background.2}}; }");
+            // Disabled (radio disconnected/reconnecting): keep the button clearly
+            // visible as a greyed-out control. The previous tokens
+            // (background.1 / meter.bar.fill / background.2) were all dim blue-greys
+            // that blended into the dialog, making the button look absent rather
+            // than disabled (#3334 follow-up).
+            "QPushButton:disabled { background: #2a1818; color: #8a6055; border-color: #4a2828; }");
         // Only enable when actually connected; subscribe so disconnect/reconnect
         // disables/re-enables the button without the user having to reopen the
         // dialog. rebootRadio() also early-returns on disconnected, but the


### PR DESCRIPTION
## Problem
The "Reboot Radio" button in Radio Setup (added in #3334) appears to vanish if you open Radio Setup while the radio is disconnected/reconnecting — e.g. during the ~40s after clicking Reboot, or any reconnect window.

## Root cause
The button is always added, but `setEnabled(m_model->isConnected())` disables it when disconnected. The disabled stylesheet used three dim blue-grey tokens — `background.1 (#1a2a3a)`, `meter.bar.fill (#405060)`, `background.2 (#304050)` — against the dialog background `background.0 (#0f0f1a)`. All near-equal dark tones, so the disabled button blends into the dialog and reads as an empty row rather than a greyed-out control. It reappears once the radio reconnects via the existing `connectionStateChanged → setEnabled` hook.

## Fix
Give the disabled state a legible muted-red appearance consistent with the button's red identity:
```
QPushButton:disabled { background: #2a1818; color: #8a6055; border-color: #4a2828; }
```

## How found
Instrumented logging confirmed the button is added with `enabled=true` when connected and `enabled=false` when the dialog is built mid-reconnect — i.e. a contrast/styling issue, not a missing widget.

## Testing
- Clean build on macOS.
- Enabled state unchanged (bright orange, verified).
- Disabled-state contrast raised from near-invisible dim blue-grey to legible muted red.

Follow-up to #3334.