### PR TITLE
ci(a11y): fix findings count writing malformed GITHUB_OUTPUT on zero findings

### DIFF
--- a/.github/workflows/a11y-check.yml
+++ b/.github/workflows/a11y-check.yml
@@ -40,7 +40,7 @@ jobs:
             exit 0
           fi
           python tools/check_a11y.py $FILES | tee /tmp/a11y_output.txt
-          COUNT=$(grep -c "^::warning" /tmp/a11y_output.txt || echo "0")
+          COUNT=$(grep -c "^::warning" /tmp/a11y_output.txt || true)
           echo "findings=$COUNT" >> $GITHUB_OUTPUT
 
       # Post a summary comment so the finding count is visible at the PR top


### PR DESCRIPTION
The accessibility check job fails on any PR where a changed `src/gui` file has **zero** findings — the check itself passes, but the step errors with:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '0'
```

## Cause
`grep -c "^::warning"` prints `0` to stdout **and** exits non-zero when there are no matches. So:

```bash
COUNT=$(grep -c "^::warning" /tmp/a11y_output.txt || echo "0")
```

captures **both** grep's own `0` and the `|| echo "0"`, producing the two-line value `"0\n0"`. Writing `findings=0\n0` to `$GITHUB_OUTPUT` is malformed → step failure.

## Fix
```diff
-          COUNT=$(grep -c "^::warning" /tmp/a11y_output.txt || echo "0")
+          COUNT=$(grep -c "^::warning" /tmp/a11y_output.txt || true)
```

`grep -c` already prints `0` on no match; `|| true` simply swallows its non-zero exit under `set -e`, without appending a duplicate. Verified locally:

| Input | Old `COUNT` | New `COUNT` |
|---|---|---|
| no `::warning` lines | `0\n0` (malformed) | `0` |
| 2 `::warning` lines | `2` | `2` |

Seen on #3441 (a clean GUI change with 0 a11y findings).