### PR TITLE
fix(gui): pack XVTR setup fields with trailing stretch (#3454)

### DIFF
--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -2915,6 +2915,7 @@ QWidget* RadioSetupDialog::buildXvtrTab()
     xvtrTabs->addTab(addPage, "+");
 
     vbox->addWidget(xvtrTabs);
+    vbox->addStretch(1);
     return page;
 }
 


### PR DESCRIPTION
## Summary

The **XVTR** tab in the Radio Setup dialog renders with large, uneven vertical gaps between every field row (Name, RF Freq/IF Freq, LO Freq/LO Error, RX Gain/RX Only, Max Power), unlike the tightly-packed sibling tabs (GPS, Audio, TX, RX, Antennas, Filters, APD, USB Cables, Peripherals).

Fixes #3454.

## Root cause

`RadioSetupDialog::buildXvtrTab()` was the **only** Radio Setup tab whose outer `QVBoxLayout` did not terminate with `addStretch(1)`. Every sibling builder does:

| Tab | trailing `vbox->addStretch(1)` |
|---|---|
| TX (`buildTxTab`) | ✅ |
| RX (`buildRxTab`) | ✅ |
| Audio (`buildAudioTab`) | ✅ |
| Filters (`buildFiltersTab`) | ✅ |
| APD (`buildApdTab`) | ✅ |
| **XVTR (`buildXvtrTab`)** | ❌ (before this PR) |

Without that trailing stretch, the `QVBoxLayout` had no flexible element to absorb leftover vertical space, so it handed all of it to the `QTabWidget`. The tab widget grew to fill the dialog, and the inner per-transverter `QGridLayout` — which has 5 content rows and **no row-stretch factors** — distributed the surplus height evenly across the rows. That even distribution is exactly the excessive inter-row spacing reported in the issue.

## Fix

Add a single trailing stretch after the tab widget:

```cpp
vbox->addWidget(xvtrTabs);
vbox->addStretch(1);   // <-- added
return page;
```

The stretch now absorbs the leftover vertical space, so the `QTabWidget` collapses to its compact size hint and the inner grid receives only its natural height — packing the field rows tightly at the top and matching the layout density of the other tabs. Behaviour on dialog resize (content stays top-aligned, empty space below) is now identical to the sibling tabs.

One-line, layout-only change; no behavioural or data-path impact.

## Testing

- Built locally (`cmake --build build -j22`, RelWithDebInfo, macOS) — clean, `[1042/1042]`.
- Deployed to a FLEX test bench (FLEX-8600) and confirmed in **Radio Setup → XVTR**: field rows are now compact and the vertical rhythm matches the Audio/TX tabs. No regression in the per-transverter sub-tabs or the "+" add-transverter tab.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat