### PR TITLE
fix(waterfall): remove 1 GHz ceiling in VITA-49 tile frequency decode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1872,6 +1872,14 @@ add_executable(xvtr_policy_test
 target_include_directories(xvtr_policy_test PRIVATE src)
 target_link_libraries(xvtr_policy_test PRIVATE Qt6::Core)
 
+# #3449 — VITA-49 waterfall tile frequency decode (no 1 GHz ceiling)
+add_executable(vita_tile_frequency_test
+    tests/vita_tile_frequency_test.cpp
+)
+target_include_directories(vita_tile_frequency_test PRIVATE src)
+target_link_libraries(vita_tile_frequency_test PRIVATE Qt6::Core)
+add_test(NAME vita_tile_frequency_test COMMAND vita_tile_frequency_test)
+
 add_executable(frequency_entry_parser_test
     tests/frequency_entry_parser_test.cpp
     src/gui/FrequencyEntryParser.cpp

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -5,6 +5,7 @@
 #include "OpusCodec.h"
 #include "PerfTelemetry.h"
 #include "RadioConnection.h"
+#include "VitaTileFrequency.h"
 
 #include <QNetworkDatagram>
 #include <QHostAddress>
@@ -841,15 +842,14 @@ void PanadapterStream::decodeWaterfallTile(const uchar* raw, int totalBytes, boo
 
     if (tileWidth == 0 || tileHeight == 0) return;
 
-    // FrameLowFreq and BinBandwidth may be VitaFrequency (Hz × 2^20) or plain Hz.
-    // Try VitaFrequency first; if the result is unreasonable, try plain Hz.
-    double lowFreqMhz  = static_cast<double>(frameLowRaw) / (1048576.0 * 1e6);
-    double binBwMhz    = static_cast<double>(binBwRaw) / (1048576.0 * 1e6);
-    if (lowFreqMhz < 0.001 || lowFreqMhz > 1000.0) {
-        // Fallback: treat as plain Hz
-        lowFreqMhz = static_cast<double>(frameLowRaw) / 1e6;
-        binBwMhz   = static_cast<double>(binBwRaw) / 1e6;
-    }
+    // FrameLowFreq and BinBandwidth arrive as either VitaFrequency (Hz × 2^20)
+    // or plain Hz; disambiguate on the raw integer magnitude so there is no
+    // upper frequency ceiling. The previous "divide then reject results above
+    // 1000 MHz" heuristic blacked out the waterfall for every transverter above
+    // 1 GHz (#3449, #1843, #1928, #2835). See VitaTileFrequency.h.
+    const auto tileFreq = AetherSDR::Vita::decodeTileFrequencyMhz(frameLowRaw, binBwRaw);
+    const double lowFreqMhz = tileFreq.lowMhz;
+    const double binBwMhz   = tileFreq.binBwMhz;
     const double highFreqMhz = lowFreqMhz + binBwMhz * tileWidth;
 
     const int payloadOffset = VITA49_HEADER_BYTES + TILE_SUBHEADER_BYTES;

--- a/src/core/VitaTileFrequency.h
+++ b/src/core/VitaTileFrequency.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <QtGlobal>
+
+#include <cmath>
+
+// VITA-49 waterfall-tile frequency decoding.
+//
+// A tile sub-header carries FrameLowFreq and BinBandwidth as 64-bit integers.
+// Depending on the radio/firmware these are encoded either as "VitaFrequency"
+// (Hz × 2^20) or as plain Hz.  Both fields always share the same encoding.
+//
+// History: the original decoder assumed VitaFrequency, divided, then rejected
+// the result as "unreasonable" if it exceeded 1000 MHz — silently re-reading it
+// as plain Hz.  That 1 GHz ceiling corrupted every legitimate transverter tile
+// above 1 GHz (1296 MHz, 2.3/2.4 GHz, …): a real ~1 GHz VitaFrequency value got
+// divided by 1e6 instead of 2^20·1e6, inflating it by 2^20, which pushed every
+// waterfall bin outside the panadapter range and rendered the row entirely
+// black while the FFT trace stayed correct.  See issues #3449, #1843, #1928,
+// #2835 and the failed remap-layer fixes #1845 / #2709 / #2853.
+//
+// Disambiguate on the *raw integer magnitude* instead, which has a clean gap:
+//   • plain Hz for any real frequency (≤ ~100 GHz) is below 1e11
+//   • the smallest VitaFrequency we can see (~95 kHz, well under the 2200 m /
+//     135 kHz band edge) is above 1e11
+// so a single raw threshold separates the two encodings across the entire
+// usable spectrum without imposing any upper frequency limit.
+
+namespace AetherSDR::Vita {
+
+struct TileFrequency {
+    double lowMhz{0.0};
+    double binBwMhz{0.0};
+};
+
+// Below this raw magnitude the value is plain Hz; at or above it, VitaFrequency
+// (Hz × 2^20).  1e11 sits in the gap between the two encodings' realistic
+// ranges (see header comment).
+inline constexpr qint64 kVitaFrequencyRawThreshold = 100000000000LL; // 1e11
+
+// Hz × 2^20 → MHz.
+inline constexpr double kVitaFrequencyToMhz = 1048576.0 * 1e6;
+
+inline TileFrequency decodeTileFrequencyMhz(qint64 frameLowRaw, qint64 binBwRaw)
+{
+    // The encoding is decided from FrameLowFreq (the large, reliable value) and
+    // applied to BinBandwidth too, since both fields share one encoding.
+    const bool isVitaFrequency =
+        std::llabs(static_cast<long long>(frameLowRaw)) >= kVitaFrequencyRawThreshold;
+    const double scale = isVitaFrequency ? kVitaFrequencyToMhz : 1e6;
+
+    TileFrequency out;
+    out.lowMhz   = static_cast<double>(frameLowRaw) / scale;
+    out.binBwMhz = static_cast<double>(binBwRaw) / scale;
+    return out;
+}
+
+} // namespace AetherSDR::Vita

--- a/src/core/VitaTileFrequency.h
+++ b/src/core/VitaTileFrequency.h
@@ -2,8 +2,6 @@
 
 #include <QtGlobal>
 
-#include <cmath>
-
 // VITA-49 waterfall-tile frequency decoding.
 //
 // A tile sub-header carries FrameLowFreq and BinBandwidth as 64-bit integers.
@@ -45,8 +43,7 @@ inline TileFrequency decodeTileFrequencyMhz(qint64 frameLowRaw, qint64 binBwRaw)
 {
     // The encoding is decided from FrameLowFreq (the large, reliable value) and
     // applied to BinBandwidth too, since both fields share one encoding.
-    const bool isVitaFrequency =
-        std::llabs(static_cast<long long>(frameLowRaw)) >= kVitaFrequencyRawThreshold;
+    const bool isVitaFrequency = qAbs(frameLowRaw) >= kVitaFrequencyRawThreshold;
     const double scale = isVitaFrequency ? kVitaFrequencyToMhz : 1e6;
 
     TileFrequency out;

--- a/tests/vita_tile_frequency_test.cpp
+++ b/tests/vita_tile_frequency_test.cpp
@@ -1,0 +1,109 @@
+// Unit tests for VITA-49 waterfall-tile frequency decoding.
+//
+// Regression coverage for the 1 GHz ceiling that blacked out the transverter
+// waterfall above 1 GHz (#3449, #1843, #1928, #2835). The decoder must pick the
+// correct encoding (VitaFrequency vs plain Hz) from the raw integer magnitude
+// with no upper frequency limit.
+
+#include "core/VitaTileFrequency.h"
+
+#include <QtGlobal>
+
+#include <cmath>
+#include <cstdio>
+
+using AetherSDR::Vita::decodeTileFrequencyMhz;
+
+namespace {
+
+int g_failures = 0;
+
+void expectNear(const char* what, double got, double want, double tolMhz)
+{
+    if (std::abs(got - want) > tolMhz) {
+        std::fprintf(stderr, "FAIL: %s — got %.9f MHz, want %.9f MHz (tol %.9f)\n",
+                     what, got, want, tolMhz);
+        ++g_failures;
+    } else {
+        std::fprintf(stderr, "ok:   %s = %.6f MHz\n", what, got);
+    }
+}
+
+// VitaFrequency raw value (Hz × 2^20) for a frequency in MHz.
+qint64 vitaRaw(double mhz)
+{
+    return static_cast<qint64>(std::llround(mhz * 1e6 * 1048576.0));
+}
+
+// Plain-Hz raw value for a frequency in MHz.
+qint64 hzRaw(double mhz)
+{
+    return static_cast<qint64>(std::llround(mhz * 1e6));
+}
+
+} // namespace
+
+int main()
+{
+    // ── VitaFrequency encoding ───────────────────────────────────────────────
+    // HF tile (well below 1 GHz) must decode correctly.
+    {
+        const auto f = decodeTileFrequencyMhz(vitaRaw(14.0), vitaRaw(0.001));
+        expectNear("vita 14 MHz low", f.lowMhz, 14.0, 1e-6);
+        expectNear("vita 14 MHz binBw", f.binBwMhz, 0.001, 1e-9);
+    }
+
+    // IF-domain transverter tile (~28 MHz) — the classic XVTR case.
+    {
+        const auto f = decodeTileFrequencyMhz(vitaRaw(28.0), vitaRaw(0.002));
+        expectNear("vita 28 MHz IF low", f.lowMhz, 28.0, 1e-6);
+    }
+
+    // THE regression: a real ~1 GHz RF-domain tile must NOT be re-read as plain
+    // Hz. The reporter in #3449 saw the break between 1000.015 and 1000.016 MHz;
+    // both must decode to ~1000 MHz, not ~1.05e9 MHz.
+    {
+        const auto ok   = decodeTileFrequencyMhz(vitaRaw(1000.015), vitaRaw(0.003));
+        const auto fail = decodeTileFrequencyMhz(vitaRaw(1000.016), vitaRaw(0.003));
+        expectNear("vita 1000.015 MHz low", ok.lowMhz, 1000.015, 1e-3);
+        expectNear("vita 1000.016 MHz low", fail.lowMhz, 1000.016, 1e-3);
+    }
+
+    // 1296 MHz (23 cm), 2304 MHz (2.3 GHz terrestrial), 2400 MHz (sat).
+    {
+        expectNear("vita 1296 MHz", decodeTileFrequencyMhz(vitaRaw(1296.0), 0).lowMhz,
+                   1296.0, 1e-2);
+        expectNear("vita 2304 MHz", decodeTileFrequencyMhz(vitaRaw(2304.1), 0).lowMhz,
+                   2304.1, 1e-2);
+        expectNear("vita 2400 MHz", decodeTileFrequencyMhz(vitaRaw(2400.0), 0).lowMhz,
+                   2400.0, 1e-2);
+    }
+
+    // 2200 m (135 kHz) — lowest band; VitaFrequency raw still lands above the
+    // disambiguation threshold, so it must decode as VitaFrequency.
+    {
+        const auto f = decodeTileFrequencyMhz(vitaRaw(0.1357), vitaRaw(0.00001));
+        expectNear("vita 2200m low", f.lowMhz, 0.1357, 1e-4);
+    }
+
+    // ── Plain-Hz encoding ────────────────────────────────────────────────────
+    // Radios/firmware that send plain Hz must still decode correctly across the
+    // same range (the old code claimed to support this but had latent gaps).
+    {
+        expectNear("hz 14 MHz", decodeTileFrequencyMhz(hzRaw(14.0), hzRaw(0.001)).lowMhz,
+                   14.0, 1e-6);
+        expectNear("hz 1296 MHz", decodeTileFrequencyMhz(hzRaw(1296.0), 0).lowMhz,
+                   1296.0, 1e-6);
+        expectNear("hz 2400 MHz", decodeTileFrequencyMhz(hzRaw(2400.0), 0).lowMhz,
+                   2400.0, 1e-6);
+        const auto bw = decodeTileFrequencyMhz(hzRaw(2400.0), hzRaw(0.005));
+        expectNear("hz binBw shares encoding", bw.binBwMhz, 0.005, 1e-9);
+    }
+
+    if (g_failures == 0) {
+        std::fprintf(stderr, "\nAll vita_tile_frequency_test checks passed.\n");
+        return 0;
+    }
+    std::fprintf(stderr, "\n%d vita_tile_frequency_test check(s) FAILED.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

The native waterfall goes **all-black for any transverter operating above 1 GHz** (1296 MHz, 2.3/2.4 GHz) while the FFT trace above it stays correct. This fixes the long-standing root cause behind #3449, #2835, #1928, and #1843 — none of which the previous attempts (#1845, #2709, #2853) could reach, because they were all editing the wrong layer.

## Root cause

`PanadapterStream::decodeWaterfallTile` decoded the VITA-49 tile's `FrameLowFreq` / `BinBandwidth` by **assuming VitaFrequency (Hz × 2²⁰), dividing, then rejecting any result `> 1000.0 MHz` and re-reading it as plain Hz**:

```cpp
double lowFreqMhz = static_cast<double>(frameLowRaw) / (1048576.0 * 1e6);
if (lowFreqMhz < 0.001 || lowFreqMhz > 1000.0) {   // ← hard 1 GHz ceiling
    lowFreqMhz = static_cast<double>(frameLowRaw) / 1e6;   // wrong scale → ×2²⁰ error
```

A real ~1296 MHz VitaFrequency value (raw ≈ 1.359e15) trips that ceiling, gets divided by `1e6` instead of `2²⁰·1e6`, and is inflated by **exactly 2²⁰** to ~1.359e9 MHz. Every waterfall bin then maps outside the panadapter range, so `SpectrumWidget::updateWaterfallRow` leaves the scanline `qRgb(0,0,0)` → entirely black. The FFT path has no frequency awareness, so it is unaffected. This ceiling has existed since the first native-waterfall commit (`406dc100`) and predates all of the XVTR work.

## Why the previous fixes never worked

PRs #1845, #2709, and #2853 all edited the IF→RF **remap** layer (`src/models/XvtrPolicy.cpp`), which runs *after* the decode — it was merely shifting an already-corrupted value. A support bundle on #2835 (FLEX-6400, 1296 MHz, XVTA) shows it directly:

```
WaterfallXVTR: ... pan_center_mhz=1296.065804 tile_mhz=1358902484.271104..1359144312.111104
```

i.e. `1296 × 2²⁰`. The bundle also shows the XVTR entry as `valid=true rf=1296 if=28`, so the `isValid` debate (#2709 ↔ #2853) was a red herring — the value was destroyed six orders of magnitude upstream of any remap.

## Changes

- **`src/core/VitaTileFrequency.h`** (new) — extracts the VitaFrequency-vs-plain-Hz disambiguation into a pure, unit-testable helper that decides the encoding from the **raw integer magnitude** (`>= 1e11` → VitaFrequency, else plain Hz). There is a clean gap between the two encodings across the entire usable spectrum (~135 kHz to ~100 GHz), so this imposes **no upper frequency limit** while still supporting radios that send plain Hz.
- **`src/core/PanadapterStream.cpp`** — decoder now calls the helper.
- **`tests/vita_tile_frequency_test.cpp`** + CMake target — regression coverage: HF, IF-domain, the 1000.015/1000.016 boundary from #3449, 1296 / 2.3G / 2.4G, 2200 m, and plain-Hz radios.

## Validation

- `./build-ninja/vita_tile_frequency_test` — all checks pass
- `./build-ninja/xvtr_policy_test` — still passes (remap layer untouched)
- `cmake --build build-ninja --target AetherSDR --parallel 22` — clean
- **Verified on hardware** (FLEX-6400, synthetic 1296 MHz XVTR profile, XVTA antenna): logs now show sane `tile_mhz` (~1296, zero garbage tiles), and the waterfall renders the noise floor (dark blue) instead of going black. Reversing the exact corrupted raw value from the #2835 bundle through the fixed decoder recovers 1295.95 MHz.

## Known follow-up (out of scope)

A separate, pre-existing gap remains for transverters whose slice antenna is **not** named `XVT*` *and* whose offset doesn't match a configured XVTR profile: such a tile is left in its own domain and would still not align with the pan. That is independent of this decode bug (which affected every >1 GHz tile regardless of antenna) and is better handled in the remap layer in a follow-up.

Fixes #3449
Fixes #2835
Fixes #1928
Fixes #1843

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat