### PR TITLE
fix(audio): reset NR2 on TX→RX so RX audio returns immediately (#1863, #3340)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -4947,8 +4947,29 @@ void AudioEngine::setTransmitting(bool tx)
 void AudioEngine::setRadioTransmitting(bool tx)
 {
     const bool previous = m_radioTransmitting.exchange(tx);
-    if (previous != tx)
-        emit radioTransmittingChanged(tx);
+    if (previous == tx)
+        return;
+
+    // TX→RX edge: NR2 is bypassed entirely during TX (see the RX DSP chain
+    // ~line 1512: raw PCM goes straight to writeAudio so the filter doesn't
+    // adapt its internal state to TX silence, #367/#1505). But that leaves NR2
+    // holding pre-TX state when RX resumes: a stale overlap-add ring (read out
+    // as a faint whistle, #3340) and a maxed-out startup-ramp counter, so
+    // suppression slams to full-wet on a stale noise estimate that then takes
+    // ~3-4s to reconverge — the audio "gap" users hear with NR2 engaged
+    // (#1863). reset() flushes the OA ring, re-seeds the noise floor high
+    // (gentle suppression), and re-arms the ~1s dry→wet ramp so audio returns
+    // immediately on the dry signal and NR2 fades back in cleanly.
+    //
+    // Scoped to NR2 for now: it's the reported filter and this keeps testing
+    // localized. RN2/NR4/DFNR/MNR share the same bypass + stale-state path and
+    // can get the same flush as a follow-up once this is validated in the field.
+    if (previous && !tx) {
+        std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+        if (m_nr2Enabled && m_nr2) m_nr2->reset();
+    }
+
+    emit radioTransmittingChanged(tx);
 }
 
 void AudioEngine::setDaxTxUseRadioRoute(bool on)


### PR DESCRIPTION
## Summary

Fixes the multi-second RX-audio gap (and faint whistle) that users hear after unkeying when **NR2** is engaged, which makes it hard to use during a live QSO.

- Closes #1863 — *Switching from TX to RX with NR2 ON taking 3-4 seconds to get audio back*
- Closes #3340 — *NR2 hanging after TX momentarily (faint whistle)*

## Root cause

NR2 (`SpectralNR`) is **bypassed entirely during TX** — raw PCM goes straight to `writeAudio()` so the filter doesn't adapt its internal state to TX silence (#367/#1505). That part is correct. The bug is on the **TX→RX edge**: `AudioEngine::setRadioTransmitting()` only flipped an atomic and emitted a signal — it never flushed the filter. So when RX resumed, NR2 held:

1. **A stale overlap-add ring** — the pre-TX residue in `m_inAccum`/`m_outAccum` is read out on the first frames back, audible as the faint whistle reported in #3340.
2. **A maxed-out startup-ramp counter** — `m_frameCount` was long past `RampFrames`, so the dry→wet crossfade was over. NR2 slammed straight to **full-wet** suppression using a stale noise estimate, which then takes ~3–4 s for the OSMS minimum-statistics tracker to reconverge. During that window the gain mask over-suppresses the incoming signal → the audible gap in #1863.

## Fix

`setRadioTransmitting()` now detects the falling edge of `m_radioTransmitting` and calls `m_nr2->reset()`, under `m_dspMutex` (the same recursive mutex the RX DSP chain holds, so it is serialized against `process()` on the audio thread).

`SpectralNR::reset()` flushes the OA ring, re-seeds the noise floor high for gentle initial suppression, and re-arms the ~1 s dry→wet ramp. Net effect: **audio returns immediately on the dry signal** and NR2 fades back in cleanly over ~1 s instead of cutting out for several seconds.

### Scope: NR2 only (deliberate)

RN2 (`RNNoiseFilter`), NR4 (`SpecbleachFilter`), DFNR (`DeepFilterFilter`), and MNR (`MacNRFilter`) share the **exact same** bypass + stale-state path and each already have a `reset()`. They are intentionally **left out of this PR** to keep field testing localized to the reported filter (#1863/#3340 are both NR2). Extending the same flush to the other filters is a clean follow-up once this is validated. BNR (`NvidiaBnrFilter`) is server-side gRPC with no client OA ring and needs no flush either way.

## Testing

- Incremental build (Ninja, all cores) — compiles clean, app links.
- `spectral_nr_test` passes (validates the `reset()` / gain-formula path NR2 depends on).
- Lock ordering verified: `setRadioTransmitting()` runs on the GUI thread via `RadioModel::radioTransmittingChanged`; the RX chain runs on the audio thread; both take `m_dspMutex`.

## Issue scrub — related but distinct (not addressed here)

- #367 (NR2/RN2 unclear after TX) — same root cause; this fix covers the NR2 case of it.
- #1127 (CW return to RX > 3 s) — CW unkey/delay timing, not NR stale state.
- #2306 (RX audio lost after CWX macro) — permanent loss needing restart; stuck-TX/stream teardown family (#2450), different root cause.
- #827 (NR4 loses audio when switching NR types) — filter init/teardown on algorithm switch, different trigger.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat