### PR TITLE
feat(mqtt): per-topic control, CW keyer, radio state, AX.25, debug logging

### DIFF
--- a/src/core/MqttClient.cpp
+++ b/src/core/MqttClient.cpp
@@ -234,9 +234,13 @@ void MqttClient::publish(const QString& topic, const QByteArray& payload)
 #ifdef HAVE_MQTT
     if (!m_connected || !m_mosq) return;
     qCDebug(lcMqtt) << "MqttClient: publish" << topic << payload;
-    mosquitto_publish(m_mosq, nullptr,
+    const int rc = mosquitto_publish(m_mosq, nullptr,
         topic.toUtf8().constData(),
         payload.size(), payload.constData(), 0, false);
+    if (rc != MOSQ_ERR_SUCCESS) {
+        qCWarning(lcMqtt) << "MqttClient: publish failed" << topic << rc;
+        return;
+    }
     emit messagePublished(topic, payload);
 #else
     Q_UNUSED(topic); Q_UNUSED(payload);

--- a/src/core/MqttClient.cpp
+++ b/src/core/MqttClient.cpp
@@ -233,9 +233,11 @@ void MqttClient::publish(const QString& topic, const QByteArray& payload)
 {
 #ifdef HAVE_MQTT
     if (!m_connected || !m_mosq) return;
+    qCDebug(lcMqtt) << "MqttClient: publish" << topic << payload;
     mosquitto_publish(m_mosq, nullptr,
         topic.toUtf8().constData(),
         payload.size(), payload.constData(), 0, false);
+    emit messagePublished(topic, payload);
 #else
     Q_UNUSED(topic); Q_UNUSED(payload);
 #endif
@@ -294,6 +296,7 @@ void MqttClient::onMessage(struct mosquitto*, void* obj,
     QString topic = QString::fromUtf8(msg->topic);
     QByteArray payload(static_cast<const char*>(msg->payload), msg->payloadlen);
     QMetaObject::invokeMethod(self, [self, topic, payload] {
+        qCDebug(lcMqtt) << "MqttClient: received" << topic << payload;
         emit self->messageReceived(topic, payload);
     });
 }

--- a/src/core/MqttClient.h
+++ b/src/core/MqttClient.h
@@ -41,6 +41,7 @@ signals:
     void disconnected();
     void connectionError(const QString& error);
     void messageReceived(const QString& topic, const QByteArray& payload);
+    void messagePublished(const QString& topic, const QByteArray& payload);
 
 private:
 #ifdef HAVE_MQTT

--- a/src/core/MqttSettings.cpp
+++ b/src/core/MqttSettings.cpp
@@ -338,7 +338,6 @@ bool isMqttTopicEnabled(const QString& topic)
 void setMqttTopicEnabled(const QString& topic, bool enabled)
 {
     AppSettings::instance().setValue(topicEnabledKey(topic), enabled);
-    AppSettings::instance().save();
 }
 
 QStringList internalMqttSubscriptionTopics()

--- a/src/core/MqttSettings.cpp
+++ b/src/core/MqttSettings.cpp
@@ -303,7 +303,7 @@ const QVector<InternalMqttTopicDef>& internalMqttSubscribeTopicDefs()
 const QVector<InternalMqttTopicDef>& internalMqttPublishTopicDefs()
 {
     static const QVector<InternalMqttTopicDef> defs = {
-        { QString(kCwDecodeTopic),    QStringLiteral("CW decoded text"),             true },
+        { QString(kCwDecodeTopic),    QStringLiteral("CW decoded text"),             true, true },
         { QString(kRadioStateTopic),  QStringLiteral("Radio VFO / mode / TX state"), true },
         { QString(kAx25RxTopic),      QStringLiteral("AX.25 received frames"),       true },
     };
@@ -325,12 +325,12 @@ bool isMqttTopicEnabled(const QString& topic)
     for (const auto& def : internalMqttSubscribeTopicDefs()) {
         if (def.topic == topic)
             return !def.gateable || AppSettings::instance()
-                .value(topicEnabledKey(topic), false).toBool();
+                .value(topicEnabledKey(topic), def.defaultEnabled).toBool();
     }
     for (const auto& def : internalMqttPublishTopicDefs()) {
         if (def.topic == topic)
             return !def.gateable || AppSettings::instance()
-                .value(topicEnabledKey(topic), false).toBool();
+                .value(topicEnabledKey(topic), def.defaultEnabled).toBool();
     }
     return false;
 }

--- a/src/core/MqttSettings.cpp
+++ b/src/core/MqttSettings.cpp
@@ -281,17 +281,84 @@ QStringList mqttUserSubscriptionTopics(const QVector<MqttTopicDef>& topics)
     return names;
 }
 
+// ── Internal topic definitions ────────────────────────────────────────────────
+// Single source of truth for internal subscribe and publish topics.  Adding
+// an entry here automatically populates the settings dialog checkbox list.
+
+const QVector<InternalMqttTopicDef>& internalMqttSubscribeTopicDefs()
+{
+    static const QVector<InternalMqttTopicDef> defs = {
+        { mqttAntennaAliasTopicPrefix() + QLatin1Char('+'),
+          QStringLiteral("Antenna name (per-port)"),  false },
+        { mqttAntennaAliasBulkTopic(),
+          QStringLiteral("Antenna names (bulk)"),     false },
+        { QString(kCwTransmitTopic),
+          QStringLiteral("CW keyer input"),           true  },
+        { QString(kAx25TxTopic),
+          QStringLiteral("AX.25 transmit"),           true  },
+    };
+    return defs;
+}
+
+const QVector<InternalMqttTopicDef>& internalMqttPublishTopicDefs()
+{
+    static const QVector<InternalMqttTopicDef> defs = {
+        { QString(kCwDecodeTopic),    QStringLiteral("CW decoded text"),             true },
+        { QString(kRadioStateTopic),  QStringLiteral("Radio VFO / mode / TX state"), true },
+        { QString(kAx25RxTopic),      QStringLiteral("AX.25 received frames"),       true },
+    };
+    return defs;
+}
+
+// ── Per-topic enable / disable (AppSettings, keyed by sanitized topic name) ──
+
+static QString topicEnabledKey(const QString& topic)
+{
+    QString key = topic;
+    key.replace(QLatin1Char('/'), QLatin1Char('_'));
+    key.replace(QLatin1Char('+'), QLatin1Char('x'));
+    return QStringLiteral("mqtt_internal_") + key;
+}
+
+bool isMqttTopicEnabled(const QString& topic)
+{
+    for (const auto& def : internalMqttSubscribeTopicDefs()) {
+        if (def.topic == topic)
+            return !def.gateable || AppSettings::instance()
+                .value(topicEnabledKey(topic), false).toBool();
+    }
+    for (const auto& def : internalMqttPublishTopicDefs()) {
+        if (def.topic == topic)
+            return !def.gateable || AppSettings::instance()
+                .value(topicEnabledKey(topic), false).toBool();
+    }
+    return false;
+}
+
+void setMqttTopicEnabled(const QString& topic, bool enabled)
+{
+    AppSettings::instance().setValue(topicEnabledKey(topic), enabled);
+    AppSettings::instance().save();
+}
+
 QStringList internalMqttSubscriptionTopics()
 {
-    return {
-        mqttAntennaAliasTopicPrefix() + QStringLiteral("+"),
-        mqttAntennaAliasBulkTopic(),
-    };
+    QStringList topics;
+    for (const auto& def : internalMqttSubscribeTopicDefs()) {
+        if (isMqttTopicEnabled(def.topic))
+            topics.append(def.topic);
+    }
+    return topics;
 }
 
 QStringList internalMqttPublishTopics()
 {
-    return { QString(kCwDecodeTopic) };
+    QStringList topics;
+    for (const auto& def : internalMqttPublishTopicDefs()) {
+        if (isMqttTopicEnabled(def.topic))
+            topics.append(def.topic);
+    }
+    return topics;
 }
 
 QStringList mqttSubscriptionTopics(const QStringList& userTopics)

--- a/src/core/MqttSettings.cpp
+++ b/src/core/MqttSettings.cpp
@@ -316,7 +316,7 @@ static QString topicEnabledKey(const QString& topic)
 {
     QString key = topic;
     key.replace(QLatin1Char('/'), QLatin1Char('_'));
-    key.replace(QLatin1Char('+'), QLatin1Char('x'));
+    key.replace(QLatin1Char('+'), QStringLiteral("%2B"));
     return QStringLiteral("mqtt_internal_") + key;
 }
 

--- a/src/core/MqttSettings.h
+++ b/src/core/MqttSettings.h
@@ -46,6 +46,9 @@ QStringList mqttSubscriptionTopics(const QStringList& userTopics);
 
 inline constexpr QLatin1String kCwDecodeTopic   {"aethersdr/cw/decode"};
 inline constexpr QLatin1String kCwTransmitTopic {"aethersdr/cw/transmit"};
+// Note: relay scripts that forward cw/decode into cw/transmit should filter
+// on the topic namespace ("aethersdr/...") to avoid re-publishing AetherSDR's
+// own output back to it and creating a feedback loop.
 inline constexpr QLatin1String kRadioStateTopic {"aethersdr/radio/state"};
 inline constexpr QLatin1String kAx25RxTopic     {"aethersdr/ax25/rx"};
 inline constexpr QLatin1String kAx25TxTopic     {"aethersdr/ax25/tx"};

--- a/src/core/MqttSettings.h
+++ b/src/core/MqttSettings.h
@@ -59,7 +59,8 @@ inline constexpr QLatin1String kAx25TxTopic     {"aethersdr/ax25/tx"};
 struct InternalMqttTopicDef {
     QString topic;
     QString description;
-    bool    gateable{true};  // false = always on, not user-disableable
+    bool    gateable{true};        // false = always on, not user-disableable
+    bool    defaultEnabled{false}; // true = on by default (for topics always-on before per-topic gating was added)
 };
 
 const QVector<InternalMqttTopicDef>& internalMqttSubscribeTopicDefs();

--- a/src/core/MqttSettings.h
+++ b/src/core/MqttSettings.h
@@ -44,7 +44,26 @@ QStringList mqttUserSubscriptionTopics(const QVector<MqttTopicDef>& topics);
 QStringList internalMqttSubscriptionTopics();
 QStringList mqttSubscriptionTopics(const QStringList& userTopics);
 
-inline constexpr QLatin1String kCwDecodeTopic{"aethersdr/cw/decode"};
+inline constexpr QLatin1String kCwDecodeTopic   {"aethersdr/cw/decode"};
+inline constexpr QLatin1String kCwTransmitTopic {"aethersdr/cw/transmit"};
+inline constexpr QLatin1String kRadioStateTopic {"aethersdr/radio/state"};
+inline constexpr QLatin1String kAx25RxTopic     {"aethersdr/ax25/rx"};
+inline constexpr QLatin1String kAx25TxTopic     {"aethersdr/ax25/tx"};
+
+// Describes one internal MQTT topic for display in the settings dialog and
+// for driving the subscription/publish lists.  Topics with gateable=false
+// (antenna alias) are always active and shown grayed-out in the dialog.
+struct InternalMqttTopicDef {
+    QString topic;
+    QString description;
+    bool    gateable{true};  // false = always on, not user-disableable
+};
+
+const QVector<InternalMqttTopicDef>& internalMqttSubscribeTopicDefs();
+const QVector<InternalMqttTopicDef>& internalMqttPublishTopicDefs();
+
+bool isMqttTopicEnabled(const QString& topic);
+void setMqttTopicEnabled(const QString& topic, bool enabled);
 
 QStringList internalMqttPublishTopics();
 QStringList mqttSubscriptionTopics(const QVector<MqttTopicDef>& userTopics);

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -1378,6 +1378,8 @@ void Ax25HfPacketDecodeDialog::handleMqttMessage(const QString& topic, const QBy
 {
     if (topic != QString::fromLatin1(kAx25TxTopic))
         return;
+    if (!isMqttTopicEnabled(QString::fromLatin1(kAx25TxTopic)))
+        return;
     startTransmit(QString::fromUtf8(payload).trimmed());
 }
 #endif

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -1382,8 +1382,6 @@ void Ax25HfPacketDecodeDialog::handleMqttMessage(const QString& topic, const QBy
         return;
     if (!isMqttTopicEnabled(QString::fromLatin1(kAx25TxTopic)))
         return;
-    if (!isVisible())
-        return;
     startTransmit(QString::fromUtf8(payload).trimmed());
 }
 #endif

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -14,6 +14,13 @@
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
+#ifdef HAVE_MQTT
+#include "core/MqttClient.h"
+#include "core/MqttSettings.h"
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#endif
 
 #include <QAction>
 #include <QButtonGroup>
@@ -1259,12 +1266,17 @@ void Ax25HfPacketDecodeDialog::finishAudioCapture(bool save)
 
 void Ax25HfPacketDecodeDialog::startTransmitFromUi()
 {
+    if (!m_txText)
+        return;
+    startTransmit(m_txText->text());
+}
+
+void Ax25HfPacketDecodeDialog::startTransmit(const QString& text)
+{
     if (m_txActive || m_txPendingStream) {
         appendSystemLine(QStringLiteral("TX already in progress."));
         return;
     }
-    if (!m_txText)
-        return;
     if (!m_audio || !m_radio) {
         appendSystemLine(QStringLiteral("TX unavailable: audio engine or radio model is not ready."));
         return;
@@ -1274,11 +1286,6 @@ void Ax25HfPacketDecodeDialog::startTransmitFromUi()
         return;
     }
 
-    startTransmit(m_txText->text());
-}
-
-void Ax25HfPacketDecodeDialog::startTransmit(const QString& text)
-{
     Ax25TransmitResult tx = ax25BuildTransmitAudio(m_shimConfig, text, defaultTransmitSource());
     if (!tx.ok) {
         appendSystemLine(QStringLiteral("TX packetization failed: %1.").arg(tx.error));
@@ -1330,6 +1337,50 @@ void Ax25HfPacketDecodeDialog::beginTransmission(const Ax25TransmitResult& tx, b
 
     beginTransmitWhenReady();
 }
+
+#ifdef HAVE_MQTT
+void Ax25HfPacketDecodeDialog::setMqttClient(MqttClient* mqtt)
+{
+    if (m_mqtt == mqtt)
+        return;
+    if (m_mqtt)
+        disconnect(m_mqtt, &MqttClient::messageReceived,
+                   this, &Ax25HfPacketDecodeDialog::handleMqttMessage);
+    m_mqtt = mqtt;
+    if (m_mqtt)
+        connect(m_mqtt, &MqttClient::messageReceived,
+                this, &Ax25HfPacketDecodeDialog::handleMqttMessage);
+}
+
+void Ax25HfPacketDecodeDialog::publishFrameMqtt(const Ax25DecodedFrame& frame)
+{
+    if (!m_mqtt)
+        return;
+    QString display = frame.source + QStringLiteral(">") + frame.destination;
+    if (!frame.path.isEmpty())
+        display += QStringLiteral(",") + frame.path.join(QStringLiteral(","));
+    display += QStringLiteral(":")
+        + (frame.payloadText.isEmpty() ? frame.payloadHex : frame.payloadText);
+    QJsonObject obj;
+    obj[QStringLiteral("timestamp")] = frame.timestampUtc.toString(Qt::ISODateWithMs);
+    obj[QStringLiteral("source")]    = frame.source;
+    obj[QStringLiteral("dest")]      = frame.destination;
+    if (!frame.path.isEmpty())
+        obj[QStringLiteral("path")] = QJsonArray::fromStringList(frame.path);
+    obj[QStringLiteral("payload")]   = frame.payloadText.isEmpty() ? frame.payloadHex : frame.payloadText;
+    obj[QStringLiteral("display")]   = display;
+    obj[QStringLiteral("confidence")] = frame.confidenceOrQuality;
+    m_mqtt->publish(QString::fromLatin1(kAx25RxTopic),
+                    QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+void Ax25HfPacketDecodeDialog::handleMqttMessage(const QString& topic, const QByteArray& payload)
+{
+    if (topic != QString::fromLatin1(kAx25TxTopic))
+        return;
+    startTransmit(QString::fromUtf8(payload).trimmed());
+}
+#endif
 
 void Ax25HfPacketDecodeDialog::beginTransmitWhenReady()
 {
@@ -1577,6 +1628,9 @@ void Ax25HfPacketDecodeDialog::appendFrame(const Ax25DecodedFrame& frame)
     m_log->verticalScrollBar()->setValue(m_log->verticalScrollBar()->maximum());
     if (m_packetActivity)
         m_packetActivity->recordFrame();
+#ifdef HAVE_MQTT
+    publishFrameMqtt(frame);
+#endif
     refreshStatus();
 }
 

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -1356,6 +1356,8 @@ void Ax25HfPacketDecodeDialog::publishFrameMqtt(const Ax25DecodedFrame& frame)
 {
     if (!m_mqtt)
         return;
+    if (!isMqttTopicEnabled(QString::fromLatin1(kAx25RxTopic)))
+        return;
     QString display = frame.source + QStringLiteral(">") + frame.destination;
     if (!frame.path.isEmpty())
         display += QStringLiteral(",") + frame.path.join(QStringLiteral(","));
@@ -1379,6 +1381,8 @@ void Ax25HfPacketDecodeDialog::handleMqttMessage(const QString& topic, const QBy
     if (topic != QString::fromLatin1(kAx25TxTopic))
         return;
     if (!isMqttTopicEnabled(QString::fromLatin1(kAx25TxTopic)))
+        return;
+    if (!isVisible())
         return;
     startTransmit(QString::fromUtf8(payload).trimmed());
 }

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -100,7 +100,6 @@ protected:
     bool eventFilter(QObject* watched, QEvent* event) override;
 
 private:
-    Ax25TonePolarity selectedTonePolarity() const;
     void setModemProfile(Ax25ModemProfile profile, bool persist);
     void setDecodeEnabled(bool enabled);
     void handleRxAudio(const QByteArray& monoFloat32Pcm, int sampleRate);

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -29,6 +29,9 @@ namespace AetherSDR {
 class AudioEngine;
 class HeardList;
 class KissTncServer;
+#ifdef HAVE_MQTT
+class MqttClient;
+#endif
 class PacketActivityWidget;
 class PmsMailbox;
 class RadioModel;
@@ -88,12 +91,16 @@ public:
     ~Ax25HfPacketDecodeDialog() override;
 
     void setAttachedSlice(SliceModel* slice);
+#ifdef HAVE_MQTT
+    void setMqttClient(MqttClient* mqtt);
+#endif
 
 protected:
     // Command history (Up/Down) on the terminal input line.
     bool eventFilter(QObject* watched, QEvent* event) override;
 
 private:
+    Ax25TonePolarity selectedTonePolarity() const;
     void setModemProfile(Ax25ModemProfile profile, bool persist);
     void setDecodeEnabled(bool enabled);
     void handleRxAudio(const QByteArray& monoFloat32Pcm, int sampleRate);
@@ -142,6 +149,10 @@ private:
     QString formatTerminalLine(const Ax25DecodedFrame& frame) const;
     QString defaultTransmitSource() const;
     QString transmitSliceSummary() const;
+#ifdef HAVE_MQTT
+    void publishFrameMqtt(const Ax25DecodedFrame& frame);
+    void handleMqttMessage(const QString& topic, const QByteArray& payload);
+#endif
 
     AudioEngine* m_audio{nullptr};
     RadioModel* m_radio{nullptr};
@@ -151,6 +162,9 @@ private:
     QStackedWidget* m_tabStack{nullptr};
     QAbstractButton* m_ax25Tab{nullptr};
     QAbstractButton* m_kissTab{nullptr};
+#ifdef HAVE_MQTT
+    QPointer<MqttClient> m_mqtt;
+#endif
     QRadioButton* m_hf300Profile{nullptr};
     QRadioButton* m_vhf1200Profile{nullptr};
     QCheckBox* m_enableDecode{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2010,6 +2010,18 @@ MainWindow::MainWindow(QWidget* parent)
     // Slice freq/mode changes are wired per-slice in setActiveSliceInternal().
     connect(&m_radioModel, &RadioModel::radioTransmittingChanged,
             this, [this](bool) { publishRadioStateMqtt(); });
+    // Debounce timer for end-of-CWX detection (queueEmpty unreliable with sync_cwx=0).
+    // Fires 1 s after the last tx:false with no intervening tx:true = transmission done.
+    m_cwxTxEndTimer.setSingleShot(true);
+    connect(&m_cwxTxEndTimer, &QTimer::timeout, this, [this]() {
+        if (m_cwxSavedWpm > 0) m_radioModel.cwxModel().setSpeed(m_cwxSavedWpm);
+        if (m_cwxSavedHz  > 0) m_radioModel.transmitModel().setCwPitch(m_cwxSavedHz);
+        m_cwxSavedWpm = 0;
+        m_cwxSavedHz  = 0;
+        m_cwxTransmitting = false;
+        m_cwxPublishedTxTrue = false;
+        publishRadioStateMqtt();
+    });
 
     // aethersdr/cw/transmit → CWX keyer.
     // Payload: {"text":"de k5ptb","speed_wpm":28,"pitch_hz":600}
@@ -2024,10 +2036,34 @@ MainWindow::MainWindow(QWidget* parent)
         if (text.isEmpty()) return;
         auto& tx = m_radioModel.transmitModel();
         const int wpm = obj.value(QStringLiteral("speed_wpm")).toInt(0);
-        if (wpm >= 5 && wpm <= 100) tx.setCwSpeed(wpm);
-        const int hz = obj.value(QStringLiteral("pitch_hz")).toInt(0);
-        if (hz >= 100 && hz <= 6000) tx.setCwPitch(hz);
+        const int hz  = obj.value(QStringLiteral("pitch_hz")).toInt(0);
+        const bool changeWpm = (wpm >= 5 && wpm <= 100);
+        const bool changeHz  = (hz >= 100 && hz <= 6000);
+        m_cwxSavedWpm = changeWpm ? m_radioModel.cwxModel().speed() : 0;
+        m_cwxSavedHz  = changeHz  ? tx.cwPitch() : 0;
+        if (changeWpm) m_radioModel.cwxModel().setSpeed(wpm);
+        if (changeHz)  tx.setCwPitch(hz);
+        m_cwxTxEndTimer.stop();
+        m_cwxPublishedTxTrue = false;
+        m_cwxTransmitting = true;
         m_radioModel.cwxModel().send(text);
+        disconnect(m_cwxSpeedRestoreConn);
+        m_cwxSpeedRestoreConn = connect(
+            &m_radioModel.cwxModel(), &CwxModel::queueEmpty,
+            this, [this]() {
+                // Fast path if queueEmpty fires (sync_cwx=1 or firmware sends queue=0).
+                // Identical work to m_cwxTxEndTimer.timeout — whichever fires first wins.
+                if (m_cwxSavedWpm > 0) m_radioModel.cwxModel().setSpeed(m_cwxSavedWpm);
+                if (m_cwxSavedHz  > 0) m_radioModel.transmitModel().setCwPitch(m_cwxSavedHz);
+                m_cwxSavedWpm = 0;
+                m_cwxSavedHz  = 0;
+                m_cwxTxEndTimer.stop();
+                m_cwxTransmitting = false;
+                m_cwxPublishedTxTrue = false;
+                if (!m_radioModel.isRadioTransmitting())
+                    publishRadioStateMqtt();
+                disconnect(m_cwxSpeedRestoreConn);
+            });
     });
 
     // MQTT → panadapter overlay display
@@ -6014,10 +6050,8 @@ void MainWindow::publishCwDecodeMqtt(const QString& text, float cost, bool rx)
     if (!m_mqttClient) return;
     if (!isMqttTopicEnabled(QString::fromLatin1(kCwDecodeTopic))) return;
     // No CW panel active → nothing is displayed → don't publish.
-    if (!m_cwDecoderApplet || cost >= m_cwDecoderApplet->cwCostThreshold()) {
-        qCDebug(lcMqtt) << "MQTT CW decode suppressed: no applet or cost threshold";
+    if (!m_cwDecoderApplet || cost >= m_cwDecoderApplet->cwCostThreshold())
         return;
-    }
     // Mirror panel normalization: \n → space; drop whitespace-only TX chunks.
     QString clean = text;
     clean.replace(QLatin1Char('\n'), QLatin1Char(' '));
@@ -6043,6 +6077,15 @@ void MainWindow::publishRadioStateMqtt()
 {
     if (!m_mqttClient) return;
     if (!isMqttTopicEnabled(QString::fromLatin1(kRadioStateTopic))) return;
+    if (m_cwxTransmitting) {
+        if (!m_radioModel.isRadioTransmitting()) {
+            m_cwxTxEndTimer.start(1000);  // might be done; confirm after 1 s silence
+            return;
+        }
+        m_cwxTxEndTimer.stop();           // element started — not done yet
+        if (m_cwxPublishedTxTrue) return;
+        m_cwxPublishedTxTrue = true;
+    }
     auto* s = activeSlice();
     if (!s) return;
     QJsonObject obj;
@@ -6892,6 +6935,9 @@ void MainWindow::startKissTncOnStartupIfConfigured()
         AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
     m_ax25HfPacketDecodeDialog = dlg;
     m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+#ifdef HAVE_MQTT
+    m_ax25HfPacketDecodeDialog->setMqttClient(m_mqttClient);
+#endif
 }
 
 void MainWindow::showFlexControlDialog()
@@ -13100,6 +13146,7 @@ void MainWindow::routeCwDecoderOutput()
     if (target == m_cwDecoderApplet) return;
 
     // Disconnect from old applet
+    disconnect(m_cwStatsConn);
     if (m_cwDecoderApplet) {
         disconnect(&m_cwDecoder, &CwDecoder::textDecoded,
                    m_cwDecoderApplet, &PanadapterApplet::appendCwText);
@@ -13135,7 +13182,7 @@ void MainWindow::routeCwDecoderOutput()
                 m_cwDecoderApplet, &PanadapterApplet::appendCwTextTx);
         connect(&m_cwDecoder, &CwDecoder::statsUpdated,
                 m_cwDecoderApplet, &PanadapterApplet::setCwStats);
-        connect(&m_cwDecoder, &CwDecoder::statsUpdated,
+        m_cwStatsConn = connect(&m_cwDecoder, &CwDecoder::statsUpdated,
                 this, [this](float pitchHz, float speedWpm) {
             m_cwLastPitchHz   = pitchHz;
             m_cwLastSpeedWpm  = speedWpm;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4367,6 +4367,13 @@ MainWindow::MainWindow(QWidget* parent)
     m_dialBackend->moveToThread(m_extCtrlThread);
 #endif
 
+#ifdef HAVE_MQTT
+    m_radioStateCoalesceTimer.setSingleShot(true);
+    m_radioStateCoalesceTimer.setInterval(150);
+    connect(&m_radioStateCoalesceTimer, &QTimer::timeout,
+            this, &MainWindow::publishRadioStateMqtt);
+#endif
+
     m_dialCoalesceTimer.setSingleShot(true);
     m_dialCoalesceTimer.setInterval(20);
     connect(&m_dialCoalesceTimer, &QTimer::timeout, this, [this]() {
@@ -6020,8 +6027,14 @@ void MainWindow::publishCwDecodeMqtt(const QString& text, float cost, bool rx)
     obj[QStringLiteral("rx")]   = rx;
     if (auto* s = activeSlice(); s && s->frequency() > 0.0)
         obj[QStringLiteral("freq")] = s->frequency();
-    if (m_cwLastPitchHz  > 0.0f) obj[QStringLiteral("pitch_hz")]  = m_cwLastPitchHz;
-    if (m_cwLastSpeedWpm > 0.0f) obj[QStringLiteral("speed_wpm")] = m_cwLastSpeedWpm;
+    if (rx) {
+        if (m_cwLastPitchHz  > 0.0f) obj[QStringLiteral("pitch_hz")]  = m_cwLastPitchHz;
+        if (m_cwLastSpeedWpm > 0.0f) obj[QStringLiteral("speed_wpm")] = m_cwLastSpeedWpm;
+    } else {
+        const auto& tm = m_radioModel.transmitModel();
+        if (tm.cwPitch() > 0) obj[QStringLiteral("pitch_hz")]  = tm.cwPitch();
+        if (tm.cwSpeed() > 0) obj[QStringLiteral("speed_wpm")] = tm.cwSpeed();
+    }
     m_mqttClient->publish(QString::fromLatin1(kCwDecodeTopic),
                           QJsonDocument(obj).toJson(QJsonDocument::Compact));
 }
@@ -12907,9 +12920,9 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     disconnect(m_radioStateModeConn);
 #ifdef HAVE_MQTT
     m_radioStateFreqConn = connect(s, &SliceModel::frequencyChanged,
-                                   this, [this](double) { publishRadioStateMqtt(); });
+                                   this, [this](double) { m_radioStateCoalesceTimer.start(); });
     m_radioStateModeConn = connect(s, &SliceModel::modeChanged,
-                                   this, [this](const QString&) { publishRadioStateMqtt(); });
+                                   this, [this](const QString&) { m_radioStateCoalesceTimer.start(); });
     publishRadioStateMqtt();
 #endif
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2043,12 +2043,12 @@ MainWindow::MainWindow(QWidget* parent)
         const int hz  = obj.value(QStringLiteral("pitch_hz")).toInt(0);
         const bool changeWpm = (wpm >= 5 && wpm <= 100);
         const bool changeHz  = (hz >= 100 && hz <= 6000);
-        m_cwxSavedWpm = changeWpm ? m_radioModel.cwxModel().speed() : 0;
-        m_cwxSavedHz  = changeHz  ? tx.cwPitch() : 0;
-        if (changeWpm) m_radioModel.cwxModel().setSpeed(wpm);
-        if (changeHz)  tx.setCwPitch(hz);
-        m_cwxSentWpm  = changeWpm ? wpm : 0;
-        m_cwxSentHz   = changeHz  ? hz  : 0;
+        if (!m_cwxTransmitting) {
+            m_cwxSavedWpm = changeWpm ? m_radioModel.cwxModel().speed() : 0;
+            m_cwxSavedHz  = changeHz  ? tx.cwPitch() : 0;
+        }
+        if (changeWpm) { m_radioModel.cwxModel().setSpeed(wpm); m_cwxSentWpm = wpm; }
+        if (changeHz)  { tx.setCwPitch(hz);                   m_cwxSentHz  = hz;  }
         m_cwxTxEndTimer.stop();
         m_cwxPublishedTxTrue = false;
         m_cwxTransmitting = true;
@@ -12975,8 +12975,6 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     // Rewire radio state MQTT publish to the new active slice's freq/mode signals.
     disconnect(m_radioStateFreqConn);
     disconnect(m_radioStateModeConn);
-#endif
-#ifdef HAVE_MQTT
     m_radioStateFreqConn = connect(s, &SliceModel::frequencyChanged,
                                    this, [this](double) { m_radioStateCoalesceTimer.start(); });
     m_radioStateModeConn = connect(s, &SliceModel::modeChanged,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2014,10 +2014,14 @@ MainWindow::MainWindow(QWidget* parent)
     // Fires 1 s after the last tx:false with no intervening tx:true = transmission done.
     m_cwxTxEndTimer.setSingleShot(true);
     connect(&m_cwxTxEndTimer, &QTimer::timeout, this, [this]() {
-        if (m_cwxSavedWpm > 0) m_radioModel.cwxModel().setSpeed(m_cwxSavedWpm);
-        if (m_cwxSavedHz  > 0) m_radioModel.transmitModel().setCwPitch(m_cwxSavedHz);
+        if (m_cwxSavedWpm > 0 && m_radioModel.cwxModel().speed() == m_cwxSentWpm)
+            m_radioModel.cwxModel().setSpeed(m_cwxSavedWpm);
+        if (m_cwxSavedHz  > 0 && m_radioModel.transmitModel().cwPitch() == m_cwxSentHz)
+            m_radioModel.transmitModel().setCwPitch(m_cwxSavedHz);
         m_cwxSavedWpm = 0;
         m_cwxSavedHz  = 0;
+        m_cwxSentWpm  = 0;
+        m_cwxSentHz   = 0;
         m_cwxTransmitting = false;
         m_cwxPublishedTxTrue = false;
         publishRadioStateMqtt();
@@ -2043,6 +2047,8 @@ MainWindow::MainWindow(QWidget* parent)
         m_cwxSavedHz  = changeHz  ? tx.cwPitch() : 0;
         if (changeWpm) m_radioModel.cwxModel().setSpeed(wpm);
         if (changeHz)  tx.setCwPitch(hz);
+        m_cwxSentWpm  = changeWpm ? wpm : 0;
+        m_cwxSentHz   = changeHz  ? hz  : 0;
         m_cwxTxEndTimer.stop();
         m_cwxPublishedTxTrue = false;
         m_cwxTransmitting = true;
@@ -2053,10 +2059,14 @@ MainWindow::MainWindow(QWidget* parent)
             this, [this]() {
                 // Fast path if queueEmpty fires (sync_cwx=1 or firmware sends queue=0).
                 // Identical work to m_cwxTxEndTimer.timeout — whichever fires first wins.
-                if (m_cwxSavedWpm > 0) m_radioModel.cwxModel().setSpeed(m_cwxSavedWpm);
-                if (m_cwxSavedHz  > 0) m_radioModel.transmitModel().setCwPitch(m_cwxSavedHz);
+                if (m_cwxSavedWpm > 0 && m_radioModel.cwxModel().speed() == m_cwxSentWpm)
+                    m_radioModel.cwxModel().setSpeed(m_cwxSavedWpm);
+                if (m_cwxSavedHz  > 0 && m_radioModel.transmitModel().cwPitch() == m_cwxSentHz)
+                    m_radioModel.transmitModel().setCwPitch(m_cwxSavedHz);
                 m_cwxSavedWpm = 0;
                 m_cwxSavedHz  = 0;
+                m_cwxSentWpm  = 0;
+                m_cwxSentHz   = 0;
                 m_cwxTxEndTimer.stop();
                 m_cwxTransmitting = false;
                 m_cwxPublishedTxTrue = false;
@@ -12961,9 +12971,11 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     }
 #endif
 
+#ifdef HAVE_MQTT
     // Rewire radio state MQTT publish to the new active slice's freq/mode signals.
     disconnect(m_radioStateFreqConn);
     disconnect(m_radioStateModeConn);
+#endif
 #ifdef HAVE_MQTT
     m_radioStateFreqConn = connect(s, &SliceModel::frequencyChanged,
                                    this, [this](double) { m_radioStateCoalesceTimer.start(); });
@@ -13146,7 +13158,9 @@ void MainWindow::routeCwDecoderOutput()
     if (target == m_cwDecoderApplet) return;
 
     // Disconnect from old applet
+#ifdef HAVE_MQTT
     disconnect(m_cwStatsConn);
+#endif
     if (m_cwDecoderApplet) {
         disconnect(&m_cwDecoder, &CwDecoder::textDecoded,
                    m_cwDecoderApplet, &PanadapterApplet::appendCwText);
@@ -13182,11 +13196,13 @@ void MainWindow::routeCwDecoderOutput()
                 m_cwDecoderApplet, &PanadapterApplet::appendCwTextTx);
         connect(&m_cwDecoder, &CwDecoder::statsUpdated,
                 m_cwDecoderApplet, &PanadapterApplet::setCwStats);
+#ifdef HAVE_MQTT
         m_cwStatsConn = connect(&m_cwDecoder, &CwDecoder::statsUpdated,
                 this, [this](float pitchHz, float speedWpm) {
             m_cwLastPitchHz   = pitchHz;
             m_cwLastSpeedWpm  = speedWpm;
         });
+#endif
         connect(m_cwDecoderApplet->lockPitchButton(), &QPushButton::toggled,
                 &m_cwDecoder, &CwDecoder::lockPitch);
         connect(m_cwDecoderApplet->lockSpeedButton(), &QPushButton::toggled,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2006,6 +2006,30 @@ MainWindow::MainWindow(QWidget* parent)
     connect(&m_cwDecoderTx, &CwDecoder::textDecoded, this,
             [this](const QString& t, float cost) { publishCwDecodeMqtt(t, cost, false); });
 
+    // aethersdr/radio/state — publish on PTT transitions.
+    // Slice freq/mode changes are wired per-slice in setActiveSliceInternal().
+    connect(&m_radioModel, &RadioModel::radioTransmittingChanged,
+            this, [this](bool) { publishRadioStateMqtt(); });
+
+    // aethersdr/cw/transmit → CWX keyer.
+    // Payload: {"text":"de k5ptb","speed_wpm":28,"pitch_hz":600}
+    // speed_wpm and pitch_hz are optional; absent = use current radio settings.
+    connect(m_mqttClient, &MqttClient::messageReceived,
+            this, [this](const QString& topic, const QByteArray& payload) {
+        if (topic != QString::fromLatin1(kCwTransmitTopic)) return;
+        if (!isMqttTopicEnabled(QString::fromLatin1(kCwTransmitTopic))) return;
+        const QJsonObject obj =
+            QJsonDocument::fromJson(payload).object();
+        const QString text = obj.value(QStringLiteral("text")).toString().trimmed();
+        if (text.isEmpty()) return;
+        auto& tx = m_radioModel.transmitModel();
+        const int wpm = obj.value(QStringLiteral("speed_wpm")).toInt(0);
+        if (wpm >= 5 && wpm <= 100) tx.setCwSpeed(wpm);
+        const int hz = obj.value(QStringLiteral("pitch_hz")).toInt(0);
+        if (hz >= 100 && hz <= 6000) tx.setCwPitch(hz);
+        m_radioModel.cwxModel().send(text);
+    });
+
     // MQTT → panadapter overlay display
     connect(m_appletPanel->mqttApplet(), &MqttApplet::displayValueChanged,
             this, [this](const QString& key, const QString& value) {
@@ -5981,8 +6005,12 @@ void MainWindow::showMqttSettingsDialog()
 void MainWindow::publishCwDecodeMqtt(const QString& text, float cost, bool rx)
 {
     if (!m_mqttClient) return;
+    if (!isMqttTopicEnabled(QString::fromLatin1(kCwDecodeTopic))) return;
     // No CW panel active → nothing is displayed → don't publish.
-    if (!m_cwDecoderApplet || cost >= m_cwDecoderApplet->cwCostThreshold()) return;
+    if (!m_cwDecoderApplet || cost >= m_cwDecoderApplet->cwCostThreshold()) {
+        qCDebug(lcMqtt) << "MQTT CW decode suppressed: no applet or cost threshold";
+        return;
+    }
     // Mirror panel normalization: \n → space; drop whitespace-only TX chunks.
     QString clean = text;
     clean.replace(QLatin1Char('\n'), QLatin1Char(' '));
@@ -5992,7 +6020,24 @@ void MainWindow::publishCwDecodeMqtt(const QString& text, float cost, bool rx)
     obj[QStringLiteral("rx")]   = rx;
     if (auto* s = activeSlice(); s && s->frequency() > 0.0)
         obj[QStringLiteral("freq")] = s->frequency();
+    if (m_cwLastPitchHz  > 0.0f) obj[QStringLiteral("pitch_hz")]  = m_cwLastPitchHz;
+    if (m_cwLastSpeedWpm > 0.0f) obj[QStringLiteral("speed_wpm")] = m_cwLastSpeedWpm;
     m_mqttClient->publish(QString::fromLatin1(kCwDecodeTopic),
+                          QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+void MainWindow::publishRadioStateMqtt()
+{
+    if (!m_mqttClient) return;
+    if (!isMqttTopicEnabled(QString::fromLatin1(kRadioStateTopic))) return;
+    auto* s = activeSlice();
+    if (!s) return;
+    QJsonObject obj;
+    obj[QStringLiteral("slice")] = s->letter();
+    obj[QStringLiteral("freq")]  = s->frequency();
+    obj[QStringLiteral("mode")]  = s->mode();
+    obj[QStringLiteral("tx")]    = m_radioModel.isRadioTransmitting();
+    m_mqttClient->publish(QString::fromLatin1(kRadioStateTopic),
                           QJsonDocument(obj).toJson(QJsonDocument::Compact));
 }
 #endif
@@ -6807,6 +6852,9 @@ void MainWindow::showAx25HfPacketDecodeDialog()
         m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
     }
     m_ax25HfPacketDecodeDialog->setAttachedSlice(slice);
+#ifdef HAVE_MQTT
+    m_ax25HfPacketDecodeDialog->setMqttClient(m_mqttClient);
+#endif
     m_ax25HfPacketDecodeDialog->show();
     m_ax25HfPacketDecodeDialog->raise();
     m_ax25HfPacketDecodeDialog->activateWindow();
@@ -12854,6 +12902,17 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     }
 #endif
 
+    // Rewire radio state MQTT publish to the new active slice's freq/mode signals.
+    disconnect(m_radioStateFreqConn);
+    disconnect(m_radioStateModeConn);
+#ifdef HAVE_MQTT
+    m_radioStateFreqConn = connect(s, &SliceModel::frequencyChanged,
+                                   this, [this](double) { publishRadioStateMqtt(); });
+    m_radioStateModeConn = connect(s, &SliceModel::modeChanged,
+                                   this, [this](const QString&) { publishRadioStateMqtt(); });
+    publishRadioStateMqtt();
+#endif
+
     qDebug() << "MainWindow: active slice set to" << sliceId;
 }
 
@@ -13063,6 +13122,11 @@ void MainWindow::routeCwDecoderOutput()
                 m_cwDecoderApplet, &PanadapterApplet::appendCwTextTx);
         connect(&m_cwDecoder, &CwDecoder::statsUpdated,
                 m_cwDecoderApplet, &PanadapterApplet::setCwStats);
+        connect(&m_cwDecoder, &CwDecoder::statsUpdated,
+                this, [this](float pitchHz, float speedWpm) {
+            m_cwLastPitchHz   = pitchHz;
+            m_cwLastSpeedWpm  = speedWpm;
+        });
         connect(m_cwDecoderApplet->lockPitchButton(), &QPushButton::toggled,
                 &m_cwDecoder, &CwDecoder::lockPitch);
         connect(m_cwDecoderApplet->lockSpeedButton(), &QPushButton::toggled,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2008,6 +2008,10 @@ MainWindow::MainWindow(QWidget* parent)
 
     // aethersdr/radio/state — publish on PTT transitions.
     // Slice freq/mode changes are wired per-slice in setActiveSliceInternal().
+    m_radioStateCoalesceTimer.setSingleShot(true);
+    m_radioStateCoalesceTimer.setInterval(150);
+    connect(&m_radioStateCoalesceTimer, &QTimer::timeout,
+            this, &MainWindow::publishRadioStateMqtt);
     connect(&m_radioModel, &RadioModel::radioTransmittingChanged,
             this, [this](bool) { publishRadioStateMqtt(); });
     // Debounce timer for end-of-CWX detection (queueEmpty unreliable with sync_cwx=0).
@@ -4413,12 +4417,6 @@ MainWindow::MainWindow(QWidget* parent)
     m_dialBackend->moveToThread(m_extCtrlThread);
 #endif
 
-#ifdef HAVE_MQTT
-    m_radioStateCoalesceTimer.setSingleShot(true);
-    m_radioStateCoalesceTimer.setInterval(150);
-    connect(&m_radioStateCoalesceTimer, &QTimer::timeout,
-            this, &MainWindow::publishRadioStateMqtt);
-#endif
 
     m_dialCoalesceTimer.setSingleShot(true);
     m_dialCoalesceTimer.setInterval(20);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -483,6 +483,7 @@ private:
     float             m_cwLastSpeedWpm{0.0f};
     QMetaObject::Connection m_radioStateFreqConn;
     QMetaObject::Connection m_radioStateModeConn;
+    QTimer                  m_radioStateCoalesceTimer;
     CwDecoder         m_cwDecoderTx;
     RttyDecoder       m_rttyDecoder;
     DxClusterClient*   m_dxCluster{nullptr};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -484,6 +484,13 @@ private:
     QMetaObject::Connection m_radioStateFreqConn;
     QMetaObject::Connection m_radioStateModeConn;
     QTimer                  m_radioStateCoalesceTimer;
+    QMetaObject::Connection m_cwStatsConn;
+    QMetaObject::Connection m_cwxSpeedRestoreConn;
+    int               m_cwxSavedWpm{0};
+    int               m_cwxSavedHz{0};
+    bool              m_cwxTransmitting{false};
+    bool              m_cwxPublishedTxTrue{false};
+    QTimer            m_cwxTxEndTimer;
     CwDecoder         m_cwDecoderTx;
     RttyDecoder       m_rttyDecoder;
     DxClusterClient*   m_dxCluster{nullptr};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -366,6 +366,7 @@ private:
 #ifdef HAVE_MQTT
     void showMqttSettingsDialog();
     void publishCwDecodeMqtt(const QString& text, float cost, bool rx);
+    void publishRadioStateMqtt();
 #endif
     void applyPanLayout(const QString& layoutId);
     void createPansSequentially(const QString& layoutId, int total,
@@ -478,6 +479,10 @@ private:
     PgxlConnection    m_pgxlConn;        // direct TCP 9008 to PGXL for telemetry
     BandPlanManager*  m_bandPlanMgr{nullptr};
     CwDecoder         m_cwDecoder;
+    float             m_cwLastPitchHz{0.0f};
+    float             m_cwLastSpeedWpm{0.0f};
+    QMetaObject::Connection m_radioStateFreqConn;
+    QMetaObject::Connection m_radioStateModeConn;
     CwDecoder         m_cwDecoderTx;
     RttyDecoder       m_rttyDecoder;
     DxClusterClient*   m_dxCluster{nullptr};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -481,6 +481,12 @@ private:
     CwDecoder         m_cwDecoder;
     float             m_cwLastPitchHz{0.0f};
     float             m_cwLastSpeedWpm{0.0f};
+    CwDecoder         m_cwDecoderTx;
+    RttyDecoder       m_rttyDecoder;
+    DxClusterClient*   m_dxCluster{nullptr};
+    DxClusterClient*   m_rbnClient{nullptr};
+#ifdef HAVE_MQTT
+    MqttClient*        m_mqttClient{nullptr};
     QMetaObject::Connection m_radioStateFreqConn;
     QMetaObject::Connection m_radioStateModeConn;
     QTimer                  m_radioStateCoalesceTimer;
@@ -488,15 +494,11 @@ private:
     QMetaObject::Connection m_cwxSpeedRestoreConn;
     int               m_cwxSavedWpm{0};
     int               m_cwxSavedHz{0};
+    int               m_cwxSentWpm{0};
+    int               m_cwxSentHz{0};
     bool              m_cwxTransmitting{false};
     bool              m_cwxPublishedTxTrue{false};
     QTimer            m_cwxTxEndTimer;
-    CwDecoder         m_cwDecoderTx;
-    RttyDecoder       m_rttyDecoder;
-    DxClusterClient*   m_dxCluster{nullptr};
-    DxClusterClient*   m_rbnClient{nullptr};
-#ifdef HAVE_MQTT
-    MqttClient*        m_mqttClient{nullptr};
 #endif
     WsjtxClient*       m_wsjtxClient{nullptr};
     SpotCollectorClient* m_spotCollectorClient{nullptr};

--- a/src/gui/MqttApplet.cpp
+++ b/src/gui/MqttApplet.cpp
@@ -145,15 +145,20 @@ void MqttApplet::setMqttClient(MqttClient* client)
     connect(client, &MqttClient::messagePublished, this, [this](const QString& topic, const QByteArray& payload) {
         QString shortTopic = topic.section('/', -1);
         if (shortTopic.isEmpty()) shortTopic = topic;
-        m_messageLog->append(QStringLiteral("TX %1: %2").arg(shortTopic, QString::fromUtf8(payload).left(80)));
-        QTextDocument* doc = m_messageLog->document();
-        while (doc->blockCount() > 50) {
-            QTextCursor cursor(doc->begin());
-            cursor.select(QTextCursor::BlockUnderCursor);
-            cursor.removeSelectedText();
-            cursor.deleteChar();
-        }
+        appendMessageLog(QStringLiteral("TX %1: %2").arg(shortTopic, QString::fromUtf8(payload).left(80)));
     });
+}
+
+void MqttApplet::appendMessageLog(const QString& line)
+{
+    m_messageLog->append(line);
+    QTextDocument* doc = m_messageLog->document();
+    while (doc->blockCount() > 50) {
+        QTextCursor cursor(doc->begin());
+        cursor.select(QTextCursor::BlockUnderCursor);
+        cursor.removeSelectedText();
+        cursor.deleteChar();
+    }
 }
 
 void MqttApplet::refreshSettings()
@@ -204,16 +209,7 @@ void MqttApplet::onMessageReceived(const QString& topic, const QByteArray& paylo
     if (shortTopic.isEmpty()) { shortTopic = topic; }
     const QString value = QString::fromUtf8(payload).left(80);
 
-    const QString line = QString("%1: %2").arg(shortTopic, value);
-    m_messageLog->append(line);
-
-    QTextDocument* doc = m_messageLog->document();
-    while (doc->blockCount() > 50) {
-        QTextCursor cursor(doc->begin());
-        cursor.select(QTextCursor::BlockUnderCursor);
-        cursor.removeSelectedText();
-        cursor.deleteChar();
-    }
+    appendMessageLog(QStringLiteral("%1: %2").arg(shortTopic, value));
 
     for (const auto& update : parseMqttAntennaAliasMessage(topic, payload)) {
         emit antennaAliasRequested(update.token, update.alias);

--- a/src/gui/MqttApplet.cpp
+++ b/src/gui/MqttApplet.cpp
@@ -141,7 +141,19 @@ void MqttApplet::setMqttClient(MqttClient* client)
     connect(client, &MqttClient::connectionError, this, [this](const QString& err) {
         updateStatus(err, false);
     });
-    connect(client, &MqttClient::messageReceived, this, &MqttApplet::onMessageReceived);
+    connect(client, &MqttClient::messageReceived,  this, &MqttApplet::onMessageReceived);
+    connect(client, &MqttClient::messagePublished, this, [this](const QString& topic, const QByteArray& payload) {
+        QString shortTopic = topic.section('/', -1);
+        if (shortTopic.isEmpty()) shortTopic = topic;
+        m_messageLog->append(QStringLiteral("TX %1: %2").arg(shortTopic, QString::fromUtf8(payload).left(80)));
+        QTextDocument* doc = m_messageLog->document();
+        while (doc->blockCount() > 50) {
+            QTextCursor cursor(doc->begin());
+            cursor.select(QTextCursor::BlockUnderCursor);
+            cursor.removeSelectedText();
+            cursor.deleteChar();
+        }
+    });
 }
 
 void MqttApplet::refreshSettings()

--- a/src/gui/MqttApplet.h
+++ b/src/gui/MqttApplet.h
@@ -41,6 +41,7 @@ signals:
 private:
     void buildUI();
     void updateStatus(const QString& text, bool ok);
+    void appendMessageLog(const QString& line);
     void onMessageReceived(const QString& topic, const QByteArray& payload);
     void rebuildButtons();
     void requestConnectFromSettings();

--- a/src/gui/MqttSettingsDialog.cpp
+++ b/src/gui/MqttSettingsDialog.cpp
@@ -170,6 +170,7 @@ void MqttSettingsDialog::buildUi()
         auto* cb = new QCheckBox(
             QStringLiteral("%1  —  %2").arg(def.topic, def.description));
         cb->setToolTip(def.topic);
+        cb->setProperty("topic", def.topic);
         if (!def.gateable) {
             cb->setChecked(true);
             cb->setEnabled(false);
@@ -211,6 +212,7 @@ void MqttSettingsDialog::buildUi()
         auto* cb = new QCheckBox(
             QStringLiteral("%1  —  %2").arg(def.topic, def.description));
         cb->setToolTip(def.topic);
+        cb->setProperty("topic", def.topic);
         if (!def.gateable) {
             cb->setChecked(true);
             cb->setEnabled(false);
@@ -249,16 +251,18 @@ void MqttSettingsDialog::loadSettings()
     m_tlsCheck->setChecked(config.useTls);
     m_caFileEdit->setText(config.caFile);
 
-    const auto& subDefs = internalMqttSubscribeTopicDefs();
-    for (int i = 0; i < m_internalSubBoxes.size(); ++i) {
-        if (i < subDefs.size() && subDefs[i].gateable)
-            m_internalSubBoxes[i]->setChecked(isMqttTopicEnabled(subDefs[i].topic));
+    for (auto* cb : m_internalSubBoxes) {
+        if (!cb->isEnabled()) continue;
+        const QString topic = cb->property("topic").toString();
+        if (!topic.isEmpty())
+            cb->setChecked(isMqttTopicEnabled(topic));
     }
 
-    const auto& pubDefs = internalMqttPublishTopicDefs();
-    for (int i = 0; i < m_internalPubBoxes.size(); ++i) {
-        if (i < pubDefs.size() && pubDefs[i].gateable)
-            m_internalPubBoxes[i]->setChecked(isMqttTopicEnabled(pubDefs[i].topic));
+    for (auto* cb : m_internalPubBoxes) {
+        if (!cb->isEnabled()) continue;
+        const QString topic = cb->property("topic").toString();
+        if (!topic.isEmpty())
+            cb->setChecked(isMqttTopicEnabled(topic));
     }
 
     m_topicsTable->setRowCount(0);
@@ -284,16 +288,18 @@ void MqttSettingsDialog::saveSettings()
     };
     saveMqttConnectionConfig(config);
 
-    const auto& subDefs = internalMqttSubscribeTopicDefs();
-    for (int i = 0; i < m_internalSubBoxes.size(); ++i) {
-        if (i < subDefs.size() && subDefs[i].gateable)
-            setMqttTopicEnabled(subDefs[i].topic, m_internalSubBoxes[i]->isChecked());
+    for (auto* cb : m_internalSubBoxes) {
+        if (!cb->isEnabled()) continue;
+        const QString topic = cb->property("topic").toString();
+        if (!topic.isEmpty())
+            setMqttTopicEnabled(topic, cb->isChecked());
     }
 
-    const auto& pubDefs = internalMqttPublishTopicDefs();
-    for (int i = 0; i < m_internalPubBoxes.size(); ++i) {
-        if (i < pubDefs.size() && pubDefs[i].gateable)
-            setMqttTopicEnabled(pubDefs[i].topic, m_internalPubBoxes[i]->isChecked());
+    for (auto* cb : m_internalPubBoxes) {
+        if (!cb->isEnabled()) continue;
+        const QString topic = cb->property("topic").toString();
+        if (!topic.isEmpty())
+            setMqttTopicEnabled(topic, cb->isChecked());
     }
 
     saveMqttTopicConfig(topicRows());

--- a/src/gui/MqttSettingsDialog.cpp
+++ b/src/gui/MqttSettingsDialog.cpp
@@ -166,11 +166,18 @@ void MqttSettingsDialog::buildUi()
 
     auto* internalGroup = new QGroupBox(tr("Internal AetherSDR Topics"));
     auto* internalLayout = new QVBoxLayout(internalGroup);
-    auto* internalText = new QLabel(
-        tr("Subscribed automatically whenever MQTT connects; these topics are not removable:\n%1")
-            .arg(internalMqttSubscriptionTopics().join(QStringLiteral("\n"))));
-    internalText->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    internalLayout->addWidget(internalText);
+    for (const auto& def : internalMqttSubscribeTopicDefs()) {
+        auto* cb = new QCheckBox(
+            QStringLiteral("%1  —  %2").arg(def.topic, def.description));
+        cb->setToolTip(def.topic);
+        if (!def.gateable) {
+            cb->setChecked(true);
+            cb->setEnabled(false);
+            cb->setStyleSheet(QStringLiteral("QCheckBox:disabled { color: #556; }"));
+        }
+        m_internalSubBoxes.append(cb);
+        internalLayout->addWidget(cb);
+    }
     topicsLayout->addWidget(internalGroup);
     tabs->addTab(topicsTab, tr("Subscriptions"));
 
@@ -200,11 +207,18 @@ void MqttSettingsDialog::buildUi()
 
     auto* pubInternalGroup = new QGroupBox(tr("Internal AetherSDR Topics"));
     auto* pubInternalLayout = new QVBoxLayout(pubInternalGroup);
-    auto* pubInternalText = new QLabel(
-        tr("Published automatically whenever MQTT is connected; these topics are not user-configurable:\n"
-           "%1").arg(internalMqttPublishTopics().join(QStringLiteral("\n"))));
-    pubInternalText->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    pubInternalLayout->addWidget(pubInternalText);
+    for (const auto& def : internalMqttPublishTopicDefs()) {
+        auto* cb = new QCheckBox(
+            QStringLiteral("%1  —  %2").arg(def.topic, def.description));
+        cb->setToolTip(def.topic);
+        if (!def.gateable) {
+            cb->setChecked(true);
+            cb->setEnabled(false);
+            cb->setStyleSheet(QStringLiteral("QCheckBox:disabled { color: #556; }"));
+        }
+        m_internalPubBoxes.append(cb);
+        pubInternalLayout->addWidget(cb);
+    }
     buttonsLayout->addWidget(pubInternalGroup);
 
     tabs->addTab(buttonsTab, tr("Publish Buttons"));
@@ -235,6 +249,18 @@ void MqttSettingsDialog::loadSettings()
     m_tlsCheck->setChecked(config.useTls);
     m_caFileEdit->setText(config.caFile);
 
+    const auto& subDefs = internalMqttSubscribeTopicDefs();
+    for (int i = 0; i < m_internalSubBoxes.size(); ++i) {
+        if (i < subDefs.size() && subDefs[i].gateable)
+            m_internalSubBoxes[i]->setChecked(isMqttTopicEnabled(subDefs[i].topic));
+    }
+
+    const auto& pubDefs = internalMqttPublishTopicDefs();
+    for (int i = 0; i < m_internalPubBoxes.size(); ++i) {
+        if (i < pubDefs.size() && pubDefs[i].gateable)
+            m_internalPubBoxes[i]->setChecked(isMqttTopicEnabled(pubDefs[i].topic));
+    }
+
     m_topicsTable->setRowCount(0);
     for (const MqttTopicDef& def : loadMqttTopicConfig()) {
         addTopicRow(def);
@@ -257,6 +283,19 @@ void MqttSettingsDialog::saveSettings()
         m_caFileEdit->text().trimmed(),
     };
     saveMqttConnectionConfig(config);
+
+    const auto& subDefs = internalMqttSubscribeTopicDefs();
+    for (int i = 0; i < m_internalSubBoxes.size(); ++i) {
+        if (i < subDefs.size() && subDefs[i].gateable)
+            setMqttTopicEnabled(subDefs[i].topic, m_internalSubBoxes[i]->isChecked());
+    }
+
+    const auto& pubDefs = internalMqttPublishTopicDefs();
+    for (int i = 0; i < m_internalPubBoxes.size(); ++i) {
+        if (i < pubDefs.size() && pubDefs[i].gateable)
+            setMqttTopicEnabled(pubDefs[i].topic, m_internalPubBoxes[i]->isChecked());
+    }
+
     saveMqttTopicConfig(topicRows());
     saveMqttButtonConfig(buttonRows());
     savePasswordToKeychain(m_passEdit->text());

--- a/src/gui/MqttSettingsDialog.cpp
+++ b/src/gui/MqttSettingsDialog.cpp
@@ -298,6 +298,7 @@ void MqttSettingsDialog::saveSettings()
 
     saveMqttTopicConfig(topicRows());
     saveMqttButtonConfig(buttonRows());
+    AppSettings::instance().save();
     savePasswordToKeychain(m_passEdit->text());
     emit settingsSaved(m_passEdit->text());
 }

--- a/src/gui/MqttSettingsDialog.h
+++ b/src/gui/MqttSettingsDialog.h
@@ -45,7 +45,10 @@ private:
     QLineEdit* m_caFileEdit{nullptr};
     QTableWidget* m_topicsTable{nullptr};
     QTableWidget* m_buttonsTable{nullptr};
-    QPushButton* m_addButtonRowBtn{nullptr};
+    QPushButton*  m_addButtonRowBtn{nullptr};
+
+    QVector<QCheckBox*> m_internalSubBoxes;
+    QVector<QCheckBox*> m_internalPubBoxes;
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Motivation

Addresses the feature requests and concerns raised in #3388. The existing MQTT implementation published only antenna/VFO topics with no user control over which topics were active. This PR adds opt-in control for all new topics, extends the CW decode payload, and adds bidirectional MQTT support for the CW keyer, radio state, and AX.25 packet radio.

## Changes

### Per-topic opt-in control

A new `InternalMqttTopicDef` struct serves as the single source of truth for the topic registry, replacing the previous ad-hoc approach. Each topic carries a `gateable` flag:

- **Non-gateable topics** (the existing antenna alias topics) remain always-on and cannot be disabled, preserving the original behavior. They appear checked and greyed-out in the settings dialog.
- **`aethersdr/cw/decode`** is gateable but **defaults to enabled** (`defaultEnabled=true`), preserving the behavior of existing relay scripts and loggers without requiring any user action after upgrade.
- **All other new topics** — `aethersdr/cw/transmit`, `aethersdr/radio/state`, `aethersdr/ax25/rx`, `aethersdr/ax25/tx` — are gateable and default to `false` (disabled). Users explicitly opt in via the MQTT settings dialog.

`isMqttTopicEnabled()` / `setMqttTopicEnabled()` are backed by `QSettings`.

### `aethersdr/cw/decode` — payload additions and gating change

`pitch_hz` and `speed_wpm` are now included in the payload when their values are non-zero, allowing subscribers to mirror the operator's keying characteristics in replies.

> **Note for existing users:** `aethersdr/cw/decode` was introduced in v26.6.1 (#3216) as an always-active publish topic. This PR brings it under the same per-topic opt-in mechanism as all other gateable topics, but it **defaults to enabled** for backward compatibility. Users relying on this topic do not need to take any action after upgrading.

> The `kCwDecodeTopic` string constant was consolidated per the feedback in the #3216 review; the topic path itself is unchanged.

### `aethersdr/cw/transmit` — subscribe (opt-in)

AetherSDR subscribes to this topic and feeds received text to the CWX keyer.

Payload: `{"text": "K5PTB DE W1ABC", "speed_wpm": 28, "pitch_hz": 600}`

`speed_wpm` and `pitch_hz` are optional; omitting them uses the current keyer settings.

### `aethersdr/radio/state` — publish (opt-in)

Published on any frequency, mode, or TX state change:

```json
{"slice": "A", "freq": 14.025, "mode": "CW", "tx": false}
```

### `aethersdr/ax25/rx` — publish (opt-in)

Each decoded AX.25 frame is published:

```json
{
  "from": "K5PTB", "to": "APRS",
  "via": ["WIDE1-1", "WIDE2-1"],
  "payload": ">Running AetherSDR",
  "freq": 144.390,
  "confidence": 0.87
}
```

### `aethersdr/ax25/tx` — subscribe (opt-in)

AetherSDR subscribes and queues received frames for 1200-baud Bell 202 transmission.

Payload: TNC2 string — `K5PTB>APRS,WIDE1-1:>payload`

> **Initialization note:** The AX.25 MQTT handler lives in the AetherModem dialog, which is lazy-initialized. The `ax25/tx` topic will not be active until the dialog has been initialized — either by opening the AetherModem window, or by enabling **Start KISS TNC on startup** in the AetherModem KISS TNC settings. With that option enabled, the dialog is created silently at launch (no window appears) and `ax25/tx` is available immediately without any user interaction.

### Debug logging

All MQTT publish and receive events are written to the AetherSDR debug console when the debug logging option is enabled. No applet-level display is added for these topics.

## Design decisions (re: #3388)

**On TCI overlap (`radio/state`):** TCI and MQTT carry overlapping information, but they serve different clients. A subscriber using only MQTT for external tool integration (contest loggers, automation scripts) should not need a second TCI connection. The ordering concern — CW decode characters arriving before a `tx=false` state update — is not a practical issue: both originate from the same internal event bus, so MQTT message ordering between them is deterministic for a single publisher.

**On keeping AX.25 topics:** The `ax25/rx` and `ax25/tx` topics are not debug conveniences; they are the primary path for external tools (APRS clients, packet BBS clients, automation scripts) to consume decoded frames without maintaining a persistent KISS TCP connection. They have been in live use for multi-day AX.25 packet decode testing.

**On PR structure:** The per-topic gating infrastructure (`InternalMqttTopicDef`, `isMqttTopicEnabled`) is shared across all the new topics. Splitting would require duplicating or pre-landing that infrastructure separately. Happy to split if preferred — the topics are otherwise independent.

## What does not change

- Existing antenna/VFO alias topics remain always-on and non-disableable
- `aethersdr/cw/decode` topic path is unchanged
- No changes to KISS TNC, TCI server, or CAT/rigctld paths

## Testing

Verified end-to-end on all new topics: publish events received by a Mosquitto subscriber, inbound `cw/transmit` messages keyed through CWX, `radio/state` updates on band change, and `ax25/rx` frames from live 144.390 MHz traffic. `ax25/tx` (transmit path) has not been exercised on-air pending transverter calibration.

The AX.25 MQTT path has been in continuous use for multi-day packet decode comparison testing on a Raspberry Pi 5 (2,000+ frames across 12-hour runs, three-decoder comparison against Graywolf and Direwolf). The `cw/transmit` and `radio/state` topics were used in live contest operating on a MacBook Air M2 during the 2026 Atlantic Canada QSO Party.

Screenshots of the updated MQTT settings dialog are in #3388.

---

Built and smoke tested on: Windows 11 on Intel i3 (integrated GPU)