### PR TITLE
feat(tnc): AX.25 worker thread, AFSK profiles A/B/AB/A+/B+/AB+, HdlcCodec Phase 1a+1b

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 build-*/
+build_*/
 deploy/
 deploy-*/
 installer-runtime/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,6 +582,7 @@ set(CORE_SOURCES
     src/core/tnc/Ax25.cpp
     src/core/tnc/Ax25Connection.cpp
     src/core/tnc/HeardList.cpp
+    src/core/tnc/HdlcCodec.cpp
     src/core/tnc/KissFraming.cpp
     src/core/tnc/KissTncServer.cpp
     src/core/tnc/TncTerminal.cpp
@@ -868,6 +869,21 @@ else()
     target_compile_options(aether_libmodem_core PRIVATE -w)
 endif()
 
+# AetherAFSKDemod — Direwolf profile-A + profile-B AFSK demodulators (GPL-3).
+# Profile A: IQ-mix + RRC + AGC/multi-slicer (best for amplitude-imbalanced signals).
+# Profile B: FM discriminator (best for frequency-offset/Doppler signals).
+# Both VHF 1200 baud only; HF 300 baud stays on aether_libmodem_core.
+# AX.25 framing (bitstream, HDLC, FCS) continues to use aether_libmodem_core.
+add_library(aether_afskdemod STATIC
+    third_party/direwolf_afsk/AetherAFSKDemod.cpp
+    third_party/direwolf_afsk/AetherFMDiscrimDemod.cpp
+)
+target_include_directories(aether_afskdemod PUBLIC
+    ${CMAKE_SOURCE_DIR}/third_party/direwolf_afsk
+)
+target_compile_features(aether_afskdemod PUBLIC cxx_std_20)
+message(STATUS "AetherAFSKDemod: Direwolf profile-A + profile-B (VHF 1200 baud), GPL-3")
+
 # Bundled liquid-dsp (MIT) — comprehensive DSP toolkit covering modems
 # (PSK/QAM/FSK/GMSK/OFDM), FEC (Hamming/Golay/RS/convolutional), adaptive
 # filters (LMS/RLS), AGC, NCO, polyphase resampling, and equalizers.
@@ -1105,6 +1121,7 @@ target_link_libraries(AetherSDR PRIVATE
     Qt6::Network
     Qt6::Multimedia
     aether_libmodem_core
+    aether_afskdemod
     ${CMAKE_DL_LIBS}   # dlopen/dlsym for tolerant X11 error handler (#1839)
 )
 
@@ -1972,6 +1989,7 @@ add_test(NAME ax25_frame_formatter_test COMMAND ax25_frame_formatter_test)
 add_executable(ax25_libmodem_shim_test
     tests/ax25_libmodem_shim_test.cpp
     src/core/tnc/AetherAx25LibmodemShim.cpp
+    src/core/tnc/HdlcCodec.cpp
     src/core/tnc/Ax25FrameFormatter.cpp
     src/core/tnc/Ax25.cpp
     src/core/tnc/KissFraming.cpp
@@ -1984,7 +2002,8 @@ add_executable(ax25_libmodem_shim_test
     src/core/AppSettings.cpp
 )
 target_include_directories(ax25_libmodem_shim_test PRIVATE src)
-target_link_libraries(ax25_libmodem_shim_test PRIVATE Qt6::Core aether_libmodem_core)
+target_link_libraries(ax25_libmodem_shim_test PRIVATE Qt6::Core aether_libmodem_core
+    aether_afskdemod)
 add_test(NAME ax25_libmodem_shim_test COMMAND ax25_libmodem_shim_test)
 
 # Offline AX.25 decode diagnostic: replays a captured WAV through the decoder.
@@ -2041,6 +2060,14 @@ add_executable(tnc_terminal_test
 target_include_directories(tnc_terminal_test PRIVATE src)
 target_link_libraries(tnc_terminal_test PRIVATE Qt6::Core)
 add_test(NAME tnc_terminal_test COMMAND tnc_terminal_test)
+
+add_executable(hdlc_codec_test
+    tests/hdlc_codec_test.cpp
+    src/core/tnc/HdlcCodec.cpp
+)
+target_include_directories(hdlc_codec_test PRIVATE src)
+target_link_libraries(hdlc_codec_test PRIVATE aether_libmodem_core)
+add_test(NAME hdlc_codec_test COMMAND hdlc_codec_test)
 
 add_executable(cwx_panel_test
     tests/cwx_panel_test.cpp

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -194,3 +194,15 @@ Windows will need to land MSVC support first.
   Copyright (c) 2007-2016 Joseph Gaeddert
   License: MIT
   Source:  https://github.com/jgaeddert/liquid-dsp
+
+
+15. Dire Wolf — AFSK Demodulator (algorithmic derivation)
+----------------------------------------------------------
+Bundled at third_party/direwolf_afsk/ as an algorithmic derivation of the
+Dire Wolf "profile A" AFSK demodulator. Rewritten in C++20 for AetherSDR.
+Referenced source files: src/demod_afsk.c, src/dsp.c from Dire Wolf 1.7.
+Used unconditionally for the VHF 1200 baud AX.25 receive path.
+
+  Copyright (C) 2011-2020 John Langner WB2OSZ
+  License: GPL-2.0-or-later (compatible into AetherSDR's GPL-3.0-or-later)
+  Source:  https://github.com/wb2osz/direwolf

--- a/src/core/MqttClient.cpp
+++ b/src/core/MqttClient.cpp
@@ -233,9 +233,11 @@ void MqttClient::publish(const QString& topic, const QByteArray& payload)
 {
 #ifdef HAVE_MQTT
     if (!m_connected || !m_mosq) return;
+    qCDebug(lcMqtt) << "MqttClient: publish" << topic << payload;
     mosquitto_publish(m_mosq, nullptr,
         topic.toUtf8().constData(),
         payload.size(), payload.constData(), 0, false);
+    emit messagePublished(topic, payload);
 #else
     Q_UNUSED(topic); Q_UNUSED(payload);
 #endif
@@ -294,6 +296,7 @@ void MqttClient::onMessage(struct mosquitto*, void* obj,
     QString topic = QString::fromUtf8(msg->topic);
     QByteArray payload(static_cast<const char*>(msg->payload), msg->payloadlen);
     QMetaObject::invokeMethod(self, [self, topic, payload] {
+        qCDebug(lcMqtt) << "MqttClient: received" << topic << payload;
         emit self->messageReceived(topic, payload);
     });
 }

--- a/src/core/MqttClient.h
+++ b/src/core/MqttClient.h
@@ -41,6 +41,7 @@ signals:
     void disconnected();
     void connectionError(const QString& error);
     void messageReceived(const QString& topic, const QByteArray& payload);
+    void messagePublished(const QString& topic, const QByteArray& payload);
 
 private:
 #ifdef HAVE_MQTT

--- a/src/core/MqttSettings.cpp
+++ b/src/core/MqttSettings.cpp
@@ -281,17 +281,84 @@ QStringList mqttUserSubscriptionTopics(const QVector<MqttTopicDef>& topics)
     return names;
 }
 
+// ── Internal topic definitions ────────────────────────────────────────────────
+// Single source of truth for internal subscribe and publish topics.  Adding
+// an entry here automatically populates the settings dialog checkbox list.
+
+const QVector<InternalMqttTopicDef>& internalMqttSubscribeTopicDefs()
+{
+    static const QVector<InternalMqttTopicDef> defs = {
+        { mqttAntennaAliasTopicPrefix() + QLatin1Char('+'),
+          QStringLiteral("Antenna name (per-port)"),  false },
+        { mqttAntennaAliasBulkTopic(),
+          QStringLiteral("Antenna names (bulk)"),     false },
+        { QString(kCwTransmitTopic),
+          QStringLiteral("CW keyer input"),           true  },
+        { QString(kAx25TxTopic),
+          QStringLiteral("AX.25 transmit"),           true  },
+    };
+    return defs;
+}
+
+const QVector<InternalMqttTopicDef>& internalMqttPublishTopicDefs()
+{
+    static const QVector<InternalMqttTopicDef> defs = {
+        { QString(kCwDecodeTopic),    QStringLiteral("CW decoded text"),             true },
+        { QString(kRadioStateTopic),  QStringLiteral("Radio VFO / mode / TX state"), true },
+        { QString(kAx25RxTopic),      QStringLiteral("AX.25 received frames"),       true },
+    };
+    return defs;
+}
+
+// ── Per-topic enable / disable (AppSettings, keyed by sanitized topic name) ──
+
+static QString topicEnabledKey(const QString& topic)
+{
+    QString key = topic;
+    key.replace(QLatin1Char('/'), QLatin1Char('_'));
+    key.replace(QLatin1Char('+'), QLatin1Char('x'));
+    return QStringLiteral("mqtt_internal_") + key;
+}
+
+bool isMqttTopicEnabled(const QString& topic)
+{
+    for (const auto& def : internalMqttSubscribeTopicDefs()) {
+        if (def.topic == topic)
+            return !def.gateable || AppSettings::instance()
+                .value(topicEnabledKey(topic), false).toBool();
+    }
+    for (const auto& def : internalMqttPublishTopicDefs()) {
+        if (def.topic == topic)
+            return !def.gateable || AppSettings::instance()
+                .value(topicEnabledKey(topic), false).toBool();
+    }
+    return false;
+}
+
+void setMqttTopicEnabled(const QString& topic, bool enabled)
+{
+    AppSettings::instance().setValue(topicEnabledKey(topic), enabled);
+    AppSettings::instance().save();
+}
+
 QStringList internalMqttSubscriptionTopics()
 {
-    return {
-        mqttAntennaAliasTopicPrefix() + QStringLiteral("+"),
-        mqttAntennaAliasBulkTopic(),
-    };
+    QStringList topics;
+    for (const auto& def : internalMqttSubscribeTopicDefs()) {
+        if (isMqttTopicEnabled(def.topic))
+            topics.append(def.topic);
+    }
+    return topics;
 }
 
 QStringList internalMqttPublishTopics()
 {
-    return { QString(kCwDecodeTopic) };
+    QStringList topics;
+    for (const auto& def : internalMqttPublishTopicDefs()) {
+        if (isMqttTopicEnabled(def.topic))
+            topics.append(def.topic);
+    }
+    return topics;
 }
 
 QStringList mqttSubscriptionTopics(const QStringList& userTopics)

--- a/src/core/MqttSettings.h
+++ b/src/core/MqttSettings.h
@@ -44,7 +44,26 @@ QStringList mqttUserSubscriptionTopics(const QVector<MqttTopicDef>& topics);
 QStringList internalMqttSubscriptionTopics();
 QStringList mqttSubscriptionTopics(const QStringList& userTopics);
 
-inline constexpr QLatin1String kCwDecodeTopic{"aethersdr/cw/decode"};
+inline constexpr QLatin1String kCwDecodeTopic   {"aethersdr/cw/decode"};
+inline constexpr QLatin1String kCwTransmitTopic {"aethersdr/cw/transmit"};
+inline constexpr QLatin1String kRadioStateTopic {"aethersdr/radio/state"};
+inline constexpr QLatin1String kAx25RxTopic     {"aethersdr/ax25/rx"};
+inline constexpr QLatin1String kAx25TxTopic     {"aethersdr/ax25/tx"};
+
+// Describes one internal MQTT topic for display in the settings dialog and
+// for driving the subscription/publish lists.  Topics with gateable=false
+// (antenna alias) are always active and shown grayed-out in the dialog.
+struct InternalMqttTopicDef {
+    QString topic;
+    QString description;
+    bool    gateable{true};  // false = always on, not user-disableable
+};
+
+const QVector<InternalMqttTopicDef>& internalMqttSubscribeTopicDefs();
+const QVector<InternalMqttTopicDef>& internalMqttPublishTopicDefs();
+
+bool isMqttTopicEnabled(const QString& topic);
+void setMqttTopicEnabled(const QString& topic, bool enabled);
 
 QStringList internalMqttPublishTopics();
 QStringList mqttSubscriptionTopics(const QVector<MqttTopicDef>& userTopics);

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -6,6 +6,11 @@
 #include "bitstream.h"
 #include "demodulator.h"
 
+#include "core/tnc/HdlcCodec.h"
+
+#include "AetherAFSKDemod.h"
+#include "AetherFMDiscrimDemod.h"
+
 #include <QDateTime>
 
 #include <algorithm>
@@ -19,6 +24,52 @@
 namespace AetherSDR {
 
 namespace lm = aether_libmodem_core;
+
+// Abstract demodulator interface — allows VHF (Direwolf-derived) and HF
+// (libmodem) demod types to coexist in the same lane vector.
+struct IAfskDemod {
+    virtual ~IAfskDemod() = default;
+    virtual bool try_demodulate(float sample, uint8_t& bit, double& confidence) noexcept = 0;
+    virtual void reset() noexcept = 0;
+};
+
+struct LibmodemAfskDemod : IAfskDemod {
+    lm::sinc_corr_afsk_demodulator inner;
+    template<typename... Args>
+    explicit LibmodemAfskDemod(Args&&... args) : inner(std::forward<Args>(args)...) {}
+    bool try_demodulate(float sample, uint8_t& bit, double& confidence) noexcept override {
+        lm::demod_result r;
+        if (!inner.try_demodulate(sample, r)) return false;
+        bit = r.bit; confidence = r.confidence; return true;
+    }
+    void reset() noexcept override { inner.reset(); }
+};
+
+struct DirewolfAfskDemod : IAfskDemod {
+    AetherDemod::AetherAFSKDemod inner;
+    template<typename... Args>
+    explicit DirewolfAfskDemod(Args&&... args) : inner(std::forward<Args>(args)...)
+    {}
+    bool try_demodulate(float sample, uint8_t& bit, double& confidence) noexcept override {
+        AetherDemod::demod_result r;
+        if (!inner.try_demodulate(sample, r)) return false;
+        bit = r.bit; confidence = r.confidence; return true;
+    }
+    void reset() noexcept override { inner.reset(); }
+};
+
+struct DirewolfFMDiscrimDemod : IAfskDemod {
+    AetherDemod::AetherFMDiscrimDemod inner;
+    template<typename... Args>
+    explicit DirewolfFMDiscrimDemod(Args&&... args) : inner(std::forward<Args>(args)...)
+    {}
+    bool try_demodulate(float sample, uint8_t& bit, double& confidence) noexcept override {
+        AetherDemod::demod_result r;
+        if (!inner.try_demodulate(sample, r)) return false;
+        bit = r.bit; confidence = r.confidence; return true;
+    }
+    void reset() noexcept override { inner.reset(); }
+};
 
 namespace {
 
@@ -55,25 +106,30 @@ constexpr std::array<int, 21> kHf300DecodePhaseOffsets = {
     43, 47, 51, 55, 59, 63, 67, 71, 75, 79
 };
 
-// 1200 baud VHF (Bell 202 / APRS): an aggressive bank of independent correlator
-// demodulators, combining two complementary strategies so the widest range of
-// bursts is captured. Duplicate suppression collapses the same frame seen by
-// several lanes into one emission, like a multi-decoder TNC (e.g. Dire Wolf).
+// 1200 baud VHF (Bell 202 / APRS): optional phase diversity spreads lanes across
+// the symbol period so at least one lands near the eye centre regardless of
+// clock offset. 10 free-running phases + 4 tracked phases × 2 PLL alphas = 18
+// phase offsets per slicer. With phase diversity off, one lane per slicer is
+// used (Direwolf-equivalent structure).
 //
-//   * Free-running lanes (PLL alpha 0) spread evenly across the symbol period.
-//     With no timing loop they sample at a fixed phase, so on a clean burst at
-//     least one lane lands on the eye center and decodes immediately — the same
-//     proven mechanism as the HF bank. Best for short / strong / clean packets.
-//   * Gardner-tracked lanes (PLL alpha > 0) actively chase the symbol clock, so
-//     they tolerate TX/RX clock drift and fading over longer or weaker bursts
-//     where a fixed-phase lane would slip off the eye. A tight and a loose loop
-//     bandwidth bracket clean-vs-fast-acquisition trade-offs.
-//
-// Total lanes = kVhf1200FreeRunPhaseCount
-//             + kVhf1200TrackedPhaseCount * kVhf1200PllAlphas.size().
-constexpr int kVhf1200FreeRunPhaseCount = 10;
-constexpr int kVhf1200TrackedPhaseCount = 4;
-constexpr std::array<double, 2> kVhf1200PllAlphas = { 0.010, 0.025 };
+// Duplicate suppression collapses the same frame seen by multiple lanes into
+// one emission, like Direwolf's multi_modem.c.
+constexpr double kVhf1200PllAlpha = 0.010;
+
+// Profile A+ space-gain multipliers — exact Direwolf A+ values (MAX_SUBCHANS=9).
+// Geometric series: MIN_G=0.5, MAX_G=4.0, 9 steps.
+// Formula: gain[0]=MIN_G, gain[j]=gain[j-1]*pow(10, log10(MAX_G/MIN_G)/(N-1)).
+constexpr std::array<float, 9> kVhf1200SpaceGains = {
+    0.500000f, 0.648420f, 0.840896f, 1.090508f, 1.414214f,
+    1.834008f, 2.378414f, 3.084422f, 4.000000f
+};
+
+// Profile B+ additive slice offsets — exact Direwolf B+ values (MAX_SLICERS=9).
+// Linear series: -0.5 + s*(1/(N-1)) for s in 0..8.
+constexpr std::array<float, 9> kVhf1200BSliceOffsets = {
+    -0.500f, -0.375f, -0.250f, -0.125f, 0.000f,
+     0.125f,  0.250f,  0.375f, 0.500f
+};
 
 QString fcsToString(const std::array<uint8_t, 2>& fcs)
 {
@@ -88,6 +144,13 @@ QString framePreviewHex(const std::array<uint8_t, N>& bytes, size_t byteCount)
 {
     const qsizetype previewBytes = static_cast<qsizetype>(std::min<size_t>(byteCount, 24));
     QByteArray preview(reinterpret_cast<const char*>(bytes.data()), previewBytes);
+    return QString::fromLatin1(preview.toHex(' ')).toUpper();
+}
+
+QString framePreviewHex(const uint8_t* bytes, size_t byteCount)
+{
+    const qsizetype previewBytes = static_cast<qsizetype>(std::min<size_t>(byteCount, 24));
+    QByteArray preview(reinterpret_cast<const char*>(bytes), previewBytes);
     return QString::fromLatin1(preview.toHex(' ')).toUpper();
 }
 
@@ -384,10 +447,8 @@ struct AetherAx25LibmodemShim::Impl {
     struct DecodeLane {
         int phaseOffsetSamples{0};
         int samplesUntilStart{0};
-        std::unique_ptr<lm::sinc_corr_afsk_demodulator> demod;
-        lm::ax25::bitstream_state bitstreamState;
-        std::vector<uint8_t> bitstreamBuffer;
-        std::array<uint8_t, 1000> candidateFrameBytes{};
+        std::unique_ptr<IAfskDemod> demod;
+        HdlcCodec hdlcCodec;
         double lastQuality{0.0};
     };
     struct RecentFrame {
@@ -497,51 +558,62 @@ struct AetherAx25LibmodemShim::Impl {
             ? config.markHz
             : config.spaceHz;
 
-        auto addLane = [&](int phaseOffsetSamples, double pllAlpha) {
+        auto addLaneA = [&](int phaseOffsetSamples, double pllAlpha, float spaceGain = 0.0f) {
             auto& lane = lanes.emplace_back();
             lane.phaseOffsetSamples = phaseOffsetSamples;
-            lane.samplesUntilStart = phaseOffsetSamples;
-            lane.demod = std::make_unique<lm::sinc_corr_afsk_demodulator>(
-                mark,
-                space,
-                config.baud,
-                config.sampleRate,
-                0.75,
-                6.0,
-                0.75,
-                3.0,
-                0.008,
-                0.005,
-                pllAlpha);
-            lane.bitstreamBuffer.reserve(8192);
-            lane.bitstreamBuffer.resize(8192);
+            lane.samplesUntilStart  = phaseOffsetSamples;
+            lane.demod = std::make_unique<DirewolfAfskDemod>(
+                mark, space, config.baud, config.sampleRate,
+                0.75, 6.0, 0.75, 3.0, 0.008, 0.005, pllAlpha, spaceGain);
+        };
+
+        auto addLaneB = [&](int phaseOffsetSamples, double pllAlpha, float sliceOffset = 0.0f) {
+            auto& lane = lanes.emplace_back();
+            lane.phaseOffsetSamples = phaseOffsetSamples;
+            lane.samplesUntilStart  = phaseOffsetSamples;
+            lane.demod = std::make_unique<DirewolfFMDiscrimDemod>(
+                mark, space, config.baud, config.sampleRate, sliceOffset);
+            (void)pllAlpha; // B's DPLL is internal; pllAlpha unused for now
+        };
+
+        auto addLaneHf = [&](int phaseOffsetSamples, double pllAlpha) {
+            auto& lane = lanes.emplace_back();
+            lane.phaseOffsetSamples = phaseOffsetSamples;
+            lane.samplesUntilStart  = phaseOffsetSamples;
+            lane.demod = std::make_unique<LibmodemAfskDemod>(
+                mark, space, config.baud, config.sampleRate,
+                0.75, 6.0, 0.75, 3.0, 0.008, 0.005, pllAlpha);
         };
 
         if (config.profile == Ax25ModemProfile::Hf300) {
             // HF: free-running lanes (pll_alpha 0), recovery by phase diversity.
             for (int phaseOffset : kHf300DecodePhaseOffsets)
-                addLane(phaseOffset, 0.0);
+                addLaneHf(phaseOffset, 0.0);
         } else {
-            // VHF 1200: hybrid bank. Phase offsets are derived from the symbol
-            // period so the spread stays correct if the sample rate ever changes.
+            // VHF 1200: one DPLL lane per slicer for each enabled algorithm.
             const int samplesPerSymbol = config.baud > 0
                 ? config.sampleRate / config.baud
                 : 0;
-            if (samplesPerSymbol <= 0) {
-                addLane(0, 0.0);
-            } else {
-                // Free-running phase-diversity lanes — decode clean/short bursts.
-                for (int phase = 0; phase < kVhf1200FreeRunPhaseCount; ++phase) {
-                    const int phaseOffset = (samplesPerSymbol * phase) / kVhf1200FreeRunPhaseCount;
-                    addLane(phaseOffset, 0.0);
-                }
-                // Gardner-tracked lanes — follow clock drift on long/weak bursts.
-                for (int phase = 0; phase < kVhf1200TrackedPhaseCount; ++phase) {
-                    const int phaseOffset = (samplesPerSymbol * phase) / kVhf1200TrackedPhaseCount;
-                    for (double laneAlpha : kVhf1200PllAlphas)
-                        addLane(phaseOffset, laneAlpha);
-                }
+
+            bool wantA = false, wantB = false, aMulti = false, bMulti = false;
+            switch (config.vhfMode) {
+            case VhfMode::Off:                                             break;
+            case VhfMode::A:      wantA = true;                           break;
+            case VhfMode::B:                       wantB = true;          break;
+            case VhfMode::AB:     wantA = true;    wantB = true;          break;
+            case VhfMode::APlus:  wantA = true;               aMulti=true; break;
+            case VhfMode::BPlus:               wantB = true;  bMulti=true; break;
+            case VhfMode::ABPlus: wantA = true; wantB = true; aMulti=true; bMulti=true; break;
             }
+            const int aSlicers = aMulti ? static_cast<int>(kVhf1200SpaceGains.size())    : 1;
+            const int bSlicers = bMulti ? static_cast<int>(kVhf1200BSliceOffsets.size()) : 1;
+
+            if (wantA)
+                for (int s = 0; s < aSlicers; ++s)
+                    addLaneA(0, kVhf1200PllAlpha, aMulti ? kVhf1200SpaceGains[s] : 0.0f);
+            if (wantB)
+                for (int s = 0; s < bSlicers; ++s)
+                    addLaneB(0, kVhf1200PllAlpha, bMulti ? kVhf1200BSliceOffsets[s] : 0.0f);
         }
         resetDecoderState(true, true);
 
@@ -603,10 +675,7 @@ struct AetherAx25LibmodemShim::Impl {
 
     void resetLaneBitstream(DecodeLane& lane)
     {
-        lane.bitstreamState.reset();
-        lane.bitstreamState.max_frame_bits = 4096;
-        lane.bitstreamBuffer.clear();
-        lane.bitstreamBuffer.resize(8192);
+        lane.hdlcCodec.reset();
     }
 
     void resetBitstreamStates()
@@ -655,12 +724,11 @@ struct AetherAx25LibmodemShim::Impl {
                 receiveGateOpen = true;
                 receiveGateIdleSamples = 0;
                 ++receiveGateResets;
-                resetBitstreamStates();
                 if (diagnosticsLoggingEnabled) {
                     qCDebug(lcAx25).nospace()
                         << "receive gate opened: rms="
                         << QString::number(receiveGateRmsDbfs, 'f', 1) << "dBFS floor="
-                        << QString::number(receiveGateFloorDbfs, 'f', 1) << "dBFS resets="
+                        << QString::number(receiveGateFloorDbfs, 'f', 1) << "dBFS opens="
                         << receiveGateResets;
                 }
                 return;
@@ -696,7 +764,7 @@ struct AetherAx25LibmodemShim::Impl {
         }
     }
 
-    bool candidateHasAx25Structure(const DecodeLane& lane,
+    bool candidateHasAx25Structure(const uint8_t* frameBytes,
                                    size_t frameBytesSize,
                                    uint8_t& control,
                                    uint8_t& pid,
@@ -714,8 +782,8 @@ struct AetherAx25LibmodemShim::Impl {
         pid = 0;
 
         auto [pathOut, dataOut, parsed] = lm::ax25::try_decode_frame_no_fcs(
-            lane.candidateFrameBytes.data(),
-            lane.candidateFrameBytes.data() + frameBytesSize - 2,
+            frameBytes,
+            frameBytes + frameBytesSize - 2,
             from,
             to,
             path.begin(),
@@ -749,11 +817,11 @@ struct AetherAx25LibmodemShim::Impl {
                       const std::array<uint8_t, 2>& expectedFcs)
     {
         ++totalDecodeRejected;
-        lastRejectFrameBits = static_cast<int>(lane.bitstreamState.frame_size_bits);
+        lastRejectFrameBits = lane.hdlcCodec.frameSizeBits();
         lastRejectFrameBytes = static_cast<int>(frameBytesSize);
-        lastRejectPreviewHex = framePreviewHex(lane.candidateFrameBytes, frameBytesSize);
-        lastRejectActualFcs = frameBytesSize >= 17 ? fcsToString(actualFcs) : QString();
-        lastRejectExpectedFcs = frameBytesSize >= 17 ? fcsToString(expectedFcs) : QString();
+        lastRejectPreviewHex = framePreviewHex(lane.hdlcCodec.frameData(), frameBytesSize);
+        lastRejectActualFcs = frameBytesSize >= 18 ? fcsToString(actualFcs) : QString();
+        lastRejectExpectedFcs = frameBytesSize >= 18 ? fcsToString(expectedFcs) : QString();
 
         // Minimum valid AX.25 frame is 17 bytes (14 address + 1 control + 2 FCS);
         // a no-PID U-frame (SABM/DISC/UA/DM) sits exactly at 17. Anything shorter
@@ -768,7 +836,7 @@ struct AetherAx25LibmodemShim::Impl {
         uint8_t pid = 0;
         size_t pathCount = 0;
         size_t dataLength = 0;
-        const bool ax25Like = candidateHasAx25Structure(lane, frameBytesSize, control, pid, pathCount, dataLength);
+        const bool ax25Like = candidateHasAx25Structure(lane.hdlcCodec.frameData(), frameBytesSize, control, pid, pathCount, dataLength);
 
         if (actualFcs != expectedFcs) {
             if (ax25Like) {
@@ -795,47 +863,62 @@ struct AetherAx25LibmodemShim::Impl {
     std::optional<Ax25DecodedFrame> processBit(DecodeLane& lane, uint8_t bit, double quality)
     {
         lane.lastQuality = 0.95 * lane.lastQuality + 0.05 * quality;
-        const bool wasComplete = lane.bitstreamState.complete;
-        const bool wasInFrame = lane.bitstreamState.in_frame;
+        const bool wasInFrame = lane.hdlcCodec.inFrame();
+
+        const bool frameComplete = lane.hdlcCodec.processBit(bit ? 1 : 0);
+
+        if (lane.hdlcCodec.inFrame() && !wasInFrame)
+            ++totalHdlcFrameStarts;
+
+        if (!frameComplete)
+            return std::nullopt;
+
+        ++totalHdlcFrameCandidates;
+
+        const size_t frameSize    = lane.hdlcCodec.frameSize();
+        const uint8_t* frameBytes = lane.hdlcCodec.frameData();
+        const auto actualFcs      = lane.hdlcCodec.actualFcs();
+        const auto expectedFcs    = lane.hdlcCodec.expectedFcs();
+
+        if (!lane.hdlcCodec.fcsValid()) {
+            if (recordReject(lane, frameSize, actualFcs, expectedFcs))
+                ++totalPlausibleAx25Candidates;
+            return std::nullopt;
+        }
+
         lm::address from;
         lm::address to;
         std::array<lm::address, 8> path = {};
         std::array<uint8_t, 256> data = {};
         uint8_t control = 0;
         uint8_t pid = 0;
-        std::array<uint8_t, 2> actualFcs = {};
-        std::array<uint8_t, 2> expectedFcs = {};
 
-        auto [candidateFrameBytesSize, pathOut, dataOut, decoded] = lm::ax25::try_decode_bitstream(
-            bit ? 1 : 0,
-            lane.bitstreamState,
-            lane.bitstreamBuffer.begin(),
-            lane.bitstreamBuffer.end(),
-            lane.candidateFrameBytes,
+        auto [pathOut, dataOut, parsed] = lm::ax25::try_decode_frame_no_fcs(
+            frameBytes,
+            frameBytes + frameSize - 2,
             from,
             to,
             path.begin(),
             data.begin(),
             data.size(),
             control,
-            pid,
-            actualFcs,
-            expectedFcs);
+            pid);
 
-        if (lane.bitstreamState.in_frame && !wasInFrame)
-            ++totalHdlcFrameStarts;
+        const std::array<uint8_t, 2> acceptedFcs = { 0, 0 };
+        const bool ax25Valid = parsed && lm::ax25::validate_frame(
+            from, to,
+            path.begin(), pathOut,
+            data.begin(), dataOut,
+            control, pid,
+            acceptedFcs, acceptedFcs);
 
-        if (lane.bitstreamState.complete && !wasComplete) {
-            ++totalHdlcFrameCandidates;
-            if (decoded) {
+        if (!ax25Valid) {
+            if (recordReject(lane, frameSize, actualFcs, expectedFcs))
                 ++totalPlausibleAx25Candidates;
-            } else {
-                if (recordReject(lane, candidateFrameBytesSize, actualFcs, expectedFcs))
-                    ++totalPlausibleAx25Candidates;
-            }
-        }
-        if (!decoded)
             return std::nullopt;
+        }
+
+        ++totalPlausibleAx25Candidates;
 
         lm::ax25::frame frame;
         frame.from = from;
@@ -847,14 +930,12 @@ struct AetherAx25LibmodemShim::Impl {
         frame.control[0] = control;
         frame.pid = pid;
         frame.crc = actualFcs;
-        Ax25DecodedFrame decodedFrame =
-            toDecodedFrame(frame, lane.lastQuality, lane.phaseOffsetSamples);
-        // Capture the exact on-air frame bytes minus the trailing 2-byte FCS so
-        // the KISS TNC can forward the decode to host apps verbatim.
-        if (candidateFrameBytesSize >= 2) {
+        Ax25DecodedFrame decodedFrame = toDecodedFrame(frame, lane.lastQuality, lane.phaseOffsetSamples);
+        // Capture on-air frame bytes minus 2-byte FCS for KISS TNC forwarding.
+        if (frameSize >= 2) {
             decodedFrame.ax25FrameNoFcs = QByteArray(
-                reinterpret_cast<const char*>(lane.candidateFrameBytes.data()),
-                static_cast<qsizetype>(candidateFrameBytesSize - 2));
+                reinterpret_cast<const char*>(frameBytes),
+                static_cast<qsizetype>(frameSize - 2));
         }
         return decodedFrame;
     }
@@ -903,11 +984,11 @@ struct AetherAx25LibmodemShim::Impl {
         ++diagnosticsWindow.audioSamples;
     }
 
-    void recordDemodSymbol(const lm::demod_result& result)
+    void recordDemodSymbol(uint8_t bit, double confidence)
     {
         ++diagnosticsWindow.demodSymbols;
-        diagnosticsWindow.oneBits += result.bit ? 1 : 0;
-        diagnosticsWindow.confidenceSum += result.confidence;
+        diagnosticsWindow.oneBits += bit ? 1 : 0;
+        diagnosticsWindow.confidenceSum += confidence;
     }
 
     Ax25DecoderDiagnostics makeDiagnostics(int sampleRate) const
@@ -954,16 +1035,16 @@ struct AetherAx25LibmodemShim::Impl {
         diagnostics.lastFrameBits = 0;
         diagnostics.preambleFlags = 0;
         for (const auto& lane : lanes) {
-            diagnostics.searching = diagnostics.searching && lane.bitstreamState.searching;
-            diagnostics.inPreamble = diagnostics.inPreamble || lane.bitstreamState.in_preamble;
-            diagnostics.inFrame = diagnostics.inFrame || lane.bitstreamState.in_frame;
-            diagnostics.aborted = diagnostics.aborted || lane.bitstreamState.aborted;
+            diagnostics.searching = diagnostics.searching && lane.hdlcCodec.searching();
+            diagnostics.inPreamble = diagnostics.inPreamble || lane.hdlcCodec.inPreamble();
+            diagnostics.inFrame = diagnostics.inFrame || lane.hdlcCodec.inFrame();
+            diagnostics.aborted = diagnostics.aborted || lane.hdlcCodec.aborted();
             diagnostics.currentFrameBits = std::max(diagnostics.currentFrameBits,
-                                                    static_cast<int>(lane.bitstreamState.bitstream_size));
+                                                    lane.hdlcCodec.bitstreamSize());
             diagnostics.lastFrameBits = std::max(diagnostics.lastFrameBits,
-                                                 static_cast<int>(lane.bitstreamState.frame_size_bits));
+                                                 lane.hdlcCodec.frameSizeBits());
             diagnostics.preambleFlags = std::max(diagnostics.preambleFlags,
-                                                 static_cast<int>(lane.bitstreamState.preamble_count));
+                                                 lane.hdlcCodec.preambleCount());
         }
         diagnostics.hdlcFrameStarts = totalHdlcFrameStarts;
         diagnostics.hdlcFrameCandidates = totalHdlcFrameCandidates;
@@ -1061,12 +1142,13 @@ QVector<Ax25DecodedFrame> AetherAx25LibmodemShim::processMonoFloat(const float* 
                 continue;
             }
 
-            lm::demod_result result;
-            if (!lane.demod || !lane.demod->try_demodulate(sample, result))
+            uint8_t bit = 0;
+            double confidence = 0.0;
+            if (!lane.demod || !lane.demod->try_demodulate(sample, bit, confidence))
                 continue;
             if (laneIndex == 0)
-                m_impl->recordDemodSymbol(result);
-            if (auto decoded = m_impl->processBit(lane, result.bit, result.confidence);
+                m_impl->recordDemodSymbol(bit, confidence);
+            if (auto decoded = m_impl->processBit(lane, bit, confidence);
                 decoded && m_impl->shouldEmitFrame(*decoded)) {
                 frames.append(*decoded);
             }
@@ -1094,15 +1176,31 @@ QVector<Ax25DecodedFrame> AetherAx25LibmodemShim::processRecoveredBitsForTest(
     return frames;
 }
 
-Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
+Ax25TransmitResult ax25BuildTransmitAudio(
+    const Ax25DemodConfig& cfg,
     const QString& text,
     const QString& defaultSource,
-    const QString& defaultDestination) const
+    const QString& defaultDestination)
 {
     Ax25TransmitResult result;
-    const auto cfg = m_impl->config;
-    if (!initTxResult(cfg, result))
+    result.sampleRate = cfg.sampleRate;
+    result.baud = cfg.baud;
+    result.polarity = cfg.polarity;
+    result.markHz = cfg.markHz;
+    result.spaceHz = cfg.spaceHz;
+    const int preambleFlags = cfg.profile == Ax25ModemProfile::Vhf1200
+        ? kVhf1200TxPreambleFlags
+        : kTxPreambleFlags;
+    result.preambleFlags = preambleFlags;
+    result.postambleFlags = kTxPostambleFlags;
+    result.vitaPacketFrames = kTxVitaPacketFrames;
+
+    if (cfg.sampleRate <= 0 || cfg.baud <= 0 || cfg.sampleRate % cfg.baud != 0) {
+        result.error = QStringLiteral("unsupported TX sample-rate/baud combination: %1 Hz / %2 baud")
+            .arg(cfg.sampleRate)
+            .arg(cfg.baud);
         return result;
+    }
 
     QString error;
     const std::optional<lm::packet> maybePacket =
@@ -1163,14 +1261,43 @@ Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudioFromFrame(
     return result;
 }
 
+Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
+    const QString& text,
+    const QString& defaultSource,
+    const QString& defaultDestination) const
+{
+    return ax25BuildTransmitAudio(m_impl->config, text, defaultSource, defaultDestination);
+}
+
 Ax25DecoderDiagnostics AetherAx25LibmodemShim::diagnosticsSnapshot() const
 {
     return m_impl->makeDiagnostics(m_impl->config.sampleRate);
 }
 
-QString AetherAx25LibmodemShim::demodDescription() const
+int ax25DemodLaneCount(const Ax25DemodConfig& cfg)
 {
-    const auto cfg = m_impl->config;
+    if (cfg.profile == Ax25ModemProfile::Hf300)
+        return static_cast<int>(kHf300DecodePhaseOffsets.size());
+
+    bool wantA = false, wantB = false, aMulti = false, bMulti = false;
+    switch (cfg.vhfMode) {
+    case VhfMode::Off:                                              break;
+    case VhfMode::A:      wantA = true;                            break;
+    case VhfMode::B:                       wantB = true;           break;
+    case VhfMode::AB:     wantA = true;    wantB = true;           break;
+    case VhfMode::APlus:  wantA = true;               aMulti=true; break;
+    case VhfMode::BPlus:               wantB = true;  bMulti=true; break;
+    case VhfMode::ABPlus: wantA = true; wantB = true; aMulti=true; bMulti=true; break;
+    }
+    const int aSlicers = aMulti ? static_cast<int>(kVhf1200SpaceGains.size())    : 1;
+    const int bSlicers = bMulti ? static_cast<int>(kVhf1200BSliceOffsets.size()) : 1;
+    const int slicerLanes = (wantA ? aSlicers : 0) + (wantB ? bSlicers : 0);
+    return slicerLanes;
+}
+
+QString ax25DemodDescription(const Ax25DemodConfig& cfg)
+{
+    const int lanes = ax25DemodLaneCount(cfg);
     return QStringLiteral("%1: %2 Hz, %3 bps, mark %4 Hz, space %5 Hz, %6, %7 lane%8")
         .arg(ax25ModemProfileName(cfg.profile))
         .arg(cfg.sampleRate)
@@ -1180,8 +1307,13 @@ QString AetherAx25LibmodemShim::demodDescription() const
         .arg(cfg.polarity == Ax25TonePolarity::Normal
              ? QStringLiteral("Normal")
              : QStringLiteral("Inverted"))
-        .arg(m_impl->lanes.size())
-        .arg(m_impl->lanes.size() == 1 ? QString() : QStringLiteral("s"));
+        .arg(lanes)
+        .arg(lanes == 1 ? QString() : QStringLiteral("s"));
+}
+
+QString AetherAx25LibmodemShim::demodDescription() const
+{
+    return ax25DemodDescription(m_impl->config);
 }
 
 void AetherAx25LibmodemShim::feedAudio(const QByteArray& monoFloat32Pcm, int sampleRate)

--- a/src/core/tnc/AetherAx25LibmodemShim.h
+++ b/src/core/tnc/AetherAx25LibmodemShim.h
@@ -17,6 +17,18 @@ enum class Ax25TonePolarity {
     Inverted,
 };
 
+// VHF 1200 baud demodulator mode. Matches Direwolf's MODEM line options.
+// Ordered by compute cost: Off < A ≈ B < AB < A+ ≈ B+ < AB+
+enum class VhfMode {
+    Off,    // VHF demodulation disabled
+    A,      // IQ-mix · 1 slicer
+    B,      // FM discriminator · 1 slicer
+    AB,     // IQ-mix + FM discriminator · 1 slicer each
+    APlus,  // IQ-mix · 9 slicers (Direwolf default)
+    BPlus,  // FM discriminator · 9 slicers
+    ABPlus, // IQ-mix + FM discriminator · 9 slicers each
+};
+
 struct Ax25DemodConfig {
     Ax25ModemProfile profile{Ax25ModemProfile::Hf300};
     int sampleRate{24000};
@@ -24,6 +36,7 @@ struct Ax25DemodConfig {
     double markHz{1600.0};
     double spaceHz{1800.0};
     Ax25TonePolarity polarity{Ax25TonePolarity::Normal};
+    VhfMode vhfMode{VhfMode::APlus}; // VHF 1200 only; default A+ (Direwolf default)
 };
 
 struct Ax25DecoderDiagnostics {
@@ -104,6 +117,12 @@ Ax25DemodConfig ax25DemodConfigForProfile(
     Ax25ModemProfile profile,
     Ax25TonePolarity polarity = Ax25TonePolarity::Normal);
 QString ax25ModemProfileName(Ax25ModemProfile profile);
+int ax25DemodLaneCount(const Ax25DemodConfig& cfg);
+QString ax25DemodDescription(const Ax25DemodConfig& cfg);
+Ax25TransmitResult ax25BuildTransmitAudio(const Ax25DemodConfig& cfg,
+                                          const QString& text,
+                                          const QString& defaultSource,
+                                          const QString& defaultDestination = QStringLiteral("APRS"));
 
 class AetherAx25LibmodemShim : public QObject {
     Q_OBJECT

--- a/src/core/tnc/HdlcCodec.cpp
+++ b/src/core/tnc/HdlcCodec.cpp
@@ -1,0 +1,226 @@
+#include "HdlcCodec.h"
+
+namespace AetherSDR {
+
+// CRC-16-CCITT lookup table, polynomial 0x8408 (bit-reversed 0x1021).
+// init=0xFFFF, final XOR=0xFFFF — identical to Direwolf fcs_calc.c and
+// libmodem compute_crc_using_lut.  Verified against both implementations.
+static constexpr uint16_t kCrcTable[256] = {
+    0x0000, 0x1189, 0x2312, 0x329B, 0x4624, 0x57AD, 0x6536, 0x74BF,
+    0x8C48, 0x9DC1, 0xAF5A, 0xBED3, 0xCA6C, 0xDBE5, 0xE97E, 0xF8F7,
+    0x1081, 0x0108, 0x3393, 0x221A, 0x56A5, 0x472C, 0x75B7, 0x643E,
+    0x9CC9, 0x8D40, 0xBFDB, 0xAE52, 0xDAED, 0xCB64, 0xF9FF, 0xE876,
+    0x2102, 0x308B, 0x0210, 0x1399, 0x6726, 0x76AF, 0x4434, 0x55BD,
+    0xAD4A, 0xBCC3, 0x8E58, 0x9FD1, 0xEB6E, 0xFAE7, 0xC87C, 0xD9F5,
+    0x3183, 0x200A, 0x1291, 0x0318, 0x77A7, 0x662E, 0x54B5, 0x453C,
+    0xBDCB, 0xAC42, 0x9ED9, 0x8F50, 0xFBEF, 0xEA66, 0xD8FD, 0xC974,
+    0x4204, 0x538D, 0x6116, 0x709F, 0x0420, 0x15A9, 0x2732, 0x36BB,
+    0xCE4C, 0xDFC5, 0xED5E, 0xFCD7, 0x8868, 0x99E1, 0xAB7A, 0xBAF3,
+    0x5285, 0x430C, 0x7197, 0x601E, 0x14A1, 0x0528, 0x37B3, 0x263A,
+    0xDECD, 0xCF44, 0xFDDF, 0xEC56, 0x98E9, 0x8960, 0xBBFB, 0xAA72,
+    0x6306, 0x728F, 0x4014, 0x519D, 0x2522, 0x34AB, 0x0630, 0x17B9,
+    0xEF4E, 0xFEC7, 0xCC5C, 0xDDD5, 0xA96A, 0xB8E3, 0x8A78, 0x9BF1,
+    0x7387, 0x620E, 0x5095, 0x411C, 0x35A3, 0x242A, 0x16B1, 0x0738,
+    0xFFCF, 0xEE46, 0xDCDD, 0xCD54, 0xB9EB, 0xA862, 0x9AF9, 0x8B70,
+    0x8408, 0x9581, 0xA71A, 0xB693, 0xC22C, 0xD3A5, 0xE13E, 0xF0B7,
+    0x0840, 0x19C9, 0x2B52, 0x3ADB, 0x4E64, 0x5FED, 0x6D76, 0x7CFF,
+    0x9489, 0x8500, 0xB79B, 0xA612, 0xD2AD, 0xC324, 0xF1BF, 0xE036,
+    0x18C1, 0x0948, 0x3BD3, 0x2A5A, 0x5EE5, 0x4F6C, 0x7DF7, 0x6C7E,
+    0xA50A, 0xB483, 0x8618, 0x9791, 0xE32E, 0xF2A7, 0xC03C, 0xD1B5,
+    0x2942, 0x38CB, 0x0A50, 0x1BD9, 0x6F66, 0x7EEF, 0x4C74, 0x5DFD,
+    0xB58B, 0xA402, 0x9699, 0x8710, 0xF3AF, 0xE226, 0xD0BD, 0xC134,
+    0x39C3, 0x284A, 0x1AD1, 0x0B58, 0x7FE7, 0x6E6E, 0x5CF5, 0x4D7C,
+    0xC60C, 0xD785, 0xE51E, 0xF497, 0x8028, 0x91A1, 0xA33A, 0xB2B3,
+    0x4A44, 0x5BCD, 0x6956, 0x78DF, 0x0C60, 0x1DE9, 0x2F72, 0x3EFB,
+    0xD68D, 0xC704, 0xF59F, 0xE416, 0x90A9, 0x8120, 0xB3BB, 0xA232,
+    0x5AC5, 0x4B4C, 0x79D7, 0x685E, 0x1CE1, 0x0D68, 0x3FF3, 0x2E7A,
+    0xE70E, 0xF687, 0xC41C, 0xD595, 0xA12A, 0xB0A3, 0x8238, 0x93B1,
+    0x6B46, 0x7ACF, 0x4854, 0x59DD, 0x2D62, 0x3CEB, 0x0E70, 0x1FF9,
+    0xF78F, 0xE606, 0xD49D, 0xC514, 0xB1AB, 0xA022, 0x92B9, 0x8330,
+    0x7BC7, 0x6A4E, 0x58D5, 0x495C, 0x3DE3, 0x2C6A, 0x1EF1, 0x0F78,
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+
+void HdlcCodec::reset()
+{
+    m_state = State::Searching;
+    m_complete = false;
+    m_aborted  = false;
+    m_fcsValid = false;
+    m_prevNrzi = 0;
+    m_patDet   = 0;
+    m_currentByte = 0;
+    m_bitIndex    = 0;
+    m_frameByteCount = 0;
+    m_frameSizeBits  = 0;
+    m_preambleCount  = 0;
+    m_rawBitsInFrame = 0;
+    m_bitsAfterFlag  = 0;
+    m_actualFcs   = {};
+    m_expectedFcs = {};
+}
+
+int HdlcCodec::bitstreamSize() const
+{
+    if (m_state != State::InFrame)
+        return 0;
+    return static_cast<int>(m_frameByteCount) * 8 + m_bitIndex;
+}
+
+void HdlcCodec::beginFrame()
+{
+    m_currentByte    = 0;
+    m_bitIndex       = 0;
+    m_frameByteCount = 0;
+    m_rawBitsInFrame = 0;
+    m_bitsAfterFlag  = 0;
+    m_fcsValid       = false;
+    m_aborted        = false;
+}
+
+void HdlcCodec::accumulateBit(uint8_t bit)
+{
+    if (bit)
+        m_currentByte |= static_cast<uint8_t>(1u << m_bitIndex);
+    ++m_bitIndex;
+
+    if (m_bitIndex == 8) {
+        if (m_frameByteCount < kMaxFrameBytes)
+            m_frameBuffer[m_frameByteCount++] = m_currentByte;
+        else {
+            // Buffer overflow — abandon frame, return to searching
+            m_state  = State::Searching;
+            m_patDet = 0;
+            beginFrame();
+        }
+        m_currentByte = 0;
+        m_bitIndex    = 0;
+    }
+}
+
+bool HdlcCodec::closeFrame()
+{
+    m_complete = true;
+    m_state    = State::InPreamble;  // ready for next frame (shared flag)
+
+    // A valid AX.25 frame body is always a whole number of bytes.  After the
+    // last complete data byte (m_bitIndex==0), the 7 flag bits that precede
+    // the closing flag zero accumulate in m_currentByte; m_bitIndex reaches 7.
+    // Any other value means the frame wasn't byte-aligned → reject.
+    if (m_bitIndex != 7 || m_frameByteCount < 2) {
+        m_fcsValid = false;
+        m_frameSizeBits = m_rawBitsInFrame;
+        return true;
+    }
+
+    m_frameSizeBits = m_rawBitsInFrame;
+    m_bitsAfterFlag = 0;  // ready for postamble flag detection in InPreamble
+
+    // Compute expected FCS over frame[0..N-3] (all bytes except the 2 FCS bytes).
+    uint16_t crc = 0xFFFF;
+    for (size_t i = 0; i + 2 < m_frameByteCount; ++i)
+        crc = (crc >> 8) ^ kCrcTable[(crc ^ m_frameBuffer[i]) & 0xFF];
+    crc ^= 0xFFFF;
+
+    m_expectedFcs[0] = static_cast<uint8_t>(crc & 0xFF);
+    m_expectedFcs[1] = static_cast<uint8_t>((crc >> 8) & 0xFF);
+
+    m_actualFcs[0] = m_frameBuffer[m_frameByteCount - 2];
+    m_actualFcs[1] = m_frameBuffer[m_frameByteCount - 1];
+
+    m_fcsValid = (m_actualFcs == m_expectedFcs);
+    return true;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+
+bool HdlcCodec::processBit(uint8_t nrziTone)
+{
+    // Deferred reset: clear complete/aborted flags at the start of the next call
+    // so callers can read them after the frame-closing call returns.
+    if (m_complete) {
+        m_complete = false;
+        m_aborted  = false;
+    }
+
+    // NRZI decode: no transition = 1 (mark held), transition = 0 (space).
+    const uint8_t decoded = (nrziTone == m_prevNrzi) ? 1u : 0u;
+    m_prevNrzi = nrziTone;
+
+    // Shift new decoded bit into the rolling pattern register, newest at MSB.
+    m_patDet = static_cast<uint8_t>((m_patDet >> 1) | (decoded << 7));
+
+    switch (m_state) {
+
+    // ── Searching: scan for the first preamble flag ─────────────────────
+    case State::Searching:
+        if (m_patDet == 0x7E) {
+            m_state = State::InPreamble;
+            m_preambleCount = 1;
+            beginFrame();
+        }
+        break;
+
+    // ── InPreamble: count consecutive flags, wait for first frame bit ───
+    //
+    // We require 8 consecutive non-flag bits before entering InFrame.
+    // This mirrors libmodem's (bitstream_size >= 8) check and prevents a
+    // false InFrame transition on the very first bit of the next preamble
+    // flag (which would briefly disrupt pat_det away from 0x7E).
+    //
+    // Bits accumulate during this window; they become the first byte of the
+    // frame.  A flag anywhere in the window calls beginFrame() and resets
+    // the count, discarding those partial bits.
+    case State::InPreamble:
+        if (m_patDet == 0x7E) {
+            // Another consecutive preamble flag.
+            ++m_preambleCount;
+            beginFrame();  // clears m_bitsAfterFlag, byte state, etc.
+        } else {
+            // Potential frame data — accumulate and count.
+            ++m_rawBitsInFrame;
+            ++m_bitsAfterFlag;
+            accumulateBit(decoded);
+            // accumulateBit may have set state = Searching on overflow;
+            // only transition to InFrame if we're still in InPreamble.
+            if (m_state == State::InPreamble && m_bitsAfterFlag >= 8)
+                m_state = State::InFrame;
+        }
+        break;
+
+    // ── InFrame: collect frame bytes ────────────────────────────────────
+    case State::InFrame:
+        ++m_rawBitsInFrame;  // first 8 bits counted in InPreamble; continue here
+
+        // Priority 1 — Flag (checked before stuffing; 0x7E matches both but
+        // flag must win so the closing zero is never discarded as a stuffed bit).
+        if (m_patDet == 0x7E) {
+            return closeFrame();
+        }
+
+        // Priority 2 — Bit stuffing: current bit is 0 (bit7=0) and the five
+        // preceding bits are all 1 (bits 6..2 = 11111).  Discard the stuffed zero.
+        if ((m_patDet >> 2) == 0x1F) {
+            break;  // discard — do not accumulate
+        }
+
+        // Priority 3 — Abort: 7 consecutive ones (0xFE = 01111111 after final 0
+        // closes the abort, or 0xFF for 8 ones).
+        if (m_patDet == 0xFE || m_patDet == 0xFF) {
+            m_aborted = true;
+            m_state   = State::Searching;
+            m_patDet  = 0;
+            beginFrame();
+            break;
+        }
+
+        // Data bit — accumulate LSB-first into current byte.
+        accumulateBit(decoded);
+        break;
+    }
+
+    return false;
+}
+
+} // namespace AetherSDR

--- a/src/core/tnc/HdlcCodec.h
+++ b/src/core/tnc/HdlcCodec.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstddef>
+
+namespace AetherSDR {
+
+// Pure C++ HDLC framing for AX.25.  Processes one NRZI tone at a time.
+// Replaces lm::ax25::bitstream_state + lm::ax25::try_decode_bitstream in the
+// VHF 1200-baud decode path, keeping libmodem only for HF demod and AX.25
+// structure parsing.  No Qt, no libmodem, no Direwolf derivation.
+//
+// Algorithm: Direwolf-style shift-register flag/stuff/abort detection with
+// incremental byte assembly and batch CRC validation at frame close.
+class HdlcCodec {
+public:
+    // Maximum frame size in bytes (includes 2 FCS bytes).
+    // AX.25 max frame body is ~330 bytes; 512 gives comfortable headroom.
+    static constexpr size_t kMaxFrameBytes = 512;
+
+    void reset();
+
+    // Feed one NRZI tone (1 = mark, 0 = space).
+    // Returns true the call that closes a frame (complete() transitions false→true).
+    // complete() stays true until the next processBit() call.
+    bool processBit(uint8_t nrziTone);
+
+    // State accessors (valid immediately after processBit returns).
+    bool searching()  const { return m_state == State::Searching; }
+    bool inPreamble() const { return m_state == State::InPreamble; }
+    bool inFrame()    const { return m_state == State::InFrame; }
+    bool complete()   const { return m_complete; }
+    bool aborted()    const { return m_aborted; }
+    bool fcsValid()   const { return m_fcsValid; }
+
+    // Raw-bit count for the current in-progress frame (diagnostic).
+    int bitstreamSize() const;
+
+    // Bit length of the last completed frame (set at frame close).
+    int frameSizeBits()  const { return m_frameSizeBits; }
+    int preambleCount()  const { return m_preambleCount; }
+
+    // Frame bytes including the 2-byte FCS field.  Valid from the
+    // processBit() call that set complete() until reset() is called.
+    const uint8_t* frameData() const { return m_frameBuffer.data(); }
+    size_t         frameSize() const { return m_frameByteCount; }
+
+    // FCS bytes: actual = last 2 bytes of frame; expected = CRC of frame[0..N-3].
+    std::array<uint8_t, 2> actualFcs()   const { return m_actualFcs; }
+    std::array<uint8_t, 2> expectedFcs() const { return m_expectedFcs; }
+
+private:
+    enum class State : uint8_t { Searching, InPreamble, InFrame };
+
+    bool closeFrame();
+    void accumulateBit(uint8_t bit);
+    void beginFrame();
+
+    State   m_state{State::Searching};
+    bool    m_complete{false};
+    bool    m_aborted{false};
+    bool    m_fcsValid{false};
+
+    uint8_t m_prevNrzi{0};
+    uint8_t m_patDet{0};   // rolling 8-bit pattern, newest bit at MSB
+
+    // Incremental byte assembly
+    uint8_t m_currentByte{0};
+    int     m_bitIndex{0};
+
+    // Frame storage
+    std::array<uint8_t, kMaxFrameBytes> m_frameBuffer{};
+    size_t m_frameByteCount{0};
+
+    // Diagnostics
+    int m_frameSizeBits{0};
+    int m_preambleCount{0};
+    int m_rawBitsInFrame{0};   // raw bits seen while in InFrame (not unstuffed)
+    int m_bitsAfterFlag{0};    // non-flag bits since last preamble flag; require >=8 to enter InFrame
+
+    std::array<uint8_t, 2> m_actualFcs{};
+    std::array<uint8_t, 2> m_expectedFcs{};
+};
+
+} // namespace AetherSDR

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -14,6 +14,13 @@
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
+#ifdef HAVE_MQTT
+#include "core/MqttClient.h"
+#include "core/MqttSettings.h"
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#endif
 
 #include <QAction>
 #include <QButtonGroup>
@@ -96,6 +103,8 @@ constexpr int kTerminalDefaultRetrySecs = 6;
 constexpr int kTerminalDefaultMaxTries = 8;
 constexpr int kTerminalDefaultPaclen = 128;
 
+constexpr auto kPacketDecoderVhfModeSetting  = "Ax25PacketDecoderVhfMode"; // 0=Off..6=AB+
+constexpr auto kPacketDecoderPolaritySetting = "Ax25PacketDecoderPolarity";
 constexpr int kAudioCaptureSeconds = 180;
 constexpr int kTxDaxSettleMs = 150;
 constexpr int kTxLeadMs = 200;
@@ -294,6 +303,20 @@ Ax25ModemProfile profileFromSettingsValue(const QString& value)
     if (value == QStringLiteral("Vhf1200"))
         return Ax25ModemProfile::Vhf1200;
     return Ax25ModemProfile::Hf300;
+}
+
+QString polaritySettingsValue(Ax25TonePolarity polarity)
+{
+    return polarity == Ax25TonePolarity::Inverted
+        ? QStringLiteral("Inverted")
+        : QStringLiteral("Normal");
+}
+
+Ax25TonePolarity polarityFromSettingsValue(const QString& value)
+{
+    if (value == QStringLiteral("Inverted"))
+        return Ax25TonePolarity::Inverted;
+    return Ax25TonePolarity::Normal;
 }
 
 QLabel* sectionLabel(const QString& text, QWidget* parent)
@@ -623,7 +646,10 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     theme::setContainer(this, QStringLiteral("dialog/ax25Decode"));
     setMinimumSize(1080, 680);
 
-    m_shim = new AetherAx25LibmodemShim(this);
+    m_shim = new AetherAx25LibmodemShim();
+    m_shim->moveToThread(&m_shimThread);
+    connect(&m_shimThread, &QThread::finished, m_shim, &QObject::deleteLater);
+    m_shimThread.start();
     m_kissServer = new KissTncServer(this);
     m_heard = new HeardList(this);
     m_terminal = new TncTerminal(this);
@@ -711,7 +737,32 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_enableDecode = new QCheckBox(QStringLiteral("Enable Modem"), modemCell);
     modemLayout->addWidget(m_enableDecode);
     controls->addWidget(modemCell, 1);
-    controls->addStretch(2);
+
+    auto* polarityCell = panel(QStringLiteral("ControlCell"), controlsFrame);
+    auto* polarityLayout = new QVBoxLayout(polarityCell);
+    polarityLayout->setContentsMargins(0, 0, 20, 0);
+    polarityLayout->setSpacing(12);
+    polarityLayout->addWidget(sectionLabel(QStringLiteral("TONE POLARITY"), polarityCell));
+    auto* polarityButtons = new QHBoxLayout;
+    polarityButtons->setSpacing(34);
+    m_polarityNormal = new QRadioButton(QStringLiteral("Normal"), polarityCell);
+    m_polarityReverse = new QRadioButton(QStringLiteral("Reverse"), polarityCell);
+    m_polarityNormal->setChecked(true);
+    polarityButtons->addWidget(m_polarityNormal);
+    polarityButtons->addWidget(m_polarityReverse);
+    polarityButtons->addStretch(1);
+    polarityLayout->addLayout(polarityButtons);
+    // VHF demod mode selector (ordered by compute cost; matches Direwolf MODEM line options)
+    polarityLayout->addWidget(sectionLabel(QStringLiteral("VHF DEMOD MODE"), polarityCell));
+    m_vhfModeCombo = new QComboBox(polarityCell);
+    m_vhfModeCombo->addItem(QStringLiteral("A    —  IQ-mix · 1 slicer"));
+    m_vhfModeCombo->addItem(QStringLiteral("B    —  FM discriminator · 1 slicer"));
+    m_vhfModeCombo->addItem(QStringLiteral("AB   —  IQ-mix + FM discriminator · 1 slicer each"));
+    m_vhfModeCombo->addItem(QStringLiteral("A+   —  IQ-mix · 9 slicers  (Direwolf default)"));
+    m_vhfModeCombo->addItem(QStringLiteral("B+   —  FM discriminator · 9 slicers"));
+    m_vhfModeCombo->addItem(QStringLiteral("AB+  —  IQ-mix + FM discriminator · 9 slicers each"));
+    polarityLayout->addWidget(m_vhfModeCombo);
+    controls->addWidget(polarityCell, 2);
 
     m_captureButton = new QPushButton(QStringLiteral("Capture 3m"), controlsFrame);
     m_captureButton->setMinimumHeight(42);
@@ -837,8 +888,14 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     const Ax25ModemProfile savedProfile = profileFromSettingsValue(
         AppSettings::instance().value(kPacketDecoderProfileSetting, QStringLiteral("Hf300")).toString());
     const bool savedDebug = AppSettings::instance().value(kPacketDecoderDebugSetting, false).toBool();
+    const int  savedVhfMode = AppSettings::instance().value(kPacketDecoderVhfModeSetting, 3).toInt(); // default A+
+    const Ax25TonePolarity savedPolarity = polarityFromSettingsValue(
+        AppSettings::instance().value(kPacketDecoderPolaritySetting, QStringLiteral("Normal")).toString());
     m_hf300Profile->setChecked(savedProfile == Ax25ModemProfile::Hf300);
     m_vhf1200Profile->setChecked(savedProfile == Ax25ModemProfile::Vhf1200);
+    m_polarityNormal->setChecked(savedPolarity == Ax25TonePolarity::Normal);
+    m_polarityReverse->setChecked(savedPolarity == Ax25TonePolarity::Inverted);
+    m_vhfModeCombo->setCurrentIndex(std::clamp(savedVhfMode, 0, m_vhfModeCombo->count() - 1));
     setDiagnosticsDebugEnabled(savedDebug, false);
     setModemProfile(savedProfile, false);
 
@@ -876,6 +933,31 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
             this, &Ax25HfPacketDecodeDialog::startTransmitFromUi);
     connect(m_txPaceTimer, &QTimer::timeout,
             this, &Ax25HfPacketDecodeDialog::paceTransmitAudio);
+    connect(m_polarityNormal, &QRadioButton::toggled, this, [this](bool checked) {
+        if (!checked)
+            return;
+        setTonePolarity(Ax25TonePolarity::Normal, true);
+    });
+    connect(m_polarityReverse, &QRadioButton::toggled, this, [this](bool checked) {
+        if (!checked)
+            return;
+        setTonePolarity(Ax25TonePolarity::Inverted, true);
+    });
+    auto applyVhfMode = [this] {
+        auto cfg = m_shimConfig;
+        cfg.vhfMode = static_cast<VhfMode>(m_vhfModeCombo->currentIndex() + 1);
+        m_shimConfig = cfg;
+        QMetaObject::invokeMethod(m_shim, [shim = m_shim, cfg]() {
+            shim->configure(cfg);
+        }, Qt::QueuedConnection);
+        AppSettings::instance().setValue(kPacketDecoderVhfModeSetting, m_vhfModeCombo->currentIndex());
+        AppSettings::instance().save();
+        appendSystemLine(QStringLiteral("VHF mode: %1. Configured %2.")
+            .arg(m_vhfModeCombo->currentText().section(QStringLiteral("  —  "), 0, 0).trimmed(),
+                 ax25DemodDescription(m_shimConfig)));
+    };
+    connect(m_vhfModeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, [applyVhfMode](int) { applyVhfMode(); });
     connect(m_shim, &AetherAx25LibmodemShim::frameDecoded,
             this, &Ax25HfPacketDecodeDialog::appendFrame);
     // RX -> KISS clients: forward every decoded frame to connected hosts.
@@ -1075,6 +1157,8 @@ Ax25HfPacketDecodeDialog::~Ax25HfPacketDecodeDialog()
         m_kissServer->stop();
     if (m_audio)
         m_audio->setTncRxTapEnabled(false);
+    m_shimThread.quit();
+    m_shimThread.wait();
 }
 
 void Ax25HfPacketDecodeDialog::setAttachedSlice(SliceModel* slice)
@@ -1118,8 +1202,17 @@ void Ax25HfPacketDecodeDialog::setAttachedSlice(SliceModel* slice)
 
 void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool persist)
 {
-    // Tone polarity is always Normal for the supported HF DIGU / VHF FM paths.
-    m_shim->configure(ax25DemodConfigForProfile(profile, Ax25TonePolarity::Normal));
+    const auto polarity = selectedTonePolarity();
+    auto cfg = ax25DemodConfigForProfile(profile, polarity);
+    const bool isVhf = (profile == Ax25ModemProfile::Vhf1200);
+    if (m_vhfModeCombo) {
+        m_vhfModeCombo->setEnabled(isVhf);
+        cfg.vhfMode = static_cast<VhfMode>(m_vhfModeCombo->currentIndex() + 1);
+    }
+    m_shimConfig = cfg;
+    QMetaObject::invokeMethod(m_shim, [shim = m_shim, cfg]() {
+        shim->configure(cfg);
+    }, Qt::QueuedConnection);
     m_lastDiagnostics = {};
     m_lastDiagnosticsUtc = {};
 
@@ -1129,14 +1222,48 @@ void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool pe
     }
 
     if (m_log)
-        appendSystemLine(QStringLiteral("Configured %1.").arg(m_shim->demodDescription()));
+        appendSystemLine(QStringLiteral("Configured %1.").arg(ax25DemodDescription(m_shimConfig)));
     refreshStatus();
 }
+
+Ax25TonePolarity Ax25HfPacketDecodeDialog::selectedTonePolarity() const
+{
+    if (m_polarityReverse && m_polarityReverse->isChecked())
+        return Ax25TonePolarity::Inverted;
+    return Ax25TonePolarity::Normal;
+}
+
+void Ax25HfPacketDecodeDialog::setTonePolarity(Ax25TonePolarity polarity, bool persist)
+{
+    auto cfg = m_shimConfig;
+    if (cfg.polarity == polarity && persist)
+        return;
+
+    cfg.polarity = polarity;
+    m_shimConfig = cfg;
+    QMetaObject::invokeMethod(m_shim, [shim = m_shim, cfg]() {
+        shim->configure(cfg);
+    }, Qt::QueuedConnection);
+    m_lastDiagnostics = {};
+    m_lastDiagnosticsUtc = {};
+
+    if (persist) {
+        AppSettings::instance().setValue(kPacketDecoderPolaritySetting, polaritySettingsValue(polarity));
+        AppSettings::instance().save();
+    }
+
+    appendSystemLine(QStringLiteral("Tone polarity changed to %1. Configured %2.")
+        .arg(polaritySettingsValue(polarity), ax25DemodDescription(m_shimConfig)));
+    refreshStatus();
+}
+
 
 void Ax25HfPacketDecodeDialog::setDecodeEnabled(bool enabled)
 {
     if (enabled) {
-        m_shim->reset();
+        QMetaObject::invokeMethod(m_shim, [shim = m_shim]() {
+            shim->reset();
+        }, Qt::QueuedConnection);
         m_lastDiagnostics = {};
         m_enabledUtc = QDateTime::currentDateTimeUtc();
         m_lastDiagnosticsUtc = {};
@@ -1153,7 +1280,9 @@ void Ax25HfPacketDecodeDialog::setDecodeEnabled(bool enabled)
             finishAudioCapture(false);
         if (m_audio)
             m_audio->setTncRxTapEnabled(false);
-        m_shim->reset();
+        QMetaObject::invokeMethod(m_shim, [shim = m_shim]() {
+            shim->reset();
+        }, Qt::QueuedConnection);
         m_lastDiagnostics = {};
         m_lastDiagnosticsUtc = {};
         m_lastActivityHdlc = 0;
@@ -1192,7 +1321,9 @@ void Ax25HfPacketDecodeDialog::handleRxAudio(const QByteArray& monoFloat32Pcm, i
         }
     }
 
-    m_shim->feedAudio(monoFloat32Pcm, sampleRate);
+    QMetaObject::invokeMethod(m_shim, [shim = m_shim, pcm = monoFloat32Pcm, sr = sampleRate]() {
+        shim->feedAudio(pcm, sr);
+    }, Qt::QueuedConnection);
 }
 
 void Ax25HfPacketDecodeDialog::startAudioCapture()
@@ -1206,7 +1337,9 @@ void Ax25HfPacketDecodeDialog::startAudioCapture()
     m_captureSampleRate = 0;
     m_captureTargetBytes = 0;
     m_captureActive = true;
-    m_shim->reset();
+    QMetaObject::invokeMethod(m_shim, [shim = m_shim]() {
+        shim->reset();
+    }, Qt::QueuedConnection);
     m_lastDiagnostics = {};
     m_lastDiagnosticsUtc = {};
     m_lastActivityHdlc = 0;
@@ -1249,12 +1382,17 @@ void Ax25HfPacketDecodeDialog::finishAudioCapture(bool save)
 
 void Ax25HfPacketDecodeDialog::startTransmitFromUi()
 {
+    if (!m_txText)
+        return;
+    startTransmit(m_txText->text());
+}
+
+void Ax25HfPacketDecodeDialog::startTransmit(const QString& text)
+{
     if (m_txActive || m_txPendingStream) {
         appendSystemLine(QStringLiteral("TX already in progress."));
         return;
     }
-    if (!m_txText)
-        return;
     if (!m_audio || !m_radio) {
         appendSystemLine(QStringLiteral("TX unavailable: audio engine or radio model is not ready."));
         return;
@@ -1264,8 +1402,7 @@ void Ax25HfPacketDecodeDialog::startTransmitFromUi()
         return;
     }
 
-    const QString text = m_txText->text();
-    Ax25TransmitResult tx = m_shim->buildTransmitAudio(text, defaultTransmitSource());
+    Ax25TransmitResult tx = ax25BuildTransmitAudio(m_shimConfig, text, defaultTransmitSource());
     if (!tx.ok) {
         appendSystemLine(QStringLiteral("TX packetization failed: %1.").arg(tx.error));
         qCWarning(lcAx25).noquote() << "AX.25 TX packetization failed:" << tx.error;
@@ -1316,6 +1453,50 @@ void Ax25HfPacketDecodeDialog::beginTransmission(const Ax25TransmitResult& tx, b
 
     beginTransmitWhenReady();
 }
+
+#ifdef HAVE_MQTT
+void Ax25HfPacketDecodeDialog::setMqttClient(MqttClient* mqtt)
+{
+    if (m_mqtt == mqtt)
+        return;
+    if (m_mqtt)
+        disconnect(m_mqtt, &MqttClient::messageReceived,
+                   this, &Ax25HfPacketDecodeDialog::handleMqttMessage);
+    m_mqtt = mqtt;
+    if (m_mqtt)
+        connect(m_mqtt, &MqttClient::messageReceived,
+                this, &Ax25HfPacketDecodeDialog::handleMqttMessage);
+}
+
+void Ax25HfPacketDecodeDialog::publishFrameMqtt(const Ax25DecodedFrame& frame)
+{
+    if (!m_mqtt)
+        return;
+    QString display = frame.source + QStringLiteral(">") + frame.destination;
+    if (!frame.path.isEmpty())
+        display += QStringLiteral(",") + frame.path.join(QStringLiteral(","));
+    display += QStringLiteral(":")
+        + (frame.payloadText.isEmpty() ? frame.payloadHex : frame.payloadText);
+    QJsonObject obj;
+    obj[QStringLiteral("timestamp")] = frame.timestampUtc.toString(Qt::ISODateWithMs);
+    obj[QStringLiteral("source")]    = frame.source;
+    obj[QStringLiteral("dest")]      = frame.destination;
+    if (!frame.path.isEmpty())
+        obj[QStringLiteral("path")] = QJsonArray::fromStringList(frame.path);
+    obj[QStringLiteral("payload")]   = frame.payloadText.isEmpty() ? frame.payloadHex : frame.payloadText;
+    obj[QStringLiteral("display")]   = display;
+    obj[QStringLiteral("confidence")] = frame.confidenceOrQuality;
+    m_mqtt->publish(QString::fromLatin1(kAx25RxTopic),
+                    QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+void Ax25HfPacketDecodeDialog::handleMqttMessage(const QString& topic, const QByteArray& payload)
+{
+    if (topic != QString::fromLatin1(kAx25TxTopic))
+        return;
+    startTransmit(QString::fromUtf8(payload).trimmed());
+}
+#endif
 
 void Ax25HfPacketDecodeDialog::beginTransmitWhenReady()
 {
@@ -1433,7 +1614,7 @@ void Ax25HfPacketDecodeDialog::paceTransmitAudio()
         qCInfo(lcAx25).noquote()
             << QStringLiteral("AX.25 TX pacing summary: baud=%1 chunks=%2 audioMs=%3 wallMs=%4 "
                               "stretch=%5x maxChunkGapMs=%6 lateChunks=%7 nominalChunkMs=%8")
-                .arg(m_shim->config().baud)
+                .arg(m_shimConfig.baud)
                 .arg(m_txChunkIndex)
                 .arg(audioMs, 0, 'f', 0)
                 .arg(wallMs)
@@ -1563,6 +1744,9 @@ void Ax25HfPacketDecodeDialog::appendFrame(const Ax25DecodedFrame& frame)
     m_log->verticalScrollBar()->setValue(m_log->verticalScrollBar()->maximum());
     if (m_packetActivity)
         m_packetActivity->recordFrame();
+#ifdef HAVE_MQTT
+    publishFrameMqtt(frame);
+#endif
     refreshStatus();
 }
 
@@ -1653,7 +1837,7 @@ void Ax25HfPacketDecodeDialog::refreshStatus()
         m_modemStatusValue->setText(status);
         m_modemStatusValue->setToolTip(QStringLiteral(
             "%1\nSlice: %2\nSquelch: %3\nFrames: %4\nLast decode: %5\nDecode lanes: %6\nHDLC starts: %7\nHDLC candidates: %8\nAX.25-like candidates: %9\nAccepted: %10\nRejected: %11\nToo short: %12\nBad FCS: %13\nMalformed: %14\nLast reject: %15\nState: %16, bits: %17, ones: %18%\nReceive gate: %19, rms %20 dBFS, floor %21 dBFS, resets %22")
-            .arg(m_shim->demodDescription())
+            .arg(ax25DemodDescription(m_shimConfig))
             .arg(m_attachedSliceId >= 0 ? QString::number(m_attachedSliceId) : QStringLiteral("-"))
             .arg(squelchText)
             .arg(m_frameCount)
@@ -1718,7 +1902,7 @@ void Ax25HfPacketDecodeDialog::refreshTransmitControls()
         m_txText->setEnabled(!m_txActive && !m_txPendingStream);
         m_txText->setToolTip(
             QStringLiteral("Transmit a %1 AX.25 UI frame. Raw text uses %2>APRS; full SRC>DST,path:payload syntax is also accepted.")
-                .arg(ax25ModemProfileName(m_shim->config().profile), defaultTransmitSource()));
+                .arg(ax25ModemProfileName(m_shimConfig.profile), defaultTransmitSource()));
     }
 }
 
@@ -1729,7 +1913,9 @@ void Ax25HfPacketDecodeDialog::setDiagnosticsDebugEnabled(bool enabled, bool per
 
     m_diagnosticsDebugEnabled = enabled;
     if (m_shim)
-        m_shim->setDiagnosticsLoggingEnabled(enabled);
+        QMetaObject::invokeMethod(m_shim, [shim = m_shim, enabled]() {
+            shim->setDiagnosticsLoggingEnabled(enabled);
+        }, Qt::QueuedConnection);
     if (m_terminal)
         m_terminal->setVerbose(enabled); // echo protocol detail inline in the terminal
     if (m_packetActivity)

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -10,6 +10,7 @@
 #include <QPointer>
 #include <QQueue>
 #include <QStringList>
+#include <QThread>
 
 class QAbstractButton;
 class QCheckBox;
@@ -28,6 +29,9 @@ namespace AetherSDR {
 class AudioEngine;
 class HeardList;
 class KissTncServer;
+#ifdef HAVE_MQTT
+class MqttClient;
+#endif
 class PacketActivityWidget;
 class PmsMailbox;
 class RadioModel;
@@ -87,12 +91,18 @@ public:
     ~Ax25HfPacketDecodeDialog() override;
 
     void setAttachedSlice(SliceModel* slice);
+#ifdef HAVE_MQTT
+    void setMqttClient(MqttClient* mqtt);
+#endif
 
 protected:
     // Command history (Up/Down) on the terminal input line.
     bool eventFilter(QObject* watched, QEvent* event) override;
 
 private:
+    void startTransmit(const QString& text);
+    Ax25TonePolarity selectedTonePolarity() const;
+    void setTonePolarity(Ax25TonePolarity polarity, bool persist);
     void setModemProfile(Ax25ModemProfile profile, bool persist);
     void setDecodeEnabled(bool enabled);
     void handleRxAudio(const QByteArray& monoFloat32Pcm, int sampleRate);
@@ -140,16 +150,28 @@ private:
     QString formatTerminalLine(const Ax25DecodedFrame& frame) const;
     QString defaultTransmitSource() const;
     QString transmitSliceSummary() const;
+#ifdef HAVE_MQTT
+    void publishFrameMqtt(const Ax25DecodedFrame& frame);
+    void handleMqttMessage(const QString& topic, const QByteArray& payload);
+#endif
 
     AudioEngine* m_audio{nullptr};
     RadioModel* m_radio{nullptr};
     AetherAx25LibmodemShim* m_shim{nullptr};
+    QThread m_shimThread;
+    Ax25DemodConfig m_shimConfig;
     QStackedWidget* m_tabStack{nullptr};
     QAbstractButton* m_ax25Tab{nullptr};
     QAbstractButton* m_kissTab{nullptr};
+#ifdef HAVE_MQTT
+    QPointer<MqttClient> m_mqtt;
+#endif
     QRadioButton* m_hf300Profile{nullptr};
     QRadioButton* m_vhf1200Profile{nullptr};
     QCheckBox* m_enableDecode{nullptr};
+    QRadioButton* m_polarityNormal{nullptr};
+    QRadioButton* m_polarityReverse{nullptr};
+    QComboBox* m_vhfModeCombo{nullptr};
     QLineEdit* m_txText{nullptr};
     QPushButton* m_txButton{nullptr};
     QTextEdit* m_log{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2006,6 +2006,30 @@ MainWindow::MainWindow(QWidget* parent)
     connect(&m_cwDecoderTx, &CwDecoder::textDecoded, this,
             [this](const QString& t, float cost) { publishCwDecodeMqtt(t, cost, false); });
 
+    // aethersdr/radio/state — publish on PTT transitions.
+    // Slice freq/mode changes are wired per-slice in setActiveSliceInternal().
+    connect(&m_radioModel, &RadioModel::radioTransmittingChanged,
+            this, [this](bool) { publishRadioStateMqtt(); });
+
+    // aethersdr/cw/transmit → CWX keyer.
+    // Payload: {"text":"de k5ptb","speed_wpm":28,"pitch_hz":600}
+    // speed_wpm and pitch_hz are optional; absent = use current radio settings.
+    connect(m_mqttClient, &MqttClient::messageReceived,
+            this, [this](const QString& topic, const QByteArray& payload) {
+        if (topic != QString::fromLatin1(kCwTransmitTopic)) return;
+        if (!isMqttTopicEnabled(QString::fromLatin1(kCwTransmitTopic))) return;
+        const QJsonObject obj =
+            QJsonDocument::fromJson(payload).object();
+        const QString text = obj.value(QStringLiteral("text")).toString().trimmed();
+        if (text.isEmpty()) return;
+        auto& tx = m_radioModel.transmitModel();
+        const int wpm = obj.value(QStringLiteral("speed_wpm")).toInt(0);
+        if (wpm >= 5 && wpm <= 100) tx.setCwSpeed(wpm);
+        const int hz = obj.value(QStringLiteral("pitch_hz")).toInt(0);
+        if (hz >= 100 && hz <= 6000) tx.setCwPitch(hz);
+        m_radioModel.cwxModel().send(text);
+    });
+
     // MQTT → panadapter overlay display
     connect(m_appletPanel->mqttApplet(), &MqttApplet::displayValueChanged,
             this, [this](const QString& key, const QString& value) {
@@ -5971,8 +5995,12 @@ void MainWindow::showMqttSettingsDialog()
 void MainWindow::publishCwDecodeMqtt(const QString& text, float cost, bool rx)
 {
     if (!m_mqttClient) return;
+    if (!isMqttTopicEnabled(QString::fromLatin1(kCwDecodeTopic))) return;
     // No CW panel active → nothing is displayed → don't publish.
-    if (!m_cwDecoderApplet || cost >= m_cwDecoderApplet->cwCostThreshold()) return;
+    if (!m_cwDecoderApplet || cost >= m_cwDecoderApplet->cwCostThreshold()) {
+        qCDebug(lcMqtt) << "MQTT CW decode suppressed: no applet or cost threshold";
+        return;
+    }
     // Mirror panel normalization: \n → space; drop whitespace-only TX chunks.
     QString clean = text;
     clean.replace(QLatin1Char('\n'), QLatin1Char(' '));
@@ -5982,7 +6010,24 @@ void MainWindow::publishCwDecodeMqtt(const QString& text, float cost, bool rx)
     obj[QStringLiteral("rx")]   = rx;
     if (auto* s = activeSlice(); s && s->frequency() > 0.0)
         obj[QStringLiteral("freq")] = s->frequency();
+    if (m_cwLastPitchHz  > 0.0f) obj[QStringLiteral("pitch_hz")]  = m_cwLastPitchHz;
+    if (m_cwLastSpeedWpm > 0.0f) obj[QStringLiteral("speed_wpm")] = m_cwLastSpeedWpm;
     m_mqttClient->publish(QString::fromLatin1(kCwDecodeTopic),
+                          QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+void MainWindow::publishRadioStateMqtt()
+{
+    if (!m_mqttClient) return;
+    if (!isMqttTopicEnabled(QString::fromLatin1(kRadioStateTopic))) return;
+    auto* s = activeSlice();
+    if (!s) return;
+    QJsonObject obj;
+    obj[QStringLiteral("slice")] = s->letter();
+    obj[QStringLiteral("freq")]  = s->frequency();
+    obj[QStringLiteral("mode")]  = s->mode();
+    obj[QStringLiteral("tx")]    = m_radioModel.isRadioTransmitting();
+    m_mqttClient->publish(QString::fromLatin1(kRadioStateTopic),
                           QJsonDocument(obj).toJson(QJsonDocument::Compact));
 }
 #endif
@@ -6797,6 +6842,9 @@ void MainWindow::showAx25HfPacketDecodeDialog()
         m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
     }
     m_ax25HfPacketDecodeDialog->setAttachedSlice(slice);
+#ifdef HAVE_MQTT
+    m_ax25HfPacketDecodeDialog->setMqttClient(m_mqttClient);
+#endif
     m_ax25HfPacketDecodeDialog->show();
     m_ax25HfPacketDecodeDialog->raise();
     m_ax25HfPacketDecodeDialog->activateWindow();
@@ -12844,6 +12892,17 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     }
 #endif
 
+    // Rewire radio state MQTT publish to the new active slice's freq/mode signals.
+    disconnect(m_radioStateFreqConn);
+    disconnect(m_radioStateModeConn);
+#ifdef HAVE_MQTT
+    m_radioStateFreqConn = connect(s, &SliceModel::frequencyChanged,
+                                   this, [this](double) { publishRadioStateMqtt(); });
+    m_radioStateModeConn = connect(s, &SliceModel::modeChanged,
+                                   this, [this](const QString&) { publishRadioStateMqtt(); });
+    publishRadioStateMqtt();
+#endif
+
     qDebug() << "MainWindow: active slice set to" << sliceId;
 }
 
@@ -13053,6 +13112,11 @@ void MainWindow::routeCwDecoderOutput()
                 m_cwDecoderApplet, &PanadapterApplet::appendCwTextTx);
         connect(&m_cwDecoder, &CwDecoder::statsUpdated,
                 m_cwDecoderApplet, &PanadapterApplet::setCwStats);
+        connect(&m_cwDecoder, &CwDecoder::statsUpdated,
+                this, [this](float pitchHz, float speedWpm) {
+            m_cwLastPitchHz   = pitchHz;
+            m_cwLastSpeedWpm  = speedWpm;
+        });
         connect(m_cwDecoderApplet->lockPitchButton(), &QPushButton::toggled,
                 &m_cwDecoder, &CwDecoder::lockPitch);
         connect(m_cwDecoderApplet->lockSpeedButton(), &QPushButton::toggled,

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -366,6 +366,7 @@ private:
 #ifdef HAVE_MQTT
     void showMqttSettingsDialog();
     void publishCwDecodeMqtt(const QString& text, float cost, bool rx);
+    void publishRadioStateMqtt();
 #endif
     void applyPanLayout(const QString& layoutId);
     void createPansSequentially(const QString& layoutId, int total,
@@ -478,6 +479,10 @@ private:
     PgxlConnection    m_pgxlConn;        // direct TCP 9008 to PGXL for telemetry
     BandPlanManager*  m_bandPlanMgr{nullptr};
     CwDecoder         m_cwDecoder;
+    float             m_cwLastPitchHz{0.0f};
+    float             m_cwLastSpeedWpm{0.0f};
+    QMetaObject::Connection m_radioStateFreqConn;
+    QMetaObject::Connection m_radioStateModeConn;
     CwDecoder         m_cwDecoderTx;
     RttyDecoder       m_rttyDecoder;
     DxClusterClient*   m_dxCluster{nullptr};

--- a/src/gui/MqttApplet.cpp
+++ b/src/gui/MqttApplet.cpp
@@ -141,7 +141,19 @@ void MqttApplet::setMqttClient(MqttClient* client)
     connect(client, &MqttClient::connectionError, this, [this](const QString& err) {
         updateStatus(err, false);
     });
-    connect(client, &MqttClient::messageReceived, this, &MqttApplet::onMessageReceived);
+    connect(client, &MqttClient::messageReceived,  this, &MqttApplet::onMessageReceived);
+    connect(client, &MqttClient::messagePublished, this, [this](const QString& topic, const QByteArray& payload) {
+        QString shortTopic = topic.section('/', -1);
+        if (shortTopic.isEmpty()) shortTopic = topic;
+        m_messageLog->append(QStringLiteral("TX %1: %2").arg(shortTopic, QString::fromUtf8(payload).left(80)));
+        QTextDocument* doc = m_messageLog->document();
+        while (doc->blockCount() > 50) {
+            QTextCursor cursor(doc->begin());
+            cursor.select(QTextCursor::BlockUnderCursor);
+            cursor.removeSelectedText();
+            cursor.deleteChar();
+        }
+    });
 }
 
 void MqttApplet::refreshSettings()

--- a/src/gui/MqttSettingsDialog.cpp
+++ b/src/gui/MqttSettingsDialog.cpp
@@ -166,11 +166,18 @@ void MqttSettingsDialog::buildUi()
 
     auto* internalGroup = new QGroupBox(tr("Internal AetherSDR Topics"));
     auto* internalLayout = new QVBoxLayout(internalGroup);
-    auto* internalText = new QLabel(
-        tr("Subscribed automatically whenever MQTT connects; these topics are not removable:\n%1")
-            .arg(internalMqttSubscriptionTopics().join(QStringLiteral("\n"))));
-    internalText->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    internalLayout->addWidget(internalText);
+    for (const auto& def : internalMqttSubscribeTopicDefs()) {
+        auto* cb = new QCheckBox(
+            QStringLiteral("%1  —  %2").arg(def.topic, def.description));
+        cb->setToolTip(def.topic);
+        if (!def.gateable) {
+            cb->setChecked(true);
+            cb->setEnabled(false);
+            cb->setStyleSheet(QStringLiteral("QCheckBox:disabled { color: #556; }"));
+        }
+        m_internalSubBoxes.append(cb);
+        internalLayout->addWidget(cb);
+    }
     topicsLayout->addWidget(internalGroup);
     tabs->addTab(topicsTab, tr("Subscriptions"));
 
@@ -200,11 +207,18 @@ void MqttSettingsDialog::buildUi()
 
     auto* pubInternalGroup = new QGroupBox(tr("Internal AetherSDR Topics"));
     auto* pubInternalLayout = new QVBoxLayout(pubInternalGroup);
-    auto* pubInternalText = new QLabel(
-        tr("Published automatically whenever MQTT is connected; these topics are not user-configurable:\n"
-           "%1").arg(internalMqttPublishTopics().join(QStringLiteral("\n"))));
-    pubInternalText->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    pubInternalLayout->addWidget(pubInternalText);
+    for (const auto& def : internalMqttPublishTopicDefs()) {
+        auto* cb = new QCheckBox(
+            QStringLiteral("%1  —  %2").arg(def.topic, def.description));
+        cb->setToolTip(def.topic);
+        if (!def.gateable) {
+            cb->setChecked(true);
+            cb->setEnabled(false);
+            cb->setStyleSheet(QStringLiteral("QCheckBox:disabled { color: #556; }"));
+        }
+        m_internalPubBoxes.append(cb);
+        pubInternalLayout->addWidget(cb);
+    }
     buttonsLayout->addWidget(pubInternalGroup);
 
     tabs->addTab(buttonsTab, tr("Publish Buttons"));
@@ -235,6 +249,18 @@ void MqttSettingsDialog::loadSettings()
     m_tlsCheck->setChecked(config.useTls);
     m_caFileEdit->setText(config.caFile);
 
+    const auto& subDefs = internalMqttSubscribeTopicDefs();
+    for (int i = 0; i < m_internalSubBoxes.size(); ++i) {
+        if (i < subDefs.size() && subDefs[i].gateable)
+            m_internalSubBoxes[i]->setChecked(isMqttTopicEnabled(subDefs[i].topic));
+    }
+
+    const auto& pubDefs = internalMqttPublishTopicDefs();
+    for (int i = 0; i < m_internalPubBoxes.size(); ++i) {
+        if (i < pubDefs.size() && pubDefs[i].gateable)
+            m_internalPubBoxes[i]->setChecked(isMqttTopicEnabled(pubDefs[i].topic));
+    }
+
     m_topicsTable->setRowCount(0);
     for (const MqttTopicDef& def : loadMqttTopicConfig()) {
         addTopicRow(def);
@@ -257,6 +283,19 @@ void MqttSettingsDialog::saveSettings()
         m_caFileEdit->text().trimmed(),
     };
     saveMqttConnectionConfig(config);
+
+    const auto& subDefs = internalMqttSubscribeTopicDefs();
+    for (int i = 0; i < m_internalSubBoxes.size(); ++i) {
+        if (i < subDefs.size() && subDefs[i].gateable)
+            setMqttTopicEnabled(subDefs[i].topic, m_internalSubBoxes[i]->isChecked());
+    }
+
+    const auto& pubDefs = internalMqttPublishTopicDefs();
+    for (int i = 0; i < m_internalPubBoxes.size(); ++i) {
+        if (i < pubDefs.size() && pubDefs[i].gateable)
+            setMqttTopicEnabled(pubDefs[i].topic, m_internalPubBoxes[i]->isChecked());
+    }
+
     saveMqttTopicConfig(topicRows());
     saveMqttButtonConfig(buttonRows());
     savePasswordToKeychain(m_passEdit->text());

--- a/src/gui/MqttSettingsDialog.h
+++ b/src/gui/MqttSettingsDialog.h
@@ -45,7 +45,10 @@ private:
     QLineEdit* m_caFileEdit{nullptr};
     QTableWidget* m_topicsTable{nullptr};
     QTableWidget* m_buttonsTable{nullptr};
-    QPushButton* m_addButtonRowBtn{nullptr};
+    QPushButton*  m_addButtonRowBtn{nullptr};
+
+    QVector<QCheckBox*> m_internalSubBoxes;
+    QVector<QCheckBox*> m_internalPubBoxes;
 };
 
 } // namespace AetherSDR

--- a/tests/ax25_libmodem_shim_test.cpp
+++ b/tests/ax25_libmodem_shim_test.cpp
@@ -367,11 +367,33 @@ void testVhf1200ProfileConfig()
     report("VHF sample rate", cfg.sampleRate == 24000);
     report("VHF baud", cfg.baud == 1200);
     report("VHF tones", cfg.markHz == 1200.0 && cfg.spaceHz == 2200.0);
-    // Aggressive multi-lane decode bank: 10 free-running phase lanes + 4 tracked
-    // phases x 2 PLL bandwidths = 18 (see kVhf1200* in the shim).
-    report("VHF profile runs the 18-lane decode bank",
-           shim.diagnosticsSnapshot().decodeLanes == 18);
+    // Default VHF mode is A+ (9 space-gain slicers, matching Direwolf).
+    report("VHF profile runs the A+ decode bank",
+           shim.diagnosticsSnapshot().decodeLanes == 9);
     report("VHF description names profile", shim.demodDescription().contains(QStringLiteral("1200 baud VHF")));
+}
+
+void testVhf1200ModeLaneCounts()
+{
+    // Lane counts for each VhfMode.  9 A-slicers (kVhf1200SpaceGains) and
+    // 9 B-slicers (kVhf1200BSliceOffsets); combinations are additive.
+    struct Case { const char* name; VhfMode mode; int expectedLanes; };
+    const Case cases[] = {
+        { "Off has 0 lanes",   VhfMode::Off,   0  },
+        { "A has 1 lane",      VhfMode::A,     1  },
+        { "B has 1 lane",      VhfMode::B,     1  },
+        { "AB has 2 lanes",    VhfMode::AB,    2  },
+        { "A+ has 9 lanes",    VhfMode::APlus, 9  },
+        { "B+ has 9 lanes",    VhfMode::BPlus, 9  },
+        { "AB+ has 18 lanes",  VhfMode::ABPlus, 18 },
+    };
+    for (const auto& c : cases) {
+        AetherAx25LibmodemShim shim;
+        Ax25DemodConfig cfg = ax25DemodConfigForProfile(Ax25ModemProfile::Vhf1200);
+        cfg.vhfMode = c.mode;
+        shim.configure(cfg);
+        report(c.name, shim.diagnosticsSnapshot().decodeLanes == c.expectedLanes);
+    }
 }
 
 void testKnownGoodBitstreamDecodes()
@@ -922,6 +944,7 @@ int main(int argc, char** argv)
 
     testConstructsWithHf300Config();
     testVhf1200ProfileConfig();
+    testVhf1200ModeLaneCounts();
     testKnownGoodBitstreamDecodes();
     testSyntheticHf300AfskLoopbackDecodes();
     testSyntheticVhf1200AfskLoopbackDecodes();

--- a/tests/hdlc_codec_test.cpp
+++ b/tests/hdlc_codec_test.cpp
@@ -1,0 +1,269 @@
+#include "core/tnc/HdlcCodec.h"
+
+#include "bitstream.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace lm = aether_libmodem_core;
+using AetherSDR::HdlcCodec;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok)
+        ++g_failed;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+// Feed a vector of NRZI bits into the codec and return the number of
+// complete-frame transitions.
+struct FeedResult {
+    int frames{0};
+    int goodFcs{0};
+};
+
+FeedResult feedBits(HdlcCodec& codec, const std::vector<uint8_t>& nrzi)
+{
+    FeedResult r;
+    for (uint8_t bit : nrzi) {
+        if (codec.processBit(bit)) {
+            ++r.frames;
+            if (codec.fcsValid())
+                ++r.goodFcs;
+        }
+    }
+    return r;
+}
+
+// Build a known AX.25 packet using libmodem and NRZI-encode it.
+// Returns the NRZI bitstream (one byte per bit, values 0/1).
+std::vector<uint8_t> makeNrziBitstream(const lm::packet& pkt,
+                                       int preamble = 10,
+                                       int postamble = 3)
+{
+    auto bs = lm::ax25::encode_bitstream(pkt, preamble, postamble);
+    return bs;  // encode_bitstream already returns NRZI-encoded bits
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void testSingleFrame()
+{
+    lm::packet pkt("N0CALL-9", "APRS", {"WIDE1-1", "WIDE2-1"}, ">Test payload 123");
+    auto nrzi = makeNrziBitstream(pkt);
+
+    HdlcCodec codec;
+    auto r = feedBits(codec, nrzi);
+
+    report("single frame: exactly one complete", r.frames == 1);
+    report("single frame: FCS valid", r.goodFcs == 1);
+}
+
+void testFrameContents()
+{
+    lm::packet pkt("W5XD", "APRS", {}, ">Hello world");
+    auto nrzi = makeNrziBitstream(pkt);
+
+    HdlcCodec codec;
+    bool gotFrame = false;
+    for (uint8_t bit : nrzi) {
+        if (codec.processBit(bit)) {
+            gotFrame = true;
+            break;
+        }
+    }
+
+    report("frame contents: complete flag set", gotFrame && codec.complete());
+    report("frame contents: FCS valid", codec.fcsValid());
+    report("frame contents: at least 15 bytes", codec.frameSize() >= 15);
+
+    // Verify via libmodem's AX.25 parser (passing frame without last 2 FCS bytes)
+    if (codec.fcsValid() && codec.frameSize() >= 2) {
+        lm::packet decoded;
+        bool ok = lm::ax25::try_decode_frame_no_fcs(
+            std::span<const uint8_t>(codec.frameData(), codec.frameSize() - 2),
+            decoded);
+        report("frame contents: libmodem parses callsigns", ok && decoded.from == "W5XD");
+        report("frame contents: libmodem parses data",
+               ok && decoded.data == ">Hello world");
+    } else {
+        report("frame contents: libmodem parses callsigns", false);
+        report("frame contents: libmodem parses data", false);
+    }
+}
+
+void testFcsMatchesLibmodem()
+{
+    lm::packet pkt("K5PTB", "BEACON", {"WIDE1-1"}, ">CRC cross-check");
+    auto nrzi = makeNrziBitstream(pkt);
+
+    // Break immediately when the frame closes so complete()/fcsValid() are
+    // still true (they are reset at the start of the *next* processBit call).
+    HdlcCodec codec;
+    bool gotFrame = false;
+    for (uint8_t bit : nrzi) {
+        if (codec.processBit(bit)) {
+            gotFrame = true;
+            break;
+        }
+    }
+
+    if (!gotFrame || !codec.fcsValid()) {
+        report("FCS cross-check: codec decoded frame", false);
+        return;
+    }
+    report("FCS cross-check: codec decoded frame", true);
+
+    // libmodem's compute_crc over the frame body (excluding last 2 FCS bytes)
+    auto span = std::span<const uint8_t>(codec.frameData(), codec.frameSize() - 2);
+    auto libmodemFcs = lm::ax25::compute_crc(span.begin(), span.end());
+
+    report("FCS cross-check: CRC low byte matches libmodem",
+           codec.expectedFcs()[0] == libmodemFcs[0]);
+    report("FCS cross-check: CRC high byte matches libmodem",
+           codec.expectedFcs()[1] == libmodemFcs[1]);
+    report("FCS cross-check: actual FCS == expected FCS",
+           codec.actualFcs() == codec.expectedFcs());
+}
+
+void testBadFcs()
+{
+    // Corrupt a bit in the middle of the bitstream and verify FCS fails.
+    lm::packet pkt("N0CALL", "APRS", {}, ">Corruption test");
+    auto nrzi = makeNrziBitstream(pkt);
+
+    // Flip a bit roughly in the middle (well away from preamble/postamble flags).
+    size_t mid = nrzi.size() / 2;
+    nrzi[mid] ^= 1;
+
+    HdlcCodec codec;
+    int frames = 0;
+    int badFcs = 0;
+    for (uint8_t bit : nrzi) {
+        if (codec.processBit(bit)) {
+            ++frames;
+            if (!codec.fcsValid())
+                ++badFcs;
+        }
+    }
+
+    // We expect at least one complete frame (may not decode as valid AX.25)
+    // but the FCS should be wrong.
+    report("bad FCS: at least one frame candidate", frames >= 1);
+    report("bad FCS: no valid FCS", badFcs == frames);
+}
+
+void testTwoConsecutiveFrames()
+{
+    lm::packet p1("AA1BB", "APRS", {}, ">First");
+    lm::packet p2("CC3DD", "APRS", {}, ">Second");
+
+    // Encode p1 normally, then encode p2 starting from the NRZI level where
+    // p1 left off.  Without this, bs2 starts at level 0 while the codec's
+    // prevNrzi is whatever bs1 ended on, causing mis-decoded first bits.
+    auto bs1 = lm::ax25::encode_bitstream(p1, 5, 2);
+    const uint8_t finalLevel = bs1.empty() ? 0 : bs1.back();
+    auto bs2 = lm::ax25::encode_bitstream(p2, finalLevel, 5, 2);
+
+    HdlcCodec codec;
+    FeedResult r1 = feedBits(codec, bs1);
+    FeedResult r2 = feedBits(codec, bs2);
+
+    report("two frames: first decoded", r1.goodFcs == 1);
+    report("two frames: second decoded", r2.goodFcs == 1);
+}
+
+void testPreambleCount()
+{
+    lm::packet pkt("N0CALL", "APRS", {}, ">preamble count");
+    auto nrzi = makeNrziBitstream(pkt, 10, 3);
+
+    HdlcCodec codec;
+    for (uint8_t bit : nrzi)
+        codec.processBit(bit);
+
+    // Preamble count should be >= 10 (the requested preamble flags).
+    report("preamble count >= 10", codec.preambleCount() >= 10);
+}
+
+void testReset()
+{
+    lm::packet pkt("N0CALL", "APRS", {}, ">Reset test");
+    auto nrzi = makeNrziBitstream(pkt);
+
+    HdlcCodec codec;
+    feedBits(codec, nrzi);
+
+    codec.reset();
+
+    report("reset: searching after reset", codec.searching());
+    report("reset: not complete after reset", !codec.complete());
+    report("reset: zero frame size after reset", codec.frameSize() == 0);
+
+    // Should decode again after reset.
+    auto r = feedBits(codec, nrzi);
+    report("reset: decodes again after reset", r.goodFcs == 1);
+}
+
+void testStateTransitions()
+{
+    HdlcCodec codec;
+    report("initial state: searching", codec.searching());
+    report("initial state: not in preamble", !codec.inPreamble());
+    report("initial state: not in frame", !codec.inFrame());
+    report("initial state: not complete", !codec.complete());
+
+    // Feed one preamble flag: 0x7E = 0,1,1,1,1,1,1,0 (NRZ LSB-first)
+    // NRZI encode it starting from level 0.
+    uint8_t level = 0;
+    const uint8_t nrzFlag[8] = {0, 1, 1, 1, 1, 1, 1, 0};
+    for (int i = 0; i < 8; ++i) {
+        if (nrzFlag[i] == 0)
+            level ^= 1;
+        codec.processBit(level);
+    }
+    report("after one flag: in preamble", codec.inPreamble());
+}
+
+void testLongPayload()
+{
+    // 256-byte payload — exercises the frame buffer boundary
+    std::string data(256, 'X');
+    data[0] = '>';
+    lm::packet pkt("N0CALL", "APRS", {}, data);
+    auto nrzi = makeNrziBitstream(pkt);
+
+    HdlcCodec codec;
+    auto r = feedBits(codec, nrzi);
+    report("long payload: decoded", r.goodFcs == 1);
+}
+
+} // namespace
+
+int main()
+{
+    testStateTransitions();
+    testSingleFrame();
+    testFrameContents();
+    testFcsMatchesLibmodem();
+    testBadFcs();
+    testTwoConsecutiveFrames();
+    testPreambleCount();
+    testReset();
+    testLongPayload();
+
+    if (g_failed == 0)
+        std::printf("All tests passed.\n");
+    else
+        std::printf("%d test(s) FAILED.\n", g_failed);
+
+    return g_failed ? 1 : 0;
+}

--- a/third_party/direwolf_afsk/AetherAFSKDemod.cpp
+++ b/third_party/direwolf_afsk/AetherAFSKDemod.cpp
@@ -42,7 +42,7 @@ bool  AetherAFSKDemod::s_cosTableReady = false;
 void AetherAFSKDemod::buildCosTable() noexcept
 {
     for (int j = 0; j < 256; ++j)
-        s_cosTable[j] = std::cosf(static_cast<float>(j) * 2.0f * float(M_PI) / 256.0f);
+        s_cosTable[j] = std::cos(static_cast<float>(j) * 2.0f * float(M_PI) / 256.0f);
     s_cosTableReady = true;
 }
 
@@ -84,16 +84,16 @@ float AetherAFSKDemod::agcStep(float in, float fast, float slow,
 // RRC kernel: sinc × raised-cosine window (from Dire Wolf dsp.c).
 static float rrcKernel(float t, float a) noexcept
 {
-    float sinc = (std::fabsf(t) < 0.001f)
+    float sinc = (std::fabs(t) < 0.001f)
                ? 1.0f
-               : std::sinf(float(M_PI) * t) / (float(M_PI) * t);
+               : std::sin(float(M_PI) * t) / (float(M_PI) * t);
 
     float at = a * t;
     float win;
-    if (std::fabsf(std::fabsf(at) - 0.5f) < 0.001f)
+    if (std::fabs(std::fabs(at) - 0.5f) < 0.001f)
         win = float(M_PI) / 4.0f;
     else
-        win = std::cosf(float(M_PI) * at) / (1.0f - (2.0f * at) * (2.0f * at));
+        win = std::cos(float(M_PI) * at) / (1.0f - (2.0f * at) * (2.0f * at));
 
     return sinc * win;
 }
@@ -117,10 +117,10 @@ void AetherAFSKDemod::buildPrefilter(double fMark, double fSpace,
 
     for (int j = 0; j < taps; ++j) {
         float d = j - center;
-        preCoeffs_[j] = (std::fabsf(d) < 1e-6f)
+        preCoeffs_[j] = (std::fabs(d) < 1e-6f)
             ? 2.0f * (f2 - f1)
-            : std::sinf(2.0f * float(M_PI) * f2 * d) / (float(M_PI) * d)
-            - std::sinf(2.0f * float(M_PI) * f1 * d) / (float(M_PI) * d);
+            : std::sin(2.0f * float(M_PI) * f2 * d) / (float(M_PI) * d)
+            - std::sin(2.0f * float(M_PI) * f1 * d) / (float(M_PI) * d);
         // Truncated (rectangular) window — matches Dire Wolf profile A.
     }
 
@@ -128,7 +128,7 @@ void AetherAFSKDemod::buildPrefilter(double fMark, double fSpace,
     float w = 2.0f * float(M_PI) * 0.5f * (f1 + f2);
     float G = 0.0f;
     for (int j = 0; j < taps; ++j)
-        G += 2.0f * preCoeffs_[j] * std::cosf((j - center) * w);
+        G += 2.0f * preCoeffs_[j] * std::cos((j - center) * w);
     if (G != 0.0f)
         for (auto& c : preCoeffs_) c /= G;
 
@@ -199,7 +199,7 @@ void AetherAFSKDemod::nudgePll(float demodOut, float amplitude) noexcept
     // Overflow from positive to negative → sample point.
     if (pll_ < 0 && prevPll_ >= 0) {
         float conf = (amplitude > 1e-7f)
-                   ? std::min(std::fabsf(demodOut) / amplitude, 1.0f)
+                   ? std::min(std::fabs(demodOut) / amplitude, 1.0f)
                    : 0.0f;
         readyBit_  = (demodOut > 0.0f) ? 1u : 0u;
         readyConf_ = conf;
@@ -253,8 +253,8 @@ bool AetherAFSKDemod::try_demodulate(double sample, demod_result& result) noexce
     float sI = convolve(sIBuf_.data(), lpCoeffs_.data(), lpTaps_);
     float sQ = convolve(sQBuf_.data(), lpCoeffs_.data(), lpTaps_);
 
-    float mAmp = std::hypotf(mI, mQ);
-    float sAmp = std::hypotf(sI, sQ);
+    float mAmp = std::hypot(mI, mQ);
+    float sAmp = std::hypot(sI, sQ);
 
     // 4. AGC — always run to track peak/valley for amplitude reporting.
     float mNorm = agcStep(mAmp, kAgcFastAttack, kAgcSlowDecay, mPeak_, mValley_);

--- a/third_party/direwolf_afsk/AetherAFSKDemod.cpp
+++ b/third_party/direwolf_afsk/AetherAFSKDemod.cpp
@@ -1,0 +1,327 @@
+// AetherAFSKDemod.cpp
+//
+// Derived from Dire Wolf by John Langner WB2OSZ
+// Copyright (C) 2011-2020 John Langner WB2OSZ
+// Dire Wolf: GPL-2.0-or-later — https://github.com/wb2osz/direwolf
+// AetherSDR: GPL-3.0-or-later — compatible via GPL-2.0-or-later upgrade path
+//
+// Reference: src/demod_afsk.c (profile A) and src/dsp.c from Dire Wolf.
+
+#include "AetherAFSKDemod.h"
+
+#include <algorithm>
+#include <bit>
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <numeric>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace AetherDemod {
+
+// ── Profile-A tuning constants (from Dire Wolf demod_afsk.c / dsp.c) ─────────
+
+static constexpr float kPrefilterBaud    = 0.155f;  // BPF skirt each side, fraction of baud
+static constexpr float kPrefilterLenSym  = 383.f * 1200.f / 44100.f; // ~8.3 symbol-times
+static constexpr float kRrcRolloff       = 0.20f;
+static constexpr float kRrcWidthSym      = 2.80f;
+static constexpr float kAgcFastAttack    = 0.70f;
+static constexpr float kAgcSlowDecay     = 0.000090f;
+static constexpr float kPllLockedInertia    = 0.74f;
+static constexpr float kPllSearchingInertia = 0.50f;
+static constexpr int   kMaxFilterTaps    = 2048;
+
+// ── Static members ────────────────────────────────────────────────────────────
+
+float AetherAFSKDemod::s_cosTable[256];
+bool  AetherAFSKDemod::s_cosTableReady = false;
+
+void AetherAFSKDemod::buildCosTable() noexcept
+{
+    for (int j = 0; j < 256; ++j)
+        s_cosTable[j] = std::cosf(static_cast<float>(j) * 2.0f * float(M_PI) / 256.0f);
+    s_cosTableReady = true;
+}
+
+// ── Inner helpers ─────────────────────────────────────────────────────────────
+
+void AetherAFSKDemod::pushSample(float val, float* buf, int size) noexcept
+{
+    std::memmove(buf + 1, buf, static_cast<size_t>(size - 1) * sizeof(float));
+    buf[0] = val;
+}
+
+float AetherAFSKDemod::convolve(const float* __restrict__ data,
+                                 const float* __restrict__ coeffs,
+                                 int taps) noexcept
+{
+    float sum = 0.0f;
+    for (int j = 0; j < taps; ++j)
+        sum += coeffs[j] * data[j];
+    return sum;
+}
+
+// Peak/valley AGC — output settles to ≈ [-0.5, +0.5].
+float AetherAFSKDemod::agcStep(float in, float fast, float slow,
+                                float& peak, float& valley) noexcept
+{
+    peak   = (in >= peak)   ? in * fast + peak   * (1.0f - fast)
+                            : in * slow + peak   * (1.0f - slow);
+    valley = (in <= valley) ? in * fast + valley * (1.0f - fast)
+                            : in * slow + valley * (1.0f - slow);
+
+    float x = std::max(valley, std::min(peak, in));
+    if (peak > valley)
+        return (x - 0.5f * (peak + valley)) / (peak - valley);
+    return 0.0f;
+}
+
+// ── Filter design ─────────────────────────────────────────────────────────────
+
+// RRC kernel: sinc × raised-cosine window (from Dire Wolf dsp.c).
+static float rrcKernel(float t, float a) noexcept
+{
+    float sinc = (std::fabsf(t) < 0.001f)
+               ? 1.0f
+               : std::sinf(float(M_PI) * t) / (float(M_PI) * t);
+
+    float at = a * t;
+    float win;
+    if (std::fabsf(std::fabsf(at) - 0.5f) < 0.001f)
+        win = float(M_PI) / 4.0f;
+    else
+        win = std::cosf(float(M_PI) * at) / (1.0f - (2.0f * at) * (2.0f * at));
+
+    return sinc * win;
+}
+
+void AetherAFSKDemod::buildPrefilter(double fMark, double fSpace,
+                                      int bitrate, int sampleRate) noexcept
+{
+    int taps = (static_cast<int>(kPrefilterLenSym * sampleRate / bitrate)) | 1;
+    taps = std::min(taps, kMaxFilterTaps);
+
+    // Normalised cutoff frequencies
+    float f1 = static_cast<float>(
+        (std::min(fMark, fSpace) - kPrefilterBaud * bitrate) / sampleRate);
+    float f2 = static_cast<float>(
+        (std::max(fMark, fSpace) + kPrefilterBaud * bitrate) / sampleRate);
+    f1 = std::max(f1, 1.0f / sampleRate);
+    f2 = std::min(f2, 0.499f);
+
+    float center = 0.5f * (taps - 1);
+    preCoeffs_.resize(taps);
+
+    for (int j = 0; j < taps; ++j) {
+        float d = j - center;
+        preCoeffs_[j] = (std::fabsf(d) < 1e-6f)
+            ? 2.0f * (f2 - f1)
+            : std::sinf(2.0f * float(M_PI) * f2 * d) / (float(M_PI) * d)
+            - std::sinf(2.0f * float(M_PI) * f1 * d) / (float(M_PI) * d);
+        // Truncated (rectangular) window — matches Dire Wolf profile A.
+    }
+
+    // Normalise for unity gain at midband.
+    float w = 2.0f * float(M_PI) * 0.5f * (f1 + f2);
+    float G = 0.0f;
+    for (int j = 0; j < taps; ++j)
+        G += 2.0f * preCoeffs_[j] * std::cosf((j - center) * w);
+    if (G != 0.0f)
+        for (auto& c : preCoeffs_) c /= G;
+
+    preTaps_ = taps;
+    preBuf_.assign(taps, 0.0f);
+}
+
+void AetherAFSKDemod::buildRrcLowpass(int bitrate, int sampleRate) noexcept
+{
+    float sps  = static_cast<float>(sampleRate) / static_cast<float>(bitrate);
+    int   taps = (static_cast<int>(kRrcWidthSym * sps)) | 1;
+    taps = std::min(taps, kMaxFilterTaps);
+
+    lpCoeffs_.resize(taps);
+    for (int k = 0; k < taps; ++k) {
+        float t = (k - (taps - 1.0f) * 0.5f) / sps;
+        lpCoeffs_[k] = rrcKernel(t, kRrcRolloff);
+    }
+
+    // Normalise for unity DC gain.
+    float sum = std::accumulate(lpCoeffs_.begin(), lpCoeffs_.end(), 0.0f);
+    if (sum != 0.0f)
+        for (auto& c : lpCoeffs_) c /= sum;
+
+    lpTaps_ = taps;
+    mIBuf_.assign(taps, 0.0f);
+    mQBuf_.assign(taps, 0.0f);
+    sIBuf_.assign(taps, 0.0f);
+    sQBuf_.assign(taps, 0.0f);
+}
+
+// ── Constructor ───────────────────────────────────────────────────────────────
+
+AetherAFSKDemod::AetherAFSKDemod(
+        double fMark,  double fSpace,  int bitrate,  int sampleRate,
+        double /*prefilterBaud*/, double /*filterSymLengths*/,
+        double /*sincBw*/,        double /*sincRw*/,
+        double /*dfbAlphaMark*/,  double /*dfbAlphaSpace*/,
+        double /*pllAlpha*/,
+        float  spaceGain)
+    : spaceGain_(spaceGain)
+{
+    if (!s_cosTableReady) buildCosTable();
+
+    buildPrefilter(fMark, fSpace, bitrate, sampleRate);
+    buildRrcLowpass(bitrate, sampleRate);
+
+    // Oscillator phase increments — 32-bit unsigned wrapping accumulator.
+    mOscDelta_ = static_cast<uint32_t>(
+        std::round(std::pow(2.0, 32.0) * fMark  / sampleRate));
+    sOscDelta_ = static_cast<uint32_t>(
+        std::round(std::pow(2.0, 32.0) * fSpace / sampleRate));
+
+    // DPLL: one full 2³² cycle per symbol period.
+    pllStep_ = static_cast<int32_t>(
+        std::round(4294967296.0 * bitrate / sampleRate));
+}
+
+// ── DPLL ─────────────────────────────────────────────────────────────────────
+
+void AetherAFSKDemod::nudgePll(float demodOut, float amplitude) noexcept
+{
+    prevPll_ = pll_;
+    // Unsigned add so wrap-around is well-defined.
+    pll_ = static_cast<int32_t>(
+        static_cast<uint32_t>(pll_) + static_cast<uint32_t>(pllStep_));
+
+    // Overflow from positive to negative → sample point.
+    if (pll_ < 0 && prevPll_ >= 0) {
+        float conf = (amplitude > 1e-7f)
+                   ? std::min(std::fabsf(demodOut) / amplitude, 1.0f)
+                   : 0.0f;
+        readyBit_  = (demodOut > 0.0f) ? 1u : 0u;
+        readyConf_ = conf;
+        bitReady_  = true;
+
+        // Sliding-window DCD heuristic.
+        bool good = (conf > 0.1f);
+        goodHist_ = (goodHist_ << 1) | (good ? 1u : 0u);
+        badHist_  = (badHist_  << 1) | (good ? 0u : 1u);
+        dcdScore_ = (dcdScore_ << 1);
+        int g = std::popcount(goodHist_ & 0xffu);
+        int b = std::popcount(badHist_  & 0xffu);
+        if (g - b >= 2) dcdScore_ |= 1u;
+        int sc = std::popcount(dcdScore_ & 0xffu);
+        if (!dataDetect_ && sc >= 6) dataDetect_ = true;
+        if ( dataDetect_ && sc <  2) dataDetect_ = false;
+    }
+
+    // Nudge phase toward signal on transitions.
+    bool d = (demodOut > 0.0f);
+    if (d != prevDemod_) {
+        float inertia = dataDetect_ ? kPllLockedInertia : kPllSearchingInertia;
+        pll_ = static_cast<int32_t>(static_cast<float>(pll_) * inertia);
+    }
+    prevDemod_ = d;
+}
+
+// ── Main demodulator ──────────────────────────────────────────────────────────
+
+bool AetherAFSKDemod::try_demodulate(double sample, demod_result& result) noexcept
+{
+    // Input is already in [-1, 1] (normalised by the shim).
+    float fsam = static_cast<float>(sample);
+
+    // 1. Bandpass prefilter.
+    pushSample(fsam, preBuf_.data(), preTaps_);
+    fsam = convolve(preBuf_.data(), preCoeffs_.data(), preTaps_);
+
+    // 2. Mix with mark and space local oscillators.
+    float mC = fcos(mOscPhase_),  mS = fsin(mOscPhase_);  mOscPhase_ += mOscDelta_;
+    float sC = fcos(sOscPhase_),  sS = fsin(sOscPhase_);  sOscPhase_ += sOscDelta_;
+
+    pushSample(fsam * mC, mIBuf_.data(), lpTaps_);
+    pushSample(fsam * mS, mQBuf_.data(), lpTaps_);
+    pushSample(fsam * sC, sIBuf_.data(), lpTaps_);
+    pushSample(fsam * sS, sQBuf_.data(), lpTaps_);
+
+    // 3. RRC lowpass then envelope (amplitude).
+    float mI = convolve(mIBuf_.data(), lpCoeffs_.data(), lpTaps_);
+    float mQ = convolve(mQBuf_.data(), lpCoeffs_.data(), lpTaps_);
+    float sI = convolve(sIBuf_.data(), lpCoeffs_.data(), lpTaps_);
+    float sQ = convolve(sQBuf_.data(), lpCoeffs_.data(), lpTaps_);
+
+    float mAmp = std::hypotf(mI, mQ);
+    float sAmp = std::hypotf(sI, sQ);
+
+    // 4. AGC — always run to track peak/valley for amplitude reporting.
+    float mNorm = agcStep(mAmp, kAgcFastAttack, kAgcSlowDecay, mPeak_, mValley_);
+    float sNorm = agcStep(sAmp, kAgcFastAttack, kAgcSlowDecay, sPeak_, sValley_);
+
+    // 5. Decision — two modes matching Direwolf demod_afsk_process_sample:
+    //
+    // Single-slicer (spaceGain_==0): AGC-normalised comparison. Both tones
+    // scaled to ±0.5 before subtraction, so amplitude imbalance is cancelled.
+    // Direwolf passes amplitude=1.0 to nudge_pll in this path.
+    //
+    // Multi-slicer (spaceGain_!=0): raw-amplitude comparison. Space amplitude
+    // is multiplied by spaceGain_ (logarithmically spread 0.5→4.0 across the
+    // slicer bank) before subtraction. This directly compensates for VHF FM
+    // de-emphasis attenuating the 2200 Hz space tone relative to 1200 Hz mark.
+    // Confidence is scaled by the signal envelope, as Direwolf does.
+    float demodOut;
+    float amplitude;
+    if (spaceGain_ == 0.0f) {
+        demodOut  = mNorm - sNorm;
+        amplitude = 1.0f;
+    } else {
+        demodOut  = mAmp - sAmp * spaceGain_;
+        amplitude = 0.5f * ((mPeak_ - mValley_) + (sPeak_ - sValley_) * spaceGain_);
+        if (amplitude < 1e-7f) amplitude = 1.0f;
+    }
+
+    // 6. DPLL — fires a bit at each symbol centre.
+    nudgePll(demodOut, amplitude);
+
+    if (bitReady_) {
+        bitReady_        = false;
+        result.bit       = readyBit_;
+        result.confidence = static_cast<double>(readyConf_);
+        return true;
+    }
+    return false;
+}
+
+bool AetherAFSKDemod::try_demodulate(double sample, uint8_t& bit) noexcept
+{
+    demod_result r;
+    if (try_demodulate(sample, r)) {
+        bit = r.bit;
+        return true;
+    }
+    return false;
+}
+
+// ── Reset ─────────────────────────────────────────────────────────────────────
+
+void AetherAFSKDemod::reset() noexcept
+{
+    std::fill(preBuf_.begin(), preBuf_.end(), 0.0f);
+    std::fill(mIBuf_.begin(), mIBuf_.end(), 0.0f);
+    std::fill(mQBuf_.begin(), mQBuf_.end(), 0.0f);
+    std::fill(sIBuf_.begin(), sIBuf_.end(), 0.0f);
+    std::fill(sQBuf_.begin(), sQBuf_.end(), 0.0f);
+
+    mOscPhase_ = sOscPhase_ = 0;
+    mPeak_ = mValley_ = sPeak_ = sValley_ = 0.0f;
+    pll_ = prevPll_ = 0;
+    prevDemod_ = dataDetect_ = false;
+    goodHist_ = badHist_ = dcdScore_ = 0;
+    bitReady_ = false;
+    readyBit_ = 0;
+    readyConf_ = 0.0f;
+}
+
+} // namespace AetherDemod

--- a/third_party/direwolf_afsk/AetherAFSKDemod.h
+++ b/third_party/direwolf_afsk/AetherAFSKDemod.h
@@ -1,0 +1,125 @@
+// AetherAFSKDemod.h
+//
+// AFSK 1200 baud demodulator — AetherSDR / AetherAFSKDemod
+//
+// Derived from Dire Wolf by John Langner WB2OSZ
+// Copyright (C) 2011-2020 John Langner WB2OSZ
+// Dire Wolf: GPL-2.0-or-later — https://github.com/wb2osz/direwolf
+// AetherSDR: GPL-3.0-or-later — compatible via GPL-2.0-or-later upgrade path
+//
+// Algorithm: Direwolf profile-A
+//   BPF → IQ mix (mark/space LOs) → RRC LPF → sqrt → AGC → DPLL
+//
+// Drop-in replacement for aether_libmodem_core::sinc_corr_afsk_demodulator.
+// Used unconditionally for the VHF 1200 baud profile; libmodem handles HF 300.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+// MSVC uses __restrict; GCC/Clang use __restrict__
+#ifdef _MSC_VER
+#  ifndef __restrict__
+#    define __restrict__ __restrict
+#  endif
+#endif
+
+namespace AetherDemod {
+
+struct demod_result {
+    uint8_t bit      = 0;
+    double  confidence = 0.0;
+};
+
+class AetherAFSKDemod {
+public:
+    AetherAFSKDemod() = default;
+
+    // Constructor signature matches aether_libmodem_core::sinc_corr_afsk_demodulator.
+    // fMark, fSpace, bitrate, sampleRate are used directly.
+    // Remaining parameters are accepted for API compatibility; Direwolf's
+    // tuned profile-A constants are used internally.
+    AetherAFSKDemod(double fMark, double fSpace, int bitrate, int sampleRate,
+                    double prefilterBaud, double filterSymLengths,
+                    double sincBw,        double sincRw,
+                    double dfbAlphaMark,  double dfbAlphaSpace,
+                    double pllAlpha,
+                    float  spaceGain = 0.0f);
+
+    // Returns true and fills result when a bit is ready (once per symbol period).
+    bool try_demodulate(double sample, demod_result& result) noexcept;
+    bool try_demodulate(double sample, uint8_t& bit)         noexcept;
+
+    void reset() noexcept;
+
+private:
+    // Bandpass prefilter
+    std::vector<float> preCoeffs_;
+    std::vector<float> preBuf_;
+    int preTaps_ {0};
+
+    // RRC lowpass — one set of coefficients, four delay lines (m_I, m_Q, s_I, s_Q)
+    std::vector<float> lpCoeffs_;
+    std::vector<float> mIBuf_, mQBuf_, sIBuf_, sQBuf_;
+    int lpTaps_ {0};
+
+    // Mark/space free-running oscillators (32-bit unsigned phase)
+    uint32_t mOscPhase_ {0};
+    uint32_t mOscDelta_ {0};
+    uint32_t sOscPhase_ {0};
+    uint32_t sOscDelta_ {0};
+
+    // Per-tone peak/valley AGC
+    float mPeak_   {0.0f};
+    float mValley_ {0.0f};
+    float sPeak_   {0.0f};
+    float sValley_ {0.0f};
+
+    // 0.0f = single-slicer (AGC mode: mNorm−sNorm)
+    // non-zero = multi-slicer (raw: mAmp−sAmp*spaceGain_, Direwolf A+ method)
+    float   spaceGain_ {0.0f};
+
+    // DPLL state
+    int32_t pll_         {0};
+    int32_t prevPll_     {0};
+    int32_t pllStep_     {0};
+    bool    prevDemod_   {false};
+    bool    dataDetect_  {false};
+
+    // Simple DCD sliding-window history
+    uint32_t goodHist_ {0};
+    uint32_t badHist_  {0};
+    uint32_t dcdScore_ {0};
+
+    // Output latch — set by nudgePll, consumed by try_demodulate
+    bool    bitReady_  {false};
+    uint8_t readyBit_  {0};
+    float   readyConf_ {0.0f};
+
+    // 256-entry cosine lookup (shared across all instances)
+    static float s_cosTable[256];
+    static bool  s_cosTableReady;
+    static void  buildCosTable() noexcept;
+
+    static inline float fcos(uint32_t phase) noexcept
+        { return s_cosTable[(phase >> 24) & 0xffu]; }
+    static inline float fsin(uint32_t phase) noexcept
+        { return s_cosTable[((phase >> 24) - 64u) & 0xffu]; }
+
+    void buildPrefilter(double fMark, double fSpace, int bitrate, int sampleRate) noexcept;
+    void buildRrcLowpass(int bitrate, int sampleRate) noexcept;
+
+    static float  convolve  (const float* __restrict__ data,
+                              const float* __restrict__ coeffs, int taps) noexcept;
+    static void   pushSample(float val, float* buf, int size) noexcept;
+    static float  agcStep   (float in, float fast, float slow,
+                              float& peak, float& valley) noexcept;
+
+    void nudgePll(float demodOut, float amplitude) noexcept;
+};
+
+// API alias — makes AetherDemod a drop-in for aether_libmodem_core's class.
+using sinc_corr_afsk_demodulator = AetherAFSKDemod;
+
+} // namespace AetherDemod

--- a/third_party/direwolf_afsk/AetherFMDiscrimDemod.cpp
+++ b/third_party/direwolf_afsk/AetherFMDiscrimDemod.cpp
@@ -1,0 +1,276 @@
+// AetherFMDiscrimDemod.cpp
+//
+// Derived from Dire Wolf by John Langner WB2OSZ
+// Copyright (C) 2011-2020 John Langner WB2OSZ
+// Dire Wolf: GPL-2.0-or-later — https://github.com/wb2osz/direwolf
+// AetherSDR: GPL-3.0-or-later — compatible via GPL-2.0-or-later upgrade path
+//
+// Reference: src/demod_afsk.c (profile B) and src/dsp.c from Dire Wolf.
+
+#include "AetherFMDiscrimDemod.h"
+
+#include <algorithm>
+#include <bit>
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <numeric>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace AetherDemod {
+
+// ── Profile-B tuning constants (from Dire Wolf demod_afsk.c) ─────────────────
+
+static constexpr float kPrefilterBaud      = 0.19f;   // BPF skirt each side
+static constexpr float kPrefilterLenSym    = 8.163f;  // filter length in symbols
+static constexpr float kRrcRolloff         = 0.40f;   // wider than profile-A (0.20)
+static constexpr float kRrcWidthSym        = 2.00f;   // shorter than profile-A (2.80)
+static constexpr float kPllLockedInertia   = 0.74f;
+static constexpr float kPllSearchingInertia = 0.50f;
+static constexpr int   kMaxFilterTaps      = 2048;
+
+// ── Static members ────────────────────────────────────────────────────────────
+
+float AetherFMDiscrimDemod::s_cosTable[256];
+bool  AetherFMDiscrimDemod::s_cosTableReady = false;
+
+void AetherFMDiscrimDemod::buildCosTable() noexcept
+{
+    for (int j = 0; j < 256; ++j)
+        s_cosTable[j] = std::cosf(static_cast<float>(j) * 2.0f * float(M_PI) / 256.0f);
+    s_cosTableReady = true;
+}
+
+// ── Inner helpers ─────────────────────────────────────────────────────────────
+
+void AetherFMDiscrimDemod::pushSample(float val, float* buf, int size) noexcept
+{
+    std::memmove(buf + 1, buf, static_cast<size_t>(size - 1) * sizeof(float));
+    buf[0] = val;
+}
+
+float AetherFMDiscrimDemod::convolve(const float* __restrict__ data,
+                                      const float* __restrict__ coeffs,
+                                      int taps) noexcept
+{
+    float sum = 0.0f;
+    for (int j = 0; j < taps; ++j)
+        sum += coeffs[j] * data[j];
+    return sum;
+}
+
+// ── Filter design ─────────────────────────────────────────────────────────────
+
+static float rrcKernel(float t, float a) noexcept
+{
+    float sinc = (std::fabsf(t) < 0.001f)
+               ? 1.0f
+               : std::sinf(float(M_PI) * t) / (float(M_PI) * t);
+
+    float at = a * t;
+    float win;
+    if (std::fabsf(std::fabsf(at) - 0.5f) < 0.001f)
+        win = float(M_PI) / 4.0f;
+    else
+        win = std::cosf(float(M_PI) * at) / (1.0f - (2.0f * at) * (2.0f * at));
+
+    return sinc * win;
+}
+
+void AetherFMDiscrimDemod::buildPrefilter(double fMark, double fSpace,
+                                           int bitrate, int sampleRate) noexcept
+{
+    int taps = (static_cast<int>(kPrefilterLenSym * sampleRate / bitrate)) | 1;
+    taps = std::min(taps, kMaxFilterTaps);
+
+    float f1 = static_cast<float>(
+        (std::min(fMark, fSpace) - kPrefilterBaud * bitrate) / sampleRate);
+    float f2 = static_cast<float>(
+        (std::max(fMark, fSpace) + kPrefilterBaud * bitrate) / sampleRate);
+    f1 = std::max(f1, 1.0f / sampleRate);
+    f2 = std::min(f2, 0.499f);
+
+    float center = 0.5f * (taps - 1);
+    preCoeffs_.resize(taps);
+
+    for (int j = 0; j < taps; ++j) {
+        float d = j - center;
+        preCoeffs_[j] = (std::fabsf(d) < 1e-6f)
+            ? 2.0f * (f2 - f1)
+            : std::sinf(2.0f * float(M_PI) * f2 * d) / (float(M_PI) * d)
+            - std::sinf(2.0f * float(M_PI) * f1 * d) / (float(M_PI) * d);
+    }
+
+    float w = 2.0f * float(M_PI) * 0.5f * (f1 + f2);
+    float G = 0.0f;
+    for (int j = 0; j < taps; ++j)
+        G += 2.0f * preCoeffs_[j] * std::cosf((j - center) * w);
+    if (G != 0.0f)
+        for (auto& c : preCoeffs_) c /= G;
+
+    preTaps_ = taps;
+    preBuf_.assign(taps, 0.0f);
+}
+
+void AetherFMDiscrimDemod::buildRrcLowpass(int bitrate, int sampleRate) noexcept
+{
+    float sps  = static_cast<float>(sampleRate) / static_cast<float>(bitrate);
+    int   taps = (static_cast<int>(kRrcWidthSym * sps)) | 1;
+    taps = std::min(taps, kMaxFilterTaps);
+
+    lpCoeffs_.resize(taps);
+    for (int k = 0; k < taps; ++k) {
+        float t = (k - (taps - 1.0f) * 0.5f) / sps;
+        lpCoeffs_[k] = rrcKernel(t, kRrcRolloff);
+    }
+
+    float sum = std::accumulate(lpCoeffs_.begin(), lpCoeffs_.end(), 0.0f);
+    if (sum != 0.0f)
+        for (auto& c : lpCoeffs_) c /= sum;
+
+    lpTaps_ = taps;
+    cIBuf_.assign(taps, 0.0f);
+    cQBuf_.assign(taps, 0.0f);
+}
+
+// ── Constructor ───────────────────────────────────────────────────────────────
+
+AetherFMDiscrimDemod::AetherFMDiscrimDemod(
+        double fMark, double fSpace, int bitrate, int sampleRate,
+        float sliceOffset)
+    : sliceOffset_(sliceOffset)
+{
+    if (!s_cosTableReady) buildCosTable();
+
+    buildPrefilter(fMark, fSpace, bitrate, sampleRate);
+    buildRrcLowpass(bitrate, sampleRate);
+
+    // Center-frequency oscillator: (fMark + fSpace) / 2
+    const double fCenter = 0.5 * (fMark + fSpace);
+    cOscDelta_ = static_cast<uint32_t>(
+        std::round(std::pow(2.0, 32.0) * fCenter / sampleRate));
+
+    pllStep_ = static_cast<int32_t>(
+        std::round(4294967296.0 * bitrate / sampleRate));
+
+    // Scale factor: radians/sample → ±1.0 for expected mark/space tones.
+    // At the mark frequency the instantaneous rate is fMark*2π/sampleRate;
+    // at space it's fSpace*2π/sampleRate.  The midpoint is fCenter*2π/sampleRate
+    // and the expected half-deviation is |fMark-fSpace|/2 * 2π/sampleRate.
+    normalizeRpsam_ = static_cast<float>(
+        1.0 / (0.5 * std::abs(fMark - fSpace) * 2.0 * M_PI / sampleRate));
+}
+
+// ── DPLL ─────────────────────────────────────────────────────────────────────
+
+void AetherFMDiscrimDemod::nudgePll(float demodOut) noexcept
+{
+    prevPll_ = pll_;
+    pll_ = static_cast<int32_t>(
+        static_cast<uint32_t>(pll_) + static_cast<uint32_t>(pllStep_));
+
+    if (pll_ < 0 && prevPll_ >= 0) {
+        // Confidence: how far the discriminator is from the decision threshold.
+        // Amplitude is always 1.0 for profile B (self-normalizing discriminator).
+        float conf = std::min(std::fabsf(demodOut), 1.0f);
+        readyBit_  = (demodOut > 0.0f) ? 1u : 0u;
+        readyConf_ = conf;
+        bitReady_  = true;
+
+        bool good = (conf > 0.1f);
+        goodHist_ = (goodHist_ << 1) | (good ? 1u : 0u);
+        badHist_  = (badHist_  << 1) | (good ? 0u : 1u);
+        dcdScore_ = (dcdScore_ << 1);
+        int g = std::popcount(goodHist_ & 0xffu);
+        int b = std::popcount(badHist_  & 0xffu);
+        if (g - b >= 2) dcdScore_ |= 1u;
+        int sc = std::popcount(dcdScore_ & 0xffu);
+        if (!dataDetect_ && sc >= 6) dataDetect_ = true;
+        if ( dataDetect_ && sc <  2) dataDetect_ = false;
+    }
+
+    bool d = (demodOut > 0.0f);
+    if (d != prevDemod_) {
+        float inertia = dataDetect_ ? kPllLockedInertia : kPllSearchingInertia;
+        pll_ = static_cast<int32_t>(static_cast<float>(pll_) * inertia);
+    }
+    prevDemod_ = d;
+}
+
+// ── Main demodulator ──────────────────────────────────────────────────────────
+
+bool AetherFMDiscrimDemod::try_demodulate(double sample, demod_result& result) noexcept
+{
+    float fsam = static_cast<float>(sample);
+
+    // 1. Bandpass prefilter.
+    pushSample(fsam, preBuf_.data(), preTaps_);
+    fsam = convolve(preBuf_.data(), preCoeffs_.data(), preTaps_);
+
+    // 2. Mix with center-frequency oscillator.
+    float cC = fcos(cOscPhase_),  cS = fsin(cOscPhase_);  cOscPhase_ += cOscDelta_;
+
+    pushSample(fsam * cC, cIBuf_.data(), lpTaps_);
+    pushSample(fsam * cS, cQBuf_.data(), lpTaps_);
+
+    // 3. RRC lowpass.
+    float cI = convolve(cIBuf_.data(), lpCoeffs_.data(), lpTaps_);
+    float cQ = convolve(cQBuf_.data(), lpCoeffs_.data(), lpTaps_);
+
+    // 4. Instantaneous phase via atan2.
+    float phase = std::atan2f(cQ, cI);
+
+    // 5. Differentiate phase → frequency deviation; handle ±π wrap.
+    float rate = phase - prevPhase_;
+    if (rate >  float(M_PI)) rate -= 2.0f * float(M_PI);
+    if (rate < -float(M_PI)) rate += 2.0f * float(M_PI);
+    prevPhase_ = phase;
+
+    // 6. Normalize so expected mark deviation ≈ +1, space ≈ −1.
+    //    sliceOffset_ shifts the decision threshold (B+ multi-slicer).
+    float demodOut = rate * normalizeRpsam_ + sliceOffset_;
+
+    // 7. DPLL — fires a bit at each symbol centre.
+    nudgePll(demodOut);
+
+    if (bitReady_) {
+        bitReady_         = false;
+        result.bit        = readyBit_;
+        result.confidence = static_cast<double>(readyConf_);
+        return true;
+    }
+    return false;
+}
+
+bool AetherFMDiscrimDemod::try_demodulate(double sample, uint8_t& bit) noexcept
+{
+    demod_result r;
+    if (try_demodulate(sample, r)) {
+        bit = r.bit;
+        return true;
+    }
+    return false;
+}
+
+// ── Reset ─────────────────────────────────────────────────────────────────────
+
+void AetherFMDiscrimDemod::reset() noexcept
+{
+    std::fill(preBuf_.begin(), preBuf_.end(), 0.0f);
+    std::fill(cIBuf_.begin(), cIBuf_.end(), 0.0f);
+    std::fill(cQBuf_.begin(), cQBuf_.end(), 0.0f);
+
+    cOscPhase_ = 0;
+    prevPhase_ = 0.0f;
+    pll_ = prevPll_ = 0;
+    prevDemod_ = dataDetect_ = false;
+    goodHist_ = badHist_ = dcdScore_ = 0;
+    bitReady_ = false;
+    readyBit_ = 0;
+    readyConf_ = 0.0f;
+}
+
+} // namespace AetherDemod

--- a/third_party/direwolf_afsk/AetherFMDiscrimDemod.cpp
+++ b/third_party/direwolf_afsk/AetherFMDiscrimDemod.cpp
@@ -40,7 +40,7 @@ bool  AetherFMDiscrimDemod::s_cosTableReady = false;
 void AetherFMDiscrimDemod::buildCosTable() noexcept
 {
     for (int j = 0; j < 256; ++j)
-        s_cosTable[j] = std::cosf(static_cast<float>(j) * 2.0f * float(M_PI) / 256.0f);
+        s_cosTable[j] = std::cos(static_cast<float>(j) * 2.0f * float(M_PI) / 256.0f);
     s_cosTableReady = true;
 }
 
@@ -66,16 +66,16 @@ float AetherFMDiscrimDemod::convolve(const float* __restrict__ data,
 
 static float rrcKernel(float t, float a) noexcept
 {
-    float sinc = (std::fabsf(t) < 0.001f)
+    float sinc = (std::fabs(t) < 0.001f)
                ? 1.0f
-               : std::sinf(float(M_PI) * t) / (float(M_PI) * t);
+               : std::sin(float(M_PI) * t) / (float(M_PI) * t);
 
     float at = a * t;
     float win;
-    if (std::fabsf(std::fabsf(at) - 0.5f) < 0.001f)
+    if (std::fabs(std::fabs(at) - 0.5f) < 0.001f)
         win = float(M_PI) / 4.0f;
     else
-        win = std::cosf(float(M_PI) * at) / (1.0f - (2.0f * at) * (2.0f * at));
+        win = std::cos(float(M_PI) * at) / (1.0f - (2.0f * at) * (2.0f * at));
 
     return sinc * win;
 }
@@ -98,16 +98,16 @@ void AetherFMDiscrimDemod::buildPrefilter(double fMark, double fSpace,
 
     for (int j = 0; j < taps; ++j) {
         float d = j - center;
-        preCoeffs_[j] = (std::fabsf(d) < 1e-6f)
+        preCoeffs_[j] = (std::fabs(d) < 1e-6f)
             ? 2.0f * (f2 - f1)
-            : std::sinf(2.0f * float(M_PI) * f2 * d) / (float(M_PI) * d)
-            - std::sinf(2.0f * float(M_PI) * f1 * d) / (float(M_PI) * d);
+            : std::sin(2.0f * float(M_PI) * f2 * d) / (float(M_PI) * d)
+            - std::sin(2.0f * float(M_PI) * f1 * d) / (float(M_PI) * d);
     }
 
     float w = 2.0f * float(M_PI) * 0.5f * (f1 + f2);
     float G = 0.0f;
     for (int j = 0; j < taps; ++j)
-        G += 2.0f * preCoeffs_[j] * std::cosf((j - center) * w);
+        G += 2.0f * preCoeffs_[j] * std::cos((j - center) * w);
     if (G != 0.0f)
         for (auto& c : preCoeffs_) c /= G;
 
@@ -175,7 +175,7 @@ void AetherFMDiscrimDemod::nudgePll(float demodOut) noexcept
     if (pll_ < 0 && prevPll_ >= 0) {
         // Confidence: how far the discriminator is from the decision threshold.
         // Amplitude is always 1.0 for profile B (self-normalizing discriminator).
-        float conf = std::min(std::fabsf(demodOut), 1.0f);
+        float conf = std::min(std::fabs(demodOut), 1.0f);
         readyBit_  = (demodOut > 0.0f) ? 1u : 0u;
         readyConf_ = conf;
         bitReady_  = true;
@@ -221,7 +221,7 @@ bool AetherFMDiscrimDemod::try_demodulate(double sample, demod_result& result) n
     float cQ = convolve(cQBuf_.data(), lpCoeffs_.data(), lpTaps_);
 
     // 4. Instantaneous phase via atan2.
-    float phase = std::atan2f(cQ, cI);
+    float phase = std::atan2(cQ, cI);
 
     // 5. Differentiate phase → frequency deviation; handle ±π wrap.
     float rate = phase - prevPhase_;

--- a/third_party/direwolf_afsk/AetherFMDiscrimDemod.h
+++ b/third_party/direwolf_afsk/AetherFMDiscrimDemod.h
@@ -1,0 +1,101 @@
+// AetherFMDiscrimDemod.h
+//
+// AFSK FM-discriminator demodulator — AetherSDR / Profile B
+//
+// Derived from Dire Wolf by John Langner WB2OSZ
+// Copyright (C) 2011-2020 John Langner WB2OSZ
+// Dire Wolf: GPL-2.0-or-later — https://github.com/wb2osz/direwolf
+// AetherSDR: GPL-3.0-or-later — compatible via GPL-2.0-or-later upgrade path
+//
+// Algorithm: Direwolf profile-B (formerly D, renamed in v1.7)
+//   BPF → center-freq IQ mix → RRC LPF → atan2 → d/dt → normalize → DPLL
+//
+// Complements AetherAFSKDemod (profile A).  A uses separate mark/space
+// correlators; B uses a single FM discriminator at the center frequency.
+// They fail on different signal types so running both in parallel (AD+)
+// captures the widest range of real-world VHF FM packets.
+
+#pragma once
+
+#include "AetherAFSKDemod.h"   // for demod_result
+
+#include <cstdint>
+#include <vector>
+
+namespace AetherDemod {
+
+class AetherFMDiscrimDemod {
+public:
+    AetherFMDiscrimDemod() = default;
+
+    // sliceOffset: additive offset on the normalized discriminator output.
+    //   0.0f = single-slicer (B): decision at zero-crossing of norm_rate
+    //   non-zero = multi-slicer (B+): evenly spread -0.5 → +0.5 across bank
+    AetherFMDiscrimDemod(double fMark, double fSpace, int bitrate, int sampleRate,
+                         float sliceOffset = 0.0f);
+
+    bool try_demodulate(double sample, demod_result& result) noexcept;
+    bool try_demodulate(double sample, uint8_t& bit)         noexcept;
+
+    void reset() noexcept;
+
+private:
+    // Bandpass prefilter (wider than profile A: 0.19 × baud each side)
+    std::vector<float> preCoeffs_;
+    std::vector<float> preBuf_;
+    int preTaps_{0};
+
+    // Center-frequency free-running oscillator
+    uint32_t cOscPhase_{0};
+    uint32_t cOscDelta_{0};
+
+    // RRC lowpass — one coefficient set, two delay lines (I and Q)
+    std::vector<float> lpCoeffs_;
+    std::vector<float> cIBuf_, cQBuf_;
+    int lpTaps_{0};
+
+    // FM discriminator state
+    float prevPhase_{0.0f};
+    float normalizeRpsam_{0.0f};  // scales radians/sample → ±1 for mark/space
+
+    // Additive slice offset (B+ mode)
+    float sliceOffset_{0.0f};
+
+    // DPLL state (identical to profile A)
+    int32_t pll_{0};
+    int32_t prevPll_{0};
+    int32_t pllStep_{0};
+    bool    prevDemod_{false};
+    bool    dataDetect_{false};
+
+    // DCD sliding-window history
+    uint32_t goodHist_{0};
+    uint32_t badHist_{0};
+    uint32_t dcdScore_{0};
+
+    // Output latch
+    bool    bitReady_{false};
+    uint8_t readyBit_{0};
+    float   readyConf_{0.0f};
+
+    // 256-entry cosine table (shared across all instances of this class)
+    static float s_cosTable[256];
+    static bool  s_cosTableReady;
+    static void  buildCosTable() noexcept;
+
+    static inline float fcos(uint32_t phase) noexcept
+        { return s_cosTable[(phase >> 24) & 0xffu]; }
+    static inline float fsin(uint32_t phase) noexcept
+        { return s_cosTable[((phase >> 24) - 64u) & 0xffu]; }
+
+    void buildPrefilter(double fMark, double fSpace, int bitrate, int sampleRate) noexcept;
+    void buildRrcLowpass(int bitrate, int sampleRate) noexcept;
+
+    static float  convolve  (const float* __restrict__ data,
+                              const float* __restrict__ coeffs, int taps) noexcept;
+    static void   pushSample(float val, float* buf, int size) noexcept;
+
+    void nudgePll(float demodOut) noexcept;
+};
+
+} // namespace AetherDemod

--- a/third_party/direwolf_afsk/README.aethersdr.md
+++ b/third_party/direwolf_afsk/README.aethersdr.md
@@ -1,0 +1,39 @@
+# AetherSDR direwolf-afsk subset
+
+This directory contains an algorithmic derivation of the Dire Wolf "profile A"
+AFSK demodulator, rewritten in self-contained C++ for AetherSDR's VHF 1200 baud
+AX.25 receive path.
+
+Upstream: https://github.com/wb2osz/direwolf
+Reference release: Dire Wolf 1.7
+Referenced files: `src/demod_afsk.c` (profile A), `src/dsp.c`
+License: GPL-2.0-or-later (Dire Wolf) — compatible into AetherSDR's GPL-3.0-or-later
+
+This is an algorithmic derivation, not a verbatim copy. The algorithm
+(bandpass prefilter → IQ mixing → RRC lowpass → amplitude → peak/valley AGC →
+DPLL) is derived from profile A in `demod_afsk.c`. Filter design helpers are
+derived from `dsp.c`. All code was rewritten in idiomatic C++20.
+
+## Files
+
+- `AetherAFSKDemod.h` — class definition + `sinc_corr_afsk_demodulator` alias
+- `AetherAFSKDemod.cpp` — full implementation
+
+## Usage
+
+Used unconditionally for the `Ax25ModemProfile::Vhf1200` (1200 baud Bell 202)
+demodulation path in `AetherAx25LibmodemShim`. The `Ax25ModemProfile::Hf300`
+path continues to use `aether_libmodem_core::sinc_corr_afsk_demodulator`.
+
+## Intentionally omitted
+
+All Dire Wolf application infrastructure: audio backends, KISS TNC server,
+GPS/APRS clients, digipeater, IGate, configuration parser, IL2P/FX.25,
+multi-channel engine, PTT drivers, and build system.
+
+## Refresh notes
+
+1. Review upstream changes to `src/demod_afsk.c` and `src/dsp.c` for any
+   profile-A algorithm improvements.
+2. Re-derive and rewrite into `AetherAFSKDemod.cpp` as needed.
+3. Validate decode rate against Direwolf and Graywolf on live APRS audio.


### PR DESCRIPTION
AetherSDR's VHF 1200 baud AX.25 decode rate was 27% of Direwolf's on identical audio. This PR brings it to 96% on the default A+ profile — matching and slightly exceeding both Direwolf and Graywolf — by replacing the libmodem sinc-correlator with a Direwolf-derived AFSK demodulator.

## Summary

Three branches of development have been squashed into a single commit for review:
- `feat/aether-afsk-demod` — Direwolf-derived AFSK demodulator, Profile A
- `feat/aether-afsk-profile-b` — full 6-mode selector (A / B / AB / A+ / B+ / AB+)
- `feat/ax25-shim-worker-thread` — worker thread + full 9-slicer bank + HdlcCodec Phase 1a+1b

Also addresses #3387.

## Relationship to issue #2701

Issue #2701 describes a phased roadmap for a native Soft-TNC. This PR lands the following pieces of that plan:

**Phase 1a — `HdlcCodec`** (`src/core/tnc/HdlcCodec.{h,cpp}` + `tests/hdlc_codec_test.cpp`): the native HDLC framing layer called out in the plan. 27 unit tests; CRC-16-CCITT cross-checked against both Direwolf and graywolf as the plan specified. This is the first of the planned test suite to land.

**Phase 2 — AFSK demodulator**: the plan described a "correlator-difference AFSK demod + early-late symbol clock" for a new `ClientTnc`. Rather than build a new wrapper, we replaced the demodulator inside the existing `AetherAx25LibmodemShim`, producing a working VHF 1200 baud decode path without disrupting the surrounding architecture. The demodulator is Direwolf-derived (Profiles A/B/AB/A+/B+/AB+). AX.25 structure parsing remains on libmodem for now.

**Threading**: The plan describes `ClientTnc` running inline on the `AudioEngine` thread. We chose a dedicated `QThread` instead — see the Worker thread section below for the reasoning.

## Changes

### 1. Direwolf-derived AFSK demodulator (`third_party/direwolf_afsk/`)

Replaces `lm::sinc_corr_afsk_demodulator` for VHF 1200 baud. HF 300 baud continues to use libmodem unchanged.

**Source location:** `third_party/direwolf_afsk/`, following the `libmodem_core/` subset pattern. `README.aethersdr.md` records the upstream release, referenced files, license compatibility rationale, and what was omitted. `THIRD_PARTY_LICENSES` updated.

**License:** Direwolf is GPL-2-or-later. AetherSDR is GPL-3. GPL-2-or-later is one-way compatible into GPL-3 (FSF). Source headers reflect GPL-3, not the previously-cited GPL-2+.

**Six VHF modes** exposed via a new `VhfMode` enum and runtime `QComboBox` selector. The `AETHERSDR_USE_AETHERDEMOD` compile-time switch from the initial draft has been removed — VHF 1200 always uses the Direwolf-derived path. The selector is disabled when HF 300 is active:

| Mode | Description | Lanes |
|---|---|---|
| **Off** | VHF demodulation disabled | 0 |
| **A** | IQ-mix · 1 slicer | 1 |
| **B** | FM discriminator · 1 slicer | 1 |
| **AB** | IQ-mix + FM discriminator · 1 slicer each | 2 |
| **A+** | IQ-mix · 9 slicers (Direwolf default) | 9 |
| **B+** | FM discriminator · 9 slicers | 9 |
| **AB+** | IQ-mix + FM discriminator · 9 slicers each | 18 |

Default is **A+**, matching Direwolf's `MODEM 1200` default.

**Profile A** (`AetherAFSKDemod`): IQ-mix + RRC + DPLL, space-gain bank. The A+ 9-slicer values `{0.500, 0.648, 0.841, 1.091, 1.414, 1.834, 2.378, 3.084, 4.000}` are the exact geometric series from Direwolf's `demod_afsk.c` (`MAX_SUBCHANS=9`), compensating for VHF FM de-emphasis on the 2200 Hz space tone.

**Profile B** (`AetherFMDiscrimDemod`): FM discriminator — IQ-mix → `atan2` → phase rate → normalize. Targets signals where amplitude balance between mark and space is unreliable (frequency-offset stations, Doppler, weak paths). Complements A+: each catches signals the other misses. The B+ 9 slice offsets `{−0.500, −0.375, …, 0.500}` match Direwolf's `MAX_SLICERS=9` linear series.

<img width="1048" height="150" alt="Screenshot 2026-06-08 at 08 18 42" src="https://github.com/user-attachments/assets/5cc6ed55-abc0-49fd-a7a8-46c3f8c2509a" />

<img width="378" height="168" alt="Screenshot 2026-06-08 at 08 18 56" src="https://github.com/user-attachments/assets/ffd5fe42-8fce-4e01-8d75-55b9c5b9b60a" />

### 2. Worker thread

`AetherAx25LibmodemShim` now runs entirely on a dedicated `QThread` (`m_shimThread`) owned by `Ax25HfPacketDecodeDialog`. Both the VHF (AetherAFSKDemod) and HF 300 baud (libmodem) paths run through the same `feedAudio()` entry point, so both move to the worker thread automatically.

Issue #2701 describes the long-term `ClientTnc` architecture running inline on the `AudioEngine` thread. We chose a dedicated worker thread instead, for two reasons:

- **The original shim ran on the GUI thread.** Multi-lane AFSK demodulation is heavy enough to cause visible UI degradation, and the RPi 5 demonstrated that audio sampling was also affected. Isolating the demod to its own thread keeps both the UI and the audio path responsive. In AB+ mode (18 lanes) on the RPi 5, the demod worker uses approximately 23% of one core.
- **The AudioEngine thread is** real-time / high-priority; blocking it with a 9–18 lane correlator bank would cause glitches in the waterfall, RX audio, and QSO recording. The roadmap's AudioEngine-thread approach assumes a lightweight single-lane demodulator; this implementation is considerably heavier.

When the roadmap's `ClientTnc` is eventually built as a lightweight single-lane demodulator, the AudioEngine-thread approach may be appropriate for that path. The shim stays on its dedicated worker.

Implementation details:
- Cross-thread calls (`configure()`, `reset()`, `feedAudio()`, `setDiagnosticsLoggingEnabled()`) dispatched via `QMetaObject::invokeMethod` with `Qt::QueuedConnection`
- A main-thread `Ax25DemodConfig` cache eliminates cross-thread reads on the hot path
- Signal connections (`frameDecoded`, `diagnosticsUpdated`, `statusChanged`) use `AutoConnection` — Qt resolves these to `QueuedConnection` automatically

Audio sampling is unaffected even when running under AddressSanitizer on the RPi 5.

### 3. HdlcCodec — Phase 1a (new file: `src/core/tnc/HdlcCodec.{h,cpp}`)

Standalone native HDLC framing class replacing `lm::ax25::bitstream_state` in the decode lanes. Pure C++, no Qt, no libmodem dependency.

Implements: NRZI decode, bit-stuffing, CRC-16-CCITT (0x8408, poly bit-reversed, init/final XOR 0xFFFF), LSB-first byte assembly. State machine: `Searching → InPreamble → InFrame → Complete/Aborted`.

Verified algorithmically equivalent to both Direwolf (`hdlc_rec.c` / `fcs_calc.c`) and libmodem before replacement. 27/27 unit tests in `tests/hdlc_codec_test.cpp`.

### 4. HdlcCodec — Phase 1b (integrated into `AetherAx25LibmodemShim`)

`DecodeLane` members replaced:
- `lm::ax25::bitstream_state bitstreamState` → `HdlcCodec hdlcCodec`
- `std::vector<uint8_t> bitstreamBuffer` → removed (internal to HdlcCodec)
- `std::array<uint8_t, 1000> candidateFrameBytes` → removed (use `hdlcCodec.frameData()`)

libmodem is retained for `try_decode_frame_no_fcs` (AX.25 structure parsing) and the TX packet builder. The HF 300 baud demodulator (`lm::sinc_corr_afsk_demodulator`) is also unchanged.

### 5. MSVC compatibility

`third_party/direwolf_afsk`: GNU `__builtin_expect` replaced with standard `[[likely]]`/`[[unlikely]]`; VLAs replaced with `std::vector`.

## Addressing #3387 triage items

**License (point 1):** Confirmed — AetherSDR is GPL-3, not GPL-2+. Direwolf GPL-2-or-later is compatible. Source headers corrected.

**Vendoring (point 2):** Direwolf sources are in `third_party/direwolf_afsk/` with `README.aethersdr.md`, matching the `libmodem_core/` pattern. `THIRD_PARTY_LICENSES` updated.

**HF 300 coverage (point 3):** The Direwolf path is VHF 1200 only. The `VhfMode` selector is disabled for HF 300. HF 300 parity is a separate future item.

**Framing layer scope (point 4):** We went one step further than the triage suggested and also replaced the HDLC framing layer (Phase 1a+1b). Justification: analysis of Direwolf's `hdlc_rec.c` and libmodem confirmed they are algorithmically identical — same NRZI formula, same bit-stuffing check, same CRC polynomial, same byte alignment rule. The decode gap is entirely in the AFSK demodulator. Replacing libmodem's HDLC gives clean ownership of the framing layer, enables future instrumentation, and is required for the Phase 2 roadmap. The blast radius is low: the AX.25 structure parser (`try_decode_frame_no_fcs`) and TX path remain on libmodem.

**Long-term build switch (point 5):** The `AETHERSDR_USE_AETHERDEMOD` compile switch is removed. VHF 1200 always uses the Direwolf-derived demodulator. The runtime `VhfMode` selector (default A+) gives operators the tradeoff knob.

## Performance

The original comparison cited in #3387 was libmodem 777 vs Direwolf 2891 over the same audio (3.7×). Long-duration live comparisons on 144.390 MHz APRS on a Raspberry Pi 5 show AetherSDR at or above parity with both Direwolf and Graywolf on the default A+ profile:

**A+ mode (default) — 987 packets heard:**

| Decoder | Frames | % of all | Avg quality |
|---|---|---|---|
| AetherSDR | 946 | 96% | confidence 61 |
| Direwolf | 940 | 95% | level 58 |
| Graywolf | 933 | 95% | confidence 54 |

**AB+ mode (18 lanes) — 2,405 packets heard, 12-hour run:**

| Decoder | Frames | % of all | Avg quality |
|---|---|---|---|
| AetherSDR | 2230 | 93% | confidence 64 |
| Graywolf | 2326 | 97% | confidence 55 |
| Direwolf | 2329 | 97% | level 29 |

On A+, AetherSDR leads both reference decoders. The AB+ result (4 points behind) is characterised by the confidence data: AetherSDR's average confidence on missed packets (GW+DW only: 23 frames, confidence 57–59) is marginally lower than on all-three packets (61), indicating conservative behaviour on the very weakest signals rather than systematic error. AetherSDR's false-positive rate is effectively zero in both datasets.

## Comparison methodology

Decode performance was measured using a three-decoder comparison running continuously on a Raspberry Pi 5, listening to live 144.390 MHz APRS traffic via a FlexRadio 6600. All three decoders ran on separate slice receivers, each receiving the same 144.390 MHz signal. Direwolf and Graywolf listened to DAX audio streams from their respective slices; AetherSDR's internal decoder published decoded frames via MQTT.

**Comparator:** A purpose-built Python webapp subscribes to all three sources simultaneously — MQTT for AetherSDR, REST API polling for Graywolf, and subprocess stdout for Direwolf. Frames are matched within a 5-second window on content. Duplicate copies of the same RF burst (digipeated repeats) are counted once per decoder, making the totals directly comparable. A live browser UI and analysis endpoint show per-decoder counts and decode-combination breakdowns in real time.

**Quality metrics:** Each decoder was instrumented to report a signal quality value alongside each decoded frame — AetherSDR's existing `confidence` field (0–1, from the MQTT payload), Graywolf's `decoded.quality` field from its REST response, and Direwolf's per-bit EMA quality from its `q=N` audio level line. These were used to characterise the missed-packet population rather than as a pass/fail threshold.

## What does not change

- HF 300 baud decode path — unchanged, still uses libmodem
- AX.25 structure parsing (`try_decode_frame_no_fcs`) — unchanged, still libmodem
- TX audio generation — unchanged
- KISS TNC, TCI server, MQTT paths — unchanged

## Testing

**`tests/hdlc_codec_test.cpp`** — 27 tests, all pass.

Built against both `HdlcCodec` and libmodem simultaneously, using libmodem as ground truth:

| Test | What it covers |
|---|---|
| `testStateTransitions` | Initial state (Searching); single-flag NRZI input transitions to InPreamble |
| `testSingleFrame` | Libmodem-encoded AX.25 packet round-trips through HdlcCodec; exactly one frame detected, FCS valid |
| `testFrameContents` | Decoded frame bytes passed to `lm::ax25::try_decode_frame_no_fcs`; callsigns and payload match the encoded packet |
| `testFcsMatchesLibmodem` | HdlcCodec's computed FCS compared byte-for-byte against `lm::ax25::compute_crc` — both produce identical CRC-16-CCITT values |
| `testBadFcs` | Single bit-flip in a valid frame produces a frame candidate with FCS failure |
| `testTwoConsecutiveFrames` | Two frames with correct NRZI continuity both decode with valid FCS |
| `testPreambleCount` | Preamble flag counter reflects the encoded preamble length |
| `testReset` | After decoding, `reset()` returns to Searching state; same bitstream decodes again cleanly |
| `testLongPayload` | 256-byte payload exercises the frame buffer boundary |

The `testFcsMatchesLibmodem` test is the key cross-check called out in the #2701 plan — it proves HdlcCodec and libmodem compute the same CRC-16-CCITT over identical frame bytes, ruling out the polynomial/init/final-XOR mismatch the plan specifically flagged as a risk.

**`tests/ax25_libmodem_shim_test`** — 120 tests, all pass. Covers the full shim end-to-end: AFSK loopback (HF 300 and VHF 1200), TX/RX round-trips, KISS framing, diagnostics, and bad-FCS detection. This suite exercises HdlcCodec through the shim integration, confirming the Phase 1b replacement did not change observable behaviour.

Live VHF decode confirmed on 144.390 MHz on macOS (Apple Silicon M2), Raspberry Pi 5, and Windows 11.

---

Built and smoke tested on: MacBook Air M2 / RPi 5 Debian trixie / Windows 11 on Intel i3

---

Happy to split into separate PRs (demodulator / worker thread / HdlcCodec) if that makes review easier — the three areas are independent once the lane-management interface is stable.