### PR TITLE
fix(rc28): replace counter dedup with velocity-proportional tuning

### DIFF
--- a/src/core/HidDeviceParser.cpp
+++ b/src/core/HidDeviceParser.cpp
@@ -43,12 +43,12 @@ std::unique_ptr<HidDeviceParser> HidDeviceParser::create(uint16_t vid, uint16_t 
 
 // ── Icom RC-28 ──────────────────────────────────────────────────────────────
 // 32-byte reports, no report ID prefix on any platform (hidraw returns 32 bytes).
-// Verified layout (cross-referenced against FlexRC-28 open-source driver):
+// Verified layout (cross-referenced against FlexRC-28 driver and wfview source):
 //   [0] = 0x01 constant — guard byte, discard report if != 0x01
-//   [1] = detent counter (increments each click; device sends burst of identical
-//         reports per detent — deduplicate on this field)
+//   [1] = rotation speed (encoder pulse count since last report; higher = faster turn)
+//         NOT a monotonic counter — stays at 1 during slow continuous rotation
 //   [2] = 0x00 (unused)
-//   [3] = direction: 0x01 = CW, 0x02 = CCW
+//   [3] = direction: 0x01 = CW, 0x02 = CCW; stays set while rotating, 0x00 when idle
 //   [4] = 0x00 (unused)
 //   [5] = button state bitmask (active-low): 0x07 = all idle,
 //         bit0=TX/PTT, bit1=F1, bit2=F2
@@ -58,9 +58,9 @@ HidEvent IcomRC28Parser::parse(const uint8_t* buf, size_t len)
     if (len < 6) return {};
     if (buf[0] != 0x01) return {};
 
-    const uint8_t counter = buf[1];
-    const uint8_t dir     = buf[3];
-    const uint8_t btns    = buf[5];
+    const uint8_t speed = buf[1];
+    const uint8_t dir   = buf[3];
+    const uint8_t btns  = buf[5];
 
     // Button events (active-low bitmask → same enum values as before).
     if (btns != m_prevButtonState) {
@@ -78,10 +78,12 @@ HidEvent IcomRC28Parser::parse(const uint8_t* buf, size_t len)
         }
     }
 
-    // Rotation: deduplicate on counter to emit exactly one step per detent.
-    if ((dir == 0x01 || dir == 0x02) && counter != m_prevCounter) {
-        m_prevCounter = counter;
-        return {HidEvent::Rotate, (dir == 0x01) ? 1 : -1, 0, 0};
+    // Rotation: one event per report, magnitude proportional to speed (buf[1]).
+    // Guard: skip when any button is held (btns != 0x07) so accidental knob
+    // movement during button presses doesn't retune — matches wfview behaviour.
+    if (btns == 0x07 && speed > 0 && (dir == 0x01 || dir == 0x02)) {
+        const int sign = (dir == 0x01) ? 1 : -1;
+        return {HidEvent::Rotate, sign * static_cast<int>(speed), 0, 0};
     }
 
     return {};

--- a/src/core/HidDeviceParser.h
+++ b/src/core/HidDeviceParser.h
@@ -36,16 +36,16 @@ public:
 
 // Icom RC-28 (VID 0x0C26, PID 0x001E)
 // 32-byte reports, no report ID prefix (hidraw returns exactly 32 bytes).
-// Actual layout (verified from hardware): [0]=0x01 constant, [1]=detent counter,
-// [2]=0x00, [3]=direction (0x01=CW, 0x02=CCW), [4]=0x00, [5]=button state enum.
-// The device sends multiple identical reports per detent; deduplicate on counter.
+// Actual layout (verified from hardware, FlexRC-28 driver, and wfview):
+//   [0]=0x01 constant, [1]=rotation speed (pulse count, NOT a monotonic counter),
+//   [2]=0x00, [3]=direction (0x01=CW, 0x02=CCW, stays set while rotating),
+//   [4]=0x00, [5]=button state (active-low bitmask, 0x07=all idle).
 class IcomRC28Parser : public HidDeviceParser {
 public:
     HidEvent parse(const uint8_t* buf, size_t len) override;
     size_t reportSize() const override { return 32; }
 private:
     uint8_t m_prevButtonState{0x07};  // 0x07 = all released (idle)
-    uint8_t m_prevCounter{0xff};
 };
 
 // Griffin PowerMate (VID 0x077D, PID 0x0410)


### PR DESCRIPTION
Fixes #3395

## Root cause

`buf[1]` in the RC-28 HID report is **not** a monotonic per-detent counter — it is an encoder pulse count (rotation speed) since the last report. The previous dedup condition `counter != m_prevCounter` suppressed all rotation events as soon as `buf[1]` stabilised at a constant value, which is exactly what the device does during slow continuous rotation (buf[1]=1 for every report). Result: slow continuous rotation emitted exactly **one** step total regardless of how long the knob was turned, making precise sub-kHz tuning impossible on all platforms.

The bot's issue analysis correctly identified the `dir==0x00` edge case on Windows, but the counter-dedup logic is the primary bug and affects Linux and macOS equally.

## Changes

- `buf[1]` renamed from `counter` to `speed` throughout
- Rotation condition changed from `counter != m_prevCounter` to `btns == 0x07 && speed > 0 && (dir == 0x01 || dir == 0x02)`
- Step magnitude changed from fixed `±1` to `sign * static_cast<int>(speed)` — velocity-proportional: slow turn = 1 step/report, fast turn = 10–35 steps/report
- `m_prevCounter` member variable removed from `IcomRC28Parser`
- Added button-held guard (`btns == 0x07`): accidental knob movement while pressing F1/F2/PTT no longer retunes the radio
- Comment blocks in both `.cpp` and `.h` updated to correctly document the wire protocol

## Cross-reference

This fix aligns with two independent open-source RC-28 implementations:

- **[CerberusSolutions/FlexRC-28](https://github.com/CerberusSolutions/FlexRC-28)** (`src/rc28.js`): explicitly names `data[1]` as `speed` and emits it directly as step magnitude with no counter-based dedup
- **[eliggett/wfview](https://gitlab.com/eliggett/wfview)** (`usbcontroller.cpp`): does `value += data[1]` / `value -= data[1]` per report, and gates rotation behind `data[5] == 0x07` (the button-held guard we adopted)

## Testing

- Tested on **Debian 13 Trixie** with a physical **Icom RC-28** (VID `0x0C26`, PID `0x001E`)
- Slow continuous rotation: `buf[1]=1` constant, 1 step emitted per report — tracks correctly at every step size
- Fast rotation: `buf[1]` reaches 20–35, proportionally larger frequency jumps
- Button press/release detection unchanged and verified
- Button-held guard verified: knob movement during F1/F2 hold does not change frequency
- Build: clean on Debian 13 Trixie, Qt 6.x, GCC, `HAVE_HIDAPI` enabled