### PR TITLE
feat(gui): Help → Check for Updates — phase 1 of #3413

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,6 +549,7 @@ set(CORE_SOURCES
     src/core/ProfileTransfer.cpp
     src/core/QsoRecorder.cpp
     src/core/FirmwareStager.cpp
+    src/core/UpdateChecker.cpp
     src/core/OleCompoundFile.cpp
     src/core/CabExtractor.cpp
     src/core/RNNoiseFilter.cpp

--- a/src/core/UpdateChecker.cpp
+++ b/src/core/UpdateChecker.cpp
@@ -1,0 +1,49 @@
+#include "UpdateChecker.h"
+#include "VersionNumber.h"
+
+#include <QCoreApplication>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+
+namespace AetherSDR {
+
+static constexpr char kReleasesApiUrl[] =
+    "https://api.github.com/repos/aethersdr/AetherSDR/releases/latest";
+
+UpdateChecker::UpdateChecker(QObject* parent)
+    : QObject(parent)
+{}
+
+void UpdateChecker::checkNow()
+{
+    QNetworkRequest req{QUrl{QString(kReleasesApiUrl)}};
+    req.setRawHeader("Accept", "application/vnd.github+json");
+    req.setRawHeader("X-GitHub-Api-Version", "2022-11-28");
+
+    auto* reply = m_nam.get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError)
+            return;
+
+        const auto doc = QJsonDocument::fromJson(reply->readAll());
+        if (doc.isNull()) return;
+
+        const QString tag = doc.object().value("tag_name").toString();
+        if (tag.isEmpty()) return;
+
+        const QString current = QCoreApplication::applicationVersion();
+        const auto latest  = VersionNumber::parse(tag);
+        const auto running = VersionNumber::parse(current);
+
+        if (latest > running)
+            emit updateAvailable(tag.startsWith('v') ? tag.mid(1) : tag);
+        else
+            emit upToDate(current);
+    });
+}
+
+} // namespace AetherSDR

--- a/src/core/UpdateChecker.cpp
+++ b/src/core/UpdateChecker.cpp
@@ -19,25 +19,36 @@ UpdateChecker::UpdateChecker(QObject* parent)
 
 void UpdateChecker::checkNow()
 {
+    if (m_inFlight) return;
+    m_inFlight = true;
+
     QNetworkRequest req{QUrl{QString(kReleasesApiUrl)}};
     req.setRawHeader("Accept", "application/vnd.github+json");
     req.setRawHeader("X-GitHub-Api-Version", "2022-11-28");
+    req.setRawHeader("User-Agent",
+        QByteArrayLiteral("AetherSDR/") + QCoreApplication::applicationVersion().toUtf8());
 
     auto* reply = m_nam.get(req);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         reply->deleteLater();
-        if (reply->error() != QNetworkReply::NoError)
+        m_inFlight = false;
+
+        if (reply->error() != QNetworkReply::NoError) {
+            emit checkFailed();
             return;
+        }
 
         const auto doc = QJsonDocument::fromJson(reply->readAll());
-        if (doc.isNull()) return;
+        if (doc.isNull()) { emit checkFailed(); return; }
 
         const QString tag = doc.object().value("tag_name").toString();
-        if (tag.isEmpty()) return;
+        if (tag.isEmpty()) { emit checkFailed(); return; }
 
         const QString current = QCoreApplication::applicationVersion();
         const auto latest  = VersionNumber::parse(tag);
         const auto running = VersionNumber::parse(current);
+
+        if (latest.isNull()) { emit checkFailed(); return; }
 
         if (latest > running)
             emit updateAvailable(tag.startsWith('v') ? tag.mid(1) : tag);

--- a/src/core/UpdateChecker.cpp
+++ b/src/core/UpdateChecker.cpp
@@ -27,6 +27,7 @@ void UpdateChecker::checkNow()
     req.setRawHeader("X-GitHub-Api-Version", "2022-11-28");
     req.setRawHeader("User-Agent",
         QByteArrayLiteral("AetherSDR/") + QCoreApplication::applicationVersion().toUtf8());
+    req.setTransferTimeout(15000);
 
     auto* reply = m_nam.get(req);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {

--- a/src/core/UpdateChecker.h
+++ b/src/core/UpdateChecker.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QNetworkAccessManager>
+#include <QObject>
+
+namespace AetherSDR {
+
+// Checks the GitHub releases API for a newer AetherSDR version.
+// All network errors are swallowed silently — no UI noise on failure.
+class UpdateChecker : public QObject {
+    Q_OBJECT
+public:
+    static constexpr char kReleasesPageUrl[] =
+        "https://github.com/aethersdr/AetherSDR/releases/latest";
+
+    explicit UpdateChecker(QObject* parent = nullptr);
+    void checkNow();
+
+signals:
+    void updateAvailable(const QString& latestVersion);
+    void upToDate(const QString& currentVersion);
+
+private:
+    QNetworkAccessManager m_nam;
+};
+
+} // namespace AetherSDR

--- a/src/core/UpdateChecker.h
+++ b/src/core/UpdateChecker.h
@@ -6,7 +6,7 @@
 namespace AetherSDR {
 
 // Checks the GitHub releases API for a newer AetherSDR version.
-// All network errors are swallowed silently — no UI noise on failure.
+// kReleasesPageUrl is the browser-facing page; the API endpoint lives in the .cpp.
 class UpdateChecker : public QObject {
     Q_OBJECT
 public:
@@ -19,9 +19,11 @@ public:
 signals:
     void updateAvailable(const QString& latestVersion);
     void upToDate(const QString& currentVersion);
+    void checkFailed();
 
 private:
     QNetworkAccessManager m_nam;
+    bool m_inFlight = false;
 };
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -188,6 +188,8 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include "core/VersionNumber.h"
+#include "core/UpdateChecker.h"
+#include <QDesktopServices>
 #include <QPointer>
 #include <QTextEdit>
 #include <QPlainTextEdit>
@@ -9860,6 +9862,9 @@ void MainWindow::buildMenuBar()
                                        });
         dlg.exec();
     });
+    helpMenu->addAction("Check for Updates...", this, [this]() {
+        m_updateChecker->checkNow();
+    });
     helpMenu->addSeparator();
     helpMenu->addAction("About AetherSDR", this, [this]{
         auto* dlg = new QDialog(this);
@@ -10901,6 +10906,32 @@ void MainWindow::buildUI()
     hbox->addWidget(timeStack);
 
     statusBar()->addWidget(container, 1);
+
+    m_updateChecker = new UpdateChecker(this);
+    connect(m_updateChecker, &UpdateChecker::updateAvailable, this, [this](const QString& ver) {
+        const QString current = QCoreApplication::applicationVersion();
+        QMessageBox box(this);
+        box.setWindowTitle("AetherSDR Update Available");
+        box.setIcon(QMessageBox::Information);
+        box.setText(QString("AetherSDR v%1 is available.").arg(ver));
+        box.setInformativeText(QString("You are running v%1.").arg(current));
+        QPushButton* viewBtn = box.addButton("View Latest Release", QMessageBox::ActionRole);
+        viewBtn->setAutoDefault(false);
+        QPushButton* closeBtn = box.addButton(QMessageBox::Close);
+        closeBtn->setAutoDefault(false);
+        // Force minimum width via layout spacer — setMinimumWidth() is ignored by QMessageBox
+        if (auto* grid = qobject_cast<QGridLayout*>(box.layout()))
+            grid->addItem(new QSpacerItem(480, 0, QSizePolicy::Minimum, QSizePolicy::Expanding),
+                          grid->rowCount(), 0, 1, grid->columnCount());
+        box.exec();
+        if (box.clickedButton() == viewBtn)
+            QDesktopServices::openUrl(QUrl(UpdateChecker::kReleasesPageUrl));
+    });
+    connect(m_updateChecker, &UpdateChecker::upToDate, this, [this](const QString& ver) {
+        QMessageBox::information(this, "Check for Updates",
+            QString("AetherSDR is up to date (v%1).").arg(ver));
+    });
+
     updateBandStackIndicator();
 
     // S History Markers expiry — sweeps stale detections once per second

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1672,7 +1672,7 @@ MainWindow::MainWindow(QWidget* parent)
         closeBtn->setAutoDefault(false);
         // Force minimum width via layout spacer — setMinimumWidth() is ignored by QMessageBox
         if (auto* grid = qobject_cast<QGridLayout*>(box.layout()))
-            grid->addItem(new QSpacerItem(480, 0, QSizePolicy::Minimum, QSizePolicy::Expanding),
+            grid->addItem(new QSpacerItem(480, 0, QSizePolicy::Minimum, QSizePolicy::Fixed),
                           grid->rowCount(), 0, 1, grid->columnCount());
         box.exec();
         if (box.clickedButton() == viewBtn)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10936,7 +10936,6 @@ void MainWindow::buildUI()
     hbox->addWidget(timeStack);
 
     statusBar()->addWidget(container, 1);
-
     updateBandStackIndicator();
 
     // S History Markers expiry — sweeps stale detections once per second

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1657,6 +1657,36 @@ MainWindow::MainWindow(QWidget* parent)
     m_bandPlanMgr = new BandPlanManager(this);
     m_bandPlanMgr->loadPlans();
 
+    // UpdateChecker — must be created before buildMenuBar() which references it
+    m_updateChecker = new UpdateChecker(this);
+    connect(m_updateChecker, &UpdateChecker::updateAvailable, this, [this](const QString& ver) {
+        const QString current = QCoreApplication::applicationVersion();
+        QMessageBox box(this);
+        box.setWindowTitle("AetherSDR Update Available");
+        box.setIcon(QMessageBox::Information);
+        box.setText(QString("AetherSDR v%1 is available.").arg(ver));
+        box.setInformativeText(QString("You are running v%1.").arg(current));
+        QPushButton* viewBtn = box.addButton("View Latest Release", QMessageBox::ActionRole);
+        viewBtn->setAutoDefault(false);
+        QPushButton* closeBtn = box.addButton(QMessageBox::Close);
+        closeBtn->setAutoDefault(false);
+        // Force minimum width via layout spacer — setMinimumWidth() is ignored by QMessageBox
+        if (auto* grid = qobject_cast<QGridLayout*>(box.layout()))
+            grid->addItem(new QSpacerItem(480, 0, QSizePolicy::Minimum, QSizePolicy::Expanding),
+                          grid->rowCount(), 0, 1, grid->columnCount());
+        box.exec();
+        if (box.clickedButton() == viewBtn)
+            QDesktopServices::openUrl(QUrl(UpdateChecker::kReleasesPageUrl));
+    });
+    connect(m_updateChecker, &UpdateChecker::upToDate, this, [this](const QString& ver) {
+        QMessageBox::information(this, "Check for Updates",
+            QString("AetherSDR is up to date (v%1).").arg(ver));
+    });
+    connect(m_updateChecker, &UpdateChecker::checkFailed, this, [this]() {
+        QMessageBox::warning(this, "Check for Updates",
+            "Could not reach GitHub. Check your connection and try again.");
+    });
+
     buildMenuBar();
     buildUI();
 #ifdef Q_OS_WIN
@@ -10906,35 +10936,6 @@ void MainWindow::buildUI()
     hbox->addWidget(timeStack);
 
     statusBar()->addWidget(container, 1);
-
-    m_updateChecker = new UpdateChecker(this);
-    connect(m_updateChecker, &UpdateChecker::updateAvailable, this, [this](const QString& ver) {
-        const QString current = QCoreApplication::applicationVersion();
-        QMessageBox box(this);
-        box.setWindowTitle("AetherSDR Update Available");
-        box.setIcon(QMessageBox::Information);
-        box.setText(QString("AetherSDR v%1 is available.").arg(ver));
-        box.setInformativeText(QString("You are running v%1.").arg(current));
-        QPushButton* viewBtn = box.addButton("View Latest Release", QMessageBox::ActionRole);
-        viewBtn->setAutoDefault(false);
-        QPushButton* closeBtn = box.addButton(QMessageBox::Close);
-        closeBtn->setAutoDefault(false);
-        // Force minimum width via layout spacer — setMinimumWidth() is ignored by QMessageBox
-        if (auto* grid = qobject_cast<QGridLayout*>(box.layout()))
-            grid->addItem(new QSpacerItem(480, 0, QSizePolicy::Minimum, QSizePolicy::Expanding),
-                          grid->rowCount(), 0, 1, grid->columnCount());
-        box.exec();
-        if (box.clickedButton() == viewBtn)
-            QDesktopServices::openUrl(QUrl(UpdateChecker::kReleasesPageUrl));
-    });
-    connect(m_updateChecker, &UpdateChecker::upToDate, this, [this](const QString& ver) {
-        QMessageBox::information(this, "Check for Updates",
-            QString("AetherSDR is up to date (v%1).").arg(ver));
-    });
-    connect(m_updateChecker, &UpdateChecker::checkFailed, this, [this]() {
-        QMessageBox::warning(this, "Check for Updates",
-            "Could not reach GitHub. Check your connection and try again.");
-    });
 
     updateBandStackIndicator();
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10931,6 +10931,10 @@ void MainWindow::buildUI()
         QMessageBox::information(this, "Check for Updates",
             QString("AetherSDR is up to date (v%1).").arg(ver));
     });
+    connect(m_updateChecker, &UpdateChecker::checkFailed, this, [this]() {
+        QMessageBox::warning(this, "Check for Updates",
+            "Could not reach GitHub. Check your connection and try again.");
+    });
 
     updateBandStackIndicator();
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -88,6 +88,7 @@ class NetworkDiagnosticsDialog;
 class AgcCalibrationDialog;
 class MemoryDialog;
 class PropDashboardDialog;
+class UpdateChecker;
 class TxBandDialog;
 class AetherDspDialog;
 class MqttSettingsDialog;
@@ -905,6 +906,7 @@ private:
     bool m_waitingForFirstPanadapterFrame{false};
     QString m_panadapterConnectionAnimationLabel;
     ShortcutManager m_shortcutManager;
+    UpdateChecker* m_updateChecker{nullptr};
 
 #ifdef HAVE_RADE
     RADEEngine* m_radeEngine{nullptr};

--- a/src/gui/WhatsNewDialog.cpp
+++ b/src/gui/WhatsNewDialog.cpp
@@ -1,4 +1,5 @@
 #include "WhatsNewDialog.h"
+#include "core/UpdateChecker.h"
 #include "core/VersionNumber.h"
 #include "core/AppSettings.h"
 
@@ -299,7 +300,7 @@ void WhatsNewDialog::buildUI(const QString& lastSeenVersion,
         upgradeBtn->setCursor(Qt::PointingHandCursor);
         upgradeBtn->setStyleSheet(secondaryButtonStyle());
         connect(upgradeBtn, &QPushButton::clicked, this, [this] {
-            QDesktopServices::openUrl(QUrl("https://github.com/aethersdr/AetherSDR/releases/latest"));
+            QDesktopServices::openUrl(QUrl(AetherSDR::UpdateChecker::kReleasesPageUrl));
             close();
         });
         footerLayout->addWidget(upgradeBtn, 0, Qt::AlignCenter);


### PR DESCRIPTION
Closes #3413 (phase 1 — see scope section below for what remains)

## Summary

Adds **Help → Check for Updates…** — an on-demand update check that fires only when the operator explicitly requests it. This is the minimum viable slice of #3413 that gets the core network/comparison machinery in place without committing to a persistent-notification UX that hasn't been agreed upon yet.

## What this PR does

### New class: `UpdateChecker` (`src/core/UpdateChecker.h/.cpp`)

- `GET https://api.github.com/repos/aethersdr/AetherSDR/releases/latest` with proper GitHub API headers including `User-Agent` and a 15 s transfer timeout (matches `WhatsNewDialog` precedent).
- Parses `tag_name` from the JSON response, strips the leading `v`.
- Compares against the running version using the existing `VersionNumber` class (CalVer `YY.M.patch[.hotfix]`).
- Emits `updateAvailable(latestVersion)`, `upToDate(currentVersion)`, or `checkFailed()`.
- `kReleasesPageUrl` is a public `static constexpr` in the header so the releases-page URL lives in exactly one place and is easy to update in the future.

### Changed: `MainWindow`

- `UpdateChecker` instantiated in the constructor **before** `buildMenuBar()` is called — mirrors the existing `m_bandPlanMgr` pattern, eliminating any implicit ordering dependency on `buildUI()`.
- **Help menu** gains **"Check for Updates…"** (positioned just before the final separator / About item).
- **Update available** → `QMessageBox` titled _"AetherSDR Update Available"_ showing the available and current versions, with a **"View Latest Release"** button that opens the releases page in the system browser via `QDesktopServices`, and a **Close** button.
- **Up to date** → `QMessageBox::information` _"AetherSDR is up to date (vX.Y.Z)"_.
- **Check failed** (network error, 403, malformed JSON, unparseable tag) → `QMessageBox::warning` _"Could not reach GitHub. Check your connection and try again."_ — appropriate for an operator-initiated action where silent failure is indistinguishable from a hung click.
- Both buttons have `autoDefault(false)` per widget guidelines.
- Layout spacer injected into the `QMessageBox` grid to guarantee the full window title renders without truncation (`setMinimumWidth` is silently ignored by `QMessageBox` internally).
- Stack-allocated `QMessageBox` + synchronous `exec()` — no heap leaks, no `WA_DeleteOnClose` needed.

## What this PR deliberately does NOT do

This is **phase 1**. The following are explicitly out of scope:

| Feature | Status |
|---|---|
| Automatic check on startup | Phase 2 |
| Background periodic check | Phase 2 |
| Persistent update badge/notification | Phase 2 — needs design agreement |
| Check throttle / cooldown | Phase 2 |
| AppSettings key for update preferences | Phase 2 |

The check fires **only on explicit operator request**. Principle XIII.

## Phase 2 needs a design discussion before implementation

Phase 2 will introduce an automatic check and a **persistent notification** visible without opening a menu. Before that is implemented, the team should agree on where that notification lives. The options currently on the table are:

1. **Title bar indicator** — a small button alongside PC Audio / PanLock. Always visible, but adds weight to an already-busy bar.
2. **Status bar badge** — an amber label/icon in the bottom strip. Low-profile but easy to miss.
3. **Blocking popup on launch** — guaranteed visibility, but disruptive during a QSO or in automated modes.
4. **Non-blocking toast / platform notification** — friendliest UX, but requires a custom widget or OS notification API.

Resolving those questions in #3413 first is exactly why this PR ships phase 1 as a standalone change.

## Compliance

- Follows `docs/style/dialog-patterns.md` (stack-alloc, `exec()`, no `WA_DeleteOnClose`, `autoDefault` disabled).
- No `QSettings` — `AppSettings` used project-wide; nothing to persist in phase 1.
- `kReleasesPageUrl` follows the `kPascalCase` constant naming convention from AGENTS.md.
- Tested on **Debian 13 Trixie**.

## Test plan

- [ ] Build clean with no new warnings
- [ ] Help → Check for Updates… appears in the Help menu
- [ ] With current version == latest: dialog shows "AetherSDR is up to date (vX.Y.Z)"
- [ ] With a spoofed older version: dialog shows "AetherSDR Update Available", "View Latest Release" opens browser, "Close" dismisses
- [ ] Window title shows full "AetherSDR Update Available" without truncation
- [ ] Network unavailable: menu item is clickable, no crash, warning dialog shows "Could not reach GitHub. Check your connection and try again."
- [ ] Double-click Help → Check for Updates… rapidly: only one dialog appears (in-flight guard)

/cc @aethersdr/reviewers @AetherClaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)