### PR TITLE
fix(gui): fix Mem label always showing — on Linux (#3470)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10693,10 +10693,13 @@ void MainWindow::buildUI()
                 memBytes = info.phys_footprint;
             }
 #else
+            // /proc files report size 0 via stat(), so QFile::atEnd() returns true
+            // immediately (pos >= size → 0 >= 0). Drive the loop off readLine()
+            // returning empty instead.
             QFile statusFile("/proc/self/status");
             if (statusFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-                while (!statusFile.atEnd()) {
-                    const QByteArray line = statusFile.readLine();
+                QByteArray line;
+                while (!(line = statusFile.readLine()).isEmpty()) {
                     if (line.startsWith("VmRSS:")) {
                         memBytes = line.mid(6).trimmed().split(' ').first().toULongLong() * 1024ULL;
                         break;


### PR DESCRIPTION
Fixes #3470.

## Summary

On Linux the **Mem** field in the status bar always shows `Mem: —` and never updates. CPU in the same stack works correctly. Windows and macOS are unaffected.

## Root cause

The Linux code path reads `VmRSS` from `/proc/self/status` using `QFile`:

```cpp
// Before — broken on Linux
QFile statusFile("/proc/self/status");
if (statusFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
    while (!statusFile.atEnd()) {          // always true immediately
        const QByteArray line = statusFile.readLine();
        if (line.startsWith("VmRSS:")) {
            memBytes = ...;
            break;
        }
    }
}
```

`/proc` is a virtual filesystem. The kernel always reports **size 0** for `/proc` files via `stat()`. `QFile::atEnd()` evaluates `pos >= size`, which is `0 >= 0 = true` the instant the file is opened — before a single byte is read. The search loop exits immediately, `memBytes` stays 0, and the label is never written.

CPU updates work because they use `getrusage()`, which has no file I/O.

## Fix

Drive the loop off `readLine()` returning an empty `QByteArray`, which is the correct idiom for virtual/proc filesystem files:

```cpp
// After — correct on Linux
QFile statusFile("/proc/self/status");
if (statusFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
    QByteArray line;
    while (!(line = statusFile.readLine()).isEmpty()) {
        if (line.startsWith("VmRSS:")) {
            memBytes = line.mid(6).trimmed().split(' ').first().toULongLong() * 1024ULL;
            break;
        }
    }
}
```

`readLine()` returns an empty `QByteArray` only when the underlying read returns 0 bytes — i.e., genuine EOF — regardless of what `stat()` reports about the file size.

## Scope

The changed code is entirely inside the `#else` branch of:

```cpp
#ifdef Q_OS_WIN
    // GetProcessMemoryInfo — unchanged
#elif defined(Q_OS_MAC)
    // task_info / phys_footprint — unchanged
#else
    // fix is here — Linux only
#endif
```

Windows and macOS builds are not affected at all.

## Verification

```bash
# While AetherSDR is running, compare:
grep VmRSS /proc/$(pgrep AetherSDR)/status
# Divide the kB value by 1024 — should match the Mem: label in the status bar
```

## Test plan

- [ ] Run on Linux — confirm **Mem: X MB** populates within 1.5 s of launch and updates on the 1.5 s timer interval
- [ ] Confirm the value tracks `VmRSS` in `/proc/<pid>/status`
- [ ] Run on macOS — confirm no regression in the Mem label
- [ ] Run on Windows — confirm no regression in the Mem label

---

/cc @aethersdr/reviewers @AetherClaude @jensenpat @NF0T @ten9876

🤖 Generated with [Claude Code](https://claude.ai/claude-code)