### PR TITLE
feat(gui): add PGXL fan speed control to AMP applet (#2176)

### DIFF
--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -105,16 +105,42 @@ AmpApplet::AmpApplet(QWidget* parent)
     btnRow->setSpacing(6);
     btnRow->addLayout(infoStack);
     btnRow->addStretch();
-    m_operateBtn = new QPushButton("OPERATE");
-    m_operateBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_operateBtn,
+
+    static const char* kBtnStyle =
         "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
-        "QPushButton:hover { background: {{color.background.1}}; }");
+        "QPushButton:hover { background: {{color.background.1}}; }";
+
+    // Fan speed cycle button — single letter: S (STANDARD), C (CONTEST), B (BROADCAST).
+    // Hidden until a direct PGXL connection delivers the first fanmode status.
+    m_fanBtn = new QPushButton(m_fanMode.left(1));
+    m_fanBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+    m_fanBtn->setFocusPolicy(Qt::TabFocus);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_fanBtn, kBtnStyle);
+    m_fanBtn->setToolTip("Fan Speed\nClick to cycle STANDARD / CONTEST / BROADCAST");
+    m_fanBtn->setAccessibleName(QString("Fan speed: %1").arg(m_fanMode));
+    m_fanBtn->setAccessibleDescription("Cycles through STANDARD, CONTEST, and BROADCAST");
+    m_fanBtn->hide();
+    connect(m_fanBtn, &QPushButton::clicked, this, [this]() {
+        static const QStringList kModes = {"STANDARD", "CONTEST", "BROADCAST"};
+        int idx = kModes.indexOf(m_fanMode);
+        if (idx < 0) {
+            qWarning() << "AmpApplet: unknown fanmode" << m_fanMode << "— resetting to STANDARD";
+            idx = 0;
+        }
+        m_fanMode = kModes[(idx + 1) % kModes.size()];
+        m_fanBtn->setText(m_fanMode.left(1));
+        m_fanBtn->setAccessibleName(QString("Fan speed: %1").arg(m_fanMode));
+        emit fanModeChanged(m_fanMode);
+    });
+    btnRow->addWidget(m_fanBtn);
+
+    m_operateBtn = new QPushButton("OPERATE");
+    m_operateBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_operateBtn, kBtnStyle);
     m_operateBtn->hide();
     connect(m_operateBtn, &QPushButton::clicked, this, [this]() {
-        bool isOp = (m_operateBtn->text() == "OPERATE");
-        emit operateToggled(!isOp);
+        emit operateToggled(m_operateBtn->text() != "OPERATE");
     });
     btnRow->addWidget(m_operateBtn);
     vbox->addLayout(btnRow);
@@ -235,6 +261,14 @@ void AmpApplet::setMainsVoltage(int volts)
     m_vacLabel->setText(QStringLiteral("Vac  %1 V").arg(volts));
 }
 
+void AmpApplet::setFanMode(const QString& mode)
+{
+    m_fanMode = mode.toUpper();
+    m_fanBtn->setText(m_fanMode.left(1));
+    m_fanBtn->setAccessibleName(QString("Fan speed: %1").arg(m_fanMode));
+    m_fanBtn->show();
+}
+
 void AmpApplet::setState(const QString& state)
 {
     // PGXL states: IDLE/OPERATE/TRANSMIT_* = operating (green), else standby (grey)
@@ -272,6 +306,8 @@ void AmpApplet::setDirectConnected(bool direct)
         m_vddLabel->setStyleSheet("QLabel { color: #505050; font-size: 10px; }");
         m_vacLabel->setText("Vac  — V");
         m_vacLabel->setStyleSheet("QLabel { color: #505050; font-size: 10px; }");
+        // Fan mode is only available via direct PGXL protocol — hide until reconnected.
+        m_fanBtn->hide();
     }
 }
 

--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -126,7 +126,7 @@ AmpApplet::AmpApplet(QWidget* parent)
         int idx = kModes.indexOf(m_fanMode);
         if (idx < 0) {
             qWarning() << "AmpApplet: unknown fanmode" << m_fanMode << "— resetting to STANDARD";
-            idx = 0;
+            idx = -1; // (-1 + 1) % 3 == 0 == STANDARD
         }
         m_fanMode = kModes[(idx + 1) % kModes.size()];
         m_fanBtn->setText(m_fanMode.left(1));

--- a/src/gui/AmpApplet.h
+++ b/src/gui/AmpApplet.h
@@ -23,11 +23,13 @@ public:
     void setDrainVoltage(float volts);
     void setMainsVoltage(int volts);
     void setState(const QString& state);
+    void setFanMode(const QString& mode);  // STANDARD, CONTEST, BROADCAST
     void setMeff(const QString& meff);
     void setDirectConnected(bool direct);
 
 signals:
     void operateToggled(bool on);
+    void fanModeChanged(const QString& mode);  // uppercase, ready for sendCommand
 
 private:
     void updateTempLabel();
@@ -49,7 +51,9 @@ private:
     QLabel*  m_sourceLabel{nullptr}; // "● DIRECT" or "● RADIO"
     bool     m_directConnected{false};
 
+    QPushButton* m_fanBtn{nullptr};
     QPushButton* m_operateBtn{nullptr};
+    QString      m_fanMode{"STANDARD"};
 
     // 100 ms timer — updates label text independently of gauge fill rate
     QTimer   m_labelTimer;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3737,6 +3737,8 @@ MainWindow::MainWindow(QWidget* parent)
             amp->setMainsVoltage(kvs["vac"].toInt());
         if (kvs.contains("state"))
             amp->setState(kvs["state"]);
+        if (kvs.contains("fanmode"))
+            amp->setFanMode(kvs["fanmode"]);
         if (kvs.contains("meffa"))
             amp->setMeff(kvs["meffa"]);
         // Convert PGXL dBm to watts and feed S-Meter alongside radio meters.
@@ -3802,6 +3804,10 @@ MainWindow::MainWindow(QWidget* parent)
             amp->setState(kvs["state"]);
         if (kvs.contains("meffa"))
             amp->setMeff(kvs["meffa"]);
+    });
+    // Fan mode cycle button → direct PGXL command (fan control is not in the radio API)
+    connect(m_appletPanel->ampApplet(), &AmpApplet::fanModeChanged, this, [this](const QString& mode) {
+        m_pgxlConn.sendCommand(QString("setup fanmode=%1").arg(mode));
     });
     // OPERATE button → PGXL standby/operate command via radio amplifier API
     connect(m_appletPanel->ampApplet(), &AmpApplet::operateToggled, this, [this](bool on) {


### PR DESCRIPTION
Closes #2176.

## Summary

Adds fan speed control to the Power Genius XL AMP applet. A compact cycle button appears in the bottom row of the applet (to the left of OPERATE/STANDBY) whenever a direct PGXL TCP connection is active. The button shows a single letter indicating the current fan mode — **S** (STANDARD), **C** (CONTEST), **B** (BROADCAST) — and cycles to the next mode on each click. Hovering shows a two-line tooltip: "Fan Speed / Click to cycle STANDARD / CONTEST / BROADCAST".

The button is hidden when no direct connection is present (e.g., telemetry is flowing via the radio API fallback), matching the existing behaviour of the Vdd and Vac labels.

---

## Protocol

All details confirmed against a physical PGXL unit and cross-checked against the PGXL control application supplied by 4O3A.

| Detail | Value |
|---|---|
| Status key | `fanmode` |
| Values | `STANDARD`, `CONTEST`, `BROADCAST` (uppercase strings) |
| Set command | `setup fanmode=<VALUE>` via `PgxlConnection::sendCommand()` on port 9008 |
| Confirmation method | Live testing with a real PGXL + comparison with 4O3A's own application |

---

## Changes

| File | Change |
|---|---|
| `src/gui/AmpApplet.h` | Add `setFanMode(const QString&)` method and `fanModeChanged(const QString&)` signal; add `m_fanBtn` and `m_fanMode` members |
| `src/gui/AmpApplet.cpp` | Build and wire fan cycle button; implement `setFanMode`; hide button in `setDirectConnected(false)` |
| `src/gui/MainWindow.cpp` | Handle `fanmode` key in `PgxlConnection::statusUpdated` lambda; connect `fanModeChanged` → `sendCommand` |

---

## Implementation notes

- **Button visibility** is gated on `setDirectConnected(true)` — fan mode is a direct PGXL protocol command unavailable via the radio API fallback path
- **Accessible name** updates dynamically (`"Fan speed: STANDARD"` etc.) so screen readers announce mode changes; `setFocusPolicy(Qt::TabFocus)` set explicitly per `docs/a11y.md`
- **Unknown mode guard** — if a future PGXL firmware sends an unrecognised `fanmode` value, the click handler logs a `qWarning` and resets to STANDARD rather than silently wrapping via modulo
- **No RFC required** — additive button inside an existing applet, hidden unless direct connection is active; no changes to existing labels, layouts, or UX flows

---

## Test plan

- [ ] Connect AetherSDR to a radio with a PGXL attached via direct TCP
- [ ] Confirm the **S** / **C** / **B** button appears in the AMP applet bottom row once the direct connection is established
- [ ] Click the button — confirm it cycles S → C → B → S and the PGXL fan speed changes accordingly (audible on CONTEST/BROADCAST)
- [ ] Confirm the button label stays in sync if fan mode is changed from the 4O3A front panel or control application (status update path)
- [ ] Disconnect and reconnect — confirm the button hides on disconnect and reappears with the correct mode on reconnect
- [ ] Hover over the button — confirm two-line tooltip reads "Fan Speed / Click to cycle STANDARD / CONTEST / BROADCAST"
- [ ] Tab to the button with keyboard — confirm it is reachable and activates on Space/Return
- [ ] Run with Orca (Linux) or VoiceOver (macOS) — confirm mode changes are announced

---

/cc @aethersdr/reviewers @AetherClaude @jensenpat @NF0T @ten9876

🤖 Generated with [Claude Code](https://claude.ai/claude-code)