### PR TITLE
feat(tnc): isolate AX.25 shim on dedicated QThread

### DIFF
--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -1094,13 +1094,26 @@ QVector<Ax25DecodedFrame> AetherAx25LibmodemShim::processRecoveredBitsForTest(
     return frames;
 }
 
-Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
+QString ax25DemodDescription(const Ax25DemodConfig& cfg)
+{
+    return QStringLiteral("%1: %2 Hz, %3 bps, mark %4 Hz, space %5 Hz, %6")
+        .arg(ax25ModemProfileName(cfg.profile))
+        .arg(cfg.sampleRate)
+        .arg(cfg.baud)
+        .arg(cfg.markHz, 0, 'f', 0)
+        .arg(cfg.spaceHz, 0, 'f', 0)
+        .arg(cfg.polarity == Ax25TonePolarity::Normal
+             ? QStringLiteral("Normal")
+             : QStringLiteral("Inverted"));
+}
+
+Ax25TransmitResult ax25BuildTransmitAudio(
+    const Ax25DemodConfig& cfg,
     const QString& text,
     const QString& defaultSource,
-    const QString& defaultDestination) const
+    const QString& defaultDestination)
 {
     Ax25TransmitResult result;
-    const auto cfg = m_impl->config;
     if (!initTxResult(cfg, result))
         return result;
 
@@ -1130,22 +1143,28 @@ Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
     return result;
 }
 
-Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudioFromFrame(
-    const QByteArray& ax25NoFcs) const
+Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudio(
+    const QString& text,
+    const QString& defaultSource,
+    const QString& defaultDestination) const
+{
+    return ax25BuildTransmitAudio(m_impl->config, text, defaultSource, defaultDestination);
+}
+
+Ax25TransmitResult ax25BuildTransmitAudioFromFrame(
+    const Ax25DemodConfig& cfg,
+    const QByteArray& ax25NoFcs)
 {
     Ax25TransmitResult result;
-    const auto cfg = m_impl->config;
     if (!initTxResult(cfg, result))
         return result;
 
-    // Minimum AX.25 UI frame: dest(7) + src(7) + control(1) = 15 bytes.
     if (ax25NoFcs.size() < 15) {
         result.error = QStringLiteral("KISS frame too short: %1 bytes (need >= 15)")
             .arg(ax25NoFcs.size());
         return result;
     }
 
-    // The host sends the frame without an FCS; the TNC computes and appends it.
     std::vector<uint8_t> frameBytes(
         reinterpret_cast<const uint8_t*>(ax25NoFcs.constData()),
         reinterpret_cast<const uint8_t*>(ax25NoFcs.constData()) + ax25NoFcs.size());
@@ -1163,6 +1182,12 @@ Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudioFromFrame(
     return result;
 }
 
+Ax25TransmitResult AetherAx25LibmodemShim::buildTransmitAudioFromFrame(
+    const QByteArray& ax25NoFcs) const
+{
+    return ax25BuildTransmitAudioFromFrame(m_impl->config, ax25NoFcs);
+}
+
 Ax25DecoderDiagnostics AetherAx25LibmodemShim::diagnosticsSnapshot() const
 {
     return m_impl->makeDiagnostics(m_impl->config.sampleRate);
@@ -1171,17 +1196,10 @@ Ax25DecoderDiagnostics AetherAx25LibmodemShim::diagnosticsSnapshot() const
 QString AetherAx25LibmodemShim::demodDescription() const
 {
     const auto cfg = m_impl->config;
-    return QStringLiteral("%1: %2 Hz, %3 bps, mark %4 Hz, space %5 Hz, %6, %7 lane%8")
-        .arg(ax25ModemProfileName(cfg.profile))
-        .arg(cfg.sampleRate)
-        .arg(cfg.baud)
-        .arg(cfg.markHz, 0, 'f', 0)
-        .arg(cfg.spaceHz, 0, 'f', 0)
-        .arg(cfg.polarity == Ax25TonePolarity::Normal
-             ? QStringLiteral("Normal")
-             : QStringLiteral("Inverted"))
-        .arg(m_impl->lanes.size())
-        .arg(m_impl->lanes.size() == 1 ? QString() : QStringLiteral("s"));
+    return ax25DemodDescription(cfg)
+        + QStringLiteral(", %1 lane%2")
+            .arg(m_impl->lanes.size())
+            .arg(m_impl->lanes.size() == 1 ? QString() : QStringLiteral("s"));
 }
 
 void AetherAx25LibmodemShim::feedAudio(const QByteArray& monoFloat32Pcm, int sampleRate)

--- a/src/core/tnc/AetherAx25LibmodemShim.h
+++ b/src/core/tnc/AetherAx25LibmodemShim.h
@@ -104,6 +104,13 @@ Ax25DemodConfig ax25DemodConfigForProfile(
     Ax25ModemProfile profile,
     Ax25TonePolarity polarity = Ax25TonePolarity::Normal);
 QString ax25ModemProfileName(Ax25ModemProfile profile);
+QString ax25DemodDescription(const Ax25DemodConfig& cfg);
+Ax25TransmitResult ax25BuildTransmitAudio(const Ax25DemodConfig& cfg,
+                                          const QString& text,
+                                          const QString& defaultSource,
+                                          const QString& defaultDestination = QStringLiteral("APRS"));
+Ax25TransmitResult ax25BuildTransmitAudioFromFrame(const Ax25DemodConfig& cfg,
+                                                   const QByteArray& ax25NoFcs);
 
 class AetherAx25LibmodemShim : public QObject {
     Q_OBJECT

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -623,7 +623,10 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     theme::setContainer(this, QStringLiteral("dialog/ax25Decode"));
     setMinimumSize(1080, 680);
 
-    m_shim = new AetherAx25LibmodemShim(this);
+    m_shim = new AetherAx25LibmodemShim();
+    m_shim->moveToThread(&m_shimThread);
+    connect(&m_shimThread, &QThread::finished, m_shim, &QObject::deleteLater);
+    m_shimThread.start();
     m_kissServer = new KissTncServer(this);
     m_heard = new HeardList(this);
     m_terminal = new TncTerminal(this);
@@ -1075,6 +1078,8 @@ Ax25HfPacketDecodeDialog::~Ax25HfPacketDecodeDialog()
         m_kissServer->stop();
     if (m_audio)
         m_audio->setTncRxTapEnabled(false);
+    m_shimThread.quit();
+    m_shimThread.wait();
 }
 
 void Ax25HfPacketDecodeDialog::setAttachedSlice(SliceModel* slice)
@@ -1119,7 +1124,10 @@ void Ax25HfPacketDecodeDialog::setAttachedSlice(SliceModel* slice)
 void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool persist)
 {
     // Tone polarity is always Normal for the supported HF DIGU / VHF FM paths.
-    m_shim->configure(ax25DemodConfigForProfile(profile, Ax25TonePolarity::Normal));
+    m_shimConfig = ax25DemodConfigForProfile(profile, Ax25TonePolarity::Normal);
+    QMetaObject::invokeMethod(m_shim, [shim = m_shim, cfg = m_shimConfig]() {
+        shim->configure(cfg);
+    }, Qt::QueuedConnection);
     m_lastDiagnostics = {};
     m_lastDiagnosticsUtc = {};
 
@@ -1129,14 +1137,14 @@ void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool pe
     }
 
     if (m_log)
-        appendSystemLine(QStringLiteral("Configured %1.").arg(m_shim->demodDescription()));
+        appendSystemLine(QStringLiteral("Configured %1.").arg(ax25DemodDescription(m_shimConfig)));
     refreshStatus();
 }
 
 void Ax25HfPacketDecodeDialog::setDecodeEnabled(bool enabled)
 {
     if (enabled) {
-        m_shim->reset();
+        QMetaObject::invokeMethod(m_shim, &AetherAx25LibmodemShim::reset, Qt::QueuedConnection);
         m_lastDiagnostics = {};
         m_enabledUtc = QDateTime::currentDateTimeUtc();
         m_lastDiagnosticsUtc = {};
@@ -1153,7 +1161,7 @@ void Ax25HfPacketDecodeDialog::setDecodeEnabled(bool enabled)
             finishAudioCapture(false);
         if (m_audio)
             m_audio->setTncRxTapEnabled(false);
-        m_shim->reset();
+        QMetaObject::invokeMethod(m_shim, &AetherAx25LibmodemShim::reset, Qt::QueuedConnection);
         m_lastDiagnostics = {};
         m_lastDiagnosticsUtc = {};
         m_lastActivityHdlc = 0;
@@ -1192,7 +1200,9 @@ void Ax25HfPacketDecodeDialog::handleRxAudio(const QByteArray& monoFloat32Pcm, i
         }
     }
 
-    m_shim->feedAudio(monoFloat32Pcm, sampleRate);
+    QMetaObject::invokeMethod(m_shim, [shim = m_shim, pcm = monoFloat32Pcm, sr = sampleRate]() {
+        shim->feedAudio(pcm, sr);
+    }, Qt::QueuedConnection);
 }
 
 void Ax25HfPacketDecodeDialog::startAudioCapture()
@@ -1206,7 +1216,7 @@ void Ax25HfPacketDecodeDialog::startAudioCapture()
     m_captureSampleRate = 0;
     m_captureTargetBytes = 0;
     m_captureActive = true;
-    m_shim->reset();
+    QMetaObject::invokeMethod(m_shim, &AetherAx25LibmodemShim::reset, Qt::QueuedConnection);
     m_lastDiagnostics = {};
     m_lastDiagnosticsUtc = {};
     m_lastActivityHdlc = 0;
@@ -1264,8 +1274,12 @@ void Ax25HfPacketDecodeDialog::startTransmitFromUi()
         return;
     }
 
-    const QString text = m_txText->text();
-    Ax25TransmitResult tx = m_shim->buildTransmitAudio(text, defaultTransmitSource());
+    startTransmit(m_txText->text());
+}
+
+void Ax25HfPacketDecodeDialog::startTransmit(const QString& text)
+{
+    Ax25TransmitResult tx = ax25BuildTransmitAudio(m_shimConfig, text, defaultTransmitSource());
     if (!tx.ok) {
         appendSystemLine(QStringLiteral("TX packetization failed: %1.").arg(tx.error));
         qCWarning(lcAx25).noquote() << "AX.25 TX packetization failed:" << tx.error;
@@ -1433,7 +1447,7 @@ void Ax25HfPacketDecodeDialog::paceTransmitAudio()
         qCInfo(lcAx25).noquote()
             << QStringLiteral("AX.25 TX pacing summary: baud=%1 chunks=%2 audioMs=%3 wallMs=%4 "
                               "stretch=%5x maxChunkGapMs=%6 lateChunks=%7 nominalChunkMs=%8")
-                .arg(m_shim->config().baud)
+                .arg(m_shimConfig.baud)
                 .arg(m_txChunkIndex)
                 .arg(audioMs, 0, 'f', 0)
                 .arg(wallMs)
@@ -1653,7 +1667,7 @@ void Ax25HfPacketDecodeDialog::refreshStatus()
         m_modemStatusValue->setText(status);
         m_modemStatusValue->setToolTip(QStringLiteral(
             "%1\nSlice: %2\nSquelch: %3\nFrames: %4\nLast decode: %5\nDecode lanes: %6\nHDLC starts: %7\nHDLC candidates: %8\nAX.25-like candidates: %9\nAccepted: %10\nRejected: %11\nToo short: %12\nBad FCS: %13\nMalformed: %14\nLast reject: %15\nState: %16, bits: %17, ones: %18%\nReceive gate: %19, rms %20 dBFS, floor %21 dBFS, resets %22")
-            .arg(m_shim->demodDescription())
+            .arg(ax25DemodDescription(m_shimConfig))
             .arg(m_attachedSliceId >= 0 ? QString::number(m_attachedSliceId) : QStringLiteral("-"))
             .arg(squelchText)
             .arg(m_frameCount)
@@ -1718,7 +1732,7 @@ void Ax25HfPacketDecodeDialog::refreshTransmitControls()
         m_txText->setEnabled(!m_txActive && !m_txPendingStream);
         m_txText->setToolTip(
             QStringLiteral("Transmit a %1 AX.25 UI frame. Raw text uses %2>APRS; full SRC>DST,path:payload syntax is also accepted.")
-                .arg(ax25ModemProfileName(m_shim->config().profile), defaultTransmitSource()));
+                .arg(ax25ModemProfileName(m_shimConfig.profile), defaultTransmitSource()));
     }
 }
 
@@ -1729,7 +1743,9 @@ void Ax25HfPacketDecodeDialog::setDiagnosticsDebugEnabled(bool enabled, bool per
 
     m_diagnosticsDebugEnabled = enabled;
     if (m_shim)
-        m_shim->setDiagnosticsLoggingEnabled(enabled);
+        QMetaObject::invokeMethod(m_shim, [shim = m_shim, enabled]() {
+            shim->setDiagnosticsLoggingEnabled(enabled);
+        }, Qt::QueuedConnection);
     if (m_terminal)
         m_terminal->setVerbose(enabled); // echo protocol detail inline in the terminal
     if (m_packetActivity)
@@ -2088,7 +2104,7 @@ void Ax25HfPacketDecodeDialog::maybeStartNextKissTx()
 
     const QByteArray frame = m_kissTxQueue.dequeue();
     m_kissTxBusyRetries = 0;
-    Ax25TransmitResult tx = m_shim->buildTransmitAudioFromFrame(frame);
+    Ax25TransmitResult tx = ax25BuildTransmitAudioFromFrame(m_shimConfig, frame);
     if (!tx.ok) {
         appendSystemLine(QStringLiteral("KISS TX packetization failed: %1.").arg(tx.error));
         qCWarning(lcAx25).noquote() << "KISS TX packetization failed:" << tx.error;

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -10,6 +10,7 @@
 #include <QPointer>
 #include <QQueue>
 #include <QStringList>
+#include <QThread>
 
 class QAbstractButton;
 class QCheckBox;
@@ -99,6 +100,7 @@ private:
     void startAudioCapture();
     void finishAudioCapture(bool save);
     void startTransmitFromUi();
+    void startTransmit(const QString& text);
     void beginTransmission(const Ax25TransmitResult& tx, bool fromKiss);
     void beginTransmitWhenReady();
     void paceTransmitAudio();
@@ -144,6 +146,8 @@ private:
     AudioEngine* m_audio{nullptr};
     RadioModel* m_radio{nullptr};
     AetherAx25LibmodemShim* m_shim{nullptr};
+    QThread m_shimThread;
+    Ax25DemodConfig m_shimConfig;
     QStackedWidget* m_tabStack{nullptr};
     QAbstractButton* m_ax25Tab{nullptr};
     QAbstractButton* m_kissTab{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5503,6 +5503,16 @@ MainWindow::~MainWindow()
     delete m_networkDiagnosticsHistory;
     m_networkDiagnosticsHistory = nullptr;
 
+    // Ax25HfPacketDecodeDialog::~Ax25HfPacketDecodeDialog calls
+    // m_audio->setTncRxTapEnabled(false) via a raw AudioEngine pointer.
+    // AudioEngine is freed below before Qt's deleteChildren() runs — same
+    // UAF pattern as m_networkDiagnosticsDialog above. Tear it down now
+    // while AudioEngine is still alive.
+    if (m_ax25HfPacketDecodeDialog) {
+        delete m_ax25HfPacketDecodeDialog.data();
+        m_ax25HfPacketDecodeDialog = nullptr;
+    }
+
     // Stop audio processing on the worker thread before destruction (#502).
     // Use BlockingQueuedConnection to ensure completion before we proceed.
     if (m_audio && m_audioThread && m_audioThread->isRunning()) {


### PR DESCRIPTION
## Summary

First of three focused PRs extracted from #3466 per @jensenpat's review guidance. Lays the threading groundwork for #2701 (Native Soft-TNC + APRS Integration) — the shim thread boundary is required before a more capable demodulator can be dropped in without blocking the GUI.

## Motivation

`AetherAx25LibmodemShim` ran on the GUI thread. Audio callbacks, HDLC decode, and profile configuration all competed with paint events and user interaction, making it impossible to later add a CPU-heavier demodulator without degrading responsiveness.

## Changes

- `AetherAx25LibmodemShim` moved to a dedicated `QThread` (`m_shimThread`)
- All GUI→shim calls use `QMetaObject::invokeMethod(..., Qt::QueuedConnection)`
- `m_shimConfig` cache added to dialog — GUI thread never reads `m_impl->config` directly
- Free functions extracted: `ax25DemodDescription`, `ax25BuildTransmitAudio`, `ax25BuildTransmitAudioFromFrame`
- `startTransmit(const QString&)` extracted from `startTransmitFromUi`
- Destructor: `m_shimThread.quit(); m_shimThread.wait()`
- **ASAN fix (`b495dac9`):** `MainWindow::~MainWindow()` now explicitly deletes `m_ax25HfPacketDecodeDialog` before AudioEngine teardown. Pre-existing UAF: dialog destructor called `m_audio->setTncRxTapEnabled(false)` via raw pointer after AudioEngine was freed via `deleteLater()`. Same pattern as the existing `m_networkDiagnosticsDialog` fix in that destructor. Found on RPi 5 with ASAN; confirmed clean after fix.

## Test plan

Tested on all three target platforms.

1. **Basic decode** — enabled modem on 144.390 MHz APRS; frames appeared in the log within seconds; disable/re-enable confirmed clean reset with no stale state.
2. **Profile switching under load** — switched HF↔VHF while audio was flowing, including rapid successive switches; no crash, new profile description appeared correctly each time.
3. **TX path** — transmitted a UI frame; confirmed key, send, and unkey with no crash or hang. KISS frame sent via `kiss_test.py` also keyed cleanly, exercising `ax25BuildTransmitAudioFromFrame` as a free function. **Hardware note:** transverter attenuated to prevent RF output — full software TX path exercised but no RF generated; iGate/APRS-IS verification deferred pending hardware modification.
4. **Clean shutdown** — closed dialog while modem was enabled; no hang or crash; reopened and re-initialized correctly.
5. **Extended run** — modem left running 10+ minutes on a busy APRS channel; no crashes, no memory growth, GUI remained responsive.
6. **ASAN (RPi 5)** — Debug+ASAN build clean after fix; no new leaks or UAF reported.

**RX sensitivity note:** A single decode was achieved with an HT at close range. Consistent decode is limited by libmodem's single-slicer VHF sensitivity — a known pre-existing limitation addressed in the third PR in this series (Direwolf demodulator). This PR does not regress decode behavior.

**300-baud HF decode** — not tested on-air; no 300-baud packet infrastructure available in the test environment.

---

Built and smoke tested on: MacBook Air M2 / RPi 5 Debian trixie / Win 11 i3

Extracted from #3466 (closed).

**Note:** The follow-on PR introducing `HdlcCodec` ([feat/ax25-hdlc-codec](https://github.com/K5PTB/AetherSDR/tree/feat/ax25-hdlc-codec)) is ready but will be held until this PR merges, so it can be opened cleanly against `main`.