### PR TITLE
feat(tnc): HdlcCodec — replace libmodem bitstream_state with pure-C++ HDLC framer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,7 @@ set(CORE_SOURCES
     src/core/MemoryCsvCompat.cpp
     src/core/MemoryRecallPolicy.cpp
     src/core/tnc/AetherAx25LibmodemShim.cpp
+    src/core/tnc/HdlcCodec.cpp
     src/core/tnc/Ax25FrameFormatter.cpp
     src/core/tnc/Ax25.cpp
     src/core/tnc/Ax25Connection.cpp
@@ -1980,6 +1981,7 @@ add_test(NAME ax25_frame_formatter_test COMMAND ax25_frame_formatter_test)
 add_executable(ax25_libmodem_shim_test
     tests/ax25_libmodem_shim_test.cpp
     src/core/tnc/AetherAx25LibmodemShim.cpp
+    src/core/tnc/HdlcCodec.cpp
     src/core/tnc/Ax25FrameFormatter.cpp
     src/core/tnc/Ax25.cpp
     src/core/tnc/KissFraming.cpp
@@ -1994,6 +1996,14 @@ add_executable(ax25_libmodem_shim_test
 target_include_directories(ax25_libmodem_shim_test PRIVATE src)
 target_link_libraries(ax25_libmodem_shim_test PRIVATE Qt6::Core aether_libmodem_core)
 add_test(NAME ax25_libmodem_shim_test COMMAND ax25_libmodem_shim_test)
+
+add_executable(hdlc_codec_test
+    tests/hdlc_codec_test.cpp
+    src/core/tnc/HdlcCodec.cpp
+)
+target_include_directories(hdlc_codec_test PRIVATE src)
+target_link_libraries(hdlc_codec_test PRIVATE aether_libmodem_core)
+add_test(NAME hdlc_codec_test COMMAND hdlc_codec_test)
 
 # Offline AX.25 decode diagnostic: replays a captured WAV through the decoder.
 # Not a ctest (needs an input file); built on demand for troubleshooting.

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -6,6 +6,8 @@
 #include "bitstream.h"
 #include "demodulator.h"
 
+#include "core/tnc/HdlcCodec.h"
+
 #include <QDateTime>
 
 #include <algorithm>
@@ -88,6 +90,13 @@ QString framePreviewHex(const std::array<uint8_t, N>& bytes, size_t byteCount)
 {
     const qsizetype previewBytes = static_cast<qsizetype>(std::min<size_t>(byteCount, 24));
     QByteArray preview(reinterpret_cast<const char*>(bytes.data()), previewBytes);
+    return QString::fromLatin1(preview.toHex(' ')).toUpper();
+}
+
+QString framePreviewHex(const uint8_t* bytes, size_t byteCount)
+{
+    const qsizetype previewBytes = static_cast<qsizetype>(std::min<size_t>(byteCount, 24));
+    QByteArray preview(reinterpret_cast<const char*>(bytes), previewBytes);
     return QString::fromLatin1(preview.toHex(' ')).toUpper();
 }
 
@@ -385,9 +394,7 @@ struct AetherAx25LibmodemShim::Impl {
         int phaseOffsetSamples{0};
         int samplesUntilStart{0};
         std::unique_ptr<lm::sinc_corr_afsk_demodulator> demod;
-        lm::ax25::bitstream_state bitstreamState;
-        std::vector<uint8_t> bitstreamBuffer;
-        std::array<uint8_t, 1000> candidateFrameBytes{};
+        HdlcCodec hdlcCodec;
         double lastQuality{0.0};
     };
     struct RecentFrame {
@@ -513,8 +520,6 @@ struct AetherAx25LibmodemShim::Impl {
                 0.008,
                 0.005,
                 pllAlpha);
-            lane.bitstreamBuffer.reserve(8192);
-            lane.bitstreamBuffer.resize(8192);
         };
 
         if (config.profile == Ax25ModemProfile::Hf300) {
@@ -603,10 +608,7 @@ struct AetherAx25LibmodemShim::Impl {
 
     void resetLaneBitstream(DecodeLane& lane)
     {
-        lane.bitstreamState.reset();
-        lane.bitstreamState.max_frame_bits = 4096;
-        lane.bitstreamBuffer.clear();
-        lane.bitstreamBuffer.resize(8192);
+        lane.hdlcCodec.reset();
     }
 
     void resetBitstreamStates()
@@ -696,7 +698,7 @@ struct AetherAx25LibmodemShim::Impl {
         }
     }
 
-    bool candidateHasAx25Structure(const DecodeLane& lane,
+    bool candidateHasAx25Structure(const uint8_t* frameBytes,
                                    size_t frameBytesSize,
                                    uint8_t& control,
                                    uint8_t& pid,
@@ -714,8 +716,8 @@ struct AetherAx25LibmodemShim::Impl {
         pid = 0;
 
         auto [pathOut, dataOut, parsed] = lm::ax25::try_decode_frame_no_fcs(
-            lane.candidateFrameBytes.data(),
-            lane.candidateFrameBytes.data() + frameBytesSize - 2,
+            frameBytes,
+            frameBytes + frameBytesSize - 2,
             from,
             to,
             path.begin(),
@@ -749,9 +751,9 @@ struct AetherAx25LibmodemShim::Impl {
                       const std::array<uint8_t, 2>& expectedFcs)
     {
         ++totalDecodeRejected;
-        lastRejectFrameBits = static_cast<int>(lane.bitstreamState.frame_size_bits);
+        lastRejectFrameBits = lane.hdlcCodec.frameSizeBits();
         lastRejectFrameBytes = static_cast<int>(frameBytesSize);
-        lastRejectPreviewHex = framePreviewHex(lane.candidateFrameBytes, frameBytesSize);
+        lastRejectPreviewHex = framePreviewHex(lane.hdlcCodec.frameData(), frameBytesSize);
         lastRejectActualFcs = frameBytesSize >= 17 ? fcsToString(actualFcs) : QString();
         lastRejectExpectedFcs = frameBytesSize >= 17 ? fcsToString(expectedFcs) : QString();
 
@@ -768,7 +770,7 @@ struct AetherAx25LibmodemShim::Impl {
         uint8_t pid = 0;
         size_t pathCount = 0;
         size_t dataLength = 0;
-        const bool ax25Like = candidateHasAx25Structure(lane, frameBytesSize, control, pid, pathCount, dataLength);
+        const bool ax25Like = candidateHasAx25Structure(lane.hdlcCodec.frameData(), frameBytesSize, control, pid, pathCount, dataLength);
 
         if (actualFcs != expectedFcs) {
             if (ax25Like) {
@@ -795,47 +797,61 @@ struct AetherAx25LibmodemShim::Impl {
     std::optional<Ax25DecodedFrame> processBit(DecodeLane& lane, uint8_t bit, double quality)
     {
         lane.lastQuality = 0.95 * lane.lastQuality + 0.05 * quality;
-        const bool wasComplete = lane.bitstreamState.complete;
-        const bool wasInFrame = lane.bitstreamState.in_frame;
+        const bool wasInFrame = lane.hdlcCodec.inFrame();
+
+        if (!lane.hdlcCodec.processBit(bit)) {
+            if (lane.hdlcCodec.inFrame() && !wasInFrame)
+                ++totalHdlcFrameStarts;
+            return std::nullopt;
+        }
+
+        // Frame closed — hdlcCodec.complete() is true.
+        ++totalHdlcFrameCandidates;
+
+        const size_t frameSize    = lane.hdlcCodec.frameSize();
+        const uint8_t* frameBytes = lane.hdlcCodec.frameData();
+        const auto actualFcs      = lane.hdlcCodec.actualFcs();
+        const auto expectedFcs    = lane.hdlcCodec.expectedFcs();
+
+        if (!lane.hdlcCodec.fcsValid()) {
+            if (recordReject(lane, frameSize, actualFcs, expectedFcs))
+                ++totalPlausibleAx25Candidates;
+            return std::nullopt;
+        }
+
         lm::address from;
         lm::address to;
         std::array<lm::address, 8> path = {};
         std::array<uint8_t, 256> data = {};
         uint8_t control = 0;
         uint8_t pid = 0;
-        std::array<uint8_t, 2> actualFcs = {};
-        std::array<uint8_t, 2> expectedFcs = {};
 
-        auto [candidateFrameBytesSize, pathOut, dataOut, decoded] = lm::ax25::try_decode_bitstream(
-            bit ? 1 : 0,
-            lane.bitstreamState,
-            lane.bitstreamBuffer.begin(),
-            lane.bitstreamBuffer.end(),
-            lane.candidateFrameBytes,
+        auto [pathOut, dataOut, parsed] = lm::ax25::try_decode_frame_no_fcs(
+            frameBytes,
+            frameBytes + frameSize - 2,
             from,
             to,
             path.begin(),
             data.begin(),
             data.size(),
             control,
-            pid,
-            actualFcs,
-            expectedFcs);
+            pid);
 
-        if (lane.bitstreamState.in_frame && !wasInFrame)
-            ++totalHdlcFrameStarts;
+        const std::array<uint8_t, 2> acceptedFcs = { 0, 0 };
+        const bool ax25Valid = parsed && lm::ax25::validate_frame(
+            from, to,
+            path.begin(), pathOut,
+            data.begin(), dataOut,
+            control, pid,
+            acceptedFcs, acceptedFcs);
 
-        if (lane.bitstreamState.complete && !wasComplete) {
-            ++totalHdlcFrameCandidates;
-            if (decoded) {
+        if (!ax25Valid) {
+            if (recordReject(lane, frameSize, actualFcs, expectedFcs))
                 ++totalPlausibleAx25Candidates;
-            } else {
-                if (recordReject(lane, candidateFrameBytesSize, actualFcs, expectedFcs))
-                    ++totalPlausibleAx25Candidates;
-            }
-        }
-        if (!decoded)
             return std::nullopt;
+        }
+
+        ++totalPlausibleAx25Candidates;
 
         lm::ax25::frame frame;
         frame.from = from;
@@ -847,14 +863,12 @@ struct AetherAx25LibmodemShim::Impl {
         frame.control[0] = control;
         frame.pid = pid;
         frame.crc = actualFcs;
-        Ax25DecodedFrame decodedFrame =
-            toDecodedFrame(frame, lane.lastQuality, lane.phaseOffsetSamples);
-        // Capture the exact on-air frame bytes minus the trailing 2-byte FCS so
-        // the KISS TNC can forward the decode to host apps verbatim.
-        if (candidateFrameBytesSize >= 2) {
+        Ax25DecodedFrame decodedFrame = toDecodedFrame(frame, lane.lastQuality, lane.phaseOffsetSamples);
+        // Capture on-air frame bytes minus 2-byte FCS for KISS TNC forwarding.
+        if (frameSize >= 2) {
             decodedFrame.ax25FrameNoFcs = QByteArray(
-                reinterpret_cast<const char*>(lane.candidateFrameBytes.data()),
-                static_cast<qsizetype>(candidateFrameBytesSize - 2));
+                reinterpret_cast<const char*>(frameBytes),
+                static_cast<qsizetype>(frameSize - 2));
         }
         return decodedFrame;
     }
@@ -954,16 +968,16 @@ struct AetherAx25LibmodemShim::Impl {
         diagnostics.lastFrameBits = 0;
         diagnostics.preambleFlags = 0;
         for (const auto& lane : lanes) {
-            diagnostics.searching = diagnostics.searching && lane.bitstreamState.searching;
-            diagnostics.inPreamble = diagnostics.inPreamble || lane.bitstreamState.in_preamble;
-            diagnostics.inFrame = diagnostics.inFrame || lane.bitstreamState.in_frame;
-            diagnostics.aborted = diagnostics.aborted || lane.bitstreamState.aborted;
+            diagnostics.searching = diagnostics.searching && lane.hdlcCodec.searching();
+            diagnostics.inPreamble = diagnostics.inPreamble || lane.hdlcCodec.inPreamble();
+            diagnostics.inFrame = diagnostics.inFrame || lane.hdlcCodec.inFrame();
+            diagnostics.aborted = diagnostics.aborted || lane.hdlcCodec.aborted();
             diagnostics.currentFrameBits = std::max(diagnostics.currentFrameBits,
-                                                    static_cast<int>(lane.bitstreamState.bitstream_size));
+                                                    lane.hdlcCodec.bitstreamSize());
             diagnostics.lastFrameBits = std::max(diagnostics.lastFrameBits,
-                                                 static_cast<int>(lane.bitstreamState.frame_size_bits));
+                                                 lane.hdlcCodec.frameSizeBits());
             diagnostics.preambleFlags = std::max(diagnostics.preambleFlags,
-                                                 static_cast<int>(lane.bitstreamState.preamble_count));
+                                                 lane.hdlcCodec.preambleCount());
         }
         diagnostics.hdlcFrameStarts = totalHdlcFrameStarts;
         diagnostics.hdlcFrameCandidates = totalHdlcFrameCandidates;

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -1108,9 +1108,18 @@ QVector<Ax25DecodedFrame> AetherAx25LibmodemShim::processRecoveredBitsForTest(
     return frames;
 }
 
+int ax25DemodLaneCount(const Ax25DemodConfig& cfg)
+{
+    if (cfg.profile == Ax25ModemProfile::Hf300)
+        return static_cast<int>(kHf300DecodePhaseOffsets.size());
+    return kVhf1200FreeRunPhaseCount
+         + kVhf1200TrackedPhaseCount * static_cast<int>(kVhf1200PllAlphas.size());
+}
+
 QString ax25DemodDescription(const Ax25DemodConfig& cfg)
 {
-    return QStringLiteral("%1: %2 Hz, %3 bps, mark %4 Hz, space %5 Hz, %6")
+    const int lanes = ax25DemodLaneCount(cfg);
+    return QStringLiteral("%1: %2 Hz, %3 bps, mark %4 Hz, space %5 Hz, %6, %7 lane%8")
         .arg(ax25ModemProfileName(cfg.profile))
         .arg(cfg.sampleRate)
         .arg(cfg.baud)
@@ -1118,7 +1127,9 @@ QString ax25DemodDescription(const Ax25DemodConfig& cfg)
         .arg(cfg.spaceHz, 0, 'f', 0)
         .arg(cfg.polarity == Ax25TonePolarity::Normal
              ? QStringLiteral("Normal")
-             : QStringLiteral("Inverted"));
+             : QStringLiteral("Inverted"))
+        .arg(lanes)
+        .arg(lanes == 1 ? QString() : QStringLiteral("s"));
 }
 
 Ax25TransmitResult ax25BuildTransmitAudio(
@@ -1173,12 +1184,14 @@ Ax25TransmitResult ax25BuildTransmitAudioFromFrame(
     if (!initTxResult(cfg, result))
         return result;
 
+    // Minimum valid AX.25 frame without FCS: 14 address bytes + 1 control byte = 15.
     if (ax25NoFcs.size() < 15) {
         result.error = QStringLiteral("KISS frame too short: %1 bytes (need >= 15)")
             .arg(ax25NoFcs.size());
         return result;
     }
 
+    // KISS host omits FCS; the TNC appends it before encoding.
     std::vector<uint8_t> frameBytes(
         reinterpret_cast<const uint8_t*>(ax25NoFcs.constData()),
         reinterpret_cast<const uint8_t*>(ax25NoFcs.constData()) + ax25NoFcs.size());
@@ -1209,11 +1222,7 @@ Ax25DecoderDiagnostics AetherAx25LibmodemShim::diagnosticsSnapshot() const
 
 QString AetherAx25LibmodemShim::demodDescription() const
 {
-    const auto cfg = m_impl->config;
-    return ax25DemodDescription(cfg)
-        + QStringLiteral(", %1 lane%2")
-            .arg(m_impl->lanes.size())
-            .arg(m_impl->lanes.size() == 1 ? QString() : QStringLiteral("s"));
+    return ax25DemodDescription(m_impl->config);
 }
 
 void AetherAx25LibmodemShim::feedAudio(const QByteArray& monoFloat32Pcm, int sampleRate)

--- a/src/core/tnc/AetherAx25LibmodemShim.h
+++ b/src/core/tnc/AetherAx25LibmodemShim.h
@@ -104,6 +104,7 @@ Ax25DemodConfig ax25DemodConfigForProfile(
     Ax25ModemProfile profile,
     Ax25TonePolarity polarity = Ax25TonePolarity::Normal);
 QString ax25ModemProfileName(Ax25ModemProfile profile);
+int ax25DemodLaneCount(const Ax25DemodConfig& cfg);
 QString ax25DemodDescription(const Ax25DemodConfig& cfg);
 Ax25TransmitResult ax25BuildTransmitAudio(const Ax25DemodConfig& cfg,
                                           const QString& text,

--- a/src/core/tnc/HdlcCodec.cpp
+++ b/src/core/tnc/HdlcCodec.cpp
@@ -1,0 +1,226 @@
+#include "HdlcCodec.h"
+
+namespace AetherSDR {
+
+// CRC-16-CCITT lookup table, polynomial 0x8408 (bit-reversed 0x1021).
+// init=0xFFFF, final XOR=0xFFFF — identical to Direwolf fcs_calc.c and
+// libmodem compute_crc_using_lut.  Verified against both implementations.
+static constexpr uint16_t kCrcTable[256] = {
+    0x0000, 0x1189, 0x2312, 0x329B, 0x4624, 0x57AD, 0x6536, 0x74BF,
+    0x8C48, 0x9DC1, 0xAF5A, 0xBED3, 0xCA6C, 0xDBE5, 0xE97E, 0xF8F7,
+    0x1081, 0x0108, 0x3393, 0x221A, 0x56A5, 0x472C, 0x75B7, 0x643E,
+    0x9CC9, 0x8D40, 0xBFDB, 0xAE52, 0xDAED, 0xCB64, 0xF9FF, 0xE876,
+    0x2102, 0x308B, 0x0210, 0x1399, 0x6726, 0x76AF, 0x4434, 0x55BD,
+    0xAD4A, 0xBCC3, 0x8E58, 0x9FD1, 0xEB6E, 0xFAE7, 0xC87C, 0xD9F5,
+    0x3183, 0x200A, 0x1291, 0x0318, 0x77A7, 0x662E, 0x54B5, 0x453C,
+    0xBDCB, 0xAC42, 0x9ED9, 0x8F50, 0xFBEF, 0xEA66, 0xD8FD, 0xC974,
+    0x4204, 0x538D, 0x6116, 0x709F, 0x0420, 0x15A9, 0x2732, 0x36BB,
+    0xCE4C, 0xDFC5, 0xED5E, 0xFCD7, 0x8868, 0x99E1, 0xAB7A, 0xBAF3,
+    0x5285, 0x430C, 0x7197, 0x601E, 0x14A1, 0x0528, 0x37B3, 0x263A,
+    0xDECD, 0xCF44, 0xFDDF, 0xEC56, 0x98E9, 0x8960, 0xBBFB, 0xAA72,
+    0x6306, 0x728F, 0x4014, 0x519D, 0x2522, 0x34AB, 0x0630, 0x17B9,
+    0xEF4E, 0xFEC7, 0xCC5C, 0xDDD5, 0xA96A, 0xB8E3, 0x8A78, 0x9BF1,
+    0x7387, 0x620E, 0x5095, 0x411C, 0x35A3, 0x242A, 0x16B1, 0x0738,
+    0xFFCF, 0xEE46, 0xDCDD, 0xCD54, 0xB9EB, 0xA862, 0x9AF9, 0x8B70,
+    0x8408, 0x9581, 0xA71A, 0xB693, 0xC22C, 0xD3A5, 0xE13E, 0xF0B7,
+    0x0840, 0x19C9, 0x2B52, 0x3ADB, 0x4E64, 0x5FED, 0x6D76, 0x7CFF,
+    0x9489, 0x8500, 0xB79B, 0xA612, 0xD2AD, 0xC324, 0xF1BF, 0xE036,
+    0x18C1, 0x0948, 0x3BD3, 0x2A5A, 0x5EE5, 0x4F6C, 0x7DF7, 0x6C7E,
+    0xA50A, 0xB483, 0x8618, 0x9791, 0xE32E, 0xF2A7, 0xC03C, 0xD1B5,
+    0x2942, 0x38CB, 0x0A50, 0x1BD9, 0x6F66, 0x7EEF, 0x4C74, 0x5DFD,
+    0xB58B, 0xA402, 0x9699, 0x8710, 0xF3AF, 0xE226, 0xD0BD, 0xC134,
+    0x39C3, 0x284A, 0x1AD1, 0x0B58, 0x7FE7, 0x6E6E, 0x5CF5, 0x4D7C,
+    0xC60C, 0xD785, 0xE51E, 0xF497, 0x8028, 0x91A1, 0xA33A, 0xB2B3,
+    0x4A44, 0x5BCD, 0x6956, 0x78DF, 0x0C60, 0x1DE9, 0x2F72, 0x3EFB,
+    0xD68D, 0xC704, 0xF59F, 0xE416, 0x90A9, 0x8120, 0xB3BB, 0xA232,
+    0x5AC5, 0x4B4C, 0x79D7, 0x685E, 0x1CE1, 0x0D68, 0x3FF3, 0x2E7A,
+    0xE70E, 0xF687, 0xC41C, 0xD595, 0xA12A, 0xB0A3, 0x8238, 0x93B1,
+    0x6B46, 0x7ACF, 0x4854, 0x59DD, 0x2D62, 0x3CEB, 0x0E70, 0x1FF9,
+    0xF78F, 0xE606, 0xD49D, 0xC514, 0xB1AB, 0xA022, 0x92B9, 0x8330,
+    0x7BC7, 0x6A4E, 0x58D5, 0x495C, 0x3DE3, 0x2C6A, 0x1EF1, 0x0F78,
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+
+void HdlcCodec::reset()
+{
+    m_state = State::Searching;
+    m_complete = false;
+    m_aborted  = false;
+    m_fcsValid = false;
+    m_prevNrzi = 0;
+    m_patDet   = 0;
+    m_currentByte = 0;
+    m_bitIndex    = 0;
+    m_frameByteCount = 0;
+    m_frameSizeBits  = 0;
+    m_preambleCount  = 0;
+    m_rawBitsInFrame = 0;
+    m_bitsAfterFlag  = 0;
+    m_actualFcs   = {};
+    m_expectedFcs = {};
+}
+
+int HdlcCodec::bitstreamSize() const
+{
+    if (m_state != State::InFrame)
+        return 0;
+    return static_cast<int>(m_frameByteCount) * 8 + m_bitIndex;
+}
+
+void HdlcCodec::beginFrame()
+{
+    m_currentByte    = 0;
+    m_bitIndex       = 0;
+    m_frameByteCount = 0;
+    m_rawBitsInFrame = 0;
+    m_bitsAfterFlag  = 0;
+    m_fcsValid       = false;
+    m_aborted        = false;
+}
+
+void HdlcCodec::accumulateBit(uint8_t bit)
+{
+    if (bit)
+        m_currentByte |= static_cast<uint8_t>(1u << m_bitIndex);
+    ++m_bitIndex;
+
+    if (m_bitIndex == 8) {
+        if (m_frameByteCount < kMaxFrameBytes)
+            m_frameBuffer[m_frameByteCount++] = m_currentByte;
+        else {
+            // Buffer overflow — abandon frame, return to searching
+            m_state  = State::Searching;
+            m_patDet = 0;
+            beginFrame();
+        }
+        m_currentByte = 0;
+        m_bitIndex    = 0;
+    }
+}
+
+bool HdlcCodec::closeFrame()
+{
+    m_complete = true;
+    m_state    = State::InPreamble;  // ready for next frame (shared flag)
+
+    // A valid AX.25 frame body is always a whole number of bytes.  After the
+    // last complete data byte (m_bitIndex==0), the 7 flag bits that precede
+    // the closing flag zero accumulate in m_currentByte; m_bitIndex reaches 7.
+    // Any other value means the frame wasn't byte-aligned → reject.
+    if (m_bitIndex != 7 || m_frameByteCount < 2) {
+        m_fcsValid = false;
+        m_frameSizeBits = m_rawBitsInFrame;
+        return true;
+    }
+
+    m_frameSizeBits = m_rawBitsInFrame;
+    m_bitsAfterFlag = 0;  // ready for postamble flag detection in InPreamble
+
+    // Compute expected FCS over frame[0..N-3] (all bytes except the 2 FCS bytes).
+    uint16_t crc = 0xFFFF;
+    for (size_t i = 0; i + 2 < m_frameByteCount; ++i)
+        crc = (crc >> 8) ^ kCrcTable[(crc ^ m_frameBuffer[i]) & 0xFF];
+    crc ^= 0xFFFF;
+
+    m_expectedFcs[0] = static_cast<uint8_t>(crc & 0xFF);
+    m_expectedFcs[1] = static_cast<uint8_t>((crc >> 8) & 0xFF);
+
+    m_actualFcs[0] = m_frameBuffer[m_frameByteCount - 2];
+    m_actualFcs[1] = m_frameBuffer[m_frameByteCount - 1];
+
+    m_fcsValid = (m_actualFcs == m_expectedFcs);
+    return true;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+
+bool HdlcCodec::processBit(uint8_t nrziTone)
+{
+    // Deferred reset: clear complete/aborted flags at the start of the next call
+    // so callers can read them after the frame-closing call returns.
+    if (m_complete) {
+        m_complete = false;
+        m_aborted  = false;
+    }
+
+    // NRZI decode: no transition = 1 (mark held), transition = 0 (space).
+    const uint8_t decoded = (nrziTone == m_prevNrzi) ? 1u : 0u;
+    m_prevNrzi = nrziTone;
+
+    // Shift new decoded bit into the rolling pattern register, newest at MSB.
+    m_patDet = static_cast<uint8_t>((m_patDet >> 1) | (decoded << 7));
+
+    switch (m_state) {
+
+    // ── Searching: scan for the first preamble flag ─────────────────────
+    case State::Searching:
+        if (m_patDet == 0x7E) {
+            m_state = State::InPreamble;
+            m_preambleCount = 1;
+            beginFrame();
+        }
+        break;
+
+    // ── InPreamble: count consecutive flags, wait for first frame bit ───
+    //
+    // We require 8 consecutive non-flag bits before entering InFrame.
+    // This mirrors libmodem's (bitstream_size >= 8) check and prevents a
+    // false InFrame transition on the very first bit of the next preamble
+    // flag (which would briefly disrupt pat_det away from 0x7E).
+    //
+    // Bits accumulate during this window; they become the first byte of the
+    // frame.  A flag anywhere in the window calls beginFrame() and resets
+    // the count, discarding those partial bits.
+    case State::InPreamble:
+        if (m_patDet == 0x7E) {
+            // Another consecutive preamble flag.
+            ++m_preambleCount;
+            beginFrame();  // clears m_bitsAfterFlag, byte state, etc.
+        } else {
+            // Potential frame data — accumulate and count.
+            ++m_rawBitsInFrame;
+            ++m_bitsAfterFlag;
+            accumulateBit(decoded);
+            // accumulateBit may have set state = Searching on overflow;
+            // only transition to InFrame if we're still in InPreamble.
+            if (m_state == State::InPreamble && m_bitsAfterFlag >= 8)
+                m_state = State::InFrame;
+        }
+        break;
+
+    // ── InFrame: collect frame bytes ────────────────────────────────────
+    case State::InFrame:
+        ++m_rawBitsInFrame;  // first 8 bits counted in InPreamble; continue here
+
+        // Priority 1 — Flag (checked before stuffing; 0x7E matches both but
+        // flag must win so the closing zero is never discarded as a stuffed bit).
+        if (m_patDet == 0x7E) {
+            return closeFrame();
+        }
+
+        // Priority 2 — Bit stuffing: current bit is 0 (bit7=0) and the five
+        // preceding bits are all 1 (bits 6..2 = 11111).  Discard the stuffed zero.
+        if ((m_patDet >> 2) == 0x1F) {
+            break;  // discard — do not accumulate
+        }
+
+        // Priority 3 — Abort: 7 consecutive ones (0xFE = 01111111 after final 0
+        // closes the abort, or 0xFF for 8 ones).
+        if (m_patDet == 0xFE || m_patDet == 0xFF) {
+            m_aborted = true;
+            m_state   = State::Searching;
+            m_patDet  = 0;
+            beginFrame();
+            break;
+        }
+
+        // Data bit — accumulate LSB-first into current byte.
+        accumulateBit(decoded);
+        break;
+    }
+
+    return false;
+}
+
+} // namespace AetherSDR

--- a/src/core/tnc/HdlcCodec.h
+++ b/src/core/tnc/HdlcCodec.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstddef>
+
+namespace AetherSDR {
+
+// Pure C++ HDLC framing for AX.25.  Processes one NRZI tone at a time.
+// Replaces lm::ax25::bitstream_state + lm::ax25::try_decode_bitstream in the
+// VHF 1200-baud decode path, keeping libmodem only for HF demod and AX.25
+// structure parsing.  No Qt, no libmodem, no Direwolf derivation.
+//
+// Algorithm: Direwolf-style shift-register flag/stuff/abort detection with
+// incremental byte assembly and batch CRC validation at frame close.
+class HdlcCodec {
+public:
+    // Maximum frame size in bytes (includes 2 FCS bytes).
+    // AX.25 max frame body is ~330 bytes; 512 gives comfortable headroom.
+    static constexpr size_t kMaxFrameBytes = 512;
+
+    void reset();
+
+    // Feed one NRZI tone (1 = mark, 0 = space).
+    // Returns true the call that closes a frame (complete() transitions false→true).
+    // complete() stays true until the next processBit() call.
+    bool processBit(uint8_t nrziTone);
+
+    // State accessors (valid immediately after processBit returns).
+    bool searching()  const { return m_state == State::Searching; }
+    bool inPreamble() const { return m_state == State::InPreamble; }
+    bool inFrame()    const { return m_state == State::InFrame; }
+    bool complete()   const { return m_complete; }
+    bool aborted()    const { return m_aborted; }
+    bool fcsValid()   const { return m_fcsValid; }
+
+    // Raw-bit count for the current in-progress frame (diagnostic).
+    int bitstreamSize() const;
+
+    // Bit length of the last completed frame (set at frame close).
+    int frameSizeBits()  const { return m_frameSizeBits; }
+    int preambleCount()  const { return m_preambleCount; }
+
+    // Frame bytes including the 2-byte FCS field.  Valid from the
+    // processBit() call that set complete() until reset() is called.
+    const uint8_t* frameData() const { return m_frameBuffer.data(); }
+    size_t         frameSize() const { return m_frameByteCount; }
+
+    // FCS bytes: actual = last 2 bytes of frame; expected = CRC of frame[0..N-3].
+    std::array<uint8_t, 2> actualFcs()   const { return m_actualFcs; }
+    std::array<uint8_t, 2> expectedFcs() const { return m_expectedFcs; }
+
+private:
+    enum class State : uint8_t { Searching, InPreamble, InFrame };
+
+    bool closeFrame();
+    void accumulateBit(uint8_t bit);
+    void beginFrame();
+
+    State   m_state{State::Searching};
+    bool    m_complete{false};
+    bool    m_aborted{false};
+    bool    m_fcsValid{false};
+
+    uint8_t m_prevNrzi{0};
+    uint8_t m_patDet{0};   // rolling 8-bit pattern, newest bit at MSB
+
+    // Incremental byte assembly
+    uint8_t m_currentByte{0};
+    int     m_bitIndex{0};
+
+    // Frame storage
+    std::array<uint8_t, kMaxFrameBytes> m_frameBuffer{};
+    size_t m_frameByteCount{0};
+
+    // Diagnostics
+    int m_frameSizeBits{0};
+    int m_preambleCount{0};
+    int m_rawBitsInFrame{0};   // raw bits seen while in InFrame (not unstuffed)
+    int m_bitsAfterFlag{0};    // non-flag bits since last preamble flag; require >=8 to enter InFrame
+
+    std::array<uint8_t, 2> m_actualFcs{};
+    std::array<uint8_t, 2> m_expectedFcs{};
+};
+
+} // namespace AetherSDR

--- a/tests/hdlc_codec_test.cpp
+++ b/tests/hdlc_codec_test.cpp
@@ -1,0 +1,269 @@
+#include "core/tnc/HdlcCodec.h"
+
+#include "bitstream.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace lm = aether_libmodem_core;
+using AetherSDR::HdlcCodec;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok)
+        ++g_failed;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+// Feed a vector of NRZI bits into the codec and return the number of
+// complete-frame transitions.
+struct FeedResult {
+    int frames{0};
+    int goodFcs{0};
+};
+
+FeedResult feedBits(HdlcCodec& codec, const std::vector<uint8_t>& nrzi)
+{
+    FeedResult r;
+    for (uint8_t bit : nrzi) {
+        if (codec.processBit(bit)) {
+            ++r.frames;
+            if (codec.fcsValid())
+                ++r.goodFcs;
+        }
+    }
+    return r;
+}
+
+// Build a known AX.25 packet using libmodem and NRZI-encode it.
+// Returns the NRZI bitstream (one byte per bit, values 0/1).
+std::vector<uint8_t> makeNrziBitstream(const lm::packet& pkt,
+                                       int preamble = 10,
+                                       int postamble = 3)
+{
+    auto bs = lm::ax25::encode_bitstream(pkt, preamble, postamble);
+    return bs;  // encode_bitstream already returns NRZI-encoded bits
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+void testSingleFrame()
+{
+    lm::packet pkt("N0CALL-9", "APRS", {"WIDE1-1", "WIDE2-1"}, ">Test payload 123");
+    auto nrzi = makeNrziBitstream(pkt);
+
+    HdlcCodec codec;
+    auto r = feedBits(codec, nrzi);
+
+    report("single frame: exactly one complete", r.frames == 1);
+    report("single frame: FCS valid", r.goodFcs == 1);
+}
+
+void testFrameContents()
+{
+    lm::packet pkt("W5XD", "APRS", {}, ">Hello world");
+    auto nrzi = makeNrziBitstream(pkt);
+
+    HdlcCodec codec;
+    bool gotFrame = false;
+    for (uint8_t bit : nrzi) {
+        if (codec.processBit(bit)) {
+            gotFrame = true;
+            break;
+        }
+    }
+
+    report("frame contents: complete flag set", gotFrame && codec.complete());
+    report("frame contents: FCS valid", codec.fcsValid());
+    report("frame contents: at least 15 bytes", codec.frameSize() >= 15);
+
+    // Verify via libmodem's AX.25 parser (passing frame without last 2 FCS bytes)
+    if (codec.fcsValid() && codec.frameSize() >= 2) {
+        lm::packet decoded;
+        bool ok = lm::ax25::try_decode_frame_no_fcs(
+            std::span<const uint8_t>(codec.frameData(), codec.frameSize() - 2),
+            decoded);
+        report("frame contents: libmodem parses callsigns", ok && decoded.from == "W5XD");
+        report("frame contents: libmodem parses data",
+               ok && decoded.data == ">Hello world");
+    } else {
+        report("frame contents: libmodem parses callsigns", false);
+        report("frame contents: libmodem parses data", false);
+    }
+}
+
+void testFcsMatchesLibmodem()
+{
+    lm::packet pkt("K5PTB", "BEACON", {"WIDE1-1"}, ">CRC cross-check");
+    auto nrzi = makeNrziBitstream(pkt);
+
+    // Break immediately when the frame closes so complete()/fcsValid() are
+    // still true (they are reset at the start of the *next* processBit call).
+    HdlcCodec codec;
+    bool gotFrame = false;
+    for (uint8_t bit : nrzi) {
+        if (codec.processBit(bit)) {
+            gotFrame = true;
+            break;
+        }
+    }
+
+    if (!gotFrame || !codec.fcsValid()) {
+        report("FCS cross-check: codec decoded frame", false);
+        return;
+    }
+    report("FCS cross-check: codec decoded frame", true);
+
+    // libmodem's compute_crc over the frame body (excluding last 2 FCS bytes)
+    auto span = std::span<const uint8_t>(codec.frameData(), codec.frameSize() - 2);
+    auto libmodemFcs = lm::ax25::compute_crc(span.begin(), span.end());
+
+    report("FCS cross-check: CRC low byte matches libmodem",
+           codec.expectedFcs()[0] == libmodemFcs[0]);
+    report("FCS cross-check: CRC high byte matches libmodem",
+           codec.expectedFcs()[1] == libmodemFcs[1]);
+    report("FCS cross-check: actual FCS == expected FCS",
+           codec.actualFcs() == codec.expectedFcs());
+}
+
+void testBadFcs()
+{
+    // Corrupt a bit in the middle of the bitstream and verify FCS fails.
+    lm::packet pkt("N0CALL", "APRS", {}, ">Corruption test");
+    auto nrzi = makeNrziBitstream(pkt);
+
+    // Flip a bit roughly in the middle (well away from preamble/postamble flags).
+    size_t mid = nrzi.size() / 2;
+    nrzi[mid] ^= 1;
+
+    HdlcCodec codec;
+    int frames = 0;
+    int badFcs = 0;
+    for (uint8_t bit : nrzi) {
+        if (codec.processBit(bit)) {
+            ++frames;
+            if (!codec.fcsValid())
+                ++badFcs;
+        }
+    }
+
+    // We expect at least one complete frame (may not decode as valid AX.25)
+    // but the FCS should be wrong.
+    report("bad FCS: at least one frame candidate", frames >= 1);
+    report("bad FCS: no valid FCS", badFcs == frames);
+}
+
+void testTwoConsecutiveFrames()
+{
+    lm::packet p1("AA1BB", "APRS", {}, ">First");
+    lm::packet p2("CC3DD", "APRS", {}, ">Second");
+
+    // Encode p1 normally, then encode p2 starting from the NRZI level where
+    // p1 left off.  Without this, bs2 starts at level 0 while the codec's
+    // prevNrzi is whatever bs1 ended on, causing mis-decoded first bits.
+    auto bs1 = lm::ax25::encode_bitstream(p1, 5, 2);
+    const uint8_t finalLevel = bs1.empty() ? 0 : bs1.back();
+    auto bs2 = lm::ax25::encode_bitstream(p2, finalLevel, 5, 2);
+
+    HdlcCodec codec;
+    FeedResult r1 = feedBits(codec, bs1);
+    FeedResult r2 = feedBits(codec, bs2);
+
+    report("two frames: first decoded", r1.goodFcs == 1);
+    report("two frames: second decoded", r2.goodFcs == 1);
+}
+
+void testPreambleCount()
+{
+    lm::packet pkt("N0CALL", "APRS", {}, ">preamble count");
+    auto nrzi = makeNrziBitstream(pkt, 10, 3);
+
+    HdlcCodec codec;
+    for (uint8_t bit : nrzi)
+        codec.processBit(bit);
+
+    // Preamble count should be >= 10 (the requested preamble flags).
+    report("preamble count >= 10", codec.preambleCount() >= 10);
+}
+
+void testReset()
+{
+    lm::packet pkt("N0CALL", "APRS", {}, ">Reset test");
+    auto nrzi = makeNrziBitstream(pkt);
+
+    HdlcCodec codec;
+    feedBits(codec, nrzi);
+
+    codec.reset();
+
+    report("reset: searching after reset", codec.searching());
+    report("reset: not complete after reset", !codec.complete());
+    report("reset: zero frame size after reset", codec.frameSize() == 0);
+
+    // Should decode again after reset.
+    auto r = feedBits(codec, nrzi);
+    report("reset: decodes again after reset", r.goodFcs == 1);
+}
+
+void testStateTransitions()
+{
+    HdlcCodec codec;
+    report("initial state: searching", codec.searching());
+    report("initial state: not in preamble", !codec.inPreamble());
+    report("initial state: not in frame", !codec.inFrame());
+    report("initial state: not complete", !codec.complete());
+
+    // Feed one preamble flag: 0x7E = 0,1,1,1,1,1,1,0 (NRZ LSB-first)
+    // NRZI encode it starting from level 0.
+    uint8_t level = 0;
+    const uint8_t nrzFlag[8] = {0, 1, 1, 1, 1, 1, 1, 0};
+    for (int i = 0; i < 8; ++i) {
+        if (nrzFlag[i] == 0)
+            level ^= 1;
+        codec.processBit(level);
+    }
+    report("after one flag: in preamble", codec.inPreamble());
+}
+
+void testLongPayload()
+{
+    // 256-byte payload — exercises the frame buffer boundary
+    std::string data(256, 'X');
+    data[0] = '>';
+    lm::packet pkt("N0CALL", "APRS", {}, data);
+    auto nrzi = makeNrziBitstream(pkt);
+
+    HdlcCodec codec;
+    auto r = feedBits(codec, nrzi);
+    report("long payload: decoded", r.goodFcs == 1);
+}
+
+} // namespace
+
+int main()
+{
+    testStateTransitions();
+    testSingleFrame();
+    testFrameContents();
+    testFcsMatchesLibmodem();
+    testBadFcs();
+    testTwoConsecutiveFrames();
+    testPreambleCount();
+    testReset();
+    testLongPayload();
+
+    if (g_failed == 0)
+        std::printf("All tests passed.\n");
+    else
+        std::printf("%d test(s) FAILED.\n", g_failed);
+
+    return g_failed ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Second of three focused PRs extracted from #3466 per @jensenpat's review guidance, implementing part of the design laid out in #2701 (Native Soft-TNC + APRS Integration). Introduces `HdlcCodec`, a self-contained pure-C++ HDLC framer with CRC-16-CCITT, and wires it into the VHF 1200-baud decode lane in place of libmodem's `bitstream_state`. libmodem is retained for HF demodulation and AX.25 frame parsing.

Also addresses non-blocking review notes 1 and 2 from #3473: lane count restored in `ax25DemodDescription()` via `ax25DemodLaneCount()`, and two explanatory comments restored in `ax25BuildTransmitAudioFromFrame`.

## Motivation

libmodem's `bitstream_state` is an opaque internal struct — not unit-testable in isolation and not replaceable without forking libmodem. Extracting HDLC framing into `HdlcCodec` makes the state machine independently testable, and establishes the boundary where the Direwolf demodulator (PR 3) will plug in.

## Changes

- **New:** `src/core/tnc/HdlcCodec.h` / `HdlcCodec.cpp` — pure C++ HDLC bit-unstuffing and CRC-16-CCITT framer
- **New:** `tests/hdlc_codec_test.cpp` — 27 tests covering state transitions, FCS validation cross-checked against libmodem, two-frame decode, long payload, and reset
- `CMakeLists.txt`: added `HdlcCodec.cpp` to main build and shim test; added `hdlc_codec_test` target
- `AetherAx25LibmodemShim`: `DecodeLane` replaces `bitstreamState` with `HdlcCodec hdlcCodec`
- `ax25DemodLaneCount()` free function added; `ax25DemodDescription()` now includes lane count suffix
- Two explanatory comments restored in `ax25BuildTransmitAudioFromFrame` (minimum-frame-size invariant; host-omits-FCS note)

## Test plan

Tested on all three target platforms.

1. **Unit tests** — `hdlc_codec_test`, `ax25_libmodem_shim_test`, `ax25_frame_formatter_test`, `tnc_terminal_test` all pass on all three platforms (these also retroactively cover the PR 1 shim refactor):

   | Platform | ax25_frame_formatter | ax25_libmodem_shim | hdlc_codec | tnc_terminal |
   |---|---|---|---|---|
   | Mac M2 | ✓ | ✓ | ✓ | ✓ |
   | Win11 i3 | ✓ 11/11 | ✓ 107/107 | ✓ 25/25 | ✓ |
   | RPi5 Debug+ASAN | ✓ | ✓ | ✓ | ✓ |

2. **Basic VHF decode on-air** — frames decoded on 144.390 MHz APRS on Mac M2, RPi 5, and Win 11. Decode rate consistent with PR 1 baseline; no regression from codec change.

3. **TX path** — UI frame transmitted; confirmed key, send, and unkey without crash or hang. Hardware note: transverter attenuated to prevent RF output — full software TX path exercised but no RF generated.

4. **Clean shutdown** — dialog closed while modem enabled; no hang or crash on all three platforms.

**RX sensitivity note:** Consistent decode requires a strong local signal (HT at close range). This is a known pre-existing libmodem limitation addressed in PR 3 (Direwolf demodulator), not a regression.

**300-baud HF decode** — not tested on-air; HF path uses libmodem's HDLC unchanged; `HdlcCodec` only affects the VHF 1200-baud lane. Risk is low but noted.

---

Extracted from #3466 (closed). Depends on #3473 (merged).

**Note:** The follow-on PR adding the Direwolf demodulator ([feat/ax25-direwolf-demod](https://github.com/K5PTB/AetherSDR/tree/feat/ax25-direwolf-demod)) is ready but will require extended comparison testing before it can be submitted. It will be opened against `main` after this PR merges and testing is complete.