### PR TITLE
fix(hid): add StreamDeck+ udev rule + correct HID migration default

### DIFF
--- a/packaging/linux/60-hid-encoders.rules
+++ b/packaging/linux/60-hid-encoders.rules
@@ -10,3 +10,5 @@ SUBSYSTEM=="hidraw", ATTRS{idVendor}=="077d", ATTRS{idProduct}=="0410", MODE="06
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0020", MODE="0666"
 # Contour ShuttlePro v2
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0030", MODE="0666"
+# Elgato StreamDeck+
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0084", MODE="0666"

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4481,9 +4481,20 @@ MainWindow::MainWindow(QWidget* parent)
     {
         auto& s = AppSettings::instance();
         if (!s.contains("HidEncoderEnabled")) {
+            // Old code treated absence of HidEncoderAutoDetect as True (implicit default).
+            // Match that: if the key was never written, the user had HID on.
             const bool hadAutodetect =
-                s.value("HidEncoderAutoDetect", "False").toString() == "True";
+                s.value("HidEncoderAutoDetect", "True").toString() == "True";
             s.setValue("HidEncoderEnabled", hadAutodetect ? "True" : "False");
+        } else if (!s.contains("HidEncoderEnabledMigrationV2")) {
+            // V2 fix: the first migration wrote "False" for users who never set
+            // HidEncoderAutoDetect (old implicit default was True, not False).
+            // Correct those installs: if AutoDetect is absent they had it on.
+            if (s.value("HidEncoderEnabled") == "False" &&
+                    !s.contains("HidEncoderAutoDetect")) {
+                s.setValue("HidEncoderEnabled", "True");
+            }
+            s.setValue("HidEncoderEnabledMigrationV2", "True");
         }
     }
     // Same TCC concern as the Ulanzi gate above (#3257). HidEncoderManager::


### PR DESCRIPTION
## Summary

Two root causes for the StreamDeck+ going dark after the v26.6 opt-in gate (#3258):

- **Missing udev rule (Linux)**: `60-hid-encoders.rules` had no entry for the StreamDeck+ (`0fd9:0084`). Without it hidraw is root-only on Linux, so `hid_open()` fails silently — the device appears in the Serial panel but never powers up.
- **Wrong migration default**: The v1 migration reads `HidEncoderAutoDetect` with a fallback of `"False"`, but the old code treated the key's *absence* as `"True"` (implicit default, line 8029). Users who never explicitly set that key had HID working via the old always-on path, but the migration silently wrote `HidEncoderEnabled=False` for them. A V2 one-shot migration now detects and corrects those installs.

## Test plan
- [ ] Plug in StreamDeck+ on Linux, reload udev rules, confirm device connects without root
- [ ] On a fresh/affected install, verify `HidEncoderEnabled` flips to `True` on startup (Preferences → Serial checkbox)
- [ ] Confirm RC-28, PowerMate, ShuttleXpress still work (their udev entries untouched)
- [ ] Confirm macOS is unaffected (no udev involved; migration logic is platform-agnostic)

Fixes regression introduced by #3258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)