### PR TITLE
fix(tci/dax): DAX RX lifecycle hotfix — stopDax ownership guard, profile-switch recreate, debounced teardown (#3363, #3364, #3476)

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -36,6 +36,12 @@ namespace {
 // matches the rigctld cap.
 constexpr qint64 kMaxWsMessageBytes = 64 * 1024;
 constexpr int    kMaxClients        = 8;
+// Grace period before tearing down DAX RX after the last audio client drops.
+// A TCP drop is frequently transient (WSJT-X throws on a CAT timeout — e.g. a
+// vfo: echo delayed by an ATU tune — then reconnects within ~2s). Deferring the
+// teardown lets the stream survive the blip so audio resumes with no recreate;
+// a reconnecting client cancels it. (#3363/#3476 + Tune/ATU)
+constexpr int    kDaxReleaseGraceMs = 5000;
 }
 
 // ── TCI binary audio frame header (per ExpertSDR3 TCI spec v2.0) ────────
@@ -237,6 +243,22 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
     m_meterTimer->setInterval(200);
     connect(m_meterTimer, &QTimer::timeout, this, &TciServer::broadcastStatus);
 
+    // Debounced DAX RX teardown — see scheduleDaxRelease(). Single-shot; a
+    // reconnecting audio client cancels it before it fires.
+    m_daxReleaseTimer = new QTimer(this);
+    m_daxReleaseTimer->setSingleShot(true);
+    connect(m_daxReleaseTimer, &QTimer::timeout, this, [this]() {
+        bool anyAudio = false;
+        for (const auto& cs : m_clients)
+            if (cs.audioEnabled) { anyAudio = true; break; }
+        if (anyAudio) {
+            qCWarning(lcCat) << "TCI: DAX release grace expired but an audio client is active — keeping DAX RX";
+            return;
+        }
+        qCWarning(lcCat) << "TCI: DAX release grace expired, no audio client returned — releasing DAX RX now";
+        releaseDaxForTci();
+    });
+
     // TX_CHRONO timer — sends timing frames to TCI client during TX.
     // WSJT-X only sends TX audio in response to these frames.
     //
@@ -301,6 +323,7 @@ bool TciServer::start(quint16 port)
 void TciServer::stop()
 {
     m_meterTimer->stop();
+    if (m_daxReleaseTimer) m_daxReleaseTimer->stop();  // immediate teardown below
     stopTxChrono();
 
     if (!m_server) return;
@@ -472,7 +495,7 @@ void TciServer::onClientDisconnected()
             for (const auto& cs : m_clients) {
                 if (cs.audioEnabled) { anyAudio = true; break; }
             }
-            if (!anyAudio) releaseDaxForTci();
+            if (!anyAudio) scheduleDaxRelease();  // debounce: survive transient WSJT-X reconnects
             break;
         }
     }
@@ -558,6 +581,7 @@ void TciServer::onTextMessage(const QString& msg)
             }
             client.audioEnabled = true;
             client.audioReceiver = requestedReceiver;
+            cancelDaxRelease();  // a (re)connecting audio client cancels a pending teardown
             ensureDaxForTci();
             replyText(ws,cmd.trimmed() + ";");
             qCDebug(lcCat) << "TCI: audio started"
@@ -582,7 +606,7 @@ void TciServer::onTextMessage(const QString& msg)
             for (const auto& cs : m_clients) {
                 if (cs.audioEnabled) { anyAudio = true; break; }
             }
-            if (!anyAudio) releaseDaxForTci();
+            if (!anyAudio) scheduleDaxRelease();  // debounce: audio_stop is often followed by a quick audio_start
             replyText(ws,cmd.trimmed() + ";");
             qCWarning(lcCat) << "TCI: audio_stop from client"
                              << ws->peerAddress().toString()
@@ -1968,6 +1992,31 @@ void TciServer::ensureDaxForTci()
             qCInfo(lcCat) << "TCI: re-asserting dax=" << ch
                           << "on slice" << s->sliceId();
         }
+    }
+}
+
+void TciServer::scheduleDaxRelease()
+{
+    // Debounce the DAX RX teardown. A TCP client drop is frequently transient:
+    // WSJT-X throws a rig-control error (e.g. a vfo: echo delayed past its 2s
+    // timeout by an ATU tune, or a profile-load band change) and reconnects
+    // within ~2s. Tearing DAX RX down immediately turns that blip into
+    // permanent silence (#3363 / #3476 / Tune-ATU). Defer it; a reconnecting
+    // client that re-arms audio cancels the timer (cancelDaxRelease()), so the
+    // stream survives and audio resumes with no recreate. If the radio actually
+    // destroyed the streams meanwhile (profile slice recreate), the reactive
+    // "stream removed" handler keeps m_tciDaxStreamIds truthful regardless.
+    if (!m_daxReleaseTimer) { releaseDaxForTci(); return; }
+    qCWarning(lcCat) << "TCI: last audio client gone — deferring DAX RX release"
+                     << kDaxReleaseGraceMs << "ms (cancelled if a client reconnects)";
+    m_daxReleaseTimer->start(kDaxReleaseGraceMs);
+}
+
+void TciServer::cancelDaxRelease()
+{
+    if (m_daxReleaseTimer && m_daxReleaseTimer->isActive()) {
+        m_daxReleaseTimer->stop();
+        qCWarning(lcCat) << "TCI: audio client (re)armed — cancelled pending DAX RX release; stream kept alive";
     }
 }
 

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -132,8 +132,19 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 for (auto it = m_tciDaxStreamIds.begin(); it != m_tciDaxStreamIds.end(); ++it) {
                     if (it.value() == streamId) {
                         qCInfo(lcCat) << "TCI: radio removed DAX RX stream" << Qt::hex << streamId
-                                      << "for channel" << it.key();
-                        it.value() = 0;
+                                      << "for channel" << it.key()
+                                      << "— clearing cache entry so re-arm recreates it (#3476)";
+                        // Erase (not zero) the entry. Leaving a key behind keeps
+                        // ensureDaxForTci()'s `contains(ch)` guard true, so after a
+                        // profile load / slice teardown — which destroys the radio's
+                        // dax_rx stream without a TCI disconnect — the sliceAdded
+                        // re-arm skips `stream create` and TCI RX stays silent until
+                        // a full reconnect. That is the #3476/#3364 "switched profile,
+                        // never came back" failure. Pending creates (value 0) are
+                        // never matched here (streamId != 0), so an in-flight request
+                        // is safe.
+                        m_tciDaxBorrowedChannels.remove(it.key());
+                        m_tciDaxStreamIds.erase(it);
                         break;
                     }
                 }

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -38,10 +38,14 @@ constexpr qint64 kMaxWsMessageBytes = 64 * 1024;
 constexpr int    kMaxClients        = 8;
 // Grace period before tearing down DAX RX after the last audio client drops.
 // A TCP drop is frequently transient (WSJT-X throws on a CAT timeout — e.g. a
-// vfo: echo delayed by an ATU tune — then reconnects within ~2s). Deferring the
-// teardown lets the stream survive the blip so audio resumes with no recreate;
-// a reconnecting client cancels it. (#3363/#3476 + Tune/ATU)
-constexpr int    kDaxReleaseGraceMs = 5000;
+// vfo: echo delayed by an ATU tune — then reconnects). Deferring the teardown
+// lets the stream survive the blip so audio resumes with no recreate; a
+// reconnecting client cancels it. (#3363/#3476 + Tune/ATU)
+// Measured drop→audio_start gaps in the field repros: 2.1s / 3.3s / 3.5s —
+// and WSJT-X is slowest to reconnect mid-FT8-decode, exactly when these
+// throws happen. 10s gives ~3x margin; the cost of lingering after a genuine
+// quit is just an unconsumed stream + dax flag for a few extra seconds.
+constexpr int    kDaxReleaseGraceMs = 10000;
 }
 
 // ── TCI binary audio frame header (per ExpertSDR3 TCI spec v2.0) ────────
@@ -214,6 +218,13 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 }
                 m_tciDaxStreamIds.clear();
                 m_tciDaxBorrowedChannels.clear();
+                // Also drop the slice-assignment bookkeeping: slices are being
+                // destroyed with the connection, and a releaseDaxForTci() that
+                // runs later (e.g. the debounced grace timer firing after a
+                // quick radio reconnect) must not setDaxChannel(0) on the
+                // RECREATED slices — that would strip a profile-restored DAX
+                // assignment from a slice we no longer manage.
+                m_tciDaxSlices.clear();
                 return;
             }
             for (const auto& cs : m_clients) {

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -478,8 +478,11 @@ void TciServer::onClientDisconnected()
     }
 
     ws->deleteLater();
-    qCInfo(lcCat) << "TciServer: client disconnected,"
-                  << m_clients.size() << "remaining";
+    // DIAG: qCWarning — a TCP-level client drop (WSJT-X threw a rig-control
+    // error in do_stop()) is the trigger for the DAX RX teardown above. Always
+    // log it so the cause of mid-session RX loss is visible.
+    qCWarning(lcCat) << "TciServer: client disconnected (TCP drop),"
+                     << m_clients.size() << "remaining";
     emit clientCountChanged(m_clients.size());
     emit clientsChanged();
 }
@@ -556,7 +559,7 @@ void TciServer::onTextMessage(const QString& msg)
             client.audioEnabled = true;
             client.audioReceiver = requestedReceiver;
             ensureDaxForTci();
-            ws->sendTextMessage(cmd.trimmed() + ";");
+            replyText(ws,cmd.trimmed() + ";");
             qCDebug(lcCat) << "TCI: audio started"
                            << "receiver=" << client.audioReceiver
                            << "rate=" << client.audioSampleRate
@@ -580,9 +583,10 @@ void TciServer::onTextMessage(const QString& msg)
                 if (cs.audioEnabled) { anyAudio = true; break; }
             }
             if (!anyAudio) releaseDaxForTci();
-            ws->sendTextMessage(cmd.trimmed() + ";");
-            qCInfo(lcCat) << "TCI: audio stopped for client"
-                          << ws->peerAddress().toString();
+            replyText(ws,cmd.trimmed() + ";");
+            qCWarning(lcCat) << "TCI: audio_stop from client"
+                             << ws->peerAddress().toString()
+                             << "(anyAudio=" << anyAudio << ")";
             emit clientsChanged();
             continue;
         }
@@ -601,7 +605,7 @@ void TciServer::onTextMessage(const QString& msg)
                 qCInfo(lcCat) << "TCI: audio sample rate set to" << rate
                               << "for" << ws->peerAddress().toString();
             }
-            ws->sendTextMessage(QStringLiteral("audio_samplerate:%1;")
+            replyText(ws,QStringLiteral("audio_samplerate:%1;")
                                     .arg(client.audioSampleRate));
             continue;
         }
@@ -617,7 +621,7 @@ void TciServer::onTextMessage(const QString& msg)
                 fmt = fmtStr.toInt();  // numeric value
             if (fmt == 0 || fmt == 3)  // int16 or float32
                 client.audioFormat = fmt;
-            ws->sendTextMessage(QStringLiteral("audio_stream_sample_type:%1;")
+            replyText(ws,QStringLiteral("audio_stream_sample_type:%1;")
                                     .arg(client.audioFormat));
             continue;
         }
@@ -626,7 +630,7 @@ void TciServer::onTextMessage(const QString& msg)
             int colonIdx2 = trimmed.indexOf(':');
             QString val = trimmed.mid(colonIdx2 + 1).split(',').first();
             client.rxSensorsEnabled = (val == "true");
-            ws->sendTextMessage(QStringLiteral("rx_sensors_enable:%1;")
+            replyText(ws,QStringLiteral("rx_sensors_enable:%1;")
                                     .arg(client.rxSensorsEnabled ? "true" : "false"));
             qCInfo(lcCat) << "TCI: rx_sensors" << (client.rxSensorsEnabled ? "enabled" : "disabled");
             emit clientsChanged();
@@ -636,7 +640,7 @@ void TciServer::onTextMessage(const QString& msg)
             int colonIdx2 = trimmed.indexOf(':');
             QString val = trimmed.mid(colonIdx2 + 1).split(',').first();
             client.txSensorsEnabled = (val == "true");
-            ws->sendTextMessage(QStringLiteral("tx_sensors_enable:%1;")
+            replyText(ws,QStringLiteral("tx_sensors_enable:%1;")
                                     .arg(client.txSensorsEnabled ? "true" : "false"));
             qCInfo(lcCat) << "TCI: tx_sensors" << (client.txSensorsEnabled ? "enabled" : "disabled");
             emit clientsChanged();
@@ -655,7 +659,7 @@ void TciServer::onTextMessage(const QString& msg)
             // Forward to protocol to create DAX IQ stream on the radio
             QString response = client.protocol->handleCommand(cmd.trimmed());
             if (!response.isEmpty())
-                ws->sendTextMessage(response);
+                replyText(ws,response);
             emit clientsChanged();
             continue;
         }
@@ -669,7 +673,7 @@ void TciServer::onTextMessage(const QString& msg)
                           << "trx=" << trx;
             QString response = client.protocol->handleCommand(cmd.trimmed());
             if (!response.isEmpty())
-                ws->sendTextMessage(response);
+                replyText(ws,response);
             emit clientsChanged();
             continue;
         }
@@ -690,19 +694,19 @@ void TciServer::onTextMessage(const QString& msg)
 
         if (trimmed.startsWith("audio_stream_samples:")) {
             // Samples per audio packet — acknowledge but we use fixed packet sizes
-            ws->sendTextMessage(cmd.trimmed() + ";");
+            replyText(ws,cmd.trimmed() + ";");
             continue;
         }
         if (trimmed.startsWith("tx_stream_audio_buffering:")) {
             // TX audio buffering in ms — acknowledge
-            ws->sendTextMessage(cmd.trimmed() + ";");
+            replyText(ws,cmd.trimmed() + ";");
             continue;
         }
         if (trimmed.startsWith("line_out_start") ||
             trimmed.startsWith("line_out_stop") ||
             trimmed.startsWith("line_out_recorder")) {
             // Line-out recording — not applicable to FlexRadio, acknowledge
-            ws->sendTextMessage(cmd.trimmed() + ";");
+            replyText(ws,cmd.trimmed() + ";");
             continue;
         }
         if (trimmed.startsWith("audio_stream_channels:")) {
@@ -710,14 +714,14 @@ void TciServer::onTextMessage(const QString& msg)
             int ch = trimmed.mid(colonIdx2 + 1).toInt();
             if (ch == 1 || ch == 2)
                 client.audioChannels = ch;
-            ws->sendTextMessage(QStringLiteral("audio_stream_channels:%1;")
+            replyText(ws,QStringLiteral("audio_stream_channels:%1;")
                                     .arg(client.audioChannels));
             continue;
         }
 
         QString response = client.protocol->handleCommand(cmd.trimmed());
         if (!response.isEmpty()) {
-            ws->sendTextMessage(response);
+            replyText(ws,response);
             qCDebug(lcCat) << "TCI cmd:" << cmd.trimmed()
                            << "-> resp:" << response.left(80).trimmed();
         }
@@ -1524,13 +1528,32 @@ void TciServer::sendInitBurst(QWebSocket* client)
     // Split the concatenated burst into individual messages.
     QString burst = protocol->generateInitBurst();
     const auto commands = burst.split(';', Qt::SkipEmptyParts);
-    for (const auto& cmd : commands)
+    for (const auto& cmd : commands) {
+        // DIAG: log each init-burst command — the startup vfo:/dds: here is what
+        // WSJT-X reconciles against on connect; a wrong/late one explains the
+        // "TCI failed set rxfreq" some users hit right at WSJT-X startup.
+        qCDebug(lcCat).noquote() << "TCI tx→init:" << (cmd + QLatin1Char(';'));
         client->sendTextMessage(cmd + ';');
+    }
     qCDebug(lcCat) << "TCI: sent init burst," << commands.size() << "commands";
+}
+
+void TciServer::replyText(QWebSocket* ws, const QString& msg)
+{
+    if (!ws) return;
+    // DIAG: per-command echoes (audio_*, vfo:, etc.) bypass the dispatch log
+    // at the top of onTextMessage via their early `continue`; log them here so
+    // every command's response is visible when chasing CAT timeouts (#tci-diag).
+    qCDebug(lcCat).noquote() << "TCI tx→client:" << msg.trimmed();
+    ws->sendTextMessage(msg);
 }
 
 void TciServer::broadcast(const QString& msg)
 {
+    // DIAG: every async broadcast (vfo:/trx:/modulation:/lock:/rx_smeter:…).
+    // The vfo: echo here is exactly what WSJT-X's do_frequency() waits ≤2s on
+    // before it throws "TCI failed set rxfreq" and drops the socket.
+    qCDebug(lcCat).noquote() << "TCI tx→all:" << msg.trimmed();
     for (auto& cs : m_clients)
         cs.socket->sendTextMessage(msg);
     emit tciMessage(QStringLiteral("tx"), msg);
@@ -1952,6 +1975,14 @@ void TciServer::releaseDaxForTci()
 {
     if (!m_model) return;
 
+    // DIAG (qCWarning so it survives default log levels): this is the path that
+    // silences WSJT-X RX on a client disconnect / audio_stop. It ran invisibly
+    // in the 26.6.2 repro because qCInfo(lcCat) is suppressed below warning.
+    qCWarning(lcCat) << "TCI: releaseDaxForTci() tearing down DAX RX —"
+                     << m_tciDaxStreamIds.size() << "stream(s),"
+                     << m_tciDaxSlices.size() << "slice assignment(s);"
+                     << "RX audio stops until the next audio_start re-arms it";
+
     // Remove DAX RX streams we created (skip borrowed streams — owned by DaxBridge
     // or pre-existing; removing them would break other audio consumers).
     for (auto it = m_tciDaxStreamIds.begin(); it != m_tciDaxStreamIds.end(); ++it) {
@@ -1966,8 +1997,8 @@ void TciServer::releaseDaxForTci()
                 m_model->sendCommand(QString("stream remove 0x%1")
                     .arg(streamId, 8, 16, QChar('0')));
             }
-            qCInfo(lcCat) << "TCI: removed DAX RX stream" << Qt::hex << streamId
-                          << "channel" << ch << "(#1331)";
+            qCWarning(lcCat) << "TCI: removed DAX RX stream" << Qt::hex << streamId
+                             << "channel" << ch << "(#1331)";
         }
     }
     m_tciDaxStreamIds.clear();
@@ -1976,7 +2007,7 @@ void TciServer::releaseDaxForTci()
     // Release DAX channel assignments we made
     for (int sliceId : m_tciDaxSlices) {
         if (auto* s = m_model->slice(sliceId)) {
-            qCInfo(lcCat) << "TCI: releasing DAX channel from slice" << sliceId << "(#1331)";
+            qCWarning(lcCat) << "TCI: releasing DAX channel from slice" << sliceId << "(#1331)";
             s->setDaxChannel(0);
         }
     }

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -200,6 +200,8 @@ private:
 
     void ensureDaxForTci();
     void releaseDaxForTci();
+    void scheduleDaxRelease();   // debounced releaseDaxForTci — cancel on reconnect
+    void cancelDaxRelease();
 
     QPointer<RadioModel> m_model;  // QPointer auto-clears when RadioModel is destroyed (#2385)
     AudioEngine*      m_audio{nullptr};
@@ -209,6 +211,7 @@ private:
     QMap<int, quint32> m_tciDaxStreamIds;      // DAX channel → stream ID created or borrowed by TCI
     QSet<int>          m_tciDaxBorrowedChannels; // channels where TCI reused an existing stream
     QTimer*           m_meterTimer{nullptr};  // 200ms status broadcast
+    QTimer*           m_daxReleaseTimer{nullptr}; // debounced DAX RX teardown
     QTimer*           m_txChronoTimer{nullptr}; // TX_CHRONO frame cadence
     QWebSocket*       m_txChronoClient{nullptr};
     int               m_txChronoTrx{0};

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -147,6 +147,9 @@ private slots:
 
 private:
     void sendInitBurst(QWebSocket* client);
+    // Diagnostic: log + send a text reply to one client (per-command echoes
+    // bypass the central dispatch log, so route them here for visibility).
+    void replyText(QWebSocket* ws, const QString& msg);
     void broadcastSpotClicked(const QString& callsign, long long frequencyHz,
                               int trx, int channel);
     SliceModel* sliceForPanId(const QString& panId) const;

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -1087,11 +1087,30 @@ void MainWindow::stopDax()
     disconnect(m_daxBridge, &DaxBridge::txAudioReady,
                this, nullptr);
 
-    // Remove DAX RX streams from radio and unregister from PanadapterStream
-    const auto daxIds = m_radioModel.panStream()->daxStreamIds();
-    for (quint32 id : daxIds) {
+    // Remove DAX RX streams from the radio — but only channels no other
+    // consumer still needs. TCI borrows bridge-created streams (#1331/#1439)
+    // and RADE may hold one; unconditionally removing every registered stream
+    // here silenced WSJT-X / RADE the instant the DAX bridge (or mute) was
+    // toggled off — the #3363 / #2886 failure. Mirror the ownership guard in
+    // onDaxChannelChanged(); full refcounting is tracked in #3305.
+    auto* ps = m_radioModel.panStream();
+    for (int ch = 1; ch <= 4; ++ch) {
+        const quint32 id = ps->daxStreamIdForChannel(ch);
+        if (id == 0) continue;
+        const bool tciUsing = tciServer() && tciServer()->ownsDaxChannel(ch);
+#ifdef HAVE_RADE
+        const bool radeUsing = (id == m_radeDaxStreamId);
+#else
+        const bool radeUsing = false;
+#endif
+        if (tciUsing || radeUsing) {
+            qCInfo(lcDax) << "MainWindow: keeping DAX RX stream"
+                          << "0x" + QString::number(id, 16) << "for channel" << ch
+                          << "— still used by" << (tciUsing ? "TCI" : "RADE") << "(#3363)";
+            continue;
+        }
         m_radioModel.sendCommand(QString("stream remove 0x%1").arg(id, 0, 16));
-        m_radioModel.panStream()->unregisterDaxStream(id);
+        ps->unregisterDaxStream(id);
     }
 
     // Restore original mic selection

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,10 +9,12 @@
 #include <QStyleFactory>
 #include <QDir>
 #include <QDebug>
+#include <QElapsedTimer>
 #include <QFile>
 #include <QFontDatabase>
 #include <QDateTime>
 #include <QStandardPaths>
+#include <QTimer>
 
 #ifdef _WIN32
 #include <io.h>
@@ -162,6 +164,31 @@ int main(int argc, char* argv[])
     app.setApplicationVersion(AETHERSDR_VERSION);
     app.setOrganizationName("AetherSDR");
     app.setDesktopFileName("AetherSDR");  // matches .desktop file for taskbar icon
+
+    // ── Main-thread stall watchdog (diagnostic, log-only) ─────────────────
+    // 250 ms heartbeat on the GUI event loop. If a tick arrives late by more
+    // than the threshold, the main thread was blocked — e.g. the ~2 s
+    // band-change+ATU stall that delays the TCI `vfo:` echo past WSJT-X's
+    // 2000 ms timeout ("TCI failed set rxfreq" → disconnect → dead RX).
+    // The warning fires immediately after the loop unblocks, so the stall's
+    // start ≈ (log timestamp − reported gap), and whatever logs right after
+    // it is what the loop was waiting to do. qWarning → visible at default
+    // log levels.
+    {
+        static QElapsedTimer s_lastBeat;
+        s_lastBeat.start();
+        auto* heartbeat = new QTimer(&app);
+        QObject::connect(heartbeat, &QTimer::timeout, &app, []() {
+            const qint64 gapMs = s_lastBeat.restart();
+            if (gapMs > 600) {
+                qWarning().nospace()
+                    << "MainThreadWatchdog: event loop stalled ~" << gapMs
+                    << " ms (heartbeat is 250 ms; stall began ~" << gapMs
+                    << " ms before this line)";
+            }
+        });
+        heartbeat->start(250);
+    }
 
     // ── Bundled DSEG fonts (SIL OFL 1.1) ──────────────────────────────────
     // Register the 13 TTFs into QFontDatabase so themes can resolve


### PR DESCRIPTION
## Summary

Closes #3363
Closes #3476

Hotfix bundle for the TCI/WSJT-X RX-audio-loss cluster (#3363, #3476, and the already-closed duplicate #3364; materially helps #2886 and #3366), plus the diagnostics that root-caused it. All failures share one shape: a DAX RX stream that WSJT-X depends on is torn down (or never recreated) by a path that doesn't know WSJT-X still needs it. Structural refcounting is tracked in #3305; these are the contained fixes users need now.

Root-caused with hardware in the loop (FLEX + PGXL + TGXL + WSJT-X-Improved console capture). Full investigation notes are on #3305 (two comments, 2026-06-08).

## Fixes

### 1. `stopDax()` ownership guard (#3363, helps #2886)
`MainWindow::stopDax()` unconditionally `stream remove`d every registered DAX RX stream, so toggling the DAX bridge (or slice mute) off ripped out the stream TCI had borrowed — silencing WSJT-X RX instantly (confirmed in #3363's support bundle: stream `0x04000009` removed at 14:38:19, ~50 s blackout until WSJT-X retried). The sibling teardown paths (RADE at ~17520, per-slice de-assign from #3308) already guard via `TciServer::ownsDaxChannel()` / `m_radeDaxStreamId`; `stopDax()` was the one that didn't. Now iterates channels 1–4 and keeps any stream another consumer still holds.

### 2. Liveness-keyed recreation after profile switch (#3476, #3364)
`profile global load` destroys/recreates slices **without** a radio disconnect. The reactive "radio removed DAX stream" handler zeroed the cached stream id but **kept the channel key**, so `ensureDaxForTci()`'s `contains(ch)` guard skipped `stream create` on the re-arm — TCI RX stayed silent until a full reconnect ("switched profile, never came back"; only Reset Settings recovered). The handler now **erases** the entry (and its borrowed flag), so the next re-arm recreates. Pending creates (value 0) are never matched (`streamId != 0`), so in-flight requests are safe.

### 3. Debounced DAX RX teardown (Tune/ATU + transient reconnects)
Field-reproduced: a band change landing during a TGXL ATU tune stalls the main loop ~2 s → the `vfo:` echo misses WSJT-X's hard 2000 ms `do_frequency` timeout → WSJT-X throws `TCI failed set rxfreq`, **closes the socket**, and reconnects ~2–3.5 s later. `onClientDisconnected`/`audio_stop` previously called `releaseDaxForTci()` immediately, turning that blip into permanent silence.

Now the teardown is deferred by `kDaxReleaseGraceMs` (10 s — measured drop→`audio_start` gaps were 2.1/3.3/3.5 s); a (re)connecting client's `audio_start` cancels it, so the stream survives and audio resumes with no recreate. `stop()` still tears down immediately. Also clears `m_tciDaxSlices` on radio disconnect so a deferred release after a quick radio bounce can't `setDaxChannel(0)` on recreated slices.

The underlying ~2 s stall is **not** fixed here — it's the remaining root bug, and the watchdog below is aimed at it.

## Diagnostics (kept deliberately)

- **Outbound TCI traffic logging** — `TCI tx→all:` / `tx→client:` / `tx→init:` (`qCDebug(lcCat)`). We logged every inbound command but nothing we sent; the `vfo:` echo WSJT-X times out on was invisible. This is what made the Tune/ATU root cause provable.
- **Teardown logs elevated to `qCWarning`** — `releaseDaxForTci()`, client TCP drop, `audio_stop`. These ran **completely invisibly** in the 26.6.2 field bundles because `qCInfo(lcCat)` sits below the default warning threshold even with `aether.cat.debug` enabled. An audio-killing teardown should never be silent.
- **Main-thread stall watchdog** (`main.cpp`) — 250 ms heartbeat; logs `MainThreadWatchdog: event loop stalled ~N ms` (warning) for any GUI-loop block > 600 ms. Stall start ≈ timestamp − gap. Converts the next field stall into a single timestamped line.

## Validation

- Built clean on macOS (RelWithDebInfo, Ninja), rebased onto current `main` and rebuilt.
- Live rig (FLEX + PGXL + TGXL + WSJT-X-Improved): 4 consecutive `profile global load` switches with TCI audio flowing — `frames_sent` climbed monotonically across all of them, zero teardowns; on client quit, the debounce deferred 10 s and released cleanly (`0 stream(s), 0 slice assignment(s)`).
- Watchdog verified live (caught a benign ~1.1 s startup stall; silent during all profile switches — confirming the 2 s stall is specific to the Tune/ATU path).
- WSJT-X console + AetherSDR log correlation for the Tune/ATU repro: throw at 05:05:40.715, our delayed `vfo:` processing at 05:05:40.726 — 2.0 s after WSJT-X sent it.

## Out of scope / follow-ups

- The ~2 s band-change+ATU main-thread stall (root cause of the WSJT-X throws) — to be filed separately; the watchdog pinpoints it on next occurrence.
- WSJT-X waterfall blanking for ~5 s when a profile load retunes the radio to a band the client didn't request (cosmetic; client-side reconciliation) — policy question, separate issue.
- Centralized DAX RX refcounting — #3305 (design requirements documented there).

💻 Generated with Claude Code (Fable 5.0) with architecture by @jensenpat
