### PR TITLE
feat(gui): user-adjustable frequency-scale text size (#3501)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -14083,6 +14083,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setShowGrid);
     connect(menu, &SpectrumOverlayMenu::freqGridSpacingChanged,
             sw, &SpectrumWidget::setFreqGridSpacing);
+    connect(menu, &SpectrumOverlayMenu::freqScaleFontPtChanged,
+            sw, &SpectrumWidget::setFreqScaleFontPt);
     connect(menu, &SpectrumOverlayMenu::fftLineWidthChanged,
             sw, &SpectrumWidget::setFftLineWidth);
     connect(menu, &SpectrumOverlayMenu::noiseFloorPositionChanged,
@@ -14260,7 +14262,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // waiting for the next syncExtraDisplaySettings round.
         menu->syncExtraDisplaySettings(sw->wfBlankerEnabled(),
             sw->wfBlankerThreshold(), sw->backgroundOpacity(),
-            sw->freqGridSpacing(), c);
+            sw->freqGridSpacing(), c, sw->freqScaleFontPt());
     });
     connect(menu, &SpectrumOverlayMenu::displaySettingsReset,
             this, [this, applet, sw, menu] {
@@ -14287,6 +14289,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setNoiseFloorEnable(false);
         sw->setNoiseFloorPosition(75);
         sw->setFreqGridSpacing(0);  // Auto (#1390)
+        sw->setFreqScaleFontPt(8);  // default scale text size (#3501)
 
         // Radio commands for radio-authoritative display settings.
         // fps and line_duration are suppressed while adaptive throttle is active

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1383,6 +1383,24 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         ++row;
     }
 
+    // ── Freq scale text size dropdown (#3501) ───────────────────────────
+    {
+        auto* lbl = new QLabel("Scale text:");
+        lbl->setStyleSheet(labelStyle);
+        grid->addWidget(lbl, row, 0);
+        m_freqScaleFontCmb = new QComboBox;
+        m_freqScaleFontCmb->setFixedHeight(18);
+        applyComboStyle(m_freqScaleFontCmb);
+        for (int pt : {8, 9, 10, 11, 12, 14})
+            m_freqScaleFontCmb->addItem(QString("%1 pt").arg(pt), pt);
+        grid->addWidget(m_freqScaleFontCmb, row, 1, 1, 3);
+        connect(m_freqScaleFontCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this](int idx) {
+            emit freqScaleFontPtChanged(m_freqScaleFontCmb->itemData(idx).toInt());
+        });
+        ++row;
+    }
+
     // ── Scheme dropdown ───────────────────────────────────────────────────
     {
         auto* lbl = new QLabel("Scheme:");
@@ -1424,6 +1442,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     m_rateSlider->setToolTip("Waterfall rate. 1% = slowest; 100% = fastest.");
     if (m_wfBlankerThreshSlider) m_wfBlankerThreshSlider->setToolTip("Waterfall noise blanking threshold. Higher values blank more aggressively.");
     if (m_freqGridSpacingCmb) m_freqGridSpacingCmb->setToolTip("Frequency grid line spacing. Auto adapts to the current span.");
+    if (m_freqScaleFontCmb) m_freqScaleFontCmb->setToolTip("Text size of the frequency scale labels. The scale strip grows to fit larger sizes.");
     if (m_colorSchemeCmb) m_colorSchemeCmb->setToolTip("Selects the waterfall color palette.");
     if (m_bgOpacitySlider) m_bgOpacitySlider->setToolTip("Opacity of the background image overlay.");
     if (m_floorEnableBtn) m_floorEnableBtn->setToolTip("Shows a noise floor reference line on the spectrum display.");
@@ -1525,13 +1544,19 @@ void SpectrumOverlayMenu::syncWfLineDuration(int rate)
 void SpectrumOverlayMenu::syncExtraDisplaySettings(bool blankerOn, float blankerThresh,
                                                     int bgOpacity,
                                                     int freqGridSpacingKhz,
-                                                    const QColor& bgFillColor)
+                                                    const QColor& bgFillColor,
+                                                    int freqScaleFontPt)
 {
     if (m_freqGridSpacingCmb) {
         QSignalBlocker b(m_freqGridSpacingCmb);
         int idx = m_freqGridSpacingCmb->findData(freqGridSpacingKhz);
         if (idx >= 0) m_freqGridSpacingCmb->setCurrentIndex(idx);
         else          m_freqGridSpacingCmb->setCurrentIndex(0);  // Auto
+    }
+    if (m_freqScaleFontCmb) {
+        QSignalBlocker b(m_freqScaleFontCmb);
+        int idx = m_freqScaleFontCmb->findData(freqScaleFontPt);
+        m_freqScaleFontCmb->setCurrentIndex(idx >= 0 ? idx : 0);  // 8 pt default
     }
     if (m_wfBlankerBtn) {
         QSignalBlocker b(m_wfBlankerBtn);

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -54,7 +54,8 @@ public:
     void syncExtraDisplaySettings(bool blankerOn, float blankerThresh,
                                   int bgOpacity,
                                   int freqGridSpacingKhz = 0,
-                                  const QColor& bgFillColor = QColor());
+                                  const QColor& bgFillColor = QColor(),
+                                  int freqScaleFontPt = 8);
 
     // Set the panadapter ID this overlay belongs to (for +RX routing).
     void setPanId(const QString& id);
@@ -113,6 +114,7 @@ signals:
     void fftHeatMapChanged(bool on);
     void showGridChanged(bool on);
     void freqGridSpacingChanged(int khz);
+    void freqScaleFontPtChanged(int pt);
     void fftLineWidthChanged(float width);
     void wfColorGainChanged(int gain);
     void wfBlackLevelChanged(int level);
@@ -268,6 +270,7 @@ private:
     QPushButton* m_floorEnableBtn{nullptr};
 
     QComboBox*   m_freqGridSpacingCmb{nullptr};
+    QComboBox*   m_freqScaleFontCmb{nullptr};
     QSlider*     m_bgOpacitySlider{nullptr};
     QLabel*      m_bgOpacityLabel{nullptr};
     QPushButton* m_bgFillColorBtn{nullptr};  // colour swatch below the bg image

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -747,6 +747,8 @@ void SpectrumWidget::loadSettings()
     m_fftHeatMap     = s.value(settingsKey("DisplayFftHeatMap"), "True").toString() == "True";
     m_showGrid       = s.value(settingsKey("DisplayShowGrid"), "True").toString() == "True";
     m_freqGridSpacingKhz = s.value(settingsKey("DisplayFreqGridSpacing"), "0").toInt();
+    m_freqScaleFontPt = std::clamp(
+        s.value(settingsKey("DisplayFreqScaleFontPt"), "8").toInt(), 8, 14);
     m_fftLineWidth   = s.value(settingsKey("DisplayFftLineWidth"), "2.0").toFloat();
     m_noiseFloorEnable   = s.value(settingsKey("DisplayNoiseFloorEnable"), "False").toString() == "True";
     m_noiseFloorPosition = std::clamp(
@@ -785,7 +787,8 @@ void SpectrumWidget::loadSettings()
             m_fftHeatMap, static_cast<int>(m_wfColorScheme), m_showGrid,
             m_fftLineWidth);
         m_overlayMenu->syncExtraDisplaySettings(m_wfBlankerEnabled,
-            m_wfBlankerThreshold, m_bgOpacity, m_freqGridSpacingKhz, m_bgFillColor);
+            m_wfBlankerThreshold, m_bgOpacity, m_freqGridSpacingKhz, m_bgFillColor,
+            m_freqScaleFontPt);
     }
     // Refresh the noise-floor target so the slider position takes effect
     // even when the overlay menu is built but not yet shown.
@@ -940,6 +943,14 @@ void SpectrumWidget::setFreqGridSpacing(int khz) {
     s.save();
     markOverlayDirty();
 }
+void SpectrumWidget::setFreqScaleFontPt(int pt) {
+    m_freqScaleFontPt = std::clamp(pt, 8, 14);
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("DisplayFreqScaleFontPt"), QString::number(m_freqScaleFontPt));
+    s.save();
+    markOverlayDirty();
+    update();
+}
 void SpectrumWidget::setShowFpsMeters(bool on) {
     applyFpsMeterVisibility(on);
     auto& s = AppSettings::instance();
@@ -1045,7 +1056,7 @@ void SpectrumWidget::updateFpsMeterLabels() {
 
 int SpectrumWidget::spectrumPixelHeight() const
 {
-    const int chromeH = FREQ_SCALE_H + DIVIDER_H;
+    const int chromeH = freqScaleH() + DIVIDER_H;
     const int contentH = std::max(0, height() - chromeH);
     return std::max(1, static_cast<int>(contentH * m_spectrumFrac));
 }
@@ -1065,7 +1076,7 @@ void SpectrumWidget::positionFpsMeterLabels() {
         return;
     }
 
-    const int chromeH = FREQ_SCALE_H + DIVIDER_H;
+    const int chromeH = freqScaleH() + DIVIDER_H;
     const int contentH = height() - chromeH;
     if (contentH <= 0) {
         hideMeters();
@@ -1073,7 +1084,7 @@ void SpectrumWidget::positionFpsMeterLabels() {
     }
 
     const int specH = spectrumPixelHeight();
-    const int wfY = specH + DIVIDER_H + FREQ_SCALE_H;
+    const int wfY = specH + DIVIDER_H + freqScaleH();
     const QRect specRect(0, 0, width(), specH);
     const QRect wfRect(0, wfY, width(), height() - wfY);
 
@@ -2054,7 +2065,7 @@ QRect SpectrumWidget::waterfallLiveButtonRect(const QRect& wfRect) const
     const int buttonW = 32;
     const int buttonH = 16;
     const int buttonX = strip.right() - buttonW - 2;
-    const int buttonY = wfRect.top() - FREQ_SCALE_H + 2;
+    const int buttonY = wfRect.top() - freqScaleH() + 2;
     return QRect(buttonX, buttonY, buttonW, buttonH);
 }
 
@@ -3370,7 +3381,7 @@ void SpectrumWidget::updateTrackedCursorState(const QPoint& localPos, bool insid
         m_tuneGuideTimer->stop();
         QToolTip::hideText();
     } else {
-        const int chromeH = FREQ_SCALE_H + DIVIDER_H;
+        const int chromeH = freqScaleH() + DIVIDER_H;
         const int contentH = height() - chromeH;
         const int specH = static_cast<int>(contentH * m_spectrumFrac);
         const bool inSpectrum = localPos.y() >= 0
@@ -3447,7 +3458,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
     const auto dragStatePublisher = makeScopeExit([this] { publishPerfDragState(); });
     (void)dragStatePublisher;
 
-    const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
+    const int chromeH  = freqScaleH() + DIVIDER_H;
     const int contentH = height() - chromeH;
     const int specH = static_cast<int>(contentH * m_spectrumFrac);
     const int y = static_cast<int>(ev->position().y());
@@ -3515,8 +3526,8 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
 
     // Click on the freq scale bar → start bandwidth drag
     const int scaleY = specH + DIVIDER_H;
-    if (y >= scaleY && y < scaleY + FREQ_SCALE_H) {
-        const QRect wfRect(0, scaleY + FREQ_SCALE_H, width(), height() - (scaleY + FREQ_SCALE_H));
+    if (y >= scaleY && y < scaleY + freqScaleH()) {
+        const QRect wfRect(0, scaleY + freqScaleH(), width(), height() - (scaleY + freqScaleH()));
         if (waterfallLiveButtonRect(wfRect).contains(ev->position().toPoint())) {
             setWaterfallLive(true);
             ev->accept();
@@ -3534,7 +3545,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
     }
 
     // Left-click in waterfall area -> start pan drag (tune on double-click only)
-    const int wfY = scaleY + FREQ_SCALE_H;
+    const int wfY = scaleY + freqScaleH();
     if (y >= wfY) {
         const QRect wfRect(0, wfY, width(), height() - wfY);
         const QRect timeScaleRect = waterfallTimeScaleRect(wfRect);
@@ -3984,7 +3995,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         return;
     }
 
-    const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
+    const int chromeH  = freqScaleH() + DIVIDER_H;
     const int contentH = height() - chromeH;
     const int specH = static_cast<int>(contentH * m_spectrumFrac);
     const int y = static_cast<int>(ev->position().y());
@@ -4074,7 +4085,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
     }
 
     if (m_draggingTimeScaleRate) {
-        const int wfY = specH + DIVIDER_H + FREQ_SCALE_H;
+        const int wfY = specH + DIVIDER_H + freqScaleH();
         const QRect wfRect(0, wfY, width(), height() - wfY);
         const QRect timeScaleRect = waterfallTimeScaleRect(wfRect);
         const int dragHeight = std::max(1, timeScaleRect.height());
@@ -4099,7 +4110,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
     }
 
     if (m_draggingTimeScale) {
-        const int wfY = specH + DIVIDER_H + FREQ_SCALE_H;
+        const int wfY = specH + DIVIDER_H + freqScaleH();
         const QRect wfRect(0, wfY, width(), height() - wfY);
         const QRect timeScaleRect = waterfallTimeScaleRect(wfRect);
         const int dragHeight = std::max(1, timeScaleRect.height());
@@ -4195,7 +4206,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
     }
 
     // Update cursor based on hover position
-    const int wfY = specH + DIVIDER_H + FREQ_SCALE_H;
+    const int wfY = specH + DIVIDER_H + freqScaleH();
 
     if (y >= specH && y < specH + DIVIDER_H) {
         setSpectrumCursor(Qt::SplitVCursor);
@@ -4336,7 +4347,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
     }
 
     // Band plan spot tooltip on hover
-    const int specH2 = static_cast<int>((height() - FREQ_SCALE_H - DIVIDER_H) * m_spectrumFrac);
+    const int specH2 = static_cast<int>((height() - freqScaleH() - DIVIDER_H) * m_spectrumFrac);
     const int bandBarTop = specH2 - 8;
     if (m_hoveredTnfId >= 0) {
         QToolTip::hideText();
@@ -4570,10 +4581,10 @@ void SpectrumWidget::showAddSpotDialog(double freqMhz)
 
 void SpectrumWidget::mouseDoubleClickEvent(QMouseEvent* ev)
 {
-    const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
+    const int chromeH  = freqScaleH() + DIVIDER_H;
     const int contentH = height() - chromeH;
     const int specH = static_cast<int>(contentH * m_spectrumFrac);
-    const int wfY = specH + DIVIDER_H + FREQ_SCALE_H;
+    const int wfY = specH + DIVIDER_H + freqScaleH();
     const int y = static_cast<int>(ev->position().y());
     const int mx = static_cast<int>(ev->position().x());
     const int rightStripW = (y >= wfY) ? waterfallStripWidth() : DBM_STRIP_W;
@@ -4743,10 +4754,10 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
     PerfInputScope perfScope("wheel");
 
     // Skip scroll on the divider + freq scale bar.
-    const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
+    const int chromeH  = freqScaleH() + DIVIDER_H;
     const int contentH2 = height() - chromeH;
     const int specH2 = static_cast<int>(contentH2 * m_spectrumFrac);
-    const int wfY = specH2 + DIVIDER_H + FREQ_SCALE_H;
+    const int wfY = specH2 + DIVIDER_H + freqScaleH();
     const int chromeTop = specH2;
     const int chromeBot = specH2 + chromeH;
     if (ev->position().y() >= chromeTop && ev->position().y() < chromeBot) {
@@ -4856,7 +4867,7 @@ void SpectrumWidget::resizeEvent(QResizeEvent* ev)
     // into a QSplitter can reset native window properties.
     setMouseTracking(true);
 
-    const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
+    const int chromeH  = freqScaleH() + DIVIDER_H;
     const int contentH = height() - chromeH;
     const int wfHeight = static_cast<int>(contentH * (1.0f - m_spectrumFrac));
     if (wfHeight > 0 && width() > 0) {
@@ -5347,14 +5358,14 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     QRhi* r = rhi();
     const int w = width();
     const int h = height();
-    if (w <= 0 || h <= FREQ_SCALE_H + DIVIDER_H + 2) return;
+    if (w <= 0 || h <= freqScaleH() + DIVIDER_H + 2) return;
     const bool perfEnabled = PerfTelemetry::instance().enabled();
     const qint64 perfStartNs = perfEnabled ? PerfTelemetry::nowNs() : 0;
 
-    const int chromeH = FREQ_SCALE_H + DIVIDER_H;
+    const int chromeH = freqScaleH() + DIVIDER_H;
     const int contentH = h - chromeH;
     const int specH = static_cast<int>(contentH * m_spectrumFrac);
-    const int wfY = specH + DIVIDER_H + FREQ_SCALE_H;
+    const int wfY = specH + DIVIDER_H + freqScaleH();
     const int wfH = h - wfY;
     const QRect specRect(0, 0, w, specH);
     const QRect wfRect(0, wfY, w, wfH);
@@ -5525,7 +5536,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             // Divider bar
             p.fillRect(0, specH, w, DIVIDER_H, AetherSDR::ThemeManager::instance().color("color.background.2"));
 
-            drawFreqScale(p, QRect(0, specH + DIVIDER_H, w, FREQ_SCALE_H));
+            drawFreqScale(p, QRect(0, specH + DIVIDER_H, w, freqScaleH()));
             drawTnfMarkers(p, specRect);
             if (m_showSpots || m_showSHistory)
                 drawSpotMarkers(p, specRect);
@@ -6091,7 +6102,7 @@ void SpectrumWidget::releaseResources()
 
 void SpectrumWidget::paintEvent(QPaintEvent* ev)
 {
-    if (width() <= 0 || height() <= FREQ_SCALE_H + DIVIDER_H + 2) return;
+    if (width() <= 0 || height() <= freqScaleH() + DIVIDER_H + 2) return;
 
 #ifdef AETHER_GPU_SPECTRUM
     // GPU mode: render() handles everything via QRhi. Skip the full
@@ -6110,18 +6121,18 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing, false);
 
-    const int chromeH  = FREQ_SCALE_H + DIVIDER_H;
+    const int chromeH  = freqScaleH() + DIVIDER_H;
     const int contentH = height() - chromeH;
     const int specH    = static_cast<int>(contentH * m_spectrumFrac);
     const int wfH      = contentH - specH;
 
     const int divY     = specH;
     const int scaleY   = specH + DIVIDER_H;
-    const int wfY      = scaleY + FREQ_SCALE_H;
+    const int wfY      = scaleY + freqScaleH();
 
     const QRect specRect (0, 0,       width(), specH);
     const QRect divRect  (0, divY,    width(), DIVIDER_H);
-    const QRect scaleRect(0, scaleY,  width(), FREQ_SCALE_H);
+    const QRect scaleRect(0, scaleY,  width(), freqScaleH());
     const QRect wfRect   (0, wfY,     width(), wfH);
 
     {
@@ -7820,6 +7831,15 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
 
 // ─── Frequency scale bar ──────────────────────────────────────────────────────
 
+int SpectrumWidget::freqScaleH() const
+{
+    if (m_freqScaleFontPt <= 8)
+        return FREQ_SCALE_H;
+    QFont f = font();
+    f.setPointSize(m_freqScaleFontPt);
+    return std::max(FREQ_SCALE_H, QFontMetrics(f).height() + 6);
+}
+
 void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
 {
     p.fillRect(r, AetherSDR::ThemeManager::instance().color("color.background.0"));
@@ -7832,7 +7852,7 @@ void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
     const double firstLine = std::ceil(startMhz / stepMhz) * stepMhz;
 
     QFont f = p.font();
-    f.setPointSize(8);
+    f.setPointSize(m_freqScaleFontPt);
     p.setFont(f);
     const QFontMetrics fm(f);
 
@@ -7865,7 +7885,12 @@ void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
 
         const QString label = formatFreqScaleLabel(freq, decimals);
         const int tw = fm.horizontalAdvance(label);
-        const int lx = qBound(0, x - tw / 2, width() - tw);
+        // Keep labels clear of the right-edge dBm / waterfall-time scale
+        // column — at larger label sizes (#3501) a label clamped to the
+        // widget edge collides with those figures.
+        const int labelMaxRight = width() - DBM_STRIP_W - 2;
+        if (x > labelMaxRight) continue;
+        const int lx = qBound(0, x - tw / 2, labelMaxRight - tw);
 
         p.setPen(AetherSDR::ThemeManager::instance().color("color.text.secondary"));
         p.drawText(lx, r.bottom() - 2, label);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -284,12 +284,14 @@ public:
     void setFftHeatMap(bool on);
     void setShowGrid(bool on);
     void setFreqGridSpacing(int khz);
+    void setFreqScaleFontPt(int pt);
     void setFftLineWidth(float w);
     float fftFillAlpha() const         { return m_fftFillAlpha; }
     QColor fftFillColor() const        { return m_fftFillColor; }
     bool fftHeatMap() const            { return m_fftHeatMap; }
     bool showGrid() const              { return m_showGrid; }
     int  freqGridSpacing() const       { return m_freqGridSpacingKhz; }
+    int  freqScaleFontPt() const       { return m_freqScaleFontPt; }
     float fftLineWidth() const         { return m_fftLineWidth; }
     int   fftAverage() const           { return m_fftAverage; }
     int   fftFps() const               { return m_fftFps; }
@@ -743,6 +745,7 @@ private:
     bool m_fftHeatMap{true};        // true = intensity heat map, false = solid color
     bool m_showGrid{true};          // false = hide grid lines
     int  m_freqGridSpacingKhz{0};   // 0=Auto, or 1/2/5/10/25/50/100 kHz (#1390)
+    int  m_freqScaleFontPt{8};      // freq-scale label size, 8..14 pt (#3501)
     float m_fftLineWidth{2.0f};     // spectrum trace width in pixels
 
     // ── Waterfall display controls (radio-side via "display panafall set") ─
@@ -793,8 +796,11 @@ private:
     static constexpr float SMOOTH_ALPHA    = 0.35f;
     // Fraction of the panadapter area (above freq scale) used for spectrum
     float m_spectrumFrac{0.40f};
-    // Height of the frequency scale bar
+    // Height of the frequency scale bar at the default 8 pt label size.
+    // Use freqScaleH() in layout code — it grows with the user's label
+    // font so larger text never clips (#3501).
     static constexpr int   FREQ_SCALE_H    = 20;
+    int freqScaleH() const;
     // Height of the draggable divider between FFT and freq scale
     static constexpr int   DIVIDER_H       = 4;
     // Divider drag state


### PR DESCRIPTION
## Summary

Closes #3501 — reported by KN7K via Discord: the panadapter frequency-scale labels were fixed at 8 pt with no way to enlarge them.

This adds a **"Scale text" dropdown (8/9/10/11/12/14 pt)** to the per-pan Display overlay menu, directly under the existing "Grid:" spacing control, mirroring the #1390 pattern end-to-end: per-pan persisted setting (`DisplayFreqScaleFontPt`), signal wiring in MainWindow, state sync when the menu reopens, and Reset-defaults restores 8 pt.

## Implementation notes

- The fixed `FREQ_SCALE_H` (20 px) becomes `freqScaleH()`, derived from the configured font, at all 28 layout/hit-test sites — larger labels get a taller strip instead of clipped ascenders. At the default 8 pt the height is byte-identical to today (never below 20 px), so existing layouts are untouched.
- `drawFreqScale()` gains a right-column guard: ruler labels are clamped (or skipped, tick retained) clear of the dBm / waterfall-time scale column. This collision existed marginally at 8 pt and became obvious at larger sizes — found during live testing.
- The dBm strip's own label size is unchanged; if there's appetite, it could get the same treatment in a follow-up.

## Testing

- Built RelWithDebInfo/Ninja (MSVC, Qt 6.10.3) and **ran live against a FLEX-6700**.
- Verified visually at every step from 8 → 14 → 8 pt: labels grow/shrink, strip height follows with no clipping, divider drag and waterfall click zones track the moved boundary, last label stays clear of the dBm/time column, menu reopens showing the current value, Reset-defaults returns to 8 pt.

First concrete operator-facing item under the #3443 accessibility initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
