### PR TITLE
Trim panadapter frequency scale trailing zeros

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -263,6 +263,22 @@ static QString formatFlagFrequency(double freqMhz)
         .arg(hzPart, 3, 10, QChar('0'));
 }
 
+static QString formatFreqScaleLabel(double freqMhz, int decimals)
+{
+    QString label = QString::number(freqMhz, 'f', decimals);
+    const qsizetype dot = label.indexOf(QLatin1Char('.'));
+    if (dot < 0) {
+        return label;
+    }
+
+    const qsizetype minDecimals = std::min(decimals, 3);
+    const qsizetype minLength = dot + 1 + minDecimals;
+    while (label.size() > minLength && label.endsWith(QLatin1Char('0'))) {
+        label.chop(1);
+    }
+    return label;
+}
+
 // ─── Waterfall color scheme gradient cache ────────────────────────────────────
 //
 // The five preset schemes (Default, Grayscale, Blue-Green, Fire, Plasma) used
@@ -7824,7 +7840,6 @@ void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
     int decimals;
     if      (stepMhz < 0.0001) decimals = 6;
     else if (stepMhz < 0.001)  decimals = 5;
-    else if (stepMhz < 0.01)   decimals = 4;
     else if (stepMhz < 1.0)    decimals = 3;
     else                        decimals = 2;
 
@@ -7848,7 +7863,7 @@ void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
         // Label only every Nth line to prevent overlap
         if (stepIdx % labelEvery != 0) continue;
 
-        const QString label = QString::number(freq, 'f', decimals);
+        const QString label = formatFreqScaleLabel(freq, decimals);
         const int tw = fm.horizontalAdvance(label);
         const int lx = qBound(0, x - tw / 2, width() - tw);
 


### PR DESCRIPTION
## Summary

Fixes #3480.

This trims non-informative trailing zero padding from the panadapter frequency-scale labels while preserving enough precision for the current grid spacing.

## Root Cause

`SpectrumWidget::drawFreqScale()` formatted grid labels with a fixed number of decimal places derived from the grid step. That made whole-kHz ticks display with extra zeroes, such as `21.0580`, and very zoomed-in sub-kHz ticks display labels such as `21.26080` and `21.26100`.

The fixed-width formatting made the scale harder to scan without adding useful information.

## Change

- Removed the 4-decimal branch for 1-10 kHz grid spacing, so whole-kHz ticks use three MHz decimals.
- Added a local `formatFreqScaleLabel()` helper that trims trailing zeroes from finer-scale labels while keeping at least three decimals.
- Left the existing precision selection intact for sub-kHz spacing so adjacent tick labels remain distinct at tight zoom levels.

Examples:

- `21.0580` -> `21.058`
- `14.0200` -> `14.020`
- `21.26080` -> `21.2608`
- `21.26100` -> `21.261`

This only changes the panadapter scale labels. VFO frequency display, slice flag formatting, and TNF frequency formatting are unchanged.

## Validation

- `git diff --check`
- `python3 tools/check_a11y.py src/gui/SpectrumWidget.cpp`
- `cmake --build build --parallel`
- `ctest --test-dir build -E theme_manager_test --output-on-failure` (31/31 passed; `theme_manager_test` is excluded here because this checkout has local persistent theme test state under the user preferences path, unrelated to the spectrum label formatter)
