### PR TITLE
ci(windows): unblock hidapi source build under CMake 4.x runner image

### DIFF
--- a/scripts/setup/setup-hidapi.ps1
+++ b/scripts/setup/setup-hidapi.ps1
@@ -58,9 +58,16 @@ Copy-Item "$($srcDir.FullName)\hidapi\hidapi.h" "$OutDir\include\hidapi\"
 Write-Host "Building hidapi from source with MSVC..." -ForegroundColor Cyan
 
 $buildDir = "$($srcDir.FullName)\build"
+# CMAKE_POLICY_VERSION_MINIMUM: hidapi 0.14.0's CMakeLists declares a
+# cmake_minimum_required below 3.5, which CMake 4.x (on GitHub's
+# windows-latest runner image since 2026-06-10) refuses outright. The
+# override tells CMake to configure with 3.5 policy semantics — the build
+# itself is unaffected. Drop this once hidapi is bumped to a release with
+# a modern minimum.
 cmake -B $buildDir -S $srcDir.FullName -G "Ninja" `
     -DCMAKE_BUILD_TYPE=Release `
-    -DBUILD_SHARED_LIBS=ON
+    -DBUILD_SHARED_LIBS=ON `
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 cmake --build $buildDir --config Release -j $env:NUMBER_OF_PROCESSORS
 

--- a/scripts/setup/setup-hidapi.ps1
+++ b/scripts/setup/setup-hidapi.ps1
@@ -64,10 +64,15 @@ $buildDir = "$($srcDir.FullName)\build"
 # override tells CMake to configure with 3.5 policy semantics — the build
 # itself is unaffected. Drop this once hidapi is bumped to a release with
 # a modern minimum.
+#
+# The flag MUST be quoted: PowerShell's native-argument tokenizer splits
+# an unquoted -Dkey=3.5 at the dot, so CMake receives "3" and rejects it
+# ("Invalid CMAKE_POLICY_VERSION_MINIMUM value"). The other -D flags only
+# survive unquoted because their values contain no dot.
 cmake -B $buildDir -S $srcDir.FullName -G "Ninja" `
     -DCMAKE_BUILD_TYPE=Release `
     -DBUILD_SHARED_LIBS=ON `
-    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 cmake --build $buildDir --config Release -j $env:NUMBER_OF_PROCESSORS
 


### PR DESCRIPTION
## Summary

**Repo-wide CI blocker.** Every `check-windows` run since 2026-06-10 ~14:36 UTC fails at the **Setup hidapi** step, before any AetherSDR code compiles. Last green run on main: 04:10 UTC. Every PR branch since fails identically (#3508, the AetherClaude bot's `aetherclaude/issue-3506` branch).

## Root cause

GitHub's `windows-latest` runner image updated to **CMake 4.x**, which removed compatibility with `cmake_minimum_required(<3.5)`. hidapi 0.14.0's CMakeLists declares an older minimum, so `scripts/setup/setup-hidapi.ps1`'s source build now hard-fails at configure:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
  ...
  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

## Fix

One flag on the configure line — the exact override CMake's own error message recommends:

```powershell
cmake -B $buildDir -S $srcDir.FullName -G "Ninja" `
    -DCMAKE_BUILD_TYPE=Release `
    -DBUILD_SHARED_LIBS=ON `
    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
```

Configure proceeds with 3.5 policy semantics; the compiled artifact is unaffected. Inline comment documents when the flag can be dropped (hidapi version bump with a modern minimum).

## Sibling-script audit

Checked the other Windows setup scripts for the same latent failure:

| Script | cmake source build? | Declared minimum | At risk? |
|---|---|---|---|
| `setup-hidapi.ps1` | yes — hidapi 0.14.0 | < 3.5 | **this PR** |
| `setup-opus.ps1` | yes — opus 1.5.2 | 3.16 | no (verified: builds locally under CMake 4.3.3) |
| `setup-onnxruntime.ps1` | no (informational echo only) | n/a | no |

## Validation

This PR's own `check-windows` run exercises the fixed script — green CI on this PR **is** the validation.

Once merged, #3508 (and the bot's PR) just need a CI re-run.