### PR TITLE
fix(audio): name CW sidetone JACK client "AetherSDR CW Sidetone"

### DIFF
--- a/src/core/CwSidetonePortAudioSink.cpp
+++ b/src/core/CwSidetonePortAudioSink.cpp
@@ -3,6 +3,9 @@
 #include "LogManager.h"
 
 #include <portaudio.h>
+#if defined(Q_OS_LINUX) && __has_include(<pa_jack.h>)
+#  include <pa_jack.h>  // PaJack_SetClientName — name the PipeWire/JACK node
+#endif
 
 #include <QString>
 
@@ -162,6 +165,16 @@ bool CwSidetonePortAudioSink::start(const QAudioDevice& device,
     m_fallbackReason.clear();
 
     if (!m_paInitialized) {
+#if defined(Q_OS_LINUX) && __has_include(<pa_jack.h>)
+        // Name the PortAudio->JACK/PipeWire client so the CW sidetone shows
+        // as "AetherSDR CW Sidetone" in qpwgraph/JACK patchbays instead of
+        // the bare PortAudio default. Must precede Pa_Initialize, and pa_jack
+        // references (does not copy) the string -> static lifetime. CW sidetone
+        // is AetherSDR's only PortAudio user, so naming the process-global JACK
+        // client here is unambiguous.
+        static const char kJackClientName[] = "AetherSDR CW Sidetone";
+        PaJack_SetClientName(kJackClientName);
+#endif
         const PaError err = Pa_Initialize();
         if (err != paNoError) {
             qCWarning(lcAudio) << "CwSidetonePortAudioSink: Pa_Initialize failed —"

--- a/src/core/CwSidetonePortAudioSink.cpp
+++ b/src/core/CwSidetonePortAudioSink.cpp
@@ -173,7 +173,15 @@ bool CwSidetonePortAudioSink::start(const QAudioDevice& device,
         // is AetherSDR's only PortAudio user, so naming the process-global JACK
         // client here is unambiguous.
         static const char kJackClientName[] = "AetherSDR CW Sidetone";
-        PaJack_SetClientName(kJackClientName);
+        // PaJack_SetClientName returns PaError; surface a failure like the
+        // Pa_Initialize path below. Non-fatal — the node keeps its default
+        // name — so log and continue rather than abort.
+        const PaError nameErr = PaJack_SetClientName(kJackClientName);
+        if (nameErr != paNoError) {
+            qCWarning(lcAudio) << "CwSidetonePortAudioSink: PaJack_SetClientName failed —"
+                               << Pa_GetErrorText(nameErr)
+                               << "(node keeps its default name)";
+        }
 #endif
         const PaError err = Pa_Initialize();
         if (err != paNoError) {


### PR DESCRIPTION
## Summary
The CW sidetone uses the PortAudio backend, which on Linux runs over PipeWire's JACK API and registers a JACK client under PortAudio's hardcoded default name **`PortAudio`**. The sidetone sink opens alongside RX and stays open for the whole RX session, so qpwgraph / JACK patchbays / WSJT-X / FLDIGI show a persistent node literally named `PortAudio` with no indication it belongs to AetherSDR — the most opaque label of any AetherSDR audio node.

## Fix
Call `PaJack_SetClientName("AetherSDR CW Sidetone")` immediately before `Pa_Initialize()`. The `pa_jack` contract requires the call precede `Pa_Initialize` and references (does not copy) the string, so it uses a static-lifetime `const char[]`. Guarded with `#if defined(Q_OS_LINUX) && __has_include(<pa_jack.h>)` so macOS CoreAudio / Windows WASAPI builds (no `pa_jack.h`, no JACK node) compile unaffected. CW sidetone is AetherSDR's only PortAudio user, so naming the process-global JACK client is unambiguous.

## Why
- Completes the "every AetherSDR audio node is identifiable in patchbays" line of work alongside the merged DAX/TX pipe-naming fix (#3438) and the still-open main RX/TX stream naming (#3440).
- A node named `PortAudio` is indistinguishable from any other PortAudio app and confuses routing in WSJT-X / FLDIGI device pickers.

## Scope
- 13 lines added in one file (`src/core/CwSidetonePortAudioSink.cpp`).
- Linux/PipeWire-only effect (guarded); no protocol, persistence, or UX change.

## Test plan
- [x] Local incremental `ninja -C build` clean on Linux (Nobara 43, Qt 6.10.3, gcc 15.2.1).
- [x] **Live A/B on a FLEX-6700 (RX-only), `pw-dump` ground truth:**
  - Baseline (upstream/main `753eb689`): sidetone node `client.name` / `node.name` / `node.description` all read **`PortAudio`**.
  - This branch: all three read **`AetherSDR CW Sidetone`**.
- [x] macOS CoreAudio / Windows WASAPI: compiles unaffected (guard excludes the call; no JACK node on those backends) — maintainer/secondary.

Related: #3438, #3440

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent, on Linux dev stack (`nobara-dell`).
