### PR TITLE
[codex] Sanitize discovery padding bytes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1692,6 +1692,15 @@ target_include_directories(model_capabilities_test PRIVATE src)
 target_link_libraries(model_capabilities_test PRIVATE Qt6::Core)
 add_test(NAME model_capabilities_test COMMAND model_capabilities_test)
 
+add_executable(radio_discovery_test
+    tests/radio_discovery_test.cpp
+    src/core/RadioDiscovery.cpp
+)
+target_include_directories(radio_discovery_test PRIVATE src)
+target_compile_definitions(radio_discovery_test PRIVATE AETHERSDR_TESTING)
+target_link_libraries(radio_discovery_test PRIVATE Qt6::Core Qt6::Network)
+add_test(NAME radio_discovery_test COMMAND radio_discovery_test)
+
 add_executable(client_quindar_test
     tests/client_quindar_test.cpp
     src/core/ClientQuindarTone.cpp

--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -3,8 +3,45 @@
 
 #include <QNetworkDatagram>
 #include <QDateTime>
+#include <QStringList>
 
 namespace AetherSDR {
+
+namespace {
+
+QString cleanDiscoveryValue(QString value, bool decodeDelSpaces = false)
+{
+    if (decodeDelSpaces) {
+        value.replace(QChar(0x7f), QLatin1Char(' '));
+    }
+
+    QString cleaned;
+    cleaned.reserve(value.size());
+    for (const QChar ch : value) {
+        const char16_t code = ch.unicode();
+        if (code < 0x20 || code == 0x7f) {
+            continue;
+        }
+        cleaned.append(ch);
+    }
+    return cleaned.trimmed();
+}
+
+QStringList splitDiscoveryListValue(QString value, bool decodeDelSpaces = false)
+{
+    value = cleanDiscoveryValue(value, decodeDelSpaces);
+
+    QStringList values;
+    for (const QString& item : value.split(',', Qt::SkipEmptyParts)) {
+        const QString trimmed = item.trimmed();
+        if (!trimmed.isEmpty()) {
+            values << trimmed;
+        }
+    }
+    return values;
+}
+
+} // namespace
 
 RadioDiscovery::RadioDiscovery(QObject* parent)
     : QObject(parent)
@@ -146,43 +183,52 @@ RadioInfo RadioDiscovery::parseDiscoveryPacket(const QByteArray& data) const
 
     for (const QString& token : text.split(' ', Qt::SkipEmptyParts)) {
         const int eq = token.indexOf('=');
-        if (eq < 0) continue;
-
-        const QString key   = token.left(eq).toLower();
-        const QString value = token.mid(eq + 1);
-
-        if      (key == "name")    info.name    = value;
-        else if (key == "model")   info.model   = value;
-        else if (key == "serial")  info.serial  = value;
-        else if (key == "version") info.version = value;
-        else if (key == "ip")      info.address = QHostAddress(value);
-        else if (key == "port")    info.port    = value.toUShort();
-        else if (key == "status")  info.status  = value;
-        else if (key == "nickname") info.nickname = value;
-        else if (key == "callsign") info.callsign = value;
-        else if (key == "inuse")       info.inUse           = (value == "1");
-        else if (key == "mf_enable")   info.multiFlexEnabled = (value != "0");
-        else if (key == "max_licensed_version") info.maxLicensedVersion = value.toInt();
-        else if (key == "is_system_model") info.isSystemModel = (value == "1");
-        else if (key == "turf_region")     info.turfRegion    = value;
-        else if (key == "gui_client_stations") {
-            QString cleaned = value;
-            cleaned.replace('\x7f', ' ');
-            info.guiClientStations = cleaned.split(',', Qt::SkipEmptyParts);
+        if (eq < 0) {
+            continue;
         }
-        else if (key == "gui_client_handles")
-            info.guiClientHandles = value.split(',', Qt::SkipEmptyParts);
-        else if (key == "gui_client_programs") {
-            QString cleaned = value;
-            cleaned.replace('\x7f', ' ');
-            info.guiClientPrograms = cleaned.split(',', Qt::SkipEmptyParts);
-        }
-        else if (key == "gui_client_ips")
-            info.guiClientIps = value.split(',', Qt::SkipEmptyParts);
-        else if (key == "gui_client_hosts") {
-            QString cleaned = value;
-            cleaned.replace('\x7f', ' ');
-            info.guiClientHosts = cleaned.split(',', Qt::SkipEmptyParts);
+
+        const QString key      = cleanDiscoveryValue(token.left(eq)).toLower();
+        const QString rawValue = token.mid(eq + 1);
+        const QString value    = cleanDiscoveryValue(rawValue);
+
+        if (key == "name") {
+            info.name = value;
+        } else if (key == "model") {
+            info.model = value;
+        } else if (key == "serial") {
+            info.serial = value;
+        } else if (key == "version") {
+            info.version = value;
+        } else if (key == "ip") {
+            info.address = QHostAddress(value);
+        } else if (key == "port") {
+            info.port = value.toUShort();
+        } else if (key == "status") {
+            info.status = value;
+        } else if (key == "nickname") {
+            info.nickname = value;
+        } else if (key == "callsign") {
+            info.callsign = value;
+        } else if (key == "inuse") {
+            info.inUse = (value == "1");
+        } else if (key == "mf_enable") {
+            info.multiFlexEnabled = (value != "0");
+        } else if (key == "max_licensed_version") {
+            info.maxLicensedVersion = value.toInt();
+        } else if (key == "is_system_model") {
+            info.isSystemModel = (value == "1");
+        } else if (key == "turf_region") {
+            info.turfRegion = value;
+        } else if (key == "gui_client_stations") {
+            info.guiClientStations = splitDiscoveryListValue(rawValue, true);
+        } else if (key == "gui_client_handles") {
+            info.guiClientHandles = splitDiscoveryListValue(rawValue);
+        } else if (key == "gui_client_programs") {
+            info.guiClientPrograms = splitDiscoveryListValue(rawValue, true);
+        } else if (key == "gui_client_ips") {
+            info.guiClientIps = splitDiscoveryListValue(rawValue);
+        } else if (key == "gui_client_hosts") {
+            info.guiClientHosts = splitDiscoveryListValue(rawValue, true);
         }
     }
     return info;

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -136,6 +136,9 @@ private slots:
     void onBindRetry();
 
 private:
+#ifdef AETHERSDR_TESTING
+    friend class RadioDiscoveryParserTest;
+#endif
     RadioInfo parseDiscoveryPacket(const QByteArray& data) const;
     void upsertRadio(const RadioInfo& info);
 

--- a/tests/radio_discovery_test.cpp
+++ b/tests/radio_discovery_test.cpp
@@ -1,0 +1,81 @@
+#include "core/RadioDiscovery.h"
+
+#include <QCoreApplication>
+#include <QLoggingCategory>
+
+#include <cstdio>
+
+namespace AetherSDR {
+Q_LOGGING_CATEGORY(lcDiscovery, "aether.discovery.test", QtWarningMsg)
+
+class RadioDiscoveryParserTest {
+public:
+    static RadioInfo parse(RadioDiscovery& discovery, const QByteArray& packet)
+    {
+        return discovery.parseDiscoveryPacket(packet);
+    }
+};
+}
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+int g_total = 0;
+
+void report(const char* label, bool ok)
+{
+    ++g_total;
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", label);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    RadioDiscovery discovery;
+    QByteArray packet("name=GeekJeep model=FLEX-6700 serial=1234-5678 "
+                      "version=4.2.18 ip=192.0.2.10 port=4992 status=Available "
+                      "nickname=GeekJeep callsign=KI4TTZ inuse=1 mf_enable=1 "
+                      "gui_client_stations=AetherSDR");
+    packet.append(char(0x7f));
+    packet.append("Station gui_client_programs=AetherSDR");
+    packet.append(char(0x7f));
+    packet.append("Client gui_client_hosts=desk");
+    packet.append(char(0x7f));
+    packet.append("mac turf_region=USA");
+    packet.append('\0');
+    packet.append('\0');
+    packet.append('\r');
+
+    const RadioInfo info = RadioDiscoveryParserTest::parse(discovery, packet);
+
+    report("trailing discovery padding stripped from turf region",
+           info.turfRegion == QStringLiteral("USA"));
+    report("DEL separator decoded in GUI client station",
+           info.guiClientStations == QStringList{QStringLiteral("AetherSDR Station")});
+    report("DEL separator decoded in GUI client program",
+           info.guiClientPrograms == QStringList{QStringLiteral("AetherSDR Client")});
+    report("DEL separator decoded in GUI client host",
+           info.guiClientHosts == QStringList{QStringLiteral("desk mac")});
+    report("ordinary discovery fields still parse",
+           info.model == QStringLiteral("FLEX-6700")
+               && info.nickname == QStringLiteral("GeekJeep")
+               && info.callsign == QStringLiteral("KI4TTZ")
+               && info.inUse
+               && info.multiFlexEnabled);
+
+    if (g_failed == 0) {
+        std::printf("\nAll %d radio-discovery tests passed.\n", g_total);
+        return 0;
+    }
+
+    std::printf("\n%d of %d radio-discovery tests failed.\n", g_failed, g_total);
+    return 1;
+}


### PR DESCRIPTION
## Root Cause

Local SmartSDR discovery packets are decoded as UTF-8 and parsed as space-separated `key=value` tokens, but the parser previously stored most values verbatim. If a discovery packet carried NUL, carriage-return, or other control/padding bytes after a printable value such as `turf_region=USA`, those bytes survived `QString::trimmed()` when embedded in the token. The connection dialog then appended `radio.turfRegion.trimmed()` directly to the available-radio label, so Qt rendered the control bytes as visible placeholder glyphs after `USA`.

## User Impact

The available-radio list could show stray box/control glyphs after otherwise valid discovery metadata. The screenshot symptom was `USA` followed by several placeholder characters in the local radio list subtitle.

## Change Summary

- Add discovery-value sanitization at the `RadioDiscovery` parser boundary.
- Strip ASCII control bytes, including NUL padding and DEL, from parsed scalar values before storing them in `RadioInfo`.
- Preserve the existing Flex DEL-as-space convention for `gui_client_stations`, `gui_client_programs`, and `gui_client_hosts` before sanitizing and splitting those list values.
- Add a focused `radio_discovery_test` regression case that feeds a padded discovery packet and verifies `turf_region` is clean while DEL-encoded GUI client fields still decode correctly.

## Validation

- `./build/radio_discovery_test`
- `ctest --test-dir build -R radio_discovery_test --output-on-failure`
- `git diff --check`
- `cmake --build build --target AetherSDR -j4`