### PR TITLE
fix(dax-iq): deliver IQ samples end-to-end (#2529)

### DIFF
--- a/src/models/DaxIqModel.cpp
+++ b/src/models/DaxIqModel.cpp
@@ -2,6 +2,7 @@
 #include "core/LogManager.h"
 
 #include <QDebug>
+#include <QDir>
 #include <QProcess>
 #include <QtEndian>
 #include <cmath>
@@ -9,9 +10,78 @@
 #ifndef Q_OS_WIN
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/stat.h>   // mkfifo, mkdir, chmod, lstat, S_ISFIFO
+#include <cerrno>       // errno
 #endif
 
 namespace AetherSDR {
+
+#ifndef Q_OS_WIN
+namespace {
+
+// Per-user FIFO dir ($XDG_RUNTIME_DIR/aethersdr, else /run/user/<uid>/aethersdr,
+// else /tmp/aethersdr-<uid>), created 0700. Mirrors PipeWireAudioBridge::daxFifoDir
+// — owner-only, NOT world-writable /tmp (GHSA-x8xf-4g5v-ppf9).
+QString iqFifoDir()
+{
+    QString base = QString::fromLocal8Bit(qgetenv("XDG_RUNTIME_DIR"));
+    if (base.isEmpty()) {
+        const QString runUser = QStringLiteral("/run/user/%1").arg(::getuid());
+        base = QDir(runUser).exists() ? runUser
+                                      : QStringLiteral("/tmp/aethersdr-%1").arg(::getuid());
+    }
+    const QString dir = base + QStringLiteral("/aethersdr");
+    if (::mkdir(dir.toUtf8().constData(), 0700) != 0 && errno != EEXIST)
+        return {};
+    ::chmod(dir.toUtf8().constData(), 0700);
+    return dir;
+}
+
+QString iqPipePath(int channel)
+{
+    const QString dir = iqFifoDir();
+    return dir.isEmpty() ? QString()
+                         : QStringLiteral("%1/iq-%2.pipe").arg(dir).arg(channel);
+}
+
+// TOCTOU-safe owner-only FIFO (mirrors PipeWireAudioBridge::makeOwnedFifo):
+// mkfifo(0600); on EEXIST, only reuse it if it is our own FIFO, else refuse.
+bool makeOwnedFifo(const QString& path)
+{
+    const QByteArray pb = path.toUtf8();
+    if (::mkfifo(pb.constData(), 0600) == 0) return true;
+    if (errno != EEXIST) return false;
+    struct stat st{};
+    if (::lstat(pb.constData(), &st) != 0 || !S_ISFIFO(st.st_mode)
+        || st.st_uid != ::getuid())
+        return false;                       // refuse to clobber a foreign file
+    if (::unlink(pb.constData()) != 0) return false;
+    return ::mkfifo(pb.constData(), 0600) == 0;
+}
+
+// Synchronous pactl; returns the loaded module index (0 on failure).
+// Mirrors PipeWireAudioBridge::runPactl — replaces the old fire-and-forget
+// QProcess::startDetached so we KNOW the module loaded (and can unload by index).
+quint32 runPactlSync(const QStringList& args)
+{
+    QProcess proc;
+    proc.start(QStringLiteral("pactl"), args);
+    if (!proc.waitForFinished(5000)) {
+        qCWarning(lcAudio) << "DaxIqWorker: pactl timed out:" << args;
+        return 0;
+    }
+    if (proc.exitCode() != 0) {
+        qCWarning(lcAudio) << "DaxIqWorker: pactl failed:"
+                           << proc.readAllStandardError().trimmed();
+        return 0;
+    }
+    bool ok = false;
+    const quint32 idx = proc.readAllStandardOutput().trimmed().toUInt(&ok);
+    return ok ? idx : 0;
+}
+
+} // namespace
+#endif // !Q_OS_WIN
 
 // ─── DaxIqModel ──────────────────────────────────────────────────────────────
 
@@ -180,30 +250,59 @@ void DaxIqWorker::createPipe(int channel, int sampleRate)
     if (idx < 0 || idx >= DaxIqModel::NUM_CHANNELS) return;
     if (m_pipeFds[idx] >= 0) destroyPipe(channel);
 
-    QString pipePath = QString("/tmp/aethersdr-iq-%1.pipe").arg(channel);
+    const QString pipePath = iqPipePath(channel);
+    if (pipePath.isEmpty()) {
+        qCWarning(lcAudio) << "DaxIqWorker: cannot resolve IQ FIFO dir for ch" << channel;
+        return;
+    }
 
-    // Create PulseAudio pipe source for IQ data (float32 stereo)
-    QString cmd = QString(
-        "pactl load-module module-pipe-source "
-        "source_name=aethersdr-iq-%1 "
-        "file=%2 "
-        "format=float32le rate=%3 channels=2 "
-        "source_properties=device.description=\"AetherSDR\\ IQ\\ %1\"")
-        .arg(channel).arg(pipePath).arg(sampleRate);
+    // Create the owner-only FIFO ourselves first, THEN load the pipe-source.
+    // (1) mkfifo-first removes the create-race: the old code fire-and-forgot
+    //     `pactl` and raced a 200ms sleep to open a FIFO module-pipe-source had
+    //     not created yet -> ENOENT "cannot open IQ pipe", no node ever appeared.
+    // (2) 0600 under $XDG_RUNTIME_DIR/aethersdr (not /tmp/aethersdr-iq-N.pipe,
+    //     which was prw-rw-rw-) closes the world-writable-FIFO IQ-injection
+    //     vector, mirroring the DAX-audio hardening (GHSA-x8xf-4g5v-ppf9).
+    if (!makeOwnedFifo(pipePath)) {
+        qCWarning(lcAudio) << "DaxIqWorker: mkfifo failed for" << pipePath;
+        return;
+    }
 
-    QProcess::startDetached("bash", {"-c", cmd});
+    // Load module-pipe-source SYNCHRONOUSLY so we know it succeeded and capture
+    // the module index for a clean unload. source_properties is single-quoted so
+    // the spaced device.description survives pipewire-pulse's module-arg parser
+    // (mirrors the DAX RX/TX naming fix); node.description drives the label shown
+    // in qpwgraph / JACK / WSJT-X.
+    const quint32 modIdx = runPactlSync({
+        "load-module", "module-pipe-source",
+        QStringLiteral("source_name=aethersdr-iq-%1").arg(channel),
+        QStringLiteral("file=%1").arg(pipePath),
+        QStringLiteral("format=float32le"),
+        QStringLiteral("rate=%1").arg(sampleRate),
+        QStringLiteral("channels=2"),
+        QStringLiteral("source_properties='device.description=\"AetherSDR DAX IQ %1\"'").arg(channel),
+    });
+    if (modIdx == 0) {
+        ::unlink(pipePath.toLocal8Bit().constData());
+        qCWarning(lcAudio) << "DaxIqWorker: pactl load-module failed for IQ ch" << channel;
+        return;
+    }
+    m_pipeModuleIdx[idx] = modIdx;
 
-    // Open the pipe for writing (non-blocking to avoid stalling if no reader)
-    // Give PulseAudio a moment to create the pipe
-    QThread::msleep(200);
-    int fd = ::open(pipePath.toLocal8Bit().constData(), O_WRONLY | O_NONBLOCK);
+    // Open the write end. O_RDWR (not O_WRONLY) never ENXIOs even if the module's
+    // read side has not attached yet; we only ever write this fd.
+    int fd = ::open(pipePath.toLocal8Bit().constData(), O_RDWR | O_NONBLOCK);
     if (fd < 0) {
-        qCWarning(lcAudio) << "DaxIqWorker: cannot open IQ pipe" << pipePath;
+        qCWarning(lcAudio) << "DaxIqWorker: cannot open IQ pipe" << pipePath
+                           << strerror(errno);
+        runPactlSync({"unload-module", QString::number(modIdx)});
+        ::unlink(pipePath.toLocal8Bit().constData());
+        m_pipeModuleIdx[idx] = 0;
         return;
     }
     m_pipeFds[idx] = fd;
-    qCDebug(lcAudio) << "DaxIqWorker: opened IQ pipe ch" << channel
-                      << "rate" << sampleRate;
+    qCDebug(lcAudio) << "DaxIqWorker: opened IQ pipe ch" << channel << "rate" << sampleRate
+                     << "module" << modIdx << "path" << pipePath;
 #else
     Q_UNUSED(channel); Q_UNUSED(sampleRate);
 #endif
@@ -218,11 +317,15 @@ void DaxIqWorker::destroyPipe(int channel)
         ::close(m_pipeFds[idx]);
         m_pipeFds[idx] = -1;
     }
-    // Unload the PulseAudio module
-    QString cmd = QString(
-        "pactl list short modules | grep aethersdr-iq-%1 | awk '{print $1}' | "
-        "xargs -r -n1 pactl unload-module").arg(channel);
-    QProcess::startDetached("bash", {"-c", cmd});
+    // Unload the pipe-source module by its stored index (clean, no grep race),
+    // then remove the FIFO we created.
+    if (m_pipeModuleIdx[idx] != 0) {
+        runPactlSync({"unload-module", QString::number(m_pipeModuleIdx[idx])});
+        m_pipeModuleIdx[idx] = 0;
+    }
+    const QString pipePath = iqPipePath(channel);
+    if (!pipePath.isEmpty())
+        ::unlink(pipePath.toLocal8Bit().constData());
 #else
     Q_UNUSED(channel);
 #endif

--- a/src/models/DaxIqModel.cpp
+++ b/src/models/DaxIqModel.cpp
@@ -82,10 +82,12 @@ void DaxIqModel::applyStreamStatus(quint32 streamId, const QMap<QString, QString
     }
 
     // New stream — assign by channel
+    bool isNew = false;
     if (idx < 0 && ch >= 1 && ch <= NUM_CHANNELS) {
         idx = channelIndex(ch);
         m_streams[idx].streamId = streamId;
         m_streams[idx].exists = true;
+        isNew = true;
         qCDebug(lcProtocol) << "DaxIqModel: new IQ stream ch" << ch
                             << "id" << Qt::hex << streamId;
     }
@@ -94,11 +96,20 @@ void DaxIqModel::applyStreamStatus(quint32 streamId, const QMap<QString, QString
 
     auto& s = m_streams[idx];
 
-    if (kvs.contains("daxiq_rate")) {
-        int newRate = kvs["daxiq_rate"].toInt();
-        if (newRate != s.sampleRate) {
+    // Create the IQ pipe when the stream first appears (isNew), not only on a
+    // rate CHANGE. The default daxiq_rate=48000 equals IqStream::sampleRate{48000},
+    // so a fresh enable at the default rate produced no rate delta and the pipe
+    // was never built (no module-pipe-source, no /tmp/aethersdr-iq-N.pipe, no
+    // node for WS2 to name). Guard merged: fire on existence OR rate change, and
+    // keep it OUTSIDE the daxiq_rate-present check so a status message that
+    // establishes the stream without carrying daxiq_rate still triggers it.
+    // destroyPipe is idempotent (m_pipeFds[idx]>=0 guard), so destroy-then-create
+    // is safe even with no prior pipe.
+    {
+        int newRate = kvs.contains("daxiq_rate") ? kvs["daxiq_rate"].toInt()
+                                                  : s.sampleRate;
+        if (isNew || newRate != s.sampleRate) {
             s.sampleRate = newRate;
-            // Recreate pipe at new sample rate
             QMetaObject::invokeMethod(m_worker, [this, ch = s.channel, newRate] {
                 m_worker->destroyPipe(ch);
                 m_worker->createPipe(ch, newRate);

--- a/src/models/DaxIqModel.cpp
+++ b/src/models/DaxIqModel.cpp
@@ -340,12 +340,17 @@ void DaxIqWorker::processIqPacket(int channel, const QByteArray& rawPayload, int
     const int numFloats = rawPayload.size() / 4;
     const int numSamples = numFloats / 2;  // I/Q pairs
 
-    // Byte-swap float32 big-endian → native (little-endian)
+    // dax_iq payloads are LITTLE-endian float32 (the radio reports
+    // payload_endian=little for this stream type — unlike pan/wf/meter/audio
+    // which are big-endian network order). Reading them big-endian byte-reverses
+    // the floats into denormals ≈ 0, which flat-lines the RMS meter AND writes
+    // garbage to the format=float32le pipe. Read little-endian (a correct no-op
+    // on an LE host) so both the meter and the pipe carry real IQ.
     QByteArray swapped(rawPayload.size(), Qt::Uninitialized);
     const quint32* src = reinterpret_cast<const quint32*>(rawPayload.constData());
     quint32* dst = reinterpret_cast<quint32*>(swapped.data());
     for (int i = 0; i < numFloats; ++i)
-        dst[i] = qFromBigEndian(src[i]);
+        dst[i] = qFromLittleEndian(src[i]);
 
     // Compute RMS magnitude for metering (every ~100ms worth of samples)
     const float* floats = reinterpret_cast<const float*>(swapped.constData());

--- a/src/models/DaxIqModel.h
+++ b/src/models/DaxIqModel.h
@@ -92,6 +92,7 @@ signals:
 
 private:
     int m_pipeFds[DaxIqModel::NUM_CHANNELS]{-1, -1, -1, -1};
+    quint32 m_pipeModuleIdx[DaxIqModel::NUM_CHANNELS]{};  // pactl module idx per pipe (0=none)
     int m_sampleCount[DaxIqModel::NUM_CHANNELS]{};
     double m_sumSq[DaxIqModel::NUM_CHANNELS]{};
 };


### PR DESCRIPTION
## Summary

DAX-IQ has **never delivered samples in-app** on Linux/macOS. The CHANGELOG advertises "DAX IQ pipe output is Linux/macOS only" as a working feature, and **#2529** reports it producing zero/empty IQ payloads. This is the root-cause fix: **three independent defects in the data path** that, together, prevented any IQ from reaching the pipe.

## Root cause (3 defects, all in `DaxIqModel`)

**1. The pipe was never created on a normal enable.** `createPipe()` was only called inside a rate-*change* guard (`if (newRate != s.sampleRate)`), but a fresh stream is born at `daxiq_rate=48000`, which equals the model's default sample rate — so enabling a channel produced no rate delta and the FIFO + its PipeWire source node were never built. → fire `createPipe` on first appearance (`isNew`) as well.

**2. Even when triggered, the FIFO open raced and failed.** The old path fire-and-forgot `pactl load-module`, slept 200 ms, then `::open(O_WRONLY|O_NONBLOCK)` — which returns `ENXIO` if the module hasn't attached its read side yet (the "cannot open IQ pipe" warning). → create the FIFO ourselves first (`mkfifo`), load the pipe-source module **synchronously** (so we know it succeeded and can unload it by index), and open `O_RDWR|O_NONBLOCK` (which never `ENXIO`s even with no reader yet). The FIFO also moves off world-writable `/tmp` to `$XDG_RUNTIME_DIR/aethersdr/iq-N.pipe` mode `0600`, mirroring the existing DAX-audio hardening.

**3. The payload was decoded with the wrong endianness.** `dax_iq` is the one stream type the radio sends as `payload_endian=little`; the client force-swapped it as big-endian (`qFromBigEndian`), byte-reversing every `float32` into a denormal ≈ 0 — a flat meter and a pipe full of near-zero. **This is the likely mechanism behind #2529's "zero-byte payload."** → honor little-endian (`qFromLittleEndian`); a correct no-op on an LE host.

## Verified

Live on a **FLEX-6700 (RX-only)** from a Linux/PipeWire host:

- The `aethersdr-iq-1` PipeWire source appears on enable (was absent before); FIFO `/run/user/<uid>/aethersdr/iq-1.pipe` present, mode `0600`.
- `parec` off that source captured **768 KB @ ~384 KB/s** (= `float32 × 2ch × 48 kHz`), **98% non-zero**, clean small-integer IQ that only resolves correctly decoded little-endian (big-endian reads as denormals).
- Note: the pipe exposes the radio's **native int16-scale `float32`** (raw baseband amplitude, magnitudes up to ~32768), matching DAX-audio convention — **not** normalized `[-1, 1]`. This is a data convention, not a wire-type guarantee.

## Scope

- 3 commits, `src/models/DaxIqModel.{cpp,h}` only.
- New FIFO/`pactl` plumbing is entirely `#ifndef Q_OS_WIN` (Windows uses its own DAX path); the endian decode is platform-independent.

## Test plan

- [x] Each commit builds standalone; full build clean (Linux, gcc 15.2.1, Qt 6.10.3).
- [x] **Live A/B on a FLEX-6700 (RX-only):** before → no `aethersdr-iq-*` node, flat meter; after → named source + real IQ. `parec` off the source captured **768 KB @ ~384 KB/s** (`float32 ×2ch ×48 kHz`), **98% non-zero**, resolving correctly only as little-endian (big-endian reads as denormals ≈ 0 — the #2529 "zero payload").
- [x] **CI green on all three platforms:** Linux build · **Windows (MSVC)** · **macOS (clang)** · CodeQL · accessibility.
- [x] **Runtime-confirmed on Windows and macOS** native builds against the same FLEX-6700: DAX-IQ works — the level meter tracks live signal, confirming the (platform-independent) little-endian decode. The full end-to-end **pipe** is proven on Linux via `parec` above; the FIFO/`pactl` plumbing is non-Windows (`#ifndef Q_OS_WIN`) and, since `pactl` is a PipeWire/PulseAudio tool, the OS pipe node materializes on Linux specifically — so the macOS confirmation here is of the decode (via the meter), not a macOS pipe node.

Closes #2529

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent, on Linux dev stack (`nobara-dell`), live-verified against a FLEX-6700.
