### PR TITLE
ci(windows): unbreak hidapi source build under CMake 4 runners

### DIFF
--- a/scripts/setup/setup-hidapi.ps1
+++ b/scripts/setup/setup-hidapi.ps1
@@ -58,9 +58,14 @@ Copy-Item "$($srcDir.FullName)\hidapi\hidapi.h" "$OutDir\include\hidapi\"
 Write-Host "Building hidapi from source with MSVC..." -ForegroundColor Cyan
 
 $buildDir = "$($srcDir.FullName)\build"
+# CMAKE_POLICY_VERSION_MINIMUM: hidapi 0.14.0's cmake_minimum_required is
+# below 3.5, which CMake 4.x (rolling out on windows-latest runners) treats
+# as a hard error instead of a deprecation warning. The flag tells CMake to
+# configure anyway; harmless on CMake 3.x.
 cmake -B $buildDir -S $srcDir.FullName -G "Ninja" `
     -DCMAKE_BUILD_TYPE=Release `
-    -DBUILD_SHARED_LIBS=ON
+    -DBUILD_SHARED_LIBS=ON `
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 cmake --build $buildDir --config Release -j $env:NUMBER_OF_PROCESSORS
 


### PR DESCRIPTION
## Problem

GitHub is mid-rollout of a `windows-latest` runner image with **CMake 4.x**, which turns hidapi 0.14.0's pre-3.5 `cmake_minimum_required` from a deprecation warning into a hard configure error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

`check-windows` runs `scripts/setup/setup-hidapi.ps1` on every PR (`ci.yml` has no hidapi cache), so right now **whether a Windows job passes depends on which runner image it lands on**:

- [Main run 27321077856](https://github.com/aethersdr/AetherSDR/actions/runs/27321077856) (CMake 3.x runner) — same script, same hidapi build → deprecation warning, passes
- [PR #3407 run 27301429930](https://github.com/aethersdr/AetherSDR/actions/runs/27301429930/job/80647974679) (CMake 4 runner) — hard error at configure, fails through no fault of the PR

Once the image rollout completes, **every Windows CI job will fail**.

## Fix

Pass `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to the hidapi configure — CMake's [documented escape hatch](https://cmake.org/cmake/help/latest/variable/CMAKE_POLICY_VERSION_MINIMUM.html) for exactly this situation. On CMake 3.x runners the variable is simply unused, so the script behaves identically on both image generations.

## Scope check on the other setup scripts

- `setup-opus.ps1` — opus 1.5.2 requires CMake 3.16 → unaffected
- `setup-onnxruntime.ps1` — prebuilt binaries, no source configure → unaffected
- `windows-installer.yml` caches hidapi keyed on this script's hash → cache invalidates and rebuilds with the flag automatically

## Testing

Can't execute PowerShell locally (macOS box) — but this PR's own `check-windows` run exercises the modified script directly, on whichever runner image it draws. A green check here on a CMake 4 runner is the end-to-end proof; on a 3.x runner it proves no regression.

Unblocks #3407's red `check-windows`.
