### PR TITLE
feat(tnc): Direwolf-derived AFSK demodulator for VHF 1200-baud AX.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2053,6 +2053,14 @@ target_link_libraries(ax25_libmodem_shim_test PRIVATE Qt6::Core aether_libmodem_
     aether_afskdemod)
 add_test(NAME ax25_libmodem_shim_test COMMAND ax25_libmodem_shim_test)
 
+add_executable(hdlc_codec_test
+    tests/hdlc_codec_test.cpp
+    src/core/tnc/HdlcCodec.cpp
+)
+target_include_directories(hdlc_codec_test PRIVATE src)
+target_link_libraries(hdlc_codec_test PRIVATE aether_libmodem_core)
+add_test(NAME hdlc_codec_test COMMAND hdlc_codec_test)
+
 # Offline AX.25 decode diagnostic: replays a captured WAV through the decoder.
 # Not a ctest (needs an input file); built on demand for troubleshooting.
 add_executable(ax25_replay EXCLUDE_FROM_ALL
@@ -2107,14 +2115,6 @@ add_executable(tnc_terminal_test
 target_include_directories(tnc_terminal_test PRIVATE src)
 target_link_libraries(tnc_terminal_test PRIVATE Qt6::Core)
 add_test(NAME tnc_terminal_test COMMAND tnc_terminal_test)
-
-add_executable(hdlc_codec_test
-    tests/hdlc_codec_test.cpp
-    src/core/tnc/HdlcCodec.cpp
-)
-target_include_directories(hdlc_codec_test PRIVATE src)
-target_link_libraries(hdlc_codec_test PRIVATE aether_libmodem_core)
-add_test(NAME hdlc_codec_test COMMAND hdlc_codec_test)
 
 add_executable(cwx_panel_test
     tests/cwx_panel_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -885,6 +885,19 @@ else()
     target_compile_options(aether_libmodem_core PRIVATE -w)
 endif()
 
+# AetherAFSKDemod — Direwolf profile-A AFSK demodulator (GPL-3).
+# Profile A: IQ-mix + RRC + AGC/multi-slicer (best for amplitude-imbalanced signals).
+# VHF 1200 baud only; HF 300 baud stays on aether_libmodem_core.
+# AX.25 framing (bitstream, HDLC, FCS) continues to use aether_libmodem_core.
+add_library(aether_afskdemod STATIC
+    third_party/direwolf_afsk/AetherAFSKDemod.cpp
+)
+target_include_directories(aether_afskdemod PUBLIC
+    ${CMAKE_SOURCE_DIR}/third_party/direwolf_afsk
+)
+target_compile_features(aether_afskdemod PUBLIC cxx_std_20)
+message(STATUS "AetherAFSKDemod: Direwolf profile-A (VHF 1200 baud), GPL-3")
+
 # Bundled liquid-dsp (MIT) — comprehensive DSP toolkit covering modems
 # (PSK/QAM/FSK/GMSK/OFDM), FEC (Hamming/Golay/RS/convolutional), adaptive
 # filters (LMS/RLS), AGC, NCO, polyphase resampling, and equalizers.
@@ -1122,6 +1135,7 @@ target_link_libraries(AetherSDR PRIVATE
     Qt6::Network
     Qt6::Multimedia
     aether_libmodem_core
+    aether_afskdemod
     ${CMAKE_DL_LIBS}   # dlopen/dlsym for tolerant X11 error handler (#1839)
 )
 
@@ -2035,16 +2049,9 @@ add_executable(ax25_libmodem_shim_test
     src/core/AppSettings.cpp
 )
 target_include_directories(ax25_libmodem_shim_test PRIVATE src)
-target_link_libraries(ax25_libmodem_shim_test PRIVATE Qt6::Core aether_libmodem_core)
+target_link_libraries(ax25_libmodem_shim_test PRIVATE Qt6::Core aether_libmodem_core
+    aether_afskdemod)
 add_test(NAME ax25_libmodem_shim_test COMMAND ax25_libmodem_shim_test)
-
-add_executable(hdlc_codec_test
-    tests/hdlc_codec_test.cpp
-    src/core/tnc/HdlcCodec.cpp
-)
-target_include_directories(hdlc_codec_test PRIVATE src)
-target_link_libraries(hdlc_codec_test PRIVATE aether_libmodem_core)
-add_test(NAME hdlc_codec_test COMMAND hdlc_codec_test)
 
 # Offline AX.25 decode diagnostic: replays a captured WAV through the decoder.
 # Not a ctest (needs an input file); built on demand for troubleshooting.
@@ -2058,7 +2065,7 @@ add_executable(ax25_replay EXCLUDE_FROM_ALL
     src/core/AppSettings.cpp
 )
 target_include_directories(ax25_replay PRIVATE src)
-target_link_libraries(ax25_replay PRIVATE Qt6::Core aether_libmodem_core)
+target_link_libraries(ax25_replay PRIVATE Qt6::Core aether_libmodem_core aether_afskdemod)
 
 add_executable(ax25_session_analyze EXCLUDE_FROM_ALL
     tools/ax25_session_analyze.cpp
@@ -2072,7 +2079,7 @@ add_executable(ax25_session_analyze EXCLUDE_FROM_ALL
     src/core/AppSettings.cpp
 )
 target_include_directories(ax25_session_analyze PRIVATE src)
-target_link_libraries(ax25_session_analyze PRIVATE Qt6::Core aether_libmodem_core)
+target_link_libraries(ax25_session_analyze PRIVATE Qt6::Core aether_libmodem_core aether_afskdemod)
 
 add_executable(pms_mailbox_test
     tests/pms_mailbox_test.cpp
@@ -2100,6 +2107,14 @@ add_executable(tnc_terminal_test
 target_include_directories(tnc_terminal_test PRIVATE src)
 target_link_libraries(tnc_terminal_test PRIVATE Qt6::Core)
 add_test(NAME tnc_terminal_test COMMAND tnc_terminal_test)
+
+add_executable(hdlc_codec_test
+    tests/hdlc_codec_test.cpp
+    src/core/tnc/HdlcCodec.cpp
+)
+target_include_directories(hdlc_codec_test PRIVATE src)
+target_link_libraries(hdlc_codec_test PRIVATE aether_libmodem_core)
+add_test(NAME hdlc_codec_test COMMAND hdlc_codec_test)
 
 add_executable(cwx_panel_test
     tests/cwx_panel_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -885,7 +885,9 @@ else()
     target_compile_options(aether_libmodem_core PRIVATE -w)
 endif()
 
-# AetherAFSKDemod — Direwolf profile-A AFSK demodulator (GPL-3).
+# AetherAFSKDemod — Direwolf profile-A AFSK demodulator.
+# Vendored Dire Wolf source is GPL-2.0-or-later; the combined AetherSDR work is
+# GPL-3.0-or-later (see THIRD_PARTY_LICENSES).
 # Profile A: IQ-mix + RRC + AGC/multi-slicer (best for amplitude-imbalanced signals).
 # VHF 1200 baud only; HF 300 baud stays on aether_libmodem_core.
 # AX.25 framing (bitstream, HDLC, FCS) continues to use aether_libmodem_core.
@@ -896,7 +898,7 @@ target_include_directories(aether_afskdemod PUBLIC
     ${CMAKE_SOURCE_DIR}/third_party/direwolf_afsk
 )
 target_compile_features(aether_afskdemod PUBLIC cxx_std_20)
-message(STATUS "AetherAFSKDemod: Direwolf profile-A (VHF 1200 baud), GPL-3")
+message(STATUS "AetherAFSKDemod: Direwolf profile-A (VHF 1200 baud), GPL-2.0-or-later")
 
 # Bundled liquid-dsp (MIT) — comprehensive DSP toolkit covering modems
 # (PSK/QAM/FSK/GMSK/OFDM), FEC (Hamming/Golay/RS/convolutional), adaptive

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -194,3 +194,15 @@ Windows will need to land MSVC support first.
   Copyright (c) 2007-2016 Joseph Gaeddert
   License: MIT
   Source:  https://github.com/jgaeddert/liquid-dsp
+
+
+15. Dire Wolf — AFSK Demodulator (algorithmic derivation)
+----------------------------------------------------------
+Bundled at third_party/direwolf_afsk/ as an algorithmic derivation of the
+Dire Wolf "profile A" AFSK demodulator. Rewritten in C++20 for AetherSDR.
+Referenced source files: src/demod_afsk.c, src/dsp.c from Dire Wolf 1.7.
+Used unconditionally for the VHF 1200 baud AX.25 receive path.
+
+  Copyright (C) 2011-2020 John Langner WB2OSZ
+  License: GPL-2.0-or-later (compatible into AetherSDR's GPL-3.0-or-later)
+  Source:  https://github.com/wb2osz/direwolf

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -97,7 +97,6 @@ constexpr std::array<int, 21> kHf300DecodePhaseOffsets = {
 // 1200 baud VHF (Bell 202 / APRS): one DPLL lane per slicer for each enabled
 // algorithm. Duplicate suppression collapses the same frame seen by multiple
 // lanes into one emission, like Direwolf's multi_modem.c.
-constexpr double kVhf1200PllAlpha = 0.010;
 
 // Profile A+ space-gain multipliers — exact Direwolf A+ values (MAX_SUBCHANS=9).
 // Geometric series: MIN_G=0.5, MAX_G=4.0, 9 steps.
@@ -550,13 +549,17 @@ struct AetherAx25LibmodemShim::Impl {
             ? config.markHz
             : config.spaceHz;
 
-        auto addLaneA = [&](int phaseOffsetSamples, double pllAlpha, float spaceGain = 0.0f) {
+        auto addLaneA = [&](int phaseOffsetSamples, float spaceGain = 0.0f) {
             auto& lane = lanes.emplace_back();
             lane.phaseOffsetSamples = phaseOffsetSamples;
             lane.samplesUntilStart  = phaseOffsetSamples;
+            // The pll_alpha positional arg (0.010) is accepted for API
+            // compatibility but ignored by AetherAFSKDemod, which uses
+            // Direwolf's internal DPLL inertia constants — so there is no
+            // tunable VHF pll_alpha (unlike the HF libmodem lane below).
             lane.demod = std::make_unique<DirewolfAfskDemod>(
                 mark, space, config.baud, config.sampleRate,
-                0.75, 6.0, 0.75, 3.0, 0.008, 0.005, pllAlpha, spaceGain);
+                0.75, 6.0, 0.75, 3.0, 0.008, 0.005, 0.010, spaceGain);
         };
 
         auto addLaneHf = [&](int phaseOffsetSamples, double pllAlpha) {
@@ -577,8 +580,7 @@ struct AetherAx25LibmodemShim::Impl {
             const auto layout = vhfModeLayout(config.vhfMode);
             if (layout.wantA)
                 for (int s = 0; s < layout.aSlicers; ++s)
-                    addLaneA(0, kVhf1200PllAlpha,
-                             layout.aSlicers > 1 ? kVhf1200SpaceGains[s] : 0.0f);
+                    addLaneA(0, layout.aSlicers > 1 ? kVhf1200SpaceGains[s] : 0.0f);
         }
         resetDecoderState(true, true);
 

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -780,8 +780,8 @@ struct AetherAx25LibmodemShim::Impl {
         lastRejectFrameBits = lane.hdlcCodec.frameSizeBits();
         lastRejectFrameBytes = static_cast<int>(frameBytesSize);
         lastRejectPreviewHex = framePreviewHex(lane.hdlcCodec.frameData(), frameBytesSize);
-        lastRejectActualFcs = frameBytesSize >= 18 ? fcsToString(actualFcs) : QString();
-        lastRejectExpectedFcs = frameBytesSize >= 18 ? fcsToString(expectedFcs) : QString();
+        lastRejectActualFcs = frameBytesSize >= 17 ? fcsToString(actualFcs) : QString();
+        lastRejectExpectedFcs = frameBytesSize >= 17 ? fcsToString(expectedFcs) : QString();
 
         // Minimum valid AX.25 frame is 17 bytes (14 address + 1 control + 2 FCS);
         // a no-PID U-frame (SABM/DISC/UA/DM) sits exactly at 17. Anything shorter
@@ -828,7 +828,10 @@ struct AetherAx25LibmodemShim::Impl {
         const bool frameComplete = lane.hdlcCodec.processBit(bit ? 1 : 0);
 
         if (lane.hdlcCodec.inFrame() && !wasInFrame) {
-            if (currentDecodeSampleIndex > lastHdlcFrameStartSampleIndex + 10) {
+            // One symbol = 20 samples at 24 kHz/1200 baud; window suppresses
+            // cross-lane duplicates.  Counter is approximate: DPLLs on
+            // different lanes may land frame-start detection slightly apart.
+            if (currentDecodeSampleIndex > lastHdlcFrameStartSampleIndex + 20) {
                 lastHdlcFrameStartSampleIndex = currentDecodeSampleIndex;
                 ++totalHdlcFrameStarts;
             }
@@ -1086,6 +1089,7 @@ QVector<Ax25DecodedFrame> AetherAx25LibmodemShim::processMonoFloat(const float* 
                                                                    int sampleRate)
 {
     QVector<Ax25DecodedFrame> frames;
+    // lanes.empty() when VhfMode::Off — diagnostics stay frozen intentionally.
     if (!samples || sampleCount <= 0 || m_impl->lanes.empty())
         return frames;
 

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -8,7 +8,10 @@
 
 #include "core/tnc/HdlcCodec.h"
 
+#include "AetherAFSKDemod.h"
+
 #include <QDateTime>
+#include <QVarLengthArray>
 
 #include <algorithm>
 #include <array>
@@ -21,6 +24,40 @@
 namespace AetherSDR {
 
 namespace lm = aether_libmodem_core;
+
+// Abstract demodulator interface — allows VHF (Direwolf-derived) and HF
+// (libmodem) demod types to coexist in the same lane vector.
+struct BitResult {
+    quint64 sampleIndex;
+    uint8_t bit;
+    double  confidence;
+};
+
+struct IAfskDemod {
+    virtual ~IAfskDemod() = default;
+    virtual void processBlock(const float* samples, int count, quint64 sampleBase,
+                               std::vector<BitResult>& out) = 0;
+    virtual void reset() noexcept = 0;
+};
+
+template<typename Demod, typename Result>
+struct AfskDemodWrapper : IAfskDemod {
+    Demod inner;
+    template<typename... Args>
+    explicit AfskDemodWrapper(Args&&... args) : inner(std::forward<Args>(args)...) {}
+    void processBlock(const float* samples, int count, quint64 sampleBase,
+                      std::vector<BitResult>& out) override {
+        for (int i = 0; i < count; ++i) {
+            Result r;
+            if (inner.try_demodulate(static_cast<double>(samples[i]), r))
+                out.push_back({sampleBase + static_cast<quint64>(i), r.bit, r.confidence});
+        }
+    }
+    void reset() noexcept override { inner.reset(); }
+};
+
+using LibmodemAfskDemod = AfskDemodWrapper<lm::sinc_corr_afsk_demodulator, lm::demod_result>;
+using DirewolfAfskDemod = AfskDemodWrapper<AetherDemod::AetherAFSKDemod, AetherDemod::demod_result>;
 
 namespace {
 
@@ -57,25 +94,18 @@ constexpr std::array<int, 21> kHf300DecodePhaseOffsets = {
     43, 47, 51, 55, 59, 63, 67, 71, 75, 79
 };
 
-// 1200 baud VHF (Bell 202 / APRS): an aggressive bank of independent correlator
-// demodulators, combining two complementary strategies so the widest range of
-// bursts is captured. Duplicate suppression collapses the same frame seen by
-// several lanes into one emission, like a multi-decoder TNC (e.g. Dire Wolf).
-//
-//   * Free-running lanes (PLL alpha 0) spread evenly across the symbol period.
-//     With no timing loop they sample at a fixed phase, so on a clean burst at
-//     least one lane lands on the eye center and decodes immediately — the same
-//     proven mechanism as the HF bank. Best for short / strong / clean packets.
-//   * Gardner-tracked lanes (PLL alpha > 0) actively chase the symbol clock, so
-//     they tolerate TX/RX clock drift and fading over longer or weaker bursts
-//     where a fixed-phase lane would slip off the eye. A tight and a loose loop
-//     bandwidth bracket clean-vs-fast-acquisition trade-offs.
-//
-// Total lanes = kVhf1200FreeRunPhaseCount
-//             + kVhf1200TrackedPhaseCount * kVhf1200PllAlphas.size().
-constexpr int kVhf1200FreeRunPhaseCount = 10;
-constexpr int kVhf1200TrackedPhaseCount = 4;
-constexpr std::array<double, 2> kVhf1200PllAlphas = { 0.010, 0.025 };
+// 1200 baud VHF (Bell 202 / APRS): one DPLL lane per slicer for each enabled
+// algorithm. Duplicate suppression collapses the same frame seen by multiple
+// lanes into one emission, like Direwolf's multi_modem.c.
+constexpr double kVhf1200PllAlpha = 0.010;
+
+// Profile A+ space-gain multipliers — exact Direwolf A+ values (MAX_SUBCHANS=9).
+// Geometric series: MIN_G=0.5, MAX_G=4.0, 9 steps.
+// Formula: gain[0]=MIN_G, gain[j]=gain[j-1]*pow(10, log10(MAX_G/MIN_G)/(N-1)).
+constexpr std::array<float, 9> kVhf1200SpaceGains = {
+    0.500000f, 0.648420f, 0.840896f, 1.090508f, 1.414214f,
+    1.834008f, 2.378414f, 3.084422f, 4.000000f
+};
 
 QString fcsToString(const std::array<uint8_t, 2>& fcs)
 {
@@ -352,14 +382,29 @@ Ax25TransmitFrame transmitFrameFromBytes(const QByteArray& ax25NoFcs)
     return out;
 }
 
+struct VhfLayout { bool wantA; int aSlicers; };
+
+VhfLayout vhfModeLayout(VhfMode mode)
+{
+    bool wantA = false, aMulti = false;
+    switch (mode) {
+    case VhfMode::Off:                         break;
+    case VhfMode::A:     wantA = true;         break;
+    case VhfMode::APlus: wantA = true; aMulti = true; break;
+    default: Q_UNREACHABLE();
+    }
+    return { wantA, aMulti ? static_cast<int>(kVhf1200SpaceGains.size()) : 1 };
+}
+
 } // namespace
 
-Ax25DemodConfig ax25DemodConfigForProfile(Ax25ModemProfile profile, Ax25TonePolarity polarity)
+Ax25DemodConfig ax25DemodConfigForProfile(Ax25ModemProfile profile, Ax25TonePolarity polarity, VhfMode vhfMode)
 {
     Ax25DemodConfig config;
     config.profile = profile;
     config.sampleRate = 24000;
     config.polarity = polarity;
+    config.vhfMode = vhfMode;
 
     switch (profile) {
     case Ax25ModemProfile::Hf300:
@@ -393,7 +438,7 @@ struct AetherAx25LibmodemShim::Impl {
     struct DecodeLane {
         int phaseOffsetSamples{0};
         int samplesUntilStart{0};
-        std::unique_ptr<lm::sinc_corr_afsk_demodulator> demod;
+        std::unique_ptr<IAfskDemod> demod;
         HdlcCodec hdlcCodec;
         double lastQuality{0.0};
     };
@@ -407,6 +452,7 @@ struct AetherAx25LibmodemShim::Impl {
     quint64 currentDecodeSampleIndex{0};
     std::vector<RecentFrame> recentFrames;
     quint64 totalHdlcFrameStarts{0};
+    quint64 lastHdlcFrameStartSampleIndex{0};
     quint64 totalHdlcFrameCandidates{0};
     quint64 totalPlausibleAx25Candidates{0};
     quint64 totalFramesAccepted{0};
@@ -504,49 +550,35 @@ struct AetherAx25LibmodemShim::Impl {
             ? config.markHz
             : config.spaceHz;
 
-        auto addLane = [&](int phaseOffsetSamples, double pllAlpha) {
+        auto addLaneA = [&](int phaseOffsetSamples, double pllAlpha, float spaceGain = 0.0f) {
             auto& lane = lanes.emplace_back();
             lane.phaseOffsetSamples = phaseOffsetSamples;
-            lane.samplesUntilStart = phaseOffsetSamples;
-            lane.demod = std::make_unique<lm::sinc_corr_afsk_demodulator>(
-                mark,
-                space,
-                config.baud,
-                config.sampleRate,
-                0.75,
-                6.0,
-                0.75,
-                3.0,
-                0.008,
-                0.005,
-                pllAlpha);
+            lane.samplesUntilStart  = phaseOffsetSamples;
+            lane.demod = std::make_unique<DirewolfAfskDemod>(
+                mark, space, config.baud, config.sampleRate,
+                0.75, 6.0, 0.75, 3.0, 0.008, 0.005, pllAlpha, spaceGain);
+        };
+
+        auto addLaneHf = [&](int phaseOffsetSamples, double pllAlpha) {
+            auto& lane = lanes.emplace_back();
+            lane.phaseOffsetSamples = phaseOffsetSamples;
+            lane.samplesUntilStart  = phaseOffsetSamples;
+            lane.demod = std::make_unique<LibmodemAfskDemod>(
+                mark, space, config.baud, config.sampleRate,
+                0.75, 6.0, 0.75, 3.0, 0.008, 0.005, pllAlpha);
         };
 
         if (config.profile == Ax25ModemProfile::Hf300) {
             // HF: free-running lanes (pll_alpha 0), recovery by phase diversity.
             for (int phaseOffset : kHf300DecodePhaseOffsets)
-                addLane(phaseOffset, 0.0);
+                addLaneHf(phaseOffset, 0.0);
         } else {
-            // VHF 1200: hybrid bank. Phase offsets are derived from the symbol
-            // period so the spread stays correct if the sample rate ever changes.
-            const int samplesPerSymbol = config.baud > 0
-                ? config.sampleRate / config.baud
-                : 0;
-            if (samplesPerSymbol <= 0) {
-                addLane(0, 0.0);
-            } else {
-                // Free-running phase-diversity lanes — decode clean/short bursts.
-                for (int phase = 0; phase < kVhf1200FreeRunPhaseCount; ++phase) {
-                    const int phaseOffset = (samplesPerSymbol * phase) / kVhf1200FreeRunPhaseCount;
-                    addLane(phaseOffset, 0.0);
-                }
-                // Gardner-tracked lanes — follow clock drift on long/weak bursts.
-                for (int phase = 0; phase < kVhf1200TrackedPhaseCount; ++phase) {
-                    const int phaseOffset = (samplesPerSymbol * phase) / kVhf1200TrackedPhaseCount;
-                    for (double laneAlpha : kVhf1200PllAlphas)
-                        addLane(phaseOffset, laneAlpha);
-                }
-            }
+            // VHF 1200: one DPLL lane per slicer for each enabled algorithm.
+            const auto layout = vhfModeLayout(config.vhfMode);
+            if (layout.wantA)
+                for (int s = 0; s < layout.aSlicers; ++s)
+                    addLaneA(0, kVhf1200PllAlpha,
+                             layout.aSlicers > 1 ? kVhf1200SpaceGains[s] : 0.0f);
         }
         resetDecoderState(true, true);
 
@@ -580,6 +612,7 @@ struct AetherAx25LibmodemShim::Impl {
             currentDecodeSampleIndex = 0;
             recentFrames.clear();
             totalHdlcFrameStarts = 0;
+            lastHdlcFrameStartSampleIndex = 0;
             totalHdlcFrameCandidates = 0;
             totalPlausibleAx25Candidates = 0;
             totalFramesAccepted = 0;
@@ -609,12 +642,6 @@ struct AetherAx25LibmodemShim::Impl {
     void resetLaneBitstream(DecodeLane& lane)
     {
         lane.hdlcCodec.reset();
-    }
-
-    void resetBitstreamStates()
-    {
-        for (auto& lane : lanes)
-            resetLaneBitstream(lane);
     }
 
     double measureBlockRmsDbfs(const float* samples, int sampleCount) const
@@ -657,12 +684,11 @@ struct AetherAx25LibmodemShim::Impl {
                 receiveGateOpen = true;
                 receiveGateIdleSamples = 0;
                 ++receiveGateResets;
-                resetBitstreamStates();
                 if (diagnosticsLoggingEnabled) {
                     qCDebug(lcAx25).nospace()
                         << "receive gate opened: rms="
                         << QString::number(receiveGateRmsDbfs, 'f', 1) << "dBFS floor="
-                        << QString::number(receiveGateFloorDbfs, 'f', 1) << "dBFS resets="
+                        << QString::number(receiveGateFloorDbfs, 'f', 1) << "dBFS opens="
                         << receiveGateResets;
                 }
                 return;
@@ -754,8 +780,8 @@ struct AetherAx25LibmodemShim::Impl {
         lastRejectFrameBits = lane.hdlcCodec.frameSizeBits();
         lastRejectFrameBytes = static_cast<int>(frameBytesSize);
         lastRejectPreviewHex = framePreviewHex(lane.hdlcCodec.frameData(), frameBytesSize);
-        lastRejectActualFcs = frameBytesSize >= 17 ? fcsToString(actualFcs) : QString();
-        lastRejectExpectedFcs = frameBytesSize >= 17 ? fcsToString(expectedFcs) : QString();
+        lastRejectActualFcs = frameBytesSize >= 18 ? fcsToString(actualFcs) : QString();
+        lastRejectExpectedFcs = frameBytesSize >= 18 ? fcsToString(expectedFcs) : QString();
 
         // Minimum valid AX.25 frame is 17 bytes (14 address + 1 control + 2 FCS);
         // a no-PID U-frame (SABM/DISC/UA/DM) sits exactly at 17. Anything shorter
@@ -799,13 +825,18 @@ struct AetherAx25LibmodemShim::Impl {
         lane.lastQuality = 0.95 * lane.lastQuality + 0.05 * quality;
         const bool wasInFrame = lane.hdlcCodec.inFrame();
 
-        if (!lane.hdlcCodec.processBit(bit)) {
-            if (lane.hdlcCodec.inFrame() && !wasInFrame)
+        const bool frameComplete = lane.hdlcCodec.processBit(bit ? 1 : 0);
+
+        if (lane.hdlcCodec.inFrame() && !wasInFrame) {
+            if (currentDecodeSampleIndex > lastHdlcFrameStartSampleIndex + 10) {
+                lastHdlcFrameStartSampleIndex = currentDecodeSampleIndex;
                 ++totalHdlcFrameStarts;
-            return std::nullopt;
+            }
         }
 
-        // Frame closed — hdlcCodec.complete() is true.
+        if (!frameComplete)
+            return std::nullopt;
+
         ++totalHdlcFrameCandidates;
 
         const size_t frameSize    = lane.hdlcCodec.frameSize();
@@ -876,14 +907,19 @@ struct AetherAx25LibmodemShim::Impl {
     bool shouldEmitFrame(const Ax25DecodedFrame& frame)
     {
         const QByteArray signature = frameSignature(frame);
-        const quint64 duplicateWindowSamples = static_cast<quint64>(
-            std::max(1, config.sampleRate) * kDuplicateSuppressSeconds);
+        const quint64 duplicateWindowSamples =
+            static_cast<quint64>(std::max(1, config.sampleRate)) * kDuplicateSuppressSeconds;
+
+        auto sampleGap = [&](quint64 a) -> quint64 {
+            return currentDecodeSampleIndex >= a
+                ? currentDecodeSampleIndex - a
+                : a - currentDecodeSampleIndex;
+        };
 
         recentFrames.erase(std::remove_if(recentFrames.begin(),
                                           recentFrames.end(),
                                           [&](const RecentFrame& recent) {
-                                              return currentDecodeSampleIndex >= recent.sampleIndex
-                                                  && currentDecodeSampleIndex - recent.sampleIndex > duplicateWindowSamples;
+                                              return sampleGap(recent.sampleIndex) > duplicateWindowSamples;
                                           }),
                            recentFrames.end());
 
@@ -891,8 +927,7 @@ struct AetherAx25LibmodemShim::Impl {
                                             recentFrames.end(),
                                             [&](const RecentFrame& recent) {
                                                 return recent.signature == signature
-                                                    && currentDecodeSampleIndex >= recent.sampleIndex
-                                                    && currentDecodeSampleIndex - recent.sampleIndex <= duplicateWindowSamples;
+                                                    && sampleGap(recent.sampleIndex) <= duplicateWindowSamples;
                                             });
         if (duplicate != recentFrames.end())
             return false;
@@ -917,11 +952,11 @@ struct AetherAx25LibmodemShim::Impl {
         ++diagnosticsWindow.audioSamples;
     }
 
-    void recordDemodSymbol(const lm::demod_result& result)
+    void recordDemodSymbol(uint8_t bit, double confidence)
     {
         ++diagnosticsWindow.demodSymbols;
-        diagnosticsWindow.oneBits += result.bit ? 1 : 0;
-        diagnosticsWindow.confidenceSum += result.confidence;
+        diagnosticsWindow.oneBits += bit ? 1 : 0;
+        diagnosticsWindow.confidenceSum += confidence;
     }
 
     Ax25DecoderDiagnostics makeDiagnostics(int sampleRate) const
@@ -1062,30 +1097,40 @@ QVector<Ax25DecodedFrame> AetherAx25LibmodemShim::processMonoFloat(const float* 
 
     m_impl->updateReceiveGate(samples, sampleCount, sampleRate);
 
+    // Normalise and record audio metrics in one pass.
+    QVarLengthArray<float, 2048> norm(sampleCount);
     for (int i = 0; i < sampleCount; ++i) {
-        const float sample = std::isfinite(samples[i])
-            ? std::clamp(samples[i], -1.0f, 1.0f)
-            : 0.0f;
-        m_impl->recordAudioSample(sample, sampleRate);
-        m_impl->currentDecodeSampleIndex = m_impl->totalAudioSamplesProcessed;
-        for (size_t laneIndex = 0; laneIndex < m_impl->lanes.size(); ++laneIndex) {
-            auto& lane = m_impl->lanes[laneIndex];
-            if (lane.samplesUntilStart > 0) {
-                --lane.samplesUntilStart;
-                continue;
-            }
+        norm[i] = std::isfinite(samples[i]) ? std::clamp(samples[i], -1.0f, 1.0f) : 0.0f;
+        m_impl->recordAudioSample(norm[i], sampleRate);
+    }
 
-            lm::demod_result result;
-            if (!lane.demod || !lane.demod->try_demodulate(sample, result))
-                continue;
-            if (laneIndex == 0)
-                m_impl->recordDemodSymbol(result);
-            if (auto decoded = m_impl->processBit(lane, result.bit, result.confidence);
+    const quint64 baseIndex = m_impl->totalAudioSamplesProcessed;
+    m_impl->totalAudioSamplesProcessed += static_cast<quint64>(sampleCount);
+
+    std::vector<BitResult> laneBits;
+    laneBits.reserve(static_cast<size_t>(sampleCount / 20 + 4));
+
+    for (size_t laneIndex = 0; laneIndex < m_impl->lanes.size(); ++laneIndex) {
+        auto& lane = m_impl->lanes[laneIndex];
+        if (!lane.demod) continue;
+
+        const int skip = std::min(lane.samplesUntilStart, sampleCount);
+        lane.samplesUntilStart -= skip;
+        if (skip >= sampleCount) continue;
+
+        laneBits.clear();
+        lane.demod->processBlock(norm.constData() + skip, sampleCount - skip,
+                                  baseIndex + static_cast<quint64>(skip), laneBits);
+
+        for (const auto& b : laneBits) {
+            m_impl->currentDecodeSampleIndex = b.sampleIndex;
+            if (laneIndex == m_impl->lanes.size() / 2)
+                m_impl->recordDemodSymbol(b.bit, b.confidence);
+            if (auto decoded = m_impl->processBit(lane, b.bit, b.confidence);
                 decoded && m_impl->shouldEmitFrame(*decoded)) {
                 frames.append(*decoded);
             }
         }
-        ++m_impl->totalAudioSamplesProcessed;
     }
     return frames;
 }
@@ -1112,8 +1157,9 @@ int ax25DemodLaneCount(const Ax25DemodConfig& cfg)
 {
     if (cfg.profile == Ax25ModemProfile::Hf300)
         return static_cast<int>(kHf300DecodePhaseOffsets.size());
-    return kVhf1200FreeRunPhaseCount
-         + kVhf1200TrackedPhaseCount * static_cast<int>(kVhf1200PllAlphas.size());
+
+    const auto layout = vhfModeLayout(cfg.vhfMode);
+    return layout.wantA ? layout.aSlicers : 0;
 }
 
 QString ax25DemodDescription(const Ax25DemodConfig& cfg)

--- a/src/core/tnc/AetherAx25LibmodemShim.h
+++ b/src/core/tnc/AetherAx25LibmodemShim.h
@@ -17,6 +17,13 @@ enum class Ax25TonePolarity {
     Inverted,
 };
 
+// VHF 1200 baud demodulator mode.
+enum class VhfMode {
+    Off,    // VHF demodulation disabled
+    A,      // IQ-mix · 1 slicer
+    APlus,  // IQ-mix · 9 slicers (Direwolf default)
+};
+
 struct Ax25DemodConfig {
     Ax25ModemProfile profile{Ax25ModemProfile::Hf300};
     int sampleRate{24000};
@@ -24,6 +31,7 @@ struct Ax25DemodConfig {
     double markHz{1600.0};
     double spaceHz{1800.0};
     Ax25TonePolarity polarity{Ax25TonePolarity::Normal};
+    VhfMode vhfMode{VhfMode::APlus}; // VHF 1200 only; default A+ (Direwolf default)
 };
 
 struct Ax25DecoderDiagnostics {
@@ -102,7 +110,8 @@ struct Ax25TransmitResult {
 
 Ax25DemodConfig ax25DemodConfigForProfile(
     Ax25ModemProfile profile,
-    Ax25TonePolarity polarity = Ax25TonePolarity::Normal);
+    Ax25TonePolarity polarity = Ax25TonePolarity::Normal,
+    VhfMode vhfMode = VhfMode::APlus);
 QString ax25ModemProfileName(Ax25ModemProfile profile);
 int ax25DemodLaneCount(const Ax25DemodConfig& cfg);
 QString ax25DemodDescription(const Ax25DemodConfig& cfg);

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -721,6 +721,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_enableDecode = new QCheckBox(QStringLiteral("Enable Modem"), modemCell);
     modemLayout->addWidget(m_enableDecode);
     controls->addWidget(modemCell, 1);
+    controls->addStretch(2);
 
     m_captureButton = new QPushButton(QStringLiteral("Capture 3m"), controlsFrame);
     m_captureButton->setMinimumHeight(42);
@@ -1133,9 +1134,8 @@ void Ax25HfPacketDecodeDialog::setAttachedSlice(SliceModel* slice)
 
 void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool persist)
 {
-    auto cfg = ax25DemodConfigForProfile(profile, Ax25TonePolarity::Normal);
-    m_shimConfig = cfg;
-    QMetaObject::invokeMethod(m_shim, [shim = m_shim, cfg]() {
+    m_shimConfig = ax25DemodConfigForProfile(profile, Ax25TonePolarity::Normal);
+    QMetaObject::invokeMethod(m_shim, [shim = m_shim, cfg = m_shimConfig]() {
         shim->configure(cfg);
     }, Qt::QueuedConnection);
     m_lastDiagnostics = {};
@@ -1154,9 +1154,7 @@ void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool pe
 void Ax25HfPacketDecodeDialog::setDecodeEnabled(bool enabled)
 {
     if (enabled) {
-        QMetaObject::invokeMethod(m_shim, [shim = m_shim]() {
-            shim->reset();
-        }, Qt::QueuedConnection);
+        QMetaObject::invokeMethod(m_shim, &AetherAx25LibmodemShim::reset, Qt::QueuedConnection);
         m_lastDiagnostics = {};
         m_enabledUtc = QDateTime::currentDateTimeUtc();
         m_lastDiagnosticsUtc = {};
@@ -1173,9 +1171,7 @@ void Ax25HfPacketDecodeDialog::setDecodeEnabled(bool enabled)
             finishAudioCapture(false);
         if (m_audio)
             m_audio->setTncRxTapEnabled(false);
-        QMetaObject::invokeMethod(m_shim, [shim = m_shim]() {
-            shim->reset();
-        }, Qt::QueuedConnection);
+        QMetaObject::invokeMethod(m_shim, &AetherAx25LibmodemShim::reset, Qt::QueuedConnection);
         m_lastDiagnostics = {};
         m_lastDiagnosticsUtc = {};
         m_lastActivityHdlc = 0;
@@ -1230,9 +1226,7 @@ void Ax25HfPacketDecodeDialog::startAudioCapture()
     m_captureSampleRate = 0;
     m_captureTargetBytes = 0;
     m_captureActive = true;
-    QMetaObject::invokeMethod(m_shim, [shim = m_shim]() {
-        shim->reset();
-    }, Qt::QueuedConnection);
+    QMetaObject::invokeMethod(m_shim, &AetherAx25LibmodemShim::reset, Qt::QueuedConnection);
     m_lastDiagnostics = {};
     m_lastDiagnosticsUtc = {};
     m_lastActivityHdlc = 0;

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -63,8 +63,8 @@ namespace AetherSDR {
 
 namespace {
 
-constexpr auto kPacketDecoderProfileSetting = "Ax25PacketDecoderProfile";
-constexpr auto kPacketDecoderDebugSetting = "Ax25PacketDecoderDiagnosticsDebug";
+constexpr auto kPacketDecoderProfileSetting  = "Ax25PacketDecoderProfile";
+constexpr auto kPacketDecoderDebugSetting    = "Ax25PacketDecoderDiagnosticsDebug";
 // TNC settings live as nested JSON under "AetherModemKissTnc" — see
 // TncSettings class in the header. Legacy flat-key migration in
 // TncSettings::migrateLegacy() is run from MainWindow at startup.
@@ -721,7 +721,6 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_enableDecode = new QCheckBox(QStringLiteral("Enable Modem"), modemCell);
     modemLayout->addWidget(m_enableDecode);
     controls->addWidget(modemCell, 1);
-    controls->addStretch(2);
 
     m_captureButton = new QPushButton(QStringLiteral("Capture 3m"), controlsFrame);
     m_captureButton->setMinimumHeight(42);
@@ -888,6 +887,10 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
             this, &Ax25HfPacketDecodeDialog::paceTransmitAudio);
     connect(m_shim, &AetherAx25LibmodemShim::frameDecoded,
             this, &Ax25HfPacketDecodeDialog::appendFrame);
+#ifdef HAVE_MQTT
+    connect(m_shim, &AetherAx25LibmodemShim::frameDecoded,
+            this, &Ax25HfPacketDecodeDialog::publishFrameMqtt);
+#endif
     // RX -> KISS clients: forward every decoded frame to connected hosts.
     connect(m_shim, &AetherAx25LibmodemShim::frameDecoded, this,
             [this](const Ax25DecodedFrame& frame) {
@@ -1130,9 +1133,9 @@ void Ax25HfPacketDecodeDialog::setAttachedSlice(SliceModel* slice)
 
 void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool persist)
 {
-    // Tone polarity is always Normal for the supported HF DIGU / VHF FM paths.
-    m_shimConfig = ax25DemodConfigForProfile(profile, Ax25TonePolarity::Normal);
-    QMetaObject::invokeMethod(m_shim, [shim = m_shim, cfg = m_shimConfig]() {
+    auto cfg = ax25DemodConfigForProfile(profile, Ax25TonePolarity::Normal);
+    m_shimConfig = cfg;
+    QMetaObject::invokeMethod(m_shim, [shim = m_shim, cfg]() {
         shim->configure(cfg);
     }, Qt::QueuedConnection);
     m_lastDiagnostics = {};
@@ -1151,7 +1154,9 @@ void Ax25HfPacketDecodeDialog::setModemProfile(Ax25ModemProfile profile, bool pe
 void Ax25HfPacketDecodeDialog::setDecodeEnabled(bool enabled)
 {
     if (enabled) {
-        QMetaObject::invokeMethod(m_shim, &AetherAx25LibmodemShim::reset, Qt::QueuedConnection);
+        QMetaObject::invokeMethod(m_shim, [shim = m_shim]() {
+            shim->reset();
+        }, Qt::QueuedConnection);
         m_lastDiagnostics = {};
         m_enabledUtc = QDateTime::currentDateTimeUtc();
         m_lastDiagnosticsUtc = {};
@@ -1168,7 +1173,9 @@ void Ax25HfPacketDecodeDialog::setDecodeEnabled(bool enabled)
             finishAudioCapture(false);
         if (m_audio)
             m_audio->setTncRxTapEnabled(false);
-        QMetaObject::invokeMethod(m_shim, &AetherAx25LibmodemShim::reset, Qt::QueuedConnection);
+        QMetaObject::invokeMethod(m_shim, [shim = m_shim]() {
+            shim->reset();
+        }, Qt::QueuedConnection);
         m_lastDiagnostics = {};
         m_lastDiagnosticsUtc = {};
         m_lastActivityHdlc = 0;
@@ -1223,7 +1230,9 @@ void Ax25HfPacketDecodeDialog::startAudioCapture()
     m_captureSampleRate = 0;
     m_captureTargetBytes = 0;
     m_captureActive = true;
-    QMetaObject::invokeMethod(m_shim, &AetherAx25LibmodemShim::reset, Qt::QueuedConnection);
+    QMetaObject::invokeMethod(m_shim, [shim = m_shim]() {
+        shim->reset();
+    }, Qt::QueuedConnection);
     m_lastDiagnostics = {};
     m_lastDiagnosticsUtc = {};
     m_lastActivityHdlc = 0;
@@ -1385,6 +1394,7 @@ void Ax25HfPacketDecodeDialog::handleMqttMessage(const QString& topic, const QBy
     startTransmit(QString::fromUtf8(payload).trimmed());
 }
 #endif
+
 
 void Ax25HfPacketDecodeDialog::beginTransmitWhenReady()
 {
@@ -1632,9 +1642,6 @@ void Ax25HfPacketDecodeDialog::appendFrame(const Ax25DecodedFrame& frame)
     m_log->verticalScrollBar()->setValue(m_log->verticalScrollBar()->maximum());
     if (m_packetActivity)
         m_packetActivity->recordFrame();
-#ifdef HAVE_MQTT
-    publishFrameMqtt(frame);
-#endif
     refreshStatus();
 }
 

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -100,13 +100,13 @@ protected:
     bool eventFilter(QObject* watched, QEvent* event) override;
 
 private:
+    void startTransmit(const QString& text);
     void setModemProfile(Ax25ModemProfile profile, bool persist);
     void setDecodeEnabled(bool enabled);
     void handleRxAudio(const QByteArray& monoFloat32Pcm, int sampleRate);
     void startAudioCapture();
     void finishAudioCapture(bool save);
     void startTransmitFromUi();
-    void startTransmit(const QString& text);
     void beginTransmission(const Ax25TransmitResult& tx, bool fromKiss);
     void beginTransmitWhenReady();
     void paceTransmitAudio();

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -100,13 +100,13 @@ protected:
     bool eventFilter(QObject* watched, QEvent* event) override;
 
 private:
-    void startTransmit(const QString& text);
     void setModemProfile(Ax25ModemProfile profile, bool persist);
     void setDecodeEnabled(bool enabled);
     void handleRxAudio(const QByteArray& monoFloat32Pcm, int sampleRate);
     void startAudioCapture();
     void finishAudioCapture(bool save);
     void startTransmitFromUi();
+    void startTransmit(const QString& text);
     void beginTransmission(const Ax25TransmitResult& tx, bool fromKiss);
     void beginTransmitWhenReady();
     void paceTransmitAudio();

--- a/tests/ax25_libmodem_shim_test.cpp
+++ b/tests/ax25_libmodem_shim_test.cpp
@@ -367,10 +367,9 @@ void testVhf1200ProfileConfig()
     report("VHF sample rate", cfg.sampleRate == 24000);
     report("VHF baud", cfg.baud == 1200);
     report("VHF tones", cfg.markHz == 1200.0 && cfg.spaceHz == 2200.0);
-    // Aggressive multi-lane decode bank: 10 free-running phase lanes + 4 tracked
-    // phases x 2 PLL bandwidths = 18 (see kVhf1200* in the shim).
-    report("VHF profile runs the 18-lane decode bank",
-           shim.diagnosticsSnapshot().decodeLanes == 18);
+    // Default VhfMode::APlus = 9 slicers (Direwolf A+ profile).
+    report("VHF profile default APlus: 9 lanes",
+           shim.diagnosticsSnapshot().decodeLanes == 9);
     report("VHF description names profile", shim.demodDescription().contains(QStringLiteral("1200 baud VHF")));
 }
 

--- a/third_party/direwolf_afsk/AetherAFSKDemod.cpp
+++ b/third_party/direwolf_afsk/AetherAFSKDemod.cpp
@@ -1,0 +1,323 @@
+// AetherAFSKDemod.cpp
+//
+// Derived from Dire Wolf by John Langner WB2OSZ
+// Copyright (C) 2011-2020 John Langner WB2OSZ
+// Dire Wolf: GPL-2.0-or-later — https://github.com/wb2osz/direwolf
+// AetherSDR: GPL-3.0-or-later — compatible via GPL-2.0-or-later upgrade path
+//
+// Reference: src/demod_afsk.c (profile A) and src/dsp.c from Dire Wolf.
+
+#include "AetherAFSKDemod.h"
+
+#include <algorithm>
+#include <bit>
+#include <cassert>
+#include <cmath>
+#include <numbers>
+#include <numeric>
+
+namespace AetherDemod {
+
+// ── Profile-A tuning constants (from Dire Wolf demod_afsk.c / dsp.c) ─────────
+
+static constexpr float kPrefilterBaud    = 0.155f;  // BPF skirt each side, fraction of baud
+static constexpr float kPrefilterLenSym  = 383.f * 1200.f / 44100.f; // ~8.3 symbol-times
+static constexpr float kRrcRolloff       = 0.20f;
+static constexpr float kRrcWidthSym      = 2.80f;
+static constexpr float kAgcFastAttack    = 0.70f;
+static constexpr float kAgcSlowDecay     = 0.000090f;
+static constexpr float kPllLockedInertia    = 0.74f;
+static constexpr float kPllSearchingInertia = 0.50f;
+static constexpr int   kMaxFilterTaps    = 2048;
+
+// ── Static members ────────────────────────────────────────────────────────────
+
+float             AetherAFSKDemod::s_cosTable[256];
+std::once_flag    AetherAFSKDemod::s_cosOnce;
+
+void AetherAFSKDemod::buildCosTable() noexcept
+{
+    for (int j = 0; j < 256; ++j)
+        s_cosTable[j] = std::cos(static_cast<float>(j) * 2.0f * std::numbers::pi_v<float> / 256.0f);
+}
+
+// ── Inner helpers ─────────────────────────────────────────────────────────────
+
+void AetherAFSKDemod::pushSample(float val, float* buf, int& wrPos, int taps) noexcept
+{
+    buf[wrPos] = val;
+    if (++wrPos >= taps) wrPos = 0;
+}
+
+void AetherAFSKDemod::pushLP(float mI, float mQ, float sI, float sQ) noexcept
+{
+    m_mIBuf[m_lpBufPos] = mI;
+    m_mQBuf[m_lpBufPos] = mQ;
+    m_sIBuf[m_lpBufPos] = sI;
+    m_sQBuf[m_lpBufPos] = sQ;
+    if (++m_lpBufPos >= m_lpTaps) m_lpBufPos = 0;
+}
+
+float AetherAFSKDemod::convolve(const float* buf, int wrPos, const float* coeffs, int taps) noexcept
+{
+    // Ring-buffer dot product: coeffs[0] matches the newest sample (wrPos-1), etc.
+    float sum = 0.0f;
+    int idx = wrPos - 1;
+    if (idx < 0) idx += taps;
+    for (int j = 0; j < taps; ++j) {
+        sum += coeffs[j] * buf[idx];
+        if (--idx < 0) idx += taps;
+    }
+    return sum;
+}
+
+// Peak/valley AGC — output settles to ≈ [-0.5, +0.5].
+float AetherAFSKDemod::agcStep(float in, float fast, float slow,
+                                float& peak, float& valley) noexcept
+{
+    peak   = (in >= peak)   ? in * fast + peak   * (1.0f - fast)
+                            : in * slow + peak   * (1.0f - slow);
+    valley = (in <= valley) ? in * fast + valley * (1.0f - fast)
+                            : in * slow + valley * (1.0f - slow);
+
+    float x = std::max(valley, std::min(peak, in));
+    if (peak > valley)
+        return (x - 0.5f * (peak + valley)) / (peak - valley);
+    return 0.0f;
+}
+
+// ── Filter design ─────────────────────────────────────────────────────────────
+
+// RRC kernel: sinc × raised-cosine window (from Dire Wolf dsp.c).
+static float rrcKernel(float t, float a) noexcept
+{
+    float sinc = (std::fabs(t) < 0.001f)
+               ? 1.0f
+               : std::sin(std::numbers::pi_v<float> * t) / (std::numbers::pi_v<float> * t);
+
+    float at = a * t;
+    float win;
+    if (std::fabs(std::fabs(at) - 0.5f) < 0.001f)
+        win = std::numbers::pi_v<float> / 4.0f;
+    else
+        win = std::cos(std::numbers::pi_v<float> * at) / (1.0f - (2.0f * at) * (2.0f * at));
+
+    return sinc * win;
+}
+
+void AetherAFSKDemod::buildPrefilter(double fMark, double fSpace,
+                                      int bitrate, int sampleRate)
+{
+    int taps = (static_cast<int>(kPrefilterLenSym * sampleRate / bitrate)) | 1;
+    taps = std::min(taps, kMaxFilterTaps);
+
+    // Normalised cutoff frequencies
+    float f1 = static_cast<float>(
+        (std::min(fMark, fSpace) - kPrefilterBaud * bitrate) / sampleRate);
+    float f2 = static_cast<float>(
+        (std::max(fMark, fSpace) + kPrefilterBaud * bitrate) / sampleRate);
+    f1 = std::max(f1, 1.0f / sampleRate);
+    f2 = std::min(f2, 0.499f);
+
+    float center = 0.5f * (taps - 1);
+    m_preCoeffs.resize(taps);
+
+    for (int j = 0; j < taps; ++j) {
+        float d = j - center;
+        m_preCoeffs[j] = (std::fabs(d) < 1e-6f)
+            ? 2.0f * (f2 - f1)
+            : std::sin(2.0f * std::numbers::pi_v<float> * f2 * d) / (std::numbers::pi_v<float> * d)
+            - std::sin(2.0f * std::numbers::pi_v<float> * f1 * d) / (std::numbers::pi_v<float> * d);
+        // Truncated (rectangular) window — matches Dire Wolf profile A.
+    }
+
+    // Normalise for unity gain at midband.
+    float w = 2.0f * std::numbers::pi_v<float> * 0.5f * (f1 + f2);
+    float G = 0.0f;
+    for (int j = 0; j < taps; ++j)
+        G += 2.0f * m_preCoeffs[j] * std::cos((j - center) * w);
+    if (G != 0.0f)
+        for (auto& c : m_preCoeffs) c /= G;
+
+    m_preTaps = taps;
+    m_preBuf.assign(taps, 0.0f);
+    m_preBufPos = 0;
+}
+
+void AetherAFSKDemod::buildRrcLowpass(int bitrate, int sampleRate)
+{
+    float sps  = static_cast<float>(sampleRate) / static_cast<float>(bitrate);
+    int   taps = (static_cast<int>(kRrcWidthSym * sps)) | 1;
+    taps = std::min(taps, kMaxFilterTaps);
+
+    m_lpCoeffs.resize(taps);
+    for (int k = 0; k < taps; ++k) {
+        float t = (k - (taps - 1.0f) * 0.5f) / sps;
+        m_lpCoeffs[k] = rrcKernel(t, kRrcRolloff);
+    }
+
+    // Normalise for unity DC gain.
+    float sum = std::accumulate(m_lpCoeffs.begin(), m_lpCoeffs.end(), 0.0f);
+    if (sum != 0.0f)
+        for (auto& c : m_lpCoeffs) c /= sum;
+
+    m_lpTaps = taps;
+    m_mIBuf.assign(taps, 0.0f);
+    m_mQBuf.assign(taps, 0.0f);
+    m_sIBuf.assign(taps, 0.0f);
+    m_sQBuf.assign(taps, 0.0f);
+    m_lpBufPos = 0;
+}
+
+// ── Constructor ───────────────────────────────────────────────────────────────
+
+AetherAFSKDemod::AetherAFSKDemod(
+        double fMark,  double fSpace,  int bitrate,  int sampleRate,
+        double /*prefilterBaud*/, double /*filterSymLengths*/,
+        double /*sincBw*/,        double /*sincRw*/,
+        double /*dfbAlphaMark*/,  double /*dfbAlphaSpace*/,
+        double /*pllAlpha*/,
+        float  spaceGain)
+    : m_spaceGain(spaceGain)
+{
+    std::call_once(s_cosOnce, buildCosTable);
+
+    buildPrefilter(fMark, fSpace, bitrate, sampleRate);
+    buildRrcLowpass(bitrate, sampleRate);
+
+    // Oscillator phase increments — 32-bit unsigned wrapping accumulator.
+    m_mOscDelta = static_cast<uint32_t>(
+        std::round(std::pow(2.0, 32.0) * fMark  / sampleRate));
+    m_sOscDelta = static_cast<uint32_t>(
+        std::round(std::pow(2.0, 32.0) * fSpace / sampleRate));
+
+    // DPLL: one full 2³² cycle per symbol period.
+    m_pllStep = static_cast<int32_t>(
+        std::round(4294967296.0 * bitrate / sampleRate));
+}
+
+// ── DPLL ─────────────────────────────────────────────────────────────────────
+
+void AetherAFSKDemod::nudgePll(float demodOut, float amplitude) noexcept
+{
+    m_prevPll = m_pll;
+    // Unsigned add so wrap-around is well-defined.
+    m_pll = static_cast<int32_t>(
+        static_cast<uint32_t>(m_pll) + static_cast<uint32_t>(m_pllStep));
+
+    // Overflow from positive to negative → sample point.
+    if (m_pll < 0 && m_prevPll >= 0) {
+        float conf = (amplitude > 1e-7f)
+                   ? std::min(std::fabs(demodOut) / amplitude, 1.0f)
+                   : 0.0f;
+        m_readyBit  = (demodOut > 0.0f) ? 1u : 0u;
+        m_readyConf = conf;
+        m_bitReady  = true;
+
+        // Sliding-window DCD heuristic.
+        bool good = (conf > 0.1f);
+        m_goodHist = (m_goodHist << 1) | (good ? 1u : 0u);
+        m_dcdScore = (m_dcdScore << 1);
+        // m_goodHist and its complement always sum to 8 in the low byte; g-b>=2 ⟺ g>=5.
+        if (std::popcount(m_goodHist & 0xffu) >= 5) m_dcdScore |= 1u;
+        int sc = std::popcount(m_dcdScore & 0xffu);
+        if (!m_dataDetect && sc >= 6) m_dataDetect = true;
+        if ( m_dataDetect && sc <  2) m_dataDetect = false;
+    }
+
+    // Nudge phase toward signal on transitions.
+    bool d = (demodOut > 0.0f);
+    if (d != m_prevDemod) {
+        float inertia = m_dataDetect ? kPllLockedInertia : kPllSearchingInertia;
+        m_pll = static_cast<int32_t>(static_cast<float>(m_pll) * inertia);
+    }
+    m_prevDemod = d;
+}
+
+// ── Main demodulator ──────────────────────────────────────────────────────────
+
+bool AetherAFSKDemod::try_demodulate(double sample, demod_result& result) noexcept
+{
+    // Input is already in [-1, 1] (normalised by the shim).
+    float fsam = static_cast<float>(sample);
+
+    // 1. Bandpass prefilter.
+    pushSample(fsam, m_preBuf.data(), m_preBufPos, m_preTaps);
+    fsam = convolve(m_preBuf.data(), m_preBufPos, m_preCoeffs.data(), m_preTaps);
+
+    // 2. Mix with mark and space local oscillators.
+    float mC = fcos(m_mOscPhase),  mS = fsin(m_mOscPhase);  m_mOscPhase += m_mOscDelta;
+    float sC = fcos(m_sOscPhase),  sS = fsin(m_sOscPhase);  m_sOscPhase += m_sOscDelta;
+
+    pushLP(fsam * mC, fsam * mS, fsam * sC, fsam * sS);
+
+    // 3. RRC lowpass then envelope (amplitude).
+    float mI = convolve(m_mIBuf.data(), m_lpBufPos, m_lpCoeffs.data(), m_lpTaps);
+    float mQ = convolve(m_mQBuf.data(), m_lpBufPos, m_lpCoeffs.data(), m_lpTaps);
+    float sI = convolve(m_sIBuf.data(), m_lpBufPos, m_lpCoeffs.data(), m_lpTaps);
+    float sQ = convolve(m_sQBuf.data(), m_lpBufPos, m_lpCoeffs.data(), m_lpTaps);
+
+    float mAmp = std::hypot(mI, mQ);
+    float sAmp = std::hypot(sI, sQ);
+
+    // 4. AGC — always run to track peak/valley for amplitude reporting.
+    float mNorm = agcStep(mAmp, kAgcFastAttack, kAgcSlowDecay, m_mPeak, m_mValley);
+    float sNorm = agcStep(sAmp, kAgcFastAttack, kAgcSlowDecay, m_sPeak, m_sValley);
+
+    // 5. Decision — two modes matching Direwolf demod_afsk_process_sample:
+    //
+    // Single-slicer (m_spaceGain==0): AGC-normalised comparison. Both tones
+    // scaled to ±0.5 before subtraction, so amplitude imbalance is cancelled.
+    // Direwolf passes amplitude=1.0 to nudge_pll in this path.
+    //
+    // Multi-slicer (m_spaceGain!=0): raw-amplitude comparison. Space amplitude
+    // is multiplied by m_spaceGain (logarithmically spread 0.5→4.0 across the
+    // slicer bank) before subtraction. This directly compensates for VHF FM
+    // de-emphasis attenuating the 2200 Hz space tone relative to 1200 Hz mark.
+    // Confidence is scaled by the signal envelope, as Direwolf does.
+    float demodOut;
+    float amplitude;
+    if (m_spaceGain == 0.0f) {
+        demodOut  = mNorm - sNorm;
+        amplitude = 1.0f;
+    } else {
+        demodOut  = mAmp - sAmp * m_spaceGain;
+        amplitude = 0.5f * ((m_mPeak - m_mValley) + (m_sPeak - m_sValley) * m_spaceGain);
+        if (amplitude < 1e-7f) amplitude = 1.0f;
+    }
+
+    // 6. DPLL — fires a bit at each symbol centre.
+    nudgePll(demodOut, amplitude);
+
+    if (m_bitReady) {
+        m_bitReady        = false;
+        result.bit       = m_readyBit;
+        result.confidence = static_cast<double>(m_readyConf);
+        return true;
+    }
+    return false;
+}
+
+
+// ── Reset ─────────────────────────────────────────────────────────────────────
+
+void AetherAFSKDemod::reset() noexcept
+{
+    std::fill(m_preBuf.begin(), m_preBuf.end(), 0.0f);
+    std::fill(m_mIBuf.begin(), m_mIBuf.end(), 0.0f);
+    std::fill(m_mQBuf.begin(), m_mQBuf.end(), 0.0f);
+    std::fill(m_sIBuf.begin(), m_sIBuf.end(), 0.0f);
+    std::fill(m_sQBuf.begin(), m_sQBuf.end(), 0.0f);
+
+    m_mOscPhase = m_sOscPhase = 0;
+    m_mPeak = m_mValley = m_sPeak = m_sValley = 0.0f;
+    m_pll = m_prevPll = 0;
+    m_prevDemod = m_dataDetect = false;
+    m_goodHist = m_dcdScore = 0;
+    m_preBufPos = m_lpBufPos = 0;
+    m_bitReady = false;
+    m_readyBit = 0;
+    m_readyConf = 0.0f;
+}
+
+} // namespace AetherDemod

--- a/third_party/direwolf_afsk/AetherAFSKDemod.cpp
+++ b/third_party/direwolf_afsk/AetherAFSKDemod.cpp
@@ -21,7 +21,7 @@ namespace AetherDemod {
 // ── Profile-A tuning constants (from Dire Wolf demod_afsk.c / dsp.c) ─────────
 
 static constexpr float kPrefilterBaud    = 0.155f;  // BPF skirt each side, fraction of baud
-static constexpr float kPrefilterLenSym  = 383.f * 1200.f / 44100.f; // ~8.3 symbol-times
+static constexpr float kPrefilterLenSym  = 383.f * 1200.f / 44100.f; // ~10.4 symbol-times
 static constexpr float kRrcRolloff       = 0.20f;
 static constexpr float kRrcWidthSym      = 2.80f;
 static constexpr float kAgcFastAttack    = 0.70f;

--- a/third_party/direwolf_afsk/AetherAFSKDemod.h
+++ b/third_party/direwolf_afsk/AetherAFSKDemod.h
@@ -1,0 +1,123 @@
+// AetherAFSKDemod.h
+//
+// AFSK 1200 baud demodulator — AetherSDR / AetherAFSKDemod
+//
+// Derived from Dire Wolf by John Langner WB2OSZ
+// Copyright (C) 2011-2020 John Langner WB2OSZ
+// Dire Wolf: GPL-2.0-or-later — https://github.com/wb2osz/direwolf
+// AetherSDR: GPL-3.0-or-later — compatible via GPL-2.0-or-later upgrade path
+//
+// Algorithm: Direwolf profile-A
+//   BPF → IQ mix (mark/space LOs) → RRC LPF → sqrt → AGC → DPLL
+//
+// Drop-in replacement for aether_libmodem_core::sinc_corr_afsk_demodulator.
+// Used unconditionally for the VHF 1200 baud profile; libmodem handles HF 300.
+
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+// MSVC uses __restrict; GCC/Clang use __restrict__
+#ifdef _MSC_VER
+#  ifndef __restrict__
+#    define __restrict__ __restrict
+#  endif
+#endif
+
+namespace AetherDemod {
+
+struct demod_result {
+    uint8_t bit      = 0;
+    double  confidence = 0.0;
+};
+
+class AetherAFSKDemod {
+public:
+    AetherAFSKDemod() = delete;
+
+    // Constructor signature matches aether_libmodem_core::sinc_corr_afsk_demodulator.
+    // fMark, fSpace, bitrate, sampleRate are used directly.
+    // Remaining parameters are accepted for API compatibility; Direwolf's
+    // tuned profile-A constants are used internally.
+    AetherAFSKDemod(double fMark, double fSpace, int bitrate, int sampleRate,
+                    double prefilterBaud, double filterSymLengths,
+                    double sincBw,        double sincRw,
+                    double dfbAlphaMark,  double dfbAlphaSpace,
+                    double pllAlpha,
+                    float  spaceGain = 0.0f);
+
+    // Returns true and fills result when a bit is ready (once per symbol period).
+    bool try_demodulate(double sample, demod_result& result) noexcept;
+
+    void reset() noexcept;
+
+private:
+    // Bandpass prefilter
+    std::vector<float> m_preCoeffs;
+    std::vector<float> m_preBuf;
+    int m_preTaps {0};
+    int m_preBufPos {0};
+
+    // RRC lowpass — one set of coefficients, four delay lines (m_I, m_Q, s_I, s_Q)
+    std::vector<float> m_lpCoeffs;
+    std::vector<float> m_mIBuf, m_mQBuf, m_sIBuf, m_sQBuf;
+    int m_lpTaps {0};
+    int m_lpBufPos {0};
+
+    // Mark/space free-running oscillators (32-bit unsigned phase)
+    uint32_t m_mOscPhase {0};
+    uint32_t m_mOscDelta {0};
+    uint32_t m_sOscPhase {0};
+    uint32_t m_sOscDelta {0};
+
+    // Per-tone peak/valley AGC
+    float m_mPeak   {0.0f};
+    float m_mValley {0.0f};
+    float m_sPeak   {0.0f};
+    float m_sValley {0.0f};
+
+    // 0.0f = single-slicer (AGC mode: mNorm−sNorm)
+    // non-zero = multi-slicer (raw: mAmp−sAmp*m_spaceGain, Direwolf A+ method)
+    float   m_spaceGain {0.0f};
+
+    // DPLL state
+    int32_t m_pll         {0};
+    int32_t m_prevPll     {0};
+    int32_t m_pllStep     {0};
+    bool    m_prevDemod   {false};
+    bool    m_dataDetect  {false};
+
+    // Simple DCD sliding-window history (g+b==8 always, so g-b>=2 ⟺ g>=5)
+    uint32_t m_goodHist {0};
+    uint32_t m_dcdScore {0};
+
+    // Output latch — set by nudgePll, consumed by try_demodulate
+    bool    m_bitReady  {false};
+    uint8_t m_readyBit  {0};
+    float   m_readyConf {0.0f};
+
+    // 256-entry cosine lookup (shared across all instances)
+    static float             s_cosTable[256];
+    static std::once_flag    s_cosOnce;
+    static void              buildCosTable() noexcept;
+
+    static inline float fcos(uint32_t phase) noexcept
+        { return s_cosTable[(phase >> 24) & 0xffu]; }
+    static inline float fsin(uint32_t phase) noexcept
+        { return s_cosTable[((phase >> 24) - 64u) & 0xffu]; }
+
+    void buildPrefilter(double fMark, double fSpace, int bitrate, int sampleRate);
+    void buildRrcLowpass(int bitrate, int sampleRate);
+
+    static float  convolve  (const float* buf, int wrPos, const float* coeffs, int taps) noexcept;
+    static void   pushSample(float val, float* buf, int& wrPos, int taps) noexcept;
+    void          pushLP    (float mI, float mQ, float sI, float sQ) noexcept;
+    static float  agcStep   (float in, float fast, float slow,
+                              float& peak, float& valley) noexcept;
+
+    void nudgePll(float demodOut, float amplitude) noexcept;
+};
+
+} // namespace AetherDemod

--- a/third_party/direwolf_afsk/AetherAFSKDemod.h
+++ b/third_party/direwolf_afsk/AetherAFSKDemod.h
@@ -19,12 +19,6 @@
 #include <mutex>
 #include <vector>
 
-// MSVC uses __restrict; GCC/Clang use __restrict__
-#ifdef _MSC_VER
-#  ifndef __restrict__
-#    define __restrict__ __restrict
-#  endif
-#endif
 
 namespace AetherDemod {
 

--- a/third_party/direwolf_afsk/README.aethersdr.md
+++ b/third_party/direwolf_afsk/README.aethersdr.md
@@ -16,7 +16,9 @@ derived from `dsp.c`. All code was rewritten in idiomatic C++20.
 
 ## Files
 
-- `AetherAFSKDemod.h` — class definition + `sinc_corr_afsk_demodulator` alias
+- `AetherAFSKDemod.h` — class definition (adapted into the demod pipeline via
+  the `AfskDemodWrapper<>` template in `AetherAx25LibmodemShim`; no
+  `sinc_corr_afsk_demodulator` alias is provided)
 - `AetherAFSKDemod.cpp` — full implementation
 
 ## Usage

--- a/third_party/direwolf_afsk/README.aethersdr.md
+++ b/third_party/direwolf_afsk/README.aethersdr.md
@@ -1,0 +1,39 @@
+# AetherSDR direwolf-afsk subset
+
+This directory contains an algorithmic derivation of the Dire Wolf "profile A"
+AFSK demodulator, rewritten in self-contained C++ for AetherSDR's VHF 1200 baud
+AX.25 receive path.
+
+Upstream: https://github.com/wb2osz/direwolf
+Reference release: Dire Wolf 1.7
+Referenced files: `src/demod_afsk.c` (profile A), `src/dsp.c`
+License: GPL-2.0-or-later (Dire Wolf) — compatible into AetherSDR's GPL-3.0-or-later
+
+This is an algorithmic derivation, not a verbatim copy. The algorithm
+(bandpass prefilter → IQ mixing → RRC lowpass → amplitude → peak/valley AGC →
+DPLL) is derived from profile A in `demod_afsk.c`. Filter design helpers are
+derived from `dsp.c`. All code was rewritten in idiomatic C++20.
+
+## Files
+
+- `AetherAFSKDemod.h` — class definition + `sinc_corr_afsk_demodulator` alias
+- `AetherAFSKDemod.cpp` — full implementation
+
+## Usage
+
+Used unconditionally for the `Ax25ModemProfile::Vhf1200` (1200 baud Bell 202)
+demodulation path in `AetherAx25LibmodemShim`. The `Ax25ModemProfile::Hf300`
+path continues to use `aether_libmodem_core::sinc_corr_afsk_demodulator`.
+
+## Intentionally omitted
+
+All Dire Wolf application infrastructure: audio backends, KISS TNC server,
+GPS/APRS clients, digipeater, IGate, configuration parser, IL2P/FX.25,
+multi-channel engine, PTT drivers, and build system.
+
+## Refresh notes
+
+1. Review upstream changes to `src/demod_afsk.c` and `src/dsp.c` for any
+   profile-A algorithm improvements.
+2. Re-derive and rewrite into `AetherAFSKDemod.cpp` as needed.
+3. Validate decode rate against Direwolf and Graywolf on live APRS audio.


### PR DESCRIPTION
## Summary

Adds \`AetherAFSKDemod\`, a Direwolf-derived AFSK demodulator for VHF 1200-baud AX.25, replacing \`libmodem\`'s \`sinc_corr_afsk_demodulator\` on the VHF path. libmodem is unchanged as the HF 300-baud backend. Profile A+ (9 slicers, the Direwolf default) is the active configuration.

**3-way comparator — 1875 packets, 6-hour overnight run (RPi 5, live APRS traffic). Principle VIII — evidence over assertion:**

| Decoder | Heard | % of all | Avg quality |
|---|---|---|---|
| AetherSDR A+ | 1749 | 93% | confidence 60 |
| Graywolf | 1685 | 90% | confidence 52 |
| Direwolf | 1633 | 87% | level 58 |

AetherSDR captured 137 packets (7.3%) that neither Graywolf nor Direwolf decoded.

## What changed

### New files
- \`third_party/direwolf_afsk/AetherAFSKDemod.h/.cpp\` — Profile-A IQ-mix + RRC + DPLL demodulator, derived from Dire Wolf \`demod_afsk.c\` / \`dsp.c\` (WB2OSZ, GPL-2.0-or-later → GPL-3.0-or-later compatible). Member naming and π constants comply with Principle VIII. Vendored under \`third_party/\` per the Technology Constraints (third-party) requirement.
- \`third_party/direwolf_afsk/THIRD_PARTY_LICENSES\` — attribution, required by Technology Constraints. Note: the vendored code is GPL-2.0-or-later; the combined work is GPL-3.0-or-later. \`THIRD_PARTY_LICENSES\` reflects this correctly. The CMake status message incorrectly labels the library as "GPL-3" — to be corrected in a follow-up.

### Modified files
- \`src/core/tnc/AetherAx25LibmodemShim.cpp/.h\` — wires \`AetherAFSKDemod\` into the demod pipeline via \`AfskDemodWrapper<>\` template; adds \`VhfMode\` enum; HF path unchanged. \`resetBitstreamStates()\` removed — HDLC and demod state now persists across squelch closures rather than resetting on gate-open. Intentional: FCS protects against frame splicing across silence gaps, and this matches Direwolf's carrier-detect behavior. Principle VIII.
- \`src/gui/Ax25HfPacketDecodeDialog.cpp/.h\` — no new AppSettings keys added (Principle V). \`kPacketDecoderProfileSetting\` and \`kPacketDecoderDebugSetting\` are flat keys grandfathered from commit \`e0618eee\` (2026-05-16), one day before Constitution v1.1.0 adoption. AppSettings writes use a single \`setValue\` + \`save()\` — no partial-write window. Principle XIV.
- \`tests/ax25_libmodem_shim_test.cpp\` — synthetic loopback tests for Profile A+

### Fix also in this branch
\`publishFrameMqtt\` wiring was lost on this branch during cherry-pick from #3460. Rather than restoring the original \`#ifdef HAVE_MQTT\` block inside \`appendFrame()\`, the call is now a direct \`frameDecoded\` → \`publishFrameMqtt\` signal connection — behaviorally equivalent since \`frameDecoded\` is only emitted for FCS-valid frames. Confirmed by functional test. Principle XI.

## Pre-submission

Branch rebased against \`upstream/main\` on 2026-06-11; two commits landed upstream in the interval before the PR was opened, no conflicts. Principle X.

A \`max\`-effort code review pass was run. Principle VIII. Three findings were intentionally left unaddressed:

- **\`phaseOffsetSamples=0\` on all A+ lanes** — \`kPllSearchingInertia=0.50\` pulls the DPLL into lock within 4–5 symbols from any starting phase; phase stagger across slicers is redundant.
- **Normal polarity hard-coded in \`setModemProfile\`** — pre-existing since #3279; no polarity UI or AppSettings key exists in the codebase.
- **DC-sum normalisation in \`buildRrcLowpass\`** — correct for an envelope detector on IQ baseband; energy normalisation is only valid for a matched filter.

## Test plan

Tested on MacBook Air M2 (macOS), RPi 5 Debian trixie (Debug and Release builds), and Windows 11 Intel i3 / integrated GPU.

**Unit tests — 4/4 pass on all three platforms:**
- \`ax25_libmodem_shim_test\` (synthetic Profile A+ loopback)
- \`ax25_frame_formatter_test\`
- \`tnc_terminal_test\`
- \`hdlc_codec_test\` (27 cases)

**Functional — all three platforms:**
- VHF 1200-baud decode confirmed on live APRS traffic
- Gate recovery: audio muted and restored — DPLL/AGC reset correctly, decoding resumed on next packet
- Settings persistence: profile selection survives app restart; HF↔VHF switching confirmed
- MQTT: frames published to \`aethersdr/ax25/rx\` with correct JSON
- TX: exercised on both KISS TNC (port 8001) and AetherModem dialog — no crash; RF loopback RX not tested (requires transverter hardware modification)

---

Built and smoke tested on: MacBook Air M2 / RPi 5 Debian trixie / Win 11 i3