### PR TITLE
feat(aprs): Add a lightweight APRS client to AetherModem AX.25 tab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -669,6 +669,7 @@ set(GUI_SOURCES
     src/gui/NetworkDiagnosticsDialog.cpp
     src/gui/Ax25HfPacketDecodeDialog.cpp
     src/gui/AprsMessagesDialog.cpp
+    src/gui/AprsSymbolIcons.cpp
     src/gui/FlexControlDialog.cpp
     src/gui/PropDashboardDialog.cpp
     src/gui/MemoryCommands.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,6 +591,11 @@ set(CORE_SOURCES
     src/core/tnc/KissTncServer.cpp
     src/core/tnc/TncTerminal.cpp
     src/core/pms/PmsMailbox.cpp
+    src/core/aprs/AprsPacket.cpp
+    src/core/aprs/AprsStationList.cpp
+    src/core/aprs/AprsMessenger.cpp
+    src/core/aprs/AprsBeacon.cpp
+    src/core/aprs/AprsSettings.cpp
 )
 
 if(APPLE)
@@ -663,6 +668,7 @@ set(GUI_SOURCES
     src/gui/RadioSetupDialog.cpp
     src/gui/NetworkDiagnosticsDialog.cpp
     src/gui/Ax25HfPacketDecodeDialog.cpp
+    src/gui/AprsMessagesDialog.cpp
     src/gui/FlexControlDialog.cpp
     src/gui/PropDashboardDialog.cpp
     src/gui/MemoryCommands.cpp
@@ -2084,6 +2090,33 @@ add_executable(pms_mailbox_test
 target_include_directories(pms_mailbox_test PRIVATE src)
 target_link_libraries(pms_mailbox_test PRIVATE Qt6::Core)
 add_test(NAME pms_mailbox_test COMMAND pms_mailbox_test)
+
+# APRS info-field codec (pure parsing/encoding, no DSP).
+add_executable(aprs_packet_test
+    tests/aprs_packet_test.cpp
+    src/core/aprs/AprsPacket.cpp
+    src/core/tnc/Ax25.cpp
+)
+target_include_directories(aprs_packet_test PRIVATE src)
+target_link_libraries(aprs_packet_test PRIVATE Qt6::Core)
+add_test(NAME aprs_packet_test COMMAND aprs_packet_test)
+
+# APRS messaging engine + station roster. LogManager.cpp provides lcAx25
+# (the qCWarning category used by the persistence paths); it drags in
+# AsyncLogWriter + AppSettings, same as ax25_libmodem_shim_test.
+add_executable(aprs_messenger_test
+    tests/aprs_messenger_test.cpp
+    src/core/aprs/AprsPacket.cpp
+    src/core/aprs/AprsMessenger.cpp
+    src/core/aprs/AprsStationList.cpp
+    src/core/tnc/Ax25.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(aprs_messenger_test PRIVATE src)
+target_link_libraries(aprs_messenger_test PRIVATE Qt6::Core)
+add_test(NAME aprs_messenger_test COMMAND aprs_messenger_test)
 
 add_executable(tnc_terminal_test
     tests/tnc_terminal_test.cpp

--- a/src/core/aprs/AprsBeacon.cpp
+++ b/src/core/aprs/AprsBeacon.cpp
@@ -1,0 +1,100 @@
+#include "core/aprs/AprsBeacon.h"
+
+#include "core/aprs/AprsPacket.h"
+
+namespace AetherSDR {
+
+using ax25::Address;
+using ax25::Frame;
+
+namespace {
+const QString kTocall = QStringLiteral("APZATH"); // experimental tocall
+} // namespace
+
+AprsBeacon::AprsBeacon(QObject* parent)
+    : QObject(parent)
+{
+    connect(&m_timer, &QTimer::timeout, this, [this] { sendNow(); });
+}
+
+void AprsBeacon::setEnabled(bool on)
+{
+    m_enabled = on;
+    // Timer only — no immediate transmission. Enabling the beacon (or the
+    // app restoring a persisted enable on startup) must not key the radio by
+    // itself; "Beacon Now" is the explicit immediate send. PmsMailbox's
+    // beacon follows the same contract.
+    if (on)
+        m_timer.start(m_intervalMin * 60 * 1000);
+    else
+        m_timer.stop();
+}
+
+void AprsBeacon::setIntervalMinutes(int minutes)
+{
+    m_intervalMin = qBound(1, minutes, 24 * 60);
+    if (m_enabled)
+        m_timer.start(m_intervalMin * 60 * 1000);
+}
+
+void AprsBeacon::setGpsPosition(double lat, double lon, bool valid)
+{
+    if (!valid)
+        return; // keep the last good fix / manual fallback
+    m_gpsValid = true;
+    m_gpsLat = lat;
+    m_gpsLon = lon;
+}
+
+void AprsBeacon::setManualPosition(double lat, double lon, bool valid)
+{
+    m_manualValid = valid;
+    m_manualLat = lat;
+    m_manualLon = lon;
+}
+
+bool AprsBeacon::currentPosition(double& lat, double& lon) const
+{
+    if (m_gpsValid) {
+        lat = m_gpsLat;
+        lon = m_gpsLon;
+        return true;
+    }
+    if (m_manualValid) {
+        lat = m_manualLat;
+        lon = m_manualLon;
+        return true;
+    }
+    return false;
+}
+
+bool AprsBeacon::sendNow()
+{
+    if (!m_myAddress.isValid()) {
+        emit activity(QStringLiteral("APRS beacon skipped: no callsign configured."));
+        return false;
+    }
+    double lat = 0.0, lon = 0.0;
+    if (!currentPosition(lat, lon)) {
+        emit activity(QStringLiteral(
+            "APRS beacon skipped: no GPS fix and no manual position."));
+        return false;
+    }
+
+    const QString info = aprs::encodeUncompressedPosition(
+        lat, lon, m_symbolTable, m_symbolCode, m_statusText, true);
+    Address dest;
+    dest.call = kTocall;
+    const Frame frame = Frame::makeUI(dest, m_myAddress, m_path, info.toLatin1());
+    emit transmitFrame(frame.encode());
+    emit activity(QStringLiteral("APRS beacon sent (%1 via %2): %3")
+                      .arg(m_gpsValid ? QStringLiteral("GPS")
+                                      : QStringLiteral("manual position"),
+                           m_myAddress.toString(), info));
+
+    if (m_enabled)
+        m_timer.start(m_intervalMin * 60 * 1000); // re-arm from "now"
+    return true;
+}
+
+} // namespace AetherSDR

--- a/src/core/aprs/AprsBeacon.cpp
+++ b/src/core/aprs/AprsBeacon.cpp
@@ -19,6 +19,12 @@ AprsBeacon::AprsBeacon(QObject* parent)
 
 void AprsBeacon::setEnabled(bool on)
 {
+    // No-op when unchanged: applyAprsConfigFromUi() calls this on every dialog
+    // interaction (editingFinished / symbol change / message send / Beacon Now),
+    // and an unconditional timer restart would let an operator defer a timed
+    // beacon indefinitely by fiddling with the UI.
+    if (m_enabled == on)
+        return;
     m_enabled = on;
     // Timer only — no immediate transmission. Enabling the beacon (or the
     // app restoring a persisted enable on startup) must not key the radio by
@@ -32,7 +38,10 @@ void AprsBeacon::setEnabled(bool on)
 
 void AprsBeacon::setIntervalMinutes(int minutes)
 {
-    m_intervalMin = qBound(1, minutes, 24 * 60);
+    const int clamped = qBound(1, minutes, 24 * 60);
+    if (clamped == m_intervalMin)
+        return;  // unchanged — don't restart the timer (would defer the beacon)
+    m_intervalMin = clamped;
     if (m_enabled)
         m_timer.start(m_intervalMin * 60 * 1000);
 }

--- a/src/core/aprs/AprsBeacon.h
+++ b/src/core/aprs/AprsBeacon.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "core/tnc/Ax25.h"
+
+#include <QObject>
+#include <QString>
+#include <QTimer>
+#include <QVector>
+
+namespace AetherSDR {
+
+// Timed APRS position beacon. Position comes from the radio's onboard GPS
+// (FLEX-8000-class / Aurora GPSDO — the owner pushes updates through
+// setGpsPosition()) with a manual lat/lon fallback for radios without GPS
+// hardware. Encoded frames go out through transmitFrame() into the shared
+// modem TX queue, the same contract PmsMailbox uses.
+class AprsBeacon : public QObject {
+    Q_OBJECT
+
+public:
+    explicit AprsBeacon(QObject* parent = nullptr);
+
+    void setMyAddress(const ax25::Address& addr) { m_myAddress = addr; }
+    void setPath(const QVector<ax25::Address>& path) { m_path = path; }
+    void setStatusText(const QString& text) { m_statusText = text; }
+    void setSymbol(char table, char code) { m_symbolTable = table; m_symbolCode = code; }
+
+    // Arms/stops the interval timer. Never transmits immediately — use
+    // sendNow() for that.
+    void setEnabled(bool on);
+    bool isEnabled() const { return m_enabled; }
+    void setIntervalMinutes(int minutes);
+    int intervalMinutes() const { return m_intervalMin; }
+
+    // GPS fix from RadioModel::gpsStatusChanged. `valid` false (no lock / no
+    // GPS hardware) keeps the previous source; the beacon falls back to the
+    // manual position when no GPS fix was ever delivered.
+    void setGpsPosition(double lat, double lon, bool valid);
+    void setManualPosition(double lat, double lon, bool valid);
+
+    // The position the next beacon would use. Returns false when neither a
+    // GPS fix nor a manual position is available.
+    bool currentPosition(double& lat, double& lon) const;
+    bool usingGps() const { return m_gpsValid; }
+
+    // Fire one beacon immediately (also restarts the interval timer so a
+    // manual send doesn't double up with an imminent timed one). Returns
+    // false when no callsign or no position is configured.
+    bool sendNow();
+
+signals:
+    void transmitFrame(const QByteArray& rawAx25NoFcs);
+    void activity(const QString& line);
+
+private:
+    ax25::Address m_myAddress;
+    QVector<ax25::Address> m_path;
+    QString m_statusText;
+    char m_symbolTable{'/'};
+    char m_symbolCode{'-'};
+
+    bool m_enabled{false};
+    int m_intervalMin{30};
+    QTimer m_timer;
+
+    bool m_gpsValid{false};
+    double m_gpsLat{0.0};
+    double m_gpsLon{0.0};
+    bool m_manualValid{false};
+    double m_manualLat{0.0};
+    double m_manualLon{0.0};
+};
+
+} // namespace AetherSDR

--- a/src/core/aprs/AprsMessenger.cpp
+++ b/src/core/aprs/AprsMessenger.cpp
@@ -1,0 +1,312 @@
+#include "core/aprs/AprsMessenger.h"
+
+#include "core/LogManager.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLoggingCategory>
+
+namespace AetherSDR {
+
+using ax25::Address;
+using ax25::Frame;
+
+namespace {
+// Destination "tocall" identifying the software that originated the frame.
+// APZ is the experimental allocation (APRS 1.0.1 appendix 4).
+const QString kTocall = QStringLiteral("APZATH");
+} // namespace
+
+AprsMessenger::AprsMessenger(QObject* parent)
+    : QObject(parent)
+{
+    m_retryTimer.setInterval(5000);
+    connect(&m_retryTimer, &QTimer::timeout, this, &AprsMessenger::serviceRetries);
+
+    m_saveCoalesce.setSingleShot(true);
+    m_saveCoalesce.setInterval(2000);
+    connect(&m_saveCoalesce, &QTimer::timeout, this, [this] { save(); });
+}
+
+AprsMessenger::~AprsMessenger()
+{
+    if (m_saveCoalesce.isActive()) {
+        m_saveCoalesce.stop();
+        save();
+    }
+}
+
+void AprsMessenger::setMyAddress(const Address& addr)
+{
+    m_myAddress = addr;
+}
+
+void AprsMessenger::setPersistencePath(const QString& path)
+{
+    m_persistPath = path;
+    if (!m_persistPath.isEmpty())
+        load();
+}
+
+void AprsMessenger::onPacket(const aprs::Packet& packet)
+{
+    if (!m_myAddress.isValid())
+        return;
+    // Ignore our own frames coming back around a digipeater.
+    if (packet.source.compare(m_myAddress.toString(), Qt::CaseInsensitive) == 0)
+        return;
+
+    if (packet.type == aprs::PacketType::MessageAck
+        || packet.type == aprs::PacketType::MessageRej) {
+        if (packet.addressee.compare(m_myAddress.toString(), Qt::CaseInsensitive) != 0)
+            return;
+        const bool acked = (packet.type == aprs::PacketType::MessageAck);
+        for (Message& m : m_messages) {
+            if (m.outgoing && m.msgNo == packet.messageNo
+                && m.counterpart.compare(packet.source, Qt::CaseInsensitive) == 0
+                && (m.state == State::Sent || m.state == State::Pending)) {
+                m.state = acked ? State::Acked : State::Rejected;
+                emit activity(QStringLiteral("APRS message %1 to %2 %3.")
+                                  .arg(m.msgNo, m.counterpart,
+                                       acked ? QStringLiteral("acknowledged")
+                                             : QStringLiteral("rejected")));
+                scheduleSave();
+                emit messagesChanged();
+                return;
+            }
+        }
+        return;
+    }
+
+    if (packet.type != aprs::PacketType::Message)
+        return;
+    if (packet.addressee.compare(m_myAddress.toString(), Qt::CaseInsensitive) != 0)
+        return;
+
+    // Always (re-)ack a numbered message — the sender retries until the ack
+    // gets through, and a duplicate means our previous ack was lost.
+    if (!packet.messageNo.isEmpty())
+        transmitText(aprs::encodeAck(packet.source, packet.messageNo));
+
+    // Duplicate detection: same station re-sending the same message number
+    // (or, for unnumbered messages, the same text within a few minutes).
+    for (const Message& m : m_messages) {
+        if (m.outgoing
+            || m.counterpart.compare(packet.source, Qt::CaseInsensitive) != 0)
+            continue;
+        if (!packet.messageNo.isEmpty()) {
+            if (m.msgNo == packet.messageNo)
+                return;
+        } else if (m.text == packet.messageText
+                   && m.utc.secsTo(QDateTime::currentDateTimeUtc()) < 300) {
+            return;
+        }
+    }
+
+    Message msg;
+    msg.counterpart = packet.source;
+    msg.text = packet.messageText;
+    msg.utc = QDateTime::currentDateTimeUtc();
+    msg.outgoing = false;
+    msg.read = false;
+    msg.msgNo = packet.messageNo;
+    msg.state = State::Received;
+    m_messages.append(msg);
+    if (m_messages.size() > kMaxStoredMessages)
+        m_messages.remove(0, m_messages.size() - kMaxStoredMessages);
+
+    emit activity(QStringLiteral("APRS message from %1: %2")
+                      .arg(msg.counterpart, msg.text));
+    scheduleSave();
+    emit messageReceived(msg);
+    emit messagesChanged();
+    emit unreadCountChanged(unreadCount());
+}
+
+bool AprsMessenger::sendMessage(const QString& to, const QString& text)
+{
+    if (!m_myAddress.isValid())
+        return false;
+    const auto dest = Address::parse(to.trimmed().toUpper());
+    if (!dest || text.trimmed().isEmpty())
+        return false;
+
+    Message msg;
+    msg.counterpart = dest->toString();
+    msg.text = text.trimmed();
+    msg.utc = QDateTime::currentDateTimeUtc();
+    msg.outgoing = true;
+    msg.read = true;
+    msg.msgNo = QString::number(m_nextMsgNo);
+    m_nextMsgNo = (m_nextMsgNo % 99999) + 1;
+    msg.state = State::Sent;
+    msg.tries = 1;
+    msg.nextTryUtc = msg.utc.addSecs(kRetryIntervalSecs);
+    m_messages.append(msg);
+
+    transmitText(aprs::encodeMessage(msg.counterpart, msg.text, msg.msgNo));
+    emit activity(QStringLiteral("APRS message %1 to %2 sent: %3")
+                      .arg(msg.msgNo, msg.counterpart, msg.text));
+
+    if (!m_retryTimer.isActive())
+        m_retryTimer.start();
+    scheduleSave();
+    emit messagesChanged();
+    return true;
+}
+
+void AprsMessenger::transmitText(const QString& infoText)
+{
+    Address dest;
+    dest.call = kTocall;
+    const Frame frame =
+        Frame::makeUI(dest, m_myAddress, m_path, infoText.toLatin1());
+    emit transmitFrame(frame.encode());
+}
+
+void AprsMessenger::serviceRetries()
+{
+    const QDateTime now = QDateTime::currentDateTimeUtc();
+    bool changed = false;
+    bool anyOutstanding = false;
+    for (Message& m : m_messages) {
+        if (!m.outgoing || m.state != State::Sent)
+            continue;
+        if (m.nextTryUtc > now) {
+            anyOutstanding = true;
+            continue;
+        }
+        if (m.tries >= kMaxTries) {
+            m.state = State::Failed;
+            emit activity(QStringLiteral("APRS message %1 to %2 failed (no ack after %3 tries).")
+                              .arg(m.msgNo, m.counterpart)
+                              .arg(m.tries));
+            changed = true;
+            continue;
+        }
+        m.tries += 1;
+        m.nextTryUtc = now.addSecs(kRetryIntervalSecs);
+        transmitText(aprs::encodeMessage(m.counterpart, m.text, m.msgNo));
+        emit activity(QStringLiteral("APRS message %1 to %2 retry %3/%4.")
+                          .arg(m.msgNo, m.counterpart)
+                          .arg(m.tries)
+                          .arg(kMaxTries));
+        anyOutstanding = true;
+        changed = true;
+    }
+    if (!anyOutstanding)
+        m_retryTimer.stop();
+    if (changed) {
+        scheduleSave();
+        emit messagesChanged();
+    }
+}
+
+int AprsMessenger::unreadCount() const
+{
+    int n = 0;
+    for (const Message& m : m_messages) {
+        if (!m.outgoing && !m.read)
+            ++n;
+    }
+    return n;
+}
+
+void AprsMessenger::markAllRead()
+{
+    bool changed = false;
+    for (Message& m : m_messages) {
+        if (!m.outgoing && !m.read) {
+            m.read = true;
+            changed = true;
+        }
+    }
+    if (changed) {
+        scheduleSave();
+        emit messagesChanged();
+        emit unreadCountChanged(0);
+    }
+}
+
+void AprsMessenger::clear()
+{
+    m_messages.clear();
+    save();
+    emit messagesChanged();
+    emit unreadCountChanged(0);
+}
+
+void AprsMessenger::scheduleSave()
+{
+    if (m_persistPath.isEmpty())
+        return;
+    m_saveCoalesce.start();
+}
+
+void AprsMessenger::load()
+{
+    m_messages.clear();
+    QFile f(m_persistPath);
+    if (!f.open(QIODevice::ReadOnly))
+        return;
+    const QJsonObject root = QJsonDocument::fromJson(f.readAll()).object();
+    m_nextMsgNo = qBound(1, root.value(QStringLiteral("nextMsgNo")).toInt(1), 99999);
+    for (const QJsonValue& v : root.value(QStringLiteral("messages")).toArray()) {
+        const QJsonObject o = v.toObject();
+        Message m;
+        m.counterpart = o.value(QStringLiteral("counterpart")).toString();
+        if (m.counterpart.isEmpty())
+            continue;
+        m.text = o.value(QStringLiteral("text")).toString();
+        m.utc = QDateTime::fromString(o.value(QStringLiteral("utc")).toString(),
+                                      Qt::ISODate);
+        m.outgoing = o.value(QStringLiteral("outgoing")).toBool();
+        m.read = o.value(QStringLiteral("read")).toBool(true);
+        m.msgNo = o.value(QStringLiteral("msgNo")).toString();
+        m.tries = o.value(QStringLiteral("tries")).toInt();
+        const int state = o.value(QStringLiteral("state")).toInt();
+        m.state = State(qBound(0, state, int(State::Failed)));
+        // Don't resurrect retry loops across restarts: anything still
+        // awaiting an ack from a previous session is closed out as Failed.
+        if (m.outgoing && (m.state == State::Sent || m.state == State::Pending))
+            m.state = State::Failed;
+        m_messages.append(m);
+    }
+}
+
+void AprsMessenger::save() const
+{
+    if (m_persistPath.isEmpty())
+        return;
+    QDir().mkpath(QFileInfo(m_persistPath).absolutePath());
+    QJsonArray arr;
+    for (const Message& m : m_messages) {
+        QJsonObject o;
+        o.insert(QStringLiteral("counterpart"), m.counterpart);
+        o.insert(QStringLiteral("text"), m.text);
+        o.insert(QStringLiteral("utc"), m.utc.toString(Qt::ISODate));
+        o.insert(QStringLiteral("outgoing"), m.outgoing);
+        o.insert(QStringLiteral("read"), m.read);
+        o.insert(QStringLiteral("msgNo"), m.msgNo);
+        o.insert(QStringLiteral("tries"), m.tries);
+        o.insert(QStringLiteral("state"), int(m.state));
+        arr.append(o);
+    }
+    QJsonObject root;
+    root.insert(QStringLiteral("messages"), arr);
+    root.insert(QStringLiteral("nextMsgNo"), m_nextMsgNo);
+    QFile f(m_persistPath);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        qCWarning(lcAx25).noquote()
+            << "AprsMessenger: could not write" << m_persistPath
+            << "—" << f.errorString();
+        return;
+    }
+    f.write(QJsonDocument(root).toJson());
+}
+
+} // namespace AetherSDR

--- a/src/core/aprs/AprsMessenger.cpp
+++ b/src/core/aprs/AprsMessenger.cpp
@@ -5,6 +5,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QSaveFile>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -92,17 +93,24 @@ void AprsMessenger::onPacket(const aprs::Packet& packet)
     if (!packet.messageNo.isEmpty())
         transmitText(aprs::encodeAck(packet.source, packet.messageNo));
 
-    // Duplicate detection: same station re-sending the same message number
-    // (or, for unnumbered messages, the same text within a few minutes).
+    // Duplicate detection: same station re-sending the same message within a
+    // few minutes. APRS clients reuse small message numbers freely (often
+    // cycling {1–{99, some restarting per session), so a numbered match must be
+    // bounded by both text AND time — an unbounded msgNo match would silently
+    // drop a genuinely-new message that happens to reuse a number we stored
+    // long ago (while still auto-acking it, so neither side notices). 30 min
+    // comfortably covers ack-loss retries.
     for (const Message& m : m_messages) {
         if (m.outgoing
             || m.counterpart.compare(packet.source, Qt::CaseInsensitive) != 0)
             continue;
+        const qint64 ageSecs = m.utc.secsTo(QDateTime::currentDateTimeUtc());
         if (!packet.messageNo.isEmpty()) {
-            if (m.msgNo == packet.messageNo)
+            if (m.msgNo == packet.messageNo
+                && m.text == packet.messageText
+                && ageSecs < 1800)
                 return;
-        } else if (m.text == packet.messageText
-                   && m.utc.secsTo(QDateTime::currentDateTimeUtc()) < 300) {
+        } else if (m.text == packet.messageText && ageSecs < 300) {
             return;
         }
     }
@@ -299,7 +307,9 @@ void AprsMessenger::save() const
     QJsonObject root;
     root.insert(QStringLiteral("messages"), arr);
     root.insert(QStringLiteral("nextMsgNo"), m_nextMsgNo);
-    QFile f(m_persistPath);
+    // Atomic write (Constitution Principle XIV) — a crash mid-write must not
+    // truncate or corrupt the message history.
+    QSaveFile f(m_persistPath);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
         qCWarning(lcAx25).noquote()
             << "AprsMessenger: could not write" << m_persistPath
@@ -307,6 +317,10 @@ void AprsMessenger::save() const
         return;
     }
     f.write(QJsonDocument(root).toJson());
+    if (!f.commit())
+        qCWarning(lcAx25).noquote()
+            << "AprsMessenger: could not commit" << m_persistPath
+            << "—" << f.errorString();
 }
 
 } // namespace AetherSDR

--- a/src/core/aprs/AprsMessenger.h
+++ b/src/core/aprs/AprsMessenger.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "core/aprs/AprsPacket.h"
+#include "core/tnc/Ax25.h"
+
+#include <QDateTime>
+#include <QObject>
+#include <QString>
+#include <QTimer>
+#include <QVector>
+
+namespace AetherSDR {
+
+// APRS messaging (APRS 1.0.1 ch. 14): the store-and-retry engine behind the
+// message UI. Incoming messages addressed to our callsign are stored, marked
+// unread, auto-acked, and de-duplicated (a retrying sender repeats the same
+// {msgNo} until our ack lands). Outgoing messages get a sequential message
+// number and are retransmitted on a timer until the peer's ack arrives or
+// the retry budget runs out. Frames go out through transmitFrame() — the
+// owner wires that into the shared modem TX queue exactly like PmsMailbox.
+class AprsMessenger : public QObject {
+    Q_OBJECT
+
+public:
+    enum class State {
+        Received, // incoming
+        Pending,  // outgoing, waiting for first/next transmission slot
+        Sent,     // outgoing, transmitted at least once, awaiting ack
+        Acked,    // outgoing, peer confirmed
+        Rejected, // outgoing, peer sent rej
+        Failed,   // outgoing, retry budget exhausted
+    };
+
+    struct Message {
+        QString counterpart;   // the remote station ("N0CALL-7")
+        QString text;
+        QDateTime utc;         // received / first-queued time, UTC
+        bool outgoing{false};
+        bool read{true};       // incoming messages start unread
+        QString msgNo;         // APRS message number (may be empty inbound)
+        State state{State::Received};
+        int tries{0};
+        QDateTime nextTryUtc;  // outgoing: next retransmission due
+    };
+
+    explicit AprsMessenger(QObject* parent = nullptr);
+    ~AprsMessenger() override;
+
+    void setMyAddress(const ax25::Address& addr);
+    ax25::Address myAddress() const { return m_myAddress; }
+    void setPath(const QVector<ax25::Address>& path) { m_path = path; }
+
+    // Empty path (the default) keeps history in-memory only.
+    void setPersistencePath(const QString& path);
+
+    // Feed every parsed packet here; non-messages and messages addressed to
+    // other stations are ignored (acks for our outbound traffic are matched).
+    void onPacket(const aprs::Packet& packet);
+
+    // Queue an outgoing message. Returns false when the destination callsign
+    // is invalid or our own callsign is not configured.
+    bool sendMessage(const QString& to, const QString& text);
+
+    QVector<Message> messages() const { return m_messages; }
+    int unreadCount() const;
+    void markAllRead();
+    void clear();
+
+signals:
+    void transmitFrame(const QByteArray& rawAx25NoFcs);
+    void messageReceived(const Message& message);
+    void messagesChanged();
+    void unreadCountChanged(int count);
+    void activity(const QString& line);
+
+private:
+    void transmitText(const QString& infoText);
+    void serviceRetries();
+    void load();
+    void save() const;
+    void scheduleSave();
+
+    ax25::Address m_myAddress;
+    QVector<ax25::Address> m_path;
+    QVector<Message> m_messages;
+    int m_nextMsgNo{1};
+    QString m_persistPath;
+    QTimer m_retryTimer;    // periodic scan for due retransmissions
+    QTimer m_saveCoalesce;  // single-shot, HeardList-style coalesced save
+
+    static constexpr int kRetryIntervalSecs = 30;
+    static constexpr int kMaxTries = 4;
+    static constexpr int kMaxStoredMessages = 500;
+};
+
+} // namespace AetherSDR

--- a/src/core/aprs/AprsPacket.cpp
+++ b/src/core/aprs/AprsPacket.cpp
@@ -314,6 +314,82 @@ bool parseMicE(const ax25::Frame& frame, const QString& info, Packet& pkt)
     return true;
 }
 
+// --- Weather (ch. 12) ------------------------------------------------------
+
+// Consume the concatenated token stream "g012t077r000p000P000h50b09900..."
+// from the head of `text`. Each token is a tag letter plus a fixed-width
+// field; dots or spaces in the field mean "sensor not present". Stops at the
+// first unrecognized tag (the remainder is the station's free text).
+void parseWeatherTokens(QString& text, WeatherReport& wx)
+{
+    static const QRegularExpression fieldChars(QStringLiteral("^[-0-9. ]+$"));
+    while (!text.isEmpty()) {
+        int len = 0;
+        const char tag = text.at(0).toLatin1();
+        switch (tag) {
+        case 'g': case 't': case 'r': case 'p': case 'P': case 's':
+            len = 3; break;       // s = snow (consumed, not surfaced)
+        case 'h':
+            len = 2; break;
+        case 'b':
+            len = 5; break;
+        case 'L': case 'l':
+            len = 3; break;       // luminosity (consumed, not surfaced)
+        default:
+            len = 0; break;
+        }
+        if (len == 0 || text.size() < 1 + len)
+            return;
+        const QString field = text.mid(1, len);
+        if (!fieldChars.match(field).hasMatch())
+            return;
+        text.remove(0, 1 + len);
+        bool ok = false;
+        const double v = field.trimmed().toDouble(&ok);
+        if (!ok)
+            continue; // "..." — sensor not present
+        switch (tag) {
+        case 'g': wx.gustMph = v; wx.valid = true; break;
+        case 't': wx.temperatureF = v; wx.valid = true; break;
+        case 'r': wx.rainHourIn = v / 100.0; wx.valid = true; break;
+        case 'p': wx.rain24hIn = v / 100.0; wx.valid = true; break;
+        case 'P': wx.rainMidnightIn = v / 100.0; wx.valid = true; break;
+        case 'h':
+            wx.humidityPct = (int(v) == 0) ? 100 : int(v); // h00 = 100%
+            wx.valid = true;
+            break;
+        case 'b': wx.pressureMbar = v / 10.0; wx.valid = true; break;
+        default: break;
+        }
+    }
+}
+
+// Fold the wx data riding in a *position* weather report (symbol '_'): wind
+// comes from the CSE/SPD extension (knots), the rest from the comment's
+// token stream. The comment is replaced with the readable summary.
+void extractPositionWeather(Packet& pkt)
+{
+    if (pkt.courseDeg >= 0.0)
+        pkt.weather.windDirDeg = qRound(pkt.courseDeg);
+    if (pkt.speedKnots >= 0.0)
+        pkt.weather.windMph = pkt.speedKnots * 1.15078;
+    pkt.weather.valid =
+        (pkt.weather.windDirDeg >= 0) || (pkt.weather.windMph >= 0);
+    QString rest = pkt.comment;
+    parseWeatherTokens(rest, pkt.weather);
+    if (!pkt.weather.valid)
+        return;
+    // Wind in the extension was wind, not movement — don't show a weather
+    // station "driving" at 5 mph in the station table.
+    pkt.courseDeg = -1.0;
+    pkt.speedKnots = -1.0;
+    QString comment = weatherSummary(pkt.weather);
+    rest = rest.trimmed();
+    if (!rest.isEmpty())
+        comment += QStringLiteral("   ") + rest;
+    pkt.comment = comment;
+}
+
 // --- Messages: ":ADDRESSEE:text{NN" (ch. 14) ------------------------------
 
 bool parseMessage(const QString& body, Packet& pkt)
@@ -370,8 +446,10 @@ std::optional<Packet> parseFrame(const ax25::Frame& frame)
         pkt.type = PacketType::Position;
         pkt.messagingCapable = (dti == '=');
         parsePositionBody(info.mid(1), pkt);
-        if (pkt.hasPosition && pkt.symbolCode == '_')
+        if (pkt.hasPosition && pkt.symbolCode == '_') {
             pkt.type = PacketType::Weather;
+            extractPositionWeather(pkt);
+        }
         break;
     case '/':
     case '@': {
@@ -380,8 +458,10 @@ std::optional<Packet> parseFrame(const ax25::Frame& frame)
         QString body = info.mid(1);
         body.remove(0, timestampLength(body));
         parsePositionBody(body, pkt);
-        if (pkt.hasPosition && pkt.symbolCode == '_')
+        if (pkt.hasPosition && pkt.symbolCode == '_') {
             pkt.type = PacketType::Weather;
+            extractPositionWeather(pkt);
+        }
         break;
     }
     case 0x1c: // Mic-E (current, rev 0)
@@ -431,10 +511,45 @@ std::optional<Packet> parseFrame(const ax25::Frame& frame)
         parsePositionBody(body.mid(sep + 1), pkt);
         break;
     }
-    case '_':
+    case '_': {
+        // Positionless weather: "_MMDDHHMM" timestamp, "cDDDsSSS" wind
+        // (degrees + mph), then the shared token stream.
         pkt.type = PacketType::Weather;
-        pkt.comment = info.mid(1).trimmed();
+        QString body = info.mid(1);
+        int digits = 0;
+        while (digits < 8 && digits < body.size() && body.at(digits).isDigit())
+            ++digits;
+        if (digits == 8)
+            body.remove(0, 8);
+        if (body.size() >= 8 && body.at(0) == QLatin1Char('c')
+            && body.at(4) == QLatin1Char('s')) {
+            bool dirOk = false, spdOk = false;
+            const int dir = body.mid(1, 3).toInt(&dirOk);
+            const double spd = body.mid(5, 3).trimmed().toDouble(&spdOk);
+            if (dirOk && dir >= 0 && dir <= 360) {
+                pkt.weather.windDirDeg = (dir == 360) ? 0 : dir;
+                pkt.weather.valid = true;
+            }
+            if (spdOk) {
+                pkt.weather.windMph = spd;
+                pkt.weather.valid = true;
+            }
+            body.remove(0, 8);
+        }
+        parseWeatherTokens(body, pkt.weather);
+        if (pkt.weather.valid) {
+            QString comment = weatherSummary(pkt.weather);
+            body = body.trimmed();
+            // Whatever trails the tokens is the station-type/software code
+            // ("wRSW") — not worth a column's width.
+            if (body.size() > 4)
+                comment += QStringLiteral("   ") + body;
+            pkt.comment = comment;
+        } else {
+            pkt.comment = info.mid(1).trimmed();
+        }
         break;
+    }
     case 'T':
         pkt.type = PacketType::Telemetry;
         pkt.comment = info.mid(1).trimmed();
@@ -579,6 +694,34 @@ QString symbolDescription(char symbolTable, char symbolCode)
     }
     return QStringLiteral("Symbol '%1%2'")
         .arg(QLatin1Char(symbolTable)).arg(QLatin1Char(symbolCode));
+}
+
+QString weatherSummary(const WeatherReport& wx)
+{
+    QStringList parts;
+    if (wx.temperatureF > -999.0)
+        parts << QStringLiteral("%1°F").arg(qRound(wx.temperatureF));
+    if (wx.windDirDeg >= 0 || wx.windMph >= 0.0) {
+        QString wind = QStringLiteral("Wind");
+        if (wx.windDirDeg >= 0)
+            wind += QStringLiteral(" %1°").arg(wx.windDirDeg);
+        if (wx.windMph >= 0.0)
+            wind += QStringLiteral(" %1 mph").arg(qRound(wx.windMph));
+        if (wx.gustMph > 0.0)
+            wind += QStringLiteral(" (gust %1)").arg(qRound(wx.gustMph));
+        parts << wind;
+    }
+    if (wx.humidityPct >= 0)
+        parts << QStringLiteral("Hum %1%").arg(wx.humidityPct);
+    if (wx.pressureMbar > 0.0) {
+        parts << QStringLiteral("%1 inHg")
+            .arg(wx.pressureMbar * 0.029530, 0, 'f', 2);
+    }
+    if (wx.rainHourIn > 0.0)
+        parts << QStringLiteral("Rain %1\"/hr").arg(wx.rainHourIn, 0, 'f', 2);
+    else if (wx.rain24hIn > 0.0)
+        parts << QStringLiteral("Rain %1\"/24h").arg(wx.rain24hIn, 0, 'f', 2);
+    return parts.join(QStringLiteral("   "));
 }
 
 QString packetTypeName(PacketType type)

--- a/src/core/aprs/AprsPacket.cpp
+++ b/src/core/aprs/AprsPacket.cpp
@@ -1,0 +1,602 @@
+#include "core/aprs/AprsPacket.h"
+
+#include <QRegularExpression>
+#include <QtMath>
+
+namespace AetherSDR::aprs {
+
+namespace {
+
+// --- Uncompressed position: "4903.50N/07201.75W-" ------------------------
+
+// Parses "ddmm.mmN" / "dddmm.mmW". Position ambiguity (trailing spaces in
+// the digits, APRS 1.0.1 ch. 6) is resolved to the cell center by replacing
+// spaces with '5' in the first blanked digit and '0' after.
+std::optional<double> parseLatLon(QString text, bool isLongitude)
+{
+    const int degDigits = isLongitude ? 3 : 2;
+    if (text.size() != degDigits + 6)
+        return std::nullopt;
+    const QChar hemi = text.back().toUpper();
+    text.chop(1);
+    bool firstBlank = true;
+    for (int i = 0; i < text.size(); ++i) {
+        if (text.at(i) == QLatin1Char(' ')) {
+            text[i] = firstBlank ? QLatin1Char('5') : QLatin1Char('0');
+            firstBlank = false;
+        }
+    }
+    bool degOk = false, minOk = false;
+    const double deg = text.left(degDigits).toDouble(&degOk);
+    const double min = text.mid(degDigits).toDouble(&minOk);
+    if (!degOk || !minOk || min >= 60.0)
+        return std::nullopt;
+    double value = deg + min / 60.0;
+    if (isLongitude) {
+        if (value > 180.0)
+            return std::nullopt;
+        if (hemi == QLatin1Char('W'))
+            value = -value;
+        else if (hemi != QLatin1Char('E'))
+            return std::nullopt;
+    } else {
+        if (value > 90.0)
+            return std::nullopt;
+        if (hemi == QLatin1Char('S'))
+            value = -value;
+        else if (hemi != QLatin1Char('N'))
+            return std::nullopt;
+    }
+    return value;
+}
+
+// Course/speed data extension "088/036" at the start of the comment
+// (APRS 1.0.1 ch. 7). Consumes the 7 characters when present.
+void extractCourseSpeed(QString& comment, Packet& pkt)
+{
+    static const QRegularExpression re(
+        QStringLiteral("^([0-9 .]{3})/([0-9 .]{3})"));
+    const QRegularExpressionMatch m = re.match(comment);
+    if (!m.hasMatch())
+        return;
+    bool crsOk = false, spdOk = false;
+    const int crs = m.captured(1).trimmed().toInt(&crsOk);
+    const int spd = m.captured(2).trimmed().toInt(&spdOk);
+    if (crsOk && crs >= 1 && crs <= 360)
+        pkt.courseDeg = (crs == 360) ? 0.0 : double(crs);
+    if (spdOk)
+        pkt.speedKnots = double(spd);
+    if (crsOk || spdOk)
+        comment.remove(0, 7);
+}
+
+// Altitude comment extension "/A=001234" (feet), anywhere in the comment.
+void extractAltitude(QString& comment, Packet& pkt)
+{
+    static const QRegularExpression re(QStringLiteral("/A=(-?\\d{6})"));
+    const QRegularExpressionMatch m = re.match(comment);
+    if (!m.hasMatch())
+        return;
+    pkt.hasAltitude = true;
+    pkt.altitudeFeet = m.captured(1).toDouble();
+    comment.remove(m.capturedStart(0), m.capturedLength(0));
+}
+
+bool isValidSymbolTable(QChar c)
+{
+    // '/', '\', or an overlay 0-9 A-Z (compressed also uses a-j for 0-9).
+    return c == QLatin1Char('/') || c == QLatin1Char('\\')
+        || (c >= QLatin1Char('0') && c <= QLatin1Char('9'))
+        || (c >= QLatin1Char('A') && c <= QLatin1Char('Z'))
+        || (c >= QLatin1Char('a') && c <= QLatin1Char('j'));
+}
+
+// Compressed position "/5L!!<*e7>7P[" (APRS 1.0.1 ch. 9): symbol table,
+// 4-char base-91 lat, 4-char base-91 lon, symbol code, cs, comp-type.
+// Returns the number of characters consumed (13), or 0 on failure.
+int parseCompressedPosition(const QString& body, Packet& pkt)
+{
+    if (body.size() < 13 || !isValidSymbolTable(body.at(0)))
+        return 0;
+    auto base91 = [](const QString& s, double& out) {
+        double v = 0;
+        for (const QChar c : s) {
+            const int d = c.toLatin1() - 33;
+            if (d < 0 || d > 90)
+                return false;
+            v = v * 91.0 + d;
+        }
+        out = v;
+        return true;
+    };
+    double latVal = 0, lonVal = 0;
+    if (!base91(body.mid(1, 4), latVal) || !base91(body.mid(5, 4), lonVal))
+        return 0;
+    pkt.hasPosition = true;
+    pkt.latitude = 90.0 - latVal / 380926.0;
+    pkt.longitude = -180.0 + lonVal / 190463.0;
+    // Overlay digits are transmitted a-j in compressed form; normalize to 0-9.
+    const QChar table = body.at(0);
+    pkt.symbolTable = (table >= QLatin1Char('a') && table <= QLatin1Char('j'))
+        ? char('0' + (table.toLatin1() - 'a'))
+        : table.toLatin1();
+    pkt.symbolCode = body.at(9).toLatin1();
+
+    const char c = body.at(10).toLatin1();
+    const char s = body.at(11).toLatin1();
+    const char compType = body.at(12).toLatin1();
+    if (c != ' ' && c >= '!' && c <= 'z' && compType >= '!') {
+        const int nmeaBits = ((compType - 33) >> 3) & 0x03;
+        if (nmeaBits == 2) { // cs carries altitude: 1.002^(c*91+s) feet
+            pkt.hasAltitude = true;
+            pkt.altitudeFeet = qPow(1.002, double((c - 33) * 91 + (s - 33)));
+        } else if (c <= 'z' && s >= '!') {
+            pkt.courseDeg = double((c - 33) * 4);
+            pkt.speedKnots = qPow(1.08, double(s - 33)) - 1.0;
+        }
+    }
+    return 13;
+}
+
+// Uncompressed position at the head of `body`; returns chars consumed or 0.
+int parseUncompressedPosition(const QString& body, Packet& pkt)
+{
+    if (body.size() < 19)
+        return 0;
+    const auto lat = parseLatLon(body.left(8), false);
+    const auto lon = parseLatLon(body.mid(9, 9), true);
+    if (!lat || !lon || !isValidSymbolTable(body.at(8)))
+        return 0;
+    pkt.hasPosition = true;
+    pkt.latitude = *lat;
+    pkt.longitude = *lon;
+    pkt.symbolTable = body.at(8).toLatin1();
+    pkt.symbolCode = body.at(18).toLatin1();
+    return 19;
+}
+
+// Either position form at the head of `body`; comment handling shared.
+void parsePositionBody(QString body, Packet& pkt)
+{
+    int used = 0;
+    if (!body.isEmpty() && body.at(0).isDigit())
+        used = parseUncompressedPosition(body, pkt);
+    else
+        used = parseCompressedPosition(body, pkt);
+    if (!used)
+        return;
+    QString comment = body.mid(used);
+    if (pkt.courseDeg < 0 && pkt.speedKnots < 0)
+        extractCourseSpeed(comment, pkt);
+    extractAltitude(comment, pkt);
+    pkt.comment = comment.trimmed();
+}
+
+// "123456z" / "123456h" / "123456/" timestamp prefix (ch. 6); we only need
+// to skip it — the decode timestamp is when *we* heard the frame.
+int timestampLength(const QString& body)
+{
+    if (body.size() < 7)
+        return 0;
+    for (int i = 0; i < 6; ++i) {
+        if (!body.at(i).isDigit())
+            return 0;
+    }
+    const QChar suffix = body.at(6).toLower();
+    if (suffix == QLatin1Char('z') || suffix == QLatin1Char('h')
+        || suffix == QLatin1Char('/'))
+        return 7;
+    return 0;
+}
+
+// --- Mic-E (APRS 1.0.1 ch. 10) -------------------------------------------
+
+// Decode one Mic-E destination-field character into its latitude digit.
+// Returns -1 for invalid, 10 for "space" (position ambiguity).
+int micEDigit(QChar c)
+{
+    const char ch = c.toLatin1();
+    if (ch >= '0' && ch <= '9')
+        return ch - '0';
+    if (ch >= 'A' && ch <= 'J')
+        return ch - 'A';
+    if (ch == 'K' || ch == 'L' || ch == 'Z')
+        return 10; // space (ambiguity)
+    if (ch >= 'P' && ch <= 'Y')
+        return ch - 'P';
+    return -1;
+}
+
+bool parseMicE(const ax25::Frame& frame, const QString& info, Packet& pkt)
+{
+    // The latitude rides in the 6-character destination callsign field.
+    const QString dest = frame.dest.call.toUpper();
+    if (dest.size() != 6 || info.size() < 9)
+        return false;
+
+    int digits[6];
+    for (int i = 0; i < 6; ++i) {
+        digits[i] = micEDigit(dest.at(i));
+        if (digits[i] < 0)
+            return false;
+    }
+    // Ambiguity digits read as the cell center, matching parseLatLon().
+    auto digitOr = [&](int i, int center) {
+        return digits[i] == 10 ? center : digits[i];
+    };
+    const double latDeg = digitOr(0, 0) * 10 + digitOr(1, 0);
+    const double latMin = digitOr(2, 5) * 10 + digitOr(3, 0)
+        + (digitOr(4, 0) * 10 + digitOr(5, 0)) / 100.0;
+    if (latDeg > 90.0 || latMin >= 60.0)
+        return false;
+    double lat = latDeg + latMin / 60.0;
+
+    // Flag bits live in the character *ranges* of dest chars 3-5.
+    auto isOneBit = [&](int i) {
+        const char ch = dest.at(i).toLatin1();
+        return (ch >= 'P' && ch <= 'Z');
+    };
+    const bool north = isOneBit(3);
+    const bool lonOffset = isOneBit(4);
+    const bool west = isOneBit(5);
+    if (!north)
+        lat = -lat;
+
+    // Longitude: info bytes 1-3 (d+28, m+28, h+28).
+    const int d28 = quint8(info.at(1).toLatin1());
+    const int m28 = quint8(info.at(2).toLatin1());
+    const int h28 = quint8(info.at(3).toLatin1());
+    int lonDeg = d28 - 28;
+    if (lonOffset)
+        lonDeg += 100;
+    if (lonDeg >= 180 && lonDeg <= 189)
+        lonDeg -= 80;
+    else if (lonDeg >= 190 && lonDeg <= 199)
+        lonDeg -= 190;
+    int lonMin = m28 - 28;
+    if (lonMin >= 60)
+        lonMin -= 60;
+    const int lonHun = h28 - 28;
+    if (lonDeg > 180 || lonMin > 59 || lonHun < 0 || lonHun > 99)
+        return false;
+    double lon = lonDeg + (lonMin + lonHun / 100.0) / 60.0;
+    if (west)
+        lon = -lon;
+
+    // Speed/course: info bytes 4-6 (SP+28, DC+28, SE+28).
+    const int sp = quint8(info.at(4).toLatin1()) - 28;
+    const int dc = quint8(info.at(5).toLatin1()) - 28;
+    const int se = quint8(info.at(6).toLatin1()) - 28;
+    if (sp < 0 || dc < 0 || se < 0)
+        return false;
+    int speed = sp * 10 + dc / 10;
+    int course = (dc % 10) * 100 + se;
+    if (speed >= 800)
+        speed -= 800;
+    if (course >= 400)
+        course -= 400;
+
+    pkt.type = PacketType::Position;
+    pkt.hasPosition = true;
+    pkt.latitude = lat;
+    pkt.longitude = lon;
+    pkt.symbolCode = info.at(7).toLatin1();
+    pkt.symbolTable = info.size() > 8 ? info.at(8).toLatin1() : '/';
+    pkt.speedKnots = double(speed);
+    if (course >= 1 && course <= 360)
+        pkt.courseDeg = (course == 360) ? 0.0 : double(course);
+    pkt.messagingCapable = true; // Mic-E rigs are message-capable by design
+
+    QString comment = info.mid(9);
+    // Optional Mic-E telemetry/device prefix and "xxx}" base-91 altitude.
+    if (!comment.isEmpty()
+        && (comment.at(0) == QLatin1Char('>') || comment.at(0) == QLatin1Char(']')
+            || comment.at(0) == QLatin1Char('`') || comment.at(0) == QLatin1Char('\'')))
+        comment.remove(0, 1);
+    if (comment.size() >= 4 && comment.at(3) == QLatin1Char('}')) {
+        int alt = 0;
+        bool ok = true;
+        for (int i = 0; i < 3; ++i) {
+            const int d = comment.at(i).toLatin1() - 33;
+            if (d < 0 || d > 90) {
+                ok = false;
+                break;
+            }
+            alt = alt * 91 + d;
+        }
+        if (ok) {
+            pkt.hasAltitude = true;
+            pkt.altitudeFeet = double(alt - 10000) * 3.28084; // meters → feet
+            comment.remove(0, 4);
+        }
+    }
+    pkt.comment = comment.trimmed();
+    return true;
+}
+
+// --- Messages: ":ADDRESSEE:text{NN" (ch. 14) ------------------------------
+
+bool parseMessage(const QString& body, Packet& pkt)
+{
+    // body excludes the ':' DTI. Addressee field is exactly 9 chars + ':'.
+    if (body.size() < 10 || body.at(9) != QLatin1Char(':'))
+        return false;
+    pkt.addressee = body.left(9).trimmed().toUpper();
+    if (pkt.addressee.isEmpty())
+        return false;
+    QString text = body.mid(10);
+
+    static const QRegularExpression ackRej(
+        QStringLiteral("^(ack|rej)([A-Za-z0-9]{1,5})$"));
+    const QRegularExpressionMatch m = ackRej.match(text);
+    if (m.hasMatch()) {
+        pkt.type = (m.captured(1) == QLatin1String("ack"))
+            ? PacketType::MessageAck : PacketType::MessageRej;
+        pkt.messageNo = m.captured(2);
+        return true;
+    }
+
+    const int brace = text.lastIndexOf(QLatin1Char('{'));
+    if (brace >= 0 && text.size() - brace - 1 >= 1 && text.size() - brace - 1 <= 5) {
+        pkt.messageNo = text.mid(brace + 1);
+        text.truncate(brace);
+    }
+    pkt.type = PacketType::Message;
+    pkt.messageText = text;
+    return true;
+}
+
+} // namespace
+
+std::optional<Packet> parseFrame(const ax25::Frame& frame)
+{
+    if (frame.type != ax25::FrameType::UI || frame.info.isEmpty())
+        return std::nullopt;
+
+    Packet pkt;
+    pkt.source = frame.src.toString();
+    pkt.destination = frame.dest.toString();
+    for (const ax25::Address& hop : frame.via)
+        pkt.path << hop.toString()
+            + (hop.hasBeenRepeated ? QStringLiteral("*") : QString());
+
+    const QString info = QString::fromLatin1(frame.info);
+    pkt.infoText = info;
+    const char dti = frame.info.at(0);
+
+    switch (dti) {
+    case '!':
+    case '=':
+        pkt.type = PacketType::Position;
+        pkt.messagingCapable = (dti == '=');
+        parsePositionBody(info.mid(1), pkt);
+        if (pkt.hasPosition && pkt.symbolCode == '_')
+            pkt.type = PacketType::Weather;
+        break;
+    case '/':
+    case '@': {
+        pkt.type = PacketType::Position;
+        pkt.messagingCapable = (dti == '@');
+        QString body = info.mid(1);
+        body.remove(0, timestampLength(body));
+        parsePositionBody(body, pkt);
+        if (pkt.hasPosition && pkt.symbolCode == '_')
+            pkt.type = PacketType::Weather;
+        break;
+    }
+    case 0x1c: // Mic-E (current, rev 0)
+    case 0x1d: // Mic-E (old, rev 0)
+    case '`':  // Mic-E (current)
+    case '\'': // Mic-E (old) — also pre-2000 TNC position; Mic-E wins here
+        if (!parseMicE(frame, info, pkt))
+            pkt.type = PacketType::Other;
+        break;
+    case '>':
+        pkt.type = PacketType::Status;
+        pkt.comment = info.mid(1 + timestampLength(info.mid(1))).trimmed();
+        break;
+    case ':':
+        if (!parseMessage(info.mid(1), pkt))
+            pkt.type = PacketType::Other;
+        break;
+    case ';': {
+        // ";NAME *DDHHMMz<position>" — alive marker '*' or killed '_'.
+        if (info.size() < 19) {
+            pkt.type = PacketType::Other;
+            break;
+        }
+        pkt.type = PacketType::Object;
+        pkt.objectName = info.mid(1, 9).trimmed();
+        QString body = info.mid(11);
+        body.remove(0, timestampLength(body));
+        parsePositionBody(body, pkt);
+        break;
+    }
+    case ')': {
+        // ")NAME!<position>" — name is 3-9 chars ended by '!' (live) / '_'.
+        const QString body = info.mid(1);
+        int sep = -1;
+        for (int i = 0; i < body.size() && i < 10; ++i) {
+            if (body.at(i) == QLatin1Char('!') || body.at(i) == QLatin1Char('_')) {
+                sep = i;
+                break;
+            }
+        }
+        if (sep < 3) {
+            pkt.type = PacketType::Other;
+            break;
+        }
+        pkt.type = PacketType::Item;
+        pkt.objectName = body.left(sep).trimmed();
+        parsePositionBody(body.mid(sep + 1), pkt);
+        break;
+    }
+    case '_':
+        pkt.type = PacketType::Weather;
+        pkt.comment = info.mid(1).trimmed();
+        break;
+    case 'T':
+        pkt.type = PacketType::Telemetry;
+        pkt.comment = info.mid(1).trimmed();
+        break;
+    case '?':
+        pkt.type = PacketType::Query;
+        pkt.comment = info.mid(1).trimmed();
+        break;
+    default:
+        pkt.type = PacketType::Other;
+        pkt.comment = info.trimmed();
+        break;
+    }
+    return pkt;
+}
+
+QString encodeUncompressedPosition(double lat, double lon,
+                                   char symbolTable, char symbolCode,
+                                   const QString& comment,
+                                   bool messagingCapable)
+{
+    lat = qBound(-90.0, lat, 90.0);
+    lon = qBound(-180.0, lon, 180.0);
+    const char latHemi = lat < 0 ? 'S' : 'N';
+    const char lonHemi = lon < 0 ? 'W' : 'E';
+    lat = qAbs(lat);
+    lon = qAbs(lon);
+    const int latDeg = int(lat);
+    const int lonDeg = int(lon);
+    const double latMin = (lat - latDeg) * 60.0;
+    const double lonMin = (lon - lonDeg) * 60.0;
+    QString out;
+    out += QLatin1Char(messagingCapable ? '=' : '!');
+    out += QString::asprintf("%02d%05.2f%c", latDeg, latMin, latHemi);
+    out += QLatin1Char(symbolTable);
+    out += QString::asprintf("%03d%05.2f%c", lonDeg, lonMin, lonHemi);
+    out += QLatin1Char(symbolCode);
+    out += comment.trimmed();
+    return out;
+}
+
+QString encodeMessage(const QString& addressee, const QString& text,
+                      const QString& msgNo)
+{
+    QString out = QStringLiteral(":%1:%2")
+        .arg(addressee.trimmed().toUpper().left(9), -9, QLatin1Char(' '))
+        .arg(text);
+    if (!msgNo.isEmpty())
+        out += QLatin1Char('{') + msgNo.left(5);
+    return out;
+}
+
+QString encodeAck(const QString& addressee, const QString& msgNo)
+{
+    return QStringLiteral(":%1:ack%2")
+        .arg(addressee.trimmed().toUpper().left(9), -9, QLatin1Char(' '))
+        .arg(msgNo.left(5));
+}
+
+QString encodeStatus(const QString& text)
+{
+    return QLatin1Char('>') + text.trimmed();
+}
+
+QString gridSquare(double lat, double lon)
+{
+    lat = qBound(-90.0, lat, 89.99999) + 90.0;
+    lon = qBound(-180.0, lon, 179.99999) + 180.0;
+    QString out;
+    out += QChar('A' + int(lon / 20.0));
+    out += QChar('A' + int(lat / 10.0));
+    out += QChar('0' + int(fmod(lon, 20.0) / 2.0));
+    out += QChar('0' + int(fmod(lat, 10.0)));
+    out += QChar('a' + int(fmod(lon, 2.0) * 12.0));
+    out += QChar('a' + int(fmod(lat, 1.0) * 24.0));
+    return out;
+}
+
+double distanceMiles(double lat1, double lon1, double lat2, double lon2)
+{
+    constexpr double kEarthRadiusMiles = 3958.756;
+    const double p1 = qDegreesToRadians(lat1);
+    const double p2 = qDegreesToRadians(lat2);
+    const double dp = qDegreesToRadians(lat2 - lat1);
+    const double dl = qDegreesToRadians(lon2 - lon1);
+    const double a = qSin(dp / 2) * qSin(dp / 2)
+        + qCos(p1) * qCos(p2) * qSin(dl / 2) * qSin(dl / 2);
+    return kEarthRadiusMiles * 2.0 * qAtan2(qSqrt(a), qSqrt(1.0 - a));
+}
+
+double bearingDeg(double lat1, double lon1, double lat2, double lon2)
+{
+    const double p1 = qDegreesToRadians(lat1);
+    const double p2 = qDegreesToRadians(lat2);
+    const double dl = qDegreesToRadians(lon2 - lon1);
+    const double y = qSin(dl) * qCos(p2);
+    const double x = qCos(p1) * qSin(p2) - qSin(p1) * qCos(p2) * qCos(dl);
+    const double deg = qRadiansToDegrees(qAtan2(y, x));
+    return fmod(deg + 360.0, 360.0);
+}
+
+QString symbolDescription(char symbolTable, char symbolCode)
+{
+    struct Entry { char code; const char* primary; const char* alternate; };
+    // The handful of symbols that actually dominate on-air traffic
+    // (APRS 1.0.1 appendix 2). Everything else falls through generically.
+    static constexpr Entry kSymbols[] = {
+        { '!', "Police", "Emergency" },
+        { '#', "Digipeater", "Digipeater (overlay)" },
+        { '$', "Phone", "Bank" },
+        { '\'', "Small aircraft", "Crash site" },
+        { '-', "Home", "Home (HF)" },
+        { '<', "Motorcycle", "Advisory" },
+        { '=', "Railroad engine", "Railroad" },
+        { '>', "Car", "Car (overlay)" },
+        { 'O', "Balloon", "Rocket" },
+        { 'P', "Police", "Parking" },
+        { 'R', "RV", "Restaurant" },
+        { 'U', "Bus", "Sunny" },
+        { 'W', "Weather service", "Flooding" },
+        { 'X', "Helicopter", "Pharmacy" },
+        { 'Y', "Sailboat", "Radios/devices" },
+        { '[', "Jogger", "Wall cloud" },
+        { '_', "Weather station", "Weather (overlay)" },
+        { 'a', "Ambulance", "ARRL/ARES" },
+        { 'b', "Bicycle", "Blowing dust" },
+        { 'f', "Fire truck", "Fog" },
+        { 'g', "Glider", "Gale flags" },
+        { 'j', "Jeep", "Lightning" },
+        { 'k', "Truck", "Kenwood HT" },
+        { 'm', "Mic-E repeater", "Milepost" },
+        { 'r', "Repeater", "Restrooms" },
+        { 's', "Power boat", "Ship/boat" },
+        { 'u', "Truck (18-wheeler)", "Truck stop" },
+        { 'v', "Van", "Van (overlay)" },
+        { 'y', "Yagi at QTH", "Skywarn" },
+    };
+    const bool primary = (symbolTable == '/');
+    for (const Entry& e : kSymbols) {
+        if (e.code == symbolCode)
+            return QString::fromLatin1(primary ? e.primary : e.alternate);
+    }
+    return QStringLiteral("Symbol '%1%2'")
+        .arg(QLatin1Char(symbolTable)).arg(QLatin1Char(symbolCode));
+}
+
+QString packetTypeName(PacketType type)
+{
+    switch (type) {
+    case PacketType::Position:   return QStringLiteral("Position");
+    case PacketType::Status:     return QStringLiteral("Status");
+    case PacketType::Message:    return QStringLiteral("Message");
+    case PacketType::MessageAck: return QStringLiteral("Ack");
+    case PacketType::MessageRej: return QStringLiteral("Reject");
+    case PacketType::Object:     return QStringLiteral("Object");
+    case PacketType::Item:       return QStringLiteral("Item");
+    case PacketType::Weather:    return QStringLiteral("Weather");
+    case PacketType::Telemetry:  return QStringLiteral("Telemetry");
+    case PacketType::Query:      return QStringLiteral("Query");
+    case PacketType::Other:      return QStringLiteral("Other");
+    }
+    return QStringLiteral("Other");
+}
+
+} // namespace AetherSDR::aprs

--- a/src/core/aprs/AprsPacket.cpp
+++ b/src/core/aprs/AprsPacket.cpp
@@ -577,10 +577,16 @@ QString encodeUncompressedPosition(double lat, double lon,
     const char lonHemi = lon < 0 ? 'W' : 'E';
     lat = qAbs(lat);
     lon = qAbs(lon);
-    const int latDeg = int(lat);
-    const int lonDeg = int(lon);
-    const double latMin = (lat - latDeg) * 60.0;
-    const double lonMin = (lon - lonDeg) * 60.0;
+    int latDeg = int(lat);
+    int lonDeg = int(lon);
+    // Round minutes to the 2 decimals we print, then carry a 60.00 overflow
+    // into the degrees. Without this, e.g. 38.999999° formats latMin=59.99994
+    // as "60.00" → "3860.00N", which every APRS parser (including ours)
+    // rejects as min >= 60. A GPS-fed beacon hits this near minute boundaries.
+    double latMin = qRound((lat - latDeg) * 60.0 * 100.0) / 100.0;
+    double lonMin = qRound((lon - lonDeg) * 60.0 * 100.0) / 100.0;
+    if (latMin >= 60.0) { latMin -= 60.0; latDeg += 1; }
+    if (lonMin >= 60.0) { lonMin -= 60.0; lonDeg += 1; }
     QString out;
     out += QLatin1Char(messagingCapable ? '=' : '!');
     out += QString::asprintf("%02d%05.2f%c", latDeg, latMin, latHemi);

--- a/src/core/aprs/AprsPacket.h
+++ b/src/core/aprs/AprsPacket.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "core/tnc/Ax25.h"
+
+#include <QString>
+#include <QStringList>
+
+#include <optional>
+
+// Lightweight APRS (Automatic Packet Reporting System) info-field codec.
+//
+// Parses decoded AX.25 UI frames into a typed Packet (position reports in
+// uncompressed, compressed and Mic-E form, status, messages/acks, objects,
+// items, positionless weather) and builds the info-field text for the
+// outbound beacon / message / ack paths. Deliberately self-contained (Qt Core
+// only, no DSP, no network) so it can be unit-tested standalone, mirroring
+// the ax25:: primitives one directory over. Reference: APRS Protocol
+// Reference 1.0.1 (aprs.org), chapters 6-12.
+
+namespace AetherSDR::aprs {
+
+enum class PacketType {
+    Position,   // ! = / @ data type indicators, plus all Mic-E forms
+    Status,     // >
+    Message,    // :ADDRESSEE :text{NN
+    MessageAck, // :ADDRESSEE :ackNN
+    MessageRej, // :ADDRESSEE :rejNN
+    Object,     // ;
+    Item,       // )
+    Weather,    // _ (positionless weather report)
+    Telemetry,  // T
+    Query,      // ?
+    Other,
+};
+
+struct Packet {
+    QString source;      // "N0CALL-9"
+    QString destination; // raw AX.25 destination field (tocall / Mic-E lat)
+    QStringList path;    // digipeater path; repeated hops carry a trailing '*'
+    PacketType type{PacketType::Other};
+
+    // Position data — valid only when hasPosition is true.
+    bool hasPosition{false};
+    double latitude{0.0};   // decimal degrees, +N
+    double longitude{0.0};  // decimal degrees, +E
+    char symbolTable{'/'};  // '/', '\' or overlay character
+    char symbolCode{'-'};
+    double courseDeg{-1.0};   // < 0 when not reported
+    double speedKnots{-1.0};  // < 0 when not reported
+    bool hasAltitude{false};
+    double altitudeFeet{0.0};
+    bool messagingCapable{false}; // '=' / '@' senders accept APRS messages
+
+    // Free-text payload: the position comment, status text, or weather data.
+    QString comment;
+
+    // Message fields (type Message / MessageAck / MessageRej).
+    QString addressee;   // normalized: trimmed, upper-cased
+    QString messageText;
+    QString messageNo;   // empty when the sender did not request an ack
+
+    // Object / item name (type Object / Item).
+    QString objectName;
+
+    QString infoText;    // the whole raw info field, for logging/raw view
+};
+
+// Parse a decoded AX.25 frame into an APRS packet. Returns nullopt when the
+// frame is not a UI frame or has an empty info field. Frames that are UI but
+// not recognizably APRS still return a Packet with type Other so the caller
+// can count/log the station.
+std::optional<Packet> parseFrame(const ax25::Frame& frame);
+
+// --- Info-field encoders (return Latin-1-safe text) ---------------------
+
+// "=4903.50N/07201.75W-comment" (or '!' when not messaging-capable).
+QString encodeUncompressedPosition(double lat, double lon,
+                                   char symbolTable, char symbolCode,
+                                   const QString& comment,
+                                   bool messagingCapable = true);
+
+// ":ADDRESSEE:text{NN" — msgNo may be empty for fire-and-forget messages.
+QString encodeMessage(const QString& addressee, const QString& text,
+                      const QString& msgNo);
+
+// ":ADDRESSEE:ackNN"
+QString encodeAck(const QString& addressee, const QString& msgNo);
+
+// ">status text"
+QString encodeStatus(const QString& text);
+
+// --- Geo helpers ---------------------------------------------------------
+
+// 6-character Maidenhead locator ("DN18rg").
+QString gridSquare(double lat, double lon);
+
+// Great-circle distance (statute miles) and initial bearing (0-360 deg).
+double distanceMiles(double lat1, double lon1, double lat2, double lon2);
+double bearingDeg(double lat1, double lon1, double lat2, double lon2);
+
+// Human-readable name for the common APRS symbols ("Home", "Car", ...);
+// falls back to "Symbol 'X'" for codes not in the table.
+QString symbolDescription(char symbolTable, char symbolCode);
+
+QString packetTypeName(PacketType type);
+
+} // namespace AetherSDR::aprs

--- a/src/core/aprs/AprsPacket.h
+++ b/src/core/aprs/AprsPacket.h
@@ -33,6 +33,26 @@ enum class PacketType {
     Other,
 };
 
+// Decoded weather data (APRS 1.0.1 ch. 12), from a positionless '_' report
+// or a position report carrying the WX symbol. Sentinel defaults mean "not
+// reported" — stations send whatever sensors they have.
+struct WeatherReport {
+    bool valid{false};
+    int windDirDeg{-1};            // < 0 unknown
+    double windMph{-1.0};          // < 0 unknown
+    double gustMph{-1.0};          // < 0 unknown
+    double temperatureF{-1000.0};  // < -999 unknown
+    int humidityPct{-1};           // < 0 unknown ("h00" means 100%)
+    double pressureMbar{-1.0};     // < 0 unknown
+    double rainHourIn{-1.0};       // < 0 unknown (inches)
+    double rain24hIn{-1.0};
+    double rainMidnightIn{-1.0};
+};
+
+// "77°F   Wind 220° 5 mph (gust 12)   Hum 50%   29.23 inHg   Rain 0.12\"/hr"
+// — triple-spaced groups so it reads cleanly in the station table.
+QString weatherSummary(const WeatherReport& wx);
+
 struct Packet {
     QString source;      // "N0CALL-9"
     QString destination; // raw AX.25 destination field (tocall / Mic-E lat)
@@ -61,6 +81,10 @@ struct Packet {
 
     // Object / item name (type Object / Item).
     QString objectName;
+
+    // Weather data (type Weather). When valid, `comment` already holds the
+    // human-readable weatherSummary() text.
+    WeatherReport weather;
 
     QString infoText;    // the whole raw info field, for logging/raw view
 };

--- a/src/core/aprs/AprsSettings.cpp
+++ b/src/core/aprs/AprsSettings.cpp
@@ -1,0 +1,125 @@
+#include "core/aprs/AprsSettings.h"
+
+#include "core/AppSettings.h"
+
+#include <QJsonDocument>
+#include <QtGlobal>
+
+namespace AetherSDR {
+
+namespace {
+const QString kAprsSettingsKey = QStringLiteral("AetherModemAprs");
+} // namespace
+
+QJsonObject AprsSettings::readObj()
+{
+    const QString json =
+        AppSettings::instance().value(kAprsSettingsKey, QString{}).toString();
+    if (json.isEmpty())
+        return {};
+    return QJsonDocument::fromJson(json.toUtf8()).object();
+}
+
+void AprsSettings::write(const QJsonObject& o)
+{
+    auto& s = AppSettings::instance();
+    s.setValue(kAprsSettingsKey,
+               QString::fromUtf8(
+                   QJsonDocument(o).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+void AprsSettings::setString(const char* key, const QString& value)
+{
+    QJsonObject o = readObj();
+    o[QLatin1String(key)] = value;
+    write(o);
+}
+
+QString AprsSettings::myCall()
+{
+    return readObj().value(QStringLiteral("myCall")).toString();
+}
+
+bool AprsSettings::beaconEnabled()
+{
+    return readObj().value(QStringLiteral("beaconEnabled"))
+               .toString(QStringLiteral("False")) == QLatin1String("True");
+}
+
+int AprsSettings::beaconIntervalMinutes()
+{
+    const int minutes = readObj().value(QStringLiteral("beaconIntervalMin"))
+        .toString(QString::number(kDefaultBeaconIntervalMin)).toInt();
+    return qBound(1, minutes > 0 ? minutes : kDefaultBeaconIntervalMin, 24 * 60);
+}
+
+QString AprsSettings::beaconText()
+{
+    return readObj().value(QStringLiteral("beaconText"))
+        .toString(QStringLiteral("AetherSDR"));
+}
+
+QString AprsSettings::symbol()
+{
+    const QString sym = readObj().value(QStringLiteral("symbol")).toString();
+    return sym.size() == 2 ? sym : QStringLiteral("/-");
+}
+
+QString AprsSettings::path()
+{
+    return readObj().value(QStringLiteral("path"))
+        .toString(QStringLiteral("WIDE1-1,WIDE2-1"));
+}
+
+QString AprsSettings::manualLat()
+{
+    return readObj().value(QStringLiteral("manualLat")).toString();
+}
+
+QString AprsSettings::manualLon()
+{
+    return readObj().value(QStringLiteral("manualLon")).toString();
+}
+
+void AprsSettings::setMyCall(const QString& call)
+{
+    setString("myCall", call.trimmed().toUpper());
+}
+
+void AprsSettings::setBeaconEnabled(bool on)
+{
+    setString("beaconEnabled",
+              on ? QStringLiteral("True") : QStringLiteral("False"));
+}
+
+void AprsSettings::setBeaconIntervalMinutes(int minutes)
+{
+    setString("beaconIntervalMin", QString::number(qBound(1, minutes, 24 * 60)));
+}
+
+void AprsSettings::setBeaconText(const QString& text)
+{
+    setString("beaconText", text.trimmed());
+}
+
+void AprsSettings::setSymbol(const QString& tableAndCode)
+{
+    setString("symbol",
+              tableAndCode.size() == 2 ? tableAndCode : QStringLiteral("/-"));
+}
+
+void AprsSettings::setPath(const QString& path)
+{
+    setString("path", path.trimmed().toUpper());
+}
+
+void AprsSettings::setManualPosition(const QString& lat, const QString& lon)
+{
+    QJsonObject o = readObj();
+    o[QStringLiteral("manualLat")] = lat.trimmed();
+    o[QStringLiteral("manualLon")] = lon.trimmed();
+    write(o);
+}
+
+} // namespace AetherSDR

--- a/src/core/aprs/AprsSettings.cpp
+++ b/src/core/aprs/AprsSettings.cpp
@@ -41,6 +41,12 @@ QString AprsSettings::myCall()
     return readObj().value(QStringLiteral("myCall")).toString();
 }
 
+bool AprsSettings::modemAutostart()
+{
+    return readObj().value(QStringLiteral("modemAutostart"))
+               .toString(QStringLiteral("False")) == QLatin1String("True");
+}
+
 bool AprsSettings::beaconEnabled()
 {
     return readObj().value(QStringLiteral("beaconEnabled"))
@@ -85,6 +91,12 @@ QString AprsSettings::manualLon()
 void AprsSettings::setMyCall(const QString& call)
 {
     setString("myCall", call.trimmed().toUpper());
+}
+
+void AprsSettings::setModemAutostart(bool on)
+{
+    setString("modemAutostart",
+              on ? QStringLiteral("True") : QStringLiteral("False"));
 }
 
 void AprsSettings::setBeaconEnabled(bool on)

--- a/src/core/aprs/AprsSettings.h
+++ b/src/core/aprs/AprsSettings.h
@@ -14,6 +14,7 @@ public:
     static constexpr int kDefaultBeaconIntervalMin = 30;
 
     static QString myCall();             // "" until the operator sets one
+    static bool modemAutostart();        // enable the modem at app launch
     static bool beaconEnabled();
     static int beaconIntervalMinutes();  // clamped to [1, 1440]
     static QString beaconText();
@@ -23,6 +24,7 @@ public:
     static QString manualLon();
 
     static void setMyCall(const QString& call);
+    static void setModemAutostart(bool on);
     static void setBeaconEnabled(bool on);
     static void setBeaconIntervalMinutes(int minutes);
     static void setBeaconText(const QString& text);

--- a/src/core/aprs/AprsSettings.h
+++ b/src/core/aprs/AprsSettings.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <QJsonObject>
+#include <QString>
+
+namespace AetherSDR {
+
+// Persistence for the AetherModem APRS client. Per Constitution Principle V,
+// the configuration lives as one nested JSON blob under a single AppSettings
+// key ("AetherModemAprs") rather than a stack of flat entries. Mirrors the
+// TncSettings pattern in Ax25HfPacketDecodeDialog.h.
+class AprsSettings {
+public:
+    static constexpr int kDefaultBeaconIntervalMin = 30;
+
+    static QString myCall();             // "" until the operator sets one
+    static bool beaconEnabled();
+    static int beaconIntervalMinutes();  // clamped to [1, 1440]
+    static QString beaconText();
+    static QString symbol();             // two chars: table + code, e.g. "/-"
+    static QString path();               // "WIDE1-1,WIDE2-1"
+    static QString manualLat();          // decimal degrees as text, "" unset
+    static QString manualLon();
+
+    static void setMyCall(const QString& call);
+    static void setBeaconEnabled(bool on);
+    static void setBeaconIntervalMinutes(int minutes);
+    static void setBeaconText(const QString& text);
+    static void setSymbol(const QString& tableAndCode);
+    static void setPath(const QString& path);
+    static void setManualPosition(const QString& lat, const QString& lon);
+
+private:
+    static QJsonObject readObj();
+    static void write(const QJsonObject& o);
+    static void setString(const char* key, const QString& value);
+};
+
+} // namespace AetherSDR

--- a/src/core/aprs/AprsStationList.cpp
+++ b/src/core/aprs/AprsStationList.cpp
@@ -5,6 +5,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QSaveFile>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -225,13 +226,19 @@ void AprsStationList::save() const
     }
     QJsonObject root;
     root.insert(QStringLiteral("stations"), arr);
-    QFile f(m_path);
+    // QSaveFile writes to a temp file and atomically renames on commit() so an
+    // unclean shutdown mid-write can't truncate or corrupt the roster
+    // (Constitution Principle XIV — Persist Atomically).
+    QSaveFile f(m_path);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
         qCWarning(lcAx25).noquote()
             << "AprsStationList: could not write" << m_path << "—" << f.errorString();
         return;
     }
     f.write(QJsonDocument(root).toJson());
+    if (!f.commit())
+        qCWarning(lcAx25).noquote()
+            << "AprsStationList: could not commit" << m_path << "—" << f.errorString();
 }
 
 } // namespace AetherSDR

--- a/src/core/aprs/AprsStationList.cpp
+++ b/src/core/aprs/AprsStationList.cpp
@@ -89,10 +89,23 @@ bool AprsStationList::record(const aprs::Packet& packet)
     }
     // Free text merges instead of overwriting: a status report shouldn't
     // blank the comment a position packet carried a minute earlier.
-    if (packet.type == aprs::PacketType::Status)
+    if (packet.type == aprs::PacketType::Status) {
         hit->status = packet.comment;
-    else if (!packet.comment.isEmpty() && packet.type == aprs::PacketType::Position)
+    } else if (packet.type == aprs::PacketType::Weather) {
+        hit->isWeather = true;
+        if (!packet.comment.isEmpty())
+            hit->comment = packet.comment; // pre-formatted weatherSummary()
+        // Condition drives the wireframe icon: rain beats wind beats cloud.
+        if (packet.weather.rainHourIn > 0.0 || packet.weather.rain24hIn > 0.0)
+            hit->wxCondition = 1;
+        else if (packet.weather.gustMph >= 20.0 || packet.weather.windMph >= 15.0)
+            hit->wxCondition = 2;
+        else
+            hit->wxCondition = 0;
+    } else if (!packet.comment.isEmpty()
+               && packet.type == aprs::PacketType::Position) {
         hit->comment = packet.comment;
+    }
 
     if (m_stations.size() > m_max) {
         std::sort(m_stations.begin(), m_stations.end(),
@@ -170,6 +183,8 @@ void AprsStationList::load()
         s.speedKnots = o.value(QStringLiteral("speedKnots")).toDouble(-1.0);
         s.hasAltitude = o.value(QStringLiteral("hasAltitude")).toBool();
         s.altitudeFeet = o.value(QStringLiteral("altitudeFeet")).toDouble();
+        s.isWeather = o.value(QStringLiteral("isWeather")).toBool();
+        s.wxCondition = o.value(QStringLiteral("wxCondition")).toInt();
         s.comment = o.value(QStringLiteral("comment")).toString();
         s.status = o.value(QStringLiteral("status")).toString();
         s.via = o.value(QStringLiteral("via")).toString();
@@ -200,6 +215,8 @@ void AprsStationList::save() const
         o.insert(QStringLiteral("speedKnots"), s.speedKnots);
         o.insert(QStringLiteral("hasAltitude"), s.hasAltitude);
         o.insert(QStringLiteral("altitudeFeet"), s.altitudeFeet);
+        o.insert(QStringLiteral("isWeather"), s.isWeather);
+        o.insert(QStringLiteral("wxCondition"), s.wxCondition);
         o.insert(QStringLiteral("comment"), s.comment);
         o.insert(QStringLiteral("status"), s.status);
         o.insert(QStringLiteral("via"), s.via);

--- a/src/core/aprs/AprsStationList.cpp
+++ b/src/core/aprs/AprsStationList.cpp
@@ -1,0 +1,220 @@
+#include "core/aprs/AprsStationList.h"
+
+#include "core/LogManager.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLoggingCategory>
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+AprsStationList::AprsStationList(QObject* parent)
+    : QObject(parent)
+{
+    m_saveCoalesce.setSingleShot(true);
+    m_saveCoalesce.setInterval(2000); // fold a digi burst into one rewrite
+    connect(&m_saveCoalesce, &QTimer::timeout, this, [this] { save(); });
+}
+
+AprsStationList::~AprsStationList()
+{
+    if (m_saveCoalesce.isActive()) {
+        m_saveCoalesce.stop();
+        save();
+    }
+}
+
+void AprsStationList::setPersistencePath(const QString& path)
+{
+    m_path = path;
+    if (!m_path.isEmpty())
+        load();
+}
+
+bool AprsStationList::record(const aprs::Packet& packet)
+{
+    if (packet.source.isEmpty())
+        return false;
+
+    const QDateTime now = QDateTime::currentDateTimeUtc();
+    const QString via = packet.path.join(QLatin1Char(','));
+
+    Station* hit = nullptr;
+    for (Station& s : m_stations) {
+        if (s.call.compare(packet.source, Qt::CaseInsensitive) == 0) {
+            hit = &s;
+            break;
+        }
+    }
+
+    // Digipeated duplicate: the same transmission relayed by another hop
+    // arrives with identical source + info within seconds of the original.
+    if (hit && hit->lastInfo == packet.infoText
+        && hit->lastHeard.secsTo(now) <= kDupeWindowSecs)
+        return false;
+
+    if (!hit) {
+        Station s;
+        s.call = packet.source;
+        s.firstHeard = now;
+        m_stations.append(s);
+        hit = &m_stations.last();
+    }
+
+    hit->lastHeard = now;
+    hit->packets += 1;
+    hit->via = via;
+    hit->lastInfo = packet.infoText;
+    hit->lastType = packet.type;
+
+    if (packet.hasPosition) {
+        hit->hasPosition = true;
+        hit->latitude = packet.latitude;
+        hit->longitude = packet.longitude;
+        hit->positionUtc = now;
+        hit->symbolTable = packet.symbolTable;
+        hit->symbolCode = packet.symbolCode;
+        hit->courseDeg = packet.courseDeg;
+        hit->speedKnots = packet.speedKnots;
+        if (packet.hasAltitude) {
+            hit->hasAltitude = true;
+            hit->altitudeFeet = packet.altitudeFeet;
+        }
+    }
+    // Free text merges instead of overwriting: a status report shouldn't
+    // blank the comment a position packet carried a minute earlier.
+    if (packet.type == aprs::PacketType::Status)
+        hit->status = packet.comment;
+    else if (!packet.comment.isEmpty() && packet.type == aprs::PacketType::Position)
+        hit->comment = packet.comment;
+
+    if (m_stations.size() > m_max) {
+        std::sort(m_stations.begin(), m_stations.end(),
+                  [](const Station& a, const Station& b) {
+                      return a.lastHeard > b.lastHeard;
+                  });
+        m_stations.resize(m_max);
+    }
+    scheduleSave();
+    emit changed();
+    return true;
+}
+
+QVector<AprsStationList::Station> AprsStationList::stations() const
+{
+    QVector<Station> sorted = m_stations;
+    std::sort(sorted.begin(), sorted.end(),
+              [](const Station& a, const Station& b) {
+                  return a.lastHeard > b.lastHeard;
+              });
+    return sorted;
+}
+
+std::optional<AprsStationList::Station> AprsStationList::find(const QString& call) const
+{
+    for (const Station& s : m_stations) {
+        if (s.call.compare(call, Qt::CaseInsensitive) == 0)
+            return s;
+    }
+    return std::nullopt;
+}
+
+void AprsStationList::clear()
+{
+    m_stations.clear();
+    save();
+    emit changed();
+}
+
+void AprsStationList::scheduleSave()
+{
+    if (m_path.isEmpty())
+        return;
+    m_saveCoalesce.start();
+}
+
+void AprsStationList::load()
+{
+    m_stations.clear();
+    QFile f(m_path);
+    if (!f.open(QIODevice::ReadOnly))
+        return;
+    const QJsonObject root = QJsonDocument::fromJson(f.readAll()).object();
+    for (const QJsonValue& v : root.value(QStringLiteral("stations")).toArray()) {
+        const QJsonObject o = v.toObject();
+        Station s;
+        s.call = o.value(QStringLiteral("call")).toString();
+        if (s.call.isEmpty())
+            continue;
+        s.firstHeard = QDateTime::fromString(
+            o.value(QStringLiteral("firstHeard")).toString(), Qt::ISODate);
+        s.lastHeard = QDateTime::fromString(
+            o.value(QStringLiteral("lastHeard")).toString(), Qt::ISODate);
+        s.packets = o.value(QStringLiteral("packets")).toInt(1);
+        s.hasPosition = o.value(QStringLiteral("hasPosition")).toBool();
+        s.latitude = o.value(QStringLiteral("lat")).toDouble();
+        s.longitude = o.value(QStringLiteral("lon")).toDouble();
+        s.positionUtc = QDateTime::fromString(
+            o.value(QStringLiteral("positionUtc")).toString(), Qt::ISODate);
+        const QString table = o.value(QStringLiteral("symbolTable")).toString("/");
+        const QString code = o.value(QStringLiteral("symbolCode")).toString("-");
+        s.symbolTable = table.isEmpty() ? '/' : table.at(0).toLatin1();
+        s.symbolCode = code.isEmpty() ? '-' : code.at(0).toLatin1();
+        s.courseDeg = o.value(QStringLiteral("courseDeg")).toDouble(-1.0);
+        s.speedKnots = o.value(QStringLiteral("speedKnots")).toDouble(-1.0);
+        s.hasAltitude = o.value(QStringLiteral("hasAltitude")).toBool();
+        s.altitudeFeet = o.value(QStringLiteral("altitudeFeet")).toDouble();
+        s.comment = o.value(QStringLiteral("comment")).toString();
+        s.status = o.value(QStringLiteral("status")).toString();
+        s.via = o.value(QStringLiteral("via")).toString();
+        s.lastInfo = o.value(QStringLiteral("lastInfo")).toString();
+        m_stations.append(s);
+    }
+}
+
+void AprsStationList::save() const
+{
+    if (m_path.isEmpty())
+        return;
+    QDir().mkpath(QFileInfo(m_path).absolutePath());
+    QJsonArray arr;
+    for (const Station& s : m_stations) {
+        QJsonObject o;
+        o.insert(QStringLiteral("call"), s.call);
+        o.insert(QStringLiteral("firstHeard"), s.firstHeard.toString(Qt::ISODate));
+        o.insert(QStringLiteral("lastHeard"), s.lastHeard.toString(Qt::ISODate));
+        o.insert(QStringLiteral("packets"), s.packets);
+        o.insert(QStringLiteral("hasPosition"), s.hasPosition);
+        o.insert(QStringLiteral("lat"), s.latitude);
+        o.insert(QStringLiteral("lon"), s.longitude);
+        o.insert(QStringLiteral("positionUtc"), s.positionUtc.toString(Qt::ISODate));
+        o.insert(QStringLiteral("symbolTable"), QString(QLatin1Char(s.symbolTable)));
+        o.insert(QStringLiteral("symbolCode"), QString(QLatin1Char(s.symbolCode)));
+        o.insert(QStringLiteral("courseDeg"), s.courseDeg);
+        o.insert(QStringLiteral("speedKnots"), s.speedKnots);
+        o.insert(QStringLiteral("hasAltitude"), s.hasAltitude);
+        o.insert(QStringLiteral("altitudeFeet"), s.altitudeFeet);
+        o.insert(QStringLiteral("comment"), s.comment);
+        o.insert(QStringLiteral("status"), s.status);
+        o.insert(QStringLiteral("via"), s.via);
+        o.insert(QStringLiteral("lastInfo"), s.lastInfo);
+        arr.append(o);
+    }
+    QJsonObject root;
+    root.insert(QStringLiteral("stations"), arr);
+    QFile f(m_path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        qCWarning(lcAx25).noquote()
+            << "AprsStationList: could not write" << m_path << "—" << f.errorString();
+        return;
+    }
+    f.write(QJsonDocument(root).toJson());
+}
+
+} // namespace AetherSDR

--- a/src/core/aprs/AprsStationList.h
+++ b/src/core/aprs/AprsStationList.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "core/aprs/AprsPacket.h"
+
+#include <QDateTime>
+#include <QObject>
+#include <QString>
+#include <QTimer>
+#include <QVector>
+
+namespace AetherSDR {
+
+// The APRS station roster behind the station table: every station heard,
+// with its most recent position, movement, and free-text data merged across
+// packets (a Mic-E position and a separate status report both land on the
+// same row). Digipeated duplicates of one transmission are suppressed so
+// packet counts reflect originated traffic, not how many copies we heard.
+// Follows the HeardList persistence pattern: optional JSON file, writes
+// coalesced through a single-shot timer.
+class AprsStationList : public QObject {
+    Q_OBJECT
+
+public:
+    struct Station {
+        QString call;            // "N0CALL-9"
+        QDateTime firstHeard;    // UTC
+        QDateTime lastHeard;     // UTC
+        int packets{0};
+
+        bool hasPosition{false};
+        double latitude{0.0};
+        double longitude{0.0};
+        QDateTime positionUtc;
+        char symbolTable{'/'};
+        char symbolCode{'-'};
+        double courseDeg{-1.0};  // < 0 when unknown
+        double speedKnots{-1.0}; // < 0 when unknown
+        bool hasAltitude{false};
+        double altitudeFeet{0.0};
+
+        QString comment;         // last position comment
+        QString status;          // last '>' status text
+        QString via;             // last digipeater path, comma-joined
+        QString lastInfo;        // raw info field of the last packet
+        aprs::PacketType lastType{aprs::PacketType::Other};
+    };
+
+    explicit AprsStationList(QObject* parent = nullptr);
+    ~AprsStationList() override;
+
+    // Empty path (the default) keeps the list in-memory only.
+    void setPersistencePath(const QString& path);
+    void setMaxStations(int n) { m_max = qBound(10, n, 5000); }
+
+    // Merge a parsed packet into the roster. Returns false when the packet
+    // was dropped as a digipeated duplicate.
+    bool record(const aprs::Packet& packet);
+
+    // Stations, most-recently-heard first.
+    QVector<Station> stations() const;
+    std::optional<Station> find(const QString& call) const;
+
+    int size() const { return m_stations.size(); }
+    void clear();
+
+signals:
+    void changed();
+
+private:
+    void load();
+    void save() const;
+    void scheduleSave();
+
+    QVector<Station> m_stations;
+    QString m_path;
+    int m_max{500};
+    QTimer m_saveCoalesce; // single-shot, ~2 s; restarts on each scheduleSave()
+
+    // Duplicate suppression: a WIDE2 digipeat delivers the same source+info
+    // seconds after the direct copy. Remember the last payload per station
+    // and drop repeats inside the window.
+    static constexpr int kDupeWindowSecs = 30;
+};
+
+} // namespace AetherSDR

--- a/src/core/aprs/AprsStationList.h
+++ b/src/core/aprs/AprsStationList.h
@@ -38,7 +38,11 @@ public:
         bool hasAltitude{false};
         double altitudeFeet{0.0};
 
-        QString comment;         // last position comment
+        // Weather station data: comment holds the readable weatherSummary().
+        bool isWeather{false};
+        int wxCondition{0};      // aprsicons weather condition (cloud/rain/wind)
+
+        QString comment;         // last position comment / weather summary
         QString status;          // last '>' status text
         QString via;             // last digipeater path, comma-joined
         QString lastInfo;        // raw info field of the last packet

--- a/src/gui/AprsMessagesDialog.cpp
+++ b/src/gui/AprsMessagesDialog.cpp
@@ -1,0 +1,155 @@
+#include "AprsMessagesDialog.h"
+
+#include "core/ThemeManager.h"
+#include "core/aprs/AprsMessenger.h"
+
+#include <QColor>
+#include <QHeaderView>
+#include <QShowEvent>
+#include <QTableWidget>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+namespace {
+
+// Visual language matches kAetherModemStyle in Ax25HfPacketDecodeDialog.cpp —
+// this window is an extension of the AetherModem APRS tab.
+constexpr const char* kMessagesStyle = R"(
+QWidget {
+    color: #aeb9cc;
+    background: #07101c;
+    font-size: 14px;
+}
+QTableWidget {
+    color: #c2ccdb;
+    background: #050b13;
+    border: 1px solid #233246;
+    border-radius: 7px;
+    gridline-color: #14202f;
+    font-family: "SF Mono", "Menlo", "Consolas", monospace;
+    font-size: 13px;
+    selection-background-color: #1b3650;
+}
+QHeaderView::section {
+    color: #8d99ad;
+    background: #0d1825;
+    border: none;
+    border-bottom: 1px solid #233246;
+    padding: 6px 8px;
+    font-size: 11px;
+    font-weight: 700;
+}
+QTableCornerButton::section {
+    background: #0d1825;
+    border: none;
+}
+QScrollBar:vertical {
+    background: #07101c;
+    width: 12px;
+    margin: 8px 2px 8px 2px;
+    border-radius: 6px;
+}
+QScrollBar::handle:vertical {
+    background: #25364d;
+    border-radius: 5px;
+    min-height: 34px;
+}
+QScrollBar::add-line:vertical,
+QScrollBar::sub-line:vertical {
+    height: 0px;
+}
+)";
+
+QString stateText(const AprsMessenger::Message& m)
+{
+    if (!m.outgoing)
+        return m.read ? QString() : QStringLiteral("new");
+    switch (m.state) {
+    case AprsMessenger::State::Pending:  return QStringLiteral("queued");
+    case AprsMessenger::State::Sent:     return QStringLiteral("sent (try %1)").arg(m.tries);
+    case AprsMessenger::State::Acked:    return QStringLiteral("✓ acked");
+    case AprsMessenger::State::Rejected: return QStringLiteral("✗ rejected");
+    case AprsMessenger::State::Failed:   return QStringLiteral("✗ no ack");
+    case AprsMessenger::State::Received: return QString();
+    }
+    return QString();
+}
+
+} // namespace
+
+AprsMessagesDialog::AprsMessagesDialog(AprsMessenger* messenger, QWidget* parent)
+    : PersistentDialog(QStringLiteral("APRS Messages"),
+                       QStringLiteral("AprsMessagesDialogGeometry"),
+                       parent)
+    , m_messenger(messenger)
+{
+    theme::setContainer(this, QStringLiteral("dialog/ax25Decode"));
+    setMinimumSize(620, 320);
+    bodyWidget()->setStyleSheet(QString::fromLatin1(kMessagesStyle));
+
+    auto* root = new QVBoxLayout(bodyWidget());
+    m_table = new QTableWidget(bodyWidget());
+    m_table->setColumnCount(5);
+    m_table->setHorizontalHeaderLabels({
+        QStringLiteral("TIME (UTC)"), QStringLiteral(""),
+        QStringLiteral("STATION"), QStringLiteral("MESSAGE"),
+        QStringLiteral("STATUS"),
+    });
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_table->verticalHeader()->setVisible(false);
+    m_table->setShowGrid(false);
+    m_table->horizontalHeader()->setStretchLastSection(false);
+    m_table->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Stretch);
+    m_table->setWordWrap(false);
+    root->addWidget(m_table);
+
+    connect(m_table, &QTableWidget::cellDoubleClicked, this, [this](int row, int) {
+        if (auto* item = m_table->item(row, 2))
+            emit replyRequested(item->text());
+    });
+    if (m_messenger) {
+        connect(m_messenger, &AprsMessenger::messagesChanged,
+                this, &AprsMessagesDialog::rebuild);
+    }
+    rebuild();
+}
+
+void AprsMessagesDialog::showEvent(QShowEvent* event)
+{
+    PersistentDialog::showEvent(event);
+    // Opening the envelope is what "reading" means here.
+    if (m_messenger)
+        m_messenger->markAllRead();
+}
+
+void AprsMessagesDialog::rebuild()
+{
+    if (!m_messenger)
+        return;
+    const QVector<AprsMessenger::Message> messages = m_messenger->messages();
+    m_table->setRowCount(messages.size());
+    for (int i = 0; i < messages.size(); ++i) {
+        const AprsMessenger::Message& m = messages.at(i);
+        auto set = [&](int col, const QString& text) {
+            auto* item = new QTableWidgetItem(text);
+            if (m.outgoing)
+                item->setForeground(QColor(0x8d, 0xc5, 0xff));
+            else if (!m.read)
+                item->setForeground(QColor(0x80, 0xed, 0x91));
+            m_table->setItem(i, col, item);
+        };
+        set(0, m.utc.toString(QStringLiteral("MM/dd HH:mm:ss")));
+        set(1, m.outgoing ? QStringLiteral("→") : QStringLiteral("←"));
+        set(2, m.counterpart);
+        set(3, m.text);
+        set(4, stateText(m));
+    }
+    m_table->resizeColumnsToContents();
+    m_table->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Stretch);
+    m_table->scrollToBottom();
+}
+
+} // namespace AetherSDR

--- a/src/gui/AprsMessagesDialog.h
+++ b/src/gui/AprsMessagesDialog.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "PersistentDialog.h"
+
+class QShowEvent;
+class QTableWidget;
+
+namespace AetherSDR {
+
+class AprsMessenger;
+
+// The envelope window: every APRS message sent or received, newest last,
+// with delivery state for outgoing traffic (sent / acked / failed). Opening
+// the dialog marks everything read, which clears the unread badge on the
+// envelope button in AetherModem's APRS tab. Double-clicking a row asks the
+// owner to prefill a reply to that station.
+class AprsMessagesDialog : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    explicit AprsMessagesDialog(AprsMessenger* messenger, QWidget* parent = nullptr);
+
+signals:
+    // Emitted on row double-click; the AetherModem dialog prefills the
+    // message "To" field with this callsign and focuses the text entry.
+    void replyRequested(const QString& callsign);
+
+protected:
+    void showEvent(QShowEvent* event) override;
+
+private:
+    void rebuild();
+
+    AprsMessenger* m_messenger{nullptr};
+    QTableWidget* m_table{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/AprsSymbolIcons.cpp
+++ b/src/gui/AprsSymbolIcons.cpp
@@ -295,6 +295,13 @@ void drawPhone(QPainter& p)
     p.drawRect(QRectF(5.2, 7.4, 5.6, 6.4)); // base
 }
 
+void drawWindyCloud(QPainter& p)
+{
+    drawCloud(p);
+    p.drawLine(QPointF(3.4, 12.8), QPointF(9.4, 12.8));
+    p.drawLine(QPointF(6, 14.6), QPointF(12.6, 14.6));
+}
+
 // Fallback: rounded badge with the raw symbol character.
 void drawBadge(QPainter& p, char code, const QColor& color)
 {
@@ -310,10 +317,20 @@ void drawBadge(QPainter& p, char code, const QColor& color)
 
 } // namespace
 
+namespace {
+
+QHash<quint64, QIcon>& iconCache()
+{
+    static QHash<quint64, QIcon> cache;
+    return cache;
+}
+
+} // namespace
+
 QIcon symbolIcon(char symbolTable, char symbolCode, const QColor& color)
 {
     Q_UNUSED(symbolTable); // alternate-table codes share the primary drawing
-    static QHash<quint64, QIcon> cache;
+    QHash<quint64, QIcon>& cache = iconCache();
     const quint64 key = (quint64(quint8(symbolCode)) << 32) | color.rgba();
     if (const auto it = cache.constFind(key); it != cache.constEnd())
         return it.value();
@@ -357,6 +374,35 @@ QIcon symbolIcon(char symbolTable, char symbolCode, const QColor& color)
         case '=':  drawTrain(p); break;
         case '$':  drawPhone(p); break;
         default:   drawBadge(p, symbolCode, color); break;
+        }
+    }
+    const QIcon icon(pm);
+    cache.insert(key, icon);
+    return icon;
+}
+
+QIcon weatherIcon(int condition, const QColor& color)
+{
+    condition = qBound(0, condition, 2);
+    QHash<quint64, QIcon>& cache = iconCache();
+    // Conditions cache under control-character pseudo-codes 0x01-0x03, which
+    // can never collide with printable APRS symbol codes.
+    const quint64 key = (quint64(quint8(condition + 1)) << 32) | color.rgba();
+    if (const auto it = cache.constFind(key); it != cache.constEnd())
+        return it.value();
+
+    QPixmap pm(int(kLogicalSize * kDpr), int(kLogicalSize * kDpr));
+    pm.setDevicePixelRatio(kDpr);
+    pm.fill(Qt::transparent);
+    {
+        QPainter p(&pm);
+        p.setRenderHint(QPainter::Antialiasing, true);
+        p.setPen(QPen(color, 1.4, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+        p.setBrush(Qt::NoBrush);
+        switch (condition) {
+        case 1:  drawWxStation(p); break;  // cloud with rain
+        case 2:  drawWindyCloud(p); break; // cloud with wind streaks
+        default: drawCloud(p); break;
         }
     }
     const QIcon icon(pm);

--- a/src/gui/AprsSymbolIcons.cpp
+++ b/src/gui/AprsSymbolIcons.cpp
@@ -1,0 +1,367 @@
+#include "AprsSymbolIcons.h"
+
+#include <QHash>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPixmap>
+
+namespace AetherSDR::aprsicons {
+
+namespace {
+
+// All shapes are sketched on a 16x16 logical canvas, rendered at 2x.
+constexpr int kLogicalSize = 16;
+constexpr qreal kDpr = 2.0;
+
+void drawHouse(QPainter& p)
+{
+    QPainterPath roof;
+    roof.moveTo(2, 8);
+    roof.lineTo(8, 2.5);
+    roof.lineTo(14, 8);
+    p.drawPath(roof);
+    p.drawRect(QRectF(3.5, 8, 9, 5.5));
+    p.drawRect(QRectF(6.8, 10, 2.4, 3.5)); // door
+}
+
+void drawWheels(QPainter& p, qreal x1, qreal x2, qreal y, qreal r)
+{
+    p.drawEllipse(QPointF(x1, y), r, r);
+    p.drawEllipse(QPointF(x2, y), r, r);
+}
+
+void drawCar(QPainter& p)
+{
+    QPainterPath body;
+    body.moveTo(2, 11);
+    body.lineTo(2, 9.2);
+    body.lineTo(4.6, 8.6);
+    body.lineTo(6.2, 6);
+    body.lineTo(10.2, 6);
+    body.lineTo(11.8, 8.6);
+    body.lineTo(14, 9.2);
+    body.lineTo(14, 11);
+    p.drawPath(body);
+    drawWheels(p, 5, 11, 11.3, 1.7);
+}
+
+void drawJeep(QPainter& p)
+{
+    p.drawRect(QRectF(2.5, 6.5, 11, 4.5)); // flat box body
+    p.drawLine(QPointF(5, 6.5), QPointF(5, 11));   // windshield post
+    p.drawLine(QPointF(2.5, 8.5), QPointF(5, 8.5)); // hood line
+    drawWheels(p, 5, 11.2, 11.6, 1.7);
+}
+
+void drawPickup(QPainter& p)
+{
+    QPainterPath body;
+    body.moveTo(2, 11);
+    body.lineTo(2, 6.5);
+    body.lineTo(7, 6.5);
+    body.lineTo(8.5, 8.6);
+    body.lineTo(14, 8.6);
+    body.lineTo(14, 11);
+    p.drawPath(body);
+    drawWheels(p, 4.6, 11.4, 11.3, 1.7);
+}
+
+void drawSemi(QPainter& p)
+{
+    p.drawRect(QRectF(2, 7.5, 3.6, 3.7));  // cab
+    p.drawRect(QRectF(6.2, 5.5, 7.8, 5.7)); // trailer
+    p.drawEllipse(QPointF(3.8, 12.3), 1.4, 1.4);
+    p.drawEllipse(QPointF(8.4, 12.3), 1.4, 1.4);
+    p.drawEllipse(QPointF(12, 12.3), 1.4, 1.4);
+}
+
+void drawVan(QPainter& p)
+{
+    QPainterPath body;
+    body.addRoundedRect(QRectF(2, 5.8, 12, 5.4), 2, 2);
+    p.drawPath(body);
+    p.drawLine(QPointF(4.8, 5.8), QPointF(4.8, 11.2)); // windshield divide
+    drawWheels(p, 5, 11.2, 11.5, 1.6);
+}
+
+void drawRv(QPainter& p)
+{
+    p.drawRect(QRectF(2, 5, 12, 6.5));
+    p.drawRect(QRectF(4, 6.8, 2.2, 2.2));   // window
+    p.drawRect(QRectF(7.5, 6.8, 2.2, 2.2)); // window
+    drawWheels(p, 5, 11.5, 11.8, 1.5);
+}
+
+void drawMotorcycle(QPainter& p)
+{
+    drawWheels(p, 4, 12, 11, 2.2);
+    p.drawLine(QPointF(4, 11), QPointF(8, 8));
+    p.drawLine(QPointF(8, 8), QPointF(12, 11));
+    p.drawLine(QPointF(10.5, 6), QPointF(12, 11)); // fork
+    p.drawLine(QPointF(9.5, 6), QPointF(11.5, 6)); // handlebar
+}
+
+void drawBicycle(QPainter& p)
+{
+    drawWheels(p, 4.2, 11.8, 11, 2.4);
+    p.drawLine(QPointF(4.2, 11), QPointF(7, 7));    // seat tube
+    p.drawLine(QPointF(7, 7), QPointF(11, 7));      // top tube
+    p.drawLine(QPointF(11, 7), QPointF(11.8, 11));  // fork
+    p.drawLine(QPointF(7, 7), QPointF(8.6, 11));    // down tube
+    p.drawLine(QPointF(8.6, 11), QPointF(4.2, 11)); // chain stay
+}
+
+void drawJogger(QPainter& p)
+{
+    p.drawEllipse(QPointF(8.6, 3.4), 1.6, 1.6);     // head
+    p.drawLine(QPointF(8.2, 5), QPointF(7.4, 9));   // torso
+    p.drawLine(QPointF(8, 6), QPointF(11, 7.4));    // front arm
+    p.drawLine(QPointF(8, 6.4), QPointF(5.4, 7.6)); // back arm
+    p.drawLine(QPointF(7.4, 9), QPointF(10.4, 11.4)); // front leg
+    p.drawLine(QPointF(10.4, 11.4), QPointF(11, 13.6));
+    p.drawLine(QPointF(7.4, 9), QPointF(5.6, 11.6)); // back leg
+    p.drawLine(QPointF(5.6, 11.6), QPointF(3.6, 12.4));
+}
+
+void drawPowerBoat(QPainter& p)
+{
+    QPainterPath hull;
+    hull.moveTo(2, 9);
+    hull.lineTo(14, 9);
+    hull.lineTo(11.6, 12.4);
+    hull.lineTo(4, 12.4);
+    hull.closeSubpath();
+    p.drawPath(hull);
+    p.drawRect(QRectF(5.5, 6, 4, 3)); // cabin
+}
+
+void drawSailboat(QPainter& p)
+{
+    p.drawLine(QPointF(8.5, 2), QPointF(8.5, 10)); // mast
+    QPainterPath sail;
+    sail.moveTo(8.5, 2.5);
+    sail.lineTo(8.5, 9.4);
+    sail.lineTo(3.4, 9.4);
+    sail.closeSubpath();
+    p.drawPath(sail);
+    QPainterPath hull;
+    hull.moveTo(2.6, 10.6);
+    hull.lineTo(13.4, 10.6);
+    hull.lineTo(11.4, 13.2);
+    hull.lineTo(4.6, 13.2);
+    hull.closeSubpath();
+    p.drawPath(hull);
+}
+
+void drawAircraft(QPainter& p)
+{
+    // Top view: vertical fuselage, straight wing, small tailplane.
+    p.drawLine(QPointF(8, 2), QPointF(8, 13.4));
+    p.drawLine(QPointF(2, 7), QPointF(14, 7));      // wing
+    p.drawLine(QPointF(5.6, 12.2), QPointF(10.4, 12.2)); // tail
+    p.drawEllipse(QPointF(8, 2.6), 0.9, 0.9);       // nose
+}
+
+void drawHelicopter(QPainter& p)
+{
+    p.drawEllipse(QRectF(4, 7, 7, 4));               // body
+    p.drawLine(QPointF(2, 4.4), QPointF(13.4, 4.4)); // rotor
+    p.drawLine(QPointF(7.5, 7), QPointF(7.5, 4.4));  // mast
+    p.drawLine(QPointF(11, 9), QPointF(14, 8));      // tail boom
+    p.drawLine(QPointF(4.4, 12.6), QPointF(11, 12.6)); // skid
+}
+
+void drawBalloon(QPainter& p)
+{
+    p.drawEllipse(QPointF(8, 5.6), 3.8, 3.8);
+    p.drawLine(QPointF(5.6, 8.6), QPointF(6.8, 11.8));
+    p.drawLine(QPointF(10.4, 8.6), QPointF(9.2, 11.8));
+    p.drawRect(QRectF(6.6, 11.8, 2.8, 2));
+}
+
+void drawTower(QPainter& p)
+{
+    p.drawLine(QPointF(8, 3), QPointF(4.6, 13.6));
+    p.drawLine(QPointF(8, 3), QPointF(11.4, 13.6));
+    p.drawLine(QPointF(6.5, 7.6), QPointF(9.5, 7.6));
+    p.drawLine(QPointF(5.6, 10.6), QPointF(10.4, 10.6));
+    p.drawLine(QPointF(6.5, 7.6), QPointF(10.4, 10.6));
+    p.drawLine(QPointF(9.5, 7.6), QPointF(5.6, 10.6));
+}
+
+void drawRepeater(QPainter& p)
+{
+    drawTower(p);
+    // Radio waves off the top.
+    p.drawArc(QRectF(5, 0.6, 6, 5), 30 * 16, 120 * 16);
+    p.drawArc(QRectF(3.4, -1, 9.2, 8), 30 * 16, 120 * 16);
+}
+
+void drawYagi(QPainter& p)
+{
+    p.drawLine(QPointF(8, 14), QPointF(8, 7));       // mast
+    p.drawLine(QPointF(3, 7), QPointF(13, 7));       // boom (slight up-tilt skipped)
+    p.drawLine(QPointF(4.2, 4.6), QPointF(4.2, 9.4));   // reflector
+    p.drawLine(QPointF(8, 5), QPointF(8, 9));            // driven element
+    p.drawLine(QPointF(11.6, 5.4), QPointF(11.6, 8.6));  // director
+}
+
+void drawCloud(QPainter& p)
+{
+    QPainterPath cloud;
+    cloud.moveTo(3.4, 10.4);
+    cloud.arcTo(QRectF(2, 7.8, 4, 4), 90, 180);
+    cloud.arcTo(QRectF(3.6, 5.2, 5, 5), 160, -140);
+    cloud.arcTo(QRectF(7.6, 4.6, 5.4, 5.4), 150, -150);
+    cloud.arcTo(QRectF(10.4, 7.6, 4, 4.2), 90, -180);
+    cloud.closeSubpath();
+    p.drawPath(cloud);
+}
+
+void drawWxStation(QPainter& p)
+{
+    drawCloud(p);
+    p.drawLine(QPointF(5.4, 12.6), QPointF(4.6, 14.6));
+    p.drawLine(QPointF(8.2, 12.6), QPointF(7.4, 14.6));
+    p.drawLine(QPointF(11, 12.6), QPointF(10.2, 14.6));
+}
+
+void drawWxService(QPainter& p)
+{
+    drawCloud(p);
+    QPainterPath bolt;
+    bolt.moveTo(8.8, 11.6);
+    bolt.lineTo(6.8, 13.6);
+    bolt.lineTo(8.2, 13.8);
+    bolt.lineTo(7, 15.6);
+    p.drawPath(bolt);
+}
+
+void drawAmbulance(QPainter& p)
+{
+    p.drawRect(QRectF(2, 6, 12, 5.4));
+    p.drawLine(QPointF(8, 7.2), QPointF(8, 10.2));   // cross
+    p.drawLine(QPointF(6.5, 8.7), QPointF(9.5, 8.7));
+    drawWheels(p, 4.8, 11.4, 11.7, 1.5);
+}
+
+void drawFireTruck(QPainter& p)
+{
+    p.drawRect(QRectF(2, 6.5, 12, 4.9));
+    p.drawLine(QPointF(3.4, 5), QPointF(12, 5));     // ladder
+    p.drawLine(QPointF(5, 5), QPointF(5, 6.5));
+    p.drawLine(QPointF(8, 5), QPointF(8, 6.5));
+    p.drawLine(QPointF(10.6, 5), QPointF(10.6, 6.5));
+    drawWheels(p, 4.8, 11.4, 11.7, 1.5);
+}
+
+void drawShield(QPainter& p)
+{
+    QPainterPath shield;
+    shield.moveTo(8, 2.4);
+    shield.cubicTo(10, 3.8, 12, 4.2, 13.2, 4.2);
+    shield.cubicTo(13.2, 9.6, 11.4, 12.4, 8, 14);
+    shield.cubicTo(4.6, 12.4, 2.8, 9.6, 2.8, 4.2);
+    shield.cubicTo(4, 4.2, 6, 3.8, 8, 2.4);
+    p.drawPath(shield);
+}
+
+void drawBus(QPainter& p)
+{
+    QPainterPath body;
+    body.addRoundedRect(QRectF(2, 4.8, 12, 6.6), 1.6, 1.6);
+    p.drawPath(body);
+    p.drawLine(QPointF(2, 7.6), QPointF(14, 7.6)); // window line
+    drawWheels(p, 4.8, 11.4, 11.9, 1.5);
+}
+
+void drawTrain(QPainter& p)
+{
+    p.drawRect(QRectF(3, 4, 10, 7));
+    p.drawRect(QRectF(5, 5.6, 6, 2.2)); // window band
+    p.drawEllipse(QPointF(5.6, 12.6), 1.3, 1.3);
+    p.drawEllipse(QPointF(10.4, 12.6), 1.3, 1.3);
+    p.drawLine(QPointF(2, 14.2), QPointF(14, 14.2)); // rail
+}
+
+void drawPhone(QPainter& p)
+{
+    QPainterPath handset;
+    handset.moveTo(3.4, 5.6);
+    handset.arcTo(QRectF(2.6, 3, 4, 4), 130, 140);
+    handset.lineTo(11.2, 3.8);
+    handset.arcTo(QRectF(9.4, 3, 4, 4), 90, -140);
+    p.drawPath(handset);
+    p.drawRect(QRectF(5.2, 7.4, 5.6, 6.4)); // base
+}
+
+// Fallback: rounded badge with the raw symbol character.
+void drawBadge(QPainter& p, char code, const QColor& color)
+{
+    p.drawRoundedRect(QRectF(2.4, 2.4, 11.2, 11.2), 3, 3);
+    QFont f = p.font();
+    f.setPixelSize(9);
+    f.setBold(true);
+    p.setFont(f);
+    p.setPen(color);
+    p.drawText(QRectF(2.4, 2.4, 11.2, 11.2), Qt::AlignCenter,
+               QString(QLatin1Char(code)));
+}
+
+} // namespace
+
+QIcon symbolIcon(char symbolTable, char symbolCode, const QColor& color)
+{
+    Q_UNUSED(symbolTable); // alternate-table codes share the primary drawing
+    static QHash<quint64, QIcon> cache;
+    const quint64 key = (quint64(quint8(symbolCode)) << 32) | color.rgba();
+    if (const auto it = cache.constFind(key); it != cache.constEnd())
+        return it.value();
+
+    QPixmap pm(int(kLogicalSize * kDpr), int(kLogicalSize * kDpr));
+    pm.setDevicePixelRatio(kDpr);
+    pm.fill(Qt::transparent);
+    {
+        QPainter p(&pm);
+        p.setRenderHint(QPainter::Antialiasing, true);
+        p.setPen(QPen(color, 1.4, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+        p.setBrush(Qt::NoBrush);
+        switch (symbolCode) {
+        case '-':  drawHouse(p); break;
+        case '>':  drawCar(p); break;
+        case 'j':  drawJeep(p); break;
+        case 'k':  drawPickup(p); break;
+        case 'u':  drawSemi(p); break;
+        case 'v':  drawVan(p); break;
+        case 'R':  drawRv(p); break;
+        case '<':  drawMotorcycle(p); break;
+        case 'b':  drawBicycle(p); break;
+        case '[':  drawJogger(p); break;
+        case 's':  drawPowerBoat(p); break;
+        case 'Y':  drawSailboat(p); break;
+        case '\'': drawAircraft(p); break;
+        case 'g':  drawAircraft(p); break;   // glider — close enough at 16 px
+        case 'X':  drawHelicopter(p); break;
+        case 'O':  drawBalloon(p); break;
+        case '#':  drawTower(p); break;      // digipeater
+        case 'r':  drawRepeater(p); break;
+        case 'm':  drawRepeater(p); break;   // Mic-E repeater
+        case 'y':  drawYagi(p); break;
+        case '_':  drawWxStation(p); break;
+        case 'W':  drawWxService(p); break;
+        case 'a':  drawAmbulance(p); break;
+        case 'f':  drawFireTruck(p); break;
+        case '!':  drawShield(p); break;     // police / emergency
+        case 'P':  drawShield(p); break;     // police
+        case 'U':  drawBus(p); break;
+        case '=':  drawTrain(p); break;
+        case '$':  drawPhone(p); break;
+        default:   drawBadge(p, symbolCode, color); break;
+        }
+    }
+    const QIcon icon(pm);
+    cache.insert(key, icon);
+    return icon;
+}
+
+} // namespace AetherSDR::aprsicons

--- a/src/gui/AprsSymbolIcons.h
+++ b/src/gui/AprsSymbolIcons.h
@@ -13,4 +13,10 @@ namespace AetherSDR::aprsicons {
 QIcon symbolIcon(char symbolTable, char symbolCode,
                  const QColor& color = QColor(0xae, 0xb9, 0xcc));
 
+// Current-conditions icon for weather stations, same wireframe style:
+// 0 = cloud, 1 = cloud with rain, 2 = cloud with wind streaks. Values match
+// AprsStationList::Station::wxCondition.
+QIcon weatherIcon(int condition,
+                  const QColor& color = QColor(0xae, 0xb9, 0xcc));
+
 } // namespace AetherSDR::aprsicons

--- a/src/gui/AprsSymbolIcons.h
+++ b/src/gui/AprsSymbolIcons.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QColor>
+#include <QIcon>
+
+namespace AetherSDR::aprsicons {
+
+// Wireframe/outline icon for an APRS symbol (house, car, sailboat, ...).
+// Drawn programmatically as 1.5 px line art on a transparent background at
+// 2x for retina, so they stay crisp in the station table and combo boxes at
+// 16 px. Codes without a dedicated drawing fall back to a rounded badge
+// showing the symbol character itself. Results are cached per (code, color).
+QIcon symbolIcon(char symbolTable, char symbolCode,
+                 const QColor& color = QColor(0xae, 0xb9, 0xcc));
+
+} // namespace AetherSDR::aprsicons

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -5,6 +5,12 @@
 #include "core/DaxTxPolicy.h"
 #include "core/LogManager.h"
 #include "core/ThemeManager.h"
+#include "core/aprs/AprsBeacon.h"
+#include "core/aprs/AprsMessenger.h"
+#include "core/aprs/AprsPacket.h"
+#include "core/aprs/AprsSettings.h"
+#include "core/aprs/AprsStationList.h"
+#include "gui/AprsMessagesDialog.h"
 #include "core/tnc/Ax25.h"
 #include "core/tnc/Ax25FrameFormatter.h"
 #include "core/tnc/HeardList.h"
@@ -27,16 +33,21 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDateTime>
+#include <QDesktopServices>
 #include <QDir>
+#include <QDoubleValidator>
 #include <QFile>
 #include <QFileInfo>
 #include <QFont>
 #include <QFrame>
+#include <QGridLayout>
 #include <QHBoxLayout>
+#include <QHeaderView>
 #include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
 #include <QMenu>
+#include <QMessageBox>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPushButton>
@@ -46,6 +57,9 @@
 #include <QSizePolicy>
 #include <QSpinBox>
 #include <QStackedWidget>
+#include <QStyle>
+#include <QTableWidget>
+#include <QUrl>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QTextCursor>
@@ -283,6 +297,39 @@ QLabel#ExperimentalBanner {
     padding: 8px 12px;
     font-size: 13px;
 }
+QTableWidget {
+    color: #c2ccdb;
+    background: #050b13;
+    border: none;
+    gridline-color: #14202f;
+    font-family: "SF Mono", "Menlo", "Consolas", monospace;
+    font-size: 13px;
+    selection-background-color: #1b3650;
+}
+QHeaderView::section {
+    color: #8d99ad;
+    background: #0d1825;
+    border: none;
+    border-bottom: 1px solid #233246;
+    padding: 5px 8px;
+    font-size: 11px;
+    font-weight: 700;
+}
+QTableCornerButton::section {
+    background: #0d1825;
+    border: none;
+}
+QSpinBox {
+    color: #c4cedd;
+    background: #0b1625;
+    border: 1px solid #26374e;
+    border-radius: 5px;
+    padding: 6px 8px;
+}
+QPushButton#EnvelopeButton[hasUnread="true"] {
+    color: #80ed91;
+    border-color: #54c768;
+}
 )";
 
 QString profileSettingsValue(Ax25ModemProfile profile)
@@ -326,14 +373,6 @@ QPushButton* tabButton(const QString& text, bool active, QWidget* parent)
     button->setChecked(active);
     button->setEnabled(active);
     button->setFlat(true);
-    return button;
-}
-
-QPushButton* disabledActionButton(const QString& text, QWidget* parent)
-{
-    auto* button = new QPushButton(text, parent);
-    button->setEnabled(false);
-    button->setMinimumHeight(48);
     return button;
 }
 
@@ -638,16 +677,25 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_heard = new HeardList(this);
     m_terminal = new TncTerminal(this);
     m_pms = new PmsMailbox(this);
+    m_aprsStations = new AprsStationList(this);
+    m_aprsMessenger = new AprsMessenger(this);
+    m_aprsBeacon = new AprsBeacon(this);
 
     // The TNC store lives next to the app settings (heard log + session logs).
     const QString tncDir =
         QFileInfo(AppSettings::instance().filePath()).absolutePath()
         + QStringLiteral("/tnc");
     m_heard->setPersistencePath(tncDir + QStringLiteral("/heard.json"));
+    m_aprsStations->setPersistencePath(tncDir + QStringLiteral("/aprs-stations.json"));
+    m_aprsMessenger->setPersistencePath(tncDir + QStringLiteral("/aprs-messages.json"));
     m_terminal->setHeardList(m_heard);
     m_terminal->setLogDirectory(tncDir + QStringLiteral("/logs"));
     m_heartbeatTimer = new QTimer(this);
     m_heartbeatTimer->setInterval(1000);
+    // Free-running (not gated on the modem): updateHeartbeat() also ticks the
+    // APRS station-table ages, which must stay honest while the modem is off.
+    // The modem-health portion of the heartbeat early-outs when disabled.
+    m_heartbeatTimer->start();
     m_txPaceTimer = new QTimer(this);
     m_txPaceTimer->setInterval(kTxChunkMs);
     bodyWidget()->setStyleSheet(QString::fromLatin1(kAetherModemStyle));
@@ -659,7 +707,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     auto* tabs = new QHBoxLayout(tabsFrame);
     tabs->setContentsMargins(0, 0, 0, 0);
     tabs->setSpacing(0);
-    m_ax25Tab = tabButton(QStringLiteral("AX.25"), true, tabsFrame);
+    m_ax25Tab = tabButton(QStringLiteral("APRS"), true, tabsFrame);
     m_kissTab = tabButton(QStringLiteral("KISS TNC"), false, tabsFrame);
     m_terminalTab = tabButton(QStringLiteral("Terminal"), false, tabsFrame);
     m_mailboxTab = tabButton(QStringLiteral("Mailbox"), false, tabsFrame);
@@ -685,8 +733,9 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     connect(m_tabStack, &QStackedWidget::currentChanged,
             this, &Ax25HfPacketDecodeDialog::updateTabChrome);
 
-    // AX.25 page: modem config + transmit. The log and status row below the
-    // stack are shared by both tabs.
+    // APRS page: modem config, beacon/messaging controls, and the station
+    // table. The raw decode log and status row below the stack are shared by
+    // all tabs.
     auto* ax25Page = new QWidget(m_tabStack);
     auto* ax25PageLayout = new QVBoxLayout(ax25Page);
     ax25PageLayout->setContentsMargins(0, 0, 0, 0);
@@ -744,8 +793,11 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_txButton = new QPushButton(QStringLiteral("Transmit"), txFrame);
     m_txButton->setMinimumHeight(42);
     txLayout->addWidget(m_txButton);
+
+    // APRS client controls (beacon, messaging, station table) — the raw
+    // UI-frame transmit row rides along at the bottom of the page.
+    buildAprsUi(ax25Page, ax25PageLayout);
     ax25PageLayout->addWidget(txFrame);
-    ax25PageLayout->addStretch(1);
 
     // KISS TNC page (built lazily into the same stack).
     m_tabStack->addWidget(buildKissTncPage());
@@ -767,33 +819,6 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_log->setPlaceholderText(QStringLiteral("Decoded AX.25 UI frames will appear here."));
     logLayout->addWidget(m_log);
     root->addWidget(logFrame, 1);
-
-    auto* actionRowFrame = new QWidget(bodyWidget());
-    m_actionRowFrame = actionRowFrame;
-    auto* actionRow = new QHBoxLayout(actionRowFrame);
-    actionRow->setContentsMargins(0, 0, 0, 0);
-    actionRow->setSpacing(8);
-    actionRow->addWidget(disabledActionButton(QStringLiteral("Send SMS"), actionRowFrame), 1);
-    actionRow->addWidget(disabledActionButton(QStringLiteral("Send APRS Msg..."), actionRowFrame), 1);
-    auto* positionFrame = panel(QStringLiteral("ActionFrame"), actionRowFrame);
-    auto* positionLayout = new QHBoxLayout(positionFrame);
-    positionLayout->setContentsMargins(18, 8, 18, 8);
-    positionLayout->setSpacing(12);
-    auto* positionButton = new QPushButton(QStringLiteral("Send APRS Position"), positionFrame);
-    positionButton->setEnabled(false);
-    positionButton->setFlat(true);
-    positionLayout->addWidget(positionButton, 1);
-    auto* intervalLabel = new QLabel(QStringLiteral("Interval:"), positionFrame);
-    intervalLabel->setObjectName(QStringLiteral("StatusValue"));
-    positionLayout->addWidget(intervalLabel);
-    auto* interval = new QComboBox(positionFrame);
-    interval->addItems({QStringLiteral("5 min"), QStringLiteral("10 min"), QStringLiteral("30 min")});
-    interval->setEnabled(false);
-    positionLayout->addWidget(interval);
-    actionRow->addWidget(positionFrame, 2);
-    actionRow->addWidget(disabledActionButton(QStringLiteral("Connect BBS"), actionRowFrame), 1);
-    root->addWidget(actionRowFrame);
-    actionRowFrame->setVisible(false);
 
     // Slim status bar: MODEM STATUS, GAIN STAGE and PACKET ACTIVITY inline in a
     // single thin strip rather than three tall stacked panels.
@@ -903,10 +928,17 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
             [this](const Ax25DecodedFrame& frame) {
         if (frame.ax25FrameNoFcs.isEmpty())
             return;
-        // Record into the shared heard log once (drives MHEARD + quick-connect).
-        if (m_heard) {
-            if (auto decoded = ax25::Frame::decode(frame.ax25FrameNoFcs))
+        // Record into the shared heard log once (drives MHEARD + quick-connect),
+        // then through the APRS parser into the station roster + messenger.
+        if (auto decoded = ax25::Frame::decode(frame.ax25FrameNoFcs)) {
+            if (m_heard)
                 m_heard->record(*decoded);
+            if (auto packet = aprs::parseFrame(*decoded)) {
+                if (m_aprsStations)
+                    m_aprsStations->record(*packet);
+                if (m_aprsMessenger)
+                    m_aprsMessenger->onPacket(*packet);
+            }
         }
         if (m_pms)
             m_pms->onAirFrame(frame.ax25FrameNoFcs);
@@ -996,6 +1028,36 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
         applyPmsConfigFromUi(true);
     });
 
+    // APRS client wiring: beacon + messenger share the one-at-a-time modem
+    // keying/pacing path with the KISS server, PMS, and terminal.
+    auto enqueueAprsTx = [this](const QByteArray& raw) {
+        if (raw.isEmpty() || !m_audio || !m_radio)
+            return;
+        if (m_enableDecode && !m_enableDecode->isChecked()) {
+            appendSystemLine(QStringLiteral("Enabling the modem for APRS transmit."));
+            m_enableDecode->setChecked(true);
+        }
+        m_kissTxQueue.enqueue(raw);
+        maybeStartNextKissTx();
+    };
+    connect(m_aprsBeacon, &AprsBeacon::transmitFrame, this, enqueueAprsTx);
+    connect(m_aprsMessenger, &AprsMessenger::transmitFrame, this, enqueueAprsTx);
+    connect(m_aprsBeacon, &AprsBeacon::activity,
+            this, &Ax25HfPacketDecodeDialog::appendSystemLine);
+    connect(m_aprsMessenger, &AprsMessenger::activity,
+            this, &Ax25HfPacketDecodeDialog::appendSystemLine);
+    connect(m_aprsMessenger, &AprsMessenger::unreadCountChanged,
+            this, [this](int) { updateAprsEnvelopeButton(); });
+    connect(m_aprsStations, &AprsStationList::changed,
+            this, &Ax25HfPacketDecodeDialog::refreshAprsStationTable);
+    if (m_radio) {
+        connect(m_radio, &RadioModel::gpsStatusChanged, this,
+                [this](const QString&, int, int, const QString&, const QString&,
+                       const QString&, const QString&, const QString&) {
+            handleGpsUpdate();
+        });
+    }
+
     // TNC Terminal wiring.
     connect(m_terminal, &TncTerminal::transmitFrame, this, [this](const QByteArray& raw) {
         if (raw.isEmpty() || !m_audio || !m_radio)
@@ -1060,6 +1122,18 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
         m_terminalLogEnable->setChecked(true); // fires the toggled handler
     refreshTerminalStatus();
     refreshTerminalHeardCombo();
+
+    // Restore APRS client state. Config is pushed into the beacon/messenger
+    // without persisting (it just came FROM settings); the beacon enable
+    // checkbox fires its toggled handler, which arms the interval timer but
+    // never transmits by itself — the first on-air beacon needs the operator
+    // (Beacon Now) or the timer.
+    applyAprsConfigFromUi(false);
+    if (AprsSettings::beaconEnabled() && m_aprsBeaconEnable)
+        m_aprsBeaconEnable->setChecked(true);
+    handleGpsUpdate();
+    refreshAprsStationTable();
+    updateAprsEnvelopeButton();
 
     // No control button may be the dialog's default button — otherwise pressing
     // Return in a text field would trigger it (Connect, Transmit, ...). Combined
@@ -1162,7 +1236,6 @@ void Ax25HfPacketDecodeDialog::setDecodeEnabled(bool enabled)
             m_audio->setTncRxTapEnabled(true);
         appendSystemLine(QStringLiteral(
             "Modem enabled. RX tap requested; waiting for 24 kHz PC RX audio."));
-        m_heartbeatTimer->start();
     } else {
         if (m_captureActive)
             finishAudioCapture(false);
@@ -1173,7 +1246,6 @@ void Ax25HfPacketDecodeDialog::setDecodeEnabled(bool enabled)
         m_lastDiagnosticsUtc = {};
         m_lastActivityHdlc = 0;
         m_lastActivityAccepted = 0;
-        m_heartbeatTimer->stop();
         appendSystemLine(QStringLiteral("Modem disabled. RX tap stopped."));
     }
     refreshStatus();
@@ -1655,6 +1727,11 @@ void Ax25HfPacketDecodeDialog::updateDiagnostics(const Ax25DecoderDiagnostics& d
 
 void Ax25HfPacketDecodeDialog::updateHeartbeat()
 {
+    // Station-table ages tick whether or not the modem is running — the
+    // roster persists across sessions and "how stale is this row" should
+    // stay honest while the modem is idle.
+    refreshAprsStationAges();
+
     if (!m_enableDecode || !m_enableDecode->isChecked())
         return;
 
@@ -2544,19 +2621,531 @@ void Ax25HfPacketDecodeDialog::refreshTerminalStatus()
 void Ax25HfPacketDecodeDialog::updateTabChrome(int index)
 {
     // The Terminal tab (stack index 2) wants the whole window: hide the shared
-    // decode-log panel and the placeholder action row, and give the tab stack the
-    // vertical stretch so the transcript fills the viewport. Other tabs keep the
-    // log panel below their controls.
+    // decode-log panel and give the tab stack the vertical stretch so the
+    // transcript fills the viewport. The APRS tab (index 0) keeps the raw log
+    // but the station table gets the lion's share of the height. Other tabs
+    // keep the log panel below their controls.
     const bool terminal = (index == 2);
+    const bool aprs = (index == 0);
     if (m_logFrame)
         m_logFrame->setVisible(!terminal);
-    if (m_actionRowFrame)
-        m_actionRowFrame->setVisible(!terminal);
     if (auto* root = qobject_cast<QVBoxLayout*>(bodyWidget()->layout())) {
-        root->setStretchFactor(m_tabStack, terminal ? 1 : 0);
+        root->setStretchFactor(m_tabStack, terminal ? 1 : (aprs ? 3 : 0));
         if (m_logFrame)
             root->setStretchFactor(m_logFrame, terminal ? 0 : 1);
     }
+}
+
+// ---------------------------------------------------------------------------
+// APRS client (APRS tab)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Compact "how long ago" for the station table: "42s", "5m", "3h 12m", "2d".
+QString aprsAgeText(const QDateTime& utc)
+{
+    if (!utc.isValid())
+        return QStringLiteral("—");
+    const qint64 secs = qMax<qint64>(0, utc.secsTo(QDateTime::currentDateTimeUtc()));
+    if (secs < 60)
+        return QStringLiteral("%1s").arg(secs);
+    if (secs < 3600)
+        return QStringLiteral("%1m").arg(secs / 60);
+    if (secs < 86400)
+        return QStringLiteral("%1h %2m").arg(secs / 3600).arg((secs % 3600) / 60);
+    return QStringLiteral("%1d").arg(secs / 86400);
+}
+
+// The on-air-common symbols offered for our own beacon; data() carries the
+// two-character table+code pair.
+struct AprsSymbolChoice { const char* pair; const char* name; };
+constexpr AprsSymbolChoice kAprsSymbolChoices[] = {
+    { "/-",  "Home" },
+    { "/y",  "Yagi at QTH" },
+    { "/>",  "Car" },
+    { "/j",  "Jeep" },
+    { "/k",  "Truck" },
+    { "/u",  "Truck (18-wheeler)" },
+    { "/v",  "Van" },
+    { "/R",  "RV" },
+    { "/<",  "Motorcycle" },
+    { "/b",  "Bicycle" },
+    { "/[",  "Jogger" },
+    { "/s",  "Power boat" },
+    { "/Y",  "Sailboat" },
+    { "/'",  "Small aircraft" },
+    { "/O",  "Balloon" },
+    { "/r",  "Repeater" },
+    { "/_",  "Weather station" },
+};
+
+} // namespace
+
+void Ax25HfPacketDecodeDialog::buildAprsUi(QWidget* page, QVBoxLayout* pageLayout)
+{
+    // ── Station + beacon configuration ────────────────────────────────────
+    auto* configFrame = panel(QStringLiteral("ControlsFrame"), page);
+    auto* config = new QGridLayout(configFrame);
+    config->setContentsMargins(16, 12, 16, 12);
+    config->setHorizontalSpacing(12);
+    config->setVerticalSpacing(8);
+
+    config->addWidget(sectionLabel(QStringLiteral("MY CALLSIGN"), configFrame), 0, 0);
+    m_aprsMyCall = new QLineEdit(configFrame);
+    m_aprsMyCall->setPlaceholderText(QStringLiteral("N0CALL-9"));
+    m_aprsMyCall->setMaximumWidth(140);
+    m_aprsMyCall->setText(AprsSettings::myCall());
+    config->addWidget(m_aprsMyCall, 1, 0);
+
+    config->addWidget(sectionLabel(QStringLiteral("SYMBOL"), configFrame), 0, 1);
+    m_aprsSymbol = new QComboBox(configFrame);
+    for (const AprsSymbolChoice& choice : kAprsSymbolChoices) {
+        m_aprsSymbol->addItem(QString::fromLatin1(choice.name),
+                              QString::fromLatin1(choice.pair));
+    }
+    const int symbolIndex = m_aprsSymbol->findData(AprsSettings::symbol());
+    m_aprsSymbol->setCurrentIndex(qMax(0, symbolIndex));
+    config->addWidget(m_aprsSymbol, 1, 1);
+
+    config->addWidget(sectionLabel(QStringLiteral("PATH"), configFrame), 0, 2);
+    m_aprsPath = new QLineEdit(configFrame);
+    m_aprsPath->setMaximumWidth(180);
+    m_aprsPath->setText(AprsSettings::path());
+    m_aprsPath->setToolTip(QStringLiteral(
+        "Digipeater path for beacons and messages (comma-separated, e.g. WIDE1-1,WIDE2-1)."));
+    config->addWidget(m_aprsPath, 1, 2);
+
+    config->addWidget(sectionLabel(QStringLiteral("BEACON"), configFrame), 0, 3, 1, 4);
+    m_aprsBeaconEnable = new QCheckBox(QStringLiteral("Every"), configFrame);
+    config->addWidget(m_aprsBeaconEnable, 1, 3);
+    m_aprsBeaconInterval = new QSpinBox(configFrame);
+    m_aprsBeaconInterval->setRange(1, 24 * 60);
+    m_aprsBeaconInterval->setSuffix(QStringLiteral(" min"));
+    m_aprsBeaconInterval->setValue(AprsSettings::beaconIntervalMinutes());
+    config->addWidget(m_aprsBeaconInterval, 1, 4);
+    m_aprsBeaconText = new QLineEdit(configFrame);
+    m_aprsBeaconText->setPlaceholderText(QStringLiteral("Beacon status text"));
+    m_aprsBeaconText->setText(AprsSettings::beaconText());
+    config->addWidget(m_aprsBeaconText, 1, 5);
+    m_aprsBeaconNow = new QPushButton(QStringLiteral("Beacon Now"), configFrame);
+    config->addWidget(m_aprsBeaconNow, 1, 6);
+    config->setColumnStretch(5, 1);
+
+    // Position source row: GPS readout plus the manual fallback fields.
+    auto* posRow = new QHBoxLayout;
+    posRow->setSpacing(10);
+    posRow->addWidget(sectionLabel(QStringLiteral("POSITION"), configFrame));
+    m_aprsPositionValue = new QLabel(configFrame);
+    m_aprsPositionValue->setObjectName(QStringLiteral("StatusValue"));
+    posRow->addWidget(m_aprsPositionValue, 1);
+    posRow->addWidget(sectionLabel(QStringLiteral("MANUAL LAT"), configFrame));
+    m_aprsManualLat = new QLineEdit(configFrame);
+    m_aprsManualLat->setPlaceholderText(QStringLiteral("48.2700"));
+    m_aprsManualLat->setMaximumWidth(110);
+    m_aprsManualLat->setValidator(
+        new QDoubleValidator(-90.0, 90.0, 6, m_aprsManualLat));
+    m_aprsManualLat->setText(AprsSettings::manualLat());
+    posRow->addWidget(m_aprsManualLat);
+    posRow->addWidget(sectionLabel(QStringLiteral("LON"), configFrame));
+    m_aprsManualLon = new QLineEdit(configFrame);
+    m_aprsManualLon->setPlaceholderText(QStringLiteral("-116.5600"));
+    m_aprsManualLon->setMaximumWidth(110);
+    m_aprsManualLon->setValidator(
+        new QDoubleValidator(-180.0, 180.0, 6, m_aprsManualLon));
+    m_aprsManualLon->setText(AprsSettings::manualLon());
+    posRow->addWidget(m_aprsManualLon);
+    config->addLayout(posRow, 2, 0, 1, 7);
+    pageLayout->addWidget(configFrame);
+
+    // ── Messaging row ──────────────────────────────────────────────────────
+    auto* msgFrame = panel(QStringLiteral("ControlsFrame"), page);
+    auto* msgLayout = new QHBoxLayout(msgFrame);
+    msgLayout->setContentsMargins(16, 12, 16, 12);
+    msgLayout->setSpacing(12);
+    msgLayout->addWidget(sectionLabel(QStringLiteral("MESSAGE"), msgFrame));
+    m_aprsMsgTo = new QLineEdit(msgFrame);
+    m_aprsMsgTo->setPlaceholderText(QStringLiteral("To (N0CALL-7)"));
+    m_aprsMsgTo->setMaximumWidth(150);
+    msgLayout->addWidget(m_aprsMsgTo);
+    m_aprsMsgText = new QLineEdit(msgFrame);
+    m_aprsMsgText->setPlaceholderText(
+        QStringLiteral("Message text (sent with ack request, retries until acked)"));
+    msgLayout->addWidget(m_aprsMsgText, 1);
+    m_aprsMsgSend = new QPushButton(QStringLiteral("Send APRS Msg"), msgFrame);
+    m_aprsMsgSend->setMinimumHeight(42);
+    msgLayout->addWidget(m_aprsMsgSend);
+    m_aprsEnvelope = new QPushButton(QStringLiteral("✉"), msgFrame);
+    m_aprsEnvelope->setObjectName(QStringLiteral("EnvelopeButton"));
+    m_aprsEnvelope->setMinimumHeight(42);
+    m_aprsEnvelope->setToolTip(QStringLiteral("View APRS messages"));
+    msgLayout->addWidget(m_aprsEnvelope);
+    pageLayout->addWidget(msgFrame);
+
+    // ── Station table ──────────────────────────────────────────────────────
+    auto* tableFrame = panel(QStringLiteral("LogFrame"), page);
+    auto* tableLayout = new QVBoxLayout(tableFrame);
+    tableLayout->setContentsMargins(8, 6, 8, 6);
+    tableLayout->setSpacing(0);
+    m_aprsTable = new QTableWidget(tableFrame);
+    m_aprsTable->setColumnCount(8);
+    m_aprsTable->setHorizontalHeaderLabels({
+        QStringLiteral("STATION"), QStringLiteral("SYMBOL"),
+        QStringLiteral("LAST"), QStringLiteral("PKTS"),
+        QStringLiteral("GRID"), QStringLiteral("DIST"),
+        QStringLiteral("CRS/SPD"), QStringLiteral("STATUS / COMMENT"),
+    });
+    m_aprsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_aprsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_aprsTable->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_aprsTable->verticalHeader()->setVisible(false);
+    m_aprsTable->setShowGrid(false);
+    m_aprsTable->setWordWrap(false);
+    m_aprsTable->horizontalHeader()->setSectionResizeMode(7, QHeaderView::Stretch);
+    m_aprsTable->setMinimumHeight(160);
+    m_aprsTable->setContextMenuPolicy(Qt::CustomContextMenu);
+    tableLayout->addWidget(m_aprsTable);
+    pageLayout->addWidget(tableFrame, 1);
+
+    // ── Control wiring ─────────────────────────────────────────────────────
+    connect(m_aprsMyCall, &QLineEdit::editingFinished,
+            this, [this] { applyAprsConfigFromUi(true); });
+    connect(m_aprsSymbol, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, [this](int) { applyAprsConfigFromUi(true); });
+    connect(m_aprsPath, &QLineEdit::editingFinished,
+            this, [this] { applyAprsConfigFromUi(true); });
+    connect(m_aprsBeaconEnable, &QCheckBox::toggled,
+            this, [this](bool) { applyAprsConfigFromUi(true); });
+    connect(m_aprsBeaconInterval, qOverload<int>(&QSpinBox::valueChanged),
+            this, [this](int) { applyAprsConfigFromUi(true); });
+    connect(m_aprsBeaconText, &QLineEdit::editingFinished,
+            this, [this] { applyAprsConfigFromUi(true); });
+    connect(m_aprsManualLat, &QLineEdit::editingFinished,
+            this, [this] { applyAprsConfigFromUi(true); });
+    connect(m_aprsManualLon, &QLineEdit::editingFinished,
+            this, [this] { applyAprsConfigFromUi(true); });
+    connect(m_aprsBeaconNow, &QPushButton::clicked, this, [this] {
+        applyAprsConfigFromUi(false); // pick up anything typed but not committed
+        m_aprsBeacon->sendNow();
+    });
+    connect(m_aprsMsgSend, &QPushButton::clicked,
+            this, &Ax25HfPacketDecodeDialog::sendAprsMessageFromUi);
+    connect(m_aprsMsgText, &QLineEdit::returnPressed,
+            this, &Ax25HfPacketDecodeDialog::sendAprsMessageFromUi);
+    connect(m_aprsEnvelope, &QPushButton::clicked,
+            this, &Ax25HfPacketDecodeDialog::openAprsMessagesDialog);
+    connect(m_aprsTable, &QTableWidget::customContextMenuRequested,
+            this, &Ax25HfPacketDecodeDialog::handleAprsStationMenu);
+    connect(m_aprsTable, &QTableWidget::cellDoubleClicked,
+            this, [this](int row, int) {
+        if (auto* item = m_aprsTable->item(row, 0)) {
+            m_aprsMsgTo->setText(item->data(Qt::UserRole).toString());
+            m_aprsMsgText->setFocus();
+        }
+    });
+}
+
+void Ax25HfPacketDecodeDialog::applyAprsConfigFromUi(bool persist)
+{
+    const QString call = m_aprsMyCall->text().trimmed().toUpper();
+    const auto myAddr = ax25::Address::parse(call);
+    const ax25::Address addr = myAddr.value_or(ax25::Address{});
+    m_aprsMessenger->setMyAddress(addr);
+    m_aprsBeacon->setMyAddress(addr);
+
+    QString symbol = m_aprsSymbol->currentData().toString();
+    if (symbol.size() != 2)
+        symbol = QStringLiteral("/-");
+    m_aprsBeacon->setSymbol(symbol.at(0).toLatin1(), symbol.at(1).toLatin1());
+
+    QVector<ax25::Address> path;
+    const QStringList hops =
+        m_aprsPath->text().split(QLatin1Char(','), Qt::SkipEmptyParts);
+    for (const QString& hop : hops) {
+        if (path.size() >= 8)
+            break;
+        if (const auto a = ax25::Address::parse(hop.trimmed().toUpper()))
+            path.append(*a);
+    }
+    m_aprsBeacon->setPath(path);
+    m_aprsMessenger->setPath(path);
+
+    m_aprsBeacon->setStatusText(m_aprsBeaconText->text());
+    m_aprsBeacon->setIntervalMinutes(m_aprsBeaconInterval->value());
+    m_aprsBeacon->setEnabled(m_aprsBeaconEnable->isChecked());
+
+    bool latOk = false, lonOk = false;
+    const double manualLat = m_aprsManualLat->text().toDouble(&latOk);
+    const double manualLon = m_aprsManualLon->text().toDouble(&lonOk);
+    const bool manualValid = latOk && lonOk
+        && manualLat >= -90.0 && manualLat <= 90.0
+        && manualLon >= -180.0 && manualLon <= 180.0
+        && (manualLat != 0.0 || manualLon != 0.0);
+    m_aprsBeacon->setManualPosition(manualLat, manualLon, manualValid);
+
+    if (persist) {
+        AprsSettings::setMyCall(call);
+        AprsSettings::setSymbol(symbol);
+        AprsSettings::setPath(m_aprsPath->text());
+        AprsSettings::setBeaconEnabled(m_aprsBeaconEnable->isChecked());
+        AprsSettings::setBeaconIntervalMinutes(m_aprsBeaconInterval->value());
+        AprsSettings::setBeaconText(m_aprsBeaconText->text());
+        AprsSettings::setManualPosition(m_aprsManualLat->text(),
+                                        m_aprsManualLon->text());
+    }
+    refreshAprsPositionLabel();
+    refreshAprsStationTable(); // distance column tracks our own position
+}
+
+void Ax25HfPacketDecodeDialog::handleGpsUpdate()
+{
+    if (!m_radio || !m_aprsBeacon)
+        return;
+    bool latOk = false, lonOk = false;
+    const double lat = m_radio->gpsLat().toDouble(&latOk);
+    const double lon = m_radio->gpsLon().toDouble(&lonOk);
+    // "Fine Lock" / "Coarse Lock" mean the fix is real; "Present" /
+    // "Not Present" mean no usable position.
+    const bool locked =
+        m_radio->gpsStatus().contains(QStringLiteral("Lock"), Qt::CaseInsensitive);
+    const bool valid = latOk && lonOk && locked && (lat != 0.0 || lon != 0.0);
+    m_aprsBeacon->setGpsPosition(lat, lon, valid);
+    refreshAprsPositionLabel();
+}
+
+void Ax25HfPacketDecodeDialog::refreshAprsPositionLabel()
+{
+    if (!m_aprsPositionValue)
+        return;
+    double lat = 0.0, lon = 0.0;
+    if (m_aprsBeacon->currentPosition(lat, lon)) {
+        m_aprsPositionValue->setText(QStringLiteral("%1  %2  %3, %4")
+            .arg(m_aprsBeacon->usingGps() ? QStringLiteral("GPS")
+                                          : QStringLiteral("Manual"),
+                 aprs::gridSquare(lat, lon),
+                 QString::number(lat, 'f', 4),
+                 QString::number(lon, 'f', 4)));
+    } else {
+        m_aprsPositionValue->setText(QStringLiteral(
+            "none — no GPS lock; enter a manual Lat/Lon to beacon"));
+    }
+}
+
+void Ax25HfPacketDecodeDialog::refreshAprsStationTable()
+{
+    if (!m_aprsTable || !m_aprsStations)
+        return;
+
+    QString selectedCall;
+    if (const auto* current = m_aprsTable->item(m_aprsTable->currentRow(), 0))
+        selectedCall = current->data(Qt::UserRole).toString();
+
+    double myLat = 0.0, myLon = 0.0;
+    const bool haveMyPos =
+        m_aprsBeacon && m_aprsBeacon->currentPosition(myLat, myLon);
+
+    const QVector<AprsStationList::Station> stations = m_aprsStations->stations();
+    m_aprsTable->setUpdatesEnabled(false);
+    m_aprsTable->setRowCount(stations.size());
+    int selectRow = -1;
+    for (int i = 0; i < stations.size(); ++i) {
+        const AprsStationList::Station& s = stations.at(i);
+        auto set = [&](int col, const QString& text) {
+            auto* item = new QTableWidgetItem(text);
+            m_aprsTable->setItem(i, col, item);
+            return item;
+        };
+        set(0, s.call)->setData(Qt::UserRole, s.call);
+        set(1, s.hasPosition
+            ? aprs::symbolDescription(s.symbolTable, s.symbolCode)
+            : aprs::packetTypeName(s.lastType));
+        set(2, aprsAgeText(s.lastHeard))
+            ->setData(Qt::UserRole, s.lastHeard.toMSecsSinceEpoch());
+        set(3, QString::number(s.packets));
+        set(4, s.hasPosition ? aprs::gridSquare(s.latitude, s.longitude)
+                             : QString());
+        QString dist;
+        if (s.hasPosition && haveMyPos) {
+            dist = QStringLiteral("%1 mi %2°")
+                .arg(aprs::distanceMiles(myLat, myLon, s.latitude, s.longitude),
+                     0, 'f', 1)
+                .arg(qRound(aprs::bearingDeg(myLat, myLon,
+                                             s.latitude, s.longitude)));
+        }
+        set(5, dist);
+        QString crsSpd;
+        if (s.speedKnots >= 0.0) {
+            crsSpd = QStringLiteral("%1 mph")
+                .arg(qRound(s.speedKnots * 1.15078));
+            if (s.courseDeg >= 0.0)
+                crsSpd += QStringLiteral(" %1°").arg(qRound(s.courseDeg));
+        }
+        set(6, crsSpd);
+        QString text = !s.comment.isEmpty() ? s.comment : s.status;
+        if (!s.comment.isEmpty() && !s.status.isEmpty())
+            text = s.comment + QStringLiteral("  |  ") + s.status;
+        set(7, text);
+        if (s.call == selectedCall)
+            selectRow = i;
+    }
+    m_aprsTable->resizeColumnsToContents();
+    m_aprsTable->horizontalHeader()->setSectionResizeMode(7, QHeaderView::Stretch);
+    if (selectRow >= 0)
+        m_aprsTable->selectRow(selectRow);
+    m_aprsTable->setUpdatesEnabled(true);
+}
+
+void Ax25HfPacketDecodeDialog::refreshAprsStationAges()
+{
+    if (!m_aprsTable)
+        return;
+    for (int row = 0; row < m_aprsTable->rowCount(); ++row) {
+        if (auto* item = m_aprsTable->item(row, 2)) {
+            const QDateTime lastHeard = QDateTime::fromMSecsSinceEpoch(
+                item->data(Qt::UserRole).toLongLong(), QTimeZone::UTC);
+            item->setText(aprsAgeText(lastHeard));
+        }
+    }
+}
+
+void Ax25HfPacketDecodeDialog::handleAprsStationMenu(const QPoint& pos)
+{
+    auto* hit = m_aprsTable->itemAt(pos);
+    if (!hit)
+        return;
+    const auto* callItem = m_aprsTable->item(hit->row(), 0);
+    if (!callItem)
+        return;
+    const QString call = callItem->data(Qt::UserRole).toString();
+
+    QMenu menu(m_aprsTable);
+    menu.addAction(QStringLiteral("Send Message to %1...").arg(call),
+                   this, [this, call] {
+        m_aprsMsgTo->setText(call);
+        m_aprsMsgText->setFocus();
+    });
+    menu.addAction(QStringLiteral("Station Info..."), this, [this, call] {
+        showAprsStationInfo(call);
+    });
+    menu.addAction(QStringLiteral("View on aprs.fi"), this, [call] {
+        QDesktopServices::openUrl(
+            QUrl(QStringLiteral("https://aprs.fi/info/a/%1").arg(call)));
+    });
+    menu.exec(m_aprsTable->viewport()->mapToGlobal(pos));
+}
+
+void Ax25HfPacketDecodeDialog::showAprsStationInfo(const QString& call)
+{
+    const auto station = m_aprsStations->find(call);
+    if (!station)
+        return;
+    const AprsStationList::Station& s = *station;
+
+    QStringList lines;
+    auto add = [&lines](const QString& key, const QString& value) {
+        if (!value.isEmpty())
+            lines << QStringLiteral("%1  %2").arg(key.leftJustified(12), value);
+    };
+    add(QStringLiteral("First heard"),
+        s.firstHeard.toString(QStringLiteral("yyyy-MM-dd HH:mm:ss 'UTC'")));
+    add(QStringLiteral("Last heard"),
+        QStringLiteral("%1  (%2 ago)")
+            .arg(s.lastHeard.toString(QStringLiteral("yyyy-MM-dd HH:mm:ss 'UTC'")),
+                 aprsAgeText(s.lastHeard)));
+    add(QStringLiteral("Packets"), QString::number(s.packets));
+    add(QStringLiteral("Via"), s.via);
+    if (s.hasPosition) {
+        add(QStringLiteral("Position"),
+            QStringLiteral("%1, %2  (%3)")
+                .arg(QString::number(s.latitude, 'f', 4),
+                     QString::number(s.longitude, 'f', 4),
+                     aprs::gridSquare(s.latitude, s.longitude)));
+        add(QStringLiteral("Symbol"),
+            aprs::symbolDescription(s.symbolTable, s.symbolCode));
+        double myLat = 0.0, myLon = 0.0;
+        if (m_aprsBeacon && m_aprsBeacon->currentPosition(myLat, myLon)) {
+            add(QStringLiteral("Distance"),
+                QStringLiteral("%1 mi, bearing %2°")
+                    .arg(aprs::distanceMiles(myLat, myLon,
+                                             s.latitude, s.longitude),
+                         0, 'f', 1)
+                    .arg(qRound(aprs::bearingDeg(myLat, myLon,
+                                                 s.latitude, s.longitude))));
+        }
+        if (s.speedKnots >= 0.0) {
+            add(QStringLiteral("Speed"),
+                QStringLiteral("%1 mph").arg(qRound(s.speedKnots * 1.15078)));
+        }
+        if (s.courseDeg >= 0.0)
+            add(QStringLiteral("Course"),
+                QStringLiteral("%1°").arg(qRound(s.courseDeg)));
+        if (s.hasAltitude)
+            add(QStringLiteral("Altitude"),
+                QStringLiteral("%1 ft").arg(qRound(s.altitudeFeet)));
+    }
+    add(QStringLiteral("Status"), s.status);
+    add(QStringLiteral("Comment"), s.comment);
+    add(QStringLiteral("Last packet"), s.lastInfo);
+
+    QMessageBox box(this);
+    box.setWindowTitle(call);
+    box.setText(QStringLiteral("<pre>%1</pre>")
+                    .arg(lines.join(QLatin1Char('\n')).toHtmlEscaped()));
+    box.setTextFormat(Qt::RichText);
+    box.exec();
+}
+
+void Ax25HfPacketDecodeDialog::openAprsMessagesDialog()
+{
+    if (!m_aprsMessagesDialog) {
+        m_aprsMessagesDialog = new AprsMessagesDialog(m_aprsMessenger, this);
+        connect(m_aprsMessagesDialog, &AprsMessagesDialog::replyRequested,
+                this, [this](const QString& callsign) {
+            m_aprsMsgTo->setText(callsign);
+            raise();
+            activateWindow();
+            m_aprsMsgText->setFocus();
+        });
+    }
+    m_aprsMessagesDialog->show();
+    m_aprsMessagesDialog->raise();
+    m_aprsMessagesDialog->activateWindow();
+}
+
+void Ax25HfPacketDecodeDialog::sendAprsMessageFromUi()
+{
+    applyAprsConfigFromUi(false); // pick up a freshly typed MY CALLSIGN
+    if (!m_aprsMessenger->myAddress().isValid()) {
+        appendSystemLine(QStringLiteral(
+            "APRS message not sent: set MY CALLSIGN first."));
+        return;
+    }
+    const QString to = m_aprsMsgTo->text().trimmed().toUpper();
+    const QString text = m_aprsMsgText->text().trimmed();
+    if (to.isEmpty() || text.isEmpty())
+        return;
+    if (!m_aprsMessenger->sendMessage(to, text)) {
+        appendSystemLine(QStringLiteral(
+            "APRS message not sent: \"%1\" is not a valid callsign.").arg(to));
+        return;
+    }
+    m_aprsMsgText->clear();
+}
+
+void Ax25HfPacketDecodeDialog::updateAprsEnvelopeButton()
+{
+    if (!m_aprsEnvelope || !m_aprsMessenger)
+        return;
+    const int unread = m_aprsMessenger->unreadCount();
+    m_aprsEnvelope->setText(unread > 0
+        ? QStringLiteral("✉ %1").arg(unread)
+        : QStringLiteral("✉"));
+    m_aprsEnvelope->setToolTip(unread > 0
+        ? QStringLiteral("View APRS messages (%1 unread)").arg(unread)
+        : QStringLiteral("View APRS messages"));
+    m_aprsEnvelope->setProperty("hasUnread", unread > 0);
+    m_aprsEnvelope->style()->unpolish(m_aprsEnvelope);
+    m_aprsEnvelope->style()->polish(m_aprsEnvelope);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -59,6 +59,7 @@
 #include <QStackedWidget>
 #include <QStyle>
 #include <QTableWidget>
+#include <QTimeZone>
 #include <QUrl>
 #include <QJsonDocument>
 #include <QJsonObject>

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -38,18 +38,22 @@
 #include <QDoubleValidator>
 #include <QFile>
 #include <QFileInfo>
+#include <QElapsedTimer>
 #include <QFont>
 #include <QFrame>
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <QHeaderView>
+#include <QHideEvent>
 #include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
+#include <QList>
 #include <QMenu>
 #include <QMessageBox>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QResizeEvent>
 #include <QPushButton>
 #include <QRadioButton>
 #include <QScrollBar>
@@ -539,16 +543,24 @@ void TncSettings::migrateLegacy()
 
 class PacketActivityWidget final : public QWidget {
 public:
+    // An EKG-style sweep trace, in the spirit of a hospital heart monitor:
+    // a cursor sweeps continuously across the strip and every decoded frame
+    // draws a sharp QRS-like spike in green. HDLC candidates that failed the
+    // FCS draw smaller amber bumps, and an open receive gate (signal above
+    // squelch) lifts and slightly agitates the baseline. The trail fades with
+    // age, so the strip reads as "the last few seconds of the channel" — at
+    // typical APRS rates of 1-3 packets/s each packet is an individually
+    // countable heartbeat, where the old per-second bar graph mushed them
+    // into near-identical columns.
     explicit PacketActivityWidget(QWidget* parent = nullptr)
         : QWidget(parent)
-        , m_levels(68)
     {
-        setMinimumHeight(56);
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         setCursor(Qt::PointingHandCursor);
         updateToolTip();
-        for (int i = 0; i < m_levels.size(); ++i)
-            m_levels[i] = 6 + ((i * 7) % 8);
+        m_sweep.setInterval(kFrameMs);
+        connect(&m_sweep, &QTimer::timeout, this, [this] { advanceSweep(); });
+        resizeBuffers(220);
     }
 
     void setDebugEnabled(bool enabled)
@@ -565,37 +577,38 @@ public:
         m_clickHandler = std::move(handler);
     }
 
-    // Bar levels are pixel heights against the (taller) usable height; values
-    // are scaled so even one or two packets/sec produce a clearly visible spike
-    // rather than sitting on the floor.
+    // One accepted (FCS-good) frame: queue a QRS complex for the pen to draw
+    // as the cursor sweeps over the next ~quarter second.
     void recordFrame()
     {
-        m_cursor = (m_cursor + 9) % m_levels.size();
-        m_levels[m_cursor] = 46;
-        if (m_cursor + 3 < m_levels.size())
-            m_levels[m_cursor + 3] = 28;
-        update();
+        // P bump, Q dip, tall R, S undershoot, T recovery.
+        static constexpr float kQrs[] = {
+            0.10f, 0.16f, 0.10f, -0.10f, 0.55f, 1.00f, 0.45f,
+            -0.30f, -0.12f, 0.08f, 0.20f, 0.16f, 0.06f,
+        };
+        enqueue(kQrs, int(sizeof(kQrs) / sizeof(kQrs[0])), SampleKind::Decode);
+        wake();
     }
 
+    // Once-per-second channel health from the decoder diagnostics.
     void tick(int hdlcCandidates, int acceptedFrames, bool receiveGateOpen)
     {
-        if (m_levels.isEmpty())
-            return;
-
-        m_cursor = (m_cursor + 1) % m_levels.size();
-        int level = receiveGateOpen ? 16 : 6;
-        if (hdlcCandidates > 0)
-            level = std::max(level, 16 + std::min(28, hdlcCandidates * 5));
-        if (acceptedFrames > 0)
-            level = 46;
-        m_levels[m_cursor] = level;
-        update();
+        m_gateOpen = receiveGateOpen;
+        m_lastTick.restart();
+        // Accepted frames already spiked via recordFrame(); what's left here
+        // is candidates that never passed the FCS — the "almost" bumps.
+        static constexpr float kBump[] = { 0.12f, 0.30f, 0.45f, 0.30f, 0.12f };
+        const int failed = qMin(3, qMax(0, hdlcCandidates - acceptedFrames));
+        for (int i = 0; i < failed; ++i)
+            enqueue(kBump, int(sizeof(kBump) / sizeof(kBump[0])), SampleKind::Candidate);
+        wake();
     }
 
     void reset()
     {
-        for (int i = 0; i < m_levels.size(); ++i)
-            m_levels[i] = 6 + ((i * 5) % 7);
+        m_pending.clear();
+        std::fill(m_values.begin(), m_values.end(), 0.0f);
+        std::fill(m_kinds.begin(), m_kinds.end(), quint8(SampleKind::Idle));
         m_cursor = 0;
         update();
     }
@@ -611,48 +624,164 @@ protected:
         QWidget::mousePressEvent(event);
     }
 
+    void resizeEvent(QResizeEvent* event) override
+    {
+        QWidget::resizeEvent(event);
+        resizeBuffers(width());
+    }
+
+    void hideEvent(QHideEvent* event) override
+    {
+        m_sweep.stop();
+        QWidget::hideEvent(event);
+    }
+
     void paintEvent(QPaintEvent*) override
     {
         QPainter painter(this);
-        painter.setRenderHint(QPainter::Antialiasing, false);
-        painter.fillRect(rect(), QColor(0, 0, 0, 0));
+        const QRectF frame = QRectF(rect()).adjusted(0.5, 0.5, -0.5, -0.5);
 
-        const int count = m_levels.size();
-        if (count <= 0)
+        // Scope bed: near-black panel with a faint phosphor baseline.
+        painter.setRenderHint(QPainter::Antialiasing, true);
+        painter.setPen(QPen(QColor(0x23, 0x32, 0x46), 1));
+        painter.setBrush(QColor(0x03, 0x08, 0x0e));
+        painter.drawRoundedRect(frame, 4, 4);
+
+        const int n = m_values.size();
+        if (n < 8)
             return;
+        const float base = height() - 6.0f;
+        const float usable = height() - 10.0f;
+        auto yFor = [&](float v) {
+            return qBound(2.0f, base - v * usable, float(height() - 2));
+        };
 
-        const int gap = 3;
-        const int barWidth = qMax(2, (width() - gap * (count - 1)) / count);
-        const int usableHeight = qMax(1, height() - 8);
-        const int base = height() - 4;
-        painter.setPen(Qt::NoPen);
-        painter.setBrush(m_debugEnabled ? QColor(210, 164, 72) : QColor(95, 206, 102));
-
-        for (int i = 0; i < count; ++i) {
-            const int level = qBound(2, m_levels[i], usableHeight);
-            const int x = i * (barWidth + gap);
-            painter.drawRect(QRect(x, base - level, barWidth, level));
-            if (m_levels[i] > 5)
-                --m_levels[i];
+        painter.setClipRect(frame);
+        // The trace, oldest-to-newest behind the cursor, alpha fading with
+        // age like phosphor afterglow. A short blank gap rides ahead of the
+        // cursor, as on a real monitor.
+        constexpr int kGapPx = 12;
+        for (int age = n - kGapPx; age >= 1; --age) {
+            const int i1 = (m_cursor - age + 1 + n) % n;
+            const int i0 = (i1 - 1 + n) % n;
+            const float fade = 1.0f - float(age) / float(n);
+            const int alpha = int(40 + 215 * fade * fade);
+            QColor color;
+            switch (SampleKind(m_kinds[i1])) {
+            case SampleKind::Decode:    color = QColor(0x80, 0xed, 0x91); break;
+            case SampleKind::Candidate: color = QColor(0xd2, 0xa4, 0x48); break;
+            case SampleKind::Idle:
+            default:
+                color = m_gateOpen ? QColor(0x4d, 0x86, 0xa8)
+                                   : QColor(0x35, 0x4a, 0x63);
+                break;
+            }
+            color.setAlpha(alpha);
+            painter.setPen(QPen(color, SampleKind(m_kinds[i1]) == SampleKind::Idle
+                                    ? 1.0 : 1.6));
+            painter.drawLine(QPointF(i0, yFor(m_values[i0])),
+                             QPointF(i1, yFor(m_values[i1])));
         }
+
+        // Cursor head: a bright dot with a soft glow.
+        const QPointF head(m_cursor, yFor(m_values[m_cursor]));
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(QColor(0x80, 0xed, 0x91, 70));
+        painter.drawEllipse(head, 4.0, 4.0);
+        painter.setBrush(QColor(0xd6, 0xff, 0xdd));
+        painter.drawEllipse(head, 1.6, 1.6);
+        painter.setClipping(false);
 
         if (m_debugEnabled) {
             painter.setBrush(Qt::NoBrush);
             painter.setPen(QPen(QColor(210, 164, 72), 1));
-            painter.drawRect(rect().adjusted(0, 0, -1, -1));
+            painter.drawRoundedRect(frame, 4, 4);
         }
     }
 
 private:
+    enum class SampleKind : quint8 { Idle = 0, Candidate = 1, Decode = 2 };
+
+    static constexpr int kFrameMs = 33;     // ~30 fps sweep animation
+    static constexpr int kPxPerFrame = 2;   // ~60 px/s; a 220 px strip ≈ 3.6 s
+
+    void resizeBuffers(int w)
+    {
+        const int n = qBound(60, w, 2000);
+        if (n == m_values.size())
+            return;
+        m_values = QVector<float>(n, 0.0f);
+        m_kinds = QVector<quint8>(n, quint8(SampleKind::Idle));
+        m_cursor = qMin(m_cursor, n - 1);
+    }
+
+    void enqueue(const float* shape, int count, SampleKind kind)
+    {
+        // Bound the backlog so a burst can't lag the pen seconds behind
+        // real time; newest data wins, matching the TX queue philosophy.
+        if (m_pending.size() > 96)
+            m_pending.clear();
+        for (int i = 0; i < count; ++i)
+            m_pending.append({ shape[i], quint8(kind) });
+    }
+
+    void wake()
+    {
+        if (!m_sweep.isActive() && isVisible())
+            m_sweep.start();
+    }
+
+    void advanceSweep()
+    {
+        const int n = m_values.size();
+        if (n <= 0)
+            return;
+        for (int step = 0; step < kPxPerFrame; ++step) {
+            m_cursor = (m_cursor + 1) % n;
+            if (!m_pending.isEmpty()) {
+                const PendingSample s = m_pending.takeFirst();
+                m_values[m_cursor] = s.value;
+                m_kinds[m_cursor] = s.kind;
+            } else {
+                // Idle pen: flat when squelched, a restless 1-2 px shimmer
+                // while the receive gate is open ("there is RF here").
+                const float wiggle = m_gateOpen
+                    ? 0.05f + 0.04f * float((m_cursor * 7) % 3)
+                    : 0.0f;
+                m_values[m_cursor] = wiggle;
+                m_kinds[m_cursor] = quint8(SampleKind::Idle);
+            }
+        }
+        // Freeze the trace (and stop repainting) once the modem stops
+        // delivering diagnostics and the backlog has drained.
+        if (m_pending.isEmpty() && m_lastTick.isValid()
+            && m_lastTick.elapsed() > 3000)
+            m_sweep.stop();
+        update();
+    }
+
     void updateToolTip()
     {
         setToolTip(m_debugEnabled
-            ? QStringLiteral("Packet diagnostics debug is on. Click to turn it off.")
-            : QStringLiteral("Packet diagnostics debug is off. Click to turn it on."));
+            ? QStringLiteral("Packet activity debug is on: raw decode log, AX.25 TX "
+                             "row and diagnostics are shown. Click to turn it off.")
+            : QStringLiteral("Each green heartbeat is a decoded packet; amber bumps "
+                             "are frames that failed the FCS. Click to show the raw "
+                             "decode log, AX.25 TX row and diagnostics."));
     }
 
-    QVector<int> m_levels;
+    struct PendingSample {
+        float value;
+        quint8 kind;
+    };
+
+    QVector<float> m_values;
+    QVector<quint8> m_kinds;
+    QList<PendingSample> m_pending;
+    QTimer m_sweep;
+    QElapsedTimer m_lastTick;
     int m_cursor{0};
+    bool m_gateOpen{false};
     bool m_debugEnabled{false};
     std::function<void()> m_clickHandler;
 };
@@ -768,9 +897,18 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     modemLayout->setContentsMargins(0, 0, 20, 0);
     modemLayout->setSpacing(12);
     modemLayout->addWidget(sectionLabel(QStringLiteral("MODEM"), modemCell));
+    auto* modemChecks = new QHBoxLayout;
+    modemChecks->setSpacing(20);
     m_enableDecode = new QCheckBox(QStringLiteral("Enable Modem"), modemCell);
-    modemLayout->addWidget(m_enableDecode);
-    controls->addWidget(modemCell, 1);
+    modemChecks->addWidget(m_enableDecode);
+    m_modemAutostart = new QCheckBox(QStringLiteral("Autostart at launch"), modemCell);
+    m_modemAutostart->setToolTip(QStringLiteral(
+        "Enable the modem automatically when AetherSDR starts."));
+    m_modemAutostart->setChecked(AprsSettings::modemAutostart());
+    modemChecks->addWidget(m_modemAutostart);
+    modemChecks->addStretch(1);
+    modemLayout->addLayout(modemChecks);
+    controls->addWidget(modemCell, 2);
     controls->addStretch(2);
 
     m_captureButton = new QPushButton(QStringLiteral("Capture 3m"), controlsFrame);
@@ -783,6 +921,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     ax25PageLayout->addWidget(controlsFrame);
 
     auto* txFrame = panel(QStringLiteral("ControlsFrame"), ax25Page);
+    m_txFrame = txFrame;
     auto* txLayout = new QHBoxLayout(txFrame);
     txLayout->setContentsMargins(16, 12, 16, 12);
     txLayout->setSpacing(12);
@@ -861,7 +1000,9 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_packetActivity = new PacketActivityWidget(statusBar);
     m_packetActivity->setMinimumHeight(18);
     m_packetActivity->setMaximumHeight(20);
-    m_packetActivity->setMinimumWidth(180);
+    // The EKG sweep is the main at-a-glance channel indicator now that the
+    // raw log hides behind the debug toggle — give it a wide strip.
+    m_packetActivity->setMinimumWidth(300);
     m_packetActivity->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     m_packetActivity->setClickHandler([this] {
         setDiagnosticsDebugEnabled(!m_diagnosticsDebugEnabled, true);
@@ -888,6 +1029,9 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     });
     connect(m_enableDecode, &QCheckBox::toggled,
             this, &Ax25HfPacketDecodeDialog::setDecodeEnabled);
+    connect(m_modemAutostart, &QCheckBox::toggled, this, [](bool on) {
+        AprsSettings::setModemAutostart(on);
+    });
     connect(m_clearButton, &QPushButton::clicked, this, [this] {
         m_log->clear();
         m_frameCount = 0;
@@ -1135,6 +1279,12 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     handleGpsUpdate();
     refreshAprsStationTable();
     updateAprsEnvelopeButton();
+
+    // Modem autostart: fires the toggled handler, which starts the RX tap.
+    // MainWindow constructs this dialog (hidden) at app launch when the
+    // setting is on, same as the KISS TNC start-on-startup path.
+    if (AprsSettings::modemAutostart() && m_enableDecode)
+        m_enableDecode->setChecked(true);
 
     // No control button may be the dialog's default button — otherwise pressing
     // Return in a text field would trigger it (Connect, Transmit, ...). Combined
@@ -1891,6 +2041,10 @@ void Ax25HfPacketDecodeDialog::setDiagnosticsDebugEnabled(bool enabled, bool per
             ? QStringLiteral("PACKET ACTIVITY DEBUG")
             : QStringLiteral("PACKET ACTIVITY"));
     }
+    // The raw decode log + raw AX.25 TX row on the APRS tab follow the debug
+    // flag; refresh the chrome so they appear/disappear immediately.
+    if (m_tabStack)
+        updateTabChrome(m_tabStack->currentIndex());
 
     if (persist) {
         AppSettings::instance().setValue(kPacketDecoderDebugSetting, enabled);
@@ -2623,17 +2777,22 @@ void Ax25HfPacketDecodeDialog::updateTabChrome(int index)
 {
     // The Terminal tab (stack index 2) wants the whole window: hide the shared
     // decode-log panel and give the tab stack the vertical stretch so the
-    // transcript fills the viewport. The APRS tab (index 0) keeps the raw log
-    // but the station table gets the lion's share of the height. Other tabs
+    // transcript fills the viewport. On the APRS tab (index 0) the raw decode
+    // log and the raw AX.25 TX row are debug chrome — shown only while Packet
+    // Activity Debug is on (click the activity trace to toggle), so the
+    // station table gets the full viewport in normal operation. Other tabs
     // keep the log panel below their controls.
     const bool terminal = (index == 2);
     const bool aprs = (index == 0);
+    const bool logVisible = !terminal && (!aprs || m_diagnosticsDebugEnabled);
     if (m_logFrame)
-        m_logFrame->setVisible(!terminal);
+        m_logFrame->setVisible(logVisible);
+    if (m_txFrame)
+        m_txFrame->setVisible(m_diagnosticsDebugEnabled);
     if (auto* root = qobject_cast<QVBoxLayout*>(bodyWidget()->layout())) {
-        root->setStretchFactor(m_tabStack, terminal ? 1 : (aprs ? 3 : 0));
+        root->setStretchFactor(m_tabStack, !logVisible ? 1 : (aprs ? 3 : 0));
         if (m_logFrame)
-            root->setStretchFactor(m_logFrame, terminal ? 0 : 1);
+            root->setStretchFactor(m_logFrame, logVisible ? 1 : 0);
     }
 }
 

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -11,6 +11,7 @@
 #include "core/aprs/AprsSettings.h"
 #include "core/aprs/AprsStationList.h"
 #include "gui/AprsMessagesDialog.h"
+#include "gui/AprsSymbolIcons.h"
 #include "core/tnc/Ax25.h"
 #include "core/tnc/Ax25FrameFormatter.h"
 #include "core/tnc/HeardList.h"
@@ -237,11 +238,12 @@ QPushButton:disabled {
     background: #0b1522;
 }
 QPushButton#TabButton {
-    border-radius: 6px;
+    border-radius: 5px;
     border: 1px solid transparent;
     background: transparent;
-    min-height: 40px;
-    font-size: 16px;
+    min-height: 20px;
+    padding: 4px 12px;
+    font-size: 13px;
 }
 QPushButton#TabButton:checked {
     color: #d4deea;
@@ -305,11 +307,15 @@ QLabel#ExperimentalBanner {
 QTableWidget {
     color: #c2ccdb;
     background: #050b13;
+    alternate-background-color: #081220;
     border: none;
     gridline-color: #14202f;
     font-family: "SF Mono", "Menlo", "Consolas", monospace;
     font-size: 13px;
     selection-background-color: #1b3650;
+}
+QTableWidget::item {
+    padding: 2px 10px;
 }
 QHeaderView::section {
     color: #8d99ad;
@@ -874,13 +880,13 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
 
     auto* controlsFrame = panel(QStringLiteral("ControlsFrame"), ax25Page);
     auto* controls = new QHBoxLayout(controlsFrame);
-    controls->setContentsMargins(16, 14, 16, 14);
+    controls->setContentsMargins(16, 10, 16, 10);
     controls->setSpacing(20);
 
     auto* baudCell = panel(QStringLiteral("ControlCell"), controlsFrame);
     auto* baudLayout = new QVBoxLayout(baudCell);
     baudLayout->setContentsMargins(0, 0, 20, 0);
-    baudLayout->setSpacing(12);
+    baudLayout->setSpacing(8);
     baudLayout->addWidget(sectionLabel(QStringLiteral("BAUD RATE"), baudCell));
     auto* baudButtons = new QHBoxLayout;
     baudButtons->setSpacing(34);
@@ -895,7 +901,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     auto* modemCell = panel(QStringLiteral("ControlCell"), controlsFrame);
     auto* modemLayout = new QVBoxLayout(modemCell);
     modemLayout->setContentsMargins(0, 0, 20, 0);
-    modemLayout->setSpacing(12);
+    modemLayout->setSpacing(8);
     modemLayout->addWidget(sectionLabel(QStringLiteral("MODEM"), modemCell));
     auto* modemChecks = new QHBoxLayout;
     modemChecks->setSpacing(20);
@@ -2041,8 +2047,13 @@ void Ax25HfPacketDecodeDialog::setDiagnosticsDebugEnabled(bool enabled, bool per
             ? QStringLiteral("PACKET ACTIVITY DEBUG")
             : QStringLiteral("PACKET ACTIVITY"));
     }
-    // The raw decode log + raw AX.25 TX row on the APRS tab follow the debug
-    // flag; refresh the chrome so they appear/disappear immediately.
+    // The raw decode log, raw AX.25 TX row, and the capture/clear-log
+    // buttons on the APRS tab are all diagnostics chrome — they follow the
+    // debug flag. Refresh so they appear/disappear immediately.
+    if (m_captureButton)
+        m_captureButton->setVisible(enabled);
+    if (m_clearButton)
+        m_clearButton->setVisible(enabled);
     if (m_tabStack)
         updateTabChrome(m_tabStack->currentIndex());
 
@@ -2817,6 +2828,21 @@ QString aprsAgeText(const QDateTime& utc)
     return QStringLiteral("%1d").arg(secs / 86400);
 }
 
+// Station-table column order. TIME is the operator's wall clock (local),
+// AGE keeps ticking so staleness is visible without doing date math.
+enum AprsColumn {
+    kColTime = 0,
+    kColCall,
+    kColSymbol,
+    kColAge,
+    kColPackets,
+    kColGrid,
+    kColDist,
+    kColCrsSpd,
+    kColText,
+    kColCount,
+};
+
 // The on-air-common symbols offered for our own beacon; data() carries the
 // two-character table+code pair.
 struct AprsSymbolChoice { const char* pair; const char* name; };
@@ -2860,8 +2886,10 @@ void Ax25HfPacketDecodeDialog::buildAprsUi(QWidget* page, QVBoxLayout* pageLayou
 
     config->addWidget(sectionLabel(QStringLiteral("SYMBOL"), configFrame), 0, 1);
     m_aprsSymbol = new QComboBox(configFrame);
+    m_aprsSymbol->setIconSize(QSize(16, 16));
     for (const AprsSymbolChoice& choice : kAprsSymbolChoices) {
-        m_aprsSymbol->addItem(QString::fromLatin1(choice.name),
+        m_aprsSymbol->addItem(aprsicons::symbolIcon(choice.pair[0], choice.pair[1]),
+                              QString::fromLatin1(choice.name),
                               QString::fromLatin1(choice.pair));
     }
     const int symbolIndex = m_aprsSymbol->findData(AprsSettings::symbol());
@@ -2948,20 +2976,24 @@ void Ax25HfPacketDecodeDialog::buildAprsUi(QWidget* page, QVBoxLayout* pageLayou
     tableLayout->setContentsMargins(8, 6, 8, 6);
     tableLayout->setSpacing(0);
     m_aprsTable = new QTableWidget(tableFrame);
-    m_aprsTable->setColumnCount(8);
+    m_aprsTable->setColumnCount(kColCount);
     m_aprsTable->setHorizontalHeaderLabels({
-        QStringLiteral("STATION"), QStringLiteral("SYMBOL"),
-        QStringLiteral("LAST"), QStringLiteral("PKTS"),
-        QStringLiteral("GRID"), QStringLiteral("DIST"),
-        QStringLiteral("CRS/SPD"), QStringLiteral("STATUS / COMMENT"),
+        QStringLiteral("TIME"), QStringLiteral("STATION"),
+        QStringLiteral("SYMBOL"), QStringLiteral("AGE"),
+        QStringLiteral("PKTS"), QStringLiteral("GRID"),
+        QStringLiteral("DIST"), QStringLiteral("CRS/SPD"),
+        QStringLiteral("STATUS / COMMENT"),
     });
     m_aprsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
     m_aprsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_aprsTable->setSelectionMode(QAbstractItemView::SingleSelection);
     m_aprsTable->verticalHeader()->setVisible(false);
+    m_aprsTable->verticalHeader()->setDefaultSectionSize(24);
+    m_aprsTable->setAlternatingRowColors(true);
+    m_aprsTable->setIconSize(QSize(16, 16));
     m_aprsTable->setShowGrid(false);
     m_aprsTable->setWordWrap(false);
-    m_aprsTable->horizontalHeader()->setSectionResizeMode(7, QHeaderView::Stretch);
+    m_aprsTable->horizontalHeader()->setSectionResizeMode(kColText, QHeaderView::Stretch);
     m_aprsTable->setMinimumHeight(160);
     m_aprsTable->setContextMenuPolicy(Qt::CustomContextMenu);
     tableLayout->addWidget(m_aprsTable);
@@ -2998,7 +3030,7 @@ void Ax25HfPacketDecodeDialog::buildAprsUi(QWidget* page, QVBoxLayout* pageLayou
             this, &Ax25HfPacketDecodeDialog::handleAprsStationMenu);
     connect(m_aprsTable, &QTableWidget::cellDoubleClicked,
             this, [this](int row, int) {
-        if (auto* item = m_aprsTable->item(row, 0)) {
+        if (auto* item = m_aprsTable->item(row, kColCall)) {
             m_aprsMsgTo->setText(item->data(Qt::UserRole).toString());
             m_aprsMsgText->setFocus();
         }
@@ -3097,7 +3129,7 @@ void Ax25HfPacketDecodeDialog::refreshAprsStationTable()
         return;
 
     QString selectedCall;
-    if (const auto* current = m_aprsTable->item(m_aprsTable->currentRow(), 0))
+    if (const auto* current = m_aprsTable->item(m_aprsTable->currentRow(), kColCall))
         selectedCall = current->data(Qt::UserRole).toString();
 
     double myLat = 0.0, myLon = 0.0;
@@ -3115,15 +3147,19 @@ void Ax25HfPacketDecodeDialog::refreshAprsStationTable()
             m_aprsTable->setItem(i, col, item);
             return item;
         };
-        set(0, s.call)->setData(Qt::UserRole, s.call);
-        set(1, s.hasPosition
+        set(kColTime,
+            s.lastHeard.toLocalTime().toString(QStringLiteral("MM/dd HH:mm:ss")));
+        set(kColCall, s.call)->setData(Qt::UserRole, s.call);
+        auto* symItem = set(kColSymbol, s.hasPosition
             ? aprs::symbolDescription(s.symbolTable, s.symbolCode)
             : aprs::packetTypeName(s.lastType));
-        set(2, aprsAgeText(s.lastHeard))
+        if (s.hasPosition)
+            symItem->setIcon(aprsicons::symbolIcon(s.symbolTable, s.symbolCode));
+        set(kColAge, aprsAgeText(s.lastHeard))
             ->setData(Qt::UserRole, s.lastHeard.toMSecsSinceEpoch());
-        set(3, QString::number(s.packets));
-        set(4, s.hasPosition ? aprs::gridSquare(s.latitude, s.longitude)
-                             : QString());
+        set(kColPackets, QString::number(s.packets));
+        set(kColGrid, s.hasPosition ? aprs::gridSquare(s.latitude, s.longitude)
+                                    : QString());
         QString dist;
         if (s.hasPosition && haveMyPos) {
             dist = QStringLiteral("%1 mi %2°")
@@ -3132,7 +3168,7 @@ void Ax25HfPacketDecodeDialog::refreshAprsStationTable()
                 .arg(qRound(aprs::bearingDeg(myLat, myLon,
                                              s.latitude, s.longitude)));
         }
-        set(5, dist);
+        set(kColDist, dist);
         QString crsSpd;
         if (s.speedKnots >= 0.0) {
             crsSpd = QStringLiteral("%1 mph")
@@ -3140,16 +3176,20 @@ void Ax25HfPacketDecodeDialog::refreshAprsStationTable()
             if (s.courseDeg >= 0.0)
                 crsSpd += QStringLiteral(" %1°").arg(qRound(s.courseDeg));
         }
-        set(6, crsSpd);
+        set(kColCrsSpd, crsSpd);
         QString text = !s.comment.isEmpty() ? s.comment : s.status;
         if (!s.comment.isEmpty() && !s.status.isEmpty())
             text = s.comment + QStringLiteral("  |  ") + s.status;
-        set(7, text);
+        set(kColText, text);
         if (s.call == selectedCall)
             selectRow = i;
     }
     m_aprsTable->resizeColumnsToContents();
-    m_aprsTable->horizontalHeader()->setSectionResizeMode(7, QHeaderView::Stretch);
+    // resizeColumnsToContents() packs columns shoulder-to-shoulder; pad each
+    // one so the table breathes. The last column stretches regardless.
+    for (int col = 0; col < kColText; ++col)
+        m_aprsTable->setColumnWidth(col, m_aprsTable->columnWidth(col) + 18);
+    m_aprsTable->horizontalHeader()->setSectionResizeMode(kColText, QHeaderView::Stretch);
     if (selectRow >= 0)
         m_aprsTable->selectRow(selectRow);
     m_aprsTable->setUpdatesEnabled(true);
@@ -3160,7 +3200,7 @@ void Ax25HfPacketDecodeDialog::refreshAprsStationAges()
     if (!m_aprsTable)
         return;
     for (int row = 0; row < m_aprsTable->rowCount(); ++row) {
-        if (auto* item = m_aprsTable->item(row, 2)) {
+        if (auto* item = m_aprsTable->item(row, kColAge)) {
             const QDateTime lastHeard = QDateTime::fromMSecsSinceEpoch(
                 item->data(Qt::UserRole).toLongLong(), QTimeZone::UTC);
             item->setText(aprsAgeText(lastHeard));
@@ -3173,7 +3213,7 @@ void Ax25HfPacketDecodeDialog::handleAprsStationMenu(const QPoint& pos)
     auto* hit = m_aprsTable->itemAt(pos);
     if (!hit)
         return;
-    const auto* callItem = m_aprsTable->item(hit->row(), 0);
+    const auto* callItem = m_aprsTable->item(hit->row(), kColCall);
     if (!callItem)
         return;
     const QString call = callItem->data(Qt::UserRole).toString();

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -3310,8 +3310,10 @@ void Ax25HfPacketDecodeDialog::refreshAprsStationAges()
         return;
     for (int row = 0; row < m_aprsTable->rowCount(); ++row) {
         if (auto* item = m_aprsTable->item(row, kColAge)) {
+            // QTimeZone::utc() rather than the Qt 6.5+ QTimeZone::UTC constant —
+            // the Linux CI image builds against an older Qt 6.
             const QDateTime lastHeard = QDateTime::fromMSecsSinceEpoch(
-                item->data(Qt::UserRole).toLongLong(), QTimeZone::UTC);
+                item->data(Qt::UserRole).toLongLong(), QTimeZone::utc());
             item->setText(aprsAgeText(lastHeard));
         }
         applyAprsRowFade(m_aprsTable, row);

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -2843,6 +2843,75 @@ enum AprsColumn {
     kColCount,
 };
 
+// Item data roles for the station table. Qt::UserRole carries the payload
+// the rest of the dialog reads (callsign / lastHeard msecs); the rest are
+// internal to sorting, age-fading, and icon refresh.
+constexpr int kAprsSortRole = Qt::UserRole + 1; // numeric sort key (double)
+constexpr int kAprsFadeRole = Qt::UserRole + 2; // last applied fade step
+constexpr int kAprsSymRole = Qt::UserRole + 3;  // "S:<table><code>" or "W:<n>"
+
+// QTableWidgetItem sorts by display text; give numeric columns (time, age,
+// packets, distance, speed) a real sort key instead.
+class AprsSortItem final : public QTableWidgetItem {
+public:
+    using QTableWidgetItem::QTableWidgetItem;
+    bool operator<(const QTableWidgetItem& other) const override
+    {
+        const QVariant a = data(kAprsSortRole);
+        const QVariant b = other.data(kAprsSortRole);
+        if (a.isValid() && b.isValid())
+            return a.toDouble() < b.toDouble();
+        return QTableWidgetItem::operator<(other);
+    }
+};
+
+// Age-fade: rows at full brightness for 5 minutes, then a linear fade down
+// to 50% at 30 minutes, where they stay. Active stations pop; the roster's
+// overnight tail recedes without disappearing.
+constexpr qint64 kAprsFadeStartSecs = 5 * 60;
+constexpr qint64 kAprsFadeEndSecs = 30 * 60;
+
+void applyAprsRowFade(QTableWidget* table, int row)
+{
+    auto* ageItem = table->item(row, kColAge);
+    if (!ageItem)
+        return;
+    const qint64 secs =
+        (QDateTime::currentMSecsSinceEpoch()
+         - ageItem->data(Qt::UserRole).toLongLong()) / 1000;
+    qreal opacity = 1.0;
+    if (secs >= kAprsFadeEndSecs) {
+        opacity = 0.5;
+    } else if (secs > kAprsFadeStartSecs) {
+        opacity = 1.0 - 0.5 * qreal(secs - kAprsFadeStartSecs)
+                            / qreal(kAprsFadeEndSecs - kAprsFadeStartSecs);
+    }
+    // Quantize to 5% steps so the per-second tick only repaints rows whose
+    // fade bucket actually changed.
+    const int step = qRound(opacity * 20.0);
+    if (ageItem->data(kAprsFadeRole).toInt() == step)
+        return;
+    ageItem->setData(kAprsFadeRole, step);
+
+    QColor text(0xc2, 0xcc, 0xdb);
+    text.setAlphaF(step / 20.0);
+    for (int col = 0; col < kColCount; ++col) {
+        if (auto* item = table->item(row, col))
+            item->setForeground(text);
+    }
+    if (auto* sym = table->item(row, kColSymbol)) {
+        const QString spec = sym->data(kAprsSymRole).toString();
+        QColor stroke(0xae, 0xb9, 0xcc);
+        stroke.setAlphaF(step / 20.0);
+        if (spec.startsWith(QLatin1String("W:"))) {
+            sym->setIcon(aprsicons::weatherIcon(spec.mid(2).toInt(), stroke));
+        } else if (spec.startsWith(QLatin1String("S:")) && spec.size() == 4) {
+            sym->setIcon(aprsicons::symbolIcon(spec.at(2).toLatin1(),
+                                               spec.at(3).toLatin1(), stroke));
+        }
+    }
+}
+
 // The on-air-common symbols offered for our own beacon; data() carries the
 // two-character table+code pair.
 struct AprsSymbolChoice { const char* pair; const char* name; };
@@ -2995,6 +3064,11 @@ void Ax25HfPacketDecodeDialog::buildAprsUi(QWidget* page, QVBoxLayout* pageLayou
     m_aprsTable->setWordWrap(false);
     m_aprsTable->horizontalHeader()->setSectionResizeMode(kColText, QHeaderView::Stretch);
     m_aprsTable->setMinimumHeight(160);
+    // Sortable headers; default order is most-recently-heard first. The
+    // rebuild re-applies whatever column/order the operator last clicked.
+    m_aprsTable->setSortingEnabled(true);
+    m_aprsTable->horizontalHeader()->setSortIndicator(kColTime, Qt::DescendingOrder);
+    m_aprsTable->horizontalHeader()->setSortIndicatorShown(true);
     m_aprsTable->setContextMenuPolicy(Qt::CustomContextMenu);
     tableLayout->addWidget(m_aprsTable);
     pageLayout->addWidget(tableFrame, 1);
@@ -3138,60 +3212,95 @@ void Ax25HfPacketDecodeDialog::refreshAprsStationTable()
 
     const QVector<AprsStationList::Station> stations = m_aprsStations->stations();
     m_aprsTable->setUpdatesEnabled(false);
+    // Populating with sorting live makes rows re-sort mid-insert; pause it
+    // and re-apply the operator's chosen column/order at the end.
+    const int sortColumn = m_aprsTable->horizontalHeader()->sortIndicatorSection();
+    const Qt::SortOrder sortOrder = m_aprsTable->horizontalHeader()->sortIndicatorOrder();
+    m_aprsTable->setSortingEnabled(false);
     m_aprsTable->setRowCount(stations.size());
-    int selectRow = -1;
     for (int i = 0; i < stations.size(); ++i) {
         const AprsStationList::Station& s = stations.at(i);
         auto set = [&](int col, const QString& text) {
-            auto* item = new QTableWidgetItem(text);
+            auto* item = new AprsSortItem(text);
             m_aprsTable->setItem(i, col, item);
             return item;
         };
-        set(kColTime,
+        const double heardMs = double(s.lastHeard.toMSecsSinceEpoch());
+        auto* timeItem = set(kColTime,
             s.lastHeard.toLocalTime().toString(QStringLiteral("MM/dd HH:mm:ss")));
+        timeItem->setData(kAprsSortRole, heardMs);
         set(kColCall, s.call)->setData(Qt::UserRole, s.call);
-        auto* symItem = set(kColSymbol, s.hasPosition
-            ? aprs::symbolDescription(s.symbolTable, s.symbolCode)
-            : aprs::packetTypeName(s.lastType));
-        if (s.hasPosition)
+
+        QTableWidgetItem* symItem = nullptr;
+        if (s.isWeather) {
+            static const char* kWxNames[] = {
+                "Weather", "Weather (rain)", "Weather (windy)" };
+            const int cond = qBound(0, s.wxCondition, 2);
+            symItem = set(kColSymbol, QString::fromLatin1(kWxNames[cond]));
+            symItem->setIcon(aprsicons::weatherIcon(cond));
+            symItem->setData(kAprsSymRole, QStringLiteral("W:%1").arg(cond));
+        } else if (s.hasPosition) {
+            symItem = set(kColSymbol,
+                          aprs::symbolDescription(s.symbolTable, s.symbolCode));
             symItem->setIcon(aprsicons::symbolIcon(s.symbolTable, s.symbolCode));
-        set(kColAge, aprsAgeText(s.lastHeard))
-            ->setData(Qt::UserRole, s.lastHeard.toMSecsSinceEpoch());
-        set(kColPackets, QString::number(s.packets));
+            symItem->setData(kAprsSymRole,
+                             QStringLiteral("S:%1%2")
+                                 .arg(QLatin1Char(s.symbolTable))
+                                 .arg(QLatin1Char(s.symbolCode)));
+        } else {
+            set(kColSymbol, aprs::packetTypeName(s.lastType));
+        }
+
+        auto* ageItem = set(kColAge, aprsAgeText(s.lastHeard));
+        ageItem->setData(Qt::UserRole, s.lastHeard.toMSecsSinceEpoch());
+        ageItem->setData(kAprsSortRole, -heardMs); // ascending age = newest first
+        set(kColPackets, QString::number(s.packets))
+            ->setData(kAprsSortRole, double(s.packets));
         set(kColGrid, s.hasPosition ? aprs::gridSquare(s.latitude, s.longitude)
                                     : QString());
         QString dist;
+        double distKey = 1e12; // unknown distances sort to the bottom
         if (s.hasPosition && haveMyPos) {
+            const double miles =
+                aprs::distanceMiles(myLat, myLon, s.latitude, s.longitude);
             dist = QStringLiteral("%1 mi %2°")
-                .arg(aprs::distanceMiles(myLat, myLon, s.latitude, s.longitude),
-                     0, 'f', 1)
+                .arg(miles, 0, 'f', 1)
                 .arg(qRound(aprs::bearingDeg(myLat, myLon,
                                              s.latitude, s.longitude)));
+            distKey = miles;
         }
-        set(kColDist, dist);
+        set(kColDist, dist)->setData(kAprsSortRole, distKey);
         QString crsSpd;
+        double speedKey = -1.0;
         if (s.speedKnots >= 0.0) {
-            crsSpd = QStringLiteral("%1 mph")
-                .arg(qRound(s.speedKnots * 1.15078));
+            const double mph = s.speedKnots * 1.15078;
+            crsSpd = QStringLiteral("%1 mph").arg(qRound(mph));
             if (s.courseDeg >= 0.0)
                 crsSpd += QStringLiteral(" %1°").arg(qRound(s.courseDeg));
+            speedKey = mph;
         }
-        set(kColCrsSpd, crsSpd);
+        set(kColCrsSpd, crsSpd)->setData(kAprsSortRole, speedKey);
         QString text = !s.comment.isEmpty() ? s.comment : s.status;
         if (!s.comment.isEmpty() && !s.status.isEmpty())
             text = s.comment + QStringLiteral("  |  ") + s.status;
         set(kColText, text);
-        if (s.call == selectedCall)
-            selectRow = i;
     }
+    m_aprsTable->setSortingEnabled(true);
+    m_aprsTable->sortItems(sortColumn, sortOrder);
     m_aprsTable->resizeColumnsToContents();
     // resizeColumnsToContents() packs columns shoulder-to-shoulder; pad each
     // one so the table breathes. The last column stretches regardless.
     for (int col = 0; col < kColText; ++col)
         m_aprsTable->setColumnWidth(col, m_aprsTable->columnWidth(col) + 18);
     m_aprsTable->horizontalHeader()->setSectionResizeMode(kColText, QHeaderView::Stretch);
-    if (selectRow >= 0)
-        m_aprsTable->selectRow(selectRow);
+    for (int row = 0; row < m_aprsTable->rowCount(); ++row) {
+        applyAprsRowFade(m_aprsTable, row);
+        if (!selectedCall.isEmpty()) {
+            const auto* callItem = m_aprsTable->item(row, kColCall);
+            if (callItem && callItem->data(Qt::UserRole).toString() == selectedCall)
+                m_aprsTable->selectRow(row);
+        }
+    }
     m_aprsTable->setUpdatesEnabled(true);
 }
 
@@ -3205,32 +3314,50 @@ void Ax25HfPacketDecodeDialog::refreshAprsStationAges()
                 item->data(Qt::UserRole).toLongLong(), QTimeZone::UTC);
             item->setText(aprsAgeText(lastHeard));
         }
+        applyAprsRowFade(m_aprsTable, row);
     }
 }
 
 void Ax25HfPacketDecodeDialog::handleAprsStationMenu(const QPoint& pos)
 {
-    auto* hit = m_aprsTable->itemAt(pos);
-    if (!hit)
-        return;
-    const auto* callItem = m_aprsTable->item(hit->row(), kColCall);
-    if (!callItem)
-        return;
-    const QString call = callItem->data(Qt::UserRole).toString();
-
     QMenu menu(m_aprsTable);
-    menu.addAction(QStringLiteral("Send Message to %1...").arg(call),
-                   this, [this, call] {
-        m_aprsMsgTo->setText(call);
-        m_aprsMsgText->setFocus();
+
+    // Station-specific actions only when the click landed on a row; the
+    // roster-wide actions below are available from anywhere in the table.
+    QString call;
+    if (auto* hit = m_aprsTable->itemAt(pos)) {
+        if (const auto* callItem = m_aprsTable->item(hit->row(), kColCall))
+            call = callItem->data(Qt::UserRole).toString();
+    }
+    if (!call.isEmpty()) {
+        menu.addAction(QStringLiteral("Send Message to %1...").arg(call),
+                       this, [this, call] {
+            m_aprsMsgTo->setText(call);
+            m_aprsMsgText->setFocus();
+        });
+        menu.addAction(QStringLiteral("Station Info..."), this, [this, call] {
+            showAprsStationInfo(call);
+        });
+        menu.addAction(QStringLiteral("View on aprs.fi"), this, [call] {
+            QDesktopServices::openUrl(
+                QUrl(QStringLiteral("https://aprs.fi/info/a/%1").arg(call)));
+        });
+        menu.addSeparator();
+    }
+    QAction* clearAll =
+        menu.addAction(QStringLiteral("Clear All Stations..."), this, [this] {
+        const int count = m_aprsStations->size();
+        const auto answer = QMessageBox::question(
+            this, QStringLiteral("Clear APRS Stations"),
+            QStringLiteral("Remove all %1 heard station%2? "
+                           "This also clears the saved roster on disk.")
+                .arg(count)
+                .arg(count == 1 ? QString() : QStringLiteral("s")));
+        if (answer == QMessageBox::Yes)
+            m_aprsStations->clear();
     });
-    menu.addAction(QStringLiteral("Station Info..."), this, [this, call] {
-        showAprsStationInfo(call);
-    });
-    menu.addAction(QStringLiteral("View on aprs.fi"), this, [call] {
-        QDesktopServices::openUrl(
-            QUrl(QStringLiteral("https://aprs.fi/info/a/%1").arg(call)));
-    });
+    clearAll->setEnabled(m_aprsStations && m_aprsStations->size() > 0);
+
     menu.exec(m_aprsTable->viewport()->mapToGlobal(pos));
 }
 

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -186,8 +186,10 @@ private:
     QRadioButton* m_hf300Profile{nullptr};
     QRadioButton* m_vhf1200Profile{nullptr};
     QCheckBox* m_enableDecode{nullptr};
+    QCheckBox* m_modemAutostart{nullptr};
     QLineEdit* m_txText{nullptr};
     QPushButton* m_txButton{nullptr};
+    QWidget* m_txFrame{nullptr};
     QTextEdit* m_log{nullptr};
     QWidget* m_logFrame{nullptr};
     QLabel* m_modemStatusDot{nullptr};

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -21,11 +21,17 @@ class QPushButton;
 class QRadioButton;
 class QSpinBox;
 class QStackedWidget;
+class QTableWidget;
 class QTextEdit;
 class QTimer;
+class QVBoxLayout;
 
 namespace AetherSDR {
 
+class AprsBeacon;
+class AprsMessagesDialog;
+class AprsMessenger;
+class AprsStationList;
 class AudioEngine;
 class HeardList;
 class KissTncServer;
@@ -112,6 +118,19 @@ private:
     void paceTransmitAudio();
     void finishTransmit(bool aborted, const QString& reason);
 
+    // APRS client (APRS tab): station table, timed beacon, messaging.
+    void buildAprsUi(QWidget* page, QVBoxLayout* pageLayout);
+    void applyAprsConfigFromUi(bool persist);
+    void refreshAprsStationTable();
+    void refreshAprsStationAges();
+    void refreshAprsPositionLabel();
+    void handleAprsStationMenu(const QPoint& pos);
+    void showAprsStationInfo(const QString& call);
+    void openAprsMessagesDialog();
+    void sendAprsMessageFromUi();
+    void updateAprsEnvelopeButton();
+    void handleGpsUpdate();
+
     // Personal Mailbox System (PMS) tab + service wiring.
     QWidget* buildMailboxPage();
     void setPmsEnabled(bool enabled, bool persist);
@@ -171,7 +190,6 @@ private:
     QPushButton* m_txButton{nullptr};
     QTextEdit* m_log{nullptr};
     QWidget* m_logFrame{nullptr};
-    QWidget* m_actionRowFrame{nullptr};
     QLabel* m_modemStatusDot{nullptr};
     QLabel* m_modemStatusValue{nullptr};
     QLabel* m_gainStageDot{nullptr};
@@ -235,6 +253,27 @@ private:
 
     // Shared station-heard log (feeds the terminal MHEARD + quick-connect).
     HeardList* m_heard{nullptr};
+
+    // APRS client services (APRS tab) and its controls.
+    AprsStationList* m_aprsStations{nullptr};
+    AprsMessenger* m_aprsMessenger{nullptr};
+    AprsBeacon* m_aprsBeacon{nullptr};
+    QPointer<AprsMessagesDialog> m_aprsMessagesDialog;
+    QTableWidget* m_aprsTable{nullptr};
+    QLineEdit* m_aprsMyCall{nullptr};
+    QComboBox* m_aprsSymbol{nullptr};
+    QLineEdit* m_aprsPath{nullptr};
+    QCheckBox* m_aprsBeaconEnable{nullptr};
+    QSpinBox* m_aprsBeaconInterval{nullptr};
+    QLineEdit* m_aprsBeaconText{nullptr};
+    QPushButton* m_aprsBeaconNow{nullptr};
+    QLabel* m_aprsPositionValue{nullptr};
+    QLineEdit* m_aprsManualLat{nullptr};
+    QLineEdit* m_aprsManualLon{nullptr};
+    QLineEdit* m_aprsMsgTo{nullptr};
+    QLineEdit* m_aprsMsgText{nullptr};
+    QPushButton* m_aprsMsgSend{nullptr};
+    QPushButton* m_aprsEnvelope{nullptr};
 
     // TNC Terminal service (connected-mode AX.25 client) and its controls.
     TncTerminal* m_terminal{nullptr};

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -34,6 +34,7 @@
 #include "core/PipeWireAudioBridge.h"
 #endif
 #include "core/AppSettings.h"
+#include "core/aprs/AprsSettings.h"
 #include "core/LogManager.h"
 #include "models/BandPlanManager.h"
 #include "models/RadioModel.h"
@@ -84,12 +85,16 @@ void MainWindow::startKissTncOnStartupIfConfigured()
     // the nested-JSON blob (Constitution Principle V). Safe to call on
     // every startup — no-op once the blob exists.
     TncSettings::migrateLegacy();
-    if (!TncSettings::startOnStartup())
+    // Two launch-time services live in the AetherModem dialog: the KISS TCP
+    // server and the APRS modem autostart. Either one warrants constructing
+    // the dialog now.
+    if (!TncSettings::startOnStartup() && !AprsSettings::modemAutostart())
         return;
 
     // Construct the AetherModem window hidden and persistent (no WA_DeleteOnClose)
-    // so the KISS TCP server runs from launch and survives the window being
-    // closed. The dialog's constructor auto-starts the TNC per the same setting.
+    // so the KISS TCP server / APRS modem runs from launch and survives the
+    // window being closed. The dialog's constructor auto-starts the TNC and
+    // the modem per their respective settings.
     auto* dlg = new Ax25HfPacketDecodeDialog(m_audio, &m_radioModel, activeSlice(), this);
     dlg->setFramelessMode(
         AppSettings::instance().value("FramelessWindow", "True").toString() == "True");

--- a/tests/aprs_messenger_test.cpp
+++ b/tests/aprs_messenger_test.cpp
@@ -1,0 +1,182 @@
+// Unit tests for the APRS messaging engine (core/aprs/AprsMessenger.*):
+// outgoing message numbering + ack matching, incoming auto-ack and duplicate
+// suppression, unread tracking, and the station roster's digipeat dedupe
+// (core/aprs/AprsStationList.*). Pure protocol layer — no DSP, no radio.
+
+#include "core/aprs/AprsMessenger.h"
+#include "core/aprs/AprsPacket.h"
+#include "core/aprs/AprsStationList.h"
+#include "core/tnc/Ax25.h"
+
+#include <QCoreApplication>
+#include <QVector>
+
+#include <cstdio>
+#include <optional>
+
+using namespace AetherSDR;
+using AetherSDR::ax25::Address;
+using AetherSDR::ax25::Frame;
+
+static int g_failures = 0;
+
+#define CHECK(cond, msg)                                                        \
+    do {                                                                        \
+        if (!(cond)) {                                                          \
+            std::fprintf(stderr, "FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__);\
+            ++g_failures;                                                       \
+        }                                                                       \
+    } while (0)
+
+static aprs::Packet parseInfo(const QString& src, const QByteArray& info)
+{
+    const Frame f = Frame::makeUI(*Address::parse(QStringLiteral("APRS")),
+                                  *Address::parse(src), {}, info);
+    const auto pkt = aprs::parseFrame(f);
+    return pkt.value_or(aprs::Packet{});
+}
+
+static void testOutgoingAckFlow()
+{
+    AprsMessenger messenger;
+    messenger.setMyAddress(*Address::parse(QStringLiteral("N0CALL-9")));
+
+    QVector<QByteArray> sentFrames;
+    QObject::connect(&messenger, &AprsMessenger::transmitFrame,
+                     [&sentFrames](const QByteArray& raw) {
+        sentFrames.append(raw);
+    });
+
+    CHECK(messenger.sendMessage(QStringLiteral("W1AW"),
+                                QStringLiteral("Hello there")),
+          "sendMessage accepts a valid destination");
+    CHECK(sentFrames.size() == 1, "one frame transmitted");
+    CHECK(!messenger.sendMessage(QStringLiteral(""), QStringLiteral("x")),
+          "empty destination rejected");
+    CHECK(!messenger.sendMessage(QStringLiteral("TOOLONGCALL"),
+                                 QStringLiteral("x")),
+          "invalid destination rejected");
+
+    // The transmitted frame must decode to the expected APRS message.
+    const auto decoded = Frame::decode(sentFrames.first());
+    CHECK(decoded.has_value(), "transmitted frame decodes");
+    if (decoded) {
+        const auto pkt = aprs::parseFrame(*decoded);
+        CHECK(pkt && pkt->type == aprs::PacketType::Message,
+              "transmitted frame is an APRS message");
+        CHECK(pkt && pkt->addressee == QStringLiteral("W1AW"),
+              "addressee on the air");
+        CHECK(pkt && pkt->messageText == QStringLiteral("Hello there"),
+              "text on the air");
+        CHECK(pkt && !pkt->messageNo.isEmpty(), "message number assigned");
+    }
+
+    auto msgs = messenger.messages();
+    CHECK(msgs.size() == 1, "one message stored");
+    CHECK(msgs.first().state == AprsMessenger::State::Sent, "state Sent");
+    const QString msgNo = msgs.first().msgNo;
+
+    // Ack from the wrong station must not match.
+    messenger.onPacket(parseInfo(QStringLiteral("K1ABC"),
+        QStringLiteral(":N0CALL-9 :ack%1").arg(msgNo).toLatin1()));
+    CHECK(messenger.messages().first().state == AprsMessenger::State::Sent,
+          "ack from wrong station ignored");
+
+    // Ack from the right station closes it out.
+    messenger.onPacket(parseInfo(QStringLiteral("W1AW"),
+        QStringLiteral(":N0CALL-9 :ack%1").arg(msgNo).toLatin1()));
+    CHECK(messenger.messages().first().state == AprsMessenger::State::Acked,
+          "ack from the destination marks Acked");
+}
+
+static void testIncomingAutoAckAndDedupe()
+{
+    AprsMessenger messenger;
+    messenger.setMyAddress(*Address::parse(QStringLiteral("N0CALL-9")));
+
+    QVector<QByteArray> sentFrames;
+    int received = 0;
+    QObject::connect(&messenger, &AprsMessenger::transmitFrame,
+                     [&sentFrames](const QByteArray& raw) {
+        sentFrames.append(raw);
+    });
+    QObject::connect(&messenger, &AprsMessenger::messageReceived,
+                     [&received](const AprsMessenger::Message&) { ++received; });
+
+    // Message addressed to someone else: ignored entirely.
+    messenger.onPacket(parseInfo(QStringLiteral("W1AW"),
+                                 QByteArray(":K1ABC    :not for us{001")));
+    CHECK(received == 0 && sentFrames.isEmpty() && messenger.messages().isEmpty(),
+          "message for another station ignored");
+
+    // Message for us: stored unread and auto-acked.
+    messenger.onPacket(parseInfo(QStringLiteral("W1AW"),
+                                 QByteArray(":N0CALL-9 :QSL?{042")));
+    CHECK(received == 1, "messageReceived emitted");
+    CHECK(messenger.unreadCount() == 1, "unread count 1");
+    CHECK(sentFrames.size() == 1, "auto-ack transmitted");
+    if (!sentFrames.isEmpty()) {
+        const auto ackFrame = Frame::decode(sentFrames.first());
+        std::optional<aprs::Packet> ack;
+        if (ackFrame)
+            ack = aprs::parseFrame(*ackFrame);
+        CHECK(ack && ack->type == aprs::PacketType::MessageAck
+                  && ack->messageNo == QStringLiteral("042")
+                  && ack->addressee == QStringLiteral("W1AW"),
+              "auto-ack carries the sender's message number");
+    }
+
+    // The sender retries the same {042}: re-ack but don't store a duplicate.
+    messenger.onPacket(parseInfo(QStringLiteral("W1AW"),
+                                 QByteArray(":N0CALL-9 :QSL?{042")));
+    CHECK(received == 1, "duplicate not re-delivered");
+    CHECK(messenger.messages().size() == 1, "duplicate not stored");
+    CHECK(sentFrames.size() == 2, "duplicate still re-acked");
+
+    messenger.markAllRead();
+    CHECK(messenger.unreadCount() == 0, "markAllRead clears the badge");
+
+    // Our own digipeated frame must not loop back into the store.
+    messenger.onPacket(parseInfo(QStringLiteral("N0CALL-9"),
+                                 QByteArray(":N0CALL-9 :echo{077")));
+    CHECK(messenger.messages().size() == 1, "own digipeated frame ignored");
+}
+
+static void testStationListDedupe()
+{
+    AprsStationList stations;
+    const aprs::Packet pkt = parseInfo(
+        QStringLiteral("W1AW-1"),
+        QByteArray("!4903.50N/07201.75W-Direct copy"));
+
+    CHECK(stations.record(pkt), "first copy recorded");
+    CHECK(!stations.record(pkt), "digipeated duplicate dropped");
+    CHECK(stations.size() == 1, "one station");
+    const auto s = stations.find(QStringLiteral("W1AW-1"));
+    CHECK(s.has_value(), "station findable");
+    CHECK(s && s->packets == 1, "duplicate did not inflate the packet count");
+    CHECK(s && s->hasPosition, "position merged");
+
+    // A different payload from the same station is new traffic.
+    CHECK(stations.record(parseInfo(QStringLiteral("W1AW-1"),
+                                    QByteArray(">Status text"))),
+          "new payload recorded");
+    const auto s2 = stations.find(QStringLiteral("W1AW-1"));
+    CHECK(s2 && s2->packets == 2, "packet count advanced");
+    CHECK(s2 && s2->status == QStringLiteral("Status text"), "status merged");
+    CHECK(s2 && s2->hasPosition, "status did not clobber the position");
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    testOutgoingAckFlow();
+    testIncomingAutoAckAndDedupe();
+    testStationListDedupe();
+    if (g_failures) {
+        std::fprintf(stderr, "%d failure(s)\n", g_failures);
+        return 1;
+    }
+    std::printf("aprs_messenger_test: all tests passed\n");
+    return 0;
+}

--- a/tests/aprs_packet_test.cpp
+++ b/tests/aprs_packet_test.cpp
@@ -170,6 +170,62 @@ static void testMessages()
           "unnumbered message");
 }
 
+static void testWeather()
+{
+    // Positionless report (APRS 1.0.1 ch. 12 worked example):
+    // wind 220° at 4 mph gusting 5, 77°F, 50% humidity, 990.0 mbar.
+    const auto wx = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("KD0XYZ"), QStringLiteral("APRS"),
+        QByteArray("_10090556c220s004g005t077r000p000P000h50b09900wRSW")));
+    CHECK(wx.has_value() && wx->type == aprs::PacketType::Weather,
+          "positionless weather parses");
+    if (wx) {
+        CHECK(wx->weather.valid, "weather data valid");
+        CHECK(wx->weather.windDirDeg == 220, "wind direction");
+        CHECK(near(wx->weather.windMph, 4.0, 0.1), "wind speed mph");
+        CHECK(near(wx->weather.gustMph, 5.0, 0.1), "gust");
+        CHECK(near(wx->weather.temperatureF, 77.0, 0.1), "temperature");
+        CHECK(wx->weather.humidityPct == 50, "humidity");
+        CHECK(near(wx->weather.pressureMbar, 990.0, 0.1), "pressure");
+        CHECK(near(wx->weather.rainHourIn, 0.0, 0.001), "rain hour zero");
+        CHECK(wx->comment.contains(QStringLiteral("77°F")),
+              "summary lands in the comment");
+        CHECK(wx->comment.contains(QStringLiteral("Wind 220° 4 mph (gust 5)")),
+              "summary wind text");
+    }
+
+    // Position report with the WX symbol '_': wind rides the CSE/SPD
+    // extension (knots), the token stream follows in the comment.
+    const auto pwx = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("KD0XYZ"), QStringLiteral("APRS"),
+        QByteArray("!4903.50N/07201.75W_220/004g005t077h50b09900")));
+    CHECK(pwx.has_value() && pwx->type == aprs::PacketType::Weather,
+          "position weather parses");
+    if (pwx) {
+        CHECK(pwx->hasPosition, "position weather has position");
+        CHECK(pwx->weather.valid, "position weather data valid");
+        CHECK(pwx->weather.windDirDeg == 220, "position weather wind dir");
+        CHECK(near(pwx->weather.windMph, 4.0 * 1.15078, 0.1),
+              "extension wind knots converted to mph");
+        CHECK(pwx->speedKnots < 0 && pwx->courseDeg < 0,
+              "wind not reported as station movement");
+        CHECK(near(pwx->weather.temperatureF, 77.0, 0.1),
+              "position weather temperature");
+    }
+
+    // "h00" means 100% humidity; missing sensors ("...") are skipped.
+    const auto edge = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("KD0XYZ"), QStringLiteral("APRS"),
+        QByteArray("_10090556c...s...g...t-04r...p...P...h00b.....")));
+    CHECK(edge.has_value() && edge->weather.valid, "sparse weather parses");
+    if (edge) {
+        CHECK(edge->weather.windDirDeg < 0, "missing wind dir stays unknown");
+        CHECK(near(edge->weather.temperatureF, -4.0, 0.1), "negative temperature");
+        CHECK(edge->weather.humidityPct == 100, "h00 is 100 percent");
+        CHECK(edge->weather.pressureMbar < 0, "missing pressure stays unknown");
+    }
+}
+
 static void testEncoders()
 {
     const QString pos = aprs::encodeUncompressedPosition(
@@ -220,6 +276,7 @@ int main(int argc, char** argv)
     testMicE();
     testStatus();
     testMessages();
+    testWeather();
     testEncoders();
     testGeoHelpers();
     if (g_failures) {

--- a/tests/aprs_packet_test.cpp
+++ b/tests/aprs_packet_test.cpp
@@ -1,0 +1,231 @@
+// Unit tests for the APRS info-field codec (core/aprs/AprsPacket.*):
+// position parsing in uncompressed, compressed and Mic-E form, status,
+// messages/acks, the outbound encoders, and the geo helpers. Reference
+// vectors come from APRS Protocol Reference 1.0.1 worked examples.
+
+#include "core/aprs/AprsPacket.h"
+#include "core/tnc/Ax25.h"
+
+#include <QCoreApplication>
+#include <QString>
+
+#include <cmath>
+#include <cstdio>
+
+using namespace AetherSDR;
+using AetherSDR::ax25::Address;
+using AetherSDR::ax25::Frame;
+
+static int g_failures = 0;
+
+#define CHECK(cond, msg)                                                        \
+    do {                                                                        \
+        if (!(cond)) {                                                          \
+            std::fprintf(stderr, "FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__);\
+            ++g_failures;                                                       \
+        }                                                                       \
+    } while (0)
+
+static bool near(double a, double b, double tol)
+{
+    return std::fabs(a - b) <= tol;
+}
+
+static Frame makeUiFrame(const QString& src, const QString& dest,
+                         const QByteArray& info)
+{
+    Frame f = Frame::makeUI(*Address::parse(dest), *Address::parse(src),
+                            {}, info);
+    return f;
+}
+
+static void testUncompressedPosition()
+{
+    // APRS 1.0.1 ch. 8 worked example (no timestamp, no messaging).
+    const auto pkt = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("N0CALL-9"), QStringLiteral("APRS"),
+        QByteArray("!4903.50N/07201.75W-Test 001234")));
+    CHECK(pkt.has_value(), "uncompressed position parses");
+    if (!pkt)
+        return;
+    CHECK(pkt->type == aprs::PacketType::Position, "type Position");
+    CHECK(pkt->hasPosition, "hasPosition");
+    CHECK(near(pkt->latitude, 49.0583, 0.001), "latitude");
+    CHECK(near(pkt->longitude, -72.0292, 0.001), "longitude");
+    CHECK(pkt->symbolTable == '/' && pkt->symbolCode == '-', "symbol home");
+    CHECK(!pkt->messagingCapable, "'!' is not messaging-capable");
+    CHECK(pkt->comment == QStringLiteral("Test 001234"), "comment preserved");
+    CHECK(pkt->source == QStringLiteral("N0CALL-9"), "source call");
+}
+
+static void testTimestampedPositionWithExtensions()
+{
+    // '@' DTI, 7-char timestamp, course/speed extension and /A= altitude.
+    const auto pkt = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("W1AW"), QStringLiteral("APRS"),
+        QByteArray("@092345z4903.50N/07201.75W>088/036/A=001234Moving east")));
+    CHECK(pkt.has_value(), "timestamped position parses");
+    if (!pkt)
+        return;
+    CHECK(pkt->hasPosition, "hasPosition (timestamped)");
+    CHECK(pkt->messagingCapable, "'@' is messaging-capable");
+    CHECK(near(pkt->courseDeg, 88.0, 0.1), "course extension");
+    CHECK(near(pkt->speedKnots, 36.0, 0.1), "speed extension");
+    CHECK(pkt->hasAltitude, "altitude extension found");
+    CHECK(near(pkt->altitudeFeet, 1234.0, 0.1), "altitude feet");
+    CHECK(pkt->comment == QStringLiteral("Moving east"), "comment after extensions");
+}
+
+static void testCompressedPosition()
+{
+    // APRS 1.0.1 ch. 9 worked example: "/5L!!<*e7>{?!" decodes to
+    // 49.5 N, 72.75 W with symbol '>' (car).
+    const auto pkt = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("N0CALL"), QStringLiteral("APRS"),
+        QByteArray("!/5L!!<*e7> sTComment")));
+    CHECK(pkt.has_value(), "compressed position parses");
+    if (!pkt)
+        return;
+    CHECK(pkt->hasPosition, "hasPosition (compressed)");
+    CHECK(near(pkt->latitude, 49.5, 0.01), "compressed latitude");
+    CHECK(near(pkt->longitude, -72.75, 0.01), "compressed longitude");
+    CHECK(pkt->symbolCode == '>', "compressed symbol code");
+    CHECK(pkt->comment == QStringLiteral("Comment"), "compressed comment");
+}
+
+static void testMicE()
+{
+    // APRS 1.0.1 ch. 10 worked example: dest "SSRUVT" encodes 33° 25.64' N
+    // (digits 3,3,2,5,6,4; chars 4-6 in P-Z set North / +100 lon / West),
+    // info "`(_fn\"Oj/" → 112° 07.74' W, speed 20 kt, course 251°,
+    // symbol '/j' (jeep).
+    QByteArray info;
+    info.append('`');
+    info.append('(');
+    info.append('_');
+    info.append(char(0x66)); // 'f'
+    info.append('n');
+    info.append('"');
+    info.append('O');
+    info.append('j');  // symbol code
+    info.append('/');  // symbol table
+    const auto pkt = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("N6XYZ-1"), QStringLiteral("SSRUVT"), info));
+    CHECK(pkt.has_value(), "Mic-E parses");
+    if (!pkt)
+        return;
+    CHECK(pkt->type == aprs::PacketType::Position, "Mic-E is a position");
+    CHECK(pkt->hasPosition, "Mic-E hasPosition");
+    CHECK(near(pkt->latitude, 33.0 + 25.64 / 60.0, 0.001), "Mic-E latitude");
+    CHECK(near(pkt->longitude, -(112.0 + 7.74 / 60.0), 0.001), "Mic-E longitude");
+    CHECK(near(pkt->speedKnots, 20.0, 0.5), "Mic-E speed");
+    CHECK(near(pkt->courseDeg, 251.0, 0.5), "Mic-E course");
+    CHECK(pkt->symbolCode == 'j' && pkt->symbolTable == '/', "Mic-E symbol");
+}
+
+static void testStatus()
+{
+    const auto pkt = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("N0CALL"), QStringLiteral("APRS"),
+        QByteArray(">Net Control Center")));
+    CHECK(pkt.has_value() && pkt->type == aprs::PacketType::Status,
+          "status parses");
+    CHECK(pkt && pkt->comment == QStringLiteral("Net Control Center"),
+          "status text");
+}
+
+static void testMessages()
+{
+    // Addressed message with message number.
+    const auto msg = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("WU2Z"), QStringLiteral("APRS"),
+        QByteArray(":KH2Z     :Testing{003")));
+    CHECK(msg.has_value() && msg->type == aprs::PacketType::Message,
+          "message parses");
+    CHECK(msg && msg->addressee == QStringLiteral("KH2Z"), "addressee trimmed");
+    CHECK(msg && msg->messageText == QStringLiteral("Testing"), "message text");
+    CHECK(msg && msg->messageNo == QStringLiteral("003"), "message number");
+
+    // Ack.
+    const auto ack = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("KH2Z"), QStringLiteral("APRS"),
+        QByteArray(":WU2Z     :ack003")));
+    CHECK(ack.has_value() && ack->type == aprs::PacketType::MessageAck,
+          "ack parses");
+    CHECK(ack && ack->messageNo == QStringLiteral("003"), "ack number");
+
+    // Rej.
+    const auto rej = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("KH2Z"), QStringLiteral("APRS"),
+        QByteArray(":WU2Z     :rej003")));
+    CHECK(rej.has_value() && rej->type == aprs::PacketType::MessageRej,
+          "rej parses");
+
+    // Unnumbered message.
+    const auto plain = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("WU2Z"), QStringLiteral("APRS"),
+        QByteArray(":KH2Z     :Hello")));
+    CHECK(plain && plain->type == aprs::PacketType::Message
+              && plain->messageNo.isEmpty(),
+          "unnumbered message");
+}
+
+static void testEncoders()
+{
+    const QString pos = aprs::encodeUncompressedPosition(
+        49.0583333, -72.0291667, '/', '-', QStringLiteral("Test"), true);
+    CHECK(pos == QStringLiteral("=4903.50N/07201.75W-Test"),
+          "position encoder round-trips the reference vector");
+
+    // Encoder output must parse back to the same coordinates.
+    const auto rt = aprs::parseFrame(makeUiFrame(
+        QStringLiteral("N0CALL"), QStringLiteral("APRS"), pos.toLatin1()));
+    CHECK(rt && rt->hasPosition && rt->messagingCapable,
+          "encoded position parses back");
+    CHECK(rt && near(rt->latitude, 49.0583, 0.001)
+              && near(rt->longitude, -72.0292, 0.001),
+          "round-trip coordinates");
+
+    CHECK(aprs::encodeMessage(QStringLiteral("KH2Z"), QStringLiteral("Testing"),
+                              QStringLiteral("3"))
+              == QStringLiteral(":KH2Z     :Testing{3"),
+          "message encoder pads addressee to 9");
+    CHECK(aprs::encodeAck(QStringLiteral("WU2Z"), QStringLiteral("003"))
+              == QStringLiteral(":WU2Z     :ack003"),
+          "ack encoder");
+    CHECK(aprs::encodeStatus(QStringLiteral("hi")) == QStringLiteral(">hi"),
+          "status encoder");
+}
+
+static void testGeoHelpers()
+{
+    CHECK(aprs::gridSquare(48.27, -116.56) == QStringLiteral("DN18rg"),
+          "grid square matches the radio's own GPS grid");
+    // Newington CT → Seattle WA: 2428.9 statute miles by haversine on the
+    // mean Earth radius, initial bearing ~285°.
+    const double mi = aprs::distanceMiles(41.71, -72.73, 47.61, -122.33);
+    CHECK(near(mi, 2428.9, 5.0), "great-circle distance");
+    const double brg = aprs::bearingDeg(41.71, -72.73, 47.61, -122.33);
+    CHECK(brg > 280.0 && brg < 300.0, "initial bearing");
+    CHECK(aprs::symbolDescription('/', '-') == QStringLiteral("Home"),
+          "symbol description");
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    testUncompressedPosition();
+    testTimestampedPositionWithExtensions();
+    testCompressedPosition();
+    testMicE();
+    testStatus();
+    testMessages();
+    testEncoders();
+    testGeoHelpers();
+    if (g_failures) {
+        std::fprintf(stderr, "%d failure(s)\n", g_failures);
+        return 1;
+    }
+    std::printf("aprs_packet_test: all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION

<img width="1241" height="814" alt="image" src="https://github.com/user-attachments/assets/7b85628d-af7b-4e3f-931a-fcfcb0c44c03" />

## Summary

The AetherModem AX.25 tab becomes a basic, lightweight **APRS client**: a live station table with wireframe symbol icons and weather decode, a timed GPS position beacon, and two-way APRS messaging — all riding the existing AFSK modem (300/1200 baud) and the shared one-at-a-time TX keying/pacing queue, so APRS traffic can never double-key against KISS clients, the PMS mailbox, or the terminal.

## New core layer — `src/core/aprs/` (Qt Core only, unit-tested standalone)

| Class | What it does |
|---|---|
| `AprsPacket` | APRS 1.0.1 info-field codec. Parses uncompressed, compressed (base-91) and **Mic-E** positions (course/speed, `/A=` + Mic-E altitude, position ambiguity), status, messages, acks/rejs, objects, items, and **weather reports** (see below). Encoders for the beacon, messages, acks. Maidenhead grid, haversine distance/bearing, symbol names. |
| `AprsStationList` | Station roster: merges position/movement/free-text/weather across packet types per station; suppresses digipeated duplicates (same source+info within 30 s) so packet counts reflect originated traffic; persists to `tnc/aprs-stations.json` with coalesced saves. |
| `AprsMessenger` | Messaging engine: outgoing messages get a sequential `{msgNo}` and retry every 30 s (max 4) until acked; incoming messages addressed to us are stored unread, **auto-acked** (and re-acked when the sender retries — a duplicate means our ack was lost), de-duplicated; persisted history. |
| `AprsBeacon` | Interval position beacon fed by the radio's **onboard GPS** (`RadioModel::gpsStatusChanged`, used when the status reports a lock — FLEX-8000-class/Aurora) with a manual lat/lon fallback. Enabling only arms the timer; "Beacon Now" is the explicit immediate send — nothing transmits by itself on startup restore. |
| `AprsSettings` | Nested-JSON config blob under a single AppSettings key (`AetherModemAprs`), per Constitution Principle V. |

## APRS tab UI

**Station table** (scrolls, newest-first by default):
- Columns: local-time **TIME**, station, symbol, ticking **AGE**, packets, grid, **distance + bearing from our own position**, course/speed, status/comment.
- **Sortable headers** with numeric sort keys for TIME / AGE / PKTS / DIST / CRS/SPD; unknown distances sort to the bottom; the chosen sort survives rebuilds.
- **Age-fade rows**: full brightness ≤ 5 min, linear fade to 50% at 30 min — active stations pop, the overnight tail recedes without disappearing.
- **Wireframe symbol icons** (`AprsSymbolIcons`): ~25 programmatic 1.5 px line-art icons (house, vehicles, boats, aircraft, balloon, towers, yagi, weather, services...) drawn at 2× for retina and cached per code+color so they fade with their row; unknown codes fall back to a badge with the raw symbol character. Same icons in the beacon symbol dropdown.
- Right-click: *Send Message…*, *Station Info…* (full-detail popup), *View on aprs.fi*, and **Clear All Stations…** (confirmation; also clears the saved roster). Double-click prefills the message destination.

**Weather decode** (APRS 1.0.1 ch. 12): positionless `_` reports and position reports with the WX symbol (wind from the CSE/SPD extension, converted knots → mph). Temp, wind/gust, humidity (`h00` = 100%), pressure (inHg) and rain land in the comment as a readable triple-spaced summary — `77°F   Wind 220° 4 mph (gust 5)   Hum 50%   29.23 inHg`. Weather rows get condition-matched wireframe icons (cloud / rain / wind streaks), and wind is scrubbed from course/speed so WX stations don't appear to be driving.

**Beacon row**: my callsign, symbol picker, digi path (default `WIDE1-1,WIDE2-1`), enable + interval (1 min–24 h), status text, *Beacon Now*, and a live position-source readout (`GPS DN18rg …` / `Manual …` / `none`).

**Message row**: destination + text + *Send APRS Msg*, plus an **envelope button with an unread badge** opening the APRS Messages window (delivery states — sent (try n) / ✓ acked / ✗ no ack; opening marks read; double-click to reply).

**Modem controls**: new **Autostart at launch** checkbox — MainWindow constructs the hidden AetherModem dialog at app launch (same hook as KISS start-on-startup) so APRS decode runs from startup without opening the window.

**EKG activity trace**: the per-second activity bar graph is replaced by a heart-monitor-style sweep — every decoded frame draws a sharp green QRS heartbeat, FCS failures draw smaller amber bumps, an open receive gate lifts/agitates the baseline, and the trail fades like phosphor afterglow. One spike = one packet, individually countable at APRS rates. The sweep self-stops a few seconds after diagnostics stop flowing (zero idle repaint cost).

**Decluttered chrome**: the raw decode log, raw AX.25 UI-frame TX row, and Capture 3m / Clear Log buttons are diagnostics tooling — visible only while **Packet Activity Debug** is on (click the activity trace to toggle). With debug off the station table gets the full viewport. Tab bar slimmed to status-bar height; columns padded; alternating row colors; the dead "Send SMS" / "Send APRS Msg..." / "Connect BBS" placeholder row is removed. KISS/Mailbox tabs keep the shared log; Terminal is unchanged.

## What makes it nicer than a bare APRS client

- Distance/bearing computed from your own (GPS or manual) position right in the table.
- Proper messaging semantics: retries with message numbers, auto-ack + re-ack on sender retry, duplicate suppression.
- Digipeat de-duplication keeps station packet counts honest on busy WIDE2 channels.
- Weather stations read as weather — decoded summary and condition icons, not raw token soup.
- One TX queue shared with KISS/PMS/terminal — no PTT contention by construction.

**Future ideas** (out of scope here): map view, SmartBeaconing (speed/corner-pegging adaptive rate), digipeater mode, APRS-IS IGate, bulletins/announcements, azimuth radar plot of heard stations.

## Tests

- `aprs_packet_test` — codec vectors incl. a hand-derived Mic-E reference (33° 25.64′ N / 112° 07.74′ W, 20 kt, 251°), the APRS 1.0.1 compressed-position example, encoder round-trips, grid/distance/bearing, and weather vectors (positionless, position-form knots→mph, sparse `...` sensors, negative temperature, `h00` = 100%).
- `aprs_messenger_test` — ack matching (wrong-station acks ignored), auto-ack/re-ack, duplicate suppression, unread tracking, own-frame loopback rejection, roster digipeat dedupe.

All AX.25/PMS/APRS ctests pass; macOS build is clean. Tested on the air against live 144.390 MHz traffic alongside the Direwolf-derived demod from #3527.

💻 Generated with Claude Code (Fable 5.0) with architecture by @jensenpat