### PR TITLE
fix(gui): render frequency-entry hint in the UI font, not the segment font

### DIFF
--- a/src/gui/FreqLineEdit.h
+++ b/src/gui/FreqLineEdit.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "core/ThemeManager.h"
+
+#include <QLineEdit>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QFont>
+#include <QRect>
+#include <QString>
+
+// QLineEdit for direct frequency entry. Typed text renders in the seven-segment
+// frequency font (font.family.freq, e.g. "DSEG7 Modern") to match the VFO
+// readout. A normal prose hint rendered in that segment font, however, paints as
+// garbage -- DSEG7 has no glyphs for letters/parentheses/space, so a placeholder
+// like "MHz (e.g. 14.225)" turns into corrupted segments the moment the field is
+// cleared. (Reported on both the VfoWidget VFO and the RxApplet side applet.)
+//
+// So instead of Qt's setPlaceholderText() -- which paints in the widget's
+// (segment) font -- this widget paints its OWN hint in the UI font
+// (font.family.ui) when the field is empty. The hint family is read from the
+// token at paint time, so it stays in lockstep with Theme Editor font changes,
+// mirroring how the field's stylesheet re-themes via font.family.freq.
+class FreqLineEdit : public QLineEdit {
+public:
+    explicit FreqLineEdit(QWidget* parent = nullptr) : QLineEdit(parent) {}
+
+    // Hint shown (in the UI font) while the field is empty. Deliberately NOT
+    // Qt's placeholderText(), which would render in the segment font.
+    void setHintText(const QString& text) { m_hint = text; update(); }
+    QString hintText() const { return m_hint; }
+
+protected:
+    void paintEvent(QPaintEvent* ev) override {
+        QLineEdit::paintEvent(ev);
+        if (m_hint.isEmpty() || !text().isEmpty())
+            return;
+
+        QPainter painter(this);
+        QFont hintFont(AetherSDR::ThemeManager::instance().value("font.family.ui"));
+        hintFont.setPixelSize(m_hintPixelSize);
+        painter.setFont(hintFont);
+        painter.setPen(palette().placeholderText().color());
+
+        QRect r = contentsRect().marginsRemoved(textMargins());
+        r.adjust(4, 0, -4, 0);
+        const Qt::Alignment align =
+            (alignment() & Qt::AlignHorizontal_Mask) | Qt::AlignVCenter;
+        painter.drawText(r, align, m_hint);
+    }
+
+private:
+    QString m_hint;
+    int m_hintPixelSize{12};
+};

--- a/src/gui/FreqLineEdit.h
+++ b/src/gui/FreqLineEdit.h
@@ -8,6 +8,7 @@
 #include <QFont>
 #include <QRect>
 #include <QString>
+#include <QStringList>
 
 // QLineEdit for direct frequency entry. Typed text renders in the seven-segment
 // frequency font (font.family.freq, e.g. "DSEG7 Modern") to match the VFO
@@ -18,12 +19,28 @@
 //
 // So instead of Qt's setPlaceholderText() -- which paints in the widget's
 // (segment) font -- this widget paints its OWN hint in the UI font
-// (font.family.ui) when the field is empty. The hint family is read from the
-// token at paint time, so it stays in lockstep with Theme Editor font changes,
-// mirroring how the field's stylesheet re-themes via font.family.freq.
+// (font.family.ui) when the field is empty. The hint family is read widget-scoped
+// (honoring any themeContainer override in the ancestry, like the field's own
+// stylesheet does) at paint time, and the constructor wires ThemeManager's
+// themeChanged signal to update(), so the hint stays in lockstep with live Theme
+// Editor font changes -- mirroring how the field's stylesheet re-themes via
+// font.family.freq.
 class FreqLineEdit : public QLineEdit {
 public:
-    explicit FreqLineEdit(QWidget* parent = nullptr) : QLineEdit(parent) {}
+    explicit FreqLineEdit(QWidget* parent = nullptr) : QLineEdit(parent) {
+        auto& tm = AetherSDR::ThemeManager::instance();
+        // Advertise the token we paint with so the Phase 5 theme inspector can
+        // answer "what paints this widget?" -- applyStyleSheet's reverse-map only
+        // sees stylesheet-driven widgets, never custom paintEvent code.
+        tm.declareWidgetTokens(this, {"font.family.ui"});
+        // Custom-paint widgets are NOT auto-repainted on themeChanged, so wire it
+        // ourselves -- this is what actually keeps the hint in lockstep with live
+        // Theme Editor font changes. (4-arg connect to a lambda with `this` as
+        // context: no Q_OBJECT/moc needed, stays header-only; auto-disconnects on
+        // destruction.)
+        connect(&tm, &AetherSDR::ThemeManager::themeChanged, this,
+                [this] { update(); });
+    }
 
     // Hint shown (in the UI font) while the field is empty. Deliberately NOT
     // Qt's placeholderText(), which would render in the segment font.
@@ -37,12 +54,14 @@ protected:
             return;
 
         QPainter painter(this);
-        QFont hintFont(AetherSDR::ThemeManager::instance().value("font.family.ui"));
+        QFont hintFont(AetherSDR::ThemeManager::instance().value(this, "font.family.ui"));
         hintFont.setPixelSize(m_hintPixelSize);
         painter.setFont(hintFont);
         painter.setPen(palette().placeholderText().color());
 
         QRect r = contentsRect().marginsRemoved(textMargins());
+        // Keep this 4px inset in sync with the field's stylesheet "padding: 0 4px"
+        // (RxApplet/VfoWidget) so the hint starts exactly where typed digits do.
         r.adjust(4, 0, -4, 0);
         const Qt::Alignment align =
             (alignment() & Qt::AlignHorizontal_Mask) | Qt::AlignVCenter;

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -43,6 +43,7 @@
 #include <cmath>
 #include <limits>
 #include "core/ThemeManager.h"
+#include "FreqLineEdit.h"
 
 // Slider that resets to a default value on double-click.
 // Extends GuardedSlider for controls-lock support (#745).
@@ -527,13 +528,14 @@ void RxApplet::buildUI()
         m_freqLabel->installEventFilter(this);
         m_freqStack->addWidget(m_freqLabel);
 
-        m_freqEdit = new QLineEdit;
+        auto* freqEdit = new FreqLineEdit;
+        m_freqEdit = freqEdit;
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_freqEdit, "QLineEdit { background: {{color.background.0}}; border: 1px solid {{color.accent}};"
             " border-radius: 3px; color: #00e5ff; font-size: 20px;"
             " font-family: \"{{font.family.freq}}\";"
             " font-weight: bold; padding: 0 4px; }");
         m_freqEdit->setAlignment(Qt::AlignRight);
-        m_freqEdit->setPlaceholderText("MHz");
+        freqEdit->setHintText("MHz");
         m_freqEdit->installEventFilter(this);
         m_freqStack->addWidget(m_freqEdit);
         m_freqStack->setCurrentIndex(0);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -46,6 +46,7 @@
 #include <QMouseEvent>
 #include <cmath>
 #include "core/ThemeManager.h"
+#include "FreqLineEdit.h"
 
 // QSlider that always accepts wheel events, preventing propagation to parent
 // (e.g. SpectrumWidget frequency scroll) at min/max boundaries. (#547 BUG-002)
@@ -623,7 +624,8 @@ void VfoWidget::buildUI()
     m_freqLabel->installEventFilter(this);
     m_freqStack->addWidget(m_freqLabel);
 
-    m_freqEdit = new QLineEdit;
+    auto* freqEdit = new FreqLineEdit;
+    m_freqEdit = freqEdit;
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_freqEdit, "QLineEdit { background: {{color.background.0}}; border: 1px solid {{color.accent}};"
         " border-radius: 3px; color: #00e5ff; font-size: 22px;"
         " font-family: \"{{font.family.freq}}\";"
@@ -635,7 +637,7 @@ void VfoWidget::buildUI()
     labelFont.setBold(true);
     const int stackW = QFontMetrics(labelFont).horizontalAdvance("0000.000.000") + 8;
     m_freqStack->setFixedWidth(stackW);
-    m_freqEdit->setPlaceholderText("MHz (e.g. 14.225)");
+    freqEdit->setHintText("MHz (e.g. 14.225)");
     m_freqEdit->installEventFilter(this);
     m_freqStack->addWidget(m_freqEdit);
     m_freqStack->setCurrentIndex(0);  // show label by default


### PR DESCRIPTION
## Summary

The direct-frequency-entry field renders its placeholder as garbled segments the moment it is cleared. When you click into a slice's frequency (the VFO on the panadapter, or the side applet) and delete the displayed value, the empty field paints corrupted segments across the whole display instead of a readable hint.

## Root cause

The frequency-entry `QLineEdit` (in both `VfoWidget` and `RxApplet`) deliberately styles its text in the **seven-segment frequency font** — `font.family.freq` (`"DSEG7 Modern"`) — so that a *typed* frequency matches the VFO readout. But the field's placeholder text is prose:

- `VfoWidget`: `"MHz (e.g. 14.225)"`
- `RxApplet`: `"MHz"`

DSEG7 is a 7-segment font with glyphs only for digits and a few symbols — it has **no glyphs for letters, parentheses, or spaces**. So when the field is empty and Qt paints the placeholder in the widget's (segment) font, the prose hint renders as corrupted segments. It's a font/placeholder mismatch, not memory corruption.

## Fix

Add a small **header-only** `FreqLineEdit` (`src/gui/FreqLineEdit.h`), mirroring the `GuardedSlider` extraction precedent (#570), and use it for both frequency-entry surfaces. Instead of Qt's `setPlaceholderText()` — which would paint in the widget's segment font — `FreqLineEdit` paints its **own** hint in the UI font (`font.family.ui`) when the field is empty:

- The hint family is read from the token **at paint time**, so it stays in lockstep with Theme-Editor font changes — matching how the field's stylesheet re-themes via `font.family.freq`.
- The hint is drawn into `contentsRect()` honouring `textMargins()` and the field's alignment, so it sits exactly where typed digits land (no jump when the first digit is entered).
- Typed text still renders in the segment font — the VFO look while typing is unchanged.

## Why not just swap the field's `font-family` to `font.family.ui`?

That one-liner would also fix the placeholder, but typed digits would then show in Inter instead of the seven-segment font during entry, losing the VFO aesthetic mid-edit. The subclass keeps the segment look for typed input while making the empty-state hint legible.

## Scope

- New `src/gui/FreqLineEdit.h` (header-only, no CMake change — like `GuardedSlider.h`)
- `VfoWidget.cpp` / `RxApplet.cpp`: 2 lines each (use `FreqLineEdit` + `setHintText()` in place of `setPlaceholderText()`)
- No protocol / persistence change. Accessibility unchanged (`setAccessibleDescription` still guides AT users).

## Before / after

| Before — cleared field paints the placeholder in DSEG7 (the bug) | After — hint painted in the UI font (legible) |
|---|---|
| ![before](https://raw.githubusercontent.com/Ozy311/AetherSDR/pr3533-assets/before.png) | ![after](https://raw.githubusercontent.com/Ozy311/AetherSDR/pr3533-assets/after.png) |

RxApplet side-applet hint (`"MHz"`):

![after-mhz](https://raw.githubusercontent.com/Ozy311/AetherSDR/pr3533-assets/after-mhz.png)

> Rendered offscreen via `QWidget::grab()` from the real `FreqLineEdit` on the Linux dev box; the "before" is a plain `QLineEdit` + `setPlaceholderText()` under the same DSEG7 stylesheet. (The UI font falls back to system sans on this box — Inter renders where installed.)

## Test plan

- [x] Local incremental `ninja -C build` clean on Linux (Nobara 43, Qt 6.10.3, gcc 15.2.1)
- [x] Offscreen `QWidget::grab()` render of the real `FreqLineEdit` confirms the empty-field hint paints legibly in the UI font on both surfaces; a plain `QLineEdit` + placeholder reproduces the segment-font corruption (before/after above)
- [x] Manual smoke: clicked into a slice frequency and cleared the field — the hint renders legibly instead of garbled segments (verified live by @Ozy311)

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent, on the Linux dev stack (`nobara-dell`).
