### PR TITLE
feat(xvtr): auto-switch slice antennas on transverter band change (#3531)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,6 +486,7 @@ endif()
 # Sources
 set(CORE_SOURCES
     src/core/AppSettings.cpp
+    src/core/XvtrAutoAntennaSettings.cpp
     src/core/AgcTCalibrator.cpp
     src/core/SettingsHelpers.cpp
     src/core/ThemeManager.cpp

--- a/resources/help/aethersdr-help.md
+++ b/resources/help/aethersdr-help.md
@@ -427,7 +427,7 @@ SpotHub brings spot sources together in one place so you can compare cluster inf
 - `Phone/CW`: microphone, CW, and digital-specific setup
 - `RX`: frequency offset, 10 MHz reference, and receive-related global settings
 - `Filters`: filter behavior and low-latency digital choices
-- `XVTR`: transverter definitions and management
+- `XVTR`: transverter definitions and management. Each transverter page also offers `Auto RX Ant` / `Auto TX Ant` selectors: when set, changing to that transverter's band automatically switches the slice's RX/TX antenna to the chosen port. The default `(no change)` leaves antenna selection to the radio's band stack.
 - `USB Cables`: CAT, BCD, bit, and passthrough cable definitions
 - `Serial`: serial port behavior, pin assignments, and FlexControl tuning knob setup when serial support is built in
 

--- a/src/core/XvtrAutoAntennaSettings.cpp
+++ b/src/core/XvtrAutoAntennaSettings.cpp
@@ -1,0 +1,61 @@
+#include "XvtrAutoAntennaSettings.h"
+
+#include "AppSettings.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr const char* kSettingsKey = "XvtrAutoAntenna";
+
+QJsonObject loadRoot()
+{
+    const QString raw =
+        AppSettings::instance().value(kSettingsKey, "").toString();
+    if (raw.isEmpty()) {
+        return {};
+    }
+    const QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8());
+    return doc.isObject() ? doc.object() : QJsonObject{};
+}
+
+} // namespace
+
+XvtrAutoAntennaPorts loadXvtrAutoAntennaPorts(int xvtrIndex)
+{
+    const QJsonObject entry =
+        loadRoot().value(QString::number(xvtrIndex)).toObject();
+    return {entry.value("rx").toString(), entry.value("tx").toString()};
+}
+
+void saveXvtrAutoAntennaPorts(int xvtrIndex, const XvtrAutoAntennaPorts& ports)
+{
+    QJsonObject root = loadRoot();
+    const QString key = QString::number(xvtrIndex);
+    if (!ports.isConfigured()) {
+        root.remove(key);
+    } else {
+        QJsonObject entry;
+        if (!ports.rx.isEmpty()) {
+            entry.insert("rx", ports.rx);
+        }
+        if (!ports.tx.isEmpty()) {
+            entry.insert("tx", ports.tx);
+        }
+        root.insert(key, entry);
+    }
+
+    auto& s = AppSettings::instance();
+    if (root.isEmpty()) {
+        s.remove(kSettingsKey);
+    } else {
+        s.setValue(kSettingsKey, QString::fromUtf8(
+            QJsonDocument(root).toJson(QJsonDocument::Compact)));
+    }
+    s.save();
+}
+
+} // namespace AetherSDR

--- a/src/core/XvtrAutoAntennaSettings.h
+++ b/src/core/XvtrAutoAntennaSettings.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+// Client-side per-transverter antenna auto-switch configuration (#3531).
+// The radio does not persist per-XVTR antenna mappings, so they live in
+// AppSettings as one nested JSON blob under the "XvtrAutoAntenna" root key
+// (Principle V), keyed by the xvtr status-object index:
+//
+//   {"12": {"rx": "XVTA", "tx": "XVTA"}, "4": {"rx": "XVTB"}}
+//
+// An empty port means "leave the radio's band-stack antenna untouched",
+// which is the default for every transverter.
+
+struct XvtrAutoAntennaPorts {
+    QString rx;
+    QString tx;
+
+    bool isConfigured() const { return !rx.isEmpty() || !tx.isEmpty(); }
+};
+
+XvtrAutoAntennaPorts loadXvtrAutoAntennaPorts(int xvtrIndex);
+void saveXvtrAutoAntennaPorts(int xvtrIndex, const XvtrAutoAntennaPorts& ports);
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -202,6 +202,7 @@
 #include <QToolTip>
 #include <QMediaDevices>
 #include "core/AppSettings.h"
+#include "core/XvtrAutoAntennaSettings.h"
 #include "core/SpotCommandPolicy.h"
 #include "core/SpotModeResolver.h"
 #ifdef HAVE_RADE
@@ -7173,6 +7174,7 @@ bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPan
                 QTimer::singleShot(300, this, [this, slicePanId]() {
                     reassertUnmutedSliceAudioForPan(slicePanId);
                 });
+                applyXvtrAutoAntennas(slicePanId, stackKeyResult.key);
             } else {
                 qCWarning(lcProtocol).noquote().nospace()
                     << "MainWindow: memory recall cannot preselect band stack memory="
@@ -7382,7 +7384,71 @@ MainWindow::BandStackPreselectResult MainWindow::preselectBandStackForTune(
     QTimer::singleShot(300, this, [this, panId = slice->panId()]() {
         reassertUnmutedSliceAudioForPan(panId);
     });
+    applyXvtrAutoAntennas(slice->panId(), stackKeyResult.key);
     return BandStackPreselectResult::Selected;
+}
+
+void MainWindow::applyXvtrAutoAntennas(const QString& panId, const QString& stackKey)
+{
+    // Client-side antenna auto-switch (#3531). Only X<n> band-stack keys
+    // (transverter bands) participate; native bands stay radio-authoritative.
+    // The per-XVTR ports are configured in Radio Setup → XVTR and stored in
+    // AppSettings because the radio does not persist per-XVTR antenna
+    // mappings. Empty ports (the "(no change)" default) disable this.
+    if (panId.isEmpty() || !stackKey.startsWith('X')) {
+        return;
+    }
+    bool indexOk = false;
+    const int xvtrIdx = stackKey.mid(1).toInt(&indexOk);
+    if (!indexOk) {
+        return;
+    }
+
+    const auto ports = AetherSDR::loadXvtrAutoAntennaPorts(xvtrIdx);
+    if (!ports.isConfigured()) {
+        return;
+    }
+    const QString rxAnt = ports.rx;
+    const QString txAnt = ports.tx;
+
+    // A Flex band change (display pan set band=) tears down and recreates the
+    // slice; recreated slices settle in ~250-340 ms observed (see the deferred
+    // vfo push in TciServer::wireSlice). Defer, then verify the settled slice
+    // actually landed on this transverter before touching its antennas — if
+    // the band change failed or the user already jumped elsewhere, sending
+    // rxant/txant would key the wrong port.
+    QTimer::singleShot(600, this, [this, panId, xvtrIdx, rxAnt, txAnt]() {
+        const auto xvtrIt = m_radioModel.xvtrList().constFind(xvtrIdx);
+        if (xvtrIt == m_radioModel.xvtrList().cend()) {
+            return;
+        }
+        const bool rxOnly = xvtrIt->rxOnly;
+        const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
+        for (auto* slice : m_radioModel.slices()) {
+            if (!slice || slice->panId() != panId) {
+                continue;
+            }
+            if (XvtrPolicy::transverterIndexForFrequency(slice->frequency(),
+                                                         xvtrs) != xvtrIdx) {
+                continue;
+            }
+            qCDebug(lcProtocol).noquote().nospace()
+                << "MainWindow: xvtr antenna auto-switch slice=" << slice->sliceId()
+                << " pan=" << panId
+                << " xvtr_idx=" << xvtrIdx
+                << " rxant=" << (rxAnt.isEmpty() ? QStringLiteral("(keep)") : rxAnt)
+                << " txant=" << (txAnt.isEmpty() ? QStringLiteral("(keep)") : txAnt)
+                << " rx_only=" << rxOnly;
+            if (!rxAnt.isEmpty() && slice->rxAntenna() != rxAnt) {
+                m_radioModel.sendCommand(QString("slice set %1 rxant=%2")
+                                             .arg(slice->sliceId()).arg(rxAnt));
+            }
+            if (!txAnt.isEmpty() && !rxOnly && slice->txAntenna() != txAnt) {
+                m_radioModel.sendCommand(QString("slice set %1 txant=%2")
+                                             .arg(slice->sliceId()).arg(txAnt));
+            }
+        }
+    });
 }
 
 void MainWindow::applyTuneRequest(SliceModel* slice, double mhz,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6455,6 +6455,14 @@ void MainWindow::onConnectionStateChanged(bool connected)
         return;
     }
 
+    // XVTR antenna auto-switch (#3531): drop all per-slice owning-transverter
+    // state on any connection transition. Pruning only via sliceRemoved goes
+    // stale across reconnects — pruneStaleSessionModels() emits sliceRemoved
+    // AFTER the new session's slices appear, so a recreated slice that lands
+    // on the same transverter index would see prevIdx == xvtrIdx at creation
+    // time and skip the switch, then lose its entry to the late prune.
+    m_sliceXvtrIndex.clear();
+
     m_connPanel->setConnected(connected);
 
     // Pause/resume the discovery re-bind loop in step with the connection
@@ -7428,8 +7436,7 @@ void MainWindow::evaluateXvtrAutoAntennas(SliceModel* slice)
     if (xvtrIdx < 0) {
         return;
     }
-    const auto ports = AetherSDR::loadXvtrAutoAntennaPorts(xvtrIdx);
-    if (!ports.isConfigured()) {
+    if (!AetherSDR::loadXvtrAutoAntennaPorts(xvtrIdx).isConfigured()) {
         return;
     }
 
@@ -7438,9 +7445,10 @@ void MainWindow::evaluateXvtrAutoAntennas(SliceModel* slice)
     // the deferred vfo push in TciServer::wireSlice) — then re-validate the
     // slice is still on this transverter before touching its antennas; if the
     // user already jumped elsewhere, sending rxant/txant would key the wrong
-    // port.
+    // port. The ports are reloaded at fire time so a settings change inside
+    // the window can't send a just-cleared port.
     QPointer<SliceModel> guard(slice);
-    QTimer::singleShot(600, this, [this, guard, xvtrIdx, ports]() {
+    QTimer::singleShot(600, this, [this, guard, xvtrIdx]() {
         if (!guard) {
             return;
         }
@@ -7452,6 +7460,10 @@ void MainWindow::evaluateXvtrAutoAntennas(SliceModel* slice)
         const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
         if (XvtrPolicy::transverterIndexForFrequency(s->frequency(), xvtrs)
                 != xvtrIdx) {
+            return;
+        }
+        const auto ports = AetherSDR::loadXvtrAutoAntennaPorts(xvtrIdx);
+        if (!ports.isConfigured()) {
             return;
         }
         qCDebug(lcProtocol).noquote().nospace()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1511,6 +1511,20 @@ MainWindow::MainWindow(QWidget* parent)
             this, &MainWindow::onSliceAdded);
     connect(&m_radioModel, &RadioModel::sliceRemoved,
             this, &MainWindow::onSliceRemoved);
+    // XVTR antenna auto-switch (#3531): evaluate every slice on every
+    // frequency change, plus once at creation — a Flex band change recreates
+    // the slice already inside the transverter band, so no frequencyChanged
+    // may fire afterwards (same trap as the deferred vfo push, #2824).
+    // Wired here rather than in onSliceAdded because that handler bails out
+    // during layout transitions.
+    connect(&m_radioModel, &RadioModel::sliceAdded,
+            this, [this](SliceModel* s) {
+        connect(s, &SliceModel::frequencyChanged,
+                this, [this, s](double) { evaluateXvtrAutoAntennas(s); });
+        evaluateXvtrAutoAntennas(s);
+    });
+    connect(&m_radioModel, &RadioModel::sliceRemoved,
+            this, [this](int id) { m_sliceXvtrIndex.remove(id); });
     connect(&m_radioModel, &RadioModel::memoryChanged,
             this, &MainWindow::syncMemorySpot);
     connect(&m_radioModel, &RadioModel::memoryRemoved,
@@ -7174,7 +7188,6 @@ bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPan
                 QTimer::singleShot(300, this, [this, slicePanId]() {
                     reassertUnmutedSliceAudioForPan(slicePanId);
                 });
-                applyXvtrAutoAntennas(slicePanId, stackKeyResult.key);
             } else {
                 qCWarning(lcProtocol).noquote().nospace()
                     << "MainWindow: memory recall cannot preselect band stack memory="
@@ -7384,69 +7397,76 @@ MainWindow::BandStackPreselectResult MainWindow::preselectBandStackForTune(
     QTimer::singleShot(300, this, [this, panId = slice->panId()]() {
         reassertUnmutedSliceAudioForPan(panId);
     });
-    applyXvtrAutoAntennas(slice->panId(), stackKeyResult.key);
     return BandStackPreselectResult::Selected;
 }
 
-void MainWindow::applyXvtrAutoAntennas(const QString& panId, const QString& stackKey)
+void MainWindow::evaluateXvtrAutoAntennas(SliceModel* slice)
 {
-    // Client-side antenna auto-switch (#3531). Only X<n> band-stack keys
-    // (transverter bands) participate; native bands stay radio-authoritative.
-    // The per-XVTR ports are configured in Radio Setup → XVTR and stored in
-    // AppSettings because the radio does not persist per-XVTR antenna
-    // mappings. Empty ports (the "(no change)" default) disable this.
-    if (panId.isEmpty() || !stackKey.startsWith('X')) {
+    // Client-side antenna auto-switch (#3531), evaluated for every slice on
+    // every frequency change so any path that moves a slice onto a
+    // transverter band participates: band selector, direct tune, CAT/TCI,
+    // memory recall, or a slice recreated by a Flex band change. The per-XVTR
+    // ports are configured in Radio Setup → XVTR and stored in AppSettings
+    // because the radio does not persist per-XVTR antenna mappings; empty
+    // ports (the "(no change)" default) disable this.
+    //
+    // Edge-triggered on the owning-transverter index: retunes inside the
+    // band, and manual antenna overrides while on it, are left alone. When a
+    // slice leaves a transverter band nothing is restored — the user's last
+    // explicit antenna choice per native band stays radio-authoritative.
+    if (!slice) {
         return;
     }
-    bool indexOk = false;
-    const int xvtrIdx = stackKey.mid(1).toInt(&indexOk);
-    if (!indexOk) {
+    const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
+    const int xvtrIdx =
+        XvtrPolicy::transverterIndexForFrequency(slice->frequency(), xvtrs);
+    const int prevIdx = m_sliceXvtrIndex.value(slice->sliceId(), -1);
+    if (xvtrIdx == prevIdx) {
         return;
     }
-
+    m_sliceXvtrIndex[slice->sliceId()] = xvtrIdx;
+    if (xvtrIdx < 0) {
+        return;
+    }
     const auto ports = AetherSDR::loadXvtrAutoAntennaPorts(xvtrIdx);
     if (!ports.isConfigured()) {
         return;
     }
-    const QString rxAnt = ports.rx;
-    const QString txAnt = ports.tx;
 
-    // A Flex band change (display pan set band=) tears down and recreates the
-    // slice; recreated slices settle in ~250-340 ms observed (see the deferred
-    // vfo push in TciServer::wireSlice). Defer, then verify the settled slice
-    // actually landed on this transverter before touching its antennas — if
-    // the band change failed or the user already jumped elsewhere, sending
-    // rxant/txant would key the wrong port.
-    QTimer::singleShot(600, this, [this, panId, xvtrIdx, rxAnt, txAnt]() {
+    // Defer so the radio's own band-stack restore (frequency, mode, antenna)
+    // finishes first — recreated slices settle in ~250-340 ms observed (see
+    // the deferred vfo push in TciServer::wireSlice) — then re-validate the
+    // slice is still on this transverter before touching its antennas; if the
+    // user already jumped elsewhere, sending rxant/txant would key the wrong
+    // port.
+    QPointer<SliceModel> guard(slice);
+    QTimer::singleShot(600, this, [this, guard, xvtrIdx, ports]() {
+        if (!guard) {
+            return;
+        }
+        SliceModel* s = guard;
         const auto xvtrIt = m_radioModel.xvtrList().constFind(xvtrIdx);
         if (xvtrIt == m_radioModel.xvtrList().cend()) {
             return;
         }
-        const bool rxOnly = xvtrIt->rxOnly;
         const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
-        for (auto* slice : m_radioModel.slices()) {
-            if (!slice || slice->panId() != panId) {
-                continue;
-            }
-            if (XvtrPolicy::transverterIndexForFrequency(slice->frequency(),
-                                                         xvtrs) != xvtrIdx) {
-                continue;
-            }
-            qCDebug(lcProtocol).noquote().nospace()
-                << "MainWindow: xvtr antenna auto-switch slice=" << slice->sliceId()
-                << " pan=" << panId
-                << " xvtr_idx=" << xvtrIdx
-                << " rxant=" << (rxAnt.isEmpty() ? QStringLiteral("(keep)") : rxAnt)
-                << " txant=" << (txAnt.isEmpty() ? QStringLiteral("(keep)") : txAnt)
-                << " rx_only=" << rxOnly;
-            if (!rxAnt.isEmpty() && slice->rxAntenna() != rxAnt) {
-                m_radioModel.sendCommand(QString("slice set %1 rxant=%2")
-                                             .arg(slice->sliceId()).arg(rxAnt));
-            }
-            if (!txAnt.isEmpty() && !rxOnly && slice->txAntenna() != txAnt) {
-                m_radioModel.sendCommand(QString("slice set %1 txant=%2")
-                                             .arg(slice->sliceId()).arg(txAnt));
-            }
+        if (XvtrPolicy::transverterIndexForFrequency(s->frequency(), xvtrs)
+                != xvtrIdx) {
+            return;
+        }
+        qCDebug(lcProtocol).noquote().nospace()
+            << "MainWindow: xvtr antenna auto-switch slice=" << s->sliceId()
+            << " xvtr_idx=" << xvtrIdx
+            << " rxant=" << (ports.rx.isEmpty() ? QStringLiteral("(keep)") : ports.rx)
+            << " txant=" << (ports.tx.isEmpty() ? QStringLiteral("(keep)") : ports.tx)
+            << " rx_only=" << xvtrIt->rxOnly;
+        if (!ports.rx.isEmpty() && s->rxAntenna() != ports.rx) {
+            m_radioModel.sendCommand(QString("slice set %1 rxant=%2")
+                                         .arg(s->sliceId()).arg(ports.rx));
+        }
+        if (!ports.tx.isEmpty() && !xvtrIt->rxOnly && s->txAntenna() != ports.tx) {
+            m_radioModel.sendCommand(QString("slice set %1 txant=%2")
+                                         .arg(s->sliceId()).arg(ports.tx));
         }
     });
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -240,7 +240,7 @@ private:
     bool panFollowEnabled() const;
     BandStackPreselectResult preselectBandStackForTune(SliceModel* slice, double mhz,
                                                        const char* source);
-    void applyXvtrAutoAntennas(const QString& panId, const QString& stackKey);
+    void evaluateXvtrAutoAntennas(SliceModel* slice);
     void applyTuneRequest(SliceModel* slice, double mhz,
                           TuneIntent intent, const char* source);
     void applyPanRangeRequest(const QString& panId, double centerMhz,
@@ -772,6 +772,9 @@ private:
 
     // Active slice tracking for multi-slice support
     int m_activeSliceId{-1};
+    // Per-slice owning-transverter index (-1 = not on a transverter band),
+    // for edge-triggered XVTR antenna auto-switch (#3531)
+    QHash<int, int> m_sliceXvtrIndex;
     bool m_splitActive{false};
     bool m_leanMode{false};  // global lean render mode state (#3283)
     // Pre-lean WaveApplet active state, captured on Lean activation so the

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -240,6 +240,7 @@ private:
     bool panFollowEnabled() const;
     BandStackPreselectResult preselectBandStackForTune(SliceModel* slice, double mhz,
                                                        const char* source);
+    void applyXvtrAutoAntennas(const QString& panId, const QString& stackKey);
     void applyTuneRequest(SliceModel* slice, double mhz,
                           TuneIntent intent, const char* source);
     void applyPanRangeRequest(const QString& panId, double centerMhz,

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -2020,8 +2020,13 @@ void MainWindow::wireExternalControllers()
             this, &MainWindow::handleFlexControlButton);
     connect(m_flexControl, &FlexControlManager::buttonPressed,
             this, [this](int button, int action) {
-        if (m_hidEncoder->isTMate2())
+        // m_hidEncoder / noteTMate2Interaction only exist under HAVE_HIDAPI;
+        // this block is guarded by HAVE_SERIALPORT, so a serialport-without-
+        // hidapi build (e.g. Windows before setup-hidapi.ps1) hits both.
+#ifdef HAVE_HIDAPI
+        if (m_hidEncoder && m_hidEncoder->isTMate2())
             noteTMate2Interaction();
+#endif
         if (m_flexControlDialog)
             m_flexControlDialog->reflectButtonPress(button, action);
     });

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1694,7 +1694,6 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             QTimer::singleShot(300, this, [this, panId = applet->panId()]() {
                 reassertUnmutedSliceAudioForPan(panId);
             });
-            applyXvtrAutoAntennas(applet->panId(), stackKey);
         }
     });
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1694,6 +1694,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             QTimer::singleShot(300, this, [this, panId = applet->panId()]() {
                 reassertUnmutedSliceAudioForPan(panId);
             });
+            applyXvtrAutoAntennas(applet->panId(), stackKey);
         }
     });
 

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -6,6 +6,7 @@
 #include "models/RadioModel.h"
 #include "models/XvtrPolicy.h"
 #include "core/AppSettings.h"
+#include "core/XvtrAutoAntennaSettings.h"
 #include "core/LogManager.h"
 #include "core/PeripheralSettings.h"
 #include <QApplication>
@@ -2796,6 +2797,47 @@ QWidget* RadioSetupDialog::buildXvtrTab()
             if (tabIdx >= 0) xvtrTabs->removeTab(tabIdx);
         });
         grid->addWidget(removeBtn, 4, 3);
+
+        // Client-side antenna auto-switch (#3531): which ports to apply when
+        // a band change lands on this transverter. The radio does not persist
+        // per-XVTR antenna mappings, so they live in AppSettings (see
+        // XvtrAutoAntennaSettings.h). The default "(no change)" keeps the
+        // radio-authoritative behavior untouched.
+        auto addAutoAntCombo = [this, grid, idx](int row, int col,
+                                                 const QString& label,
+                                                 bool isRx) {
+            auto* lbl = new QLabel(label);
+            lbl->setStyleSheet(kLabelStyle);
+            grid->addWidget(lbl, row, col * 2);
+            auto* cmb = new QComboBox;
+            AetherSDR::applyComboStyle(cmb);
+            cmb->addItem(QStringLiteral("(no change)"));
+            const auto ports = AetherSDR::loadXvtrAutoAntennaPorts(idx);
+            const QString saved = isRx ? ports.rx : ports.tx;
+            QStringList ants = m_model->antennaList();
+            if (!saved.isEmpty() && !ants.contains(saved)) {
+                ants.append(saved);
+            }
+            cmb->addItems(ants);
+            cmb->setCurrentIndex(saved.isEmpty() ? 0 : cmb->findText(saved));
+            cmb->setToolTip("Antenna applied automatically when a band change "
+                            "lands on this transverter. \"(no change)\" leaves "
+                            "the radio's band-stack antenna untouched.");
+            connect(cmb, &QComboBox::currentIndexChanged, this,
+                    [cmb, idx, isRx](int i) {
+                auto ports = AetherSDR::loadXvtrAutoAntennaPorts(idx);
+                const QString port = i <= 0 ? QString() : cmb->currentText();
+                if (isRx) {
+                    ports.rx = port;
+                } else {
+                    ports.tx = port;
+                }
+                AetherSDR::saveXvtrAutoAntennaPorts(idx, ports);
+            });
+            grid->addWidget(cmb, row, col * 2 + 1);
+        };
+        addAutoAntCombo(5, 0, "Auto RX Ant:", true);
+        addAutoAntCombo(5, 1, "Auto TX Ant:", false);
 
         auto maxPowerRange = [this, ifEdit] {
             return XvtrPolicy::maxPowerRangeFor(ifEdit->text().toDouble(), m_model->model());

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -2793,6 +2793,10 @@ QWidget* RadioSetupDialog::buildXvtrTab()
             "QPushButton:hover { background: #502020; }");
         connect(removeBtn, &QPushButton::clicked, pg, [this, idx, xvtrTabs, pg] {
             m_model->sendCommand(QString("xvtr remove %1").arg(idx));
+            // Drop the saved auto-antenna mapping too — the radio reuses xvtr
+            // indices, so a transverter created later would silently inherit
+            // this one's ports (#3531 review).
+            AetherSDR::saveXvtrAutoAntennaPorts(idx, {});
             int tabIdx = xvtrTabs->indexOf(pg);
             if (tabIdx >= 0) xvtrTabs->removeTab(tabIdx);
         });

--- a/src/models/XvtrPolicy.cpp
+++ b/src/models/XvtrPolicy.cpp
@@ -94,6 +94,34 @@ BandStackKeyResult resolveBandStackKey(const QString& bandName,
     };
 }
 
+int transverterIndexForFrequency(double freqMhz,
+                                 const QVector<Transverter>& xvtrs)
+{
+    // The RF window of a transverter has no explicit width in the xvtr
+    // status object; the radio can tune at most its native 54 MHz span
+    // above the IF, so cap the window there. Overlapping windows (e.g. a
+    // 2 m and a 70 cm transverter) are resolved by picking the nearest
+    // RF start at-or-below the frequency.
+    constexpr double kMaxRfWindowMhz = 54.0;
+    constexpr double kEdgeEpsilonMhz = 1e-6;
+
+    int bestIndex = -1;
+    double bestRfStart = -1.0;
+    for (const auto& xvtr : xvtrs) {
+        if (!xvtr.isValid || xvtr.rfFreqMhz <= 0.0)
+            continue;
+        if (freqMhz < xvtr.rfFreqMhz - kEdgeEpsilonMhz)
+            continue;
+        if (freqMhz - xvtr.rfFreqMhz > kMaxRfWindowMhz)
+            continue;
+        if (xvtr.rfFreqMhz > bestRfStart) {
+            bestRfStart = xvtr.rfFreqMhz;
+            bestIndex = xvtr.index;
+        }
+    }
+    return bestIndex;
+}
+
 bool isWaterfallTileOutsidePan(double lowMhz, double highMhz, double panCenterMhz)
 {
     const double bw = tileBandwidth(lowMhz, highMhz);

--- a/src/models/XvtrPolicy.h
+++ b/src/models/XvtrPolicy.h
@@ -48,6 +48,13 @@ BandStackKeyResult resolveBandStackKey(const QString& bandName,
                                        const QVector<Transverter>& xvtrs,
                                        ModelCapabilities caps = {});
 
+// Which transverter owns an RF frequency: the valid transverter whose RF
+// start is nearest at-or-below freqMhz, within the radio's IF tuning span.
+// Returns the transverter's status-object index, or -1 when the frequency
+// is not inside any transverter's RF window.
+int transverterIndexForFrequency(double freqMhz,
+                                 const QVector<Transverter>& xvtrs);
+
 bool isWaterfallTileOutsidePan(double lowMhz, double highMhz, double panCenterMhz);
 
 WaterfallTileMatch matchWaterfallTileTransverterOffset(double lowMhz, double highMhz,

--- a/tests/xvtr_policy_test.cpp
+++ b/tests/xvtr_policy_test.cpp
@@ -256,6 +256,36 @@ void testXvtrWaterfallGuardrails()
                 inRange, 144.125, 144.625, false);
 }
 
+void testTransverterIndexForFrequency()
+{
+    const QVector<XvtrPolicy::Transverter> xvtrs = {
+        xvtr(12, 3, "2m",    144.0, 28.0),
+        xvtr(4,  7, "70cm",  432.0, 28.0),
+        xvtr(1,  9, "1.2G", 1296.0, 28.0),
+        xvtr(6,  2, "23cm", 1240.0, 28.0, false),
+    };
+
+    auto expectIndex = [](const char* label, double freqMhz,
+                          const QVector<XvtrPolicy::Transverter>& xvtrs,
+                          int expected) {
+        const int idx = XvtrPolicy::transverterIndexForFrequency(freqMhz, xvtrs);
+        report(label, idx == expected,
+               QStringLiteral("idx=%1 expected=%2").arg(idx).arg(expected)
+                   .toStdString());
+    };
+
+    expectIndex("2m frequency resolves to 2m XVTR index", 144.2, xvtrs, 12);
+    expectIndex("RF window start is inclusive", 144.0, xvtrs, 12);
+    expectIndex("70cm frequency picks nearest RF start below", 432.1, xvtrs, 4);
+    expectIndex("1.2 GHz frequency resolves past lower XVTRs", 1296.3, xvtrs, 1);
+    expectIndex("invalid XVTR is never matched", 1241.0, xvtrs, -1);
+    expectIndex("HF frequency matches no XVTR", 14.225, xvtrs, -1);
+    expectIndex("frequency below every RF start matches nothing", 100.0, xvtrs, -1);
+    expectIndex("frequency beyond the 54 MHz IF span matches nothing",
+                432.1 + 60.0, xvtrs, -1);
+    expectIndex("empty XVTR list matches nothing", 144.2, {}, -1);
+}
+
 void testMaxPowerClampMirrorsFlexLib()
 {
     expectMaxPowerRange("6400 low IF caps max power at +10 dBm",
@@ -287,6 +317,7 @@ int main()
     testHfWaterfallDoesNotShiftWhenTileLagsByOneSpan();
     testXvtrWaterfallMapsIfToRfBands();
     testXvtrWaterfallGuardrails();
+    testTransverterIndexForFrequency();
     testMaxPowerClampMirrorsFlexLib();
 
     return g_failed == 0 ? 0 : 1;


### PR DESCRIPTION
Closes #3531

## What

Per-transverter antenna auto-switch. **Settings → Radio Setup → XVTR** gains two selectors per transverter page — `Auto RX Ant:` / `Auto TX Ant:` — populated from the radio's antenna list. When any slice's frequency lands on a transverter whose ports are configured, the slice's RX/TX antennas are switched automatically; the VFO antenna flags update through the normal status push. The default `(no change)` leaves existing behavior untouched.

## Design (deviates from the issue — maintainer review requested)

The issue sketched a per-band mapping table plus a global `XvtrAutoSwitchEnabled` toggle. This implementation configures ports **per transverter** directly in the existing XVTR setup pages instead:

- The radio's `xvtr` objects are the natural key — band names are user labels and can collide with native bands (#2342), while the xvtr index is what `display pan set band=X<n>` already uses.
- The per-XVTR `(no change)` default replaces the global toggle: the feature is opt-in per transverter and inert by default.
- Mapping persists client-side as one nested JSON blob under the `AppSettings` `XvtrAutoAntenna` root key (Principle V) because the radio does not persist per-XVTR antenna mappings.

## How

- `XvtrPolicy::transverterIndexForFrequency()` — pure function resolving which transverter owns an RF frequency (nearest RF start at-or-below, capped at the 54 MHz native IF span). 9 new cases in `xvtr_policy_test` (44/44 pass).
- `MainWindow::evaluateXvtrAutoAntennas()` — evaluated on every slice's `frequencyChanged` plus once at slice creation (a Flex band change recreates the slice already inside the transverter band and may emit no `frequencyChanged` afterwards — same trap as #2824). Covers band selector, direct tune, CAT/TCI on any slice, memory recall.
- Edge-triggered on the owning-transverter index per slice: retunes inside the band and manual antenna overrides while on it are left alone; leaving a transverter band restores nothing (native-band antennas stay radio-authoritative). Antenna commands are deferred 600 ms after the transition and re-validated so the radio's own band-stack restore settles first (slices settle in ~250–340 ms observed). TX port is skipped for `rx_only` transverters.

## Also in this PR

- `0ecfd6e` fix(gui): the Phase 2a extraction (#3534) left `m_hidEncoder->isTMate2()` / `noteTMate2Interaction()` inside the `HAVE_SERIALPORT` block of `MainWindow_Controllers.cpp`; both only exist under `HAVE_HIDAPI`, so serialport-without-hidapi builds (e.g. Windows before `setup-hidapi.ps1`) failed to compile. Standalone commit, cherry-pickable if you want it on main faster.

## Testing

- `xvtr_policy_test`: 44/44 pass (9 new).
- Full Windows (MinGW/Qt6) build clean.
- Not yet exercised against a live radio with a transverter — the 600 ms settle window and port naming (`XVTA`/`XVTB`) deserve a live check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
