### PR TITLE
feat(tmate2): enhanced display — TX bargraph, text overlays, encoder labels

### DIFF
--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -41,12 +41,37 @@ static const uint8_t kSmallLow[10] = {
     0xA0, 0x00, 0x60, 0x40, 0xC0, 0xC0, 0xE0, 0x00, 0xE0, 0xC0
 };
 
+struct SmallGlyph { uint8_t high; uint8_t low; };
+
+static SmallGlyph tmate2SmallGlyph(QChar ch)
+{
+    if (ch.isDigit()) {
+        const int digit = ch.digitValue();
+        return { kSmallHigh[digit], kSmallLow[digit] };
+    }
+
+    switch (ch.toLatin1()) {
+    case 'k':
+    case 'K':
+        // Seven-segment approximation: left strokes, center, and lower-right.
+        return { 0x20, 0xE0 };
+    case '-':
+        return { 0x00, 0x40 };
+    case ' ':
+        return { 0x00, 0x00 };
+    default:
+        return { 0x00, 0x00 };
+    }
+}
+
 // Indicator segment lookup: {byte_index, bitmask}.
 // Derived from USB captures (session_20260605_051711/segments_*.csv).
 // Byte range 0-31 only; indicator bits never overlap with digit A-G bits.
 struct SegEntry { uint8_t byte; uint8_t mask; };
 static constexpr SegEntry kSeg_RX        = {  0, 0x04 };
 static constexpr SegEntry kSeg_TX        = {  0, 0x08 };
+static constexpr SegEntry kSeg_E1        = {  0, 0x80 };
+static constexpr SegEntry kSeg_E2        = {  8, 0x10 };
 static constexpr SegEntry kSeg_S         = {  0, 0x10 };
 static constexpr SegEntry kSeg_VOL       = {  1, 0x80 };
 static constexpr SegEntry kSeg_SMETER_LINE = { 2, 0x01 };
@@ -66,8 +91,21 @@ static constexpr SegEntry kSeg_DOT1      = {  9, 0x10 };  // after digit 3 (kHz/
 static constexpr SegEntry kSeg_DOT2      = { 15, 0x10 };  // after digit 6 (MHz/kHz)
 static constexpr SegEntry kSeg_HZ        = { 23, 0x01 };
 static constexpr SegEntry kSeg_W         = { 20, 0x20 };
+static constexpr SegEntry kSeg_LOW       = { 11, 0x10 };
+static constexpr SegEntry kSeg_HIGH      = { 10, 0x10 };
 static constexpr SegEntry kSeg_RIT       = { 13, 0x10 };
 static constexpr SegEntry kSeg_XIT       = { 14, 0x10 };
+static constexpr SegEntry kSeg_SMETER_1      = {  1, 0x10 };
+static constexpr SegEntry kSeg_SMETER_3      = {  2, 0x10 };
+static constexpr SegEntry kSeg_SMETER_5      = {  2, 0x08 };
+static constexpr SegEntry kSeg_SMETER_7      = {  2, 0x04 };
+static constexpr SegEntry kSeg_SMETER_9      = {  2, 0x02 };
+static constexpr SegEntry kSeg_SMETER_PLUS20 = {  9, 0x20 };
+static constexpr SegEntry kSeg_SMETER_PLUS40 = { 15, 0x20 };
+static constexpr SegEntry kSeg_SMETER_PLUS60 = { 18, 0x20 };
+static constexpr SegEntry kSeg_SMETER_20     = { 10, 0x20 };
+static constexpr SegEntry kSeg_SMETER_40     = { 16, 0x20 };
+static constexpr SegEntry kSeg_SMETER_60     = { 19, 0x20 };
 // 15-segment S-meter bargraph (BAR1=weakest, BAR15=strongest)
 static constexpr SegEntry kSMeterBars[15] = {
     { 1, 0x08 }, { 1, 0x04 }, { 1, 0x02 }, // BAR1-3
@@ -90,6 +128,61 @@ static int smeterBars(float dbm)
     if (dbm < -121.0f) return 0;
     if (dbm <= -73.0f) return static_cast<int>((dbm + 121.0f) / 6.0f) + 1;
     return std::min(15, 9 + static_cast<int>((dbm + 73.0f) / 10.0f));
+}
+
+static void setSmeterScaleSegs(uint8_t* lcd, bool on)
+{
+    tmate2Seg(lcd, kSeg_SMETER_1, on);
+    tmate2Seg(lcd, kSeg_SMETER_3, on);
+    tmate2Seg(lcd, kSeg_SMETER_5, on);
+    tmate2Seg(lcd, kSeg_SMETER_7, on);
+    tmate2Seg(lcd, kSeg_SMETER_9, on);
+    tmate2Seg(lcd, kSeg_SMETER_PLUS20, on);
+    tmate2Seg(lcd, kSeg_SMETER_PLUS40, on);
+    tmate2Seg(lcd, kSeg_SMETER_PLUS60, on);
+    tmate2Seg(lcd, kSeg_SMETER_20, on);
+    tmate2Seg(lcd, kSeg_SMETER_40, on);
+    tmate2Seg(lcd, kSeg_SMETER_60, on);
+}
+
+static void clearTMate2EncoderActionSegs(uint8_t* lcd)
+{
+    tmate2Seg(lcd, kSeg_E1, false);
+    tmate2Seg(lcd, kSeg_E2, false);
+    tmate2Seg(lcd, kSeg_VOL, false);
+    tmate2Seg(lcd, kSeg_LOW, false);
+    tmate2Seg(lcd, kSeg_HIGH, false);
+}
+
+static void setTMate2EncoderActionSegs(uint8_t* lcd,
+                                       const QString& encoder1Action,
+                                       const QString& encoder2Action)
+{
+    clearTMate2EncoderActionSegs(lcd);
+    const bool e1Assigned = !encoder1Action.isEmpty()
+        && encoder1Action != QLatin1String("None");
+    const bool e2Assigned = !encoder2Action.isEmpty()
+        && encoder2Action != QLatin1String("None");
+    tmate2Seg(lcd, kSeg_E1, e1Assigned);
+    tmate2Seg(lcd, kSeg_E2, e2Assigned);
+
+    const bool volume = encoder1Action == QLatin1String("WheelVolume")
+        || encoder1Action == QLatin1String("WheelMasterAf")
+        || encoder2Action == QLatin1String("WheelVolume")
+        || encoder2Action == QLatin1String("WheelMasterAf")
+        || encoder1Action == QLatin1String("WheelSliceAudio")
+        || encoder2Action == QLatin1String("WheelSliceAudio")
+        || encoder1Action == QLatin1String("WheelHeadphoneVolume")
+        || encoder2Action == QLatin1String("WheelHeadphoneVolume");
+    const bool high = encoder1Action == QLatin1String("WheelPower")
+        || encoder2Action == QLatin1String("WheelPower")
+        || encoder1Action == QLatin1String("WheelAgcT")
+        || encoder2Action == QLatin1String("WheelAgcT")
+        || encoder1Action == QLatin1String("WheelApf")
+        || encoder2Action == QLatin1String("WheelApf");
+
+    tmate2Seg(lcd, kSeg_VOL, volume);
+    tmate2Seg(lcd, kSeg_HIGH, high);
 }
 
 static void applyModeSegs(uint8_t* lcd, const QString& mode)
@@ -168,6 +261,20 @@ static void tmate2WriteSmallDisplay(uint8_t* v, uint32_t val)
         v[hi] |= kSmallHigh[val % 10u];
         v[lo] |= kSmallLow [val % 10u];
         val /= 10u;
+    }
+}
+
+static void tmate2WriteSmallDisplayText(uint8_t* v, const QString& text)
+{
+    const QString clean = text.left(3).rightJustified(3, QLatin1Char(' '));
+    for (int d = 1; d <= 3; ++d) {
+        uint8_t hi = static_cast<uint8_t>(21 + 2 * d);
+        uint8_t lo = static_cast<uint8_t>(22 + 2 * d);
+        const SmallGlyph glyph = tmate2SmallGlyph(clean.at(3 - d));
+        v[hi] &= 0x0Fu;
+        v[lo] &= 0x1Fu;
+        v[hi] |= glyph.high;
+        v[lo] |= glyph.low;
     }
 }
 
@@ -600,8 +707,18 @@ void HidEncoderManager::setTMate2Display(uint32_t freq_hz, uint32_t small_val)
     sendTMate2();
 }
 
+void HidEncoderManager::setTMate2DisplayText(uint32_t freq_hz, const QString& small_text)
+{
+    if (!m_device || !isTMate2()) return;
+    tmate2WriteMainDisplay(m_lcdVector, freq_hz);
+    tmate2WriteSmallDisplayText(m_lcdVector, small_text);
+    sendTMate2();
+}
+
 void HidEncoderManager::setTMate2Indicators(bool tx, const QString& mode,
-                                             float smeter_dbm, bool rit, bool xit)
+                                             float smeter_dbm, bool rit, bool xit,
+                                             const QString& encoder1Action,
+                                             const QString& encoder2Action)
 {
     if (!m_device || !isTMate2()) return;
 
@@ -611,9 +728,10 @@ void HidEncoderManager::setTMate2Indicators(bool tx, const QString& mode,
     tmate2Seg(m_lcdVector, kSeg_W,   tx);
     tmate2Seg(m_lcdVector, kSeg_DBM, !tx);
     tmate2Seg(m_lcdVector, kSeg_S,   !tx);
-    tmate2Seg(m_lcdVector, kSeg_VOL, true);
-    tmate2Seg(m_lcdVector, kSeg_SMETER_LINE, true);
+    tmate2Seg(m_lcdVector, kSeg_SMETER_LINE, !tx);
     tmate2Seg(m_lcdVector, kSeg_SMETER_DB_MINUS, !tx && smeter_dbm < 0.0f);
+    setSmeterScaleSegs(m_lcdVector, !tx);
+    setTMate2EncoderActionSegs(m_lcdVector, encoder1Action, encoder2Action);
 
     // Static frequency-display decorations (decimal dots + Hz unit). These are
     // always on in the normal view; re-assert them here — not only in open() —
@@ -630,9 +748,13 @@ void HidEncoderManager::setTMate2Indicators(bool tx, const QString& mode,
     for (int i = 0; i < 15; ++i)
         tmate2Seg(m_lcdVector, kSMeterBars[i], i < bars);
 
-    // RIT / XIT
-    tmate2Seg(m_lcdVector, kSeg_RIT, rit);
-    tmate2Seg(m_lcdVector, kSeg_XIT, xit);
+    // RIT / XIT double as function-label segments for the E1/E2 encoders.
+    const bool ritMapped = encoder1Action == QLatin1String("WheelRit")
+        || encoder2Action == QLatin1String("WheelRit");
+    const bool xitMapped = encoder1Action == QLatin1String("WheelXit")
+        || encoder2Action == QLatin1String("WheelXit");
+    tmate2Seg(m_lcdVector, kSeg_RIT, rit || ritMapped);
+    tmate2Seg(m_lcdVector, kSeg_XIT, xit || xitMapped);
 
     sendTMate2();
 }
@@ -650,6 +772,8 @@ void HidEncoderManager::setTMate2OverlayIndicators(const QString& overlayType,
     const bool isRit    = overlayType == QLatin1String("rit");
 
     tmate2Seg(m_lcdVector, kSeg_SMETER_LINE, false);
+    setSmeterScaleSegs(m_lcdVector, false);
+    clearTMate2EncoderActionSegs(m_lcdVector);
     tmate2Seg(m_lcdVector, kSeg_DOT1, false);
     tmate2Seg(m_lcdVector, kSeg_DOT2, false);
     tmate2Seg(m_lcdVector, kSeg_VOL, isVolume);
@@ -685,6 +809,8 @@ void HidEncoderManager::clearTMate2Indicators()
     tmate2Seg(m_lcdVector, kSeg_VOL, false);
     tmate2Seg(m_lcdVector, kSeg_SMETER_LINE, false);
     tmate2Seg(m_lcdVector, kSeg_SMETER_DB_MINUS, false);
+    setSmeterScaleSegs(m_lcdVector, false);
+    clearTMate2EncoderActionSegs(m_lcdVector);
     tmate2Seg(m_lcdVector, kSeg_DOT1, false);
     tmate2Seg(m_lcdVector, kSeg_DOT2, false);
     tmate2Seg(m_lcdVector, kSeg_HZ, false);

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -59,14 +59,17 @@ static MainGlyph tmate2MainGlyph(QChar ch)
     case 'G': case 'g': return { 0x05, 0x0D };
     case 'H': case 'h': return { 0x06, 0x07 };
     case 'I': case 'i': return { 0x00, 0x04 };
+    case 'K': case 'k': return { 0x00, 0x0F };
     case 'L': case 'l': return { 0x00, 0x0D };
+    case 'M': case 'm': return { 0x04, 0x06 };
+    case 'N': case 'n': return { 0x04, 0x06 };
     case 'O': case 'o': return { 0x07, 0x0D };
     case 'P': case 'p': return { 0x03, 0x07 };
     case 'R': case 'r': return { 0x00, 0x06 };
     case 'S': case 's': return { 0x05, 0x0B };
     case 'T': case 't': return { 0x00, 0x0F };
     case 'U': case 'u': return { 0x06, 0x0D };
-    case 'V': case 'v': return { 0x04, 0x0D };
+    case 'V': case 'v': return { 0x06, 0x0D };
     case 'W': case 'w': return { 0x06, 0x0D };
     case 'X': case 'x': return { 0x06, 0x07 };
     case 'Y': case 'y': return { 0x06, 0x0B };

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -7,6 +7,7 @@
 #include <QJsonObject>
 #include <QJsonDocument>
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 
 // ── TMate 2 display helpers ────────────────────────────────────────────────
@@ -171,6 +172,14 @@ static int smeterBars(float dbm)
     if (dbm < -121.0f) return 0;
     if (dbm <= -73.0f) return static_cast<int>((dbm + 121.0f) / 6.0f) + 1;
     return std::min(15, 9 + static_cast<int>((dbm + 73.0f) / 10.0f));
+}
+
+static int powerBars(float watts, float fullScaleWatts)
+{
+    if (!std::isfinite(watts) || !std::isfinite(fullScaleWatts) || fullScaleWatts <= 0.0f)
+        return 0;
+    const float clampedWatts = std::clamp(watts, 0.0f, fullScaleWatts);
+    return std::clamp(static_cast<int>(std::lround((clampedWatts / fullScaleWatts) * 15.0f)), 0, 15);
 }
 
 static void setSmeterScaleSegs(uint8_t* lcd, bool on)
@@ -793,7 +802,9 @@ void HidEncoderManager::setTMate2OverlayDisplay(const QString& main_text)
 void HidEncoderManager::setTMate2Indicators(bool tx, const QString& mode,
                                              float smeter_dbm, bool rit, bool xit,
                                              const QString& encoder1Action,
-                                             const QString& encoder2Action)
+                                             const QString& encoder2Action,
+                                             float txPowerWatts,
+                                             float txPowerFullScaleWatts)
 {
     if (!m_device || !isTMate2()) return;
 
@@ -819,7 +830,9 @@ void HidEncoderManager::setTMate2Indicators(bool tx, const QString& mode,
     applyModeSegs(m_lcdVector, mode);
 
     // S-meter bargraph — set bars 1..N on, rest off
-    const int bars = smeterBars(smeter_dbm);
+    const int bars = tx
+        ? powerBars(txPowerWatts, txPowerFullScaleWatts)
+        : smeterBars(smeter_dbm);
     for (int i = 0; i < 15; ++i)
         tmate2Seg(m_lcdVector, kSMeterBars[i], i < bars);
 

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -41,7 +41,40 @@ static const uint8_t kSmallLow[10] = {
     0xA0, 0x00, 0x60, 0x40, 0xC0, 0xC0, 0xE0, 0x00, 0xE0, 0xC0
 };
 
+struct MainGlyph { uint8_t high; uint8_t low; };
 struct SmallGlyph { uint8_t high; uint8_t low; };
+
+static MainGlyph tmate2MainGlyph(QChar ch)
+{
+    if (ch.isDigit()) {
+        const int digit = ch.digitValue();
+        return { kMainHigh[digit], kMainLow[digit] };
+    }
+
+    switch (ch.toLatin1()) {
+    case 'A': case 'a': return { 0x07, 0x07 };
+    case 'C': case 'c': return { 0x01, 0x0D };
+    case 'E': case 'e': return { 0x01, 0x0F };
+    case 'F': case 'f': return { 0x01, 0x07 };
+    case 'G': case 'g': return { 0x05, 0x0D };
+    case 'H': case 'h': return { 0x06, 0x07 };
+    case 'I': case 'i': return { 0x00, 0x04 };
+    case 'L': case 'l': return { 0x00, 0x0D };
+    case 'O': case 'o': return { 0x07, 0x0D };
+    case 'P': case 'p': return { 0x03, 0x07 };
+    case 'R': case 'r': return { 0x00, 0x06 };
+    case 'S': case 's': return { 0x05, 0x0B };
+    case 'T': case 't': return { 0x00, 0x0F };
+    case 'U': case 'u': return { 0x06, 0x0D };
+    case 'V': case 'v': return { 0x04, 0x0D };
+    case 'W': case 'w': return { 0x06, 0x0D };
+    case 'X': case 'x': return { 0x06, 0x07 };
+    case 'Y': case 'y': return { 0x06, 0x0B };
+    case '-': return { 0x00, 0x02 };
+    case ' ': return { 0x00, 0x00 };
+    default:  return { 0x00, 0x00 };
+    }
+}
 
 static SmallGlyph tmate2SmallGlyph(QChar ch)
 {
@@ -74,6 +107,12 @@ static constexpr SegEntry kSeg_E1        = {  0, 0x80 };
 static constexpr SegEntry kSeg_E2        = {  8, 0x10 };
 static constexpr SegEntry kSeg_S         = {  0, 0x10 };
 static constexpr SegEntry kSeg_VOL       = {  1, 0x80 };
+static constexpr SegEntry kSeg_RFG       = {  2, 0x80 };
+static constexpr SegEntry kSeg_SQL       = {  3, 0x10 };
+static constexpr SegEntry kSeg_DRV       = {  4, 0x10 };
+static constexpr SegEntry kSeg_NR2       = {  5, 0x10 };
+static constexpr SegEntry kSeg_NB2       = {  6, 0x10 };
+static constexpr SegEntry kSeg_AN2       = {  7, 0x10 };
 static constexpr SegEntry kSeg_SMETER_LINE = { 2, 0x01 };
 static constexpr SegEntry kSeg_SMETER_DB_MINUS = {28, 0x10 };
 static constexpr SegEntry kSeg_DIG_PLUS  = { 21, 0x04 };
@@ -93,6 +132,7 @@ static constexpr SegEntry kSeg_HZ        = { 23, 0x01 };
 static constexpr SegEntry kSeg_W         = { 20, 0x20 };
 static constexpr SegEntry kSeg_LOW       = { 11, 0x10 };
 static constexpr SegEntry kSeg_HIGH      = { 10, 0x10 };
+static constexpr SegEntry kSeg_SHIFT     = { 12, 0x10 };
 static constexpr SegEntry kSeg_RIT       = { 13, 0x10 };
 static constexpr SegEntry kSeg_XIT       = { 14, 0x10 };
 static constexpr SegEntry kSeg_SMETER_1      = {  1, 0x10 };
@@ -150,8 +190,15 @@ static void clearTMate2EncoderActionSegs(uint8_t* lcd)
     tmate2Seg(lcd, kSeg_E1, false);
     tmate2Seg(lcd, kSeg_E2, false);
     tmate2Seg(lcd, kSeg_VOL, false);
+    tmate2Seg(lcd, kSeg_RFG, false);
+    tmate2Seg(lcd, kSeg_SQL, false);
+    tmate2Seg(lcd, kSeg_DRV, false);
+    tmate2Seg(lcd, kSeg_NR2, false);
+    tmate2Seg(lcd, kSeg_NB2, false);
+    tmate2Seg(lcd, kSeg_AN2, false);
     tmate2Seg(lcd, kSeg_LOW, false);
     tmate2Seg(lcd, kSeg_HIGH, false);
+    tmate2Seg(lcd, kSeg_SHIFT, false);
 }
 
 static void setTMate2EncoderActionSegs(uint8_t* lcd,
@@ -166,23 +213,26 @@ static void setTMate2EncoderActionSegs(uint8_t* lcd,
     tmate2Seg(lcd, kSeg_E1, e1Assigned);
     tmate2Seg(lcd, kSeg_E2, e2Assigned);
 
-    const bool volume = encoder1Action == QLatin1String("WheelVolume")
-        || encoder1Action == QLatin1String("WheelMasterAf")
-        || encoder2Action == QLatin1String("WheelVolume")
-        || encoder2Action == QLatin1String("WheelMasterAf")
-        || encoder1Action == QLatin1String("WheelSliceAudio")
-        || encoder2Action == QLatin1String("WheelSliceAudio")
-        || encoder1Action == QLatin1String("WheelHeadphoneVolume")
-        || encoder2Action == QLatin1String("WheelHeadphoneVolume");
-    const bool high = encoder1Action == QLatin1String("WheelPower")
-        || encoder2Action == QLatin1String("WheelPower")
-        || encoder1Action == QLatin1String("WheelAgcT")
-        || encoder2Action == QLatin1String("WheelAgcT")
-        || encoder1Action == QLatin1String("WheelApf")
-        || encoder2Action == QLatin1String("WheelApf");
+    // E1 has the left-side function words from the TMate 2 silkscreen.
+    tmate2Seg(lcd, kSeg_VOL,
+              encoder1Action == QLatin1String("WheelVolume")
+              || encoder1Action == QLatin1String("WheelMasterAf")
+              || encoder1Action == QLatin1String("WheelSliceAudio")
+              || encoder1Action == QLatin1String("WheelHeadphoneVolume"));
+    tmate2Seg(lcd, kSeg_DRV, encoder1Action == QLatin1String("WheelPower"));
+    tmate2Seg(lcd, kSeg_SQL, encoder1Action == QLatin1String("WheelAgcT"));
+    tmate2Seg(lcd, kSeg_RFG, false);
+    tmate2Seg(lcd, kSeg_NR2, false);
+    tmate2Seg(lcd, kSeg_NB2, false);
+    tmate2Seg(lcd, kSeg_AN2, false);
 
-    tmate2Seg(lcd, kSeg_VOL, volume);
-    tmate2Seg(lcd, kSeg_HIGH, high);
+    // E2 has only the right-side function words.
+    tmate2Seg(lcd, kSeg_HIGH,
+              encoder2Action == QLatin1String("WheelPower")
+              || encoder2Action == QLatin1String("WheelAgcT")
+              || encoder2Action == QLatin1String("WheelApf"));
+    tmate2Seg(lcd, kSeg_LOW, false);
+    tmate2Seg(lcd, kSeg_SHIFT, encoder2Action == QLatin1String("WheelFrequency"));
 }
 
 static void applyModeSegs(uint8_t* lcd, const QString& mode)
@@ -245,6 +295,20 @@ static void tmate2WriteMainDisplay(uint8_t* v, uint32_t hz)
         v[hi] |= kMainHigh[hz % 10u];
         v[lo] |= kMainLow [hz % 10u];
         hz /= 10u;
+    }
+}
+
+static void tmate2WriteMainDisplayText(uint8_t* v, const QString& text)
+{
+    const QString clean = text.left(9).rightJustified(9, QLatin1Char(' '));
+    for (int d = 1; d <= 9; ++d) {
+        uint8_t hi = static_cast<uint8_t>(22 - 2 * d);
+        uint8_t lo = static_cast<uint8_t>(21 - 2 * d);
+        const MainGlyph glyph = tmate2MainGlyph(clean.at(9 - d));
+        v[hi] &= 0xF8u;
+        v[lo] &= 0xF0u;
+        v[hi] |= glyph.high;
+        v[lo] |= glyph.low;
     }
 }
 
@@ -715,6 +779,14 @@ void HidEncoderManager::setTMate2DisplayText(uint32_t freq_hz, const QString& sm
     sendTMate2();
 }
 
+void HidEncoderManager::setTMate2OverlayDisplay(const QString& main_text)
+{
+    if (!m_device || !isTMate2()) return;
+    tmate2WriteMainDisplayText(m_lcdVector, main_text);
+    tmate2WriteSmallDisplayText(m_lcdVector, QString());
+    sendTMate2();
+}
+
 void HidEncoderManager::setTMate2Indicators(bool tx, const QString& mode,
                                              float smeter_dbm, bool rit, bool xit,
                                              const QString& encoder1Action,
@@ -770,6 +842,11 @@ void HidEncoderManager::setTMate2OverlayIndicators(const QString& overlayType,
     const bool isSpeed  = overlayType == QLatin1String("speed");
     const bool isWpm    = overlayType == QLatin1String("wpm");
     const bool isRit    = overlayType == QLatin1String("rit");
+    const bool isXit    = overlayType == QLatin1String("xit");
+    const bool isShift  = overlayType == QLatin1String("shift");
+    const bool isLevel  = overlayType == QLatin1String("agc")
+        || overlayType == QLatin1String("apf");
+    const bool isHzValue = isSpeed || isRit || isXit || isShift;
 
     tmate2Seg(m_lcdVector, kSeg_SMETER_LINE, false);
     setSmeterScaleSegs(m_lcdVector, false);
@@ -778,19 +855,22 @@ void HidEncoderManager::setTMate2OverlayIndicators(const QString& overlayType,
     tmate2Seg(m_lcdVector, kSeg_DOT2, false);
     tmate2Seg(m_lcdVector, kSeg_VOL, isVolume);
     tmate2Seg(m_lcdVector, kSeg_W, isPower);
-    tmate2Seg(m_lcdVector, kSeg_HZ, isSpeed || isRit);
+    tmate2Seg(m_lcdVector, kSeg_HZ, isHzValue);
     tmate2Seg(m_lcdVector, kSeg_RIT, isRit);
-    tmate2Seg(m_lcdVector, kSeg_SMETER_DB_MINUS, isRit && overlayValue < 0);
+    tmate2Seg(m_lcdVector, kSeg_XIT, isXit);
+    tmate2Seg(m_lcdVector, kSeg_SHIFT, isShift);
+    tmate2Seg(m_lcdVector, kSeg_SMETER_DB_MINUS,
+              (isRit || isXit || isShift) && overlayValue < 0);
     tmate2Seg(m_lcdVector, kSeg_DBM, false);
     tmate2Seg(m_lcdVector, kSeg_S, false);
     tmate2Seg(m_lcdVector, kSeg_RX, false);
     tmate2Seg(m_lcdVector, kSeg_TX, false);
-    tmate2Seg(m_lcdVector, kSeg_XIT, false);
 
-    // Keep the current mode visible; for WPM force CW as an additional cue.
-    applyModeSegs(m_lcdVector, isWpm ? QStringLiteral("CW") : mode);
+    // Overlays are transient numeric readouts; blank normal mode labels
+    // (USB/LSB/DIG+/...) so they do not visually mix with the feedback value.
+    applyModeSegs(m_lcdVector, QString());
 
-    const int bars = (isVolume || isPower)
+    const int bars = (isVolume || isPower || isLevel)
         ? std::clamp((std::clamp(overlayValue, 0, 100) * 15 + 99) / 100, 0, 15)
         : 0;
     for (int i = 0; i < 15; ++i)

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -55,6 +55,7 @@ static MainGlyph tmate2MainGlyph(QChar ch)
     switch (ch.toLatin1()) {
     case 'A': case 'a': return { 0x07, 0x07 };
     case 'C': case 'c': return { 0x01, 0x0D };
+    case 'D': case 'd': return { 0x06, 0x0E };  // lowercase-d: B+C + D+E+G
     case 'E': case 'e': return { 0x01, 0x0F };
     case 'F': case 'f': return { 0x01, 0x07 };
     case 'G': case 'g': return { 0x05, 0x0D };
@@ -856,7 +857,6 @@ void HidEncoderManager::setTMate2OverlayIndicators(const QString& overlayType,
     const bool isVolume = overlayType == QLatin1String("volume");
     const bool isPower  = overlayType == QLatin1String("power");
     const bool isSpeed  = overlayType == QLatin1String("speed");
-    const bool isWpm    = overlayType == QLatin1String("wpm");
     const bool isRit    = overlayType == QLatin1String("rit");
     const bool isXit    = overlayType == QLatin1String("xit");
     const bool isShift  = overlayType == QLatin1String("shift");

--- a/src/core/HidEncoderManager.h
+++ b/src/core/HidEncoderManager.h
@@ -103,6 +103,9 @@ public slots:
     // Text variant for the 3-digit S-meter/power display. Accepts up to three
     // 7-segment glyphs, used for amplified power such as "1k5" + W segment.
     void setTMate2DisplayText(uint32_t freq_hz, const QString& small_text);
+    // Text variant for transient overlays. Accepts up to nine 7-segment glyphs
+    // on the main display and blanks the small display.
+    void setTMate2OverlayDisplay(const QString& main_text);
     // Update the TMate 2 segment indicators (RX/TX, mode, S-meter bargraph,
     // RIT/XIT, decimal dots).  Call whenever any of these state items changes.
     //   tx        : true = transmitting, false = receiving

--- a/src/core/HidEncoderManager.h
+++ b/src/core/HidEncoderManager.h
@@ -110,13 +110,16 @@ public slots:
     // RIT/XIT, decimal dots).  Call whenever any of these state items changes.
     //   tx        : true = transmitting, false = receiving
     //   mode      : demodulation mode string ("USB","LSB","AM","FM","CW","DIGL","DIGU",…)
-    //   smeter_dbm: S-meter reading in dBm; drives the 15-segment bargraph
+    //   smeter_dbm: S-meter reading in dBm; drives the 15-segment bargraph in RX
+    //   txPowerWatts/txPowerFullScaleWatts: bargraph scale in TX
     //   rit/xit   : RIT / XIT active flags
     // No-op if device is not a TMate 2.
     void setTMate2Indicators(bool tx, const QString& mode, float smeter_dbm,
                               bool rit, bool xit,
                               const QString& encoder1Action = QString(),
-                              const QString& encoder2Action = QString());
+                              const QString& encoder2Action = QString(),
+                              float txPowerWatts = 0.0f,
+                              float txPowerFullScaleWatts = 100.0f);
     // Temporarily switch indicator segments to a TMate 2 overlay view.
     // overlayType: "volume", "power", "speed", "wpm", or "rit".
     void setTMate2OverlayIndicators(const QString& overlayType,

--- a/src/core/HidEncoderManager.h
+++ b/src/core/HidEncoderManager.h
@@ -100,6 +100,9 @@ public slots:
     // Sends a full LCDVector update (backlight, contrast, timing are preserved).
     // No-op if device is not a TMate 2.
     void setTMate2Display(uint32_t freq_hz, uint32_t small_val);
+    // Text variant for the 3-digit S-meter/power display. Accepts up to three
+    // 7-segment glyphs, used for amplified power such as "1k5" + W segment.
+    void setTMate2DisplayText(uint32_t freq_hz, const QString& small_text);
     // Update the TMate 2 segment indicators (RX/TX, mode, S-meter bargraph,
     // RIT/XIT, decimal dots).  Call whenever any of these state items changes.
     //   tx        : true = transmitting, false = receiving
@@ -108,7 +111,9 @@ public slots:
     //   rit/xit   : RIT / XIT active flags
     // No-op if device is not a TMate 2.
     void setTMate2Indicators(bool tx, const QString& mode, float smeter_dbm,
-                              bool rit, bool xit);
+                              bool rit, bool xit,
+                              const QString& encoder1Action = QString(),
+                              const QString& encoder2Action = QString());
     // Temporarily switch indicator segments to a TMate 2 overlay view.
     // overlayType: "volume", "power", "speed", "wpm", or "rit".
     void setTMate2OverlayIndicators(const QString& overlayType,

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -623,7 +623,7 @@ private:
     bool    m_rc28PttLatched{false};
     bool    m_hidFastTune{false};
     bool    m_hidFineTune{false};
-    enum class TMate2Overlay { None, Volume, Power, Speed, Wpm, Rit };
+    enum class TMate2Overlay { None, Volume, Power, Speed, Wpm, Rit, Xit, Shift, Agc, Apf };
     TMate2Overlay m_tmate2Overlay{TMate2Overlay::None};
     int     m_tmate2OverlayValue{0};
     qint64  m_tmate2OverlayUntilMs{0};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -623,9 +623,10 @@ private:
     bool    m_rc28PttLatched{false};
     bool    m_hidFastTune{false};
     bool    m_hidFineTune{false};
-    enum class TMate2Overlay { None, Volume, Power, Speed, Wpm, Rit, Xit, Shift, Agc, Apf };
+    enum class TMate2Overlay { None, Volume, Power, Speed, Wpm, Rit, Xit, Shift, Agc, Apf, Text };
     TMate2Overlay m_tmate2Overlay{TMate2Overlay::None};
     int     m_tmate2OverlayValue{0};
+    QString m_tmate2OverlayText;
     qint64  m_tmate2OverlayUntilMs{0};
     qint64  m_tmate2LastUserInteractionMs{0};
     bool    m_tmate2DisplayBlanked{false};
@@ -642,6 +643,7 @@ private:
     void noteTMate2Interaction();
     void blankTMate2Display();
     void triggerTMate2Overlay(TMate2Overlay overlay, int value);
+    void triggerTMate2TextOverlay(const QString& text);
     void updateTMate2Display();
     void updateTMate2Status();
     void updateTMate2Indicators();

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -767,6 +767,9 @@ void MainWindow::updateTMate2Indicators()
     const bool rit    = s && s->ritOn();
     const bool xit    = s && s->xitOn();
     const float dbm   = m_tmate2SmeterDbm;
+    const float txPowerWatts = m_tmate2TxWatts;
+    const float txPowerFullScaleWatts =
+        (m_radioModel.hasAmplifier() && m_radioModel.ampOperate()) ? 2000.0f : 100.0f;
     auto& settings = AppSettings::instance();
     // TMate 2 settings list the main tuning encoder first, then the two
     // auxiliary encoders. The LCD labels those auxiliaries in the opposite
@@ -794,10 +797,12 @@ void MainWindow::updateTMate2Indicators()
         return;
     }
     QMetaObject::invokeMethod(m_hidEncoder,
-        [this, tx, mode, dbm, rit, xit, r, g, b, lcdE1Action, lcdE2Action] {
+        [this, tx, mode, dbm, rit, xit, r, g, b, lcdE1Action, lcdE2Action,
+         txPowerWatts, txPowerFullScaleWatts] {
         m_hidEncoder->setTMate2Backlight(r, g, b);
         m_hidEncoder->setTMate2Indicators(tx, mode, dbm, rit, xit,
-                                          lcdE1Action, lcdE2Action);
+                                          lcdE1Action, lcdE2Action,
+                                          txPowerWatts, txPowerFullScaleWatts);
     });
 }
 

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -53,6 +53,9 @@ constexpr int kTMate2DefaultOverlayDurationMs = 1500;
 
 QString formatTMate2PowerSmallText(float watts)
 {
+    // std::lround(NaN) is unspecified; clamp to 0 first, mirroring powerBars().
+    if (!std::isfinite(watts))
+        watts = 0.0f;
     const int roundedWatts = std::clamp(static_cast<int>(std::lround(watts)), 0, 9999);
     if (roundedWatts <= 999)
         return QString::number(roundedWatts);
@@ -695,9 +698,17 @@ void MainWindow::updateTMate2Display()
             overlayText = QStringLiteral("XIT %1")
                 .arg(mainVal, 5, 10, QLatin1Char(' '));
             break;
-        case TMate2Overlay::Shift:
         case TMate2Overlay::Speed:
-            overlayText = QStringLiteral("STEP %1")
+            // Tuning step in Hz. Max preset step is 10 kHz, so use the short
+            // "STP" label: "STP 10000" is exactly 9 chars and fits the main
+            // display ("STEP 10000" would be 10 and truncate to "STEP 1000").
+            overlayText = QStringLiteral("STP %1")
+                .arg(mainVal, 5, 10, QLatin1Char(' '));
+            break;
+        case TMate2Overlay::Shift:
+            // Groundwork: not yet triggered (no dispatcher raises Shift). Own
+            // label so it never inherits the STEP readout if it is wired later.
+            overlayText = QStringLiteral("SHFT %1")
                 .arg(mainVal, 4, 10, QLatin1Char(' '));
             break;
         case TMate2Overlay::None:

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -536,6 +536,10 @@ QString MainWindow::tmate2OverlayName() const
     case TMate2Overlay::Speed:  return QStringLiteral("speed");
     case TMate2Overlay::Wpm:    return QStringLiteral("wpm");
     case TMate2Overlay::Rit:    return QStringLiteral("rit");
+    case TMate2Overlay::Xit:    return QStringLiteral("xit");
+    case TMate2Overlay::Shift:  return QStringLiteral("shift");
+    case TMate2Overlay::Agc:    return QStringLiteral("agc");
+    case TMate2Overlay::Apf:    return QStringLiteral("apf");
     case TMate2Overlay::None:   break;
     }
     return QString();
@@ -636,8 +640,46 @@ void MainWindow::updateTMate2Display()
 
     if (tmate2OverlayActive()) {
         const int32_t mainVal = m_tmate2OverlayValue;
-        QMetaObject::invokeMethod(m_hidEncoder, [this, mainVal] {
-            m_hidEncoder->setTMate2Display(static_cast<uint32_t>(std::abs(mainVal)), 0);
+        QString overlayText;
+        auto fixed3 = [](int value) {
+            return QStringLiteral("%1").arg(std::clamp(value, 0, 999), 3, 10,
+                                            QLatin1Char('0'));
+        };
+        switch (m_tmate2Overlay) {
+        case TMate2Overlay::Volume:
+            overlayText = QStringLiteral("VOL %1").arg(fixed3(mainVal));
+            break;
+        case TMate2Overlay::Power:
+            overlayText = QStringLiteral("PWR %1").arg(fixed3(mainVal));
+            break;
+        case TMate2Overlay::Agc:
+            overlayText = QStringLiteral("AGC %1").arg(fixed3(mainVal));
+            break;
+        case TMate2Overlay::Apf:
+            overlayText = QStringLiteral("APF %1").arg(fixed3(mainVal));
+            break;
+        case TMate2Overlay::Wpm:
+            overlayText = QStringLiteral("WPM %1").arg(fixed3(mainVal));
+            break;
+        case TMate2Overlay::Rit:
+            overlayText = QStringLiteral("RIT %1")
+                .arg(mainVal, 5, 10, QLatin1Char(' '));
+            break;
+        case TMate2Overlay::Xit:
+            overlayText = QStringLiteral("XIT %1")
+                .arg(mainVal, 5, 10, QLatin1Char(' '));
+            break;
+        case TMate2Overlay::Shift:
+        case TMate2Overlay::Speed:
+            overlayText = QStringLiteral("STEP %1")
+                .arg(mainVal, 4, 10, QLatin1Char(' '));
+            break;
+        case TMate2Overlay::None:
+            overlayText.clear();
+            break;
+        }
+        QMetaObject::invokeMethod(m_hidEncoder, [this, overlayText] {
+            m_hidEncoder->setTMate2OverlayDisplay(overlayText);
         });
         return;
     }
@@ -1184,6 +1226,9 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
         if (auto* s = activeSlice()) {
             const int hz = std::clamp(s->xitFreq() + steps * 10, -9999, 9999);
             s->setXit(true, hz);
+#ifdef HAVE_HIDAPI
+            triggerTMate2Overlay(TMate2Overlay::Xit, hz);
+#endif
         }
     } else if (actionId == "WheelVolume" || actionId == "WheelMasterAf") {
         // Route to master volume to match SmartSDR behavior (#2921).
@@ -1215,11 +1260,21 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
         triggerTMate2Overlay(TMate2Overlay::Volume, next);
 #endif
     } else if (actionId == "WheelAgcT") {
-        if (auto* s = activeSlice())
-            s->setAgcThreshold(std::clamp(s->agcThreshold() + steps, 0, 100));
+        if (auto* s = activeSlice()) {
+            const int next = std::clamp(s->agcThreshold() + steps, 0, 100);
+            s->setAgcThreshold(next);
+#ifdef HAVE_HIDAPI
+            triggerTMate2Overlay(TMate2Overlay::Agc, next);
+#endif
+        }
     } else if (actionId == "WheelApf") {
-        if (auto* s = activeSlice())
-            s->setApfLevel(std::clamp(s->apfLevel() + steps, 0, 100));
+        if (auto* s = activeSlice()) {
+            const int next = std::clamp(s->apfLevel() + steps, 0, 100);
+            s->setApfLevel(next);
+#ifdef HAVE_HIDAPI
+            triggerTMate2Overlay(TMate2Overlay::Apf, next);
+#endif
+        }
     } else if (actionId == "NextSlice" || actionId == "PrevSlice") {
         const auto& slices = m_radioModel.slices();
         if (slices.size() <= 1) return;

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -540,6 +540,7 @@ QString MainWindow::tmate2OverlayName() const
     case TMate2Overlay::Shift:  return QStringLiteral("shift");
     case TMate2Overlay::Agc:    return QStringLiteral("agc");
     case TMate2Overlay::Apf:    return QStringLiteral("apf");
+    case TMate2Overlay::Text:   return QStringLiteral("text");
     case TMate2Overlay::None:   break;
     }
     return QString();
@@ -613,6 +614,28 @@ void MainWindow::triggerTMate2Overlay(TMate2Overlay overlay, int value)
         100, 10000);
     m_tmate2Overlay = overlay;
     m_tmate2OverlayValue = value;
+    m_tmate2OverlayText.clear();
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    m_tmate2LastUserInteractionMs = now;
+    m_tmate2DisplayBlanked = false;
+    m_tmate2OverlayUntilMs = now + durationMs;
+    m_tmate2OverlayTimer.start(durationMs);
+    updateTMate2Display();
+    updateTMate2Indicators();
+    restartTMate2IdleTimer();
+}
+
+void MainWindow::triggerTMate2TextOverlay(const QString& text)
+{
+    if (!m_hidEncoder || !m_hidEncoder->isOpen() || !m_hidEncoder->isTMate2()) return;
+    auto& settings = AppSettings::instance();
+    const int durationMs = std::clamp(
+        settings.value("TMate2OverlayDurationMs",
+                       QString::number(kTMate2DefaultOverlayDurationMs)).toInt(),
+        100, 10000);
+    m_tmate2Overlay = TMate2Overlay::Text;
+    m_tmate2OverlayValue = 0;
+    m_tmate2OverlayText = text;
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
     m_tmate2LastUserInteractionMs = now;
     m_tmate2DisplayBlanked = false;
@@ -646,6 +669,9 @@ void MainWindow::updateTMate2Display()
                                             QLatin1Char('0'));
         };
         switch (m_tmate2Overlay) {
+        case TMate2Overlay::Text:
+            overlayText = m_tmate2OverlayText;
+            break;
         case TMate2Overlay::Volume:
             overlayText = QStringLiteral("VOL %1").arg(fixed3(mainVal));
             break;
@@ -686,6 +712,7 @@ void MainWindow::updateTMate2Display()
     if (m_tmate2Overlay != TMate2Overlay::None) {
         m_tmate2Overlay = TMate2Overlay::None;
         m_tmate2OverlayUntilMs = 0;
+        m_tmate2OverlayText.clear();
     }
 
     // Frequency: active slice in Hz, 0 if no slice.
@@ -810,25 +837,58 @@ void MainWindow::dispatchHidAction(const QString& actionName,
     } else if (actionName == "ClearXit") {
         if (auto* s = activeSlice()) s->setXit(s->xitOn(), 0);
     } else if (actionName == "ToggleMox") {
-        m_radioModel.setTransmit(!m_radioModel.transmitModel().isTransmitting());
+        const bool next = !m_radioModel.transmitModel().isTransmitting();
+        m_radioModel.setTransmit(next);
     } else if (actionName == "ToggleTune") {
-        if (m_radioModel.transmitModel().isTuning())
+        const bool next = !m_radioModel.transmitModel().isTuning();
+        if (!next)
             m_radioModel.transmitModel().stopTune();
         else
             m_radioModel.transmitModel().startTune();
+#ifdef HAVE_HIDAPI
+        triggerTMate2TextOverlay(next ? QStringLiteral("TUNE ON")
+                                      : QStringLiteral("TUNE OFF"));
+#endif
     } else if (actionName == "ToggleMute") {
-        if (m_audio) m_audio->setMuted(!m_audio->isMuted());
+        if (m_audio) {
+            const bool next = !m_audio->isMuted();
+            m_audio->setMuted(next);
+#ifdef HAVE_HIDAPI
+            triggerTMate2TextOverlay(next ? QStringLiteral("MUTE ON")
+                                          : QStringLiteral("MUTE OFF"));
+#endif
+        }
     } else if (actionName == "ToggleLock") {
-        if (auto* s = activeSlice()) s->setLocked(!s->isLocked());
+        if (auto* s = activeSlice()) {
+            const bool next = !s->isLocked();
+            s->setLocked(next);
+#ifdef HAVE_HIDAPI
+            updateTMate2Status();
+            triggerTMate2TextOverlay(next ? QStringLiteral("LOCK ON")
+                                          : QStringLiteral("LOCK OFF"));
+#endif
+        }
     } else if (actionName == "ToggleApf") {
-        if (auto* s = activeSlice()) s->setApf(!s->apfOn());
+        if (auto* s = activeSlice()) {
+            const bool next = !s->apfOn();
+            s->setApf(next);
+#ifdef HAVE_HIDAPI
+            triggerTMate2TextOverlay(next ? QStringLiteral("APF ON")
+                                          : QStringLiteral("APF OFF"));
+#endif
+        }
     } else if (actionName == "ToggleAgc") {
         if (auto* s = activeSlice()) {
             static const char* modes[] = {"off","slow","med","fast"};
             const QString cur = s->agcMode().toLower();
             int idx = 0;
             for (int i = 0; i < 4; ++i) if (cur == modes[i]) { idx = i; break; }
-            s->setAgcMode(modes[(idx + 1) % 4]);
+            const int nextIdx = (idx + 1) % 4;
+            s->setAgcMode(modes[nextIdx]);
+#ifdef HAVE_HIDAPI
+            static const char* labels[] = {"AGC OFF", "AGC SLO", "AGC MED", "AGC FST"};
+            triggerTMate2TextOverlay(QString::fromLatin1(labels[nextIdx]));
+#endif
         }
     } else if (actionName == "BandZoom") {
         auto* s = activeSlice();

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -51,6 +51,16 @@ namespace {
 
 constexpr int kTMate2DefaultOverlayDurationMs = 1500;
 
+QString formatTMate2PowerSmallText(float watts)
+{
+    const int roundedWatts = std::clamp(static_cast<int>(std::lround(watts)), 0, 9999);
+    if (roundedWatts <= 999)
+        return QString::number(roundedWatts);
+
+    const int tenthsKw = std::clamp(static_cast<int>(std::lround(watts / 100.0f)), 10, 99);
+    return QStringLiteral("%1k%2").arg(tenthsKw / 10).arg(tenthsKw % 10);
+}
+
 QString tmate2EncoderDefaultAction(int encoderIndex)
 {
     switch (encoderIndex) {
@@ -650,12 +660,16 @@ void MainWindow::updateTMate2Display()
     const int dbm       = static_cast<int>(std::round(m_tmate2SmeterDbm));
     const uint32_t sVal = static_cast<uint32_t>(std::clamp(std::abs(dbm), 0, 999));
 
-    const uint32_t smallVal = m_radioModel.transmitModel().isTransmitting()
-        ? static_cast<uint32_t>(m_tmate2TxWatts + 0.5f)
-        : sVal;
+    if (m_radioModel.transmitModel().isTransmitting()) {
+        const QString powerText = formatTMate2PowerSmallText(m_tmate2TxWatts);
+        QMetaObject::invokeMethod(m_hidEncoder, [this, freqHz, powerText] {
+            m_hidEncoder->setTMate2DisplayText(freqHz, powerText);
+        });
+        return;
+    }
 
-    QMetaObject::invokeMethod(m_hidEncoder, [this, freqHz, smallVal] {
-        m_hidEncoder->setTMate2Display(freqHz, smallVal);
+    QMetaObject::invokeMethod(m_hidEncoder, [this, freqHz, sVal] {
+        m_hidEncoder->setTMate2Display(freqHz, sVal);
     });
 }
 
@@ -685,6 +699,13 @@ void MainWindow::updateTMate2Indicators()
     const bool xit    = s && s->xitOn();
     const float dbm   = m_tmate2SmeterDbm;
     auto& settings = AppSettings::instance();
+    // TMate 2 settings list the main tuning encoder first, then the two
+    // auxiliary encoders. The LCD labels those auxiliaries in the opposite
+    // physical order: settings Encoder 3 is printed E1, Encoder 2 is printed E2.
+    const QString lcdE1Action = settings.value(
+        QStringLiteral("TMate2EncoderAction2"), QStringLiteral("WheelXit")).toString();
+    const QString lcdE2Action = settings.value(
+        QStringLiteral("TMate2EncoderAction1"), QStringLiteral("WheelRit")).toString();
     const uint8_t r = static_cast<uint8_t>(settings.value(
         tx ? "TMate2TxBacklightR" : "TMate2BacklightR",
         tx ? "255" : "0").toInt());
@@ -703,9 +724,11 @@ void MainWindow::updateTMate2Indicators()
         });
         return;
     }
-    QMetaObject::invokeMethod(m_hidEncoder, [this, tx, mode, dbm, rit, xit, r, g, b] {
+    QMetaObject::invokeMethod(m_hidEncoder,
+        [this, tx, mode, dbm, rit, xit, r, g, b, lcdE1Action, lcdE2Action] {
         m_hidEncoder->setTMate2Backlight(r, g, b);
-        m_hidEncoder->setTMate2Indicators(tx, mode, dbm, rit, xit);
+        m_hidEncoder->setTMate2Indicators(tx, mode, dbm, rit, xit,
+                                          lcdE1Action, lcdE2Action);
     });
 }
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2185,8 +2185,10 @@ void MainWindow::wireMeters()
         m_appletPanel->sMeterWidget()->setTxMeters(fwd, swr);
 #ifdef HAVE_HIDAPI
         m_tmate2TxWatts = fwd;
-        if (m_radioModel.transmitModel().isTransmitting())
+        if (m_radioModel.transmitModel().isTransmitting()) {
             updateTMate2Display();
+            updateTMate2Indicators();
+        }
 #endif
     });
     connect(&m_radioModel.meterModel(), &MeterModel::micMetersChanged,
@@ -2299,6 +2301,13 @@ void MainWindow::wireMeters()
             else if (kvs.contains("state") && !kvs.value("state").startsWith("TRANSMIT"))
                 m_appletPanel->sMeterWidget()->setTransmitting(false);
             m_appletPanel->sMeterWidget()->setTxMeters(watts, swr);
+#ifdef HAVE_HIDAPI
+            m_tmate2TxWatts = watts;
+            if (m_radioModel.transmitModel().isTransmitting()) {
+                updateTMate2Display();
+                updateTMate2Indicators();
+            }
+#endif
         }
     });
     connect(&m_pgxlConn, &PgxlConnection::connected, this, [this]() {
@@ -2435,6 +2444,13 @@ void MainWindow::wireMeters()
         // path, so we just stop overriding it here).
         if (m_radioModel.hasAmplifier() && m_radioModel.ampOperate()) {
             m_appletPanel->sMeterWidget()->setTxMeters(fwdPwr, swr);
+#ifdef HAVE_HIDAPI
+            m_tmate2TxWatts = fwdPwr;
+            if (m_radioModel.transmitModel().isTransmitting()) {
+                updateTMate2Display();
+                updateTMate2Indicators();
+            }
+#endif
             static int ampDbg = 0;
             if (++ampDbg % 50 == 1)
                 qCDebug(lcTuner) << "AMP→SMeter: fwd=" << fwdPwr << "W swr=" << swr;


### PR DESCRIPTION
## Summary

Follow-up to #3401 (TMate 2 HID integration). Four improvements hardware-verified on ELAD TMate 2, all guarded with `#ifdef HAVE_HIDAPI`.

### TX power bargraph (`HidEncoderManager.cpp`)
- During transmit the 15-bar S-meter bargraph now shows TX forward power instead of the RX S-meter reading.
- Full-scale auto-adapts: 100 W normally, 2000 W when an amplifier is connected and in operate.
- Reads from three power sources: FWD meter, PGxl amplifier forwarded power, and the standard `transmitPowerChanged` signal — whichever fires updates the display.

### TX power on small display (`MainWindow_Controllers.cpp`)
- Small 3-digit display shows watts during TX (e.g. `95` → "95 W") and switches to `Nk M` format above 999 W (e.g. 1500 W → "1k5 W") so the segment count never overflows.
- In RX the display continues to show `|dBm|` as before.

### Encoder label segments (`HidEncoderManager.cpp`)
- `setTMate2EncoderActionSegs()` reads the two auxiliary encoder assignments and lights the matching silkscreen labels (VOL / DRV / SQL and HIGH / SHIFT) so the LCD reflects the user's mapping without opening the settings dialog.
- S-meter scale tick marks (S1 S3 S5 S7 S9 +20 +40 +60 dB) are now driven in RX and blanked in TX/overlay, matching what the physical LCD is labelled.
- RIT / XIT segments light when the respective wheel action is mapped to an encoder, even when RIT/XIT offset is zero.

### Text overlays + letter glyphs (`HidEncoderManager.cpp`, `MainWindow_Controllers.cpp`)
- Added `tmate2MainGlyph()` / `tmate2SmallGlyph()` for a 7-segment letter subset (A C E F G H I K L M N O P R S T U V W X Y, `-`, space) — enough to spell the feedback labels below.
- New `triggerTMate2TextOverlay()` + `TMate2Overlay::Text` variant for arbitrary 9-character strings on the main display.
- `updateTMate2Display()` now builds a human-readable overlay string per type: `"VOL 050"`, `"RIT +1200"`, `"AGC SLO"`, `"APF  42"`, `"TUNE ON"`, etc.
- New overlay types: Xit, Shift, Agc, Apf (with indicator segment handling in `setTMate2OverlayIndicators`).
- Toggle actions now confirm state on the display: ToggleTune → `"TUNE ON/OFF"`, ToggleMute → `"MUTE ON/OFF"`, ToggleLock → `"LOCK ON/OFF"`, ToggleApf → `"APF ON/OFF"`, ToggleAgc → `"AGC OFF/SLO/MED/FST"`.

## Files changed
| File | Change |
|---|---|
| `src/core/HidEncoderManager.h` | `setTMate2Indicators` signature extended (new params default-valued); two new public slots |
| `src/core/HidEncoderManager.cpp` | Glyph tables, text write helpers, encoder-label helpers, `powerBars()`, overlay indicator updates |
| `src/gui/MainWindow.h` | `TMate2Overlay` enum extended; `m_tmate2OverlayText`; `triggerTMate2TextOverlay()` |
| `src/gui/MainWindow.cpp` | TX indicator refresh hooked into three power-update paths |
| `src/gui/MainWindow_Controllers.cpp` | `formatTMate2PowerSmallText()`, richer overlay dispatch, toggle action feedback |

## Test plan
- [ ] RX: S-meter bargraph tracks signal; tick marks S1–+60 dB visible
- [ ] TX: bargraph tracks forward power 0–100 W; small display shows watts
- [ ] TX with amplifier in OPER: bargraph full-scale = 2000 W; small display shows `Nk M` above 999 W
- [ ] Encoder-label segments (VOL/DRV/SQL/HIGH/SHIFT) match settings after reconnect
- [ ] RIT active → RIT segment lit; encoder mapped to WheelRit with RIT off → RIT segment lit
- [ ] Overlay text overlays: rotate volume/AGC/APF/RIT/XIT; observe formatted readout
- [ ] Toggle actions: Tune/Mute/Lock/APF/AGC show confirmation overlay text

🤖 Generated with [Claude Code](https://claude.com/claude-code)