### PR TITLE
feat(arch): introduce RadioSession — the per-radio aggregate (#3351 / #3445)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,6 +610,7 @@ endif()
 
 set(MODEL_SOURCES
     src/models/RadioModel.cpp
+    src/models/RadioSession.cpp
     src/models/ModelCapabilities.cpp
     src/models/AntennaAliasStore.cpp
     src/models/SliceModel.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -817,8 +817,22 @@ void MainWindow::showForcedDisconnectDialog(bool wasWan,
     dialog->activateWindow();
 }
 
+namespace {
+// One session at startup (#3445 Camp B: the multi-radio seam is this vector).
+std::vector<std::unique_ptr<RadioSession>> makeInitialSessions()
+{
+    std::vector<std::unique_ptr<RadioSession>> sessions;
+    sessions.push_back(std::make_unique<RadioSession>());
+    sessions.front()->setSessionId(0);
+    return sessions;
+}
+} // namespace
+
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
+    , m_sessions(makeInitialSessions())
+    , m_session(m_sessions.front().get())
+    , m_radioModel(m_session->radioModel())
 {
     // Status bar is the only top-level shell besides the spectrum / applet
     // rail / titlebar that the operator can directly retheme.  Declare its

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -32,6 +32,11 @@
 #include <QThread>
 #ifdef HAVE_SERIALPORT
 #include "core/SerialPortController.h"
+#include "models/RadioSession.h"
+
+#include <memory>
+#include <vector>
+
 #include "core/FlexControlManager.h"
 #endif
 #ifdef HAVE_MIDI
@@ -458,7 +463,16 @@ private:
 
     // Core objects
     RadioDiscovery    m_discovery;
-    RadioModel        m_radioModel;
+    // Radio sessions (#3445 Camp B / #3351). Each session owns the full
+    // per-radio aggregate; today there is exactly one. The vector sits at
+    // the old `RadioModel m_radioModel` member position so destruction
+    // order relative to the surrounding members is unchanged.
+    std::vector<std::unique_ptr<RadioSession>> m_sessions;
+    RadioSession*     m_session{nullptr};  // active session (m_sessions.front())
+    // Alias into the active session's model. Keeps the ~900 m_radioModel
+    // call sites across the MainWindow TUs source-compatible; new code
+    // should prefer m_session->radioModel().
+    RadioModel&       m_radioModel;
     DxccColorProvider m_dxccProvider;
     AudioEngine*      m_audio{nullptr};
     QThread*          m_audioThread{nullptr};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -32,13 +32,13 @@
 #include <QThread>
 #ifdef HAVE_SERIALPORT
 #include "core/SerialPortController.h"
+#include "core/FlexControlManager.h"
+#endif
 #include "models/RadioSession.h"
 
 #include <memory>
 #include <vector>
 
-#include "core/FlexControlManager.h"
-#endif
 #ifdef HAVE_MIDI
 #include "core/MidiControlManager.h"
 #endif

--- a/src/models/RadioSession.cpp
+++ b/src/models/RadioSession.cpp
@@ -1,0 +1,12 @@
+#include "models/RadioSession.h"
+
+namespace AetherSDR {
+
+RadioSession::RadioSession(QObject* parent)
+    : QObject(parent)
+{
+}
+
+RadioSession::~RadioSession() = default;
+
+} // namespace AetherSDR

--- a/src/models/RadioSession.h
+++ b/src/models/RadioSession.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "models/RadioModel.h"
+
+#include <QObject>
+#include <QString>
+
+namespace AetherSDR {
+
+// RadioSession — the aggregate that constitutes "a connected radio".
+//
+// Born from the #3351 monolith decomposition and the #3445 multi-radio
+// brief (Camp B): MainWindow historically embedded one RadioModel by
+// value plus the per-radio servers and lifecycle as loose members,
+// which hard-coded the single-radio assumption into the application
+// layer. RadioSession gives that bundle a name and an owner.
+//
+// v1 scope (this class today):
+//   • owns the RadioModel (by value — identical construction semantics
+//     to the old MainWindow member)
+//   • carries session identity (id, label) for the future session
+//     switcher UI
+//
+// Planned v2+ scope (see #3445):
+//   • TciServer + CatPort[] ownership (today constructed and owned by
+//     MainWindow in wireRadioModel()/wireCatPorts())
+//   • the wireDiscovery/wireRadioModel/wirePanLifecycle bodies from
+//     MainWindow_Session.cpp move here as session methods
+//   • per-session settings facade (Principle V nested JSON)
+//
+// MainWindow currently binds `RadioModel& m_radioModel` to
+// session->radioModel() so the ~900 existing call sites across the
+// MainWindow TUs compile unchanged. New code SHOULD prefer going
+// through the session.
+class RadioSession : public QObject {
+    Q_OBJECT
+
+public:
+    explicit RadioSession(QObject* parent = nullptr);
+    ~RadioSession() override;
+
+    RadioModel& radioModel() { return m_radioModel; }
+    const RadioModel& radioModel() const { return m_radioModel; }
+
+    // Session identity — stable across reconnects to the same radio.
+    int sessionId() const { return m_sessionId; }
+    void setSessionId(int id) { m_sessionId = id; }
+
+    // Operator-facing label (radio nickname once connected, else model).
+    QString label() const { return m_label; }
+    void setLabel(const QString& label) { m_label = label; }
+
+private:
+    RadioModel m_radioModel;
+    int m_sessionId{0};
+    QString m_label;
+};
+
+} // namespace AetherSDR


### PR DESCRIPTION
## Summary

Eleventh PR of the #3351 series — **the first architectural (non-pure-motion) change**. The single-radio assumption identified as "the single biggest assumption to lift" in @nigelfenton's multi-radio brief (#3445) stops being load-bearing.

## What changes

**New `models/RadioSession.{h,cpp}`** — the aggregate that constitutes "a connected radio":
- Owns the `RadioModel` by value (identical construction semantics to the old MainWindow member)
- Carries session identity (`sessionId`, `label`) for the future session-switcher UI
- Class doc spells out v2+ scope per the #3445 Camp B plan: TciServer + CatPort[] ownership, the `MainWindow_Session.cpp` wire bodies becoming session methods, a per-session settings facade (Principle V)

**`MainWindow.h`** — the by-value member becomes:

```cpp
std::vector<std::unique_ptr<RadioSession>> m_sessions;  // at the old member position
RadioSession* m_session;     // active session (m_sessions.front())
RadioModel&   m_radioModel;  // alias into the active session's model
```

## Why the alias bridge

**937 `m_radioModel` references across the 11 MainWindow TUs compile completely unchanged.** The single-session runtime path is byte-for-byte identical: one session in the vector, the same RadioModel constructed at the same sequence point. Destruction order is preserved by keeping the vector at the old member's declaration position (verified: no `-Wreorder` for MainWindow).

The multi-radio seam is now `m_sessions.size() > 1` + an active-session switch — a contained future PR instead of surgery on a by-value member with 937 call sites.

## What deliberately does NOT change in this PR

- TciServer / CatPort ownership (stays in MainWindow; moves in session v2)
- The five `wireXxx()` session methods (stay as MainWindow methods in `MainWindow_Session.cpp`; they convert to `RadioSession::` methods when ownership moves)
- Any call site — the alias means zero touch across 11 TUs

## Verification

- Full build clean — **zero new warnings** (the `-Wreorder` absence on MainWindow is itself the init-order proof)
- All 33 ctest suites pass
- a11y lint: 0 findings

## QA checklist for the bench

Ownership of the central model object moved, so this deserves the full connection-lifecycle regression even though the code paths are identical:

- [ ] Connect (LAN + SmartLink if available) / operate / disconnect / reconnect cycle
- [ ] Full shutdown while connected — clean exit, no crash-on-close (destruction-order is the one realistic risk class)
- [ ] Profile load, slice ops, pan ops — anything that hammers m_radioModel
- [ ] Memory recall, spots, meters — secondary model consumers

Refs #3351 #3445