### PR TITLE
feat(arch): RadioSession owns TciServer + CatPorts (#3351 session v2)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1415,7 +1415,7 @@ MainWindow::MainWindow(QWidget* parent)
     });
     // Master volume — title bar slider routes through applyMasterVolume()
     // so the TCI `volume:N;` command (#1764) can hit the same code path
-    // when m_tciServer is created later in this constructor.
+    // when tciServer() is created later in this constructor.
     connect(m_titleBar, &TitleBar::masterVolumeChanged,
             this, &MainWindow::applyMasterVolume);
     connect(m_titleBar, &TitleBar::headphoneVolumeChanged,
@@ -1948,8 +1948,7 @@ MainWindow::~MainWindow()
     // back-reference first so no dangling pointer remains in the widget tree.
     if (m_appletPanel && m_appletPanel->tciApplet())
         m_appletPanel->tciApplet()->setTciServer(nullptr);
-    delete m_tciServer;
-    m_tciServer = nullptr;
+    m_session->shutdownTciServer();
 #endif
 
     // Stop external controller thread (#502)
@@ -3069,7 +3068,7 @@ void MainWindow::showNetworkDiagnosticsDialog()
 #ifdef HAVE_WEBSOCKETS
     showOrRaisePersistent(m_networkDiagnosticsDialog,
                           &m_radioModel, m_audio, m_networkDiagnosticsHistory,
-                          m_tciServer);
+                          tciServer());
 #else
     showOrRaisePersistent(m_networkDiagnosticsDialog,
                           &m_radioModel, m_audio, m_networkDiagnosticsHistory);
@@ -4489,25 +4488,25 @@ void MainWindow::applyCatPortCount()
     const int  target   = catPortTargetCount();
 
     for (int i = 0; i < kCatPorts; ++i) {
-        if (!m_catPorts[i]) continue;
+        if (!catPort(i)) continue;
 
         const QString prefix = QString("CatPort_%1_").arg(i);
         const bool portEnabled = s.value(prefix + "Enabled", "False").toString() == "True";
         const int  portNum     = s.value(prefix + "Port", "").toInt();
         const bool shouldRun   = masterOn && portEnabled && (portNum >= 1024) && (i < target);
 
-        if (shouldRun && !m_catPorts[i]->isRunning()) {
+        if (shouldRun && !catPort(i)->isRunning()) {
             // Re-apply config in case dialect/VFO was changed while stopped
             QString d = s.value(prefix + "Dialect", "Rigctld").toString();
             CatDialect dial = (d == "FlexCAT") ? CatDialect::FlexCAT
                             : (d == "TS2000")  ? CatDialect::TS2000
                             : CatDialect::Rigctld;
-            m_catPorts[i]->setDialect(dial);
-            m_catPorts[i]->setVfoA(s.value(prefix + "VfoA", "0").toInt());
-            m_catPorts[i]->setVfoB(s.value(prefix + "VfoB", "-1").toInt());
-            m_catPorts[i]->start(static_cast<quint16>(portNum));
-        } else if (!shouldRun && m_catPorts[i]->isRunning()) {
-            m_catPorts[i]->stop();
+            catPort(i)->setDialect(dial);
+            catPort(i)->setVfoA(s.value(prefix + "VfoA", "0").toInt());
+            catPort(i)->setVfoB(s.value(prefix + "VfoB", "-1").toInt());
+            catPort(i)->start(static_cast<quint16>(portNum));
+        } else if (!shouldRun && catPort(i)->isRunning()) {
+            catPort(i)->stop();
         }
     }
 
@@ -4732,17 +4731,17 @@ void MainWindow::onConnectionStateChanged(bool connected)
 #ifdef HAVE_WEBSOCKETS
         // Auto-start TCI WebSocket server if enabled
         if (AppSettings::instance().value("AutoStartTCI", "False").toString() == "True") {
-            if (m_tciServer && !m_tciServer->isRunning()) {
+            if (tciServer() && !tciServer()->isRunning()) {
                 int tciPort = AppSettings::instance().value("TciPort", "50001").toInt();
-                m_tciServer->start(static_cast<quint16>(tciPort));
+                tciServer()->start(static_cast<quint16>(tciPort));
                 qDebug() << "AutoStart: TCI on port" << tciPort
-                         << " running=" << m_tciServer->isRunning();
+                         << " running=" << tciServer()->isRunning();
             }
             // Only light up the Enable button if the server actually bound —
             // otherwise the UI shows a green "Enable" while the port is in use.
             if (m_appletPanel && m_appletPanel->tciApplet())
                 m_appletPanel->tciApplet()->setTciEnabled(
-                    m_tciServer && m_tciServer->isRunning());
+                    tciServer() && tciServer()->isRunning());
         }
 #endif
         // Populate XVTR bands after radio status settles, and refresh
@@ -5416,7 +5415,7 @@ void MainWindow::applyMasterVolume(int pct)
     s.setValue("MasterVolume", QString::number(pct));
     s.save();
 #ifdef HAVE_WEBSOCKETS
-    if (m_tciServer) m_tciServer->broadcastMasterVolume(pct);
+    if (tciServer()) tciServer()->broadcastMasterVolume(pct);
 #endif
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -488,8 +488,9 @@ private:
     ClientPuduMonitor* m_finalMonitor{nullptr};
     BandSettings      m_bandSettings;
     // CAT ports: up to 8 unified ports (rigctld / TS-2000 / FlexCAT), one per slice.
-    static constexpr int kCatPorts = 8;
-    CatPort* m_catPorts[kCatPorts]{};
+    // CAT ports are owned by the active RadioSession (#3351 session v2).
+    static constexpr int kCatPorts = RadioSession::kCatPorts;
+    CatPort* catPort(int i) const { return m_session->catPort(i); }
 
     // Returns how many CAT ports should be visible in the UI given radio state.
     // 1 when no radio; maxSlicesForModel() when connected.
@@ -499,7 +500,8 @@ private:
     // One-time settings migration from the old dual-server key schema.
     void migrateCatSettings();
 #ifdef HAVE_WEBSOCKETS
-    TciServer*             m_tciServer{nullptr};
+    // TciServer is owned by the active RadioSession (#3351 session v2).
+    TciServer* tciServer() const { return m_session->tciServer(); }
     FreeDvReporterDialog*  m_freedvReporterDialog{nullptr};
 #endif
     SmartLinkClient   m_smartLink;

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -571,7 +571,7 @@ void MainWindow::deactivateRADE()
             // silently kill TCI audio. Leave TCI responsible for cleanup in
             // that case. TODO: replace with proper ref-counting in PanadapterStream
             // so any creator/borrower can safely release independently (#stream-lifecycle).
-            bool tciActive = m_tciServer && m_tciServer->clientCount() > 0;
+            bool tciActive = tciServer() && tciServer()->clientCount() > 0;
             bool daxBridgeActive = false;
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
             daxBridgeActive = (m_daxBridge != nullptr);
@@ -1166,7 +1166,7 @@ void MainWindow::onDaxChannelChanged(SliceModel* slice, int newCh)
             // another consumer is still using would silence WSJT-X or RADE
             // audio — the mirror image of #3270. Only tear down a stream that
             // no other consumer needs. (#2895)
-            const bool tciUsing = m_tciServer && m_tciServer->ownsDaxChannel(oldCh);
+            const bool tciUsing = tciServer() && tciServer()->ownsDaxChannel(oldCh);
 #ifdef HAVE_RADE
             const bool radeUsing = (id != 0 && id == m_radeDaxStreamId);
 #else

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -464,12 +464,12 @@ void MainWindow::buildMenuBar()
         s.setValue("AutoStartTCI", on ? "True" : "False");
         s.save();
 #ifdef HAVE_WEBSOCKETS
-        if (m_tciServer) {
-            if (on && !m_tciServer->isRunning()) {
+        if (tciServer()) {
+            if (on && !tciServer()->isRunning()) {
                 int port = s.value("TciPort", "50001").toInt();
-                m_tciServer->start(static_cast<quint16>(port));
-            } else if (!on && m_tciServer->isRunning()) {
-                m_tciServer->stop();
+                tciServer()->start(static_cast<quint16>(port));
+            } else if (!on && tciServer()->isRunning()) {
+                tciServer()->stop();
             }
             if (m_appletPanel && m_appletPanel->tciApplet())
                 m_appletPanel->tciApplet()->setTciEnabled(on);

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1292,9 +1292,11 @@ void MainWindow::wireCatPorts()
     // Migrate old dual-server settings to the new per-port schema on first run.
     migrateCatSettings();
     for (int i = 0; i < kCatPorts; ++i) {
-        m_catPorts[i] = new CatPort(&m_radioModel, this);
+        // Owned by the session — no QObject parent (parent-based deletion
+        // would run after member destruction and recreate #2385).
+        m_session->setCatPort(i, new CatPort(&m_radioModel, nullptr));
         // Per-user symlink path (GHSA-qxhr-cwrc-pvrm — matches RigctlPty fix).
-        m_catPorts[i]->setSymlinkPath(CatPort::defaultSymlinkPath(i));
+        catPort(i)->setSymlinkPath(CatPort::defaultSymlinkPath(i));
         // Load persisted dialect and VFO config; port and enabled are read
         // in applyCatPortCount() just before starting.
         const QString prefix = QString("CatPort_%1_").arg(i);
@@ -1303,13 +1305,13 @@ void MainWindow::wireCatPorts()
         CatDialect dial = (d == "FlexCAT") ? CatDialect::FlexCAT
                         : (d == "TS2000")  ? CatDialect::TS2000
                         : CatDialect::Rigctld;
-        m_catPorts[i]->setDialect(dial);
-        m_catPorts[i]->setVfoA(s.value(prefix + "VfoA", "0").toInt());
-        m_catPorts[i]->setVfoB(s.value(prefix + "VfoB", "-1").toInt());
+        catPort(i)->setDialect(dial);
+        catPort(i)->setVfoA(s.value(prefix + "VfoA", "0").toInt());
+        catPort(i)->setVfoB(s.value(prefix + "VfoB", "-1").toInt());
     }
 
     // Wire the applet to the port objects
-    m_appletPanel->catControlApplet()->setPorts(m_catPorts, kCatPorts);
+    m_appletPanel->catControlApplet()->setPorts(m_session->catPortsArray(), kCatPorts);
     m_appletPanel->catControlApplet()->setMaxSlices(catPortTargetCount());
 
     // Wire master enable toggle from the docked applet
@@ -1325,30 +1327,31 @@ void MainWindow::wireCatPorts()
     m_appletPanel->daxApplet()->setRadioModel(&m_radioModel);
     m_appletPanel->daxIqApplet()->setRadioModel(&m_radioModel);
 #ifdef HAVE_WEBSOCKETS
-    m_tciServer = new TciServer(&m_radioModel, this);
-    m_tciServer->setAudioEngine(m_audio);
+    // Owned by the session — no QObject parent (see RadioSession docs, #2385).
+    m_session->setTciServer(new TciServer(&m_radioModel, nullptr));
+    tciServer()->setAudioEngine(m_audio);
     m_appletPanel->tciApplet()->setRadioModel(&m_radioModel);
-    m_appletPanel->tciApplet()->setTciServer(m_tciServer);
+    m_appletPanel->tciApplet()->setTciServer(tciServer());
 
     // TCI applet sliders → TciServer gain setters
     connect(m_appletPanel->tciApplet(), &TciApplet::tciRxGainChanged,
-            m_tciServer, &TciServer::setRxChannelGain);
+            tciServer(), &TciServer::setRxChannelGain);
     connect(m_appletPanel->tciApplet(), &TciApplet::tciTxGainChanged,
-            m_tciServer, &TciServer::setTxGain);
+            tciServer(), &TciServer::setTxGain);
     connect(m_appletPanel->tciApplet(), &TciApplet::tciTxOverflowModeChanged,
-            m_tciServer, &TciServer::setOverflowMode);
+            tciServer(), &TciServer::setOverflowMode);
 
     // TciServer level signals → TCI applet meters
-    connect(m_tciServer, &TciServer::rxLevel,
+    connect(tciServer(), &TciServer::rxLevel,
             m_appletPanel->tciApplet(), &TciApplet::setTciRxLevel);
-    connect(m_tciServer, &TciServer::txLevel,
+    connect(tciServer(), &TciServer::txLevel,
             m_appletPanel->tciApplet(), &TciApplet::setTciTxLevel);
 
     // TCI `volume:N;` master-volume SET → mirror on the title bar slider
     // and route through the same applyMasterVolume() slot the slider uses
     // (audio path + persistence + broadcast back to other TCI clients).
     // See issue #1764 — no master-volume TCI hook existed before.
-    connect(m_tciServer, &TciServer::masterVolumeRequested,
+    connect(tciServer(), &TciServer::masterVolumeRequested,
             this, [this](int pct) {
         if (m_titleBar) m_titleBar->setMasterVolume(pct);
         applyMasterVolume(pct);
@@ -1358,10 +1361,10 @@ void MainWindow::wireCatPorts()
     // indexes within our owned slice list; Flex slice ids can be non-zero when
     // another client owns lower-numbered slices.
     auto wireTciSlice = [this](SliceModel* s) {
-        if (!m_tciServer || !s)
+        if (!tciServer() || !s)
             return;
         const int trx = m_radioModel.slices().indexOf(s);
-        m_tciServer->wireSlice(trx >= 0 ? trx : s->sliceId(), s);
+        tciServer()->wireSlice(trx >= 0 ? trx : s->sliceId(), s);
     };
     connect(&m_radioModel, &RadioModel::sliceAdded, this, [wireTciSlice](SliceModel* s) {
         wireTciSlice(s);
@@ -1369,18 +1372,18 @@ void MainWindow::wireCatPorts()
     // Wire existing slices (radio may already be connected with slices)
     for (auto* s : m_radioModel.slices())
         wireTciSlice(s);
-    m_tciServer->wireSpotModel();
+    tciServer()->wireSpotModel();
 
     // Wire RX audio from PanadapterStream → TCI server for audio streaming.
     // TCI audio feeds exclusively from DAX (not audioDataReady) so that
     // audio_mute doesn't kill TCI audio (#1331).
     if (m_radioModel.panStream()) {
         connect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
-                m_tciServer, &TciServer::onDaxAudioReady);
+                tciServer(), &TciServer::onDaxAudioReady);
         connect(m_radioModel.panStream(), &PanadapterStream::iqDataReady,
-                m_tciServer, &TciServer::onIqDataReady);
+                tciServer(), &TciServer::onIqDataReady);
         connect(m_radioModel.panStream(), &PanadapterStream::waterfallRowReady,
-                m_tciServer, &TciServer::onWaterfallRowReady);
+                tciServer(), &TciServer::onWaterfallRowReady);
     }
 
     // TCI client count changes no longer auto-create/remove the audio stream.

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1470,8 +1470,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // Do not "normalise" these — collapsing the guards regresses Log4OM
         // behavior under lock or SWR sweep.
         if (tciSpot) {
-            if (m_tciServer && s && !s->isLocked() && !m_swrSweep.running)
-                m_tciServer->notifySpotClicked(spotIndex, s);
+            if (tciServer() && s && !s->isLocked() && !m_swrSweep.running)
+                tciServer()->notifySpotClicked(spotIndex, s);
         } else if (!isPassiveLocalSpotId(spotIndex)) {
             m_radioModel.sendCommand(
                 QString("spot trigger %1 pan=%2").arg(spotIndex).arg(applet->panId()));

--- a/src/models/RadioSession.cpp
+++ b/src/models/RadioSession.cpp
@@ -1,5 +1,10 @@
 #include "models/RadioSession.h"
 
+#include "core/CatPort.h"
+#ifdef HAVE_WEBSOCKETS
+#include "core/TciServer.h"
+#endif
+
 namespace AetherSDR {
 
 RadioSession::RadioSession(QObject* parent)
@@ -7,6 +12,49 @@ RadioSession::RadioSession(QObject* parent)
 {
 }
 
-RadioSession::~RadioSession() = default;
+RadioSession::~RadioSession()
+{
+    // Destruction order is the contract (#2385): every owned server holds a
+    // raw RadioModel*, so they die here — in the destructor body — before
+    // the m_radioModel member destructs.
+#ifdef HAVE_WEBSOCKETS
+    shutdownTciServer();
+#endif
+    for (CatPort*& port : m_catPorts) {
+        delete port;
+        port = nullptr;
+    }
+}
+
+#ifdef HAVE_WEBSOCKETS
+void RadioSession::setTciServer(TciServer* server)
+{
+    Q_ASSERT(!server || !server->parent());  // parent would recreate #2385
+    shutdownTciServer();
+    m_tciServer = server;
+}
+
+void RadioSession::shutdownTciServer()
+{
+    delete m_tciServer;
+    m_tciServer = nullptr;
+}
+#endif
+
+CatPort* RadioSession::catPort(int i) const
+{
+    return (i >= 0 && i < kCatPorts) ? m_catPorts[size_t(i)] : nullptr;
+}
+
+void RadioSession::setCatPort(int i, CatPort* port)
+{
+    if (i < 0 || i >= kCatPorts) {
+        delete port;
+        return;
+    }
+    Q_ASSERT(!port || !port->parent());
+    delete m_catPorts[size_t(i)];
+    m_catPorts[size_t(i)] = port;
+}
 
 } // namespace AetherSDR

--- a/src/models/RadioSession.h
+++ b/src/models/RadioSession.h
@@ -5,6 +5,8 @@
 #include <QObject>
 #include <QString>
 
+#include <array>
+
 namespace AetherSDR {
 
 // RadioSession — the aggregate that constitutes "a connected radio".
@@ -21,9 +23,19 @@ namespace AetherSDR {
 //   • carries session identity (id, label) for the future session
 //     switcher UI
 //
-// Planned v2+ scope (see #3445):
-//   • TciServer + CatPort[] ownership (today constructed and owned by
-//     MainWindow in wireRadioModel()/wireCatPorts())
+// v2 scope (this PR): TciServer + CatPort[] OWNERSHIP. Construction and
+// signal wiring stay in MainWindow's wireRadioModel()/wireCatPorts()
+// (they are UI-coupled); the session owns lifetime. Why this matters:
+// both server types hold a raw RadioModel* — if they outlive the model,
+// that's the #2385 crash-on-quit class. With the session owning both,
+// teardown order is structural: servers are deleted in ~RadioSession's
+// BODY, which the language guarantees runs before the m_radioModel
+// member destructs. The old manual delete-before-members dance in
+// MainWindow's shutdown path remains only for its *early* teardown
+// requirement (DAX stream-remove commands must reach the radio while
+// audio is already stopped) and now routes through shutdownTciServer().
+//
+// Planned v3+ scope (see #3445):
 //   • the wireDiscovery/wireRadioModel/wirePanLifecycle bodies from
 //     MainWindow_Session.cpp move here as session methods
 //   • per-session settings facade (Principle V nested JSON)
@@ -32,6 +44,9 @@ namespace AetherSDR {
 // session->radioModel() so the ~900 existing call sites across the
 // MainWindow TUs compile unchanged. New code SHOULD prefer going
 // through the session.
+class TciServer;
+class CatPort;
+
 class RadioSession : public QObject {
     Q_OBJECT
 
@@ -50,8 +65,34 @@ public:
     QString label() const { return m_label; }
     void setLabel(const QString& label) { m_label = label; }
 
+    // ── Owned servers (v2) ───────────────────────────────────────────────
+    // The session takes ownership on set; servers must NOT have a QObject
+    // parent (parent-based deletion would run after member destruction and
+    // recreate #2385).
+
+    static constexpr int kCatPorts = 8;
+
+#ifdef HAVE_WEBSOCKETS
+    TciServer* tciServer() const { return m_tciServer; }
+    void setTciServer(TciServer* server);   // takes ownership
+    // Early teardown for the shutdown path (#2385): delete while the
+    // RadioModel is alive and audio is already stopped. Idempotent.
+    void shutdownTciServer();
+#endif
+
+    CatPort* catPort(int i) const;
+    void setCatPort(int i, CatPort* port);  // takes ownership
+    // Raw array view for CatControlApplet::setPorts(CatPort**, int).
+    CatPort** catPortsArray() { return m_catPorts.data(); }
+
 private:
     RadioModel m_radioModel;
+    // Owned; deleted in ~RadioSession's body (and shutdownTciServer()),
+    // i.e. strictly before m_radioModel destructs — both hold RadioModel*.
+#ifdef HAVE_WEBSOCKETS
+    TciServer* m_tciServer{nullptr};
+#endif
+    std::array<CatPort*, kCatPorts> m_catPorts{};
     int m_sessionId{0};
     QString m_label;
 };


### PR DESCRIPTION
## Summary

Twelfth PR of the #3351 series — **session v2**. The per-radio servers move from loose MainWindow members onto the RadioSession aggregate. Beyond the architecture, this makes the **#2385 crash class structurally impossible**.

## The ownership argument

Both `TciServer` and `CatPort` hold a raw `RadioModel*`. #2385 (crash on quit) happened because Qt's child sweep deleted TciServer *after* MainWindow's value members — including the model — were already gone; the fix was a carefully-ordered manual teardown with a long explanatory comment. With the session owning **both the model and the servers**, the ordering becomes a language guarantee: servers die in `~RadioSession`'s body, which always runs before the `m_radioModel` member destructs.

## Changes

| Piece | Before | After |
|---|---|---|
| `TciServer` | `MainWindow::m_tciServer`, parented to MainWindow, manual delete dance | session-owned, no parent (`Q_ASSERT`ed), deleted in `~RadioSession` body |
| `CatPort[8]` | `MainWindow::m_catPorts[]`, parented to MainWindow | session-owned array, same structural guarantee |
| Read sites (~40 across 5 TUs) | `m_tciServer` / `m_catPorts[i]` | inline forwarding accessors `tciServer()` / `catPort(i)` — mechanical rename |
| #2385 shutdown block | null applet back-ref → `delete` → `nullptr` | null applet back-ref → `m_session->shutdownTciServer()` (early-teardown timing preserved: DAX stream-removes still reach the radio while audio is stopped) |
| `CatControlApplet::setPorts` | fed from the raw member array | fed from `m_session->catPortsArray()` |

## Destruction-order analysis (the review surface)

The one subtle window: the session (a member) dies before the applet panel (a QObject child, swept later). The applets hold copied `CatPort*` / `TciServer*`:

- **CatControlApplet** — verified it only dereferences ports from signal-driven slots; Qt auto-disconnects on CatPort destruction and no event loop spins during destructor teardown. Inert.
- **TciApplet** — its back-reference is explicitly nulled before `shutdownTciServer()`, same as the original #2385 fix.

## Verification

- Full build clean, zero new warnings
- All 33 ctest suites pass
- a11y lint: 0 findings
- Zero residual `m_tciServer` / `m_catPorts` references (grep-verified)

## QA checklist for the bench

- [ ] TCI: WSJT-X connects, audio flows, disconnect/reconnect WSJT-X mid-session
- [ ] TCI port toggle off/on from the menu (exercises start/stop on the session-owned server)
- [ ] CAT: rigctld client connects on each configured port; PTY symlinks present (Linux)
- [ ] CAT applet shows live client counts + PTY paths
- [ ] **Quit while connected with TCI clients attached** — the #2385 regression test, now structurally guaranteed
- [ ] Quit while disconnected — both paths clean

Refs #3351 #3445 #2385