### PR TITLE
fix(spectrum): always draw bandwidth indicator at full brightness for non-active slices

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -8000,13 +8000,18 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
         if (so.freqMhz < startMhz || so.freqMhz > endMhz) return;
 
         const QColor col = sliceColorForOverlay(so);
-        // Bandwidth affordances (passband fill + filter edges) always use the
-        // full-brightness active colour so they remain visible on non-active
-        // slices (#3484). The VFO centre line, triangle, and RIT/XIT lines
-        // keep using `col` (dimmed when inactive) to preserve the active-slice
-        // focus cue.
+        // Bandwidth affordances (passband fill + filter edges) render at full
+        // brightness so they stay visible on non-active slices (#3484) — but an
+        // inactive slice uses the neutral secondary colour instead of the
+        // slice's own colour, so it is COLOUR (not brightness) that signals
+        // inactive. That keeps the panadapter from making an inactive slice look
+        // TX-selectable (the #2389 confusion concern) while fixing the
+        // near-invisible passband. The VFO centre line, triangle, and RIT/XIT
+        // lines keep `col` (dimmed when inactive) to preserve the focus cue.
         const int colourIdx = SliceLabel::displayColorIndex(so.sliceId, so.perClientLetter);
-        const QColor bandCol = SliceColorManager::instance().activeColor(colourIdx);
+        const QColor bandCol = so.isActive
+            ? SliceColorManager::instance().activeColor(colourIdx)
+            : AetherSDR::ThemeManager::instance().color("color.text.secondary");
         const int freqLineBottom = m_extendedFrequencyLine ? wfRect.bottom() : specRect.bottom();
         const double fLoMhz = so.freqMhz + so.filterLowHz / 1.0e6;
         const double fHiMhz = so.freqMhz + so.filterHighHz / 1.0e6;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -8000,6 +8000,13 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
         if (so.freqMhz < startMhz || so.freqMhz > endMhz) return;
 
         const QColor col = sliceColorForOverlay(so);
+        // Bandwidth affordances (passband fill + filter edges) always use the
+        // full-brightness active colour so they remain visible on non-active
+        // slices (#3484). The VFO centre line, triangle, and RIT/XIT lines
+        // keep using `col` (dimmed when inactive) to preserve the active-slice
+        // focus cue.
+        const int colourIdx = SliceLabel::displayColorIndex(so.sliceId, so.perClientLetter);
+        const QColor bandCol = SliceColorManager::instance().activeColor(colourIdx);
         const int freqLineBottom = m_extendedFrequencyLine ? wfRect.bottom() : specRect.bottom();
         const double fLoMhz = so.freqMhz + so.filterLowHz / 1.0e6;
         const double fHiMhz = so.freqMhz + so.filterHighHz / 1.0e6;
@@ -8014,11 +8021,11 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
         // record of received signals; painting a UI affordance over it
         // makes the passband look like a signal in the history (#1270).
         p.fillRect(QRect(fX1, specRect.top(), fW, specRect.height()),
-                   QColor(col.red(), col.green(), col.blue(), 35));
+                   QColor(bandCol.red(), bandCol.green(), bandCol.blue(), 35));
 
         // Filter edge lines — user-hidden via per-slice VFO flag toggle (#1526)
         if (!so.filterEdgesHidden) {
-            p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 130), 1));
+            p.setPen(QPen(QColor(bandCol.red(), bandCol.green(), bandCol.blue(), 130), 1));
             p.drawLine(fX1, specRect.top(), fX1, specRect.bottom());
             p.drawLine(fX2, specRect.top(), fX2, specRect.bottom());
         }


### PR DESCRIPTION
## Summary

Fixes #3484. Bandwidth affordances (passband fill and filter-edge lines) in `SpectrumWidget::drawSliceMarkers` now always use the full-brightness active colour, regardless of which slice is currently active.

Previously both used `sliceColorForOverlay()`, which returns `dimColor()` on non-active slices - combining ~40% RGB with the low-alpha draw produced approximately 5.5% effective brightness, making the bandwidth indicator nearly invisible on inactive slices.

The fix introduces `bandCol = SliceColorManager::activeColor(colourIdx)` alongside the existing `col = sliceColorForOverlay(so)` and uses `bandCol` only for the two passband draw calls. Focus affordances (VFO centre line, triangle marker, RIT/XIT lines) retain the dimmed `col` to preserve the active-slice visual cue. Change is confined to `src/gui/SpectrumWidget.cpp`.

## Constitution principle honored

Principle VIII - Evidence Over Assertion. The change traces directly to a user-reported regression (#3484). The color API used (`SliceColorManager::activeColor(colourIdx)`) matches the existing pattern inside `sliceColorForOverlay()` itself - no new API surface, no assertion-without-evidence.

## Test plan

- [ ] Local build passes (`cmake --build build`)
- [ ] Open two slices on the same panadapter; switch focus to the second slice and verify the first slice's passband shading and filter-edge lines remain clearly visible at full brightness
- [ ] Verify the non-active slice's VFO centre line and triangle marker remain visually dimmed
- [ ] Existing tests pass (CI)

## Checklist

- [ ] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [ ] No new flat-key `AppSettings` calls - use nested-JSON-under-one-key (Principle V)
- [ ] All meter UI uses `MeterSmoother` (Principle II)
- [ ] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable
