### PR TITLE
docs(arch): correct RadioSession v3 scope (#3351 / #3445)

### DIFF
--- a/src/models/RadioSession.h
+++ b/src/models/RadioSession.h
@@ -35,10 +35,23 @@ namespace AetherSDR {
 // requirement (DAX stream-remove commands must reach the radio while
 // audio is already stopped) and now routes through shutdownTciServer().
 //
-// Planned v3+ scope (see #3445):
-//   • the wireDiscovery/wireRadioModel/wirePanLifecycle bodies from
-//     MainWindow_Session.cpp move here as session methods
-//   • per-session settings facade (Principle V nested JSON)
+// Planned v3+ scope (see #3445) — corrected after the v2 landing:
+//   • The wireDiscovery/wireRadioModel/wirePanLifecycle bodies do NOT
+//     belong here. They are ~100 connect() calls with ~76 references to
+//     MainWindow's widgets (applet panel, title bar, pan stack, spectrum
+//     widgets, status bar) — model→UI glue that is application-layer by
+//     nature. Moving it onto a models/ class would invert the dependency
+//     (RadioSession would have to #include the GUI). It stays in
+//     MainWindow_Session.cpp (or a future GUI-layer per-session
+//     controller), not on this aggregate.
+//   • A per-session *settings* facade is premature: there is no per-radio
+//     AppSettings namespace to wrap today. Per-radio state is either
+//     global (StationName, LastConnectedRadioSerial), radio-side (slice/
+//     pan/mode → SSDR profiles, see #3384), or already correctly
+//     namespaced — BandStackSettings::sanitizeSerial() keys on
+//     "Radio_<serial>" and is the working template multi-radio should
+//     follow when it needs per-radio persistence. Build that facade when
+//     a second session creates a real consumer, not before.
 //
 // MainWindow currently binds `RadioModel& m_radioModel` to
 // session->radioModel() so the ~900 existing call sites across the


### PR DESCRIPTION
## Summary

Doc-only. Corrects two items the RadioSession v1 class doc (merged in #3544) listed as "v3 scope" that don't survive closer inspection. No code change — captures a finding so neither gets attempted as written.

I went to build the **SessionSettings facade** (the documented next step) and the investigation showed it's premature. Rather than build speculative infrastructure with no consumer — the first such thing in the 12-PR series — here's the finding, recorded in the class doc where the next contributor will see it.

## Finding 1: the wire bodies can't move onto RadioSession

`wireDiscovery` / `wireRadioModel` / `wirePanLifecycle` are **~100 `connect()` calls with ~76 references to MainWindow's widgets** (applet panel, title bar, pan stack, spectrum widgets, status bar). They're application-layer model→UI glue. Moving them onto a `src/models/` class would invert the dependency — RadioSession would have to `#include` the GUI. They belong in the GUI layer (where they are now), full stop.

## Finding 2: the SessionSettings facade is premature

There is no per-radio AppSettings namespace to wrap. Per-radio state today is:

| Category | Examples | Where it lives |
|---|---|---|
| Global | `StationName`, `LastConnectedRadioSerial` | flat AppSettings (genuinely global — station is per-operator, last-serial is a reconnect pointer) |
| Radio-side | slice/pan positions, modes | FlexRadio SSDR profiles (`profile global info`) — see #3384 |
| Already per-radio | band-stack entries | `BandStackSettings::sanitizeSerial()` → `"Radio_<serial>"` keys |

**`BandStackSettings` is the one working per-radio-namespacing pattern in the codebase** — it's the template multi-radio should follow when a second session creates a real consumer. A facade built now would wrap nothing and have no caller.

## What this means for the series

The #3351 refactor is **complete**. The architecturally hard work — the 19,474→8,135-line decomposition and the by-value→session-collection extraction (937 call sites) — is merged. RadioSession owns `{RadioModel, TciServer, CatPort[8], identity}`; the #2385 crash class is structurally impossible. What remains for multi-radio (#3445) is feature/design work — the `m_sessions.size() > 1` activation, the active-radio UI, the audio-plane decision — which is the team's call, not more refactoring.

Refs #3351 #3445 #3384