### PR TITLE
[codex] Harden profile load recovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1939,6 +1939,13 @@ target_link_libraries(radio_status_ownership_test PRIVATE Qt6::Core)
 enable_testing()
 add_test(NAME radio_status_ownership_test COMMAND radio_status_ownership_test)
 
+add_executable(profile_load_command_test
+    tests/profile_load_command_test.cpp
+)
+target_include_directories(profile_load_command_test PRIVATE src)
+target_link_libraries(profile_load_command_test PRIVATE Qt6::Core)
+add_test(NAME profile_load_command_test COMMAND profile_load_command_test)
+
 # #3212 — slice recreate policy (reuse restored pan vs create new; slice freq)
 add_executable(slice_recreate_policy_test
     tests/slice_recreate_policy_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2236,6 +2236,7 @@ target_link_libraries(transmit_model_test PRIVATE Qt6::Core)
 if(UNIX)
     target_link_libraries(transmit_model_test PRIVATE pthread)
 endif()
+add_test(NAME transmit_model_test COMMAND transmit_model_test)
 
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -2031,6 +2031,41 @@ void TciServer::cancelDaxRelease()
     }
 }
 
+void TciServer::rearmDaxForProfileLoad()
+{
+    if (!m_model || !m_model->isConnected()) {
+        return;
+    }
+
+    bool hasAudioClient = false;
+    for (const auto& cs : m_clients) {
+        if (cs.audioEnabled) {
+            hasAudioClient = true;
+            break;
+        }
+    }
+    if (!hasAudioClient) {
+        return;
+    }
+
+    if (m_model->panStream()) {
+        for (auto it = m_tciDaxStreamIds.cbegin(); it != m_tciDaxStreamIds.cend(); ++it) {
+            if (it.value() != 0 && !m_tciDaxBorrowedChannels.contains(it.key())) {
+                m_model->sendCommand(QString("stream remove 0x%1")
+                    .arg(it.value(), 8, 16, QChar('0')));
+                m_model->panStream()->unregisterDaxStream(it.value());
+            }
+        }
+    }
+
+    m_tciDaxStreamIds.clear();
+    m_tciDaxBorrowedChannels.clear();
+    m_tciDaxSlices.clear();
+
+    qCInfo(lcCat) << "TCI: profile load completed - re-arming DAX for active audio client";
+    ensureDaxForTci();
+}
+
 void TciServer::releaseDaxForTci()
 {
     if (!m_model) return;

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -104,6 +104,7 @@ public:
     void wireSlice(int trx, SliceModel* slice);
     void wireSpotModel();
     void notifySpotClicked(int spotIndex, SliceModel* slice = nullptr);
+    void rearmDaxForProfileLoad();
 
 public slots:
     // RX audio from main audio pipeline (float32 stereo, 24 kHz)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1651,6 +1651,11 @@ MainWindow::MainWindow(QWidget* parent)
             // Throttle lifted — push each pan's user-configured fps back to the radio.
             // The reconcile timers are suppressed while throttle is active, so they
             // won't have done this automatically.
+            if (profileLoadRadioStateWritesHeld()) {
+                qCDebug(lcProtocol)
+                    << "MainWindow: adaptive throttle restore suppressed during profile load";
+                return;
+            }
             if (!m_panStack) return;
             for (auto* applet : m_panStack->allApplets()) {
                 if (!applet) continue;
@@ -3896,6 +3901,7 @@ void MainWindow::buildUI()
     connect(m_bsAutoSaveTimer, &QTimer::timeout, this, [this]() {
         const int dwellSec = BandStackSettings::instance().autoSaveDwellSeconds();
         if (dwellSec <= 0) return;
+        if (profileLoadRadioStateWritesHeld()) return;
         if (m_radioModel.serial().isEmpty()) return;
         if (m_radioModel.transmitModel().isTransmitting()) return;
         if (QDateTime::currentMSecsSinceEpoch() < m_bsConnectGraceUntilMs) return;
@@ -5796,7 +5802,9 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     // Send "slice set N active=1" only when switching to a different slice
     // (matches SmartSDR pcap — sent on VFO flag click, not on every tune).
     // Guard: don't send if triggered by the radio's own activeChanged echo
-    // (m_updatingFromModel is set in the activeChanged handler).
+    // (m_updatingFromModel is set in the activeChanged handler). During profile
+    // recall, RadioModel's profile-load hold suppresses this radio write so we
+    // do not dirty the radio's restoring GUIClient session.
     if (sliceId != prevId && !m_updatingFromModel)
         s->setActive(true);
 
@@ -5821,7 +5829,7 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     // Active slice changed → restart dwell window for the new active slice
     if (sliceId != prevId && m_bsAutoSaveTimer) {
         const int dwellSec = BandStackSettings::instance().autoSaveDwellSeconds();
-        if (dwellSec > 0)
+        if (dwellSec > 0 && !profileLoadRadioStateWritesHeld())
             m_bsAutoSaveTimer->start(dwellSec * 1000);
         else
             m_bsAutoSaveTimer->stop();
@@ -6279,6 +6287,12 @@ void MainWindow::schedulePanFpsReconcile(const QString& panId, int reportedFps)
             << " reported=" << reportedFps << " (adaptive throttle active)";
         return;
     }
+    if (profileLoadRadioStateWritesHeld()) {
+        qCDebug(lcProtocol).noquote().nospace()
+            << "MainWindow: fps reconcile suppressed for profile load pan=" << panId
+            << " reported=" << reportedFps;
+        return;
+    }
 
     auto* pan = m_radioModel.panadapter(panId);
     if (!pan)
@@ -6324,6 +6338,11 @@ void MainWindow::schedulePanFpsReconcile(const QString& panId, int reportedFps)
             }
             if (!pan || !sw)
                 return;
+            if (profileLoadRadioStateWritesHeld()) {
+                qCDebug(lcProtocol).noquote().nospace()
+                    << "MainWindow: fps timer suppressed for profile load pan=" << panId;
+                return;
+            }
 
             const int reported = pan->fps();
             const int desired = sw->fftFps();
@@ -6360,6 +6379,12 @@ void MainWindow::scheduleWaterfallLineDurationReconcile(const QString& panId, in
         qCDebug(lcProtocol).noquote().nospace()
             << "MainWindow: wf line_duration reconcile suppressed for pan=" << panId
             << " reported=" << reportedMs << "ms (adaptive throttle active)";
+        return;
+    }
+    if (profileLoadRadioStateWritesHeld()) {
+        qCDebug(lcProtocol).noquote().nospace()
+            << "MainWindow: wf line_duration reconcile suppressed for profile load pan=" << panId
+            << " reported=" << reportedMs << "ms";
         return;
     }
 
@@ -6407,6 +6432,11 @@ void MainWindow::scheduleWaterfallLineDurationReconcile(const QString& panId, in
             }
             if (!pan || !sw)
                 return;
+            if (profileLoadRadioStateWritesHeld()) {
+                qCDebug(lcProtocol).noquote().nospace()
+                    << "MainWindow: wf line_duration timer suppressed for profile load pan=" << panId;
+                return;
+            }
 
             const QString wfId = pan->waterfallId();
             const int reported = pan->waterfallLineDuration();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -58,6 +58,7 @@
 #include <QLabel>
 #include <QList>
 #include <QMenu>
+#include <QSet>
 #include <QStatusBar>
 #include <QSizeGrip>
 #include <QHash>
@@ -755,6 +756,8 @@ private:
 
     // Audio stream re-creation flag (after profile load)
     bool             m_needAudioStream{false};
+    qint64           m_profileLoadRadioStateWriteHoldUntilMs{0};
+    QSet<QString>    m_pendingProfileLoadPanDimensions;
 
     // Pending WAN radio (between requestConnect and connectReady)
     WanRadioInfo     m_pendingWanRadio;
@@ -827,6 +830,16 @@ private:
     QDialog* m_reconnectDlg{nullptr}; // shown on unexpected disconnect, dismissed on reconnect
     QPointer<class ThemeEditorDialog> m_themeEditorDialog; // Phase 5 — lazy, modeless
     void cancelTransmitFromIndicator();
+    void beginProfileLoadRadioStateWriteHold(const QString& profileType, const QString& profileName);
+    bool profileLoadRadioStateWritesHeld() const;
+    void holdNoiseFloorAutoAdjustForProfileLoad(qint64 untilMs);
+    void reacquireNoiseFloorLocksAfterProfileLoad();
+    void scheduleProfileLoadRecovery(const QString& profileType, const QString& profileName);
+    void runProfileLoadRecoveryPass(const QString& profileType, const QString& profileName,
+                                    bool rearmDaxIq, bool resetDaxRxStreams);
+    void requestPanDimensionsForRadio(const QString& panId, SpectrumWidget* sw);
+    void sendPanDimensionsToRadio(const QString& panId, SpectrumWidget* sw);
+    void flushPendingProfileLoadPanDimensions();
     class ClientEqEditor* m_clientEqEditor{nullptr}; // lazy — created on first Edit… click
     // Lazy-construct the floating EQ editor on first access, with all
     // bypass-toggled wiring set up once.  Used from every site that

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -468,6 +468,10 @@ void MainWindow::wireRadioModel()
     });
     connect(&m_radioModel, &RadioModel::radioMessageReceived,
             this, &MainWindow::onRadioMessage);
+    connect(&m_radioModel, &RadioModel::profileLoadStarted,
+            this, &MainWindow::beginProfileLoadRadioStateWriteHold);
+    connect(&m_radioModel, &RadioModel::profileLoadCompleted,
+            this, &MainWindow::scheduleProfileLoadRecovery);
     connect(&m_radioModel.spotModel(), &SpotModel::spotsCleared,
             this, &MainWindow::rebuildMemorySpotFeed);
 
@@ -1069,17 +1073,7 @@ void MainWindow::wirePanLifecycle()
         // FFT data is essentially empty/unusable. Use widget width and the
         // actual FFT pane height for 1:1 bin-to-pixel mapping.
         auto* sw = applet->spectrumWidget();
-        const int xpix = panXpixelsFor(sw);
-        const int ypix = panYpixelsFor(sw);
-        m_radioModel.sendCommand(
-            QString("display pan set %1 xpixels=%2 ypixels=%3")
-                .arg(pan->panId()).arg(xpix).arg(ypix));
-
-        // Tell PanadapterStream the ypixels for FFT bin→dBm conversion
-        if (pan->panStreamId()) {
-            m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
-            sw->prepareForFftScaleChange();
-        }
+        requestPanDimensionsForRadio(pan->panId(), sw);
 
         qDebug() << "MainWindow: added panadapter applet for" << pan->panId();
 
@@ -1131,15 +1125,7 @@ void MainWindow::wirePanLifecycle()
                             auto* sw = applet->spectrumWidget();
                             auto* pan = m_radioModel.panadapter(applet->panId());
                             if (!sw || !pan) continue;
-                            const int xpix = panXpixelsFor(sw);
-                            const int ypix = panYpixelsFor(sw);
-                            m_radioModel.sendCommand(
-                                QString("display pan set %1 xpixels=%2 ypixels=%3")
-                                    .arg(pan->panId()).arg(xpix).arg(ypix));
-                            if (pan->panStreamId()) {
-                                m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
-                                sw->prepareForFftScaleChange();
-                            }
+                            requestPanDimensionsForRadio(pan->panId(), sw);
                         }
                     });
                 }
@@ -1184,15 +1170,7 @@ void MainWindow::wirePanLifecycle()
         auto* sw = applet->spectrumWidget();
         auto* pan = m_radioModel.panadapter(panId);
         if (!sw || !pan) return;
-        const int xpix = panXpixelsFor(sw);
-        const int ypix = panYpixelsFor(sw);
-        m_radioModel.sendCommand(
-            QString("display pan set %1 xpixels=%2 ypixels=%3")
-                .arg(panId).arg(xpix).arg(ypix));
-        if (pan->panStreamId()) {
-            m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
-            sw->prepareForFftScaleChange();
-        }
+        requestPanDimensionsForRadio(panId, sw);
     });
 
 #ifdef Q_OS_MAC
@@ -1210,15 +1188,7 @@ void MainWindow::wirePanLifecycle()
                 if (!panPixelDimensionsReady(sw)) {
                     continue;
                 }
-                const int xpix = panXpixelsFor(sw);
-                const int ypix = panYpixelsFor(sw);
-                m_radioModel.sendCommand(
-                    QString("display pan set %1 xpixels=%2 ypixels=%3")
-                        .arg(pan->panId()).arg(xpix).arg(ypix));
-                if (pan->panStreamId()) {
-                    m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
-                    sw->prepareForFftScaleChange();
-                }
+                requestPanDimensionsForRadio(pan->panId(), sw);
             }
         });
     };
@@ -1277,7 +1247,9 @@ void MainWindow::wirePanLifecycle()
 
         // Rearrange remaining pans to a sensible layout. Do not persist this
         // fallback: a temporary resource-shortage session must not overwrite
-        // the user's saved multi-pan layout.
+        // the user's saved multi-pan layout. This is local splitter cleanup,
+        // not a radio-state write, so it must still run during profile loads
+        // to avoid leaving empty nested splitter cells behind.
         int remaining = m_panStack->count();
         if (remaining > 1) {
             m_panStack->rearrangeLayout(defaultPanLayoutForCount(remaining));

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -45,6 +45,7 @@
 #ifdef HAVE_RADE
 #include "core/RADEEngine.h"
 #endif
+#include "models/ProfileLoadCommand.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 
@@ -90,11 +91,6 @@ bool dbmRangeLooksPlausible(float minDbm, float maxDbm)
         && maxDbm <= kMaxAllowedDbm
         && rangeDb >= kMinRangeDb
         && rangeDb <= kMaxRangeDb;
-}
-
-bool profileLoadMayRebuildRadioTopology(const QString& profileType)
-{
-    return profileType.compare(QStringLiteral("global"), Qt::CaseInsensitive) == 0;
 }
 
 // Pan-follow tuning internals — moved with their only callers from

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -48,7 +48,9 @@
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 
+#include <QDateTime>
 #include <QFileDialog>
+#include <QSet>
 #include <QTimer>
 
 #include <algorithm>
@@ -70,6 +72,29 @@ bool memoryRevealTargetMatches(double actualMhz, double targetMhz)
 {
     return targetMhz <= 0.0
         || std::abs(actualMhz - targetMhz) <= kMemoryRevealTargetToleranceMhz;
+}
+
+bool dbmRangeLooksPlausible(float minDbm, float maxDbm)
+{
+    constexpr float kMinAllowedDbm = -180.0f;
+    constexpr float kMaxAllowedDbm = 80.0f;
+    constexpr float kMinRangeDb = 10.0f;
+    constexpr float kMaxRangeDb = 180.0f;
+
+    if (!std::isfinite(minDbm) || !std::isfinite(maxDbm)) {
+        return false;
+    }
+
+    const float rangeDb = maxDbm - minDbm;
+    return minDbm >= kMinAllowedDbm
+        && maxDbm <= kMaxAllowedDbm
+        && rangeDb >= kMinRangeDb
+        && rangeDb <= kMaxRangeDb;
+}
+
+bool profileLoadMayRebuildRadioTopology(const QString& profileType)
+{
+    return profileType.compare(QStringLiteral("global"), Qt::CaseInsensitive) == 0;
 }
 
 // Pan-follow tuning internals — moved with their only callers from
@@ -212,15 +237,20 @@ void MainWindow::onSliceAdded(SliceModel* s)
     }
 
     // Restore per-slice DAX channel from last session (#1221).
-    // Deferred so the radio's initial slice status has arrived first.
+    // Deferred so the radio's initial slice status has arrived first. Skip this
+    // during profile recall: setDaxChannel() updates local slice state before
+    // sending the radio command, and profile-created slices must keep the
+    // radio/profile DAX assignment.
     {
         const int sliceIdx = m_radioModel.slices().indexOf(s);
         if (sliceIdx >= 0) {
             const QString key = QString("DaxChannel_Slice%1").arg(QChar('A' + sliceIdx));
             int savedDax = AppSettings::instance().value(key, "0").toInt();
             if (savedDax > 0) {
-                QTimer::singleShot(300, this, [s, savedDax]() {
-                    if (s) { s->setDaxChannel(savedDax); }
+                QTimer::singleShot(300, this, [this, s, savedDax]() {
+                    if (s && !profileLoadRadioStateWritesHeld()) {
+                        s->setDaxChannel(savedDax);
+                    }
                 });
             }
         }
@@ -229,6 +259,8 @@ void MainWindow::onSliceAdded(SliceModel* s)
     // Re-claim TX assignment after profile load or slice recreation (#145).
     // The radio sets tx=1 on the slice but tx_client_handle may be 0x00000000
     // if the slice was destroyed and recreated (e.g. by profile global load).
+    // During profile recall, RadioModel's profile-load hold suppresses this
+    // slice write so it cannot fight the radio's restored profile state.
     if (s->isTxSlice())
         m_radioModel.sendCommand(QString("slice set %1 tx=1").arg(s->sliceId()));
 
@@ -263,10 +295,13 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // the user re-arms it from the DAX2 window.  Let the user manage that
         // state via DAX2 — matches SmartSDR Console behavior. (#2315)
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
-        m_radioModel.transmitModel().setDax(isDigital);
         m_audio->setDaxTxMode(isDigital);
-        if (isDigital)
-            m_radioModel.ensureDaxTxStream(DaxTxRequestReason::HostedDaxBridge);
+        if (!profileLoadRadioStateWritesHeld()) {
+            m_radioModel.transmitModel().setDax(isDigital);
+            if (isDigital) {
+                m_radioModel.ensureDaxTxStream(DaxTxRequestReason::HostedDaxBridge);
+            }
+        }
 #else
         Q_UNUSED(isDigital);
 #endif
@@ -597,6 +632,7 @@ void MainWindow::onSliceAdded(SliceModel* s)
     connect(s, &SliceModel::frequencyChanged, this, [this, s]() {
         if (s->sliceId() != m_activeSliceId) return;
         if (!m_bsAutoSaveTimer) return;
+        if (profileLoadRadioStateWritesHeld()) return;
         const int dwellSec = BandStackSettings::instance().autoSaveDwellSeconds();
         if (dwellSec <= 0) return;
         m_bsAutoSaveTimer->start(dwellSec * 1000);
@@ -743,11 +779,352 @@ void MainWindow::onSliceRemoved(int id)
     m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
 }
 
+void MainWindow::beginProfileLoadRadioStateWriteHold(const QString& profileType,
+                                                     const QString& profileName)
+{
+    if (!profileLoadMayRebuildRadioTopology(profileType)) {
+        qCDebug(lcProtocol).noquote()
+            << "MainWindow: profile load does not require topology write hold"
+            << QStringLiteral("type=%1").arg(profileType)
+            << QStringLiteral("name=%1").arg(profileName);
+        return;
+    }
+
+    constexpr qint64 kProfileLoadStateWriteHoldMs = 10000;
+    const qint64 untilMs = QDateTime::currentMSecsSinceEpoch() + kProfileLoadStateWriteHoldMs;
+    m_profileLoadRadioStateWriteHoldUntilMs =
+        std::max(m_profileLoadRadioStateWriteHoldUntilMs, untilMs);
+    m_suppressStartupPanLayoutRearrange = false;
+    m_layoutRestoreUntilMs = kPanLayoutRestoreWaitingForFirstPan;
+    if (m_layoutRestoreTimer) {
+        m_layoutRestoreTimer->stop();
+    }
+    if (m_bsAutoSaveTimer) {
+        m_bsAutoSaveTimer->stop();
+    }
+    holdNoiseFloorAutoAdjustForProfileLoad(untilMs);
+
+    qCInfo(lcProtocol).noquote()
+        << "MainWindow: holding profile-owned radio state writes"
+        << QStringLiteral("type=%1").arg(profileType)
+        << QStringLiteral("name=%1").arg(profileName);
+}
+
+bool MainWindow::profileLoadRadioStateWritesHeld() const
+{
+    return QDateTime::currentMSecsSinceEpoch() < m_profileLoadRadioStateWriteHoldUntilMs;
+}
+
+void MainWindow::holdNoiseFloorAutoAdjustForProfileLoad(qint64 untilMs)
+{
+    // Do not let auto noise-floor reposition the client-side dBm scale while a
+    // profile is rebuilding pans. The radio owns profile dBm ranges; auto floor
+    // can reacquire only after those ranges and deferred xpixels/ypixels settle.
+    if (!m_panStack) {
+        return;
+    }
+
+    for (PanadapterApplet* applet : m_panStack->allApplets()) {
+        if (!applet || !applet->spectrumWidget()) {
+            continue;
+        }
+        applet->spectrumWidget()->suspendNoiseFloorAutoAdjustUntil(untilMs);
+    }
+}
+
+void MainWindow::reacquireNoiseFloorLocksAfterProfileLoad()
+{
+    if (m_shuttingDown || !m_radioModel.isConnected() || !m_panStack) {
+        return;
+    }
+
+    for (PanadapterApplet* applet : m_panStack->allApplets()) {
+        if (!applet || !applet->spectrumWidget()) {
+            continue;
+        }
+
+        SpectrumWidget* sw = applet->spectrumWidget();
+        if (auto* pan = m_radioModel.panadapter(applet->panId())) {
+            if (pan->panStreamId()) {
+                m_radioModel.panStream()->setDbmRange(
+                    pan->panStreamId(), pan->minDbm(), pan->maxDbm());
+            }
+            sw->setDbmRange(pan->minDbm(), pan->maxDbm());
+        }
+        sw->reacquireNoiseFloorLock();
+    }
+}
+
+void MainWindow::sendPanDimensionsToRadio(const QString& panId, SpectrumWidget* sw)
+{
+    // Raw sender for radio FFT dimensions. Normal lifecycle/resize paths must
+    // call requestPanDimensionsForRadio() instead so profile loads can defer
+    // these writes; sending xpixels/ypixels while the radio is rebuilding a
+    // profile can make the radio autosave a partial GUIClient slice layout.
+    if (panId.isEmpty() || !sw || !panPixelDimensionsReady(sw)) {
+        return;
+    }
+
+    auto* pan = m_radioModel.panadapter(panId);
+    if (!pan) {
+        return;
+    }
+
+    const int xpix = panXpixelsFor(sw);
+    const int ypix = panYpixelsFor(sw);
+    m_radioModel.sendCommand(
+        QString("display pan set %1 xpixels=%2 ypixels=%3")
+            .arg(panId).arg(xpix).arg(ypix));
+
+    if (pan->panStreamId()) {
+        m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
+        sw->prepareForFftScaleChange();
+    }
+}
+
+void MainWindow::requestPanDimensionsForRadio(const QString& panId, SpectrumWidget* sw)
+{
+    if (panId.isEmpty() || !sw || !panPixelDimensionsReady(sw)) {
+        return;
+    }
+
+    // Pixel dimensions are client-owned display metadata, but sending them
+    // while the radio is tearing down/rebuilding a profile can dirty the
+    // GUIClient restore snapshot with an intermediate topology. That was the
+    // root cause of profile-loaded sessions later restarting with missing
+    // slices. Keep all pan size pushes on this path so they are deferred and
+    // coalesced until the profile load has been accepted and settled.
+    if (profileLoadRadioStateWritesHeld()) {
+        m_pendingProfileLoadPanDimensions.insert(panId);
+        qCDebug(lcProtocol).noquote()
+            << "MainWindow: deferring pan dimensions during profile load"
+            << QStringLiteral("pan=%1").arg(panId);
+        return;
+    }
+
+    sendPanDimensionsToRadio(panId, sw);
+}
+
+void MainWindow::flushPendingProfileLoadPanDimensions()
+{
+    if (m_shuttingDown || !m_radioModel.isConnected()
+            || m_pendingProfileLoadPanDimensions.isEmpty() || !m_panStack) {
+        return;
+    }
+
+    const QSet<QString> pending = m_pendingProfileLoadPanDimensions;
+    m_pendingProfileLoadPanDimensions.clear();
+
+    int sent = 0;
+    for (PanadapterApplet* applet : m_panStack->allApplets()) {
+        if (!applet || !pending.contains(applet->panId())) {
+            continue;
+        }
+
+        sendPanDimensionsToRadio(applet->panId(), applet->spectrumWidget());
+        ++sent;
+    }
+
+    if (sent > 0) {
+        qCDebug(lcProtocol).noquote()
+            << "MainWindow: flushed deferred profile-load pan dimensions"
+            << QStringLiteral("count=%1").arg(sent);
+    }
+}
+
+void MainWindow::scheduleProfileLoadRecovery(const QString& profileType,
+                                             const QString& profileName)
+{
+    if (!profileLoadMayRebuildRadioTopology(profileType)) {
+        qCInfo(lcProtocol).noquote()
+            << "MainWindow: scheduling lightweight profile-load recovery"
+            << QStringLiteral("type=%1").arg(profileType)
+            << QStringLiteral("name=%1").arg(profileName);
+        QTimer::singleShot(350, this, [this, profileType, profileName]() {
+            runProfileLoadRecoveryPass(profileType, profileName, false, false);
+        });
+        return;
+    }
+
+    constexpr qint64 kProfileLoadStateWriteHoldMs = 10000;
+    const qint64 untilMs = QDateTime::currentMSecsSinceEpoch() + kProfileLoadStateWriteHoldMs;
+    m_profileLoadRadioStateWriteHoldUntilMs =
+        std::max(m_profileLoadRadioStateWriteHoldUntilMs, untilMs);
+    holdNoiseFloorAutoAdjustForProfileLoad(m_profileLoadRadioStateWriteHoldUntilMs);
+
+    qCInfo(lcProtocol).noquote()
+        << "MainWindow: scheduling profile-load recovery"
+        << QStringLiteral("type=%1").arg(profileType)
+        << QStringLiteral("name=%1").arg(profileName);
+
+    QTimer::singleShot(350, this, [this, profileType, profileName]() {
+        runProfileLoadRecoveryPass(profileType, profileName, false, true);
+    });
+    QTimer::singleShot(1200, this, [this, profileType, profileName]() {
+        runProfileLoadRecoveryPass(profileType, profileName, true, false);
+    });
+    QTimer::singleShot(2500, this, [this, profileType, profileName]() {
+        runProfileLoadRecoveryPass(profileType, profileName, false, false);
+    });
+    QTimer::singleShot(1500, this, [this]() {
+        flushPendingProfileLoadPanDimensions();
+    });
+    QTimer::singleShot(3500, this, [this]() {
+        flushPendingProfileLoadPanDimensions();
+    });
+    QTimer::singleShot(11000, this, [this]() {
+        flushPendingProfileLoadPanDimensions();
+    });
+    QTimer::singleShot(11250, this, [this]() {
+        reacquireNoiseFloorLocksAfterProfileLoad();
+#ifdef HAVE_WEBSOCKETS
+        if (tciServer()) {
+            tciServer()->rearmDaxForProfileLoad();
+        }
+#endif
+    });
+}
+
+void MainWindow::runProfileLoadRecoveryPass(const QString& profileType,
+                                            const QString& profileName,
+                                            bool rearmDaxIq,
+                                            bool resetDaxRxStreams)
+{
+    Q_UNUSED(profileType);
+    Q_UNUSED(profileName);
+
+    if (m_shuttingDown || !m_radioModel.isConnected()) {
+        return;
+    }
+
+    // Keep this pass to client-owned sessions. A profile load can rewrite
+    // radio-owned pan/slice topology; pushing display pan state here can dirty
+    // the radio's GUIClient restore snapshot while it is settling.
+
+    SliceModel* referenceSlice = m_radioModel.slice(m_activeSliceId);
+    if (!referenceSlice && !m_radioModel.slices().isEmpty()) {
+        referenceSlice = m_radioModel.slices().first();
+    }
+    if (referenceSlice && referenceSlice->frequency() > 0.0) {
+        const QString bandName = BandSettings::bandForFrequency(referenceSlice->frequency());
+        if (!bandName.isEmpty()) {
+            m_bandSettings.setCurrentBand(bandName);
+        }
+        if (referenceSlice->sliceId() == m_activeSliceId) {
+            m_antennaGenius.setRadioFrequency(referenceSlice->frequency());
+        }
+    }
+
+    if (AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True") {
+        audioStartRx();
+    }
+
+#ifdef HAVE_WEBSOCKETS
+    if (resetDaxRxStreams && tciServer() && !profileLoadRadioStateWritesHeld()) {
+        tciServer()->rearmDaxForProfileLoad();
+    }
+#endif
+
+#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
+    if (m_daxBridge) {
+        auto* panStream = m_radioModel.panStream();
+        QSet<int> requestedChannels;
+        bool txSliceIsDigital = false;
+
+        for (auto* slice : m_radioModel.slices()) {
+            if (!slice) {
+                continue;
+            }
+            if (!m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+                continue;
+            }
+
+            if (slice->isTxSlice()) {
+                const QString mode = slice->mode();
+                txSliceIsDigital = (mode == "DIGU" || mode == "DIGL" || mode == "RTTY"
+                                  || mode == "DFM"  || mode == "NFM"  || mode == "NT");
+            }
+
+            const int channel = slice->daxChannel();
+            m_daxSliceLastCh[slice->sliceId()] = channel;
+            if (channel < 1 || channel > 4) {
+                continue;
+            }
+
+#ifdef HAVE_WEBSOCKETS
+            const bool tciUsingChannel = tciServer() && tciServer()->ownsDaxChannel(channel);
+#else
+            const bool tciUsingChannel = false;
+#endif
+#ifdef HAVE_RADE
+            const bool radeUsingChannel =
+                (m_radeDaxStreamId != 0 && panStream
+                 && m_radeDaxStreamId == panStream->daxStreamIdForChannel(channel));
+#else
+            const bool radeUsingChannel = false;
+#endif
+            quint32 existingStream = panStream ? panStream->daxStreamIdForChannel(channel) : 0;
+            if (!tciUsingChannel && panStream && resetDaxRxStreams) {
+                if (existingStream != 0 && !radeUsingChannel) {
+                    m_radioModel.sendCommand(
+                        QString("stream remove 0x%1").arg(existingStream, 0, 16));
+                    panStream->unregisterDaxStream(existingStream);
+                    existingStream = 0;
+                }
+            }
+
+            if (!tciUsingChannel && !radeUsingChannel && existingStream == 0
+                    && !requestedChannels.contains(channel)) {
+                m_radioModel.sendCommand(
+                    QString("stream create type=dax_rx dax_channel=%1").arg(channel));
+                requestedChannels.insert(channel);
+            }
+        }
+
+        m_audio->setDaxTxMode(txSliceIsDigital);
+        if (txSliceIsDigital && m_radioModel.transmitModel().daxOn()) {
+            m_radioModel.ensureDaxTxStream(DaxTxRequestReason::HostedDaxBridge);
+        }
+    }
+#endif
+
+    if (rearmDaxIq) {
+        auto& settings = AppSettings::instance();
+        for (int channel = 1; channel <= 4; ++channel) {
+            if (settings.value(QStringLiteral("DaxIqEnabled%1").arg(channel), "False").toString() != "True") {
+                continue;
+            }
+            const DaxIqModel::IqStream stream = m_radioModel.daxIqModel().stream(channel);
+            if (stream.exists && stream.streamId != 0) {
+                if (m_radioModel.panStream()) {
+                    m_radioModel.panStream()->unregisterIqStream(stream.streamId);
+                }
+                m_radioModel.daxIqModel().removeStream(channel);
+                m_radioModel.daxIqModel().handleStreamRemoved(stream.streamId);
+            }
+            m_radioModel.daxIqModel().createStream(channel);
+            const int rate = settings.value(QStringLiteral("DaxIqRate%1").arg(channel), "48000").toInt();
+            QTimer::singleShot(600, this, [this, channel, rate]() {
+                if (m_radioModel.isConnected()) {
+                    m_radioModel.daxIqModel().setSampleRate(channel, rate);
+                }
+            });
+        }
+    }
+}
+
 
 void MainWindow::wirePanadapter(PanadapterApplet* applet)
 {
     auto* sw = applet->spectrumWidget();
     auto* menu = sw->overlayMenu();
+    if (profileLoadRadioStateWritesHeld()) {
+        // Profile recall briefly rebuilds pan topology and pixel dimensions.
+        // Keep auto noise-floor from sliding the client-side dBm scale during
+        // that window; the radio's profile-owned min_dbm/max_dbm status must
+        // seed the display first, then auto floor can reacquire afterward.
+        sw->suspendNoiseFloorAutoAdjustUntil(m_profileLoadRadioStateWriteHoldUntilMs);
+    }
 
     struct PendingDbmRange {
         bool active{false};
@@ -768,6 +1145,15 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         }
     };
     auto sendDbmRangeCommand = [this, applet](float minDbm, float maxDbm) {
+        if (!dbmRangeLooksPlausible(minDbm, maxDbm)) {
+            qCWarning(lcProtocol).noquote()
+                << "MainWindow: rejecting implausible dBm range"
+                << QStringLiteral("pan=%1").arg(applet->panId())
+                << QStringLiteral("min=%1").arg(minDbm, 0, 'f', 2)
+                << QStringLiteral("max=%1").arg(maxDbm, 0, 'f', 2);
+            return;
+        }
+
         m_radioModel.sendCommand(
             QString("display pan set %1 min_dbm=%2 max_dbm=%3")
                 .arg(applet->panId())
@@ -903,15 +1289,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             if (!panPixelDimensionsReady(sw)) {
                 return;
             }
-            const int xpix = panXpixelsFor(sw);
-            const int ypix = panYpixelsFor(sw);
-            m_radioModel.sendCommand(
-                QString("display pan set %1 xpixels=%2 ypixels=%3")
-                    .arg(pan->panId()).arg(xpix).arg(ypix));
-            if (pan->panStreamId()) {
-                m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
-                sw->prepareForFftScaleChange();
-            }
+            requestPanDimensionsForRadio(pan->panId(), sw);
         });
     }
 
@@ -971,7 +1349,32 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
 
     connect(sw, &SpectrumWidget::dbmRangeChangeRequested,
-            this, [pendingDbm, setStreamDbmRange, sendDbmRangeCommand](float minDbm, float maxDbm) {
+            this, [this, applet, sw, pendingDbm, setStreamDbmRange, sendDbmRangeCommand]
+                  (float minDbm, float maxDbm) {
+        const bool profileLoadHeld = profileLoadRadioStateWritesHeld();
+        const bool autoFloorChange = sw->pendingAutoNoiseFloorDbmRange();
+        if (profileLoadHeld && autoFloorChange) {
+            if (auto* pan = m_radioModel.panadapter(applet->panId())) {
+                if (pan->panStreamId()) {
+                    setStreamDbmRange(pan->minDbm(), pan->maxDbm());
+                }
+                sw->setDbmRange(pan->minDbm(), pan->maxDbm());
+            }
+            sw->reacquireNoiseFloorLock();
+            return;
+        }
+
+        const bool localOnly = profileLoadHeld || autoFloorChange;
+        if (localOnly) {
+            // Local-only dBm changes must not update PanadapterStream. The
+            // stream decodes radio FFT pixel values using the radio's actual
+            // min_dbm/max_dbm; changing that decoder without sending the same
+            // range to the radio creates a feedback loop where the estimated
+            // noise floor and display scale chase each other indefinitely.
+            sw->setDbmRange(minDbm, maxDbm);
+            return;
+        }
+
         pendingDbm->active = true;
         pendingDbm->minDbm = minDbm;
         pendingDbm->maxDbm = maxDbm;

--- a/src/gui/ProfileManagerDialog.cpp
+++ b/src/gui/ProfileManagerDialog.cpp
@@ -165,7 +165,7 @@ QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,
         if (type == "global")
             m_model->loadGlobalProfile(name);
         else if (type == "transmit")
-            m_model->sendCommand(QString("profile transmit load \"%1\"").arg(name));
+            m_model->sendCommand(QString("profile tx load \"%1\"").arg(name));
         else if (type == "mic")
             m_model->sendCommand(QString("profile mic load \"%1\"").arg(name));
     });
@@ -178,7 +178,7 @@ QWidget* ProfileManagerDialog::buildProfileTab(const QString& type,
         if (type == "global")
             m_model->loadGlobalProfile(name);
         else if (type == "transmit")
-            m_model->sendCommand(QString("profile transmit load \"%1\"").arg(name));
+            m_model->sendCommand(QString("profile tx load \"%1\"").arg(name));
         else if (type == "mic")
             m_model->sendCommand(QString("profile mic load \"%1\"").arg(name));
     });

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1053,6 +1053,23 @@ void SpectrumWidget::reacquireNoiseFloorLock() {
     m_measuredNoiseFloorDbm = -1000.0f;
 }
 
+void SpectrumWidget::suspendNoiseFloorAutoAdjustUntil(qint64 untilMs)
+{
+    if (untilMs <= 0) {
+        return;
+    }
+
+    m_noiseFloorAutoAdjustHoldUntilMs =
+        std::max(m_noiseFloorAutoAdjustHoldUntilMs, untilMs);
+    if (m_pendingDbmRangeEchoFromAutoFloor) {
+        m_pendingDbmRangeEcho = false;
+        m_pendingDbmRangeEchoFromAutoFloor = false;
+        m_pendingDbmRangeEchoStartMs = 0;
+    }
+    m_noiseFloorCandidateValid = false;
+    m_noiseFloorCandidateFrames = 0;
+}
+
 void SpectrumWidget::prepareForFftScaleChange()
 {
     m_resetFftSmoothingOnNextFrame = true;
@@ -1434,6 +1451,14 @@ void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
         m_pendingDbmRangeEchoFromAutoFloor = false;
         m_pendingDbmRangeEchoStartMs = 0;
     }
+    if (noiseFloorAutoAdjustHeld(nowMs)) {
+        if (m_pendingDbmRangeEchoFromAutoFloor) {
+            m_pendingDbmRangeEcho = false;
+            m_pendingDbmRangeEchoFromAutoFloor = false;
+            m_pendingDbmRangeEchoStartMs = 0;
+        }
+        return;
+    }
     if (m_pendingDbmRangeEcho) {
         if (m_pendingDbmRangeEchoFromAutoFloor
             && m_noiseFloorBaselineValid
@@ -1537,6 +1562,10 @@ void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
 
 void SpectrumWidget::applyNoiseFloorAutoAdjust(qint64 nowMs)
 {
+    if (noiseFloorAutoAdjustHeld(nowMs)) {
+        return;
+    }
+
     // Pan: keep span fixed, slide refLevel so the smoothed baseline
     // sits at the user-chosen fraction.  (The earlier zoom-based
     // approach changed span every time the floor moved, which made
@@ -1547,6 +1576,19 @@ void SpectrumWidget::applyNoiseFloorAutoAdjust(qint64 nowMs)
     if (std::abs(clampedRef - m_refLevel) < 0.45f) return;
 
     moveRefLevelToward(clampedRef, nowMs);
+}
+
+bool SpectrumWidget::noiseFloorAutoAdjustHeld(qint64 nowMs)
+{
+    if (m_noiseFloorAutoAdjustHoldUntilMs > nowMs) {
+        return true;
+    }
+    if (m_noiseFloorAutoAdjustHoldUntilMs > 0) {
+        m_noiseFloorAutoAdjustHoldUntilMs = 0;
+        resetNoiseFloorBaseline();
+        return true;
+    }
+    return false;
 }
 
 void SpectrumWidget::moveRefLevelToward(float targetRef, qint64 nowMs)
@@ -1586,6 +1628,7 @@ void SpectrumWidget::moveRefLevelToward(float targetRef, qint64 nowMs)
 void SpectrumWidget::sendNoiseFloorRangeCommand(qint64 nowMs, bool force)
 {
     if (!m_noiseFloorEnable || m_dynamicRange <= 0.0f) return;
+    if (noiseFloorAutoAdjustHeld(nowMs)) return;
 
     constexpr qint64 kCommandIntervalMs = 150;
     constexpr float kCommandThresholdDb = 0.75f;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -116,6 +116,7 @@ public:
     void setNoiseFloorPosition(int pos);
     void setNoiseFloorEnable(bool on);
     void prepareForFftScaleChange();
+    void suspendNoiseFloorAutoAdjustUntil(qint64 untilMs);
     void reacquireNoiseFloorLock();
 
     // Two-pass trimmed-mean noise floor from live FFT bins (dBm), EMA-smoothed.
@@ -153,6 +154,9 @@ public:
     float refLevel()      const { return m_refLevel; }
     float dynamicRange()  const { return m_dynamicRange; }
     bool isDraggingDbmScale() const { return m_draggingDbm || m_draggingDbmRange; }
+    bool pendingAutoNoiseFloorDbmRange() const {
+        return m_pendingDbmRangeEcho && m_pendingDbmRangeEchoFromAutoFloor;
+    }
     double centerMhz()    const { return m_centerMhz; }
     double bandwidthMhz() const { return m_bandwidthMhz; }
 
@@ -616,6 +620,7 @@ private:
     // semantic was jarring — span changes shifted signal visual heights
     // every time the floor drifted).
     void applyNoiseFloorAutoAdjust(qint64 nowMs);
+    bool noiseFloorAutoAdjustHeld(qint64 nowMs);
     void moveRefLevelToward(float targetRef, qint64 nowMs);
     void sendNoiseFloorRangeCommand(qint64 nowMs, bool force);
     void clearDbmReleaseRebase();
@@ -706,6 +711,7 @@ private:
     qint64 m_noiseFloorLastMotionMs{0};
     qint64 m_noiseFloorLastCommandMs{0};
     qint64 m_noiseFloorScaleSettlingUntilMs{0};
+    qint64 m_noiseFloorAutoAdjustHoldUntilMs{0};
     float  m_noiseFloorLastCommandRef{-1000.0f};
     bool   m_noiseFloorCandidateValid{false};
     float  m_noiseFloorCandidateDbm{-1000.0f};

--- a/src/models/ProfileLoadCommand.h
+++ b/src/models/ProfileLoadCommand.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QRegularExpression>
+#include <QString>
+
+namespace AetherSDR {
+
+struct ProfileLoadCommand {
+    bool valid{false};
+    QString type;
+    QString name;
+};
+
+inline bool profileLoadMayRebuildRadioTopology(const QString& profileType)
+{
+    return profileType == QStringLiteral("global");
+}
+
+inline ProfileLoadCommand parseProfileLoadCommand(const QString& command)
+{
+    static const QRegularExpression re(
+        QStringLiteral("^\\s*profile\\s+(global|tx|mic)\\s+load\\s+\"([^\"]*)\"\\s*$"),
+        QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpressionMatch match = re.match(command);
+    if (!match.hasMatch()) {
+        return {};
+    }
+
+    return {
+        true,
+        match.captured(1).toLower(),
+        match.captured(2),
+    };
+}
+
+} // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -82,6 +82,65 @@ bool statusFlagSet(const QMap<QString, QString>& kvs, const QString& key)
         || value.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0;
 }
 
+struct ProfileLoadRequest {
+    bool valid{false};
+    QString type;
+    QString name;
+};
+
+constexpr qint64 kProfileLoadStateWriteHoldMs = 10000;
+
+bool profileLoadMayRebuildRadioTopology(const QString& profileType)
+{
+    return profileType == QStringLiteral("global");
+}
+
+ProfileLoadRequest parseProfileLoadCommand(const QString& command)
+{
+    static const QRegularExpression re(
+        R"profileLoad(^\s*profile\s+(global|tx|mic)\s+load\s+"([^"]*)"\s*$)profileLoad",
+        QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpressionMatch match = re.match(command);
+    if (!match.hasMatch()) {
+        return {};
+    }
+    return {
+        true,
+        match.captured(1).toLower(),
+        match.captured(2),
+    };
+}
+
+bool isProfileOwnedRadioStateWrite(const QString& command)
+{
+    const QString trimmed = command.trimmed();
+    const QStringList tokens = trimmed.simplified().split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    if (tokens.size() >= 5
+        && tokens[0] == QStringLiteral("display")
+        && tokens[1] == QStringLiteral("pan")
+        && tokens[2] == QStringLiteral("set")) {
+        bool hasPixelDimension = false;
+        for (int i = 4; i < tokens.size(); ++i) {
+            const QString key = tokens[i].section(QLatin1Char('='), 0, 0);
+            if (key != QStringLiteral("xpixels") && key != QStringLiteral("ypixels")) {
+                return true;
+            }
+            hasPixelDimension = true;
+        }
+        // xpixels/ypixels are allowed past this low-level guard because
+        // MainWindow queues them during a profile load and flushes them after
+        // the radio accepts the profile. Do not bypass
+        // MainWindow::requestPanDimensionsForRadio(); early dimension writes
+        // can cause the radio to save a partial GUIClient slice layout.
+        return !hasPixelDimension;
+    }
+
+    return trimmed.startsWith(QStringLiteral("slice set "))
+        || trimmed.startsWith(QStringLiteral("display pan set "))
+        || trimmed.startsWith(QStringLiteral("display panafall set "))
+        || trimmed.startsWith(QStringLiteral("display waterfall set "));
+}
+
 void appendUniqueAntennaToken(QStringList& tokens, const QString& token)
 {
     if (!token.isEmpty() && !tokens.contains(token))
@@ -2433,8 +2492,8 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
                             });
                     });
             });
-            // Request global profile list
-            sendCmd("profile global info");
+            // Request profile lists/current selections using FlexLib's info command.
+            refreshProfiles();
             sendCmd("sub tnf all");
             sendCmd("sub memories all");
             // Additional subscriptions (matches SmartSDR connection sequence)
@@ -2947,6 +3006,7 @@ int RadioModel::adaptiveWfMsForCap(int fpsCap) const
 void RadioModel::sendAdaptiveCapToPan(const QString& panId, int fpsCap)
 {
     if (panId.isEmpty() || fpsCap <= 0) return;
+    if (profileLoadRadioStateWritesHeld()) return;
     auto* pan = m_panadapters.value(panId, nullptr);
     if (!pan) return;
     sendCommand(QString("display pan set %1 fps=%2").arg(panId).arg(fpsCap));
@@ -3272,12 +3332,8 @@ void RadioModel::requestFileDownloadPort(const QString& downloadKind, ResponseCa
 void RadioModel::refreshProfiles()
 {
     sendCmd(QStringLiteral("profile global info"));
-    sendCmd(QStringLiteral("profile global list"));
-    sendCmd(QStringLiteral("profile global current"));
-    sendCmd(QStringLiteral("profile tx list"));
-    sendCmd(QStringLiteral("profile tx current"));
-    sendCmd(QStringLiteral("profile mic list"));
-    sendCmd(QStringLiteral("profile mic current"));
+    sendCmd(QStringLiteral("profile tx info"));
+    sendCmd(QStringLiteral("profile mic info"));
 }
 
 bool RadioModel::isProfileTransferBlocked() const
@@ -3533,6 +3589,64 @@ quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
         perf.recordPanCenterCommand();
     }
 
+    const ProfileLoadRequest profileLoad = parseProfileLoadCommand(command);
+    if (profileLoad.valid) {
+        const bool topologyProfile = profileLoadMayRebuildRadioTopology(profileLoad.type);
+        if (topologyProfile) {
+            m_profileLoadRadioStateWriteHoldUntilMs =
+                std::max(m_profileLoadRadioStateWriteHoldUntilMs,
+                         QDateTime::currentMSecsSinceEpoch() + kProfileLoadStateWriteHoldMs);
+        }
+        emit profileLoadStarted(profileLoad.type, profileLoad.name);
+
+        ResponseCallback originalCallback = std::move(cb);
+        cb = [this, profileLoad, topologyProfile, originalCallback = std::move(originalCallback)]
+             (int code, const QString& body) mutable {
+            if (originalCallback) {
+                originalCallback(code, body);
+            }
+
+            if (code != 0) {
+                qCWarning(lcProtocol).noquote()
+                    << "RadioModel: profile load rejected"
+                    << QStringLiteral("type=%1").arg(profileLoad.type)
+                    << QStringLiteral("name=%1").arg(profileLoad.name)
+                    << QStringLiteral("code=%1").arg(hexCode(code))
+                    << QStringLiteral("body=%1").arg(body);
+                return;
+            }
+
+            qCInfo(lcProtocol).noquote()
+                << "RadioModel: profile load accepted"
+                << QStringLiteral("type=%1").arg(profileLoad.type)
+                << QStringLiteral("name=%1").arg(profileLoad.name);
+            if (topologyProfile) {
+                m_profileLoadRadioStateWriteHoldUntilMs =
+                    std::max(m_profileLoadRadioStateWriteHoldUntilMs,
+                             QDateTime::currentMSecsSinceEpoch() + kProfileLoadStateWriteHoldMs);
+                scheduleRxAudioStreamEnsure(QStringLiteral("profile-load:%1").arg(profileLoad.type));
+            }
+            QTimer::singleShot(750, this, [this]() {
+                if (isConnected()) {
+                    refreshProfiles();
+                }
+            });
+            emit profileLoadCompleted(profileLoad.type, profileLoad.name);
+        };
+    }
+
+    if (!profileLoad.valid
+        && profileLoadRadioStateWritesHeld()
+        && isProfileOwnedRadioStateWrite(command)) {
+        qCDebug(lcProtocol).noquote()
+            << "RadioModel: suppressing profile-load radio-state write"
+            << command;
+        if (cb) {
+            cb(0x50000061, QStringLiteral("suppressed during profile load"));
+        }
+        return 0;
+    }
+
     if (m_wanConn)
         return m_wanConn->sendCommand(command, std::move(cb));
 
@@ -3640,6 +3754,14 @@ PanadapterModel* RadioModel::ensureOwnedPanadapter(const QString& panId)
 }
 
 quint32 RadioModel::ourClientHandle() const { return clientHandle(); }
+
+bool RadioModel::sliceMayBelongToUs(int sliceId) const
+{
+    if (m_foreignSliceOwners.contains(sliceId)) {
+        return false;
+    }
+    return m_ownedSliceIds.isEmpty() || m_ownedSliceIds.contains(sliceId);
+}
 
 void RadioModel::emitOtherClientsChanged()
 {
@@ -4954,12 +5076,12 @@ void RadioModel::handleSliceStatus(int id,
         m_meterModel.setActiveTxSlice(activeTxSliceNum());
         if (!reclaimed) {
             emit sliceAdded(s);
-        } else if (s->isTxSlice()) {
+        } else if (s->isTxSlice()
+                   && QDateTime::currentMSecsSinceEpoch() >= m_profileLoadRadioStateWriteHoldUntilMs) {
             // Re-claim TX after a radio reboot (#145 semantics): the radio
-            // recreates the slice with tx=1 but tx_client_handle pointing at
-            // our dead pre-reboot handle (or 0). Fresh slices get this from
-            // MainWindow::onSliceAdded; reclaimed slices skip sliceAdded, so
-            // re-assert it here.
+            // recreates a stale slice model with tx=1 but tx_client_handle
+            // pointing at our dead pre-reboot handle (or 0). Fresh startup
+            // slices are left radio-owned so GUIClient restore can settle.
             sendCmd(QString("slice set %1 tx=1").arg(id));
         }
         emit slotOccupancyChanged(id);  // empty/foreign → ours
@@ -5148,12 +5270,10 @@ void RadioModel::configurePan(const QString& panId)
     // Do NOT hardcode xpixels/ypixels here — MainWindow knows the real sizes.
     emit panDimensionsNeeded(targetPanId);
 
-    sendCmd(
-        QString("display pan set %1 min_dbm=-130 max_dbm=-40").arg(targetPanId),
-        [](int code, const QString&) {
-            if (code != 0)
-                qCWarning(lcProtocol) << "RadioModel: display pan set dbm failed, code" << Qt::hex << code;
-        });
+    // Do not push a default min_dbm/max_dbm here. configurePan() also runs for
+    // radio-restored pans on startup/profile recall, and the radio owns saved
+    // pan dBm ranges. New user-created pans can still be initialized by the
+    // createPanadapter() response path.
 }
 
 void RadioModel::configureWaterfall(const QString& waterfallId)
@@ -5184,6 +5304,11 @@ void RadioModel::configureWaterfall(const QString& waterfallId)
             qCDebug(lcProtocol) << "RadioModel: waterfall configured (auto_black=0 black_level=15 color_gain=50)";
         }
     });
+}
+
+bool RadioModel::profileLoadRadioStateWritesHeld() const
+{
+    return QDateTime::currentMSecsSinceEpoch() < m_profileLoadRadioStateWriteHoldUntilMs;
 }
 
 void RadioModel::ensureDefaultSlicePreferringRestoredPan()

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -8,6 +8,7 @@
 #include "core/PerfTelemetry.h"
 #include "core/StreamStatus.h"
 #include "core/UdpRegistrationPolicy.h"
+#include "ProfileLoadCommand.h"
 #include "RadioStatusOwnership.h"
 #include "SliceRecreatePolicy.h"
 #include <QCoreApplication>
@@ -82,34 +83,7 @@ bool statusFlagSet(const QMap<QString, QString>& kvs, const QString& key)
         || value.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0;
 }
 
-struct ProfileLoadRequest {
-    bool valid{false};
-    QString type;
-    QString name;
-};
-
 constexpr qint64 kProfileLoadStateWriteHoldMs = 10000;
-
-bool profileLoadMayRebuildRadioTopology(const QString& profileType)
-{
-    return profileType == QStringLiteral("global");
-}
-
-ProfileLoadRequest parseProfileLoadCommand(const QString& command)
-{
-    static const QRegularExpression re(
-        R"profileLoad(^\s*profile\s+(global|tx|mic)\s+load\s+"([^"]*)"\s*$)profileLoad",
-        QRegularExpression::CaseInsensitiveOption);
-    const QRegularExpressionMatch match = re.match(command);
-    if (!match.hasMatch()) {
-        return {};
-    }
-    return {
-        true,
-        match.captured(1).toLower(),
-        match.captured(2),
-    };
-}
 
 bool isProfileOwnedRadioStateWrite(const QString& command)
 {
@@ -3589,7 +3563,7 @@ quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
         perf.recordPanCenterCommand();
     }
 
-    const ProfileLoadRequest profileLoad = parseProfileLoadCommand(command);
+    const ProfileLoadCommand profileLoad = parseProfileLoadCommand(command);
     if (profileLoad.valid) {
         const bool topologyProfile = profileLoadMayRebuildRadioTopology(profileLoad.type);
         if (topologyProfile) {

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -250,6 +250,7 @@ public:
     const QMap<quint32, QString>& clientStations() const { return m_clientStations; }
     quint32 txClientHandle() const { return m_txClientHandle; }
     quint32 ourClientHandle() const;
+    bool sliceMayBelongToUs(int sliceId) const;
 
     struct ClientInfo {
         QString station;
@@ -457,6 +458,13 @@ signals:
     void globalProfilesChanged();
     void profileDatabaseImportingChanged(bool importing);
     void profileDatabaseExportingChanged(bool exporting);
+    // Emitted when a profile load command is sent, before the radio tears down
+    // and rebuilds profile-owned slices/pans.
+    void profileLoadStarted(const QString& profileType, const QString& profileName);
+    // Emitted after the radio accepts a profile load command. Profile recall can
+    // tear down per-session streams; GUI/session code should re-arm client-owned
+    // state from this signal instead of guessing from later status churn.
+    void profileLoadCompleted(const QString& profileType, const QString& profileName);
 
     // Emitted when the radio reports a change to the global Auto-Save
     // profile setting (radio status field "auto_save").  UI consumers
@@ -531,6 +539,7 @@ private:
 
     void configurePan(const QString& panId);
     void configureWaterfall(const QString& waterfallId);
+    bool profileLoadRadioStateWritesHeld() const;
     void registerAsGuiClient(const QString& clientId);
     void disconnectPendingClientsThen(std::function<void()> continuation);
     // LAN-only: subscribe to radio+client topics early, wait 400 ms for
@@ -833,6 +842,7 @@ private:
     bool               m_fullDuplex{false};
     int                m_rttyMarkDefault{2125};
     quint32            m_txClientHandle{0};  // handle of the client that owns TX
+    qint64             m_profileLoadRadioStateWriteHoldUntilMs{0};
     QMap<quint32, ClientInfo> m_clientInfoMap; // handle → full client info
     std::function<void()> m_multiFlexContinuation; // saved continuation during conflict pause
     QMap<quint32, QString> m_clientStations;   // handle → station name (legacy, kept in sync)

--- a/tests/profile_load_command_test.cpp
+++ b/tests/profile_load_command_test.cpp
@@ -1,0 +1,61 @@
+#include "models/ProfileLoadCommand.h"
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name)
+{
+    if (condition) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n", name);
+        ++failures;
+    }
+}
+
+void checkProfileLoad(const QString& command,
+                      const QString& expectedType,
+                      const QString& expectedName,
+                      const char* name)
+{
+    const ProfileLoadCommand profileLoad = parseProfileLoadCommand(command);
+    check(profileLoad.valid, name);
+    check(profileLoad.type == expectedType, "profile load type capture");
+    check(profileLoad.name == expectedName, "profile load name capture");
+}
+
+} // namespace
+
+int main()
+{
+    checkProfileLoad(QStringLiteral("profile global load \"SO2R\""),
+                     QStringLiteral("global"),
+                     QStringLiteral("SO2R"),
+                     "global profile load command parses");
+    check(profileLoadMayRebuildRadioTopology(QStringLiteral("global")),
+          "global profile load is topology-changing");
+
+    checkProfileLoad(QStringLiteral(" profile TX load \"Low Power\" "),
+                     QStringLiteral("tx"),
+                     QStringLiteral("Low Power"),
+                     "TX profile load command parses case-insensitively");
+    check(!profileLoadMayRebuildRadioTopology(QStringLiteral("tx")),
+          "TX profile load is not topology-changing");
+
+    checkProfileLoad(QStringLiteral("profile mic load \"Studio Mic\""),
+                     QStringLiteral("mic"),
+                     QStringLiteral("Studio Mic"),
+                     "mic profile load command parses");
+    check(!profileLoadMayRebuildRadioTopology(QStringLiteral("mic")),
+          "mic profile load is not topology-changing");
+
+    check(!parseProfileLoadCommand(QStringLiteral("profile global save \"SO2R\"")).valid,
+          "non-load profile command is ignored");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/transmit_model_test.cpp
+++ b/tests/transmit_model_test.cpp
@@ -87,5 +87,15 @@ int main(int argc, char** argv)
                  && blockedMessages == QStringList({"blocked"}),
                  "two-tone preflight blocks setup and tune commands");
 
+    commands.clear();
+    tx.loadProfile(QStringLiteral("Contest"));
+    ok &= expect(commands == QStringList({"profile tx load \"Contest\""}),
+                 "TX profile load uses profile tx load");
+
+    commands.clear();
+    tx.loadMicProfile(QStringLiteral("Studio Mic"));
+    ok &= expect(commands == QStringList({"profile mic load \"Studio Mic\""}),
+                 "Mic profile load uses profile mic load");
+
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

This PR hardens profile loading and session recovery so AetherSDR does not fight the radio while the radio is restoring profile-owned state.

The main fixes are:

- Fix TX profile loading from Profile Manager. Profile Manager was sending `profile transmit load`, while FlexLib/radio usage is `profile tx load`. The TX applet path already used the correct command; this makes Profile Manager match it.
- Refresh profile lists/current selections using FlexLib-style `profile global info`, `profile tx info`, and `profile mic info`.
- Add a profile-load lifecycle around accepted profile loads so client-owned sessions can be recovered intentionally after global profile recall.
- Suppress or defer profile-owned slice/pan/waterfall writes during global profile restore, including early pan dimension writes, pan FPS/waterfall line-duration reconciliation, bandstack autosave, and active-slice/TX-slice reasserts.
- Defer pan `xpixels`/`ypixels` pushes until after the global profile load settles. The helper is documented so future lifecycle/resize code does not bypass the deferral and dirty the radio's GUIClient restore snapshot.
- Stop pushing default `min_dbm=-130 max_dbm=-40` for radio-restored pans on startup/profile recall. The radio's saved pan dBm range is authoritative; the default remains only for explicitly created new panadapters.
- Hold and reacquire auto noise-floor positioning around global profile restore, and prevent local-only auto-floor moves from changing `PanadapterStream`'s decoder scale. The stream decoder must use the radio's actual min/max dBm range.
- Re-arm client-owned DAX, DAX IQ, TCI DAX, and RX audio state after global profile load without restoring radio-owned settings like frequency, mode, filter, antennas, power, or profile contents.
- Preserve radio/profile per-slice DAX assignments during profile recall by skipping the delayed AppSettings DAX-channel restore while the global profile load hold is active.
- Keep TX/mic profile recovery lightweight. TX and mic profile loads refresh profile state and can re-establish hosted DAX TX stream state, but they do not freeze pan controls or reset DAX RX/TCI topology.

## Root Cause

Several profile-load paths were either using the wrong radio command or were treating profile restore like an ordinary slice/pan update. Global profile recall can rebuild radio-owned topology and live stream state. If AetherSDR pushes display/slice settings too early, it can dirty the radio's restored GUIClient/session state. Separately, the client-side auto noise-floor logic could move the local dBm scale while the stream decoder still needed to use the radio's true min/max dBm range, causing scale drift/chase behavior.

## Intentional Non-Goals

This does not make AetherSDR save or override radio-owned profile settings. Frequency, mode, filters, antennas, TX power, tune power, pan count, and saved pan dBm profile contents remain radio-authoritative.

Normal user-driven active-slice selection still works. During the global profile restore window only, outgoing `slice set ... active=1` writes are suppressed so profile restore does not dirty radio session state.

## Validation

- `git fetch upstream`
- Fast-forwarded branch to current `upstream/main` (`d43a77a7`) before committing
- `cmake --build build --target AetherSDR -j4`
- `ctest --test-dir build --output-on-failure -R 'profile_transfer_test|radio_status_ownership_test|slice_recreate_policy_test|transmit_model_test'`
- `cmake --build build --target wfm_dsp_test -j4`
- `ctest --test-dir build --output-on-failure -E '^theme_manager_test$'`
- `git diff --check`

`theme_manager_test` was excluded from the broad local suite because this sandbox cannot write the macOS AppSettings temp file path it uses. The profile-focused tests and the remaining 34 tests passed on the refreshed upstream base.
