### PR TITLE
docs: notify agents + contributors of the MainWindow decomposition (#3351)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -98,3 +98,16 @@ docs/RELEASE-SIGNING-KEY.pub.asc  @aethersdr/maintainers
 
 # Bot / agent instruction (source of truth for AI tool behaviour)
 .claude/commands/            @aethersdr/maintainers
+
+# Central GUI architecture — the core MainWindow only.
+# MainWindow is the signal-routing hub + central-state owner; changes to it are
+# direction-impacting (CONTRIBUTING.md "Maintainer-only" tier). These two exact
+# patterns gate ONLY the core files.
+#
+# IMPORTANT: the #3351 decomposition's MainWindow_*.cpp sibling TUs are
+# INTENTIONALLY left on the Tier 3 reviewer default (the `*` line) — broadening
+# review of extracted feature code to the whole reviewer team was a primary goal
+# of the split. Do NOT add a `src/gui/MainWindow*` glob here; it would re-gate
+# the siblings and undo that. See docs/architecture/mainwindow-decomposition.md.
+src/gui/MainWindow.cpp       @aethersdr/maintainers
+src/gui/MainWindow.h         @aethersdr/maintainers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,7 +276,7 @@ declared in `MainWindow.h`. The split is about *which file* a body lives in.
 
 | Your change | Goes in |
 |---|---|
-| Feature lifecycle/handler fitting an existing subsystem | that subsystem's TU — demods (RADE/FreeDV/DAX/RTTY/WFM) → `MainWindow_DigitalModes.cpp`; physical controllers → `MainWindow_Controllers.cpp`; SWR sweep → `MainWindow_SwrSweep.cpp`; spot clients → `MainWindow_Spots.cpp` |
+| Feature lifecycle/handler fitting an existing subsystem | that subsystem's TU — demods (RADE/FreeDV/DAX/RTTY/WFM) → `MainWindow_DigitalModes.cpp`; physical controllers → `MainWindow_Controllers.cpp`; SWR sweep → `MainWindow_SwrSweep.cpp`; spot clients → `MainWindow_Spots.cpp`; discovery/connection/pan-lifecycle → `MainWindow_Session.cpp`; client-DSP applets → `MainWindow_DspApplets.cpp` |
 | Wiring a newly-created radio object (slice/pan/VFO/DSP) to the UI | `MainWindow_Wiring.cpp` |
 | A menu item / action | `MainWindow_Menus.cpp` |
 | A keyboard shortcut | `MainWindow_Shortcuts.cpp` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ tool. Each tool has its own well-known file at a different path
 project-wide lives in **this** file.
 
 If you are an AI assistant: read this file end-to-end before writing
-code or recommending merges. The file is ~330 lines; that's the cost
+code or recommending merges. The file is ~440 lines; that's the cost
 of doing the job right on this codebase.
 
 ## Project Goal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,7 +200,10 @@ Key source directories: `src/core/` (protocol, audio, DSP), `src/models/`
 - `RadioModel` — central state, owns connection + all sub-models
 - `AudioEngine` — RX/TX audio, NR2/RN2/NR4/BNR/DFNR DSP pipeline
 - `SpectrumWidget` — GPU-accelerated FFT spectrum + waterfall (QRhiWidget)
-- `MainWindow` — wires everything together, signal routing hub
+- `MainWindow` — wires everything together, signal routing hub. **Decomposed
+  (#3351)** into one class across `MainWindow.cpp` + `MainWindow_*.cpp` sibling
+  TUs; new feature code goes in a sibling, NOT `MainWindow.cpp` — see
+  [Adding code to MainWindow](#adding-code-to-mainwindow)
 - `PanadapterStream` — VITA-49 UDP parsing, routes FFT/waterfall/audio/meters
 
 **Threading:** up to 11 threads — see `docs/architecture/pipelines.md` for the
@@ -261,6 +264,32 @@ audio payload, meter data — see `docs/architecture/vita49-format.md`.
 ---
 
 ## Key Implementation Patterns
+
+### Adding code to MainWindow
+
+`MainWindow` was a ~19,500-line monolith; **#3351 split it into one class across
+`MainWindow.cpp` + a family of `MainWindow_*.cpp` sibling TUs.** It is still one
+`MainWindow` class — every sibling-TU function is a `MainWindow::` member
+declared in `MainWindow.h`. The split is about *which file* a body lives in.
+
+**Do not add new feature code to `MainWindow.cpp`.** Route it by subsystem:
+
+| Your change | Goes in |
+|---|---|
+| Feature lifecycle/handler fitting an existing subsystem | that subsystem's TU — demods (RADE/FreeDV/DAX/RTTY/WFM) → `MainWindow_DigitalModes.cpp`; physical controllers → `MainWindow_Controllers.cpp`; SWR sweep → `MainWindow_SwrSweep.cpp`; spot clients → `MainWindow_Spots.cpp` |
+| Wiring a newly-created radio object (slice/pan/VFO/DSP) to the UI | `MainWindow_Wiring.cpp` |
+| A menu item / action | `MainWindow_Menus.cpp` |
+| A keyboard shortcut | `MainWindow_Shortcuts.cpp` |
+| A stateless helper with no `MainWindow` dependency | `MainWindowHelpers.{h,cpp}` |
+| A whole new subsystem with no TU home | a **new** `MainWindow_<Subsystem>.cpp` sibling |
+| A member field, or a guard inside a function that can't move | stays in `MainWindow.{h,cpp}` (keep minimal) |
+
+Sibling TUs must **carry their includes explicitly** — the Linux CI floor is
+Qt 6.4.2; don't rely on transitive includes (this broke #3532). When you move
+the last user of a header out of `MainWindow.cpp`, drop that `#include` too.
+
+Full map + decision guide:
+**[`docs/architecture/mainwindow-decomposition.md`](docs/architecture/mainwindow-decomposition.md)**.
 
 ### Adding or converting a dialog
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,8 +281,14 @@ declared in `MainWindow.h`. The split is about *which file* a body lives in.
 | A menu item / action | `MainWindow_Menus.cpp` |
 | A keyboard shortcut | `MainWindow_Shortcuts.cpp` |
 | A stateless helper with no `MainWindow` dependency | `MainWindowHelpers.{h,cpp}` |
-| A whole new subsystem with no TU home | a **new** `MainWindow_<Subsystem>.cpp` sibling |
+| A whole new subsystem with no TU home | a **new** `MainWindow_<Subsystem>.cpp` sibling — only if it's a cohesive subsystem ~500+ lines; smaller waits in the closest sibling |
 | A member field, or a guard inside a function that can't move | stays in `MainWindow.{h,cpp}` (keep minimal) |
+
+A new TU is not free — every sibling re-parses the ~1,000-line `MainWindow.h`,
+and any header edit rebuilds all of them. Split only to a cohesive, reviewable
+granularity, then **stop**: if tempted to subdivide one subsystem into several
+thin TUs, extract a real class instead (the #3557 direction) — that's the only
+move that actually decouples.
 
 Sibling TUs must **carry their includes explicitly** — the Linux CI floor is
 Qt 6.4.2; don't rely on transitive includes (this broke #3532). When you move

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,20 @@ changes.
 - **Radio-authoritative**: Never persist or override settings the radio manages
   (frequency, mode, filter, step size, AGC, antennas, TX power).
 
+### Working in MainWindow
+
+`MainWindow` was a ~19,500-line monolith; **#3351 decomposed it** into one class
+spread across `MainWindow.cpp` + a family of `MainWindow_*.cpp` sibling TUs
+(controllers, menus, shortcuts, wiring, digital modes, SWR sweep, spots). It's
+still one class — the siblings hold `MainWindow::` method bodies.
+
+**Don't add new feature code to `MainWindow.cpp`.** Put a feature's
+lifecycle/handlers in the matching sibling TU, signal wiring in
+`MainWindow_Wiring.cpp`, and reserve `MainWindow.{h,cpp}` for genuinely
+cross-cutting code. The full TU map and a "where does my change go?" table are in
+[`docs/architecture/mainwindow-decomposition.md`](docs/architecture/mainwindow-decomposition.md)
+— read it before touching anything named `MainWindow*`.
+
 ### Thread Architecture
 
 | Thread | Components |
@@ -244,6 +258,14 @@ threading and central-state architecture, protocol bedrock, build
 configuration, and project policy. Per
 [CLAUDE.md](CLAUDE.md#autonomous-agent-boundaries), changes here need
 maintainer eyes regardless of who wrote them.
+
+Note the boundary inside `src/gui/`: only the core **`MainWindow.{h,cpp}`** is
+maintainer-only. The **`MainWindow_*.cpp` sibling TUs** from the #3351
+decomposition (`MainWindow_DigitalModes.cpp`, `MainWindow_Wiring.cpp`,
+`MainWindow_Controllers.cpp`, etc.) are **deliberately at the Default reviewer
+tier** — widening review/approval of extracted feature code to more of the team
+was a primary goal of the decomposition, so feature work that lands in a sibling
+TU does not bottleneck on a maintainer.
 
 The mechanical tier exists so the @AetherClaude bot can land low-risk
 changes (test additions, documentation tweaks, dependency bumps,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,9 +90,10 @@ changes.
 ### Working in MainWindow
 
 `MainWindow` was a ~19,500-line monolith; **#3351 decomposed it** into one class
-spread across `MainWindow.cpp` + a family of `MainWindow_*.cpp` sibling TUs
-(controllers, menus, shortcuts, wiring, digital modes, SWR sweep, spots). It's
-still one class — the siblings hold `MainWindow::` method bodies.
+spread across `MainWindow.cpp` + a family of nine `MainWindow_*.cpp` sibling TUs
+(controllers, menus, shortcuts, wiring, digital modes, SWR sweep, spots,
+session, DSP applets). It's still one class — the siblings hold `MainWindow::`
+method bodies.
 
 **Don't add new feature code to `MainWindow.cpp`.** Put a feature's
 lifecycle/handlers in the matching sibling TU, signal wiring in

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -22,6 +22,9 @@ context that would otherwise live in tribal knowledge.
   lessons learned from the multi-panadapter rollout.
 - [`recenter-policy.md`](recenter-policy.md) — when AetherSDR re-centers
   the panadapter view on a slice change.
+- [`mainwindow-decomposition.md`](mainwindow-decomposition.md) — the
+  `MainWindow_*.cpp` TU map and a decision guide for where new
+  `MainWindow` code belongs (read before touching anything `MainWindow*`).
 
 Code-level reviewers should also skim the corresponding header files
 in `src/core/` and `src/models/`.

--- a/docs/architecture/mainwindow-decomposition.md
+++ b/docs/architecture/mainwindow-decomposition.md
@@ -42,6 +42,59 @@ Read this before adding code to anything named `MainWindow*`. The one rule:
 | A member field/declaration a sibling method needs | `MainWindow.h` (unavoidable — C++ requires members on the class), kept minimal |
 | A small guard/condition inside a function that itself lives in `MainWindow.cpp` and can't move | Stays inline in `MainWindow.cpp` (e.g. the WFM guard inside `setPanFollow()`) |
 
+## When a new TU is warranted
+
+Splitting `MainWindow` across TUs is a **readability + parallel-compile** move —
+it is **not** decoupling. Every sibling `#include`s the ~1,000-line
+`MainWindow.h` (which transitively pulls ~50 heavy headers, with no precompiled
+header), so:
+
+- Each new TU adds a **full re-parse** of that header stack to the build.
+- Any edit to `MainWindow.h` (e.g. adding a member for a feature) **rebuilds
+  every sibling TU** — there are 8 today.
+- Siblings share all private state through the header, so they are separate
+  *files*, not separate *modules*. No boundary is enforced.
+
+So a new TU has real, recurring cost. Create one only when it earns its keep:
+
+1. **Default to an existing sibling.** If the work belongs to a subsystem
+   already housed (a new demod → `DigitalModes`, a menu → `Menus`, wiring → `Wiring`),
+   it goes there. Do not spawn a TU for work that has a home.
+2. **A new TU is a distinct, cohesive subsystem with no existing home** — a
+   feature-family with its own lifecycle/state, for which you could write a
+   one-line charter that fits *none* of the existing siblings. Not a stray
+   method or two.
+3. **Size is a signal, not a trigger.** The existing siblings run ~500–2,500
+   lines, each one subsystem. A new area that is only ~50 lines can wait in the
+   closest sibling (or `MainWindow.cpp` if genuinely cross-cutting) until it
+   grows. Do **not** pre-create near-empty TUs — that is pure cost for no
+   readability gain.
+4. **Split an existing sibling when it accretes a *second* unrelated
+   subsystem.** The driver is cohesion, not a hard line count: a sibling that
+   has grown to cover more than one subsystem is the split candidate (e.g. if
+   `DigitalModes` later also swallowed all CW/keyer logic, that splits out).
+
+### The ceiling — split to cohesion, then extract a class, don't slice finer
+
+There is a floor *and* a ceiling. Once a TU is a single cohesive subsystem at a
+reviewable size, **stop splitting.** If you are tempted to subdivide *below*
+that — carving one subsystem into several thin TUs — that is the signal to
+**extract a real class instead**, not to add more `MainWindow_*.cpp` files.
+
+Slicing thinner adds build cost and arbitrary seams while the actual coupling
+(the god-class with shared private state) is untouched — it can masquerade as
+decoupling work and substitute for it. A real class (e.g. a `WfmController` that
+owns its own state and *removes* members from `MainWindow.h`) is the only move
+that shrinks the shared header, cuts the rebuild fan-out, and creates a boundary
+the compiler enforces. That is the **#3557** direction; prefer it over a
+finer-grained TU split.
+
+**Naming/shape for a justified new TU:** `MainWindow_<Subsystem>.cpp`; methods
+stay `MainWindow::` members declared in `MainWindow.h`; open the file with the
+standard header-comment charter (what it holds + the issue ref), matching the
+existing siblings. When torn between a new TU and `MainWindow.cpp`, pick the new
+TU — the whole point is to stop `MainWindow.cpp` from re-accreting.
+
 ## Conventions when moving or adding a sibling-TU method
 
 - **It's the same class.** Define `void MainWindow::foo()` in the sibling TU;

--- a/docs/architecture/mainwindow-decomposition.md
+++ b/docs/architecture/mainwindow-decomposition.md
@@ -26,6 +26,8 @@ Read this before adding code to anything named `MainWindow*`. The one rule:
 | `MainWindow_DigitalModes.cpp` | 1e | Demod / mode subsystems and their activate/deactivate lifecycles: RADE, FreeDV, DAX, AX.25 / KISS TNC, RTTY, **WFM**. |
 | `MainWindow_SwrSweep.cpp` | 1e | The AetherSweep SWR-sweep engine (lock → step → state machine → pan overlay). |
 | `MainWindow_Spots.cpp` | 2b | `wireSpotSubsystem()` — DX Cluster / RBN / WSJT-X / SpotCollector / POTA clients and their UI plumbing. |
+| `MainWindow_Session.cpp` | 2c | `wireDiscovery()` / `wireRadioModel()` / `wirePanLifecycle()` — LAN + SmartLink discovery, heartbeat/disconnect detection, connection-state routing, and pan-stream lifecycle: the wiring that constitutes "a connected radio". Seed of the future `RadioSession` aggregate (#3445). |
+| `MainWindow_DspApplets.cpp` | 2d | `wirePooDooTiles()` + `wireDspApplets()` — PooDoo RX status tiles and the client-DSP applet family (Compressor / Gate / De-esser / Tube / Reverb / AetherDSP / PUDU TX+RX) plus TX signal-chain wiring. |
 | `MainWindowHelpers.{h,cpp}` | 0 | Stateless formatters / value transforms with **no** `MainWindow` dependency (tooltip builders, spot-ID math, client-list parsing, small pixmap painters). |
 | `MainWindowShortcutState.h` | 1b | Internal shared shortcut state — **not** a public API; only `MainWindow*.cpp` TUs include it. |
 
@@ -34,7 +36,9 @@ Read this before adding code to anything named `MainWindow*`. The one rule:
 | Your change | Goes in |
 |---|---|
 | A new feature's activate/deactivate or event handler that fits an existing subsystem above | That subsystem's TU (e.g. a new demod → `MainWindow_DigitalModes.cpp`, next to RADE/WFM) |
-| Connecting a newly-created radio object (slice / pan / VFO / DSP widget) to the UI | `MainWindow_Wiring.cpp` |
+| Wiring a newly-created slice / pan / VFO / DSP *widget* to the UI | `MainWindow_Wiring.cpp` |
+| Discovery / connection-state / pan-stream-lifecycle wiring | `MainWindow_Session.cpp` (not `_Wiring`) |
+| Client-DSP applet or PooDoo-tile wiring | `MainWindow_DspApplets.cpp` (not `_Wiring`) |
 | A new menu item or action | `MainWindow_Menus.cpp` |
 | A new keyboard shortcut | `MainWindow_Shortcuts.cpp` |
 | A stateless formatter/helper with no `MainWindow` dependency | `MainWindowHelpers.{h,cpp}` |
@@ -51,7 +55,8 @@ header), so:
 
 - Each new TU adds a **full re-parse** of that header stack to the build.
 - Any edit to `MainWindow.h` (e.g. adding a member for a feature) **rebuilds
-  every sibling TU** — there are 8 today.
+  every sibling TU** — there are 9 today (10 files include the header, counting
+  `MainWindow.cpp` itself).
 - Siblings share all private state through the header, so they are separate
   *files*, not separate *modules*. No boundary is enforced.
 

--- a/docs/architecture/mainwindow-decomposition.md
+++ b/docs/architecture/mainwindow-decomposition.md
@@ -1,0 +1,78 @@
+# MainWindow decomposition — where new code goes
+
+`MainWindow` used to be a ~19,500-line monolith (`src/gui/MainWindow.cpp`).
+Issue **#3351** split it into one class spread across many translation units
+(TUs): `MainWindow.cpp` plus a family of `MainWindow_*.cpp` siblings. **It is
+still one `MainWindow` class** — the split is purely about *which file* a method
+body lives in, not about class boundaries. Every sibling-TU function is a
+`MainWindow::` member declared in `MainWindow.h`.
+
+Read this before adding code to anything named `MainWindow*`. The one rule:
+
+> **`MainWindow.cpp` is not the default home for new feature code.** New
+> feature lifecycle/handlers go in the matching sibling TU; per-object signal
+> wiring goes in `MainWindow_Wiring.cpp`. `MainWindow.{h,cpp}` is reserved for
+> genuinely cross-cutting code.
+
+## The TU map
+
+| File | Phase | Holds |
+|---|---|---|
+| `MainWindow.cpp` / `MainWindow.h` | — | The core: constructor (now mostly `wireXxx()` calls), central state members, the signal-routing hub, and cross-cutting code that belongs to no single feature. **Maintainer-gated.** |
+| `MainWindow_Controllers.cpp` | 1a | Physical-controller subsystems: FlexControl, HID encoders (RC-28 / TMate 2 / Ulanzi / PowerMate / Shuttle), StreamDeck labels, controller + meter wiring. |
+| `MainWindow_Menus.cpp` | 1b | `buildMenuBar()` — every `QMenu`/`QAction`, their enable/disable wiring, and the inline lambdas they trigger. |
+| `MainWindow_Shortcuts.cpp` | 1c | The keyboard-shortcut system + its shared state accessors. |
+| `MainWindow_Wiring.cpp` | 1d | Per-object signal wiring: the `wirePanadapter()` / `wireSlice()` / `wireVfoWidget()` / `wireDsp…()` methods that connect each dynamically-created radio object to the UI. |
+| `MainWindow_DigitalModes.cpp` | 1e | Demod / mode subsystems and their activate/deactivate lifecycles: RADE, FreeDV, DAX, AX.25 / KISS TNC, RTTY, **WFM**. |
+| `MainWindow_SwrSweep.cpp` | 1e | The AetherSweep SWR-sweep engine (lock → step → state machine → pan overlay). |
+| `MainWindow_Spots.cpp` | 2b | `wireSpotSubsystem()` — DX Cluster / RBN / WSJT-X / SpotCollector / POTA clients and their UI plumbing. |
+| `MainWindowHelpers.{h,cpp}` | 0 | Stateless formatters / value transforms with **no** `MainWindow` dependency (tooltip builders, spot-ID math, client-list parsing, small pixmap painters). |
+| `MainWindowShortcutState.h` | 1b | Internal shared shortcut state — **not** a public API; only `MainWindow*.cpp` TUs include it. |
+
+## Decision guide — "where does my change go?"
+
+| Your change | Goes in |
+|---|---|
+| A new feature's activate/deactivate or event handler that fits an existing subsystem above | That subsystem's TU (e.g. a new demod → `MainWindow_DigitalModes.cpp`, next to RADE/WFM) |
+| Connecting a newly-created radio object (slice / pan / VFO / DSP widget) to the UI | `MainWindow_Wiring.cpp` |
+| A new menu item or action | `MainWindow_Menus.cpp` |
+| A new keyboard shortcut | `MainWindow_Shortcuts.cpp` |
+| A stateless formatter/helper with no `MainWindow` dependency | `MainWindowHelpers.{h,cpp}` |
+| A whole new subsystem with no existing TU home | A **new** `MainWindow_<Subsystem>.cpp` sibling (copy the header-comment style) — not `MainWindow.cpp` |
+| A member field/declaration a sibling method needs | `MainWindow.h` (unavoidable — C++ requires members on the class), kept minimal |
+| A small guard/condition inside a function that itself lives in `MainWindow.cpp` and can't move | Stays inline in `MainWindow.cpp` (e.g. the WFM guard inside `setPanFollow()`) |
+
+## Conventions when moving or adding a sibling-TU method
+
+- **It's the same class.** Define `void MainWindow::foo()` in the sibling TU;
+  declare `foo()` in `MainWindow.h` as usual. No `friend`, no new class.
+- **Carry includes explicitly.** The Linux CI floor is **Qt 6.4.2**; do not rely
+  on transitive includes that only resolve on newer Qt. A sibling TU must
+  `#include` every header for the symbols *it* uses, even if `MainWindow.cpp`
+  already included them. (This bit #3532; grep moved code for `Q[A-Z]` symbols
+  and add the includes.)
+- **Don't leave orphaned includes behind.** When you move the last user of a
+  header out of `MainWindow.cpp`, remove that `#include` from `MainWindow.cpp`
+  too. (But verify the header isn't used by something else first — e.g.
+  `PanadapterStream.h` looks WFM-adjacent but is used pervasively for pan audio.)
+- **Wiring split mirrors the widget's lifecycle.** A singleton wired in the
+  constructor (e.g. the `RxApplet`) keeps its `connect()` in `MainWindow.cpp`;
+  a per-instance object (e.g. each `VfoWidget`) is wired in its
+  `wireXxx()` in `MainWindow_Wiring.cpp`. RADE and WFM both follow this split —
+  match the nearest sibling feature rather than forcing artificial consistency.
+
+## Ownership
+
+`MainWindow.{h,cpp}` is maintainer-gated (central architecture). The
+`MainWindow_*.cpp` sibling TUs are **deliberately at the broad reviewer tier** —
+opening up review/approval of extracted feature code to more of the team was a
+primary goal of the decomposition. See [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+and [`.github/CODEOWNERS`](../../.github/CODEOWNERS).
+
+## Further direction
+
+- **#3557** — extract per-feature *controllers* (RADE / FreeDV / WFM as a
+  family) out of the `MainWindow` class entirely, so they stop being members.
+- **#3558** — table-drive the menu construction in `MainWindow_Menus.cpp`.
+
+Until those land, keep adding to the sibling TUs as above.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1,3 +1,13 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// ⚠️  MainWindow is DECOMPOSED (#3351). This file is NOT the default home for new
+//     feature code. Feature lifecycle/handlers belong in the matching
+//     MainWindow_*.cpp sibling TU; per-object signal wiring belongs in
+//     MainWindow_Wiring.cpp. Add here only for genuinely cross-cutting state
+//     (central members, the constructor's wireXxx() calls, a guard inside a
+//     function that itself can't move). When in doubt, see the map + decision
+//     guide: docs/architecture/mainwindow-decomposition.md
+// ─────────────────────────────────────────────────────────────────────────────
+
 #include "MainWindow.h"
 
 #include "MainWindowHelpers.h"

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1,5 +1,13 @@
 #pragma once
 
+// ─────────────────────────────────────────────────────────────────────────────
+// ⚠️  MainWindow is DECOMPOSED (#3351). Add member fields/declarations here ONLY
+//     when genuinely cross-cutting — a feature's method bodies live in the
+//     matching MainWindow_*.cpp sibling TU (still MainWindow:: members, declared
+//     here only because C++ requires it). Don't grow this class for feature work.
+//     Map + decision guide: docs/architecture/mainwindow-decomposition.md
+// ─────────────────────────────────────────────────────────────────────────────
+
 #include "models/RadioModel.h"
 #include "models/BandSettings.h"
 #include "models/AntennaGeniusModel.h"


### PR DESCRIPTION
## Why

The #3351 MainWindow decomposition is real in the code but **invisible at the
project level** — it's documented only inside each `MainWindow_*.cpp` header
comment, which you only see *after* you've already opened the wrong file to add
code. This surfaces it up front for both AI tools and human contributors, and
closes an ownership gap the split opened.

## What's in here (5 pieces)

1. **Point-of-use banners** at the top of `MainWindow.cpp` and `MainWindow.h` —
   the one place everyone sees the instant they go to add code: *"this file is
   not the home for new feature code; use the matching `MainWindow_*.cpp`
   sibling."* Reaches every tool (Copilot, Aider, a human in an editor), not
   just ones that load AGENTS.md.
2. **New canonical doc** `docs/architecture/mainwindow-decomposition.md` — the
   TU map, a "where does my change go?" decision table, and the
   include/wiring conventions (incl. the Qt 6.4.2 explicit-includes rule).
   Indexed in the `docs/architecture` README.
3. **AGENTS.md** — flags the decomposition on the `MainWindow` architecture
   line and adds an "Adding code to MainWindow" pattern. Since CLAUDE.md /
   GEMINI.md / the Copilot + Aider files all point at AGENTS.md, this reaches
   every AI tool at once.
4. **CONTRIBUTING.md** — a "Working in MainWindow" note for humans, and a
   clarification in the review-tier section.
5. **CODEOWNERS** — enforces maintainer-only on the two **core** files
   (`MainWindow.{h,cpp}`), which CONTRIBUTING already claimed but CODEOWNERS
   never actually encoded.

## Ownership decision (intentional)

Only core `MainWindow.{h,cpp}` is maintainer-gated. The `MainWindow_*.cpp`
sibling TUs are **deliberately left on the Tier 3 reviewer default** — widening
review/approval of extracted feature code to the whole reviewer team was a
primary goal of the decomposition, so feature work in a sibling TU doesn't
bottleneck on a maintainer. The CODEOWNERS comment documents this so a future
edit doesn't re-gate the siblings with a `MainWindow*` glob.

## Verification

`AetherSDR` builds clean (banners are comments); all doc cross-links and the
AGENTS.md anchor resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)