### PR TITLE
docs(gui): correct stale wireDaxIq() call-site comment (#2530)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1606,8 +1606,9 @@ MainWindow::MainWindow(QWidget* parent)
     // Unified CAT ports → wireCatPorts() (MainWindow_Session.cpp, #3351 Phase 2d).
     wireCatPorts();
 
-    // DAX IQ wiring (no-audio-bridge platforms) → wireDaxIq()
-    // (MainWindow_Session.cpp, #3351 Phase 2d).
+    // DAX IQ routing wiring — established once at construction for all platforms
+    // (independent of the audio bridge) → wireDaxIq() (MainWindow_Session.cpp;
+    // extracted #3351 Phase 2d, de-gated #3522).
     wireDaxIq();
 
     // ── Status bar telemetry ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

#2530 asks to extract a `wireDaxIqRouting()` helper to collapse the duplicated DAX-IQ `connect()` wiring that #2524 copied between the `MainWindow` constructor and `startDax()`.

**That refactor has already landed — the duplication is gone:**

- #3541 (#3351 Phase 2d) extracted #2524's constructor copy into `MainWindow::wireDaxIq()` (`src/gui/MainWindow_Session.cpp`).
- #3522 then deleted the `startDax()` copy and removed the `#if !defined(Q_OS_MAC) && !defined(HAVE_PIPEWIRE)` gate, so the helper is now called **once, unconditionally, on all platforms** from the constructor (`src/gui/MainWindow.cpp:1611`); `startDax()` carries the "wired ONCE at construction … deliberately NOT wired here" comment and contains zero IQ wiring.

So there is nothing left to extract — current `main` already has the single platform-agnostic helper #2530 asked for (it exists as `wireDaxIq`, not `wireDaxIqRouting`).

## What this PR does

Fixes the one stale residual: the call-site comment above `wireDaxIq();` still read "(no-audio-bridge platforms)", which is no longer accurate after #3522. Updated to reflect the all-platforms wiring. **Comment-only; no code/behaviour change.**

Closes #2530.

> If you'd rather simply close #2530 as already-resolved instead of taking a comment-only PR, that's completely fine — flagging the evidence either way.

## Test plan
- [x] Incremental `ninja -C build` clean on Linux (Nobara, Qt 6.10.3) — comment-only, no behaviour change.

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent, on the Linux dev stack (`nobara-dell`).
