### PR TITLE
ci(windows): auto-stage Microsoft Store submission on release tags

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -199,3 +199,40 @@ jobs:
             AetherSDR-*.zip
             AetherSDR-*-setup.exe
             AetherSDR-*.msixupload
+
+      # ----------------------------------------------------------------------
+      # Automated Microsoft Store submission (weekly release cycle).
+      #
+      # Runs ONLY on a v* tag push, and ONLY when the AETHERSDR_STORE_PRODUCT_ID
+      # repository VARIABLE is set. PRs, branch workflow_dispatch runs, and forks
+      # never touch Partner Center because (a) the tag-ref guard, (b) the
+      # product-Id guard, and (c) forks have no access to the repo secrets.
+      #
+      # The submission is staged as a DRAFT (publish-store.ps1 passes
+      # --noCommit): the package uploads to Partner Center but certification is
+      # NOT started. A maintainer reviews the pending submission and clicks
+      # "Submit to Store". CI never publishes to the live channel on its own.
+      #
+      # Free-product only (AetherSDR qualifies). The app must already be live in
+      # the Store. One-time Entra/Partner Center setup is in
+      # docs/WINDOWS-STORE-MSIX.md.
+      # ----------------------------------------------------------------------
+      - name: Setup Microsoft Store Developer CLI
+        if: startsWith(github.ref, 'refs/tags/') && vars.AETHERSDR_STORE_PRODUCT_ID != ''
+        uses: microsoft/microsoft-store-apppublisher@15abd1c50fcc164b19cb240fb04ef3c49bf715a2  # v1.1
+
+      - name: Stage Microsoft Store submission (draft)
+        if: startsWith(github.ref, 'refs/tags/') && vars.AETHERSDR_STORE_PRODUCT_ID != ''
+        env:
+          AZURE_AD_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
+          AZURE_AD_APPLICATION_CLIENT_ID: ${{ secrets.AZURE_AD_APPLICATION_CLIENT_ID }}
+          AZURE_AD_APPLICATION_SECRET: ${{ secrets.AZURE_AD_APPLICATION_SECRET }}
+          SELLER_ID: ${{ secrets.SELLER_ID }}
+          AETHERSDR_STORE_PRODUCT_ID: ${{ vars.AETHERSDR_STORE_PRODUCT_ID }}
+        run: |
+          msstore reconfigure `
+            --tenantId $env:AZURE_AD_TENANT_ID `
+            --sellerId $env:SELLER_ID `
+            --clientId $env:AZURE_AD_APPLICATION_CLIENT_ID `
+            --clientSecret $env:AZURE_AD_APPLICATION_SECRET
+          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\publish-store.ps1 -ProductId $env:AETHERSDR_STORE_PRODUCT_ID

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -120,37 +120,48 @@ the checked-in defaults when set:
 If the identity variables are unset, CI now uses the checked-in Partner Center
 identity defaults from `store-identity.ps1`.
 
-## Automated Store Submission (weekly release cycle) — PLANNED
+## Automated Store Submission (weekly release cycle) — WIRED
 
-> Status: **not yet wired.** Today the workflow only builds the `.msixupload`
-> and attaches it to the GitHub release / workflow artifacts; a maintainer
-> downloads it and uploads to Partner Center by hand. The automated path below
-> is the design we intend to add once the Entra/Partner Center credentials are
-> set up.
+> Status: **wired, dormant until credentials are set.** The `Windows Installer`
+> workflow now stages a **draft** Store submission on every `v*` tag push, but
+> the step is a no-op until the maintainer completes the one-time Entra /
+> Partner Center setup below and sets the `AETHERSDR_STORE_PRODUCT_ID`
+> repository variable. Until then the workflow behaves exactly as before
+> (builds the `.msixupload`, attaches it to the release).
 
-The plan is for the `Windows Installer` workflow to upload each tagged build to
-Partner Center as a **draft** submission via the Microsoft Store Developer CLI
-(`msstore`), deliberately stopping at the draft — a maintainer reviews the
-pending submission in Partner Center and clicks **Submit to Store** to start
-certification. CI would never publish to the live channel on its own.
+On a `v*` tag push the workflow:
 
-Planned flow on a `v*` tag push:
+1. Builds `AetherSDR.exe`, runs `windeployqt`, packages the MSIX, and creates
+   the `.msixupload` (existing steps).
+2. `microsoft/microsoft-store-apppublisher@v1.1` puts the `msstore` CLI on PATH.
+3. `msstore reconfigure` authenticates from the four GitHub secrets.
+4. `packaging/windows/publish-store.ps1` finds the `.msixupload` and runs
+   `msstore publish <pkg>.msixupload -id <ProductId> --noCommit` — staging a
+   **draft**. `--noCommit` is the safety gate that keeps it out of
+   certification. A maintainer reviews the pending submission in Partner Center
+   and clicks **Submit to Store** to start certification. **CI never publishes
+   to the live channel on its own.**
 
-1. Build `AetherSDR.exe`, `windeployqt`, MSIX packaging (existing steps).
-2. `microsoft/microsoft-store-apppublisher` installs the `msstore` CLI.
-3. `msstore reconfigure` authenticates with the Entra/Partner Center secrets.
-4. `msstore publish -i <pkg>.msixupload -id <ProductId> --noCommit` stages the
-   draft. `--noCommit` is the safety gate that keeps it out of certification.
+Guard rails (all three must pass before Partner Center is touched):
 
-The step would be skipped unless the `AETHERSDR_STORE_PRODUCT_ID` **repository
-variable** is set, so PRs, branch `workflow_dispatch` runs, and forks never
-touch Partner Center.
+- The step runs only on a `refs/tags/` ref — never on PRs or branch
+  `workflow_dispatch` runs.
+- The step is skipped unless the `AETHERSDR_STORE_PRODUCT_ID` **repository
+  variable** is set — so the feature is dormant until you opt in.
+- Forks cannot read the repo secrets, so the `reconfigure` step is a no-op
+  there even on a tag.
+
+If the MSIX packaging step (which is `continue-on-error`) produced no
+`.msixupload`, `publish-store.ps1` warns and exits 0 rather than turning an
+otherwise-successful release red.
 
 ### One-time setup (maintainer, outside the repo)
 
 The `msstore` GitHub Actions path is currently supported for **free products
 only**, which AetherSDR is. The app must already be published and live in the
-Store — done via the manual `.msixupload`.
+Store — done via the manual `.msixupload`. **TL;DR:** create an Entra app
+registration, give it the **Manager** role in Partner Center, then store four
+secrets + one variable in GitHub.
 
 0. **Individual accounts: create a free Entra tenant first.** An individual
    (personal-MSA) Partner Center account has no Entra/Azure AD tenant by
@@ -159,28 +170,41 @@ Store — done via the manual `.msixupload`.
    needs no paid Azure subscription, and the account owner already has the
    **Manager** role required to do it. Company accounts can skip this.
 
-1. **Microsoft Entra (Azure AD) app registration**
-   - Register an app in Entra ID (`entra.microsoft.com` → App registrations)
-     in the tenant from step 0.
+1. **Microsoft Entra (Azure AD) app registration** — this is the "service
+   account" the CI uses to authenticate.
+   - Register an app in Entra ID (`entra.microsoft.com` → **App registrations**
+     → New registration) in the tenant from step 0. Single-tenant is fine; no
+     redirect URI is needed for the client-credentials flow.
    - In Partner Center → Account settings → User management → *Microsoft Entra
-     applications*, add that app and assign it the **Manager** role.
-   - Create a client secret under Certificates & secrets (copy the value once).
+     applications*, add that app and assign it the **Manager** role. (This is
+     the step that actually authorizes the app to submit; the Entra
+     registration alone is not enough.)
+   - In the app registration → **Certificates & secrets** → New client secret,
+     create a secret and copy the **value** immediately (it is shown once).
 
-2. **Collect four values:**
-   - **Tenant ID** — Entra → Overview.
-   - **Client ID** — the App registration's Application ID.
-   - **Client Secret** — the secret value created above.
-   - **Seller ID** — Partner Center → Account settings → Identifiers
-     (a.k.a. Publisher/Seller ID).
-   - **Store product ID** — the 12-char ID for the AetherSDR Store listing
-     (`msstore apps list` after a local `msstore reconfigure`, or from the
-     Partner Center product URL).
+2. **Collect the four credential values + the product Id:**
+
+   | What | Where to find it | Goes into GitHub as |
+   |---|---|---|
+   | **Tenant ID** | Entra admin center → Overview → Tenant ID | secret `AZURE_AD_TENANT_ID` |
+   | **Client ID** | The app registration's *Application (client) ID* | secret `AZURE_AD_APPLICATION_CLIENT_ID` |
+   | **Client Secret** | The secret *value* from step 1 | secret `AZURE_AD_APPLICATION_SECRET` |
+   | **Seller ID** | Partner Center → Account settings → Identifiers (a.k.a. Publisher/Seller ID) | secret `SELLER_ID` |
+   | **Store product ID** | 12-char ID from the Partner Center product URL, or `msstore apps list` after a local `msstore reconfigure` | **variable** `AETHERSDR_STORE_PRODUCT_ID` |
 
 3. **GitHub repo configuration** (Settings → Secrets and variables → Actions):
-   - Secrets: `AZURE_AD_TENANT_ID`, `AZURE_AD_APPLICATION_CLIENT_ID`,
-     `AZURE_AD_APPLICATION_SECRET`, `SELLER_ID`.
-   - Variable: `AETHERSDR_STORE_PRODUCT_ID` (the Store product ID). Leaving this
-     unset disables the upload step.
+   - Secrets (the four credentials above): `AZURE_AD_TENANT_ID`,
+     `AZURE_AD_APPLICATION_CLIENT_ID`, `AZURE_AD_APPLICATION_SECRET`,
+     `SELLER_ID`.
+   - Variable: `AETHERSDR_STORE_PRODUCT_ID` (the Store product ID). **Leaving
+     this unset keeps the whole Store-submission step disabled** — set it last,
+     once the four secrets are in place, to switch the automation on.
+
+4. **First run.** Cut a release (or re-tag) so a `v*` tag pushes. Watch the
+   *Stage Microsoft Store submission (draft)* step in the **Windows Installer**
+   workflow, then confirm a new **draft** submission appears in Partner Center.
+   Click **Submit to Store** there to start certification for the first
+   automated build; later you can promote to fully automatic (see below).
 
 ### Version discipline
 

--- a/packaging/windows/publish-store.ps1
+++ b/packaging/windows/publish-store.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Stage a Microsoft Store submission for an AetherSDR MSIX build.
+
+.DESCRIPTION
+    Wraps the Microsoft Store Developer CLI (`msstore`) publish step that the
+    Windows Installer workflow runs on a `v*` tag push. It locates the
+    `.msixupload` produced by create-msix.ps1 and hands it to `msstore publish`
+    for the given Store product Id.
+
+    By default it stages a DRAFT submission (`--noCommit`): the package is
+    uploaded to Partner Center but certification is NOT started. A maintainer
+    reviews the pending submission in Partner Center and clicks "Submit to
+    Store" to begin certification. Pass -Commit to skip the draft gate and send
+    the submission straight to certification (each tag goes live on approval).
+
+    Authentication is expected to already be configured via a prior
+    `msstore reconfigure` call (tenant/seller/client id + client secret), which
+    the workflow does from GitHub secrets.
+
+    Behavior on a missing package is deliberate: the MSIX build step in CI is
+    `continue-on-error`, so a flaky package build leaves no `.msixupload`. In
+    that case this script warns and exits 0 rather than turning an
+    already-completed release red — the missing-package failure is already
+    surfaced by the MSIX step's own annotation. A genuine publish API failure
+    still exits non-zero so it is visible.
+
+.PARAMETER ProductId
+    The 12-character Microsoft Store product Id for the AetherSDR listing.
+    Defaults to $env:AETHERSDR_STORE_PRODUCT_ID.
+
+.PARAMETER UploadGlob
+    Glob used to find the upload package. Defaults to the create-msix.ps1
+    naming convention "AetherSDR-*.msixupload".
+
+.PARAMETER SearchDir
+    Directory to search for the upload package. Defaults to the current
+    directory (where the workflow runs create-msix.ps1 with -OutputDir .).
+
+.PARAMETER Commit
+    Send the submission straight to certification instead of staging a draft.
+    Drops the `--noCommit` safety gate.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$ProductId = $env:AETHERSDR_STORE_PRODUCT_ID,
+    [string]$UploadGlob = "AetherSDR-*.msixupload",
+    [string]$SearchDir = ".",
+    [switch]$Commit
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($ProductId)) {
+    throw "ProductId is required. Set AETHERSDR_STORE_PRODUCT_ID or pass -ProductId."
+}
+
+$uploads = @(Get-ChildItem -LiteralPath $SearchDir -Filter $UploadGlob -File -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending)
+
+if ($uploads.Count -eq 0) {
+    Write-Warning ("No '$UploadGlob' found in '$SearchDir'; nothing to publish. " +
+        "The MSIX packaging step likely did not produce an upload package " +
+        "(it is continue-on-error). Skipping Store submission.")
+    exit 0
+}
+
+if ($uploads.Count -gt 1) {
+    $names = ($uploads | ForEach-Object { $_.Name }) -join ", "
+    throw "Expected exactly one '$UploadGlob' but found $($uploads.Count): $names. " +
+        "Refusing to guess which package to submit."
+}
+
+$upload = $uploads[0].FullName
+Write-Host "Store product Id : $ProductId"
+Write-Host "Upload package   : $upload"
+
+$publishArgs = @("publish", $upload, "-id", $ProductId)
+if (-not $Commit) {
+    # --noCommit (-nc) uploads the package but keeps the submission in DRAFT
+    # state; a maintainer commits it from Partner Center. This is the safety
+    # gate that keeps CI from pushing to the live channel on its own.
+    $publishArgs += "--noCommit"
+    Write-Host "Mode             : DRAFT (--noCommit; a maintainer submits from Partner Center)"
+}
+else {
+    Write-Host "Mode             : COMMIT (submission sent to certification)"
+}
+
+Write-Host "Running: msstore $($publishArgs -join ' ')"
+& msstore @publishArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "msstore publish failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Microsoft Store submission staged successfully."


### PR DESCRIPTION
## Summary

Automates Microsoft Store publishing as part of the weekly (Sunday) release
cycle. Today the **Windows Installer** workflow builds the `.msixupload` and
attaches it to the GitHub release; a maintainer then uploads it to Partner
Center by hand. This PR wires the upload step so that every `v*` tag **stages a
draft submission** to the Store via the Microsoft Store Developer CLI
(`msstore`).

**CI never publishes to the live channel on its own.** The submission is staged
with `--noCommit`, so it lands as a *draft* in Partner Center — a maintainer
reviews it and clicks **Submit to Store** to start certification.

The feature is **wired but dormant**: until the credentials below are set, the
workflow behaves exactly as it does today.

## What changed

- **`packaging/windows/publish-store.ps1`** (new) — finds the `.msixupload`
  produced by `create-msix.ps1` and runs
  `msstore publish <pkg> -id <ProductId> --noCommit`. If the (continue-on-error)
  MSIX step produced no upload, it warns and exits 0 rather than reddening an
  otherwise-successful release.
- **`.github/workflows/windows-installer.yml`** — adds *Setup Microsoft Store
  Developer CLI* (`microsoft/microsoft-store-apppublisher@v1.1`, SHA-pinned) and
  *Stage Microsoft Store submission (draft)* after the release-attach step.
- **`docs/WINDOWS-STORE-MSIX.md`** — flips the section from PLANNED → WIRED and
  expands the one-time Entra/Partner Center setup into a concrete checklist.

## Guard rails (all must pass before Partner Center is touched)

1. **Tag-only** — runs only on a `refs/tags/` ref (never PRs or branch dispatch).
2. **Opt-in** — skipped unless the `AETHERSDR_STORE_PRODUCT_ID` repo *variable*
   is set. Absent ⇒ the whole step is a no-op.
3. **Forks can't read secrets** — so `reconfigure` is a no-op on forks even on a
   tag.
4. **Draft gate** — `--noCommit` keeps it out of certification until a human
   submits.

Eligibility is already met: the `msstore` GitHub Actions path supports
**free products** (AetherSDR qualifies) and requires the app to be **already
live** in the Store (it is — two prior manual submissions).

## Credentials the maintainer (@jensenpat) will provide

These are configured outside the repo (Entra ID + Partner Center) and then
stored in **Settings → Secrets and variables → Actions**. Posting the full
table so maintainers know exactly what is coming and why:

| Concept | What it is | How it's obtained | Stored in GitHub as |
|---|---|---|---|
| **Directory** | A Microsoft **Entra ID tenant** on the Partner Center account | Partner Center → Account settings → **Tenants** → *Create Microsoft Entra ID* (free; skipped if one exists) | — |
| **Service account** | An **Entra app registration** + client secret | entra.microsoft.com → App registrations → New registration; Certificates & secrets → new secret | — |
| **Authorization** | The app holds the **Manager** role | Partner Center → User management → *Microsoft Entra applications* → add the app, assign **Manager** | — |
| Tenant ID | Entra → Overview | copy | secret `AZURE_AD_TENANT_ID` |
| Client ID | App registration's *Application (client) ID* | copy | secret `AZURE_AD_APPLICATION_CLIENT_ID` |
| Client Secret | the secret **value** (shown once) | copy at creation | secret `AZURE_AD_APPLICATION_SECRET` |
| Seller ID | Partner Center → Account settings → Identifiers | copy | secret `SELLER_ID` |
| Store product ID | 12-char ID from the product's Partner Center URL | copy | **variable** `AETHERSDR_STORE_PRODUCT_ID` ← set **last** to switch the automation on |

> ⚠️ Set `AETHERSDR_STORE_PRODUCT_ID` **last**, after the four secrets are in
> place. The workflow gates on this variable being non-empty, so setting it is
> what flips the feature from dormant to active. (This is also why the PR does
> not pre-create it — a placeholder would enable the step before the secrets
> exist and fail every release.)

## Version discipline

Each Store submission must carry a higher `Identity.Version` than the live one.
The MSIX version derives from `project(AetherSDR VERSION ...)` in
`CMakeLists.txt`; the existing release-prep version bump already guarantees a
newer version each release.

## Promoting to fully automatic later

Drop `--noCommit` in `publish-store.ps1` to send each tag straight to
certification, or publish to a **flight/insider ring** first with `-f <flightId>`
and promote manually. Keep the draft gate until the weekly cadence is proven.

## Testing

- Workflow YAML validated (`yaml.safe_load`).
- Dormant by default — no behavior change until the variable is set, so this
  merges safely ahead of the credential setup.

---

💻 Generated with Claude Code (Fable 5.0) with architecture by @jensenpat
