### PR TITLE
[codex] Fix DEXP protocol mapping

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2931,9 +2931,6 @@ void MainWindow::closeEvent(QCloseEvent* event)
     s.setValue("ClientDfnrEnabled", m_audio->dfnrEnabled() ? "True" : "False");
     s.setValue("ClientMnrEnabled", m_audio->mnrEnabled() ? "True" : "False");
     // BNR not persisted — requires manual enable each session
-    // DEXP saved on-change in PhoneApplet — do NOT overwrite here, because
-    // the radio may have reset DEXP to off (model reflects radio state, not
-    // the user's preference).
 
     s.save();
 

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1762,7 +1762,7 @@ void MainWindow::registerMidiParams()
 
     reg("phone.procEnable", "Speech Processor", "Phone/CW", P::Toggle, 0, 1,
         [this](float v) { m_radioModel.transmitModel().setSpeechProcessorEnable(v > 0.5f); },
-        [this]() -> float { return m_radioModel.transmitModel().companderOn() ? 1 : 0; });
+        [this]() -> float { return m_radioModel.transmitModel().speechProcessorEnable() ? 1 : 0; });
 
     reg("phone.daxEnable", "DAX", "Phone/CW", P::Toggle, 0, 1,
         [this](float v) { m_radioModel.transmitModel().setDax(v > 0.5f); },

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -701,7 +701,7 @@ void MainWindow::registerShortcutActions()
         QKeySequence(), [this]() {
             if (!m_radioModel.isConnected()) return;
             auto& tx = m_radioModel.transmitModel();
-            tx.setSpeechProcessorEnable(!tx.companderOn());
+            tx.setSpeechProcessorEnable(!tx.speechProcessorEnable());
         });
     m_shortcutManager.registerAction("dax_toggle", "DAX TX Toggle", "TX",
         QKeySequence(), [this]() {

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -196,16 +196,6 @@ void MainWindow::onSliceAdded(SliceModel* s)
                 QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setMnrEnabled(true); });
             // BNR not auto-restored — requires manual enable each session
 
-            // Restore DEXP (downward expander) — radio does not persist across sessions
-            bool dexpSaved = settings.value("DexpEnabled", "False").toString() == "True";
-            int dexpLevel = settings.value("DexpLevel", "0").toInt();
-            if (dexpSaved) {
-                m_radioModel.transmitModel().setDexp(true);
-                if (dexpLevel > 0) {
-                    m_radioModel.transmitModel().setDexpLevel(dexpLevel);
-                }
-            }
-
             refreshCwDecodeState();
             refreshRttyDecodeState();
         });

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -2,7 +2,6 @@
 #include "GuardedSlider.h"
 #include "models/TransmitModel.h"
 #include "Theme.h"
-#include "core/AppSettings.h"
 
 #include <QPushButton>
 #include <QLabel>
@@ -213,9 +212,6 @@ void PhoneApplet::buildUI()
     }
 
     // ── DEXP row: toggle + level slider ────────────────────────────────
-    // NOTE: DEXP (downward expander / noise gate) commands return error
-    // 0x5000002D on firmware v1.4.0.0. UI is present but non-functional
-    // until the correct protocol command is identified. See GitHub issue.
     {
         auto* rowW = new QWidget;
         rowW->setFixedHeight(24);
@@ -232,9 +228,6 @@ void PhoneApplet::buildUI()
         connect(m_dexpBtn, &QPushButton::toggled, this, [this](bool on) {
             if (!m_updatingFromModel && m_model) {
                 m_model->setDexp(on);
-                auto& s = AppSettings::instance();
-                s.setValue("DexpEnabled", on ? "True" : "False");
-                s.save();
             }
         });
         row->addWidget(m_dexpBtn);
@@ -249,9 +242,6 @@ void PhoneApplet::buildUI()
         connect(m_dexpSlider, &QSlider::valueChanged, this, [this](int v) {
             if (!m_updatingFromModel && m_model) {
                 m_model->setDexpLevel(v);
-                auto& s = AppSettings::instance();
-                s.setValue("DexpLevel", QString::number(v));
-                s.save();
             }
             m_dexpLabel->setText(QString::number(v));
         });

--- a/src/gui/PhoneApplet.h
+++ b/src/gui/PhoneApplet.h
@@ -19,7 +19,7 @@ class TransmitModel;
 //  - AM Carrier level slider
 //  - VOX toggle + level slider
 //  - VOX delay slider
-//  - DEXP toggle + level slider (non-functional on fw v1.4.0.0)
+//  - DEXP toggle + level slider
 //  - TX filter: Low Cut / High Cut step buttons
 class PhoneApplet : public QWidget {
     Q_OBJECT
@@ -48,7 +48,7 @@ private:
     QSlider* m_voxDelaySlider{nullptr};
     QLabel*  m_voxDelayLabel{nullptr};
 
-    // DEXP (non-functional on fw v1.4.0.0 — see GitHub issue)
+    // DEXP (radio compander control)
     QPushButton* m_dexpBtn{nullptr};
     GuardedSlider* m_dexpSlider{nullptr};
     QLabel*      m_dexpLabel{nullptr};

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -65,6 +65,7 @@ void TransmitModel::applyTransmitStatus(const QMap<QString, QString>& kvs)
 
     // ── Mic / monitor / processor keys ──────────────────────────────────────
     bool micChanged = false;
+    bool phoneChanged = false;
 
     if (kvs.contains("mic_selection")) {
         QString v = kvs["mic_selection"].toUpper();
@@ -89,10 +90,12 @@ void TransmitModel::applyTransmitStatus(const QMap<QString, QString>& kvs)
     if (kvs.contains("compander")) {
         bool v = kvs["compander"] == "1";
         if (m_companderOn != v) { m_companderOn = v; micChanged = true; }
+        if (m_dexpOn != v) { m_dexpOn = v; phoneChanged = true; }
     }
     if (kvs.contains("compander_level")) {
         int v = qBound(0, kvs["compander_level"].toInt(), 100);
         if (m_companderLevel != v) { m_companderLevel = v; micChanged = true; }
+        if (m_dexpLevel != v) { m_dexpLevel = v; phoneChanged = true; }
     }
     if (kvs.contains("dax")) {
         bool v = kvs["dax"] == "1";
@@ -108,7 +111,6 @@ void TransmitModel::applyTransmitStatus(const QMap<QString, QString>& kvs)
     }
 
     // ── VOX keys ───────────────────────────────────────────────────────────
-    bool phoneChanged = false;
 
     if (kvs.contains("vox_enable")) {
         bool v = kvs["vox_enable"] == "1";
@@ -142,12 +144,14 @@ void TransmitModel::applyTransmitStatus(const QMap<QString, QString>& kvs)
         int v = qBound(0, kvs["am_carrier_level"].toInt(), 100);
         if (m_amCarrierLevel != v) { m_amCarrierLevel = v; phoneChanged = true; }
     }
-    if (kvs.contains("dexp")) {
+    if (kvs.contains("dexp") && !kvs.contains("compander")) {
         bool v = kvs["dexp"] == "1";
+        if (m_companderOn != v) { m_companderOn = v; micChanged = true; }
         if (m_dexpOn != v) { m_dexpOn = v; phoneChanged = true; }
     }
-    if (kvs.contains("noise_gate_level")) {
+    if (kvs.contains("noise_gate_level") && !kvs.contains("compander_level")) {
         int v = qBound(0, kvs["noise_gate_level"].toInt(), 100);
+        if (m_companderLevel != v) { m_companderLevel = v; micChanged = true; }
         if (m_dexpLevel != v) { m_dexpLevel = v; phoneChanged = true; }
     }
     bool filterCutoffChanged = false;
@@ -619,19 +623,24 @@ void TransmitModel::setAmCarrierLevel(int level)
 
 void TransmitModel::setDexp(bool on)
 {
-    // Optimistic update — radio may not echo dexp in incremental status
+    // FlexLib v4.2.18 and a SmartSDR v4.2.20 capture show DEXP is the
+    // radio's compander control; older dexp/noise_gate keys are rejected.
     m_dexpOn = on;
+    m_companderOn = on;
     emit phoneStateChanged();
-    emit commandReady(QString("transmit set dexp=%1").arg(on ? 1 : 0));
+    emit micStateChanged();
+    emit commandReady(QString("transmit set compander=%1").arg(on ? 1 : 0));
 }
 
 void TransmitModel::setDexpLevel(int level)
 {
     level = qBound(0, level, 100);
-    // Optimistic update — radio may not echo noise_gate_level in incremental status
+    // See setDexp(): SmartSDR backs DEXP level with compander_level.
     m_dexpLevel = level;
+    m_companderLevel = level;
     emit phoneStateChanged();
-    emit commandReady(QString("transmit set noise_gate_level=%1").arg(level));
+    emit micStateChanged();
+    emit commandReady(QString("transmit set compander_level=%1").arg(level));
 }
 
 void TransmitModel::setTxFilterLow(int hz)

--- a/tests/transmit_model_test.cpp
+++ b/tests/transmit_model_test.cpp
@@ -67,6 +67,41 @@ int main(int argc, char** argv)
     ok &= expect(commands.isEmpty(),
                  "invalid tune mode is ignored");
 
+    commands.clear();
+    tx.setDexp(true);
+    ok &= expect(commands == QStringList({"transmit set compander=1"})
+                 && tx.dexpOn()
+                 && tx.companderOn(),
+                 "DEXP toggle sends compander command and updates local state");
+
+    commands.clear();
+    tx.setDexpLevel(42);
+    ok &= expect(commands == QStringList({"transmit set compander_level=42"})
+                 && tx.dexpLevel() == 42
+                 && tx.companderLevel() == 42,
+                 "DEXP level sends compander_level command and updates local state");
+
+    tx.applyTransmitStatus({{"compander", "0"}, {"compander_level", "17"}});
+    ok &= expect(!tx.dexpOn()
+                 && !tx.companderOn()
+                 && tx.dexpLevel() == 17
+                 && tx.companderLevel() == 17,
+                 "compander status updates DEXP state");
+
+    tx.applyTransmitStatus({{"compander", "1"}, {"dexp", "0"}, {"compander_level", "33"}, {"noise_gate_level", "9"}});
+    ok &= expect(tx.dexpOn()
+                 && tx.companderOn()
+                 && tx.dexpLevel() == 33
+                 && tx.companderLevel() == 33,
+                 "canonical compander status wins over legacy DEXP aliases");
+
+    tx.applyTransmitStatus({{"dexp", "0"}, {"noise_gate_level", "8"}});
+    ok &= expect(!tx.dexpOn()
+                 && !tx.companderOn()
+                 && tx.dexpLevel() == 8
+                 && tx.companderLevel() == 8,
+                 "legacy DEXP aliases update state when canonical compander status is absent");
+
     tx.setPttPreflight([](TransmitModel::PttSource source) {
         return source == TransmitModel::PttSource::Tune
             ? QStringLiteral("blocked")


### PR DESCRIPTION
## Summary

Fixes #3464 by wiring the PHONE applet DEXP controls to the radio protocol keys that SmartSDR actually uses:

- `transmit set compander=0/1` for the DEXP toggle
- `transmit set compander_level=<0..100>` for the DEXP threshold slider

The reporter provided a SmartSDR capture on #3464 showing those command/status keys during DEXP toggle and slider changes, and FlexLib v4.2.18 exposes the same `CompanderOn` / `CompanderLevel` commands. AetherSDR was previously sending `transmit set dexp=...` and `transmit set noise_gate_level=...`, which the radio rejects, so the UI could look changed while radio-side DEXP never changed.

## What Changed

- Map incoming `compander` / `compander_level` transmit status into the existing DEXP model state so the PHONE applet follows radio-authoritative state.
- Change `TransmitModel::setDexp()` and `setDexpLevel()` to emit `compander` / `compander_level` commands.
- Remove client-side `DexpEnabled` / `DexpLevel` persistence and reconnect restore logic. DEXP is radio-side state; AetherSDR should not replay stale local settings over the radio on reconnect.
- Fix two stale Speech Processor state reads that were checking `companderOn()` instead of `speechProcessorEnable()`.
- Add focused `TransmitModel` regression coverage for DEXP command emission and compander status parsing.

## Maintainer Notes

This intentionally leaves the visible UI label as `DEXP`; the protocol field is named `compander`, but the user-facing control is still the downward expander/noise gate. `PROC` remains backed by the separate `speech_processor_enable` / `speech_processor_level` protocol keys.

## Validation

- `cmake --build build --target transmit_model_test --parallel`
- `./build/transmit_model_test`
- `cmake --build build --target AetherSDR --parallel`
- `python3 tools/check_a11y.py src/gui/PhoneApplet.cpp src/gui/PhoneApplet.h src/gui/MainWindow.cpp src/gui/MainWindow_Controllers.cpp src/gui/MainWindow_Shortcuts.cpp src/gui/MainWindow_Wiring.cpp`
- `git diff --check upstream/main...HEAD`

Fixes #3464.