### PR TITLE
[codex] Defer ping watchdog during Multi-Flex joins

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2708,6 +2708,8 @@ void RadioModel::startNetworkMonitor()
     m_maxPingRtt = 0;
     m_pingMissCount = 0;
     m_pingDisconnectTriggered = false;
+    m_lastMultiFlexClientConnectMs = 0;
+    m_multiFlexPingGraceUntilMs = 0;
     m_pendingThrottleLift = false;
     // Safety: ensure MainWindow's m_adaptiveThrottleActive is cleared even if
     // the connectionStateChanged(false) path was somehow skipped.  Pans are not
@@ -2738,8 +2740,38 @@ void RadioModel::startNetworkMonitor()
                                       ? PING_MISS_DISCONNECT_POOR
                                       : PING_MISS_DISCONNECT;
         if (m_pingMissCount >= missThreshold) {
-            if (m_pingDisconnectTriggered)
+            const qint64 now = QDateTime::currentMSecsSinceEpoch();
+            if (now < m_multiFlexPingGraceUntilMs) {
+                qCDebug(lcProtocol) << "RadioModel: deferring ping disconnect during Multi-Flex client-connect grace"
+                                    << "misses:" << m_pingMissCount
+                                    << "remaining_ms:" << (m_multiFlexPingGraceUntilMs - now);
+                sendCmd("ping");
                 return;
+            }
+
+            // A new Multi-Flex GUI can briefly starve TCP ping replies while
+            // the radio replays status and stream ownership. If that burst
+            // overlaps the missed-ping window, grant one short grace period
+            // before treating the TCP control path as dead.
+            const qint64 recentClientConnectWindowMs =
+                static_cast<qint64>(missThreshold + 1) * m_pingTimer.interval();
+            const bool recentMultiFlexClientConnect =
+                m_lastMultiFlexClientConnectMs > 0
+                && now >= m_lastMultiFlexClientConnectMs
+                && now - m_lastMultiFlexClientConnectMs <= recentClientConnectWindowMs;
+            if (recentMultiFlexClientConnect) {
+                m_multiFlexPingGraceUntilMs = now + MULTIFLEX_CLIENT_CONNECT_PING_GRACE_MS;
+                qCDebug(lcProtocol) << "RadioModel: deferring ping disconnect after recent Multi-Flex client connect"
+                                    << "misses:" << m_pingMissCount
+                                    << "since_client_connect_ms:" << (now - m_lastMultiFlexClientConnectMs)
+                                    << "grace_ms:" << MULTIFLEX_CLIENT_CONNECT_PING_GRACE_MS;
+                sendCmd("ping");
+                return;
+            }
+
+            if (m_pingDisconnectTriggered) {
+                return;
+            }
 
             m_pingDisconnectTriggered = true;
             m_pingTimer.stop();
@@ -3918,6 +3950,15 @@ void RadioModel::onStatusReceived(const QString& object,
                 client.source = source;
                 client.localPtt = ptt;
                 m_clientInfoMap[handle] = client;
+                if (handle != clientHandle()) {
+                    m_lastMultiFlexClientConnectMs = QDateTime::currentMSecsSinceEpoch();
+                    qCDebug(lcProtocol).noquote()
+                        << "RadioModel: noted Multi-Flex client connect for ping grace"
+                        << QStringLiteral("handle=%1").arg(hexId(handle))
+                        << QStringLiteral("program=%1").arg(program)
+                        << QStringLiteral("station=%1").arg(station)
+                        << QStringLiteral("source=%1").arg(source.isEmpty() ? QStringLiteral("direct") : source);
+                }
                 emitOtherClientsChanged();
                 if (!shouldSuppressClientConnectionNotice(handle))
                     announceClientConnection(handle, source, station, program);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -891,11 +891,14 @@ private:
     NetState      m_netState{NetState::Off};
     int           m_pingMissCount{0};          // consecutive unanswered pings
     bool          m_pingDisconnectTriggered{false};
+    qint64        m_lastMultiFlexClientConnectMs{0};
+    qint64        m_multiFlexPingGraceUntilMs{0};
     // Normal: disconnect after 5 unanswered pings (~5 s).
     // Poor: allow 15 (~15 s) — adaptive throttle has already cut UDP load, so
     // brief TCP stalls are more likely to be transient congestion than a dead link.
     static constexpr int PING_MISS_DISCONNECT      = 5;
     static constexpr int PING_MISS_DISCONNECT_POOR = 15;
+    static constexpr qint64 MULTIFLEX_CLIENT_CONNECT_PING_GRACE_MS = 5000;
     // Minimum time at a throttled state before the throttle is allowed to lift.
     // Prevents Good<->VeryGood oscillation: reducing fps lowers UDP load which
     // improves the score, which would immediately lift the throttle and restart


### PR DESCRIPTION
## Summary

Fixes a Multi-Flex reconnect false-positive where AetherSDR could force-disconnect after 5 unanswered pings while another SmartSDR client was joining and the radio was replaying status/stream ownership. The ping watchdog now records recent foreign `client ... connected` status messages and grants one 5-second grace period if the missed-ping threshold overlaps that client-connect burst. This keeps the normal watchdog behavior unchanged outside the Multi-Flex connect window.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The fix is based on logs showing the prior failure path (`5 consecutive pings unanswered — forcing disconnect`) immediately after SmartSDR connected, and was verified with a reproduction log where the watchdog reached 5 misses but deferred instead of disconnecting.

## Test plan

- [x] Local build passes (`cmake --build build --parallel`)
- [x] Behavior verified on a real radio
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Reproduction verification:
- Start AetherSDR with 4 panadapters and 5 slices.
- Start SmartSDR from another computer and let it restore multiple panadapters/slices.
- Confirm AetherSDR remains connected and keeps its own waterfall/audio streams.

Observed in `aethersdr-20260614-001547.log`:
- SmartSDR connected as `0x106E3651`.
- AetherSDR logged `noted Multi-Flex client connect for ping grace`.
- The watchdog reached `misses: 5`.
- AetherSDR logged `deferring ping disconnect after recent Multi-Flex client connect ... grace_ms: 5000`.
- No forced disconnect followed.
- AetherSDR kept owned `remote_audio_rx 0x04000008` and ignored SmartSDR's `remote_audio_rx 0x04000009`.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] All meter UI uses `MeterSmoother` (Principle II)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
