### PR TITLE
[codex] Consolidate profile load hold timing

### DIFF
--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -776,7 +776,6 @@ void MainWindow::beginProfileLoadRadioStateWriteHold(const QString& profileType,
         return;
     }
 
-    constexpr qint64 kProfileLoadStateWriteHoldMs = 10000;
     const qint64 untilMs = QDateTime::currentMSecsSinceEpoch() + kProfileLoadStateWriteHoldMs;
     m_profileLoadRadioStateWriteHoldUntilMs =
         std::max(m_profileLoadRadioStateWriteHoldUntilMs, untilMs);
@@ -932,7 +931,6 @@ void MainWindow::scheduleProfileLoadRecovery(const QString& profileType,
         return;
     }
 
-    constexpr qint64 kProfileLoadStateWriteHoldMs = 10000;
     const qint64 untilMs = QDateTime::currentMSecsSinceEpoch() + kProfileLoadStateWriteHoldMs;
     m_profileLoadRadioStateWriteHoldUntilMs =
         std::max(m_profileLoadRadioStateWriteHoldUntilMs, untilMs);
@@ -958,10 +956,10 @@ void MainWindow::scheduleProfileLoadRecovery(const QString& profileType,
     QTimer::singleShot(3500, this, [this]() {
         flushPendingProfileLoadPanDimensions();
     });
-    QTimer::singleShot(11000, this, [this]() {
+    QTimer::singleShot(kProfileLoadDeferredPanFlushDelayMs, this, [this]() {
         flushPendingProfileLoadPanDimensions();
     });
-    QTimer::singleShot(11250, this, [this]() {
+    QTimer::singleShot(kProfileLoadPostHoldRecoveryDelayMs, this, [this]() {
         reacquireNoiseFloorLocksAfterProfileLoad();
 #ifdef HAVE_WEBSOCKETS
         if (tciServer()) {

--- a/src/models/ProfileLoadCommand.h
+++ b/src/models/ProfileLoadCommand.h
@@ -2,6 +2,7 @@
 
 #include <QRegularExpression>
 #include <QString>
+#include <QtGlobal>
 
 namespace AetherSDR {
 
@@ -10,6 +11,16 @@ struct ProfileLoadCommand {
     QString type;
     QString name;
 };
+
+inline constexpr qint64 kProfileLoadStateWriteHoldMs = 10000;
+inline constexpr int kProfileLoadDeferredPanFlushDelayMs =
+    static_cast<int>(kProfileLoadStateWriteHoldMs + 1000);
+inline constexpr int kProfileLoadPostHoldRecoveryDelayMs =
+    static_cast<int>(kProfileLoadStateWriteHoldMs + 1250);
+
+// Internal sentinel for commands AetherSDR suppresses before sending to the
+// radio during profile recall. This is not a SmartSDR protocol response code.
+inline constexpr int kProfileLoadSuppressedCommandCode = 0x50000061;
 
 inline bool profileLoadMayRebuildRadioTopology(const QString& profileType)
 {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -83,8 +83,6 @@ bool statusFlagSet(const QMap<QString, QString>& kvs, const QString& key)
         || value.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0;
 }
 
-constexpr qint64 kProfileLoadStateWriteHoldMs = 10000;
-
 bool isProfileOwnedRadioStateWrite(const QString& command)
 {
     const QString trimmed = command.trimmed();
@@ -3653,7 +3651,8 @@ quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
             << "RadioModel: suppressing profile-load radio-state write"
             << command;
         if (cb) {
-            cb(0x50000061, QStringLiteral("suppressed during profile load"));
+            cb(kProfileLoadSuppressedCommandCode,
+               QStringLiteral("suppressed during profile load"));
         }
         return 0;
     }

--- a/tests/profile_load_command_test.cpp
+++ b/tests/profile_load_command_test.cpp
@@ -56,6 +56,10 @@ int main()
 
     check(!parseProfileLoadCommand(QStringLiteral("profile global save \"SO2R\"")).valid,
           "non-load profile command is ignored");
+    check(kProfileLoadDeferredPanFlushDelayMs > kProfileLoadStateWriteHoldMs,
+          "deferred pan flush runs after profile-load write hold");
+    check(kProfileLoadPostHoldRecoveryDelayMs > kProfileLoadDeferredPanFlushDelayMs,
+          "post-hold recovery runs after deferred pan flush");
 
     return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Fixes #3572. This follow-up consolidates the profile-load radio-state write hold into the shared profile-load command helper, derives the delayed pan-dimension flush and post-hold recovery timers from that same hold window, and names the internal suppressed-write sentinel so it is clear the callback is not reporting a SmartSDR protocol response. The goal is to keep AetherSDR from sending profile-owned slice/panadapter state back to the radio while the radio is still restoring its saved profile/session layout.

## Constitution principle honored

Principle I - FlexLib Is The Protocol Authority. The change keeps profile recall radio-state timing centralized around the radio-authoritative profile-load path instead of scattering independent magic delays through the client.

## Test plan

- [x] Local build passes (`cmake --build build --target profile_load_command_test AetherSDR aprs_packet_test aprs_messenger_test -j4`)
- [ ] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Local validation run:

- `ctest --test-dir build --output-on-failure -R 'profile_load_command_test|profile_transfer_test|radio_status_ownership_test|slice_recreate_policy_test|transmit_model_test'`
- `ctest --test-dir build --output-on-failure -E '^theme_manager_test$'`
- `git diff --check`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls - use nested-JSON-under-one-key (Principle V)
- [x] All meter UI uses `MeterSmoother` (Principle II)
- [x] Documentation updated if user-visible behavior changed (no user-facing docs needed; internal timing comment/test updated)
- [x] Security-sensitive changes reference a GHSA if applicable
