### PR TITLE
feat(spectrum): continuous edge auto-pan while dragging a slice

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5651,25 +5651,35 @@ MainWindow::BandStackPreselectResult MainWindow::preselectBandStackForTune(
     return BandStackPreselectResult::Selected;
 }
 
+bool MainWindow::tuneBlockedByGuards(SliceModel* slice)
+{
+    if (!slice)
+        return true;
+    if (m_swrSweep.running)
+        return true;
+    if (slice->isLocked()) {
+        slice->notifyTuneBlockedByLock();
+        auto* sw = spectrumForSlice(slice);
+        if (slice->sliceId() == m_activeSliceId && sw) {
+            m_updatingFromModel = true;
+            sw->setVfoFrequency(slice->frequency());
+            m_updatingFromModel = false;
+        }
+        return true;
+    }
+    return false;
+}
+
 void MainWindow::applyTuneRequest(SliceModel* slice, double mhz,
                                   TuneIntent intent, const char* source)
 {
     if (!slice)
         return;
-    if (m_swrSweep.running)
+    if (tuneBlockedByGuards(slice))
         return;
 
     const double oldFreqMhz = slice->frequency();
     auto* sw = spectrumForSlice(slice);
-    if (slice->isLocked()) {
-        slice->notifyTuneBlockedByLock();
-        if (slice->sliceId() == m_activeSliceId && sw) {
-            m_updatingFromModel = true;
-            sw->setVfoFrequency(oldFreqMhz);
-            m_updatingFromModel = false;
-        }
-        return;
-    }
 
     // Absolute-target intents (typed VFO entry, spectrum click, spot recall,
     // bandstack recall) must invalidate any in-flight encoder accumulator.

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -259,6 +259,11 @@ private:
                                                        const char* source);
     void applyTuneRequest(SliceModel* slice, double mhz,
                           TuneIntent intent, const char* source);
+    // Lock / SWR-sweep guards shared by every tune source.  Returns true if the
+    // tune must be blocked (and, for a locked active slice, restores the VFO
+    // readout).  Lets the edge-pan tune path — which bypasses applyTuneRequest
+    // to avoid pan-follow — still honour the same lock/sweep affordances.
+    bool tuneBlockedByGuards(SliceModel* slice);
     void applyPanRangeRequest(const QString& panId, double centerMhz,
                               double bandwidthMhz, const char* source);
     // leftFlagEdgeOffsetMhz / rightFlagEdgeOffsetMhz extend the trigger

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1843,6 +1843,13 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         if (!target) {
             return;
         }
+        // Honour the same lock / SWR-sweep guards as applyTuneRequest: bypassing
+        // it (to avoid pan-follow) must not also drop the lock affordance or
+        // retune mid-sweep. A blocked tune pans nothing either, matching the
+        // pre-existing locked-slice drag behaviour.
+        if (tuneBlockedByGuards(target)) {
+            return;
+        }
         if (auto* pan = m_radioModel.panadapter(target->panId())) {
             centerMhz = std::max(centerMhz, pan->bandwidthMhz() / 2.0);
             // In-window drag moves pass the unchanged center purely to tune
@@ -1855,6 +1862,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         }
         queueActiveSliceForSpectrumTarget(target->sliceId());
         target->setFrequency(sliceFreqMhz);
+        mirrorDiversityChildFrequency(target, sliceFreqMhz);  // keep diversity child in step
     });
 
     // ── Spot trigger — notify the radio/TCI clients when a spot label is clicked (#341)

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1831,6 +1831,32 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // conjure a slice; click is the explicit "create here" affordance.
     });
 
+    // ── Edge auto-pan step during slice drag (user-reported) ─────────────────
+    // Pan the view AND tune the slice in one shot, deliberately bypassing the
+    // pan-follow/reveal path: the SpectrumWidget already computed the explicit
+    // center, so re-running reveal here would fight the velocity controller.
+    // The slice tune uses setFrequency (autopan=0), so the radio doesn't
+    // recenter either.
+    connect(sw, &SpectrumWidget::edgePanTuneRequested,
+            this, [this, resolveSpectrumTuneTarget](double centerMhz, double sliceFreqMhz) {
+        auto* target = resolveSpectrumTuneTarget();
+        if (!target) {
+            return;
+        }
+        if (auto* pan = m_radioModel.panadapter(target->panId())) {
+            centerMhz = std::max(centerMhz, pan->bandwidthMhz() / 2.0);
+            // In-window drag moves pass the unchanged center purely to tune
+            // without reveal — only emit the pan command when it actually moves.
+            if (!qFuzzyCompare(centerMhz, pan->centerMhz())) {
+                m_radioModel.sendCommand(
+                    QString("display pan set %1 center=%2")
+                        .arg(pan->panId()).arg(centerMhz, 0, 'f', 6));
+            }
+        }
+        queueActiveSliceForSpectrumTarget(target->sliceId());
+        target->setFrequency(sliceFreqMhz);
+    });
+
     // ── Spot trigger — notify the radio/TCI clients when a spot label is clicked (#341)
     connect(sw, &SpectrumWidget::spotTriggered, this, [this, applet](int spotIndex) {
         const auto& spots = m_radioModel.spotModel().spots();

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -642,6 +642,32 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     });
     createFpsMeterLabels();
 
+    // Continuous edge auto-pan while dragging a slice (user-reported).  While the
+    // cursor sits in the edge zone this timer drives a real pan velocity (see
+    // edgePanVelocityStep) so the band keeps scrolling without further
+    // mouse-move events.  Velocity knobs are env-tunable so the feel can be
+    // swept without rebuilding; AETHER_NO_DRAG_EDGEPAN=1 disables the whole
+    // thing (restores the legacy reveal-only behaviour for A/B testing).
+    m_vfoDragEdgePanDisabled = qEnvironmentVariableIntValue("AETHER_NO_DRAG_EDGEPAN") != 0;
+    if (int v = qEnvironmentVariableIntValue("AETHER_DRAG_EDGEPAN_VMAX"); v > 0) {
+        m_edgePanVmaxPctBw = v;
+    }
+    if (int v = qEnvironmentVariableIntValue("AETHER_DRAG_EDGEPAN_RAMP"); v > 0) {
+        m_edgePanRampMs = v;
+    }
+    if (int v = qEnvironmentVariableIntValue("AETHER_DRAG_EDGEPAN_INTERVAL"); v > 0) {
+        m_edgePanIntervalMs = v;
+    }
+    m_vfoDragEdgePanTimer = new QTimer(this);
+    m_vfoDragEdgePanTimer->setInterval(m_edgePanIntervalMs);
+    connect(m_vfoDragEdgePanTimer, &QTimer::timeout, this, [this]() {
+        if (m_draggingVfo) {
+            edgePanVelocityStep();
+        } else {
+            m_vfoDragEdgePanTimer->stop();
+        }
+    });
+
     // Load display settings (panIndex 0 by default — loadSettings() can be
     // called again after setPanIndex() for multi-pan)
     loadSettings();
@@ -4251,6 +4277,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             if (mx >= left && mx <= right) {
                 emit sliceClicked(so.sliceId);
                 m_draggingVfo = true;
+                m_vfoDragLastX = mx;
                 m_vfoDragOffsetHz = static_cast<int>(
                     std::round((xToMhz(mx) - so.freqMhz) * 1.0e6));
                 setSpectrumCursor(Qt::ClosedHandCursor);
@@ -4286,6 +4313,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         // Click inside the filter passband → start VFO drag (#404)
         if (filterPassbandBodyHitAtPixel(mx, loX, hiX, kFilterEdgeGrabPx)) {
             m_draggingVfo = true;
+            m_vfoDragLastX = mx;
             m_vfoDragOffsetHz = static_cast<int>(std::round((xToMhz(mx) - ao->freqMhz) * 1.0e6));
             setSpectrumCursor(Qt::ClosedHandCursor);
             ev->accept();
@@ -4302,6 +4330,115 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
 }
 
 static QString spotMarkerTooltip(const SpectrumWidget::SpotMarker& sm);
+
+// Compute the slice target frequency under cursor X (offset-anchored, snapped)
+// Tune the slice for the live, in-window drag path (cursor not at the edge).
+// Deliberately routed through edgePanTuneRequested with the center UNCHANGED so
+// the whole drag bypasses pan-follow/reveal: reveal is a position controller
+// whose flag-extended trigger (#2761) fires asymmetrically a little inside the
+// edge — inside our velocity zone on the flag side — and fights the edge-pan,
+// producing a one-sided "rubber band" stutter.  With reveal out of the drag
+// path, in-window moves only tune; the velocity zone owns all panning.  The
+// MainWindow handler skips the redundant pan command when the center is
+// unchanged.  (user-reported)
+void SpectrumWidget::driveVfoDragTune(int mx, const char* phase)
+{
+    const double mhz = snapToStep(xToMhz(mx) - m_vfoDragOffsetHz / 1.0e6, m_stepHz);
+    qCDebug(lcPerf).nospace()
+        << "SliceDrag phase=" << phase
+        << " mx=" << mx << " w=" << width()
+        << " center=" << m_centerMhz << " bw=" << m_bandwidthMhz
+        << " tuneMhz=" << mhz;
+    emit edgePanTuneRequested(m_centerMhz, mhz);
+}
+
+// Start the edge-pan velocity timer while the cursor sits in the edge zone
+// (within kVfoDragEdgeZoneFrac of either border), stop it otherwise.  Returns
+// whether the cursor is currently in the edge zone, so the caller can skip the
+// normal in-window tune and let the timer own panning.  Restarts the hold ramp
+// each time the zone is (re-)entered.  (user-reported)
+bool SpectrumWidget::updateVfoDragEdgePan(int mx)
+{
+    const int zonePx = std::max(1, static_cast<int>(width() * kVfoDragEdgeZoneFrac));
+    const bool inEdgeZone = !m_vfoDragEdgePanDisabled
+        && ((mx <= zonePx) || (mx >= width() - zonePx));
+    if (!m_vfoDragEdgePanTimer) {
+        return inEdgeZone;
+    }
+    if (inEdgeZone) {
+        if (!m_vfoDragEdgePanTimer->isActive()) {
+            m_vfoDragEdgeHoldTicks = 0;     // fresh ramp on (re-)entry
+            m_vfoDragEdgePanTimer->start();
+        }
+    } else if (m_vfoDragEdgePanTimer->isActive()) {
+        m_vfoDragEdgePanTimer->stop();
+    }
+    return inEdgeZone;
+}
+
+// One edge-pan velocity tick: pan the view at a speed that scales with how deep
+// the cursor is in the edge zone (depth) and ramps up the longer it is held,
+// keeping the dragged slice parked just inside the leading edge.  Unlike the
+// reveal-follow
+// (a position controller whose nudge is bounded by the cursor's bounded
+// overshoot — the old "rubber band" creep), this is a velocity controller, so
+// the band sweeps continuously and reaches across the whole range.  Pans the
+// waterfall/overlay locally for an immediate response, then hands the
+// pan+tune to MainWindow via edgePanTuneRequested (no reveal).  (user-reported)
+void SpectrumWidget::edgePanVelocityStep()
+{
+    const int w = width();
+    const int zonePx = std::max(1, static_cast<int>(w * kVfoDragEdgeZoneFrac));
+    int borderDist;
+    double dir;
+    if (m_vfoDragLastX <= zonePx) {
+        borderDist = m_vfoDragLastX;
+        dir = -1.0;                          // pan toward lower frequencies
+    } else if (m_vfoDragLastX >= w - zonePx) {
+        borderDist = w - m_vfoDragLastX;
+        dir = 1.0;                           // pan toward higher frequencies
+    } else {
+        m_vfoDragEdgePanTimer->stop();         // cursor left the zone
+        return;
+    }
+
+    const double depth = std::clamp(
+        static_cast<double>(zonePx - borderDist) / static_cast<double>(zonePx), 0.0, 1.0);
+    ++m_vfoDragEdgeHoldTicks;
+    const double rampFactor = std::min(1.0,
+        static_cast<double>(m_vfoDragEdgeHoldTicks * m_edgePanIntervalMs)
+            / static_cast<double>(std::max(1, m_edgePanRampMs)));
+    const double vmaxBwPerSec = m_edgePanVmaxPctBw / 100.0;
+    const double deltaMhz = depth * rampFactor * vmaxBwPerSec * m_bandwidthMhz
+                          * (m_edgePanIntervalMs / 1000.0);
+    if (deltaMhz <= 0.0) {
+        return;
+    }
+
+    const double newCenter = std::max(m_centerMhz + dir * deltaMhz, m_bandwidthMhz / 2.0);
+    if (qFuzzyCompare(newCenter, m_centerMhz)) {
+        return;
+    }
+
+    reprojectWaterfall(m_centerMhz, m_bandwidthMhz, newCenter, m_bandwidthMhz);
+    m_centerMhz = newCenter;
+    markOverlayDirty();
+
+    // Park the slice a comfortable margin inside the leading edge rather than
+    // exactly under the cursor: the cursor is jammed against the window border,
+    // so following it literally pushes the slice (and its flag) off-screen.
+    // Clamping the reference X to the zone boundary keeps the slice visibly
+    // parked at the edge while the band scrolls under it, and stays continuous
+    // with the in-window path at the boundary.  (user-reported)
+    const int sliceX = std::clamp(m_vfoDragLastX, zonePx, w - zonePx);
+    const double sliceFreq = snapToStep(xToMhz(sliceX) - m_vfoDragOffsetHz / 1.0e6, m_stepHz);
+    qCDebug(lcPerf).nospace()
+        << "SliceDrag phase=edgepan dir=" << dir
+        << " depth=" << depth << " ramp=" << rampFactor
+        << " dMhz=" << deltaMhz << " center=" << m_centerMhz
+        << " sliceX=" << sliceX << " sliceMhz=" << sliceFreq;
+    emit edgePanTuneRequested(newCenter, sliceFreq);
+}
 
 void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
 {
@@ -4522,8 +4659,13 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
 
     if (m_draggingVfo) {
         const int mx = static_cast<int>(ev->position().x());
-        const double mhz = snapToStep(xToMhz(mx) - m_vfoDragOffsetHz / 1.0e6, m_stepHz);
-        emit incrementalTuneRequested(mhz);
+        m_vfoDragLastX = mx;
+        // In the edge zone the velocity timer owns panning (keeps the slice
+        // pinned under the cursor); only tune directly when in-window so a
+        // normal drag still tunes live.
+        if (!updateVfoDragEdgePan(mx)) {
+            driveVfoDragTune(mx, "move");
+        }
         ev->accept();
         return;
     }
@@ -4772,6 +4914,9 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
     }
     if (m_draggingVfo) {
         m_draggingVfo = false;
+        if (m_vfoDragEdgePanTimer)
+            m_vfoDragEdgePanTimer->stop();
+        m_vfoDragEdgeHoldTicks = 0;
         setSpectrumCursor(Qt::CrossCursor);
         ev->accept();
         return;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -474,6 +474,11 @@ signals:
     // Emitted when the user makes an incremental tuning gesture such as
     // wheel tuning or VFO drag.
     void incrementalTuneRequested(double mhz);
+    // Edge auto-pan step: pan the view to newCenterMhz AND tune the slice to
+    // sliceFreqMhz in one shot, WITHOUT triggering pan-follow/reveal (which is
+    // already accounted for by the explicit center).  Keeps the dragged slice
+    // pinned under the cursor while the band scrolls.  (user-reported)
+    void edgePanTuneRequested(double newCenterMhz, double sliceFreqMhz);
     void spotTriggered(int spotIndex);
     // Emitted when the user changes both center and bandwidth as one explicit
     // pan/zoom operation and the radio should apply them coherently. Splitting
@@ -853,6 +858,33 @@ private:
     // VFO passband drag state (#404)
     bool m_draggingVfo{false};
     int  m_vfoDragOffsetHz{0};  // Hz offset from VFO at grab point (#1120)
+    // Continuous edge auto-pan during VFO drag (user-reported).  The edge-follow
+    // pan (revealFrequencyIfNeeded) is a *position* controller — it nudges the
+    // slice a little past the trigger margin — not a *velocity* controller, so
+    // holding the cursor at the border produced a tiny, self-limiting creep
+    // (~0.1×span/s, the "rubber band" feel): the overshoot can't grow because
+    // the cursor can't move past the physical border.  Instead, while the
+    // cursor sits in the edge zone a timer drives a real pan *velocity* that
+    // scales with edge depth and ramps up with hold time, panning the view and
+    // keeping the slice pinned under the cursor via edgePanTuneRequested (a
+    // pan-without-reveal path, so it doesn't fight the follow logic).
+    QTimer* m_vfoDragEdgePanTimer{nullptr};
+    int  m_vfoDragLastX{0};                 // last cursor X during VFO drag (px)
+    int  m_vfoDragEdgeHoldTicks{0};         // ticks held in edge zone (ramp)
+    bool m_vfoDragEdgePanDisabled{false};   // AETHER_NO_DRAG_EDGEPAN=1 escape hatch
+    // Velocity knobs, env-tunable so the feel can be swept WITHOUT rebuilding:
+    //   AETHER_DRAG_EDGEPAN_VMAX     — top speed, % of span width per second
+    //   AETHER_DRAG_EDGEPAN_RAMP     — ms held to ramp from 0 → top speed
+    //   AETHER_DRAG_EDGEPAN_INTERVAL — timer interval ms (~30 Hz default)
+    int  m_edgePanVmaxPctBw{120};
+    int  m_edgePanRampMs{600};
+    int  m_edgePanIntervalMs{33};
+    // Edge zone width as a fraction of widget width (matches the incremental
+    // pan-follow trigger margin kIncrementalTriggerEdgeMarginFrac=0.05).
+    static constexpr double kVfoDragEdgeZoneFrac = 0.05;
+    void driveVfoDragTune(int mx, const char* phase);  // normal in-window tune
+    bool updateVfoDragEdgePan(int mx);                 // → true if in edge zone
+    void edgePanVelocityStep();                        // timer tick: velocity pan
     // dBm scale strip drag state
     static constexpr int DBM_STRIP_W = 36;  // width of the dBm scale strip
     static constexpr int DBM_ARROW_H = 14;  // height of each arrow button


### PR DESCRIPTION
## Summary
Continuous edge auto-pan while dragging a slice across the panadapter, so you can
sweep the whole band in one gesture without zooming in first. Fixes #3580.

Replaces the edge-follow *position* controller (`revealFrequencyIfNeeded`) —
whose nudge is bounded by the cursor's self-limiting overshoot at the frame
border (~0.1× span/s, the "rubber band" creep) — with a *velocity* controller:
while the cursor sits in the edge zone a ~30 Hz timer pans at a speed that scales
with edge depth and ramps with hold time (~1.2× span/s at full depth+ramp),
parking the slice just inside the leading edge so it stays visible while the band
scrolls under it. Pan+tune go through a new `edgePanTuneRequested` signal that
bypasses pan-follow so the two controllers can't fight; reveal is removed from
the drag path entirely (in-window moves tune-only). This also removes a
one-sided stutter/jump-back caused by the flag-extended trigger (#2761) firing
asymmetrically just inside the edge on the flag side.

## ⚠️ Maintainer decision needed (UX)
This is a UX behaviour change — per AGENTS.md not an autonomous change. The
**velocity defaults** (top speed / ramp / interval) are a feel decision and need
your sign-off. They're exposed as env overrides so you can tune them live without
rebuilding:
- `AETHER_DRAG_EDGEPAN_VMAX` — top speed, % of span per second (default 120)
- `AETHER_DRAG_EDGEPAN_RAMP` — ms to ramp to top speed (default 600)
- `AETHER_DRAG_EDGEPAN_INTERVAL` — timer interval ms (default 33)
- `AETHER_NO_DRAG_EDGEPAN=1` — restore legacy reveal-only behaviour (A/B)

## Test plan / evidence
- Built on Windows (Qt 6.8.3, GPU QRhi path). Validated by drag-to-edge in both
  directions on a live FLEX.
- `aether.perf` `SliceDrag` telemetry: legacy ≈ 0.0027 MHz/tick regardless of how
  hard you push (~0.1× span/s); fixed = 0.00182 MHz/tick at full depth+ramp
  (1.2× span/s), center monotonic, no jump-back, symmetric L/R, slice parked at
  the 5% boundary.
- `AETHER_NO_DRAG_EDGEPAN=1` reproduces the old behaviour on the same build for a
  direct A/B comparison.

## Scope
Independent of #3578 (waterfall perf) and deliberately kept separate from #3444
(mouseMoveEvent overload).

Principle XI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
