### PR TITLE
feat(spectrum): add "Purple" waterfall color scheme

### DIFF
--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -134,6 +134,19 @@
                 { "at": 0.75, "color": "#f07800" },
                 { "at": 1.00, "color": "#ffff50" }
               ]
+            },
+            "purple": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.15, "color": "#0000ff" },
+                { "at": 0.30, "color": "#00ff00" },
+                { "at": 0.45, "color": "#ffff00" },
+                { "at": 0.60, "color": "#ff0000" },
+                { "at": 0.75, "color": "#800080" },
+                { "at": 1.00, "color": "#ffffff" }
+              ]
             }
           },
           "slice": {

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -135,6 +135,19 @@
                 { "at": 0.75, "color": "#f07800" },
                 { "at": 1.00, "color": "#ffff50" }
               ]
+            },
+            "purple": {
+              "type": "linear-gradient",
+              "angle": 180,
+              "stops": [
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.15, "color": "#0000ff" },
+                { "at": 0.30, "color": "#00ff00" },
+                { "at": 0.45, "color": "#ffff00" },
+                { "at": 0.60, "color": "#ff0000" },
+                { "at": 0.75, "color": "#800080" },
+                { "at": 1.00, "color": "#ffffff" }
+              ]
             }
           },
           "slice": {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -420,6 +420,7 @@ const char* wfSchemeToken(WfColorScheme s)
     case WfColorScheme::BlueGreen: return "color.waterfall.colormap.blueGreen";
     case WfColorScheme::Fire:      return "color.waterfall.colormap.fire";
     case WfColorScheme::Plasma:    return "color.waterfall.colormap.plasma";
+    case WfColorScheme::Purple:    return "color.waterfall.colormap.purple";
     default:                       return "color.waterfall.colormap.default";
     }
 }
@@ -470,6 +471,7 @@ const char* wfSchemeName(WfColorScheme scheme)
     case WfColorScheme::BlueGreen: return "Blue-Green";
     case WfColorScheme::Fire:      return "Fire";
     case WfColorScheme::Plasma:    return "Plasma";
+    case WfColorScheme::Purple:    return "Purple";
     default:                       return "Default";
     }
 }

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -44,6 +44,7 @@ enum class WfColorScheme : int {
     BlueGreen,     // black → blue → teal → green → white
     Fire,          // black → red → orange → yellow → white
     Plasma,        // black → purple → magenta → orange → yellow
+    Purple,        // SmartSDR "Add Purple": black→blue→green→yellow→red→purple→white
     Count          // sentinel — number of schemes
 };
 


### PR DESCRIPTION
## Summary

Adds a **"Purple"** waterfall colour scheme — an additive preset that joins the existing ones (Default, Grayscale, Blue-Green, Fire, Plasma) in the panadapter overlay colour-scheme combo. The gradient runs black → blue → green → yellow → red → purple (`#800080`) → white at positions `0.00 / 0.15 / 0.30 / 0.45 / 0.60 / 0.75 / 1.00`.

It follows the existing theme-token architecture:

- One enum value, **appended after `Plasma`** so the persisted `DisplayWfColorScheme` index is unchanged for existing users.
- Two switch cases mapping it to the `color.waterfall.colormap.purple` token and the `"Purple"` display label.
- Gradient stops added to both bundled themes (`default-dark.json`, `default-light.json`).

No hardcoded stop table — waterfall colourmaps load only from the qrc JSON, so the combo box and the gradient editor pick the new scheme up automatically.

## Constitution principle honored

**Principle III — User-Facing Names Match The Visible UI Labels.** `"Purple"` is the single source for the combo-box entry via `wfSchemeName()`.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Scheme selectable in the overlay menu; renders black → … → white floor-to-peak
- [ ] Existing tests pass (CI)

## Checklist

- [x] No new flat-key `AppSettings` calls (reuses the existing `DisplayWfColorScheme`)
- [x] All meter UI uses `MeterSmoother` — N/A (no meters touched)
- [x] Commits are signed (SSH)
- [x] Security-sensitive changes reference a GHSA — N/A
