### PR TITLE
feat(waveform): Docker waveform install via file upload protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,6 +562,7 @@ set(CORE_SOURCES
     src/core/MqttClient.cpp
     src/core/PgxlConnection.cpp
     src/core/FirmwareUploader.cpp
+    src/core/WaveformInstaller.cpp
     src/core/DvkWavTransfer.cpp
     src/core/ZipArchive.cpp
     src/core/ProfileTransfer.cpp

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -38,6 +38,7 @@ Q_LOGGING_CATEGORY(lcPerf,       "aether.perf",        QtWarningMsg)
 Q_LOGGING_CATEGORY(lcCw,         "aether.cw",          QtWarningMsg)
 Q_LOGGING_CATEGORY(lcSHistory,  "aether.shistory",    QtWarningMsg)
 Q_LOGGING_CATEGORY(lcAx25,       "aether.ax25",        QtWarningMsg)
+Q_LOGGING_CATEGORY(lcWaveform,   "aether.waveform",    QtWarningMsg)
 
 LogManager::LogManager()
 {
@@ -68,6 +69,7 @@ LogManager::LogManager()
         {"aether.cw",         "CW / netCW",    "CW keying, MIDI paddle, iambic, and netCW timing"},
         {"aether.shistory",   "S History",     "Past-Signals voice detection: noise floor, region width, band-plan filter"},
         {"aether.ax25",       "AetherModem", "AX.25 modem lifecycle, RX/TX audio, demod, framing, and packet diagnostics"},
+        {"aether.waveform",   "Waveform",    "Docker waveform image install upload"},
     };
 
     // QLoggingCategory objects are defined above via Q_LOGGING_CATEGORY macros.

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -38,6 +38,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcPerf)
 Q_DECLARE_LOGGING_CATEGORY(lcCw)
 Q_DECLARE_LOGGING_CATEGORY(lcSHistory)
 Q_DECLARE_LOGGING_CATEGORY(lcAx25)
+Q_DECLARE_LOGGING_CATEGORY(lcWaveform)
 
 // Central registry for toggling per-module diagnostic logging at runtime.
 // The Support dialog (Help → Support) uses this to let users enable/disable

--- a/src/core/WaveformInstaller.cpp
+++ b/src/core/WaveformInstaller.cpp
@@ -1,0 +1,194 @@
+#include "WaveformInstaller.h"
+#include "LogManager.h"
+#include "../models/RadioModel.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QHostAddress>
+#include <QTimer>
+
+namespace AetherSDR {
+
+WaveformInstaller::WaveformInstaller(RadioModel* model, QObject* parent)
+    : QObject(parent), m_model(model)
+{
+    connect(&m_socket, &QTcpSocket::connected,     this, &WaveformInstaller::onConnected);
+    connect(&m_socket, &QTcpSocket::bytesWritten,  this, &WaveformInstaller::onBytesWritten);
+    connect(&m_socket, &QTcpSocket::errorOccurred, this, [this] { onError(); });
+}
+
+void WaveformInstaller::install(const QString& filePath)
+{
+    if (m_installing) {
+        emit finished(false, tr("Install already in progress"));
+        return;
+    }
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        emit finished(false, tr("Cannot open file: %1").arg(file.errorString()));
+        return;
+    }
+
+    // Validate file format: accept gzip-compressed tars (magic 0x1F 0x8B) and
+    // plain uncompressed tars (POSIX "ustar" magic at byte 257).
+    // FlexRadio waveform packages may use either format — newer releases ship
+    // Docker OCI image layout tars without gzip compression despite a .tar.gz
+    // extension (confirmed with freedv-waveform-2.4.0-dev-7132.tar.gz).
+    const QByteArray header = file.read(262);
+    const bool isGzip = header.size() >= 2
+                        && static_cast<quint8>(header[0]) == 0x1F
+                        && static_cast<quint8>(header[1]) == 0x8B;
+    const bool isTar  = header.size() >= 262
+                        && header.mid(257, 5) == QByteArray("ustar", 5);
+    if (!isGzip && !isTar) {
+        emit finished(false, tr("Not a valid waveform image (expected a .tar.gz or tar archive)"));
+        return;
+    }
+    file.seek(0);
+
+    m_fileData = file.readAll();
+    file.close();
+
+    if (m_fileData.isEmpty()) {
+        emit finished(false, tr("File is empty"));
+        return;
+    }
+
+    if (m_fileData.size() > MAX_FILE_BYTES) {
+        emit finished(false, tr("File too large (> 500 MB)"));
+        return;
+    }
+
+    m_fileName   = QFileInfo(filePath).fileName();
+    m_bytesSent  = 0;
+    m_uploadPort = -1;
+    m_installing = true;
+    m_cancelled  = false;
+
+    emit progressChanged(0, tr("Requesting upload port…"));
+
+    // Single command — filename is embedded directly (no separate "file filename" step).
+    // Protocol confirmed by pcap 4.2.18-waveform-install.pcapng frame 4496.
+    m_model->sendCmdPublic(
+        QStringLiteral("file upload %1 waveform_docker_image %2")
+            .arg(m_fileData.size()).arg(m_fileName),
+        [this](int code, const QString& body) {
+            onUploadPortReceived(code, body);
+        });
+}
+
+void WaveformInstaller::cancel()
+{
+    if (!m_installing) return;
+    m_cancelled  = true;
+    m_socket.abort();
+    m_installing = false;
+    m_fileData.clear();
+    emit finished(false, tr("Install cancelled"));
+}
+
+void WaveformInstaller::onUploadPortReceived(int code, const QString& body)
+{
+    if (m_cancelled) return;
+
+    if (code != 0) {
+        m_installing = false;
+        m_fileData.clear();
+        emit finished(false, tr("Radio rejected upload (error 0x%1)").arg(code, 0, 16));
+        return;
+    }
+
+    bool ok = false;
+    int port = body.trimmed().toInt(&ok);
+    if (!ok || port <= 0)
+        port = FALLBACK_PORT;
+
+    m_uploadPort = port;
+    qCDebug(lcWaveform) << "WaveformInstaller: connecting to upload port" << m_uploadPort;
+    emit progressChanged(0, tr("Connecting to port %1…").arg(m_uploadPort));
+
+    // Small delay to let the radio set up its TCP server.
+    QTimer::singleShot(200, this, [this] {
+        if (m_cancelled) return;
+        m_socket.connectToHost(m_model->radioAddress(), m_uploadPort);
+
+        // Timeout: try fallback port if no connection after 10 s.
+        QTimer::singleShot(10000, this, [this] {
+            if (m_installing && m_socket.state() != QAbstractSocket::ConnectedState) {
+                if (m_uploadPort != FALLBACK_PORT) {
+                    m_uploadPort = FALLBACK_PORT;
+                    qCDebug(lcWaveform) << "WaveformInstaller: trying fallback port" << FALLBACK_PORT;
+                    emit progressChanged(0, tr("Trying fallback port %1…").arg(FALLBACK_PORT));
+                    m_socket.abort();
+                    m_socket.connectToHost(m_model->radioAddress(), m_uploadPort);
+                } else {
+                    m_installing = false;
+                    m_fileData.clear();
+                    emit finished(false, tr("Cannot connect to upload port"));
+                }
+            }
+        });
+    });
+}
+
+void WaveformInstaller::onConnected()
+{
+    if (m_cancelled) return;
+
+    qCDebug(lcWaveform) << "WaveformInstaller: connected, sending" << m_fileData.size() << "bytes";
+    emit progressChanged(0, tr("Uploading waveform image…"));
+
+    const qint64 toSend = qMin(static_cast<qint64>(CHUNK_SIZE),
+                                m_fileData.size() - m_bytesSent);
+    m_socket.write(m_fileData.constData() + m_bytesSent, toSend);
+}
+
+void WaveformInstaller::onBytesWritten(qint64 bytes)
+{
+    if (m_cancelled || !m_installing) return;
+
+    m_bytesSent += bytes;
+    const int percent = static_cast<int>(m_bytesSent * 100 / m_fileData.size());
+    emit progressChanged(percent,
+                         tr("Uploading… %1 / %2 KB")
+                             .arg(m_bytesSent / 1024)
+                             .arg(m_fileData.size() / 1024));
+
+    if (m_bytesSent >= m_fileData.size()) {
+        qCDebug(lcWaveform) << "WaveformInstaller: upload complete";
+        m_socket.flush();
+        m_socket.disconnectFromHost();
+        m_installing = false;
+        m_fileData.clear();
+        emit progressChanged(100, tr("Upload complete — installing on radio…"));
+        emit finished(true, tr("Waveform image uploaded successfully. "
+                               "The radio will install it momentarily."));
+        return;
+    }
+
+    const qint64 toSend = qMin(static_cast<qint64>(CHUNK_SIZE),
+                                m_fileData.size() - m_bytesSent);
+    m_socket.write(m_fileData.constData() + m_bytesSent, toSend);
+}
+
+void WaveformInstaller::onError()
+{
+    if (m_cancelled || !m_installing) return;
+
+    // First error on the primary port: try the fallback before giving up.
+    if (m_bytesSent == 0 && m_uploadPort != FALLBACK_PORT) {
+        m_uploadPort = FALLBACK_PORT;
+        qCDebug(lcWaveform) << "WaveformInstaller: error on primary port, trying" << FALLBACK_PORT;
+        emit progressChanged(0, tr("Retrying on port %1…").arg(FALLBACK_PORT));
+        m_socket.abort();
+        m_socket.connectToHost(m_model->radioAddress(), m_uploadPort);
+        return;
+    }
+
+    m_installing = false;
+    m_fileData.clear();
+    emit finished(false, tr("Upload failed: %1").arg(m_socket.errorString()));
+}
+
+} // namespace AetherSDR

--- a/src/core/WaveformInstaller.h
+++ b/src/core/WaveformInstaller.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <QObject>
+#include <QTcpSocket>
+#include <QByteArray>
+#include <QString>
+
+namespace AetherSDR {
+
+class RadioModel;
+
+// Installs a Docker waveform container image on the radio via the file upload
+// protocol introduced in firmware 4.2.18.
+//
+// Protocol (confirmed by pcap 4.2.18-waveform-install.pcapng, frame 4496):
+//   1. Client → Radio: "file upload <size> waveform_docker_image <filename>"
+//   2. Radio  → Client: R<seq>|0|<port>   (radio opens TCP server on <port>)
+//   3. Radio  → Client: S0|file server active
+//   4. Client connects TCP to radio:<port> and streams raw .tar.gz bytes
+//   5. Radio  → Client: S0|waveform container name=<name> version=<ver>
+//      (handled by FlexWaveformModel::handleContainerStatus — no action needed here)
+//
+// Note: unlike FirmwareUploader, there is NO "file filename <name>" step.
+// The filename is embedded directly in the "file upload" command (per pcap).
+//
+// Mirrors the FirmwareUploader class structure.
+class WaveformInstaller : public QObject {
+    Q_OBJECT
+
+public:
+    explicit WaveformInstaller(RadioModel* model, QObject* parent = nullptr);
+
+    // Begin installing the .tar.gz waveform image at filePath.
+    // Emits progressChanged() during transfer and finished() on completion.
+    void install(const QString& filePath);
+
+    // Abort an in-progress install.
+    void cancel();
+
+    bool isInstalling() const { return m_installing; }
+
+signals:
+    void progressChanged(int percent, const QString& status);
+    void finished(bool success, const QString& message);
+
+private:
+    void onUploadPortReceived(int code, const QString& body);
+    void onConnected();
+    void onBytesWritten(qint64 bytes);
+    void onError();
+
+    RadioModel* m_model{nullptr};
+    QTcpSocket  m_socket;
+    QByteArray  m_fileData;
+    QString     m_fileName;
+    qint64      m_bytesSent{0};
+    int         m_uploadPort{-1};
+    bool        m_installing{false};
+    bool        m_cancelled{false};
+
+    static constexpr qint64 MAX_FILE_BYTES = 500LL * 1024 * 1024;  // 500 MB
+    static constexpr int    CHUNK_SIZE     = 65536;                 // 64 KB
+    static constexpr int    FALLBACK_PORT  = 42607;  // fw 4.2.18 observed default
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -68,7 +68,7 @@ void MainWindow::buildMenuBar()
     auto* waveformsAct = fileMenu->addAction("Waveforms...");
     waveformsAct->setMenuRole(QAction::NoRole);
     connect(waveformsAct, &QAction::triggered, this, [this] {
-        showOrRaisePersistent(m_waveformsDialog, &m_radioModel.flexWaveformModel());
+        showOrRaisePersistent(m_waveformsDialog, &m_radioModel);
     });
 
     fileMenu->addSeparator();

--- a/src/gui/WaveformsDialog.cpp
+++ b/src/gui/WaveformsDialog.cpp
@@ -1,20 +1,24 @@
 #include "WaveformsDialog.h"
 #include "core/ThemeManager.h"
+#include "core/WaveformInstaller.h"
 #include "models/FlexWaveformModel.h"
+#include "models/RadioModel.h"
 
+#include <QFileDialog>
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMessageBox>
+#include <QProgressDialog>
 #include <QPushButton>
 #include <QScrollArea>
 #include <QVBoxLayout>
 
 namespace AetherSDR {
 
-WaveformsDialog::WaveformsDialog(FlexWaveformModel* model, QWidget* parent)
+WaveformsDialog::WaveformsDialog(RadioModel* model, QWidget* parent)
     : PersistentDialog(tr("Waveforms"), QStringLiteral("WaveformsDialogGeometry"), parent)
-    , m_model(model)
+    , m_radioModel(model)
 {
     theme::setContainer(this, QStringLiteral("dialog/waveforms"));
     setMinimumSize(440, 200);
@@ -34,6 +38,13 @@ WaveformsDialog::WaveformsDialog(FlexWaveformModel* model, QWidget* parent)
     statusRow->addWidget(m_statusLabel);
     statusRow->addStretch();
 
+    m_installBtn = new QPushButton(tr("Install…"));
+    m_installBtn->setAccessibleName(tr("Install Docker Waveform"));
+    m_installBtn->setFixedWidth(80);
+    m_installBtn->setEnabled(false);  // enabled once WFP is powered and ready
+    connect(m_installBtn, &QPushButton::clicked, this, &WaveformsDialog::onInstallClicked);
+    statusRow->addWidget(m_installBtn);
+
     root->addWidget(statusFrame);
 
     // ── Waveform list (scrollable) ────────────────────────────────────────────
@@ -50,26 +61,98 @@ WaveformsDialog::WaveformsDialog(FlexWaveformModel* model, QWidget* parent)
     scroll->setWidget(m_listContainer);
     root->addWidget(scroll, 1);
 
-    // ── Wire model signals ────────────────────────────────────────────────────
-    connect(m_model, &FlexWaveformModel::wfpStatusChanged,
+    // ── Wire model + theme signals ────────────────────────────────────────────
+    FlexWaveformModel& wfModel = m_radioModel->flexWaveformModel();
+    connect(&wfModel, &FlexWaveformModel::wfpStatusChanged,
             this, &WaveformsDialog::refreshStatus);
-    connect(m_model, &FlexWaveformModel::waveformsChanged,
+    connect(&wfModel, &FlexWaveformModel::wfpStatusChanged,
+            this, &WaveformsDialog::updateInstallButtonState);
+    connect(&wfModel, &FlexWaveformModel::waveformsChanged,
+            this, &WaveformsDialog::refreshWaveformList);
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
+            this, &WaveformsDialog::refreshStatus);
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
             this, &WaveformsDialog::refreshWaveformList);
 
     refreshStatus();
+    updateInstallButtonState();
     refreshWaveformList();
+}
+
+void WaveformsDialog::updateInstallButtonState()
+{
+    const FlexWaveformModel& wfModel = m_radioModel->flexWaveformModel();
+    const bool wfpUp = wfModel.wfpPowered() && wfModel.wfpReady();
+    const bool busy  = m_installer && m_installer->isInstalling();
+    m_installBtn->setEnabled(wfpUp && !busy);
+}
+
+void WaveformsDialog::onInstallClicked()
+{
+    const QString path = QFileDialog::getOpenFileName(
+        this,
+        tr("Select Waveform Image"),
+        {},
+        tr("Waveform Images (*.tar.gz *.tgz);;All Files (*)"));
+
+    if (path.isEmpty())
+        return;
+
+    if (!m_installer)
+        m_installer = new WaveformInstaller(m_radioModel, this);
+
+    if (m_installer->isInstalling())
+        return;
+
+    m_installBtn->setEnabled(false);
+
+    auto* progress = new QProgressDialog(
+        tr("Installing waveform…"), tr("Cancel"), 0, 100, this);
+    progress->setWindowModality(Qt::WindowModal);
+    progress->setMinimumDuration(0);
+    progress->setValue(0);
+    ThemeManager::instance().applyStyleSheet(progress,
+        QStringLiteral("QProgressBar { text-align: center; "
+                       "background: {{color.background.0}}; "
+                       "color: {{color.text.primary}}; }"));
+
+    connect(m_installer, &WaveformInstaller::progressChanged,
+            progress, [progress](int pct, const QString& msg) {
+                progress->setValue(pct);
+                progress->setLabelText(msg);
+            });
+
+    connect(progress, &QProgressDialog::canceled,
+            m_installer, &WaveformInstaller::cancel);
+
+    connect(m_installer, &WaveformInstaller::finished,
+            this, [this, progress](bool ok, const QString& msg) {
+                progress->close();
+                progress->deleteLater();
+                updateInstallButtonState();
+                if (ok)
+                    QMessageBox::information(this, tr("Install Complete"), msg);
+                else
+                    QMessageBox::warning(this, tr("Install Failed"), msg);
+            }, Qt::SingleShotConnection);
+
+    m_installer->install(path);
 }
 
 void WaveformsDialog::refreshStatus()
 {
-    const QString powerColor = m_model->wfpPowered() ? QStringLiteral("#00ff88")
-                                                      : QStringLiteral("#505050");
-    const QString readyColor = m_model->wfpReady()   ? QStringLiteral("#00ff88")
-                                                      : QStringLiteral("#505050");
-    const QString powerText  = m_model->wfpPowered() ? tr("ON")  : tr("OFF");
-    const QString readyText  = m_model->wfpReady()   ? tr("READY") : tr("NOT READY");
+    const FlexWaveformModel& wfModel = m_radioModel->flexWaveformModel();
+    auto& tm = ThemeManager::instance();
 
-    QString ip = m_model->wfpIpAddress();
+    const QString onColor  = tm.color(this, QStringLiteral("color.accent")).name();
+    const QString offColor = tm.color(this, QStringLiteral("color.text.secondary")).name();
+
+    const QString powerColor = wfModel.wfpPowered() ? onColor : offColor;
+    const QString readyColor = wfModel.wfpReady()   ? onColor : offColor;
+    const QString powerText  = wfModel.wfpPowered() ? tr("ON")    : tr("OFF");
+    const QString readyText  = wfModel.wfpReady()   ? tr("READY") : tr("NOT READY");
+
+    QString ip = wfModel.wfpIpAddress();
     if (ip.isEmpty())
         ip = QStringLiteral("--");
 
@@ -93,19 +176,21 @@ void WaveformsDialog::refreshWaveformList()
         delete item;
     }
 
-    const QList<FlexWaveformEntry>& waveforms = m_model->waveforms();
+    const FlexWaveformModel& wfModel = m_radioModel->flexWaveformModel();
+    const QList<FlexWaveformEntry>& waveforms = wfModel.waveforms();
 
     if (waveforms.isEmpty()) {
         auto* placeholder = new QLabel(tr("No waveforms installed"));
         placeholder->setAlignment(Qt::AlignCenter);
-        placeholder->setStyleSheet(QStringLiteral("color: #8090a0;"));
+        ThemeManager::instance().applyStyleSheet(placeholder,
+            QStringLiteral("QLabel { color: {{color.text.secondary}}; }"));
         m_listLayout->insertWidget(0, placeholder);
         return;
     }
 
     for (const FlexWaveformEntry& entry : waveforms) {
-        const QString name    = entry.name;
-        const bool isContainer = entry.isContainer;
+        const QString name        = entry.name;
+        const bool    isContainer = entry.isContainer;
 
         auto* row = new QFrame;
         row->setFrameShape(QFrame::StyledPanel);
@@ -120,17 +205,17 @@ void WaveformsDialog::refreshWaveformList()
         rowLayout->addWidget(nameLabel, 1);
 
         // Type badge
-        const QString badgeText  = isContainer ? tr("Container") : tr("Waveform");
-        auto* typeLabel = new QLabel(
-            QStringLiteral("<font color='#8090a0'>[%1]</font>").arg(badgeText));
-        typeLabel->setTextFormat(Qt::RichText);
+        const QString badgeText = isContainer ? tr("Container") : tr("Waveform");
+        auto* typeLabel = new QLabel(QStringLiteral("[%1]").arg(badgeText));
+        ThemeManager::instance().applyStyleSheet(typeLabel,
+            QStringLiteral("QLabel { color: {{color.text.secondary}}; }"));
         rowLayout->addWidget(typeLabel);
 
         // Restart button
         auto* restartBtn = new QPushButton(tr("Restart"));
         restartBtn->setFixedWidth(70);
         connect(restartBtn, &QPushButton::clicked, this, [this, name]() {
-            m_model->requestRestart(name);
+            m_radioModel->flexWaveformModel().requestRestart(name);
         });
         rowLayout->addWidget(restartBtn);
 
@@ -145,9 +230,9 @@ void WaveformsDialog::refreshWaveformList()
             if (QMessageBox::question(this, tr("Confirm"), question) != QMessageBox::Yes)
                 return;
             if (isContainer)
-                m_model->requestRemoveContainer(name);
+                m_radioModel->flexWaveformModel().requestRemoveContainer(name);
             else
-                m_model->requestUninstall(name);
+                m_radioModel->flexWaveformModel().requestUninstall(name);
         });
         rowLayout->addWidget(removeBtn);
 

--- a/src/gui/WaveformsDialog.h
+++ b/src/gui/WaveformsDialog.h
@@ -3,31 +3,43 @@
 #include "PersistentDialog.h"
 
 class QLabel;
+class QPushButton;
 class QVBoxLayout;
 
 namespace AetherSDR {
 
-class FlexWaveformModel;
+class RadioModel;
+class WaveformInstaller;
 
 // Non-modal dialog for WFP status and waveform management (File → Waveforms).
 // Mirrors the SmartSDR File → Waveforms panel: shows WFP power/ready/IP at the
 // top and one row per installed waveform with Restart and Remove/Uninstall
-// buttons.  Connects directly to FlexWaveformModel signals so it stays live
-// without any MainWindow involvement in refresh.
+// buttons.  An Install… button at the top-right lets the user upload a Docker
+// waveform image (.tar.gz) via WaveformInstaller.
+//
+// Takes RadioModel* so it can construct WaveformInstaller (which needs
+// sendCmdPublic and radioAddress()) while still connecting to FlexWaveformModel
+// signals for live list updates.
 class WaveformsDialog : public PersistentDialog {
     Q_OBJECT
 
 public:
-    explicit WaveformsDialog(FlexWaveformModel* model, QWidget* parent = nullptr);
+    explicit WaveformsDialog(RadioModel* model, QWidget* parent = nullptr);
+
+private slots:
+    void onInstallClicked();
 
 private:
     void refreshStatus();
     void refreshWaveformList();
+    void updateInstallButtonState();
 
-    FlexWaveformModel* m_model;
+    RadioModel*        m_radioModel{nullptr};
     QLabel*            m_statusLabel{nullptr};
+    QPushButton*       m_installBtn{nullptr};
     QWidget*           m_listContainer{nullptr};
     QVBoxLayout*       m_listLayout{nullptr};
+    WaveformInstaller* m_installer{nullptr};
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Summary

Adds Docker waveform container install to the **File → Waveforms** dialog, mirroring the SmartSDR Waveform Manager's Install flow.

**What's new:**
- **Install… button** in the WFP status bar, enabled only when WFP is powered and ready. Opens a file picker filtered to `*.tar.gz / *.tgz`, streams the image to the radio, and shows a cancelable progress dialog.
- **`WaveformInstaller`** (`src/core/`) — new class implementing the `file upload <size> waveform_docker_image <filename>` protocol confirmed by pcap (fw 4.2.18). Validates the archive before loading (gzip magic `0x1F 0x8B` or POSIX tar `ustar` magic at byte 257; accepts both because newer FlexRadio releases ship uncompressed OCI-layout tars despite the `.tar.gz` extension). 500 MB ceiling, 64 KB chunk streaming, 10 s connect timeout with fallback to port 42607. Mirrors `FirmwareUploader` in structure.
- **`WaveformsDialog`** now takes `RadioModel*` (was `FlexWaveformModel*`) to give it access to the installer's dependencies. Existing Remove/Restart per-row buttons are unchanged. Status indicator colors and list badges now resolve from theme tokens (`color.accent`, `color.text.secondary`) and reconnect on `themeChanged`.
- **`lcWaveform`** (`aether.waveform`) logging category added to LogManager.

The waveform list updates automatically after install via the existing `FlexWaveformModel::handleContainerStatus` / `waveformsChanged` signal — no extra wiring required.

Legacy waveform install (non-Docker) is deferred.

## Constitution principle honored

**Principle VIII — Evidence Over Assertion.** The install protocol — `file upload <size> waveform_docker_image <filename>`, dynamic TCP port, ustar/gzip dual-format validation — is derived entirely from pcap `4.2.18-waveform-install.pcapng`, not from documentation or assumptions. The plain-tar format discovery (OCI layout, no gzip) was confirmed by inspecting the actual bytes of `freedv-waveform-2.4.0-dev-7132.tar.gz` before widening the validator.

**Principle XI — Fixes Are Demonstrated.** Install of a fresh container, remove, and reinstall of the same container verified OTA on a FLEX-8400 (NF0T).

## Test plan

- [x] Local build passes (MinGW GCC 13 / Qt 6.11.0, `cmake --build /c/AetherBuild`)
- [x] Docker waveform install verified on real radio — FLEX-8400, NF0T: fresh install of newer version, remove container, reinstall same version, all confirmed working
- [x] Install button correctly disabled before WFP ready; enables on `wfp_status power=on ready=true`
- [x] Cancel during upload aborts the TCP transfer and re-enables the button
- [x] Gzip magic check rejects non-archive files; ustar check accepts OCI-layout tars
- [x] CI (pending)

## Checklist

- [x] Commits signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — waveform state is radio-authoritative; no client-side persistence added
- [x] No meter UI added — `MeterSmoother` not applicable
- [x] `WaveformsDialog` theming: status indicators, list badges, and progress dialog resolve via ThemeManager tokens; `themeChanged` wired for live re-paint