### PR TITLE
fix(spectrum): use the radio's auto-black level for an evenly-levelled waterfall floor

### DIFF
--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -926,8 +926,9 @@ void MainWindow::wirePanLifecycle()
             if (pan->wfStreamId() == streamId) {
                 if (auto* sw = m_panStack->spectrum(pan->panId())) {
                     if (sw->wfAutoBlack()) {
-                        const int level = std::clamp(static_cast<int>(autoBlack), 0, 125);
-                        sw->setWfBlackLevel(level);
+                        // Feed the radio's per-tile auto-black level straight to
+                        // the renderer (radio-authoritative low/black point).
+                        sw->setRadioAutoBlackLevel(autoBlack);
                     }
                 }
                 return;

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -925,9 +925,10 @@ void MainWindow::wirePanLifecycle()
         for (auto* pan : m_radioModel.panadapters()) {
             if (pan->wfStreamId() == streamId) {
                 if (auto* sw = m_panStack->spectrum(pan->panId())) {
-                    if (sw->wfAutoBlack()) {
+                    if (sw->wfAutoBlack() && sw->wfAutoBlackRadioSide()) {
                         // Feed the radio's per-tile auto-black level straight to
-                        // the renderer (radio-authoritative low/black point).
+                        // the renderer only when the user selected radio-side
+                        // auto-black (radio-authoritative low/black point).
                         sw->setRadioAutoBlackLevel(autoBlack);
                     }
                 }
@@ -950,6 +951,7 @@ void MainWindow::wirePanLifecycle()
             m_radioModel.setWaterfallColorGain(sw->wfColorGain());
             m_radioModel.setWaterfallBlackLevel(sw->wfBlackLevel());
             m_radioModel.setWaterfallAutoBlack(sw->wfAutoBlack());
+            m_radioModel.setWaterfallAutoBlackSource(sw->wfAutoBlackRadioSide());
             int rate = sw->wfLineDuration();
             if (!m_adaptiveThrottleActive)
                 m_radioModel.setWaterfallLineDuration(rate);

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1632,10 +1632,20 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     connect(menu, &SpectrumOverlayMenu::wfAutoBlackChanged,
             this, [this, sw](bool on) {
         sw->setWfAutoBlack(on);
+        // Keep the radio's auto_black flag in sync at runtime; it only reaches
+        // 1 when auto-black is on AND the radio-side source is selected.
+        m_radioModel.setWaterfallAutoBlack(on);
     });
     connect(menu, &SpectrumOverlayMenu::wfAutoBlackOffsetChanged,
             this, [sw](int offset) {
         sw->setWfAutoBlackOffset(offset);
+    });
+    connect(menu, &SpectrumOverlayMenu::wfAutoBlackSourceChanged,
+            this, [this, sw](bool radioSide) {
+        sw->setWfAutoBlackRadioSide(radioSide);
+        // Radio-side → tell the radio to compute its per-tile auto-black level;
+        // client-side → stop it (auto_black=0) and use our own estimate.
+        m_radioModel.setWaterfallAutoBlackSource(radioSide);
     });
     const auto applyWaterfallLineDuration = [this, applet, sw](int ms) {
         const int clampedMs = std::clamp(ms, 1, 100);
@@ -1706,6 +1716,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setWfBlackLevel(15);
         sw->setWfAutoBlack(true);
         sw->setWfAutoBlackOffset(50);
+        sw->setWfAutoBlackRadioSide(false);
         sw->setWfLineDuration(100);
         sw->setWfBlankerEnabled(false);
         sw->setWfBlankerThreshold(1.15f);
@@ -1754,6 +1765,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         s.setValue(sw->settingsKey("DisplayWfColorGain"),         "50");
         s.setValue(sw->settingsKey("DisplayWfBlackLevel"),        "15");
         s.setValue(sw->settingsKey("DisplayWfAutoBlack"),         "True");
+        s.setValue(sw->settingsKey("DisplayWfAutoBlackRadioSide"), "False");
         s.setValue(sw->settingsKey("DisplayWfLineDuration"),      "100");
         s.setValue(sw->settingsKey("WaterfallBlankingEnabled"),   "False");
         s.setValue(sw->settingsKey("WaterfallBlankingThreshold"), "1.15");

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1203,40 +1203,24 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     //              persists in m_blackAutoOffsetValue and emits
     //              wfAutoBlackOffsetChanged.
     makeRowWithBtn("Black Level:", 0, 100, 50, m_blackSlider, m_blackLabel,
-                   m_autoBlackBtn, "Auto");
-    m_autoBlackBtn->setChecked(true);
+                   m_autoBlackBtn, "SW");
     connect(m_blackSlider, &QSlider::valueChanged, this, [this](int v) {
         m_blackLabel->setText(QString::number(v));
-        if (m_autoBlackBtn && m_autoBlackBtn->isChecked()) {
+        if (m_autoBlackMode != 0) {      // Auto-C / Auto-R → bias the offset
             m_blackAutoOffsetValue = v;
             emit wfAutoBlackOffsetChanged(v);
-        } else {
+        } else {                         // Off → manual black level
             m_blackManualValue = v;
             emit wfBlackLevelChanged(v);
         }
     });
-    connect(m_autoBlackBtn, &QPushButton::toggled, this, [this](bool on) {
-        emit wfAutoBlackChanged(on);
-        // Swap the displayed slider value to whichever role just became
-        // active.  Block signals so the swap doesn't echo back as a user
-        // edit — we just want the UI to reflect the matching stored value.
-        if (m_blackSlider) {
-            QSignalBlocker bs(m_blackSlider);
-            const int v = on ? m_blackAutoOffsetValue : m_blackManualValue;
-            m_blackSlider->setValue(v);
-            if (m_blackLabel)
-                m_blackLabel->setText(QString::number(v));
-        }
-        if (m_blackSlider) {
-            m_blackSlider->setToolTip(on
-                ? "Auto-black target offset. 50 = at noise floor; lower = darker, higher = lighter."
-                : "Waterfall black level. Decrease to darken the noise floor.");
-        }
-        if (!on)
-            emit wfBlackLevelChanged(m_blackManualValue);
-        else
-            emit wfAutoBlackOffsetChanged(m_blackAutoOffsetValue);
+    // One click advances the 3-way mode: Off → Auto-C → Auto-R → Off.
+    // applyAutoBlackMode swaps the slider role, updates the label/highlight, and
+    // emits the on/off + client/radio-source signals together.
+    connect(m_autoBlackBtn, &QPushButton::clicked, this, [this]() {
+        applyAutoBlackMode((m_autoBlackMode + 1) % 3, /*emitSignals=*/true);
     });
+    applyAutoBlackMode(m_autoBlackMode, /*emitSignals=*/false);  // initial label/slider role
 
     // Gain
     makeRow("WtrFall Gain:", 0, 100, 50, m_gainSlider, m_gainLabel);
@@ -1451,6 +1435,50 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     m_displayPanel->adjustSize();
 }
 
+// Apply a 3-way auto-black mode to the single cycle button + shared Black slider.
+//   0 = Off    → manual black level
+//   1 = SW → AetherSDR client-side (software) noise-floor estimate
+//   2 = HW → radio's per-tile (hardware) auto-black level (FlexLib AutoBlackLevel)
+// The button highlights in either Auto mode and shows the mode name; the slider
+// swaps between its manual and auto-offset roles.  When emitSignals is true (a
+// user click) it drives the on/off + client/radio-source signals plus the
+// matching slider-value signal so the renderer and radio both update.
+void SpectrumOverlayMenu::applyAutoBlackMode(int mode, bool emitSignals)
+{
+    m_autoBlackMode = mode;
+    const bool autoOn    = (mode != 0);
+    const bool radioSide = (mode == 2);
+
+    if (m_autoBlackBtn) {
+        QSignalBlocker bb(m_autoBlackBtn);
+        m_autoBlackBtn->setCheckable(true);
+        m_autoBlackBtn->setChecked(autoOn);   // highlight in either Auto mode
+        // SW = client-side (software) estimate, HW = radio's (hardware) level —
+        // short labels that fit the compact button.
+        m_autoBlackBtn->setText(mode == 0 ? "Off" : mode == 1 ? "SW" : "HW");
+        m_autoBlackBtn->setToolTip(
+            "Waterfall auto-black (click to cycle):\n"
+            "Off = manual black level\n"
+            "SW = client-side noise-floor estimate (software)\n"
+            "HW = radio's per-tile auto-black level (hardware)");
+    }
+    if (m_blackSlider) {
+        QSignalBlocker bs(m_blackSlider);
+        const int v = autoOn ? m_blackAutoOffsetValue : m_blackManualValue;
+        m_blackSlider->setValue(v);
+        if (m_blackLabel) m_blackLabel->setText(QString::number(v));
+        m_blackSlider->setToolTip(autoOn
+            ? "Auto-black target offset. 50 = at noise floor; lower = darker, higher = lighter."
+            : "Waterfall black level. Decrease to darken the noise floor.");
+    }
+    if (emitSignals) {
+        emit wfAutoBlackChanged(autoOn);
+        emit wfAutoBlackSourceChanged(radioSide);
+        if (autoOn) emit wfAutoBlackOffsetChanged(m_blackAutoOffsetValue);
+        else        emit wfBlackLevelChanged(m_blackManualValue);
+    }
+}
+
 void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
                                                bool weightedAvg, const QColor& fillColor,
                                                int gain, int black, bool autoBlack,
@@ -1458,7 +1486,8 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
                                                int floorPos, bool floorEnable,
                                                bool heatMap, int colorScheme,
                                                bool showGrid,
-                                               float lineWidth)
+                                               float lineWidth,
+                                               bool autoBlackRadioSide)
 {
     if (!m_avgSlider) return;  // panel not built yet
 
@@ -1481,13 +1510,11 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
     m_gainLabel->setText(QString::number(gain));
     m_blackManualValue     = black;
     m_blackAutoOffsetValue = autoBlackOffset;
-    const int displayBlack = autoBlack ? autoBlackOffset : black;
-    m_blackSlider->setValue(displayBlack);
-    m_blackLabel->setText(QString::number(displayBlack));
-    m_blackSlider->setToolTip(autoBlack
-        ? "Auto-black target offset. 50 = at noise floor; lower = darker, higher = lighter."
-        : "Waterfall black level. Decrease to darken the noise floor.");
-    m_autoBlackBtn->setChecked(autoBlack);
+    // Reflect the persisted 3-way auto-black mode on the cycle button + slider.
+    // (m_blackManualValue / m_blackAutoOffsetValue were just set above; the
+    // helper picks the right one for the mode and updates the label/tooltip.)
+    const int abMode = !autoBlack ? 0 : (autoBlackRadioSide ? 2 : 1);
+    applyAutoBlackMode(abMode, /*emitSignals=*/false);
     syncWfLineDuration(rate);
 
     if (m_floorSlider) {

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -48,7 +48,8 @@ public:
                              int floorPos = 75, bool floorEnable = false,
                              bool heatMap = true, int colorScheme = 0,
                              bool showGrid = true,
-                             float lineWidth = 2.0f);
+                             float lineWidth = 2.0f,
+                             bool autoBlackRadioSide = false);
     void syncWfLineDuration(int rate);
     // Sync blanker/cursor/opacity controls not covered by syncDisplaySettings.
     void syncExtraDisplaySettings(bool blankerOn, float blankerThresh,
@@ -122,6 +123,8 @@ signals:
     // Auto-black target offset (0-100, 50 = at noise floor).  Emitted when
     // the Black slider moves while AUTO is engaged.
     void wfAutoBlackOffsetChanged(int offset);
+    // Auto-black source: false = client-side estimate (default), true = radio.
+    void wfAutoBlackSourceChanged(bool radioSide);
     void wfLineDurationChanged(int ms);
     void wfColorSchemeChanged(int scheme);
     void noiseFloorPositionChanged(int pos);
@@ -253,6 +256,10 @@ private:
     QSlider*     m_blackSlider{nullptr};
     QLabel*      m_blackLabel{nullptr};
     QPushButton* m_autoBlackBtn{nullptr};
+    // Auto-black is a 3-way cycle on one button: 0 = Off, 1 = Auto-C (client
+    // noise-floor estimate), 2 = Auto-R (radio per-tile level).
+    int m_autoBlackMode{1};
+    void applyAutoBlackMode(int mode, bool emitSignals);
     // Two values backing the single Black slider; the slider shows whichever
     // matches the current AUTO state.  Toggling AUTO swaps the displayed
     // value, edits route to the matching member + matching signal.

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -836,6 +836,8 @@ void SpectrumWidget::loadSettings()
     m_wfBlackLevel   = s.value(settingsKey("DisplayWfBlackLevel"), "15").toInt();
     m_wfAutoBlack    = s.value(settingsKey("DisplayWfAutoBlack"), "True").toString() == "True";
     m_wfAutoBlackOffset = s.value(settingsKey("DisplayWfAutoBlackOffset"), "50").toInt();
+    // Auto-black source defaults to client-side (legacy look); radio-side opt-in.
+    m_wfAutoBlackRadioSide = s.value(settingsKey("DisplayWfAutoBlackRadioSide"), "False").toString() == "True";
     m_wfLineDuration = std::clamp(s.value(settingsKey("DisplayWfLineDuration"), "100").toInt(),
                                   kWaterfallLineDurationMinMs,
                                   kWaterfallLineDurationMaxMs);
@@ -894,7 +896,7 @@ void SpectrumWidget::loadSettings()
             m_wfLineDuration,
             m_noiseFloorPosition, m_noiseFloorEnable,
             m_fftHeatMap, static_cast<int>(m_wfColorScheme), m_showGrid,
-            m_fftLineWidth);
+            m_fftLineWidth, m_wfAutoBlackRadioSide);
         m_overlayMenu->syncExtraDisplaySettings(m_wfBlankerEnabled,
             m_wfBlankerThreshold, m_bgOpacity, m_freqGridSpacingKhz, m_bgFillColor,
             m_freqScaleFontPt);
@@ -1760,6 +1762,21 @@ void SpectrumWidget::setRadioAutoBlackLevel(quint32 rawLevel) {
     const float v = static_cast<float>(rawLevel);
     if (v == m_radioAutoBlackRaw) return;
     m_radioAutoBlackRaw = v;
+    update();
+}
+void SpectrumWidget::setWfAutoBlackRadioSide(bool radioSide) {
+    if (radioSide == m_wfAutoBlackRadioSide) {
+        return;
+    }
+    m_wfAutoBlackRadioSide = radioSide;
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("DisplayWfAutoBlackRadioSide"), radioSide ? "True" : "False");
+    s.save();
+    // Drop any stale radio level when switching back to client-side so the
+    // client estimate takes over immediately; a fresh tile repopulates it.
+    if (!radioSide) {
+        m_radioAutoBlackRaw = 0.0f;
+    }
     update();
 }
 void SpectrumWidget::setWfLineDuration(int ms) {
@@ -5353,7 +5370,7 @@ QRgb SpectrumWidget::intensityToRgb(float intensity) const
     // <50 darker, >50 lighter.
     float blackThresh;   // low point  (intensity domain)
     float rangeWidth;    // high − low (intensity domain)
-    if (m_wfAutoBlack && m_radioAutoBlackRaw > 0.0f) {
+    if (m_wfAutoBlack && m_wfAutoBlackRadioSide && m_radioAutoBlackRaw > 0.0f) {
         // Clamp once so the black point, white point, and range all derive from
         // the same low value — the offset can push lowRaw out of [0, 65535].
         const float lowRaw = qBound(

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -5354,8 +5354,12 @@ QRgb SpectrumWidget::intensityToRgb(float intensity) const
     float blackThresh;   // low point  (intensity domain)
     float rangeWidth;    // high − low (intensity domain)
     if (m_wfAutoBlack && m_radioAutoBlackRaw > 0.0f) {
-        const float lowRaw =
-            m_radioAutoBlackRaw + (50 - m_wfAutoBlackOffset) * 0.5f * 128.0f;
+        // Clamp once so the black point, white point, and range all derive from
+        // the same low value — the offset can push lowRaw out of [0, 65535].
+        const float lowRaw = qBound(
+            0.0f,
+            m_radioAutoBlackRaw + (50 - m_wfAutoBlackOffset) * 0.5f * 128.0f,
+            65535.0f);
         const float highRaw = wfHighThresholdRaw(lowRaw, m_wfColorGain);
         blackThresh = lowRaw / 128.0f;
         rangeWidth  = std::max(1.0f, (highRaw - lowRaw) / 128.0f);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1756,6 +1756,12 @@ void SpectrumWidget::setWfAutoBlackOffset(int level) {
     }
     update();
 }
+void SpectrumWidget::setRadioAutoBlackLevel(quint32 rawLevel) {
+    const float v = static_cast<float>(rawLevel);
+    if (v == m_radioAutoBlackRaw) return;
+    m_radioAutoBlackRaw = v;
+    update();
+}
 void SpectrumWidget::setWfLineDuration(int ms) {
     const int clamped = std::clamp(ms, kWaterfallLineDurationMinMs, kWaterfallLineDurationMaxMs);
     if (m_wfLineDuration == clamped) {
@@ -5316,29 +5322,51 @@ QRgb SpectrumWidget::dbmToRgb(float dbm) const
     return interpolateGradient(t, stops, n);
 }
 
+// Cubic colour-gain curve mapping the radio's black point (low) to a white
+// point (high):
+//   num  = (100 − colorGain)/100 · cbrt(65535 − low)
+//   high = low + num³        (floored at low + 100)
+// colorGain 0 → full range (dim); 100 → narrow range (max contrast).
+static float wfHighThresholdRaw(float lowRaw, int colorGain)
+{
+    const float low = qBound(0.0f, lowRaw, 65535.0f);
+    const double num = (100.0 - colorGain) / 100.0 * std::cbrt(65535.0 - low);
+    double high = low + num * num * num;
+    if (high < low + 100.0) {
+        high = low + 100.0;
+    }
+    return static_cast<float>(high);
+}
+
 // Map native waterfall tile intensity to RGB.
 // Intensity is int16(raw)/128.0f — observed range ~96-120 on HF.
 // m_wfBlackLevel and m_wfColorGain control the mapping independently from FFT.
 QRgb SpectrumWidget::intensityToRgb(float intensity) const
 {
-    // Map black_level (0-100) to an intensity threshold.
-    // When auto-black is on, anchor to the measured noise floor and let the
-    // user bias it via the auto-black offset slider:
-    //   offset 50 → no bias (threshold sits at the noise floor)
-    //   offset  0 → +25 intensity above the noise floor (darker waterfall)
-    //   offset 100 → -25 intensity below the noise floor (lighter waterfall)
-    float blackThresh;
-    if (m_wfAutoBlack) {
+    // Two auto-black paths (intensity arrives as raw_uint16 / 128):
+    //  • Radio-authoritative: the radio's per-tile black level is the low/black
+    //    point; the white point follows the cubic colour-gain curve
+    //    (wfHighThresholdRaw). Reproduces the radio's evenly-levelled floor.
+    //  • Fallback (no radio auto-black yet, or auto-black off): the prior
+    //    client-side noise-floor estimate / manual black level.
+    // The auto-black offset slider biases the black point: 50 = no bias,
+    // <50 darker, >50 lighter.
+    float blackThresh;   // low point  (intensity domain)
+    float rangeWidth;    // high − low (intensity domain)
+    if (m_wfAutoBlack && m_radioAutoBlackRaw > 0.0f) {
+        const float lowRaw =
+            m_radioAutoBlackRaw + (50 - m_wfAutoBlackOffset) * 0.5f * 128.0f;
+        const float highRaw = wfHighThresholdRaw(lowRaw, m_wfColorGain);
+        blackThresh = lowRaw / 128.0f;
+        rangeWidth  = std::max(1.0f, (highRaw - lowRaw) / 128.0f);
+    } else if (m_wfAutoBlack) {
         blackThresh = m_autoBlackThresh + (50 - m_wfAutoBlackOffset) * 0.5f;
+        rangeWidth  = std::max(1.0f, 120.0f - m_wfColorGain * 0.91f);
     } else {
         // Manual: slider 0 → thresh 160 (well above noise), slider 100 → thresh 60.
         blackThresh = 160.0f - m_wfBlackLevel * 1.0f;
+        rangeWidth  = std::max(1.0f, 120.0f - m_wfColorGain * 0.91f);
     }
-
-    // Map color_gain (0-100) to the visible range width.
-    // Higher gain = narrower range = more color contrast.
-    // gain=0 → 120 dB range (very dim), gain=100 → 29 dB range (max contrast)
-    const float rangeWidth = std::max(1.0f, 120.0f - m_wfColorGain * 0.91f);
 
     const float t = qBound(0.0f, (intensity - blackThresh) / rangeWidth, 1.0f);
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -314,6 +314,10 @@ public:
     // domain, radio-authoritative). 0 = not yet received → the client falls back
     // to its own noise-floor estimate.
     void setRadioAutoBlackLevel(quint32 rawLevel);
+    // Auto-black source: false = client-side noise-floor estimate (default,
+    // legacy look); true = the radio's per-tile auto-black level. Only consulted
+    // while m_wfAutoBlack is on.
+    void setWfAutoBlackRadioSide(bool radioSide);
     void setWfLineDuration(int ms);
     void setWfColorScheme(int scheme);
     void resetWfTimeScale();
@@ -321,6 +325,7 @@ public:
     int   wfBlackLevel() const         { return m_wfBlackLevel; }
     bool  wfAutoBlack() const          { return m_wfAutoBlack; }
     int   wfAutoBlackOffset() const    { return m_wfAutoBlackOffset; }
+    bool  wfAutoBlackRadioSide() const { return m_wfAutoBlackRadioSide; }
     int   wfLineDuration() const       { return m_wfLineDuration; }
     int   wfColorScheme() const        { return static_cast<int>(m_wfColorScheme); }
 
@@ -774,6 +779,9 @@ private:
     // pulls it below (lighter).  Stored separately from m_wfBlackLevel so
     // toggling AUTO swaps between the two without losing either value.
     int   m_wfAutoBlackOffset{50};
+    // Auto-black source: false = client-side noise-floor estimate (default,
+    // legacy look); true = the radio's per-tile auto-black level.
+    bool  m_wfAutoBlackRadioSide{false};
     WfColorScheme m_wfColorScheme{WfColorScheme::Default};
     float m_autoBlackThresh{145.0f}; // client-side auto-black: tracked noise floor
     // Radio's per-tile auto-black level (raw uint16). Preferred over the client

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -310,6 +310,10 @@ public:
     // Only consulted while m_wfAutoBlack is on; lets users bias the noise-
     // floor target without leaving auto-black.
     void setWfAutoBlackOffset(int level);
+    // Radio-computed auto-black level from the latest waterfall tile (raw uint16
+    // domain, radio-authoritative). 0 = not yet received → the client falls back
+    // to its own noise-floor estimate.
+    void setRadioAutoBlackLevel(quint32 rawLevel);
     void setWfLineDuration(int ms);
     void setWfColorScheme(int scheme);
     void resetWfTimeScale();
@@ -772,6 +776,9 @@ private:
     int   m_wfAutoBlackOffset{50};
     WfColorScheme m_wfColorScheme{WfColorScheme::Default};
     float m_autoBlackThresh{145.0f}; // client-side auto-black: tracked noise floor
+    // Radio's per-tile auto-black level (raw uint16). Preferred over the client
+    // estimate when non-zero; matches FlexLib's auto-level pipeline.
+    float m_radioAutoBlackRaw{0.0f};
     int   m_wfLineDuration{100};     // ms per waterfall row
 
     // Waterfall colour range for FFT-derived fallback (dBm).

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1808,14 +1808,27 @@ void RadioModel::setWaterfallBlackLevel(int level)
 
 void RadioModel::setWaterfallAutoBlack(bool on)
 {
-    // Radio-authoritative auto-black: when on, let the radio compute the
-    // auto-black level and embed it in each waterfall tile (the client uses it
-    // as the black/low point). When off, the client falls back to its
-    // manual/estimated threshold.
+    m_wfAutoBlackOn = on;
+    applyWaterfallAutoBlack();
+}
+
+void RadioModel::setWaterfallAutoBlackSource(bool radioSide)
+{
+    m_wfAutoBlackRadioSide = radioSide;
+    applyWaterfallAutoBlack();
+}
+
+void RadioModel::applyWaterfallAutoBlack()
+{
+    // The radio only needs to compute and embed its per-tile auto-black level
+    // when the user has selected radio-side auto-black AND auto-black is on.
+    // Otherwise the client renders the floor from its own estimate, so keep
+    // auto_black=0 (radio-authoritative when, and only when, the user asks).
     if (activeWfId().isEmpty()) return;
+    const int v = (m_wfAutoBlackOn && m_wfAutoBlackRadioSide) ? 1 : 0;
     sendCmd(
         QString("display panafall set %1 auto_black=%2")
-            .arg(activeWfId()).arg(on ? 1 : 0));
+            .arg(activeWfId()).arg(v));
 }
 
 void RadioModel::setWaterfallLineDuration(int ms)
@@ -5303,12 +5316,14 @@ void RadioModel::configureWaterfall(const QString& waterfallId)
     const QString targetWaterfallId = RadioStatusOwnership::normalizedFlexId(waterfallId);
     if (targetWaterfallId.isEmpty()) return;
 
-    // Enable radio auto-black so the radio computes the per-tile black level
-    // (radio-authoritative); the client reads it from each tile. black_level is
-    // the manual fallback (ignored while auto_black=1); color_gain is applied
-    // client-side via wfHighThresholdRaw.
+    // Initialize with radio auto-black OFF (the client renders the floor from
+    // its own estimate by default). The persisted auto-black on/off and
+    // client-vs-radio source are pushed moments later from the session layer
+    // via setWaterfallAutoBlack()/setWaterfallAutoBlackSource(), which raise
+    // auto_black=1 only when the user has selected radio-side. black_level is
+    // the manual fallback; color_gain is applied client-side via wfHighThresholdRaw.
     // FlexLib uses "display panafall set" addressed to the waterfall stream ID.
-    const QString cmd = QString("display panafall set %1 auto_black=1 black_level=15 color_gain=50")
+    const QString cmd = QString("display panafall set %1 auto_black=0 black_level=15 color_gain=50")
                             .arg(targetWaterfallId);
     sendCmd(cmd, [this, targetWaterfallId](int code, const QString&) {
         if (code != 0) {
@@ -5316,7 +5331,7 @@ void RadioModel::configureWaterfall(const QString& waterfallId)
                      << Qt::hex << code << "— trying display waterfall set";
             // Fallback for firmware that doesn't support panafall addressing
             sendCmd(
-                QString("display waterfall set %1 auto_black=1 black_level=15 color_gain=50")
+                QString("display waterfall set %1 auto_black=0 black_level=15 color_gain=50")
                     .arg(targetWaterfallId),
                 [](int code2, const QString&) {
                     if (code2 != 0)
@@ -5326,7 +5341,7 @@ void RadioModel::configureWaterfall(const QString& waterfallId)
                         qCDebug(lcProtocol) << "RadioModel: waterfall configured via display waterfall set";
                 });
         } else {
-            qCDebug(lcProtocol) << "RadioModel: waterfall configured (auto_black=1 black_level=15 color_gain=50)";
+            qCDebug(lcProtocol) << "RadioModel: waterfall configured (auto_black=0 black_level=15 color_gain=50)";
         }
     });
 }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1808,12 +1808,14 @@ void RadioModel::setWaterfallBlackLevel(int level)
 
 void RadioModel::setWaterfallAutoBlack(bool on)
 {
-    Q_UNUSED(on);
-    // Auto-black is handled client-side. Always keep radio's auto_black off
-    // because its algorithm targets SmartSDR's rendering, not ours.
+    // Radio-authoritative auto-black: when on, let the radio compute the
+    // auto-black level and embed it in each waterfall tile (the client uses it
+    // as the black/low point). When off, the client falls back to its
+    // manual/estimated threshold.
     if (activeWfId().isEmpty()) return;
     sendCmd(
-        QString("display panafall set %1 auto_black=0").arg(activeWfId()));
+        QString("display panafall set %1 auto_black=%2")
+            .arg(activeWfId()).arg(on ? 1 : 0));
 }
 
 void RadioModel::setWaterfallLineDuration(int ms)
@@ -5301,9 +5303,12 @@ void RadioModel::configureWaterfall(const QString& waterfallId)
     const QString targetWaterfallId = RadioStatusOwnership::normalizedFlexId(waterfallId);
     if (targetWaterfallId.isEmpty()) return;
 
-    // Disable automatic black-level and set a fixed threshold.
+    // Enable radio auto-black so the radio computes the per-tile black level
+    // (radio-authoritative); the client reads it from each tile. black_level is
+    // the manual fallback (ignored while auto_black=1); color_gain is applied
+    // client-side via wfHighThresholdRaw.
     // FlexLib uses "display panafall set" addressed to the waterfall stream ID.
-    const QString cmd = QString("display panafall set %1 auto_black=0 black_level=15 color_gain=50")
+    const QString cmd = QString("display panafall set %1 auto_black=1 black_level=15 color_gain=50")
                             .arg(targetWaterfallId);
     sendCmd(cmd, [this, targetWaterfallId](int code, const QString&) {
         if (code != 0) {
@@ -5311,7 +5316,7 @@ void RadioModel::configureWaterfall(const QString& waterfallId)
                      << Qt::hex << code << "— trying display waterfall set";
             // Fallback for firmware that doesn't support panafall addressing
             sendCmd(
-                QString("display waterfall set %1 auto_black=0 black_level=15 color_gain=50")
+                QString("display waterfall set %1 auto_black=1 black_level=15 color_gain=50")
                     .arg(targetWaterfallId),
                 [](int code2, const QString&) {
                     if (code2 != 0)
@@ -5321,7 +5326,7 @@ void RadioModel::configureWaterfall(const QString& waterfallId)
                         qCDebug(lcProtocol) << "RadioModel: waterfall configured via display waterfall set";
                 });
         } else {
-            qCDebug(lcProtocol) << "RadioModel: waterfall configured (auto_black=0 black_level=15 color_gain=50)";
+            qCDebug(lcProtocol) << "RadioModel: waterfall configured (auto_black=1 black_level=15 color_gain=50)";
         }
     });
 }

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -357,6 +357,10 @@ public:
     void setWaterfallColorGain(int gain);
     void setWaterfallBlackLevel(int level);
     void setWaterfallAutoBlack(bool on);
+    // Auto-black source: false = client-side estimate (radio auto_black off),
+    // true = radio's per-tile level (radio auto_black on). The radio only
+    // receives auto_black=1 when auto-black is on AND radio-side is selected.
+    void setWaterfallAutoBlackSource(bool radioSide);
     void setWaterfallLineDuration(int ms);
 
     // Display controls — Noise floor
@@ -539,6 +543,11 @@ private:
 
     void configurePan(const QString& panId);
     void configureWaterfall(const QString& waterfallId);
+    // Sends the radio auto_black flag from the combined auto-black on/off +
+    // client/radio-source state (auto_black=1 only when both select radio-side).
+    void applyWaterfallAutoBlack();
+    bool m_wfAutoBlackOn{true};         // mirrors the client auto-black on/off
+    bool m_wfAutoBlackRadioSide{false}; // false = client-side, true = radio-side
     bool profileLoadRadioStateWritesHeld() const;
     void registerAsGuiClient(const QString& clientId);
     void disconnectPendingClientsThen(std::function<void()> continuation);


### PR DESCRIPTION
## Summary

Makes the waterfall noise floor render as a flat, evenly-levelled band by using the **radio's own per-tile auto-black level** instead of a client-side estimate.

AetherSDR was computing its own noise-floor estimate and sending the radio `auto_black=0`, which produced a textured, black-speckled floor. The radio already computes a noise-floor black level and embeds it in every waterfall tile (FlexLib's `WaterfallTile.AutoBlackLevel`) — AetherSDR even parsed it (`PanadapterStream.cpp`) and emitted `waterfallAutoBlackLevel()`, but the value was discarded (the handler clamped the raw uint16 to 0–125).

This wires it up:

1. `RadioModel` sends `auto_black=1` so the radio populates the tile field.
2. `MainWindow_Session` feeds the per-tile value into the renderer via the new `SpectrumWidget::setRadioAutoBlackLevel()`.
3. `intensityToRgb` maps `low` = radio auto-black, `high` = `wfHighThresholdRaw()` — a cubic colour-gain curve:
   ```
   num  = (100 − colorGain)/100 · cbrt(65535 − low)
   high = low + num³          (floored at low + 100)
   ```
   then `t = (rawValue − low) / (high − low)` → gradient. The client-side estimate stays as a fallback (FFT fallback / auto-black off).

Both display paths are covered — the native waterfall is coloured on the CPU via `intensityToRgb`, then uploaded as a texture (no GPU-side mapping).

## Reviewer note

Try it with **Waterfall (Color) Gain ≈ 30** and **Auto Black Level ≈ 30** — it works very well, particularly with the new **Purple** colour scheme (#3583). At default Color Gain and Black Level offset = 50 (no bias), the floor follows the radio's computed level directly.

## Constitution principle honored

**Principle I — FlexLib Is The Protocol Authority.** Replaces a client-side approximation with the radio's own auto-black value (FlexLib's per-tile `AutoBlackLevel`), the authoritative noise-floor figure.

It also **reverses a deliberate client-side decision** and changes a rendering default for all waterfall schemes, so it is flagged for **maintainer sign-off** on the look (Principle XIII — the operator/maintainer is the authority on visual design).

## Test plan

- [x] Local build passes (`cmake --build build`) — links clean
- [x] Verified on a live FLEX-8600 (fw 4.2.20.41343) — floor now evenly levelled
- [ ] Existing tests pass (CI)
- [ ] Maintainer review of the architecture reversal + visual default

## Open questions for review

- The auto-black **offset** slider now biases the radio black point (`(50 − offset)·0.5·128` raw); scaling is open to tuning.
- Initial waterfall config sends `auto_black=1` unconditionally; could instead reflect the persisted client auto-black state.

## Checklist

- [x] No new flat-key `AppSettings` calls (none added)
- [x] All meter UI uses `MeterSmoother` — N/A (no meters touched)
- [x] Commits are signed (SSH)
- [x] Security-sensitive changes reference a GHSA — N/A
