### PR TITLE
docs(agents): cue AI contributors to sign commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,13 @@ When helping with AetherSDR:
 - **Use `AppSettings`, never `QSettings`** — see "Settings Persistence" below
 - **Read `CONTRIBUTING.md`** for full contributor guidelines, coding conventions,
   and the AI-to-AI debugging protocol (open a GitHub issue for cross-agent coordination)
+- **Sign every commit you author.** `main` enforces `required_signatures`, so a
+  PR with unsigned commits cannot merge without an admin override. If the
+  contributor has not set up commit signing yet, walk them through
+  `docs/COMMIT-SIGNING.md` **before** you commit — the top of that file is a
+  step-by-step AI-assistant algorithm covering Windows / macOS / Linux / WSL /
+  Raspberry Pi. Default to SSH signing; GPG is the fallback for existing GPG
+  workflows. Verify with `git log --show-signature -1` after the first commit.
 - **Read the AetherSDR Constitution before writing or reviewing code.**
   Canonical source: `.specify/memory/constitution.md`. Byte-identical
   mirror at `CONSTITUTION.md` in repo root for discoverability. 14


### PR DESCRIPTION
## What

Adds a contributor-facing bullet to the **AI Agent Guidelines** in `AGENTS.md` so that an AI helping a new contributor author a PR proactively picks up that `main` enforces `required_signatures`, and points it at `docs/COMMIT-SIGNING.md` to set signing up **before** the first commit.

## Why

`AGENTS.md` already has a maintainer-facing note ("Helping a contributor set up commit signing?") in the CI/CD section, but nothing in the top-of-file guidelines list that an AI reads when it starts authoring. New contributors using an AI assistant would hit the unsigned-commit wall only at merge time. This surfaces the requirement up front.

## Change

One bullet, grouped with the other "read these" pointers (CONTRIBUTING.md / Constitution):
- States `main` enforces `required_signatures`.
- Routes to `docs/COMMIT-SIGNING.md` (which already carries the step-by-step AI-assistant algorithm for Windows/macOS/Linux/WSL/Pi).
- Default SSH signing, GPG fallback; verify with `git log --show-signature -1`.

Docs-only. No code paths touched.

Principle XII (signed-commit enforcement is infrastructure, not prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)