### PR TITLE
Constitution v2.0.0: trim domain conventions, add governance principles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ an issue, lead with "Fixes #N" or "Closes #N". -->
 
 <!-- Cite the principle by Roman numeral when relevant.  E.g.
 "Principle V — new feature uses nested-JSON persistence."
-"Principle II — MeterSmoother used for the new meter widget."
+"Principle IV — code is clean-room, not derived from decompiled sources."
 See CONSTITUTION.md for the full list. -->
 
 ## Test plan
@@ -36,6 +36,8 @@ See CONSTITUTION.md for the full list. -->
 - [ ] Commits are signed (`docs/COMMIT-SIGNING.md`)
 - [ ] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
       (Principle V)
-- [ ] All meter UI uses `MeterSmoother` (Principle II)
+- [ ] Code is clean-room — not decompiled, disassembled, or
+      reverse-engineered from a proprietary binary (Principle IV)
+- [ ] All meter UI uses `MeterSmoother` (AGENTS.md convention)
 - [ ] Documentation updated if user-visible behavior changed
 - [ ] Security-sensitive changes reference a GHSA if applicable

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ priority must-knows that fit in Copilot's chat context window.
    stores `{"enabled": true, "mode": "auto"}` under `AppSettings["MyFeature"]`,
    not `MyFeatureEnabled` + `MyFeatureMode` as flat keys.
 
-5. **All meter UI uses `MeterSmoother`** (Principle II). Do not
+5. **All meter UI uses `MeterSmoother`** (AGENTS.md convention). Do not
    suggest envelope followers, `std::pow`/`exp` smoothing, or
    asymmetric `kAlpha` blenders for new meter widgets.
 

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,14 +1,14 @@
 <!--
 SYNC IMPACT REPORT — maintained by /speckit.constitution
 ═══════════════════════════════════════════════════════
-Version change   : 1.0.1 → 1.1.0  [MINOR: 7 new principles adopted from Foundry constitution + Operator Outranks promoted]
-Principles       : +VIII Evidence Over Assertion, +IX Surface Only What Survives, +X Claims Are Atomic And Mortal, +XI Fixes Are Demonstrated, +XII Sandbox By Infrastructure Not By Prompt, +XIII The Operator Outranks Every Agent (promoted from Governance), +XIV Persist Atomically
-Sections changed : Core Principles (VIII-XIV added); Governance > Precedence (Foundry X citation removed — now Principle XIII)
-Templates needing update : aetherclaude/skills/implement-fix.md (still principle-agnostic, no change required; citations remain "Principle <N>." format)
-Downstream re-check      : CONSTITUTION.md (root mirror) ⟳  CLAUDE.md pointer ⟳ (principle count 7 → 14)  CONTRIBUTING.md pointer ⟳ (principle count 7 → 14)
-Follow-up TODOs  : pre-commit check to enforce .specify/memory/constitution.md ≡ CONSTITUTION.md byte-equality
-Last sync        : 2026-05-17
-Rationale        : AetherSDR's contribution surface is multi-agent in practice — at least 6 distinct AI tools touch the codebase (AetherClaude bot, Claude Code, OpenAI Codex, GPT 5.5 Pro, GitHub Copilot, contributor-side IDE agents).  The original 7 principles are AetherSDR-domain-specific architectural conventions; the 7 new principles codify defensive engineering for the multi-agent contribution model.  Foundry origin is cited per principle.
+Version change   : 1.1.0 → 2.0.0  [MAJOR: 5 AetherSDR-domain implementation conventions removed (relocated to AGENTS.md); 5 new governance principles added in their place. Net 14 principles, no gaps.]
+Principles       : Removed (now AGENTS.md pointers): the conventions formerly at II (MeterSmoother), III (User-Facing UI Labels), IV (BandPlanManager), VI (CHAIN Widget), VII (Auto-Generated Contributors). Added: +II The Radio Is Authoritative On Live State, +III Radio-Persistable Settings Live On The Radio, +IV Every Contribution Is Clean-Room, +VI AetherSDR Never Transmits Without Operator Intent, +VII Untrusted Input Is Validated At The Boundary. Retained: I FlexLib Authority and VIII–XIV (Foundry defensive set) unchanged; V kept its numeral but was rewritten/retitled — now "Each Feature Owns Its Configuration As A Single Object" (reframed from a nested-JSON convention to a config-ownership governance invariant; the nested-JSON substance is unchanged, so "Principle V." citations stay valid).
+Sections changed : Core Principles — old II/III/IV/VI/VII removed, new II/III/IV/VI/VII added; V rewritten/retitled (convention → governance invariant); I and VIII–XIV unchanged; Foundry-adopted note unchanged.
+Citation note    : Prior "Principle <N>." references to I, V, and VIII–XIV remain valid (V's numeral and nested-JSON substance are unchanged). References to II/III/IV/VI/VII now denote the NEW principles, not the relocated conventions — a deliberate refill of the numerals; a clean renumber is deferred to a later revision.
+Downstream re-check      : .specify/memory/constitution.md (byte mirror) ⟳  AGENTS.md (count still 14; domain-principle list changes; relocated conventions added as pointers) ⟳  CONTRIBUTING.md (count still 14; domain list changes) ⟳  README.md / GEMINI.md / .github/copilot-instructions.md / .github/PULL_REQUEST_TEMPLATE.md (count + stale "Principle II/IV" example citations) ⟳
+Follow-up TODOs  : a future revision may renumber to retire the refilled-numeral ambiguity; pre-commit check to enforce .specify/memory/constitution.md ≡ CONSTITUTION.md byte-equality
+Last sync        : 2026-06-14
+Rationale        : The conventions formerly at II/III/IV/VI/VII were AetherSDR-domain implementation guidance ("use this class, read from that manager") rather than governance principles encoding a cross-cutting failure mode; they move to AGENTS.md as pointers. The five new principles ARE governance invariants: radio-as-source-of-truth (live state and saved settings), clean-room provenance, transmit-only-on-intent, and boundary validation of untrusted input — each encoding a failure this project must never ship. Principle V was also rewritten — from "use nested JSON" guidance into the invariant beneath it (each feature owns its configuration as one self-contained, defaultable, atomically-writable object), the integrity pair to Principle XIV. I and VIII–XIV keep their numerals and meaning, and V keeps its numeral and nested-JSON substance, so their prior citations stay valid.
 ═══════════════════════════════════════════════════════
 This block is regenerated on every constitution change; do not hand-edit below the rule.
 -->
@@ -17,7 +17,7 @@ This block is regenerated on every constitution change; do not hand-edit below t
 
 | Field | Value |
 |---|---|
-| **Version** | 1.1.0 |
+| **Version** | 2.0.0 |
 | **Status** | `STABLE` |
 | **Applies to** | All AetherSDR contributions: source code, documentation, automation, release artifacts |
 
@@ -60,99 +60,155 @@ radio. The failure mode is "I sent the command, the radio ignored it,
 nothing logged the mismatch." FlexLib doesn't have that ambiguity
 because it is the implementation the radio side was built against.*
 
-### II. The Canonical MeterSmoother Owns All Meter Ballistics
+### II. The Radio Is Authoritative On Live State
 
-Every meter UI in AetherSDR uses `src/gui/MeterSmoother.h` (30 ms
-attack / 180 ms release at 120 Hz / 8 ms interval). Targets are
-normalized to `[0, 1]` via a `dbToRatio` helper before being passed
-to `setTarget()`. Asymmetric `kAlphaUp`/`kAlphaDown` blenders,
-`std::pow`/`exp` envelope followers, or copy-pasted smoothing from
-other meter widgets are prohibited unless the source widget is
-verified to itself be using `MeterSmoother`.
+The radio holds the live state; the client mirrors it. Whenever the
+client's model and the radio's reported state disagree about what is
+live — a frequency, a mode, a filter width, a slice or panadapter
+property — the radio wins and the client reconciles to it.
+Reconciliation flows one way only: radio status updates the client
+model; the client never writes its remembered value back over the
+radio's.
 
-*Why this is inviolable: meter ballistics are an interface-wide design
-property. When one meter follows different ballistics than its
-neighbors the whole panel reads as miscalibrated, and chasing the
-inconsistency back to its source takes far longer than always using
-the canonical class. If a meter genuinely needs different ballistics
-(e.g., a slower GR-bar release), use `MeterSmoother::Ballistics` to
-opt into different constants; never roll your own envelope follower.*
+A user action is a *request* to the radio. Where a command has no
+status echo the client may update optimistically, but the radio's
+subsequent status is the truth and supersedes the optimistic value if
+they differ. The command path runs client → radio; the truth path
+runs radio → client; the two must never form a feedback loop.
 
-### III. User-Facing Names Match The Visible UI Labels
+*Why this is inviolable: when the client lets its own model override
+what the radio reports, the two form a feedback loop and the operator
+sees values fight or flicker. The sharper failure is Multi-Flex — a
+second client that trusts its own optimistic guess over the radio's
+status drifts out of agreement with the radio and every other client,
+and nothing logs the divergence. Principle I fixes the protocol source
+of truth (FlexLib); this principle fixes the live-state source of
+truth (the radio): radio status is read as truth, client commands are
+only requests.*
 
-The toggle button at the top of `AppletPanel` says **DIGI**, so every
-user-facing reference — issue comments, wiki pages, README, the
-What's-New strings, error toasts — calls it **DIGI applet**. The
-internal class name `CatApplet` is *not* user-facing. Same convention
-applies anywhere the on-screen label and the C++ identifier disagree:
-the on-screen label wins for prose.
+### III. Radio-Persistable Settings Live On The Radio
 
-Similarly: the Help → Support → diagnostic logging toggles are
-**Discovery**, **Commands**, and **Status** — never `radio.connection`
-or any other backend category name. When asking a user to enable
-logging, use the names they actually see in the UI.
+If the radio can persist and recall a setting, that setting is saved
+to and recalled from the radio — never duplicated in client-side
+config. This holds for the whole of the radio's stored state, today's
+and whatever the firmware adds later; the deciding test is simply
+*whether the radio can save and restore the value*, not whether it
+appears on any list. The client persists only state the radio does not
+store at all — things like window geometry, layout, client-side-only
+DSP, and UI/display preferences.
 
-*Why this is inviolable: asking a user to "Enable DAX in the CAT
-applet" or "toggle radio.connection logging" sends them looking for a
-button that does not exist by that name. Support-channel friction
-compounds.*
+*Why this is inviolable: when both the client and the radio persist
+the same setting, they fight on reconnect. The radio's GUIClientID
+session restore is always more current than the client's remembered
+copy, so a client that recalls its own value clobbers the radio's live
+state and the operator watches their rig jump to stale settings for no
+reason they can see. Storing every radio-persistable setting only on
+the radio removes the second source of truth that can drift. This is
+the persistence corollary to Principle II: II says the radio wins on
+live state; III says the radio owns the saved state that becomes live
+state on the next connect.*
 
-### IV. Region-Aware Data Comes From BandPlanManager, Not BandDefs.h
+### IV. Every Contribution Is Clean-Room
 
-Anything that needs band edges, segment sizes, or per-band metadata
-reads from the active band plan loaded by `BandPlanManager` (driven
-by `AppSettings["BandPlanName"]` and the JSON files in
-`resources/bandplans/`). `src/models/BandDefs.h::kBands[]` is
-ARRL/US-allocations only and is not region-aware; it must not be the
-source for new features. The dialog should display the active plan
-read-only ("Using band plan: IARU Region 1 — change in View > Band
-Plan").
+Every contribution is clean-room from start to finish. Its code, and
+the protocol knowledge behind it, must come from clean sources: public
+documentation, open-source references, behavior observed on the wire,
+and the contributor's own design and implementation. Code that is
+decompiled, disassembled, or otherwise reverse-engineered from a
+proprietary binary — or transcribed, translated, or paraphrased from
+such output — must never enter the codebase, however correct or
+convenient it is.
 
-*Why this is inviolable: AetherSDR's user base spans IARU regions
-1/2/3. A feature that hardcodes ARRL band edges is wrong for everyone
-outside Region 2 and silently transmits outside the band plan in
-specific cases.*
+The clean inputs are explicit. Reading FlexLib's published open-source
+code (Principle I), capturing and studying the protocol as it actually
+behaves on the wire, and reading official or public documentation are
+all clean-room.
 
-### V. New Configuration Uses Nested JSON Per Feature, Not Flat AppSettings
+The standard holds end to end: a contribution that began clean but
+pulled in decompiler output at any point is contaminated, and
+contamination is not a local defect — it travels to everything written
+by reading it.
 
-`AppSettings` has ~460 call sites in a flat key namespace; that
-flatness is on the refactor roadmap. New features must store their
-configuration as a single nested JSON blob under one root key (e.g.
-`AppSettings["AtuPreTune"] = {region, mode, …}`), not as a stack of
-new flat keys. Existing flat keys can stay until they are migrated.
+*Why this is inviolable: decompiled code carries its original
+copyright and license, so merging it silently relicenses someone
+else's proprietary work as GPLv3 — which we have no right to do.
+Worse, the contamination spreads to everything written from it, so the
+only remedy is to rip all of it out and rebuild clean; one tainted PR
+can put the licensing of the whole tree, and every fork, in question.
+Trivial to refuse at the door, ruinous to undo after.*
 
-*Why this is inviolable: every new flat key adds friction to the
-roadmapped refactor and produces an `AppSettings` namespace that is
-harder to reason about, harder to migrate, and harder to default
-correctly across versions. Nested JSON gives each feature its own
-isolated scope.*
+### V. Each Feature Owns Its Configuration As A Single Object
 
-### VI. The TX DSP Chain Has A Visual CHAIN Widget As Primary Entry
+Every feature's configuration is one self-contained object, owned by
+that feature and stored under a single root key as a nested value
+(e.g. `AppSettings["AtuPreTune"] = {region, mode, …}`) — never
+scattered as loose flat keys across the shared `AppSettings`
+namespace. The object is the unit of ownership: one place to default
+when it is absent, one place to migrate across versions, one value to
+write atomically.
 
-The TX DSP chain is stage-per-applet, and the visual CHAIN widget is
-the primary entry point for understanding and configuring it. New TX
-DSP stages must integrate with the CHAIN widget (be ordered, be
-toggleable, be inspectable through it) rather than introducing
-parallel UI entry points.
+Because it is whole, the feature's config can be defaulted, versioned,
+and persisted as a unit — the self-contained blob Principle XIV
+(atomic persistence) requires. New configuration always takes this
+shape; the legacy flat keys are grandfathered until migrated, and
+nothing new is added to them.
 
-*Why this is inviolable: the CHAIN widget is the user's mental model
-for the TX signal path. A new stage that bypasses the widget is a
-stage the user cannot reorder, cannot disable, and cannot see in
-context — which fragments the model and produces support calls about
-"missing" controls that are actually present elsewhere.*
+*Why this is inviolable: configuration scattered as independent keys
+has no owner and no boundary. Defaults drift as keys accrete piecemeal,
+keys orphan when a feature changes shape, and no migration or atomic
+write can treat the feature's settings as the coherent unit they
+actually are — a crash mid-write or a half-finished migration leaves
+the namespace in a state no feature put it in and no reader expects. A
+single owned object has one place to default, one to migrate, and one
+value to write atomically, so its persistence is correct by
+construction; a flat namespace of hundreds of keys is one nobody can
+fully reason about, and every change to it carries unpredictable blast
+radius.*
 
-### VII. The About Dialog Contributors List Is Auto-Generated
+### VI. AetherSDR Never Transmits Without Operator Intent
 
-The Contributors list in the About dialog is built at runtime from
-the GitHub API. Manual edits to it are reverted on the next build.
-If a contributor is missing, fix the GitHub-side attribution (commit
-authorship, co-authored-by trailer) — do not patch the dialog string.
+The operator is the licensed control operator and is responsible for
+every emission. The radio enforces its own out-of-band limits;
+AetherSDR's duty is narrower and absolute — it never causes a
+transmission the operator did not deliberately initiate.
 
-*Why this is inviolable: manual edits drift, get reverted by the
-auto-generation, and create a maintenance burden where every release
-must re-curate a list that the build system will overwrite anyway.
-Fixing the underlying attribution data is durable; patching the
-dialog is not.*
+AetherSDR never keys the transmitter on its own: not on a timer, not
+as a side effect of a status update or model change, not to recover or
+resync a state, not as an automatic retry. Every emission traces to a
+deliberate operator action — PTT, a tune request, a keyer or beacon
+the operator explicitly started. Any code path that can transmit fails
+closed: if the operator's intent to transmit is not unambiguous, it
+does not key.
+
+*Why this is inviolable: a transmission the operator never asked for
+puts a signal on the air under their callsign and their legal
+responsibility, and it cannot be recalled once it leaves the antenna.
+A client that can key the radio as a side effect — a stray retry, a
+state-recovery path, a misfired timer — makes a software defect
+transmit on the operator's license. Transmit is the one action where,
+if intent is in any doubt, the only safe choice is not to.*
+
+### VII. Untrusted Input Is Validated At The Boundary
+
+AetherSDR consumes many external byte streams — the radio's VITA-49
+status and IQ, TCI, MQTT, KISS, rigctl, SmartLink/WAN, HTTP map and
+spot feeds, and contributor-supplied files. None of it is trusted to
+be well-formed. Every parser bounds-checks lengths, caps allocations,
+validates ranges, and fails closed on malformed input; it must not
+crash, hang, over-allocate, or act on bad data.
+
+Validation happens at the boundary — where the bytes enter, once,
+before the data reaches the rest of the app — so the interior can
+treat parsed values as sound. A malformed or hostile message is an
+expected input, not an exceptional one, especially on paths reachable
+beyond localhost (SmartLink/WAN, a shared MQTT broker, an exposed KISS
+or rigctl port).
+
+*Why this is inviolable: the radio is on the LAN and several of these
+protocols are reachable over the WAN or a shared broker, so a single
+oversized field, truncated frame, or out-of-range index that a parser
+trusts becomes a crash, a hang, or a memory-safety bug an attacker can
+drive.*
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,11 @@ When helping with AetherSDR:
 - **Read the AetherSDR Constitution before writing or reviewing code.**
   Canonical source: `.specify/memory/constitution.md`. Byte-identical
   mirror at `CONSTITUTION.md` in repo root for discoverability. 14
-  principles total: 7 AetherSDR-domain conventions (FlexLib authority,
-  MeterSmoother, UI labels, BandPlanManager, nested-JSON config, CHAIN
-  widget, auto-generated Contributors) + 7 defensive engineering
-  principles adopted from Cisco's
+  principles total (constitution v2.0.0): 7 AetherSDR-domain governance
+  principles (FlexLib authority, radio-authoritative live state,
+  radio-persistable settings, clean-room contributions, per-feature
+  config ownership, transmit-on-intent, boundary input validation) + 7
+  defensive engineering principles adopted from Cisco's
   [Foundry Constitution](https://github.com/CiscoDevNet/foundry-security-spec/blob/main/constitution.md)
   (Evidence Over Assertion, Surface Only What Survives, Claims Are
   Atomic And Mortal, Fixes Are Demonstrated, Sandbox By Infrastructure,
@@ -367,9 +368,10 @@ Run once at app or feature startup, not on every access.
 
 ### Radio-Authoritative Settings Policy
 
-**The radio is always authoritative for any setting it stores.** AetherSDR
-must never save, recall, or override radio-side settings from client-side
-persistence. Only save client-side settings for things the radio does NOT save.
+**The radio is always authoritative for any setting it stores** (Constitution
+Principles II & III). AetherSDR must never save, recall, or override radio-side
+settings from client-side persistence. Only save client-side settings for things
+the radio does NOT save.
 
 **Radio-authoritative (do NOT persist):** frequency, mode, filter, step size,
 AGC, squelch, DSP flags, antennas, TX power, panadapter *count* and per-pan
@@ -405,6 +407,37 @@ Every meter / level-bar / GR readout in the GUI must drive its display
 value through `MeterSmoother` (`src/gui/MeterSmoother.h`). Don't write
 new envelope-follower code or copy smoothing logic from other widgets
 — `MeterSmoother`'s header has the API and a usage example.
+
+### User-facing names match the on-screen UI labels
+
+In prose (issue comments, README, What's-New strings, error toasts, support
+requests) call a control by the label the user sees, not the C++ class name —
+e.g. the **DIGI applet** (class `CatApplet`), and the Help → Support logging
+toggles **Discovery / Commands / Status** (not backend names like
+`radio.connection`). The on-screen label wins for prose, so users can find the
+control you're naming.
+
+### Region-aware band data — read from BandPlanManager, not BandDefs.h
+
+Anything needing band edges, segment sizes, or per-band metadata reads the
+active plan via `BandPlanManager` (`AppSettings["BandPlanName"]` + the JSON in
+`resources/bandplans/`). `src/models/BandDefs.h::kBands[]` is ARRL/US-only and
+not region-aware — don't source new features from it; AetherSDR's users span
+IARU regions 1/2/3.
+
+### TX DSP stages integrate with the CHAIN widget
+
+The TX DSP chain is stage-per-applet and the visual **CHAIN** widget is the
+primary entry point. New TX DSP stages must be ordered, toggleable, and
+inspectable through the CHAIN widget rather than adding a parallel UI entry —
+it's the user's mental model for the TX signal path.
+
+### The About-dialog Contributors list is auto-generated
+
+The Contributors list in the About dialog is built at runtime from the GitHub
+API; manual edits are overwritten on the next build. If someone is missing, fix
+the GitHub-side attribution (commit authorship / `Co-Authored-By` trailer),
+don't patch the dialog string.
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2218,7 +2218,7 @@ add_executable(perf_telemetry_test
     tests/perf_telemetry_test.cpp
     src/core/PerfTelemetry.cpp
     # LogManager.cpp owns the lcPerf Q_LOGGING_CATEGORY definition (per
-    # Principle III consolidation, #2770); LogManager has AsyncLogWriter
+    # the Q_LOGGING_CATEGORY consolidation in #2770); LogManager has AsyncLogWriter
     # as a member which transitively needs AppSettings, so all three .cpp
     # files come along to satisfy the ctor/dtor chain at link time.
     src/core/LogManager.cpp

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -1,14 +1,14 @@
 <!--
 SYNC IMPACT REPORT — maintained by /speckit.constitution
 ═══════════════════════════════════════════════════════
-Version change   : 1.0.1 → 1.1.0  [MINOR: 7 new principles adopted from Foundry constitution + Operator Outranks promoted]
-Principles       : +VIII Evidence Over Assertion, +IX Surface Only What Survives, +X Claims Are Atomic And Mortal, +XI Fixes Are Demonstrated, +XII Sandbox By Infrastructure Not By Prompt, +XIII The Operator Outranks Every Agent (promoted from Governance), +XIV Persist Atomically
-Sections changed : Core Principles (VIII-XIV added); Governance > Precedence (Foundry X citation removed — now Principle XIII)
-Templates needing update : aetherclaude/skills/implement-fix.md (still principle-agnostic, no change required; citations remain "Principle <N>." format)
-Downstream re-check      : CONSTITUTION.md (root mirror) ⟳  CLAUDE.md pointer ⟳ (principle count 7 → 14)  CONTRIBUTING.md pointer ⟳ (principle count 7 → 14)
-Follow-up TODOs  : pre-commit check to enforce .specify/memory/constitution.md ≡ CONSTITUTION.md byte-equality
-Last sync        : 2026-05-17
-Rationale        : AetherSDR's contribution surface is multi-agent in practice — at least 6 distinct AI tools touch the codebase (AetherClaude bot, Claude Code, OpenAI Codex, GPT 5.5 Pro, GitHub Copilot, contributor-side IDE agents).  The original 7 principles are AetherSDR-domain-specific architectural conventions; the 7 new principles codify defensive engineering for the multi-agent contribution model.  Foundry origin is cited per principle.
+Version change   : 1.1.0 → 2.0.0  [MAJOR: 5 AetherSDR-domain implementation conventions removed (relocated to AGENTS.md); 5 new governance principles added in their place. Net 14 principles, no gaps.]
+Principles       : Removed (now AGENTS.md pointers): the conventions formerly at II (MeterSmoother), III (User-Facing UI Labels), IV (BandPlanManager), VI (CHAIN Widget), VII (Auto-Generated Contributors). Added: +II The Radio Is Authoritative On Live State, +III Radio-Persistable Settings Live On The Radio, +IV Every Contribution Is Clean-Room, +VI AetherSDR Never Transmits Without Operator Intent, +VII Untrusted Input Is Validated At The Boundary. Retained: I FlexLib Authority and VIII–XIV (Foundry defensive set) unchanged; V kept its numeral but was rewritten/retitled — now "Each Feature Owns Its Configuration As A Single Object" (reframed from a nested-JSON convention to a config-ownership governance invariant; the nested-JSON substance is unchanged, so "Principle V." citations stay valid).
+Sections changed : Core Principles — old II/III/IV/VI/VII removed, new II/III/IV/VI/VII added; V rewritten/retitled (convention → governance invariant); I and VIII–XIV unchanged; Foundry-adopted note unchanged.
+Citation note    : Prior "Principle <N>." references to I, V, and VIII–XIV remain valid (V's numeral and nested-JSON substance are unchanged). References to II/III/IV/VI/VII now denote the NEW principles, not the relocated conventions — a deliberate refill of the numerals; a clean renumber is deferred to a later revision.
+Downstream re-check      : .specify/memory/constitution.md (byte mirror) ⟳  AGENTS.md (count still 14; domain-principle list changes; relocated conventions added as pointers) ⟳  CONTRIBUTING.md (count still 14; domain list changes) ⟳  README.md / GEMINI.md / .github/copilot-instructions.md / .github/PULL_REQUEST_TEMPLATE.md (count + stale "Principle II/IV" example citations) ⟳
+Follow-up TODOs  : a future revision may renumber to retire the refilled-numeral ambiguity; pre-commit check to enforce .specify/memory/constitution.md ≡ CONSTITUTION.md byte-equality
+Last sync        : 2026-06-14
+Rationale        : The conventions formerly at II/III/IV/VI/VII were AetherSDR-domain implementation guidance ("use this class, read from that manager") rather than governance principles encoding a cross-cutting failure mode; they move to AGENTS.md as pointers. The five new principles ARE governance invariants: radio-as-source-of-truth (live state and saved settings), clean-room provenance, transmit-only-on-intent, and boundary validation of untrusted input — each encoding a failure this project must never ship. Principle V was also rewritten — from "use nested JSON" guidance into the invariant beneath it (each feature owns its configuration as one self-contained, defaultable, atomically-writable object), the integrity pair to Principle XIV. I and VIII–XIV keep their numerals and meaning, and V keeps its numeral and nested-JSON substance, so their prior citations stay valid.
 ═══════════════════════════════════════════════════════
 This block is regenerated on every constitution change; do not hand-edit below the rule.
 -->
@@ -17,7 +17,7 @@ This block is regenerated on every constitution change; do not hand-edit below t
 
 | Field | Value |
 |---|---|
-| **Version** | 1.1.0 |
+| **Version** | 2.0.0 |
 | **Status** | `STABLE` |
 | **Applies to** | All AetherSDR contributions: source code, documentation, automation, release artifacts |
 
@@ -60,99 +60,155 @@ radio. The failure mode is "I sent the command, the radio ignored it,
 nothing logged the mismatch." FlexLib doesn't have that ambiguity
 because it is the implementation the radio side was built against.*
 
-### II. The Canonical MeterSmoother Owns All Meter Ballistics
+### II. The Radio Is Authoritative On Live State
 
-Every meter UI in AetherSDR uses `src/gui/MeterSmoother.h` (30 ms
-attack / 180 ms release at 120 Hz / 8 ms interval). Targets are
-normalized to `[0, 1]` via a `dbToRatio` helper before being passed
-to `setTarget()`. Asymmetric `kAlphaUp`/`kAlphaDown` blenders,
-`std::pow`/`exp` envelope followers, or copy-pasted smoothing from
-other meter widgets are prohibited unless the source widget is
-verified to itself be using `MeterSmoother`.
+The radio holds the live state; the client mirrors it. Whenever the
+client's model and the radio's reported state disagree about what is
+live — a frequency, a mode, a filter width, a slice or panadapter
+property — the radio wins and the client reconciles to it.
+Reconciliation flows one way only: radio status updates the client
+model; the client never writes its remembered value back over the
+radio's.
 
-*Why this is inviolable: meter ballistics are an interface-wide design
-property. When one meter follows different ballistics than its
-neighbors the whole panel reads as miscalibrated, and chasing the
-inconsistency back to its source takes far longer than always using
-the canonical class. If a meter genuinely needs different ballistics
-(e.g., a slower GR-bar release), use `MeterSmoother::Ballistics` to
-opt into different constants; never roll your own envelope follower.*
+A user action is a *request* to the radio. Where a command has no
+status echo the client may update optimistically, but the radio's
+subsequent status is the truth and supersedes the optimistic value if
+they differ. The command path runs client → radio; the truth path
+runs radio → client; the two must never form a feedback loop.
 
-### III. User-Facing Names Match The Visible UI Labels
+*Why this is inviolable: when the client lets its own model override
+what the radio reports, the two form a feedback loop and the operator
+sees values fight or flicker. The sharper failure is Multi-Flex — a
+second client that trusts its own optimistic guess over the radio's
+status drifts out of agreement with the radio and every other client,
+and nothing logs the divergence. Principle I fixes the protocol source
+of truth (FlexLib); this principle fixes the live-state source of
+truth (the radio): radio status is read as truth, client commands are
+only requests.*
 
-The toggle button at the top of `AppletPanel` says **DIGI**, so every
-user-facing reference — issue comments, wiki pages, README, the
-What's-New strings, error toasts — calls it **DIGI applet**. The
-internal class name `CatApplet` is *not* user-facing. Same convention
-applies anywhere the on-screen label and the C++ identifier disagree:
-the on-screen label wins for prose.
+### III. Radio-Persistable Settings Live On The Radio
 
-Similarly: the Help → Support → diagnostic logging toggles are
-**Discovery**, **Commands**, and **Status** — never `radio.connection`
-or any other backend category name. When asking a user to enable
-logging, use the names they actually see in the UI.
+If the radio can persist and recall a setting, that setting is saved
+to and recalled from the radio — never duplicated in client-side
+config. This holds for the whole of the radio's stored state, today's
+and whatever the firmware adds later; the deciding test is simply
+*whether the radio can save and restore the value*, not whether it
+appears on any list. The client persists only state the radio does not
+store at all — things like window geometry, layout, client-side-only
+DSP, and UI/display preferences.
 
-*Why this is inviolable: asking a user to "Enable DAX in the CAT
-applet" or "toggle radio.connection logging" sends them looking for a
-button that does not exist by that name. Support-channel friction
-compounds.*
+*Why this is inviolable: when both the client and the radio persist
+the same setting, they fight on reconnect. The radio's GUIClientID
+session restore is always more current than the client's remembered
+copy, so a client that recalls its own value clobbers the radio's live
+state and the operator watches their rig jump to stale settings for no
+reason they can see. Storing every radio-persistable setting only on
+the radio removes the second source of truth that can drift. This is
+the persistence corollary to Principle II: II says the radio wins on
+live state; III says the radio owns the saved state that becomes live
+state on the next connect.*
 
-### IV. Region-Aware Data Comes From BandPlanManager, Not BandDefs.h
+### IV. Every Contribution Is Clean-Room
 
-Anything that needs band edges, segment sizes, or per-band metadata
-reads from the active band plan loaded by `BandPlanManager` (driven
-by `AppSettings["BandPlanName"]` and the JSON files in
-`resources/bandplans/`). `src/models/BandDefs.h::kBands[]` is
-ARRL/US-allocations only and is not region-aware; it must not be the
-source for new features. The dialog should display the active plan
-read-only ("Using band plan: IARU Region 1 — change in View > Band
-Plan").
+Every contribution is clean-room from start to finish. Its code, and
+the protocol knowledge behind it, must come from clean sources: public
+documentation, open-source references, behavior observed on the wire,
+and the contributor's own design and implementation. Code that is
+decompiled, disassembled, or otherwise reverse-engineered from a
+proprietary binary — or transcribed, translated, or paraphrased from
+such output — must never enter the codebase, however correct or
+convenient it is.
 
-*Why this is inviolable: AetherSDR's user base spans IARU regions
-1/2/3. A feature that hardcodes ARRL band edges is wrong for everyone
-outside Region 2 and silently transmits outside the band plan in
-specific cases.*
+The clean inputs are explicit. Reading FlexLib's published open-source
+code (Principle I), capturing and studying the protocol as it actually
+behaves on the wire, and reading official or public documentation are
+all clean-room.
 
-### V. New Configuration Uses Nested JSON Per Feature, Not Flat AppSettings
+The standard holds end to end: a contribution that began clean but
+pulled in decompiler output at any point is contaminated, and
+contamination is not a local defect — it travels to everything written
+by reading it.
 
-`AppSettings` has ~460 call sites in a flat key namespace; that
-flatness is on the refactor roadmap. New features must store their
-configuration as a single nested JSON blob under one root key (e.g.
-`AppSettings["AtuPreTune"] = {region, mode, …}`), not as a stack of
-new flat keys. Existing flat keys can stay until they are migrated.
+*Why this is inviolable: decompiled code carries its original
+copyright and license, so merging it silently relicenses someone
+else's proprietary work as GPLv3 — which we have no right to do.
+Worse, the contamination spreads to everything written from it, so the
+only remedy is to rip all of it out and rebuild clean; one tainted PR
+can put the licensing of the whole tree, and every fork, in question.
+Trivial to refuse at the door, ruinous to undo after.*
 
-*Why this is inviolable: every new flat key adds friction to the
-roadmapped refactor and produces an `AppSettings` namespace that is
-harder to reason about, harder to migrate, and harder to default
-correctly across versions. Nested JSON gives each feature its own
-isolated scope.*
+### V. Each Feature Owns Its Configuration As A Single Object
 
-### VI. The TX DSP Chain Has A Visual CHAIN Widget As Primary Entry
+Every feature's configuration is one self-contained object, owned by
+that feature and stored under a single root key as a nested value
+(e.g. `AppSettings["AtuPreTune"] = {region, mode, …}`) — never
+scattered as loose flat keys across the shared `AppSettings`
+namespace. The object is the unit of ownership: one place to default
+when it is absent, one place to migrate across versions, one value to
+write atomically.
 
-The TX DSP chain is stage-per-applet, and the visual CHAIN widget is
-the primary entry point for understanding and configuring it. New TX
-DSP stages must integrate with the CHAIN widget (be ordered, be
-toggleable, be inspectable through it) rather than introducing
-parallel UI entry points.
+Because it is whole, the feature's config can be defaulted, versioned,
+and persisted as a unit — the self-contained blob Principle XIV
+(atomic persistence) requires. New configuration always takes this
+shape; the legacy flat keys are grandfathered until migrated, and
+nothing new is added to them.
 
-*Why this is inviolable: the CHAIN widget is the user's mental model
-for the TX signal path. A new stage that bypasses the widget is a
-stage the user cannot reorder, cannot disable, and cannot see in
-context — which fragments the model and produces support calls about
-"missing" controls that are actually present elsewhere.*
+*Why this is inviolable: configuration scattered as independent keys
+has no owner and no boundary. Defaults drift as keys accrete piecemeal,
+keys orphan when a feature changes shape, and no migration or atomic
+write can treat the feature's settings as the coherent unit they
+actually are — a crash mid-write or a half-finished migration leaves
+the namespace in a state no feature put it in and no reader expects. A
+single owned object has one place to default, one to migrate, and one
+value to write atomically, so its persistence is correct by
+construction; a flat namespace of hundreds of keys is one nobody can
+fully reason about, and every change to it carries unpredictable blast
+radius.*
 
-### VII. The About Dialog Contributors List Is Auto-Generated
+### VI. AetherSDR Never Transmits Without Operator Intent
 
-The Contributors list in the About dialog is built at runtime from
-the GitHub API. Manual edits to it are reverted on the next build.
-If a contributor is missing, fix the GitHub-side attribution (commit
-authorship, co-authored-by trailer) — do not patch the dialog string.
+The operator is the licensed control operator and is responsible for
+every emission. The radio enforces its own out-of-band limits;
+AetherSDR's duty is narrower and absolute — it never causes a
+transmission the operator did not deliberately initiate.
 
-*Why this is inviolable: manual edits drift, get reverted by the
-auto-generation, and create a maintenance burden where every release
-must re-curate a list that the build system will overwrite anyway.
-Fixing the underlying attribution data is durable; patching the
-dialog is not.*
+AetherSDR never keys the transmitter on its own: not on a timer, not
+as a side effect of a status update or model change, not to recover or
+resync a state, not as an automatic retry. Every emission traces to a
+deliberate operator action — PTT, a tune request, a keyer or beacon
+the operator explicitly started. Any code path that can transmit fails
+closed: if the operator's intent to transmit is not unambiguous, it
+does not key.
+
+*Why this is inviolable: a transmission the operator never asked for
+puts a signal on the air under their callsign and their legal
+responsibility, and it cannot be recalled once it leaves the antenna.
+A client that can key the radio as a side effect — a stray retry, a
+state-recovery path, a misfired timer — makes a software defect
+transmit on the operator's license. Transmit is the one action where,
+if intent is in any doubt, the only safe choice is not to.*
+
+### VII. Untrusted Input Is Validated At The Boundary
+
+AetherSDR consumes many external byte streams — the radio's VITA-49
+status and IQ, TCI, MQTT, KISS, rigctl, SmartLink/WAN, HTTP map and
+spot feeds, and contributor-supplied files. None of it is trusted to
+be well-formed. Every parser bounds-checks lengths, caps allocations,
+validates ranges, and fails closed on malformed input; it must not
+crash, hang, over-allocate, or act on bad data.
+
+Validation happens at the boundary — where the bytes enter, once,
+before the data reaches the rest of the app — so the interior can
+treat parsed values as sound. A malformed or hostile message is an
+expected input, not an exceptional one, especially on paths reachable
+beyond localhost (SmartLink/WAN, a shared MQTT broker, an exposed KISS
+or rigctl port).
+
+*Why this is inviolable: the radio is on the LAN and several of these
+protocols are reachable over the WAN or a shared broker, so a single
+oversized field, truncated frame, or out-of-range index that a parser
+trusts becomes a crash, a hang, or a memory-safety bug an attacker can
+drive.*
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,12 @@ that matches our conventions.
 2. **Read the [AetherSDR Constitution](CONSTITUTION.md).** (Canonical
    source: [`.specify/memory/constitution.md`](.specify/memory/constitution.md);
    the root [`CONSTITUTION.md`](CONSTITUTION.md) is a byte-identical
-   mirror.) **14 principles total**: 7 AetherSDR-specific (FlexLib
-   authority, MeterSmoother, UI labels, BandPlanManager, nested-JSON
-   config, CHAIN widget, auto-generated Contributors) + 7 defensive
-   engineering principles adopted from Cisco's
+   mirror.) **14 principles total** (constitution v2.0.0): 7
+   AetherSDR-specific (FlexLib authority, radio-authoritative live
+   state, radio-persistable settings, clean-room contributions,
+   per-feature config ownership, transmit-on-intent, boundary input
+   validation) + 7 defensive engineering principles adopted from
+   Cisco's
    [Foundry Constitution](https://github.com/CiscoDevNet/foundry-security-spec/blob/main/constitution.md)
    (Evidence Over Assertion, Surface Only What Survives, Atomic Claims,
    Demonstrated Fixes, Infra Sandbox, Operator Outranks Agents, Atomic

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -26,8 +26,8 @@ the must-knows that fit in Gemini's chat context efficiently.
    under one root key per feature (Principle V). Example pattern:
    `AppSettings["MyFeature"] = {"enabled": true, "mode": "auto"}`.
 
-5. **All meter UI uses `MeterSmoother`** (Principle II) — never
-   roll your own envelope follower.
+5. **All meter UI uses `MeterSmoother`** — never roll your own
+   envelope follower. (AGENTS.md → Key Implementation Patterns.)
 
 6. **Assign yourself to an issue or PR before posting a review,
    comment, or merge action** (`gh issue edit NNNN --add-assignee @me`

--- a/tests/band_plan_license_filter_test.cpp
+++ b/tests/band_plan_license_filter_test.cpp
@@ -6,8 +6,8 @@
 // disallowed frequency.  A future refactor (STL-algorithm consolidation,
 // parallelisation) could silently break this; these tests pin it. (#3060)
 //
-// Constitution: Principle IV (region-aware data comes from
-// BandPlanManager, not BandDefs.h).
+// Convention: region-aware data comes from BandPlanManager, not
+// BandDefs.h (AGENTS.md → Key Implementation Patterns).
 
 #include "models/BandPlanManager.h"
 


### PR DESCRIPTION
## What

Amends the AetherSDR Constitution **1.1.0 → 2.0.0** (MAJOR). Updates `CONSTITUTION.md` and the canonical `.specify/memory/constitution.md` (byte-identical) plus all downstream artifacts.

## Why

Five of the original principles (II MeterSmoother, III UI Labels, IV BandPlanManager, VI CHAIN Widget, VII Auto-Generated Contributors) were **AetherSDR-domain implementation conventions** — "use this class / read from that manager" guidance — not governance invariants encoding a cross-cutting failure mode. They're better expressed as pointers in `AGENTS.md`. In their place we add principles that *are* governance invariants for a TX-capable, networked, multi-client, AI-built SDR.

## Principle changes

**Removed → relocated to `AGENTS.md`** (Key Implementation Patterns): MeterSmoother ballistics, UI-label naming, BandPlanManager, CHAIN widget, auto-generated Contributors.

**Added:**
| # | Principle |
|---|---|
| II | **The Radio Is Authoritative On Live State** — on conflict the radio wins; reconciliation is radio→client only |
| III | **Radio-Persistable Settings Live On The Radio** — if the radio can save/recall it, it lives there, not the client |
| IV | **Every Contribution Is Clean-Room** — no decompiled/reverse-engineered code, start to finish (licensing integrity) |
| VI | **AetherSDR Never Transmits Without Operator Intent** — no keying as a side effect; the radio owns OOB limits, we own intent |
| VII | **Untrusted Input Is Validated At The Boundary** — every external stream parsed defensively, fails closed |

**Rewritten:** V — from "use nested JSON" guidance into the invariant beneath it: *Each Feature Owns Its Configuration As A Single Object* (defaultable, versionable, atomically-writable — the integrity pair to XIV).

**Unchanged:** I (FlexLib Authority), VIII–XIV (Foundry defensive set).

## Net result

Gapless **I–XIV, 14 principles**. I, V, and VIII–XIV keep their numerals and meaning, so their prior `Principle <N>.` citations stay valid. II/III/IV/VI/VII numerals were **refilled** with new principles — old citations to those numerals (git history, CHANGELOG) now denote different principles; a clean renumber is deferred to a later revision and recorded in the SYNC header's Citation note.

## Downstream sync (in this PR)

- `AGENTS.md` / `CONTRIBUTING.md` / `GEMINI.md` / `.github/copilot-instructions.md` — principle **count back to 14**, domain-principle list updated, the 5 relocated conventions added as `AGENTS.md` pointers, radio-authority section cross-references II & III.
- `.github/PULL_REQUEST_TEMPLATE.md` — fixed the stale Principle-II example; **added a clean-room (Principle IV) checklist item**.
- `CMakeLists.txt` — dropped an orphaned "Principle III" build comment.
- `tests/band_plan_license_filter_test.cpp` — re-pointed the old "Principle IV" comment to the AGENTS.md convention.

Constitution mirror verified byte-identical; no stale counts or dangling principle citations remain (CHANGELOG entries left as historical record).

Principle XIII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)