### PR TITLE
[codex] Fix profile FFT settling on load

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -774,6 +774,8 @@ private:
     bool             m_needAudioStream{false};
     qint64           m_profileLoadRadioStateWriteHoldUntilMs{0};
     QSet<QString>    m_pendingProfileLoadPanDimensions;
+    QHash<QString, int> m_profileLoadPendingFftYpixels;
+    QHash<QString, qint64> m_profileLoadPanDimensionsSettlingUntilMs;
 
     // Pending WAN radio (between requestConnect and connectReady)
     WanRadioInfo     m_pendingWanRadio;
@@ -848,13 +850,23 @@ private:
     void cancelTransmitFromIndicator();
     void beginProfileLoadRadioStateWriteHold(const QString& profileType, const QString& profileName);
     bool profileLoadRadioStateWritesHeld() const;
+    bool profileLoadPanDisplaySettling(const QString& panId) const;
     void holdNoiseFloorAutoAdjustForProfileLoad(qint64 untilMs);
     void reacquireNoiseFloorLocksAfterProfileLoad();
+    void releaseProfileLoadPanDisplayHold(const QString& panId, SpectrumWidget* sw);
+    void markProfileLoadPanDimensionsReady(const QString& panId, int yPixels);
+    bool profileLoadPanDimensionsMatchExpected(const QString& panId,
+                                               SpectrumWidget* sw) const;
+    void retryProfileLoadPanDimensions(const QString& panId, SpectrumWidget* sw);
     void scheduleProfileLoadRecovery(const QString& profileType, const QString& profileName);
     void runProfileLoadRecoveryPass(const QString& profileType, const QString& profileName,
                                     bool rearmDaxIq, bool resetDaxRxStreams);
-    void requestPanDimensionsForRadio(const QString& panId, SpectrumWidget* sw);
-    void sendPanDimensionsToRadio(const QString& panId, SpectrumWidget* sw);
+    void requestPanDimensionsForRadio(const QString& panId,
+                                      SpectrumWidget* sw,
+                                      bool updateLocalDecoderImmediately = false);
+    void sendPanDimensionsToRadio(const QString& panId,
+                                  SpectrumWidget* sw,
+                                  bool updateLocalDecoderImmediately);
     void flushPendingProfileLoadPanDimensions();
     class ClientEqEditor* m_clientEqEditor{nullptr}; // lazy — created on first Edit… click
     // Lazy-construct the floating EQ editor on first access, with all

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -58,6 +58,7 @@
 #include "models/SliceModel.h"
 
 #include <QMessageBox>
+#include <QDateTime>
 #include <QThread>
 #include <QTimer>
 
@@ -82,6 +83,19 @@ QString defaultPanLayoutForCount(int panCount)
     return kDefaultLayouts.value(panCount, QStringLiteral("1"));
 }
 constexpr qint64 kXvtrWaterfallDecisionLogIntervalMs = 20000;
+constexpr int kProfileLoadMinRenderableFrameBins = 128;
+
+bool profileLoadFrameLooksRenderable(const SpectrumWidget* spectrum, int binCount)
+{
+    if (binCount <= 0 || !panPixelDimensionsReady(spectrum)) {
+        return false;
+    }
+
+    // This is only a coarse sanity floor for profile-load release. Vertical
+    // FFT scale agreement is enforced separately via radio-reported y_pixels;
+    // horizontal bin counts can be reprojected by SpectrumWidget.
+    return binCount >= kProfileLoadMinRenderableFrameBins;
+}
 
 void logXvtrWaterfallDecision(quint32 streamId,
                               const QString& panId,
@@ -835,8 +849,49 @@ void MainWindow::wirePanLifecycle()
 {
     // ── Panadapter stream → spectrum widget ───────────────────────────────
     // Route FFT/waterfall data to the correct SpectrumWidget by stream ID
+    auto profileLoadFrameReady = [this](const QString& panId,
+                                        SpectrumWidget* sw,
+                                        int binCount) {
+        if (!profileLoadRadioStateWritesHeld()
+            && !profileLoadPanDisplaySettling(panId)) {
+            return true;
+        }
+
+        if (m_pendingProfileLoadPanDimensions.contains(panId)) {
+            if (!profileLoadRadioStateWritesHeld()) {
+                flushPendingProfileLoadPanDimensions();
+            }
+            return false;
+        }
+
+        const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+        if (auto expectedIt = m_profileLoadPendingFftYpixels.find(panId);
+            expectedIt != m_profileLoadPendingFftYpixels.end()) {
+            auto deadlineIt = m_profileLoadPanDimensionsSettlingUntilMs.find(panId);
+            if (deadlineIt == m_profileLoadPanDimensionsSettlingUntilMs.end()
+                || nowMs < deadlineIt.value()) {
+                return false;
+            }
+            if (!profileLoadPanDimensionsMatchExpected(panId, sw)) {
+                retryProfileLoadPanDimensions(panId, sw);
+                return false;
+            }
+            releaseProfileLoadPanDisplayHold(panId, sw);
+        } else if (auto it = m_profileLoadPanDimensionsSettlingUntilMs.find(panId);
+            it != m_profileLoadPanDimensionsSettlingUntilMs.end()) {
+            if (nowMs < it.value()) {
+                return false;
+            }
+            releaseProfileLoadPanDisplayHold(panId, sw);
+        }
+
+        return profileLoadFrameLooksRenderable(sw, binCount);
+    };
+
     connect(m_radioModel.panStream(), &PanadapterStream::spectrumReady,
-            this, [this](quint32 streamId, const QVector<float>& bins, qint64 emittedNs) {
+            this, [this, profileLoadFrameReady](quint32 streamId,
+                                                const QVector<float>& bins,
+                                                qint64 emittedNs) {
         if (m_shuttingDown || !m_panStack) {
             return;
         }
@@ -848,16 +903,27 @@ void MainWindow::wirePanLifecycle()
         for (auto* pan : m_radioModel.panadapters()) {
             if (pan->panStreamId() == streamId) {
                 if (auto* sw = m_panStack->spectrum(pan->panId())) {
+                    if (!profileLoadFrameReady(pan->panId(), sw, bins.size())) {
+                        return;
+                    }
                     sw->updateSpectrum(bins);
                     finishPanadapterConnectionAnimation();
                 }
                 return;
             }
         }
-        // Fallback: active spectrum (covers "default" pan before radio connects)
-        if (auto* sw = spectrum()) {
-            sw->updateSpectrum(bins);
-            finishPanadapterConnectionAnimation();
+        // Fallback: active spectrum only before any radio-owned pan has been
+        // claimed. During profile loads/removals, queued frames from streams
+        // that were just removed can arrive after their model is gone; drawing
+        // them into the current active pane produces a brief bogus trace.
+        if (m_radioModel.panadapters().isEmpty() && !profileLoadRadioStateWritesHeld()) {
+            if (auto* sw = spectrum()) {
+                sw->updateSpectrum(bins);
+                finishPanadapterConnectionAnimation();
+            }
+        } else {
+            qCDebug(lcProtocol) << "MainWindow: dropped unmatched FFT stream"
+                                << QStringLiteral("0x%1").arg(streamId, 0, 16);
         }
     });
     // ── S History Markers — tap into FFT frames for voice signal detection ──
@@ -865,8 +931,12 @@ void MainWindow::wirePanLifecycle()
             this, &MainWindow::onSpectrumReadyForSHistory);
 
     connect(m_radioModel.panStream(), &PanadapterStream::waterfallRowReady,
-            this, [this](quint32 streamId, const QVector<float>& bins,
-                         double low, double high, quint32 tc, qint64 emittedNs) {
+            this, [this, profileLoadFrameReady](quint32 streamId,
+                                                const QVector<float>& bins,
+                                                double low,
+                                                double high,
+                                                quint32 tc,
+                                                qint64 emittedNs) {
         if (m_shuttingDown || !m_panStack) {
             return;
         }
@@ -906,15 +976,23 @@ void MainWindow::wirePanLifecycle()
                     high = mapped.highMhz;
                 }
                 if (auto* sw = m_panStack->spectrum(pan->panId())) {
+                    if (!profileLoadFrameReady(pan->panId(), sw, bins.size())) {
+                        return;
+                    }
                     sw->updateWaterfallRow(bins, low, high, tc);
                     finishPanadapterConnectionAnimation();
                 }
                 return;
             }
         }
-        if (auto* sw = spectrum()) {
-            sw->updateWaterfallRow(bins, low, high, tc);
-            finishPanadapterConnectionAnimation();
+        if (m_radioModel.panadapters().isEmpty() && !profileLoadRadioStateWritesHeld()) {
+            if (auto* sw = spectrum()) {
+                sw->updateWaterfallRow(bins, low, high, tc);
+                finishPanadapterConnectionAnimation();
+            }
+        } else {
+            qCDebug(lcProtocol) << "MainWindow: dropped unmatched waterfall stream"
+                                << QStringLiteral("0x%1").arg(streamId, 0, 16);
         }
     });
     connect(m_radioModel.panStream(), &PanadapterStream::waterfallAutoBlackLevel,
@@ -1076,7 +1154,7 @@ void MainWindow::wirePanLifecycle()
         // FFT data is essentially empty/unusable. Use widget width and the
         // actual FFT pane height for 1:1 bin-to-pixel mapping.
         auto* sw = applet->spectrumWidget();
-        requestPanDimensionsForRadio(pan->panId(), sw);
+        requestPanDimensionsForRadio(pan->panId(), sw, true);
 
         qDebug() << "MainWindow: added panadapter applet for" << pan->panId();
 
@@ -1104,19 +1182,6 @@ void MainWindow::wirePanLifecycle()
                         .value("FloatingPanIds", "").toString();
                     m_panStack->rearrangeLayout(layoutId);
                     AppSettings::instance().setValue("FloatingPanIds", floatingPanIds);
-
-                    // Optimistically set local yPixels immediately so FFT frames
-                    // arriving before the radio echoes back use correct scaling (#1511).
-                    for (auto* a : m_panStack->allApplets()) {
-                        auto* s = a->spectrumWidget();
-                        auto* p = m_radioModel.panadapter(a->panId());
-                        if (!s || !p || !p->panStreamId()) continue;
-                        if (panPixelDimensionsReady(s)) {
-                            m_radioModel.panStream()->setYPixels(
-                                p->panStreamId(), panYpixelsFor(s));
-                            s->prepareForFftScaleChange();
-                        }
-                    }
 
                     // Defensive re-push xpixels for all pans after layout settles.
                     // Covers race where radio hadn't finished pan init when first push arrived.
@@ -1174,6 +1239,16 @@ void MainWindow::wirePanLifecycle()
         auto* pan = m_radioModel.panadapter(panId);
         if (!sw || !pan) return;
         requestPanDimensionsForRadio(panId, sw);
+    });
+    connect(&m_radioModel, &RadioModel::panadapterFftScaleChanged,
+            this, [this](const QString& panId, int yPixels) {
+        if (m_shuttingDown || !m_panStack) {
+            return;
+        }
+        markProfileLoadPanDimensionsReady(panId, yPixels);
+        if (auto* sw = m_panStack->spectrum(panId)) {
+            sw->prepareForFftScaleChange();
+        }
     });
 
 #ifdef Q_OS_MAC

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -68,6 +68,8 @@ constexpr double kRevealComfortEdgeMarginFrac = 0.18;
 constexpr double kSpectrumClickEdgeMarginFrac = 0.05;
 
 constexpr double kMemoryRevealTargetToleranceMhz = 0.000001;
+constexpr int kPanDimensionDecoderFallbackMs = 650;
+constexpr qint64 kProfileLoadDimensionSettleMs = kPanDimensionDecoderFallbackMs + 100;
 
 bool memoryRevealTargetMatches(double actualMhz, double targetMhz)
 {
@@ -787,7 +789,18 @@ void MainWindow::beginProfileLoadRadioStateWriteHold(const QString& profileType,
     if (m_bsAutoSaveTimer) {
         m_bsAutoSaveTimer->stop();
     }
+    m_pendingProfileLoadPanDimensions.clear();
+    m_profileLoadPendingFftYpixels.clear();
+    m_profileLoadPanDimensionsSettlingUntilMs.clear();
     holdNoiseFloorAutoAdjustForProfileLoad(untilMs);
+    if (m_panStack) {
+        for (PanadapterApplet* applet : m_panStack->allApplets()) {
+            if (applet && applet->spectrumWidget()) {
+                applet->spectrumWidget()->clearDisplay();
+            }
+        }
+    }
+    setPanadapterConnectionAnimation(true, "Loading profile...");
 
     qCInfo(lcProtocol).noquote()
         << "MainWindow: holding profile-owned radio state writes"
@@ -798,6 +811,13 @@ void MainWindow::beginProfileLoadRadioStateWriteHold(const QString& profileType,
 bool MainWindow::profileLoadRadioStateWritesHeld() const
 {
     return QDateTime::currentMSecsSinceEpoch() < m_profileLoadRadioStateWriteHoldUntilMs;
+}
+
+bool MainWindow::profileLoadPanDisplaySettling(const QString& panId) const
+{
+    return m_pendingProfileLoadPanDimensions.contains(panId)
+        || m_profileLoadPendingFftYpixels.contains(panId)
+        || m_profileLoadPanDimensionsSettlingUntilMs.contains(panId);
 }
 
 void MainWindow::holdNoiseFloorAutoAdjustForProfileLoad(qint64 untilMs)
@@ -834,13 +854,82 @@ void MainWindow::reacquireNoiseFloorLocksAfterProfileLoad()
                 m_radioModel.panStream()->setDbmRange(
                     pan->panStreamId(), pan->minDbm(), pan->maxDbm());
             }
-            sw->setDbmRange(pan->minDbm(), pan->maxDbm());
+            if (!sw->noiseFloorAutoAdjustEnabled()) {
+                sw->setDbmRange(pan->minDbm(), pan->maxDbm());
+            }
         }
-        sw->reacquireNoiseFloorLock();
+        if (sw->noiseFloorAutoAdjustEnabled()) {
+            sw->resumeNoiseFloorAutoAdjust();
+        } else {
+            sw->reacquireNoiseFloorLock();
+        }
     }
 }
 
-void MainWindow::sendPanDimensionsToRadio(const QString& panId, SpectrumWidget* sw)
+void MainWindow::releaseProfileLoadPanDisplayHold(const QString& panId, SpectrumWidget* sw)
+{
+    if (panId.isEmpty()) {
+        return;
+    }
+
+    m_pendingProfileLoadPanDimensions.remove(panId);
+    m_profileLoadPendingFftYpixels.remove(panId);
+    m_profileLoadPanDimensionsSettlingUntilMs.remove(panId);
+    if (sw) {
+        sw->resumeNoiseFloorAutoAdjust();
+    }
+}
+
+void MainWindow::markProfileLoadPanDimensionsReady(const QString& panId, int yPixels)
+{
+    auto expectedIt = m_profileLoadPendingFftYpixels.find(panId);
+    if (expectedIt == m_profileLoadPendingFftYpixels.end()
+        || expectedIt.value() != yPixels) {
+        return;
+    }
+
+    releaseProfileLoadPanDisplayHold(
+        panId,
+        m_panStack ? m_panStack->spectrum(panId) : nullptr);
+}
+
+bool MainWindow::profileLoadPanDimensionsMatchExpected(const QString& panId,
+                                                       SpectrumWidget* sw) const
+{
+    auto expectedIt = m_profileLoadPendingFftYpixels.find(panId);
+    if (expectedIt == m_profileLoadPendingFftYpixels.end()) {
+        return true;
+    }
+
+    return sw
+        && panPixelDimensionsReady(sw)
+        && panYpixelsFor(sw) == expectedIt.value();
+}
+
+void MainWindow::retryProfileLoadPanDimensions(const QString& panId, SpectrumWidget* sw)
+{
+    if (panId.isEmpty() || !sw) {
+        return;
+    }
+
+    m_profileLoadPendingFftYpixels.remove(panId);
+    m_profileLoadPanDimensionsSettlingUntilMs.remove(panId);
+
+    if (!panPixelDimensionsReady(sw)) {
+        m_pendingProfileLoadPanDimensions.insert(panId);
+        return;
+    }
+
+    m_profileLoadPendingFftYpixels.insert(panId, panYpixelsFor(sw));
+    m_profileLoadPanDimensionsSettlingUntilMs.insert(
+        panId,
+        QDateTime::currentMSecsSinceEpoch() + kProfileLoadDimensionSettleMs);
+    sendPanDimensionsToRadio(panId, sw, false);
+}
+
+void MainWindow::sendPanDimensionsToRadio(const QString& panId,
+                                          SpectrumWidget* sw,
+                                          bool updateLocalDecoderImmediately)
 {
     // Raw sender for radio FFT dimensions. Normal lifecycle/resize paths must
     // call requestPanDimensionsForRadio() instead so profile loads can defer
@@ -861,13 +950,48 @@ void MainWindow::sendPanDimensionsToRadio(const QString& panId, SpectrumWidget* 
         QString("display pan set %1 xpixels=%2 ypixels=%3")
             .arg(panId).arg(xpix).arg(ypix));
 
-    if (pan->panStreamId()) {
-        m_radioModel.panStream()->setYPixels(pan->panStreamId(), ypix);
-        sw->prepareForFftScaleChange();
+    if (profileLoadRadioStateWritesHeld()) {
+        m_profileLoadPendingFftYpixels.insert(panId, ypix);
+        m_profileLoadPanDimensionsSettlingUntilMs.insert(
+            panId,
+            QDateTime::currentMSecsSinceEpoch() + kProfileLoadDimensionSettleMs);
+    }
+
+    const quint32 streamId = pan->panStreamId();
+    if (streamId) {
+        QPointer<SpectrumWidget> swGuard(sw);
+        auto updateLocalDecoder = [this, panId, swGuard, streamId, ypix]() {
+            if (m_shuttingDown || !swGuard) {
+                return;
+            }
+            auto* currentPan = m_radioModel.panadapter(panId);
+            if (!currentPan || currentPan->panStreamId() != streamId) {
+                return;
+            }
+            if (!panPixelDimensionsReady(swGuard.data())
+                || panYpixelsFor(swGuard.data()) != ypix) {
+                return;
+            }
+            m_radioModel.panStream()->setYPixels(streamId, ypix);
+            swGuard->prepareForFftScaleChange();
+        };
+
+        if (updateLocalDecoderImmediately) {
+            updateLocalDecoder();
+        } else {
+            // Radio status echo is the normal sync point. The delayed fallback
+            // preserves resize recovery if the echo is missed, without decoding
+            // queued old-height FFT frames with the new height.
+            QTimer::singleShot(kPanDimensionDecoderFallbackMs,
+                               this,
+                               updateLocalDecoder);
+        }
     }
 }
 
-void MainWindow::requestPanDimensionsForRadio(const QString& panId, SpectrumWidget* sw)
+void MainWindow::requestPanDimensionsForRadio(const QString& panId,
+                                              SpectrumWidget* sw,
+                                              bool updateLocalDecoderImmediately)
 {
     if (panId.isEmpty() || !sw || !panPixelDimensionsReady(sw)) {
         return;
@@ -887,7 +1011,7 @@ void MainWindow::requestPanDimensionsForRadio(const QString& panId, SpectrumWidg
         return;
     }
 
-    sendPanDimensionsToRadio(panId, sw);
+    sendPanDimensionsToRadio(panId, sw, updateLocalDecoderImmediately);
 }
 
 void MainWindow::flushPendingProfileLoadPanDimensions()
@@ -906,7 +1030,7 @@ void MainWindow::flushPendingProfileLoadPanDimensions()
             continue;
         }
 
-        sendPanDimensionsToRadio(applet->panId(), applet->spectrumWidget());
+        sendPanDimensionsToRadio(applet->panId(), applet->spectrumWidget(), false);
         ++sent;
     }
 
@@ -960,6 +1084,8 @@ void MainWindow::scheduleProfileLoadRecovery(const QString& profileType,
         flushPendingProfileLoadPanDimensions();
     });
     QTimer::singleShot(kProfileLoadPostHoldRecoveryDelayMs, this, [this]() {
+        m_profileLoadPendingFftYpixels.clear();
+        m_profileLoadPanDimensionsSettlingUntilMs.clear();
         reacquireNoiseFloorLocksAfterProfileLoad();
 #ifdef HAVE_WEBSOCKETS
         if (tciServer()) {
@@ -1337,7 +1463,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                   (float minDbm, float maxDbm) {
         const bool profileLoadHeld = profileLoadRadioStateWritesHeld();
         const bool autoFloorChange = sw->pendingAutoNoiseFloorDbmRange();
-        if (profileLoadHeld && autoFloorChange) {
+        if (profileLoadPanDisplaySettling(applet->panId()) && autoFloorChange) {
             if (auto* pan = m_radioModel.panadapter(applet->panId())) {
                 if (pan->panStreamId()) {
                     setStreamDbmRange(pan->minDbm(), pan->maxDbm());

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -893,7 +893,9 @@ void SpectrumWidget::loadSettings()
     // Match the enable-time fresh-frame seed used by setNoiseFloorEnable so a
     // restored Floor=on locks onto the current floor without smoothing from a
     // stale value.
-    m_noiseFloorFreshFrameCount = m_noiseFloorEnable ? 5 : 0;
+    if (m_noiseFloorEnable) {
+        armNoiseFloorFastLock(5, 1);
+    }
     applyFpsMeterVisibility(
         s.value("DisplayFpsMeters", "False").toString() == "True");
     m_wfColorScheme  = static_cast<WfColorScheme>(
@@ -1061,7 +1063,9 @@ void SpectrumWidget::setNoiseFloorEnable(bool on) {
     resetNoiseFloorBaseline();
     // Five fresh frames after enable so we lock onto the current
     // floor without smoothing from a stale value.
-    m_noiseFloorFreshFrameCount = on ? 5 : 0;
+    if (on) {
+        armNoiseFloorFastLock(5, 1);
+    }
     if (on) {
         refreshNoiseFloorTarget();
     }
@@ -1079,7 +1083,7 @@ void SpectrumWidget::reacquireNoiseFloorLock() {
     // slice command, so keep cold-acquiring long enough to catch the new floor.
     // 30 frames ≈ 1 s of cold-acquire at the default 30 Hz FFT update rate —
     // long enough for the antenna change to settle through the radio.
-    m_noiseFloorFreshFrameCount = 30;
+    armNoiseFloorFastLock(30, 1);
     m_measuredNoiseFloorDbm = -1000.0f;
 }
 
@@ -1100,6 +1104,17 @@ void SpectrumWidget::suspendNoiseFloorAutoAdjustUntil(qint64 untilMs)
     m_noiseFloorCandidateFrames = 0;
 }
 
+void SpectrumWidget::resumeNoiseFloorAutoAdjust()
+{
+    m_noiseFloorAutoAdjustHoldUntilMs = 0;
+    if (!m_noiseFloorEnable) {
+        return;
+    }
+
+    resetNoiseFloorBaseline();
+    armNoiseFloorFastLock(8, 1);
+}
+
 void SpectrumWidget::prepareForFftScaleChange()
 {
     m_resetFftSmoothingOnNextFrame = true;
@@ -1109,6 +1124,7 @@ void SpectrumWidget::prepareForFftScaleChange()
     const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
     m_noiseFloorScaleSettlingUntilMs =
         std::max(m_noiseFloorScaleSettlingUntilMs, nowMs + kScaleSettleMs);
+    armNoiseFloorFastLock(8, 1);
     m_noiseFloorCandidateValid = false;
     m_noiseFloorCandidateFrames = 0;
 }
@@ -1399,6 +1415,7 @@ void SpectrumWidget::resetNoiseFloorBaseline()
     m_noiseFloorCandidateStartMs = 0;
     m_noiseFloorCandidateFrames = 0;
     m_noiseFloorFreshFrameCount = m_noiseFloorEnable ? 5 : 0;
+    m_noiseFloorFastLockFrames = 0;
     m_pendingDbmRangeEcho = false;
     m_pendingDbmRangeEchoFromAutoFloor = false;
     m_pendingDbmRangeEchoStartMs = 0;
@@ -1469,9 +1486,9 @@ bool SpectrumWidget::captureNoiseFloorTargetFromCurrentScale(bool notify, bool p
     return true;
 }
 
-void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool forceBaseline)
+bool SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool forceBaseline)
 {
-    if (!m_noiseFloorEnable || m_transmitting || bins.isEmpty()) return;
+    if (!m_noiseFloorEnable || m_transmitting || bins.isEmpty()) return false;
 
     const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
     if (m_pendingDbmRangeEcho
@@ -1487,7 +1504,7 @@ void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
             m_pendingDbmRangeEchoFromAutoFloor = false;
             m_pendingDbmRangeEchoStartMs = 0;
         }
-        return;
+        return false;
     }
     if (m_pendingDbmRangeEcho) {
         if (m_pendingDbmRangeEchoFromAutoFloor
@@ -1496,10 +1513,13 @@ void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
             && !isDraggingDbmScale()) {
             applyNoiseFloorAutoAdjust(nowMs);
         }
-        return;
+        return false;
     }
 
-    if (m_noiseFloorScaleSettlingUntilMs > nowMs) return;
+    const bool fastLockFrame = forceBaseline && m_noiseFloorFastLockFrames > 0;
+    if (m_noiseFloorScaleSettlingUntilMs > nowMs && !fastLockFrame) {
+        return false;
+    }
     if (m_noiseFloorScaleSettlingUntilMs > 0) {
         m_noiseFloorScaleSettlingUntilMs = 0;
         m_noiseFloorCandidateValid = false;
@@ -1507,7 +1527,7 @@ void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
     }
 
     const float frameFloor = estimateNoiseFloorDbm(bins);
-    if (frameFloor <= -500.0f || m_dynamicRange <= 0.0f) return;
+    if (frameFloor <= -500.0f || m_dynamicRange <= 0.0f) return false;
 
     if (!m_noiseFloorBaselineValid || m_noiseFloorLastSampleMs <= 0 || forceBaseline) {
         // Cold-acquire: force the baseline to this frame's reading.
@@ -1535,7 +1555,7 @@ void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
                 m_noiseFloorCandidateStartMs = nowMs;
                 m_noiseFloorCandidateFrames = 1;
                 m_noiseFloorLastSampleMs = nowMs;
-                return;
+                return false;
             }
             m_noiseFloorCandidateDbm =
                 0.65f * m_noiseFloorCandidateDbm + 0.35f * frameFloor;
@@ -1552,7 +1572,7 @@ void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
                    && candidateAgeMs < requiredAgeMs);
             if (keepWaiting) {
                 m_noiseFloorLastSampleMs = nowMs;
-                return;
+                return false;
             }
         } else {
             m_noiseFloorCandidateValid = false;
@@ -1582,12 +1602,13 @@ void SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
 
     if (!m_noiseFloorTargetValid) {
         refreshNoiseFloorTarget();
-        if (!m_noiseFloorTargetValid) return;
+        if (!m_noiseFloorTargetValid) return true;
     }
 
-    if (isDraggingDbmScale() || m_pendingDbmRangeEcho) return;
+    if (isDraggingDbmScale() || m_pendingDbmRangeEcho) return true;
 
     applyNoiseFloorAutoAdjust(nowMs);
+    return true;
 }
 
 void SpectrumWidget::applyNoiseFloorAutoAdjust(qint64 nowMs)
@@ -1603,7 +1624,21 @@ void SpectrumWidget::applyNoiseFloorAutoAdjust(qint64 nowMs)
     const float desiredRef = m_noiseFloorBaselineDbm
         + m_noiseFloorTargetFrac * m_dynamicRange;
     const float clampedRef = std::max(desiredRef, kMinDisplayDbm + m_dynamicRange);
-    if (std::abs(clampedRef - m_refLevel) < 0.45f) return;
+    if (std::abs(clampedRef - m_refLevel) < 0.45f) {
+        if (m_noiseFloorFastLockFrames > 0) {
+            --m_noiseFloorFastLockFrames;
+        }
+        return;
+    }
+
+    if (m_noiseFloorFastLockFrames > 0) {
+        --m_noiseFloorFastLockFrames;
+        m_noiseFloorLastMotionMs = nowMs;
+        m_refLevel = clampedRef;
+        markOverlayDirty();
+        sendNoiseFloorRangeCommand(nowMs, true);
+        return;
+    }
 
     moveRefLevelToward(clampedRef, nowMs);
 }
@@ -1616,9 +1651,20 @@ bool SpectrumWidget::noiseFloorAutoAdjustHeld(qint64 nowMs)
     if (m_noiseFloorAutoAdjustHoldUntilMs > 0) {
         m_noiseFloorAutoAdjustHoldUntilMs = 0;
         resetNoiseFloorBaseline();
+        armNoiseFloorFastLock(8, 1);
         return true;
     }
     return false;
+}
+
+void SpectrumWidget::armNoiseFloorFastLock(int freshFrames, int snapFrames)
+{
+    if (!m_noiseFloorEnable) {
+        return;
+    }
+
+    m_noiseFloorFreshFrameCount = std::max(m_noiseFloorFreshFrameCount, freshFrames);
+    m_noiseFloorFastLockFrames = std::max(m_noiseFloorFastLockFrames, snapFrames);
 }
 
 void SpectrumWidget::moveRefLevelToward(float targetRef, qint64 nowMs)
@@ -2924,7 +2970,13 @@ void SpectrumWidget::applyDbmRangeImmediate(float minDbm, float maxDbm)
     m_dynamicRange = dyn;
     m_resetFftSmoothingOnNextFrame = true;
     resetNoiseFloorBaseline();
-    markOverlayDirty();
+    if (m_noiseFloorEnable) {
+        // Do not repaint the radio-owned range as an intermediate state when
+        // client-side auto floor is about to place the trace on the next frame.
+        armNoiseFloorFastLock(5, 1);
+    } else {
+        markOverlayDirty();
+    }
 }
 
 // ─── Slice color table (shared via SliceColors.h) ────────────────────────────
@@ -3384,9 +3436,10 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
     // rfoust's PR #2643 work and consolidated into this existing path.
     const bool useFreshLockFrame =
         m_noiseFloorFreshFrameCount > 0 && !spectrumBins->isEmpty();
-    updateNoiseFloorBaseline(useFreshLockFrame ? *spectrumBins : m_smoothed,
-                             useFreshLockFrame);
-    if (useFreshLockFrame) --m_noiseFloorFreshFrameCount;
+    const bool noiseFloorFrameConsumed =
+        updateNoiseFloorBaseline(useFreshLockFrame ? *spectrumBins : m_smoothed,
+                                 useFreshLockFrame);
+    if (useFreshLockFrame && noiseFloorFrameConsumed) --m_noiseFloorFreshFrameCount;
 
     // ── Auto-squelch: own two-pass trimmed-mean noise floor ───────────────
     // Independent copy of the floor measurement — not borrowed from the

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -118,6 +118,7 @@ public:
     void setNoiseFloorEnable(bool on);
     void prepareForFftScaleChange();
     void suspendNoiseFloorAutoAdjustUntil(qint64 untilMs);
+    void resumeNoiseFloorAutoAdjust();
     void reacquireNoiseFloorLock();
 
     // Two-pass trimmed-mean noise floor from live FFT bins (dBm), EMA-smoothed.
@@ -158,6 +159,7 @@ public:
     bool pendingAutoNoiseFloorDbmRange() const {
         return m_pendingDbmRangeEcho && m_pendingDbmRangeEchoFromAutoFloor;
     }
+    bool noiseFloorAutoAdjustEnabled() const { return m_noiseFloorEnable; }
     double centerMhz()    const { return m_centerMhz; }
     double bandwidthMhz() const { return m_bandwidthMhz; }
 
@@ -628,7 +630,7 @@ private:
     // adjust path.  Per-frame, asymmetric smoothing (drops follow
     // quickly, rises slowly), with a candidate-state transient filter
     // so brief upward spikes (lightning crashes) don't pull the lock.
-    void updateNoiseFloorBaseline(const QVector<float>& bins, bool forceBaseline);
+    bool updateNoiseFloorBaseline(const QVector<float>& bins, bool forceBaseline);
     // Adjust m_refLevel toward the target so the smoothed noise floor
     // sits at m_noiseFloorPosition.  Pans the dB range (keeps span
     // fixed) rather than zooming it (existing zoom-when-floor-moves
@@ -636,6 +638,7 @@ private:
     // every time the floor drifted).
     void applyNoiseFloorAutoAdjust(qint64 nowMs);
     bool noiseFloorAutoAdjustHeld(qint64 nowMs);
+    void armNoiseFloorFastLock(int freshFrames, int snapFrames);
     void moveRefLevelToward(float targetRef, qint64 nowMs);
     void sendNoiseFloorRangeCommand(qint64 nowMs, bool force);
     void clearDbmReleaseRebase();
@@ -733,6 +736,7 @@ private:
     qint64 m_noiseFloorCandidateStartMs{0};
     int    m_noiseFloorCandidateFrames{0};
     int    m_noiseFloorFreshFrameCount{0};
+    int    m_noiseFloorFastLockFrames{0};
 
     // Percentile EWMA used for the amber floor overlay line and auto-squelch.
     // Tracked separately from m_measuredNoiseFloorDbm (two-pass trimmed mean)

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -45,6 +45,14 @@ public:
     bool loopB() const { return m_loopB; }
     int fps() const { return m_fps; }
     int waterfallLineDuration() const { return m_waterfallLineDuration; }
+    int fftYPixels() const { return m_fftYPixels; }
+    bool setFftYPixels(int yPixels) {
+        if (m_fftYPixels == yPixels) {
+            return false;
+        }
+        m_fftYPixels = yPixels;
+        return true;
+    }
     QString preamp() const { return m_preamp; }
     void setPreamp(const QString& pre) {
         // Preamp is internal state only — no UI listeners. Do not emit
@@ -105,6 +113,7 @@ private:
     int         m_wnbLevel{50};
     int         m_fps{-1};
     int         m_waterfallLineDuration{-1};
+    int         m_fftYPixels{-1};
     QString     m_preamp;
     int         m_daxiqChannel{0};
     bool        m_resized{false};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -27,7 +27,8 @@ namespace AetherSDR {
 
 namespace {
 
-constexpr int kMinUsablePanYpixels = 100;
+constexpr int kMinFftDecodeYpixels = 2;
+constexpr int kDefaultPanDimensionThreshold = 100;
 constexpr int kSessionRestorePruneDelayMs = 5000;
 constexpr int kWaterfallLineDurationMinMs = 1;
 constexpr int kWaterfallLineDurationMaxMs = 100;
@@ -5240,6 +5241,7 @@ void RadioModel::handlePanadapterStatus(const QString& panId, const QMap<QString
 {
     // Delegate to the specific PanadapterModel, not just the active one
     auto* pan = m_panadapters.value(panId, nullptr);
+    const bool panMatchedById = pan != nullptr;
     if (!pan) pan = activePanadapter();  // fallback
     const float previousMinDbm = pan ? pan->minDbm() : 0.0f;
     const float previousMaxDbm = pan ? pan->maxDbm() : 0.0f;
@@ -5267,18 +5269,28 @@ void RadioModel::handlePanadapterStatus(const QString& panId, const QMap<QString
     // Y positions (0..ypixels-1), so PanadapterStream needs this for dBm conversion.
     // Also detect when the radio resets to default dimensions (e.g. after profile
     // load) and re-request correct dimensions from MainWindow.
-    if (kvs.contains("y_pixels") && pan) {
-        int yPix = kvs["y_pixels"].toInt();
-        if (yPix > kMinUsablePanYpixels) {
+    if (kvs.contains("y_pixels") && pan && panMatchedById) {
+        const int yPix = kvs["y_pixels"].toInt();
+        if (yPix >= kMinFftDecodeYpixels) {
+            // Profile recall can temporarily reset the radio to small default
+            // dimensions. The FFT decoder still needs that exact value because
+            // samples are encoded as radio pixel Y positions; only the dimension
+            // re-push decision below treats small values as unusable long-term.
+            const bool scaleChanged = pan->setFftYPixels(yPix);
             m_panStream->setYPixels(pan->panStreamId(), yPix);
+            if (scaleChanged) {
+                emit panadapterFftScaleChanged(pan->panId(), yPix);
+            }
         }
     }
-    if ((kvs.contains("x_pixels") || kvs.contains("y_pixels")) && pan) {
-        int xPix = kvs.value("x_pixels", "0").toInt();
-        int yPix = kvs.value("y_pixels", "0").toInt();
+    if ((kvs.contains("x_pixels") || kvs.contains("y_pixels")) && pan && panMatchedById) {
+        const int xPix = kvs.value("x_pixels", "0").toInt();
+        const int yPix = kvs.value("y_pixels", "0").toInt();
         // Radio reset to defaults (profile load, reconnect) — re-push real dimensions
-        if ((xPix > 0 && xPix <= 100) || (yPix > 0 && yPix <= 100))
+        if ((xPix > 0 && xPix <= kDefaultPanDimensionThreshold)
+            || (yPix > 0 && yPix <= kDefaultPanDimensionThreshold)) {
             emit panDimensionsNeeded(pan->panId());
+        }
     }
     if (kvs.contains("ant_list")) {
         const QStringList ants = kvs["ant_list"].split(',', Qt::SkipEmptyParts);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -391,6 +391,8 @@ signals:
     void panadapterInfoChanged(double centerMhz, double bandwidthMhz);
     // Emitted when the radio reports the panadapter's dBm display range.
     void panadapterLevelChanged(float minDbm, float maxDbm);
+    // Emitted when the radio reports FFT pixel height for a panadapter.
+    void panadapterFftScaleChanged(const QString& panId, int yPixels);
     void panadapterAdded(PanadapterModel* pan);
     // Emitted when a previous-session pan model is reclaimed on reconnect
     // instead of created fresh. The applet/widget wiring from the original


### PR DESCRIPTION
## Summary

Fixes intermittent bogus FFT rendering during app startup and profile load. The panadapter display now waits until radio-reported FFT pixel height, local decoder scale, and widget dimensions are aligned before drawing restored-profile FFT/waterfall frames. It also drops stale/unmatched stream frames during profile rebuild, clears old display contents while the profile topology is settling, and lets client-side auto FFT leveling reacquire locally without writing radio-owned pan dBm state back to the radio.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. This addresses a user-reported visual regression and was iterated against live radio behavior, with local build and focused regression checks run before PR.

## Test plan

- [x] Local build passes (`cmake --build build --parallel`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug
  - App startup with restored multi-pan layout no longer briefly draws high/incorrect FFT traces during layout reorg.
  - Profile load no longer briefly draws stale/high FFT traces while restored pan dimensions and auto FFT leveling settle.

Local checks run:

```bash
git diff --check
cmake --build build --parallel
ctest --test-dir build --output-on-failure -R profile_load_command_test
ctest --test-dir build --output-on-failure -R panadapter_model_rx_antenna_test
```

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] All meter UI uses `MeterSmoother` (Principle II)
- [ ] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable
