### PR TITLE
feat(websdr): add optional listen-only WebSDR receive module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1195,6 +1195,13 @@ if(Qt6WebSockets_FOUND)
         src/core/FreeDvClient.cpp
         src/gui/FreeDvReporterDialog.cpp
         src/gui/FreeDvReporterModel.cpp
+        # WebSDR receive module (passive bolt-on, listen-only)
+        src/core/WebSdrAudioDecoder.cpp
+        src/core/WebSdrWaterfallDecoder.cpp
+        src/core/WebSdrSource.cpp
+        src/gui/WebSdrPanel.cpp
+        src/gui/WebSdrWaterfallView.cpp
+        src/gui/MainWindow_WebSdr.cpp
     )
     target_link_libraries(AetherSDR PRIVATE Qt6::WebSockets)
 endif()

--- a/docs/architecture/websdr-module-spec.md
+++ b/docs/architecture/websdr-module-spec.md
@@ -1,0 +1,334 @@
+# WebSDR Receive Module — Technical Specification
+
+Status: **implementation-ready**. Branch: `feat/websdr-module`.
+Companion to [`websdr-module.md`](websdr-module.md) (concept & rationale). This
+document is the buildable spec: protocol, class interfaces, signals, threading,
+integration points, settings, and acceptance criteria. All protocol facts below
+were reverse-engineered from a live PA3FWM WebSDR instance and validated; the
+audio codec additionally has a reference implementation in the `websdr-client`
+repo.
+
+---
+
+## 1. Protocol reference
+
+All public WebSDR servers run the same software; only host/port and band layout
+differ. Two independent WebSockets, both on the same host:port as the HTTP UI.
+
+### 1.1 Audio stream — `ws://<host>/~~stream?v=11`
+
+- `binaryType = arraybuffer`. Tuning command (text frame):
+  `GET /~~param?f=<kHz>&band=<idx>&lo=<kHz>&hi=<kHz>&mode=<m>&name=<str>`
+- Mode integer: `0` = SSB/CW (USB/LSB/CW differ only via `lo`/`hi`), `1` = AM,
+  `4` = FM.
+- Binary frames are type-byte routed: `0xF0–0xFF` S-meter, `0x80` a-law block
+  (128 samples), `0x90–0xDF` and `0x00–0x7F` compressed adaptive-predictor audio,
+  `0x81` sample rate, `0x82` quantiser scale, `0x83` filter/mode, `0x84` silence,
+  `0x85` true frequency. Full codec + frame layout: `websdr-client/PROTOCOL.md`
+  and the C++ port spec in §3.2.
+- Native audio rate `D` is signalled by `0x81` (commonly 7–12 kHz), mono.
+
+### 1.2 Waterfall stream — `ws://<host>/~~waterstream<band>?format=<n>&width=<w>&zoom=<z>&start=<s>`
+
+- Note: band index is part of the **path** (`~~waterstream0`, `~~waterstream1`…).
+- `binaryType = arraybuffer`. Control command (text frame):
+  `GET /~~waterparam?zoom=<z>&scale=<s>&slow=<n>&width=<w>&band=<idx>&start=<x>`
+- We request **`format=1`** — the simplest row encoding: each payload byte
+  produces **two** horizontal pixels as palette indices:
+  - `pixel[2*e]   = 16*(byte & 0x0F) + 2`
+  - `pixel[2*e+1] = byte & 0xF2`
+- Rows are up to 1024 px wide; `width` sets the actual count. One binary message
+  ≈ one waterfall row (newest line).
+- **Meta frames** begin with byte `0xFF`:
+  - `0xFF 0x01 …`: scale/reference. `freq32 = b[3] | b[4]<<8 | b[5]<<16 | b[6]<<24`;
+    if `b[2] < 128`, `b[2]` is a level/scale hint; row payload resumes at byte 8.
+  - `0xFF 0x02 …`: `count = b[2] | b[3]<<8` leading pixels are blanked (zeroed).
+  - `0xFF 0xFF …`: escaped literal `0xFF` — strip one byte, the rest is row data.
+  - A row not starting with `0xFF` is raw row data from byte 0.
+- **Palette** (index 0–255 → RGB), replicated verbatim (8-bit wraparound as in the
+  original `Uint8Array`):
+
+  ```
+  e in   0..63 : R=0,           G=0,                       B=2*e
+  e in  64..127: R=3*e-192,     G=0,                       B=2*e
+  e in 128..191: R=e+64,        G=256*sqrt((e-128)/64),    B=511-2*e
+  e in 192..255: R=255,         G=255,                     B=512+2*e
+  (all components stored into a uint8 → take & 0xFF)
+  ```
+
+> Format 9 (compressed) exists but is **out of scope**; we always request
+> `format=1`.
+
+### 1.3 Band metadata — `http://<host>/tmp/bandinfo.js`
+
+JS literal: `nbands`, `ini_freq`, `ini_mode`, and `bandinfo[]` with
+`{ centerfreq, samplerate (kHz), tuningstep, vfo, maxzoom, name, scaleimgs[] }`.
+Band selection: pick the band whose `[centerfreq ± samplerate/2]` contains the
+requested frequency. Parsed once on connect.
+
+---
+
+## 2. Module overview
+
+```
+   ws ~~stream (audio)      ws ~~waterstream<band> (rows)
+            │                          │
+   ┌────────┴──────────────────────────┴────────┐  ◄── WEBSDR worker thread
+   │                WebSdrSource                  │      (moveToThread + init())
+   │  QWebSocket m_audioWs   QWebSocket m_wfWs     │
+   │  WebSdrAudioDecoder     WebSdrWaterfallDecoder│
+   │  state machine, reconnect backoff             │
+   └───┬───────────────────────────────┬──────────┘
+       │ webSdrAudioReady(QByteArray)   │ webSdrRowReady(WebSdrRow)   [auto-queued]
+       │ webSdrStateChanged(State)      │ webSdrSMeter(int)
+       ▼                                ▼
+  AudioEngine (source gate)        WebSdrPanel (QDockWidget)        [MAIN]
+       ▼                                ▼ paintEvent (QImage waterfall)
+   QAudioSink                      corner dock / detached window
+```
+
+- **Threading:** one dedicated worker thread (`m_webSdrThread`), created with the
+  established `moveToThread` + `init()` slot pattern (see `RadioConnection`,
+  `FreeDvClient`). Both `QWebSocket`s and both decoders live on it. All output is
+  via auto-queued signals to MAIN (panel) and to the AUDIO thread (audio).
+- **Authority:** the module is strictly read-only toward Flex. It never calls
+  `RadioModel`/`SliceModel`, never emits `commandReady`, never touches TX.
+
+---
+
+## 3. New classes
+
+### 3.1 `WebSdrSource` — `src/core/WebSdrSource.{h,cpp}`
+
+```cpp
+class WebSdrSource : public QObject {
+    Q_OBJECT
+public:
+    enum class State { Disconnected, Connecting, Connected, Streaming, Error };
+
+    explicit WebSdrSource(QObject* parent = nullptr);
+
+    struct BandInfo { double centerFreqKHz; double sampleRateKHz; QString name; };
+
+public slots:
+    void init();                          // runs on worker thread; creates sockets
+    void connectToServer(const QString& host /*host:port*/);
+    void disconnectFromServer();
+    void tune(double freqKHz, const QString& mode);  // mode: usb/lsb/cw/cwu/cwl/am/fm
+    void setWaterfallWidth(int px);       // ≤ 1024
+    void setZoom(int zoom);               // 0..maxzoom for the band
+
+signals:
+    void stateChanged(WebSdrSource::State, const QString& detail);
+    void bandsResolved(const QVector<WebSdrSource::BandInfo>&, int selectedBand);
+    void audioReady(const QByteArray& pcm24kStereoF32);   // → AudioEngine
+    void rowReady(const WebSdrRow& row);                  // → WebSdrPanel
+    void sMeter(int dbm);
+
+private:
+    // m_audioWs (~~stream?v=11), m_wfWs (~~waterstream<band>...)
+    // m_audioDec, m_wfDec; m_resampler; reconnect QTimer w/ exponential backoff
+    // current band/freq/mode/zoom; bandinfo cache
+};
+```
+
+- **State machine:** `Disconnected → Connecting → Connected` (sockets open,
+  bandinfo fetched) `→ Streaming` (first audio/row decoded). Any socket error →
+  `Error`, then a single reconnect attempt with **exponential backoff**
+  (2s, 4s, 8s, capped 30s) — *no reconnect storms* (etiquette, §8).
+- `tune()` sends `GET /~~param?…` on the audio socket and, if the band changed,
+  reopens the waterfall socket on the new `~~waterstream<band>` path.
+- `connectToServer()` fetches `bandinfo.js` (QNetworkAccessManager) before opening
+  the waterfall socket; emits `bandsResolved`.
+
+### 3.2 `WebSdrAudioDecoder` — `src/core/WebSdrAudioDecoder.{h,cpp}`
+
+- Direct C++ port of the verified decoder (`websdr-client/websdr_client.py`,
+  class `WebsdrDecoder`): 256-entry a-law table + 20-tap adaptive predictor,
+  persistent state (`coeff[20]`, `hist[20]`, `ie`, `re`, `oe`, `ae`, `D`).
+- API:
+  ```cpp
+  void feed(const QByteArray& frame);   // decode one binary WS message
+  QVector<int16_t> takeSamples();       // drained Int16 @ nativeRate()
+  int  nativeRate() const;              // D (Hz)
+  int  sMeter() const;
+  ```
+- Pure DSP, no Qt threading concerns; owned by `WebSdrSource`. Unit-testable
+  against captured frames (§9).
+
+### 3.3 `WebSdrWaterfallDecoder` — `src/core/WebSdrWaterfallDecoder.{h,cpp}`
+
+```cpp
+struct WebSdrRow {
+    QVector<QRgb> pixels;     // already palette-mapped, width px
+    quint32 freqRef = 0;      // from 0xFF 0x01 meta (optional)
+};
+
+class WebSdrWaterfallDecoder {
+public:
+    void setWidth(int px);
+    bool feed(const QByteArray& frame, WebSdrRow& out);  // true if a row produced
+private:
+    static QRgb palette(int idx);   // the §1.2 formulas, precomputed LUT[256]
+};
+```
+
+- Implements format-1 decode + the three meta-frame cases. Palette is a static
+  `QRgb[256]` LUT built once from the §1.2 formulas.
+
+### 3.4 `WebSdrPanel` — `src/gui/WebSdrPanel.{h,cpp}`
+
+- A `QDockWidget` (default docked bottom-right; floatable/detachable via the
+  standard `QDockWidget` feature flags — same UX as the existing pop-out pans).
+- Contents:
+  - **Header row:** host combo (recent hosts), frequency spin, mode combo
+    (USB/LSB/CW/CWU/CWL/AM/FM), Connect/Disconnect, **"Audio → WebSDR"** toggle,
+    S-meter, state/latency label.
+  - **Waterfall area:** `QImage` ring-buffer (height = N rows), repainted on
+    `rowReady`; newest row at top, scroll down. Plain `QPainter` — **not** the
+    QRhi pipeline.
+  - Optional thin spectrum strip above the waterfall (peak of recent rows).
+- **Click-to-tune:** clicking/dragging in the waterfall maps the x-pixel to a
+  frequency within the current band span and calls `WebSdrSource::tune()`.
+  Internal only — never tunes the Flex.
+- Reflects `stateChanged`; on disconnect/error, the "Audio → WebSDR" toggle drops
+  back to Flex automatically.
+
+### 3.5 `WebSdrSettings` — `src/core/WebSdrSettings.{h,cpp}`
+
+`QSettings`-backed, under group `webSdr/`:
+
+| key | type | meaning |
+|-----|------|---------|
+| `recentHosts` | QStringList | host:port MRU |
+| `lastHost` | QString | autofill |
+| `lastFreqKHz` | double | |
+| `lastMode` | QString | |
+| `zoom` | int | |
+| `panelVisible` | bool | dock shown |
+| `panelFloating` / `panelGeometry` | bool / QByteArray | detached state |
+| `audioPreferred` | bool | restore "Audio → WebSDR" on launch? (default false) |
+
+---
+
+## 4. AudioEngine integration — the source gate
+
+The **only** non-trivial edit to existing code. Today `feedAudioData()` is fed
+solely by `PanadapterStream::audioDataReady()` and the RX sink lifecycle is tied
+to the Flex connect. We add a small, thread-safe gate.
+
+### 4.1 Additions to `AudioEngine`
+
+```cpp
+enum class RxSource { Flex, WebSdr };
+
+Q_INVOKABLE void setRxSource(RxSource);          // default Flex
+RxSource rxSource() const;                        // atomic read
+Q_INVOKABLE void feedWebSdrAudio(const QByteArray& pcm24kStereoF32);
+```
+
+- `m_rxSource` is a `std::atomic<RxSource>` (default `Flex`).
+- In `feedAudioData()` (Flex path): if `m_rxSource == WebSdr`, **drop** the Flex
+  buffer (early return before DSP) so the speaker isn't double-fed.
+- `feedWebSdrAudio()`: if `m_rxSource == WebSdr`, route the buffer into the *same*
+  downstream DSP + `QAudioSink` path `feedAudioData()` uses; otherwise drop.
+- The RX sink (`startRxStream`) must be able to run when WebSDR is selected even
+  if no Flex is connected — decouple sink-open from the Flex connect so the panel
+  can `startRxStream()` on demand. (Audio worker thread; use the existing
+  `Q_INVOKABLE`/`QMetaObject::invokeMethod` pattern.)
+- **Fallback:** switching back to Flex, or WebSDR disconnect, restores the Flex
+  feed with no sink restart. WebSDR audio never reaches the radio (no TX path).
+
+### 4.2 Format contract
+
+`WebSdrSource` always emits **24 kHz stereo float32** (pipeline native). WebSDR
+native (mono, `D` Hz) → `Resampler` to 24 kHz → mono duplicated to L/R. No change
+to downstream DSP.
+
+---
+
+## 5. MainWindow / wiring
+
+- Own the `WebSdrSource` + worker thread (lazily created when the panel is first
+  enabled), and the `WebSdrPanel` dock.
+- Connections (all auto-queued across threads):
+  - `WebSdrSource::audioReady` → `AudioEngine::feedWebSdrAudio`
+  - `WebSdrSource::rowReady` / `sMeter` / `stateChanged` / `bandsResolved`
+    → `WebSdrPanel`
+  - `WebSdrPanel` "Audio → WebSDR" toggle → `AudioEngine::setRxSource` (+ ensure
+    `startRxStream`)
+  - `WebSdrPanel` connect/tune/zoom → `WebSdrSource`
+- A View-menu / toolbar entry toggles the dock. No changes to any Flex model.
+
+---
+
+## 6. Build wiring
+
+- New sources behind an optional `HAVE_WEBSDR` definition, gated on the already
+  present `Qt6WebSockets_FOUND` (reuse `Qt6::WebSockets`, no new dependency).
+- Mirror the existing `HAVE_WEBSOCKETS` block in `CMakeLists.txt`. When
+  WebSockets is absent, the module compiles out cleanly and the dock entry is
+  hidden.
+
+---
+
+## 7. Data formats & conversions
+
+| Stage | Format |
+|-------|--------|
+| WebSDR audio on the wire | type-routed binary, a-law / adaptive predictor, mono @ `D` Hz |
+| `WebSdrAudioDecoder` out | Int16 mono @ `D` Hz |
+| `WebSdrSource` audio out | float32 **stereo @ 24 kHz** (resampled, mono→LR) |
+| WebSDR waterfall on the wire | format-1 rows, 2 palette indices/byte, + `0xFF` meta |
+| `WebSdrWaterfallDecoder` out | `WebSdrRow` of `QRgb`, width px |
+
+---
+
+## 8. Lifecycle, errors, etiquette
+
+- **One** audio + **one** waterfall socket per server; no parallel sessions.
+- Reconnect: single attempt with exponential backoff (2→30 s cap). On repeated
+  failure, surface `Error` in the panel and stop — never hammer.
+- Disconnect / app close: close both sockets cleanly; if WebSDR was the audio
+  source, revert to Flex.
+- Public-server etiquette is a first-class concern: the host is user-chosen, the
+  panel shows the selected instance, and docs recommend a self-hosted WebSDR for
+  heavy use. No automated polling beyond the live streams.
+
+---
+
+## 9. Test plan
+
+- **Unit — `WebSdrAudioDecoder`:** feed captured `~~stream` frames (recorded via
+  the `websdr-client` tool), assert sample count, native rate, and that output
+  matches the Python reference within tolerance (no rails, plausible RMS).
+- **Unit — `WebSdrWaterfallDecoder`:** feed captured `~~waterstream` frames;
+  assert row width, palette mapping for known indices, and correct handling of
+  the three `0xFF` meta cases.
+- **Integration (manual, live):** connect to a real instance, tune CW/SSB/FM,
+  confirm audio on switch, waterfall scrolls, click-to-tune works, detach/redock,
+  reconnect after a forced socket drop.
+- **Regression:** with the module idle/absent, Flex RX audio + panadapter are
+  byte-for-byte unchanged (source gate defaults to Flex; `HAVE_WEBSDR` off path).
+
+---
+
+## 10. Milestones & acceptance
+
+| Milestone | Done when… | Effort |
+|-----------|------------|--------|
+| **M0 — Waterfall spike** | ✅ **DONE** — protocol documented in §1.2 (and `websdr-client/PROTOCOL.md`). | — |
+| **M1 — Audio module** | ✅ **IMPLEMENTED** — connect/tune via dock header; audio switchable to WebSDR and back; Flex stays default. Audio decoder verified bit-exact (0 diff / 46080 samples) vs the Python reference; full app builds + links (MSVC 2019 / Qt 6.8.3). Live on-device A/B test pending. | done |
+| **M2 — Mini-waterfall** | ✅ **IMPLEMENTED** — `WebSdrSource` opens `~~waterstream<band>`; `WebSdrWaterfallDecoder` (format 1 + palette, validated against a live capture) feeds a self-rendered scrolling waterfall in `WebSdrPanel`; detachable; click-to-tune via band span. Builds + links. Live on-device test pending. | done |
+
+Total ~5–8 days (M0/M1/M2 implemented; manual live test outstanding).
+
+---
+
+## 11. Open questions (resolved/remaining)
+
+- ~~Waterfall stream format~~ — **resolved** (§1.2).
+- Mix vs switch audio: spec is **switch** (one source at a time). Mixing Flex +
+  WebSDR into one sink is a deliberate later option, not in M1/M2.
+- `0xFF 0x01` `freqRef` exact units (Hz vs band-relative) — not needed for
+  rendering; confirm only if we add a numeric frequency readout on the panel.

--- a/docs/architecture/websdr-module.md
+++ b/docs/architecture/websdr-module.md
@@ -1,0 +1,167 @@
+# WebSDR Receive Module — Concept
+
+Status: **proposal / pre-implementation**. Branch: `feat/websdr-module`.
+Author: Jan (svabi79 fork). This document is the design we agreed before writing
+code. It is intentionally fork-local and optional — see *Scope & upstream*.
+
+## 1. Goal
+
+Add a public [WebSDR](https://www.websdr.org/) (PA3FWM software) as a secondary,
+**listen-only** receive source inside AetherSDR — "another antenna for the ears."
+A small live waterfall for the WebSDR shows up in a corner / detachable window,
+and the user can switch the speaker audio over to it. The connected Flex radio
+stays the authority and master at all times.
+
+### Non-goals (explicit)
+
+- **No TX** through the WebSDR. Receive only.
+- **No control of the Flex** by the module, and **no Flex model writes**
+  (`RadioModel` / `SliceModel` / command bus are off-limits).
+- **No overlay** on the Flex panadapter and **no reuse** of the Flex
+  `SpectrumWidget` / `PanadapterModel`.
+- Not a general multi-source SDR abstraction. One Flex + one WebSDR panel.
+
+## 2. Guiding principle — Flex is master, WebSDR is a passive bolt-on
+
+> The WebSDR module only **reads** from its own WebSocket and **owns** three
+> things: its socket, its own waterfall widget, and (optionally, while switched
+> on) the audio sink. It never writes into the Flex model, never sends Flex
+> commands, never participates in TX.
+
+This keeps the module a true add-on, keeps upstream divergence minimal, and makes
+it impossible for the WebSDR path to disturb the Flex master. It is also what
+makes the waterfall cheap: by rendering into its **own** widget with its **own**
+data we avoid the Flex-coupled spectrum/model layer entirely.
+
+## 3. Placement decision
+
+| Option | Decision | Reason |
+|--------|----------|--------|
+| Overlay on the Flex panadapter | **Rejected** | `SpectrumWidget` is a `QRhiWidget` GPU hot path; the WebSDR band span ≠ Flex pan span, so two independent frequency axes would have to be reconciled on the GPU path. High risk, confusing UX. |
+| Mini-waterfall docked in a corner | **Chosen (default)** | Self-contained widget, own data, touches nothing Flex-side. Low friction, always visible. |
+| Separate / detachable window | **Chosen (same impl)** | AetherSDR already has detachable pop-out windows for pans. The dock panel reuses that detach pattern, so "corner *or* own window" is a runtime user choice, not a second implementation. |
+
+**Result:** a `WebSdrPanel` implemented as a `QDockWidget` with a simple
+self-rendered mini-waterfall, poppable into its own window via the existing
+detach mechanism. Rendering uses plain `QImage`/`QPainter` (a mini view does not
+need the QRhi GPU pipeline).
+
+## 4. Components
+
+```
+        ws://host:8901/~~stream?v=11           (audio)
+        ws://host:8901/~~<waterfall path>      (FFT/waterfall — see §7 spike)
+                     │
+              ┌──────┴───────────────┐   ◄── new WEBSDR worker thread
+              │   WebSdrSource        │       (QWebSocket, moveToThread,
+              │   - QWebSocket(s)     │        mirrors FreeDvClient pattern)
+              │   - WebSdrAudioDecoder│
+              │   - WebSdrWfDecoder   │
+              └───┬───────────────┬───┘
+                  │ audioReady     │ waterfallRowReady   [auto-queued signals]
+                  ▼ (24k st f32)   ▼
+        AudioEngine.feedWebSdr…   WebSdrPanel.updateWfRow()   [MAIN]
+        (source gate)                  │
+                  ▼                    ▼ paintEvent (QImage)
+              QAudioSink           mini waterfall in dock / pop-out
+```
+
+### New classes
+
+- **`WebSdrSource`** (`src/core/`): owns the `QWebSocket`(s), sends the
+  `GET /~~param?…` tune command, drives the decoders, lives on a dedicated
+  worker thread created with the established `moveToThread` + `init()` slot
+  pattern. Copy structure from `FreeDvClient` (already QWebSocket-based).
+- **`WebSdrAudioDecoder`** (`src/core/`): C++ port of the verified decoder
+  (a-law table + adaptive-predictor codec). Reference implementation and protocol
+  notes live in the standalone `websdr-client` repo (`websdr_client.py`,
+  `PROTOCOL.md`). ~100 lines.
+- **`WebSdrWfDecoder`** (`src/core/`): parses the WebSDR waterfall/FFT stream
+  into spectrum rows. **Depends on the §7 spike.**
+- **`WebSdrPanel`** (`src/gui/`): `QDockWidget` with the mini-waterfall + a small
+  control header (host, frequency, mode, connect, "audio → here" toggle).
+- **`WebSdrSettings`** (`src/core/`): persisted host list, last freq/mode,
+  panel visibility/geometry.
+
+### Touched existing code (kept minimal)
+
+- **`AudioEngine`** — add a receive-audio **source gate**: Flex RX (current
+  default) ↔ WebSDR. Today `feedAudioData()` is fed only by
+  `PanadapterStream::audioDataReady()` and `startRxStream()` is tied to the Flex
+  connect lifecycle. We add a way to (a) accept WebSDR PCM frames and (b) mute /
+  bypass the Flex feed while WebSDR is selected. One source at a time initially;
+  mixing is a later option. *This is the only non-trivial edit in the
+  audio-only milestone.*
+- **`MainWindow`** — register/show the dock widget; menu/toolbar entry.
+- **`CMakeLists.txt`** — new sources behind an optional `HAVE_WEBSDR` flag,
+  reusing the existing `Qt6::WebSockets` dependency.
+
+## 5. Audio path
+
+- Internal pipeline format is **24 kHz stereo float32** (`AudioEngine`
+  `DEFAULT_SAMPLE_RATE = 24000`). WebSDR audio is mono at ~7–12 kHz.
+- Conversion in `WebSdrSource`: decode → resample to 24 kHz (reuse
+  `Resampler`) → duplicate mono to stereo → emit `webSdrAudioReady(QByteArray)`.
+- `AudioEngine` gate:
+  - **Flex (default):** unchanged; WebSDR frames are dropped.
+  - **WebSDR:** Flex `feedAudioData()` input is muted/bypassed and WebSDR frames
+    are routed into the same downstream DSP/`QAudioSink` path.
+- Switching is a user toggle on the panel; default and fallback is always Flex.
+  Disconnecting or losing the WebSDR returns audio to Flex.
+
+## 6. Waterfall path
+
+- Rendered entirely in `WebSdrPanel` from `WebSdrWfDecoder` rows. **No** contact
+  with `SpectrumWidget` / `PanadapterModel`.
+- Mini view: `QImage` ring-buffer waterfall + a thin spectrum line, repainted on
+  `waterfallRowReady`. Click-to-tune within the WebSDR span maps to a new
+  `~~param` command (module-internal; never touches Flex tuning).
+- Band scale labels can come from the WebSDR `bandinfo.js` (`centerfreq`,
+  `samplerate`, per-band scale PNGs) fetched once on connect.
+
+## 7. R&D — resolved
+
+The audio protocol was already reverse-engineered (see
+`websdr-client/PROTOCOL.md`). The **waterfall stream is now decoded too** (M0
+spike done): a second WebSocket `~~waterstream<band>?format=…`, format-1 rows of
+2 palette-indexed pixels/byte, with `0xFF`-prefixed meta frames, controlled via
+`~~waterparam?…`. Full details and the palette are in the technical spec,
+[`websdr-module-spec.md`](websdr-module-spec.md) §1.2, and in
+`websdr-client/PROTOCOL.md`. No remaining unknowns block implementation.
+
+## 8. Milestones & effort
+
+| Milestone | Deliverable | Effort |
+|-----------|-------------|--------|
+| **M1 — Audio module** | `WebSdrSource` + `WebSdrAudioDecoder` on a worker thread; dock panel header (host/freq/mode/connect); audio source gate in `AudioEngine`; switchable, Flex stays default. No waterfall. | ~3–5 days |
+| **M0 — Waterfall spike** | ✅ done — see `websdr-module-spec.md` §1.2. | — |
+| **M2 — Mini-waterfall** | `WebSdrWfDecoder` + self-rendered waterfall in `WebSdrPanel`, detach-to-window, click-to-tune. | ~2–3 days on top of M0 |
+
+Total to "switchable audio + mini-waterfall in a corner / own window":
+**~6–10 days**, of which ~1–2 are pure reverse-engineering.
+
+## 9. Risks
+
+1. **`AudioEngine` is single-source and Flex-lifecycle-bound** — the source gate
+   is the only sensitive edit; must not regress the Flex RX path.
+2. **Waterfall protocol unknown** until the M0 spike (§7).
+3. **WebSDR etiquette/ToS** — public servers; the module must keep sessions sane
+   (no reconnect storms), expose the host so the user picks a tolerant instance,
+   and document "prefer your own WebSDR install."
+4. **Upstream scope** — see below.
+
+## 10. Scope & upstream
+
+This is a fork-local feature behind an optional `HAVE_WEBSDR` build flag. Given
+the strict aethersdr contribution process and the Flex-centric product focus, it
+is **not** assumed to be upstream-bound; it ships in the `svabi79` fork as an
+optional module. Revisit upstreaming only if there is maintainer interest.
+
+## 11. Reference
+
+- Standalone decoder + verified protocol: `websdr-client` repo
+  (`websdr_client.py`, `PROTOCOL.md`) — the audio codec, frame types and
+  `~~param` tuning command, validated against a live capture.
+- AetherSDR audio injection contract: `src/core/AudioEngine.h` (`feedAudioData`,
+  `startRxStream`), `docs/architecture/audio-pipeline.md`.
+- QWebSocket worker pattern to copy: `src/core/FreeDvClient.{h,cpp}`.

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1381,6 +1381,22 @@ QByteArray AudioEngine::resampleStereo(const QByteArray& pcm)
 
 void AudioEngine::feedAudioData(const QByteArray& pcm)
 {
+    // RX source gate: when WebSDR is selected, drop the Flex feed so the
+    // speaker isn't double-fed. Flex stays the default/master.
+    if (m_rxSourceWebSdr.load(std::memory_order_relaxed)) return;
+    feedAudioDataImpl(pcm);
+}
+
+void AudioEngine::feedWebSdrAudio(const QByteArray& pcm)
+{
+    // Passive WebSDR module: only reaches the speaker while it is the selected
+    // RX source. Never forwarded to the radio (no TX path).
+    if (!m_rxSourceWebSdr.load(std::memory_order_relaxed)) return;
+    feedAudioDataImpl(pcm);
+}
+
+void AudioEngine::feedAudioDataImpl(const QByteArray& pcm)
+{
     if (!m_audioSink) return;  // PC audio disabled
     m_lastAudioFeedTime.start();  // reset liveness watchdog (#1411)
 

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -479,8 +479,19 @@ public:
     }
 
 public slots:
-    // Receives stripped PCM from PanadapterStream::audioDataReady().
+    // Receives stripped PCM from PanadapterStream::audioDataReady() (Flex RX).
+    // When the RX source is switched to WebSDR, Flex frames are dropped here.
     void feedAudioData(const QByteArray& pcm);
+
+    // WebSDR receive module (passive bolt-on). 24 kHz stereo float32, same
+    // shape as feedAudioData(). Dropped unless the RX source is WebSDR.
+    void feedWebSdrAudio(const QByteArray& pcm);
+
+    // RX audio source gate. Default false = Flex (master). true routes the
+    // WebSDR module's audio to the speaker and mutes the Flex feed. WebSDR is
+    // never sent to the radio (no TX path).
+    Q_INVOKABLE void setRxSourceWebSdr(bool on) { m_rxSourceWebSdr.store(on); }
+    bool rxSourceIsWebSdr() const { return m_rxSourceWebSdr.load(); }
 
 signals:
     void rxStarted();
@@ -533,6 +544,10 @@ private slots:
     void onTxAudioReady();
 
 private:
+    // Shared RX delivery body for both feedAudioData() (Flex) and
+    // feedWebSdrAudio() (WebSDR module). The public slots gate on m_rxSourceWebSdr.
+    void feedAudioDataImpl(const QByteArray& pcm);
+
     QAudioFormat makeFormat() const;
     float computeRMS(const QByteArray& pcm) const;
     QByteArray applyBoost(const QByteArray& pcm, float gain) const;
@@ -670,6 +685,7 @@ private:
     std::atomic<int>   m_rxPan{50};       // 0=left, 50=centre, 100=right (#1460)
     std::atomic<int>   m_rxBufferCapMs{200}; // RX buffer cap in ms (#1505)
     std::atomic<bool>  m_muted{false};
+    std::atomic<bool>  m_rxSourceWebSdr{false}; // RX audio source gate (false = Flex)
     // RX sink device rate (negotiated via AudioFormatNegotiator). Audio is
     // resampled from the 24k canonical rate up to this when they differ (#3306).
     // Atomic: written from startRxStream() (GUI thread) and read from the RX

--- a/src/core/WebSdrAudioDecoder.cpp
+++ b/src/core/WebSdrAudioDecoder.cpp
@@ -1,0 +1,214 @@
+#include "WebSdrAudioDecoder.h"
+
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+// 256-entry a-law decode table, verbatim from websdr-sound.js.
+const qint16 kAlaw[256] = {
+-5504,-5248,-6016,-5760,-4480,-4224,-4992,-4736,-7552,-7296,-8064,-7808,-6528,-6272,-7040,-6784,
+-2752,-2624,-3008,-2880,-2240,-2112,-2496,-2368,-3776,-3648,-4032,-3904,-3264,-3136,-3520,-3392,
+-22016,-20992,-24064,-23040,-17920,-16896,-19968,-18944,-30208,-29184,-32256,-31232,-26112,-25088,-28160,-27136,
+-11008,-10496,-12032,-11520,-8960,-8448,-9984,-9472,-15104,-14592,-16128,-15616,-13056,-12544,-14080,-13568,
+-344,-328,-376,-360,-280,-264,-312,-296,-472,-456,-504,-488,-408,-392,-440,-424,
+-88,-72,-120,-104,-24,-8,-56,-40,-216,-200,-248,-232,-152,-136,-184,-168,
+-1376,-1312,-1504,-1440,-1120,-1056,-1248,-1184,-1888,-1824,-2016,-1952,-1632,-1568,-1760,-1696,
+-688,-656,-752,-720,-560,-528,-624,-592,-944,-912,-1008,-976,-816,-784,-880,-848,
+5504,5248,6016,5760,4480,4224,4992,4736,7552,7296,8064,7808,6528,6272,7040,6784,
+2752,2624,3008,2880,2240,2112,2496,2368,3776,3648,4032,3904,3264,3136,3520,3392,
+22016,20992,24064,23040,17920,16896,19968,18944,30208,29184,32256,31232,26112,25088,28160,27136,
+11008,10496,12032,11520,8960,8448,9984,9472,15104,14592,16128,15616,13056,12544,14080,13568,
+344,328,376,360,280,264,312,296,472,456,504,488,408,392,440,424,
+88,72,120,104,24,8,56,40,216,200,248,232,152,136,184,168,
+1376,1312,1504,1440,1120,1056,1248,1184,1888,1824,2016,1952,1632,1568,1760,1696,
+688,656,752,720,560,528,624,592,944,912,1008,976,816,784,880,848};
+
+// JS ToInt32 + bitwise ops on the 32-bit window.
+inline qint32 i32(double x)  { return static_cast<qint32>(static_cast<quint32>(static_cast<qint64>(x))); }
+inline qint32 i32(qint64 x)  { return static_cast<qint32>(static_cast<quint32>(x)); }
+inline qint32 shl(qint32 a, int b) { return static_cast<qint32>(static_cast<quint32>(a) << (b & 31)); }
+inline qint32 shr(qint32 a, int b) { return a >> (b & 31); }   // arithmetic
+
+inline qint16 toInt16(double x) { return static_cast<qint16>(static_cast<qint64>(x)); }
+
+// const lookup used by the predictor exponent selection
+const int kC[8] = {999, 999, 8, 4, 2, 1, 99, 99};
+
+} // namespace
+
+WebSdrAudioDecoder::WebSdrAudioDecoder()
+{
+    resetPredictor();
+}
+
+void WebSdrAudioDecoder::resetPredictor()
+{
+    for (int i = 0; i < 20; ++i) { m_coeff[i] = 0.0; m_hist[i] = 0.0; }
+    m_ie = 0.0;
+}
+
+QVector<qint16> WebSdrAudioDecoder::takeSamples()
+{
+    QVector<qint16> s = std::move(m_out);
+    m_out.clear();
+    return s;
+}
+
+void WebSdrAudioDecoder::feed(const QByteArray& frame)
+{
+    const quint8* t = reinterpret_cast<const quint8*>(frame.constData());
+    const int L = frame.size();
+    auto b = [t, L](int idx) -> int { return (idx >= 0 && idx < L) ? t[idx] : 0; };
+
+    int n = 0;
+    while (n < L) {
+        bool decode = false;
+        int  r = 0;
+        const int byte = t[n];
+
+        if ((byte & 0xF0) == 0xF0) {                       // S-meter
+            m_smeter = ((byte & 15) << 8) + b(n + 1);
+            n += 1;
+        } else if (byte == 0x80) {                         // a-law block, 128 samples
+            for (int s = 0; s < 128; ++s) {
+                m_out.push_back(kAlaw[b(n + 1 + s)]);
+            }
+            n += 128;
+            resetPredictor();
+        } else if (byte >= 0x90 && byte <= 0xDF) {         // compressed audio
+            r = 4;
+            decode = true;
+            m_re = 14 - (byte >> 4);
+        } else if ((byte & 0x80) == 0) {                   // compressed audio (variant)
+            r = 1;
+            decode = true;
+        } else if (byte == 0x81) {                         // sample-rate change
+            m_D = (b(n + 1) << 8) + b(n + 2);
+            if (m_D == 0) {
+                m_stopped = true;
+            }
+            n += 2;
+        } else if (byte == 0x82) {                         // quantiser scale
+            m_oe = (b(n + 1) << 8) + b(n + 2);
+            n += 2;
+        } else if (byte == 0x83) {                         // filter/mode selection
+            m_ae = b(n + 1);
+            const int low = m_ae & 15;
+            if (low != m_ee) {
+                m_ee = low;
+            }
+            n += 1;
+        } else if (byte == 0x84) {                         // 128 samples of silence
+            for (int s = 0; s < 128; ++s) {
+                m_out.push_back(0);
+            }
+            resetPredictor();
+        } else if (byte == 0x85) {                         // true frequency (ignored value)
+            n += 6;
+        }
+        // else: 0x86-0x8F, 0xE0-0xEF -> ignored
+
+        if (decode) {
+            decodeBlock(t, L, n, r);
+            if (r == 0) {
+                n -= 1;
+            }
+        }
+        n += 1;
+    }
+}
+
+void WebSdrAudioDecoder::decodeBlock(const quint8* t, int len, int& n, int& r)
+{
+    auto b = [t, len](int idx) -> int { return (idx >= 0 && idx < len) ? t[idx] : 0; };
+
+    const int re = m_re;
+    const int oe = m_oe;
+    const int aShift = (m_ae & 16) ? 12 : 14;
+    const bool dcReset = (m_ae & 16) != 0;
+
+    for (int nsamp = 0; nsamp < 128; ++nsamp) {
+        // 32-bit big-endian window at the current byte pointer, shifted by r
+        qint32 win = static_cast<qint32>(
+            (static_cast<quint32>(b(n + 3))      ) |
+            (static_cast<quint32>(b(n + 2)) <<  8) |
+            (static_cast<quint32>(b(n + 1)) << 16) |
+            (static_cast<quint32>(b(n))     << 24));
+        win = shl(win, r);
+
+        int s = 0;
+        if (win != 0) {
+            const int u0 = 15 - re;
+            while (win >= 0 && s < u0) { win = shl(win, 1); ++s; }
+        }
+        int u = 15 - re;
+        if (s < u) {
+            u = s;
+            ++s;
+            win = shl(win, 1);
+        } else {
+            u = shr(win, 24) & 0xFF;
+            s += 8;
+            win = shl(win, 8);
+        }
+
+        int f = 0;
+        if (u >= kC[re]) {
+            ++f;
+        }
+        if (u >= kC[re - 1]) {
+            ++f;
+        }
+        if (f > re - 1) {
+            f = re - 1;
+        }
+
+        qint32 part = shr((shr(win, 16) & 0xFFFF), 17 - re);
+        qint32 c = part & i32(static_cast<qint64>(shl(-1, f)));
+        c = c + shl(u, re - 1);
+        if ((win & shl(1, 32 - re + f)) != 0) {
+            c = c | ((1 << f) - 1);
+            c = i32(static_cast<qint64>(~c));
+        }
+
+        r += s + re - f;
+        while (r >= 8) { ++n; r -= 8; }
+
+        // prediction
+        double pred = 0.0;
+        for (int k = 0; k < 20; ++k) {
+            pred += m_coeff[k] * m_hist[k];
+        }
+        qint32 predi = i32(pred);
+        qint32 predOut = (predi >= 0) ? (predi >> 12) : ((predi + 4095) >> 12);
+
+        // dequantise residual
+        double resid = static_cast<double>(c) * oe + oe / 2.0;
+        c = shr(i32(resid), 4);
+
+        // adapt coefficients (k = 19..0) and shift history (k = 19..1)
+        for (int k = 19; k >= 0; --k) {
+            m_coeff[k] += -(i32(m_coeff[k]) >> 7)
+                        + (i32(m_hist[k] * static_cast<double>(c)) >> aShift);
+            if (k == 0) {
+                break;
+            }
+            m_hist[k] = m_hist[k - 1];
+        }
+
+        m_hist[0] = static_cast<double>(predOut) + resid;
+
+        double sample = m_hist[0] + (i32(m_ie) >> 4);
+        if (dcReset) {
+            m_ie = 0.0;
+        } else {
+            m_ie = m_ie + shr(shl(i32(m_hist[0]), 4), 3);
+        }
+
+        m_out.push_back(toInt16(sample));
+    }
+}
+
+} // namespace AetherSDR

--- a/src/core/WebSdrAudioDecoder.h
+++ b/src/core/WebSdrAudioDecoder.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <QByteArray>
+#include <QVector>
+#include <cstdint>
+
+namespace AetherSDR {
+
+// Decoder for the PA3FWM WebSDR audio stream (ws://<host>/~~stream).
+//
+// Direct C++ port of the server's own websdr-sound.js onmessage handler
+// (Copyright 2007-2018 P.T. de Boer, pa3fwm@websdr.org). The reference
+// implementation and protocol notes live in the standalone `websdr-client`
+// repo (websdr_client.py / PROTOCOL.md).
+//
+// Stateful: feed() one binary WebSocket message at a time; decoded Int16 mono
+// samples (at nativeRate() Hz) accumulate and are drained by takeSamples().
+// Not thread-safe — own one instance per stream on its worker thread.
+class WebSdrAudioDecoder {
+public:
+    WebSdrAudioDecoder();
+
+    // Decode one binary WebSocket message, appending samples to the buffer.
+    void feed(const QByteArray& frame);
+
+    // Drain and return all samples decoded so far (Int16 mono @ nativeRate()).
+    QVector<qint16> takeSamples();
+
+    int  nativeRate() const { return m_D; }   // audio sample rate in Hz (0x81)
+    int  sMeter()     const { return m_smeter; }
+    bool stopped()    const { return m_stopped; }
+
+private:
+    void resetPredictor();
+    // Decode a compressed block (128 samples). Updates the byte pointer `n`
+    // and bit offset `r`; returns via references.
+    void decodeBlock(const quint8* t, int len, int& n, int& r);
+
+    // Predictor / stream state (persists across frames).
+    double  m_coeff[20];
+    double  m_hist[20];
+    double  m_ie    = 0.0;
+    int     m_re    = 1;        // gain exponent (sticky)
+    int     m_oe    = 1;        // quantiser scale (0x82)
+    int     m_ae    = 0;        // filter/mode byte (0x83)
+    int     m_ee    = -1;       // active filter index
+    int     m_D     = 8000;     // audio sample rate (0x81)
+    int     m_smeter = 0;
+    bool    m_stopped = false;
+
+    QVector<qint16> m_out;
+};
+
+} // namespace AetherSDR

--- a/src/core/WebSdrSource.cpp
+++ b/src/core/WebSdrSource.cpp
@@ -1,0 +1,334 @@
+#include "WebSdrSource.h"
+
+#include "Resampler.h"
+
+#include <QWebSocket>
+#include <QTimer>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+#include <QRegularExpression>
+#include <QLoggingCategory>
+
+#include <vector>
+
+Q_LOGGING_CATEGORY(lcWebSdr, "aether.websdr")
+
+namespace AetherSDR {
+
+namespace {
+
+struct ModePreset { int modeInt; double lo; double hi; };
+
+// mode integer: 0 = SSB/CW, 1 = AM, 4 = FM. USB/LSB/CW differ only via lo/hi.
+ModePreset presetFor(const QString& modeLower)
+{
+    const QString m = modeLower.toLower();
+    if (m == "usb") return {0,  0.0,  2.7};
+    if (m == "lsb") return {0, -2.7,  0.0};
+    if (m == "cw")  return {0, -0.2,  0.2};
+    if (m == "cwu") return {0,  0.2,  0.7};
+    if (m == "cwl") return {0, -0.7, -0.2};
+    if (m == "am")  return {1, -4.5,  4.5};
+    if (m == "fm")  return {4, -6.0,  6.0};
+    return {0, 0.0, 2.7}; // default USB
+}
+
+} // namespace
+
+WebSdrSource::WebSdrSource(QObject* parent) : QObject(parent) {}
+
+WebSdrSource::~WebSdrSource()
+{
+    if (m_audioWs) {
+        m_audioWs->abort();
+    }
+    if (m_wfWs) {
+        m_wfWs->abort();
+    }
+}
+
+void WebSdrSource::init()
+{
+    // Construct sockets/timers on the worker thread (#1929 pattern).
+    m_net = new QNetworkAccessManager(this);
+    m_reconnectTimer = new QTimer(this);
+    m_reconnectTimer->setSingleShot(true);
+    connect(m_reconnectTimer, &QTimer::timeout, this, &WebSdrSource::onReconnect);
+    m_wfDec.setWidth(m_wfWidth);
+}
+
+void WebSdrSource::setState(State s, const QString& detail)
+{
+    m_state = s;
+    m_connected.store(s == State::Connected || s == State::Streaming);
+    emit stateChanged(static_cast<int>(s), detail);
+}
+
+void WebSdrSource::connectToServer(const QString& host)
+{
+    m_host = host;
+    m_intentionalDisconnect = false;
+    m_reconnectDelayMs = kInitialReconnectDelayMs;
+    setState(State::Connecting);
+    fetchBandInfo();
+    openAudioSocket();
+}
+
+void WebSdrSource::disconnectFromServer()
+{
+    m_intentionalDisconnect = true;
+    if (m_reconnectTimer) {
+        m_reconnectTimer->stop();
+    }
+    if (m_audioWs) {
+        m_audioWs->abort();
+        m_audioWs->deleteLater();
+        m_audioWs = nullptr;
+    }
+    if (m_wfWs) {
+        m_wfWs->abort();
+        m_wfWs->deleteLater();
+        m_wfWs = nullptr;
+    }
+    m_wfOpenBand = -1;
+    setState(State::Disconnected);
+}
+
+void WebSdrSource::openAudioSocket()
+{
+    if (m_audioWs) {
+        m_audioWs->abort();
+        m_audioWs->deleteLater();
+        m_audioWs = nullptr;
+    }
+
+    m_audioWs = new QWebSocket(QStringLiteral("http://%1").arg(m_host),
+                               QWebSocketProtocol::VersionLatest, this);
+    connect(m_audioWs, &QWebSocket::connected,             this, &WebSdrSource::onConnected);
+    connect(m_audioWs, &QWebSocket::disconnected,          this, &WebSdrSource::onDisconnected);
+    connect(m_audioWs, &QWebSocket::binaryMessageReceived, this, &WebSdrSource::onBinaryMessage);
+    auto onSocketError = [this](QAbstractSocket::SocketError) {
+        qCWarning(lcWebSdr) << "audio socket error:" << m_audioWs->errorString();
+        setState(State::Error, m_audioWs->errorString());
+        if (!m_intentionalDisconnect && m_reconnectTimer) {
+            m_reconnectTimer->start(m_reconnectDelayMs);
+            m_reconnectDelayMs = qMin(m_reconnectDelayMs * 2, kMaxReconnectDelayMs);
+        }
+    };
+    // QWebSocket::errorOccurred is Qt 6.5+; the Linux CI floor is 6.4.2.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    connect(m_audioWs, &QWebSocket::errorOccurred, this, onSocketError);
+#else
+    connect(m_audioWs, QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error),
+            this, onSocketError);
+#endif
+
+    const QUrl url(QStringLiteral("ws://%1/~~stream?v=11").arg(m_host));
+    m_audioWs->open(url);
+}
+
+void WebSdrSource::onReconnect()
+{
+    if (m_intentionalDisconnect) {
+        return;
+    }
+    setState(State::Connecting);
+    openAudioSocket();
+}
+
+void WebSdrSource::onConnected()
+{
+    m_reconnectDelayMs = kInitialReconnectDelayMs;
+    setState(State::Connected);
+    if (m_haveTune && m_bandValid) { sendTuneCommand(); ensureWaterfall(); }
+}
+
+void WebSdrSource::openWaterfallSocket()
+{
+    if (m_wfWs) {
+        m_wfWs->abort();
+        m_wfWs->deleteLater();
+        m_wfWs = nullptr;
+    }
+
+    m_wfWs = new QWebSocket(QStringLiteral("http://%1").arg(m_host),
+                            QWebSocketProtocol::VersionLatest, this);
+    connect(m_wfWs, &QWebSocket::binaryMessageReceived,
+            this, &WebSdrSource::onWaterfallMessage);
+    // The band index is part of the path; format 1, full-band zoom.
+    const QUrl url(QStringLiteral("ws://%1/~~waterstream%2?format=1&width=%3&zoom=0&start=0")
+                       .arg(m_host).arg(m_band).arg(m_wfWidth));
+    m_wfWs->open(url);
+    m_wfOpenBand = m_band;
+}
+
+void WebSdrSource::ensureWaterfall()
+{
+    if (!m_haveTune || !m_bandValid) {
+        return;
+    }
+    if (m_wfWs && m_wfOpenBand == m_band &&
+        m_wfWs->state() != QAbstractSocket::UnconnectedState) {
+        return;   // already open for this band
+    }
+    openWaterfallSocket();
+}
+
+void WebSdrSource::onWaterfallMessage(const QByteArray& message)
+{
+    QImage row;
+    if (m_wfDec.feed(message, row)) {
+        emit rowReady(row);
+    }
+}
+
+void WebSdrSource::emitBandSpan()
+{
+    if (m_band >= 0 && m_band < m_bands.size()) {
+        emit bandSpan(m_bands[m_band].centerKHz, m_bands[m_band].srKHz, m_bands[m_band].name);
+    }
+}
+
+void WebSdrSource::onDisconnected()
+{
+    if (m_intentionalDisconnect) { setState(State::Disconnected); return; }
+    setState(State::Error, QStringLiteral("disconnected"));
+    if (m_reconnectTimer) {
+        m_reconnectTimer->start(m_reconnectDelayMs);
+        m_reconnectDelayMs = qMin(m_reconnectDelayMs * 2, kMaxReconnectDelayMs);
+    }
+}
+
+void WebSdrSource::onBinaryMessage(const QByteArray& message)
+{
+    m_dec.feed(message);
+    const QVector<qint16> mono = m_dec.takeSamples();
+    if (!mono.isEmpty()) {
+        if (m_state != State::Streaming) {
+            setState(State::Streaming);
+        }
+        emitResampled(mono, m_dec.nativeRate());
+    }
+    emit sMeter(m_dec.sMeter());
+}
+
+void WebSdrSource::emitResampled(const QVector<qint16>& mono, int srcRate)
+{
+    if (srcRate <= 0) {
+        return;
+    }
+    if (!m_resampler || m_resamplerSrcRate != srcRate) {
+        m_resampler = std::make_unique<Resampler>(static_cast<double>(srcRate),
+                                                  static_cast<double>(kOutputRate),
+                                                  8192);
+        m_resamplerSrcRate = srcRate;
+    }
+    std::vector<float> f(mono.size());
+    for (int i = 0; i < mono.size(); ++i) {
+        f[i] = mono[i] / 32768.0f;
+    }
+    QByteArray stereo = m_resampler->processMonoToStereo(f.data(), static_cast<int>(f.size()));
+    if (!stereo.isEmpty()) {
+        emit audioReady(stereo);
+    }
+}
+
+void WebSdrSource::tune(double freqKHz, const QString& mode, double loKHz, double hiKHz)
+{
+    m_freqKHz = freqKHz;
+    m_mode = mode;
+    m_loKHz = loKHz;
+    m_hiKHz = hiKHz;
+    m_haveTune = true;
+
+    if (m_bands.isEmpty()) {
+        return;   // band chosen once bandinfo arrives
+    }
+
+    const int nb = pickBand(freqKHz);
+    if (nb < 0) {                    // not covered by this WebSDR — don't break the stream
+        m_bandValid = false;
+        setState(m_state, QStringLiteral("%1 kHz outside WebSDR bands").arg(freqKHz, 0, 'f', 1));
+        return;
+    }
+    m_band = nb;
+    m_bandValid = true;
+    emitBandSpan();
+    if (m_connected.load()) {
+        sendTuneCommand();
+        ensureWaterfall();
+    }
+}
+
+void WebSdrSource::sendTuneCommand()
+{
+    if (!m_audioWs || m_audioWs->state() != QAbstractSocket::ConnectedState) {
+        return;
+    }
+    const ModePreset p = presetFor(m_mode);   // for the demodulator integer only
+    const QString cmd = QStringLiteral("GET /~~param?f=%1&band=%2&lo=%3&hi=%4&mode=%5&name=aethersdr")
+                            .arg(m_freqKHz, 0, 'f', 3)
+                            .arg(m_band)
+                            .arg(m_loKHz, 0, 'f', 3)
+                            .arg(m_hiKHz, 0, 'f', 3)
+                            .arg(p.modeInt);
+    m_audioWs->sendTextMessage(cmd);
+}
+
+int WebSdrSource::pickBand(double freqKHz) const
+{
+    for (int i = 0; i < m_bands.size(); ++i) {
+        const double half = m_bands[i].srKHz / 2.0;
+        if (freqKHz >= m_bands[i].centerKHz - half &&
+            freqKHz <= m_bands[i].centerKHz + half) {
+            return i;
+        }
+    }
+    return -1;   // frequency not covered by any band
+}
+
+void WebSdrSource::fetchBandInfo()
+{
+    if (!m_net) {
+        return;
+    }
+    const QUrl url(QStringLiteral("http://%1/tmp/bandinfo.js").arg(m_host));
+    QNetworkReply* reply = m_net->get(QNetworkRequest(url));
+    connect(reply, &QNetworkReply::finished, this, [this, reply] {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            qCWarning(lcWebSdr) << "bandinfo fetch failed:" << reply->errorString();
+            return;
+        }
+        const QString js = QString::fromUtf8(reply->readAll());
+        m_bands.clear();
+        QStringList names;
+        // centerfreq: N ... samplerate: N ... name: '...'
+        QRegularExpression re(
+            QStringLiteral("centerfreq:\\s*([0-9.]+).*?samplerate:\\s*([0-9.]+).*?name:\\s*'([^']*)'"),
+            QRegularExpression::DotMatchesEverythingOption);
+        auto it = re.globalMatch(js);
+        while (it.hasNext()) {
+            const auto m = it.next();
+            m_bands.push_back({m.captured(1).toDouble(), m.captured(2).toDouble(), m.captured(3)});
+            names << m.captured(3);
+        }
+        if (m_haveTune) {
+            const int nb = pickBand(m_freqKHz);
+            if (nb >= 0) {
+                m_band = nb;
+                m_bandValid = true;
+                emitBandSpan();
+                if (m_connected.load()) {
+                    sendTuneCommand();
+                    ensureWaterfall();
+                }
+            }
+        }
+        emit bandsResolved(names, m_band);
+    });
+}
+
+} // namespace AetherSDR

--- a/src/core/WebSdrSource.h
+++ b/src/core/WebSdrSource.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QByteArray>
+#include <QVector>
+#include <QImage>
+#include <memory>
+#include <atomic>
+
+#include "WebSdrAudioDecoder.h"
+#include "WebSdrWaterfallDecoder.h"
+
+class QWebSocket;
+class QTimer;
+class QNetworkAccessManager;
+
+namespace AetherSDR {
+
+class Resampler;
+
+// Listen-only WebSDR receive source (PA3FWM software). Owns a QWebSocket to the
+// audio stream, tunes via GET /~~param, decodes the audio and emits 24 kHz
+// stereo float32 frames ready for AudioEngine::feedWebSdrAudio().
+//
+// Passive bolt-on: never touches the Flex radio model. Lives on a dedicated
+// worker thread (moveToThread + init(), like FreeDvClient). The waterfall
+// stream is added in M2.
+class WebSdrSource : public QObject {
+    Q_OBJECT
+public:
+    enum class State { Disconnected, Connecting, Connected, Streaming, Error };
+
+    explicit WebSdrSource(QObject* parent = nullptr);
+    ~WebSdrSource() override;
+
+    bool isConnected() const { return m_connected.load(); }
+
+public slots:
+    void init();                                  // construct socket/timers on worker thread
+    void connectToServer(const QString& host);    // "host:port"
+    void disconnectFromServer();
+    void tune(double freqKHz, const QString& mode, double loKHz, double hiKHz);
+
+signals:
+    void stateChanged(int state, const QString& detail);   // State as int
+    void bandsResolved(const QStringList& bandNames, int selectedBand);
+    void bandSpan(double centerKHz, double srKHz, const QString& name);  // active band
+    void audioReady(const QByteArray& pcm24kStereoF32);
+    void rowReady(const QImage& waterfallRow);             // width×1 RGB32
+    void sMeter(int level);
+
+private slots:
+    void onConnected();
+    void onDisconnected();
+    void onBinaryMessage(const QByteArray& message);
+    void onWaterfallMessage(const QByteArray& message);
+    void onReconnect();
+
+private:
+    void setState(State s, const QString& detail = QString());
+    void openAudioSocket();
+    void openWaterfallSocket();
+    void ensureWaterfall();
+    void emitBandSpan();
+    void fetchBandInfo();
+    int  pickBand(double freqKHz) const;
+    void sendTuneCommand();
+    void emitResampled(const QVector<qint16>& mono, int srcRate);
+
+    struct Band { double centerKHz; double srKHz; QString name; };
+
+    QString  m_host;
+    QWebSocket* m_audioWs{nullptr};
+    QWebSocket* m_wfWs{nullptr};
+    QTimer*  m_reconnectTimer{nullptr};
+    QNetworkAccessManager* m_net{nullptr};
+
+    WebSdrAudioDecoder m_dec;
+    WebSdrWaterfallDecoder m_wfDec;
+    // At zoom 0 the full band is exactly 1024 px wide (units = 1024<<maxzoom).
+    // Requesting 1024 makes the row span the whole band, so center±sr/2 maps
+    // correctly to [0,width] and the listening marker lines up.
+    int  m_wfWidth{1024};
+    int  m_wfOpenBand{-1};   // band the waterfall socket is currently open for
+    std::unique_ptr<Resampler> m_resampler;
+    int m_resamplerSrcRate{0};
+
+    QVector<Band> m_bands;
+    int     m_band{0};
+    double  m_freqKHz{0.0};
+    QString m_mode{"usb"};
+    double  m_loKHz{0.0};
+    double  m_hiKHz{2.7};
+    bool    m_haveTune{false};
+    bool    m_bandValid{false};   // a real band was selected for the current freq
+
+    State m_state{State::Disconnected};
+    std::atomic<bool> m_connected{false};
+    bool  m_intentionalDisconnect{false};
+    int   m_reconnectDelayMs{kInitialReconnectDelayMs};
+
+    static constexpr int kInitialReconnectDelayMs = 2000;
+    static constexpr int kMaxReconnectDelayMs     = 30000;
+    static constexpr int kOutputRate              = 24000;  // AudioEngine native
+};
+
+} // namespace AetherSDR

--- a/src/core/WebSdrWaterfallDecoder.cpp
+++ b/src/core/WebSdrWaterfallDecoder.cpp
@@ -1,0 +1,69 @@
+#include "WebSdrWaterfallDecoder.h"
+
+#include <cmath>
+
+namespace AetherSDR {
+
+QRgb WebSdrWaterfallDecoder::paletteColor(int e)
+{
+    // Verbatim from websdr-waterfall.js; each component stored into a uint8.
+    int r, g, b;
+    if (e < 64)        { r = 0;            g = 0;                                   b = 2 * e; }
+    else if (e < 128)  { r = 3 * e - 192;  g = 0;                                   b = 2 * e; }
+    else if (e < 192)  { r = e + 64;       g = int(256.0 * std::sqrt((e - 128) / 64.0)); b = 511 - 2 * e; }
+    else               { r = 255;          g = 255;                                 b = 512 + 2 * e; }
+    return qRgb(r & 0xFF, g & 0xFF, b & 0xFF);
+}
+
+WebSdrWaterfallDecoder::WebSdrWaterfallDecoder()
+{
+    for (int i = 0; i < 256; ++i) {
+        m_lut[i] = paletteColor(i);
+    }
+}
+
+bool WebSdrWaterfallDecoder::feed(const QByteArray& frame, QImage& outRow)
+{
+    const quint8* t = reinterpret_cast<const quint8*>(frame.constData());
+    const int L = frame.size();
+    if (L == 0) {
+        return false;
+    }
+
+    int off = 0;
+    if (t[0] == 0xFF) {
+        if (L > 1 && t[1] != 0xFF) {
+            // meta frame
+            if (t[1] == 1 && L >= 7) {
+                m_freqRef = static_cast<quint32>(t[3])
+                          | (static_cast<quint32>(t[4]) << 8)
+                          | (static_cast<quint32>(t[5]) << 16)
+                          | (static_cast<quint32>(t[6]) << 24);
+            }
+            // 0xFF 0x02 (blank N leading pixels) is ignored for the mini view.
+            return false;
+        }
+        off = 1;   // 0xFF 0xFF -> escaped literal: row data after one byte
+    }
+
+    outRow = QImage(m_width, 1, QImage::Format_RGB32);
+    outRow.fill(qRgb(0, 0, 0));
+    QRgb* px = reinterpret_cast<QRgb*>(outRow.bits());
+
+    for (int j = off; j < L; ++j) {
+        const int e = j - off;
+        const int p0 = 2 * e;
+        const int p1 = 2 * e + 1;
+        if (p0 < m_width) {
+            px[p0] = m_lut[(16 * (t[j] & 15) + 2) & 0xFF];
+        }
+        if (p1 < m_width) {
+            px[p1] = m_lut[t[j] & 0xF2];
+        } else {
+            break;
+        }
+    }
+    return true;
+}
+
+} // namespace AetherSDR

--- a/src/core/WebSdrWaterfallDecoder.h
+++ b/src/core/WebSdrWaterfallDecoder.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <QByteArray>
+#include <QImage>
+#include <QRgb>
+#include <cstdint>
+
+namespace AetherSDR {
+
+// Decoder for the PA3FWM WebSDR waterfall stream (ws://<host>/~~waterstream<band>).
+// We request format=1: each payload byte yields two palette-indexed pixels.
+// 0xFF-prefixed frames are meta (scale reference / blanking / escaped literal).
+// See websdr-client/PROTOCOL.md and docs/architecture/websdr-module-spec.md §1.2.
+//
+// Stateful only for the scale reference; rows are independent. One instance per
+// stream on its worker thread.
+class WebSdrWaterfallDecoder {
+public:
+    WebSdrWaterfallDecoder();
+
+    void setWidth(int px) { m_width = (px > 0) ? px : 1; }
+    int  width() const { return m_width; }
+
+    // Decode one binary message. Returns true and fills `outRow` (a width×1
+    // Format_RGB32 image) when the message is a waterfall row; false for meta
+    // frames (which may update freqRef()).
+    bool feed(const QByteArray& frame, QImage& outRow);
+
+    quint32 freqRef() const { return m_freqRef; }
+
+private:
+    static QRgb paletteColor(int index);   // §1.2 formulas
+
+    int     m_width{512};
+    quint32 m_freqRef{0};
+    QRgb    m_lut[256];
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1215,6 +1215,13 @@ MainWindow::MainWindow(QWidget* parent)
     // subsystem doesn't ride along when RadioSession is extracted.
     wireSpotSubsystem();
 
+#ifdef HAVE_WEBSOCKETS
+    // WebSDR receive module (optional, passive bolt-on) → wireWebSdrModule()
+    // (MainWindow_WebSdr.cpp). Runs after buildMenuBar() so the View-menu
+    // toggle can be attached. Flex stays master; this only borrows the speaker.
+    wireWebSdrModule();
+#endif
+
     // Radio-model + TX-audio-stream wiring → wireRadioModel()
     // (MainWindow_Session.cpp, #3351 Phase 2c).
     wireRadioModel();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -87,6 +87,8 @@ class QShowEvent;
 namespace AetherSDR {
 
 class ConnectionPanel;
+class WebSdrSource;
+class WebSdrPanel;
 class TitleBar;
 class SpectrumWidget;
 class PanadapterApplet;
@@ -292,6 +294,9 @@ private:
     // from the constructor, in original order, defined in its subject TU.
     void wireMeters();              // MainWindow_Wiring.cpp
     void wireSpotSubsystem();       // MainWindow_Spots.cpp
+#ifdef HAVE_WEBSOCKETS
+    void wireWebSdrModule();        // MainWindow_WebSdr.cpp
+#endif
     // RadioSession precursors (#3351 Phase 2c / #3445) — MainWindow_Session.cpp
     void wireDiscovery();
     void wireRadioModel();
@@ -551,6 +556,10 @@ private:
     PropForecastClient*  m_propForecast{nullptr};
 #ifdef HAVE_WEBSOCKETS
     FreeDvClient*      m_freedvClient{nullptr};
+    WebSdrSource*      m_webSdrSource{nullptr};
+    QThread*           m_webSdrThread{nullptr};
+    WebSdrPanel*       m_webSdrPanel{nullptr};
+    int                m_webSdrFollowSliceId{-1};
 #endif
     QThread*           m_spotThread{nullptr};
 
@@ -763,6 +772,7 @@ private:
 
     // Menus
     QMenu*           m_profilesMenu{nullptr};
+    QMenu*           m_viewMenu{nullptr};   // stored so add-ins reach it after it moves into the TitleBar
     QAction*         m_txBandAction{nullptr};
 
     // Audio stream re-creation flag (after profile load)

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -571,6 +571,7 @@ void MainWindow::buildMenuBar()
     });
 
     auto* viewMenu = menuBar()->addMenu("&View");
+    m_viewMenu = viewMenu;   // keep a handle: the bar later moves into the TitleBar
 
     // Applet-panel show/hide and pop-out are now driven entirely from the
     // title-bar dock icons (#1713 Phase 6).  Ctrl+Shift+S retained here as

--- a/src/gui/MainWindow_WebSdr.cpp
+++ b/src/gui/MainWindow_WebSdr.cpp
@@ -1,0 +1,155 @@
+// MainWindow_WebSdr.cpp — WebSDR receive module wiring (M1, audio).
+//
+// Optional, passive bolt-on. Creates the WebSdrSource on its own worker thread
+// (FreeDvClient pattern) and a dockable WebSdrPanel, then wires the panel's
+// intent signals to the source and the source's audio to AudioEngine via the
+// RX source gate. Flex stays the authority/master — nothing here writes the
+// Flex model. Compiled only when HAVE_WEBSOCKETS is defined.
+
+#include "MainWindow.h"
+
+#ifdef HAVE_WEBSOCKETS
+
+#include "WebSdrPanel.h"
+#include "SliceColorManager.h"
+#include "core/AudioEngine.h"
+#include "core/WebSdrSource.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include <QThread>
+#include <QMenuBar>
+#include <QMenu>
+#include <QMetaObject>
+#include <QTimer>
+
+namespace {
+// Map a Flex slice mode to a WebSDR mode suffix.
+QString mapFlexMode(const QString& flex) {
+    const QString m = flex.toUpper();
+    if (m == "LSB" || m == "DIGL") {
+        return QStringLiteral("LSB");
+    }
+    if (m == "USB" || m == "DIGU") {
+        return QStringLiteral("USB");
+    }
+    if (m == "CW" || m == "CWL" || m == "CWU") {
+        return QStringLiteral("CW");
+    }
+    if (m == "AM" || m == "SAM") {
+        return QStringLiteral("AM");
+    }
+    if (m == "FM" || m == "NFM" || m == "DFM") {
+        return QStringLiteral("FM");
+    }
+    return QStringLiteral("USB");
+}
+}
+
+namespace AetherSDR {
+
+void MainWindow::wireWebSdrModule()
+{
+    // ── Source on a dedicated worker thread ────────────────────────────────
+    m_webSdrSource = new WebSdrSource;          // no parent — moved to thread
+    m_webSdrThread = new QThread(this);
+    m_webSdrThread->setObjectName(QStringLiteral("WebSdr"));
+    m_webSdrSource->moveToThread(m_webSdrThread);
+    m_webSdrThread->start();
+    // Construct sockets/timers on the worker thread (#1929).
+    QMetaObject::invokeMethod(m_webSdrSource, &WebSdrSource::init, Qt::QueuedConnection);
+
+    // ── Dockable panel ─────────────────────────────────────────────────────
+    // Docked + visible by default so the module is discoverable. The user can
+    // close it (and reopen via the WebSDR menu) or drag it out to float.
+    m_webSdrPanel = new WebSdrPanel(this);
+    addDockWidget(Qt::RightDockWidgetArea, m_webSdrPanel);
+
+    // Add the show/hide toggle to the View menu. We use the stored m_viewMenu
+    // pointer (set in buildMenuBar): the menu bar gets reparented into the
+    // TitleBar, so menuBar() no longer returns the populated bar here.
+    QAction* toggle = m_webSdrPanel->toggleViewAction();
+    toggle->setText(tr("WebSDR Panel"));
+    if (m_viewMenu) { m_viewMenu->addSeparator(); m_viewMenu->addAction(toggle); }
+
+    // ── Panel → Source (queued across threads) ─────────────────────────────
+    connect(m_webSdrPanel, &WebSdrPanel::connectRequested,
+            m_webSdrSource, &WebSdrSource::connectToServer);
+    connect(m_webSdrPanel, &WebSdrPanel::disconnectRequested,
+            m_webSdrSource, &WebSdrSource::disconnectFromServer);
+    connect(m_webSdrPanel, &WebSdrPanel::tuneRequested,
+            m_webSdrSource, &WebSdrSource::tune);
+
+    // ── Panel → AudioEngine source gate ────────────────────────────────────
+    connect(m_webSdrPanel, &WebSdrPanel::audioToWebSdrToggled,
+            this, [this](bool on) {
+        // Ensure the RX sink is open, then flip the gate (both on the audio thread).
+        QMetaObject::invokeMethod(m_audio, &AudioEngine::startRxStream, Qt::QueuedConnection);
+        QMetaObject::invokeMethod(m_audio, [this, on] { m_audio->setRxSourceWebSdr(on); },
+                                  Qt::QueuedConnection);
+    });
+
+    // ── Follow a chosen Flex slice (read-only) ─────────────────────────────
+    // Per-slice buttons (A/B/…) select which slice to follow. We poll it and
+    // drive the panel's freq/mode/passband. Reading the Flex model only.
+    auto rebuildSliceButtons = [this] {
+        QList<int> ids; QStringList labels, colors;
+        for (SliceModel* s : m_radioModel.slices()) {
+            ids << s->sliceId();
+            labels << s->letter();
+            colors << SliceColorManager::instance().hexActive(s->sliceId());
+        }
+        m_webSdrPanel->setSliceButtons(ids, labels, colors);
+    };
+    rebuildSliceButtons();
+    connect(&m_radioModel, &RadioModel::sliceAdded, this,
+            [rebuildSliceButtons](SliceModel*) { rebuildSliceButtons(); });
+    connect(&m_radioModel, &RadioModel::sliceRemoved, this,
+            [rebuildSliceButtons](int) { rebuildSliceButtons(); });
+    connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged, this,
+            [rebuildSliceButtons] { rebuildSliceButtons(); });
+
+    auto pushSlice = [this] {
+        SliceModel* s = (m_webSdrFollowSliceId >= 0) ? m_radioModel.slice(m_webSdrFollowSliceId)
+                                                     : nullptr;
+        if (!s) {
+            return;
+        }
+        m_webSdrPanel->applyExternalTune(s->frequency() * 1000.0,  // MHz -> kHz
+                                         mapFlexMode(s->mode()),
+                                         s->filterLow()  / 1000.0,  // Hz -> kHz
+                                         s->filterHigh() / 1000.0);
+    };
+    auto* followTimer = new QTimer(this);
+    followTimer->setInterval(400);
+    connect(followTimer, &QTimer::timeout, this, pushSlice);
+    connect(m_webSdrPanel, &WebSdrPanel::followSliceChanged, this,
+            [this, followTimer, pushSlice](int sliceId) {
+        m_webSdrFollowSliceId = sliceId;
+        if (sliceId >= 0) { pushSlice(); followTimer->start(); }
+        else                followTimer->stop();
+    });
+
+    // ── Source → AudioEngine audio (queued to the audio thread) ────────────
+    connect(m_webSdrSource, &WebSdrSource::audioReady,
+            m_audio, &AudioEngine::feedWebSdrAudio);
+
+    // ── Source → Panel UI (queued to the main thread) ──────────────────────
+    connect(m_webSdrSource, &WebSdrSource::stateChanged,
+            m_webSdrPanel, &WebSdrPanel::setSourceState);
+    connect(m_webSdrSource, &WebSdrSource::bandSpan,
+            m_webSdrPanel, &WebSdrPanel::setBandSpan);
+    connect(m_webSdrSource, &WebSdrSource::rowReady,
+            m_webSdrPanel, &WebSdrPanel::addWaterfallRow);
+
+    // ── Clean shutdown of the worker thread ────────────────────────────────
+    connect(m_webSdrThread, &QThread::finished,
+            m_webSdrSource, &QObject::deleteLater);
+    connect(this, &QObject::destroyed, this, [this] {
+        if (m_webSdrThread) { m_webSdrThread->quit(); m_webSdrThread->wait(2000); }
+    });
+}
+
+} // namespace AetherSDR
+
+#endif // HAVE_WEBSOCKETS

--- a/src/gui/WebSdrPanel.cpp
+++ b/src/gui/WebSdrPanel.cpp
@@ -1,0 +1,315 @@
+#include "WebSdrPanel.h"
+
+#include "WebSdrWaterfallView.h"
+#include "core/AppSettings.h"
+#include "core/ThemeManager.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QWidget>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QLineEdit>
+#include <QDoubleSpinBox>
+#include <QPushButton>
+#include <QLabel>
+#include <QButtonGroup>
+#include <QFont>
+
+namespace AetherSDR {
+
+namespace {
+const char* kStateNames[] = {"Disconnected", "Connecting", "Connected", "Streaming", "Error"};
+
+// Standard themed button (applet-style-guide §Buttons), token-based.
+const char* kBtnStyle =
+    "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+    "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; "
+    "padding: 2px 6px; }"
+    "QPushButton:hover { background: {{color.background.1}}; }";
+
+// As above but with an accent-filled checked state (Blue-active role).
+const char* kToggleBtnStyle =
+    "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+    "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; "
+    "padding: 2px 6px; }"
+    "QPushButton:hover { background: {{color.background.1}}; }"
+    "QPushButton:checked { background: {{color.accent}}; color: {{color.background.0}}; "
+    "border: 1px solid {{color.accent}}; }";
+
+// Dark input fields (host / frequency) to match the themed surfaces.
+const char* kInputStyle =
+    "QLineEdit, QAbstractSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; "
+    "border: 1px solid {{color.border.subtle}}; border-radius: 2px; padding: 2px 4px; font-size: 11px; }"
+    "QLineEdit:focus, QAbstractSpinBox:focus { border: 1px solid {{color.accent}}; }";
+}
+
+WebSdrPanel::WebSdrPanel(QWidget* parent)
+    : QDockWidget(tr("WebSDR"), parent)
+{
+    setObjectName(QStringLiteral("WebSdrPanel"));
+    setFeatures(QDockWidget::DockWidgetMovable
+              | QDockWidget::DockWidgetFloatable
+              | QDockWidget::DockWidgetClosable);
+
+    auto* content = new QWidget(this);
+    QFont pf = content->font();
+    pf.setPixelSize(11);                     // compact applet-style text (style guide §Typography)
+    content->setFont(pf);
+
+    auto* root = new QVBoxLayout(content);
+    root->setContentsMargins(4, 4, 4, 4);    // tight applet-style margins (style guide §Layout)
+    root->setSpacing(4);
+
+    auto& theme = ThemeManager::instance();
+
+    // Row 1 — server host + connect.
+    auto* row1 = new QHBoxLayout();
+    row1->setSpacing(4);
+    m_host = new QLineEdit(content);
+    m_host->setPlaceholderText(QStringLiteral("host:port  (e.g. example.org:8901)"));
+    m_host->setAccessibleName(tr("WebSDR server host and port"));
+    theme.applyStyleSheet(m_host, kInputStyle);
+    m_connectBtn = new QPushButton(tr("Connect"), content);
+    m_connectBtn->setAccessibleName(tr("Connect or disconnect the WebSDR"));
+    theme.applyStyleSheet(m_connectBtn, kBtnStyle);
+    row1->addWidget(m_host, 1);
+    row1->addWidget(m_connectBtn);
+    root->addLayout(row1);
+
+    // Row 2 — frequency + audio toggle.
+    auto* row2 = new QHBoxLayout();
+    row2->setSpacing(4);
+    m_freq = new QDoubleSpinBox(content);
+    m_freq->setRange(0.0, 30000000.0);       // kHz, up to 30 GHz headroom
+    m_freq->setDecimals(3);
+    m_freq->setSuffix(QStringLiteral(" kHz"));
+    m_freq->setValue(3557.0);
+    m_freq->setAccessibleName(tr("WebSDR frequency in kHz"));
+    theme.applyStyleSheet(m_freq, kInputStyle);
+    m_audioToggle = new QPushButton(tr("WebSDR Audio"), content);
+    m_audioToggle->setCheckable(true);
+    m_audioToggle->setAccessibleName(tr("Route speaker audio to the WebSDR"));
+    theme.applyStyleSheet(m_audioToggle, kToggleBtnStyle);
+    row2->addWidget(m_freq, 1);
+    row2->addWidget(m_audioToggle);
+    root->addLayout(row2);
+
+    // Row 3 — per-slice follow buttons.
+    auto* row3 = new QHBoxLayout();
+    row3->setSpacing(4);
+    row3->addWidget(new QLabel(tr("Follow:"), content));
+    m_sliceRow = new QWidget(content);
+    auto* sliceLay = new QHBoxLayout(m_sliceRow);
+    sliceLay->setContentsMargins(0, 0, 0, 0);
+    sliceLay->setSpacing(2);
+    row3->addWidget(m_sliceRow);
+    m_sliceGroup = new QButtonGroup(this);
+    m_sliceGroup->setExclusive(false);       // allow clicking the active one to stop
+    row3->addStretch(1);
+    root->addLayout(row3);
+
+    // Status row.
+    auto* statusRow = new QHBoxLayout();
+    m_stateLabel = new QLabel(tr("Disconnected"), content);
+    m_bandLabel  = new QLabel(QString(), content);
+    m_bandLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    statusRow->addWidget(m_stateLabel);
+    statusRow->addWidget(m_bandLabel, 1);
+    root->addLayout(statusRow);
+
+    m_waterfall = new WebSdrWaterfallView(content);
+    m_waterfall->setOnClick([this](double freqKHz) {
+        m_freq->setValue(freqKHz);     // canvas reports an absolute kHz (crop-aware)
+        tuneNow();
+    });
+    root->addWidget(m_waterfall, 1);
+
+    setWidget(content);
+    loadSettings();
+
+    connect(m_connectBtn, &QPushButton::clicked, this, &WebSdrPanel::onConnectClicked);
+    connect(m_freq, &QDoubleSpinBox::editingFinished, this, &WebSdrPanel::onTuneChanged);
+    connect(m_audioToggle, &QPushButton::toggled, this, &WebSdrPanel::audioToWebSdrToggled);
+    connect(m_sliceGroup, &QButtonGroup::idClicked, this, [this](int id) {
+        QAbstractButton* btn = m_sliceGroup->button(id);
+        if (btn && btn->isChecked()) {
+            for (QAbstractButton* b : m_sliceGroup->buttons()) {
+                if (m_sliceGroup->id(b) != id) {
+                    b->setChecked(false);
+                }
+            }
+            m_followingId = id;
+        } else {
+            m_followingId = -1;
+        }
+        const bool following = (m_followingId >= 0);
+        m_freq->setEnabled(!following);   // manual tuning is driven by the slice while following
+        emit followSliceChanged(m_followingId);
+    });
+    tuneNow();   // initialise the marker from the default freq/mode
+}
+
+void WebSdrPanel::onConnectClicked()
+{
+    if (!m_connected) {
+        const QString host = m_host->text().trimmed();
+        if (host.isEmpty()) {
+            return;
+        }
+        saveSettings();
+        emit connectRequested(host);
+        tuneNow();
+    } else {
+        emit disconnectRequested();
+    }
+}
+
+void WebSdrPanel::onTuneChanged()
+{
+    tuneNow();
+    saveSettings();
+}
+
+void WebSdrPanel::passbandFor(const QString& mode, double& loKHz, double& hiKHz) const
+{
+    const QString m = mode.toLower();
+    if      (m == "usb") { loKHz =  0.0; hiKHz =  2.7; }
+    else if (m == "lsb") { loKHz = -2.7; hiKHz =  0.0; }
+    else if (m == "cw")  { loKHz = -0.2; hiKHz =  0.2; }
+    else if (m == "cwu") { loKHz =  0.2; hiKHz =  0.7; }
+    else if (m == "cwl") { loKHz = -0.7; hiKHz = -0.2; }
+    else if (m == "am")  { loKHz = -4.5; hiKHz =  4.5; }
+    else if (m == "fm")  { loKHz = -6.0; hiKHz =  6.0; }
+    else                 { loKHz =  0.0; hiKHz =  2.7; }
+}
+
+void WebSdrPanel::tuneNow()
+{
+    double lo, hi;
+    passbandFor(m_mode, lo, hi);
+    m_curLoKHz = lo;
+    m_curHiKHz = hi;
+    if (m_waterfall) {
+        m_waterfall->setTuning(m_freq->value(), lo, hi);
+    }
+    emit tuneRequested(m_freq->value(), m_mode, lo, hi);
+}
+
+void WebSdrPanel::applyExternalTune(double freqKHz, const QString& mode,
+                                    double loKHz, double hiKHz)
+{
+    if (qAbs(freqKHz - m_freq->value()) < 1e-6 &&
+        mode.compare(m_mode, Qt::CaseInsensitive) == 0 &&
+        qAbs(loKHz - m_curLoKHz) < 1e-6 && qAbs(hiKHz - m_curHiKHz) < 1e-6) {
+        return;   // unchanged — avoid command spam while following
+    }
+    QSignalBlocker bf(m_freq);
+    m_freq->setValue(freqKHz);
+    m_mode = mode;
+    m_curLoKHz = loKHz;
+    m_curHiKHz = hiKHz;
+    if (m_waterfall) {
+        m_waterfall->setTuning(freqKHz, loKHz, hiKHz);
+    }
+    emit tuneRequested(freqKHz, mode, loKHz, hiKHz);
+}
+
+void WebSdrPanel::setSourceState(int state, const QString& detail)
+{
+    m_connected = (state == 2 /*Connected*/ || state == 3 /*Streaming*/);
+    QString label = (state >= 0 && state <= 4) ? QString::fromLatin1(kStateNames[state])
+                                               : QStringLiteral("?");
+    if (!detail.isEmpty()) {
+        label += QStringLiteral(" (%1)").arg(detail);
+    }
+    m_stateLabel->setText(label);
+    m_connectBtn->setText(m_connected || state == 1 ? tr("Disconnect") : tr("Connect"));
+    if (!m_connected && state != 1) {
+        // dropped: revert the audio toggle so Flex regains the speaker
+        if (m_audioToggle->isChecked()) {
+            m_audioToggle->setChecked(false);
+        }
+    }
+}
+
+void WebSdrPanel::setSliceButtons(const QList<int>& ids, const QStringList& labels,
+                                  const QStringList& colors)
+{
+    if (!m_sliceRow || !m_sliceGroup) {
+        return;
+    }
+    for (QAbstractButton* b : m_sliceGroup->buttons()) {
+        m_sliceGroup->removeButton(b);
+        b->deleteLater();
+    }
+    auto* lay = qobject_cast<QHBoxLayout*>(m_sliceRow->layout());
+    for (int i = 0; i < ids.size(); ++i) {
+        auto* btn = new QPushButton(i < labels.size() ? labels[i] : QString::number(ids[i]), m_sliceRow);
+        btn->setCheckable(true);
+        btn->setFixedSize(22, 22);   // standard button height (style guide §Layout)
+        const QString hex = (i < colors.size() && !colors[i].isEmpty()) ? colors[i]
+                                                                        : QStringLiteral("#00d4ff");
+        // Outlined in the slice colour; filled with it when selected (following).
+        // 10px bold matches the standard button text (style guide §Typography).
+        btn->setStyleSheet(QStringLiteral(
+            "QPushButton { border: 1px solid %1; border-radius: 3px; color: %1;"
+            " background: transparent; padding: 0px; font-size: 10px; font-weight: bold; }"
+            "QPushButton:checked { background: %1; color: #000; }").arg(hex));
+        btn->setToolTip(tr("Follow Flex slice %1 (read-only)").arg(btn->text()));
+        btn->setAccessibleName(tr("Follow slice %1").arg(btn->text()));
+        if (ids[i] == m_followingId) {
+            btn->setChecked(true);
+        }
+        if (lay) {
+            lay->addWidget(btn);
+        }
+        m_sliceGroup->addButton(btn, ids[i]);
+    }
+    if (m_followingId >= 0 && !ids.contains(m_followingId)) {   // followed slice gone
+        m_followingId = -1;
+        m_freq->setEnabled(true);
+        emit followSliceChanged(-1);
+    }
+}
+
+void WebSdrPanel::setBandSpan(double centerKHz, double srKHz, const QString& name)
+{
+    if (!name.isEmpty()) {
+        m_bandLabel->setText(tr("band: %1").arg(name));
+    }
+    if (m_waterfall) {
+        m_waterfall->setGeometryInfo(centerKHz, srKHz);
+    }
+}
+
+void WebSdrPanel::addWaterfallRow(const QImage& row)
+{
+    if (m_waterfall) {
+        m_waterfall->addRow(row);
+    }
+}
+
+void WebSdrPanel::loadSettings()
+{
+    // Nested JSON under one root key per feature (Constitution Principle V).
+    const QJsonObject o = QJsonDocument::fromJson(
+        AppSettings::instance().value("WebSdr").toString().toUtf8()).object();
+    m_host->setText(o.value("host").toString());   // no default — user enters their WebSDR
+    m_freq->setValue(o.value("freqKHz").toDouble(3557.0));
+    m_mode = o.value("mode").toString(QStringLiteral("CW"));
+}
+
+void WebSdrPanel::saveSettings() const
+{
+    // Whole config regenerated and written atomically (Principles V + XIV).
+    QJsonObject o;
+    o["host"]    = m_host->text().trimmed();
+    o["freqKHz"] = m_freq->value();
+    o["mode"]    = m_mode;
+    auto& s = AppSettings::instance();
+    s.setValue("WebSdr", QString::fromUtf8(QJsonDocument(o).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+} // namespace AetherSDR

--- a/src/gui/WebSdrPanel.h
+++ b/src/gui/WebSdrPanel.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <QDockWidget>
+#include <QString>
+#include <QStringList>
+#include <QImage>
+
+class QLineEdit;
+class QDoubleSpinBox;
+class QPushButton;
+class QLabel;
+class QWidget;
+class QButtonGroup;
+
+namespace AetherSDR {
+
+class WebSdrWaterfallView;   // mini-waterfall canvas (WebSdrPanel.cpp)
+
+// Dockable WebSDR module panel. M1: connection + tuning controls and an
+// "Audio → WebSDR" toggle. The live mini-waterfall canvas is added in M2.
+//
+// Pure view/controller: emits intent signals, never touches the Flex model.
+class WebSdrPanel : public QDockWidget {
+    Q_OBJECT
+public:
+    explicit WebSdrPanel(QWidget* parent = nullptr);
+
+signals:
+    void connectRequested(const QString& host);
+    void disconnectRequested();
+    void tuneRequested(double freqKHz, const QString& mode, double loKHz, double hiKHz);
+    void audioToWebSdrToggled(bool on);
+    void followSliceChanged(int sliceId);   // -1 = stop following
+
+public slots:
+    void setSourceState(int state, const QString& detail);   // WebSdrSource::State
+    void setBandSpan(double centerKHz, double srKHz, const QString& name);
+    void addWaterfallRow(const QImage& row);
+    // Drive freq/mode/passband from outside (Flex slice follow). De-dups.
+    void applyExternalTune(double freqKHz, const QString& mode, double loKHz, double hiKHz);
+    // Rebuild the per-slice follow buttons (A/B/…) from the current Flex slices.
+    // colors: per-slice hex strings (e.g. "#00d4ff") for consistency with the flags.
+    void setSliceButtons(const QList<int>& ids, const QStringList& labels,
+                         const QStringList& colors);
+
+private slots:
+    void onConnectClicked();
+    void onTuneChanged();
+
+private:
+    void loadSettings();
+    void saveSettings() const;
+    void tuneNow();                       // emit tuneRequested + refresh marker
+    void passbandFor(const QString& mode, double& loKHz, double& hiKHz) const;
+
+    QLineEdit*      m_host{nullptr};
+    QDoubleSpinBox* m_freq{nullptr};
+    QPushButton*    m_connectBtn{nullptr};
+    QPushButton*    m_audioToggle{nullptr};   // checkable toggle
+    QWidget*        m_sliceRow{nullptr};      // hosts the per-slice follow buttons
+    QButtonGroup*   m_sliceGroup{nullptr};
+    int             m_followingId{-1};
+    QLabel*         m_stateLabel{nullptr};
+    QLabel*         m_bandLabel{nullptr};
+    WebSdrWaterfallView* m_waterfall{nullptr};
+
+    QString m_mode{QStringLiteral("CW")};   // demod mode (no UI: follow/settings drive it)
+    bool    m_connected{false};
+    double  m_curLoKHz{0.0};
+    double  m_curHiKHz{2.7};
+};
+
+} // namespace AetherSDR

--- a/src/gui/WebSdrWaterfallView.cpp
+++ b/src/gui/WebSdrWaterfallView.cpp
@@ -1,0 +1,214 @@
+#include "WebSdrWaterfallView.h"
+
+#include "core/ThemeManager.h"
+
+#include <QAccessible>
+#include <QAccessibleWidget>
+#include <QPainter>
+#include <QMouseEvent>
+#include <QFont>
+
+#include <cmath>
+#include <cstring>
+
+namespace AetherSDR {
+
+// Accessibility: the widget overrides paintEvent, so a11y rules require a
+// QAccessibleInterface. Expose it as a chart; the name/description come from
+// the widget's accessibleName/accessibleDescription via QAccessibleWidget.
+namespace {
+
+class WaterfallAccessible : public QAccessibleWidget {
+public:
+    explicit WaterfallAccessible(QWidget* w)
+        : QAccessibleWidget(w, QAccessible::Chart) {}
+};
+
+QAccessibleInterface* waterfallFactory(const QString& key, QObject* obj)
+{
+    if (key == QLatin1String("AetherSDR::WebSdrWaterfallView")) {
+        return new WaterfallAccessible(qobject_cast<QWidget*>(obj));
+    }
+    return nullptr;
+}
+
+double niceStep(double range)
+{
+    if (range <= 0) {
+        return 1.0;
+    }
+    const double raw = range / 6.0;
+    const double mag = std::pow(10.0, std::floor(std::log10(raw)));
+    const double n = raw / mag;
+    const double step = (n < 1.5) ? 1.0 : (n < 3.5) ? 2.0 : (n < 7.5) ? 5.0 : 10.0;
+    return step * mag;
+}
+
+} // namespace
+
+WebSdrWaterfallView::WebSdrWaterfallView(QWidget* parent) : QWidget(parent)
+{
+    setMinimumHeight(160);
+    setAccessibleName(tr("WebSDR waterfall"));
+    setAccessibleDescription(tr("Live spectrum waterfall; click to tune"));
+
+    static bool s_factoryInstalled = false;
+    if (!s_factoryInstalled) {
+        s_factoryInstalled = true;
+        QAccessible::installFactory(waterfallFactory);
+    }
+
+    m_img = QImage(1024, 280, QImage::Format_RGB32);
+    m_img.fill(Qt::black);
+    m_cropR = m_img.width();
+}
+
+void WebSdrWaterfallView::setGeometryInfo(double centerKHz, double srKHz)
+{
+    if (centerKHz != m_centerKHz || srKHz != m_srKHz) {
+        m_img.fill(Qt::black);          // clear stale data on band change
+        m_colAvg.clear();               // re-learn the guard edges
+        m_cropL = 0;
+        m_cropR = m_img.width();
+    }
+    m_centerKHz = centerKHz;
+    m_srKHz = srKHz;
+    update();
+}
+
+void WebSdrWaterfallView::setTuning(double freqKHz, double loKHz, double hiKHz)
+{
+    m_tunedKHz = freqKHz;
+    m_loKHz = loKHz;
+    m_hiKHz = hiKHz;
+    m_haveTuning = true;
+    update();
+}
+
+void WebSdrWaterfallView::addRow(const QImage& row)
+{
+    QImage r = row.convertToFormat(QImage::Format_RGB32);
+    if (m_img.width() != r.width()) {
+        m_img = QImage(qMax(1, r.width()), m_img.height(), QImage::Format_RGB32);
+        m_img.fill(Qt::black);
+        m_colAvg.clear();
+        m_cropL = 0;
+        m_cropR = m_img.width();
+    }
+    const int w = m_img.width();
+    const int h = m_img.height();
+    const int bpl = m_img.bytesPerLine();
+    uchar* base = m_img.bits();
+    std::memmove(base + bpl, base, static_cast<size_t>(bpl) * (h - 1));
+    std::memcpy(base, r.constBits(), static_cast<size_t>(bpl));
+
+    // Track per-column activity (EMA of luminance) to locate the live region.
+    if (static_cast<int>(m_colAvg.size()) != w) {
+        m_colAvg.assign(w, 0.0);
+    }
+    const QRgb* px = reinterpret_cast<const QRgb*>(r.constBits());
+    for (int c = 0; c < w; ++c) {
+        const double lum = qGray(px[c]);
+        m_colAvg[c] = 0.92 * m_colAvg[c] + 0.08 * lum;
+    }
+    if (++m_rowsSinceCrop >= 16) {
+        m_rowsSinceCrop = 0;
+        recomputeCrop();
+    }
+    update();
+}
+
+void WebSdrWaterfallView::recomputeCrop()
+{
+    const int w = m_img.width();
+    if (static_cast<int>(m_colAvg.size()) != w) {
+        m_cropL = 0;
+        m_cropR = w;
+        return;
+    }
+    const double thresh = 3.0;        // dead (index 2) ~0.6, live (index 16+) ~5+
+    int l = 0;
+    while (l < w && m_colAvg[l] < thresh) {
+        ++l;
+    }
+    int rgt = w;
+    while (rgt > l && m_colAvg[rgt - 1] < thresh) {
+        --rgt;
+    }
+    if (rgt - l < w / 8) {   // sanity: too little live, keep the full view
+        m_cropL = 0;
+        m_cropR = w;
+    } else {
+        m_cropL = l;
+        m_cropR = rgt;
+    }
+}
+
+double WebSdrWaterfallView::freqAtCol(int c) const
+{
+    const int w = qMax(1, m_img.width());
+    return m_centerKHz - m_srKHz / 2.0 + (static_cast<double>(c) / w) * m_srKHz;
+}
+
+double WebSdrWaterfallView::freqLeft()  const { return freqAtCol(m_cropL); }
+double WebSdrWaterfallView::freqRight() const { return freqAtCol(m_cropR); }
+
+double WebSdrWaterfallView::xOf(double freqKHz) const
+{
+    const double fl = freqLeft();
+    const double fr = freqRight();
+    return (fr > fl) ? (freqKHz - fl) / (fr - fl) * width() : 0.0;
+}
+
+void WebSdrWaterfallView::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    const int scaleH = 16;
+    const int wfTop = scaleH;
+    const int wfH = qMax(1, height() - scaleH);
+    const int cropW = qMax(1, m_cropR - m_cropL);
+    p.drawImage(QRect(0, wfTop, width(), wfH), m_img,
+                QRect(m_cropL, 0, cropW, m_img.height()));
+
+    if (m_srKHz <= 0.0) {
+        return;
+    }
+    auto& theme = ThemeManager::instance();
+    if (m_haveTuning) {
+        const double xl = xOf(m_tunedKHz + m_loKHz);
+        const double xh = xOf(m_tunedKHz + m_hiKHz);
+        p.fillRect(QRectF(xl, wfTop, qMax(1.0, xh - xl), wfH),
+                   theme::withAlpha("color.text.primary", 50));
+        const double xc = xOf(m_tunedKHz);
+        p.setPen(QPen(theme.color("color.accent.danger"), 1));
+        p.drawLine(QPointF(xc, wfTop), QPointF(xc, height()));
+    }
+    // frequency scale strip on top (panadapter-style), over the live span
+    p.fillRect(QRect(0, 0, width(), scaleH), theme::withAlpha("color.background.0", 180));
+    p.setPen(theme.color("color.text.secondary"));
+    QFont f = p.font();
+    f.setPixelSize(9);   // scale annotations: 9px (style guide §Typography)
+    p.setFont(f);
+    const double lo = freqLeft();
+    const double hi = freqRight();
+    const double step = niceStep(hi - lo);
+    const double first = std::ceil(lo / step) * step;
+    for (double fk = first; fk <= hi; fk += step) {
+        const double x = xOf(fk);
+        p.drawText(QRectF(x - 28, 0, 56, scaleH - 3),
+                   Qt::AlignHCenter | Qt::AlignBottom,
+                   QString::number(fk / 1000.0, 'f', 3));
+        p.drawLine(QPointF(x, scaleH - 3), QPointF(x, scaleH));
+    }
+}
+
+void WebSdrWaterfallView::mousePressEvent(QMouseEvent* e)
+{
+    if (m_onClick && width() > 0 && m_srKHz > 0.0) {
+        const double fl = freqLeft();
+        const double fr = freqRight();
+        m_onClick(fl + (static_cast<double>(e->position().x()) / width()) * (fr - fl));
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/WebSdrWaterfallView.h
+++ b/src/gui/WebSdrWaterfallView.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <QWidget>
+#include <QImage>
+
+#include <functional>
+#include <vector>
+
+namespace AetherSDR {
+
+// Self-rendered mini-waterfall for the WebSDR panel. A QImage ring buffer
+// scrolled one row per message (newest at the top, below a frequency scale).
+// The dead SDR guard bands at the edges (sent as black by the WebSDR) are
+// detected from per-column luminance and cropped so the useful spectrum fills
+// the width. Overlays the listening marker + passband. Clicks report an
+// absolute kHz (crop-aware). Plain QWidget — no QRhi; QPainter only.
+//
+// Q_OBJECT so QAccessible can identify it by class name (see the factory in
+// the .cpp) — required because it overrides paintEvent (a11y rules).
+class WebSdrWaterfallView : public QWidget {
+    Q_OBJECT
+public:
+    explicit WebSdrWaterfallView(QWidget* parent = nullptr);
+
+    void setOnClick(std::function<void(double)> cb) { m_onClick = std::move(cb); }
+    void setGeometryInfo(double centerKHz, double srKHz);
+    void setTuning(double freqKHz, double loKHz, double hiKHz);
+    void addRow(const QImage& row);
+
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent* e) override;
+
+private:
+    void   recomputeCrop();
+    double freqAtCol(int c) const;
+    double freqLeft() const;
+    double freqRight() const;
+    double xOf(double freqKHz) const;
+
+    QImage m_img;
+    std::function<void(double)> m_onClick;
+    std::vector<double> m_colAvg;
+    int    m_cropL{0};
+    int    m_cropR{0};
+    int    m_rowsSinceCrop{0};
+    double m_centerKHz{0.0};
+    double m_srKHz{0.0};
+    double m_tunedKHz{0.0};
+    double m_loKHz{0.0};
+    double m_hiKHz{0.0};
+    bool   m_haveTuning{false};
+};
+
+} // namespace AetherSDR


### PR DESCRIPTION
## Summary

Adds an **optional, passive WebSDR (PA3FWM) receive module**: the operator can
listen on a remote, RF-quiet receiver alongside the connected Flex radio. Many
amateurs have an RF-noisy home (switch-mode PSUs, PLC, LED drivers, chargers),
so a clean remote ear next to the local rig is genuinely useful — see the
linked issue for the motivation.

The Flex stays the authority/master. The module **only reads** the Flex model
(for optional slice-follow) and **never transmits** — WebSDR audio is never
routed to the radio.

Highlights:
- `WebSdrSource` — QWebSocket worker on its own thread (audio `~~stream` +
  waterfall `~~waterstream`), `~~param` tuning, band auto-select from
  `bandinfo.js`, mono→24 kHz stereo via `Resampler`, reconnect backoff.
- `WebSdrAudioDecoder` / `WebSdrWaterfallDecoder` — decoders for the served
  client's wire format (a-law + adaptive predictor; format-1 waterfall +
  palette). Audio decoder verified **bit-exact** vs a reference implementation.
- `WebSdrPanel` — dockable panel (host/freq/Connect, "WebSDR Audio" toggle,
  per-slice **follow** buttons in slice colours), self-rendered mini-waterfall
  in its **own** `QWidget` (not the GPU `SpectrumWidget`), with frequency scale,
  listening marker + passband, guard-band cropping, click-to-tune.
- `AudioEngine` — RX source gate (Flex ↔ WebSDR), never sent to the radio.
- Builds under `HAVE_WEBSOCKETS` (reuses `Qt6::WebSockets`); **no new dependency**.

Closes #3613

> **Process note:** opening PR-first per the de-facto practice (feature_request
> + PR). I know Constitution v2.0.0 (#3602, merged today) introduces an RFC gate
> for significant/UX changes — **happy to file an RFC if you'd like one**; just
> say the word and I'll add it and link it here.

## Constitution principle honored

- **Principle IV — Clean-room.** All protocol knowledge is derived from the
  JavaScript the WebSDR server serves to every browser and from on-the-wire
  behaviour. Nothing is decompiled, disassembled, or taken from a proprietary
  binary.
- **Principle V — Each feature owns its configuration as one object.** All
  panel settings are a single nested-JSON blob under one `AppSettings` key
  (`WebSdr`), regenerated and written atomically.

## Test plan

- [x] Local build passes (`cmake --build build`, MSVC/Qt 6.8.3)
- [x] Behavior verified on a real radio (audio switch + per-slice follow tested
      live against a connected Flex)
- [x] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug (n/a — new feature)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered
      from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (no meter UI added — the raw S-meter
      readout was intentionally dropped)
- [x] Documentation updated (`docs/architecture/websdr-module*.md`)
- [ ] Security-sensitive changes reference a GHSA if applicable (n/a)
