### PR TITLE
fix(gui): make CAT per-port enable toggle visible

### DIFF
--- a/src/gui/CatControlApplet.cpp
+++ b/src/gui/CatControlApplet.cpp
@@ -64,6 +64,17 @@ const char* kComboStyle =
 const char* kSepStyle =
     "QFrame { color: {{color.border.subtle}}; }";
 
+// Per-port enable checkbox. The default indicator is nearly invisible against
+// the dark applet background, so users miss that each CAT port has its own
+// enable toggle (#cat-port-enable). Give it a high-contrast border and a filled
+// accent when checked so the on/off state reads at a glance.
+const char* kEnableCheck =
+    "QCheckBox::indicator { width: 15px; height: 15px; border-radius: 3px;"
+    " border: 1px solid {{color.text.secondary}}; background: {{color.background.0}}; }"
+    "QCheckBox::indicator:hover { border-color: {{color.accent}}; }"
+    "QCheckBox::indicator:checked { border: 1px solid {{color.accent}}; background: {{color.accent}}; }"
+    "QCheckBox::indicator:disabled { border-color: {{color.border.subtle}}; background: {{color.background.1}}; }";
+
 constexpr int kMinPort = 1024;
 constexpr int kMaxPort = 65535;
 
@@ -292,9 +303,9 @@ void CatControlApplet::buildTableRows()
         m_grid->addWidget(lbl, 0, col);
     };
     int hcol = 0;
-    addHdr("En",       22, hcol++);
+    addHdr("Enabled",  54, hcol++, Qt::AlignHCenter | Qt::AlignVCenter);
     addHdr("Port",     50, hcol++, Qt::AlignHCenter | Qt::AlignVCenter);
-    addHdr("Dialect",  68, hcol++);
+    addHdr("Dialect",  84, hcol++);
     addHdr("VFO A",    42, hcol++, Qt::AlignHCenter | Qt::AlignVCenter);
     addHdr("VFO B",    42, hcol++, Qt::AlignHCenter | Qt::AlignVCenter);
 #ifndef Q_OS_WIN
@@ -310,7 +321,8 @@ void CatControlApplet::buildTableRows()
 
         // Enable checkbox
         row.enableCheck = new QCheckBox;
-        row.enableCheck->setFixedWidth(22);
+        ThemeManager::instance().applyStyleSheet(row.enableCheck, kEnableCheck);
+        row.enableCheck->setToolTip("Enable this CAT port");
         {
             bool en = settings.value(prefix + "Enabled", "False").toString() == "True";
             QSignalBlocker b(row.enableCheck);
@@ -333,7 +345,7 @@ void CatControlApplet::buildTableRows()
         // Dialect combo
         row.dialectCombo = new QComboBox;
         ThemeManager::instance().applyStyleSheet(row.dialectCombo, kComboStyle);
-        row.dialectCombo->setFixedWidth(68);
+        row.dialectCombo->setFixedWidth(84);
         row.dialectCombo->addItem("Rigctld",  static_cast<int>(CatDialect::Rigctld));
         row.dialectCombo->addItem("TS-2000",  static_cast<int>(CatDialect::TS2000));
         row.dialectCombo->addItem("Flex",     static_cast<int>(CatDialect::FlexCAT));
@@ -424,7 +436,7 @@ void CatControlApplet::buildTableRows()
 
         // Grid layout — data rows start at 1 (row 0 is the header)
         int col = 0;
-        m_grid->addWidget(row.enableCheck,  i+1, col++);
+        m_grid->addWidget(row.enableCheck,  i+1, col++, Qt::AlignHCenter);
         m_grid->addWidget(row.portEdit,     i+1, col++);
         m_grid->addWidget(row.dialectCombo, i+1, col++);
         m_grid->addWidget(row.vfoACombo,    i+1, col++);

--- a/src/gui/CatPopoutWindow.cpp
+++ b/src/gui/CatPopoutWindow.cpp
@@ -35,6 +35,17 @@ const char* kComboStyle =
 const char* kSep =
     "QFrame { color: #1e2e3e; }";
 
+// Per-port enable checkbox. The default indicator is nearly invisible against
+// the dark background, so users miss that each CAT port has its own enable
+// toggle. High-contrast border + filled accent when checked so on/off reads
+// at a glance.
+const char* kCheckStyle =
+    "QCheckBox::indicator { width: 15px; height: 15px; border-radius: 3px;"
+    " border: 1px solid #8090a0; background: #0a0a18; }"
+    "QCheckBox::indicator:hover { border-color: #81abd9; }"
+    "QCheckBox::indicator:checked { border: 1px solid #8cc8ff; background: #2f71b6; }"
+    "QCheckBox::indicator:disabled { border-color: #1e2e3e; background: #10161d; }";
+
 // Minimum valid port number for CAT (exclude system ports)
 constexpr int kMinPort = 1024;
 constexpr int kMaxPort = 65535;
@@ -114,17 +125,18 @@ void CatPopoutWindow::buildTable()
     auto* headerRow = new QHBoxLayout;
     headerRow->setSpacing(0);
 
-    auto addHeader = [&](const QString& text, int fixedW) {
+    auto addHeader = [&](const QString& text, int fixedW,
+                         Qt::Alignment align = Qt::AlignLeft | Qt::AlignVCenter) {
         auto* lbl = new QLabel(text);
         lbl->setStyleSheet(kHeaderStyle);
         lbl->setFixedWidth(fixedW);
-        lbl->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+        lbl->setAlignment(align);
         headerRow->addWidget(lbl);
     };
 
-    addHeader("En",      24);
+    addHeader("Enabled", 54, Qt::AlignHCenter | Qt::AlignVCenter);
     addHeader("Port",    52);
-    addHeader("Dialect", 88);
+    addHeader("Dialect", 102);
     addHeader("VFO A",   56);
     addHeader("VFO B",   56);
 #ifndef Q_OS_WIN
@@ -151,6 +163,10 @@ void CatPopoutWindow::buildTable()
     m_grid = new QGridLayout(rowContainer);
     m_grid->setContentsMargins(0, 0, 0, 0);
     m_grid->setSpacing(3);
+    // Match the "Enabled" header column (54px header, less the 2px header/grid
+    // offset used by the other columns) so the centered checkbox lines up under
+    // the header and downstream columns stay aligned.
+    m_grid->setColumnMinimumWidth(0, 52);
 
     scroll->setWidget(rowContainer);
     root->addWidget(scroll);
@@ -183,7 +199,8 @@ void CatPopoutWindow::rebuildRows()
 
         // Enable checkbox
         row.enableCheck = new QCheckBox;
-        row.enableCheck->setFixedWidth(22);
+        row.enableCheck->setStyleSheet(kCheckStyle);
+        row.enableCheck->setToolTip("Enable this CAT port");
         {
             bool en = settings.value(prefix + "Enabled", "False").toString() == "True";
             QSignalBlocker b(row.enableCheck);
@@ -206,7 +223,7 @@ void CatPopoutWindow::rebuildRows()
         // Dialect combo
         row.dialectCombo = new QComboBox;
         row.dialectCombo->setStyleSheet(kComboStyle);
-        row.dialectCombo->setFixedWidth(86);
+        row.dialectCombo->setFixedWidth(100);
         row.dialectCombo->addItem("Rigctld",  static_cast<int>(CatDialect::Rigctld));
         row.dialectCombo->addItem("TS-2000",  static_cast<int>(CatDialect::TS2000));
         row.dialectCombo->addItem("FlexCAT",  static_cast<int>(CatDialect::FlexCAT));
@@ -279,7 +296,7 @@ void CatPopoutWindow::rebuildRows()
 
         // Add to grid
         int col = 0;
-        m_grid->addWidget(row.enableCheck,  i, col++);
+        m_grid->addWidget(row.enableCheck,  i, col++, Qt::AlignHCenter);
         m_grid->addWidget(row.portEdit,     i, col++);
         m_grid->addWidget(row.dialectCombo, i, col++);
         m_grid->addWidget(row.vfoACombo,    i, col++);


### PR DESCRIPTION
Resolves #3609

## Summary

A user reported being unable to access the CAT port. The cause turned out to be discoverability: the CAT control table has a per-port **enable checkbox**, but it was easy to miss on two fronts — the column header read `En` (looks truncated), and the default `QCheckBox` indicator is nearly invisible against the dark applet/pop-out background. You can have the CAT server on globally yet never tick the individual port's box. The reporter confirmed he hadn't realized he needed to enable the port with the checkbox, and liked the new design.

## Changes

- **Relabel** the column header `En` → `Enabled` (widened and centered) in both the floating applet (`CatControlApplet.cpp`) and the pop-out window (`CatPopoutWindow.cpp`).
- **Dark-mode checkbox contrast:** style the enable `QCheckBox::indicator` with a high-contrast border when unchecked and a **filled accent when checked**, so on/off reads at a glance. Added an `"Enable this CAT port"` tooltip. The applet uses theme tokens (`{{color.accent}}` …); the pop-out uses hardcoded hex to match each file's existing styling convention.
- **Widen the Dialect column** so `TS-2000` is no longer clipped (applet 68→84px, pop-out 86→100px; pop-out header 88→102px to preserve its header/grid offset).

## Screenshot

<img width="625" height="246" alt="Screenshot 2026-06-15 at 08 21 33" src="https://github.com/user-attachments/assets/08d5480a-6018-4b35-bee8-af266c2d2cb0" />

## Files changed

| File | What changed |
|---|---|
| `src/gui/CatControlApplet.cpp` | Header relabel + width, `kEnableCheck` indicator style, tooltip, Dialect width |
| `src/gui/CatPopoutWindow.cpp` | Header relabel + width, `kCheckStyle` indicator style, tooltip, column-0 min width, Dialect width |

## Testing

Built clean on MacBook Air M2; verified visually in the running app (applet + pop-out): `Enabled` header fits, checkboxes clearly show enabled/disabled state in dark mode, `TS-2000` no longer clipped. The original reporter confirmed the redesigned control made the per-port enable obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

