### PR TITLE
fix(cat): bare ZZTX; is a read, not a key — uncommanded TX in Flex dialect (#3625)

### DIFF
--- a/src/core/SmartCatProtocol.cpp
+++ b/src/core/SmartCatProtocol.cpp
@@ -183,8 +183,15 @@ QString SmartCatProtocol::processCommandImpl(const QString& cmd)
         if (name == "ZZDE") return cmdZZDE(arg);
         if (name == "ZZFI") return cmdZZFI(arg);
         if (name == "ZZFJ") return cmdZZFJ(arg);
-        if (name == "ZZFR") return cmdZZFR();
-        if (name == "ZZFT") { m_splitEnabled = !m_splitEnabled; return {}; }
+        if (name == "ZZFR") return cmdZZFR(arg);
+        if (name == "ZZFT") {
+            // Bare "ZZFT;" is a READ of split state, not a toggle. Polling it
+            // previously flipped split on every call (same defect class as ZZTX).
+            if (arg.isEmpty() || arg == "?")
+                return QString("ZZFT%1;").arg(m_splitEnabled ? "1" : "0");
+            m_splitEnabled = (arg == "1");
+            return {};
+        }
         if (name == "ZZGT") return cmdZZGT(arg);
         if (name == "ZZLE") return cmdZZLE(arg);
         if (name == "ZZLB") return cmdZZLB(arg);
@@ -1069,11 +1076,23 @@ QString SmartCatProtocol::cmdSH(const QString& arg)
     return {};
 }
 
-// ── ZZFR — toggle active VFO (swaps m_vfoA ↔ m_vfoB) ───────────────────────
+// ── ZZFR — RX VFO select (0 = VFO A, 1 = VFO B) ─────────────────────────────
+//
+// FR selects the receive VFO. A bare "ZZFR;" is a READ and must not mutate
+// state — polling it previously swapped VFO A↔B on every call (same defect
+// class as ZZTX). Selecting the non-active VFO swaps the A/B slice mapping;
+// re-selecting the active VFO is a no-op (idempotent).
 
-QString SmartCatProtocol::cmdZZFR()
+QString SmartCatProtocol::cmdZZFR(const QString& arg)
 {
-    std::swap(m_vfoA, m_vfoB);
+    if (arg.isEmpty() || arg == "?")
+        return QString("ZZFR%1;").arg(m_rxVfoB ? "1" : "0");
+    if (arg != "0" && arg != "1") return "?;";
+    const bool wantB = (arg == "1");
+    if (wantB != m_rxVfoB) {
+        std::swap(m_vfoA, m_vfoB);
+        m_rxVfoB = wantB;
+    }
     return {};
 }
 

--- a/src/core/SmartCatProtocol.cpp
+++ b/src/core/SmartCatProtocol.cpp
@@ -164,7 +164,15 @@ QString SmartCatProtocol::processCommandImpl(const QString& cmd)
             return {};  // set handled by session
         }
         if (name == "ZZSW") return cmdZZSW(arg);
-        if (name == "ZZTX") return cmdTX(arg);
+        if (name == "ZZTX") {
+            // Bare "ZZTX;" (no parameter) is a READ of the transmit state, not a
+            // command to key. External apps poll TX status this way; treating the
+            // read as a set keyed the radio on every poll (uncommanded transmit).
+            // Only ZZTX0/1/2 reach cmdTX() to change state.
+            if (arg.isEmpty() || arg == "?")
+                return QString("ZZTX%1;").arg(m_model->isRadioTransmitting() ? "1" : "0");
+            return cmdTX(arg);
+        }
         if (name == "ZZRX") return cmdRX();
         if (name == "ZZSM") return cmdZZSM(arg);
         // ── Tier-2 ZZ commands ──────────────────────────────────────────────

--- a/src/core/SmartCatProtocol.h
+++ b/src/core/SmartCatProtocol.h
@@ -149,7 +149,7 @@ private:
     // ── Misc ─────────────────────────────────────────────────────────────────
     QString cmdZZBI(const QString& arg);
     QString cmdZZDE(const QString& arg);
-    QString cmdZZFR();
+    QString cmdZZFR(const QString& arg);
 
     QString processCommandImpl(const QString& cmd);
 
@@ -165,6 +165,7 @@ private:
     bool        m_flexExtensions{true};
     bool        m_aiEnabled{false};
     bool        m_splitEnabled{false};
+    bool        m_rxVfoB{false};   // false = VFO A is the RX VFO (FR/ZZFR selector)
     bool        m_pttAssertedByMe{false};
 };
 

--- a/tests/CAT_Flex_test.cpp
+++ b/tests/CAT_Flex_test.cpp
@@ -647,7 +647,23 @@ void section10ptt(CatClient& c, Runner& r)
     r.check(QStringLiteral("10.0 ZZIF confirms TX=0 before keying"),
             fields.tx == QChar('0'), repr(QString(fields.tx)));
 
-    c.send(QStringLiteral("ZZTX"));
+    // 10.0r REGRESSION: a bare "ZZTX;" (no parameter) is a READ of the TX state,
+    // NOT a key command. Apps poll TX status this way; if the read keys the radio,
+    // every poll causes uncommanded transmit. It must return "ZZTX0" and NOT key.
+    resp = c.query(QStringLiteral("ZZTX"));
+    r.check(QStringLiteral("10.0r bare ZZTX; is a read → 'ZZTX0' (not a key)"),
+            resp == QLatin1String("ZZTX0"), repr(resp));
+    QThread::msleep(500);
+    {
+        QString chk = c.query(QStringLiteral("ZZIF"));
+        IfFields cf = parseIfBody(chk.startsWith(QLatin1String("ZZIF")) ? chk.mid(4) : QString());
+        r.check(QStringLiteral("10.0r2 bare ZZTX; did NOT key radio; ZZIF TX='0'"),
+                cf.tx == QChar('0'), repr(QString(cf.tx)));
+        if (cf.tx != QChar('0')) { c.send(QStringLiteral("ZZRX")); c.send(QStringLiteral("RX")); }
+    }
+
+    // Key with the explicit set form ZZTX1 (parameterised), then verify.
+    c.send(QStringLiteral("ZZTX1"));
     QThread::msleep(1000);
 
     resp = c.query(QStringLiteral("ZZIF"));
@@ -655,8 +671,10 @@ void section10ptt(CatClient& c, Runner& r)
     const bool txOn = (fields.tx == QChar('1'));
 
     if (!txOn) {
-        r.skip(QStringLiteral("10.1 ZZTX; keys radio; ZZIF TX='1'"),
+        r.skip(QStringLiteral("10.1 ZZTX1; keys radio; ZZIF TX='1'"),
                QStringLiteral("TX blocked — check interlock/inhibit line"));
+        r.skip(QStringLiteral("10.1r read while keyed → 'ZZTX1'"),
+               QStringLiteral("TX blocked"));
         r.skip(QStringLiteral("10.2 ZZRX; unkeys radio; ZZIF TX='0'"),
                QStringLiteral("TX blocked"));
         r.skip(QStringLiteral("10.3 base TX;/RX; also work; IF TX='0'"),
@@ -666,8 +684,14 @@ void section10ptt(CatClient& c, Runner& r)
         return;
     }
 
-    r.check(QStringLiteral("10.1 ZZTX; keys radio; ZZIF body TX field = '1'"),
+    r.check(QStringLiteral("10.1 ZZTX1; keys radio; ZZIF body TX field = '1'"),
             txOn, repr(QString(fields.tx)));
+
+    // 10.1r: while keyed, the bare read must report the keyed state ('ZZTX1')
+    // and must not toggle it.
+    resp = c.query(QStringLiteral("ZZTX"));
+    r.check(QStringLiteral("10.1r bare ZZTX; read reflects keyed state → 'ZZTX1'"),
+            resp == QLatin1String("ZZTX1"), repr(resp));
 
     c.send(QStringLiteral("ZZRX"));
     QThread::msleep(250);
@@ -710,7 +734,8 @@ void section10ptt(CatClient& c, Runner& r)
 void section10skip(Runner& r)
 {
     r.section(QStringLiteral("Section 10 — PTT  (skipped — pass --ptt to enable)"));
-    for (const char* name : { "10.0 baseline", "10.1 ZZTX; keys",
+    for (const char* name : { "10.0 baseline", "10.0r bare ZZTX read (no key)",
+                               "10.1 ZZTX1 keys", "10.1r read while keyed",
                                "10.2 ZZRX; unkeys", "10.3 base TX/RX" }) {
         r.skip(QString::fromLatin1(name), QStringLiteral("--ptt not set"));
     }

--- a/tests/CAT_Flex_test.cpp
+++ b/tests/CAT_Flex_test.cpp
@@ -615,6 +615,26 @@ void section8(CatClient& c, Runner& r)
             respZz == QLatin1String("ZZSW0"), repr(respZz));
     r.check(QStringLiteral("8.6  FT; also reflects split off (FT0)"),
             respFt == QLatin1String("FT0"), repr(respFt));
+
+    // 8.7 REGRESSION: bare "ZZFT;" reads split state and must NOT toggle it.
+    // (Previously ZZFT unconditionally flipped split on every call.)
+    QString ft1 = c.query(QStringLiteral("ZZFT"));
+    QString ft2 = c.query(QStringLiteral("ZZFT"));
+    r.check(QStringLiteral("8.7  bare ZZFT; reads split (ZZFT0) and does not toggle on repeat"),
+            ft1 == QLatin1String("ZZFT0") && ft2 == QLatin1String("ZZFT0"),
+            QStringLiteral("first=%1 second=%2").arg(repr(ft1), repr(ft2)));
+
+    // 8.8 ZZFT1/ZZFT0 set split, consistent with ZZSW.
+    c.send(QStringLiteral("ZZFT1"));
+    QString ftOn = c.query(QStringLiteral("ZZFT"));
+    QString swOn = c.query(QStringLiteral("ZZSW"));
+    r.check(QStringLiteral("8.8  ZZFT1; enables split; ZZFT; → ZZFT1, ZZSW; → ZZSW1"),
+            ftOn == QLatin1String("ZZFT1") && swOn == QLatin1String("ZZSW1"),
+            QStringLiteral("ZZFT=%1 ZZSW=%2").arg(repr(ftOn), repr(swOn)));
+    c.send(QStringLiteral("ZZFT0"));  // restore split off
+    QString ftOff = c.query(QStringLiteral("ZZFT"));
+    r.check(QStringLiteral("8.9  ZZFT0; clears split; ZZFT; → ZZFT0"),
+            ftOff == QLatin1String("ZZFT0"), repr(ftOff));
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -1052,22 +1072,32 @@ void section13(CatClient& c, Runner& r)
     c.send(origBi);
     QThread::msleep(200);
 
-    // ── ZZFR: toggle active VFO ───────────────────────────────────────────
+    // ── ZZFR: RX VFO select (0=A, 1=B) — bare form is a READ, not a swap ──────
     QString faBefore = c.query(QStringLiteral("ZZFA"));
     QString fbBefore = c.query(QStringLiteral("ZZFB"));
-    c.send(QStringLiteral("ZZFR"));
+    // 13.34r REGRESSION: bare "ZZFR;" reads the selector and must NOT swap VFOs.
+    QString zzfrRead = c.query(QStringLiteral("ZZFR"));
+    QThread::msleep(50);
+    QString faUnchanged = c.query(QStringLiteral("ZZFA"));
+    r.check(QStringLiteral("13.34r bare ZZFR; reads selector ('ZZFR0') without swapping"),
+            zzfrRead == QLatin1String("ZZFR0") && faUnchanged.mid(4) == faBefore.mid(4),
+            QStringLiteral("read=%1 ZZFA before=%2 after=%3")
+                .arg(repr(zzfrRead), repr(faBefore.mid(4)), repr(faUnchanged.mid(4))));
+    // 13.34 explicit select: ZZFR1 selects VFO B as RX → new ZZFA matches old ZZFB.
+    c.send(QStringLiteral("ZZFR1"));
     QThread::msleep(50);
     QString faAfter = c.query(QStringLiteral("ZZFA"));
-    // If VFO A and B differ, after ZZFR the new ZZFA should match old ZZFB.
+    QString zzfrAfter = c.query(QStringLiteral("ZZFR"));
+    // If VFO A and B differ, after ZZFR1 the new ZZFA should match old ZZFB.
     // If they're equal (single-slice session), the swap is a no-op — treat as pass.
     const bool zzfrOk = (faBefore.mid(4) == fbBefore.mid(4))
                         ? true
                         : (faAfter.mid(4) == fbBefore.mid(4));
-    r.check(QStringLiteral("13.34 ZZFR; swaps VFOs — new ZZFA matches old ZZFB freq"),
-            zzfrOk,
-            QStringLiteral("before: ZZFA=%1 ZZFB=%2 after ZZFA=%3")
-                .arg(repr(faBefore.mid(4)), repr(fbBefore.mid(4)), repr(faAfter.mid(4))));
-    c.send(QStringLiteral("ZZFR"));  // swap back
+    r.check(QStringLiteral("13.34 ZZFR1; selects VFO B — new ZZFA matches old ZZFB; ZZFR; → 'ZZFR1'"),
+            zzfrOk && zzfrAfter == QLatin1String("ZZFR1"),
+            QStringLiteral("before: ZZFA=%1 ZZFB=%2 after ZZFA=%3 sel=%4")
+                .arg(repr(faBefore.mid(4)), repr(fbBefore.mid(4)), repr(faAfter.mid(4)), repr(zzfrAfter)));
+    c.send(QStringLiteral("ZZFR0"));  // select VFO A again (swap back)
     QThread::msleep(50);
 
     // ── ZZAR: VFO A AGC threshold (0-100, 3-digit) ───────────────────────────


### PR DESCRIPTION
**Resolves #3625**

## Summary

In the **Flex (ZZ-extension) CAT dialect**, a parameter-less `ZZTX;` — which is a *read* of the transmit state — was parsed as a *set* and keyed the transmitter. External applications poll TX status with `ZZTX;` roughly once per second, so every poll caused an **uncommanded transmission**.

## Root cause

`ZZTX` dispatched to the shared `cmdTX()`, which keys on any argument except `0`. A bare `ZZTX;` arrives with an **empty argument**, doesn't match `"0"`, and falls through to `setTransmit(true)` → `xmit 1`.

Per the Kenwood/Flex GET/SET convention, `ZZTX;` (no parameter) is a **read** that must return `ZZTX0;`/`ZZTX1;`; only `ZZTX1`/`ZZTX2` should key.

## Evidence (from reporter debug logs, Flex vs TS-2000)

```
aether.cat:        CAT ← ZZTX
aether.cat:        SmartCAT "ZZTX" (set)      ← misclassified as a SET
aether.connection: TX: "Cnn|xmit 1"           ← keys the transmitter
```

- **Flex:** 30 `ZZTX` polls → **30 `xmit 1`**, exact 1:1.
- **TS-2000:** the same app sent `ZZTX` 34 times → answered `?;` (the dialect doesn't implement the ZZ extension) → **0 `xmit`**. The bug is specific to the Flex dialect's `ZZTX` handler.

**Severity:** high — any Flex-dialect client that polls TX status continuously keys the transmitter (unintended emissions; possible interference / PA stress).

## Fix (commit 1)

Handle the bare/`?` read in the `ZZTX` dispatch, returning the same authoritative state `IF`/`ZZIF` report (`isRadioTransmitting()`); only `ZZTX0/1/2` reach `cmdTX()`. Plain Kenwood `TX;` keying is deliberately untouched (it is a set command in TS-2000).

## Audit (commit 2 — kept separate)

Finding a defect like this, the responsible step is to check for siblings. I audited **every** handler in `SmartCatProtocol` (both the Flex/ZZ and TS-2000/base dispatch tables) for the same class — a bare/parameter-less *read* falling through to a state change:

- **Found two more, both in the Flex (ZZ-extension) dialect:**
  - `ZZFR;` — unconditionally swapped VFO A↔B on every call.
  - `ZZFT;` — unconditionally toggled split on every call.

  Both now follow the GET/SET convention used by their twins (`cmdFT`, `cmdZZSW`): bare/`?` reads, explicit `0`/`1` sets. `ZZFR` gains an idempotent RX-VFO selector.
- **TS-2000 dialect: none.** Read guards live inside the shared handlers, so they protect both dialects; the only intentional divergence is `TX;` keying, which is correct Kenwood behavior.

This is the **second commit** so a reviewer who prefers to scope the PR to the reported bug can drop the audit commit independently.

## Testing

Verified live against a FlexRadio with `CAT_Flex_test --ptt` (keys the rig into a dummy load):
- New regression checks: `10.0r`/`10.0r2`/`10.1r` (ZZTX read vs key), `13.34r`/`13.34` (ZZFR read vs select), `8.7`–`8.9` (ZZFT read vs set).
- **120/120 passed.**

Built and tested on **MacBook Air M2 (macOS)** only. Not built on Linux/Windows for this change — it's a small, platform-agnostic CAT parsing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
