### PR TITLE
refactor(audio): negotiate QuindarLocalSink format via the factory (Phase 6, #3306)

### DIFF
--- a/src/core/QuindarLocalSink.cpp
+++ b/src/core/QuindarLocalSink.cpp
@@ -1,4 +1,5 @@
 #include "QuindarLocalSink.h"
+#include "AudioDeviceNegotiator.h"
 #include "AudioSummaryLogger.h"
 #include "ClientQuindarTone.h"
 #include "LogManager.h"
@@ -49,24 +50,44 @@ bool QuindarLocalSink::start(const QAudioDevice& device,
         return false;
     }
 
-    QAudioFormat fmt;
-    fmt.setSampleRate(48000);
-    fmt.setChannelCount(2);
-    fmt.setSampleFormat(QAudioFormat::Float);
+    // Negotiate the output format via the shared factory (#3306). The Quindar
+    // tone is generated in Float, so walk only the Float rungs of the ladder —
+    // which now gives this sink, in one place, the per-OS preferred rate plus
+    // the 44.1 kHz and device-preferredFormat fallbacks it previously lacked (it
+    // failed outright on a 44.1k-only output, with only 48k + preferred tried).
     QStringList attemptedFormats;
-    attemptedFormats << QStringLiteral("48000Hz 2ch Float");
-    if (!dev.isFormatSupported(fmt)) {
-        fallbackOccurred = true;
-        fallbackReasons << QStringLiteral("48000Hz Float stereo unsupported -> preferred output format");
-        fmt = dev.preferredFormat();
-        if (fmt.sampleFormat() != QAudioFormat::Float) {
-            fmt.setSampleFormat(QAudioFormat::Float);
+    QAudioFormat fmt;
+    bool haveFormat = false;
+    const QList<QAudioFormat> ladder = AudioDeviceNegotiator::formatLadder(
+        dev, AudioFormatNegotiator::Direction::Output,
+        AudioFormatNegotiator::ResamplerPolicy::RegenerateAtRate);
+    for (const QAudioFormat& cand : ladder) {
+        if (cand.sampleFormat() != QAudioFormat::Float)
+            continue;   // the tone is generated in Float
+        attemptedFormats << QStringLiteral("%1Hz %2ch Float")
+            .arg(cand.sampleRate()).arg(cand.channelCount());
+        if (dev.isFormatSupported(cand)) {
+            fmt = cand;
+            haveFormat = true;
+            if (cand.sampleRate() != 48000) {
+                fallbackOccurred = true;
+                fallbackReasons << QStringLiteral("negotiated %1Hz Float").arg(cand.sampleRate());
+            }
+            break;
         }
-        fmt.setChannelCount(2);
-        attemptedFormats << QStringLiteral("%1Hz %2ch %3")
-            .arg(fmt.sampleRate())
-            .arg(fmt.channelCount())
-            .arg(AudioSummaryLogger::sampleFormatName(fmt.sampleFormat()));
+    }
+    if (!haveFormat) {
+        qCWarning(lcAudio) << "QuindarLocalSink: device supports no Float stereo rate"
+                           << dev.description();
+        AudioSummaryLogger::OpenFailureSummary failure;
+        failure.path = QStringLiteral("Quindar local sink");
+        failure.backend = QStringLiteral("QAudioSink");
+        failure.deviceDescription = dev.description();
+        failure.attemptedFormats = attemptedFormats.join(QStringLiteral("; "));
+        failure.failureReason = QStringLiteral("no Float stereo rung supported in the negotiation ladder");
+        failure.fallbackReason = fallbackReasons.join(QStringLiteral("; "));
+        AudioSummaryLogger::logOpenFailure(failure);
+        return false;
     }
     m_actualRate = fmt.sampleRate();
 


### PR DESCRIPTION
> **Stacks on #3630** (AudioOutputRouter). The first commit here is #3630's; the new commit is the Quindar migration. (The #3556 recorder fix that was previously bundled here has been split out to its own PR.)

## Phase 6, first sink — QuindarLocalSink → AudioDeviceNegotiator (#3306)

`QuindarLocalSink` previously tried only **48 kHz Float then the device preferredFormat** — no 44.1 kHz rung and no graceful fallback — so it failed outright on a 44.1k-only output. It was the worst offender in #3306 (effectively no ladder).

It now walks the shared `AudioDeviceNegotiator`'s **Float** rungs (the tone is generated in Float, so Int16 rungs are skipped, mirroring the RX-speaker migration), gaining the per-OS preferred rate plus the 44.1 kHz and preferredFormat fallbacks in one place. RegenerateAtRate (the generator retunes — no resampler); the "every transmitted Quindar sample also plays locally" contract is unchanged. Diagnostics/summary logging preserved.

### Phase 6 scope
Quindar was the high-value sink (it had an actual no-fallback bug). The other three aux sinks are deferred with reasons: CW sidetone's QAudio path is only the *fallback* backend (PortAudio is primary and can't use the Qt negotiator) and is started at a constant 48 kHz; `ClientPuduMonitor` + `QsoRecorder` playback are **Int16-native** and already robust, so migrating them cleanly wants a small negotiator *format-preference (Int16-first)* enabler — its own follow-up.

## Test / build
All three audio tests green under CTest (negotiation 25/25, device wrapper 8/8, router 9/9). Full macOS app builds & links clean (RelWithDebInfo).

Refs #3306

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat