### PR TITLE
fix(audio): capture TX in Client-Side QsoRecorder recordings (#3556)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -4646,6 +4646,11 @@ void AudioEngine::onTxAudioReady()
     if (auto* mon = m_txFinalMonitor.load(std::memory_order_acquire)) {
         mon->feedTxPostDsp(data);
     }
+    // Expose the same post-limiter int16 stream as a signal so the QSO recorder
+    // can capture TX for Client-Side recording (#3556). Emitted unconditionally
+    // (independent of whether the PUDU monitor is attached); the recorder slot
+    // fast-returns when not recording / not transmitting, so this is cheap.
+    emit txFinalMonitorPcmReady(data);
 
     // ── TX post-final-limiter scope tap ─────────────────────────
     // Sampled here, AFTER everything the strip can do to the audio

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -495,6 +495,12 @@ signals:
     void bnrConnectionChanged(bool connected);
     void dfnrEnabledChanged(bool on);
     void txRawPcmReady(const QByteArray& pcm);  // raw 24kHz stereo int16 PCM for RADEEngine
+    // Post-final-limiter TX monitor PCM (24 kHz stereo int16) — the exact stream
+    // packetised to the radio. Fires for all phone/SSB TX (unlike txRawPcmReady,
+    // which is RADE-only), so it is the source for Client-Side TX recording:
+    // connect to QsoRecorder::feedTxAudio (#3556). Emitted from the audio thread;
+    // receivers connect via Qt::AutoConnection (queued across threads).
+    void txFinalMonitorPcmReady(const QByteArray& int16Stereo);
     void txPacketReady(const QByteArray& vitaPacket);  // VITA-49 TX packet for PanadapterStream
     // Sidetone-tapped audio for the TX-side CW decoder (#2417).  Emitted
     // from the audio thread; receivers should connect via Qt::AutoConnection

--- a/src/core/QsoRecorder.cpp
+++ b/src/core/QsoRecorder.cpp
@@ -125,25 +125,35 @@ static QByteArray float32ToInt16(const QByteArray& pcm)
 void QsoRecorder::feedRxAudio(const QByteArray& pcm)
 {
     std::lock_guard<std::mutex> lock(m_writeMutex);
-    if (!m_recording || !m_file) return;
+    // While transmitting the radio mutes RX (this stream would be silence), and
+    // the TX monitor is recorded instead — skip RX so the two don't double-write
+    // and the file stays a clean time-interleaved RX/TX stream (#3556).
+    if (!m_recording || !m_file || m_transmitting.load(std::memory_order_acquire)) return;
     QByteArray converted = float32ToInt16(pcm);
     m_file->write(converted);
     m_dataBytes += static_cast<quint32>(converted.size());
 }
 
-void QsoRecorder::feedTxAudio(const QByteArray& pcm)
+void QsoRecorder::feedTxAudio(const QByteArray& int16Stereo)
 {
     std::lock_guard<std::mutex> lock(m_writeMutex);
-    if (!m_recording || !m_file) return;
-    QByteArray converted = float32ToInt16(pcm);
-    m_file->write(converted);
-    m_dataBytes += static_cast<quint32>(converted.size());
+    // Only capture the TX monitor while actually transmitting (the tap can fire
+    // whenever mic capture runs), so RX and TX never both write.
+    if (!m_recording || !m_file || !m_transmitting.load(std::memory_order_acquire)) return;
+    // The post-limiter TX monitor is already 24 kHz stereo int16 — the WAV's
+    // native format — so write it directly, no float32 conversion (#3556).
+    m_file->write(int16Stereo);
+    m_dataBytes += static_cast<quint32>(int16Stereo.size());
 }
 
 // ── TX state tracking ───────────────────────────────────────────────────────
 
 void QsoRecorder::onMoxChanged(bool mox)
 {
+    // Gate RX vs TX writes (#3556). Set before any early-return so the feed
+    // slots see the correct state immediately on the TX/RX edge.
+    m_transmitting.store(mox, std::memory_order_release);
+
     // Only auto-record when in client-side recording mode
     bool clientSide = AppSettings::instance().value("RecordingMode", "Radio").toString() == "Client";
     if (mox) {

--- a/src/core/QsoRecorder.h
+++ b/src/core/QsoRecorder.h
@@ -9,6 +9,7 @@
 #include <QObject>
 #include <QString>
 #include <QTimer>
+#include <atomic>
 #include <mutex>
 
 class QAudioSink;
@@ -21,10 +22,17 @@ class TransmitModel;
 // Records QSO audio (both RX and TX sides) to WAV files.
 //
 // Usage:
-//   - Connect feedRxAudio() to AudioEngine::feedAudioData() (or post-DSP tap)
-//   - Connect feedTxAudio() to AudioEngine::txRawPcmReady()
+//   - Connect feedRxAudio() (float32 RX) to PanadapterStream::audioDataReady
+//   - Connect feedTxAudio() (int16 post-limiter TX monitor) to
+//     AudioEngine::txFinalMonitorPcmReady — the source that carries SSB/phone TX
+//     (txRawPcmReady is RADE-only and would leave SSB recordings silent, #3556)
 //   - Connect onMoxChanged() to TransmitModel::moxChanged()
 //   - Set the active slice for frequency/mode metadata via setSlice()
+//
+// While transmitting, the radio mutes the RX stream, so feedRxAudio() would
+// otherwise write full-length silence. Writes are MOX-gated: RX is written only
+// while receiving, the TX monitor only while transmitting, producing a single
+// time-interleaved RX/TX file that matches Radio-Side recording (#3556).
 //
 // Recording triggers:
 //   - Auto: starts when MOX goes true (first TX), stops after idle timeout
@@ -114,6 +122,7 @@ private:
 
     // Recording state
     bool        m_recording{false};
+    std::atomic<bool> m_transmitting{false};  // MOX state; gates RX vs TX writes (#3556)
     QFile*      m_file{nullptr};
     QDateTime   m_startTime;
     quint32     m_dataBytes{0};    // PCM data bytes written (for WAV header patching)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1235,11 +1235,16 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_radioModel.panStream(), &PanadapterStream::audioDataReady,
             m_audio, &AudioEngine::feedAudioData);
 
-    // ── QSO recorder: tap RX audio, trigger on MOX (#1297) ────────────
-    // Only RX audio is recorded — TX audio (txRawPcmReady) is int16 and
-    // would need separate handling to avoid format mismatch.
+    // ── QSO recorder: tap RX audio + TX monitor, trigger on MOX (#1297) ────
+    // RX (float32) comes from the panadapter stream; TX (int16 post-limiter
+    // monitor) from AudioEngine::txFinalMonitorPcmReady — the source that
+    // carries SSB/phone TX. Without the TX tap, Client-Side recordings were
+    // full-length silence during transmit (#3556). The recorder MOX-gates the
+    // two so the file is a single time-interleaved RX/TX stream.
     connect(m_radioModel.panStream(), &PanadapterStream::audioDataReady,
             m_qsoRecorder, &QsoRecorder::feedRxAudio);
+    connect(m_audio, &AudioEngine::txFinalMonitorPcmReady,
+            m_qsoRecorder, &QsoRecorder::feedTxAudio);
     connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
             m_qsoRecorder, &QsoRecorder::onMoxChanged);
 


### PR DESCRIPTION
Fixes #3556. Based directly on `main` (independent of the audio-sink-factory work).

## Bug

With record mode set to **Client Side**, the WAV is full-length but **silent during any SSB/phone transmit** (reporter measured −91 dB — pure int16 noise floor — across the whole file). Radio-Side recording of the same QSO works.

## Root cause (per the reporter's investigation, confirmed)

- **Nothing is ever connected to `QsoRecorder::feedTxAudio`** — the slot is never called.
- The only wired source is RX: `PanadapterStream::audioDataReady → feedRxAudio`. During TX the radio **mutes** the RX stream, so `feedRxAudio` writes full-length silence while the operator's TX audio is never captured.
- The RADE-only `txRawPcmReady` tap doesn't fire for SSB, so wiring that alone wouldn't fix phone TX.

## Fix

Route the **post-final-limiter TX monitor** — the exact int16 stream packetised to the radio, already used by the Aetherial strip's record button — into the recorder:

- **New signal** `AudioEngine::txFinalMonitorPcmReady(int16 stereo)`, emitted at the post-limiter monitor tap (independent of whether the PUDU monitor is attached, so recording works regardless).
- **`MainWindow`** connects it to `QsoRecorder::feedTxAudio`.
- **`QsoRecorder` MOX-gates** its two feeds (atomic, set in `onMoxChanged`): RX is written only while receiving, the TX monitor only while transmitting, so they never double-write and the WAV is a single **time-interleaved RX/TX** stream that matches Radio-Side behaviour (what the reporter expected). `feedTxAudio` writes the int16 monitor **directly** — it's already the WAV's native 24 kHz stereo int16 format, no float round-trip.
- Corrects the stale `MainWindow` comment that claimed `txRawPcmReady` is int16, and the `QsoRecorder` usage docs.

## Test / soak

- Full macOS app builds & links clean (RelWithDebInfo) directly on `main`.
- **Needs a real-radio soak** (the defect is integration-level): set Client-Side, record across RX → SSB TX → RX, and confirm the WAV carries TX audio (not −91 dB silence) with RX/TX time-correct. Deployed to my macOS test box.

Closes #3556

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat