### PR TITLE
ci(windows): build and bundle qtkeychain for SmartLink credential persistence. Principle XI.

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -82,6 +82,17 @@ jobs:
         if: steps.cache-deepfilter.outputs.cache-hit != 'true'
         run: .\scripts\setup\setup-deepfilter.ps1
 
+      - name: Cache qtkeychain
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        id: cache-qtkeychain
+        with:
+          path: third_party/qtkeychain
+          key: qtkeychain-${{ runner.os }}-${{ hashFiles('scripts/setup/setup-qtkeychain.ps1') }}
+
+      - name: Setup qtkeychain (SmartLink credential persistence)
+        if: steps.cache-qtkeychain.outputs.cache-hit != 'true'
+        run: .\scripts\setup\setup-qtkeychain.ps1
+
       - name: Configure
         run: |
           cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DMQTT_TLS=OFF -DCMAKE_TOOLCHAIN_FILE="$env:CMAKE_TOOLCHAIN_FILE" -DVCPKG_TARGET_TRIPLET="$env:VCPKG_TARGET_TRIPLET"
@@ -99,6 +110,12 @@ jobs:
         run: |
           mkdir deploy
           copy build\AetherSDR.exe deploy\
+          # windeployqt treats any Qt6* DLL as an official Qt module and looks for
+          # it in the Qt bin directory to scan its transitive dependencies. Copy
+          # qt6keychain.dll there before invoking windeployqt so it can resolve it.
+          if (Test-Path "third_party\qtkeychain\bin\qt6keychain.dll") {
+            copy third_party\qtkeychain\bin\qt6keychain.dll "$env:QT_ROOT_DIR\bin\"
+          }
           windeployqt deploy\AetherSDR.exe --release --no-translations --no-system-d3d-compiler
           if (Test-Path "third_party\fftw3\bin\libfftw3-3.dll") {
             copy third_party\fftw3\bin\libfftw3-3.dll deploy\
@@ -119,6 +136,9 @@ jobs:
           # NOTE: MQTT TLS is disabled (-DMQTT_TLS=OFF) so no OpenSSL DLLs
           # are needed. This avoids the "libssl-3-x64.dll not found" crash
           # on systems without OpenSSL installed (#1341, #1362).
+          if (Test-Path "third_party\qtkeychain\bin\qt6keychain.dll") {
+            copy third_party\qtkeychain\bin\qt6keychain.dll deploy\
+          }
           if ($false) {
           }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,12 @@ if(UNIX AND NOT APPLE)
         message(STATUS "Qt6::DBus not found — sleep inhibition disabled on Linux")
     endif()
 endif()
+# On Windows, qtkeychain is built from source by scripts/setup/setup-qtkeychain.ps1
+# and staged to third_party/qtkeychain. Prepend it so find_package resolves there
+# before falling back to any system install.
+if(WIN32)
+    list(PREPEND CMAKE_PREFIX_PATH "${CMAKE_SOURCE_DIR}/third_party/qtkeychain")
+endif()
 find_package(Qt6Keychain QUIET)
 if(Qt6Keychain_FOUND)
     message(STATUS "Qt6Keychain found — SmartLink credential persistence enabled")

--- a/scripts/setup/setup-qtkeychain.ps1
+++ b/scripts/setup/setup-qtkeychain.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+    Download and build qtkeychain for Windows x64.
+
+.DESCRIPTION
+    Downloads qtkeychain 0.16.0 source from GitHub, builds it with CMake + MSVC
+    against the Qt6 installation pointed to by QT_ROOT_DIR (set by install-qt-action
+    in CI, or by a local Qt installation), and installs it into third_party/qtkeychain/
+    ready for CMake find_package(Qt6Keychain).
+
+    Required for SmartLink credential persistence (saves the Auth0 refresh token
+    in the Windows Credential Manager so users are not prompted on every launch).
+
+.EXAMPLE
+    .\setup-qtkeychain.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+
+$QtKeychainVersion = "0.16.0"
+$QtKeychainUrl     = "https://github.com/frankosterfeld/qtkeychain/archive/refs/tags/${QtKeychainVersion}.tar.gz"
+$OutDir            = "$PSScriptRoot\..\..\third_party\qtkeychain"
+$TarFile           = "$PSScriptRoot\..\..\third_party\qtkeychain-${QtKeychainVersion}.tar.gz"
+
+# Normalize to absolute paths
+$OutDir  = [System.IO.Path]::GetFullPath($OutDir)
+$TarFile = [System.IO.Path]::GetFullPath($TarFile)
+
+# ── Check if already set up ──────────────────────────────────────────────
+if (Test-Path "$OutDir\lib\cmake\Qt6Keychain\Qt6KeychainConfig.cmake") {
+    Write-Host "qtkeychain already set up in $OutDir" -ForegroundColor Green
+    exit 0
+}
+
+# ── Locate Qt ────────────────────────────────────────────────────────────
+# install-qt-action sets QT_ROOT_DIR; fall back to Qt6_DIR three levels up.
+$QtPrefix = $env:QT_ROOT_DIR
+if (-not $QtPrefix -and $env:Qt6_DIR) {
+    $QtPrefix = [System.IO.Path]::GetFullPath((Join-Path $env:Qt6_DIR "../../.."))
+}
+if (-not $QtPrefix) {
+    Write-Error "Qt not found. Set QT_ROOT_DIR or Qt6_DIR before running this script."
+    exit 1
+}
+Write-Host "Using Qt from: $QtPrefix" -ForegroundColor Cyan
+
+# ── Create staging directory ─────────────────────────────────────────────
+New-Item -ItemType Directory -Force -Path ([System.IO.Path]::GetFullPath("$OutDir\..\")) | Out-Null
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+# ── Download source ──────────────────────────────────────────────────────
+if (-not (Test-Path $TarFile)) {
+    Write-Host "Downloading qtkeychain ${QtKeychainVersion} source..." -ForegroundColor Cyan
+    Invoke-WebRequest -Uri $QtKeychainUrl -OutFile $TarFile
+}
+
+# ── Extract ──────────────────────────────────────────────────────────────
+Write-Host "Extracting..." -ForegroundColor Cyan
+$TempDir = [System.IO.Path]::GetFullPath("$OutDir\..\qtkeychain-temp")
+if (Test-Path $TempDir) { Remove-Item -Recurse -Force $TempDir }
+New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
+tar -xzf $TarFile -C $TempDir
+if ($LASTEXITCODE -ne 0) { Write-Error "tar extraction failed with exit code $LASTEXITCODE"; exit 1 }
+
+$SrcDir = Get-ChildItem "$TempDir\qtkeychain-*" -Directory | Select-Object -First 1
+if (-not $SrcDir) {
+    Write-Error "Failed to locate extracted qtkeychain source directory in $TempDir"
+    exit 1
+}
+
+# ── Build with CMake + MSVC ──────────────────────────────────────────────
+Write-Host "Building qtkeychain ${QtKeychainVersion} from source..." -ForegroundColor Cyan
+
+$BuildDir = Join-Path $SrcDir.FullName "build"
+cmake -B $BuildDir -S $SrcDir.FullName -G "Ninja" `
+    -DCMAKE_BUILD_TYPE=Release `
+    -DBUILD_WITH_QT6=ON `
+    -DBUILD_SHARED_LIBS=ON `
+    -DBUILD_TRANSLATIONS=OFF `
+    "-DCMAKE_PREFIX_PATH=$QtPrefix" `
+    "-DCMAKE_INSTALL_PREFIX=$OutDir"
+
+if ($LASTEXITCODE -ne 0) { Write-Error "CMake configure failed"; exit 1 }
+
+cmake --build $BuildDir --config Release -j $env:NUMBER_OF_PROCESSORS
+if ($LASTEXITCODE -ne 0) { Write-Error "CMake build failed"; exit 1 }
+
+# ── Install to staging directory ─────────────────────────────────────────
+# cmake --install places headers, lib, DLL, and cmake config files in the
+# correct layout so find_package(Qt6Keychain) resolves against $OutDir.
+cmake --install $BuildDir
+if ($LASTEXITCODE -ne 0) { Write-Error "CMake install failed"; exit 1 }
+
+# ── Cleanup ──────────────────────────────────────────────────────────────
+Remove-Item -Recurse -Force $TempDir
+Remove-Item -Force $TarFile
+
+Write-Host "qtkeychain ready in $OutDir" -ForegroundColor Green
+Write-Host "  cmake config: $OutDir\lib\cmake\Qt6Keychain\Qt6KeychainConfig.cmake"
+if (Test-Path "$OutDir\bin\qt6keychain.dll") {
+    Write-Host "  DLL:          $OutDir\bin\qt6keychain.dll"
+}


### PR DESCRIPTION
**Closes #3600**

## Problem

SmartLink credential persistence — saving the Auth0 refresh token to the OS credential store so users aren't prompted for their password on every launch — is fully implemented in application code behind `#ifdef HAVE_KEYCHAIN`. `HAVE_KEYCHAIN` is defined only when CMake finds `Qt6Keychain` at configure time.

On Windows CI, `find_package(Qt6Keychain QUIET)` has always returned not-found: nothing in the Windows build pipeline installs or builds qtkeychain. The feature silently compiled out of every Windows release artifact (installer, portable ZIP, MSIX), making credential persistence a no-op for all Windows users.

macOS Apple Silicon already has it via `brew install qtkeychain`. Linux AppImage and macOS Intel are a separate gap tracked in a follow-on issue.

## Root cause

```yaml
# windows-installer.yml — before this PR
modules: 'qtmultimedia qtserialport qtwebsockets qtshadertools'
# qtkeychain: not installed, not built
```

`find_package(Qt6Keychain QUIET)` fails silently → `HAVE_KEYCHAIN` undefined → `saveCredentials()` and `tryAutoLogin()` in `SmartLinkClient.cpp` compile as empty no-ops.

## Implementation

Follows the established pattern used by hidapi, FFTW3, and DeepFilterNet3: a setup script downloads and builds from source, CI caches the result, CMake finds it via a staged `third_party/` directory.

**`scripts/setup/setup-qtkeychain.ps1`** (new)
- Downloads qtkeychain 0.16.0 from GitHub and builds with CMake + Ninja + MSVC against the Qt installation at `QT_ROOT_DIR` (set by `install-qt-action`) so the qtkeychain ABI matches the application's Qt exactly
- Passes `-DBUILD_TRANSLATIONS=OFF` to avoid a `Qt6LinguistTools` dependency on unused locale files
- Uses `cmake --install` to stage the full package layout — headers, import lib, DLL, and cmake config files — to `third_party/qtkeychain/`; the cmake config files are what `find_package(Qt6Keychain)` actually resolves against

**`CMakeLists.txt`**
- On `WIN32`, prepends `${CMAKE_SOURCE_DIR}/third_party/qtkeychain` to `CMAKE_PREFIX_PATH` immediately before the existing `find_package(Qt6Keychain QUIET)` call
- Linux and macOS untouched — they continue to find the system or brew package

**`.github/workflows/windows-installer.yml`**
- Cache step for `third_party/qtkeychain`, keyed on the script hash (invalidates on version bump)
- Setup step placed after Install Qt6 and before Configure
- `qt6keychain.dll` pre-staged to the Qt bin directory before `windeployqt` runs — `windeployqt` treats any `Qt6*` DLL as an official Qt module and looks for it in the Qt installation to scan transitive dependencies; without this it aborts with exit code 1
- `qt6keychain.dll` copy in the deploy block covers all three artifacts (portable ZIP, Inno installer, MSIX)

## No application code changes

The credential save/load paths in `SmartLinkClient.cpp` are already correct and already work on macOS Apple Silicon. This PR only makes the Windows build pipeline supply the dependency those paths require.

## Testing

Validated end-to-end via `workflow_dispatch` on `NF0T/AetherSDR` ([run 27658397042](https://github.com/NF0T/AetherSDR/actions/runs/27658397042)):
- `Setup qtkeychain` step completed — qtkeychain 0.16.0 built against Qt 6.8.3 MSVC 2022
- CMake configure output: `Qt6Keychain found — SmartLink credential persistence enabled`
- Full build succeeded with `HAVE_KEYCHAIN` defined
- Deploy step completed — `qt6keychain.dll` present in artifact

Principle XI (Fixes Are Demonstrated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)