### PR TITLE
fix(cwx): run local sidetone keyer on a steady_clock worker thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2052,6 +2052,9 @@ add_executable(cwx_local_keyer_drift_test
 )
 target_include_directories(cwx_local_keyer_drift_test PRIVATE src)
 target_link_libraries(cwx_local_keyer_drift_test PRIVATE Qt6::Core)
+if(UNIX)
+    target_link_libraries(cwx_local_keyer_drift_test PRIVATE pthread)
+endif()
 add_test(NAME cwx_local_keyer_drift_test COMMAND cwx_local_keyer_drift_test)
 
 add_executable(ax25_frame_formatter_test

--- a/src/core/CwxLocalKeyer.cpp
+++ b/src/core/CwxLocalKeyer.cpp
@@ -34,31 +34,61 @@ const QHash<QChar, QString>& morseTable()
 
 } // namespace
 
-CwxLocalKeyer::CwxLocalKeyer(QObject* parent) : QObject(parent)
+CwxLocalKeyer::CwxLocalKeyer() : CwxLocalKeyer(true) {}
+
+CwxLocalKeyer::CwxLocalKeyer(bool spawnWorker) : m_spawnWorker(spawnWorker) {}
+
+CwxLocalKeyer::~CwxLocalKeyer()
 {
-    m_timer.setSingleShot(true);
-    m_timer.setTimerType(Qt::PreciseTimer);
-    QObject::connect(&m_timer, &QTimer::timeout, this, &CwxLocalKeyer::onTick);
+    m_shutdown.store(true, std::memory_order_release);
+    m_abort.store(true, std::memory_order_release);
+    m_cv.notify_all();
+    if (m_thread.joinable())
+        m_thread.join();
+    keyUpIfDown();
+}
+
+void CwxLocalKeyer::setOnKeyDownChange(KeyDownCallback cb)
+{
+    m_onKeyDownChange = std::move(cb);
 }
 
 void CwxLocalKeyer::start(const QString& text, int wpm)
 {
     if (text.isEmpty() || wpm <= 0) return;
-    m_queue.enqueue({text, wpm});
-    if (!m_running)
+    {
+        std::lock_guard<std::mutex> lk(m_mu);
+        m_queue.enqueue({text, wpm});
+    }
+    if (m_spawnWorker) {
+        // Spawn the worker lazily on first use, then keep it alive for the
+        // session (it parks on the condition_variable between sends).
+        if (!m_workerStarted.exchange(true, std::memory_order_acq_rel))
+            m_thread = std::thread(&CwxLocalKeyer::workerLoop, this);
+        m_cv.notify_all();
+    } else if (!m_running) {
+        // Synchronous test path: emit the first edge now; the test ticks the
+        // rest via onTick().
         scheduleNext();
+    }
 }
 
 void CwxLocalKeyer::stop()
 {
-    m_timer.stop();
-    m_queue.clear();
-    m_elements.clear();
-    m_running = false;
-    resetElapsed();
-    if (m_currentlyDown) {
-        m_currentlyDown = false;
-        emit keyStateChanged(false);
+    {
+        std::lock_guard<std::mutex> lk(m_mu);
+        m_queue.clear();
+    }
+    m_abort.store(true, std::memory_order_release);
+    if (m_spawnWorker) {
+        m_cv.notify_all();
+    } else {
+        // Synchronous test path: abort immediately.
+        keyUpIfDown();
+        m_elements.clear();
+        m_running = false;
+        resetEpoch();
+        m_abort.store(false, std::memory_order_release);
     }
 }
 
@@ -101,13 +131,19 @@ void CwxLocalKeyer::encode(const QString& text, int wpm)
 void CwxLocalKeyer::scheduleNext()
 {
     if (m_elements.isEmpty()) {
-        if (m_queue.isEmpty()) {
-            m_running = false;
-            resetElapsed();
-            if (m_currentlyDown) {
-                m_currentlyDown = false;
-                emit keyStateChanged(false);
+        Pending p;
+        bool havePending = false;
+        {
+            std::lock_guard<std::mutex> lk(m_mu);
+            if (!m_queue.isEmpty()) {
+                p = m_queue.dequeue();
+                havePending = true;
             }
+        }
+        if (!havePending) {
+            m_running = false;
+            resetEpoch();
+            keyUpIfDown();
             return;
         }
         // In live mode each keystroke arrives as a separate Pending entry.
@@ -116,10 +152,8 @@ void CwxLocalKeyer::scheduleNext()
         // encoded character is always Dit or Dah, leaving m_currentlyDown=true
         // here; without an explicit gap the key stays down continuously and
         // adjacent characters merge into undecodable noise (#2473).
-        if (m_currentlyDown) {
+        if (m_currentlyDown)
             m_elements.enqueue(Element::CharGap);
-        }
-        const Pending p = m_queue.dequeue();
         encode(p.text, p.wpm);
         if (m_elements.isEmpty()) {
             scheduleNext();
@@ -140,17 +174,14 @@ void CwxLocalKeyer::scheduleNext()
     }
     if (keyDownNext != m_currentlyDown) {
         m_currentlyDown = keyDownNext;
-        emit keyStateChanged(keyDownNext);
+        emitKeyDown(keyDownNext);
     }
-    // Drift-correct against an absolute clock: the next edge should land
-    // at m_nextEdgeMs from the start of the run, not durationMs from now.
-    // Without this, GUI-thread event-loop coalescing on macOS (panadapter
-    // paint, VITA-49 burst handling) pushes each successive edge later
-    // and the slip accumulates — audible as stuttering and structurally
-    // wrong letter/word spacing on long contest macros (#2980).
-    if (!m_elapsed.isValid()) {
-        startElapsed();
-    }
+    // Drift-correct against an absolute clock: the next edge should land at
+    // m_nextEdgeMs from the start of the run, not durationMs from now, so a
+    // late wake is followed by a correspondingly shorter wait and the slip
+    // does not accumulate (#2980/#3202).
+    if (!m_epochValid)
+        startEpoch();
     m_nextEdgeMs += durationMs;
     const qint64 wait = qMax<qint64>(1, m_nextEdgeMs - elapsedMs());
     armTimer(static_cast<int>(wait));
@@ -163,24 +194,92 @@ void CwxLocalKeyer::onTick()
 
 qint64 CwxLocalKeyer::elapsedMs() const
 {
-    return m_elapsed.isValid() ? m_elapsed.elapsed() : 0;
+    if (!m_epochValid) return 0;
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - m_epoch)
+        .count();
 }
 
 void CwxLocalKeyer::armTimer(int waitMs)
 {
-    m_timer.start(waitMs);
+    // Production: the worker thread sleeps to the absolute steady_clock
+    // deadline (m_epoch + m_nextEdgeMs); this records the equivalent relative
+    // wait for diagnostics and for the drift-correction unit test, which
+    // overrides this seam.
+    m_nextWaitMs = waitMs;
 }
 
-void CwxLocalKeyer::resetElapsed()
+void CwxLocalKeyer::resetEpoch()
 {
-    m_elapsed.invalidate();
+    m_epochValid = false;
     m_nextEdgeMs = 0;
 }
 
-void CwxLocalKeyer::startElapsed()
+void CwxLocalKeyer::startEpoch()
 {
-    m_elapsed.start();
+    m_epoch = std::chrono::steady_clock::now();
+    m_epochValid = true;
     m_nextEdgeMs = 0;
+}
+
+void CwxLocalKeyer::emitKeyDown(bool down)
+{
+    if (down == m_lastEmittedKeyDown) return;
+    m_lastEmittedKeyDown = down;
+    if (m_onKeyDownChange) m_onKeyDownChange(down);
+}
+
+void CwxLocalKeyer::keyUpIfDown()
+{
+    m_currentlyDown = false;
+    emitKeyDown(false);
+}
+
+void CwxLocalKeyer::workerLoop()
+{
+    for (;;) {
+        // ── Idle wait — park until there is text to send (or shutdown) ──
+        {
+            std::unique_lock<std::mutex> lk(m_mu);
+            m_cv.wait(lk, [this] {
+                return m_shutdown.load(std::memory_order_acquire)
+                    || !m_queue.isEmpty();
+            });
+            if (m_shutdown.load(std::memory_order_acquire))
+                break;
+        }
+        // Fresh send run — clear any stale abort latched while idle.
+        m_abort.store(false, std::memory_order_release);
+
+        for (;;) {
+            scheduleNext();          // advance one edge; pulls m_queue, emits gate
+            if (!m_running)
+                break;               // fully drained → back to idle wait
+
+            // Interruptible sleep to the element's absolute steady_clock
+            // deadline.  No QTimer / event loop, so panadapter paint and
+            // VITA-49 bursts can't coalesce the edge (#3623).
+            const auto deadline = m_epoch + std::chrono::milliseconds(m_nextEdgeMs);
+            {
+                std::unique_lock<std::mutex> lk(m_mu);
+                m_cv.wait_until(lk, deadline, [this] {
+                    return m_abort.load(std::memory_order_acquire)
+                        || m_shutdown.load(std::memory_order_acquire);
+                });
+            }
+            if (m_abort.load(std::memory_order_acquire)
+                || m_shutdown.load(std::memory_order_acquire)) {
+                keyUpIfDown();
+                m_elements.clear();
+                resetEpoch();
+                m_running = false;
+                break;
+            }
+        }
+        if (m_shutdown.load(std::memory_order_acquire))
+            break;
+    }
+    keyUpIfDown();
 }
 
 } // namespace AetherSDR

--- a/src/core/CwxLocalKeyer.h
+++ b/src/core/CwxLocalKeyer.h
@@ -1,51 +1,78 @@
 #pragma once
 
-#include <QElapsedTimer>
-#include <QObject>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+
 #include <QQueue>
 #include <QString>
-#include <QTimer>
+#include <QtGlobal>
 
 namespace AetherSDR {
 
 // Local Morse keyer — generates dit/dah timing events from CWX text so the
 // AetherSDR sidetone path can play a tone matching what the radio is
 // transmitting.  Independent of the radio's own keyer; both use the same
-// configured WPM, so they stay in sync within ±1 element on typical
-// hardware.  If they drift, sidetone is informational only — the radio
-// produces the actual on-air CW.
+// configured WPM, so they stay in sync within ±1 element on typical hardware.
+// If they drift, sidetone is informational only — the radio produces the
+// actual on-air CW.
 //
-// Usage: enqueue text with start(); the keyer schedules QTimer firings
-// for each element transition (dit-on / dit-off / dah-on / dah-off /
-// inter-element / inter-character / word gaps) and emits keyStateChanged
-// for each on→off or off→on transition.
-class CwxLocalKeyer : public QObject {
-    Q_OBJECT
+// Threading
+// ─────────
+// The element schedule runs on a dedicated worker thread.  Each edge is timed
+// to an absolute std::chrono::steady_clock deadline (drift-corrected against
+// the run epoch) waited on an interruptible condition_variable — NOT a QTimer.
+// QTimer fires on whichever event loop owns it, and under panadapter paint +
+// VITA-49 burst handling that loop coalesces the firing, landing the edge a
+// block or two late and clipping individual CW elements (#3623).  IambicKeyer
+// abandoned QTimer for exactly this reason ("QTimer's jitter is too high for
+// CW"); this keyer now mirrors that pattern.
+//
+// Output
+// ──────
+// onKeyDownChange(bool down) flips the sidetone gate.  It is called directly
+// from the worker thread, so the receiver MUST be lock-free (e.g.
+// CwSidetoneGenerator::setKeyDown, which is std::atomic).
+class CwxLocalKeyer {
 public:
-    explicit CwxLocalKeyer(QObject* parent = nullptr);
+    using KeyDownCallback = std::function<void(bool down)>;
 
-    // Append a transmission segment.  If the keyer is idle this kicks off
-    // playback; if it's mid-transmission the new text is queued and plays
-    // when the current segment finishes.
+    CwxLocalKeyer();
+    ~CwxLocalKeyer();
+
+    CwxLocalKeyer(const CwxLocalKeyer&) = delete;
+    CwxLocalKeyer& operator=(const CwxLocalKeyer&) = delete;
+
+    // Install before start().  Called on the worker thread — the receiver must
+    // be lock-free.
+    void setOnKeyDownChange(KeyDownCallback cb);
+
+    // Append a transmission segment.  Spawns the worker thread on first use; if
+    // a segment is already playing, the new text is queued and plays when the
+    // current one finishes.
     void start(const QString& text, int wpm);
 
     // Cancel any pending text and key-up immediately.  Used by
-    // CwxModel::clearBuffer / erase so the operator's "stop sending" maps
-    // to instant silence locally.
+    // CwxModel::clearBuffer / erase so the operator's "stop sending" maps to
+    // instant local silence.  The worker stays alive for the next send.
     void stop();
 
     bool isIdle() const { return m_elements.isEmpty() && !m_running; }
 
-signals:
-    void keyStateChanged(bool down);
-
 protected:
-    // Test seams for deterministic drift-correction coverage.
+    // Test seam: a subclass constructed with spawnWorker=false drives the
+    // schedule synchronously (no real thread) by calling onTick() itself and
+    // injecting elapsedMs(), so the #3271 drift-correction coverage stays
+    // deterministic.
+    explicit CwxLocalKeyer(bool spawnWorker);
     void onTick();
-    virtual qint64 elapsedMs() const;
-    virtual void armTimer(int waitMs);
+    virtual qint64 elapsedMs() const;       // ms since the run epoch
+    virtual void armTimer(int waitMs);       // record the next (drift-corrected) wait
     qint64 nextEdgeMsForTest() const { return m_nextEdgeMs; }
-    bool elapsedValidForTest() const { return m_elapsed.isValid(); }
+    bool elapsedValidForTest() const { return m_epochValid; }
 
 private:
     enum class Element : char { Dit, Dah, ElementGap, CharGap, WordGap };
@@ -54,22 +81,39 @@ private:
 
     void encode(const QString& text, int wpm);
     void scheduleNext();
-    void resetElapsed();
-    void startElapsed();
+    void resetEpoch();
+    void startEpoch();
+    void emitKeyDown(bool down);
+    void keyUpIfDown();
+    void workerLoop();
 
-    QTimer        m_timer;
-    QQueue<Pending> m_queue;
+    // Schedule state — touched only by the thread that runs scheduleNext()
+    // (the worker in production, or the test thread when spawnWorker=false).
     QQueue<Element> m_elements;
     int           m_unitMs{60};   // 60 ms = 20 WPM
     bool          m_running{false};
     bool          m_currentlyDown{false};
-    // Drift-corrected scheduling: absolute target edge time vs an elapsed
-    // reference, so a late tick is followed by a correspondingly shorter
-    // wait. Without this, every event-loop coalescing event on the GUI
-    // thread (panadapter paint, VITA-49 burst) pushes the next edge later
-    // and accumulates audible stutter / wrong word spacing on macOS (#2980).
-    QElapsedTimer m_elapsed;
+    // Drift-corrected scheduling: an absolute target edge time vs an elapsed
+    // reference, so a late wake is followed by a correspondingly shorter wait.
+    // Without this, scheduler jitter would push each successive edge later and
+    // accumulate audible stutter / wrong word spacing (#2980/#3202).
+    std::chrono::steady_clock::time_point m_epoch{};
+    bool          m_epochValid{false};
     qint64        m_nextEdgeMs{0};
+    int           m_nextWaitMs{0};   // last wait armTimer() recorded
+
+    KeyDownCallback m_onKeyDownChange;
+    bool            m_lastEmittedKeyDown{false};
+
+    // Cross-thread control.  m_queue is guarded by m_mu; the flags are atomic.
+    const bool              m_spawnWorker{true};
+    std::thread             m_thread;
+    mutable std::mutex      m_mu;
+    std::condition_variable m_cv;
+    QQueue<Pending>         m_queue;
+    std::atomic<bool>       m_workerStarted{false};
+    std::atomic<bool>       m_abort{false};
+    std::atomic<bool>       m_shutdown{false};
 };
 
 } // namespace AetherSDR

--- a/src/core/CwxLocalKeyer.h
+++ b/src/core/CwxLocalKeyer.h
@@ -60,6 +60,11 @@ public:
     // instant local silence.  The worker stays alive for the next send.
     void stop();
 
+    // Not thread-safe: reads worker-owned schedule state without a lock, so it
+    // is for the synchronous drift test / diagnostics only and must not be
+    // called from another thread while the worker is running (it would race
+    // scheduleNext()). Route through m_mu if ever promoted to a live
+    // cross-thread query. (#3623 review)
     bool isIdle() const { return m_elements.isEmpty() && !m_running; }
 
 protected:

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1948,6 +1948,11 @@ MainWindow::~MainWindow()
     qApp->removeEventFilter(this);
     preparePanadapterUiForShutdown();
 
+    // Stop the CWX sidetone keyer (its own worker thread) before AudioEngine is
+    // torn down below — its onKeyDownChange callback touches m_audio->cwSidetone()
+    // (#3623). reset() joins the worker, so no key edge can fire afterward.
+    m_cwxLocalKeyer.reset();
+
 #ifdef HAVE_RADE
     if (m_radeSliceId >= 0)
         deactivateRADE();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -908,7 +908,7 @@ private:
     QTimer* m_bsExpiryTimer{nullptr};    // band-stack bookmark auto-expiry, started on connect only (#1471)
     QTimer* m_bsAutoSaveTimer{nullptr};  // band-stack dwell auto-save (single-shot per dwell window)
     QTimer* m_agManualConnectTimer{nullptr}; // deferred AG manual connect — cancelled on disconnect
-    class CwxLocalKeyer* m_cwxLocalKeyer{nullptr};  // local Morse keyer for CWX sidetone
+    std::unique_ptr<class CwxLocalKeyer> m_cwxLocalKeyer;  // local Morse keyer for CWX sidetone (own worker thread)
     std::unique_ptr<class IambicKeyer> m_iambicKeyer;  // local iambic state machine for paddle sidetone
     std::atomic<quint64> m_lastCwPaddleTraceId{0};
     std::atomic<quint64> m_lastCwPaddleSourceMs{0};

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -650,15 +650,24 @@ void MainWindow::wireRadioModel()
         // radio's keyer because both run at the configured WPM.  Drift
         // tolerance is high — we're not transmitting, just providing the
         // operator with audible feedback of what they sent.
-        m_cwxLocalKeyer = new CwxLocalKeyer(this);
-        connect(&m_radioModel.cwxModel(), &CwxModel::transmissionRequested,
-                m_cwxLocalKeyer, &CwxLocalKeyer::start);
-        connect(&m_radioModel.cwxModel(), &CwxModel::transmissionCancelled,
-                m_cwxLocalKeyer, &CwxLocalKeyer::stop);
-        connect(m_cwxLocalKeyer, &CwxLocalKeyer::keyStateChanged,
-                this, [this](bool down) {
+        // The keyer runs its element schedule on its own worker thread, timed
+        // against steady_clock rather than a QTimer, so panadapter paint /
+        // VITA-49 burst pressure on the GUI event loop can't gap CW elements
+        // (#3623) — same reason the iambic keyer below avoids QTimer.
+        m_cwxLocalKeyer = std::make_unique<CwxLocalKeyer>();
+        m_cwxLocalKeyer->setOnKeyDownChange([this](bool down) {
+            // Lock-free atomic gate; safe to call directly from the keyer
+            // thread, matching the iambic keyer's gate path below.
             if (m_audio && m_audio->cwSidetone())
                 m_audio->cwSidetone()->setKeyDown(down);
+        });
+        connect(&m_radioModel.cwxModel(), &CwxModel::transmissionRequested,
+                this, [this](const QString& text, int wpm) {
+            if (m_cwxLocalKeyer) m_cwxLocalKeyer->start(text, wpm);
+        });
+        connect(&m_radioModel.cwxModel(), &CwxModel::transmissionCancelled,
+                this, [this]() {
+            if (m_cwxLocalKeyer) m_cwxLocalKeyer->stop();
         });
 
         // Local iambic keyer — when the radio's iambic mode is on, this

--- a/tests/cwx_local_keyer_drift_test.cpp
+++ b/tests/cwx_local_keyer_drift_test.cpp
@@ -60,6 +60,10 @@ void expectStates(const std::string& name,
 
 class TestKeyer final : public CwxLocalKeyer {
 public:
+    // Drive the schedule synchronously — no real worker thread — so the
+    // drift-correction math stays deterministic under onTick()/setElapsed().
+    TestKeyer() : CwxLocalKeyer(/*spawnWorker=*/false) {}
+
     void setElapsed(qint64 elapsedMs) { m_elapsedMs = elapsedMs; }
     void tick() { onTick(); }
 
@@ -90,10 +94,9 @@ struct Fixture {
 
     Fixture()
     {
-        QObject::connect(&keyer, &CwxLocalKeyer::keyStateChanged,
-                         [this](bool down) {
-                             states.push_back(down ? 1 : 0);
-                         });
+        keyer.setOnKeyDownChange([this](bool down) {
+            states.push_back(down ? 1 : 0);
+        });
     }
 };
 


### PR DESCRIPTION
## Summary
Fixes #3623 — the CWX local sidetone drops/clips individual CW elements under panadapter/VITA-49 load on Windows.

## Root cause
`CwxLocalKeyer` scheduled every element edge with a `QTimer` parented to `MainWindow`, so the timer ran on the GUI event loop and `keyStateChanged` was delivered through a GUI-thread slot. Under panadapter paint + VITA-49 burst handling the loop coalesces both, the key gate lands a block or two late, and an element gets gapped/clipped. #3202's drift-correction fixes *cumulative* slip (the message stays in sync) but not this *per-edge* jitter, and reasons specifically about macOS — this is the residual Windows case.

## Fix
Re-architect `CwxLocalKeyer` to mirror **`IambicKeyer`**, which already abandoned `QTimer` for exactly this reason (*"QTimer's jitter is too high for CW"*):

- Run the element schedule on a dedicated worker thread.
- Time each edge to an absolute `std::chrono::steady_clock` deadline waited on an interruptible `condition_variable` — no QTimer, no event loop.
- Drive the sidetone gate via a lock-free `onKeyDownChange` callback; `CwSidetoneGenerator::setKeyDown` is `std::atomic`, the same gate path the iambic keyer uses.

`encode()` and the drift-correction logic are unchanged, so message timing and the live-mode CharGap behaviour (#2473/#2754) are preserved. `MainWindow` now owns the keyer as a `unique_ptr` and stops it (joining the worker) before `AudioEngine` is torn down, since the gate callback touches `m_audio->cwSidetone()`.

This is the approach recommended in the issue triage.

## Testing
- **`cwx_local_keyer_drift_test` (#3271)** retargeted to the new clock seam (worker-disabled synchronous subclass + callback) — **passes**; all drift-correction assertions (absolute edge targets, slip-shortened waits, sustained-overload clamping, queued-macro epoch continuity, stop/drain resets) still hold, so the scheduling math is unchanged.
- Clean build (Windows MSVC, Qt 6.10.3).
- Ran the app against a synthetic FlexRadio source under a heavy spectrum load and sent long CWX macros: **CW sends cleanly at both 20 and 40 wpm — the element drops/stutter are gone**, including at 40 wpm where the tighter element timing is the more demanding case. Clean startup / connect / shutdown (worker joins without hanging).

## Known residual
Verified clean at **both 20 and 40 wpm** under heavy synthetic load. A single faint, low-level click heard at 20 wpm did not recur and isn't speed-correlated (40 wpm — tighter timing — is completely clean), consistent with an incidental audio under-run under the deliberately brutal synthetic load rather than the keyer. `CwSidetoneGenerator` is unchanged by this PR and its raised-cosine envelope ramps cleanly across block-quantized edges. The "fullest fix" floated in the issue (advancing the gate by sample count inside `CwSidetoneGenerator::process()`) remains available as a follow-up if sub-block edge precision is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
