### PR TITLE
fix(theme): migrate hardcoded highlight and disabled-state colours to ThemeManager tokens. Principle IX.

### DIFF
--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -202,6 +202,20 @@
             "warning.background.checked": "#5a3a0a",
             "warning.foreground.checked": "{color.amber.500}",
             "warning.border.checked":     "{color.amber.500}"
+          },
+          "highlight": {
+            "tx":      "#fc4500",
+            "rx":      "#379baf",
+            "message": "#e58be5",
+            "fg":      "#000000"
+          },
+          "button": {
+            "background.disabled":        "#203040",
+            "foreground.disabled":        "{color.gray.500}",
+            "border.disabled":            "{color.gray.700}",
+            "danger.background.disabled": "#2a1818",
+            "danger.foreground.disabled": "#8a6055",
+            "danger.border.disabled":     "#4a2828"
           }
         },
         "font": {

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -203,6 +203,20 @@
             "warning.background.checked": "#f5e8d0",
             "warning.foreground.checked": "{color.amber.500}",
             "warning.border.checked":     "{color.amber.500}"
+          },
+          "highlight": {
+            "tx":      "#fc4500",
+            "rx":      "#379baf",
+            "message": "#e58be5",
+            "fg":      "#000000"
+          },
+          "button": {
+            "background.disabled":        "{color.gray.700}",
+            "foreground.disabled":        "{color.gray.500}",
+            "border.disabled":            "{color.gray.600}",
+            "danger.background.disabled": "#f0d8d8",
+            "danger.foreground.disabled": "#b08080",
+            "danger.border.disabled":     "#d0a8a8"
           }
         },
         "font": {

--- a/src/gui/FreeDvReporterModel.cpp
+++ b/src/gui/FreeDvReporterModel.cpp
@@ -2,6 +2,7 @@
 
 #include "FreeDvReporterModel.h"
 #include "core/MaidenheadLocator.h"
+#include "core/ThemeManager.h"
 
 #include <QBrush>
 #include <QDateTime>
@@ -9,16 +10,7 @@
 
 namespace AetherSDR {
 
-// ── Highlight colour palette ─────────────────────────────────────────────────
-// Matches freedv-gui reference (freedv_reporter.cpp / ReportingConfiguration.cpp).
-// TX orange / RX teal / Msg purple — all with black foreground for contrast.
 namespace {
-
-// Row highlight colors — match freedv-gui reference palette.
-const QColor kTxBg {0xfc, 0x45, 0x00};   // orange  (#fc4500)
-const QColor kRxBg {0x37, 0x9b, 0xaf};   // teal    (#379baf)
-const QColor kMsgBg{0xe5, 0x8b, 0xe5};   // purple  (#e58be5)
-const QColor kHlFg {0x00, 0x00, 0x00};   // black foreground on all highlights
 
 // Timeouts (seconds)
 constexpr int kRxSec  = 5;  // RX highlight expires 5s after last rx_report
@@ -36,6 +28,14 @@ FreeDvReporterModel::FreeDvReporterModel(QObject* parent)
     connect(m_highlightTimer, &QTimer::timeout,
             this, &FreeDvReporterModel::onHighlightTick);
     m_highlightTimer->start();
+
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
+            this, [this] {
+                if (!m_rows.isEmpty())
+                    emit dataChanged(index(0, 0),
+                                     index(m_rows.size() - 1, Col::Count - 1),
+                                     {Qt::BackgroundRole, Qt::ForegroundRole});
+            });
 }
 
 // ── QAbstractTableModel overrides ────────────────────────────────────────────
@@ -106,16 +106,19 @@ QVariant FreeDvReporterModel::data(const QModelIndex& index, int role) const
 
     if (role == Qt::BackgroundRole) {
         if (info.status == u"TX")
-            return QBrush(kTxBg);
+            return QBrush(ThemeManager::instance().color(QStringLiteral("color.highlight.tx")));
         if (isHighlightActive(row)) {
-            return QBrush(row.highlightType == HighlightType::RX ? kRxBg : kMsgBg);
+            const QString token = row.highlightType == HighlightType::RX
+                                  ? QStringLiteral("color.highlight.rx")
+                                  : QStringLiteral("color.highlight.message");
+            return QBrush(ThemeManager::instance().color(token));
         }
         return {};
     }
 
     if (role == Qt::ForegroundRole) {
         if (info.status == u"TX" || isHighlightActive(row))
-            return QBrush(kHlFg);
+            return QBrush(ThemeManager::instance().color(QStringLiteral("color.highlight.fg")));
         return {};
     }
 

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -601,12 +601,7 @@ QWidget* RadioSetupDialog::buildRadioTab()
             "QPushButton { background: #3a1a1a; color: #ffb080; border: 1px solid #6e3030;"
             " border-radius: 3px; font-size: 11px; font-weight: bold; padding: 3px 10px; }"
             "QPushButton:hover { background: #4a2020; }"
-            // Disabled (radio disconnected/reconnecting): keep the button clearly
-            // visible as a greyed-out control. The previous tokens
-            // (background.1 / meter.bar.fill / background.2) were all dim blue-greys
-            // that blended into the dialog, making the button look absent rather
-            // than disabled (#3334 follow-up).
-            "QPushButton:disabled { background: #2a1818; color: #8a6055; border-color: #4a2828; }");
+            "QPushButton:disabled { background: {{color.button.danger.background.disabled}}; color: {{color.button.danger.foreground.disabled}}; border-color: {{color.button.danger.border.disabled}}; }");
         // Only enable when actually connected; subscribe so disconnect/reconnect
         // disables/re-enables the button without the user having to reopen the
         // dialog. rebootRadio() also early-returns on disconnected, but the
@@ -843,7 +838,7 @@ QWidget* RadioSetupDialog::buildRadioTab()
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_fwUploadBtn, "QPushButton { background: #1a3a1a; color: #80e080; border: 1px solid #2e6e2e;"
             " border-radius: 3px; padding: 4px 8px; }"
             "QPushButton:hover { background: #2a4a2a; }"
-            "QPushButton:disabled { background: #1a1a2a; color: {{color.meter.bar.fill}}; border-color: {{color.background.1}}; }");
+            "QPushButton:disabled { background: {{color.button.background.disabled}}; color: {{color.button.foreground.disabled}}; border-color: {{color.button.border.disabled}}; }");
         btnRow->addWidget(m_fwUploadBtn);
         vlay->addLayout(btnRow);
 
@@ -4059,16 +4054,16 @@ QWidget* RadioSetupDialog::buildSerialTab()
             "QPushButton { background: #00b4d8; color: #0f0f1a; font-weight: bold; "
             "border: 1px solid #008ba8; padding: 3px; border-radius: 3px; }"
             "QPushButton:hover { background: #00c8f0; }"
-            "QPushButton:disabled { background: #203040; color: #506070; border-color: #304050; }";
+            "QPushButton:disabled { background: {{color.button.background.disabled}}; color: {{color.button.foreground.disabled}}; border-color: {{color.button.border.disabled}}; }";
 
         auto* openBtn = new QPushButton("Open");
         // Min-width rather than fixed-width: macOS native button metrics need
         // more horizontal room than the 80 px Windows/Fusion baseline.
         openBtn->setMinimumWidth(80);
-        openBtn->setStyleSheet(btnStyle);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(openBtn, btnStyle);
         auto* closeBtn = new QPushButton("Close");
         closeBtn->setMinimumWidth(80);
-        closeBtn->setStyleSheet(btnStyle);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(closeBtn, btnStyle);
 
         auto* statusLabel = new QLabel;
         statusLabel->setStyleSheet("QLabel { font-size: 11px; }");


### PR DESCRIPTION
## Summary

Follow-up to #3439 and #3441. Fills three hardcoded-colour gaps in the theme token system — the last surfaces in the FreeDV Reporter dialog and Radio Setup dialog that hadn't been migrated to ThemeManager.

**FreeDvReporterModel — row highlight colours**
- Removes four hardcoded `QColor` constants (`kTxBg` / `kRxBg` / `kMsgBg` / `kHlFg`) and replaces their three use sites in `data()` with `ThemeManager::instance().color(token)` calls.
- Adds a `themeChanged` → `dataChanged{BackgroundRole, ForegroundRole}` connection in the constructor so highlighted rows repaint immediately on a theme switch instead of waiting for the next 250 ms highlight tick.
- Note: `color.background.tx` (`#3a2a0e`) is a chrome-panel tint used in 35+ surfaces and could not be reused here. The TX-row highlight (`#fc4500`) is a distinct high-visibility colour matching the freedv-gui reference palette, so new tokens were required for all four constants.

**RadioSetupDialog — button disabled states**
- Migrates three `QPushButton:disabled` CSS blocks to tokens.
- Reboot Radio button (`buildRadioTab` ~line 601): uses new `color.button.danger.*disabled` tokens — preserves the intentional danger-red colouring in the disabled state.
- Upload Firmware button (`buildRadioTab` ~line 838): was using `{{color.meter.bar.fill}}` and `{{color.background.1}}` as disabled-state stand-ins (semantically wrong tokens from a prior partial migration). Now uses correct `color.button.*disabled` tokens.
- Serial tab Open/Close port buttons (`buildSerialTab` ~line 4054): hardcoded hex replaced with `color.button.*disabled` tokens; `setStyleSheet` calls replaced with `applyStyleSheet` so the template engine resolves tokens and the widgets participate in live theme switching.

**New tokens — 10 total across both theme files**

| Token | Dark | Light |
|---|---|---|
| `color.highlight.tx` | `#fc4500` | `#fc4500` |
| `color.highlight.rx` | `#379baf` | `#379baf` |
| `color.highlight.message` | `#e58be5` | `#e58be5` |
| `color.highlight.fg` | `#000000` | `#000000` |
| `color.button.background.disabled` | `#203040` | `{color.gray.700}` |
| `color.button.foreground.disabled` | `{color.gray.500}` | `{color.gray.500}` |
| `color.button.border.disabled` | `{color.gray.700}` | `{color.gray.600}` |
| `color.button.danger.background.disabled` | `#2a1818` | `#f0d8d8` |
| `color.button.danger.foreground.disabled` | `#8a6055` | `#b08080` |
| `color.button.danger.border.disabled` | `#4a2828` | `#d0a8a8` |

Highlight colours are kept identical between dark and light themes — they are high-saturation reference palette colours from freedv-gui that provide adequate contrast with the black foreground on both backgrounds. A future theme author can override them via the token.

Fixes #3446.

## Test plan

- [ ] Build clean on Windows (MinGW), no new warnings
- [ ] FreeDV Reporter: open dialog, observe another station transmitting — TX row shows orange background with black text
- [ ] FreeDV Reporter: RX highlight (teal) and message highlight (purple) appear and expire after ~5 s
- [ ] FreeDV Reporter: switch theme while a highlight is active — row repaints immediately (does not wait for the 250 ms tick)
- [ ] Radio Setup → General tab: disconnect radio, confirm Reboot Radio button disabled state is dark red-tinted (not generic grey)
- [ ] Radio Setup → General tab: Upload Firmware button renders correct disabled state when no firmware check has run
- [ ] Radio Setup → Serial tab: open a port config, confirm Open/Close buttons show correct disabled styling when not applicable
- [ ] Light theme: open FreeDV Reporter and Radio Setup, confirm all three token groups (highlight, button, danger) render legibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)