### PR TITLE
fix: Stream Deck Tune Toggle parses wrong TCI status field

### DIFF
--- a/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/plugin.js
+++ b/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/plugin.js
@@ -63,7 +63,7 @@ function parseTci(msg) {
             case "vfo":          if (p.length >= 3) radio.frequency = parseInt(p[2]); break;
             case "modulation":   if (p.length >= 2) radio.mode = p[1]; break;
             case "trx":          if (p.length >= 2) radio.transmitting = p[1] === "true"; break;
-            case "tune":         if (p.length >= 1) radio.tuning = p[0] === "true"; break;
+            case "tune":         if (p.length >= 2) radio.tuning = p[1] === "true"; break;
             case "mute":         if (p.length >= 2) radio.muted = p[1] === "true"; break;
             case "volume":       if (p.length >= 1) radio.volume = parseInt(p[0]); break;
             case "drive":        if (p.length >= 1) radio.rfPower = parseInt(p[0]); break;


### PR DESCRIPTION
## Summary

Fixes #3622. The Stream Deck **Tune Toggle** only ever turned tuning on; pressing it again never turned it off. The Tune Toggle action emits `tune:0,${!radio.tuning};`, which relies on the plugin's cached `radio.tuning` staying in sync with the radio. The TCI status parser read the `tune` boolean from `p[0]` (the trx index) instead of `p[1]`, so `radio.tuning` was always evaluated as `("0" === "true")` = `false`. That made `!radio.tuning` always `true`, so the toggle was stuck on.

AetherSDR's TCI server emits `tune:<trx>,<true|false>;` — confirmed at `src/core/TciProtocol.cpp:518` (`tune:%1,%2;` with `%1` = trx, `%2` = the boolean). Every sibling boolean handler in `plugin.js` (`trx`, `mute`, `rx_nb`, `split_enable`, `lock`) already reads `p[1]` with a `>= 2` length guard; the `tune` case was the lone outlier. This brings it in line:

```diff
-            case "tune":         if (p.length >= 1) radio.tuning = p[0] === "true"; break;
+            case "tune":         if (p.length >= 2) radio.tuning = p[1] === "true"; break;
```

`radio.tuning` now stays synced, so the toggle alternates on/off correctly. The bug is in the JS plugin, so it is platform-independent (not Windows-specific). `mox-toggle` already reads `p[1]` and is unaffected.

## Constitution principle honored

Radio-authoritative live state — the plugin's cached `radio.tuning` must faithfully reflect the state the radio reports over TCI. The fix restores that mirror by parsing the boolean from the field the radio actually emits, rather than holding a stale value.

## Test plan

- [x] Reproduction documented (see Summary): `tune:0,true;` was parsed as `radio.tuning = ("0" === "true")` = `false`.
- [x] `node --check` passes on `plugin.js` (single-line change, JS syntax valid).
- [ ] Behavior verified on a real radio: incoming `tune:0,true;` sets `radio.tuning = true`; a malformed `tune:0;` (length < 2) leaves it unchanged rather than misparsing; subsequent presses alternate `tune:0,false;` / `tune:0,true;`.

## Checklist

- [x] Commit is signed (SSH)
- [x] No new flat-key `AppSettings` calls (Principle V) — N/A, JS plugin change only
- [x] Code is clean-room (Principle IV) — the fix is derived from this repo's own TCI emission code, not a proprietary binary
- [x] All meter UI uses `MeterSmoother` — N/A, no meter UI touched
- [ ] Documentation updated — N/A, no user-visible doc behavior changed
- [ ] Security-sensitive changes reference a GHSA — N/A
