### PR TITLE
Improve fan mode button label clarity

### DIFF
--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -9,8 +9,16 @@
 
 namespace AetherSDR {
 
-namespace {
 
+namespace {
+QString fanModeLabel(const QString& mode)
+{
+    if (mode == "STANDARD") return "Fan: Std";
+    if (mode == "CONTEST") return "Fan: Contest";
+    if (mode == "BROADCAST") return "Fan: Bcast";
+
+    return "Fan";
+}
 // Left-side label that shows the field name + live value ("PWR 1148").
 // Fixed width so all three gauge rows line up.
 QLabel* makeValueLabel(QWidget* parent)
@@ -113,7 +121,7 @@ AmpApplet::AmpApplet(QWidget* parent)
 
     // Fan speed cycle button — single letter: S (STANDARD), C (CONTEST), B (BROADCAST).
     // Hidden until a direct PGXL connection delivers the first fanmode status.
-    m_fanBtn = new QPushButton(m_fanMode.left(1));
+    m_fanBtn = new QPushButton(fanModeLabel(m_fanMode));
     m_fanBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     m_fanBtn->setFocusPolicy(Qt::TabFocus);
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_fanBtn, kBtnStyle);
@@ -129,7 +137,7 @@ AmpApplet::AmpApplet(QWidget* parent)
             idx = -1; // (-1 + 1) % 3 == 0 == STANDARD
         }
         m_fanMode = kModes[(idx + 1) % kModes.size()];
-        m_fanBtn->setText(m_fanMode.left(1));
+        m_fanBtn->setText(fanModeLabel(m_fanMode));
         m_fanBtn->setAccessibleName(QString("Fan speed: %1").arg(m_fanMode));
         emit fanModeChanged(m_fanMode);
     });
@@ -264,7 +272,7 @@ void AmpApplet::setMainsVoltage(int volts)
 void AmpApplet::setFanMode(const QString& mode)
 {
     m_fanMode = mode.toUpper();
-    m_fanBtn->setText(m_fanMode.left(1));
+    m_fanBtn->setText(fanModeLabel(m_fanMode));
     m_fanBtn->setAccessibleName(QString("Fan speed: %1").arg(m_fanMode));
     m_fanBtn->show();
 }

--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -9,7 +9,6 @@
 
 namespace AetherSDR {
 
-
 namespace {
 QString fanModeLabel(const QString& mode)
 {
@@ -119,8 +118,9 @@ AmpApplet::AmpApplet(QWidget* parent)
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
         "QPushButton:hover { background: {{color.background.1}}; }";
 
-    // Fan speed cycle button — single letter: S (STANDARD), C (CONTEST), B (BROADCAST).
-    // Hidden until a direct PGXL connection delivers the first fanmode status.
+    // Fan speed cycle button — labelled per mode via fanModeLabel()
+    // ("Fan: Std" / "Fan: Contest" / "Fan: Bcast").  Hidden until a direct
+    // PGXL connection delivers the first fanmode status.
     m_fanBtn = new QPushButton(fanModeLabel(m_fanMode));
     m_fanBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     m_fanBtn->setFocusPolicy(Qt::TabFocus);


### PR DESCRIPTION
<!--
Thanks for contributing to AetherSDR!

Before opening the PR, please:
- Read AGENTS.md if this is your first contribution (or your AI tool's
  first contribution) — it has the conventions every contributor agent
  is expected to follow.
- Read CONTRIBUTING.md for the commit-signing and branch-protection
  rules.
- If you're an AI agent: claim the originating issue first by assigning
  yourself via `gh issue edit <N> --add-assignee <handle>`. Double-
  assigning alongside the @aethersdr-agent triage bot is fine.
-->

## Summary

<!-- One-paragraph description of what changes and why.  If this fixes
an issue, lead with "Fixes #N" or "Closes #N". -->

## Constitution principle honored

<!-- Cite the principle by Roman numeral when relevant.  E.g.
"Principle V — new feature uses nested-JSON persistence."
"Principle IV — code is clean-room, not derived from decompiled sources."
See CONSTITUTION.md for the full list. -->

## Test plan

- [ ] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug

## Checklist

- [ ] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [ ] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [ ] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [ ] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable

## Summary

This change makes the amplifier fan mode button more descriptive by replacing the single-letter labels (S, C, B) with clearer text labels.

### Changes
- Added a helper function to map fan modes to user-friendly labels.
- Replaced:
  - S → Fan: Std
  - C → Fan: Contest
  - B → Fan: Bcast
- Updated all fan mode button text assignments to use the helper function.

### Motivation
The previous single-letter labels could be confused with amplifier state indicators, especially "S" being interpreted as "Standby". The new labels make the button purpose clearer while preserving existing behavior.

Fixes #3649