### PR TITLE
refactor(audio): finish Phase 6 — Pudu/QSO/CW sinks onto the factory (#3306 6b/6c)

### DIFF
--- a/docs/audio-sink-factory.md
+++ b/docs/audio-sink-factory.md
@@ -190,9 +190,19 @@ rate ones; the others are enforced in the router/wrapper.
    `MainWindow` lambda, so a future sink can't re-open the uncoupling class.
    Behaviour-identical; unit-tested headless. (CW sidetone + Quindar are
    AudioEngine-internal and already follow via the RX restart.)
-6. **Aux output sinks → wrapper** — CW sidetone, Pudu monitor, Quindar, QSO
-   playback drop their own per-sink format ladders and negotiate via
-   `AudioDeviceNegotiator` (gaining the 44.1k rung + Float32 catch-all). *Next.*
+6. **Aux output sinks → wrapper** — drop their own per-sink format ladders and
+   negotiate via `AudioDeviceNegotiator` (gaining the 44.1k rung + Float32
+   catch-all, and the per-OS 48k-prefer that dodges the WASAPI 24k artifacts):
+   - **6a** ✅ — **Quindar** (Float-only walk; it had no fallback and failed on
+     44.1k-only devices).
+   - **6b** ✅ — **Pudu monitor + QSO playback**. These are Int16-native, so a
+     small `FormatPreference::Int16First` negotiator option was added first
+     (they get Int16 on normal devices — no conversion — Float only as the
+     Float-only-WASAPI fallback #3231). QSO playback also *gained* the
+     Int16→Float guard (it previously bailed on Float-only devices).
+   - **6c** ✅ — **CW sidetone (QAudio backend)** walks the Float-first ladder
+     (Int16 fallback for VB-Audio #2629). The PortAudio backend stays separate
+     (Qt-negotiator can't drive it).
 7. **TCI TX** — drive the resampler from the client-negotiated rate instead of
    the hardcoded `Resampler(48000, 24000)` (`TciServer.cpp`).
 8. **PipeWire DAX** — replace the hand-rolled linear interpolator with the shared

--- a/src/core/AudioDeviceNegotiator.cpp
+++ b/src/core/AudioDeviceNegotiator.cpp
@@ -90,10 +90,10 @@ AFN::DeviceCaps probe(const QAudioDevice& dev, AFN::Direction dir, AFN::TargetOs
 }
 
 Result negotiate(const QAudioDevice& dev, AFN::Direction dir, AFN::ResamplerPolicy policy,
-                 AFN::TargetOs os, int internalRate, bool bluetoothHfp)
+                 AFN::TargetOs os, int internalRate, bool bluetoothHfp, AFN::FormatPreference pref)
 {
     const AFN::DeviceCaps caps = probe(dev, dir, os, bluetoothHfp);
-    const AFN::NegotiatedFormat n = AFN::negotiate(os, dir, caps, policy, internalRate);
+    const AFN::NegotiatedFormat n = AFN::negotiate(os, dir, caps, policy, internalRate, pref);
 
     Result r;
     r.ok = n.ok;
@@ -108,11 +108,12 @@ Result negotiate(const QAudioDevice& dev, AFN::Direction dir, AFN::ResamplerPoli
 
 QList<QAudioFormat> formatLadder(const QAudioDevice& dev, AFN::Direction dir,
                                  AFN::ResamplerPolicy policy, AFN::TargetOs os,
-                                 int internalRate, bool bluetoothHfp, int preferredRateOverride)
+                                 int internalRate, bool bluetoothHfp, int preferredRateOverride,
+                                 AFN::FormatPreference pref)
 {
     const AFN::DeviceCaps caps = probe(dev, dir, os, bluetoothHfp, preferredRateOverride);
     const QList<AFN::FormatCandidate> ladder =
-        AFN::buildLadder(os, dir, caps, policy, internalRate);
+        AFN::buildLadder(os, dir, caps, policy, internalRate, pref);
 
     QList<QAudioFormat> out;
     out.reserve(ladder.size());

--- a/src/core/AudioDeviceNegotiator.h
+++ b/src/core/AudioDeviceNegotiator.h
@@ -50,10 +50,13 @@ Result negotiate(
     AudioFormatNegotiator::ResamplerPolicy policy,
     AudioFormatNegotiator::TargetOs os = AudioFormatNegotiator::hostTargetOs(),
     int internalRate = AudioFormatNegotiator::kInternalRate,
-    bool bluetoothHfp = false);
+    bool bluetoothHfp = false,
+    AudioFormatNegotiator::FormatPreference pref = AudioFormatNegotiator::FormatPreference::Auto);
 
 // The full ordered Qt-format ladder, for backends where isFormatSupported()
-// is unreliable and the caller must try-at-open (Windows WASAPI).
+// is unreliable and the caller must try-at-open (Windows WASAPI), or for sinks
+// that walk-and-probe themselves (Quindar/Pudu/QSO). `pref` leads the format
+// order — Int16-native playback sinks pass Int16First.
 QList<QAudioFormat> formatLadder(
     const QAudioDevice& dev,
     AudioFormatNegotiator::Direction dir,
@@ -61,7 +64,8 @@ QList<QAudioFormat> formatLadder(
     AudioFormatNegotiator::TargetOs os = AudioFormatNegotiator::hostTargetOs(),
     int internalRate = AudioFormatNegotiator::kInternalRate,
     bool bluetoothHfp = false,
-    int preferredRateOverride = 0);
+    int preferredRateOverride = 0,
+    AudioFormatNegotiator::FormatPreference pref = AudioFormatNegotiator::FormatPreference::Auto);
 
 QAudioFormat::SampleFormat       toQt(AudioFormatNegotiator::SampleFmt f);
 AudioFormatNegotiator::SampleFmt fromQt(QAudioFormat::SampleFormat f);

--- a/src/core/AudioFormatNegotiator.cpp
+++ b/src/core/AudioFormatNegotiator.cpp
@@ -46,12 +46,18 @@ QList<int> primaryRateOrder(TargetOs os, Direction dir, int internalRate)
     Q_UNREACHABLE(); // every TargetOs value is covered in both branches above
 }
 
-// Format attempt order per direction. Output is Float-first (RX/sidetone/Quindar
-// produce float internally; Int16 is the WASAPI Int16-only fallback — #2669).
-// Input is Int16-first (mic native is Int16; Float is the virtual-driver /
-// Float-only-capture fallback — #1090).
-QList<SampleFmt> formatOrder(Direction dir)
+// Format attempt order. A caller hint (FormatPreference) overrides the default;
+// otherwise output is Float-first (RX/sidetone/Quindar produce float internally;
+// Int16 is the WASAPI Int16-only fallback — #2669) and input is Int16-first (mic
+// native is Int16; Float is the virtual-driver / Float-only fallback — #1090).
+// Int16-native playback sinks (QSO/Pudu) pass Int16First so they avoid a
+// conversion on normal devices while still falling back to Float.
+QList<SampleFmt> formatOrder(Direction dir, FormatPreference pref)
 {
+    if (pref == FormatPreference::Int16First)
+        return {SampleFmt::Int16, SampleFmt::Float32};
+    if (pref == FormatPreference::Float32First)
+        return {SampleFmt::Float32, SampleFmt::Int16};
     return dir == Direction::Output
         ? QList<SampleFmt>{SampleFmt::Float32, SampleFmt::Int16}
         : QList<SampleFmt>{SampleFmt::Int16, SampleFmt::Float32};
@@ -82,10 +88,11 @@ QList<FormatCandidate> buildLadder(TargetOs os,
                                    Direction dir,
                                    const DeviceCaps& caps,
                                    ResamplerPolicy policy,
-                                   int internalRate)
+                                   int internalRate,
+                                   FormatPreference pref)
 {
     QList<FormatCandidate> ladder;
-    const QList<SampleFmt> fmts = formatOrder(dir);
+    const QList<SampleFmt> fmts = formatOrder(dir, pref);
 
     const auto add = [&](int rate, SampleFmt fmt, const QString& reason) {
         if (rate <= 0) return;
@@ -143,9 +150,10 @@ NegotiatedFormat negotiate(TargetOs os,
                            Direction dir,
                            const DeviceCaps& caps,
                            ResamplerPolicy policy,
-                           int internalRate)
+                           int internalRate,
+                           FormatPreference pref)
 {
-    const QList<FormatCandidate> ladder = buildLadder(os, dir, caps, policy, internalRate);
+    const QList<FormatCandidate> ladder = buildLadder(os, dir, caps, policy, internalRate, pref);
 
     const bool reliable = caps.isFormatSupportedReliable;
     const bool nothingProbeable = caps.supportedRates.isEmpty();

--- a/src/core/AudioFormatNegotiator.h
+++ b/src/core/AudioFormatNegotiator.h
@@ -65,6 +65,16 @@ enum class ResamplerPolicy {
     MonoCollapse,     // TCI DAX TX / RADE -> MonoCollapse when rate != internal
 };
 
+// Optional caller hint to lead the format order with a specific sample format.
+//   Auto         — keep the per-direction default (Float-first output for
+//                  float-native sinks like RX/sidetone; Int16-first input).
+//   Int16First   — for Int16-native sinks (QSO/Pudu playback, recorded int16):
+//                  prefer Int16 on normal devices so no conversion is needed,
+//                  with Float as the fallback for Float-only endpoints.
+//   Float32First — explicit float-first (== Auto for output today; here for
+//                  symmetry/clarity).
+enum class FormatPreference { Auto, Int16First, Float32First };
+
 // Injected capability snapshot — everything the policy would otherwise read
 // live from a QAudioDevice / PortAudio / the HAL. Pure inputs only.
 struct DeviceCaps {
@@ -122,7 +132,8 @@ QList<FormatCandidate> buildLadder(TargetOs os,
                                    Direction dir,
                                    const DeviceCaps& caps,
                                    ResamplerPolicy policy,
-                                   int internalRate = kInternalRate);
+                                   int internalRate = kInternalRate,
+                                   FormatPreference pref = FormatPreference::Auto);
 
 // Resolve the ladder against the device's actual capabilities — the PURE
 // equivalent of walking the ladder and opening the device. When
@@ -134,7 +145,8 @@ NegotiatedFormat negotiate(TargetOs os,
                            Direction dir,
                            const DeviceCaps& caps,
                            ResamplerPolicy policy,
-                           int internalRate = kInternalRate);
+                           int internalRate = kInternalRate,
+                           FormatPreference pref = FormatPreference::Auto);
 
 // The resampler kind for a concrete (deviceRate, policy) pair, independent of
 // the ladder — used by sinks that already know their negotiated rate.

--- a/src/core/ClientPuduMonitor.cpp
+++ b/src/core/ClientPuduMonitor.cpp
@@ -1,4 +1,5 @@
 #include "ClientPuduMonitor.h"
+#include "AudioDeviceNegotiator.h"
 #include "AudioSummaryLogger.h"
 #include "Resampler.h"
 
@@ -220,63 +221,58 @@ void ClientPuduMonitor::startPlayback()
         bail(); return;
     }
 
+    // Negotiate the playback format via the shared factory (#3306, Phase 6b).
+    // The monitor holds recorded Int16, so prefer Int16 (no conversion on a
+    // normal device) and fall back to Float for Float-only WASAPI mixers — the
+    // Int16->Float conversion below handles that case (#3231). The factory
+    // supplies, in one place, the per-OS preferred rate (Win/Mac 48k to dodge
+    // the WASAPI 24k resampler artifacts #2120 — same policy as the RX sink;
+    // Linux native 24k) plus the 44.1k and preferredFormat fallbacks the old
+    // hand-rolled ladder enumerated by hand. We walk it with isFormatSupported
+    // (trusted here — that is exactly how #3231's Float-only devices are
+    // detected, by Int16 being correctly rejected).
     QAudioFormat fmt;
-    fmt.setChannelCount(kChannels);
-    fmt.setSampleFormat(QAudioFormat::Int16);
-    fmt.setSampleRate(kSampleRate);
     int sinkRate = kSampleRate;
     bool fallbackOccurred = false;
     QStringList fallbackReasons;
     QStringList attemptedFormats;
-    attemptedFormats << QStringLiteral("24000Hz 2ch Int16");
-
-    if (!dev.isFormatSupported(fmt)) {
-        fmt.setSampleRate(48000);
-        sinkRate = 48000;
-        fallbackOccurred = true;
-        fallbackReasons << QStringLiteral("24000Hz Int16 stereo unsupported -> 48000Hz");
-        attemptedFormats << QStringLiteral("48000Hz 2ch Int16");
-        if (!dev.isFormatSupported(fmt)) {
-            // Try 44.1 kHz Int16 before giving up on Int16 — some Windows
-            // output devices (HFP/SCO routes, certain USB DACs) reject 48 kHz
-            // outright but accept 44.1 kHz.  Mirrors CwSidetoneQAudioSink's
-            // 48/44.1/24 ladder so the monitor doesn't fall straight through
-            // to preferredFormat on devices that would have taken 44.1.
-            fmt.setSampleRate(44100);
-            sinkRate = 44100;
-            fallbackReasons << QStringLiteral("48000Hz Int16 unsupported -> 44100Hz");
-            attemptedFormats << QStringLiteral("44100Hz 2ch Int16");
-        }
-        if (!dev.isFormatSupported(fmt)) {
-            // Int16 @ 24 / 48 / 44.1 kHz all rejected.  On Windows this is
-            // typically WASAPI shared mode running a Float32 mix pipeline -
-            // the hardware is capable of Int16 but the OS-level mixer refuses
-            // the format.  Try the device's preferred format before giving up,
-            // following the QuindarLocalSink / AudioEngine precedent.
-            QAudioFormat preferred = dev.preferredFormat();
-            preferred.setChannelCount(kChannels);
-            if (preferred.isValid() && dev.isFormatSupported(preferred)) {
-                fmt = preferred;
-                sinkRate = fmt.sampleRate();
-                fallbackReasons << QStringLiteral("44100Hz Int16 unsupported -> preferredFormat (%1Hz %2)")
-                                       .arg(sinkRate)
-                                       .arg(AudioSummaryLogger::sampleFormatName(fmt.sampleFormat()));
-                attemptedFormats << QStringLiteral("%1Hz %2ch %3")
-                                        .arg(sinkRate)
-                                        .arg(fmt.channelCount())
-                                        .arg(AudioSummaryLogger::sampleFormatName(fmt.sampleFormat()));
-            } else {
-                AudioSummaryLogger::OpenFailureSummary failure;
-                failure.path = QStringLiteral("Aetherial monitor playback");
-                failure.backend = QStringLiteral("QAudioSink");
-                failure.deviceDescription = dev.description();
-                failure.attemptedFormats = attemptedFormats.join(QStringLiteral("; "));
-                failure.failureReason = QStringLiteral("output device supports neither Int16 stereo nor its own preferredFormat");
-                failure.fallbackReason = fallbackReasons.join(QStringLiteral("; "));
-                AudioSummaryLogger::logOpenFailure(failure);
-                bail(); return;
+    bool haveFormat = false;
+    const QList<QAudioFormat> ladder = AudioDeviceNegotiator::formatLadder(
+        dev, AudioFormatNegotiator::Direction::Output,
+        AudioFormatNegotiator::ResamplerPolicy::PreservePan,
+        AudioFormatNegotiator::hostTargetOs(),
+        AudioFormatNegotiator::kInternalRate,
+        /*bluetoothHfp=*/false, /*preferredRateOverride=*/0,
+        AudioFormatNegotiator::FormatPreference::Int16First);
+    for (const QAudioFormat& cand : ladder) {
+        QAudioFormat c = cand;
+        c.setChannelCount(kChannels);
+        attemptedFormats << QStringLiteral("%1Hz %2ch %3")
+            .arg(c.sampleRate()).arg(c.channelCount())
+            .arg(AudioSummaryLogger::sampleFormatName(c.sampleFormat()));
+        if (dev.isFormatSupported(c)) {
+            fmt = c;
+            sinkRate = c.sampleRate();
+            haveFormat = true;
+            if (c.sampleRate() != kSampleRate || c.sampleFormat() != QAudioFormat::Int16) {
+                fallbackOccurred = true;
+                fallbackReasons << QStringLiteral("negotiated %1Hz %2")
+                    .arg(sinkRate)
+                    .arg(AudioSummaryLogger::sampleFormatName(c.sampleFormat()));
             }
+            break;
         }
+    }
+    if (!haveFormat) {
+        AudioSummaryLogger::OpenFailureSummary failure;
+        failure.path = QStringLiteral("Aetherial monitor playback");
+        failure.backend = QStringLiteral("QAudioSink");
+        failure.deviceDescription = dev.description();
+        failure.attemptedFormats = attemptedFormats.join(QStringLiteral("; "));
+        failure.failureReason = QStringLiteral("device supports no rung in the negotiation ladder");
+        failure.fallbackReason = fallbackReasons.join(QStringLiteral("; "));
+        AudioSummaryLogger::logOpenFailure(failure);
+        bail(); return;
     }
 
     if (!preparePlaybackPcm(sinkRate)) { bail(); return; }

--- a/src/core/CwSidetoneQAudioSink.cpp
+++ b/src/core/CwSidetoneQAudioSink.cpp
@@ -1,4 +1,5 @@
 #include "CwSidetoneQAudioSink.h"
+#include "AudioDeviceNegotiator.h"
 #include "CwSidetoneGenerator.h"
 #include "LogManager.h"
 
@@ -39,32 +40,35 @@ bool CwSidetoneQAudioSink::start(const QAudioDevice& device,
     }
     m_deviceDescription = dev.description();
 
-    const int kCandidateRates[] = { desiredRateHz > 0 ? desiredRateHz : 48000,
-                                    48000, 44100, 24000 };
+    // Negotiate the output format via the shared factory (#3306, Phase 6c). The
+    // sidetone generator retunes to the negotiated rate (RegenerateAtRate) and
+    // the tick handles both Float and Int16, so we walk the default Float-first
+    // ladder — Int16 is the VB-Audio / Int16-only-WASAPI fallback (#2629) — and
+    // take the first rung the device supports. The factory supplies the per-OS
+    // preferred rate plus the 44.1k and preferredFormat fallbacks in one place.
     QAudioFormat fmt;
-    fmt.setChannelCount(2);
-
-    // Probe Float first (the historical path), then Int16. VB-Audio Virtual
-    // Cable and other Int16-only WASAPI endpoints fail the Float probe but
-    // succeed at Int16; without the fallback the sidetone sink silently
-    // refuses to open against SmartSDR-parity output devices (issue #2629).
     int chosenRate = 0;
     QAudioFormat::SampleFormat chosenFmt = QAudioFormat::Unknown;
-    for (auto sf : { QAudioFormat::Float, QAudioFormat::Int16 }) {
-        fmt.setSampleFormat(sf);
-        for (int rate : kCandidateRates) {
-            fmt.setSampleRate(rate);
-            if (dev.isFormatSupported(fmt)) { chosenRate = rate; chosenFmt = sf; break; }
+    const QList<QAudioFormat> ladder = AudioDeviceNegotiator::formatLadder(
+        dev, AudioFormatNegotiator::Direction::Output,
+        AudioFormatNegotiator::ResamplerPolicy::RegenerateAtRate);
+    for (const QAudioFormat& cand : ladder) {
+        QAudioFormat c = cand;
+        c.setChannelCount(2);
+        if (c.sampleFormat() != QAudioFormat::Float && c.sampleFormat() != QAudioFormat::Int16)
+            continue;   // the sidetone tick only knows Float / Int16
+        if (dev.isFormatSupported(c)) {
+            fmt = c;
+            chosenRate = c.sampleRate();
+            chosenFmt = c.sampleFormat();
+            break;
         }
-        if (chosenRate) break;
     }
     if (chosenRate == 0) {
         qCWarning(lcAudio) << "CwSidetoneQAudioSink: no supported float/int16-stereo rate on device"
                            << dev.description();
         return false;
     }
-    fmt.setSampleFormat(chosenFmt);
-    fmt.setSampleRate(chosenRate);
     m_actualRate   = chosenRate;
     m_sampleFormat = chosenFmt;
     if (chosenRate != (desiredRateHz > 0 ? desiredRateHz : 48000)

--- a/src/core/QsoRecorder.cpp
+++ b/src/core/QsoRecorder.cpp
@@ -1,5 +1,6 @@
 #include "QsoRecorder.h"
 #include "AppSettings.h"
+#include "AudioDeviceNegotiator.h"
 #include "LogManager.h"
 #include "Resampler.h"
 #include "../models/SliceModel.h"
@@ -390,28 +391,50 @@ void QsoRecorder::startPlayback()
     }
     if (dev.isNull()) return;
 
+    // Negotiate the playback format via the shared factory (#3306, Phase 6b).
+    // The recording is Int16, so prefer Int16 (no conversion on a normal device)
+    // and fall back to Float for Float-only WASAPI mixers — the Int16->Float
+    // conversion below handles that (#3231). The factory supplies the per-OS
+    // preferred rate (Win/Mac 48k to dodge the WASAPI 24k resampler artifacts
+    // #2120; Linux native 24k) plus the 44.1k and preferredFormat fallbacks.
+    // Previously QSO playback bailed on a Float-only device; now it works.
+    // Walk with isFormatSupported (trusted), mirroring ClientPuduMonitor.
     QAudioFormat fmt;
-    fmt.setChannelCount(NUM_CHANNELS);
-    fmt.setSampleFormat(QAudioFormat::Int16);
-    fmt.setSampleRate(SAMPLE_RATE);
     int sinkRate = SAMPLE_RATE;
-
-    if (!dev.isFormatSupported(fmt)) {
-        fmt.setSampleRate(48000);
-        sinkRate = 48000;
-        if (!dev.isFormatSupported(fmt)) {
-            // Try 44.1 kHz Int16 before giving up on Int16 — some Windows
-            // output devices (HFP/SCO routes, certain USB DACs) reject 48 kHz
-            // outright but accept 44.1 kHz.  Mirrors ClientPuduMonitor's
-            // 24/48/44.1 ladder so QSO recording playback doesn't bail on
-            // devices where monitor playback succeeds (#3385).
-            fmt.setSampleRate(44100);
-            sinkRate = 44100;
-            if (!dev.isFormatSupported(fmt)) return;
+    bool haveFormat = false;
+    const QList<QAudioFormat> ladder = AudioDeviceNegotiator::formatLadder(
+        dev, AudioFormatNegotiator::Direction::Output,
+        AudioFormatNegotiator::ResamplerPolicy::PreservePan,
+        AudioFormatNegotiator::hostTargetOs(),
+        AudioFormatNegotiator::kInternalRate,
+        /*bluetoothHfp=*/false, /*preferredRateOverride=*/0,
+        AudioFormatNegotiator::FormatPreference::Int16First);
+    for (const QAudioFormat& cand : ladder) {
+        QAudioFormat c = cand;
+        c.setChannelCount(NUM_CHANNELS);
+        if (dev.isFormatSupported(c)) {
+            fmt = c;
+            sinkRate = c.sampleRate();
+            haveFormat = true;
+            break;
         }
     }
+    if (!haveFormat) return;
 
     if (!preparePlaybackPcm(sinkRate)) return;
+
+    // Float-only WASAPI mixers reject Int16 — convert the Int16 playback PCM to
+    // Float32 to match the negotiated sink format (#3231 / Phase 6b), mirroring
+    // ClientPuduMonitor. Only Float32 is handled (the only non-Int16 format
+    // preferredFormat() returns in practice on WASAPI/CoreAudio).
+    if (fmt.sampleFormat() == QAudioFormat::Float) {
+        const int samples = m_playPcm.size() / static_cast<int>(sizeof(int16_t));
+        QByteArray floatPcm(samples * static_cast<int>(sizeof(float)), '\0');
+        const auto* src = reinterpret_cast<const int16_t*>(m_playPcm.constData());
+        auto*       dst = reinterpret_cast<float*>(floatPcm.data());
+        for (int i = 0; i < samples; ++i) dst[i] = src[i] / 32768.0f;
+        m_playPcm = std::move(floatPcm);
+    }
 
     m_playBuffer.close();
     m_playBuffer.setBuffer(&m_playPcm);

--- a/tests/audio_format_negotiation_test.cpp
+++ b/tests/audio_format_negotiation_test.cpp
@@ -51,11 +51,12 @@ struct Row {
     ResamplerKind resampler;
     int           channels;
     bool          fellBack;
+    FormatPreference pref = FormatPreference::Auto;   // optional caller hint
 };
 
 void runRow(const Row& r)
 {
-    const NegotiatedFormat n = negotiate(r.os, r.dir, r.caps, r.policy);
+    const NegotiatedFormat n = negotiate(r.os, r.dir, r.caps, r.policy, kInternalRate, r.pref);
     const bool ok = n.ok == r.ok
                  && (!r.ok || (n.rate == r.rate && n.fmt == r.fmt
                                && n.resampler == r.resampler && n.channels == r.channels
@@ -142,6 +143,19 @@ int main()
             true, 48000, F, ResamplerKind::None, 2, false});
     runRow({"sidetone 24k-cap / Linux -> 24k, no resampler", Lin, Out, Regen, dev({24000, 48000}),
             true, 24000, F, ResamplerKind::None, 2, false});
+
+    // ── Int16-first output (Pudu/QSO playback are Int16-native, #3306 6b). On a
+    //    normal device they get Int16 — no conversion — at the per-OS rate;
+    //    Win/Mac prefer 48k (dodges the WASAPI 24k artifacts #2120, same as RX),
+    //    Linux stays native 24k. On a Float-only device they fall back to Float
+    //    (then the sink's Int16->Float guard #3231 converts). ───────────────────
+    runRow({"Int16-native / Mac / playback -> 48k Int16", Mac, Out, Pan, dev({24000, 48000}),
+            true, 48000, I, ResamplerKind::PreservePan, 2, false, FormatPreference::Int16First});
+    runRow({"Int16-native / Linux / playback -> native 24k Int16", Lin, Out, Pan, dev({24000, 48000}),
+            true, 24000, I, ResamplerKind::None, 2, false, FormatPreference::Int16First});
+    runRow({"Int16-native / Mac / Float-only dev -> Float fallback (#3231 guard)",
+            Mac, Out, Pan, dev({48000}, {F}),
+            true, 48000, F, ResamplerKind::PreservePan, 2, true, FormatPreference::Int16First});
 
     // ── macOS Bluetooth-HFP mic: native low rate first, NOT forced to 48k
     //    (#2615). preferred-first puts 16k ahead of the 48k ladder. ───────────


### PR DESCRIPTION
> **Stacks on #3631 → #3630.** First two commits are #3630 (router) + #3631 (Quindar); the new commits are the enabler + 6b + 6c. Merge the parents first and this collapses to the three new commits. Each is a clean standalone commit.

Closes out **Phase 6** of the audio sink factory (#3306) — every auxiliary output sink now negotiates format through the shared factory instead of a bespoke per-sink ladder.

## Commits

1. **Int16-first `FormatPreference` enabler** — the Output ladder is Float-first (right for the float-native RX/sidetone/Quindar). The Int16-native playback sinks want the opposite, so this adds an optional `FormatPreference { Auto, Int16First, Float32First }` threaded through `buildLadder`/`negotiate` + the wrapper. Default `Auto` leaves RX/mic **byte-identical**. +3 golden rows (28/28).

2. **6b — Pudu monitor + QSO playback** negotiate via `AudioDeviceNegotiator(Int16First, PreservePan)`. On a normal device they get **Int16 at the per-OS rate** (no conversion, as before) with the universal 44.1k + preferredFormat fallbacks in one place. `ClientPuduMonitor` keeps its Int16→Float guard (#3231); **`QsoRecorder` playback gains the same guard** — it previously *bailed* on a Float-only WASAPI device, now it works.

3. **6c — CW sidetone (QAudio backend)** walks the Float-first ladder (Int16 fallback preserved for VB-Audio #2629). The **PortAudio backend is untouched** (Qt negotiator can't drive it).

## Behaviour notes (for soak)

Normal devices are unchanged **except** Pudu/QSO/CW now prefer **48k on Win/Mac** (was 24k for Pudu/QSO) — this is the factory's deliberate #2120 policy (dodges WASAPI 24k-resampler artifacts, same as the RX sink); playback is resampled up-front, one-shot. Linux stays native 24k. Strictly-additive wins: QSO playback now survives Float-only devices; all three gain the 44.1k rung.

## Test / build

- `audio_format_negotiation_test` **28/28**, `audio_device_negotiator_test` 8/8, `audio_output_router_test` 9/9 — all green under CTest.
- Full macOS app builds & links clean (RelWithDebInfo); deployed to the macOS test box.

After this, the factory covers every device-facing sink. Remaining #3306 items (TCI-TX client-rate, PipeWire DAX resampler, Windows mic) are separate.

Refs #3306

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat