### PR TITLE
feat(gpu): Display-menu render-GPU selector for multi-GPU systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,6 +503,7 @@ endif()
 # Sources
 set(CORE_SOURCES
     src/core/AppSettings.cpp
+    src/core/GpuSelector.cpp
     src/core/AgcTCalibrator.cpp
     src/core/SettingsHelpers.cpp
     src/core/ThemeManager.cpp
@@ -1292,6 +1293,7 @@ if(APPLE)
 elseif(WIN32)
     target_compile_definitions(AetherSDR PRIVATE __WINDOWS_MM__)
     target_link_libraries(AetherSDR PRIVATE winmm)
+    target_link_libraries(AetherSDR PRIVATE dxgi)  # GpuSelector adapter enumeration
 else()
     target_compile_definitions(AetherSDR PRIVATE __LINUX_ALSA__)
     find_package(PkgConfig REQUIRED)

--- a/src/core/GpuSelector.cpp
+++ b/src/core/GpuSelector.cpp
@@ -2,12 +2,13 @@
 
 #include "AppSettings.h"
 
-#include <QJsonDocument>
-#include <QJsonObject>
-
-#if defined(Q_OS_LINUX)
 #include <QDir>
 #include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QXmlStreamReader>
+
+#if defined(Q_OS_LINUX)
 #include <QFileInfo>
 #include <QSet>
 #elif defined(Q_OS_WIN)
@@ -73,6 +74,10 @@ QVector<GpuInfo> enumeratePlatform()
         g.id = QStringLiteral("pci:") + pci;
         g.name = vendorName + (discrete ? QStringLiteral(" (discrete)") : QStringLiteral(" (integrated)"));
         g.discrete = discrete;
+        // Only the NVIDIA PRIME-offload path is hardware-soaked.  The non-NVIDIA
+        // DRI_PRIME path follows Mesa's documented PCI-tag semantics but hasn't
+        // been validated on an AMD/Intel discrete box — flag it experimental.
+        g.experimental = (vendorName != QLatin1String("NVIDIA"));
         out.push_back(g);
     }
     return out;
@@ -97,6 +102,15 @@ QVector<GpuInfo> enumeratePlatform()
             g.id = QStringLiteral("dxgi:%1").arg(i);
             g.name = QString::fromWCharArray(desc.Description);
             g.discrete = desc.DedicatedVideoMemory > (static_cast<quint64>(256) << 20);
+            // The integrated adapter is the exact config #1921 crashes on: the
+            // Intel iGPU D3D11 driver corrupts its stack during QRhiWidget
+            // reparenting, which is *why* main.cpp force-exports NvOptimusEnablement.
+            // Letting a user point QT_D3D_ADAPTER_INDEX at it would re-arm that
+            // crash, so it is present-but-not-selectable.
+            g.selectable = g.discrete;
+            // QT_D3D_ADAPTER_INDEX selection isn't hardware-soaked yet (needs a
+            // Windows hybrid tester, incl. the NvOptimus interaction).
+            g.experimental = true;
             out.push_back(g);
         }
         adapter->Release();
@@ -130,11 +144,55 @@ bool willUseWayland()
 }
 #endif
 
+// Post-QApplication read: the settings singleton is fully initialised, so the
+// menu uses it directly.
 QString readSavedId()
 {
     const QJsonObject o = QJsonDocument::fromJson(
         AppSettings::instance().value(QStringLiteral("Graphics")).toString().toUtf8()).object();
     return o.value(QStringLiteral("gpu")).toString(QString::fromLatin1(GpuSelector::kAutoId));
+}
+
+// The AppSettings file path, reproduced by hand — applyAtStartup() runs before
+// QApplication, where QStandardPaths is unavailable and AppSettings must not be
+// constructed.  Mirrors main.cpp's UiScale bootstrap and AppSettings's own
+// GenericConfigLocation layout.
+QString settingsFilePath()
+{
+#if defined(Q_OS_MAC)
+    return QDir::homePath() + QStringLiteral("/Library/Preferences/AetherSDR/AetherSDR.settings");
+#elif defined(Q_OS_WIN)
+    return QDir::fromNativeSeparators(qEnvironmentVariable("LOCALAPPDATA"))
+           + QStringLiteral("/AetherSDR/AetherSDR.settings");
+#else
+    return QDir::homePath() + QStringLiteral("/.config/AetherSDR/AetherSDR.settings");
+#endif
+}
+
+// Startup read: parse the persisted "Graphics" → "gpu" id straight from the
+// settings XML.  Constructing AppSettings::instance() this early would run its
+// migrateSettingsPath() before setApplicationName(), computing the wrong
+// AppConfigLocation path and permanently skipping the old→new migration for
+// upgrading users.  Reading the file by hand (like the UiScale bootstrap) avoids
+// touching the singleton at all.
+QString readSavedIdFromFile()
+{
+    const QString fallback = QString::fromLatin1(GpuSelector::kAutoId);
+    QFile f(settingsFilePath());
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return fallback;
+    }
+    QXmlStreamReader xml(&f);
+    while (!xml.atEnd()) {
+        if (xml.readNext() == QXmlStreamReader::StartElement
+                && xml.name() == QLatin1String("Graphics")) {
+            // readElementText() unescapes the XML entities, yielding the raw JSON.
+            const QJsonObject o =
+                QJsonDocument::fromJson(xml.readElementText().toUtf8()).object();
+            return o.value(QStringLiteral("gpu")).toString(fallback);
+        }
+    }
+    return fallback;
 }
 
 } // namespace
@@ -170,13 +228,11 @@ void GpuSelector::saveChoiceId(const QString& id)
 
 void GpuSelector::applyAtStartup()
 {
-    // This runs in main() BEFORE QApplication and before main()'s own
-    // AppSettings::load(), so the settings map is still empty.  Load it here so
-    // the persisted choice is actually read (load() only touches QFile/XML and
-    // is re-run harmlessly during normal startup).
-    AppSettings::instance().load();
-
-    const QString id = savedChoiceId();
+    // Runs in main() BEFORE QApplication.  Read the persisted choice straight
+    // from the settings file — constructing AppSettings::instance() here would
+    // run its path migration before setApplicationName() and break it for
+    // upgrading users (see readSavedIdFromFile()).
+    const QString id = readSavedIdFromFile();
     if (id.isEmpty() || id == QLatin1String(kAutoId)) {
         s_appliedSummary = QStringLiteral("Auto (system default — no override)");
         return;
@@ -188,6 +244,15 @@ void GpuSelector::applyAtStartup()
     }
     if (!chosen) {
         s_appliedSummary = QStringLiteral("saved GPU '%1' not present — using system default").arg(id);
+        return;
+    }
+    if (!chosen->selectable) {
+        // Defence in depth: the menu disables non-selectable adapters, but a
+        // hand-edited settings file could still name one.  Refuse it and keep
+        // the system default (on Windows that means NvOptimusEnablement keeps
+        // driving the discrete GPU, avoiding the #1921 iGPU crash).
+        s_appliedSummary = QStringLiteral("saved GPU '%1' is not selectable (#1921) — using system default")
+                               .arg(chosen->name);
         return;
     }
 

--- a/src/core/GpuSelector.cpp
+++ b/src/core/GpuSelector.cpp
@@ -192,10 +192,11 @@ void GpuSelector::applyAtStartup()
     }
 
 #if defined(Q_OS_LINUX)
-    // Honour an explicit user override of the offload env.
+    // Honour an explicit user override of any GPU-selection env.
     if (qEnvironmentVariableIsSet("__NV_PRIME_RENDER_OFFLOAD")
-            || qEnvironmentVariableIsSet("__GLX_VENDOR_LIBRARY_NAME")) {
-        s_appliedSummary = QStringLiteral("'%1' requested, but __NV_PRIME/__GLX env already set — left as-is")
+            || qEnvironmentVariableIsSet("__GLX_VENDOR_LIBRARY_NAME")
+            || qEnvironmentVariableIsSet("DRI_PRIME")) {
+        s_appliedSummary = QStringLiteral("'%1' requested, but __NV_PRIME/__GLX/DRI_PRIME env already set — left as-is")
                                .arg(chosen->name);
         return;
     }
@@ -216,14 +217,20 @@ void GpuSelector::applyAtStartup()
                 + QStringLiteral(" via PRIME offload (X11/GLX, __GLX_VENDOR_LIBRARY_NAME=nvidia)");
         }
     } else {
-        // Integrated / AMD.  Under Wayland the integrated GPU is already the
-        // default, so nothing to force; under X11 pin the Mesa GLX vendor.
-        if (wayland) {
-            s_appliedSummary = chosen->name + QStringLiteral(" (Wayland default — no override needed)");
-        } else {
-            qputenv("__GLX_VENDOR_LIBRARY_NAME", "mesa");
-            s_appliedSummary = chosen->name + QStringLiteral(" via __GLX_VENDOR_LIBRARY_NAME=mesa (X11/GLX)");
-        }
+        // Non-NVIDIA (AMD / Intel): target the chosen card by PCI address via the
+        // Mesa loader's DRI_PRIME, which works under both X11 and Wayland. This is
+        // what actually offloads rendering onto an AMD discrete GPU (the old
+        // mesa-GLX-vendor hint never moved rendering to a specific card); picking
+        // the integrated GPU pins it explicitly. chosen->id is "pci:0000:01:00.0";
+        // DRI_PRIME wants "pci-0000_01_00_0".
+        QString pciTag = chosen->id.mid(4);   // drop "pci:" → "0000:01:00.0"
+        pciTag.replace(QLatin1Char(':'), QLatin1Char('_'))
+              .replace(QLatin1Char('.'), QLatin1Char('_'));
+        const QByteArray driPrime = QByteArray("pci-") + pciTag.toUtf8();
+        qputenv("DRI_PRIME", driPrime);
+        // NVIDIA-Optimus offload remains the NVIDIA branch above; DRI_PRIME is
+        // Mesa-only and does not drive the proprietary NVIDIA driver.
+        s_appliedSummary = chosen->name + QStringLiteral(" via DRI_PRIME=") + QString::fromUtf8(driPrime);
     }
 #elif defined(Q_OS_WIN)
     if (qEnvironmentVariableIsSet("QT_D3D_ADAPTER_INDEX")) {

--- a/src/core/GpuSelector.cpp
+++ b/src/core/GpuSelector.cpp
@@ -1,0 +1,247 @@
+#include "GpuSelector.h"
+
+#include "AppSettings.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#if defined(Q_OS_LINUX)
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QSet>
+#elif defined(Q_OS_WIN)
+#include <QtGlobal>
+#include <dxgi.h>
+#endif
+
+namespace AetherSDR {
+
+namespace {
+
+#if defined(Q_OS_LINUX)
+// Enumerate GPUs from DRM sysfs.  Each top-level cardN exposes a PCI device with
+// a vendor id and a boot_vga flag (the primary, usually-integrated GPU).
+QVector<GpuInfo> enumeratePlatform()
+{
+    QVector<GpuInfo> out;
+    QDir drm(QStringLiteral("/sys/class/drm"));
+    if (!drm.exists()) {
+        return out;
+    }
+    QSet<QString> seenPci;
+    const auto entries = drm.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+    for (const QString& card : entries) {
+        // Top-level GPUs are "card0", "card1"…; connector subdirs are
+        // "card0-DP-1" etc. — skip those.
+        if (!card.startsWith(QLatin1String("card")) || card.contains('-')) {
+            continue;
+        }
+        const QString devDir = QStringLiteral("/sys/class/drm/") + card + QStringLiteral("/device");
+        const QString pci = QFileInfo(devDir).canonicalFilePath().section('/', -1);
+        if (pci.isEmpty() || seenPci.contains(pci)) {
+            continue;
+        }
+        seenPci.insert(pci);
+
+        auto readTrim = [](const QString& path) -> QString {
+            QFile f(path);
+            return f.open(QIODevice::ReadOnly)
+                       ? QString::fromLatin1(f.readAll()).trimmed()
+                       : QString();
+        };
+        const QString vendor = readTrim(devDir + QStringLiteral("/vendor"));
+        const bool bootVga   = readTrim(devDir + QStringLiteral("/boot_vga")) == QLatin1String("1");
+
+        QString vendorName;
+        bool discrete = false;
+        if (vendor == QLatin1String("0x10de")) {            // NVIDIA
+            vendorName = QStringLiteral("NVIDIA");
+            discrete = true;
+        } else if (vendor == QLatin1String("0x1002")) {     // AMD (dGPU or APU)
+            vendorName = QStringLiteral("AMD");
+            discrete = !bootVga;
+        } else if (vendor == QLatin1String("0x8086")) {     // Intel (usually iGPU)
+            vendorName = QStringLiteral("Intel");
+            discrete = false;
+        } else {
+            vendorName = vendor.isEmpty() ? QStringLiteral("GPU") : (QStringLiteral("GPU ") + vendor);
+            discrete = !bootVga;
+        }
+
+        GpuInfo g;
+        g.id = QStringLiteral("pci:") + pci;
+        g.name = vendorName + (discrete ? QStringLiteral(" (discrete)") : QStringLiteral(" (integrated)"));
+        g.discrete = discrete;
+        out.push_back(g);
+    }
+    return out;
+}
+
+#elif defined(Q_OS_WIN)
+// Enumerate GPUs via DXGI; the adapter index lines up with QT_D3D_ADAPTER_INDEX.
+QVector<GpuInfo> enumeratePlatform()
+{
+    QVector<GpuInfo> out;
+    IDXGIFactory1* factory = nullptr;
+    if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory1), reinterpret_cast<void**>(&factory)))
+            || !factory) {
+        return out;
+    }
+    IDXGIAdapter1* adapter = nullptr;
+    for (UINT i = 0; factory->EnumAdapters1(i, &adapter) != DXGI_ERROR_NOT_FOUND; ++i) {
+        DXGI_ADAPTER_DESC1 desc;
+        if (SUCCEEDED(adapter->GetDesc1(&desc))
+                && !(desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)) {   // skip the WARP/software adapter
+            GpuInfo g;
+            g.id = QStringLiteral("dxgi:%1").arg(i);
+            g.name = QString::fromWCharArray(desc.Description);
+            g.discrete = desc.DedicatedVideoMemory > (static_cast<quint64>(256) << 20);
+            out.push_back(g);
+        }
+        adapter->Release();
+        adapter = nullptr;
+    }
+    factory->Release();
+    return out;
+}
+
+#else
+QVector<GpuInfo> enumeratePlatform() { return {}; }
+#endif
+
+QString s_appliedSummary = QStringLiteral("not run");
+
+#if defined(Q_OS_LINUX)
+// Will the app run on a Wayland (EGL) platform rather than X11 (GLX)?  Mirrors
+// main.cpp's Wayland-preference logic; applyAtStartup() runs before QApplication
+// so we read the environment directly.  GLX vendor selection only applies under
+// X11 — under Wayland it is useless and __GLX_VENDOR_LIBRARY_NAME=nvidia can even
+// raise a GLX BadValue.
+bool willUseWayland()
+{
+    const QByteArray plat = qgetenv("QT_QPA_PLATFORM");
+    if (!plat.isEmpty()) {
+        if (plat.contains("wayland")) return true;
+        if (plat.contains("xcb"))     return false;
+    }
+    return qEnvironmentVariableIsSet("WAYLAND_DISPLAY")
+        || qgetenv("XDG_SESSION_TYPE") == QByteArrayLiteral("wayland");
+}
+#endif
+
+QString readSavedId()
+{
+    const QJsonObject o = QJsonDocument::fromJson(
+        AppSettings::instance().value(QStringLiteral("Graphics")).toString().toUtf8()).object();
+    return o.value(QStringLiteral("gpu")).toString(QString::fromLatin1(GpuSelector::kAutoId));
+}
+
+} // namespace
+
+QVector<GpuInfo> GpuSelector::available()
+{
+    QVector<GpuInfo> out;
+    out.push_back({ QString::fromLatin1(kAutoId), QStringLiteral("Auto (system default)"), false });
+    out += enumeratePlatform();
+    return out;
+}
+
+bool GpuSelector::hasMultiple()
+{
+    // available() includes the synthetic "Auto" entry, so >1 real GPU == size>2.
+    return available().size() > 2;
+}
+
+QString GpuSelector::savedChoiceId()
+{
+    return readSavedId();
+}
+
+void GpuSelector::saveChoiceId(const QString& id)
+{
+    QJsonObject o;
+    o[QStringLiteral("gpu")] = id;
+    auto& s = AppSettings::instance();
+    s.setValue(QStringLiteral("Graphics"),
+               QString::fromUtf8(QJsonDocument(o).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+void GpuSelector::applyAtStartup()
+{
+    // This runs in main() BEFORE QApplication and before main()'s own
+    // AppSettings::load(), so the settings map is still empty.  Load it here so
+    // the persisted choice is actually read (load() only touches QFile/XML and
+    // is re-run harmlessly during normal startup).
+    AppSettings::instance().load();
+
+    const QString id = savedChoiceId();
+    if (id.isEmpty() || id == QLatin1String(kAutoId)) {
+        s_appliedSummary = QStringLiteral("Auto (system default — no override)");
+        return;
+    }
+    const auto gpus = available();
+    const GpuInfo* chosen = nullptr;
+    for (const auto& g : gpus) {
+        if (g.id == id) { chosen = &g; break; }
+    }
+    if (!chosen) {
+        s_appliedSummary = QStringLiteral("saved GPU '%1' not present — using system default").arg(id);
+        return;
+    }
+
+#if defined(Q_OS_LINUX)
+    // Honour an explicit user override of the offload env.
+    if (qEnvironmentVariableIsSet("__NV_PRIME_RENDER_OFFLOAD")
+            || qEnvironmentVariableIsSet("__GLX_VENDOR_LIBRARY_NAME")) {
+        s_appliedSummary = QStringLiteral("'%1' requested, but __NV_PRIME/__GLX env already set — left as-is")
+                               .arg(chosen->name);
+        return;
+    }
+    // The right lever differs by windowing system: __GLX_VENDOR_LIBRARY_NAME only
+    // applies under X11/XWayland (GLX).  Under Wayland the app uses EGL, where it
+    // is useless and =nvidia can raise GLX BadValue, so set only the
+    // windowing-agnostic offload hints.
+    const bool wayland = willUseWayland();
+    if (chosen->name.contains(QLatin1String("NVIDIA"))) {
+        qputenv("__NV_PRIME_RENDER_OFFLOAD", "1");        // GLX + EGL offload hint
+        qputenv("__VK_LAYER_NV_optimus", "NVIDIA_only");  // Vulkan offload hint
+        if (wayland) {
+            s_appliedSummary = chosen->name
+                + QStringLiteral(" via __NV_PRIME_RENDER_OFFLOAD (Wayland/EGL offload)");
+        } else {
+            qputenv("__GLX_VENDOR_LIBRARY_NAME", "nvidia");
+            s_appliedSummary = chosen->name
+                + QStringLiteral(" via PRIME offload (X11/GLX, __GLX_VENDOR_LIBRARY_NAME=nvidia)");
+        }
+    } else {
+        // Integrated / AMD.  Under Wayland the integrated GPU is already the
+        // default, so nothing to force; under X11 pin the Mesa GLX vendor.
+        if (wayland) {
+            s_appliedSummary = chosen->name + QStringLiteral(" (Wayland default — no override needed)");
+        } else {
+            qputenv("__GLX_VENDOR_LIBRARY_NAME", "mesa");
+            s_appliedSummary = chosen->name + QStringLiteral(" via __GLX_VENDOR_LIBRARY_NAME=mesa (X11/GLX)");
+        }
+    }
+#elif defined(Q_OS_WIN)
+    if (qEnvironmentVariableIsSet("QT_D3D_ADAPTER_INDEX")) {
+        s_appliedSummary = QStringLiteral("'%1' requested, but QT_D3D_ADAPTER_INDEX already set — left as-is")
+                               .arg(chosen->name);
+        return;
+    }
+    if (chosen->id.startsWith(QLatin1String("dxgi:"))) {
+        const QByteArray idx = chosen->id.mid(5).toUtf8();
+        qputenv("QT_D3D_ADAPTER_INDEX", idx);
+        s_appliedSummary = chosen->name + QStringLiteral(" via QT_D3D_ADAPTER_INDEX=") + QString::fromUtf8(idx);
+    }
+#endif
+}
+
+QString GpuSelector::appliedSummary()
+{
+    return s_appliedSummary;
+}
+
+} // namespace AetherSDR

--- a/src/core/GpuSelector.h
+++ b/src/core/GpuSelector.h
@@ -18,6 +18,15 @@ struct GpuInfo {
     QString id;            // stable, platform-specific id (persisted); "auto" = default
     QString name;          // human-readable label for the menu
     bool    discrete{false};
+    // False when the adapter is present but unsafe to select: the Windows
+    // integrated adapter re-triggers the #1921 QRhiWidget-reparenting crash that
+    // the NvOptimusEnablement export exists to avoid.  The menu disables such
+    // entries and applyAtStartup() refuses them (keeping the system default).
+    bool    selectable{true};
+    // True when this adapter's selection path is not yet hardware-soaked (only
+    // the Linux NVIDIA-offload path is validated on real hardware).  The menu
+    // marks these "(experimental)".
+    bool    experimental{false};
 };
 
 class GpuSelector {

--- a/src/core/GpuSelector.h
+++ b/src/core/GpuSelector.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <QString>
+#include <QVector>
+
+namespace AetherSDR {
+
+// Cross-platform GPU enumeration + persisted render-adapter selection.
+//
+// The QRhi render adapter cannot be hot-swapped under a live GL/D3D context, so
+// the choice is applied ONCE at startup — applyAtStartup() runs in main() before
+// QApplication and sets the platform's adapter-selection environment:
+//   • Linux : PRIME offload (__NV_PRIME_RENDER_OFFLOAD / __GLX_VENDOR_LIBRARY_NAME)
+//   • Windows: QT_D3D_ADAPTER_INDEX (honoured by Qt's D3D11/D3D12 RHI backend)
+// The UI persists the choice (AppSettings "Graphics" key, one nested JSON blob —
+// Principle V) and takes effect on the next launch.
+struct GpuInfo {
+    QString id;            // stable, platform-specific id (persisted); "auto" = default
+    QString name;          // human-readable label for the menu
+    bool    discrete{false};
+};
+
+class GpuSelector {
+public:
+    static constexpr const char* kAutoId = "auto";
+
+    // GPUs the system exposes, "Auto (system default)" always first.  Best
+    // effort; a result with a single real GPU means there is nothing to choose.
+    static QVector<GpuInfo> available();
+
+    // True when the system exposes more than one selectable GPU (so the UI
+    // should show the selector).
+    static bool hasMultiple();
+
+    // Persisted choice id (AppSettings "Graphics" → "gpu"); kAutoId when unset.
+    static QString savedChoiceId();
+    static void    saveChoiceId(const QString& id);
+
+    // Called from main() BEFORE QApplication.  Reads the saved choice and sets
+    // the adapter-selection env for the active backend.  No-op for Auto, when
+    // the saved GPU is no longer present, or when the user already set the
+    // relevant environment variable explicitly.
+    static void applyAtStartup();
+
+    // One-line description of what applyAtStartup() did, for logging once the
+    // log handler is up (applyAtStartup itself runs before logging exists).
+    static QString appliedSummary();
+};
+
+} // namespace AetherSDR

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -12,6 +12,7 @@
 
 #include <QPushButton>
 #include <QComboBox>
+#include <QStandardItemModel>
 #include <QSlider>
 #include <QLabel>
 #include <QGridLayout>
@@ -1431,9 +1432,33 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         applyComboStyle(m_gpuCombo);
         const QString savedId = GpuSelector::savedChoiceId();
         for (const GpuInfo& g : GpuSelector::available()) {
-            m_gpuCombo->addItem(g.name, g.id);
-            if (g.id == savedId) {
-                m_gpuCombo->setCurrentIndex(m_gpuCombo->count() - 1);
+            QString label = g.name;
+            if (!g.selectable) {
+                label += "  — disabled (#1921)";
+            } else if (g.experimental) {
+                label += "  (experimental)";
+            }
+            m_gpuCombo->addItem(label, g.id);
+            const int idx = m_gpuCombo->count() - 1;
+            if (!g.selectable) {
+                // Present-but-unsafe (Windows iGPU → #1921): show it greyed so
+                // users understand why the discrete GPU is forced, but block it.
+                if (auto* model = qobject_cast<QStandardItemModel*>(m_gpuCombo->model())) {
+                    if (QStandardItem* item = model->item(idx)) {
+                        item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
+                    }
+                }
+                m_gpuCombo->setItemData(
+                    idx, "Integrated rendering crashes during panadapter "
+                         "reparenting (#1921); the discrete GPU is used instead.",
+                    Qt::ToolTipRole);
+            } else if (g.experimental) {
+                m_gpuCombo->setItemData(
+                    idx, "This adapter-selection path isn't hardware-verified yet.",
+                    Qt::ToolTipRole);
+            }
+            if (g.id == savedId && g.selectable) {
+                m_gpuCombo->setCurrentIndex(idx);
             }
         }
         m_gpuCombo->setToolTip(

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -5,6 +5,7 @@
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "Theme.h"
+#include "core/GpuSelector.h"
 #include "models/SliceModel.h"
 #include "models/BandDefs.h"
 #include "core/AppSettings.h"
@@ -1415,6 +1416,44 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         connect(m_colorSchemeCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
                 this, [this](int idx) { emit wfColorSchemeChanged(idx); });
         ++row;
+    }
+
+    // ── Render GPU (multi-GPU systems only) ───────────────────────────────
+    // The graphics adapter can't be switched under a live context, so the
+    // choice is persisted and applied on the next launch (GpuSelector reads it
+    // before QApplication).  Hidden entirely on single-GPU systems.
+    if (GpuSelector::hasMultiple()) {
+        auto* lbl = new QLabel("GPU:");
+        lbl->setStyleSheet(labelStyle);
+        grid->addWidget(lbl, row, 0);
+        m_gpuCombo = new QComboBox;
+        m_gpuCombo->setFixedHeight(18);
+        applyComboStyle(m_gpuCombo);
+        const QString savedId = GpuSelector::savedChoiceId();
+        for (const GpuInfo& g : GpuSelector::available()) {
+            m_gpuCombo->addItem(g.name, g.id);
+            if (g.id == savedId) {
+                m_gpuCombo->setCurrentIndex(m_gpuCombo->count() - 1);
+            }
+        }
+        m_gpuCombo->setToolTip(
+            "Render GPU for the spectrum/waterfall. Takes effect on the next "
+            "launch — the graphics adapter can't be switched while running.");
+        grid->addWidget(m_gpuCombo, row, 1, 1, 3);
+        ++row;
+
+        auto* gpuNote = new QLabel("Restart to apply");
+        gpuNote->setStyleSheet("QLabel { color: #6a7a8a; font-size: 9px; border: none; }");
+        gpuNote->setVisible(false);
+        grid->addWidget(gpuNote, row, 1, 1, 3);
+        ++row;
+
+        connect(m_gpuCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this, gpuNote](int idx) {
+            if (!m_gpuCombo) return;
+            GpuSelector::saveChoiceId(m_gpuCombo->itemData(idx).toString());
+            gpuNote->setVisible(true);   // surface the restart requirement once changed
+        });
     }
 
     // ── Reset button ──────────────────────────────────────────────────────

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -259,6 +259,7 @@ private:
     int          m_blackManualValue{15};
     int          m_blackAutoOffsetValue{50};
     QComboBox*   m_colorSchemeCmb{nullptr};
+    QComboBox*   m_gpuCombo{nullptr};   // render-GPU selector (multi-GPU only)
     QSlider*     m_rateSlider{nullptr};
     QLabel*      m_rateLabel{nullptr};
     // NB Waterfall Blanker (#277)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "gui/MainWindow.h"
 #include "gui/SliceColorManager.h"
 #include "core/AppSettings.h"
+#include "core/GpuSelector.h"
 #include "core/LogManager.h"
 #include "core/MacMicPermission.h"
 
@@ -83,6 +84,11 @@ int main(int argc, char* argv[])
     if (qEnvironmentVariableIsSet("AETHER_NO_GPU")) {
         qputenv("QT_OPENGL", "software");
     }
+
+    // Render-adapter selection on multi-GPU systems.  Must run before the GL/D3D
+    // context is created (i.e. before QApplication): sets PRIME offload (Linux)
+    // or QT_D3D_ADAPTER_INDEX (Windows) from the persisted Display-menu choice.
+    AetherSDR::GpuSelector::applyAtStartup();
 
     // Prefer native Wayland when running under a Wayland session (#1233).
     // Without this, Qt may fall back to XWayland (xcb platform) where GLX
@@ -352,6 +358,11 @@ int main(int argc, char* argv[])
     auto& logManager = AetherSDR::LogManager::instance();
     if (logManager.startLogging(logPath, stderrIsTty)) {
         qInstallMessageHandler(messageHandler);
+
+        // Record the GPU-selection decision now the log handler exists
+        // (GpuSelector::applyAtStartup() ran before logging was available).
+        qInfo().noquote() << "GpuSelector: render GPU ->"
+                          << AetherSDR::GpuSelector::appliedSummary();
 
         // Symlink aethersdr.log → latest timestamped file (for Support dialog)
         const QString symlink = logDir + "/aethersdr.log";


### PR DESCRIPTION
## Summary

Adds a **render-GPU selector** to the panadapter Display menu so users on multi-GPU systems can choose which adapter the QRhi spectrum/waterfall renders on. The dropdown appears **only when more than one GPU is present**. Because the graphics adapter can't be hot-swapped under a live render context, the choice is **persisted and applied on the next launch** (with a "Restart to apply" note).

Motivation: on a hybrid laptop (Intel iGPU + NVIDIA dGPU) AetherSDR defaulted to the integrated GPU under Wayland, with no in-app way to move the flagship GPU render path to the discrete card.

## How it works

`GpuSelector::applyAtStartup()` runs in `main()` **before `QApplication`** (the adapter env must be set before the GL/D3D context is created) and sets the right lever per windowing system:

| Platform | Mechanism |
|---|---|
| **Linux / Wayland (EGL)** | `__NV_PRIME_RENDER_OFFLOAD=1` (+ `__VK_LAYER_NV_optimus`); **no** GLX vars |
| **Linux / X11 + XWayland (GLX)** | `__NV_PRIME_RENDER_OFFLOAD=1` + `__GLX_VENDOR_LIBRARY_NAME` |
| **Windows (D3D11/D3D12 RHI)** | `QT_D3D_ADAPTER_INDEX` |

It honours an explicit user env override (won't clobber a hand-set `__NV_PRIME_RENDER_OFFLOAD` / `QT_D3D_ADAPTER_INDEX`), no-ops on "Auto" or a missing GPU, and logs the decision once the log handler is up.

GPU enumeration:
- **Linux** — DRM sysfs (`/sys/class/drm/card*/device` vendor id + `boot_vga`), stable PCI-address ids.
- **Windows** — DXGI `EnumAdapters1` (adapter index → `QT_D3D_ADAPTER_INDEX`, skips the software/WARP adapter).

The choice persists as one nested-JSON `Graphics` key via `AppSettings` (Principle V).

## Files

- `src/core/GpuSelector.{h,cpp}` (new) — enumeration, persistence, startup apply.
- `src/main.cpp` — load settings + `applyAtStartup()` before `QApplication`; log the decision.
- `src/gui/SpectrumOverlayMenu.{h,cpp}` — the Display-menu dropdown + restart note.
- `CMakeLists.txt` — register the source; link `dxgi` on Windows.

## Test plan

- [x] Local build (Linux, GPU=ON, Ninja) — links clean.
- [x] **Verified on a hybrid Intel iGPU + NVIDIA RTX 4090 laptop under native Wayland:** selecting **NVIDIA (discrete)** moves the render context to the dGPU — process opens `renderD128` (the NVIDIA node) and `nvidia-smi` lists AetherSDR as a graphics process (~226 MiB). Selecting **Auto/Integrated** returns to the iGPU.
- [x] Persistence round-trips; selector hidden on single-GPU systems.
- [ ] **Windows path not yet tested on hardware** — it's compile-guarded (`#ifdef Q_OS_WIN`) so CI builds it, but the `QT_D3D_ADAPTER_INDEX` runtime behaviour needs a Windows tester before merge.
- [ ] Existing tests pass (CI).

## Notes for reviewers

- **RFC gate (Constitution v2.0.0):** this is a new user-facing feature; flagging that it likely wants an RFC before merge.
- **No live switching by design** — the adapter is fixed at context creation, so the UX is persist-and-restart, not instant. This matches how the underlying graphics stack works.
- **Cross-platform:** GPU selection is inherently platform-specific (PRIME/EGL on Linux, DXGI/`QT_D3D_ADAPTER_INDEX` on Windows); the UI, persistence, and enumeration are structured uniformly with per-platform apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
