### PR TITLE
feat(memory): sanitize NULs, add field dropdowns, and smoother editing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,6 +596,7 @@ set(CORE_SOURCES
     src/core/DxccColorProvider.cpp
     src/core/SleepInhibitor.cpp
     src/core/MemoryCsvCompat.cpp
+    src/core/MemoryFieldValues.cpp
     src/core/MemoryRecallPolicy.cpp
     src/core/WfmDemodulator.cpp
     src/core/WfmDsp.cpp
@@ -2240,6 +2241,15 @@ add_executable(memory_recall_policy_test
 )
 target_include_directories(memory_recall_policy_test PRIVATE src)
 target_link_libraries(memory_recall_policy_test PRIVATE Qt6::Core)
+add_test(NAME memory_recall_policy_test COMMAND memory_recall_policy_test)
+
+add_executable(memory_field_values_test
+    tests/memory_field_values_test.cpp
+    src/core/MemoryFieldValues.cpp
+)
+target_include_directories(memory_field_values_test PRIVATE src)
+target_link_libraries(memory_field_values_test PRIVATE Qt6::Core)
+add_test(NAME memory_field_values_test COMMAND memory_field_values_test)
 
 add_executable(transmit_model_apd_test
     tests/transmit_model_apd_test.cpp

--- a/src/core/MemoryCsvCompat.cpp
+++ b/src/core/MemoryCsvCompat.cpp
@@ -1,8 +1,13 @@
 #include "MemoryCsvCompat.h"
 
+#include "MemoryFieldValues.h"
+
+#include <QLoggingCategory>
 #include <QRegularExpression>
 
 #include <algorithm>
+
+Q_LOGGING_CATEGORY(lcMemoryCsv, "aether.memory.csv")
 
 namespace AetherSDR {
 
@@ -217,11 +222,11 @@ QStringList recordToFields(const MemoryCsvRecord& record)
     const MemoryEntry& memory = record.memory;
     return {
         "MEMORY",
-        memory.owner,
-        memory.group,
+        MemoryFields::sanitizeText(memory.owner),
+        MemoryFields::sanitizeText(memory.group),
         formatFrequency(memory.freq),
-        memory.name,
-        memory.mode.trimmed().toUpper(),
+        MemoryFields::sanitizeText(memory.name),
+        MemoryFields::sanitizeText(memory.mode).trimmed().toUpper(),
         formatInt(memory.step),
         formatOffsetDirection(memory.offsetDir),
         formatDouble(memory.repeaterOffset, 1),
@@ -273,10 +278,16 @@ bool parseRecord(const QStringList& fields,
     }
 
     MemoryEntry memory;
-    memory.owner = normalizedFields.at(1).trimmed();
-    memory.group = normalizedFields.at(2).trimmed();
-    memory.name = normalizedFields.at(4).trimmed();
-    memory.mode = normalizedFields.at(5).trimmed().toUpper();
+    // Strip NUL/control bytes from every free-text field on the way in so a
+    // corrupt CSV (or one another program wrote) can't seed bad memories.
+    memory.owner = MemoryFields::sanitizeText(normalizedFields.at(1)).trimmed();
+    memory.group = MemoryFields::sanitizeText(normalizedFields.at(2)).trimmed();
+    memory.name = MemoryFields::sanitizeText(normalizedFields.at(4)).trimmed();
+    memory.mode = MemoryFields::sanitizeText(normalizedFields.at(5)).trimmed().toUpper();
+    if (!memory.mode.isEmpty() && !MemoryFields::isKnownMode(memory.mode)) {
+        qCInfo(lcMemoryCsv) << rowLabel << "imported with unrecognized mode"
+                            << memory.mode << "- passing through to radio for validation";
+    }
 
     if (!parseDoubleField(normalizedFields.at(3), memory.freq) || !validateRange(memory.freq, 0.0, 10000.0)) {
         error = QString("%1: invalid frequency '%2'.").arg(rowLabel).arg(normalizedFields.at(3));

--- a/src/core/MemoryFieldValues.cpp
+++ b/src/core/MemoryFieldValues.cpp
@@ -1,0 +1,108 @@
+#include "MemoryFieldValues.h"
+
+namespace AetherSDR::MemoryFields {
+
+QString sanitizeText(const QString& in)
+{
+    QString out;
+    out.reserve(in.size());
+    for (const QChar ch : in) {
+        const char16_t u = ch.unicode();
+        // Drop C0 control chars (incl. NUL, TAB, CR, LF) and the DEL byte that
+        // the protocol reserves as the space encoding.
+        if (u < 0x20 || u == 0x7f)
+            continue;
+        out.append(ch);
+    }
+    return out;
+}
+
+const QStringList& modes()
+{
+    static const QStringList kModes = {
+        "USB", "LSB", "CW", "AM", "SAM", "DSB",
+        "FM", "NFM", "DFM", "DIGU", "DIGL", "RTTY",
+        "FDV", "DSTR", "AME"
+    };
+    return kModes;
+}
+
+const QStringList& offsetDirectionsDisplay()
+{
+    static const QStringList kDirs = { "SIMPLEX", "UP", "DOWN" };
+    return kDirs;
+}
+
+const QStringList& toneModesDisplay()
+{
+    static const QStringList kModes = { "OFF", "CTCSS_TX" };
+    return kModes;
+}
+
+const QStringList& ctcssTones()
+{
+    static const QStringList kTones = {
+        "67.0",  "69.3",  "71.9",  "74.4",  "77.0",  "79.7",  "82.5",  "85.4",
+        "88.5",  "91.5",  "94.8",  "97.4",  "100.0", "103.5", "107.2", "110.9",
+        "114.8", "118.8", "123.0", "127.3", "131.8", "136.5", "141.3", "146.2",
+        "151.4", "156.7", "159.8", "162.2", "165.5", "167.9", "171.3", "173.8",
+        "177.3", "179.9", "183.5", "186.2", "189.9", "192.8", "196.6", "199.5",
+        "203.5", "206.5", "210.7", "218.1", "225.7", "229.1", "233.6", "241.8",
+        "250.3", "254.1"
+    };
+    return kTones;
+}
+
+const QStringList& tuningSteps()
+{
+    static const QStringList kSteps = {
+        "10", "100", "500", "1000", "2500", "5000",
+        "6250", "9000", "10000", "12500", "25000", "50000", "100000"
+    };
+    return kSteps;
+}
+
+bool isKnownMode(const QString& mode)
+{
+    const QString upper = sanitizeText(mode).trimmed().toUpper();
+    return modes().contains(upper);
+}
+
+QString offsetDirToWire(const QString& any)
+{
+    const QString upper = sanitizeText(any).trimmed().toUpper();
+    if (upper == "UP")      return "up";
+    if (upper == "DOWN")    return "down";
+    if (upper == "SIMPLEX") return "simplex";
+    return {};
+}
+
+QString offsetDirToDisplay(const QString& any)
+{
+    const QString upper = sanitizeText(any).trimmed().toUpper();
+    if (upper == "UP")   return "UP";
+    if (upper == "DOWN") return "DOWN";
+    return "SIMPLEX";
+}
+
+QString toneModeToWire(const QString& any)
+{
+    const QString upper = sanitizeText(any).trimmed().toUpper();
+    if (upper == "OFF")      return "off";
+    if (upper == "CTCSS_TX") return "ctcss_tx";
+    return {};
+}
+
+QString toneModeToDisplay(const QString& any)
+{
+    const QString upper = sanitizeText(any).trimmed().toUpper();
+    if (upper == "CTCSS_TX") return "CTCSS_TX";
+    return "OFF";
+}
+
+QString modeToWire(const QString& any)
+{
+    return sanitizeText(any).trimmed().toUpper();
+}
+
+} // namespace AetherSDR::MemoryFields

--- a/src/core/MemoryFieldValues.h
+++ b/src/core/MemoryFieldValues.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+// Canonical value lists and text sanitization for memory-channel fields.
+//
+// These mirror the constrained value sets FlexLib uses for slices and
+// memories (see FlexLib Slice.cs / Memory.cs):
+//   - demod modes:  Slice.cs filter switch-statements
+//   - FMTXOffsetDirection enum:  simplex / up / down
+//   - FMToneMode enum:  off / ctcss_tx  (ctcss_txrx is reserved, not exposed)
+//
+// Everything here is wire-agnostic at the type level: the *display* form is
+// upper-case (what the operator reads/picks), the *wire* form matches what the
+// radio expects (modes upper-case, offset/tone lower-case). Helpers convert
+// between the two so the GUI, the radio I/O path, and CSV all agree.
+namespace AetherSDR::MemoryFields {
+
+// Strip characters that corrupt the radio protocol and downstream tooling:
+// all C0 control characters (0x00-0x1F, including the NUL bytes that have been
+// observed in imported/hand-entered Mode fields) and the lone DEL byte (0x7f),
+// which the protocol reserves as the on-the-wire encoding for a space. Callers
+// that need a literal space preserved must decode 0x7f -> ' ' before calling.
+QString sanitizeText(const QString& in);
+
+// Canonical demodulation modes the FlexRadio supports, in operator-friendly
+// order. Upper-case is both the display and the wire form for modes.
+const QStringList& modes();
+
+// FM repeater TX offset directions, display (upper-case) form.
+const QStringList& offsetDirectionsDisplay();
+
+// FM tone modes, display (upper-case) form.
+const QStringList& toneModesDisplay();
+
+// Standard EIA CTCSS tone frequencies as "%.1f" strings (e.g. "88.5").
+const QStringList& ctcssTones();
+
+// Common tuning-step suggestions in Hz, as strings.
+const QStringList& tuningSteps();
+
+// True if `mode` (compared case-insensitively) is one the radio supports.
+bool isKnownMode(const QString& mode);
+
+// Offset direction: any-case in -> canonical lower-case wire form
+// ("simplex"/"up"/"down"); empty if unrecognized.
+QString offsetDirToWire(const QString& any);
+// Offset direction: any-case in -> upper-case display form; defaults to
+// "SIMPLEX" when unrecognized.
+QString offsetDirToDisplay(const QString& any);
+
+// Tone mode: any-case in -> lower-case wire form ("off"/"ctcss_tx"); empty if
+// unrecognized.
+QString toneModeToWire(const QString& any);
+// Tone mode: any-case in -> upper-case display form; defaults to "OFF".
+QString toneModeToDisplay(const QString& any);
+
+// Mode: sanitize and upper-case (the wire form). Does not validate membership.
+QString modeToWire(const QString& any);
+
+} // namespace AetherSDR::MemoryFields

--- a/src/gui/MemoryCommands.cpp
+++ b/src/gui/MemoryCommands.cpp
@@ -1,5 +1,6 @@
 #include "MemoryCommands.h"
 
+#include "core/MemoryFieldValues.h"
 #include "models/SliceModel.h"
 
 #include <QPointer>
@@ -8,7 +9,10 @@ namespace AetherSDR {
 
 QString encodeMemoryText(const QString& value)
 {
-    return QString(value).replace(' ', QChar(0x7f));
+    // Strip NUL/control bytes first, then apply the protocol space-encoding so
+    // a hand-entered or imported value can never push a raw control byte (which
+    // breaks the radio and other SmartSDR-compatible software) onto the wire.
+    return MemoryFields::sanitizeText(value).replace(' ', QChar(0x7f));
 }
 
 MemoryEntry captureMemoryFromSlice(const RadioModel& model,
@@ -52,11 +56,11 @@ MemoryUpdateData buildMemoryUpdateData(const MemoryEntry& memory)
     appendField("owner", encodeMemoryText(memory.owner));
     appendField("freq", QString::number(memory.freq, 'f', 6));
     appendField("name", encodeMemoryText(memory.name));
-    appendField("mode", memory.mode);
+    appendField("mode", MemoryFields::modeToWire(memory.mode));
     appendField("step", QString::number(memory.step));
-    appendField("repeater", memory.offsetDir);
+    appendField("repeater", MemoryFields::offsetDirToWire(memory.offsetDir));
     appendField("repeater_offset", QString::number(memory.repeaterOffset, 'f', 6));
-    appendField("tone_mode", memory.toneMode);
+    appendField("tone_mode", MemoryFields::toneModeToWire(memory.toneMode));
     appendField("tone_value", QString::number(memory.toneValue, 'f', 1));
     appendField("squelch", memory.squelch ? "1" : "0");
     appendField("squelch_level", QString::number(memory.squelchLevel));

--- a/src/gui/MemoryDialog.cpp
+++ b/src/gui/MemoryDialog.cpp
@@ -1,6 +1,7 @@
 #include "MemoryDialog.h"
 #include "MemoryCommands.h"
 #include "core/MemoryCsvCompat.h"
+#include "core/MemoryFieldValues.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
@@ -16,6 +17,9 @@
 #include <QHBoxLayout>
 #include <QPushButton>
 #include <QComboBox>
+#include <QStyledItemDelegate>
+#include <QIntValidator>
+#include <QDoubleValidator>
 #include <QLineEdit>
 #include <QLabel>
 #include <QHeaderView>
@@ -54,6 +58,90 @@ public:
     }
 };
 
+// Combo-box editor for constrained memory fields (Mode, Offset Dir, Tone Mode,
+// Tone Value, Step, Group). For strict fields the combo is locked to the known
+// values; editable fields seed common values but still accept typed input
+// (validated by the radio on commit). The list pops open immediately so picking
+// a value is effectively one click once the cell is being edited.
+class MemoryFieldDelegate : public QStyledItemDelegate {
+public:
+    enum class Validator { None, Int, Double };
+
+    MemoryFieldDelegate(std::function<QStringList()> provider,
+                        bool editable,
+                        Validator validator,
+                        QObject* parent)
+        : QStyledItemDelegate(parent),
+          m_provider(std::move(provider)),
+          m_editable(editable),
+          m_validator(validator)
+    {
+    }
+
+    QWidget* createEditor(QWidget* parent,
+                          const QStyleOptionViewItem& /*option*/,
+                          const QModelIndex& /*index*/) const override
+    {
+        auto* combo = new QComboBox(parent);
+        combo->setEditable(m_editable);
+        combo->setInsertPolicy(QComboBox::NoInsert);
+        if (m_provider)
+            combo->addItems(m_provider());
+        if (m_editable && m_validator == Validator::Int) {
+            combo->setValidator(new QIntValidator(combo));
+        } else if (m_editable && m_validator == Validator::Double) {
+            auto* dv = new QDoubleValidator(combo);
+            dv->setNotation(QDoubleValidator::StandardNotation);
+            dv->setLocale(QLocale::c());
+            combo->setValidator(dv);
+        }
+        // Drop the list open right away so it reads as a one-click pick.
+        QTimer::singleShot(0, combo, [combo]() {
+            if (combo)
+                combo->showPopup();
+        });
+        return combo;
+    }
+
+    void setEditorData(QWidget* editor, const QModelIndex& index) const override
+    {
+        auto* combo = qobject_cast<QComboBox*>(editor);
+        if (!combo) {
+            QStyledItemDelegate::setEditorData(editor, index);
+            return;
+        }
+        const QString value = index.data(Qt::EditRole).toString();
+        const int found = combo->findText(value, Qt::MatchFixedString);
+        if (found >= 0)
+            combo->setCurrentIndex(found);
+        else if (m_editable)
+            combo->setEditText(value);
+        else {
+            // Preserve an out-of-list value (e.g. a legacy/corrupt mode) so the
+            // operator can see it rather than having it silently swapped.
+            combo->insertItem(0, value);
+            combo->setCurrentIndex(0);
+        }
+    }
+
+    void setModelData(QWidget* editor,
+                      QAbstractItemModel* model,
+                      const QModelIndex& index) const override
+    {
+        auto* combo = qobject_cast<QComboBox*>(editor);
+        if (!combo) {
+            QStyledItemDelegate::setModelData(editor, model, index);
+            return;
+        }
+        model->setData(index, combo->currentText().trimmed(), Qt::EditRole);
+    }
+
+private:
+    std::function<QStringList()> m_provider;
+    bool m_editable;
+    Validator m_validator;
+};
+
 bool buildMemoryFieldUpdate(int col, const QTableWidgetItem* item,
                             QString& commandSuffix, QMap<QString, QString>& kvs)
 {
@@ -84,26 +172,32 @@ bool buildMemoryFieldUpdate(int col, const QTableWidgetItem* item,
         kvs["name"] = encoded;
         return true;
     }
-    case 4:
-        commandSuffix = "mode=" + value;
-        kvs["mode"] = value;
+    case 4: {
+        const QString mode = MemoryFields::modeToWire(value);
+        commandSuffix = "mode=" + mode;
+        kvs["mode"] = mode;
         return true;
+    }
     case 5:
         commandSuffix = "step=" + value;
         kvs["step"] = value;
         return true;
-    case 6:
-        commandSuffix = "repeater=" + value;
-        kvs["repeater"] = value;
+    case 6: {
+        const QString dir = MemoryFields::offsetDirToWire(value);
+        commandSuffix = "repeater=" + dir;
+        kvs["repeater"] = dir;
         return true;
+    }
     case 7:
         commandSuffix = "repeater_offset=" + value;
         kvs["repeater_offset"] = value;
         return true;
-    case 8:
-        commandSuffix = "tone_mode=" + value;
-        kvs["tone_mode"] = value;
+    case 8: {
+        const QString toneMode = MemoryFields::toneModeToWire(value);
+        commandSuffix = "tone_mode=" + toneMode;
+        kvs["tone_mode"] = toneMode;
         return true;
+    }
     case 9:
         commandSuffix = "tone_value=" + value;
         kvs["tone_value"] = value;
@@ -178,9 +272,9 @@ QList<MemoryCsvRecord> currentExportRecords(const QMap<int, MemoryEntry>& memori
 QString selectionHintText()
 {
 #if defined(Q_OS_MACOS)
-    return "Tip: Double-click tunes. Shift-click selects a range. Command-click adds or removes rows.";
+    return "Tip: Double-click tunes. Click a selected cell (or F2) to edit; Tab moves between fields. Shift-click selects a range; Command-click adds or removes rows.";
 #else
-    return "Tip: Double-click tunes. Shift-click selects a range. Ctrl-click adds or removes rows.";
+    return "Tip: Double-click tunes. Click a selected cell (or F2) to edit; Tab moves between fields. Shift-click selects a range; Ctrl-click adds or removes rows.";
 #endif
 }
 
@@ -216,7 +310,7 @@ QString formatImportIssue(const QString& rowLabel,
 
 static const QStringList COLUMNS = {
     "Group", "Owner", "Frequency", "Name", "Mode", "Step",
-    "FM TX Offset Dir", "Repeater Offset", "Tone Mode", "Tone Value",
+    "Offset Dir", "Repeater Offset", "Tone Mode", "Tone Value",
     "Squelch", "Squelch Level", "RX Filter Low", "RX Filter High",
     "RTTY Mark", "RTTY Shift", "DIGL Offset", "DIGU Offset"
 };
@@ -258,7 +352,13 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     m_table->setHorizontalHeaderLabels(COLUMNS);
     m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_table->setSelectionMode(QAbstractItemView::ExtendedSelection);
-    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    // Cells edit in place: click a selected cell, press F2/Enter on the keyboard
+    // focus, or just start typing. Double-click stays reserved for "tune", so it
+    // is deliberately not an edit trigger.
+    m_table->setEditTriggers(QAbstractItemView::SelectedClicked
+                             | QAbstractItemView::EditKeyPressed
+                             | QAbstractItemView::AnyKeyPressed);
+    m_table->setTabKeyNavigation(true);
     m_table->horizontalHeader()->setStretchLastSection(true);
     m_table->verticalHeader()->setVisible(false);
     m_table->setAlternatingRowColors(true);
@@ -284,6 +384,42 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
         header->setSortIndicator(m_sortColumn, m_sortOrder);
         m_table->sortItems(m_sortColumn, m_sortOrder);
     });
+
+    // One-click dropdowns for the constrained columns. Strict lists for Mode,
+    // Offset Dir and Tone Mode; editable (type-or-pick) lists for Step, Tone
+    // Value and Group, which seed common values but still accept free input.
+    using Validator = MemoryFieldDelegate::Validator;
+    auto staticList = [](const QStringList& values) {
+        return [values]() { return values; };
+    };
+    m_table->setItemDelegateForColumn(0, new MemoryFieldDelegate(
+        [this]() {
+            QStringList groups;
+            for (const auto& m : m_model->memories()) {
+                const QString g = m.group.trimmed();
+                if (!g.isEmpty() && !groups.contains(g))
+                    groups << g;
+            }
+            for (const QString& p : m_model->globalProfiles())
+                if (!p.isEmpty() && !groups.contains(p))
+                    groups << p;
+            for (const QString& p : m_model->transmitModel().profileList())
+                if (!p.isEmpty() && !groups.contains(p))
+                    groups << p;
+            groups.sort(Qt::CaseInsensitive);
+            return groups;
+        }, true, Validator::None, this));
+    m_table->setItemDelegateForColumn(4, new MemoryFieldDelegate(
+        staticList(MemoryFields::modes()), false, Validator::None, this));
+    m_table->setItemDelegateForColumn(5, new MemoryFieldDelegate(
+        staticList(MemoryFields::tuningSteps()), true, Validator::Int, this));
+    m_table->setItemDelegateForColumn(6, new MemoryFieldDelegate(
+        staticList(MemoryFields::offsetDirectionsDisplay()), false, Validator::None, this));
+    m_table->setItemDelegateForColumn(8, new MemoryFieldDelegate(
+        staticList(MemoryFields::toneModesDisplay()), false, Validator::None, this));
+    m_table->setItemDelegateForColumn(9, new MemoryFieldDelegate(
+        staticList(MemoryFields::ctcssTones()), true, Validator::Double, this));
+
     root->addWidget(m_table);
     root->addWidget(new QLabel(selectionHintText()));
 
@@ -293,12 +429,10 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     auto* exportBtn = new QPushButton("Export...");
     auto* addBtn = new QPushButton("Add");
     m_selectionLabel = new QLabel("0 selected");
-    m_editBtn = new QPushButton("Edit");
     m_selectBtn = new QPushButton("Tune");
     m_selectAllBtn = new QPushButton("Select All");
     m_removeBtn = new QPushButton("Remove");
     btnRow->addWidget(addBtn);
-    btnRow->addWidget(m_editBtn);
     btnRow->addWidget(m_selectBtn);
     btnRow->addWidget(m_selectAllBtn);
     btnRow->addWidget(importBtn);
@@ -308,7 +442,7 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     btnRow->addWidget(m_removeBtn);
     root->addLayout(btnRow);
 
-    for (QPushButton* button : {addBtn, m_editBtn, m_selectBtn, m_selectAllBtn, importBtn, exportBtn, m_removeBtn}) {
+    for (QPushButton* button : {addBtn, m_selectBtn, m_selectAllBtn, importBtn, exportBtn, m_removeBtn}) {
         button->setAutoDefault(false);
         button->setDefault(false);
     }
@@ -316,7 +450,6 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
     connect(importBtn, &QPushButton::clicked, this, &MemoryDialog::onImport);
     connect(exportBtn, &QPushButton::clicked, this, &MemoryDialog::onExport);
     connect(addBtn, &QPushButton::clicked, this, &MemoryDialog::onAdd);
-    connect(m_editBtn, &QPushButton::clicked, this, &MemoryDialog::onEdit);
     connect(m_selectBtn, &QPushButton::clicked, this, &MemoryDialog::onSelect);
     connect(m_selectAllBtn, &QPushButton::clicked, this, &MemoryDialog::onSelectAll);
     connect(m_removeBtn, &QPushButton::clicked, this, &MemoryDialog::onRemove);
@@ -335,8 +468,8 @@ MemoryDialog::MemoryDialog(RadioModel* model, QWidget* parent)
         m_searchEdit->selectAll();
     });
     new QShortcut(QKeySequence::New, this, [this]() { onAdd(); });
-    new QShortcut(QKeySequence(Qt::Key_F2), this, [this]() { onEdit(); });
-    new QShortcut(QKeySequence(QStringLiteral("Ctrl+E")), this, [this]() { onEdit(); });
+    new QShortcut(QKeySequence(Qt::Key_F2), this, [this]() { editCurrentCell(); });
+    new QShortcut(QKeySequence(QStringLiteral("Ctrl+E")), this, [this]() { editCurrentCell(); });
     new QShortcut(QKeySequence(QStringLiteral("Ctrl+Shift+A")), this, [this]() { onSelectAll(); });
 
     // Rebuild filter combo when profile lists change
@@ -480,7 +613,6 @@ void MemoryDialog::activateMemoryRow(int row)
     if (m_model->memories().constFind(idx) == m_model->memories().constEnd())
         return;
 
-    setInlineEditMode(false);
     m_table->setCurrentCell(row, 0);
     focusTableOnCurrentRow();
     emit memoryActivated(idx);
@@ -504,7 +636,6 @@ void MemoryDialog::beginEditingMemoryName(int memoryIndex)
                 m_table->model()->index(row, 0),
                 QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
         }
-        setInlineEditMode(true);
         m_table->setCurrentCell(row, 3, QItemSelectionModel::NoUpdate);
         m_table->scrollToItem(nameItem, QAbstractItemView::PositionAtCenter);
         m_table->setFocus(Qt::OtherFocusReason);
@@ -522,17 +653,6 @@ void MemoryDialog::focusTableOnCurrentRow()
     if (m_table->currentRow() < 0 && m_table->rowCount() > 0)
         m_table->setCurrentCell(0, 0, QItemSelectionModel::NoUpdate);
     m_table->setFocus(Qt::OtherFocusReason);
-}
-
-void MemoryDialog::setInlineEditMode(bool enabled)
-{
-    m_inlineEditMode = enabled;
-    if (!m_table)
-        return;
-
-    m_table->setEditTriggers(enabled
-        ? (QAbstractItemView::SelectedClicked | QAbstractItemView::EditKeyPressed)
-        : QAbstractItemView::NoEditTriggers);
 }
 
 void MemoryDialog::populateTable()
@@ -574,10 +694,12 @@ void MemoryDialog::populateTable()
         m_table->setItem(row, col++, new QTableWidgetItem(m.mode));
         m_table->setItem(row, col++, new QTableWidgetItem(
             QString::number(m.step)));
-        m_table->setItem(row, col++, new QTableWidgetItem(m.offsetDir));
+        m_table->setItem(row, col++, new QTableWidgetItem(
+            MemoryFields::offsetDirToDisplay(m.offsetDir)));
         m_table->setItem(row, col++, new QTableWidgetItem(
             QString::number(m.repeaterOffset, 'f', 1)));
-        m_table->setItem(row, col++, new QTableWidgetItem(m.toneMode));
+        m_table->setItem(row, col++, new QTableWidgetItem(
+            MemoryFields::toneModeToDisplay(m.toneMode)));
         m_table->setItem(row, col++, new QTableWidgetItem(
             QString::number(m.toneValue, 'f', 1)));
 
@@ -614,9 +736,35 @@ void MemoryDialog::populateTable()
     }
 
     m_table->resizeColumnsToContents();
-    m_table->setColumnWidth(2, std::max(m_table->columnWidth(2), 105));
-    const int minNameWidth = fontMetrics().horizontalAdvance(QString(20, QChar('M')));
-    m_table->setColumnWidth(3, std::max(m_table->columnWidth(3), minNameWidth));
+    // resizeColumnsToContents is a couple of pixels too tight on macOS — short
+    // values like "CW" elide to a single character — and it leaves the headers
+    // cramped. Pad every column for breathing room (idempotent: the resize above
+    // recomputes from content each time, so padding never accumulates).
+    constexpr int kColumnPadding = 18;
+    for (int c = 0; c < m_table->columnCount(); ++c)
+        m_table->setColumnWidth(c, m_table->columnWidth(c) + kColumnPadding);
+
+    // Measure with the TABLE's font (the theme may scale it larger than the
+    // dialog's) so a dropdown column always fits its widest possible value plus
+    // the cell margins and the combo arrow shown while editing.
+    const QFontMetrics fm = m_table->fontMetrics();
+    auto floorWidth = [this](int col, int minPx) {
+        m_table->setColumnWidth(col, std::max(m_table->columnWidth(col), minPx));
+    };
+    auto floorForValues = [&](int col, const QStringList& values) {
+        int widest = m_table->horizontalHeaderItem(col)
+            ? fm.horizontalAdvance(m_table->horizontalHeaderItem(col)->text()) : 0;
+        for (const QString& v : values)
+            widest = std::max(widest, fm.horizontalAdvance(v));
+        floorWidth(col, widest + 34); // margins + combo arrow + slack
+    };
+    floorWidth(2, 110);                                          // Frequency
+    floorWidth(3, fm.horizontalAdvance(QString(20, QChar('M')))); // Name
+    floorForValues(4, MemoryFields::modes());                    // Mode
+    floorForValues(5, MemoryFields::tuningSteps());              // Step
+    floorForValues(6, MemoryFields::offsetDirectionsDisplay());  // Offset Dir
+    floorForValues(8, MemoryFields::toneModesDisplay());         // Tone Mode
+    floorForValues(9, MemoryFields::ctcssTones());               // Tone Value
     if (isSortableColumn(m_sortColumn)) {
         auto* header = m_table->horizontalHeader();
         header->setSortIndicatorShown(true);
@@ -994,16 +1142,19 @@ void MemoryDialog::onSelect()
     activateMemoryRow(m_table->currentRow());
 }
 
-void MemoryDialog::onEdit()
+void MemoryDialog::editCurrentCell()
 {
-    if (!m_table || selectedMemoryIndices().size() != 1)
+    if (!m_table)
         return;
 
-    auto* indexItem = m_table->item(m_table->currentRow(), 0);
-    if (!indexItem)
-        return;
-
-    beginEditingMemoryName(indexItem->data(Qt::UserRole).toInt());
+    const QModelIndex current = m_table->currentIndex();
+    if (!current.isValid()) {
+        if (m_table->rowCount() <= 0)
+            return;
+        m_table->setCurrentCell(0, 0);
+    }
+    if (auto* item = m_table->currentItem())
+        m_table->editItem(item);
 }
 
 void MemoryDialog::onSelectAll()
@@ -1011,7 +1162,6 @@ void MemoryDialog::onSelectAll()
     if (!m_table || m_table->rowCount() <= 0)
         return;
 
-    setInlineEditMode(false);
     m_table->selectAll();
     if (m_table->currentRow() < 0)
         m_table->setCurrentCell(0, 0, QItemSelectionModel::NoUpdate);
@@ -1025,7 +1175,6 @@ void MemoryDialog::onRemove()
     if (selectedIndices.isEmpty())
         return;
 
-    setInlineEditMode(false);
     QList<int> indices = selectedIndices.values();
     std::sort(indices.begin(), indices.end());
 
@@ -1206,16 +1355,8 @@ void MemoryDialog::updateSelectionActions()
 {
     const int selectedCount = selectedMemoryIndices().size();
     const int visibleCount = m_table ? m_table->rowCount() : 0;
-    if (selectedCount != 1 && m_inlineEditMode)
-        setInlineEditMode(false);
     if (m_selectionLabel) {
         m_selectionLabel->setText(QString("%1 of %2 selected").arg(selectedCount).arg(visibleCount));
-    }
-    if (m_editBtn) {
-        m_editBtn->setEnabled(selectedCount == 1);
-        m_editBtn->setToolTip(selectedCount == 1
-            ? "Edit the highlighted memory fields."
-            : "Edit is available when exactly one memory is highlighted.");
     }
     if (m_selectBtn) {
         m_selectBtn->setEnabled(selectedCount == 1);

--- a/src/gui/MemoryDialog.h
+++ b/src/gui/MemoryDialog.h
@@ -37,12 +37,11 @@ private:
     void beginEditingMemoryName(int memoryIndex);
     void focusTableOnCurrentRow();
     void populateTable();
-    void setInlineEditMode(bool enabled);
+    void editCurrentCell();
     void submitCellEdit(int row, int col);
     void onAdd();
     void onImport();
     void onExport();
-    void onEdit();
     void onSelect();
     void onSelectAll();
     void onRemove();
@@ -56,13 +55,11 @@ private:
     QLineEdit* m_searchEdit;
     QComboBox* m_filterCombo;
     QLabel* m_selectionLabel{nullptr};
-    QPushButton* m_editBtn{nullptr};
     QPushButton* m_selectBtn{nullptr};
     QPushButton* m_selectAllBtn{nullptr};
     QPushButton* m_removeBtn{nullptr};
     int m_pendingEditMemoryIndex{-1};
     int m_pendingEditRetries{0};
-    bool m_inlineEditMode{false};
     int m_sortColumn{2};
     Qt::SortOrder m_sortOrder{Qt::AscendingOrder};
 };

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -5,6 +5,7 @@
 #include "core/AppSettings.h"
 #include "core/CwTrace.h"
 #include "core/LogManager.h"
+#include "core/MemoryFieldValues.h"
 #include "core/PerfTelemetry.h"
 #include "core/StreamStatus.h"
 #include "core/UdpRegistrationPolicy.h"
@@ -3202,18 +3203,25 @@ void RadioModel::handleMemoryStatus(int index, const QMap<QString, QString>& kvs
     auto& m = m_memories[index];
     m.index = index;
 
+    // Decode the protocol space-encoding (0x7f -> ' ') for free-text fields,
+    // then strip any NUL/control bytes so corrupt values from the radio (or a
+    // previously corrupted memory) never reach the UI, CSV export, or a re-send.
+    auto decodeText = [](const QString& v) {
+        return AetherSDR::MemoryFields::sanitizeText(QString(v).replace('\x7f', ' '));
+    };
+
     for (auto it = kvs.begin(); it != kvs.end(); ++it) {
         const QString& k = it.key();
         const QString& v = it.value();
-        if      (k == "group")           m.group = QString(v).replace('\x7f', ' ');
-        else if (k == "owner")           m.owner = QString(v).replace('\x7f', ' ');
+        if      (k == "group")           m.group = decodeText(v);
+        else if (k == "owner")           m.owner = decodeText(v);
         else if (k == "freq")            m.freq = v.toDouble();
-        else if (k == "name")            m.name = QString(v).replace('\x7f', ' ');
-        else if (k == "mode")            m.mode = v;
+        else if (k == "name")            m.name = decodeText(v);
+        else if (k == "mode")            m.mode = AetherSDR::MemoryFields::sanitizeText(v);
         else if (k == "step")            m.step = v.toInt();
-        else if (k == "repeater")        m.offsetDir = v;
+        else if (k == "repeater")        m.offsetDir = AetherSDR::MemoryFields::sanitizeText(v);
         else if (k == "repeater_offset") m.repeaterOffset = v.toDouble();
-        else if (k == "tone_mode")       m.toneMode = v;
+        else if (k == "tone_mode")       m.toneMode = AetherSDR::MemoryFields::sanitizeText(v);
         else if (k == "tone_value")      m.toneValue = v.toDouble();
         else if (k == "squelch")         m.squelch = (v == "1");
         else if (k == "squelch_level")   m.squelchLevel = v.toInt();

--- a/tests/memory_field_values_test.cpp
+++ b/tests/memory_field_values_test.cpp
@@ -1,0 +1,83 @@
+#include "core/MemoryFieldValues.h"
+
+#include <QString>
+
+#include <iostream>
+
+namespace {
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition)
+        std::cerr << "FAIL: " << message << '\n';
+    return condition;
+}
+
+} // namespace
+
+int main()
+{
+    using namespace AetherSDR::MemoryFields;
+    bool ok = true;
+
+    // ── sanitizeText strips NUL and control bytes ───────────────────────────
+    {
+        QString withNul = "FM";
+        withNul.insert(1, QChar(QChar::Null)); // "F\0M"
+        ok &= expect(sanitizeText(withNul) == "FM",
+                     "sanitizeText removes an embedded NUL from a mode value");
+    }
+    ok &= expect(sanitizeText(QString("A\tB\nC\rD")) == "ABCD",
+                 "sanitizeText removes TAB/LF/CR control bytes");
+    ok &= expect(sanitizeText(QString("X") + QChar(0x7f) + "Y") == "XY",
+                 "sanitizeText removes the reserved DEL byte");
+    ok &= expect(sanitizeText("normal name") == "normal name",
+                 "sanitizeText preserves ordinary printable text incl. spaces");
+
+    // ── mode helpers ────────────────────────────────────────────────────────
+    ok &= expect(isKnownMode("usb"), "isKnownMode is case-insensitive for USB");
+    ok &= expect(isKnownMode("NFM"), "isKnownMode accepts NFM");
+    ok &= expect(!isKnownMode("FOO"), "isKnownMode rejects an unknown mode");
+    ok &= expect(modeToWire(" digu ") == "DIGU",
+                 "modeToWire trims and upper-cases");
+    {
+        QString dirty = "USB";
+        dirty.insert(1, QChar(QChar::Null));
+        ok &= expect(modeToWire(dirty) == "USB",
+                     "modeToWire also sanitizes control bytes");
+    }
+
+    // ── offset direction round-trips ────────────────────────────────────────
+    ok &= expect(offsetDirToWire("SIMPLEX") == "simplex", "offsetDirToWire simplex");
+    ok &= expect(offsetDirToWire("up") == "up", "offsetDirToWire up");
+    ok &= expect(offsetDirToWire("Down") == "down", "offsetDirToWire down");
+    ok &= expect(offsetDirToWire("garbage").isEmpty(),
+                 "offsetDirToWire empties an unrecognized direction");
+    ok &= expect(offsetDirToDisplay("up") == "UP", "offsetDirToDisplay up");
+    ok &= expect(offsetDirToDisplay("") == "SIMPLEX",
+                 "offsetDirToDisplay defaults blank to SIMPLEX");
+
+    // ── tone mode round-trips ───────────────────────────────────────────────
+    ok &= expect(toneModeToWire("CTCSS_TX") == "ctcss_tx", "toneModeToWire ctcss_tx");
+    ok &= expect(toneModeToWire("off") == "off", "toneModeToWire off");
+    ok &= expect(toneModeToWire("bogus").isEmpty(),
+                 "toneModeToWire empties an unrecognized tone mode");
+    ok &= expect(toneModeToDisplay("ctcss_tx") == "CTCSS_TX", "toneModeToDisplay ctcss_tx");
+    ok &= expect(toneModeToDisplay("") == "OFF",
+                 "toneModeToDisplay defaults blank to OFF");
+
+    // ── value lists are populated and well-formed ───────────────────────────
+    ok &= expect(modes().contains("USB") && modes().contains("AME"),
+                 "modes() spans the FlexLib demod set");
+    ok &= expect(offsetDirectionsDisplay().size() == 3,
+                 "offsetDirectionsDisplay() has SIMPLEX/UP/DOWN");
+    ok &= expect(toneModesDisplay() == QStringList({"OFF", "CTCSS_TX"}),
+                 "toneModesDisplay() is OFF then CTCSS_TX");
+    ok &= expect(ctcssTones().contains("88.5") && ctcssTones().contains("254.1"),
+                 "ctcssTones() includes standard EIA tones");
+    ok &= expect(!tuningSteps().isEmpty(), "tuningSteps() is populated");
+
+    std::cerr << (ok ? "memory_field_values_test PASSED\n"
+                     : "memory_field_values_test FAILED\n");
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Memory Channels dialog: tougher data, friendlier editing ⚡

This is a focused glow-up of the **Memory Channels** dialog — it fixes a real data-corruption bug, makes the constrained fields impossible to fat-finger, and turns the spreadsheet from "fight it" into "fly through it."

---

### 🐛 The bug that started it: NUL bytes in `Mode`

Memory entries were turning up with embedded **NUL (`\0`) characters in the Mode field** — invisible in the UI, but enough to confuse the radio and any other SmartSDR-compatible software that later reads the channel. Nothing in the pipeline was scrubbing control characters, on the way in *or* out.

**Fixed at every boundary.** New `MemoryFields::sanitizeText()` strips all C0 control bytes (`0x00`–`0x1F`, including those NULs) plus the reserved `0x7f` DEL byte, and it's wired into all four crossing points:

| Boundary | Where |
|---|---|
| Radio status → app | `RadioModel::handleMemoryStatus` (decode `0x7f`→space, then sanitize) |
| App → radio command | `encodeMemoryText` + mode/offset/tone wire conversion |
| CSV import | `MemoryCsvCompat::parseRecord` (+ logs unrecognized modes) |
| CSV export | `recordToFields` — so corruption can never leak to other tools |

Garbage can no longer enter the model, reach the radio, or escape into a `.csv`.

---

### 🎯 One-click dropdowns for the constrained fields

No more typing `CTCSS_TX` by hand and hoping. A new `MemoryFieldDelegate` gives the constrained columns proper combo-box editors that **pop open on a single click**:

- **Mode** — strict list: `USB, LSB, CW, AM, SAM, DSB, FM, NFM, DFM, DIGU, DIGL, RTTY, FDV, DSTR, AME`
- **Offset Dir** — strict: `SIMPLEX, UP, DOWN`
- **Tone Mode** — strict: `OFF, CTCSS_TX`
- **Tone Value** — type-or-pick: all 50 standard EIA CTCSS tones, free entry still allowed
- **Step** & **Group** — type-or-pick (Group seeded live from existing groups + global/TX profiles)

Every value list is sourced from the **authoritative FlexLib definitions** (`Slice.cs` / `Memory.cs`), and display↔wire conversion is centralized in one place so the table, the radio commands, and CSV always agree (modes upper-case on the wire, offset/tone lower-case).

---

### ⌨️ Editing that gets out of your way

- **Retired the modal "Edit" toggle.** Cells are always editable — click a selected cell, hit **F2**, or just start typing.
- **Tab / Shift+Tab** walk you across the fields like a real spreadsheet.
- **Double-click stays reserved for Tune**, so editing and tuning never collide.

---

### 📏 macOS column sizing fixes

Two papercuts squashed:

1. `resizeColumnsToContents()` runs a couple pixels tight on macOS, eliding short values — **`CW` showed as just `C`** after selection.
2. Long values like **`DIGU`** and **`CTCSS_TX`** got chopped because the floor widths were measured in the *dialog's* font while the table renders in the (larger) themed font.

Now every column gets breathing room, and each dropdown column is floored to its **widest possible value, measured in the table's own font** + slack for cell margins and the combo arrow — so the value always shows in full. Also shortened the most crowded header (`FM TX Offset Dir` → `Offset Dir`).

---

### ✅ Tests

New `memory_field_values_test` covering sanitization (NUL / TAB / CR / LF / DEL), mode validation, and offset/tone display↔wire round-trips. Passes alongside the existing `memory_recall_policy_test`.

---

### 🔍 How to verify

1. Open **Memory Channels**.
2. Edit **Mode**, **Offset Dir**, **Tone Mode** — confirm the dropdowns open in one click and the picked value (incl. `DIGU` / `CTCSS_TX`) shows in full.
3. **Tab** across fields; confirm **double-click** still tunes.
4. Import a CSV containing a Mode value with an embedded NUL → confirm it's scrubbed clean and the channel round-trips to the radio and back out to export with no control bytes.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
