### PR TITLE
fix(audio): prune dead followers in AudioOutputRouter (#3660)

### DIFF
--- a/src/core/AudioOutputRouter.cpp
+++ b/src/core/AudioOutputRouter.cpp
@@ -9,12 +9,20 @@ AudioOutputRouter::AudioOutputRouter(QObject* parent)
 
 void AudioOutputRouter::addFollower(std::function<void(const QAudioDevice&)> apply)
 {
+    // Raw callback follower: no liveness info, so it's always considered alive
+    // (the caller owns its lifetime).
+    registerFollower(std::move(apply), nullptr);
+}
+
+void AudioOutputRouter::registerFollower(std::function<void(const QAudioDevice&)> apply,
+                                         std::function<bool()> alive)
+{
     if (!apply)
         return;
     // Seed the new follower with the current selection so it starts on the right
     // device without waiting for the next change.
     apply(m_device);
-    m_followers.push_back(std::move(apply));
+    m_followers.push_back({std::move(apply), std::move(alive)});
 }
 
 void AudioOutputRouter::setCurrentDevice(const QAudioDevice& dev)
@@ -23,14 +31,22 @@ void AudioOutputRouter::setCurrentDevice(const QAudioDevice& dev)
     // Fan out over a snapshot: a follower's setOutputDevice() could register
     // another follower (or otherwise mutate m_followers) during the callback,
     // which would invalidate a live iterator / reallocate the vector mid-loop.
-    // A follower added during the fan-out is already seeded by addFollower(), so
-    // skipping it here is correct, not a miss. The list is tiny (registered once
-    // at startup) so the copy is negligible.
+    // A follower added during the fan-out is already seeded by registerFollower(),
+    // so skipping it here is correct, not a miss. The list is tiny (registered
+    // once at startup) so the copy is negligible.
     const auto followers = m_followers;
-    for (const auto& apply : followers) {
-        if (apply)
-            apply(m_device);
+    for (const auto& f : followers) {
+        if (f.apply)
+            f.apply(m_device);   // guarded followers self-skip when their QPointer is null
     }
+    // Prune followers whose QPointer guard has gone null so dead entries don't
+    // accumulate over the router's lifetime (#3660). Done after the fan-out on
+    // the live vector; a follower added re-entrantly during the loop is alive
+    // and therefore kept. Raw std::function followers have no `alive` predicate
+    // and are never pruned (the caller owns their lifetime).
+    std::erase_if(m_followers, [](const Follower& f) {
+        return f.alive && !f.alive();
+    });
 }
 
 } // namespace AetherSDR

--- a/src/core/AudioOutputRouter.h
+++ b/src/core/AudioOutputRouter.h
@@ -60,10 +60,12 @@ public:
     void addFollower(T* sink)
     {
         QPointer<T> guarded(sink);
-        addFollower([guarded](const QAudioDevice& dev) {
-            if (guarded)
-                guarded->setOutputDevice(dev);
-        });
+        registerFollower(
+            [guarded](const QAudioDevice& dev) {
+                if (guarded)
+                    guarded->setOutputDevice(dev);
+            },
+            [guarded]() { return !guarded.isNull(); });
     }
 
     // The device followers are currently bound to (may be null == "system
@@ -78,8 +80,21 @@ public slots:
     void setCurrentDevice(const QAudioDevice& dev);
 
 private:
-    QAudioDevice m_device;
-    std::vector<std::function<void(const QAudioDevice&)>> m_followers;
+    // A registered follower plus an optional liveness predicate. `alive` is set
+    // only by the QPointer-guarded template overload; a raw std::function
+    // follower carries no liveness info (null `alive` == always alive). Dead
+    // followers (guard gone null) are pruned after each fan-out (#3660).
+    struct Follower {
+        std::function<void(const QAudioDevice&)> apply;
+        std::function<bool()>                    alive;
+    };
+
+    // Shared registration path for both addFollower() overloads: seed + store.
+    void registerFollower(std::function<void(const QAudioDevice&)> apply,
+                          std::function<bool()> alive);
+
+    QAudioDevice          m_device;
+    std::vector<Follower> m_followers;
 };
 
 } // namespace AetherSDR

--- a/tests/audio_output_router_test.cpp
+++ b/tests/audio_output_router_test.cpp
@@ -82,15 +82,25 @@ int main(int argc, char** argv)
     }
 
     {
-        // QPointer guard: a follower destroyed before the router must not crash
-        // or be invoked on the next change.
+        // QPointer guard + pruning (#3660): a follower destroyed before the
+        // router must not crash or be invoked on the next change, AND must be
+        // pruned from the registry on that fan-out — while live followers are
+        // kept and still updated.
         AudioOutputRouter router;
+        FakeSink live;
         auto* heapSink = new FakeSink;
+        router.addFollower(&live);
         router.addFollower(heapSink);
+        report("two followers registered", router.followerCount() == 2);
         report("heap follower seeded", heapSink->calls == 1);
+
         delete heapSink;                 // QPointer in the router goes null
-        router.setCurrentDevice(devA);   // must be a no-op for the dead follower
+        const int liveBefore = live.calls;
+        router.setCurrentDevice(devA);   // dead follower skipped; live updated
         report("destroyed follower skipped (no crash)", true);
+        report("live follower still updated", live.calls == liveBefore + 1);
+        report("dead follower pruned, live kept (#3660)",
+               router.followerCount() == 1);
     }
 
     {


### PR DESCRIPTION
## Summary

Follow-up to #3630, closes #3660. `AudioOutputRouter` never pruned followers whose `QPointer` guard had gone null — a destroyed sink lingered in `m_followers` as a no-op closure iterated (and skipped) on every `setCurrentDevice()` fan-out.

Harmless for the current register-once-at-startup use (two lifetime-owned followers: `ClientPuduMonitor`, `QsoRecorder`), but it would accumulate unbounded once dynamically created/destroyed followers land — e.g. a future per-receiver or WebSDR-sourced sink per the audio-sink-factory roadmap.

## How

- Each follower now carries an optional **liveness predicate** alongside its apply callback. The `QPointer`-guarded template `addFollower(T*)` sets it (`[guarded]{ return !guarded.isNull(); }`); raw `std::function` followers leave it null and are treated as **always alive** (the caller owns their lifetime).
- `setCurrentDevice()` prunes dead followers with `std::erase_if` **after** the fan-out, operating on the live vector — so a follower added re-entrantly during the loop is alive and kept. The snapshot fan-out and re-entrancy behavior are unchanged.

Public API (`addFollower(std::function)`, `addFollower(T*)`) is unchanged; the two overloads now share an internal `registerFollower(apply, alive)`.

## Test

`audio_output_router_test` extended: registers a live + a heap follower, deletes the heap one, fans out, and asserts the dead follower is **pruned** (`followerCount` 2 → 1) while the live one is **kept and still updated**. **14/14** (was 9/9). Full app builds clean.

Refs #3306

🤖 Generated with [Claude Code](https://claude.com/claude-code)