### PR TITLE
Add clean-room KiwiSDR receive integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -553,6 +553,9 @@ set(CORE_SOURCES
     src/core/SmartCatSession.cpp
     src/core/CatPort.cpp
     src/core/SmartLinkClient.cpp
+    src/core/KiwiSdrProtocol.cpp
+    src/core/KiwiSdrClient.cpp
+    src/core/KiwiSdrManager.cpp
     src/core/WanConnection.cpp
     src/core/DxClusterClient.cpp
     src/core/WsjtxClient.cpp
@@ -685,6 +688,7 @@ set(GUI_SOURCES
     src/gui/MainWindow_Spots.cpp
     src/gui/MainWindow_SwrSweep.cpp
     src/gui/MainWindow_Wiring.cpp
+    src/gui/MainWindow_KiwiSdr.cpp
     src/gui/map/MapView.cpp
     src/gui/map/MapMarkerItem.cpp
     src/gui/map/MapPathItem.cpp
@@ -739,6 +743,7 @@ set(GUI_SOURCES
     src/gui/PanadapterStack.cpp
     src/gui/PanLayoutDialog.cpp
     src/gui/AppletPanel.cpp
+    src/gui/KiwiSdrApplet.cpp
     src/gui/FavoritesPickerDialog.cpp
     src/gui/RxApplet.cpp
     src/gui/FilterPassbandWidget.cpp
@@ -1874,6 +1879,14 @@ add_executable(spectral_nr_test
 target_include_directories(spectral_nr_test PRIVATE src)
 target_link_libraries(spectral_nr_test PRIVATE Qt6::Core)
 add_test(NAME spectral_nr_test COMMAND spectral_nr_test)
+
+add_executable(kiwi_sdr_protocol_test
+    tests/kiwi_sdr_protocol_test.cpp
+    src/core/KiwiSdrProtocol.cpp
+)
+target_include_directories(kiwi_sdr_protocol_test PRIVATE src)
+target_link_libraries(kiwi_sdr_protocol_test PRIVATE Qt6::Core)
+add_test(NAME kiwi_sdr_protocol_test COMMAND kiwi_sdr_protocol_test)
 
 add_executable(client_gate_test
     tests/client_gate_test.cpp

--- a/docs/kiwisdr-cleanroom-design.md
+++ b/docs/kiwisdr-cleanroom-design.md
@@ -1,0 +1,736 @@
+# KiwiSDR Clean-Room Design Note
+
+Status: receive-only client implemented from clean AetherSDR interfaces plus
+black-box observations made in this thread.
+
+## Allowed Inputs Used
+
+- User requirements from the KiwiSDR receive-only integration request.
+- User-provided waterfall adjustment input: the Kiwi waterfall exposes
+  `wf cell` and `wf floor` settings, each adjustable from -30 dB to +30 dB.
+- User-provided endpoint input rule: if the endpoint has no port, append port
+  8073 and do not attempt fallback ports.
+- User-provided applet UI requirements from 2026-06-18: move Kiwi Audio and
+  Kiwi Waterfall buttons to the applet bottom, compact the waterfall controls,
+  add a WF Rate slider, remove the Owned Slices label, render slice badges with
+  the same slice letter/color convention as RX Controls, choose a non-active
+  fallback slice for initial tracking without making it active, add
+  Auto Connect, and persist these Kiwi applet settings across restarts.
+- User-provided applet refinement from 2026-06-18: Kiwi applet slice badges
+  should behave like RX Controls slice buttons, with the active badge filled
+  and inactive badges outlined; the row outline/highlight should not enclose
+  the slice badge; WF Rate should match the other slider widths; Auto Connect
+  should be right-aligned beside the left-aligned Connect button.
+- User-provided screenshot feedback from 2026-06-18: the Kiwi applet slice
+  letters were clipped at the bottom, and the detail outline was too tight and
+  overlapped the row text.
+- User-provided audio-routing requirement from 2026-06-18: the Kiwi Audio
+  toggle should mute the AetherSDR slice that Kiwi audio replaces, restore that
+  slice when Kiwi audio is turned off, and leave other slices audible so Flex
+  slice audio and Kiwi audio can be heard together through AetherSDR audio/DSP.
+- User-provided regression report from 2026-06-18: NR2-related Kiwi static
+  returned after the later audio-source blending changes.
+- User-provided multi-endpoint RX antenna requirement from 2026-06-18:
+  KiwiSDR endpoints are client-side receive-only antenna profiles that can be
+  added and removed from Settings -> Antennas, each profile has
+  connect/disconnect and Auto Connect controls, slice RX antenna menus can
+  select a Kiwi profile without sending that profile name to the Flex radio,
+  selecting a Kiwi profile silently replaces Flex audio/waterfall for that
+  slice while keeping the slice mute icon available for the Kiwi audio, and
+  multiple Kiwi audio streams must mix with normal Flex audio without
+  reintroducing the NR2 static.
+- User-provided follow-up requirement from 2026-06-18: when a slice selects a
+  Kiwi RX antenna, the panadapter's FFT/spectrum trace should also be derived
+  from the received Kiwi waterfall bins instead of continuing to show the Flex
+  FFT trace.
+- User-provided follow-up requirement from 2026-06-18: when a selected Kiwi
+  profile disconnects, the panadapter should remain in Kiwi view and show a
+  local "Not connected to KiwiSDR" overlay with the connection detail until the
+  profile reconnects; Settings -> Antennas should show each Kiwi profile as a
+  readable name/server entry; and the panadapter waterfall controls should map
+  to Kiwi W/F cell, floor, and rate while a Kiwi antenna is selected, then
+  return to normal Flex waterfall behavior when it is not.
+- User-provided edge-case audit request from 2026-06-18: check muting,
+  unmuting, volume control, band switching, and source switching behavior when
+  either Kiwi or Flex receive audio/waterfall is active.
+- User-provided macOS crash report from 2026-06-18 showing a shutdown crash on
+  the main thread: `KiwiSdrManager::~KiwiSdrManager()` called
+  `disconnectAll()`, a Kiwi state change reached `MainWindow::wireKiwiSdr()`,
+  and the connected handler called back into `RadioModel::slice()` during
+  teardown.
+- User-provided screenshot/report from 2026-06-18: on a 20-meter Kiwi
+  panadapter, zooming out left the Kiwi FFT/waterfall segment narrower than
+  the visible panadapter and exposed odd horizontal lines in the side regions.
+- User-provided report from 2026-06-18: switching between two Kiwi receivers
+  left the panadapter showing the same waterfall data, indicating that rows
+  from a previously selected endpoint or a shared Kiwi cache could still be
+  displayed after selecting another receiver.
+- User-provided edge-case request from 2026-06-18: when the same connected
+  Kiwi receiver is selected on another slice/panadapter, that single receiver
+  should move to the new slice's frequency/audio and the new panadapter's
+  waterfall range, while the old panadapter stops showing that Kiwi receiver's
+  waterfall.
+- User-provided open protocol specification pasted on 2026-06-18, later
+  corrected by the implementation-oriented draft pasted the same day:
+  timestamp-style WebSocket stream paths ending in `/SND` and `/W/F`,
+  `SET auth t=kiwi p=#`, `SET ident_user=...`, `SERVER DE CLIENT ... SND`,
+  `SERVER DE CLIENT ... W/F`, `SET compression=0`,
+  `SET mod=... low_cut=... high_cut=... freq=...`, AGC as the combined
+  `SET agc=... hang=... thresh=... slope=... decay=... manGain=...` command,
+  squelch as `SET squelch=... max=...`, waterfall positioning via
+  `SET zoom=... cf=...` with compatibility `start=...`, `SET maxdb=... mindb=...`,
+  `SET wf_speed=...`, `SET interp=...`, `SET keepalive`, tagged `MSG`, `SND`,
+  `W/F`, and `EXT` binary/text dispatch, variable SND and W/F payload layouts,
+  and display-only waterfall byte mapping.
+  Binary frames are routed by the first three tag bytes so text, SND, and W/F
+  frames can be accepted even if an endpoint multiplexes them on one socket.
+  Remaining spec-derived receiver behavior is implemented only when it maps to
+  an existing AetherSDR/Flex receive concept without adding Kiwi-only UI:
+  auth-first identity setup, AGC defaults, squelch defaults, NFM mode mapping,
+  SND RSSI/sequence telemetry, W/F sequence telemetry, and text metadata
+  capture for users, reported frequency, ADC clipping, and GPS-good status.
+  Attenuation, remote mute, PBT, extension launch, IQ streams, and compressed
+  audio are not exposed because they would add Kiwi-only product behavior or
+  require undefined wire details.
+- User-provided report from 2026-06-18: after protocol setup changes, some
+  endpoints returned "sound connection closed" during connection setup, and
+  `QWebSocketPrivate::processHandshake` reported HTTP 200 for the root-query
+  paths from the earlier draft. The corrected user-provided spec says not to
+  use `/?A` or `/?W`; use timestamp-style stream paths ending in `/SND` and
+  `/W/F`. A clean black-box handshake check against the user's active endpoints
+  confirmed that `/?A`/`/?W` returned HTTP 200/307, while
+  `/<timestamp>/SND`, `/<timestamp>/W/F`,
+  `/ws/kiwi/<session-id>/SND`, and `/ws/kiwi/<session-id>/W/F` returned
+  HTTP 101 Switching Protocols. The runtime uses the corrected
+  `/<timestamp>/SND` and `/<timestamp>/W/F` paths.
+- User-provided protocol correction from 2026-06-18: SND binary frames have a
+  four-byte `SND` + rolling sequence byte header; the first two bytes of the
+  payload are the signed big-endian RSSI value and standard audio samples
+  follow immediately after that as signed little-endian 16-bit mono PCM at
+  12 kHz. IQ mode uses interleaved little-endian I/Q pairs at 20.25 kHz but is
+  not requested by this receive-audio implementation. W/F frames use a
+  four-byte `W/F` + sequence header followed by 1024 linear waterfall bins.
+  The corrected spec later cautions that SND payload offsets vary by compatible
+  client/server version. The runtime therefore accepts the corrected 6-byte
+  little-endian PCM layout and the previously observed 1034-byte live-frame
+  layout with a 10-byte header and big-endian PCM. Sequence gaps are counted
+  only when the sequence byte is considered reliable; bounded missing W/F rows
+  are duplicated to avoid display drift.
+- User-provided protocol correction from 2026-06-18: Kiwi proxy hostnames may
+  require retrying with `wss://` on port 443 when unencrypted WebSocket
+  connection setup fails or closes.
+- User-provided report from 2026-06-18: some endpoints showed a TLS host-name
+  mismatch after the secure proxy retry, while others still showed "sound
+  connection closed during setup." The secure retry is therefore limited to
+  failures before any plain WebSocket transport is established. Once SND or W/F
+  reaches the WebSocket connected state, later closes are treated as endpoint or
+  protocol setup failures and are not converted into a secure-proxy retry.
+- User-provided corrected implementation spec from 2026-06-18: do not use
+  root query endpoints such as `/?A` or `/?W`; do not require
+  `SET client_type=MicroKiwi`, `SET name=...`, `SET password=...`,
+  `SET audio_on=1`, or `SET wf_on=1`; use `SET auth t=kiwi p=...`,
+  `SET ident_user=...`, and the stream client marker commands instead.
+- User-provided protocol correction from 2026-06-18: string values in `SET`
+  commands must not contain spaces. The current runtime sends only sanitized
+  callsign identity strings and fixed client labels without spaces.
+- User-provided corrected implementation spec from 2026-06-18: W/F byte values
+  are raw display/bin values, not calibrated dBm. The runtime no longer uses
+  `byte - 255`; it maps raw bytes into a Kiwi-only display range and applies
+  local auto-aperture/color shaping without claiming RF calibration.
+- User-provided screenshots from 2026-06-18 showed the panadapter overlay
+  displaying a full URL-encoded `MSG load_cfg=...` record as a connection
+  error. The corrected parser treats `MSG` records as key-value fields and only
+  raises connection errors for actual top-level `too_busy=` or
+  `reason_disabled=` fields. Configuration payloads such as `load_cfg` are not
+  substring-scanned for error words.
+- User-provided implementation-completeness warning from 2026-06-18: this
+  implementation must not treat the high-level spec as a rigid binary ABI.
+  Exact SND layout, W/F layout, compression, S-meter conversion, waterfall
+  calibration, redirects, directory/proxy handling, and extensions remain
+  version-sensitive. The runtime is therefore conservative: SND setup is
+  split across the endpoint's `audio_rate` and `sample_rate` MSG fields, UI
+  connected state remains event-driven around `audio_rate`/`audio_init` or the
+  first SND frame, MSG fields are parsed independently, `badp`, `too_busy`,
+  `down`, `reason_disabled`, `redirect`, and `camp_disconnect` become explicit
+  local errors, unknown fields/tags are ignored, and unsupported compressed
+  audio, calibrated S-meter, calibrated dBm waterfall, directory discovery, and
+  extension behavior are not claimed.
+- User-provided SND troubleshooting input from 2026-06-18: "sound connection
+  closed" should be treated as an SND setup failure, and the useful reason is
+  usually in MSG records before the close. The client now logs the exact SND
+  and W/F WebSocket URLs, outbound SET commands with auth passwords redacted,
+  every inbound MSG field, WebSocket close code/reason, and whether any SND
+  binary frame was seen before close.
+- User-provided additional fixes from 2026-06-18: `SET compression=0` and
+  `SET wf_comp=0` are requests, not proof that incoming frames are
+  uncompressed. The runtime logs SND and W/F frame shape, decodes only
+  supported PCM/direct-row shapes, drops compact/encoded W/F rows, logs and
+  ignores `EXT` or unknown binary tags, and does not expose calibrated S-meter
+  dBm until the SND meter layout is independently verified.
+- User-provided KiwiSDR meter subsystem specification from 2026-06-19:
+  meter capability states, honest user-facing labels, unavailable-meter
+  behavior, relative audio-level and waterfall-intensity meters, smoothing and
+  peak-hold guidance, dBm-to-S-unit conversion utility, non-fatal extraction
+  failures, and mandatory stubs for real SND meter extraction until the SND
+  meter field layout and conversion formula are independently verified.
+- User-authorized experimental SND meter extraction from 2026-06-19, backed by
+  short receive-only black-box SND probes against `22033.proxy.kiwisdr.com:8073`:
+  observed 1034-byte frames with `SND` at bytes 0-2, byte 3 as flags, bytes 4-7
+  as a little-endian rolling frame counter, bytes 8-9 as a big-endian signed
+  candidate meter field, and big-endian PCM beginning at byte 10. The candidate
+  field varied plausibly across 7.2 MHz LSB, 10 MHz AM, and 14.2 MHz USB probes.
+  AetherSDR maps it as `raw / 10 - 127 dBm` only under the `experimental` meter
+  capability until independent live validation confirms it. The user-facing
+  meter surface uses the normal S-meter labels while the internal capability
+  remains experimental.
+- Red-team review in this clean-room worktree found integration risks without
+  using any Kiwi/WebSDR implementation source: unassigned profile connects could
+  reuse stale slice tracking, exact 1024-bin W/F rows could be misread as older
+  observed extended metadata, one WebSocket could fail while leaving the sibling
+  socket alive, removed slices could leave Kiwi audio assignments enabled,
+  endpoint edits could reuse saved waterfall rows from the previous endpoint,
+  and NR2 toggles did not clear every Kiwi receive buffer. The implementation
+  now treats those as local AetherSDR state-management bugs.
+- Clean upstream AetherSDR `main` checkout at `/Users/rfoust/Documents/source/AetherSDR`.
+- Project governance files read before implementation:
+  `AGENTS.md`, `CONTRIBUTING.md`, `.specify/memory/constitution.md`, and
+  `docs/a11y.md`.
+- AetherSDR source interfaces inspected from clean upstream `main`:
+  `AppletPanel`, `PanadapterApplet`, `SpectrumWidget`, `AudioEngine`,
+  `SliceModel`, `RadioModel`, and `MainWindow` wiring declarations.
+- Clean black-box observations against the user-approved endpoint
+  `g8ure.ddns.net:8077`:
+  - `HEAD /` returned `Server: KiwiSDR_1.842/Mongoose_7.14`; no body was read.
+  - A headless browser network observer, without reading DOM, HTML,
+    JavaScript, CSS, images, or response bodies, showed receive WebSockets at
+    `/ws/kiwi/<session-id>/SND` and `/ws/kiwi/<session-id>/W/F`.
+  - Observed receive-only text commands included `SET auth t=kiwi p=#`,
+    `SERVER DE CLIENT ... SND`, `SERVER DE CLIENT ... W/F`,
+    `SET AR OK in=12000 out=44100`, `SET mod=am low_cut=-4900 high_cut=4900
+    freq=3615`, waterfall setup commands, and keepalives.
+  - A single direct `SND` probe with `SET compression=0` produced binary
+    `SND` frames of 1034 bytes. Earlier historical interpretation treated
+    this as a 10-byte header plus 512 big-endian mono 16-bit samples at the
+    reported 12 kHz audio rate; the later user-provided master reference
+    supersedes this for runtime decoding with the 6-byte SND/RSSI header and
+    little-endian PCM samples.
+  - A single direct `W/F` probe with `SET send_dB=1` produced binary `W/F`
+    frames of 1040 bytes, with a 16-byte header and 1024 one-byte waterfall
+    bins. With observed `center_freq=15000000` and `bandwidth=30000000`, the
+    row spans 0-30 MHz at zoom 0. At the time, observed bin values appeared
+    plausible when interpreted as `byte - 255`; the later corrected
+    user-provided spec supersedes that interpretation and treats W/F bytes as
+    display/bin intensity values rather than calibrated dBm.
+- Clean black-box follow-up observations against user-provided endpoints
+  `sdr.hfunderground.com:8077`, `w0air.ddns.net:8073`, and
+  `22033.proxy.kiwisdr.com:8073`, using only rendered UI screenshots and
+  WebSocket frame metadata/text commands:
+  - An early `sdr.hfunderground.com:8077` check accepted a password-free sound
+    socket (`badp=0`) but produced no `audio_init` or `SND` frames while the
+    rendered page reported all Kiwi channels busy and offered queue/camp
+    actions. A later short receive-only direct SND probe against the same
+    endpoint reported `sample_rate=11998.902083`, `audio_init=0
+    audio_rate=12000`, and 1034-byte `SND` frames with a 10-byte header plus
+    512 big-endian signed 16-bit samples.
+  - `w0air.ddns.net:8073` produced `audio_init=0 audio_rate=12000` and
+    uncompressed `SND` frames. With `SET agc=0 ... manGain=0`, sustained
+    samples were effectively silent. A browser trace later sent receive-side
+    AGC defaults `SET agc=1 hang=0 thresh=-100 slope=6 decay=1000 manGain=50`;
+    using those values with `SET compression=0` yielded sustained nonzero
+    12 kHz PCM samples.
+  - A later direct receive-only `w0air.ddns.net:8073` timing probe with the
+    implemented uncompressed command sequence observed 1034-byte `SND` frames
+    containing 512 12 kHz samples. The average cadence was about 41 ms, but
+    frames arrived in bursts with gaps over 100 ms.
+  - A follow-up decode check on `w0air.ddns.net:8073` compared plausible
+    header offsets and byte orderings from the received `SND` frames. Even
+    offsets with big-endian signed 16-bit samples were coherent in that
+    historical capture, but the later user-provided master reference
+    supersedes the runtime decoder with the 6-byte SND/RSSI header and
+    little-endian PCM samples.
+  - A direct receive-only `22033.proxy.kiwisdr.com:8073` SND probe produced
+    1034-byte frames and `audio_init=0 audio_rate=12000`. A continuity check
+    over 180 frames historically supported a 10-byte SND header plus
+    big-endian signed 16-bit mono PCM interpretation. The later user-provided
+    master reference supersedes that runtime layout with a 6-byte SND/RSSI
+    header and little-endian PCM samples.
+  - A later receive-only SND static-analysis probe against
+    `22033.proxy.kiwisdr.com:8073` observed `sample_rate` values near
+    11998.9 Hz, `audio_rate=12000`, and 1034-byte SND frames. Header bytes
+    4-7 formed a little-endian sequence counter, bytes 8-9 were non-audio
+    metadata, and PCM still began at byte 10. The sampled PCM was not clipping.
+    The existing AetherSDR frame-boundary ramp altered otherwise contiguous
+    speech frames often enough, and by a large enough amount, to plausibly
+    produce speech-correlated static. This pass therefore leaves contiguous
+    SND frame joins unmodified and uses the observed audio rate metadata for
+    the SND resampler rate.
+  - A later receive-only SND follow-up against the same endpoint confirmed
+    offset 10 had the best frame-boundary continuity among tested even PCM
+    offsets 8, 10, and 12. The raw stream again had stable 1034-byte frames,
+    `audio_rate=12000`, and no clipping. A direct WAV playback of this raw
+    SND capture had no audible static, so the Kiwi adapter keeps decoded SND
+    samples transparent before sample-rate conversion.
+  - Direct receive-only W/F probes against `22033.proxy.kiwisdr.com:8073`
+    showed that `SET wf_speed=20` echoed `wf_fps=0` and produced no W/F
+    rows. `SET wf_speed=1`, `2`, `3`, and `4` produced rows at about 1, 5,
+    13, and 23 fps respectively; values 5 and higher produced no rows in
+    the observed sample. Zoomed W/F rows at `zoom=7 start=30` were 533 bytes:
+    16-byte header, 5-byte zoom prefix, and 512 row bytes.
+  - A later short W/F row-statistics probe against
+    `22033.proxy.kiwisdr.com:8073` with `zoom=7 start=30`, `send_dB=1`, and
+    `maxdb=-50 mindb=-130` observed a wide raw byte distribution:
+    approximately p5=1, p50=67, p95=195, and max=252 over the sampled rows.
+    This makes fixed full-window color mapping visually amplify normal row
+    variation into speckles.
+  - A follow-up receive-only W/F range-comparison probe against the same
+    endpoint changed only `maxdb`/`mindb`, but returned no W/F rows in the
+    short sample. No server-side display-range behavior is inferred from that
+    no-row probe.
+  - A short receive-only SND probe against `zl2j.proxy.kiwisdr.com:8073`
+    accepted the WebSocket upgrade but returned `badp=5` and closed before
+    sending audio for both `p=#` and empty public-password auth. A non-personal
+    `ident_user=AetherSDR` probe did not produce audio either. The user then
+    clarified that AetherSDR should send the callsign stored in the radio as
+    the Kiwi identity; the client sends the sanitized radio callsign as
+    `SET ident_user=<callsign>` after public auth on both SND and W/F sockets.
+  - A short receive-only SND probe against `k9czi-1.proxy.kiwisdr.com:8073`
+    accepted the WebSocket upgrade and returned `badp=5` for public auth
+    before closing. With the current pre-auth identity order and a
+    non-personal placeholder identity, the same endpoint sent only
+    `sample_rate` before closing. The client now reports setup socket closes
+    immediately instead of waiting for the generic audio-ready timeout.
+    Follow-up probes using the radio-stored callsign observed in AetherSDR's
+    own runtime log did not produce audio: `SET ident_user=<callsign>` before
+    auth, after `SERVER DE CLIENT`, or after `SET AR OK` caused a close after
+    `sample_rate`, while placing the callsign in the public auth field still
+    returned `badp=5`. No further callsign-auth command is inferred from these
+    observations.
+  - A short receive-only SND probe against `162.199.177.108:8073` reproduced
+    the app's setup-close symptom when `SET ident_user=<callsign>` was sent
+    before public auth. Sending public auth first returned `badp=0` and normal
+    setup status messages. The client therefore sends public auth before the
+    optional callsign identity.
+- User-provided screenshot and reports from local AetherSDR testing:
+  - Kiwi audio reached the speaker path but was rapidly choppy/staticy.
+  - Native Flex audio could retain background artifacts after switching away
+    from Kiwi audio.
+  - The Kiwi waterfall toggle showed real Kiwi W/F rows over old native
+    waterfall history instead of fully replacing the displayed waterfall.
+  - A short W/F-only probe against `sdr.hfunderground.com:8077` showed that
+    `SET zoom=<n> start=<m>` changes the requested server-side waterfall span,
+    and that returned W/F frame headers echo the requested `start` and `zoom`.
+    For the 7.1 MHz test range, `zoom=8 start=60` and `zoom=8 start=61`
+    produced row data. Higher zoom/start combinations could produce short
+    21-byte W/F frames with no row payload.
+  - Zoom-0 W/F frames were observed as 16-byte header plus 1024 direct row
+    bytes. Earlier zoomed W/F rows from the 7.1 MHz probe were observed as a
+    16-byte header, a short 5-byte row prefix, then 512 payload bytes. A later
+    2026-06-18 probe showed that this 5-byte-prefixed form is compact encoded
+    waterfall data, not direct one-byte-per-bin row data. The short 21-byte
+    W/F frames match the header plus the 5-byte prefix only and are ignored.
+  - A screenshot at 7.12-7.18 MHz showed that selecting the W/F `start` from
+    only the active slice frequency can leave part of the visible panadapter
+    outside the returned Kiwi segment. The W/F request must therefore choose
+    the highest zoom whose `start` segment fully contains the current
+    panadapter visible range.
+  - A later short W/F-only probe against `sdr.hfunderground.com:8077` for the
+    same 7.12-7.18 MHz view confirmed the client-side request shape:
+    `SET zoom=7 start=30` was echoed by `MSG zoom=7 start=30`, and matching
+    `W/F` frames returned 512 payload bytes after the observed 5-byte
+    zoomed-row prefix. A later 2026-06-18 probe showed that rendering this
+    compact encoded payload as direct bins produces visible speckle and does
+    not display coherent received signals.
+  - Later short W/F-only probes against `22033.proxy.kiwisdr.com:8073` and
+    `sdr.hfunderground.com:8077`, plus a short paired SND/W/F receive-only
+    probe against `g8ure.ddns.net:8077`, accepted WebSocket upgrades but
+    returned no W/F rows in the short sample. No header or segment behavior is
+    inferred from those no-row samples.
+  - A later paired receive-only SND/W/F probe against
+    `sdr.hfunderground.com:8077` using the same numeric session-id shape as
+    the app produced W/F rows. With `SET zoom=7 start=16`, returned 533-byte
+    frames echoed `start=16` and `zoom=7`: 16-byte header, observed 5-byte
+    zoom-row prefix, and 512 compact encoded payload bytes.
+  - A follow-up paired receive-only SND/W/F probe against the same endpoint
+    confirmed that `SET zoom=9 start=121` also returned 533-byte W/F frames
+    echoing `start=121` and `zoom=9`.
+  - A later receive-only browser WebSocket observation against
+    `sdr.hfunderground.com:8077`, without reading page source, served
+    JavaScript, DOM, CSS, image assets, or response bodies, captured the
+    rendered page's own outbound W/F zoom commands. Starting from the
+    endpoint's reported 0-30 MHz W/F span, the page sent examples such as
+    `SET zoom=1 start=1935951` with a reported marker range beginning at
+    3461.750 kHz, `SET zoom=2 start=2903926` with a marker range beginning at
+    5192.624 kHz, and `SET zoom=3 start=3387914` with a marker range
+    beginning at 6058.062 kHz. Those starts match
+    `round((visible_low_kHz / 30000 kHz) * 2^24)`, showing that W/F `start`
+    is a 24-bit fixed-point low-edge offset within the full W/F bandwidth,
+    not a small segment index.
+
+## NR2 / Multiple Kiwi Audio Sources Regression Guard
+
+Kiwi audio must not be mixed with Flex audio before NR2, and separate Kiwi
+endpoints must not alternate through one shared NR2 state. The stable invariant
+is: process Flex audio through `RxDspSource::Main` / `m_nr2`, process the legacy
+single Kiwi stream through `RxDspSource::KiwiSdr` / `m_kiwiSdrNr2`, process each
+virtual Kiwi antenna through that antenna's own NR2/resampler/output state, and
+mix Flex plus Kiwi only after DSP. When NR2 is enabled, Kiwi packets stay as
+whole packet-sized blocks until the audio timer processes them into post-DSP
+FIFOs; Flex packets use the same packet-preserving rule for the main NR2 path.
+The speaker timer must not re-chop raw source audio into timer-sized NR2 blocks.
+This preserves the first clean-room checkpoint behavior that removed the
+speech-correlated NR2 static without mutating output FIFOs from source callbacks.
+The final post-DSP speaker mix applies strict active-source averaging before
+clamping; post-DSP Flex and multiple Kiwi streams must not be summed full scale
+or scaled only by `1/sqrt(N)` because clipping can sound like NR2 static when
+three speech sources are active.
+Kiwi enable/disable transitions clear only Kiwi buffers/state; they must not
+reset `m_nr2` or other Flex RX DSP state.
+The speaker timer fills each post-DSP FIFO independently; a buffered Kiwi FIFO
+must not stop Flex raw audio from being processed into the Flex post-DSP FIFO.
+Managed Kiwi RX antenna streams must keep that same per-source FIFO boundary
+with NR2 disabled; they must not be collapsed into the legacy applet Kiwi
+output buffer, because the final mixer only treats that buffer as active when
+the applet-level Kiwi Audio toggle is enabled.
+
+## Sources Not Used
+
+- No KiwiSDR source code, AGPL repositories, served JavaScript, server code,
+  decoder code, protocol handlers, copied snippets, blogs, forums, or
+  implementation-derived assets were used.
+- No WebSDR source code, prior WebSDR worktrees, PR #3612, prior WebSDR
+  threads, contaminated temporary files, or rollout summaries were used.
+
+## Clean-Room Boundary
+
+The AetherSDR-side integration can be designed from the user requirements and
+clean upstream AetherSDR alone:
+
+- The side-dock UI is a normal `AppletPanel` applet wrapped by the existing
+  container system.
+- The current owned-slice list is available from `RadioModel::slices()`, with
+  the active slice identified by `MainWindow`.
+- Normal speaker audio enters `AudioEngine::feedAudioData()` as 24 kHz stereo
+  float PCM and then passes through the client RX DSP chain before reaching the
+  sink.
+- Per-panadapter waterfall controls belong in the existing `SpectrumWidget`
+  waterfall overlay control cluster, with waterfall pixels flowing through
+  `SpectrumWidget::updateWaterfallRow()`.
+
+Multi-endpoint KiwiSDR support treats Kiwi entries as AetherSDR-owned virtual
+RX antenna profiles. These profiles are not radio antenna tokens and must not
+be written through `slice set ... rxant=...`. The RX antenna menus append the
+virtual profile labels on the client side and intercept those selections before
+the radio command path. A normal Flex antenna selection clears the virtual
+assignment and uses the radio's ordinary `rxant` command. A Kiwi profile
+selection records a slice-to-profile assignment, starts or reuses that
+profile's receive connection, points the Kiwi client at the selected slice's
+frequency/mode/filter and panadapter range, and switches that panadapter to the
+Kiwi waterfall stream. While that stream is active, the visible panadapter
+trace is also sourced from the most recent Kiwi waterfall bins for the current
+view. This is a display projection of received Kiwi W/F data only; it does not
+derive spectrum data from audio and does not mix in Flex FFT bins.
+
+The profile list is one feature-owned `AppSettings` object. Each profile stores
+only client-side state: id, display label, normalized endpoint, Auto Connect,
+and waterfall display/rate adjustments. It deliberately does not persist radio
+frequency, mode, filter, or Flex antenna state because those remain
+radio-authoritative. Startup Auto Connect opens only profiles marked for it;
+shutdown disconnects every open Kiwi socket so an endpoint does not see a stale
+duplicate session on the next launch.
+When a selected Kiwi profile is disconnected or errors, the panadapter remains
+assigned to that profile and shows a local connection overlay rather than
+falling back silently to Flex waterfall data. Reconnection hides the overlay and
+new W/F rows continue into the same Kiwi waterfall stream.
+
+While a slice is assigned to a Kiwi profile, the Flex slice audio is muted only
+as an implementation detail of replacing that slice's receive source. The UI
+must keep the slice's speaker/mute controls available for the effective Kiwi
+source rather than showing the Flex mute icon as the active state. The mute and
+volume controls therefore route to the Kiwi source when a Kiwi profile is
+selected, and route back to the Flex slice when a normal antenna is selected.
+
+Multiple Kiwi streams are independent receive sources at the connection,
+raw jitter-buffer, NR2, resampler, and post-DSP FIFO boundaries. The audio
+engine must not mix Flex with Kiwi before NR2, and must not alternate separate
+Kiwi endpoints through one shared adaptive NR2 state. Each virtual Kiwi antenna
+therefore owns its own Kiwi NR2/resampler/output path. The speaker drain mixes
+those post-DSP Kiwi FIFOs with post-DSP Flex audio.
+Managed Kiwi RX antenna clients decode SND audio only while their profile is
+the active audio source. Connected but inactive profiles may continue serving
+waterfall data, but they must not spend CPU decoding/resampling unused audio
+frames because that can starve the active NR2 path.
+
+The KiwiSDR-side behavior is implemented only where it was observed directly.
+The client opens the observed `SND` and `W/F` sockets, sends only receive-side
+setup commands, requests uncompressed audio, converts 12 kHz mono samples to
+24 kHz stereo float PCM, and projects received W/F rows onto the current
+AetherSDR panadapter using the server-reported full W/F center and bandwidth.
+The existing panadapter waterfall controls are source-aware: while a Kiwi
+profile is selected they update the selected profile's W/F cell, W/F floor, and
+W/F rate settings only; while a normal Flex antenna is selected they retain the
+radio waterfall gain, black-level, auto-black, and rate behavior.
+The requested W/F row must fully contain the current AetherSDR panadapter
+range after the Kiwi fixed-point `start` value is quantized. When an exact
+high-resolution row does not cover the viewport after quantization, the client
+chooses the next wider row rather than displaying a narrower segment with blank
+or stale side margins. It does not add an arbitrary safety margin to the visible
+span, because direct Kiwi W/F rows have a fixed bin count and any extra RF span
+reduces bins-per-Hz. Rendering of cached Kiwi rows treats columns with no
+frequency overlap with the row as black, so a zoom-out cannot smear edge bins
+into horizontal side-line artifacts.
+When multiple Kiwi receiver profiles are connected, waterfall rows are accepted
+for a panadapter only if the row's profile id matches the currently selected
+Kiwi profile for that panadapter. Each Kiwi profile has its own cached
+waterfall stream state, including the Kiwi-derived FFT trace, so switching
+receivers does not display stale spectrum or waterfall history from a
+different endpoint.
+A single Kiwi profile is owned by at most one slice at a time. Selecting that
+same profile on another slice clears the old slice/panadapter assignment,
+restores that old slice's Flex audio state, moves the Kiwi client tracking to
+the new slice frequency/mode/filter, and requests the new panadapter's visible
+waterfall range.
+
+SND startup is staged from endpoint messages. On socket open, the client sends
+only auth, identity, and `SET compression=0`. When `MSG audio_rate=...` arrives,
+the client sends `SET AR OK in=<audio_rate> out=24000`, matching AetherSDR's
+Kiwi decoded-audio path. When
+`MSG sample_rate=...` arrives, the client sends squelch, generator disable,
+AGC, demodulator/tuning, and keepalive commands. Connection state is still
+considered receive-ready only after `audio_init` or the first accepted `SND`
+frame. Completing the `sample_rate` follow-up setup is not sufficient by
+itself; if no SND frames arrive before the timeout, the connection reports that
+sound setup completed but no SND audio frames arrived instead of presenting a
+silent audio toggle.
+If an already-established sound or waterfall WebSocket later closes or reports
+a socket error, the client reports the local error and the profile manager
+retries the profile after a short delay only when the profile is still
+operator-relevant: Auto Connect is enabled or a slice is still assigned to that
+Kiwi RX antenna. Server-declared terminal conditions such as `badp`, busy,
+disabled, down, redirect, or camp disconnect are not retried by this local
+recovery path.
+
+Because the observed uncompressed `SND` payload is 512 mono samples at 12 kHz,
+arrival cadence averages about 43 ms per frame but can bunch into burst/gap
+delivery. The client therefore uses AetherSDR's existing resampler to convert
+12 kHz mono to 24 kHz stereo, then holds a Kiwi-only jitter buffer before
+mixing decoded Kiwi audio with the normal Flex RX speaker path.
+
+Decoded Kiwi audio is queued as whole aligned 24 kHz stereo float chunks. When
+NR2 is off, the speaker drain owns Kiwi-only jitter smoothing and drains each
+raw Kiwi source into that source's own post-DSP FIFO. When NR2 is on, each Kiwi
+packet remains whole until the audio timer processes it through its dedicated
+Kiwi NR2 path and appends it to that source's post-DSP FIFO. This keeps NR2
+adaptive state and output resampler state from interleaving Flex and Kiwi
+cadences, and from interleaving different Kiwi endpoints. The final speaker
+drain sample-mixes the post-DSP Flex FIFO, every post-DSP Kiwi FIFO, and
+decoded RADE speech so other slices remain audible without pushing Flex-only
+or zero-muted radio frames through Kiwi's NR2 state.
+If the Kiwi FIFO runs dry, the client re-enters the Kiwi prebuffer state before
+playing more Kiwi audio. Enabling or disabling Kiwi Audio clears the current
+Kiwi source/output FIFOs and Kiwi DSP state at the transition so stale
+pre-toggle audio cannot be mixed into the delayed Kiwi stream; it must leave
+the Flex RX DSP state intact.
+
+For SND decode rate, the client uses the observed 12 kHz default unless an
+explicit `audio_rate` status supplies a plausible 8-48 kHz value. Generic
+`sample_rate` status is not used for SND resampling because it can describe
+other endpoint state; using it as audio rate can make one endpoint sound like
+static while another endpoint remains clean.
+
+Because Kiwi SND is already remote-demodulated audio, AetherSDR treats it as a
+transparent alternate decoded source. A follow-up listening test showed the
+remaining Kiwi speech-correlated static disappeared when NR2 was disabled.
+Local inspection found Kiwi audio reaches NR2 as packet-sized bursts that can
+be much larger than NR2's native 128-sample hop cadence. NR2 now splits
+oversized `process()` calls internally so bursty Kiwi packets produce the same
+output as the normal Flex RX cadence instead of wrapping the overlap-add ring
+within one call.
+
+When Kiwi Audio is enabled, AetherSDR also applies a client-owned mute to the
+tracked AetherSDR slice that Kiwi is replacing. The previous mute state is
+remembered and restored when Kiwi Audio is turned off or the Kiwi connection
+ends. If the tracked slice changes while Kiwi Audio is active, the old slice is
+restored before the new tracked slice is muted. This is deliberately limited to
+the slice audio mute command; it does not tune, change mode/filter, transmit,
+or otherwise alter Flex radio state.
+
+Kiwi waterfall rendering uses only the received `W/F` socket rows. It does not
+derive waterfall pixels from audio and does not use AetherSDR FFT bins for Kiwi
+rows. Native and Kiwi waterfall image/history buffers are kept as separate local
+stream states so toggling between them restores the prior waterfall instead of
+clearing and starting over. Both streams continue ingesting rows while the other
+stream is displayed.
+
+When the user pans or zooms a panadapter, both the native and Kiwi waterfall
+states are reprojected using the same local mechanism as the native Flex
+waterfall, and a new `SET zoom=<n> start=<m>` request is sent immediately from
+the local pan/zoom gesture whenever the pan contains the active owned slice and
+KiwiSDR is connected. Matching W/F rows then continue the reprojected history.
+A small horizontal and temporal smoother is applied only to Kiwi W/F rows to
+reduce byte-level speckle without inventing waterfall data or using
+audio-derived data.
+
+The W/F socket is kept on a server-side span near the active pan/slice by
+sending `SET zoom=<n> start=<m>` derived from the current AetherSDR
+panadapter center/bandwidth and from the server-reported full W/F
+`center_freq`/`bandwidth`. A 2026-06-18 clean black-box W/F probe observed
+server setup text reporting `wf_fft_size=1024`, 1040-byte W/F frames with a
+16-byte header and 1024 direct payload bytes after `SET wf_comp=0`, and W/F
+headers echoing the requested 32-bit `start` plus one-byte `zoom`. A later
+receive-only browser WebSocket observation showed that the rendered page sends
+million-scale `start` values matching a 24-bit fixed-point low-edge offset
+within the full W/F bandwidth. AetherSDR therefore treats `start` as
+`round(((row_low - full_low) / full_bandwidth) * 2^24)`, not as a coarse
+segment index. The chosen zoom is the narrowest row span that covers the
+visible panadapter bandwidth after fixed-point `start` quantization, and
+`start` centers that row on the visible RF range while clamping to the server's
+full W/F span. After rounding `start`,
+AetherSDR converts the sent fixed-point value back to an RF low edge and uses
+that exact quantized row span when stamping incoming rows into the local
+waterfall history. A request is recorded as current only after the W/F socket is
+connected and the `SET zoom/start` command is sent; this prevents pre-connect
+view calculations from suppressing the real setup command. Incoming W/F frame
+headers are checked against the requested `start`/`zoom` so stale rows from an
+older server span are dropped.
+
+When AetherSDR's active slice changes, the Kiwi client is explicitly updated
+from the new active slice and the `SpectrumWidget` attached to that slice's
+panadapter. If Kiwi waterfall display was active on a different panadapter, the
+visible Kiwi toggle is moved to the new active slice panadapter and the W/F
+socket is sent that panadapter's current center/bandwidth-derived view. This
+keeps cross-panadapter slice switching from leaving the remote W/F stream on
+the previous panadapter range.
+
+Kiwi waterfall row flow is server-paced. AetherSDR does not locally drop W/F
+rows to imitate the Flex line-duration value because dropping rows causes the
+stored Kiwi history and on-screen scroll rate to fall behind the native
+waterfall. The W/F socket is sent an approximate monotonic speed request in
+the observed working 1..4 range derived from the active AetherSDR waterfall
+rate so larger Flex rates request faster Kiwi W/F delivery without disabling
+row delivery on endpoints that return `wf_fps=0` for larger values.
+
+Remaining uncertainties are deliberately conservative:
+
+- Only password-free public receive access is supported.
+- Audio uses uncompressed `SND` requested via `SET compression=0`; no
+  compressed KiwiSDR audio codec is implemented. The user-provided protocol
+  says an SND flag can indicate ADPCM, but does not define the flag bit or the
+  compressed block framing, so AetherSDR does not guess a decoder path.
+- A short receive-only SND timing probe against `w0air.ddns.net:8073` observed
+  1034-byte uncompressed SND frames with about 42 ms average cadence, but burst
+  delivery with a 275 ms max inter-frame gap in the sample. The Kiwi-only
+  jitter buffer therefore targets 360 ms before draining to the speaker path.
+- SND frames are decoded only across layouts independently observed in this
+  clean-room thread. AetherSDR does not request Kiwi IQ mode in this
+  implementation. AetherSDR does not smooth or ramp normal frame boundaries,
+  because clean-room captures showed those joins are ordinary audio continuity
+  points and the previous ramp could impose audible speech-correlated
+  artifacts. When the SND or W/F sequence counter skips, AetherSDR applies
+  bounded gap concealment by repeating the previous decoded audio frame or
+  previous W/F row. The SND meter/RSSI field and conversion remain unverified.
+- Kiwi S-meter display uses an experimental SND candidate only for the
+  independently observed 1034-byte frame layout described above. The extractor
+  is intentionally labeled `experimental`; it must not be promoted to verified
+  calibrated SND metering until the field and conversion are validated against
+  an independent reference.
+- Kiwi meter display is capability-aware. The SND metadata extraction path is
+  an explicit experimental extractor and must not silently guess unsupported
+  layouts. Decoded Kiwi audio and W/F rows may still produce internal
+  `relative_audio` and `relative_waterfall` readings for diagnostics, but those
+  uncalibrated readings do not drive the user-facing VFO or applet S-meter. The
+  existing Flex-style meter surfaces show either the experimental SND candidate
+  or an unavailable readout. Flex `SLC/LEVEL` meter updates are ignored for
+  slices currently assigned to a Kiwi virtual RX antenna, preventing local
+  calibrated Flex dBm from racing the remote Kiwi meter state.
+- Waterfall row bytes are treated as raw display/bin intensity values, not
+  calibrated dBm. They are mapped into a Kiwi-only pseudo-dB display range and
+  color-mapped through a Kiwi-only automatic aperture with square-root contrast
+  stretch across the active waterfall color scheme. This is client-side display
+  normalization only: it does not synthesize waterfall data, does not derive
+  pixels from audio, and does not claim calibrated RF power. Earlier black-box
+  W/F captures showed both extended 16-byte-header direct rows and compact
+  encoded rows. AetherSDR requests direct uncompressed W/F rows and drops
+  compact encoded rows until a clean decoder is available.
+- The applet exposes Waterfall Cell and Waterfall Floor sliders using the
+  user-supplied -30 dB to +30 dB range. The corrected protocol draft maps
+  portable waterfall aperture control to `SET maxdb=... mindb=...`, so slider
+  changes bias the profile's max/min dB settings sent to the endpoint. The
+  same values are also applied as local display adjustments to the Kiwi
+  waterfall renderer so the controls provide immediate visible feedback even if
+  a public endpoint ignores or quantizes the setting command.
+- The applet exposes WF Rate as a compact 0..5 control. Value 0 preserves the
+  existing default behavior: derive the remote W/F speed from the active Flex
+  waterfall line duration. Values 1..5 are user-requested fixed speed values
+  sent as `SET wf_speed=<n>` so endpoint behavior can be tested without
+  changing the default automatic tracking path.
+- Kiwi RX antenna profile settings are stored as one
+  `AppSettings["KiwiSdrRxAntennas"]` JSON object containing each profile's
+  id, required display label, normalized endpoint, Auto Connect flag, WF Cell,
+  WF Floor, and WF Rate.
+- If AetherSDR has owned slices but no active slice when KiwiSDR tracking is
+  initialized, the applet selects the first owned slice as a tracking-only
+  fallback. It emits that slice to the Kiwi client so receive data can start,
+  but it does not call AetherSDR slice activation or otherwise alter Flex
+  radio state. The fallback row is marked with an outline/bar rather than the
+  filled active-slice highlight.
+- Kiwi waterfall rows use the same per-row retained-history model as the
+  native waterfall. Each stored Kiwi row records the server RF span it was
+  received from, and the visible row is remapped into the current panadapter
+  frame. Live pan/zoom changes rebuild the visible waterfall from those
+  row-level frames instead of stretching the current on-screen bitmap as one
+  image. This avoids smearing older Kiwi rows when the operator zooms out while
+  preserving the available data and leaving newly exposed frequencies black
+  until fresh rows arrive.
+- Kiwi W/F row smoothing is reset whenever the incoming row's server RF span
+  changes. Consecutive rows can only be temporally blended when they describe
+  the same `zoom/start`-derived frequency frame; otherwise strong carriers from
+  an old frame would be blended into the new frame at the wrong horizontal
+  position during pan/zoom gestures.
+- The corrected user-provided protocol specification names `cf` in kHz as the
+  W/F center-frequency request. Earlier black-box observations showed some
+  public endpoints also accept a fixed-point `start` offset. AetherSDR sends
+  the spec-defined `cf` and includes the previously observed `start`
+  compatibility key while recording incoming rows against the RF span computed
+  from the selected zoom and quantized start value.
+- Unsupported AetherSDR demod modes fall back to AM while still tracking
+  frequency.
+- Kiwi `nfm` is used only when the AetherSDR slice mode is already FM/NFM.
+  Kiwi `iq` is not requested because the current AetherSDR Kiwi audio path is
+  remote-demodulated mono PCM, and treating IQ pairs as audio would corrupt the
+  existing receive chain.
+- The pasted spec includes attenuation, remote mute, `SET pbt=...`, and
+  `SET ext=...`. AetherSDR does not expose those for Kiwi receivers in this
+  implementation because there is no existing selected-Kiwi receiver control
+  surface equivalent being reused here. Adding them would be a new Kiwi-only
+  feature rather than parity with an existing Flex receive control.
+
+## Implementation Shape
+
+The first safe step is protocol-independent scaffolding:
+
+- Add a `KiwiSdrApplet` with manual endpoint entry, connection state display,
+  owned-slice tracking, active-slice highlighting, and a local audio-source
+  toggle.
+- Add an isolated `KiwiSdrClient` state owner whose connect path validates
+  endpoint shape, normalizes pasted endpoints by removing leading
+  `http://`/`https://` and trailing slashes, opens the observed receive
+  sockets, and emits decoded audio and waterfall rows through AetherSDR-local
+  signals. The last endpoint is saved only after a successful connection.
+- Add a `AudioEngine::feedKiwiSdrAudioData()` entry point that accepts already
+  decoded 24 kHz stereo float PCM and routes it through the same RX DSP and
+  speaker path as normal AetherSDR audio. This method does not decode KiwiSDR
+  data and does not alter Flex radio state.
+- Add a per-panadapter Kiwi waterfall toggle in the `SpectrumWidget` waterfall
+  overlay control cluster, visible only when `MainWindow` determines that
+  KiwiSDR is connected and that the pan has an active owned slice. The toggle
+  controls display routing state only.
+
+## Non-Goals For This Scaffolding Pass
+
+- No transmitted state, PTT, MOX, tune, or Flex radio mutations.
+- No KiwiSDR wire messages or decoder behavior guessed from memory; every
+  implemented wire command and frame interpretation above came from the
+  black-box observations in this thread.
+- No reuse of WebSDR code paths or assumptions.
+- No visual-theme or main-layout changes beyond the requested applet and
+  per-panadapter toggle.

--- a/docs/kiwisdr-cleanroom-design.md
+++ b/docs/kiwisdr-cleanroom-design.md
@@ -191,7 +191,7 @@ black-box observations made in this thread.
   endpoint edits could reuse saved waterfall rows from the previous endpoint,
   and NR2 toggles did not clear every Kiwi receive buffer. The implementation
   now treats those as local AetherSDR state-management bugs.
-- Clean upstream AetherSDR `main` checkout at `/Users/rfoust/Documents/source/AetherSDR`.
+- Clean upstream AetherSDR `main` checkout.
 - Project governance files read before implementation:
   `AGENTS.md`, `CONTRIBUTING.md`, `.specify/memory/constitution.md`, and
   `docs/a11y.md`.

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -66,6 +66,7 @@ namespace AetherSDR {
 static QString wisdomDir();
 static void logNr2WisdomSummary(const QString& context);
 static void logNr2WisdomGenerationSummary(SpectralNR::WisdomResult result);
+static void applyNr2SettingsFromAppSettings(SpectralNR& nr2);
 
 namespace {
 constexpr qint64 kTxAutoRestartMinRuntimeMs = 60000;
@@ -103,6 +104,23 @@ QString formatAudioAttempt(int sampleRate,
         .arg(AudioSummaryLogger::sampleFormatName(sampleFormat));
 }
 
+qsizetype queuedAudioBytes(const std::deque<QByteArray>& packets)
+{
+    qsizetype total = 0;
+    for (const QByteArray& packet : packets) {
+        total += packet.size();
+    }
+    return total;
+}
+
+void trimAudioPacketQueue(std::deque<QByteArray>& packets, qsizetype maxBytes)
+{
+    qsizetype total = queuedAudioBytes(packets);
+    while (total > maxBytes && !packets.empty()) {
+        total -= packets.front().size();
+        packets.pop_front();
+    }
+}
 QString audioErrorName(QAudio::Error error)
 {
     switch (error) {
@@ -520,9 +538,93 @@ void AudioEngine::emitTncRxTapFromFloat32Stereo(const QByteArray& pcm, int sampl
 
 void AudioEngine::updateRxBufferStats()
 {
-    const qsizetype total = m_rxBuffer.size() + m_radeRxBuffer.size();
+    qsizetype externalTotal = 0;
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source) {
+            continue;
+        }
+        externalTotal += source->rxBuffer.size()
+                       + queuedAudioBytes(source->rxPackets)
+                       + source->outputBuffer.size();
+    }
+
+    const qsizetype total =
+        m_rxBuffer.size() + queuedAudioBytes(m_rxPackets)
+        + m_kiwiSdrRxBuffer.size() + queuedAudioBytes(m_kiwiSdrRxPackets)
+        + m_rxOutputBuffer.size() + m_kiwiSdrOutputBuffer.size()
+        + m_radeRxBuffer.size() + externalTotal;
     m_rxBufferBytes.store(total);
     m_rxBufferPeakBytes.store(std::max(m_rxBufferPeakBytes.load(), total));
+}
+
+AudioEngine::ExternalRxAudioSourceState*
+AudioEngine::externalKiwiSource(const QString& sourceId, bool create)
+{
+    const QString id = sourceId.trimmed();
+    if (id.isEmpty()) {
+        return nullptr;
+    }
+
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->id == id) {
+            return source.get();
+        }
+    }
+
+    if (!create) {
+        return nullptr;
+    }
+
+    auto source = std::make_unique<ExternalRxAudioSourceState>();
+    source->id = id;
+    source->prebuffering = true;
+    if (m_nr2Enabled.load(std::memory_order_relaxed) && m_kiwiSdrNr2) {
+        source->nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
+        if (source->nr2->hasPlanFailed()) {
+            qCWarning(lcAudio) << "AudioEngine: external Kiwi NR2 plan failed for"
+                               << id;
+            source->nr2.reset();
+        } else {
+            applyNr2SettingsFromAppSettings(*source->nr2);
+        }
+    }
+    m_externalKiwiSources.push_back(std::move(source));
+    return m_externalKiwiSources.back().get();
+}
+
+bool AudioEngine::anyExternalKiwiAudioEnabled() const
+{
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->enabled && !source->muted) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool AudioEngine::anyExternalKiwiBufferQueued() const
+{
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && !source->muted
+            && (!source->rxBuffer.isEmpty() || !source->rxPackets.empty()
+                || !source->outputBuffer.isEmpty())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+qsizetype AudioEngine::externalKiwiOutputBufferBytes() const
+{
+    qsizetype maxBytes = 0;
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->enabled && !source->muted
+            && !source->prebuffering) {
+            maxBytes = std::max(maxBytes, source->outputBuffer.size());
+        }
+    }
+    return maxBytes;
 }
 
 AudioEngine::AudioEngine(QObject* parent)
@@ -661,7 +763,8 @@ AudioEngine::AudioEngine(QObject* parent)
     });
     m_opusTxPaceTimer->start();
 
-    // RX pacing timer -- drains m_rxBuffer into QAudioSink at regular intervals.
+    // RX pacing timer -- processes source queues through their RX DSP paths
+    // and drains speaker-ready output into QAudioSink at regular intervals.
     // Includes latency management: caps buffer at ~200ms to prevent unbounded
     // growth when network packets arrive in bursts (common on Windows WASAPI
     // with virtual audio routers like Voicemeeter).
@@ -674,25 +777,82 @@ AudioEngine::AudioEngine(QObject* parent)
         // Cap buffer to bound latency. Default 200ms, user-adjustable for
         // high-jitter connections (VPN, SmartLink) where drops cause choppy audio.
         const int sampleRate = m_rxOutputRate.load();
-        const int bufMs = m_rxBufferCapMs.load();
-        const qsizetype maxBufBytes = sampleRate * 2 * static_cast<qsizetype>(sizeof(float)) * bufMs / 1000;
-        if (m_rxBuffer.size() > maxBufBytes) {
+        const bool kiwiAudio =
+            m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed);
+        const bool externalKiwiAudio = anyExternalKiwiAudioEnabled();
+        const bool anyKiwiAudio = kiwiAudio || externalKiwiAudio;
+        const int configuredBufMs = m_rxBufferCapMs.load();
+        const int effectiveBufMs = anyKiwiAudio
+            ? std::max(configuredBufMs, kKiwiSdrBufferCapMs)
+            : configuredBufMs;
+        const qsizetype sourceMaxBufBytes =
+            DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
+            * effectiveBufMs / 1000;
+        const qsizetype outputMaxBufBytes =
+            sampleRate * 2 * static_cast<qsizetype>(sizeof(float))
+            * effectiveBufMs / 1000;
+        trimAudioPacketQueue(m_rxPackets, sourceMaxBufBytes);
+        if (m_rxBuffer.size() > sourceMaxBufBytes) {
             // Drop oldest samples to keep latency bounded
-            m_rxBuffer.remove(0, m_rxBuffer.size() - maxBufBytes);
+            m_rxBuffer.remove(0, m_rxBuffer.size() - sourceMaxBufBytes);
         }
-        if (m_radeRxBuffer.size() > maxBufBytes) {
-            m_radeRxBuffer.remove(0, m_radeRxBuffer.size() - maxBufBytes);
+        if (m_kiwiSdrRxBuffer.size() > sourceMaxBufBytes) {
+            m_kiwiSdrRxBuffer.remove(0, m_kiwiSdrRxBuffer.size() - sourceMaxBufBytes);
+        }
+        if (m_rxOutputBuffer.size() > outputMaxBufBytes) {
+            m_rxOutputBuffer.remove(0, m_rxOutputBuffer.size() - outputMaxBufBytes);
+        }
+        if (m_kiwiSdrOutputBuffer.size() > outputMaxBufBytes) {
+            m_kiwiSdrOutputBuffer.remove(
+                0, m_kiwiSdrOutputBuffer.size() - outputMaxBufBytes);
+        }
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source) {
+                continue;
+            }
+            if (source->rxBuffer.size() > sourceMaxBufBytes) {
+                source->rxBuffer.remove(0, source->rxBuffer.size() - sourceMaxBufBytes);
+            }
+            if (source->outputBuffer.size() > outputMaxBufBytes) {
+                source->outputBuffer.remove(
+                    0, source->outputBuffer.size() - outputMaxBufBytes);
+            }
+        }
+        if (m_radeRxBuffer.size() > outputMaxBufBytes) {
+            m_radeRxBuffer.remove(0, m_radeRxBuffer.size() - outputMaxBufBytes);
         }
 
         const qsizetype freeBytes = m_audioSink->bytesFree();
-        if (freeBytes > 0 && m_rxBuffer.isEmpty() && m_radeRxBuffer.isEmpty()) {
-            m_rxBufferUnderrunCount.fetch_add(1);
+        if (freeBytes > 0 && m_rxBuffer.isEmpty()
+            && m_rxPackets.empty()
+            && m_kiwiSdrRxBuffer.isEmpty() && m_kiwiSdrRxPackets.empty()
+            && m_rxOutputBuffer.isEmpty()
+            && m_kiwiSdrOutputBuffer.isEmpty()
+            && m_radeRxBuffer.isEmpty()
+            && !anyExternalKiwiBufferQueued()) {
+            if (anyKiwiAudio) {
+                m_kiwiSdrPrebuffering = true;
+                for (const auto& source : m_externalKiwiSources) {
+                    if (source && source->enabled) {
+                        source->prebuffering = true;
+                    }
+                }
+            } else {
+                m_rxBufferUnderrunCount.fetch_add(1);
+            }
         }
 
         // Zombie sink watchdog: if we have data waiting but the sink reports
         // zero bytes free for ~2 seconds, the WASAPI handle is likely stale
         // (e.g. after screensaver/idle on Windows with USB audio). (#1361)
-        if (freeBytes == 0 && !m_rxBuffer.isEmpty()) {
+        if (freeBytes == 0 && (!m_rxBuffer.isEmpty()
+                               || !m_rxPackets.empty()
+                               || !m_radeRxBuffer.isEmpty()
+                               || !m_kiwiSdrRxBuffer.isEmpty()
+                               || !m_kiwiSdrRxPackets.empty()
+                               || !m_rxOutputBuffer.isEmpty()
+                               || !m_kiwiSdrOutputBuffer.isEmpty()
+                               || anyExternalKiwiBufferQueued())) {
             if (++m_rxZombieTickCount >= kZombieTickThreshold) {
                 m_rxZombieTickCount = 0;
                 qCWarning(lcAudio) << "AudioEngine: sink appears zombie (bytesFree stuck at 0 for"
@@ -715,7 +875,14 @@ AudioEngine::AudioEngine(QObject* parent)
         // Restart the sink to re-acquire a fresh handle. (#1411)
         if (m_lastAudioFeedTime.isValid()
             && m_lastAudioFeedTime.elapsed() > kAudioLivenessTimeoutMs
-            && m_rxBuffer.isEmpty()) {
+            && m_rxBuffer.isEmpty()
+            && m_rxPackets.empty()
+            && m_rxOutputBuffer.isEmpty()
+            && m_radeRxBuffer.isEmpty()
+            && m_kiwiSdrOutputBuffer.isEmpty()
+            && m_kiwiSdrRxBuffer.isEmpty()
+            && m_kiwiSdrRxPackets.empty()
+            && !anyExternalKiwiBufferQueued()) {
             qCWarning(lcAudio) << "AudioEngine: no audio data received for"
                                << m_lastAudioFeedTime.elapsed() << "ms, restarting RX (#1411)";
             m_lastAudioFeedTime.start();  // prevent repeated rapid restarts
@@ -727,47 +894,304 @@ AudioEngine::AudioEngine(QObject* parent)
             return;
         }
 
-        // Align to float32 frame boundary before any arithmetic.
+        if (m_nr2Enabled.load(std::memory_order_relaxed)) {
+            std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+            while (!m_rxPackets.empty()) {
+                QByteArray packet = std::move(m_rxPackets.front());
+                m_rxPackets.pop_front();
+                processMixedRxAudioData(packet, RxDspSource::Main);
+            }
+            while (kiwiAudio && !m_kiwiSdrRxPackets.empty()) {
+                QByteArray packet = std::move(m_kiwiSdrRxPackets.front());
+                m_kiwiSdrRxPackets.pop_front();
+                processMixedRxAudioData(packet, RxDspSource::KiwiSdr);
+            }
+            for (const auto& source : m_externalKiwiSources) {
+                if (!source || !source->enabled || source->muted) {
+                    continue;
+                }
+                while (!source->rxPackets.empty()) {
+                    QByteArray packet = std::move(source->rxPackets.front());
+                    source->rxPackets.pop_front();
+                    processMixedRxAudioData(packet, RxDspSource::KiwiSdr, source.get());
+                }
+            }
+        }
+
+        if (kiwiAudio && m_kiwiSdrPrebuffering) {
+            // KiwiSDR uncompressed audio is observed as 512-sample 12 kHz
+            // blocks (~43 ms), but WebSocket delivery bunches frames with
+            // >100 ms gaps. Hold only the Kiwi jitter buffer before mixing;
+            // the normal Flex RX buffer must keep draining while Kiwi fills.
+            const int prebufferMs = std::min(
+                kKiwiSdrJitterTargetMs,
+                std::max(50, effectiveBufMs / 2));
+            const qsizetype prebufferBytes =
+                (m_nr2Enabled.load(std::memory_order_relaxed)
+                     ? sampleRate
+                     : DEFAULT_SAMPLE_RATE)
+                * 2 * static_cast<qsizetype>(sizeof(float)) * prebufferMs / 1000;
+            const qsizetype bufferedBytes =
+                m_nr2Enabled.load(std::memory_order_relaxed)
+                    ? m_kiwiSdrOutputBuffer.size()
+                    : m_kiwiSdrRxBuffer.size();
+            if (bufferedBytes >= prebufferBytes) {
+                m_kiwiSdrPrebuffering = false;
+            }
+        }
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source || !source->enabled || !source->prebuffering) {
+                continue;
+            }
+            const int prebufferMs = std::min(
+                kKiwiSdrJitterTargetMs,
+                std::max(50, effectiveBufMs / 2));
+            const qsizetype prebufferBytes =
+                (m_nr2Enabled.load(std::memory_order_relaxed)
+                     ? sampleRate
+                     : DEFAULT_SAMPLE_RATE)
+                * 2 * static_cast<qsizetype>(sizeof(float)) * prebufferMs / 1000;
+            const qsizetype bufferedBytes =
+                m_nr2Enabled.load(std::memory_order_relaxed)
+                    ? source->outputBuffer.size()
+                    : source->rxBuffer.size();
+            if (bufferedBytes >= prebufferBytes) {
+                source->prebuffering = false;
+            }
+        }
+
+        // Align to stereo float32 frame boundaries before any arithmetic.
         const qsizetype floatBytes = static_cast<qsizetype>(sizeof(float));
-        qsizetype len = (freeBytes / floatBytes) * floatBytes;
-        len = std::min(len, std::max(m_rxBuffer.size(), m_radeRxBuffer.size()));
+        const qsizetype frameBytes = 2 * floatBytes;
+        const bool nr2PacketMode = m_nr2Enabled.load(std::memory_order_relaxed);
+        const bool kiwiNr2PacketMode = kiwiAudio && nr2PacketMode;
+        if (kiwiNr2PacketMode && !m_kiwiSdrPrebuffering
+            && m_kiwiSdrOutputBuffer.isEmpty()) {
+            m_kiwiSdrPrebuffering = true;
+        }
+        const bool kiwiMixActive =
+            kiwiAudio && !kiwiNr2PacketMode && !m_kiwiSdrPrebuffering;
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source || !source->enabled || source->muted || source->prebuffering) {
+                continue;
+            }
+            const bool sourceEmpty =
+                nr2PacketMode ? source->outputBuffer.isEmpty()
+                              : source->rxBuffer.isEmpty();
+            if (sourceEmpty) {
+                source->prebuffering = true;
+            }
+        }
+        const qsizetype kiwiMixBytes =
+            kiwiMixActive ? m_kiwiSdrRxBuffer.size() : 0;
+        const qsizetype freeFrames = freeBytes / frameBytes;
+        // Fill each post-DSP FIFO independently. A prebuffered Kiwi FIFO must
+        // not make the timer skip Flex processing, otherwise Flex only leaks
+        // into the final mix when the Kiwi FIFO briefly drains.
+        const qsizetype queuedMainFrames = m_rxOutputBuffer.size() / frameBytes;
+        const qsizetype wantedMainOutputFrames =
+            freeFrames > queuedMainFrames ? freeFrames - queuedMainFrames : 0;
+        const qsizetype wantedMainNativeFrames =
+            sampleRate > 0
+                ? (wantedMainOutputFrames * DEFAULT_SAMPLE_RATE) / sampleRate
+                : wantedMainOutputFrames;
+        const qsizetype wantedMainNativeBytes = wantedMainNativeFrames * frameBytes;
+        const qsizetype mainBytes =
+            nr2PacketMode
+                ? 0
+                : (std::min(wantedMainNativeBytes, m_rxBuffer.size()) / frameBytes)
+                    * frameBytes;
+        if (mainBytes > 0) {
+            const QByteArray mainPcm = m_rxBuffer.left(mainBytes);
+            m_rxBuffer.remove(0, mainBytes);
+            processMixedRxAudioData(mainPcm, RxDspSource::Main);
+        }
+
+        // NR2 regression guard:
+        // With NR2 enabled, Kiwi packets stay whole until this timer processes
+        // them through their Kiwi-only NR2 state into post-DSP Kiwi FIFOs.
+        // Do not chop raw Kiwi into timer-sized pieces and feed NR2 here; that
+        // reintroduced speech-correlated static. Raw Kiwi draining below is
+        // only used while NR2 is off.
+        const qsizetype queuedKiwiFrames = m_kiwiSdrOutputBuffer.size() / frameBytes;
+        const qsizetype wantedKiwiOutputFrames =
+            freeFrames > queuedKiwiFrames ? freeFrames - queuedKiwiFrames : 0;
+        const qsizetype wantedKiwiNativeFrames =
+            sampleRate > 0
+                ? (wantedKiwiOutputFrames * DEFAULT_SAMPLE_RATE) / sampleRate
+                : wantedKiwiOutputFrames;
+        const qsizetype wantedKiwiNativeBytes = wantedKiwiNativeFrames * frameBytes;
+        const qsizetype kiwiBytes =
+            (std::min(wantedKiwiNativeBytes, kiwiMixBytes) / frameBytes)
+            * frameBytes;
+        if (kiwiBytes > 0) {
+            const QByteArray kiwiPcm = m_kiwiSdrRxBuffer.left(kiwiBytes);
+            m_kiwiSdrRxBuffer.remove(0, kiwiBytes);
+            processMixedRxAudioData(kiwiPcm, RxDspSource::KiwiSdr);
+        }
+
+        // Managed Kiwi RX antennas must keep the same per-source output FIFO
+        // boundary with NR2 off as they do with NR2 on. If they are collapsed
+        // into the legacy applet Kiwi buffer here, the final mixer ignores
+        // them unless the applet-level Kiwi Audio toggle is also enabled.
+        if (!nr2PacketMode) {
+            for (const auto& source : m_externalKiwiSources) {
+                if (!source || !source->enabled || source->muted
+                    || source->prebuffering) {
+                    continue;
+                }
+
+                const qsizetype queuedSourceFrames =
+                    source->outputBuffer.size() / frameBytes;
+                const qsizetype wantedSourceOutputFrames =
+                    freeFrames > queuedSourceFrames
+                        ? freeFrames - queuedSourceFrames
+                        : 0;
+                const qsizetype wantedSourceNativeFrames =
+                    sampleRate > 0
+                        ? (wantedSourceOutputFrames * DEFAULT_SAMPLE_RATE) / sampleRate
+                        : wantedSourceOutputFrames;
+                const qsizetype wantedSourceNativeBytes =
+                    wantedSourceNativeFrames * frameBytes;
+                const qsizetype sourceBytes =
+                    (std::min(wantedSourceNativeBytes, source->rxBuffer.size())
+                     / frameBytes) * frameBytes;
+                if (sourceBytes <= 0) {
+                    continue;
+                }
+
+                const QByteArray sourcePcm = source->rxBuffer.left(sourceBytes);
+                source->rxBuffer.remove(0, sourceBytes);
+                processMixedRxAudioData(
+                    sourcePcm, RxDspSource::KiwiSdr, source.get());
+            }
+        }
+
+        const qsizetype kiwiOutputBytes =
+            (kiwiAudio && !m_kiwiSdrPrebuffering)
+                ? m_kiwiSdrOutputBuffer.size()
+                : 0;
+        const qsizetype externalKiwiOutputBytes = externalKiwiOutputBufferBytes();
+        const qsizetype aggregateKiwiOutputBytes =
+            std::max(kiwiOutputBytes, externalKiwiOutputBytes);
+        qsizetype len = (freeBytes / frameBytes) * frameBytes;
+        len = std::min(len, std::max({m_rxOutputBuffer.size(),
+                                      aggregateKiwiOutputBytes,
+                                      m_radeRxBuffer.size()}));
+        len = (len / frameBytes) * frameBytes;
         if (len > 0)
         {
             QByteArray chunk;
-            if (m_radeRxBuffer.isEmpty()) {
-                // Fast path: no RADE speech active — write m_rxBuffer directly.
-                chunk = m_rxBuffer.left(len);
-                m_rxBuffer.remove(0, chunk.size());
+            if (m_radeRxBuffer.isEmpty() && aggregateKiwiOutputBytes <= 0) {
+                // Fast path: no decoded overlay active -- write the
+                // already-processed RX output directly.
+                chunk = m_rxOutputBuffer.left(len);
+                m_rxOutputBuffer.remove(0, chunk.size());
+            } else if (m_rxOutputBuffer.isEmpty() && m_radeRxBuffer.isEmpty()
+                       && kiwiOutputBytes > 0 && externalKiwiOutputBytes <= 0) {
+                // Fast path: only Kiwi decoded audio is active.
+                chunk = m_kiwiSdrOutputBuffer.left(len);
+                m_kiwiSdrOutputBuffer.remove(0, chunk.size());
             } else {
-                // Mix path: add m_rxBuffer (SSB/CW audio or zero-filled muted-RADE
-                // frames) and m_radeRxBuffer (decoded RADE speech) sample-wise.
-                // Both are float32 stereo at the same rate. Zero-init the output
-                // so that whichever buffer is shorter contributes silence for its
-                // missing tail samples without special-casing.
+                // Mix path: add post-DSP Flex, every post-DSP Kiwi stream,
+                // and decoded RADE sample-wise at the output device rate.
                 chunk = QByteArray(len, '\0');
                 auto* out = reinterpret_cast<float*>(chunk.data());
+                int activeOutputSources = 0;
+                constexpr float kOutputSilenceThreshold = 1.0e-6f;
 
-                const qsizetype rxTake = (std::min(len, m_rxBuffer.size()) / floatBytes) * floatBytes;
+                const qsizetype rxTake =
+                    (std::min(len, m_rxOutputBuffer.size()) / floatBytes)
+                    * floatBytes;
                 if (rxTake > 0) {
-                    const auto* rx = reinterpret_cast<const float*>(m_rxBuffer.constData());
+                    const auto* rx =
+                        reinterpret_cast<const float*>(m_rxOutputBuffer.constData());
                     const qsizetype rxSamples = rxTake / floatBytes;
-                    for (qsizetype i = 0; i < rxSamples; ++i)
+                    bool sourceActive = false;
+                    for (qsizetype i = 0; i < rxSamples; ++i) {
+                        sourceActive = sourceActive
+                            || std::fabs(rx[i]) > kOutputSilenceThreshold;
                         out[i] += rx[i];
-                    m_rxBuffer.remove(0, rxTake);
+                    }
+                    if (sourceActive) {
+                        ++activeOutputSources;
+                    }
+                    m_rxOutputBuffer.remove(0, rxTake);
+                }
+
+                const qsizetype kiwiTake =
+                    (std::min(len, kiwiOutputBytes) / floatBytes)
+                    * floatBytes;
+                if (kiwiTake > 0) {
+                    const auto* kiwi =
+                        reinterpret_cast<const float*>(m_kiwiSdrOutputBuffer.constData());
+                    const qsizetype kiwiSamples = kiwiTake / floatBytes;
+                    bool sourceActive = false;
+                    for (qsizetype i = 0; i < kiwiSamples; ++i) {
+                        sourceActive = sourceActive
+                            || std::fabs(kiwi[i]) > kOutputSilenceThreshold;
+                        out[i] += kiwi[i];
+                    }
+                    if (sourceActive) {
+                        ++activeOutputSources;
+                    }
+                    m_kiwiSdrOutputBuffer.remove(0, kiwiTake);
+                }
+
+                for (const auto& source : m_externalKiwiSources) {
+                    if (!source || !source->enabled || source->muted
+                        || source->prebuffering) {
+                        continue;
+                    }
+                    const qsizetype sourceTake =
+                        (std::min(len, source->outputBuffer.size()) / floatBytes)
+                        * floatBytes;
+                    if (sourceTake <= 0) {
+                        continue;
+                    }
+                    const auto* kiwi =
+                        reinterpret_cast<const float*>(source->outputBuffer.constData());
+                    const qsizetype kiwiSamples = sourceTake / floatBytes;
+                    bool sourceActive = false;
+                    for (qsizetype i = 0; i < kiwiSamples; ++i) {
+                        const float sample = kiwi[i] * source->gain;
+                        sourceActive = sourceActive
+                            || std::fabs(sample) > kOutputSilenceThreshold;
+                        out[i] += sample;
+                    }
+                    if (sourceActive) {
+                        ++activeOutputSources;
+                    }
+                    source->outputBuffer.remove(0, sourceTake);
                 }
 
                 const qsizetype radeTake = (std::min(len, m_radeRxBuffer.size()) / floatBytes) * floatBytes;
                 if (radeTake > 0) {
                     const auto* rade = reinterpret_cast<const float*>(m_radeRxBuffer.constData());
                     const qsizetype radeSamples = radeTake / floatBytes;
-                    for (qsizetype i = 0; i < radeSamples; ++i)
+                    bool sourceActive = false;
+                    for (qsizetype i = 0; i < radeSamples; ++i) {
+                        sourceActive = sourceActive
+                            || std::fabs(rade[i]) > kOutputSilenceThreshold;
                         out[i] += rade[i];
+                    }
+                    if (sourceActive) {
+                        ++activeOutputSources;
+                    }
                     m_radeRxBuffer.remove(0, radeTake);
                 }
-                // Single clamp pass after all sources are mixed.
+
+                // Single gain/clamp pass after all sources are mixed. Use
+                // strict 1/N active-source scaling here: 1/sqrt(N) preserves
+                // more loudness but still lets three speech streams hard-clip
+                // and sound like NR2 static.
                 const qsizetype totalSamples = len / floatBytes;
-                for (qsizetype i = 0; i < totalSamples; ++i)
-                    out[i] = std::clamp(out[i], -1.0f, 1.0f);
+                const float mixGain = activeOutputSources > 1
+                    ? 1.0f / static_cast<float>(activeOutputSources)
+                    : 1.0f;
+                for (qsizetype i = 0; i < totalSamples; ++i) {
+                    out[i] = std::clamp(out[i] * mixGain, -1.0f, 1.0f);
+                }
             }
 
             len = m_audioDevice->write(chunk);
@@ -795,7 +1219,7 @@ AudioEngine::AudioEngine(QObject* parent)
             }
         }
 
-        m_rxBufferBytes.store(m_rxBuffer.size());
+        updateRxBufferStats();
     });
     m_rxTimer->start();
 }
@@ -933,6 +1357,24 @@ bool AudioEngine::startRxStream()
     if (m_audioSink) return true;   // already running
 
     m_rxBuffer.clear();
+    m_rxPackets.clear();
+    m_kiwiSdrRxBuffer.clear();
+    m_kiwiSdrRxPackets.clear();
+    m_rxOutputBuffer.clear();
+    m_kiwiSdrOutputBuffer.clear();
+    m_radeRxBuffer.clear();
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source) {
+            continue;
+        }
+        source->rxBuffer.clear();
+        source->rxPackets.clear();
+        source->outputBuffer.clear();
+        source->nr2Output.clear();
+        source->rxResampler.reset();
+        source->rxResamplerR.reset();
+        source->prebuffering = source->enabled;
+    }
     m_rxBufferBytes.store(0);
     m_rxBufferPeakBytes.store(0);
     m_rxBufferUnderrunCount.store(0);
@@ -1128,7 +1570,26 @@ void AudioEngine::stopRxStream()
     stopSidetoneStream();
     stopQuindarLocalSink();
     m_rxBuffer.clear();
+    m_rxPackets.clear();
+    m_kiwiSdrRxBuffer.clear();
+    m_kiwiSdrRxPackets.clear();
+    m_rxOutputBuffer.clear();
+    m_kiwiSdrOutputBuffer.clear();
+    m_radeRxBuffer.clear();
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source) {
+            continue;
+        }
+        source->rxBuffer.clear();
+        source->rxPackets.clear();
+        source->outputBuffer.clear();
+        source->nr2Output.clear();
+        source->rxResampler.reset();
+        source->rxResamplerR.reset();
+        source->prebuffering = source->enabled;
+    }
     m_rxBufferBytes.store(0);
+    m_rxBufferPeakBytes.store(0);
     m_rxBufferSampleRate.store(DEFAULT_SAMPLE_RATE);
 
     if (m_audioSink) {
@@ -1339,15 +1800,25 @@ static void applyRxPanInPlace(float* stereo, int nFrames, int pan)
 // L and R are processed through separate Resampler instances so that any
 // per-channel difference (radio-applied audio_pan) is preserved.
 // processStereoToStereo() collapses L+R to mono — do NOT use it here.
-QByteArray AudioEngine::resampleStereo(const QByteArray& pcm)
+QByteArray AudioEngine::resampleStereo(const QByteArray& pcm,
+                                       RxDspSource source,
+                                       ExternalRxAudioSourceState* externalSource)
 {
     // Two independent L/R instances preserve VITA-49 per-channel pan (PreservePan
     // strategy — never collapse to mono here, #2403/#2459). Target the negotiated
     // device rate so 44.1k / 48k devices both work (#3306).
-    if (!m_rxResampler)
-        m_rxResampler = std::make_unique<Resampler>(24000, m_rxOutputRate.load());
-    if (!m_rxResamplerR)
-        m_rxResamplerR = std::make_unique<Resampler>(24000, m_rxOutputRate.load());
+    std::unique_ptr<Resampler>& leftResampler = externalSource
+        ? externalSource->rxResampler
+        : (source == RxDspSource::KiwiSdr ? m_kiwiSdrRxResampler : m_rxResampler);
+    std::unique_ptr<Resampler>& rightResampler = externalSource
+        ? externalSource->rxResamplerR
+        : (source == RxDspSource::KiwiSdr ? m_kiwiSdrRxResamplerR : m_rxResamplerR);
+    if (!leftResampler) {
+        leftResampler = std::make_unique<Resampler>(24000, m_rxOutputRate.load());
+    }
+    if (!rightResampler) {
+        rightResampler = std::make_unique<Resampler>(24000, m_rxOutputRate.load());
+    }
 
     const int frames = pcm.size() / (2 * static_cast<int>(sizeof(float)));
     if (frames <= 0) return {};
@@ -1360,8 +1831,8 @@ QByteArray AudioEngine::resampleStereo(const QByteArray& pcm)
         rBuf[i] = src[2 * i + 1];
     }
 
-    QByteArray lOut = m_rxResampler->process(lBuf.data(), frames);
-    QByteArray rOut = m_rxResamplerR->process(rBuf.data(), frames);
+    QByteArray lOut = leftResampler->process(lBuf.data(), frames);
+    QByteArray rOut = rightResampler->process(rBuf.data(), frames);
 
     const int outFrames = lOut.size() / static_cast<int>(sizeof(float));
     const int rFrames   = rOut.size() / static_cast<int>(sizeof(float));
@@ -1381,21 +1852,316 @@ QByteArray AudioEngine::resampleStereo(const QByteArray& pcm)
 
 void AudioEngine::feedAudioData(const QByteArray& pcm)
 {
+    processRxAudioData(pcm, true);
+}
+
+void AudioEngine::feedKiwiSdrAudioData(const QByteArray& pcm24kStereoFloat)
+{
+    if (!m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed)) {
+        return;
+    }
+    m_lastAudioFeedTime.start();
+
+    constexpr qsizetype kFrameBytes =
+        2 * static_cast<qsizetype>(sizeof(float));
+    const qsizetype alignedBytes =
+        (pcm24kStereoFloat.size() / kFrameBytes) * kFrameBytes;
+    if (alignedBytes <= 0) {
+        return;
+    }
+
+    const QByteArray alignedPcm =
+        alignedBytes == pcm24kStereoFloat.size()
+            ? pcm24kStereoFloat
+            : pcm24kStereoFloat.left(alignedBytes);
+
+    if (m_nr2Enabled.load(std::memory_order_relaxed)) {
+        std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+        m_kiwiSdrRxPackets.push_back(alignedPcm);
+        updateRxBufferStats();
+        return;
+    }
+
+    processRxAudioData(alignedPcm, false, RxAudioBuffer::KiwiSdr);
+}
+
+void AudioEngine::feedKiwiSdrAudioData(const QString& sourceId,
+                                       const QByteArray& pcm24kStereoFloat)
+{
+    ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
+    if (!source || !source->enabled || source->muted) {
+        return;
+    }
+    m_lastAudioFeedTime.start();
+
+    constexpr qsizetype kFrameBytes =
+        2 * static_cast<qsizetype>(sizeof(float));
+    const qsizetype alignedBytes =
+        (pcm24kStereoFloat.size() / kFrameBytes) * kFrameBytes;
+    if (alignedBytes <= 0) {
+        return;
+    }
+
+    const QByteArray alignedPcm =
+        alignedBytes == pcm24kStereoFloat.size()
+            ? pcm24kStereoFloat
+            : pcm24kStereoFloat.left(alignedBytes);
+
+    if (m_nr2Enabled.load(std::memory_order_relaxed)) {
+        std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+        source->rxPackets.push_back(alignedPcm);
+        updateRxBufferStats();
+        return;
+    }
+
+    source->rxBuffer.append(alignedPcm);
+    updateRxBufferStats();
+}
+
+void AudioEngine::setKiwiSdrAudioEnabled(bool on)
+{
+    if (m_kiwiSdrAudioEnabled.exchange(on, std::memory_order_relaxed) == on) {
+        return;
+    }
+
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    m_kiwiSdrRxBuffer.clear();
+    m_kiwiSdrRxPackets.clear();
+    m_kiwiSdrOutputBuffer.clear();
+    m_kiwiSdrNr2Mono.clear();
+    m_kiwiSdrNr2Processed.clear();
+    m_kiwiSdrNr2Output.clear();
+    m_kiwiSdrRxResampler.reset();
+    m_kiwiSdrRxResamplerR.reset();
+    if (m_nr2Enabled && m_kiwiSdrNr2) {
+        m_kiwiSdrNr2->reset();
+    }
+    m_kiwiSdrPrebuffering = on;
+    updateRxBufferStats();
+}
+
+void AudioEngine::setKiwiSdrAudioSourceEnabled(const QString& sourceId, bool on)
+{
+    ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, on);
+    if (!source || source->enabled == on) {
+        return;
+    }
+
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    source->enabled = on;
+    source->rxBuffer.clear();
+    source->rxPackets.clear();
+    source->outputBuffer.clear();
+    source->nr2Mono.clear();
+    source->nr2Processed.clear();
+    source->nr2Output.clear();
+    source->rxResampler.reset();
+    source->rxResamplerR.reset();
+    if (on && m_nr2Enabled.load(std::memory_order_relaxed) && !source->nr2) {
+        source->nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
+        if (source->nr2->hasPlanFailed()) {
+            qCWarning(lcAudio) << "AudioEngine: external Kiwi NR2 plan failed for"
+                               << source->id;
+            source->nr2.reset();
+        } else {
+            applyNr2SettingsFromAppSettings(*source->nr2);
+        }
+    }
+    source->prebuffering = on;
+    updateRxBufferStats();
+}
+
+void AudioEngine::setKiwiSdrAudioSourceGain(const QString& sourceId,
+                                            float gainPercent)
+{
+    ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
+    if (!source) {
+        return;
+    }
+
+    source->gain = std::clamp(gainPercent, 0.0f, 100.0f) / 100.0f;
+}
+
+void AudioEngine::setKiwiSdrAudioSourceMuted(const QString& sourceId,
+                                             bool muted)
+{
+    ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
+    if (!source || source->muted == muted) {
+        return;
+    }
+
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    source->muted = muted;
+    source->rxBuffer.clear();
+    source->rxPackets.clear();
+    source->outputBuffer.clear();
+    source->nr2Mono.clear();
+    source->nr2Processed.clear();
+    source->nr2Output.clear();
+    source->prebuffering = !muted && source->enabled;
+    updateRxBufferStats();
+}
+
+void AudioEngine::removeKiwiSdrAudioSource(const QString& sourceId)
+{
+    const QString id = sourceId.trimmed();
+    if (id.isEmpty()) {
+        return;
+    }
+
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    const auto it = std::remove_if(
+        m_externalKiwiSources.begin(), m_externalKiwiSources.end(),
+        [&id](const std::unique_ptr<ExternalRxAudioSourceState>& source) {
+            return source && source->id == id;
+        });
+    if (it != m_externalKiwiSources.end()) {
+        m_externalKiwiSources.erase(it, m_externalKiwiSources.end());
+        updateRxBufferStats();
+    }
+}
+
+void AudioEngine::resetRxChainStateForSourceSwitch()
+{
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+
+    m_rxResampler.reset();
+    m_rxResamplerR.reset();
+    m_rxPackets.clear();
+    m_kiwiSdrRxResampler.reset();
+    m_kiwiSdrRxResamplerR.reset();
+    m_clientEqRxScratch.clear();
+    m_clientGateRxScratch.clear();
+    m_clientCompRxScratch.clear();
+    m_clientDeEssRxScratch.clear();
+    m_clientTubeRxScratch.clear();
+    m_clientPuduRxScratch.clear();
+    m_nr2Mono.clear();
+    m_nr2Processed.clear();
+    m_nr2Output.clear();
+    m_kiwiSdrNr2Mono.clear();
+    m_kiwiSdrNr2Processed.clear();
+    m_kiwiSdrNr2Output.clear();
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source) {
+            continue;
+        }
+        source->rxBuffer.clear();
+        source->rxPackets.clear();
+        source->outputBuffer.clear();
+        source->nr2Mono.clear();
+        source->nr2Processed.clear();
+        source->nr2Output.clear();
+        source->rxResampler.reset();
+        source->rxResamplerR.reset();
+        if (m_nr2Enabled && source->nr2) {
+            source->nr2->reset();
+        }
+        source->prebuffering = source->enabled && !source->muted;
+    }
+
+    if (m_clientEqRx) {
+        m_clientEqRx->reset();
+    }
+    if (m_clientGateRx) {
+        m_clientGateRx->reset();
+    }
+    if (m_clientCompRx) {
+        m_clientCompRx->reset();
+    }
+    if (m_clientDeEssRx) {
+        m_clientDeEssRx->reset();
+    }
+    if (m_clientTubeRx) {
+        m_clientTubeRx->reset();
+    }
+    if (m_clientPuduRx) {
+        m_clientPuduRx->reset();
+    }
+    if (m_nr2Enabled && m_nr2) {
+        m_nr2->reset();
+    }
+    if (m_nr2Enabled && m_kiwiSdrNr2) {
+        m_kiwiSdrNr2->reset();
+    }
+    if (m_rn2Enabled && m_rn2) {
+        m_rn2->reset();
+    }
+#ifdef HAVE_SPECBLEACH
+    if (m_nr4Enabled && m_nr4) {
+        m_nr4->reset();
+    }
+#endif
+#ifdef HAVE_DFNR
+    if (m_dfnrEnabled && m_dfnr) {
+        m_dfnr->reset();
+    }
+#endif
+#ifdef __APPLE__
+    if (m_mnrEnabled && m_mnr) {
+        m_mnr->reset();
+    }
+#endif
+    if (m_bnrEnabled) {
+        m_bnrUp = std::make_unique<Resampler>(24000, 48000, 16384);
+        m_bnrDown = std::make_unique<Resampler>(48000, 24000, 16384);
+        m_bnrOutBuf.clear();
+        m_bnrPrimed = false;
+    }
+}
+
+void AudioEngine::processRxAudioData(const QByteArray& pcm, bool emitTncTap,
+                                     RxAudioBuffer targetBuffer)
+{
     if (!m_audioSink) return;  // PC audio disabled
     m_lastAudioFeedTime.start();  // reset liveness watchdog (#1411)
 
-    // feedAudioData() handles all remote_audio_rx paths: SSB/CW/digital on any pan,
-    // and the zero-filled frames the radio sends for the muted RADE slice
-    // (audio_mute=1 zeroes the payload — it does NOT suppress packets).
-    // All of these write to m_rxBuffer. Decoded RADE speech is separate:
-    // feedDecodedSpeech() writes to m_radeRxBuffer. The drain timer mixes both
-    // sample-wise before writing to the device, so zero frames from the muted
-    // RADE slice add nothing to the output and SSB audio on a second pan is
-    // heard alongside RADE decoded speech without fill-rate interference.
-    if (m_tncRxTapEnabled.load(std::memory_order_relaxed))
+    // Source callbacks queue native 24 kHz stereo PCM only. With NR2 enabled,
+    // each receive source keeps whole packet-sized blocks until the timer
+    // processes that source through its own NR2/output path. The speaker drain
+    // mixes post-DSP output FIFOs at the sink.
+    if (emitTncTap && m_tncRxTapEnabled.load(std::memory_order_relaxed)) {
         emitTncRxTapFromFloat32Stereo(pcm, DEFAULT_SAMPLE_RATE);
+    }
 
-    auto writeAudio = [this](const QByteArray& data) {
+    constexpr qsizetype kFrameBytes = 2 * static_cast<qsizetype>(sizeof(float));
+    const qsizetype alignedBytes = (pcm.size() / kFrameBytes) * kFrameBytes;
+    if (alignedBytes <= 0) {
+        return;
+    }
+
+    const QByteArray alignedPcm =
+        alignedBytes == pcm.size() ? pcm : pcm.left(alignedBytes);
+
+    if (targetBuffer == RxAudioBuffer::Main
+        && m_nr2Enabled.load(std::memory_order_relaxed)) {
+        std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+        m_rxPackets.push_back(alignedPcm);
+        updateRxBufferStats();
+        return;
+    }
+
+    QByteArray& target =
+        targetBuffer == RxAudioBuffer::KiwiSdr ? m_kiwiSdrRxBuffer
+                                               : m_rxBuffer;
+    target.append(alignedPcm);
+    updateRxBufferStats();
+}
+
+void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
+                                          RxDspSource source,
+                                          ExternalRxAudioSourceState* externalSource)
+{
+    if (!m_audioSink) return;  // PC audio disabled
+
+    // feedAudioData() handles all remote_audio_rx paths: SSB/CW/digital on any
+    // pan, and the zero-filled frames the radio sends for muted slices
+    // (audio_mute=1 zeroes the payload; it does NOT suppress packets).
+    // The caller supplies exactly one native 24 kHz stereo source stream:
+    // Flex audio, the legacy Kiwi stream, or one virtual Kiwi antenna stream.
+    // Stateful NR/output resamplers must never see alternating Flex/Kiwi or
+    // different Kiwi endpoints on the same DSP state.
+    auto writeAudio = [this, source, externalSource](const QByteArray& data) {
         if (!m_audioDevice || !m_audioDevice->isOpen()) return;
 
         // Client-side parametric EQ runs at the native 24 kHz rate, after
@@ -1469,7 +2235,10 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
         }
 
         const int scopeSampleRate = m_rxOutputRate.load();
-        const QByteArray& resampled = (m_rxOutputRate.load() != DEFAULT_SAMPLE_RATE) ? resampleStereo(*puduSource) : *puduSource;
+        const QByteArray& resampled =
+            (m_rxOutputRate.load() != DEFAULT_SAMPLE_RATE)
+                ? resampleStereo(*puduSource, source, externalSource)
+                : *puduSource;
         const QByteArray* output = &resampled;
         QByteArray boosted;
         if (m_rxBoost.load()) {
@@ -1496,7 +2265,11 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
             for (int i = 0; i < nSamples; ++i) dst[i] = src[i] * gain;
             output = &trimmed;
         }
-        m_rxBuffer.append(*output);
+        QByteArray& outputBuffer = externalSource
+            ? externalSource->outputBuffer
+            : (source == RxDspSource::KiwiSdr ? m_kiwiSdrOutputBuffer
+                                               : m_rxOutputBuffer);
+        outputBuffer.append(*output);
         emitScopeFromFloat32Stereo(*output, scopeSampleRate, false);
         emitRxPostChainScopeFromFloat32Stereo(*output, scopeSampleRate);
         updateRxBufferStats();
@@ -1521,9 +2294,13 @@ void AudioEngine::feedAudioData(const QByteArray& pcm)
             writeAudio(processed);
             emit levelChanged(computeRMS(processed));
         } else if (m_nr2Enabled && m_nr2) {
-            processNr2(pcm);  // applyRxPanInPlace called inside processNr2
-            writeAudio(m_nr2Output);
-            emit levelChanged(computeRMS(m_nr2Output));
+            processNr2(pcm, source, externalSource);  // applyRxPanInPlace called inside processNr2
+            const QByteArray& nr2Output = externalSource
+                ? externalSource->nr2Output
+                : (source == RxDspSource::KiwiSdr ? m_kiwiSdrNr2Output
+                                                   : m_nr2Output);
+            writeAudio(nr2Output);
+            emit levelChanged(computeRMS(nr2Output));
 
 #ifdef HAVE_SPECBLEACH
         } else if (m_nr4Enabled && m_nr4) {
@@ -3450,6 +4227,17 @@ static void logNr2WisdomGenerationSummary(SpectralNR::WisdomResult result)
     }
 }
 
+static void applyNr2SettingsFromAppSettings(SpectralNR& nr2)
+{
+    auto& s = AppSettings::instance();
+    nr2.setGainMax(s.value("NR2GainMax", "1.00").toFloat());  // default 1.0 = no amplification (#1507)
+    nr2.setGainSmooth(s.value("NR2GainSmooth", "0.85").toFloat());
+    nr2.setQspp(s.value("NR2Qspp", "0.20").toFloat());
+    nr2.setGainMethod(s.value("NR2GainMethod", "2").toInt());
+    nr2.setNpeMethod(s.value("NR2NpeMethod", "0").toInt());
+    nr2.setAeFilter(s.value("NR2AeFilter", "True").toString() == "True");
+}
+
 bool AudioEngine::needsWisdomGeneration()
 {
 #ifndef HAVE_FFTW3
@@ -3485,6 +4273,35 @@ void AudioEngine::setNr2Enabled(bool on)
 {
     if (m_nr2Enabled == on) return;
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    m_rxBuffer.clear();
+    m_rxPackets.clear();
+    m_rxOutputBuffer.clear();
+    m_kiwiSdrRxBuffer.clear();
+    m_kiwiSdrRxPackets.clear();
+    m_kiwiSdrOutputBuffer.clear();
+    m_kiwiSdrRxResampler.reset();
+    m_kiwiSdrRxResamplerR.reset();
+    m_nr2Mono.clear();
+    m_nr2Processed.clear();
+    m_nr2Output.clear();
+    m_kiwiSdrNr2Mono.clear();
+    m_kiwiSdrNr2Processed.clear();
+    m_kiwiSdrNr2Output.clear();
+    m_kiwiSdrPrebuffering = m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed);
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source) {
+            continue;
+        }
+        source->rxBuffer.clear();
+        source->rxPackets.clear();
+        source->outputBuffer.clear();
+        source->nr2Mono.clear();
+        source->nr2Processed.clear();
+        source->nr2Output.clear();
+        source->rxResampler.reset();
+        source->rxResamplerR.reset();
+        source->prebuffering = source->enabled && !source->muted;
+    }
     if (on) {
         // Disable all other NR modes — they're mutually exclusive
         if (m_rn2Enabled)  setRn2Enabled(false);
@@ -3501,35 +4318,118 @@ void AudioEngine::setNr2Enabled(bool on)
                                << "using runtime FFTW_MEASURE plans";
 #endif
         m_nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
-        if (m_nr2->hasPlanFailed()) {
+        m_kiwiSdrNr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
+        if (m_nr2->hasPlanFailed() || m_kiwiSdrNr2->hasPlanFailed()) {
             qCWarning(lcAudio) << "AudioEngine: NR2 FFTW plan creation failed — disabling";
             m_nr2.reset();
+            m_kiwiSdrNr2.reset();
             emit nr2EnabledChanged(false);
             return;
         }
         // Restore user-adjusted parameters from AppSettings
-        auto& s = AppSettings::instance();
-        m_nr2->setGainMax(s.value("NR2GainMax", "1.00").toFloat());  // default 1.0 = no amplification (#1507)
-        m_nr2->setGainSmooth(s.value("NR2GainSmooth", "0.85").toFloat());
-        m_nr2->setQspp(s.value("NR2Qspp", "0.20").toFloat());
-        m_nr2->setGainMethod(s.value("NR2GainMethod", "2").toInt());
-        m_nr2->setNpeMethod(s.value("NR2NpeMethod", "0").toInt());
-        m_nr2->setAeFilter(s.value("NR2AeFilter", "True").toString() == "True");
+        applyNr2SettingsFromAppSettings(*m_nr2);
+        applyNr2SettingsFromAppSettings(*m_kiwiSdrNr2);
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source) {
+                continue;
+            }
+            source->nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
+            if (source->nr2->hasPlanFailed()) {
+                qCWarning(lcAudio) << "AudioEngine: external Kiwi NR2 plan failed for"
+                                   << source->id;
+                source->nr2.reset();
+            } else {
+                applyNr2SettingsFromAppSettings(*source->nr2);
+            }
+        }
         m_nr2Enabled = true;
     } else {
         m_nr2Enabled = false;
         m_nr2.reset();
+        m_kiwiSdrNr2.reset();
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source) {
+                continue;
+            }
+            source->nr2.reset();
+            source->nr2Mono.clear();
+            source->nr2Processed.clear();
+            source->nr2Output.clear();
+            source->outputBuffer.clear();
+            source->rxResampler.reset();
+            source->rxResamplerR.reset();
+            source->prebuffering = source->enabled && !source->muted;
+        }
     }
     qCDebug(lcAudio) << "AudioEngine: NR2" << (on ? "enabled" : "disabled");
     emit nr2EnabledChanged(on);
 }
 
-void AudioEngine::setNr2GainMax(float v)    { if (m_nr2) m_nr2->setGainMax(v); }
-void AudioEngine::setNr2Qspp(float v)      { if (m_nr2) m_nr2->setQspp(v); }
-void AudioEngine::setNr2GainSmooth(float v) { if (m_nr2) m_nr2->setGainSmooth(v); }
-void AudioEngine::setNr2GainMethod(int m)   { if (m_nr2) m_nr2->setGainMethod(m); }
-void AudioEngine::setNr2NpeMethod(int m)    { if (m_nr2) m_nr2->setNpeMethod(m); }
-void AudioEngine::setNr2AeFilter(bool on)   { if (m_nr2) m_nr2->setAeFilter(on); }
+void AudioEngine::setNr2GainMax(float v)
+{
+    if (m_nr2) m_nr2->setGainMax(v);
+    if (m_kiwiSdrNr2) m_kiwiSdrNr2->setGainMax(v);
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr2) {
+            source->nr2->setGainMax(v);
+        }
+    }
+}
+
+void AudioEngine::setNr2Qspp(float v)
+{
+    if (m_nr2) m_nr2->setQspp(v);
+    if (m_kiwiSdrNr2) m_kiwiSdrNr2->setQspp(v);
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr2) {
+            source->nr2->setQspp(v);
+        }
+    }
+}
+
+void AudioEngine::setNr2GainSmooth(float v)
+{
+    if (m_nr2) m_nr2->setGainSmooth(v);
+    if (m_kiwiSdrNr2) m_kiwiSdrNr2->setGainSmooth(v);
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr2) {
+            source->nr2->setGainSmooth(v);
+        }
+    }
+}
+
+void AudioEngine::setNr2GainMethod(int m)
+{
+    if (m_nr2) m_nr2->setGainMethod(m);
+    if (m_kiwiSdrNr2) m_kiwiSdrNr2->setGainMethod(m);
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr2) {
+            source->nr2->setGainMethod(m);
+        }
+    }
+}
+
+void AudioEngine::setNr2NpeMethod(int m)
+{
+    if (m_nr2) m_nr2->setNpeMethod(m);
+    if (m_kiwiSdrNr2) m_kiwiSdrNr2->setNpeMethod(m);
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr2) {
+            source->nr2->setNpeMethod(m);
+        }
+    }
+}
+
+void AudioEngine::setNr2AeFilter(bool on)
+{
+    if (m_nr2) m_nr2->setAeFilter(on);
+    if (m_kiwiSdrNr2) m_kiwiSdrNr2->setAeFilter(on);
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr2) {
+            source->nr2->setAeFilter(on);
+        }
+    }
+}
 
 
 #ifdef HAVE_SPECBLEACH
@@ -3860,7 +4760,7 @@ void AudioEngine::processBnr(const QByteArray& stereoPcm)
                 for (int i = 0; i < nSamples; ++i) dst[i] = src[i] * gain;
                 output = &trimmed;
             }
-            m_rxBuffer.append(*output);
+            m_rxOutputBuffer.append(*output);
             emitScopeFromFloat32Stereo(*output, scopeSampleRate, false);
             emitRxPostChainScopeFromFloat32Stereo(*output, scopeSampleRate);
             updateRxBufferStats();
@@ -3928,34 +4828,52 @@ float AudioEngine::dfnrAttenLimit() const { return 100.0f; }
 void AudioEngine::setDfnrPostFilterBeta(float) {}
 #endif // HAVE_DFNR
 
-void AudioEngine::processNr2(const QByteArray& stereoPcm)
+void AudioEngine::processNr2(const QByteArray& stereoPcm,
+                             RxDspSource source,
+                             ExternalRxAudioSourceState* externalSource)
 {
     const int totalFloats = stereoPcm.size() / static_cast<int>(sizeof(float));
     const int stereoFrames = totalFloats / 2;
     const auto* src = reinterpret_cast<const float*>(stereoPcm.constData());
+    SpectralNR* nr2 = externalSource
+        ? externalSource->nr2.get()
+        : (source == RxDspSource::KiwiSdr ? m_kiwiSdrNr2.get() : m_nr2.get());
+    std::vector<float>& mono = externalSource
+        ? externalSource->nr2Mono
+        : (source == RxDspSource::KiwiSdr ? m_kiwiSdrNr2Mono : m_nr2Mono);
+    std::vector<float>& processed = externalSource
+        ? externalSource->nr2Processed
+        : (source == RxDspSource::KiwiSdr ? m_kiwiSdrNr2Processed : m_nr2Processed);
+    QByteArray& output = externalSource
+        ? externalSource->nr2Output
+        : (source == RxDspSource::KiwiSdr ? m_kiwiSdrNr2Output : m_nr2Output);
+    if (!nr2) {
+        output = stereoPcm;
+        return;
+    }
 
     // Resize pre-allocated buffers if needed
-    if (static_cast<int>(m_nr2Mono.size()) < stereoFrames) {
-        m_nr2Mono.resize(stereoFrames);
-        m_nr2Processed.resize(stereoFrames);
+    if (static_cast<int>(mono.size()) < stereoFrames) {
+        mono.resize(stereoFrames);
+        processed.resize(stereoFrames);
     }
 
     // Stereo float32 → mono float32 (average L+R)
     for (int i = 0; i < stereoFrames; ++i)
-        m_nr2Mono[i] = (src[2 * i] + src[2 * i + 1]) * 0.5f;
+        mono[i] = (src[2 * i] + src[2 * i + 1]) * 0.5f;
 
     // Process through SpectralNR (float32 I/O)
-    m_nr2->process(m_nr2Mono.data(), m_nr2Processed.data(), stereoFrames);
+    nr2->process(mono.data(), processed.data(), stereoFrames);
 
     // Mono float32 → stereo float32, then re-apply the pan the radio had set
     // before NR mono-mixed it away (#1460).
     // Hard-clamp to ±1.0: if gainMax was tuned above 1.0 (not recommended),
     // unclamped samples would cause digital crackling at the audio sink (#1507).
     const int outBytes = stereoFrames * 2 * static_cast<int>(sizeof(float));
-    m_nr2Output.resize(outBytes);
-    auto* dst = reinterpret_cast<float*>(m_nr2Output.data());
+    output.resize(outBytes);
+    auto* dst = reinterpret_cast<float*>(output.data());
     for (int i = 0; i < stereoFrames; ++i) {
-        const float s = std::clamp(m_nr2Processed[i], -1.0f, 1.0f);
+        const float s = std::clamp(processed[i], -1.0f, 1.0f);
         dst[2 * i]     = s;
         dst[2 * i + 1] = s;
     }
@@ -5127,10 +6045,11 @@ void AudioEngine::feedDecodedSpeech(const QByteArray& pcm)
 {
     if (!m_audioSink || !m_audioDevice || !m_audioDevice->isOpen()) return;
 
-    // Decoded RADE speech goes into its own buffer. The drain timer mixes
-    // m_radeRxBuffer with m_rxBuffer sample-wise so both are heard simultaneously
-    // without doubling the fill rate. A dedicated resampler preserves the filter
-    // state independently from the m_rxResampler used by feedAudioData().
+    // Decoded RADE speech goes into its own output-rate buffer. The drain
+    // timer mixes it with m_rxOutputBuffer sample-wise so both are heard
+    // simultaneously without doubling the fill rate. A dedicated resampler
+    // preserves the filter state independently from the main RX output
+    // resampler used by processMixedRxAudioData().
     if (m_rxOutputRate.load() != DEFAULT_SAMPLE_RATE) {
         if (!m_radeRxResampler)
             m_radeRxResampler = std::make_unique<Resampler>(24000, m_rxOutputRate.load());

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -16,6 +16,7 @@
 #include <QByteArray>
 #include <QElapsedTimer>
 #include <QPointer>
+#include <QString>
 
 #include "TxMicChannelNormalizer.h"
 #include "SpectralNR.h"
@@ -24,6 +25,7 @@ class QMediaDevices;
 
 #include <functional>
 #include <memory>
+#include <deque>
 #include <vector>
 #include <cstdint>
 
@@ -481,6 +483,16 @@ public:
 public slots:
     // Receives stripped PCM from PanadapterStream::audioDataReady().
     void feedAudioData(const QByteArray& pcm);
+    // Receives decoded KiwiSDR PCM after a clean protocol decoder exists.
+    // Same format as feedAudioData(): 24 kHz stereo float32.
+    void feedKiwiSdrAudioData(const QByteArray& pcm24kStereoFloat);
+    void feedKiwiSdrAudioData(const QString& sourceId,
+                              const QByteArray& pcm24kStereoFloat);
+    void setKiwiSdrAudioEnabled(bool on);
+    void setKiwiSdrAudioSourceEnabled(const QString& sourceId, bool on);
+    void setKiwiSdrAudioSourceGain(const QString& sourceId, float gainPercent);
+    void setKiwiSdrAudioSourceMuted(const QString& sourceId, bool muted);
+    void removeKiwiSdrAudioSource(const QString& sourceId);
 
 signals:
     void rxStarted();
@@ -539,6 +551,33 @@ private slots:
     void onTxAudioReady();
 
 private:
+    enum class RxAudioBuffer {
+        Main,
+        KiwiSdr,
+    };
+
+    enum class RxDspSource {
+        Main,
+        KiwiSdr,
+    };
+
+    struct ExternalRxAudioSourceState {
+        QString id;
+        QByteArray rxBuffer;
+        std::deque<QByteArray> rxPackets;
+        QByteArray outputBuffer;
+        std::vector<float> nr2Mono;
+        std::vector<float> nr2Processed;
+        QByteArray nr2Output;
+        std::unique_ptr<SpectralNR> nr2;
+        std::unique_ptr<Resampler> rxResampler;
+        std::unique_ptr<Resampler> rxResamplerR;
+        float gain{1.0f};
+        bool enabled{false};
+        bool muted{false};
+        bool prebuffering{false};
+    };
+
     QAudioFormat makeFormat() const;
     float computeRMS(const QByteArray& pcm) const;
     QByteArray applyBoost(const QByteArray& pcm, float gain) const;
@@ -550,9 +589,23 @@ private:
     void emitTxPostChainScopeFromFloat32Stereo(const QByteArray& pcm, int sampleRate);
     void emitRxPostChainScopeFromFloat32Stereo(const QByteArray& pcm, int sampleRate);
     void emitTncRxTapFromFloat32Stereo(const QByteArray& pcm, int sampleRate);
-    QByteArray resampleStereo(const QByteArray& pcm);
-    void processNr2(const QByteArray& stereoPcm);
+    QByteArray resampleStereo(const QByteArray& pcm,
+                              RxDspSource source = RxDspSource::Main,
+                              ExternalRxAudioSourceState* externalSource = nullptr);
+    void processRxAudioData(const QByteArray& pcm, bool emitTncTap,
+                            RxAudioBuffer targetBuffer = RxAudioBuffer::Main);
+    void processMixedRxAudioData(const QByteArray& pcm,
+                                 RxDspSource source = RxDspSource::Main,
+                                 ExternalRxAudioSourceState* externalSource = nullptr);
+    void processNr2(const QByteArray& stereoPcm,
+                    RxDspSource source = RxDspSource::Main,
+                    ExternalRxAudioSourceState* externalSource = nullptr);
     void updateRxBufferStats();
+    ExternalRxAudioSourceState* externalKiwiSource(const QString& sourceId,
+                                                   bool create);
+    bool anyExternalKiwiAudioEnabled() const;
+    bool anyExternalKiwiBufferQueued() const;
+    qsizetype externalKiwiOutputBufferBytes() const;
     // Apply client-side TX EQ in-place. No-op if disabled. Caller owns data.
     void applyClientEqTxInt16(QByteArray& int16stereo);
     void applyClientEqTxFloat32(QByteArray& float32);
@@ -712,6 +765,7 @@ private:
 
     // Client-side NR2 (spectral)
     std::unique_ptr<SpectralNR> m_nr2;
+    std::unique_ptr<SpectralNR> m_kiwiSdrNr2;
     std::atomic<bool> m_nr2Enabled{false};
     // Client-side NR4 (libspecbleach)
 #ifdef HAVE_SPECBLEACH
@@ -851,6 +905,9 @@ private:
     std::vector<float> m_nr2Mono;
     std::vector<float> m_nr2Processed;
     QByteArray m_nr2Output;
+    std::vector<float> m_kiwiSdrNr2Mono;
+    std::vector<float> m_kiwiSdrNr2Processed;
+    QByteArray m_kiwiSdrNr2Output;
 
     // Zombie sink watchdog: tracks consecutive RX timer ticks where we have
     // data to write but bytesFree() == 0, indicating a stale WASAPI handle.
@@ -884,12 +941,25 @@ private:
 
     // RX audio buffer handling
     QTimer*       m_rxTimer{nullptr};
-    QByteArray    m_rxBuffer;
-    QByteArray    m_radeRxBuffer;  // decoded RADE speech; mixed into drain output, never appended to m_rxBuffer
+    QByteArray    m_rxBuffer;  // normal Flex RX source audio at 24 kHz, pre-DSP
+    std::deque<QByteArray> m_rxPackets;  // whole Flex packets for NR2 packet-mode
+    QByteArray    m_kiwiSdrRxBuffer;  // decoded Kiwi source audio at 24 kHz, pre-DSP
+    std::deque<QByteArray> m_kiwiSdrRxPackets;  // whole Kiwi packets for NR2 packet-mode
+    QByteArray    m_rxOutputBuffer;  // post-DSP speaker audio at output device rate
+    QByteArray    m_kiwiSdrOutputBuffer;  // post-DSP Kiwi speaker audio at output device rate
+    QByteArray    m_radeRxBuffer;  // decoded RADE speech at output device rate
+    std::atomic<bool> m_kiwiSdrAudioEnabled{false};
+    bool          m_kiwiSdrPrebuffering{false};
+    std::vector<std::unique_ptr<ExternalRxAudioSourceState>> m_externalKiwiSources;
     std::atomic<qsizetype> m_rxBufferBytes{0};
     std::atomic<qsizetype> m_rxBufferPeakBytes{0};
     std::atomic<quint64>   m_rxBufferUnderrunCount{0};
     std::atomic<int>       m_rxBufferSampleRate{DEFAULT_SAMPLE_RATE};
+    static constexpr int   kKiwiSdrJitterTargetMs = 360;
+    static constexpr int   kKiwiSdrBufferCapMs = 1000;
+    void resetRxChainStateForSourceSwitch();
+    std::unique_ptr<Resampler> m_kiwiSdrRxResampler;
+    std::unique_ptr<Resampler> m_kiwiSdrRxResamplerR;
 
     // VITA-49 TX constants
     static constexpr int    TX_SAMPLES_PER_PACKET = 128;  // audio frames per packet

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -1,0 +1,1659 @@
+#include "KiwiSdrClient.h"
+
+#include "KiwiSdrProtocol.h"
+#include "LogManager.h"
+#include "Resampler.h"
+
+#include <QDateTime>
+#include <QStringList>
+#include <QTimer>
+#include <QUrl>
+
+#ifdef HAVE_WEBSOCKETS
+#include <QAbstractSocket>
+#include <QWebSocket>
+#include <QWebSocketProtocol>
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace AetherSDR {
+namespace {
+constexpr int kAudioReadyTimeoutMs = 12000;
+constexpr quint16 kDefaultKiwiSdrPort = 8073;
+constexpr double kDefaultWaterfallCenterMhz = 15.0;
+constexpr double kDefaultWaterfallBandwidthMhz = 30.0;
+constexpr int kSpecSoundHeaderBytes = 6;
+constexpr int kObservedSoundHeaderBytes = 10;
+constexpr int kObservedSoundFrameBytes = 1034;
+constexpr int kSpecWaterfallHeaderBytes = 4;
+constexpr int kExtendedWaterfallHeaderBytes = 16;
+constexpr int kZoomedWaterfallPrefixBytes = 5;
+constexpr int kDefaultWaterfallZoomCap = 14;
+constexpr int kDefaultWaterfallFftBins = 1024;
+constexpr quint64 kMaxSequenceGapPaddingFrames = 8;
+constexpr double kWaterfallStartFixedPointScale = 16777216.0; // 2^24
+constexpr quint32 kWaterfallStartServerSnapTolerance = 16;
+
+quint32 readLittleEndianU32(const char* data)
+{
+    const auto* bytes = reinterpret_cast<const uchar*>(data);
+    return static_cast<quint32>(bytes[0])
+        | (static_cast<quint32>(bytes[1]) << 8)
+        | (static_cast<quint32>(bytes[2]) << 16)
+        | (static_cast<quint32>(bytes[3]) << 24);
+}
+
+int sanitizedWaterfallFftBins(int binCount)
+{
+    return std::clamp(binCount, 16, 65536);
+}
+
+bool plausibleWaterfallFftBins(int binCount)
+{
+    return binCount >= 128
+        && binCount <= 65536
+        && (binCount & (binCount - 1)) == 0;
+}
+
+double waterfallZoomScale(int zoom)
+{
+    return std::ldexp(1.0, std::clamp(zoom, 0, 30));
+}
+
+double waterfallRowSpanMhz(double fullBandwidthMhz, int zoom)
+{
+    return fullBandwidthMhz / waterfallZoomScale(zoom);
+}
+
+quint32 waterfallStartFixedPoint(double fullLowMhz, double fullBandwidthMhz,
+                                 double rowLowMhz)
+{
+    const double requested = fullBandwidthMhz > 0.0
+        ? ((rowLowMhz - fullLowMhz) / fullBandwidthMhz)
+              * kWaterfallStartFixedPointScale
+        : 0.0;
+    return static_cast<quint32>(std::clamp(
+        std::isfinite(requested) ? std::round(requested) : 0.0,
+        0.0,
+        std::min(kWaterfallStartFixedPointScale - 1.0,
+                 static_cast<double>(std::numeric_limits<quint32>::max()))));
+}
+
+double waterfallStartFixedPointToLowMhz(double fullLowMhz,
+                                        double fullBandwidthMhz,
+                                        quint32 start)
+{
+    return fullLowMhz
+        + (static_cast<double>(start) / kWaterfallStartFixedPointScale)
+            * fullBandwidthMhz;
+}
+
+double waterfallMetadataValueToMhz(double value)
+{
+    if (!std::isfinite(value) || value <= 0.0) {
+        return 0.0;
+    }
+    if (value >= 1000000.0) {
+        return value / 1000000.0;
+    }
+    if (value >= 1000.0) {
+        return value / 1000.0;
+    }
+    return value;
+}
+
+KiwiSdrReceiverControls normalizedControls(
+    const KiwiSdrReceiverControls& controls)
+{
+    KiwiSdrReceiverControls normalized = controls;
+    normalized.agcGainDb = std::clamp(normalized.agcGainDb, 0, 100);
+    normalized.agcThresholdDb = std::clamp(normalized.agcThresholdDb, -100, -10);
+    normalized.agcDecayMs = std::clamp(normalized.agcDecayMs, 200, 5000);
+    normalized.squelchLevelDbm =
+        std::clamp(normalized.squelchLevelDbm, -160.0, 0.0);
+    return normalized;
+}
+
+bool controlsEqual(const KiwiSdrReceiverControls& a,
+                   const KiwiSdrReceiverControls& b)
+{
+    return a.agcEnabled == b.agcEnabled
+        && a.agcGainDb == b.agcGainDb
+        && a.agcHang == b.agcHang
+        && a.agcThresholdDb == b.agcThresholdDb
+        && a.agcDecayMs == b.agcDecayMs
+        && a.squelchEnabled == b.squelchEnabled
+        && std::abs(a.squelchLevelDbm - b.squelchLevelDbm) < 0.001;
+}
+
+QString redactedKiwiCommand(const QString& command)
+{
+    if (!command.startsWith(QStringLiteral("SET auth "))) {
+        return command;
+    }
+
+    const QString passwordMarker = QStringLiteral(" p=");
+    const int passwordStart = command.indexOf(passwordMarker);
+    if (passwordStart < 0) {
+        return command;
+    }
+
+    const int valueStart = passwordStart + passwordMarker.size();
+    const int valueEnd = command.indexOf(QLatin1Char(' '), valueStart);
+    const QString password = valueEnd < 0
+        ? command.mid(valueStart)
+        : command.mid(valueStart, valueEnd - valueStart);
+    if (password == QStringLiteral("#")) {
+        return command;
+    }
+
+    QString redacted = command;
+    redacted.replace(valueStart, password.size(), QStringLiteral("<redacted>"));
+    return redacted;
+}
+
+QString firstBytesHex(const QByteArray& frame, int limit = 16)
+{
+    return QString::fromLatin1(frame.left(std::max(0, limit)).toHex(' '));
+}
+
+}
+
+KiwiSdrClient::KiwiSdrClient(QObject* parent)
+    : QObject(parent)
+{
+    m_keepaliveTimer = new QTimer(this);
+    m_keepaliveTimer->setInterval(10000);
+    connect(m_keepaliveTimer, &QTimer::timeout,
+            this, &KiwiSdrClient::sendKeepalive);
+
+    m_audioReadyTimer = new QTimer(this);
+    m_audioReadyTimer->setSingleShot(true);
+    m_audioReadyTimer->setInterval(kAudioReadyTimeoutMs);
+    connect(m_audioReadyTimer, &QTimer::timeout, this, [this]() {
+        if (m_soundAudioReady || m_userDisconnecting
+            || m_state != State::Connecting) {
+            return;
+        }
+
+        setState(State::Error,
+                 m_soundSampleRateCommandsSent
+                     ? tr("KiwiSDR sound setup completed but no SND audio frames arrived.")
+                     : tr("No KiwiSDR audio channel became available."));
+        cleanupSockets();
+    });
+}
+
+KiwiSdrClient::~KiwiSdrClient()
+{
+    m_userDisconnecting = true;
+    cleanupSockets();
+}
+
+void KiwiSdrClient::setOperatorCallsign(const QString& callsign)
+{
+    const QString normalized = callsign.trimmed().toUpper();
+    if (m_operatorCallsign == normalized) {
+        return;
+    }
+
+    m_operatorCallsign = normalized;
+    sendSoundIdentityToServer();
+    sendWaterfallIdentityToServer();
+}
+
+void KiwiSdrClient::setReceiverControls(
+    const KiwiSdrReceiverControls& controls)
+{
+    const KiwiSdrReceiverControls normalized = normalizedControls(controls);
+    if (controlsEqual(m_receiverControls, normalized)) {
+        return;
+    }
+
+    m_receiverControls = normalized;
+    sendReceiverControlsToServer();
+}
+
+void KiwiSdrClient::connectToEndpoint(const QString& endpoint)
+{
+    QString host;
+    quint16 port = 0;
+    if (!parseEndpoint(endpoint, &host, &port)) {
+        setState(State::Error, tr("Enter a KiwiSDR endpoint as hostname or hostname:port."));
+        return;
+    }
+
+    m_endpoint = QStringLiteral("%1:%2").arg(host).arg(port);
+    m_host = host;
+    m_port = port;
+    m_secureWebSocket = false;
+    m_secureWebSocketRetryAttempted = false;
+    m_soundSocketConnected = false;
+    m_waterfallSocketConnected = false;
+    m_soundAudioReady = false;
+    m_soundAudioRateAcked = false;
+    m_soundSampleRateCommandsSent = false;
+    m_soundSampleRatePending = false;
+    m_soundFrameSeen = false;
+    m_loggedSoundFrameShape = false;
+    m_loggedWaterfallFrameShape = false;
+    m_soundSampleRateHz = 12000.0;
+    m_soundResamplerRateHz = 0.0;
+    m_soundResampler.reset();
+    m_haveSoundAudioRate = false;
+    m_telemetry = {};
+    m_telemetryPending = false;
+    m_lastSoundIdentityCallsign.clear();
+    m_lastWaterfallIdentityCallsign.clear();
+    m_lastDecodedSoundPcm.clear();
+    m_lastWaterfallBins.clear();
+    m_lastWaterfallPanId.clear();
+    m_lastWaterfallLowMhz = 0.0;
+    m_lastWaterfallHighMhz = 0.0;
+    m_lastWaterfallRowValid = false;
+    m_waterfallServerCenterMhz = kDefaultWaterfallCenterMhz;
+    m_waterfallServerBandwidthMhz = kDefaultWaterfallBandwidthMhz;
+    m_waterfallZoomCap = kDefaultWaterfallZoomCap;
+    m_waterfallFftBins = kDefaultWaterfallFftBins;
+    m_waterfallRequestValid = false;
+    m_waterfallRequestPanId.clear();
+    m_waterfallRequestLowMhz = 0.0;
+    m_waterfallRequestHighMhz = 0.0;
+    m_userDisconnecting = true;
+    cleanupSockets();
+    m_userDisconnecting = false;
+    const QString callsign = kiwiIdentityCallsign();
+    setState(State::Connecting,
+             callsign.isEmpty()
+                 ? tr("Connecting to %1 without a radio callsign.").arg(m_endpoint)
+                 : tr("Connecting to %1 as %2.").arg(m_endpoint, callsign));
+
+#ifdef HAVE_WEBSOCKETS
+    openWebSockets();
+#else
+    setState(State::Error, tr("Qt WebSockets support is required for KiwiSDR."));
+#endif
+}
+
+#ifdef HAVE_WEBSOCKETS
+void KiwiSdrClient::openWebSockets()
+{
+    const QString scheme = m_secureWebSocket
+        ? QStringLiteral("wss")
+        : QStringLiteral("ws");
+    const quint16 socketPort = m_secureWebSocket ? 443 : m_port;
+    const QString sessionId = QString::number(QDateTime::currentMSecsSinceEpoch());
+    const QString secureAwareBase = QStringLiteral("%1://%2:%3/%4")
+        .arg(scheme)
+        .arg(m_host)
+        .arg(socketPort)
+        .arg(sessionId);
+    const QString soundUrl = secureAwareBase + QStringLiteral("/SND");
+    const QString waterfallUrl = secureAwareBase + QStringLiteral("/W/F");
+
+    m_soundSocket = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
+    connect(m_soundSocket, &QWebSocket::connected, this, [this]() {
+        m_soundSocketConnected = true;
+        sendSoundSetupCommands();
+        m_keepaliveTimer->start();
+        m_audioReadyTimer->start();
+    });
+    connect(m_soundSocket, &QWebSocket::textMessageReceived,
+            this, &KiwiSdrClient::handleTextMessage);
+    connect(m_soundSocket, &QWebSocket::binaryMessageReceived,
+            this, &KiwiSdrClient::handleBinaryMessage);
+    connect(m_soundSocket, &QWebSocket::disconnected, this, [this]() {
+        qCInfo(lcProtocol).noquote()
+            << "KiwiSDR SND closed code="
+            << (m_soundSocket
+                    ? static_cast<int>(m_soundSocket->closeCode())
+                    : -1)
+            << "reason="
+            << (m_soundSocket ? m_soundSocket->closeReason() : QString())
+            << "saw_snd="
+            << (m_soundFrameSeen ? QStringLiteral("yes") : QStringLiteral("no"));
+        if (!m_userDisconnecting) {
+            if (m_state == State::Connecting) {
+                if (retryWithSecureWebSocket(m_soundSocketConnected)) {
+                    return;
+                }
+                setState(State::Error,
+                         tr("KiwiSDR sound connection closed during setup. %1")
+                             .arg(identityDiagnosticText()));
+                cleanupSockets();
+            } else if (m_state == State::Connected) {
+                if (retryWithSecureWebSocket(m_soundSocketConnected)) {
+                    return;
+                }
+                const QString detail = tr("KiwiSDR sound connection closed.");
+                setState(State::Error, detail);
+                cleanupSockets();
+                emit recoverableDisconnect(detail);
+            }
+        }
+    });
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    connect(m_soundSocket, &QWebSocket::errorOccurred, this,
+#else
+    connect(m_soundSocket,
+            QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error),
+            this,
+#endif
+            [this](QAbstractSocket::SocketError) {
+                handleSocketError(m_soundSocket ? m_soundSocket->errorString()
+                                                : tr("KiwiSDR sound socket error."),
+                                  m_soundSocketConnected);
+            });
+    qCInfo(lcProtocol).noquote() << "KiwiSDR SND URL" << soundUrl;
+    m_soundSocket->open(QUrl(soundUrl));
+
+    m_waterfallSocket = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
+    connect(m_waterfallSocket, &QWebSocket::connected, this, [this]() {
+        m_waterfallSocketConnected = true;
+        sendWaterfallSetupCommands();
+    });
+    connect(m_waterfallSocket, &QWebSocket::textMessageReceived,
+            this, &KiwiSdrClient::handleTextMessage);
+    connect(m_waterfallSocket, &QWebSocket::binaryMessageReceived,
+            this, &KiwiSdrClient::handleBinaryMessage);
+    connect(m_waterfallSocket, &QWebSocket::disconnected, this, [this]() {
+        qCInfo(lcProtocol).noquote()
+            << "KiwiSDR W/F closed code="
+            << (m_waterfallSocket
+                    ? static_cast<int>(m_waterfallSocket->closeCode())
+                    : -1)
+            << "reason="
+            << (m_waterfallSocket ? m_waterfallSocket->closeReason() : QString());
+        if (!m_userDisconnecting) {
+            if (retryWithSecureWebSocket(m_waterfallSocketConnected)) {
+                return;
+            }
+            const QString detail = tr("KiwiSDR waterfall connection closed.");
+            const bool wasConnected = m_state == State::Connected;
+            setState(State::Error, detail);
+            cleanupSockets();
+            if (wasConnected) {
+                emit recoverableDisconnect(detail);
+            }
+        }
+    });
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    connect(m_waterfallSocket, &QWebSocket::errorOccurred, this,
+#else
+    connect(m_waterfallSocket,
+            QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error),
+            this,
+#endif
+            [this](QAbstractSocket::SocketError) {
+                handleSocketError(m_waterfallSocket ? m_waterfallSocket->errorString()
+                                                    : tr("KiwiSDR waterfall socket error."),
+                                  m_waterfallSocketConnected);
+            });
+    qCInfo(lcProtocol).noquote() << "KiwiSDR W/F URL" << waterfallUrl;
+    m_waterfallSocket->open(QUrl(waterfallUrl));
+}
+#endif
+
+void KiwiSdrClient::disconnectFromEndpoint()
+{
+    m_userDisconnecting = true;
+    setAudioActive(false);
+    cleanupSockets();
+    setState(State::Disconnected, QString());
+}
+
+void KiwiSdrClient::setTrackedSlice(int sliceId, double frequencyMhz,
+                                    const QString& mode, int filterLowHz,
+                                    int filterHighHz, const QString& panId)
+{
+    if (m_trackedSliceId == sliceId
+        && qFuzzyCompare(m_trackedFrequencyMhz, frequencyMhz)
+        && m_trackedMode == mode
+        && m_trackedFilterLowHz == filterLowHz
+        && m_trackedFilterHighHz == filterHighHz
+        && m_trackedPanId == panId) {
+        return;
+    }
+
+    m_trackedSliceId = sliceId;
+    m_trackedFrequencyMhz = frequencyMhz;
+    m_trackedMode = mode;
+    m_trackedFilterLowHz = filterLowHz;
+    m_trackedFilterHighHz = filterHighHz;
+    m_trackedPanId = panId;
+
+    emit trackedSliceChanged(sliceId, frequencyMhz, mode,
+                             filterLowHz, filterHighHz, panId);
+    sendTrackedSliceToServer();
+    sendWaterfallViewToServer();
+}
+
+void KiwiSdrClient::setWaterfallView(const QString& panId, double centerMhz,
+                                     double bandwidthMhz)
+{
+    if (panId.isEmpty() || centerMhz <= 0.0 || bandwidthMhz <= 0.0) {
+        return;
+    }
+
+    if (m_waterfallViewPanId == panId
+        && qFuzzyCompare(m_waterfallViewCenterMhz, centerMhz)
+        && qFuzzyCompare(m_waterfallViewBandwidthMhz, bandwidthMhz)) {
+        return;
+    }
+
+    m_waterfallViewPanId = panId;
+    m_waterfallViewCenterMhz = centerMhz;
+    m_waterfallViewBandwidthMhz = bandwidthMhz;
+    sendWaterfallViewToServer();
+}
+
+void KiwiSdrClient::setWaterfallLineDurationMs(int lineDurationMs)
+{
+    const int clamped = std::clamp(lineDurationMs, 1, 100);
+    if (m_waterfallLineDurationMs == clamped) {
+        return;
+    }
+
+    m_waterfallLineDurationMs = clamped;
+    sendWaterfallRateToServer();
+}
+
+void KiwiSdrClient::setWaterfallDisplayAdjustments(int cellDb, int floorDb)
+{
+    const int clampedCell = std::clamp(cellDb, -30, 30);
+    const int clampedFloor = std::clamp(floorDb, -30, 30);
+    if (m_waterfallCellDb == clampedCell
+        && m_waterfallFloorDb == clampedFloor) {
+        return;
+    }
+
+    m_waterfallCellDb = clampedCell;
+    m_waterfallFloorDb = clampedFloor;
+    sendWaterfallDisplayAdjustmentsToServer();
+}
+
+void KiwiSdrClient::setWaterfallRateOverride(int rate)
+{
+    const int clamped = std::clamp(rate, 0, 5);
+    if (m_waterfallRateOverride == clamped) {
+        return;
+    }
+
+    m_waterfallRateOverride = clamped;
+    sendWaterfallRateToServer();
+}
+
+void KiwiSdrClient::setAudioActive(bool active)
+{
+    const bool allowed = active && m_state == State::Connected;
+    if (m_audioActive == allowed) {
+        return;
+    }
+
+    m_audioActive = allowed;
+    emit audioActiveChanged(m_audioActive);
+}
+
+void KiwiSdrClient::setDecodeAudioWhenInactive(bool decode)
+{
+    m_decodeAudioWhenInactive = decode;
+}
+
+bool KiwiSdrClient::parseEndpoint(const QString& endpoint,
+                                  QString* host,
+                                  quint16* port)
+{
+    const QString trimmed = normalizeEndpoint(endpoint);
+    if (trimmed.isEmpty() || trimmed.contains(QLatin1Char('/'))
+        || trimmed.contains(QLatin1Char('\\'))) {
+        return false;
+    }
+
+    const int colon = trimmed.lastIndexOf(QLatin1Char(':'));
+    if (colon <= 0 || colon == trimmed.size() - 1) {
+        return false;
+    }
+
+    const QString parsedHost = trimmed.left(colon).trimmed();
+    const QString parsedPortText = trimmed.mid(colon + 1).trimmed();
+    if (parsedHost.isEmpty() || parsedHost.contains(QLatin1Char(' '))
+        || parsedPortText.isEmpty()) {
+        return false;
+    }
+
+    bool ok = false;
+    const int parsedPort = parsedPortText.toInt(&ok);
+    if (!ok || parsedPort <= 0 || parsedPort > 65535) {
+        return false;
+    }
+
+    if (host) {
+        *host = parsedHost;
+    }
+    if (port) {
+        *port = static_cast<quint16>(parsedPort);
+    }
+    return true;
+}
+
+QString KiwiSdrClient::normalizeEndpoint(const QString& endpoint)
+{
+    QString normalized = endpoint.trimmed();
+
+    if (normalized.startsWith(QStringLiteral("http://"), Qt::CaseInsensitive)) {
+        normalized.remove(0, 7);
+    } else if (normalized.startsWith(QStringLiteral("https://"), Qt::CaseInsensitive)) {
+        normalized.remove(0, 8);
+    }
+
+    while (normalized.endsWith(QLatin1Char('/'))) {
+        normalized.chop(1);
+    }
+
+    normalized = normalized.trimmed();
+    if (normalized.isEmpty()
+        || normalized.contains(QLatin1Char('/'))
+        || normalized.contains(QLatin1Char('\\'))
+        || normalized.contains(QLatin1Char(':'))) {
+        return normalized;
+    }
+
+    return QStringLiteral("%1:%2").arg(normalized).arg(kDefaultKiwiSdrPort);
+}
+
+void KiwiSdrClient::cleanupSockets()
+{
+    if (m_keepaliveTimer) {
+        m_keepaliveTimer->stop();
+    }
+    if (m_audioReadyTimer) {
+        m_audioReadyTimer->stop();
+    }
+    m_soundAudioReady = false;
+    m_soundAudioRateAcked = false;
+    m_soundSampleRateCommandsSent = false;
+    m_soundSampleRatePending = false;
+    m_soundFrameSeen = false;
+    m_loggedSoundFrameShape = false;
+    m_loggedWaterfallFrameShape = false;
+    m_lastDecodedSoundPcm.clear();
+    m_lastWaterfallBins.clear();
+    m_lastWaterfallPanId.clear();
+    m_lastWaterfallLowMhz = 0.0;
+    m_lastWaterfallHighMhz = 0.0;
+    m_lastWaterfallRowValid = false;
+
+#ifdef HAVE_WEBSOCKETS
+    auto cleanup = [this](QWebSocket*& socket) {
+        if (!socket) {
+            return;
+        }
+        socket->disconnect(this);
+        if (socket->state() != QAbstractSocket::UnconnectedState) {
+            socket->close();
+        }
+        socket->deleteLater();
+        socket = nullptr;
+    };
+    cleanup(m_soundSocket);
+    cleanup(m_waterfallSocket);
+#endif
+}
+
+void KiwiSdrClient::sendSoundSetupCommands()
+{
+    sendSoundCommand(QStringLiteral("SET auth t=kiwi p=#"));
+    sendSoundIdentityToServer();
+    sendSoundCommand(QStringLiteral("SET compression=0"));
+}
+
+void KiwiSdrClient::sendSoundAudioRateAck()
+{
+    if (m_soundAudioRateAcked) {
+        return;
+    }
+
+    m_soundAudioRateAcked = true;
+    sendSoundCommand(QStringLiteral("SET AR OK in=%1 out=24000")
+        .arg(m_soundSampleRateHz, 0, 'f', 0));
+}
+
+void KiwiSdrClient::sendSoundSampleRateCommands()
+{
+    if (m_soundSampleRateCommandsSent) {
+        return;
+    }
+
+    if (!m_soundAudioRateAcked) {
+        m_soundSampleRatePending = true;
+        return;
+    }
+
+    m_soundSampleRatePending = false;
+    m_soundSampleRateCommandsSent = true;
+    sendSoundCommand(QStringLiteral("SERVER DE CLIENT AetherSDR SND"));
+    const KiwiSdrReceiverControls c = normalizedControls(m_receiverControls);
+    sendSoundCommand(QStringLiteral("SET squelch=%1 max=%2")
+        .arg(c.squelchEnabled ? 1 : 0)
+        .arg(c.squelchEnabled ? c.squelchLevelDbm : 0.0, 0, 'f', 2));
+    sendSoundCommand(QStringLiteral("SET genattn=0"));
+    sendSoundCommand(QStringLiteral("SET gen=0 mix=-1"));
+    sendSoundCommand(QStringLiteral("SET agc=%1 hang=%2 thresh=%3 slope=6 decay=%4 manGain=%5")
+        .arg(c.agcEnabled ? 1 : 0)
+        .arg(c.agcHang ? 1 : 0)
+        .arg(c.agcThresholdDb)
+        .arg(c.agcDecayMs)
+        .arg(c.agcGainDb));
+    sendTrackedSliceToServer();
+    sendKeepalive();
+}
+
+void KiwiSdrClient::sendWaterfallSetupCommands()
+{
+    sendWaterfallCommand(QStringLiteral("SET auth t=kiwi p=#"));
+    sendWaterfallIdentityToServer();
+    sendWaterfallCommand(QStringLiteral("SERVER DE CLIENT AetherSDR W/F"));
+    sendWaterfallCommand(QStringLiteral("SET wf_comp=0"));
+    sendWaterfallCommand(QStringLiteral("SET send_dB=1"));
+    sendWaterfallViewToServer();
+    sendWaterfallDisplayAdjustmentsToServer();
+    sendWaterfallCommand(QStringLiteral("SET interp=13"));
+    sendWaterfallCommand(QStringLiteral("SET window_func=2"));
+    sendWaterfallRateToServer();
+}
+
+void KiwiSdrClient::sendTrackedSliceToServer()
+{
+    if (m_trackedSliceId < 0 || m_trackedFrequencyMhz <= 0.0) {
+        return;
+    }
+#ifdef HAVE_WEBSOCKETS
+    if (!m_soundSocket
+        || m_soundSocket->state() != QAbstractSocket::ConnectedState
+        || !m_soundSampleRateCommandsSent) {
+        return;
+    }
+#endif
+
+    const double freqKhz = m_trackedFrequencyMhz * 1000.0;
+    const QString mode = kiwiMode();
+    const int lowCutHz = kiwiLowCutHz();
+    const int highCutHz = kiwiHighCutHz();
+    if (lowCutHz >= highCutHz) {
+        qCWarning(lcProtocol).noquote()
+            << "KiwiSDR refusing invalid passband mode=" << mode
+            << "freq_khz=" << QString::number(freqKhz, 'f', 3)
+            << "low_cut=" << lowCutHz
+            << "high_cut=" << highCutHz;
+        return;
+    }
+    sendSoundCommand(QStringLiteral("SET mod=%1 low_cut=%2 high_cut=%3 freq=%4")
+        .arg(mode)
+        .arg(lowCutHz)
+        .arg(highCutHz)
+        .arg(freqKhz, 0, 'f', 3));
+}
+
+void KiwiSdrClient::sendReceiverControlsToServer()
+{
+#ifdef HAVE_WEBSOCKETS
+    if (!m_soundSocket
+        || m_soundSocket->state() != QAbstractSocket::ConnectedState
+        || !m_soundSampleRateCommandsSent) {
+        return;
+    }
+#endif
+    const KiwiSdrReceiverControls c = normalizedControls(m_receiverControls);
+    sendSoundCommand(QStringLiteral("SET squelch=%1 max=%2")
+        .arg(c.squelchEnabled ? 1 : 0)
+        .arg(c.squelchEnabled ? c.squelchLevelDbm : 0.0, 0, 'f', 2));
+    sendSoundCommand(QStringLiteral("SET agc=%1 hang=%2 thresh=%3 slope=6 decay=%4 manGain=%5")
+        .arg(c.agcEnabled ? 1 : 0)
+        .arg(c.agcHang ? 1 : 0)
+        .arg(c.agcThresholdDb)
+        .arg(c.agcDecayMs)
+        .arg(c.agcGainDb));
+}
+
+void KiwiSdrClient::sendWaterfallViewToServer()
+{
+#ifdef HAVE_WEBSOCKETS
+    if (!m_waterfallSocket
+        || m_waterfallSocket->state() != QAbstractSocket::ConnectedState) {
+        m_waterfallRequestValid = false;
+        return;
+    }
+#else
+    m_waterfallRequestValid = false;
+    return;
+#endif
+
+    double viewCenterMhz = m_waterfallViewCenterMhz;
+    double viewBandwidthMhz = m_waterfallViewBandwidthMhz;
+    if (viewCenterMhz <= 0.0 || viewBandwidthMhz <= 0.0) {
+        viewCenterMhz = m_trackedFrequencyMhz > 0.0
+            ? m_trackedFrequencyMhz
+            : m_waterfallServerCenterMhz;
+        viewBandwidthMhz = 0.2;
+    }
+
+    const double fullBandwidthMhz = std::max(
+        0.001,
+        m_waterfallServerBandwidthMhz > 0.0
+            ? m_waterfallServerBandwidthMhz
+            : kDefaultWaterfallBandwidthMhz);
+    const double fullCenterMhz = m_waterfallServerCenterMhz > 0.0
+        ? m_waterfallServerCenterMhz
+        : kDefaultWaterfallCenterMhz;
+    const double fullLowMhz = fullCenterMhz - fullBandwidthMhz * 0.5;
+    const double fullHighMhz = fullCenterMhz + fullBandwidthMhz * 0.5;
+    const int zoomCap = std::clamp(m_waterfallZoomCap, 0, 20);
+    const double halfBandwidthMhz = std::max(0.0005, viewBandwidthMhz * 0.5);
+    const double viewLowMhz = std::clamp(viewCenterMhz - halfBandwidthMhz,
+                                         fullLowMhz,
+                                         fullHighMhz);
+    const double viewHighMhz = std::clamp(viewCenterMhz + halfBandwidthMhz,
+                                          fullLowMhz,
+                                          fullHighMhz);
+
+    const double viewSpanMhz = std::max(0.0, viewHighMhz - viewLowMhz);
+    const double requiredSpanMhz = std::min(fullBandwidthMhz, viewSpanMhz);
+    const double viewMidMhz = (viewLowMhz + viewHighMhz) * 0.5;
+    int zoom = 0;
+    quint32 start = 0;
+    double requestLowMhz = fullLowMhz;
+    double requestHighMhz = fullHighMhz;
+    bool selectedRequest = false;
+    for (int candidate = zoomCap; candidate >= 0; --candidate) {
+        const double candidateRowSpanMhz = std::min(
+            fullBandwidthMhz,
+            waterfallRowSpanMhz(fullBandwidthMhz, candidate));
+        if (candidateRowSpanMhz + 1.0e-9 < requiredSpanMhz) {
+            continue;
+        }
+
+        double candidateLowMhz = std::clamp(
+            viewMidMhz - candidateRowSpanMhz * 0.5,
+            fullLowMhz,
+            std::max(fullLowMhz, fullHighMhz - candidateRowSpanMhz));
+        const quint32 candidateStart = waterfallStartFixedPoint(
+            fullLowMhz, fullBandwidthMhz, candidateLowMhz);
+        candidateLowMhz = waterfallStartFixedPointToLowMhz(
+            fullLowMhz, fullBandwidthMhz, candidateStart);
+        const double candidateHighMhz = candidateLowMhz
+            + std::min(fullBandwidthMhz,
+                       waterfallRowSpanMhz(fullBandwidthMhz, candidate));
+
+        // Kiwi W/F rows are discrete fixed-point windows with a fixed bin
+        // count. Prefer the highest resolution row that fully covers the
+        // AetherSDR viewport after start quantization; otherwise zooming near
+        // a row boundary leaves black side bands until the next coarser row is
+        // requested.
+        const double coverEpsilonMhz = std::max(
+            1.0e-9,
+            (fullBandwidthMhz / kWaterfallStartFixedPointScale) * 2.0);
+        if (candidateLowMhz <= viewLowMhz + coverEpsilonMhz
+            && candidateHighMhz + coverEpsilonMhz >= viewHighMhz) {
+            zoom = candidate;
+            start = candidateStart;
+            requestLowMhz = candidateLowMhz;
+            requestHighMhz = candidateHighMhz;
+            selectedRequest = true;
+            break;
+        }
+    }
+    if (!selectedRequest) {
+        zoom = 0;
+        start = waterfallStartFixedPoint(fullLowMhz, fullBandwidthMhz,
+                                         fullLowMhz);
+        requestLowMhz = fullLowMhz;
+        requestHighMhz = fullHighMhz;
+    }
+
+    if (m_waterfallRequestValid
+        && m_waterfallRequestPanId == m_waterfallViewPanId
+        && m_waterfallRequestStart == start
+        && m_waterfallRequestZoom == zoom
+        && std::abs(m_waterfallRequestLowMhz - requestLowMhz) <= 1.0e-9
+        && std::abs(m_waterfallRequestHighMhz - requestHighMhz) <= 1.0e-9) {
+        return;
+    }
+
+    m_waterfallRequestValid = true;
+    m_waterfallRequestPanId = m_waterfallViewPanId;
+    m_waterfallRequestStart = start;
+    m_waterfallRequestZoom = zoom;
+    m_waterfallRequestLowMhz = requestLowMhz;
+    m_waterfallRequestHighMhz = requestHighMhz;
+    m_lastWaterfallBins.clear();
+    m_lastWaterfallPanId.clear();
+    m_lastWaterfallLowMhz = 0.0;
+    m_lastWaterfallHighMhz = 0.0;
+    m_lastWaterfallRowValid = false;
+
+    const double centerFreqKhz = ((requestLowMhz + requestHighMhz) * 0.5)
+        * 1000.0;
+    sendWaterfallCommand(QStringLiteral("SET zoom=%1 cf=%2 start=%3")
+        .arg(zoom)
+        .arg(centerFreqKhz, 0, 'f', 3)
+        .arg(start));
+}
+
+void KiwiSdrClient::sendWaterfallDisplayAdjustmentsToServer()
+{
+    const float maxDb = m_waterfallMaxDbm
+        + static_cast<float>(m_waterfallCellDb);
+    const float minDb = std::min(
+        maxDb - 1.0f,
+        m_waterfallMinDbm + static_cast<float>(m_waterfallFloorDb));
+    sendWaterfallCommand(QStringLiteral("SET maxdb=%1 mindb=%2")
+        .arg(static_cast<double>(maxDb), 0, 'f', 0)
+        .arg(static_cast<double>(minDb), 0, 'f', 0));
+}
+
+QString KiwiSdrClient::kiwiIdentityCallsign() const
+{
+    QString identity;
+    const QString source = m_operatorCallsign.trimmed().toUpper();
+    identity.reserve(source.size());
+    for (const QChar ch : source) {
+        if (ch.isLetterOrNumber()
+            || ch == QLatin1Char('-')
+            || ch == QLatin1Char('/')) {
+            identity.append(ch);
+        }
+    }
+    return identity.left(32);
+}
+
+void KiwiSdrClient::sendSoundIdentityToServer()
+{
+    const QString callsign = kiwiIdentityCallsign();
+    m_lastSoundIdentityCallsign = callsign;
+    if (!callsign.isEmpty()) {
+        sendSoundCommand(QStringLiteral("SET ident_user=%1").arg(callsign));
+    }
+}
+
+void KiwiSdrClient::sendWaterfallIdentityToServer()
+{
+    const QString callsign = kiwiIdentityCallsign();
+    m_lastWaterfallIdentityCallsign = callsign;
+    if (!callsign.isEmpty()) {
+        sendWaterfallCommand(QStringLiteral("SET ident_user=%1").arg(callsign));
+    }
+}
+
+QString KiwiSdrClient::identityDiagnosticText() const
+{
+    const QString callsign = !m_lastSoundIdentityCallsign.isEmpty()
+        ? m_lastSoundIdentityCallsign
+        : kiwiIdentityCallsign();
+    if (callsign.isEmpty()) {
+        return tr("No radio callsign was available to send.");
+    }
+    return tr("Radio callsign sent: %1.").arg(callsign);
+}
+
+QString KiwiSdrClient::kiwiMode() const
+{
+    const QString mode = m_trackedMode.trimmed().toUpper();
+    if (mode == QStringLiteral("LSB") || mode == QStringLiteral("DIGL")) {
+        return QStringLiteral("lsb");
+    }
+    if (mode == QStringLiteral("USB") || mode == QStringLiteral("DIGU")
+        || mode == QStringLiteral("RTTY")) {
+        return QStringLiteral("usb");
+    }
+    if (mode == QStringLiteral("CW") || mode == QStringLiteral("CWU")
+        || mode == QStringLiteral("CWL")) {
+        return QStringLiteral("cw");
+    }
+    if (mode == QStringLiteral("NFM") || mode == QStringLiteral("FM")) {
+        return QStringLiteral("nfm");
+    }
+    return QStringLiteral("am");
+}
+
+int KiwiSdrClient::kiwiLowCutHz() const
+{
+    if (m_trackedFilterLowHz < m_trackedFilterHighHz) {
+        return m_trackedFilterLowHz;
+    }
+
+    const QString mode = kiwiMode();
+    if (mode == QStringLiteral("lsb")) {
+        return -2900;
+    }
+    if (mode == QStringLiteral("usb")) {
+        return 100;
+    }
+    if (mode == QStringLiteral("cw")) {
+        return 400;
+    }
+    if (mode == QStringLiteral("nfm")) {
+        return -6000;
+    }
+    return -4900;
+}
+
+int KiwiSdrClient::kiwiHighCutHz() const
+{
+    if (m_trackedFilterLowHz < m_trackedFilterHighHz) {
+        return m_trackedFilterHighHz;
+    }
+
+    const QString mode = kiwiMode();
+    if (mode == QStringLiteral("lsb")) {
+        return -100;
+    }
+    if (mode == QStringLiteral("usb")) {
+        return 2900;
+    }
+    if (mode == QStringLiteral("cw")) {
+        return 800;
+    }
+    if (mode == QStringLiteral("nfm")) {
+        return 6000;
+    }
+    return 4900;
+}
+
+bool KiwiSdrClient::isSupportedPcmSoundFrame(
+    const QByteArray& frame,
+    const KiwiSdrProtocol::SoundFrameHeader& header) const
+{
+    if (!header.valid) {
+        return false;
+    }
+
+    const bool observedExtendedFrame = frame.size() == kObservedSoundFrameBytes;
+    if (observedExtendedFrame) {
+        return true;
+    }
+
+    const int sampleBytes = frame.size() - kSpecSoundHeaderBytes;
+    if (sampleBytes <= 0 || (sampleBytes % 2) != 0) {
+        return false;
+    }
+
+    return true;
+}
+
+QByteArray KiwiSdrClient::decodeSoundFrame(const QByteArray& frame)
+{
+    if (frame.size() <= kSpecSoundHeaderBytes || !frame.startsWith("SND")) {
+        return {};
+    }
+
+    int payloadOffset = kSpecSoundHeaderBytes;
+    const bool observedExtendedFrame = frame.size() == kObservedSoundFrameBytes;
+    if (observedExtendedFrame) {
+        payloadOffset = kObservedSoundHeaderBytes;
+    }
+    const int sampleBytes = frame.size() - payloadOffset;
+    const int inSamples = sampleBytes / 2;
+    if (inSamples <= 0 || (sampleBytes % 2) != 0) {
+        return {};
+    }
+
+    std::vector<float> mono(static_cast<std::size_t>(inSamples));
+    const auto* data = reinterpret_cast<const uchar*>(frame.constData() + payloadOffset);
+    for (int i = 0; i < inSamples; ++i) {
+        int sample = 0;
+        if (observedExtendedFrame) {
+            sample = (static_cast<int>(data[2 * i]) << 8)
+                   | static_cast<int>(data[2 * i + 1]);
+        } else {
+            sample = static_cast<int>(data[2 * i])
+                   | (static_cast<int>(data[2 * i + 1]) << 8);
+        }
+        if (sample & 0x8000) {
+            sample -= 0x10000;
+        }
+        mono[static_cast<std::size_t>(i)] = std::clamp(
+            static_cast<float>(sample) / 32768.0f, -1.0f, 1.0f);
+    }
+    if (!m_soundResampler || std::abs(m_soundResamplerRateHz - m_soundSampleRateHz) > 1.0) {
+        m_soundResampler = std::make_unique<Resampler>(
+            m_soundSampleRateHz, 24000.0);
+        m_soundResamplerRateHz = m_soundSampleRateHz;
+    }
+    return m_soundResampler->processMonoToStereo(mono.data(), inSamples);
+}
+
+bool KiwiSdrClient::parseWaterfallFrameHeader(const QByteArray& frame,
+                                              quint32* start,
+                                              int* zoom) const
+{
+    if (frame.size() < kExtendedWaterfallHeaderBytes || !frame.startsWith("W/F")) {
+        return false;
+    }
+    if (frame.size() == kSpecWaterfallHeaderBytes + kDefaultWaterfallFftBins) {
+        // User-provided protocol correction: normal W/F frames are a 4-byte
+        // tag/sequence header followed by exactly 1024 bins. Do not interpret
+        // early bin bytes as the older observed extended start/zoom fields.
+        return false;
+    }
+
+    const quint32 parsedStart = readLittleEndianU32(frame.constData() + 4);
+    const int parsedZoom = static_cast<uchar>(frame[8]);
+    if (parsedZoom < 0 || parsedZoom > m_waterfallZoomCap) {
+        return false;
+    }
+    if (start) {
+        *start = parsedStart;
+    }
+    if (zoom) {
+        *zoom = parsedZoom;
+    }
+    return true;
+}
+
+QVector<float> KiwiSdrClient::decodeWaterfallFrame(const QByteArray& frame) const
+{
+    if (frame.size() <= kSpecWaterfallHeaderBytes || !frame.startsWith("W/F")) {
+        return {};
+    }
+
+    int payloadOffset = kSpecWaterfallHeaderBytes;
+    int frameZoom = 0;
+    const bool haveExtendedHeader = parseWaterfallFrameHeader(
+        frame, nullptr, &frameZoom);
+    if (haveExtendedHeader) {
+        payloadOffset = kExtendedWaterfallHeaderBytes;
+    }
+    int payloadBytes = frame.size() - payloadOffset;
+    if (payloadBytes == kZoomedWaterfallPrefixBytes) {
+        return {};
+    }
+    const auto* payload = reinterpret_cast<const uchar*>(
+        frame.constData() + payloadOffset);
+    if (haveExtendedHeader
+        && frameZoom > 0
+        && payloadBytes > kZoomedWaterfallPrefixBytes
+        && payload[0] == 0x77
+        && payload[1] == 0x01) {
+        // Clean-room W/F captures on 2026-06-18 showed this zoom-row
+        // prefix marks the compact encoded W/F format. It is not one
+        // byte-per-bin waterfall data; rendering it caused the speckled
+        // display. We request wf_comp=0 during setup, and drop encoded rows
+        // from endpoints that ignore that request until a clean decoder is
+        // available.
+        qCDebug(lcProtocol).noquote()
+            << "KiwiSDR W/F compressed row ignored len=" << frame.size()
+            << "zoom=" << frameZoom
+            << "first=" << firstBytesHex(frame);
+        return {};
+    }
+    if (payloadBytes <= 0) {
+        return {};
+    }
+
+    QVector<float> bins;
+    bins.reserve(payloadBytes);
+    const auto* data = reinterpret_cast<const uchar*>(frame.constData() + payloadOffset);
+    for (int i = 0; i < payloadBytes; ++i) {
+        bins.append(KiwiSdrProtocol::waterfallByteToDisplayLevel(*data++));
+    }
+    return bins;
+}
+
+void KiwiSdrClient::handleBinaryMessage(const QByteArray& frame)
+{
+    if (frame.startsWith("MSG")) {
+        handleMessage(frame);
+    } else if (frame.startsWith("SND")) {
+        handleSoundFrame(frame);
+    } else if (frame.startsWith("W/F")) {
+        handleWaterfallFrame(frame);
+    } else if (frame.startsWith("EXT")) {
+        qCDebug(lcProtocol).noquote()
+            << "KiwiSDR EXT ignored len=" << frame.size()
+            << "first=" << firstBytesHex(frame);
+    } else {
+        const QString tag = QString::fromLatin1(frame.left(3));
+        qCDebug(lcProtocol).noquote()
+            << "KiwiSDR unknown binary tag=" << tag
+            << "len=" << frame.size()
+            << "first=" << firstBytesHex(frame);
+    }
+}
+
+void KiwiSdrClient::handleSoundFrame(const QByteArray& frame)
+{
+    m_soundFrameSeen = true;
+    if (!m_loggedSoundFrameShape) {
+        m_loggedSoundFrameShape = true;
+        qCDebug(lcProtocol).noquote()
+            << "KiwiSDR SND frame len=" << frame.size()
+            << "first=" << firstBytesHex(frame);
+    }
+    const KiwiSdrProtocol::SoundFrameHeader header =
+        KiwiSdrProtocol::parseSoundFrameHeader(frame);
+    if (!isSupportedPcmSoundFrame(frame, header)) {
+        qCWarning(lcProtocol).noquote()
+            << "KiwiSDR SND unsupported frame shape len=" << frame.size()
+            << "first=" << firstBytesHex(frame);
+        return;
+    }
+    const quint64 sequenceGaps = header.valid
+        ? KiwiSdrProtocol::sequenceGapCount(m_telemetry.soundSequence,
+                                            header.sequence)
+        : 0;
+    updateSoundTelemetry(frame);
+    const KiwiSdrProtocol::MeterReading meterReading =
+        KiwiSdrProtocol::extractMeterFromSndVerifiedLayout(
+            frame, KiwiSdrProtocol::MeterContext{});
+    markSoundAudioReady();
+    if (!m_audioActive && !m_decodeAudioWhenInactive) {
+        return;
+    }
+
+    const QByteArray pcm = decodeSoundFrame(frame);
+    if (!pcm.isEmpty()) {
+        const quint64 padFrames = std::min(sequenceGaps,
+                                          kMaxSequenceGapPaddingFrames);
+        if (!m_lastDecodedSoundPcm.isEmpty()) {
+            for (quint64 i = 0; i < padFrames; ++i) {
+                emit decodedAudioReady(m_lastDecodedSoundPcm);
+            }
+        }
+        emit decodedAudioReady(pcm);
+        m_lastDecodedSoundPcm = pcm;
+        emit meterReadingReady(meterReading);
+    }
+}
+
+void KiwiSdrClient::handleWaterfallFrame(const QByteArray& frame)
+{
+    if (!m_loggedWaterfallFrameShape) {
+        m_loggedWaterfallFrameShape = true;
+        qCDebug(lcProtocol).noquote()
+            << "KiwiSDR W/F frame len=" << frame.size()
+            << "first=" << firstBytesHex(frame);
+    }
+    const KiwiSdrProtocol::WaterfallLineHeader header =
+        KiwiSdrProtocol::parseWaterfallLineHeader(frame);
+    const quint64 sequenceGaps = header.valid
+        ? KiwiSdrProtocol::sequenceGapCount(m_telemetry.waterfallSequence,
+                                            header.sequence)
+        : 0;
+    updateWaterfallTelemetry(frame);
+    quint32 frameStart = 0;
+    int frameZoom = 0;
+    const bool hasExtendedHeader =
+        parseWaterfallFrameHeader(frame, &frameStart, &frameZoom);
+    if (!m_waterfallRequestValid
+        || m_waterfallRequestLowMhz <= 0.0
+        || m_waterfallRequestHighMhz <= m_waterfallRequestLowMhz) {
+        return;
+    }
+    if (hasExtendedHeader
+        && frameZoom != m_waterfallRequestZoom) {
+        return;
+    }
+    if (hasExtendedHeader) {
+        const quint32 startDelta =
+            frameStart > m_waterfallRequestStart
+                ? frameStart - m_waterfallRequestStart
+                : m_waterfallRequestStart - frameStart;
+        if (startDelta > kWaterfallStartServerSnapTolerance) {
+            return;
+        }
+    }
+
+    const QVector<float> bins = decodeWaterfallFrame(frame);
+    if (bins.isEmpty()) {
+        return;
+    }
+    if (updateWaterfallFftBins(bins.size())) {
+        return;
+    }
+
+    const QString panId = !m_waterfallRequestPanId.isEmpty()
+        ? m_waterfallRequestPanId
+        : (!m_waterfallViewPanId.isEmpty()
+              ? m_waterfallViewPanId
+              : m_trackedPanId);
+    if (panId.isEmpty()) {
+        return;
+    }
+    double rowLowMhz = m_waterfallRequestLowMhz;
+    double rowHighMhz = m_waterfallRequestHighMhz;
+    if (hasExtendedHeader) {
+        const double fullBandwidthMhz = std::max(
+            0.001,
+            m_waterfallServerBandwidthMhz > 0.0
+                ? m_waterfallServerBandwidthMhz
+                : kDefaultWaterfallBandwidthMhz);
+        const double fullCenterMhz = m_waterfallServerCenterMhz > 0.0
+            ? m_waterfallServerCenterMhz
+            : kDefaultWaterfallCenterMhz;
+        const double fullLowMhz = fullCenterMhz - fullBandwidthMhz * 0.5;
+        rowLowMhz = waterfallStartFixedPointToLowMhz(
+            fullLowMhz, fullBandwidthMhz, frameStart);
+        rowHighMhz = rowLowMhz
+            + std::min(fullBandwidthMhz,
+                       waterfallRowSpanMhz(fullBandwidthMhz, frameZoom));
+    }
+    const quint64 padRows = std::min(sequenceGaps,
+                                     kMaxSequenceGapPaddingFrames);
+    if (m_lastWaterfallRowValid
+        && m_lastWaterfallPanId == panId
+        && std::abs(m_lastWaterfallLowMhz - rowLowMhz) <= 1.0e-9
+        && std::abs(m_lastWaterfallHighMhz - rowHighMhz) <= 1.0e-9) {
+        for (quint64 i = 0; i < padRows; ++i) {
+            emit waterfallRowReady(panId, m_lastWaterfallBins,
+                                   m_lastWaterfallLowMhz,
+                                   m_lastWaterfallHighMhz,
+                                   0);
+        }
+    }
+    emit waterfallRowReady(panId, bins, rowLowMhz, rowHighMhz, 0);
+    m_lastWaterfallBins = bins;
+    m_lastWaterfallPanId = panId;
+    m_lastWaterfallLowMhz = rowLowMhz;
+    m_lastWaterfallHighMhz = rowHighMhz;
+    m_lastWaterfallRowValid = true;
+}
+
+void KiwiSdrClient::handleMessage(const QByteArray& frame)
+{
+    const QString text = QString::fromLatin1(frame.constData(), frame.size());
+    handleTextMessage(text);
+}
+
+void KiwiSdrClient::handleTextMessage(const QString& text)
+{
+    const QString message = text.startsWith(QStringLiteral("MSG"))
+        ? text.mid(3).trimmed()
+        : text.trimmed();
+
+    const QStringList parts = message.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    auto setSoundSampleRate = [this](double value) {
+        if (!std::isfinite(value) || value < 8000.0 || value > 48000.0) {
+            return;
+        }
+        if (std::abs(value - m_soundSampleRateHz) > 1.0) {
+            m_soundSampleRateHz = value;
+            m_soundResamplerRateHz = 0.0;
+            m_soundResampler.reset();
+        }
+    };
+    for (const QString& part : parts) {
+        const int eq = part.indexOf(QLatin1Char('='));
+        if (eq <= 0) {
+            continue;
+        }
+        const QString key = part.left(eq);
+        const QString valueText = part.mid(eq + 1);
+        qCDebug(lcProtocol).noquote()
+            << "KiwiSDR MSG" << key << "=" << valueText;
+        if (key == QStringLiteral("too_busy")) {
+            bool busyOk = false;
+            const int busyValue = valueText.toInt(&busyOk);
+            if (!busyOk || busyValue != 0) {
+                setState(State::Error, tr("KiwiSDR endpoint is busy."));
+                cleanupSockets();
+                return;
+            }
+            continue;
+        }
+        if (key == QStringLiteral("reason_disabled")) {
+            const QString reason =
+                QUrl::fromPercentEncoding(valueText.toUtf8()).trimmed();
+            setState(State::Error,
+                     reason.isEmpty()
+                         ? tr("KiwiSDR endpoint is disabled.")
+                         : tr("KiwiSDR endpoint is disabled: %1").arg(reason));
+            cleanupSockets();
+            return;
+        }
+        if (key == QStringLiteral("down")) {
+            bool downOk = false;
+            const int downValue = valueText.toInt(&downOk);
+            if (!downOk || downValue != 0) {
+                setState(State::Error, tr("KiwiSDR endpoint is down."));
+                cleanupSockets();
+                return;
+            }
+            continue;
+        }
+        if (key == QStringLiteral("camp_disconnect")) {
+            setState(State::Error,
+                     tr("KiwiSDR camping queue disconnected this client."));
+            cleanupSockets();
+            return;
+        }
+        if (key == QStringLiteral("redirect")) {
+            const QString target =
+                QUrl::fromPercentEncoding(valueText.toUtf8()).trimmed();
+            setState(State::Error,
+                     target.isEmpty()
+                         ? tr("KiwiSDR endpoint requested redirect.")
+                         : tr("KiwiSDR endpoint requested redirect to %1.")
+                               .arg(target));
+            cleanupSockets();
+            return;
+        }
+        if (key == QStringLiteral("audio_init")) {
+            markSoundAudioReady();
+            continue;
+        }
+
+        bool ok = false;
+        const double value = valueText.toDouble(&ok);
+        if (!ok) {
+            continue;
+        }
+        if (key == QStringLiteral("badp")) {
+            const int badp = static_cast<int>(value);
+            if (badp != 0) {
+                setState(
+                    State::Error,
+                    tr("KiwiSDR rejected public receive access (badp=%1). "
+                       "%2 This endpoint may require a password or site-specific login.")
+                        .arg(badp)
+                        .arg(identityDiagnosticText()));
+                cleanupSockets();
+                return;
+            }
+        } else if (key == QStringLiteral("center_freq")) {
+            const double centerMhz = waterfallMetadataValueToMhz(value);
+            if (centerMhz > 0.0) {
+                m_waterfallServerCenterMhz = centerMhz;
+                m_waterfallRequestValid = false;
+                sendWaterfallViewToServer();
+            }
+        } else if (key == QStringLiteral("bandwidth")) {
+            const double bandwidthMhz = waterfallMetadataValueToMhz(value);
+            if (bandwidthMhz > 0.0) {
+                m_waterfallServerBandwidthMhz = bandwidthMhz;
+                m_waterfallRequestValid = false;
+                sendWaterfallViewToServer();
+            }
+        } else if (key == QStringLiteral("zoom_cap")
+                   || key == QStringLiteral("zoom_max")) {
+            m_waterfallZoomCap = std::clamp(static_cast<int>(value), 0, 20);
+            m_waterfallRequestValid = false;
+            sendWaterfallViewToServer();
+        } else if (key == QStringLiteral("wf_fft_size")) {
+            updateWaterfallFftBins(static_cast<int>(value));
+        } else if (key == QStringLiteral("audio_rate")) {
+            m_haveSoundAudioRate = true;
+            setSoundSampleRate(value);
+            sendSoundAudioRateAck();
+            if (m_soundSampleRatePending) {
+                sendSoundSampleRateCommands();
+            }
+        } else if (key == QStringLiteral("sample_rate")) {
+            sendSoundSampleRateCommands();
+        } else if (key == QStringLiteral("users")) {
+            const int users = static_cast<int>(value);
+            if (m_telemetry.users != users) {
+                m_telemetry.users = users;
+                emitTelemetryChanged();
+            }
+        } else if (key == QStringLiteral("freq")) {
+            if (std::abs(m_telemetry.reportedFrequencyKhz - value) > 0.001) {
+                m_telemetry.reportedFrequencyKhz = value;
+                emitTelemetryChanged();
+            }
+        } else if (key == QStringLiteral("adc_clipping")) {
+            const bool clipping = value != 0.0;
+            if (!m_telemetry.hasAdcClipping
+                || m_telemetry.adcClipping != clipping) {
+                m_telemetry.hasAdcClipping = true;
+                m_telemetry.adcClipping = clipping;
+                emitTelemetryChanged();
+            }
+        } else if (key == QStringLiteral("gps_good")) {
+            const bool good = value != 0.0;
+            if (!m_telemetry.hasGpsGood || m_telemetry.gpsGood != good) {
+                m_telemetry.hasGpsGood = true;
+                m_telemetry.gpsGood = good;
+                emitTelemetryChanged();
+            }
+        }
+    }
+}
+
+bool KiwiSdrClient::updateWaterfallFftBins(int binCount)
+{
+    if (!plausibleWaterfallFftBins(binCount)) {
+        return false;
+    }
+
+    const int fftBins = sanitizedWaterfallFftBins(binCount);
+    if (m_waterfallFftBins == fftBins) {
+        return false;
+    }
+
+    m_waterfallFftBins = fftBins;
+    m_waterfallRequestValid = false;
+    sendWaterfallViewToServer();
+    return true;
+}
+
+void KiwiSdrClient::updateSoundTelemetry(const QByteArray& frame)
+{
+    const KiwiSdrProtocol::SoundFrameHeader header =
+        KiwiSdrProtocol::parseSoundFrameHeader(frame);
+    if (!header.valid) {
+        return;
+    }
+
+    const quint64 gaps = header.sequence >= 0
+        ? KiwiSdrProtocol::sequenceGapCount(m_telemetry.soundSequence,
+                                            header.sequence)
+        : 0;
+    if (header.sequence >= 0) {
+        m_telemetry.soundSequenceGaps += gaps;
+        m_telemetry.soundSequence = header.sequence;
+    }
+    bool changed = gaps > 0;
+    if (header.hasRssi
+        && (!m_telemetry.hasSoundRssi
+            || std::abs(m_telemetry.soundRssiDbm - header.rssiDbm) > 0.05f)) {
+        m_telemetry.hasSoundRssi = true;
+        m_telemetry.soundRssiDbm = header.rssiDbm;
+        changed = true;
+    }
+    if (changed) {
+        emitTelemetryChanged();
+    }
+}
+
+void KiwiSdrClient::updateWaterfallTelemetry(const QByteArray& frame)
+{
+    const KiwiSdrProtocol::WaterfallLineHeader header =
+        KiwiSdrProtocol::parseWaterfallLineHeader(frame);
+    if (!header.valid) {
+        return;
+    }
+
+    const quint64 gaps =
+        KiwiSdrProtocol::sequenceGapCount(m_telemetry.waterfallSequence,
+                                          header.sequence);
+    m_telemetry.waterfallSequence = header.sequence;
+    if (gaps > 0) {
+        m_telemetry.waterfallSequenceGaps += gaps;
+        emitTelemetryChanged();
+    }
+}
+
+void KiwiSdrClient::emitTelemetryChanged()
+{
+    if (m_telemetryPending) {
+        return;
+    }
+
+    m_telemetryPending = true;
+    QTimer::singleShot(0, this, [this]() {
+        m_telemetryPending = false;
+        emit telemetryChanged();
+    });
+}
+
+void KiwiSdrClient::sendWaterfallRateToServer()
+{
+    if (m_waterfallRateOverride > 0) {
+        sendWaterfallCommand(QStringLiteral("SET wf_speed=%1")
+            .arg(m_waterfallRateOverride));
+        return;
+    }
+
+    const int flexRate = std::clamp(m_waterfallLineDurationMs, 1, 100);
+    // Clean-room W/F probes on public endpoints showed that the supported
+    // speed control is a compact 1..4 range. On 22033.proxy.kiwisdr.com,
+    // values 5 and above echoed wf_fps=0 and produced no W/F rows.
+    const int speed = std::clamp(
+        1 + static_cast<int>(std::lround((flexRate - 1) * 3.0 / 99.0)),
+        1,
+        4);
+    sendWaterfallCommand(QStringLiteral("SET wf_speed=%1").arg(speed));
+}
+
+void KiwiSdrClient::markSoundAudioReady()
+{
+    if (m_soundAudioReady) {
+        return;
+    }
+
+    m_soundAudioReady = true;
+    if (m_audioReadyTimer) {
+        m_audioReadyTimer->stop();
+    }
+    setState(State::Connected, tr("Connected to %1.").arg(m_endpoint));
+}
+
+void KiwiSdrClient::sendKeepalive()
+{
+    sendSoundCommand(QStringLiteral("SET keepalive"));
+    sendWaterfallCommand(QStringLiteral("SET keepalive"));
+}
+
+#ifdef HAVE_WEBSOCKETS
+bool KiwiSdrClient::retryWithSecureWebSocket(bool transportEstablished)
+{
+    if (transportEstablished
+        || m_soundSocketConnected || m_waterfallSocketConnected
+        || m_secureWebSocket || m_secureWebSocketRetryAttempted
+        || m_host.isEmpty()) {
+        return false;
+    }
+
+    const QString lowerHost = m_host.toLower();
+    if (!lowerHost.endsWith(QStringLiteral(".proxy.kiwisdr.com"))) {
+        return false;
+    }
+
+    m_secureWebSocketRetryAttempted = true;
+    m_secureWebSocket = true;
+    m_soundSocketConnected = false;
+    m_waterfallSocketConnected = false;
+    m_soundAudioReady = false;
+    m_soundAudioRateAcked = false;
+    m_soundSampleRateCommandsSent = false;
+    m_soundSampleRatePending = false;
+    m_soundFrameSeen = false;
+    m_loggedSoundFrameShape = false;
+    m_loggedWaterfallFrameShape = false;
+    m_haveSoundAudioRate = false;
+    m_soundResamplerRateHz = 0.0;
+    m_soundResampler.reset();
+
+    m_userDisconnecting = true;
+    cleanupSockets();
+    m_userDisconnecting = false;
+    setState(State::Connecting,
+             tr("Retrying %1 over secure KiwiSDR WebSocket.")
+                 .arg(m_endpoint));
+
+    QTimer::singleShot(0, this, [this]() {
+        if (!m_userDisconnecting) {
+            openWebSockets();
+        }
+    });
+    return true;
+}
+
+void KiwiSdrClient::sendSoundCommand(const QString& command)
+{
+    if (m_soundSocket && m_soundSocket->state() == QAbstractSocket::ConnectedState) {
+        qCDebug(lcProtocol).noquote()
+            << "KiwiSDR SND ->" << redactedKiwiCommand(command);
+        m_soundSocket->sendTextMessage(command);
+    }
+}
+
+void KiwiSdrClient::sendWaterfallCommand(const QString& command)
+{
+    if (m_waterfallSocket
+        && m_waterfallSocket->state() == QAbstractSocket::ConnectedState) {
+        qCDebug(lcProtocol).noquote()
+            << "KiwiSDR W/F ->" << redactedKiwiCommand(command);
+        m_waterfallSocket->sendTextMessage(command);
+    }
+}
+
+void KiwiSdrClient::handleSocketError(const QString& detail,
+                                      bool transportEstablished)
+{
+    if (!m_userDisconnecting) {
+        if (retryWithSecureWebSocket(transportEstablished)) {
+            return;
+        }
+        const bool wasConnected = m_state == State::Connected;
+        setState(State::Error, detail);
+        cleanupSockets();
+        if (wasConnected) {
+            emit recoverableDisconnect(detail);
+        }
+    }
+}
+#else
+void KiwiSdrClient::sendSoundCommand(const QString&)
+{
+}
+
+void KiwiSdrClient::sendWaterfallCommand(const QString&)
+{
+}
+#endif
+
+QString KiwiSdrClient::stateLabel(State state)
+{
+    switch (state) {
+    case State::Disconnected: return tr("Disconnected");
+    case State::Connecting:   return tr("Connecting");
+    case State::Connected:    return tr("Connected");
+    case State::Error:        return tr("Error");
+    }
+    return tr("Disconnected");
+}
+
+void KiwiSdrClient::setState(State state, const QString& detail)
+{
+    if (m_state == state && m_stateDetail == detail) {
+        return;
+    }
+
+    m_state = state;
+    m_stateDetail = detail;
+    if (m_audioReadyTimer && m_state != State::Connecting) {
+        m_audioReadyTimer->stop();
+    }
+    if (m_state != State::Connected) {
+        setAudioActive(false);
+    }
+
+    emit stateChanged(m_state, detail);
+}
+
+} // namespace AetherSDR

--- a/src/core/KiwiSdrClient.h
+++ b/src/core/KiwiSdrClient.h
@@ -1,0 +1,227 @@
+#pragma once
+
+#include "KiwiSdrProtocol.h"
+
+#include <QByteArray>
+#include <QObject>
+#include <QString>
+#include <QVector>
+
+#include <QtGlobal>
+
+#include <memory>
+#include <vector>
+
+class QTimer;
+#ifdef HAVE_WEBSOCKETS
+class QWebSocket;
+#endif
+
+namespace AetherSDR {
+
+class Resampler;
+
+struct KiwiSdrReceiverControls {
+    bool agcEnabled{true};
+    int agcGainDb{50};
+    bool agcHang{false};
+    int agcThresholdDb{-100};
+    int agcDecayMs{1000};
+    bool squelchEnabled{false};
+    double squelchLevelDbm{-105.0};
+};
+
+struct KiwiSdrReceiverTelemetry {
+    int soundSequence{-1};
+    float soundRssiDbm{0.0f};
+    bool hasSoundRssi{false};
+    quint64 soundSequenceGaps{0};
+    int waterfallSequence{-1};
+    quint64 waterfallSequenceGaps{0};
+    int users{-1};
+    double reportedFrequencyKhz{0.0};
+    bool adcClipping{false};
+    bool hasAdcClipping{false};
+    bool gpsGood{false};
+    bool hasGpsGood{false};
+};
+
+class KiwiSdrClient : public QObject {
+    Q_OBJECT
+
+public:
+    enum class State {
+        Disconnected,
+        Connecting,
+        Connected,
+        Error,
+    };
+    Q_ENUM(State)
+
+    explicit KiwiSdrClient(QObject* parent = nullptr);
+    ~KiwiSdrClient() override;
+
+    State state() const { return m_state; }
+    QString endpoint() const { return m_endpoint; }
+    bool isConnected() const { return m_state == State::Connected; }
+    bool audioActive() const { return m_audioActive; }
+    bool hasTrackedSlice() const
+    {
+        return m_trackedSliceId >= 0 && m_trackedFrequencyMhz > 0.0;
+    }
+    KiwiSdrReceiverControls receiverControls() const { return m_receiverControls; }
+    KiwiSdrReceiverTelemetry telemetry() const { return m_telemetry; }
+    static QString normalizeEndpoint(const QString& endpoint);
+
+public slots:
+    void setOperatorCallsign(const QString& callsign);
+    void setReceiverControls(const KiwiSdrReceiverControls& controls);
+    void connectToEndpoint(const QString& endpoint);
+    void disconnectFromEndpoint();
+    void setTrackedSlice(int sliceId, double frequencyMhz,
+                         const QString& mode, int filterLowHz,
+                         int filterHighHz, const QString& panId);
+    void setWaterfallView(const QString& panId, double centerMhz,
+                          double bandwidthMhz);
+    void setWaterfallLineDurationMs(int lineDurationMs);
+    void setWaterfallDisplayAdjustments(int cellDb, int floorDb);
+    void setWaterfallRateOverride(int rate);
+    void setAudioActive(bool active);
+    void setDecodeAudioWhenInactive(bool decode);
+
+signals:
+    void stateChanged(AetherSDR::KiwiSdrClient::State state,
+                      const QString& detail);
+    void audioActiveChanged(bool active);
+    void trackedSliceChanged(int sliceId, double frequencyMhz,
+                             const QString& mode, int filterLowHz,
+                             int filterHighHz, const QString& panId);
+    void decodedAudioReady(const QByteArray& pcm24kStereoFloat);
+    void waterfallRowReady(const QString& panId, const QVector<float>& binsDbm,
+                           double lowFreqMhz, double highFreqMhz,
+                           quint32 timecode);
+    void meterReadingReady(
+        const AetherSDR::KiwiSdrProtocol::MeterReading& reading);
+    void telemetryChanged();
+    void recoverableDisconnect(const QString& detail);
+
+private:
+    static bool parseEndpoint(const QString& endpoint, QString* host, quint16* port);
+    static QString stateLabel(State state);
+    void setState(State state, const QString& detail);
+    void cleanupSockets();
+    void sendSoundSetupCommands();
+    void sendSoundAudioRateAck();
+    void sendSoundSampleRateCommands();
+    void sendWaterfallSetupCommands();
+    void sendTrackedSliceToServer();
+    void sendReceiverControlsToServer();
+    void sendWaterfallViewToServer();
+    void sendWaterfallDisplayAdjustmentsToServer();
+    QString kiwiIdentityCallsign() const;
+    QString identityDiagnosticText() const;
+    void sendSoundIdentityToServer();
+    void sendWaterfallIdentityToServer();
+    QString kiwiMode() const;
+    int kiwiLowCutHz() const;
+    int kiwiHighCutHz() const;
+    bool isSupportedPcmSoundFrame(
+        const QByteArray& frame,
+        const KiwiSdrProtocol::SoundFrameHeader& header) const;
+    bool parseWaterfallFrameHeader(const QByteArray& frame, quint32* start,
+                                   int* zoom) const;
+    QByteArray decodeSoundFrame(const QByteArray& frame);
+    QVector<float> decodeWaterfallFrame(const QByteArray& frame) const;
+    void handleBinaryMessage(const QByteArray& frame);
+    void handleSoundFrame(const QByteArray& frame);
+    void handleWaterfallFrame(const QByteArray& frame);
+    void handleMessage(const QByteArray& frame);
+    void handleTextMessage(const QString& text);
+    bool updateWaterfallFftBins(int binCount);
+    void updateSoundTelemetry(const QByteArray& frame);
+    void updateWaterfallTelemetry(const QByteArray& frame);
+    void emitTelemetryChanged();
+    void sendWaterfallRateToServer();
+    void markSoundAudioReady();
+    void sendKeepalive();
+    void sendSoundCommand(const QString& command);
+    void sendWaterfallCommand(const QString& command);
+
+#ifdef HAVE_WEBSOCKETS
+    void handleSocketError(const QString& detail, bool transportEstablished);
+    void openWebSockets();
+    bool retryWithSecureWebSocket(bool transportEstablished);
+#endif
+
+    State m_state{State::Disconnected};
+    QString m_stateDetail;
+    QString m_endpoint;
+    QString m_host;
+    QString m_operatorCallsign;
+    QString m_lastSoundIdentityCallsign;
+    QString m_lastWaterfallIdentityCallsign;
+    quint16 m_port{0};
+    bool m_audioActive{false};
+    KiwiSdrReceiverControls m_receiverControls;
+    KiwiSdrReceiverTelemetry m_telemetry;
+    bool m_telemetryPending{false};
+    int m_trackedSliceId{-1};
+    double m_trackedFrequencyMhz{0.0};
+    QString m_trackedMode;
+    int m_trackedFilterLowHz{0};
+    int m_trackedFilterHighHz{0};
+    QString m_trackedPanId;
+    bool m_userDisconnecting{false};
+    bool m_secureWebSocket{false};
+    bool m_secureWebSocketRetryAttempted{false};
+    bool m_soundSocketConnected{false};
+    bool m_waterfallSocketConnected{false};
+    bool m_soundAudioReady{false};
+    bool m_soundAudioRateAcked{false};
+    bool m_soundSampleRateCommandsSent{false};
+    bool m_soundSampleRatePending{false};
+    bool m_soundFrameSeen{false};
+    bool m_loggedSoundFrameShape{false};
+    bool m_loggedWaterfallFrameShape{false};
+    bool m_decodeAudioWhenInactive{true};
+    double m_soundSampleRateHz{12000.0};
+    double m_soundResamplerRateHz{0.0};
+    bool m_haveSoundAudioRate{false};
+    double m_waterfallServerCenterMhz{15.0};
+    double m_waterfallServerBandwidthMhz{30.0};
+    QString m_waterfallViewPanId;
+    double m_waterfallViewCenterMhz{0.0};
+    double m_waterfallViewBandwidthMhz{0.0};
+    bool m_waterfallRequestValid{false};
+    QString m_waterfallRequestPanId;
+    quint32 m_waterfallRequestStart{0};
+    int m_waterfallRequestZoom{0};
+    double m_waterfallRequestLowMhz{0.0};
+    double m_waterfallRequestHighMhz{0.0};
+    int m_waterfallZoomCap{14};
+    int m_waterfallFftBins{1024};
+    float m_waterfallMinDbm{-130.0f};
+    float m_waterfallMaxDbm{-50.0f};
+    int m_waterfallCellDb{0};
+    int m_waterfallFloorDb{0};
+    int m_waterfallRateOverride{0};
+    int m_waterfallLineDurationMs{100};
+    std::unique_ptr<Resampler> m_soundResampler;
+    QByteArray m_lastDecodedSoundPcm;
+    QVector<float> m_lastWaterfallBins;
+    QString m_lastWaterfallPanId;
+    double m_lastWaterfallLowMhz{0.0};
+    double m_lastWaterfallHighMhz{0.0};
+    bool m_lastWaterfallRowValid{false};
+    QTimer* m_keepaliveTimer{nullptr};
+    QTimer* m_audioReadyTimer{nullptr};
+
+#ifdef HAVE_WEBSOCKETS
+    QWebSocket* m_soundSocket{nullptr};
+    QWebSocket* m_waterfallSocket{nullptr};
+#endif
+};
+
+} // namespace AetherSDR
+
+Q_DECLARE_METATYPE(AetherSDR::KiwiSdrReceiverTelemetry)

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -217,6 +217,10 @@ void KiwiSdrManager::removeProfile(const QString& id)
     m_telemetry.remove(id);
     m_profiles.removeAt(idx);
     saveSettings();
+    // The client is already deleted above, so no further audio will be fed for
+    // this id; free its audio-engine source state (disable alone leaves the
+    // per-source entry allocated — #3668 review).
+    emit audioSourceRemoved(id);
     emit profilesChanged();
 }
 

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -1,0 +1,607 @@
+#include "KiwiSdrManager.h"
+
+#include "AppSettings.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTimer>
+#include <QUuid>
+
+#include <algorithm>
+#include <utility>
+
+namespace AetherSDR {
+namespace {
+
+constexpr const char* kKiwiSdrRxAntennasSettingsKey = "KiwiSdrRxAntennas";
+constexpr const char* kVirtualAntennaPrefix = "KIWI:";
+constexpr int kRecoverableReconnectDelayMs = 3000;
+constexpr int kKiwiSdrProfileNameMaxChars = 16;
+
+QString normalizedProfileEndpoint(const QString& endpoint)
+{
+    return KiwiSdrClient::normalizeEndpoint(endpoint);
+}
+
+} // namespace
+
+KiwiSdrManager::KiwiSdrManager(QObject* parent)
+    : QObject(parent)
+{
+    loadSettings();
+}
+
+KiwiSdrManager::~KiwiSdrManager()
+{
+    disconnectAll();
+}
+
+KiwiSdrAntennaProfile KiwiSdrManager::profile(const QString& id) const
+{
+    const int idx = profileIndex(id);
+    return idx >= 0 ? m_profiles[idx] : KiwiSdrAntennaProfile{};
+}
+
+bool KiwiSdrManager::hasProfile(const QString& id) const
+{
+    return profileIndex(id) >= 0;
+}
+
+QString KiwiSdrManager::displayName(const QString& id) const
+{
+    const KiwiSdrAntennaProfile p = profile(id);
+    if (!p.name.trimmed().isEmpty()) {
+        return p.name.trimmed();
+    }
+    if (!p.endpoint.isEmpty()) {
+        return p.endpoint;
+    }
+    return tr("KiwiSDR");
+}
+
+QString KiwiSdrManager::virtualAntennaToken(const QString& id) const
+{
+    return QStringLiteral("%1%2").arg(QString::fromLatin1(kVirtualAntennaPrefix), id);
+}
+
+QString KiwiSdrManager::profileIdForVirtualAntennaToken(const QString& token) const
+{
+    return token.startsWith(QString::fromLatin1(kVirtualAntennaPrefix))
+        ? token.mid(QString::fromLatin1(kVirtualAntennaPrefix).size())
+        : QString();
+}
+
+QStringList KiwiSdrManager::virtualAntennaTokens() const
+{
+    QStringList tokens;
+    tokens.reserve(m_profiles.size());
+    for (const KiwiSdrAntennaProfile& p : m_profiles) {
+        tokens.append(virtualAntennaToken(p.id));
+    }
+    return tokens;
+}
+
+QStringList KiwiSdrManager::virtualAntennaLabels() const
+{
+    QStringList labels;
+    labels.reserve(m_profiles.size());
+    for (const KiwiSdrAntennaProfile& p : m_profiles) {
+        labels.append(displayName(p.id));
+    }
+    return labels;
+}
+
+KiwiSdrClient::State KiwiSdrManager::state(const QString& id) const
+{
+    if (KiwiSdrClient* c = client(id)) {
+        return c->state();
+    }
+    return KiwiSdrClient::State::Disconnected;
+}
+
+QString KiwiSdrManager::stateDetail(const QString& id) const
+{
+    return m_stateDetails.value(id);
+}
+
+KiwiSdrReceiverTelemetry KiwiSdrManager::telemetry(const QString& id) const
+{
+    if (KiwiSdrClient* c = client(id)) {
+        return c->telemetry();
+    }
+    return m_telemetry.value(id);
+}
+
+bool KiwiSdrManager::isConnected(const QString& id) const
+{
+    if (KiwiSdrClient* c = client(id)) {
+        return c->isConnected();
+    }
+    return false;
+}
+
+QString KiwiSdrManager::assignedProfileForSlice(int sliceId) const
+{
+    return m_sliceAssignments.value(sliceId);
+}
+
+int KiwiSdrManager::assignedSliceForProfile(const QString& id) const
+{
+    for (auto it = m_sliceAssignments.constBegin(); it != m_sliceAssignments.constEnd(); ++it) {
+        if (it.value() == id) {
+            return it.key();
+        }
+    }
+    return -1;
+}
+
+QString KiwiSdrManager::addProfile(const QString& name, const QString& endpoint)
+{
+    const QString normalizedEndpoint = normalizedProfileEndpoint(endpoint);
+    const QString displayName = name.trimmed().left(kKiwiSdrProfileNameMaxChars);
+    if (displayName.isEmpty() || normalizedEndpoint.isEmpty()) {
+        return QString();
+    }
+
+    KiwiSdrAntennaProfile profile;
+    profile.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    profile.endpoint = normalizedEndpoint;
+    profile.name = displayName;
+    m_profiles.append(profile);
+    saveSettings();
+    emit profilesChanged();
+    return profile.id;
+}
+
+void KiwiSdrManager::updateProfile(const KiwiSdrAntennaProfile& profile)
+{
+    const int idx = profileIndex(profile.id);
+    if (idx < 0) {
+        return;
+    }
+
+    KiwiSdrAntennaProfile updated = profile;
+    updated.endpoint = normalizedProfileEndpoint(profile.endpoint);
+    updated.name = sanitizedName(profile.name, updated.endpoint);
+    updated.waterfallCellDb = std::clamp(updated.waterfallCellDb, -30, 30);
+    updated.waterfallFloorDb = std::clamp(updated.waterfallFloorDb, -30, 30);
+    updated.waterfallRate = std::clamp(updated.waterfallRate, 0, 5);
+    const QString oldEndpoint = m_profiles[idx].endpoint;
+    m_profiles[idx] = updated;
+    saveSettings();
+    const bool endpointChanged = oldEndpoint != updated.endpoint;
+    if (endpointChanged) {
+        cancelReconnect(updated.id);
+        emit profileStreamReset(updated.id);
+    }
+
+    if (KiwiSdrClient* c = client(updated.id)) {
+        c->setWaterfallDisplayAdjustments(updated.waterfallCellDb,
+                                          updated.waterfallFloorDb);
+        c->setWaterfallRateOverride(updated.waterfallRate);
+        if (endpointChanged && c->state() != KiwiSdrClient::State::Disconnected) {
+            c->disconnectFromEndpoint();
+            if (!updated.endpoint.isEmpty()) {
+                c->connectToEndpoint(updated.endpoint);
+            }
+        }
+    }
+    emit profilesChanged();
+}
+
+void KiwiSdrManager::removeProfile(const QString& id)
+{
+    const int idx = profileIndex(id);
+    if (idx < 0) {
+        return;
+    }
+
+    cancelReconnect(id);
+    disconnectProfile(id);
+    if (KiwiSdrClient* c = m_clients.take(id)) {
+        c->deleteLater();
+    }
+    if (QTimer* timer = m_reconnectTimers.take(id)) {
+        timer->deleteLater();
+    }
+
+    const QList<int> assignedSlices = m_sliceAssignments.keys(id);
+    for (int sliceId : assignedSlices) {
+        m_sliceAssignments.remove(sliceId);
+        emit audioSourceEnabledChanged(id, false);
+        emit sliceAssignmentChanged(sliceId, QString());
+    }
+
+    m_stateDetails.remove(id);
+    m_telemetry.remove(id);
+    m_profiles.removeAt(idx);
+    saveSettings();
+    emit profilesChanged();
+}
+
+void KiwiSdrManager::connectProfile(const QString& id)
+{
+    const int idx = profileIndex(id);
+    if (idx < 0) {
+        return;
+    }
+
+    cancelReconnect(id);
+    KiwiSdrClient* c = ensureClient(id);
+    if (!c || m_profiles[idx].endpoint.isEmpty()) {
+        return;
+    }
+    if (c->state() == KiwiSdrClient::State::Connecting
+        || c->state() == KiwiSdrClient::State::Connected) {
+        return;
+    }
+    c->setOperatorCallsign(m_operatorCallsign);
+    c->setWaterfallDisplayAdjustments(m_profiles[idx].waterfallCellDb,
+                                      m_profiles[idx].waterfallFloorDb);
+    c->setWaterfallRateOverride(m_profiles[idx].waterfallRate);
+    if (assignedSliceForProfile(id) < 0) {
+        c->setTrackedSlice(-1, 0.0, QString(), 0, 0, QString());
+        emit profileNeedsInitialTracking(id);
+    }
+    if (!c->hasTrackedSlice()) {
+        return;
+    }
+    c->connectToEndpoint(m_profiles[idx].endpoint);
+}
+
+void KiwiSdrManager::disconnectProfile(const QString& id)
+{
+    cancelReconnect(id);
+    if (KiwiSdrClient* c = client(id)) {
+        c->disconnectFromEndpoint();
+    }
+    emit audioSourceEnabledChanged(id, false);
+}
+
+void KiwiSdrManager::disconnectAll()
+{
+    for (QTimer* timer : std::as_const(m_reconnectTimers)) {
+        if (timer) {
+            timer->stop();
+        }
+    }
+    for (KiwiSdrClient* c : std::as_const(m_clients)) {
+        if (c) {
+            c->disconnectFromEndpoint();
+        }
+    }
+}
+
+void KiwiSdrManager::setOperatorCallsign(const QString& callsign)
+{
+    m_operatorCallsign = callsign;
+    for (KiwiSdrClient* c : std::as_const(m_clients)) {
+        if (c) {
+            c->setOperatorCallsign(callsign);
+        }
+    }
+}
+
+void KiwiSdrManager::startAutoConnect()
+{
+    for (const KiwiSdrAntennaProfile& p : std::as_const(m_profiles)) {
+        if (p.autoConnect && !p.endpoint.isEmpty()) {
+            connectProfile(p.id);
+        }
+    }
+}
+
+void KiwiSdrManager::primeProfileTracking(const QString& id, int sliceId,
+                                          double frequencyMhz,
+                                          const QString& mode,
+                                          int filterLowHz,
+                                          int filterHighHz,
+                                          const QString& panId,
+                                          double centerMhz,
+                                          double bandwidthMhz,
+                                          int lineDurationMs)
+{
+    if (!hasProfile(id) || sliceId < 0 || frequencyMhz <= 0.0) {
+        return;
+    }
+
+    if (KiwiSdrClient* c = ensureClient(id)) {
+        c->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
+                           filterHighHz, panId);
+        c->setWaterfallLineDurationMs(lineDurationMs);
+        if (!panId.isEmpty() && centerMhz > 0.0 && bandwidthMhz > 0.0) {
+            c->setWaterfallView(panId, centerMhz, bandwidthMhz);
+        }
+    }
+}
+
+void KiwiSdrManager::assignSliceToProfile(int sliceId, const QString& profileId,
+                                          double frequencyMhz,
+                                          const QString& mode,
+                                          int filterLowHz, int filterHighHz,
+                                          const QString& panId)
+{
+    if (sliceId < 0 || !hasProfile(profileId)) {
+        clearSliceAssignment(sliceId);
+        return;
+    }
+
+    const QString previousProfile = m_sliceAssignments.value(sliceId);
+    if (!previousProfile.isEmpty() && previousProfile != profileId) {
+        emit audioSourceEnabledChanged(previousProfile, false);
+        if (KiwiSdrClient* previousClient = client(previousProfile)) {
+            previousClient->setAudioActive(false);
+        }
+    }
+
+    const QList<int> otherSlices = m_sliceAssignments.keys(profileId);
+    for (int otherSliceId : otherSlices) {
+        if (otherSliceId == sliceId) {
+            continue;
+        }
+        m_sliceAssignments.remove(otherSliceId);
+        emit sliceAssignmentChanged(otherSliceId, QString());
+    }
+
+    m_sliceAssignments.insert(sliceId, profileId);
+    emit sliceAssignmentChanged(sliceId, profileId);
+
+    if (KiwiSdrClient* c = ensureClient(profileId)) {
+        c->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
+                           filterHighHz, panId);
+        c->setAudioActive(c->isConnected());
+    }
+    connectProfile(profileId);
+    emit audioSourceEnabledChanged(profileId, true);
+}
+
+void KiwiSdrManager::clearSliceAssignment(int sliceId)
+{
+    const QString previousProfile = m_sliceAssignments.take(sliceId);
+    if (previousProfile.isEmpty()) {
+        return;
+    }
+
+    emit audioSourceEnabledChanged(previousProfile, false);
+    if (KiwiSdrClient* c = client(previousProfile)) {
+        c->setAudioActive(false);
+    }
+    emit sliceAssignmentChanged(sliceId, QString());
+}
+
+void KiwiSdrManager::updateSliceTracking(int sliceId, double frequencyMhz,
+                                         const QString& mode,
+                                         int filterLowHz, int filterHighHz,
+                                         const QString& panId)
+{
+    const QString profileId = m_sliceAssignments.value(sliceId);
+    if (profileId.isEmpty()) {
+        return;
+    }
+    if (KiwiSdrClient* c = ensureClient(profileId)) {
+        c->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
+                           filterHighHz, panId);
+    }
+}
+
+void KiwiSdrManager::updateWaterfallView(int sliceId, const QString& panId,
+                                         double centerMhz, double bandwidthMhz,
+                                         int lineDurationMs)
+{
+    const QString profileId = m_sliceAssignments.value(sliceId);
+    if (profileId.isEmpty()) {
+        return;
+    }
+    if (KiwiSdrClient* c = ensureClient(profileId)) {
+        c->setWaterfallLineDurationMs(lineDurationMs);
+        c->setWaterfallView(panId, centerMhz, bandwidthMhz);
+    }
+}
+
+void KiwiSdrManager::setProfileWaterfallSettings(const QString& id, int cellDb,
+                                                 int floorDb, int rate)
+{
+    const int idx = profileIndex(id);
+    if (idx < 0) {
+        return;
+    }
+
+    KiwiSdrAntennaProfile p = m_profiles[idx];
+    p.waterfallCellDb = std::clamp(cellDb, -30, 30);
+    p.waterfallFloorDb = std::clamp(floorDb, -30, 30);
+    p.waterfallRate = std::clamp(rate, 0, 5);
+    updateProfile(p);
+}
+
+KiwiSdrClient* KiwiSdrManager::ensureClient(const QString& id)
+{
+    if (KiwiSdrClient* existing = client(id)) {
+        return existing;
+    }
+
+    if (!hasProfile(id)) {
+        return nullptr;
+    }
+
+    auto* c = new KiwiSdrClient(this);
+    c->setDecodeAudioWhenInactive(false);
+    c->setOperatorCallsign(m_operatorCallsign);
+    m_clients.insert(id, c);
+    connect(c, &KiwiSdrClient::stateChanged,
+            this, [this, id, c](KiwiSdrClient::State state, const QString& detail) {
+        m_stateDetails.insert(id, detail);
+        if (state == KiwiSdrClient::State::Connecting) {
+            m_telemetry.insert(id, {});
+            emit profileTelemetryChanged(id, m_telemetry.value(id));
+        }
+        if (state == KiwiSdrClient::State::Connected) {
+            const int idx = profileIndex(id);
+            if (idx >= 0) {
+                c->setWaterfallDisplayAdjustments(m_profiles[idx].waterfallCellDb,
+                                                  m_profiles[idx].waterfallFloorDb);
+                c->setWaterfallRateOverride(m_profiles[idx].waterfallRate);
+            }
+            if (assignedSliceForProfile(id) >= 0) {
+                c->setAudioActive(true);
+                emit audioSourceEnabledChanged(id, true);
+            }
+        } else if (state == KiwiSdrClient::State::Disconnected
+                   || state == KiwiSdrClient::State::Error) {
+            emit audioSourceEnabledChanged(id, false);
+            emit meterReadingReady(
+                id,
+                KiwiSdrProtocol::meterUnavailable(
+                    KiwiSdrProtocol::MeterSource::Unknown,
+                    detail));
+        }
+        emit profileStateChanged(id, state, detail);
+    });
+    connect(c, &KiwiSdrClient::recoverableDisconnect,
+            this, [this, id](const QString&) {
+        scheduleReconnect(id);
+    });
+    connect(c, &KiwiSdrClient::telemetryChanged, this, [this, id, c]() {
+        m_telemetry.insert(id, c->telemetry());
+        emit profileTelemetryChanged(id, m_telemetry.value(id));
+    });
+    connect(c, &KiwiSdrClient::decodedAudioReady,
+            this, [this, id](const QByteArray& pcm) {
+        emit decodedAudioReady(id, pcm);
+    });
+    connect(c, &KiwiSdrClient::waterfallRowReady,
+            this, [this, id](const QString& panId, const QVector<float>& binsDbm,
+                             double lowFreqMhz, double highFreqMhz,
+                             quint32 timecode) {
+        emit waterfallRowReady(id, panId, binsDbm, lowFreqMhz, highFreqMhz,
+                               timecode);
+    });
+    connect(c, &KiwiSdrClient::meterReadingReady,
+            this, [this, id](const KiwiSdrProtocol::MeterReading& reading) {
+        emit meterReadingReady(id, reading);
+    });
+    return c;
+}
+
+KiwiSdrClient* KiwiSdrManager::client(const QString& id) const
+{
+    return m_clients.value(id, nullptr);
+}
+
+int KiwiSdrManager::profileIndex(const QString& id) const
+{
+    for (int i = 0; i < m_profiles.size(); ++i) {
+        if (m_profiles[i].id == id) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+void KiwiSdrManager::loadSettings()
+{
+    m_profiles.clear();
+    const QString raw = AppSettings::instance()
+        .value(kKiwiSdrRxAntennasSettingsKey, "{}").toString();
+    const QJsonObject root = QJsonDocument::fromJson(raw.toUtf8()).object();
+    const QJsonArray profiles = root.value(QStringLiteral("profiles")).toArray();
+    for (const QJsonValue& value : profiles) {
+        const QJsonObject obj = value.toObject();
+        KiwiSdrAntennaProfile p;
+        p.id = obj.value(QStringLiteral("id")).toString();
+        if (p.id.isEmpty()) {
+            p.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+        }
+        p.endpoint = normalizedProfileEndpoint(
+            obj.value(QStringLiteral("endpoint")).toString());
+        p.name = sanitizedName(obj.value(QStringLiteral("name")).toString(),
+                               p.endpoint);
+        p.autoConnect = obj.value(QStringLiteral("autoConnect")).toBool(false);
+        p.waterfallCellDb = std::clamp(
+            obj.value(QStringLiteral("waterfallCellDb")).toInt(0), -30, 30);
+        p.waterfallFloorDb = std::clamp(
+            obj.value(QStringLiteral("waterfallFloorDb")).toInt(0), -30, 30);
+        p.waterfallRate = std::clamp(
+            obj.value(QStringLiteral("waterfallRate")).toInt(0), 0, 5);
+        m_profiles.append(p);
+    }
+}
+
+void KiwiSdrManager::saveSettings() const
+{
+    QJsonArray profiles;
+    for (const KiwiSdrAntennaProfile& p : m_profiles) {
+        QJsonObject obj;
+        obj.insert(QStringLiteral("id"), p.id);
+        obj.insert(QStringLiteral("name"), p.name);
+        obj.insert(QStringLiteral("endpoint"), normalizedProfileEndpoint(p.endpoint));
+        obj.insert(QStringLiteral("autoConnect"), p.autoConnect);
+        obj.insert(QStringLiteral("waterfallCellDb"), std::clamp(p.waterfallCellDb, -30, 30));
+        obj.insert(QStringLiteral("waterfallFloorDb"), std::clamp(p.waterfallFloorDb, -30, 30));
+        obj.insert(QStringLiteral("waterfallRate"), std::clamp(p.waterfallRate, 0, 5));
+        profiles.append(obj);
+    }
+
+    QJsonObject root;
+    root.insert(QStringLiteral("profiles"), profiles);
+    auto& settings = AppSettings::instance();
+    settings.setValue(kKiwiSdrRxAntennasSettingsKey, QString::fromUtf8(
+        QJsonDocument(root).toJson(QJsonDocument::Compact)));
+    settings.save();
+}
+
+bool KiwiSdrManager::shouldMaintainProfileConnection(const QString& id) const
+{
+    const int idx = profileIndex(id);
+    if (idx < 0 || m_profiles[idx].endpoint.trimmed().isEmpty()) {
+        return false;
+    }
+
+    return m_profiles[idx].autoConnect || assignedSliceForProfile(id) >= 0;
+}
+
+void KiwiSdrManager::scheduleReconnect(const QString& id)
+{
+    if (!shouldMaintainProfileConnection(id)) {
+        return;
+    }
+
+    QTimer* timer = m_reconnectTimers.value(id, nullptr);
+    if (!timer) {
+        timer = new QTimer(this);
+        timer->setSingleShot(true);
+        timer->setInterval(kRecoverableReconnectDelayMs);
+        m_reconnectTimers.insert(id, timer);
+        connect(timer, &QTimer::timeout, this, [this, id]() {
+            if (shouldMaintainProfileConnection(id)) {
+                connectProfile(id);
+            }
+        });
+    }
+
+    if (!timer->isActive()) {
+        timer->start();
+    }
+}
+
+void KiwiSdrManager::cancelReconnect(const QString& id)
+{
+    if (QTimer* timer = m_reconnectTimers.value(id, nullptr)) {
+        timer->stop();
+    }
+}
+
+QString KiwiSdrManager::sanitizedName(const QString& name,
+                                      const QString& endpoint)
+{
+    const QString trimmed = name.trimmed();
+    if (!trimmed.isEmpty()) {
+        return trimmed.left(kKiwiSdrProfileNameMaxChars);
+    }
+    if (!endpoint.trimmed().isEmpty()) {
+        return endpoint.trimmed().left(kKiwiSdrProfileNameMaxChars);
+    }
+    return QStringLiteral("KiwiSDR");
+}
+
+} // namespace AetherSDR

--- a/src/core/KiwiSdrManager.h
+++ b/src/core/KiwiSdrManager.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "KiwiSdrClient.h"
+
+#include <QHash>
+#include <QObject>
+#include <QString>
+#include <QVector>
+
+class QTimer;
+
+namespace AetherSDR {
+
+struct KiwiSdrAntennaProfile {
+    QString id;
+    QString name;
+    QString endpoint;
+    bool autoConnect{false};
+    int waterfallCellDb{0};
+    int waterfallFloorDb{0};
+    int waterfallRate{0};
+};
+
+class KiwiSdrManager : public QObject {
+    Q_OBJECT
+
+public:
+    explicit KiwiSdrManager(QObject* parent = nullptr);
+    ~KiwiSdrManager() override;
+
+    QVector<KiwiSdrAntennaProfile> profiles() const { return m_profiles; }
+    KiwiSdrAntennaProfile profile(const QString& id) const;
+    bool hasProfile(const QString& id) const;
+    QString displayName(const QString& id) const;
+    QString virtualAntennaToken(const QString& id) const;
+    QString profileIdForVirtualAntennaToken(const QString& token) const;
+    QStringList virtualAntennaTokens() const;
+    QStringList virtualAntennaLabels() const;
+
+    KiwiSdrClient::State state(const QString& id) const;
+    QString stateDetail(const QString& id) const;
+    KiwiSdrReceiverTelemetry telemetry(const QString& id) const;
+    bool isConnected(const QString& id) const;
+
+    QString assignedProfileForSlice(int sliceId) const;
+    int assignedSliceForProfile(const QString& id) const;
+
+public slots:
+    QString addProfile(const QString& name, const QString& endpoint);
+    void updateProfile(const KiwiSdrAntennaProfile& profile);
+    void removeProfile(const QString& id);
+    void connectProfile(const QString& id);
+    void disconnectProfile(const QString& id);
+    void disconnectAll();
+    void setOperatorCallsign(const QString& callsign);
+    void startAutoConnect();
+    void primeProfileTracking(const QString& id, int sliceId,
+                              double frequencyMhz, const QString& mode,
+                              int filterLowHz, int filterHighHz,
+                              const QString& panId, double centerMhz,
+                              double bandwidthMhz, int lineDurationMs);
+    void assignSliceToProfile(int sliceId, const QString& profileId,
+                              double frequencyMhz, const QString& mode,
+                              int filterLowHz, int filterHighHz,
+                              const QString& panId);
+    void clearSliceAssignment(int sliceId);
+    void updateSliceTracking(int sliceId, double frequencyMhz,
+                             const QString& mode, int filterLowHz,
+                             int filterHighHz, const QString& panId);
+    void updateWaterfallView(int sliceId, const QString& panId,
+                             double centerMhz, double bandwidthMhz,
+                             int lineDurationMs);
+    void setProfileWaterfallSettings(const QString& id, int cellDb,
+                                     int floorDb, int rate);
+
+signals:
+    void profilesChanged();
+    void profileStateChanged(const QString& id, AetherSDR::KiwiSdrClient::State state,
+                             const QString& detail);
+    void profileTelemetryChanged(
+        const QString& id,
+        const AetherSDR::KiwiSdrReceiverTelemetry& telemetry);
+    void profileStreamReset(const QString& id);
+    void sliceAssignmentChanged(int sliceId, const QString& profileId);
+    void audioSourceEnabledChanged(const QString& id, bool enabled);
+    void decodedAudioReady(const QString& id, const QByteArray& pcm24kStereoFloat);
+    void waterfallRowReady(const QString& id, const QString& panId,
+                           const QVector<float>& binsDbm,
+                           double lowFreqMhz, double highFreqMhz,
+                           quint32 timecode);
+    void meterReadingReady(
+        const QString& id,
+        const AetherSDR::KiwiSdrProtocol::MeterReading& reading);
+    void profileNeedsInitialTracking(const QString& id);
+
+private:
+    KiwiSdrClient* ensureClient(const QString& id);
+    KiwiSdrClient* client(const QString& id) const;
+    int profileIndex(const QString& id) const;
+    void loadSettings();
+    void saveSettings() const;
+    bool shouldMaintainProfileConnection(const QString& id) const;
+    void scheduleReconnect(const QString& id);
+    void cancelReconnect(const QString& id);
+    static QString sanitizedName(const QString& name, const QString& endpoint);
+
+    QVector<KiwiSdrAntennaProfile> m_profiles;
+    QHash<QString, KiwiSdrClient*> m_clients;
+    QHash<QString, QTimer*> m_reconnectTimers;
+    QHash<QString, QString> m_stateDetails;
+    QHash<QString, KiwiSdrReceiverTelemetry> m_telemetry;
+    QHash<int, QString> m_sliceAssignments;
+    QString m_operatorCallsign;
+};
+
+} // namespace AetherSDR

--- a/src/core/KiwiSdrManager.h
+++ b/src/core/KiwiSdrManager.h
@@ -83,6 +83,9 @@ signals:
     void profileStreamReset(const QString& id);
     void sliceAssignmentChanged(int sliceId, const QString& profileId);
     void audioSourceEnabledChanged(const QString& id, bool enabled);
+    // Emitted when a profile is removed entirely, so the audio engine can free
+    // the per-source DSP state (disabling alone only quiesces it — #3668 review).
+    void audioSourceRemoved(const QString& id);
     void decodedAudioReady(const QString& id, const QByteArray& pcm24kStereoFloat);
     void waterfallRowReady(const QString& id, const QString& panId,
                            const QVector<float>& binsDbm,

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -47,7 +47,8 @@ SoundFrameHeader parseSoundFrameHeader(const QByteArray& frame)
 
     SoundFrameHeader header;
     header.flags = static_cast<uchar>(frame[3]);
-    const bool observedExtendedFrame = frame.size() == 1034;
+    const bool observedExtendedFrame =
+        frame.size() == kObservedExtendedSoundFrameBytes;
     if (observedExtendedFrame && frame.size() >= 8) {
         const auto* data = reinterpret_cast<const uchar*>(frame.constData() + 4);
         const quint32 counter = static_cast<quint32>(data[0])

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -1,0 +1,286 @@
+#include "KiwiSdrProtocol.h"
+
+#include <QDateTime>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR::KiwiSdrProtocol {
+namespace {
+
+constexpr int kObservedExtendedSoundFrameBytes = 1034;
+constexpr int kObservedMeterOffset = 8;
+constexpr float kExperimentalMeterDbmOffset = -127.0f;
+constexpr float kExperimentalMeterDbPerRawUnit = 0.1f;
+
+float percentile(QVector<float> values, float fraction)
+{
+    if (values.isEmpty()) {
+        return 0.0f;
+    }
+
+    const int lastIndex = values.size() - 1;
+    const int index = std::clamp(
+        static_cast<int>(std::lround(std::clamp(fraction, 0.0f, 1.0f)
+            * static_cast<float>(lastIndex))),
+        0,
+        lastIndex);
+    std::nth_element(values.begin(), values.begin() + index, values.end());
+    return values[index];
+}
+
+qint16 readSignedBigEndian16(const QByteArray& bytes, int offset)
+{
+    const auto* data = reinterpret_cast<const uchar*>(bytes.constData() + offset);
+    const quint16 value = (static_cast<quint16>(data[0]) << 8)
+        | static_cast<quint16>(data[1]);
+    return static_cast<qint16>(value);
+}
+
+} // namespace
+
+SoundFrameHeader parseSoundFrameHeader(const QByteArray& frame)
+{
+    if (frame.size() < 6 || !frame.startsWith("SND")) {
+        return {};
+    }
+
+    SoundFrameHeader header;
+    header.flags = static_cast<uchar>(frame[3]);
+    const bool observedExtendedFrame = frame.size() == 1034;
+    if (observedExtendedFrame && frame.size() >= 8) {
+        const auto* data = reinterpret_cast<const uchar*>(frame.constData() + 4);
+        const quint32 counter = static_cast<quint32>(data[0])
+            | (static_cast<quint32>(data[1]) << 8)
+            | (static_cast<quint32>(data[2]) << 16)
+            | (static_cast<quint32>(data[3]) << 24);
+        header.sequence = static_cast<int>(counter & 0xffu);
+    } else {
+        header.sequence = header.flags;
+    }
+    header.valid = true;
+    return header;
+}
+
+WaterfallLineHeader parseWaterfallLineHeader(const QByteArray& frame)
+{
+    if (frame.size() < 4 || !frame.startsWith("W/F")) {
+        return {};
+    }
+
+    WaterfallLineHeader header;
+    header.sequence = static_cast<uchar>(frame[3]);
+    header.valid = true;
+    return header;
+}
+
+quint64 sequenceGapCount(int previousSequence, int currentSequence)
+{
+    if (previousSequence < 0 || currentSequence < 0) {
+        return 0;
+    }
+
+    const int previous = previousSequence & 0xff;
+    const int current = currentSequence & 0xff;
+    if (previous == current) {
+        return 0;
+    }
+
+    const int delta = (current - previous + 256) % 256;
+    return delta > 0 ? static_cast<quint64>(delta - 1) : 0;
+}
+
+float waterfallByteToDisplayLevel(unsigned char value)
+{
+    // Corrected clean-room spec: raw W/F bytes are display/bin intensity
+    // values, not calibrated dBm. Map them into AetherSDR's existing
+    // Kiwi-only pseudo-dB display range without claiming RF calibration.
+    constexpr float kDisplayFloor = -130.0f;
+    constexpr float kDisplayCeiling = 0.0f;
+    constexpr float kDisplaySpan = kDisplayCeiling - kDisplayFloor;
+    return kDisplayFloor
+        + (static_cast<float>(value) / 255.0f) * kDisplaySpan;
+}
+
+WaterfallAperture autoWaterfallAperture(const QVector<float>& binsDbm)
+{
+    QVector<float> finite;
+    finite.reserve(binsDbm.size());
+    for (float dbm : binsDbm) {
+        if (std::isfinite(dbm)) {
+            finite.append(dbm);
+        }
+    }
+
+    if (finite.size() < 8) {
+        return {};
+    }
+
+    const float noiseFloor = percentile(finite, 0.50f);
+    const float signalPeak = percentile(finite, 0.98f);
+    WaterfallAperture aperture;
+    aperture.minDbm = noiseFloor - 10.0f;
+    aperture.maxDbm = signalPeak + 30.0f;
+    if (aperture.maxDbm <= aperture.minDbm + 1.0f) {
+        aperture.maxDbm = aperture.minDbm + 1.0f;
+    }
+    aperture.valid = true;
+    return aperture;
+}
+
+float waterfallColorIndex(float dbm, float minDbm, float maxDbm)
+{
+    const float span = std::max(1.0f, maxDbm - minDbm);
+    const float normalized = std::clamp((dbm - minDbm) / span, 0.0f, 1.0f);
+    return std::sqrt(normalized);
+}
+
+MeterReading meterUnavailable(MeterSource source, const QString& notes)
+{
+    MeterReading reading;
+    reading.timestampUtcMs = QDateTime::currentMSecsSinceEpoch();
+    reading.source = source;
+    reading.capability = MeterCapability::Unavailable;
+    reading.valid = false;
+    reading.confidence = MeterConfidence::None;
+    reading.label = QStringLiteral("Meter unavailable");
+    reading.notes = notes;
+    return reading;
+}
+
+MeterReading extractMeterFromSndVerifiedLayout(const QByteArray& frame,
+                                               const MeterContext& context)
+{
+    Q_UNUSED(context);
+    if (frame.size() == kObservedExtendedSoundFrameBytes
+        && frame.startsWith("SND")) {
+        const qint16 rawMeter =
+            readSignedBigEndian16(frame, kObservedMeterOffset);
+        const float dbm = kExperimentalMeterDbmOffset
+            + (static_cast<float>(rawMeter)
+               * kExperimentalMeterDbPerRawUnit);
+
+        MeterReading reading;
+        reading.timestampUtcMs = QDateTime::currentMSecsSinceEpoch();
+        reading.source = MeterSource::SndMetadata;
+        reading.capability = MeterCapability::Experimental;
+        reading.rawValue = static_cast<float>(rawMeter);
+        reading.hasRawValue = true;
+        reading.dbm = dbm;
+        reading.hasDbm = true;
+        reading.sUnits = convertDbmToSUnits(dbm);
+        reading.valid = true;
+        reading.confidence = MeterConfidence::Low;
+        reading.label = QStringLiteral("S-Meter");
+        reading.notes = QStringLiteral(
+            "Experimental SND bytes 8-9 big-endian candidate, dbm=raw/10-127");
+        return reading;
+    }
+
+    return meterUnavailable(
+        MeterSource::SndMetadata,
+        QStringLiteral("SND meter layout not verified"));
+}
+
+MeterReading computeRelativeAudioLevel(const float* samples, int sampleCount)
+{
+    if (!samples || sampleCount <= 0) {
+        return meterUnavailable(
+            MeterSource::AudioSamples,
+            QStringLiteral("No decoded audio samples available"));
+    }
+
+    double sumSquares = 0.0;
+    int validSamples = 0;
+    for (int i = 0; i < sampleCount; ++i) {
+        const float sample = std::clamp(samples[i], -1.0f, 1.0f);
+        if (!std::isfinite(sample)) {
+            continue;
+        }
+        sumSquares += static_cast<double>(sample) * static_cast<double>(sample);
+        ++validSamples;
+    }
+
+    if (validSamples <= 0) {
+        return meterUnavailable(
+            MeterSource::AudioSamples,
+            QStringLiteral("Decoded audio samples were not finite"));
+    }
+
+    const double rms = std::sqrt(sumSquares / static_cast<double>(validSamples));
+    constexpr float kMinimumDbfs = -60.0f;
+    constexpr float kMaximumDbfs = 0.0f;
+    const float dbfs = rms > 0.0
+        ? static_cast<float>(20.0 * std::log10(rms))
+        : kMinimumDbfs;
+    const float relativeLevel = std::clamp(
+        (dbfs - kMinimumDbfs) / (kMaximumDbfs - kMinimumDbfs),
+        0.0f,
+        1.0f);
+
+    MeterReading reading;
+    reading.timestampUtcMs = QDateTime::currentMSecsSinceEpoch();
+    reading.source = MeterSource::AudioSamples;
+    reading.capability = MeterCapability::RelativeAudio;
+    reading.relativeLevel = relativeLevel;
+    reading.hasRelativeLevel = true;
+    reading.valid = true;
+    reading.confidence = MeterConfidence::Medium;
+    reading.label = QStringLiteral("Audio level, relative");
+    return reading;
+}
+
+MeterReading computeRelativeWaterfallLevel(const QVector<float>& bins)
+{
+    QVector<float> finite;
+    finite.reserve(bins.size());
+    for (float bin : bins) {
+        if (std::isfinite(bin)) {
+            finite.append(bin);
+        }
+    }
+
+    if (finite.isEmpty()) {
+        return meterUnavailable(
+            MeterSource::WaterfallBins,
+            QStringLiteral("No decoded waterfall bins available"));
+    }
+
+    const float signal = percentile(finite, 0.95f);
+    constexpr float kDisplayFloor = -130.0f;
+    constexpr float kDisplayCeiling = 0.0f;
+    const float relativeLevel = std::clamp(
+        (signal - kDisplayFloor) / (kDisplayCeiling - kDisplayFloor),
+        0.0f,
+        1.0f);
+
+    MeterReading reading;
+    reading.timestampUtcMs = QDateTime::currentMSecsSinceEpoch();
+    reading.source = MeterSource::WaterfallBins;
+    reading.capability = MeterCapability::RelativeWaterfall;
+    reading.relativeLevel = relativeLevel;
+    reading.hasRelativeLevel = true;
+    reading.valid = true;
+    reading.confidence = MeterConfidence::Low;
+    reading.label = QStringLiteral("Waterfall intensity, relative");
+    reading.notes = QStringLiteral("Relative waterfall value, not calibrated dBm");
+    return reading;
+}
+
+QString convertDbmToSUnits(float dbm)
+{
+    constexpr float kS9Dbm = -73.0f;
+    constexpr float kDbPerSUnit = 6.0f;
+    if (dbm > kS9Dbm) {
+        return QStringLiteral("S9 + %1 dB")
+            .arg(qRound(dbm - kS9Dbm));
+    }
+
+    const int sValue = std::clamp(
+        qRound(9.0f + ((dbm - kS9Dbm) / kDbPerSUnit)),
+        0,
+        9);
+    return QStringLiteral("S%1").arg(sValue);
+}
+
+} // namespace AetherSDR::KiwiSdrProtocol

--- a/src/core/KiwiSdrProtocol.h
+++ b/src/core/KiwiSdrProtocol.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <QByteArray>
+#include <QMetaType>
+#include <QString>
+#include <QVector>
+
+#include <QtGlobal>
+
+namespace AetherSDR::KiwiSdrProtocol {
+
+struct SoundFrameHeader {
+    int sequence{-1};
+    quint8 flags{0};
+    float rssiDbm{0.0f};
+    bool hasRssi{false};
+    bool valid{false};
+};
+
+struct WaterfallLineHeader {
+    int sequence{-1};
+    bool valid{false};
+};
+
+struct WaterfallAperture {
+    float minDbm{0.0f};
+    float maxDbm{0.0f};
+    bool valid{false};
+};
+
+enum class MeterSource {
+    Unknown,
+    SndMetadata,
+    AudioSamples,
+    WaterfallBins,
+    MsgMetadata,
+    ManualTest,
+};
+
+enum class MeterCapability {
+    Unavailable,
+    RelativeAudio,
+    RelativeWaterfall,
+    RawSndMeter,
+    CalibratedSndMeter,
+    Experimental,
+};
+
+enum class MeterConfidence {
+    None,
+    Low,
+    Medium,
+    High,
+    Verified,
+};
+
+struct MeterContext {
+    QString mode;
+    double audioRateHz{0.0};
+    double sampleRateHz{0.0};
+    bool compressionRequested{false};
+    bool compressionObserved{false};
+    QString serverVersion;
+    QString streamState;
+};
+
+struct MeterReading {
+    qint64 timestampUtcMs{0};
+    MeterSource source{MeterSource::Unknown};
+    MeterCapability capability{MeterCapability::Unavailable};
+    float rawValue{0.0f};
+    bool hasRawValue{false};
+    float dbm{0.0f};
+    bool hasDbm{false};
+    QString sUnits;
+    float relativeLevel{0.0f};
+    bool hasRelativeLevel{false};
+    bool valid{false};
+    MeterConfidence confidence{MeterConfidence::None};
+    QString label{QStringLiteral("Meter unavailable")};
+    QString notes;
+};
+
+SoundFrameHeader parseSoundFrameHeader(const QByteArray& frame);
+WaterfallLineHeader parseWaterfallLineHeader(const QByteArray& frame);
+quint64 sequenceGapCount(int previousSequence, int currentSequence);
+float waterfallByteToDisplayLevel(unsigned char value);
+WaterfallAperture autoWaterfallAperture(const QVector<float>& binsDbm);
+float waterfallColorIndex(float dbm, float minDbm, float maxDbm);
+MeterReading meterUnavailable(MeterSource source, const QString& notes = {});
+MeterReading extractMeterFromSndVerifiedLayout(const QByteArray& frame,
+                                               const MeterContext& context);
+MeterReading computeRelativeAudioLevel(const float* samples, int sampleCount);
+MeterReading computeRelativeWaterfallLevel(const QVector<float>& bins);
+QString convertDbmToSUnits(float dbm);
+
+} // namespace AetherSDR::KiwiSdrProtocol
+
+Q_DECLARE_METATYPE(AetherSDR::KiwiSdrProtocol::MeterReading)

--- a/src/core/SpectralNR.cpp
+++ b/src/core/SpectralNR.cpp
@@ -421,6 +421,25 @@ SpectralNR::WisdomResult SpectralNR::generateWisdom(const std::string& directory
 
 void SpectralNR::process(const float* input, float* output, int numSamples)
 {
+    if (numSamples <= 0) {
+        return;
+    }
+
+    // The overlap-add rings are sized for streaming at the native hop cadence.
+    // Larger packet-sized calls can wrap the output ring before the call reads
+    // its output, aliasing future synthesis data into the returned samples.
+    // Split internally so callers with bursty packet sizes still get the same
+    // result as the normal 128-sample Flex RX cadence.
+    if (numSamples > m_hopSize) {
+        int offset = 0;
+        while (offset < numSamples) {
+            const int chunk = std::min(m_hopSize, numSamples - offset);
+            process(input + offset, output + offset, chunk);
+            offset += chunk;
+        }
+        return;
+    }
+
     const int accSize = static_cast<int>(m_inAccum.size());
     const int outSize = static_cast<int>(m_outAccum.size());
 

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -30,6 +30,7 @@
 #include "ShackSwitchApplet.h"
 #include "MeterApplet.h"
 #include "HealthApplet.h"
+#include "KiwiSdrApplet.h"
 #ifdef HAVE_RADE
 #include "RadeApplet.h"
 #endif
@@ -71,7 +72,7 @@
 namespace AetherSDR {
 
 const QStringList AppletPanel::kDefaultOrder = {
-    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "WAVE", "TXDSP", "CAT", "DAX", "TCI", "IQ", "MTR", "HLTH", "AG", "SS"
+    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "WAVE", "TXDSP", "CAT", "DAX", "TCI", "IQ", "MTR", "KSDR", "HLTH", "AG", "SS"
 };
 
 // ── Drop-aware scroll area ──────────────────────────────────────────────────
@@ -854,6 +855,10 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
     m_meterApplet = new MeterApplet;
     m_appletOrder.append(makeEntry("MTR", "Meters", m_meterApplet, false, m_drawer, m_drawerLayout));
+
+    m_kiwiSdrApplet = new KiwiSdrApplet;
+    m_appletOrder.append(makeEntry("KSDR", "KiwiSDR", m_kiwiSdrApplet, false,
+                                   m_drawer, m_drawerLayout));
 
 #ifdef HAVE_RADE
     m_radeApplet = new RadeApplet;

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -52,6 +52,7 @@ class ShackSwitchApplet;
 class MeterApplet;
 class HealthApplet;
 class MqttApplet;
+class KiwiSdrApplet;
 class FavoritesPickerDialog;
 #ifdef HAVE_RADE
 class RadeApplet;
@@ -122,6 +123,7 @@ public:
     ShackSwitchApplet*   ssApplet()  { return m_ssApplet; }
     MeterApplet*  meterApplet()  { return m_meterApplet; }
     HealthApplet* healthApplet() { return m_healthApplet; }
+    KiwiSdrApplet* kiwiSdrApplet() { return m_kiwiSdrApplet; }
 #ifdef HAVE_RADE
     RadeApplet*   radeApplet()   { return m_radeApplet; }
 #endif
@@ -284,6 +286,7 @@ private:
     ShackSwitchApplet*   m_ssApplet{nullptr};
     MeterApplet* m_meterApplet{nullptr};
     HealthApplet* m_healthApplet{nullptr};
+    KiwiSdrApplet* m_kiwiSdrApplet{nullptr};
 #ifdef HAVE_RADE
     RadeApplet*  m_radeApplet{nullptr};
 #endif

--- a/src/gui/KiwiSdrApplet.cpp
+++ b/src/gui/KiwiSdrApplet.cpp
@@ -1,0 +1,306 @@
+#include "KiwiSdrApplet.h"
+
+#include "SliceColorManager.h"
+#include "SliceLabel.h"
+#include "Theme.h"
+#include "core/ThemeManager.h"
+#include "models/SliceModel.h"
+
+#include <QAbstractItemView>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QStringList>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+namespace {
+
+QString listStyle()
+{
+    return ThemeManager::instance().resolve(
+        QStringLiteral(
+            "QListWidget { background: transparent; border: none; "
+            "color: {{color.text.primary}}; font-size: 10px; }"
+            "QListWidget::item { padding: 0; margin: 0; }"));
+}
+
+QString emptyStyle()
+{
+    return ThemeManager::instance().resolve(
+        QStringLiteral(
+            "QLabel { color: {{color.text.label}}; font-size: 10px; "
+            "padding: 4px 2px; }"));
+}
+
+QString labelStyle()
+{
+    return ThemeManager::instance().resolve(
+        QStringLiteral("QLabel { color: {{color.text.label}}; font-size: 10px; }"));
+}
+
+QString primaryLabelStyle()
+{
+    return ThemeManager::instance().resolve(
+        QStringLiteral(
+            "QLabel { color: {{color.text.primary}}; font-size: 10px; "
+            "font-weight: bold; }"));
+}
+
+QString receiverRowStyle()
+{
+    return ThemeManager::instance().resolve(
+        QStringLiteral(
+            "QWidget#kiwiReceiverRow { background: {{color.background.0}}; "
+            "border: 1px solid {{color.background.1}}; border-radius: 3px; }"));
+}
+
+QString stateToken(KiwiSdrClient::State state)
+{
+    switch (state) {
+    case KiwiSdrClient::State::Connected:
+        return QStringLiteral("color.accent.success");
+    case KiwiSdrClient::State::Connecting:
+        return QStringLiteral("color.accent.warning");
+    case KiwiSdrClient::State::Error:
+        return QStringLiteral("color.accent.danger");
+    case KiwiSdrClient::State::Disconnected:
+        return QStringLiteral("color.text.label");
+    }
+    return QStringLiteral("color.text.label");
+}
+
+QString statusStyle(KiwiSdrClient::State state)
+{
+    return ThemeManager::instance().resolve(
+        QStringLiteral("QLabel { color: {{%1}}; font-size: 10px; font-weight: bold; }")
+            .arg(stateToken(state)));
+}
+
+QString stateText(KiwiSdrClient::State state)
+{
+    switch (state) {
+    case KiwiSdrClient::State::Disconnected:
+        return QObject::tr("Disconnected");
+    case KiwiSdrClient::State::Connecting:
+        return QObject::tr("Connecting");
+    case KiwiSdrClient::State::Connected:
+        return QObject::tr("Connected");
+    case KiwiSdrClient::State::Error:
+        return QObject::tr("Error");
+    }
+    return QObject::tr("Disconnected");
+}
+
+QString detailStyle()
+{
+    return ThemeManager::instance().resolve(
+        QStringLiteral("QLabel { color: {{color.text.label}}; font-size: 9px; }"));
+}
+
+QString sliceBadgeStyle(int colorIdx, bool assigned)
+{
+    const QString color = SliceColorManager::instance().hexActive(colorIdx);
+    if (assigned) {
+        return QStringLiteral(
+            "QLabel { background: %1; color: #000000; border: 1px solid %1; "
+            "border-radius: 3px; font-weight: bold; font-size: 9px; padding: 0; }")
+            .arg(color);
+    }
+    return QStringLiteral(
+        "QLabel { background: #2a2a2a; color: %1; border: 1px solid %1; "
+        "border-radius: 3px; font-weight: bold; font-size: 9px; padding: 0; }")
+        .arg(color);
+}
+
+QString receiverAccessibleText(const KiwiSdrReceiverStatus& receiver)
+{
+    QStringList parts;
+    parts << receiver.name
+          << stateText(receiver.state);
+    if (!receiver.detail.trimmed().isEmpty()) {
+        parts << receiver.detail.trimmed();
+    }
+    if (receiver.assignedSlice) {
+        parts << QStringLiteral("Assigned to slice %1")
+                     .arg(receiver.assignedSlice->letter());
+    } else {
+        parts << QStringLiteral("Not assigned to a slice");
+    }
+    return parts.join(QStringLiteral(", "));
+}
+
+} // namespace
+
+KiwiSdrApplet::KiwiSdrApplet(QWidget* parent)
+    : QWidget(parent)
+{
+    theme::setContainer(this, QStringLiteral("applet/kiwisdr"));
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(4, 2, 4, 4);
+    root->setSpacing(4);
+
+    m_emptyLabel = new QLabel(tr("No KiwiSDR RX antennas configured"), this);
+    m_emptyLabel->setAccessibleName(tr("KiwiSDR receiver status"));
+    m_emptyLabel->setStyleSheet(emptyStyle());
+    m_emptyLabel->setWordWrap(true);
+    root->addWidget(m_emptyLabel);
+
+    m_receiverList = new QListWidget(this);
+    m_receiverList->setAccessibleName(tr("KiwiSDR receiver status"));
+    m_receiverList->setAccessibleDescription(
+        tr("Shows configured KiwiSDR receive antennas, connection state, and assigned slice."));
+    m_receiverList->setFocusPolicy(Qt::NoFocus);
+    m_receiverList->setSelectionMode(QAbstractItemView::NoSelection);
+    m_receiverList->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_receiverList->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_receiverList->setMinimumHeight(48);
+    m_receiverList->setMaximumHeight(176);
+    m_receiverList->setStyleSheet(listStyle());
+    root->addWidget(m_receiverList);
+
+    rebuildReceiverList();
+}
+
+void KiwiSdrApplet::setReceivers(const QVector<KiwiSdrReceiverStatus>& receivers)
+{
+    for (const QMetaObject::Connection& connection : m_sliceConnections) {
+        disconnect(connection);
+    }
+    m_sliceConnections.clear();
+    m_receivers = receivers;
+
+    for (const KiwiSdrReceiverStatus& receiver : m_receivers) {
+        SliceModel* slice = receiver.assignedSlice.data();
+        if (!slice) {
+            continue;
+        }
+        m_sliceConnections.append(connect(slice, &SliceModel::letterChanged,
+                                          this, &KiwiSdrApplet::rebuildReceiverList));
+        m_sliceConnections.append(connect(slice, &SliceModel::frequencyChanged,
+                                          this, &KiwiSdrApplet::rebuildReceiverList));
+        m_sliceConnections.append(connect(slice, &SliceModel::modeChanged,
+                                          this, &KiwiSdrApplet::rebuildReceiverList));
+        m_sliceConnections.append(connect(slice, &SliceModel::filterChanged,
+                                          this, &KiwiSdrApplet::rebuildReceiverList));
+        m_sliceConnections.append(connect(slice, &SliceModel::panIdChanged,
+                                          this, &KiwiSdrApplet::rebuildReceiverList));
+    }
+
+    rebuildReceiverList();
+}
+
+void KiwiSdrApplet::rebuildReceiverList()
+{
+    if (!m_receiverList || !m_emptyLabel) {
+        return;
+    }
+
+    m_receiverList->clear();
+    const bool hasReceivers = !m_receivers.isEmpty();
+    m_emptyLabel->setVisible(!hasReceivers);
+    m_receiverList->setVisible(hasReceivers);
+
+    for (const KiwiSdrReceiverStatus& receiver : m_receivers) {
+        auto* item = new QListWidgetItem(m_receiverList);
+        item->setData(Qt::UserRole, receiver.id);
+        QWidget* row = buildReceiverRow(receiver);
+        item->setSizeHint(row->sizeHint());
+        m_receiverList->setItemWidget(item, row);
+    }
+}
+
+QWidget* KiwiSdrApplet::buildReceiverRow(const KiwiSdrReceiverStatus& receiver)
+{
+    auto* row = new QWidget(m_receiverList);
+    row->setObjectName(QStringLiteral("kiwiReceiverRow"));
+    row->setStyleSheet(receiverRowStyle());
+    row->setAccessibleName(receiverAccessibleText(receiver));
+
+    auto* layout = new QVBoxLayout(row);
+    layout->setContentsMargins(5, 4, 5, 4);
+    layout->setSpacing(3);
+
+    auto* topRow = new QHBoxLayout;
+    topRow->setContentsMargins(0, 0, 0, 0);
+    topRow->setSpacing(4);
+
+    auto* name = new QLabel(receiver.name, row);
+    name->setTextFormat(Qt::PlainText);
+    name->setStyleSheet(primaryLabelStyle());
+    name->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    topRow->addWidget(name, 1);
+
+    auto* status = new QLabel(stateText(receiver.state), row);
+    status->setTextFormat(Qt::PlainText);
+    status->setStyleSheet(statusStyle(receiver.state));
+    status->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    topRow->addWidget(status, 0, Qt::AlignRight);
+    layout->addLayout(topRow);
+
+    const QString detail = receiver.detail.trimmed();
+    if (!detail.isEmpty()) {
+        auto* detailLabel = new QLabel(detail, row);
+        detailLabel->setTextFormat(Qt::PlainText);
+        detailLabel->setStyleSheet(detailStyle());
+        detailLabel->setWordWrap(true);
+        layout->addWidget(detailLabel);
+    }
+
+    layout->addWidget(buildSliceAssignmentRow(receiver.assignedSlice.data(), row));
+    return row;
+}
+
+QWidget* KiwiSdrApplet::buildSliceAssignmentRow(SliceModel* slice, QWidget* parent)
+{
+    auto* row = new QWidget(parent);
+    auto* layout = new QHBoxLayout(row);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(4);
+
+    if (!slice) {
+        auto* label = new QLabel(tr("Not assigned"), row);
+        label->setTextFormat(Qt::PlainText);
+        label->setStyleSheet(labelStyle());
+        layout->addWidget(label, 1);
+        return row;
+    }
+
+    auto* badge = new QLabel(row);
+    badge->setFixedSize(18, 19);
+    badge->setAlignment(Qt::AlignCenter);
+    badge->setTextFormat(Qt::PlainText);
+    badge->setText(SliceLabel::unicodeForm(slice->sliceId(), slice->letter()));
+    const int colorIdx = SliceLabel::displayColorIndex(slice->sliceId(),
+                                                       slice->letter());
+    badge->setStyleSheet(sliceBadgeStyle(colorIdx, true));
+    layout->addWidget(badge, 0, Qt::AlignVCenter);
+
+    auto* text = new QLabel(sliceText(slice), row);
+    text->setTextFormat(Qt::PlainText);
+    text->setStyleSheet(labelStyle());
+    text->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+    text->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    layout->addWidget(text, 1);
+    return row;
+}
+
+QString KiwiSdrApplet::sliceText(SliceModel* slice) const
+{
+    if (!slice) {
+        return QString();
+    }
+
+    const QString filter = QStringLiteral("%1..%2 Hz")
+        .arg(slice->filterLow())
+        .arg(slice->filterHigh());
+    return QStringLiteral("%1 MHz  %2  %3")
+        .arg(slice->frequency(), 0, 'f', 6)
+        .arg(slice->mode())
+        .arg(filter);
+}
+
+} // namespace AetherSDR

--- a/src/gui/KiwiSdrApplet.h
+++ b/src/gui/KiwiSdrApplet.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "core/KiwiSdrClient.h"
+
+#include <QMetaObject>
+#include <QPointer>
+#include <QString>
+#include <QVector>
+#include <QWidget>
+
+class QLabel;
+class QListWidget;
+
+namespace AetherSDR {
+
+class SliceModel;
+
+struct KiwiSdrReceiverStatus {
+    QString id;
+    QString name;
+    KiwiSdrClient::State state{KiwiSdrClient::State::Disconnected};
+    QString detail;
+    QPointer<SliceModel> assignedSlice;
+};
+
+class KiwiSdrApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit KiwiSdrApplet(QWidget* parent = nullptr);
+
+    void setReceivers(const QVector<KiwiSdrReceiverStatus>& receivers);
+
+private:
+    void rebuildReceiverList();
+    QWidget* buildReceiverRow(const KiwiSdrReceiverStatus& receiver);
+    QWidget* buildSliceAssignmentRow(SliceModel* slice, QWidget* parent);
+    QString sliceText(SliceModel* slice) const;
+
+    QLabel* m_emptyLabel{nullptr};
+    QListWidget* m_receiverList{nullptr};
+    QVector<KiwiSdrReceiverStatus> m_receivers;
+    QList<QMetaObject::Connection> m_sliceConnections;
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -80,6 +80,8 @@
 #include "core/CwSidetoneGenerator.h"
 #include "core/CwxLocalKeyer.h"
 #include "core/IambicKeyer.h"
+#include "core/KiwiSdrClient.h"
+#include "core/KiwiSdrManager.h"
 #include "CatControlApplet.h"
 #include "DaxApplet.h"
 #include "TciApplet.h"
@@ -1088,6 +1090,9 @@ MainWindow::MainWindow(QWidget* parent)
     m_bandPlanMgr = new BandPlanManager(this);
     m_bandPlanMgr->loadPlans();
 
+    m_kiwiSdrManager = new KiwiSdrManager(this);
+    m_kiwiSdrManager->setOperatorCallsign(m_radioModel.callsign());
+
     // UpdateChecker — must be created before buildMenuBar() which references it
     m_updateChecker = new UpdateChecker(this);
     connect(m_updateChecker, &UpdateChecker::updateAvailable, this, [this](const QString& ver) {
@@ -1240,6 +1245,10 @@ MainWindow::MainWindow(QWidget* parent)
     // audioDataReady(); we feed that directly to the QAudioSink.
     connect(m_radioModel.panStream(), &PanadapterStream::audioDataReady,
             m_audio, &AudioEngine::feedAudioData);
+
+    // KiwiSDR is a receive-only alternate source for the active slice.
+    // Wiring is local-only: no Flex radio commands are sent from this path.
+    wireKiwiSdr();
 
     // ── QSO recorder: tap RX audio + TX monitor, trigger on MOX (#1297) ────
     // RX (float32) comes from the panadapter stream; TX (int16 post-limiter
@@ -1958,6 +1967,29 @@ MainWindow::~MainWindow()
 {
     qApp->removeEventFilter(this);
     preparePanadapterUiForShutdown();
+
+    // KiwiSDR clients are QObject children, but their disconnect path emits
+    // state changes that are wired back into MainWindow and AudioEngine. Tear
+    // them down while MainWindow members are still alive instead of waiting for
+    // QWidget child cleanup after member destruction.
+    if (m_kiwiSdrClient) {
+        QObject::disconnect(m_kiwiSdrClient, nullptr, this, nullptr);
+        if (m_audio) {
+            QObject::disconnect(m_kiwiSdrClient, nullptr, m_audio, nullptr);
+        }
+        m_kiwiSdrClient->disconnectFromEndpoint();
+        delete m_kiwiSdrClient;
+        m_kiwiSdrClient = nullptr;
+    }
+    if (m_kiwiSdrManager) {
+        QObject::disconnect(m_kiwiSdrManager, nullptr, this, nullptr);
+        if (m_audio) {
+            QObject::disconnect(m_kiwiSdrManager, nullptr, m_audio, nullptr);
+        }
+        m_kiwiSdrManager->disconnectAll();
+        delete m_kiwiSdrManager;
+        m_kiwiSdrManager = nullptr;
+    }
 
     // Stop the CWX sidetone keyer (its own worker thread) before AudioEngine is
     // torn down below — its onKeyDownChange callback touches m_audio->cwSidetone()
@@ -5888,6 +5920,9 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     }
     m_appletPanel->setSlice(s);
     m_appletPanel->updateSliceButtons(m_radioModel.slices(), sliceId);
+    refreshKiwiSdrSlices();
+    syncKiwiSdrTrackingToActiveSlice();
+    refreshKiwiSdrWaterfallAvailability();
     // Sync squelch line to newly active slice (handles slice switch without waiting
     // for squelchChanged signal)
     if (auto* sw2 = spectrumForSlice(s))
@@ -6127,6 +6162,9 @@ void MainWindow::reassertUnmutedSliceAudioForPan(const QString& panId)
 void MainWindow::onMuteAllSlicesToggle()
 {
     const auto slices = m_radioModel.slices();
+    const auto kiwiOwnsSliceMute = [this](const SliceModel* s) {
+        return s && s->sliceId() == m_kiwiSdrAudioSliceId;
+    };
 
     // Determine intent: mute all if any owned slice is currently unmuted,
     // otherwise unmute all.  RadioModel::slices() returns only owned slices
@@ -6136,6 +6174,7 @@ void MainWindow::onMuteAllSlicesToggle()
 #ifdef HAVE_RADE
         if (s && s->sliceId() == m_radeSliceId) continue;  // RADE owns its mute
 #endif
+        if (kiwiOwnsSliceMute(s)) continue;  // Kiwi Audio owns its replaced slice
         if (s && !s->audioMute()) { anyUnmuted = true; break; }
     }
 
@@ -6148,6 +6187,7 @@ void MainWindow::onMuteAllSlicesToggle()
         //   corrupt m_radePrevMute's restore value on deactivateRADE().
         if (s && s->sliceId() == m_radeSliceId) continue;
 #endif
+        if (kiwiOwnsSliceMute(s)) continue;
         if (s) s->setAudioMute(anyUnmuted);
     }
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -89,6 +89,7 @@ namespace AetherSDR {
 
 class ConnectionPanel;
 class TitleBar;
+class KiwiSdrManager;
 class SpectrumWidget;
 class PanadapterApplet;
 class PanadapterStack;
@@ -140,6 +141,7 @@ using DaxBridge = PipeWireAudioBridge;
 #endif
 class VfoWidget;
 class WfmDemodulator;
+class KiwiSdrClient;
 
 // Wheel mode for FlexControl: determines what the encoder knob adjusts.
 //
@@ -307,6 +309,24 @@ private:
     void wirePooDooTiles();         // MainWindow_DspApplets.cpp
     void wireDspApplets();          // MainWindow_DspApplets.cpp
     void wireExternalControllers(); // MainWindow_Controllers.cpp
+    void wireKiwiSdr();             // MainWindow_KiwiSdr.cpp
+    void refreshKiwiSdrAppletReceivers();
+    void refreshKiwiSdrSlices();
+    void refreshKiwiSdrWaterfallAvailability();
+    void syncKiwiSdrTrackingToActiveSlice();
+    void setKiwiSdrWaterfallForActiveSlice(bool active);
+    void syncKiwiSdrAppletWaterfallState();
+    SliceModel* kiwiSdrAudioTargetSlice() const;
+    bool setKiwiSdrAudioRouting(bool active);
+    bool applyKiwiSdrSliceMute();
+    void restoreKiwiSdrSliceMute();
+    void setKiwiSdrVirtualAntennaForSlice(int sliceId, const QString& profileId);
+    void clearKiwiSdrVirtualAntennaForSlice(int sliceId);
+    void updateKiwiSdrVirtualTrackingForSlice(SliceModel* slice);
+    void updateKiwiSdrVirtualAudioControlsForSlice(SliceModel* slice);
+    QString kiwiSdrProfileForPan(const QString& panId) const;
+    void syncKiwiSdrPanadapterUiState(const QString& panId);
+    void syncKiwiSdrPanadapterUiStates();
     void wirePanadapter(PanadapterApplet* applet);
     void wirePanReconcilers(PanadapterApplet* applet, PanadapterModel* pan);
     void schedulePanFpsReconcile(const QString& panId, int reportedFps);
@@ -733,6 +753,15 @@ private:
 
     // GUI — right applet panel
     AppletPanel*     m_appletPanel{nullptr};
+    KiwiSdrManager*  m_kiwiSdrManager{nullptr};
+    KiwiSdrClient*   m_kiwiSdrClient{nullptr};
+    int              m_kiwiSdrTrackedSliceId{-1};
+    int              m_kiwiSdrAudioSliceId{-1};
+    bool             m_kiwiSdrAudioPreviousMute{false};
+    bool             m_kiwiSdrAudioMuteApplied{false};
+    bool             m_kiwiSdrAudioMuteChanging{false};
+    QMetaObject::Connection m_kiwiSdrAudioMuteConnection;
+    QHash<int, bool> m_kiwiSdrVirtualPreviousMute;
 
     // Modeless dialogs
     QPointer<DxClusterDialog> m_spotHubDialog;

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -1,0 +1,805 @@
+#include "MainWindow.h"
+
+#include "AppletPanel.h"
+#include "KiwiSdrApplet.h"
+#include "PanadapterApplet.h"
+#include "PanadapterStack.h"
+#include "SpectrumOverlayMenu.h"
+#include "SpectrumWidget.h"
+#include "SMeterWidget.h"
+#include "VfoWidget.h"
+#include "core/AudioEngine.h"
+#include "core/KiwiSdrClient.h"
+#include "core/KiwiSdrManager.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include <QMetaObject>
+#include <QTimer>
+
+namespace AetherSDR {
+namespace {
+
+constexpr int kKiwiSdrMeterDisplayDelayMs = 520;
+
+const SliceModel* kiwiSliceForPan(const RadioModel& radioModel,
+                                  const QString& panId,
+                                  int activeSliceId)
+{
+    if (panId.isEmpty()) {
+        return nullptr;
+    }
+
+    for (SliceModel* slice : radioModel.slices()) {
+        if (!slice || slice->panId() != panId
+            || !radioModel.sliceMayBelongToUs(slice->sliceId())) {
+            continue;
+        }
+
+        if (slice->sliceId() == activeSliceId) {
+            return slice;
+        }
+    }
+    return nullptr;
+}
+
+QString kiwiConnectionOverlayDetail(KiwiSdrClient::State state,
+                                    const QString& detail)
+{
+    const QString trimmed = detail.trimmed();
+    switch (state) {
+    case KiwiSdrClient::State::Connecting:
+        return trimmed.isEmpty() ? QStringLiteral("Connecting") : trimmed;
+    case KiwiSdrClient::State::Error:
+        return trimmed.isEmpty() ? QStringLiteral("Connection error") : trimmed;
+    case KiwiSdrClient::State::Connected:
+        return QString();
+    case KiwiSdrClient::State::Disconnected:
+        return trimmed.isEmpty() ? QStringLiteral("Disconnected") : trimmed;
+    }
+    return trimmed.isEmpty() ? QStringLiteral("Disconnected") : trimmed;
+}
+
+void restoreFlexPanadapterDisplayRange(RadioModel& radioModel,
+                                       const QString& panId,
+                                       SpectrumWidget* spectrum)
+{
+    if (!spectrum) {
+        return;
+    }
+
+    if (PanadapterModel* pan = radioModel.panadapter(panId)) {
+        if (pan->panStreamId() && radioModel.panStream()) {
+            radioModel.panStream()->setDbmRange(
+                pan->panStreamId(), pan->minDbm(), pan->maxDbm());
+        }
+        spectrum->setDbmRange(pan->minDbm(), pan->maxDbm());
+    }
+
+    spectrum->prepareForFftScaleChange();
+    spectrum->reacquireNoiseFloorLock();
+}
+
+void setKiwiSdrWaterfallActive(RadioModel& radioModel,
+                               const QString& panId,
+                               SpectrumWidget* spectrum,
+                               bool active)
+{
+    if (!spectrum) {
+        return;
+    }
+
+    const bool wasActive = spectrum->kiwiSdrWaterfallActive();
+    spectrum->setKiwiSdrWaterfallActive(active);
+    if (wasActive && !active) {
+        restoreFlexPanadapterDisplayRange(radioModel, panId, spectrum);
+    }
+}
+
+} // namespace
+
+SliceModel* MainWindow::kiwiSdrAudioTargetSlice() const
+{
+    if (SliceModel* slice = activeSlice()) {
+        if (m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+            return slice;
+        }
+    }
+
+    if (m_kiwiSdrTrackedSliceId >= 0) {
+        if (SliceModel* slice = m_radioModel.slice(m_kiwiSdrTrackedSliceId)) {
+            if (m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+                return slice;
+            }
+        }
+    }
+
+    for (SliceModel* slice : m_radioModel.slices()) {
+        if (slice && m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+            return slice;
+        }
+    }
+
+    return nullptr;
+}
+
+void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
+                                                  const QString& profileId)
+{
+    if (!m_kiwiSdrManager || profileId.isEmpty()) {
+        return;
+    }
+
+    SliceModel* slice = m_radioModel.slice(sliceId);
+    if (!slice || !m_radioModel.sliceMayBelongToUs(sliceId)) {
+        return;
+    }
+
+    if (!m_kiwiSdrVirtualPreviousMute.contains(sliceId)) {
+        m_kiwiSdrVirtualPreviousMute.insert(sliceId, slice->flexAudioMute());
+    }
+    slice->setExternalReceiveAudioReplacementMute(true);
+
+    m_kiwiSdrManager->assignSliceToProfile(
+        sliceId, profileId, slice->frequency(), slice->mode(),
+        slice->filterLow(), slice->filterHigh(), slice->panId());
+    updateKiwiSdrVirtualTrackingForSlice(slice);
+    updateKiwiSdrVirtualAudioControlsForSlice(slice);
+
+    if (SpectrumWidget* spectrum = spectrumForSlice(slice)) {
+        spectrum->setKiwiSdrWaterfallAvailable(true);
+        spectrum->setKiwiSdrWaterfallProfile(profileId);
+        spectrum->setKiwiSdrWaterfallActive(true);
+        if (VfoWidget* vfo = spectrum->vfoWidget(slice->sliceId())) {
+            vfo->setReceiveMeterReading(
+                KiwiSdrProtocol::meterUnavailable(
+                    KiwiSdrProtocol::MeterSource::Unknown,
+                    QStringLiteral("Waiting for KiwiSDR meter data")));
+        }
+    }
+    if (slice->sliceId() == m_activeSliceId && m_appletPanel
+        && m_appletPanel->sMeterWidget()) {
+        m_appletPanel->sMeterWidget()->setReceiveMeterReading(
+            KiwiSdrProtocol::meterUnavailable(
+                KiwiSdrProtocol::MeterSource::Unknown,
+                QStringLiteral("Waiting for KiwiSDR meter data")));
+    }
+    syncKiwiSdrPanadapterUiState(slice->panId());
+    refreshKiwiSdrWaterfallAvailability();
+}
+
+void MainWindow::clearKiwiSdrVirtualAntennaForSlice(int sliceId)
+{
+    QString panId;
+    if (SliceModel* slice = m_radioModel.slice(sliceId)) {
+        panId = slice->panId();
+        const bool restoreMute =
+            m_kiwiSdrVirtualPreviousMute.contains(sliceId)
+                ? m_kiwiSdrVirtualPreviousMute.take(sliceId)
+                : slice->flexAudioMute();
+        slice->setExternalReceiveAudioReplacementMute(false, restoreMute);
+        if (SpectrumWidget* spectrum = spectrumForSlice(slice)) {
+            setKiwiSdrWaterfallActive(m_radioModel, panId, spectrum, false);
+            spectrum->setKiwiSdrConnectionOverlay(false);
+            spectrum->setKiwiSdrWaterfallProfile(QString());
+        }
+    }
+
+    if (m_kiwiSdrManager) {
+        m_kiwiSdrManager->clearSliceAssignment(sliceId);
+    }
+    refreshKiwiSdrWaterfallAvailability();
+    if (!panId.isEmpty()) {
+        syncKiwiSdrPanadapterUiState(panId);
+    }
+}
+
+void MainWindow::updateKiwiSdrVirtualTrackingForSlice(SliceModel* slice)
+{
+    if (!m_kiwiSdrManager || !slice) {
+        return;
+    }
+
+    const QString profileId =
+        m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId());
+    if (profileId.isEmpty()) {
+        return;
+    }
+
+    m_kiwiSdrManager->updateSliceTracking(
+        slice->sliceId(), slice->frequency(), slice->mode(),
+        slice->filterLow(), slice->filterHigh(), slice->panId());
+    if (SpectrumWidget* spectrum = spectrumForSlice(slice)) {
+        m_kiwiSdrManager->updateWaterfallView(
+            slice->sliceId(), slice->panId(), spectrum->centerMhz(),
+            spectrum->bandwidthMhz(), spectrum->wfLineDuration());
+        if (m_kiwiSdrManager->isConnected(profileId)) {
+            spectrum->setKiwiSdrWaterfallAvailable(true);
+            spectrum->setKiwiSdrWaterfallActive(true);
+            syncKiwiSdrAppletWaterfallState();
+        }
+        syncKiwiSdrPanadapterUiState(slice->panId());
+    }
+}
+
+QString MainWindow::kiwiSdrProfileForPan(const QString& panId) const
+{
+    if (!m_kiwiSdrManager || panId.isEmpty()) {
+        return QString();
+    }
+
+    if (SliceModel* slice = activeSlice()) {
+        if (slice->panId() == panId
+            && m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+            const QString profileId =
+                m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId());
+            if (!profileId.isEmpty()) {
+                return profileId;
+            }
+        }
+    }
+
+    for (SliceModel* slice : m_radioModel.slices()) {
+        if (!slice || slice->panId() != panId
+            || !m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+            continue;
+        }
+        const QString profileId =
+            m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId());
+        if (!profileId.isEmpty()) {
+            return profileId;
+        }
+    }
+    return QString();
+}
+
+void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
+{
+    if (!m_panStack || panId.isEmpty()) {
+        return;
+    }
+
+    SpectrumWidget* spectrum = m_panStack->spectrum(panId);
+    if (!spectrum) {
+        return;
+    }
+
+    const QString profileId = kiwiSdrProfileForPan(panId);
+    SpectrumOverlayMenu* menu = spectrum->overlayMenu();
+    if (profileId.isEmpty()) {
+        spectrum->setKiwiSdrConnectionOverlay(false);
+        setKiwiSdrWaterfallActive(m_radioModel, panId, spectrum, false);
+        spectrum->setKiwiSdrWaterfallAvailable(false);
+        spectrum->setKiwiSdrWaterfallProfile(QString());
+        if (menu) {
+            menu->syncDisplaySettings(
+                spectrum->fftAverage(), spectrum->fftFps(),
+                static_cast<int>(spectrum->fftFillAlpha() * 100.0f),
+                spectrum->fftWeightedAvg(), spectrum->fftFillColor(),
+                spectrum->wfColorGain(), spectrum->wfBlackLevel(),
+                spectrum->wfAutoBlack(), spectrum->wfAutoBlackOffset(),
+                spectrum->wfLineDuration(), spectrum->noiseFloorPosition(),
+                spectrum->noiseFloorEnabled(), spectrum->fftHeatMap(),
+                spectrum->wfColorScheme(), spectrum->showGrid(),
+                spectrum->fftLineWidth());
+        }
+        return;
+    }
+
+    const KiwiSdrAntennaProfile profile = m_kiwiSdrManager->profile(profileId);
+    spectrum->setKiwiSdrWaterfallAvailable(true);
+    spectrum->setKiwiSdrWaterfallProfile(profileId);
+    spectrum->setKiwiSdrWaterfallActive(true);
+    spectrum->setKiwiSdrWaterfallAdjustments(profile.waterfallCellDb,
+                                             profile.waterfallFloorDb);
+    const KiwiSdrClient::State state = m_kiwiSdrManager->state(profileId);
+    spectrum->setKiwiSdrConnectionOverlay(
+        state != KiwiSdrClient::State::Connected,
+        kiwiConnectionOverlayDetail(
+            state, m_kiwiSdrManager->stateDetail(profileId)));
+    if (menu) {
+        menu->syncKiwiWaterfallSettings(profile.waterfallCellDb,
+                                        profile.waterfallFloorDb,
+                                        profile.waterfallRate);
+    }
+}
+
+void MainWindow::syncKiwiSdrPanadapterUiStates()
+{
+    if (!m_panStack) {
+        return;
+    }
+    for (PanadapterApplet* applet : m_panStack->allApplets()) {
+        if (!applet) {
+            continue;
+        }
+        syncKiwiSdrPanadapterUiState(applet->panId());
+    }
+}
+
+void MainWindow::updateKiwiSdrVirtualAudioControlsForSlice(SliceModel* slice)
+{
+    if (!m_kiwiSdrManager || !m_audio || !slice) {
+        return;
+    }
+
+    const QString profileId =
+        m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId());
+    if (profileId.isEmpty()) {
+        return;
+    }
+
+    const float gainPercent = slice->audioGain();
+    const bool muted = slice->audioMute();
+    QMetaObject::invokeMethod(m_audio,
+                              [audio = m_audio, profileId, gainPercent, muted]() {
+        audio->setKiwiSdrAudioSourceGain(profileId, gainPercent);
+        audio->setKiwiSdrAudioSourceMuted(profileId, muted);
+    }, Qt::QueuedConnection);
+}
+
+bool MainWindow::applyKiwiSdrSliceMute()
+{
+    SliceModel* target = kiwiSdrAudioTargetSlice();
+    if (!target) {
+        restoreKiwiSdrSliceMute();
+        return false;
+    }
+
+    if (m_kiwiSdrAudioSliceId == target->sliceId()) {
+        return true;
+    }
+
+    restoreKiwiSdrSliceMute();
+
+    m_kiwiSdrAudioSliceId = target->sliceId();
+    m_kiwiSdrAudioPreviousMute = target->audioMute();
+    m_kiwiSdrAudioMuteApplied = !target->audioMute();
+    m_kiwiSdrAudioMuteConnection =
+        connect(target, &SliceModel::audioMuteChanged,
+                this, [this, sliceId = target->sliceId()](bool muted) {
+                    if (m_kiwiSdrAudioMuteChanging
+                        || m_kiwiSdrAudioSliceId != sliceId) {
+                        return;
+                    }
+
+                    if (m_kiwiSdrAudioMuteApplied && !muted) {
+                        m_kiwiSdrAudioMuteApplied = false;
+                    }
+                });
+
+    if (m_kiwiSdrAudioMuteApplied) {
+        m_kiwiSdrAudioMuteChanging = true;
+        target->setAudioMute(true);
+        m_kiwiSdrAudioMuteChanging = false;
+    }
+
+    return true;
+}
+
+void MainWindow::restoreKiwiSdrSliceMute()
+{
+    const int sliceId = m_kiwiSdrAudioSliceId;
+    const bool previousMute = m_kiwiSdrAudioPreviousMute;
+    const bool muteApplied = m_kiwiSdrAudioMuteApplied;
+
+    if (m_kiwiSdrAudioMuteConnection) {
+        QObject::disconnect(m_kiwiSdrAudioMuteConnection);
+        m_kiwiSdrAudioMuteConnection = {};
+    }
+
+    m_kiwiSdrAudioSliceId = -1;
+    m_kiwiSdrAudioPreviousMute = false;
+    m_kiwiSdrAudioMuteApplied = false;
+    m_kiwiSdrAudioMuteChanging = false;
+
+    if (sliceId < 0 || !muteApplied) {
+        return;
+    }
+
+    SliceModel* slice = m_radioModel.slice(sliceId);
+    if (!slice || slice->audioMute() == previousMute) {
+        return;
+    }
+
+    slice->setAudioMute(previousMute);
+}
+
+bool MainWindow::setKiwiSdrAudioRouting(bool active)
+{
+    bool routed = active;
+    if (active) {
+        routed = applyKiwiSdrSliceMute();
+    } else {
+        restoreKiwiSdrSliceMute();
+    }
+
+    if (!routed) {
+        restoreKiwiSdrSliceMute();
+    }
+
+    if (m_audio) {
+        QMetaObject::invokeMethod(m_audio, [audio = m_audio, routed]() {
+            audio->setKiwiSdrAudioEnabled(routed);
+        }, Qt::QueuedConnection);
+    }
+
+    return routed;
+}
+
+void MainWindow::wireKiwiSdr()
+{
+    if (!m_appletPanel || !m_appletPanel->kiwiSdrApplet() || m_kiwiSdrClient) {
+        return;
+    }
+
+    m_kiwiSdrClient = new KiwiSdrClient(this);
+    if (m_kiwiSdrManager) {
+        m_kiwiSdrManager->setOperatorCallsign(m_radioModel.callsign());
+        connect(m_kiwiSdrManager, &KiwiSdrManager::profileNeedsInitialTracking,
+                this, [this](const QString& profileId) {
+            if (!m_kiwiSdrManager || profileId.isEmpty()) {
+                return;
+            }
+
+            SliceModel* slice = kiwiSdrAudioTargetSlice();
+            if (!slice) {
+                return;
+            }
+
+            SpectrumWidget* spectrum = spectrumForSlice(slice);
+            m_kiwiSdrManager->primeProfileTracking(
+                profileId, slice->sliceId(), slice->frequency(), slice->mode(),
+                slice->filterLow(), slice->filterHigh(), slice->panId(),
+                spectrum ? spectrum->centerMhz() : slice->frequency(),
+                spectrum ? spectrum->bandwidthMhz() : 0.2,
+                spectrum ? spectrum->wfLineDuration() : 100);
+        });
+        if (m_audio) {
+            connect(m_kiwiSdrManager, &KiwiSdrManager::decodedAudioReady,
+                    m_audio, [audio = m_audio](const QString& id,
+                                                const QByteArray& pcm) {
+                audio->feedKiwiSdrAudioData(id, pcm);
+            }, Qt::QueuedConnection);
+            connect(m_kiwiSdrManager, &KiwiSdrManager::audioSourceEnabledChanged,
+                    m_audio, [audio = m_audio](const QString& id, bool enabled) {
+                audio->setKiwiSdrAudioSourceEnabled(id, enabled);
+            }, Qt::QueuedConnection);
+        }
+        connect(m_kiwiSdrManager, &KiwiSdrManager::waterfallRowReady,
+                this, [this](const QString& profileId, const QString&,
+                             const QVector<float>& binsDbm,
+                             double lowFreqMhz, double highFreqMhz,
+                             quint32 timecode) {
+            if (!m_panStack) {
+                return;
+            }
+            if (profileId.isEmpty() || !m_kiwiSdrManager) {
+                return;
+            }
+
+            const int sliceId =
+                m_kiwiSdrManager->assignedSliceForProfile(profileId);
+            SliceModel* slice = m_radioModel.slice(sliceId);
+            if (!slice || !m_radioModel.sliceMayBelongToUs(sliceId)) {
+                return;
+            }
+
+            if (SpectrumWidget* sw = spectrumForSlice(slice)) {
+                sw->setKiwiSdrWaterfallProfile(profileId);
+                sw->updateKiwiSdrWaterfallRow(binsDbm, lowFreqMhz,
+                                              highFreqMhz, timecode);
+            }
+        });
+        connect(m_kiwiSdrManager, &KiwiSdrManager::meterReadingReady,
+                this, [this](const QString& profileId,
+                             const KiwiSdrProtocol::MeterReading& reading) {
+            const auto applyMeterReading =
+                [this](const QString& id,
+                       const KiwiSdrProtocol::MeterReading& meter,
+                       bool requireConnected) {
+                if (!m_kiwiSdrManager || id.isEmpty()) {
+                    return;
+                }
+                const int sliceId =
+                    m_kiwiSdrManager->assignedSliceForProfile(id);
+                if (sliceId < 0
+                    || m_kiwiSdrManager->assignedProfileForSlice(sliceId)
+                        != id) {
+                    return;
+                }
+                if (requireConnected
+                    && m_kiwiSdrManager->state(id)
+                    != KiwiSdrClient::State::Connected) {
+                    return;
+                }
+                SliceModel* slice = m_radioModel.slice(sliceId);
+                if (!slice || !m_radioModel.sliceMayBelongToUs(sliceId)) {
+                    return;
+                }
+                if (SpectrumWidget* sw = spectrumForSlice(slice)) {
+                    if (VfoWidget* vfo = sw->vfoWidget(sliceId)) {
+                        vfo->setReceiveMeterReading(meter);
+                    }
+                }
+                if (sliceId == m_activeSliceId && m_appletPanel
+                    && m_appletPanel->sMeterWidget()) {
+                    m_appletPanel->sMeterWidget()->setReceiveMeterReading(meter);
+                }
+            };
+
+            if (!reading.valid || !reading.hasDbm) {
+                applyMeterReading(profileId, reading, false);
+                return;
+            }
+
+            // Kiwi audio intentionally prebuffers before mixing to avoid
+            // WebSocket jitter. Delay visual meter samples by the same target
+            // so the S-meter follows the audio the operator is hearing.
+            QTimer::singleShot(
+                kKiwiSdrMeterDisplayDelayMs, this,
+                [profileId, reading, applyMeterReading]() {
+                    applyMeterReading(profileId, reading, true);
+                });
+        });
+        connect(m_kiwiSdrManager, &KiwiSdrManager::sliceAssignmentChanged,
+                this, [this](int sliceId, const QString& profileId) {
+            const QString panId = m_radioModel.slice(sliceId)
+                ? m_radioModel.slice(sliceId)->panId()
+                : QString();
+            refreshKiwiSdrAppletReceivers();
+            if (!profileId.isEmpty()) {
+                syncKiwiSdrPanadapterUiState(panId);
+                return;
+            }
+            if (SliceModel* slice = m_radioModel.slice(sliceId)) {
+                const bool restoreMute =
+                    m_kiwiSdrVirtualPreviousMute.contains(sliceId)
+                        ? m_kiwiSdrVirtualPreviousMute.take(sliceId)
+                        : slice->flexAudioMute();
+                slice->setExternalReceiveAudioReplacementMute(false, restoreMute);
+                if (SpectrumWidget* spectrum = spectrumForSlice(slice)) {
+                    setKiwiSdrWaterfallActive(
+                        m_radioModel, slice->panId(), spectrum, false);
+                    spectrum->setKiwiSdrConnectionOverlay(false);
+                    spectrum->setKiwiSdrWaterfallProfile(QString());
+                }
+            }
+            refreshKiwiSdrWaterfallAvailability();
+            syncKiwiSdrPanadapterUiState(panId);
+        });
+        connect(m_kiwiSdrManager, &KiwiSdrManager::profileStateChanged,
+                this, [this](const QString& profileId, KiwiSdrClient::State state,
+                             const QString&) {
+            QString panId;
+            if (state == KiwiSdrClient::State::Connected) {
+                const int sliceId =
+                    m_kiwiSdrManager
+                        ? m_kiwiSdrManager->assignedSliceForProfile(profileId)
+                        : -1;
+                if (SliceModel* slice = m_radioModel.slice(sliceId)) {
+                    panId = slice->panId();
+                    updateKiwiSdrVirtualTrackingForSlice(slice);
+                    updateKiwiSdrVirtualAudioControlsForSlice(slice);
+                }
+            } else if (m_kiwiSdrManager) {
+                const int sliceId =
+                    m_kiwiSdrManager->assignedSliceForProfile(profileId);
+                if (SliceModel* slice = m_radioModel.slice(sliceId)) {
+                    panId = slice->panId();
+                }
+            }
+            refreshKiwiSdrWaterfallAvailability();
+            refreshKiwiSdrAppletReceivers();
+            if (!panId.isEmpty()) {
+                syncKiwiSdrPanadapterUiState(panId);
+            }
+        });
+        connect(m_kiwiSdrManager, &KiwiSdrManager::profileStreamReset,
+                this, [this](const QString& profileId) {
+            if (!m_panStack || profileId.isEmpty()) {
+                return;
+            }
+            for (PanadapterApplet* applet : m_panStack->allApplets()) {
+                if (applet && applet->spectrumWidget()) {
+                    applet->spectrumWidget()
+                        ->clearKiwiSdrWaterfallRowsForProfile(profileId);
+                }
+            }
+            syncKiwiSdrPanadapterUiStates();
+        });
+        connect(m_kiwiSdrManager, &KiwiSdrManager::profilesChanged,
+                this, [this] {
+            refreshKiwiSdrWaterfallAvailability();
+            refreshKiwiSdrAppletReceivers();
+            syncKiwiSdrPanadapterUiStates();
+        });
+    }
+    m_kiwiSdrClient->setOperatorCallsign(m_radioModel.callsign());
+    connect(&m_radioModel, &RadioModel::infoChanged,
+            m_kiwiSdrClient, [this]() {
+                if (m_kiwiSdrClient) {
+                    m_kiwiSdrClient->setOperatorCallsign(m_radioModel.callsign());
+                }
+                if (m_kiwiSdrManager) {
+                    m_kiwiSdrManager->setOperatorCallsign(m_radioModel.callsign());
+                }
+            });
+    refreshKiwiSdrSlices();
+    refreshKiwiSdrWaterfallAvailability();
+
+    if (m_kiwiSdrManager) {
+        QTimer::singleShot(0, m_kiwiSdrManager, &KiwiSdrManager::startAutoConnect);
+    }
+    syncKiwiSdrPanadapterUiStates();
+}
+
+void MainWindow::refreshKiwiSdrAppletReceivers()
+{
+    if (!m_appletPanel || !m_appletPanel->kiwiSdrApplet()) {
+        return;
+    }
+
+    QVector<KiwiSdrReceiverStatus> receivers;
+    if (m_kiwiSdrManager) {
+        for (const KiwiSdrAntennaProfile& profile : m_kiwiSdrManager->profiles()) {
+            KiwiSdrReceiverStatus receiver;
+            receiver.id = profile.id;
+            receiver.name = m_kiwiSdrManager->displayName(profile.id);
+            receiver.state = m_kiwiSdrManager->state(profile.id);
+            receiver.detail = m_kiwiSdrManager->stateDetail(profile.id);
+            const int sliceId = m_kiwiSdrManager->assignedSliceForProfile(profile.id);
+            receiver.assignedSlice = m_radioModel.slice(sliceId);
+            receivers.append(receiver);
+        }
+    }
+
+    m_appletPanel->kiwiSdrApplet()->setReceivers(receivers);
+}
+
+void MainWindow::refreshKiwiSdrSlices()
+{
+    refreshKiwiSdrAppletReceivers();
+}
+
+void MainWindow::refreshKiwiSdrWaterfallAvailability()
+{
+    if (!m_panStack) {
+        return;
+    }
+
+    const bool connected = m_kiwiSdrClient && m_kiwiSdrClient->isConnected();
+
+    for (PanadapterApplet* applet : m_panStack->allApplets()) {
+        if (!applet || !applet->spectrumWidget()) {
+            continue;
+        }
+
+        SpectrumWidget* spectrum = applet->spectrumWidget();
+        bool available = connected
+            && kiwiSliceForPan(m_radioModel, applet->panId(), m_activeSliceId) != nullptr;
+        if (!available && m_kiwiSdrManager) {
+            for (SliceModel* slice : m_radioModel.slices()) {
+                if (!slice || slice->panId() != applet->panId()
+                    || !m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+                    continue;
+                }
+                const QString profileId =
+                    m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId());
+                if (!profileId.isEmpty()) {
+                    available = true;
+                    break;
+                }
+            }
+        }
+        spectrum->setKiwiSdrWaterfallAvailable(available);
+        syncKiwiSdrPanadapterUiState(applet->panId());
+    }
+    syncKiwiSdrAppletWaterfallState();
+}
+
+void MainWindow::syncKiwiSdrTrackingToActiveSlice()
+{
+    if (!m_kiwiSdrClient || !m_kiwiSdrClient->isConnected()) {
+        return;
+    }
+
+    SliceModel* slice = activeSlice();
+    if (!slice || !m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+        return;
+    }
+
+    SpectrumWidget* target = spectrumForSlice(slice);
+    if (!target) {
+        return;
+    }
+
+    bool kiwiWaterfallWasActive = false;
+    if (m_panStack) {
+        for (PanadapterApplet* applet : m_panStack->allApplets()) {
+            if (!applet || !applet->spectrumWidget()) {
+                continue;
+            }
+            SpectrumWidget* spectrum = applet->spectrumWidget();
+            if (spectrum->kiwiSdrWaterfallActive()) {
+                kiwiWaterfallWasActive = true;
+                if (spectrum != target) {
+                    setKiwiSdrWaterfallActive(
+                        m_radioModel, applet->panId(), spectrum, false);
+                }
+            }
+        }
+    }
+
+    m_kiwiSdrClient->setTrackedSlice(
+        slice->sliceId(),
+        slice->frequency(),
+        slice->mode(),
+        slice->filterLow(),
+        slice->filterHigh(),
+        slice->panId());
+    m_kiwiSdrClient->setWaterfallLineDurationMs(target->wfLineDuration());
+    m_kiwiSdrClient->setWaterfallView(
+        slice->panId(), target->centerMhz(), target->bandwidthMhz());
+
+    if (kiwiWaterfallWasActive) {
+        target->setKiwiSdrWaterfallActive(true);
+    }
+    syncKiwiSdrAppletWaterfallState();
+}
+
+void MainWindow::setKiwiSdrWaterfallForActiveSlice(bool active)
+{
+    bool allowed = active && m_kiwiSdrClient && m_kiwiSdrClient->isConnected();
+    SliceModel* slice = activeSlice();
+    SpectrumWidget* target = slice ? spectrumForSlice(slice) : nullptr;
+    if (allowed
+        && (!slice || !target || !m_radioModel.sliceMayBelongToUs(slice->sliceId()))) {
+        allowed = false;
+    }
+
+    if (allowed) {
+        m_kiwiSdrClient->setTrackedSlice(
+            slice->sliceId(),
+            slice->frequency(),
+            slice->mode(),
+            slice->filterLow(),
+            slice->filterHigh(),
+            slice->panId());
+        m_kiwiSdrClient->setWaterfallLineDurationMs(target->wfLineDuration());
+        m_kiwiSdrClient->setWaterfallView(
+            slice->panId(), target->centerMhz(), target->bandwidthMhz());
+
+        if (m_panStack) {
+            for (PanadapterApplet* applet : m_panStack->allApplets()) {
+                if (!applet || applet->spectrumWidget() == target) {
+                    continue;
+                }
+                setKiwiSdrWaterfallActive(
+                    m_radioModel, applet->panId(), applet->spectrumWidget(), false);
+            }
+        }
+    }
+
+    if (target) {
+        setKiwiSdrWaterfallActive(
+            m_radioModel, slice ? slice->panId() : QString(), target, allowed);
+    } else if (!allowed && m_panStack) {
+        for (PanadapterApplet* applet : m_panStack->allApplets()) {
+            if (!applet || !applet->spectrumWidget()) {
+                continue;
+            }
+            setKiwiSdrWaterfallActive(
+                m_radioModel, applet->panId(), applet->spectrumWidget(), false);
+        }
+    }
+    refreshKiwiSdrWaterfallAvailability();
+    syncKiwiSdrAppletWaterfallState();
+}
+
+void MainWindow::syncKiwiSdrAppletWaterfallState()
+{
+    refreshKiwiSdrAppletReceivers();
+}
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -465,6 +465,10 @@ void MainWindow::wireKiwiSdr()
                     m_audio, [audio = m_audio](const QString& id, bool enabled) {
                 audio->setKiwiSdrAudioSourceEnabled(id, enabled);
             }, Qt::QueuedConnection);
+            connect(m_kiwiSdrManager, &KiwiSdrManager::audioSourceRemoved,
+                    m_audio, [audio = m_audio](const QString& id) {
+                audio->removeKiwiSdrAudioSource(id);
+            }, Qt::QueuedConnection);
         }
         connect(m_kiwiSdrManager, &KiwiSdrManager::waterfallRowReady,
                 this, [this](const QString& profileId, const QString&,

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -94,7 +94,8 @@ void MainWindow::buildMenuBar()
         const bool wasFresh = !m_radioSetupDialog;
         showOrRaisePersistent(m_radioSetupDialog,
                               &m_radioModel, m_audio,
-                              &m_tgxlConn, &m_pgxlConn, &m_antennaGenius);
+                              &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
+                              m_kiwiSdrManager);
         if (wasFresh && m_radioSetupDialog)
             wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
     });
@@ -130,7 +131,8 @@ void MainWindow::buildMenuBar()
         const bool wasFresh = !m_radioSetupDialog;
         showOrRaisePersistent(m_radioSetupDialog,
                               &m_radioModel, m_audio,
-                              &m_tgxlConn, &m_pgxlConn, &m_antennaGenius);
+                              &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
+                              m_kiwiSdrManager);
         if (wasFresh && m_radioSetupDialog)
             wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
         if (m_radioSetupDialog)

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -34,6 +34,8 @@
 #include "TunerApplet.h"
 #include "TxApplet.h"
 #include "core/PeripheralSettings.h"
+#include "core/KiwiSdrClient.h"
+#include "core/KiwiSdrManager.h"
 #include "SpectrumOverlayMenu.h"
 #include "SpectrumWidget.h"
 #include "VfoWidget.h"
@@ -93,6 +95,27 @@ bool dbmRangeLooksPlausible(float minDbm, float maxDbm)
         && maxDbm <= kMaxAllowedDbm
         && rangeDb >= kMinRangeDb
         && rangeDb <= kMaxRangeDb;
+}
+
+const SliceModel* kiwiSliceForPan(const RadioModel& radioModel,
+                                  const QString& panId,
+                                  int activeSliceId)
+{
+    if (panId.isEmpty()) {
+        return nullptr;
+    }
+
+    for (SliceModel* slice : radioModel.slices()) {
+        if (!slice || slice->panId() != panId
+            || !radioModel.sliceMayBelongToUs(slice->sliceId())) {
+            continue;
+        }
+
+        if (slice->sliceId() == activeSliceId) {
+            return slice;
+        }
+    }
+    return nullptr;
 }
 
 // Pan-follow tuning internals — moved with their only callers from
@@ -561,6 +584,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
         pushSliceOverlay(s);
         if (s->isTxSlice())
             syncTxWaterfallSliceToSpectrums();
+        updateKiwiSdrVirtualTrackingForSlice(s);
+        refreshKiwiSdrWaterfallAvailability();
+        syncKiwiSdrPanadapterUiStates();
     });
 
     // Create a VfoWidget for this slice on the correct panadapter
@@ -603,9 +629,12 @@ void MainWindow::onSliceAdded(SliceModel* s)
     // Feed S-meter per-slice — only this VFO's slice level
     const int sid = s->sliceId();
     connect(&m_radioModel.meterModel(), &MeterModel::sLevelChanged,
-            vfo, [vfo, sid](int sliceIndex, float dbm) {
-        if (sliceIndex == sid)
+            vfo, [this, vfo, sid](int sliceIndex, float dbm) {
+        if (sliceIndex == sid
+            && (!m_kiwiSdrManager
+                || m_kiwiSdrManager->assignedProfileForSlice(sid).isEmpty())) {
             vfo->setSignalLevel(dbm);
+        }
     });
     // Feed ESC meter per-slice — signal strength after ESC processing
     connect(&m_radioModel.meterModel(), &MeterModel::escLevelChanged,
@@ -675,6 +704,8 @@ void MainWindow::onSliceAdded(SliceModel* s)
 
     // Refresh slice tab buttons (#1278)
     m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
+    refreshKiwiSdrSlices();
+    refreshKiwiSdrWaterfallAvailability();
 }
 
 void MainWindow::onSliceRemoved(int id)
@@ -682,6 +713,11 @@ void MainWindow::onSliceRemoved(int id)
     if (m_applyingLayout) return;
 
     qDebug() << "MainWindow: slice removed" << id;
+
+    m_kiwiSdrVirtualPreviousMute.remove(id);
+    if (m_kiwiSdrManager) {
+        m_kiwiSdrManager->clearSliceAssignment(id);
+    }
 
 #ifdef HAVE_RADE
     // If the RADE slice was closed, deactivate RADE
@@ -765,6 +801,8 @@ void MainWindow::onSliceRemoved(int id)
 
     // Refresh slice tab buttons (#1278)
     m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
+    refreshKiwiSdrSlices();
+    refreshKiwiSdrWaterfallAvailability();
 }
 
 void MainWindow::beginProfileLoadRadioStateWriteHold(const QString& profileType,
@@ -1281,6 +1319,51 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     menu->disconnect(this);
     applet->disconnect(this);
 
+    auto updateKiwiWaterfallView = [this, applet, sw](double centerMhz,
+                                                      double bandwidthMhz) {
+        if (m_kiwiSdrManager && applet && sw) {
+            for (SliceModel* slice : m_radioModel.slices()) {
+                if (!slice || slice->panId() != applet->panId()
+                    || !m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+                    continue;
+                }
+                const QString profileId =
+                    m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId());
+                if (profileId.isEmpty()) {
+                    continue;
+                }
+                m_kiwiSdrManager->updateWaterfallView(
+                    slice->sliceId(), applet->panId(), centerMhz,
+                    bandwidthMhz, sw->wfLineDuration());
+                if (m_kiwiSdrManager->isConnected(profileId)) {
+                    sw->setKiwiSdrWaterfallAvailable(true);
+                    sw->setKiwiSdrWaterfallActive(true);
+                    syncKiwiSdrAppletWaterfallState();
+                }
+            }
+        }
+        if (!m_kiwiSdrClient || !m_kiwiSdrClient->isConnected()
+            || !applet || !sw
+            || !kiwiSliceForPan(m_radioModel, applet->panId(), m_activeSliceId)) {
+            return;
+        }
+        m_kiwiSdrClient->setWaterfallLineDurationMs(sw->wfLineDuration());
+        m_kiwiSdrClient->setWaterfallView(
+            applet->panId(), centerMhz, bandwidthMhz);
+    };
+
+    connect(sw, &SpectrumWidget::frequencyRangeChanged,
+            this, updateKiwiWaterfallView);
+    connect(sw, &SpectrumWidget::frequencyRangeChangeRequested,
+            this, updateKiwiWaterfallView);
+    connect(sw, &SpectrumWidget::centerChangeRequested,
+            this, [updateKiwiWaterfallView, sw](double centerMhz) {
+                if (!sw) {
+                    return;
+                }
+                updateKiwiWaterfallView(centerMhz, sw->bandwidthMhz());
+            });
+
     // Wire band plan manager to this spectrum widget
     sw->setBandPlanManager(m_bandPlanMgr);
 
@@ -1292,6 +1375,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     menu->setPanId(applet->panId());
     menu->setMemories(m_radioModel.memories());
     menu->setRadioModel(&m_radioModel);
+    menu->setKiwiSdrManager(m_kiwiSdrManager);
     menu->setRadioCapabilities(m_radioModel.capabilities());
 
     // Antenna list → this overlay menu (per-pan, mirrors VfoWidget pattern) (#1260)
@@ -1461,6 +1545,13 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     connect(sw, &SpectrumWidget::dbmRangeChangeRequested,
             this, [this, applet, sw, pendingDbm, setStreamDbmRange, sendDbmRangeCommand]
                   (float minDbm, float maxDbm) {
+        if (sw->kiwiSdrWaterfallActive()) {
+            sw->setDbmRange(minDbm, maxDbm);
+            sw->prepareForFftScaleChange();
+            sw->reacquireNoiseFloorLock();
+            return;
+        }
+
         const bool profileLoadHeld = profileLoadRadioStateWritesHeld();
         const bool autoFloorChange = sw->pendingAutoNoiseFloorDbmRange();
         if (profileLoadPanDisplaySettling(applet->panId()) && autoFloorChange) {
@@ -1493,7 +1584,14 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sendDbmRangeCommand(minDbm, maxDbm);
     });
     connect(sw, &SpectrumWidget::dbmRangeDragFinished,
-            this, [pendingDbm, setStreamDbmRange, sendDbmRangeCommand](float minDbm, float maxDbm) {
+            this, [sw, pendingDbm, setStreamDbmRange, sendDbmRangeCommand](float minDbm, float maxDbm) {
+        if (sw->kiwiSdrWaterfallActive()) {
+            sw->setDbmRange(minDbm, maxDbm);
+            sw->prepareForFftScaleChange();
+            sw->reacquireNoiseFloorLock();
+            return;
+        }
+
         pendingDbm->active = true;
         pendingDbm->minDbm = minDbm;
         pendingDbm->maxDbm = maxDbm;
@@ -1739,6 +1837,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setWfColorScheme);
     connect(menu, &SpectrumOverlayMenu::wfColorGainChanged,
             this, [this, applet, sw](int v) {
+        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+            return;
+        }
         sw->setWfColorGain(v);
         auto* pan = m_radioModel.panadapter(applet->panId());
         if (pan && !pan->waterfallId().isEmpty())
@@ -1747,6 +1848,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     connect(menu, &SpectrumOverlayMenu::wfBlackLevelChanged,
             this, [this, applet, sw](int v) {
+        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+            return;
+        }
         sw->setWfBlackLevel(v);
         auto* pan = m_radioModel.panadapter(applet->panId());
         if (pan && !pan->waterfallId().isEmpty())
@@ -1754,14 +1858,20 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                 QString("display panafall set %1 black_level=%2").arg(pan->waterfallId()).arg(v));
     });
     connect(menu, &SpectrumOverlayMenu::wfAutoBlackChanged,
-            this, [this, sw](bool on) {
+            this, [this, applet, sw](bool on) {
+        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+            return;
+        }
         sw->setWfAutoBlack(on);
         // Keep the radio's auto_black flag in sync at runtime; it only reaches
         // 1 when auto-black is on AND the radio-side source is selected.
         m_radioModel.setWaterfallAutoBlack(on);
     });
     connect(menu, &SpectrumOverlayMenu::wfAutoBlackOffsetChanged,
-            this, [sw](int offset) {
+            this, [this, applet, sw](int offset) {
+        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+            return;
+        }
         sw->setWfAutoBlackOffset(offset);
     });
     connect(menu, &SpectrumOverlayMenu::wfAutoBlackSourceChanged,
@@ -1773,7 +1883,31 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     const auto applyWaterfallLineDuration = [this, applet, sw](int ms) {
         const int clampedMs = std::clamp(ms, 1, 100);
+        const QString profileId = kiwiSdrProfileForPan(applet->panId());
+        if (!profileId.isEmpty()) {
+            const KiwiSdrAntennaProfile profile =
+                m_kiwiSdrManager ? m_kiwiSdrManager->profile(profileId)
+                                 : KiwiSdrAntennaProfile{};
+            if (m_kiwiSdrManager && profile.waterfallRate == 0) {
+                for (SliceModel* slice : m_radioModel.slices()) {
+                    if (!slice || slice->panId() != applet->panId()
+                        || m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId())
+                            != profileId) {
+                        continue;
+                    }
+                    m_kiwiSdrManager->updateWaterfallView(
+                        slice->sliceId(), applet->panId(), sw->centerMhz(),
+                        sw->bandwidthMhz(), clampedMs);
+                    break;
+                }
+            }
+            return;
+        }
         sw->setWfLineDuration(clampedMs);
+        if (m_kiwiSdrClient && m_kiwiSdrClient->isConnected()
+            && kiwiSliceForPan(m_radioModel, applet->panId(), m_activeSliceId)) {
+            m_kiwiSdrClient->setWaterfallLineDurationMs(clampedMs);
+        }
         auto* pan = m_radioModel.panadapter(applet->panId());
         if (pan && !pan->waterfallId().isEmpty())
             m_radioModel.sendCommand(
@@ -1783,6 +1917,58 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             this, applyWaterfallLineDuration);
     connect(sw, &SpectrumWidget::waterfallLineDurationChangeRequested,
             this, applyWaterfallLineDuration);
+    connect(menu, &SpectrumOverlayMenu::kiwiWaterfallCellChanged,
+            this, [this, applet, sw](int cellDb) {
+        if (!m_kiwiSdrManager) {
+            return;
+        }
+        const QString profileId = kiwiSdrProfileForPan(applet->panId());
+        if (profileId.isEmpty()) {
+            return;
+        }
+        const KiwiSdrAntennaProfile profile =
+            m_kiwiSdrManager->profile(profileId);
+        m_kiwiSdrManager->setProfileWaterfallSettings(
+            profileId, cellDb, profile.waterfallFloorDb,
+            profile.waterfallRate);
+        sw->setKiwiSdrWaterfallAdjustments(cellDb,
+                                           profile.waterfallFloorDb);
+        syncKiwiSdrPanadapterUiState(applet->panId());
+    });
+    connect(menu, &SpectrumOverlayMenu::kiwiWaterfallFloorChanged,
+            this, [this, applet, sw](int floorDb) {
+        if (!m_kiwiSdrManager) {
+            return;
+        }
+        const QString profileId = kiwiSdrProfileForPan(applet->panId());
+        if (profileId.isEmpty()) {
+            return;
+        }
+        const KiwiSdrAntennaProfile profile =
+            m_kiwiSdrManager->profile(profileId);
+        m_kiwiSdrManager->setProfileWaterfallSettings(
+            profileId, profile.waterfallCellDb, floorDb,
+            profile.waterfallRate);
+        sw->setKiwiSdrWaterfallAdjustments(profile.waterfallCellDb,
+                                           floorDb);
+        syncKiwiSdrPanadapterUiState(applet->panId());
+    });
+    connect(menu, &SpectrumOverlayMenu::kiwiWaterfallRateChanged,
+            this, [this, applet](int rate) {
+        if (!m_kiwiSdrManager) {
+            return;
+        }
+        const QString profileId = kiwiSdrProfileForPan(applet->panId());
+        if (profileId.isEmpty()) {
+            return;
+        }
+        const KiwiSdrAntennaProfile profile =
+            m_kiwiSdrManager->profile(profileId);
+        m_kiwiSdrManager->setProfileWaterfallSettings(
+            profileId, profile.waterfallCellDb, profile.waterfallFloorDb,
+            rate);
+        syncKiwiSdrPanadapterUiState(applet->panId());
+    });
     // NB Waterfall Blanker (#277)
     connect(menu, &SpectrumOverlayMenu::wfBlankerEnabledChanged,
             sw, &SpectrumWidget::setWfBlankerEnabled);
@@ -2154,6 +2340,10 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             this, [this](const QString& panId) {
         showQuickAddMemoryDialog(panId);
     });
+    connect(menu, &SpectrumOverlayMenu::kiwiRxAntennaSelected,
+            this, &MainWindow::setKiwiSdrVirtualAntennaForSlice);
+    connect(menu, &SpectrumOverlayMenu::flexRxAntennaSelected,
+            this, &MainWindow::clearKiwiSdrVirtualAntennaForSlice);
 
     // ── Slice marker clicks ──────────────────────────────────────────────
     connect(sw, &SpectrumWidget::sliceClicked,
@@ -2264,7 +2454,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         const bool wasFresh = !m_radioSetupDialog;
         showOrRaisePersistent(m_radioSetupDialog,
                               &m_radioModel, m_audio,
-                              &m_tgxlConn, &m_pgxlConn, &m_antennaGenius);
+                              &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
+                              m_kiwiSdrManager);
         if (wasFresh && m_radioSetupDialog)
             wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
         if (m_radioSetupDialog)
@@ -2317,6 +2508,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     // Client-side DSP toggles (NR2 / RN2 / NR4 / MNR / BNR / DFNR) now
     // live exclusively in the AetherDSP applet; the spectrum overlay menu
     // no longer surfaces them.
+    refreshKiwiSdrWaterfallAvailability();
 }
 
 MainWindow::TuneCenteringResult MainWindow::revealFrequencyIfNeeded(
@@ -2505,10 +2697,33 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     // algorithm enable/disable, and the manual cache stay in one place.
     if (m_appletPanel && m_appletPanel->rxApplet())
         w->setRxApplet(m_appletPanel->rxApplet());
+    w->setKiwiSdrManager(m_kiwiSdrManager);
 
     // Note: w->setSlice(s) is called at the end of this method (line ~1895)
 
     // Per-slice signals — these are specific to the slice this widget represents
+    connect(w, &VfoWidget::kiwiRxAntennaSelected,
+            this, &MainWindow::setKiwiSdrVirtualAntennaForSlice);
+    connect(w, &VfoWidget::flexRxAntennaSelected,
+            this, &MainWindow::clearKiwiSdrVirtualAntennaForSlice);
+    connect(s, &SliceModel::frequencyChanged, this, [this, s](double) {
+        updateKiwiSdrVirtualTrackingForSlice(s);
+    });
+    connect(s, &SliceModel::modeChanged, this, [this, s](const QString&) {
+        updateKiwiSdrVirtualTrackingForSlice(s);
+    });
+    connect(s, &SliceModel::filterChanged, this, [this, s](int, int) {
+        updateKiwiSdrVirtualTrackingForSlice(s);
+    });
+    connect(s, &SliceModel::panIdChanged, this, [this, s](const QString&) {
+        updateKiwiSdrVirtualTrackingForSlice(s);
+    });
+    connect(s, &SliceModel::audioGainChanged, this, [this, s](float) {
+        updateKiwiSdrVirtualAudioControlsForSlice(s);
+    });
+    connect(s, &SliceModel::audioMuteChanged, this, [this, s](bool) {
+        updateKiwiSdrVirtualAudioControlsForSlice(s);
+    });
     connect(w, &VfoWidget::closeSliceRequested, this, [this, sliceId]() {
         if (m_radioModel.slices().size() <= 1) return;
         m_radioModel.sendCommand(QString("slice remove %1").arg(sliceId));
@@ -2730,7 +2945,10 @@ void MainWindow::wireMeters()
     // ── S-Meter: MeterModel → SMeterWidget (active slice only) ─────────────
     connect(&m_radioModel.meterModel(), &MeterModel::sLevelChanged,
             this, [this](int sliceIndex, float dbm) {
-        if (sliceIndex == m_activeSliceId) {
+        if (sliceIndex == m_activeSliceId
+            && (!m_kiwiSdrManager
+                || m_kiwiSdrManager
+                       ->assignedProfileForSlice(sliceIndex).isEmpty())) {
             m_appletPanel->sMeterWidget()->setLevel(dbm);
 #ifdef HAVE_HIDAPI
             m_tmate2SmeterDbm = dbm;
@@ -3049,7 +3267,12 @@ void MainWindow::wireMeters()
     m_appletPanel->txApplet()->setRadioModel(&m_radioModel);
     m_appletPanel->txApplet()->setBandPlanManager(m_bandPlanMgr);
     m_appletPanel->rxApplet()->setRadioModel(&m_radioModel);
+    m_appletPanel->rxApplet()->setKiwiSdrManager(m_kiwiSdrManager);
     m_appletPanel->rxApplet()->setTransmitModel(&m_radioModel.transmitModel());
+    connect(m_appletPanel->rxApplet(), &RxApplet::kiwiRxAntennaSelected,
+            this, &MainWindow::setKiwiSdrVirtualAntennaForSlice);
+    connect(m_appletPanel->rxApplet(), &RxApplet::flexRxAntennaSelected,
+            this, &MainWindow::clearKiwiSdrVirtualAntennaForSlice);
 
     // Hide APD row on radios that don't support it
     connect(&m_radioModel.transmitModel(), &TransmitModel::apdStateChanged, this, [this]() {

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -6,9 +6,11 @@
 #include "models/RadioModel.h"
 #include "models/XvtrPolicy.h"
 #include "core/AppSettings.h"
+#include "core/KiwiSdrManager.h"
 #include "core/LogManager.h"
 #include "core/PeripheralSettings.h"
 #include <QApplication>
+#include <QAbstractItemView>
 #include <QSysInfo>
 #include "core/AudioEngine.h"
 #ifdef HAVE_SERIALPORT
@@ -29,6 +31,7 @@
 #include <QHBoxLayout>
 #include <QGridLayout>
 #include <QGroupBox>
+#include <QFrame>
 #include <QHeaderView>
 #include <QTableWidget>
 #include <QTableWidgetItem>
@@ -56,6 +59,7 @@
 #include <QProcess>
 #include <QListWidget>
 #include <QStackedWidget>
+#include <QStyle>
 #include <QPlainTextEdit>
 #include <QSplitter>
 #include <QScrollArea>
@@ -94,6 +98,23 @@ static const QString kValueStyle =
 static const QString kEditStyle =
     "QLineEdit { background: #1a2a3a; border: 1px solid #304050; "
     "border-radius: 3px; color: #c8d8e8; font-size: 12px; padding: 2px 4px; }";
+
+static const QString kKiwiRowStyle =
+    "QFrame#kiwiAntennaRow { background: #101622; border: 1px solid #203040; "
+    "border-radius: 3px; }";
+
+static const QString kKiwiActionButtonStyle =
+    "QPushButton { background: #183548; border: 1px solid #28506a; "
+    "border-radius: 4px; color: #d6e7f5; font-size: 12px; "
+    "font-weight: bold; padding: 4px 10px; }"
+    "QPushButton:hover { background: #20465e; }"
+    "QPushButton:pressed { background: #132c3d; }";
+
+static const QString kKiwiIconButtonStyle =
+    "QPushButton { background: #183548; border: 1px solid #28506a; "
+    "border-radius: 4px; padding: 3px; }"
+    "QPushButton:hover { background: #20465e; }"
+    "QPushButton:pressed { background: #132c3d; }";
 
 static constexpr int kInfoLeftLabelWidth = 112;
 static constexpr int kInfoRightLabelWidth = 160;
@@ -435,11 +456,14 @@ static void refreshOscillatorSourceCombo(QComboBox* combo, const RadioModel* mod
 
 RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
                                    TgxlConnection* tgxl, PgxlConnection* pgxl,
-                                   AntennaGeniusModel* ag, QWidget* parent)
+                                   AntennaGeniusModel* ag,
+                                   KiwiSdrManager* kiwiSdrManager,
+                                   QWidget* parent)
     : PersistentDialog(QStringLiteral("Radio Setup"),
                        QStringLiteral("RadioSetupDialogGeometry"), parent),
       m_model(model), m_audio(audio),
-      m_tgxl(tgxl), m_pgxl(pgxl), m_ag(ag)
+      m_tgxl(tgxl), m_pgxl(pgxl), m_ag(ag),
+      m_kiwiSdrManager(kiwiSdrManager)
 {
     theme::setContainer(this, QStringLiteral("dialog/radioSetup"));
     setMinimumSize(820, 620);
@@ -2953,6 +2977,35 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
     groupLayout->addWidget(scroll);
     vbox->addWidget(group, 1);
 
+    QVBoxLayout* kiwiRowsLayout = nullptr;
+
+    if (m_kiwiSdrManager) {
+        auto* kiwiGroup = new QGroupBox("KiwiSDR RX Antennas");
+        kiwiGroup->setStyleSheet(kGroupStyle);
+        auto* kiwiLayout = new QVBoxLayout(kiwiGroup);
+        kiwiLayout->setSpacing(6);
+
+        auto* kiwiScroll = new QScrollArea;
+        kiwiScroll->setWidgetResizable(true);
+        kiwiScroll->setFrameShape(QFrame::NoFrame);
+        kiwiScroll->setMinimumHeight(190);
+        kiwiScroll->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::MinimumExpanding);
+        kiwiScroll->setStyleSheet("QScrollArea { background: transparent; border: none; }");
+        kiwiScroll->setAccessibleName("KiwiSDR RX antennas");
+        kiwiScroll->setAccessibleDescription(
+            "Configured KiwiSDR receive-only antenna endpoints.");
+
+        auto* kiwiRowsWidget = new QWidget;
+        kiwiRowsWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Maximum);
+        kiwiRowsLayout = new QVBoxLayout(kiwiRowsWidget);
+        kiwiRowsLayout->setContentsMargins(8, 4, 8, 4);
+        kiwiRowsLayout->setSpacing(6);
+        kiwiRowsLayout->setAlignment(Qt::AlignTop);
+        kiwiScroll->setWidget(kiwiRowsWidget);
+        kiwiLayout->addWidget(kiwiScroll);
+        vbox->addWidget(kiwiGroup, 0);
+    }
+
     // Antenna display names are intentionally local to AetherSDR. FlexLib exposes
     // canonical RX/TX antenna lists and rxant/txant setters, but no verified
     // writable display-name API; radio commands must keep using ANT1/XVTR/etc.
@@ -3053,7 +3106,262 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
             [scheduleRefresh](const QStringList&) { scheduleRefresh(); });
     connect(m_model, &RadioModel::antennaAliasesChanged, this, scheduleRefresh);
 
+    auto refreshKiwi = std::make_shared<std::function<void()>>();
+    if (m_kiwiSdrManager && kiwiRowsLayout) {
+        auto stateText = [this](const QString& id) {
+            const KiwiSdrClient::State state = m_kiwiSdrManager->state(id);
+            QString base;
+            switch (state) {
+            case KiwiSdrClient::State::Disconnected:
+                base = QStringLiteral("Disconnected");
+                break;
+            case KiwiSdrClient::State::Connecting:
+                base = QStringLiteral("Connecting");
+                break;
+            case KiwiSdrClient::State::Connected:
+                base = QStringLiteral("Connected");
+                break;
+            case KiwiSdrClient::State::Error:
+                base = QStringLiteral("Error");
+                break;
+            }
+            const QString detail = m_kiwiSdrManager->stateDetail(id).trimmed();
+            if (!detail.isEmpty()
+                && state != KiwiSdrClient::State::Connected
+                && state != KiwiSdrClient::State::Connecting) {
+                return QStringLiteral("%1\n%2").arg(base, detail);
+            }
+            return base.isEmpty() ? QStringLiteral("Disconnected") : base;
+        };
+
+        auto styleKiwiEdit = [](QLineEdit* edit) {
+            edit->setStyleSheet(kEditStyle);
+            edit->setMinimumHeight(24);
+        };
+
+        auto styleKiwiButton = [](QPushButton* button) {
+            button->setStyleSheet(kKiwiActionButtonStyle);
+            button->setMinimumWidth(96);
+            button->setAutoDefault(false);
+        };
+
+        auto styleKiwiIconButton = [](QPushButton* button) {
+            button->setStyleSheet(kKiwiIconButtonStyle);
+            button->setFixedSize(30, 26);
+            button->setAutoDefault(false);
+        };
+
+        *refreshKiwi = [this, kiwiRowsLayout, stateText, styleKiwiEdit,
+                        styleKiwiButton, styleKiwiIconButton] {
+            while (QLayoutItem* item = kiwiRowsLayout->takeAt(0)) {
+                if (QWidget* widget = item->widget()) {
+                    widget->deleteLater();
+                }
+                delete item;
+            }
+
+            const QVector<KiwiSdrAntennaProfile> profiles =
+                m_kiwiSdrManager->profiles();
+            for (int row = 0; row < profiles.size(); ++row) {
+                const KiwiSdrAntennaProfile profile = profiles[row];
+
+                auto* rowFrame = new QFrame;
+                rowFrame->setObjectName("kiwiAntennaRow");
+                rowFrame->setStyleSheet(kKiwiRowStyle);
+                auto* rowLayout = new QGridLayout(rowFrame);
+                rowLayout->setContentsMargins(6, 5, 6, 5);
+                rowLayout->setHorizontalSpacing(6);
+                rowLayout->setVerticalSpacing(3);
+                rowLayout->setColumnStretch(0, 1);
+
+                auto* nameEdit = new QLineEdit(profile.name);
+                nameEdit->setMaxLength(16);
+                nameEdit->setPlaceholderText("Custom Name");
+                nameEdit->setAccessibleName("KiwiSDR antenna name");
+                nameEdit->setAccessibleDescription(
+                    "Required display name for this KiwiSDR receive antenna.");
+                styleKiwiEdit(nameEdit);
+                rowLayout->addWidget(nameEdit, 0, 0);
+
+                auto* status = new QLabel(stateText(profile.id));
+                status->setAccessibleName("KiwiSDR antenna status");
+                status->setStyleSheet(
+                    "QLabel { color: #c8d8e8; font-size: 12px; padding-left: 6px; }");
+                status->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+                status->setWordWrap(true);
+                status->setToolTip(status->text());
+                rowLayout->addWidget(status, 0, 1, 1, 3);
+
+                auto* endpointEdit = new QLineEdit(profile.endpoint);
+                endpointEdit->setAccessibleName("KiwiSDR server");
+                endpointEdit->setAccessibleDescription(
+                    "Hostname or hostname:port for this KiwiSDR endpoint.");
+                styleKiwiEdit(endpointEdit);
+                rowLayout->addWidget(endpointEdit, 1, 0);
+
+                auto* autoCheck = new QCheckBox;
+                autoCheck->setText("Auto");
+                autoCheck->setChecked(profile.autoConnect);
+                autoCheck->setAccessibleName("Auto connect KiwiSDR antenna");
+                autoCheck->setStyleSheet(
+                    "QCheckBox { color: #c8d8e8; font-size: 12px; spacing: 4px; }");
+                rowLayout->addWidget(autoCheck, 1, 1, Qt::AlignCenter);
+
+                const bool connected =
+                    m_kiwiSdrManager->state(profile.id)
+                    == KiwiSdrClient::State::Connected;
+                auto* connectButton =
+                    new QPushButton(connected ? "Disconnect" : "Connect");
+                connectButton->setAccessibleName(
+                    connected ? "Disconnect KiwiSDR antenna"
+                              : "Connect KiwiSDR antenna");
+                styleKiwiButton(connectButton);
+                rowLayout->addWidget(connectButton, 1, 2);
+
+                auto* removeButton = new QPushButton;
+                removeButton->setIcon(style()->standardIcon(QStyle::SP_TrashIcon));
+                removeButton->setToolTip("Remove");
+                removeButton->setAccessibleName("Remove KiwiSDR antenna");
+                styleKiwiIconButton(removeButton);
+                rowLayout->addWidget(removeButton, 1, 3);
+                kiwiRowsLayout->addWidget(rowFrame);
+
+                auto updateProfile = [this, profile, nameEdit, endpointEdit,
+                                      autoCheck] {
+                    const QString name = nameEdit->text().trimmed();
+                    const QString endpoint =
+                        KiwiSdrClient::normalizeEndpoint(endpointEdit->text());
+                    if (name.isEmpty()) {
+                        QSignalBlocker blocker(nameEdit);
+                        nameEdit->setText(profile.name);
+                        return;
+                    }
+                    if (endpoint.isEmpty()) {
+                        QSignalBlocker blocker(endpointEdit);
+                        endpointEdit->setText(profile.endpoint);
+                        return;
+                    }
+                    if (endpointEdit->text() != endpoint) {
+                        QSignalBlocker blocker(endpointEdit);
+                        endpointEdit->setText(endpoint);
+                    }
+                    KiwiSdrAntennaProfile updated = profile;
+                    updated.name = name;
+                    updated.endpoint = endpoint;
+                    updated.autoConnect = autoCheck->isChecked();
+                    m_kiwiSdrManager->updateProfile(updated);
+                };
+                connect(nameEdit, &QLineEdit::editingFinished,
+                        this, updateProfile);
+                connect(nameEdit, &QLineEdit::returnPressed,
+                        this, updateProfile);
+                connect(endpointEdit, &QLineEdit::editingFinished,
+                        this, updateProfile);
+                connect(endpointEdit, &QLineEdit::returnPressed,
+                        this, updateProfile);
+                connect(autoCheck, &QCheckBox::toggled,
+                        this, [updateProfile](bool) { updateProfile(); });
+                connect(connectButton, &QPushButton::clicked,
+                        this, [this, profile, connected] {
+                    if (connected) {
+                        m_kiwiSdrManager->disconnectProfile(profile.id);
+                    } else {
+                        m_kiwiSdrManager->connectProfile(profile.id);
+                    }
+                });
+                connect(removeButton, &QPushButton::clicked,
+                        this, [this, profile] {
+                    m_kiwiSdrManager->removeProfile(profile.id);
+                });
+            }
+
+            auto* rowFrame = new QFrame;
+            rowFrame->setObjectName("kiwiAntennaRow");
+            rowFrame->setStyleSheet(kKiwiRowStyle);
+            auto* rowLayout = new QGridLayout(rowFrame);
+            rowLayout->setContentsMargins(6, 5, 6, 5);
+            rowLayout->setHorizontalSpacing(6);
+            rowLayout->setVerticalSpacing(3);
+            rowLayout->setColumnStretch(0, 1);
+
+            auto* nameEdit = new QLineEdit;
+            nameEdit->setMaxLength(16);
+            nameEdit->setPlaceholderText("Custom Name");
+            nameEdit->setAccessibleName("New KiwiSDR antenna name");
+            nameEdit->setAccessibleDescription(
+                "Required display name for the new KiwiSDR receive antenna.");
+            styleKiwiEdit(nameEdit);
+            rowLayout->addWidget(nameEdit, 0, 0);
+
+            auto* endpointEdit = new QLineEdit;
+            endpointEdit->setPlaceholderText("host:8073");
+            endpointEdit->setAccessibleName("New KiwiSDR server");
+            endpointEdit->setAccessibleDescription(
+                "Hostname or hostname:port for the new KiwiSDR receive antenna.");
+            styleKiwiEdit(endpointEdit);
+            rowLayout->addWidget(endpointEdit, 1, 0);
+
+            auto* autoCheck = new QCheckBox;
+            autoCheck->setText("Auto");
+            autoCheck->setAccessibleName("Auto connect new KiwiSDR antenna");
+            autoCheck->setStyleSheet(
+                "QCheckBox { color: #c8d8e8; font-size: 12px; spacing: 4px; }");
+            rowLayout->addWidget(autoCheck, 1, 1, Qt::AlignCenter);
+            kiwiRowsLayout->addWidget(rowFrame);
+
+            auto committed = std::make_shared<bool>(false);
+            auto commitNewRow = [this, nameEdit, endpointEdit, autoCheck,
+                                 committed] {
+                if (*committed) {
+                    return;
+                }
+                const QString name = nameEdit->text().trimmed();
+                const QString endpoint =
+                    KiwiSdrClient::normalizeEndpoint(endpointEdit->text());
+                if (name.isEmpty() || endpoint.isEmpty()) {
+                    return;
+                }
+                *committed = true;
+                const QString id = m_kiwiSdrManager->addProfile(name, endpoint);
+                if (autoCheck->isChecked()) {
+                    KiwiSdrAntennaProfile profile = m_kiwiSdrManager->profile(id);
+                    profile.autoConnect = true;
+                    m_kiwiSdrManager->updateProfile(profile);
+                }
+            };
+            connect(nameEdit, &QLineEdit::editingFinished,
+                    this, commitNewRow);
+            connect(nameEdit, &QLineEdit::returnPressed,
+                    this, commitNewRow);
+            connect(endpointEdit, &QLineEdit::editingFinished,
+                    this, commitNewRow);
+            connect(endpointEdit, &QLineEdit::returnPressed,
+                    this, commitNewRow);
+            connect(autoCheck, &QCheckBox::toggled,
+                    this, [commitNewRow](bool) { commitNewRow(); });
+
+            kiwiRowsLayout->addStretch(1);
+        };
+
+        connect(m_kiwiSdrManager, &KiwiSdrManager::profilesChanged,
+                this, [refreshKiwi] {
+            if (*refreshKiwi) {
+                (*refreshKiwi)();
+            }
+        });
+        connect(m_kiwiSdrManager, &KiwiSdrManager::profileStateChanged,
+                this, [refreshKiwi](const QString&, KiwiSdrClient::State,
+                                    const QString&) {
+            if (*refreshKiwi) {
+                (*refreshKiwi)();
+            }
+        });
+    }
+
     (*refresh)();
+    if (refreshKiwi && *refreshKiwi) {
+        (*refreshKiwi)();
+    }
     return page;
 }
 

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -28,6 +28,7 @@ class FirmwareStager;
 class TgxlConnection;
 class PgxlConnection;
 class AntennaGeniusModel;
+class KiwiSdrManager;
 
 // Radio Setup dialog — tabbed configuration window matching SmartSDR's
 // Settings → Radio Setup. Shows radio info, GPS, TX, RX, filters, etc.
@@ -39,6 +40,7 @@ public:
                               TgxlConnection* tgxl = nullptr,
                               PgxlConnection* pgxl = nullptr,
                               AntennaGeniusModel* ag = nullptr,
+                              KiwiSdrManager* kiwiSdrManager = nullptr,
                               QWidget* parent = nullptr);
     void selectTab(const QString& tabName);
     void refreshFlexControlButtonActions();
@@ -99,6 +101,7 @@ private:
     TgxlConnection*    m_tgxl{nullptr};
     PgxlConnection*    m_pgxl{nullptr};
     AntennaGeniusModel* m_ag{nullptr};
+    KiwiSdrManager* m_kiwiSdrManager{nullptr};
     QTabWidget*  m_tabs{nullptr};
     QHash<QString, QComboBox*> m_flexControlActionCombos;
     QHash<QString, QString> m_flexControlActionDefaults;

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -6,6 +6,7 @@
 #include "InteractionSettings.h"
 #include "SliceColorManager.h"
 #include "SliceLabel.h"
+#include "core/KiwiSdrManager.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "Theme.h"
@@ -401,18 +402,41 @@ void RxApplet::buildUI()
             const QStringList options = m_slice && !m_slice->rxAntennaList().isEmpty()
                 ? m_slice->rxAntennaList()
                 : m_antList;
-            for (const QString& ant : options) {
-                QAction* act = menu.addAction(antennaMenuLabel(ant, options));
+            QStringList menuOptions = options;
+            if (m_kiwiSdrManager) {
+                menuOptions.append(m_kiwiSdrManager->virtualAntennaTokens());
+            }
+            const QString activeKiwiProfile =
+                (m_kiwiSdrManager && m_slice)
+                    ? m_kiwiSdrManager->assignedProfileForSlice(m_slice->sliceId())
+                    : QString();
+            for (const QString& ant : menuOptions) {
+                QAction* act = menu.addAction(antennaMenuLabel(ant, menuOptions));
                 act->setData(ant);
                 act->setCheckable(true);
-                act->setChecked(ant == cur);
+                const QString profileId = m_kiwiSdrManager
+                    ? m_kiwiSdrManager->profileIdForVirtualAntennaToken(ant)
+                    : QString();
+                act->setChecked(profileId.isEmpty()
+                    ? ant == cur && activeKiwiProfile.isEmpty()
+                    : profileId == activeKiwiProfile);
                 act->setToolTip(ant);
                 act->setStatusTip(ant);
             }
             const QAction* sel = menu.exec(
                 m_rxAntBtn->mapToGlobal(QPoint(0, m_rxAntBtn->height())));
-            if (sel && m_slice)
-                m_slice->setRxAntenna(sel->data().toString());
+            if (sel && m_slice) {
+                const QString token = sel->data().toString();
+                const QString profileId = m_kiwiSdrManager
+                    ? m_kiwiSdrManager->profileIdForVirtualAntennaToken(token)
+                    : QString();
+                if (!profileId.isEmpty()) {
+                    emit kiwiRxAntennaSelected(m_slice->sliceId(), profileId);
+                } else {
+                    emit flexRxAntennaSelected(m_slice->sliceId());
+                    m_slice->setRxAntenna(token);
+                }
+            }
         });
         row->addWidget(m_rxAntBtn);
 
@@ -1739,6 +1763,28 @@ void RxApplet::setRadioModel(RadioModel* radioModel)
     updateAntennaButtons();
 }
 
+void RxApplet::setKiwiSdrManager(KiwiSdrManager* manager)
+{
+    if (m_kiwiSdrManager) {
+        disconnect(m_kiwiSdrManager, &KiwiSdrManager::profilesChanged,
+                   this, &RxApplet::updateAntennaButtons);
+        disconnect(m_kiwiSdrManager, &KiwiSdrManager::sliceAssignmentChanged,
+                   this, nullptr);
+    }
+    m_kiwiSdrManager = manager;
+    if (m_kiwiSdrManager) {
+        connect(m_kiwiSdrManager, &KiwiSdrManager::profilesChanged,
+                this, &RxApplet::updateAntennaButtons);
+        connect(m_kiwiSdrManager, &KiwiSdrManager::sliceAssignmentChanged,
+                this, [this](int sliceId, const QString&) {
+            if (m_slice && m_slice->sliceId() == sliceId) {
+                updateAntennaButtons();
+            }
+        });
+    }
+    updateAntennaButtons();
+}
+
 void RxApplet::setTransmitModel(TransmitModel* txModel)
 {
     if (m_txModel) m_txModel->disconnect(this);
@@ -1759,6 +1805,13 @@ void RxApplet::setTransmitModel(TransmitModel* txModel)
 QString RxApplet::antennaMenuLabel(const QString& token,
                                    const QStringList& options) const
 {
+    if (m_kiwiSdrManager) {
+        const QString profileId =
+            m_kiwiSdrManager->profileIdForVirtualAntennaToken(token);
+        if (!profileId.isEmpty()) {
+            return m_kiwiSdrManager->displayName(profileId);
+        }
+    }
     if (!m_radioModel)
         return token;
     return m_radioModel->antennaDisplayName(
@@ -1794,9 +1847,23 @@ void RxApplet::updateAntennaButton(QPushButton* button, const QString& token, bo
     if (!button)
         return;
 
-    const QString shortLabel = m_radioModel
-        ? m_radioModel->antennaShortDisplayName(token, 6)
-        : token;
+    QString effectiveToken = token;
+    if (!tx && m_kiwiSdrManager && m_slice) {
+        const QString profileId =
+            m_kiwiSdrManager->assignedProfileForSlice(m_slice->sliceId());
+        if (!profileId.isEmpty()) {
+            effectiveToken = m_kiwiSdrManager->virtualAntennaToken(profileId);
+        }
+    }
+
+    const QString profileId = m_kiwiSdrManager
+        ? m_kiwiSdrManager->profileIdForVirtualAntennaToken(effectiveToken)
+        : QString();
+    const QString shortLabel = !profileId.isEmpty()
+        ? m_kiwiSdrManager->displayName(profileId)
+        : (m_radioModel
+            ? m_radioModel->antennaShortDisplayName(effectiveToken, 6)
+            : effectiveToken);
     const QFontMetrics fm(button->font());
     constexpr int kMinWidth = 30;
     constexpr int kMaxWidth = 58;
@@ -1805,12 +1872,17 @@ void RxApplet::updateAntennaButton(QPushButton* button, const QString& token, bo
     button->setText(text);
     button->setFixedWidth(qBound(kMinWidth, fm.horizontalAdvance(text) + kPad, kMaxWidth));
 
-    const QString full = m_radioModel
-        ? m_radioModel->antennaDisplayName(token, !m_radioModel->antennaAlias(token).isEmpty())
-        : token;
-    button->setToolTip(QStringLiteral("%1 antenna port: %2")
-                           .arg(tx ? QStringLiteral("Transmit") : QStringLiteral("Receive"),
-                                full));
+    const QString full = !profileId.isEmpty()
+        ? m_kiwiSdrManager->displayName(profileId)
+        : (m_radioModel
+            ? m_radioModel->antennaDisplayName(
+                  effectiveToken, !m_radioModel->antennaAlias(effectiveToken).isEmpty())
+            : effectiveToken);
+    button->setToolTip(!profileId.isEmpty()
+        ? QStringLiteral("Receive antenna: %1").arg(full)
+        : QStringLiteral("%1 antenna port: %2")
+              .arg(tx ? QStringLiteral("Transmit") : QStringLiteral("Receive"),
+                   full));
 }
 
 void RxApplet::updateAntennaButtons()

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -23,6 +23,7 @@ namespace AetherSDR {
 
 class SliceModel;
 class RadioModel;
+class KiwiSdrManager;
 
 // RX Applet — controls for a single receive slice.
 //
@@ -78,6 +79,7 @@ public:
     // Connect to transmit model for QSK (break_in) indicator.
     void setTransmitModel(class TransmitModel* txModel);
     void setRadioModel(class RadioModel* radioModel);
+    void setKiwiSdrManager(KiwiSdrManager* manager);
 
     // Set the available antenna list (from ant_list in panadapter status).
     void setAntennaList(const QStringList& ants);
@@ -109,6 +111,8 @@ signals:
     // that should not fire on radio-driven syncs: pushing to the radio,
     // persisting, and the "Step: …" status-bar toast.
     void stepSizeChangedByUser(int hz);
+    void kiwiRxAntennaSelected(int sliceId, const QString& profileId);
+    void flexRxAntennaSelected(int sliceId);
     // Emitted when Auto SQL tracking is toggled.
     void sqlAutoChanged(bool on);
     // Emitted on every SQL mode transition (Off / Manual / Auto), so any
@@ -185,6 +189,7 @@ private:
     SliceModel* m_slice{nullptr};
     TransmitModel* m_txModel{nullptr};
     RadioModel* m_radioModel{nullptr};
+    KiwiSdrManager* m_kiwiSdrManager{nullptr};
     QStringList m_antList{"ANT1", "ANT2"};   // populated from ant_list key
 
     // Step sizes (Hz) — per-mode, swapped on mode change

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -8,6 +8,9 @@
 #include <QtMath>
 #include <QFontMetrics>
 
+#include <algorithm>
+#include <utility>
+
 namespace AetherSDR {
 
 // --- Construction ------------------------------------------------------------
@@ -53,6 +56,7 @@ SMeterWidget::SMeterWidget(QWidget* parent)
 
 void SMeterWidget::setLevel(float dbm)
 {
+    m_receiveMeterReadingActive = false;
     m_levelDbm = dbm;
 
     // Peak hold (existing needle/triangle behavior)
@@ -90,6 +94,53 @@ void SMeterWidget::setLevel(float dbm)
             const QString accessText = sText + QStringLiteral(", ")
                 + QString::number(static_cast<int>(displayDbm))
                 + QStringLiteral(" dBm");
+            QAccessibleValueChangeEvent event(this, accessText);
+            QAccessible::updateAccessibility(&event);
+        }
+    }
+}
+
+void SMeterWidget::setReceiveMeterReading(
+    const KiwiSdrProtocol::MeterReading& reading)
+{
+    m_receiveMeterReading = reading;
+    m_receiveMeterReadingActive = true;
+
+    const bool hasDisplayDbm =
+        (reading.capability == KiwiSdrProtocol::MeterCapability::CalibratedSndMeter
+         || reading.capability == KiwiSdrProtocol::MeterCapability::Experimental)
+        && reading.hasDbm;
+
+    if (hasDisplayDbm) {
+        m_levelDbm = reading.dbm;
+        if (reading.dbm > m_peakDbm) {
+            m_peakDbm = reading.dbm;
+            m_peakDecay.start();
+        }
+        if (m_peakHoldEnabled && reading.dbm > m_peakHoldDbm) {
+            m_peakHoldDbm = reading.dbm;
+            m_peakHoldDecayStartDbm = reading.dbm;
+            m_peakHoldTimer.start();
+            m_peakHoldTimerRunning = true;
+        }
+    } else {
+        m_levelDbm = S0_DBM;
+        m_peakDbm = S0_DBM;
+        m_peakHoldDbm = S0_DBM;
+        m_peakHoldDecayStartDbm = S0_DBM;
+        m_peakHoldTimerRunning = false;
+    }
+
+    updateNeedleTarget();
+    if (!m_transmitting) {
+        update();
+        if (hasFocus() && QAccessible::isActive()) {
+            QString accessText = unavailableRxMeterLabel();
+            if (hasDisplayDbm) {
+                accessText = reading.label;
+                accessText += QStringLiteral(", %1 dBm")
+                    .arg(static_cast<int>(reading.dbm));
+            }
             QAccessibleValueChangeEvent event(this, accessText);
             QAccessible::updateAccessibility(&event);
         }
@@ -168,6 +219,8 @@ void SMeterWidget::updateNeedleTarget()
 
     if (m_transmitting) {
         m_targetNeedleFraction = txValueToFraction(currentTxValue());
+    } else if (usesUnavailableRxMeter()) {
+        m_targetNeedleFraction = 0.0f;
     } else if (m_rxMode == RxMode::SMeterPeak) {
         m_targetNeedleFraction = dbmToFraction(m_peakDbm);
     } else {
@@ -233,6 +286,29 @@ void SMeterWidget::animateNeedle()
     if (settled || m_smooth.shouldRepaint()) {
         update();
     }
+}
+
+bool SMeterWidget::usesUnavailableRxMeter() const
+{
+    return m_receiveMeterReadingActive
+        && !(m_receiveMeterReading.valid
+            && (m_receiveMeterReading.capability
+                    == KiwiSdrProtocol::MeterCapability::CalibratedSndMeter
+                || m_receiveMeterReading.capability
+                    == KiwiSdrProtocol::MeterCapability::Experimental)
+            && m_receiveMeterReading.hasDbm);
+}
+
+QString SMeterWidget::unavailableRxMeterLabel() const
+{
+    if (!m_receiveMeterReadingActive) {
+        return QStringLiteral("Meter unavailable");
+    }
+    if (m_receiveMeterReading.capability
+        == KiwiSdrProtocol::MeterCapability::RawSndMeter) {
+        return QStringLiteral("Raw S-meter");
+    }
+    return QStringLiteral("Meter unavailable");
 }
 
 void SMeterWidget::updatePeakHoldValue()
@@ -334,6 +410,8 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     const float arcStartRad = qDegreesToRadians(ARC_START_DEG);
     const float arcEndRad   = qDegreesToRadians(ARC_END_DEG);
     const float arcSpanRad  = arcEndRad - arcStartRad;
+    const bool unavailableRxScale = usesUnavailableRxMeter();
+    const bool calibratedRxScale = !unavailableRxScale;
 
     // fraction 0.0 -> left end (ARC_END_DEG), fraction 1.0 -> right end (ARC_START_DEG)
     auto fractionToAngle = [&](float frac) -> float {
@@ -341,9 +419,10 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     };
 
     // -- Draw colored outer arc (RX scale) ------------------------------------
-    // White from S0 to S9, red from S9+
     {
         const QRectF outerArc(cx - radius, cy - radius, radius * 2, radius * 2);
+        // RX face always uses the existing Flex-style S scale. Uncalibrated
+        // Kiwi fallback readings do not move the needle or show fake dBm.
         const float s9Deg = qRadiansToDegrees(fractionToAngle(0.6f));
 
         QPen whitePen(QColor(0xc8, 0xd8, 0xe8), 3);
@@ -463,7 +542,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
 
     const QColor whiteColor(0xc8, 0xd8, 0xe8);
 
-    // -- Outside ticks (RX): S-meter scale -- odd S-units only ----------------
+    // -- Outside ticks (RX) ---------------------------------------------------
     for (int s = 1; s <= 9; s += 2) {
         const float dbm = S0_DBM + s * DB_PER_S;
         drawOutsideTick(dbmToFraction(dbm), QString::number(s), whiteColor, true);
@@ -555,7 +634,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     }
 
     // Draw peak marker (small triangle) — only in RX S-Meter Peak mode
-    if (!m_transmitting && m_rxMode == RxMode::SMeterPeak
+    if (!m_transmitting && calibratedRxScale && m_rxMode == RxMode::SMeterPeak
         && m_peakDbm > m_levelDbm + 1.0f) {
         const float frac = dbmToFraction(m_peakDbm);
         const float angle = fractionToAngle(frac);
@@ -582,7 +661,7 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     }
 
     // -- Draw peak hold line (configurable overlay, independent of RX mode) ---
-    if (m_peakHoldEnabled && !m_transmitting
+    if (m_peakHoldEnabled && !m_transmitting && calibratedRxScale
         && m_peakHoldDbm > S0_DBM + 1.0f) {
         float frac = dbmToFraction(m_peakHoldDbm);
         if (m_peakHoldDbm <= m_levelDbm + 0.01f) {
@@ -639,6 +718,24 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         p.drawText(w - vfm.horizontalAdvance(valText) - 6, topY, valText);
     } else {
         // RX mode: show source label (center), S-units (left), dBm (right)
+        if (unavailableRxScale) {
+            const QString sourceLabel = unavailableRxMeterLabel();
+            p.setFont(srcFont);
+            p.setPen(QColor(0x80, 0x90, 0xa0));
+            p.drawText((w - sfm.horizontalAdvance(sourceLabel)) / 2,
+                       topY, sourceLabel);
+
+            p.setFont(valFont);
+            p.setPen(QColor(0x00, 0xb4, 0xd8));
+            p.drawText(6, topY, QStringLiteral("---"));
+
+            const QString rightText = QStringLiteral("---");
+            p.setPen(QColor(0xc8, 0xd8, 0xe8));
+            p.drawText(w - vfm.horizontalAdvance(rightText) - 6,
+                       topY, rightText);
+            return;
+        }
+
         p.setFont(srcFont);
         p.setPen(QColor(0x80, 0x90, 0xa0));
         p.drawText((w - sfm.horizontalAdvance(m_source)) / 2, topY, m_source);

--- a/src/gui/SMeterWidget.h
+++ b/src/gui/SMeterWidget.h
@@ -4,6 +4,7 @@
 #include <QTimer>
 #include <QElapsedTimer>
 
+#include "core/KiwiSdrProtocol.h"
 #include "MeterSmoother.h"
 
 namespace AetherSDR {
@@ -38,6 +39,8 @@ public:
 public slots:
     // Update the displayed RX level (S-meter dBm).
     void setLevel(float dbm);
+    void setReceiveMeterReading(
+        const AetherSDR::KiwiSdrProtocol::MeterReading& reading);
 
     // Update TX meter values.
     void setTxMeters(float fwdPower, float swr);
@@ -69,6 +72,8 @@ private:
     void updateNeedleTarget();
     void animateNeedle();
     void updatePeakHoldValue();
+    bool usesUnavailableRxMeter() const;
+    QString unavailableRxMeterLabel() const;
 
     // Map dBm to fraction (0.0 = left, 1.0 = right) for RX S-meter scale
     float dbmToFraction(float dbm) const;
@@ -83,6 +88,8 @@ private:
     float   m_levelDbm{-127.0f};    // current RX reading
     float   m_peakDbm{-127.0f};     // RX peak hold
     QString m_source{"S-Meter Peak"};
+    KiwiSdrProtocol::MeterReading m_receiveMeterReading;
+    bool m_receiveMeterReadingActive{false};
 
     // TX meter values (updated continuously, used when transmitting)
     float   m_txPower{0.0f};

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -8,6 +8,7 @@
 #include "models/SliceModel.h"
 #include "models/BandDefs.h"
 #include "core/AppSettings.h"
+#include "core/KiwiSdrManager.h"
 
 #include <QPushButton>
 #include <QComboBox>
@@ -44,9 +45,40 @@ static constexpr int WF_RATE_SLIDER_MAX = 100;
 static constexpr int WF_LINE_DURATION_MIN_MS = 1;
 static constexpr int WF_LINE_DURATION_MAX_MS = 100;
 
+SliceModel* antennaTargetSliceForPan(RadioModel* radioModel,
+                                     SliceModel* currentSlice,
+                                     const QString& panId)
+{
+    if (currentSlice && (panId.isEmpty() || currentSlice->panId() == panId)) {
+        return currentSlice;
+    }
+
+    if (radioModel && !panId.isEmpty()) {
+        for (SliceModel* candidate : radioModel->slices()) {
+            if (candidate && candidate->panId() == panId) {
+                return candidate;
+            }
+        }
+    }
+
+    return currentSlice;
+}
+
 static QString rateSliderLabelText(int sliderValue)
 {
     return QString::number(sliderValue);
+}
+
+static QString kiwiWaterfallDbText(int db)
+{
+    return QStringLiteral("%1%2 dB")
+        .arg(db >= 0 ? QStringLiteral("+") : QString())
+        .arg(db);
+}
+
+static QString kiwiWaterfallRateText(int rate)
+{
+    return rate <= 0 ? QStringLiteral("Auto") : QString::number(rate);
 }
 
 static constexpr int lineDurationToRateSliderValue(int lineDuration)
@@ -409,11 +441,26 @@ void SpectrumOverlayMenu::buildAntPanel()
             ant = m_rxAntCmb->itemText(index);
         if (ant.isEmpty())
             return;
+        const QString profileId = m_kiwiSdrManager
+            ? m_kiwiSdrManager->profileIdForVirtualAntennaToken(ant)
+            : QString();
+        SliceModel* targetSlice =
+            antennaTargetSliceForPan(m_radioModel, m_slice, m_panId);
+        if (!profileId.isEmpty()) {
+            if (targetSlice) {
+                emit kiwiRxAntennaSelected(targetSlice->sliceId(), profileId);
+            }
+            updateLoopButtonVisibility();
+            return;
+        }
+        if (targetSlice) {
+            emit flexRxAntennaSelected(targetSlice->sliceId());
+        }
         if (m_radioModel && !m_panId.isEmpty()) {
             m_radioModel->sendCommand(
                 QStringLiteral("display pan set %1 rxant=%2").arg(m_panId, ant));
-        } else if (m_slice) {
-            m_slice->setRxAntenna(ant);
+        } else if (targetSlice) {
+            targetSlice->setRxAntenna(ant);
         }
         updateLoopButtonVisibility();
     });
@@ -605,6 +652,25 @@ void SpectrumOverlayMenu::setAntennaList(const QStringList& ants)
     refreshAntennaCombo();
 }
 
+void SpectrumOverlayMenu::setKiwiSdrManager(KiwiSdrManager* manager)
+{
+    if (m_kiwiSdrManager) {
+        disconnect(m_kiwiSdrManager, nullptr, this, nullptr);
+    }
+    m_kiwiSdrManager = manager;
+    if (m_kiwiSdrManager) {
+        connect(m_kiwiSdrManager, &KiwiSdrManager::profilesChanged,
+                this, &SpectrumOverlayMenu::refreshAntennaCombo);
+        connect(m_kiwiSdrManager, &KiwiSdrManager::sliceAssignmentChanged,
+                this, [this](int sliceId, const QString&) {
+            if (!m_slice || m_slice->sliceId() == sliceId) {
+                refreshAntennaCombo();
+            }
+        });
+    }
+    refreshAntennaCombo();
+}
+
 void SpectrumOverlayMenu::setPanId(const QString& id)
 {
     if (m_panId == id)
@@ -680,10 +746,19 @@ void SpectrumOverlayMenu::wirePanadapterRxAntenna()
 
 QString SpectrumOverlayMenu::currentRxAntennaToken() const
 {
+    SliceModel* targetSlice =
+        antennaTargetSliceForPan(m_radioModel, m_slice, m_panId);
+    if (m_kiwiSdrManager && targetSlice) {
+        const QString profileId =
+            m_kiwiSdrManager->assignedProfileForSlice(targetSlice->sliceId());
+        if (!profileId.isEmpty()) {
+            return m_kiwiSdrManager->virtualAntennaToken(profileId);
+        }
+    }
     if (m_panadapter && !m_panadapter->rxAntenna().isEmpty())
         return m_panadapter->rxAntenna();
-    if (m_slice)
-        return m_slice->rxAntenna();
+    if (targetSlice)
+        return targetSlice->rxAntenna();
     return m_rxAntCmb ? m_rxAntCmb->currentData().toString() : QString();
 }
 
@@ -692,15 +767,18 @@ void SpectrumOverlayMenu::refreshAntennaCombo()
     if (!m_rxAntCmb)
         return;
     const QString cur = currentRxAntennaToken();
+    QStringList options = m_antList;
+    if (m_kiwiSdrManager) {
+        for (const QString& token : m_kiwiSdrManager->virtualAntennaTokens()) {
+            if (!options.contains(token)) {
+                options.append(token);
+            }
+        }
+    }
     QSignalBlocker sb(m_rxAntCmb);
     m_rxAntCmb->clear();
-    for (const QString& ant : m_antList) {
-        const bool disambiguate = m_radioModel
-            && m_radioModel->antennaAliasNeedsDisambiguation(ant, m_antList);
-        const QString label = m_radioModel
-            ? m_radioModel->antennaDisplayName(ant, disambiguate)
-            : ant;
-        m_rxAntCmb->addItem(label, ant);
+    for (const QString& ant : options) {
+        m_rxAntCmb->addItem(antennaComboLabel(ant, options), ant);
     }
     setRxAntennaComboToken(cur);
     updateLoopButtonVisibility();
@@ -720,11 +798,29 @@ void SpectrumOverlayMenu::setRxAntennaComboToken(const QString& token)
     updateLoopButtonVisibility();
 }
 
+QString SpectrumOverlayMenu::antennaComboLabel(const QString& token,
+                                               const QStringList& options) const
+{
+    if (m_kiwiSdrManager) {
+        const QString profileId =
+            m_kiwiSdrManager->profileIdForVirtualAntennaToken(token);
+        if (!profileId.isEmpty()) {
+            return m_kiwiSdrManager->displayName(profileId);
+        }
+    }
+    if (!m_radioModel) {
+        return token;
+    }
+    return m_radioModel->antennaDisplayName(
+        token, m_radioModel->antennaAliasNeedsDisambiguation(token, options));
+}
+
 void SpectrumOverlayMenu::setSlice(SliceModel* slice)
 {
     if (m_slice)
         m_slice->disconnect(this);
     m_slice = slice;
+    refreshAntennaCombo();
     if (!m_slice) return;
 
     connect(m_slice, &SliceModel::rxAntennaChanged, this, [this](const QString& ant) {
@@ -1205,7 +1301,17 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     makeRowWithBtn("Black Level:", 0, 100, 50, m_blackSlider, m_blackLabel,
                    m_autoBlackBtn, "SW");
     connect(m_blackSlider, &QSlider::valueChanged, this, [this](int v) {
-        m_blackLabel->setText(QString::number(v));
+        m_blackLabel->setText(m_kiwiWaterfallControlMode
+            ? kiwiWaterfallDbText(v)
+            : QString::number(v));
+        if (m_kiwiWaterfallControlMode) {
+            if (m_autoBlackBtn && m_autoBlackBtn->isChecked() && v != 0) {
+                QSignalBlocker blocker(m_autoBlackBtn);
+                m_autoBlackBtn->setChecked(false);
+            }
+            emit kiwiWaterfallFloorChanged(v);
+            return;
+        }
         if (m_autoBlackMode != 0) {      // Auto-C / Auto-R → bias the offset
             m_blackAutoOffsetValue = v;
             emit wfAutoBlackOffsetChanged(v);
@@ -1215,9 +1321,25 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         }
     });
     // One click advances the 3-way mode: Off → Auto-C → Auto-R → Off.
-    // applyAutoBlackMode swaps the slider role, updates the label/highlight, and
-    // emits the on/off + client/radio-source signals together.
+    // In Kiwi mode the same button resets the Kiwi waterfall floor to its
+    // automatic baseline instead of changing the Flex auto-black source.
     connect(m_autoBlackBtn, &QPushButton::clicked, this, [this]() {
+        if (m_kiwiWaterfallControlMode) {
+            if (m_blackSlider) {
+                QSignalBlocker blocker(m_blackSlider);
+                m_blackSlider->setValue(0);
+                if (m_blackLabel) {
+                    m_blackLabel->setText(kiwiWaterfallDbText(0));
+                }
+                emit kiwiWaterfallFloorChanged(0);
+            }
+            if (m_autoBlackBtn) {
+                QSignalBlocker blocker(m_autoBlackBtn);
+                m_autoBlackBtn->setChecked(true);
+            }
+            return;
+        }
+
         applyAutoBlackMode((m_autoBlackMode + 1) % 3, /*emitSignals=*/true);
     });
     applyAutoBlackMode(m_autoBlackMode, /*emitSignals=*/false);  // initial label/slider role
@@ -1225,7 +1347,13 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     // Gain
     makeRow("WtrFall Gain:", 0, 100, 50, m_gainSlider, m_gainLabel);
     connect(m_gainSlider, &QSlider::valueChanged, this, [this](int v) {
-        m_gainLabel->setText(QString::number(v));
+        m_gainLabel->setText(m_kiwiWaterfallControlMode
+            ? kiwiWaterfallDbText(v)
+            : QString::number(v));
+        if (m_kiwiWaterfallControlMode) {
+            emit kiwiWaterfallCellChanged(v);
+            return;
+        }
         emit wfColorGainChanged(v);
     });
 
@@ -1252,6 +1380,11 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     m_rateSlider->setInvertedAppearance(false);
     m_rateSlider->setInvertedControls(false);
     connect(m_rateSlider, &QSlider::valueChanged, this, [this](int v) {
+        if (m_kiwiWaterfallControlMode) {
+            m_rateLabel->setText(kiwiWaterfallRateText(v));
+            emit kiwiWaterfallRateChanged(v);
+            return;
+        }
         const int lineDurationMs = rateSliderValueToLineDuration(v);
         m_rateLabel->setText(rateSliderLabelText(v));
         emit wfLineDurationChanged(lineDurationMs);
@@ -1495,6 +1628,8 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
                    b4(m_weightedAvgBtn), b5(m_gainSlider), b6(m_blackSlider),
                    b7(m_autoBlackBtn), b8(m_rateSlider);
 
+    setKiwiWaterfallControlMode(false);
+
     m_avgSlider->setValue(avg);
     m_avgLabel->setText(QString::number(avg));
     m_fpsSlider->setValue(fps);
@@ -1544,6 +1679,71 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
     }
 }
 
+void SpectrumOverlayMenu::setKiwiWaterfallControlMode(bool kiwiMode)
+{
+    if (m_kiwiWaterfallControlMode == kiwiMode) {
+        return;
+    }
+
+    m_kiwiWaterfallControlMode = kiwiMode;
+    if (m_gainSlider) {
+        m_gainSlider->setRange(kiwiMode ? -30 : 0, kiwiMode ? 30 : 100);
+        m_gainSlider->setToolTip(kiwiMode
+            ? "KiwiSDR waterfall cell adjustment, -30 to +30 dB."
+            : "Waterfall color gain.");
+    }
+    if (m_blackSlider) {
+        m_blackSlider->setRange(kiwiMode ? -30 : 0, kiwiMode ? 30 : 100);
+        m_blackSlider->setToolTip(kiwiMode
+            ? "KiwiSDR waterfall floor adjustment, -30 to +30 dB."
+            : (m_autoBlackBtn && m_autoBlackBtn->isChecked()
+                   ? "Auto-black target offset. 50 = at noise floor; lower = darker, higher = lighter."
+                   : "Waterfall black level. Decrease to darken the noise floor."));
+    }
+    if (m_rateSlider) {
+        m_rateSlider->setRange(kiwiMode ? 0 : WF_RATE_SLIDER_MIN,
+                               kiwiMode ? 5 : WF_RATE_SLIDER_MAX);
+        m_rateSlider->setToolTip(kiwiMode
+            ? "KiwiSDR waterfall rate. Auto follows the Flex waterfall rate."
+            : "Waterfall rate.");
+    }
+    if (m_autoBlackBtn) {
+        m_autoBlackBtn->setToolTip(kiwiMode
+            ? "Reset KiwiSDR waterfall floor to automatic baseline."
+            : "Use the measured noise floor for waterfall black level.");
+        if (kiwiMode) {
+            m_autoBlackBtn->setCheckable(true);
+            m_autoBlackBtn->setText("Auto");
+        } else {
+            applyAutoBlackMode(m_autoBlackMode, /*emitSignals=*/false);
+        }
+    }
+}
+
+void SpectrumOverlayMenu::syncKiwiWaterfallSettings(int cellDb, int floorDb,
+                                                    int rate)
+{
+    if (!m_gainSlider || !m_blackSlider || !m_rateSlider) {
+        return;
+    }
+
+    const int clampedCell = std::clamp(cellDb, -30, 30);
+    const int clampedFloor = std::clamp(floorDb, -30, 30);
+    const int clampedRate = std::clamp(rate, 0, 5);
+    QSignalBlocker b1(m_gainSlider), b2(m_blackSlider),
+                   b3(m_rateSlider), b4(m_autoBlackBtn);
+
+    setKiwiWaterfallControlMode(true);
+
+    m_gainSlider->setValue(clampedCell);
+    m_gainLabel->setText(kiwiWaterfallDbText(clampedCell));
+    m_blackSlider->setValue(clampedFloor);
+    m_blackLabel->setText(kiwiWaterfallDbText(clampedFloor));
+    m_autoBlackBtn->setChecked(clampedFloor == 0);
+    m_rateSlider->setValue(clampedRate);
+    m_rateLabel->setText(kiwiWaterfallRateText(clampedRate));
+}
+
 void SpectrumOverlayMenu::syncNoiseFloorPosition(int pos)
 {
     if (!m_floorSlider) return;
@@ -1559,6 +1759,9 @@ void SpectrumOverlayMenu::syncNoiseFloorPosition(int pos)
 void SpectrumOverlayMenu::syncWfLineDuration(int rate)
 {
     if (!m_rateSlider || !m_rateLabel) {
+        return;
+    }
+    if (m_kiwiWaterfallControlMode) {
         return;
     }
 

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -19,6 +19,7 @@ class QLabel;
 namespace AetherSDR {
 
 class MemoryBrowsePanel;
+class KiwiSdrManager;
 class SliceModel;
 
 // Floating overlay menu anchored to the top-left of the SpectrumWidget.
@@ -36,6 +37,7 @@ public:
 
     // Set the antenna list (from RadioModel::antListChanged).
     void setAntennaList(const QStringList& ants);
+    void setKiwiSdrManager(KiwiSdrManager* manager);
     void setRadioModel(RadioModel* model);
 
     // Sync Display sub-panel controls with saved settings.  The Black slider
@@ -51,6 +53,7 @@ public:
                              float lineWidth = 2.0f,
                              bool autoBlackRadioSide = false);
     void syncWfLineDuration(int rate);
+    void syncKiwiWaterfallSettings(int cellDb, int floorDb, int rate);
     // Sync blanker/cursor/opacity controls not covered by syncDisplaySettings.
     void syncExtraDisplaySettings(bool blankerOn, float blankerThresh,
                                   int bgOpacity,
@@ -126,6 +129,9 @@ signals:
     // Auto-black source: false = client-side estimate (default), true = radio.
     void wfAutoBlackSourceChanged(bool radioSide);
     void wfLineDurationChanged(int ms);
+    void kiwiWaterfallCellChanged(int cellDb);
+    void kiwiWaterfallFloorChanged(int floorDb);
+    void kiwiWaterfallRateChanged(int rate);
     void wfColorSchemeChanged(int scheme);
     void noiseFloorPositionChanged(int pos);
     void noiseFloorEnableChanged(bool on);
@@ -146,6 +152,8 @@ signals:
     void rfGainChanged(int gain);
     void swrSweepStartRequested(int sliceId, int sweepPowerWatts);
     void swrSweepClearRequested();
+    void kiwiRxAntennaSelected(int sliceId, const QString& profileId);
+    void flexRxAntennaSelected(int sliceId);
     // NB Waterfall Blanker (#277)
     void wfBlankerEnabledChanged(bool on);
     void wfBlankerThresholdChanged(float threshold);
@@ -162,6 +170,7 @@ private:
     QPointer<PanadapterModel> m_panadapter;
     QMetaObject::Connection m_panRxAntennaConnection;
     QMetaObject::Connection m_panLoopConnection;
+    void setKiwiWaterfallControlMode(bool kiwiMode);
     void toggle();
     void updateLayout();
     void toggleBandPanel();
@@ -182,6 +191,7 @@ private:
     void refreshAntennaCombo();
     void setRxAntennaComboToken(const QString& token);
     QString currentRxAntennaToken() const;
+    QString antennaComboLabel(const QString& token, const QStringList& options) const;
     void updateLoopButtonVisibility();
 
     static constexpr int kBtnAddRx = 0;
@@ -268,6 +278,7 @@ private:
     QComboBox*   m_colorSchemeCmb{nullptr};
     QSlider*     m_rateSlider{nullptr};
     QLabel*      m_rateLabel{nullptr};
+    bool         m_kiwiWaterfallControlMode{false};
     // NB Waterfall Blanker (#277)
     QPushButton* m_wfBlankerBtn{nullptr};
     QSlider*     m_wfBlankerThreshSlider{nullptr};
@@ -284,6 +295,7 @@ private:
 
     QStringList  m_antList;
     RadioModel*  m_radioModel{nullptr};
+    QPointer<KiwiSdrManager> m_kiwiSdrManager;
     QPointer<SliceModel> m_slice;
     bool         m_updatingFromModel{false};
     int          m_lastEmittedRfGain{INT_MIN};  // dedupe rfgain emits across drag snap ticks (#1498)

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -15,6 +15,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QResizeEvent>
+#include <QScopeGuard>
 #include <QMouseEvent>
 #include <QWheelEvent>
 #include <QNativeGestureEvent>
@@ -40,6 +41,7 @@
 #include <QStringList>
 #include <QUrl>
 #include "core/AppSettings.h"
+#include "core/KiwiSdrProtocol.h"
 #include "InteractionSettings.h"
 #include "models/BandPlanManager.h"
 #include "models/BandDefs.h"
@@ -70,6 +72,8 @@ static constexpr int kWaterfallLineDurationMaxMs = 100;
 static constexpr int kWaterfallHistoryCapacityMsPerRow = 50;
 static constexpr int kWaterfallRatePercentMin = 1;
 static constexpr int kWaterfallRatePercentMax = 100;
+static constexpr float kKiwiSdrWaterfallMinDbm = -130.0f;
+static constexpr float kKiwiSdrWaterfallMaxDbm = 0.0f;
 static constexpr int kNativeWaterfallFallbackMinTimeoutMs = 2000;
 static constexpr int kNativeWaterfallFallbackMaxTimeoutMs = 20000;
 static constexpr int kNativeWaterfallRateChangeGraceMaxMs = 14000;
@@ -681,6 +685,7 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         " border-radius: 2px; color: #90a0b0; font-size: 11px; font-weight: bold;"
         " padding: 0; margin: 0; min-width: 0; }"
         "QPushButton:hover { background: rgba(30,50,70,200); color: #c8d8e8; }"
+        "QPushButton:checked { background: rgba(0,180,216,210); color: #000; }"
         "QPushButton:pressed { background: #00b4d8; color: #000; }";
 
     auto makeBtn = [&](const QString& text) {
@@ -722,7 +727,8 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         }
         newCenter = std::max(newCenter, newBw / 2.0);
 
-        reprojectWaterfall(m_centerMhz, m_bandwidthMhz, newCenter, newBw);
+        handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
+                                            newCenter, newBw);
         if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, newCenter, newBw)) {
             m_bins.clear();
             m_smoothed.clear();
@@ -1038,8 +1044,8 @@ void SpectrumWidget::setNoiseFloorPosition(int pos) {
     m_pendingDbmRangeEchoStartMs = 0;
     refreshNoiseFloorTarget();
     if (m_noiseFloorEnable) {
-        if (!m_noiseFloorBaselineValid && (!m_smoothed.isEmpty() || !m_bins.isEmpty())) {
-            const QVector<float>& baselineBins = !m_smoothed.isEmpty() ? m_smoothed : m_bins;
+        const QVector<float>& baselineBins = noiseFloorAutoLevelBins();
+        if (!m_noiseFloorBaselineValid && !baselineBins.isEmpty()) {
             const float baselineDbm = estimateNoiseFloorDbm(baselineBins);
             if (baselineDbm > -500.0f) {
                 m_noiseFloorBaselineDbm = baselineDbm;
@@ -1085,6 +1091,28 @@ void SpectrumWidget::reacquireNoiseFloorLock() {
     // long enough for the antenna change to settle through the radio.
     armNoiseFloorFastLock(30, 1);
     m_measuredNoiseFloorDbm = -1000.0f;
+}
+
+void SpectrumWidget::reacquireNoiseFloorLockFromVisibleSource()
+{
+    reacquireNoiseFloorLock();
+    if (!m_noiseFloorEnable) {
+        return;
+    }
+
+    const QVector<float>& bins = noiseFloorAutoLevelBins();
+    if (bins.isEmpty()) {
+        return;
+    }
+
+    const float frameFloor = estimateNoiseFloorDbm(bins);
+    if (frameFloor > -500.0f) {
+        m_measuredNoiseFloorDbm = frameFloor;
+    }
+    updateNoiseFloorBaseline(bins, true);
+    if (m_noiseFloorFreshFrameCount > 0) {
+        --m_noiseFloorFreshFrameCount;
+    }
 }
 
 void SpectrumWidget::suspendNoiseFloorAutoAdjustUntil(qint64 untilMs)
@@ -1199,8 +1227,10 @@ void SpectrumWidget::applyFpsMeterVisibility(bool on) {
 void SpectrumWidget::resetFpsMeterWindow() {
     m_panadapterFrameCount = 0;
     m_waterfallFrameCount = 0;
+    m_kiwiSdrWaterfallFrameCount = 0;
     m_panadapterFps = 0.0;
     m_waterfallFps = 0.0;
+    m_kiwiSdrWaterfallFps = 0.0;
     m_fpsMeterWindow.restart();
 }
 void SpectrumWidget::updateFpsMeterValues() {
@@ -1217,8 +1247,10 @@ void SpectrumWidget::updateFpsMeterValues() {
     const double scale = 1000.0 / static_cast<double>(elapsedMs);
     m_panadapterFps = m_panadapterFrameCount * scale;
     m_waterfallFps = m_waterfallFrameCount * scale;
+    m_kiwiSdrWaterfallFps = m_kiwiSdrWaterfallFrameCount * scale;
     m_panadapterFrameCount = 0;
     m_waterfallFrameCount = 0;
+    m_kiwiSdrWaterfallFrameCount = 0;
     m_fpsMeterWindow.restart();
     updateFpsMeterLabels();
 }
@@ -1229,6 +1261,10 @@ void SpectrumWidget::recordPanadapterFrame() {
 void SpectrumWidget::recordWaterfallFrame(int rows) {
     if (m_showFpsMeters && rows > 0)
         m_waterfallFrameCount += rows;
+}
+void SpectrumWidget::recordKiwiSdrWaterfallFrame(int rows) {
+    if (m_showFpsMeters && rows > 0)
+        m_kiwiSdrWaterfallFrameCount += rows;
 }
 
 void SpectrumWidget::createFpsMeterLabels() {
@@ -1265,8 +1301,14 @@ void SpectrumWidget::updateFpsMeterLabels() {
         return;
     }
 
-    m_panFpsMeterLabel->setText(QStringLiteral("PAN %1 FPS").arg(m_panadapterFps, 0, 'f', 1));
-    m_wfFpsMeterLabel->setText(QStringLiteral("WF %1 FPS").arg(m_waterfallFps, 0, 'f', 1));
+    const double visibleWaterfallFps = m_kiwiSdrWaterfallActive
+        ? m_kiwiSdrWaterfallFps
+        : m_waterfallFps;
+    const double visiblePanadapterFps = m_kiwiSdrWaterfallActive
+        ? m_kiwiSdrWaterfallFps
+        : m_panadapterFps;
+    m_panFpsMeterLabel->setText(QStringLiteral("PAN %1 FPS").arg(visiblePanadapterFps, 0, 'f', 1));
+    m_wfFpsMeterLabel->setText(QStringLiteral("WF %1 FPS").arg(visibleWaterfallFps, 0, 'f', 1));
     m_panFpsMeterLabel->adjustSize();
     m_wfFpsMeterLabel->adjustSize();
     positionFpsMeterLabels();
@@ -1449,8 +1491,8 @@ bool SpectrumWidget::captureNoiseFloorTargetFromCurrentScale(bool notify, bool p
     }
 
     float baselineDbm = -1000.0f;
-    if (!m_smoothed.isEmpty() || !m_bins.isEmpty()) {
-        const QVector<float>& baselineBins = !m_smoothed.isEmpty() ? m_smoothed : m_bins;
+    const QVector<float>& baselineBins = noiseFloorAutoLevelBins();
+    if (!baselineBins.isEmpty()) {
         baselineDbm = estimateNoiseFloorDbm(baselineBins);
     }
     if (baselineDbm <= -500.0f && m_noiseFloorBaselineValid) {
@@ -2197,7 +2239,7 @@ void SpectrumWidget::updateNativeWaterfallFallbackState(qint64 nowMs)
 
 bool SpectrumWidget::pushRxWaterfallFallbackIfDue(const QVector<float>& bins, qint64 nowMs)
 {
-    if (!m_waterfallFallbackActive || m_waterfall.isNull() || bins.isEmpty()) {
+    if (!m_waterfallFallbackActive || bins.isEmpty()) {
         return false;
     }
     if (m_nextFallbackWaterfallRowMs <= 0) {
@@ -2207,6 +2249,13 @@ bool SpectrumWidget::pushRxWaterfallFallbackIfDue(const QVector<float>& bins, qi
         return false;
     }
 
+    const bool visibleStream = beginWaterfallStreamWrite(false);
+    auto restoreStream = qScopeGuard([&] {
+        endWaterfallStreamWrite(false, visibleStream);
+    });
+    if (m_waterfall.isNull()) {
+        return false;
+    }
     pushWaterfallRow(bins, m_waterfall.width());
     m_nextFallbackWaterfallRowMs = nowMs + waterfallFallbackIntervalMs();
     return true;
@@ -2269,7 +2318,9 @@ void SpectrumWidget::appendVisibleRow(const QRgb* rowData)
         PerfTelemetry::instance().recordWaterfallVisibleRows();
 }
 
-void SpectrumWidget::appendHistoryRow(const QRgb* rowData, qint64 timestampMs)
+void SpectrumWidget::appendHistoryRow(const QRgb* rowData, qint64 timestampMs,
+                                      double frameCenterMhz,
+                                      double frameBandwidthMhz)
 {
     ensureWaterfallHistory();
     if (m_waterfallHistory.isNull() || rowData == nullptr) {
@@ -2286,9 +2337,15 @@ void SpectrumWidget::appendHistoryRow(const QRgb* rowData, qint64 timestampMs)
     }
     // Stamp the frequency frame this row was captured in, so the viewport can
     // remap it later regardless of how the center/bandwidth has since panned.
+    const double stampCenterMhz = (frameCenterMhz > 0.0 && frameBandwidthMhz > 0.0)
+        ? frameCenterMhz
+        : m_centerMhz;
+    const double stampBandwidthMhz = frameBandwidthMhz > 0.0
+        ? frameBandwidthMhz
+        : m_bandwidthMhz;
     if (m_wfHistoryWriteRow >= 0 && m_wfHistoryWriteRow < m_wfHistoryRowCenterMhz.size()) {
-        m_wfHistoryRowCenterMhz[m_wfHistoryWriteRow] = m_centerMhz;
-        m_wfHistoryRowBwMhz[m_wfHistoryWriteRow] = m_bandwidthMhz;
+        m_wfHistoryRowCenterMhz[m_wfHistoryWriteRow] = stampCenterMhz;
+        m_wfHistoryRowBwMhz[m_wfHistoryWriteRow] = stampBandwidthMhz;
     }
     if (m_wfHistoryRowCount < h) {
         ++m_wfHistoryRowCount;
@@ -2305,12 +2362,103 @@ void SpectrumWidget::appendHistoryRow(const QRgb* rowData, qint64 timestampMs)
 // Copy one history scanline into the viewport, remapping its columns from the
 // frame it was captured in (rowCenter/rowBw) to the current frame (curCenter/
 // curBw). When the frames match (no pan/zoom since capture) this is a plain
-// copy; otherwise it is a nearest-neighbour horizontal resample — newly-exposed
-// columns are black. Mirrors reprojectWaterfallImage but per row, so only the
-// ~700 visible rows are touched (on time-scrollback), never the full history.
+// copy; otherwise it is a horizontal resample and newly-exposed columns are
+// black. Kiwi rows can be narrower than the current viewport after a zoom-out,
+// so its path preserves the brightest source pixel covered by each destination
+// column instead of point-sampling carriers out of existence.
+static int waterfallPixelScore(QRgb pixel)
+{
+    const int maxChannel = std::max(qRed(pixel), std::max(qGreen(pixel), qBlue(pixel)));
+    return maxChannel * 1024 + qRed(pixel) + qGreen(pixel) + qBlue(pixel);
+}
+
+static QRgb peakPreservedWaterfallSample(const QRgb* src, int w,
+                                         double srcLeft, double srcRight,
+                                         double srcCenter)
+{
+    if (srcRight <= 0.0 || srcLeft >= static_cast<double>(w)) {
+        return qRgb(0, 0, 0);
+    }
+
+    const double clampedLeft = std::clamp(srcLeft, 0.0, static_cast<double>(w));
+    const double clampedRight = std::clamp(srcRight, 0.0, static_cast<double>(w));
+    if (clampedRight - clampedLeft <= 1.0) {
+        return (srcCenter < 0.0 || srcCenter >= static_cast<double>(w))
+            ? qRgb(0, 0, 0)
+            : src[static_cast<int>(srcCenter)];
+    }
+
+    const int first = std::clamp(static_cast<int>(std::floor(clampedLeft)), 0, w - 1);
+    const int last = std::clamp(static_cast<int>(std::ceil(clampedRight)) - 1, 0, w - 1);
+    QRgb best = src[first];
+    int bestScore = waterfallPixelScore(best);
+    for (int i = first + 1; i <= last; ++i) {
+        const int score = waterfallPixelScore(src[i]);
+        if (score > bestScore) {
+            best = src[i];
+            bestScore = score;
+        }
+    }
+    return best;
+}
+
+static float interpolatedBinSample(const QVector<float>& bins,
+                                   double srcCenter,
+                                   float fallback)
+{
+    const int n = bins.size();
+    if (n <= 0) {
+        return fallback;
+    }
+    if (n == 1) {
+        return std::isfinite(bins[0]) ? bins[0] : fallback;
+    }
+
+    const double clamped = std::clamp(srcCenter, 0.0, static_cast<double>(n - 1));
+    const int left = std::clamp(static_cast<int>(std::floor(clamped)), 0, n - 1);
+    const int right = std::min(left + 1, n - 1);
+    const float leftValue = std::isfinite(bins[left]) ? bins[left] : fallback;
+    const float rightValue = std::isfinite(bins[right]) ? bins[right] : leftValue;
+    const float frac = static_cast<float>(clamped - static_cast<double>(left));
+    return leftValue + frac * (rightValue - leftValue);
+}
+
+static float peakPreservedBinSample(const QVector<float>& bins,
+                                    double srcLeft, double srcRight,
+                                    double srcCenter, float fallback)
+{
+    const int n = bins.size();
+    if (n <= 0 || srcRight <= 0.0 || srcLeft >= static_cast<double>(n)) {
+        return fallback;
+    }
+
+    const double clampedLeft = std::clamp(srcLeft, 0.0, static_cast<double>(n));
+    const double clampedRight = std::clamp(srcRight, 0.0, static_cast<double>(n));
+    if (clampedRight - clampedLeft <= 1.0) {
+        return interpolatedBinSample(bins, srcCenter, fallback);
+    }
+
+    const int first = std::clamp(static_cast<int>(std::floor(clampedLeft)), 0, n - 1);
+    const int last = std::clamp(static_cast<int>(std::ceil(clampedRight)) - 1, 0, n - 1);
+    float best = fallback;
+    bool haveBest = false;
+    for (int i = first; i <= last; ++i) {
+        const float value = bins[i];
+        if (!std::isfinite(value)) {
+            continue;
+        }
+        if (!haveBest || value > best) {
+            best = value;
+            haveBest = true;
+        }
+    }
+    return haveBest ? best : fallback;
+}
+
 static void remapHistoryRowInto(QRgb* dst, const QRgb* src, int w,
                                 double rowCenterMhz, double rowBwMhz,
-                                double curCenterMhz, double curBwMhz)
+                                double curCenterMhz, double curBwMhz,
+                                bool preservePeaks)
 {
     if (rowBwMhz <= 0.0 || curBwMhz <= 0.0
         || (rowCenterMhz == curCenterMhz && rowBwMhz == curBwMhz)) {
@@ -2318,16 +2466,38 @@ static void remapHistoryRowInto(QRgb* dst, const QRgb* src, int w,
         return;
     }
     const double rowStartMhz = rowCenterMhz - rowBwMhz / 2.0;
+    const double rowEndMhz = rowStartMhz + rowBwMhz;
     const double curStartMhz = curCenterMhz - curBwMhz / 2.0;
     for (int x = 0; x < w; ++x) {
         const double freqMhz = curStartMhz + (static_cast<double>(x) + 0.5) / w * curBwMhz;
         const double srcX = (freqMhz - rowStartMhz) / rowBwMhz * w;
-        dst[x] = (srcX < 0.0 || srcX >= w) ? qRgb(0, 0, 0)
-                                           : src[static_cast<int>(srcX)];
+        if (!preservePeaks) {
+            dst[x] = (srcX < 0.0 || srcX >= w) ? qRgb(0, 0, 0)
+                                               : src[static_cast<int>(srcX)];
+            continue;
+        }
+
+        const double freqLeftMhz = curStartMhz
+            + static_cast<double>(x) / w * curBwMhz;
+        const double freqRightMhz = curStartMhz
+            + static_cast<double>(x + 1) / w * curBwMhz;
+        if (freqRightMhz <= rowStartMhz || freqLeftMhz >= rowEndMhz) {
+            dst[x] = qRgb(0, 0, 0);
+            continue;
+        }
+        const double srcLeft = (freqLeftMhz - rowStartMhz) / rowBwMhz * w;
+        const double srcRight = (freqRightMhz - rowStartMhz) / rowBwMhz * w;
+        dst[x] = peakPreservedWaterfallSample(src, w, srcLeft, srcRight, srcX);
     }
 }
 
 void SpectrumWidget::rebuildWaterfallViewport()
+{
+    rebuildWaterfallViewportForFrame(m_centerMhz, m_bandwidthMhz);
+}
+
+void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
+                                                      double bandwidthMhz)
 {
     if (m_waterfall.isNull()) {
         return;
@@ -2354,7 +2524,8 @@ void SpectrumWidget::rebuildWaterfallViewport()
         auto* dst = reinterpret_cast<QRgb*>(m_waterfall.scanLine(y));
         const double rowCenter = haveFrames ? m_wfHistoryRowCenterMhz[rowIndex] : m_centerMhz;
         const double rowBw = haveFrames ? m_wfHistoryRowBwMhz[rowIndex] : m_bandwidthMhz;
-        remapHistoryRowInto(dst, src, w, rowCenter, rowBw, m_centerMhz, m_bandwidthMhz);
+        remapHistoryRowInto(dst, src, w, rowCenter, rowBw, centerMhz, bandwidthMhz,
+                            m_kiwiSdrWaterfallActive);
     }
 
 #ifdef AETHER_GPU_SPECTRUM
@@ -2376,6 +2547,35 @@ void SpectrumWidget::setWaterfallLive(bool live)
     m_wfLive = live;
     rebuildWaterfallViewport();
     markOverlayDirty();
+}
+
+void SpectrumWidget::handleWaterfallFrequencyFrameChange(double oldCenterMhz,
+                                                         double oldBandwidthMhz,
+                                                         double newCenterMhz,
+                                                         double newBandwidthMhz)
+{
+    const bool originalKiwiActive = m_kiwiSdrWaterfallActive;
+
+    auto reprojectStream = [this, oldCenterMhz, oldBandwidthMhz,
+                            newCenterMhz, newBandwidthMhz](bool kiwiStream) {
+        const bool visibleStream = beginWaterfallStreamWrite(kiwiStream);
+        auto restoreStream = qScopeGuard([&] {
+            endWaterfallStreamWrite(kiwiStream, visibleStream);
+        });
+        if (kiwiStream) {
+            m_kiwiSdrLastWaterfallBins.clear();
+        }
+        reprojectWaterfall(oldCenterMhz, oldBandwidthMhz,
+                           newCenterMhz, newBandwidthMhz);
+    };
+
+    reprojectStream(false);
+    reprojectStream(true);
+    if (m_kiwiSdrWaterfallActive != originalKiwiActive) {
+        saveCurrentWaterfallStreamState();
+        m_kiwiSdrWaterfallActive = originalKiwiActive;
+        restoreCurrentWaterfallStreamState();
+    }
 }
 
 int SpectrumWidget::waterfallStripWidth() const
@@ -2406,6 +2606,18 @@ void SpectrumWidget::clearDisplay()
 {
     m_bins.clear();
     m_smoothed.clear();
+    clearWaterfallRows();
+    m_hasNativeWaterfall = false;
+    m_lastNativeTileMs = 0;
+    m_waterfallFallbackActive = false;
+    m_nextFallbackWaterfallRowMs = 0;
+    const int graceMs = nativeWaterfallFallbackHoldMs(waterfallFallbackIntervalMs());
+    m_nativeWaterfallFallbackHoldUntilMs = QDateTime::currentMSecsSinceEpoch() + graceMs;
+    markOverlayDirty();
+}
+
+void SpectrumWidget::clearCurrentWaterfallRows()
+{
     if (!m_waterfall.isNull()) {
         m_waterfall.fill(Qt::black);
     }
@@ -2420,13 +2632,216 @@ void SpectrumWidget::clearDisplay()
     m_wfHistoryRowCount = 0;
     m_wfHistoryOffsetRows = 0;
     m_wfLive = true;
-    m_hasNativeWaterfall = false;
-    m_lastNativeTileMs = 0;
-    m_waterfallFallbackActive = false;
-    m_nextFallbackWaterfallRowMs = 0;
-    const int graceMs = nativeWaterfallFallbackHoldMs(waterfallFallbackIntervalMs());
-    m_nativeWaterfallFallbackHoldUntilMs = QDateTime::currentMSecsSinceEpoch() + graceMs;
-    markOverlayDirty();
+    m_wfRowsSinceRateChange = 0;
+    m_prevTileScanline.clear();
+    m_kiwiSdrFftTrace.clear();
+    m_kiwiSdrLastWaterfallBins.clear();
+    m_kiwiSdrLastWaterfallCenterMhz = 0.0;
+    m_kiwiSdrLastWaterfallBandwidthMhz = 0.0;
+    m_kiwiSdrLastWaterfallFrameValid = false;
+    m_kiwiSdrAutoFloorDbm = kKiwiSdrWaterfallMinDbm;
+    m_kiwiSdrAutoCeilDbm = kKiwiSdrWaterfallMaxDbm;
+    m_kiwiSdrAutoRangeValid = false;
+#ifdef AETHER_GPU_SPECTRUM
+    m_wfTexFullUpload = true;
+#endif
+}
+
+void SpectrumWidget::clearWaterfallRows()
+{
+    clearCurrentWaterfallRows();
+    m_nativeWaterfallState = WaterfallStreamState{};
+    m_kiwiWaterfallState = WaterfallStreamState{};
+    m_kiwiProfileWaterfallStates.clear();
+}
+
+SpectrumWidget::WaterfallStreamState& SpectrumWidget::activeKiwiWaterfallState()
+{
+    if (!m_kiwiSdrWaterfallProfileId.isEmpty()) {
+        return m_kiwiProfileWaterfallStates[m_kiwiSdrWaterfallProfileId];
+    }
+    return m_kiwiWaterfallState;
+}
+
+void SpectrumWidget::saveCurrentWaterfallStreamState()
+{
+    WaterfallStreamState& state = m_kiwiSdrWaterfallActive
+        ? activeKiwiWaterfallState()
+        : m_nativeWaterfallState;
+    state.waterfall = m_waterfall;
+    state.wfWriteRow = m_wfWriteRow;
+    state.waterfallHistory = m_waterfallHistory;
+    state.historyTimestamps = m_wfHistoryTimestamps;
+    state.historyWriteRow = m_wfHistoryWriteRow;
+    state.historyRowCount = m_wfHistoryRowCount;
+    state.historyOffsetRows = m_wfHistoryOffsetRows;
+    state.historyRowCenterMhz = m_wfHistoryRowCenterMhz;
+    state.historyRowBwMhz = m_wfHistoryRowBwMhz;
+    state.live = m_wfLive;
+    state.rowsSinceRateChange = m_wfRowsSinceRateChange;
+    state.prevTileScanline = m_prevTileScanline;
+    state.kiwiFftTrace = m_kiwiSdrFftTrace;
+    state.kiwiLastWaterfallBins = m_kiwiSdrLastWaterfallBins;
+    state.kiwiLastWaterfallCenterMhz = m_kiwiSdrLastWaterfallCenterMhz;
+    state.kiwiLastWaterfallBandwidthMhz = m_kiwiSdrLastWaterfallBandwidthMhz;
+    state.kiwiLastWaterfallFrameValid = m_kiwiSdrLastWaterfallFrameValid;
+    state.kiwiAutoFloorDbm = m_kiwiSdrAutoFloorDbm;
+    state.kiwiAutoCeilDbm = m_kiwiSdrAutoCeilDbm;
+    state.kiwiAutoRangeValid = m_kiwiSdrAutoRangeValid;
+    state.valid = true;
+}
+
+void SpectrumWidget::restoreCurrentWaterfallStreamState()
+{
+    WaterfallStreamState& state = m_kiwiSdrWaterfallActive
+        ? activeKiwiWaterfallState()
+        : m_nativeWaterfallState;
+    const QSize currentSize = m_waterfall.size();
+    const QSize currentHistorySize = m_waterfallHistory.size();
+    if (!state.valid
+        || (!currentSize.isEmpty() && !state.waterfall.isNull()
+            && state.waterfall.size() != currentSize)
+        || (!currentHistorySize.isEmpty() && !state.waterfallHistory.isNull()
+            && state.waterfallHistory.size() != currentHistorySize)) {
+        clearCurrentWaterfallRows();
+        return;
+    }
+
+    if (!state.waterfall.isNull()) {
+        m_waterfall = state.waterfall;
+    }
+    m_wfWriteRow = state.wfWriteRow;
+    if (!state.waterfallHistory.isNull()) {
+        m_waterfallHistory = state.waterfallHistory;
+    }
+    m_wfHistoryTimestamps = state.historyTimestamps;
+    m_wfHistoryWriteRow = state.historyWriteRow;
+    m_wfHistoryRowCount = state.historyRowCount;
+    m_wfHistoryOffsetRows = state.historyOffsetRows;
+    m_wfHistoryRowCenterMhz = state.historyRowCenterMhz;
+    m_wfHistoryRowBwMhz = state.historyRowBwMhz;
+    m_wfLive = state.live;
+    m_wfRowsSinceRateChange = state.rowsSinceRateChange;
+    m_prevTileScanline = state.prevTileScanline;
+    m_kiwiSdrFftTrace = state.kiwiFftTrace;
+    m_kiwiSdrLastWaterfallBins = state.kiwiLastWaterfallBins;
+    m_kiwiSdrLastWaterfallCenterMhz = state.kiwiLastWaterfallCenterMhz;
+    m_kiwiSdrLastWaterfallBandwidthMhz = state.kiwiLastWaterfallBandwidthMhz;
+    m_kiwiSdrLastWaterfallFrameValid = state.kiwiLastWaterfallFrameValid;
+    m_kiwiSdrAutoFloorDbm = state.kiwiAutoFloorDbm;
+    m_kiwiSdrAutoCeilDbm = state.kiwiAutoCeilDbm;
+    m_kiwiSdrAutoRangeValid = state.kiwiAutoRangeValid;
+#ifdef AETHER_GPU_SPECTRUM
+    m_wfTexFullUpload = true;
+#endif
+}
+
+bool SpectrumWidget::beginWaterfallStreamWrite(bool kiwiStream)
+{
+    const bool visibleStream = m_kiwiSdrWaterfallActive == kiwiStream;
+    if (visibleStream) {
+        return true;
+    }
+
+    saveCurrentWaterfallStreamState();
+    m_kiwiSdrWaterfallActive = kiwiStream;
+    restoreCurrentWaterfallStreamState();
+    return false;
+}
+
+void SpectrumWidget::endWaterfallStreamWrite(bool kiwiStream,
+                                             bool visibleStream)
+{
+    if (visibleStream) {
+        return;
+    }
+
+    saveCurrentWaterfallStreamState();
+    m_kiwiSdrWaterfallActive = !kiwiStream;
+    restoreCurrentWaterfallStreamState();
+}
+
+QVector<float> SpectrumWidget::smoothKiwiSdrWaterfallBins(const QVector<float>& bins)
+{
+    if (bins.isEmpty()) {
+        m_kiwiSdrLastWaterfallBins.clear();
+        m_kiwiSdrLastWaterfallFrameValid = false;
+        return {};
+    }
+
+    QVector<float> horizontal(bins.size());
+    if (bins.size() == 1) {
+        horizontal[0] = bins[0];
+    } else {
+        horizontal[0] = 0.75f * bins[0] + 0.25f * bins[1];
+        for (int i = 1; i < bins.size() - 1; ++i) {
+            horizontal[i] = 0.25f * bins[i - 1]
+                + 0.50f * bins[i]
+                + 0.25f * bins[i + 1];
+        }
+        horizontal[bins.size() - 1] =
+            0.25f * bins[bins.size() - 2] + 0.75f * bins[bins.size() - 1];
+    }
+
+    if (m_kiwiSdrLastWaterfallBins.size() == horizontal.size()) {
+        for (int i = 0; i < horizontal.size(); ++i) {
+            horizontal[i] = 0.65f * horizontal[i]
+                + 0.35f * m_kiwiSdrLastWaterfallBins[i];
+        }
+    }
+    m_kiwiSdrLastWaterfallBins = horizontal;
+    return horizontal;
+}
+
+void SpectrumWidget::updateKiwiSdrAutoColorRange(const QVector<float>& bins)
+{
+    const KiwiSdrProtocol::WaterfallAperture aperture =
+        KiwiSdrProtocol::autoWaterfallAperture(bins);
+    if (!aperture.valid) {
+        return;
+    }
+
+    static constexpr float kMinSpanDb = 32.0f;
+    static constexpr float kMaxSpanDb = 120.0f;
+    static constexpr float kSmoothing = 0.10f;
+
+    float candidateFloor = qBound(
+        kKiwiSdrWaterfallMinDbm,
+        aperture.minDbm,
+        kKiwiSdrWaterfallMaxDbm - kMinSpanDb);
+    float candidateCeil = qBound(
+        candidateFloor + kMinSpanDb,
+        aperture.maxDbm,
+        kKiwiSdrWaterfallMaxDbm);
+
+    float candidateSpan = candidateCeil - candidateFloor;
+    if (candidateSpan > kMaxSpanDb) {
+        candidateCeil = candidateFloor + kMaxSpanDb;
+        candidateSpan = kMaxSpanDb;
+    }
+    if (candidateCeil > kKiwiSdrWaterfallMaxDbm) {
+        candidateCeil = kKiwiSdrWaterfallMaxDbm;
+    }
+    if (candidateCeil - candidateFloor < kMinSpanDb) {
+        candidateFloor = qMax(kKiwiSdrWaterfallMinDbm,
+                              candidateCeil - kMinSpanDb);
+    }
+
+    if (!m_kiwiSdrAutoRangeValid) {
+        m_kiwiSdrAutoFloorDbm = candidateFloor;
+        m_kiwiSdrAutoCeilDbm = candidateCeil;
+        m_kiwiSdrAutoRangeValid = true;
+        return;
+    }
+
+    m_kiwiSdrAutoFloorDbm += kSmoothing
+        * (candidateFloor - m_kiwiSdrAutoFloorDbm);
+    m_kiwiSdrAutoCeilDbm += kSmoothing
+        * (candidateCeil - m_kiwiSdrAutoCeilDbm);
+    if (m_kiwiSdrAutoCeilDbm - m_kiwiSdrAutoFloorDbm < kMinSpanDb) {
+        m_kiwiSdrAutoFloorDbm = qMax(kKiwiSdrWaterfallMinDbm,
+                                     m_kiwiSdrAutoCeilDbm - kMinSpanDb);
+    }
 }
 
 void SpectrumWidget::setConnectionAnimationVisible(bool on, const QString& label)
@@ -2450,6 +2865,20 @@ void SpectrumWidget::setConnectionAnimationVisible(bool on, const QString& label
         m_connectionAnimationLabel.clear();
         m_connectionAnimationTimer->stop();
     }
+    markOverlayDirty();
+}
+
+void SpectrumWidget::setKiwiSdrConnectionOverlay(bool visible,
+                                                 const QString& detail)
+{
+    const QString trimmedDetail = detail.trimmed();
+    if (m_kiwiSdrConnectionOverlayVisible == visible
+        && m_kiwiSdrConnectionOverlayDetail == trimmedDetail) {
+        return;
+    }
+
+    m_kiwiSdrConnectionOverlayVisible = visible;
+    m_kiwiSdrConnectionOverlayDetail = trimmedDetail;
     markOverlayDirty();
 }
 
@@ -2637,6 +3066,67 @@ void SpectrumWidget::drawConnectionAnimation(QPainter& p, const QRect& contentRe
     p.restore();
 }
 
+void SpectrumWidget::drawKiwiSdrConnectionOverlay(QPainter& p,
+                                                  const QRect& contentRect)
+{
+    if (!m_kiwiSdrConnectionOverlayVisible || contentRect.width() < 160
+        || contentRect.height() < 80) {
+        return;
+    }
+
+    const QString title = QStringLiteral("Not connected to KiwiSDR");
+    const QString detail = m_kiwiSdrConnectionOverlayDetail.isEmpty()
+        ? QStringLiteral("Disconnected")
+        : m_kiwiSdrConnectionOverlayDetail;
+
+    QFont titleFont = p.font();
+    titleFont.setPointSize(15);
+    titleFont.setBold(true);
+    QFont detailFont = titleFont;
+    detailFont.setPointSize(10);
+    detailFont.setBold(false);
+
+    const QFontMetrics titleFm(titleFont);
+    const QFontMetrics detailFm(detailFont);
+    const int maxTextWidth =
+        qMax(120, qMin(contentRect.width() - 48, 460));
+    const QRect titleBounds = titleFm.boundingRect(
+        QRect(0, 0, maxTextWidth, 200),
+        Qt::AlignCenter | Qt::TextWordWrap,
+        title);
+    const QRect detailBounds = detailFm.boundingRect(
+        QRect(0, 0, maxTextWidth, 240),
+        Qt::AlignCenter | Qt::TextWordWrap,
+        detail);
+    const int boxW =
+        qBound(180, qMax(titleBounds.width(), detailBounds.width()) + 40,
+               qMax(180, contentRect.width() - 32));
+    const int boxH = titleBounds.height() + detailBounds.height() + 34;
+    const QRect box(contentRect.center().x() - boxW / 2,
+                    contentRect.center().y() - boxH / 2,
+                    boxW, boxH);
+
+    p.save();
+    p.setRenderHint(QPainter::Antialiasing, true);
+    p.setPen(QPen(AetherSDR::theme::withAlpha("color.accent.warning", 210), 1));
+    p.setBrush(AetherSDR::theme::withAlpha("color.background.0", 220));
+    p.drawRoundedRect(box, 6, 6);
+
+    p.setFont(titleFont);
+    p.setPen(AetherSDR::ThemeManager::instance().color("color.text.primary"));
+    QRect textRect = box.adjusted(16, 10, -16, -10);
+    const QRect titleRect(textRect.left(), textRect.top(),
+                          textRect.width(), titleBounds.height() + 4);
+    p.drawText(titleRect, Qt::AlignCenter | Qt::TextWordWrap, title);
+
+    p.setFont(detailFont);
+    p.setPen(AetherSDR::ThemeManager::instance().color("color.text.secondary"));
+    const QRect detailRect(textRect.left(), titleRect.bottom() + 4,
+                           textRect.width(), detailBounds.height() + 6);
+    p.drawText(detailRect, Qt::AlignCenter | Qt::TextWordWrap, detail);
+    p.restore();
+}
+
 void SpectrumWidget::resetGpuResources()
 {
 #ifdef AETHER_GPU_SPECTRUM
@@ -2704,18 +3194,23 @@ void SpectrumWidget::reprojectWaterfall(double oldCenterMhz, double oldBandwidth
         return;
     }
 
-    // Visible waterfall: reproject immediately — it is on screen and is only a
-    // few hundred rows (~3 ms at ultrawide).
-    reprojectWaterfallImage(m_waterfall, oldCenterMhz, oldBandwidthMhz,
-                            newCenterMhz, newBandwidthMhz);
+    // Prefer the per-row history. Rows can be captured across several pan/zoom
+    // frames, especially when switching between native and Kiwi waterfall data;
+    // rebuilding from stamped history preserves each row's own frequency frame.
+    if (!m_waterfallHistory.isNull() && m_wfHistoryRowCount > 0) {
+        rebuildWaterfallViewportForFrame(newCenterMhz, newBandwidthMhz);
+    } else {
+        reprojectWaterfallImage(m_waterfall, oldCenterMhz, oldBandwidthMhz,
+                                newCenterMhz, newBandwidthMhz);
+    }
     m_prevTileScanline.clear();
 #ifdef AETHER_GPU_SPECTRUM
     m_wfTexFullUpload = true;
 #endif
 
     // History image is intentionally NOT reprojected here: each row carries its
-    // own capture frame (m_wfHistoryRowCenterMhz/BwMhz) and is remapped lazily —
-    // only the visible rows, only on time-scrollback — in rebuildWaterfallViewport.
+    // own capture frame (m_wfHistoryRowCenterMhz/BwMhz) and is remapped on
+    // demand into the current visible viewport.
 }
 
 bool SpectrumWidget::reprojectSpectrum(double oldCenterMhz, double oldBandwidthMhz,
@@ -2824,8 +3319,10 @@ void SpectrumWidget::setFrequencyRange(double centerMhz, double bandwidthMhz)
             m_panCenterAnim->stop();
         }
         if (oldBandwidthMhz > 0.0 && bandwidthMhz > 0.0) {
-            reprojectWaterfall(waterfallFrameCenterMhz, oldBandwidthMhz,
-                               centerMhz, bandwidthMhz);
+            handleWaterfallFrequencyFrameChange(waterfallFrameCenterMhz,
+                                                oldBandwidthMhz,
+                                                centerMhz,
+                                                bandwidthMhz);
         }
         const bool keptSpectrum = reprojectSpectrum(oldCenterMhz, oldBandwidthMhz,
                                                     centerMhz, bandwidthMhz);
@@ -2838,6 +3335,7 @@ void SpectrumWidget::setFrequencyRange(double centerMhz, double bandwidthMhz)
         m_panCenterTarget = centerMhz;
         resetNoiseFloorBaseline();
         markOverlayDirty();
+        emit frequencyRangeChanged(m_centerMhz, m_bandwidthMhz);
         return;
     }
 
@@ -2868,8 +3366,10 @@ void SpectrumWidget::setFrequencyRange(double centerMhz, double bandwidthMhz)
     // center animation lands. During rapid edge-follow retargets the waterfall
     // image is already in the previous target's coordinate frame, so reproject
     // from m_panCenterTarget rather than the mid-animation visual center.
-    reprojectWaterfall(waterfallSourceCenterMhz, m_bandwidthMhz,
-                       centerMhz, m_bandwidthMhz);
+    handleWaterfallFrequencyFrameChange(waterfallSourceCenterMhz,
+                                        m_bandwidthMhz,
+                                        centerMhz,
+                                        m_bandwidthMhz);
 
     m_panCenterTarget = centerMhz;
 
@@ -2900,6 +3400,7 @@ void SpectrumWidget::setFrequencyRange(double centerMhz, double bandwidthMhz)
     m_panCenterAnim->setEndValue(centerMhz);
     m_panCenterAnim->setDuration(110);
     m_panCenterAnim->start();
+    emit frequencyRangeChanged(centerMhz, m_bandwidthMhz);
 }
 
 void SpectrumWidget::setSpectrumFrac(float f)
@@ -3410,36 +3911,34 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
     }
     m_bins = *spectrumBins;
 
-    // ── Live noise floor measurement (two-pass trimmed mean) ─────────────
-    // Same technique as the waterfall auto-black: compute the mean of ALL bins,
-    // then average only the bins at-or-below that mean.  Signal peaks inflate
-    // the first-pass mean and therefore exclude themselves from the second pass,
-    // leaving only the "consistently low, close-in-value" noise bins — exactly
-    // the flat green line a human eye reads as the noise floor on the scope.
-    // This is robust even on a very crowded band (40-50% bins occupied).
-    if (!spectrumBins->isEmpty()) {
-        const float frameFloor = estimateNoiseFloorDbm(*spectrumBins);
-        constexpr float kAlpha = 0.05f;  // ~20-frame window ≈ 0.8 s at 25 fps
-        m_measuredNoiseFloorDbm = (m_measuredNoiseFloorDbm <= -500.0f)
-            ? frameFloor
-            : m_measuredNoiseFloorDbm * (1.0f - kAlpha) + frameFloor * kAlpha;
-    }
+    if (!m_kiwiSdrWaterfallActive) {
+        // ── Live noise floor measurement (two-pass trimmed mean) ─────────
+        // Same technique as the waterfall auto-black: compute the mean of ALL
+        // bins, then average only the bins at-or-below that mean. Signal peaks
+        // inflate the first-pass mean and therefore exclude themselves from the
+        // second pass, leaving only the flat noise baseline a human eye reads
+        // as the noise floor on the scope.
+        if (!spectrumBins->isEmpty()) {
+            const float frameFloor = estimateNoiseFloorDbm(*spectrumBins);
+            constexpr float kAlpha = 0.05f;  // ~20-frame window ≈ 0.8 s at 25 fps
+            m_measuredNoiseFloorDbm = (m_measuredNoiseFloorDbm <= -500.0f)
+                ? frameFloor
+                : m_measuredNoiseFloorDbm * (1.0f - kAlpha)
+                    + frameFloor * kAlpha;
+        }
 
-    // Noise-floor auto-adjust (the existing Display → Floor slider).
-    // Per-frame baseline tracking with asymmetric smoothing (fast on
-    // drops, slow on rises) and a candidate-state transient filter so
-    // brief upward spikes — lightning crashes, key-up edge clicks —
-    // don't pull the lock.  Pans m_refLevel to keep the smoothed floor
-    // at m_noiseFloorPosition; span stays fixed (replaces the earlier
-    // zoom-when-floor-moves behaviour that changed signal visual heights
-    // every time the floor drifted).  Algorithm cherry-picked from
-    // rfoust's PR #2643 work and consolidated into this existing path.
-    const bool useFreshLockFrame =
-        m_noiseFloorFreshFrameCount > 0 && !spectrumBins->isEmpty();
-    const bool noiseFloorFrameConsumed =
-        updateNoiseFloorBaseline(useFreshLockFrame ? *spectrumBins : m_smoothed,
-                                 useFreshLockFrame);
-    if (useFreshLockFrame && noiseFloorFrameConsumed) --m_noiseFloorFreshFrameCount;
+        // Noise-floor auto-adjust (Display → Floor slider) follows the visible
+        // FFT source. Native Flex FFT frames drive it only while Flex is visible;
+        // Kiwi rows update it from the Kiwi-derived FFT trace below.
+        const bool useFreshLockFrame =
+            m_noiseFloorFreshFrameCount > 0 && !spectrumBins->isEmpty();
+        const bool noiseFloorFrameConsumed =
+            updateNoiseFloorBaseline(useFreshLockFrame ? *spectrumBins : m_smoothed,
+                                     useFreshLockFrame);
+        if (useFreshLockFrame && noiseFloorFrameConsumed) {
+            --m_noiseFloorFreshFrameCount;
+        }
+    }
 
     // ── Auto-squelch: own two-pass trimmed-mean noise floor ───────────────
     // Independent copy of the floor measurement — not borrowed from the
@@ -3486,8 +3985,14 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
         // the same paced FFT rows and TX filter mask; unrelated pans keep their
         // native waterfall path.
         const bool txAffectsPan = txWaterfallAffectsThisPan();
-        if (txAffectsPan && m_showTxInWaterfall && !m_waterfall.isNull()) {
-            pushWaterfallRow(*spectrumBins, m_waterfall.width());
+        if (txAffectsPan && m_showTxInWaterfall) {
+            const bool visibleStream = beginWaterfallStreamWrite(false);
+            auto restoreStream = qScopeGuard([&] {
+                endWaterfallStreamWrite(false, visibleStream);
+            });
+            if (!m_waterfall.isNull()) {
+                pushWaterfallRow(*spectrumBins, m_waterfall.width());
+            }
         } else if (!txAffectsPan) {
             const qint64 now = QDateTime::currentMSecsSinceEpoch();
             updateNativeWaterfallFallbackState(now);
@@ -3526,6 +4031,10 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     PerfUpdateScope perfScope(PerfUpdateScope::Kind::Waterfall);
     // Native waterfall tiles carry intensity values (int16/128.0f, ~96-120 on HF).
     if (binsIntensity.isEmpty()) return;
+    const bool visibleStream = beginWaterfallStreamWrite(false);
+    auto restoreStream = qScopeGuard([&] {
+        endWaterfallStreamWrite(false, visibleStream);
+    });
 
     // Forward to GPU renderer (#502)
 
@@ -3696,7 +4205,213 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     if (PerfTelemetry::instance().enabled())
         PerfTelemetry::instance().recordWaterfallNativeRows(rowsToPush);
 
+    if (visibleStream) {
+        leanCappedUpdate();
+    }
+}
+
+void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
+{
+    if (m_kiwiSdrWaterfallActive == active) {
+        return;
+    }
+
+    saveCurrentWaterfallStreamState();
+    m_kiwiSdrWaterfallActive = active;
+    restoreCurrentWaterfallStreamState();
+    if (!active) {
+        m_pendingDbmRangeEcho = false;
+        m_pendingDbmRangeEchoFromAutoFloor = false;
+        m_pendingDbmRangeEchoStartMs = 0;
+        clearDbmReleaseRebase();
+        m_resetFftSmoothingOnNextFrame = true;
+        resetNoiseFloorBaseline();
+    }
+    reacquireNoiseFloorLockFromVisibleSource();
+    updateFpsMeterLabels();
+#ifdef AETHER_GPU_SPECTRUM
+    m_wfTexFullUpload = true;
+#endif
     leanCappedUpdate();
+}
+
+void SpectrumWidget::setKiwiSdrWaterfallAvailable(bool available)
+{
+    if (m_kiwiSdrWaterfallAvailable == available) {
+        return;
+    }
+
+    m_kiwiSdrWaterfallAvailable = available;
+    if (!available) {
+        setKiwiSdrWaterfallActive(false);
+    }
+}
+
+void SpectrumWidget::setKiwiSdrWaterfallProfile(const QString& profileId)
+{
+    const QString normalized = profileId.trimmed();
+    if (m_kiwiSdrWaterfallProfileId == normalized) {
+        return;
+    }
+
+    if (m_kiwiSdrWaterfallActive) {
+        saveCurrentWaterfallStreamState();
+    }
+    m_kiwiSdrWaterfallProfileId = normalized;
+    if (m_kiwiSdrWaterfallActive) {
+        restoreCurrentWaterfallStreamState();
+        reacquireNoiseFloorLockFromVisibleSource();
+        leanCappedUpdate();
+    }
+}
+
+void SpectrumWidget::clearKiwiSdrWaterfallRows()
+{
+    m_kiwiWaterfallState = WaterfallStreamState{};
+    m_kiwiProfileWaterfallStates.clear();
+    m_kiwiSdrFftTrace.clear();
+    if (m_kiwiSdrWaterfallActive) {
+        clearCurrentWaterfallRows();
+        leanCappedUpdate();
+    }
+}
+
+void SpectrumWidget::clearKiwiSdrWaterfallRowsForProfile(const QString& profileId)
+{
+    const QString normalized = profileId.trimmed();
+    if (normalized.isEmpty()) {
+        return;
+    }
+
+    m_kiwiProfileWaterfallStates.remove(normalized);
+    if (m_kiwiSdrWaterfallActive
+        && m_kiwiSdrWaterfallProfileId == normalized) {
+        clearCurrentWaterfallRows();
+        leanCappedUpdate();
+    }
+}
+
+const QVector<float>& SpectrumWidget::displaySpectrumBins() const
+{
+    return m_kiwiSdrWaterfallActive ? m_kiwiSdrFftTrace : m_smoothed;
+}
+
+const QVector<float>& SpectrumWidget::noiseFloorAutoLevelBins() const
+{
+    if (m_kiwiSdrWaterfallActive) {
+        return m_kiwiSdrFftTrace;
+    }
+    return !m_smoothed.isEmpty() ? m_smoothed : m_bins;
+}
+
+void SpectrumWidget::setKiwiSdrWaterfallAdjustments(int cellDb, int floorDb)
+{
+    const int clampedCell = std::clamp(cellDb, -30, 30);
+    const int clampedFloor = std::clamp(floorDb, -30, 30);
+    if (m_kiwiSdrWaterfallCellDb == clampedCell
+        && m_kiwiSdrWaterfallFloorDb == clampedFloor) {
+        return;
+    }
+
+    m_kiwiSdrWaterfallCellDb = clampedCell;
+    m_kiwiSdrWaterfallFloorDb = clampedFloor;
+    if (m_kiwiSdrWaterfallActive) {
+        leanCappedUpdate();
+    }
+}
+
+void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
+                                               double lowFreqMhz,
+                                               double highFreqMhz,
+                                               quint32 timecode)
+{
+    Q_UNUSED(timecode);
+    if (binsDbm.isEmpty()) {
+        return;
+    }
+
+    const bool visibleStream = beginWaterfallStreamWrite(true);
+    auto restoreStream = qScopeGuard([&] {
+        endWaterfallStreamWrite(true, visibleStream);
+    });
+
+    const int destWidth = m_waterfall.width();
+    if (destWidth <= 0) {
+        return;
+    }
+
+    double rowLowMhz = lowFreqMhz;
+    double rowHighMhz = highFreqMhz;
+    if (rowHighMhz <= rowLowMhz || rowLowMhz <= 0.0 || m_bandwidthMhz <= 0.0) {
+        return;
+    }
+    const double rowCenterMhz = (rowLowMhz + rowHighMhz) * 0.5;
+    const double rowBandwidthMhz = rowHighMhz - rowLowMhz;
+    const double centerToleranceMhz = std::max(1.0e-9, rowBandwidthMhz * 1.0e-6);
+    const double bandwidthToleranceMhz = std::max(1.0e-9, rowBandwidthMhz * 1.0e-6);
+    const bool sameWaterfallFrame = m_kiwiSdrLastWaterfallFrameValid
+        && std::abs(rowCenterMhz - m_kiwiSdrLastWaterfallCenterMhz) <= centerToleranceMhz
+        && std::abs(rowBandwidthMhz - m_kiwiSdrLastWaterfallBandwidthMhz) <= bandwidthToleranceMhz;
+    if (!sameWaterfallFrame) {
+        m_kiwiSdrLastWaterfallBins.clear();
+        m_kiwiSdrLastWaterfallCenterMhz = rowCenterMhz;
+        m_kiwiSdrLastWaterfallBandwidthMhz = rowBandwidthMhz;
+        m_kiwiSdrLastWaterfallFrameValid = true;
+    }
+
+    const QVector<float> smoothedBins = smoothKiwiSdrWaterfallBins(binsDbm);
+    if (m_kiwiSdrWaterfallActive && destWidth > 0) {
+        QVector<float> kiwiTrace(destWidth, kKiwiSdrWaterfallMinDbm);
+        const double rowLow = rowCenterMhz - rowBandwidthMhz * 0.5;
+        const double viewLow = m_centerMhz - m_bandwidthMhz * 0.5;
+        const int srcSize = smoothedBins.size();
+        for (int x = 0; x < destWidth; ++x) {
+            const double freqMhz = viewLow
+                + (static_cast<double>(x) + 0.5)
+                    * m_bandwidthMhz / static_cast<double>(destWidth);
+            const double srcCenter =
+                ((freqMhz - rowLow) / rowBandwidthMhz)
+                    * static_cast<double>(srcSize) - 0.5;
+            if (srcCenter < -0.5
+                || srcCenter > static_cast<double>(srcSize) - 0.5) {
+                continue;
+            }
+            const double srcLeft = std::max(0.0, srcCenter - 0.5);
+            const double srcRight =
+                std::min(static_cast<double>(srcSize), srcCenter + 0.5);
+            kiwiTrace[x] = peakPreservedBinSample(
+                smoothedBins, srcLeft, srcRight, srcCenter,
+                kKiwiSdrWaterfallMinDbm);
+        }
+        if (m_kiwiSdrFftTrace.size() != kiwiTrace.size()) {
+            m_kiwiSdrFftTrace = kiwiTrace;
+        } else {
+            for (int i = 0; i < kiwiTrace.size(); ++i) {
+                m_kiwiSdrFftTrace[i] = SMOOTH_ALPHA * kiwiTrace[i]
+                    + (1.0f - SMOOTH_ALPHA) * m_kiwiSdrFftTrace[i];
+            }
+        }
+        if (!m_kiwiSdrFftTrace.isEmpty()) {
+            const float frameFloor = estimateNoiseFloorDbm(m_kiwiSdrFftTrace);
+            constexpr float kAlpha = 0.05f;
+            m_measuredNoiseFloorDbm = (m_measuredNoiseFloorDbm <= -500.0f)
+                ? frameFloor
+                : m_measuredNoiseFloorDbm * (1.0f - kAlpha)
+                    + frameFloor * kAlpha;
+
+            const bool useFreshLockFrame = m_noiseFloorFreshFrameCount > 0;
+            const bool noiseFloorFrameConsumed =
+                updateNoiseFloorBaseline(m_kiwiSdrFftTrace, useFreshLockFrame);
+            if (useFreshLockFrame && noiseFloorFrameConsumed) {
+                --m_noiseFloorFreshFrameCount;
+            }
+        }
+    }
+    pushKiwiSdrWaterfallRow(smoothedBins, destWidth,
+                            rowCenterMhz, rowBandwidthMhz);
+    if (visibleStream) {
+        leanCappedUpdate();
+    }
 }
 
 // ─── Layout helpers ────────────────────────────────────────────────────────────
@@ -4697,7 +5412,8 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         const double mouseXFrac = static_cast<double>(m_bwDragStartX) / width() - 0.5;
         const double zoomCenter = std::max(m_bwDragAnchorMhz - mouseXFrac * newBw,
                                            newBw / 2.0);
-        reprojectWaterfall(m_centerMhz, m_bandwidthMhz, zoomCenter, newBw);
+        handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
+                                            zoomCenter, newBw);
         if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, zoomCenter, newBw)) {
             m_bins.clear();
             m_smoothed.clear();
@@ -4752,7 +5468,8 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         const double deltaMhz = -(static_cast<double>(dx) / width()) * m_bandwidthMhz;
         const double newCenter = std::max(m_panDragStartCenter + deltaMhz,
                                           m_bandwidthMhz / 2.0);
-        reprojectWaterfall(m_centerMhz, m_bandwidthMhz, newCenter, m_bandwidthMhz);
+        handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
+                                            newCenter, m_bandwidthMhz);
         m_centerMhz = newCenter;
         markOverlayDirty();
         emit centerChangeRequested(newCenter);
@@ -5255,7 +5972,8 @@ bool SpectrumWidget::event(QEvent* ev)
             const double anchorMhz = m_centerMhz + mouseXFrac * m_bandwidthMhz;
             const double newCenter = std::max(anchorMhz - mouseXFrac * newBw,
                                               newBw / 2.0);
-            reprojectWaterfall(m_centerMhz, m_bandwidthMhz, newCenter, newBw);
+            handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
+                                                newCenter, newBw);
             if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, newCenter, newBw)) {
                 m_bins.clear();
                 m_smoothed.clear();
@@ -5421,7 +6139,8 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
         const double mouseXFrac = ev->position().x() / width() - 0.5;
         const double anchorMhz  = m_centerMhz + mouseXFrac * m_bandwidthMhz;
         const double newCenter  = std::max(anchorMhz - mouseXFrac * newBw, newBw / 2.0);
-        reprojectWaterfall(m_centerMhz, m_bandwidthMhz, newCenter, newBw);
+        handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
+                                            newCenter, newBw);
         if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, newCenter, newBw)) {
             m_bins.clear();
             m_smoothed.clear();
@@ -5531,6 +6250,30 @@ QRgb SpectrumWidget::dbmToRgb(float dbm) const
     const float effectiveMax = effectiveMin + visRange;
 
     const float t = qBound(0.0f, (dbm - effectiveMin) / (effectiveMax - effectiveMin), 1.0f);
+
+    int n = 0;
+    const auto* stops = wfSchemeStops(m_wfColorScheme, n);
+    return interpolateGradient(t, stops, n);
+}
+
+QRgb SpectrumWidget::kiwiSdrLevelToRgb(float level) const
+{
+    // Kiwi W/F bytes are display/bin intensity values, not calibrated dBm.
+    // They are mapped into a Kiwi-only pseudo-dB display range so the
+    // existing waterfall color machinery can be reused without touching Flex.
+    const float floorDbm = m_kiwiSdrAutoRangeValid
+        ? m_kiwiSdrAutoFloorDbm
+        : kKiwiSdrWaterfallMinDbm;
+    const float ceilDbm = m_kiwiSdrAutoRangeValid
+        ? m_kiwiSdrAutoCeilDbm
+        : kKiwiSdrWaterfallMaxDbm;
+    const float adjustedFloorDbm = floorDbm
+        + static_cast<float>(m_kiwiSdrWaterfallFloorDb);
+    const float adjustedCeilDbm = qMax(
+        adjustedFloorDbm + 1.0f,
+        ceilDbm + static_cast<float>(m_kiwiSdrWaterfallCellDb));
+    const float t = KiwiSdrProtocol::waterfallColorIndex(
+        level, adjustedFloorDbm, adjustedCeilDbm);
 
     int n = 0;
     const auto* stops = wfSchemeStops(m_wfColorScheme, n);
@@ -5663,6 +6406,58 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins, int destWidth,
     recordWaterfallFrame();
     if (PerfTelemetry::instance().enabled())
         PerfTelemetry::instance().recordWaterfallFallbackRows(1);
+}
+
+void SpectrumWidget::pushKiwiSdrWaterfallRow(const QVector<float>& bins,
+                                             int destWidth,
+                                             double rowCenterMhz,
+                                             double rowBandwidthMhz)
+{
+    if (m_waterfall.isNull() || destWidth <= 0 || bins.isEmpty()) {
+        return;
+    }
+
+    const int h = m_waterfall.height();
+    if (h <= 1) {
+        return;
+    }
+
+    const int srcSize = bins.size();
+    updateKiwiSdrAutoColorRange(bins);
+    if (rowCenterMhz <= 0.0 || rowBandwidthMhz <= 0.0) {
+        rowCenterMhz = m_centerMhz;
+        rowBandwidthMhz = m_bandwidthMhz;
+    }
+
+    QVector<QRgb> scanline(destWidth, qRgb(0, 0, 0));
+    for (int x = 0; x < destWidth; ++x) {
+        const double srcLeft = static_cast<double>(x)
+            * static_cast<double>(srcSize) / static_cast<double>(destWidth);
+        const double srcRight = static_cast<double>(x + 1)
+            * static_cast<double>(srcSize) / static_cast<double>(destWidth);
+        const double srcCenter = (static_cast<double>(x) + 0.5)
+            * static_cast<double>(srcSize) / static_cast<double>(destWidth) - 0.5;
+        const float level = peakPreservedBinSample(
+            bins, srcLeft, srcRight, srcCenter, kKiwiSdrWaterfallMinDbm);
+        scanline[x] = kiwiSdrLevelToRgb(level);
+    }
+
+    appendHistoryRow(scanline.constData(), QDateTime::currentMSecsSinceEpoch(),
+                     rowCenterMhz, rowBandwidthMhz);
+    if (m_wfLive) {
+        QVector<QRgb> visibleLine(destWidth, qRgb(0, 0, 0));
+        remapHistoryRowInto(visibleLine.data(), scanline.constData(), destWidth,
+                            rowCenterMhz, rowBandwidthMhz,
+                            m_centerMhz, m_bandwidthMhz,
+                            true);
+        appendVisibleRow(visibleLine.constData());
+    } else {
+        rebuildWaterfallViewport();
+    }
+    recordKiwiSdrWaterfallFrame();
+    if (PerfTelemetry::instance().enabled()) {
+        PerfTelemetry::instance().recordWaterfallFallbackRows(1);
+    }
 }
 
 #ifdef AETHER_GPU_SPECTRUM
@@ -6340,6 +7135,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             }
 
             drawConnectionAnimation(p, specRect);
+            drawKiwiSdrConnectionOverlay(
+                p, QRect(0, 0, qMax(0, w - DBM_STRIP_W), h));
             drawDbmScale(p, specRect);
             drawTimeScale(p, wfRect);
 
@@ -6364,8 +7161,9 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         }
 
         // Generate FFT spectrum vertices with baked colors
-        if (!m_smoothed.isEmpty() && m_fftLineVbo && m_fftFillVbo) {
-            const int n = qMin(m_smoothed.size(), kMaxFftBins);
+        const QVector<float>& fftBins = displaySpectrumBins();
+        if (!fftBins.isEmpty() && m_fftLineVbo && m_fftFillVbo) {
+            const int n = qMin(fftBins.size(), kMaxFftBins);
             const float minDbm = m_refLevel - m_dynamicRange;
             const float maxDbm = m_refLevel;
             const float range = maxDbm - minDbm;
@@ -6411,7 +7209,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             QVector<Pt> pts(n);
             for (int i = 0; i < n; ++i) {
                 pts[i].x = 2.0f * i / (n - 1) - 1.0f;
-                float t = qBound(0.0f, (m_smoothed[i] - minDbm) / range, 1.0f);
+                float t = qBound(0.0f, (fftBins[i] - minDbm) / range, 1.0f);
                 pts[i].y = yBot + t * (yTop - yBot);
             }
 
@@ -6425,7 +7223,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             const float hPx = static_cast<float>(qMax(1, specH));
 
             for (int i = 0; i < n; ++i) {
-                float t = qBound(0.0f, (m_smoothed[i] - minDbm) / range, 1.0f);
+                float t = qBound(0.0f, (fftBins[i] - minDbm) / range, 1.0f);
 
                 // Compute perpendicular normal from adjacent points
                 float dx, dy;
@@ -6555,8 +7353,9 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     }
 
     // Draw FFT spectrum — viewport restricted to spectrum rect
-    if (m_fftFillPipeline && m_fftLinePipeline && !m_smoothed.isEmpty()) {
-        const int n = qMin(m_smoothed.size(), kMaxFftBins);
+    const QVector<float>& fftDrawBins = displaySpectrumBins();
+    if (m_fftFillPipeline && m_fftLinePipeline && !fftDrawBins.isEmpty()) {
+        const int n = qMin(fftDrawBins.size(), kMaxFftBins);
         float specVpX = static_cast<float>(specRect.x()) * dpr;
         float specVpY = static_cast<float>(h - specRect.bottom() - 1) * dpr;
         float specVpW = static_cast<float>(specRect.width()) * dpr;
@@ -6818,6 +7617,8 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         }
 
         drawConnectionAnimation(p, specRect);
+        drawKiwiSdrConnectionOverlay(
+            p, QRect(0, 0, qMax(0, width() - DBM_STRIP_W), height()));
     }
 
     // Reposition all VFO widgets — deconflict flags so they fly away from each other
@@ -7127,7 +7928,8 @@ void SpectrumWidget::drawGrid(QPainter& p, const QRect& r)
 
 void SpectrumWidget::drawSpectrum(QPainter& p, const QRect& r)
 {
-    if (m_smoothed.isEmpty()) {
+    const QVector<float>& fftBins = displaySpectrumBins();
+    if (fftBins.isEmpty()) {
         p.setPen(AetherSDR::ThemeManager::instance().color("color.accent.dim"));
         p.drawText(r, Qt::AlignCenter, "No panadapter data — waiting for radio stream");
         return;
@@ -7135,7 +7937,7 @@ void SpectrumWidget::drawSpectrum(QPainter& p, const QRect& r)
 
     const int w = r.width();
     const int h = r.height();
-    const int n = m_smoothed.size();
+    const int n = fftBins.size();
 
     // Heat map: blue(0) → cyan(0.25) → green(0.5) → yellow(0.75) → red(1.0)
     auto heatColor = [](float t) -> QColor {
@@ -7160,7 +7962,7 @@ void SpectrumWidget::drawSpectrum(QPainter& p, const QRect& r)
     struct Pt { int x, y; float t; };
     QVector<Pt> pts(n);
     for (int i = 0; i < n; ++i) {
-        const float dbm  = m_smoothed[i];
+        const float dbm  = fftBins[i];
         const float norm = qBound(0.0f, (m_refLevel - dbm) / m_dynamicRange, 1.0f);
         pts[i].x = r.left() + static_cast<int>(static_cast<float>(i) / n * w);
         pts[i].y = r.top()  + qMin(static_cast<int>(norm * h), h - 1);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -95,6 +95,7 @@ public:
     void prepareForShutdown(); // tear down QRhi/native resources before QWidget backing store destruction
     QString rendererDescription() const;
     void setConnectionAnimationVisible(bool on, const QString& label = {});
+    void setKiwiSdrConnectionOverlay(bool visible, const QString& detail = {});
     void showInterlockNotification(const QString& message, int durationMs = 5000);
 
     // Feed a new FFT frame. bins are scaled dBm values.
@@ -107,6 +108,16 @@ public:
     void updateWaterfallRow(const QVector<float>& binsDbm,
                             double lowFreqMhz, double highFreqMhz,
                             quint32 timecode = 0);
+    void setKiwiSdrWaterfallAvailable(bool available);
+    void setKiwiSdrWaterfallActive(bool active);
+    bool kiwiSdrWaterfallActive() const { return m_kiwiSdrWaterfallActive; }
+    void setKiwiSdrWaterfallProfile(const QString& profileId);
+    void clearKiwiSdrWaterfallRows();
+    void clearKiwiSdrWaterfallRowsForProfile(const QString& profileId);
+    void setKiwiSdrWaterfallAdjustments(int cellDb, int floorDb);
+    void updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
+                                   double lowFreqMhz, double highFreqMhz,
+                                   quint32 timecode = 0);
 
     // Update the dBm range used for the waterfall colour map and spectrum Y axis.
     void setDbmRange(float minDbm, float maxDbm);
@@ -330,6 +341,8 @@ public:
     bool  wfAutoBlackRadioSide() const { return m_wfAutoBlackRadioSide; }
     int   wfLineDuration() const       { return m_wfLineDuration; }
     int   wfColorScheme() const        { return static_cast<int>(m_wfColorScheme); }
+    int   noiseFloorPosition() const   { return m_noiseFloorPosition; }
+    bool  noiseFloorEnabled() const    { return m_noiseFloorEnable; }
 
     // Set slice info for the off-screen VFO indicator (legacy single-slice).
     void setSliceInfo(int sliceId, bool isTxSlice);
@@ -496,6 +509,7 @@ signals:
     // those into separate commands was a known source of waterfall edge loss
     // and zoom drift during bandwidth drag / keyboard zoom.
     void frequencyRangeChangeRequested(double newCenterMhz, double newBandwidthMhz);
+    void frequencyRangeChanged(double centerMhz, double bandwidthMhz);
     // Emitted when the user drags the frequency scale bar to change bandwidth.
     void bandwidthChangeRequested(double newBandwidthMhz);
     // Band/segment zoom: radio handles center/bandwidth (SmartSDR pcap: "band_zoom=1" / "segment_zoom=1")
@@ -591,14 +605,51 @@ private:
     void drawDbmScale(QPainter& p, const QRect& specRect);
     void drawTimeScale(QPainter& p, const QRect& wfRect);
     void drawConnectionAnimation(QPainter& p, const QRect& contentRect);
+    void drawKiwiSdrConnectionOverlay(QPainter& p, const QRect& contentRect);
     void positionInterlockNotification();
     int waterfallStripWidth() const;
     QRect waterfallLiveButtonRect(const QRect& wfRect) const;
     QRect waterfallTimeScaleRect(const QRect& wfRect) const;
     void ensureWaterfallHistory();
     void rebuildWaterfallViewport();
+    void rebuildWaterfallViewportForFrame(double centerMhz, double bandwidthMhz);
     void setWaterfallLive(bool live);
-    void appendHistoryRow(const QRgb* rowData, qint64 timestampMs);
+    void handleWaterfallFrequencyFrameChange(double oldCenterMhz,
+                                             double oldBandwidthMhz,
+                                             double newCenterMhz,
+                                             double newBandwidthMhz);
+    struct WaterfallStreamState {
+        QImage waterfall;
+        int wfWriteRow{0};
+        QImage waterfallHistory;
+        QVector<qint64> historyTimestamps;
+        int historyWriteRow{0};
+        int historyRowCount{0};
+        int historyOffsetRows{0};
+        QVector<double> historyRowCenterMhz;
+        QVector<double> historyRowBwMhz;
+        bool live{true};
+        int rowsSinceRateChange{0};
+        QVector<QRgb> prevTileScanline;
+        QVector<float> kiwiFftTrace;
+        QVector<float> kiwiLastWaterfallBins;
+        double kiwiLastWaterfallCenterMhz{0.0};
+        double kiwiLastWaterfallBandwidthMhz{0.0};
+        bool kiwiLastWaterfallFrameValid{false};
+        float kiwiAutoFloorDbm{-130.0f};
+        float kiwiAutoCeilDbm{-50.0f};
+        bool kiwiAutoRangeValid{false};
+        bool valid{false};
+    };
+    void clearCurrentWaterfallRows();
+    void saveCurrentWaterfallStreamState();
+    void restoreCurrentWaterfallStreamState();
+    WaterfallStreamState& activeKiwiWaterfallState();
+    bool beginWaterfallStreamWrite(bool kiwiStream);
+    void endWaterfallStreamWrite(bool kiwiStream, bool visibleStream);
+    void appendHistoryRow(const QRgb* rowData, qint64 timestampMs,
+                          double frameCenterMhz = -1.0,
+                          double frameBandwidthMhz = -1.0);
     void appendVisibleRow(const QRgb* rowData);
     int waterfallHistoryCapacityRows() const;
     int maxWaterfallHistoryOffsetRows() const;
@@ -615,6 +666,7 @@ private:
     void updateFpsMeterValues();
     void recordPanadapterFrame();
     void recordWaterfallFrame(int rows = 1);
+    void recordKiwiSdrWaterfallFrame(int rows = 1);
     bool anyDragActive() const;
     void publishPerfDragState() const;
 
@@ -646,6 +698,7 @@ private:
     // band switch, manual dBm drag) so the next frame re-acquires
     // rather than smooths from a stale value.
     void resetNoiseFloorBaseline();
+    void reacquireNoiseFloorLockFromVisibleSource();
     // Re-capture the target frac. Explicit user changes (slider/right dBm bar)
     // can persist; startup/enable/layout refreshes only rebuild transient state.
     void refreshNoiseFloorTarget(bool captureCurrentScale = false, bool persistCapture = false);
@@ -665,10 +718,18 @@ private:
     void deferTxDbmRange(float minDbm, float maxDbm);
     void applyDbmRangeImmediate(float minDbm, float maxDbm);
     void reprojectBinsToFrozenTxDbmRange(QVector<float>& bins) const;
+    void clearWaterfallRows();
+    QVector<float> smoothKiwiSdrWaterfallBins(const QVector<float>& bins);
+    void updateKiwiSdrAutoColorRange(const QVector<float>& bins);
+    const QVector<float>& displaySpectrumBins() const;
+    const QVector<float>& noiseFloorAutoLevelBins() const;
 
     void pushWaterfallRow(const QVector<float>& bins, int destWidth,
                           double tileLowMhz = -1, double tileHighMhz = -1);
+    void pushKiwiSdrWaterfallRow(const QVector<float>& bins, int destWidth,
+                                 double rowCenterMhz, double rowBandwidthMhz);
     QRgb dbmToRgb(float dbm) const;
+    QRgb kiwiSdrLevelToRgb(float level) const;
     QRgb intensityToRgb(float intensity) const;  // for native waterfall tiles
 
     // Pixel x coordinate for a given frequency in MHz (0 = left edge).
@@ -678,7 +739,25 @@ private:
 
     QVector<float> m_bins;       // raw FFT frame (dBm)
     QVector<float> m_smoothed;   // exponential-smoothed for visual stability
+    QVector<float> m_kiwiSdrFftTrace;  // Kiwi-derived FFT trace, kept separate from Flex FFT
     bool m_shutdownPrepared{false};
+    bool m_kiwiSdrWaterfallAvailable{false};
+    bool m_kiwiSdrWaterfallActive{false};
+    bool m_kiwiSdrConnectionOverlayVisible{false};
+    QString m_kiwiSdrConnectionOverlayDetail;
+    WaterfallStreamState m_nativeWaterfallState;
+    WaterfallStreamState m_kiwiWaterfallState;
+    QHash<QString, WaterfallStreamState> m_kiwiProfileWaterfallStates;
+    QString m_kiwiSdrWaterfallProfileId;
+    QVector<float> m_kiwiSdrLastWaterfallBins;
+    double m_kiwiSdrLastWaterfallCenterMhz{0.0};
+    double m_kiwiSdrLastWaterfallBandwidthMhz{0.0};
+    bool m_kiwiSdrLastWaterfallFrameValid{false};
+    float m_kiwiSdrAutoFloorDbm{-130.0f};
+    float m_kiwiSdrAutoCeilDbm{-50.0f};
+    bool m_kiwiSdrAutoRangeValid{false};
+    int m_kiwiSdrWaterfallCellDb{0};
+    int m_kiwiSdrWaterfallFloorDb{0};
 
     double m_centerMhz{14.225};
     double m_bandwidthMhz{0.200};
@@ -814,9 +893,8 @@ private:
     // was captured at (parallel to m_wfHistoryTimestamps). The full history image
     // (up to ~24k rows, ~0.5 GB at ultrawide widths) is therefore never globally
     // reprojected on a pan — instead rebuildWaterfallViewport remaps only the
-    // ~700 visible rows from their own frame to the current one on time-
-    // scrollback. The live view never reads the history, so panning touches only
-    // the cheap visible waterfall.
+    // ~700 visible rows from their own frame to the requested viewport on live
+    // pan/zoom changes and time-scrollback.
     QVector<double> m_wfHistoryRowCenterMhz;
     QVector<double> m_wfHistoryRowBwMhz;
     bool   m_wfLive{true};
@@ -1039,8 +1117,10 @@ private:
     QElapsedTimer m_fpsMeterWindow;
     int m_panadapterFrameCount{0};
     int m_waterfallFrameCount{0};
+    int m_kiwiSdrWaterfallFrameCount{0};
     double m_panadapterFps{0.0};
     double m_waterfallFps{0.0};
+    double m_kiwiSdrWaterfallFps{0.0};
     QLabel* m_panFpsMeterLabel{nullptr};
     QLabel* m_wfFpsMeterLabel{nullptr};
     qint64 m_lastMouseMoveNs{0};
@@ -1099,7 +1179,7 @@ private:
     QMap<int, VfoWidget*> m_vfoWidgets;
     VfoWidget* m_vfoWidget{nullptr};  // alias to active slice widget (compat)
 
-    // Bottom-left waterfall zoom buttons: S(egment), B(and), −/+ (bandwidth)
+    // Bottom-left waterfall buttons: S(egment), B(and), −/+.
     QPushButton* m_zoomSegBtn{nullptr};
     QPushButton* m_zoomBandBtn{nullptr};
     QPushButton* m_zoomOutBtn{nullptr};

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -6,6 +6,7 @@
 #include "RxApplet.h"
 #include "SliceColorManager.h"
 #include "SliceLabel.h"
+#include "core/KiwiSdrManager.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
@@ -44,7 +45,9 @@
 #include <QEvent>
 #include <QKeyEvent>
 #include <QMouseEvent>
+#include <algorithm>
 #include <cmath>
+#include <utility>
 #include "core/ThemeManager.h"
 #include "FreqLineEdit.h"
 
@@ -441,16 +444,39 @@ void VfoWidget::buildUI()
         const QStringList options = !m_slice->rxAntennaList().isEmpty()
             ? m_slice->rxAntennaList()
             : m_antList;
-        for (const QString& ant : options) {
-            auto* act = menu.addAction(antennaMenuLabel(ant, options));
+        QStringList menuOptions = options;
+        if (m_kiwiSdrManager) {
+            menuOptions.append(m_kiwiSdrManager->virtualAntennaTokens());
+        }
+        const QString activeKiwiProfile =
+            m_kiwiSdrManager
+                ? m_kiwiSdrManager->assignedProfileForSlice(m_slice->sliceId())
+                : QString();
+        for (const QString& ant : menuOptions) {
+            auto* act = menu.addAction(antennaMenuLabel(ant, menuOptions));
             act->setData(ant);
             act->setCheckable(true);
-            act->setChecked(ant == m_slice->rxAntenna());
+            const QString profileId = m_kiwiSdrManager
+                ? m_kiwiSdrManager->profileIdForVirtualAntennaToken(ant)
+                : QString();
+            act->setChecked(profileId.isEmpty()
+                ? ant == m_slice->rxAntenna() && activeKiwiProfile.isEmpty()
+                : profileId == activeKiwiProfile);
             act->setToolTip(ant);
             act->setStatusTip(ant);
         }
-        if (auto* sel = menu.exec(m_rxAntBtn->mapToGlobal(QPoint(0, m_rxAntBtn->height()))))
-            m_slice->setRxAntenna(sel->data().toString());
+        if (auto* sel = menu.exec(m_rxAntBtn->mapToGlobal(QPoint(0, m_rxAntBtn->height())))) {
+            const QString token = sel->data().toString();
+            const QString profileId = m_kiwiSdrManager
+                ? m_kiwiSdrManager->profileIdForVirtualAntennaToken(token)
+                : QString();
+            if (!profileId.isEmpty()) {
+                emit kiwiRxAntennaSelected(m_slice->sliceId(), profileId);
+            } else {
+                emit flexRxAntennaSelected(m_slice->sliceId());
+                m_slice->setRxAntenna(token);
+            }
+        }
     });
     hdr->addWidget(m_rxAntBtn);
 
@@ -2518,21 +2544,19 @@ void VfoWidget::paintEvent(QPaintEvent* event)
     // Background
     p.fillRect(barX, barY, barW, barH, QColor(0x10, 0x18, 0x20));
 
-    // S-meter scale: S0=-127, S9=-73 (6 dB per S-unit), S9+60=-13
-    // S0–S9 occupies left 60%, S9–S9+60 occupies right 40%
     const int s9X = barX + barW * 60 / 100;  // S9 boundary pixel
 
-    // Signal fill — color gradient matching SmartSDR visual convention
+    // Signal fill.
     const int fillW = static_cast<int>(m_signalMeterFraction * barW);
 
     if (fillW > 0) {
         QLinearGradient grad(barX, 0, barX + barW, 0);
-        grad.setColorAt(0.00, QColor(0x00, 0x90, 0x30));  // dark green  — S0
-        grad.setColorAt(0.30, QColor(0x00, 0xc0, 0x40));  // green       — ~S5
-        grad.setColorAt(0.50, QColor(0xd4, 0xc0, 0x00));  // yellow      — ~S7
-        grad.setColorAt(0.70, QColor(0xdd, 0x14, 0x00));  // red         — S9+10
-        grad.setColorAt(0.85, QColor(0xff, 0x00, 0x00));  // bright red  — S9+30
-        grad.setColorAt(1.00, QColor(0xff, 0x00, 0x00));  // bright red  — S9+60
+        grad.setColorAt(0.00, QColor(0x00, 0x90, 0x30));  // dark green
+        grad.setColorAt(0.30, QColor(0x00, 0xc0, 0x40));  // green
+        grad.setColorAt(0.50, QColor(0xd4, 0xc0, 0x00));  // yellow
+        grad.setColorAt(0.70, QColor(0xdd, 0x14, 0x00));  // red
+        grad.setColorAt(0.85, QColor(0xff, 0x00, 0x00));  // bright red
+        grad.setColorAt(1.00, QColor(0xff, 0x00, 0x00));  // bright red
         p.fillRect(barX, barY, fillW, barH, grad);
     }
 
@@ -2540,15 +2564,13 @@ void VfoWidget::paintEvent(QPaintEvent* event)
     const int scaleY = barY + barH + 2;
     const int tickH  = 3;
 
-    // Horizontal line: blue from start to S9, red from S9 to end
+    // Horizontal line: blue from start to S9, red from S9 to end.
     p.setPen(QColor(0x30, 0x80, 0xff));
     p.drawLine(barX, scaleY, s9X, scaleY);
     p.setPen(QColor(0xd0, 0x20, 0x20));
     p.drawLine(s9X, scaleY, barX + barW, scaleY);
 
-    p.setPen(QColor(0x30, 0x80, 0xff));  // blue for S1–S9
-
-    // S-unit ticks: S1, S3, S5, S7, S9 — S1 at left edge, S9 at 60%
+    p.setPen(QColor(0x30, 0x80, 0xff));
     for (int s = 1; s <= 9; s += 2) {
         float sf = static_cast<float>(s - 1) / 8.0f * 0.6f;
         int tx = barX + static_cast<int>(sf * barW);
@@ -2556,17 +2578,9 @@ void VfoWidget::paintEvent(QPaintEvent* event)
         p.drawLine(tx, scaleY, tx, scaleY + h);
     }
 
-    p.setPen(QColor(0xd0, 0x20, 0x20));  // red for +20, +40
-
-    // +20 tick
-    {
-        float sf = 0.6f + (20.0f / 60.0f) * 0.4f;
-        int tx = barX + static_cast<int>(sf * barW);
-        p.drawLine(tx, scaleY, tx, scaleY + tickH);
-    }
-    // +40 tick
-    {
-        float sf = 0.6f + (40.0f / 60.0f) * 0.4f;
+    p.setPen(QColor(0xd0, 0x20, 0x20));
+    for (float sf : {0.6f + (20.0f / 60.0f) * 0.4f,
+                     0.6f + (40.0f / 60.0f) * 0.4f}) {
         int tx = barX + static_cast<int>(sf * barW);
         p.drawLine(tx, scaleY, tx, scaleY + tickH);
     }
@@ -2579,7 +2593,6 @@ void VfoWidget::paintEvent(QPaintEvent* event)
 
     const int lblY = scaleY + tickH + 7;
 
-    // Blue labels: 1, 3, 5, 7, 9 — S1 at left edge, S9 at 60%
     p.setPen(QColor(0x30, 0x80, 0xff));
     for (int s : {1, 3, 5, 7, 9}) {
         float sf = static_cast<float>(s - 1) / 8.0f * 0.6f;
@@ -2587,17 +2600,15 @@ void VfoWidget::paintEvent(QPaintEvent* event)
         p.drawText(tx - 3, lblY, QString::number(s));
     }
 
-    // Red labels: +20, +40
     p.setPen(QColor(0xd0, 0x20, 0x20));
-    {
-        float sf = 0.6f + (20.0f / 60.0f) * 0.4f;
-        int tx = barX + static_cast<int>(sf * barW);
-        p.drawText(tx - 6, lblY, "+20");
-    }
-    {
-        float sf = 0.6f + (40.0f / 60.0f) * 0.4f;
-        int tx = barX + static_cast<int>(sf * barW);
-        p.drawText(tx - 6, lblY, "+40");
+    for (const auto& label : {std::pair<float, QString>{
+                                  0.6f + (20.0f / 60.0f) * 0.4f,
+                                  QStringLiteral("+20")},
+                              std::pair<float, QString>{
+                                  0.6f + (40.0f / 60.0f) * 0.4f,
+                                  QStringLiteral("+40")}}) {
+        int tx = barX + static_cast<int>(label.first * barW);
+        p.drawText(tx - 6, lblY, label.second);
     }
 
 }
@@ -2606,9 +2617,37 @@ void VfoWidget::paintEvent(QPaintEvent* event)
 
 void VfoWidget::setSignalLevel(float dbm)
 {
+    m_receiveMeterReadingActive = false;
     m_signalDbm = dbm;
     m_dbmLabel->setText(QString("%1 dBm").arg(static_cast<int>(dbm)));
+    m_dbmLabel->setAccessibleName("Signal level dBm");
     updateSignalMeterTarget();
+}
+
+void VfoWidget::setReceiveMeterReading(
+    const KiwiSdrProtocol::MeterReading& reading)
+{
+    m_receiveMeterReading = reading;
+    m_receiveMeterReadingActive = true;
+    const bool hasDisplayDbm =
+        (reading.capability == KiwiSdrProtocol::MeterCapability::CalibratedSndMeter
+         || reading.capability == KiwiSdrProtocol::MeterCapability::Experimental)
+        && reading.hasDbm;
+
+    if (hasDisplayDbm) {
+        m_signalDbm = reading.dbm;
+        m_dbmLabel->setText(QString("%1 dBm").arg(static_cast<int>(reading.dbm)));
+        m_dbmLabel->setAccessibleName("Signal level dBm");
+    } else {
+        m_signalDbm = -130.0f;
+        m_dbmLabel->setText(QStringLiteral("Meter ---"));
+        m_dbmLabel->setAccessibleName("Meter unavailable");
+    }
+    updateSignalMeterTarget();
+    if (QAccessible::isActive()) {
+        QAccessibleValueChangeEvent event(this, m_dbmLabel->text());
+        QAccessible::updateAccessibility(&event);
+    }
 }
 
 float VfoWidget::signalDbmToMeterFraction(float dbm)
@@ -2631,7 +2670,11 @@ float VfoWidget::signalDbmToMeterFraction(float dbm)
 
 void VfoWidget::updateSignalMeterTarget()
 {
-    m_targetSignalMeterFraction = signalDbmToMeterFraction(m_signalDbm);
+    if (usesUnavailableSignalMeter()) {
+        m_targetSignalMeterFraction = 0.0f;
+    } else {
+        m_targetSignalMeterFraction = signalDbmToMeterFraction(m_signalDbm);
+    }
 
     if (qAbs(m_targetSignalMeterFraction - m_signalMeterFraction) <= kSignalMeterSnapEpsilon) {
         m_signalMeterFraction = m_targetSignalMeterFraction;
@@ -2646,6 +2689,17 @@ void VfoWidget::updateSignalMeterTarget()
         m_signalMeterElapsed.restart();
         m_signalMeterAnimation.start();
     }
+}
+
+bool VfoWidget::usesUnavailableSignalMeter() const
+{
+    return m_receiveMeterReadingActive
+        && !(m_receiveMeterReading.valid
+            && (m_receiveMeterReading.capability
+                    == KiwiSdrProtocol::MeterCapability::CalibratedSndMeter
+                || m_receiveMeterReading.capability
+                    == KiwiSdrProtocol::MeterCapability::Experimental)
+            && m_receiveMeterReading.hasDbm);
 }
 
 void VfoWidget::animateSignalMeter()
@@ -4121,9 +4175,38 @@ void VfoWidget::setRadioModel(RadioModel* radioModel)
     updateAntennaButtons();
 }
 
+void VfoWidget::setKiwiSdrManager(KiwiSdrManager* manager)
+{
+    if (m_kiwiSdrManager) {
+        disconnect(m_kiwiSdrManager, &KiwiSdrManager::profilesChanged,
+                   this, &VfoWidget::updateAntennaButtons);
+        disconnect(m_kiwiSdrManager, &KiwiSdrManager::sliceAssignmentChanged,
+                   this, nullptr);
+    }
+    m_kiwiSdrManager = manager;
+    if (m_kiwiSdrManager) {
+        connect(m_kiwiSdrManager, &KiwiSdrManager::profilesChanged,
+                this, &VfoWidget::updateAntennaButtons);
+        connect(m_kiwiSdrManager, &KiwiSdrManager::sliceAssignmentChanged,
+                this, [this](int sliceId, const QString&) {
+            if (m_slice && m_slice->sliceId() == sliceId) {
+                updateAntennaButtons();
+            }
+        });
+    }
+    updateAntennaButtons();
+}
+
 QString VfoWidget::antennaMenuLabel(const QString& token,
                                     const QStringList& options) const
 {
+    if (m_kiwiSdrManager) {
+        const QString profileId =
+            m_kiwiSdrManager->profileIdForVirtualAntennaToken(token);
+        if (!profileId.isEmpty()) {
+            return m_kiwiSdrManager->displayName(profileId);
+        }
+    }
     if (!m_radioModel)
         return token;
     return m_radioModel->antennaDisplayName(
@@ -4159,9 +4242,22 @@ void VfoWidget::updateAntennaButton(QPushButton* button, const QString& token, b
     if (!button)
         return;
 
-    const QString shortLabel = m_radioModel
-        ? m_radioModel->antennaShortDisplayName(token, 6)
-        : token;
+    QString effectiveToken = token;
+    if (!tx && m_kiwiSdrManager && m_slice) {
+        const QString profileId =
+            m_kiwiSdrManager->assignedProfileForSlice(m_slice->sliceId());
+        if (!profileId.isEmpty()) {
+            effectiveToken = m_kiwiSdrManager->virtualAntennaToken(profileId);
+        }
+    }
+    const QString profileId = m_kiwiSdrManager
+        ? m_kiwiSdrManager->profileIdForVirtualAntennaToken(effectiveToken)
+        : QString();
+    const QString shortLabel = !profileId.isEmpty()
+        ? m_kiwiSdrManager->displayName(profileId)
+        : (m_radioModel
+            ? m_radioModel->antennaShortDisplayName(effectiveToken, 6)
+            : effectiveToken);
     const QFontMetrics fm(button->font());
     constexpr int kMinWidth = 34;
     constexpr int kMaxWidth = 66;
@@ -4170,12 +4266,17 @@ void VfoWidget::updateAntennaButton(QPushButton* button, const QString& token, b
     button->setText(text);
     button->setFixedWidth(qBound(kMinWidth, fm.horizontalAdvance(text) + kPad, kMaxWidth));
 
-    const QString full = m_radioModel
-        ? m_radioModel->antennaDisplayName(token, !m_radioModel->antennaAlias(token).isEmpty())
-        : token;
-    button->setToolTip(QStringLiteral("%1 antenna port: %2")
-                           .arg(tx ? QStringLiteral("Transmit") : QStringLiteral("Receive"),
-                                full));
+    const QString full = !profileId.isEmpty()
+        ? m_kiwiSdrManager->displayName(profileId)
+        : (m_radioModel
+            ? m_radioModel->antennaDisplayName(
+                  effectiveToken, !m_radioModel->antennaAlias(effectiveToken).isEmpty())
+            : effectiveToken);
+    button->setToolTip(!profileId.isEmpty()
+        ? QStringLiteral("Receive antenna: %1").arg(full)
+        : QStringLiteral("%1 antenna port: %2")
+              .arg(tx ? QStringLiteral("Transmit") : QStringLiteral("Receive"),
+                   full));
 }
 
 void VfoWidget::updateAntennaButtons()

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -10,6 +10,8 @@
 #include <QTimer>
 #include <QElapsedTimer>
 
+#include "core/KiwiSdrProtocol.h"
+
 class QPushButton;
 class ScrollableLabel;
 class QLabel;
@@ -27,6 +29,7 @@ class TransmitModel;
 class RadioModel;
 class PhaseKnob;
 class RxApplet;
+class KiwiSdrManager;
 
 // Floating VFO info panel attached to the VFO marker on the spectrum display.
 // Shows slice info (antennas, frequency, signal level, filter width, TX/SPLIT)
@@ -43,12 +46,15 @@ public:
     void setAntennaList(const QStringList& ants);
     void setTransmitModel(TransmitModel* txModel);
     void setRadioModel(RadioModel* radioModel);
+    void setKiwiSdrManager(KiwiSdrManager* manager);
     // Wire the SQL button + slider as a mirror of the RxApplet's 3-way
     // SQL UI (Off / Manual / Auto, manual-level cache, Auto margin).
     // Without this call, the SQL row still functions but in the old
     // 2-state on/off mode against the slice's squelchLevel only.
     void setRxApplet(RxApplet* rx);
     void setSignalLevel(float dbm);
+    void setReceiveMeterReading(
+        const AetherSDR::KiwiSdrProtocol::MeterReading& reading);
 
     // Split mode: call whenever TX assignment or active slice changes.
     //   isTxSlice  — this VFO's slice has tx=1
@@ -132,6 +138,8 @@ Q_SIGNALS:
     void zeroBeatRequested();                   // client-side CW zero-beat
     void addSpotRequested(double freqMhz);
     void sliceActivationRequested(int sliceId);
+    void kiwiRxAntennaSelected(int sliceId, const QString& profileId);
+    void flexRxAntennaSelected(int sliceId);
     // Emitted when the wheel tunes by step so MainWindow can apply the shared
     // tuning/reveal policy.
     void stepTuneRequested(double mhz);
@@ -151,6 +159,7 @@ protected:
 private:
     void updateSignalMeterTarget();
     void animateSignalMeter();
+    bool usesUnavailableSignalMeter() const;
     static float signalDbmToMeterFraction(float dbm);
 
     void buildUI();
@@ -175,10 +184,13 @@ private:
     SliceModel*    m_slice{nullptr};
     TransmitModel* m_txModel{nullptr};
     RadioModel*    m_radioModel{nullptr};
+    KiwiSdrManager* m_kiwiSdrManager{nullptr};
     QStringList    m_antList;
     bool           m_updatingFromModel{false};
     bool           m_lastOnLeft{true};
     float          m_signalDbm{-130.0f};
+    KiwiSdrProtocol::MeterReading m_receiveMeterReading;
+    bool           m_receiveMeterReadingActive{false};
     QTimer         m_signalMeterAnimation;
     QElapsedTimer  m_signalMeterElapsed;
     float          m_signalMeterFraction{0.0f};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -641,8 +641,11 @@ int RadioModel::maxSlicesForModel(const QString& model)
 
 SliceModel* RadioModel::slice(int id) const
 {
-    for (auto* s : m_slices)
-        if (s->sliceId() == id) return s;
+    for (SliceModel* s : m_slices) {
+        if (s && s->sliceId() == id) {
+            return s;
+        }
+    }
     return nullptr;
 }
 

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -468,6 +468,15 @@ void SliceModel::setFmDeviation(int hz)
 void SliceModel::setAudioGain(float gain)
 {
     gain = qBound(0.0f, gain, 100.0f);
+    if (m_externalReceiveAudioReplacement) {
+        if (m_externalReceiveAudioGain == gain) {
+            return;
+        }
+        m_externalReceiveAudioGain = gain;
+        emit audioGainChanged(m_externalReceiveAudioGain);
+        return;
+    }
+
     if (m_audioGain == gain) return;
     m_audioGain = gain;
     emit commandReady(QString("slice set %1 audio_level=%2")
@@ -483,10 +492,54 @@ void SliceModel::setRfGain(float gain)
 
 void SliceModel::setAudioMute(bool mute)
 {
+    const bool previousVisibleMute = audioMute();
+    if (m_externalReceiveAudioReplacement) {
+        if (m_externalReceiveAudioMute == mute) {
+            return;
+        }
+        m_externalReceiveAudioMute = mute;
+        if (audioMute() != previousVisibleMute) {
+            emit audioMuteChanged(audioMute());
+        }
+        return;
+    }
+
     if (m_audioMute == mute) return;
     m_audioMute = mute;
     sendCommand(QString("slice set %1 audio_mute=%2").arg(m_id).arg(mute ? 1 : 0));
-    emit audioMuteChanged(mute);
+    if (audioMute() != previousVisibleMute) {
+        emit audioMuteChanged(audioMute());
+    }
+}
+
+void SliceModel::setExternalReceiveAudioReplacementMute(bool active,
+                                                        bool restoreMute)
+{
+    const bool previousVisibleMute = audioMute();
+    const float previousVisibleGain = audioGain();
+    if (active) {
+        m_externalReceiveAudioGain = m_audioGain;
+        m_externalReceiveAudioMute = false;
+        m_externalReceiveAudioReplacement = true;
+        if (!m_audioMute) {
+            m_audioMute = true;
+            sendCommand(QString("slice set %1 audio_mute=1").arg(m_id));
+        }
+    } else {
+        m_externalReceiveAudioReplacement = false;
+        if (m_audioMute != restoreMute) {
+            m_audioMute = restoreMute;
+            sendCommand(QString("slice set %1 audio_mute=%2")
+                            .arg(m_id)
+                            .arg(restoreMute ? 1 : 0));
+        }
+    }
+    if (audioMute() != previousVisibleMute) {
+        emit audioMuteChanged(audioMute());
+    }
+    if (audioGain() != previousVisibleGain) {
+        emit audioGainChanged(audioGain());
+    }
 }
 
 void SliceModel::setDiversity(bool on)
@@ -646,7 +699,13 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
     }
     if (kvs.contains("audio_level")) {
         float g = kvs["audio_level"].toFloat();
-        if (m_audioGain != g) { m_audioGain = g; emit audioGainChanged(g); }
+        if (m_audioGain != g) {
+            const float previousVisibleGain = audioGain();
+            m_audioGain = g;
+            if (audioGain() != previousVisibleGain) {
+                emit audioGainChanged(audioGain());
+            }
+        }
     }
     if (kvs.contains("audio_pan")) {
         m_audioPan = kvs["audio_pan"].toInt();
@@ -655,16 +714,30 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
     if (kvs.contains("audio_mute")) {
         bool mute = kvs["audio_mute"] == "1";
         if (mute != m_audioMute) {
+            const bool previousVisibleMute = audioMute();
             m_audioMute = mute;
-            emit audioMuteChanged(mute);
+            if (m_externalReceiveAudioReplacement && !m_audioMute) {
+                m_audioMute = true;
+                sendCommand(QString("slice set %1 audio_mute=1").arg(m_id));
+            }
+            if (audioMute() != previousVisibleMute) {
+                emit audioMuteChanged(audioMute());
+            }
         }
     } else if (kvs.value("in_use") == "1" && m_audioMute) {
         // Full status w/o audio_mute key → radio reset to default (0)
         // on (re)connect. Resync so UI doesn't show a stale 🔇 while
         // audio is actually playing. Radio does not persist audio_mute
         // (see MainWindow.cpp migration note ~line 1264).
-        m_audioMute = false;
-        emit audioMuteChanged(false);
+        if (m_externalReceiveAudioReplacement) {
+            sendCommand(QString("slice set %1 audio_mute=1").arg(m_id));
+        } else {
+            const bool previousVisibleMute = audioMute();
+            m_audioMute = false;
+            if (audioMute() != previousVisibleMute) {
+                emit audioMuteChanged(audioMute());
+            }
+        }
     }
     // Parse child/parent flags before emitting diversityChanged so handlers
     // can check isDiversityChild() to gate ESC panel visibility.

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -43,7 +43,10 @@ public:
     bool    isActive()   const { return m_active; }
     bool    isTxSlice()  const { return m_txSlice; }
     float   rfGain()     const { return m_rfGain; }
-    float   audioGain()  const { return m_audioGain; }
+    float   audioGain()  const { return m_externalReceiveAudioReplacement
+                                      ? m_externalReceiveAudioGain
+                                      : m_audioGain; }
+    float   flexAudioGain() const { return m_audioGain; }
     int     audioPan()   const { return m_audioPan; }
 
     // Getters — RX DSP state
@@ -74,7 +77,10 @@ public:
     QString agcMode()      const { return m_agcMode; }
     int     agcThreshold() const { return m_agcThreshold; }
     int     agcOffLevel()  const { return m_agcOffLevel; }
-    bool    audioMute()   const { return m_audioMute; }
+    bool    audioMute()   const { return m_externalReceiveAudioReplacement
+                                      ? m_externalReceiveAudioMute
+                                      : m_audioMute; }
+    bool    flexAudioMute() const { return m_audioMute; }
     bool    squelchOn()   const { return m_squelchOn; }
     int     squelchLevel()const { return m_squelchLevel; }
     bool    ritOn()       const { return m_ritOn; }
@@ -112,6 +118,8 @@ public:
     void setRfGain(float gain);
     void setAudioPan(int pan);
     void setAudioMute(bool mute);
+    void setExternalReceiveAudioReplacementMute(bool active,
+                                                bool restoreMute = false);
     void setDiversity(bool on);
     bool diversity() const { return m_diversity; }
     bool isDiversityChild() const { return m_diversityChild; }
@@ -285,6 +293,9 @@ private:
     bool    m_locked{false};
     bool    m_qsk{false};
     bool    m_audioMute{false};
+    bool    m_externalReceiveAudioReplacement{false};
+    bool    m_externalReceiveAudioMute{false};
+    float   m_externalReceiveAudioGain{70.0f};
     bool    m_diversity{false};
     bool    m_diversityChild{false};
     bool    m_diversityParent{false};

--- a/tests/kiwi_sdr_protocol_test.cpp
+++ b/tests/kiwi_sdr_protocol_test.cpp
@@ -1,0 +1,178 @@
+#include "core/KiwiSdrProtocol.h"
+
+#include <QVector>
+
+#include <cmath>
+#include <cstdio>
+
+namespace {
+
+bool nearlyEqual(float a, float b, float epsilon = 0.0001f)
+{
+    return std::fabs(a - b) <= epsilon;
+}
+
+int fail(const char* message)
+{
+    std::fprintf(stderr, "kiwi_sdr_protocol_test: %s\n", message);
+    return 1;
+}
+
+} // namespace
+
+int main()
+{
+    using namespace AetherSDR::KiwiSdrProtocol;
+
+    const QByteArray soundFrame =
+        QByteArray("SND", 3)
+        + QByteArray::fromHex("051234")
+        + QByteArray::fromHex("0001fffe");
+    const SoundFrameHeader soundHeader = parseSoundFrameHeader(soundFrame);
+    if (!soundHeader.valid
+        || soundHeader.sequence != 5
+        || soundHeader.flags != 5
+        || soundHeader.hasRssi) {
+        return fail("SND header sequence parsing should not invent calibrated RSSI");
+    }
+
+    QByteArray observedSoundFrame("SND", 3);
+    observedSoundFrame.append('\x01');
+    observedSoundFrame.append(QByteArray(1030, '\0'));
+    observedSoundFrame[4] = '\x2a';
+    const SoundFrameHeader observedSoundHeader =
+        parseSoundFrameHeader(observedSoundFrame);
+    if (!observedSoundHeader.valid
+        || observedSoundHeader.sequence != 42
+        || observedSoundHeader.hasRssi) {
+        return fail("observed SND compatibility header sequence is wrong");
+    }
+
+    const QByteArray waterfallFrame =
+        QByteArray("W/F", 3)
+        + QByteArray::fromHex("fe00010203");
+    const WaterfallLineHeader waterfallHeader =
+        parseWaterfallLineHeader(waterfallFrame);
+    if (!waterfallHeader.valid || waterfallHeader.sequence != 254) {
+        return fail("W/F line sequence parsing is wrong");
+    }
+
+    if (sequenceGapCount(5, 7) != 1
+        || sequenceGapCount(254, 1) != 2
+        || sequenceGapCount(-1, 10) != 0) {
+        return fail("sequence gap accounting is wrong");
+    }
+
+    if (!nearlyEqual(waterfallByteToDisplayLevel(0), -130.0f)
+        || !nearlyEqual(waterfallByteToDisplayLevel(255), 0.0f)) {
+        return fail("waterfall byte display-level conversion is wrong");
+    }
+
+    QVector<float> row(1024, -100.0f);
+    for (int i = 1003; i < row.size(); ++i) {
+        row[i] = -60.0f;
+    }
+
+    const WaterfallAperture aperture = autoWaterfallAperture(row);
+    if (!aperture.valid) {
+        return fail("auto aperture did not become valid");
+    }
+    if (!nearlyEqual(aperture.minDbm, -110.0f)
+        || !nearlyEqual(aperture.maxDbm, -30.0f)) {
+        return fail("auto aperture does not follow median/98th percentile rule");
+    }
+
+    const float index = waterfallColorIndex(-90.0f, -110.0f, -30.0f);
+    if (!nearlyEqual(index, 0.5f)) {
+        return fail("waterfall color index does not use sqrt contrast");
+    }
+
+    QByteArray extendedSoundFrame(1034, '\0');
+    extendedSoundFrame[0] = 'S';
+    extendedSoundFrame[1] = 'N';
+    extendedSoundFrame[2] = 'D';
+    extendedSoundFrame[8] = static_cast<char>(0x02);
+    extendedSoundFrame[9] = static_cast<char>(0x1c);
+    const MeterReading experimentalMeter =
+        extractMeterFromSndVerifiedLayout(extendedSoundFrame, MeterContext{});
+    if (!experimentalMeter.valid
+        || experimentalMeter.capability != MeterCapability::Experimental
+        || !experimentalMeter.hasRawValue
+        || !nearlyEqual(experimentalMeter.rawValue, 540.0f)
+        || !experimentalMeter.hasDbm
+        || !nearlyEqual(experimentalMeter.dbm, -73.0f)
+        || experimentalMeter.sUnits != QStringLiteral("S9")
+        || experimentalMeter.label != QStringLiteral("S-Meter")) {
+        return fail("experimental SND meter candidate extraction is wrong");
+    }
+
+    const MeterReading unavailable =
+        extractMeterFromSndVerifiedLayout(soundFrame, MeterContext{});
+    if (unavailable.valid
+        || unavailable.capability != MeterCapability::Unavailable
+        || unavailable.label != QStringLiteral("Meter unavailable")
+        || !unavailable.notes.contains(QStringLiteral("layout not verified"))) {
+        return fail("non-extended SND meter extraction should remain unavailable");
+    }
+
+    QVector<float> silence(128, 0.0f);
+    const MeterReading silentAudio =
+        computeRelativeAudioLevel(silence.constData(), silence.size());
+    if (!silentAudio.valid
+        || silentAudio.capability != MeterCapability::RelativeAudio
+        || silentAudio.label != QStringLiteral("Audio level, relative")
+        || !nearlyEqual(silentAudio.relativeLevel, 0.0f)
+        || silentAudio.hasDbm
+        || !silentAudio.sUnits.isEmpty()) {
+        return fail("silent audio relative meter is wrong");
+    }
+
+    QVector<float> fullScale;
+    fullScale.reserve(256);
+    for (int i = 0; i < 256; ++i) {
+        fullScale.append((i % 2) == 0 ? 1.0f : -1.0f);
+    }
+    const MeterReading fullScaleAudio =
+        computeRelativeAudioLevel(fullScale.constData(), fullScale.size());
+    if (!fullScaleAudio.valid || fullScaleAudio.relativeLevel < 0.99f
+        || fullScaleAudio.hasDbm || !fullScaleAudio.sUnits.isEmpty()) {
+        return fail("full-scale audio relative meter is wrong");
+    }
+
+    QVector<float> lowNoise(128, 0.01f);
+    const MeterReading lowAudio =
+        computeRelativeAudioLevel(lowNoise.constData(), lowNoise.size());
+    if (!lowAudio.valid
+        || lowAudio.relativeLevel <= 0.0f
+        || lowAudio.relativeLevel >= 0.5f
+        || lowAudio.hasDbm
+        || !lowAudio.sUnits.isEmpty()) {
+        return fail("low-level audio relative meter is wrong");
+    }
+
+    QVector<float> waterfallBins(64, -120.0f);
+    for (int i = 60; i < waterfallBins.size(); ++i) {
+        waterfallBins[i] = -20.0f;
+    }
+    const MeterReading waterfallReading =
+        computeRelativeWaterfallLevel(waterfallBins);
+    if (!waterfallReading.valid
+        || waterfallReading.capability != MeterCapability::RelativeWaterfall
+        || waterfallReading.label != QStringLiteral("Waterfall intensity, relative")
+        || waterfallReading.relativeLevel <= 0.75f
+        || waterfallReading.hasDbm
+        || !waterfallReading.sUnits.isEmpty()) {
+        return fail("waterfall relative meter is wrong");
+    }
+
+    if (convertDbmToSUnits(-73.0f) != QStringLiteral("S9")
+        || convertDbmToSUnits(-79.0f) != QStringLiteral("S8")
+        || convertDbmToSUnits(-85.0f) != QStringLiteral("S7")
+        || convertDbmToSUnits(-91.0f) != QStringLiteral("S6")
+        || convertDbmToSUnits(-63.0f) != QStringLiteral("S9 + 10 dB")
+        || convertDbmToSUnits(-53.0f) != QStringLiteral("S9 + 20 dB")) {
+        return fail("dBm to S-unit conversion is wrong");
+    }
+
+    return 0;
+}

--- a/tests/spectral_nr_test.cpp
+++ b/tests/spectral_nr_test.cpp
@@ -7,6 +7,7 @@
 
 #include "core/SpectralNR.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <numbers>
@@ -217,6 +218,59 @@ void test_gain_finiteness()
     report("gain_finiteness: no NaN/Inf in 1000 hops of 1 kHz full-scale sine", nanCount == 0, detail);
 }
 
+std::vector<float> buildSyntheticAudio(int samples)
+{
+    constexpr int sampleRate = 24000;
+    std::vector<float> audio(samples);
+    for (int i = 0; i < samples; ++i) {
+        const double t = static_cast<double>(i) / sampleRate;
+        audio[i] = static_cast<float>(
+            0.30 * std::sin(2.0 * std::numbers::pi * 720.0 * t)
+          + 0.18 * std::sin(2.0 * std::numbers::pi * 1740.0 * t)
+          + 0.04 * std::sin(2.0 * std::numbers::pi * 43.0 * t));
+    }
+    return audio;
+}
+
+std::vector<float> processWithBlockSize(const std::vector<float>& input,
+                                        int blockSamples)
+{
+    SpectralNR nr;
+    nr.setGainMethod(2);
+
+    std::vector<float> output(input.size());
+    int offset = 0;
+    while (offset < static_cast<int>(input.size())) {
+        const int count = std::min(blockSamples,
+                                   static_cast<int>(input.size()) - offset);
+        nr.process(input.data() + offset, output.data() + offset, count);
+        offset += count;
+    }
+    return output;
+}
+
+void test_block_size_invariance()
+{
+    // KiwiSDR audio arrives in packet-sized bursts, while native Flex RX audio
+    // typically reaches NR2 at the 128-sample hop cadence. NR2 must produce the
+    // same stream either way; otherwise burst-sized calls can wrap the OLA ring
+    // and sound like rapid periodic audio gaps.
+    const std::vector<float> input = buildSyntheticAudio(24000);
+    const std::vector<float> hopOutput = processWithBlockSize(input, 128);
+    const std::vector<float> packetOutput = processWithBlockSize(input, 1024);
+
+    double maxAbsDiff = 0.0;
+    for (std::size_t i = 0; i < hopOutput.size(); ++i) {
+        maxAbsDiff = std::max(maxAbsDiff,
+                              static_cast<double>(std::abs(hopOutput[i] - packetOutput[i])));
+    }
+
+    char detail[96];
+    std::snprintf(detail, sizeof(detail), " (max abs diff: %.3e)", maxAbsDiff);
+    report("block_size_invariance: 1024-sample packets match 128-sample hops",
+           maxAbsDiff < 1e-7, detail);
+}
+
 void test_gain_formula_extreme_v()
 {
     // Directly verify the Ephraim-Malah gain formula at v values that caused
@@ -277,6 +331,9 @@ int main()
 
     std::printf("\n-- Gain finiteness (1000 hops, full-scale 1 kHz sine) --\n");
     test_gain_finiteness();
+
+    std::printf("\n-- Block-size invariance (Kiwi packet cadence regression) --\n");
+    test_block_size_invariance();
 
     std::printf("\n-- Gain formula at extreme v (NaN-clamp regression) --\n");
     test_gain_formula_extreme_v();


### PR DESCRIPTION
## Summary

![KiwiSDR receiver waterfall/FFT preview](https://raw.githubusercontent.com/rfoust/AetherSDR/5cbbd953309c3934755decc2e2b44a39159acf3f/docs/pr-assets/kiwisdr-cleanroom-preview.png)

Adds receive-only KiwiSDR integration as client-owned virtual RX antennas. KiwiSDR profiles can be configured in Settings -> Antennas, auto-connected, selected from existing slice/panadapter antenna controls, and used as alternate receive sources without transmitting or sending Flex antenna mutations. When a slice uses a Kiwi profile, AetherSDR routes Kiwi audio through the RX DSP/speaker path, keeps Flex and Kiwi audio sources mixable, shows Kiwi waterfall/FFT data for that panadapter, and overlays connection errors when the selected Kiwi receiver is unavailable.

The implementation keeps KiwiSDR isolated behind new `KiwiSdrClient`, `KiwiSdrManager`, and `KiwiSdrProtocol` components, adds an informational KiwiSDR applet, maps existing waterfall controls to Kiwi W/F cell/floor/rate while a Kiwi antenna is selected, and documents the clean-room protocol/design boundary in `docs/kiwisdr-cleanroom-design.md`.

## Constitution principle honored

Principle IV — this is a clean-room receive-only integration. The implementation was based on user requirements, user-provided protocol/spec text, clean black-box receive observations against user-approved KiwiSDR endpoints, and clean upstream AetherSDR interfaces.

## Clean-room provenance

Allowed sources used:

- User requirements and iterative behavior reports from this clean-room thread.
- User-provided KiwiSDR protocol/spec corrections pasted into this thread.
- Clean black-box receive-only observations against user-approved public KiwiSDR endpoints.
- Clean upstream AetherSDR `main`.
- AetherSDR project governance and accessibility docs.

Sources not used:

- No KiwiSDR AGPL source, WebSDR source, served JavaScript, server code, decoder code, protocol handlers, copied snippets, blogs, forums, or implementation-derived assets.
- No PR #3612, prior WebSDR worktrees/threads, contaminated temp files, rollout summaries, or previous WebSDR/RX-DSP implementation context.

## What changed

- Adds KiwiSDR virtual RX antenna profiles with custom names, endpoint normalization, auto-connect, reconnect handling, and persisted client-side settings.
- Allows slice/panadapter antenna menus to select Kiwi profiles without sending those names to the Flex radio.
- Routes Kiwi audio through AetherSDR RX DSP and speaker output while preserving independent Flex and per-Kiwi NR2/resampler/FIFO state.
- Mixes Flex audio and multiple Kiwi audio streams post-DSP so other slices remain audible.
- Adds Kiwi waterfall/FFT rendering from received W/F rows only, with independent retained history per Kiwi profile and per-panadapter source switching.
- Maps waterfall rate, gain/cell, floor/black-level, and auto behavior to Kiwi controls when a Kiwi RX antenna is active, and restores normal Flex behavior when it is not.
- Adds Kiwi S-meter support through the existing Flex-style meter surfaces and `MeterSmoother`, with unsupported layouts reported honestly instead of guessed.
- Adds connection overlays for selected Kiwi receivers when sound or waterfall sockets close.
- Adds protocol tests and NR2 regression coverage for the Kiwi receive path.

## Skipped / intentionally unsupported

- No TX/PTT/MOX/tune behavior.
- No password-protected Kiwi receiver support beyond public receive auth.
- No compressed/ADPCM Kiwi audio decoder.
- No Kiwi IQ stream support.
- No Kiwi directory discovery or extension launch/control surface.
- No calibrated dBm claim for Kiwi waterfall bytes; they are treated as raw display/bin intensity.
- No Kiwi-only controls that do not already map to an existing AetherSDR/Flex receive UI concept.

## Test plan

- [x] Local build passes (`cmake --build build --parallel`)
- [x] Focused Kiwi/NR2 tests pass (`ctest --test-dir build -R "kiwi|spectral_nr" --output-on-failure`)
- [x] Whitespace check passes (`git diff --check --cached`)
- [x] Accessibility scanner run (`python3 tools/check_a11y.py`; warning-only existing findings remain)
- [x] Manual receive testing during development against public KiwiSDR endpoints and existing AetherSDR panadapter/audio workflows
- [ ] Existing tests pass in CI

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — Kiwi RX antenna profiles are stored under one feature-owned JSON key
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from proprietary or AGPL implementation source
- [x] All meter UI uses `MeterSmoother`
- [x] Documentation updated for user-visible behavior and clean-room provenance
- [x] Security-sensitive changes reference a GHSA if applicable: N/A
