### PR TITLE
Added metainfo for AppStream (for Linux)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2467,4 +2467,7 @@ else()
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/256x256/apps
         RENAME aethersdr.png
     )
+    install(FILES packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo
+    )
 endif()

--- a/packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml
+++ b/packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.aethersdr.aethersdr</id>
+  
+  <name>AetherSDR</name>
+  <summary>A Linux-native client for FlexRadio Systems transceivers</summary>
+  
+  <metadata_license>MIT</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  
+  <description>
+    <p>
+      AetherSDR brings FlexRadio operation to Linux without Wine or virtual machines. Built from the ground up with Qt6 and C++20, it speaks the SmartSDR protocol natively and aims to replicate the full SmartSDR experience.
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">AetherSDR.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/aethersdr/AetherSDR/refs/heads/main/docs/assets/screenshot-current.png</image>
+    </screenshot>
+  </screenshots>
+  
+  <url type="homepage">https://github.com/aethersdr/AetherSDR</url>
+  <url type="bugtracker">https://github.com/aethersdr/AetherSDR/issues</url>
+  <url type="help">https://github.com/aethersdr/AetherSDR/blob/main/SUPPORT.md</url>
+  <url type="vcs-browser">https://github.com/aethersdr/AetherSDR</url>
+  <url type="contribute">https://github.com/aethersdr/AetherSDR#contributing</url>
+</component>


### PR DESCRIPTION
Hello,
I added the AppStream metadata for Linux.

It allows the graphical stores to properly show the AetherSDR, with description and screenshot.

It can be (and should be!) expanded in the future. This is the only basic one.
Here are the links for the reference:
<https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent>
<https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Releases.html>
<https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html>

I also added the proper installation in CMakeLists.txt

Thanks!
Dawid Kulas
SP9SKA