### PR TITLE
Added a simple manpage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2472,4 +2472,9 @@ else()
     install(FILES packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo
     )
+    # Install the man page uncompressed; distro packaging compresses man pages
+    # per its own policy (Debian/Arch re-gzip, so shipping a .gz would clash).
+    install(FILES packaging/linux/aethersdr.1
+        DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+    )
 endif()

--- a/packaging/linux/aethersdr.1
+++ b/packaging/linux/aethersdr.1
@@ -1,0 +1,11 @@
+.TH AETHERSDR "1" "2026-06-20" "AetherSDR" "User Commands"
+.SH NAME
+AetherSDR \- FlexRadio transceiver client
+.SH SYNOPSIS
+.B aethersdr
+.SH DESCRIPTION
+AetherSDR brings FlexRadio operation to Linux without Wine or virtual machines.
+Built from the ground up with Qt6 and C++20, it speaks the SmartSDR protocol
+natively and aims to replicate the full SmartSDR experience.
+.SH SEE ALSO
+Project homepage: https://github.com/aethersdr/AetherSDR


### PR DESCRIPTION
Hello,

I added a simple manual page for AetherSDR.

Of course, it is only for the sake of standards, but I think it is not a problem to add it :smile:

I also tried to a add proper CMake install rule, but I am not sure if it is good.

Thanks
Dawid Kulas
SP9SKA