### PR TITLE
feat(kiwisdr): dedicated Support-menu logging categories

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1949,6 +1949,8 @@ void AudioEngine::setKiwiSdrAudioSourceEnabled(const QString& sourceId, bool on)
 
     std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
     source->enabled = on;
+    qCDebug(lcKiwiSdrAudio).noquote()
+        << "Audio source" << (on ? "enabled" : "disabled") << source->id;
     source->rxBuffer.clear();
     source->rxPackets.clear();
     source->outputBuffer.clear();
@@ -2017,6 +2019,7 @@ void AudioEngine::removeKiwiSdrAudioSource(const QString& sourceId)
         });
     if (it != m_externalKiwiSources.end()) {
         m_externalKiwiSources.erase(it, m_externalKiwiSources.end());
+        qCDebug(lcKiwiSdrAudio).noquote() << "Audio source removed" << id;
         updateRxBufferStats();
     }
 }

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -307,7 +307,7 @@ void KiwiSdrClient::openWebSockets()
     connect(m_soundSocket, &QWebSocket::binaryMessageReceived,
             this, &KiwiSdrClient::handleBinaryMessage);
     connect(m_soundSocket, &QWebSocket::disconnected, this, [this]() {
-        qCInfo(lcProtocol).noquote()
+        qCInfo(lcKiwiSdr).noquote()
             << "KiwiSDR SND closed code="
             << (m_soundSocket
                     ? static_cast<int>(m_soundSocket->closeCode())
@@ -348,7 +348,7 @@ void KiwiSdrClient::openWebSockets()
                                                 : tr("KiwiSDR sound socket error."),
                                   m_soundSocketConnected);
             });
-    qCInfo(lcProtocol).noquote() << "KiwiSDR SND URL" << soundUrl;
+    qCInfo(lcKiwiSdr).noquote() << "KiwiSDR SND URL" << soundUrl;
     m_soundSocket->open(QUrl(soundUrl));
 
     m_waterfallSocket = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
@@ -361,7 +361,7 @@ void KiwiSdrClient::openWebSockets()
     connect(m_waterfallSocket, &QWebSocket::binaryMessageReceived,
             this, &KiwiSdrClient::handleBinaryMessage);
     connect(m_waterfallSocket, &QWebSocket::disconnected, this, [this]() {
-        qCInfo(lcProtocol).noquote()
+        qCInfo(lcKiwiSdr).noquote()
             << "KiwiSDR W/F closed code="
             << (m_waterfallSocket
                     ? static_cast<int>(m_waterfallSocket->closeCode())
@@ -393,7 +393,7 @@ void KiwiSdrClient::openWebSockets()
                                                     : tr("KiwiSDR waterfall socket error."),
                                   m_waterfallSocketConnected);
             });
-    qCInfo(lcProtocol).noquote() << "KiwiSDR W/F URL" << waterfallUrl;
+    qCInfo(lcKiwiSdr).noquote() << "KiwiSDR W/F URL" << waterfallUrl;
     m_waterfallSocket->open(QUrl(waterfallUrl));
 }
 #endif
@@ -684,7 +684,7 @@ void KiwiSdrClient::sendTrackedSliceToServer()
     const int lowCutHz = kiwiLowCutHz();
     const int highCutHz = kiwiHighCutHz();
     if (lowCutHz >= highCutHz) {
-        qCWarning(lcProtocol).noquote()
+        qCWarning(lcKiwiSdr).noquote()
             << "KiwiSDR refusing invalid passband mode=" << mode
             << "freq_khz=" << QString::number(freqKhz, 'f', 3)
             << "low_cut=" << lowCutHz
@@ -1084,7 +1084,7 @@ QVector<float> KiwiSdrClient::decodeWaterfallFrame(const QByteArray& frame) cons
         // display. We request wf_comp=0 during setup, and drop encoded rows
         // from endpoints that ignore that request until a clean decoder is
         // available.
-        qCDebug(lcProtocol).noquote()
+        qCDebug(lcKiwiSdr).noquote()
             << "KiwiSDR W/F compressed row ignored len=" << frame.size()
             << "zoom=" << frameZoom
             << "first=" << firstBytesHex(frame);
@@ -1112,12 +1112,12 @@ void KiwiSdrClient::handleBinaryMessage(const QByteArray& frame)
     } else if (frame.startsWith("W/F")) {
         handleWaterfallFrame(frame);
     } else if (frame.startsWith("EXT")) {
-        qCDebug(lcProtocol).noquote()
+        qCDebug(lcKiwiSdr).noquote()
             << "KiwiSDR EXT ignored len=" << frame.size()
             << "first=" << firstBytesHex(frame);
     } else {
         const QString tag = QString::fromLatin1(frame.left(3));
-        qCDebug(lcProtocol).noquote()
+        qCDebug(lcKiwiSdr).noquote()
             << "KiwiSDR unknown binary tag=" << tag
             << "len=" << frame.size()
             << "first=" << firstBytesHex(frame);
@@ -1129,14 +1129,14 @@ void KiwiSdrClient::handleSoundFrame(const QByteArray& frame)
     m_soundFrameSeen = true;
     if (!m_loggedSoundFrameShape) {
         m_loggedSoundFrameShape = true;
-        qCDebug(lcProtocol).noquote()
+        qCDebug(lcKiwiSdrAudio).noquote()
             << "KiwiSDR SND frame len=" << frame.size()
             << "first=" << firstBytesHex(frame);
     }
     const KiwiSdrProtocol::SoundFrameHeader header =
         KiwiSdrProtocol::parseSoundFrameHeader(frame);
     if (!isSupportedPcmSoundFrame(frame, header)) {
-        qCWarning(lcProtocol).noquote()
+        qCWarning(lcKiwiSdrAudio).noquote()
             << "KiwiSDR SND unsupported frame shape len=" << frame.size()
             << "first=" << firstBytesHex(frame);
         return;
@@ -1173,7 +1173,7 @@ void KiwiSdrClient::handleWaterfallFrame(const QByteArray& frame)
 {
     if (!m_loggedWaterfallFrameShape) {
         m_loggedWaterfallFrameShape = true;
-        qCDebug(lcProtocol).noquote()
+        qCDebug(lcKiwiSdr).noquote()
             << "KiwiSDR W/F frame len=" << frame.size()
             << "first=" << firstBytesHex(frame);
     }
@@ -1280,6 +1280,9 @@ void KiwiSdrClient::handleTextMessage(const QString& text)
             return;
         }
         if (std::abs(value - m_soundSampleRateHz) > 1.0) {
+            qCInfo(lcKiwiSdr).noquote()
+                << "KiwiSDR audio rate negotiated" << value
+                << "Hz (resampler rebuild)";
             m_soundSampleRateHz = value;
             m_soundResamplerRateHz = 0.0;
             m_soundResampler.reset();
@@ -1292,7 +1295,7 @@ void KiwiSdrClient::handleTextMessage(const QString& text)
         }
         const QString key = part.left(eq);
         const QString valueText = part.mid(eq + 1);
-        qCDebug(lcProtocol).noquote()
+        qCDebug(lcKiwiSdr).noquote()
             << "KiwiSDR MSG" << key << "=" << valueText;
         if (key == QStringLiteral("too_busy")) {
             bool busyOk = false;
@@ -1586,7 +1589,7 @@ bool KiwiSdrClient::retryWithSecureWebSocket(bool transportEstablished)
 void KiwiSdrClient::sendSoundCommand(const QString& command)
 {
     if (m_soundSocket && m_soundSocket->state() == QAbstractSocket::ConnectedState) {
-        qCDebug(lcProtocol).noquote()
+        qCDebug(lcKiwiSdr).noquote()
             << "KiwiSDR SND ->" << redactedKiwiCommand(command);
         m_soundSocket->sendTextMessage(command);
     }
@@ -1596,7 +1599,7 @@ void KiwiSdrClient::sendWaterfallCommand(const QString& command)
 {
     if (m_waterfallSocket
         && m_waterfallSocket->state() == QAbstractSocket::ConnectedState) {
-        qCDebug(lcProtocol).noquote()
+        qCDebug(lcKiwiSdr).noquote()
             << "KiwiSDR W/F ->" << redactedKiwiCommand(command);
         m_waterfallSocket->sendTextMessage(command);
     }

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -1,6 +1,7 @@
 #include "KiwiSdrManager.h"
 
 #include "AppSettings.h"
+#include "LogManager.h"
 
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -150,6 +151,9 @@ QString KiwiSdrManager::addProfile(const QString& name, const QString& endpoint)
     profile.name = displayName;
     m_profiles.append(profile);
     saveSettings();
+    qCInfo(lcKiwiSdr).noquote()
+        << "Profile added" << profile.name << "endpoint=" << profile.endpoint
+        << "id=" << profile.id;
     emit profilesChanged();
     return profile.id;
 }
@@ -197,6 +201,7 @@ void KiwiSdrManager::removeProfile(const QString& id)
         return;
     }
 
+    qCInfo(lcKiwiSdr).noquote() << "Profile removed" << displayName(id) << "id=" << id;
     cancelReconnect(id);
     disconnectProfile(id);
     if (KiwiSdrClient* c = m_clients.take(id)) {
@@ -251,6 +256,9 @@ void KiwiSdrManager::connectProfile(const QString& id)
     if (!c->hasTrackedSlice()) {
         return;
     }
+    qCInfo(lcKiwiSdr).noquote()
+        << "Connecting" << m_profiles[idx].name
+        << "->" << m_profiles[idx].endpoint;
     c->connectToEndpoint(m_profiles[idx].endpoint);
 }
 
@@ -258,6 +266,7 @@ void KiwiSdrManager::disconnectProfile(const QString& id)
 {
     cancelReconnect(id);
     if (KiwiSdrClient* c = client(id)) {
+        qCInfo(lcKiwiSdr).noquote() << "Disconnecting" << displayName(id);
         c->disconnectFromEndpoint();
     }
     emit audioSourceEnabledChanged(id, false);
@@ -349,6 +358,9 @@ void KiwiSdrManager::assignSliceToProfile(int sliceId, const QString& profileId,
     }
 
     m_sliceAssignments.insert(sliceId, profileId);
+    qCInfo(lcKiwiSdr).noquote()
+        << "Slice" << sliceId << "assigned to" << displayName(profileId)
+        << "freq=" << frequencyMhz << "MHz mode=" << mode;
     emit sliceAssignmentChanged(sliceId, profileId);
 
     if (KiwiSdrClient* c = ensureClient(profileId)) {
@@ -367,6 +379,8 @@ void KiwiSdrManager::clearSliceAssignment(int sliceId)
         return;
     }
 
+    qCInfo(lcKiwiSdr).noquote()
+        << "Slice" << sliceId << "cleared from" << displayName(previousProfile);
     emit audioSourceEnabledChanged(previousProfile, false);
     if (KiwiSdrClient* c = client(previousProfile)) {
         c->setAudioActive(false);
@@ -435,6 +449,9 @@ KiwiSdrClient* KiwiSdrManager::ensureClient(const QString& id)
     connect(c, &KiwiSdrClient::stateChanged,
             this, [this, id, c](KiwiSdrClient::State state, const QString& detail) {
         m_stateDetails.insert(id, detail);
+        qCInfo(lcKiwiSdr).noquote()
+            << "State" << displayName(id) << "->" << static_cast<int>(state)
+            << (detail.isEmpty() ? QString() : QStringLiteral("(") + detail + QStringLiteral(")"));
         if (state == KiwiSdrClient::State::Connecting) {
             m_telemetry.insert(id, {});
             emit profileTelemetryChanged(id, m_telemetry.value(id));
@@ -584,6 +601,9 @@ void KiwiSdrManager::scheduleReconnect(const QString& id)
     }
 
     if (!timer->isActive()) {
+        qCInfo(lcKiwiSdr).noquote()
+            << "Reconnect scheduled for" << displayName(id)
+            << "in" << kRecoverableReconnectDelayMs << "ms";
         timer->start();
     }
 }

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -39,6 +39,8 @@ Q_LOGGING_CATEGORY(lcCw,         "aether.cw",          QtWarningMsg)
 Q_LOGGING_CATEGORY(lcSHistory,  "aether.shistory",    QtWarningMsg)
 Q_LOGGING_CATEGORY(lcAx25,       "aether.ax25",        QtWarningMsg)
 Q_LOGGING_CATEGORY(lcWaveform,   "aether.waveform",    QtWarningMsg)
+Q_LOGGING_CATEGORY(lcKiwiSdr,    "aether.kiwisdr",     QtDebugMsg)
+Q_LOGGING_CATEGORY(lcKiwiSdrAudio, "aether.kiwisdr.audio", QtWarningMsg)
 
 LogManager::LogManager()
 {
@@ -70,6 +72,8 @@ LogManager::LogManager()
         {"aether.shistory",   "S History",     "Past-Signals voice detection: noise floor, region width, band-plan filter"},
         {"aether.ax25",       "AetherModem", "AX.25 modem lifecycle, RX/TX audio, demod, framing, and packet diagnostics"},
         {"aether.waveform",   "Waveform",    "Docker waveform image install upload"},
+        {"aether.kiwisdr",    "KiwiSDR",     "KiwiSDR remote RX antennas: connect, handshake, audio/waterfall negotiation, reconnect, profile lifecycle"},
+        {"aether.kiwisdr.audio", "KiwiSDR Audio/DSP", "Verbose KiwiSDR receive audio: frame decode, resampler, jitter/FIFO under/overrun, mixing (high-rate; off by default)"},
     };
 
     // QLoggingCategory objects are defined above via Q_LOGGING_CATEGORY macros.
@@ -250,7 +254,7 @@ void LogManager::loadSettings()
     // Default Discovery, Commands, and Status to on
     static const QStringList defaultOn = {
         "aether.discovery", "aether.connection", "aether.protocol",
-        "aether.audio.summary"
+        "aether.audio.summary", "aether.kiwisdr"
     };
     for (auto& c : m_categories) {
         QString def = defaultOn.contains(c.id) ? "True" : "False";

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -39,6 +39,8 @@ Q_DECLARE_LOGGING_CATEGORY(lcCw)
 Q_DECLARE_LOGGING_CATEGORY(lcSHistory)
 Q_DECLARE_LOGGING_CATEGORY(lcAx25)
 Q_DECLARE_LOGGING_CATEGORY(lcWaveform)
+Q_DECLARE_LOGGING_CATEGORY(lcKiwiSdr)
+Q_DECLARE_LOGGING_CATEGORY(lcKiwiSdrAudio)
 
 // Central registry for toggling per-module diagnostic logging at runtime.
 // The Support dialog (Help → Support) uses this to let users enable/disable

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -11,6 +11,7 @@
 #include "core/AudioEngine.h"
 #include "core/KiwiSdrClient.h"
 #include "core/KiwiSdrManager.h"
+#include "core/LogManager.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 
@@ -140,6 +141,13 @@ void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
     }
     slice->setExternalReceiveAudioReplacementMute(true);
 
+    // Receive-only: route audio from the Kiwi profile and mute Flex audio for
+    // this slice. No antenna command is sent to the radio (Principle I).
+    qCInfo(lcKiwiSdr).noquote()
+        << "Virtual RX antenna selected for slice" << sliceId
+        << "profile=" << m_kiwiSdrManager->displayName(profileId)
+        << "(Flex audio muted, no radio command sent)";
+
     m_kiwiSdrManager->assignSliceToProfile(
         sliceId, profileId, slice->frequency(), slice->mode(),
         slice->filterLow(), slice->filterHigh(), slice->panId());
@@ -170,6 +178,9 @@ void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
 
 void MainWindow::clearKiwiSdrVirtualAntennaForSlice(int sliceId)
 {
+    qCInfo(lcKiwiSdr).noquote()
+        << "Virtual RX antenna cleared for slice" << sliceId
+        << "(Flex audio restored)";
     QString panId;
     if (SliceModel* slice = m_radioModel.slice(sliceId)) {
         panId = slice->panId();


### PR DESCRIPTION
## Summary

Follow-up to #3668. KiwiSDR currently borrows the shared `aether.protocol` logging category (so its messages can't be toggled apart from SmartSDR protocol logging), and four of its five source files log nothing at all. This adds two dedicated QLoggingCategory entries that surface as checkboxes in **Help → Support → Diagnostic Logging** (auto-built from `LogManager`'s category list).

## What changed

- **`aether.kiwisdr` — "KiwiSDR" (default ON):** the connection/diagnosis story — connect/disconnect, handshake, audio-rate/waterfall negotiation, reconnect scheduling, profile add/remove, slice assignment, and the virtual-RX-antenna select/clear (which logs that **no antenna command is sent to the radio — Principle I**).
- **`aether.kiwisdr.audio` — "KiwiSDR Audio/DSP" (default OFF, verbose):** per-source audio enable/disable/remove and frame-shape diagnostics. Mirrors the existing `aether.audio` / `aether.audio.summary` split so the high-rate decode chatter is separately toggleable.
- **Migrated** the 14 existing `KiwiSdrClient` calls off `aether.protocol` onto these categories, so KiwiSDR logging toggles independently of SmartSDR protocol logging.
- **Added** lifecycle logging to the previously-silent `KiwiSdrManager` and `MainWindow_KiwiSdr`.
- Warnings (unsupported stream shapes, invalid passband) always pass the filter regardless of toggle.

## Notes

- No new flat `AppSettings` keys — the Support dialog auto-persists each category under its existing `LogCategory_*` key; only the two `m_categories` rows + `defaultOn` entry are added.
- Cross-platform: pure `QLoggingCategory` / `LogManager`, no platform-specific code.

## Test plan

- [x] Builds clean on current `main`
- [x] `kiwi_sdr_protocol_test` + `spectral_nr_test` pass
- [x] Verified both categories register and appear in the Support dialog (auto-built from the category list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)