### PR TITLE
fix(ulanzi): Linux evdev access — detect inaccessible dial + one-click udev grant

### DIFF
--- a/packaging/linux/70-ulanzi-dial.rules
+++ b/packaging/linux/70-ulanzi-dial.rules
@@ -1,0 +1,17 @@
+# AetherSDR — Ulanzi Dial access (#3670)
+#
+# Grants the active local user access to Ulanzi Dial control-surface input
+# nodes so AetherSDR's evdev encoder mapper can read rotation/button events.
+# Without this, /dev/input/event* for the dial is root:input 0660 and the
+# (non-root, non-"input"-group) AetherSDR process cannot open it — the mapper
+# then shows "disconnected" with no obvious cause.
+#
+# uaccess hands the node to whoever owns the active local session (via a
+# systemd-logind ACL), so no static group membership is required.
+#
+# This file is NOT installed by the build. AetherSDR installs an identical copy
+# on demand — only after it actually detects a Dial it cannot open — via a
+# polkit-authenticated action (Settings → Ulanzi Dial mapper → "Grant access").
+# Distro packagers who prefer to ship it unconditionally may install it to
+# /usr/lib/udev/rules.d/.
+SUBSYSTEM=="input", KERNEL=="event*", ATTRS{name}=="Ulanzi Dial*", TAG+="uaccess"

--- a/packaging/linux/70-ulanzi-dial.rules
+++ b/packaging/linux/70-ulanzi-dial.rules
@@ -1,4 +1,4 @@
-# AetherSDR — Ulanzi Dial access (#3670)
+# AetherSDR — Ulanzi Dial access (#3599)
 #
 # Grants the active local user access to Ulanzi Dial control-surface input
 # nodes so AetherSDR's evdev encoder mapper can read rotation/button events.

--- a/src/core/EvdevEncoderManager.cpp
+++ b/src/core/EvdevEncoderManager.cpp
@@ -51,6 +51,18 @@ QString bareKeySignature(int keycode)
     }
 }
 
+// Read an input device's name from sysfs (e.g. "Ulanzi Dial Keyboard").  The
+// sysfs `name` attribute is world-readable, so this works even when we lack
+// permission to open the /dev/input/event* node itself — which is exactly how
+// we detect a present-but-inaccessible dial.
+QString sysfsInputName(const QString& eventNode)
+{
+    QFile f(QStringLiteral("/sys/class/input/%1/device/name").arg(eventNode));
+    if (f.open(QIODevice::ReadOnly))
+        return QString::fromUtf8(f.readAll()).trimmed();
+    return {};
+}
+
 QString chordSignature(int keycode, bool withPreviousSong)
 {
     QString letter;
@@ -105,8 +117,24 @@ void EvdevEncoderManager::stop()
 void EvdevEncoderManager::onInputDirChanged()
 {
     if (m_fd >= 0) return;  // already attached
-    const QString path = findMatchingDevice();
-    if (path.isEmpty()) return;
+    QString blockedName;
+    const QString path = findMatchingDevice(&blockedName);
+    if (path.isEmpty()) {
+        // A recognized dial is present but we can't open its node — the udev
+        // access rule isn't installed.  Surface it once so the UI can offer to
+        // install the rule, rather than silently reading as "disconnected".
+        if (!blockedName.isEmpty() && !m_accessRequiredEmitted) {
+            m_accessRequiredEmitted = true;
+            qCWarning(lcDevices)
+                << "EvdevEncoderManager:" << blockedName
+                << "detected but its /dev/input node is not accessible (EACCES)."
+                << "Install the udev access rule (Ulanzi Dial mapper → Grant"
+                << "access) or add this user to the 'input' group.";
+            emit accessRequired(blockedName);
+        }
+        return;
+    }
+    m_accessRequiredEmitted = false;
     if (openAndGrab(path)) {
         qCInfo(lcDevices) << "EvdevEncoderManager: attached"
                           << m_deviceName << "at" << m_devicePath;
@@ -114,25 +142,28 @@ void EvdevEncoderManager::onInputDirChanged()
     }
 }
 
-QString EvdevEncoderManager::findMatchingDevice() const
+QString EvdevEncoderManager::findMatchingDevice(QString* blockedName) const
 {
     QDir dir(QStringLiteral("/dev/input"));
     const auto entries = dir.entryList({QStringLiteral("event*")}, QDir::System);
     for (const QString& name : entries) {
+        // Match on the sysfs name first (always readable), so a dial we lack
+        // permission to open is still recognized as "present".
+        const QString devName = sysfsInputName(name);
+        bool supported = false;
+        for (const QString& pattern : supportedNames()) {
+            if (devName == pattern) { supported = true; break; }
+        }
+        if (!supported) continue;
+
         const QString path = dir.filePath(name);
         int fd = ::open(path.toLocal8Bit().constData(), O_RDONLY | O_NONBLOCK | O_CLOEXEC);
-        if (fd < 0) continue;
-        char devName[256] = {};
-        if (ioctl(fd, EVIOCGNAME(sizeof(devName) - 1), devName) >= 0) {
-            const QString s = QString::fromUtf8(devName);
-            for (const QString& pattern : supportedNames()) {
-                if (s == pattern) {
-                    ::close(fd);
-                    return path;
-                }
-            }
+        if (fd >= 0) {
+            ::close(fd);
+            return path;
         }
-        ::close(fd);
+        if ((errno == EACCES || errno == EPERM) && blockedName)
+            *blockedName = devName;
     }
     return {};
 }

--- a/src/core/EvdevEncoderManager.h
+++ b/src/core/EvdevEncoderManager.h
@@ -51,6 +51,10 @@ signals:
     void tuneSteps(int steps);
     void buttonEvent(const QString& signature, int action);
     void connectionChanged(bool connected, const QString& name);
+    // Emitted when a recognized dial is present but its /dev/input node can't
+    // be opened (EACCES) — i.e. the udev access rule isn't installed. The UI
+    // uses this to offer a one-click, polkit-authenticated rule install.
+    void accessRequired(const QString& deviceName);
 
 private slots:
     void onReadable();
@@ -58,8 +62,10 @@ private slots:
 
 private:
     // Scan /dev/input/event* for a device matching one of our name patterns.
-    // Returns the path of the first match, or empty string if none found.
-    QString findMatchingDevice() const;
+    // Returns the path of the first openable match, or empty string if none.
+    // If a name-matching device is found but its node can't be opened
+    // (EACCES), its name is written to *blockedName (when non-null).
+    QString findMatchingDevice(QString* blockedName = nullptr) const;
     bool openAndGrab(const QString& path);
     void closeFd();
     void emitChord(int keycode, int action);  // chord assembly + signature emit
@@ -70,6 +76,7 @@ private:
     QSocketNotifier* m_notifier{nullptr};
     QFileSystemWatcher* m_watcher{nullptr};
     QTimer* m_rescanTimer{nullptr};  // debounced rescan after directory change
+    bool m_accessRequiredEmitted{false};  // de-dupe accessRequired across rescans
 
     // Decoder state — Ulanzi Dial encodes some buttons as Ctrl+key chords
     // and one as a Ctrl+Y+KEY_PREVIOUSSONG compound. We assemble chords

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -20,6 +20,14 @@
 #include <QPushButton>
 #include <QResizeEvent>
 #include <QVBoxLayout>
+#ifdef Q_OS_LINUX
+#include "core/LogManager.h"
+#include <QMessageBox>
+#include <QMetaObject>
+#include <QProcess>
+#include <QStandardPaths>
+#include <QTimer>
+#endif
 
 namespace AetherSDR {
 
@@ -173,6 +181,18 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
     m_statusLabel->setStyleSheet("QLabel { color: #8ea8c0; }");
     bottomRow->addWidget(m_statusLabel);
 
+#ifdef Q_OS_LINUX
+    // Shown only when a dial is detected but its evdev node can't be opened.
+    m_grantAccessBtn = new QPushButton(tr("Grant access"));
+    m_grantAccessBtn->setToolTip(
+        tr("Install a udev rule (with administrator approval) so AetherSDR can "
+           "read this dial's input. Required once per machine."));
+    m_grantAccessBtn->setVisible(false);
+    connect(m_grantAccessBtn, &QPushButton::clicked,
+            this, &UlanziDialMapperDialog::onGrantAccessClicked);
+    bottomRow->addWidget(m_grantAccessBtn);
+#endif
+
     bottomRow->addStretch(1);
 
     m_lastEventLabel = new QLabel(tr("Last event: —"));
@@ -209,6 +229,10 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
                 this, &UlanziDialMapperDialog::onButtonEvent);
         connect(m_manager, &UlanziDialBackend::connectionChanged,
                 this, &UlanziDialMapperDialog::onConnectionChanged);
+#ifdef Q_OS_LINUX
+        connect(m_manager, &UlanziDialBackend::accessRequired,
+                this, &UlanziDialMapperDialog::onAccessRequired);
+#endif
         onConnectionChanged(m_manager->isConnected(), m_manager->deviceName());
     } else {
         m_statusLabel->setText(tr("Manager unavailable (Linux build only)"));
@@ -528,7 +552,93 @@ void UlanziDialMapperDialog::onConnectionChanged(bool connected, const QString& 
     m_statusLabel->setStyleSheet(connected
         ? "QLabel { color: #4dd87a; }"
         : "QLabel { color: #cc3333; }");
+#ifdef Q_OS_LINUX
+    // Once connected, the access problem is resolved — hide the offer.
+    if (connected && m_grantAccessBtn)
+        m_grantAccessBtn->setVisible(false);
+#endif
 }
+
+#ifdef Q_OS_LINUX
+void UlanziDialMapperDialog::onAccessRequired(const QString& deviceName)
+{
+    if (!m_statusLabel) return;
+    QString display = deviceName;
+    if (display.endsWith(QStringLiteral(" Keyboard"), Qt::CaseInsensitive))
+        display.chop(QStringLiteral(" Keyboard").size());
+    m_statusLabel->setText(tr("%1 detected — needs permission").arg(display));
+    m_statusLabel->setStyleSheet("QLabel { color: #e0a030; }");
+    if (m_grantAccessBtn) {
+        m_grantAccessBtn->setVisible(true);
+        m_grantAccessBtn->setEnabled(true);
+    }
+}
+
+void UlanziDialMapperDialog::onGrantAccessClicked()
+{
+    const QString pkexec = QStandardPaths::findExecutable(QStringLiteral("pkexec"));
+    if (pkexec.isEmpty()) {
+        QMessageBox::warning(this, tr("Grant access"),
+            tr("pkexec was not found. Install polkit, or add this user to the "
+               "'input' group manually."));
+        return;
+    }
+
+    if (m_grantAccessBtn) {
+        m_grantAccessBtn->setEnabled(false);
+        m_grantAccessBtn->setText(tr("Authorizing…"));
+    }
+
+    // Install the udev access rule and reload, as root via polkit. The rule
+    // content matches packaging/linux/70-ulanzi-dial.rules. The rule is passed
+    // as an argv element (not interpolated into the script) to avoid any
+    // quoting/injection concern.
+    static const QString kRule = QStringLiteral(
+        "# AetherSDR — Ulanzi Dial access (#3670)\n"
+        "SUBSYSTEM==\"input\", KERNEL==\"event*\", "
+        "ATTRS{name}==\"Ulanzi Dial*\", TAG+=\"uaccess\"\n");
+    static const QString kScript = QStringLiteral(
+        "set -e; "
+        "printf '%s' \"$1\" > /etc/udev/rules.d/70-ulanzi-dial.rules; "
+        "udevadm control --reload-rules; "
+        "udevadm trigger --subsystem-match=input");
+
+    auto* proc = new QProcess(this);
+    connect(proc, &QProcess::finished, this,
+            [this, proc](int code, QProcess::ExitStatus) {
+        const QByteArray err = proc->readAllStandardError();
+        proc->deleteLater();
+        if (m_grantAccessBtn) m_grantAccessBtn->setText(tr("Grant access"));
+        if (code == 0) {
+            if (m_statusLabel) {
+                m_statusLabel->setText(tr("Access granted — connecting…"));
+                m_statusLabel->setStyleSheet("QLabel { color: #4dd87a; }");
+            }
+            // The udev trigger applies the ACL asynchronously; give logind a
+            // moment, then ask the backend to rescan. If that misses, the user
+            // can re-toggle the dial's Bluetooth connection.
+            QTimer::singleShot(900, this, [this] {
+                if (m_manager)
+                    QMetaObject::invokeMethod(m_manager, &UlanziDialBackend::start,
+                                              Qt::QueuedConnection);
+            });
+        } else {
+            qCWarning(lcDevices) << "Ulanzi Dial: rule install failed code"
+                                 << code << err;
+            if (m_grantAccessBtn) m_grantAccessBtn->setEnabled(true);
+            if (m_statusLabel) {
+                // code 126/127 = polkit auth dismissed/failed.
+                m_statusLabel->setText(code == 126 || code == 127
+                    ? tr("Authorization cancelled")
+                    : tr("Access install failed"));
+                m_statusLabel->setStyleSheet("QLabel { color: #cc3333; }");
+            }
+        }
+    });
+    proc->start(pkexec, {QStringLiteral("/bin/sh"), QStringLiteral("-c"),
+                         kScript, QStringLiteral("aethersdr"), kRule});
+}
+#endif  // Q_OS_LINUX
 
 } // namespace AetherSDR
 

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -594,7 +594,7 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
     // as an argv element (not interpolated into the script) to avoid any
     // quoting/injection concern.
     static const QString kRule = QStringLiteral(
-        "# AetherSDR — Ulanzi Dial access (#3670)\n"
+        "# AetherSDR — Ulanzi Dial access (#3599)\n"
         "SUBSYSTEM==\"input\", KERNEL==\"event*\", "
         "ATTRS{name}==\"Ulanzi Dial*\", TAG+=\"uaccess\"\n");
     static const QString kScript = QStringLiteral(
@@ -604,6 +604,21 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
         "udevadm trigger --subsystem-match=input");
 
     auto* proc = new QProcess(this);
+    // If pkexec can't even start, QProcess emits errorOccurred and never emits
+    // finished — recover the button instead of leaving it stuck on "Authorizing…".
+    connect(proc, &QProcess::errorOccurred, this,
+            [this, proc](QProcess::ProcessError) {
+        if (proc->state() != QProcess::NotRunning) return;  // started; finished will handle it
+        proc->deleteLater();
+        if (m_grantAccessBtn) {
+            m_grantAccessBtn->setEnabled(true);
+            m_grantAccessBtn->setText(tr("Grant access"));
+        }
+        if (m_statusLabel) {
+            m_statusLabel->setText(tr("Access install failed"));
+            m_statusLabel->setStyleSheet("QLabel { color: #cc3333; }");
+        }
+    });
     connect(proc, &QProcess::finished, this,
             [this, proc](int code, QProcess::ExitStatus) {
         const QByteArray err = proc->readAllStandardError();

--- a/src/gui/UlanziDialMapperDialog.h
+++ b/src/gui/UlanziDialMapperDialog.h
@@ -74,6 +74,12 @@ private slots:
     void onTuneSteps(int steps);
     void onButtonEvent(const QString& signature, int action);
     void onConnectionChanged(bool connected, const QString& name);
+#ifdef Q_OS_LINUX
+    // Dial present but its evdev node isn't accessible — offer to install the
+    // udev access rule via polkit.
+    void onAccessRequired(const QString& deviceName);
+    void onGrantAccessClicked();
+#endif
 
 private:
     struct Pill {
@@ -112,6 +118,9 @@ private:
     QLabel* m_lastEventLabel{nullptr};
     QPushButton* m_resetBtn{nullptr};
     QPushButton* m_closeBtn{nullptr};
+#ifdef Q_OS_LINUX
+    QPushButton* m_grantAccessBtn{nullptr};  // shown only on accessRequired
+#endif
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
## Summary

Fixes the Linux Ulanzi Dial "disconnected" failure (**Closes #3599**, repurposed from its original BLE-GATT premise — see that issue for why).

On Linux, BlueZ HoG bridges the dial fine and creates `/dev/input/event*` nodes, but they're `root:input 0660`. A normal AetherSDR process (not root, not in `input`, no `uaccess` ACL) can't `open()` them — and `EvdevEncoderManager::findMatchingDevice()` hit `EACCES` and **silently `continue`d**, so the dial read as "disconnected" with no diagnostic.

## What changed (Linux-specific — evdev access defect; Windows/macOS unchanged)

- **Detect a present-but-inaccessible dial:** match on the **sysfs** device name (`/sys/class/input/event*/device/name`, world-readable) so the dial is recognized even when its node can't be opened. On `EACCES`, emit a new `accessRequired(name)` signal + a clear log line instead of failing silently.
- **One-click on-demand grant:** the Ulanzi mapper shows a **"Grant access"** button on `accessRequired` → installs a `uaccess` udev rule via **polkit/pkexec**, reloads udev, re-scans. Gated on real detection + user consent — nothing lands on dial-less machines.
- **`packaging/linux/70-ulanzi-dial.rules`** — canonical rule, committed as reference / distro-packager opt-in; **not** installed by the build.

## Verification (Principle XI — demonstrated live)

On an Intel iGPU box with a BLE Ulanzi Dial:
- Before: `open(/dev/input/event25)` → `EACCES` (user not in `input`, no `uaccess`).
- After installing the rule: logind applies `user:<me>:rw` automatically on connect; the dial attaches, and turning it tunes the radio — `source=ulanzi-dial intent=IncrementalTune` confirmed in the log.
- The dial emits exactly the decoder's expected keycodes (rotation `KEY_VOLUMEUP`/`DOWN`; buttons `KEY_PLAYPAUSE`/`MUTE`/`PREVIOUSSONG`/`NEXTSONG`; chords `Ctrl+Y/Z/V/C`).

## Notes

- Builds clean on Linux. The new code is `#ifdef Q_OS_LINUX`-guarded, so Windows/macOS are unaffected (the `accessRequired` signal and grant-access UI are Linux-only).
- The separate Windows **H100** issue (#3670) is a different root cause (product-string match) and is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)